### PR TITLE
Expose fiber primitives for continuation cloning

### DIFF
--- a/runtime/caml/fiber.h
+++ b/runtime/caml/fiber.h
@@ -236,6 +236,8 @@ void caml_scan_stack(
   scanning_action f, scanning_action_flags fflags, void* fdata,
   struct stack_info* stack, value* v_gc_regs);
 
+struct stack_info* caml_alloc_stack_noexc(mlsize_t wosize, value hval,
+                                          value hexn, value heff, int64_t id);
 /* try to grow the stack until at least required_size words are available.
    returns nonzero on success */
 CAMLextern int caml_try_realloc_stack (asize_t required_wsize);
@@ -250,6 +252,9 @@ void caml_free_gc_regs_buckets(value *gc_regs_buckets);
 #ifdef NATIVE_CODE
 void caml_get_stack_sp_pc (struct stack_info* stack,
                            char** sp /* out */, uintnat* pc /* out */);
+void
+caml_rewrite_exception_stack(struct stack_info *old_stack,
+                             value** exn_ptr, struct stack_info *new_stack);
 #endif
 
 value caml_continuation_use (value cont);
@@ -259,6 +264,7 @@ value caml_continuation_use (value cont);
    between continuation_use and continuation_replace.
    Used for cloning continuations and continuation backtraces. */
 void caml_continuation_replace(value cont, struct stack_info* stack);
+
 
 #endif /* CAML_INTERNALS */
 

--- a/runtime/fiber.c
+++ b/runtime/fiber.c
@@ -185,9 +185,9 @@ alloc_size_class_stack_noexc(mlsize_t wosize, int cache_bucket, value hval,
 }
 
 /* allocate a stack with at least "wosize" usable words of stack */
-static struct stack_info*
-alloc_stack_noexc(mlsize_t wosize, value hval, value hexn, value heff,
-                  int64_t id)
+struct stack_info*
+caml_alloc_stack_noexc(mlsize_t wosize, value hval, value hexn, value heff,
+                       int64_t id)
 {
   int cache_bucket = stack_cache_bucket (wosize);
   return alloc_size_class_stack_noexc(wosize, cache_bucket, hval, hexn, heff,
@@ -404,9 +404,8 @@ void caml_scan_stack(
 
 #ifdef NATIVE_CODE
 /* Update absolute exception pointers for new stack*/
-static void
-rewrite_exception_stack(struct stack_info *old_stack,
-                        value** exn_ptr, struct stack_info *new_stack)
+void caml_rewrite_exception_stack(struct stack_info *old_stack,
+                                  value** exn_ptr, struct stack_info *new_stack)
 {
   fiber_debug_log("Old [%p, %p]", Stack_base(old_stack), Stack_high(old_stack));
   fiber_debug_log("New [%p, %p]", Stack_base(new_stack), Stack_high(new_stack));
@@ -514,11 +513,12 @@ int caml_try_realloc_stack(asize_t required_space)
                  (uintnat) wsize * sizeof(value));
   }
 
-  new_stack = alloc_stack_noexc(wsize,
-                                Stack_handle_value(old_stack),
-                                Stack_handle_exception(old_stack),
-                                Stack_handle_effect(old_stack),
-                                old_stack->id);
+  new_stack = caml_alloc_stack_noexc(wsize,
+                                     Stack_handle_value(old_stack),
+                                     Stack_handle_exception(old_stack),
+                                     Stack_handle_effect(old_stack),
+                                     old_stack->id);
+
   if (!new_stack) return 0;
   memcpy(Stack_high(new_stack) - stack_used,
          Stack_high(old_stack) - stack_used,
@@ -526,8 +526,8 @@ int caml_try_realloc_stack(asize_t required_space)
   new_stack->sp = Stack_high(new_stack) - stack_used;
   Stack_parent(new_stack) = Stack_parent(old_stack);
 #ifdef NATIVE_CODE
-  rewrite_exception_stack(old_stack, (value**)&Caml_state->exn_handler,
-                          new_stack);
+  caml_rewrite_exception_stack(old_stack, (value**)&Caml_state->exn_handler,
+                              new_stack);
 #ifdef WITH_FRAME_POINTERS
   rewrite_frame_pointers(old_stack, new_stack);
 #endif
@@ -556,7 +556,7 @@ struct stack_info* caml_alloc_main_stack (uintnat init_wsize)
 {
   const int64_t id = atomic_fetch_add(&fiber_id, 1);
   struct stack_info* stk =
-    alloc_stack_noexc(init_wsize, Val_unit, Val_unit, Val_unit, id);
+    caml_alloc_stack_noexc(init_wsize, Val_unit, Val_unit, Val_unit, id);
   return stk;
 }
 


### PR DESCRIPTION
This PR makes available the `alloc_stack_noexc` and
`rewrite_exception_stack` from `runtime/fiber.c` in the C API. In
accordance with the C API the functions are renamed to
`caml_alloc_stack_noexc` and `caml_rewrite_exception_stack`,
respectively.

My motivation for this change is to be able to support multi-shot
continuations in OCaml via a library. I am interested in exploring
design and programming with multi-shot continuations in my own
research. To facility this research, I am in the process of building a
[library](https://github.com/dhil/ocaml-multicont) that provides
multi-shot continuations on top of OCaml's linear continuations. Under
the hood, the library uses a variation of the `clone_continuation`
primitive that used to reside in the `Obj` module in previous versions
of Multicore OCaml. In order to implement `clone_continuation` as
library I need access to the two above mentioned fiber manipulation
primitives in `runtime/fiber.c` which are currently marked
`static`. It is not clear to me whether there is a good reason for
having them as `static`, whereas if they are non-static then I am able
to implement continuation cloning externally. I need access to
`alloc_stack_noexc` in order to allocate enough space for a
carbon-copy of an existing stack segment, and
`rewrite_exception_stack` in order to patch up exception pointers for
cloned stack segments.

In my current implementation I duplicate the implementations of these
primitives in order to get going. Obviously, it would be a lot better
and more robust if I could simply reuse the implementations in the
OCaml runtime directly.

As of writing, this PR exposes only the two primitives that I need to
get my minimal implementation of multi-shot continuations
going. However, I think there is a boarder discussion to be had about
whether we should make available the rest of the fiber manipulation
primitives in `runtime/fiber.c` too.

CC @kayceesrk and @dra27, both of whom I have had previous
conversations with about proposing this change.

CC @gasche and @gadmm with whom I have had discussions about adding
multi-shot continuations to OCaml via a library.