### PR TITLE
Use same flags for AS and ASPP by default

### DIFF
--- a/Changes
+++ b/Changes
@@ -189,6 +189,9 @@ Working version
 - #10603, #10611: Fix if condition marked as inconstant in flambda
   (Vincent Laviron and Pierre Chambart, report by Marcello Seri)
 
+- #10634: Use the same flags for AS and ASPP when AS is the C compiler.
+  (David Allsopp, review by Sébastien Hinderer)
+
 OCaml 4.13.0
 -------------
 
@@ -672,7 +675,7 @@ OCaml 4.13.0
 - #10156: configure script: fix sockets feature detection.
   (Lucas Pluvinage, review by David Allsopp and Damien Doligez)
 
-- #10176: By default, call the assembler through the C compiler driver
+- #10176, #10632: By default, call the assembler through the C compiler driver
   (Sébastien Hinderer, review by Gabriel Scherer, David Allsopp and Xavier
   Leroy)
 

--- a/configure
+++ b/configure
@@ -14536,6 +14536,17 @@ fi
 default_as="$CC -c"
 default_aspp="$CC -c"
 
+if test "$with_pic"; then :
+  fpic=true
+  $as_echo "#define CAML_WITH_FPIC 1" >>confdefs.h
+
+  internal_cflags="$internal_cflags $sharedlib_cflags"
+  default_as="$default_as $sharedlib_cflags"
+  default_aspp="$default_aspp $sharedlib_cflags"
+else
+  fpic=false
+fi
+
 case $as_target,$ocaml_cv_cc_vendor in #(
   *-*-linux*,gcc-*) :
     case $as_cpu in #(
@@ -14556,17 +14567,6 @@ esac ;; #(
   *) :
      ;;
 esac
-
-if test "$with_pic"; then :
-  fpic=true
-  $as_echo "#define CAML_WITH_FPIC 1" >>confdefs.h
-
-  internal_cflags="$internal_cflags $sharedlib_cflags"
-  default_as="$default_as $sharedlib_cflags"
-  default_aspp="$default_aspp $sharedlib_cflags"
-else
-  fpic=false
-fi
 
 if test -z "$AS"; then :
   AS="$default_as"

--- a/configure.ac
+++ b/configure.ac
@@ -1210,6 +1210,14 @@ AS_IF([test -n "$target_alias"],
 default_as="$CC -c"
 default_aspp="$CC -c"
 
+AS_IF([test "$with_pic"],
+  [fpic=true
+  AC_DEFINE([CAML_WITH_FPIC])
+  internal_cflags="$internal_cflags $sharedlib_cflags"
+  default_as="$default_as $sharedlib_cflags"
+  default_aspp="$default_aspp $sharedlib_cflags"],
+  [fpic=false])
+
 AS_CASE([$as_target,$ocaml_cv_cc_vendor],
   [*-*-linux*,gcc-*],
     [AS_CASE([$as_cpu],
@@ -1225,14 +1233,6 @@ AS_CASE([$as_target,$ocaml_cv_cc_vendor],
     [default_as="$default_as -Wno-trigraphs"
     default_aspp="$default_as"],
   [])
-
-AS_IF([test "$with_pic"],
-  [fpic=true
-  AC_DEFINE([CAML_WITH_FPIC])
-  internal_cflags="$internal_cflags $sharedlib_cflags"
-  default_as="$default_as $sharedlib_cflags"
-  default_aspp="$default_aspp $sharedlib_cflags"],
-  [fpic=false])
 
 AS_IF([test -z "$AS"], [AS="$default_as"])
 


### PR DESCRIPTION
On the basis of https://github.com/ocaml/ocaml/pull/10632#issuecomment-918179098, here's the original version of #10632, should we wish to include it for 4.14. The original PR remains as the urgent bugfix for 4.13