### PR TITLE
Atomic.update (was: Atomic.modify, Atomic.modify_get)

### DIFF
--- a/Changes
+++ b/Changes
@@ -95,7 +95,7 @@ Working version
 ### Standard library:
 
 - #10798: Atomic helper function
-    modify : ('a -> 'a) -> 'a t -> unit
+    update : ('a -> 'a) -> 'a t -> unit
   (Gabriel Scherer, review by Simon Cruanes, Stephen Dolan,
    Xavier Leroy, Guillaume Munch-Maccagnoni, Vesa Karvonen,
    Noah Bogart, Léo Andrès and Olivier Nicole)

--- a/Changes
+++ b/Changes
@@ -94,6 +94,12 @@ Working version
 
 ### Standard library:
 
+- #10798: Atomic helper function
+    modify : ('a -> 'a) -> 'a t -> unit
+  (Gabriel Scherer, review by Simon Cruanes, Stephen Dolan,
+   Xavier Leroy, Guillaume Munch-Maccagnoni, Vesa Karvonen,
+   Noah Bogart, Léo Andrès and Olivier Nicole)
+
 - #13554: Add `List.append_map` and `List.rev_append_map`.
   (Sylvain Boilard and Hugo Heuzard, review by Nicolás Ojeda Bär, Daniel Bünzli,
    Damien Doligez and Jeremy Yallop)

--- a/stdlib/.depend
+++ b/stdlib/.depend
@@ -649,6 +649,7 @@ stdlib__Printexc.cmo : printexc.ml \
     stdlib.cmi \
     stdlib__Printf.cmi \
     stdlib__Obj.cmi \
+    stdlib__List.cmi \
     stdlib__Buffer.cmi \
     stdlib__Atomic.cmi \
     stdlib__Array.cmi \
@@ -657,6 +658,7 @@ stdlib__Printexc.cmx : printexc.ml \
     stdlib.cmx \
     stdlib__Printf.cmx \
     stdlib__Obj.cmx \
+    stdlib__List.cmx \
     stdlib__Buffer.cmx \
     stdlib__Atomic.cmx \
     stdlib__Array.cmx \

--- a/stdlib/atomic.ml
+++ b/stdlib/atomic.ml
@@ -28,6 +28,20 @@ module Loc = struct
     ignore (fetch_and_add t 1)
   let decr t =
     ignore (fetch_and_add t (-1))
+
+  let rec modify f t =
+    let v_old = get t in
+    let v_new = f v_old in
+    if compare_and_set t v_old v_new
+    then ()
+    else modify f t
+
+  let rec modify_get f t =
+    let v_old = get t in
+    let res, v_new = f v_old in
+    if compare_and_set t v_old v_new
+    then res
+    else modify_get f t
 end
 
 type !'a t =
@@ -54,6 +68,11 @@ let incr t =
   Loc.incr [%atomic.loc t.contents]
 let decr t =
   Loc.decr [%atomic.loc t.contents]
+
+let modify f t =
+  Loc.modify f [%atomic.loc t.contents]
+let modify_get f t =
+  Loc.modify_get f [%atomic.loc t.contents]
 
 module Array = struct
   type !'a t =
@@ -106,6 +125,12 @@ module Array = struct
   let[@inline] fetch_and_add t i incr =
     check_array_bound t i;
     unsafe_fetch_and_add t i incr
+
+  let[@inline] unsafe_modify f t i =
+    Loc.modify f (unsafe_index t i)
+  let[@inline] modify f t i =
+    check_array_bound t i;
+    unsafe_modify f t i
 
   let make len v =
     if len < 0 then

--- a/stdlib/atomic.ml
+++ b/stdlib/atomic.ml
@@ -129,7 +129,7 @@ module Loc = struct
     let rec loop ~backoff f t =
       let v_old = get t in
       let v_new = f v_old in
