### PR TITLE
Introduce `fallthrough` as a wrapper around the fallthrough attribute

### DIFF
--- a/Changes
+++ b/Changes
@@ -58,6 +58,13 @@ _______________
   Now these tables will go in the readonly segment, where they belong.
   (Antonin Décimo, review by David Allsopp)
 
+- #10696: Introduce __has_attribute and __has_c_attributes in
+  <caml/misc.h> to test the support of specific atributes in C
+  code. Introduce fallthrough as a wrapper around the fallthrough
+  attribute.
+  (Antonin Décimo, review by Nicolás Ojeda Bär, Xavier Leroy, and
+   Gabriel Scherer)
+
 ### Code generation and optimizations:
 
 - #13014: Enable compile-time option -function-sections on all previously

--- a/configure
+++ b/configure
@@ -13967,6 +13967,50 @@ else $as_nop
 fi
 
 
+# Use -Wimplicit-fallthrough if supported
+for flag in '-Wimplicit-fallthrough=5' '-Wimplicit-fallthrough'; do
+  as_CACHEVAR=`printf "%s\n" "ax_cv_check_cflags_$warn_error_flag_$flag" | $as_tr_sh`
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether the C compiler accepts $flag" >&5
+printf %s "checking whether the C compiler accepts $flag... " >&6; }
+if eval test \${$as_CACHEVAR+y}
+then :
+  printf %s "(cached) " >&6
+else $as_nop
+
+  ax_check_save_flags=$CFLAGS
+  CFLAGS="$CFLAGS $warn_error_flag $flag"
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+int
+main (void)
+{
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_compile "$LINENO"
+then :
+  eval "$as_CACHEVAR=yes"
+else $as_nop
+  eval "$as_CACHEVAR=no"
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
+  CFLAGS=$ax_check_save_flags
+fi
+eval ac_res=\$$as_CACHEVAR
+	       { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+printf "%s\n" "$ac_res" >&6; }
+if eval test \"x\$"$as_CACHEVAR"\" = x"yes"
+then :
+  cc_warnings="$cc_warnings $flag"; break
+else $as_nop
+  :
+fi
+
+done
+
 case $enable_warn_error,true in #(
   yes,*|,true) :
     cc_warnings="$cc_warnings $warn_error_flag" ;; #(

--- a/configure.ac
+++ b/configure.ac
@@ -819,6 +819,12 @@ AX_CHECK_COMPILE_FLAG([-Wold-style-declaration],
   [cc_warnings="$cc_warnings -Wold-style-declaration"], [],
   [$warn_error_flag])
 
+# Use -Wimplicit-fallthrough if supported
+for flag in '-Wimplicit-fallthrough=5' '-Wimplicit-fallthrough'; do
+  AX_CHECK_COMPILE_FLAG([$flag],
+    [cc_warnings="$cc_warnings $flag"; break], [], [$warn_error_flag])
+done
+
 AS_CASE([$enable_warn_error,OCAML__DEVELOPMENT_VERSION],
   [yes,*|,true],
     [cc_warnings="$cc_warnings $warn_error_flag"])

--- a/runtime/bigarray.c
+++ b/runtime/bigarray.c
@@ -300,7 +300,7 @@ CAMLexport void caml_ba_finalize(value v)
     break;
   case CAML_BA_MAPPED_FILE:
     /* Bigarrays for mapped files use a different finalization method */
-    /* fallthrough */
+    fallthrough;
   default:
     CAMLassert(0);
   }
@@ -361,11 +361,11 @@ CAMLexport int caml_ba_compare(value v1, value v2)
   case CAML_BA_FLOAT16:
     DO_GENERIC_UNORDERED_COMPARISON(uint16, float, caml_float16_to_float);
   case CAML_BA_COMPLEX32:
-    num_elts *= 2; /*fallthrough*/
+    num_elts *= 2; fallthrough;
   case CAML_BA_FLOAT32:
     DO_FLOAT_COMPARISON(float);
   case CAML_BA_COMPLEX64:
-    num_elts *= 2; /*fallthrough*/
+    num_elts *= 2; fallthrough;
   case CAML_BA_FLOAT64:
     DO_FLOAT_COMPARISON(double);
   case CAML_BA_CHAR:
@@ -418,8 +418,8 @@ CAMLexport intnat caml_ba_hash(value v)
     }
     w = 0;
     switch (num_elts & 3) {
-    case 3: w  = p[2] << 16;    /* fallthrough */
-    case 2: w |= p[1] << 8;     /* fallthrough */
+    case 3: w  = p[2] << 16; fallthrough;
+    case 2: w |= p[1] << 8;  fallthrough;
     case 1: w |= p[0];
             h = caml_hash_mix_uint32(h, w);
     }
@@ -467,7 +467,8 @@ CAMLexport intnat caml_ba_hash(value v)
     break;
   }
   case CAML_BA_COMPLEX32:
-    num_elts *= 2;              /* fallthrough */
+    num_elts *= 2;
+    fallthrough;
   case CAML_BA_FLOAT32:
   {
     float * p = b->data;
@@ -476,7 +477,8 @@ CAMLexport intnat caml_ba_hash(value v)
     break;
   }
   case CAML_BA_COMPLEX64:
-    num_elts *= 2;              /* fallthrough */
+    num_elts *= 2;
+    fallthrough;
   case CAML_BA_FLOAT64:
   {
     double * p = b->data;
@@ -727,8 +729,6 @@ value caml_ba_get_N(value vb, volatile value * vind, int nind)
   offset = caml_ba_offset(b, index);
   /* Perform read */
   switch ((b->flags) & CAML_BA_KIND_MASK) {
-  default:
-    CAMLassert(0);
   case CAML_BA_FLOAT16:
     return caml_copy_double(
       (double) caml_float16_to_float(((uint16 *) b->data)[offset]));
@@ -760,6 +760,9 @@ value caml_ba_get_N(value vb, volatile value * vind, int nind)
       return copy_two_doubles(p[0], p[1]); }
   case CAML_BA_CHAR:
     return Val_int(((unsigned char *) b->data)[offset]);
+  default:
+    CAMLassert(0);
+    return Val_int(0);
   }
 }
 
@@ -872,8 +875,6 @@ static value caml_ba_set_aux(value vb, volatile value * vind,
   offset = caml_ba_offset(b, index);
   /* Perform write */
   switch (b->flags & CAML_BA_KIND_MASK) {
-  default:
-    CAMLassert(0);
   case CAML_BA_FLOAT16:
     ((uint16 *) b->data)[offset] =
       caml_float_to_float16(Double_val(newval)); break;
@@ -906,6 +907,8 @@ static value caml_ba_set_aux(value vb, volatile value * vind,
       p[0] = Double_flat_field(newval, 0);
       p[1] = Double_flat_field(newval, 1);
       break; }
+  default:
+    CAMLassert(0);
   }
   return Val_unit;
 }
@@ -1288,8 +1291,6 @@ CAMLprim value caml_ba_fill(value vb, value vinit)
   intnat num_elts = caml_ba_num_elts(b);
 
   switch (b->flags & CAML_BA_KIND_MASK) {
-  default:
-    CAMLassert(0);
   case CAML_BA_FLOAT16: {
     uint16 init = caml_float_to_float16(Double_val(vinit));
     uint16 * p;
@@ -1361,6 +1362,8 @@ CAMLprim value caml_ba_fill(value vb, value vinit)
     FILL_COMPLEX_LOOP;
     break;
   }
+  default:
+    CAMLassert(0);
   }
   CAMLreturn (Val_unit);
 }

--- a/runtime/caml/misc.h
+++ b/runtime/caml/misc.h
@@ -204,6 +204,17 @@ CAMLdeprecated_typedef(addr, char *);
   #define CAMLunused
 #endif
 
+#ifdef CAML_INTERNALS
+#if (defined(__cplusplus) && __cplusplus >= 201703L) || \
+    __has_c_attribute(fallthrough)
+  #define fallthrough [[fallthrough]]
+#elif __has_attribute(fallthrough)
+  #define fallthrough __attribute__ ((fallthrough))
+#else
+  #define fallthrough ((void) 0)
+#endif
+#endif /* CAML_INTERNALS */
+
 /* GC timing hooks. These can be assigned by the user. These hooks
    must not allocate, change any heap value, nor call OCaml code. They
    can obtain the domain id with Caml_state->id. These functions must

--- a/runtime/caml/misc.h
+++ b/runtime/caml/misc.h
@@ -29,6 +29,16 @@
 
 #include "camlatomic.h"
 
+/* Detection of available C attributes */
+
+#ifndef __has_c_attribute
+#define __has_c_attribute(x) 0
+#endif
+
+#ifndef __has_attribute
+#define __has_attribute(x) 0
+#endif
+
 /* Deprecation warnings */
 
 #if defined(__GNUC__) || defined(__clang__)

