### PR TITLE
Fix a flaky test by refactoring TypePairs

### DIFF
--- a/testsuite/tests/typing-gadts/principality-and-gadts.ml
+++ b/testsuite/tests/typing-gadts/principality-and-gadts.ml
@@ -362,7 +362,7 @@ val foo : int foo -> int = <fun>
 Line 3, characters 26-31:
 3 |   | { x = (x : int); eq = Refl3 } -> x
                               ^^^^^
-Warning 18 [not-principal]: typing this pattern requires considering M.t and int as equal.
+Warning 18 [not-principal]: typing this pattern requires considering M.t and N.t as equal.
 But the knowledge of these types is not principal.
 val foo : int foo -> int = <fun>
 |}]
@@ -404,7 +404,7 @@ val foo : string foo -> string = <fun>
 Line 3, characters 29-34:
 3 |   | { x = (x : string); eq = Refl3 } -> x
                                  ^^^^^
-Warning 18 [not-principal]: typing this pattern requires considering M.t and string as equal.
+Warning 18 [not-principal]: typing this pattern requires considering M.t and N.t as equal.
 But the knowledge of these types is not principal.
 val foo : string foo -> string = <fun>
 |}]

--- a/typing/btype.mli
+++ b/typing/btype.mli
@@ -44,11 +44,12 @@ module TypeHash : sig
   val iter: (type_expr -> 'a -> unit) -> 'a t -> unit
 end
 module TypePairs : sig
-  include Hashtbl.S with type key = transient_expr * transient_expr
-  val add: 'a t -> type_expr * type_expr -> 'a -> unit
-  val find: 'a t -> type_expr * type_expr -> 'a
-  val mem: 'a t -> type_expr * type_expr -> bool
-  val iter: (type_expr * type_expr -> 'a -> unit) -> 'a t -> unit
+  type t
+  val create: int -> t
+  val clear: t -> unit
+  val add: t -> type_expr * type_expr -> unit
+  val mem: t -> type_expr * type_expr -> bool
+  val iter: (type_expr * type_expr -> unit) -> t -> unit
 end
 
 (**** Levels ****)

--- a/typing/ctype.mli
+++ b/typing/ctype.mli
@@ -221,7 +221,7 @@ val unify: Env.t -> type_expr -> type_expr -> unit
         (* Unify the two types given. Raise [Unify] if not possible. *)
 val unify_gadt:
         equations_level:int -> allow_recursive:bool ->
-        Env.t ref -> type_expr -> type_expr -> unit Btype.TypePairs.t
+        Env.t ref -> type_expr -> type_expr -> Btype.TypePairs.t
         (* Unify the two types given and update the environment with the
            local constraints. Raise [Unify] if not possible.
            Returns the pairs of types that have been equated.  *)

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -720,7 +720,7 @@ let solve_Ppat_construct ~refine env loc constr no_existentials
     let exception Warn_only_once in
     try
       TypePairs.iter
-        (fun (t1, t2) () ->
+        (fun (t1, t2) ->
           generalize_structure t1;
           generalize_structure t2;
           if not (fully_generic t1 && fully_generic t2) then


### PR DESCRIPTION
In a branch of the typechecker, I found that the test `typing-gadts/principality-and-gadts.ml` was failing, by seemingly randomly switching between two versions of a particular principality warning. (@lpw25 tells me I'm not the first to hit this).

The culprit turned out to be `Btype.TypePairs.iter`:  if two warnings occur on the same pattern, the compiler sensibly prints only the first, but "first" was defined by hashtable iteration order. This hashtable was keyed by type IDs, so the order depended on exactly how many types had been allocated before the relevent ones, regardless of how they were used.

This patch refactors TypePairs to preserve insertion order. I also changed the module API to remove a type parameter: although TypePairs was a table mapping pairs of types to arbitrary values, every user used `unit` as the value type. So, it's now a set.
