### PR TITLE
Random.self_init with getentropy

### DIFF
--- a/Changes
+++ b/Changes
@@ -104,6 +104,11 @@ Working version
   bigarray library (the Bigarray module is now part of the standard library).
   (Nicolás Ojeda Bär, review by Kate Deplaix and Anil Madhavapeddy)
 
+- #10921: Use getentropy, when available, to seed the generator during
+  `Random.self_init`
+  (Michael Hendricks, review by Gabriel Scherer, Xavier Leroy, and
+  Anil Madhavapeddy)
+
 * #10924: Add deprecated attribute to Printexc.catch, Printf.kprintf and
   Unix.SO_ERROR.
   (Nicolás Ojeda Bär, review by Damien Doligez)

--- a/configure
+++ b/configure
@@ -14868,6 +14868,15 @@ fi
 fi
 fi
 
+## getentropy
+ac_fn_c_check_decl "$LINENO" "getentropy" "ac_cv_have_decl_getentropy" "#include <unistd.h>
+"
+if test "x$ac_cv_have_decl_getentropy" = xyes; then :
+  $as_echo "#define HAS_GETENTROPY 1" >>confdefs.h
+
+fi
+
+
 ## getrusage
 ac_fn_c_check_func "$LINENO" "getrusage" "ac_cv_func_getrusage"
 if test "x$ac_cv_func_getrusage" = xyes; then :

--- a/configure
+++ b/configure
@@ -14869,12 +14869,17 @@ fi
 fi
 
 ## getentropy
-ac_fn_c_check_decl "$LINENO" "getentropy" "ac_cv_have_decl_getentropy" "#include <unistd.h>
+ac_fn_c_check_header_mongrel "$LINENO" "unistd.h" "ac_cv_header_unistd_h" "$ac_includes_default"
+if test "x$ac_cv_header_unistd_h" = xyes; then :
+  ac_fn_c_check_decl "$LINENO" "getentropy" "ac_cv_have_decl_getentropy" "#include <unistd.h>
 "
 if test "x$ac_cv_have_decl_getentropy" = xyes; then :
   $as_echo "#define HAS_GETENTROPY 1" >>confdefs.h
 
 fi
+
+fi
+
 
 
 ## getrusage

--- a/configure.ac
+++ b/configure.ac
@@ -1298,7 +1298,11 @@ AS_IF([$has_c99_float_ops],
          (ancient Visual Studio)]))])])])
 
 ## getentropy
-AC_CHECK_DECL([getentropy], [AC_DEFINE([HAS_GETENTROPY])], [], [[#include <unistd.h>]])
+AC_CHECK_HEADER([unistd.h],
+  [AC_CHECK_DECL([getentropy],
+                 [AC_DEFINE([HAS_GETENTROPY])], [],
+                 [[#include <unistd.h>]])],
+  [])
 
 ## getrusage
 AC_CHECK_FUNC([getrusage], [AC_DEFINE([HAS_GETRUSAGE])])

--- a/configure.ac
+++ b/configure.ac
@@ -1297,6 +1297,9 @@ AS_IF([$has_c99_float_ops],
          C99 float ops unavailable, replacements enabled
          (ancient Visual Studio)]))])])])
 
+## getentropy
+AC_CHECK_DECL([getentropy], [AC_DEFINE([HAS_GETENTROPY])], [], [[#include <unistd.h>]])
+
 ## getrusage
 AC_CHECK_FUNC([getrusage], [AC_DEFINE([HAS_GETRUSAGE])])
 

--- a/runtime/caml/s.h.in
+++ b/runtime/caml/s.h.in
@@ -60,6 +60,8 @@
 /* Define HAS_WORKING_ROUND is the round function is correctly implemented. This
    hatch exists primarily for https://sourceforge.net/p/mingw-w64/bugs/573/ */
 
+#undef HAS_GETENTROPY
+
 #undef HAS_GETRUSAGE
 
 #undef HAS_TIMES

--- a/runtime/sys.c
+++ b/runtime/sys.c
@@ -598,14 +598,13 @@ int caml_unix_random_seed(intnat data[16])
   if (getentropy(buffer, 12) != -1) {
     nread = 12;
   } else
-#else
+#endif
   { int fd = open("/dev/urandom", O_RDONLY, 0);
     if (fd != -1) {
       nread = read(fd, buffer, 12);
       close(fd);
     }
   }
-#endif
   while (nread > 0) data[n++] = buffer[--nread];
   /* If the kernel provided enough entropy, we now have 96 bits
      of good random data and can stop here. */


### PR DESCRIPTION
`Random.self_init` currently uses `/dev/urandom` to acquire entropy.  `/dev/urandom` may not be available in chroot environments or in some containers. It's also subject to file handle exhaustion. To work around these problems, many systems have introduced system calls which supply high-quality random numbers. They're designed to seed a process-local PRNG, as we do in `Random.self_init`.

This draft pull request teaches `caml_unix_random_seed` to try `getentropy` before falling back to `/dev/urandom`. There's some incompatibility across platforms, but it's not bad:

- [Linux](https://manpages.debian.org/bullseye/manpages-dev/getentropy.3.en.html), [FreeBSD](https://www.freebsd.org/cgi/man.cgi?query=getentropy&apropos=0&sektion=0&manpath=FreeBSD+13.0-RELEASE+and+Ports&arch=default&format=html), [OpenBSD](https://man.openbsd.org/OpenBSD-7.0/getentropy), [Solaris](https://docs.oracle.com/cd/E88353_01/html/E37841/getentropy-2.html), and [Illumos](https://illumos.org/man/3c/getentropy) declare `getentropy` in `unistd.h`
- [macOS](https://keith.github.io/xcode-man-pages/getentropy.2.html) declares `getentropy` in `sys/random.h`
- [NetBSD](https://man.netbsd.org/arc4random.3) doesn't have `getentropy` (it has `arc4random_buf` but this PR doesn't use it)

This PR works on the machines that I have access to: Ubuntu 20.04 LTS, macOS 10.15.7, and OpenBSD 7.0 (with #10875 applied).

Outstanding questions:
- is it worth `#include <unistd.h>` when `HAS_GETENTROPY`? If a system `HAS_GETENTROPY`, it almost certainly `HAS_UNISTD` so it will have already done the import
- should I add support for NetBSD via `arc4random_buf`?
- if `getentropy` fails, is it worth falling back to `/dev/urandom`.  `getentropy` is designed not to fail unless things are really bad, in which case `/dev/urandom` seems unlikely to work either. I guess it doesn't hurt anything to try both