### PR TITLE
Simplify shared library support in `configure`

### DIFF
--- a/configure
+++ b/configure
@@ -2800,7 +2800,6 @@ ocamlc_cflags=""
 ocamlc_cppflags=""
 oc_ldflags=""
 oc_dll_ldflags=""
-with_sharedlibs=true
 ostype="Unix"
 SO="so"
 toolchain="cc"
@@ -12846,13 +12845,15 @@ esac
 #    [enable_shared=yes])
 
 if test x"$enable_shared" = "xno"; then :
-  with_sharedlibs=false
+  supports_shared_libraries=false
   case $host in #(
   *-pc-windows|*-w64-mingw32) :
     as_fn_error $? "Cannot build native Win32 with --disable-shared" "$LINENO" 5 ;; #(
   *) :
      ;;
 esac
+else
+  supports_shared_libraries=true
 fi
 
 # Define flexlink chain and flags correctly for the different Windows ports
@@ -12881,7 +12882,7 @@ case $host in #(
      ;;
 esac
 
-if test x"$enable_shared" != 'xno'; then :
+if test x"$supports_shared_libraries" != 'xfalse'; then :
 
   { $as_echo "$as_me:${as_lineno-$LINENO}: checking for flexdll sources" >&5
 $as_echo_n "checking for flexdll sources... " >&6; }
@@ -13162,8 +13163,8 @@ fi
 if test x"$have_flexdll_h" = 'xno'; then :
   case $host in #(
   *-*-cygwin*) :
-    if $with_sharedlibs; then :
-  with_sharedlibs=false
+    if $supports_shared_libraries; then :
+  supports_shared_libraries=false
         { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: flexdll.h not found: shared library support disabled." >&5
 $as_echo "$as_me: WARNING: flexdll.h not found: shared library support disabled." >&2;}
 
@@ -13178,9 +13179,9 @@ fi
 if test -z "$flexdir" -o x"$have_flexdll_h" = 'xno'; then :
   case $host in #(
   *-*-cygwin*) :
-    if $with_sharedlibs; then :
+    if $supports_shared_libraries; then :
   if test -z "$flexlink"; then :
-  with_sharedlibs=false
+  supports_shared_libraries=false
           { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: flexlink/flexdll.h not found: shared library support disabled." >&5
 $as_echo "$as_me: WARNING: flexlink/flexdll.h not found: shared library support disabled." >&2;}
 
@@ -13204,7 +13205,7 @@ case $CC,$host in #(
     mathlib="" ;; #(
   *,*-*-cygwin*) :
     common_cppflags="$common_cppflags -U_WIN32"
-    if $with_sharedlibs; then :
+    if $supports_shared_libraries; then :
   mkexe='$(FLEXLINK) -exe $(if $(OC_LDFLAGS),-link "$(OC_LDFLAGS)")'
       mkexedebugflag="-link -g"
 else
@@ -14021,7 +14022,6 @@ fi
 
 # Shared library support
 
-shared_libraries_supported=false
 sharedlib_cflags=''
 mksharedlib='shared-libs-not-available'
 rpath=''
@@ -14034,7 +14034,7 @@ if test x"$enable_shared" != "xno"; then :
     mksharedlib="$CC -shared \
                    -flat_namespace -undefined suppress -Wl,-no_compact_unwind \
                    \$(LDFLAGS)"
-      shared_libraries_supported=true ;; #(
+      supports_shared_libraries=true ;; #(
   *-*-mingw32) :
     mksharedlib='$(FLEXLINK)'
       mkmaindll='$(FLEXLINK) -maindll'
@@ -14042,21 +14042,18 @@ if test x"$enable_shared" != "xno"; then :
 
         mksharedlib="$mksharedlib -link \"$oc_dll_ldflags\""
         mkmaindll="$mkmaindll -link \"$oc_dll_ldflags\""
-fi
-      shared_libraries_supported=$with_sharedlibs ;; #(
+fi ;; #(
   *-pc-windows) :
     mksharedlib='$(FLEXLINK)'
-      mkmaindll='$(FLEXLINK) -maindll'
-      shared_libraries_supported=$with_sharedlibs ;; #(
+      mkmaindll='$(FLEXLINK) -maindll' ;; #(
   *-*-cygwin*) :
     mksharedlib='$(FLEXLINK)'
-      mkmaindll='$(FLEXLINK) -maindll'
-      shared_libraries_supported=$with_sharedlibs ;; #(
+      mkmaindll='$(FLEXLINK) -maindll' ;; #(
   powerpc-ibm-aix*) :
     case $ocaml_cv_cc_vendor in #(
   xlc*) :
     mksharedlib="$CC -qmkshrobj -G \$(LDFLAGS)"
-                shared_libraries_supported=true ;; #(
+                supports_shared_libraries=true ;; #(
   *) :
      ;;
 esac ;; #(
