### PR TITLE
Fix probing name of the C compiler in configure

### DIFF
--- a/Changes
+++ b/Changes
@@ -255,9 +255,10 @@ Working version
 - #10659: Fix freshening substitutions on imported modules
   (Leo White and Stephen Dolan, review by Matthew Ryan)
 
-- #10679: Fix detection of CC as gcc in configure (allow for triplet-prefixed
-  GCC).
-  (David Allsopp, review by Gabriel Scherer)
+- #10677, #10679: Fix detection of CC as gcc in configure (allow for
+  triplet-prefixed GCC) and fix all C compiler detection when CC is a path
+  rather than a basename.
+  (David Allsopp, report by Fabian @copy, review by Gabriel Scherer)
 
 OCaml 4.13 maintenance branch
 -----------------------------

--- a/Changes
+++ b/Changes
@@ -255,6 +255,10 @@ Working version
 - #10659: Fix freshening substitutions on imported modules
   (Leo White and Stephen Dolan, review by Matthew Ryan)
 
+- #10679: Fix detection of CC as gcc in configure (allow for triplet-prefixed
+  GCC).
+  (David Allsopp, review by Gabriel Scherer)
+
 OCaml 4.13 maintenance branch
 -----------------------------
 

--- a/configure
+++ b/configure
@@ -13183,7 +13183,7 @@ $as_echo "$as_me: WARNING: flexlink not found: shared library support disabled."
      ;;
 esac
 
-case $CC,$host in #(
+case $cc_basename,$host in #(
   *,*-*-darwin*) :
     mkexe="$mkexe -Wl,-no_compact_unwind";
     $as_echo "#define HAS_ARCH_CODE32 1" >>confdefs.h
@@ -14053,7 +14053,7 @@ esac ;; #(
   *-*-linux*|*-*-freebsd[3-9]*|*-*-freebsd[1-9][0-9]*\
     |*-*-openbsd*|*-*-netbsd*|*-*-dragonfly*|*-*-gnu*|*-*-haiku*) :
     sharedlib_cflags="-fPIC"
-       case $CC,$host in #(
+       case $cc_basename,$host in #(
   *gcc*,powerpc-*-linux*) :
     mksharedlib="$CC -shared -mbss-plt \$(LDFLAGS)" ;; #(
   *) :
@@ -14143,7 +14143,7 @@ esac
 fi
 
 # Try to work around the Skylake/Kaby Lake processor bug.
-case "$CC,$host" in #(
+case "$cc_basename,$host" in #(
   *gcc*,x86_64-*|*gcc*,i686-*) :
 
   { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether the C compiler supports -fno-tree-vrp" >&5
@@ -14436,7 +14436,7 @@ else
 fi
 
 if test -z "$PARTIALLD"; then :
-  case "$arch,$CC,$system,$model" in #(
+  case "$arch,$cc_basename,$system,$model" in #(
   amd64,*gcc*,macosx,*) :
     PACKLD_FLAGS=' -arch x86_64' ;; #(
   power,*gcc*,elf,ppc) :
@@ -14452,7 +14452,7 @@ esac
   # output filename. Don't assume that all C compilers understand GNU -ofoo
   # form, so ensure that the definition includes a space at the end (which is
   # achieved using the $(EMPTY) expansion trick).
-   if test x"$CC" = "xcl"; then :
+   if test x"$cc_basename" = "xcl"; then :
   # For the Microsoft C compiler there must be no space at the end of the
     # string.
     PACKLD="link -lib -nologo $machine -out:"
@@ -17453,7 +17453,7 @@ fi
 ## Frame pointers
 
 if test x"$enable_frame_pointers" = "xyes"; then :
-  case "$host,$CC" in #(
+  case "$host,$cc_basename" in #(
   x86_64-*-linux*,gcc*|x86_64-*-linux*,clang*) :
     common_cflags="$common_cflags -g  -fno-omit-frame-pointer"
       frame_pointers=true

