### PR TITLE
Fix documentation comments

### DIFF
--- a/HACKING.adoc
+++ b/HACKING.adoc
@@ -144,7 +144,10 @@ result by running
 make html_doc
 ----
 
-and then opening link:./api_docgen/build/html/libref/index.html[] in a web browser.
+and then opening link:./api_docgen/ocamldoc/build/html/libref/index.html[] in a web browser.
+The documentation is located in
+link:./api_docgen/odoc/build/html/libref/index.html[] when `--with-odoc` is
+passed to the configure script.
 
 === Tools
 

--- a/Makefile
+++ b/Makefile
@@ -944,7 +944,6 @@ partialclean::
 .PHONY: html_doc
 html_doc: ocamldoc
 	$(MAKE) -C api_docgen html
-	@echo "documentation is in ./api_docgen/html/"
 
 .PHONY: manpages
 manpages:

--- a/api_docgen/Format_tutorial.mld
+++ b/api_docgen/Format_tutorial.mld
@@ -39,22 +39,21 @@ There are 4 types of boxes. (The most often used is the "hov" box type, so skip
 the rest at first reading).
 
   - {b horizontal box} ({i h} box, as obtained by the
-    {!open_hbox} procedure): within this box, break hints do not
+    {!Format.open_hbox} procedure): within this box, break hints do not
     lead to line breaks.
   - {b vertical box} ({i v} box, as obtained by the
-    {!open_vbox} procedure): within this box, every break hint lead
+    {!Format.open_vbox} procedure): within this box, every break hint lead
     to a new line.
   - {b vertical/horizontal box} ({i hv} box, as obtained by
-    the {!open_hvbox} procedure): if it is possible, the entire box
+    the {!Format.open_hvbox} procedure): if it is possible, the entire box
     is written on a single line; otherwise, every break hint within the box
     leads to a new line.
   - {b vertical or horizontal box} ({i hov} box, as obtained
-    by the {!open_box} or {!open_hovbox} procedures): within this box, break
-    hints are used to cut the line when there is no more room on the line.
-    There are two kinds of "hov" boxes, you can find the details
-    below. In first approximation, let me
-    consider these two kinds of "hov" boxes as equivalent and
-    obtained by calling the {!open_box} procedure.
+    by the {!Format.open_box} or {!Format.open_hovbox} procedures): within this
+    box, break hints are used to cut the line when there is no more room on the
+    line. There are two kinds of "hov" boxes, you can find the details below.
+    In first approximation, let me consider these two kinds of "hov" boxes as
+    equivalent and obtained by calling the {!Format.open_box} procedure.
 
 Let me give an example. Suppose we can write 10 chars before
 the right margin (that indicates no more room). We represent any
@@ -218,13 +217,14 @@ indentation (as obtained by [open_hovbox 1]), and b is [print_break 1 2], then
 The "hov" box type is refined into two categories.
 
 - {b the vertical or horizontal {i packing} box} (as obtained by the
-{!open_hovbox} procedure): break hints are used to cut the line when there is no
-more room on the line; no new line occurs if there is enough room on the line.
-- {b vertical or horizontal {i structural} box} (as obtained by the {!open_box}
-procedure): similar to the "hov" packing box, the break hints are used to cut
-the line when there is no more room on the line; in addition, break hints that
-can show the box structure lead to new lines even if there is enough room on
-the current line.
+{!Format.open_hovbox} procedure): break hints are used to cut the line when
+there is no more room on the line; no new line occurs if there is enough room
+on the line.
+- {b vertical or horizontal {i structural} box} (as obtained by the
+{!Format.open_box} procedure): similar to the "hov" packing box, the break
+hints are used to cut the line when there is no more room on the line; in
+addition, break hints that can show the box structure lead to new lines even if
+there is enough room on the current line.
 
 The difference between a packing and a structural "hov" box is shown by a
 routine that closes boxes and parentheses at the end of printing: with packing
@@ -233,7 +233,8 @@ is enough room on the line, whereas with structural boxes each break hint will
 lead to a new line. For instance, when printing
 "\[(---\[(----\[(---b)\]b)\]b)\]", where "b" is a break hint without extra
 indentation ([print_cut ()]). If "\[" means opening of a packing "hov" box
-({!open_hovbox}), "\[(---\[(----\[(---b)\]b)\]b)\]" is printed as follows:
+({!Format.open_hovbox}), "\[(---\[(----\[(---b)\]b)\]b)\]" is printed as
+follows:
 
 {[
 (---
@@ -241,9 +242,9 @@ indentation ([print_cut ()]). If "\[" means opening of a packing "hov" box
   (---)))
 ]}
 
