### PR TITLE
Make Minor_heap_max and Max_domains OCAMLRUNPARAM options

### DIFF
--- a/Changes
+++ b/Changes
@@ -104,6 +104,10 @@ OCaml 4.14.0
 
 ### Runtime system:
 
+* #10955: Add OCAMLRUNPARAM options d ("max_domains") and N
+  ("minor_heap_max_wsz") to set the maximum number of domains, and,
+  respectively, the maximum size of the minor gc zone per domain.
+
 * #9391, #9424: Fix failed assertion in runtime due to ephemerons *set_* and
   *blit_* function during Mark phase
   (François Bobot, reported by Stephen Dolan, reviewed by Damien Doligez)

--- a/Changes
+++ b/Changes
@@ -106,7 +106,9 @@ OCaml 4.14.0
 
 * #10955: Add OCAMLRUNPARAM options d ("max_domains") and N
   ("minor_heap_max_wsz") to set the maximum number of domains, and,
-  respectively, the maximum size of the minor gc zone per domain.
+  respectively, the maximum size of the minor gc zone per domain on program
+  start. Changed the default max domains to 16 (previously, it was 128).
+  (Sabine Schmaltz, KC Sivaramakrishnan, review by ...)
 
 * #9391, #9424: Fix failed assertion in runtime due to ephemerons *set_* and
   *blit_* function during Mark phase

--- a/man/ocamlrun.1
+++ b/man/ocamlrun.1
@@ -142,32 +142,19 @@ chapter "Standard Library", section "Gc".
 
 .RS 7
 .TP
-.BR a \ (allocation_policy)
-The policy used for allocating in the OCaml heap.  Possible values
-are 0 for the next-fit policy, 1 for the first-fit
-policy, and 2 for the best-fit policy. The default is 2.
-See the Gc module documentation for details.
-.TP
-.B b
+.BR b \ (backtrace_enabled)
 Trigger the printing of a stack backtrace
 when an uncaught exception aborts the program.
 This option takes no argument.
 .TP
-.B c
-(cleanup_on_exit) Shut the runtime down gracefully on exit. The option
+.BR c \ (cleanup_on_exit)
+Shut the runtime down gracefully on exit. The option
 also enables pooling (as in caml_startup_pooled). This mode can be used
 to detect leaks with a third-party memory debugger.
 .TP
-.BR h
-The initial size of the major heap (in words).
-.TP
-.BR H
-Allocate heap chunks by mmapping huge pages. Huge pages are locked into
-memory, and are not swapped.
-.TP
-.BR i \ (major_heap_increment)
-The default size increment for the major heap (in words if greater than 1000,
-else in percents of the heap size).
+.BR d \ (max_domains)
+Maximum number of domains that can exist at the same time.
+Default: 16.
 .TP
 .BR l \ (stack_limit)
 The limit (in words) of the stack size.
@@ -180,7 +167,7 @@ heap. Expressed as a percentage of minor heap size.
 Note: this only applies to values allocated with
 .B caml_alloc_custom_mem
 (e.g. bigarrays).
- Default: 100.
+Default: 100.
 .TP
 .BR M \ (custom_major_ratio)
 Target ratio of floating garbage to
@@ -208,11 +195,12 @@ Note: this only applies to values allocated with
 (e.g. bigarrays).
 Default: 8192 bytes.
 .TP
+.BR N \ (minor_heap_max_wsz)
+Maximum size of the minor zone (words).
+Default: 256k.
+.TP
 .BR o \ (space_overhead)
 The major GC speed setting.
-.TP
-.BR O \ (max_overhead)
-The heap compaction trigger setting.
 .TP
 .B p
 Turn on debugging support for
@@ -271,10 +259,6 @@ Computation of compaction-triggering condition.
 
 .BR 0x400
 Output GC statistics at program exit, in the same format as Gc.print_stat.
