### PR TITLE
add Stack.drop

### DIFF
--- a/Changes
+++ b/Changes
@@ -15,6 +15,9 @@ Working version
 - #11128: Add In_channel.isatty, Out_channel.isatty.
   (Nicolás Ojeda Bär, review by Gabriel Scherer and Florian Angeletti)
 
+- #10789: Add `Stack.drop`
+  (Léo Andrès, review by Gabriel Scherer)
+
 ### Other libraries:
 
 ### Tools:

--- a/stdlib/stack.ml
+++ b/stdlib/stack.ml
@@ -35,6 +35,11 @@ let pop_opt s =
   | hd::tl -> s.c <- tl; s.len <- s.len - 1; Some hd
   | []     -> None
 
+let drop s =
+  match s.c with
+  | _hd::tl -> s.c <- tl; s.len <- s.len - 1
+  | [] -> raise Empty
+
 let top s =
   match s.c with
   | hd::_ -> hd

--- a/stdlib/stack.mli
+++ b/stdlib/stack.mli
@@ -40,6 +40,11 @@ val pop_opt : 'a t -> 'a option
    or returns [None] if the stack is empty.
    @since 4.08 *)
 
+val drop : 'a t -> unit
+(** [drop s] removes the topmost element in stack [s],
+   or raises {!Empty} if the stack is empty.
+   @since 5.1.0 *)
+
 val top : 'a t -> 'a
 (** [top s] returns the topmost element in stack [s],
    or raises {!Empty} if the stack is empty. *)

--- a/testsuite/tests/lib-stack/test.ml
+++ b/testsuite/tests/lib-stack/test.ml
@@ -118,4 +118,24 @@ let () =
   assert (S.length s2 = 4); assert (S.to_list s2 = [1; 2; 3; 4]);
 ;;
 
+let () =
+  let s = S.create () in
+  S.push 0 s;
+  S.push 1 s;
+  S.push 2 s;
+  assert (S.to_list s = [0; 1; 2]);
+  S.drop s;
+  assert (S.to_list s = [0; 1]);
+  S.drop s;
+  assert (S.to_list s = [0]);
+  S.drop s;
+  assert (S.to_list s = []);
+  begin
+    try
+      S.drop s;
+      assert false
+    with S.Empty -> ()
+  end;
+;;
+
 let () = print_endline "OK"


### PR DESCRIPTION
Hi,

This PR adds a `val drop : 'a t -> unit` function to the `Stack` module.

It behaves as `Stack.pop` except that it returns `()` instead of the topmost element.

This is useful when you're e.g. writing a WebAssembly interpreter. :)

More seriously, Sherlocode shows [118 results] when searching for `ignore (Stack.pop` and there are [probably more] - IIRC Sherlocode doesn't index all opam packages so I bet the real number is higher.

With the feature freeze, I wasn't sure about when this can be merged. I used `@since 5.00`, let me know if this should be changed.

[118 results]: https://sherlocode.com/?q=ignore%20(Stack.pop
[probably more]: https://sherlocode.com/?q=ignore%20%40%40%20Stack.pop