### PR TITLE
Use 4.12 value macros in C code

### DIFF
--- a/Changes
+++ b/Changes
@@ -50,6 +50,9 @@ Working version
 - #11022: Track GC work for all managed bigarray allocations
   (Stephen Dolan, report by Andrew Hunter, review by Damien Doligez)
 
+- #10802: Use 4.12 value macros and helpers in C code
+  (Antonin Décimo, review by Gabriel Scherer)
+
 ### Code generation and optimizations:
 
 - #10972: ARM64 multicore support: OCaml & C stack separation;

--- a/otherlibs/systhreads/st_posix.h
+++ b/otherlibs/systhreads/st_posix.h
@@ -343,10 +343,9 @@ static int st_atfork(void (*fn)(void))
 static void st_decode_sigset(value vset, sigset_t * set)
 {
   sigemptyset(set);
-  while (vset != Val_int(0)) {
+  for (/*nothing*/; vset != Val_emptylist; vset = Field(vset, 1)) {
     int sig = caml_convert_signal_number(Int_val(Field(vset, 0)));
     sigaddset(set, sig);
-    vset = Field(vset, 1);
   }
 }
 
@@ -364,7 +363,8 @@ static value st_encode_sigset(sigset_t * set)
 
   for (i = 1; i < NSIG; i++)
     if (sigismember(set, i) > 0) {
-      res = caml_alloc_2(0, Val_int(caml_rev_convert_signal_number(i)), res);
+      res = caml_alloc_2(Tag_cons,
+                         Val_int(caml_rev_convert_signal_number(i)), res);
     }
   CAMLreturn(res);
 }

--- a/otherlibs/unix/getaddrinfo.c
+++ b/otherlibs/unix/getaddrinfo.c
@@ -65,7 +65,7 @@ CAMLprim value unix_getaddrinfo(value vnode, value vserv, value vopts)
   int retcode;
 
   if (! (caml_string_is_c_safe(vnode) && caml_string_is_c_safe(vserv)))
