### PR TITLE
More parameter passing registers for Power and Z systems

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,6 @@
 Working version
 ----------------
+
 ### Language features:
 
 - #10437: Allow explicit binders for type variables.
@@ -16,6 +17,10 @@ Working version
 
 
 ### Code generation and optimizations:
+
+- #10578: Increase the number of integer registers used for
+  parameter passing on PowerPC (16 registers) and on s390x (8 registers).
+  (Xavier Leroy, review by Mark Shinwell)
 
 ### Standard library:
 

--- a/asmcomp/power/proc.ml
+++ b/asmcomp/power/proc.ml
@@ -155,17 +155,17 @@ let incoming ofs = Incoming ofs
 let outgoing ofs = Outgoing ofs
 let not_supported _ofs = fatal_error "Proc.loc_results: cannot call"
 
-let max_arguments_for_tailcalls = 8
+let max_arguments_for_tailcalls = 16
 
 let loc_arguments arg =
-    calling_conventions 0 7 100 112 outgoing arg
+    calling_conventions 0 15 100 112 outgoing arg
 
 let loc_parameters arg =
-  let (loc, _ofs) = calling_conventions 0 7 100 112 incoming arg
+  let (loc, _ofs) = calling_conventions 0 15 100 112 incoming arg
   in loc
 
 let loc_results res =
-  let (loc, _ofs) = calling_conventions 0 7 100 112 not_supported res
+  let (loc, _ofs) = calling_conventions 0 15 100 112 not_supported res
   in loc
 
 (* C calling conventions for ELF32:

--- a/asmcomp/s390x/proc.ml
+++ b/asmcomp/s390x/proc.ml
@@ -128,14 +128,14 @@ let incoming ofs = Incoming ofs
 let outgoing ofs = Outgoing ofs
 let not_supported _ofs = fatal_error "Proc.loc_results: cannot call"
 
-let max_arguments_for_tailcalls = 5
+let max_arguments_for_tailcalls = 8
 
 let loc_arguments arg =
-  calling_conventions 0 4 100 103 outgoing 0 arg
+  calling_conventions 0 7 100 103 outgoing 0 arg
 let loc_parameters arg =
-  let (loc, _ofs) = calling_conventions 0 4 100 103 incoming 0 arg in loc
+  let (loc, _ofs) = calling_conventions 0 7 100 103 incoming 0 arg in loc
 let loc_results res =
-  let (loc, _ofs) = calling_conventions 0 4 100 103 not_supported 0 res in loc
+  let (loc, _ofs) = calling_conventions 0 7 100 103 not_supported 0 res in loc
 
 (*   C calling conventions under SVR4:
      use GPR 2-6 and FPR 0,2,4,6 just like ML calling conventions.


### PR DESCRIPTION
This is the uncontroversial part of #10426.  It increases the number of integer registers available for passing integer arguments on Power and s390z / Z systems.  This gives more opportunities for tail calls on these platforms.
