### PR TITLE
Make young_limit atomic

### DIFF
--- a/runtime/caml/domain.h
+++ b/runtime/caml/domain.h
@@ -30,7 +30,9 @@ extern "C" {
 
 #define Caml_check_gc_interrupt(dom_st)   \
   (CAMLalloc_point_here, \
-   CAMLunlikely((uintnat)(dom_st)->young_ptr < (dom_st)->young_limit))
+   CAMLunlikely( \
+     (uintnat)(dom_st)->young_ptr < \
+     atomic_load_explicit(&((dom_st)->young_limit), memory_order_relaxed)))
 
 asize_t caml_norm_minor_heap_size (intnat);
 int caml_reallocate_minor_heap(asize_t);

--- a/runtime/caml/domain_state.tbl
+++ b/runtime/caml/domain_state.tbl
@@ -14,7 +14,7 @@
 /*                                                                        */
 /**************************************************************************/
 
-DOMAIN_STATE(volatile uintnat, young_limit)
+DOMAIN_STATE(atomic_uintnat, young_limit)
 /* Minor heap limit. Typically young_limit == young_start, but this field is set
  * by other domains to signal this domain by causing a spurious allocation
  * failure. */

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -383,7 +383,8 @@ int caml_reallocate_minor_heap(asize_t wsize)
   domain_state->young_start = (value*)domain_self->minor_heap_area;
   domain_state->young_end =
       (value*)(domain_self->minor_heap_area + Bsize_wsize(wsize));
-  domain_state->young_limit = (uintnat) domain_state->young_start;
+  atomic_store_rel(&domain_state->young_limit,
+                   (uintnat) domain_state->young_start);
   domain_state->young_ptr = domain_state->young_end;
   return 0;
 }
@@ -416,7 +417,7 @@ static void create_domain(uintnat initial_minor_heap_wsize) {
         goto domain_init_complete;
       }
       domain_state = (caml_domain_state*)(d->tls_area);
-      young_limit = (atomic_uintnat*)&domain_state->young_limit;
+      young_limit = &domain_state->young_limit;
       s->interrupt_word = young_limit;
       atomic_store_rel(young_limit, (uintnat)domain_state->young_start);
     }

--- a/runtime/minor_gc.c
+++ b/runtime/minor_gc.c
@@ -632,7 +632,7 @@ void caml_empty_minor_heap_promote(caml_domain_state* domain,
      released to avoid races where another domain signals an interrupt
      and we clobber it */
   atomic_store_rel
-    ((atomic_uintnat*)&domain->young_limit, (uintnat)domain->young_start);
+    (&domain->young_limit, (uintnat)domain->young_start);
 
   atomic_store_rel
     ((atomic_uintnat*)&domain->young_ptr, (uintnat)domain->young_end);

--- a/runtime/signals.c
+++ b/runtime/signals.c
@@ -46,7 +46,7 @@ int caml_check_for_pending_signals(void)
 {
   int i;
   /* [MM] This fence compensates for the fact that Caml_check_gc_interrupt
-     reads young_limit non-atomically.  It is possible in theory to
+     reads young_limit with a relaxed load.  It is possible in theory to
      see young_limit updated without caml_pending_signals being set
      and then resetting young_limit after the check.  This would delay
      processing the pending signal until young_limit is updated again.

--- a/runtime/signals_nat.c
+++ b/runtime/signals_nat.c
@@ -98,7 +98,8 @@ void caml_garbage_collection(void)
     do {
       caml_process_pending_actions();
     } while
-       ( (uintnat)(Caml_state->young_ptr - whsize) <= Caml_state->young_limit );
+       ( (uintnat)(Caml_state->young_ptr - whsize) <=
+         atomic_load_explicit(&Caml_state->young_limit, memory_order_relaxed) );
 
     /* Re-do the allocation: we now have enough space in the minor heap. */
     Caml_state->young_ptr -= whsize;


### PR DESCRIPTION
As discussed during the memory model working group:
- Declare the `young_limit` field of the domain state as atomic (instead of volatile like today).
- Test it relaxed atomic loads.
- Update it using release atomic stores.  (Most updates were release atomic already.)