-      if compare_and_set t v_old v_new
+      if v_old == v_new || compare_and_set t v_old v_new
       then ()
       else loop ~backoff:(Backoff.once backoff) f t
     in loop ~backoff:Backoff.default f t

--- a/stdlib/atomic.ml
+++ b/stdlib/atomic.ml
@@ -35,13 +35,6 @@ module Loc = struct
     if compare_and_set t v_old v_new
     then ()
     else modify f t
-
-  let rec modify_get f t =
-    let v_old = get t in
-    let res, v_new = f v_old in
-    if compare_and_set t v_old v_new
-    then res
-    else modify_get f t
 end
 
 type !'a t =
@@ -71,8 +64,6 @@ let decr t =
 
 let modify f t =
   Loc.modify f [%atomic.loc t.contents]
-let modify_get f t =
-  Loc.modify_get f [%atomic.loc t.contents]
 
 module Array = struct
   type !'a t =

--- a/stdlib/atomic.ml
+++ b/stdlib/atomic.ml
@@ -3,6 +3,7 @@
 (*                                 OCaml                                  *)
 (*                                                                        *)
 (*                 Stephen Dolan, University of Cambridge                 *)
+(*                 Vesa Karvonen <vesa.a.j.k@gmail.com>                   *)
 (*                                                                        *)
 (*   Copyright 2017-2018 University of Cambridge.                         *)
 (*                                                                        *)
@@ -11,6 +12,92 @@
 (*   special exception on linking described in the file LICENSE.          *)
 (*                                                                        *)
 (**************************************************************************)
