### PR TITLE
Fix a crash in `Obj.reachable_words`

### DIFF
--- a/Changes
+++ b/Changes
@@ -428,6 +428,10 @@ OCaml 4.14.0
   toplevel, as in the bytecode toplevel.
   (David Allsopp, report by Nathan Rebours, review by Gabriel Scherer)
 
+- #10853: `Obj.reachable_words` could crash if called after a marshaling
+  operation in `NO_SHARING` mode.
+  (Xavier Leroy, report by Anil Madhavapeddy, review by Alain Frisch)
+
 
 OCaml 4.13 maintenance branch
 -----------------------------

--- a/runtime/extern.c
+++ b/runtime/extern.c
@@ -1136,6 +1136,7 @@ CAMLprim value caml_obj_reachable_words(value v)
   uintnat pos;
 
   obj_counter = 0;
+  extern_flags = 0;
   extern_init_position_table();
   sp = extern_stack;
   size = 0;

--- a/testsuite/tests/lib-obj/reachable_words_bug.ml
+++ b/testsuite/tests/lib-obj/reachable_words_bug.ml
@@ -1,0 +1,9 @@
+(* TEST
+*)
+
+let _ =
+  (* In 4.13 this causes Obj.reachable_words to segfault
+     because of a missing initialization in caml_obj_reachable_words *)
+  ignore (Marshal.(to_string 123 [No_sharing]));
+  let n = Obj.reachable_words (Obj.repr (Array.init 10 (fun i -> i))) in
+  assert (n = 11)


### PR DESCRIPTION
This PR fixes a crash in `Obj.reachable_words` first observed in Multicore OCaml: https://github.com/ocaml-multicore/ocaml-multicore/issues/824 . 

A marshaling operation can leave `extern_flags` with the `NO_SHARING` bit set.  In this context, `caml_obj_reachable_words` calls `extern_init_position_table`, which does nothing, then proceeds to access the position table, causing a crash.
    
The solution is trivial: initialize `extern_flags` before calling `extern_init_position_table`.

A regression test was added.

This fix is against 4.14 because 5.00 will need a slightly different fix.
    
