### PR TITLE
Use a bit-vector to record pending signals

### DIFF
--- a/otherlibs/unix/signals.c
+++ b/otherlibs/unix/signals.c
@@ -25,13 +25,6 @@
 #include <caml/signals.h>
 #include "unixsupport.h"
 
-#ifndef NSIG
-#define NSIG 65
-#endif
-
-#define BITS_PER_WORD (sizeof(uintnat) * 8)
-#define NSIG_WORDS ((NSIG - 1 + BITS_PER_WORD - 1) / BITS_PER_WORD)
-
 #ifdef POSIX_SIGNALS
 
 static void decode_sigset(value vset, sigset_t * set)

--- a/otherlibs/unix/signals.c
+++ b/otherlibs/unix/signals.c
@@ -26,11 +26,11 @@
 #include "unixsupport.h"
 
 #ifndef NSIG
-#define NSIG 64
+#define NSIG 65
 #endif
 
 #define BITS_PER_WORD (sizeof(uintnat) * 8)
-#define NSIG_WORDS ((NSIG + BITS_PER_WORD - 1) / BITS_PER_WORD)
+#define NSIG_WORDS ((NSIG - 1 + BITS_PER_WORD - 1) / BITS_PER_WORD)
 
 #ifdef POSIX_SIGNALS
 
@@ -91,7 +91,7 @@ CAMLprim value unix_sigpending(value unit)
     if (curr == 0) continue;
     for (j = 0; j < BITS_PER_WORD; j++) {
       if (curr & ((uintnat)1 << j))
-      sigaddset(&pending, i * BITS_PER_WORD + j);
+      sigaddset(&pending, i * BITS_PER_WORD + j + 1);
     }
   }
   return encode_sigset(&pending);

--- a/otherlibs/unix/signals.c
+++ b/otherlibs/unix/signals.c
@@ -29,6 +29,9 @@
 #define NSIG 64
 #endif
 
+#define BITS_PER_WORD (sizeof(uintnat) * 8)
+#define NSIG_WORDS ((NSIG + BITS_PER_WORD - 1) / BITS_PER_WORD)
+
 #ifdef POSIX_SIGNALS
 
 static void decode_sigset(value vset, sigset_t * set)
@@ -80,11 +83,17 @@ CAMLprim value unix_sigprocmask(value vaction, value vset)
 CAMLprim value unix_sigpending(value unit)
 {
   sigset_t pending;
-  int i;
+  int i, j;
+  uintnat curr;
   if (sigpending(&pending) == -1) uerror("sigpending", Nothing);
-  for (i = 1; i < NSIG; i++)
-    if(atomic_load_explicit(&caml_pending_signals[i], memory_order_seq_cst))
-      sigaddset(&pending, i);
+  for (i = 0; i < NSIG_WORDS; i++) {
+    curr = atomic_load(&caml_pending_signals[i]);
+    if (curr == 0) continue;
+    for (j = 0; j < BITS_PER_WORD; j++) {
+      if (curr & ((uintnat)1 << j))
+      sigaddset(&pending, i * BITS_PER_WORD + j);
+    }
+  }
   return encode_sigset(&pending);
 }
 

--- a/runtime/caml/camlatomic.h
+++ b/runtime/caml/camlatomic.h
@@ -75,6 +75,8 @@ typedef struct { intnat repr; } atomic_intnat;
   __atomic_exchange_n(&(x)->repr, (newv), memory_order_seq_cst)
 #define atomic_fetch_add(x, n) \
   __atomic_fetch_add(&(x)->repr, (n), memory_order_seq_cst)
+#define atomic_fetch_or(x, n) \
+  __atomic_fetch_or(&(x)->repr, (n), memory_order_seq_cst)
 #define atomic_thread_fence __atomic_thread_fence
 
 #else

--- a/runtime/caml/platform.h
+++ b/runtime/caml/platform.h
@@ -23,7 +23,6 @@
 #include <string.h>
 #include "config.h"
 #include "mlvalues.h"
-#include "signals.h"
 
 #if defined(MAP_ANON) && !defined(MAP_ANONYMOUS)
 #define MAP_ANONYMOUS MAP_ANON

--- a/runtime/caml/signals.h
+++ b/runtime/caml/signals.h
@@ -41,7 +41,7 @@ CAMLextern int caml_check_pending_actions (void);
 /* Returns 1 if there are pending actions, 0 otherwise. */
 
 #ifdef CAML_INTERNALS
-CAMLextern atomic_intnat caml_pending_signals[];
+CAMLextern atomic_uintnat caml_pending_signals[];
 
 /* Global variables moved to Caml_state in 4.10 */
 #define caml_requested_major_slice (Caml_state_field(requested_major_slice))

--- a/runtime/caml/signals.h
+++ b/runtime/caml/signals.h
@@ -16,8 +16,8 @@
 #ifndef CAML_SIGNALS_H
 #define CAML_SIGNALS_H
 
-#if defined(CAML_INTERNALS) && defined(POSIX_SIGNALS)
-#include<signal.h>
+#if defined(CAML_INTERNALS)
+#include <signal.h>
 #endif
 
 #include "misc.h"
@@ -41,7 +41,15 @@ CAMLextern int caml_check_pending_actions (void);
 /* Returns 1 if there are pending actions, 0 otherwise. */
 
 #ifdef CAML_INTERNALS
