### PR TITLE
AMD64 integer multiply immediate cannot write result to a stack location

### DIFF
--- a/Changes
+++ b/Changes
@@ -846,6 +846,11 @@ OCaml 4.12, maintenance version
   ID when a thread starts.
   (David Allsopp, Nicolás Ojeda Bär, review by Xavier Leroy)
 
+- #10626, #10628: Wrong reloading of the x86-64 instruction for
+  integer multiplication by a constant, causing the assembler to
+  reject the ocamlopt-generated code.
+  (Xavier Leroy, report by Dave Aitken, review by Vincent Laviron)
+
 OCaml 4.12.0 (24 February 2021)
 -------------------------------
 

--- a/asmcomp/amd64/reload.ml
+++ b/asmcomp/amd64/reload.ml
@@ -40,6 +40,7 @@ open Mach
      Iintop(others)             R       R       S
                             or  S       S       R
      Iintop_imm(Iadd, n)/lea    R       R
+     Iintop_imm(Imul, n)        R       R
      Iintop_imm(others)         S       S
      Inegf...Idivf              R       R       S
      Ifloatofint                R       S
@@ -74,6 +75,11 @@ method! reload_operation op arg res =
       (* This add will be turned into a lea; args and results must be
          in registers *)
       super#reload_operation op arg res
+  | Iintop_imm(Imul, _) ->
+      (* The result (= the argument) must be a register (#10626) *)
+      if stackp arg.(0)
+      then (let r = self#makereg arg.(0) in ([|r|], [|r|]))
+      else (arg, res)
   | Iintop(Imulh | Idiv | Imod | Ilsl | Ilsr | Iasr)
   | Iintop_imm(_, _) ->
       (* The argument(s) and results can be either in register or on stack *)


### PR DESCRIPTION
Force reload into a register if needed.

This was correctly done in the i386 port.

Fixes: #10626
