### PR TITLE
Always define `CAML_NAME_SPACE`

### DIFF
--- a/Changes
+++ b/Changes
@@ -7,9 +7,9 @@ Working version
 - #10831: Multicore OCaml
   (The multicore team, caml-devel and more)
 
-* #10863: Remove support for old, unprefixed C runtime function names such as
-  `alloc`.  The new names prefixed with `caml_` must be used instead, such as
-  `caml_alloc`.  Consequently, it is no longer needed to define
+* #10863, #10933: Remove support for old, unprefixed C runtime function names
+  such as `alloc`.  The new names prefixed with `caml_` must be used instead,
+  such as `caml_alloc`.  Consequently, it is no longer needed to define
   `CAML_NAME_SPACE` to avoid bringing unprefixed names into scope: this is now
   the default behavior.
   (Nicolás Ojeda Bär, review by Xavier Leroy)

--- a/runtime/caml/config.h
+++ b/runtime/caml/config.h
@@ -16,6 +16,15 @@
 #ifndef CAML_CONFIG_H
 #define CAML_CONFIG_H
 
+/* CAML_NAME_SPACE was introduced in OCaml 3.08 to declare compatibility with
+   the newly caml_-prefixed names of C runtime functions and to disable the
+   definition of compatibility macros for the un-prefixed names. The
+   compatibility layer was removed in OCaml 5.00, so CAML_NAME_SPACE is the
+   default. */
+#ifndef CAML_NAME_SPACE
+#define CAML_NAME_SPACE
+#endif
+
 #include "m.h"
 
 /* If supported, tell gcc that we can use 32-bit code addresses for


### PR DESCRIPTION
Small follow-up to #10863 inspired by the points being made at https://github.com/ocaml/ocaml/pull/10675#issuecomment-1018473853.

Rather than obliterating `CAML_NAME_SPACE`, we've made it the "default", so this just ensures in `config.h` that it's always set (all the public headers pull in `config.h`). Apart from anything else, it ensures that it never gets used for anything else in OCaml 10 in another 25 years' time 🙂