--- a/configure
+++ b/configure
@@ -14054,7 +14054,7 @@ esac ;; #(
     |*-*-openbsd*|*-*-netbsd*|*-*-dragonfly*|*-*-gnu*|*-*-haiku*) :
     sharedlib_cflags="-fPIC"
        case $CC,$host in #(
-  gcc*,powerpc-*-linux*) :
+  *gcc*,powerpc-*-linux*) :
     mksharedlib="$CC -shared -mbss-plt \$(LDFLAGS)" ;; #(
   *) :
     mksharedlib="$CC -shared \$(LDFLAGS)" ;;
@@ -14437,13 +14437,13 @@ fi
 
 if test -z "$PARTIALLD"; then :
   case "$arch,$CC,$system,$model" in #(
-  amd64,gcc*,macosx,*) :
+  amd64,*gcc*,macosx,*) :
     PACKLD_FLAGS=' -arch x86_64' ;; #(
-  power,gcc*,elf,ppc) :
+  power,*gcc*,elf,ppc) :
     PACKLD_FLAGS=' -m elf32ppclinux' ;; #(
-  power,gcc*,elf,ppc64) :
+  power,*gcc*,elf,ppc64) :
     PACKLD_FLAGS=' -m elf64ppc' ;; #(
-  power,gcc*,elf,ppc64le) :
+  power,*gcc*,elf,ppc64le) :
     PACKLD_FLAGS=' -m elf64lppc' ;; #(
   *) :
     PACKLD_FLAGS='' ;;

--- a/configure.ac
+++ b/configure.ac
@@ -794,7 +794,7 @@ AS_CASE([$flexdir,$supports_shared_libraries,$flexlink,$host],
   [,*,,*-w64-mingw32|,*,,*-pc-windows],
     [AC_MSG_ERROR([flexlink is required for native Win32])])
 
