### PR TITLE
#10836: recognize unrecoverable errors in the signature inclusion check

### DIFF
--- a/Changes
+++ b/Changes
@@ -541,6 +541,10 @@ OCaml 4.14.0
 - #10822, #10823: Bad interaction between ambivalent types and subtyping
   coercions (Jacques Garrigue, report and review by Frédéric Bour)
 
+- #10836, #?????: avoid internal typechecker errors when checking signature
+  inclusion in presence of incompatible types.
+  (Florian Angeletti, review by ????)
+
 - #10849: Display the result of `let _ : <type> = <expr>` in the native
   toplevel, as in the bytecode toplevel.
   (David Allsopp, report by Nathan Rebours, review by Gabriel Scherer)

--- a/Changes
+++ b/Changes
@@ -541,9 +541,9 @@ OCaml 4.14.0
 - #10822, #10823: Bad interaction between ambivalent types and subtyping
   coercions (Jacques Garrigue, report and review by Frédéric Bour)
 
-- #10836, #?????: avoid internal typechecker errors when checking signature
+- #10836, #10952: avoid internal typechecker errors when checking signature
   inclusion in presence of incompatible types.
-  (Florian Angeletti, review by ????)
+  (Florian Angeletti, report by Craig Ferguson, review by Gabriel Scherer)
 
 - #10849: Display the result of `let _ : <type> = <expr>` in the native
   toplevel, as in the bytecode toplevel.

--- a/testsuite/tests/typing-misc/distant_errors.ml
+++ b/testsuite/tests/typing-misc/distant_errors.ml
@@ -1,0 +1,34 @@
+(* TEST
+  * expect
+*)
+
+(** The aim of this file is to keep track of programs that are "far" from being well-typed *)
+
+
+(** Arity mismatch between structure and signature *)
+
+module M : sig
+  type (_, _) t
+  val f : (_, _) t -> unit
+end = struct
+  type _ t
+  let f _ = ()
+end
+
+[%%expect{|
+Lines 9-12, characters 6-3:
+ 9 | ......struct
+10 |   type _ t
+11 |   let f _ = ()
+12 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig type _ t val f : 'a -> unit end
+       is not included in
+         sig type (_, _) t val f : ('a, 'b) t -> unit end
+       Type declarations do not match:
+         type _ t
+       is not included in
+         type (_, _) t
+       They have different arities.
+|}]

--- a/typing/includemod.ml
+++ b/typing/includemod.ml
@@ -104,7 +104,7 @@ module Error = struct
     missings: signature_item list;
     incompatibles: (Ident.t * sigitem_symptom) list;
     oks: (int * module_coercion) list;
-    unknowns: (signature_item * signature_item * int) list;
+    leftovers: (signature_item * signature_item * int) list;
   }
   and sigitem_symptom =
     | Core of core_sigitem_symptom
@@ -618,12 +618,12 @@ and signatures  ~in_eq ~loc env ~mark subst sig1 sig2 mod_shape =
      and the coercion to be applied to it. *)
   let rec pair_components subst paired unpaired = function
       [] ->
-        let oks, (shape_map, deep_modifications), errors, unknowns =
+        let oks, (shape_map, deep_modifications), errors, leftovers =
           signature_components ~in_eq ~loc env ~mark new_env subst mod_shape
             Shape.Map.empty
             (List.rev paired)
         in
-        begin match unpaired, errors, oks, unknowns with
+        begin match unpaired, errors, oks, leftovers with
             | [], [], cc, [] ->
                 let shape =
                   if not deep_modifications && exported_len1 = exported_len2
@@ -634,13 +634,13 @@ and signatures  ~in_eq ~loc env ~mark subst sig1 sig2 mod_shape =
                   Ok (simplify_structure_coercion cc id_pos_list, shape)
                 else
                   Ok (Tcoerce_structure (cc, id_pos_list), shape)
-            | missings, incompatibles, cc, unknowns ->
+            | missings, incompatibles, cc, leftovers ->
                 Error {
                   Error.env=new_env;
                   missings;
                   incompatibles;
                   oks=cc;
-                  unknowns
+                  leftovers;
                 }
         end
     | item2 :: rem ->

--- a/typing/includemod.ml
+++ b/typing/includemod.ml
@@ -820,11 +820,8 @@ and signature_components  ~in_eq ~loc old_env ~mark env subst
               if present_at_runtime then [pos,x] else []
             in
             Sign_diff.{ empty with deep_modifications; runtime_coercions }
-        | Error { recoverable = true; error } ->
+        | Error { error; recoverable=_ } ->
             Sign_diff.{ empty with errors=[id,error]; deep_modifications }
-        | Error { recoverable = false; error } ->
-            let errors =[id,error] in
-            Sign_diff.{ empty with deep_modifications; errors; leftovers=rem }
       in
       let continue = match item with
         | Ok _ -> true
@@ -834,7 +831,7 @@ and signature_components  ~in_eq ~loc old_env ~mark env subst
         if continue then
           signature_components ~in_eq ~loc old_env ~mark env subst
             orig_shape shape_map rem
-        else Sign_diff.empty
+        else Sign_diff.{ empty with leftovers=rem }
        in
        Sign_diff.merge first rest
 

--- a/typing/includemod.mli
+++ b/typing/includemod.mli
@@ -93,7 +93,8 @@ module Error: sig
     missings: Types.signature_item list;
     incompatibles: (Ident.t * sigitem_symptom) list;
     oks: (int * Typedtree.module_coercion) list;
-    unknowns: ((Types.signature_item as 'it) * 'it * int) list
+    leftovers: ((Types.signature_item as 'it) * 'it * int) list
+    (** signature items that could not be compared due to type divergence *)
   }
   and sigitem_symptom =
     | Core of core_sigitem_symptom

--- a/typing/includemod.mli
+++ b/typing/includemod.mli
@@ -93,6 +93,7 @@ module Error: sig
     missings: Types.signature_item list;
     incompatibles: (Ident.t * sigitem_symptom) list;
     oks: (int * Typedtree.module_coercion) list;
+    unknowns: ((Types.signature_item as 'it) * 'it * int) list
   }
   and sigitem_symptom =
     | Core of core_sigitem_symptom


### PR DESCRIPTION
This PR stops the computation of signatures difference as soon as types start to diverge in order to avoid trying to typecheck items in incoherent environments. This avoid raising internal type errors due to, for instance, having type constructors with incoherent arity.

close #10836