### PR TITLE
api_docgen/ocamldoc/Makefile: be portable with printf use

### DIFF
--- a/api_docgen/ocamldoc/Makefile
+++ b/api_docgen/ocamldoc/Makefile
@@ -36,7 +36,7 @@ ALL_MAN= $(ALL_DOC:%=build/man/%.3o)
 ALL_LATEX= $(ALL_DOC:%=build/latex/%.tex)
 
 build/latex/ifocamldoc.tex: | build/latex
-	printf '\\newif\ifocamldoc\ocamldoctrue\n' > $@
+	printf '\\newif\\ifocamldoc\\ocamldoctrue\n' > $@
 
 $(libref:%=build/libref/%.odoc): build/libref/%.odoc: %.mli | build/libref
 	$(OCAMLDOC_RUN) -nostdlib -hide Stdlib -lib Stdlib \

--- a/api_docgen/odoc/Makefile
+++ b/api_docgen/odoc/Makefile
@@ -38,7 +38,7 @@ endef
 
 # define the right conditional for the manual
 build/latex/ifocamldoc.tex: | build/latex
-	printf '\\newif\ifocamldoc\ocamldocfalse\n' > $@
+	printf '\\newif\\ifocamldoc\\ocamldocfalse\n' > $@
 
 
 # \input{} all modules in the stdlib for the latex api manual


### PR DESCRIPTION
According to SUSv8, printf(1) interpretation of the backslash following
a character not listed by the clause 3 of printf "EXTENDED DESCRIPTION",
is implementation-defined.  So with Linux' /usr/bin/printf:
	$ printf '\\newif\ifocamldoc\ocamldoctrue\n'
	\newif\ifocamldoc\ocamldoctrue
while FreeBSD /bin/sh built-in printf
	$ printf '\\newif\ifocamldoc\ocamldoctrue\n'
	\newififocamldococamldoctrue

Be portable and escape all backslashes, not just first one.