### PR TITLE
Build system: add and use the distclean target to all makefiles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1154,6 +1154,7 @@ depend: beforedepend
 
 .PHONY: distclean
 distclean: clean
+	$(MAKE) -C debugger distclean
 	$(MAKE) -C manual distclean
 	$(MAKE) -C ocamltest distclean
 	$(MAKE) -C runtime distclean

--- a/Makefile
+++ b/Makefile
@@ -1155,6 +1155,7 @@ depend: beforedepend
 .PHONY: distclean
 distclean: clean
 	$(MAKE) -C debugger distclean
+	$(MAKE) -C lex distclean
 	$(MAKE) -C manual distclean
 	$(MAKE) -C ocamldoc distclean
 	$(MAKE) -C ocamltest distclean

--- a/Makefile
+++ b/Makefile
@@ -1159,6 +1159,7 @@ distclean: clean
 	$(MAKE) -C manual distclean
 	$(MAKE) -C ocamldoc distclean
 	$(MAKE) -C ocamltest distclean
+	$(MAKE) -C otherlibs distclean
 	$(MAKE) -C runtime distclean
 	$(MAKE) -C stdlib distclean
 	$(MAKE) -C tools distclean

--- a/Makefile
+++ b/Makefile
@@ -1155,6 +1155,7 @@ depend: beforedepend
 .PHONY: distclean
 distclean: clean
 	$(MAKE) -C manual distclean
+	$(MAKE) -C ocamltest distclean
 	$(MAKE) -C runtime distclean
 	$(MAKE) -C stdlib distclean
 	rm -f boot/ocamlrun boot/ocamlrun.exe boot/camlheader \

--- a/Makefile
+++ b/Makefile
@@ -1158,6 +1158,7 @@ distclean: clean
 	$(MAKE) -C ocamltest distclean
 	$(MAKE) -C runtime distclean
 	$(MAKE) -C stdlib distclean
+	$(MAKE) -C tools distclean
 	rm -f boot/ocamlrun boot/ocamlrun.exe boot/camlheader \
 	      boot/ocamlruns boot/ocamlruns.exe \
 	      boot/flexlink.byte boot/flexlink.byte.exe \
@@ -1166,8 +1167,6 @@ distclean: clean
 	rm -f Makefile.config Makefile.build_config
 	rm -rf autom4te.cache flexdll-sources
 	rm -f config.log config.status libtool