--- a/runtime/compare.c
+++ b/runtime/compare.c
@@ -160,7 +160,7 @@ static intnat do_compare_val(struct compare_stack* stk,
             if (res != 0) return res;
             goto next_item;
           }
-          default: /*fallthrough*/;
+          default: break;
           }
 
         return LESS;                /* v1 long < v2 block */
@@ -181,7 +181,7 @@ static intnat do_compare_val(struct compare_stack* stk,
             if (res != 0) return res;
             goto next_item;
           }
-          default: /*fallthrough*/;
+          default: break;
           }
         return GREATER;            /* v1 block > v2 long */
       }

--- a/runtime/debugger.c
+++ b/runtime/debugger.c
@@ -569,7 +569,7 @@ void caml_debugger(enum event_kind event, value param)
     case REQ_INITIAL_FRAME:
       frame_block = Caml_state->current_stack;
       frame = frame_block->sp + 1;
-      /* Fall through */
+      fallthrough;
     case REQ_GET_FRAME:
       caml_putword(dbg_out, frame_block_number (frame_block));
       caml_putword(dbg_out, Stack_high(frame_block) - frame);

--- a/runtime/globroots.c
+++ b/runtime/globroots.c
@@ -118,6 +118,7 @@ CAMLexport void caml_remove_generational_global_root(value *r)
       caml_delete_global_root(&caml_global_roots_old, r);
       /* Fallthrough: the root can be in the young list while actually
          being in the major heap. */
+      fallthrough;
     case YOUNG:
       caml_delete_global_root(&caml_global_roots_young, r);
       break;

--- a/runtime/hash.c
+++ b/runtime/hash.c
@@ -163,10 +163,10 @@ CAMLexport uint32_t caml_hash_mix_string(uint32_t h, value s)
   /* Finish with up to 3 bytes */
   w = 0;
   switch (len & 3) {
-  case 3: w  = Byte_u(s, i+2) << 16;   /* fallthrough */
-  case 2: w |= Byte_u(s, i+1) << 8;    /* fallthrough */
+  case 3: w  = Byte_u(s, i+2) << 16; fallthrough;
+  case 2: w |= Byte_u(s, i+1) << 8;  fallthrough;
   case 1: w |= Byte_u(s, i);
-          MIX(h, w);
+          MIX(h, w);                 fallthrough;
   default: /*skip*/;     /* len & 3 == 0, no extra bytes, do nothing */
   }
   /* Finally, mix in the length.  Ignore the upper 32 bits, generally 0. */

--- a/runtime/instrtrace.c
+++ b/runtime/instrtrace.c
@@ -92,7 +92,7 @@ void caml_disasm_instr(code_t pc)
     /* Instructions with a C primitive as operand */
   case C_CALLN:
     snprintf(buf, sizeof(buf), "%s %d,", opbuf, pc[0]); pc++;
-    /* fallthrough */
+    fallthrough;
   case C_CALL1: case C_CALL2: case C_CALL3: case C_CALL4: case C_CALL5:
     if (pc[0] < 0 || pc[0] >= caml_prim_name_table.size)
       snprintf(buf, sizeof(buf), "%s unknown primitive %d\n", opbuf, pc[0]);

--- a/runtime/interp.c
+++ b/runtime/interp.c
@@ -64,9 +64,11 @@ sp is a local copy of the global variable Caml_state->extern_sp. */
 #  else
 #    define Next goto *(void *)(jumptbl_base + *pc++)
 #  endif
+#  define Fallthrough ((void) 0)
 #else
 #  define Instruct(name) case name
 #  define Next break
+#  define Fallthrough fallthrough
 #endif
 
 /* GC interface */
@@ -418,7 +420,7 @@ value caml_interprete(code_t prog, asize_t prog_size)
 
     Instruct(PUSHACC):
       *--sp = accu;
-      /* Fallthrough */
+      Fallthrough;
     Instruct(ACC):
       accu = sp[*pc++];
       Next;
@@ -453,7 +455,7 @@ value caml_interprete(code_t prog, asize_t prog_size)
 
     Instruct(PUSHENVACC):
       *--sp = accu;