+
+(* This submodule is imported from the Backoff library:
+     https://github.com/ocaml-multicore/backoff
+   It is currently not exposed in the public interface, and reserved
+   to the implementation of derived Atomic operations.
+*)
+module Backoff : sig
+  (** Randomized exponential backoff mechanism. *)
+
+  type t [@@immediate]
+  (** Type of backoff values. *)
+
+  val max_wait_log : int
+  (** Logarithm of the maximum allowed value for wait. *)
+
+  val create : ?lower_wait_log:int -> ?upper_wait_log:int -> unit -> t
+  (** [create] creates a backoff value. [upper_wait_log], [lower_wait_log]
+      override the logarithmic upper and lower bound on the number of spins
+      executed by {!once}. *)
+
+  val default : t
+  (** [default] is equivalent to [create ()]. *)
+
+  val once : t -> t
+  (** [once b] executes one random wait and returns a new backoff with logarithm
+      of the current maximum value incremented unless it is already at
+      [upper_wait_log] of [b].
+
+      Note that this uses the default Stdlib [Random] per-domain generator. *)
+
+  val reset : t -> t
+  (** [reset b] returns a backoff equivalent to [b] except with
+      current value set to the [lower_wait_log] of [b]. *)
+
+  val get_wait_log : t -> int
+  (** [get_wait_log b] returns logarithm of the maximum value of wait for next
+      {!once}. *)
+end = struct
+  type t = int
+
+  let single_mask = Bool.to_int (Domain.recommended_domain_count () = 1) - 1
+  let bits = 5
+  let max_wait_log = 30 (* [Random.bits] returns 30 random bits. *)
+  let mask = (1 lsl bits) - 1
+
+  let create ?(lower_wait_log = 4) ?(upper_wait_log = 17) () =
+    assert (
+      0 <= lower_wait_log
+      && lower_wait_log <= upper_wait_log
+      && upper_wait_log <= max_wait_log);
+    (upper_wait_log lsl (bits * 2))
+    lor (lower_wait_log lsl bits) lor lower_wait_log
+
+  let get_upper_wait_log backoff = backoff lsr (bits * 2)
+  let get_lower_wait_log backoff = (backoff lsr bits) land mask
+  let get_wait_log backoff = backoff land mask
+
+  let reset backoff =
+    let lower_wait_log = get_lower_wait_log backoff in
+    backoff land lnot mask lor lower_wait_log
+
+  (* We don't want [once] to be inlined.  This may avoid code bloat. *)
+  let[@inline never] once backoff =
+    let wait_log = get_wait_log backoff in
+    let wait_mask = (1 lsl wait_log) - 1 in
+    (* We use a ref and a countdown while-loop (uses one variable)
+       instead of a for-loop (uses two variables) to reduce register
+       pressure.  Local ref does not allocate with native compiler. *)
+    let t = ref (wait_mask land single_mask) in
+    while 0 <= !t do
+      cpu_relax ();
+      t := !t - 1
+    done;
+    let upper_wait_log = get_upper_wait_log backoff in
+    (* We recompute [wait_log] to reduce register pressure. *)
+    let wait_log = get_wait_log backoff in
+    (* [bool_to_int] generates branchless code, this reduces branch predictor
+       pressure and generates shorter code. *)
+    let next_wait_log = wait_log + bool_to_int (wait_log < upper_wait_log) in
+    backoff - wait_log + next_wait_log
+
+  let default = create ()
+end
+[@@warning "-unused-value-declaration"]
+
+module _ = Backoff
 
 external ignore : 'a -> unit = "%ignore"
 

--- a/stdlib/atomic.ml
+++ b/stdlib/atomic.ml
@@ -125,7 +125,7 @@ module Loc = struct
   let decr t =
     ignore (fetch_and_add t (-1))
 
-  let modify f t =
+  let update f t =
     let rec loop ~backoff f t =
       let v_old = get t in
       let v_new = f v_old in
@@ -160,8 +160,8 @@ let incr t =
 let decr t =
   Loc.decr [%atomic.loc t.contents]
 
-let modify f t =
-  Loc.modify f [%atomic.loc t.contents]
+let update f t =
+  Loc.update f [%atomic.loc t.contents]
 
 module Array = struct
   type !'a t =
@@ -215,11 +215,11 @@ module Array = struct
     check_array_bound t i;
     unsafe_fetch_and_add t i incr
 
-  let[@inline] unsafe_modify f t i =
-    Loc.modify f (unsafe_index t i)
-  let[@inline] modify f t i =
+  let[@inline] unsafe_update f t i =
+    Loc.update f (unsafe_index t i)
+  let[@inline] update f t i =
     check_array_bound t i;
-    unsafe_modify f t i
+    unsafe_update f t i
 
   let make len v =
     if len < 0 then

--- a/stdlib/atomic.ml
+++ b/stdlib/atomic.ml
@@ -17,9 +17,13 @@
      https://github.com/ocaml-multicore/backoff
    It is currently not exposed in the public interface, and reserved
    to the implementation of derived Atomic operations.
+
+   To avoid dependency cycles within the runtime, we removed the use
+   of Random.bits to introduce random jitter. Instead we now wait
+   deterministically for 2^R loop iterations after R retries.
 *)
 module Backoff : sig
-  (** Randomized exponential backoff mechanism. *)
+  (** Exponential backoff mechanism. *)
 
   type t [@@immediate]
   (** Type of backoff values. *)
@@ -36,11 +40,9 @@ module Backoff : sig
   (** [default] is equivalent to [create ()]. *)
 
   val once : t -> t
