### PR TITLE
 Improve the location reported by parenthesized assertions

### DIFF
--- a/Changes
+++ b/Changes
@@ -75,6 +75,9 @@ Working version
 - #11338: Turn some partial application warnings into hints.
   (Leo White, review by Stephen Dolan)
 
+- #10911: Improve the location reported by parenthesized assert expressions
+  (Fabian Hemmer, review by Gabriel Scherer)
+
 ### Internal/compiler-libs changes:
 
 - #11364: Allow `make -C testsuite promote` to take `TEST` and `LIST` variables

--- a/lambda/translcore.ml
+++ b/lambda/translcore.ml
@@ -186,12 +186,11 @@ let event_function ~scopes exp lam =
 
 (* Assertions *)
 
-let assert_failed ~scopes exp =
+let assert_failed loc ~scopes exp =
   let slot =
     transl_extension_path Loc_unknown
       Env.initial Predef.path_assert_failure
   in
-  let loc = exp.exp_loc in
   let (fname, line, char) =
     Location.get_pos_info loc.Location.loc_start
   in
@@ -547,13 +546,13 @@ and transl_exp0 ~in_new_scope ~scopes e =
            transl_exp ~scopes body)
   | Texp_pack modl ->
       !transl_module ~scopes Tcoerce_none None modl
-  | Texp_assert {exp_desc=Texp_construct(_, {cstr_name="false"}, _)} ->
-      assert_failed ~scopes e
-  | Texp_assert (cond) ->
+  | Texp_assert ({exp_desc=Texp_construct(_, {cstr_name="false"}, _)}, loc) ->
+      assert_failed loc ~scopes e
+  | Texp_assert (cond, loc) ->
       if !Clflags.noassert
       then lambda_unit
       else Lifthenelse (transl_exp ~scopes cond, lambda_unit,
-                        assert_failed ~scopes e)
+                        assert_failed loc ~scopes e)
   | Texp_lazy e ->
       (* when e needs no computation (constants, identifiers, ...), we
          optimize the translation just as Lazy.lazy_from_val would

--- a/testsuite/tests/parsing/assert_location.ml
+++ b/testsuite/tests/parsing/assert_location.ml
@@ -1,0 +1,7 @@
+(* TEST
+   exit_status = "2"
+*)
+
+let () = (
+    assert false
+  )

--- a/testsuite/tests/parsing/assert_location.reference
+++ b/testsuite/tests/parsing/assert_location.reference
@@ -1,0 +1,1 @@
+Fatal error: exception Assert_failure("assert_location.ml", 6, 4)

--- a/typing/printtyped.ml
+++ b/typing/printtyped.ml
@@ -406,7 +406,7 @@ and expression i ppf x =
       line i ppf "Texp_letexception\n";
       extension_constructor i ppf cd;
       expression i ppf e;
-  | Texp_assert (e) ->
+  | Texp_assert (e, _) ->
       line i ppf "Texp_assert";
       expression i ppf e;
   | Texp_lazy (e) ->

--- a/typing/rec_check.ml
+++ b/typing/rec_check.ml
@@ -725,7 +725,7 @@ let rec expression : Typedtree.expression -> term_judg =
          G |- let exception A in e: m
       *)
       remove_id ext_id (expression e)
-    | Texp_assert e ->
+    | Texp_assert (e, _) ->
       (*
         G |- e: m[Dereference]
         -----------------------

--- a/typing/tast_iterator.ml
+++ b/typing/tast_iterator.ml
@@ -247,7 +247,7 @@ let expr sub {exp_extra; exp_desc; exp_env; _} =
   | Texp_letexception (cd, exp) ->
       sub.extension_constructor sub cd;
       sub.expr sub exp
-  | Texp_assert exp -> sub.expr sub exp
+  | Texp_assert (exp, _) -> sub.expr sub exp
   | Texp_lazy exp -> sub.expr sub exp
   | Texp_object (cl, _) -> sub.class_structure sub cl
   | Texp_pack mexpr -> sub.module_expr sub mexpr

--- a/typing/tast_mapper.ml
+++ b/typing/tast_mapper.ml
@@ -353,8 +353,8 @@ let expr sub x =
           sub.extension_constructor sub cd,
           sub.expr sub exp
         )
-    | Texp_assert exp ->
-        Texp_assert (sub.expr sub exp)
+    | Texp_assert (exp, loc) ->
+        Texp_assert (sub.expr sub exp, loc)
     | Texp_lazy exp ->
         Texp_lazy (sub.expr sub exp)
     | Texp_object (cl, sl) ->

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -2353,7 +2353,7 @@ let rec is_nonexpansive exp =
      equivalent to (raise e; diverge), and a nonexpansive "diverge" can be
      produced using lazy values or the relaxed value restriction.
      See GPR#1142 *)
-  | Texp_assert exp ->
+  | Texp_assert (exp, _) ->
       is_nonexpansive exp
   | Texp_apply (
       { exp_desc = Texp_ident (_, _, {val_kind =
@@ -3743,8 +3743,14 @@ and type_expect_
         | _ ->
             instance Predef.type_unit
       in
+      let rec innermost_location loc_stack =
+        match loc_stack with
+        | [] -> loc
+        | [l] -> l
+        | _ :: s -> innermost_location s
+      in
       rue {
-        exp_desc = Texp_assert cond;
+        exp_desc = Texp_assert (cond, innermost_location sexp.pexp_loc_stack);
         exp_loc = loc; exp_extra = [];
         exp_type;
         exp_attributes = sexp.pexp_attributes;

--- a/typing/typedtree.ml
+++ b/typing/typedtree.ml
@@ -133,7 +133,7 @@ and expression_desc =
       Ident.t option * string option loc * Types.module_presence * module_expr *
         expression
   | Texp_letexception of extension_constructor * expression
-  | Texp_assert of expression
+  | Texp_assert of expression * Location.t
   | Texp_lazy of expression
   | Texp_object of class_structure * string list
   | Texp_pack of module_expr

--- a/typing/typedtree.mli
+++ b/typing/typedtree.mli
@@ -264,7 +264,7 @@ and expression_desc =
       Ident.t option * string option loc * Types.module_presence * module_expr *
         expression
   | Texp_letexception of extension_constructor * expression
-  | Texp_assert of expression
+  | Texp_assert of expression * Location.t
   | Texp_lazy of expression
   | Texp_object of class_structure * string list
   | Texp_pack of module_expr

--- a/typing/untypeast.ml
+++ b/typing/untypeast.ml
@@ -493,7 +493,7 @@ let expression sub exp =
     | Texp_letexception (ext, exp) ->
         Pexp_letexception (sub.extension_constructor sub ext,
                            sub.expr sub exp)
-    | Texp_assert exp -> Pexp_assert (sub.expr sub exp)
+    | Texp_assert (exp, _) -> Pexp_assert (sub.expr sub exp)
     | Texp_lazy exp -> Pexp_lazy (sub.expr sub exp)
     | Texp_object (cl, _) ->
         Pexp_object (sub.class_structure sub cl)


### PR DESCRIPTION
Extend the typedtree with a location field for assertions, which is taken from the location stack of the parsetree.

Addresses #10852.