### PR TITLE
relocation issues with clang on 32bit FreeBSD

### DIFF
--- a/Changes
+++ b/Changes
@@ -377,6 +377,11 @@ OCaml 4.14.0
 
 ### Build system:
 
+- #10835 Disable DT_TEXTREL warnings on x86 32 bit architecture by passing
+  -Wl,-z,notext in mksharedlib and mkmaindll. Fixes relocation issues, reported
+  in #9800, making local patches in Debian, Alpine, and FreeBSD superfluous.
+  (Hannes Mehnert with Kate Deplaix and Stéphane Glondu, review by Xavier Leroy)
+
 - #10717: Simplify the installation of man pages
   (Sébastien Hinderer, review by David Allsopp)
 

--- a/configure
+++ b/configure
@@ -14542,6 +14542,17 @@ case $arch in #(
 esac ;;
 esac
 
+# Disable DT_TEXTREL warnings on Linux and BSD i386
+# See https://github.com/ocaml/ocaml/issues/9800
+
+case "$system" in #(
+  linux_elf|bsd_elf) :
+    mksharedlib="$mksharedlib -Wl,-z,notext"
+    mkmaindll="$mkmaindll -Wl,-z,notext" ;; #(
+  *) :
+     ;;
+esac
+
 # Assembler
 
 if test -n "$target_alias"; then :

--- a/configure
+++ b/configure
@@ -14542,17 +14542,6 @@ case $arch in #(
 esac ;;
 esac
 
-# Disable DT_TEXTREL warnings on Linux and BSD i386
-# See https://github.com/ocaml/ocaml/issues/9800
-
-case "$system" in #(
-  linux_elf|bsd_elf) :
-    mksharedlib="$mksharedlib -Wl,-z,notext"
-    mkmaindll="$mkmaindll -Wl,-z,notext" ;; #(
-  *) :
-     ;;
-esac
-
 # Assembler
 
 if test -n "$target_alias"; then :

--- a/configure
+++ b/configure
@@ -14100,6 +14100,10 @@ esac ;; #(
        case $cc_basename,$host in #(
   *gcc*,powerpc-*-linux*) :
     mksharedlib="$CC -shared -mbss-plt \$(LDFLAGS)" ;; #(
+  *,i[3456]86-*) :
+    # Disable DT_TEXTREL warnings on Linux and BSD i386
+           # See https://github.com/ocaml/ocaml/issues/9800
+           mksharedlib="$CC -shared \$(LDFLAGS) -Wl,-z,notext" ;; #(
   *) :
     mksharedlib="$CC -shared \$(LDFLAGS)" ;;
 esac

--- a/configure.ac
+++ b/configure.ac
@@ -983,6 +983,10 @@ AS_IF([test x"$enable_shared" != "xno"],
        AS_CASE([$cc_basename,$host],
            [*gcc*,powerpc-*-linux*],
            [mksharedlib="$CC -shared -mbss-plt \$(LDFLAGS)"],
+           [[*,i[3456]86-*]],
+           # Disable DT_TEXTREL warnings on Linux and BSD i386
+           # See https://github.com/ocaml/ocaml/issues/9800
+           [mksharedlib="$CC -shared \$(LDFLAGS) -Wl,-z,notext"],
            [mksharedlib="$CC -shared \$(LDFLAGS)"])
       oc_ldflags="$oc_ldflags -Wl,-E"
       rpath="-Wl,-rpath,"

--- a/configure.ac
+++ b/configure.ac
@@ -1196,15 +1196,6 @@ AS_CASE([$arch],
        [common_cflags="-no-pie $common_cflags"],
     [])])
 
-# Disable DT_TEXTREL warnings on Linux and BSD i386
-# See https://github.com/ocaml/ocaml/issues/9800
-
-AS_CASE(["$system"],
-  [linux_elf|bsd_elf],
-    [mksharedlib="$mksharedlib -Wl,-z,notext"
-    mkmaindll="$mkmaindll -Wl,-z,notext"],
-  [])
-
 # Assembler
 
 AS_IF([test -n "$target_alias"],

--- a/configure.ac
+++ b/configure.ac
@@ -1196,6 +1196,15 @@ AS_CASE([$arch],
        [common_cflags="-no-pie $common_cflags"],
     [])])
 
