### PR TITLE
Thread safety for all runtime hooks

### DIFF
--- a/Changes
+++ b/Changes
@@ -17,6 +17,12 @@ Working version
 - #10902: Do not register empty code fragments in natdynlink.
   (David Allsopp, review by Xavier Leroy and Damien Doligez)
 
+- #10965: `caml_fatal_error_hook`, GC timing hooks, and
+  `caml_scan_roots_hook` are now atomic variables. Restore GC timing
+  hooks.
+  (Guillaume Munch-Maccagnoni, review by Enguerrand Decorne, Xavier
+  Leroy, Gabriel Scherer, and KC Sivaramakrishnan)
+
 ### Code generation and optimizations:
 
 ### Standard library:

--- a/otherlibs/systhreads/st_stubs.c
+++ b/otherlibs/systhreads/st_stubs.c
@@ -133,8 +133,7 @@ static st_retcode caml_threadstatus_wait (value);
 
 /* Hook for scanning the stacks of the other threads */
 
-static void (*prev_scan_roots_hook) (scanning_action, void *,
-                                     caml_domain_state *);
+static scan_roots_hook prev_scan_roots_hook;
 
 static void caml_thread_scan_roots(scanning_action action,
                                    void *fdata,
@@ -419,8 +418,8 @@ CAMLprim value caml_thread_initialize(value unit)   /* ML */
   /* First initialise the systhread chain on this domain */
   caml_thread_initialize_domain(Val_unit);
 
-  prev_scan_roots_hook = caml_scan_roots_hook;
-  caml_scan_roots_hook = caml_thread_scan_roots;
+  prev_scan_roots_hook = atomic_exchange(&caml_scan_roots_hook,
+                                         caml_thread_scan_roots);
   caml_enter_blocking_section_hook = caml_thread_enter_blocking_section;
   caml_leave_blocking_section_hook = caml_thread_leave_blocking_section;
   caml_domain_external_interrupt_hook = caml_thread_interrupt_hook;

--- a/otherlibs/systhreads/st_stubs.c
+++ b/otherlibs/systhreads/st_stubs.c
@@ -415,6 +415,10 @@ CAMLprim value caml_thread_initialize(value unit)   /* ML */
 {
   CAMLparam0();
 
+  if (!caml_domain_alone())
+    caml_failwith("caml_thread_initialize: cannot initialize Thread "
+                  "while several domains are running.");
+
   /* First initialise the systhread chain on this domain */
   caml_thread_initialize_domain(Val_unit);
 

--- a/otherlibs/systhreads/thread.ml
+++ b/otherlibs/systhreads/thread.ml
@@ -85,9 +85,9 @@ let preempt_signal =
   | _       -> Sys.sigvtalrm
 
 let () =
-  Sys.set_signal preempt_signal (Sys.Signal_handle preempt);
-  Domain.at_startup thread_initialize_domain;
   thread_initialize ();
+  Domain.at_startup thread_initialize_domain;
+  Sys.set_signal preempt_signal (Sys.Signal_handle preempt);
   Callback.register "Thread.at_shutdown" (fun () ->
     thread_cleanup();
     (* In case of DLL-embedded OCaml the preempt_signal handler

--- a/runtime/caml/camlatomic.h
+++ b/runtime/caml/camlatomic.h
@@ -17,7 +17,6 @@
 #define CAML_ATOMIC_H
 
 #include "config.h"
-#include "misc.h"
 
 /* On platforms supporting C11 atomics, this file just includes <stdatomic.h>.
 

--- a/runtime/caml/domain.h
+++ b/runtime/caml/domain.h
@@ -55,7 +55,6 @@ CAMLextern void caml_release_domain_lock(void);
 
 /* These hooks are not modified after other domains are spawned. */
 CAMLextern void (*caml_atfork_hook)(void);
-CAMLextern void (*caml_domain_start_hook)(void);
 CAMLextern void (*caml_domain_stop_hook)(void);
 CAMLextern void (*caml_domain_external_interrupt_hook)(void);
 

--- a/runtime/caml/domain.h
+++ b/runtime/caml/domain.h
@@ -53,8 +53,8 @@ CAMLextern void caml_bt_exit_ocaml(void);
 CAMLextern void caml_acquire_domain_lock(void);
 CAMLextern void caml_release_domain_lock(void);
 
+/* These hooks are not modified after other domains are spawned. */
 CAMLextern void (*caml_atfork_hook)(void);
-
 CAMLextern void (*caml_domain_start_hook)(void);
 CAMLextern void (*caml_domain_stop_hook)(void);
 CAMLextern void (*caml_domain_external_interrupt_hook)(void);

--- a/runtime/caml/hooks.h
+++ b/runtime/caml/hooks.h
@@ -28,7 +28,8 @@ extern "C" {
 #ifdef NATIVE_CODE
 
 /* executed just before calling the entry point of a dynamically
-   loaded native code module. */
+   loaded native code module.
+   This hook is not modified after other domains are spawned. */
 CAMLextern void (*caml_natdynlink_hook)(void* handle, const char* unit);
 
 #endif /* NATIVE_CODE */

--- a/runtime/caml/memprof.h
+++ b/runtime/caml/memprof.h
@@ -49,6 +49,8 @@ CAMLextern void caml_memprof_enter_thread(struct caml_memprof_th_ctx*);
 CAMLextern void caml_memprof_delete_th_ctx(struct caml_memprof_th_ctx*);
 
 typedef void (*th_ctx_action)(struct caml_memprof_th_ctx*, void*);
+
+/* This hook is not modified after other domains are spawned. */
 extern void (*caml_memprof_th_ctx_iter_hook)(th_ctx_action, void*);
 
 #endif

--- a/runtime/caml/misc.h
+++ b/runtime/caml/misc.h
@@ -282,8 +282,11 @@ void caml_alloc_point_here(void);
    If it returns, the runtime calls [abort()].
 
    If it is [NULL], the error message is printed on stderr and then
-   [abort()] is called. */
-extern void (*caml_fatal_error_hook) (char *msg, va_list args);
+   [abort()] is called.
+
+   This function must be reentrant. */
+typedef void (*fatal_error_hook) (char *msg, va_list args);
+extern _Atomic fatal_error_hook caml_fatal_error_hook;
 
 CAMLnoreturn_start
 CAMLextern void caml_fatal_error (char *, ...)

--- a/runtime/caml/misc.h
+++ b/runtime/caml/misc.h
@@ -185,12 +185,26 @@ extern "C" {
 #endif
 
 /* GC timing hooks. These can be assigned by the user. These hooks
-   must not allocate, change any heap value, nor call OCaml code.
-*/
+   must not allocate, change any heap value, nor call OCaml code. They
+   can obtain the domain id with Caml_state->id. These functions must
+   be reentrant. */
 typedef void (*caml_timing_hook) (void);
-extern caml_timing_hook caml_major_slice_begin_hook, caml_major_slice_end_hook;
-extern caml_timing_hook caml_minor_gc_begin_hook, caml_minor_gc_end_hook;
-extern caml_timing_hook caml_finalise_begin_hook, caml_finalise_end_hook;
+extern _Atomic caml_timing_hook caml_major_slice_begin_hook;
+extern _Atomic caml_timing_hook caml_major_slice_end_hook;
+extern _Atomic caml_timing_hook caml_minor_gc_begin_hook;
+extern _Atomic caml_timing_hook caml_minor_gc_end_hook;
+extern _Atomic caml_timing_hook caml_finalise_begin_hook;
+extern _Atomic caml_timing_hook caml_finalise_end_hook;
+
+#ifdef CAML_INTERNALS
+
+Caml_inline void call_timing_hook(_Atomic caml_timing_hook * a)
+{
+  caml_timing_hook h = atomic_load_explicit(a, memory_order_relaxed);
+  if (h != NULL) (*h)();
+}
+
+#endif /* CAML_INTERNALS */
 
 #define CAML_STATIC_ASSERT_3(b, l) \
   CAMLunused_start \

--- a/runtime/caml/roots.h
+++ b/runtime/caml/roots.h
@@ -22,8 +22,8 @@
 #include "memory.h"
 
 typedef void (*scanning_action) (void*, value, value *);
-CAMLextern void (*caml_scan_roots_hook)(scanning_action, void*,
-                                        caml_domain_state*);
+typedef void (*scan_roots_hook) (scanning_action, void*, caml_domain_state*);
+CAMLextern _Atomic scan_roots_hook caml_scan_roots_hook;
 
 CAMLextern void caml_do_roots (scanning_action f, void* data,
                                caml_domain_state* d, int do_final_val);

--- a/runtime/caml/signals.h
+++ b/runtime/caml/signals.h
@@ -72,6 +72,7 @@ void caml_init_signal_handling(void);
 int caml_init_signal_stack(void);
 void caml_free_signal_stack(void);
 
+/* These hooks are not modified after other threads are spawned. */
 CAMLextern void (*caml_enter_blocking_section_hook)(void);
 CAMLextern void (*caml_leave_blocking_section_hook)(void);
 #endif /* CAML_INTERNALS */

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -810,18 +810,10 @@ static void caml_domain_stop_default(void)
   return;
 }
 
-static void caml_domain_start_default(void)
-{
-  return;
-}
-
 static void caml_domain_external_interrupt_hook_default(void)
 {
   return;
 }
-
-CAMLexport void (*caml_domain_start_hook)(void) =
-   caml_domain_start_default;
 
 CAMLexport void (*caml_domain_stop_hook)(void) =
    caml_domain_stop_default;
@@ -872,7 +864,6 @@ static void* domain_thread_func(void* v)
     caml_gc_log("Domain starting (unique_id = %"ARCH_INTNAT_PRINTF_FORMAT"u)",
                 domain_self->interruptor.unique_id);
     caml_domain_set_name("Domain");
-    caml_domain_start_hook();
     caml_callback(ml_values->callback, Val_unit);
     domain_terminate();
     /* Joining domains will lock/unlock the terminate_mutex so this unlock will

--- a/runtime/finalise.c
+++ b/runtime/finalise.c
@@ -146,6 +146,7 @@ void caml_final_do_calls (void)
 
   if (fi->running_finalisation_function) return;
   if (fi->todo_head != NULL) {
+    call_timing_hook(&caml_finalise_begin_hook);
     caml_gc_message (0x80, "Calling finalisation functions.\n");
     while (1) {
       while (fi->todo_head != NULL && fi->todo_head->size == 0) {
@@ -164,6 +165,7 @@ void caml_final_do_calls (void)
       if (Is_exception_result(res)) caml_raise (Extract_exception (res));
     }
     caml_gc_message (0x80, "Done calling finalisation functions.\n");
+    call_timing_hook(&caml_finalise_end_hook);
   }
 }
 

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -1276,6 +1276,7 @@ static intnat major_collection_slice(intnat howmuch,
   }
 
   if (log_events) CAML_EV_BEGIN(EV_MAJOR_SLICE);
+  call_timing_hook(&caml_major_slice_begin_hook);
 
   if (!domain_state->sweeping_done) {
     if (log_events) CAML_EV_BEGIN(EV_MAJOR_SWEEP);
@@ -1387,6 +1388,7 @@ mark_again:
     }
   }
 
+  call_timing_hook(&caml_major_slice_end_hook);
   if (log_events) CAML_EV_END(EV_MAJOR_SLICE);
 
   caml_gc_log

--- a/runtime/minor_gc.c
+++ b/runtime/minor_gc.c
@@ -474,6 +474,7 @@ void caml_empty_minor_heap_promote(caml_domain_state* domain,
 
   caml_gc_log ("Minor collection of domain %d starting", domain->id);
   CAML_EV_BEGIN(EV_MINOR);
+  call_timing_hook(&caml_minor_gc_begin_hook);
 
   if( participating[0] == Caml_state ) {
     CAML_EV_BEGIN(EV_MINOR_GLOBAL_ROOTS);
@@ -648,6 +649,7 @@ void caml_empty_minor_heap_promote(caml_domain_state* domain,
   domain->stat_minor_collections++;
   domain->stat_promoted_words += domain->allocated_words - prev_alloc_words;
 
+  call_timing_hook(&caml_minor_gc_end_hook);
   CAML_EV_END(EV_MINOR);
   caml_gc_log ("Minor collection of domain %d completed: %2.0f%% of %u KB live",
                domain->id,

--- a/runtime/minor_gc.c
+++ b/runtime/minor_gc.c
@@ -466,6 +466,7 @@ void caml_empty_minor_heap_promote(caml_domain_state* domain,
   value **r;
   intnat c, curr_idx;
   int remembered_roots = 0;
+  scan_roots_hook scan_roots_hook;
 
   st.domain = domain;
 
@@ -620,8 +621,9 @@ void caml_empty_minor_heap_promote(caml_domain_state* domain,
   caml_do_local_roots(&oldify_one, &st, domain->local_roots,
                       domain->current_stack, domain->gc_regs);
 
-  if (caml_scan_roots_hook != NULL)
-    (*caml_scan_roots_hook)(&oldify_one, &st, domain);
+  scan_roots_hook = atomic_load(&caml_scan_roots_hook);
+  if (scan_roots_hook != NULL)
+    (*scan_roots_hook)(&oldify_one, &st, domain);
 
   CAML_EV_BEGIN(EV_MINOR_LOCAL_ROOTS_PROMOTE);
   oldify_mopup (&st, 0);

--- a/runtime/misc.c
+++ b/runtime/misc.c
@@ -98,14 +98,16 @@ void caml_gc_message (int level, char *msg, ...)
   }
 }
 
-void (*caml_fatal_error_hook) (char *msg, va_list args) = NULL;
+_Atomic fatal_error_hook caml_fatal_error_hook = (fatal_error_hook)NULL;
 
 CAMLexport void caml_fatal_error (char *msg, ...)
 {
   va_list ap;
+  fatal_error_hook hook;
   va_start(ap, msg);
-  if(caml_fatal_error_hook != NULL) {
-    caml_fatal_error_hook(msg, ap);
+  hook = atomic_load(&caml_fatal_error_hook);
+  if (hook != NULL) {
+    (*hook)(msg, ap);
   } else {
     fprintf (stderr, "Fatal error: ");
     vfprintf (stderr, msg, ap);

--- a/runtime/misc.c
+++ b/runtime/misc.c
@@ -37,12 +37,12 @@ __declspec(noreturn) void __cdecl abort(void);
 #include "caml/startup.h"
 #include "caml/startup_aux.h"
 
-caml_timing_hook caml_major_slice_begin_hook = NULL;
-caml_timing_hook caml_major_slice_end_hook = NULL;
-caml_timing_hook caml_minor_gc_begin_hook = NULL;
-caml_timing_hook caml_minor_gc_end_hook = NULL;
-caml_timing_hook caml_finalise_begin_hook = NULL;
-caml_timing_hook caml_finalise_end_hook = NULL;
+_Atomic caml_timing_hook caml_major_slice_begin_hook = (caml_timing_hook)NULL;
+_Atomic caml_timing_hook caml_major_slice_end_hook = (caml_timing_hook)NULL;
+_Atomic caml_timing_hook caml_minor_gc_begin_hook = (caml_timing_hook)NULL;
+_Atomic caml_timing_hook caml_minor_gc_end_hook = (caml_timing_hook)NULL;
+_Atomic caml_timing_hook caml_finalise_begin_hook = (caml_timing_hook)NULL;
+_Atomic caml_timing_hook caml_finalise_end_hook = (caml_timing_hook)NULL;
 
 #ifdef DEBUG
 

--- a/runtime/roots.c
+++ b/runtime/roots.c
@@ -42,14 +42,16 @@
 intnat caml_globals_inited = 0;
 #endif
 
-CAMLexport void (*caml_scan_roots_hook)
-  (scanning_action, void* fdata, caml_domain_state *) = NULL;
+CAMLexport _Atomic scan_roots_hook caml_scan_roots_hook =
+  (scan_roots_hook)NULL;
 
 void caml_do_roots (scanning_action f, void* fdata, caml_domain_state* d,
                     int do_final_val)
 {
+  scan_roots_hook hook;
   caml_do_local_roots(f, fdata, d->local_roots, d->current_stack, d->gc_regs);
-  if (caml_scan_roots_hook != NULL) (*caml_scan_roots_hook)(f, fdata, d);
+  hook = atomic_load(&caml_scan_roots_hook);
+  if (hook != NULL) (*hook)(f, fdata, d);
   caml_final_do_roots(f, fdata, d, do_final_val);
 
 }


### PR DESCRIPTION
This implements the thread-safety of hooks via:
- making global variables atomic when needed,
- documenting thread-safety assumptions.

Hooks used by users are made atomic, the other ones are documented that they do not change when several domains are running.

For thread-safety, the initialization of the `Thread` module fails if more than one domain is running.

This PR restores GC timing hooks in multicore.

This PR is best reviewed commit-per-commit.

(this could interest @kayceesrk, @jhjourdan, @Engil for reviewing)