### PR TITLE
win32unix: fix inheritance of accept sockets

### DIFF
--- a/Changes
+++ b/Changes
@@ -278,6 +278,11 @@ Working version
   instead of `value`.
   (Xavier Leroy, review by David Allsopp)
 
+- #10885: On Windows, change the inheritance bit (close-on-exec /
+  keep-on-exec) on sockets returned by `accept` only if needed, and
+  duplicate the socket instead of calling `SetHandleInformation`.
+  (Antonin Décimo, review by Nicolás Ojeda Bär)
+
 ### Tools:
 
 - #12340: testsuite: collect known issues with current -short-paths

--- a/otherlibs/unix/dup_win32.c
+++ b/otherlibs/unix/dup_win32.c
@@ -34,7 +34,7 @@ static HANDLE duplicate_handle(BOOL inherit, HANDLE oldh)
   return newh;
 }
 
-static SOCKET duplicate_socket(BOOL inherit, SOCKET oldsock)
+SOCKET caml_win32_duplicate_socket(BOOL inherit, SOCKET oldsock)
 {
   WSAPROTOCOL_INFO info;
 
@@ -64,8 +64,8 @@ CAMLprim value caml_unix_dup(value cloexec, value fd)
     CAMLreturn(newfd);
   }
   case KIND_SOCKET: {
-    SOCKET newsock = duplicate_socket(! caml_unix_cloexec_p(cloexec),
-                                      Socket_val(fd));
+    SOCKET newsock = caml_win32_duplicate_socket(! caml_unix_cloexec_p(cloexec),
+                                                 Socket_val(fd));
     if (newsock == INVALID_SOCKET)
       caml_uerror("dup", Nothing);
     newfd = caml_win32_alloc_socket(newsock);
@@ -96,8 +96,8 @@ CAMLprim value caml_unix_dup2(value cloexec, value fd1, value fd2)
   }
   case KIND_SOCKET: {
     SOCKET oldsock = Socket_val(fd2),
-      newsock = duplicate_socket(! caml_unix_cloexec_p(cloexec),
-                                 Socket_val(fd1));
+      newsock = caml_win32_duplicate_socket(! caml_unix_cloexec_p(cloexec),
+                                            Socket_val(fd1));
     if (newsock == INVALID_SOCKET)
       caml_uerror("dup2", Nothing);
     Socket_val(fd2) = newsock;


### PR DESCRIPTION
By default, sockets returned by `accept` and `WSAAccept` seem to be
non-inheritable (close-on-exec) (but those returned by `socket` and
`WSASocket` are inheritable!). Testing shows that behaviour, but where
is it documented?

We used to call `SetHandleInformation` to set the inheritance bit of
the socket, but it may error with `ERROR_INVALID_HANDLE` in some
cases. It's better to duplicate the socket to set the correct
inheritance. We only need to duplicate it when the requested
inheritance differs from the new socket.

This PR awaits the merge of a previous PR. It should consist only of the
last commit after rebase.
- [x] #10809