-  (** [once b] executes one random wait and returns a new backoff with logarithm
+  (** [once b] executes one wait and returns a new backoff with logarithm
       of the current maximum value incremented unless it is already at
-      [upper_wait_log] of [b].
-
-      Note that this uses the default Stdlib [Random] per-domain generator. *)
+      [upper_wait_log] of [b]. *)
 
   val reset : t -> t
   (** [reset b] returns a backoff equivalent to [b] except with
@@ -52,7 +54,14 @@ module Backoff : sig
 end = struct
   type t = int
 
-  let single_mask = Bool.to_int (Domain.recommended_domain_count () = 1) - 1
+  (* externals imported to avoid dependency cycles *)
+  external bool_to_int : bool -> int = "%identity"
+  external cpu_relax : unit -> unit
+    = "caml_ml_domain_cpu_relax"
+  external get_recommended_domain_count: unit -> int
+    = "caml_recommended_domain_count" [@@noalloc]
+
+  let single_mask = bool_to_int (get_recommended_domain_count () = 1) - 1
   let bits = 5
   let max_wait_log = 30 (* [Random.bits] returns 30 random bits. *)
   let mask = (1 lsl bits) - 1

--- a/stdlib/atomic.ml
+++ b/stdlib/atomic.ml
@@ -125,12 +125,14 @@ module Loc = struct
   let decr t =
     ignore (fetch_and_add t (-1))
 
-  let rec modify f t =
-    let v_old = get t in
-    let v_new = f v_old in
-    if compare_and_set t v_old v_new
-    then ()
-    else modify f t
+  let modify f t =
+    let rec loop ~backoff f t =
+      let v_old = get t in
+      let v_new = f v_old in
+      if compare_and_set t v_old v_new
+      then ()
+      else loop ~backoff:(Backoff.once backoff) f t
+    in loop ~backoff:Backoff.default f t
 end
 
 type !'a t =

--- a/stdlib/atomic.mli
+++ b/stdlib/atomic.mli
@@ -70,19 +70,19 @@ val incr : int t -> unit
 (** [decr r] atomically decrements the value of [r] by [1]. *)
 val decr : int t -> unit
 
-(** [modify f r] computes a new value for [r] by applying [f] to its
+(** [update f r] computes a new value for [r] by applying [f] to its
     current value, sets this new value or retries (calling [f] again)
     if [r] was concurrently changed to a physically different value.
 
     Example:
 {[
 let global_list = Atomic.make []
-let global_push elem = Atomic.modify (List.cons elem) global_list
+let global_push elem = Atomic.update (List.cons elem) global_list
 ]}
 
     @since 5.6
 *)
-val modify : ('a -> 'a) -> 'a t -> unit
+val update : ('a -> 'a) -> 'a t -> unit
 
 (** Atomic "locations", such as record fields.
 
@@ -110,7 +110,7 @@ module Loc : sig
   external fetch_and_add : int t -> int -> int = "%atomic_fetch_add_loc"
   val incr : int t -> unit
   val decr : int t -> unit
-  val modify : ('a -> 'a) -> 'a t -> unit
+  val update : ('a -> 'a) -> 'a t -> unit
 end
 
 
@@ -155,9 +155,9 @@ module Array : sig
   val fetch_and_add :
     int t -> int -> int -> int
 
-  val unsafe_modify :
+  val unsafe_update :
     ('a -> 'a) -> 'a t -> int -> unit
-  val modify :
+  val update :
     ('a -> 'a) -> 'a t -> int -> unit
 end
 
@@ -264,9 +264,9 @@ end
     ]}
 
     The simple retry-loop pattern of [push] can be expressed
-    with {!Atomic.modify} instead:
+    with {!Atomic.update} instead:
 
     {[
-    let push stack elt = Atomic.modify (fun li -> elt :: li) stack
+    let push stack elt = Atomic.update (fun li -> elt :: li) stack
     ]}
   *)

--- a/stdlib/atomic.mli
+++ b/stdlib/atomic.mli
@@ -70,6 +70,40 @@ val incr : int t -> unit
 (** [decr r] atomically decrements the value of [r] by [1]. *)
 val decr : int t -> unit
 
