### PR TITLE
Buffer: reimplement UTF encoders with the new UTF Bytes encoders.

### DIFF
--- a/stdlib/.depend
+++ b/stdlib/.depend
@@ -60,19 +60,15 @@ stdlib__Bool.cmx : bool.ml \
     stdlib__Bool.cmi
 stdlib__Bool.cmi : bool.mli
 stdlib__Buffer.cmo : buffer.ml \
-    stdlib__Uchar.cmi \
     stdlib__Sys.cmi \
     stdlib__String.cmi \
     stdlib__Seq.cmi \
-    stdlib__Char.cmi \
     stdlib__Bytes.cmi \
     stdlib__Buffer.cmi
 stdlib__Buffer.cmx : buffer.ml \
-    stdlib__Uchar.cmx \
     stdlib__Sys.cmx \
     stdlib__String.cmx \
     stdlib__Seq.cmx \
-    stdlib__Char.cmx \
     stdlib__Bytes.cmx \
     stdlib__Buffer.cmi
 stdlib__Buffer.cmi : buffer.mli \

--- a/stdlib/buffer.ml
+++ b/stdlib/buffer.ml
@@ -134,83 +134,32 @@ let add_char b c =
   Bytes.unsafe_set b.buffer pos c;
   b.position <- pos + 1
 
- let add_utf_8_uchar b u = match Uchar.to_int u with
- | u when u < 0 -> assert false
- | u when u <= 0x007F ->
-     add_char b (Char.unsafe_chr u)
- | u when u <= 0x07FF ->
-     let pos = b.position in
-     if pos + 2 > b.length then resize b 2;
-     Bytes.unsafe_set b.buffer (pos    )
-       (Char.unsafe_chr (0xC0 lor (u lsr 6)));
-     Bytes.unsafe_set b.buffer (pos + 1)
-       (Char.unsafe_chr (0x80 lor (u land 0x3F)));
-     b.position <- pos + 2
- | u when u <= 0xFFFF ->
-     let pos = b.position in
-     if pos + 3 > b.length then resize b 3;
-     Bytes.unsafe_set b.buffer (pos    )
-       (Char.unsafe_chr (0xE0 lor (u lsr 12)));
-     Bytes.unsafe_set b.buffer (pos + 1)
-       (Char.unsafe_chr (0x80 lor ((u lsr 6) land 0x3F)));
-     Bytes.unsafe_set b.buffer (pos + 2)
-       (Char.unsafe_chr (0x80 lor (u land 0x3F)));
-     b.position <- pos + 3
- | u when u <= 0x10FFFF ->
-     let pos = b.position in
-     if pos + 4 > b.length then resize b 4;
-     Bytes.unsafe_set b.buffer (pos    )
-       (Char.unsafe_chr (0xF0 lor (u lsr 18)));
-     Bytes.unsafe_set b.buffer (pos + 1)
-       (Char.unsafe_chr (0x80 lor ((u lsr 12) land 0x3F)));
-     Bytes.unsafe_set b.buffer (pos + 2)
-       (Char.unsafe_chr (0x80 lor ((u lsr 6) land 0x3F)));
-     Bytes.unsafe_set b.buffer (pos + 3)
-       (Char.unsafe_chr (0x80 lor (u land 0x3F)));
-     b.position <- pos + 4
- | _ -> assert false
+let uchar_utf_8_byte_length_max = 4
+let uchar_utf_16_byte_length_max = 4
 
- let add_utf_16be_uchar b u = match Uchar.to_int u with
- | u when u < 0 -> assert false
- | u when u <= 0xFFFF ->
-     let pos = b.position in
-     if pos + 2 > b.length then resize b 2;
-     Bytes.unsafe_set b.buffer (pos    ) (Char.unsafe_chr (u lsr 8));
-     Bytes.unsafe_set b.buffer (pos + 1) (Char.unsafe_chr (u land 0xFF));
-     b.position <- pos + 2
- | u when u <= 0x10FFFF ->
-     let u' = u - 0x10000 in
-     let hi = 0xD800 lor (u' lsr 10) in
-     let lo = 0xDC00 lor (u' land 0x3FF) in
-     let pos = b.position in
-     if pos + 4 > b.length then resize b 4;
-     Bytes.unsafe_set b.buffer (pos    ) (Char.unsafe_chr (hi lsr 8));
-     Bytes.unsafe_set b.buffer (pos + 1) (Char.unsafe_chr (hi land 0xFF));
-     Bytes.unsafe_set b.buffer (pos + 2) (Char.unsafe_chr (lo lsr 8));
-     Bytes.unsafe_set b.buffer (pos + 3) (Char.unsafe_chr (lo land 0xFF));
-     b.position <- pos + 4
- | _ -> assert false
+let rec add_utf_8_uchar b u =
+  let pos = b.position in
+  if pos >= b.length then resize b uchar_utf_8_byte_length_max;
+  let n = Bytes.set_utf_8_uchar b.buffer pos u in
+  if n = 0
+  then (resize b uchar_utf_8_byte_length_max; add_utf_8_uchar b u)
+  else (b.position <- pos + n)
 
- let add_utf_16le_uchar b u = match Uchar.to_int u with
- | u when u < 0 -> assert false
- | u when u <= 0xFFFF ->
-     let pos = b.position in
-     if pos + 2 > b.length then resize b 2;
-     Bytes.unsafe_set b.buffer (pos    ) (Char.unsafe_chr (u land 0xFF));
-     Bytes.unsafe_set b.buffer (pos + 1) (Char.unsafe_chr (u lsr 8));
-     b.position <- pos + 2
- | u when u <= 0x10FFFF ->
-     let u' = u - 0x10000 in
-     let hi = 0xD800 lor (u' lsr 10) in
-     let lo = 0xDC00 lor (u' land 0x3FF) in
-     let pos = b.position in
-     if pos + 4 > b.length then resize b 4;
-     Bytes.unsafe_set b.buffer (pos    ) (Char.unsafe_chr (hi land 0xFF));
-     Bytes.unsafe_set b.buffer (pos + 1) (Char.unsafe_chr (hi lsr 8));
-     Bytes.unsafe_set b.buffer (pos + 2) (Char.unsafe_chr (lo land 0xFF));
-     Bytes.unsafe_set b.buffer (pos + 3) (Char.unsafe_chr (lo lsr 8));
-     b.position <- pos + 4
- | _ -> assert false
+let rec add_utf_16be_uchar b u =
+  let pos = b.position in
+  if pos >= b.length then resize b uchar_utf_16_byte_length_max;
+  let n = Bytes.set_utf_16be_uchar b.buffer pos u in
+  if n = 0
+  then (resize b uchar_utf_16_byte_length_max; add_utf_16be_uchar b u)
+  else (b.position <- pos + n)
+
+let rec add_utf_16le_uchar b u =
+  let pos = b.position in
+  if pos >= b.length then resize b uchar_utf_16_byte_length_max;
+  let n = Bytes.set_utf_16le_uchar b.buffer pos u in
+  if n = 0
+  then (resize b uchar_utf_16_byte_length_max; add_utf_16le_uchar b u)
+  else (b.position <- pos + n)
 
 let add_substring b s offset len =
   if offset < 0 || len < 0 || offset > String.length s - len


### PR DESCRIPTION
Note this is not urgent, if there's no time to review it can afford to wait the reheat. 

We just avoid bloating the `Stdlib` with multiple UTF decoding functions by reimplementing the existing `Buffer` UTF encoders with the new `Bytes` encoder that were just merged.