### PR TITLE
Fix flambda issues following multicore merge

### DIFF
--- a/.depend
+++ b/.depend
@@ -5466,6 +5466,7 @@ middle_end/flambda/simple_value_approx.cmo : \
     middle_end/compilation_unit.cmi \
     middle_end/flambda/base_types/closure_origin.cmi \
     middle_end/flambda/base_types/closure_id.cmi \
+    utils/clflags.cmi \
     middle_end/flambda/allocated_const.cmi \
     middle_end/flambda/simple_value_approx.cmi
 middle_end/flambda/simple_value_approx.cmx : \
@@ -5490,6 +5491,7 @@ middle_end/flambda/simple_value_approx.cmx : \
     middle_end/compilation_unit.cmx \
     middle_end/flambda/base_types/closure_origin.cmx \
     middle_end/flambda/base_types/closure_id.cmx \
+    utils/clflags.cmx \
     middle_end/flambda/allocated_const.cmx \
     middle_end/flambda/simple_value_approx.cmi
 middle_end/flambda/simple_value_approx.cmi : \

--- a/Changes
+++ b/Changes
@@ -26,6 +26,10 @@ Working version
 
 ### Compiler user-interface and warnings:
 
+- #10909: Disable warning 59 (assignment to immutable blocks) unless flambda
+  invariant checks are enabled.
+  (Vincent Laviron, review by Gabriel Scherer)
+
 ### Internal/compiler-libs changes:
 
 ### Build system:

--- a/lambda/matching.ml
+++ b/lambda/matching.ml
@@ -1889,11 +1889,24 @@ let code_force_lazy = get_mod_field "CamlinternalLazy" "force_gen"
    Forward(val_out_of_heap).
 *)
 
+let call_force_lazy_block varg loc =
+  (* The argument is wrapped with [Popaque] to prevent the compiler from making
+     any assumptions on its contents. Alternatively, [ap_inlined] could be set
+     to [Never_inline]. *)
+  let force_fun = Lazy.force code_force_lazy_block in
+  Lapply
+    { ap_tailcall = Default_tailcall;
+      ap_loc = loc;
+      ap_func = force_fun;
+      ap_args = [ Lprim (Popaque, [ varg ], loc) ];
+      ap_inlined = Default_inline;
+      ap_specialised = Default_specialise
+    }
+
 let inline_lazy_force_cond arg loc =
   let idarg = Ident.create_local "lzarg" in
   let varg = Lvar idarg in
   let tag = Ident.create_local "tag" in
-  let force_fun = Lazy.force code_force_lazy_block in
   let test_tag t =
     Lprim(Pintcomp Ceq, [Lvar tag; Lconst(Const_base(Const_int t))], loc)
   in
@@ -1919,21 +1932,13 @@ let inline_lazy_force_cond arg loc =
                        else ... *)
                   Lprim (Psequor,
                        [test_tag Obj.lazy_tag; test_tag Obj.forcing_tag], loc),
-                  Lapply
-                    { ap_tailcall = Default_tailcall;
-                      ap_loc = loc;
-                      ap_func = force_fun;
-                      ap_args = [ varg ];
-                      ap_inlined = Default_inline;
-                      ap_specialised = Default_specialise
-                    },
+                  call_force_lazy_block varg loc,
                   (* ... arg *)
                   varg ) ) ) )
 
 let inline_lazy_force_switch arg loc =
   let idarg = Ident.create_local "lzarg" in
   let varg = Lvar idarg in
-  let force_fun = Lazy.force code_force_lazy_block in
   Llet
     ( Strict,
       Pgenval,
@@ -1951,26 +1956,8 @@ let inline_lazy_force_switch arg loc =
                 sw_consts =
                   [ (Obj.forward_tag, Lprim (Pfield(0, Pointer, Mutable),
                                              [ varg ], loc));
-
-                    (Obj.lazy_tag,
-                      Lapply
-                        { ap_tailcall = Default_tailcall;
-                          ap_loc = loc;
-                          ap_func = force_fun;
-                          ap_args = [varg];
-                          ap_inlined = Default_inline;
-                          ap_specialised = Default_specialise
-                        } );
-
-                    (Obj.forcing_tag,
-                      Lapply
-                        { ap_tailcall = Default_tailcall;
-                          ap_loc = loc;
-                          ap_func = force_fun;
-                          ap_args = [ varg ];
-                          ap_inlined = Default_inline;
-                          ap_specialised = Default_specialise
-                        } )
+                    (Obj.lazy_tag, call_force_lazy_block varg loc);
+                    (Obj.forcing_tag, call_force_lazy_block varg loc)
                   ];
                 sw_failaction = Some varg
               },

