### PR TITLE
Fix marking of if condition as inconstant in flambda Fix #10603

### DIFF
--- a/Changes
+++ b/Changes
@@ -156,6 +156,9 @@ Working version
 - #10590: Some typechecker optimisations
   (Stephen Dolan, review by Gabriel Scherer and Leo White)
 
+- #10603, #10611: Fix if condition marked as inconstant in flambda
+  (Vincent Laviron and Pierre Chambart, report by Marcello Seri)
+
 OCaml 4.13.0
 -------------
 

--- a/middle_end/flambda/inconstant_idents.ml
+++ b/middle_end/flambda/inconstant_idents.ml
@@ -269,9 +269,9 @@ module Inconstants (P:Param) (Backend:Backend_intf.S) = struct
       mark_curr curr;
       mark_loop ~toplevel [] f1;
       mark_loop ~toplevel:false [] body
-    | If_then_else (f1,f2,f3) ->
+    | If_then_else (cond,f2,f3) ->
       mark_curr curr;
-      mark_curr [Var f1];
+      mark_var cond curr;
       mark_loop ~toplevel [] f2;
       mark_loop ~toplevel [] f3
     | Static_raise (_,l) ->

--- a/testsuite/tests/regression/pr10611/pr10611.ml
+++ b/testsuite/tests/regression/pr10611/pr10611.ml
@@ -1,0 +1,12 @@
+(* TEST *)
+
+type t = A | B of (int -> int)
+
+let p = 1 + 1
+
+let rec b = B g
+and g n =
+  let b' = b in
+  match b' with
+  | A -> n + p
+  | B f -> f n


### PR DESCRIPTION
This is a fix for https://github.com/ocaml/ocaml/issues/10603.

The problem was that the `Inconstant_ident` pass of flambda marks the variable used as the condition for an if as systematically inconstant, which is obviously wrong. But this is often not really a noticeable. Normally, when a if condition is a constant, the if is removed by `Simplify`. But this is not the case in let rec's where the information about the variable being bound is not available while analysing the body of the definition. The reason why this could lead to the issue is 'amusing'.

The problematic example can be reduced to:

```OCaml
type t = A | B of (int -> int)

let p = 1 + 1

let rec b = B g
and g n =
  let b' = b in
  match b' with
  | A -> n + p
  | B f -> f n
```

The `Inconstant_ident` pass has no restriction on let rec's and can correctly mark `b` and `g` as constants. But the bug made `b'` inconstant. Indeed, a match to such a type is compiled to an if. So `Lift_constants` turn both `b` and `g` into `let_rec_symbol`. For that `g` has to be close, which should be the case since `Inconstant_ident` has taken every free variables into account. But `b'` being inconstant breaks that. And we end up lifting `g`, but keeping a free variable, which is obviously wrong.

The example is more complex than this explanation suggest because the stars have to align correctly for this to trigger. In fact with an example looking like that, it would work. `b'` is inconstant, but the inner version of `b` inside the closure is not. This would allow to substitute this version of b to the new symbol. And everything would work. The bug requires that every intermediate alias has been eliminated, which is one thing that simplify does. So `Simplify` has to run before `Lift_constants`. But this is not the case in the default optimisation pipeline. So we add that `p` variable to prevent both `b` and `g` from being constant before any simplification.
