### PR TITLE
Ensure that build_apply respects Lambda.max_arity 

### DIFF
--- a/Changes
+++ b/Changes
@@ -179,6 +179,9 @@ OCaml 4.14.0
 - #10681: Enforce boolean conditions for the native backend
   (Vincent Laviron, review by Gabriel Scherer)
 
+- #10719: Ensure that build_apply respects Lambda.max_arity
+  (Stephen Dolan, review by Xavier Leroy)
+
 - #10728: Ensure that functions are evaluated after their arguments
   (Stephen Dolan, review by Mark Shinwell)
 

--- a/lambda/lambda.ml
+++ b/lambda/lambda.ml
@@ -360,6 +360,15 @@ let const_int n = Const_base (Const_int n)
 
 let const_unit = const_int 0
 
+let max_arity () =
+  if !Clflags.native_code then 126 else max_int
+  (* 126 = 127 (the maximal number of parameters supported in C--)
+           - 1 (the hidden parameter containing the environment) *)
+
+let lfunction ~kind ~params ~return ~body ~attr ~loc =
+  assert (List.length params <= max_arity ());
+  Lfunction { kind; params; return; body; attr; loc }
+
 let lambda_unit = Lconst const_unit
 
 let default_function_attribute = {
@@ -997,11 +1006,6 @@ let find_exact_application kind ~arity args =
           else Some (List.map (fun cst -> Lconst cst) const_args)
       | _ -> None
       end
-
-let max_arity () =
-  if !Clflags.native_code then 126 else max_int
-  (* 126 = 127 (the maximal number of parameters supported in C--)
-           - 1 (the hidden parameter containing the environment) *)
 
 let reset () =
   raise_count := 0

--- a/lambda/lambda.mli
+++ b/lambda/lambda.mli
@@ -305,7 +305,7 @@ type lambda =
   | Levent of lambda * lambda_event
   | Lifused of Ident.t * lambda
 
-and lfunction =
+and lfunction = private
   { kind: function_kind;
     params: (Ident.t * value_kind) list;
     return: value_kind;
@@ -367,6 +367,16 @@ val const_int : int -> structured_constant
 val lambda_unit: lambda
 val name_lambda: let_kind -> lambda -> (Ident.t -> lambda) -> lambda
 val name_lambda_list: lambda list -> (lambda list -> lambda) -> lambda
+
+val lfunction :
+  kind:function_kind ->
+  params:(Ident.t * value_kind) list ->
+  return:value_kind ->
+  body:lambda ->
+  attr:function_attribute -> (* specified with [@inline] attribute *)
+  loc:scoped_location ->
+  lambda
+
 
 val iter_head_constructor: (lambda -> unit) -> lambda -> unit
 (** [iter_head_constructor f lam] apply [f] to only the first level of

--- a/lambda/translattribute.ml
+++ b/lambda/translattribute.ml
@@ -234,6 +234,9 @@ let check_poll_local loc attr =
   | _ ->
       ()
 
+let lfunction_with_attr ~attr { kind; params; return; body; attr=_; loc } =
+  lfunction ~kind ~params ~return ~body ~attr ~loc
+
 let add_inline_attribute expr loc attributes =
   match expr, get_inline_attribute attributes with
   | expr, Default_inline -> expr
@@ -247,7 +250,7 @@ let add_inline_attribute expr loc attributes =
       let attr = { attr with inline } in
       check_local_inline loc attr;
       check_poll_inline loc attr;
-      Lfunction { funct with attr = attr }
+      lfunction_with_attr ~attr funct
   | expr, (Always_inline | Hint_inline | Never_inline | Unroll _) ->
       Location.prerr_warning loc
         (Warnings.Misplaced_attribute "inline");
@@ -264,7 +267,7 @@ let add_specialise_attribute expr loc attributes =
             (Warnings.Duplicated_attribute "specialise")
       end;
       let attr = { attr with specialise } in
-      Lfunction { funct with attr }
+      lfunction_with_attr ~attr funct
   | expr, (Always_specialise | Never_specialise) ->
       Location.prerr_warning loc
         (Warnings.Misplaced_attribute "specialise");
@@ -283,7 +286,7 @@ let add_local_attribute expr loc attributes =
       let attr = { attr with local } in
       check_local_inline loc attr;
       check_poll_local loc attr;
-      Lfunction { funct with attr }
+      lfunction_with_attr ~attr funct
   | expr, (Always_local | Never_local) ->
       Location.prerr_warning loc
         (Warnings.Misplaced_attribute "local");
@@ -298,7 +301,7 @@ let add_tmc_attribute expr loc attributes =
             Location.prerr_warning loc
               (Warnings.Duplicated_attribute "tail_mod_cons");
         let attr = { funct.attr with tmc_candidate = true } in
-        Lfunction { funct with attr }
+        lfunction_with_attr ~attr funct
     | expr ->
         Location.prerr_warning loc
           (Warnings.Misplaced_attribute "tail_mod_cons");
@@ -320,7 +323,7 @@ let add_poll_attribute expr loc attributes =
       check_poll_inline loc attr;
       check_poll_local loc attr;
       let attr = { attr with inline = Never_inline; local = Never_local } in
-      Lfunction { funct with attr }
+      lfunction_with_attr ~attr funct
   | expr, Error_poll ->
       Location.prerr_warning loc
         (Warnings.Misplaced_attribute "error_poll");

--- a/lambda/translcore.ml
+++ b/lambda/translcore.ml
@@ -586,12 +586,12 @@ and transl_exp0 ~in_new_scope ~scopes e =
          transl_exp ~scopes e
       | `Other ->
          (* other cases compile to a lazy block holding a function *)
-         let fn = Lfunction {kind = Curried;
-                             params= [Ident.create_local "param", Pgenval];
-                             return = Pgenval;
-                             attr = default_function_attribute;
-                             loc = of_location ~scopes e.exp_loc;
-                             body = transl_exp ~scopes e} in
+         let fn = lfunction ~kind:Curried
+                            ~params:[Ident.create_local "param", Pgenval]
+                            ~return:Pgenval
+                            ~attr:default_function_attribute
+                            ~loc:(of_location ~scopes e.exp_loc)
+                            ~body:(transl_exp ~scopes e) in
           Lprim(Pmakeblock(Config.lazy_tag, Mutable, None), [fn],
                 of_location ~scopes e.exp_loc)
       end
@@ -735,21 +735,15 @@ and transl_apply ~scopes
           match build_apply handle ((Lvar id_arg, optional)::args') l with
             Lfunction{kind = Curried; params = ids; return;
                       body = lam; attr; loc} ->
-              Lfunction{kind = Curried;
-                        params = (id_arg, Pgenval)::ids;
-                        return;
-                        body = lam; attr;
-                        loc}
-          | Levent(Lfunction{kind = Curried; params = ids; return;
-                             body = lam; attr; loc}, _) ->
-              Lfunction{kind = Curried; params = (id_arg, Pgenval)::ids;
-                        return;
-                        body = lam; attr;
-                        loc}
+              lfunction ~kind:Curried
+                        ~params:((id_arg, Pgenval)::ids)
+                        ~return
+                        ~body:lam ~attr
+                        ~loc
           | lam ->
-              Lfunction{kind = Curried; params = [id_arg, Pgenval];
-                        return = Pgenval; body = lam;
-                        attr = default_stub_attribute; loc = loc}
+              lfunction ~kind:Curried ~params:[id_arg, Pgenval]
+                        ~return:Pgenval ~body:lam
+                        ~attr:default_stub_attribute ~loc
         in
         List.fold_left
           (fun body (id, lam) -> Llet(Strict, Pgenval, id, lam, body))
@@ -879,7 +873,7 @@ and transl_function ~scopes e param cases partial =
   in
   let attr = default_function_attribute in
   let loc = of_location ~scopes e.exp_loc in
-  let lam = Lfunction{kind; params; return; body; attr; loc} in
+  let lam = lfunction ~kind ~params ~return ~body ~attr ~loc in
   Translattribute.add_function_attributes lam e.exp_loc e.exp_attributes
 
 (* Like transl_exp, but used when a new scope was just introduced. *)
@@ -1185,7 +1179,7 @@ and transl_letop ~scopes loc env let_ ands param case partial =
     in
     let attr = default_function_attribute in
     let loc = of_location ~scopes case.c_rhs.exp_loc in
-    Lfunction{kind; params; return; body; attr; loc}
+    lfunction ~kind ~params ~return ~body ~attr ~loc
   in
   Lapply{
     ap_loc = of_location ~scopes loc;

--- a/lambda/translcore.ml
+++ b/lambda/translcore.ml
@@ -734,7 +734,8 @@ and transl_apply ~scopes
         let body =
           match build_apply handle ((Lvar id_arg, optional)::args') l with
             Lfunction{kind = Curried; params = ids; return;
-                      body = lam; attr; loc} ->
+                      body = lam; attr; loc}
+               when List.length ids < Lambda.max_arity () ->
               lfunction ~kind:Curried
                         ~params:((id_arg, Pgenval)::ids)
                         ~return

--- a/lambda/translmod.ml
+++ b/lambda/translmod.ml
@@ -115,16 +115,15 @@ and apply_coercion_result loc strict funct params args cc_res =
   | _ ->
       name_lambda strict funct
         (fun id ->
-           Lfunction
-             {
-               kind = Curried;
-               params = List.rev params;
-               return = Pgenval;
-               attr = { default_function_attribute with
+           lfunction
+             ~kind:Curried
+             ~params:(List.rev params)
+             ~return:Pgenval
+             ~attr:{ default_function_attribute with
                         is_a_functor = true;
-                        stub = true; };
-               loc = loc;
-               body = apply_coercion
+                        stub = true; }
+             ~loc
+             ~body:(apply_coercion
                    loc Strict cc_res
                    (Lapply{
                       ap_loc=loc;
@@ -133,7 +132,7 @@ and apply_coercion_result loc strict funct params args cc_res =
                       ap_tailcall=Default_tailcall;
                       ap_inlined=Default_inline;
                       ap_specialised=Default_specialise;
-                    })})
+                    })))
 
 and wrap_id_pos_list loc id_pos_list get_field lam =
   let fv = free_variables lam in
@@ -483,11 +482,11 @@ let rec compile_functor ~scopes mexp coercion root_path loc =
       ([], transl_module ~scopes res_coercion body_path body)
       functor_params_rev
   in
-  Lfunction {
-    kind = Curried;
-    params;
-    return = Pgenval;
-    attr = {
+  lfunction
+    ~kind:Curried
+    ~params
+    ~return:Pgenval
+    ~attr:{
       inline = inline_attribute;
       specialise = Default_specialise;
       local = Default_local;
@@ -495,10 +494,9 @@ let rec compile_functor ~scopes mexp coercion root_path loc =
       is_a_functor = true;
       stub = false;
       tmc_candidate = false;
-    };
-    loc;
-    body;
-  }
+    }
+    ~loc
+    ~body
 
 (* Compile a module expression *)
 

--- a/lambda/translprim.ml
+++ b/lambda/translprim.ml
@@ -787,12 +787,12 @@ let transl_primitive loc p env ty path =
   match params with
   | [] -> body
   | _ ->
-      Lfunction{ kind = Curried;
-                 params;
-                 return = Pgenval;
-                 attr = default_stub_attribute;
-                 loc;
-                 body; }
+      lfunction ~kind:Curried
+                ~params
+                ~return:Pgenval
+                ~attr:default_stub_attribute
+                ~loc
+                ~body
 
 let lambda_primitive_needs_event_after = function
   (* We add an event after any primitive resulting in a C call that

--- a/middle_end/closure/closure.ml
+++ b/middle_end/closure/closure.ml
@@ -963,20 +963,20 @@ let rec close ({ backend; fenv; cenv ; mutable_vars } as env) lam =
         let funct_var = V.create_local "funct" in
         let fenv = V.Map.add funct_var fapprox fenv in
         let (new_fun, approx) = close { backend; fenv; cenv; mutable_vars }
-          (Lfunction{
-               kind = Curried;
-               return = Pgenval;
-               params = List.map (fun v -> v, Pgenval) final_args;
-               body = Lapply{
-                 ap_loc=loc;
-                 ap_func=(Lvar funct_var);
-                 ap_args=internal_args;
-                 ap_tailcall=Default_tailcall;
-                 ap_inlined=Default_inline;
-                 ap_specialised=Default_specialise;
-               };
-               loc;
-               attr = default_function_attribute})
+          (lfunction
+             ~kind:Curried
+             ~return:Pgenval
+             ~params:(List.map (fun v -> v, Pgenval) final_args)
+             ~body:(Lapply{
+                ap_loc=loc;
+                ap_func=(Lvar funct_var);
+                ap_args=internal_args;
+                ap_tailcall=Default_tailcall;
+                ap_inlined=Default_inline;
+                ap_specialised=Default_specialise;
+              })
+             ~loc
+             ~attr:default_function_attribute)
         in
         let new_fun =
           iter first_args


### PR DESCRIPTION
`Lambda.Lfunction` now has a maximum arity, but this is not always respected. Specifically, there's a missing check in `build_apply`, when partial applications of labelled functions are turned into closures. This results in a compiler assertion failure somewhere in Cmmgen when a large number of optional arguments are abstracted over:
```ocaml
let f 
  ?a1:_ ?a2:_ ?a3:_ ?a4:_ ?a5:_ ?a6:_ ?a7:_ ?a8:_ ?a9:_ ?a10:_
  ?a11:_ ?a12:_ ?a13:_ ?a14:_ ?a15:_ ?a16:_ ?a17:_ ?a18:_ ?a19:_ ?a20:_
  ?a21:_ ?a22:_ ?a23:_ ?a24:_ ?a25:_ ?a26:_ ?a27:_ ?a28:_ ?a29:_ ?a30:_
  ?a31:_ ?a32:_ ?a33:_ ?a34:_ ?a35:_ ?a36:_ ?a37:_ ?a38:_ ?a39:_ ?a40:_
  ?a41:_ ?a42:_ ?a43:_ ?a44:_ ?a45:_ ?a46:_ ?a47:_ ?a48:_ ?a49:_ ?a50:_
  ?a51:_ ?a52:_ ?a53:_ ?a54:_ ?a55:_ ?a56:_ ?a57:_ ?a58:_ ?a59:_ ?a60:_
  ?a61:_ ?a62:_ ?a63:_ ?a64:_ ?a65:_ ?a66:_ ?a67:_ ?a68:_ ?a69:_ ?a70:_
  ?a71:_ ?a72:_ ?a73:_ ?a74:_ ?a75:_ ?a76:_ ?a77:_ ?a78:_ ?a79:_ ?a80:_
  ?a81:_ ?a82:_ ?a83:_ ?a84:_ ?a85:_ ?a86:_ ?a87:_ ?a88:_ ?a89:_ ?a90:_
  ?a91:_ ?a92:_ ?a93:_ ?a94:_ ?a95:_ ?a96:_ ?a97:_ ?a98:_ ?a99:_ ?a100:_
  ?a101:_ ?a102:_ ?a103:_ ?a104:_ ?a105:_ ?a106:_ ?a107:_ ?a108:_ ?a109:_ ?a110:_
  ?a111:_ ?a112:_ ?a113:_ ?a114:_ ?a115:_ ?a116:_ ?a117:_ ?a118:_ ?a119:_ ?a120:_
  ?a121:_ ?a122:_ ?a123:_ ?a124:_ ?a125:_ ?a126:_ ?a127:_ ?a128:_ ?a129:_ ?a130:_
  ?a131:_ ?a132:_ ?a133:_ ?a134:_ ?a135:_ ?a136:_ ?a137:_ ?a138:_ ?a139:_ ?a140:_
  ?a141:_ ?a142:_ ?a143:_ ?a144:_ ?a145:_ ?a146:_ ?a147:_ ?a148:_ ?a149:_ ?a150:_
  ~r () = r

let g z = f ~r:1
```

This PR contains, in separate commits:

  - The one-line fix for this bug, adding `when List.length ids < Lambda.max_arity ()` to `build_apply`

  - A larger but entirely mechanical refactoring to make `Lambda.lfunction` private, so that whenever an `Lfunction` is constructed its arity is checked. (This will make any future arity errors fail somewhere closer to where the bug is)

The refactoring commit also contains another small change to `build_apply`: removing an impossible `Levent` case.