### PR TITLE
Limit CSE of integer constants

### DIFF
--- a/Changes
+++ b/Changes
@@ -22,6 +22,11 @@ Working version
   parameter passing on PowerPC (16 registers) and on s390x (8 registers).
   (Xavier Leroy, review by Mark Shinwell)
 
+- #10591, #10615: Tune the heuristic for CSE of integer constants
+  so as to avoid excessive CSE on compiler-generated constants
+  and long register allocation times.
+  (Xavier Leroy, report by Edwin Török, review by Nicolás Ojeda Bär)
+
 ### Standard library:
 
 * #7812, #10475: `Filename.chop_suffix name suff` now checks that `suff`

--- a/asmcomp/arm/CSE.ml
+++ b/asmcomp/arm/CSE.ml
@@ -29,11 +29,6 @@ method! class_of_operation op =
   | Ispecific _ -> Op_pure
   | _ -> super#class_of_operation op
 
-method! is_cheap_operation op =
-  match op with
-  | Iconst_int n -> n <= 255n && n >= 0n
-  | _ -> false
-
 end
 
 let fundecl f =

--- a/asmcomp/arm64/CSE.ml
+++ b/asmcomp/arm64/CSE.ml
@@ -31,7 +31,7 @@ method! class_of_operation op =
 
 method! is_cheap_operation op =
   match op with
-  | Iconst_int n -> n <= 65535n && n >= 0n
+  | Iconst_int n -> n <= 0x7FFF_FFFFn && n >= -0x8000_0000n
   | _ -> false
 
 end

--- a/asmcomp/power/CSE.ml
+++ b/asmcomp/power/CSE.ml
@@ -31,7 +31,7 @@ method! class_of_operation op =
 
 method! is_cheap_operation op =
   match op with
-  | Iconst_int n -> n <= 32767n && n >= -32768n
+  | Iconst_int n -> n <= 0x7FFF_FFFFn && n >= -0x8000_0000n
   | _ -> false
 
 end

--- a/asmcomp/riscv/CSE.ml
+++ b/asmcomp/riscv/CSE.ml
@@ -30,7 +30,7 @@ method! class_of_operation op =
 
 method! is_cheap_operation op =
   match op with
-  | Iconst_int n -> n <= 0x7FFn && n >= -0x800n
+  | Iconst_int n -> n <= 0x7FFF_FFFFn && n >= -0x8000_0000n
   | _ -> false
 
 end


### PR DESCRIPTION
When a given integer constant is used several times in an extended basic block, the CSE (Common Subexpression Elimination) pass tends to put the constant in a register and use the register multiple times, instead of loading the constant in a register at every use.  There's nothing special about constants here: it's just the way CSE works in general.

If there are enough registers, CSE of constants is fine.  Otherwise, the constant end up stored in a stack location, which could be more costly than just recomputing the constant at every use.  In extreme cases, for very big extended basic blocks, CSE of constants can create many long-lived temporaries and an explosion in register allocation time, see #10591 for an example in the wild.

To mitigate this problem, sophisticated register allocators implement rematerialization: if no register is available to cache the constant, the allocator undoes the effect of CSE and reloads the constant at every use.

OCaml's register allocator is not that sophisticated.  Instead, CSE chooses to not factor out multiple occurrences of a constant if it is "cheap enough" to load the constant in a register at every use.

The notion of "cheap enough" used until now is "a single machine instruction suffices to load the constant in a register".  (See below for what this means on the various architectures supported by ocamlopt.)  Large constants may require multiple instructions to be loaded, and then OCaml's CSE consider that factoring the constant is worthwhile.

This heuristic is bad, at least on ARM and RISC-V.  ocamlopt generates a lot of integer constants in the range 0x400 - 0x4000 corresponding to headers for newly-allocated blocks.  On ARM (v6), everything above 0x100 is considered expensive; on RISC-V, everything above 0x800.  As #10591 illustrates, ocamlopt applies CSE to these constants, resulting in many long-lived temporaries and high register allocation times.

To find a better heuristic, let's look at integer constant generation on our target architectures:

| Archi         |  Range for 1 instr  |  Max instrs for 32-bit csts | Max instrs for 64-bit csts|
|---------------|---------------------|-----------------------------|---------------------------|
| ARMv6 32 bits |  -0x100..0xFF       |  4                          | n/a                       |
| ARMv7 32 bits |  -0x100..0xFFFF     |  2                          | n/a                       |
| ARMv8 64 bits |  -0x10000..0xFFFF    |  2                          | 4                         |
| AMD64         |  all 64 bits        |  1                          | 1                         |
| I386          |  all 32 bits        |  1                          | n/a                         |
| POWER         |  -0x8000..0x7FFF    |  2                          | 2 (incl. a load)          |
| RISC-V        |  -0x800..0x7FF      |  2                          | 8 (with gas's strategy)   |
| S390X         |  all 32 bits        |  1                          | 1 (a load)                |

Excluding ARMv6, which is dead, all platforms can load a constant in the 32-bit signed range (-2^31 to 2^31 - 1) with at most two instructions and no memory accesses.  This is cheap enough!  Let's not do CSE for these constants.  

Larger constants (which can only occur in 64-bit platforms) take more work to load on 64-bit platforms other than AMD64.  I think it's still worthwhile to apply CSE to these big constants.  They are (usually) not generated by ocamlopt and occur only if present in the source code.  The risk of a long-lived temporary resulting from CSE should therefore be quite low.

This PR implements the considerations above: CSE will not factor out integer constants, unless they don't fit in 32 signed bits and we are on a 64-bit platform other than AMD64.

Closes: #10591
Closes: #10608