+# Disable DT_TEXTREL warnings on Linux and BSD i386
+# See https://github.com/ocaml/ocaml/issues/9800
+
+AS_CASE(["$system"],
+  [linux_elf|bsd_elf],
+    [mksharedlib="$mksharedlib -Wl,-z,notext"
+    mkmaindll="$mkmaindll -Wl,-z,notext"],
+  [])
+
 # Assembler
 
 AS_IF([test -n "$target_alias"],


### PR DESCRIPTION
Hi,

the issue observed are relocation issues on a 32bit x86 system running FreeBSD 13:

```
cc -c -O2 -fno-strict-aliasing -fwrapv -Wall -Wdeclaration-after-statement -fno-common -ffunction-sections -g -fPIC  -D_FILE_OFFSET_BITS=64 -D_REENTRANT -DCAML_NAME_SPACE   -DCAMLDLLIMPORT= -DNATIVE_CODE -DTARGET_i386 -DMODEL_default -DSYS_bsd_elf   -o domain.npic.o domain.c
cc -c -O2 -fno-strict-aliasing -fwrapv -Wall -Wdeclaration-after-statement -fno-common -ffunction-sections -g -fPIC  -D_FILE_OFFSET_BITS=64 -D_REENTRANT -DCAML_NAME_SPACE   -DCAMLDLLIMPORT= -DNATIVE_CODE -DTARGET_i386 -DMODEL_default -DSYS_bsd_elf   -o skiplist.npic.o skiplist.c
cc -c -O2 -fno-strict-aliasing -fwrapv -Wall -Wdeclaration-after-statement -fno-common -ffunction-sections -g -fPIC  -D_FILE_OFFSET_BITS=64 -D_REENTRANT -DCAML_NAME_SPACE   -DCAMLDLLIMPORT= -DNATIVE_CODE -DTARGET_i386 -DMODEL_default -DSYS_bsd_elf   -o codefrag.npic.o codefrag.c
clang -c -Wno-trigraphs -DSYS_bsd_elf -I../runtime -DMODEL_default -fPIC -o i386_libasmrunpic.o i386.S
rm -f libasmrun_pic.a && ar rc libasmrun_pic.a  startup_aux.npic.o startup_nat.npic.o main.npic.o fail_nat.npic.o roots_nat.npic.o signals.npic.o signals_nat.npic.o misc.npic.o freelist.npic.o major_gc.npic.o minor_gc.npic.o memory.npic.o alloc.npic.o compare.npic.o ints.npic.o floats.npic.o str.npic.o array.npic.o io.npic.o extern.npic.o intern.npic.o hash.npic.o sys.npic.o parsing.npic.o gc_ctrl.npic.o eventlog.npic.o md5.npic.o obj.npic.o lexing.npic.o unix.npic.o printexc.npic.o callback.npic.o weak.npic.o compact.npic.o finalise.npic.o custom.npic.o globroots.npic.o backtrace_nat.npic.o backtrace.npic.o dynlink_nat.npic.o debugger.npic.o meta.npic.o dynlink.npic.o clambda_checks.npic.o afl.npic.o bigarray.npic.o memprof.npic.o domain.npic.o skiplist.npic.o codefrag.npic.o i386_libasmrunpic.o && ranlib libasmrun_pic.a
cc -shared -o libasmrun_shared.so startup_aux.npic.o startup_nat.npic.o main.npic.o fail_nat.npic.o roots_nat.npic.o signals.npic.o signals_nat.npic.o misc.npic.o freelist.npic.o major_gc.npic.o minor_gc.npic.o memory.npic.o alloc.npic.o compare.npic.o ints.npic.o floats.npic.o str.npic.o array.npic.o io.npic.o extern.npic.o intern.npic.o hash.npic.o sys.npic.o parsing.npic.o gc_ctrl.npic.o eventlog.npic.o md5.npic.o obj.npic.o lexing.npic.o unix.npic.o printexc.npic.o callback.npic.o weak.npic.o compact.npic.o finalise.npic.o custom.npic.o globroots.npic.o backtrace_nat.npic.o backtrace.npic.o dynlink_nat.npic.o debugger.npic.o meta.npic.o dynlink.npic.o clambda_checks.npic.o afl.npic.o bigarray.npic.o memprof.npic.o domain.npic.o skiplist.npic.o codefrag.npic.o i386_libasmrunpic.o -lm 
ld: error: can't create dynamic relocation R_386_32 against symbol: Caml_state in readonly segment; recompile object files with -fPIC or pass '-Wl,-z,notext' to allow text relocations in the output
>>> defined in domain.npic.o
>>> referenced by i386_libasmrunpic.o:(caml_call_gc)

ld: error: relocation R_386_PC32 cannot be used against symbol caml_garbage_collection; recompile with -fPIC
>>> defined in signals_nat.npic.o
>>> referenced by i386_libasmrunpic.o:(caml_call_gc)

ld: error: can't create dynamic relocation R_386_32 against symbol: Caml_state in readonly segment; recompile object files with -fPIC or pass '-Wl,-z,notext' to allow text relocations in the output
>>> defined in domain.npic.o
>>> referenced by i386_libasmrunpic.o:(caml_alloc1)
```
(full log at http://jenkins.ygy.io/job/freebsd-ports-testing-12.2R-i386/1159/consoleFull - this is a FreeBSD package built of opam 2.1.2, which includes OCaml 4.12.1)

While investigating, I discovered #9800 which is closed, but some distributions (debian, raspian, potentially others) patch configure.

I think it is worthwhile to add this patch to the mainline OCaml compiler development, and backport it to compilers that are still relevant.

configure: pass -Wl,-z,notext to the linker on 32bit Linux and BSD.

This avoids relocations issues, as explained by
@xavierleroy https://github.com/ocaml/ocaml/issues/9800#issuecomment-669058533

Patch is adapted from @glondu
https://salsa.debian.org/ocaml-team/ocaml/-/blob/2f4a827125dcf79e2b6a193de69b018379bae836/debian/patches/0006-Disable-DT_TEXTREL-warnings-on-Linux-i386.patch

In case you want to re-test this on a FreeBSD/amd64 system, there is a simple way to setup a 32bit userland (as a jail) at https://gundersen.net/32bit-jail-on-64bit-freebsd/
