### PR TITLE
toplevel: Show hints for the "undefined global" error

### DIFF
--- a/.depend
+++ b/.depend
@@ -6305,6 +6305,7 @@ toplevel/genprintval.cmi : \
     typing/env.cmi
 toplevel/topcommon.cmo : \
     typing/typedtree.cmi \
+    bytecomp/symtable.cmi \
     parsing/printast.cmi \
     typing/predef.cmi \
     parsing/pprintast.cmi \
@@ -6332,6 +6333,7 @@ toplevel/topcommon.cmo : \
     toplevel/topcommon.cmi
 toplevel/topcommon.cmx : \
     typing/typedtree.cmx \
+    bytecomp/symtable.cmx \
     parsing/printast.cmx \
     typing/predef.cmx \
     parsing/pprintast.cmx \

--- a/Changes
+++ b/Changes
@@ -240,6 +240,9 @@ Working version
 - #11774: ocamlyacc: fail if there is an I/O error
   (Demi Marie Obenour)
 
+- #10647: Show hints for the "undefined global" error in the toplevel
+  (Wiktor Kuchta, review by Gabriel Scherer)
+
 ### Manual and documentation:
 
 - #9430, #11291: Document the general desugaring rules for binding operators.

--- a/toplevel/topcommon.ml
+++ b/toplevel/topcommon.ml
@@ -383,38 +383,33 @@ let try_run_directive ppf dir_name pdir_arg =
 
 (* Overriding exception printers with toplevel-specific ones *)
 
-let loading_hint_printer ppf err =
-  Symtable.report_error ppf err;
-  match err with
-  | Symtable.Undefined_global s ->
-    if !Sys.interactive then begin
-      let find_with_ext ext =
-        try Some (Load_path.find_uncap (s ^ ext)) with Not_found -> None
-      in
-      fprintf ppf
-        "@.Hint: @[\
-         This means that the interface of a module is loaded, \
-         but its implementation is not.@,";
-      begin match List.find_map find_with_ext [".cma"; ".cmo"] with
-      | Some path ->
-        fprintf ppf
-          "Found %s @,in the load paths. \
-           @,Did you mean to load it using @,#load \"%s\" \
-           @,or by passing it as an argument to the toplevel?"
-           path (Filename.basename path)
-      | None ->
-        fprintf ppf
-          "Did you mean to load a compiled implementation of the module \
-           @,using #load or by passing it as an argument to the toplevel?"
-      end;
-      fprintf ppf "@]"
-    end
-  | _ -> ()
+let loading_hint_printer ppf s =
+  Symtable.report_error ppf (Symtable.Undefined_global s);
+  let find_with_ext ext =
+    try Some (Load_path.find_uncap (s ^ ext)) with Not_found -> None
+  in
+  fprintf ppf
+    "@.Hint: @[\
+     This means that the interface of a module is loaded, \
+     but its implementation is not.@,";
+  begin match List.find_map find_with_ext [".cma"; ".cmo"] with
+  | Some path ->
+    fprintf ppf
+      "Found %s @,in the load paths. \
+       @,Did you mean to load it using @,#load \"%s\" \
+       @,or by passing it as an argument to the toplevel?"
+       path (Filename.basename path)
+  | None ->
+    fprintf ppf
+      "Did you mean to load a compiled implementation of the module \
+       @,using #load or by passing it as an argument to the toplevel?"
+  end;
+  fprintf ppf "@]"
 
 let () =
   Location.register_error_of_exn
     (function
-      | Symtable.Error err ->
-        Some (Location.error_of_printer_file loading_hint_printer err)
+      | Symtable.Error (Symtable.Undefined_global s) ->
+        Some (Location.error_of_printer_file loading_hint_printer s)
       | _ -> None
     )

--- a/toplevel/topcommon.ml
+++ b/toplevel/topcommon.ml
@@ -380,3 +380,41 @@ let try_run_directive ppf dir_name pdir_arg =
             dir_name dir_type arg_type;
           false
   end
+
+(* Overriding exception printers with toplevel-specific ones *)
+
+let loading_hint_printer ppf err =
+  Symtable.report_error ppf err;
+  match err with
+  | Symtable.Undefined_global s ->
+    if !Sys.interactive then begin
+      let find_with_ext ext =
+        try Some (Load_path.find_uncap (s ^ ext)) with Not_found -> None
+      in
+      fprintf ppf
+        "@.Hint: @[\
+         This means a module's interface is loaded, \
+         but its implementation is not.@,";
+      begin match List.find_map find_with_ext [".cma"; ".cmo"] with
+      | Some path ->
+        fprintf ppf
+          "Found %s @,in the load paths. \
+           @,Did you mean to load it using @,#load \"%s\" \
+           @,or by passing it as an argument to the toplevel?"
+           path (Filename.basename path)
+      | None ->
+        fprintf ppf
+          "Did you mean to load a compiled implementation of the module \
+           @,using #load or by passing it as an argument to the toplevel?"
+      end;
+      fprintf ppf "@]"
+    end
+  | _ -> ()
+
+let () =
+  Location.register_error_of_exn
+    (function
+      | Symtable.Error err ->
+        Some (Location.error_of_printer_file loading_hint_printer err)
+      | _ -> None
+    )

--- a/toplevel/topcommon.ml
+++ b/toplevel/topcommon.ml
@@ -392,6 +392,9 @@ let loading_hint_printer ppf s =
     "@.Hint: @[\
      This means that the interface of a module is loaded, \
      but its implementation is not.@,";
+  (* Filenames don't have to correspond to module names,
+     especially for archives (cmas), which bundle multiple modules.
+     But very often they do. *)
   begin match List.find_map find_with_ext [".cma"; ".cmo"] with
   | Some path ->
     fprintf ppf

--- a/toplevel/topcommon.ml
+++ b/toplevel/topcommon.ml
@@ -393,7 +393,7 @@ let loading_hint_printer ppf err =
       in
       fprintf ppf
         "@.Hint: @[\
-         This means a module's interface is loaded, \
+         This means that the interface of a module is loaded, \
          but its implementation is not.@,";
       begin match List.find_map find_with_ext [".cma"; ".cmo"] with
       | Some path ->


### PR DESCRIPTION
This PR adds hints for loading modules when hitting the "undefined global" error. The advice is basically taken from the toplevel chapter of the manual, but we can make it a bit more helpful because we can see what files are already there (in the load paths).

For example, this is the hint in the following (possibly confusing for the user) interaction:

```
# #show Dynlink.is_native;;
val is_native : bool
# Dynlink.is_native;;
Error: Reference to undefined global `Dynlink'
Hint: This means a module's interface is loaded, but its implementation is not.
      Found otherlibs/dynlink/dynlink.cma in the load paths. 
      Did you mean to load it with #load "dynlink.cma" 
      or by passing it as an argument to the toplevel?
```

The advice with the `.ml` file in the code might be not as useful, because it probably only fires if there is a `.cmi` file but no `.cmo` file, so I don't know whether to keep it.

I realize the code looks repetitive, but the clever ways to rewrite it I can think of don't feel right and don't save much code.