### PR TITLE
Free the alternate signal stack when the main OCaml code / an OCaml thread stops

### DIFF
--- a/Changes
+++ b/Changes
@@ -64,6 +64,10 @@ OCaml 4.14.0
   (Xavier Leroy and David Allsopp, review by Sébastien Hinderer and
    Damien Doligez)
 
+- #10698, #10726: Free the alternate signal stack when the main OCaml
+   code or an OCaml thread stops
+  (Xavier Leroy, review by David Allsopp and Damien Doligez)
+
 - #10730, 10731: Fix bug in `Obj.reachable_words` causing a slowdown when called
   multiple time (Alain Frisch, report by ygrek, review by Xavier Leroy)
 

--- a/manual/src/cmds/intf-c.etex
+++ b/manual/src/cmds/intf-c.etex
@@ -1778,6 +1778,12 @@ Once a runtime is unloaded, it cannot be started up again without reloading the
 shared library and reinitializing its static data. Therefore, at the moment, the
 facility is only useful for building reloadable shared libraries.
 
+\paragraph{Unix signal handling.}  Depending on the target platform and
+operating system, the native-code runtime system may install signal
+handlers for one or several of the "SIGSEGV", "SIGTRAP" and "SIGFPE"
+signals when "caml_startup" is called, and reset these signals to
+their default behaviors when "caml_shutdown" is called.  The main
+program written in~C should not try to handle these signals itself.
 
 \section{s:c-advexample}{Advanced example with callbacks}
 

--- a/manual/src/cmds/intf-c.etex
+++ b/manual/src/cmds/intf-c.etex
@@ -1727,8 +1727,8 @@ compilation of OCaml, as the variable "OC_LDFLAGS".
 OCaml have been compiled with the "/MD" flag, and therefore
 all other object files linked with it should also be compiled with
 "/MD".
-\item other systems: you may have to add one or more of "-lcurses",
-"-lm", "-ldl", depending on your OS and C compiler.
+\item other systems: you may have to add one or both of
+"-lm" and "-ldl", depending on your OS and C compiler.
 \end{itemize}
 
 \paragraph{Stack backtraces.}  When OCaml bytecode produced by

--- a/otherlibs/systhreads/st_stubs.c
+++ b/otherlibs/systhreads/st_stubs.c
@@ -550,6 +550,7 @@ static ST_THREAD_FUNCTION caml_thread_start(void * arg)
 #ifdef NATIVE_CODE
   }
 #endif
+  caml_stop_stack_overflow_detection();
   /* The thread now stops running */
   return 0;
 }

--- a/runtime/caml/signals.h
+++ b/runtime/caml/signals.h
@@ -88,7 +88,9 @@ value caml_process_pending_actions_with_root (value extra_root); // raises
 value caml_process_pending_actions_with_root_exn (value extra_root);
 int caml_set_signal_action(int signo, int action);
 CAMLextern int caml_setup_stack_overflow_detection(void);
-
+CAMLextern int caml_stop_stack_overflow_detection(void);
+CAMLextern void caml_init_signals(void);
+CAMLextern void caml_terminate_signals(void);
 CAMLextern void (*caml_enter_blocking_section_hook)(void);
 CAMLextern void (*caml_leave_blocking_section_hook)(void);
 #ifdef POSIX_SIGNALS

--- a/runtime/fail_nat.c
+++ b/runtime/fail_nat.c
@@ -31,6 +31,7 @@
 #include "caml/stack.h"
 #include "caml/roots.h"
 #include "caml/callback.h"
+#include "caml/signals.h"
 
 /* The globals holding predefined exceptions */
 
@@ -70,7 +71,10 @@ void caml_raise(value v)
   if (Is_exception_result(v))
     v = Extract_exception(v);
 
-  if (Caml_state->exception_pointer == NULL) caml_fatal_uncaught_exception(v);
+  if (Caml_state->exception_pointer == NULL) {
+    caml_terminate_signals();
+    caml_fatal_uncaught_exception(v);
+  }
 
   while (Caml_state->local_roots != NULL &&
          (char *) Caml_state->local_roots < Caml_state->exception_pointer) {

--- a/runtime/signals_byt.c
+++ b/runtime/signals_byt.c
@@ -82,3 +82,6 @@ int caml_set_signal_action(int signo, int action)
 }
 
 CAMLexport int caml_setup_stack_overflow_detection(void) { return 0; }
+CAMLexport int caml_stop_stack_overflow_detection(void) { return 0; }
+CAMLexport void caml_init_signals(void) { }
+CAMLexport void caml_terminate_signals(void) { }

--- a/runtime/startup_nat.c
+++ b/runtime/startup_nat.c
@@ -36,6 +36,7 @@
 #include "caml/mlvalues.h"
 #include "caml/osdeps.h"
 #include "caml/printexc.h"
+#include "caml/signals.h"
 #include "caml/stack.h"
 #include "caml/startup_aux.h"
 #include "caml/sys.h"
@@ -91,7 +92,6 @@ struct longjmp_buffer caml_termination_jmpbuf;
 void (*caml_termination_hook)(void *) = NULL;
 
 extern value caml_start_program (caml_domain_state*);
-extern void caml_init_signals (void);
 #ifdef _WIN32
 extern void caml_win32_overflow_detection (void);
 #endif
@@ -106,6 +106,7 @@ extern void caml_install_invalid_parameter_handler();
 value caml_startup_common(char_os **argv, int pooling)
 {
   char_os * exe_name, * proc_self_exe;
+  value res;
   char tos;
 
   /* Initialize the domain */
@@ -152,10 +153,13 @@ value caml_startup_common(char_os **argv, int pooling)
     exe_name = caml_search_exe_in_path(exe_name);
   caml_sys_init(exe_name, argv);
   if (sigsetjmp(caml_termination_jmpbuf.buf, 0)) {
+    caml_terminate_signals();
     if (caml_termination_hook != NULL) caml_termination_hook(NULL);
     return Val_unit;
   }
-  return caml_start_program(Caml_state);
+  res = caml_start_program(Caml_state);
+  caml_terminate_signals();
+  return res;
 }
 
 value caml_startup_exn(char_os **argv)

--- a/runtime/sys.c
+++ b/runtime/sys.c
@@ -159,6 +159,7 @@ CAMLexport void caml_do_exit(int retcode)
 #ifdef _WIN32
   caml_restore_win32_terminal();
 #endif
+  caml_terminate_signals();
 #ifdef NAKED_POINTERS_CHECKER
   if (retcode == 0 && caml_naked_pointers_detected) {
     fprintf (stderr, "\nOut-of-heap pointers were detected by the runtime.\n"

--- a/tools/ci/inria/sanitizers/lsan-suppr.txt
+++ b/tools/ci/inria/sanitizers/lsan-suppr.txt
@@ -1,4 +1,2 @@
 # ocamlyacc doesn't clean memory on exit
 leak:ocamlyacc
-# Alternate signal stacks are currently never freed (see #10266)
-leak:caml_setup_stack_overflow_detection


### PR DESCRIPTION
Commit fc9534746 / PR #10266 introduced dynamic allocation of the alternate stack used to process signals.

This PR makes sure the dynamically-allocated stack is freed when the main OCaml code terminates or an OCaml thread terminates.

In passing, we also reset relevant signal handlers to their default behavior when the main OCaml code terminates.

Fixes: #10698
