### PR TITLE
PIC runtime for 32-bit ARM with __PIC__

### DIFF
--- a/Changes
+++ b/Changes
@@ -80,6 +80,11 @@ OCaml 4.14.0
 - #10730, 10731: Fix bug in `Obj.reachable_words` causing a slowdown when called
   multiple time (Alain Frisch, report by ygrek, review by Xavier Leroy)
 
+- #10860: Create position independent code for ARM32 runtime when compiler flag
+  __PIC__ is defined. Renamed Caml_state() macro to Caml_state_var() macro to
+  unshadow compiler expressions, especially Caml_state(GOT_PREL)
+  (Jonah Beckford)
+
 ### Code generation and optimizations:
 
 - #10578: Increase the number of integer registers used for

--- a/runtime/amd64.S
+++ b/runtime/amd64.S
@@ -171,7 +171,7 @@
 #include "../runtime/caml/domain_state.tbl"
 #undef DOMAIN_STATE
 
-#define Caml_state(var) (8*domain_field_caml_##var)(%r14)
+#define Caml_state_var(var) (8*domain_field_caml_##var)(%r14)
 
 /* Load address of global [label] in register [dst]. */
 #if defined(__PIC__) && !defined(SYS_mingw64) && !defined(SYS_cygwin)
@@ -184,12 +184,12 @@
 
 /* Push the current exception handler. Clobbers %r11 */
 #define PUSH_EXN_HANDLER \
-        movq    Caml_state(exn_handler), %r11; \
+        movq    Caml_state_var(exn_handler), %r11; \
         pushq   %r11; CFI_ADJUST(8);
 
 /* Pop the current exception handler. Undoes PUSH_EXN_HANDLER. Clobbers %r11 */
 #define POP_EXN_HANDLER \
-        leaq    Caml_state(exn_handler), %r11; \
+        leaq    Caml_state_var(exn_handler), %r11; \
         popq    (%r11); CFI_ADJUST(-8)
 
 /******************************************************************************/
@@ -209,10 +209,10 @@
 #endif
 #define SWITCH_OCAML_TO_C                                  \
     /* Fill in Caml_state->current_stack->sp */            \
-        movq    Caml_state(current_stack), %r10;           \
+        movq    Caml_state_var(current_stack), %r10;           \
         movq    %rsp, Stack_sp(%r10);                      \
     /* Fill in Caml_state->c_stack */                      \
-        movq    Caml_state(c_stack), %r11;                 \
+        movq    Caml_state_var(c_stack), %r11;                 \
         movq    %rsp, Cstack_sp(%r11);                     \
         movq    %r10, Cstack_stack(%r11);                  \
     /* Switch to C stack */                                \
@@ -223,8 +223,8 @@
 #define SWITCH_C_TO_OCAML                                           \
     /* Assert that %rsp == Caml_state->c_stack &&
         Caml_state->c_stack->sp == Caml_state->current_stack->sp */ \
