### PR TITLE
Fix an overflow bug in major GC work computation

### DIFF
--- a/Changes
+++ b/Changes
@@ -16,9 +16,9 @@ Working version
   *blit_* function during Mark phase
   (François Bobot, reported by Stephen Dolan, reviewed by Damien Doligez)
 
-- #10195: Speed up GC by prefetching during marking
+- #10195, #10680: Speed up GC by prefetching during marking
   (Stephen Dolan, review by Xavier Leroy, Guillaume Munch-Maccagnoni,
-   Jacques-Henri Jourdan and Damien Doligez)
+   Jacques-Henri Jourdan, Damien Doligez and Leo White)
 
 - #10549: Stack overflow detection and naked pointers checking for ARM64
   (Xavier Leroy, review by Stephen Dolan)

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -647,6 +647,7 @@ Caml_noinline static intnat do_some_marking
 
   while (1) {
     value *scan, *obj_end, *scan_end;
+    intnat scan_len;
 
     if (pb_enqueued > pb_dequeued + min_pb) {
       /* Dequeue from prefetch buffer */
@@ -700,11 +701,13 @@ Caml_noinline static intnat do_some_marking
       obj_end = m.end;
     }
 
-    scan_end = obj_end;
-    work -= obj_end - scan;
-    if (work < 0) {
-      scan_end += work;
+    scan_len = obj_end - scan;
+    if (work < scan_len) {
+      scan_len = work;
+      if (scan_len < 0) scan_len = 0;
     }
+    work -= scan_len;
+    scan_end = scan + scan_len;
 
     for (; scan < scan_end; scan++) {
       value v = *scan;
@@ -716,7 +719,9 @@ Caml_noinline static intnat do_some_marking
         slice_pointers ++;
 #endif
         if (pb_enqueued == pb_dequeued + Pb_size) {
-          break; /* Prefetch buffer is full */
+          /* Prefetch buffer is full */
+          work += scan_end - scan; /* scanning work not done */
+          break;
         }
         prefetch_block(v);
         pb[(pb_enqueued++) & Pb_mask] = v;
@@ -732,7 +737,6 @@ Caml_noinline static intnat do_some_marking
       /* Didn't finish scanning this object, either because work <= 0,
          or the prefetch buffer filled up. Leave the rest on the stack. */
       mark_entry m = { scan, obj_end };
-      work += obj_end - scan;
       caml_prefetch(scan+1);
       if (stk.count == stk.size) {
         *Caml_state->mark_stack = stk;


### PR DESCRIPTION
This is a fix for a GC bug introduced by #10195 caused by an overflow when computing the amount of an object to scan, which causes hard-to-reproduce sporadic segfaults.

The current logic is as follows:
```c
    scan_end = obj_end;
    work -= obj_end - scan;
    if (work < 0) {
      scan_end += work;
    }
```
Here `work` is the amount of marking work left to do. Normally, we scan to the end of the object and decrease `work` by the length scanned. However, if the object to be scanned is longer than the work remaining, we should stop scanning part-way (e.g. to split scanning of a large array over multiple slices).

However, it is possible for `work` to be arbitrarily negative even before we reach this check. Since strings do not need to be scanned, marking an n-word string immediately counts as doing (n+1) words worth of work. So, if the remaining work is 10 words, and we mark a 517 MB string (as happened in an internal Jane Street application), then work will suddenly become approx. -68,000,000. This will cause `scan_end` to be far below `scan`.

Normally, this causes no problems, since the loop on `scan < scan_end` then correctly runs zero times. However, if libc / the kernel happens to place heap memory in the first few MB of address space, then `scan_end += work` underflows to a very large address, `scan < scan_end` becomes true, and the GC starts marking beyond the end of the object.

The fix is to add an additional check for negative work, to ensure that we always have `scan <= scan_end <= obj_end`. (Work being negative is not inherently a problem: negative work is an accurate description of the state where you've done more work than you intended to, which can happen when you find a long string towards the end of marking)

Reproducing this is tricky, as triggering the bug relies on a coincidence of memory addresses, as well as the presence of a very long string. Even when the bug triggers, the page table check often masks the issue, so it is easier to reproduce in no-naked-pointers mode. Depending on your computer's mood, the following program may reproduce the issue:

```ocaml
let[@inline never] f k1 k2 g =
  Gc.full_major ();
  let block = (Bytes.create 100_000_000, k1, k2) in
  for i = 1 to 100000 do ignore (Bytes.create 10_000) done;
  g block

let () =
  for i = 1 to 100 do ignore (Bytes.create 10_000_000); done;
  let a = ref 1 and b = ref 2 in
  Gc.minor ();
  f a b ignore
```