### PR TITLE
[Documentation] Unix: Invite people to look more in depth at the definition of "standard signal number"

### DIFF
--- a/otherlibs/unix/unix.mli
+++ b/otherlibs/unix/unix.mli
@@ -192,10 +192,11 @@ type process_status =
            the argument is the return code. *)
   | WSIGNALED of int
         (** The process was killed by a signal;
-           the argument is the signal number. *)
+           the argument is the `standard signal number'.
+           See below for more information. *)
   | WSTOPPED of int
         (** The process was stopped by a signal; the argument is the
-           signal number. *)
+           `standard signal number'. See below for more information. *)
 (** The termination status of a process.  See module {!Sys} for the
     definitions of the standard signal numbers.  Note that they are
     not the numbers used by the OS. *)

--- a/otherlibs/unix/unixLabels.mli
+++ b/otherlibs/unix/unixLabels.mli
@@ -192,10 +192,11 @@ type process_status = Unix.process_status =
            the argument is the return code. *)
   | WSIGNALED of int
         (** The process was killed by a signal;
-           the argument is the signal number. *)
+           the argument is the `standard signal number'.
+           See below for more information. *)
   | WSTOPPED of int
         (** The process was stopped by a signal; the argument is the
-           signal number. *)
+           `standard signal number'. See below for more information. *)
 (** The termination status of a process.  See module {!Sys} for the
     definitions of the standard signal numbers.  Note that they are
     not the numbers used by the OS. *)


### PR DESCRIPTION
In https://github.com/ocsigen/lwt/issues/878 I made the mistake of assuming that `int` was a (unix) signal number, even after reading the API documentation.
The mistake I made was that I did not see the paragraph after the definition of `process_status`, which would have helped me understand my assumption was wrong. (I only read the individual description for each variants)
This PR is an attempt to help users who will encounter the same issue by encouraging them to look further and not assume that `"signal number" means "unix signal number" because we're in the Unix module` ^^"