### PR TITLE
Use GNU parallel for the CI testsuite runs

### DIFF
--- a/tools/ci/actions/runner.sh
+++ b/tools/ci/actions/runner.sh
@@ -67,7 +67,7 @@ Build () {
 
 Test () {
   echo Running the testsuite
-  $MAKE -C testsuite all
+  $MAKE -C testsuite parallel
   cd ..
 }
 


### PR DESCRIPTION
The Jenkins scripts have been using GNU parallel for a while - this updates the GitHub Actions runner and AppVeyor to use them too. Both AppVeyor and GHA Runners have 2 vCPUs, so this gets an expected speed-up, at the cost of the logs taking longer to appear while the tests are running (since GNU parallel preserves the logging order).