### PR TITLE
Preserve integer literal formatting in type hint

### DIFF
--- a/Changes
+++ b/Changes
@@ -34,6 +34,9 @@ Working version
 
 ### Compiler user-interface and warnings:
 
+- #10818: Preserve integer literal formatting in type hint.
+  (Leonhard Markert, review by Gabriel Scherer and Florian Angeletti)
+
 - #11338: Turn some partial application warnings into hints.
   (Leo White, review by Stephen Dolan)
 

--- a/testsuite/tests/typing-core-bugs/const_int_hint.ml
+++ b/testsuite/tests/typing-core-bugs/const_int_hint.ml
@@ -144,3 +144,56 @@ Line 1, characters 14-16:
 Error: This expression has type int64 but an expression was expected of type
          int
 |}]
+
+(* Check that the hint preserves formatting of int, int32, int64 and nativeint
+   literals in decimal, hexadecimal, octal and binary notation *)
+let _ : int64 = min 0L 1_000;;
+[%%expect{|
+Line 1, characters 23-28:
+1 | let _ : int64 = min 0L 1_000;;
+                           ^^^^^
+Error: This expression has type int but an expression was expected of type
+         int64
+  Hint: Did you mean `1_000L'?
+|}]
+let _ : nativeint * nativeint = 0n, 0xAA_BBL;;
+[%%expect{|
+Line 1, characters 36-44:
+1 | let _ : nativeint * nativeint = 0n, 0xAA_BBL;;
+                                        ^^^^^^^^
+Error: This expression has type int64 but an expression was expected of type
+         nativeint
+  Hint: Did you mean `0xAA_BBn'?
+|}]
+let _ : int32 -> int32 = function
+  | 1l | 0o2_345 -> 3l
+  | x -> x;;
+[%%expect{|
+Line 2, characters 9-16:
+2 |   | 1l | 0o2_345 -> 3l
+             ^^^^^^^
+Error: This pattern matches values of type int
+       but a pattern was expected which matches values of type int32
+  Hint: Did you mean `0o2_345l'?
+|}]
+let _ : int32 -> int32 = fun x -> match x with
+  | 1l | 0b1000_1101 -> 3l
+  | x -> x;;
+[%%expect{|
+Line 2, characters 9-20:
+2 |   | 1l | 0b1000_1101 -> 3l
+             ^^^^^^^^^^^
+Error: This pattern matches values of type int
+       but a pattern was expected which matches values of type int32
+  Hint: Did you mean `0b1000_1101l'?
+|}]
+type t1 = {f1: int32};; let _ = fun x -> x.f1 <- 1_000n;;
+[%%expect{|
+type t1 = { f1 : int32; }
+Line 1, characters 49-55:
+1 | type t1 = {f1: int32};; let _ = fun x -> x.f1 <- 1_000n;;
+                                                     ^^^^^^
+Error: This expression has type nativeint
+       but an expression was expected of type int32
+  Hint: Did you mean `1_000l'?
+|}]

--- a/typing/typecore.mli
+++ b/typing/typecore.mli
@@ -146,14 +146,14 @@ type error =
   | Constructor_arity_mismatch of Longident.t * int * int
   | Label_mismatch of Longident.t * Errortrace.unification_error
   | Pattern_type_clash :
-      Errortrace.unification_error * _ Typedtree.pattern_desc option
+      Errortrace.unification_error * Parsetree.pattern_desc option
       -> error
   | Or_pattern_type_clash of Ident.t * Errortrace.unification_error
   | Multiply_bound_variable of string
   | Orpat_vars of Ident.t * Ident.t list
   | Expr_type_clash of
       Errortrace.unification_error * type_forcing_context option
-      * Typedtree.expression_desc option
+      * Parsetree.expression_desc option
   | Apply_non_function of type_expr
   | Apply_wrong_label of arg_label * type_expr * bool
   | Label_multiply_defined of string


### PR DESCRIPTION
Closes https://github.com/ocaml/ocaml/issues/10766, implementing "Proposal 1".

This is a more localised implementation than the implementation proposed in #10767, which changes `Asttype.constant`. It is based on [this comment](https://github.com/ocaml/ocaml/pull/10767#issuecomment-987948616).

# User-visible changes

The goal of this PR is to preserve the original formatting of integer literals (`int32`, `int64` and `nativeint`) in the "Did you mean ...?" hint.

**Before**
```
    1 | let _ = Int64.add 0xAA_BBl 2L;;
                          ^^^^^^^^
    Error: This expression has type int32 but an expression was expected of type
             int64
      Hint: Did you mean `43707L'?
```

**After**
```
    1 | let _ = Int64.add 0xAA_BBl 2L;;
                          ^^^^^^^^
    Error: This expression has type int32 but an expression was expected of type
             int64
      Hint: Did you mean `0xAA_BBL'?
```

# API changes

In `Typecore.error`:
- `Pattern_type_clash` contains an optional `Parsetree.pattern_desc` instead of `Typetree.pattern_desc`
- `Expr_type_clash` contains an optional `Parsetree.expression_desc` instead of `Typetree.expression_desc`

In both cases, the description was and is only used to output the type hint. The difference is that the `Parsetree` descriptions contain the original formatting of the integer literal, but the `Typetree` descriptions do not. Using the `Parsetree` descriptions instead of the `Typetree` descriptions allows us to output the integer literals with their original formatting in the type hint.