--- a/lambda/matching.ml
+++ b/lambda/matching.ml
@@ -1892,8 +1892,8 @@ let code_force_lazy = get_mod_field "CamlinternalLazy" "force_gen"
 let call_force_lazy_block varg loc =
   (* The argument is wrapped with [Popaque] to prevent the rest of the compiler
      from making any assumptions on its contents (see comments on
-     [CamlinternalLazy.force_gen]).
-     Alternatively, [ap_inlined] could be set to [Never_inline] to acheive a
+     [CamlinternalLazy.force_gen], and discussions on PRs #9998 and #10909).
+     Alternatively, [ap_inlined] could be set to [Never_inline] to achieve a
      similar result. *)
   let force_fun = Lazy.force code_force_lazy_block in
   Lapply

--- a/lambda/matching.ml
+++ b/lambda/matching.ml
@@ -1890,9 +1890,11 @@ let code_force_lazy = get_mod_field "CamlinternalLazy" "force_gen"
 *)
 
 let call_force_lazy_block varg loc =
-  (* The argument is wrapped with [Popaque] to prevent the compiler from making
-     any assumptions on its contents. Alternatively, [ap_inlined] could be set
-     to [Never_inline]. *)
+  (* The argument is wrapped with [Popaque] to prevent the rest of the compiler
+     from making any assumptions on its contents (see comments on
+     [CamlinternalLazy.force_gen]).
+     Alternatively, [ap_inlined] could be set to [Never_inline] to acheive a
+     similar result. *)
   let force_fun = Lazy.force code_force_lazy_block in
   Lapply
     { ap_tailcall = Default_tailcall;

--- a/middle_end/flambda/simple_value_approx.ml
+++ b/middle_end/flambda/simple_value_approx.ml
@@ -552,15 +552,17 @@ let useful t =
 let all_not_useful ts = List.for_all (fun t -> not (useful t)) ts
 
 let warn_on_mutation t =
-  match t.descr with
-  | Value_block(_, fields) -> Array.length fields > 0
-  | Value_string { contents = Some _ }
-  | Value_int _ | Value_char _
-  | Value_set_of_closures _ | Value_float _ | Value_boxed_int _
-  | Value_closure _ -> true
-  | Value_string { contents = None } | Value_float_array _
-  | Value_unresolved _ | Value_unknown _ | Value_bottom -> false
-  | Value_extern _ | Value_symbol _ -> assert false
+  if not !Clflags.flambda_invariant_checks then false
+  else
+    match t.descr with
+    | Value_block(_, fields) -> Array.length fields > 0
+    | Value_string { contents = Some _ }
+    | Value_int _ | Value_char _
+    | Value_set_of_closures _ | Value_float _ | Value_boxed_int _
+    | Value_closure _ -> true
+    | Value_string { contents = None } | Value_float_array _
+    | Value_unresolved _ | Value_unknown _ | Value_bottom -> false
+    | Value_extern _ | Value_symbol _ -> assert false
 
 type get_field_result =
   | Ok of t

--- a/stdlib/camlinternalLazy.ml
+++ b/stdlib/camlinternalLazy.ml
@@ -81,6 +81,15 @@ let force_lazy_block blk = force_gen_lazy_block ~only_val:false blk
    declared as a primitive whose code inlines the tag tests of its
    argument, except when afl instrumentation is turned on. *)
 let force_gen ~only_val (lzv : 'arg lazy_t) =
+  (* Using [Sys.opaque_identity] prevents two potential problems:
+     - If the value is known to have Forward_tag, then it could have been
+       shorcut during GC, so that information must be forgotten (see GPR#713
+       and issue #7301). This is not an issue here at the moment since
+       [Obj.tag] is not simplified by the compiler, and GPR#713 also
+       ensures that no value will be known to have Forward_tag.
+     - If the value is known to be immutable, then if the compiler
+       cannot prove that the last branch is not taken it will issue a
+       warning 59 (modification of an immutable value) *)
   let lzv = Sys.opaque_identity lzv in
   let x = Obj.repr lzv in
   (* START no safe points. If a GC occurs here, then the object [x] may be

--- a/stdlib/camlinternalLazy.ml
+++ b/stdlib/camlinternalLazy.ml
@@ -42,7 +42,7 @@ external update_to_forward : Obj.t -> unit =
 
 (* Assumes [blk] is a block with tag forcing *)
 let do_force_block blk =
-  let b = Obj.repr (Sys.opaque_identity blk) in
+  let b = Obj.repr blk in
   let closure = (Obj.obj (Obj.field b 0) : unit -> 'arg) in
   Obj.set_field b 0 (Obj.repr ()); (* Release the closure *)
   try

--- a/stdlib/camlinternalLazy.ml
+++ b/stdlib/camlinternalLazy.ml
@@ -42,7 +42,7 @@ external update_to_forward : Obj.t -> unit =
 
 (* Assumes [blk] is a block with tag forcing *)
 let do_force_block blk =
-  let b = Obj.repr blk in
+  let b = Obj.repr (Sys.opaque_identity blk) in
   let closure = (Obj.obj (Obj.field b 0) : unit -> 'arg) in
   Obj.set_field b 0 (Obj.repr ()); (* Release the closure *)
   try

--- a/testsuite/tests/backtrace/backtrace_dynlink.flambda.reference
+++ b/testsuite/tests/backtrace/backtrace_dynlink.flambda.reference
@@ -1,0 +1,21 @@
+Raised by primitive operation at Backtrace_dynlink_plugin in file "backtrace_dynlink_plugin.ml", line 6, characters 13-38
+Called from Dynlink.Native.run.(fun) in file "otherlibs/dynlink/native/dynlink.ml", line 85, characters 12-29
+Called from Stdlib__List.iter in file "list.ml" (inlined), line 110, characters 12-15
+Called from Dynlink.Native.run in file "otherlibs/dynlink/native/dynlink.ml", line 84, characters 4-273
+Called from Dynlink_common.Make.load.(fun) in file "otherlibs/dynlink/dynlink_common.ml" (inlined), line 350, characters 13-44
+Called from Stdlib__List.iter in file "list.ml" (inlined), line 110, characters 12-15
+Called from Dynlink_common.Make.load in file "otherlibs/dynlink/dynlink_common.ml" (inlined), line 348, characters 8-240
+Called from Dynlink_common.Make.loadfile in file "otherlibs/dynlink/dynlink_common.ml", line 360, characters 26-45
+Called from Backtrace_dynlink in file "backtrace_dynlink.ml", line 39, characters 4-52
+execution of module initializers in the shared library failed: Failure("SUCCESS")
+Raised by primitive operation at Dynlink.Native.run.(fun) in file "otherlibs/dynlink/native/dynlink.ml", line 85, characters 12-29
+Re-raised at Dynlink.Native.run.(fun) in file "otherlibs/dynlink/native/dynlink.ml", line 87, characters 10-149
+Called from Stdlib__List.iter in file "list.ml" (inlined), line 110, characters 12-15
+Called from Dynlink.Native.run in file "otherlibs/dynlink/native/dynlink.ml", line 84, characters 4-273
+Called from Dynlink_common.Make.load.(fun) in file "otherlibs/dynlink/dynlink_common.ml" (inlined), line 350, characters 13-44
+Called from Stdlib__List.iter in file "list.ml" (inlined), line 110, characters 12-15
+Called from Dynlink_common.Make.load in file "otherlibs/dynlink/dynlink_common.ml" (inlined), line 348, characters 8-240
+Called from Dynlink_common.Make.loadfile in file "otherlibs/dynlink/dynlink_common.ml", line 360, characters 26-45
+Re-raised at Dynlink_common.Make.load in file "otherlibs/dynlink/dynlink_common.ml" (inlined), line 358, characters 8-17
+Called from Dynlink_common.Make.loadfile in file "otherlibs/dynlink/dynlink_common.ml", line 360, characters 26-45
+Called from Backtrace_dynlink in file "backtrace_dynlink.ml", line 39, characters 4-52

--- a/testsuite/tests/backtrace/backtrace_dynlink.ml
+++ b/testsuite/tests/backtrace/backtrace_dynlink.ml
@@ -22,7 +22,11 @@ libraries = "dynlink"
 all_modules = "backtrace_dynlink.cmx"
 ***** run
 ocamlrunparam += ",b=1"
-****** check-program-output
+****** no-flambda
+******* check-program-output
+****** flambda
+reference = "${test_source_directory}/backtrace_dynlink.flambda.reference"
+******* check-program-output
 *)
 
 (* test for backtrace and stack unwinding with dynlink. *)

--- a/testsuite/tests/backtrace/backtrace_dynlink.reference
+++ b/testsuite/tests/backtrace/backtrace_dynlink.reference
@@ -5,7 +5,7 @@ Called from Dynlink_common.Make.load.(fun) in file "otherlibs/dynlink/dynlink_co
 Called from Stdlib__List.iter in file "list.ml", line 110, characters 12-15
 Called from Dynlink_common.Make.load in file "otherlibs/dynlink/dynlink_common.ml", line 348, characters 8-240
 Called from Dynlink_common.Make.loadfile in file "otherlibs/dynlink/dynlink_common.ml" (inlined), line 360, characters 26-45
-Called from Backtrace_dynlink in file "backtrace_dynlink.ml", line 35, characters 4-52
+Called from Backtrace_dynlink in file "backtrace_dynlink.ml", line 39, characters 4-52
 execution of module initializers in the shared library failed: Failure("SUCCESS")
 Raised by primitive operation at Dynlink.Native.run.(fun) in file "otherlibs/dynlink/native/dynlink.ml", line 85, characters 12-29
 Re-raised at Dynlink.Native.run.(fun) in file "otherlibs/dynlink/native/dynlink.ml", line 87, characters 10-149
@@ -15,4 +15,4 @@ Called from Stdlib__List.iter in file "list.ml", line 110, characters 12-15
 Called from Dynlink_common.Make.load in file "otherlibs/dynlink/dynlink_common.ml", line 348, characters 8-240
 Re-raised at Dynlink_common.Make.load in file "otherlibs/dynlink/dynlink_common.ml", line 358, characters 8-17
 Called from Dynlink_common.Make.loadfile in file "otherlibs/dynlink/dynlink_common.ml" (inlined), line 360, characters 26-45
-Called from Backtrace_dynlink in file "backtrace_dynlink.ml", line 35, characters 4-52
+Called from Backtrace_dynlink in file "backtrace_dynlink.ml", line 39, characters 4-52

--- a/testsuite/tests/backtrace/backtrace_effects_nested.flambda.reference
+++ b/testsuite/tests/backtrace/backtrace_effects_nested.flambda.reference
@@ -1,3 +1,4 @@
 Raised by primitive operation at Backtrace_effects_nested.blorp in file "backtrace_effects_nested.ml", line 21, characters 2-11
+Called from Stdlib__EffectHandlers.Deep.continue in file "effectHandlers.ml" (inlined), line 36, characters 21-62
 Called from Backtrace_effects_nested.baz.(fun) in file "backtrace_effects_nested.ml", line 29, characters 16-29
 43

--- a/testsuite/tests/backtrace/backtrace_effects_nested.ml
+++ b/testsuite/tests/backtrace/backtrace_effects_nested.ml
@@ -1,5 +1,13 @@
 (* TEST
-   flags = "-g"
+
+flags = "-g"
+* bytecode
+* no-flambda
+** native
+* flambda
+reference = "${test_source_directory}/backtrace_effects_nested.flambda.reference"
+** native
+
 *)
 
 open EffectHandlers

--- a/testsuite/tests/basic-modules/anonymous.ocamlopt.flambda.reference
+++ b/testsuite/tests/basic-modules/anonymous.ocamlopt.flambda.reference
@@ -8,9 +8,9 @@
          [0: "anonymous.ml" 35 6] [0: [0]]))
     (seq (ignore (let (x = [0: 4 2]) (makeblock 0 x)))
       (apply (field_imm 1 (global CamlinternalMod!)) [0: [0]] A
-        (module-defn(A) anonymous.ml(23):567-608 A))
+        (module-defn(A) Anonymous anonymous.ml(23):567-608 A))
       (apply (field_imm 1 (global CamlinternalMod!)) [0: [0]] B
-        (module-defn(B) anonymous.ml(33):703-773
+        (module-defn(B) Anonymous anonymous.ml(33):703-773
           (let (x = [0: "foo" "bar"]) (makeblock 0))))
       (let (f = (function param : int 0) s = (makemutable 0 ""))
         (seq
@@ -18,5 +18,5 @@
             (let (*match* = (setfield_ptr 0 s "Hello World!")) (makeblock 0)))
           (let
             (drop = (function param : int 0)
-             *match* = (apply drop (field 0 s)))
+             *match* = (apply drop (field_mut 0 s)))
             (makeblock 0 A B f s drop)))))))

