### PR TITLE
typechecker, #10762: restrict redo in unify_row_field

### DIFF
--- a/testsuite/tests/typing-misc/polyvars.ml
+++ b/testsuite/tests/typing-misc/polyvars.ml
@@ -197,3 +197,15 @@ Error: This recursive type is not regular.
          ('e, 'c, 'b, 'd, 'a) c = [ `C of ('e, 'c, 'b, 'd, 'a) a ]
        All uses need to match the definition for the recursive type to be regular.
 |}]
+
+(* PR 10762 *)
+type a = int
+type t = [ `A of a ]
+let inspect: [< t ] -> unit = function
+  | `A 0 -> ()
+  | `A _ -> ()
+[%%expect {|
+type a = int
+type t = [ `A of a ]
+val inspect : [< `A of a & int ] -> unit = <fun>
+|}]

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -3048,8 +3048,9 @@ and unify_row_field env fixed1 fixed2 rm1 rm2 l f1 f2 =
         begin match tl1 @ tl2 with [] -> false
         | t1 :: tl ->
             if no_arg then raise_unexplained_for Unify;
-            if List.for_all (unify_eq t1) tl then false else
-            (List.iter (unify env t1) tl; true)
+            Types.changed_row_field_exts [f1;f2] (fun () ->
+                List.iter (unify env t1) tl
+              )
         end in
       if redo then unify_row_field env fixed1 fixed2 rm1 rm2 l f1 f2 else
       let remq tl =

--- a/typing/types.ml
+++ b/typing/types.ml
@@ -653,6 +653,11 @@ let rf_either_of = function
 let eq_row_field_ext rf1 rf2 =
   row_field_ext rf1 == row_field_ext rf2
 
+let changed_row_field_exts l f =
+  let exts = List.map row_field_ext l in
+  f ();
+  List.exists (fun r -> !r <> RFnone) exts
+
 let match_row_field ~present ~absent ~either (f : row_field) =
   match f with
   | RFabsent -> absent ()

--- a/typing/types.mli
+++ b/typing/types.mli
@@ -344,6 +344,8 @@ val rf_either:
 val rf_either_of: type_expr option -> row_field
 
 val eq_row_field_ext: row_field -> row_field -> bool
+val changed_row_field_exts: row_field list -> (unit -> unit) -> bool
+
 val match_row_field:
     present:(type_expr option -> 'a) ->
     absent:(unit -> 'a) ->


### PR DESCRIPTION
This PR restores the behavior of `Ctypes.unify_row_field` to the one before #10627 : it redoes the computation of the field unification only if the unification of the conjunction of argument types extended the current conjunction. This avoids an infinite loop when a type abbreviation might hide a type equality at a cost of a new abstraction-leaking function in `Types`. 

Close #10762