-CAMLextern atomic_uintnat caml_pending_signals[];
+
+#ifndef NSIG
+#define NSIG 65
+#endif
+
+#define BITS_PER_WORD (sizeof(uintnat) * 8)
+#define NSIG_WORDS ((NSIG - 1 + BITS_PER_WORD - 1) / BITS_PER_WORD)
+
+CAMLextern atomic_uintnat caml_pending_signals[NSIG_WORDS];
 
 /* Global variables moved to Caml_state in 4.10 */
 #define caml_requested_major_slice (Caml_state_field(requested_major_slice))

--- a/runtime/signals.c
+++ b/runtime/signals.c
@@ -33,13 +33,6 @@
 #include "caml/memprof.h"
 #include "caml/finalise.h"
 
-#ifndef NSIG
-#define NSIG 65
-#endif
-
-#define BITS_PER_WORD (sizeof(uintnat) * 8)
-#define NSIG_WORDS ((NSIG - 1 + BITS_PER_WORD - 1) / BITS_PER_WORD)
-
 /* The set of pending signals (received but not yet processed).
    It is represented as a bit vector.
    Valid signal numbers range from 1 to NSIG - 1 included.

--- a/runtime/signals.c
+++ b/runtime/signals.c
@@ -46,7 +46,13 @@ static caml_plat_mutex signal_install_mutex = CAML_PLAT_MUTEX_INITIALIZER;
 int caml_check_for_pending_signals(void)
 {
   int i;
-
+  /* [MM] This fence compensates for the fact that Caml_check_gc_interrupt
+     reads young_limit non-atomically.  It is possible in theory to
+     see young_limit updated without caml_pending_signals being set
+     and then resetting young_limit after the check.  This would delay
+     processing the pending signal until young_limit is updated again.
+     There may be nicer ways to address this scenario. */
+  atomic_thread_fence(memory_order_acquire);
   for (i = 0; i < NSIG_WORDS; i++) {
     if (atomic_load_explicit(&caml_pending_signals[i], memory_order_relaxed))
       return 1;

--- a/runtime/signals.c
+++ b/runtime/signals.c
@@ -51,7 +51,7 @@ int caml_check_for_pending_signals(void)
   int i;
 
   for (i = 0; i < NSIG_WORDS; i++) {
-    if (atomic_load_explicit(&caml_pending_signals[i], memory_order_seq_cst))
+    if (atomic_load_explicit(&caml_pending_signals[i], memory_order_relaxed))
       return 1;
   }
   return 0;
@@ -78,7 +78,8 @@ CAMLexport value caml_process_pending_signals_exn(void)
 #endif
 
   for (i = 0; i < NSIG_WORDS; i++) {
-    curr = atomic_load(&caml_pending_signals[i]);
+    curr = atomic_load_explicit(&caml_pending_signals[i],
+                                memory_order_relaxed);
     if (curr == 0) goto next_word;
     /* Scan curr for bits set */
     for (j = 0; j < BITS_PER_WORD; j++) {
@@ -98,7 +99,8 @@ CAMLexport value caml_process_pending_signals_exn(void)
       if (Is_exception_result(exn)) return exn;
       /* curr probably changed during the evaluation of the signal handler;
          refresh it from memory */
-      curr = atomic_load(&caml_pending_signals[i]);
+      curr = atomic_load_explicit(&caml_pending_signals[i],
+                                  memory_order_relaxed);
       if (curr == 0) goto next_word;
     next_bit: /* skip */;
     }

--- a/runtime/signals_byt.c
+++ b/runtime/signals_byt.c
@@ -27,10 +27,6 @@
 #include "caml/signals.h"
 #include "caml/signals_machdep.h"
 
-#ifndef NSIG
-#define NSIG 64
-#endif
-
 #ifdef _WIN32
 typedef void (*sighandler)(int sig);
 extern sighandler caml_win32_signal(int sig, sighandler action);
@@ -45,7 +41,6 @@ static void handle_signal(int signal_number)
 #if !defined(POSIX_SIGNALS) && !defined(BSD_SIGNALS)
   signal(signal_number, handle_signal);
 #endif
-  if (signal_number < 0 || signal_number >= NSIG) return;
   caml_record_signal(signal_number);
   errno = saved_errno;
 }

--- a/runtime/signals_nat.c
+++ b/runtime/signals_nat.c
@@ -37,10 +37,6 @@
 #include "signals_osdep.h"
 #include "caml/stack.h"
 
-#ifndef NSIG
-#define NSIG 64
-#endif
-
 typedef void (*signal_handler)(int signo);
 
 #ifdef _WIN32
@@ -131,7 +127,6 @@ DECLARE_SIGNAL_HANDLER(handle_signal)
 #if !defined(POSIX_SIGNALS) && !defined(BSD_SIGNALS)
   signal(sig, handle_signal);
 #endif
-  if (sig < 0 || sig >= NSIG) return;
   caml_record_signal(sig);
   errno = saved_errno;
 }

--- a/runtime/sync.c
+++ b/runtime/sync.c
@@ -25,6 +25,7 @@
 #include "caml/fail.h"
 #include "caml/memory.h"
 
+#include "caml/signals.h"
 #include "caml/sync.h"
 #include "caml/eventlog.h"
 


### PR DESCRIPTION
Currently, we use an array of `NSIG` atomic 0-or-1 integers to record the presence of pending signals.

This PR uses an array of bits instead, encoded as an array of `ceil (NSIG / BITS_PER_WORD)` atomic words.

Linux has `NSIG` = 65 and macOS has `NSIG` = 32, so we end up with one or two atomic words that can be tested very efficiently. 

In turn, this results in a major (x 2) speedup in the bytecode interpreter.  See the profiles below for a run of the test suite.
