### PR TITLE
Tweak for evaluation order of labelled partial applications

### DIFF
--- a/testsuite/tests/basic-more/labels_evaluation_order.reference
+++ b/testsuite/tests/basic-more/labels_evaluation_order.reference
@@ -1,7 +1,7 @@
 c argument
 a argument
+a parameter
 f defined
 b argument
-a parameter
 b parameter
 c parameter


### PR DESCRIPTION
Fixes #10652.

One part of this patch removes some code that changes the behaviour when all previous arguments were optional. I'm not sure what it was supposed to help with, and none of the tests in the testsuite rely on it.
The second part switches from `List.fold_left` to `List.fold_right` for emitting bindings, as it corresponds to a right-to-left evaluation order for arguments, which is more coherent with normal applications.

I think the result is more coherent (and it fits @lpw25's expectations for his test case), but I would welcome discussion on the purpose of the original code.