### PR TITLE
Additions to the module Seq

### DIFF
--- a/Changes
+++ b/Changes
@@ -90,6 +90,9 @@ Working version
   (Nicolás Ojeda Bär, review by John Whitington, Daniel Bünzli, David Allsopp
   and Xavier Leroy)
 
+* #10583: Many additions to Seq.
+  (François Pottier, Simon Cruanes)
+
 - #10596: Add with_open_bin, with_open_text and with_open_gen to In_channel and
   Out_channel. Also, add In_channel.input_all.
   (Nicolás Ojeda Bär, review by Daniel Bünzli, Jérémie Dimino, Damien Doligez

--- a/Changes
+++ b/Changes
@@ -90,8 +90,10 @@ Working version
   (Nicolás Ojeda Bär, review by John Whitington, Daniel Bünzli, David Allsopp
   and Xavier Leroy)
 
-* #10583: Many additions to Seq.
-  (François Pottier, Simon Cruanes)
+* #10583: Add over 40 new functions in Seq.
+  (François Pottier and Simon Cruanes, review by Nicolás Ojeda Bär,
+   Daniel Bünzli, Naëla Courant, Craig Ferguson, Wiktor Kuchta, Xavier
+   Leroy, Guillaume Munch-Maccagnoni, Raphaël Proust, and Gabriel Scherer)
 
 - #10596: Add with_open_bin, with_open_text and with_open_gen to In_channel and
   Out_channel. Also, add In_channel.input_all.

--- a/stdlib/.depend
+++ b/stdlib/.depend
@@ -637,10 +637,15 @@ stdlib__Scanf.cmx : scanf.ml \
 stdlib__Scanf.cmi : scanf.mli \
     stdlib.cmi
 stdlib__Seq.cmo : seq.ml \
+    stdlib__Lazy.cmi \
+    stdlib__Either.cmi \
     stdlib__Seq.cmi
 stdlib__Seq.cmx : seq.ml \
+    stdlib__Lazy.cmx \
+    stdlib__Either.cmx \
     stdlib__Seq.cmi
-stdlib__Seq.cmi : seq.mli
+stdlib__Seq.cmi : seq.mli \
+    stdlib__Either.cmi
 stdlib__Set.cmo : set.ml \
     stdlib__Seq.cmi \
     stdlib__List.cmi \

--- a/stdlib/.depend
+++ b/stdlib/.depend
@@ -639,10 +639,12 @@ stdlib__Scanf.cmi : scanf.mli \
 stdlib__Seq.cmo : seq.ml \
     stdlib__Lazy.cmi \
     stdlib__Either.cmi \
+    camlinternalAtomic.cmi \
     stdlib__Seq.cmi
 stdlib__Seq.cmx : seq.ml \
     stdlib__Lazy.cmx \
     stdlib__Either.cmx \
+    camlinternalAtomic.cmx \
     stdlib__Seq.cmi
 stdlib__Seq.cmi : seq.mli \
     stdlib__Either.cmi

--- a/stdlib/StdlibModules
+++ b/stdlib/StdlibModules
@@ -35,9 +35,11 @@
 # with lowercase first letters). These must be listed in dependency order.
 STDLIB_MODULE_BASENAMES = \
   camlinternalFormatBasics camlinternalAtomic \
-  stdlib pervasives seq option either result bool char uchar \
-  sys list int bytes string unit marshal obj array float int32 int64 nativeint \
-  lexing parsing set map stack queue camlinternalLazy lazy stream buffer \
+  stdlib pervasives either \
+  sys obj camlinternalLazy lazy \
+  seq option result bool char uchar \
+  list int bytes string unit marshal array float int32 int64 nativeint \
+  lexing parsing set map stack queue stream buffer \
   camlinternalFormat printf arg atomic \
   printexc fun gc digest random hashtbl weak \
   format scanf callback camlinternalOO oo camlinternalMod genlex ephemeron \

--- a/stdlib/seq.ml
+++ b/stdlib/seq.ml
@@ -260,21 +260,6 @@ let rec repeat x () =
 let rec forever f () =
   Cons (f(), forever f)
 
-(* [assert_length_is_at_least msg k xs] produces a sequence that is equivalent
-   to [xs], but whose evaluation fails if it turns out that the sequence has
-   fewer than [k] elements. *)
-
-let rec assert_length_is_at_least msg k xs =
-  if k <= 0 then
-    xs
-  else
-    fun () ->
-      match xs() with
-      | Nil ->
-          invalid_arg msg
-      | Cons (x, xs) ->
-          Cons (x, assert_length_is_at_least msg (k-1) xs)
-
 (* This version of [cycle] requires the sequence [xs] to be nonempty. Applying
    it to an empty sequence would produce a sequence that diverges when it is
    forced. *)
@@ -282,12 +267,15 @@ let rec assert_length_is_at_least msg k xs =
 let rec cycle xs () =
   append xs (cycle xs) ()
 
-(* [cycle] is redefined to check (at runtime) that [xs] is nonempty. Thus,
-   [cycle empty] produces a sequence that fails when it is forced. Note that
-   this is *not* a recursive definition. *)
+(* [cycle] is redefined to check whether [xs] is empty and, if so, return
+   an empty sequence. Note that this is *not* a recursive definition. *)
 
-let cycle xs =
-  append (assert_length_is_at_least "Seq.cycle" 1 xs) (cycle xs)
+let cycle xs () =
+  match xs() with
+  | Nil ->
+      Nil
+  | Cons (x, xs') ->
+      Cons (x, append xs' (cycle xs))
 
 (* [iterate1 f x] is the sequence [f x, f (f x), ...].
    It is equivalent to [tail (iterate f x)].

--- a/stdlib/seq.ml
+++ b/stdlib/seq.ml
@@ -594,7 +594,7 @@ let rec filter_map_find_right xs () =
   | Cons (Either.Right x, xs) ->
       Cons (x, filter_map_find_right xs)
 
-let dispatch xs =
+let partition_either xs =
   filter_map_find_left xs,
   filter_map_find_right xs
 

--- a/stdlib/seq.ml
+++ b/stdlib/seq.ml
@@ -656,11 +656,6 @@ let product_with f xs ys =
 let product xs ys =
   product_with (fun x y -> (x, y)) xs ys
 
-let ap fs xs =
-  product_with (fun f x -> f x) fs xs
-
-
-
 let of_iterator it =
   let rec c () =
     match it() with

--- a/stdlib/seq.ml
+++ b/stdlib/seq.ml
@@ -474,6 +474,9 @@ let rec zip xs ys () =
       | Cons (y, ys) ->
           Cons ((x, y), zip xs ys)
 
+let combine =
+  zip
+
 let rec map2 f xs ys () =
   match xs() with
   | Nil ->
@@ -551,6 +554,9 @@ let rec map_snd xys () =
 
 let unzip xys =
   map_fst xys, map_snd xys
+
+let split =
+  unzip
 
 (* [filter_map_find_left_map f xs] is equivalent to
    [filter_map Either.find_left (map f xs)]. *)

--- a/stdlib/seq.ml
+++ b/stdlib/seq.ml
@@ -238,8 +238,7 @@ let rec compare cmp xs ys =
 
 
 
-(* [init_aux f i j] is the sequence [f i, ..., f (j-1)].
-   It is equivalent to [map f (up i j)]. *)
+(* [init_aux f i j] is the sequence [f i, ..., f (j-1)]. *)
 
 let rec init_aux f i j () =
   if i < j then begin

--- a/stdlib/seq.ml
+++ b/stdlib/seq.ml
@@ -132,16 +132,16 @@ let rec iteri_aux f i xs =
 let[@inline] iteri f xs =
   iteri_aux f 0 xs
 
-let rec fold_left_i_aux f i accu xs =
+let rec fold_lefti_aux f i accu xs =
   match xs() with
   | Nil ->
       accu
   | Cons (x, xs) ->
       let accu = f i accu x in
-      fold_left_i_aux f (i+1) accu xs
+      fold_lefti_aux f (i+1) accu xs
 
-let fold_left_i f accu xs =
-  fold_left_i_aux f 0 accu xs
+let fold_lefti f accu xs =
+  fold_lefti_aux f 0 accu xs
 
 let rec for_all p xs =
   match xs() with
@@ -427,7 +427,7 @@ let rec group eq xs () =
   | Cons (x, xs) ->
       Cons (cons x (take_while (eq x) xs), group eq (drop_while (eq x) xs))
 
-exception ForcedTwice
+exception Forced_twice
 
 module Suspension = struct
 
@@ -453,10 +453,10 @@ module Suspension = struct
   let failure : _ suspension =
     fun () ->
       (* A suspension created by [once] has been forced twice. *)
-      raise ForcedTwice
+      raise Forced_twice
 
   (* If [f] is a suspension, then [once f] is a suspension that can be forced
-     at most once. If it is forced more than once, then [ForcedTwice] is
+     at most once. If it is forced more than once, then [Forced_twice] is
      raised. *)
 
   let once (f : 'a suspension) : 'a suspension =

--- a/stdlib/seq.ml
+++ b/stdlib/seq.ml
@@ -376,26 +376,6 @@ let rec drop_while p xs () =
   | Cons (x, xs) as node ->
       if p x then drop_while p xs () else node
 
-(* [uniq1 eq x ys] is equivalent to [uniq eq (cons x ys)].
-   [uniq1] is used as a building block in the definition of [uniq]. *)
-
-let rec uniq1 eq x ys () =
-  match ys() with
-  | Nil ->
-      Nil
-  | Cons (y, ys) ->
-      if eq x y then
-        uniq1 eq x ys ()
-      else
-        Cons (y, uniq1 eq y ys)
-
-let uniq eq xs () =
-  match xs() with
-  | Nil ->
-      Nil
-  | Cons (x, ys) ->
-      Cons (x, uniq1 eq x ys)
-
 let rec group eq xs () =
   match xs() with
   | Nil ->

--- a/stdlib/seq.ml
+++ b/stdlib/seq.ml
@@ -62,14 +62,12 @@ let rec flat_map f seq () = match seq () with
 
 let concat_map = flat_map
 
-let fold_left f acc seq =
-  let rec aux f acc seq = match seq () with
+let rec fold_left f acc seq =
+  match seq () with
     | Nil -> acc
     | Cons (x, next) ->
         let acc = f acc x in
-        aux f acc next
-  in
-  aux f acc seq
+        fold_left f acc next
 
 let iter f seq =
   let rec aux seq = match seq () with

--- a/stdlib/seq.ml
+++ b/stdlib/seq.ml
@@ -50,10 +50,14 @@ let rec filter f seq () = match seq() with
       then Cons (x, filter f next)
       else filter f next ()
 
-let rec concat seq () = match seq () with
+let rec concat_rec sep seq () = match seq () with
   | Nil -> Nil
   | Cons (x, next) ->
-     append x (concat next) ()
+      append sep (append x (concat_rec sep next)) ()
+
+let concat ?(sep=empty) seq () = match seq() with
+  | Cons (x, next) -> append x (concat_rec sep next) ()
+  | Nil -> Nil
 
 let rec flat_map f seq () = match seq () with
   | Nil -> Nil
@@ -87,20 +91,6 @@ let is_empty xs =
       true
   | Cons (_, _) ->
       false
-
-let head xs =
-  match xs() with
-  | Nil ->
-      invalid_arg "Seq.head"
-  | Cons (x, _) ->
-      x
-
-let tail xs =
-  match xs() with
-  | Nil ->
-      invalid_arg "Seq.tail"
-  | Cons (_, xs) ->
-      xs
 
 let uncons xs =
   match xs() with
@@ -696,16 +686,3 @@ let to_iterator xs =
 let rec ints i () =
   Cons (i, ints (i + 1))
 
-let rec up i j () =
-  if i < j then Cons (i, up (i + 1) j) else Nil
-
-let rec down i j () =
-  if i > j then Cons (i - 1, down (i - 1) j) else Nil
-
-
-module Infix = struct
-  let (@) = append
-  let (>>=) xs f = flat_map f xs
-  let (>|=) xs f = map f xs
-  let (<*>) = ap
-end

--- a/stdlib/seq.ml
+++ b/stdlib/seq.ml
@@ -656,7 +656,7 @@ let map_product f xs ys =
 let product xs ys =
   map_product (fun x y -> (x, y)) xs ys
 
-let of_iterator it =
+let of_distributor it =
   let rec c () =
     match it() with
     | None ->
@@ -666,7 +666,7 @@ let of_iterator it =
   in
   c
 
-let to_iterator xs =
+let to_distributor xs =
   let s = ref xs in
   fun () ->
     match (!s)() with

--- a/stdlib/seq.ml
+++ b/stdlib/seq.ml
@@ -50,14 +50,10 @@ let rec filter f seq () = match seq() with
       then Cons (x, filter f next)
       else filter f next ()
 
-let rec concat_rec sep seq () = match seq () with
+let rec concat seq () = match seq () with
   | Nil -> Nil
   | Cons (x, next) ->
-      append sep (append x (concat_rec sep next)) ()
-
-let concat ?(sep=empty) seq () = match seq() with
-  | Cons (x, next) -> append x (concat_rec sep next) ()
-  | Nil -> Nil
+     append x (concat next) ()
 
 let rec flat_map f seq () = match seq () with
   | Nil -> Nil

--- a/stdlib/seq.ml
+++ b/stdlib/seq.ml
@@ -566,27 +566,34 @@ let rec map_snd xys () =
 let unzip xys =
   map_fst xys, map_snd xys
 
-let rec filter_map_find_left xs () =
+(* [filter_map_find_left_map f xs] is equivalent to
+   [filter_map Either.find_left (map f xs)]. *)
+
+let rec filter_map_find_left_map f xs () =
   match xs() with
   | Nil ->
       Nil
-  | Cons (Either.Left x, xs) ->
-      Cons (x, filter_map_find_left xs)
-  | Cons (Either.Right _, xs) ->
-      filter_map_find_left xs ()
+  | Cons (x, xs) ->
+      match f x with
+      | Either.Left y ->
+          Cons (y, filter_map_find_left_map f xs)
+      | Either.Right _ ->
+          filter_map_find_left_map f xs ()
 
-let rec filter_map_find_right xs () =
+let rec filter_map_find_right_map f xs () =
   match xs() with
   | Nil ->
       Nil
-  | Cons (Either.Left _, xs) ->
-      filter_map_find_right xs ()
-  | Cons (Either.Right x, xs) ->
-      Cons (x, filter_map_find_right xs)
+  | Cons (x, xs) ->
+      match f x with
+      | Either.Left _ ->
+          filter_map_find_right_map f xs ()
+      | Either.Right z ->
+          Cons (z, filter_map_find_right_map f xs)
 
-let partition_either xs =
-  filter_map_find_left xs,
-  filter_map_find_right xs
+let partition_map f xs =
+  filter_map_find_left_map f xs,
+  filter_map_find_right_map f xs
 
 let partition p xs =
   filter p xs, filter (fun x -> not (p x)) xs
@@ -691,4 +698,3 @@ let to_iterator xs =
 
 let rec ints i () =
   Cons (i, ints (i + 1))
-

--- a/stdlib/seq.ml
+++ b/stdlib/seq.ml
@@ -660,7 +660,7 @@ let rec diagonals remainders xss () =
 let diagonals xss =
   diagonals empty xss
 
-let product_with f xs ys =
+let map_product f xs ys =
   concat (diagonals (
     map (fun x ->
       map (fun y ->
@@ -670,7 +670,7 @@ let product_with f xs ys =
   ))
 
 let product xs ys =
-  product_with (fun x y -> (x, y)) xs ys
+  map_product (fun x y -> (x, y)) xs ys
 
 let of_iterator it =
   let rec c () =

--- a/stdlib/seq.ml
+++ b/stdlib/seq.ml
@@ -69,14 +69,12 @@ let rec fold_left f acc seq =
         let acc = f acc x in
         fold_left f acc next
 
-let iter f seq =
-  let rec aux seq = match seq () with
+let rec iter f seq =
+  match seq () with
     | Nil -> ()
     | Cons (x, next) ->
         f x;
-        aux next
-  in
-  aux seq
+        iter f next
 
 let rec unfold f u () =
   match f u with

--- a/stdlib/seq.ml
+++ b/stdlib/seq.ml
@@ -288,6 +288,13 @@ let rec iterate1 f x () =
 
 (* [iterate f x] is the sequence [x, f x, ...]. *)
 
+(* The reason why we give this slightly indirect definition of [iterate],
+   as opposed to the more naive definition that may come to mind, is that
+   we are careful to avoid evaluating [f x] until this function call is
+   actually necessary. The naive definition (not shown here) computes the
+   second argument of the sequence, [f x], when the first argument is
+   requested by the user. *)
+
 let iterate f x =
   cons x (iterate1 f x)
 
@@ -305,6 +312,9 @@ let[@inline] mapi f xs =
 
 (* [tail_scan f s xs] is equivalent to [tail (scan f s xs)].
    [tail_scan] is used as a building block in the definition of [scan]. *)
+
+(* This slightly indirect definition of [scan] is meant to avoid computing
+   elements too early; see the above comment about [iterate1] and [iterate]. *)
 
 let rec tail_scan f s xs () =
   match xs() with

--- a/stdlib/seq.ml
+++ b/stdlib/seq.ml
@@ -654,11 +654,13 @@ let rec diagonals remainders xss () =
    The first diagonal contains just the first element of the
    first row. The second diagonal contains the first element of the
    second row and the second element of the first row; and so on.
+   This kind of diagonal is in fact sometimes known as an antidiagonal.
 
    - Every diagonal is a finite sequence.
    - The rows of the matrix [xss] are not required to have the same length.
    - The matrix [xss] is not required to be finite (in either direction).
    - The matrix [xss] must be persistent. *)
+
 let diagonals xss =
   diagonals empty xss
 

--- a/stdlib/seq.ml
+++ b/stdlib/seq.ml
@@ -80,3 +80,632 @@ let rec unfold f u () =
   match f u with
   | None -> Nil
   | Some (x, u') -> Cons (x, unfold f u')
+
+let is_empty xs =
+  match xs() with
+  | Nil ->
+      true
+  | Cons (_, _) ->
+      false
+
+let head xs =
+  match xs() with
+  | Nil ->
+      invalid_arg "Seq.head"
+  | Cons (x, _) ->
+      x
+
+let tail xs =
+  match xs() with
+  | Nil ->
+      invalid_arg "Seq.tail"
+  | Cons (_, xs) ->
+      xs
+
+let uncons xs =
+  match xs() with
+  | Cons (x, xs) ->
+      Some (x, xs)
+  | Nil ->
+      None
+
+
+
+let rec length_aux accu xs =
+  match xs() with
+  | Nil ->
+      accu
+  | Cons (_, xs) ->
+      length_aux (accu + 1) xs
+
+let[@inline] length xs =
+  length_aux 0 xs
+
+let rec iteri_aux f i xs =
+  match xs() with
+  | Nil ->
+      ()
+  | Cons (x, xs) ->
+      f i x;
+      iteri_aux f (i+1) xs
+
+let[@inline] iteri f xs =
+  iteri_aux f 0 xs
+
+let rec fold_left_i_aux f i accu xs =
+  match xs() with
+  | Nil ->
+      accu
+  | Cons (x, xs) ->
+      let accu = f i accu x in
+      fold_left_i_aux f (i+1) accu xs
+
+let fold_left_i f accu xs =
+  fold_left_i_aux f 0 accu xs
+
+let rec for_all p xs =
+  match xs() with
+  | Nil ->
+      true
+  | Cons (x, xs) ->
+      p x && for_all p xs
+
+let rec exists p xs =
+  match xs() with
+  | Nil ->
+      false
+  | Cons (x, xs) ->
+      p x || exists p xs
+
+let rec find p xs =
+  match xs() with
+  | Nil ->
+      None
+  | Cons (x, xs) ->
+      if p x then Some x else find p xs
+
+let rec find_map f xs =
+  match xs() with
+  | Nil ->
+      None
+  | Cons (x, xs) ->
+      match f x with
+      | None ->
+          find_map f xs
+      | Some _ as result ->
+          result
+
+(* [iter2], [fold_left2], [for_all2], [exists2], [map2], [zip] work also in
+   the case where the two sequences have different lengths. They stop as soon
+   as one sequence is exhausted. Their behavior is slightly asymmetric: when
+   [xs] is empty, they do not force [ys]; however, when [ys] is empty, [xs] is
+   forced, even though the result of the function application [xs()] turns out
+   to be useless. *)
+
+let rec iter2 f xs ys =
+  match xs() with
+  | Nil ->
+      ()
+  | Cons (x, xs) ->
+      match ys() with
+      | Nil ->
+          ()
+      | Cons (y, ys) ->
+          f x y;
+          iter2 f xs ys
+
+let rec fold_left2 f accu xs ys =
+  match xs() with
+  | Nil ->
+      accu
+  | Cons (x, xs) ->
+      match ys() with
+      | Nil ->
+          accu
+      | Cons (y, ys) ->
+          let accu = f accu x y in
+          fold_left2 f accu xs ys
+
+let rec for_all2 f xs ys =
+  match xs() with
+  | Nil ->
+      true
+  | Cons (x, xs) ->
+      match ys() with
+      | Nil ->
+          true
+      | Cons (y, ys) ->
+          f x y && for_all2 f xs ys
+
+let rec exists2 f xs ys =
+  match xs() with
+  | Nil ->
+      false
+  | Cons (x, xs) ->
+      match ys() with
+      | Nil ->
+          false
+      | Cons (y, ys) ->
+          f x y || exists2 f xs ys
+
+let rec equal eq xs ys =
+  match xs(), ys() with
+  | Nil, Nil ->
+      true
+  | Cons (x, xs), Cons (y, ys) ->
+      eq x y && equal eq xs ys
+  | Nil, Cons (_, _)
+  | Cons (_, _), Nil ->
+      false
+
+let rec compare cmp xs ys =
+  match xs(), ys() with
+  | Nil, Nil ->
+      0
+  | Cons (x, xs), Cons (y, ys) ->
+      let c = cmp x y in
+      if c <> 0 then c else compare cmp xs ys
+  | Nil, Cons (_, _) ->
+      -1
+  | Cons (_, _), Nil ->
+      +1
+
+
+
+(* [init_aux f i j] is the sequence [f i, ..., f (j-1)].
+   It is equivalent to [map f (up i j)]. *)
+
+let rec init_aux f i j () =
+  if i < j then begin
+    Cons (f i, init_aux f (i + 1) j)
+  end
+  else
+    Nil
+
+let init n f =
+  if n < 0 then
+    invalid_arg "Seq.init"
+  else
+    init_aux f 0 n
+
+let rec repeat x () =
+  Cons (x, repeat x)
+
+let rec forever f () =
+  Cons (f(), forever f)
+
+(* [assert_length_is_at_least msg k xs] produces a sequence that is equivalent
+   to [xs], but whose evaluation fails if it turns out that the sequence has
+   fewer than [k] elements. *)
+
+let rec assert_length_is_at_least msg k xs =
+  if k <= 0 then
+    xs
+  else
+    fun () ->
+      match xs() with
+      | Nil ->
+          invalid_arg msg
+      | Cons (x, xs) ->
+          Cons (x, assert_length_is_at_least msg (k-1) xs)
+
+(* This version of [cycle] requires the sequence [xs] to be nonempty. Applying
+   it to an empty sequence would produce a sequence that diverges when it is
+   forced. *)
+
+let rec cycle xs () =
+  append xs (cycle xs) ()
+
+(* [cycle] is redefined to check (at runtime) that [xs] is nonempty. Thus,
+   [cycle empty] produces a sequence that fails when it is forced. Note that
+   this is *not* a recursive definition. *)
+
+let cycle xs =
+  append (assert_length_is_at_least "Seq.cycle" 1 xs) (cycle xs)
+
+(* [iterate1 f x] is the sequence [f x, f (f x), ...].
+   It is equivalent to [tail (iterate f x)].
+   [iterate1] is used as a building block in the definition of [iterate]. *)
+
+let rec iterate1 f x () =
+  let y = f x in
+  Cons (y, iterate1 f y)
+
+(* [iterate f x] is the sequence [x, f x, ...]. *)
+
+let iterate f x =
+  cons x (iterate1 f x)
+
+
+
+let rec mapi_aux f i xs () =
+  match xs() with
+  | Nil ->
+      Nil
+  | Cons (x, xs) ->
+      Cons (f i x, mapi_aux f (i+1) xs)
+
+let[@inline] mapi f xs =
+  mapi_aux f 0 xs
+
+(* [tail_scan f s xs] is equivalent to [tail (scan f s xs)].
+   [tail_scan] is used as a building block in the definition of [scan]. *)
+
+let rec tail_scan f s xs () =
+  match xs() with
+  | Nil ->
+      Nil
+  | Cons (x, xs) ->
+      let s = f s x in
+      Cons (s, tail_scan f s xs)
+
+let scan f s xs =
+  cons s (tail_scan f s xs)
+
+(* [take] is defined in such a way that [take 0 xs] returns [empty]
+   immediately, without allocating any memory. *)
+
+let rec take_aux n xs =
+  if n = 0 then
+    empty
+  else
+    fun () ->
+      match xs() with
+      | Nil ->
+          Nil
+      | Cons (x, xs) ->
+          Cons (x, take_aux (n-1) xs)
+
+let take n xs =
+  if n < 0 then invalid_arg "Seq.take";
+  take_aux n xs
+
+(* [force_drop n xs] is equivalent to [drop n xs ()].
+   [force_drop n xs] requires [n > 0].
+   [force_drop] is used as a building block in the definition of [drop]. *)
+
+let rec force_drop n xs =
+  match xs() with
+  | Nil ->
+      Nil
+  | Cons (_, xs) ->
+      let n = n - 1 in
+      if n = 0 then
+        xs()
+      else
+        force_drop n xs
+
+(* [drop] is defined in such a way that [drop 0 xs] returns [xs] immediately,
+   without allocating any memory. *)
+
+let drop n xs =
+  if n < 0 then invalid_arg "Seq.drop"
+  else if n = 0 then
+    xs
+  else
+    fun () ->
+      force_drop n xs
+
+let rec take_while p xs () =
+  match xs() with
+  | Nil ->
+      Nil
+  | Cons (x, xs) ->
+      if p x then Cons (x, take_while p xs) else Nil
+
+let rec drop_while p xs () =
+  match xs() with
+  | Nil ->
+      Nil
+  | Cons (x, xs) as node ->
+      if p x then drop_while p xs () else node
+
+(* [uniq1 eq x ys] is equivalent to [uniq eq (cons x ys)].
+   [uniq1] is used as a building block in the definition of [uniq]. *)
+
+let rec uniq1 eq x ys () =
+  match ys() with
+  | Nil ->
+      Nil
+  | Cons (y, ys) ->
+      if eq x y then
+        uniq1 eq x ys ()
+      else
+        Cons (y, uniq1 eq y ys)
+
+let uniq eq xs () =
+  match xs() with
+  | Nil ->
+      Nil
+  | Cons (x, ys) ->
+      Cons (x, uniq1 eq x ys)
+
+let rec group eq xs () =
+  match xs() with
+  | Nil ->
+      Nil
+  | Cons (x, xs) ->
+      Cons (cons x (take_while (eq x) xs), group eq (drop_while (eq x) xs))
+
+exception ForcedTwice
+
+module Suspension = struct
+
+  type 'a suspension =
+    unit -> 'a
+
+  (* Conversions. *)
+
+  let to_lazy : 'a suspension -> 'a Lazy.t =
+    Lazy.from_fun
+    (* fun s -> lazy (s()) *)
+
+  let from_lazy (s : 'a Lazy.t) : 'a suspension =
+    fun () -> Lazy.force s
+
+  (* [memoize] turns an arbitrary suspension into a persistent suspension. *)
+
+  let memoize (s : 'a suspension) : 'a suspension =
+    from_lazy (to_lazy s)
+
+  (* [failure] is a suspension that fails when forced. *)
+
+  let failure : _ suspension =
+    fun () ->
+      (* A suspension created by [once] has been forced twice. *)
+      raise ForcedTwice
+
+  (* If [f] is a suspension, then [once f] is a suspension that can be forced
+     at most once. If it is forced more than once, then [ForcedTwice] is
+     raised. *)
+
+  let once (f : 'a suspension) : 'a suspension =
+    let action = ref f in
+    fun () ->
+      let f = !action in
+      action := failure;
+      f()
+
+end (* Suspension *)
+
+let rec memoize xs =
+  Suspension.memoize (fun () ->
+    match xs() with
+    | Nil ->
+        Nil
+    | Cons (x, xs) ->
+        Cons (x, memoize xs)
+  )
+
+let rec once xs =
+  Suspension.once (fun () ->
+    match xs() with
+    | Nil ->
+        Nil
+    | Cons (x, xs) ->
+        Cons (x, once xs)
+  )
+
+
+let rec zip xs ys () =
+  match xs() with
+  | Nil ->
+      Nil
+  | Cons (x, xs) ->
+      match ys() with
+      | Nil ->
+          Nil
+      | Cons (y, ys) ->
+          Cons ((x, y), zip xs ys)
+
+let rec map2 f xs ys () =
+  match xs() with
+  | Nil ->
+      Nil
+  | Cons (x, xs) ->
+      match ys() with
+      | Nil ->
+          Nil
+      | Cons (y, ys) ->
+          Cons (f x y, map2 f xs ys)
+
+let rec interleave xs ys () =
+  match xs() with
+  | Nil ->
+      ys()
+  | Cons (x, xs) ->
+      Cons (x, interleave ys xs)
+
+(* [sorted_merge1l cmp x xs ys] is equivalent to
+     [sorted_merge cmp (cons x xs) ys].
+
+   [sorted_merge1r cmp xs y ys] is equivalent to
+     [sorted_merge cmp xs (cons y ys)].
+
+   [sorted_merge1 cmp x xs y ys] is equivalent to
+     [sorted_merge cmp (cons x xs) (cons y ys)].
+
+   These three functions are used as building blocks in the definition
+   of [sorted_merge]. *)
+
+let rec sorted_merge1l cmp x xs ys () =
+  match ys() with
+  | Nil ->
+      Cons (x, xs)
+  | Cons (y, ys) ->
+      sorted_merge1 cmp x xs y ys
+
+and sorted_merge1r cmp xs y ys () =
+  match xs() with
+  | Nil ->
+      Cons (y, ys)
+  | Cons (x, xs) ->
+      sorted_merge1 cmp x xs y ys
+
+and sorted_merge1 cmp x xs y ys =
+  if cmp x y <= 0 then
+    Cons (x, sorted_merge1r cmp xs y ys)
+  else
+    Cons (y, sorted_merge1l cmp x xs ys)
+
+let sorted_merge cmp xs ys () =
+  match xs(), ys() with
+    | Nil, Nil ->
+        Nil
+    | Nil, c
+    | c, Nil ->
+        c
+    | Cons (x, xs), Cons (y, ys) ->
+        sorted_merge1 cmp x xs y ys
+
+
+let rec map_fst xys () =
+  match xys() with
+  | Nil ->
+      Nil
+  | Cons ((x, _), xys) ->
+      Cons (x, map_fst xys)
+
+let rec map_snd xys () =
+  match xys() with
+  | Nil ->
+      Nil
+  | Cons ((_, y), xys) ->
+      Cons (y, map_snd xys)
+
+let unzip xys =
+  map_fst xys, map_snd xys
+
+let rec filter_map_find_left xs () =
+  match xs() with
+  | Nil ->
+      Nil
+  | Cons (Either.Left x, xs) ->
+      Cons (x, filter_map_find_left xs)
+  | Cons (Either.Right _, xs) ->
+      filter_map_find_left xs ()
+
+let rec filter_map_find_right xs () =
+  match xs() with
+  | Nil ->
+      Nil
+  | Cons (Either.Left _, xs) ->
+      filter_map_find_right xs ()
+  | Cons (Either.Right x, xs) ->
+      Cons (x, filter_map_find_right xs)
+
+let dispatch xs =
+  filter_map_find_left xs,
+  filter_map_find_right xs
+
+let partition p xs =
+  filter p xs, filter (fun x -> not (p x)) xs
+
+(* If [xss] is a matrix (a sequence of rows), then [peel xss] is a pair of
+   the first column (a sequence of elements) and of the remainder of the
+   matrix (a sequence of shorter rows). These two sequences have the same
+   length. The rows of the matrix [xss] are not required to have the same
+   length. An empty row is ignored. *)
+
+(* Because [peel] uses [unzip], its argument must be persistent. The same
+   remark applies to [transpose], [diagonals], [product], etc. *)
+
+let peel xss =
+  unzip (filter_map uncons xss)
+
+let rec transpose xss () =
+  let heads, tails = peel xss in
+  if is_empty heads then begin
+    assert (is_empty tails);
+    Nil
+  end
+  else
+    Cons (heads, transpose tails)
+
+(* The internal function [diagonals] takes an extra argument, [remainders],
+   which contains the remainders of the rows that have already been
+   discovered. *)
+
+let rec diagonals remainders xss () =
+  match xss() with
+  | Cons (xs, xss) ->
+      begin match xs() with
+      | Cons (x, xs) ->
+          (* We discover a new nonempty row [x :: xs]. Thus, the next diagonal
+             is [x :: heads]: this diagonal begins with [x] and continues with
+             the first element of every row in [remainders]. In the recursive
+             call, the argument [remainders] is instantiated with [xs ::
+             tails], which means that we have one more remaining row, [xs],
+             and that we keep the tails of the pre-existing remaining rows. *)
+          let heads, tails = peel remainders in
+          Cons (cons x heads, diagonals (cons xs tails) xss)
+      | Nil ->
+          (* We discover a new empty row. In this case, the new diagonal is
+             just [heads], and [remainders] is instantiated with just [tails],
+             as we do not have one more remaining row. *)
+          let heads, tails = peel remainders in
+          Cons (heads, diagonals tails xss)
+      end
+  | Nil ->
+      (* There are no more rows to be discovered. There remains to exhaust
+         the remaining rows. *)
+      transpose remainders ()
+
+let diagonals xss =
+  diagonals empty xss
+
+let product_with f xs ys =
+  concat (diagonals (
+    map (fun x ->
+      map (fun y ->
+        f x y
+      ) ys
+    ) xs
+  ))
+
+let product xs ys =
+  product_with (fun x y -> (x, y)) xs ys
+
+let ap fs xs =
+  product_with (fun f x -> f x) fs xs
+
+
+
+let of_iterator it =
+  let rec c () =
+    match it() with
+    | None ->
+        Nil
+    | Some x ->
+        Cons (x, c)
+  in
+  c
+
+let to_iterator xs =
+  let s = ref xs in
+  fun () ->
+    match (!s)() with
+    | Nil ->
+        None
+    | Cons (x, xs) ->
+        s := xs;
+        Some x
+
+
+
+let rec ints i () =
+  Cons (i, ints (i + 1))
+
+let rec up i j () =
+  if i < j then Cons (i, up (i + 1) j) else Nil
+
+let rec down i j () =
+  if i > j then Cons (i - 1, down (i - 1) j) else Nil
+
+
+module Infix = struct
+  let (@) = append
+  let (>>=) xs f = flat_map f xs
+  let (>|=) xs f = map f xs
+  let (<*>) = ap
+end

--- a/stdlib/seq.ml
+++ b/stdlib/seq.ml
@@ -126,7 +126,7 @@ let rec fold_lefti_aux f i accu xs =
       let accu = f i accu x in
       fold_lefti_aux f (i+1) accu xs
 
-let fold_lefti f accu xs =
+let[@inline] fold_lefti f accu xs =
   fold_lefti_aux f 0 accu xs
 
 let rec for_all p xs =

--- a/stdlib/seq.ml
+++ b/stdlib/seq.ml
@@ -260,22 +260,24 @@ let rec repeat x () =
 let rec forever f () =
   Cons (f(), forever f)
 
-(* This version of [cycle] requires the sequence [xs] to be nonempty. Applying
-   it to an empty sequence would produce a sequence that diverges when it is
-   forced. *)
+(* This preliminary definition of [cycle] requires the sequence [xs]
+   to be nonempty. Applying it to an empty sequence would produce a
+   sequence that diverges when it is forced. *)
 
-let rec cycle xs () =
-  append xs (cycle xs) ()
+let rec cycle_nonempty xs () =
+  append xs (cycle_nonempty xs) ()
 
-(* [cycle] is redefined to check whether [xs] is empty and, if so, return
-   an empty sequence. Note that this is *not* a recursive definition. *)
+(* [cycle xs] checks whether [xs] is empty and, if so, returns an empty
+   sequence. Otherwise, [cycle xs] produces one copy of [xs] followed
+   with the infinite sequence [cycle_nonempty xs]. Thus, the nonemptiness
+   check is performed just once. *)
 
 let cycle xs () =
   match xs() with
   | Nil ->
       Nil
   | Cons (x, xs') ->
-      Cons (x, append xs' (cycle xs))
+      Cons (x, append xs' (cycle_nonempty xs))
 
 (* [iterate1 f x] is the sequence [f x, f (f x), ...].
    It is equivalent to [tail (iterate f x)].

--- a/stdlib/seq.ml
+++ b/stdlib/seq.ml
@@ -641,6 +641,17 @@ let rec diagonals remainders xss () =
          the remaining rows. *)
       transpose remainders ()
 
+(* If [xss] is a matrix (a sequence of rows), then [diagonals xss] is
+   the sequence of its diagonals.
+
+   The first diagonal contains just the first element of the
+   first row. The second diagonal contains the first element of the
+   second row and the second element of the first row; and so on.
+
+   - Every diagonal is a finite sequence.
+   - The rows of the matrix [xss] are not required to have the same length.
+   - The matrix [xss] is not required to be finite (in either direction).
+   - The matrix [xss] must be persistent. *)
 let diagonals xss =
   diagonals empty xss
 

--- a/stdlib/seq.ml
+++ b/stdlib/seq.ml
@@ -465,9 +465,6 @@ let rec zip xs ys () =
       | Cons (y, ys) ->
           Cons ((x, y), zip xs ys)
 
-let combine =
-  zip
-
 let rec map2 f xs ys () =
   match xs() with
   | Nil ->

--- a/stdlib/seq.ml
+++ b/stdlib/seq.ml
@@ -656,7 +656,7 @@ let map_product f xs ys =
 let product xs ys =
   map_product (fun x y -> (x, y)) xs ys
 
-let of_distributor it =
+let of_dispenser it =
   let rec c () =
     match it() with
     | None ->
@@ -666,7 +666,7 @@ let of_distributor it =
   in
   c
 
-let to_distributor xs =
+let to_dispenser xs =
   let s = ref xs in
   fun () ->
     match (!s)() with

--- a/stdlib/seq.ml
+++ b/stdlib/seq.ml
@@ -446,10 +446,12 @@ module Suspension = struct
      raised. *)
 
   let once (f : 'a suspension) : 'a suspension =
-    let action = ref f in
+    let action = CamlinternalAtomic.make f in
     fun () ->
-      let f = !action in
-      action := failure;
+      (* Get the function currently stored in [action], and write the
+         function [failure] in its place, so the next access will result
+         in a call to [failure()]. *)
+      let f = CamlinternalAtomic.exchange action failure in
       f()
 
 end (* Suspension *)

--- a/stdlib/seq.mli
+++ b/stdlib/seq.mli
@@ -133,9 +133,9 @@ val is_empty : 'a t -> bool
 (** [is_empty xs] determines whether the sequence [xs] is empty.
 
     It is recommended that the sequence [xs] be persistent.
-    Indeed, if [xs] is ephemeral, then [is_empty xs] counts as
-    one use of the sequence [xs], and may prevent further uses
-    of [xs].
+    Indeed, [is_empty xs] demands the head of the sequence [xs],
+    so, if [xs] is ephemeral, it may be the case that [xs] cannot
+    be used any more after this call has taken place.
 
     @since 4.14 *)
 

--- a/stdlib/seq.mli
+++ b/stdlib/seq.mli
@@ -116,9 +116,9 @@ and +'a node =
 
    Similarly, among the functions that consume two sequences,
    one can distinguish two groups:
-   - [iter2], [fold_left2], [for_all2] consumes both sequences all the way
+   - [iter2] and [fold_left2] consume both sequences all the way
      to the end, provided the sequences have the same length.
-   - [exists2], [equal], [compare] consume the sequences down to a certain
+   - [for_all2], [exists2], [equal], [compare] consume the sequences down to a certain
      depth, which is a priori unpredictable.
 
    The functions that consume two sequences can be applied to two sequences

--- a/stdlib/seq.mli
+++ b/stdlib/seq.mli
@@ -76,7 +76,7 @@
    As a general rule, the functions that build sequences, such as [map],
    [filter], [scan], [take], etc., produce sequences whose elements are
    computed only on demand. The functions that eagerly consume sequences,
-   such as [is_empty], [head], [tail], [find], [length], [iter], [fold_left],
+   such as [is_empty], [find], [length], [iter], [fold_left],
    etc., are the functions that force computation to take place.
 
    When possible, we recommend using sequences rather than iterators
@@ -108,7 +108,7 @@ and +'a node =
 
    The functions in this section consume their argument, a sequence, either
    partially or completely:
-   - [is_empty], [head], [tail], [uncons] consume the sequence down to depth 1.
+   - [is_empty] and [uncons] consume the sequence down to depth 1.
      That is, they demand the first argument of the sequence, if there is one.
    - [iter], [fold_left], [length], etc., consume the sequence all the way to
      its end. The sequence must be finite; otherwise, they do not terminate.

--- a/stdlib/seq.mli
+++ b/stdlib/seq.mli
@@ -78,12 +78,12 @@
    such as [is_empty], [find], [length], [iter], [fold_left],
    etc., are the functions that force computation to take place.
 
-   When possible, we recommend using sequences rather than distributors
+   When possible, we recommend using sequences rather than dispensers
    (functions of type [unit -> 'a option] that produce elements upon
-   demand). Whereas sequences can be persistent or ephemeral, distributors
+   demand). Whereas sequences can be persistent or ephemeral, dispensers
    are always ephemeral, and are typically more difficult to work with
-   than sequences. Two conversion functions, {!to_distributor} and
-   {!of_distributor}, are provided.
+   than sequences. Two conversion functions, {!to_dispenser} and
+   {!of_dispenser}, are provided.
 
     @since 4.07 *)
 
@@ -733,27 +733,27 @@ val partition : ('a -> bool) -> 'a t -> 'a t * 'a t
 
     @since 4.14 *)
 
-(** {1 Converting between sequences and distributors} *)
+(** {1 Converting between sequences and dispensers} *)
 
-(** A distributor is a representation of a sequence as a function of type
+(** A dispenser is a representation of a sequence as a function of type
     [unit -> 'a option]. Every time this function is invoked, it returns
     the next element of the sequence. When there are no more elements,
-    it returns [None]. A distributor has mutable internal state, therefore
+    it returns [None]. A dispenser has mutable internal state, therefore
     is ephemeral: the sequence that it represents can be consumed at most
     once. *)
 
-val of_distributor : (unit -> 'a option) -> 'a t
-(** [of_distributor it] is the sequence of the elements produced by the
-    distributor [it]. It is an ephemeral sequence: it can be consumed at most
+val of_dispenser : (unit -> 'a option) -> 'a t
+(** [of_dispenser it] is the sequence of the elements produced by the
+    dispenser [it]. It is an ephemeral sequence: it can be consumed at most
     once. If a persistent sequence is needed, use
-    [memoize (of_distributor it)].
+    [memoize (of_dispenser it)].
 
     @since 4.14 *)
 
-val to_distributor : 'a t -> (unit -> 'a option)
-(** [to_distributor xs] is a fresh distributor on the sequence [xs].
+val to_dispenser : 'a t -> (unit -> 'a option)
+(** [to_dispenser xs] is a fresh dispenser on the sequence [xs].
 
-    This distributor has mutable internal state,
+    This dispenser has mutable internal state,
     which is not protected by a lock;
     so, it must not be used by several threads concurrently.
 

--- a/stdlib/seq.mli
+++ b/stdlib/seq.mli
@@ -557,24 +557,6 @@ val transpose : 'a t t -> 'a t t
 
     @since 4.14 *)
 
-val diagonals : 'a t t -> 'a t t
-(** If [xss] is a matrix (a sequence of rows), then [diagonals xss] is
-    the sequence of its diagonals.
-
-    The first diagonal contains just the first element of the
-    first row. The second diagonal contains the first element of the
-    second row and the second element of the first row; and so on.
-
-    Every diagonal is a finite sequence.
-
-    The rows of the matrix [xss] are not required to have the same length.
-
-    The matrix [xss] is not required to be finite (in either direction).
-
-    The matrix [xss] must be persistent.
-
-    @since 4.14 *)
-
 (** {1 Combining sequences} *)
 
 val append : 'a t -> 'a t -> 'a t

--- a/stdlib/seq.mli
+++ b/stdlib/seq.mli
@@ -118,8 +118,8 @@ and +'a node =
    one can distinguish two groups:
    - [iter2] and [fold_left2] consume both sequences all the way
      to the end, provided the sequences have the same length.
-   - [for_all2], [exists2], [equal], [compare] consume the sequences down to a certain
-     depth, which is a priori unpredictable.
+   - [for_all2], [exists2], [equal], [compare] consume the sequences down
+     to a certain depth, which is a priori unpredictable.
 
    The functions that consume two sequences can be applied to two sequences
    of distinct lengths: in that case, the excess elements in the longer
@@ -654,8 +654,8 @@ val product : 'a t -> 'b t -> ('a * 'b) t
     @since 4.14 *)
 
 val map_product : ('a -> 'b -> 'c) -> 'a t -> 'b t -> 'c t
-(** The sequence [map_product f xs ys] is the image through [f] of the Cartesian
-    product of the sequences [xs] and [ys].
+(** The sequence [map_product f xs ys] is the image through [f]
+    of the Cartesian product of the sequences [xs] and [ys].
 
     For every element [x] of [xs] and for every element [y] of [ys],
     the element [f x y] appears once as an element of [map_product f xs ys].
@@ -696,8 +696,9 @@ val partition_map : ('a -> ('b, 'c) Either.t) -> 'a t -> 'b t * 'c t
     - [zs] is the sequence of the elements [z] such that
       [f x = Right z], where [x] ranges over [xs].
 
-    [partition_map f xs] is equivalent to
-    [(filter_map Either.find_left (map f xs), filter_map Either.find_right (map f xs))].
+    [partition_map f xs] is equivalent to a pair of
+    [filter_map Either.find_left (map f xs)] and
+    [filter_map Either.find_right (map f xs)].
 
     Querying either of the sequences returned by [partition_map f xs]
     causes [xs] to be queried.

--- a/stdlib/seq.mli
+++ b/stdlib/seq.mli
@@ -505,20 +505,6 @@ val drop_while : ('a -> bool) -> 'a t -> 'a t
 
     @since 4.14 *)
 
-val uniq : ('a -> 'a -> bool) -> 'a t -> 'a t
-(** Provided the function [eq] defines an equality on elements,
-    [uniq eq xs] is the sequence [xs],
-    deprived of its adjacent duplicate elements.
-
-    Thus, [uniq eq xs] has no adjacent duplicate elements.
-    Furthermore, if [xs] is sorted according to an ordering
-    that is compatible with [eq],
-    then [uniq eq xs] has no duplicate elements at all.
-
-    [uniq eq xs] is equivalent to [map head (group eq xs)].
-
-    @since 4.14 *)
-
 val group : ('a -> 'a -> bool) -> 'a t -> 'a t t
 (** Provided the function [eq] defines an equality on elements,
     [group eq xs] is the sequence of the maximal runs

--- a/stdlib/seq.mli
+++ b/stdlib/seq.mli
@@ -34,9 +34,8 @@
      just like an immutable list; or
    - {b ephemeral},
      which means that the sequence is not persistent.
-     Querying an ephemeral sequence can have an observable side effect,
-     such as incrementing a mutable counter or reading data from some
-     external source.
+     Querying an ephemeral sequence might have an observable side effect,
+     such as incrementing a mutable counter.
      As a common special case, an ephemeral sequence can be {b affine},
      which means that it must be queried at most once.
 

--- a/stdlib/seq.mli
+++ b/stdlib/seq.mli
@@ -391,13 +391,13 @@ val cycle : 'a t -> 'a t
 (** [cycle xs] is the infinite sequence which consists of an infinite
     number of repetitions of the sequence [xs].
 
-    The sequence [xs] must be nonempty.
+    If [xs] is an empty sequence,
+    then [cycle xs] is empty as well.
 
     Consuming (a prefix of) the sequence [cycle xs] once
     can cause the sequence [xs] to be consumed more than once.
     Therefore, [xs] must be persistent.
 
-    @raise Invalid_argument if [xs] is empty.
     @since 4.14 *)
 
 val iterate : ('a -> 'a) -> 'a -> 'a t

--- a/stdlib/seq.mli
+++ b/stdlib/seq.mli
@@ -194,15 +194,15 @@ val iteri : (int -> 'a -> unit) -> 'a t -> unit
 
     @since 4.14 *)
 
-val fold_left_i : (int -> 'b -> 'a -> 'b) -> 'b -> 'a t -> 'b
-(** [fold_left_i f _ xs] invokes [f _ i x] successively
+val fold_lefti : (int -> 'b -> 'a -> 'b) -> 'b -> 'a t -> 'b
+(** [fold_lefti f _ xs] invokes [f _ i x] successively
     for every element [x] located at index [i] of the sequence [xs].
 
     An accumulator of type ['a] is threaded through the calls to [f].
 
     The sequence [xs] must be finite.
 
-    [fold_left_i f accu xs] is equivalent to
+    [fold_lefti f accu xs] is equivalent to
     [fold_left (fun accu (i, x) -> f accu i x) accu (zip (ints 0) xs)].
 
     @since 4.14 *)
@@ -541,7 +541,7 @@ val memoize : 'a t -> 'a t
     [xs] is queried at most once.
     @since 4.14 *)
 
-exception ForcedTwice
+exception Forced_twice
 (** This exception is raised when a sequence returned by [once]
     (or a suffix of it) is queried more than once.
     @since 4.14 *)
@@ -552,10 +552,10 @@ val once: 'a t -> 'a t
     Regardless of whether [xs] is ephemeral or persistent,
     [once xs] is an ephemeral sequence: it can be queried at most once.
     If it (or a suffix of it) is queried more than once, then the exception
-    [ForcedTwice] is raised. This can be useful, while debugging or testing,
+    [Forced_twice] is raised. This can be useful, while debugging or testing,
     to ensure that a sequence is consumed at most once.
 
-    @raise ForcedTwice if [once xs], or a suffix of it,
+    @raise Forced_twice if [once xs], or a suffix of it,
            is queried more than once.
     @since 4.14 *)
 

--- a/stdlib/seq.mli
+++ b/stdlib/seq.mli
@@ -577,15 +577,12 @@ val append : 'a t -> 'a t -> 'a t
 
     @since 4.11 *)
 
-val concat : ?sep:'a t -> 'a t t -> 'a t
+val concat : 'a t t -> 'a t
 (** If [xss] is a sequence of sequences,
     then [concat xss] is its concatenation.
 
     If [xss] is the sequence [xs0; xs1; ...] then
     [concat xss] is the sequence [xs0 @ xs1 @ ...].
-
-    @param sep a (finite, persistent) sequence of items to insert in between
-    each elements of [xss]. By default it is [empty].
 
     @since 4.13 *)
 

--- a/stdlib/seq.mli
+++ b/stdlib/seq.mli
@@ -129,7 +129,10 @@ and +'a node =
 val is_empty : 'a t -> bool
 (** [is_empty xs] determines whether the sequence [xs] is empty.
 
-    On an ephemeral sequence, it will consume the first element.
+    It is recommended that the sequence [xs] be persistent.
+    Indeed, if [xs] is ephemeral, then [is_empty xs] counts as
+    one use of the sequence [xs], and may prevent further uses
+    of [xs].
 
     @since 4.14 *)
 

--- a/stdlib/seq.mli
+++ b/stdlib/seq.mli
@@ -111,13 +111,13 @@ and +'a node =
    - [is_empty] and [uncons] consume the sequence down to depth 1.
      That is, they demand the first argument of the sequence, if there is one.
    - [iter], [fold_left], [length], etc., consume the sequence all the way to
-     its end. The sequence must be finite; otherwise, they do not terminate.
+     its end. They terminate only if the sequence is finite.
    - [for_all], [exists], [find], etc. consume the sequence down to a certain
      depth, which is a priori unpredictable.
 
    The functions that consume two sequences can be organized in two subgroups:
    - [iter2], [fold_left2], [for_all2], etc., consume both sequences all the
-     way to the end, provided they have the same length. Otherwise, they fully
+     way to the end, provided the sequences have the same length. Otherwise, they fully
      consume the shorter sequence, and ignore the remainder of the longer
      sequence.
    - [exists2], [equal], [compare] consume the sequences down to a certain
@@ -161,7 +161,7 @@ val iter : ('a -> unit) -> 'a t -> unit
     for every element [x] of the sequence [xs],
     from left to right.
 
-    The sequence [xs] must be finite. *)
+    It terminates only if the sequence [xs] is finite. *)
 
 val fold_left : ('a -> 'b -> 'a) -> 'a -> 'b t -> 'a
 (** [fold_left f _ xs] invokes [f _ x] successively
@@ -170,13 +170,13 @@ val fold_left : ('a -> 'b -> 'a) -> 'a -> 'b t -> 'a
 
     An accumulator of type ['a] is threaded through the calls to [f].
 
-    The sequence [xs] must be finite. *)
+    It terminates only if the sequence [xs] is finite. *)
 
 val iteri : (int -> 'a -> unit) -> 'a t -> unit
 (** [iteri f xs] invokes [f i x] successively
     for every element [x] located at index [i] in the sequence [xs].
 
-    The sequence [xs] must be finite.
+    It terminates only if the sequence [xs] is finite.
 
     [iteri f xs] is equivalent to
     [iter (fun (i, x) -> f i x) (zip (ints 0) xs)].
@@ -189,7 +189,7 @@ val fold_lefti : (int -> 'b -> 'a -> 'b) -> 'b -> 'a t -> 'b
 
     An accumulator of type ['a] is threaded through the calls to [f].
 
-    The sequence [xs] must be finite.
+    It terminates only if the sequence [xs] is finite.
 
     [fold_lefti f accu xs] is equivalent to
     [fold_left (fun accu (i, x) -> f accu i x) accu (zip (ints 0) xs)].
@@ -216,8 +216,9 @@ val find : ('a -> bool) -> 'a t -> 'a option
 (** [find p xs] returns [Some x], where [x] is the first element of the
     sequence [xs] that satisfies [p x], if there is such an element.
 
-    It returns [None] if there is no such element,
-    provided the sequence [xs] is finite.
+    It returns [None] if there is no such element.node
+
+    The sequence [xs] must be finite.
 
     @since 4.14 *)
 
@@ -226,8 +227,9 @@ val find_map : ('a -> 'b option) -> 'a t -> 'b option
     sequence [xs] such that [f x = Some _], if there is such an element,
     and where [y] is defined by [f x = Some y].
 
-    It returns [None] if there is no such element,
-    provided the sequence [xs] is finite.
+    It returns [None] if there is no such element.
+
+    The sequence [xs] must be finite.
 
     @since 4.14 *)
 
@@ -239,7 +241,8 @@ val iter2 : ('a -> 'b -> unit) -> 'a t -> 'b t -> unit
     iteration stops as soon as one sequence is exhausted;
     the excess elements in the other sequence are ignored.
 
-    At least one of the sequences [xs] and [ys] must be finite.
+    Iteration terminates only if at least one of the sequences
+    [xs] and [ys] is finite.
 
     [iter2 f xs ys] is equivalent to
     [iter (fun (x, y) -> f x y) (zip xs ys)].
@@ -257,7 +260,8 @@ val fold_left2 : ('a -> 'b -> 'c -> 'a) -> 'a -> 'b t -> 'c t -> 'a
     iteration stops as soon as one sequence is exhausted;
     the excess elements in the other sequence are ignored.
 
-    At least one of the sequences [xs] and [ys] must be finite.
+    Iteration terminates only if at least one of the sequences
+    [xs] and [ys] is finite.
 
     [fold_left2 f accu xs ys] is equivalent to
     [fold_left (fun accu (x, y) -> f accu x y) (zip xs ys)].

--- a/stdlib/seq.mli
+++ b/stdlib/seq.mli
@@ -539,7 +539,7 @@ val memoize : 'a t -> 'a t
     @since 4.14 *)
 
 exception Forced_twice
-(** This exception is raised when a sequence returned by [once]
+(** This exception is raised when a sequence returned by {!once}
     (or a suffix of it) is queried more than once.
 
     @since 4.14 *)

--- a/stdlib/seq.mli
+++ b/stdlib/seq.mli
@@ -766,7 +766,7 @@ val to_iterator : 'a t -> (unit -> 'a option)
 (** {1 Sequences of integers} *)
 
 val ints : int -> int t
-(** [ints i] is the infinite sequence of the integers, beginning at [i] and
+(** [ints i] is the infinite sequence of the integers beginning at [i] and
     counting up.
 
     @since 4.14 *)

--- a/stdlib/seq.mli
+++ b/stdlib/seq.mli
@@ -610,11 +610,6 @@ val zip : 'a t -> 'b t -> ('a * 'b) t
 
     @since 4.14 *)
 
-val combine : 'a t -> 'b t -> ('a * 'b) t
-(** [combine] is an alias for {!zip}.
-
-    @since 4.14 *)
-
 val map2 : ('a -> 'b -> 'c) -> 'a t -> 'b t -> 'c t
 (** [map2 f xs ys] is the sequence of the elements [f x y],
     where the pairs [(x, y)] are drawn synchronously from the

--- a/stdlib/seq.mli
+++ b/stdlib/seq.mli
@@ -220,7 +220,7 @@ val find : ('a -> bool) -> 'a t -> 'a option
 (** [find p xs] returns [Some x], where [x] is the first element of the
     sequence [xs] that satisfies [p x], if there is such an element.
 
-    It returns [None] if there is no such element.node
+    It returns [None] if there is no such element.
 
     The sequence [xs] must be finite.
 

--- a/stdlib/seq.mli
+++ b/stdlib/seq.mli
@@ -34,9 +34,11 @@
      just like an immutable list; or
    - {b ephemeral},
      which means that the sequence is not persistent.
-     It can be used at most once, and producing an element can have an
-     observable side effect, such as incrementing a mutable counter or
-     consuming some resource such as a {!Stream}.
+     Querying an ephemeral sequence can have an observable side effect,
+     such as incrementing a mutable counter or reading data from some
+     external source.
+     As a common special case, an ephemeral sequence can be {b affine},
+     which means that it must be queried at most once.
 
    It also does {i not} reveal whether the elements of the sequence are:
 

--- a/stdlib/seq.mli
+++ b/stdlib/seq.mli
@@ -394,7 +394,7 @@ val forever : (unit -> 'a) -> 'a t
     @since 4.14 *)
 
 val cycle : 'a t -> 'a t
-(** [cycle xs] is the infinite sequence which consists of an infinite
+(** [cycle xs] is the infinite sequence that consists of an infinite
     number of repetitions of the sequence [xs].
 
     If [xs] is an empty sequence,

--- a/stdlib/seq.mli
+++ b/stdlib/seq.mli
@@ -575,7 +575,7 @@ val transpose : 'a t t -> 'a t t
 val append : 'a t -> 'a t -> 'a t
 (** [append xs ys] is the concatenation of the sequences [xs] and [ys].
 
-    Its elements are the elements of [xs], followed with the elements of [ys].
+    Its elements are the elements of [xs], followed by the elements of [ys].
 
     @since 4.11 *)
 

--- a/stdlib/seq.mli
+++ b/stdlib/seq.mli
@@ -13,7 +13,7 @@
 (*                                                                        *)
 (**************************************************************************)
 
-(** Sequences (functional iterators).
+(** Sequences.
 
    A sequence of type ['a Seq.t] can be thought of as a {b delayed list},
    that is, a list whose elements are computed only when they are demanded

--- a/stdlib/seq.mli
+++ b/stdlib/seq.mli
@@ -78,12 +78,12 @@
    such as [is_empty], [find], [length], [iter], [fold_left],
    etc., are the functions that force computation to take place.
 
-   When possible, we recommend using sequences rather than iterators
+   When possible, we recommend using sequences rather than distributors
    (functions of type [unit -> 'a option] that produce elements upon
-   demand). Whereas sequences can be persistent or ephemeral, iterators
+   demand). Whereas sequences can be persistent or ephemeral, distributors
    are always ephemeral, and are typically more difficult to work with
-   than sequences. Two conversion functions, {!to_iterator} and
-   {!of_iterator}, are provided.
+   than sequences. Two conversion functions, {!to_distributor} and
+   {!of_distributor}, are provided.
 
     @since 4.07 *)
 
@@ -733,26 +733,27 @@ val partition : ('a -> bool) -> 'a t -> 'a t * 'a t
 
     @since 4.14 *)
 
-(** {1 Converting between sequences and iterators} *)
+(** {1 Converting between sequences and distributors} *)
 
-(** An iterator is a representation of a sequence as a function of type
+(** A distributor is a representation of a sequence as a function of type
     [unit -> 'a option]. Every time this function is invoked, it returns
     the next element of the sequence. When there are no more elements,
-    it returns [None]. An iterator has mutable internal state, therefore
+    it returns [None]. A distributor has mutable internal state, therefore
     is ephemeral: the sequence that it represents can be consumed at most
     once. *)
 
-val of_iterator : (unit -> 'a option) -> 'a t
-(** [of_iterator it] is the sequence of the elements produced by the iterator
-    [it]. It is an ephemeral sequence: it can be consumed at most once. If a
-    persistent sequence is needed, use [memoize (of_iterator it)].
+val of_distributor : (unit -> 'a option) -> 'a t
+(** [of_distributor it] is the sequence of the elements produced by the
+    distributor [it]. It is an ephemeral sequence: it can be consumed at most
+    once. If a persistent sequence is needed, use
+    [memoize (of_distributor it)].
 
     @since 4.14 *)
 
-val to_iterator : 'a t -> (unit -> 'a option)
-(** [to_iterator xs] is a fresh iterator on the sequence [xs].
+val to_distributor : 'a t -> (unit -> 'a option)
+(** [to_distributor xs] is a fresh distributor on the sequence [xs].
 
-    This iterator has mutable internal state,
+    This distributor has mutable internal state,
     which is not protected by a lock;
     so, it must not be used by several threads concurrently.
 

--- a/stdlib/seq.mli
+++ b/stdlib/seq.mli
@@ -611,7 +611,7 @@ val zip : 'a t -> 'b t -> ('a * 'b) t
     @since 4.14 *)
 
 val combine : 'a t -> 'b t -> ('a * 'b) t
-(** [combine] is an alias for [zip].
+(** [combine] is an alias for {!zip}.
 
     @since 4.14 *)
 

--- a/stdlib/seq.mli
+++ b/stdlib/seq.mli
@@ -114,13 +114,17 @@ and +'a node =
    - [for_all], [exists], [find], etc. consume the sequence down to a certain
      depth, which is a priori unpredictable.
 
-   The functions that consume two sequences can be organized in two subgroups:
-   - [iter2], [fold_left2], [for_all2], etc., consume both sequences all the
-     way to the end, provided the sequences have the same length. Otherwise, they fully
-     consume the shorter sequence, and ignore the remainder of the longer
-     sequence.
+   Similarly, among the functions that consume two sequences,
+   one can distinguish two groups:
+   - [iter2], [fold_left2], [for_all2] consumes both sequences all the way
+     to the end, provided the sequences have the same length.
    - [exists2], [equal], [compare] consume the sequences down to a certain
      depth, which is a priori unpredictable.
+
+   The functions that consume two sequences can be applied to two sequences
+   of distinct lengths: in that case, the excess elements in the longer
+   sequence are ignored. (It may be the case that one excess element is
+   demanded, even though this element is not used.)
 
    None of the functions in this section is lazy. These functions
    are consumers: they force some computation to take place. *)

--- a/stdlib/seq.mli
+++ b/stdlib/seq.mli
@@ -149,8 +149,6 @@ val uncons : 'a t -> ('a * 'a t) option
 
     @since 4.14 *)
 
-
-
 val length : 'a t -> int
 (** [length xs] is the length of the sequence [xs].
 

--- a/stdlib/seq.mli
+++ b/stdlib/seq.mli
@@ -721,19 +721,19 @@ val unzip : ('a * 'b) t -> 'a t * 'b t
 
     @since 4.14 *)
 
-val dispatch : ('a, 'b) Either.t t -> 'a t * 'b t
-(** [dispatch] transforms a sequence of fruit (either apples or oranges)
+val partition_either : ('a, 'b) Either.t t -> 'a t * 'b t
+(** [partition_either] transforms a sequence of fruit (either apples or oranges)
     into a pair of a sequence of apples and a sequence of oranges.
 
-    [dispatch xs] is equivalent to
+    [partition_either xs] is equivalent to
     [(filter_map Either.find_left xs, filter_map Either.find_right xs)].
 
-    Querying either of the sequences returned by [dispatch xs]
+    Querying either of the sequences returned by [partition_either xs]
     causes [xs] to be queried.
     Therefore, querying both of them
     causes [xs] to be queried twice.
     Thus, [xs] must be persistent and cheap.
-    If that is not the case, use [dispatch (memoize xs)].
+    If that is not the case, use [partition_either (memoize xs)].
 
     @since 4.14 *)
 

--- a/stdlib/seq.mli
+++ b/stdlib/seq.mli
@@ -403,7 +403,8 @@ val iterate : ('a -> 'a) -> 'a -> 'a t
 (** [iterate f x] is the infinite sequence whose elements are
     [x], [f x], [f (f x)], and so on.
 
-    In other words, it is the sequence of iterates of [f] starting with [x].
+    In other words, it is the orbit of the function [f],
+    starting at [x].
 
     @since 4.14 *)
 

--- a/stdlib/seq.mli
+++ b/stdlib/seq.mli
@@ -537,6 +537,12 @@ val memoize : 'a t -> 'a t
     Regardless of whether [xs] is ephemeral or persistent,
     [memoize xs] is persistent: even if it is queried several times,
     [xs] is queried at most once.
+
+    The construction of the sequence [memoize xs] internally relies on
+    suspensions provided by the module {!Lazy}. These suspensions are
+    {i not} thread-safe. Therefore, the sequence [memoize xs]
+    must {i not} be queried by multiple threads concurrently.
+
     @since 4.14 *)
 
 exception Forced_twice

--- a/stdlib/seq.mli
+++ b/stdlib/seq.mli
@@ -107,3 +107,626 @@ val unfold : ('b -> ('a * 'b) option) -> 'b -> 'a t
     For example, [unfold (function [] -> None | h::t -> Some (h,t)) l]
     is equivalent to [List.to_seq l].
     @since 4.11 *)
+
+(** {1 Consuming sequences} *)
+
+(**
+
+   The functions in this section consume their argument, a sequence, either
+   partially or completely:
+   - [is_empty], [head], [tail], [uncons] consume the sequence down to depth 1.
+     That is, they demand the first argument of the sequence, if there is one.
+   - [iter], [fold_left], [length], etc., consume the sequence all the way to
+     its end. The sequence must be finite; otherwise, they do not terminate.
+   - [for_all], [exists], [find], etc. consume the sequence down to a certain
+     depth, which is a priori unpredictable.
+
+   The functions that consume two sequences can be organized in two subgroups:
+   - [iter2], [fold_left2], [for_all2], etc., consume both sequences all the
+     way to the end, provided they have the same length. Otherwise, they fully
+     consume the shorter sequence, and ignore the remainder of the longer
+     sequence.
+   - [exists2], [equal], [compare] consume the sequences down to a certain
+     depth, which is a priori unpredictable.
+
+   None of the functions in this section is lazy. These functions
+   are consumers: they force some computation to take place. *)
+
+val is_empty:  'a t -> bool
+(** [is_empty xs] determines whether the sequence [xs] is empty.
+
+    @since 4.14 *)
+
+val head : 'a t -> 'a
+(** [head xs] is the first element of the sequence [xs].
+
+    The sequence [xs] must be nonempty.
+
+    @raise Invalid_argument if [xs] is empty.
+    @since 4.14 *)
+
+val tail : 'a t -> 'a t
+(** [tail xs] is the sequence [xs], deprived of its first element.
+
+    The sequence [xs] must be nonempty.
+
+    @raise Invalid_argument if [xs] is empty.
+    @since 4.14 *)
+
+val uncons : 'a t -> ('a * 'a t) option
+(** If [xs] is empty, then [uncons xs] is [None].
+
+    If [xs] is nonempty, then [uncons xs] is
+    [Some (head xs, tail xs)],
+    that is, a pair of the head and tail of the sequence [xs].
+
+    This equivalence holds if [xs] is persistent.
+    If [xs] is ephemeral, then [uncons] must be preferred
+    over separate calls to [head] and [tail],
+    which would cause [xs] to be queried twice.
+
+    @since 4.14 *)
+
+
+
+val length : 'a t -> int
+(** [length xs] is the length of the sequence [xs].
+
+    The sequence [xs] must be finite.
+
+    @since 4.14 *)
+
+val iteri : (int -> 'a -> unit) -> 'a t -> unit
+(** [iteri f xs] invokes [f i x] successively
+    for every element [x] located at index [i] in the sequence [xs].
+
+    The sequence [xs] must be finite.
+
+    [iteri f xs] is equivalent to
+    [iter (fun (i, x) -> f i x) (zip (ints 0) xs)].
+
+    @since 4.14 *)
+
+val fold_left_i : (int -> 'b -> 'a -> 'b) -> 'b -> 'a t -> 'b
+(** [fold_left_i f _ xs] invokes [f _ i x] successively
+    for every element [x] located at index [i] of the sequence [xs].
+
+    An accumulator of type ['a] is threaded through the calls to [f].
+
+    The sequence [xs] must be finite.
+
+    [fold_left_i f accu xs] is equivalent to
+    [fold_left (fun accu (i, x) -> f accu i x) accu (zip (ints 0) xs)].
+
+    @since 4.14 *)
+
+val for_all : ('a -> bool) -> 'a t -> bool
+(** [for_all p xs] determines whether all elements [x] of the sequence [xs]
+    satisfy [p x].
+
+    The sequence [xs] must be finite.
+
+    @since 4.14 *)
+
+val exists : ('a -> bool) -> 'a t -> bool
+(** [exists xs p] determines whether at least one element [x]
+    of the sequence [xs] satisfies [p x].
+
+    The sequence [xs] must be finite.
+
+    @since 4.14 *)
+
+val find : ('a -> bool) -> 'a t -> 'a option
+(** [find p xs] returns [Some x], where [x] is the first element of the
+    sequence [xs] that satisfies [p x], if there is such an element.
+
+    It returns [None] if there is no such element,
+    provided the sequence [xs] is finite.
+
+    @since 4.14 *)
+
+val find_map : ('a -> 'b option) -> 'a t -> 'b option
+(** [find_map f xs] returns [Some y], where [x] is the first element of the
+    sequence [xs] such that [f x = Some _], if there is such an element,
+    and where [y] is defined by [f x = Some y].
+
+    It returns [None] if there is no such element,
+    provided the sequence [xs] is finite.
+
+    @since 4.14 *)
+
+val iter2 : ('a -> 'b -> unit) -> 'a t -> 'b t -> unit
+(** [iter2 f xs ys] invokes [f x y] successively for every pair [(x, y)] of
+    elements drawn synchronously from the sequences [xs] and [ys].
+
+    If the sequences [xs] and [ys] have different lengths, then
+    iteration stops as soon as one sequence is exhausted;
+    the excess elements in the other sequence are ignored.
+
+    At least one of the sequences [xs] and [ys] must be finite.
+
+    [iter2 f xs ys] is equivalent to
+    [iter (fun (x, y) -> f x y) (zip xs ys)].
+
+    @since 4.14 *)
+
+val fold_left2 : ('a -> 'b -> 'c -> 'a) -> 'a -> 'b t -> 'c t -> 'a
+(** [fold_left2 f _ xs ys] invokes [f _ x y] successively
+    for every pair [(x, y)] of elements drawn synchronously
+    from the sequences [xs] and [ys].
+
+    An accumulator of type ['a] is threaded through the calls to [f].
+
+    If the sequences [xs] and [ys] have different lengths, then
+    iteration stops as soon as one sequence is exhausted;
+    the excess elements in the other sequence are ignored.
+
+    At least one of the sequences [xs] and [ys] must be finite.
+
+    [fold_left2 f accu xs ys] is equivalent to
+    [fold_left (fun accu (x, y) -> f accu x y) (zip xs ys)].
+
+    @since 4.14 *)
+
+val for_all2 : ('a -> 'b -> bool) -> 'a t -> 'b t -> bool
+(** [for_all2 p xs ys] determines whether all pairs [(x, y)] of elements
+    drawn synchronously from the sequences [xs] and [ys] satisfy [p x y].
+
+    If the sequences [xs] and [ys] have different lengths, then
+    iteration stops as soon as one sequence is exhausted;
+    the excess elements in the other sequence are ignored.
+
+    At least one of the sequences [xs] and [ys] must be finite.
+
+    [for_all2 p xs ys] is equivalent to [for_all (fun b -> b) (map2 p xs ys)].
+
+    @since 4.14 *)
+
+val exists2 : ('a -> 'b -> bool) -> 'a t -> 'b t -> bool
+(** [exists2 p xs ys] determines whether some pair [(x, y)] of elements
+    drawn synchronously from the sequences [xs] and [ys] satisfies [p x y].
+
+    If the sequences [xs] and [ys] have different lengths, then
+    iteration must stop as soon as one sequence is exhausted;
+    the excess elements in the other sequence are ignored.
+
+    At least one of the sequences [xs] and [ys] must be finite.
+
+    [exists2 p xs ys] is equivalent to [exists (fun b -> b) (map2 p xs ys)].
+
+    @since 4.14 *)
+
+val equal: ('a -> 'b -> bool) -> 'a t -> 'b t -> bool
+(** Provided the function [eq] defines an equality on elements,
+    [equal eq xs ys] determines whether the sequences [xs] and [ys]
+    are pointwise equal.
+
+    At least one of the sequences [xs] and [ys] must be finite.
+
+    @since 4.14 *)
+
+val compare : ('a -> 'b -> int) -> 'a t -> 'b t -> int
+(** Provided the function [cmp] defines a preorder on elements,
+    [compare cmp xs ys] compares the sequences [xs] and [ys]
+    according to the lexicographic preorder.
+
+    For more details on comparison functions, see {!Array.sort}.
+
+    At least one of the sequences [xs] and [ys] must be finite.
+
+    @since 4.14 *)
+
+(** {1 Constructing sequences} *)
+
+(** The functions in this section are lazy: that is, they return sequences
+    whose elements are computed only when demanded. *)
+
+val init : int -> (int -> 'a) -> 'a t
+(** [init n f] is the sequence [f 0; f 1; ...; f (n-1)].
+
+    [n] must be nonnegative.
+
+    [init n f] is equivalent to [map f (up 0 n)].
+
+    @raise Invalid_argument if [n] is negative.
+    @since 4.14 *)
+
+val repeat : 'a -> 'a t
+(** [repeat x] is the infinite sequence
+    where the element [x] is repeated indefinitely.
+
+    [repeat x] is equivalent to [cycle (return x)].
+
+    @since 4.14 *)
+
+val forever : (unit -> 'a) -> 'a t
+(** [forever f] is an infinite sequence where every element is produced
+    (on demand) by the function call [f()].
+
+    For instance,
+    [forever Random.bool] is an infinite sequence of random bits.
+
+    [forever f] is equivalent to [map f (repeat ())].
+
+    @since 4.14 *)
+
+val cycle : 'a t -> 'a t
+(** [cycle xs] is the infinite sequence which consists of an infinite
+    number of repetitions of the sequence [xs].
+
+    The sequence [xs] must be nonempty.
+
+    Consuming (a prefix of) the sequence [cycle xs] once
+    can cause the sequence [xs] to be consumed more than once.
+    Therefore, [xs] must be persistent.
+
+    @raise Invalid_argument if [xs] is empty.
+    @since 4.14 *)
+
+val iterate : ('a -> 'a) -> 'a -> 'a t
+(** [iterate f x] is the infinite sequence whose elements are
+    [x], [f x], [f (f x)], and so on.
+
+    In other words, it is the orbit of the function [f] out of
+    the element [x].
+
+    @since 4.14 *)
+
+(** {1 Transforming sequences} *)
+
+(** The functions in this section are lazy: that is, they return sequences
+    whose elements are computed only when demanded. *)
+
+val mapi : (int -> 'a -> 'b) -> 'a t -> 'b t
+(** [mapi] is analogous to [map], but applies the function [f] to
+    an index and an element.
+
+    [mapi f xs] is equivalent to [map2 f (ints 0) xs].
+
+    @since 4.14 *)
+
+val scan : ('b -> 'a -> 'b) -> 'b -> 'a t -> 'b t
+(** If [xs] is a sequence [[x0; x1; x2; ...]], then
+    [scan f a0 xs] is a sequence of accumulators
+    [[a0; a1; a2; ...]]
+    where [a1] is [f a0 x0], [a2] is [f a1 x1], and so on.
+
+    Thus, [scan f a0 xs] is conceptually related to
+    [fold_left f a0 xs]. However, instead of performing an
+    eager iteration and immediately returning the final accumulator,
+    it returns a sequence of accumulators.
+
+    For instance, [scan (+) 0] transforms a sequence of integers
+    into the sequence of its partial sums.
+
+    If [xs] has length [n]
+    then [scan f a0 xs] has length [n+1].
+
+    @since 4.14 *)
+
+val take : int -> 'a t -> 'a t
+(** [take n xs] is the sequence of the first [n] elements of [xs].
+
+    If [xs] has fewer than [n] elements,
+    then [take n xs] is equivalent to [xs].
+
+    [n] must be nonnegative.
+
+    @raise Invalid_argument if [n] is negative.
+    @since 4.14 *)
+
+val drop : int -> 'a t -> 'a t
+(** [drop n xs] is the sequence [xs], deprived of its first [n] elements.
+
+    If [xs] has fewer than [n] elements,
+    then [drop n xs] is empty.
+
+    [n] must be nonnegative.
+
+    [drop] is lazy: the first [n+1] elements of the sequence [xs]
+    are demanded only when the first element of [drop n xs] is
+    demanded. For this reason, [drop 1 xs] is {i not} equivalent
+    to [tail xs], which queries [xs] immediately.
+
+    @raise Invalid_argument if [n] is negative.
+    @since 4.14 *)
+
+val take_while : ('a -> bool) -> 'a t -> 'a t
+(** [take_while p xs] is the longest prefix of the sequence [xs]
+    where every element [x] satisfies [p x].
+
+    @since 4.14 *)
+
+val drop_while : ('a -> bool) -> 'a t -> 'a t
+(** [drop_while p xs] is the sequence [xs], deprived of the prefix
+    [take_while p xs].
+
+    @since 4.14 *)
+
+val uniq : ('a -> 'a -> bool) -> 'a t -> 'a t
+(** Provided the function [eq] defines an equality on elements,
+    [uniq eq xs] is the sequence [xs],
+    deprived of its adjacent duplicate elements.
+
+    Thus, [uniq eq xs] has no adjacent duplicate elements.
+    Furthermore, if [xs] is sorted according to an ordering
+    that is compatible with [eq],
+    then [uniq eq xs] has no duplicate elements at all.
+
+    [uniq eq xs] is equivalent to [map head (group eq xs)].
+
+    @since 4.14 *)
+
+val group : ('a -> 'a -> bool) -> 'a t -> 'a t t
+(** Provided the function [eq] defines an equality on elements,
+    [group eq xs] is the sequence of the maximal runs
+    of adjacent duplicate elements of the sequence [xs].
+
+    Every element of [group eq xs] is a nonempty sequence of equal elements.
+
+    The concatenation [concat (group eq xs)] is equal to [xs].
+
+    Consuming [group eq xs], and consuming the sequences that it contains,
+    can cause [xs] to be consumed more than once. Therefore, [xs] must be
+    persistent.
+
+    @since 4.14 *)
+
+val memoize : 'a t -> 'a t
+(** The sequence [memoize xs] has the same elements as the sequence [xs].
+
+    Regardless of whether [xs] is ephemeral or persistent,
+    [memoize xs] is persistent: even if it is queried several times,
+    [xs] is queried at most once.
+    @since 4.14 *)
+
+exception ForcedTwice
+(** This exception is raised when a sequence returned by [once]
+    (or a suffix of it) is queried more than once.
+    @since 4.14 *)
+
+val once: 'a t -> 'a t
+(** The sequence [once xs] has the same elements as the sequence [xs].
+
+    Regardless of whether [xs] is ephemeral or persistent,
+    [once xs] is an ephemeral sequence: it can be queried at most once.
+    If it (or a suffix of it) is queried more than once, then the exception
+    [ForcedTwice] is raised. This can be useful, while debugging or testing,
+    to ensure that a sequence is consumed at most once.
+
+    @raise ForcedTwice if [once xs], or a suffix of it,
+           is queried more than once.
+    @since 4.14 *)
+
+val transpose : 'a t t -> 'a t t
+(** If [xss] is a matrix (a sequence of rows), then [transpose xss] is
+    the sequence of the columns of the matrix [xss].
+
+    The rows of the matrix [xss] are not required to have the same length.
+
+    The matrix [xss] is not required to be finite (in either direction).
+
+    The matrix [xss] must be persistent.
+
+    @since 4.14 *)
+
+val diagonals : 'a t t -> 'a t t
+(** If [xss] is a matrix (a sequence of rows), then [diagonals xss] is
+    the sequence of its diagonals.
+
+    The first diagonal contains just the first element of the
+    first row. The second diagonal contains the first element of the
+    second row and the second element of the first row; and so on.
+
+    Every diagonal is a finite sequence.
+
+    The rows of the matrix [xss] are not required to have the same length.
+
+    The matrix [xss] is not required to be finite (in either direction).
+
+    The matrix [xss] must be persistent.
+
+    @since 4.14 *)
+
+(** {1 Combining sequences} *)
+
+val zip : 'a t -> 'b t -> ('a * 'b) t
+(** [zip xs ys] is the sequence of pairs [(x, y)]
+    drawn synchronously from the sequences [xs] and [ys].
+
+    If the sequences [xs] and [ys] have different lengths, then
+    the sequence ends as soon as one sequence is exhausted;
+    the excess elements in the other sequence are ignored.
+
+    [zip xs ys] is equivalent to [map2 (fun a b -> (a, b)) xs ys].
+
+    @since 4.14 *)
+
+val map2 : ('a -> 'b -> 'c) -> 'a t -> 'b t -> 'c t
+(** [map2 f xs ys] is the sequence of the elements [f x y],
+    where the pairs [(x, y)] are drawn synchronously from the
+    sequences [xs] and [ys].
+
+    If the sequences [xs] and [ys] have different lengths, then
+    the sequence ends as soon as one sequence is exhausted;
+    the excess elements in the other sequence are ignored.
+
+    [map2 f xs ys] is equivalent to [map (fun (x, y) -> f x y) (zip xs ys)].
+
+    @since 4.14 *)
+
+val interleave: 'a t -> 'a t -> 'a t
+(** [interleave xs ys] is the sequence that begins with the first element of
+    [xs], continues with the first element of [ys], and so on.
+
+    When one of the sequences [xs] and [ys] is exhausted,
+    [interleave xs ys] continues with the rest of the other sequence.
+
+    @since 4.14 *)
+
+val sorted_merge: ('a -> 'a -> int) -> 'a t -> 'a t -> 'a t
+(** If the sequences [xs] and [ys] are sorted according to the total preorder
+    [cmp], then [sorted_merge cmp xs ys] is the sorted sequence obtained by
+    merging the sequences [xs] and [ys].
+
+    For more details on comparison functions, see {!Array.sort}.
+
+    @since 4.14 *)
+
+val product : 'a t -> 'b t -> ('a * 'b) t
+(** [product xs ys] is the Cartesian product of the sequences [xs] and [ys].
+
+    For every element [x] of [xs] and for every element [y] of [ys],
+    the pair [(x, y)] appears once as an element of [product xs ys].
+
+    The order in which the pairs appear is unspecified.
+
+    The sequences [xs] and [ys] are not required to be finite.
+
+    The sequences [xs] and [ys] must be persistent.
+
+    @since 4.14 *)
+
+val product_with : ('a -> 'b -> 'c) -> 'a t -> 'b t -> 'c t
+(** The sequence [product xs ys] is the image through [f] of the Cartesian
+    product of the sequences [xs] and [ys].
+
+    For every element [x] of [xs] and for every element [y] of [ys],
+    the element [f x y] appears once as an element of [product_with f xs ys].
+
+    The order in which these elements appear is unspecified.
+
+    The sequences [xs] and [ys] are not required to be finite.
+
+    The sequences [xs] and [ys] must be persistent.
+
+    [product_with f xs ys] is equivalent to
+    [map (fun (x, y) -> f x y) (product xs ys)].
+
+    @since 4.14 *)
+
+val ap : ('a -> 'b) t -> 'a t -> 'b t
+(** [ap] is the application operator of the type constructor [_ t],
+    viewed as an applicative functor.
+
+    For every element [x] of [xs] and for every element [y] of [ys],
+    the element [x y] appears once as an element of [ap xs ys].
+
+    The sequences [xs] and [ys] must be persistent.
+
+    [ap xs ys] is equivalent to [product_with (@@) xs ys].
+
+    @since 4.14 *)
+
+(** {1 Splitting a sequence into two sequences} *)
+
+val unzip : ('a * 'b) t -> 'a t * 'b t
+(** [unzip] transforms a sequence of pairs into a pair of sequences.
+
+    [unzip xs] is equivalent to [(map fst xs, map snd xs)].
+
+    Querying either of the sequences returned by [unzip xs]
+    causes [xs] to be queried.
+    Therefore, querying both of them
+    causes [xs] to be queried twice.
+    Thus, [xs] must be persistent and cheap.
+    If that is not the case, use [unzip (memoize xs)].
+
+    @since 4.14 *)
+
+val dispatch : ('a, 'b) Either.t t -> 'a t * 'b t
+(** [dispatch] transforms a sequence of fruit (either apples or oranges)
+    into a pair of a sequence of apples and a sequence of oranges.
+
+    [dispatch xs] is equivalent to
+    [(filter_map Either.find_left xs, filter_map Either.find_right xs)].
+
+    Querying either of the sequences returned by [dispatch xs]
+    causes [xs] to be queried.
+    Therefore, querying both of them
+    causes [xs] to be queried twice.
+    Thus, [xs] must be persistent and cheap.
+    If that is not the case, use [dispatch (memoize xs)].
+
+    @since 4.14 *)
+
+val partition : ('a -> bool) -> 'a t -> 'a t * 'a t
+(** [partition p xs] returns a pair of the subsequence of the elements
+    of [xs] that satisfy [p] and the subsequence of the elements of
+    [xs] that do not satisfy [p].
+
+    [partition p xs] is equivalent to
+    [filter p xs, filter (fun x -> not (p x)) xs].
+
+    Consuming both of the sequences returned by [partition p xs] causes
+    [xs] to be consumed twice and causes the function [f] to be applied
+    twice to each element of the list.
+    Therefore, [f] should be pure and cheap.
+    Furthermore, [xs] should be persistent and cheap.
+    If that is not the case, use [partition p (memoize xs)].
+
+    @since 4.14 *)
+
+(** {1 Converting between sequences and iterators} *)
+
+(** An iterator is a representation of a sequence as a function of type
+    [unit -> 'a option]. Every time this function is invoked, it returns
+    the next element of the sequence. When there are no more elements,
+    it returns [None]. An iterator has mutable internal state, therefore
+    is ephemeral: the sequence that it represents can be consumed at most
+    once. *)
+
+val of_iterator: (unit -> 'a option) -> 'a t
+(** [of_iterator it] is the sequence of the elements produced by the iterator
+    [it]. It is an ephemeral sequence: it can be consumed at most once. If a
+    persistent sequence is needed, use [memoize (of_iterator it)].
+    @since 4.14 *)
+
+val to_iterator: 'a t -> (unit -> 'a option)
+(** [to_iterator xs] is a fresh iterator on the sequence [xs].
+    @since 4.14 *)
+
+(** {1 Sequences of integers} *)
+
+val ints: int -> int t
+(** [ints i] is the infinite sequence of the integers, beginning at [i] and
+    counting up.
+    @since 4.14 *)
+
+val up: int -> int -> int t
+(** [up i j] is the finite sequence of the integers comprised between
+    [i] included and [j] excluded, counting up. It is nonempty if and
+    only if [i < j] holds.
+    @since 4.14 *)
+
+val down: int -> int -> int t
+(** [down i j] is the finite sequence of the integers between [i]
+    excluded and [j] included, counting down. It is nonempty if and
+    only if [i > j] holds.
+    @since 4.14 *)
+
+(** {1 Infix operators} *)
+
+(** Infix operators.
+    @since 4.14 *)
+module Infix : sig
+
+  val (@) : 'a t -> 'a t -> 'a t
+  (** [(@)] is an alias for {!append}.
+      @since 4.14 *)
+
+  val (>>=) : 'a t -> ('a -> 'b t) -> 'b t
+  (** [(>>=)] is the monadic [bind] operator.
+      [xs >>= f] is equivalent to [flat_map f xs].
+      @since 4.14 *)
+
+  val (>|=) : 'a t -> ('a -> 'b) -> 'b t
+  (** [(>|=)] is the monadic [map] operator.
+      [xs >|= f] is equivalent to [map f xs].
+      @since 4.14 *)
+
+  val (<*>) : ('a -> 'b) t -> 'a t -> 'b t
+  (** [(<*>)] is an alias for {!ap}.
+      @since 4.14 *)
+
+end

--- a/stdlib/seq.mli
+++ b/stdlib/seq.mli
@@ -609,6 +609,11 @@ val zip : 'a t -> 'b t -> ('a * 'b) t
 
     @since 4.14 *)
 
+val combine : 'a t -> 'b t -> ('a * 'b) t
+(** [combine] is an alias for [zip].
+
+    @since 4.14 *)
+
 val map2 : ('a -> 'b -> 'c) -> 'a t -> 'b t -> 'c t
 (** [map2 f xs ys] is the sequence of the elements [f x y],
     where the pairs [(x, y)] are drawn synchronously from the
@@ -685,6 +690,11 @@ val unzip : ('a * 'b) t -> 'a t * 'b t
     causes [xs] to be queried twice.
     Thus, [xs] must be persistent and cheap.
     If that is not the case, use [unzip (memoize xs)].
+
+    @since 4.14 *)
+
+val split : ('a * 'b) t -> 'a t * 'b t
+(** [split] is an alias for [unzip].
 
     @since 4.14 *)
 

--- a/stdlib/seq.mli
+++ b/stdlib/seq.mli
@@ -99,102 +99,6 @@ and +'a node =
     or [Cons (x, xs)], which means that [x] is the first element
     of the sequence and that [xs] is the remainder of the sequence. *)
 
-val empty : 'a t
-(** [empty] is the empty sequence.
-    It has no elements. Its length is 0. *)
-
-val return : 'a -> 'a t
-(** [return x] is the sequence whose sole element is [x].
-    Its length is 1. *)
-
-val cons : 'a -> 'a t -> 'a t
-(** [cons x xs] is the sequence that begins with the element [x],
-    followed with the sequence [xs].
-
-    Writing [cons (f()) xs] causes the function call [f()]
-    to take place immediately. For this call to be delayed until the
-    sequence is queried, one must instead write
-    [(fun () -> Cons(f(), xs))].
-
-    @since 4.11 *)
-
-val append : 'a t -> 'a t -> 'a t
-(** [append xs ys] is the concatenation of the sequences [xs] and [ys].
-
-    Its elements are the elements of [xs], followed with the elements of [ys].
-
-    @since 4.11 *)
-
-val map : ('a -> 'b) -> 'a t -> 'b t
-(** [map f xs] is the image of the sequence [xs] through the
-    transformation [f].
-
-    If [xs] is the sequence [x0; x1; ...] then
-    [map f xs] is the sequence [f x0; f x1; ...]. *)
-
-val filter : ('a -> bool) -> 'a t -> 'a t
-(** [filter p xs] is the sequence of the elements [x] of [xs]
-    that satisfy [p x].
-
-    In other words, [filter p xs] is the sequence [xs],
-    deprived of the elements [x] such that [p x] is false. *)
-
-val filter_map : ('a -> 'b option) -> 'a t -> 'b t
-(** [filter_map f xs] is the sequence of the elements [y] such that
-    [f x = Some y], where [x] ranges over [xs].
-
-    [filter_map f xs] is equivalent to
-    [map Option.get (filter Option.is_some (map f xs))]. *)
-
-val concat : 'a t t -> 'a t
-(** If [xss] is a sequence of sequences,
-    then [concat xss] is its concatenation.
-
-    If [xss] is the sequence [xs0; xs1; ...] then
-    [concat xss] is the sequence [xs0 @ xs1 @ ...].
-
-    @since 4.13 *)
-
-val flat_map : ('a -> 'b t) -> 'a t -> 'b t
-(** [flat_map f xs] is equivalent to [concat (map f xs)]. *)
-
-val concat_map : ('a -> 'b t) -> 'a t -> 'b t
-(** [concat_map f xs] is equivalent to [concat (map f xs)].
-
-    [concat_map] is an alias for [flat_map].
-
-    @since 4.13 *)
-
-val fold_left : ('a -> 'b -> 'a) -> 'a -> 'b t -> 'a
-(** [fold_left f _ xs] invokes [f _ x] successively
-    for every element [x] of the sequence [xs],
-    from left to right.
-
-    An accumulator of type ['a] is threaded through the calls to [f].
-
-    The sequence [xs] must be finite. *)
-
-val iter : ('a -> unit) -> 'a t -> unit
-(** [iter f xs] invokes [f x] successively
-    for every element [x] of the sequence [xs],
-    from left to right.
-
-    The sequence [xs] must be finite. *)
-
-val unfold : ('b -> ('a * 'b) option) -> 'b -> 'a t
-(** [unfold] constructs a sequence
-    out of a step function and an initial state.
-
-    If [f u] is [None] then
-    [unfold f u] is the empty sequence.
-    If [f u] is [Some (x, u')] then
-    [unfold f u] is the nonempty sequence [cons x (unfold f u')].
-
-    For example, [unfold (function [] -> None | h :: t -> Some (h, t)) l]
-    is equivalent to [List.to_seq l].
-
-    @since 4.11 *)
-
 (** {1 Consuming sequences} *)
 
 (**
@@ -262,6 +166,22 @@ val length : 'a t -> int
     The sequence [xs] must be finite.
 
     @since 4.14 *)
+
+val iter : ('a -> unit) -> 'a t -> unit
+(** [iter f xs] invokes [f x] successively
+    for every element [x] of the sequence [xs],
+    from left to right.
+
+    The sequence [xs] must be finite. *)
+
+val fold_left : ('a -> 'b -> 'a) -> 'a -> 'b t -> 'a
+(** [fold_left f _ xs] invokes [f _ x] successively
+    for every element [x] of the sequence [xs],
+    from left to right.
+
+    An accumulator of type ['a] is threaded through the calls to [f].
+
+    The sequence [xs] must be finite. *)
 
 val iteri : (int -> 'a -> unit) -> 'a t -> unit
 (** [iteri f xs] invokes [f i x] successively
@@ -408,6 +328,25 @@ val compare : ('a -> 'b -> int) -> 'a t -> 'b t -> int
 (** The functions in this section are lazy: that is, they return sequences
     whose elements are computed only when demanded. *)
 
+val empty : 'a t
+(** [empty] is the empty sequence.
+    It has no elements. Its length is 0. *)
+
+val return : 'a -> 'a t
+(** [return x] is the sequence whose sole element is [x].
+    Its length is 1. *)
+
+val cons : 'a -> 'a t -> 'a t
+(** [cons x xs] is the sequence that begins with the element [x],
+    followed with the sequence [xs].
+
+    Writing [cons (f()) xs] causes the function call [f()]
+    to take place immediately. For this call to be delayed until the
+    sequence is queried, one must instead write
+    [(fun () -> Cons(f(), xs))].
+
+    @since 4.11 *)
+
 val init : int -> (int -> 'a) -> 'a t
 (** [init n f] is the sequence [f 0; f 1; ...; f (n-1)].
 
@@ -417,6 +356,20 @@ val init : int -> (int -> 'a) -> 'a t
 
     @raise Invalid_argument if [n] is negative.
     @since 4.14 *)
+
+val unfold : ('b -> ('a * 'b) option) -> 'b -> 'a t
+(** [unfold] constructs a sequence
+    out of a step function and an initial state.
+
+    If [f u] is [None] then
+    [unfold f u] is the empty sequence.
+    If [f u] is [Some (x, u')] then
+    [unfold f u] is the nonempty sequence [cons x (unfold f u')].
+
+    For example, [unfold (function [] -> None | h :: t -> Some (h, t)) l]
+    is equivalent to [List.to_seq l].
+
+    @since 4.11 *)
 
 val repeat : 'a -> 'a t
 (** [repeat x] is the infinite sequence
@@ -464,6 +417,13 @@ val iterate : ('a -> 'a) -> 'a -> 'a t
 (** The functions in this section are lazy: that is, they return sequences
     whose elements are computed only when demanded. *)
 
+val map : ('a -> 'b) -> 'a t -> 'b t
+(** [map f xs] is the image of the sequence [xs] through the
+    transformation [f].
+
+    If [xs] is the sequence [x0; x1; ...] then
+    [map f xs] is the sequence [f x0; f x1; ...]. *)
+
 val mapi : (int -> 'a -> 'b) -> 'a t -> 'b t
 (** [mapi] is analogous to [map], but applies the function [f] to
     an index and an element.
@@ -471,6 +431,20 @@ val mapi : (int -> 'a -> 'b) -> 'a t -> 'b t
     [mapi f xs] is equivalent to [map2 f (ints 0) xs].
 
     @since 4.14 *)
+
+val filter : ('a -> bool) -> 'a t -> 'a t
+(** [filter p xs] is the sequence of the elements [x] of [xs]
+    that satisfy [p x].
+
+    In other words, [filter p xs] is the sequence [xs],
+    deprived of the elements [x] such that [p x] is false. *)
+
+val filter_map : ('a -> 'b option) -> 'a t -> 'b t
+(** [filter_map f xs] is the sequence of the elements [y] such that
+    [f x = Some y], where [x] ranges over [xs].
+
+    [filter_map f xs] is equivalent to
+    [map Option.get (filter Option.is_some (map f xs))]. *)
 
 val scan : ('b -> 'a -> 'b) -> 'b -> 'a t -> 'b t
 (** If [xs] is a sequence [[x0; x1; x2; ...]], then
@@ -616,6 +590,32 @@ val diagonals : 'a t t -> 'a t t
     @since 4.14 *)
 
 (** {1 Combining sequences} *)
+
+val append : 'a t -> 'a t -> 'a t
+(** [append xs ys] is the concatenation of the sequences [xs] and [ys].
+
+    Its elements are the elements of [xs], followed with the elements of [ys].
+
+    @since 4.11 *)
+
+val concat : 'a t t -> 'a t
+(** If [xss] is a sequence of sequences,
+    then [concat xss] is its concatenation.
+
+    If [xss] is the sequence [xs0; xs1; ...] then
+    [concat xss] is the sequence [xs0 @ xs1 @ ...].
+
+    @since 4.13 *)
+
+val flat_map : ('a -> 'b t) -> 'a t -> 'b t
+(** [flat_map f xs] is equivalent to [concat (map f xs)]. *)
+
+val concat_map : ('a -> 'b t) -> 'a t -> 'b t
+(** [concat_map f xs] is equivalent to [concat (map f xs)].
+
+    [concat_map] is an alias for [flat_map].
+
+    @since 4.13 *)
 
 val zip : 'a t -> 'b t -> ('a * 'b) t
 (** [zip xs ys] is the sequence of pairs [(x, y)]

--- a/stdlib/seq.mli
+++ b/stdlib/seq.mli
@@ -689,19 +689,24 @@ val unzip : ('a * 'b) t -> 'a t * 'b t
 
     @since 4.14 *)
 
-val partition_either : ('a, 'b) Either.t t -> 'a t * 'b t
-(** [partition_either] transforms a sequence of fruit (either apples or oranges)
-    into a pair of a sequence of apples and a sequence of oranges.
+val partition_map : ('a -> ('b, 'c) Either.t) -> 'a t -> 'b t * 'c t
+(** [partition_map f xs] returns a pair of sequences [(ys, zs)], where:
 
-    [partition_either xs] is equivalent to
-    [(filter_map Either.find_left xs, filter_map Either.find_right xs)].
+    - [ys] is the sequence of the elements [y] such that
+      [f x = Left y], where [x] ranges over [xs];
 
-    Querying either of the sequences returned by [partition_either xs]
+    - [zs] is the sequence of the elements [z] such that
+      [f x = Right z], where [x] ranges over [xs].
+
+    [partition_map f xs] is equivalent to
+    [(filter_map Either.find_left (map f xs), filter_map Either.find_right (map f xs))].
+
+    Querying either of the sequences returned by [partition_map f xs]
     causes [xs] to be queried.
     Therefore, querying both of them
     causes [xs] to be queried twice.
     Thus, [xs] must be persistent and cheap.
-    If that is not the case, use [partition_either (memoize xs)].
+    If that is not the case, use [partition_map f (memoize xs)].
 
     @since 4.14 *)
 

--- a/stdlib/seq.mli
+++ b/stdlib/seq.mli
@@ -349,7 +349,8 @@ val init : int -> (int -> 'a) -> 'a t
 
     [n] must be nonnegative.
 
-    [init n f] is equivalent to [map f (up 0 n)].
+    If desired, the infinite sequence [f 0; f 1; ...]
+    can be defined as [map f (ints 0)].
 
     @raise Invalid_argument if [n] is negative.
     @since 4.14 *)

--- a/stdlib/seq.mli
+++ b/stdlib/seq.mli
@@ -353,6 +353,7 @@ val init : int -> (int -> 'a) -> 'a t
     can be defined as [map f (ints 0)].
 
     @raise Invalid_argument if [n] is negative.
+
     @since 4.14 *)
 
 val unfold : ('b -> ('a * 'b) option) -> 'b -> 'a t
@@ -472,6 +473,7 @@ val take : int -> 'a t -> 'a t
     [n] must be nonnegative.
 
     @raise Invalid_argument if [n] is negative.
+
     @since 4.14 *)
 
 val drop : int -> 'a t -> 'a t
@@ -488,6 +490,7 @@ val drop : int -> 'a t -> 'a t
     to [tail xs], which queries [xs] immediately.
 
     @raise Invalid_argument if [n] is negative.
+
     @since 4.14 *)
 
 val take_while : ('a -> bool) -> 'a t -> 'a t
@@ -548,6 +551,7 @@ val memoize : 'a t -> 'a t
 exception Forced_twice
 (** This exception is raised when a sequence returned by [once]
     (or a suffix of it) is queried more than once.
+
     @since 4.14 *)
 
 val once : 'a t -> 'a t
@@ -561,6 +565,7 @@ val once : 'a t -> 'a t
 
     @raise Forced_twice if [once xs], or a suffix of it,
            is queried more than once.
+
     @since 4.14 *)
 
 val transpose : 'a t t -> 'a t t
@@ -756,6 +761,7 @@ val of_iterator : (unit -> 'a option) -> 'a t
 (** [of_iterator it] is the sequence of the elements produced by the iterator
     [it]. It is an ephemeral sequence: it can be consumed at most once. If a
     persistent sequence is needed, use [memoize (of_iterator it)].
+
     @since 4.14 *)
 
 val to_iterator : 'a t -> (unit -> 'a option)
@@ -764,6 +770,7 @@ val to_iterator : 'a t -> (unit -> 'a option)
     This iterator has mutable internal state,
     which is not protected by a lock;
     so, it must not be used by several threads concurrently.
+
     @since 4.14 *)
 
 (** {1 Sequences of integers} *)
@@ -771,4 +778,5 @@ val to_iterator : 'a t -> (unit -> 'a option)
 val ints : int -> int t
 (** [ints i] is the infinite sequence of the integers, beginning at [i] and
     counting up.
+
     @since 4.14 *)

--- a/stdlib/seq.mli
+++ b/stdlib/seq.mli
@@ -279,6 +279,10 @@ val for_all2 : ('a -> 'b -> bool) -> 'a t -> 'b t -> bool
     If the sequences [xs] and [ys] have different lengths, then
     iteration stops as soon as one sequence is exhausted;
     the excess elements in the other sequence are ignored.
+    In particular, if [xs] or [ys] is empty, then
+    [for_all2 p xs ys] is true. This is where
+    [for_all2] and [equal] differ: [equal eq xs ys] can
+    be true only if [xs] and [ys] have the same length.
 
     At least one of the sequences [xs] and [ys] must be finite.
 

--- a/stdlib/seq.mli
+++ b/stdlib/seq.mli
@@ -742,6 +742,10 @@ val of_iterator : (unit -> 'a option) -> 'a t
 
 val to_iterator : 'a t -> (unit -> 'a option)
 (** [to_iterator xs] is a fresh iterator on the sequence [xs].
+
+    This iterator has mutable internal state,
+    which is not protected by a lock;
+    so, it must not be used by several threads concurrently.
     @since 4.14 *)
 
 (** {1 Sequences of integers} *)

--- a/stdlib/seq.mli
+++ b/stdlib/seq.mli
@@ -664,7 +664,7 @@ val product : 'a t -> 'b t -> ('a * 'b) t
     @since 4.14 *)
 
 val product_with : ('a -> 'b -> 'c) -> 'a t -> 'b t -> 'c t
-(** The sequence [product xs ys] is the image through [f] of the Cartesian
+(** The sequence [product_with f xs ys] is the image through [f] of the Cartesian
     product of the sequences [xs] and [ys].
 
     For every element [x] of [xs] and for every element [y] of [ys],
@@ -678,19 +678,6 @@ val product_with : ('a -> 'b -> 'c) -> 'a t -> 'b t -> 'c t
 
     [product_with f xs ys] is equivalent to
     [map (fun (x, y) -> f x y) (product xs ys)].
-
-    @since 4.14 *)
-
-val ap : ('a -> 'b) t -> 'a t -> 'b t
-(** [ap] is the application operator of the type constructor [_ t],
-    viewed as an applicative functor.
-
-    For every element [x] of [xs] and for every element [y] of [ys],
-    the element [x y] appears once as an element of [ap xs ys].
-
-    The sequences [xs] and [ys] must be persistent.
-
-    [ap xs ys] is equivalent to [product_with (@@) xs ys].
 
     @since 4.14 *)
 

--- a/stdlib/seq.mli
+++ b/stdlib/seq.mli
@@ -737,4 +737,3 @@ val ints : int -> int t
 (** [ints i] is the infinite sequence of the integers, beginning at [i] and
     counting up.
     @since 4.14 *)
-

--- a/stdlib/seq.mli
+++ b/stdlib/seq.mli
@@ -653,12 +653,12 @@ val product : 'a t -> 'b t -> ('a * 'b) t
 
     @since 4.14 *)
 
-val product_with : ('a -> 'b -> 'c) -> 'a t -> 'b t -> 'c t
-(** The sequence [product_with f xs ys] is the image through [f] of the Cartesian
+val map_product : ('a -> 'b -> 'c) -> 'a t -> 'b t -> 'c t
+(** The sequence [map_product f xs ys] is the image through [f] of the Cartesian
     product of the sequences [xs] and [ys].
 
     For every element [x] of [xs] and for every element [y] of [ys],
-    the element [f x y] appears once as an element of [product_with f xs ys].
+    the element [f x y] appears once as an element of [map_product f xs ys].
 
     The order in which these elements appear is unspecified.
 
@@ -666,7 +666,7 @@ val product_with : ('a -> 'b -> 'c) -> 'a t -> 'b t -> 'c t
 
     The sequences [xs] and [ys] must be persistent.
 
-    [product_with f xs ys] is equivalent to
+    [map_product f xs ys] is equivalent to
     [map (fun (x, y) -> f x y) (product xs ys)].
 
     @since 4.14 *)

--- a/testsuite/tests/lib-seq/test.ml
+++ b/testsuite/tests/lib-seq/test.ml
@@ -6,7 +6,6 @@ let (!!) = List.of_seq
 let cmp = compare
 
 let head s = match s() with Seq.Cons(x,_) -> x | _ -> assert false
-let filter1 x = x mod 2 = 0 ;;
 
 let poison : _ Seq.t =
   fun () ->

--- a/testsuite/tests/lib-seq/test.ml
+++ b/testsuite/tests/lib-seq/test.ml
@@ -84,11 +84,11 @@ let () =
   let xs = Seq.(init 4 (fun i -> i+10)) in
   assert (!!xs = [10;11;12;13])
 
-(* [fold_left_i] *)
+(* [fold_lefti] *)
 let () =
   let xs = !?["a"; "b"] in
   assert (
-    Seq.fold_left_i (fun i acc x -> (i, x) :: acc) [] xs = [ 1, "b"; 0, "a" ]
+    Seq.fold_lefti (fun i acc x -> (i, x) :: acc) [] xs = [ 1, "b"; 0, "a" ]
   )
 
 (* [scan] *)
@@ -210,7 +210,7 @@ let () =
   try
     let (_ : int) = Seq.length xs in
     print_endline "Oops"
-  with Seq.ForcedTwice ->
+  with Seq.Forced_twice ->
     ()
 
 (* [memoize] *)

--- a/testsuite/tests/lib-seq/test.ml
+++ b/testsuite/tests/lib-seq/test.ml
@@ -48,11 +48,7 @@ let () =
   assert (
       List.concat [[1]; []; [2; 3];]
       = !!(Seq.concat !?[!?[1]; !?[]; !?[2; 3]])
-    );
-  assert (
-    List.concat [[1]; [0]; []; [0]; [2; 3];]
-      = !!(Seq.concat ~sep:(Seq.return 0) !?[!?[1]; !?[]; !?[2; 3]])
-  )
+    )
 
 (* [cycle empty] is expected to fail. *)
 let () =

--- a/testsuite/tests/lib-seq/test.ml
+++ b/testsuite/tests/lib-seq/test.ml
@@ -1,7 +1,15 @@
 (* TEST
 *)
 
+let (!?) = List.to_seq
+let (!!) = List.of_seq
+let cmp = compare
+
 let filter1 x = x mod 2 = 0 ;;
+
+let poison : _ Seq.t =
+  fun () ->
+    failwith "Poisoned"
 
 (* Standard test case *)
 let () =
@@ -21,8 +29,8 @@ let () =
     Seq.unfold step first
   in
   begin
-    assert ([1;2;3] = List.of_seq (range 1 3));
-    assert ([] = List.of_seq (range 1 0));
+    assert ([1;2;3] = !!(range 1 3));
+    assert ([] = !!(range 1 0));
   end
 ;;
 
@@ -39,7 +47,252 @@ let () =
 let () =
   assert (
       List.concat [[1]; []; [2; 3];]
-      = (let (!?) = List.to_seq in
-         List.of_seq (Seq.concat !?[!?[1]; !?[]; !?[2; 3]])))
+      = !!(Seq.concat !?[!?[1]; !?[]; !?[2; 3]])
+  )
+
+(* [cycle empty] is expected to fail. *)
+let () =
+  try
+    let xs = Seq.(cycle empty) in
+    let _ = xs() in
+    print_endline "Oops"
+  with Invalid_argument _ ->
+    () (* OK *)
+
+(* [cycle] *)
+let () =
+  let xs = Seq.(take 7 (cycle !?[1;2;3])) in
+  assert (!!xs = [1;2;3;1;2;3;1])
+
+(* [iterate] *)
+let () =
+  let f x = x + 7 in
+  let xs = Seq.(take 4 (iterate f 0)) in
+  assert (!!xs = [0; 7; 14; 21])
+
+(* [iterate] must not invoke [f] too early. (An easy trap to fall into.)
+   The function [f] does not tolerate being invoked 4 times. Indeed, in
+   this example, it should be called 3 times only. *)
+let () =
+  let c = ref 0 in
+  let f x = incr c; assert (!c < 4); x + 7 in
+  let xs = Seq.(take 4 (iterate f 0)) in
+  assert (!!xs = [0; 7; 14; 21])
+
+(* [init] *)
+let () =
+  let xs = Seq.(init 4 (fun i -> i+10)) in
+  assert (!!xs = [10;11;12;13])
+
+(* [fold_left_i] *)
+let () =
+  let xs = !?["a"; "b"] in
+  assert (
+    Seq.fold_left_i (fun i acc x -> (i, x) :: acc) [] xs = [ 1, "b"; 0, "a" ]
+  )
+
+(* [scan] *)
+let () =
+  let xs = Seq.(scan (+) 0 !?[1;2;3;4;5]) in
+  assert (!!xs = [0; 1; 3; 6; 10; 15])
+
+(* [scan] *)
+let () =
+  let xs = Seq.(scan (fun acc x -> x+1::acc) [] !?[1;2;3;4;5]) in
+  assert (!!xs = [[]; [2]; [3;2]; [4;3;2]; [5;4;3;2]; [6;5;4;3;2]])
+
+(* [is_empty] *)
+let () =
+  assert (Seq.is_empty Seq.empty);
+  assert (not @@ Seq.is_empty (List.to_seq [1;2;3]))
+
+(* [head] *)
+let () =
+  assert (Seq.head (List.to_seq [1;2;3]) = 1);
+  assert (try ignore (Seq.head Seq.empty); false with _ -> true)
+
+(* [tail] *)
+let () =
+  assert (List.of_seq @@ Seq.tail (List.to_seq [1;2;3]) = [2;3]);
+  assert (try ignore (Seq.tail Seq.empty : _ -> _); false with _ -> true)
+
+(* [uncons] *)
+let () =
+  assert (match Seq.uncons (List.to_seq [1;2;3]) with
+      | None -> false
+      | Some (x,tl) -> x = 1 && List.of_seq tl = [2;3])
+
+(* [repeat] *)
+let () =
+  let seq = Seq.repeat 1 in
+  assert (Seq.length (Seq.take 1000 seq) = 1000);
+  assert (Seq.head seq = 1);
+  assert (Seq.head (Seq.drop 100_000 seq) = 1);
+  ()
+
+(* [forever] *)
+let () =
+  let r = ref 0 in
+  let seq = Seq.forever (fun () ->
+      let x = !r in incr r; x)
+  in
+  assert (List.of_seq (Seq.take 10 seq) = [0;1;2;3;4;5;6;7;8;9]);
+  assert (Seq.head seq = 10);
+  assert (Seq.length (Seq.take 1_000_000 seq) = 1_000_000);
+  ()
+
+(* [scan] must not invoke [f] too early. (An easy trap to fall into.)
+   The function [f] does not tolerate being invoked 4 times. Indeed, in
+   this example, it should be called 3 times only. *)
+let () =
+  let c = ref 0 in
+  let f x y = incr c; assert (!c < 4); x + y in
+  let xs = Seq.(take 4 (scan f 0 !?[1;2;3;4;5])) in
+  assert (!!xs = [0; 1; 3; 6])
+
+(* [take] *)
+let () =
+  let xs = Seq.take 0 poison in
+  assert (!!xs = [])
+
+(* [take_while] *)
+let () =
+  let xs = Seq.iterate succ 0 |> Seq.take_while (fun x->x<10) in
+  assert (!!xs = [0;1;2;3;4;5;6;7;8;9])
+
+(* [take_while] *)
+let () =
+  let xs = Seq.append (List.to_seq [1;2;3]) poison |> Seq.take_while (fun x -> x<3) in
+  assert (!!xs = [1;2])
+
+(* [drop] *)
+let () =
+  let xs = !?[1;2;3] in
+  assert (Seq.drop 0 xs == xs);
+  assert (!!(Seq.drop 1 xs) = [2;3]);
+  assert (!!(Seq.drop 2 xs) = [3]);
+  assert (!!(Seq.drop 3 xs) = []);
+  assert (!!(Seq.drop 4 xs) = []);
+  ()
+
+(* [sorted_merge] *)
+let () =
+  let xs = !?[1;3;4;7]
+  and ys = !?[2;2;5;7;16] in
+  assert (!!(Seq.sorted_merge cmp xs ys) = [1;2;2;3;4;5;7;7;16])
+
+(* [sorted_merge] should not consume its arguments too far. *)
+let () =
+  let (_ : int Seq.t) = Seq.sorted_merge cmp poison poison in
+  assert true;
+  let xs = Seq.(cons 1 (cons 3 poison))
+  and ys = Seq.(cons 2 poison) in
+  assert (!!(Seq.(take 2 (sorted_merge cmp xs ys))) = [1;2]);
+  assert (!!(Seq.(take 2 (sorted_merge cmp ys xs))) = [1;2]);
+  ()
+
+(* [interleave] *)
+let () =
+  let xs = !?[1;2;3]
+  and ys = !?[4;5] in
+  assert (!!(Seq.interleave xs ys) = [1;4;2;5;3]);
+  let xs = Seq.repeat 0 in
+  assert (!!(Seq.(take 6 (interleave xs ys))) = [0;4;0;5;0;0]);
+  let ys = Seq.repeat 1 in
+  assert (!!(Seq.(take 6 (interleave xs ys))) = [0;1;0;1;0;1]);
+  ()
+
+(* [once] *)
+let () =
+  let xs = Seq.once (!?[1;2;3]) in
+  let (n : int) = Seq.length xs in
+  assert (n = 3);
+  try
+    let (_ : int) = Seq.length xs in
+    print_endline "Oops"
+  with Seq.ForcedTwice ->
+    ()
+
+(* [memoize] *)
+let () =
+  let xs = Seq.(memoize (once (!?[1;2;3]))) in
+  assert (Seq.length xs = 3);
+  assert (Seq.fold_left (+) 0 xs = 6);
+  ()
+
+(* [of_iterator] *)
+let () =
+  let c = ref 0 in
+  let it () = let x = !c in c := x + 1; Some x in
+  let xs = Seq.of_iterator it in
+  assert (!!(Seq.take 5 xs) = [0;1;2;3;4]);
+  assert (!!(Seq.take 5 xs) = [5;6;7;8;9]);
+  ()
+
+(* [memoize] and [of_iterator] *)
+let () =
+  let c = ref 0 in
+  let it () = let x = !c in c := x + 1; Some x in
+  let xs = Seq.(memoize (of_iterator it)) in
+  assert (!!(Seq.take 5 xs) = [0;1;2;3;4]);
+  assert (!!(Seq.take 5 xs) = [0;1;2;3;4]);
+  ()
+
+(* [mapi] *)
+let() =
+  let seq = List.to_seq [0;1;2;3] |> Seq.mapi (fun i x -> i, x) in
+  assert (Seq.length seq = 4);
+  assert (Seq.for_all (fun (x,y) -> x=y) seq)
+
+(* [product] *)
+let () =
+  (* test it works on infinite sequences *)
+  let s = Seq.(product (repeat 1) (repeat true)) in
+  assert ([1,true; 1,true; 1,true] = List.of_seq (Seq.take 3 s));
+  (* basic functionality test *)
+  let s = Seq.product (List.to_seq [1;2;3]) (List.to_seq [true;false]) in
+  assert ([1,false; 1,true; 2,false; 2,true; 3,false; 3,true]
+          = (List.of_seq s |> List.sort compare));
+  ()
+
+(* Auxiliary definitions of 2d matrices. *)
+let square n f =
+  Seq.(init n (fun i -> init n (fun j -> f i j)))
+
+let rec infinite i () =
+  Seq.(Cons (
+    map (fun j -> (i, j)) (ints 0),
+    infinite (i+1)
+  ))
+
+(* [transpose] of a finite square matrix. *)
+let () =
+  let matrix = square 3 (fun i j -> (i, j)) in
+  (* Check the first line of our square matrix. *)
+  assert (!!(Seq.head matrix) = [(0, 0); (0, 1); (0, 2)]);
+  (* Check the first column of our square matrix. *)
+  assert (!!(Seq.map Seq.head matrix) = [(0, 0); (1, 0); (2, 0)]);
+  (* Transpose the matrix. *)
+  let matrix = Seq.transpose matrix in
+  (* Check the first line of the transposed matrix. *)
+  assert (!!(Seq.head matrix) = [(0, 0); (1, 0); (2, 0)]);
+  (* Check the first column of the transposed matrix. *)
+  assert (!!(Seq.map Seq.head matrix) = [(0, 0); (0, 1); (0, 2)]);
+  ()
+
+(* [transpose] of a doubly-infinite matrix. *)
+let () =
+  let matrix = infinite 0 in
+  (* Check the first line. *)
+  assert (!!(Seq.(take 3 (head matrix))) = [(0, 0); (0, 1); (0, 2)]);
+  (* Check the first column. *)
+  assert (!!(Seq.(take 3 (map head matrix))) = [(0, 0); (1, 0); (2, 0)]);
+  (* Transpose the matrix. *)
+  let matrix = Seq.transpose matrix in
+  (* Check the first line of the transposed matrix. *)
+  assert (!!(Seq.(take 3 (head matrix))) = [(0, 0); (1, 0); (2, 0)]);
+  (* Check the first column of the transposed matrix. *)
+  assert (!!(Seq.(take 3 (map head matrix))) = [(0, 0); (0, 1); (0, 2)]);
+  ()
 
 let () = print_endline "OK";;

--- a/testsuite/tests/lib-seq/test.ml
+++ b/testsuite/tests/lib-seq/test.ml
@@ -211,20 +211,20 @@ let () =
   assert (Seq.fold_left (+) 0 xs = 6);
   ()
 
-(* [of_distributor] *)
+(* [of_dispenser] *)
 let () =
   let c = ref 0 in
   let it () = let x = !c in c := x + 1; Some x in
-  let xs = Seq.of_distributor it in
+  let xs = Seq.of_dispenser it in
   assert (!!(Seq.take 5 xs) = [0;1;2;3;4]);
   assert (!!(Seq.take 5 xs) = [5;6;7;8;9]);
   ()
 
-(* [memoize] and [of_distributor] *)
+(* [memoize] and [of_dispenser] *)
 let () =
   let c = ref 0 in
   let it () = let x = !c in c := x + 1; Some x in
-  let xs = Seq.(memoize (of_distributor it)) in
+  let xs = Seq.(memoize (of_dispenser it)) in
   assert (!!(Seq.take 5 xs) = [0;1;2;3;4]);
   assert (!!(Seq.take 5 xs) = [0;1;2;3;4]);
   ()

--- a/testsuite/tests/lib-seq/test.ml
+++ b/testsuite/tests/lib-seq/test.ml
@@ -50,16 +50,17 @@ let () =
       = !!(Seq.concat !?[!?[1]; !?[]; !?[2; 3]])
     )
 
-(* [cycle empty] is expected to fail. *)
+(* [cycle empty] is empty. *)
 let () =
-  try
-    let xs = Seq.(cycle empty) in
-    let _ = xs() in
-    print_endline "Oops"
-  with Invalid_argument _ ->
-    () (* OK *)
+  let xs = Seq.(cycle empty) in
+  assert (Seq.length xs = 0)
 
-(* [cycle] *)
+(* [cycle] of a singleton. *)
+let () =
+  let xs = Seq.(take 7 (cycle !?[1])) in
+  assert (!!xs = [1;1;1;1;1;1;1])
+
+(* [cycle] of a longer sequence. *)
 let () =
   let xs = Seq.(take 7 (cycle !?[1;2;3])) in
   assert (!!xs = [1;2;3;1;2;3;1])

--- a/testsuite/tests/lib-seq/test.ml
+++ b/testsuite/tests/lib-seq/test.ml
@@ -5,6 +5,7 @@ let (!?) = List.to_seq
 let (!!) = List.of_seq
 let cmp = compare
 
+let head s = match s() with Seq.Cons(x,_) -> x | _ -> assert false
 let filter1 x = x mod 2 = 0 ;;
 
 let poison : _ Seq.t =
@@ -48,6 +49,10 @@ let () =
   assert (
       List.concat [[1]; []; [2; 3];]
       = !!(Seq.concat !?[!?[1]; !?[]; !?[2; 3]])
+    );
+  assert (
+    List.concat [[1]; [0]; []; [0]; [2; 3];]
+      = !!(Seq.concat ~sep:(Seq.return 0) !?[!?[1]; !?[]; !?[2; 3]])
   )
 
 (* [cycle empty] is expected to fail. *)
@@ -106,16 +111,6 @@ let () =
   assert (Seq.is_empty Seq.empty);
   assert (not @@ Seq.is_empty (List.to_seq [1;2;3]))
 
-(* [head] *)
-let () =
-  assert (Seq.head (List.to_seq [1;2;3]) = 1);
-  assert (try ignore (Seq.head Seq.empty); false with _ -> true)
-
-(* [tail] *)
-let () =
-  assert (List.of_seq @@ Seq.tail (List.to_seq [1;2;3]) = [2;3]);
-  assert (try ignore (Seq.tail Seq.empty : _ -> _); false with _ -> true)
-
 (* [uncons] *)
 let () =
   assert (match Seq.uncons (List.to_seq [1;2;3]) with
@@ -126,8 +121,8 @@ let () =
 let () =
   let seq = Seq.repeat 1 in
   assert (Seq.length (Seq.take 1000 seq) = 1000);
-  assert (Seq.head seq = 1);
-  assert (Seq.head (Seq.drop 100_000 seq) = 1);
+  assert (head seq = 1);
+  assert (head (Seq.drop 100_000 seq) = 1);
   ()
 
 (* [forever] *)
@@ -137,7 +132,7 @@ let () =
       let x = !r in incr r; x)
   in
   assert (List.of_seq (Seq.take 10 seq) = [0;1;2;3;4;5;6;7;8;9]);
-  assert (Seq.head seq = 10);
+  assert (head seq = 10);
   assert (Seq.length (Seq.take 1_000_000 seq) = 1_000_000);
   ()
 
@@ -269,15 +264,15 @@ let rec infinite i () =
 let () =
   let matrix = square 3 (fun i j -> (i, j)) in
   (* Check the first line of our square matrix. *)
-  assert (!!(Seq.head matrix) = [(0, 0); (0, 1); (0, 2)]);
+  assert (!!(head matrix) = [(0, 0); (0, 1); (0, 2)]);
   (* Check the first column of our square matrix. *)
-  assert (!!(Seq.map Seq.head matrix) = [(0, 0); (1, 0); (2, 0)]);
+  assert (!!(Seq.map head matrix) = [(0, 0); (1, 0); (2, 0)]);
   (* Transpose the matrix. *)
   let matrix = Seq.transpose matrix in
   (* Check the first line of the transposed matrix. *)
-  assert (!!(Seq.head matrix) = [(0, 0); (1, 0); (2, 0)]);
+  assert (!!(head matrix) = [(0, 0); (1, 0); (2, 0)]);
   (* Check the first column of the transposed matrix. *)
-  assert (!!(Seq.map Seq.head matrix) = [(0, 0); (0, 1); (0, 2)]);
+  assert (!!(Seq.map head matrix) = [(0, 0); (0, 1); (0, 2)]);
   ()
 
 (* [transpose] of a doubly-infinite matrix. *)

--- a/testsuite/tests/lib-seq/test.ml
+++ b/testsuite/tests/lib-seq/test.ml
@@ -211,20 +211,20 @@ let () =
   assert (Seq.fold_left (+) 0 xs = 6);
   ()
 
-(* [of_iterator] *)
+(* [of_distributor] *)
 let () =
   let c = ref 0 in
   let it () = let x = !c in c := x + 1; Some x in
-  let xs = Seq.of_iterator it in
+  let xs = Seq.of_distributor it in
   assert (!!(Seq.take 5 xs) = [0;1;2;3;4]);
   assert (!!(Seq.take 5 xs) = [5;6;7;8;9]);
   ()
 
-(* [memoize] and [of_iterator] *)
+(* [memoize] and [of_distributor] *)
 let () =
   let c = ref 0 in
   let it () = let x = !c in c := x + 1; Some x in
-  let xs = Seq.(memoize (of_iterator it)) in
+  let xs = Seq.(memoize (of_distributor it)) in
   assert (!!(Seq.take 5 xs) = [0;1;2;3;4]);
   assert (!!(Seq.take 5 xs) = [0;1;2;3;4]);
   ()


### PR DESCRIPTION
This PR (co-developed by @c-cube and myself) adds many new functions to the module `Seq`. Our goal is to include most of the functions that one might naturally expect to find in this module, and which have been missing until now. Many of these functions are analogous to functions that exist in Haskell's Prelude and `Data.List`. Some functions (such as `memoize`, `once`, `of_iterator` and `to_iterator`) have no Haskell equivalent.

This PR adds dependencies of `Seq` towards `Either` and `Lazy`.

We update the documentation of `Seq` so as to document all functions in a uniform style and so as to organize the (old and new) functions in logical groups, as far as possible.

To help with reviewing, we distinguish commits that add new functions, commits that update the documentation of existing functions, and commits that move things around.

Here is a list of the 50 new functions and exceptions:

```
val is_empty:  'a t -> bool
val head : 'a t -> 'a
val tail : 'a t -> 'a t
val uncons : 'a t -> ('a * 'a t) option
val length : 'a t -> int
val iteri : (int -> 'a -> unit) -> 'a t -> unit
val fold_left_i : (int -> 'b -> 'a -> 'b) -> 'b -> 'a t -> 'b
val for_all : ('a -> bool) -> 'a t -> bool
val exists : ('a -> bool) -> 'a t -> bool
val find : ('a -> bool) -> 'a t -> 'a option
val find_map : ('a -> 'b option) -> 'a t -> 'b option
val iter2 : ('a -> 'b -> unit) -> 'a t -> 'b t -> unit
val fold_left2 : ('a -> 'b -> 'c -> 'a) -> 'a -> 'b t -> 'c t -> 'a
val for_all2 : ('a -> 'b -> bool) -> 'a t -> 'b t -> bool
val exists2 : ('a -> 'b -> bool) -> 'a t -> 'b t -> bool
val equal: ('a -> 'b -> bool) -> 'a t -> 'b t -> bool
val compare : ('a -> 'b -> int) -> 'a t -> 'b t -> int
val init : int -> (int -> 'a) -> 'a t
val repeat : 'a -> 'a t
val forever : (unit -> 'a) -> 'a t
val cycle : 'a t -> 'a t
val iterate : ('a -> 'a) -> 'a -> 'a t
val mapi : (int -> 'a -> 'b) -> 'a t -> 'b t
val scan : ('b -> 'a -> 'b) -> 'b -> 'a t -> 'b t
val take : int -> 'a t -> 'a t
val drop : int -> 'a t -> 'a t
val take_while : ('a -> bool) -> 'a t -> 'a t
val drop_while : ('a -> bool) -> 'a t -> 'a t
val uniq : ('a -> 'a -> bool) -> 'a t -> 'a t
val group : ('a -> 'a -> bool) -> 'a t -> 'a t t
val memoize : 'a t -> 'a t
exception ForcedTwice
val once: 'a t -> 'a t
val transpose : 'a t t -> 'a t t
val diagonals : 'a t t -> 'a t t
val zip : 'a t -> 'b t -> ('a * 'b) t
val map2 : ('a -> 'b -> 'c) -> 'a t -> 'b t -> 'c t
val interleave: 'a t -> 'a t -> 'a t
val sorted_merge: ('a -> 'a -> int) -> 'a t -> 'a t -> 'a t
val product : 'a t -> 'b t -> ('a * 'b) t
val product_with : ('a -> 'b -> 'c) -> 'a t -> 'b t -> 'c t
val ap : ('a -> 'b) t -> 'a t -> 'b t
val unzip : ('a * 'b) t -> 'a t * 'b t
val dispatch : ('a, 'b) Either.t t -> 'a t * 'b t
val partition : ('a -> bool) -> 'a t -> 'a t * 'a t
val of_iterator: (unit -> 'a option) -> 'a t
val to_iterator: 'a t -> (unit -> 'a option)
val ints: int -> int t
val up: int -> int -> int t
val down: int -> int -> int t
```

Furthermore, a new submodule, `Seq.Infix`, introduces a small number of infix operators on sequences.

We also have a (shorter) list of functions that we decided *not* to include for now, and which we could discuss if desired.

And here are some questions that might be worth discussing:
* Is the quality (and level of detail) of the documentation adequate?
* Is it OK for `map2` and friends to silently ignore excess elements when the two sequences have different lengths? (We depart from the `List` module here, but this behavior seems more generally useful. If desired, we could add a variant of the `zip` function that requires the two lists to have the same length.)
* Do we need more tests? The test coverage is still pretty bad at this point.
* Should `zip` (also) be named `combine`, by analogy with `List.combine`?
* Should `unzip` (also) be named `split`, by analogy with `List.split`?
* Should `concat` (also) be named `flatten`, by analogy with `List.flatten`?
* Are the names `up` and `down` appropriate?
* Should `head` and `tail` be named `hd` and `tl`, by analogy with `List.hd` and `List.tl`?
* Should we introduce sequencing operators such as `(let*)`, etc.?

We are looking forward to your comments.
-- Simon and François.