### PR TITLE
Flambda testsuite fixes, continued

### DIFF
--- a/testsuite/tests/backtrace/backtrace_effects_nested.flambda.reference
+++ b/testsuite/tests/backtrace/backtrace_effects_nested.flambda.reference
@@ -1,4 +1,4 @@
 Raised by primitive operation at Backtrace_effects_nested.blorp in file "backtrace_effects_nested.ml", line 21, characters 2-11
-Called from Stdlib__EffectHandlers.Deep.continue in file "effectHandlers.ml" (inlined), line 36, characters 21-62
+Called from Stdlib__Effect.Deep.continue in file "effect.ml" (inlined), line 36, characters 21-62
 Called from Backtrace_effects_nested.baz.(fun) in file "backtrace_effects_nested.ml", line 29, characters 16-29
 43

--- a/testsuite/tests/warnings/w59.flambda.reference
+++ b/testsuite/tests/warnings/w59.flambda.reference
@@ -1,29 +1,29 @@
-File "w59.ml", line 46, characters 2-43:
-46 |   Obj.set_field (Obj.repr o) 0 (Obj.repr 3);
-       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Warning 59 [flambda-assignment-to-non-mutable-value]: A potential assignment to a non-mutable value was detected 
-in this source file.  Such assignments may generate incorrect code 
-when using Flambda.
 File "w59.ml", line 47, characters 2-43:
-47 |   Obj.set_field (Obj.repr p) 0 (Obj.repr 3);
+47 |   Obj.set_field (Obj.repr o) 0 (Obj.repr 3);
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 59 [flambda-assignment-to-non-mutable-value]: A potential assignment to a non-mutable value was detected 
 in this source file.  Such assignments may generate incorrect code 
 when using Flambda.
 File "w59.ml", line 48, characters 2-43:
-48 |   Obj.set_field (Obj.repr q) 0 (Obj.repr 3);
+48 |   Obj.set_field (Obj.repr p) 0 (Obj.repr 3);
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 59 [flambda-assignment-to-non-mutable-value]: A potential assignment to a non-mutable value was detected 
 in this source file.  Such assignments may generate incorrect code 
 when using Flambda.
 File "w59.ml", line 49, characters 2-43:
-49 |   Obj.set_field (Obj.repr r) 0 (Obj.repr 3)
+49 |   Obj.set_field (Obj.repr q) 0 (Obj.repr 3);
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 59 [flambda-assignment-to-non-mutable-value]: A potential assignment to a non-mutable value was detected 
 in this source file.  Such assignments may generate incorrect code 
 when using Flambda.
-File "w59.ml", line 56, characters 2-7:
-56 |   set o
+File "w59.ml", line 50, characters 2-43:
+50 |   Obj.set_field (Obj.repr r) 0 (Obj.repr 3)
+       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Warning 59 [flambda-assignment-to-non-mutable-value]: A potential assignment to a non-mutable value was detected 
+in this source file.  Such assignments may generate incorrect code 
+when using Flambda.
+File "w59.ml", line 57, characters 2-7:
+57 |   set o
        ^^^^^
 Warning 59 [flambda-assignment-to-non-mutable-value]: A potential assignment to a non-mutable value was detected 
 in this source file.  Such assignments may generate incorrect code 

--- a/testsuite/tests/warnings/w59.ml
+++ b/testsuite/tests/warnings/w59.ml
@@ -14,6 +14,7 @@ compile_only = "true"
 
 * flambda
 compiler_reference = "${test_source_directory}/w59.flambda.reference"
+flags = "-w +A-70 -dflambda-invariants"
 ** setup-ocamlopt.byte-build-env
 *** ocamlopt.byte
 **** check-ocamlopt.byte-output


### PR DESCRIPTION
This is a follow-up to PR #10909, fixing the test for warning 59 and one backtrace output.