### PR TITLE
generalize the Domain.DLS interface to split PRNG state for child domains

### DIFF
--- a/stdlib/.depend
+++ b/stdlib/.depend
@@ -213,22 +213,23 @@ stdlib__Digest.cmx : digest.ml \
     stdlib__Digest.cmi
 stdlib__Digest.cmi : digest.mli
 stdlib__Domain.cmo : domain.ml \
-    stdlib__Sys.cmi \
     stdlib.cmi \
     stdlib__Obj.cmi \
     stdlib__Mutex.cmi \
+    stdlib__Lazy.cmi \
     stdlib__Atomic.cmi \
     stdlib__Array.cmi \
     stdlib__Domain.cmi
 stdlib__Domain.cmx : domain.ml \
-    stdlib__Sys.cmx \
     stdlib.cmx \
     stdlib__Obj.cmx \
     stdlib__Mutex.cmx \
+    stdlib__Lazy.cmx \
     stdlib__Atomic.cmx \
     stdlib__Array.cmx \
     stdlib__Domain.cmi
-stdlib__Domain.cmi : domain.mli
+stdlib__Domain.cmi : domain.mli \
+    stdlib__Lazy.cmi
 stdlib__EffectHandlers.cmo : effectHandlers.ml \
     stdlib__Printexc.cmi \
     stdlib__Obj.cmi \

--- a/stdlib/.depend
+++ b/stdlib/.depend
@@ -213,23 +213,24 @@ stdlib__Digest.cmx : digest.ml \
     stdlib__Digest.cmi
 stdlib__Digest.cmi : digest.mli
 stdlib__Domain.cmo : domain.ml \
+    stdlib__Sys.cmi \
     stdlib.cmi \
     stdlib__Obj.cmi \
     stdlib__Mutex.cmi \
-    stdlib__Lazy.cmi \
+    stdlib__List.cmi \
     stdlib__Atomic.cmi \
     stdlib__Array.cmi \
     stdlib__Domain.cmi
 stdlib__Domain.cmx : domain.ml \
+    stdlib__Sys.cmx \
     stdlib.cmx \
     stdlib__Obj.cmx \
     stdlib__Mutex.cmx \
-    stdlib__Lazy.cmx \
+    stdlib__List.cmx \
     stdlib__Atomic.cmx \
     stdlib__Array.cmx \
     stdlib__Domain.cmi
-stdlib__Domain.cmi : domain.mli \
-    stdlib__Lazy.cmi
+stdlib__Domain.cmi : domain.mli
 stdlib__EffectHandlers.cmo : effectHandlers.ml \
     stdlib__Printexc.cmi \
     stdlib__Obj.cmi \

--- a/stdlib/domain.mli
+++ b/stdlib/domain.mli
@@ -80,6 +80,11 @@ module DLS : sig
 
         If [split_from_parent] is provided, spawning a domain will derive the
         child value (for this key) from the parent value.
+
+        Note that the [split_from_parent] call is computed in the parent
+        domain, and is always computed regardless of whether the child domain
+        will use it. If the splitting function is expensive or requires
+        client-side computation, consider using ['a Lazy.t key].
     *)
 
     val get : 'a key -> 'a

--- a/stdlib/domain.mli
+++ b/stdlib/domain.mli
@@ -74,18 +74,29 @@ module DLS : sig
     type 'a key
     (** Type of a DLS key *)
 