-AS_CASE([$CC,$host],
+AS_CASE([$cc_basename,$host],
   [*,*-*-darwin*],
     [mkexe="$mkexe -Wl,-no_compact_unwind";
     AC_DEFINE([HAS_ARCH_CODE32], [1])],
@@ -963,7 +963,7 @@ AS_IF([test x"$enable_shared" != "xno"],
     [[*-*-linux*|*-*-freebsd[3-9]*|*-*-freebsd[1-9][0-9]*\
     |*-*-openbsd*|*-*-netbsd*|*-*-dragonfly*|*-*-gnu*|*-*-haiku*]],
       [sharedlib_cflags="-fPIC"
-       AS_CASE([$CC,$host],
+       AS_CASE([$cc_basename,$host],
            [*gcc*,powerpc-*-linux*],
            [mksharedlib="$CC -shared -mbss-plt \$(LDFLAGS)"],
            [mksharedlib="$CC -shared \$(LDFLAGS)"])
@@ -1012,7 +1012,7 @@ AS_IF([test x"$supports_shared_libraries" = 'xtrue'],
     [riscv*-*-linux*], [natdynlink=true])])
 
 # Try to work around the Skylake/Kaby Lake processor bug.
-AS_CASE(["$CC,$host"],
+AS_CASE(["$cc_basename,$host"],
   [*gcc*,x86_64-*|*gcc*,i686-*],
     [OCAML_CC_HAS_FNO_TREE_VRP
     AS_IF([$cc_has_fno_tree_vrp],
@@ -1132,7 +1132,7 @@ AC_DEFINE_UNQUOTED([OCAML_OS_TYPE], ["$ostype"])
 
 AC_CHECK_TOOL([DIRECT_LD],[ld])
 AS_IF([test -z "$PARTIALLD"],
-  [AS_CASE(["$arch,$CC,$system,$model"],
+  [AS_CASE(["$arch,$cc_basename,$system,$model"],
     [amd64,*gcc*,macosx,*], [PACKLD_FLAGS=' -arch x86_64'],
     [power,*gcc*,elf,ppc], [PACKLD_FLAGS=' -m elf32ppclinux'],
     [power,*gcc*,elf,ppc64], [PACKLD_FLAGS=' -m elf64ppc'],
@@ -1142,7 +1142,7 @@ AS_IF([test -z "$PARTIALLD"],
   # output filename. Don't assume that all C compilers understand GNU -ofoo
   # form, so ensure that the definition includes a space at the end (which is
   # achieved using the $(EMPTY) expansion trick).
-   AS_IF([test x"$CC" = "xcl"],
+   AS_IF([test x"$cc_basename" = "xcl"],
     # For the Microsoft C compiler there must be no space at the end of the
     # string.
     [PACKLD="link -lib -nologo $machine -out:"],
@@ -1806,7 +1806,7 @@ AS_IF([$native_compiler],
 ## Frame pointers
 
 AS_IF([test x"$enable_frame_pointers" = "xyes"],
-  [AS_CASE(["$host,$CC"],
+  [AS_CASE(["$host,$cc_basename"],
     [x86_64-*-linux*,gcc*|x86_64-*-linux*,clang*],
       [common_cflags="$common_cflags -g  -fno-omit-frame-pointer"
       frame_pointers=true

--- a/configure.ac
+++ b/configure.ac
@@ -964,7 +964,7 @@ AS_IF([test x"$enable_shared" != "xno"],
     |*-*-openbsd*|*-*-netbsd*|*-*-dragonfly*|*-*-gnu*|*-*-haiku*]],
       [sharedlib_cflags="-fPIC"
        AS_CASE([$CC,$host],
-           [gcc*,powerpc-*-linux*],
+           [*gcc*,powerpc-*-linux*],
            [mksharedlib="$CC -shared -mbss-plt \$(LDFLAGS)"],
            [mksharedlib="$CC -shared \$(LDFLAGS)"])
       oc_ldflags="$oc_ldflags -Wl,-E"
@@ -1133,10 +1133,10 @@ AC_DEFINE_UNQUOTED([OCAML_OS_TYPE], ["$ostype"])
 AC_CHECK_TOOL([DIRECT_LD],[ld])
 AS_IF([test -z "$PARTIALLD"],
   [AS_CASE(["$arch,$CC,$system,$model"],
-    [amd64,gcc*,macosx,*], [PACKLD_FLAGS=' -arch x86_64'],
-    [power,gcc*,elf,ppc], [PACKLD_FLAGS=' -m elf32ppclinux'],
-    [power,gcc*,elf,ppc64], [PACKLD_FLAGS=' -m elf64ppc'],
-    [power,gcc*,elf,ppc64le], [PACKLD_FLAGS=' -m elf64lppc'],
+    [amd64,*gcc*,macosx,*], [PACKLD_FLAGS=' -arch x86_64'],
+    [power,*gcc*,elf,ppc], [PACKLD_FLAGS=' -m elf32ppclinux'],
+    [power,*gcc*,elf,ppc64], [PACKLD_FLAGS=' -m elf64ppc'],
+    [power,*gcc*,elf,ppc64le], [PACKLD_FLAGS=' -m elf64lppc'],
     [PACKLD_FLAGS=''])
   # The string for PACKLD must be capable of being concatenated with the
   # output filename. Don't assume that all C compilers understand GNU -ofoo


### PR DESCRIPTION
Two related, by independent, fixes:
- There are several places where the GCC is detected on the assumption that `CC` is `gcc*` which excludes triplet-prefixed compilers. These instances have been changed `*gcc*`.
- Fix for #10677 - the matching on `$CC` essentially assumed that `CC` would be a basename (possibly with parameters) but only worked in a few places if `CC` is a path by fluke. `LT_INIT` sets up `$cc_basename` which seems the most reliable fix for this (if my reading of `libtool.m4` is correct, I think it even removes flags, `$cc_basename` really is the command which will be run. Note that it's only used is `AS_CASE`/`AS_IF` conditionals - it's _always_ `$CC` which get emitted.