### PR TITLE
Recommend using verbatim string literals for regexes

### DIFF
--- a/otherlibs/str/str.mli
+++ b/otherlibs/str/str.mli
@@ -50,21 +50,20 @@ val regexp : string -> regexp
    - [\     ] Quotes special characters.  The special characters
               are [$^\.*+?[]].
 
-   Note: the argument to [regexp] is usually a string literal. In this
-   case, any backslash character in the regular expression must be
-   doubled to make it past the OCaml string parser. For example, the
-   following expression:
-   {[ let r = Str.regexp "hello \\([A-Za-z]+\\)" in
-      Str.replace_first r "\\1" "hello world" ]}
+   In regular expressions you will often use backslash characters; it's
+   easier to use a verbatim string literal [{|...|}] to avoid having to
+   escape backslashes. And, if you want a regular expression that
+   matches a literal backslash character, you need to double it, i.e.
+   [Str.regexp {|\\|}].
+
+   For example, the following expression:
+   {[ let r = Str.regexp {|hello \([A-Za-z]+\)|} in
+      Str.replace_first r {|\1|} "hello world" ]}
    returns the string ["world"].
 
-   In particular, if you want a regular expression that matches a single
-   backslash character, you need to quote it in the argument to [regexp]
-   (according to the last item of the list above) by adding a second
-   backslash. Then you need to quote both backslashes (according to the
-   syntax of string constants in OCaml) by doubling them again, so you
-   need to write four backslash characters: [Str.regexp "\\\\"].
-*)
+   This is just a recommendation; you can use double quote string
+   literals i.e.  ["..."], however you will have to carefully escape
+   backslashes. *)
 
 val regexp_case_fold : string -> regexp
 (** Same as [regexp], but the compiled expression will match text

--- a/otherlibs/str/str.mli
+++ b/otherlibs/str/str.mli
@@ -51,19 +51,24 @@ val regexp : string -> regexp
               are [$^\.*+?[]].
 
    In regular expressions you will often use backslash characters; it's
-   easier to use a verbatim string literal [{|...|}] to avoid having to
-   escape backslashes. And, if you want a regular expression that
-   matches a literal backslash character, you need to double it, i.e.
-   [Str.regexp {|\\|}].
+   easier to use a quoted string literal [{|...|}] to avoid having to
+   escape backslashes.
 
    For example, the following expression:
    {[ let r = Str.regexp {|hello \([A-Za-z]+\)|} in
       Str.replace_first r {|\1|} "hello world" ]}
    returns the string ["world"].
 
-   This is just a recommendation; you can use double quote string
-   literals i.e.  ["..."], however you will have to carefully escape
-   backslashes. *)
+   If you want a regular expression that matches a literal backslash
+   character, you need to double it: [Str.regexp {|\\|}].
+
+   You can use regular string literals ["..."] too, however you will
+   have to escape backslashes. To repeat the example above with a
+   regular string literal:
+   {[ let r = Str.regexp "hello \\([A-Za-z]+\\)" in
+      Str.replace_first r "\\1" "hello world" ]}
+
+   And the double backslash regular expression: [Str.regexp "\\\\"]. *)
 
 val regexp_case_fold : string -> regexp
 (** Same as [regexp], but the compiled expression will match text

--- a/otherlibs/str/str.mli
+++ b/otherlibs/str/str.mli
@@ -63,12 +63,13 @@ val regexp : string -> regexp
    character, you need to double it: [Str.regexp {|\\|}].
 
    You can use regular string literals ["..."] too, however you will
-   have to escape backslashes. To repeat the example above with a
-   regular string literal:
+   have to escape backslashes. The example above can be rewritten with a
+   regular string literal as:
    {[ let r = Str.regexp "hello \\([A-Za-z]+\\)" in
       Str.replace_first r "\\1" "hello world" ]}
 
-   And the double backslash regular expression: [Str.regexp "\\\\"]. *)
+   And the regular expression for matching a backslash becomes a
+   quadruple backslash: [Str.regexp "\\\\"]. *)
 
 val regexp_case_fold : string -> regexp
 (** Same as [regexp], but the compiled expression will match text


### PR DESCRIPTION
To avoid the need to escape backslashes.