### PR TITLE
make ocaml-option-nnp a conflict

### DIFF
--- a/ocaml-variants.opam
+++ b/ocaml-variants.opam
@@ -8,7 +8,6 @@ depends: [
   "base-bigarray" {post}
   "base-threads" {post}
   "base-domains" {post}
-  "ocaml-option-nnp"
 ]
 conflict-class: "ocaml-core-compiler"
 flags: compiler
@@ -46,6 +45,7 @@ build: [
 install: [make "install"]
 conflicts: [
   "ocaml-option-32bit"      # Not yet implemented
+  "ocaml-option-nnp"
   "ocaml-option-nnpchecker" # Fundamentally not possible
 ]
 depopts: [


### PR DESCRIPTION
Currently trunk is not able to build using opam:
```
The following dependencies couldn't be met:
  - ocaml-variants → ocaml-option-nnp → ocaml-variants < 5.00.0~~
      not available because the package is pinned to version 5.00.0+trunk
```

It seems that both trunk and the ocaml-option-nnp opam package try to express the same limitation in two different and conflicting ways: "nnp-options cannot be set" vs. "nnp-option has to be disabled":
https://github.com/ocaml/opam-repository/blob/master/packages/ocaml-option-nnp/ocaml-option-nnp.1/opam

The PR changes trunk's opam-file to agree with ocaml-option-nnp's ("nnp-options cannot be set"),