### PR TITLE
Deobfuscate ignored-partial-application and non-unit-statement check

### DIFF
--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -2517,6 +2517,26 @@ let generalize_and_check_univars env kind exp ty_expected vars =
   List.iter generalize vars;
   check_univars env kind exp ty_expected vars
 
+(* [check_partial_application] implements both the [non-unit-statemnt] and the
+   [ignored-partial-application] warnings.
+
+   [non-unit-statemnt] verifies that [exp] has type [unit]. It is applied in
+   contexts where their value of [exp] is known to be discarded (eg the lhs of a
+   sequence).
+
+   [ignored-partial-application] verifies that if [exp] has a function type then
+   it is not syntactically the result of a function application. It is applied
+   in contexts where this is often a bug (eg the rhs of a let-binding or in the
+   argument of [ignore]). This check can be disabled by explicitly annotating
+   the expression with a type constraint, eg [(e : _ -> _)].
+
+   If [statement] is [true] and [ignored-partial-application] is {em not}
+   triggered, then the [non-unit-statement] check is performaed. If [statement]
+   is [false], only the [ignored-partial-application] check is performed.
+
+   If the type of [exp] is not known when the function is called, then the check
+   is retried after typechecking. *)
+
 let check_partial_application statement exp =
   let rec f delay =
     let ty = get_desc (expand_head exp.exp_env exp.exp_type) in

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -2519,8 +2519,10 @@ let generalize_and_check_univars env kind exp ty_expected vars =
 
 (* [check_statement] implements the [non-unit-statement] check.
 
-   It is checked that [exp] has type [unit]. This check is applied in contexts
-   where their value is known to be discarded (eg the lhs of a sequence). *)
+   This check is called in contexts where the value of the expression is known
+   to be discarded (eg. the lhs of a sequence). We check that [exp] has type
+   unit, or has an explicit type annotation; otherwise we raise the
+   [non-unit-statement] warning. *)
 
 let check_statement exp =
   let ty = get_desc (expand_head exp.exp_env exp.exp_type) in
@@ -2554,9 +2556,12 @@ let check_statement exp =
 
    If [exp] has a function type, we check that it is not syntactically the
    result of a function application, as this is often a bug in certain contexts
-   (eg the rhs of a let-binding or in the argument of [ignore]). The check can
-   be disabled by explicitly annotating the expression with a type constraint,
-   eg [(e : _ -> _)].
+   (eg the rhs of a let-binding or in the argument of [ignore]). For example,
+   [ignore (List.map print_int)] written by mistake instad of [ignore (List.map
+   print_int li)].
+
+   The check can be disabled by explicitly annotating the expression with a type
+   constraint, eg [(e : _ -> _)].
 
    If [statement] is [true] and the [ignored-partial-application] is {em not}
    triggered, then the [non-unit-statement] check is performaed (see

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -2566,8 +2566,8 @@ let check_partial_application statement exp =
             in
             loop exp
     in
-    match ty, exp.exp_desc with
-    | Tarrow _, _ ->
+    match ty with
+    | Tarrow _ ->
         let rec check {exp_desc; exp_loc; exp_extra; _} =
           if List.exists (function
               | (Texp_constraint _, _, _) -> true
@@ -2598,7 +2598,7 @@ let check_partial_application statement exp =
           end
         in
         check exp
-    | Tvar _, _ ->
+    | Tvar _ ->
         if delay then add_delayed_check (fun () -> f false)
     | _ ->
         check_statement ()

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -2565,7 +2565,7 @@ let check_statement exp =
    If the type of [exp] is not known at the time this function is called, the
    check is retried again after typechecking. *)
 
-let check_partial_application statement exp =
+let check_partial_application ~statement exp =
   let check_statement () = if statement then check_statement exp in
   let doit () =
     let ty = get_desc (expand_head exp.exp_env exp.exp_type) in
@@ -3030,7 +3030,7 @@ and type_expect_
         try rue exp
         with Error (_, _, Expr_type_clash _) as err ->
           Misc.reraise_preserving_backtrace err (fun () ->
-            check_partial_application false exp)
+            check_partial_application ~statement:false exp)
       end
   | Pexp_match(sarg, caselist) ->
       begin_def ();
@@ -4673,7 +4673,7 @@ and type_application env funct sargs =
     [Nolabel, sarg] when is_ignore funct ->
       let ty_arg, ty_res = filter_arrow env (instance funct.exp_type) Nolabel in
       let exp = type_expect env sarg (mk_expected ty_arg) in
-      check_partial_application false exp;
+      check_partial_application ~statement:false exp;
       ([Nolabel, Some exp], ty_res)
   | _ ->
     let ty = funct.exp_type in
@@ -4781,7 +4781,7 @@ and type_statement ?explanation env sexp =
       unify_exp env exp expected_ty);
     exp
   else begin
-    check_partial_application true exp;
+    check_partial_application ~statement:true exp;
     unify_var env tv ty;
     exp
   end
@@ -5315,7 +5315,7 @@ and type_let
       | {vb_pat = {pat_desc = Tpat_any; pat_extra; _}; vb_expr; _} ->
           if not (List.exists (function (Tpat_constraint _, _, _) -> true
                                       | _ -> false) pat_extra) then
-            check_partial_application false vb_expr
+            check_partial_application ~statement:false vb_expr
       | _ -> ()) l;
   (l, new_env, unpacks)
 


### PR DESCRIPTION
This PR follows a [comment](https://github.com/ocaml/ocaml/issues/10604#issue-987777462) of @gasche 

> I don't know precisely how the `ignore` warning behaves (is it documented somewhere?), and I find the implementation of [Typecore.check_partial_application](https://github.com/ocaml/ocaml/blob/trunk/typing/typecore.ml#L2520) obscure (some documentation would help).

Initially I just tried to document the existing code (first commit) but found the code rather hard to decipher and so I tried to simplify it. This PR is the result (it can be reviewed commit-by-commit).