### PR TITLE
Printexc.catch, Printf.kprintf, Unix.SO_ERROR: add deprecation warning

### DIFF
--- a/Changes
+++ b/Changes
@@ -50,7 +50,7 @@ Working version
 
 * #10924: Add deprecated attribute to Printexc.catch, Printf.kprintf and
   Unix.SO_ERROR.
-  (Nicolás Ojeda Bär)
+  (Nicolás Ojeda Bär, review by Damien Doligez)
 
 ### Other libraries:
 

--- a/Changes
+++ b/Changes
@@ -48,6 +48,10 @@ Working version
   bigarray library (the Bigarray module is now part of the standard library).
   (Nicolás Ojeda Bär, review by Kate Deplaix and Anil Madhavapeddy)
 
+* #10924: Add deprecated attribute to Printexc.catch, Printf.kprintf and
+  Unix.SO_ERROR.
+  (Nicolás Ojeda Bär)
+
 ### Other libraries:
 
 ### Tools:

--- a/lex/main.ml
+++ b/lex/main.ml
@@ -123,4 +123,4 @@ let main () =
     end;
     exit 3
 
-let _ = (* Printexc.catch *) main (); exit 0
+let _ = main (); exit 0

--- a/otherlibs/unix/unix.mli
+++ b/otherlibs/unix/unix.mli
@@ -1543,7 +1543,9 @@ type socket_bool_option =
 type socket_int_option =
     SO_SNDBUF    (** Size of send buffer *)
   | SO_RCVBUF    (** Size of received buffer *)
-  | SO_ERROR     (** Deprecated.  Use {!getsockopt_error} instead. *)
+  | SO_ERROR
+    [@ocaml.deprecated "Use Unix.getsockopt_error instead."]
+    (** Deprecated.  Use {!getsockopt_error} instead. *)
   | SO_TYPE      (** Report the socket type *)
   | SO_RCVLOWAT  (** Minimum number of bytes to process for input operations *)
   | SO_SNDLOWAT  (** Minimum number of bytes to process for output operations *)

--- a/otherlibs/unix/unixLabels.mli
+++ b/otherlibs/unix/unixLabels.mli
@@ -1543,7 +1543,9 @@ type socket_bool_option = Unix.socket_bool_option =
 type socket_int_option = Unix.socket_int_option =
     SO_SNDBUF    (** Size of send buffer *)
   | SO_RCVBUF    (** Size of received buffer *)
-  | SO_ERROR     (** Deprecated.  Use {!getsockopt_error} instead. *)
+  | SO_ERROR
+    [@ocaml.deprecated "Use Unix.getsockopt_error instead."]
+    (** Deprecated.  Use {!getsockopt_error} instead. *)
   | SO_TYPE      (** Report the socket type *)
   | SO_RCVLOWAT  (** Minimum number of bytes to process for input operations *)
   | SO_SNDLOWAT  (** Minimum number of bytes to process for output operations *)

--- a/stdlib/printexc.mli
+++ b/stdlib/printexc.mli
@@ -37,6 +37,7 @@ val print: ('a -> 'b) -> 'a -> 'b
    escape a function application. *)
 
 val catch: ('a -> 'b) -> 'a -> 'b
+[@@ocaml.deprecated "This function is no longer needed."]
 (** [Printexc.catch fn x] is similar to {!Printexc.print}, but
    aborts the program with exit code 2 after printing the
    uncaught exception.  This function is deprecated: the runtime

--- a/stdlib/printf.mli
+++ b/stdlib/printf.mli
@@ -191,4 +191,5 @@ val ikbprintf : (Buffer.t -> 'd) -> Buffer.t ->
 (** Deprecated *)
 
 val kprintf : (string -> 'b) -> ('a, unit, string, 'b) format4 -> 'a
+[@@ocaml.deprecated "Use Printf.ksprintf instead."]
 (** A deprecated synonym for [ksprintf]. *)

--- a/testsuite/tests/lib-arg/testarg.ml
+++ b/testsuite/tests/lib-arg/testarg.ml
@@ -5,7 +5,7 @@ let current = ref 0;;
 let accum = ref [];;
 
 let record fmt (* args *) =
-  Printf.kprintf (fun s -> accum := s :: !accum) fmt
+  Printf.ksprintf (fun s -> accum := s :: !accum) fmt
 ;;
 
 let f_unit () = record "unit()";;

--- a/testsuite/tests/lib-marshal/intext.ml
+++ b/testsuite/tests/lib-marshal/intext.ml
@@ -626,4 +626,4 @@ let main() =
     print_newline()
   end
 
-let _ = Printexc.catch main (); exit 0
+let _ = main (); exit 0

--- a/testsuite/tests/misc/sorts.ml
+++ b/testsuite/tests/misc/sorts.ml
@@ -4452,4 +4452,4 @@ let main () =
     end;
 ;;
 
-if not !Sys.interactive then Printexc.catch main ();;
+if not !Sys.interactive then main ();;

--- a/testsuite/tests/typing-poly-bugs/pr6922_ok.ml
+++ b/testsuite/tests/typing-poly-bugs/pr6922_ok.ml
@@ -93,7 +93,7 @@ module Create(P: Order.Total) = struct
                             List.iter (fun j -> j#emit e) archivers_;
                         cont e
                     in
-                    Printf.kprintf f
+                    Printf.ksprintf f
         end
 end
 

--- a/toplevel/expunge.ml
+++ b/toplevel/expunge.ml
@@ -76,4 +76,4 @@ let main () =
   close_in ic;
   close_out oc
 
-let _ = Printexc.catch main (); exit 0
+let _ = main (); exit 0

--- a/utils/build_path_prefix_map.ml
+++ b/utils/build_path_prefix_map.ml
@@ -17,7 +17,7 @@ type path = string
 type path_prefix = string
 type error_message = string
 
-let errorf fmt = Printf.kprintf (fun err -> Error err) fmt
+let errorf fmt = Printf.ksprintf (fun err -> Error err) fmt
 
 let encode_prefix str =
   let buf = Buffer.create (String.length str) in


### PR DESCRIPTION
These functions have been deprecated for a long time but did not have an official deprecated attribute. This PR adds the attribute so that they will be able to be removed at some point in the future.