### PR TITLE
Disable colors if NO_COLOR env var set

### DIFF
--- a/Changes
+++ b/Changes
@@ -42,6 +42,11 @@ Working version
 - #10524: Directive argument type error now shows expected and received type.
   (Wiktor Kuchta, review by Gabriel Scherer)
 
+- #10560: Disable colors if the env variable `NO_COLOR` is set.  If
+  `OCAML_COLOR` is set, its setting takes precedence over `NO_COLOR`.
+  (Nicolás Ojeda Bär, report by Gabriel Scherer, review by Daniel Bünzli and
+  Gabriel Scherer)
+
 ### Manual and documentation:
 
 - #7812, #10475: reworded the description of the behaviors of

--- a/Changes
+++ b/Changes
@@ -44,8 +44,8 @@ Working version
 
 - #10560: Disable colors if the env variable `NO_COLOR` is set.  If
   `OCAML_COLOR` is set, its setting takes precedence over `NO_COLOR`.
-  (Nicolás Ojeda Bär, report by Gabriel Scherer, review by Daniel Bünzli and
-  Gabriel Scherer)
+  (Nicolás Ojeda Bär, report by Gabriel Scherer, review by Daniel Bünzli,
+  Gabriel Scherer and David Allsopp)
 
 ### Manual and documentation:
 

--- a/driver/compmisc.ml
+++ b/driver/compmisc.ml
@@ -68,6 +68,11 @@ let set_from_env flag Clflags.{ parse; usage; env_var } =
 
 let read_clflags_from_env () =
   set_from_env Clflags.color Clflags.color_reader;
+  if
+    Option.is_none !Clflags.color &&
+    Option.is_some (Sys.getenv_opt "NO_COLOR")
+  then
+    Clflags.color := Some Misc.Color.Never;
   set_from_env Clflags.error_style Clflags.error_style_reader;
   ()
 

--- a/man/ocaml.m
+++ b/man/ocaml.m
@@ -263,6 +263,9 @@ not empty or "dumb", and that isatty(stderr) holds.
 The environment variable "OCAML_COLOR" is considered if \-color is not
 provided. Its values are auto/always/never as above.
 
+If \-color is not provided, "OCAML_COLOR" is not set and the environment
+variable "NO_COLOR" is set, then color output is disabled.
+
 .TP
 .BI \-error\-style \ mode
 Control the way error messages and warnings are printed.

--- a/man/ocaml.m
+++ b/man/ocaml.m
@@ -254,17 +254,16 @@ enable colors unconditionally;
 .B never
 disable color output.
 
-The default setting is
-.B auto,
-and the current heuristic
-checks that the "TERM" environment variable exists and is
-not empty or "dumb", and that isatty(stderr) holds.
-
 The environment variable "OCAML_COLOR" is considered if \-color is not
 provided. Its values are auto/always/never as above.
 
 If \-color is not provided, "OCAML_COLOR" is not set and the environment
-variable "NO_COLOR" is set, then color output is disabled.
+variable "NO_COLOR" is set, then color output is disabled. Otherwise,
+the default setting is
+.B auto,
+and the current heuristic
+checks that the "TERM" environment variable exists and is
+not empty or "dumb", and that isatty(stderr) holds.
 
 .TP
 .BI \-error\-style \ mode

--- a/man/ocamlc.m
+++ b/man/ocamlc.m
@@ -268,17 +268,16 @@ enable colors unconditionally;
 .B never
 disable color output.
 
-The default setting is
-.B auto,
-and the current heuristic
-checks that the "TERM" environment variable exists and is
-not empty or "dumb", and that isatty(stderr) holds.
-
 The environment variable "OCAML_COLOR" is considered if \-color is not
 provided. Its values are auto/always/never as above.
 
 If \-color is not provided, "OCAML_COLOR" is not set and the environment
