### PR TITLE
Document exception raised by read_line

### DIFF
--- a/stdlib/stdlib.mli
+++ b/stdlib/stdlib.mli
@@ -892,11 +892,11 @@ val prerr_newline : unit -> unit
 
 val read_line : unit -> string
 (** Flush standard output, then read characters from standard input
-   until a newline character is encountered. 
-   
+   until a newline character is encountered.
+
    Return the string of all characters read, without the newline character
-   at the end. 
-   
+   at the end.
+
    @raise End_of_file if the end of the file is reached at the beginning of
    line.
 *)

--- a/stdlib/stdlib.mli
+++ b/stdlib/stdlib.mli
@@ -897,7 +897,9 @@ val read_line : unit -> string
    Return the string of all characters read, without the newline character
    at the end. 
    
-   @raise End_of_file if the end of the file is reached at the beginning of line.*)
+   @raise End_of_file if the end of the file is reached at the beginning of
+   line.
+*)
 
 val read_int_opt: unit -> int option
 (** Flush standard output, then read one line from standard input

--- a/stdlib/stdlib.mli
+++ b/stdlib/stdlib.mli
@@ -892,8 +892,12 @@ val prerr_newline : unit -> unit
 
 val read_line : unit -> string
 (** Flush standard output, then read characters from standard input
-   until a newline character is encountered. Return the string of
-   all characters read, without the newline character at the end. *)
+   until a newline character is encountered. 
+   
+   Return the string of all characters read, without the newline character
+   at the end. 
+   
+   @raise End_of_file if the end of the file is reached at the beginning of line.*)
 
 val read_int_opt: unit -> int option
 (** Flush standard output, then read one line from standard input


### PR DESCRIPTION
read_line may throw an exception when EOF reached before an input is available.

read_line calls version of input_line that may throw an exception, see https://github.com/ocaml/ocaml/blob/95b347a5f4c7906f1816377c2fecf0e28c9597ef/stdlib/stdlib.ml#L454

To reproduce:
```ocaml
let _ = while true do
	read_line () |> print_endline
done
```

```bash
echo -e "^D" | ocaml ./above_code.ml
```