### PR TITLE
Allocate domain state using malloc instead of mmap

### DIFF
--- a/Changes
+++ b/Changes
@@ -29,6 +29,12 @@ Working version
   (Anil Madhavapeddy, review by Gabriel Scherer, Tom Kelly,
    Michael Hendricks and KC Sivaramakrishnan).
 
+- #10950: Do not use mmap to allocate Caml_state.
+  In order to reduce virtual memory usage, we dynamically allocate
+  the domain_state structure.
+  (Enguerrand Decorne, KC Sivaramakrishnan and Tom Kelly,
+  review by Anil Madhavapeddy and Gabriel Scherer)
+
 ### Code generation and optimizations:
 
 ### Standard library:

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -438,7 +438,7 @@ static void create_domain(uintnat initial_minor_heap_wsize) {
     /* If the chosen domain slot has not been previously used, allocate a fresh
      * domain state. Otherwise, reuse it. Reusing the slot ensures that the GC
      * stats are not lost. */
-    if (!d->state) {
+    if (d->state == NULL) {
       /* FIXME: Never freed. Not clear when to. */
       domain_state = (caml_domain_state*)
         caml_stat_calloc_noexc(1, sizeof(caml_domain_state));


### PR DESCRIPTION
This pull request addresses ocaml-multicore/ocaml-multicore#796. 

The motivation is to avoid unnecessary use of `mmap` in the runtime. The PR replaces the use of `mmap`, which is a vestige of the old multicore GC design, with `malloc` (through `caml_stat_alloc_noexc`). 

The dynamically allocated domain state structures are not freed similar to the current `mmap` based implementation. This is because the runtime stores the GC stats in the domain state structures, and freeing them at domain termination would lose stats. The proper solution to this would be to orphan the stats to a global structure in the runtime. At this point, we will also get the benefit of being able to provide accurate GC stats per domain (for which no API exists now). This should be addressed in a separate PR.

There is also no attempt to align the domain state structure to cache lines as we suggested earlier in ocaml-multicore/ocaml-multicore#796 discussion. This needs experimental evidence for the purported benefits.

cc @kayceesrk @ctk21.