### PR TITLE
Replace `Stdlib.stdout` with `Unix.stdout` in doc of `Unix.create_process`

### DIFF
--- a/otherlibs/unix/unix.mli
+++ b/otherlibs/unix/unix.mli
@@ -844,7 +844,7 @@ val create_process :
    concurrently with the current process.
    The standard input and outputs of the new process are connected
    to the descriptors [stdin], [stdout] and [stderr].
-   Passing e.g. [Stdlib.stdout] for [stdout] prevents the redirection
+   Passing e.g. {!Unix.stdout} for [stdout] prevents the redirection
    and causes the new process to have the same standard output
    as the current process.
    The executable file [prog] is searched in the path.

--- a/otherlibs/unix/unixLabels.mli
+++ b/otherlibs/unix/unixLabels.mli
@@ -844,7 +844,7 @@ val create_process :
    concurrently with the current process.
    The standard input and outputs of the new process are connected
    to the descriptors [stdin], [stdout] and [stderr].
-   Passing e.g. [Stdlib.stdout] for [stdout] prevents the redirection
+   Passing e.g. {!Unix.stdout} for [stdout] prevents the redirection
    and causes the new process to have the same standard output
    as the current process.
    The executable file [prog] is searched in the path.


### PR DESCRIPTION
The function `Unix.create_process` takes `Unix.file_descr` parameters, and
`Stdlib.stdout` is an `out_channel`.

No change entry needed?