### PR TITLE
Test whether mingw32 (cc and asm) supports debug-prefix-map option

### DIFF
--- a/Changes
+++ b/Changes
@@ -285,6 +285,10 @@ Working version
 
 ### Build system:
 
+- #10769: Enable debug-prefix-map with mingw32 and clang compiler and
+  assembler.
+  (Antonin Décimo, review by David Allsopp)
+
 - #11590: Allow installing to a destination path containing spaces.
    (Élie Brami, review by Sébastien Hinderer and David Allsopp)
 

--- a/aclocal.m4
+++ b/aclocal.m4
@@ -188,7 +188,7 @@ camlPervasives__loop_1128:
     ])],
     [as_has_debug_prefix_map=true
     AC_MSG_RESULT([yes])],
-    [ashas_debug_prefix_map=false
+    [as_has_debug_prefix_map=false
     AC_MSG_RESULT([no])])
 
   OCAML_CC_RESTORE_VARIABLES

--- a/aclocal.m4
+++ b/aclocal.m4
@@ -175,7 +175,7 @@ AC_DEFUN([OCAML_AS_HAS_DEBUG_PREFIX_MAP], [
 
   # Modify C-compiler variables to use the assembler
   CC="$AS"
-  CFLAGS="--debug-prefix-map old=new -o conftest.$ac_objext"
+  CFLAGS="--debug-prefix-map=old=new -o conftest.$ac_objext"
   CPPFLAGS=""
   ac_ext="S"
   ac_compile='$CC $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'

--- a/configure
+++ b/configure
@@ -18857,7 +18857,7 @@ then :
     { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
 printf "%s\n" "yes" >&6; }
 else $as_nop
-  ashas_debug_prefix_map=false
+  as_has_debug_prefix_map=false
     { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
 printf "%s\n" "no" >&6; }
 fi

--- a/configure
+++ b/configure
@@ -17304,8 +17304,6 @@ fi
 
 ## -fdebug-prefix-map support by the C compiler
 case $ocaml_cv_cc_vendor,$host in #(
-  *,*-*-mingw32) :
-    cc_has_debug_prefix_map=false ;; #(
   *,*-pc-windows) :
     cc_has_debug_prefix_map=false ;; #(
   xlc*,powerpc-ibm-aix*) :
@@ -18813,13 +18811,12 @@ printf "%s\n" "$as_me: the threads library is disabled" >&6;} ;; #(
 printf "%s\n" "$as_me: the threads library is supported" >&6;} ;;
 esac
 
-## Does the assembler support debug prefix map and CFI directives
+## Does the assembler support debug prefix map
 as_has_debug_prefix_map=false
-asm_cfi_supported=false
 if $native_compiler
 then :
   case $host in #(
-  *-*-mingw32|*-pc-windows) :
+  *-pc-windows) :
      ;; #(
   *) :
 
@@ -18841,7 +18838,7 @@ printf %s "checking whether the assembler supports --debug-prefix-map... " >&6; 
 
   # Modify C-compiler variables to use the assembler
   CC="$AS"
-  CFLAGS="--debug-prefix-map old=new -o conftest.$ac_objext"
+  CFLAGS="--debug-prefix-map=old=new -o conftest.$ac_objext"
   CPPFLAGS=""
   ac_ext="S"
   ac_compile='$CC $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
@@ -18876,7 +18873,18 @@ rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
   CC="$saved_CC"
   LIBS="$saved_LIBS"
 
+ ;;
+esac
+fi
 
+## Does the assembler support CFI directives
+asm_cfi_supported=false
+if $native_compiler
+then :
+  case $host in #(
+  *-*-mingw32|*-pc-windows) :
+     ;; #(
+  *) :
 
   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether the assembler supports CFI directives" >&5
 printf %s "checking whether the assembler supports CFI directives... " >&6; }

--- a/configure.ac
+++ b/configure.ac
@@ -1804,7 +1804,6 @@ AC_CHECK_FUNC([pwrite], [AC_DEFINE([HAS_PWRITE])])
 
 ## -fdebug-prefix-map support by the C compiler
 AS_CASE([$ocaml_cv_cc_vendor,$host],
-  [*,*-*-mingw32], [cc_has_debug_prefix_map=false],
   [*,*-pc-windows], [cc_has_debug_prefix_map=false],
   [xlc*,powerpc-ibm-aix*], [cc_has_debug_prefix_map=false],
   [sunc*,sparc-sun-*], [cc_has_debug_prefix_map=false],
@@ -1987,14 +1986,19 @@ AS_CASE([$enable_systhreads,$enable_unix_lib],
   lib_systhreads=true
   AC_MSG_NOTICE([the threads library is supported])])
 
-## Does the assembler support debug prefix map and CFI directives
+## Does the assembler support debug prefix map
 as_has_debug_prefix_map=false
+AS_IF([$native_compiler],
+  [AS_CASE([$host],
+    [*-pc-windows], [],
+    [OCAML_AS_HAS_DEBUG_PREFIX_MAP])])
+
+## Does the assembler support CFI directives
 asm_cfi_supported=false
 AS_IF([$native_compiler],
   [AS_CASE([$host],
     [*-*-mingw32|*-pc-windows], [],
-    [OCAML_AS_HAS_DEBUG_PREFIX_MAP
-    OCAML_AS_HAS_CFI_DIRECTIVES])])
+    [OCAML_AS_HAS_CFI_DIRECTIVES])])
 
 ## Frame pointers
 

--- a/utils/misc.ml
+++ b/utils/misc.ml
@@ -857,7 +857,7 @@ let debug_prefix_map_flags () =
            match map_elem with
            | None -> acc
            | Some { Build_path_prefix_map.target; source; } ->
-             (Printf.sprintf "--debug-prefix-map %s=%s"
+             (Printf.sprintf "--debug-prefix-map=%s=%s"
                 (Filename.quote source)
                 (Filename.quote target)) :: acc)
         map


### PR DESCRIPTION
I noticed that mingw32 was left out of the detection of debug-prefix-map in the configure script. The compiler and the assembler definitely support that flag (with a minor parsing difference with stock GCC), so I changed the configure script to include mingw32 in the testing for the support of the flags.
I also spotted a minor typo that shouldn't change anything since the default value of `as_has_debug_prefix_map` is `false`.