### PR TITLE
Disable the commit message Changes escape hatch

### DIFF
--- a/tools/ci/actions/check-changes-modified.sh
+++ b/tools/ci/actions/check-changes-modified.sh
@@ -18,7 +18,6 @@ set -e
 # Hygiene Checks: check that Changes has been updated in PRs
 # One of the following must be true:
 #   - A commit in the PR alters the Changes file
-#   - A commit in the PR contains a line like 'No change needed' ($REGEX below)
 #   - The no-change-entry-needed label is applied to the PR (handled in YAML)
 
 # We need all the commits in the PR to be available
@@ -29,13 +28,8 @@ COMMIT_RANGE="$MERGE_BASE..$PR_HEAD"
 
 # Check if Changes has been updated in the PR
 if git diff "$COMMIT_RANGE" --name-only --exit-code Changes > /dev/null; then
-  # Check if any commit messages include something like No Changes entry needed
-  REGEX='[Nn]o [Cc]hange.* needed'
-  if [[ -n $(git log --grep="$REGEX" --max-count=1 "$COMMIT_RANGE") ]]; then
-    echo -e "$MSG: \e[33mSKIPPED\e[0m (owing to commit message)"
-  else
-    echo -e "$MSG: \e[31mNO\e[0m"
-    cat <<"EOF"
+  echo -e "$MSG: \e[31mNO\e[0m"
+  cat <<"EOF"
 ------------------------------------------------------------------------
 Most contributions should come with a message in the Changes file, as
 described in our contributor documentation:
@@ -44,13 +38,10 @@ described in our contributor documentation:
 
 Some very minor changes (typo fixes for example) may not need
 a Changes entry. In this case, you may explicitly disable this test by
-adding the code word "No change entry needed" (on a single line) to
-a commit message of the PR, or using the "no-change-entry-needed" label
-on the github pull request.
+using the "no-change-entry-needed" label on the github pull request.
 ------------------------------------------------------------------------
 EOF
-    exit 1
-  fi
+  exit 1
 else
   echo -e "$MSG: \e[32mYES\e[0m"
 fi


### PR DESCRIPTION
I've never particularly been a fan of the "No change needed" scanning in commit messages - partly because it's not relevant to anyone who ever reads the commit message after merging and partly because the label requires someone with triage/commit rights to have confirmed the decision. There've been a few instances of the commit message escape hatch being used by the author, but the reviewer disagreeing (and we have also had a grumble of a relevant change not being included in Changes, so there are people who care!).

I propose we remove the escape hatch - the GitHub Actions workflow separates Hygiene from the Build (unlike Travis did) and also automatically retriggers when the label is applied or removed (which Travis didn't; Travis was also unreliable at detecting the label, which GHA is not).