### PR TITLE
Add {In,Out}_channel.with_open_{bin,text,gen} and In_channel.input_all

### DIFF
--- a/Changes
+++ b/Changes
@@ -71,6 +71,10 @@ Working version
   (Nicolás Ojeda Bär, review by John Whitington, Daniel Bünzli, David Allsopp
   and Xavier Leroy)
 
+- #10596: Add with_open_bin, with_open_text and with_open_gen to In_channel and
+  Out_channel. Also, add In_channel.input_all.
+  (Nicolás Ojeda Bär, review by Daniel Bünzli and Xavier Leroy)
+
 ### Other libraries:
 
 - #10192: Add support for Unix domain sockets on Windows and use them

--- a/Changes
+++ b/Changes
@@ -73,7 +73,8 @@ Working version
 
 - #10596: Add with_open_bin, with_open_text and with_open_gen to In_channel and
   Out_channel. Also, add In_channel.input_all.
-  (Nicolás Ojeda Bär, review by Daniel Bünzli and Xavier Leroy)
+  (Nicolás Ojeda Bär, review by Daniel Bünzli, Jérémie Dimino, Damien Doligez
+  and Xavier Leroy)
 
 ### Other libraries:
 

--- a/stdlib/.depend
+++ b/stdlib/.depend
@@ -360,14 +360,14 @@ stdlib__Hashtbl.cmx : hashtbl.ml \
 stdlib__Hashtbl.cmi : hashtbl.mli \
     stdlib__Seq.cmi
 stdlib__In_channel.cmo : in_channel.ml \
+    stdlib__Sys.cmi \
     stdlib.cmi \
-    stdlib__List.cmi \
     stdlib__Fun.cmi \
     stdlib__Bytes.cmi \
     stdlib__In_channel.cmi
 stdlib__In_channel.cmx : in_channel.ml \
+    stdlib__Sys.cmx \
     stdlib.cmx \
-    stdlib__List.cmx \
     stdlib__Fun.cmx \
     stdlib__Bytes.cmx \
     stdlib__In_channel.cmi

--- a/stdlib/.depend
+++ b/stdlib/.depend
@@ -361,9 +361,13 @@ stdlib__Hashtbl.cmi : hashtbl.mli \
     stdlib__Seq.cmi
 stdlib__In_channel.cmo : in_channel.ml \
     stdlib.cmi \
+    stdlib__List.cmi \
+    stdlib__Bytes.cmi \
     stdlib__In_channel.cmi
 stdlib__In_channel.cmx : in_channel.ml \
     stdlib.cmx \
+    stdlib__List.cmx \
+    stdlib__Bytes.cmx \
     stdlib__In_channel.cmi
 stdlib__In_channel.cmi : in_channel.mli \
     stdlib.cmi

--- a/stdlib/.depend
+++ b/stdlib/.depend
@@ -362,11 +362,13 @@ stdlib__Hashtbl.cmi : hashtbl.mli \
 stdlib__In_channel.cmo : in_channel.ml \
     stdlib.cmi \
     stdlib__List.cmi \
+    stdlib__Fun.cmi \
     stdlib__Bytes.cmi \
     stdlib__In_channel.cmi
 stdlib__In_channel.cmx : in_channel.ml \
     stdlib.cmx \
     stdlib__List.cmx \
+    stdlib__Fun.cmx \
     stdlib__Bytes.cmx \
     stdlib__In_channel.cmi
 stdlib__In_channel.cmi : in_channel.mli \
@@ -510,9 +512,11 @@ stdlib__Option.cmi : option.mli \
     stdlib__Seq.cmi
 stdlib__Out_channel.cmo : out_channel.ml \
     stdlib.cmi \
+    stdlib__Fun.cmi \
     stdlib__Out_channel.cmi
 stdlib__Out_channel.cmx : out_channel.ml \
     stdlib.cmx \
+    stdlib__Fun.cmx \
     stdlib__Out_channel.cmi
 stdlib__Out_channel.cmi : out_channel.mli \
     stdlib.cmi

