### PR TITLE
 #10780: a missing cmi can hide a concrete type declaration

### DIFF
--- a/Changes
+++ b/Changes
@@ -231,7 +231,8 @@ OCaml 4.14.0
 
 ### Compiler user-interface and warnings:
 
-- #10328: Give more precise error when disambiguation could not possibly work.
+- #10328, #10780: Give more precise error when disambiguation could not
+  possibly work.
   (Leo White, review by Gabriel Scherer and Florian Angeletti)
 
 - #10361: Improve error messages for mismatched record and variant

--- a/testsuite/tests/typing-missing-cmi-3/middle.ml
+++ b/testsuite/tests/typing-missing-cmi-3/middle.ml
@@ -6,3 +6,10 @@ let g: (module Original.T) -> unit = fun _ -> ()
 type pack1 = (module Original.T with type t = int)
 module type T = sig module M : Original.T end
 type pack2 = (module T with type M.t = int)
+
+(* Check the detection of type kind in type-directed disambiguation. *)
+type r = Original.r = { x:unit }
+let r = Original.r
+
+type s = Original.s = S
+let s = Original.s

--- a/testsuite/tests/typing-missing-cmi-3/original.ml
+++ b/testsuite/tests/typing-missing-cmi-3/original.ml
@@ -1,2 +1,8 @@
 type 'a t = T
 module type T = sig type t end
+
+type r = { x:unit }
+let r = { x = () }
+
+type s = S
+let s = S

--- a/testsuite/tests/typing-missing-cmi-3/user.ml
+++ b/testsuite/tests/typing-missing-cmi-3/user.ml
@@ -13,6 +13,7 @@ script = "rm -f original.cmi"
 
 
 #directory "ocamlc.byte";;
+#load "original.cmo"
 #load "middle.cmo"
 
 let x:'a. 'a Middle.t =
@@ -86,4 +87,15 @@ Line 2, characters 12-45:
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: Type Middle.pack2 = (module Middle.T with type M.t = int)
        is not a subtype of (module T2)
+|}]
+
+(* Check the detection of type kind in type-directed disambiguation . *)
+let t = Middle.r.Middle.x
+[%%expect {|
+val t : unit = ()
+|}]
+
+let k = match Middle.s with Middle.S -> ()
+[%%expect {|
+val k : unit = ()
 |}]

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -1616,16 +1616,19 @@ type typedecl_extraction_result =
 let rec extract_concrete_typedecl env ty =
   match get_desc ty with
     Tconstr (p, _, _) ->
-      let decl = Env.find_type p env in
-      if decl.type_kind <> Type_abstract then Typedecl(p, p, decl)
-      else begin
-        match try_expand_safe env ty with
-        | exception Cannot_expand -> May_have_typedecl
-        | ty ->
-            match extract_concrete_typedecl env ty with
-            | Typedecl(_, p', decl) -> Typedecl(p, p', decl)
-            | Has_no_typedecl -> Has_no_typedecl
-            | May_have_typedecl -> May_have_typedecl
+      begin match Env.find_type p env with
+      | exception Not_found -> May_have_typedecl
+      | decl ->
+          if decl.type_kind <> Type_abstract then Typedecl(p, p, decl)
+          else begin
+            match try_expand_safe env ty with
+            | exception Cannot_expand -> May_have_typedecl
+            | ty ->
+                match extract_concrete_typedecl env ty with
+                | Typedecl(_, p', decl) -> Typedecl(p, p', decl)
+                | Has_no_typedecl -> Has_no_typedecl
+                | May_have_typedecl -> May_have_typedecl
+          end
       end
   | Tpoly(ty, _) -> extract_concrete_typedecl env ty
   | Tarrow _ | Ttuple _ | Tobject _ | Tfield _ | Tnil


### PR DESCRIPTION
This PR fixes an oversight in my review of #10328:  when the typechecker is querying a concrete type declaration from a path, the query might fail due to a missing cmi.

Those unhandled query failures manifested in #10780 as uncaught `Not_found` exceptions when building some opam projects which use the `no implicit transitive dependencies` option of dune.

This PR fixes this issue by directly handling the query failure in `Ctype.extract_concrete_typedecl`.
Fortunately, this fix fits neatly in the refactoring introduced by #10328 .

After a [quick glance](https://github.com/Octachron/ocaml/commit/5c0408cd39dd5ca1888612ba0bd47a06ef288330), this was probably the only unsafe use of `Env.find_type`.