### PR TITLE
add immediate attribute

### DIFF
--- a/Changes
+++ b/Changes
@@ -24,6 +24,9 @@ Working version
 
 ### Standard library:
 
+* #10622: Annotate `Uchar.t` with immediate attribute
+  (Hongbo Zhang, reivew by Gabriel Scherer and Nicolás Ojeda Bär)
+
 * #7812, #10475: `Filename.chop_suffix name suff` now checks that `suff`
   is actually a suffix of `name` and raises Invalid_argument otherwise.
   (Xavier Leroy, report by whitequark, review by David Allsopp)

--- a/stdlib/uchar.mli
+++ b/stdlib/uchar.mli
@@ -18,6 +18,7 @@
     @since 4.03 *)
 
 type t
+[@@immediate]
 (** The type for Unicode characters.
 
     A value of this type represents a Unicode


### PR DESCRIPTION
when using sedlex in flow, we noticed that Uchar.t array is a bottleneck. This attribute mitigated this issue