--- a/stdlib/in_channel.ml
+++ b/stdlib/in_channel.ml
@@ -102,7 +102,7 @@ let read_upto ic buf ofs len =
    The returned buffer may have *fewer* than [ofs + n] bytes of storage if this
    number is > [Sys.max_string_length]. However the returned buffer will
    *always* have > [ofs] bytes of storage. In the limiting case when [ofs = len
-   = Sys.max_string_lenght] (so that it is not possible to resize the buffer at
+   = Sys.max_string_length] (so that it is not possible to resize the buffer at
    all), an exception is raised. *)
 
 let ensure buf ofs n =

--- a/stdlib/in_channel.ml
+++ b/stdlib/in_channel.ml
@@ -95,12 +95,4 @@ let input_all ic =
   in
   loop (Bytes.create bufsz) 0
 
-let input_lines ic =
-  let rec loop accu =
-    match Stdlib.input_line ic with
-    | s -> loop (s :: accu)
-    | exception End_of_file -> List.rev accu
-  in
-  loop []
-
 let set_binary_mode = Stdlib.set_binary_mode_in

--- a/stdlib/in_channel.ml
+++ b/stdlib/in_channel.ml
@@ -30,6 +30,22 @@ let stdin = Stdlib.stdin
 let open_bin = Stdlib.open_in_bin
 let open_text = Stdlib.open_in
 let open_gen = Stdlib.open_in_gen
+
+let with_open openfun s f =
+  let ic = openfun s in
+  match f ic with
+  | r -> Stdlib.close_in ic; r
+  | exception e -> Stdlib.close_in_noerr ic; raise e
+
+let with_open_bin s f =
+  with_open Stdlib.open_in_bin s f
+
+let with_open_text s f =
+  with_open Stdlib.open_in s f
+
+let with_open_gen flags perm s f =
+  with_open (Stdlib.open_in_gen flags perm) s f
+
 let seek = Stdlib.LargeFile.seek_in
 let pos = Stdlib.LargeFile.pos_in
 let length = Stdlib.LargeFile.in_channel_length
@@ -62,5 +78,30 @@ let really_input_string ic len =
   match Stdlib.really_input_string ic len with
   | s -> Some s
   | exception End_of_file -> None
+
+let input_all ic =
+  let bufsz = 65536 in (* IO_BUFFER_SIZE *)
+  let rec loop buf ofs =
+    let buf =
+      if Bytes.length buf - ofs >= bufsz then
+        buf
+      else begin
+        let newbuf = Bytes.create (2 * Bytes.length buf + 1) in
+        Bytes.blit buf 0 newbuf 0 ofs;
+        newbuf
+      end
+    in
+    let r = Stdlib.input ic buf ofs bufsz in
+    if r = 0 then Bytes.sub_string buf 0 ofs else loop buf (ofs + r)
+  in
+  loop (Bytes.create bufsz) 0
+
+let input_lines ic =
+  let rec loop accu =
+    match Stdlib.input_line ic with
+    | s -> loop (s :: accu)
+    | exception End_of_file -> List.rev accu
+  in
+  loop []
 
 let set_binary_mode = Stdlib.set_binary_mode_in

--- a/stdlib/in_channel.ml
+++ b/stdlib/in_channel.ml
@@ -99,7 +99,8 @@ let input_all ic =
             else if len < Sys.max_string_length then
               Sys.max_string_length
             else
-              failwith "In_channel.input_all: cannot grow buffer"
+              failwith "In_channel.input_all: channel content \
+                        is larger than maximum string length"
           in
           let new_buf = Bytes.create new_len in
           Bytes.blit buf 0 new_buf 0 ofs;

--- a/stdlib/in_channel.ml
+++ b/stdlib/in_channel.ml
@@ -104,7 +104,7 @@ let input_all ic =
           let new_buf = Bytes.create new_len in
           Bytes.blit buf 0 new_buf 0 ofs;
           Bytes.set buf ofs c;
-          loop new_buf ofs
+          loop new_buf (ofs + 1)
     end
   in
   let initial_size =

--- a/stdlib/in_channel.ml
+++ b/stdlib/in_channel.ml
@@ -92,7 +92,7 @@ let input_all ic =
       | exception End_of_file ->
           Bytes.unsafe_to_string buf
       | c ->
-          let new_len = 2 * Bytes.length buf in
+          let new_len = if len = 0 then 65536 else 2 * Bytes.length buf in
           let new_len =
             if new_len <= Sys.max_string_length then
               new_len
