### PR TITLE
Introduce atomic loads in Cmm and Mach IRs

### DIFF
--- a/asmcomp/CSEgen.ml
+++ b/asmcomp/CSEgen.ml
@@ -226,7 +226,7 @@ method class_of_operation op =
   | Icall_ind | Icall_imm _ | Itailcall_ind | Itailcall_imm _
   | Iextcall _ | Iopaque -> assert false       (* treated specially *)
   | Istackoffset _ -> Op_other
-  | Iload(_,_,mut) -> Op_load mut
+  | Iload { mutability } -> Op_load mutability
   | Istore(_,_,asg) -> Op_store asg
   | Ialloc _ | Ipoll _ -> assert false     (* treated specially *)
   | Iintop(Icheckbound) -> Op_checkbound

--- a/asmcomp/amd64/emit.mlp
+++ b/asmcomp/amd64/emit.mlp
@@ -574,27 +574,27 @@ let emit_instr env fallthrough i =
       if n <> 0
       then cfi_adjust_cfa_offset n;
       env.stack_offset <- env.stack_offset + n
-  | Lop(Iload(chunk, addr, _mut)) ->
+  | Lop(Iload { memory_chunk; addressing_mode; _ }) ->
       let dest = res i 0 in
-      begin match chunk with
+      begin match memory_chunk with
       | Word_int | Word_val ->
-          I.mov (addressing addr QWORD i 0) dest
+          I.mov (addressing addressing_mode QWORD i 0) dest
       | Byte_unsigned ->
-          I.movzx (addressing addr BYTE i 0) dest
+          I.movzx (addressing addressing_mode BYTE i 0) dest
       | Byte_signed ->
-          I.movsx (addressing addr BYTE i 0) dest
+          I.movsx (addressing addressing_mode BYTE i 0) dest
       | Sixteen_unsigned ->
-          I.movzx (addressing addr WORD i 0) dest
+          I.movzx (addressing addressing_mode WORD i 0) dest
       | Sixteen_signed ->
-          I.movsx (addressing addr WORD i 0) dest;
+          I.movsx (addressing addressing_mode WORD i 0) dest;
       | Thirtytwo_unsigned ->
-          I.mov (addressing addr DWORD i 0) (res32 i 0)
+          I.mov (addressing addressing_mode DWORD i 0) (res32 i 0)
       | Thirtytwo_signed ->
-          I.movsxd (addressing addr DWORD i 0) dest
+          I.movsxd (addressing addressing_mode DWORD i 0) dest
       | Single ->
-          I.cvtss2sd (addressing addr REAL4 i 0) dest
+          I.cvtss2sd (addressing addressing_mode REAL4 i 0) dest
       | Double ->
-          I.movsd (addressing addr REAL8 i 0) dest
+          I.movsd (addressing addressing_mode REAL8 i 0) dest
       end
   | Lop(Istore(chunk, addr, _)) ->
       begin match chunk with

--- a/asmcomp/cmm_helpers.ml
+++ b/asmcomp/cmm_helpers.ml
@@ -628,6 +628,9 @@ let rec remove_unit = function
 let mk_load_mut memory_chunk =
   Cload {memory_chunk; mutability=Mutable; is_atomic=false}
 
+let mk_load_atomic memory_chunk =
+  Cload {memory_chunk; mutability=Mutable; is_atomic=true}
+
 let field_address ptr n dbg =
   if n = 0
   then ptr

--- a/asmcomp/cmm_helpers.mli
+++ b/asmcomp/cmm_helpers.mli
@@ -188,7 +188,12 @@ val return_unit : Debuginfo.t -> expression -> expression
 val remove_unit : expression -> expression
 
 (** Blocks *)
+
+(** Non-atomic load of a mutable field *)
 val mk_load_mut : memory_chunk -> operation
+
+(** Atomic load. All atomic fields are mutable. *)
+val mk_load_atomic : memory_chunk -> operation
 
 (** [field_address ptr n dbg] returns an expression for the address of the
     [n]th field of the block pointed to by [ptr] *)

--- a/asmcomp/cmmgen.ml
+++ b/asmcomp/cmmgen.ml
@@ -864,9 +864,9 @@ and transl_prim_1 env p arg dbg =
   | Pdls_get ->
       Cop(Cdls_get, [transl env arg], dbg)
   | Patomic_load {immediate_or_pointer = Immediate} ->
-      Cop(mk_load_mut Word_int, [transl env arg], dbg)
+      Cop(mk_load_atomic Word_int, [transl env arg], dbg)
   | Patomic_load {immediate_or_pointer = Pointer} ->
-      Cop(mk_load_mut Word_val, [transl env arg], dbg)
+      Cop(mk_load_atomic Word_val, [transl env arg], dbg)
   | (Pfield_computed | Psequand | Psequor
     | Prunstack | Presume | Preperform
     | Patomic_exchange | Patomic_cas | Patomic_fetch_add

--- a/asmcomp/mach.ml
+++ b/asmcomp/mach.ml
@@ -52,7 +52,10 @@ type operation =
                   alloc : bool;
                   stack_ofs : int; }
   | Istackoffset of int
