### PR TITLE
#10790: Pprintast, print type parameter variance in `with` constraints

### DIFF
--- a/Changes
+++ b/Changes
@@ -781,6 +781,10 @@ OCaml 4.14.0
   (Gabriel Scherer and Nathanaëlle Courant,
    review by Florian Angeletti, Ulysse Gérard and Thomas Refis)
 
+- #10790: don't drop variance and injectivity annotations when pretty printing
+  `with` constraints (for example, `with type +!'a t = ...`).
+  (Florian Angeletti, report by Luke Maurer, review by ???)
+
 ### Build system:
 
 - #10835 Disable DT_TEXTREL warnings on x86 32 bit architecture by passing

--- a/Changes
+++ b/Changes
@@ -333,6 +333,11 @@ OCaml 5.0
 
 ### Bug fixes:
 
+- #10790: don't drop variance and injectivity annotations when pretty printing
+  `with` constraints (for example, `with type +!'a t = ...`).
+  (Florian Angeletti, report by Luke Maurer, review by Matthew Ryan and
+   Gabriel Scherer)
+
 - #11167: Fix memory leak from signal stack.
   (Antoni Żewierżejew, review by Gabriel Scherer and Enguerrand Decorne)
 
@@ -780,10 +785,6 @@ OCaml 4.14.0
 - #10742: strong call-by-need reduction for shapes
   (Gabriel Scherer and Nathanaëlle Courant,
    review by Florian Angeletti, Ulysse Gérard and Thomas Refis)
-
-- #10790: don't drop variance and injectivity annotations when pretty printing
-  `with` constraints (for example, `with type +!'a t = ...`).
-  (Florian Angeletti, report by Luke Maurer, review by ???)
 
 ### Build system:
 

--- a/parsing/pprintast.ml
+++ b/parsing/pprintast.ml
@@ -1068,19 +1068,17 @@ and module_type ctxt f x =
 
 and with_constraint ctxt f = function
   | Pwith_type (li, ({ptype_params= ls ;_} as td)) ->
-      let ls = List.map fst ls in
       pp f "type@ %a %a =@ %a"
-        (list (core_type ctxt) ~sep:"," ~first:"(" ~last:")")
-        ls longident_loc li (type_declaration ctxt) td
+        (type_params ctxt) ls
+        longident_loc li (type_declaration ctxt) td
   | Pwith_module (li, li2) ->
       pp f "module %a =@ %a" longident_loc li longident_loc li2;
   | Pwith_modtype (li, mty) ->
       pp f "module type %a =@ %a" longident_loc li (module_type ctxt) mty;
   | Pwith_typesubst (li, ({ptype_params=ls;_} as td)) ->
-      let ls = List.map fst ls in
       pp f "type@ %a %a :=@ %a"
-        (list (core_type ctxt) ~sep:"," ~first:"(" ~last:")")
-        ls longident_loc li
+        (type_params ctxt) ls
+        longident_loc li
         (type_declaration ctxt) td
   | Pwith_modsubst (li, li2) ->
       pp f "module %a :=@ %a" longident_loc li longident_loc li2

--- a/testsuite/tests/parsetree/source.ml
+++ b/testsuite/tests/parsetree/source.ml
@@ -7443,3 +7443,9 @@ let g y =
   f ~(y:int)
 
 let goober a = match a with C (type a b) y -> y
+
+
+(** With constraints *)
+
+module type s = sig type ('a,'b) t end with type (-!'a, !+'b) t = 'b -> 'a list
+module type s = sig type ('a,'b) t end with type (!-'a, +!'b) t := 'b -> 'a list

--- a/testsuite/tests/parsetree/source.ml
+++ b/testsuite/tests/parsetree/source.ml
@@ -7449,3 +7449,4 @@ let goober a = match a with C (type a b) y -> y
 
 module type s = sig type ('a,'b) t end with type (-!'a, !+'b) t = 'b -> 'a list
 module type s = sig type ('a,'b) t end with type (!-'a, +!'b) t := 'b -> 'a list
+module type s = sig type ('a,'b) t end with type ('a,'b) t := 'b -> 'a list


### PR DESCRIPTION
This PR updates the `Pprintast` printer to correctly print type parameters in the left-hand side of `with` constraints (e.g 
`S with type +! 'a t = 'a list` — which has also the advantage of simplifying the printer.

close #10790