### PR TITLE
Fix compile error due to unused open

### DIFF
--- a/manual/src/html_processing/src/common.ml.in
+++ b/manual/src/html_processing/src/common.ml.in
@@ -10,7 +10,6 @@
    process_manual.ml *)
 
 open Soup
-open Printf
 
 let debug = not (Array.mem "quiet" Sys.argv)
 


### PR DESCRIPTION
[38449ab1](https://github.com/ocaml/ocaml/commit/38449ab1b016c0f4ba0371dcab55bb2e74556e8f#diff-402c305df22539aa11f50f61b91d520f61461796976149bfc2ecfd2b508ceb41L128) broke the manual/html_processing build (and so `dune build @libs`) by making the `Printf` open unused. (broken only if you have generated a new `common.ml` with `./configure`)

see also https://github.com/ocaml/ocaml/pull/10707#issuecomment-946737239