### PR TITLE
Small refactoring in predef.ml when computing the initial environment  

### DIFF
--- a/typing/predef.ml
+++ b/typing/predef.ml
@@ -194,50 +194,52 @@ let common_initial_env add_type add_extension empty_env =
       }
   in
   empty_env
-  (* Predefined types - alphabetical order *)
-  |> add_type1 ident_array ~variance:Variance.full ~separability:Separability.Ind
+  (* Predefined types *)
+  |> add_type ident_floatarray
+  |> add_type ident_extension_constructor
+  |> add_type ident_int ~immediate:Always
+  |> add_type ident_char ~immediate:Always
+  |> add_type ident_string
+  |> add_type ident_float
   |> add_type ident_bool ~immediate:Always
        ~kind:(Type_variant([cstr ident_false []; cstr ident_true []],
                            Variant_regular))
-  |> add_type ident_char ~immediate:Always
+  |> add_type ident_unit ~immediate:Always
+       ~kind:(Type_variant([cstr ident_void []], Variant_regular))
   |> add_type ident_exn ~kind:Type_open
-  |> add_type ident_extension_constructor
-  |> add_type ident_float
-  |> add_type ident_floatarray
-  |> add_type ident_int ~immediate:Always
-  |> add_type ident_int32
-  |> add_type ident_int64
-  |> add_type1 ident_lazy_t ~variance:Variance.covariant
-       ~separability:Separability.Ind
+  |> add_type1 ident_array ~variance:Variance.full ~separability:Separability.Ind
   |> add_type1 ident_list ~variance:Variance.covariant
        ~separability:Separability.Ind
        ~kind:(fun tvar ->
          Type_variant([cstr ident_nil []; cstr ident_cons [tvar; type_list tvar]],
                       Variant_regular))
-  |> add_type ident_nativeint
   |> add_type1 ident_option ~variance:Variance.covariant
        ~separability:Separability.Ind
        ~kind:(fun tvar ->
          Type_variant([cstr ident_none []; cstr ident_some [tvar]],
                       Variant_regular))
-  |> add_type ident_string
-  |> add_type ident_unit ~immediate:Always
-       ~kind:(Type_variant([cstr ident_void []], Variant_regular))
-  (* Predefined exceptions - alphabetical order *)
+  |> add_type1 ident_lazy_t ~variance:Variance.covariant
+       ~separability:Separability.Ind
+  |> add_type ident_nativeint
+  |> add_type ident_int32
+  |> add_type ident_int64
+  |> add_extension ident_undefined_recursive_module
+       [newgenty (Ttuple[type_string; type_int; type_int])]
+  (* Predefined exceptions *)
+  |> add_extension ident_undefined_recursive_module
+       [newgenty (Ttuple[type_string; type_int; type_int])]
   |> add_extension ident_assert_failure
        [newgenty (Ttuple[type_string; type_int; type_int])]
   |> add_extension ident_division_by_zero []
   |> add_extension ident_end_of_file []
+  |> add_extension ident_sys_error [type_string]
+  |> add_extension ident_sys_blocked_io []
+  |> add_extension ident_not_found []
   |> add_extension ident_failure [type_string]
   |> add_extension ident_invalid_argument [type_string]
-  |> add_extension ident_match_failure
-       [newgenty (Ttuple[type_string; type_int; type_int])]
-  |> add_extension ident_not_found []
-  |> add_extension ident_out_of_memory []
   |> add_extension ident_stack_overflow []
-  |> add_extension ident_sys_blocked_io []
-  |> add_extension ident_sys_error [type_string]
-  |> add_extension ident_undefined_recursive_module
+  |> add_extension ident_out_of_memory []
+  |> add_extension ident_match_failure
        [newgenty (Ttuple[type_string; type_int; type_int])]
 
 let build_initial_env add_type add_exception empty_env =

--- a/typing/predef.ml
+++ b/typing/predef.ml
@@ -194,52 +194,50 @@ let common_initial_env add_type add_extension empty_env =
       }
   in
   empty_env
