### PR TITLE
Fix build for mingw-w64 on Jenkins

### DIFF
--- a/tools/ci/inria/main
+++ b/tools/ci/inria/main
@@ -176,6 +176,8 @@ case "${OCAML_ARCH}" in
     instdir='C:/ocamlmgw64'
     cleanup=true
     check_make_alldepend=true
+    # This is needed until the winpthreads support is implemented directly
+    export PATH="$PATH:/usr/x86_64-w64-mingw32/sys-root/mingw/bin"
   ;;
   msvc)
     build='--build=i686-pc-cygwin'


### PR DESCRIPTION
winpthread-1.dll is required for the time being - this sets the PATH for it.

One test is failing - IIRC something changed 25 Oct when it was still on ocaml-multicore/ocaml-multicore but it's probably quicker just to debug it now, rather than bisect.