### PR TITLE
removing unused OCAMLRUNPARAM parameters from the code and from the manual

### DIFF
--- a/manual/src/cmds/runtime.etex
+++ b/manual/src/cmds/runtime.etex
@@ -117,11 +117,6 @@ The following environment variables are also consulted:
  section~\ref{Gc}.
 \fi
   \begin{options}
-  \item[a] ("allocation_policy")
-        The policy used for allocating in the OCaml heap. Possible values
-        are "0" for the next-fit policy, "1" for the first-fit
-        policy, and "2" for the best-fit policy. The default is "2" (best-fit).
-        See the Gc module documentation for details.
   \item[b] (backtrace) Trigger the printing of a stack backtrace
         when an uncaught exception aborts the program. An optional argument can
         be provided: "b=0" turns backtrace printing off; "b=1" is equivalent to
@@ -134,12 +129,6 @@ The following environment variables are also consulted:
         "caml_shutdown" in section~\ref{ss:c-embedded-code}). The option also enables
         pooling (as in "caml_startup_pooled"). This mode can be used to detect
         leaks with a third-party memory debugger.
-  \item[h] The initial size of the major heap (in words).
-  \item[H] Allocate heap chunks by mmapping huge pages. Huge pages are locked into
-        memory, and are not swapped.
-  \item[i] ("major_heap_increment")  Default size increment for the
-        major heap. (in words if greater than 1000, else in percents of the 
-        head size)
   \item[l] ("stack_limit") The limit (in words) of the stack size. This is only
         relevant to the byte-code runtime, as the native code runtime uses the
         operating system's stack.
@@ -169,7 +158,6 @@ The following environment variables are also consulted:
         $2^{20}$, and $2^{30}$ respectively.
   \item[o] ("space_overhead")  The major GC speed setting.
         See the Gc module documentation for details.
-  \item[O] ("max_overhead")  The heap compaction trigger setting.
   \item[p] (parser trace) Turn on debugging support for
         "ocamlyacc"-generated parsers.  When this option is on,
         the pushdown automaton that executes the parsers prints a
@@ -200,9 +188,6 @@ The following environment variables are also consulted:
         \item[512 (= 0x200)] Computation of compaction-triggering condition.
         \item[1024 (= 0x400)] Output GC statistics at program exit.
   \end{options}
-  \item[w] ("window_size") Set the size of the window used by major GC for smoothing out 
-    variations in its workload. This is an integer between 1 and 50. 
-    (Default: 1)
   \item[W] Print runtime warnings to stderr (such as Channel opened on file 
     dies without being closed, unflushed data, etc.)
 

--- a/manual/src/cmds/runtime.etex
+++ b/manual/src/cmds/runtime.etex
@@ -188,6 +188,8 @@ The following environment variables are also consulted:
         \item[512 (= 0x200)] Computation of compaction-triggering condition.
         \item[1024 (= 0x400)] Output GC statistics at program exit.
   \end{options}
+  \item[V] ("verify_heap") runs an integrity check on the heap just after
+    the completion of a major GC cycle
   \item[W] Print runtime warnings to stderr (such as Channel opened on file 
     dies without being closed, unflushed data, etc.)
 

--- a/runtime/caml/config.h
+++ b/runtime/caml/config.h
@@ -229,28 +229,11 @@ typedef uint64_t uintnat;
    Must be a multiple of [Page_size / sizeof (value)]. */
 #define Heap_chunk_min (15 * Page_size)
 
-/* Default size increment when growing the heap.
-   If this is <= 1000, it's a percentage of the current heap size.
-   If it is > 1000, it's a number of words. */
-#define Heap_chunk_def 15
-
-/* Default initial size of the major heap (words);
-   Must be a multiple of [Page_size / sizeof (value)]. */
-#define Init_heap_def (31 * Page_size)
-/* (about 512 kB for a 32-bit platform, 1 MB for a 64-bit platform.) */
-
 
 /* Default speed setting for the major GC.  The heap will grow until
    the dead objects and the free list represent this percentage of the
    total size of live objects. */
 #define Percent_free_def 120
