### PR TITLE
Restore Toploop.use_file

### DIFF
--- a/toplevel/toploop.ml
+++ b/toplevel/toploop.ml
@@ -96,6 +96,8 @@ let mod_use_input ppf name =
   use_input ppf ~wrap_in_module:true name
 let use_input ppf name =
   use_input ppf ~wrap_in_module:false name
+let use_file ppf name =
+  use_input ppf (File name)
 
 let use_silently ppf name =
   Misc.protect_refs

--- a/toplevel/toploop.mli
+++ b/toplevel/toploop.mli
@@ -95,6 +95,7 @@ val use_input : formatter -> input -> bool
 val use_output : formatter -> string -> bool
 val use_silently : formatter -> input -> bool
 val mod_use_input : formatter -> input -> bool
+val use_file : formatter -> string -> bool
         (* Read and execute commands from a file.
            [use_input] prints the types and values of the results.
            [use_silently] does not print them.


### PR DESCRIPTION
This function, which is part of the "public" `Toploop` API, was removed in #10438. This PR restores it.

Fixes #10556 