### PR TITLE
Preserve literal formatting in "Did you mean ...?"

### DIFF
--- a/bytecomp/symtable.ml
+++ b/bytecomp/symtable.ml
@@ -221,9 +221,9 @@ let rec transl_const = function
   | Const_base(Const_char c) -> Obj.repr c
   | Const_base(Const_string (s, _, _)) -> Obj.repr s
   | Const_base(Const_float f) -> Obj.repr (float_of_string f)
-  | Const_base(Const_int32 i) -> Obj.repr i
-  | Const_base(Const_int64 i) -> Obj.repr i
-  | Const_base(Const_nativeint i) -> Obj.repr i
+  | Const_base(Const_int32 (i, _)) -> Obj.repr i
+  | Const_base(Const_int64 (i, _)) -> Obj.repr i
+  | Const_base(Const_nativeint (i, _)) -> Obj.repr i
   | Const_immstring s -> Obj.repr s
   | Const_block(tag, fields) ->
       let block = Obj.new_block tag (List.length fields) in

--- a/lambda/printlambda.ml
+++ b/lambda/printlambda.ml
@@ -26,9 +26,9 @@ let rec struct_const ppf = function
   | Const_base(Const_string (s, _, _)) -> fprintf ppf "%S" s
   | Const_immstring s -> fprintf ppf "#%S" s
   | Const_base(Const_float f) -> fprintf ppf "%s" f
-  | Const_base(Const_int32 n) -> fprintf ppf "%lil" n
-  | Const_base(Const_int64 n) -> fprintf ppf "%LiL" n
-  | Const_base(Const_nativeint n) -> fprintf ppf "%nin" n
+  | Const_base(Const_int32 (_, s)) -> fprintf ppf "%sl" s
+  | Const_base(Const_int64 (_, s)) -> fprintf ppf "%sL" s
+  | Const_base(Const_nativeint (_, s)) -> fprintf ppf "%sn" s
   | Const_block(tag, []) ->
       fprintf ppf "[%i]" tag
   | Const_block(tag, sc1::scl) ->

--- a/middle_end/closure/closure.ml
+++ b/middle_end/closure/closure.ml
@@ -920,9 +920,9 @@ let rec close ({ backend; fenv; cenv ; mutable_vars } as env) lam =
                  that one could modify our string literal.  *)
             str ~shared:Config.safe_string (Uconst_string s)
         | Const_base(Const_float x) -> str (Uconst_float (float_of_string x))
-        | Const_base(Const_int32 x) -> str (Uconst_int32 x)
-        | Const_base(Const_int64 x) -> str (Uconst_int64 x)
-        | Const_base(Const_nativeint x) -> str (Uconst_nativeint x)
+        | Const_base(Const_int32 (x, _)) -> str (Uconst_int32 x)
+        | Const_base(Const_int64 (x, _)) -> str (Uconst_int64 x)
+        | Const_base(Const_nativeint (x, _)) -> str (Uconst_nativeint x)
       in
       make_const (transl cst)
   | Lfunction _ as funct ->

--- a/middle_end/flambda/closure_conversion.ml
+++ b/middle_end/flambda/closure_conversion.ml
@@ -129,13 +129,13 @@ let rec declare_const t (const : Lambda.structured_constant)
     register_const t
       (Allocated_const (Float (float_of_string c)))
       Names.const_float
-  | Const_base (Const_int32 c) ->
+  | Const_base (Const_int32 (c, _)) ->
     register_const t (Allocated_const (Int32 c))
       Names.const_int32
-  | Const_base (Const_int64 c) ->
+  | Const_base (Const_int64 (c, _)) ->
     register_const t (Allocated_const (Int64 c))
       Names.const_int64
-  | Const_base (Const_nativeint c) ->
+  | Const_base (Const_nativeint (c, _)) ->
     register_const t (Allocated_const (Nativeint c)) Names.const_nativeint
   | Const_immstring c ->
     register_const t (Allocated_const (Immutable_string c))

--- a/parsing/asttypes.mli
+++ b/parsing/asttypes.mli
@@ -25,9 +25,9 @@ type constant =
   | Const_char of char
   | Const_string of string * Location.t * string option
   | Const_float of string
