### PR TITLE
Fix compilation of systhreads on Visual Studio 2019 and 2022

### DIFF
--- a/Changes
+++ b/Changes
@@ -384,6 +384,11 @@ OCaml 4.14.0
   (Sébastien Hinderer, review by David Allsopp, Daniel Bünzli, Xavier Leroy
   and Gabriel Scherer)
 
+- #10797: Compile with -d2VolatileMetadata- on supporting versions of Visual
+  Studio. This suppresses the addition of .voltbl sections and eliminates
+  linking errors in systhreads.
+  (David Allsopp, review by Jonah Beckford and Sébastien Hinderer)
+
 ### Bug fixes:
 
 - #9214, #10709: Wrong unmarshaling of function pointers in debugger mode.

--- a/aclocal.m4
+++ b/aclocal.m4
@@ -129,6 +129,19 @@ AC_DEFUN([OCAML_CC_HAS_DEBUG_PREFIX_MAP], [
   CFLAGS="$saved_CFLAGS"
 ])
 
+AC_DEFUN([OCAML_CL_HAS_VOLATILE_METADATA], [
+  AC_MSG_CHECKING([whether the C compiler supports -d2VolatileMetadata-])
+  saved_CFLAGS="$CFLAGS"
+  CFLAGS="-d2VolatileMetadata- $CFLAGS"
+  AC_COMPILE_IFELSE(
+    [AC_LANG_SOURCE([int main() { return 0; }])],
+    [cl_has_volatile_metadata=true
+    AC_MSG_RESULT([yes])],
+    [cl_has_volatile_metadata=false
+    AC_MSG_RESULT([no])])
+  CFLAGS="$saved_CFLAGS"
+])
+
 # Save C compiler related variables
 AC_DEFUN([OCAML_CC_SAVE_VARIABLES], [
   saved_CC="$CC"

--- a/configure
+++ b/configure
@@ -12846,6 +12846,30 @@ $as_echo "$as_me: WARNING: Consider using GCC version 4.2 or above." >&2;};
     common_cflags="-nologo -O2 -Gy- -MD $cc_warnings"
       common_cppflags="-D_CRT_SECURE_NO_DEPRECATE"
       internal_cppflags='-DUNICODE -D_UNICODE'
+
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether the C compiler supports -d2VolatileMetadata-" >&5
+$as_echo_n "checking whether the C compiler supports -d2VolatileMetadata-... " >&6; }
+  saved_CFLAGS="$CFLAGS"
+  CFLAGS="-d2VolatileMetadata- $CFLAGS"
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+int main() { return 0; }
+_ACEOF
+if ac_fn_c_try_compile "$LINENO"; then :
+  cl_has_volatile_metadata=true
+    { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
+else
+  cl_has_volatile_metadata=false
+    { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+  CFLAGS="$saved_CFLAGS"
+
+      if test "x$cl_has_volatile_metadata" = "xtrue"; then :
+  internal_cflags='-d2VolatileMetadata-'
+fi
       internal_cppflags="$internal_cppflags -DWINDOWS_UNICODE="
       internal_cppflags="${internal_cppflags}\$(WINDOWS_UNICODE)" ;; #(
   xlc-*) :

--- a/configure.ac
+++ b/configure.ac
@@ -676,6 +676,9 @@ AS_CASE([$host],
       [common_cflags="-nologo -O2 -Gy- -MD $cc_warnings"
       common_cppflags="-D_CRT_SECURE_NO_DEPRECATE"
       internal_cppflags='-DUNICODE -D_UNICODE'
+      OCAML_CL_HAS_VOLATILE_METADATA
+      AS_IF([test "x$cl_has_volatile_metadata" = "xtrue"],
+            [internal_cflags='-d2VolatileMetadata-'])
       internal_cppflags="$internal_cppflags -DWINDOWS_UNICODE="
       internal_cppflags="${internal_cppflags}\$(WINDOWS_UNICODE)"],
     [xlc-*],


### PR DESCRIPTION
Subtly buried in [this blog post](https://devblogs.microsoft.com/cppblog/msvc-backend-updates-in-visual-studio-2019-version-16-10-preview-2/) from the Microsoft C++ Team is:

> - Enabled volatile metadata by default when targeting x64 to improve emulation performance

This coincides with this cryptic error we've been seeing on the Docker base images builds for Windows, for example, in [this log](https://images.ci.ocaml.org/job/2021-11-23/152603-ocluster-build-6964d1):

```
OCAML_FLEXLINK="../../flexlink.opt.exe -I ../../stdlib/flexdll" ../../boot/ocamlrun.exe ../../tools/ocamlmklib.exe -o threads st_stubs.b.obj 
dyndllb72035.obj : fatal error LNK1400: section 0x17 contains invalid volatile metadata
** Fatal error: Error during linking
```

The precise trigger for this is not clear to me: msvc64 is failing for 4.10.2, 4.12.1 and 4.13.1 but _not_ for 4.11.1 and if my memory (if not my log trawling) serves then for a while this _only_ affected 4.10 and not earlier revisions of 4.12 and 4.13. It can be unequivocally fixed by removing the `volatile` qualifier at

https://github.com/ocaml/ocaml/blob/01c6f16cc69ce1d8cf157e66d5702fadaa18d247/otherlibs/systhreads/st_win32.h#L503

but that obviously is not a fix, because that variable is volatile for a reason. Information on all this is a little bit scant, but in this [Twitter thread](https://twitter.com/ericbrumer/status/1422305190414217244?s=21), @ericbrumer suggests (with authority!) that this is to do with improving Windows emulation of AMD64 on ARM64.

With some more information and some time, I would like prefer to fix what flexlink is not quite doing correctly, but in the meantime I have confirmed in testing that adding `-d2VolatileMetadata-` to our internal cflags in this PR and also using `/EMITVOLATILEMETADATA:NO` to the linker calls in flexlink (see alainfrisch/flexdll#96) both independently eliminate this problem. I am suggesting that we adopt both for now.