### PR TITLE
Fix minor heap stats for bigarrays allocated with custom data pointers.

### DIFF
--- a/Changes
+++ b/Changes
@@ -424,6 +424,9 @@ OCaml 4.14.0
 - #10763, #10764: fix miscompilation of method delegation
   (Alain Frisch, review by Vincent Laviron and Jacques Garrigue)
 
+- #10788: fix minor GC memory associated with allocated
+  bigarrays when passing cutom data pointers
+  (Romain Beauxis)
 
 OCaml 4.13 maintenance branch
 -----------------------------

--- a/runtime/bigarray.c
+++ b/runtime/bigarray.c
@@ -86,7 +86,7 @@ CAMLexport struct custom_operations caml_ba_ops = {
    [dim] may point into an object in the OCaml heap.
 
    When calling with a custom data pointer, the function may raise
-   an exception ff passed length is inconsistent with the bigarray's
+   an exception if passed length is inconsistent with the bigarray's
    parameters.
 */
 CAMLexport value


### PR DESCRIPTION
While debugging a user-reported memory leak in liquidsoap here: https://github.com/savonet/liquidsoap/issues/2054, after going down the rabbit hole, I ended up looking at this piece of code:
```c
  data = aligned_alloc(alignment, len);
  if (data == NULL)
    uerror("aligned_alloc", Nothing);
  ans = caml_ba_alloc_dims(CAML_BA_MANAGED | CAML_BA_C_LAYOUT | CAML_BA_UINT8,
                           1, data, len);
```

I was able to confirm that, if `data` was passed as `NULL` here, the compiler would allocate the memory itself and no memory leak would be happening. Furthermore, allocating `data` using `malloc` like the compiler does also lead to a memleak. I was also able to confirm that, by forcing a `Gc.full_major()` on each allocation, no memory leak was happening.

After more investigations and head scratching, it turned out that the problem comes from this code:
```c
  size = 0;
  if (data == NULL) {
    num_elts = 1;
    for (i = 0; i < num_dims; i++) {
      if (caml_umul_overflow(num_elts, dimcopy[i], &num_elts))
        caml_raise_out_of_memory();
    }
    if (caml_umul_overflow(num_elts,
                           caml_ba_element_size[flags & CAML_BA_KIND_MASK],
                           &size))
      caml_raise_out_of_memory();
    data = malloc(size);
    if (data == NULL && size != 0) caml_raise_out_of_memory();
    flags |= CAML_BA_MANAGED;
  }
  asize = SIZEOF_BA_ARRAY + num_dims * sizeof(intnat);
  res = caml_alloc_custom_mem(&caml_ba_ops, asize, size);
```

The `size` variable in this code is passed as `0` when using a custom `data` pointer, thus confusing the `Gc` about how much data the allocated value actually represents.

The natural fix seems to be to make sure that `size` is always filled. 