-
-/* Default setting for the compacter: 500%
-   (i.e. trigger the compacter when 5/6 of the heap is free or garbage)
-   This can be set quite high because the overhead is over-estimated
-   when fragmentation occurs.
- */
-#define Max_percent_free_def 500
 
 /* Maximum number of domains */
 #define Max_domains 128

--- a/runtime/caml/memory.h
+++ b/runtime/caml/memory.h
@@ -180,8 +180,6 @@ CAMLextern wchar_t* caml_stat_wcsconcat(int n, ...);
 
 #ifdef CAML_INTERNALS
 
-extern uintnat caml_use_huge_pages;
-
 #ifdef HAS_HUGE_PAGES
 #include <sys/mman.h>
 #define Heap_page_size HUGE_PAGE_SIZE

--- a/runtime/caml/startup_aux.h
+++ b/runtime/caml/startup_aux.h
@@ -42,10 +42,7 @@ struct caml_params {
   uintnat print_config;
 
   uintnat init_percent_free;
-  uintnat init_max_percent_free;
   uintnat init_minor_heap_wsz;
-  uintnat init_heap_chunk_sz;
-  uintnat init_heap_wsz;
   uintnat init_custom_major_ratio;
   uintnat init_custom_minor_ratio;
   uintnat init_custom_minor_max_bsz;

--- a/runtime/caml/startup_aux.h
+++ b/runtime/caml/startup_aux.h
@@ -48,7 +48,6 @@ struct caml_params {
   uintnat init_custom_minor_max_bsz;
 
   uintnat init_max_stack_wsz;
-  uintnat init_fiber_wsz;
 
   uintnat backtrace_enabled;
   uintnat runtime_warnings;

--- a/runtime/caml/startup_aux.h
+++ b/runtime/caml/startup_aux.h
@@ -36,7 +36,6 @@ struct caml_params {
   uintnat verb_gc;
   uintnat parser_trace;
   uintnat trace_level;
-  uintnat eventlog_enabled;
   uintnat verify_heap;
   uintnat print_magic;
   uintnat print_config;

--- a/runtime/gc_ctrl.c
+++ b/runtime/gc_ctrl.c
@@ -285,7 +285,7 @@ CAMLprim value caml_get_minor_free (value v)
 void caml_init_gc (void)
 {
   caml_max_stack_size = caml_params->init_max_stack_wsz;
-  caml_fiber_wsz = caml_params->init_fiber_wsz;
+  caml_fiber_wsz = (Stack_threshold * 2) / sizeof(value);
   caml_percent_free = norm_pfree (caml_params->init_percent_free);
   caml_gc_log ("Initial stack limit: %"
                ARCH_INTNAT_PRINTF_FORMAT "uk bytes",

--- a/runtime/startup_aux.c
+++ b/runtime/startup_aux.c
@@ -93,7 +93,6 @@ void caml_parse_ocamlrunparam(void)
       switch (*opt++){
       case 'b': scanmult (opt, &params.backtrace_enabled); break;
       case 'c': scanmult (opt, &params.cleanup_on_exit); break;
-      case 'e': scanmult (opt, &params.eventlog_enabled); break;
       case 'l': scanmult (opt, &params.init_max_stack_wsz); break;
       case 'M': scanmult (opt, &params.init_custom_major_ratio); break;
       case 'm': scanmult (opt, &params.init_custom_minor_ratio); break;

--- a/runtime/startup_aux.c
+++ b/runtime/startup_aux.c
@@ -46,10 +46,7 @@ static void init_startup_params(void)
 #endif
 
   params.init_percent_free = Percent_free_def;
-  params.init_max_percent_free = Max_percent_free_def;
   params.init_minor_heap_wsz = Minor_heap_def;
-  params.init_heap_chunk_sz = Heap_chunk_def;
-  params.init_heap_wsz = Init_heap_def;
   params.init_custom_major_ratio = Custom_major_ratio_def;
   params.init_custom_minor_ratio = Custom_minor_ratio_def;
   params.init_custom_minor_max_bsz = Custom_minor_max_bsz_def;
@@ -95,27 +92,21 @@ void caml_parse_ocamlrunparam(void)
   if (opt != NULL){
     while (*opt != '\0'){
       switch (*opt++){
-      //case 'a': scanmult (opt, &p); caml_set_allocation_policy (p); break;
       case 'b': scanmult (opt, &params.backtrace_enabled); break;
       case 'c': scanmult (opt, &params.cleanup_on_exit); break;
       case 'e': scanmult (opt, &params.eventlog_enabled); break;
       case 'f': scanmult (opt, &params.init_fiber_wsz); break;
-      case 'h': scanmult (opt, &params.init_heap_wsz); break;
-      //case 'H': scanmult (opt, &caml_use_huge_pages); break;
-      case 'i': scanmult (opt, &params.init_heap_chunk_sz); break;
       case 'l': scanmult (opt, &params.init_max_stack_wsz); break;
       case 'M': scanmult (opt, &params.init_custom_major_ratio); break;
       case 'm': scanmult (opt, &params.init_custom_minor_ratio); break;
       case 'n': scanmult (opt, &params.init_custom_minor_max_bsz); break;
       case 'o': scanmult (opt, &params.init_percent_free); break;
-      case 'O': scanmult (opt, &params.init_max_percent_free); break;
       case 'p': scanmult (opt, &params.parser_trace); break;
       case 'R': break; /*  see stdlib/hashtbl.mli */
       case 's': scanmult (opt, &params.init_minor_heap_wsz); break;
       case 't': scanmult (opt, &params.trace_level); break;
       case 'v': scanmult (opt, &params.verb_gc); break;
       case 'V': scanmult (opt, &params.verify_heap); break;
-      //case 'w': scanmult (opt, &caml_init_major_window); break;
       case 'W': scanmult (opt, &caml_runtime_warnings); break;
       case ',': continue;
       }

--- a/runtime/startup_aux.c
+++ b/runtime/startup_aux.c
@@ -51,7 +51,6 @@ static void init_startup_params(void)
   params.init_custom_minor_ratio = Custom_minor_ratio_def;
   params.init_custom_minor_max_bsz = Custom_minor_max_bsz_def;
   params.init_max_stack_wsz = Max_stack_def;
-  params.init_fiber_wsz = (Stack_threshold * 2) / sizeof(value);
 #ifdef DEBUG
   params.verb_gc = 0x3F;
 #endif
@@ -95,7 +94,6 @@ void caml_parse_ocamlrunparam(void)
       case 'b': scanmult (opt, &params.backtrace_enabled); break;
       case 'c': scanmult (opt, &params.cleanup_on_exit); break;
       case 'e': scanmult (opt, &params.eventlog_enabled); break;
-      case 'f': scanmult (opt, &params.init_fiber_wsz); break;
       case 'l': scanmult (opt, &params.init_max_stack_wsz); break;
       case 'M': scanmult (opt, &params.init_custom_major_ratio); break;
       case 'm': scanmult (opt, &params.init_custom_minor_ratio); break;


### PR DESCRIPTION
Relating to ocaml-multicore/ocaml-multicore#794

backtrace_enabled: in use
cleanup_on_exit: in use
eventlog_enabled: in use
init_fiber_wsz: in use
init_heap_wsz: UNUSED
init_heap_chunk_sz: UNUSED
init_max_stack_wsz: in use 
init_custom_major_ratio: in use
init_custom_minor_ratio: in use
init_custom_minor_max_bsz: in use
init_percent_free: in use
init_max_percent_free: UNUSED
parser_trace: in use
init_minor_heap_wsz: in use
trace_level: in use
verb_gc: in use
verify_heap: in use
caml_runtime_warnings: in use

I found some options that were already commented out in 750e2123076d99bc5d04b323d8aa976a832eb74c and that have no implementation associated with them:
- caml_set_allocation_policy - has a manual entry
- caml_use_huge_pages - has a manual entry
- caml_init_major_window - has a manual entry

I noticed there are discrepancies between the names in the code and in the manual:
For example, `init_max_percent_free` has a manual entry `\item[O] ("max_overhead")`. I assume this is intentional.

- [x] remove the code associated with the unused parameters
- [x] update the manual chapter 13 `runtime.etex` to remove all unused parameters, including the ones that already had no implementation
- [x] remove `init_fiber_wsz` option

To discuss: do any of the removed options need to be reimplemented for multicore?