### PR TITLE
HACKING.adoc: add tip about using linscan

### DIFF
--- a/HACKING.adoc
+++ b/HACKING.adoc
@@ -449,6 +449,17 @@ If `boot/ocamlc` changes (e.g. because you ran `make bootstrap`), then
 the build will revert to the slower bytecode-compiled `ocamlc` until
 you do the above step again.
 
+=== Speeding up native builds on architectures with a lot of registers
+
+On architectures with a lot of registers you can also speed up the build by using
+the linear scan register allocator, e.g.:
+
+----
+export OCAMLPARAM=_,linscan=1
+----
+
+You can try this if building driver/main_args takes a lot of time.
+
 === Using merlin
 
 During the development of the compiler, the internal format of compiled object


### PR DESCRIPTION
Timings for a full ./configure --disable-ocamldoc && make -j4 on FU740:
* default: 1183s
* linscan: 997s
* flambda: 1465s

Building driver/main_args with ocamlopt.opt takes ages:
```
83.200s driver/main_args.ml
  00.127s parsing
    00.127s parser
    00.001s other
  01.398s typing
  00.143s transl
  81.531s generate
    00.058s cmm
    80.507s compile_phrases
      00.004s cmm_invariants
      00.317s selection
      00.020s comballoc
      00.886s cse
      00.399s liveness
      00.094s deadcode
      00.530s spill
      00.098s split
      77.901s regalloc
      00.028s linearize
      00.003s scheduling
      00.143s emit
      00.085s other
    00.612s assemble
    00.355s other
00.130s other
```

Using linscan is so much faster:
```
6.507s driver/main_args.ml
  0.125s parsing
    0.124s parser
  1.387s typing
  0.142s transl
  4.852s generate
    0.057s cmm
    3.796s compile_phrases
      0.004s cmm_invariants
      0.310s selection
      0.029s comballoc
      0.975s cse
      0.309s liveness
      0.084s deadcode
      0.223s spill
      0.073s split
      1.532s regalloc
      0.022s linearize
      0.003s scheduling
      0.150s emit
      0.083s other
    0.645s assemble
    0.354s other
0.126s other
```

Another way to speed up compilation of that file is to use an flambda build.
Although more time spent is spent in flambda it gives less work to the
register allocator:
```
6.176s driver/main_args.ml
  0.115s parsing
    0.115s parser
    0.001s other
  1.353s typing
  0.096s transl
  4.612s generate
    2.511s flambda
      2.511s middle_end
        0.256s closure_conversion
        0.134s lift_lets 1
        0.811s Lift_constants
        0.063s Share_constants
        0.024s Remove_unused_program_constructs
        0.134s Lift_let_to_initialize_symbol
        0.109s lift_lets 2
        0.039s Remove_unused_closure_vars 1
        0.488s Inline_and_simplify
        0.018s Remove_unused_closure_vars 2
        0.061s lift_lets 3
        0.292s Inline_and_simplify noinline
        0.024s Remove_unused_closure_vars 3
        0.032s Ref_to_variables
        0.002s Initialize_symbol_to_let_symbol
        0.020s Remove_unused_closure_vars
        0.004s other
    0.154s backend
    0.037s cmm
    0.895s compile_phrases
      0.003s cmm_invariants
      0.067s selection
      0.015s comballoc
      0.037s cse
      0.061s liveness
      0.015s deadcode
      0.059s spill
      0.022s split
      0.352s regalloc
      0.017s linearize
      0.051s scheduling
      0.100s emit
      0.096s other
    0.449s assemble
    0.567s other
0.156s other
```

However overall flambda is slower than the default.
