### PR TITLE
Git ignore `/runtime/caml/NUL`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -203,6 +203,7 @@ _build
 /runtime/sak
 /runtime/domain_state32.inc
 /runtime/domain_state64.inc
+/runtime/caml/NUL
 
 /stdlib/camlheader
 /stdlib/target_camlheader


### PR DESCRIPTION
This file is created when compiling OCaml with the mingw-w64 port.
This is the content of the file:

```
        .file   "<stdin>"
        .text
        .ident  "GCC: (GNU) 11.2.0"
```

No change entry needed