### PR TITLE
Improve warning 14: illegal backslash. Fix #10929

### DIFF
--- a/Changes
+++ b/Changes
@@ -281,9 +281,10 @@ Working version
 - #11338: Turn some partial application warnings into hints.
   (Leo White, review by Stephen Dolan)
 
-- #10929: Improve warning 14 (illegal backslash) with a better explanation
+- #10931: Improve warning 14 (illegal backslash) with a better explanation
   of the causes and how to fix it.
-  (David Allsopp, Florian Angeletti, Lucas De Angelis, Gabriel Scherer)
+  (David Allsopp, Florian Angeletti, Lucas De Angelis, Gabriel Scherer,
+  review by Nicolás Ojeda Bär and Florian Angeletti)
 
 - #10911: Improve the location reported by parenthesized assert expressions
   (Fabian Hemmer, review by Gabriel Scherer)

--- a/Changes
+++ b/Changes
@@ -281,6 +281,10 @@ Working version
 - #11338: Turn some partial application warnings into hints.
   (Leo White, review by Stephen Dolan)
 
+- #10929: Improve warning 14 (illegal backslash) with a better explanation
+  of the causes and how to fix it.
+  (David Allsopp, Florian Angeletti, Lucas De Angelis, Gabriel Scherer)
+
 - #10911: Improve the location reported by parenthesized assert expressions
   (Fabian Hemmer, review by Gabriel Scherer)
 

--- a/Changes
+++ b/Changes
@@ -284,7 +284,8 @@ Working version
 - #10931: Improve warning 14 (illegal backslash) with a better explanation
   of the causes and how to fix it.
   (David Allsopp, Florian Angeletti, Lucas De Angelis, Gabriel Scherer,
-  review by Nicolás Ojeda Bär and Florian Angeletti)
+  review by Nicolás Ojeda Bär, Florian Angeletti, David Allsopp and
+  Gabriel Scherer)
 
 - #10911: Improve the location reported by parenthesized assert expressions
   (Fabian Hemmer, review by Gabriel Scherer)

--- a/testsuite/tests/lexing/escape.ocaml.reference
+++ b/testsuite/tests/lexing/escape.ocaml.reference
@@ -2,6 +2,10 @@ Line 7, characters 15-17:
 7 | let invalid = "\99" ;;
                    ^^
 Warning 14 [illegal-backslash]: illegal backslash escape in string.
+Hint: Single backslashes \ are reserved for escape sequences
+(\n, \r...). Did you check the list of OCaml escape sequences?
+To get a backslash character, escape it with a second backslash: \\.
+Hint: Quoted strings literals may help you avoid this: {|Hel\*o|}.
 val invalid : string = "\\99"
 Line 1, characters 15-19:
 1 | let invalid = "\999" ;;
@@ -15,10 +19,18 @@ Line 1, characters 15-17:
 1 | let invalid = "\o77" ;;
                    ^^
 Warning 14 [illegal-backslash]: illegal backslash escape in string.
+Hint: Single backslashes \ are reserved for escape sequences
+(\n, \r...). Did you check the list of OCaml escape sequences?
+To get a backslash character, escape it with a second backslash: \\.
+Hint: Quoted strings literals may help you avoid this: {|Hel\*o|}.
 val invalid : string = "\\o77"
 Line 1, characters 15-17:
 1 | let invalid = "\o99" ;;
                    ^^
 Warning 14 [illegal-backslash]: illegal backslash escape in string.
+Hint: Single backslashes \ are reserved for escape sequences
+(\n, \r...). Did you check the list of OCaml escape sequences?
+To get a backslash character, escape it with a second backslash: \\.
+Hint: Quoted strings literals may help you avoid this: {|Hel\*o|}.
 val invalid : string = "\\o99"
 

--- a/testsuite/tests/lexing/escape.ocaml.reference
+++ b/testsuite/tests/lexing/escape.ocaml.reference
@@ -3,7 +3,7 @@ Line 7, characters 15-17:
                    ^^
 Warning 14 [illegal-backslash]: illegal backslash escape in string.
 Hint: Single backslashes \ are reserved for escape sequences
-(\n, \r,...). Did you check the list of OCaml escape sequences?
+(\n, \r, ...). Did you check the list of OCaml escape sequences?
 To get a backslash character, escape it with a second backslash: \\.
 val invalid : string = "\\99"
 Line 1, characters 15-19:
