### PR TITLE
manual: use the babel package to allow underscore in labels

### DIFF
--- a/api_docgen/alldoc.tex
+++ b/api_docgen/alldoc.tex
@@ -1,10 +1,8 @@
 \documentclass{book}
-
 \usepackage[colorlinks=true,breaklinks=true]{hyperref}
 \usepackage{color}
 \usepackage{lmodern}
 \usepackage[T1]{fontenc}
-\usepackage[strings,nohyphen]{underscore}
 \input{ifocamldoc}
 \ifocamldoc
 \usepackage{ocamldoc}
@@ -67,6 +65,8 @@
 \else
 \newcommand{\docitem}[2]{\input{#1/#2}}
 \fi
+\usepackage[english]{babel}
+\usepackage[strings,nohyphen]{underscore}
 
 \begin{document}
 \chapter{Stdlib}

--- a/manual/src/manual.tex
+++ b/manual/src/manual.tex
@@ -185,6 +185,9 @@
 % Make _ a normal character in text mode
 % it must be the last package included
 \usepackage[strings,nohyphen]{underscore}
+% Babel enables a finer control of the catcode of '_'
+% and ensures that '_' is allowed in labels and references.
+\usepackage[english]{babel}
 
 %\makeatletter \def\@wrindex#1#2{\xdef \@indexfile{\csname #1@idxfile\endcsname}\@@wrindex#2||\\}\makeatother
 


### PR DESCRIPTION
This is a fix for the documentation side of #10710 which allow the use of `_` in labels by using the english setting of the `babel` package.