### PR TITLE
re-enable afl-instrumentation test, run without a virtual memory limit (#10864)

### DIFF
--- a/manual/src/cmds/afl-fuzz.etex
+++ b/manual/src/cmds/afl-fuzz.etex
@@ -68,6 +68,9 @@ Next, we run the program under afl-fuzz:
 mkdir input
 echo asdf > input/testcase
 mkdir output
-afl-fuzz -i input -o output ./readline
+afl-fuzz -m none -i input -o output ./readline
 \end{verbatim}
 By inspecting instrumentation output, the fuzzer finds the crashing input quickly.
+
+Note: To fuzz-test an OCaml program with afl-fuzz, passing the option {\tt -m none}
+is required to disable afl-fuzz's default 50MB virtual memory limit.

--- a/runtime/afl.c
+++ b/runtime/afl.c
@@ -115,7 +115,7 @@ CAMLexport value caml_setup_afl(value unit)
   afl_read();
 
   /* ensure that another module has not already spawned a domain */
-  if (!caml_domain_is_multicore())
+  if (caml_domain_is_multicore())
     caml_fatal_error("afl-fuzz: cannot fork with multiple domains running");
 
   while (1) {

--- a/testsuite/tests/afl-instrumentation/afltest.ml
+++ b/testsuite/tests/afl-instrumentation/afltest.ml
@@ -1,10 +1,4 @@
 (* TEST (* Just a test-driver *)
-   * skip
-     reason = "See https://github.com/ocaml/ocaml/issues/10864"
-*)
-
-(* The previous test, to be reinstated later *)
-(*
    * native-compiler
    ** script
        script = "sh ${test_source_directory}/has-afl-showmap.sh"

--- a/testsuite/tests/afl-instrumentation/afltest.run
+++ b/testsuite/tests/afl-instrumentation/afltest.run
@@ -11,8 +11,8 @@ echo "running $NTESTS tests..."
 for t in `seq 1 $NTESTS`; do
   printf "%14s: " `./test name $t`
   # when run twice, the instrumentation output should double
-  afl-showmap -q -o output-1 -- ./test 1 $t
-  afl-showmap -q -o output-2 -- ./test 2 $t
+  afl-showmap -m none -q -o output-1 -- ./test 1 $t
+  afl-showmap -m none -q -o output-2 -- ./test 2 $t
   # see afl-showmap.c for what the numbers mean
   cat output-1 | sed '
     s/:6/:7/; s/:5/:6/;


### PR DESCRIPTION
This PR re-enables the afl-instrumentation tests for trunk/5.00 as described in #10864.

By default `afl-fuzz` runs a test program as a child process with only 50MB of virtual memory, which is insufficient for multicore.
A fix is thus to raise this limit or remove it with `-m none`. This PR goes for the latter.

I can include an update to the manual if the fix is OK.