### PR TITLE
Build and install ocamltoplevel.cmxa by default

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,7 +55,7 @@ jobs:
         MAKE_ARG=-j make distclean
     - name: configure tree
       run: |
-        MAKE_ARG=-j XARCH=x64 CONFIG_ARG='--enable-flambda --enable-cmm-invariants --enable-dependency-generation' OCAMLRUNPARAM=b,v=0 bash -xe tools/ci/actions/runner.sh configure
+        MAKE_ARG=-j XARCH=x64 CONFIG_ARG='--enable-flambda --enable-cmm-invariants --enable-dependency-generation --enable-native-toplevel' OCAMLRUNPARAM=b,v=0 bash -xe tools/ci/actions/runner.sh configure
     - name: Build
       run: |
         MAKE_ARG=-j OCAMLRUNPARAM=b,v=0 bash -xe tools/ci/actions/runner.sh build

--- a/Changes
+++ b/Changes
@@ -281,8 +281,8 @@ Working version
   rather than a basename.
   (David Allsopp, report by Fabian @copy, review by Gabriel Scherer)
 
-- #10690: Add --enable-native-toplevel to configure to enable building and
-  installing ocamlnat as part of the main build (default is not to)
+- #10690: Add --enable-native-toplevel to configure to enable installing
+  ocamlnat as part of the main build (default is not to install it)
   (David Allsopp, review by Gabriel Scherer)
 
 - #10693: Fix ident collision in includemod

--- a/Changes
+++ b/Changes
@@ -243,6 +243,9 @@ Working version
 - #10678: Expose descriptions in Warnings module
   (Leo White, review by Gabriel Scherer and Alain Frisch)
 
+- #10690: Always build ocamltoplevel.cmxa
+  (David Allsopp, review by Gabriel Scherer)
+
 - #10692: Expose Parse.module_type and Parse.module_expr
   (Guillaume Petiot, review by Gabriel Scherer)
 

--- a/Changes
+++ b/Changes
@@ -281,6 +281,10 @@ Working version
   rather than a basename.
   (David Allsopp, report by Fabian @copy, review by Gabriel Scherer)
 
+- #10690: Add --enable-native-toplevel to configure to enable building and
+  installing ocamlnat as part of the main build (default is not to)
+  (David Allsopp, review by Gabriel Scherer)
+
 - #10693: Fix ident collision in includemod
   (Leo White, review by Matthew Ryan)
 

--- a/Makefile
+++ b/Makefile
@@ -256,10 +256,7 @@ endif
 	$(MAKE) ocamlopt.opt
 	$(MAKE) otherlibrariesopt
 	$(MAKE) ocamllex.opt ocamltoolsopt ocamltoolsopt.opt $(OCAMLDOC_OPT) \
-	  $(OCAMLTEST_OPT) $(ocamlnat_dependencies)
-ifeq "$(INSTALL_OCAMLNAT)" "true"
-	$(MAKE) ocamlnat
-endif
+	  $(OCAMLTEST_OPT) ocamlnat
 ifeq "$(WITH_OCAMLDOC)-$(STDLIB_MANPAGES)" "ocamldoc-true"
 	$(MAKE) manpages
 endif

--- a/Makefile
+++ b/Makefile
@@ -256,7 +256,7 @@ endif
 	$(MAKE) ocamlopt.opt
 	$(MAKE) otherlibrariesopt
 	$(MAKE) ocamllex.opt ocamltoolsopt ocamltoolsopt.opt $(OCAMLDOC_OPT) \
-	  $(OCAMLTEST_OPT)
+	  $(OCAMLTEST_OPT) $(ocamlnat_dependencies)
 ifeq "$(WITH_OCAMLDOC)-$(STDLIB_MANPAGES)" "ocamldoc-true"
 	$(MAKE) manpages
 endif
