### PR TITLE
Fix AC_CONFIG_HEADERS on CRLF-checkouts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -182,8 +182,6 @@ tools/ocaml-objcopy-macosx text eol=lf
 tools/ocamlsize text eol=lf
 tools/pre-commit-githook text eol=lf
 tools/markdown-add-pr-links.sh text eol=lf
-runtime/caml/m.h.in text eol=lf
-runtime/caml/s.h.in text eol=lf
 runtime/caml/compatibility.h typo.long-line=may
 
 # These are all Perl scripts, so may not actually require this

--- a/configure
+++ b/configure
@@ -19165,9 +19165,9 @@ cat >>$CONFIG_STATUS <<_ACEOF || ac_write_fail=1
   for (key in D) D_is_set[key] = 1
   FS = ""
 }
-/^[\t ]*#[\t ]*(define|undef)[\t ]+$ac_word_re([\t (]|\$)/ {
+/^[\t ]*#[\t ]*(define|undef)[\t ]+$ac_word_re([\t (]|\r?\$)/ {
   line = \$ 0
-  split(line, arg, " ")
+  split(line, arg, /[ \r\t]/)
   if (arg[1] == "#") {
     defundef = arg[2]
     mac1 = arg[3]

--- a/tools/autogen
+++ b/tools/autogen
@@ -33,6 +33,8 @@ sed -e '/^runstatedir/d' \
     -e '/-runstatedir /{N;N;N;N;N;N;N;N;d;}' \
     -e '/--runstatedir=DIR/d' \
     -e 's/ runstatedir//' \
+    -e '/split(line, arg/s|" "|/[ \\r\\t]/|' \
+    -e '/define|undef/s/|\\\$/|\\r?\\$/' \
     -e '1d' \
     configure >> configure.tmp
 


### PR DESCRIPTION
#10658 added `runtime/caml/version.h.in` which isn't generated correctly by `configure` on a CRLF git checkout. We've encountered this before, that's why `.gitattributes` has:
https://github.com/ocaml/ocaml/blob/0684867f703ad16dee7b26fa56d8d66e4a5cfe36/.gitattributes#L185-L186

I was about to add `runtime/caml/version.h.in` to that list, but I figured I'd look a little deeper. We can still just add the line, but this PR fixes the problem at its source. It turns out it's a relatively small bug in autoconf (and I've submitted the [fix upstream as well](https://savannah.gnu.org/support/index.php?110554)).

On this occasion, it is worth "clicking" the "Load diff" option on `configure`, as the fix here is to autoconf itself, so there's no visible change in `configure.ac`.

cc @shindere