### PR TITLE
Add -verbose option to the ocaml toplevel

### DIFF
--- a/driver/main_args.ml
+++ b/driver/main_args.ml
@@ -1062,7 +1062,7 @@ end;;
 module type Bytetop_options = sig
   include Toplevel_options
   val _dinstr : unit -> unit
-
+  val _verbose : unit -> unit
 end;;
 
 module type Optcommon_options = sig
@@ -1337,6 +1337,8 @@ struct
     mk_args F._args;
     mk_args0 F._args0;
     mk_eval F._eval;
+
+    mk_verbose F._verbose;
   ]
 end;;
 
@@ -1949,6 +1951,7 @@ module Default = struct
     include Toplevel
     include Core
     let _dinstr = set dump_instr
+    let _verbose = set verbose
   end
 
   module Opttopmain = struct

--- a/driver/main_args.mli
+++ b/driver/main_args.mli
@@ -166,7 +166,7 @@ end;;
 module type Bytetop_options = sig
   include Toplevel_options
   val _dinstr : unit -> unit
-
+  val _verbose : unit -> unit
 end;;
 
 module type Optcommon_options = sig

--- a/testsuite/tools/expect_test.ml
+++ b/testsuite/tools/expect_test.ml
@@ -344,6 +344,7 @@ let main fname =
 module Options = Main_args.Make_bytetop_options (struct
   include Main_args.Default.Topmain
   let _stdin () = (* disabled *) ()
+  let _verbose () = (* disabled *) ()
   let _args = Arg.read_arg
   let _args0 = Arg.read_arg0
   let anonymous s = main s


### PR DESCRIPTION
Resolves #7099.

I'd really like to add tests for this, but I don't know any more commands that get logged besides ppxes which takes random (temporary files) arguments and makes difficult to have a reference file for it.