### PR TITLE
Fix regression introduced by #9960

### DIFF
--- a/Changes
+++ b/Changes
@@ -486,9 +486,10 @@ OCaml 4.13.0
 - #9407: added warning for missing mli interface file
   (Anukriti Kumar, review by Florian Angeletti)
 
-- #9960: extend ocamlc/ocamlopt's -o option to work when compiling C files
-  (Sébastien Hinderer, reported by Daniel Bünzli, review by Florian
-  Angeletti and Gabriel Scherer)
+- #9960, #10619: extend ocamlc/ocamlopt's -o option to work when
+  compiling C files
+  (Sébastien Hinderer, reported by Daniel Bünzli, review by
+  Florian Angeletti and Gabriel Scherer)
 
 - #10095: simplify the syntax error messages produced by the compiler.
   In many cases, the compiler would produce an error message that looked

--- a/driver/compenv.ml
+++ b/driver/compenv.ml
@@ -645,7 +645,7 @@ let process_action
         | None -> c_object_of_filename name
         | Some n -> n
       in
-      if Ccomp.compile_file ~output:obj_name name <> 0
+      if Ccomp.compile_file ?output:!output_name name <> 0
       then raise (Exit_with_status 2);
       ccobjs := obj_name :: !ccobjs
   | ProcessObjects names ->


### PR DESCRIPTION
This commit restores the compiler's behaviour when called on a C file
and with no "-o" otption.