### PR TITLE
webman: Fix empty anchor elements being visible

### DIFF
--- a/manual/src/html_processing/scss/manual.scss
+++ b/manual/src/html_processing/scss/manual.scss
@@ -116,8 +116,7 @@ a:hover{
 }
 :target{
     background-color:rgba(255,215,181,.3)!important;
-    box-shadow:0 0 0 1px rgba(255,215,181,.8)!important;
-    border-radius:1px
+    box-shadow: inset 0 0 0 1px rgba(255,215,181,.8)!important;
 }
 :hover>a.section-anchor{
     visibility:visible


### PR DESCRIPTION
On pages such as https://ocaml.org/manual/gadts-tutorial.html#c%3Agadts-tutorial there is a minor visual glitch: the empty `<a id="c:gadts-tutorial"></a>` at the top of the viewport appears as a faint orange line/square (depending on the browser). This PR fixes that.

Currently, targeted elements cast a 1px orange shadow around them.
Adding `inset` moves the shadow to inside the element, so it disappears for empty elements.

The border-radius property was unnecessary, as there was no border.