### PR TITLE
Explicit non-atomic load generation in Cmm

### DIFF
--- a/asmcomp/cmm_helpers.mli
+++ b/asmcomp/cmm_helpers.mli
@@ -188,7 +188,7 @@ val return_unit : Debuginfo.t -> expression -> expression
 val remove_unit : expression -> expression
 
 (** Blocks *)
-val mk_load_mut : memory_chunk -> operation
+val mk_load_mut : is_atomic:bool -> memory_chunk -> operation
 
 (** [field_address ptr n dbg] returns an expression for the address of the
     [n]th field of the block pointed to by [ptr] *)
@@ -421,7 +421,7 @@ type unary_primitive = expression -> Debuginfo.t -> expression
 
 (** Return the n-th field of a float array (or float-only record), as an
     unboxed float *)
-val floatfield : int -> unary_primitive
+val floatfield : load_atomic:bool -> int -> unary_primitive
 
 (** Int_as_pointer primitive *)
 val int_as_pointer : unary_primitive
@@ -480,8 +480,8 @@ val int_comp_caml : Lambda.integer_comparison -> binary_primitive
 (** Strings, Bytes and Bigstrings *)
 
 (** Regular string/bytes access. Args: string/bytes, index *)
-val stringref_unsafe : binary_primitive
-val stringref_safe : binary_primitive
+val stringref_unsafe : is_atomic:bool -> binary_primitive
+val stringref_safe : is_atomic:bool -> binary_primitive
 
 (** Load by chunk from string/bytes, bigstring. Args: string, index *)
 val string_load :


### PR DESCRIPTION
While implementing atomic access primitives on arrays, I noticed three things:

* The `Patomic_load` primitive gives lieu to a non-atomic load (i.e. `Cload { is_atomic = false; _ }`) in Cmm. This seems to be the wrong place to drop atomicity constraints, which should be done when generating x86 assembly.
* All memory loads and stores in the generated code (bytecode or native) are non-atomic, except for explicit uses of the `Atomic` module. I am not sure this is safe in all cases (discussed below).
* Reading a block header is translated as a mutable (non-atomic) load. After discussing it with @kayceesrk and @ctk21, these could probably be treated as immutable loads, as long as the color bits of the header are not used.

As far as loads are concerned, none of this matters for the x86 architecture, for which atomic loads are just plain loads. However, since it could affect the work needed to support other architectures, I'm opening this draft PR to discuss it. It mainly gives an explicit `is_atomic` argument to the `mk_load_mut` helper so that the atomicity of loads in Cmm generation is explicit. I think this may avoid generating non-atomic loads by mistake. In addition, reading a block header (when the color bits are not used) is now translated to a non-mutable, non-atomic.

Also, I was surprised to see that all stores are compiled as non-atomic stores.

**Disclaimer:** I am far from being proficient with Multicore and concurrency programming in general, so please tell me if I'm talking nonsense.

Below are the places where non-atomic loads are used and I am unsure about it being thread-safe:
- OO stuff: object methods, message sending.
- read and write accesses to strings and bigarrays, and “bigstrings” (what are these?).
- the helpers performing unaligned loads, although they are currently not used outside of `Cmm_helpers`.
- int unboxing.
- The `Psetfield_computed` primitive.
- `bigstring_length`. (This PR turns it into an atomic load, but I'm not sure about that.)
- The `Pbigarraydim` primitive. (Idem.)

Edit.: accesses to arrays and strings and bigarrays are non-atomic but that is the intended default (explicit atomic accesses are being implemented).