### PR TITLE
Wrong unmarshaling of function pointers in debugger mode

### DIFF
--- a/Changes
+++ b/Changes
@@ -259,6 +259,11 @@ Working version
 
 ### Bug fixes:
 
+- #9214, #10709: Wrong unmarshaling of function pointers in debugger mode.
+  This was causing ocamldebug to crash when running some user-defined printers.
+  (Xavier Leroy, report by Rehan Malak, review by Gabriel Scherer and
+   Vincent Laviron)
+
 - #10473: Add CFI directives to RISC-V runtime and asmcomp.
   This allows stacktraces to work in gdb through C and OCaml calls.
   (Edwin Török, review by Nicolás Ojeda Bär and Xavier Leroy)
@@ -297,6 +302,8 @@ Working version
 - #10702: Fix cast of more strictly aligned pointer in win32unix
   implementation of stat
   (Antonin Décimo, review by David Allsopp)
+
+
 
 OCaml 4.13 maintenance branch
 -----------------------------

--- a/debugger/main.ml
+++ b/debugger/main.ml
@@ -197,7 +197,7 @@ let speclist = [
    ]
 
 let function_placeholder () =
-  raise Not_found
+  failwith "custom printer tried to invoke a function from the debuggee"
 
 let report report_error error =
   eprintf "Debugger [version %s] environment error:@ @[@;%a@]@.;"

--- a/runtime/intern.c
+++ b/runtime/intern.c
@@ -511,7 +511,8 @@ static void intern_rec(value *dest)
           const value * function_placeholder =
             caml_named_value ("Debugger.function_placeholder");
           if (function_placeholder != NULL) {
-            v = *function_placeholder;
+            /* Use the code pointer from the "placeholder" function */
+            v = Field(*function_placeholder, 0);
           } else {
             intern_cleanup();
             intern_bad_code_pointer(digest);

--- a/runtime/intern.c
+++ b/runtime/intern.c
@@ -512,7 +512,7 @@ static void intern_rec(value *dest)
             caml_named_value ("Debugger.function_placeholder");
           if (function_placeholder != NULL) {
             /* Use the code pointer from the "placeholder" function */
-            v = Field(*function_placeholder, 0);
+            v = (value) Code_val(*function_placeholder);
           } else {
             intern_cleanup();
             intern_bad_code_pointer(digest);


### PR DESCRIPTION
In debugger mode, function closures sent by the debuggee have their code pointer modified so that it points to the `function_placeholder` code in debugger/main.ml.  The idea is that the non-closure parts of the value sent by the debuggee can still be inspected and printed, but if a custom printer invokes the closure, `function_placeholder` is called and raises an exception.

However, this has never worked because this modification was performed incorrectly: the whole closure for `function_placeholder` was used as the code pointer for the unmarshalled closure.  This PR fixes this error by using the code pointer from `function_placeholder` is used as code pointer for the unmarshaled closure.
    
Fixes: #9214