-.TP
-.BR w \ (window_size)
-Set size of the window used by major GC for smoothing out variations in
-its workload. This is an integer between 1 and 50. (Default: 1)
 .TP
 .BR W
 Print runtime warnings to stderr (such as Channel opened on file dies without

--- a/manual/src/cmds/afl-fuzz.etex
+++ b/manual/src/cmds/afl-fuzz.etex
@@ -72,5 +72,13 @@ afl-fuzz -m none -i input -o output ./readline
 \end{verbatim}
 By inspecting instrumentation output, the fuzzer finds the crashing input quickly.
 
-Note: To fuzz-test an OCaml program with afl-fuzz, passing the option {\tt -m none}
-is required to disable afl-fuzz's default 50MB virtual memory limit.
+Note: To fuzz-test an OCaml program with afl-fuzz, either
+\begin{itemize}
+\item the virtual memory reserved by the OCaml program must not exceed afl-fuzz's
+default 50MB virtual memory limit (this can be done by limiting the maximum
+number of domains ("max_domains") and maximum minor heap size ("number of domains ("max_domains") and maximum minor heap size ("minor_heap_max_wsz")
+")
+by setting them explicitly through OCAMLRUNPARAM), or
+\item afl-fuzz needs to be passed the option {\tt -m none} to disable afl-fuzz's
+default 50MB virtual memory limit.
+\end{itemize}

--- a/manual/src/cmds/runtime.etex
+++ b/manual/src/cmds/runtime.etex
@@ -130,6 +130,9 @@ The following environment variables are also consulted:
         pooling (as in "caml_startup_pooled"). This mode can be used to detect
         leaks with a third-party memory debugger.
   \item[d] ("max_domains") Maximum number of domains that can exist at the same time.
+        Default: 16. Note: The default settings of "max_domains" and
+        "minor_heap_max_wsz" cause valgrind to fail with "Fatal error: Not enough heap
+        memory to start up". Smaller values must be used to run valgrind.
   \item[l] ("stack_limit") The limit (in words) of the stack size. This is only
         relevant to the byte-code runtime, as the native code runtime uses the
         operating system's stack.
@@ -158,7 +161,7 @@ The following environment variables are also consulted:
         The multiplier is "k", "M", or "G", for multiplication by $2^{10}$,
         $2^{20}$, and $2^{30}$ respectively.
   \item[N] ("minor_heap_max_wsz") Maximum size of the minor zone (words).
-   Must be greater than or equal to [Minor_heap_min].
+   Must be greater than or equal to [Minor_heap_min]. Default: 256k.
   \item[o] ("space_overhead")  The major GC speed setting.
         See the Gc module documentation for details.
   \item[p] (parser trace) Turn on debugging support for

--- a/manual/src/cmds/runtime.etex
+++ b/manual/src/cmds/runtime.etex
@@ -129,6 +129,7 @@ The following environment variables are also consulted:
         "caml_shutdown" in section~\ref{ss:c-embedded-code}). The option also enables
         pooling (as in "caml_startup_pooled"). This mode can be used to detect
         leaks with a third-party memory debugger.
+  \item[d] ("max_domains") Maximum number of domains that can exist at the same time.
   \item[l] ("stack_limit") The limit (in words) of the stack size. This is only
         relevant to the byte-code runtime, as the native code runtime uses the
         operating system's stack.
@@ -156,6 +157,8 @@ The following environment variables are also consulted:
         \end{options}
         The multiplier is "k", "M", or "G", for multiplication by $2^{10}$,
         $2^{20}$, and $2^{30}$ respectively.
+  \item[N] ("minor_heap_max_wsz") Maximum size of the minor zone (words).
+   Must be greater than or equal to [Minor_heap_min].
   \item[o] ("space_overhead")  The major GC speed setting.
         See the Gc module documentation for details.
   \item[p] (parser trace) Turn on debugging support for

--- a/otherlibs/systhreads/st_posix.h
+++ b/otherlibs/systhreads/st_posix.h
@@ -32,7 +32,7 @@
 typedef int st_retcode;
 
 /* Variables used to stop "tick" threads */
-static atomic_uintnat tick_thread_stop[Max_domains];
+static atomic_uintnat tick_thread_stop[caml_params->max_domains];
 #define Tick_thread_stop tick_thread_stop[Caml_state->id]
 
 /* OS-specific initialization */

--- a/otherlibs/systhreads/st_posix.h
+++ b/otherlibs/systhreads/st_posix.h
@@ -38,7 +38,7 @@ static atomic_uintnat* tick_thread_stop;
 
 /* OS-specific initialization */
 
-static int st_initialize(uint max_domains)
+static int st_initialize(uintnat max_domains)
 {
   if (tick_thread_stop == NULL) {
     /* not freed */

--- a/otherlibs/systhreads/st_posix.h
+++ b/otherlibs/systhreads/st_posix.h
@@ -31,8 +31,9 @@
 
 typedef int st_retcode;
 
-/* Variables used to stop "tick" threads, array of length caml_params->max_domains */
-static atomic_uintnat* tick_thread_stop; //[caml_params->max_domains];
+/* Variables used to stop "tick" threads, array of length
+caml_params->max_domains */
+static atomic_uintnat* tick_thread_stop;
 #define Tick_thread_stop tick_thread_stop[Caml_state->id]
 
 /* OS-specific initialization */
@@ -40,8 +41,9 @@ static atomic_uintnat* tick_thread_stop; //[caml_params->max_domains];
 static int st_initialize(uint max_domains)
 {
   if (tick_thread_stop == NULL) {
-    /* not freed, https://github.com/ocaml-multicore/ocaml-multicore/issues/795#issuecomment-1015314683 */
-    tick_thread_stop = caml_stat_alloc_noexc(max_domains * sizeof(atomic_uintnat));
+    /* not freed */
+    tick_thread_stop =
+      caml_stat_alloc_noexc(max_domains * sizeof(atomic_uintnat));
     if (tick_thread_stop == NULL) {
       caml_fatal_error("not enough memory to startup");
     }

--- a/otherlibs/systhreads/st_posix.h
+++ b/otherlibs/systhreads/st_posix.h
@@ -42,6 +42,9 @@ static int st_initialize(uint max_domains)
   if (tick_thread_stop == NULL) {
     /* not freed, https://github.com/ocaml-multicore/ocaml-multicore/issues/795#issuecomment-1015314683 */
     tick_thread_stop = caml_stat_alloc_noexc(max_domains * sizeof(atomic_uintnat));
+    if (tick_thread_stop == NULL) {
+      caml_fatal_error("not enough memory to startup");
+    }
   }
   atomic_store_rel(&Tick_thread_stop, 0);
   return 0;

--- a/otherlibs/systhreads/st_posix.h
+++ b/otherlibs/systhreads/st_posix.h
@@ -31,14 +31,18 @@
 
 typedef int st_retcode;
 
-/* Variables used to stop "tick" threads */
-static atomic_uintnat tick_thread_stop[caml_params->max_domains];
+/* Variables used to stop "tick" threads, array of length caml_params->max_domains */
+static atomic_uintnat* tick_thread_stop; //[caml_params->max_domains];
 #define Tick_thread_stop tick_thread_stop[Caml_state->id]
 
 /* OS-specific initialization */
 
-static int st_initialize(void)
+static int st_initialize(uint max_domains)
 {
+  if (tick_thread_stop == NULL) {
+    /* not freed, https://github.com/ocaml-multicore/ocaml-multicore/issues/795#issuecomment-1015314683 */
+    tick_thread_stop = caml_stat_alloc_noexc(max_domains * sizeof(atomic_uintnat));
+  }
   atomic_store_rel(&Tick_thread_stop, 0);
   return 0;
 }

--- a/otherlibs/systhreads/st_stubs.c
+++ b/otherlibs/systhreads/st_stubs.c
@@ -393,6 +393,9 @@ CAMLprim value caml_thread_initialize_domain(value v)
   if (thread_table == NULL) {
     /* not freed https://github.com/ocaml-multicore/ocaml-multicore/issues/795#issuecomment-1015314683 */
     thread_table = caml_stat_alloc_noexc(caml_params->max_domains * sizeof(struct caml_thread_table));
+    if (thread_table == NULL) {
+      caml_fatal_error("not enough memory to startup");
+    }
   }
 
   st_masterlock_init(&Thread_main_lock);

--- a/otherlibs/systhreads/st_stubs.c
+++ b/otherlibs/systhreads/st_stubs.c
@@ -103,8 +103,8 @@ struct caml_thread_table {
   st_thread_id tick_thread_id;
 };
 
-/* thread_table instance, up to Max_domains */
-static struct caml_thread_table thread_table[Max_domains];
+/* thread_table instance, up to max_domains */
+static struct caml_thread_table thread_table[caml_params->max_domains];
 
 /* the "head" of the circular list of thread descriptors for this domain */
 #define All_threads thread_table[Caml_state->id].all_threads

--- a/otherlibs/systhreads/st_stubs.c
+++ b/otherlibs/systhreads/st_stubs.c
@@ -104,8 +104,8 @@ struct caml_thread_table {
   st_thread_id tick_thread_id;
 };
 
-/* thread_table instance, up to max_domains */
-static struct caml_thread_table* thread_table; /* array of length caml_params->max_domains */
+/* thread_table instance, up to caml_params->max_domains */
+static struct caml_thread_table* thread_table;
 
 /* the "head" of the circular list of thread descriptors for this domain */
 #define All_threads thread_table[Caml_state->id].all_threads
@@ -391,8 +391,10 @@ CAMLprim value caml_thread_initialize_domain(value v)
   st_initialize(caml_params->max_domains);
 
   if (thread_table == NULL) {
-    /* not freed https://github.com/ocaml-multicore/ocaml-multicore/issues/795#issuecomment-1015314683 */
-    thread_table = caml_stat_alloc_noexc(caml_params->max_domains * sizeof(struct caml_thread_table));
+    /* not freed */
+    thread_table = caml_stat_alloc_noexc(
+      caml_params->max_domains * sizeof(struct caml_thread_table)
+    );
     if (thread_table == NULL) {
       caml_fatal_error("not enough memory to startup");
     }

--- a/runtime/caml/config.h
+++ b/runtime/caml/config.h
@@ -236,7 +236,7 @@ typedef uint64_t uintnat;
 #define Percent_free_def 120
 
 /* Maximum number of domains */
-#define Max_domains_def 128
+#define Max_domains_def 16
 
 /* Default setting for the major GC slice smoothing window: 1
    (i.e. no smoothing)

--- a/runtime/caml/config.h
+++ b/runtime/caml/config.h
@@ -219,7 +219,7 @@ typedef uint64_t uintnat;
 /* Maximum size of the minor zone (words).
    Must be greater than or equal to [Minor_heap_min].
 */
-#define Minor_heap_max_def (1 << 28)
+#define Minor_heap_max_def Minor_heap_def
 
 /* Default size of the minor zone. (words)  */
 #define Minor_heap_def 262144

--- a/runtime/caml/config.h
+++ b/runtime/caml/config.h
@@ -219,7 +219,7 @@ typedef uint64_t uintnat;
 /* Maximum size of the minor zone (words).
    Must be greater than or equal to [Minor_heap_min].
 */
-#define Minor_heap_max (1 << 28)
+#define Minor_heap_max_def (1 << 28)
 
 /* Default size of the minor zone. (words)  */
 #define Minor_heap_def 262144
@@ -236,7 +236,7 @@ typedef uint64_t uintnat;
 #define Percent_free_def 120
 
 /* Maximum number of domains */
-#define Max_domains 128
+#define Max_domains_def 128
 
 /* Default setting for the major GC slice smoothing window: 1
    (i.e. no smoothing)

--- a/runtime/caml/config.h
+++ b/runtime/caml/config.h
@@ -216,13 +216,13 @@ typedef uint64_t uintnat;
    This must be at least [Max_young_wosize + 1]. */
 #define Minor_heap_min (Max_young_wosize + 1)
 
+/* Default size of the minor zone. (words)  */
+#define Minor_heap_def 262144
+
 /* Maximum size of the minor zone (words).
    Must be greater than or equal to [Minor_heap_min].
 */
 #define Minor_heap_max_def Minor_heap_def
-
-/* Default size of the minor zone. (words)  */
-#define Minor_heap_def 262144
 
 
 /* Minimum size increment when growing the heap (words).

--- a/runtime/caml/startup_aux.h
+++ b/runtime/caml/startup_aux.h
@@ -48,6 +48,9 @@ struct caml_params {
 
   uintnat init_max_stack_wsz;
 
+  uintnat minor_heap_max_wsz;
+  uintnat max_domains;
+
   uintnat backtrace_enabled;
   uintnat runtime_warnings;
   uintnat cleanup_on_exit;

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -589,10 +589,19 @@ void caml_init_domains(uintnat minor_heap_wsz) {
   */
   participating_size = caml_params->max_domains * sizeof(caml_domain_state*);
   stw_request.participating = caml_stat_alloc_noexc(participating_size);  /* not freed */
+  if (stw_request.participating == NULL) {
+      caml_fatal_error("not enough memory to startup");
+  }
   all_domains_size = caml_params->max_domains * sizeof(struct dom_internal);
   all_domains = caml_stat_alloc_noexc(all_domains_size); /* not freed */
+  if (all_domains == NULL) {
+      caml_fatal_error("not enough memory to startup");
+  }
   stw_domains_size = caml_params->max_domains * sizeof(struct dom_internal*);
   stw_domains.domains = caml_stat_alloc_noexc(stw_domains_size);  /* not freed */
+  if (stw_domains.domains == NULL) {
+      caml_fatal_error("not enough memory to startup");
+  }
 
   for (i = 0; i < caml_params->max_domains; i++) {
     struct dom_internal* dom = &all_domains[i];
@@ -860,7 +869,7 @@ static void* domain_thread_func(void* v)
     sync_mutex_unlock(terminate_mutex);
     free_domain_ml_values(ml_values);
   } else {
-    caml_gc_log("Failed to create domain");
+    caml_gc_log("Failed to create domain.");
   }
   return 0;
 }
@@ -904,7 +913,7 @@ CAMLprim value caml_domain_spawn(value callback, value mutex)
 #endif
 
   if (err) {
-    caml_failwith("failed to create domain thread");
+    caml_failwith("failed to create domain thread. You can set the 'Max_domains' OCAMLRUNPARAM parameter to increase the domain limit.");
   }
 
   /* While waiting for the child thread to start up, we need to service any

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -918,9 +918,7 @@ CAMLprim value caml_domain_spawn(value callback, value mutex)
 #endif
 
   if (err) {
-    caml_failwith("failed to create domain thread. "
-      "You can set the 'Max_domains' OCAMLRUNPARAM parameter "
-      "to increase the domain limit.");
+    caml_failwith("failed to create domain thread.");
   }
 
   /* While waiting for the child thread to start up, we need to service any
@@ -946,7 +944,9 @@ CAMLprim value caml_domain_spawn(value callback, value mutex)
     /* failed */
     pthread_join(th, 0);
     free_domain_ml_values(p.ml_values);
-    caml_failwith("failed to allocate domain");
+    caml_failwith("failed to allocate domain. "
+      "You can set the 'Max_domains' OCAMLRUNPARAM parameter "
+      "to increase the domain limit.");
   }
   /* When domain 0 first spawns a domain, the backup thread is not active, we
      ensure it is started here. */

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -584,12 +584,15 @@ void caml_init_domains(uintnat minor_heap_wsz) {
   caml_minor_heaps_end = (uintnat) heaps_base + size;
   caml_tls_areas_base = (uintnat) tls_base;
 
+  /* none of the following allocations is freed,
+     see https://github.com/ocaml-multicore/ocaml-multicore/issues/795#issuecomment-1015314683.
+  */
   participating_size = caml_params->max_domains * sizeof(caml_domain_state*);
-  stw_request.participating = caml_mem_map(participating_size, participating_size, 0);
+  stw_request.participating = caml_stat_alloc_noexc(participating_size);  /* not freed */
   all_domains_size = caml_params->max_domains * sizeof(struct dom_internal);
-  all_domains = caml_mem_map(all_domains_size, all_domains_size, 0);
+  all_domains = caml_stat_alloc_noexc(all_domains_size); /* not freed */
   stw_domains_size = caml_params->max_domains * sizeof(struct dom_internal*);
-  stw_domains.domains = caml_mem_map(stw_domains_size, stw_domains_size, 0);
+  stw_domains.domains = caml_stat_alloc_noexc(stw_domains_size);  /* not freed */
 
   for (i = 0; i < caml_params->max_domains; i++) {
     struct dom_internal* dom = &all_domains[i];

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -558,6 +558,9 @@ void caml_init_domains(uintnat minor_heap_wsz) {
   uintnat size;
   uintnat tls_size;
   uintnat tls_areas_size;
+  uintnat participating_size;
+  uintnat all_domains_size;
+  uintnat stw_domains_size;
   void* heaps_base;
   void* tls_base;
 
@@ -581,9 +584,12 @@ void caml_init_domains(uintnat minor_heap_wsz) {
   caml_minor_heaps_end = (uintnat) heaps_base + size;
   caml_tls_areas_base = (uintnat) tls_base;
 
-  stw_request.participating = caml_mem_map(caml_params->max_domains * sizeof(caml_domain_state*), sizeof(caml_domain_state*), 0);
-  all_domains = caml_mem_map(caml_params->max_domains * sizeof(struct dom_internal), sizeof(dom_internal), 0);
-  stw_domains.domains = caml_mem_map(caml_params->max_domains * sizeof(struct dom_internal*), sizeof(dom_internal*), 0);
+  participating_size = caml_params->max_domains * sizeof(caml_domain_state*);
+  stw_request.participating = caml_mem_map(participating_size, participating_size, 0);
+  all_domains_size = caml_params->max_domains * sizeof(struct dom_internal);
+  all_domains = caml_mem_map(all_domains_size, all_domains_size, 0);
+  stw_domains_size = caml_params->max_domains * sizeof(struct dom_internal*);
+  stw_domains.domains = caml_mem_map(stw_domains_size, stw_domains_size, 0);
 
   for (i = 0; i < caml_params->max_domains; i++) {
     struct dom_internal* dom = &all_domains[i];

--- a/runtime/gc_ctrl.c
+++ b/runtime/gc_ctrl.c
@@ -48,7 +48,7 @@ extern uintnat caml_allocation_policy;    /*        see freelist.c */
 extern uintnat caml_custom_major_ratio;   /* see custom.c */
 extern uintnat caml_custom_minor_ratio;   /* see custom.c */
 extern uintnat caml_custom_minor_max_bsz; /* see custom.c */
-extern struct gc_stats *sampled_gc_stats; /* see major_gc.c */
+extern struct gc_stats *caml_sampled_gc_stats; /* see major_gc.c */
 
 CAMLprim value caml_gc_quick_stat(value v)
 {
@@ -285,8 +285,8 @@ CAMLprim value caml_get_minor_free (value v)
 
 void caml_init_gc (void)
 {
-  sampled_gc_stats = caml_stat_alloc_noexc(caml_params->max_domains * sizeof(struct gc_stats));
-  if (sampled_gc_stats == NULL) {
+  caml_sampled_gc_stats = caml_stat_alloc_noexc(caml_params->max_domains * sizeof(struct gc_stats));
+  if (caml_sampled_gc_stats == NULL) {
     caml_fatal_error("not enough memory to startup");
   }
   caml_max_stack_size = caml_params->init_max_stack_wsz;

--- a/runtime/gc_ctrl.c
+++ b/runtime/gc_ctrl.c
@@ -285,7 +285,7 @@ CAMLprim value caml_get_minor_free (value v)
 
 void caml_init_gc (void)
 {
-  sampled_gc_stats = (struct gc_stats*) malloc(sizeof(struct gc_stats) * caml_params->max_domains);
+  sampled_gc_stats = (struct gc_stats*) calloc(caml_params->max_domains, sizeof(struct gc_stats));
   caml_max_stack_size = caml_params->init_max_stack_wsz;
   caml_fiber_wsz = (Stack_threshold * 2) / sizeof(value);
   caml_percent_free = norm_pfree (caml_params->init_percent_free);

--- a/runtime/gc_ctrl.c
+++ b/runtime/gc_ctrl.c
@@ -285,7 +285,8 @@ CAMLprim value caml_get_minor_free (value v)
 
 void caml_init_gc (void)
 {
-  caml_sampled_gc_stats = caml_stat_alloc_noexc(caml_params->max_domains * sizeof(struct gc_stats));
+  caml_sampled_gc_stats =
+    caml_stat_alloc_noexc(caml_params->max_domains * sizeof(struct gc_stats));
   if (caml_sampled_gc_stats == NULL) {
     caml_fatal_error("not enough memory to startup");
   }

--- a/runtime/gc_ctrl.c
+++ b/runtime/gc_ctrl.c
@@ -285,7 +285,10 @@ CAMLprim value caml_get_minor_free (value v)
 
 void caml_init_gc (void)
 {
-  sampled_gc_stats = (struct gc_stats*) calloc(caml_params->max_domains, sizeof(struct gc_stats));
+  sampled_gc_stats = caml_stat_alloc_noexc(caml_params->max_domains * sizeof(struct gc_stats));
+  if (sampled_gc_stats == NULL) {
+    caml_fatal_error("not enough memory to startup");
+  }
   caml_max_stack_size = caml_params->init_max_stack_wsz;
   caml_fiber_wsz = (Stack_threshold * 2) / sizeof(value);
   caml_percent_free = norm_pfree (caml_params->init_percent_free);

--- a/runtime/gc_ctrl.c
+++ b/runtime/gc_ctrl.c
@@ -48,6 +48,7 @@ extern uintnat caml_allocation_policy;    /*        see freelist.c */
 extern uintnat caml_custom_major_ratio;   /* see custom.c */
 extern uintnat caml_custom_minor_ratio;   /* see custom.c */
 extern uintnat caml_custom_minor_max_bsz; /* see custom.c */
+extern struct gc_stats *sampled_gc_stats; /* see major_gc.c */
 
 CAMLprim value caml_gc_quick_stat(value v)
 {
@@ -284,6 +285,7 @@ CAMLprim value caml_get_minor_free (value v)
 
 void caml_init_gc (void)
 {
+  sampled_gc_stats = (struct gc_stats*) malloc(sizeof(struct gc_stats) * caml_params->max_domains);
   caml_max_stack_size = caml_params->init_max_stack_wsz;
   caml_fiber_wsz = (Stack_threshold * 2) / sizeof(value);
   caml_percent_free = norm_pfree (caml_params->init_percent_free);

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -907,7 +907,8 @@ static intnat ephe_sweep (caml_domain_state* domain_state, intnat budget)
   return budget;
 }
 
-static struct gc_stats sampled_gc_stats[caml_params->max_domains];
+/* this is an array of length caml_params->max_domains */
+static struct gc_stats *sampled_gc_stats;
 
 void caml_accum_heap_stats(struct heap_stats* acc, const struct heap_stats* h)
 {

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -907,8 +907,7 @@ static intnat ephe_sweep (caml_domain_state* domain_state, intnat budget)
   return budget;
 }
 
-/* this is an array of length caml_params->max_domains */
-static struct gc_stats *sampled_gc_stats;
+struct gc_stats *sampled_gc_stats; /* see gc_ctrl.c */
 
 void caml_accum_heap_stats(struct heap_stats* acc, const struct heap_stats* h)
 {

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -907,7 +907,7 @@ static intnat ephe_sweep (caml_domain_state* domain_state, intnat budget)
   return budget;
 }
 
-struct gc_stats *sampled_gc_stats; /* see gc_ctrl.c */
+struct gc_stats *sampled_gc_stats;
 
 void caml_accum_heap_stats(struct heap_stats* acc, const struct heap_stats* h)
 {

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -907,7 +907,7 @@ static intnat ephe_sweep (caml_domain_state* domain_state, intnat budget)
   return budget;
 }
 
-static struct gc_stats sampled_gc_stats[Max_domains];
+static struct gc_stats sampled_gc_stats[caml_params->max_domains];
 
 void caml_accum_heap_stats(struct heap_stats* acc, const struct heap_stats* h)
 {
@@ -941,7 +941,7 @@ void caml_sample_gc_stats(struct gc_stats* buf)
   int my_id = Caml_state->id;
   memset(buf, 0, sizeof(*buf));
 
-  for (i=0; i<Max_domains; i++) {
+  for (i=0; i<caml_params->max_domains; i++) {
     struct gc_stats* s = &sampled_gc_stats[i];
     struct heap_stats* h = &s->major_heap;
     if (i != my_id) {

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -907,7 +907,7 @@ static intnat ephe_sweep (caml_domain_state* domain_state, intnat budget)
   return budget;
 }
 
-struct gc_stats *sampled_gc_stats;
+struct gc_stats *caml_sampled_gc_stats;
 
 void caml_accum_heap_stats(struct heap_stats* acc, const struct heap_stats* h)
 {
@@ -942,7 +942,7 @@ void caml_sample_gc_stats(struct gc_stats* buf)
   memset(buf, 0, sizeof(*buf));
 
   for (i=0; i<caml_params->max_domains; i++) {
-    struct gc_stats* s = &sampled_gc_stats[i];
+    struct gc_stats* s = &caml_sampled_gc_stats[i];
     struct heap_stats* h = &s->major_heap;
     if (i != my_id) {
       buf->minor_words += s->minor_words;
@@ -976,7 +976,7 @@ void caml_sample_gc_stats(struct gc_stats* buf)
 /* update GC stats for this given domain */
 inline void caml_sample_gc_collect(caml_domain_state* domain)
 {
-  struct gc_stats* stats = &sampled_gc_stats[domain->id];
+  struct gc_stats* stats = &caml_sampled_gc_stats[domain->id];
 
   stats->minor_words = domain->stat_minor_words;
   stats->promoted_words = domain->stat_promoted_words;

--- a/runtime/startup_aux.c
+++ b/runtime/startup_aux.c
@@ -51,6 +51,8 @@ static void init_startup_params(void)
   params.init_custom_minor_ratio = Custom_minor_ratio_def;
   params.init_custom_minor_max_bsz = Custom_minor_max_bsz_def;
   params.init_max_stack_wsz = Max_stack_def;
+  params.minor_heap_max_wsz = Minor_heap_max_def;
+  params.max_domains = Max_domains_def;
 #ifdef DEBUG
   params.verb_gc = 0x3F;
 #endif
@@ -93,10 +95,12 @@ void caml_parse_ocamlrunparam(void)
       switch (*opt++){
       case 'b': scanmult (opt, &params.backtrace_enabled); break;
       case 'c': scanmult (opt, &params.cleanup_on_exit); break;
+      case 'd': scanmult (opt, &params.max_domains); break;
       case 'l': scanmult (opt, &params.init_max_stack_wsz); break;
       case 'M': scanmult (opt, &params.init_custom_major_ratio); break;
       case 'm': scanmult (opt, &params.init_custom_minor_ratio); break;
       case 'n': scanmult (opt, &params.init_custom_minor_max_bsz); break;
+      case 'N': scanmult (opt, &params.minor_heap_max_wsz); break;
       case 'o': scanmult (opt, &params.init_percent_free); break;
       case 'p': scanmult (opt, &params.parser_trace); break;
       case 'R': break; /*  see stdlib/hashtbl.mli */

--- a/testsuite/tests/afl-instrumentation/afl-fuzz-test.run
+++ b/testsuite/tests/afl-instrumentation/afl-fuzz-test.run
@@ -6,7 +6,7 @@ exec > ${output} 2>&1
 mkdir readline-input
 echo a > readline-input/testcase
 export AFL_SKIP_CPUFREQ=1 AFL_FAST_CAL=1 AFL_NO_UI=1 AFL_BENCH_UNTIL_CRASH=1
-timeout 10s afl-fuzz -m none -i readline-input -o readline-output ./readline > afl-output
+OCAMLRUNPARAM="d=8,N=256k" timeout 10s afl-fuzz -i readline-input -o readline-output ./readline > afl-output
 
 if [ `grep "unique_crashes" readline-output/fuzzer_stats | cut -d ':' -f 2` -gt 0 ];
 then

--- a/testsuite/tests/afl-instrumentation/afl-fuzz-test.run
+++ b/testsuite/tests/afl-instrumentation/afl-fuzz-test.run
@@ -6,7 +6,7 @@ exec > ${output} 2>&1
 mkdir readline-input
 echo a > readline-input/testcase
 export AFL_SKIP_CPUFREQ=1 AFL_FAST_CAL=1 AFL_NO_UI=1 AFL_BENCH_UNTIL_CRASH=1
-OCAMLRUNPARAM="d=8,N=256k" timeout 10s afl-fuzz -i readline-input -o readline-output ./readline > afl-output
+OCAMLRUNPARAM="d=1" timeout 10s afl-fuzz -i readline-input -o readline-output ./readline > afl-output
 
 if [ `grep "unique_crashes" readline-output/fuzzer_stats | cut -d ':' -f 2` -gt 0 ];
 then

--- a/testsuite/tests/afl-instrumentation/afl-showmap-test.run
+++ b/testsuite/tests/afl-instrumentation/afl-showmap-test.run
@@ -11,8 +11,8 @@ echo "running $NTESTS tests..."
 for t in `seq 1 $NTESTS`; do
   printf "%14s: " `./test name $t`
   # when run twice, the instrumentation output should double
-  OCAMLRUNPARAM="d=8,N=256k" afl-showmap  -q -o output-1 -- ./test 1 $t
-  OCAMLRUNPARAM="d=8,N=256k" afl-showmap  -q -o output-2 -- ./test 2 $t
+  OCAMLRUNPARAM="d=1" afl-showmap  -q -o output-1 -- ./test 1 $t
+  OCAMLRUNPARAM="d=1" afl-showmap  -q -o output-2 -- ./test 2 $t
   # see afl-showmap.c for what the numbers mean
   cat output-1 | sed '
     s/:6/:7/; s/:5/:6/;

--- a/testsuite/tests/afl-instrumentation/afl-showmap-test.run
+++ b/testsuite/tests/afl-instrumentation/afl-showmap-test.run
@@ -11,8 +11,8 @@ echo "running $NTESTS tests..."
 for t in `seq 1 $NTESTS`; do
   printf "%14s: " `./test name $t`
   # when run twice, the instrumentation output should double
-  afl-showmap -m none -q -o output-1 -- ./test 1 $t
-  afl-showmap -m none -q -o output-2 -- ./test 2 $t
+  OCAMLRUNPARAM="d=8,N=256k" afl-showmap  -q -o output-1 -- ./test 1 $t
+  OCAMLRUNPARAM="d=8,N=256k" afl-showmap  -q -o output-2 -- ./test 2 $t
   # see afl-showmap.c for what the numbers mean
   cat output-1 | sed '
     s/:6/:7/; s/:5/:6/;

--- a/testsuite/tests/parallel/domain_id.ml
+++ b/testsuite/tests/parallel/domain_id.ml
@@ -20,7 +20,7 @@ let test_domain_reuse () =
   (* checks that domain slots are getting reused quickly,
      by checking that subsequent domain IDs are an arithmetic
      progression (implies that you're getting the same domain
-     over and over, but its ID increases by Max_domains.
+     over and over, but its ID increases by caml_params->max_domains.
 
      this test has to run first, since it makes assumptions
      about domain IDs *)

--- a/testsuite/tests/parallel/domain_parallel_spawn_burn.ml
+++ b/testsuite/tests/parallel/domain_parallel_spawn_burn.ml
@@ -3,6 +3,7 @@
 include unix
 ** bytecode
 ** native
+  ocamlrunparam += ",d=32"
 *)
 
 open Domain

--- a/testsuite/tests/regression/pr9326/gc_set.ml
+++ b/testsuite/tests/regression/pr9326/gc_set.ml
@@ -1,4 +1,5 @@
 (* TEST
+   ocamlrunparam += ",N=512k"
 *)
 
 open Gc


### PR DESCRIPTION
This implements https://github.com/ocaml-multicore/ocaml-multicore/issues/795.

`Minor_heap_max` and `Max_domains` become runtime parameters set through OCAMLRUNPARAM. Manual entries added.

Multiple fixed-size static arrays of length `Max_domains` turned into array pointers. Allocations happen at program startup based on `caml_params->max_domains`.

New default of `16` for `Max_domains` is proposed. Default for `Minor_heap_max` not changed from 256k.

Valgrind runs with  `OCAMLRUNPARAM="d=15"`, but fails with default settings: `Fatal error: Not enough heap memory to start up`.

For running AFL, we need to use a lower number of domains to stay below AFL's 50MB virtual memory limit, or use the `-m none` option. Updated the manual to add this information. Modified AFL testcase to use OCAMLRUNPARAMS instead of the `-m none` option.

Discuss:

- Are the proposed default values reasonable?
- Deallocation - do we need to deallocate, and if so, where do we deallocate?