### PR TITLE
Fix html manual post-processing

### DIFF
--- a/manual/src/html_processing/Makefile
+++ b/manual/src/html_processing/Makefile
@@ -59,7 +59,7 @@ $(WEBDIRAPI)/search_icon.svg: | $(WEBDIRAPI)
 $(WEBDIRCOMP)/%: $(WEBDIRAPI)/% | $(WEBDIRCOMP)
 	cp $< $@
 
-$(WEBDIRMAIN)/%: $(WEBDIRAPI/% | $(WEBDIRAPI)
+$(WEBDIRMAN)/%: $(WEBDIRAPI)/% | $(WEBDIRMAN)
 	cp $< $@
 
 LOGO := colour-logo.svg

--- a/manual/src/html_processing/Makefile
+++ b/manual/src/html_processing/Makefile
@@ -50,10 +50,11 @@ $(WEBDIRCOMP)/%.js: js/%.js | $(WEBDIRCOMP)
 
 js: $(JS_FILES)
 
+CURL = curl -s
 # download images for local use
 SEARCH := search_icon.svg
 $(WEBDIRAPI)/search_icon.svg: | $(WEBDIRAPI)
-	curl "https://ocaml.org/img/search.svg" > $(WEBDIRAPI)/$(SEARCH)
+	$(CURL) "https://ocaml.org/img/search.svg" > $(WEBDIRAPI)/$(SEARCH)
 
 $(WEBDIRCOMP)/%: $(WEBDIRAPI)/% | $(WEBDIRCOMP)
 	cp $< $@
@@ -63,11 +64,11 @@ $(WEBDIRMAIN)/%: $(WEBDIRAPI/% | $(WEBDIRAPI)
 
 LOGO := colour-logo.svg
 $(WEBDIRAPI)/colour-logo.svg: | $(WEBDIRAPI) $(WEBDIRMAN) $(WEBDIRCOMP)
-	curl "https://raw.githubusercontent.com/ocaml/ocaml-logo/master/Colour/SVG/colour-logo.svg" > $(WEBDIRAPI)/$(LOGO)
+	$(CURL) "https://raw.githubusercontent.com/ocaml/ocaml-logo/master/Colour/SVG/colour-logo.svg" > $(WEBDIRAPI)/$(LOGO)
 
 ICON := favicon.ico
 $(WEBDIRAPI)/favicon.ico: | $(WEBDIRAPI) $(WEBDIRMAN) $(WEBDIRCOMP)
-	curl "https://raw.githubusercontent.com/ocaml/ocaml-logo/master/Colour/Favicon/32x32.ico" > $(WEBDIRAPI)/$(ICON)
+	$(CURL) "https://raw.githubusercontent.com/ocaml/ocaml-logo/master/Colour/Favicon/32x32.ico" > $(WEBDIRAPI)/$(ICON)
 
 IMG_FILES0 := colour-logo.svg
 IMG_FILES := $(addprefix $(WEBDIRAPI)/, $(IMG_FILES0)) $(addprefix $(WEBDIRCOMP)/, $(IMG_FILES0)) $(addprefix $(WEBDIRMAN)/, $(IMG_FILES0)) 


### PR DESCRIPTION
As noted https://github.com/ocaml/ocaml/pull/10537#commitcomment-55599875, the reviewer made a mistake!

This needs to go on 4.13 as well.

The changes in `make -C manual web` are:

```diff
--- a   2021-08-29 11:26:46.763980758 +0100
+++ b   2021-08-29 11:26:48.392013115 +0100
@@ -15,13 +15,13 @@
 cp js/search.js ../webman/api/compilerlibref/search.js
 cp js/scroll.js ../webman/manual/scroll.js
 cp js/navigation.js ../webman/manual/navigation.js
-curl "https://ocaml.org/img/search.svg" > ../webman/api/search_icon.svg
-curl "https://raw.githubusercontent.com/ocaml/ocaml-logo/master/Colour/Favicon/32x32.ico" > ../webman/api/favicon.ico
+curl -s "https://ocaml.org/img/search.svg" > ../webman/api/search_icon.svg
+curl -s "https://raw.githubusercontent.com/ocaml/ocaml-logo/master/Colour/Favicon/32x32.ico" > ../webman/api/favicon.ico
 cp ../webman/api/search_icon.svg ../webman/api/compilerlibref/search_icon.svg
 cp ../webman/api/favicon.ico ../webman/api/compilerlibref/favicon.ico
-curl "https://raw.githubusercontent.com/ocaml/ocaml-logo/master/Colour/SVG/colour-logo.svg" > ../webman/api/colour-logo.svg
+curl -s "https://raw.githubusercontent.com/ocaml/ocaml-logo/master/Colour/SVG/colour-logo.svg" > ../webman/api/colour-logo.svg
 cp ../webman/api/colour-logo.svg ../webman/api/compilerlibref/colour-logo.svg
-mkdir -p ../webman/manual/colour-logo.svg
+cp ../webman/api/colour-logo.svg ../webman/manual/colour-logo.svg
 dune/dune.exe exec --root=. src/process_manual.exe quiet
 File "markup.ml/src/kstream.ml", line 20, characters 9-12:
 20 | let next {f} throw e k = f throw e k
```

cc @sanette 