### PR TITLE
runtime/signals_osdep.h: add amd64 FreeBSD block

### DIFF
--- a/runtime/signals_osdep.h
+++ b/runtime/signals_osdep.h
@@ -120,6 +120,23 @@
  #define CONTEXT_YOUNG_PTR (context->uc_mcontext.gregs[REG_R15])
  #define CONTEXT_FAULTING_ADDRESS ((char *) info->si_addr)
 
+/****************** AMD64, FreeBSD */
+
+#elif defined(TARGET_amd64) && defined (SYS_freebsd)
+
+ #define DECLARE_SIGNAL_HANDLER(name) \
+ static void name(int sig, siginfo_t * info, struct sigcontext * context)
+
+ #define SET_SIGACT(sigact,name) \
+ sigact.sa_sigaction = (void (*)(int,siginfo_t *,void *)) (name); \
+ sigact.sa_flags = SA_SIGINFO
+
+ #define CONTEXT_PC (context->sc_rip)
+ #define CONTEXT_C_ARG_1 (context->sc_rdi)
+ #define CONTEXT_SP (context->sc_rsp)
+ #define CONTEXT_YOUNG_PTR (context->sc_r15)
+ #define CONTEXT_FAULTING_ADDRESS ((char *) info->si_addr)
+
 /****************** ARM, Linux */
 
 #elif defined(TARGET_arm) && (defined(SYS_linux_eabi) \


### PR DESCRIPTION
This seems to be formal, since only DECLARE_SIGNAL_HANDLER() and
SET_SIGACT() are actually used.  But even then, it is better to use
sa_sigaction/SA_SIGINFO over sa_handler.