### PR TITLE
Parsetree: add a comment with an example for module_substitution

### DIFF
--- a/parsing/parsetree.mli
+++ b/parsing/parsetree.mli
@@ -804,6 +804,7 @@ and module_substitution =
      pms_attributes: attributes; (* ... [@@id1] [@@id2] *)
      pms_loc: Location.t;
     }
+(* S := M *)
 
 and module_type_declaration =
     {


### PR DESCRIPTION
Just a very small change to add this comment to be consistent with the other parsetree nodes.