-  (* Predefined types *)
-  |> add_type ident_floatarray
-  |> add_type ident_extension_constructor
-  |> add_type ident_int ~immediate:Always
-  |> add_type ident_char ~immediate:Always
-  |> add_type ident_string
-  |> add_type ident_float
+  (* Predefined types - alphabetical order *)
+  |> add_type1 ident_array ~variance:Variance.full ~separability:Separability.Ind
   |> add_type ident_bool ~immediate:Always
        ~kind:(Type_variant([cstr ident_false []; cstr ident_true []],
                            Variant_regular))
-  |> add_type ident_unit ~immediate:Always
-       ~kind:(Type_variant([cstr ident_void []], Variant_regular))
+  |> add_type ident_char ~immediate:Always
   |> add_type ident_exn ~kind:Type_open
-  |> add_type1 ident_array ~variance:Variance.full ~separability:Separability.Ind
+  |> add_type ident_extension_constructor
+  |> add_type ident_float
+  |> add_type ident_floatarray
+  |> add_type ident_int ~immediate:Always
+  |> add_type ident_int32
+  |> add_type ident_int64
+  |> add_type1 ident_lazy_t ~variance:Variance.covariant
+       ~separability:Separability.Ind
   |> add_type1 ident_list ~variance:Variance.covariant
        ~separability:Separability.Ind
        ~kind:(fun tvar ->
          Type_variant([cstr ident_nil []; cstr ident_cons [tvar; type_list tvar]],
                       Variant_regular))
+  |> add_type ident_nativeint
   |> add_type1 ident_option ~variance:Variance.covariant
        ~separability:Separability.Ind
        ~kind:(fun tvar ->
          Type_variant([cstr ident_none []; cstr ident_some [tvar]],
                       Variant_regular))
-  |> add_type1 ident_lazy_t ~variance:Variance.covariant
-       ~separability:Separability.Ind
-  |> add_type ident_nativeint
-  |> add_type ident_int32
-  |> add_type ident_int64
-  |> add_extension ident_undefined_recursive_module
-       [newgenty (Ttuple[type_string; type_int; type_int])]
-  (* Predefined exceptions *)
-  |> add_extension ident_undefined_recursive_module
-       [newgenty (Ttuple[type_string; type_int; type_int])]
+  |> add_type ident_string
+  |> add_type ident_unit ~immediate:Always
+       ~kind:(Type_variant([cstr ident_void []], Variant_regular))
+  (* Predefined exceptions - alphabetical order *)
   |> add_extension ident_assert_failure
        [newgenty (Ttuple[type_string; type_int; type_int])]
   |> add_extension ident_division_by_zero []
   |> add_extension ident_end_of_file []
-  |> add_extension ident_sys_error [type_string]
-  |> add_extension ident_sys_blocked_io []
-  |> add_extension ident_not_found []
   |> add_extension ident_failure [type_string]
   |> add_extension ident_invalid_argument [type_string]
-  |> add_extension ident_stack_overflow []
-  |> add_extension ident_out_of_memory []
   |> add_extension ident_match_failure
+       [newgenty (Ttuple[type_string; type_int; type_int])]
+  |> add_extension ident_not_found []
+  |> add_extension ident_out_of_memory []
+  |> add_extension ident_stack_overflow []
+  |> add_extension ident_sys_blocked_io []
+  |> add_extension ident_sys_error [type_string]
+  |> add_extension ident_undefined_recursive_module
        [newgenty (Ttuple[type_string; type_int; type_int])]
 
 let build_initial_env add_type add_exception empty_env =

--- a/typing/predef.ml
+++ b/typing/predef.ml
@@ -195,8 +195,11 @@ let common_initial_env add_type add_extension empty_env =
   in
   empty_env
   (* Predefined types - alphabetical order *)
-  |> add_type1 ident_array ~variance:Variance.full ~separability:Separability.Ind
-  |> add_type ident_bool ~immediate:Always
+  |> add_type1 ident_array
+       ~variance:Variance.full
+       ~separability:Separability.Ind
+  |> add_type ident_bool
+       ~immediate:Always
        ~kind:(Type_variant([cstr ident_false []; cstr ident_true []],
                            Variant_regular))
   |> add_type ident_char ~immediate:Always
@@ -207,21 +210,25 @@ let common_initial_env add_type add_extension empty_env =
   |> add_type ident_int ~immediate:Always
   |> add_type ident_int32
   |> add_type ident_int64