-If we replace the packing boxes by structural boxes ({!open_box}), each break
-hint that precedes a closing parenthesis can show the boxes structure, if it
-leads to a new line; hence "\[(---\[(----\[(---b)\]b)\]b)\]" is printed like
+If we replace the packing boxes by structural boxes ({!Format.open_box}), each
+break hint that precedes a closing parenthesis can show the boxes structure, if
+it leads to a new line; hence "\[(---\[(----\[(---b)\]b)\]b)\]" is printed like
 this:
 
 {[
@@ -259,8 +260,8 @@ this:
 
 When writing a pretty-printing routine, follow these simple rules:
 
-+ Boxes must be opened and closed consistently ([open_*] and {!close_box} must
-be nested like parentheses).
++ Boxes must be opened and closed consistently ([open_*] and
+{!Format.close_box} must be nested like parentheses).
 + Never hesitate to open a box.
 + Output many break hints, otherwise the pretty-printer is in a bad situation
 where it tries to do its best, which is always "worse than your bad".
@@ -277,10 +278,10 @@ is a usual (and elegant) way to indent the expression part of a definition.  In
 short, it is often necessary to print unbreakable spaces; however, most of the
 time a space should be considered a break hint.
 + Do not try to force new lines, let the pretty-printer do it for you: that's
-its only job.  In particular, do not use {!force_newline}: this procedure
-effectively leads to a newline, but it also as the unfortunate side effect to
-partially reinitialise the pretty-printing engine, so that the rest of the
-printing material is noticeably messed up.
+its only job.  In particular, do not use {!Format.force_newline}: this
+procedure effectively leads to a newline, but it also as the unfortunate side
+effect to partially reinitialise the pretty-printing engine, so that the rest
+of the printing material is noticeably messed up.
 + Never put newline characters directly in the strings to be printed: pretty
 printing engine will consider this newline character as any other character
 written on the current line and this will completely mess up the output.

--- a/api_docgen/Format_tutorial.mld
+++ b/api_docgen/Format_tutorial.mld
@@ -1,3 +1,5 @@
+{0 Using the Format module}
+
 {1 Principles}
 
 Line breaking is based on three concepts:

--- a/api_docgen/Makefile
+++ b/api_docgen/Makefile
@@ -16,7 +16,6 @@ ROOTDIR = ..
 -include $(ROOTDIR)/Makefile.build_config
 
 ifeq ($(DOCUMENTATION_TOOL),odoc)
-  include odoc/Makefile
 else
   include ocamldoc/Makefile
 endif

--- a/api_docgen/Makefile
+++ b/api_docgen/Makefile
@@ -12,14 +12,15 @@
 #*   special exception on linking described in the file LICENSE.          *
 #*                                                                        *
 #**************************************************************************
+# Used by included Makefiles
 ROOTDIR = ..
--include $(ROOTDIR)/Makefile.build_config
+-include ../Makefile.build_config
 
 odoc-%:
-	$(MAKE) -C odoc $* ROOTDIR=../..
+	$(MAKE) -C odoc $*
 
 ocamldoc-%:
-	$(MAKE) -C ocamldoc $* ROOTDIR=../..
+	$(MAKE) -C ocamldoc $*
 
 ifeq ($(DOCUMENTATION_TOOL),odoc)
 man: odoc-man

--- a/api_docgen/Makefile
+++ b/api_docgen/Makefile
@@ -15,20 +15,33 @@
 ROOTDIR = ..
 -include $(ROOTDIR)/Makefile.build_config
 
-ifeq ($(DOCUMENTATION_TOOL),odoc)
-else
-  include ocamldoc/Makefile
-endif
-
 odoc-%:
 	$(MAKE) -C odoc $* ROOTDIR=../..
 
 ocamldoc-%:
 	$(MAKE) -C ocamldoc $* ROOTDIR=../..
 
-.PHONY: clean
+ifeq ($(DOCUMENTATION_TOOL),odoc)
+man: odoc-man
+latex: odoc-latex
+html: odoc-html
+	@echo "documentation is in ./api_docgen/odoc/build/html/"
+all: html latex man
+install: odoc-install
+else
+man: ocamldoc-man
+latex: ocamldoc-latex
+html: ocamldoc-html
+	@echo "documentation is in ./api_docgen/ocamldoc/build/html/"
+texi: ocamldoc-texi
+pdf: ocamldoc-pdf
+all: html pdf man latex texi
+install: ocamldoc-install
+endif
+
 clean:
 	rm -rf build odoc/build ocamldoc/build
 
-.PHONY: distclean
 distclean: clean
+
+.PHONY: html latex man clean distclean install texi pdf

--- a/api_docgen/Makefile.common
+++ b/api_docgen/Makefile.common
@@ -30,7 +30,7 @@ DOC_STDLIB_DIRS = $(addprefix $(ROOTDIR)/, stdlib \
 .PHONY: all
 all: html pdf man
 
-DIRS = $(addprefix build/,libref compilerlibref man latex texi \
+DIRS = build/ $(addprefix build/,libref compilerlibref man latex texi \
   html html/libref html/compilerlibref)
 
 $(DIRS):

--- a/api_docgen/Makefile.common
+++ b/api_docgen/Makefile.common
@@ -43,7 +43,7 @@ html:
 build/latex/alldoc.pdf: build/latex/stdlib_input.tex \
   build/latex/compilerlibs_input.tex | build/latex/ifocamldoc.tex
 
-$(DOCGEN)/build/Compiler_libs.mld: $(DOCGEN)/Compiler_libs.pre.mld
+build/Compiler_libs.mld: $(DOCGEN)/Compiler_libs.pre.mld | build/
 	cp $< $@ && echo "{!modules:$(compilerlibref_C)}" >> $@
 
 build/latex/ifocamldoc.tex: $(ROOTDIR)/Makefile.config | build/latex
@@ -51,6 +51,5 @@ build/latex/ifocamldoc.tex: $(ROOTDIR)/Makefile.config | build/latex
 build/latex/alldoc.tex:$(DOCGEN)/alldoc.tex | build/latex
 	cp $< $@
 
-$(compilerlibref_TEXT:%=build/%.mld) $(libref_TEXT:%=build/%.mld): \
-build/%.mld:$(DOCGEN)/%.mld
+build/%.mld: $(DOCGEN)/%.mld | build/
 	cp $< $@

--- a/api_docgen/Makefile.common
+++ b/api_docgen/Makefile.common
@@ -12,7 +12,6 @@
 #*   special exception on linking described in the file LICENSE.          *
 #*                                                                        *
 #**************************************************************************
-ROOTDIR = ..
 DOCGEN= $(ROOTDIR)/api_docgen
 
 include $(ROOTDIR)/Makefile.common

--- a/api_docgen/Ocaml_operators.mld
+++ b/api_docgen/Ocaml_operators.mld
@@ -1,4 +1,4 @@
-Precedence level and associativity of operators
+{0 Precedence level and associativity of operators}
 
 The following table lists the precedence level of all operator classes
 from the highest to the lowest precedence. A few other syntactic constructions

--- a/api_docgen/ocamldoc/Makefile
+++ b/api_docgen/ocamldoc/Makefile
@@ -50,11 +50,11 @@ build/compilerlibref/%.odoc: %.mli | build/compilerlibref
 	$(DOC_ALL_INCLUDES) $< -dump  $@
 
 $(compilerlibref_TEXT:%=build/compilerlibref/%.odoc):\
-build/compilerlibref/%.odoc: $(DOCGEN)/build/%.mld | build/compilerlibref
+build/compilerlibref/%.odoc: build/%.mld | build/compilerlibref
 	$(OCAMLDOC_RUN) $(DOC_ALL_INCLUDES) -text $< -dump  $@
 
 $(libref_TEXT:%=build/libref/%.odoc):\
-build/libref/%.odoc: $(DOCGEN)/%.mld | build/libref
+build/libref/%.odoc: build/%.mld | build/libref
 	$(OCAMLDOC_RUN) $(DOC_STDLIB_INCLUDES) -text $< -dump  $@
 
 ALL_COMPILED_DOC=$(ALL_DOC:%=build/%.odoc)
@@ -76,7 +76,7 @@ build/html/compilerlibref/Compiler_libs.html: \
 	$(OCAMLDOC_RUN) -html -d build/html/compilerlibref \
 	-nostdlib -hide Stdlib -t "OCaml compiler library" \
 	$(HTML_OPTIONS) \
-	-intro $(DOCGEN)/build/Compiler_libs.mld \
+	-intro build/Compiler_libs.mld \
 	$(addprefix -load , $(ALL_COMPILERLIBREF:%=build/%.odoc))
 
 build/texi/stdlib.texi: $(ALL_COMPILED_DOC) | build/texi

--- a/api_docgen/ocamldoc/Makefile
+++ b/api_docgen/ocamldoc/Makefile
@@ -12,9 +12,11 @@
 #*   special exception on linking described in the file LICENSE.          *
 #*                                                                        *
 #**************************************************************************
-include $(ROOTDIR)/api_docgen/Makefile.common
-include $(ROOTDIR)/ocamldoc/Makefile.best_ocamldoc
-vpath %.mli $(ROOTDIR)/stdlib $(DOC_COMPILERLIBS_DIRS)  $(DOC_STDLIB_DIRS)
+# Used by included Makefiles
+ROOTDIR = ../..
+include ../Makefile.common
+include ../../ocamldoc/Makefile.best_ocamldoc
+vpath %.mli ../../stdlib $(DOC_COMPILERLIBS_DIRS)  $(DOC_STDLIB_DIRS)
 
 
 man: build/man/Stdlib.3o
@@ -41,7 +43,7 @@ build/latex/ifocamldoc.tex: | build/latex
 $(libref:%=build/libref/%.odoc): build/libref/%.odoc: %.mli | build/libref
 	$(OCAMLDOC_RUN) -nostdlib -hide Stdlib -lib Stdlib \
 	-pp \
-"$(AWK) -v ocamldoc=true -f $(ROOTDIR)/stdlib/expand_module_aliases.awk" \
+"$(AWK) -v ocamldoc=true -f ../../stdlib/expand_module_aliases.awk" \
 	$(DOC_STDLIB_INCLUDES) $< -dump  $@
 
 $(compilerlibref:%=build/compilerlibref/%.odoc):\
@@ -100,9 +102,9 @@ build/latex/Stdlib.tex: $(ALL_COMPILED_DOC) | build/latex
 build/latex/alldoc.pdf: build/latex/Stdlib.tex build/latex/alldoc.tex \
   | build/latex
 	cd build/latex && \
-          TEXINPUTS=$${TEXINPUTS}:$(ROOTDIR)/ocamldoc pdflatex alldoc
+          TEXINPUTS=$${TEXINPUTS}:../../ocamldoc pdflatex alldoc
 	cd build/latex && \
-	  TEXINPUTS=$${TEXINPUTS}:$(ROOTDIR)/ocamldoc pdflatex alldoc
+	  TEXINPUTS=$${TEXINPUTS}:../../ocamldoc pdflatex alldoc
 
 stdlib_INPUT=$(foreach module,\
 $(filter-out stdlib.mli camlinternal%,$(stdlib_UNPREFIXED)),\

--- a/api_docgen/odoc/Makefile
+++ b/api_docgen/odoc/Makefile
@@ -12,10 +12,14 @@
 #*   special exception on linking described in the file LICENSE.          *
 #*                                                                        *
 #**************************************************************************
-include $(ROOTDIR)/api_docgen/Makefile.common
 
-vpath %.cmti $(ROOTDIR)/stdlib $(DOC_COMPILERLIBS_DIRS) $(DOC_STDLIB_DIRS)
-vpath %.cmt $(ROOTDIR)/stdlib
+# Used by included Makefiles
+ROOTDIR = ../..
+
+include ../Makefile.common
+
+vpath %.cmti ../../stdlib $(DOC_COMPILERLIBS_DIRS) $(DOC_STDLIB_DIRS)
+vpath %.cmt ../../stdlib
 
 ifeq ($(DOCUMENTATION_TOOL),odoc)
   odoc ?= $(DOCUMENTATION_TOOL_CMD)

--- a/api_docgen/odoc/Makefile
+++ b/api_docgen/odoc/Makefile
@@ -60,11 +60,11 @@ build/latex/compilerlibs_input.tex: | build/latex
 
 # rules for the mld files
 $(libref_TEXT:%=build/libref/page-%.odoc):
-build/libref/page-%.odoc:$(DOCGEN)/%.mld | build/libref
+build/libref/page-%.odoc: build/%.mld | build/libref
 	$(odoc) compile -I build/libref --package libref $< -o $@
 
 $(compilerlibref_TEXT:%=build/compilerlibref/page-%.odoc):\
-build/compilerlibref/page-%.odoc:$(DOCGEN)/build/%.mld | build/compilerlibref
+build/compilerlibref/page-%.odoc: build/%.mld | build/compilerlibref
 	$(odoc) compile -I build/libref --package compilerlibref $< -o $@
 
 # rules for the stdlib and otherlibs .doc files
@@ -137,9 +137,11 @@ stdlib_INDEX=\
   $(foreach m,$(stdlib_UNPREFIXED),$(call stdlib_prefix,$m))\
   $(call capitalize, $(otherlibref))
 build/libref.mld:
-	echo {0 OCaml standard library} {!modules:$(stdlib_INDEX)} > $@
+	( echo "{0 OCaml standard library}"; \
+	  echo "{!modules:$(stdlib_INDEX)}" ) > $@
 
-build/libref/index.html.stamp: $(ALL_HTML) build/libref.mld | build/libref
+build/libref/index.html.stamp: $(ALL_HTML) build/libref.mld \
+| build/libref build/html/libref
 	$(odoc) compile --package libref build/libref.mld
 	$(odoc) link -I build/libref build/page-libref.odoc
 	$(odoc) html-generate build/page-libref.odocl --output-dir build/html
@@ -147,7 +149,7 @@ build/libref/index.html.stamp: $(ALL_HTML) build/libref.mld | build/libref
 	touch $@
 
 build/compilerlibref/index.html.stamp: $(ALL_HTML) \
-  build/compilerlibref/page-Compiler_libs.html.stamp | build/compilerlibref
+  build/compilerlibref/page-Compiler_libs.html.stamp | build/html/compilerlibref
 	cp build/html/compilerlibref/Compiler_libs.html \
            build/html/compilerlibref/index.html
 	touch $@

--- a/api_docgen/odoc/Makefile
+++ b/api_docgen/odoc/Makefile
@@ -190,3 +190,24 @@ install:
 	if test -d build/man/compilerlibref ; then \
 	  $(INSTALL_DATA) build/man/libref/* "$(INSTALL_LIBRARIES_MAN_DIR)"; \
 	fi
+
+# Dependencies for stdlib modules.
+# Use the same dependencies used for compiling .cmx files.
+# The existing rules look like this:
+#   stdlib__X.cmx: x.ml \
+#       stdlib__Y.cmx \
+#       stdlib__X.cmi
+# We want:
+#   build/libref/stdlib__X.odoc: \
+#       build/libref/stdlib__Y.odoc \
+#       stdlib__X.cmti
+build/.depend: ../../stdlib/.depend | build/
+	sed \
+    -e ':l; /\\ *$$/ { N; bl }; # Read lines separated by \\' \
+    -e '/^\S*\.cmx *:/! d; # Keep only rules to .cmx' \
+    -e 's#\<\(\w*\)\.cmx\>#build/libref/\1.odoc#g; # .cmx -> .odoc' \
+    -e 's/\.cmi\>/.cmti/g; # .cmi -> .cmti' \
+    -e 's/\<\S*\.ml\>//g; # .ml -> removed' \
+    $< > $@
+
+include build/.depend

--- a/api_docgen/odoc/Makefile
+++ b/api_docgen/odoc/Makefile
@@ -95,13 +95,15 @@ ALL_PAGED_DOC = $(TARGET_UNITS) $(ALL_PAGE_TEXT)
 # rules for odocl generation
 # Note that we are using a dependency on the whole phase 1 rather than tracking
 # the individual file dependencies
-$(ALL_UNITS:%=build/%.odocl):%.odocl:%.odoc \
+%.odocl:%.odoc \
   | $(ALL_PAGED_DOC:%=build/%.odoc)
-	$(odoc) link -I build/libref -I build/compilerlibref $<
+	$(odoc) link -I build/libref -I build/compilerlibref $(ODOC_LINK_ARGS) $<
 
-$(ALL_PAGE_TEXT:%=build/%.odocl):%.odocl:%.odoc \
+%.odocl:%.odoc \
   | $(ALL_PAGED_DOC:%=build/%.odoc)
-	$(odoc) link -I build/libref -I build/compilerlibref $<
+	$(odoc) link -I build/libref -I build/compilerlibref $(ODOC_LINK_ARGS) $<
+
+build/libref/stdlib.odocl: ODOC_LINK_ARGS+=--open=""
 
 # Rules for all three backends:
 

--- a/manual/src/Makefile
+++ b/manual/src/Makefile
@@ -22,21 +22,31 @@ APIDOC=$(ROOTDIR)/api_docgen
 ifeq ($(DOCUMENTATION_TOOL),odoc)
 latex_files:
 	make -C $(APIDOC) latex
-	cp $(APIDOC)/build/latex/*/*.tex library
+	cp $(APIDOC)/odoc/build/latex/*/*.tex library
+
 html_files:
 	make -C $(APIDOC) html
-	cp -r $(APIDOC)/build/html/*  htmlman
+	cp -r $(APIDOC)/odoc/build/html/*  htmlman
+
+ifocamldoc.tex: $(ROOTDIR)/Makefile.build_config
+	$(MAKE) -C $(APIDOC)/odoc build/latex/ifocamldoc.tex
+	cp $(APIDOC)/odoc/build/latex/ifocamldoc.tex $@
 else
 latex_files:
 	$(MAKE) -C $(APIDOC) latex
-	cp $(APIDOC)/build/latex/*.tex library
+	cp $(APIDOC)/ocamldoc/build/latex/*.tex library
+
 html_files:
 	$(MAKE) -C $(APIDOC) html
 	mkdir -p htmlman/libref
-	cp -r $(APIDOC)/build/html/libref htmlman
-	cp -r $(APIDOC)/build/html/compilerlibref htmlman
+	cp -r $(APIDOC)/ocamldoc/build/html/libref htmlman
+	cp -r $(APIDOC)/ocamldoc/build/html/compilerlibref htmlman
 	cp style.css htmlman/libref
 	cp style.css htmlman/compilerlibref
+
+ifocamldoc.tex: $(ROOTDIR)/Makefile.build_config
+	$(MAKE) -C $(APIDOC)/ocamldoc build/latex/ifocamldoc.tex
+	cp $(APIDOC)/ocamldoc/build/latex/ifocamldoc.tex $@
 endif
 
 manual: files latex_files
@@ -141,10 +151,6 @@ cmds/warnings-help.etex: $(ROOTDIR)/utils/warnings.ml $(ROOTDIR)/ocamlc
 	    $@ > $@.tmp;\
 	  mv $@.tmp $@;\
 	done
-
-ifocamldoc.tex: $(ROOTDIR)/Makefile.build_config
-	$(MAKE) -C $(APIDOC) build/latex/ifocamldoc.tex
-	cp $(APIDOC)/build/latex/ifocamldoc.tex $@
 
 .PHONY: clean
 clean:

--- a/parsing/ast_iterator.mli
+++ b/parsing/ast_iterator.mli
@@ -13,9 +13,10 @@
 (*                                                                        *)
 (**************************************************************************)
 
-(** {!iterator} enables AST inspection using open recursion.  A
-    typical mapper would be based on {!default_iterator}, a trivial iterator,
-    and will fall back on it for handling the syntax it does not modify.
+(** {!Ast_iterator.iterator} enables AST inspection using open recursion.  A
+    typical mapper would be based on {!Ast_iterator.default_iterator}, a
+    trivial iterator, and will fall back on it for handling the syntax it does
+    not modify.
 
   {b Warning:} this module is unstable and part of
   {{!Compiler_libs}compiler-libs}.

--- a/stdlib/bigarray.mli
+++ b/stdlib/bigarray.mli
@@ -236,7 +236,7 @@ type fortran_layout = Fortran_layout_typ (**)
    phantom types {!Bigarray.c_layout} and {!Bigarray.fortran_layout}
    respectively. *)
 
-(** {7 Supported layouts}
+(** {2 Supported layouts}
 
    The GADT type ['a layout] represents one of the two supported
    memory layouts: C-style or Fortran-style. Its constructors are

--- a/stdlib/bigarray.mli
+++ b/stdlib/bigarray.mli
@@ -210,7 +210,7 @@ val kind_size_in_bytes : ('a, 'b) kind -> int
 (** {1 Array layouts} *)
 
 type c_layout = C_layout_typ (**)
-(** See {!Bigarray.fortran_layout}.*)
+(** See {!Bigarray.type-fortran_layout}.*)
 
 type fortran_layout = Fortran_layout_typ (**)
 (** To facilitate interoperability with existing C and Fortran code,
@@ -233,7 +233,7 @@ type fortran_layout = Fortran_layout_typ (**)
    and [(x+1, y)] are adjacent in memory.
 
    Each layout style is identified at the type level by the
-   phantom types {!Bigarray.c_layout} and {!Bigarray.fortran_layout}
+   phantom types {!Bigarray.type-c_layout} and {!Bigarray.type-fortran_layout}
    respectively. *)
 
 (** {2 Supported layouts}

--- a/stdlib/bigarray.mli
+++ b/stdlib/bigarray.mli
@@ -210,7 +210,7 @@ val kind_size_in_bytes : ('a, 'b) kind -> int
 (** {1 Array layouts} *)
 
 type c_layout = C_layout_typ (**)
-(** See {!Bigarray.type-fortran_layout}.*)
+(** See {!type:Bigarray.fortran_layout}.*)
 
 type fortran_layout = Fortran_layout_typ (**)
 (** To facilitate interoperability with existing C and Fortran code,
@@ -233,7 +233,7 @@ type fortran_layout = Fortran_layout_typ (**)
    and [(x+1, y)] are adjacent in memory.
 
    Each layout style is identified at the type level by the
-   phantom types {!Bigarray.type-c_layout} and {!Bigarray.type-fortran_layout}
+   phantom types {!type:Bigarray.c_layout} and {!type:Bigarray.fortran_layout}
    respectively. *)
 
 (** {2 Supported layouts}

--- a/stdlib/bigarray.mli
+++ b/stdlib/bigarray.mli
@@ -971,7 +971,8 @@ end
 external genarray_of_array0 :
   ('a, 'b, 'c) Array0.t -> ('a, 'b, 'c) Genarray.t = "%identity"
 (** Return the generic Bigarray corresponding to the given zero-dimensional
-   Bigarray. @since 4.05.0 *)
+    Bigarray.
+    @since 4.05.0 *)
 
 external genarray_of_array1 :
   ('a, 'b, 'c) Array1.t -> ('a, 'b, 'c) Genarray.t = "%identity"

--- a/stdlib/bytes.mli
+++ b/stdlib/bytes.mli
@@ -562,13 +562,14 @@ val is_valid_utf_16le : t -> bool
 
     8-bit and 16-bit integers are represented by the [int] type,
     which has more bits than the binary encoding.  These extra bits
-    are handled as follows: {ul
+    are handled as follows:
+    {ul
     {- Functions that decode signed (resp. unsigned) 8-bit or 16-bit
-    integers represented by [int] values sign-extend
-    (resp. zero-extend) their result.}
+       integers represented by [int] values sign-extend
+       (resp. zero-extend) their result.}
     {- Functions that encode 8-bit or 16-bit integers represented by
-    [int] values truncate their input to their least significant
-    bytes.}}
+       [int] values truncate their input to their least significant
+       bytes.}}
 *)
 
 val get_uint8 : bytes -> int -> int

--- a/stdlib/bytesLabels.mli
+++ b/stdlib/bytesLabels.mli
@@ -562,13 +562,14 @@ val is_valid_utf_16le : t -> bool
 
     8-bit and 16-bit integers are represented by the [int] type,
     which has more bits than the binary encoding.  These extra bits
-    are handled as follows: {ul
+    are handled as follows:
+    {ul
     {- Functions that decode signed (resp. unsigned) 8-bit or 16-bit
-    integers represented by [int] values sign-extend
-    (resp. zero-extend) their result.}
+       integers represented by [int] values sign-extend
+       (resp. zero-extend) their result.}
     {- Functions that encode 8-bit or 16-bit integers represented by
-    [int] values truncate their input to their least significant
-    bytes.}}
+       [int] values truncate their input to their least significant
+       bytes.}}
 *)
 
 val get_uint8 : bytes -> int -> int

--- a/stdlib/expand_module_aliases.awk
+++ b/stdlib/expand_module_aliases.awk
@@ -23,7 +23,7 @@ NR == 1 { printf ("# 1 \"%s\"\n", FILENAME) }
   else if (state==1)
     state=2;
   else if ($1 == "module")
-  { if (ocamldoc!="true") printf("\n(** @canonical %s *)", $2);
+  { if (ocamldoc!="true") printf("\n(** @canonical Stdlib.%s *)", $2);
     printf("\nmodule %s = Stdlib__%s\n", $2, $4);
   }
   else

--- a/stdlib/filename.mli
+++ b/stdlib/filename.mli
@@ -23,7 +23,9 @@ val parent_dir_name : string
    (e.g. [..] in Unix). *)
 
 val dir_sep : string
-(** The directory separator (e.g. [/] in Unix). @since 3.11.2 *)
+(** The directory separator (e.g. [/] in Unix).
+
+    @since 3.11.2 *)
 
 val concat : string -> string -> string
 (** [concat dir file] returns a file name that designates file

--- a/stdlib/format.mli
+++ b/stdlib/format.mli
@@ -332,7 +332,7 @@ val pp_print_custom_break :
 
    The custom break is useful if you want to change which visible
    (non-whitespace) characters are printed in case of break or no break. For
-   example, when printing a list {[ [a; b; c] ]}, you might want to add a
+   example, when printing a list [ [a; b; c] ], you might want to add a
    trailing semicolon when it is printed vertically:
 
    {[
@@ -1028,10 +1028,12 @@ val make_formatter :
 (** [make_formatter out flush] returns a new formatter that outputs with
   function [out], and flushes with function [flush].
 
-  For instance, {[
+  For instance,
+  {[
     make_formatter
       (Stdlib.output oc)
-      (fun () -> Stdlib.flush oc) ]}
+      (fun () -> Stdlib.flush oc)
+  ]}
   returns a formatter to the {!Stdlib.out_channel} [oc].
 *)
 

--- a/stdlib/gc.mli
+++ b/stdlib/gc.mli
@@ -374,7 +374,7 @@ val finalise : ('a -> unit) -> 'a -> unit
 
 
    The results of calling {!String.make}, {!Bytes.make}, {!Bytes.create},
-   {!Array.make}, and {!Stdlib.ref} are guaranteed to be
+   {!Array.make}, and {!Stdlib.val-ref} are guaranteed to be
    heap-allocated and non-constant except when the length argument is [0].
 *)
 

--- a/stdlib/gc.mli
+++ b/stdlib/gc.mli
@@ -374,7 +374,7 @@ val finalise : ('a -> unit) -> 'a -> unit
 
 
    The results of calling {!String.make}, {!Bytes.make}, {!Bytes.create},
-   {!Array.make}, and {!Stdlib.val-ref} are guaranteed to be
+   {!Array.make}, and {!val:Stdlib.ref} are guaranteed to be
    heap-allocated and non-constant except when the length argument is [0].
 *)
 

--- a/stdlib/gc.mli
+++ b/stdlib/gc.mli
@@ -85,11 +85,13 @@ type stat =
     (** Maximum size reached by the major heap, in words. *)
 
     stack_size: int;
-    (** Current size of the stack, in words. @since 3.12.0 *)
+    (** Current size of the stack, in words.
+        @since 3.12.0 *)
 
     forced_major_collections: int;
     (** Number of forced full major collections completed since the program
-        was started. @since 4.12.0 *)
+        was started.
+        @since 4.12.0 *)
 }
 (** The memory management counters are returned in a [stat] record. These
    counters give values for the whole program.
@@ -195,7 +197,8 @@ type control =
     (** The size of the window used by the major GC for smoothing
         out variations in its workload. This is an integer between
         1 and 50.
-        Default: 1. @since 4.03.0 *)
+        Default: 1.
+        @since 4.03.0 *)
 
     custom_major_ratio : int;
     (** Target ratio of floating garbage to major heap size for

--- a/stdlib/hashtbl.mli
+++ b/stdlib/hashtbl.mli
@@ -400,8 +400,8 @@ module type SeededHashedType =
       (** A seeded hashing function on keys.  The first argument is
           the seed.  It must be the case that if [equal x y] is true,
           then [hash seed x = hash seed y] for any value of [seed].
-          A suitable choice for [hash] is the function {!seeded_hash}
-          below. *)
+          A suitable choice for [hash] is the function
+          {!Stdlib.Hashtbl.seeded_hash} below. *)
   end
 (** The input signature of the functor {!MakeSeeded}.
     @since 4.00.0 *)

--- a/stdlib/lexing.mli
+++ b/stdlib/lexing.mli
@@ -187,8 +187,6 @@ val flush_input : lexbuf -> unit
 
 (**/**)
 
-(** {1  } *)
-
 (** The following definitions are used by the generated scanners only.
    They are not intended to be used directly by user programs. *)
 

--- a/stdlib/map.mli
+++ b/stdlib/map.mli
@@ -220,7 +220,7 @@ module type S =
     (** Return the list of all bindings of the given map.
        The returned list is sorted in increasing order of keys with respect
        to the ordering [Ord.compare], where [Ord] is the argument
-       given to {!Map.Make}.
+       given to {!Stdlib.Map.Make}.
         @since 3.12.0
      *)
 

--- a/stdlib/map.mli
+++ b/stdlib/map.mli
@@ -220,7 +220,7 @@ module type S =
     (** Return the list of all bindings of the given map.
        The returned list is sorted in increasing order of keys with respect
        to the ordering [Ord.compare], where [Ord] is the argument
-       given to {!Make}.
+       given to {!Map.Make}.
         @since 3.12.0
      *)
 
@@ -239,13 +239,13 @@ module type S =
      *)
 
     val max_binding: 'a t -> (key * 'a)
-    (** Same as {!S.min_binding}, but returns the binding with
+    (** Same as {!min_binding}, but returns the binding with
         the largest key in the given map.
         @since 3.12.0
      *)
 
     val max_binding_opt: 'a t -> (key * 'a) option
-    (** Same as {!S.min_binding_opt}, but returns the binding with
+    (** Same as {!min_binding_opt}, but returns the binding with
         the largest key in the given map.
         @since 4.05
      *)
@@ -328,7 +328,7 @@ module type S =
        with respect to the ordering over the type of the keys. *)
 
     val mapi: (key -> 'a -> 'b) -> 'a t -> 'b t
-    (** Same as {!S.map}, but the function receives as arguments both the
+    (** Same as {!map}, but the function receives as arguments both the
        key and the associated value for each binding of the map. *)
 
     (** {1 Maps and Sequences} *)

--- a/stdlib/moreLabels.mli
+++ b/stdlib/moreLabels.mli
@@ -419,8 +419,8 @@ module Hashtbl : sig
         (** A seeded hashing function on keys.  The first argument is
             the seed.  It must be the case that if [equal x y] is true,
             then [hash seed x = hash seed y] for any value of [seed].
-            A suitable choice for [hash] is the function {!seeded_hash}
-            below. *)
+            A suitable choice for [hash] is the function
+            {!Stdlib.Hashtbl.seeded_hash} below. *)
     end
   (** The input signature of the functor {!MakeSeeded}.
       @since 4.00.0 *)
@@ -735,7 +735,7 @@ module Map : sig
       (** Return the list of all bindings of the given map.
          The returned list is sorted in increasing order of keys with respect
          to the ordering [Ord.compare], where [Ord] is the argument
-         given to {!Map.Make}.
+         given to {!Stdlib.Map.Make}.
           @since 3.12.0
        *)
 
@@ -1050,7 +1050,7 @@ module Set : sig
       (** Return the list of all elements of the given set.
          The returned list is sorted in increasing order with respect
          to the ordering [Ord.compare], where [Ord] is the argument
-         given to {!Set.Make}. *)
+         given to {!Stdlib.Set.Make}. *)
 
       val min_elt: t -> elt
       (** Return the smallest element of the given set

--- a/stdlib/moreLabels.mli
+++ b/stdlib/moreLabels.mli
@@ -735,7 +735,7 @@ module Map : sig
       (** Return the list of all bindings of the given map.
          The returned list is sorted in increasing order of keys with respect
          to the ordering [Ord.compare], where [Ord] is the argument
-         given to {!Make}.
+         given to {!Map.Make}.
           @since 3.12.0
        *)
 
@@ -754,13 +754,13 @@ module Map : sig
        *)
 
       val max_binding: 'a t -> (key * 'a)