@@ -114,7 +114,7 @@ let input_all ic =
     with Sys_error _ ->
       0
   in
-  let initial_size = if initial_size <= 0 then 65536 else initial_size in
+  let initial_size = if initial_size <= 0 then 0 else initial_size in
   loop (Bytes.create initial_size) 0
 
 let set_binary_mode = Stdlib.set_binary_mode_in

--- a/stdlib/in_channel.ml
+++ b/stdlib/in_channel.ml
@@ -33,9 +33,8 @@ let open_gen = Stdlib.open_in_gen
 
 let with_open openfun s f =
   let ic = openfun s in
-  match f ic with
-  | r -> Stdlib.close_in ic; r
-  | exception e -> Stdlib.close_in_noerr ic; raise e
+  Fun.protect ~finally:(fun () -> Stdlib.close_in_noerr ic)
+    (fun () -> f ic)
 
 let with_open_bin s f =
   with_open Stdlib.open_in_bin s f

--- a/stdlib/in_channel.ml
+++ b/stdlib/in_channel.ml
@@ -113,7 +113,7 @@ let input_all ic =
     with Sys_error _ ->
       0
   in
-  let initial_size = if initial_size <= 0 then 65563 else initial_size in
+  let initial_size = if initial_size <= 0 then 65536 else initial_size in
   loop (Bytes.create initial_size) 0
 
 let set_binary_mode = Stdlib.set_binary_mode_in

--- a/stdlib/in_channel.mli
+++ b/stdlib/in_channel.mli
@@ -51,6 +51,19 @@ val open_gen : open_flag list -> int -> string -> t
     file permissions.  {!open_text} and {!open_bin} are special cases of this
     function. *)
 