-    val new_key : (unit -> 'a) -> 'a key
+    val new_key : ?split_from_parent:('a -> 'a Lazy.t) -> (unit -> 'a) -> 'a key
     (** [new_key f] returns a new key bound to initialiser [f] for accessing
-        domain-local variable. *)
+        domain-local variables.
 
-    val set : 'a key -> 'a -> unit
-    (** [set k v] updates the calling domain's domain-local state to associate
-        the key [k] with value [v]. It overwrites any previous values associated
-        to [k], which cannot be restored later. *)
+        If [split_from_parent] is provided, spawning a domain will derive the
+        child value (for this key) from the parent value. The parent calls
+        [split_from_parent], the child forces the resulting lazy thunk.
+    *)
+
+    val init : 'a key -> unit
+    (** [init k] ensures that the value corresponding to the key [k]
+        in the domain's domain-local state is initialized: it is
+        a no-op if [k] already has a value in the domain, and calls the
+        initialiser of [k] otherwise. *)
 
     val get : 'a key -> 'a
     (** [get k] returns [v] if a value [v] is associated to the key [k] on
         the calling domain's domain-local state. Sets [k]'s value with its
         initialiser and returns it otherwise. *)
+
+    val set : 'a key -> 'a -> unit
+    (** [set k v] updates the calling domain's domain-local state to associate
+        the key [k] with value [v]. It overwrites any previous values associated
+        to [k], which cannot be restored later. *)
 
   end

--- a/stdlib/domain.mli
+++ b/stdlib/domain.mli
@@ -74,20 +74,13 @@ module DLS : sig
     type 'a key
     (** Type of a DLS key *)
 
-    val new_key : ?split_from_parent:('a -> 'a Lazy.t) -> (unit -> 'a) -> 'a key
+    val new_key : ?split_from_parent:('a -> 'a) -> (unit -> 'a) -> 'a key
     (** [new_key f] returns a new key bound to initialiser [f] for accessing
         domain-local variables.
 
         If [split_from_parent] is provided, spawning a domain will derive the
-        child value (for this key) from the parent value. The parent calls
-        [split_from_parent], the child forces the resulting lazy thunk.
+        child value (for this key) from the parent value.
     *)
-
-    val init : 'a key -> unit
-    (** [init k] ensures that the value corresponding to the key [k]
-        in the domain's domain-local state is initialized: it is
-        a no-op if [k] already has a value in the domain, and calls the
-        initialiser of [k] otherwise. *)
 
     val get : 'a key -> 'a
     (** [get k] returns [v] if a value [v] is associated to the key [k] on

--- a/stdlib/filename.ml
+++ b/stdlib/filename.ml
@@ -326,7 +326,8 @@ let remove_extension name =
 external open_desc: string -> open_flag list -> int -> int = "caml_sys_open"
 external close_desc: int -> unit = "caml_sys_close"
 
-let prng_key = Domain.DLS.new_key Random.State.make_self_init
+let prng_key =
+  Domain.DLS.new_key Random.State.make_self_init
 
 let temp_file_name temp_dir prefix suffix =
   let random_state = Domain.DLS.get prng_key in

--- a/stdlib/random.ml
+++ b/stdlib/random.ml
@@ -194,7 +194,7 @@ module State = struct
 
   let split st =
     let seed = Array.init 4 (fun _i -> bits st) in
-    lazy (make seed)
+    make seed
 end
 
 (* This is the state you get with [init 27182818] and then applying

--- a/stdlib/random.ml
+++ b/stdlib/random.ml
@@ -215,7 +215,8 @@ let mk_default () = {
   State.idx = 0;
 }
 
-let random_key = Domain.DLS.new_key mk_default
+let random_key =
+  Domain.DLS.new_key ~split_from_parent:State.split mk_default
 
 let bits () = State.bits (Domain.DLS.get random_key)
 let int bound = State.int (Domain.DLS.get random_key) bound

--- a/stdlib/random.ml
+++ b/stdlib/random.ml
@@ -192,6 +192,9 @@ module State = struct
     then fun s -> Nativeint.of_int32 (bits32 s)
     else fun s -> Int64.to_nativeint (bits64 s)
 
+  let split st =
+    let seed = Array.init 4 (fun _i -> bits st) in
+    lazy (make seed)
 end
 
 (* This is the state you get with [init 27182818] and then applying

--- a/stdlib/random.mli
+++ b/stdlib/random.mli
@@ -121,7 +121,7 @@ module State : sig
   val copy : t -> t
   (** Return a copy of the given state. *)
 
-  val split : t -> t Lazy.t
+  val split : t -> t
   (** Splits the PRNG state, returning a supposedly-independent state.
       (The current state advances immediately,
        but effect-free initialization of the split state is performed lazily.)

--- a/stdlib/random.mli
+++ b/stdlib/random.mli
@@ -121,6 +121,15 @@ module State : sig
   val copy : t -> t
   (** Return a copy of the given state. *)
 
+  val split : t -> t Lazy.t
+  (** Splits the PRNG state, returning a supposedly-independent state.
+      (The current state advances immediately,
+       but effect-free initialization of the split state is performed lazily.)
+
+      Note: with the current PRNG algorithm, we do not expect splitting to have
+      good statistical properties.
+  *)
+
   val bits : t -> int
   val int : t -> int -> int
   val full_int : t -> int -> int

--- a/testsuite/tests/gc-roots/globroots.ml
+++ b/testsuite/tests/gc-roots/globroots.ml
@@ -30,7 +30,10 @@ module Test(G: GLOBREF) () = struct
 
   let size = 1024
 
-  let random_state = Domain.DLS.new_key Random.State.make_self_init
+  let random_state =
+    Domain.DLS.new_key
+      ~split_from_parent:Random.State.split
+      Random.State.make_self_init
 
   let vals = Array.init size Int.to_string
 

--- a/testsuite/tests/lib-random/parallel.ml
+++ b/testsuite/tests/lib-random/parallel.ml
@@ -1,0 +1,42 @@
+(* TEST
+   include unix
+   * libunix
+   ** bytecode
+   ** native
+ *)
+
+let () = Random.init 42
+
+let domain_count = 10
+
+let delays =
+  (* These Random calls are intentionally:
+   - taken from an independent Random state, not the global state we are testing
+   - initialized with make_self_init, to return different delays on each tst run
+  *)
+  let delay_rng = Random.State.make_self_init () in
+  List.init domain_count (fun _i -> Random.State.float delay_rng 0.5)
+
+(* Each domain will start by waiting a random amount, to ensure that
+   the Random.int functions we are testing execute in
+   non-deterministic order. The Random.int result should remain
+   deterministic, as domains are spawned in a determinstic order and
+   each domain state is obtaind by splitting the global Random state
+   that was initialized with a fixed seed. *)
+let f delay () =
+  Unix.sleepf delay;
+  let a = Random.int 100 in
+  let b = Random.int 100 in
+  let c = Random.int 100 in
+  (a, b, c)
+
+let () =
+  delays
+  |> List.map (fun delay -> Domain.spawn (f delay))
+  |> List.map Domain.join
+  |> List.iter (fun (a, b, c) -> Printf.printf "%d %d %d\n%!" a b c)
+
+let () =
+  print_endline
+    "Note: the result of this test is currently BROKEN,\n\
+     the random numbers produced by child domain are highly correlated."

--- a/testsuite/tests/lib-random/parallel.ml
+++ b/testsuite/tests/lib-random/parallel.ml
@@ -38,5 +38,5 @@ let () =
 
 let () =
   print_endline
-    "Note: the result of this test is currently BROKEN,\n\
-     the random numbers produced by child domain are highly correlated."
+    "Note: we observe in this output that the random numbers of each child domain\n\
+     appear uncorrelated, yet are produced deterministically."

--- a/testsuite/tests/lib-random/parallel.reference
+++ b/testsuite/tests/lib-random/parallel.reference
@@ -1,12 +1,12 @@
-44 85 82
-44 85 82
-44 85 82
-44 85 82
-44 85 82
-44 85 82
-44 85 82
-44 85 82
-44 85 82
-44 85 82
-Note: the result of this test is currently BROKEN,
-the random numbers produced by child domain are highly correlated.
+31 7 82
+20 86 99
+3 74 67
+73 1 53
+15 48 91
+48 37 72
+54 68 47
+43 2 60
+41 29 67
+39 43 91
+Note: we observe in this output that the random numbers of each child domain
+appear uncorrelated, yet are produced deterministically.

--- a/testsuite/tests/lib-random/parallel.reference
+++ b/testsuite/tests/lib-random/parallel.reference
@@ -1,0 +1,12 @@
+44 85 82
+44 85 82
+44 85 82
+44 85 82
+44 85 82
+44 85 82
+44 85 82
+44 85 82
+44 85 82
+44 85 82
+Note: the result of this test is currently BROKEN,
+the random numbers produced by child domain are highly correlated.

--- a/testsuite/tests/weak-ephe-final/weaklifetime_par.ml
+++ b/testsuite/tests/weak-ephe-final/weaklifetime_par.ml
@@ -3,7 +3,10 @@
 
 let size = 1000;;
 let num_domains = 4;;
-let random_state = Domain.DLS.new_key Random.State.make_self_init
+let random_state =
+  Domain.DLS.new_key
+    ~split_from_parent:Random.State.split
+    Random.State.make_self_init
 
 let random_int = Random.State.int (Domain.DLS.get random_state)
 


### PR DESCRIPTION
This PR intends to demonstrate an approach to implement a "proper" PRNG+Domains semantics where spawning a domain "splits" the PRNG state. This required changes to the Domain.DLS interface to support domain-local values that are "inherited" from the parent/spawning domain, with a user-provided function to derive the child state from the parent state.

(The PRNG "split" function implemented in this PR is naive and probably bad, or at least not suspected to be any good, the intent is to replace it with a proper splittable PRNG, see https://github.com/ocaml/ocaml/issues/10877, https://github.com/ocaml/RFCs/pull/28, https://github.com/ocaml/ocaml/pull/10742 )

Note: this PR was initially submitted at https://github.com/ocaml-multicore/ocaml-multicore/pull/756 , but did not receive feedback from Multicore devs yet. I am re-submitting upstream now that the Multicore tree has been merged.

Some parts of the code are from @xavierleroy.

cc: people who have worked on Domain: @kayceesrk, @ctk21, @Sudha247, @Engil