### PR TITLE
Ensure -fPIC doesn't get passed to an assembler

### DIFF
--- a/Changes
+++ b/Changes
@@ -672,7 +672,7 @@ OCaml 4.13.0
 - #10156: configure script: fix sockets feature detection.
   (Lucas Pluvinage, review by David Allsopp and Damien Doligez)
 
-- #10176: By default, call the assembler through the C compiler driver
+- #10176, #10632: By default, call the assembler through the C compiler driver
   (Sébastien Hinderer, review by Gabriel Scherer, David Allsopp and Xavier
   Leroy)
 

--- a/configure
+++ b/configure
@@ -14562,7 +14562,6 @@ if test "$with_pic"; then :
   $as_echo "#define CAML_WITH_FPIC 1" >>confdefs.h
 
   internal_cflags="$internal_cflags $sharedlib_cflags"
-  default_as="$default_as $sharedlib_cflags"
   default_aspp="$default_aspp $sharedlib_cflags"
 else
   fpic=false

--- a/configure.ac
+++ b/configure.ac
@@ -1230,7 +1230,6 @@ AS_IF([test "$with_pic"],
   [fpic=true
   AC_DEFINE([CAML_WITH_FPIC])
   internal_cflags="$internal_cflags $sharedlib_cflags"
-  default_as="$default_as $sharedlib_cflags"
   default_aspp="$default_aspp $sharedlib_cflags"],
   [fpic=false])
 


### PR DESCRIPTION
Tentative fix for #10630. It's tentative inasmuch as I haven't thoroughly convinced myself that we _ever_ need to pass `$sharedlib_cflags` when assembling (because the responsibility for PIC rested with ocamlopt, not with the gcc-as-assembler).

The fix itself is simple - `$default_as` starts out as C compiler and is then selectively overridden to become an assembler if necessary. So this PR adds the `$sharedlib_cflags` to `$default_as` _before_ the overriding, guaranteeing that `-fPIC` is only ever added when `$default_as` is still a call to `$CC`.