### PR TITLE
mem_read: avoid Unix.read size limitation with bigarrays.

### DIFF
--- a/otherlibs/unix/Makefile
+++ b/otherlibs/unix/Makefile
@@ -34,7 +34,7 @@ COBJS=accept.o access.o addrofstr.o alarm.o bind.o channels.o chdir.o \
   getnameinfo.o getpeername.o getpid.o getppid.o getproto.o getpw.o \
   gettimeofday.o getserv.o getsockname.o getuid.o gmtime.o \
   initgroups.o isatty.o itimer.o kill.o link.o listen.o lockf.o lseek.o \
-  mkdir.o mkfifo.o mmap.o mmap_ba.o \
+  mem_read.o mkdir.o mkfifo.o mmap.o mmap_ba.o \
   nice.o open.o opendir.o pipe.o putenv.o read.o realpath.o \
   readdir.o readlink.o rename.o rewinddir.o rmdir.o select.o sendrecv.o \
   setgid.o setgroups.o setsid.o setuid.o shutdown.o signals.o \

--- a/otherlibs/unix/mem_read.c
+++ b/otherlibs/unix/mem_read.c
@@ -1,0 +1,38 @@
+
+/**************************************************************************/
+/*                                                                        */
+/*                                 OCaml                                  */
+/*                                                                        */
+/*             Xavier Leroy, projet Cristal, INRIA Rocquencourt           */
+/*                                                                        */
+/*   Copyright 1996 Institut National de Recherche en Informatique et     */
+/*     en Automatique.                                                    */
+/*                                                                        */
+/*   All rights reserved.  This file is distributed under the terms of    */
+/*   the GNU Lesser General Public License version 2.1, with the          */
+/*   special exception on linking described in the file LICENSE.          */
+/*                                                                        */
+/**************************************************************************/
+
+#include <string.h>
+#include <caml/bigarray.h>
+#include <caml/mlvalues.h>
+#include <caml/memory.h>
+#include <caml/signals.h>
+#include "unixsupport.h"
+
+
+CAMLprim value unix_mem_read(value fdv, value memv, value offv, value lenv)
+{
+    intnat numbytes;
+    intnat ret;
+    char *data;
+
+    numbytes = Long_val(lenv);
+    data = ((char *) (Caml_ba_array_val(memv)->data)) + Long_val(offv);
+    caml_enter_blocking_section();
+    ret = read(Int_val(fdv), data, (int) numbytes);
+    caml_leave_blocking_section();   /* keeps errno intact */
+    if (ret == -1) uerror("mem_read", Nothing);
+    return Val_long(ret);
+}

--- a/otherlibs/unix/unix.ml
+++ b/otherlibs/unix/unix.ml
@@ -240,6 +240,7 @@ type open_flag =
   | O_KEEPEXEC
 
 type file_perm = int
+type buffer = (int, Bigarray.int8_unsigned_elt, Bigarray.c_layout) Bigarray.Array1.t
 
 
 external openfile : string -> open_flag list -> file_perm -> file_descr
@@ -248,6 +249,8 @@ external close : file_descr -> unit = "unix_close"
 external fsync : file_descr -> unit = "unix_fsync"
 external unsafe_read : file_descr -> bytes -> int -> int -> int
    = "unix_read"
+external unsafe_mem_read : file_descr -> buffer -> int -> int -> int
+   = "unix_mem_read"
 external unsafe_write : file_descr -> bytes -> int -> int -> int = "unix_write"
 external unsafe_single_write : file_descr -> bytes -> int -> int -> int
    = "unix_single_write"
@@ -256,6 +259,10 @@ let read fd buf ofs len =
   if ofs < 0 || len < 0 || ofs > Bytes.length buf - len
   then invalid_arg "Unix.read"
   else unsafe_read fd buf ofs len
+let mem_read fd buf ofs len =
+  if ofs < 0 || len < 0 || ofs > Bigarray.Array1.size_in_bytes buf - len
+  then invalid_arg "Unix.mem_read"
+  else unsafe_mem_read fd buf ofs len
 let write fd buf ofs len =
   if ofs < 0 || len < 0 || ofs > Bytes.length buf - len
   then invalid_arg "Unix.write"

--- a/otherlibs/unix/unix.mli
+++ b/otherlibs/unix/unix.mli
@@ -360,6 +360,12 @@ val read : file_descr -> bytes -> int -> int -> int
     storing them in byte sequence [buf], starting at position [pos] in
     [buf]. Return the number of bytes actually read. *)
 
+type buffer = (int, Bigarray.int8_unsigned_elt, Bigarray.c_layout) Bigarray.Array1.t
+val mem_read : file_descr -> buffer -> int -> int -> int
+(** [read fd buf pos len] reads [len] bytes from descriptor [fd],
+    storing them in bigstring [buf], starting at position [pos] in
+    [buf]. Return the number of bytes actually read. *)
+
 val write : file_descr -> bytes -> int -> int -> int
 (** [write fd buf pos len] writes [len] bytes to descriptor [fd],
     taking them from byte sequence [buf], starting at position [pos]


### PR DESCRIPTION
This PR addresses issue: #8352 
As stated in the issue; Unix.read has a fixed size.  We can work around that with a new Unix.mem_read.  Also noted in the issue, write, recv, send have similar problems.  If the approach I've made is correct, I'll generate a patch-set for those to tack on this PR as well.
