### PR TITLE
opam: remove ocaml-options-nnp from depends

### DIFF
--- a/ocaml-variants.opam
+++ b/ocaml-variants.opam
@@ -8,7 +8,6 @@ depends: [
   "base-bigarray" {post}
   "base-threads" {post}
   "base-domains" {post}
-  "ocaml-option-nnp"
 ]
 conflict-class: "ocaml-core-compiler"
 flags: compiler


### PR DESCRIPTION
This package should be set by the user, and is not needed on
ocaml 5.0+. Removing it allows the trunk compiler to be pinned
properly using opam

cc @kit-ty-kate @dra27, reported by @jmid @OlivierNicole 