### PR TITLE
#10721: fix the marking of unused values in module type definitions

### DIFF
--- a/testsuite/tests/warnings/w32.ml
+++ b/testsuite/tests/warnings/w32.ml
@@ -65,3 +65,7 @@ module F (X : sig val x : int end) = struct end
 module G (X : sig val x : int end) = X
 
 module H (X : sig val x : int end) = X
+
+module type S = sig
+  module F:  sig val x : int end -> sig end
+end

--- a/testsuite/tests/warnings/w32.mli
+++ b/testsuite/tests/warnings/w32.mli
@@ -14,3 +14,7 @@ module F (X : sig val x : int end) : sig end
 module G (X : sig val x : int end) : sig end
 
 module H (X : sig val x : int end) : sig val x : int end
+
+module type S = sig
+  module F:  sig val x : int end -> sig end
+end

--- a/typing/includemod.ml
+++ b/typing/includemod.ml
@@ -742,7 +742,9 @@ and check_modtype_equiv ~in_eq ~loc env ~mark mty1 mty2 =
        of the equivalence.
      *)
     if in_eq then None
-    else Some (modtypes ~in_eq:true ~loc env ~mark Subst.identity mty2 mty1)
+    else
+      let mark = negate_mark mark in
+      Some (modtypes ~in_eq:true ~loc env ~mark Subst.identity mty2 mty1)
   in
   match c1, c2 with
   | Ok Tcoerce_none, (Some Ok Tcoerce_none|None) -> Ok Tcoerce_none


### PR DESCRIPTION
I forgot to negate the mark when checking the contravariant side of module type inclusion in #10616 (see [more precisely](https://github.com/ocaml/ocaml/pull/10616/files#diff-a44c8814b4fa6d4d4831c671315485855c04f82cc7c0bee5ac06fcce0f97292aR743)), consequently components of functor arguments inside module type declarations were not marked as used.

This PR fixes this mistake.

Close #10721 