--- a/testsuite/tests/weak-ephe-final/finaliser2.ml
+++ b/testsuite/tests/weak-ephe-final/finaliser2.ml
@@ -1,6 +1,6 @@
 (* TEST *)
 
-let test1 =
+let[@inline never][@local never] test1 () =
   let r' = ref 0 in
   let rec foo () =
     let r = ref 0 in
@@ -10,13 +10,13 @@ let test1 =
   Gc.minor();
   assert (!r' = 1)
 
-let test2 =
+let[@inline never][@local never] test2 () =
   let r = ref 0 in
   Gc.finalise (fun r -> assert (!r = 1); print_endline "test2: 1") r;
   Gc.finalise (fun r -> assert (!r = 0); print_endline "test2: 2"; r := 1) r;
   Gc.full_major()
 
-let test3 =
+let[@inline never][@local never] test3 () =
   Gc.full_major ();
   let rec foo () =
     let r = ref 0 in
@@ -34,3 +34,8 @@ let test3 =
   print_endline "test3: joined";
   (* Now this domain takes over the finalisers from d *)
   Gc.full_major()
+
+let _ =
+  test1 ();
+  test2 ();
+  test3 ()


### PR DESCRIPTION
As discussed in #10878.

The only change from what has been discussed there is that I haven't removed warning 59, but made it conditional on flambda invariant checks (@chambart thinks the check can still be useful).
As a consequence, I've also added a `Sys.opaque_identity` call in `CamlinternalLazy` to prevent the warning from triggering there even if it is enabled.

Closes #10878.