### PR TITLE
#10450: restore support for %apply and %revapply with non-translucid types

### DIFF
--- a/Changes
+++ b/Changes
@@ -694,6 +694,11 @@ OCaml 4.13.0
   (Damien Doligez, report by Stephen Dolan, review by Nicolás Ojeda Bär
    and Sadiq Jaffer)
 
+- #10450, #10558: keep %apply and %revapply primitives working with abstract
+  types. This breach of backward compatibility was only present in the alpha
+  releases of OCaml 4.13.0 .
+  (Florian Angeletti, review by Thomas Refis and Leo White)
+
 - #10454: Check row_more in nondep_type_rec.
   (Leo White, review by Thomas Refis)
 

--- a/testsuite/tests/prim-revapply/apply.ml
+++ b/testsuite/tests/prim-revapply/apply.ml
@@ -42,3 +42,20 @@ let _ =
 (* PR#10081 *)
 let bump ?(cap = 100) x = min cap (x + 1)
 let _f x = bump @@ x (* no warning 48 *)
+
+(* Abstract functions *)
+let _ =
+  let module A:sig
+    type f
+    type x
+    val succ: f
+    val zero:x
+    external (@@): f -> x -> int = "%apply"
+  end = struct
+    type f = int -> int
+    type x = int
+    let succ = succ
+    let zero = 0
+    external (@@): f -> x -> int = "%apply"
+  end in
+  A.(succ @@ zero)

--- a/testsuite/tests/prim-revapply/revapply.ml
+++ b/testsuite/tests/prim-revapply/revapply.ml
@@ -30,3 +30,20 @@ let _f x = x |> bump (* no warning 48 *)
 type t = A | B
 type s = A | B
 let _f (x : t) = x |> function A -> 0 | B -> 1
+
+(* Abstract functions *)
+let _ =
+  let module A:sig
+    type f
+    type x
+    val succ: f
+    val zero:x
+    external (|>): x -> f -> int = "%revapply"
+  end = struct
+    type f = int -> int
+    type x = int
+    let succ = succ
+    let zero = 0
+    external (|>): x -> f -> int = "%revapply"
+  end in
+  A.(zero |> succ)

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -2738,6 +2738,32 @@ let rec is_inferred sexp =
   | Pexp_ifthenelse (_, e1, Some e2) -> is_inferred e1 && is_inferred e2
   | _ -> false
 
+(* check if the type of %apply or %revapply matches the type expected by
+   the specialized typing rule for those primitives.
+*)
+type apply_prim =
+  | Apply
+  | Revapply
+let check_apply_prim_type prim typ =
+  match get_desc typ with
+  | Tarrow (Nolabel,a,b,_) ->
+      begin match get_desc b with
+      | Tarrow(Nolabel,c,d,_) ->
+          let f, x, res =
+            match prim with
+            | Apply -> a, c, d
+            | Revapply -> c, a, d
+          in
+          begin match get_desc f with
+          | Tarrow(Nolabel,fl,fr,_) ->
+              is_Tvar fl && is_Tvar fr && is_Tvar x && is_Tvar res
+              && Types.eq_type fl x && Types.eq_type fr res
+          | _ -> false
+          end
+      | _ -> false
+      end
+  | _ -> false
+
 (* Merge explanation to type clash error *)
 
 let with_explanation explanation f =
@@ -2943,12 +2969,16 @@ and type_expect_
       let funct, sargs =
         let funct = type_sfunct sfunct in
         match funct.exp_desc, sargs with
-        | Texp_ident (_, _, {val_kind = Val_prim {prim_name = "%revapply"}}),
+        | Texp_ident (_, _,
+                      {val_kind = Val_prim {prim_name="%revapply"}; val_type}),
           [Nolabel, sarg; Nolabel, actual_sfunct]
-          when is_inferred actual_sfunct ->
+          when is_inferred actual_sfunct
+            && check_apply_prim_type Revapply val_type ->
             type_sfunct actual_sfunct, [Nolabel, sarg]
-        | Texp_ident (_, _, {val_kind = Val_prim {prim_name = "%apply"}}),
-          [Nolabel, actual_sfunct; Nolabel, sarg] ->
+        | Texp_ident (_, _,
+                      {val_kind = Val_prim {prim_name="%apply"}; val_type}),
+          [Nolabel, actual_sfunct; Nolabel, sarg]
+          when check_apply_prim_type Apply val_type ->
             type_sfunct actual_sfunct, [Nolabel, sarg]
         | _ ->
             funct, sargs


### PR DESCRIPTION
The new special typing rules in 4.13 for `%apply` and `%revapply` are only guaranteed to work when the types of the external values are exactly `('a -> 'b) -> 'a -> 'b` and `'a -> ('a->'b) -> 'b` respectively.

This PR ensures that when the types of the external do not match those expected types,
the standard typing rule is applied.

This restores support for various instances of
```ocaml
type f type x type y
external (@@): f -> x -> y = "%apply"
```

close #10450