### PR TITLE
Make `stderr` unbuffered by default

### DIFF
--- a/Changes
+++ b/Changes
@@ -63,7 +63,7 @@ Working version
   (Nicolás Ojeda Bär, review by John Whitington, Daniel Bünzli, David Allsopp
   and Xavier Leroy)
 
-- #10639: make `stderr` unbuffered by default.
+* #10639: make `stderr` unbuffered by default.
   (Nicolás Ojeda Bär)
 
 ### Other libraries:

--- a/Changes
+++ b/Changes
@@ -63,6 +63,9 @@ Working version
   (Nicolás Ojeda Bär, review by John Whitington, Daniel Bünzli, David Allsopp
   and Xavier Leroy)
 
+- #10639: make `stderr` unbuffered by default.
+  (Nicolás Ojeda Bär)
+
 ### Other libraries:
 
 - #10192: Add support for Unix domain sockets on Windows and use them

--- a/otherlibs/unix/channels.c
+++ b/otherlibs/unix/channels.c
@@ -81,5 +81,5 @@ CAMLprim value unix_outchannel_of_filedescr(value fd)
   err = unix_check_stream_semantics(Int_val(fd));
   caml_leave_blocking_section();
   if (err != 0) unix_error(err, "out_channel_of_descr", Nothing);
-  return caml_ml_open_descriptor_out(fd);
+  return caml_ml_open_descriptor_out(fd, Val_true);
 }

--- a/otherlibs/win32unix/channels.c
+++ b/otherlibs/win32unix/channels.c
@@ -103,7 +103,7 @@ CAMLprim value win_outchannel_of_filedescr(value handle)
 
   err = win_check_stream_semantics(handle);
   if (err != 0) { win32_maperr(err); uerror("out_channel_of_descr", Nothing); }
-  chan = caml_open_descriptor_out(win_CRT_fd_of_filedescr(handle));
+  chan = caml_open_descriptor_out(win_CRT_fd_of_filedescr(handle), Val_true);
   chan->flags |= CHANNEL_FLAG_MANAGED_BY_GC;
                  /* as in caml_ml_open_descriptor_out() */
   if (Descr_kind_val(handle) == KIND_SOCKET)

--- a/runtime/caml/io.h
+++ b/runtime/caml/io.h
@@ -120,7 +120,7 @@ CAMLextern struct channel * caml_all_opened_channels;
 
 /* Primitives required by the Unix library */
 CAMLextern value caml_ml_open_descriptor_in(value fd);
-CAMLextern value caml_ml_open_descriptor_out(value fd);
+CAMLextern value caml_ml_open_descriptor_out(value fd, value buffered);
 
 #endif /* CAML_INTERNALS */
 

--- a/runtime/io.c
+++ b/runtime/io.c
@@ -519,10 +519,11 @@ CAMLprim value caml_ml_open_descriptor_in(value fd)
   return caml_alloc_channel(chan);
 }
 
-CAMLprim value caml_ml_open_descriptor_out(value fd)
+CAMLprim value caml_ml_open_descriptor_out(value fd, value buffered)
 {
   struct channel * chan = caml_open_descriptor_out(Int_val(fd));
   chan->flags |= CHANNEL_FLAG_MANAGED_BY_GC;
+  if (! Bool_val(buffered)) chan->flags |= CHANNEL_FLAG_UNBUFFERED;
   return caml_alloc_channel(chan);
 }
 

--- a/stdlib/out_channel.mli
+++ b/stdlib/out_channel.mli
@@ -36,7 +36,7 @@ val stdout : t
 (** The standard output for the process. *)
 
 val stderr : t
-(** The standard error output for the process. *)
+(** The standard error output for the process. Unbuffered by default. *)
 
 val open_bin : string -> t
 (** Open the named file for writing, and return a new output channel on that

--- a/stdlib/stdlib.ml
+++ b/stdlib/stdlib.ml
@@ -307,13 +307,13 @@ let rec ( @ ) l1 l2 =
 type in_channel
 type out_channel
 
-external open_descriptor_out : int -> out_channel
+external open_descriptor_out : int -> bool -> out_channel
                              = "caml_ml_open_descriptor_out"
 external open_descriptor_in : int -> in_channel = "caml_ml_open_descriptor_in"
 
 let stdin = open_descriptor_in 0
-let stdout = open_descriptor_out 1
-let stderr = open_descriptor_out 2
+let stdout = open_descriptor_out 1 true
+let stderr = open_descriptor_out 2 false
 
 (* General output functions *)
 
@@ -328,7 +328,7 @@ external set_out_channel_name: out_channel -> string -> unit =
   "caml_ml_set_channel_name"
 
 let open_out_gen mode perm name =
-  let c = open_descriptor_out(open_desc name mode perm) in
+  let c = open_descriptor_out(open_desc name mode perm) true in
   set_out_channel_name c name;
   c
 

--- a/stdlib/stdlib.mli
+++ b/stdlib/stdlib.mli
@@ -842,7 +842,7 @@ val stdout : out_channel
 (** The standard output for the process. *)
 
 val stderr : out_channel
-(** The standard error output for the process. *)
+(** The standard error output for the process. Unbuffered by default. *)
 
 
 (** {2 Output functions on standard output} *)


### PR DESCRIPTION
Hot on the heels of #10538, this PR proposes to switch `stderr` to be unbuffered by default. I would be particularly interested in opinions *against* this change, as most of the opinions I heard so far seemed to be supportive of it...

cc @johnwhitington 