-  | Const_int32 of int32
-  | Const_int64 of int64
-  | Const_nativeint of nativeint
+  | Const_int32 of int32 * string
+  | Const_int64 of int64 * string
+  | Const_nativeint of nativeint * string
 
 type rec_flag = Nonrecursive | Recursive
 

--- a/testsuite/tests/typing-core-bugs/const_int_hint.ml
+++ b/testsuite/tests/typing-core-bugs/const_int_hint.ml
@@ -144,3 +144,126 @@ Line 1, characters 14-16:
 Error: This expression has type int64 but an expression was expected of type
          int
 |}]
+
+(* Check that the hint preserves formatting for int32 literals *)
+let _ = Int64.(add 1_000l 2L);;
+[%%expect{|
+Line 1, characters 19-25:
+1 | let _ = Int64.(add 1_000l 2L);;
+                       ^^^^^^
+Error: This expression has type int32 but an expression was expected of type
+         int64
+  Hint: Did you mean `1_000L'?
+|}]
+
+let _ = Int64.(add 0xAA_BBl 2L);;
+[%%expect{|
+Line 1, characters 19-27:
+1 | let _ = Int64.(add 0xAA_BBl 2L);;
+                       ^^^^^^^^
+Error: This expression has type int32 but an expression was expected of type
+         int64
+  Hint: Did you mean `0xAA_BBL'?
+|}]
+
+let _ = Int64.(add 0o2_345l 2L);;
+[%%expect{|
+Line 1, characters 19-27:
+1 | let _ = Int64.(add 0o2_345l 2L);;
+                       ^^^^^^^^
+Error: This expression has type int32 but an expression was expected of type
+         int64
+  Hint: Did you mean `0o2_345L'?
+|}]
+
+let _ = Int64.(add 0b1000_1101l 2L);;
+[%%expect{|
+Line 1, characters 19-31:
+1 | let _ = Int64.(add 0b1000_1101l 2L);;
+                       ^^^^^^^^^^^^
+Error: This expression has type int32 but an expression was expected of type
+         int64
+  Hint: Did you mean `0b1000_1101L'?
+|}]
+
+(* Check that the hint preserves formatting for int64 literals *)
+let _ = Int32.(add 1_000L 2l);;
+[%%expect{|
+Line 1, characters 19-25:
+1 | let _ = Int32.(add 1_000L 2l);;
+                       ^^^^^^
+Error: This expression has type int64 but an expression was expected of type
+         int32
+  Hint: Did you mean `1_000l'?
+|}]
+
+let _ = Int32.(add 0xAA_BBL 2l);;
+[%%expect{|
+Line 1, characters 19-27:
+1 | let _ = Int32.(add 0xAA_BBL 2l);;
+                       ^^^^^^^^
+Error: This expression has type int64 but an expression was expected of type
+         int32
+  Hint: Did you mean `0xAA_BBl'?
+|}]
+
+let _ = Int32.(add 0o2_345L 2l);;
+[%%expect{|
+Line 1, characters 19-27:
+1 | let _ = Int32.(add 0o2_345L 2l);;
+                       ^^^^^^^^
+Error: This expression has type int64 but an expression was expected of type
+         int32
+  Hint: Did you mean `0o2_345l'?
+|}]
+
+let _ = Int32.(add 0b1000_1101L 2l);;
+[%%expect{|
+Line 1, characters 19-31:
+1 | let _ = Int32.(add 0b1000_1101L 2l);;
+                       ^^^^^^^^^^^^
+Error: This expression has type int64 but an expression was expected of type
+         int32
+  Hint: Did you mean `0b1000_1101l'?
+|}]
+
+(* Check that the hint preserves formatting for nativeint literals *)
+let _ = Int64.(add 1_000n 2L);;
+[%%expect{|
+Line 1, characters 19-25:
+1 | let _ = Int64.(add 1_000n 2L);;
+                       ^^^^^^
+Error: This expression has type nativeint
+       but an expression was expected of type int64
+  Hint: Did you mean `1_000L'?
+|}]
+
+let _ = Int64.(add 0xAA_BBn 2L);;
+[%%expect{|
+Line 1, characters 19-27:
+1 | let _ = Int64.(add 0xAA_BBn 2L);;
+                       ^^^^^^^^
+Error: This expression has type nativeint
+       but an expression was expected of type int64
+  Hint: Did you mean `0xAA_BBL'?
+|}]
+
+let _ = Int64.(add 0o2_345n 2L);;
+[%%expect{|
+Line 1, characters 19-27:
+1 | let _ = Int64.(add 0o2_345n 2L);;
+                       ^^^^^^^^
+Error: This expression has type nativeint
+       but an expression was expected of type int64
+  Hint: Did you mean `0o2_345L'?
+|}]
+
+let _ = Int64.(add 0b1000_1101n 2L);;
+[%%expect{|
+Line 1, characters 19-31:
+1 | let _ = Int64.(add 0b1000_1101n 2L);;
+                       ^^^^^^^^^^^^
+Error: This expression has type nativeint
+       but an expression was expected of type int64
+  Hint: Did you mean `0b1000_1101L'?
+|}]

