### PR TITLE
Constant propagation for Float.sign_bit

### DIFF
--- a/middle_end/closure/closure.ml
+++ b/middle_end/closure/closure.ml
@@ -320,6 +320,8 @@ let simplif_arith_prim_pure ~backend fpc p (args, approxs) dbg =
       | Pintoffloat -> make_const_int (int_of_float n1)
       | Pnegfloat -> make_const_float (-. n1)
       | Pabsfloat -> make_const_float (abs_float n1)
+      | Pccall {prim_native_name = "caml_signbit"; _} ->
+          make_const_bool (Float.sign_bit n1)
       | _ -> default
       end
   (* float, float *)

--- a/middle_end/flambda/simplify_primitives.ml
+++ b/middle_end/flambda/simplify_primitives.ml
@@ -210,6 +210,8 @@ let primitive (p : Clambda_primitives.primitive) (args, approxs)
       | Pintoffloat -> S.const_int_expr expr (int_of_float x)
       | Pnegfloat -> S.const_float_expr expr (-. x)
       | Pabsfloat -> S.const_float_expr expr (abs_float x)
+      | Pccall {prim_native_name = "caml_signbit"; _} ->
+          S.const_bool_expr expr (Float.sign_bit x)
       | _ -> expr, A.value_unknown Other, C.Benefit.zero
       end
     | [Value_float (Some n1); Value_float (Some n2)] when fpc ->


### PR DESCRIPTION
This PR adds constant propagation for `Float.sign_bit`.

On my machine, the following micro-benchmarks becomes 5x faster after this optimization.

````ocaml
let () =
  let r = ref 0. in
  for i = 1 to 1000000000 do
    r := Float.max !r (-1.)
  done
````

(The negative argument to `Float.max` avoids two calls to the C function after `Float.max` is being inlined.)

There are other similar constant propagation that could easily be added (e.g. on `sqrt`, `log`, `exp`, ...).  Is it considered bad style to optimize C primitives (as opposed to %-primitives)?

