### PR TITLE
Restore minor heap pointer after a Stack_overflow

### DIFF
--- a/Changes
+++ b/Changes
@@ -189,6 +189,11 @@ Working version
 - #10603, #10611: Fix if condition marked as inconstant in flambda
   (Vincent Laviron and Pierre Chambart, report by Marcello Seri)
 
+- #10633: Stack overflow recovery in ocamlopt for AMD64/Linux and ARM/Linux
+  was not restoring the minor heap pointer correctly
+  (Stephen Dolan, review by Xavier Leroy)
+
+
 OCaml 4.13.0
 -------------
 

--- a/runtime/signals_nat.c
+++ b/runtime/signals_nat.c
@@ -224,9 +224,11 @@ DECLARE_SIGNAL_HANDLER(segv_handler)
 #endif
 #else
     /* Raise a Stack_overflow exception straight from this signal handler */
-#if defined(CONTEXT_YOUNG_PTR) && defined(CONTEXT_EXCEPTION_POINTER)
-    Caml_state->exception_pointer == (char *) CONTEXT_EXCEPTION_POINTER;
+#if defined(CONTEXT_YOUNG_PTR)
     Caml_state->young_ptr = (value *) CONTEXT_YOUNG_PTR;
+#endif
+#if defined(CONTEXT_EXCEPTION_POINTER)
+    Caml_state->exception_pointer = (char *) CONTEXT_EXCEPTION_POINTER;
 #endif
     caml_raise_stack_overflow();
 #endif

--- a/runtime/signals_osdep.h
+++ b/runtime/signals_osdep.h
@@ -137,8 +137,8 @@
   typedef unsigned long context_reg;
   #define CONTEXT_PC (context->uc_mcontext.arm_pc)
   #define CONTEXT_SP (context->uc_mcontext.arm_sp)
-  #define CONTEXT_EXCEPTION_POINTER (context->uc_mcontext.arm_fp)
-  #define CONTEXT_YOUNG_PTR (context->uc_mcontext.arm_r8)
+  #define CONTEXT_EXCEPTION_PTR (context->uc_mcontext.arm_r8)
+  #define CONTEXT_YOUNG_PTR (context->uc_mcontext.arm_r10)
   #define CONTEXT_FAULTING_ADDRESS ((char *) context->uc_mcontext.fault_address)
 
 /****************** ARM64, Linux */
@@ -158,6 +158,7 @@
   #define CONTEXT_PC (context->uc_mcontext.pc)
   #define CONTEXT_SP (context->uc_mcontext.sp)
   #define CONTEXT_C_ARG_1 (context->uc_mcontext.regs[0])
+  #define CONTEXT_EXCEPTION_POINTER (context->uc_mcontext.regs[26])
   #define CONTEXT_YOUNG_PTR (context->uc_mcontext.regs[27])
   #define CONTEXT_FAULTING_ADDRESS ((char *) context->uc_mcontext.fault_address)
 
@@ -181,6 +182,7 @@
   #define CONTEXT_PC (CONTEXT_STATE.__pc)
   #define CONTEXT_SP (CONTEXT_STATE.__sp)
   #define CONTEXT_C_ARG_1 (CONTEXT_STATE.__x[0])
+  #define CONTEXT_EXCEPTION_POINTER (CONTEXT_STATE.__x[26])
   #define CONTEXT_YOUNG_PTR (CONTEXT_STATE.__x[27])
   #define CONTEXT_FAULTING_ADDRESS ((char *) info->si_addr)
 

--- a/testsuite/tests/runtime-errors/stackoverflow.ml
+++ b/testsuite/tests/runtime-errors/stackoverflow.ml
@@ -34,12 +34,14 @@ let rec f x =
       raise Stack_overflow
 
 let _ =
+ let p = Sys.opaque_identity (ref 42) in
  begin
   try
     ignore(f 0)
   with Stack_overflow ->
     print_string "Stack overflow caught"; print_newline()
  end ;
+ for i = 1 to 1000 do ignore (Sys.opaque_identity (ref 1_000_000)) done;
  (* GPR#1289 *)
  Printexc.record_backtrace true;
  begin
@@ -47,4 +49,5 @@ let _ =
     ignore(f 0)
   with Stack_overflow ->
     print_string "second Stack overflow caught"; print_newline()
- end
+ end;
+ print_string "!p = "; print_int !p; print_newline ()

--- a/testsuite/tests/runtime-errors/stackoverflow.native.reference
+++ b/testsuite/tests/runtime-errors/stackoverflow.native.reference
@@ -6,3 +6,4 @@ x = 20000
 x = 10000
 x = 0
 second Stack overflow caught
+!p = 42

--- a/testsuite/tests/runtime-errors/stackoverflow.reference
+++ b/testsuite/tests/runtime-errors/stackoverflow.reference
@@ -6,3 +6,4 @@ x = 20000
 x = 10000
 x = 0
 second Stack overflow caught
+!p = 42


### PR DESCRIPTION
On at least amd64, the runtime state is not restored correctly after recovering from a stack overflow: the young pointer and the exception pointer are restored only if *both* have reserved registers. These days, only the young pointer has a reserved register, so the tests should be separate.

Also, the logic for `Caml_state->exception_pointer` is very suspect - a `==` where there should be a `=`. I'm surprised CI didn't complain about this...

(The test case is reduced from an example discovered by @jmid at https://github.com/c-cube/qcheck/issues/175)

cc @gasche 