### PR TITLE
additional functions on Semaphore

### DIFF
--- a/otherlibs/systhreads/semaphore.ml
+++ b/otherlibs/systhreads/semaphore.ml
@@ -54,6 +54,10 @@ let try_acquire s =
 
 let get_value s = s.v
 
+let with_acquire s f =
+  acquire s;
+  Fun.protect f
+    ~finally:(fun () -> release s)
 end
 
 module Binary = struct
@@ -82,5 +86,11 @@ let try_acquire s =
   let ret = if s.v = 0 then false else (s.v <- 0; true) in
   Mutex.unlock s.mut;
   ret
+
+let with_acquire s f =
+  acquire s;
+  Fun.protect
+    ~finally:(fun () -> release s)
+    f
 
 end

--- a/otherlibs/systhreads/semaphore.ml
+++ b/otherlibs/systhreads/semaphore.ml
@@ -45,7 +45,7 @@ let release_multi s n =
   else if n = 1 then release s
   else (
     Mutex.lock s.mut;
-    if s.v + n < max_int then begin
+    if s.v < max_int - n then begin
       s.v <- s.v + n;
       Condition.broadcast s.nonzero;
       Mutex.unlock s.mut

--- a/otherlibs/systhreads/semaphore.mli
+++ b/otherlibs/systhreads/semaphore.mli
@@ -68,6 +68,13 @@ val acquire : t -> unit
     is not zero, then atomically decrements the value of [s] and returns.
 *)
 
+val with_acquire : t -> (unit -> 'a) -> 'a
+(** [with_acquire s f] runs [f()] in a context where [s] is acquired,
+    and makes sure to release [s] before returning.
+
+    @since 4.14
+*)
+
 val try_acquire : t -> bool
 (** [try_acquire s] immediately returns [false] if the value of semaphore [s]
     is zero.  Otherwise, the value of [s] is atomically decremented
@@ -136,5 +143,11 @@ val try_acquire : t -> bool
     has value 0.  If [s] has value 1, its value is atomically set to 0
     and [try_acquire s] returns [true].
 *)
+
+val with_acquire : t -> (unit -> 'a) -> 'a
+(** [with_acquire s f] runs [f()] in a context where [s] is acquired,
+    and makes sure to release [s] before returning.
+
+    @since 4.14 *)
 
 end

--- a/otherlibs/systhreads/semaphore.mli
+++ b/otherlibs/systhreads/semaphore.mli
@@ -63,15 +63,41 @@ val release : t -> unit
     @raise Sys_error if the value of the semaphore would overflow [max_int]
 *)
 
+val release_multi : t -> int -> unit
+(** [release_multi s n] releases [n] units to the semaphore.
+
+    @raise Sys_error if the value would overflow.
+    @raise Invalid_arg if [n] is less than 1
+    @see {!release} for more details.
+    @since 4.14
+*)
+
 val acquire : t -> unit
 (** [acquire s] blocks the calling thread until the value of semaphore [s]
     is not zero, then atomically decrements the value of [s] and returns.
+*)
+
+val acquire_multi : t -> int -> unit
+(** [acquire_multi s n] acquires [n] "units" from the semaphore [s].
+    It will block until [n] units are available.
+
+    @raise Invalid_arg if [n] is less than 1.
+    @since 4.14
 *)
 
 val with_acquire : t -> (unit -> 'a) -> 'a
 (** [with_acquire s f] runs [f()] in a context where [s] is acquired,
     and makes sure to release [s] before returning.
 
+    @since 4.14
+*)
+
+val with_acquire_multi : t -> int -> (unit -> 'a) -> 'a
+(** [with_acquire_multi s n f] runs [f()] in a context where [n]
+    units of [s] are acquired,
+    and makes sure to release them before returning.
+
+    @see {!with_acquire} and {!acquire_multi} for more details.
     @since 4.14
 *)
 

--- a/otherlibs/systhreads/semaphore.mli
+++ b/otherlibs/systhreads/semaphore.mli
@@ -170,10 +170,4 @@ val try_acquire : t -> bool
     and [try_acquire s] returns [true].
 *)
 
-val with_acquire : t -> (unit -> 'a) -> 'a
-(** [with_acquire s f] runs [f()] in a context where [s] is acquired,
-    and makes sure to release [s] before returning.
-
-    @since 4.14 *)
-
 end


### PR DESCRIPTION
This adds a bit of meat on the mimalistic API currently present. I think the `with_acquire` functions are really important; the `_multi` are less often useful, but because there's no way for users to implement them safely I think they still belong.

edit: a tricky thing is the use of `Condition.signal` rather than `broadcast`, which might be wrong in the case of the awakened thread using `acquire_multi` with too big a constant, when another thread is blocked on `acquire` but isn't wakened up by the condition.