### PR TITLE
Fix ranlib error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -549,6 +549,8 @@ else
 endif
 	$(MAKE) -C tools installopt
 
+LIBRARIES = $(addsuffix .$(A), ocamlcommon ocamlbytecomp ocamloptcomp)
+
 .PHONY: installoptopt
 installoptopt:
 	$(INSTALL_PROG) ocamlc.opt$(EXE) "$(INSTALL_BINDIR)"
@@ -585,8 +587,11 @@ endif
 ifeq "$(INSTALL_OCAMLNAT)" "true"
 	  $(INSTALL_PROG) ocamlnat$(EXE) "$(INSTALL_BINDIR)"
 endif
-	cd "$(INSTALL_COMPLIBDIR)" && \
-	   $(RANLIB) ocamlcommon.$(A) ocamlbytecomp.$(A) ocamloptcomp.$(A)
+# Some versions of ranlib do not support multiple archives
+	for library in $(LIBRARIES); \
+	do \
+	  $(RANLIB) "$(INSTALL_COMPLIBDIR)/$$library"; \
+	done
 
 # Installation of the *.ml sources of compiler-libs
 .PHONY: install-compiler-sources

--- a/otherlibs/Makefile.otherlibs.common
+++ b/otherlibs/Makefile.otherlibs.common
@@ -95,7 +95,7 @@ install::
 	fi
 ifneq "$(STUBSLIB)" ""
 	$(INSTALL_DATA) $(STUBSLIB) "$(INSTALL_LIBDIR)/"
-	cd "$(INSTALL_LIBDIR)"; $(RANLIB) lib$(CLIBNAME).$(A)
+	$(RANLIB) "$(INSTALL_LIBDIR)/lib$(CLIBNAME).$(A)"
 endif
 
 	$(INSTALL_DATA) \
@@ -104,7 +104,7 @@ endif
 ifeq "$(INSTALL_SOURCE_ARTIFACTS)" "true"
 	$(INSTALL_DATA) \
 	  $(CMIFILES:.cmi=.mli) \
-          $(CMIFILES:.cmi=.cmti) \
+	        $(CMIFILES:.cmi=.cmti) \
 	  "$(INSTALL_LIBDIR)/"
 endif
 	if test -n "$(HEADERS)"; then \
@@ -115,7 +115,7 @@ installopt:
 	$(INSTALL_DATA) \
 	   $(CAMLOBJS_NAT) $(LIBNAME).cmxa $(LIBNAME).$(A) \
 	   "$(INSTALL_LIBDIR)/"
-	cd "$(INSTALL_LIBDIR)"; $(RANLIB) $(LIBNAME).a
+	$(RANLIB) "$(INSTALL_LIBDIR)/$(LIBNAME).$(A)"
 	if test -f $(LIBNAME).cmxs; then \
 	  $(INSTALL_PROG) $(LIBNAME).cmxs "$(INSTALL_LIBDIR)"; \
 	fi

--- a/otherlibs/dynlink/Makefile
+++ b/otherlibs/dynlink/Makefile
@@ -249,12 +249,12 @@ ifeq "$(INSTALL_SOURCE_ARTIFACTS)" "true"
 endif
 
 installopt:
-	if $(NATDYNLINK); then \
-	  $(INSTALL_DATA) \
-	    $(NATOBJS) dynlink.cmxa dynlink.$(A) \
-	    "$(INSTALL_LIBDIR)" && \
-	  cd "$(INSTALL_LIBDIR)" && $(RANLIB) dynlink.$(A); \
-	fi
+ifeq "$(NATDYNLINK)" "true"
+	$(INSTALL_DATA) \
+	  $(NATOBJS) dynlink.cmxa dynlink.$(A) \
+	  "$(INSTALL_LIBDIR)"
+	$(RANLIB) "$(INSTALL_LIBDIR)/dynlink.$(A)"
+endif
 
 partialclean:
 	rm -f $(extract_crc) *.cm[ioaxt] *.cmti *.cmxa \

--- a/otherlibs/systhreads/Makefile
+++ b/otherlibs/systhreads/Makefile
@@ -121,7 +121,7 @@ install:
 	  $(INSTALL_PROG) dllthreads$(EXT_DLL) "$(INSTALL_STUBLIBDIR)"; \
 	fi
 	$(INSTALL_DATA) libthreads.$(A) "$(INSTALL_LIBDIR)"
-	cd "$(INSTALL_LIBDIR)"; $(RANLIB) libthreads.$(A)
+	$(RANLIB) "$(INSTALL_LIBDIR)/libthreads.$(A)"
 	mkdir -p "$(INSTALL_THREADSLIBDIR)"
 	$(INSTALL_DATA) \
 	  $(CMIFILES) threads.cma \
@@ -136,11 +136,11 @@ endif
 
 installopt:
 	$(INSTALL_DATA) libthreadsnat.$(A) "$(INSTALL_LIBDIR)"
-	cd "$(INSTALL_LIBDIR)"; $(RANLIB) libthreadsnat.$(A)
+	$(RANLIB) "$(INSTALL_LIBDIR)/libthreadsnat.$(A)"
 	$(INSTALL_DATA) \
 	  $(THREADS_NCOBJS) threads.cmxa threads.$(A) \
 	  "$(INSTALL_THREADSLIBDIR)"
-	cd "$(INSTALL_THREADSLIBDIR)" && $(RANLIB) threads.$(A)
+	$(RANLIB) "$(INSTALL_THREADSLIBDIR)/threads.$(A)"
 
 %.cmi: %.mli
 	$(CAMLC) -c $(COMPFLAGS) $<

--- a/stdlib/Makefile
+++ b/stdlib/Makefile
@@ -105,7 +105,7 @@ installopt-default::
 	$(INSTALL_DATA) \
 	  stdlib.cmxa stdlib.$(A) std_exit.$(O) *.cmx \
 	  "$(INSTALL_LIBDIR)"
-	cd "$(INSTALL_LIBDIR)"; $(RANLIB) stdlib.$(A)
+	$(RANLIB) "$(INSTALL_LIBDIR)/stdlib.$(A)"
 
 ifeq "$(UNIX_OR_WIN32)" "unix"
 HEADERPROGRAM = header


### PR DESCRIPTION
On certain versions of ranlib we get an error:

    ranlib: error: Exactly one archive should be specified.

This change circumvents that error.