### PR TITLE
riscv: do not attempt CSE of int constants

### DIFF
--- a/Changes
+++ b/Changes
@@ -22,6 +22,10 @@ Working version
   parameter passing on PowerPC (16 registers) and on s390x (8 registers).
   (Xavier Leroy, review by Mark Shinwell)
 
+- #10608: Fix a bug in the RISC-V native-code backend that could result in
+  long compilation times under certain circumstances.
+  (Nicolás Ojeda Bär, report by Edwin Török, review by Xavier Leroy)
+
 ### Standard library:
 
 * #7812, #10475: `Filename.chop_suffix name suff` now checks that `suff`

--- a/asmcomp/riscv/CSE.ml
+++ b/asmcomp/riscv/CSE.ml
@@ -28,11 +28,6 @@ method! class_of_operation op =
   | Ispecific(Imultaddf _ | Imultsubf _) -> Op_pure
   | _ -> super#class_of_operation op
 
-method! is_cheap_operation op =
-  match op with
-  | Iconst_int n -> n <= 0x7FFn && n >= -0x800n
-  | _ -> false
-
 end
 
 let fundecl f =


### PR DESCRIPTION
This PR fixes a performance bug in the RISC-V code generator which can cause long compilation times under certain circumstances. As reported in #10591 this situation is triggered when compiling `driver/main_args.ml`.

Typically CSE is not attempted for integer constants, but the bit of code removed in this PR was actually directing the CSE pass to apply to integer constants outside the range in which they can be used as immediate operands. The lifetime intervals of temporaries holding such constants were then, in some cases, made significantly longer which taxed the register allocator.