--- a/tools/dumpobj.ml
+++ b/tools/dumpobj.ml
@@ -89,9 +89,9 @@ let rec print_struct_const = function
   | Const_base(Const_string (s, _, _)) -> printf "%S" s
   | Const_immstring s -> printf "%S" s
   | Const_base(Const_char c) -> printf "%C" c
-  | Const_base(Const_int32 i) -> printf "%ldl" i
-  | Const_base(Const_nativeint i) -> printf "%ndn" i
-  | Const_base(Const_int64 i) -> printf "%LdL" i
+  | Const_base(Const_int32 (i, _)) -> printf "%ldl" i
+  | Const_base(Const_nativeint (i, _)) -> printf "%ndn" i
+  | Const_base(Const_int64 (i, _)) -> printf "%LdL" i
   | Const_block(tag, args) ->
       printf "<%d>" tag;
       begin match args with

--- a/typing/parmatch.ml
+++ b/typing/parmatch.ml
@@ -1007,18 +1007,18 @@ let build_other ext env =
             0 succ d env
       | Constant Const_int32 _ ->
           build_other_constant
-            (function Constant(Const_int32 i) -> i | _ -> assert false)
-            (function i -> Tpat_constant(Const_int32 i))
+            (function Constant(Const_int32 (i, _)) -> i | _ -> assert false)
+            (function i -> Tpat_constant(Const_int32 (i, Int32.to_string i)))
             0l Int32.succ d env
       | Constant Const_int64 _ ->
           build_other_constant
-            (function Constant(Const_int64 i) -> i | _ -> assert false)
-            (function i -> Tpat_constant(Const_int64 i))
+            (function Constant(Const_int64 (i, _)) -> i | _ -> assert false)
+            (function i -> Tpat_constant(Const_int64 (i, Int64.to_string i)))
             0L Int64.succ d env
       | Constant Const_nativeint _ ->
           build_other_constant
-            (function Constant(Const_nativeint i) -> i | _ -> assert false)
-            (function i -> Tpat_constant(Const_nativeint i))
+            (function Constant(Const_nativeint (i, _)) -> i | _ -> assert false)
+            (function i -> Tpat_constant(Const_nativeint (i, Nativeint.to_string i)))
             0n Nativeint.succ d env
       | Constant Const_string _ ->
           build_other_constant

--- a/typing/printpat.ml
+++ b/typing/printpat.ml
@@ -29,9 +29,9 @@ let pretty_const c = match c with
 | Const_char c -> Printf.sprintf "%C" c
 | Const_string (s, _, _) -> Printf.sprintf "%S" s
 | Const_float f -> Printf.sprintf "%s" f
-| Const_int32 i -> Printf.sprintf "%ldl" i
-| Const_int64 i -> Printf.sprintf "%LdL" i
-| Const_nativeint i -> Printf.sprintf "%ndn" i
+| Const_int32 (_, s) -> Printf.sprintf "%sl" s
+| Const_int64 (_, s) -> Printf.sprintf "%sL" s
+| Const_nativeint (_, s) -> Printf.sprintf "%sn" s
 
 let pretty_extra ppf (cstr, _loc, _attrs) pretty_rest rest =
   match cstr with

--- a/typing/printtyped.ml
+++ b/typing/printtyped.ml
@@ -69,9 +69,9 @@ let fmt_constant f x =
   | Const_string (s, strloc, Some delim) ->
       fprintf f "Const_string (%S,%a,Some %S)" s fmt_location strloc delim;
   | Const_float (s) -> fprintf f "Const_float %s" s;
