### PR TITLE
Add a `-dump-dir` flag

### DIFF
--- a/Changes
+++ b/Changes
@@ -285,6 +285,10 @@ OCaml 4.14.0
   (Jacques Garrigue and Takafumi Saikawa,
    review by Thomas Refis and Florian Angeletti)
 
+- #10575: add a -dump-dir flag, which redirects all debugging printer
+   (`-dprofile`, `-dlambda`, ...) to the target directory
+  (Florian Angeletti, review by Thomas Refis and Gabriel Scherer)
+
 * #10627: Make row_field abstract
   Completes #10474 by making row_field abstract too.
   An immutable view row_field_view is provided, and one converts between it

--- a/driver/compenv.ml
+++ b/driver/compenv.ml
@@ -474,6 +474,8 @@ let read_one_param ppf position name v =
       | None -> ()
       | Some pass -> set_save_ir_after pass true
     end
+  | "dump-into-file" -> Clflags.dump_into_file := true
+  | "dump-dir" -> Clflags.dump_dir := Some v
 
   | _ ->
     if not (List.mem name !can_discard) then begin

--- a/driver/main_args.ml
+++ b/driver/main_args.ml
@@ -708,6 +708,11 @@ let mk_dump_into_file f =
   "-dump-into-file", Arg.Unit f, " dump output like -dlambda into <target>.dump"
 ;;
 
+let mk_dump_dir f =
+  "-dump-dir", Arg.String f,
+  "<dir> dump output like -dlambda into <dir>/<target>.dump"
+;;
+
 let mk_dparsetree f =
   "-dparsetree", Arg.Unit f, " (undocumented)"
 ;;
@@ -1012,6 +1017,7 @@ module type Compiler_options = sig
   val _dtimings : unit -> unit
   val _dprofile : unit -> unit
   val _dump_into_file : unit -> unit
+  val _dump_dir : string -> unit
 
   val _args: string -> string array
   val _args0: string -> string array
@@ -1262,6 +1268,7 @@ struct
     mk_dtimings F._dtimings;
     mk_dprofile F._dprofile;
     mk_dump_into_file F._dump_into_file;
+    mk_dump_dir F._dump_dir;
 
     mk_args F._args;
     mk_args0 F._args0;
@@ -1484,6 +1491,7 @@ struct
     mk_dtimings F._dtimings;
     mk_dprofile F._dprofile;
     mk_dump_into_file F._dump_into_file;
+    mk_dump_dir F._dump_dir;
     mk_dump_pass F._dump_pass;
 
     mk_args F._args;
@@ -1864,6 +1872,7 @@ module Default = struct
     let _dprofile () = profile_columns := Profile.all_columns
     let _dtimings () = profile_columns := [`Time]
     let _dump_into_file = set dump_into_file
+    let _dump_dir s = dump_dir := Some s
     let _for_pack s = for_package := (Some s)
     let _g = set debug
     let _i = set print_types

--- a/driver/main_args.mli
+++ b/driver/main_args.mli
@@ -121,6 +121,7 @@ module type Compiler_options = sig
   val _dtimings : unit -> unit
   val _dprofile : unit -> unit
   val _dump_into_file : unit -> unit
+  val _dump_dir : string -> unit
 
   val _args: string -> string array
   val _args0: string -> string array

--- a/driver/maindriver.ml
+++ b/driver/maindriver.ml
@@ -110,5 +110,6 @@ let main argv ppf =
     Location.report_exception ppf x;
     2
   | () ->
-    Profile.print Format.std_formatter !Clflags.profile_columns;
+    Compmisc.with_ppf_dump ~file_prefix:"profile"
+      (fun ppf -> Profile.print ppf !Clflags.profile_columns);
     0

--- a/driver/optmaindriver.ml
+++ b/driver/optmaindriver.ml
@@ -136,5 +136,6 @@ let main argv ppf =
     Location.report_exception ppf x;
     2
   | () ->
-    Profile.print Format.std_formatter !Clflags.profile_columns;
-    0
+      Compmisc.with_ppf_dump ~file_prefix:"profile"
+        (fun ppf -> Profile.print ppf !Clflags.profile_columns);
+      0

--- a/utils/clflags.ml
+++ b/utils/clflags.ml
@@ -375,6 +375,7 @@ let set_dumped_pass s enabled =
   end
 
 let dump_into_file = ref false (* -dump-into-file *)
+let dump_dir: string option ref = ref None (* -dump-dir *)
 
 type 'a env_reader = {
   parse : string -> 'a option;

--- a/utils/clflags.mli
+++ b/utils/clflags.mli
@@ -218,6 +218,7 @@ val dumped_pass : string -> bool
 val set_dumped_pass : string -> bool -> unit
 
 val dump_into_file : bool ref
+val dump_dir : string option ref
 
 (* Support for flags that can also be set from an environment variable *)
 type 'a env_reader = {


### PR DESCRIPTION
This PR adds a `-dump-dir dir` flag which redirects the output of all debugging printers (`-dprofile`, `-dlambda`, ...) to files within the  directory `dir`.

The purpose of this flag is to facilitate the collect of information of the compilation process when building arbitrary libraries or executable.

Typically, I have used this flag with
```
OCAMLPARAM=",_,timings=1,dump-dir=/tmp/pkgname" opam install pkgname
```
to harvest the compilation profile of various files on a set of opam packages.
This has been quite useful when measuring the impact of a PR on the compilation time (see https://github.com/Octachron/ocaml-perfomance-monitoring for an example).