### PR TITLE
Generate a symbol table for faster linking.

### DIFF
--- a/utils/ccomp.ml
+++ b/utils/ccomp.ml
@@ -50,7 +50,7 @@ let quote_files lst =
   let quoted = List.map Filename.quote lst in
   let s = String.concat " " quoted in
   if String.length s >= 65536
-  || (String.length s >= 4096 && Sys.os_type = "Win32")
+  || (String.length s >= 4096 && Sys.win32)
   then build_diversion quoted
   else s
 
@@ -141,7 +141,7 @@ let create_archive archive file_list =
     | _ ->
         assert(String.length Config.ar > 0);
         let r1 =
-          command(Printf.sprintf "%s rc %s %s"
+          command(Printf.sprintf "%s rcs %s %s"
                   Config.ar quoted_archive (quote_files file_list)) in
         if r1 <> 0 || String.length Config.ranlib = 0
         then r1


### PR DESCRIPTION
Change from `Sys.os_type = "Win32"` to `Sys.win32` is unrelated. The s command is a xsi extension of posix https://pubs.opengroup.org/onlinepubs/9699919799/utilities/ar.html. It is available in MacOs, linux. Online man page of bsd, centos also mention this option, so it shouldn't cause portability issue.

The contribution guidelines ask to modify Changelog for user facing change. Since this is an internal command user might not see this PR.