### PR TITLE
Fixup Filename.check_suffix; remove duplicate ',' fix for OCAMLRUNPARAM

### DIFF
--- a/runtime/startup_aux.c
+++ b/runtime/startup_aux.c
@@ -119,7 +119,6 @@ void caml_parse_ocamlrunparam(void)
       case 'W': scanmult (opt, &caml_runtime_warnings); break;
       case ',': continue;
       }
-      --opt; /* to handle patterns like ",b=1" */
       while (*opt != '\0'){
         if (*opt++ == ',') break;
       }

--- a/stdlib/filename.ml
+++ b/stdlib/filename.ml
@@ -100,9 +100,7 @@ module Unix : SYSDEPS = struct
     && (String.length n < 2 || String.sub n 0 2 <> "./")
     && (String.length n < 3 || String.sub n 0 3 <> "../")
   let check_suffix name suff =
-    String.length name >= String.length suff &&
-    String.sub name (String.length name - String.length suff)
-                    (String.length suff) = suff
+    String.ends_with ~suffix:suff name
 
   let chop_suffix_opt ~suffix filename =
     let len_s = String.length suffix and len_f = String.length filename in

--- a/testsuite/tests/lib-string/test_string.ml
+++ b/testsuite/tests/lib-string/test_string.ml
@@ -52,4 +52,16 @@ let ()  =
     while !sz <= 0 do push big l; sz += Sys.max_string_length done;
     try ignore (String.concat "" !l); assert false
     with Invalid_argument _ -> ();
+    assert(String.starts_with ~prefix:"foob" "foobarbaz");
+    assert(String.starts_with ~prefix:"" "foobarbaz");
+    assert(String.starts_with ~prefix:"" "");
+    assert(not (String.starts_with ~prefix:"foobar" "bar"));
+    assert(not (String.starts_with ~prefix:"foo" ""));
+    assert(not (String.starts_with ~prefix:"fool" "foobar"));
+    assert(String.ends_with ~suffix:"baz" "foobarbaz");
+    assert(String.ends_with ~suffix:"" "foobarbaz");
+    assert(String.ends_with ~suffix:"" "");
+    assert(not (String.ends_with ~suffix:"foobar" "bar"));
+    assert(not (String.ends_with ~suffix:"foo" ""));
+    assert(not (String.ends_with ~suffix:"obaz" "foobar"));
   end


### PR DESCRIPTION
This PR tidies up unfinished business from @damiendoligez's review of #10831:
 - `Filename.check_suffix` unintended revert: https://github.com/ocaml/ocaml/pull/10831#discussion_r780265037
 - `caml_parse_ocamlrunparam` duplicate fix for empty `,` in OCAMLRUNPARAM:  https://github.com/ocaml/ocaml/pull/10831#discussion_r780248981
 
 For those interested in the archeology of this:
  - The `Filename.check_suffix` change was introduced with ddb1b5e, but then reverted in the 4.12 release with 226b3a8. Multicore ended up not backing out 226b3a8 when rebasing to trunk from 4.12. This PR fixes the mistake. 
  - Two competing fixes for `,` in OCAMLRUNPARAM were introduced 79870cd1 (multicore) and c0440d81 (trunk). Git happily allowed both to co-exist. This PR takes the (trunk) implementation.
 