### PR TITLE
Use $(ROOTDIR) rather than $(SRC) in manual build system

### DIFF
--- a/manual/README.md
+++ b/manual/README.md
@@ -25,10 +25,6 @@ the one from the source tree.
 
 1. Run `make` in the manual directory.
 
-NB: If you already set `LD_LIBRARY_PATH` (OS X: `DYLD_LIBRARY_PATH`)
- in your environment don't forget to append the absolute paths to
- `otherlibs/unix` and `otherlibs/str` to it.
-
 Outputs
 -------
 

--- a/manual/src/Makefile
+++ b/manual/src/Makefile
@@ -1,8 +1,5 @@
-ROOTDIR = $(abspath ../..)
+ROOTDIR = ../..
 -include $(ROOTDIR)/Makefile.config
-
-export LD_LIBRARY_PATH   ?= "$(ROOTDIR)/otherlibs/unix/:$(ROOTDIR)/otherlibs/str/"
-export DYLD_LIBRARY_PATH ?= "$(ROOTDIR)/otherlibs/unix/:$(ROOTDIR)/otherlibs/str/"
 
 TEXQUOTE = $(ROOTDIR)/runtime/ocamlrun ../tools/texquote2
 

--- a/manual/src/Makefile
+++ b/manual/src/Makefile
@@ -1,10 +1,10 @@
-SRC = $(abspath ../..)
--include $(SRC)/Makefile.config
+ROOTDIR = $(abspath ../..)
+-include $(ROOTDIR)/Makefile.config
 
-export LD_LIBRARY_PATH   ?= "$(SRC)/otherlibs/unix/:$(SRC)/otherlibs/str/"
-export DYLD_LIBRARY_PATH ?= "$(SRC)/otherlibs/unix/:$(SRC)/otherlibs/str/"
+export LD_LIBRARY_PATH   ?= "$(ROOTDIR)/otherlibs/unix/:$(ROOTDIR)/otherlibs/str/"
+export DYLD_LIBRARY_PATH ?= "$(ROOTDIR)/otherlibs/unix/:$(ROOTDIR)/otherlibs/str/"
 
-TEXQUOTE = $(SRC)/runtime/ocamlrun ../tools/texquote2
+TEXQUOTE = $(ROOTDIR)/runtime/ocamlrun ../tools/texquote2
 
 FILES = allfiles.tex biblio.tex foreword.tex version.tex cmds/warnings-help.etex ifocamldoc.tex
 
@@ -18,8 +18,8 @@ INFO_FLAGS = -fix -exec xxdate.exe -info -w 79 -s
 HTML_FLAGS = -fix -exec xxdate.exe -O
 TEXT_FLAGS = -fix -exec xxdate.exe -text -w 79 -s
 
-# Copy the documentation files from SRC/api_docgen
-APIDOC=$(SRC)/api_docgen
+# Copy the documentation files from ROOTDIR/api_docgen
+APIDOC=$(ROOTDIR)/api_docgen
 .PHONY: html_files
 .PHONY: latex_files
 ifeq ($(DOCUMENTATION_TOOL),odoc)
@@ -125,17 +125,17 @@ etex-files: $(FILES)
 	$(TEXQUOTE) < $< > $*.texquote_error.tex
 	mv $*.texquote_error.tex $@
 
-version.tex: $(SRC)/VERSION
+version.tex: $(ROOTDIR)/VERSION
 	sed -n -e '1s/^\([0-9]*\.[0-9]*\).*$$/\\def\\ocamlversion{\1}/p' $< > $@
 