-  |> add_type1 ident_lazy_t ~variance:Variance.covariant
+  |> add_type1 ident_lazy_t
+       ~variance:Variance.covariant
        ~separability:Separability.Ind
-  |> add_type1 ident_list ~variance:Variance.covariant
+  |> add_type1 ident_list
+       ~variance:Variance.covariant
        ~separability:Separability.Ind
        ~kind:(fun tvar ->
          Type_variant([cstr ident_nil []; cstr ident_cons [tvar; type_list tvar]],
                       Variant_regular))
   |> add_type ident_nativeint
-  |> add_type1 ident_option ~variance:Variance.covariant
+  |> add_type1 ident_option
+       ~variance:Variance.covariant
        ~separability:Separability.Ind
        ~kind:(fun tvar ->
          Type_variant([cstr ident_none []; cstr ident_some [tvar]],
                       Variant_regular))
   |> add_type ident_string
-  |> add_type ident_unit ~immediate:Always
+  |> add_type ident_unit
+       ~immediate:Always
        ~kind:(Type_variant([cstr ident_void []], Variant_regular))
   (* Predefined exceptions - alphabetical order *)
   |> add_extension ident_assert_failure

--- a/typing/predef.ml
+++ b/typing/predef.ml
@@ -193,52 +193,52 @@ let common_initial_env add_type add_extension empty_env =
         ext_uid = Uid.of_predef_id id;
       }
   in
-  add_extension ident_match_failure
-                         [newgenty (Ttuple[type_string; type_int; type_int])] (
-  add_extension ident_out_of_memory [] (
-  add_extension ident_stack_overflow [] (
-  add_extension ident_invalid_argument [type_string] (
-  add_extension ident_failure [type_string] (
-  add_extension ident_not_found [] (
-  add_extension ident_sys_blocked_io [] (
-  add_extension ident_sys_error [type_string] (
-  add_extension ident_end_of_file [] (
-  add_extension ident_division_by_zero [] (
-  add_extension ident_assert_failure
-                         [newgenty (Ttuple[type_string; type_int; type_int])] (
-  add_extension ident_undefined_recursive_module
-                         [newgenty (Ttuple[type_string; type_int; type_int])] (
-  add_type ident_int64 (
-  add_type ident_int32 (
-  add_type ident_nativeint (
-  add_type1 ident_lazy_t ~variance:Variance.covariant
-    ~separability:Separability.Ind (
-  add_type1 ident_option ~variance:Variance.covariant
-    ~separability:Separability.Ind
-    ~kind:(fun tvar ->
-      Type_variant([cstr ident_none []; cstr ident_some [tvar]],
-                   Variant_regular)
-    ) (
-  add_type1 ident_list ~variance:Variance.covariant
-    ~separability:Separability.Ind
-    ~kind:(fun tvar ->
-      Type_variant([cstr ident_nil []; cstr ident_cons [tvar; type_list tvar]],
-                   Variant_regular)
-    ) (
-  add_type1 ident_array ~variance:Variance.full ~separability:Separability.Ind (
-  add_type ident_exn ~kind:Type_open (
-  add_type ident_unit ~immediate:Always
-    ~kind:(Type_variant([cstr ident_void []], Variant_regular)) (
-  add_type ident_bool ~immediate:Always
-    ~kind:(Type_variant([cstr ident_false []; cstr ident_true []],
-                        Variant_regular)) (
-  add_type ident_float (
-  add_type ident_string (
-  add_type ident_char ~immediate:Always (
-  add_type ident_int ~immediate:Always (
-  add_type ident_extension_constructor (
-  add_type ident_floatarray (
-    empty_env))))))))))))))))))))))))))))
+  empty_env
+  (* Predefined types - alphabetical order *)
+  |> add_type1 ident_array ~variance:Variance.full ~separability:Separability.Ind
+  |> add_type ident_bool ~immediate:Always
+       ~kind:(Type_variant([cstr ident_false []; cstr ident_true []],
+                           Variant_regular))
+  |> add_type ident_char ~immediate:Always
+  |> add_type ident_exn ~kind:Type_open
+  |> add_type ident_extension_constructor
+  |> add_type ident_float
+  |> add_type ident_floatarray
+  |> add_type ident_int ~immediate:Always
+  |> add_type ident_int32
+  |> add_type ident_int64
+  |> add_type1 ident_lazy_t ~variance:Variance.covariant
+       ~separability:Separability.Ind
+  |> add_type1 ident_list ~variance:Variance.covariant
+       ~separability:Separability.Ind
+       ~kind:(fun tvar ->
+         Type_variant([cstr ident_nil []; cstr ident_cons [tvar; type_list tvar]],
+                      Variant_regular))
+  |> add_type ident_nativeint
+  |> add_type1 ident_option ~variance:Variance.covariant
+       ~separability:Separability.Ind
+       ~kind:(fun tvar ->
+         Type_variant([cstr ident_none []; cstr ident_some [tvar]],
+                      Variant_regular))
+  |> add_type ident_string
+  |> add_type ident_unit ~immediate:Always
+       ~kind:(Type_variant([cstr ident_void []], Variant_regular))
+  (* Predefined exceptions - alphabetical order *)
+  |> add_extension ident_assert_failure
+       [newgenty (Ttuple[type_string; type_int; type_int])]
+  |> add_extension ident_division_by_zero []
+  |> add_extension ident_end_of_file []
+  |> add_extension ident_failure [type_string]
+  |> add_extension ident_invalid_argument [type_string]
+  |> add_extension ident_match_failure
+       [newgenty (Ttuple[type_string; type_int; type_int])]
+  |> add_extension ident_not_found []
+  |> add_extension ident_out_of_memory []
+  |> add_extension ident_stack_overflow []
+  |> add_extension ident_sys_blocked_io []
+  |> add_extension ident_sys_error [type_string]
+  |> add_extension ident_undefined_recursive_module
+       [newgenty (Ttuple[type_string; type_int; type_int])]
 
 let build_initial_env add_type add_exception empty_env =
   let common = common_initial_env add_type add_exception empty_env in

