### PR TITLE
Let configure generate stdlib/sys.ml

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1145,6 +1145,7 @@ distclean: clean
 	rm -f tools/eventlog_metadata
 	rm -f tools/*.bak
 	rm -f testsuite/_log*
+	$(MAKE) -C stdlib distclean
 
 include .depend
 

--- a/configure
+++ b/configure
@@ -2952,6 +2952,8 @@ ac_config_files="$ac_config_files Makefile.build_config"
 
 ac_config_files="$ac_config_files Makefile.config"
 
+ac_config_files="$ac_config_files stdlib/sys.ml"
+
 ac_config_files="$ac_config_files tools/eventlog_metadata"
 
 ac_config_headers="$ac_config_headers runtime/caml/m.h"
@@ -18829,6 +18831,7 @@ do
   case $ac_config_target in
     "Makefile.build_config") CONFIG_FILES="$CONFIG_FILES Makefile.build_config" ;;
     "Makefile.config") CONFIG_FILES="$CONFIG_FILES Makefile.config" ;;
+    "stdlib/sys.ml") CONFIG_FILES="$CONFIG_FILES stdlib/sys.ml" ;;
     "tools/eventlog_metadata") CONFIG_FILES="$CONFIG_FILES tools/eventlog_metadata" ;;
     "runtime/caml/m.h") CONFIG_HEADERS="$CONFIG_HEADERS runtime/caml/m.h" ;;
     "runtime/caml/s.h") CONFIG_HEADERS="$CONFIG_HEADERS runtime/caml/s.h" ;;

--- a/configure.ac
+++ b/configure.ac
@@ -176,6 +176,7 @@ AC_SUBST([naked_pointers_checker])
 
 AC_CONFIG_FILES([Makefile.build_config])
 AC_CONFIG_FILES([Makefile.config])
+AC_CONFIG_FILES([stdlib/sys.ml])
 AC_CONFIG_FILES([tools/eventlog_metadata])
 AC_CONFIG_HEADERS([runtime/caml/m.h])
 AC_CONFIG_HEADERS([runtime/caml/s.h])

--- a/stdlib/Makefile
+++ b/stdlib/Makefile
@@ -200,13 +200,11 @@ stdlib.cma: $(OBJS)
 stdlib.cmxa: $(OBJS:.cmo=.cmx)
 	$(CAMLOPT) -a -o $@ $^
 
-sys.ml: $(ROOTDIR)/VERSION sys.mlp
-	sed -e "s|%%VERSION%%|`sed -e 1q $< | tr -d '\r'`|" sys.mlp > $@
-
-.PHONY: clean
-clean::
+.PHONY: distclean
+distclean: clean
 	rm -f sys.ml
 
+.PHONY: clean
 clean::
 	rm -f $(CAMLHEADERS)
 

--- a/stdlib/sys.ml.in
+++ b/stdlib/sys.ml.in
@@ -1,4 +1,5 @@
-#2 "stdlib/sys.mlp"
+(* @configure_input@ *)
+#2 "stdlib/sys.ml.in"
 (**************************************************************************)
 (*                                                                        *)
 (*                                 OCaml                                  *)
@@ -13,10 +14,6 @@
 (*   special exception on linking described in the file LICENSE.          *)
 (*                                                                        *)
 (**************************************************************************)
-
-(* WARNING: sys.ml is generated from sys.mlp.  DO NOT EDIT sys.ml or
-   your changes will be lost.
-*)
 
 type backend_type =
   | Native
@@ -128,7 +125,7 @@ external runtime_warnings_enabled: unit -> bool =
 
 (* The version string is found in file ../VERSION *)
 
-let ocaml_version = "%%VERSION%%"
+let ocaml_version = "@VERSION@"
 
 (* Optimization *)
 


### PR DESCRIPTION
This PR follows the discussion on #1057.

It contains just the bit that transforms `stdlib/sys.ml` into a proper
`configured module`, so to speak, in the sense that it is generated
by the approrpiate autoconf machinery rather than being generated
by a sed invocation during the build itself.


With this commit, the stdlib/sys.ml file is generated at configure time
rather than by stdlib/Makefile.

@nojb would you mind reviewing this, please?