### PR TITLE
fix #show regression in 4.14

### DIFF
--- a/Changes
+++ b/Changes
@@ -148,6 +148,9 @@ OCaml 4.14.0
 
 ### Tools:
 
+- #10839: Fix regression of #show when printing class type
+  (Élie Brami, review by Florian Angeletti)
+
 - #3959, #7202, #10476: ocaml, in script mode, directive errors
   (`#use "missing_file";;`) use stderr and exit with an error.
   (Florian Angeletti, review by Gabriel Scherer)

--- a/testsuite/tests/tool-toplevel/show.ml
+++ b/testsuite/tests/tool-toplevel/show.ml
@@ -5,6 +5,26 @@
 (* this is a set of tests to test the #show functionality
  * of toplevel *)
 
+class o = object val x = 0 end;;
+[%%expect{|
+class o : object val x : int end
+|}];;
+#show o;;
+[%%expect{|
+type o = <  >
+class o : object val x : int end
+class type o = object val x : int end
+|}];;
+class type t = object val x : int end;;
+[%%expect{|
+class type t = object val x : int end
+|}];;
+#show t;;
+[%%expect{|
+type t = <  >
+class type t = object val x : int end
+|}];;
+
 #show Foo;;
 [%%expect {|
 Unknown element.

--- a/toplevel/topdirs.ml
+++ b/toplevel/topdirs.ml
@@ -571,16 +571,30 @@ let () =
 let () =
   reg_show_prim "show_class"
     (fun env loc id lid ->
-       let _path, desc = Env.lookup_class ~loc lid env in
-       [ Sig_class (id, desc, Trec_not, Exported) ]
+       let path, desc_class = Env.lookup_class ~loc lid env in
+       let _path, desc_cltype = Env.lookup_cltype ~loc lid env in
+       let _path, typedcl = Env.lookup_type ~loc lid env in
+       let hash_typedcl = Env.find_hash_type path env in
+       [
+         Sig_class (id, desc_class, Trec_not, Exported);
+         Sig_class_type (id, desc_cltype, Trec_not, Exported);
+         Sig_type (id, typedcl, Trec_not, Exported);
+         Sig_type (id, hash_typedcl, Trec_not, Exported);
+       ]
     )
     "Print the signature of the corresponding class."
 
 let () =
   reg_show_prim "show_class_type"
     (fun env loc id lid ->
-       let _path, desc = Env.lookup_cltype ~loc lid env in
-       [ Sig_class_type (id, desc, Trec_not, Exported) ]
+       let path, desc = Env.lookup_cltype ~loc lid env in
+       let _path, typedcl = Env.lookup_type ~loc lid env in
+       let hash_typedcl = Env.find_hash_type path env in
+       [
+         Sig_class_type (id, desc, Trec_not, Exported);
+         Sig_type (id, typedcl, Trec_not, Exported);
+         Sig_type (id, hash_typedcl, Trec_not, Exported);
+       ]
     )
     "Print the signature of the corresponding class type."
 


### PR DESCRIPTION
system's OCaml:
```
% ocaml
        OCaml version 4.12.0

# class type t = object val x : int end;;
class type t = object val x : int end
# #show t;;
type nonrec t = <  >
class type t = object val x : int end
# class o = object val x = 0 end;;
class o : object val x : int end
# #show o;;
type nonrec o = <  >
class o : object val x : int end
class type o = object val x : int end
```

I compiled version 2a6df5eb6 current head of https://github.com/ocaml/ocaml/tree/4.14:
```
% ./runtime/ocamlrun ./ocaml -nostdlib -I stdlib
OCaml version 4.14.0+dev2-2021-10-05
Enter #help;; for help.

# class t = object val x = 0 end;;
class t : object val x : int end
# #show t;;
Fatal error: exception File "typing/signature_group.ml", line 52, characters 19-25: Assertion failed
```

After this PR:
```
% ./runtime/ocamlrun ./ocaml -nostdlib -I stdlib
OCaml version 4.14.0+dev2-2021-10-05
Enter #help;; for help.

# class type t = object val x : int end;;
class type t = object val x : int end
# #show t;;
type t = <  >
class type t = object val x : int end
# class o = object val x = 0 end;;
class o : object val x : int end
# #show o;;
type o = <  >
class o : object val x : int end
```
I think the fix wanted to hide `type o = < >` and `type t = < >` in the printing so it is not the correct patch. Can you give me pointer in this case ?