--- a/typing/predef.ml
+++ b/typing/predef.ml
@@ -193,6 +193,7 @@ let common_initial_env add_type add_extension empty_env =
         ext_uid = Uid.of_predef_id id;
       }
   in
+  let variant constrs = Type_variant (constrs, Variant_regular) in
   empty_env
   (* Predefined types - alphabetical order *)
   |> add_type1 ident_array
@@ -200,8 +201,7 @@ let common_initial_env add_type add_extension empty_env =
        ~separability:Separability.Ind
   |> add_type ident_bool
        ~immediate:Always
-       ~kind:(Type_variant([cstr ident_false []; cstr ident_true []],
-                           Variant_regular))
+       ~kind:(variant [cstr ident_false []; cstr ident_true []])
   |> add_type ident_char ~immediate:Always
   |> add_type ident_exn ~kind:Type_open
   |> add_type ident_extension_constructor
@@ -217,19 +217,17 @@ let common_initial_env add_type add_extension empty_env =
        ~variance:Variance.covariant
        ~separability:Separability.Ind
        ~kind:(fun tvar ->
-         Type_variant([cstr ident_nil []; cstr ident_cons [tvar; type_list tvar]],
-                      Variant_regular))
+         variant [cstr ident_nil []; cstr ident_cons [tvar; type_list tvar]])
   |> add_type ident_nativeint
   |> add_type1 ident_option
        ~variance:Variance.covariant
        ~separability:Separability.Ind
        ~kind:(fun tvar ->
-         Type_variant([cstr ident_none []; cstr ident_some [tvar]],
-                      Variant_regular))
+         variant [cstr ident_none []; cstr ident_some [tvar]])
   |> add_type ident_string
   |> add_type ident_unit
        ~immediate:Always
-       ~kind:(Type_variant([cstr ident_void []], Variant_regular))
+       ~kind:(variant [cstr ident_void []])
   (* Predefined exceptions - alphabetical order *)
   |> add_extension ident_assert_failure
        [newgenty (Ttuple[type_string; type_int; type_int])]


### PR DESCRIPTION
- avoid nested function calls (and its closing parens `)))))))))))))))))))))))))))`)
- sort entries alphabetically instead of the current pseudo-random order
  I don't know whether changing the order of construction requires a bootstrap or not.
- (bonus) the new layout behaves much better when using formatting tools (ocp-indent, ocamlformat)