### PR TITLE
oprint: Truncate strings only after 8 bytes

### DIFF
--- a/Changes
+++ b/Changes
@@ -51,6 +51,9 @@ Working version
   (Nicolás Ojeda Bär, report by Gabriel Scherer, review by Daniel Bünzli,
   Gabriel Scherer and David Allsopp)
 
+- #10565: Toplevel value printing: truncate strings only after 8 bytes.
+  (Wiktor Kuchta, review by Xavier Leroy)
+
 ### Manual and documentation:
 
 - #7812, #10475: reworded the description of the behaviors of

--- a/typing/oprint.ml
+++ b/typing/oprint.ml
@@ -188,6 +188,7 @@ let print_out_value ppf tree =
     | Oval_string (s, maxlen, kind) ->
        begin try
          let len = String.length s in
+         let maxlen = max maxlen 8 in (* always show a little prefix *)
          let s = if len > maxlen then String.sub s 0 maxlen else s in
          begin match kind with
          | Ostr_bytes -> fprintf ppf "Bytes.of_string %S" s


### PR DESCRIPTION
When we run

    List.init 300 (Fun.const "a")

we can see that the toplevel in one case prints

    ""... (* string length 1; truncated *)

instead of just "a". The comment that the string was truncated takes at
least 36 characters, so truncating does not make much sense here.
If we are going to print the comment, it doesn't hurt much to also show
a part of the string to the user.

A byte can be printed as up to 4 characters, due to escaping.
So printing strings of length up to 8 bytes will always be shorter
without truncating.

There are still cases when truncating gives a longer text than not,
but it's unavoidable if the length of the printed prefix is a
nondecreasing function of the string length.