### PR TITLE
Shapes: Optionally print shape in ocamlobjinfo

### DIFF
--- a/Changes
+++ b/Changes
@@ -252,6 +252,10 @@ OCaml 4.14.0
 - #10527: Show "#help;; for help" at toplevel startup
   (Wiktor Kuchta, review by David Allsopp and Florian Angeletti)
 
+- #10846: add the `-shape` command-line option to ocamlobjinfo. When reading a
+  `cmt` file, shape information will only be shown if that option is used.
+  (Ulysse Gérard, review by Florian Angeletti)
+
 ### Debugging:
 
 - #10517, #10594: when running ocamldebug on a program linked with the

--- a/tools/objinfo.ml
+++ b/tools/objinfo.ml
@@ -28,6 +28,7 @@ open Cmo_format
 let no_approx = ref false
 let no_code = ref false
 let no_crc = ref false
+let shape = ref false
 
 module Magic_number = Misc.Magic_number
 
@@ -115,10 +116,12 @@ let print_cmt_infos cmt =
     (match cmt.cmt_interface_digest with
      | None -> ""
      | Some crc -> string_of_crc crc);
-  printf "Implementation shape: ";
+  if !shape then begin
+    printf "Implementation shape: ";
     (match cmt.cmt_impl_shape with
     | None -> printf "(none)\n"
     | Some shape -> Format.printf "\n%a" Shape.print shape)
+  end
 
 let print_general_infos name crc defines cmi cmx =
   printf "Name: %s\n" name;
@@ -387,6 +390,8 @@ let arg_list = [
     " Do not print module approximation information";
   "-no-code", Arg.Set no_code,
     " Do not print code from exported flambda functions";
+  "-shape", Arg.Set shape,
+    " Print the shape of the module";
   "-null-crc", Arg.Set no_crc, " Print a null CRC for imported interfaces";
   "-args", Arg.Expand Arg.read_arg,
      "<file> Read additional newline separated command line arguments \n\


### PR DESCRIPTION
Shapes can be very verbose when printed without sharing.
This PR adds an option `-shape` to `ocamlobjinfo` so that the shape stored in a `cmt` file is printed only when explicitly requested by the user. (This PR is independent from #10825)

@Octachron this should be backported to 4.14. Do you want me to open a PR targetting that branch ? (there should be no conflicts anyway)

~~Also, does that change requires a changelog entry ?~~ 