### PR TITLE
Add UTF codec and validations support to the Stdlib

### DIFF
--- a/Changes
+++ b/Changes
@@ -50,6 +50,11 @@ Working version
 
 ### Standard library:
 
+* #10710: Add UTF tools, codecs and validations to the Uchar, Bytes and
+  String modules.
+  (Daniel Bünzli, review by Florian Angeletti, Nicolás Ojeda Bär, Alain
+   Frisch and Gabriel Scherer)
+
 * #10622: Annotate `Uchar.t` with immediate attribute
   (Hongbo Zhang, reivew by Gabriel Scherer and Nicolás Ojeda Bär)
 

--- a/stdlib/.depend
+++ b/stdlib/.depend
@@ -702,6 +702,7 @@ stdlib__String.cmx : string.ml \
     stdlib__Bytes.cmx \
     stdlib__String.cmi
 stdlib__String.cmi : string.mli \
+    stdlib__Uchar.cmi \
     stdlib__Seq.cmi
 stdlib__StringLabels.cmo : stringLabels.ml \
     stdlib__String.cmi \
@@ -710,6 +711,7 @@ stdlib__StringLabels.cmx : stringLabels.ml \
     stdlib__String.cmx \
     stdlib__StringLabels.cmi
 stdlib__StringLabels.cmi : stringLabels.mli \
+    stdlib__Uchar.cmi \
     stdlib__Seq.cmi
 stdlib__Sys.cmo : sys.ml \
     stdlib__Sys.cmi

--- a/stdlib/.depend
+++ b/stdlib/.depend
@@ -79,6 +79,7 @@ stdlib__Buffer.cmi : buffer.mli \
     stdlib__Uchar.cmi \
     stdlib__Seq.cmi
 stdlib__Bytes.cmo : bytes.ml \
+    stdlib__Uchar.cmi \
     stdlib__Sys.cmi \
     stdlib.cmi \
     stdlib__Seq.cmi \
@@ -86,6 +87,7 @@ stdlib__Bytes.cmo : bytes.ml \
     stdlib__Char.cmi \
     stdlib__Bytes.cmi
 stdlib__Bytes.cmx : bytes.ml \
+    stdlib__Uchar.cmx \
     stdlib__Sys.cmx \
     stdlib.cmx \
     stdlib__Seq.cmx \
@@ -93,6 +95,7 @@ stdlib__Bytes.cmx : bytes.ml \
     stdlib__Char.cmx \
     stdlib__Bytes.cmi
 stdlib__Bytes.cmi : bytes.mli \
+    stdlib__Uchar.cmi \
     stdlib__Seq.cmi
 stdlib__BytesLabels.cmo : bytesLabels.ml \
     stdlib__Bytes.cmi \
@@ -101,6 +104,7 @@ stdlib__BytesLabels.cmx : bytesLabels.ml \
     stdlib__Bytes.cmx \
     stdlib__BytesLabels.cmi
 stdlib__BytesLabels.cmi : bytesLabels.mli \
+    stdlib__Uchar.cmi \
     stdlib__Seq.cmi
 stdlib__Callback.cmo : callback.ml \
     stdlib__Obj.cmi \

--- a/stdlib/bytes.ml
+++ b/stdlib/bytes.ml
@@ -436,10 +436,16 @@ let of_seq i =
 
 (* The get_ functions are all duplicated in string.ml *)
 
+external unsafe_get_uint8 : bytes -> int -> int = "%bytes_unsafe_get"
+external unsafe_get_uint16_ne : bytes -> int -> int = "%caml_bytes_get16u"
 external get_uint8 : bytes -> int -> int = "%bytes_safe_get"
 external get_uint16_ne : bytes -> int -> int = "%caml_bytes_get16"
 external get_int32_ne : bytes -> int -> int32 = "%caml_bytes_get32"
 external get_int64_ne : bytes -> int -> int64 = "%caml_bytes_get64"
+
+external unsafe_set_uint8 : bytes -> int -> int -> unit = "%bytes_unsafe_set"
+external unsafe_set_uint16_ne : bytes -> int -> int -> unit
+                              = "%caml_bytes_set16u"
 external set_int8 : bytes -> int -> int -> unit = "%bytes_safe_set"
 external set_int16_ne : bytes -> int -> int -> unit = "%caml_bytes_set16"
 external set_int32_ne : bytes -> int -> int32 -> unit = "%caml_bytes_set32"
@@ -447,6 +453,16 @@ external set_int64_ne : bytes -> int -> int64 -> unit = "%caml_bytes_set64"
 external swap16 : int -> int = "%bswap16"
 external swap32 : int32 -> int32 = "%bswap_int32"
 external swap64 : int64 -> int64 = "%bswap_int64"
+
+let unsafe_get_uint16_le b i =
+  if Sys.big_endian
+  then swap16 (unsafe_get_uint16_ne b i)
+  else unsafe_get_uint16_ne b i
+
+let unsafe_get_uint16_be b i =
+  if Sys.big_endian
+  then unsafe_get_uint16_ne b i
+  else swap16 (unsafe_get_uint16_ne b i)
 
 let get_int8 b i =
   ((get_uint8 b i) lsl (Sys.int_size - 8)) asr (Sys.int_size - 8)
@@ -484,6 +500,16 @@ let get_int64_be b i =
   if not Sys.big_endian then swap64 (get_int64_ne b i)
   else get_int64_ne b i
 
+let unsafe_set_uint16_le b i x =
+  if Sys.big_endian
+  then unsafe_set_uint16_ne b i (swap16 x)
+  else unsafe_set_uint16_ne b i x
+
+let unsafe_set_uint16_be b i x =
+  if Sys.big_endian
+  then unsafe_set_uint16_ne b i x else
+  unsafe_set_uint16_ne b i (swap16 x)
+
 let set_int16_le b i x =
   if Sys.big_endian then set_int16_ne b i (swap16 x)
   else set_int16_ne b i x
@@ -512,3 +538,299 @@ let set_uint8 = set_int8
 let set_uint16_ne = set_int16_ne
 let set_uint16_be = set_int16_be
 let set_uint16_le = set_int16_le