-        IF_DEBUG(cmpq %rsp, Caml_state(c_stack); je 8f; int3; 8:    \
-                 movq Caml_state(current_stack), %r11;              \
+        IF_DEBUG(cmpq %rsp, Caml_state_var(c_stack); je 8f; int3; 8:    \
+                 movq Caml_state_var(current_stack), %r11;              \
                  movq Stack_sp(%r11), %r11;                         \
                  cmpq %r11, Cstack_sp(%rsp); je 8f; int3; 8:)       \
         movq    Cstack_sp(%rsp), %rsp;                              \
@@ -233,7 +233,7 @@
 /* Load Caml_state->exn_handler into %rsp and restores prior exn_handler.
    Clobbers %r10 and %r11. */
 #define RESTORE_EXN_HANDLER_OCAML              \
-        movq    Caml_state(exn_handler), %rsp; \
+        movq    Caml_state_var(exn_handler), %rsp; \
         CFI_DEF_CFA_OFFSET(16);                \
         POP_EXN_HANDLER
 
@@ -243,15 +243,15 @@
 #define SWITCH_OCAML_STACKS                               \
     /* Save OCaml SP and exn_handler in the stack info */ \
         movq    %rsp, Stack_sp(%rsi);                     \
-        movq    Caml_state(exn_handler), %r12;            \
+        movq    Caml_state_var(exn_handler), %r12;            \
         movq    %r12, Stack_exception(%rsi);              \
     /* switch stacks */                                   \
-        movq    %r10, Caml_state(current_stack);          \
+        movq    %r10, Caml_state_var(current_stack);          \
         movq    Stack_sp(%r10), %rsp;                     \
         CFI_DEF_CFA_OFFSET(8);                            \
     /* restore exn_handler for new stack */               \
         movq    Stack_exception(%r10), %r12;              \
-        movq    %r12, Caml_state(exn_handler)
+        movq    %r12, Caml_state_var(exn_handler)
 
 /******************************************************************************/
 /* Save and restore all callee-save registers on stack.
@@ -388,13 +388,13 @@ G(caml_system__code_begin):
    Returns: bucket in %r15. Clobbers %r11 (after saving it) */
 #define SAVE_ALL_REGS                                  \
     /* First, save the young_ptr. */                   \
-        movq    %r15, Caml_state(young_ptr);           \
+        movq    %r15, Caml_state_var(young_ptr);           \
     /* Now, use %r15 to point to the gc_regs bucket */ \
     /* We save %r11 first to allow it to be scratch */ \
-        movq    Caml_state(gc_regs_buckets), %r15;     \
+        movq    Caml_state_var(gc_regs_buckets), %r15;     \
         movq    %r11, 11*8(%r15);                      \
         movq    0(%r15), %r11; /* next ptr */          \
-        movq    %r11, Caml_state(gc_regs_buckets);     \
+        movq    %r11, Caml_state_var(gc_regs_buckets);     \
         movq    %rax,         0*8(%r15);               \
         movq    %rbx,         1*8(%r15);               \
         movq    %rdi,         2*8(%r15);               \
@@ -429,9 +429,9 @@ G(caml_system__code_begin):
 #define RESTORE_ALL_REGS                               \
     /* Restore %rax, freeing up the next ptr slot */   \
         movq    0*8(%r15), %rax;                       \
-        movq    Caml_state(gc_regs_buckets), %r11;     \
+        movq    Caml_state_var(gc_regs_buckets), %r11;     \
         movq    %r11, 0(%r15); /* next ptr */          \
-        movq    %r15, Caml_state(gc_regs_buckets);     \
+        movq    %r15, Caml_state_var(gc_regs_buckets);     \
            /* above:  0*8(%r15),%rax; */               \
         movq          1*8(%r15),%rbx;                  \
         movq          2*8(%r15),%rdi;                  \
@@ -461,7 +461,7 @@ G(caml_system__code_begin):
         movsd   (13+13)*8(%r15),%xmm13;                \
         movsd   (14+13)*8(%r15),%xmm14;                \
         movsd   (15+13)*8(%r15),%xmm15;                \
-        movq    Caml_state(young_ptr), %r15
+        movq    Caml_state_var(young_ptr), %r15
 
 FUNCTION(G(caml_call_realloc_stack))
 CFI_STARTPROC
@@ -487,11 +487,11 @@ CFI_STARTPROC
         CFI_SIGNAL_FRAME
 LBL(caml_call_gc):
         SAVE_ALL_REGS
-        movq    %r15, Caml_state(gc_regs)
+        movq    %r15, Caml_state_var(gc_regs)
         SWITCH_OCAML_TO_C
         C_call (GCALL(caml_garbage_collection))
         SWITCH_C_TO_OCAML
-        movq    Caml_state(gc_regs), %r15
+        movq    Caml_state_var(gc_regs), %r15
         RESTORE_ALL_REGS
         ret
 CFI_ENDPROC
@@ -500,7 +500,7 @@ ENDFUNCTION(G(caml_call_gc))
 FUNCTION(G(caml_alloc1))
 CFI_STARTPROC
         subq    $16, %r15
-        cmpq    Caml_state(young_limit), %r15
+        cmpq    Caml_state_var(young_limit), %r15
         jb      LBL(caml_call_gc)
         ret
 CFI_ENDPROC
@@ -509,7 +509,7 @@ ENDFUNCTION(G(caml_alloc1))
 FUNCTION(G(caml_alloc2))
 CFI_STARTPROC
         subq    $24, %r15
-        cmpq    Caml_state(young_limit), %r15
+        cmpq    Caml_state_var(young_limit), %r15
         jb      LBL(caml_call_gc)
         ret
 CFI_ENDPROC
@@ -518,7 +518,7 @@ ENDFUNCTION(G(caml_alloc2))
 FUNCTION(G(caml_alloc3))
 CFI_STARTPROC
         subq    $32, %r15
-        cmpq    Caml_state(young_limit), %r15
+        cmpq    Caml_state_var(young_limit), %r15
         jb      LBL(caml_call_gc)
         ret
 CFI_ENDPROC
@@ -526,7 +526,7 @@ ENDFUNCTION(G(caml_alloc3))
 
 FUNCTION(G(caml_allocN))
 CFI_STARTPROC
-        cmpq    Caml_state(young_limit), %r15
+        cmpq    Caml_state_var(young_limit), %r15
         jb      LBL(caml_call_gc)
         ret
 CFI_ENDPROC
@@ -546,11 +546,11 @@ LBL(caml_c_call):
     /* Switch from OCaml to C */
         SWITCH_OCAML_TO_C
     /* Make the alloc ptr available to the C code */
-        movq    %r15, Caml_state(young_ptr)
+        movq    %r15, Caml_state_var(young_ptr)
     /* Call the function (address in %rax) */
         C_call  (*%rax)
     /* Prepare for return to OCaml */
-        movq    Caml_state(young_ptr), %r15
+        movq    Caml_state_var(young_ptr), %r15
     /* Load ocaml stack and restore global variables */
         SWITCH_C_TO_OCAML
     /* Return to OCaml caller */
@@ -576,7 +576,7 @@ CFI_STARTPROC
           DW_OP_plus_uconst, 8 /* ret addr */
 #endif
     /* Make the alloc ptr available to the C code */
-        movq    %r15, Caml_state(young_ptr)
+        movq    %r15, Caml_state_var(young_ptr)
     /* Copy arguments from OCaml to C stack */
 LBL(105):
         subq    $8, %r12
@@ -588,9 +588,9 @@ LBL(106):
     /* Call the function (address in %rax) */
         C_call  (*%rax)
     /* Pop arguments back off the stack */
-        movq    Caml_state(c_stack), %rsp
+        movq    Caml_state_var(c_stack), %rsp
     /* Prepare for return to OCaml */
-        movq    Caml_state(young_ptr), %r15
+        movq    Caml_state_var(young_ptr), %r15
     /* Load ocaml stack and restore global variables */
         SWITCH_C_TO_OCAML
     /* Return to OCaml caller */
@@ -620,32 +620,32 @@ CFI_STARTPROC
     /* Common code for caml_start_program and caml_callback* */
 LBL(caml_start_program):
     /* Load young_ptr into %r15 */
-        movq    Caml_state(young_ptr), %r15
+        movq    Caml_state_var(young_ptr), %r15
     /* Build struct c_stack_link on the C stack */
         subq    $24 /* sizeof struct c_stack_link */, %rsp; CFI_ADJUST(24)
         movq    $0, Cstack_stack(%rsp)
         movq    $0, Cstack_sp(%rsp)
-        movq    Caml_state(c_stack), %r10
+        movq    Caml_state_var(c_stack), %r10
         movq    %r10, Cstack_prev(%rsp)
-        movq    %rsp, Caml_state(c_stack)
+        movq    %rsp, Caml_state_var(c_stack)
         CHECK_STACK_ALIGNMENT
     /* Load the OCaml stack. */
-        movq    Caml_state(current_stack), %r11
+        movq    Caml_state_var(current_stack), %r11
         movq    Stack_sp(%r11), %r10
     /* Store the stack pointer to allow DWARF unwind */
         subq    $16, %r10
         movq    %rsp, 0(%r10) /* C_STACK_SP */
     /* Store the gc_regs for callbacks during a GC */
-        movq    Caml_state(gc_regs), %r11
+        movq    Caml_state_var(gc_regs), %r11
         movq    %r11, 8(%r10)
     /* Build a handler for exceptions raised in OCaml on the OCaml stack. */
         subq    $16, %r10
         lea     LBL(109)(%rip), %r11
         movq    %r11, 8(%r10)
     /* link in the previous exn_handler so that copying stacks works */
-        movq    Caml_state(exn_handler), %r11
+        movq    Caml_state_var(exn_handler), %r11
         movq    %r11, 0(%r10)
-        movq    %r10, Caml_state(exn_handler)
+        movq    %r10, Caml_state_var(exn_handler)
     /* Switch stacks and call the OCaml code */
         movq    %r10, %rsp
 #ifdef ASM_CFI_SUPPORTED
@@ -663,22 +663,22 @@ LBL(caml_start_program):
 LBL(108):
     /* pop exn handler */
         movq    0(%rsp), %r11
-        movq    %r11, Caml_state(exn_handler)
+        movq    %r11, Caml_state_var(exn_handler)
         leaq    16(%rsp), %r10
 1:  /* restore GC regs */
         movq    8(%r10), %r11
-        movq    %r11, Caml_state(gc_regs)
+        movq    %r11, Caml_state_var(gc_regs)
         addq    $16, %r10
     /* Update alloc ptr */
-        movq    %r15, Caml_state(young_ptr)
+        movq    %r15, Caml_state_var(young_ptr)
     /* Return to C stack. */
-        movq    Caml_state(current_stack), %r11
+        movq    Caml_state_var(current_stack), %r11
         movq    %r10, Stack_sp(%r11)
-        movq    Caml_state(c_stack), %rsp
+        movq    Caml_state_var(c_stack), %rsp
         CFI_RESTORE_STATE
     /* Pop the struct c_stack_link */
         movq    Cstack_prev(%rsp), %r10
-        movq    %r10, Caml_state(c_stack)
+        movq    %r10, Caml_state_var(c_stack)
         addq    $24, %rsp; CFI_ADJUST(-24)
     /* Restore callee-save registers. */
         POP_CALLEE_SAVE_REGS
@@ -703,20 +703,20 @@ ENDFUNCTION(G(caml_start_program))
 FUNCTION(G(caml_raise_exn))
 CFI_STARTPROC
 LBL(caml_raise_exn):
-        testq   $1, Caml_state(backtrace_active)
+        testq   $1, Caml_state_var(backtrace_active)
         jne   LBL(116)
         RESTORE_EXN_HANDLER_OCAML
         ret
 LBL(116):
-        movq    $0, Caml_state(backtrace_pos)
+        movq    $0, Caml_state_var(backtrace_pos)
 LBL(117):
         movq    %rsp, %r10        /* Save OCaml stack pointer */
         movq    %rax, %r12        /* Save exception bucket */
-        movq    Caml_state(c_stack), %rsp
+        movq    Caml_state_var(c_stack), %rsp
         movq    %rax, C_ARG_1     /* arg 1: exception bucket */
         movq    (%r10), C_ARG_2   /* arg 2: pc of raise */
         leaq    8(%r10), C_ARG_3  /* arg 3: sp at raise */
-        movq    Caml_state(exn_handler), C_ARG_4
+        movq    Caml_state_var(exn_handler), C_ARG_4
                                   /* arg 4: sp of handler */
         C_call  (GCALL(caml_stash_backtrace))
         movq    %r12, %rax        /* Recover exception bucket */
@@ -727,7 +727,7 @@ ENDFUNCTION(G(caml_raise_exn))
 
 FUNCTION(G(caml_reraise_exn))
 CFI_STARTPROC
-        testq   $1, Caml_state(backtrace_active)
+        testq   $1, Caml_state_var(backtrace_active)
         jne   LBL(117)
         RESTORE_EXN_HANDLER_OCAML
         ret
@@ -741,9 +741,9 @@ CFI_STARTPROC
         movq    C_ARG_1, %r14                /* Caml_state */
         movq    C_ARG_2, %rax
     /* Load young_ptr into %r15 */
-        movq    Caml_state(young_ptr), %r15
+        movq    Caml_state_var(young_ptr), %r15
     /* Discard the C stack pointer and reset to ocaml stack */
-        movq    Caml_state(current_stack), %r10
+        movq    Caml_state_var(current_stack), %r10
         movq    Stack_sp(%r10), %rsp         /* FIXME: CFI */
         jmp LBL(caml_raise_exn)
 CFI_ENDPROC
@@ -812,7 +812,7 @@ FUNCTION(G(caml_perform))
 CFI_STARTPROC
     /*  %rax: effect to perform
         %rbx: freshly allocated continuation */
-        movq    Caml_state(current_stack), %rsi /* %rsi := old stack */
+        movq    Caml_state_var(current_stack), %rsi /* %rsi := old stack */
         leaq    1(%rsi), %rdi /* %rdi (last_fiber) := Val_ptr(old stack) */
         movq    %rdi, 0(%rbx) /* Initialise continuation */
 LBL(do_perform):
@@ -833,7 +833,7 @@ LBL(112):
         (no-op unless this is a reperform) */
         movq    0(%rbx), %r10  /* load performer stack from continuation */
         subq    $1, %r10       /* r10 := Ptr_val(r10) */
-        movq    Caml_state(current_stack), %rsi
+        movq    Caml_state_var(current_stack), %rsi
         SWITCH_OCAML_STACKS
     /* No parent stack. Raise Unhandled. */
         LEA_VAR(caml_exn_Unhandled, %rax)
@@ -846,7 +846,7 @@ CFI_STARTPROC
     /*  %rax: effect to reperform
         %rbx: continuation
         %rdi: last_fiber */
-        movq    Caml_state(current_stack), %rsi  /* %rsi := old stack */
+        movq    Caml_state_var(current_stack), %rsi  /* %rsi := old stack */
         movq    (Stack_handler-1)(%rdi), %r10
         movq    %rsi, Handler_parent(%r10)       /* Append to last_fiber */
         leaq    1(%rsi), %rdi  /* %rdi (last_fiber) := Val_ptr(old stack) */
@@ -868,7 +868,7 @@ CFI_STARTPROC
         movq    Handler_parent(%rcx), %rsi
         testq   %rsi, %rsi
         jnz     1b
-        movq    Caml_state(current_stack), %rsi
+        movq    Caml_state_var(current_stack), %rsi
         movq    %rsi, Handler_parent(%rcx)
         SWITCH_OCAML_STACKS
         jmp     *(%rbx)
@@ -885,14 +885,14 @@ CFI_STARTPROC
     /* %rax -> stack, %rbx -> fun, %rdi -> arg */
         andq    $-2, %rax       /* %rax = Ptr_val(%rax) */
     /* save old stack pointer and exception handler */
-        movq    Caml_state(current_stack), %rcx
-        movq    Caml_state(exn_handler), %r10
+        movq    Caml_state_var(current_stack), %rcx
+        movq    Caml_state_var(exn_handler), %r10
         movq    %rsp, Stack_sp(%rcx)
         movq    %r10, Stack_exception(%rcx)
     /* Load new stack pointer and set parent */
         movq    Stack_handler(%rax), %r11
         movq    %rcx, Handler_parent(%r11)
-        movq    %rax, Caml_state(current_stack)
+        movq    %rax, Caml_state_var(current_stack)
         movq    Stack_sp(%rax), %r11
     /* Create an exception handler on the target stack
        after 16byte DWARF & gc_regs block (which is unused here) */
@@ -902,7 +902,7 @@ CFI_STARTPROC
     /* link the previous exn_handler so that copying stacks works */
         movq    Stack_exception(%rax), %r10
         movq    %r10, 0(%r11)
-        movq    %r11, Caml_state(exn_handler)
+        movq    %r11, Caml_state_var(exn_handler)
     /* Switch to the new stack */
         movq    %r11, %rsp
 #ifdef ASM_CFI_SUPPORTED
@@ -921,19 +921,19 @@ CFI_STARTPROC
 LBL(frame_runstack):
         leaq    32(%rsp), %r11 /* SP with exn handler popped */
         movq    Handler_value(%r11), %rbx
-1:      movq    Caml_state(current_stack), C_ARG_1 /* arg to caml_free_stack */
+1:      movq    Caml_state_var(current_stack),C_ARG_1 /*arg to caml_free_stack*/
     /* restore parent stack and exn_handler into Caml_state */
         movq    Handler_parent(%r11), %r10
         movq    Stack_exception(%r10), %r11
-        movq    %r10, Caml_state(current_stack)
-        movq    %r11, Caml_state(exn_handler)
+        movq    %r10, Caml_state_var(current_stack)
+        movq    %r11, Caml_state_var(exn_handler)
     /* free old stack by switching directly to c_stack; is a no-alloc call */
         movq    Stack_sp(%r10), %r13 /* saved across C call */
         CFI_RESTORE_STATE
         CFI_REMEMBER_STATE
         CFI_DEF_CFA_REGISTER(DW_REG_r13)
         movq    %rax, %r12 /* save %rax across C call */
-        movq    Caml_state(c_stack), %rsp
+        movq    Caml_state_var(c_stack), %rsp
         C_call  (GCALL(caml_free_stack))
     /* switch directly to parent stack with correct return */
         movq    %r13, %rsp
@@ -959,7 +959,7 @@ ENDFUNCTION(G(caml_ml_array_bound_error))
 FUNCTION(G(caml_assert_stack_invariants))
 CFI_STARTPROC
 /*      CHECK_STACK_ALIGNMENT */
-        movq    Caml_state(current_stack), %r11
+        movq    Caml_state_var(current_stack), %r11
         movq    %rsp, %r10
         subq    %r11, %r10      /* %r10: number of bytes left on stack */
         /* can be two words over: the return addresses */

--- a/runtime/arm.S
+++ b/runtime/arm.S
@@ -129,7 +129,7 @@ caml_hot__code_end:
 #include "../runtime/caml/domain_state.tbl"
 #undef DOMAIN_STATE
 
-#define Caml_state(var) [domain_state_ptr, 8*domain_field_caml_##var]
+#define Caml_state_var(var) [domain_state_ptr, 8*domain_field_caml_##var]
 
 /* Allocation functions and GC interface */
         TEXT_SECTION(caml_system__code_begin)
@@ -140,9 +140,9 @@ FUNCTION(caml_call_gc)
         CFI_STARTPROC
 .Lcaml_call_gc:
     /* Record return address */
-        str     lr, Caml_state(last_return_address)
+        str     lr, Caml_state_var(last_return_address)
     /* Record lowest stack address */
-        str     sp, Caml_state(bottom_of_stack)
+        str     sp, Caml_state_var(bottom_of_stack)
 #if defined(SYS_linux_eabihf) || defined(SYS_netbsd)
     /* Save caller floating-point registers on the stack */
         vpush   {d0-d7}; CFI_ADJUST(64)
@@ -155,11 +155,11 @@ FUNCTION(caml_call_gc)
         CFI_OFFSET(lr, -4)
 #endif
     /* Store pointer to saved integer registers in Caml_state->gc_regs */
-        str     sp, Caml_state(gc_regs)
+        str     sp, Caml_state_var(gc_regs)
     /* Save current allocation pointer for debugging purposes */
-        str     alloc_ptr, Caml_state(young_ptr)
+        str     alloc_ptr, Caml_state_var(young_ptr)
     /* Save trap pointer in case an exception is raised during GC */
-        str     trap_ptr, Caml_state(exception_pointer)
+        str     trap_ptr, Caml_state_var(exception_pointer)
     /* Call the garbage collector */
         bl      caml_garbage_collection
     /* Restore integer registers and return address from the stack */
@@ -169,7 +169,7 @@ FUNCTION(caml_call_gc)
         vpop    {d0-d7}; CFI_ADJUST(-64)
 #endif
     /* Reload new allocation pointer */
-        ldr     alloc_ptr, Caml_state(young_ptr)
+        ldr     alloc_ptr, Caml_state_var(young_ptr)
     /* Return to caller */
         bx      lr
         CFI_ENDPROC
@@ -178,7 +178,7 @@ FUNCTION(caml_call_gc)
 FUNCTION(caml_alloc1)
         CFI_STARTPROC
         sub     alloc_ptr, alloc_ptr, 8
-        ldr     r7, Caml_state(young_limit)
+        ldr     r7, Caml_state_var(young_limit)
         cmp     alloc_ptr, r7
         bcc     .Lcaml_call_gc
         bx      lr
@@ -188,7 +188,7 @@ FUNCTION(caml_alloc1)
 FUNCTION(caml_alloc2)
         CFI_STARTPROC
         sub     alloc_ptr, alloc_ptr, 12
-        ldr     r7, Caml_state(young_limit)
+        ldr     r7, Caml_state_var(young_limit)
         cmp     alloc_ptr, r7
         bcc     .Lcaml_call_gc
         bx      lr
@@ -198,7 +198,7 @@ FUNCTION(caml_alloc2)
 FUNCTION(caml_alloc3)
         CFI_STARTPROC
         sub     alloc_ptr, alloc_ptr, 16
-        ldr     r7, Caml_state(young_limit)
+        ldr     r7, Caml_state_var(young_limit)
         cmp     alloc_ptr, r7
         bcc     .Lcaml_call_gc
         bx      lr
@@ -208,7 +208,7 @@ FUNCTION(caml_alloc3)
 FUNCTION(caml_allocN)
         CFI_STARTPROC
         sub     alloc_ptr, alloc_ptr, r7
-        ldr     r7, Caml_state(young_limit)
+        ldr     r7, Caml_state_var(young_limit)
         cmp     alloc_ptr, r7
         bcc     .Lcaml_call_gc
         bx      lr
@@ -216,39 +216,66 @@ FUNCTION(caml_allocN)
         .size   caml_allocN, .-caml_allocN
 
 /* Call a C function from OCaml */
-/* Function to call is in r7 */
+/* Function to call is in r7 for non-PIC code, or is a
+   named PLT function for PIC code */
+/* A PLT function address is only available when "cited by a BL-class
+   relocation directive" like `bl func(PLT)`. We can't, for example, do
+   `adr r7, func(PLT)` and then jump to caml_c_call or Ljump_to_caml. So
+   implemented as a macro that inserts the instructions inline and branch jumps
+   (branch_op = bl or blx) to (c_code_addr or caml_code_funcptr). Use blx for
+   r7/r12 register and bl for named PLT functions.
+   Warning: Unlike blx the bl instruction does not switch to/from Thumb state
+   since "it is generally pointless trying to construct a PLT entry entirely in
+   16-bit Thumb instructions". In other words: Do not emit Thumb PLT entries
+   for PIC code!
+   Confer: https://github.com/ARM-software/abi-aa/blob/
+   320a56971fdcba282b7001cf4b84abb4fd993131/aaelf32/
+   aaelf32.rst#plt-sequences-and-usage-models
+*/
 
-FUNCTION(caml_c_call)
-        CFI_STARTPROC
+        .macro inline_caml_c_call branch_op c_code_addr
     /* Record lowest stack address and return address */
-        str     lr, Caml_state(last_return_address)
-        str     sp, Caml_state(bottom_of_stack)
+        str     lr, Caml_state_var(last_return_address)
+        str     sp, Caml_state_var(bottom_of_stack)
     /* Preserve return address in callee-save register r4 */
         mov     r4, lr
         CFI_REGISTER(lr, r4)
     /* Make the exception handler alloc ptr available to the C code */
-        str     alloc_ptr, Caml_state(young_ptr)
-        str     trap_ptr, Caml_state(exception_pointer)
+        str     alloc_ptr, Caml_state_var(young_ptr)
+        str     trap_ptr, Caml_state_var(exception_pointer)
     /* Call the function */
-        blx     r7
+        \branch_op \c_code_addr
     /* Reload alloc ptr */
-        ldr     alloc_ptr, Caml_state(young_ptr)
+        ldr     alloc_ptr, Caml_state_var(young_ptr)
     /* Return */
         bx      r4
+        .endm
+
+FUNCTION(caml_c_call)
+        CFI_STARTPROC
+        inline_caml_c_call blx r7
         CFI_ENDPROC
         .size   caml_c_call, .-caml_c_call
 
 /* Start the OCaml program */
 
-FUNCTION(caml_start_program)
-        CFI_STARTPROC
-        ldr     r12, =caml_program
-
 /* Code shared with caml_callback* */
-/* Address of OCaml code to call is in r12 */
 /* Arguments to the OCaml code are in r0...r3 */
+/* Instructions for using call_caml_XXXX:
+        1. (optional) set r12
+        2. `call_caml_enter`
+        3. `blx some_function(PLT)` ...or if you preset r12... `bx r12`
+        4. `call_caml_exit`
 
-.Ljump_to_caml:
+        At end inside the CFI PROC do `call_caml_relocs`.
+                Why? Linker will do PIC relocations in this word space.
+
+        Add `call_caml_framedescr` in the PIC portion of
+        caml_system__frametable.
+        And increment caml_system__frametable.num_descriptors.
+                Why? All callsite return addresses have to be visible to GC.
+*/
+        .macro call_caml_enter callsite:req
 #if defined(SYS_linux_eabihf) || defined(SYS_netbsd)
     /* Save callee-save floating-point registers */
         vpush   {d8-d15}; CFI_ADJUST(64)
@@ -260,43 +287,57 @@ FUNCTION(caml_start_program)
 #else
         CFI_OFFSET(lr, -4)
 #endif
+#ifdef __PIC__
+    /* Read the PREL word in the local .text section, which is the PC-relative
+       address of Caml_state's GOT entry */
+        ldr.w   domain_state_ptr, \callsite\()_isp
+    /* Label for PC of next add instruction */
+\callsite\()_pcnai: /* `.Lxyz_pcnai:` if callsite=`.Lxyz` */
+        add.w   domain_state_ptr, pc
+    /* Load the entry from the GOT; the address of Caml_state variable */
+        ldr     domain_state_ptr, [domain_state_ptr]
+#else
+    /* Load the address of Caml_state variable */
         ldr     domain_state_ptr, =Caml_state
+#endif
+    /* Load the Caml_state pointer */
         ldr     domain_state_ptr, [domain_state_ptr]
     /* Setup a callback link on the stack */
         sub     sp, sp, 16; CFI_ADJUST(16)              /* 8-byte alignment */
-        ldr     r4, Caml_state(bottom_of_stack)
-        ldr     r5, Caml_state(last_return_address)
-        ldr     r6, Caml_state(gc_regs)
+        ldr     r4, Caml_state_var(bottom_of_stack)
+        ldr     r5, Caml_state_var(last_return_address)
+        ldr     r6, Caml_state_var(gc_regs)
         str     r4, [sp, 0]
         str     r5, [sp, 4]
         str     r6, [sp, 8]
     /* Setup a trap frame to catch exceptions escaping the OCaml code */
         sub     sp, sp, 8; CFI_ADJUST(8)
-        ldr     r5, =.Ltrap_handler
-        ldr     r4, Caml_state(exception_pointer)
+        adr     r5, .Ltrap_handler
+        ldr     r4, Caml_state_var(exception_pointer)
         str     r4, [sp, 0]
         str     r5, [sp, 4]
         mov     trap_ptr, sp
     /* Reload allocation pointer */
-        ldr     alloc_ptr, Caml_state(young_ptr)
-    /* Call the OCaml code */
-        blx     r12
-.Lcaml_retaddr:
+        ldr     alloc_ptr, Caml_state_var(young_ptr)
+        .endm
+
+        .macro  call_caml_exit retaddr_label:req return_result_label:req
+\retaddr_label:
     /* Pop the trap frame, restoring caml_exception_pointer */
         ldr     r5, [sp, 0]
-        str     r5, Caml_state(exception_pointer)
+        str     r5, Caml_state_var(exception_pointer)
         add     sp, sp, 8; CFI_ADJUST(-8)
     /* Pop the callback link, restoring the global variables */
-.Lreturn_result:
+\return_result_label:
         ldr     r5, [sp, 0]
-        str     r5, Caml_state(bottom_of_stack)
+        str     r5, Caml_state_var(bottom_of_stack)
         ldr     r5, [sp, 4]
-        str     r5, Caml_state(last_return_address)
+        str     r5, Caml_state_var(last_return_address)
         ldr     r5, [sp, 8]
-        str     r5, Caml_state(gc_regs)
+        str     r5, Caml_state_var(gc_regs)
         add     sp, sp, 16; CFI_ADJUST(-16)
     /* Update allocation pointer */
-        str     alloc_ptr, Caml_state(young_ptr)
+        str     alloc_ptr, Caml_state_var(young_ptr)
     /* Reload callee-save registers and return address */
         pop     {r4-r8,r10,r11,lr}; CFI_ADJUST(-32)
 #if defined(SYS_linux_eabihf) || defined(SYS_netbsd)
@@ -304,6 +345,44 @@ FUNCTION(caml_start_program)
         vpop    {d8-d15}; CFI_ADJUST(-64)
 #endif
         bx      lr
+        .endm
+
+        .macro call_caml_relocs callsite:req
+#ifdef __PIC__
+        .align  2
+    /* Local indirect symbol pointer for \label that will be linked statically
+       with the correct GOT math. */
+\callsite\()_isp: /* `.Lxyz_isp:` if callsite=`.Lxyz` */
+    /* 8 = opcode_size( ldr.w ; \callsite\()_pcnai: adr.w ) */
+        .word	Caml_state(GOT_PREL)-((\callsite\()_pcnai+8)-\callsite\()_isp)
+#endif
+        .endm
+
+        .macro call_caml_framedescr retaddr_label:req
+#ifdef __PIC__
+        .word	  \retaddr_label  /* return address into callback */
+        .short  0               /* zero frame size */
+        .short  0               /* no roots */
+        .align  2
+#endif
+        .endm
+
+FUNCTION(caml_start_program)
+        CFI_STARTPROC
+
+#ifdef __PIC__
+        call_caml_enter         .Lcaml_start_program
+        bl      caml_program(PLT)
+#else
+        ldr     r12, =caml_program
+
+/* Address of OCaml code to call is in r12 */
+.Ljump_to_caml:
+        call_caml_enter         .Lcaml_start_program
+        blx     r12
+#endif
+        call_caml_exit          .Lcaml_retaddr, .Lreturn_result
+        call_caml_relocs        .Lcaml_start_program
         CFI_ENDPROC
         .type   .Lcaml_retaddr, %function
         .size   .Lcaml_retaddr, .-.Lcaml_retaddr
@@ -315,7 +394,7 @@ FUNCTION(caml_start_program)
 .Ltrap_handler:
         CFI_STARTPROC
     /* Save exception pointer */
-        str     trap_ptr, Caml_state(exception_pointer)
+        str     trap_ptr, Caml_state_var(exception_pointer)
     /* Encode exception bucket as an exception result */
         orr     r0, r0, 2
     /* Return it */
@@ -329,7 +408,7 @@ FUNCTION(caml_start_program)
 FUNCTION(caml_raise_exn)
         CFI_STARTPROC
     /* Test if backtrace is active */
-        ldr     r1, Caml_state(backtrace_active)
+        ldr     r1, Caml_state_var(backtrace_active)
         cbz     r1, 1f
     /* Preserve exception bucket in callee-save register r4 */
         mov     r4, r0
@@ -356,15 +435,15 @@ FUNCTION(caml_raise_exception)
     /* Load exception bucket */
         mov     r0, r1
     /* Reload trap ptr and alloc ptr */
-        ldr     trap_ptr, Caml_state(exception_pointer)
-        ldr     alloc_ptr, Caml_state(young_ptr)
+        ldr     trap_ptr, Caml_state_var(exception_pointer)
+        ldr     alloc_ptr, Caml_state_var(young_ptr)
     /* Test if backtrace is active */
-        ldr     r1, Caml_state(backtrace_active)
+        ldr     r1, Caml_state_var(backtrace_active)
         cbz     r1, 1f
     /* Preserve exception bucket in callee-save register r4 */
         mov     r4, r0
-        ldr     r1, Caml_state(last_return_address) /* arg2: pc of raise */
-        ldr     r2, Caml_state(bottom_of_stack)     /* arg3: sp of raise */
+        ldr     r1, Caml_state_var(last_return_address) /* arg2: pc of raise */
+        ldr     r2, Caml_state_var(bottom_of_stack)     /* arg3: sp of raise */
         mov     r3, trap_ptr                        /* arg4: sp of handler */
         bl      caml_stash_backtrace
     /* Restore exception bucket */
@@ -385,9 +464,20 @@ FUNCTION(caml_callback_asm)
         ldr     r0, [r2]        /* r0 = first arg */
                                 /* r1 = closure environment */
         ldr     r12, [r1]       /* code pointer */
+#ifdef __PIC__
+        call_caml_enter         .Lcaml_callback_asm
+        blx     r12
+#else
         b       .Ljump_to_caml
+#endif
+        call_caml_exit          .Lcca_retaddr, .Lcca_return_result
+        call_caml_relocs        .Lcaml_callback_asm
         CFI_ENDPROC
         .size   caml_callback_asm, .-caml_callback_asm
+#ifdef __PIC__
+        .type   .Lcca_retaddr, %function
+        .size   .Lcca_retaddr, .-.Lcca_retaddr
+#endif
 
 FUNCTION(caml_callback2_asm)
         CFI_STARTPROC
@@ -397,10 +487,21 @@ FUNCTION(caml_callback2_asm)
         ldr     r0, [r2]          /* r0 = first arg */
         ldr     r1, [r2,4]        /* r1 = second arg */
         mov     r2, r12           /* r2 = closure environment */
+#ifdef __PIC__
+        call_caml_enter         .Lcaml_callback2_asm
+        bl      caml_apply2(PLT)
+#else
         ldr     r12, =caml_apply2
         b       .Ljump_to_caml
+#endif
+        call_caml_exit          .Lcca2_retaddr, .Lcca2_return_result
+        call_caml_relocs        .Lcaml_callback2_asm
         CFI_ENDPROC
         .size   caml_callback2_asm, .-caml_callback2_asm
+#ifdef __PIC__
+        .type   .Lcca2_retaddr, %function
+        .size   .Lcca2_retaddr, .-.Lcaml2_callback_asm_retaddr
+#endif
 
 FUNCTION(caml_callback3_asm)
         CFI_STARTPROC
@@ -411,17 +512,32 @@ FUNCTION(caml_callback3_asm)
         ldr     r0, [r2]          /* r0 = first arg */
         ldr     r1, [r2,4]        /* r1 = second arg */
         ldr     r2, [r2,8]        /* r2 = third arg */
+#ifdef __PIC__
+        call_caml_enter         .Lcaml_callback3_asm
+        bl      caml_apply3(PLT)
+#else
         ldr     r12, =caml_apply3
         b       .Ljump_to_caml
+#endif
+        call_caml_exit          .Lcca3_retaddr, .Lcca3_return_result
+        call_caml_relocs        .Lcaml_callback3_asm
         CFI_ENDPROC
         .size   caml_callback3_asm, .-caml_callback3_asm
+#ifdef __PIC__
+        .type   .Lcca3_retaddr, %function
+        .size   .Lcca3_retaddr, .-.Lcaml3_callback_asm_retaddr
+#endif
 
 FUNCTION(caml_ml_array_bound_error)
         CFI_STARTPROC
+#ifdef __PIC__
+        inline_caml_c_call bl caml_array_bound_error(PLT)
+#else
     /* Load address of [caml_array_bound_error] in r7 */
-        ldr     r7, =caml_array_bound_error
+        ldr  r7, =caml_array_bound_error
     /* Call that function */
         b       caml_c_call
+#endif
         CFI_ENDPROC
         .size   caml_ml_array_bound_error, .-caml_ml_array_bound_error
 
@@ -435,7 +551,14 @@ caml_system__code_end:
         .align  2
         .globl  caml_system__frametable
 caml_system__frametable:
-        .word   1               /* one descriptor */
+#ifdef __PIC__
+        .word   4               /* num_descriptors including .Lcaml_retaddr */
+        call_caml_framedescr    .Lcca_retaddr
+        call_caml_framedescr    .Lcca2_retaddr
+        call_caml_framedescr    .Lcca3_retaddr
+#else
+        .word   1               /* one descriptor (only .Lcaml_retaddr) */
+#endif
         .word   .Lcaml_retaddr  /* return address into callback */
         .short  -1              /* negative frame size => use callback link */
         .short  0               /* no roots */

--- a/runtime/arm64.S
+++ b/runtime/arm64.S
@@ -63,7 +63,7 @@
 #include "../runtime/caml/domain_state.tbl"
 #undef DOMAIN_STATE
 
-#define Caml_state(var) [DOMAIN_STATE_PTR, 8*domain_field_caml_##var]
+#define Caml_state_var(var) [DOMAIN_STATE_PTR, 8*domain_field_caml_##var]
 
 /* Globals and labels */
 #if defined(SYS_macosx)
@@ -159,10 +159,10 @@ FUNCTION(caml_call_gc)
         CFI_STARTPROC
 L(caml_call_gc):
     /* Record return address */
-        str     x30, Caml_state(last_return_address)
+        str     x30, Caml_state_var(last_return_address)
     /* Record lowest stack address */
         mov     TMP, sp
-        str     TMP, Caml_state(bottom_of_stack)
+        str     TMP, Caml_state_var(bottom_of_stack)
     /* Set up stack space, saving return address and frame pointer */
     /* (2 regs RA/GP, 24 allocatable int regs, 24 caller-save float regs) * 8 */
         CFI_OFFSET(29, -400)
@@ -200,11 +200,11 @@ L(caml_call_gc):
         stp     d30, d31, [sp, 384]
     /* Store pointer to saved integer registers in Caml_state->gc_regs */
         add     TMP, sp, #16
-        str     TMP, Caml_state(gc_regs)
+        str     TMP, Caml_state_var(gc_regs)
     /* Save current allocation pointer for debugging purposes */
-        str     ALLOC_PTR, Caml_state(young_ptr)
+        str     ALLOC_PTR, Caml_state_var(young_ptr)
     /* Save trap pointer in case an exception is raised during GC */
-        str     TRAP_PTR, Caml_state(exception_pointer)
+        str     TRAP_PTR, Caml_state_var(exception_pointer)
     /* Call the garbage collector */
         bl      G(caml_garbage_collection)
     /* Restore registers */
@@ -233,7 +233,7 @@ L(caml_call_gc):
         ldp     d28, d29, [sp, 368]
         ldp     d30, d31, [sp, 384]
     /* Reload new allocation pointer */
-        ldr     ALLOC_PTR, Caml_state(young_ptr)
+        ldr     ALLOC_PTR, Caml_state_var(young_ptr)
     /* Free stack space and return to caller */
         ldp     x29, x30, [sp], 400
         ret
@@ -242,7 +242,7 @@ L(caml_call_gc):
 
 FUNCTION(caml_alloc1)
         CFI_STARTPROC
-        ldr     TMP, Caml_state(young_limit)
+        ldr     TMP, Caml_state_var(young_limit)
         sub     ALLOC_PTR, ALLOC_PTR, #16
         cmp     ALLOC_PTR, TMP
         b.lo    L(caml_call_gc)
@@ -252,7 +252,7 @@ FUNCTION(caml_alloc1)
 
 FUNCTION(caml_alloc2)
         CFI_STARTPROC
-        ldr     TMP, Caml_state(young_limit)
+        ldr     TMP, Caml_state_var(young_limit)
         sub     ALLOC_PTR, ALLOC_PTR, #24
         cmp     ALLOC_PTR, TMP
         b.lo    L(caml_call_gc)
@@ -262,7 +262,7 @@ FUNCTION(caml_alloc2)
 
 FUNCTION(caml_alloc3)
         CFI_STARTPROC
-        ldr     TMP, Caml_state(young_limit)
+        ldr     TMP, Caml_state_var(young_limit)
         sub     ALLOC_PTR, ALLOC_PTR, #32
         cmp     ALLOC_PTR, TMP
         b.lo    L(caml_call_gc)
@@ -272,7 +272,7 @@ FUNCTION(caml_alloc3)
 
 FUNCTION(caml_allocN)
         CFI_STARTPROC
-        ldr     TMP, Caml_state(young_limit)
+        ldr     TMP, Caml_state_var(young_limit)
         sub     ALLOC_PTR, ALLOC_PTR, ADDITIONAL_ARG
         cmp     ALLOC_PTR, TMP
         b.lo    L(caml_call_gc)
@@ -289,16 +289,16 @@ FUNCTION(caml_c_call)
         mov     x19, x30
         CFI_REGISTER(30, 19)
     /* Record lowest stack address and return address */
-        str     x30, Caml_state(last_return_address)
+        str     x30, Caml_state_var(last_return_address)
         add     TMP, sp, #0
-        str     TMP, Caml_state(bottom_of_stack)
+        str     TMP, Caml_state_var(bottom_of_stack)
     /* Make the exception handler alloc ptr available to the C code */
-        str     ALLOC_PTR, Caml_state(young_ptr)
-        str     TRAP_PTR, Caml_state(exception_pointer)
+        str     ALLOC_PTR, Caml_state_var(young_ptr)
+        str     TRAP_PTR, Caml_state_var(exception_pointer)
     /* Call the function */
         blr     ADDITIONAL_ARG
     /* Reload alloc ptr  */
-        ldr     ALLOC_PTR, Caml_state(young_ptr)
+        ldr     ALLOC_PTR, Caml_state_var(young_ptr)
     /* Return */
         ret     x19
         CFI_ENDPROC
@@ -335,37 +335,37 @@ L(jump_to_caml):
     /* Load domain state pointer from argument */
         mov     DOMAIN_STATE_PTR, TMP
     /* Setup a callback link on the stack */
-        ldr     x8, Caml_state(bottom_of_stack)
-        ldr     x9, Caml_state(last_return_address)
-        ldr     x10, Caml_state(gc_regs)
+        ldr     x8, Caml_state_var(bottom_of_stack)
+        ldr     x9, Caml_state_var(last_return_address)
+        ldr     x10, Caml_state_var(gc_regs)
         stp     x8, x9, [sp, -32]!     /* 16-byte alignment */
         CFI_ADJUST(32)
         str     x10, [sp, 16]
     /* Setup a trap frame to catch exceptions escaping the OCaml code */
-        ldr     x8, Caml_state(exception_pointer)
+        ldr     x8, Caml_state_var(exception_pointer)
         adr     x9, L(trap_handler)
         stp     x8, x9, [sp, -16]!
         CFI_ADJUST(16)
         add     TRAP_PTR, sp, #0
     /* Reload allocation pointer */
-        ldr     ALLOC_PTR, Caml_state(young_ptr)
+        ldr     ALLOC_PTR, Caml_state_var(young_ptr)
     /* Call the OCaml code */
         blr     TMP2
 L(caml_retaddr):
     /* Pop the trap frame, restoring caml_exception_pointer */
         ldr     x8, [sp], 16
         CFI_ADJUST(-16)
-        str     x8, Caml_state(exception_pointer)
+        str     x8, Caml_state_var(exception_pointer)
     /* Pop the callback link, restoring the global variables */
 L(return_result):
         ldr     x10, [sp, 16]
         ldp     x8, x9, [sp], 32
         CFI_ADJUST(-32)
-        str     x8, Caml_state(bottom_of_stack)
-        str     x9, Caml_state(last_return_address)
-        str     x10, Caml_state(gc_regs)
+        str     x8, Caml_state_var(bottom_of_stack)
+        str     x9, Caml_state_var(last_return_address)
+        str     x10, Caml_state_var(gc_regs)
     /* Update allocation pointer */
-        str     ALLOC_PTR, Caml_state(young_ptr)
+        str     ALLOC_PTR, Caml_state_var(young_ptr)
     /* Reload callee-save registers and return address */
         ldp     x19, x20, [sp, 16]
         ldp     x21, x22, [sp, 32]
@@ -389,7 +389,7 @@ L(return_result):
 L(trap_handler):
         CFI_STARTPROC
     /* Save exception pointer */
-        str     TRAP_PTR, Caml_state(exception_pointer)
+        str     TRAP_PTR, Caml_state_var(exception_pointer)
     /* Encode exception bucket as an exception result */
         orr     x0, x0, #2
     /* Return it */
@@ -401,7 +401,7 @@ L(trap_handler):
 FUNCTION(caml_raise_exn)
         CFI_STARTPROC
     /* Test if backtrace is active */
-        ldr     TMP, Caml_state(backtrace_active)
+        ldr     TMP, Caml_state_var(backtrace_active)
         cbnz    TMP, 2f
 1:  /* Cut stack at current trap handler */
         mov     sp, TRAP_PTR
@@ -432,10 +432,10 @@ FUNCTION(caml_raise_exception)
     /* Load the exception bucket */
         mov     x0, C_ARG_2
     /* Reload trap ptr and alloc ptr */
-        ldr     TRAP_PTR, Caml_state(exception_pointer)
-        ldr     ALLOC_PTR, Caml_state(young_ptr)
+        ldr     TRAP_PTR, Caml_state_var(exception_pointer)
+        ldr     ALLOC_PTR, Caml_state_var(young_ptr)
     /* Test if backtrace is active */
-        ldr     TMP, Caml_state(backtrace_active)
+        ldr     TMP, Caml_state_var(backtrace_active)
         cbnz    TMP, 2f
 1:  /* Cut stack at current trap handler */
         mov     sp, TRAP_PTR
@@ -447,8 +447,8 @@ FUNCTION(caml_raise_exception)
         mov     x19, x0
     /* Stash the backtrace */
                                                       /* arg1: exn bucket */
-        ldr     x1, Caml_state(last_return_address)   /* arg2: pc of raise */
-        ldr     x2, Caml_state(bottom_of_stack)       /* arg3: sp of raise */
+        ldr     x1, Caml_state_var(last_return_address)  /* arg2: pc of raise */
+        ldr     x2, Caml_state_var(bottom_of_stack)      /* arg3: sp of raise */
         mov     x3, TRAP_PTR   /* arg4: sp of handler */
         bl      G(caml_stash_backtrace)
     /* Restore exception bucket and raise */

--- a/runtime/power.S
+++ b/runtime/power.S
@@ -148,7 +148,7 @@
 #include "../runtime/caml/domain_state.tbl"
 #undef DOMAIN_STATE
 
-#define Caml_state(var) 8*domain_field_caml_##var(DOMAIN_STATE_PTR)
+#define Caml_state_var(var) 8*domain_field_caml_##var(DOMAIN_STATE_PTR)
 
 #if defined(MODEL_ppc64)
         .section ".opd","aw"
@@ -167,17 +167,17 @@ FUNCTION(caml_call_gc)
         stwu    1, -STACKSIZE(1)
     /* Record return address into OCaml code */
         mflr    0
-        stg     0, Caml_state(last_return_address)
+        stg     0, Caml_state_var(last_return_address)
     /* Record lowest stack address */
         addi    0, 1, STACKSIZE
-        stg     0, Caml_state(bottom_of_stack)
+        stg     0, Caml_state_var(bottom_of_stack)
     /* Record pointer to register array */
         addi    0, 1, 8*32 + PARAM_SAVE_AREA + RESERVED_STACK
-        stg     0, Caml_state(gc_regs)
+        stg     0, Caml_state_var(gc_regs)
     /* Save current allocation pointer for debugging purposes */
-        stg     ALLOC_PTR, Caml_state(young_ptr)
+        stg     ALLOC_PTR, Caml_state_var(young_ptr)
     /* Save exception pointer (if e.g. a sighandler raises) */
-        stg     TRAP_PTR, Caml_state(exception_pointer)
+        stg     TRAP_PTR, Caml_state_var(exception_pointer)
     /* Save all registers used by the code generator */
         addi    11, 1, 8*32 + PARAM_SAVE_AREA + RESERVED_STACK - WORD
         stgu    3, WORD(11)
@@ -241,7 +241,7 @@ FUNCTION(caml_call_gc)
         nop
 #endif
     /* Reload new allocation pointer */
-        lg      ALLOC_PTR, Caml_state(young_ptr)
+        lg      ALLOC_PTR, Caml_state_var(young_ptr)
     /* Restore all regs used by the code generator */
         addi    11, 1, 8*32 + PARAM_SAVE_AREA + RESERVED_STACK - WORD
         lgu     3, WORD(11)
@@ -300,7 +300,7 @@ FUNCTION(caml_call_gc)
         lfdu    30, 8(11)
         lfdu    31, 8(11)
     /* Return to caller, resuming the allocation */
-        lg      11, Caml_state(last_return_address)
+        lg      11, Caml_state_var(last_return_address)
         mtlr    11
     /* For PPC64: restore the TOC that the caller saved at the usual place */
 #ifdef TOC_SAVE
@@ -320,11 +320,11 @@ FUNCTION(caml_c_call)
         mflr    C_CALL_RET_ADDR
         .cfi_register 65, C_CALL_RET_ADDR
     /* Record lowest stack address and return address */
-        stg     1, Caml_state(bottom_of_stack)
-        stg     C_CALL_RET_ADDR, Caml_state(last_return_address)
+        stg     1, Caml_state_var(bottom_of_stack)
+        stg     C_CALL_RET_ADDR, Caml_state_var(last_return_address)
     /* Make the exception handler and alloc ptr available to the C code */
-        stg     ALLOC_PTR, Caml_state(young_ptr)
-        stg     TRAP_PTR, Caml_state(exception_pointer)
+        stg     ALLOC_PTR, Caml_state_var(young_ptr)
+        stg     TRAP_PTR, Caml_state_var(exception_pointer)
     /* Call C function (address in C_CALL_FUN) */
 #if defined(MODEL_ppc)
         mtctr   C_CALL_FUN
@@ -348,7 +348,7 @@ FUNCTION(caml_c_call)
     /* Restore return address (in 27, preserved by the C function) */
         mtlr    C_CALL_RET_ADDR
     /* Reload allocation pointer*/
-        lg      ALLOC_PTR, Caml_state(young_ptr)
+        lg      ALLOC_PTR, Caml_state_var(young_ptr)
     /* Return to caller */
         blr
         .cfi_endproc
@@ -357,7 +357,7 @@ ENDFUNCTION(caml_c_call)
 /* Raise an exception from OCaml */
 
 FUNCTION(caml_raise_exn)
-        lg      0, Caml_state(backtrace_active)
+        lg      0, Caml_state_var(backtrace_active)
         cmpwi   0, 0
         bne     .L111
 .L110:
@@ -391,13 +391,13 @@ FUNCTION(caml_raise_exception)
     /* Load domain state pointer */
         mr      DOMAIN_STATE_PTR, 3
         mr      3, 4
-        lg      0, Caml_state(backtrace_active)
+        lg      0, Caml_state_var(backtrace_active)
         cmpwi   0, 0
         bne     .L121
 .L120:
     /* Reload OCaml global registers */
-        lg      1, Caml_state(exception_pointer)
-        lg      ALLOC_PTR, Caml_state(young_ptr)
+        lg      1, Caml_state_var(exception_pointer)
+        lg      ALLOC_PTR, Caml_state_var(young_ptr)
     /* Pop trap frame */
         lg      0, TRAP_HANDLER_OFFSET(1)
         mtctr   0
@@ -408,9 +408,9 @@ FUNCTION(caml_raise_exception)
 .L121:
         mr      27, 3           /* preserve exn bucket in callee-save reg */
                                 /* arg1: exception bucket, already in r3 */
-        lg      4, Caml_state(last_return_address) /* arg2: PC of raise */
-        lg      5, Caml_state(bottom_of_stack)     /* arg3: SP of raise */
-        lg      6, Caml_state(exception_pointer)   /* arg4: SP of handler */
+        lg      4, Caml_state_var(last_return_address) /* arg2: PC of raise */
+        lg      5, Caml_state_var(bottom_of_stack)     /* arg3: SP of raise */
+        lg      6, Caml_state_var(exception_pointer)   /* arg4: SP of handler */
         addi    1, 1, -(PARAM_SAVE_AREA + RESERVED_STACK)
                                          /* reserve stack space for C call */
         bl      caml_stash_backtrace
@@ -484,11 +484,11 @@ FUNCTION(caml_start_program)
     /* Load domain state pointer from argument */
         mr      DOMAIN_STATE_PTR, START_PRG_DOMAIN_STATE_PTR
     /* Set up a callback link */
-        lg      11, Caml_state(bottom_of_stack)
+        lg      11, Caml_state_var(bottom_of_stack)
         stg     11, CALLBACK_LINK_OFFSET(1)
-        lg      11, Caml_state(last_return_address)
+        lg      11, Caml_state_var(last_return_address)
         stg     11, (CALLBACK_LINK_OFFSET + WORD)(1)
-        lg      11, Caml_state(gc_regs)
+        lg      11, Caml_state_var(gc_regs)
         stg     11, (CALLBACK_LINK_OFFSET + 2 * WORD)(1)
     /* Build an exception handler to catch exceptions escaping out of OCaml */
         bl      .L103
@@ -498,11 +498,11 @@ FUNCTION(caml_start_program)
         .cfi_adjust_cfa_offset TRAP_SIZE
         mflr    0
         stg     0, TRAP_HANDLER_OFFSET(1)
-        lg      11, Caml_state(exception_pointer)
+        lg      11, Caml_state_var(exception_pointer)
         stg     11, TRAP_PREVIOUS_OFFSET(1)
         mr      TRAP_PTR, 1
     /* Reload allocation pointer */
-        lg      ALLOC_PTR, Caml_state(young_ptr)
+        lg      ALLOC_PTR, Caml_state_var(young_ptr)
     /* Call the OCaml code (address in r12) */
 #if defined(MODEL_ppc)
         mtctr   12
@@ -524,19 +524,19 @@ FUNCTION(caml_start_program)
 #endif
     /* Pop the trap frame, restoring caml_exception_pointer */
         lg      0, TRAP_PREVIOUS_OFFSET(1)
-        stg     0, Caml_state(exception_pointer)
+        stg     0, Caml_state_var(exception_pointer)
         addi    1, 1, TRAP_SIZE
         .cfi_adjust_cfa_offset -TRAP_SIZE
     /* Pop the callback link, restoring the global variables */
 .L106:
         lg      0, CALLBACK_LINK_OFFSET(1)
-        stg     0, Caml_state(bottom_of_stack)
+        stg     0, Caml_state_var(bottom_of_stack)
         lg      0, (CALLBACK_LINK_OFFSET + WORD)(1)
-        stg     0, Caml_state(last_return_address)
+        stg     0, Caml_state_var(last_return_address)
         lg      0, (CALLBACK_LINK_OFFSET + 2 * WORD)(1)
-        stg     0, Caml_state(gc_regs)
+        stg     0, Caml_state_var(gc_regs)
     /* Update allocation pointer */
-        stg     ALLOC_PTR, Caml_state(young_ptr)
+        stg     ALLOC_PTR, Caml_state_var(young_ptr)
     /* Restore callee-save registers */
         addi    11, 1, CALLBACK_LINK_SIZE + RESERVED_STACK - WORD
         lgu     14, WORD(11)
@@ -589,7 +589,7 @@ FUNCTION(caml_start_program)
         ld      2, (STACKSIZE + TOC_SAVE_PARENT)(1)
 #endif
     /* Update caml_exception_pointer */
-        stg     TRAP_PTR, Caml_state(exception_pointer)
+        stg     TRAP_PTR, Caml_state_var(exception_pointer)
     /* Encode exception bucket as an exception result and return it */
         ori     3, 3, 2
         b       .L106

--- a/runtime/riscv.S
+++ b/runtime/riscv.S
@@ -49,7 +49,7 @@
 #include "../runtime/caml/domain_state.tbl"
 #undef DOMAIN_STATE
 
-#define Caml_state(var) (8*domain_field_caml_##var)(DOMAIN_STATE_PTR)
+#define Caml_state_var(var) (8*domain_field_caml_##var)(DOMAIN_STATE_PTR)
 
 #define FUNCTION(name) \
         .align 2; \
@@ -79,9 +79,9 @@ caml_system__code_begin:
 FUNCTION(caml_call_gc)
 .Lcaml_call_gc:
         /* Record return address */
-        STORE   ra, Caml_state(last_return_address)
+        STORE   ra, Caml_state_var(last_return_address)
         /* Record lowest stack address */
-        STORE   sp, Caml_state(bottom_of_stack)
+        STORE   sp, Caml_state_var(bottom_of_stack)
         /* Set up stack space, saving return address */
         /* (1 reg for RA, 1 reg for FP, 23 allocatable int regs,
             20 caller-save float regs) * 8 */
@@ -139,11 +139,11 @@ FUNCTION(caml_call_gc)
         fsd     ft11, 0x168(sp)
         /* Store pointer to saved integer registers in caml_gc_regs */
         addi    TMP, sp, 0x10
-        STORE   TMP, Caml_state(gc_regs)
+        STORE   TMP, Caml_state_var(gc_regs)
         /* Save current allocation pointer for debugging purposes */
-        STORE   ALLOC_PTR, Caml_state(young_ptr)
+        STORE   ALLOC_PTR, Caml_state_var(young_ptr)
         /* Save trap pointer in case an exception is raised during GC */
-        STORE   TRAP_PTR, Caml_state(exception_pointer)
+        STORE   TRAP_PTR, Caml_state_var(exception_pointer)
         /* Call the garbage collector */
         call    PLT(caml_garbage_collection)
         /* Restore registers */
@@ -191,7 +191,7 @@ FUNCTION(caml_call_gc)
         fld     ft10, 0x160(sp)
         fld     ft11, 0x168(sp)
         /* Reload new allocation pointer */
-        LOAD    ALLOC_PTR, Caml_state(young_ptr)
+        LOAD    ALLOC_PTR, Caml_state_var(young_ptr)
         /* Free stack space and return to caller */
         LOAD    ra, 0x8(sp)
         addi    sp, sp, 0x170
@@ -207,15 +207,15 @@ FUNCTION(caml_c_call)
         mv      s2, ra
         CFI_REGISTER(ra, s2)
         /* Record lowest stack address and return address */
-        STORE   ra, Caml_state(last_return_address)
-        STORE   sp, Caml_state(bottom_of_stack)
+        STORE   ra, Caml_state_var(last_return_address)
+        STORE   sp, Caml_state_var(bottom_of_stack)
         /* Make the exception handler alloc ptr available to the C code */
-        STORE   ALLOC_PTR, Caml_state(young_ptr)
-        STORE   TRAP_PTR, Caml_state(exception_pointer)
+        STORE   ALLOC_PTR, Caml_state_var(young_ptr)
+        STORE   TRAP_PTR, Caml_state_var(exception_pointer)
         /* Call the function */
         jalr    ARG
         /* Reload alloc ptr */
-        LOAD    ALLOC_PTR, Caml_state(young_ptr)
+        LOAD    ALLOC_PTR, Caml_state_var(young_ptr)
         /* Return */
         jr      s2
 END_FUNCTION(caml_c_call)
@@ -223,7 +223,7 @@ END_FUNCTION(caml_c_call)
 /* Raise an exception from OCaml */
 FUNCTION(caml_raise_exn)
         /* Test if backtrace is active */
-        LOAD    TMP, Caml_state(backtrace_active)
+        LOAD    TMP, Caml_state_var(backtrace_active)
         bnez    TMP, 2f
 1:      /* Cut stack at current trap handler */
         mv      sp, TRAP_PTR
@@ -253,9 +253,9 @@ END_FUNCTION(caml_raise_exn)
 FUNCTION(caml_raise_exception)
         mv      DOMAIN_STATE_PTR, a0
         mv      a0, a1
-        LOAD    TRAP_PTR, Caml_state(exception_pointer)
-        LOAD    ALLOC_PTR, Caml_state(young_ptr)
-        LOAD    TMP, Caml_state(backtrace_active)
+        LOAD    TRAP_PTR, Caml_state_var(exception_pointer)
+        LOAD    ALLOC_PTR, Caml_state_var(young_ptr)
+        LOAD    TMP, Caml_state_var(backtrace_active)
         bnez    TMP, 2f
 1:      /* Cut stack at current trap handler */
         mv      sp, TRAP_PTR
@@ -266,8 +266,8 @@ FUNCTION(caml_raise_exception)
         jr      TMP
 2:      /* Preserve exception bucket in callee-save register s2 */
         mv      s2, a0
-        LOAD    a1, Caml_state(last_return_address)
-        LOAD    a2, Caml_state(bottom_of_stack)
+        LOAD    a1, Caml_state_var(last_return_address)
+        LOAD    a2, Caml_state_var(bottom_of_stack)
         mv      a3, TRAP_PTR
         call    PLT(caml_stash_backtrace)
         mv      a0, s2
@@ -317,39 +317,39 @@ FUNCTION(caml_start_program)
         /* Load domain state pointer from argument */
         mv      DOMAIN_STATE_PTR, ARG_DOMAIN_STATE_PTR
         /* Setup a callback link on the stack */
-        LOAD    TMP, Caml_state(bottom_of_stack)
+        LOAD    TMP, Caml_state_var(bottom_of_stack)
         STORE   TMP, 0(sp)
-        LOAD    TMP, Caml_state(last_return_address)
+        LOAD    TMP, Caml_state_var(last_return_address)
         STORE   TMP, 8(sp)
-        LOAD    TMP, Caml_state(gc_regs)
+        LOAD    TMP, Caml_state_var(gc_regs)
         STORE   TMP, 16(sp)
         /* set up a trap frame */
         addi    sp, sp, -16
         CFI_ADJUST(16)
-        LOAD    TMP, Caml_state(exception_pointer)
+        LOAD    TMP, Caml_state_var(exception_pointer)
         STORE   TMP, 0(sp)
         lla     TMP, .Ltrap_handler
         STORE   TMP, 8(sp)
         mv      TRAP_PTR, sp
-        LOAD    ALLOC_PTR, Caml_state(young_ptr)
-        STORE   x0, Caml_state(last_return_address)
+        LOAD    ALLOC_PTR, Caml_state_var(young_ptr)
+        STORE   x0, Caml_state_var(last_return_address)
         jalr    ARG
 .Lcaml_retaddr:         /* pop trap frame, restoring caml_exception_pointer */
         LOAD    TMP, 0(sp)
-        STORE   TMP, Caml_state(exception_pointer)
+        STORE   TMP, Caml_state_var(exception_pointer)
         addi    sp, sp, 16
         CFI_ADJUST(-16)
 .Lreturn_result:        /* pop callback link, restoring global variables */
         LOAD    TMP, 0(sp)
-        STORE   TMP, Caml_state(bottom_of_stack)
+        STORE   TMP, Caml_state_var(bottom_of_stack)
         LOAD    TMP, 8(sp)
-        STORE   TMP, Caml_state(last_return_address)
+        STORE   TMP, Caml_state_var(last_return_address)
         LOAD    TMP, 16(sp)
-        STORE   TMP, Caml_state(gc_regs)
+        STORE   TMP, Caml_state_var(gc_regs)
         addi    sp, sp, 32
         CFI_ADJUST(-32)
         /* Update allocation pointer */
-        STORE   ALLOC_PTR, Caml_state(young_ptr)
+        STORE   ALLOC_PTR, Caml_state_var(young_ptr)
         /* reload callee-save registers and return */
         LOAD    ra, 0xc0(sp)
         LOAD    s0, 0x0(sp)
@@ -386,7 +386,7 @@ END_FUNCTION(caml_start_program)
         .align  2
 .Ltrap_handler:
         CFI_STARTPROC
-        STORE   TRAP_PTR, Caml_state(exception_pointer)
+        STORE   TRAP_PTR, Caml_state_var(exception_pointer)
         ori     a0, a0, 2
         j       .Lreturn_result
         .type   .Ltrap_handler, @function

--- a/runtime/s390x.S
+++ b/runtime/s390x.S
@@ -32,7 +32,7 @@
 #include "../runtime/caml/domain_state.tbl"
 #undef DOMAIN_STATE
 
-#define Caml_state(var) 8*domain_field_caml_##var(%r10)
+#define Caml_state_var(var) 8*domain_field_caml_##var(%r10)
 
         .section ".text"
 
@@ -48,17 +48,17 @@ caml_call_gc:
 #define FRAMESIZE (16*8 + 16*8)
         lay     %r15, -FRAMESIZE(%r15)
     /* Record return address into OCaml code */
-        stg     %r14, Caml_state(last_return_address)
+        stg     %r14, Caml_state_var(last_return_address)
     /* Record lowest stack address */
         lay     %r0, FRAMESIZE(%r15)
-        stg     %r0, Caml_state(bottom_of_stack)
+        stg     %r0, Caml_state_var(bottom_of_stack)
     /* Record pointer to register array */
         lay     %r0, (8*16)(%r15)
-        stg     %r0, Caml_state(gc_regs)
+        stg     %r0, Caml_state_var(gc_regs)
     /* Save current allocation pointer for debugging purposes */
-        stg     %r11, Caml_state(young_ptr)
+        stg     %r11, Caml_state_var(young_ptr)
     /* Save exception pointer (if e.g. a sighandler raises) */
-        stg     %r13, Caml_state(exception_pointer)
+        stg     %r13, Caml_state_var(exception_pointer)
     /* Save all registers used by the code generator */
         stmg    %r2,%r9, (8*16)(%r15)
         stg     %r12, (8*16 + 8*8)(%r15)
@@ -84,7 +84,7 @@ caml_call_gc:
         brasl   %r14, caml_garbage_collection@PLT
         lay     %r15, 160(%r15)
     /* Reload new allocation pointer */
-        lg      %r11, Caml_state(young_ptr)
+        lg      %r11, Caml_state_var(young_ptr)
     /* Restore all regs used by the code generator */
         lmg     %r2,%r9, (8*16)(%r15)
         lg      %r12, (8*16 + 8*8)(%r15)
@@ -105,7 +105,7 @@ caml_call_gc:
         ld      %f14, 112(%r15)
         ld      %f15, 120(%r15)
     /* Return to caller */
-        lg      %r1, Caml_state(last_return_address)
+        lg      %r1, Caml_state_var(last_return_address)
     /* Deallocate stack frame */
         lay     %r15, FRAMESIZE(%r15)
     /* Return */
@@ -116,22 +116,22 @@ caml_call_gc:
         .globl  caml_c_call
         .type   caml_c_call, @function
 caml_c_call:
-        stg     %r15, Caml_state(bottom_of_stack)
+        stg     %r15, Caml_state_var(bottom_of_stack)
 .L101:
     /* Save return address */
         ldgr    %f15, %r14
     /* Get ready to call C function (address in r7) */
     /* Record lowest stack address and return address */
-        stg     %r14, Caml_state(last_return_address)
+        stg     %r14, Caml_state_var(last_return_address)
     /* Make the exception handler and alloc ptr available to the C code */
-        stg     %r11, Caml_state(young_ptr)
-        stg     %r13, Caml_state(exception_pointer)
+        stg     %r11, Caml_state_var(young_ptr)
+        stg     %r13, Caml_state_var(exception_pointer)
     /* Call the function */
         basr %r14, %r7
     /* restore return address */
         lgdr    %r14,%f15
     /* Reload allocation pointer */
-        lg      %r11, Caml_state(young_ptr)
+        lg      %r11, Caml_state_var(young_ptr)
     /* Return to caller */
         br %r14
 
@@ -139,7 +139,7 @@ caml_c_call:
         .globl  caml_raise_exn
         .type   caml_raise_exn, @function
 caml_raise_exn:
-        lg      %r0, Caml_state(backtrace_active)
+        lg      %r0, Caml_state_var(backtrace_active)
         cgfi    %r0, 0
         jne     .L110
 .L111:
@@ -169,13 +169,13 @@ caml_raise_exn:
 caml_raise_exception:
         lgr     %r10, %r2       /* Load domain state pointer */
         lgr     %r2, %r3        /* Move exception bucket to arg1 register */
-        lg      %r0, Caml_state(backtrace_active)
+        lg      %r0, Caml_state_var(backtrace_active)
         cgfi    %r0, 0
         jne    .L112
 .L113:
     /* Reload OCaml global registers */
-        lg      %r15, Caml_state(exception_pointer)
-        lg      %r11, Caml_state(young_ptr)
+        lg      %r15, Caml_state_var(exception_pointer)
+        lg      %r11, Caml_state_var(young_ptr)
     /* Pop trap frame */
         lg      %r1, 0(%r15)
         lg      %r13, 8(%r15)
@@ -185,9 +185,9 @@ caml_raise_exception:
 .L112:
         ldgr    %f15,%r2        /* preserve exn bucket in callee-save reg */
                                 /* arg1: exception bucket, already in r2 */
-        lg      %r3, Caml_state(last_return_address) /* arg2: PC of raise */
-        lg      %r4, Caml_state(bottom_of_stack)     /* arg3: SP of raise */
-        lg      %r5, Caml_state(exception_pointer)   /* arg4: SP of handler */
+        lg      %r3, Caml_state_var(last_return_address) /*arg2: PC of raise*/
+        lg      %r4, Caml_state_var(bottom_of_stack)     /*arg3: SP of raise*/
+        lg      %r5, Caml_state_var(exception_pointer)   /*arg4: SP of handler*/
     /* reserve stack space for C call */
         lay     %r15, -160(%r15)
         brasl   %r14, caml_stash_backtrace@PLT
@@ -225,11 +225,11 @@ caml_start_program:
         lgr     %r10, %r1
     /* Set up a callback link */
         lay     %r15, -32(%r15)
-        lg      %r1, Caml_state(bottom_of_stack)
+        lg      %r1, Caml_state_var(bottom_of_stack)
         stg     %r1, 0(%r15)
-        lg      %r1, Caml_state(last_return_address)
+        lg      %r1, Caml_state_var(last_return_address)
         stg     %r1, 8(%r15)
-        lg      %r1, Caml_state(gc_regs)
+        lg      %r1, Caml_state_var(gc_regs)
         stg     %r1, 16(%r15)
     /* Build an exception handler to catch exceptions escaping out of OCaml */
         brasl   %r14, .L103
@@ -237,31 +237,31 @@ caml_start_program:
 .L103:
         lay     %r15, -16(%r15)
         stg     %r14, 0(%r15)
-        lg      %r1, Caml_state(exception_pointer)
+        lg      %r1, Caml_state_var(exception_pointer)
         stg     %r1, 8(%r15)
         lgr     %r13, %r15
     /* Reload allocation pointer */
-        lg      %r11, Caml_state(young_ptr)
+        lg      %r11, Caml_state_var(young_ptr)
     /* Call the OCaml code */
         lgr     %r1,%r0
         basr    %r14, %r1
 .L105:
     /* Pop the trap frame, restoring caml_exception_pointer */
         lg      %r0, 8(%r15)
-        stg     %r0, Caml_state(exception_pointer)
+        stg     %r0, Caml_state_var(exception_pointer)
         la      %r15, 16(%r15)
     /* Pop the callback link, restoring the global variables */
 .L106:
         lg      %r5, 0(%r15)
         lg      %r6, 8(%r15)
         lg      %r0, 16(%r15)
-        stg     %r5, Caml_state(bottom_of_stack)
-        stg     %r6, Caml_state(last_return_address)
-        stg     %r0, Caml_state(gc_regs)
+        stg     %r5, Caml_state_var(bottom_of_stack)
+        stg     %r6, Caml_state_var(last_return_address)
+        stg     %r0, Caml_state_var(gc_regs)
         la      %r15, 32(%r15)
 
     /* Update allocation pointer */
-        stg     %r11, Caml_state(young_ptr)
+        stg     %r11, Caml_state_var(young_ptr)
 
     /* Restore registers */
         lmg     %r6,%r14, 0(%r15)
@@ -281,7 +281,7 @@ caml_start_program:
     /* The trap handler: */
 .L104:
     /* Update caml_exception_pointer */
-        stg     %r13, Caml_state(exception_pointer)
+        stg     %r13, Caml_state_var(exception_pointer)
     /* Encode exception bucket as an exception result and return it */
         oill     %r2,  2
         j       .L106
@@ -331,7 +331,7 @@ caml_callback3_asm:
 caml_ml_array_bound_error:
         /* Save return address before decrementing SP, otherwise
            the frame descriptor for the call site is not correct */
-        stg     %r15, Caml_state(bottom_of_stack)
+        stg     %r15, Caml_state_var(bottom_of_stack)
         lay     %r15, -160(%r15)    /* Reserve stack space for C call */
         Addrglobal(%r7, caml_array_bound_error)
         j       .L101


### PR DESCRIPTION
Since Android requires position independent code with the security feature [Text Relocations (Enforced for API level >= 23)](https://android.googlesource.com/platform/bionic/+/master/android-changes-for-ndk-developers.md#text-relocations-enforced-for-api-level-23) | ([permalink](https://android.googlesource.com/platform/bionic/+/e2c784f15912115f778e427f0ce9a21189a3b494/android-changes-for-ndk-developers.md#text-relocations-enforced-for-api-level-23)) the existing arm32 native code fails to run on Android when using API 23+.

Android does officially support [32bit ARM: armeabi-v7a](https://developer.android.com/ndk/guides/abis#sa). You'll get an "Illegal Instruction" running native OCaml code (ex. in the Android Emulator) in the following absolute relocations of `arm.S`:

```assembly
        ldr     r12, =caml_program

        ldr     domain_state_ptr, =Caml_state

        ldr     r5, =.Ltrap_handler

        ldr     r12, =caml_apply2

        ldr     r12, =caml_apply3

        ldr     r7, =caml_array_bound_error
````

To make PIC code both 1) absolute relocations have to be removed and 2) the indirection of PLT needs to be used for external functions.

This PR does that in `arm.S` if and only if `__PIC__` is defined.

The [original commit Merge the new ARM backend into trunk (PR#5433)](https://github.com/ocaml/ocaml/commit/05627e0de4a50067f36d1eca9dcc9ebd5736c3f8) that introduced PIC code for ARM did not fully complete the PIC transition (aka. make a 100% position independent executable) because although the OCaml compiler emitted code was PIC compliant, it still used absolute relocations in the glue code `arm.S`. For example https://github.com/ocaml/ocaml/blame/cb9826b1322a64a6f760de287848b73c7e429ee5/asmrun/arm.S#L161:

```assembly
        ldr     r12, =caml_young_limit
```

---

Tested was a bit complicated; I used a [4.12.1 cross-compilation apparatus](https://gitlab.com/diskuv/diskuv-ocaml/-/blob/next/installtime/unix/private/reproducible-compile-ocaml-1-setup.sh) to cross an Ubuntu Linux build machine with an 32-bit ARM Android Emulator host machine. I also used lldb + lldb-server to step through the runtime code (arm.S) and generated code for verification. At the end I was able to build and run:

```ocaml
let () = print_endline "Hello World!"
```

with `ocamlopt.opt hello_world.ml -o hello_world.armeabi-v7a.opt.exe`.

> I suspect this PR will be sitting for a while waiting for the Multicore OCaml code freeze. When this passes a sniff test from a core dev I'll update the cross-compiler apparatus from 4.12.1 to whatever the latest OCaml is, and then do another retest.

The basic OCaml configuration was Android NDK 23 toolchain with NDK's GNU AS for the assembler and NDK's clang compiler for C. All flags you see below come from the toolchain (I added `-g3` and `-fdebug-macro` for debugging, and `-Wl,--fix-cortex-a8` since it was recommended).

```sh
AR="$HOME/Android/Sdk/ndk/23.1.7779620/toolchains/llvm/prebuilt/linux-x86_64/bin/llvm-ar" \
AS="$HOME/Android/Sdk/ndk/23.1.7779620/toolchains/llvm/prebuilt/linux-x86_64/bin/arm-linux-androideabi-as -g" \
ASPP="$HOME/Android/Sdk/ndk/23.1.7779620/toolchains/llvm/prebuilt/linux-x86_64/bin/clang --target=armv7-none-linux-androideabi21  -fPIE -fPIC -DANDROID -fdata-sections -ffunction-sections -funwind-tables -fstack-protector-strong -no-canonical-prefixes -D_FORTIFY_SOURCE=2 -march=armv7-a -mthumb -mfpu=vfpv3-d16 -Wformat -Werror=format-security -fexceptions -g3 -g  -fno-limit-debug-info -c -fdebug-macro" \
CC="$HOME/Android/Sdk/ndk/23.1.7779620/toolchains/llvm/prebuilt/linux-x86_64/bin/clang --target=armv7-none-linux-androideabi21 --sysroot=$HOME/Android/Sdk/ndk/23.1.7779620/toolchains/llvm/prebuilt/linux-x86_64/sysroot" \
CFLAGS=" -fPIE -fPIC -DANDROID -fdata-sections -ffunction-sections -funwind-tables -fstack-protector-strong -no-canonical-prefixes -D_FORTIFY_SOURCE=2 -march=armv7-a -mthumb -mfpu=vfpv3-d16 -Wformat -Werror=format-security -fexceptions -g3 -g  -fno-limit-debug-info" \
CPP="$HOME/Android/Sdk/ndk/23.1.7779620/toolchains/llvm/prebuilt/linux-x86_64/bin/clang --target=armv7-none-linux-androideabi21 --sysroot=$HOME/Android/Sdk/ndk/23.1.7779620/toolchains/llvm/prebuilt/linux-x86_64/sysroot -E" \
DIRECT_LD="$HOME/Android/Sdk/ndk/23.1.7779620/toolchains/llvm/prebuilt/linux-x86_64/bin/ld.lld" \
LD="$HOME/Android/Sdk/ndk/23.1.7779620/toolchains/llvm/prebuilt/linux-x86_64/bin/ld.lld" \
LDFLAGS=" -fPIE -pie -Wl,--fix-cortex-a8" \
NM="$HOME/Android/Sdk/ndk/23.1.7779620/toolchains/llvm/prebuilt/linux-x86_64/bin/llvm-nm" \
OBJDUMP="$HOME/Android/Sdk/ndk/23.1.7779620/toolchains/llvm/prebuilt/linux-x86_64/bin/llvm-objdump" \
RANLIB="$HOME/Android/Sdk/ndk/23.1.7779620/toolchains/llvm/prebuilt/linux-x86_64/bin/llvm-ranlib" \
RANLIBCMD="$HOME/Android/Sdk/ndk/23.1.7779620/toolchains/llvm/prebuilt/linux-x86_64/bin/llvm-ranlib" \
STRIP="$HOME/Android/Sdk/ndk/23.1.7779620/toolchains/llvm/prebuilt/linux-x86_64/bin/llvm-strip" \
./configure \
    --prefix "/tmp/$(git rev-parse --abbrev-ref HEAD)" \
    --with-sysroot="$HOME/Android/Sdk/ndk/23.1.7779620/toolchains/llvm/prebuilt/linux-x86_64/sysroot" \
    --host=armv7-none-linux-androideabi21 \
    --disable-ocamldoc
```