+(** [modify f r] computes a new value for [r] by applying [f] to its
+    current value, sets this new value or retries (calling [f] again)
+    if [r] was concurrently changed to a physically different value.
+
+    Example:
+{[
+let global_list = Atomic.make []
+let global_push elem = Atomic.modify (List.cons elem) global_list
+]}
+
+    @since 5.6
+*)
+val modify : ('a -> 'a) -> 'a t -> unit
+
+(** [modify_get f r] computes a pair [(v, new_r)] by calling [f]
+    to the value of [r]. It tries to set this new value in [r]
+    and returns [v], or retries (calling [f] again) if [r] was
+    concurrently changed to a physically different value.
+
+    Example:
+{[
+let global_list = Atomic.make []
+let global_pop () =
+  let pop = function
+  | [] -> raise Not_found
+  | x::xs -> x, xs
+  in
+  Atomic.modify_get pop global_lit
+]}
+
+    @since 5.6
+*)
+val modify_get : ('a -> 'b * 'a) -> 'a t -> 'b
+
 (** Atomic "locations", such as record fields.
 
     @since 5.4 *)
@@ -96,6 +130,7 @@ module Loc : sig
   external fetch_and_add : int t -> int -> int = "%atomic_fetch_add_loc"
   val incr : int t -> unit
   val decr : int t -> unit
+  val modify : ('a -> 'a) -> 'a t -> unit
 end
 
 
@@ -139,6 +174,11 @@ module Array : sig
     int t -> int -> int -> int
   val fetch_and_add :
     int t -> int -> int -> int
+
+  val unsafe_modify :
+    ('a -> 'a) -> 'a t -> int -> unit
+  val modify :
+    ('a -> 'a) -> 'a t -> int -> unit
 end
 
 (** {1:examples Examples}
@@ -241,5 +281,12 @@ end
     - : int option = Some 1
     # pop st
     - : int option = None
+    ]}
+
+    The simple retry-loop pattern of [push] can be expressed
+    with {!Atomic.modify} instead:
+
+    {[
+    let push stack elt = Atomic.modify (fun li -> elt :: li) stack
     ]}
   *)

--- a/stdlib/atomic.mli
+++ b/stdlib/atomic.mli
@@ -84,26 +84,6 @@ let global_push elem = Atomic.modify (List.cons elem) global_list
 *)
 val modify : ('a -> 'a) -> 'a t -> unit
 