@@ -19,7 +19,7 @@ Line 1, characters 15-17:
                    ^^
 Warning 14 [illegal-backslash]: illegal backslash escape in string.
 Hint: Single backslashes \ are reserved for escape sequences
-(\n, \r,...). Did you check the list of OCaml escape sequences?
+(\n, \r, ...). Did you check the list of OCaml escape sequences?
 To get a backslash character, escape it with a second backslash: \\.
 val invalid : string = "\\o77"
 Line 1, characters 15-17:
@@ -27,7 +27,7 @@ Line 1, characters 15-17:
                    ^^
 Warning 14 [illegal-backslash]: illegal backslash escape in string.
 Hint: Single backslashes \ are reserved for escape sequences
-(\n, \r,...). Did you check the list of OCaml escape sequences?
+(\n, \r, ...). Did you check the list of OCaml escape sequences?
 To get a backslash character, escape it with a second backslash: \\.
 val invalid : string = "\\o99"
 

--- a/testsuite/tests/lexing/escape.ocaml.reference
+++ b/testsuite/tests/lexing/escape.ocaml.reference
@@ -3,9 +3,8 @@ Line 7, characters 15-17:
                    ^^
 Warning 14 [illegal-backslash]: illegal backslash escape in string.
 Hint: Single backslashes \ are reserved for escape sequences
-(\n, \r...). Did you check the list of OCaml escape sequences?
+(\n, \r,...). Did you check the list of OCaml escape sequences?
 To get a backslash character, escape it with a second backslash: \\.
-Hint: Quoted strings literals may help you avoid this: {|Hel\*o|}.
 val invalid : string = "\\99"
 Line 1, characters 15-19:
 1 | let invalid = "\999" ;;
@@ -20,17 +19,15 @@ Line 1, characters 15-17:
                    ^^
 Warning 14 [illegal-backslash]: illegal backslash escape in string.
 Hint: Single backslashes \ are reserved for escape sequences
-(\n, \r...). Did you check the list of OCaml escape sequences?
+(\n, \r,...). Did you check the list of OCaml escape sequences?
 To get a backslash character, escape it with a second backslash: \\.
-Hint: Quoted strings literals may help you avoid this: {|Hel\*o|}.
 val invalid : string = "\\o77"
 Line 1, characters 15-17:
 1 | let invalid = "\o99" ;;
                    ^^
 Warning 14 [illegal-backslash]: illegal backslash escape in string.
 Hint: Single backslashes \ are reserved for escape sequences
-(\n, \r...). Did you check the list of OCaml escape sequences?
+(\n, \r,...). Did you check the list of OCaml escape sequences?
 To get a backslash character, escape it with a second backslash: \\.
-Hint: Quoted strings literals may help you avoid this: {|Hel\*o|}.
 val invalid : string = "\\o99"
 

--- a/testsuite/tests/lexing/uchar_esc.ocaml.reference
+++ b/testsuite/tests/lexing/uchar_esc.ocaml.reference
@@ -26,10 +26,18 @@ Line 1, characters 21-23:
 1 | let no_hex_digits = "\u{}" ;;
                          ^^
 Warning 14 [illegal-backslash]: illegal backslash escape in string.
+Hint: Single backslashes \ are reserved for escape sequences
+(\n, \r...). Did you check the list of OCaml escape sequences?
+To get a backslash character, escape it with a second backslash: \\.
+Hint: Quoted strings literals may help you avoid this: {|Hel\*o|}.
 val no_hex_digits : string = "\\u{}"
 Line 1, characters 25-27:
 1 | let illegal_hex_digit = "\u{u}" ;;
                              ^^
 Warning 14 [illegal-backslash]: illegal backslash escape in string.
+Hint: Single backslashes \ are reserved for escape sequences
+(\n, \r...). Did you check the list of OCaml escape sequences?
+To get a backslash character, escape it with a second backslash: \\.
+Hint: Quoted strings literals may help you avoid this: {|Hel\*o|}.
 val illegal_hex_digit : string = "\\u{u}"
 

--- a/testsuite/tests/lexing/uchar_esc.ocaml.reference
+++ b/testsuite/tests/lexing/uchar_esc.ocaml.reference
@@ -27,7 +27,7 @@ Line 1, characters 21-23:
                          ^^
 Warning 14 [illegal-backslash]: illegal backslash escape in string.
 Hint: Single backslashes \ are reserved for escape sequences