-	rm -f tools/eventlog_metadata
-	rm -f tools/*.bak
 	rm -f testsuite/_log*
 
 include .depend

--- a/Makefile
+++ b/Makefile
@@ -1156,6 +1156,7 @@ depend: beforedepend
 distclean: clean
 	$(MAKE) -C debugger distclean
 	$(MAKE) -C manual distclean
+	$(MAKE) -C ocamldoc distclean
 	$(MAKE) -C ocamltest distclean
 	$(MAKE) -C runtime distclean
 	$(MAKE) -C stdlib distclean

--- a/Makefile
+++ b/Makefile
@@ -1162,6 +1162,7 @@ distclean: clean
 	$(MAKE) -C otherlibs distclean
 	$(MAKE) -C runtime distclean
 	$(MAKE) -C stdlib distclean
+	$(MAKE) -C testsuite distclean
 	$(MAKE) -C tools distclean
 	$(MAKE) -C yacc distclean
 	rm -f boot/ocamlrun boot/ocamlrun.exe boot/camlheader \
@@ -1172,7 +1173,6 @@ distclean: clean
 	rm -f Makefile.config Makefile.build_config
 	rm -rf autom4te.cache flexdll-sources
 	rm -f config.log config.status libtool
-	rm -f testsuite/_log*
 
 include .depend
 

--- a/Makefile
+++ b/Makefile
@@ -1159,6 +1159,7 @@ distclean: clean
 	$(MAKE) -C runtime distclean
 	$(MAKE) -C stdlib distclean
 	$(MAKE) -C tools distclean
+	$(MAKE) -C yacc distclean
 	rm -f boot/ocamlrun boot/ocamlrun.exe boot/camlheader \
 	      boot/ocamlruns boot/ocamlruns.exe \
 	      boot/flexlink.byte boot/flexlink.byte.exe \

--- a/api_docgen/Makefile
+++ b/api_docgen/Makefile
@@ -27,5 +27,9 @@ odoc-%:
 ocamldoc-%:
 	$(MAKE) -C ocamldoc $* ROOTDIR=../..
 
+.PHONY: clean
 clean:
 	rm -rf build odoc/build ocamldoc/build
+
+.PHONY: distclean
+distclean: clean

--- a/debugger/Makefile
+++ b/debugger/Makefile
@@ -62,9 +62,13 @@ ocamldebug$(EXE): $(libraries) $(compiler_objects) ocamldebug.cmo \
 install:
 	$(INSTALL_PROG) ocamldebug$(EXE) "$(INSTALL_BINDIR)"
 
+.PHONY: clean
 clean::
 	rm -f ocamldebug ocamldebug.exe
 	rm -f *.cmo *.cmi
+
+.PHONY: distclean
+distclean: clean
 
 ocamldebug_entry.cmo: ocamldebug_entry.ml ocamldebug.cmo
 	$(CAMLC) -c $(COMPFLAGS) $<

--- a/lex/Makefile
+++ b/lex/Makefile
@@ -61,6 +61,9 @@ clean::
 clean::
 	rm -f parser.ml parser.mli parser.output
 
+.PHONY: distclean
+distclean: clean
+
 beforedepend:: parser.ml parser.mli
 
 clean::

--- a/manual/Makefile
+++ b/manual/Makefile
@@ -41,9 +41,11 @@ pregen: tools
 .PHONY: clean
 clean:
 	$(MAKE) -C src clean
-	$(MAKE) -C tools  clean
-	$(MAKE) -C tests  clean
+	$(MAKE) -C tools clean
+	$(MAKE) -C tests clean
 
 .PHONY: distclean
 distclean: clean
 	$(MAKE) -C src distclean
+	$(MAKE) -C tools distclean
+	$(MAKE) -C tests distclean

--- a/manual/src/Makefile
+++ b/manual/src/Makefile
@@ -149,12 +149,12 @@ ifocamldoc.tex: $(ROOTDIR)/Makefile.build_config
 .PHONY: clean
 clean:
 	rm -f $(filter-out version.tex,$(FILES)) *.texquote_error
-	$(MAKE) -C cmds      clean
-	$(MAKE) -C library   clean
-	$(MAKE) -C refman    clean
-	$(MAKE) -C tutorials clean
+	$(MAKE) -C cmds clean
 	$(MAKE) -C html_processing clean
-	-rm -f texstuff/*
+	$(MAKE) -C library clean
+	$(MAKE) -C refman clean
+	$(MAKE) -C tutorials clean
+	rm -f texstuff/*
 	cd htmlman; rm -rf libref compilerlibref *.htoc *.html *.haux *.hind *.svg \
 	                   manual.hmanual manual.hmanual.kwd manual.css
 	cd textman; rm -f manual.txt *.haux *.hind *.htoc
@@ -163,4 +163,8 @@ clean:
 .PHONY: distclean
 distclean: clean
 	rm -f version.tex
+	$(MAKE) -C cmds distclean
 	$(MAKE) -C html_processing distclean
+	$(MAKE) -C library distclean
+	$(MAKE) -C refman distclean
+	$(MAKE) -C tutorials distclean

--- a/manual/src/cmds/Makefile
+++ b/manual/src/cmds/Makefile
@@ -29,3 +29,6 @@ all: $(FILES)
 .PHONY: clean
 clean:
 	rm -f *.tex
+
+.PHONY: distclean
+distclean: clean

--- a/manual/src/library/Makefile
+++ b/manual/src/library/Makefile
@@ -16,3 +16,6 @@ all: etex-files
 .PHONY: clean
 clean:
 	rm -f *.tex ocamldoc.out ocamldoc.sty
+
+.PHONY: distclean
+distclean: clean

--- a/manual/src/refman/Makefile
+++ b/manual/src/refman/Makefile
@@ -41,3 +41,6 @@ all: $(FILES)
 clean:
 	rm -f *.tex
 	rm -f extensions/*.tex
+
+.PHONY: distclean
+distclean: clean

--- a/manual/src/tutorials/Makefile
+++ b/manual/src/tutorials/Makefile
@@ -29,3 +29,6 @@ all: $(FILES)
 .PHONY: clean
 clean:
 	rm -f *.tex
+
+.PHONY: distclean
+distclean: clean

--- a/manual/tests/Makefile
+++ b/manual/tests/Makefile
@@ -58,3 +58,6 @@ endif
 .PHONY: clean
 clean:
 	rm -f *.cm? *.cmx? cross-reference-checker
+
+.PHONY: distclean
+distclean: clean

--- a/manual/tools/Makefile
+++ b/manual/tools/Makefile
@@ -21,8 +21,12 @@ texquote2: texquote2.ml
 
 %.cmi: %.mli
 	$(OCAMLC) $(COMPFLAGS) -c $<
+
 .PHONY: clean
 clean:
 	rm -f *.o *.cm? *.cmx?
 	rm -f transf.ml
 	rm -f texquote2 transf
+
+.PHONY: distclean
+distclean: clean

--- a/ocamldoc/Makefile
+++ b/ocamldoc/Makefile
@@ -347,6 +347,9 @@ clean:
 	rm -f generators/*.cm[taiox] generators/*.a generators/*.lib generators/*.o generators/*.obj \
         generators/*.cmx[as]
 
+.PHONY: distclean
+distclean: clean
+
 .PHONY: depend
 depend: $(DEPEND_PREREQS)
 	$(OCAMLDEP) $(DEPFLAGS) $(DEPINCLUDES) *.mll *.mly *.ml *.mli > .depend

--- a/ocamltest/Makefile
+++ b/ocamltest/Makefile
@@ -301,6 +301,9 @@ ifeq "$(COMPUTE_DEPS)" "true"
 include $(addprefix $(DEPDIR)/, $(c_files:.c=.$(D)))
 endif
 
+.PHONY: distclean
+distclean: clean
+
 $(DEPDIR)/%.$(D): %.c | $(DEPDIR)
 	$(DEP_CC) $(OC_CPPFLAGS) $(CPPFLAGS) $< -MT '$*.$(O)' -MF $@
 

--- a/otherlibs/Makefile
+++ b/otherlibs/Makefile
@@ -30,8 +30,9 @@ define dispatch
 $(eval $(call dispatch_,$1))
 endef
 
-.PHONY: all allopt clean partialclean
+.PHONY: all allopt clean distclean partialclean
 $(call dispatch,all)
 $(call dispatch,allopt)
 $(call dispatch,clean)
+$(call dispatch,distclean)
 $(call dispatch,partialclean)

--- a/otherlibs/Makefile.otherlibs.common
+++ b/otherlibs/Makefile.otherlibs.common
@@ -127,6 +127,9 @@ clean:: partialclean
 	rm -f *.dll *.so *.a *.lib *.o *.obj
 	rm -rf $(DEPDIR)
 
+.PHONY: distclean
+distclean: clean
+
 %.cmi: %.mli
 	$(CAMLC) -c $(COMPFLAGS) $<
 

--- a/otherlibs/dynlink/Makefile
+++ b/otherlibs/dynlink/Makefile
@@ -269,6 +269,9 @@ clean: partialclean
 	      $(LOCAL_SRC)/*.ml $(LOCAL_SRC)/*.mli $(LOCAL_SRC)/Makefile \
 	      $(LOCAL_SRC)/.depend byte/dynlink.mli native/dynlink.mli
 
+.PHONY: distclean
+distclean: clean
+
 .PHONY: beforedepend
 beforedepend: dynlink_platform_intf.mli
 

--- a/otherlibs/systhreads/Makefile
+++ b/otherlibs/systhreads/Makefile
@@ -105,12 +105,17 @@ endif
 	$(CC) -c $(OC_CFLAGS) $(CFLAGS) $(OC_CPPFLAGS) $(CPPFLAGS) \
 	  $(OUTPUTOBJ)$@ $<
 
+.PHONY: partialclean
 partialclean:
 	rm -f *.cm*
 
+.PHONY: clean
 clean: partialclean
 	rm -f dllthreads*.so dllthreads*.dll *.a *.lib *.o *.obj
 	rm -rf $(DEPDIR)
+
+.PHONY: distclean
+distclean: clean
 
 INSTALL_THREADSLIBDIR=$(INSTALL_LIBDIR)/$(LIBNAME)
 

--- a/runtime/Makefile
+++ b/runtime/Makefile
@@ -203,9 +203,9 @@ ld.conf: $(ROOTDIR)/Makefile.config
 # CAMLprim value caml_foo() ...
 # #else
 # CAMLprim value caml_foo() ...
-# end), horrible things will happen (duplicated entries in Runtimedef ->
+# #endif), horrible things will happen: duplicated entries in Runtimedef ->
 # double registration in Symtable -> empty entry in the PRIM table ->
-# the bytecode interpreter is confused).
+# the bytecode interpreter is confused.
 # We sort the primitive file and remove duplicates to avoid this problem.
 
 # Warning: we use "sort | uniq" instead of "sort -u" because in the MSVC

--- a/testsuite/Makefile
+++ b/testsuite/Makefile
@@ -345,6 +345,12 @@ clean:
 	find . -name '*_ocamltest*' | xargs rm -rf
 	rm -f $(failstamp)
 
+.PHONY: distclean
+distclean: clean
+	rm -f _log*
+	$(MACE) -C lib distclean
+	$(MAKE) -C tools distclean
+
 .PHONY: report
 report:
 	@if [ ! -f $(TESTLOG) ]; then echo "No $(TESTLOG) file."; exit 1; fi

--- a/testsuite/lib/Makefile
+++ b/testsuite/lib/Makefile
@@ -55,3 +55,6 @@ testing.cmo : testing.cmi
 .PHONY: clean
 clean:
 	rm -f *.cm* *.o *.obj *.a *.lib
+
+.PHONY: distclean
+distclean: clean

--- a/testsuite/tools/Makefile
+++ b/testsuite/tools/Makefile
@@ -97,3 +97,6 @@ clean:
 	rm -f *.cm* *.o *.obj
 	rm -f expect_test expect_test.exe codegen codegen.exe
 	rm -f parsecmm.ml parsecmm.mli lexcmm.ml
+
+.PHONY: distclean
+distclean: clean

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -347,6 +347,9 @@ DEPINCLUDES=$(INCLUDES)
 depend: beforedepend
 	$(CAMLDEP) $(DEPFLAGS) $(DEPINCLUDES) *.mli *.ml > .depend
 
-.PHONY: clean install beforedepend depend
+.PHONY: clean distclean install beforedepend depend
+
+distclean: clean
+	rm -f eventlog_metadata *.bak
 
 include .depend

--- a/yacc/Makefile
+++ b/yacc/Makefile
@@ -45,6 +45,10 @@ clean:
 	rm -f ocamlyacc ocamlyacc.exe wstr.o wstr.obj \
         $(ocamlyacc_SOURCES:.c=.o) $(ocamlyacc_SOURCES:.c=.obj)
 
+.PHONY: distclean
+distclean: clean
+
+.PHONY: depend
 depend:
 
 closure.$(O): defs.h


### PR DESCRIPTION
This PR consists in a succession of short and easy to reviw commits.

It systematically adds a distclean target to all the makefiles that have
a clean one and makes sure the root makefile uses it to remove the files
in each directory, rather than removing them directly as was done before.

It is likely that the declaration of distclean could have been factorized
in Makefile.common rather than being added explicitly to each file
but that would have been different of how it's done for other targets
so I preferred not to do this here. The aim of this PR is really
only to make sure every makefile has a distclean target.

Factorizing how the rules are declared can be done later in a dedicated
PR if one wishes so.