### PR TITLE
Add X86_proc.with_internal_assembler

### DIFF
--- a/Changes
+++ b/Changes
@@ -255,6 +255,10 @@ Working version
 - #10692: Expose Parse.module_type and Parse.module_expr
   (Guillaume Petiot, review by Gabriel Scherer)
 
+- #10714: Add X86_proc.with_internal_assembler for temporarily changing the
+  assembler used by the backend.
+  (David Allsopp, review by Gabriel Scherer)
+
 ### Build system:
 
 ### Bug fixes:

--- a/asmcomp/x86_proc.ml
+++ b/asmcomp/x86_proc.ml
@@ -221,6 +221,8 @@ let string_of_rounding = function
 
 let internal_assembler = ref None
 let register_internal_assembler f = internal_assembler := Some f
+let with_internal_assembler assemble k =
+  Misc.protect_refs [ R (internal_assembler, Some assemble) ] k
 
 (* Which asm conventions to use *)
 let masm =

--- a/asmcomp/x86_proc.mli
+++ b/asmcomp/x86_proc.mli
@@ -87,3 +87,5 @@ val use_plt : bool
 (** Support for plumbing a binary code emitter *)
 
 val register_internal_assembler: (asm_program -> string -> unit) -> unit
+val with_internal_assembler:
+  (asm_program -> string -> unit) -> (unit -> 'a) -> 'a


### PR DESCRIPTION
This PR adds a small additional hook around `X86_proc.internal_assembler` to provide `Misc.protect_refs`-style changing of it for the duration of a function call.

This hook is used by "ocaml-jit" project; cc @mshinwell; @NathanReb