### PR TITLE
Install toplevel printers using `[@@toplevel_printer]`

### DIFF
--- a/Changes
+++ b/Changes
@@ -42,6 +42,10 @@ Working version
 - #10524: Directive argument type error now shows expected and received type.
   (Wiktor Kuchta, review by Gabriel Scherer)
 
+- #10559: Toplevel printers in loaded modules can now be installed by annotating
+  their signature with `[@@toplevel_printer]`.
+  (Jérémie Dimino, Nicolás Ojeda Bär)
+
 ### Manual and documentation:
 
 - #7812, #10475: reworded the description of the behaviors of

--- a/toplevel/topdirs.ml
+++ b/toplevel/topdirs.ml
@@ -731,3 +731,6 @@ let _ = add_directive "help"
       doc = "Prints a list of all available directives, with \
           corresponding argument type if appropriate.";
     }
+
+let () =
+  Toploop.dir_install_printer := dir_install_printer

--- a/toplevel/toploop.mli
+++ b/toplevel/toploop.mli
@@ -194,3 +194,7 @@ val override_sys_argv : string array -> unit
    This is called by [run_script] so that [Sys.argv] represents
    "script.ml args..." instead of the full command line:
    "ocamlrun unix.cma ... script.ml args...". *)
+
+(**/**)
+
+val dir_install_printer : (formatter -> Longident.t -> unit) ref


### PR DESCRIPTION
Following discussion in #10557, this PR is to discuss the patch proposed in #7770 written originally by @jeremiedimino to automatically install values annotated with `[@@toplevel_printer]` as toplevel printers.

Fixes #7770