### PR TITLE
Printast: consistently print locations in ast

### DIFF
--- a/testsuite/tests/tool-ocamlc-stop-after/stop_after_parsing_impl.compilers.reference
+++ b/testsuite/tests/tool-ocamlc-stop-after/stop_after_parsing_impl.compilers.reference
@@ -2,7 +2,7 @@
   structure_item (stop_after_parsing_impl.ml[12,306+0]..[12,306+24])
     Pstr_value Nonrec
     [
-      <def>
+      <def> (stop_after_parsing_impl.ml[12,306+0]..[12,306+24])
         pattern (stop_after_parsing_impl.ml[12,306+4]..[12,306+5])
           Ppat_any
         expression (stop_after_parsing_impl.ml[12,306+8]..[12,306+24])


### PR DESCRIPTION
This PR brings more consistency in `Printast`, a lot of locations were not printed. This is a change we made in `ocamlformat` to improve our debug mode (we need to exhaustively print all locations in the AST, as the comments are attached to locations), and it would be great to see this change upstreamed.
