### PR TITLE
Two minor fixes to check-typo

### DIFF
--- a/tools/check-typo
+++ b/tools/check-typo
@@ -202,6 +202,7 @@ EXIT_CODE=0
       *$f*) is_cmd_line=true;;
       *) is_cmd_line=false;;
     esac
+    if $path_in_index || $is_cmd_line; then :; else continue; fi
     if [ -z "$OCAML_CT_PREFIX" ] ; then
       if [ -x "$f" ] ; then
         check_script "$f"
@@ -211,7 +212,6 @@ EXIT_CODE=0
         check_script "$f"
       fi
     fi
-    if $path_in_index || $is_cmd_line; then :; else continue; fi
     attr_rules=''
     if $path_in_index; then
       # Below is a git plumbing command to detect whether git regards a

--- a/tools/check-typo
+++ b/tools/check-typo
@@ -112,6 +112,10 @@ case "$1" in
           echo "INFO: pruned path $2 (.git)" >&2
           exit 0;;
     esac
+    if git check-ignore -q "$2"; then
+        echo "INFO: pruned path $2 (.gitignore)" >&2
+        exit 0
+    fi
     if test -n "$(check_prune "$2")"; then
         echo "INFO: pruned path $2 (typo.prune)" >&2
         exit 0


### PR DESCRIPTION
- Re https://github.com/ocaml/ocaml/issues/10648#issuecomment-922525406 - prune directories listed in `.gitignore`, so you now get output like:
```
dra@thor:~/ocaml$ tools/check-typo
INFO: pruned path ./build-aux (typo.prune)
INFO: pruned path ./_opam (.gitignore)
```
- While fixing that, I noticed that the `check_script` function added in #2298 to check the executable bit of scripts is in the wrong place - it should appear after the line following it. The effect is that other scripts (e.g. bisect scripts, etc.) which may be lying around in one's tree trigger the warning, but not check-typo itself.