### PR TITLE
Add various fast-paths in typechecking

### DIFF
--- a/Changes
+++ b/Changes
@@ -146,6 +146,9 @@ Working version
 - #10542: Fix detection of immediate64 types through unboxed types.
   (Leo White, review by Stephen Dolan and Gabriel Scherer)
 
+- #10590: Some typechecker optimisations
+  (Stephen Dolan, review by Gabriel Scherer and Leo White)
+
 OCaml 4.13.0
 -------------
 

--- a/typing/includemod.ml
+++ b/typing/includemod.ml
@@ -575,8 +575,8 @@ and signatures ~loc env ~mark subst sig1 sig2 =
               false
           | _ -> name2, true
         in
-        begin try
-          let (id1, item1, pos1) = FieldMap.find name2 comps1 in
+        begin match FieldMap.find name2 comps1 with
+        | (id1, item1, pos1) ->
           let new_subst =
             match item2 with
               Sig_type _ ->
@@ -591,7 +591,7 @@ and signatures ~loc env ~mark subst sig1 sig2 =
           in
           pair_components new_subst
             ((item1, item2, pos1) :: paired) unpaired rem
-        with Not_found ->
+        | exception Not_found ->
           let unpaired =
             if report then
               item2 :: unpaired


### PR DESCRIPTION
Here are a few trivial optimisations to the typechecker, which amount to skipping a complicated computation in the easy case. They add up to about 5% saved in time and allocations during typechecking (measured on typecore.ml)

  - ~~Skip Builtin_attributes.warning_scope if there are no attributes~~ (Actually, the Warnings.save/restore seems to be required by some tests. I've disabled this one, as it didn't have very much effect anyway)
  - Skip Typecore.type_unpacks if there are no first-class modules
  - Skip Rec_check if the recursive binding is a function
  - Skip computation of disambiguation warnings, if disabled