### PR TITLE
Improve detection of sed for make alldepend

### DIFF
--- a/Makefile.build_config.in
+++ b/Makefile.build_config.in
@@ -38,6 +38,9 @@ OC_DLL_LDFLAGS=@oc_dll_ldflags@
 # The rlwrap command (for the *runtop targets)
 RLWRAP=@rlwrap@
 
+# The best sed which is available (GNU sed if available)
+SED=@SED@
+
 # Which document generator: odoc or ocamldoc?
 DOCUMENTATION_TOOL=@documentation_tool@
 DOCUMENTATION_TOOL_CMD=@documentation_tool_cmd@

--- a/stdlib/Makefile
+++ b/stdlib/Makefile
@@ -258,13 +258,17 @@ include .depend
 
 STDLIB_NAMESPACE_MODULES = $(subst $(SPACE),|,$(STDLIB_PREFIXED_MODULES))
 
+GNUISH_SED = \
+  $(if $(filter X,$(shell echo x | $(SED) -E -e 's/./\u&/' 2>/dev/null)),\
+       $(SED),$(error GNU sed is needed for make depend))
+
 .PHONY: depend
 depend:
 	$(CAMLDEP) $(DEPFLAGS) $(filter-out stdlib.%,$(wildcard *.mli *.ml)) \
 	  > .depend.tmp
 	$(CAMLDEP) $(DEPFLAGS) -pp "$(AWK) -f ./remove_module_aliases.awk" \
 	  stdlib.ml stdlib.mli >> .depend.tmp
-	sed -E \
+	$(GNUISH_SED) -E \
 	-e 's/^(${STDLIB_NAMESPACE_MODULES})(\.[^i]*)(i?) :/\1\2\3 : \1.ml\3/' \
 	-e 's#(^| )(${STDLIB_NAMESPACE_MODULES})[.]#\1stdlib__\u\2.#' \
 	  .depend.tmp > .depend


### PR DESCRIPTION
I ended up coding this as part of replying to @alissa-tung's PR in #10747, so here it is as a PR, itself.

At present, the generation of `stdlib/.depend` requires a version of `sed` supporting both `-E` (non-standard GNU/BSD compatible option to enable ERE instead of BRE support) and also the `\u` uppercase-single-character replacement GNU extension to the s command.

The detection is done by feature probing, just ensuring whether a single `x` is successfully converted to `X` by sed. Since it's only required in one place, it's just done in `stdlib/Makefile`. The macro first tries the `sed` command, then `gsed` and finally displays an informative error message if no suitable sed can be found. On my Mac, which has GNU sed installed via Homebrew and available as `gsed` but where the `sed` command is still macOS's BSD sed. On that machine, `make -C stdlib depend` now automatically uses `gsed` and if that is not available then a clear error message is displayed.

A few answers to possible questions:
- `$(GNUISH_SED)` is only expanded when the `depend` target is requested (i.e. in `make alldepend` or `make -C stdlib depend`). It's used exactly once, so I have neither replicated the `string lazy_t` pattern in [stdlib/StdlibModules#L52-L57](https://github.com/ocaml/ocaml/blob/trunk/stdlib/StdlibModules#L52-L57) nor put this variable in `Makefile.common`.
- It should be a massive alarm klaxon if we felt this were needed elsewhere in the build system, so it seems fine - in fact, almost better - to do this _lazily_ in `stdlib/Makefile` vs having more m4sh in `configure.ac` which _always_ performs a feature probe which is not required by virtually all builds.
- Ultimately, this code disappears completely because either we sort out the stdlib prefixing in a more principled manner or, post-5.00, I return to my excision of shell-scripts and the uppercasing change is a trivial addition to the sak tool. Or even both!