### PR TITLE
Fix possible race in caml_mem_map on Windows

### DIFF
--- a/runtime/caml/platform.h
+++ b/runtime/caml/platform.h
@@ -118,6 +118,7 @@ uintnat caml_mem_round_up_pages(uintnat size);
 void* caml_mem_map(uintnat size, uintnat alignment, int reserve_only);
 void* caml_mem_commit(void* mem, uintnat size);
 void caml_mem_decommit(void* mem, uintnat size);
+void caml_mem_unmap(void* mem, uintnat size);
 
 
 CAMLnoreturn_start

--- a/runtime/caml/platform.h
+++ b/runtime/caml/platform.h
@@ -118,7 +118,6 @@ uintnat caml_mem_round_up_pages(uintnat size);
 void* caml_mem_map(uintnat size, uintnat alignment, int reserve_only);
 void* caml_mem_commit(void* mem, uintnat size);
 void caml_mem_decommit(void* mem, uintnat size);
-void caml_mem_unmap(void* mem, uintnat size);
 
 
 CAMLnoreturn_start

--- a/runtime/platform.c
+++ b/runtime/platform.c
@@ -195,8 +195,8 @@ again:
   }
   CAMLassert(mem == (void*)aligned_start);
 #else
-  caml_mem_unmap((void*)base, aligned_start - base);
-  caml_mem_unmap((void*)aligned_end, (base + alloc_sz) - aligned_end);
+  munmap((void*)base, aligned_start - base);
+  munmap((void*)aligned_end, (base + alloc_sz) - aligned_end);
 #endif
   return (void*)aligned_start;
 }
@@ -238,15 +238,6 @@ void caml_mem_decommit(void* mem, uintnat size)
   VirtualFree(mem, size, MEM_DECOMMIT);
 #else
   map_fixed(mem, size, PROT_NONE);
-#endif
-}
-
-void caml_mem_unmap(void* mem, uintnat size)
-{
-#ifdef _WIN32
-  VirtualFree(mem, size, MEM_RELEASE);
-#else
-  munmap(mem, size);
 #endif
 }
 

--- a/runtime/platform.c
+++ b/runtime/platform.c
@@ -243,6 +243,15 @@ void caml_mem_decommit(void* mem, uintnat size)
 #endif
 }
 
+void caml_mem_unmap(void* mem, uintnat size)
+{
+#ifdef _WIN32
+  VirtualFree(mem, 0, MEM_RELEASE);
+#else
+  munmap(mem, size);
+#endif
+}
+
 #define Min_sleep_ns       10000 // 10 us
 #define Slow_sleep_ns    1000000 //  1 ms
 #define Max_sleep_ns  1000000000 //  1 s