-(** [modify_get f r] computes a pair [(v, new_r)] by calling [f]
-    to the value of [r]. It tries to set this new value in [r]
-    and returns [v], or retries (calling [f] again) if [r] was
-    concurrently changed to a physically different value.
-
-    Example:
-{[
-let global_list = Atomic.make []
-let global_pop () =
-  let pop = function
-  | [] -> raise Not_found
-  | x::xs -> x, xs
-  in
-  Atomic.modify_get pop global_lit
-]}
-
-    @since 5.6
-*)
-val modify_get : ('a -> 'b * 'a) -> 'a t -> 'b
-
 (** Atomic "locations", such as record fields.
 
     @since 5.4 *)

--- a/stdlib/atomic.mli
+++ b/stdlib/atomic.mli
@@ -74,6 +74,9 @@ val decr : int t -> unit
     current value, sets this new value or retries (calling [f] again)
     if [r] was concurrently changed to a physically different value.
 
+    Remark: no [set] is performed when [f] returns a value that is
+    physically equal to its input, the update terminates immediately.
+
     Example:
 {[
 let global_list = Atomic.make []

--- a/stdlib/printexc.ml
+++ b/stdlib/printexc.ml
@@ -280,11 +280,8 @@ let get_backtrace () = raw_backtrace_to_string (get_raw_backtrace ())
 external record_backtrace: bool -> unit = "caml_record_backtrace"
 external backtrace_status: unit -> bool = "caml_backtrace_status"
 
-let rec register_printer fn =
-  let old_printers = Atomic.get printers in
-  let new_printers = fn :: old_printers in
-  let success = Atomic.compare_and_set printers old_printers new_printers in
-  if not success then register_printer fn
+let register_printer fn =
+  Atomic.modify (List.cons fn) printers
 
 external get_callstack: int -> raw_backtrace = "caml_get_current_callstack"
 

--- a/stdlib/printexc.ml
+++ b/stdlib/printexc.ml
@@ -281,7 +281,7 @@ external record_backtrace: bool -> unit = "caml_record_backtrace"
 external backtrace_status: unit -> bool = "caml_backtrace_status"
 
 let register_printer fn =
-  Atomic.modify (List.cons fn) printers
+  Atomic.update (List.cons fn) printers
 
 external get_callstack: int -> raw_backtrace = "caml_get_current_callstack"
 

--- a/testsuite/tests/atomic-locs/record_fields.ml
+++ b/testsuite/tests/atomic-locs/record_fields.ml
@@ -22,7 +22,7 @@ module Basic = struct
     Atomic.Loc.compare_and_set (get_loc r) oldv newv
 end
 [%%expect{|
-(apply (field_mut 1 (global Toploop!)) "Basic/341"
+(apply (field_mut 1 (global Toploop!)) "Basic/344"
   (let
     (get = (function r (atomic_load r 1))
      set = (function r v : int (ignore (caml_atomic_exchange_field r 1 v)))
@@ -147,7 +147,7 @@ end : sig
   type t = { mutable x : int [@atomic] }
 end)
 [%%expect{|
-(apply (field_mut 1 (global Toploop!)) "Ok/368" (makeblock 0))
+(apply (field_mut 1 (global Toploop!)) "Ok/371" (makeblock 0))
 module Ok : sig type t = { mutable x : int [@atomic]; } end
 |}];;
 
@@ -161,7 +161,7 @@ module Inline_record = struct
   let test : t -> int = fun (A r) -> r.x
 end
 [%%expect{|
-(apply (field_mut 1 (global Toploop!)) "Inline_record/376"
+(apply (field_mut 1 (global Toploop!)) "Inline_record/379"
   (let (test = (function param : int (atomic_load param 0)))
     (makeblock 0 test)))
 module Inline_record :
@@ -181,7 +181,7 @@ module Extension_with_inline_record = struct
   let () = assert (test (A { x = 42 }) = 42)
 end
 [%%expect{|
-(apply (field_mut 1 (global Toploop!)) "Extension_with_inline_record/384"
+(apply (field_mut 1 (global Toploop!)) "Extension_with_inline_record/387"
   (let
     (A =
        (makeblock 248 "Extension_with_inline_record.A" (caml_fresh_oo_id 0))
@@ -210,7 +210,7 @@ module Float_records = struct
   let get v = v.y
 end
 [%%expect{|
-(apply (field_mut 1 (global Toploop!)) "Float_records/399"
+(apply (field_mut 1 (global Toploop!)) "Float_records/402"
   (let
     (mk_t = (function x[float] y[float] (makemutable 0 (float,float) x y))
      get = (function v : float (atomic_load v 1)))
@@ -256,7 +256,7 @@ Line 5, characters 14-19:
 Warning 9 [missing-record-field-pattern]: the following labels are not bound
   in this record pattern: "y".
   Either bind these labels explicitly or add "; _" to the pattern.
-(apply (field_mut 1 (global Toploop!)) "Pattern_matching_wildcard/419"
+(apply (field_mut 1 (global Toploop!)) "Pattern_matching_wildcard/422"
   (let
     (warning = (function param : int (field_int 0 param))
      allowed = (function param : int (field_int 0 param)))

--- a/testsuite/tests/lib-atomic/test_atomic.ml
+++ b/testsuite/tests/lib-atomic/test_atomic.ml
@@ -37,3 +37,27 @@ let () =
   let cur = Atomic.get r in
   ignore (Atomic.incr r, Atomic.decr r);
   assert (Atomic.get r = cur)
+
+let () =
+  let r = Atomic.make 1 in
+  Atomic.modify (fun i ->
+    begin
+      (* simulate concurrent modifications *)
+      if i < 10 then Atomic.incr r;
+    end;
+    i + 1
+  ) r;
+  assert (Atomic.get r = 11)
+
+let () =
+  let r = Atomic.make 1 in
+  let v =
+    Atomic.modify_get (fun i ->
+      begin
+        (* simulate concurrent modifications *)
+        if i < 10 then Atomic.incr r;
+      end;
+      string_of_int i, i + 1
+    ) r
+  in
+  assert (v = "10")

--- a/testsuite/tests/lib-atomic/test_atomic.ml
+++ b/testsuite/tests/lib-atomic/test_atomic.ml
@@ -48,16 +48,3 @@ let () =
     i + 1
   ) r;
   assert (Atomic.get r = 11)
-
-let () =
-  let r = Atomic.make 1 in
-  let v =
-    Atomic.modify_get (fun i ->
-      begin
-        (* simulate concurrent modifications *)
-        if i < 10 then Atomic.incr r;
-      end;
-      string_of_int i, i + 1
-    ) r
-  in
-  assert (v = "10")

--- a/testsuite/tests/lib-atomic/test_atomic.ml
+++ b/testsuite/tests/lib-atomic/test_atomic.ml
@@ -40,7 +40,7 @@ let () =
 
 let () =
   let r = Atomic.make 1 in
-  Atomic.modify (fun i ->
+  Atomic.update (fun i ->
     begin
       (* simulate concurrent modifications *)
       if i < 10 then Atomic.incr r;


### PR DESCRIPTION
```ocaml
val modify : ('a -> 'a) -> 'a t -> unit
val modify_get : ('a -> 'b * 'a) -> 'a t -> 'b
```

Many uses of `Atomic.compare_and_set` are in retry loops that can be factored out by these new functions. Consider:

https://github.com/ocaml-multicore/ocaml-multicore/blob/4469f89/stdlib/printexc.ml#L268-L272
```ocaml
(* old version *)
let rec register_printer fn =
  let old_printers = Atomic.get printers in
  let new_printers = fn :: old_printers in
  let success = Atomic.compare_and_set printers old_printers new_printers in
  if not success then register_printer fn

(* new version *)
let register_printer fn = Atomic.modify (List.cons fn) printers
```

https://github.com/ocaml-multicore/ocaml-multicore/blob/4469f89/testsuite/tests/parallel/mctest.ml#L222-L226
```ocaml
(* old version *)
  let rec finish () =
    let v = Atomic.get counter in
    if not (Atomic.compare_and_set counter v (v+1)) then finish ();
    if v + 1 = procs then exit 0

(* new version *)
  let finish () =
    (* this could also be done with the more specialized Atomic.fetch_and_add *)
    let next = Atomic.modify_get (fun v -> v+1, v+1) in
    if next = procs then exit 0
```

https://github.com/ocaml-bench/sandmark/blob/642d16edeb1ad68e5fbe5019035f6fc4f8223dea/benchmarks/multicore-structures/treiber_stack.ml
```ocaml
(* old version *)
let rec add_node s n =
  let old_top = Atomic.get s.top in
  Atomic.set n.next old_top ;
  if Atomic.compare_and_set s.top old_top (Some n) then () else add_node s n

(* new version *)
let add_node s n =
  Atomic.modify (fun old_top ->
    Atomic.set n.next old_top ; Some n
  ) s.top
```

https://github.com/dune-universe/dune-universe/blob/eef415c39aa4533cf5fad448e2b9a31e15ee03b8/packages/uring.0.1/lib/uring/uring.ml
```ocaml
(* old *)
let rec update_gc_roots fn =
  let old_set = Atomic.get gc_roots in
  let new_set = fn old_set in
  if not (Atomic.compare_and_set gc_roots old_set new_set) then
    update_gc_roots fn

(* new *)
let update_gc_roots fn = Atomic.modify fn gc_roots
```

Remark:
- Some more elaborate uses of `compare_and_set` are in more complex retry loops (see for example the [Domainslib.Chan](https://github.com/ocaml-multicore/domainslib/blob/master/lib/chan.ml) implementation)
- The current definitions do not call `cpu_relax ()` or any other backoff logic. Some uses in the wild would be expressible if we parametrized over the backoff function. I don't know if this is a choice that users should be forced to make.