### PR TITLE
Don't display prune information for .gitignore

### DIFF
--- a/tools/check-typo
+++ b/tools/check-typo
@@ -113,7 +113,6 @@ case "$1" in
           exit 0;;
     esac
     if git check-ignore -q "$2"; then
-        echo "INFO: pruned path $2 (.gitignore)" >&2
         exit 0
     fi
     if test -n "$(check_prune "$2")"; then


### PR DESCRIPTION
Apropos https://github.com/ocaml/ocaml/pull/10656#issuecomment-956341057, lines like:
```
INFO: pruned path ./_opam (.gitignore)
```
seemed consistent with that done for `.gitattributes` but are far too noisy in worktrees which haven't been cleaned (`_ocamltest` and `.dep` entries dominate the output).

Directories listed with `typo.prune` are actually checked in, so it's reasonable to warn that they aren't scanned but the same is not true for directories listed in `.gitignore`, so just silently prune them.