--- a/runtime/platform.c
+++ b/runtime/platform.c
@@ -235,7 +235,9 @@ void* caml_mem_commit(void* mem, uintnat size)
 void caml_mem_decommit(void* mem, uintnat size)
 {
 #ifdef _WIN32
-  VirtualFree(mem, size, MEM_DECOMMIT);
+  /* VirtualFree can't decommit zero bytes */
+  if (size)
+    VirtualFree(mem, size, MEM_DECOMMIT);
 #else
   map_fixed(mem, size, PROT_NONE);
 #endif

--- a/runtime/platform.c
+++ b/runtime/platform.c
@@ -174,16 +174,11 @@ void* caml_mem_map(uintnat size, uintnat alignment, int reserve_only)
   /* VirtualFree can be used to decommit portions of memory, but it can only
      release the entire block of memory. For Windows, repeat the call but this
      time specify the address. */
-  if (!VirtualFree(mem, 0, MEM_RELEASE))
-    printf("The world seems to be upside down\n");
-  mem = VirtualAlloc((void*)aligned_start,
-                     aligned_end - aligned_start + 1,
-                     MEM_RESERVE | (reserve_only ? 0 : MEM_COMMIT),
-                     reserve_only ? PAGE_NOACCESS : PAGE_READWRITE);
-  if (!mem)
-    printf("Trimming failed\n");
-  else if (mem != (void*)aligned_start)
-    printf("Hang on a sec - it's allocated a different block?!\n");
+  VirtualFree(mem, 0, MEM_RELEASE);
+  VirtualAlloc((void*)aligned_start,
+               aligned_end - aligned_start + 1,
+               MEM_RESERVE | (reserve_only ? 0 : MEM_COMMIT),
+               reserve_only ? PAGE_NOACCESS : PAGE_READWRITE);
 #else
   caml_mem_unmap((void*)base, aligned_start - base);
   caml_mem_unmap((void*)aligned_end, (base + alloc_sz) - aligned_end);
@@ -225,8 +220,7 @@ void* caml_mem_commit(void* mem, uintnat size)
 void caml_mem_decommit(void* mem, uintnat size)
 {
 #ifdef _WIN32
-  if (!VirtualFree(mem, size, MEM_DECOMMIT))
-    printf("VirtualFree failed to decommit\n");
+  VirtualFree(mem, size, MEM_DECOMMIT);
 #else
   map_fixed(mem, size, PROT_NONE);
 #endif
@@ -235,8 +229,7 @@ void caml_mem_decommit(void* mem, uintnat size)
 void caml_mem_unmap(void* mem, uintnat size)
 {
 #ifdef _WIN32
-  if (!VirtualFree(mem, size, MEM_RELEASE))
-    printf("VirtualFree failed\n");
+  VirtualFree(mem, size, MEM_RELEASE);
 #else
   munmap(mem, size);
 #endif

--- a/runtime/platform.c
+++ b/runtime/platform.c
@@ -246,9 +246,11 @@ void caml_mem_decommit(void* mem, uintnat size)
 void caml_mem_unmap(void* mem, uintnat size)
 {
 #ifdef _WIN32
-  VirtualFree(mem, 0, MEM_RELEASE);
+  if (!VirtualFree(mem, 0, MEM_RELEASE))
+    CAMLassert(0);
 #else
-  munmap(mem, size);
+  if (munmap(mem, size) != 0)
+    CAMLassert(0);
 #endif
 }
 

--- a/runtime/platform.c
+++ b/runtime/platform.c
@@ -21,11 +21,15 @@
 #include <sys/time.h>
 #include "caml/platform.h"
 #include "caml/fail.h"
+#include "caml/lf_skiplist.h"
 #ifdef HAS_SYS_MMAN_H
 #include <sys/mman.h>
 #endif
 #ifdef _WIN32
 #include <windows.h>
+#endif
+#ifdef DEBUG
+#include "caml/domain.h"
 #endif
 
 /* Error reporting */
@@ -144,11 +148,24 @@ uintnat caml_mem_round_up_pages(uintnat size)
 #define MAP_FAILED 0
 #endif
 
+#ifdef DEBUG
+static struct lf_skiplist mmap_blocks = {NULL};
+#endif
+
 void* caml_mem_map(uintnat size, uintnat alignment, int reserve_only)
 {
   uintnat alloc_sz = caml_mem_round_up_pages(size + alignment);
   void* mem;
   uintnat base, aligned_start, aligned_end;
+
+#ifdef DEBUG
+  if (mmap_blocks.head == NULL) {
+    /* The first call to caml_mem_map should be during caml_init_domains, called
+       by caml_init_gc during startup - i.e. before any domains have started. */
+    CAMLassert(atomic_load_acq(&caml_num_domains_running) <= 1);
+    caml_lf_skiplist_init(&mmap_blocks);
+  }
+#endif
 
   CAMLassert(Is_power_of_2(alignment));
   alignment = caml_mem_round_up_pages(alignment);
@@ -198,6 +215,9 @@ again:
   munmap((void*)base, aligned_start - base);
   munmap((void*)aligned_end, (base + alloc_sz) - aligned_end);
 #endif
+#ifdef DEBUG
+  caml_lf_skiplist_insert(&mmap_blocks, aligned_start, size);
+#endif
   return (void*)aligned_start;
 }
 
@@ -245,12 +265,20 @@ void caml_mem_decommit(void* mem, uintnat size)
 
 void caml_mem_unmap(void* mem, uintnat size)
 {
+#ifdef DEBUG
+  uintnat data;
+  CAMLassert(caml_lf_skiplist_find(&mmap_blocks, (uintnat)mem, &data) != 0);
+  CAMLassert(data == size);
+#endif
 #ifdef _WIN32
   if (!VirtualFree(mem, 0, MEM_RELEASE))
     CAMLassert(0);
 #else
   if (munmap(mem, size) != 0)
     CAMLassert(0);
+#endif
+#ifdef DEBUG
+  caml_lf_skiplist_remove(&mmap_blocks, (uintnat)mem);
 #endif
 }
 


### PR DESCRIPTION
It appears I managed to leave some `printf`-debugging in my 2018 hacking from the concurrent minor collector in `platform.c`. The first commit in this PR nukes those statements - they were never intended to see the light of day! 🙈

As noted in https://github.com/ocaml/ocaml/pull/10831#discussion_r780850386, there is a possibility of a race when trimming the memory block.

I'm not certain about the implementation of the loop here, but I'll open this as a starter. In particular, I think there may be a "fast path" being missed. If the start address is aligned as required, it's almost certainly better to avoid the risk of a race and allow a tiny waste of memory at the end of the block. I don't know the details of Go's allocator, but I can't see how we'd end up with enough (any?) parallel contention to warrant a retry loop counter, especially as in all the various test runs of this in the last 4 years, the "error" traps there before weren't triggered (in the testsuite, etc.).