### PR TITLE
manual: don't mix up library modules and language extensions

### DIFF
--- a/manual/src/macros.tex
+++ b/manual/src/macros.tex
@@ -229,8 +229,8 @@
 \fi
 \newenvironment{linklist}{\begingroup\ocamldocinputstart}{\endgroup}
 
-\newcommand{\compilerdocitem}[2]{\input{#1.tex}}
-\newcommand{\libdocitem}[2]{\input{#1.tex}}
+\newcommand{\compilerdocitem}[2]{\input{library/#1.tex}}
+\newcommand{\libdocitem}[2]{\input{library/#1.tex}}
 \ifocamldoc
 \newcommand{\stddocitem}[2]{\libdocitem{#1}{#2}}
 \else

--- a/manual/src/manual.tex
+++ b/manual/src/manual.tex
@@ -157,6 +157,7 @@
 \newcommand{\ocamlcodefragment}[1]{{\ttfamily\setlength{\parindent}{0cm}%
 \raggedright#1}}
 \newcommand{\ocamlinlinecode}[1]{{\ttfamily#1}}
+\newenvironment{ocamlarrow}{}{}
 \newenvironment{ocamlexception}{\bfseries}{}
 \newenvironment{ocamlextension}{\bfseries}{}
 \newenvironment{ocamlconstructor}{\bfseries}{}


### PR DESCRIPTION
There is a small bug in the library part of the pdf version of the manual where an `\input{Bigarray}` may pick up the extension section for `bigarray` instead of the documentation for the `Bigarray` module.

This PR fixes this issues by ensuring that we include only `tex` files from the library folder when including the documentation for the standard and compiler libraries.

The second commit is fixing a small unrelated odoc issue (which I needed to check the above change in the odoc-path too).