-      (** Same as {!S.min_binding}, but returns the binding with
+      (** Same as {!min_binding}, but returns the binding with
           the largest key in the given map.
           @since 3.12.0
        *)
 
       val max_binding_opt: 'a t -> (key * 'a) option
-      (** Same as {!S.min_binding_opt}, but returns the binding with
+      (** Same as {!min_binding_opt}, but returns the binding with
           the largest key in the given map.
           @since 4.05
        *)
@@ -843,7 +843,7 @@ module Map : sig
          with respect to the ordering over the type of the keys. *)
 
       val mapi: f:(key -> 'a -> 'b) -> 'a t -> 'b t
-      (** Same as {!S.map}, but the function receives as arguments both the
+      (** Same as {!map}, but the function receives as arguments both the
          key and the associated value for each binding of the map. *)
 
       (** {1 Maps and Sequences} *)
@@ -1050,7 +1050,7 @@ module Set : sig
       (** Return the list of all elements of the given set.
          The returned list is sorted in increasing order with respect
          to the ordering [Ord.compare], where [Ord] is the argument
-         given to {!Make}. *)
+         given to {!Set.Make}. *)
 
       val min_elt: t -> elt
       (** Return the smallest element of the given set
@@ -1065,11 +1065,11 @@ module Set : sig
       *)
 
       val max_elt: t -> elt
