### PR TITLE
Windows: replace `socket` with `WSASocket` and set `WSA_FLAG_NO_HANDLE_INHERIT`

### DIFF
--- a/Changes
+++ b/Changes
@@ -218,6 +218,12 @@ Working version
   can use the OCaml runtime.
   (Gabriel Scherer, review by Xavier Leroy, report by Brahima Dibassi)
 
+- #10809: Use the WSA_FLAG_NO_HANDLE_INHERIT on Windows when creating
+  sockets with WSASocket if the cloexec (non-inheritable) parameter is
+  true. Fixes a race condition where a child process could inherit the
+  socket and deadlock the parent.
+  (Antonin Décimo, review by Xavier Leroy)
+
 OCaml 4.14.0
 ----------------
 

--- a/otherlibs/win32unix/dup.c
+++ b/otherlibs/win32unix/dup.c
@@ -37,7 +37,7 @@ static HANDLE duplicate_handle(BOOL inherit, HANDLE oldh)
 static SOCKET duplicate_socket(BOOL inherit, SOCKET oldsock)
 {
   WSAPROTOCOL_INFO info;
-  SOCKET newsock;
+
   if (SOCKET_ERROR == WSADuplicateSocket(oldsock,
                                          GetCurrentProcessId(),
                                          &info)) {
@@ -45,13 +45,8 @@ static SOCKET duplicate_socket(BOOL inherit, SOCKET oldsock)
     return INVALID_SOCKET;
   }
 
-  newsock = WSASocket(info.iAddressFamily, info.iSocketType, info.iProtocol,
-                      &info, 0, WSA_FLAG_OVERLAPPED);
-  if (INVALID_SOCKET == newsock)
-    win32_maperr(WSAGetLastError());
-  else
-    win_set_inherit((HANDLE) newsock, inherit);
-  return newsock;
+  return win32_socket(info.iAddressFamily, info.iSocketType, info.iProtocol,
+                      &info, inherit);
 }
 
 CAMLprim value unix_dup(value cloexec, value fd)

