### PR TITLE
Fix manpages build when libraries are disabled

### DIFF
--- a/Changes
+++ b/Changes
@@ -762,6 +762,10 @@ OCaml 4.13.0
 - #10550, #10551: fix pretty-print of gadt-pattern-with-type-vars
   (Chet Murthy, review by Gabriel Scherer)
 
+- #10584, #10856: Standard Library documentation build no longer fails if
+  optional libraries have been disabled.
+  (David Allsopp, report by Yuri Victorovich review by ???)
+
 OCaml 4.12, maintenance version
 -------------------------------
 

--- a/api_docgen/Makefile.docfiles
+++ b/api_docgen/Makefile.docfiles
@@ -42,11 +42,20 @@ STDLIB=$(filter-out stdlib__Pervasives, $(STDLIB_MODULES))
 
 stdlib_UNPREFIXED=$(filter-out pervasives, $(STDLIB_MODULE_BASENAMES))
 
-otherlibref= \
-  $(str_MLIS:%.mli=%) \
-  $(unix_MLIS:%.mli=%) \
-  $(dynlink_MLIS:%.mli=%) \
-  $(thread_MLIS:%.mli=%)
+otherlibref := $(dynlink_MLIS:%.mli=%)
+
+ifneq "$(filter str,$(OTHERLIBRARIES))" ""
+otherlibref += $(str_MLIS:%.mli=%)
+endif
+
+ifneq "$(filter %unix,$(OTHERLIBRARIES))" ""
+otherlibref += $(unix_MLIS:%.mli=%)
+endif
+
+ifneq "$(filter systhreads,$(OTHERLIBRARIES))" ""
+otherlibref += $(thread_MLIS:%.mli=%)
+endif
+
 libref_EXTRA=stdlib__pervasives
 libref_TEXT=Ocaml_operators Format_tutorial
 libref_C=$(call capitalize,$(libref) $(libref_EXTRA))


### PR DESCRIPTION
Don't include libraries in otherlibs/ which have been disabled.

Fixes #10584.