### PR TITLE
Stop installling executable programs in LIBDIR

### DIFF
--- a/Changes
+++ b/Changes
@@ -356,6 +356,10 @@ OCaml 4.14.0
 - #10717: Simplify the installation of man pages
   (Sébastien Hinderer, review by David Allsopp)
 
+- #10739: Stop installing extract_crc
+  (Sébastien Hinderer, review by David Allsopp, Daniel Bünzli, Xavier Leroy
+  and Gabriel Scherer)
+
 ### Bug fixes:
 
 - #9214, #10709: Wrong unmarshaling of function pointers in debugger mode.

--- a/otherlibs/dynlink/Makefile
+++ b/otherlibs/dynlink/Makefile
@@ -246,7 +246,6 @@ ifeq "$(INSTALL_SOURCE_ARTIFACTS)" "true"
 	  dynlink.cmti dynlink.mli \
 	  "$(INSTALL_LIBDIR)"
 endif
-	$(INSTALL_PROG) $(extract_crc) "$(INSTALL_LIBDIR)"
 
 installopt:
 	if $(NATDYNLINK); then \


### PR DESCRIPTION
This pull request addresses issue #6959 by implementing the suggestion
from comment https://github.com/ocaml/ocaml/issues/6959#issuecomment-897646005

The first commit merely implements the suggestion linked above, namely
stopping to install the expunge and extract_crc utilities.

The second commit contains a set of simplifications, mainly in
ocamldoc/Makefile, which were trivial and done while going through all the
makefiles to ensure no other executable program is installed in the
library directory.

By the way: the title of #6959 feels a bit misleading: the actual problem is
not that we install _binary files_ in LIBDIR, since the libraries
tthemselves are binary files. The problem is rather that we installed
_executable programs_ (both words matter because shared libraries need to
have executalbe permissions) in this directory so the title of the
issue may be updated to make it more accurate.