@@ -566,6 +566,7 @@ ifeq "$(BOOTSTRAPPING_FLEXDLL)" "true"
 endif
 	$(INSTALL_DATA) \
 	   utils/*.cmx parsing/*.cmx typing/*.cmx bytecomp/*.cmx \
+	   toplevel/*.cmx toplevel/native/*.cmx \
 	   file_formats/*.cmx \
 	   lambda/*.cmx \
 	   driver/*.cmx asmcomp/*.cmx middle_end/*.cmx \
@@ -579,14 +580,10 @@ endif
 	$(INSTALL_DATA) \
 	   $(BYTESTART:.cmo=.cmx) $(BYTESTART:.cmo=.$(O)) \
 	   $(OPTSTART:.cmo=.cmx) $(OPTSTART:.cmo=.$(O)) \
+	   $(TOPLEVELSTART:.cmo=.$(O)) \
 	   "$(INSTALL_COMPLIBDIR)"
 	if test -f ocamlnat$(EXE) ; then \
 	  $(INSTALL_PROG) ocamlnat$(EXE) "$(INSTALL_BINDIR)"; \
-	  $(INSTALL_DATA) \
-	     toplevel/*.cmx \
-	     toplevel/native/*.cmx \
-	     $(TOPLEVELSTART:.cmo=.$(O)) \
-	     "$(INSTALL_COMPLIBDIR)"; \
 	fi
 	cd "$(INSTALL_COMPLIBDIR)" && \
 	   $(RANLIB) ocamlcommon.$(A) ocamlbytecomp.$(A) ocamloptcomp.$(A)
@@ -1074,13 +1071,16 @@ endif
 
 # The native toplevel
 
-ocamlnat$(EXE): compilerlibs/ocamlcommon.cmxa compilerlibs/ocamloptcomp.cmxa \
-    compilerlibs/ocamlbytecomp.cmxa \
-    otherlibs/dynlink/dynlink.cmxa \
-    compilerlibs/ocamltoplevel.cmxa \
-    $(TOPLEVELSTART:.cmo=.cmx)
-	$(CAMLOPT_CMD) $(LINKFLAGS) -linkall -I toplevel/native -o $@ $^
+ocamlnat_dependencies := \
+  compilerlibs/ocamlcommon.cmxa \
+  compilerlibs/ocamloptcomp.cmxa \
+  compilerlibs/ocamlbytecomp.cmxa \
+  otherlibs/dynlink/dynlink.cmxa \
+  compilerlibs/ocamltoplevel.cmxa \
+  $(TOPLEVELSTART:.cmo=.cmx)
 
+ocamlnat$(EXE): $(ocamlnat_dependencies)
+	$(CAMLOPT_CMD) $(LINKFLAGS) -linkall -I toplevel/native -o $@ $^
 
 toplevel/topdirs.cmx: toplevel/topdirs.ml
 	$(CAMLOPT_CMD) $(COMPFLAGS) $(OPTCOMPFLAGS) -I toplevel/native -c $<

--- a/Makefile
+++ b/Makefile
@@ -257,6 +257,9 @@ endif
 	$(MAKE) otherlibrariesopt
 	$(MAKE) ocamllex.opt ocamltoolsopt ocamltoolsopt.opt $(OCAMLDOC_OPT) \
 	  $(OCAMLTEST_OPT) $(ocamlnat_dependencies)
+ifeq "$(INSTALL_OCAMLNAT)" "true"
+	$(MAKE) ocamlnat
+endif
 ifeq "$(WITH_OCAMLDOC)-$(STDLIB_MANPAGES)" "ocamldoc-true"
 	$(MAKE) manpages
 endif
@@ -582,9 +585,9 @@ endif
 	   $(OPTSTART:.cmo=.cmx) $(OPTSTART:.cmo=.$(O)) \
 	   $(TOPLEVELSTART:.cmo=.$(O)) \
 	   "$(INSTALL_COMPLIBDIR)"
-	if test -f ocamlnat$(EXE) ; then \
-	  $(INSTALL_PROG) ocamlnat$(EXE) "$(INSTALL_BINDIR)"; \
-	fi
+ifeq "$(INSTALL_OCAMLNAT)" "true"
+	  $(INSTALL_PROG) ocamlnat$(EXE) "$(INSTALL_BINDIR)"
+endif
 	cd "$(INSTALL_COMPLIBDIR)" && \
 	   $(RANLIB) ocamlcommon.$(A) ocamlbytecomp.$(A) ocamloptcomp.$(A)
 

--- a/Makefile.build_config.in
+++ b/Makefile.build_config.in
@@ -24,6 +24,9 @@ INSTALL ?= @INSTALL@
 INSTALL_DATA ?= @INSTALL_DATA@
 INSTALL_PROG ?= @INSTALL_PROGRAM@
 
+# Whether to install the native toplevel (ocamlnat)
+INSTALL_OCAMLNAT = @install_ocamlnat@
+
 # The command to generate C dependency information
 DEP_CC=@DEP_CC@ -MM
 COMPUTE_DEPS=@compute_deps@

--- a/configure
+++ b/configure
@@ -766,6 +766,7 @@ flambda
 frame_pointers
 profinfo_width
 profinfo
+install_ocamlnat
 install_source_artifacts
 install_bytecode_programs
 mksharedlibrpath
@@ -900,6 +901,7 @@ enable_bigarray_lib
 enable_ocamldoc
 with_odoc
 enable_ocamltest
+enable_native_toplevel
 enable_frame_pointers
 enable_naked_pointers
 enable_naked_pointers_checker
@@ -1573,6 +1575,8 @@ Optional Features:
   --disable-bigarray-lib  do not build the legacy separate bigarray library
   --disable-ocamldoc      do not build the ocamldoc documentation system
   --disable-ocamltest     do not build the ocamltest driver
+  --enable-native-toplevel
+                          build the native toplevel
   --enable-frame-pointers use frame pointers in runtime and generated code
   --disable-naked-pointers
                           do not allow naked pointers
@@ -2966,6 +2970,7 @@ OCAML_VERSION_SHORT=4.14
 
 
 
+
 ## Generated files
 
 ac_config_files="$ac_config_files Makefile.build_config"
@@ -3234,6 +3239,12 @@ fi
 # Check whether --enable-ocamltest was given.
 if test "${enable_ocamltest+set}" = set; then :
   enableval=$enable_ocamltest;
+fi
+
+
+# Check whether --enable-native-toplevel was given.
+if test "${enable_native_toplevel+set}" = set; then :
+  enableval=$enable_native_toplevel;
 fi
 
 
@@ -14184,6 +14195,15 @@ if test x"$supports_shared_libraries" = 'xtrue'; then :
      ;;
 esac
 fi
+
+case $enable_native_toplevel,$natdynlink in #(
+  yes,false) :
+    as_fn_error $? "The native toplevel requires native dynlink support" "$LINENO" 5 ;; #(
+  yes,*) :
+    install_ocamlnat=true ;; #(
+  *) :
+    install_ocamlnat=false ;;
+esac
 
 # Try to work around the Skylake/Kaby Lake processor bug.
 case "$cc_basename,$host" in #(

--- a/configure.ac
+++ b/configure.ac
@@ -158,6 +158,7 @@ AC_SUBST([mkmaindll])
 AC_SUBST([mksharedlibrpath])
 AC_SUBST([install_bytecode_programs])
 AC_SUBST([install_source_artifacts])
+AC_SUBST([install_ocamlnat])
 AC_SUBST([profinfo])
 AC_SUBST([profinfo_width])
 AC_SUBST([frame_pointers])
@@ -298,6 +299,10 @@ AC_ARG_WITH([odoc],
 AC_ARG_ENABLE([ocamltest],
   [AS_HELP_STRING([--disable-ocamltest],
     [do not build the ocamltest driver])])
+
+AC_ARG_ENABLE([native-toplevel],
+  [AS_HELP_STRING([--enable-native-toplevel],
+    [build the native toplevel])])
 
 AC_ARG_ENABLE([frame-pointers],
   [AS_HELP_STRING([--enable-frame-pointers],
@@ -1030,6 +1035,14 @@ AS_IF([test x"$supports_shared_libraries" = 'xtrue'],
     [aarch64-*-linux*], [natdynlink=true],
     [aarch64-*-freebsd*], [natdynlink=true],
     [riscv*-*-linux*], [natdynlink=true])])
+
+AS_CASE([$enable_native_toplevel,$natdynlink],
+  [yes,false],
+    [AC_MSG_ERROR(m4_normalize([
+      The native toplevel requires native dynlink support]))],
+  [yes,*],
+    [install_ocamlnat=true],
+    [install_ocamlnat=false])
 
 # Try to work around the Skylake/Kaby Lake processor bug.
 AS_CASE(["$cc_basename,$host"],

--- a/tools/ci/actions/runner.sh
+++ b/tools/ci/actions/runner.sh
@@ -66,7 +66,6 @@ EOF
 
 Build () {
   script --return --command "$MAKE_WARN world.opt" build.log
-  script --return --append --command "$MAKE_WARN ocamlnat" build.log
   echo Ensuring that all names are prefixed in the runtime
   ./tools/check-symbol-names runtime/*.a
 }


### PR DESCRIPTION
This PR tweaks the compilation of the `world.opt`/`opt.opt` target so that the native toplevel library is _always_ built if natdynlink is available.

However, `ocamlnat` itself remains unlinked by default, although I've taken this opportunity to add `--enable-native-toplevel` to `configure` which provides an explicit mechanism for enabling and installing `ocamlnat`

Building `ocamltoplevel.cmxa` by default is a prerequisite for the ocaml JIT work; cc @NathanReb, @mshinwell