-(\n, \r,...). Did you check the list of OCaml escape sequences?
+(\n, \r, ...). Did you check the list of OCaml escape sequences?
 To get a backslash character, escape it with a second backslash: \\.
 val no_hex_digits : string = "\\u{}"
 Line 1, characters 25-27:
@@ -35,7 +35,7 @@ Line 1, characters 25-27:
                              ^^
 Warning 14 [illegal-backslash]: illegal backslash escape in string.
 Hint: Single backslashes \ are reserved for escape sequences
-(\n, \r,...). Did you check the list of OCaml escape sequences?
+(\n, \r, ...). Did you check the list of OCaml escape sequences?
 To get a backslash character, escape it with a second backslash: \\.
 val illegal_hex_digit : string = "\\u{u}"
 

--- a/testsuite/tests/lexing/uchar_esc.ocaml.reference
+++ b/testsuite/tests/lexing/uchar_esc.ocaml.reference
@@ -27,17 +27,15 @@ Line 1, characters 21-23:
                          ^^
 Warning 14 [illegal-backslash]: illegal backslash escape in string.
 Hint: Single backslashes \ are reserved for escape sequences
-(\n, \r...). Did you check the list of OCaml escape sequences?
+(\n, \r,...). Did you check the list of OCaml escape sequences?
 To get a backslash character, escape it with a second backslash: \\.
-Hint: Quoted strings literals may help you avoid this: {|Hel\*o|}.
 val no_hex_digits : string = "\\u{}"
 Line 1, characters 25-27:
 1 | let illegal_hex_digit = "\u{u}" ;;
                              ^^
 Warning 14 [illegal-backslash]: illegal backslash escape in string.
 Hint: Single backslashes \ are reserved for escape sequences
-(\n, \r...). Did you check the list of OCaml escape sequences?
+(\n, \r,...). Did you check the list of OCaml escape sequences?
 To get a backslash character, escape it with a second backslash: \\.
-Hint: Quoted strings literals may help you avoid this: {|Hel\*o|}.
 val illegal_hex_digit : string = "\\u{u}"
 

--- a/utils/warnings.ml
+++ b/utils/warnings.ml
@@ -918,9 +918,8 @@ let message = function
   | Illegal_backslash ->
     "illegal backslash escape in string.\n\
     Hint: Single backslashes \\ are reserved for escape sequences\n\
-    (\\n, \\r...). Did you check the list of OCaml escape sequences?\n\
-    To get a backslash character, escape it with a second backslash: \\\\.\n\
-    Hint: Quoted strings literals may help you avoid this: {|Hel\\*o|}."
+    (\\n, \\r,...). Did you check the list of OCaml escape sequences?\n\
+    To get a backslash character, escape it with a second backslash: \\\\."
   | Implicit_public_methods l ->
       "the following private methods were made public implicitly:\n "
       ^ String.concat " " l ^ "."

--- a/utils/warnings.ml
+++ b/utils/warnings.ml
@@ -915,7 +915,12 @@ let message = function
         ("the following instance variables are overridden by the class"
          :: cname  :: ":\n " :: slist)
   | Instance_variable_override [] -> assert false
-  | Illegal_backslash -> "illegal backslash escape in string."
+  | Illegal_backslash ->
+    "illegal backslash escape in string.\n\
+    Hint: Single backslashes \\ are reserved for escape sequences\n\
+    (\\n, \\r...). Did you check the list of OCaml escape sequences?\n\
+    To get a backslash character, escape it with a second backslash: \\\\.\n\
+    Hint: Quoted strings literals may help you avoid this: {|Hel\\*o|}."
   | Implicit_public_methods l ->
       "the following private methods were made public implicitly:\n "
       ^ String.concat " " l ^ "."

--- a/utils/warnings.ml
+++ b/utils/warnings.ml
@@ -918,7 +918,7 @@ let message = function
   | Illegal_backslash ->
     "illegal backslash escape in string.\n\
     Hint: Single backslashes \\ are reserved for escape sequences\n\
-    (\\n, \\r,...). Did you check the list of OCaml escape sequences?\n\
+    (\\n, \\r, ...). Did you check the list of OCaml escape sequences?\n\
     To get a backslash character, escape it with a second backslash: \\\\."
   | Implicit_public_methods l ->
       "the following private methods were made public implicitly:\n "


### PR DESCRIPTION
There's already some discussion in the linked issue, #10929. All tests pass locally, `check-typo` doesn't report any issue.