### PR TITLE
Use malloc/free for alternate signal stack

### DIFF
--- a/runtime/signals.c
+++ b/runtime/signals.c
@@ -351,6 +351,11 @@ int caml_init_signal_stack(void)
   stack_t stk;
   stk.ss_flags = 0;
   stk.ss_size = SIGSTKSZ;
+  /* The memory used for the alternate signal stack must not free'd before
+     calling sigaltstack with SS_DISABLE. malloc is therefore used rather
+     than caml_stat_alloc_noexc so that if a shutdown path erroneously fails
+     to call caml_free_signal_stack then we have a memory leak rather than a
+     nasty piece of undefined behaviour forced on the caller. */
   stk.ss_sp = malloc(stk.ss_size);
   if(stk.ss_sp == NULL) {
     return -1;
@@ -389,6 +394,7 @@ void caml_free_signal_stack(void)
   if (sigaltstack(&disable, &stk) < 0) {
     caml_fatal_error_arg("Failed to reset signal stack: %s", strerror(errno));
   }
+  /* Memory was allocated with malloc directly; see caml_init_signal_stack */
   free(stk.ss_sp);
 #endif
 }

--- a/runtime/signals.c
+++ b/runtime/signals.c
@@ -351,12 +351,12 @@ int caml_init_signal_stack(void)
   stack_t stk;
   stk.ss_flags = 0;
   stk.ss_size = SIGSTKSZ;
-  stk.ss_sp = caml_stat_alloc_noexc(stk.ss_size);
+  stk.ss_sp = malloc(stk.ss_size);
   if(stk.ss_sp == NULL) {
     return -1;
   }
   if (sigaltstack(&stk, NULL) < 0) {
-    caml_stat_free(stk.ss_sp);
+    free(stk.ss_sp);
     return -1;
   }
 
@@ -389,7 +389,7 @@ void caml_free_signal_stack(void)
   if (sigaltstack(&disable, &stk) < 0) {
     caml_fatal_error_arg("Failed to reset signal stack: %s", strerror(errno));
   }
-  caml_stat_free(stk.ss_sp);
+  free(stk.ss_sp);
 #endif
 }
 


### PR DESCRIPTION
Spotted while preparing #10891, the memory passed to `sigaltstack` in the trunk implementation is correctly freed on error, but the memory is allocated using `caml_stat_alloc_noexc`. The pooled runtime isn't appropriate here - the memory must never be freed without first calling `sigaltstack` to disable the alternate signal stack, so use `malloc`/`free` directly.