### PR TITLE
Allow the C compiler to be overidden for sak

### DIFF
--- a/Changes
+++ b/Changes
@@ -693,10 +693,10 @@ OCaml 4.13.0
   which runtime to use while building the compilers (Sébastien Hinderer,
   review by David Allsopp)
 
-- #10451: Replace the use of iconv with a C utility to convert $(LIBDIR) to a
-  C string constant on Windows when building the runtime. Hardens the generation
-  of the constant on Unix for paths with backslashes, double-quotes and
-  newlines.
+- #10451, #10635: Replace the use of iconv with a C utility to convert $(LIBDIR)
+  to a C string constant on Windows when building the runtime. Hardens the
+  generation of the constant on Unix for paths with backslashes, double-quotes
+  and newlines.
   (David Allsopp, review by Florian Angeletti and Sébastien Hinderer)
 
 - #10471: Fix detection of arm32 architectures with musl in configure.

--- a/runtime/Makefile
+++ b/runtime/Makefile
@@ -243,8 +243,17 @@ caml/jumptbl.h : caml/instruct.h
 caml/version.h : $(ROOTDIR)/tools/make-version-header.sh $(ROOTDIR)/VERSION
 	$^ > $@
 
+# These are provided as a temporary shim to allow cross-compilation systems
+# to supply a host C compiler and different flags and a linking macro.
+SAK_CC ?= $(CC)
+SAK_CFLAGS ?= $(OC_CFLAGS) $(CFLAGS) $(OC_CPPFLAGS) $(CPPFLAGS)
+SAK_LINK ?= $(MKEXE_USING_COMPILER)
+
 sak$(EXE): sak.$(O)
-	$(call MKEXE_USING_COMPILER,$@,$^)
+	$(call SAK_LINK,$@,$^)
+
+sak.$(O): sak.c caml/misc.h caml/config.h
+	$(SAK_CC) -c $(SAK_CFLAGS) $(OUTPUTOBJ)$@ $<
 
 C_LITERAL = $(shell ./sak$(EXE) encode-C-literal '$(1)')
 


### PR DESCRIPTION
When cross-compilation lands, two (or even three) versions of ocamlrun will be built, and configure will have the precise details of the "build" C compiler for `sak`. In the meantime, for existing third party cross-compilation systems, put the C compiler and flags in a separate variable to allow these systems to override it.

cf. https://github.com/mirage/ocaml-freestanding/pull/94

cc @kit-ty-kate 