### PR TITLE
Remove Obj.{marshal,unmarshal}.

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,6 @@
 Working version
 ----------------
+
 ### Language features:
 
 - #10437: Allow explicit binders for type variables.
@@ -26,6 +27,11 @@ Working version
 
 - #10526: add Random.bits32, Random.bits64, Random.nativebits
   (Xavier Leroy, review by Gabriel Scherer and François Bobot)
+
+* #10568: remove Obj.marshal and Obj.unmarshal
+  (these functions have been deprecated for a while and are superseded
+   by the functions from module Marshal)
+  (François Pottier, review by Gabriel Scherer and Kate Deplaix)
 
 ### Other libraries:
 

--- a/stdlib/.depend
+++ b/stdlib/.depend
@@ -471,13 +471,11 @@ stdlib__Nativeint.cmi : nativeint.mli
 stdlib__Obj.cmo : obj.ml \
     stdlib__Sys.cmi \
     stdlib__Nativeint.cmi \
-    stdlib__Marshal.cmi \
     stdlib__Int32.cmi \
     stdlib__Obj.cmi
 stdlib__Obj.cmx : obj.ml \
     stdlib__Sys.cmx \
     stdlib__Nativeint.cmx \
-    stdlib__Marshal.cmx \
     stdlib__Int32.cmx \
     stdlib__Obj.cmi
 stdlib__Obj.cmi : obj.mli \

--- a/stdlib/obj.ml
+++ b/stdlib/obj.ml
@@ -46,11 +46,6 @@ external truncate : t -> int -> unit = "caml_obj_truncate"
 external add_offset : t -> Int32.t -> t = "caml_obj_add_offset"
 external with_tag : int -> t -> t = "caml_obj_with_tag"
 
-let marshal (obj : t) =
-  Marshal.to_bytes obj []
-let unmarshal str pos =
-  (Marshal.from_bytes str pos, pos + Marshal.total_size str pos)
-
 let first_non_constant_constructor_tag = 0
 let last_non_constant_constructor_tag = 245
 

--- a/stdlib/obj.mli
+++ b/stdlib/obj.mli
@@ -122,14 +122,6 @@ val [@inline always] extension_name : extension_constructor -> string
 val [@inline always] extension_id : extension_constructor -> int
   [@@ocaml.deprecated "use Obj.Extension_constructor.id"]
 
-(** The following two functions are deprecated.  Use module {!Marshal}
-    instead. *)
-
-val marshal : t -> bytes
-  [@@ocaml.deprecated "Use Marshal.to_bytes instead."]
-val unmarshal : bytes -> int -> t * int
-  [@@ocaml.deprecated "Use Marshal.from_bytes and Marshal.total_size instead."]
-
 module Ephemeron: sig
   (** Ephemeron with arbitrary arity and untyped *)
 


### PR DESCRIPTION
This removes the dependency of Obj on Marshal.