@@ -14065,7 +14062,7 @@ esac ;; #(
       mksharedlib="$CC -shared"
       rpath="-Wl,-rpath,"
       mksharedlibrpath="-Wl,-rpath,"
-      shared_libraries_supported=true ;; #(
+      supports_shared_libraries=true ;; #(
   *-*-linux*|*-*-freebsd[3-9]*|*-*-freebsd[1-9][0-9]*\
     |*-*-openbsd*|*-*-netbsd*|*-*-dragonfly*|*-*-gnu*|*-*-haiku*) :
     sharedlib_cflags="-fPIC"
@@ -14079,7 +14076,7 @@ esac
       rpath="-Wl,-rpath,"
       mksharedlibrpath="-Wl,-rpath,"
       natdynlinkopts="-Wl,-E"
-      shared_libraries_supported=true ;; #(
+      supports_shared_libraries=true ;; #(
   *) :
      ;;
 esac
@@ -14093,7 +14090,7 @@ fi
 
 natdynlink=false
 
-if test x"$shared_libraries_supported" = 'xtrue'; then :
+if test x"$supports_shared_libraries" = 'xtrue'; then :
   case "$host" in #(
   *-*-cygwin*) :
     natdynlink=true ;; #(
@@ -15858,10 +15855,10 @@ fi
 esac
 
 ## shared library support
-if $shared_libraries_supported; then :
+if $supports_shared_libraries; then :
   case $host in #(
   *-*-mingw32|*-pc-windows|*-*-cygwin*) :
-    supports_shared_libraries=$shared_libraries_supported; DLLIBS="" ;; #(
+    DLLIBS="" ;; #(
   *) :
     ac_fn_c_check_func "$LINENO" "dlopen" "ac_cv_func_dlopen"
 if test "x$ac_cv_func_dlopen" = xyes; then :

--- a/configure
+++ b/configure
@@ -13160,41 +13160,27 @@ fi
 
 fi
 
-if test x"$have_flexdll_h" = 'xno'; then :
-  case $host in #(
-  *-*-cygwin*) :
-    if $supports_shared_libraries; then :
-  supports_shared_libraries=false
-        { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: flexdll.h not found: shared library support disabled." >&5
-$as_echo "$as_me: WARNING: flexdll.h not found: shared library support disabled." >&2;}
-
-fi ;; #(
-  *-w64-mingw32|*-pc-windows) :
+case $have_flexdll_h,$supports_shared_libraries,$host in #(
+  no,true,*-*-cygwin*) :
+    supports_shared_libraries=false
+   { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: flexdll.h not found: shared library support disabled." >&5
+$as_echo "$as_me: WARNING: flexdll.h not found: shared library support disabled." >&2;} ;; #(
+  no,*,*-w64-mingw32|no,*,*-pc-windows) :
     as_fn_error $? "flexdll.h is required for native Win32" "$LINENO" 5 ;; #(
   *) :
      ;;
 esac
-fi
 
-if test -z "$flexdir" -o x"$have_flexdll_h" = 'xno'; then :
-  case $host in #(
-  *-*-cygwin*) :
-    if $supports_shared_libraries; then :
-  if test -z "$flexlink"; then :
-  supports_shared_libraries=false
-          { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: flexlink/flexdll.h not found: shared library support disabled." >&5
-$as_echo "$as_me: WARNING: flexlink/flexdll.h not found: shared library support disabled." >&2;}
-
-fi
-fi ;; #(
-  *-w64-mingw32|*-pc-windows) :
-    if test -z "$flexlink"; then :
-  as_fn_error $? "flexlink is required for native Win32" "$LINENO" 5
-fi ;; #(
+case $flexdir,$supports_shared_libraries,$flexlink,$host in #(
+  ,true,,*-*-cygwin*) :
+    supports_shared_libraries=false
+    { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: flexlink not found: shared library support disabled." >&5
+$as_echo "$as_me: WARNING: flexlink not found: shared library support disabled." >&2;} ;; #(
+  ,*,,*-w64-mingw32|,*,,*-pc-windows) :
+    as_fn_error $? "flexlink is required for native Win32" "$LINENO" 5 ;; #(
   *) :
      ;;
 esac
-fi
 
 case $CC,$host in #(
   *,*-*-darwin*) :

--- a/configure.ac
+++ b/configure.ac
@@ -55,7 +55,6 @@ ocamlc_cflags=""
 ocamlc_cppflags=""
 oc_ldflags=""
 oc_dll_ldflags=""
-with_sharedlibs=true
 ostype="Unix"
 SO="so"
 toolchain="cc"
