### PR TITLE
Free alternate signal stack on error

### DIFF
--- a/Changes
+++ b/Changes
@@ -39,7 +39,7 @@ OCaml 4.14.0
   (Xavier Leroy and David Allsopp, review by Sébastien Hinderer and
    Damien Doligez)
 
-- #10698, #10726: Free the alternate signal stack when the main OCaml
+- #10698, #10726, #10891: Free the alternate signal stack when the main OCaml
    code or an OCaml thread stops
   (Xavier Leroy, review by David Allsopp and Damien Doligez)
 

--- a/runtime/signals_nat.c
+++ b/runtime/signals_nat.c
@@ -333,10 +333,13 @@ CAMLexport int caml_setup_stack_overflow_detection(void)
   if (stk.ss_sp == NULL) return -1;
   stk.ss_size = SIGSTKSZ;
   stk.ss_flags = 0;
-  return sigaltstack(&stk, NULL);
-#else
-  return 0;
+  if (sigaltstack(&stk, NULL) == -1) {
+    free(stk.ss_sp);
+    return -1;
+  }
 #endif
+  /* Success (or stack overflow detection not available) */
+  return 0;
 }
 
 CAMLexport int caml_stop_stack_overflow_detection(void)


### PR DESCRIPTION
While double-checking the back-ports, I suddenly noticed that we don't free the memory allocated for the alternate signal stack if the `sigaltstack` call fails. A minor memory leak, but a leak nonetheless.

`caml_init_signal_stack` on trunk already does this: https://github.com/ocaml/ocaml/blob/750e2123076d99bc5d04b323d8aa976a832eb74c/runtime/signals.c#L358-L361