+val with_open_bin : string -> (t -> 'a) -> 'a
+(** [with_open_bin fn f] opens file [fn] for reading, and passes the resulting
+    channel to [f]. The channel is closed before [f] returns with a value or by
+    raising an exception. *)
+
+val with_open_text : string -> (t -> 'a) -> 'a
+(** Like {!with_open_bin}, but the channel is opened in text mode (see
+    {!open_text}). *)
+
+val with_open_gen : open_flag list -> int -> string -> (t -> 'a) -> 'a
+(** Like {!with_open_bin}, but can specify the opening mode and file permission,
+    in case the file must be created (see {!open_gen}). *)
+
 val seek : t -> int64 -> unit
 (** [seek chan pos] sets the current reading position to [pos] for channel
     [chan]. This works only for regular files. On files of other kinds, the
@@ -122,6 +135,13 @@ val really_input_string : t -> int -> string option
 (** [really_input_string ic len] reads [len] characters from channel [ic] and
     returns them in a new string.  Returns [None] if the end of file is reached
     before [len] characters have been read. *)
+
+val input_all : t -> string
+(** [input_all ic] reads all remaining data in [ic]. *)
+
+val input_lines : t -> string list
+(** [input_lines ic] reads all remaining data in [ic], splits it at each newline
+    character [\n], and returns the resulting list. *)
 
 val set_binary_mode : t -> bool -> unit
 (** [set_binary_mode ic true] sets the channel [ic] to binary mode: no

--- a/stdlib/in_channel.mli
+++ b/stdlib/in_channel.mli
@@ -139,10 +139,6 @@ val really_input_string : t -> int -> string option
 val input_all : t -> string
 (** [input_all ic] reads all remaining data in [ic]. *)
 
-val input_lines : t -> string list
-(** [input_lines ic] reads all remaining data in [ic], splits it at each newline
-    character [\n], and returns the resulting list. *)
-
 val set_binary_mode : t -> bool -> unit
 (** [set_binary_mode ic true] sets the channel [ic] to binary mode: no
     translations take place during input.

--- a/stdlib/in_channel.mli
+++ b/stdlib/in_channel.mli
@@ -52,9 +52,9 @@ val open_gen : open_flag list -> int -> string -> t
     function. *)
 
 val with_open_bin : string -> (t -> 'a) -> 'a
-(** [with_open_bin fn f] opens a channel [ic] on file [fn] and returns
-    [f ic]. After the function returns, either with a value or by raising an
-    exception, [ic] is guaranteed to be closed. *)
+(** [with_open_bin fn f] opens a channel [ic] on file [fn] and returns [f
+    ic]. After [f] returns, either with a value or by raising an exception, [ic]
+    is guaranteed to be closed. *)
 
 val with_open_text : string -> (t -> 'a) -> 'a
 (** Like {!with_open_bin}, but the channel is opened in text mode (see

--- a/stdlib/in_channel.mli
+++ b/stdlib/in_channel.mli
@@ -52,9 +52,9 @@ val open_gen : open_flag list -> int -> string -> t
     function. *)
 
 val with_open_bin : string -> (t -> 'a) -> 'a
-(** [with_open_bin fn f] opens file [fn] for reading, and passes the resulting
-    channel to [f]. The channel is closed before [f] returns with a value or by
-    raising an exception. *)
+(** [with_open_bin fn f] opens a channel [ic] on file [fn] and returns
+    [f ic]. After the function returns, either with a value or by raising an
+    exception, [ic] is guaranteed to be closed. *)
 
 val with_open_text : string -> (t -> 'a) -> 'a
 (** Like {!with_open_bin}, but the channel is opened in text mode (see
@@ -137,7 +137,7 @@ val really_input_string : t -> int -> string option
     before [len] characters have been read. *)
 
 val input_all : t -> string
-(** [input_all ic] reads all remaining data in [ic]. *)
+(** [input_all ic] reads all remaining data from [ic]. *)
 
 val set_binary_mode : t -> bool -> unit
 (** [set_binary_mode ic true] sets the channel [ic] to binary mode: no

--- a/stdlib/out_channel.ml
+++ b/stdlib/out_channel.ml
@@ -31,6 +31,22 @@ let stderr = Stdlib.stderr
 let open_bin = Stdlib.open_out_bin
 let open_text = Stdlib.open_out
 let open_gen = Stdlib.open_out_gen
+
+let with_open openfun s f =
+  let oc = openfun s in
+  match f oc with
+  | r -> Stdlib.close_out oc; r
+  | exception e -> Stdlib.close_out_noerr oc; raise e
+
+let with_open_bin s f =
+  with_open Stdlib.open_out_bin s f
+
+let with_open_text s f =
+  with_open Stdlib.open_out s f
+
+let with_open_gen flags perm s f =
+  with_open (Stdlib.open_out_gen flags perm) s f
+
 let seek = Stdlib.LargeFile.seek_out
 let pos = Stdlib.LargeFile.pos_out
 let length = Stdlib.LargeFile.out_channel_length

--- a/stdlib/out_channel.ml
+++ b/stdlib/out_channel.ml
@@ -34,9 +34,8 @@ let open_gen = Stdlib.open_out_gen
 
 let with_open openfun s f =
   let oc = openfun s in
-  match f oc with
-  | r -> Stdlib.close_out oc; r
-  | exception e -> Stdlib.close_out_noerr oc; raise e
+  Fun.protect ~finally:(fun () -> Stdlib.close_out_noerr oc)
+    (fun () -> f oc)
 
 let with_open_bin s f =
   with_open Stdlib.open_out_bin s f

--- a/stdlib/out_channel.mli
+++ b/stdlib/out_channel.mli
@@ -57,9 +57,9 @@ val open_gen : open_flag list -> int -> string -> t
     function. *)
 
 val with_open_bin : string -> (t -> 'a) -> 'a
-(** [with_open_bin fn f] opens a channel [oc] on file [fn] and returns
-    [f oc]. After the function returns, either with a value or by raising an
-    exception, [oc] is guaranteed to be closed. *)
+(** [with_open_bin fn f] opens a channel [oc] on file [fn] and returns [f
+    oc]. After [f] returns, either with a value or by raising an exception, [oc]
+    is guaranteed to be closed. *)
 
 val with_open_text : string -> (t -> 'a) -> 'a
 (** Like {!with_open_bin}, but the channel is opened in text mode (see

--- a/stdlib/out_channel.mli
+++ b/stdlib/out_channel.mli
@@ -57,9 +57,9 @@ val open_gen : open_flag list -> int -> string -> t
     function. *)
 
 val with_open_bin : string -> (t -> 'a) -> 'a
-(** [with_open_bin fn f] opens file [fn] for writing, and passes the resulting
-    channel to [f]. The channel is closed before [f] returns with a value or by
-    raising an exception. *)
+(** [with_open_bin fn f] opens a channel [oc] on file [fn] and returns
+    [f oc]. After the function returns, either with a value or by raising an
+    exception, [oc] is guaranteed to be closed. *)
 
 val with_open_text : string -> (t -> 'a) -> 'a
 (** Like {!with_open_bin}, but the channel is opened in text mode (see

--- a/stdlib/out_channel.mli
+++ b/stdlib/out_channel.mli
@@ -56,6 +56,19 @@ val open_gen : open_flag list -> int -> string -> t
     created.  {!open_text} and {!open_bin} are special cases of this
     function. *)
 
+val with_open_bin : string -> (t -> 'a) -> 'a
+(** [with_open_bin fn f] opens file [fn] for writing, and passes the resulting
+    channel to [f]. The channel is closed before [f] returns with a value or by
+    raising an exception. *)
+
+val with_open_text : string -> (t -> 'a) -> 'a
+(** Like {!with_open_bin}, but the channel is opened in text mode (see
+    {!open_text}). *)
+
+val with_open_gen : open_flag list -> int -> string -> (t -> 'a) -> 'a
+(** Like {!with_open_bin}, but can specify the opening mode and file permission,
+    in case the file must be created (see {!open_gen}). *)
+
 val seek : t -> int64 -> unit
 (** [seek chan pos] sets the current writing position to [pos] for channel
     [chan]. This works only for regular files. On files of other kinds (such as

--- a/testsuite/tests/lib-channels/input_all.ml
+++ b/testsuite/tests/lib-channels/input_all.ml
@@ -1,0 +1,72 @@
+(* TEST
+readonly_files = "input_all.ml"
+*)
+
+let data_file =
+  "data.txt"
+
+let random_string size =
+  String.init size (fun _ -> Char.chr (Random.int 256))
+
+(* various sizes, binary mode *)
+
+let check size =
+  let data = random_string size in
+  Out_channel.with_open_bin data_file (fun oc -> Out_channel.output_string oc data);
+  let read_data = In_channel.with_open_bin data_file In_channel.input_all in
+  assert (data = read_data)
+
+let () =
+  List.iter check [ 0; 1; 65536; 65536 + 1; 2 * 65536 ]
+
+(* binary mode; non-zero starting position *)
+
+let data_size = 65536
+
+let check midpoint =
+  let data = random_string data_size in
+  Out_channel.with_open_bin data_file
+    (fun oc -> Out_channel.output_string oc data);
+  let contents =
+    In_channel.with_open_bin data_file
+      (fun ic ->
+         let s1 = Option.get (In_channel.really_input_string ic midpoint) in
+         let s2 = In_channel.input_all ic in
+         s1 ^ s2
+      )
+  in
+  assert (contents = data)
+
+let () =
+  List.iter check [0; 1; 100; data_size]
+
+(* text mode *)
+
+(* translates LF into CRLF in-place in [fn] *)
+let unix2dos fn =
+  let s = In_channel.with_open_text fn In_channel.input_all in
+  Out_channel.with_open_text fn
+    (fun oc -> Out_channel.output_string oc s)
+
+let source_fn =
+  "input_all.ml"
+
+let source =
+  In_channel.with_open_bin source_fn In_channel.input_all
+
+let () =
+  unix2dos source_fn
+
+let check midpoint =
+  let contents =
+    In_channel.with_open_text source_fn
+      (fun ic ->
+         let s1 = Option.get (In_channel.really_input_string ic midpoint) in
+         let s2 = In_channel.input_all ic in
+         s1 ^ s2
+      )
+  in
+  assert (contents = source)
+
+let () =
+  List.iter check [0; 1; String.length source]


### PR DESCRIPTION
Hot on the tail of #10545 this PR proposes the addition of `with_open_*` functions to both `In_channel` and `Out_channel` and also  `In_channel.input_all` and `In_channel.input_lines`. These functions work well together:

- `let contents = In_channel.(with_open_bin fn input_all)`
- `let lines = In_channel.(with_open_text fn input_lines)`
- etc

The implementation of `In_channel.input_all` is a bit simplistic. Suggestions for improvements (as well as any other opinion or review) are welcome!