+
+(* UTF codecs and validations *)
+
+let dec_invalid = Uchar.utf_decode_invalid
+let[@inline] dec_ret n u = Uchar.utf_decode n (Uchar.unsafe_of_int u)
+
+(* In case of decoding error, if we error on the first byte, we
+   consume the byte, otherwise we consume the [n] bytes preceeding
+   the erroring byte.
+
+   This means that if a client uses decodes without caring about
+   validity it naturally replace bogus data with Uchar.rep according
+   to the WHATWG Encoding standard. Other schemes are possible by
+   consulting the number of used bytes on invalid decodes. For more
+   details see https://hsivonen.fi/broken-utf-8/
+
+   For this reason in [get_utf_8_uchar] we gradually check the next
+   byte is available rather than doing it immediately after the
+   first byte. Contrast with [is_valid_utf_8]. *)
+
+(* UTF-8 *)
+
+let[@inline] not_in_x80_to_xBF b = b lsr 6 <> 0b10
+let[@inline] not_in_xA0_to_xBF b = b lsr 5 <> 0b101
+let[@inline] not_in_x80_to_x9F b = b lsr 5 <> 0b100
+let[@inline] not_in_x90_to_xBF b = b < 0x90 || 0xBF < b
+let[@inline] not_in_x80_to_x8F b = b lsr 4 <> 0x8
+
+let[@inline] utf_8_uchar_2 b0 b1 =
+  ((b0 land 0x1F) lsl 6) lor
+  ((b1 land 0x3F))
+
+let[@inline] utf_8_uchar_3 b0 b1 b2 =
+  ((b0 land 0x0F) lsl 12) lor
+  ((b1 land 0x3F) lsl 6) lor
+  ((b2 land 0x3F))
+
+let[@inline] utf_8_uchar_4 b0 b1 b2 b3 =
+  ((b0 land 0x07) lsl 18) lor
+  ((b1 land 0x3F) lsl 12) lor
+  ((b2 land 0x3F) lsl 6) lor
+  ((b3 land 0x3F))
+
+let get_utf_8_uchar b i =
+  let b0 = get_uint8 b i in (* raises if [i] is not a valid index. *)
+  let get = unsafe_get_uint8 in
+  let max = length b - 1 in
+  match Char.unsafe_chr b0 with (* See The Unicode Standard, Table 3.7 *)
+  | '\x00' .. '\x7F' -> dec_ret 1 b0
+  | '\xC2' .. '\xDF' ->
+      let i = i + 1 in if i > max then dec_invalid 1 else
+      let b1 = get b i in if not_in_x80_to_xBF b1 then dec_invalid 1 else
+      dec_ret 2 (utf_8_uchar_2 b0 b1)
+  | '\xE0' ->
+      let i = i + 1 in if i > max then dec_invalid 1 else
+      let b1 = get b i in if not_in_xA0_to_xBF b1 then dec_invalid 1 else
+      let i = i + 1 in if i > max then dec_invalid 2 else
+      let b2 = get b i in if not_in_x80_to_xBF b2 then dec_invalid 2 else
+      dec_ret 3 (utf_8_uchar_3 b0 b1 b2)
+  | '\xE1' .. '\xEC' | '\xEE' .. '\xEF' ->
+      let i = i + 1 in if i > max then dec_invalid 1 else
+      let b1 = get b i in if not_in_x80_to_xBF b1 then dec_invalid 1 else
+      let i = i + 1 in if i > max then dec_invalid 2 else
+      let b2 = get b i in if not_in_x80_to_xBF b2 then dec_invalid 2 else
+      dec_ret 3 (utf_8_uchar_3 b0 b1 b2)
+  | '\xED' ->
+      let i = i + 1 in if i > max then dec_invalid 1 else
+      let b1 = get b i in if not_in_x80_to_x9F b1 then dec_invalid 1 else
+      let i = i + 1 in if i > max then dec_invalid 2 else
+      let b2 = get b i in if not_in_x80_to_xBF b2 then dec_invalid 2 else
+      dec_ret 3 (utf_8_uchar_3 b0 b1 b2)
+  | '\xF0' ->
+      let i = i + 1 in if i > max then dec_invalid 1 else
+      let b1 = get b i in if not_in_x90_to_xBF b1 then dec_invalid 1 else
+      let i = i + 1 in if i > max then dec_invalid 2 else
+      let b2 = get b i in if not_in_x80_to_xBF b2 then dec_invalid 2 else
+      let i = i + 1 in if i > max then dec_invalid 3 else
+      let b3 = get b i in if not_in_x80_to_xBF b3 then dec_invalid 3 else
+      dec_ret 4 (utf_8_uchar_4 b0 b1 b2 b3)
+  | '\xF1' .. '\xF3' ->
+      let i = i + 1 in if i > max then dec_invalid 1 else
+      let b1 = get b i in if not_in_x80_to_xBF b1 then dec_invalid 1 else
+      let i = i + 1 in if i > max then dec_invalid 2 else
+      let b2 = get b i in if not_in_x80_to_xBF b2 then dec_invalid 2 else
+      let i = i + 1 in if i > max then dec_invalid 3 else
+      let b3 = get b i in if not_in_x80_to_xBF b3 then dec_invalid 3 else
+      dec_ret 4 (utf_8_uchar_4 b0 b1 b2 b3)
+  | '\xF4' ->
+      let i = i + 1 in if i > max then dec_invalid 1 else
+      let b1 = get b i in if not_in_x80_to_x8F b1 then dec_invalid 1 else
+      let i = i + 1 in if i > max then dec_invalid 2 else
+      let b2 = get b i in if not_in_x80_to_xBF b2 then dec_invalid 2 else
+      let i = i + 1 in if i > max then dec_invalid 3 else
+      let b3 = get b i in if not_in_x80_to_xBF b3 then dec_invalid 3 else
+      dec_ret 4 (utf_8_uchar_4 b0 b1 b2 b3)
+  | _ -> dec_invalid 1
+
+let set_utf_8_uchar b i u =
+  let set = unsafe_set_uint8 in
+  let max = length b - 1 in
+  match Uchar.to_int u with
+  | u when u < 0 -> assert false
+  | u when u <= 0x007F ->
+      set_uint8 b i u;
+      1
+  | u when u <= 0x07FF ->
+      let last = i + 1 in
+      if last > max then 0 else
+      (set_uint8 b i (0xC0 lor (u lsr 6));
+       set b last (0x80 lor (u land 0x3F));
+       2)
+  | u when u <= 0xFFFF ->
+      let last = i + 2 in
+      if last > max then 0 else
+      (set_uint8 b i (0xE0 lor (u lsr 12));
+       set b (i + 1) (0x80 lor ((u lsr 6) land 0x3F));
+       set b last (0x80 lor (u land 0x3F));
+       3)
+  | u when u <= 0x10FFFF ->
+      let last = i + 3 in
+      if last > max then 0 else
+      (set_uint8 b i (0xF0 lor (u lsr 18));
+       set b (i + 1) (0x80 lor ((u lsr 12) land 0x3F));
+       set b (i + 2) (0x80 lor ((u lsr 6) land 0x3F));
+       set b last (0x80 lor (u land 0x3F));
+       4)
+  | _ -> assert false
+
+let is_valid_utf_8 b =
+  let rec loop max b i =
+    if i > max then true else
+    let get = unsafe_get_uint8 in
+    match Char.unsafe_chr (get b i) with
+    | '\x00' .. '\x7F' -> loop max b (i + 1)
+    | '\xC2' .. '\xDF' ->
+        let last = i + 1 in
+        if last > max
+        || not_in_x80_to_xBF (get b last)
+        then false
+        else loop max b (last + 1)
+    | '\xE0' ->
+        let last = i + 2 in
+        if last > max
+        || not_in_xA0_to_xBF (get b (i + 1))
+        || not_in_x80_to_xBF (get b last)
+        then false
+        else loop max b (last + 1)
+    | '\xE1' .. '\xEC' | '\xEE' .. '\xEF' ->
+        let last = i + 2 in
+        if last > max
+        || not_in_x80_to_xBF (get b (i + 1))
+        || not_in_x80_to_xBF (get b last)
+        then false
+        else loop max b (last + 1)
+    | '\xED' ->
+        let last = i + 2 in
+        if last > max
+        || not_in_x80_to_x9F (get b (i + 1))
+        || not_in_x80_to_xBF (get b last)
+        then false
+        else loop max b (last + 1)
+    | '\xF0' ->
+        let last = i + 3 in
+        if last > max
+        || not_in_x90_to_xBF (get b (i + 1))
+        || not_in_x80_to_xBF (get b (i + 2))
+        || not_in_x80_to_xBF (get b last)
+        then false
+        else loop max b (last + 1)
+    | '\xF1' .. '\xF3' ->
+        let last = i + 3 in
+        if last > max
+        || not_in_x80_to_xBF (get b (i + 1))
+        || not_in_x80_to_xBF (get b (i + 2))
+        || not_in_x80_to_xBF (get b last)
+        then false
+        else loop max b (last + 1)
+    | '\xF4' ->
+        let last = i + 3 in
+        if last > max
+        || not_in_x80_to_x8F (get b (i + 1))
+        || not_in_x80_to_xBF (get b (i + 2))
+        || not_in_x80_to_xBF (get b last)
+        then false
+        else loop max b (last + 1)
+    | _ -> false
+  in
+  loop (length b - 1) b 0
+
+(* UTF-16BE *)
+
+let get_utf_16be_uchar b i =
+  let get = unsafe_get_uint16_be in
+  let max = length b - 1 in
+  if i < 0 || i > max then invalid_arg "index out of bounds" else
+  if i = max then dec_invalid 1 else
+  match get b i with
+  | u when u < 0xD800 || u > 0xDFFF -> dec_ret 2 u
+  | u when u > 0xDBFF -> dec_invalid 2
+  | hi -> (* combine [hi] with a low surrogate *)
+      let last = i + 3 in
+      if last > max then dec_invalid (max - i + 1) else
+      match get b (i + 2) with
+      | u when u < 0xDC00 || u > 0xDFFF -> dec_invalid 2 (* retry here *)
+      | lo ->
+          let u = (((hi land 0x3FF) lsl 10) lor (lo land 0x3FF)) + 0x10000 in
+          dec_ret 4 u
+
+let set_utf_16be_uchar b i u =
+  let set = unsafe_set_uint16_be in
+  let max = length b - 1 in
+  if i < 0 || i > max then invalid_arg "index out of bounds" else
+  match Uchar.to_int u with
+  | u when u < 0 -> assert false
+  | u when u <= 0xFFFF ->
+      let last = i + 1 in
+      if last > max then 0 else (set b i u; 2)
+  | u when u <= 0x10FFFF ->
+      let last = i + 3 in
+      if last > max then 0 else
+      let u' = u - 0x10000 in
+      let hi = (0xD800 lor (u' lsr 10)) in
+      let lo = (0xDC00 lor (u' land 0x3FF)) in
+      set b i hi; set b (i + 2) lo; 4
+  | _ -> assert false
+
+let is_valid_utf_16be b =
+  let rec loop max b i =
+    let get = unsafe_get_uint16_be in
+    if i > max then true else
+    if i = max then false else
+    match get b i with
+    | u when u < 0xD800 || u > 0xDFFF -> loop max b (i + 2)
+    | u when u > 0xDBFF -> false
+    | _hi ->
+        let last = i + 3 in
+        if last > max then false else
+        match get b (i + 2) with
+        | u when u < 0xDC00 || u > 0xDFFF -> false
+        | _lo -> loop max b (i + 4)
+  in
+  loop (length b - 1) b 0
+
+(* UTF-16LE *)
+
+let get_utf_16le_uchar b i =
+  let get = unsafe_get_uint16_le in
+  let max = length b - 1 in
+  if i < 0 || i > max then invalid_arg "index out of bounds" else
+  if i = max then dec_invalid 1 else
+  match get b i with
+  | u when u < 0xD800 || u > 0xDFFF -> dec_ret 2 u
+  | u when u > 0xDBFF -> dec_invalid 2
+  | hi -> (* combine [hi] with a low surrogate *)
+      let last = i + 3 in
+      if last > max then dec_invalid (max - i + 1) else
+      match get b (i + 2) with
+      | u when u < 0xDC00 || u > 0xDFFF -> dec_invalid 2 (* retry here *)
+      | lo ->
+          let u = (((hi land 0x3FF) lsl 10) lor (lo land 0x3FF)) + 0x10000 in
+          dec_ret 4 u
+
+let set_utf_16le_uchar b i u =
+  let set = unsafe_set_uint16_le in
+  let max = length b - 1 in
+  if i < 0 || i > max then invalid_arg "index out of bounds" else
+  match Uchar.to_int u with
+  | u when u < 0 -> assert false
+  | u when u <= 0xFFFF ->
+      let last = i + 1 in
+      if last > max then 0 else (set b i u; 2)
+  | u when u <= 0x10FFFF ->
+      let last = i + 3 in
+      if last > max then 0 else
+      let u' = u - 0x10000 in
+      let hi = (0xD800 lor (u' lsr 10)) in
+      let lo = (0xDC00 lor (u' land 0x3FF)) in
+      set b i hi; set b (i + 2) lo; 4
+  | _ -> assert false
+
+let is_valid_utf_16le b =
+  let rec loop max b i =
+    let get = unsafe_get_uint16_le in
+    if i > max then true else
+    if i = max then false else
+    match get b i with
+    | u when u < 0xD800 || u > 0xDFFF -> loop max b (i + 2)
+    | u when u > 0xDBFF -> false
+    | _hi ->
+        let last = i + 3 in
+        if last > max then false else
+        match get b (i + 2) with
+        | u when u < 0xDC00 || u > 0xDFFF -> false
+        | _lo -> loop max b (i + 4)
+  in
+  loop (length b - 1) b 0

--- a/stdlib/bytes.mli
+++ b/stdlib/bytes.mli
@@ -517,6 +517,61 @@ val of_seq : char Seq.t -> t
 (** Create a string from the generator
     @since 4.07 *)
 
+(** {1:utf UTF codecs and validations}
+
+    @since 4.14 *)
+
+(** {2:utf_8 UTF-8} *)
+
+val get_utf_8_uchar : t -> int -> Uchar.utf_decode
+(** [get_utf_8_uchar b i] decodes an UTF-8 character at index [i] in
+    [b]. *)
+
+val set_utf_8_uchar : t -> int -> Uchar.t -> int
+(** [set_utf_8_uchar b i u] UTF-8 encodes [u] at index [i] in [b]
+    and returns the number of bytes [n] that were written starting
+    at [i]. If [n] is [0] there was not enough space to encode [u]
+    at [i] and [b] was left untouched. Otherwise a new character can
+    be encoded at [i + n]. *)
+
+val is_valid_utf_8 : t -> bool
+(** [is_valid_utf_8 b] is [true] if and only if [b] contains valid
+    UTF-8 data. *)
+
+(** {2:utf_16be UTF-16BE} *)
+
+val get_utf_16be_uchar : t -> int -> Uchar.utf_decode
+(** [get_utf_16be_uchar b i] decodes an UTF-16BE character at index
+    [i] in [b]. *)
+
+val set_utf_16be_uchar : t -> int -> Uchar.t -> int
+(** [set_utf_16be_uchar b i u] UTF-16BE encodes [u] at index [i] in [b]
+    and returns the number of bytes [n] that were written starting
+    at [i]. If [n] is [0] there was not enough space to encode [u]
+    at [i] and [b] was left untouched. Otherwise a new character can
+    be encoded at [i + n]. *)
+
+val is_valid_utf_16be : t -> bool
+(** [is_valid_utf_16be b] is [true] if and only if [b] contains valid
+    UTF-16BE data. *)
+
+(** {2:utf_16le UTF-16LE} *)
+
+val get_utf_16le_uchar : t -> int -> Uchar.utf_decode
+(** [get_utf_16le_uchar b i] decodes an UTF-16LE character at index
+    [i] in [b]. *)
+
+val set_utf_16le_uchar : t -> int -> Uchar.t -> int
+(** [set_utf_16le_uchar b i u] UTF-16LE encodes [u] at index [i] in [b]
+    and returns the number of bytes [n] that were written starting
+    at [i]. If [n] is [0] there was not enough space to encode [u]
+    at [i] and [b] was left untouched. Otherwise a new character can
+    be encoded at [i + n]. *)
+
+val is_valid_utf_16le : t -> bool
+(** [is_valid_utf_16le b] is [true] if and only if [b] contains valid
+    UTF-16LE data. *)
+
 (** {1 Binary encoding/decoding of integers} *)
 
 (** The functions in this section binary encode and decode integers to

--- a/stdlib/bytesLabels.mli
+++ b/stdlib/bytesLabels.mli
@@ -517,6 +517,61 @@ val of_seq : char Seq.t -> t
 (** Create a string from the generator
     @since 4.07 *)
 
+(** {1:utf UTF codecs and validations}
+
+    @since 4.14 *)
+
+(** {2:utf_8 UTF-8} *)
+
+val get_utf_8_uchar : t -> int -> Uchar.utf_decode
+(** [get_utf_8_uchar b i] decodes an UTF-8 character at index [i] in
+    [b]. *)
+
+val set_utf_8_uchar : t -> int -> Uchar.t -> int
+(** [set_utf_8_uchar b i u] UTF-8 encodes [u] at index [i] in [b]
+    and returns the number of bytes [n] that were written starting
+    at [i]. If [n] is [0] there was not enough space to encode [u]
+    at [i] and [b] was left untouched. Otherwise a new character can
+    be encoded at [i + n]. *)
+
+val is_valid_utf_8 : t -> bool
+(** [is_valid_utf_8 b] is [true] if and only if [b] contains valid
+    UTF-8 data. *)
+
+(** {2:utf_16be UTF-16BE} *)
+
+val get_utf_16be_uchar : t -> int -> Uchar.utf_decode
+(** [get_utf_16be_uchar b i] decodes an UTF-16BE character at index
+    [i] in [b]. *)
+
+val set_utf_16be_uchar : t -> int -> Uchar.t -> int
+(** [set_utf_16be_uchar b i u] UTF-16BE encodes [u] at index [i] in [b]
+    and returns the number of bytes [n] that were written starting
+    at [i]. If [n] is [0] there was not enough space to encode [u]
+    at [i] and [b] was left untouched. Otherwise a new character can
+    be encoded at [i + n]. *)
+
+val is_valid_utf_16be : t -> bool
+(** [is_valid_utf_16be b] is [true] if and only if [b] contains valid
+    UTF-16BE data. *)
+
+(** {2:utf_16le UTF-16LE} *)
+
+val get_utf_16le_uchar : t -> int -> Uchar.utf_decode
+(** [get_utf_16le_uchar b i] decodes an UTF-16LE character at index
+    [i] in [b]. *)
+
+val set_utf_16le_uchar : t -> int -> Uchar.t -> int
+(** [set_utf_16le_uchar b i u] UTF-16LE encodes [u] at index [i] in [b]
+    and returns the number of bytes [n] that were written starting
+    at [i]. If [n] is [0] there was not enough space to encode [u]
+    at [i] and [b] was left untouched. Otherwise a new character can
+    be encoded at [i + n]. *)
+
+val is_valid_utf_16le : t -> bool
+(** [is_valid_utf_16le b] is [true] if and only if [b] contains valid
+    UTF-16LE data. *)
+
 (** {1 Binary encoding/decoding of integers} *)
 
 (** The functions in this section binary encode and decode integers to

--- a/stdlib/string.ml
+++ b/stdlib/string.ml
@@ -267,6 +267,17 @@ let to_seqi s = bos s |> B.to_seqi
 
 let of_seq g = B.of_seq g |> bts
 
+(* UTF decoders and validators *)
+
+let get_utf_8_uchar s i = B.get_utf_8_uchar (bos s) i
+let is_valid_utf_8 s = B.is_valid_utf_8 (bos s)
+
+let get_utf_16be_uchar s i = B.get_utf_16be_uchar (bos s) i
+let is_valid_utf_16be s = B.is_valid_utf_16be (bos s)
+
+let get_utf_16le_uchar s i = B.get_utf_16le_uchar (bos s) i
+let is_valid_utf_16le s = B.is_valid_utf_16le (bos s)
+
 (** {6 Binary encoding/decoding of integers} *)
 
 external get_uint8 : string -> int -> int = "%string_safe_get"

--- a/stdlib/string.mli
+++ b/stdlib/string.mli
@@ -364,6 +364,40 @@ val of_seq : char Seq.t -> t
 
     @since 4.07 *)
 
+(** {1:utf UTF decoding and validations}
+
+    @since 4.14 *)
+
+(** {2:utf_8 UTF-8} *)
+
+val get_utf_8_uchar : t -> int -> Uchar.utf_decode
+(** [get_utf_8_uchar b i] decodes an UTF-8 character at index [i] in
+    [b]. *)
+
+val is_valid_utf_8 : t -> bool
+(** [is_valid_utf_8 b] is [true] if and only if [b] contains valid
+    UTF-8 data. *)
+
+(** {2:utf_16be UTF-16BE} *)
+
+val get_utf_16be_uchar : t -> int -> Uchar.utf_decode
+(** [get_utf_16be_uchar b i] decodes an UTF-16BE character at index
+    [i] in [b]. *)
+
+val is_valid_utf_16be : t -> bool
+(** [is_valid_utf_16be b] is [true] if and only if [b] contains valid
+    UTF-16BE data. *)
+
+(** {2:utf_16le UTF-16LE} *)
+
+val get_utf_16le_uchar : t -> int -> Uchar.utf_decode
+(** [get_utf_16le_uchar b i] decodes an UTF-16LE character at index
+    [i] in [b]. *)
+
+val is_valid_utf_16le : t -> bool
+(** [is_valid_utf_16le b] is [true] if and only if [b] contains valid
+    UTF-16LE data. *)
+
 (** {1:deprecated Deprecated functions} *)
 
 external create : int -> bytes = "caml_create_string"

--- a/stdlib/stringLabels.mli
+++ b/stdlib/stringLabels.mli
@@ -364,6 +364,40 @@ val of_seq : char Seq.t -> t
 
     @since 4.07 *)
 
+(** {1:utf UTF decoding and validations}
+
+    @since 4.14 *)
+
+(** {2:utf_8 UTF-8} *)
+
+val get_utf_8_uchar : t -> int -> Uchar.utf_decode
+(** [get_utf_8_uchar b i] decodes an UTF-8 character at index [i] in
+    [b]. *)
+
+val is_valid_utf_8 : t -> bool
+(** [is_valid_utf_8 b] is [true] if and only if [b] contains valid
+    UTF-8 data. *)
+
+(** {2:utf_16be UTF-16BE} *)
+
+val get_utf_16be_uchar : t -> int -> Uchar.utf_decode
+(** [get_utf_16be_uchar b i] decodes an UTF-16BE character at index
+    [i] in [b]. *)
+
+val is_valid_utf_16be : t -> bool
+(** [is_valid_utf_16be b] is [true] if and only if [b] contains valid
+    UTF-16BE data. *)
+
+(** {2:utf_16le UTF-16LE} *)
+
+val get_utf_16le_uchar : t -> int -> Uchar.utf_decode
+(** [get_utf_16le_uchar b i] decodes an UTF-16LE character at index
+    [i] in [b]. *)
+
+val is_valid_utf_16le : t -> bool
+(** [is_valid_utf_16le b] is [true] if and only if [b] contains valid
+    UTF-16LE data. *)
+
 (** {1:deprecated Deprecated functions} *)
 
 external create : int -> bytes = "caml_create_string"

--- a/stdlib/uchar.ml
+++ b/stdlib/uchar.ml
@@ -56,3 +56,36 @@ let unsafe_to_char = Char.unsafe_chr
 let equal : int -> int -> bool = ( = )
 let compare : int -> int -> int = Stdlib.compare
 let hash = to_int
+
+(* UTF codecs tools *)
+
+type utf_decode = int
+(* This is an int [0xDUUUUUU] decomposed as follows:
+   - [D] is four bits for decode information, the highest bit is set if the
+     decode is valid. The three lower bits indicate the number of elements
+     from the source that were consumed by the decode.
+   - [UUUUUU] is the decoded Unicode character or the Unicode replacement
+     character U+FFFD if for invalid decodes. *)
+
+let valid_bit = 27
+let decode_bits = 24
+
+let[@inline] utf_decode_is_valid d = (d lsr valid_bit) = 1
+let[@inline] utf_decode_length d = (d lsr decode_bits) land 0b111
+let[@inline] utf_decode_uchar d = unsafe_of_int (d land 0xFFFFFF)
+let[@inline] utf_decode n u = ((8 lor n) lsl decode_bits) lor (to_int u)
+let[@inline] utf_decode_invalid n = (n lsl decode_bits) lor rep
+
+let utf_8_byte_length u = match to_int u with
+| u when u < 0 -> assert false
+| u when u <= 0x007F -> 1
+| u when u <= 0x07FF -> 2
+| u when u <= 0xFFFF -> 3
+| u when u <= 0x10FFFF -> 4
+| _ -> assert false
+
+let utf_16_byte_length u = match to_int u with
+| u when u < 0 -> assert false
+| u when u <= 0xFFFF -> 2
+| u when u <= 0x10FFFF -> 4
+| _ -> assert false

--- a/stdlib/uchar.mli
+++ b/stdlib/uchar.mli
@@ -97,3 +97,45 @@ val compare : t -> t -> int
 
 val hash : t -> int
 (** [hash u] associates a non-negative integer to [u]. *)
+
+(** {1:utf UTF codecs tools}
+
+    @since 4.14 *)
+
+type utf_decode [@@immediate]
+(** The type for UTF decode results. Values of this type represent
+    the result of a Unicode Transformation Format decoding attempt. *)
+
+val utf_decode_is_valid : utf_decode -> bool
+(** [utf_decode_is_valid d] is [true] if and only if [d] holds a valid
+    decode. *)
+
+val utf_decode_uchar : utf_decode -> t
+(** [utf_decode_uchar d] is the Unicode character decoded by [d] if
+    [utf_decode_is_valid d] is [true] and {!Uchar.rep} otherwise. *)
+
+val utf_decode_length : utf_decode -> int
+(** [utf_decode_length d] is the number of elements from the source
+    that were consumed by the decode [d]. This is always strictly
+    positive and smaller or equal to [4]. The kind of source elements
+    depends on the actual decoder; for the decoders of the standard
+    library this function always returns a length in bytes. *)
+
+val utf_decode : int -> t -> utf_decode
+(** [utf_decode n u] is a valid UTF decode for [u] that consumed [n]
+    elements from the source for decoding. [n] must be positive and
+    smaller or equal to [4] (this is not checked by the module). *)
+
+val utf_decode_invalid : int -> utf_decode
+(** [utf_decode_invalid n] is an invalid UTF decode that consumed [n]
+    elements from the source to error. [n] must be positive and
+    smaller or equal to [4] (this is not checked by the module). The
+    resulting decode has {!rep} as the decoded Unicode character. *)
+
+val utf_8_byte_length : t -> int
+(** [utf_8_byte_length u] is the number of bytes needed to encode
+    [u] in UTF-8. *)
+
+val utf_16_byte_length : t -> int
+(** [utf_16_byte_length u] is the number of bytes needed to encode
+    [u] in UTF-16. *)

--- a/testsuite/tests/lib-bytes-utf/test.ml
+++ b/testsuite/tests/lib-bytes-utf/test.ml
@@ -1,0 +1,275 @@
+(* TEST
+*)
+
+(* UTF codec tests *)
+
+let fold_uchars f acc =
+  let rec loop f acc u =
+    let acc = f acc u in
+    if Uchar.equal u Uchar.max then acc else loop f acc (Uchar.succ u)
+  in
+  loop f acc Uchar.min
+
+(* This tests that we encode and decode each character according
+   to its specification. *)
+
+let utf_8_spec =
+  (* UTF-8 byte sequences, cf. table 3.7 Unicode 14. *)
+  [(0x0000,0x007F),     [|(0x00,0x7F)|];
+   (0x0080,0x07FF),     [|(0xC2,0xDF); (0x80,0xBF)|];
+   (0x0800,0x0FFF),     [|(0xE0,0xE0); (0xA0,0xBF); (0x80,0xBF)|];
+   (0x1000,0xCFFF),     [|(0xE1,0xEC); (0x80,0xBF); (0x80,0xBF)|];
+   (0xD000,0xD7FF),     [|(0xED,0xED); (0x80,0x9F); (0x80,0xBF)|];
+   (0xE000,0xFFFF),     [|(0xEE,0xEF); (0x80,0xBF); (0x80,0xBF)|];
+   (0x10000,0x3FFFF),   [|(0xF0,0xF0); (0x90,0xBF); (0x80,0xBF); (0x80,0xBF)|];
+   (0x40000,0xFFFFF),   [|(0xF1,0xF3); (0x80,0xBF); (0x80,0xBF); (0x80,0xBF)|];
+   (0x100000,0x10FFFF), [|(0xF4,0xF4); (0x80,0x8F); (0x80,0xBF); (0x80,0xBF)|]]
+
+let utf_16be_spec =
+  (* UTF-16BE byte sequences, derived from table 3.5 Unicode 14. *)
+  [(0x0000,0xD7FF),    [|(0x00,0xD7); (0x00,0xFF)|];
+   (0xE000,0xFFFF),    [|(0xE0,0xFF); (0x00,0xFF)|];
+   (0x10000,0x10FFFF), [|(0xD8,0xDB); (0x00,0xFF); (0xDC,0xDF); (0x00,0xFF)|]]
+
+let uchar_map_of_spec spec =
+  (* array mapping Uchar.t as ints to byte sequences according to [spec]. *)
+  let map = Array.make ((Uchar.to_int Uchar.max) + 1) Bytes.empty in
+  let add_range ((umin, umax), bytes) =
+    let len = Array.length bytes in
+    let bmin i = if i < len then fst bytes.(i) else max_int in
+    let bmax i = if i < len then snd bytes.(i) else min_int in
+    let uchar = ref umin in
+    let buf = Bytes.create len in
+    let add len' = match len = len' with
+    | false -> ()
+    | true -> map.(!uchar) <- Bytes.copy buf; incr uchar
+    in
+    for b0 = bmin 0 to bmax 0 do Bytes.set_uint8 buf 0 b0;
+      for b1 = bmin 1 to bmax 1 do Bytes.set_uint8 buf 1 b1;
+        for b2 = bmin 2 to bmax 2 do Bytes.set_uint8 buf 2 b2;
+          for b3 = bmin 3 to bmax 3 do Bytes.set_uint8 buf 3 b3; add 4
+          done; add 3;
+        done; add 2;
+      done; add 1;
+    done; assert (!uchar - 1 = umax)
+  in
+  List.iter add_range spec;
+  map
+
+let uchar_map_get u map = map.(Uchar.to_int u)
+let utf_8 = uchar_map_of_spec utf_8_spec
+let utf_16be = uchar_map_of_spec utf_16be_spec
+let utf_16le =
+  let swap u b =
+    let len = Bytes.length b in
+    if len = 0 then () else
+    for i = 0 to Bytes.length b / 2 - 1 do
+      let j = i * 2 in
+      Bytes.set_uint16_le b j (Bytes.get_uint16_be b j);
+    done;
+  in
+  let map = Array.map Bytes.copy utf_16be in
+  Array.iteri swap map; map
+
+let test_utf utf utf_len get_utf set_utf utf_is_valid =
+  (* Test codec and validation of each Uchar.t against the spec. *)
+  let f () u =
+    let utf_len = utf_len u in
+    let buf = Bytes.create utf_len in
+    assert (set_utf buf 0 u = utf_len);
+    assert (Bytes.equal buf (uchar_map_get u utf));
+    assert (Bytes.equal buf (uchar_map_get u utf));
+    let dec = get_utf buf 0 in
+    assert (Uchar.utf_decode_is_valid dec);
+    assert (Uchar.utf_decode_length dec = utf_len);
+    assert (Uchar.equal (Uchar.utf_decode_uchar dec) u);
+    assert (utf_is_valid buf);
+    ()
+  in
+  fold_uchars f ()
+
+let () =
+  test_utf utf_8 Uchar.utf_8_byte_length
+    Bytes.get_utf_8_uchar Bytes.set_utf_8_uchar Bytes.is_valid_utf_8
+
+let () =
+  test_utf utf_16be Uchar.utf_16_byte_length
+    Bytes.get_utf_16be_uchar Bytes.set_utf_16be_uchar Bytes.is_valid_utf_16be
+
+let () =
+  test_utf utf_16le Uchar.utf_16_byte_length
+    Bytes.get_utf_16le_uchar Bytes.set_utf_16le_uchar Bytes.is_valid_utf_16le
+
+let () =
+  (* Test out of bounds *)
+  let raises f = assert (try f (); false with Invalid_argument _ -> true) in
+  (raises @@ fun () -> Bytes.get_utf_8_uchar Bytes.empty 0);
+  (raises @@ fun () -> Bytes.set_utf_8_uchar Bytes.empty 0 Uchar.min);
+  (raises @@ fun () -> Bytes.get_utf_16le_uchar Bytes.empty 0);
+  (raises @@ fun () -> Bytes.set_utf_16le_uchar Bytes.empty 0 Uchar.min);
+  (raises @@ fun () -> Bytes.get_utf_16be_uchar Bytes.empty 0);
+  (raises @@ fun () -> Bytes.set_utf_16be_uchar Bytes.empty 0 Uchar.min);
+  ()
+
+let () =
+  (* Test lack of space encodes *)
+  let b = Bytes.make 1 '\xab' in
+  assert (Bytes.set_utf_8_uchar b 0 Uchar.max = 0 && Bytes.get b 0 = '\xab');
+  assert (Bytes.set_utf_16be_uchar b 0 Uchar.max = 0 && Bytes.get b 0 = '\xab');
+  assert (Bytes.set_utf_16le_uchar b 0 Uchar.max = 0 && Bytes.get b 0 = '\xab');
+  ()
+
+let () =
+  (* Test bug found during review *)
+  let b = Bytes.create 2 in
+  let () = Bytes.set_uint8 b 0 0xC3 in
+  let () = Bytes.set_uint8 b 1 0x00 in
+  assert (not (Bytes.is_valid_utf_8 b))
+
+let () =
+  (* Test used bytes and replacement according to WHATWG recommendation.
+     This is just a recommendation.
+     These examples are from TUS p. 126-127 Unicode 14  *)
+  let b = Bytes.of_string "\xC0\xAF\xE0\x80\xBF\xF0\x81\x82\x41" in
+  let ok i = i = Bytes.length b - 1 in
+  for i = 0 to Bytes.length b - 1 do
+    let dec = Bytes.get_utf_8_uchar b i in
+    if not (ok i) then begin
+      assert (Uchar.utf_decode_is_valid dec = false);
+      assert (Uchar.utf_decode_length dec = 1);
+      assert (Uchar.equal (Uchar.utf_decode_uchar dec) Uchar.rep)
+    end else begin
+      assert (Uchar.utf_decode_is_valid dec = true);
+      assert (Uchar.utf_decode_length dec = 1);
+      assert (Uchar.equal (Uchar.utf_decode_uchar dec) (Uchar.of_int 0x0041))
+    end
+  done;
+  let b = Bytes.of_string "\xED\xA0\x80\xED\xBF\xBF\xED\xAF\x41" in
+  let ok i = i = Bytes.length b - 1 in
+  for i = 0 to Bytes.length b - 1 do
+    let dec = Bytes.get_utf_8_uchar b i in
+    if not (ok i) then begin
+      assert (Uchar.utf_decode_is_valid dec = false);
+      assert (Uchar.utf_decode_length dec = 1);
+      assert (Uchar.equal (Uchar.utf_decode_uchar dec) Uchar.rep)
+    end else begin
+      assert (Uchar.utf_decode_is_valid dec = true);
+      assert (Uchar.utf_decode_length dec = 1);
+      assert (Uchar.equal (Uchar.utf_decode_uchar dec) (Uchar.of_int 0x0041))
+    end
+  done;
+  let b = Bytes.of_string "\xF4\x91\x92\x93\xFF\x41\x80\xBF\x42" in
+  let ok i = i = 5 || i = 8 in
+  for i = 0 to Bytes.length b - 1 do
+    let dec = Bytes.get_utf_8_uchar b i in
+    if not (ok i) then begin
+      assert (Uchar.utf_decode_is_valid dec = false);
+      assert (Uchar.utf_decode_length dec = 1);
+      assert (Uchar.equal (Uchar.utf_decode_uchar dec) Uchar.rep)
+    end else begin
+      assert (Uchar.utf_decode_is_valid dec = true);
+      assert (Uchar.utf_decode_length dec = 1);
+      assert (Uchar.equal (Uchar.utf_decode_uchar dec)
+                (Uchar.of_char (Bytes.get b i)))
+    end
+  done;
+  let b = Bytes.of_string "\xE1\x80\xE2\xF0\x91\x92\xF1\xBF\x41" in
+  let d0 = Bytes.get_utf_8_uchar b 0 in
+  assert (Uchar.utf_decode_is_valid d0 = false);
+  assert (Uchar.utf_decode_length d0 = 2);
+  assert (Uchar.equal (Uchar.utf_decode_uchar d0) Uchar.rep);
+  let d2 = Bytes.get_utf_8_uchar b 2 in
+  assert (Uchar.utf_decode_is_valid d2 = false);
+  assert (Uchar.utf_decode_length d2 = 1);
+  assert (Uchar.equal (Uchar.utf_decode_uchar d2) Uchar.rep);
+  let d3 = Bytes.get_utf_8_uchar b 3 in
+  assert (Uchar.utf_decode_is_valid d3 = false);
+  assert (Uchar.utf_decode_length d3 = 3);
+  assert (Uchar.equal (Uchar.utf_decode_uchar d3) Uchar.rep);
+  let d6 = Bytes.get_utf_8_uchar b 6 in
+  assert (Uchar.utf_decode_is_valid d6 = false);
+  assert (Uchar.utf_decode_length d6 = 2);
+  assert (Uchar.equal (Uchar.utf_decode_uchar d6) Uchar.rep);
+  let d8 = Bytes.get_utf_8_uchar b 8 in
+  assert (Uchar.utf_decode_length d8 = 1);
+  assert (Uchar.equal (Uchar.utf_decode_uchar d8) (Uchar.of_int 0x0041));
+  ()
+
+let () = Printf.printf "All UTF tests passed!\n"
+
+(* This is a very long test added here for reference just in case. It
+   is not run.
+
+   It assumes the good encoding and decodes have been checked by test_utf
+   above. It exhaustively tests all 1-4 bytes invalid sequences for decodes.
+   This ensures we do not decode invalid sequence to uchars. *)
+
+let test_invalid_decodes () =
+  let module Sset = Set.Make (String) in
+  let utf_8_encs, utf_16be_encs, utf_16le_encs =
+    Printf.printf "Building encoding sequence sets\n%!";
+    let add (set8, set16be, set16le) u =
+      let s = Bytes.unsafe_to_string in
+      let e8 = Bytes.create (Uchar.utf_8_byte_length u) in
+      let e16be = Bytes.create (Uchar.utf_16_byte_length u) in
+      let e16le = Bytes.create (Uchar.utf_16_byte_length u) in
+      ignore (Bytes.set_utf_8_uchar e8 0 u);
+      ignore (Bytes.set_utf_16be_uchar e16be 0 u);
+      ignore (Bytes.set_utf_16le_uchar e16le 0 u);
+      Sset.add (s e8) set8,
+      Sset.add (s e16be) set16be,
+      Sset.add (s e16le) set16le
+    in
+    fold_uchars add (Sset.empty, Sset.empty, Sset.empty)
+  in
+  let test_seqs utf utf_encs get_utf_char is_valid_utf =
+    let test seq =
+      let dec = get_utf_char seq 0 in
+      let valid = Uchar.utf_decode_is_valid dec in
+      let is_valid = is_valid_utf seq in
+      let is_enc = Sset.mem (Bytes.unsafe_to_string seq) utf_encs in
+      if not ((valid && is_enc) || (not valid && not is_enc)) ||
+         not ((is_valid && is_enc) || (not is_valid && not is_enc))
+      then begin
+        for i = 0 to Bytes.length seq - 1 do
+          Printf.printf "%02X " (Bytes.get_uint8 seq i);
+        done;
+        Printf.printf "valid: %b is_encoding: %b decode: U+%04X\n is_valid:%b"
+          valid is_enc (Uchar.to_int (Uchar.utf_decode_uchar dec)) is_valid;
+        assert false
+      end;
+      valid
+    in
+    let[@inline] set buf i b = Bytes.unsafe_set buf i (Char.unsafe_chr b) in
+    let s1 = Bytes.create 1 and s2 = Bytes.create 2
+    and s3 = Bytes.create 3 and s4 = Bytes.create 4 in
+    Printf.printf "Testing %s invalid decodes...\n%!" utf;
+    for b0 = 0x00 to 0xFF do
+      set s1 0 b0;
+      if test s1 then ((* this prefix decoded, stop here *)) else begin
+        set s2 0 b0;
+        for b1 = 0x00 to 0xFF do
+          set s2 1 b1;
+          if test s2 then ((* this prefix decoded, stop here *)) else begin
+            set s3 0 b0;
+            set s3 1 b1;
+            for b2 = 0x00 to 0xFF do
+              set s3 2 b2;
+              if test s3 then ((* this prefix decoded, stop here *)) else begin
+                set s4 0 b0;
+                set s4 1 b1;
+                set s4 2 b2;
+                for b3 = 0x00 to 0xFF do set s4 3 b3; ignore (test s4) done;
+              end
+            done;
+          end
+        done;
+      end
+    done
+  in
+  test_seqs "UTF-8" utf_8_encs Bytes.get_utf_8_uchar Bytes.is_valid_utf_8;
+  test_seqs "UTF-16BE"
+    utf_16be_encs Bytes.get_utf_16be_uchar Bytes.is_valid_utf_16be;
+  test_seqs "UTF-16LE" utf_16le_encs Bytes.get_utf_16le_uchar
+    Bytes.is_valid_utf_16le;
+  ()

--- a/testsuite/tests/lib-bytes-utf/test.reference
+++ b/testsuite/tests/lib-bytes-utf/test.reference
@@ -1,0 +1,1 @@
+All UTF tests passed!

--- a/testsuite/tests/lib-uchar/test.ml
+++ b/testsuite/tests/lib-uchar/test.ml
@@ -72,6 +72,34 @@ let test_compare () =
   assert (Uchar.(compare max min) = 1);
   ()
 
+let test_utf_decode () =
+  let d0 = Uchar.utf_decode 1 Uchar.min in
+  let d1 = Uchar.utf_decode 4 Uchar.max in
+  let invalid = Uchar.utf_decode_invalid 3 in
+  assert (Uchar.utf_decode_is_valid d0);
+  assert (Uchar.utf_decode_length d0 = 1);
+  assert (Uchar.equal (Uchar.utf_decode_uchar d0) Uchar.min);
+  assert (Uchar.utf_decode_is_valid d1);
+  assert (Uchar.utf_decode_length d1 = 4);
+  assert (Uchar.equal (Uchar.utf_decode_uchar d1) Uchar.max);
+  assert (not (Uchar.utf_decode_is_valid invalid));
+  assert (Uchar.utf_decode_length invalid = 3);
+  assert (Uchar.equal (Uchar.utf_decode_uchar invalid) Uchar.rep);
+  ()
+
+let test_utf_x_byte_length () =
+  assert (Uchar.utf_8_byte_length Uchar.min = 1);
+  assert (Uchar.utf_16_byte_length Uchar.min = 2);
+  assert (Uchar.utf_8_byte_length Uchar.max = 4);
+  assert (Uchar.utf_16_byte_length Uchar.max = 4);
+  let c = Uchar.of_int 0x1F42B in
+  assert (Uchar.utf_8_byte_length c = 4);
+  assert (Uchar.utf_16_byte_length c = 4);
+  let c = Uchar.of_int 0x9A7C in
+  assert (Uchar.utf_8_byte_length c = 3);
+  assert (Uchar.utf_16_byte_length c = 2);
+  ()
+
 let tests () =
   test_constants ();
   test_succ ();
@@ -82,6 +110,8 @@ let tests () =
   test_to_char ();
   test_equal ();
   test_compare ();
+  test_utf_decode ();
+  test_utf_x_byte_length ();
   ()
 
 let () =


### PR DESCRIPTION
This PR adds UTF tools, codecs and validations to the `Uchar`, `Bytes` and `String` modules.

For more information and background discussion see #10660.

Closes #10660. 