--- a/otherlibs/win32unix/socket.c
+++ b/otherlibs/win32unix/socket.c
@@ -28,9 +28,11 @@ CAMLprim value unix_socket(value cloexec, value domain, value type, value proto)
 {
   SOCKET s;
 
-  s = socket(socket_domain_table[Int_val(domain)],
-                   socket_type_table[Int_val(type)],
-                   Int_val(proto));
+  s = WSASocket(socket_domain_table[Int_val(domain)],
+                socket_type_table[Int_val(type)],
+                Int_val(proto),
+                NULL, 0,
+                WSA_FLAG_OVERLAPPED);
   if (s == INVALID_SOCKET) {
     win32_maperr(WSAGetLastError());
     uerror("socket", Nothing);

--- a/otherlibs/win32unix/socket.c
+++ b/otherlibs/win32unix/socket.c
@@ -14,6 +14,7 @@
 /**************************************************************************/
 
 #include <caml/mlvalues.h>
+#include <caml/memory.h>
 #include "unixsupport.h"
 
 int socket_domain_table[] = {
@@ -24,19 +25,54 @@ int socket_type_table[] = {
   SOCK_STREAM, SOCK_DGRAM, SOCK_RAW, SOCK_SEQPACKET
 };
 
-CAMLprim value unix_socket(value cloexec, value domain, value type, value proto)
+SOCKET win32_socket(int domain, int type, int protocol,
+                    LPWSAPROTOCOL_INFO info,
+                    BOOL inherit)
 {
   SOCKET s;
+  DWORD flags = WSA_FLAG_OVERLAPPED;
 
-  s = WSASocket(socket_domain_table[Int_val(domain)],
-                socket_type_table[Int_val(type)],
-                Int_val(proto),
-                NULL, 0,
-                WSA_FLAG_OVERLAPPED);
+#ifndef WSA_FLAG_NO_HANDLE_INHERIT
+#define WSA_FLAG_NO_HANDLE_INHERIT 0x80
+#endif
+
+  if (! inherit)
+    flags |= WSA_FLAG_NO_HANDLE_INHERIT;
+
+  s = WSASocket(domain, type, protocol, info, 0, flags);
   if (s == INVALID_SOCKET) {
-    win32_maperr(WSAGetLastError());
-    uerror("socket", Nothing);
+    if (! inherit && WSAGetLastError() == WSAEINVAL) {
+      /* WSASocket probably doesn't suport WSA_FLAG_NO_HANDLE_INHERIT,
+       * retry without. */
+      flags &= ~(DWORD)WSA_FLAG_NO_HANDLE_INHERIT;
+      s = WSASocket(domain, type, protocol, info, 0, flags);
+      if (s == INVALID_SOCKET)
+        goto err;
+      win_set_inherit((HANDLE) s, FALSE);
+      return s;
+    }
+    goto err;
   }
-  win_set_cloexec((HANDLE) s, cloexec);
-  return win_alloc_socket(s);
+
+  return s;
+
+err:
+  win32_maperr(WSAGetLastError());
+  return INVALID_SOCKET;
+}
+
+CAMLprim value unix_socket(value cloexec, value domain, value type, value proto)
+{
+  CAMLparam4(cloexec, domain, type, proto);
+  CAMLlocal1(v_socket);
+  SOCKET s;
+  s = win32_socket(socket_domain_table[Int_val(domain)],
+                   socket_type_table[Int_val(type)],
+                   Int_val(proto),
+                   NULL,
+                   ! unix_cloexec_p(cloexec));
+  if (s == INVALID_SOCKET)
+    uerror("socket", Nothing);
+  v_socket = win_alloc_socket(s);
+  CAMLreturn(v_socket);
 }

--- a/otherlibs/win32unix/socketpair.c
+++ b/otherlibs/win32unix/socketpair.c
@@ -74,7 +74,7 @@ static int socketpair(int domain, int type, int protocol,
     goto fail_path;
   }
 
-  listener = socket(domain, type, protocol);
+  listener = WSASocket(domain, type, protocol, NULL, 0, WSA_FLAG_OVERLAPPED);
   if (listener == INVALID_SOCKET)
     goto fail_wsa;
 
@@ -95,7 +95,7 @@ static int socketpair(int domain, int type, int protocol,
   if (rc == SOCKET_ERROR)
     goto fail_wsa;
 
-  client = socket(domain, type, protocol);
+  client = WSASocket(domain, type, protocol, NULL, 0, WSA_FLAG_OVERLAPPED);
   if (client == INVALID_SOCKET)
     goto fail_wsa;
 

--- a/otherlibs/win32unix/socketpair.c
+++ b/otherlibs/win32unix/socketpair.c
@@ -35,7 +35,8 @@ extern int socket_type_table[]; /* from socket.c */
 #else
 
 static int socketpair(int domain, int type, int protocol,
-                      SOCKET socket_vector[2])
+                      SOCKET socket_vector[2],
+                      BOOL inherit)
 {
   wchar_t dirname[MAX_PATH + 1], path[MAX_PATH + 1];
   union sock_addr_union addr;
@@ -74,7 +75,7 @@ static int socketpair(int domain, int type, int protocol,
     goto fail_path;
   }
 
-  listener = WSASocket(domain, type, protocol, NULL, 0, WSA_FLAG_OVERLAPPED);
+  listener = win32_socket(domain, type, protocol, NULL, inherit);
   if (listener == INVALID_SOCKET)
     goto fail_wsa;
 
@@ -95,7 +96,7 @@ static int socketpair(int domain, int type, int protocol,
   if (rc == SOCKET_ERROR)
     goto fail_wsa;
 
-  client = WSASocket(domain, type, protocol, NULL, 0, WSA_FLAG_OVERLAPPED);
+  client = win32_socket(domain, type, protocol, NULL, inherit);
   if (client == INVALID_SOCKET)
     goto fail_wsa;
 
@@ -181,14 +182,12 @@ CAMLprim value unix_socketpair(value cloexec, value domain, value type,
   rc = socketpair(socket_domain_table[Int_val(domain)],
                   socket_type_table[Int_val(type)],
                   Int_val(protocol),
-                  sv);
+                  sv,
+                  ! unix_cloexec_p(cloexec));
   caml_leave_blocking_section();
 
   if (rc == SOCKET_ERROR)
     uerror("socketpair", Nothing);
-
-  win_set_cloexec((HANDLE) sv[0], cloexec);
-  win_set_cloexec((HANDLE) sv[1], cloexec);
 
   result = caml_alloc_tuple(2);
   Store_field(result, 0, win_alloc_socket(sv[0]));

--- a/otherlibs/win32unix/unixsupport.h
+++ b/otherlibs/win32unix/unixsupport.h
@@ -52,6 +52,10 @@ extern value win_alloc_handle(HANDLE);
 extern value win_alloc_socket(SOCKET);
 extern int win_CRT_fd_of_filedescr(value handle);
 
+extern SOCKET win32_socket(int domain, int type, int protocol,
+                           LPWSAPROTOCOL_INFO info,
+                           BOOL inherit);
+
 #define NO_CRT_FD (-1)
 #define Nothing ((value) 0)
 


### PR DESCRIPTION
The call to

    socket(domain, type, protocol);

is equivalent to

    WSASocket(domain, type, protocol, NULL, 0, WSA_FLAG_OVERLAPPED);

the latter offering more (needed) control over the creation of
sockets.

On Windows, in order to mark sockets non-inheritable (close-on-exec),
it is sometimes not sufficient to use SetHandleInformation. There's
some explanation why in [1] and [KB2398202].

Introduced in the hotfix [KB2398202] and supported on Windows 7 with
SP1, Windows Server 2008 R2 with SP1, and later, the flag
`WSA_FLAG_NO_HANDLE_INHERIT` can be used with `WSASocket` to create a
non-inheritable socket.

We can still call `SetHandleInformation` to clear the inheritable flag
on the socket in case the flag isn't supported (running on an early
Windows Vista or 7).

[1]: https://stackoverflow.com/questions/12058911/can-tcp-socket-handles-be-set-not-inheritable
[KB2398202]: https://support.microsoft.com/en-us/topic/an-application-may-stop-responding-when-the-application-closes-a-socket-connection-or-shuts-down-41321a1f-d80c-6975-98df-ae499d63133c