### PR TITLE
change domain thread name setting to be more portable and best-effort

### DIFF
--- a/runtime/caml/misc.h
+++ b/runtime/caml/misc.h
@@ -536,8 +536,8 @@ extern int caml_snwprintf(wchar_t * buf,
 #define snprintf_os snprintf
 #endif
 
-/* platform dependent thread naming */
-extern int caml_thread_setname(const char* name);
+/* platform dependent best-effort thread naming */
+extern void caml_thread_setname(const char* name);
 
 /* Macro used to deactivate thread and address sanitizers on some
    functions. */

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -677,7 +677,7 @@ static void* backup_thread_func(void* v)
   domain_self = di;
   SET_Caml_state((void*)(di->tls_area));
 
-  caml_domain_set_name("BackupThread");
+  caml_domain_set_name("Backup");
 
   CAML_EVENTLOG_IS_BACKUP_THREAD();
 

--- a/runtime/win32.c
+++ b/runtime/win32.c
@@ -1093,16 +1093,11 @@ CAMLexport clock_t caml_win32_clock(void)
   return (clock_t)(total / clocks_per_sec);
 }
 
-int caml_thread_setname(const char* name)
+void caml_thread_setname(const char* name)
 {
-  int ret;
   /* XXX Duplicates unix.c, but MSVC will add some specific code here */
   pthread_t self = pthread_self();
-
-  ret = pthread_setname_np(self, name);
-  if (ret == ERANGE)
-    return -1;
-  return 0;
+  pthread_setname_np(self, name);
 }
 
 static LARGE_INTEGER frequency;


### PR DESCRIPTION
- change caml_set_domain_name to best-effort and a void return
- shorten backup thread name to just "Backup" to avoid hitting the
  15-character limit when domain ids are appended
- add cases for *BSD permutations of the functions

There is an unfortunate portability mess around setting pthread names, so we now use the various permutations on FreeBSD and OpenBSD (which require another header include as well) and NetBSD (which is similar to Linux, but with a different error code set).

The code previously used GNU_SOURCE to detect Linux, which isnt much use as GNU_SOURCE is unconditionally defined at the top of unix.c, so we just assume that the 'default' platform is Linux. pthread_setname_np is only defined in glibc 2.12 or higher, but looking for that specifically makes it complex to also detect musl, so it's simplest to leave it as the default case.

Since setting the thread name is always best-effort and used for debugging, there are no new configure tests added.

Fixes #10870 and FreeBSD/amd64 passes the test suite with this change. OpenBSD now builds but requires more runtime fixes (to follow). 