### PR TITLE
Fix performance regression introduced in 4.08

### DIFF
--- a/Changes
+++ b/Changes
@@ -136,6 +136,10 @@ Working version
 - #10559: Evaluate signature substitutions lazily
   (Stephen Dolan, review by Leo White)
 
+- #8776, #10624: Fix compilation time regression introduced in 4.08
+  (Nicolás Ojeda Bär, fix by Leo White, report by Alain Frisch, review by Thomas
+  Refis)
+
 ### Build system:
 
 ### Bug fixes:

--- a/typing/typeopt.ml
+++ b/typing/typeopt.ml
@@ -22,18 +22,23 @@ open Typedtree
 open Lambda
 
 let scrape_ty env ty =
-  let ty = Ctype.expand_head_opt env (Ctype.correct_levels ty) in
   match get_desc ty with
-  | Tconstr (p, _, _) ->
-      begin match Env.find_type p env with
-      | {type_kind = ( Type_variant (_, Variant_unboxed)
-                     | Type_record (_, Record_unboxed _) ); _} -> begin
-          match Typedecl_unboxed.get_unboxed_type_representation env ty with
-          | None -> ty
-          | Some ty2 -> ty2
-        end
-      | _ -> ty
-      | exception Not_found -> ty
+  | Tconstr _ ->
+      let ty = Ctype.expand_head_opt env (Ctype.correct_levels ty) in
+      begin match get_desc ty with
+      | Tconstr (p, _, _) ->
+          begin match Env.find_type p env with
+          | {type_kind = ( Type_variant (_, Variant_unboxed)
+          | Type_record (_, Record_unboxed _) ); _} -> begin
+              match Typedecl_unboxed.get_unboxed_type_representation env ty with
+              | None -> ty
+              | Some ty2 -> ty2
+          end
+          | _ -> ty
+          | exception Not_found -> ty
+          end
+      | _ ->
+          ty
       end
   | _ -> ty
 


### PR DESCRIPTION
This PR submits a possible fix for a performance slowdown introduced in the 4.08 release and discussed in #8776. The fix was suggested by @lpw25 https://github.com/ocaml/ocaml/issues/8776#issuecomment-506791906 and I am not familiar enough with the typechecker to evaluate if it is the right thing to do, other that verify that the proposed patch indeed fixes the slowdown.

I bisected the history to find out the commit that introduced the problem. *Seems* to be 7a746deed18c70e52faded414faab21173b1b9bb (confirmation from other devs would be appreciated).

Review from typechecker-competent devs required!

For the record the test program used to bisect is the result of the following script
```ocaml
let n2 = 200
let n3 = 40

let () =
  let f () =
    for j = 1 to n2 do
      Printf.printf "method f%i = ()\n" j
    done
  in
  for i = 1 to n3 do
    Printf.printf "let a%i = object\n" i;
    f ();
    Printf.printf "end\n"
  done
```
Compiled with `ocamlc.opt -dtimings -c <test script>`, keeping an eye on the `transl` time in particular (>= 1s for "bad" cases, < 1s for "good" cases).

cc @lpw25 @alainfrisch @chambart @trefis 

Fixes #8776