### PR TITLE
Typo in parsetree.mli

### DIFF
--- a/parsing/parsetree.mli
+++ b/parsing/parsetree.mli
@@ -381,7 +381,7 @@ and expression_desc =
   | Pexp_open of open_declaration * expression
         (* M.(E)
            let open M in E
-           let! open M in E *)
+           let open! M in E *)
   | Pexp_letop of letop
         (* let* P = E in E
            let* P = E and* P = E in E *)


### PR DESCRIPTION
Local open `let open! in` was mistyped as `let! open in ...` in the `Parsetree` module.