### PR TITLE
Add the missing license field to the opam file

### DIFF
--- a/ocaml-variants.opam
+++ b/ocaml-variants.opam
@@ -1,5 +1,6 @@
 opam-version: "2.0"
 version: "4.14.0+trunk"
+license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 synopsis: "OCaml development version"
 depends: [
   "ocaml" {= "4.14.0" & post}


### PR DESCRIPTION
The presence of this field will be checked by opam lint starting with opam 2.2.0
Partly related to https://github.com/ocaml/opam-repository/pull/19327 and https://github.com/ocaml/opam/issues/4598