### PR TITLE
Generate .depend without requiring gnu sed

### DIFF
--- a/stdlib/Makefile
+++ b/stdlib/Makefile
@@ -266,6 +266,6 @@ depend:
 	  stdlib.ml stdlib.mli >> .depend.tmp
 	sed -E \
 	-e 's/^(${STDLIB_NAMESPACE_MODULES})(\.[^i]*)(i?) :/\1\2\3 : \1.ml\3/' \
-	-e 's#(^| )(${STDLIB_NAMESPACE_MODULES})[.]#\1stdlib__\u\2.#' \
-	  .depend.tmp > .depend
-	rm -f .depend.tmp
+	  .depend.tmp > .depend.tmp2
+	awk -v STDLIB_NAMESPACE_MODULES="(^| )($(STDLIB_NAMESPACE_MODULES))[.]" -f add_stdlib.awk .depend.tmp2 > .depend
+	rm -f .depend.tmp .depend.tmp2

--- a/stdlib/add_stdlib.awk
+++ b/stdlib/add_stdlib.awk
@@ -1,0 +1,25 @@
+{ skip = 1 }
+$0 ~ STDLIB_NAMESPACE_MODULES { skip = 0 }
+
+/:/ {
+  if (skip == 1) {
+    print $0
+  } else {
+    printf "stdlib__%s", toupper(substr($1, 1, 1)) substr($1, 2) " " $2 " " $3
+    if ($4 != "")
+      print " " $4
+    else
+      print ""
+  }
+}
+/^[^:]+$/ {
+  if (skip) {
+    print $0
+  } else {
+    printf "    stdlib__%s", toupper(substr($1, 1, 1)) substr($1, 2)
+    if ($2 != "")
+      print " " $2
+    else
+      print ""
+  }
+}


### PR DESCRIPTION
@dbuenzli or @dra27 Here is my try to fix #10708 . I tested on Mac without gnu sed and I get the same .depend :)

It might be overkill (but maybe we can remove the first sed invocation also didn't think about it). Anyway I did it to learn awk. I also think it is always appreciable to require less tool.