@@ -693,10 +692,11 @@ AS_CASE([$host],
 #    [enable_shared=yes])
 
 AS_IF([test x"$enable_shared" = "xno"],
-  [with_sharedlibs=false
+  [supports_shared_libraries=false
   AS_CASE([$host],
     [*-pc-windows|*-w64-mingw32],
-    [AC_MSG_ERROR([Cannot build native Win32 with --disable-shared])])])
+    [AC_MSG_ERROR([Cannot build native Win32 with --disable-shared])])],
+  [supports_shared_libraries=true])
 
 # Define flexlink chain and flags correctly for the different Windows ports
 AS_CASE([$host],
@@ -721,7 +721,7 @@ AS_CASE([$host],
     [flexdll_chain='msvc64'
     flexlink_flags="-x64 -merge-manifest -stack 33554432"])
 
-AS_IF([test x"$enable_shared" != 'xno'], [
+AS_IF([test x"$supports_shared_libraries" != 'xfalse'], [
   AC_MSG_CHECKING([for flexdll sources])
   AS_IF([test x"$with_flexdll" = "xno"],
     [flexdir=''
@@ -782,8 +782,8 @@ AS_IF([test x"$enable_shared" != 'xno'], [
 AS_IF([test x"$have_flexdll_h" = 'xno'],
   [AS_CASE([$host],
     [*-*-cygwin*],
-      [AS_IF([$with_sharedlibs],
-        [with_sharedlibs=false
+      [AS_IF([$supports_shared_libraries],
+        [supports_shared_libraries=false
         AC_MSG_WARN([flexdll.h not found: shared library support disabled.])
         ])],
     [*-w64-mingw32|*-pc-windows],
@@ -792,9 +792,9 @@ AS_IF([test x"$have_flexdll_h" = 'xno'],
 AS_IF([test -z "$flexdir" -o x"$have_flexdll_h" = 'xno'],
   [AS_CASE([$host],
     [*-*-cygwin*],
-      [AS_IF([$with_sharedlibs],
+      [AS_IF([$supports_shared_libraries],
         [AS_IF([test -z "$flexlink"],
-          [with_sharedlibs=false
+          [supports_shared_libraries=false
           AC_MSG_WARN(
           [flexlink/flexdll.h not found: shared library support disabled.])
         ])])],
@@ -809,7 +809,7 @@ AS_CASE([$CC,$host],
   [*,*-*-haiku*], [mathlib=""],
   [*,*-*-cygwin*],
     [common_cppflags="$common_cppflags -U_WIN32"
-    AS_IF([$with_sharedlibs],
+    AS_IF([$supports_shared_libraries],
       [mkexe='$(FLEXLINK) -exe $(if $(OC_LDFLAGS),-link "$(OC_LDFLAGS)")'
       mkexedebugflag="-link -g"],
       [mkexe="$mkexe -Wl,--stack,16777216"
@@ -932,7 +932,6 @@ AS_IF([! $arch64],
 
 # Shared library support
 
-shared_libraries_supported=false
 sharedlib_cflags=''
 mksharedlib='shared-libs-not-available'
 rpath=''
@@ -945,33 +944,30 @@ AS_IF([test x"$enable_shared" != "xno"],
       [mksharedlib="$CC -shared \
                    -flat_namespace -undefined suppress -Wl,-no_compact_unwind \
                    \$(LDFLAGS)"
-      shared_libraries_supported=true],
+      supports_shared_libraries=true],
     [*-*-mingw32],
       [mksharedlib='$(FLEXLINK)'
       mkmaindll='$(FLEXLINK) -maindll'
       AS_IF([test -n "$oc_dll_ldflags"],[
         mksharedlib="$mksharedlib -link \"$oc_dll_ldflags\""
-        mkmaindll="$mkmaindll -link \"$oc_dll_ldflags\""])
-      shared_libraries_supported=$with_sharedlibs],
+        mkmaindll="$mkmaindll -link \"$oc_dll_ldflags\""])],
     [*-pc-windows],
       [mksharedlib='$(FLEXLINK)'
-      mkmaindll='$(FLEXLINK) -maindll'
-      shared_libraries_supported=$with_sharedlibs],
+      mkmaindll='$(FLEXLINK) -maindll'],
     [*-*-cygwin*],
       [mksharedlib='$(FLEXLINK)'
-      mkmaindll='$(FLEXLINK) -maindll'
-      shared_libraries_supported=$with_sharedlibs],
+      mkmaindll='$(FLEXLINK) -maindll'],
     [powerpc-ibm-aix*],
       [AS_CASE([$ocaml_cv_cc_vendor],
                [xlc*],
                [mksharedlib="$CC -qmkshrobj -G \$(LDFLAGS)"
-                shared_libraries_supported=true])],
+                supports_shared_libraries=true])],
     [*-*-solaris*],
       [sharedlib_cflags="-fPIC"
       mksharedlib="$CC -shared"
       rpath="-Wl,-rpath,"
       mksharedlibrpath="-Wl,-rpath,"
-      shared_libraries_supported=true],
+      supports_shared_libraries=true],
     [[*-*-linux*|*-*-freebsd[3-9]*|*-*-freebsd[1-9][0-9]*\
     |*-*-openbsd*|*-*-netbsd*|*-*-dragonfly*|*-*-gnu*|*-*-haiku*]],
       [sharedlib_cflags="-fPIC"
@@ -983,7 +979,7 @@ AS_IF([test x"$enable_shared" != "xno"],
       rpath="-Wl,-rpath,"
       mksharedlibrpath="-Wl,-rpath,"
       natdynlinkopts="-Wl,-E"
-      shared_libraries_supported=true])])
+      supports_shared_libraries=true])])
 
 AS_IF([test -z "$mkmaindll"], [mkmaindll=$mksharedlib])
 
@@ -991,7 +987,7 @@ AS_IF([test -z "$mkmaindll"], [mkmaindll=$mksharedlib])
 
 natdynlink=false
 
-AS_IF([test x"$shared_libraries_supported" = 'xtrue'],
+AS_IF([test x"$supports_shared_libraries" = 'xtrue'],
   [AS_CASE(["$host"],
     [*-*-cygwin*], [natdynlink=true],
     [*-*-mingw32], [natdynlink=true],
@@ -1614,10 +1610,10 @@ AS_CASE([$host],
   [AC_CHECK_FUNC([strtod_l], [AC_DEFINE([HAS_STRTOD_L])])])
 
 ## shared library support
-AS_IF([$shared_libraries_supported],
+AS_IF([$supports_shared_libraries],
   [AS_CASE([$host],
     [*-*-mingw32|*-pc-windows|*-*-cygwin*],
-      [supports_shared_libraries=$shared_libraries_supported; DLLIBS=""],
+      [DLLIBS=""],
     [AC_CHECK_FUNC([dlopen],
       [supports_shared_libraries=true DLLIBS=""],
       [AC_CHECK_LIB([dl], [dlopen],

--- a/configure.ac
+++ b/configure.ac
@@ -779,28 +779,19 @@ AS_IF([test x"$supports_shared_libraries" != 'xfalse'], [
   ])
 ])
 
-AS_IF([test x"$have_flexdll_h" = 'xno'],
-  [AS_CASE([$host],
-    [*-*-cygwin*],
-      [AS_IF([$supports_shared_libraries],
-        [supports_shared_libraries=false
-        AC_MSG_WARN([flexdll.h not found: shared library support disabled.])
-        ])],
-    [*-w64-mingw32|*-pc-windows],
-      [AC_MSG_ERROR([flexdll.h is required for native Win32])])])
+AS_CASE([$have_flexdll_h,$supports_shared_libraries,$host],
+ [no,true,*-*-cygwin*],
+   [supports_shared_libraries=false
+   AC_MSG_WARN([flexdll.h not found: shared library support disabled.])],
+ [no,*,*-w64-mingw32|no,*,*-pc-windows],
+   [AC_MSG_ERROR([flexdll.h is required for native Win32])])
 
-AS_IF([test -z "$flexdir" -o x"$have_flexdll_h" = 'xno'],
-  [AS_CASE([$host],
-    [*-*-cygwin*],
-      [AS_IF([$supports_shared_libraries],
-        [AS_IF([test -z "$flexlink"],
-          [supports_shared_libraries=false
-          AC_MSG_WARN(
-          [flexlink/flexdll.h not found: shared library support disabled.])
-        ])])],
-    [*-w64-mingw32|*-pc-windows],
-      [AS_IF([test -z "$flexlink"],
-        [AC_MSG_ERROR([flexlink is required for native Win32])])])])
+AS_CASE([$flexdir,$supports_shared_libraries,$flexlink,$host],
+  [,true,,*-*-cygwin*],
+    [supports_shared_libraries=false
+    AC_MSG_WARN([flexlink not found: shared library support disabled.])],
+  [,*,,*-w64-mingw32|,*,,*-pc-windows],
+    [AC_MSG_ERROR([flexlink is required for native Win32])])
 
 AS_CASE([$CC,$host],
   [*,*-*-darwin*],


### PR DESCRIPTION
There are three variables in `configure.ac` which relate to the complicated story of shared library support detection. This PR builds on the bug fix in #10511 and eliminates `$with_sharedlibs` and `$shared_libraries_supported`, folding everything into the "final" `$supports_shared_libraries` variable (which is what actually gets written to the build configuration).

The two commits are best reviewed separately - the first eliminates the variables, and the second uses that simplification to reduce the complexity of the warnings displayed when configuring shared library support on Windows/Cygwin.

cc @shindere (but there's no urgency - in fixing the bug in #10511 I also dealt with this, finally)