### PR TITLE
Fix cast of more strictly aligned pointer

### DIFF
--- a/Changes
+++ b/Changes
@@ -288,6 +288,10 @@ Working version
 - #10693: Fix ident collision in includemod
   (Leo White, review by Matthew Ryan)
 
+- #10702: Fix cast of more strictly aligned pointer in win32unix
+  implementation of stat
+  (Antonin Décimo, review by David Allsopp)
+
 OCaml 4.13 maintenance branch
 -----------------------------
 

--- a/otherlibs/win32unix/stat.c
+++ b/otherlibs/win32unix/stat.c
@@ -228,15 +228,17 @@ static int safe_do_stat(int do_lstat, int use_64, wchar_t* path, HANDLE fstat, _
        *      reparse point allows a POSIX-compatible value to be returned in
        *      st_size
        */
-      char buffer[16384];
       DWORD read;
-      REPARSE_DATA_BUFFER* point;
+      union {
+        char raw[16384];
+        REPARSE_DATA_BUFFER point;
+      } buffer;
 
       caml_enter_blocking_section();
-      if (DeviceIoControl(h, FSCTL_GET_REPARSE_POINT, NULL, 0, buffer, 16384, &read, NULL)) {
-        if (((REPARSE_DATA_BUFFER*)buffer)->ReparseTag == IO_REPARSE_TAG_SYMLINK) {
+      if (DeviceIoControl(h, FSCTL_GET_REPARSE_POINT, NULL, 0, &buffer.point, sizeof(buffer.raw), &read, NULL)) {
+        if (buffer.point.ReparseTag == IO_REPARSE_TAG_SYMLINK) {
           is_symlink = do_lstat;
-          res->st_size = ((REPARSE_DATA_BUFFER*)buffer)->SymbolicLinkReparseBuffer.SubstituteNameLength / 2;
+          res->st_size = buffer.point.SymbolicLinkReparseBuffer.SubstituteNameLength / 2;
         }
       }
       caml_leave_blocking_section();


### PR DESCRIPTION
The `char buffer[]` is cast to `REPARSE_DATA_BUFFER*` but the latter is
more strictly aligned. The point variable was also unused. The
`REPARSE_DATA_BUFFER` struct has a flexible array member (pre-C99
style), so we replace them with the classic idiom of an anonymous
union composed of a backing char buffer for storage, and a value
of the targeted type for alignment.

No change entry needed.