### PR TITLE
Enforce boolean conditions in `Lifthenelse` in native mode

### DIFF
--- a/Changes
+++ b/Changes
@@ -45,6 +45,9 @@ Working version
   are used for passing arguments that do not fit in registers.
   (Xavier Leroy, review by Vincent Laviron)
 
+- #10681: Enforce boolean conditions for the native backend
+  (Vincent Laviron, review by Gabriel Scherer)
+
 ### Standard library:
 
 * #10622: Annotate `Uchar.t` with immediate attribute

--- a/asmcomp/cmm_helpers.ml
+++ b/asmcomp/cmm_helpers.ml
@@ -1517,6 +1517,7 @@ struct
   let make_isout h arg = Cop (Ccmpa Clt, [h ; arg], Debuginfo.none)
   let make_isin h arg = Cop (Ccmpa Cge, [h ; arg], Debuginfo.none)
   let make_is_nonzero arg = arg
+  let arg_as_test arg = arg
   let make_if cond ifso ifnot =
     Cifthenelse (cond, Debuginfo.none, ifso, Debuginfo.none, ifnot,
       Debuginfo.none)

--- a/asmcomp/cmmgen.ml
+++ b/asmcomp/cmmgen.ml
@@ -609,8 +609,16 @@ let rec transl env e =
       let ifso_dbg = Debuginfo.none in
       let ifnot_dbg = Debuginfo.none in
       let dbg = Debuginfo.none in
-      transl_if env Unknown dbg cond
-        ifso_dbg (transl env ifso) ifnot_dbg (transl env ifnot)
+      let ifso = transl env ifso in
+      let ifnot = transl env ifnot in
+      let approx =
+        match ifso, ifnot with
+        | Cconst_int (1, _), Cconst_int (3, _) -> Then_false_else_true
+        | Cconst_int (3, _), Cconst_int (1, _) -> Then_true_else_false
+        | _, _ -> Unknown
+      in
+      transl_if env approx dbg cond
+        ifso_dbg ifso ifnot_dbg ifnot
   | Usequence(exp1, exp2) ->
       Csequence(remove_unit(transl env exp1), transl env exp2)
   | Uwhile(cond, body) ->

--- a/lambda/simplif.ml
+++ b/lambda/simplif.ml
@@ -712,7 +712,9 @@ and list_emit_tail_infos is_tail =
 
 let split_default_wrapper ~id:fun_id ~kind ~params ~return ~body ~attr ~loc =
   let rec aux map = function
-    | Llet(Strict, k, id, (Lifthenelse(Lvar optparam, _, _) as def), rest) when
+    | Llet(Strict, k, id,
+           (Lifthenelse(Lprim (Pisint, [Lvar optparam], _), _, _) as def),
+           rest) when
         Ident.name optparam = "*opt*" && List.mem_assoc optparam params
           && not (List.mem_assoc optparam map)
       ->

--- a/lambda/switch.ml
+++ b/lambda/switch.ml
@@ -126,6 +126,7 @@ sig
   val make_isout : arg -> arg -> test
   val make_isin : arg -> arg -> test
   val make_is_nonzero : arg -> test
+  val arg_as_test : arg -> test
 
   val make_if : test -> act -> act -> act
   val make_switch : loc -> arg -> int array -> act array -> act
@@ -190,6 +191,9 @@ let prerr_inter i = Printf.fprintf stderr
     r
   and get_low cases i =
     let r,_,_ = cases.(i) in
+    r
+  and get_high cases i =
+    let _,r,_ = cases.(i) in
     r
 
   type ctests = {
@@ -578,6 +582,9 @@ let rec pkey chan  = function
   let make_if_nonzero arg ifso ifnot =
     Arg.make_if (Arg.make_is_nonzero arg) ifso ifnot
 
+  let make_if_bool arg ifso ifnot =
+    Arg.make_if (Arg.arg_as_test arg) ifso ifnot
+
   let do_make_if_out h arg ifso ifno =
     Arg.make_if (Arg.make_isout h arg) ifso ifno
 
@@ -667,9 +674,14 @@ let rec pkey chan  = function
           and right = {s with cases=right} in
 
           if i=1 && (lim+ctx.off)=1 && get_low cases 0+ctx.off=0 then
-            make_if_nonzero
-              ctx.arg
-              (c_test ctx right) (c_test ctx left)
+            if lcases = 2 && get_high cases 1+ctx.off = 1 then
+              make_if_bool
+                ctx.arg
+                (c_test ctx right) (c_test ctx left)
+            else
+              make_if_nonzero
+                ctx.arg
+                (c_test ctx right) (c_test ctx left)
           else if less_tests cright cleft then
             make_if_lt
               ctx.arg (lim+ctx.off)

--- a/lambda/switch.mli
+++ b/lambda/switch.mli
@@ -91,6 +91,7 @@ module type S =
     val make_isout : arg -> arg -> test
     val make_isin : arg -> arg -> test
     val make_is_nonzero : arg -> test
+    val arg_as_test : arg -> test
 
     val make_if : test -> act -> act -> act
    (* construct an actual switch :

--- a/lambda/switch.mli
+++ b/lambda/switch.mli
@@ -84,15 +84,32 @@ module type S =
 
     (* Various constructors, for making a binder,
         adding one integer, etc. *)
-    val bind : arg -> (arg -> act) -> act
-    val make_const : int -> arg
-    val make_offset : arg -> int -> arg
-    val make_prim : primitive -> arg list -> test
-    val make_isout : arg -> arg -> test
-    val make_isin : arg -> arg -> test
-    val make_is_nonzero : arg -> test
-    val arg_as_test : arg -> test
 
+    (* [bind arg cont] should bind the expression arg to a variable,
+       then call [cont] on that variable, and return the term made of
+       the binding and the result of the call. *)
+    val bind : arg -> (arg -> act) -> act
+    (* [make_const n] generates a term for the integer constant [n] *)
+    val make_const : int -> arg
+    (* [make_offset arg n] generates a term for adding the constant
+       integer [n] to the term [arg] *)
+    val make_offset : arg -> int -> arg
+    (* [make_prim p args] generates a test using the primitive operation [p]
+       applied to arguments [args] *)
+    val make_prim : primitive -> arg list -> test
+    (* [make_isout h arg] generates a test that holds when [arg] is out of
+       the interval [0, h] *)
+    val make_isout : arg -> arg -> test
+    (* [make_isin h arg] generates a test that holds when [arg] is in
+       the interval [0, h] *)
+    val make_isin : arg -> arg -> test
+    (* [make_is_nonzero arg] generates a test that holds when [arg] is any
+       value except 0 *)
+    val make_is_nonzero : arg -> test
+    (* [arg_as_test arg] casts [arg], known to be either 0 or 1,
+       to a boolean test *)
+    val arg_as_test : arg -> test
+    (* [make_if cond ifso ifnot] generates a conditional branch *)
     val make_if : test -> act -> act -> act
    (* construct an actual switch :
       make_switch arg cases acts


### PR DESCRIPTION
First commit is the implementation, second commit is a patch to `Cmmgen` that profits from it.

~~The patch is slightly different from the one we have in Flambda 2. For matches with only constant constructors, where all constructors except the first one return the same value, this patch always generates `if  arg != 0 then ...` while the Flambda 2 patch has a special case for types with only two constructors (boolean-like) in which case it generates `if arg then ...` directly.~~

~~I'm going to update this PR to bridge that last gap, but because of #10516 the diff for that is going to be bigger than one would expect.~~

EDIT: done in 2a3ba07