-      (** Same as {!S.min_elt}, but returns the largest element of the
+      (** Same as {!min_elt}, but returns the largest element of the
          given set. *)
 
       val max_elt_opt: t -> elt option
-      (** Same as {!S.min_elt_opt}, but returns the largest element of the
+      (** Same as {!min_elt_opt}, but returns the largest element of the
           given set.
           @since 4.05
       *)

--- a/stdlib/obj.mli
+++ b/stdlib/obj.mli
@@ -132,40 +132,40 @@ module Ephemeron: sig
   (** return the number of keys *)
 
   val get_key: t -> int -> obj_t option
-  (** Same as {!Ephemeron.K1.get_key} *)
+  (** Same as {!Stdlib.Ephemeron.K1.get_key} *)
 
   val get_key_copy: t -> int -> obj_t option
-  (** Same as {!Ephemeron.K1.get_key_copy} *)
+  (** Same as {!Stdlib.Ephemeron.K1.get_key_copy} *)
 
   val set_key: t -> int -> obj_t -> unit
-  (** Same as {!Ephemeron.K1.set_key} *)
+  (** Same as {!Stdlib.Ephemeron.K1.set_key} *)
 
   val unset_key: t -> int -> unit
-  (** Same as {!Ephemeron.K1.unset_key} *)
+  (** Same as {!Stdlib.Ephemeron.K1.unset_key} *)
 
   val check_key: t -> int -> bool
-  (** Same as {!Ephemeron.K1.check_key} *)
+  (** Same as {!Stdlib.Ephemeron.K1.check_key} *)
 
   val blit_key : t -> int -> t -> int -> int -> unit
-  (** Same as {!Ephemeron.K1.blit_key} *)
+  (** Same as {!Stdlib.Ephemeron.K1.blit_key} *)
 
   val get_data: t -> obj_t option
-  (** Same as {!Ephemeron.K1.get_data} *)
+  (** Same as {!Stdlib.Ephemeron.K1.get_data} *)
 
   val get_data_copy: t -> obj_t option
-  (** Same as {!Ephemeron.K1.get_data_copy} *)
+  (** Same as {!Stdlib.Ephemeron.K1.get_data_copy} *)
 
   val set_data: t -> obj_t -> unit
-  (** Same as {!Ephemeron.K1.set_data} *)
+  (** Same as {!Stdlib.Ephemeron.K1.set_data} *)
 
   val unset_data: t -> unit
-  (** Same as {!Ephemeron.K1.unset_data} *)
+  (** Same as {!Stdlib.Ephemeron.K1.unset_data} *)
 
   val check_data: t -> bool
-  (** Same as {!Ephemeron.K1.check_data} *)
+  (** Same as {!Stdlib.Ephemeron.K1.check_data} *)
 
   val blit_data : t -> t -> unit
-  (** Same as {!Ephemeron.K1.blit_data} *)
+  (** Same as {!Stdlib.Ephemeron.K1.blit_data} *)
 
   val max_ephe_length: int
   (** Maximum length of an ephemeron, ie the maximum number of keys an

--- a/stdlib/obj.mli
+++ b/stdlib/obj.mli
@@ -36,7 +36,7 @@ external reachable_words : t -> int = "caml_obj_reachable_words"
      allocated blocks are excluded, unless the runtime system
      was configured with [--disable-naked-pointers].
 
-     @Since 4.04
+     @since 4.04
   *)
 
 external field : t -> int -> t = "%obj_field"

--- a/stdlib/option.mli
+++ b/stdlib/option.mli
@@ -34,7 +34,9 @@ val value : 'a option -> default:'a -> 'a
 (** [value o ~default] is [v] if [o] is [Some v] and [default] otherwise. *)
 
 val get : 'a option -> 'a
-(** [get o] is [v] if [o] is [Some v] and @raise Invalid_argument otherwise. *)
+(** [get o] is [v] if [o] is [Some v] and raise otherwise.
+
+    @raise Invalid_argument if [o] is [None]. *)
 
 val bind : 'a option -> ('a -> 'b option) -> 'b option
 (** [bind o f] is [f v] if [o] is [Some v] and [None] if [o] is [None]. *)

--- a/stdlib/parsing.mli
+++ b/stdlib/parsing.mli
@@ -71,8 +71,6 @@ val set_trace: bool -> bool
 
 (**/**)
 
-(** {1  } *)
-
 (** The following definitions are used by the generated parsers only.
    They are not intended to be used directly by user programs. *)
 

--- a/stdlib/result.mli
+++ b/stdlib/result.mli
@@ -35,12 +35,14 @@ val value : ('a, 'e) result -> default:'a -> 'a
 (** [value r ~default] is [v] if [r] is [Ok v] and [default] otherwise. *)
 
 val get_ok : ('a, 'e) result -> 'a
-(** [get_ok r] is [v] if [r] is [Ok v] and @raise Invalid_argument
-    otherwise. *)
+(** [get_ok r] is [v] if [r] is [Ok v] and raise otherwise.
+
+    @raise Invalid_argument if [r] is [Error _]. *)
 
 val get_error : ('a, 'e) result -> 'e
-(** [get_error r] is [e] if [r] is [Error e] and @raise Invalid_argument
-    otherwise. *)
+(** [get_error r] is [e] if [r] is [Error e] and raise otherwise.
+
+    @raise Invalid_argument if [r] is [Ok _]. *)
 
 val bind : ('a, 'e) result -> ('a -> ('b, 'e) result) -> ('b, 'e) result
 (** [bind r f] is [f v] if [r] is [Ok v] and [r] if [r] is [Error _]. *)

--- a/stdlib/scanf.mli
+++ b/stdlib/scanf.mli
@@ -296,7 +296,8 @@ val bscanf : Scanning.in_channel -> ('a, 'b, 'c, 'd) scanner
     - [x] or [X]: reads an unsigned hexadecimal integer ([[0-9a-fA-F]+]).
     - [o]: reads an unsigned octal integer ([[0-7]+]).
     - [s]: reads a string argument that spreads as much as possible, until the
-      following bounding condition holds: {ul
+      following bounding condition holds:
+      {ul
       {- a whitespace has been found (see {!Scanf.space}),}
       {- a scanning indication (see scanning {!Scanf.indication}) has been
          encountered,}

--- a/stdlib/set.mli
+++ b/stdlib/set.mli
@@ -186,7 +186,7 @@ module type S =
     (** Return the list of all elements of the given set.
        The returned list is sorted in increasing order with respect
        to the ordering [Ord.compare], where [Ord] is the argument
-       given to {!Make}. *)
+       given to {!Set.Make}. *)
 
     val min_elt: t -> elt
     (** Return the smallest element of the given set
@@ -201,11 +201,11 @@ module type S =
     *)
 
     val max_elt: t -> elt
-    (** Same as {!S.min_elt}, but returns the largest element of the
+    (** Same as {!min_elt}, but returns the largest element of the
        given set. *)
 
     val max_elt_opt: t -> elt option
-    (** Same as {!S.min_elt_opt}, but returns the largest element of the
+    (** Same as {!min_elt_opt}, but returns the largest element of the
         given set.
         @since 4.05
     *)

--- a/stdlib/set.mli
+++ b/stdlib/set.mli
@@ -186,7 +186,7 @@ module type S =
     (** Return the list of all elements of the given set.
        The returned list is sorted in increasing order with respect
        to the ordering [Ord.compare], where [Ord] is the argument
-       given to {!Set.Make}. *)
+       given to {!Stdlib.Set.Make}. *)
 
     val min_elt: t -> elt
     (** Return the smallest element of the given set

--- a/stdlib/stdlib.mli
+++ b/stdlib/stdlib.mli
@@ -1278,7 +1278,7 @@ type ('a,'b) result = Ok of 'a | Error of 'b
       For [printf]-style functions from module {!Printf}, ['b] is typically
       [out_channel];
       for [printf]-style functions from module {!Format}, ['b] is typically
-      {!Format.formatter};
+      {!Format.type-formatter};
       for [scanf]-style functions from module {!Scanf}, ['b] is typically
       {!Scanf.Scanning.in_channel}.
 

--- a/stdlib/stdlib.mli
+++ b/stdlib/stdlib.mli
@@ -1278,7 +1278,7 @@ type ('a,'b) result = Ok of 'a | Error of 'b
       For [printf]-style functions from module {!Printf}, ['b] is typically
       [out_channel];
       for [printf]-style functions from module {!Format}, ['b] is typically
-      {!Format.type-formatter};
+      {!type:Format.formatter};
       for [scanf]-style functions from module {!Scanf}, ['b] is typically
       {!Scanf.Scanning.in_channel}.
 

--- a/stdlib/templates/hashtbl.template.mli
+++ b/stdlib/templates/hashtbl.template.mli
@@ -400,8 +400,8 @@ module type SeededHashedType =
       (** A seeded hashing function on keys.  The first argument is
           the seed.  It must be the case that if [equal x y] is true,
           then [hash seed x = hash seed y] for any value of [seed].
-          A suitable choice for [hash] is the function {!seeded_hash}
-          below. *)
+          A suitable choice for [hash] is the function
+          {!Stdlib.Hashtbl.seeded_hash} below. *)
   end
 (** The input signature of the functor {!MakeSeeded}.
     @since 4.00.0 *)

--- a/stdlib/templates/map.template.mli
+++ b/stdlib/templates/map.template.mli
@@ -220,7 +220,7 @@ module type S =
     (** Return the list of all bindings of the given map.
        The returned list is sorted in increasing order of keys with respect
        to the ordering [Ord.compare], where [Ord] is the argument
-       given to {!Map.Make}.
+       given to {!Stdlib.Map.Make}.
         @since 3.12.0
      *)
 

--- a/stdlib/templates/map.template.mli
+++ b/stdlib/templates/map.template.mli
@@ -220,7 +220,7 @@ module type S =
     (** Return the list of all bindings of the given map.
        The returned list is sorted in increasing order of keys with respect
        to the ordering [Ord.compare], where [Ord] is the argument
-       given to {!Make}.
+       given to {!Map.Make}.
         @since 3.12.0
      *)
 
@@ -239,13 +239,13 @@ module type S =
      *)
 
     val max_binding: 'a t -> (key * 'a)
-    (** Same as {!S.min_binding}, but returns the binding with
+    (** Same as {!min_binding}, but returns the binding with
         the largest key in the given map.
         @since 3.12.0
      *)
 
     val max_binding_opt: 'a t -> (key * 'a) option
-    (** Same as {!S.min_binding_opt}, but returns the binding with
+    (** Same as {!min_binding_opt}, but returns the binding with
         the largest key in the given map.
         @since 4.05
      *)
@@ -328,7 +328,7 @@ module type S =
        with respect to the ordering over the type of the keys. *)
 
     val mapi: f:(key -> 'a -> 'b) -> 'a t -> 'b t
-    (** Same as {!S.map}, but the function receives as arguments both the
+    (** Same as {!map}, but the function receives as arguments both the
        key and the associated value for each binding of the map. *)
 
     (** {1 Maps and Sequences} *)

--- a/stdlib/templates/set.template.mli
+++ b/stdlib/templates/set.template.mli
@@ -186,7 +186,7 @@ module type S =
     (** Return the list of all elements of the given set.
        The returned list is sorted in increasing order with respect
        to the ordering [Ord.compare], where [Ord] is the argument
-       given to {!Make}. *)
+       given to {!Set.Make}. *)
 
     val min_elt: t -> elt
     (** Return the smallest element of the given set
@@ -201,11 +201,11 @@ module type S =
     *)
 
     val max_elt: t -> elt
-    (** Same as {!S.min_elt}, but returns the largest element of the
+    (** Same as {!min_elt}, but returns the largest element of the
        given set. *)
 
     val max_elt_opt: t -> elt option
-    (** Same as {!S.min_elt_opt}, but returns the largest element of the
+    (** Same as {!min_elt_opt}, but returns the largest element of the
         given set.
         @since 4.05
     *)

--- a/stdlib/templates/set.template.mli
+++ b/stdlib/templates/set.template.mli
@@ -186,7 +186,7 @@ module type S =
     (** Return the list of all elements of the given set.
        The returned list is sorted in increasing order with respect
        to the ordering [Ord.compare], where [Ord] is the argument
-       given to {!Set.Make}. *)
+       given to {!Stdlib.Set.Make}. *)
 
     val min_elt: t -> elt
     (** Return the smallest element of the given set

--- a/utils/diffing.mli
+++ b/utils/diffing.mli
@@ -1,4 +1,3 @@
-
 (**************************************************************************)
 (*                                                                        *)
 (*                                 OCaml                                  *)
@@ -14,7 +13,7 @@
 (*                                                                        *)
 (**************************************************************************)
 
-(** {1 Parametric diffing}
+(** Parametric diffing
 
     This module implements diffing over lists of arbitrary content.
     It is parameterized by

--- a/utils/diffing.mli
+++ b/utils/diffing.mli
@@ -14,7 +14,7 @@
 (*                                                                        *)
 (**************************************************************************)
 
-(** {0 Parametric diffing}
+(** {1 Parametric diffing}
 
     This module implements diffing over lists of arbitrary content.
     It is parameterized by

--- a/utils/local_store.mli
+++ b/utils/local_store.mli
@@ -23,7 +23,7 @@
 (** {1 Creators} *)
 
 val s_ref : 'a -> 'a ref
-(** Similar to {!val-ref}, except the allocated reference is registered into
+(** Similar to {!val:ref}, except the allocated reference is registered into
     the store. *)
 
 val s_table : ('a -> 'b) -> 'a -> 'b ref

--- a/utils/local_store.mli
+++ b/utils/local_store.mli
@@ -62,5 +62,5 @@ val reset : unit -> unit
     that new instances start with). *)
 
 val is_bound : unit -> bool
-(** Returns [true] when a scope is active (i.e. when called from the callback
+(** Returns [true] when a store is active (i.e. when called from the callback
     passed to {!with_store}), [false] otherwise. *)

--- a/utils/local_store.mli
+++ b/utils/local_store.mli
@@ -23,8 +23,8 @@
 (** {1 Creators} *)
 
 val s_ref : 'a -> 'a ref
-(** Similar to {!ref}, except the allocated reference is registered into the
-    store. *)
+(** Similar to {!val-ref}, except the allocated reference is registered into
+    the store. *)
 
 val s_table : ('a -> 'b) -> 'a -> 'b ref
 (** Used to register hash tables. Those also need to be placed into refs to be
@@ -52,7 +52,7 @@ val fresh : unit -> store
     initialized to those values. *)
 
 val with_store : store -> (unit -> 'a) -> 'a
-(** [with_scope s f] resets all the registered references to the value they have
+(** [with_store s f] resets all the registered references to the value they have
     in [s] for the run of [f].
     If [f] updates any of the registered refs, [s] is updated to remember those
     changes. *)
@@ -63,4 +63,4 @@ val reset : unit -> unit
 
 val is_bound : unit -> bool
 (** Returns [true] when a scope is active (i.e. when called from the callback
-    passed to {!with_scope}), [false] otherwise. *)
+    passed to {!with_store}), [false] otherwise. *)

--- a/utils/misc.mli
+++ b/utils/misc.mli
@@ -157,7 +157,7 @@ module Stdlib : sig
        different lengths. *)
 
     val for_alli : (int -> 'a -> bool) -> 'a array -> bool
-    (** Same as {!Array.for_all}, but the
+    (** Same as {!Stdlib.Array.for_all}, but the
         function is applied with the index of the element as first argument,
         and the element itself as second argument. *)
 

--- a/utils/misc.mli
+++ b/utils/misc.mli
@@ -152,12 +152,10 @@ module Stdlib : sig
 
   module Array : sig
     val exists2 : ('a -> 'b -> bool) -> 'a array -> 'b array -> bool
-    (* Same as [Array.exists], but for a two-argument predicate. Raise
-       Invalid_argument if the two arrays are determined to have
-       different lengths. *)
+    (** Same as [Array.exists2] from the standard library. *)
 
     val for_alli : (int -> 'a -> bool) -> 'a array -> bool
-    (** Same as {!Stdlib.Array.for_all}, but the
+    (** Same as [Array.for_all] from the standard library, but the
         function is applied with the index of the element as first argument,
         and the element itself as second argument. *)
 


### PR DESCRIPTION
Fixes the syntax errors reported by Odoc 2.0.2, make sure references resolve and a few other tweaks.

Odoc 2.0.2 report no warnings now :)