### PR TITLE
Allow type aliases with re-exporting to be specialised

### DIFF
--- a/testsuite/tests/typing-misc/records.ml
+++ b/testsuite/tests/typing-misc/records.ml
@@ -258,3 +258,218 @@ Line 1, characters 0-30:
 Error: This variant or record definition does not match that of type d
        Fields x and y have been swapped.
 |}]
+
+(* Adding type variables *)
+module M = struct
+  type t = {foo: int}
+end
+module N = struct
+  type 'a t = M.t = {foo: int}
+end;;
+let m = {M.foo= 15};;
+let n = {N.foo= 15};;
+let f = function | {M.foo= x} -> x;;
+let g = function | {N.foo= x} -> x;;
+let f_m = f m;;
+let f_n = f n;;
+let g_m = g m;;
+let g_n = g n;;
+[%%expect{|
+module M : sig type t = { foo : int; } end
+module N : sig type 'a t = M.t = { foo : int; } end
+val m : M.t = {M.foo = 15}
+val n : 'a N.t = {N.foo = 15}
+val f : M.t -> int = <fun>
+val g : 'a N.t -> int = <fun>
+val f_m : int = 15
+val f_n : int = 15
+val g_m : int = 15
+val g_n : int = 15
+|}]
+
+(* Adding type variables with invalid constraint *)
+module M = struct
+  type t = {foo: int}
+end
+module N = struct
+  type 'a t = M.t = {foo: 'a}
+end;;
+[%%expect{|
+module M : sig type t = { foo : int; } end
+Line 5, characters 2-29:
+5 |   type 'a t = M.t = {foo: 'a}
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This variant or record definition does not match that of type M.t
+       Fields do not match:
+         foo : int;
+       is not the same as:
+         foo : 'a;
+       The type int is not equal to the type 'a
+|}]
+
+(* Adding constrained type variables *)
+module M = struct
+  type t = {foo: int}
+end
+module N = struct
+  type 'a t = M.t = {foo: 'a} constraint 'a = int
+end;;
+let m = {M.foo= 15};;
+let n = {N.foo= 15};;
+let f = function | {M.foo= x} -> x;;
+let g = function | {N.foo= x} -> x;;
+let f_m = f m;;
+let f_n = f n;;
+let g_m = g m;;
+let g_n = g n;;
+[%%expect{|
+module M : sig type t = { foo : int; } end
+module N : sig type 'a t = M.t = { foo : 'a; } constraint 'a = int end
+val m : M.t = {M.foo = 15}
+val n : int N.t = {N.foo = 15}
+val f : M.t -> int = <fun>
+val g : int N.t -> int = <fun>
+val f_m : int = 15
+val f_n : int = 15
+val g_m : int = 15
+val g_n : int = 15
+|}]
+let n_bad = {N.foo= true};;
+[%%expect{|
+Line 1, characters 20-24:
+1 | let n_bad = {N.foo= true};;
+                        ^^^^
+Error: This expression has type bool but an expression was expected of type
+         int
+|}]
+
+(* Mixing type variables *)
+module M = struct
+  type ('a, 'b) t = {a: 'a; b: 'b}
+end
+module N = struct
+  type ('a, 'b) t = ('a -> 'b, int) M.t = {a: ('a -> 'b); b: int}
+end;;
+let m = {M.a= (fun x -> (x, x)); b= 15};;
+let n = {N.a= (fun x -> (x, x)); b= 15};;
+let f = function {M.a; b} -> (a, b);;
+let g = function {N.a; b} -> (a, b);;
+let f_m = f m;;
+let f_n = f n;;
+let g_m = g m;;
+let g_n = g n;;
+[%%expect{|
+module M : sig type ('a, 'b) t = { a : 'a; b : 'b; } end
+module N :
+  sig type ('a, 'b) t = ('a -> 'b, int) M.t = { a : 'a -> 'b; b : int; } end
+val m : ('a -> 'a * 'a, int) M.t = {M.a = <fun>; b = 15}
+val n : ('a, 'a * 'a) N.t = {N.a = <fun>; b = 15}
+val f : ('a, 'b) M.t -> 'a * 'b = <fun>
+val g : ('a, 'b) N.t -> ('a -> 'b) * int = <fun>
+val f_m : ('_weak1 -> '_weak1 * '_weak1) * int = (<fun>, 15)
+val f_n : ('_weak2 -> '_weak2 * '_weak2) * int = (<fun>, 15)
+val g_m : ('_weak3 -> '_weak3 * '_weak3) * int = (<fun>, 15)
+val g_n : ('_weak4 -> '_weak4 * '_weak4) * int = (<fun>, 15)
+|}]
+let m_bad = {M.a= 15; b= true};;
+let g_m_bad = g m_bad;;
+[%%expect{|
+val m_bad : (int, bool) M.t = {M.a = 15; b = true}
+Line 2, characters 16-21:
+2 | let g_m_bad = g m_bad;;
+                    ^^^^^
+Error: This expression has type (int, bool) M.t
+       but an expression was expected of type
+         ('a, 'b) N.t = ('a -> 'b, int) M.t
+       Type int is not compatible with type 'a -> 'b
+|}]
+
+(* Invalid mixing of type variables *)
+module M = struct
+  type ('a, 'b) t = {a: 'a; b: 'b}
+end
+module N = struct
+  type ('a, 'b) t = ('a -> 'b, int) M.t = {a: 'a; b: bool}
+end;;
+[%%expect{|
+module M : sig type ('a, 'b) t = { a : 'a; b : 'b; } end
+Line 5, characters 2-58:
+5 |   type ('a, 'b) t = ('a -> 'b, int) M.t = {a: 'a; b: bool}
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This variant or record definition does not match that of type
+         ('a -> 'b, int) M.t
+       1. Fields do not match:
+         a : 'a -> 'b;
+       is not the same as:
+         a : 'a;
+       The type 'a -> 'b is not equal to the type 'a
+       2. Fields do not match:
+         b : int;
+       is not the same as:
+         b : bool;
+       The type int is not equal to the type bool
+|}]
+
+(* Mixing between aliases *)
+module M = struct
+  type ('a, 'b) t = {a: 'a; b: 'b}
+end
+module N = struct
+  type ('a, 'b) t = ('a * 'b, bool) M.t = {a: ('a * 'b); b: bool}
+end
+module O = struct
+  type 'c t = (int * unit, 'c) M.t = {a: (int * unit); b: 'c}
+end
+let m = {M.a= (1, ()); b= true};;
+let n = {N.a= (1, ()); b= true};;
+let o = {O.a= (1, ()); b= true};;
+let f = function {M.a; b} -> (a, b);;
+let g = function {N.a; b} -> (a, b);;
+let h = function {O.a; b} -> (a, b);;
+let f_m = f m;;
+let f_n = f n;;
+let f_o = f o;;
+let g_m = g m;;
+let g_n = g n;;
+let g_o = g o;;
+let h_m = h m;;
+let h_n = h n;;
+let h_o = h o;;
+[%%expect{|
+module M : sig type ('a, 'b) t = { a : 'a; b : 'b; } end
+module N :
+  sig type ('a, 'b) t = ('a * 'b, bool) M.t = { a : 'a * 'b; b : bool; } end
+module O :
+  sig type 'c t = (int * unit, 'c) M.t = { a : int * unit; b : 'c; } end
+val m : (int * unit, bool) M.t = {M.a = (1, ()); b = true}
+val n : (int, unit) N.t = {N.a = (1, ()); b = true}
+val o : bool O.t = {O.a = (1, ()); b = true}
+val f : ('a, 'b) M.t -> 'a * 'b = <fun>
+val g : ('a, 'b) N.t -> ('a * 'b) * bool = <fun>
+val h : 'a O.t -> (int * unit) * 'a = <fun>
+val f_m : (int * unit) * bool = ((1, ()), true)
+val f_n : (int * unit) * bool = ((1, ()), true)
+val f_o : (int * unit) * bool = ((1, ()), true)
+val g_m : (int * unit) * bool = ((1, ()), true)
+val g_n : (int * unit) * bool = ((1, ()), true)
+val g_o : (int * unit) * bool = ((1, ()), true)
+val h_m : (int * unit) * bool = ((1, ()), true)
+val h_n : (int * unit) * bool = ((1, ()), true)
+val h_o : (int * unit) * bool = ((1, ()), true)
+|}]
+
+(* Mixing between patterns *)
+let f_m_n = function {M.a; N.b} -> (a, b);;
+let f_m_o = function {M.a; O.b} -> (a, b);;
+let f_n_m = function {N.a; M.b} -> (a, b);;
+let f_n_o = function {N.a; O.b} -> (a, b);;
+let f_o_m = function {O.a; M.b} -> (a, b);;
+let f_o_n = function {O.a; N.b} -> (a, b);;
+[%%expect {|
+val f_m_n : ('a, 'b) N.t -> ('a * 'b) * bool = <fun>
+val f_m_o : 'a O.t -> (int * unit) * 'a = <fun>
+val f_n_m : ('a, 'b) N.t -> ('a * 'b) * bool = <fun>
+val f_n_o : (int, unit) N.t -> (int * unit) * bool = <fun>
+val f_o_m : 'a O.t -> (int * unit) * 'a = <fun>
+val f_o_n : bool O.t -> (int * unit) * bool = <fun>
+|}]

--- a/testsuite/tests/typing-misc/records.ml
+++ b/testsuite/tests/typing-misc/records.ml
@@ -182,23 +182,12 @@ type ('a,'b) def = { x:int } constraint 'b = [> `A]
 type arity = (int, [`A]) def = {x:int};;
 [%%expect{|
 type ('a, 'b) def = { x : int; } constraint 'b = [> `A ]
-Line 3, characters 0-38:
-3 | type arity = (int, [`A]) def = {x:int};;
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This variant or record definition does not match that of type
-         (int, [ `A ]) def
-       They have different arities.
+type arity = (int, [ `A ]) def = { x : int; }
 |}]
 
 type ('a,'b) ct = (int,'b) def = {x:int};;
 [%%expect{|
-Line 1, characters 0-40:
-1 | type ('a,'b) ct = (int,'b) def = {x:int};;
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This variant or record definition does not match that of type
-         (int, [> `A ]) def
-       Their parameters differ
-       The type int is not equal to the type 'a
+type ('a, 'b) ct = (int, 'b) def = { x : int; } constraint 'b = [ `A ]
 |}]
 
 type ('a,'b) kind = ('a, 'b) def = A constraint 'b = [> `A];;
@@ -207,7 +196,7 @@ Line 1, characters 0-59:
 1 | type ('a,'b) kind = ('a, 'b) def = A constraint 'b = [> `A];;
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This variant or record definition does not match that of type
-         ('a, [> `A ]) def
+         ('a, [ `A ]) def
        Their kinds differ.
 |}]
 

--- a/testsuite/tests/typing-misc/variant.ml
+++ b/testsuite/tests/typing-misc/variant.ml
@@ -141,3 +141,376 @@ Error: Signature mismatch:
          Foo of int
        The first has explicit return type and the second doesn't.
 |}]
+
+(* Adding type variables *)
+module M = struct
+  type t = Foo of int
+end
+module N = struct
+  type 'a t = M.t = Foo of int
+end;;
+let m = M.Foo 15;;
+let n = N.Foo 15;;
+let f = function | M.Foo x -> x;;
+let g = function | N.Foo x -> x;;
+let f_m = f m;;
+let f_n = f n;;
+let g_m = g m;;
+let g_n = g n;;
+[%%expect{|
+module M : sig type t = Foo of int end
+module N : sig type 'a t = M.t = Foo of int end
+val m : M.t = M.Foo 15
+val n : 'a N.t = N.Foo 15
+val f : M.t -> int = <fun>
+val g : 'a N.t -> int = <fun>
+val f_m : int = 15
+val f_n : int = 15
+val g_m : int = 15
+val g_n : int = 15
+|}]
+
+(* Adding type variables with invalid constraint *)
+module M = struct
+  type t = Foo of int
+end
+module N = struct
+  type 'a t = M.t = Foo of 'a
+end;;
+[%%expect{|
+module M : sig type t = Foo of int end
+Line 5, characters 2-29:
+5 |   type 'a t = M.t = Foo of 'a
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This variant or record definition does not match that of type M.t
+       Constructors do not match:
+         Foo of int
+       is not the same as:
+         Foo of 'a
+       The type int is not equal to the type 'a
+|}]
+
+(* Adding constrained type variables *)
+module M = struct
+  type t = Foo of int
+end
+module N = struct
+  type 'a t = M.t = Foo of 'a constraint 'a = int
+end;;
+let m = M.Foo 15;;
+let n = N.Foo 15;;
+let f = function | M.Foo x -> x;;
+let g = function | N.Foo x -> x;;
+let f_m = f m;;
+let f_n = f n;;
+let g_m = g m;;
+let g_n = g n;;
+[%%expect{|
+module M : sig type t = Foo of int end
+module N : sig type 'a t = M.t = Foo of 'a constraint 'a = int end
+val m : M.t = M.Foo 15
+val n : int N.t = N.Foo 15
+val f : M.t -> int = <fun>
+val g : int N.t -> int = <fun>
+val f_m : int = 15
+val f_n : int = 15
+val g_m : int = 15
+val g_n : int = 15
+|}]
+let n_bad = N.Foo true;;
+[%%expect{|
+Line 1, characters 18-22:
+1 | let n_bad = N.Foo true;;
+                      ^^^^
+Error: This expression has type bool but an expression was expected of type
+         int
+|}]
+
+(* Mixing type variables *)
+module M = struct
+  type ('a, 'b) t = A of 'a | B of 'b
+end
+module N = struct
+  type ('a, 'b) t = ('a -> 'b, int) M.t = A of ('a -> 'b) | B of int
+end;;
+let m_a = M.A (fun x -> (x, x));;
+let m_b = M.B 15;;
+let n_a = N.A (fun x -> (x, x));;
+let n_b = N.B 15;;
+let f = function | M.A f -> f 1 | M.B x -> (x, x);;
+let g = function | N.A f -> f 1 | N.B x -> (x, x);;
+let f_m_a = f m_a;;
+let f_m_b = f m_b;;
+let f_n_a = f n_a;;
+let f_n_b = f n_b;;
+let g_m_a = g m_a;;
+let g_m_b = g m_b;;
+let g_n_a = g n_a;;
+let g_n_b = g n_b;;
+[%%expect{|
+module M : sig type ('a, 'b) t = A of 'a | B of 'b end
+module N :
+  sig type ('a, 'b) t = ('a -> 'b, int) M.t = A of ('a -> 'b) | B of int end
+val m_a : ('a -> 'a * 'a, 'b) M.t = M.A <fun>
+val m_b : ('a, int) M.t = M.B 15
+val n_a : ('a, 'a * 'a) N.t = N.A <fun>
+val n_b : ('a, 'b) N.t = N.B 15
+val f : (int -> 'a * 'a, 'a) M.t -> 'a * 'a = <fun>
+val g : (int, int * int) N.t -> int * int = <fun>
+val f_m_a : int * int = (1, 1)
+val f_m_b : int * int = (15, 15)
+val f_n_a : int * int = (1, 1)
+val f_n_b : int * int = (15, 15)
+val g_m_a : int * int = (1, 1)
+val g_m_b : int * int = (15, 15)
+val g_n_a : int * int = (1, 1)
+val g_n_b : int * int = (15, 15)
+|}]
+let m_a_bad = M.A 15;;
+let g_m_a_bad = g m_a_bad;;
+[%%expect{|
+val m_a_bad : (int, 'a) M.t = M.A 15
+Line 2, characters 18-25:
+2 | let g_m_a_bad = g m_a_bad;;
+                      ^^^^^^^
+Error: This expression has type (int, 'a) M.t
+       but an expression was expected of type
+         (int, int * int) N.t = (int -> int * int, int) M.t
+       Type int is not compatible with type int -> int * int
+|}]
+let m_b_bad = M.B true;;
+let g_m_b_bad = g m_b_bad;;
+[%%expect{|
+val m_b_bad : ('a, bool) M.t = M.B true
+Line 2, characters 18-25:
+2 | let g_m_b_bad = g m_b_bad;;
+                      ^^^^^^^
+Error: This expression has type (int -> int * int, bool) M.t
+       but an expression was expected of type
+         (int, int * int) N.t = (int -> int * int, int) M.t
+       Type bool is not compatible with type int
+|}]
+
+(* Invalid mixing of type variables *)
+module M = struct
+  type ('a, 'b) t = A of 'a | B of 'b
+end
+module N = struct
+  type ('a, 'b) t = ('a -> 'b, int) M.t = A of 'a | B of bool
+end;;
+[%%expect{|
+module M : sig type ('a, 'b) t = A of 'a | B of 'b end
+Line 5, characters 2-61:
+5 |   type ('a, 'b) t = ('a -> 'b, int) M.t = A of 'a | B of bool
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This variant or record definition does not match that of type
+         ('a -> 'b, int) M.t
+       1. Constructors do not match:
+         A of ('a -> 'b)
+       is not the same as:
+         A of 'a
+       The type 'a -> 'b is not equal to the type 'a
+       2. Constructors do not match:
+         B of int
+       is not the same as:
+         B of bool
+       The type int is not equal to the type bool
+|}]
+
+(* Mixing between aliases *)
+module M = struct
+  type ('a, 'b) t = A of 'a | B of 'b
+end
+module N = struct
+  type ('a, 'b) t = ('a * 'b, bool) M.t = A of ('a * 'b) | B of bool
+end
+module O = struct
+  type 'c t = (int * unit, 'c) M.t = A of (int * unit) | B of 'c
+end
+let m_a = M.A ((1, ()));;
+let m_b = M.B true;;
+let n_a = N.A ((1, ()));;
+let n_b = N.B true;;
+let o_a = O.A ((1, ()));;
+let o_b = O.B true;;
+let f = function | M.A x -> Result.Ok x | M.B y -> Result.Error y;;
+let g = function | N.A x -> Result.Ok x | N.B y -> Result.Error y;;
+let h = function | O.A x -> Result.Ok x | O.B y -> Result.Error y;;
+let f_m_a = f m_a;;
+let f_m_b = f m_b;;
+let f_n_a = f n_a;;
+let f_n_b = f n_b;;
+let f_o_a = f o_a;;
+let f_o_b = f o_b;;
+let g_m_a = g m_a;;
+let g_m_b = g m_b;;
+let g_n_a = g n_a;;
+let g_n_b = g n_b;;
+let g_o_a = g o_a;;
+let g_o_b = g o_b;;
+let h_m_a = h m_a;;
+let h_m_b = h m_b;;
+let h_n_a = h n_a;;
+let h_n_b = h n_b;;
+let h_o_a = h o_a;;
+let h_o_b = h o_b;;
+[%%expect{|
+module M : sig type ('a, 'b) t = A of 'a | B of 'b end
+module N :
+  sig type ('a, 'b) t = ('a * 'b, bool) M.t = A of ('a * 'b) | B of bool end
+module O :
+  sig type 'c t = (int * unit, 'c) M.t = A of (int * unit) | B of 'c end
+val m_a : (int * unit, 'a) M.t = M.A (1, ())
+val m_b : ('a, bool) M.t = M.B true
+val n_a : (int, unit) N.t = N.A (1, ())
+val n_b : ('a, 'b) N.t = N.B true
+val o_a : 'a O.t = O.A (1, ())
+val o_b : bool O.t = O.B true
+val f : ('a, 'b) M.t -> ('a, 'b) Result.t = <fun>
+val g : ('a, 'b) N.t -> ('a * 'b, bool) Result.t = <fun>
+val h : 'a O.t -> (int * unit, 'a) Result.t = <fun>
+val f_m_a : (int * unit, 'a) Result.t = Result.Ok (1, ())
+val f_m_b : ('a, bool) Result.t = Result.Error true
+val f_n_a : (int * unit, bool) Result.t = Result.Ok (1, ())
+val f_n_b : ('a * 'b, bool) Result.t = Result.Error true
+val f_o_a : (int * unit, 'a) Result.t = Result.Ok (1, ())
+val f_o_b : (int * unit, bool) Result.t = Result.Error true
+val g_m_a : (int * unit, bool) Result.t = Result.Ok (1, ())
+val g_m_b : ('a * 'b, bool) Result.t = Result.Error true
+val g_n_a : (int * unit, bool) Result.t = Result.Ok (1, ())
+val g_n_b : ('a * 'b, bool) Result.t = Result.Error true
+val g_o_a : (int * unit, bool) Result.t = Result.Ok (1, ())
+val g_o_b : (int * unit, bool) Result.t = Result.Error true
+val h_m_a : (int * unit, 'a) Result.t = Result.Ok (1, ())
+val h_m_b : (int * unit, bool) Result.t = Result.Error true
+val h_n_a : (int * unit, bool) Result.t = Result.Ok (1, ())
+val h_n_b : (int * unit, bool) Result.t = Result.Error true
+val h_o_a : (int * unit, 'a) Result.t = Result.Ok (1, ())
+val h_o_b : (int * unit, bool) Result.t = Result.Error true
+|}]
+
+(* Mixing between patterns *)
+let f_m_n = function | M.A x -> Result.Ok x | N.B y -> Result.Error y;;
+let f_m_o = function | M.A x -> Result.Ok x | O.B y -> Result.Error y;;
+let f_n_m = function | N.A x -> Result.Ok x | M.B y -> Result.Error y;;
+let f_n_o = function | N.A x -> Result.Ok x | O.B y -> Result.Error y;;
+let f_o_m = function | N.A x -> Result.Ok x | M.B y -> Result.Error y;;
+let f_o_n = function | O.A x -> Result.Ok x | N.B y -> Result.Error y;;
+[%%expect {|
+val f_m_n : ('a, 'b) N.t -> ('a * 'b, bool) Result.t = <fun>
+val f_m_o : 'a O.t -> (int * unit, 'a) Result.t = <fun>
+val f_n_m : ('a, 'b) N.t -> ('a * 'b, bool) Result.t = <fun>
+val f_n_o : (int, unit) N.t -> (int * unit, bool) Result.t = <fun>
+val f_o_m : ('a, 'b) N.t -> ('a * 'b, bool) Result.t = <fun>
+val f_o_n : bool O.t -> (int * unit, bool) Result.t = <fun>
+|}]
+
+(* Restricting GADTs *)
+module M = struct
+  type 'a t = Foo : 'a -> 'a t
+end
+module N = struct
+  type t = int M.t = Foo : int -> t
+end;;
+let m = M.Foo 15;;
+let n = N.Foo 15;;
+let f = function M.Foo x -> x;;
+let g = function N.Foo x -> x;;
+let f_m = f m;;
+let f_n = f n;;
+let g_m = g m;;
+let g_n = g n;;
+[%%expect {|
+module M : sig type 'a t = Foo : 'a -> 'a t end
+module N : sig type t = int M.t = Foo : int -> t end
+val m : int M.t = M.Foo 15
+val n : N.t = N.Foo 15
+val f : int M.t -> int = <fun>
+val g : N.t -> int = <fun>
+val f_m : int = 15
+val f_n : int = 15
+val g_m : int = 15
+val g_n : int = 15
+|}]
+let m_bad = M.Foo true;;
+let g_m_bad = g m_bad;;
+[%%expect {|
+Line 1, characters 18-22:
+1 | let m_bad = M.Foo true;;
+                      ^^^^
+Error: This expression has type bool but an expression was expected of type
+         int
+|}]
+
+(* Restricted GADTs *)
+let f (x : _ M.t) =
+  match x with
+  | N.Foo y -> y;;
+let g (x : N.t) =
+  match x with
+  | N.Foo y -> y;;
+let h (type a) (x : a M.t) =
+  match x with
+  | N.Foo y -> y;;
+[%%expect {|
+val f : int M.t -> int = <fun>
+val g : N.t -> int = <fun>
+Line 9, characters 4-11:
+9 |   | N.Foo y -> y;;
+        ^^^^^^^
+Error: This pattern matches values of type N.t = int M.t
+       but a pattern was expected which matches values of type a M.t
+       Type int is not compatible with type a
+|}]
+
+(* Irreconcilable GADTs *)
+module M = struct
+  type _ t = Int : int t | Bool : bool t
+end
+module N = struct
+  type t = int M.t = Int : t | Bool : t
+end
+[%%expect {|
+module M : sig type _ t = Int : int t | Bool : bool t end
+Line 5, characters 2-39:
+5 |   type t = int M.t = Int : t | Bool : t
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This variant or record definition does not match that of type int M.t
+       Constructors do not match:
+         Bool : bool M.t
+       is not the same as:
+         Bool : int M.t
+       The type bool M.t is not equal to the type int M.t
+       Type bool is not equal to type int
+|}]
+
+(* Conditionally reconcilable GADTs *)
+module M = struct
+  type _ t = Any : 'a t | Bool : bool t
+end
+module N = struct
+  type t = bool M.t = Any : t | Bool : t
+end
+module O = struct
+  type t = int M.t = Any : t | Bool : t
+end
+[%%expect {|
+module M : sig type _ t = Any : 'a t | Bool : bool t end
+module N : sig type t = bool M.t = Any : t | Bool : t end
+Line 8, characters 2-39:
+8 |   type t = int M.t = Any : t | Bool : t
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This variant or record definition does not match that of type int M.t
+       1. Constructors do not match:
+         Any : bool M.t
+       is not the same as:
+         Any : int M.t
+       The type bool M.t is not equal to the type int M.t
+       Type bool is not equal to type int
+       2. Constructors do not match:
+         Bool : bool M.t
+       is not the same as:
+         Bool : int M.t
+       The type bool M.t is not equal to the type int M.t
+       Type bool is not equal to type int
+|}]

--- a/testsuite/tests/typing-misc/variant.ml
+++ b/testsuite/tests/typing-misc/variant.ml
@@ -51,23 +51,12 @@ type ('a,'b) def = X of int constraint 'b = [> `A]
 type arity = (int, [`A]) def = X of int;;
 [%%expect{|
 type ('a, 'b) def = X of int constraint 'b = [> `A ]
-Line 3, characters 0-39:
-3 | type arity = (int, [`A]) def = X of int;;
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This variant or record definition does not match that of type
-         (int, [ `A ]) def
-       They have different arities.
+type arity = (int, [ `A ]) def = X of int
 |}]
 
 type ('a,'b) ct = (int,'b) def = X of int;;
 [%%expect{|
-Line 1, characters 0-41:
-1 | type ('a,'b) ct = (int,'b) def = X of int;;
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This variant or record definition does not match that of type
-         (int, [> `A ]) def
-       Their parameters differ
-       The type int is not equal to the type 'a
+type ('a, 'b) ct = (int, 'b) def = X of int constraint 'b = [ `A ]
 |}]
 
 type ('a,'b) kind = ('a, 'b) def = {a:int} constraint 'b = [> `A];;
@@ -76,7 +65,7 @@ Line 1, characters 0-65:
 1 | type ('a,'b) kind = ('a, 'b) def = {a:int} constraint 'b = [> `A];;
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This variant or record definition does not match that of type
-         ('a, [> `A ]) def
+         ('a, [ `A ]) def
        Their kinds differ.
 |}]
 

--- a/typing/includecore.ml
+++ b/typing/includecore.ml
@@ -951,49 +951,21 @@ let type_declarations ?(equality = false) ~loc env ~mark name
   let abstr = abstr || decl2.type_private = Private in
   let opn = decl2.type_kind = Type_open && decl2.type_manifest = None in
   let constrained ty = not (Btype.is_Tvar ty) in
-  let variance_pairs =
-    match oargs with
-    | None ->
-        List.map2 (fun v1 v2 -> ([v1], v2))
-          decl1.type_variance decl2.type_variance
-    | Some _ ->
-        let initial =
-          List.map2 (fun ty v -> (ty, v, []))
-            decl2.type_params decl2.type_variance
-        in
-        (* For each parameter in [decl1], mark it and check whether each
-           parameter to [decl2] was marked as a result.
-           We accumulate the variances of parameters in [decl1] against each
-           parameter variance in [decl2], so that we can ensure that the input
-           variances are consistent. *)
-        let res =
-          List.fold_left2 (fun acc ty1 v1 ->
-              Btype.mark_type ty1;
-              let acc =
-                List.map (fun (ty2, v2, v1s) ->
-                    if Btype.not_marked_node ty2 then (ty2, v2, v1s)
-                    else (ty2, v2, v1 :: v1s))
-                  acc
-              in
-              Btype.unmark_type ty1;
-              acc)
-            initial decl1.type_params decl1.type_variance
-        in
-        List.map (fun (_ty, v2, v1s) -> (v1s, v2)) res
-  in
-  if List.for_all2
-      (fun ty (v1s,v2) ->
-        List.for_all (fun v1 ->
-            let open Variance in
-            let imp a b = not a || b in
-            let (co1,cn1) = get_upper v1 and (co2,cn2) = get_upper v2 in
-            (if abstr then (imp co1 co2 && imp cn1 cn2)
-             else if opn || constrained ty then (co1 = co2 && cn1 = cn2)
-             else true) &&
-            let (p1,n1,i1,j1) = get_lower v1 and (p2,n2,i2,j2) = get_lower v2 in
-            imp abstr (imp p2 p1 && imp n2 n1 && imp i2 i1 && imp j2 j1))
-          v1s)
-      decl2.type_params variance_pairs
+  (* When [equality = true], we know that the variance is already correct,
+     because [decl1] was found by expanding the path in the type manifest of
+     [decl2], and the variance was checked while constructing the type
+     manifest. See the use of [Typedecl_variance] in typing/typedecl.ml. *)
+  if equality || List.for_all2
+      (fun ty (v1,v2) ->
+        let open Variance in
+        let imp a b = not a || b in
+        let (co1,cn1) = get_upper v1 and (co2,cn2) = get_upper v2 in
+        (if abstr then (imp co1 co2 && imp cn1 cn2)
+         else if opn || constrained ty then (co1 = co2 && cn1 = cn2)
+         else true) &&
+        let (p1,n1,i1,j1) = get_lower v1 and (p2,n2,i2,j2) = get_lower v2 in
+        imp abstr (imp p2 p1 && imp n2 n1 && imp i2 i1 && imp j2 j1))
+      decl2.type_params (List.combine decl1.type_variance decl2.type_variance)
   then None else Some Variance
 
 (* Inclusion between extension constructors *)

--- a/typing/includecore.ml
+++ b/typing/includecore.ml
@@ -927,7 +927,7 @@ let type_declarations ?(equality = false) ~loc env ~mark name
           labels1 labels2
           rep1 rep2
     | (Type_open, Type_open) ->
-        if arity_mismatch then Some Arity else None
+        if has_oargs then Some Arity else None
     | (_, _) -> Some Kind
   in
   if err <> None then err else

--- a/typing/includecore.ml
+++ b/typing/includecore.ml
@@ -847,14 +847,20 @@ let type_manifest env ty1 params1 ty2 params2 priv2 kind2 =
     end
 
 let type_declarations ?(equality = false) ~loc env ~mark name
-      decl1 path decl2 =
+      decl1 path decl2 oargs =
   Builtin_attributes.check_alerts_inclusion
     ~def:decl1.type_loc
     ~use:decl2.type_loc
     loc
     decl1.type_attributes decl2.type_attributes
     name;
-  if decl1.type_arity <> decl2.type_arity then Some Arity else
+  let has_oargs, decl2_params =
+    match oargs with
+    | Some args -> true, args
+    | None -> false, decl2.type_params
+  in
+  let arity_mismatch = decl1.type_arity <> decl2.type_arity in
+  if not has_oargs && arity_mismatch then Some Arity else
   let err =
     match privacy_mismatch env decl1 decl2 with
     | Some err -> Some (Privacy err)
@@ -864,18 +870,18 @@ let type_declarations ?(equality = false) ~loc env ~mark name
   let err = match (decl1.type_manifest, decl2.type_manifest) with
       (_, None) ->
         begin
-          match Ctype.equal env true decl1.type_params decl2.type_params with
+          match Ctype.equal env true decl1.type_params decl2_params with
           | exception Ctype.Equality err -> Some (Constraint err)
           | () -> None
         end
     | (Some ty1, Some ty2) ->
-         type_manifest env ty1 decl1.type_params ty2 decl2.type_params
+         type_manifest env ty1 decl1.type_params ty2 decl2_params
            decl2.type_private decl2.type_kind
     | (None, Some ty2) ->
         let ty1 =
           Btype.newgenty (Tconstr(path, decl2.type_params, ref Mnil))
         in
-        match Ctype.equal env true decl1.type_params decl2.type_params with
+        match Ctype.equal env true decl1.type_params decl2_params with
         | exception Ctype.Equality err -> Some (Constraint err)
         | () ->
           match Ctype.equal env false [ty1] [ty2] with
@@ -899,7 +905,7 @@ let type_declarations ?(equality = false) ~loc env ~mark name
         end;
         Variant_diffing.compare_with_representation ~loc env
           decl1.type_params
-          decl2.type_params
+          decl2_params
           cstrs1
           cstrs2
           rep1
@@ -917,10 +923,11 @@ let type_declarations ?(equality = false) ~loc env ~mark name
           if equality then mark Env.Exported labels2
         end;
         Record_diffing.compare_with_representation ~loc env
-          decl1.type_params decl2.type_params
+          decl1.type_params decl2_params
           labels1 labels2
           rep1 rep2
-    | (Type_open, Type_open) -> None
+    | (Type_open, Type_open) ->
+        if arity_mismatch then Some Arity else None
     | (_, _) -> Some Kind
   in
   if err <> None then err else
@@ -944,6 +951,7 @@ let type_declarations ?(equality = false) ~loc env ~mark name
   let abstr = abstr || decl2.type_private = Private in
   let opn = decl2.type_kind = Type_open && decl2.type_manifest = None in
   let constrained ty = not (Btype.is_Tvar ty) in
+  (* TODO *)
   if List.for_all2
       (fun ty (v1,v2) ->
         let open Variance in

--- a/typing/includecore.mli
+++ b/typing/includecore.mli
@@ -104,7 +104,8 @@ val type_declarations:
   ?equality:bool ->
   loc:Location.t ->
   Env.t -> mark:bool -> string ->
-  type_declaration -> Path.t -> type_declaration -> type_mismatch option
+  type_declaration -> Path.t -> type_declaration -> type_expr list option ->
+  type_mismatch option
 
 val extension_constructors:
   loc:Location.t -> Env.t -> mark:bool -> Ident.t ->

--- a/typing/includemod.ml
+++ b/typing/includemod.ml
@@ -171,7 +171,7 @@ let type_declarations ~loc env ~mark ?old_env:_ subst id decl1 decl2 =
   let decl2 = Subst.type_declaration subst decl2 in
   match
     Includecore.type_declarations ~loc env ~mark
-      (Ident.name id) decl1 (Path.Pident id) decl2
+      (Ident.name id) decl1 (Path.Pident id) decl2 None
   with
   | None -> Ok Tcoerce_none
   | Some err ->

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -600,7 +600,7 @@ let check_constraints env sdecl (_, decl) =
    need to check that the equation refers to a type of the same kind
    with the same constructors and labels.
 *)
-let check_coherence env loc dpath decl =
+let check_coherence ?(arity = true) env loc dpath decl =
   match decl with
     { type_kind = (Type_variant _ | Type_record _| Type_open);
       type_manifest = Some ty } ->
@@ -609,20 +609,106 @@ let check_coherence env loc dpath decl =
           begin try
             let decl' = Env.find_type path env in
             let err =
-              if List.length args <> List.length decl.type_params
-              then Some Includecore.Arity
+              let inconsistent_arity =
+                List.length args <> List.length decl.type_params
+              in
+              if arity && inconsistent_arity then Some Includecore.Arity
               else begin
-                match Ctype.equal env false args decl.type_params with
-                | exception Ctype.Equality err ->
-                    Some (Includecore.Constraint err)
-                | () ->
-                    Includecore.type_declarations ~loc ~equality:true env
-                      ~mark:true
-                      (Path.last path)
-                      decl'
-                      dpath
-                      (Subst.type_declaration
-                         (Subst.add_type_path dpath path Subst.identity) decl)
+                let err, oargs =
+                  match
+                    if arity || not inconsistent_arity then begin
+                      Ctype.equal env false args decl.type_params; true
+                    end else arity
+                  with
+                  | exception Ctype.Equality err ->
+                      if arity then
+                        (Some (Includecore.Constraint err), None)
+                      else
+                        (None, Some args)
+                  | true -> (None, None)
+                  | false -> (None, Some args)
+                in
+                let decl, decl', oargs =
+                  match oargs with
+                  | None ->
+                      ( Subst.type_declaration
+                          (Subst.add_type_path dpath path Subst.identity) decl
+                      , decl'
+                      , None )
+                  | Some args ->
+                      let with_fresh_params decl f =
+                        Btype.For_copy.with_scope (fun copy_scope ->
+                          let params =
+                            List.map (fun ty ->
+                                let ty' =
+                                  newty2 ~level:(get_level ty) (get_desc ty)
+                                in
+                                Btype.For_copy.redirect_desc copy_scope ty
+                                  (Tsubst (ty', None));
+                                ty' )
+                              decl.type_params
+                          in
+                          f params)
+                      in
+                      (* We emit fresh variables for the types to ensure that
+                         [Ctype.equal] will correctly treat both copies as
+                         independent, and to ensure that the substitution of
+                         [ty] doesn't interfere with its use as a type
+                         function for other substitutions.  *)
+                      let args, decl =
+                        with_fresh_params decl (fun params ->
+                          let args =
+                            List.map (Subst.type_expr Subst.identity) args
+                          in
+                          let body = Subst.type_expr Subst.identity ty in
+                          ( args
+                          , Subst.type_declaration
+                              (Subst.add_type_function dpath ~params ~body
+                                Subst.identity)
+                              decl ) )
+                      in
+                      (* We also emit fresh variables for the manifest type's
+                         declaration, so that we can unify without affecting the
+                         type declaration in the environment. *)
+                      let decl' =
+                        with_fresh_params decl' (fun _params ->
+                          Subst.type_declaration Subst.identity decl' )
+                      in
+                      begin match decl'.type_kind with
+                      | Type_variant (cstrs, _) ->
+                          (* Constrain the return type of GADTs, where
+                             possible. *)
+                          List.iter (fun cstr ->
+                            Option.iter (fun cd_res ->
+                                let snap = Btype.snapshot () in
+                                (* Create a fresh copy of the target type, to
+                                   avoid cross-unification. *)
+                                let ty =
+                                  with_fresh_params decl (fun _params ->
+                                    Subst.type_expr Subst.identity ty)
+                                in
+                                try Ctype.unify env cd_res ty
+                                with _ -> Btype.backtrack snap )
+                              cstr.Types.cd_res )
+                            cstrs
+                      | _ -> ()
+                      end;
+                      (* Constrain the type parameters of the declaration to
+                         match those given in the manifest. *)
+                      List.iter2 (Ctype.unify env) decl'.type_params args;
+                      ( decl
+                      , decl'
+                      , Some args )
+                in
+                if err <> None then err
+                else
+                  Includecore.type_declarations ~loc ~equality:true env
+                    ~mark:true
+                    (Path.last path)
+                    decl'
+                    dpath
+                    decl
+                    oargs
               end
             in
             if err <> None then
@@ -635,7 +721,7 @@ let check_coherence env loc dpath decl =
   | _ -> ()
 
 let check_abbrev env sdecl (id, decl) =
-  check_coherence env sdecl.ptype_loc (Path.Pident id) decl
+  check_coherence ~arity:false env sdecl.ptype_loc (Path.Pident id) decl
 
 (* Check that recursion is well-founded *)
 

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -612,6 +612,10 @@ let check_coherence ?(arity = true) env loc dpath decl =
               let inconsistent_arity =
                 List.length args <> List.length decl.type_params
               in
+              let arity =
+                (* Always check arity and parameter equality for open types. *)
+                match decl.type_kind with Type_open -> true | _ -> arity
+              in
               if arity && inconsistent_arity then Some Includecore.Arity
               else begin
                 let err, oargs =

--- a/typing/typedecl.mli
+++ b/typing/typedecl.mli
@@ -53,7 +53,7 @@ val approx_type_decl:
 val check_recmod_typedecl:
     Env.t -> Location.t -> Ident.t list -> Path.t -> type_declaration -> unit
 val check_coherence:
-    Env.t -> Location.t -> Path.t -> type_declaration -> unit
+    ?arity:bool -> Env.t -> Location.t -> Path.t -> type_declaration -> unit
 
 (* for fixed types *)
 val is_fixed_type : Parsetree.type_declaration -> bool


### PR DESCRIPTION
This PR adds the ability for type aliases with re-exporting (ie. having non-abstract kind) to differ in arity and constraints from the target type.

This is particularly useful when defining types and helpers that are generic over some type variables, but where there are a small number of specialisations that get used in practice. This pattern arises a lot in the [MinaProtocol/mina](https://github.com/MinaProtocol/mina) repo, as a result of the use of [o1-labs/snarky](https://github.com/o1-labs/snarky). For example, we often have types like the following:

```ocaml
module Poly = struct
  type ('foo, 'bar, 'baz) t = {foo: 'foo; bar: 'bar; baz: 'baz}
end
let foo {Poly.foo; _} = foo
let bar {Poly.bar; _} = bar
let baz {Poly.baz; _} = baz
module Value = struct
  type ('foo, 'bar, 'baz) poly = ('foo, 'bar, 'baz) Poly.t = {foo: 'foo; bar: 'bar; baz: 'baz}
  type t = (Foo.Value.t, Bar.Value.t, Baz.Value.t) Poly.t
      (* = {foo: Foo.Value.t; bar: Bar.Value.t, baz: Baz.Value.t} *)
end
module Var = struct
  type ('foo, 'bar, 'baz) poly = ('foo, 'bar, 'baz) Poly.t = {foo: 'foo; bar: 'bar; baz: 'baz}
  type t = (Foo.Var.t, Bar.Var.t, Baz.Var.t) Poly.t
      (* = {foo: Foo.Var.t; bar: Bar.Var.t, baz: Baz.Var.t} *)
end
```

If we allow the types to re-export a restricted form of the original, the typechecker can detect errors like the below more quickly
```ocaml
let value = {Value.foo= Foo.Value.x; bar= Bar.Value.x; baz= Baz.Var.x}
```
and also give immediately better type errors (or hinting via merlin) for patterns such as
```ocaml
let f {Value.foo; bar; baz} = (* ... *)
```

This also allows the use of structural preprocessors (esp. `[@@deriving ...]`) on specialisations of polymorphic types without forcing the user to re-export and derive upon the polymorphic type to do so.

This PR explicitly avoids handling the case of extensible (ie. open) types, focusing only on variants and records. Both records and variants should already be compatible with the type system, with this syntax only providing easier access to and typechecking of the structure of the aliases.

----------------------------

Notes on technical implementation:
* This is designed to detect the 'usual' case of equal aliases and treat it exactly as before
* Where the arity of the type and its target differ, and where there type variables do not exactly match in order, a copy of the target type is made and specialised before checking for equality
  - The type variables in the type declaration itself are specialised to match constraints placed on them, so that `(int, bool) t` specialises the declaration of `('a, 'b) t` as if it had constraints `'a = int`, `'b = bool`
  - Sharing ensures that any uses of these variables are similarly specialised at their usage points, so that `A of 'a` becomes `A of int` in the copied type
  - The return types of any GADT constructors are specialised separately, so that their constructors also obey the constraints (`A : 'a -> ('a, 'b) t` becomes `A : int -> (int, bool) t`.
  - Where any of the GADT constructor return types cannot be specialised due to a unification error, the unification is backtracked and will be reported as a mismatched constructor (e.g. `B : (bool, bool) t` is not the same as `B : (int, bool) t`).
* The variance of type aliases is no longer checked in `Includecore.type_declarations`, because equivalent checks are already run in `Typedecl_variance` by the `Typedecl` module.