### PR TITLE
[refactoring] Outcometree: introduce a record type for constructors

### DIFF
--- a/Changes
+++ b/Changes
@@ -163,6 +163,9 @@ Working version
 - #10618: Expose more Pprintast functions
   (Guillaume Petiot, review by Gabriel Scherer)
 
+- #10637: Outcometree: introduce a record type for constructors
+  (Gabriel Scherer, review by Thomas Refis)
+
 ### Build system:
 
 ### Bug fixes:

--- a/typing/oprint.mli
+++ b/typing/oprint.mli
@@ -20,8 +20,7 @@ val out_ident : (formatter -> out_ident -> unit) ref
 val out_value : (formatter -> out_value -> unit) ref
 val out_label : (formatter -> string * bool * out_type -> unit) ref
 val out_type : (formatter -> out_type -> unit) ref
-val out_constr :
-  (formatter -> string * out_type list * out_type option -> unit) ref
+val out_constr : (formatter -> out_constructor -> unit) ref
 val out_class_type : (formatter -> out_class_type -> unit) ref
 val out_module_type : (formatter -> out_module_type -> unit) ref
 val out_sig_item : (formatter -> out_sig_item -> unit) ref

--- a/typing/outcometree.mli
+++ b/typing/outcometree.mli
@@ -69,7 +69,7 @@ type out_type =
   | Otyp_object of (string * out_type) list * bool option
   | Otyp_record of (string * bool * out_type) list
   | Otyp_stuff of string
-  | Otyp_sum of (string * out_type list * out_type option) list
+  | Otyp_sum of out_constructor list
   | Otyp_tuple of out_type list
   | Otyp_var of bool * string
   | Otyp_variant of
@@ -77,6 +77,12 @@ type out_type =
   | Otyp_poly of string list * out_type
   | Otyp_module of out_ident * (string * out_type) list
   | Otyp_attribute of out_type * out_attribute
+
+and out_constructor = {
+  ocstr_name: string;
+  ocstr_args: out_type list;
+  ocstr_return_type: out_type option;
+}
 
 and out_variant =
   | Ovar_fields of (string * bool * out_type list) list
@@ -128,7 +134,7 @@ and out_extension_constructor =
 and out_type_extension =
   { otyext_name: string;
     otyext_params: string list;
-    otyext_constructors: (string * out_type list * out_type option) list;
+    otyext_constructors: out_constructor list;
     otyext_private: Asttypes.private_flag }
 and out_val_decl =
   { oval_name: string;

--- a/typing/printtyp.ml
+++ b/typing/printtyp.ml
@@ -1421,12 +1421,20 @@ and tree_of_constructor cd =
   let name = Ident.name cd.cd_id in
   let arg () = tree_of_constructor_arguments cd.cd_args in
   match cd.cd_res with
-  | None -> (name, arg (), None)
+  | None -> {
+      ocstr_name = name;
+      ocstr_args = arg ();
+      ocstr_return_type = None;
+    }
   | Some res ->
       Names.with_local_names (fun () ->
         let ret = tree_of_typexp Type res in
         let args = arg () in
-        (name, args, Some ret))
+        {
+          ocstr_name = name;
+          ocstr_args = args;
+          ocstr_return_type = Some ret;
+        })
 
 and tree_of_label l =
   (Ident.name l.ld_id, l.ld_mutable = Mutable, tree_of_typexp Type l.ld_type)
@@ -1511,7 +1519,11 @@ let extension_only_constructor id ppf ext =
       ext.ext_ret_type
   in
   Format.fprintf ppf "@[<hv>%a@]"
-    !Oprint.out_constr (name, args, ret)
+    !Oprint.out_constr {
+      ocstr_name = name;
+      ocstr_args = args;
+      ocstr_return_type = ret;
+    }
 
 (* Print a value declaration *)
 


### PR DESCRIPTION
This small refactoring is part of ongoing work on unboxed constructors.