### PR TITLE
manual: keep white spaces in error messages

### DIFF
--- a/manual/src/html_processing/scss/manual.scss
+++ b/manual/src/html_processing/scss/manual.scss
@@ -256,8 +256,7 @@ code.caml-output.ok,div.caml-output.ok{
     color:#045804
 }
 code.caml-output.error,div.caml-output.error{
-    color:#ff4500;
-    white-space:normal
+    color:#ff4500
 }
 .chapter span,.tutorial span,.maintitle h1 span{
     color:$logocolor


### PR DESCRIPTION
The current web manual does not render all white spaces in generated error messages. This is problematic e.g. [here](https://ocaml.org/manual/objectexamples.html#s:reference-to-self) where a reference to "the first two lines" does not make sense (except when the width of the page is just right). Also, it looks unintentional, as the pages in `manual/src/htmlman` do render e.g. newlines as newlines.

I removed one line in `manual.scss`, which seems to fix this.