### PR TITLE
Stop registering empty code fragments

### DIFF
--- a/Changes
+++ b/Changes
@@ -14,6 +14,9 @@ Working version
   the default behavior.
   (Nicolás Ojeda Bär, review by Xavier Leroy)
 
+- #10902: Do not register empty code fragments in natdynlink.
+  (David Allsopp, review by Xavier Leroy and Damien Doligez)
+
 ### Code generation and optimizations:
 
 ### Standard library:

--- a/runtime/dynlink_nat.c
+++ b/runtime/dynlink_nat.c
@@ -117,7 +117,8 @@ CAMLprim value caml_natdynlink_run(value handle_v, value symbol) {
 
   sym = optsym("__code_begin");
   sym2 = optsym("__code_end");
-  if (NULL != sym && NULL != sym2) {
+  /* Do not register empty code fragments */
+  if (NULL != sym && NULL != sym2 && sym != sym2) {
     caml_register_code_fragment((char *) sym, (char *) sym2,
                                 DIGEST_LATER, NULL);
   }


### PR DESCRIPTION
Part of #10884. The PR is in two parts - the first eliminates the registering of empty code fragments in natdynlink and the second part adds an assertion to catch them in the debug runtime.