### PR TITLE
Introduce the Thread.Exit exception

### DIFF
--- a/Changes
+++ b/Changes
@@ -149,6 +149,11 @@ OCaml 4.14.0
   WSADuplicateSocket on sockets instead of DuplicateHandle.
   (Antonin Décimo, review by Xavier Leroy and Nicolás Ojeda Bär)
 
+- #10951: Introduce the Thread.Exit exception as an alternative way to
+  terminate threads prematurely.  This alternative way will become
+  the standard way in 5.00.
+  (Xavier Leroy, review by Florian Angeletti)
+
 ### Tools:
 
 - #3959, #7202, #10476: ocaml, in script mode, directive errors

--- a/otherlibs/systhreads/thread.mli
+++ b/otherlibs/systhreads/thread.mli
@@ -27,8 +27,9 @@ val create : ('a -> 'b) -> 'a -> t
    The application of [Thread.create]
    returns the handle of the newly created thread.
    The new thread terminates when the application [funct arg]
-   returns, either normally or by raising an uncaught exception.
-   In the latter case, the exception is printed on standard error,
+   returns, either normally or by raising the {!Thread.Exit} exception
+   or by raising any other uncaught exception.
+   In the last case, the uncaught exception is printed on standard error,
    but not propagated back to the parent thread. Similarly, the
    result of the application [funct arg] is discarded and not
    directly accessible to the parent thread. *)
@@ -40,6 +41,18 @@ val id : t -> int
 (** Return the identifier of the given thread. A thread identifier
    is an integer that identifies uniquely the thread.
    It can be used to build data structures indexed by threads. *)
+
+exception Exit
+(** Exception raised by user code to initiate termination of the
+    current thread.
+    In a thread created by [{!Thread.create} funct arg], if the
+    {!Thread.Exit} exception reaches the top of the application
+    [funct arg], it has the effect of terminating the current thread
+    silently.  In other contexts, there is no implicit handling of the
+    {!Thread.Exit} exception.
+
+    @since 4.14.0
+*)
 
 val exit : unit -> unit
 (** Terminate prematurely the currently executing thread. *)

--- a/otherlibs/systhreads/thread.mli
+++ b/otherlibs/systhreads/thread.mli
@@ -43,13 +43,12 @@ val id : t -> int
    It can be used to build data structures indexed by threads. *)
 
 exception Exit
-(** Exception raised by user code to initiate termination of the
-    current thread.
-    In a thread created by [{!Thread.create} funct arg], if the
-    {!Thread.Exit} exception reaches the top of the application
-    [funct arg], it has the effect of terminating the current thread
-    silently.  In other contexts, there is no implicit handling of the
-    {!Thread.Exit} exception.
+(** Exception that can be raised by user code to initiate termination
+    of the current thread.
+    Compared to calling [{!Thread.exit} ()], raising the {!Thread.Exit}
+    exception will trigger {!Fun.finally} finalizers and catch-all
+    exception handlers.
+    It is the recommended way to terminate threads prematurely.
 
     @since 4.14.0
 *)

--- a/otherlibs/systhreads/thread.mli
+++ b/otherlibs/systhreads/thread.mli
@@ -45,9 +45,9 @@ val id : t -> int
 exception Exit
 (** Exception that can be raised by user code to initiate termination
     of the current thread.
-    Compared to calling [{!Thread.exit} ()], raising the {!Thread.Exit}
-    exception will trigger {!Fun.finally} finalizers and catch-all
-    exception handlers.
+    Compared to calling the {!Thread.exit} function, raising the
+    {!Thread.Exit} exception will trigger {!Fun.finally} finalizers
+    and catch-all exception handlers.
     It is the recommended way to terminate threads prematurely.
 
     @since 4.14.0

--- a/testsuite/tests/backtrace/callstack.reference
+++ b/testsuite/tests/backtrace/callstack.reference
@@ -12,4 +12,4 @@ Raised by primitive operation at Callstack.f0 in file "callstack.ml", line 11, c
 Called from Callstack.f1 in file "callstack.ml", line 12, characters 27-32
 Called from Callstack.f2 in file "callstack.ml", line 13, characters 27-32
 Called from Callstack.f3 in file "callstack.ml", line 14, characters 27-32
-Called from Thread.create.(fun) in file "thread.ml", line 47, characters 8-14
+Called from Thread.create.(fun) in file "thread.ml", line 49, characters 8-14

--- a/testsuite/tests/lib-threads/uncaught_exception_handler.reference
+++ b/testsuite/tests/lib-threads/uncaught_exception_handler.reference
@@ -1,12 +1,15 @@
 Thread 1 killed on uncaught exception Uncaught_exception_handler.CallbackExn
 Raised at Uncaught_exception_handler.fn in file "uncaught_exception_handler.ml", line 28, characters 12-113
-Called from Thread.create.(fun) in file "thread.ml", line 47, characters 8-14
+Called from Thread.create.(fun) in file "thread.ml", line 49, characters 8-14
 [thread 2] caught Uncaught_exception_handler.CallbackExn
 Raised at Uncaught_exception_handler.fn in file "uncaught_exception_handler.ml", line 28, characters 12-113
-Called from Thread.create.(fun) in file "thread.ml", line 47, characters 8-14
+Called from Thread.create.(fun) in file "thread.ml", line 49, characters 8-14
 Thread 2 killed on uncaught exception Uncaught_exception_handler.CallbackExn
 Raised at Uncaught_exception_handler.fn in file "uncaught_exception_handler.ml", line 28, characters 12-113
-Called from Thread.create.(fun) in file "thread.ml", line 47, characters 8-14
+Called from Thread.create.(fun) in file "thread.ml", line 49, characters 8-14
 Thread 2 uncaught exception handler raised Uncaught_exception_handler.UncaughtHandlerExn
-Raised at Uncaught_exception_handler.handler in file "uncaught_exception_handler.ml", line 26, characters 2-26
-Called from Thread.create.(fun) in file "thread.ml", line 53, characters 10-41
+Raised at Uncaught_exception_handler.handler in file "uncaught_exception_handler.ml", line 26, characters 2-17
+Called from Thread.create.(fun) in file "thread.ml", line 58, characters 10-41
+[thread 3] caught Uncaught_exception_handler.CallbackExn
+Raised at Uncaught_exception_handler.fn in file "uncaught_exception_handler.ml", line 28, characters 12-113
+Called from Thread.create.(fun) in file "thread.ml", line 49, characters 8-14


### PR DESCRIPTION
As discussed in #10935:

Raising `Thread.Exit` provides an alternative to `Thread.exit` for terminating the current thread, an alternative that is more compatible with explicit resource  management (e.g. `Fun.finally` finalizers are called).

The semantics of `Thread.exit` is unchanged, so this is just an extension of 4.14 that paves the way for 5.00.

In 5.00, Thread.exit is deprecated and its semantics changes to `raise Thread.Exit`.  Hence, raising `Thread.Exit` explicitly is the standard way to terminate threads prematurely in 5.00.

Having `Thread.Exit` in 4.14 as well makes it possible to write code that works the same in 4.14 and in 5.
