### PR TITLE
Expose descriptions in Warnings module

### DIFF
--- a/Changes
+++ b/Changes
@@ -225,6 +225,9 @@ Working version
 - #10670: avoid global C state in the RE engine for the "str" library
   (Xavier Leroy, review by Gabriel Scherer)
 
+- #10678: Expose descriptions in Warnings module
+  (Leo White, review by Gabriel Scherer and Alain Frisch)
+
 ### Build system:
 
 ### Bug fixes:

--- a/utils/warnings.ml
+++ b/utils/warnings.ml
@@ -190,173 +190,258 @@ let number = function
 let last_warning_number = 70
 ;;
 
-(* Third component of each tuple is the list of names for each warning. The
-   first element of the list is the current name, any following ones are
-   deprecated. The current name should always be derived mechanically from the
-   constructor name. *)
+type description =
+  { number : int;
+    names : string list;
+    (* The first element of the list is the current name, any following ones are
+       deprecated. The current name should always be derived mechanically from
+       the constructor name. *)
+    description : string; }
 
-let descriptions =
-  [
-    1, "Suspicious-looking start-of-comment mark.",
-    ["comment-start"];
-    2, "Suspicious-looking end-of-comment mark.",
-    ["comment-not-end"];
-    3, "Deprecated synonym for the 'deprecated' alert.",
-    [];
-    4, "Fragile pattern matching: matching that will remain complete even\n\
-       \    if additional constructors are added to one of the variant types\n\
-       \    matched.",
-    ["fragile-match"];
-    5, "Partially applied function: expression whose result has function\n\
-       \    type and is ignored.",
-    ["ignored-partial-application"];
-    6, "Label omitted in function application.",
-    ["labels-omitted"];
-    7, "Method overridden.",
-    ["method-override"];
-    8, "Partial match: missing cases in pattern-matching.",
-    ["partial-match"];
-    9, "Missing fields in a record pattern.",
-    ["missing-record-field-pattern"];
-    10,
-    "Expression on the left-hand side of a sequence that doesn't have type\n\
-    \    \"unit\" (and that is not a function, see warning number 5).",
-    ["non-unit-statement"];
-    11, "Redundant case in a pattern matching (unused match case).",
-    ["redundant-case"];
-    12, "Redundant sub-pattern in a pattern-matching.",
-    ["redundant-subpat"];
-    13, "Instance variable overridden.",
-    ["instance-variable-override"];
-    14, "Illegal backslash escape in a string constant.",
-    ["illegal-backslash"];
-    15, "Private method made public implicitly.",
-    ["implicit-public-methods"];
-    16, "Unerasable optional argument.",
-    ["unerasable-optional-argument"];
-    17, "Undeclared virtual method.",
-    ["undeclared-virtual-method"];
-    18, "Non-principal type.",
-    ["not-principal"];
-    19, "Type without principality.",
-    ["non-principal-labels"];
-    20, "Unused function argument.",
-    ["ignored-extra-argument"];
-    21, "Non-returning statement.",
-    ["nonreturning-statement"];
-    22, "Preprocessor warning.",
-    ["preprocessor"];
-    23, "Useless record \"with\" clause.",
-    ["useless-record-with"];
-    24,
-    "Bad module name: the source file name is not a valid OCaml module name.",
-    ["bad-module-name"];
-    25, "Ignored: now part of warning 8.",
-    [];
-    26,
+let descriptions = [
+  { number = 1;
+    names = ["comment-start"];
+    description = "Suspicious-looking start-of-comment mark." };
+  { number = 2;
+    names =  ["comment-not-end"];
+    description = "Suspicious-looking end-of-comment mark." };
+  { number = 3;
+    names = [];
+    description = "Deprecated synonym for the 'deprecated' alert." };
+  { number = 4;
+    names = ["fragile-match"];
+    description =
+      "Fragile pattern matching: matching that will remain complete even\n\
+      \    if additional constructors are added to one of the variant types\n\
+      \    matched." };
+  { number = 5;
+    names = ["ignored-partial-application"];
+    description =
+      "Partially applied function: expression whose result has function\n\
+      \    type and is ignored." };
+  { number = 6;
+    names = ["labels-omitted"];
+    description = "Label omitted in function application." };
+  { number = 7;
+    names = ["method-override"];
+    description = "Method overridden." };
+  { number = 8;
+    names = ["partial-match"];
+    description = "Partial match: missing cases in pattern-matching." };
+  { number = 9;
+    names = ["missing-record-field-pattern"];
+    description = "Missing fields in a record pattern." };
+  { number = 10;
+    names = ["non-unit-statement"];
+    description =
+      "Expression on the left-hand side of a sequence that doesn't have type\n\
+      \    \"unit\" (and that is not a function, see warning number 5)." };
+  { number = 11;
+    names = ["redundant-case"];
+    description =
+      "Redundant case in a pattern matching (unused match case)." };
+  { number = 12;
+    names = ["redundant-subpat"];
+    description = "Redundant sub-pattern in a pattern-matching." };
+  { number = 13;
+    names = ["instance-variable-override"];
+    description = "Instance variable overridden." };
+  { number = 14;
+    names = ["illegal-backslash"];
+    description = "Illegal backslash escape in a string constant." };
+  { number = 15;
+    names = ["implicit-public-methods"];
+    description = "Private method made public implicitly." };
+  { number = 16;
+    names = ["unerasable-optional-argument"];
+    description = "Unerasable optional argument." };
+  { number = 17;
+    names = ["undeclared-virtual-method"];
+    description = "Undeclared virtual method." };
+  { number = 18;
+    names = ["not-principal"];
+    description = "Non-principal type." };
+  { number = 19;
+    names = ["non-principal-labels"];
+    description = "Type without principality." };
+  { number = 20;
+    names = ["ignored-extra-argument"];
+    description = "Unused function argument." };
+  { number = 21;
+    names = ["nonreturning-statement"];
+    description = "Non-returning statement." };
+  { number = 22;
+    names = ["preprocessor"];
+    description = "Preprocessor warning." };
+  { number = 23;
+    names = ["useless-record-with"];
+    description = "Useless record \"with\" clause." };
+  { number = 24;
+    names = ["bad-module-name"];
+    description =
+    "Bad module name: the source file name is not a valid OCaml module name."};
+  { number = 25;
+    names = [];
+    description = "Ignored: now part of warning 8." };
+  { number = 26;
+    names = ["unused-var"];
+    description =
     "Suspicious unused variable: unused variable that is bound\n\
     \    with \"let\" or \"as\", and doesn't start with an underscore (\"_\")\n\
-    \    character.",
-    ["unused-var"];
-    27, "Innocuous unused variable: unused variable that is not bound with\n\
-        \    \"let\" nor \"as\", and doesn't start with an underscore (\"_\")\n\
-        \    character.",
-    ["unused-var-strict"];
-    28, "Wildcard pattern given as argument to a constant constructor.",
-    ["wildcard-arg-to-constant-constr"];
-    29, "Unescaped end-of-line in a string constant (non-portable code).",
-    ["eol-in-string"];
-    30, "Two labels or constructors of the same name are defined in two\n\
-        \    mutually recursive types.",
-    ["duplicate-definitions"];
-    31, "A module is linked twice in the same executable.",
-    ["module-linked-twice"];
-    32, "Unused value declaration.",
-    ["unused-value-declaration"];
-    33, "Unused open statement.",
-    ["unused-open"];
-    34, "Unused type declaration.",
-    ["unused-type-declaration"];
-    35, "Unused for-loop index.",
-    ["unused-for-index"];
-    36, "Unused ancestor variable.",
-    ["unused-ancestor"];
-    37, "Unused constructor.",
-    ["unused-constructor"];
-    38, "Unused extension constructor.",
-    ["unused-extension"];
-    39, "Unused rec flag.",
-    ["unused-rec-flag"];
-    40, "Constructor or label name used out of scope.",
-    ["name-out-of-scope"];
-    41, "Ambiguous constructor or label name.",
-    ["ambiguous-name"];
-    42, "Disambiguated constructor or label name (compatibility warning).",
-    ["disambiguated-name"];
-    43, "Nonoptional label applied as optional.",
-    ["nonoptional-label"];
-    44, "Open statement shadows an already defined identifier.",
-    ["open-shadow-identifier"];
-    45, "Open statement shadows an already defined label or constructor.",
-    ["open-shadow-label-constructor"];
-    46, "Error in environment variable.",
-    ["bad-env-variable"];
-    47, "Illegal attribute payload.",
-    ["attribute-payload"];
-    48, "Implicit elimination of optional arguments.",
-    ["eliminated-optional-arguments"];
-    49, "Absent cmi file when looking up module alias.",
-    ["no-cmi-file"];
-    50, "Unexpected documentation comment.",
-    ["unexpected-docstring"];
-    51, "Function call annotated with an incorrect @tailcall attribute",
-    ["wrong-tailcall-expectation"];
-    52, "Fragile constant pattern.",
-    ["fragile-literal-pattern"];
-    53, "Attribute cannot appear in this context.",
-    ["misplaced-attribute"];
-    54, "Attribute used more than once on an expression.",
-    ["duplicated-attribute"];
-    55, "Inlining impossible.",
-    ["inlining-impossible"];
-    56, "Unreachable case in a pattern-matching (based on type information).",
-    ["unreachable-case"];
-    57, "Ambiguous or-pattern variables under guard.",
-    ["ambiguous-var-in-pattern-guard"];
-    58, "Missing cmx file.",
-    ["no-cmx-file"];
-    59, "Assignment to non-mutable value.",
-    ["flambda-assignment-to-non-mutable-value"];
-    60, "Unused module declaration.",
-    ["unused-module"];
-    61, "Unboxable type in primitive declaration.",
-    ["unboxable-type-in-prim-decl"];
-    62, "Type constraint on GADT type declaration.",
-    ["constraint-on-gadt"];
-    63, "Erroneous printed signature.",
-    ["erroneous-printed-signature"];
-    64, "-unsafe used with a preprocessor returning a syntax tree.",
-    ["unsafe-array-syntax-without-parsing"];
-    65, "Type declaration defining a new '()' constructor.",
-    ["redefining-unit"];
-    66, "Unused open! statement.",
-    ["unused-open-bang"];
-    67, "Unused functor parameter.",
-    ["unused-functor-parameter"];
-    68, "Pattern-matching depending on mutable state prevents the remaining \
-         arguments from being uncurried.",
-    ["match-on-mutable-state-prevent-uncurry"];
-    69, "Unused record field.",
-    ["unused-field"];
-    70, "Missing interface file.",
-    ["missing-mli"]
-  ]
+    \    character." };
+  { number = 27;
+    names = ["unused-var-strict"];
+    description =
+    "Innocuous unused variable: unused variable that is not bound with\n\
+    \    \"let\" nor \"as\", and doesn't start with an underscore (\"_\")\n\
+    \    character." };
+  { number = 28;
+    names = ["wildcard-arg-to-constant-constr"];
+    description =
+      "Wildcard pattern given as argument to a constant constructor." };
+  { number = 29;
+    names = ["eol-in-string"];
+    description =
+      "Unescaped end-of-line in a string constant (non-portable code)." };
+  { number = 30;
+    names = ["duplicate-definitions"];
+    description =
+      "Two labels or constructors of the same name are defined in two\n\
+      \    mutually recursive types." };
+  { number = 31;
+    names = ["module-linked-twice"];
+    description = "A module is linked twice in the same executable." };
+  { number = 32;
+    names = ["unused-value-declaration"];
+    description = "Unused value declaration." };
+  { number = 33;
+    names = ["unused-open"];
+    description = "Unused open statement." };
+  { number = 34;
+    names = ["unused-type-declaration"];
+    description = "Unused type declaration." };
+  { number = 35;
+    names = ["unused-for-index"];
+    description = "Unused for-loop index." };
+  { number = 36;
+    names = ["unused-ancestor"];
+    description = "Unused ancestor variable." };
+  { number = 37;
+    names = ["unused-constructor"];
+    description = "Unused constructor." };
+  { number = 38;
+    names = ["unused-extension"];
+    description = "Unused extension constructor." };
+  { number = 39;
+    names = ["unused-rec-flag"];
+    description = "Unused rec flag." };
+  { number = 40;
+    names = ["name-out-of-scope"];
+    description = "Constructor or label name used out of scope." };
+  { number = 41;
+    names = ["ambiguous-name"];
+    description = "Ambiguous constructor or label name." };
+  { number = 42;
+    names = ["disambiguated-name"];
+    description =
+      "Disambiguated constructor or label name (compatibility warning)." };
+  { number = 43;
+    names = ["nonoptional-label"];
+    description = "Nonoptional label applied as optional." };
+  { number = 44;
+    names = ["open-shadow-identifier"];
+    description = "Open statement shadows an already defined identifier." };
+  { number = 45;
+    names = ["open-shadow-label-constructor"];
+    description =
+      "Open statement shadows an already defined label or constructor." };
+  { number = 46;
+    names = ["bad-env-variable"];
+    description = "Error in environment variable." };
+  { number = 47;
+    names = ["attribute-payload"];
+    description = "Illegal attribute payload." };
+  { number = 48;
+    names = ["eliminated-optional-arguments"];
+    description = "Implicit elimination of optional arguments." };
+  { number = 49;
+    names = ["no-cmi-file"];
+    description = "Absent cmi file when looking up module alias." };
+  { number = 50;
+    names = ["unexpected-docstring"];
+    description = "Unexpected documentation comment." };
+  { number = 51;
+    names = ["wrong-tailcall-expectation"];
+    description =
+      "Function call annotated with an incorrect @tailcall attribute" };
+  { number = 52;
+    names = ["fragile-literal-pattern"];
+    description = "Fragile constant pattern." };
+  { number = 53;
+    names = ["misplaced-attribute"];
+    description = "Attribute cannot appear in this context." };
+  { number = 54;
+    names = ["duplicated-attribute"];
+    description = "Attribute used more than once on an expression." };
+  { number = 55;
+    names = ["inlining-impossible"];
+    description = "Inlining impossible." };
+  { number = 56;
+    names = ["unreachable-case"];
+    description =
+      "Unreachable case in a pattern-matching (based on type information)." };
+  { number = 57;
+    names = ["ambiguous-var-in-pattern-guard"];
+    description = "Ambiguous or-pattern variables under guard." };
+  { number = 58;
+    names = ["no-cmx-file"];
+    description = "Missing cmx file." };
+  { number = 59;
+    names = ["flambda-assignment-to-non-mutable-value"];
+    description = "Assignment to non-mutable value." };
+  { number = 60;
+    names = ["unused-module"];
+    description = "Unused module declaration." };
+  { number = 61;
+    names = ["unboxable-type-in-prim-decl"];
+    description = "Unboxable type in primitive declaration." };
+  { number = 62;
+    names = ["constraint-on-gadt"];
+    description = "Type constraint on GADT type declaration." };
+  { number = 63;
+    names = ["erroneous-printed-signature"];
+    description = "Erroneous printed signature." };
+  { number = 64;
+    names = ["unsafe-array-syntax-without-parsing"];
+    description =
+      "-unsafe used with a preprocessor returning a syntax tree." };
+  { number = 65;
+    names = ["redefining-unit"];
+    description = "Type declaration defining a new '()' constructor." };
+  { number = 66;
+    names = ["unused-open-bang"];
+    description = "Unused open! statement." };
+  { number = 67;
+    names = ["unused-functor-parameter"];
+    description = "Unused functor parameter." };
+  { number = 68;
+    names = ["match-on-mutable-state-prevent-uncurry"];
+    description =
+      "Pattern-matching depending on mutable state prevents the remaining \n\
+      \    arguments from being uncurried." };
+  { number = 69;
+    names = ["unused-field"];
+    description = "Unused record field." };
+  { number = 70;
+    names = ["missing-mli"];
+    description = "Missing interface file." };
+]
 ;;
 
 let name_to_number =
   let h = Hashtbl.create last_warning_number in
-  List.iter (fun (num, _, names) ->
-      List.iter (fun name -> Hashtbl.add h name num) names
+  List.iter (fun {number; names; _} ->
+      List.iter (fun name -> Hashtbl.add h name number) names
     ) descriptions;
   fun s -> Hashtbl.find_opt h s
 ;;
@@ -944,8 +1029,8 @@ type reporting_information =
 
 let id_name w =
   let n = number w in
-  match List.find_opt (fun (m, _, _) -> m = n) descriptions with
-  | Some (_, _, s :: _) ->
+  match List.find_opt (fun {number; _} -> number = n) descriptions with
+  | Some {names = s :: _; _} ->
       Printf.sprintf "%d [%s]" n s
   | _ ->
       string_of_int n
@@ -1006,13 +1091,13 @@ let check_fatal () =
 
 let help_warnings () =
   List.iter
-    (fun (i, s, names) ->
+    (fun {number; description; names} ->
        let name =
          match names with
          | s :: _ -> " [" ^ s ^ "]"
          | [] -> ""
        in
-       Printf.printf "%3i%s %s\n" i name s)
+       Printf.printf "%3i%s %s\n" number name description)
     descriptions;
   print_endline "  A all warnings";
   for i = Char.code 'b' to Char.code 'z' do

--- a/utils/warnings.mli
+++ b/utils/warnings.mli
@@ -152,3 +152,10 @@ val with_state : state -> (unit -> 'a) -> 'a
 val mk_lazy: (unit -> 'a) -> 'a Lazy.t
     (** Like [Lazy.of_fun], but the function is applied with
         the warning/alert settings at the time [mk_lazy] is called. *)
+
+type description =
+  { number : int;
+    names : string list;
+    description : string; }
+
+val descriptions : description list


### PR DESCRIPTION
Expose the list of all warnings in the `Warnings` module so that people can use it from compiler libs. Also changes it from a tuple to a record type so that the meanings of the fields are clear.