-cmds/warnings-help.etex: $(SRC)/utils/warnings.ml $(SRC)/ocamlc
+cmds/warnings-help.etex: $(ROOTDIR)/utils/warnings.ml $(ROOTDIR)/ocamlc
 	(echo "% This file is generated from (ocamlc -warn-help)";\
 	 echo "% according to a rule in manual/src/Makefile.";\
 	 echo "% In particular, the reference to documentation sections";\
 	 echo "% are inserted through the Makefile, which should be updated";\
 	 echo "% when a new warning is documented.";\
 	 echo "%";\
-	 $(SRC)/boot/ocamlrun $(SRC)/ocamlc -warn-help \
+	 $(ROOTDIR)/boot/ocamlrun $(ROOTDIR)/ocamlc -warn-help \
 	 | LC_ALL=C sed -e 's/^ *\([0-9][0-9]*\) *\[\([a-z][a-z-]*\)\]\(.*\)/\\item[\1 "\2"] \3/' \
 	                -e 's/^ *\([0-9A-Z][0-9]*\) *\([^]].*\)/\\item[\1] \2/'\
 	 | sed -e 's/@/\\@/g' \
@@ -148,7 +148,7 @@ cmds/warnings-help.etex: $(SRC)/utils/warnings.ml $(SRC)/ocamlc
 	  mv $@.tmp $@;\
 	done
 
-ifocamldoc.tex: $(SRC)/Makefile.config
+ifocamldoc.tex: $(ROOTDIR)/Makefile.config
 	$(MAKE) -C $(APIDOC) build/latex/ifocamldoc.tex
 	cp $(APIDOC)/build/latex/ifocamldoc.tex $@
 

--- a/manual/src/Makefile
+++ b/manual/src/Makefile
@@ -1,5 +1,5 @@
 ROOTDIR = ../..
--include $(ROOTDIR)/Makefile.config
+-include $(ROOTDIR)/Makefile.build_config
 
 TEXQUOTE = $(ROOTDIR)/runtime/ocamlrun ../tools/texquote2
 
@@ -145,7 +145,7 @@ cmds/warnings-help.etex: $(ROOTDIR)/utils/warnings.ml $(ROOTDIR)/ocamlc
 	  mv $@.tmp $@;\
 	done
 
-ifocamldoc.tex: $(ROOTDIR)/Makefile.config
+ifocamldoc.tex: $(ROOTDIR)/Makefile.build_config
 	$(MAKE) -C $(APIDOC) build/latex/ifocamldoc.tex
 	cp $(APIDOC)/build/latex/ifocamldoc.tex $@
 

--- a/manual/src/library/Makefile
+++ b/manual/src/library/Makefile
@@ -1,8 +1,8 @@
-SRC = ../../..
+ROOTDIR = ../../..
 
-CSLDIR = $(SRC)
+CSLDIR = $(ROOTDIR)
 
-TEXQUOTE = $(SRC)/runtime/ocamlrun ../../tools/texquote2
+TEXQUOTE = $(ROOTDIR)/runtime/ocamlrun ../../tools/texquote2
 
 FILES = core.tex builtin.tex stdlib-blurb.tex compilerlibs.tex \
   libunix.tex libstr.tex old.tex libthreads.tex libdynlink.tex

--- a/manual/tools/Makefile
+++ b/manual/tools/Makefile
@@ -1,5 +1,4 @@
 ROOTDIR = ../..
-COMPFLAGS = -I $(ROOTDIR)/otherlibs/str -I $(ROOTDIR)/otherlibs/unix
 include $(ROOTDIR)/Makefile.common
 include $(ROOTDIR)/Makefile.best_binaries
 

--- a/ocaml-variants.opam
+++ b/ocaml-variants.opam
@@ -10,7 +10,6 @@ depends: [
 ]
 conflict-class: "ocaml-core-compiler"
 flags: compiler
-setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   ["./configure" "--prefix=%{prefix}%"]
   [make "-j%{jobs}%"]

--- a/ocamldoc/Makefile
+++ b/ocamldoc/Makefile
@@ -323,8 +323,6 @@ test_texi:
 
 # stdlib non-prefixed :
 #######################
-SRC=$(ROOTDIR)
-
 
 .PHONY: autotest_stdlib
 autotest_stdlib:

--- a/ocamldoc/Makefile.best_ocamldoc
+++ b/ocamldoc/Makefile.best_ocamldoc
@@ -13,34 +13,29 @@
 #*                                                                        *
 #**************************************************************************
 
-OCAMLDOC=$(ROOTDIR)/ocamldoc/ocamldoc$(EXE)
-OCAMLDOC_OPT=$(ROOTDIR)/ocamldoc/ocamldoc.opt$(EXE)
+OCAMLDOC = $(ROOTDIR)/ocamldoc/ocamldoc$(EXE)
+OCAMLDOC_OPT = $(ROOTDIR)/ocamldoc/ocamldoc.opt$(EXE)
 
-# TODO: clarify whether the following really needs to be that complicated
-ifeq "$(UNIX_OR_WIN32)" "unix"
-  ifeq "$(TARGET)" "$(HOST)"
-    ifeq "$(SUPPORTS_SHARED_LIBRARIES)" "true"
-      OCAMLDOC_RUN_BYTE=$(OCAMLRUN) -I $(ROOTDIR)/otherlibs/$(UNIXLIB) -I $(ROOTDIR)/otherlibs/str ./$(OCAMLDOC)
-    else
-# if shared-libraries are not supported, unix.cma and str.cma
-# are compiled with -custom, so ocamldoc also uses -custom,
-# and (ocamlrun ocamldoc) does not work.
-      OCAMLDOC_RUN_BYTE=./$(OCAMLDOC)
-    endif
+ifeq "$(TARGET)" "$(HOST)"
+  ifeq "$(SUPPORTS_SHARED_LIBRARIES)" "true"
+    OCAMLDOC_RUN_BYTE = $(OCAMLRUN) -I $(ROOTDIR)/otherlibs/$(UNIXLIB) \
+                                    -I $(ROOTDIR)/otherlibs/str ./$(OCAMLDOC)
   else
-    OCAMLDOC_RUN_BYTE=$(OCAMLRUN) ./$(OCAMLDOC)
+    # if shared-libraries are not supported, unix.cma and str.cma
+    # are compiled with -custom, so ocamldoc also uses -custom,
+    # and (ocamlrun ocamldoc) does not work.
+    OCAMLDOC_RUN_BYTE = ./$(OCAMLDOC)
   endif
-else # Windows
-  OCAMLDOC_RUN_BYTE = \
-    CAML_LD_LIBRARY_PATH="$(ROOTDIR)/otherlibs/win32unix;$(ROOTDIR)/otherlibs/str" $(OCAMLRUN) ./$(OCAMLDOC)
+else
+  OCAMLDOC_RUN_BYTE = $(OCAMLRUN) ./$(OCAMLDOC)
 endif
 
-OCAMLDOC_RUN_OPT=./$(OCAMLDOC_OPT)
+OCAMLDOC_RUN_OPT = ./$(OCAMLDOC_OPT)
 
-OCAMLDOC_RUN_PLUGINS=$(OCAMLDOC_RUN_BYTE)
+OCAMLDOC_RUN_PLUGINS = $(OCAMLDOC_RUN_BYTE)
 
 ifeq "$(wildcard $(OCAMLDOC_OPT))" ""
-  OCAMLDOC_RUN=$(OCAMLDOC_RUN_BYTE)
+  OCAMLDOC_RUN = $(OCAMLDOC_RUN_BYTE)
 else
-  OCAMLDOC_RUN=$(OCAMLDOC_RUN_OPT)
+  OCAMLDOC_RUN = $(OCAMLDOC_RUN_OPT)
 endif


### PR DESCRIPTION
While working on #10586, I found several instances where `$(SRC)` was still used instead of `$(ROOTDIR)` - most of the manual build system had already switched from SRC to ROOTDIR in other changes; this PR finishes that off.