-variable "NO_COLOR" is set, then color output is disabled.
+variable "NO_COLOR" is set, then color output is disabled. Otherwise,
+the default setting is
+.B auto,
+and the current heuristic
+checks that the "TERM" environment variable exists and is
+not empty or "dumb", and that isatty(stderr) holds.
 
 .TP
 .BI \-error\-style \ mode

--- a/man/ocamlc.m
+++ b/man/ocamlc.m
@@ -277,6 +277,9 @@ not empty or "dumb", and that isatty(stderr) holds.
 The environment variable "OCAML_COLOR" is considered if \-color is not
 provided. Its values are auto/always/never as above.
 
+If \-color is not provided, "OCAML_COLOR" is not set and the environment
+variable "NO_COLOR" is set, then color output is disabled.
+
 .TP
 .BI \-error\-style \ mode
 Control the way error messages and warnings are printed.

--- a/man/ocamlopt.m
+++ b/man/ocamlopt.m
@@ -233,6 +233,9 @@ not empty or "dumb", and that isatty(stderr) holds.
 The environment variable "OCAML_COLOR" is considered if \-color is not
 provided. Its values are auto/always/never as above.
 
+If \-color is not provided, "OCAML_COLOR" is not set and the environment
+variable "NO_COLOR" is set, then color output is disabled.
+
 .TP
 .BI \-error\-style \ mode
 Control the way error messages and warnings are printed.

--- a/man/ocamlopt.m
+++ b/man/ocamlopt.m
@@ -224,17 +224,16 @@ enable colors unconditionally;
 .B never
 disable color output.
 
-The default setting is
-.B auto,
-and the current heuristic
-checks that the "TERM" environment variable exists and is
-not empty or "dumb", and that isatty(stderr) holds.
-
 The environment variable "OCAML_COLOR" is considered if \-color is not
 provided. Its values are auto/always/never as above.
 
 If \-color is not provided, "OCAML_COLOR" is not set and the environment
-variable "NO_COLOR" is set, then color output is disabled.
+variable "NO_COLOR" is set, then color output is disabled. Otherwise,
+the default setting is
+.B auto,
+and the current heuristic
+checks that the "TERM" environment variable exists and is
+not empty or "dumb", and that isatty(stderr) holds.
 
 .TP
 .BI \-error\-style \ mode

--- a/manual/src/cmds/unified-options.etex
+++ b/manual/src/cmds/unified-options.etex
@@ -126,15 +126,15 @@ The following modes are supported:
   \item["always"] enable colors unconditionally;
   \item["never"] disable color output.
 \end{description}
-The default setting is 'auto', and the current heuristic
-checks that the "TERM" environment variable exists and is
-not empty or "dumb", and that 'isatty(stderr)' holds.
 
 The environment variable "OCAML_COLOR" is considered if "-color" is not
 provided. Its values are auto/always/never as above.
 
 If "-color" is not provided, "OCAML_COLOR" is not set and the environment
-variable "NO_COLOR" is set, then color output is disabled.
+variable "NO_COLOR" is set, then color output is disabled. Otherwise,
+the default setting is 'auto', and the current heuristic
+checks that the "TERM" environment variable exists and is
+not empty or "dumb", and that 'isatty(stderr)' holds.
 }%notop
 
 \notop{%

--- a/manual/src/cmds/unified-options.etex
+++ b/manual/src/cmds/unified-options.etex
@@ -132,6 +132,9 @@ not empty or "dumb", and that 'isatty(stderr)' holds.
 
 The environment variable "OCAML_COLOR" is considered if "-color" is not
 provided. Its values are auto/always/never as above.
+
+If "-color" is not provided, "OCAML_COLOR" is not set and the environment
+variable "NO_COLOR" is set, then color output is disabled.
 }%notop
 
 \notop{%


### PR DESCRIPTION
Disables colors if `NO_COLOR` is set (see https://no-color.org/). If this variable is set but also `OCAML_COLOR`, the latter takes precedence.

Fixes #10548 