### PR TITLE
Remove `-flat_namespace` flag in `configure.ac` on Darwin

### DIFF
--- a/Changes
+++ b/Changes
@@ -7,6 +7,9 @@ Working version
 - #10831: Multicore OCaml
   (The multicore team, caml-devel and more)
 
+* #10723: do not use `-flat-namespace` linking for macOS.
+  (Carlo Cabrera, review by Damien Doligez)
+
 * #10863, #10933: Remove support for old, unprefixed C runtime function names
   such as `alloc`.  The new names prefixed with `caml_` must be used instead,
   such as `caml_alloc`.  Consequently, it is no longer needed to define

--- a/configure
+++ b/configure
@@ -14078,7 +14078,7 @@ if test x"$enable_shared" != "xno"; then :
   case $host in #(
   *-apple-darwin*) :
     mksharedlib="$CC -shared \
-                   -flat_namespace -undefined suppress -Wl,-no_compact_unwind \
+                   -undefined dynamic_lookup -Wl,-no_compact_unwind \
                    \$(LDFLAGS)"
       supports_shared_libraries=true ;; #(
   *-*-mingw32) :

--- a/configure.ac
+++ b/configure.ac
@@ -934,7 +934,7 @@ AS_IF([test x"$enable_shared" != "xno"],
   [AS_CASE([$host],
     [*-apple-darwin*],
       [mksharedlib="$CC -shared \
-                   -flat_namespace -undefined suppress -Wl,-no_compact_unwind \
+                   -undefined dynamic_lookup -Wl,-no_compact_unwind \
                    \$(LDFLAGS)"
       supports_shared_libraries=true],
     [*-*-mingw32],


### PR DESCRIPTION
Apple discourages use of the `-flat_namespace` flag, and it exists only
for compatibility with very old versions of OS X. Using
`-flat_namespace` can cause various cryptic linker errors (e.g. due to
name collisions), so it's best to avoid its use unless needed.

This change removes the flag, and also changes `-undefined suppress` to
`-undefined dynamic_lookup`. We need to change the argument to
`-undefined` because omitting the `-flat_namespace` flag will build
shared libraries with a two-level namespace, and this does not support
`-undefined suppress`. `dynamic_lookup` means that the dynamic linker
will resolve undefined symbols at runtime.

This should have no visible impact on any users who do not explicitly
exploit the flat namespace, but this is of often only useful for
debugging purposes. Users who need this still have alternatives such as
setting `DYLD_FORCE_FLAT_NAMESPACE`, which instructs the linker to treat
libraries as if they were compiled with a flat namespace.