### PR TITLE
manual: fewer hevea-generated css classes

### DIFF
--- a/Changes
+++ b/Changes
@@ -86,6 +86,9 @@ Working version
   in case of concurrent modifications.
   (Xavier Leroy, report by whitequark, review by David Allsopp)
 
+- #10605: manual, name few css classes to ease styling and maintainability.
+  (Florian Angeletti, review by Wiktor Kuchta and Gabriel Scherer)
+
 ### Compiler user-interface and warnings:
 
 - #10328: Give more precise error when disambiguation could not possibly work.

--- a/manual/src/html_processing/scss/manual.scss
+++ b/manual/src/html_processing/scss/manual.scss
@@ -316,7 +316,7 @@ span.syntax-token {
 span.ocamlprompt{
     color:#888
 }
-span.font-bold.machine{
+span.font-bold .machine{
     font-weight:700;
     color:#564233;
 }

--- a/manual/src/html_processing/scss/manual.scss
+++ b/manual/src/html_processing/scss/manual.scss
@@ -48,7 +48,7 @@
 	    span {
 		color:#c88b5f;
 	    }
-	    span.c003{
+	    span.syntax-token{
 		color:#564233;
 	    }
 	}
@@ -294,7 +294,7 @@ blockquote.quote{
 	border-spacing: 6px;
 	border-collapse: separate;
 }
-span.c003{
+span.syntax-token{
     color:#564233;
     font-family: $font-mono;
     border-radius:6px
@@ -307,10 +307,10 @@ div.caml-example.toplevel div.caml-input::before{
 span.number{
     padding-right: 1ex;
 }
-span.c004, span.c005, span.c007 {
+span.c004, span.syntax-token, span.c007 {
 	font-family: $font-mono;
 }
-span.c003, span.c005 {
+span.syntax-token {
 	color: rgba(91, 33, 6, 0.87);
 }
 span.c002{
@@ -331,7 +331,7 @@ span.authors{
     font-style:italic;
     background-color:inherit
 }
-span.c011 {
+span.nonterminal {
 	font-style: italic;
 }
 .c012 {

--- a/manual/src/html_processing/scss/manual.scss
+++ b/manual/src/html_processing/scss/manual.scss
@@ -323,7 +323,7 @@ span.font-bold.machine{
 .osvariant {
 	font-family: $font-sans;
 }
-span.font-it {
+.font-it {
 	font-style: italic;
 }
 span.authors{
@@ -331,13 +331,10 @@ span.authors{
     background-color:inherit
 }
 span.nonterminal {
-	font-style: italic;
+	font-style: oblique;
 }
 .font-sl {
 	font-style: oblique;
-}
-span.sl{
-    font-style: oblique;
 }
 .center table {
 	margin-left: inherit;
@@ -346,7 +343,7 @@ span.sl{
 td .font-bold {
 	font-weight: bold;
 }
-.syntax-token {
+.c003 {
 	text-align: center;
 }
 .cellpadding1 tr td {

--- a/manual/src/html_processing/scss/manual.scss
+++ b/manual/src/html_processing/scss/manual.scss
@@ -307,7 +307,7 @@ div.caml-example.toplevel div.caml-input::before{
 span.number{
     padding-right: 1ex;
 }
-span.machine, span.syntax-token {
+span.syntax-token {
 	font-family: $font-mono;
 }
 span.syntax-token {
@@ -325,6 +325,9 @@ span.font-bold.machine{
 }
 .font-it {
 	font-style: italic;
+}
+.font-tt {
+	font-family: $font-mono;
 }
 span.authors{
     font-style:italic;

--- a/manual/src/html_processing/scss/manual.scss
+++ b/manual/src/html_processing/scss/manual.scss
@@ -307,24 +307,23 @@ div.caml-example.toplevel div.caml-input::before{
 span.number{
     padding-right: 1ex;
 }
-span.c004, span.syntax-token, span.c007 {
+span.machine, span.syntax-token {
 	font-family: $font-mono;
 }
 span.syntax-token {
 	color: rgba(91, 33, 6, 0.87);
 }
-span.c002{
+span.ocamlprompt{
     color:#888
 }
-span.c006{
+span.font-bold.machine{
     font-weight:700;
     color:#564233;
-    font-family: $font-mono;
 }
-.c008 {
+.osvariant {
 	font-family: $font-sans;
 }
-span.c010 {
+span.font-it {
 	font-style: italic;
 }
 span.authors{
@@ -334,20 +333,20 @@ span.authors{
 span.nonterminal {
 	font-style: italic;
 }
-.c012 {
-	font-style: italic;
+.font-sl {
+	font-style: oblique;
 }
-span.c013{
-    font-style: italic;
+span.sl{
+    font-style: oblique;
 }
 .center table {
 	margin-left: inherit;
 	margin-right: inherit;
 }
-td .c014 {
+td .font-bold {
 	font-weight: bold;
 }
-.c016 {
+.syntax-token {
 	text-align: center;
 }
 .cellpadding1 tr td {

--- a/manual/src/html_processing/src/process_manual.ml
+++ b/manual/src/html_processing/src/process_manual.ml
@@ -42,7 +42,7 @@ let preg_anyspace =
 let preg_emspace = "\\(\u{2003}\\| \\)"
 (* What hevea inserts between "Chapter" and the chapter number: *)
 let preg_chapter_space = "\\(\u{2004}\u{200d}\\|" ^ preg_anyspace ^ "\\)"
-let writtenby_css = "span.c010" (* "span.c009" for hevea 2.32 *)
+let writtenby_css = "span.font-it" (* "span.c009" for hevea 2.32 *)
 
 (* Remove number: "Chapter 1  The core language" ==> "The core language" *)
 let remove_number s =

--- a/manual/src/macros.hva
+++ b/manual/src/macros.hva
@@ -160,8 +160,7 @@
 %%% Code examples
 \newcommand{\input@color}{\htmlcolor{006000}}
 \newcommand{\output@color}{\maroon}
-\newcommand{\machine}{\@span{class=machine}}
-\newstyle{.machine}{font-family:monospace}
+\newcommand{\machine}{\@span{class=machine}\tt}
 \newenvironment{machineenv}{\begin{alltt}}{\end{alltt}}
 \newcommand{\var}[1]{\textit{#1}}
 

--- a/manual/src/macros.hva
+++ b/manual/src/macros.hva
@@ -160,7 +160,8 @@
 %%% Code examples
 \newcommand{\input@color}{\htmlcolor{006000}}
 \newcommand{\output@color}{\maroon}
-\newcommand{\machine}{\tt}
+\newcommand{\machine}{\@span{class=machine}}
+\newstyle{.machine}{font-family:monospace}
 \newenvironment{machineenv}{\begin{alltt}}{\end{alltt}}
 \newcommand{\var}[1]{\textit{#1}}
 
@@ -180,6 +181,8 @@
 \newcommand{\ocamlcomment}{\@span{class="ocamlcomment"}}
 \newcommand{\ocamlstring}{\@span{class="ocamlstring"}}
 
+\newcommand{\?}{\@span{class=ocamlprompt}\#}
+\newstyle{.ocamlprompt}{color:black;}
 
 %%% End of code example
 
@@ -191,8 +194,9 @@
 
 
 %%venant de macros.tex
-
-\def\versionspecific#1{\begin{quote}\textsf{#1:}\quad}
+\newcommand{\osvariant}{\@span{class=osvariant}}
+\newstyle{.osvariant}{font-family:sans-serif}
+\def\versionspecific#1{\begin{quote}{\osvariant{}#1:}\quad}
 \def\unix{\versionspecific{Unix}}
 \def\endunix{\end{quote}}
 \def\windows{\versionspecific{Windows}}
@@ -252,7 +256,8 @@
 \def\ikwd#1{\indexentry{\jobname.kwd}{#1}}
 % nth
 
-\def\th{^{\mbox{\scriptsize th}}}
+\def\th{^{\mbox{\@span{class=th}th}}}
+\newstyle{.th}{font-size:small;}
 \renewcommand{\hbox}[1]{\mbox{#1}}
 
 % Notations pour les metavariables
@@ -302,3 +307,13 @@
 \else
 \newcommand{\stddocitem}[2]{\docitem{libref/Stdlib}{#1}{#2}}
 \fi
+
+\renewcommand{\tt}{\@span{class=font-tt}}
+\newstyle{.font-tt}{font-family:monospace;}
+\renewcommand{\it}{\@span{class=font-it}}
+\newstyle{.font-it}{font-style:italic;}
+\renewcommand{\bf}{\@span{class=font-bold}}
+\newstyle{.font-bold}{font-weight:bold;}
+\renewcommand{\sl}{\ifmath\ifmathml\@span{class='sl-math'}%
+\else\@span{class="font-sl"}\fi\else\@span{class="font-sl"}\fi}
+\newstyle{.font-sl}{font-style:oblique;}

--- a/manual/src/macros.tex
+++ b/manual/src/macros.tex
@@ -247,6 +247,7 @@
 \newcommand{\ocamlhighlight}{\bfseries\uline}
 \newcommand{\ocamlerror}{\bfseries}
 \newcommand{\ocamlwarning}{\bfseries}
+\newcommand{\?}{\color{black}\normalsize\tt\#{}}
 
 \definecolor{gray}{gray}{0.5}
 \newcommand{\ocamlcomment}{\color{gray}\normalfont\small}

--- a/manual/src/manual.tex
+++ b/manual/src/manual.tex
@@ -127,7 +127,6 @@
 \fi
 }{}
 
-\newcommand{\?}{\color{black}\normalsize\tt\#{}}
 
 \ifocamldoc\else
 \lstnewenvironment{ocamlcodeblock}{
@@ -187,7 +186,6 @@
 \usepackage[strings,nohyphen]{underscore}
 
 %\makeatletter \def\@wrindex#1#2{\xdef \@indexfile{\csname #1@idxfile\endcsname}\@@wrindex#2||\\}\makeatother
-\def\th{^{\hbox{\scriptsize th}}}
 
 
 \raggedbottom

--- a/manual/styles/syntaxdef.hva
+++ b/manual/styles/syntaxdef.hva
@@ -27,7 +27,8 @@
 \newif\ifspace
 \def\addspace{\ifspace\;\spacefalse\fi}
 \ifhtml
-\newcommand{\token}[1]{\texttt{\blue#1}}
+\newcommand{\token}[1]{{\@span{class=syntax-token}#1}}
+\newstyle{.syntax-token}{color:blue;font-family:monospace}
 \else
 \newcommand{\token}[1]{\texttt{#1}}
 \fi
@@ -133,7 +134,8 @@
 \def\@anchor{}
 \fi
 %%%Format non-terminal
-\def\nt#1{\textit{\maroon#1}}
+\def\nt#1{{\@span{class=nonterminal}#1}}
+\newstyle{.nonterminal}{color:maroon;font-style:italic}
 %%%Link for non-terminal and format
 \def\nonterm#1{\addspace\nt{\@anchor{#1}}\spacetrue}
 \def\brepet{\addspace\{}

--- a/manual/styles/syntaxdef.hva
+++ b/manual/styles/syntaxdef.hva
@@ -27,7 +27,7 @@
 \newif\ifspace
 \def\addspace{\ifspace\;\spacefalse\fi}
 \ifhtml
-\newcommand{\token}[1]{{\@span{class=syntax-token}#1}}
+\newcommand{\token}[1]{\textnormal{\@span{class=syntax-token}#1}}
 \newstyle{.syntax-token}{color:blue;font-family:monospace}
 \else
 \newcommand{\token}[1]{\texttt{#1}}
@@ -134,7 +134,7 @@
 \def\@anchor{}
 \fi
 %%%Format non-terminal
-\def\nt#1{{\@span{class=nonterminal}#1}}
+\def\nt#1{\textnormal{\@span{class=nonterminal}#1}}
 \newstyle{.nonterminal}{color:maroon;font-style:oblique}
 %%%Link for non-terminal and format
 \def\nonterm#1{\addspace\nt{\@anchor{#1}}\spacetrue}

--- a/manual/styles/syntaxdef.hva
+++ b/manual/styles/syntaxdef.hva
@@ -135,7 +135,7 @@
 \fi
 %%%Format non-terminal
 \def\nt#1{{\@span{class=nonterminal}#1}}
-\newstyle{.nonterminal}{color:maroon;font-style:italic}
+\newstyle{.nonterminal}{color:maroon;font-style:oblique}
 %%%Link for non-terminal and format
 \def\nonterm#1{\addspace\nt{\@anchor{#1}}\spacetrue}
 \def\brepet{\addspace\{}


### PR DESCRIPTION
When generating the html manual, `hevea` translates on the fly set of style attributes into `c%03i` css classes. Those generated css classes are quite unpractical when editing the manual style sheet because their names is both brittle (`c008` might become `c009` without warning) and sibylline (what is the semantic of `c009` class?) as can be seen in #10589.

This PR proposes to avoid this issue by making sure that the manual latex macros are always mapped to explicit css classes and rather than style attributes. For instance, rather than using `\tt` directly for inline code, this PR creates a span with class `machine` (to reflect the current name of the macro).

This discipline removes half of the hevea-generated css classes in the html version of the manual. The names of the new css classes are probably not ideal but it should be easier to rename them later, without the implicit inter-dependency between all `c%03i` classes.

The remaining hevea-generated css classes are used by hevea to style table cells. Those classes can only be removed by patching hevea. However, they are slightly less cumbersome, and it seems to ignore them for now.

For fun and, here is the conversion list between css classes before and after this PR:

Before|  After               |   Original css style                                                          |
------|----------------------|-------------------------------------------------------------------------------|
.c000 |  .c000               |  {border-spacing:0;width:80%}                                                 |
.c001 |  .c001               |  {border-spacing:6px;border-collapse:separate;}                               |
.c002 |  .ocamlprompt        |  {color:black}                                                                |
.c003 |  .syntax-token       |  {color:blue}                                                                 |
.c004 |  .machine            |  {font-family:monospace}                                                      |
.c005 |  .syntax-token       |  {font-family:monospace;color:blue}                                           |
.c006 |  .font-tt .font-it   |  {font-family:monospace;font-style:italic}                                    |
.c007 |  .font-bold .machine |  {font-family:monospace;font-weight:bold}                                     |
.c008 |  .osvariant          |  {font-family:sans-serif}                                                     |
.c009 |  .th                 |  {font-size:small}                                                            |
.c010 |  .font-it            |  {font-style:italic}                                                          |
.c011 |  .nonterminal        |  {font-style:italic;color:maroon}                                             |
.c012 |  .font-it -font-bold |  {font-style:italic;font-weight:bold}                                         |
.c013 |  .font-sl            |  {font-style:oblique}                                                         |
.c014 |  .font-bold          |  {font-weight:bold}                                                           |
.c015 |  .c002               |  {text-align:center;border:solid 1px;white-space:nowrap}                      |
.c016 |  .c003               |  {text-align:center;white-space:nowrap}                                       |
.c017 |  .c004               |  {text-align:left;border:solid 1px;white-space:nowrap}                        |
.c018 |  .c005               |  {text-align:left;white-space:nowrap}                                         |
.c019 |  .c006               |  {text-align:right;white-space:nowrap}                                        |
.c020 |  .c007               |  {vertical-align:middle}                                                      |
.c021 |  .c008               |  {vertical-align:top;text-align:left;}                                        |
.c022 |  .c009               |  {vertical-align:top;text-align:left;border:solid 1px;}                       |
.c023 |  .c010               |  {vertical-align:top;text-align:left;border:solid 1px;white-space:nowrap}     |
.c024 |  .c011               |  {vertical-align:top;text-align:left;white-space:nowrap}                      |
.c025 |  .c012               |  {vertical-align:top;text-align:right;white-space:nowrap}                     |
