### PR TITLE
Don't ignore `isdst` in `Unix.mktime`

### DIFF
--- a/otherlibs/unix/gmtime.c
+++ b/otherlibs/unix/gmtime.c
@@ -75,7 +75,7 @@ CAMLprim value unix_mktime(value t)
     tm.tm_year = Int_val(Field(t, 5));
     tm.tm_wday = Int_val(Field(t, 6));
     tm.tm_yday = Int_val(Field(t, 7));
-    tm.tm_isdst = -1; /* tm.tm_isdst = Bool_val(Field(t, 8)); */
+    tm.tm_isdst = Bool_val(Field(t, 8));
     clock = mktime(&tm);
     if (clock == (time_t) -1) unix_error(ERANGE, "mktime", Nothing);
     tmval = alloc_tm(&tm);

--- a/otherlibs/unix/unix.mli
+++ b/otherlibs/unix/unix.mli
@@ -1190,8 +1190,7 @@ val localtime : float -> tm
 
 val mktime : tm -> float * tm
 (** Convert a date and time, specified by the [tm] argument, into
-   a time in seconds, as returned by {!time}.  The [tm_isdst],
-   [tm_wday] and [tm_yday] fields of [tm] are ignored.  Also return a
+   a time in seconds, as returned by {!time}. Also return a
    normalized copy of the given [tm] record, with the [tm_wday],
    [tm_yday], and [tm_isdst] fields recomputed from the other fields,
    and the other fields normalized (so that, e.g., 40 October is


### PR DESCRIPTION
Hi,

I was implementing time conversion functions based off OCaml's `Unix` library and noticed this oddity. 

Is there a reason for ignoring `isdst` in this function? Because of the nature of daylight saving, some times can exist in two version, before and after daylight saving, e.g. once as Sunday 2:30PM before daylight saving turns back the clock and then again as Sunday 2:30PM after daylight saving turned back one hour.

Thus, without this parameter, some time conversion can be ambiguous and lead the incorrect times.

The original commit from this change is 24 years old and doesn't say much about the reasoning behind this: https://github.com/ocaml/ocaml/commit/11a4c45b78e72c4038a24023eea5c243c0624ca9

I understand that this is potentially breaking existing code. It could be possible to add an optional parameter to turn this new behavior on, or add a warning.

