### PR TITLE
Fix single-line source highlighting in the presence of tabs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -114,6 +114,7 @@ testsuite/tests/generated-parse-errors/errors.*         typo.very-long-line
 testsuite/tools/*.S                                     typo.missing-header
 testsuite/tools/*.asm                                   typo.missing-header
 testsuite/typing                                        typo.missing-header
+testsuite/tests/messages/highlight_tabs.ml              typo.tab
 
 # prune testsuite reference files
 testsuite/tests/**/*.reference               typo.prune

--- a/Changes
+++ b/Changes
@@ -85,6 +85,11 @@ Working version
   Makefile.config.
   (Damien Doligez, review by Mark Shinwell and Gabriel Scherer)
 
+- #9116, #9118, #10582: Fix single-line source highlighting in the
+  presence of tabs
+  (Armaël Guéneau, review by Gabriel Scherer,
+   split off from #9118 by Kate Deplaix, report by Ricardo M. Correia)
+
 ### Internal/compiler-libs changes:
 
 - #1599: add unset directive to ocamltest to clear environment variables before

--- a/parsing/location.ml
+++ b/parsing/location.ml
@@ -464,14 +464,20 @@ let highlight_quote ppf
         (* Single-line error *)
         Format.fprintf ppf "%s | %s@," line_nb line;
         Format.fprintf ppf "%*s   " (String.length line_nb) "";
-        for pos = line_start_cnum to rightmost.pos_cnum - 1 do
+        String.iteri (fun i c ->
+          let pos = line_start_cnum + i in
           if ISet.is_start iset ~pos <> None then
             Format.fprintf ppf "@{<%s>" highlight_tag;
           if ISet.mem iset ~pos then Format.pp_print_char ppf '^'
-          else Format.pp_print_char ppf ' ';
+          else if pos < rightmost.pos_cnum then begin
+            (* For alignment purposes, align using a tab for each tab in the
+               source code *)
+            if c = '\t' then Format.pp_print_char ppf '\t'
+            else Format.pp_print_char ppf ' '
+          end;
           if ISet.is_end iset ~pos <> None then
             Format.fprintf ppf "@}"
-        done;
+        ) line;
         Format.fprintf ppf "@}@,"
     | _ ->
         (* Multi-line error *)

--- a/testsuite/tests/messages/highlight_tabs.ml
+++ b/testsuite/tests/messages/highlight_tabs.ml
@@ -1,0 +1,13 @@
+(* TEST
+  * expect
+*)
+
+		let x = abc
+;;
+[%%expect{|
+Line 1, characters 10-13:
+1 | 		let x = abc
+              ^^^
+Error: Unbound value abc
+Hint: Did you mean abs?
+|}];;

--- a/testsuite/tests/messages/highlight_tabs.ml
+++ b/testsuite/tests/messages/highlight_tabs.ml
@@ -7,7 +7,7 @@
 [%%expect{|
 Line 1, characters 10-13:
 1 | 		let x = abc
-              ^^^
+    		        ^^^
 Error: Unbound value abc
 Hint: Did you mean abs?
 |}];;


### PR DESCRIPTION
This PR simply extracts commits from @Armael in https://github.com/ocaml/ocaml/pull/9118 which was an attempt to fix https://github.com/ocaml/ocaml/issues/9116

The main reason why the PR was stalling was that multi-lines source highlighting was a lot more tricky to fix and due to some lack of time to work on this.

From what @Armael told me, the fix for single-line source highlighting should work fine on its own and be relatively uncontrovertial. I thus propose to split this PR into an easy to merge fix for the most common case (this hereby PR) and leave #9118 to attempt to fix the multi-line case which should be less common.