-      /* Fallthrough */
+      Fallthrough;
     Instruct(ENVACC):
       accu = Field(env, *pc++);
       Next;
@@ -698,20 +700,20 @@ value caml_interprete(code_t prog, asize_t prog_size)
     }
 
     Instruct(PUSHOFFSETCLOSURE):
-      *--sp = accu; /* fallthrough */
+      *--sp = accu; Fallthrough;
     Instruct(OFFSETCLOSURE):
       accu = env + *pc++ * sizeof(value); Next;
 
     Instruct(PUSHOFFSETCLOSUREM3):
-      *--sp = accu; /* fallthrough */
+      *--sp = accu; Fallthrough;
     Instruct(OFFSETCLOSUREM3):
       accu = env - 3 * sizeof(value); Next;
     Instruct(PUSHOFFSETCLOSURE0):
-      *--sp = accu; /* fallthrough */
+      *--sp = accu; Fallthrough;
     Instruct(OFFSETCLOSURE0):
       accu = env; Next;
     Instruct(PUSHOFFSETCLOSURE3):
-      *--sp = accu; /* fallthrough */
+      *--sp = accu; Fallthrough;
     Instruct(OFFSETCLOSURE3):
       accu = env + 3 * sizeof(value); Next;
 
@@ -720,7 +722,7 @@ value caml_interprete(code_t prog, asize_t prog_size)
 
     Instruct(PUSHGETGLOBAL):
       *--sp = accu;
-      /* Fallthrough */
+      Fallthrough;
     Instruct(GETGLOBAL):
       accu = Field(caml_global_data, *pc);
       pc++;
@@ -728,7 +730,7 @@ value caml_interprete(code_t prog, asize_t prog_size)
 
     Instruct(PUSHGETGLOBALFIELD):
       *--sp = accu;
-      /* Fallthrough */
+      Fallthrough;
     Instruct(GETGLOBALFIELD): {
       accu = Field(caml_global_data, *pc);
       pc++;
@@ -748,13 +750,13 @@ value caml_interprete(code_t prog, asize_t prog_size)
 
     Instruct(PUSHATOM0):
       *--sp = accu;
-      /* Fallthrough */
+      Fallthrough;
     Instruct(ATOM0):
       accu = Atom(0); Next;
 
     Instruct(PUSHATOM):
       *--sp = accu;
-      /* Fallthrough */
+      Fallthrough;
     Instruct(ATOM):
       accu = Atom(*pc++); Next;
 
@@ -1021,7 +1023,7 @@ value caml_interprete(code_t prog, asize_t prog_size)
         }
         sp = domain_state->current_stack->sp;
       }
-      /* Fall through CHECK_SIGNALS */
+      Fallthrough; /* CHECK_SIGNALS */
 
 /* Signal handling */
 
@@ -1105,7 +1107,7 @@ value caml_interprete(code_t prog, asize_t prog_size)
 
     Instruct(PUSHCONSTINT):
       *--sp = accu;
-      /* Fallthrough */
+      Fallthrough;
     Instruct(CONSTINT):
       accu = Val_int(*pc);
       pc++;
@@ -1242,7 +1244,7 @@ value caml_interprete(code_t prog, asize_t prog_size)
       *--sp = accu;
       accu = Val_int(*pc);
       pc += 2;
-      /* Fallthrough */
+      Fallthrough;
 #endif
     Instruct(GETDYNMET): {
       /* accu == tag, sp[0] == object, *pc == cache */

--- a/yacc/reader.c
+++ b/yacc/reader.c
@@ -524,7 +524,7 @@ nextc(void)
                 s = cptr;
                 break;
             }
-            /* fall through */
+            fallthrough;
 
         default:
             cptr = s;
@@ -646,7 +646,7 @@ loop:
             FREE(t_line);
             return;
         }
-        /* fall through */
+        fallthrough;
 
     case '{':
         putc(c, f);


### PR DESCRIPTION
Recent compilers have introduced the `-Wimplicit-fallthrough` warning
against the C switch fallthrough. OCaml already uses the `/* fallthrough */`
 C comment that GCC 7 and above recognize for some level
given to the warning, but the fallthrough statement is also available
since C++17 and either as a language statement (expected in C2X) or as
a compiler/language attribute.

This commit makes use of the statement/attribute when available, or
falls back to the fallthrough comment, and uses the new
`CAMLfallthrough` macro wherever the comment was used.