### PR TITLE
Add comment to document flag in Cmm

### DIFF
--- a/asmcomp/cmm.mli
+++ b/asmcomp/cmm.mli
@@ -143,7 +143,8 @@ and operation =
   | Cextcall of string * machtype * exttype list * bool
       (** The [machtype] is the machine type of the result.
           The [exttype list] describes the unboxing types of the arguments.
-          An empty list means "all arguments are machine words [XInt]". *)
+          An empty list means "all arguments are machine words [XInt]".
+          The boolean indicates whether the function may allocate. *)
   | Cload of
       { memory_chunk: memory_chunk
       ; mutability: Asttypes.mutable_flag


### PR DESCRIPTION
The `Cextcall` constructor of Cmm operations has a boolean flag indicating whether the primitive may allocate. All the other (non-obvious) arguments of the constructor are documented but this one.