### PR TITLE
Do not put deprecation warnings on int8, uint8, int16, uint16

### DIFF
--- a/Changes
+++ b/Changes
@@ -33,7 +33,7 @@ OCaml 4.14.0
 - #10549: Stack overflow detection and naked pointers checking for ARM64
   (Xavier Leroy, review by Stephen Dolan)
 
-* #10675: Emit deprecation warnings when old C runtime function names
+* #10675, #10937: Emit deprecation warnings when old C runtime function names
   are used.  This will break C stub code that uses these old names and
   treats warnings as errors.  The workaround is to use the new names.
   (Xavier Leroy and David Allsopp, review by Sébastien Hinderer and

--- a/runtime/caml/compatibility.h
+++ b/runtime/caml/compatibility.h
@@ -307,10 +307,10 @@
 /* ************************************************************* */
 
 /* **** otherlibs/bigarray */
-#define int8 CAML_DEPRECATED("int8", "caml_ba_int8") caml_ba_int8
-#define uint8 CAML_DEPRECATED("uint8", "caml_ba_uint8") caml_ba_uint8
-#define int16 CAML_DEPRECATED("int16", "caml_ba_int16") caml_ba_int16
-#define uint16 CAML_DEPRECATED("uint16", "caml_ba_uint16") caml_ba_uint16
+#define int8 caml_ba_int8
+#define uint8 caml_ba_uint8
+#define int16 caml_ba_int16
+#define uint16 caml_ba_uint16
 #define MAX_NUM_DIMS CAML_DEPRECATED("MAX_NUM_DIMS", "CAML_BA_MAX_NUM_DIMS") CAML_BA_MAX_NUM_DIMS
 #define caml_bigarray_kind CAML_DEPRECATED("caml_bigarray_kind", "caml_ba_kind") caml_ba_kind
 #define BIGARRAY_FLOAT32 CAML_DEPRECATED("BIGARRAY_FLOAT32", "CAML_BA_FLOAT32") CAML_BA_FLOAT32


### PR DESCRIPTION
As reported in #10675, user C code often defines these names (typically as typedefs), as opposed to using the definitions provided by `<caml/bigarray.h>`.  The deprecation warning is confusing and not useful in the former case.
