### PR TITLE
Rename symbol for Caml_state to caml_state

### DIFF
--- a/runtime/caml/domain_state.h
+++ b/runtime/caml/domain_state.h
@@ -60,7 +60,8 @@ CAML_STATIC_ASSERT(
   #define SET_Caml_state(x) \
       (pthread_setspecific(caml_domain_state_key, x))
 #else
-  CAMLextern __thread caml_domain_state* Caml_state;
+  CAMLextern __thread caml_domain_state* caml_state;
+  #define Caml_state caml_state
   #define CAML_INIT_DOMAIN_STATE
   #define SET_Caml_state(x) (Caml_state = (x))
 #endif

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -247,7 +247,7 @@ void caml_init_domain_state_key (void)
 }
 
 #else
-CAMLexport __thread caml_domain_state* Caml_state;
+CAMLexport __thread caml_domain_state* caml_state;
 #endif
 
 /* Interrupt functions */

--- a/tools/check-symbol-names
+++ b/tools/check-symbol-names
@@ -26,8 +26,6 @@ $3 ~ /^[a-zU]$/ { next }
 # ignore "main", which should be externally linked
 $2 ~ /^_?main$/ { next }
 $2 ~ /^_?wmain$/ { next }
-# Caml_state escapes the prefixing rule for now
-$2 ~ /^_?Caml_state$/ { next }
 # for x86 PIC mode
 $2 ~ /^__x86.get_pc_thunk./ { next }
 # for mingw32


### PR DESCRIPTION
`Caml_state` is a macro on macOS and a symbol elsewhere. If memory serves, that capital "C" was preserved in #8713 to stop painful to-and-fro with the multicore repo (@kayceesrk?).

Given that the symbol can never be relied on, this PR changes it to be `caml_state`, prefixed in the same way as the other runtime global symbols and removes the special case from the global symbol checker.