### PR TITLE
webman: Remove colored list bullets

### DIFF
--- a/Changes
+++ b/Changes
@@ -148,6 +148,10 @@ Working version
   (Nicolás Ojeda Bär, report by Daniel Bünzli, review by David Allsopp,
   Sébastien Hinderer, and Daniel Bünzli)
 
+- #10671, #10672: webman: Fix misalignments in unordered lists by changing the
+  CSS for coloring bullets
+  (Wiktor Kuchta, review by Florian Angeletti)
+
 ### Compiler user-interface and warnings:
 
 - #10328: Give more precise error when disambiguation could not possibly work.

--- a/manual/src/html_processing/scss/_common.scss
+++ b/manual/src/html_processing/scss/_common.scss
@@ -249,14 +249,9 @@ html {
     margin-left:-1em
 }
 
-@mixin disc {
-    content:"●";
-    color:$logocolor;
-    margin-right:4px;
-    margin-left:-1em;
-    font-family: $font-sans;
-    font-size:13px;
-    vertical-align:1px;
+@mixin colored-disc-marker {
+    list-style-type: disc;
+    li::marker { color:$logocolor; }
 }
 
 @mixin diamond {

--- a/manual/src/html_processing/scss/manual.scss
+++ b/manual/src/html_processing/scss/manual.scss
@@ -23,7 +23,7 @@
 	}
     }
     ul{list-style:none;}
-    ul.itemize li::before{@include disc;}
+    ul.itemize {@include colored-disc-marker;}
 
     /* When the TOC is repeated in the main content */
     ul.ul-content {
@@ -44,7 +44,6 @@
     ul{
 	list-style: none;
 	li {
-	    margin-left: 0.5ex;
 	    span {
 		color:#c88b5f;
 	    }
@@ -54,9 +53,8 @@
 	}
     }
     /* only for Contents/Foreword in index.html: */
-    ul.ul-content li::before{
-	@include disc;
-	margin-left: 0;
+    ul.ul-content {
+	@include colored-disc-marker;
     }
     /* table of contents: (manual.001.html): */
     ul.toc ul.toc ul.toc{


### PR DESCRIPTION
Fixes #10671 (extraneous spaces in first `<li>` elements in webman).

This removes a trick for coloring list bullets that disables the normal list decoration and instead inserts colored `●` at the beginning of `<li>` contents. HTML normally ignores whitespace at the beginning of elements and it so happens that many first `<li>` elements in the hevea-generated HTML begin with a newline. Inserting something at the beginning with `::before` seems to break this trimming of leading whitespace.

cc @sanette



