### PR TITLE
Fix untypeast for patterns

### DIFF
--- a/Changes
+++ b/Changes
@@ -766,6 +766,10 @@ OCaml 4.13.0
   optional libraries have been disabled.
   (David Allsopp, report by Yuri Victorovich review by Florian Angeletti)
 
+- #10593: Fix untyping of patterns without named existential quantifiers. This
+  bug was only present in the beta version of OCaml 4.13.0.
+  (Ulysse Gérard, review by Florian Angeletti)
+
 OCaml 4.12, maintenance version
 -------------------------------
 

--- a/testsuite/tests/compiler-libs/test_untypeast.ml
+++ b/testsuite/tests/compiler-libs/test_untypeast.ml
@@ -1,0 +1,17 @@
+(* TEST
+   flags = "-I ${ocamlsrcdir}/typing \
+    -I ${ocamlsrcdir}/parsing"
+   include ocamlcommon
+   * expect
+*)
+
+let res =
+  let s = {| match None with Some (Some _) -> () | _ -> () |} in
+  let pe = Parse.expression (Lexing.from_string s) in
+  let te = Typecore.type_expression (Env.initial_safe_string) pe in
+  let ute = Untypeast.untype_expression te in
+  Format.asprintf "%a" Pprintast.expression ute
+
+[%%expect{|
+val res : string = "match None with | Some (Some _) -> () | _ -> ()"
+|}]


### PR DESCRIPTION
I encountered what looks like an issue with `Untypeast.pattern/expression` while upgrading Merlin to use OCaml 4.13.0.
The problem was introduced in #9584 ([relevant diff](https://github.com/ocaml/ocaml/pull/9584/files#diff-f315ba52e0e0393914ce39e195e68e7ec9364cdaee5be96c28bff5fc122824a5)).

Patterns with no named existential are not  correctly treated and their arguments disappear after the "untyping".

I added a test to illustrate the issue: the expression `match None with Some (Some _) -> () | _ -> ()` is parsed, typed, untyped and pretty-printed. With the trunk version of `Untypeast` the result is: `match None with Some -> () | _ -> ()` which is obviously wrong.

This is my first PR to the compiler, I will be glad to follow your instructions to improve it ! (I was especially unsure of where to add the new test.)

(this PR should probably be backported to the 4.13 branch)