-  | Const_int32 (i) -> fprintf f "Const_int32 %ld" i;
-  | Const_int64 (i) -> fprintf f "Const_int64 %Ld" i;
-  | Const_nativeint (i) -> fprintf f "Const_nativeint %nd" i;
+  | Const_int32 (_, s) -> fprintf f "Const_int32 %sl" s;
+  | Const_int64 (_, s) -> fprintf f "Const_int64 %sL" s;
+  | Const_nativeint (_, s) -> fprintf f "Const_nativeint %sn" s;
 ;;
 
 let fmt_mutable_flag f x =

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -253,17 +253,17 @@ let constant : Parsetree.constant -> (Asttypes.constant, error) result =
      end
   | Pconst_integer (i,Some 'l') ->
      begin
-       try Ok (Const_int32 (Misc.Int_literal_converter.int32 i))
+       try Ok (Const_int32 (Misc.Int_literal_converter.int32 i, i))
        with Failure _ -> Error (Literal_overflow "int32")
      end
   | Pconst_integer (i,Some 'L') ->
      begin
-       try Ok (Const_int64 (Misc.Int_literal_converter.int64 i))
+       try Ok (Const_int64 (Misc.Int_literal_converter.int64 i, i))
        with Failure _ -> Error (Literal_overflow "int64")
      end
   | Pconst_integer (i,Some 'n') ->
      begin
-       try Ok (Const_nativeint (Misc.Int_literal_converter.nativeint i))
+       try Ok (Const_nativeint (Misc.Int_literal_converter.nativeint i, i))
        with Failure _ -> Error (Literal_overflow "nativeint")
      end
   | Pconst_integer (i,Some c) -> Error (Unknown_literal (i, c))
@@ -5445,9 +5445,9 @@ let type_clash_of_trace trace =
 let report_literal_type_constraint expected_type const =
   let const_str = match const with
     | Const_int n -> Some (Int.to_string n)
-    | Const_int32 n -> Some (Int32.to_string n)
-    | Const_int64 n -> Some (Int64.to_string n)
-    | Const_nativeint n -> Some (Nativeint.to_string n)
+    | Const_int32 (_, s) -> Some s
+    | Const_int64 (_, s) -> Some s
+    | Const_nativeint (_, s) -> Some s
     | _ -> None
   in
   let suffix =

--- a/typing/untypeast.ml
+++ b/typing/untypeast.ml
@@ -134,9 +134,9 @@ let constant = function
   | Const_char c -> Pconst_char c
   | Const_string (s,loc,d) -> Pconst_string (s,loc,d)
   | Const_int i -> Pconst_integer (Int.to_string i, None)
-  | Const_int32 i -> Pconst_integer (Int32.to_string i, Some 'l')
-  | Const_int64 i -> Pconst_integer (Int64.to_string i, Some 'L')
-  | Const_nativeint i -> Pconst_integer (Nativeint.to_string i, Some 'n')
+  | Const_int32 (_, s) -> Pconst_integer (s, Some 'l')
+  | Const_int64 (_, s) -> Pconst_integer (s, Some 'L')
+  | Const_nativeint (_, s) -> Pconst_integer (s, Some 'n')
   | Const_float f -> Pconst_float (f,None)
 
 let attribute sub a = {


### PR DESCRIPTION
Implements "Proposal 1" in https://github.com/ocaml/ocaml/issues/10766.

**Alternative implementation: see #10818.**

# User-visible changes

The goal of this PR is to preserve the original formatting of integer literals (`int32`, `int64` and `nativeint`) in the "Did you mean ...?" hint.

**Before**
```
1 | let _ = Int64.(add 0xAA_BBl 2L);;
                       ^^^^^^^^
Error: This expression has type int32 but an expression was expected of type
         int64
  Hint: Did you mean `43707L'?
```
 
**After**
```
1 | let _ = Int64.(add 0xAA_BBl 2L);;
                       ^^^^^^^^
Error: This expression has type int32 but an expression was expected of type
         int64
  Hint: Did you mean `0xAA_BBL'?
```

# API changes

`Asttypes.constant` changes: `Const_int32`, `Const_int64` and `Const_nativeint` are now tuples; the second value is a string containing the original formatting of the literal (but without the suffix).

Note that `Asttypes.mli` warns about this module being unstable and part of `compiler-libs`.