-  | Iload of Cmm.memory_chunk * Arch.addressing_mode * Asttypes.mutable_flag
+  | Iload of { memory_chunk : Cmm.memory_chunk;
+               addressing_mode : Arch.addressing_mode;
+               mutability : Asttypes.mutable_flag;
+               is_atomic : bool }
   | Istore of Cmm.memory_chunk * Arch.addressing_mode * bool
   | Ialloc of { bytes : int; dbginfo : Debuginfo.alloc_dbginfo; }
   | Iintop of integer_operation

--- a/asmcomp/mach.mli
+++ b/asmcomp/mach.mli
@@ -52,7 +52,10 @@ type operation =
                   alloc : bool;
                   stack_ofs : int; }
   | Istackoffset of int
-  | Iload of Cmm.memory_chunk * Arch.addressing_mode * Asttypes.mutable_flag
+  | Iload of { memory_chunk : Cmm.memory_chunk;
+               addressing_mode : Arch.addressing_mode;
+               mutability : Asttypes.mutable_flag;
+               is_atomic : bool }
   | Istore of Cmm.memory_chunk * Arch.addressing_mode * bool
                                  (* false = initialization, true = assignment *)
   | Ialloc of { bytes : int; dbginfo : Debuginfo.alloc_dbginfo; }

--- a/asmcomp/printmach.ml
+++ b/asmcomp/printmach.ml
@@ -122,12 +122,16 @@ let operation op arg ppf res =
       (if alloc then "" else " (noalloc)")
   | Istackoffset n ->
       fprintf ppf "offset stack %i" n
-  | Iload(chunk, addr, Immutable) ->
-      fprintf ppf "%s[%a]"
-       (Printcmm.chunk chunk) (Arch.print_addressing reg addr) arg
-  | Iload(chunk, addr, Mutable) ->
-      fprintf ppf "%s mut[%a]"
-       (Printcmm.chunk chunk) (Arch.print_addressing reg addr) arg
+  | Iload { memory_chunk; addressing_mode; mutability=Immutable; is_atomic } ->
+      fprintf ppf "%s %a[%a]"
+       (Printcmm.chunk memory_chunk)
+       (fun pp a -> if a then fprintf pp "atomic" else ()) is_atomic
+       (Arch.print_addressing reg addressing_mode) arg
+  | Iload { memory_chunk; addressing_mode; mutability=Mutable; is_atomic } ->
+      fprintf ppf "%s %a mut[%a]"
+       (Printcmm.chunk memory_chunk)
+       (fun pp a -> if a then fprintf pp "atomic" else ()) is_atomic
+       (Arch.print_addressing reg addressing_mode) arg
   | Istore(chunk, addr, is_assign) ->
       fprintf ppf "%s[%a] := %a %s"
        (Printcmm.chunk chunk)

--- a/asmcomp/schedgen.ml
+++ b/asmcomp/schedgen.ml
@@ -135,7 +135,12 @@ let rec remove_instr node = function
 
 (* We treat Lreloadretaddr as a word-sized load *)
 
-let some_load = (Iload(Cmm.Word_int, Arch.identity_addressing, Mutable))
+let some_load =
+  Iload {
+    memory_chunk = Cmm.Word_int;
+    addressing_mode = Arch.identity_addressing;
+    mutability = Mutable;
+    is_atomic = false }
 
 (* The generic scheduler *)
 
@@ -181,7 +186,7 @@ method is_store = function
   | _ -> false
 
 method is_load = function
-    Iload(_, _, _) -> true
+    Iload _ -> true
   | _ -> false
 
 method is_checkbound = function

--- a/asmcomp/selectgen.ml
+++ b/asmcomp/selectgen.ml
@@ -446,9 +446,9 @@ method select_operation op args _dbg =
     (Icall_ind, args)
   | (Cextcall(func, ty_res, ty_args, alloc), _) ->
     Iextcall { func; alloc; ty_res; ty_args; stack_ofs = -1}, args
-  | (Cload {memory_chunk; mutability}, [arg]) ->
-      let (addr, eloc) = self#select_addressing memory_chunk arg in
-      (Iload(memory_chunk, addr, mutability), [eloc])
+  | (Cload {memory_chunk; mutability; is_atomic}, [arg]) ->
+      let (addressing_mode, eloc) = self#select_addressing memory_chunk arg in
+      (Iload {memory_chunk; addressing_mode; mutability; is_atomic}, [eloc])
   | (Cstore (chunk, init), [arg1; arg2]) ->
       let (addr, eloc) = self#select_addressing chunk arg1 in
       let is_assign =


### PR DESCRIPTION
The `Patomic_load` primitive gives lieu to a non-atomic load (i.e. `Cload { is_atomic = false; _ }`) in Cmm. This is correct in x86 but needs to be lowered down the pipeline to ease support of other architectures.

In addition, this PR proposes to add an `~is_atomic` argument to the `mk_load_mut` helper to make the atomicity of loads explicit during Cmm generation.