-    CAMLreturn (Val_int(0));
+    CAMLreturn (Val_emptylist);
 
   /* Extract "node" parameter */
   if (caml_string_length(vnode) == 0) {
@@ -82,7 +82,7 @@ CAMLprim value unix_getaddrinfo(value vnode, value vserv, value vopts)
   /* Parse options, set hints */
   memset(&hints, 0, sizeof(hints));
   hints.ai_family = PF_UNSPEC;
-  for (/*nothing*/; Is_block(vopts); vopts = Field(vopts, 1)) {
+  for (/*nothing*/; vopts != Val_emptylist; vopts = Field(vopts, 1)) {
     v = Field(vopts, 0);
     if (Is_block(v))
       switch (Tag_val(v)) {
@@ -113,11 +113,11 @@ CAMLprim value unix_getaddrinfo(value vnode, value vserv, value vopts)
   if (node != NULL) caml_stat_free(node);
   if (serv != NULL) caml_stat_free(serv);
   /* Convert result */
-  vres = Val_int(0);
+  vres = Val_emptylist;
   if (retcode == 0) {
     for (r = res; r != NULL; r = r->ai_next) {
       e = convert_addrinfo(r);
-      v = caml_alloc_small(2, 0);
+      v = caml_alloc_small(2, Tag_cons);
       Field(v, 0) = e;
       Field(v, 1) = vres;
       vres = v;

--- a/otherlibs/unix/select.c
+++ b/otherlibs/unix/select.c
@@ -53,7 +53,7 @@ static value fdset_to_fdlist(value fdlist, fd_set *fdset)
   for (l = fdlist; l != Val_emptylist; l = Field(l, 1)) {
     int fd = Int_val(Field(l, 0));
     if (FD_ISSET(fd, fdset)) {
-      value newres = caml_alloc_small(2, 0);
+      value newres = caml_alloc_small(2, Tag_cons);
       Field(newres, 0) = Val_int(fd);
       Field(newres, 1) = res;
       res = newres;

--- a/otherlibs/unix/signals.c
+++ b/otherlibs/unix/signals.c
@@ -30,10 +30,9 @@
 static void decode_sigset(value vset, sigset_t * set)
 {
   sigemptyset(set);
-  while (vset != Val_int(0)) {
+  for (/*nothing*/; vset != Val_emptylist; vset = Field(vset, 1)) {
     int sig = caml_convert_signal_number(Int_val(Field(vset, 0)));
     sigaddset(set, sig);
-    vset = Field(vset, 1);
   }
 }
 
@@ -45,7 +44,7 @@ static value encode_sigset(sigset_t * set)
 
   for (i = 1; i < NSIG; i++)
     if (sigismember(set, i) > 0) {
-      value newcons = caml_alloc_2(0,
+      value newcons = caml_alloc_2(Tag_cons,
         Val_int(caml_rev_convert_signal_number(i)),
         res);
       res = newcons;

--- a/otherlibs/win32unix/createprocess.c
+++ b/otherlibs/win32unix/createprocess.c
@@ -99,8 +99,8 @@ value win_create_process_native(value cmd, value cmdline, value env,
   caml_stat_free(wcmd);
   wcmdline = caml_stat_strdup_to_utf16(String_val(cmdline));
 
-  if (env != Val_int(0)) {
-    env = Field(env, 0);
+  if (Is_some(env)) {
+    env = Some_val(env);
     size =
       win_multi_byte_to_wide_char(String_val(env),
                                   caml_string_length(env), NULL, 0);

--- a/runtime/afl.c
+++ b/runtime/afl.c
@@ -164,7 +164,7 @@ CAMLexport value caml_setup_afl(value unit)
 
 CAMLprim value caml_reset_afl_instrumentation(value full)
 {
-  if (full != Val_int(0)) {
+  if (full == Val_true) {
     memset(caml_afl_area_ptr, 0, sizeof(afl_area_initial));
   }
   caml_afl_prev_loc = 0;

--- a/runtime/alloc.c
+++ b/runtime/alloc.c
@@ -276,12 +276,9 @@ CAMLexport value caml_copy_string_array(char const * const * arr)
 
 CAMLexport int caml_convert_flag_list(value list, const int *flags)
 {
-  int res;
-  res = 0;
-  while (list != Val_int(0)) {
+  int res = 0;
+  for (/*nothing*/; list != Val_emptylist; list = Field(list, 1))
     res |= flags[Int_val(Field(list, 0))];
-    list = Field(list, 1);
-  }
   return res;
 }
 
@@ -373,7 +370,7 @@ CAMLprim value caml_update_dummy(value dummy, value newval)
 CAMLexport value caml_alloc_some(value v)
 {
   CAMLparam1(v);
-  value some = caml_alloc_small(1, 0);
+  value some = caml_alloc_small(1, Tag_some);
   Field(some, 0) = v;
   CAMLreturn(some);
 }

--- a/runtime/array.c
+++ b/runtime/array.c
@@ -511,7 +511,7 @@ CAMLprim value caml_array_concat(value al)
   value l, res;
 
   /* Length of list = number of arrays */
-  for (n = 0, l = al; l != Val_int(0); l = Field(l, 1)) n++;
+  for (n = 0, l = al; l != Val_emptylist; l = Field(l, 1)) n++;
   /* Allocate extra storage if too many arrays */
   if (n <= STATIC_SIZE) {
     arrays = static_arrays;
@@ -532,7 +532,7 @@ CAMLprim value caml_array_concat(value al)
     }
   }
   /* Build the parameters to caml_array_gather */
-  for (i = 0, l = al; l != Val_int(0); l = Field(l, 1), i++) {
+  for (i = 0, l = al; l != Val_emptylist; l = Field(l, 1), i++) {
     arrays[i] = Field(l, 0);
     offsets[i] = 0;
     lengths[i] = caml_array_length(Field(l, 0));

--- a/runtime/backtrace.c
+++ b/runtime/backtrace.c
@@ -333,12 +333,9 @@ CAMLprim value caml_raw_backtrace_next_slot(value slot)
   dbg = caml_debuginfo_next(dbg);
 
   if (dbg == NULL)
-    v = Val_int(0); /* None */
+    v = Val_none;
   else
-  {
-    v = caml_alloc(1, 0);
-    Field(v, 0) = Val_debuginfo(dbg);
-  }
+    v = caml_alloc_some(Val_debuginfo(dbg));
 
   CAMLreturn(v);
 }
@@ -358,7 +355,7 @@ CAMLprim value caml_get_exception_backtrace(value unit)
   intnat i;
 
   if (!caml_debug_info_available()) {
-    res = Val_int(0); /* None */
+    res = Val_none;
   } else {
     backtrace = caml_get_exception_raw_backtrace(Val_unit);
 
@@ -369,8 +366,7 @@ CAMLprim value caml_get_exception_backtrace(value unit)
       Store_field(arr, i, caml_convert_debuginfo(dbg));
     }
 
-    res = caml_alloc_small(1, 0);
-    Field(res, 0) = arr; /* Some */
+    res = caml_alloc_some(arr);
   }
 
   CAMLreturn(res);

--- a/runtime/meta.c
+++ b/runtime/meta.c
@@ -100,12 +100,10 @@ CAMLprim value caml_reify_bytecode(value ls_prog,
   prog = (code_t)buffer_of_bytes_array(ls_prog, &len);
   caml_add_debug_info(prog, Val_long(len), debuginfo);
   /* match (digest_opt : string option) with */
-  if (Is_block(digest_opt)) {
-    /* | Some digest -> */
+  if (Is_some(digest_opt)) {
     digest_kind = DIGEST_PROVIDED;
-    digest = (unsigned char *) String_val(Field(digest_opt, 0));
+    digest = (unsigned char *) String_val(Some_val(digest_opt));
   } else {
-    /* | None -> */
     digest_kind = DIGEST_LATER;
     digest = NULL;
   }

--- a/runtime/weak.c
+++ b/runtime/weak.c
@@ -34,9 +34,6 @@ value caml_dummy[] =
    Val_unit};
 value caml_ephe_none = (value)&caml_dummy[1];
 
-#define None_val (Val_int(0))
-#define Some_tag 0
-
 struct caml_ephe_info* caml_alloc_ephe_info (void)
 {
   struct caml_ephe_info* e =
@@ -216,8 +213,8 @@ CAMLprim value caml_ephe_unset_key (value e, value n)
 
 value caml_ephe_set_key_option (value e, value n, value el)
 {
-  if (el != None_val && Is_block (el)) {
-    return caml_ephe_set_key (e, n, Field(el, 0));
+  if (Is_some (el)) {
+    return caml_ephe_set_key (e, n, Some_val(el));
   } else {
     return caml_ephe_unset_key (e, n);
   }
@@ -247,11 +244,11 @@ static value ephe_get_field (value e, mlsize_t offset)
   elt = Field(e, offset);
 
   if (elt == caml_ephe_none) {
-    res = None_val;
+    res = Val_none;
   } else {
     elt = Field(e, offset);
     caml_darken (0, elt, 0);
-    res = caml_alloc_shr (1, Some_tag);
+    res = caml_alloc_shr (1, Tag_some);
     caml_initialize(&Field(res, 0), elt);
   }
   /* run GC and memprof callbacks */
@@ -284,7 +281,7 @@ static value ephe_get_field_copy (value e, mlsize_t offset)
   clean_field(e, offset);
   v = Field(e, offset);
   if (v == caml_ephe_none) {
-    res = None_val;
+    res = Val_none;
     goto out;
   }
 
@@ -298,7 +295,7 @@ static value ephe_get_field_copy (value e, mlsize_t offset)
 
     clean_field(e, offset);
     v = Field(e, offset);
-    if (v == caml_ephe_none) CAMLreturn (None_val);
+    if (v == caml_ephe_none) CAMLreturn (Val_none);
 
     if (Tag_val(v) == Infix_tag) {
       infix_offs = Infix_offset_val(v);
@@ -324,7 +321,7 @@ static value ephe_get_field_copy (value e, mlsize_t offset)
   } else {
     Field(e, offset) = elt = v;
   }
-  res = caml_alloc_shr (1, Some_tag);
+  res = caml_alloc_shr (1, Tag_some);
   caml_initialize(&Field(res, 0), elt + infix_offs);
  out:
   /* run GC and memprof callbacks */


### PR DESCRIPTION
Follow-up to my previous #10255, I think this helps readability quite a lot: now `Val_int(0)` really means an integer of value 0.
I also changed list-walking to use the for loop style that was already used in most places.