### PR TITLE
Simplifications/cleanups/clarifications from multicore review

### DIFF
--- a/otherlibs/systhreads/st_posix.h
+++ b/otherlibs/systhreads/st_posix.h
@@ -388,7 +388,7 @@ value caml_thread_sigmask(value cmd, value sigs) /* ML */
   caml_leave_blocking_section();
   sync_check_error(retcode, "Thread.sigmask");
   /* Run any handlers for just-unmasked pending signals */
-  caml_process_pending_signals();
+  caml_process_pending_actions();
   return st_encode_sigset(&oldset);
 #else
   caml_invalid_argument("Thread.sigmask not implemented");

--- a/otherlibs/systhreads/st_stubs.c
+++ b/otherlibs/systhreads/st_stubs.c
@@ -711,12 +711,18 @@ CAMLprim value caml_thread_yield(value unit)        /* ML */
 {
   if (atomic_load_acq(&Thread_main_lock.waiters) == 0) return Val_unit;
 
-  caml_process_pending_signals();
+  /* Do all the parts of a blocking section enter/leave except lock
+     manipulation, which we'll do more efficiently in st_thread_yield. (Since
+     our blocking section doesn't contain anything interesting, don't bother
+     with saving errno.)
+  */
+
+  caml_raise_if_exception(caml_process_pending_signals_exn());
   caml_thread_save_runtime_state();
   st_thread_yield(&Thread_main_lock);
   Current_thread = st_tls_get(Thread_key);
   caml_thread_restore_runtime_state();
-  caml_process_pending_signals();
+  caml_raise_if_exception(caml_process_pending_signals_exn());
 
   return Val_unit;
 }

--- a/otherlibs/unix/kill.c
+++ b/otherlibs/unix/kill.c
@@ -27,6 +27,6 @@ CAMLprim value unix_kill(value pid, value signal)
   sig = caml_convert_signal_number(Int_val(signal));
   if (kill(Int_val(pid), sig) == -1)
     uerror("kill", Nothing);
-  caml_process_pending_signals();
+  caml_process_pending_actions();
   return Val_unit;
 }

--- a/otherlibs/unix/signals.c
+++ b/otherlibs/unix/signals.c
@@ -68,7 +68,7 @@ CAMLprim value unix_sigprocmask(value vaction, value vset)
   retcode = sigprocmask(how, &set, &oldset);
   caml_leave_blocking_section();
   /* Run any handlers for just-unmasked pending signals */
-  caml_process_pending_signals();
+  caml_process_pending_actions();
   if (retcode != 0) unix_error(retcode, "sigprocmask", Nothing);
   return encode_sigset(&oldset);
 }

--- a/runtime/addrmap.c
+++ b/runtime/addrmap.c
@@ -12,6 +12,8 @@
 /*                                                                        */
 /**************************************************************************/
 
+#define CAML_INTERNALS
+
 #include "caml/config.h"
 #include "caml/memory.h"
 #include "caml/addrmap.h"

--- a/runtime/alloc.c
+++ b/runtime/alloc.c
@@ -41,8 +41,7 @@ CAMLexport value caml_alloc (mlsize_t wosize, tag_t tag)
     if (wosize == 0){
       result = Atom (tag);
     }else{
-      Alloc_small (result, wosize, tag,
-                   { caml_handle_gc_interrupt_no_async_exceptions(); });
+      Alloc_small (result, wosize, tag, { caml_handle_gc_interrupt(); });
       if (tag < No_scan_tag){
         for (i = 0; i < wosize; i++) Field (result, i) = Val_unit;
       }
@@ -66,7 +65,7 @@ Caml_inline void enter_gc_preserving_vals(mlsize_t wosize, value* vals)
      the fast path. */
   CAMLlocalN(vals_copy, wosize);
   for (i = 0; i < wosize; i++) vals_copy[i] = vals[i];
-  caml_handle_gc_interrupt_no_async_exceptions();
+  caml_handle_gc_interrupt();
   for (i = 0; i < wosize; i++) vals[i] = vals_copy[i];
   CAMLreturn0;
 }
@@ -167,8 +166,7 @@ CAMLexport value caml_alloc_small (mlsize_t wosize, tag_t tag)
   CAMLassert (wosize <= Max_young_wosize);
   CAMLassert (tag < 256);
   CAMLassert (tag != Infix_tag);
-  Alloc_small (result, wosize, tag,
-               { caml_handle_gc_interrupt_no_async_exceptions(); });
+  Alloc_small (result, wosize, tag, { caml_handle_gc_interrupt(); });
   return result;
 }
 
@@ -186,8 +184,7 @@ CAMLexport value caml_alloc_string (mlsize_t len)
   mlsize_t wosize = (len + sizeof (value)) / sizeof (value);
 
   if (wosize <= Max_young_wosize) {
-    Alloc_small (result, wosize, String_tag,
-                 { caml_handle_gc_interrupt_no_async_exceptions(); });
+    Alloc_small (result, wosize, String_tag, { caml_handle_gc_interrupt(); });
   }else{
     result = caml_alloc_shr (wosize, String_tag);
     result = caml_check_urgent_gc (result);
@@ -260,7 +257,7 @@ value caml_alloc_float_array(mlsize_t len)
       return Atom(0);
     else
       Alloc_small (result, wosize, Double_array_tag,
-                   { caml_handle_gc_interrupt_no_async_exceptions(); });
+                   { caml_handle_gc_interrupt(); });
   } else {
     result = caml_alloc_shr (wosize, Double_array_tag);
     result = caml_check_urgent_gc (result);

--- a/runtime/array.c
+++ b/runtime/array.c
@@ -68,8 +68,7 @@ CAMLprim value caml_floatarray_get(value array, value index)
   if (idx < 0 || idx >= Wosize_val(array) / Double_wosize)
     caml_array_bound_error();
   d = Double_flat_field(array, idx);
-  Alloc_small(res, Double_wosize, Double_tag,
-    { caml_handle_gc_interrupt_no_async_exceptions(); });
+  Alloc_small(res, Double_wosize, Double_tag, { caml_handle_gc_interrupt(); });
   Store_double_val(res, d);
   return res;
 }
@@ -129,7 +128,7 @@ CAMLprim value caml_floatarray_unsafe_get(value array, value index)
   CAMLassert (Tag_val(array) == Double_array_tag);
   d = Double_flat_field(array, idx);
   Alloc_small(res, Double_wosize, Double_tag,
-    { caml_handle_gc_interrupt_no_async_exceptions(); });
+              { caml_handle_gc_interrupt(); });
   Store_double_val(res, d);
   return res;
 }
@@ -190,7 +189,7 @@ CAMLprim value caml_floatarray_create(value len)
       return Atom(0);
     else
       Alloc_small (result, wosize, Double_array_tag,
-        { caml_handle_gc_interrupt_no_async_exceptions(); });
+                   { caml_handle_gc_interrupt(); });
   }else if (wosize > Max_wosize)
     caml_invalid_argument("Float.Array.create");
   else {

--- a/runtime/array.c
+++ b/runtime/array.c
@@ -195,8 +195,8 @@ CAMLprim value caml_floatarray_create(value len)
   else {
     result = caml_alloc_shr (wosize, Double_array_tag);
   }
-  /* Give the GC a chance to run */
-  return caml_check_urgent_gc (result);
+  /* Give the GC a chance to run, and run memprof callbacks */
+  return caml_process_pending_actions_with_root(result);
 }
 
 /* [len] is a [value] representing number of words or floats */
@@ -242,7 +242,7 @@ CAMLprim value caml_make_vect(value len, value init)
       for (i = 0; i < size; i++) Field(res, i) = init;
     }
   }
-  /* Give the GC a chance to run */
+  /* Give the GC a chance to run, and run memprof callbacks */
   caml_process_pending_actions ();
   CAMLreturn (res);
 }
@@ -295,6 +295,7 @@ CAMLprim value caml_make_array(value init)
         double d = Double_val(Field(init, i));
         Store_double_flat_field(res, i, d);
       }
+      /* run memprof callbacks */
       caml_process_pending_actions();
       CAMLreturn (res);
     }
@@ -479,7 +480,7 @@ static value caml_array_gather(intnat num_arrays,
     /* Many caml_initialize in a row can create a lot of old-to-young
        refs.  Give the minor GC a chance to run if it needs to.
        Run memprof callbacks for the major allocation. */
-    res = caml_check_urgent_gc(res);
+    res = caml_process_pending_actions_with_root (res);
   }
   CAMLreturn (res);
 }

--- a/runtime/caml/alloc.h
+++ b/runtime/caml/alloc.h
@@ -24,6 +24,10 @@
 extern "C" {
 #endif
 
+/* It is guaranteed that these allocation functions will not trigger
+   any OCaml callback such as finalizers or signal handlers.
+   FIXME: Not implemented in OCaml 5.0. */
+
 CAMLextern value caml_alloc (mlsize_t, tag_t);
 CAMLextern value caml_alloc_N(mlsize_t, tag_t, ...);
 CAMLextern value caml_alloc_1(tag_t, value);

--- a/runtime/caml/domain.h
+++ b/runtime/caml/domain.h
@@ -40,7 +40,6 @@ int caml_reallocate_minor_heap(asize_t);
 int caml_incoming_interrupts_queued(void);
 
 void caml_handle_gc_interrupt(void);
-void caml_handle_gc_interrupt_no_async_exceptions(void);
 void caml_handle_incoming_interrupts(void);
 
 CAMLextern void caml_interrupt_self(void);

--- a/runtime/caml/domain.h
+++ b/runtime/caml/domain.h
@@ -39,6 +39,7 @@ int caml_reallocate_minor_heap(asize_t);
 
 int caml_incoming_interrupts_queued(void);
 
+int caml_check_pending_interrupt(void);
 void caml_handle_gc_interrupt(void);
 void caml_handle_incoming_interrupts(void);
 

--- a/runtime/caml/memory.h
+++ b/runtime/caml/memory.h
@@ -221,10 +221,8 @@ CAMLextern wchar_t* caml_stat_wcsconcat(int n, ...);
 
 #endif /* CAML_INTERNALS */
 
-struct caml__mutex_unwind;
 struct caml__roots_block {
   struct caml__roots_block *next;
-  struct caml__mutex_unwind *mutexes;
   intnat ntables;
   intnat nitems;
   value *tables [5];
@@ -296,7 +294,6 @@ struct caml__roots_block {
   CAMLunused_start int caml__dummy_##x = ( \
     (caml__roots_##x.next = *caml_local_roots_ptr), \
     (*caml_local_roots_ptr = &caml__roots_##x), \
-    (caml__roots_##x.mutexes = 0), \
     (caml__roots_##x.nitems = 1), \
     (caml__roots_##x.ntables = 1), \
     (caml__roots_##x.tables [0] = &x), \
@@ -308,7 +305,6 @@ struct caml__roots_block {
   CAMLunused_start int caml__dummy_##x = ( \
     (caml__roots_##x.next = *caml_local_roots_ptr), \
     (*caml_local_roots_ptr = &caml__roots_##x), \
-    (caml__roots_##x.mutexes = 0), \
     (caml__roots_##x.nitems = 1), \
     (caml__roots_##x.ntables = 2), \
     (caml__roots_##x.tables [0] = &x), \
@@ -321,7 +317,6 @@ struct caml__roots_block {
   CAMLunused_start int caml__dummy_##x = ( \
     (caml__roots_##x.next = *caml_local_roots_ptr), \
     (*caml_local_roots_ptr = &caml__roots_##x), \
-    (caml__roots_##x.mutexes = 0), \
     (caml__roots_##x.nitems = 1), \
     (caml__roots_##x.ntables = 3), \
     (caml__roots_##x.tables [0] = &x), \
@@ -335,7 +330,6 @@ struct caml__roots_block {
   CAMLunused_start int caml__dummy_##x = ( \
     (caml__roots_##x.next = *caml_local_roots_ptr), \
     (*caml_local_roots_ptr = &caml__roots_##x), \
-    (caml__roots_##x.mutexes = 0), \
     (caml__roots_##x.nitems = 1), \
     (caml__roots_##x.ntables = 4), \
     (caml__roots_##x.tables [0] = &x), \
@@ -350,7 +344,6 @@ struct caml__roots_block {
   CAMLunused_start int caml__dummy_##x = ( \
     (caml__roots_##x.next = *caml_local_roots_ptr), \
     (*caml_local_roots_ptr = &caml__roots_##x), \
-    (caml__roots_##x.mutexes = 0), \
     (caml__roots_##x.nitems = 1), \
     (caml__roots_##x.ntables = 5), \
     (caml__roots_##x.tables [0] = &x), \
@@ -366,7 +359,6 @@ struct caml__roots_block {
   CAMLunused_start int caml__dummy_##x = ( \
     (caml__roots_##x.next = *caml_local_roots_ptr), \
     (*caml_local_roots_ptr = &caml__roots_##x), \
-    (caml__roots_##x.mutexes = 0), \
     (caml__roots_##x.nitems = (size)), \
     (caml__roots_##x.ntables = 1), \
     (caml__roots_##x.tables[0] = &(x[0])), \
@@ -401,21 +393,7 @@ struct caml__roots_block {
     x[caml__i_##x] = Val_unit; \
   }
 
-#ifdef DEBUG
-#define CAMLcheck_mutexes do {   \
-  struct caml__roots_block* r;   \
-  for (r = CAML_LOCAL_ROOTS;     \
-       r != caml__frame;         \
-       r = r->next) {            \
-    CAMLassert(r->mutexes == 0); \
-  }                              \
-} while (0)
-#else
-#define CAMLcheck_mutexes do {} while(0)
-#endif
-
 #define CAMLdrop do{              \
-  CAMLcheck_mutexes;              \
   *caml_local_roots_ptr = caml__frame; \
 }while (0)
 
@@ -469,7 +447,6 @@ struct caml__roots_block {
   caml_domain_state* domain_state = Caml_state; \
   caml__roots_block.next = domain_state->local_roots; \
   domain_state->local_roots = &caml__roots_block; \
-  caml__roots_block.mutexes = 0; \
   caml__roots_block.nitems = 1; \
   caml__roots_block.ntables = 1; \
   caml__roots_block.tables[0] = &(r0);
@@ -479,7 +456,6 @@ struct caml__roots_block {
   caml_domain_state* domain_state = Caml_state; \
   caml__roots_block.next = domain_state->local_roots; \
   domain_state->local_roots = &caml__roots_block; \
-  caml__roots_block.mutexes = 0; \
   caml__roots_block.nitems = 1; \
   caml__roots_block.ntables = 2; \
   caml__roots_block.tables[0] = &(r0); \
@@ -490,7 +466,6 @@ struct caml__roots_block {
   caml_domain_state* domain_state = Caml_state; \
   caml__roots_block.next = domain_state->local_roots; \
   domain_state->local_roots = &caml__roots_block; \
-  caml__roots_block.mutexes = 0; \
   caml__roots_block.nitems = 1; \
   caml__roots_block.ntables = 3; \
   caml__roots_block.tables[0] = &(r0); \
@@ -502,7 +477,6 @@ struct caml__roots_block {
   caml_domain_state* domain_state = Caml_state; \
   caml__roots_block.next = domain_state->local_roots; \
   domain_state->local_roots = &caml__roots_block; \
-  caml__roots_block.mutexes = 0; \
   caml__roots_block.nitems = 1; \
   caml__roots_block.ntables = 4; \
   caml__roots_block.tables[0] = &(r0); \
@@ -515,7 +489,6 @@ struct caml__roots_block {
   caml_domain_state* domain_state = Caml_state; \
   caml__roots_block.next = domain_state->local_roots; \
   domain_state->local_roots = &caml__roots_block; \
-  caml__roots_block.mutexes = 0; \
   caml__roots_block.nitems = 1; \
   caml__roots_block.ntables = 5; \
   caml__roots_block.tables[0] = &(r0); \
@@ -529,7 +502,6 @@ struct caml__roots_block {
   caml_domain_state* domain_state = Caml_state; \
   caml__roots_block.next = domain_state->local_roots; \
   domain_state->local_roots = &caml__roots_block; \
-  caml__roots_block.mutexes = 0; \
   caml__roots_block.nitems = (size); \
   caml__roots_block.ntables = 1; \
   caml__roots_block.tables[0] = (table);

--- a/runtime/caml/memory.h
+++ b/runtime/caml/memory.h
@@ -45,7 +45,7 @@ CAMLextern value caml_alloc_shr_preserving_profinfo (mlsize_t, tag_t,
 #define caml_alloc_shr_preserving_profinfo(size, tag, header) \
   caml_alloc_shr(size, tag)
 #endif /* WITH_PROFINFO */
-CAMLextern value caml_alloc_shr_no_raise (mlsize_t wosize, tag_t);
+
 CAMLextern void caml_adjust_gc_speed (mlsize_t, mlsize_t);
 CAMLextern void caml_alloc_dependent_memory (mlsize_t bsz);
 CAMLextern void caml_free_dependent_memory (mlsize_t bsz);
@@ -58,8 +58,6 @@ CAMLextern char *caml_alloc_for_heap (asize_t request);   /* Size in bytes. */
 CAMLextern void caml_free_for_heap (char *mem);
 CAMLextern int caml_add_to_heap (char *mem);
 #endif /* CAML_INTERNALS */
-
-CAMLextern int caml_huge_fallback_count; /* FIXME KC: Make per domain */
 
 
 /* [caml_stat_*] functions below provide an interface to the static memory

--- a/runtime/caml/misc.h
+++ b/runtime/caml/misc.h
@@ -156,7 +156,7 @@ CAMLdeprecated_typedef(addr, char *);
 #else
 #define caml_prefetch(p)
 #endif
-#endif
+#endif /* CAML_INTERNALS */
 
 /* CAMLunused is preserved for compatibility reasons.
    Instead of the legacy GCC/Clang-only
@@ -246,6 +246,8 @@ CAMLnoreturn_end;
 #define CAMLassert(x) ((void) 0)
 #endif
 
+#ifdef CAML_INTERNALS
+
 #ifdef __GNUC__
 #define CAMLlikely(e)   __builtin_expect((e), 1)
 #define CAMLunlikely(e) __builtin_expect((e), 0)
@@ -273,6 +275,8 @@ void caml_alloc_point_here(void);
 #endif
 
 #define Is_power_of_2(x) ((x) > 0 && ((x) & ((x) - 1)) == 0)
+
+#endif
 
 /* This hook is called when a fatal error occurs in the OCaml
    runtime. It is given arguments to be passed to the [vprintf]-like

--- a/runtime/caml/misc.h
+++ b/runtime/caml/misc.h
@@ -247,11 +247,9 @@ CAMLnoreturn_end;
 #endif
 
 #ifdef __GNUC__
-#define CAMLcheckresult __attribute__((warn_unused_result))
 #define CAMLlikely(e)   __builtin_expect((e), 1)
 #define CAMLunlikely(e) __builtin_expect((e), 0)
 #else
-#define CAMLcheckresult
 #define CAMLlikely(e) (e)
 #define CAMLunlikely(e) (e)
 #endif
@@ -294,11 +292,6 @@ CAMLextern void caml_fatal_error (char *, ...)
   __attribute__ ((format (printf, 1, 2)))
 #endif
 CAMLnoreturn_end;
-CAMLextern void caml_fatal_error_arg (const char *fmt, const char *arg)
-                                     Noreturn;
-CAMLextern void caml_fatal_error_arg2 (const char *fmt1, const char *arg1,
-                                       const char *fmt2, const char *arg2)
-                                      Noreturn;
 
 /* Detection of available C built-in functions, the Clang way. */
 

--- a/runtime/caml/platform.h
+++ b/runtime/caml/platform.h
@@ -109,11 +109,6 @@ void caml_plat_broadcast(caml_plat_cond*);
 void caml_plat_signal(caml_plat_cond*);
 void caml_plat_cond_free(caml_plat_cond*);
 
-struct caml__mutex_unwind {
-  caml_plat_mutex* mutex;
-  struct caml__mutex_unwind* next;
-};
-
 /* Memory management primitives (mmap) */
 
 uintnat caml_mem_round_up_pages(uintnat size);

--- a/runtime/caml/platform.h
+++ b/runtime/caml/platform.h
@@ -18,6 +18,8 @@
 #define CAML_PLAT_THREADS_H
 /* Platform-specific concurrency and memory primitives */
 
+#ifdef CAML_INTERNALS
+
 #include <pthread.h>
 #include <errno.h>
 #include <string.h>
@@ -161,5 +163,7 @@ Caml_inline void caml_plat_unlock(caml_plat_mutex* m)
 /* On Windows, the SYSTEM_INFO.dwPageSize is a DWORD (32-bit), but conveniently
    long is also 32-bit */
 extern long caml_sys_pagesize;
+
+#endif /* CAML_INTERNALS */
 
 #endif /* CAML_PLATFORM_H */

--- a/runtime/caml/platform.h
+++ b/runtime/caml/platform.h
@@ -121,8 +121,7 @@ void caml_mem_unmap(void* mem, uintnat size);
 Caml_inline void check_err(char* action, int err)
 {
   if (err) {
-    caml_fatal_error_arg2(
-      "Fatal error during %s", action, ": %s\n", strerror(err));
+    caml_fatal_error("Fatal error during %s: %s\n", action, strerror(err));
   }
 }
 

--- a/runtime/caml/signals.h
+++ b/runtime/caml/signals.h
@@ -38,7 +38,13 @@ CAMLextern void caml_process_pending_actions (void);
    exceptions asynchronously into OCaml code. */
 
 CAMLextern int caml_check_pending_actions (void);
-/* Returns 1 if there are pending actions, 0 otherwise. */
+/* Returns 1 if there are pending actions, 0 otherwise.
+   FIXME: Unreliable in OCaml 5.0. */
+
+// FIXME: Not implemented in OCaml 5.0.
+//CAMLextern value caml_process_pending_actions_exn (void);
+/* Same as [caml_process_pending_actions], but returns the exception
+   if any (otherwise returns [Val_unit]). */
 
 #ifdef CAML_INTERNALS
 
@@ -64,10 +70,10 @@ CAMLextern int caml_rev_convert_signal_number (int);
 value caml_execute_signal_exn(int signal_number, int in_signal_handler);
 CAMLextern void caml_record_signal(int signal_number);
 CAMLextern value caml_process_pending_signals_exn(void);
-CAMLextern void caml_process_pending_signals(void);
 void caml_set_action_pending (void);
+value caml_process_pending_actions_with_root (value extra_root); // raises
+value caml_process_pending_actions_with_root_exn (value extra_root);
 
-CAMLextern value caml_process_pending_signals_with_root_exn (value extra_root);
 void caml_init_signal_handling(void);
 int caml_init_signal_stack(void);
 void caml_free_signal_stack(void);

--- a/runtime/caml/signals.h
+++ b/runtime/caml/signals.h
@@ -38,8 +38,7 @@ CAMLextern void caml_process_pending_actions (void);
    exceptions asynchronously into OCaml code. */
 
 CAMLextern int caml_check_pending_actions (void);
-/* Returns 1 if there are pending actions, 0 otherwise.
-   FIXME: Unreliable in OCaml 5.0. */
+/* Returns 1 if there are pending actions, 0 otherwise. */
 
 // FIXME: Not implemented in OCaml 5.0.
 //CAMLextern value caml_process_pending_actions_exn (void);
@@ -61,7 +60,7 @@ CAMLextern atomic_uintnat caml_pending_signals[NSIG_WORDS];
 #define caml_requested_major_slice (Caml_state_field(requested_major_slice))
 #define caml_requested_minor_gc (Caml_state_field(requested_minor_gc))
 
-int caml_check_for_pending_signals(void);
+int caml_check_pending_signals(void);
 void caml_update_young_limit(void);
 void caml_request_major_slice (void);
 void caml_request_minor_gc (void);

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -1244,13 +1244,9 @@ CAMLexport void caml_process_pending_actions(void)
   caml_process_pending_signals();
 }
 
-void caml_handle_gc_interrupt_no_async_exceptions(void)
-{
-  handle_gc_interrupt();
-}
-
 void caml_handle_gc_interrupt(void)
 {
+  /* FIXME: do not run async callbakcs */
   handle_gc_interrupt();
 }
 

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -1209,10 +1209,9 @@ static void caml_poll_gc_work(void)
 
 }
 
-CAMLexport int caml_check_pending_actions (void)
+int caml_check_pending_interrupt(void)
 {
   atomic_uintnat* young_limit = domain_self->interruptor.interrupt_word;
-
   return atomic_load_acq(young_limit) == INTERRUPT_MAGIC;
 }
 
@@ -1223,10 +1222,10 @@ void caml_handle_gc_interrupt(void)
   CAMLalloc_point_here;
 
   CAML_EV_BEGIN(EV_INTERRUPT_GC);
-  if (caml_check_pending_actions()) {
+  if (caml_check_pending_interrupt()) {
     /* interrupt */
     CAML_EV_BEGIN(EV_INTERRUPT_REMOTE);
-    while (caml_check_pending_actions()) {
+    while (caml_check_pending_interrupt()) {
       uintnat i = INTERRUPT_MAGIC;
       atomic_compare_exchange_strong(
           young_limit, &i, (uintnat)Caml_state->young_start);

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -1216,7 +1216,9 @@ CAMLexport int caml_check_pending_actions (void)
   return atomic_load_acq(young_limit) == INTERRUPT_MAGIC;
 }
 
-static void handle_gc_interrupt() {
+/* FIXME: do not raise async exceptions */
+void caml_handle_gc_interrupt(void)
+{
   atomic_uintnat* young_limit = domain_self->interruptor.interrupt_word;
   CAMLalloc_point_here;
 
@@ -1236,18 +1238,6 @@ static void handle_gc_interrupt() {
   caml_poll_gc_work();
 
   CAML_EV_END(EV_INTERRUPT_GC);
-}
-
-CAMLexport void caml_process_pending_actions(void)
-{
-  handle_gc_interrupt();
-  caml_process_pending_signals();
-}
-
-void caml_handle_gc_interrupt(void)
-{
-  /* FIXME: do not run async callbakcs */
-  handle_gc_interrupt();
 }
 
 CAMLexport int caml_bt_is_in_blocking_section(void)

--- a/runtime/fail_byt.c
+++ b/runtime/fail_byt.c
@@ -44,9 +44,7 @@ CAMLexport void caml_raise(value v)
   if (Caml_state->external_raise == NULL) caml_fatal_uncaught_exception(v);
   *Caml_state->external_raise->exn_bucket = v;
 
-  while(Caml_state->local_roots != Caml_state->external_raise->local_roots) {
-    Caml_state->local_roots = Caml_state->local_roots->next;
-  }
+  Caml_state->local_roots = Caml_state->external_raise->local_roots;
 
   siglongjmp(Caml_state->external_raise->jmp->buf, 1);
 }

--- a/runtime/fail_byt.c
+++ b/runtime/fail_byt.c
@@ -37,7 +37,7 @@ CAMLexport void caml_raise(value v)
   CAMLassert(!Is_exception_result(v));
 
   // avoid calling caml_raise recursively
-  v = caml_process_pending_signals_with_root_exn(v);
+  v = caml_process_pending_actions_with_root_exn(v);
   if (Is_exception_result(v))
     v = Extract_exception(v);
 

--- a/runtime/fail_nat.c
+++ b/runtime/fail_nat.c
@@ -70,7 +70,7 @@ void caml_raise(value v)
   CAMLassert(!Is_exception_result(v));
 
   // avoid calling caml_raise recursively
-  v = caml_process_pending_signals_with_root_exn(v);
+  v = caml_process_pending_actions_with_root_exn(v);
   if (Is_exception_result(v))
     v = Extract_exception(v);
 

--- a/runtime/floats.c
+++ b/runtime/floats.c
@@ -153,8 +153,7 @@ CAMLexport value caml_copy_double(double d)
 {
   value res;
 
-  Alloc_small(res, Double_wosize, Double_tag,
-              { caml_handle_gc_interrupt_no_async_exceptions(); });
+  Alloc_small(res, Double_wosize, Double_tag, { caml_handle_gc_interrupt(); });
   Store_double_val(res, d);
   return res;
 }

--- a/runtime/intern.c
+++ b/runtime/intern.c
@@ -676,7 +676,7 @@ static value intern_end(struct caml_intern_state* s, value res)
   intern_cleanup(s);
 
   /* Give gc a chance to run, and run memprof callbacks */
-  res = caml_check_urgent_gc(res);
+  caml_process_pending_actions();
 
   CAMLreturn(res);
 }

--- a/runtime/interp.c
+++ b/runtime/interp.c
@@ -913,7 +913,7 @@ value caml_interprete(code_t prog, asize_t prog_size)
 
     Instruct(POPTRAP):
       if (Caml_check_gc_interrupt(domain_state) ||
-          caml_check_for_pending_signals()) {
+          caml_check_pending_signals()) {
         /* We must check here so that if a signal is pending and its
            handler triggers an exception, the exception is trapped
            by the current try...with, not the enclosing one. */
@@ -997,7 +997,7 @@ value caml_interprete(code_t prog, asize_t prog_size)
 
     Instruct(CHECK_SIGNALS):    /* accu not preserved */
       if (Caml_check_gc_interrupt(domain_state) ||
-          caml_check_for_pending_signals())
+          caml_check_pending_signals())
         goto process_signal;
       Next;
 

--- a/runtime/interp.c
+++ b/runtime/interp.c
@@ -71,14 +71,12 @@ sp is a local copy of the global variable Caml_state->extern_sp. */
 
 /* GC interface */
 
-#undef Alloc_small_origin
-// Do call asynchronous callbacks from allocation functions
-#define Alloc_small_origin CAML_FROM_CAML
 #define Setup_for_gc \
   { sp -= 3; sp[0] = accu; sp[1] = env; sp[2] = (value)pc; \
     domain_state->current_stack->sp = sp; }
 #define Restore_after_gc \
   { sp = domain_state->current_stack->sp; accu = sp[0]; env = sp[1]; sp += 3; }
+/* Do call asynchronous callbacks from allocation functions */
 #define Enter_gc \
   { Setup_for_gc; \
     caml_process_pending_actions();         \

--- a/runtime/meta.c
+++ b/runtime/meta.c
@@ -271,6 +271,4 @@ value caml_static_release_bytecode(value prog, value len)
   return Val_unit; /* not reached */
 }
 
-void (* volatile caml_async_action_hook)(void);
-
 #endif

--- a/runtime/obj.c
+++ b/runtime/obj.c
@@ -30,6 +30,7 @@
 #include "caml/mlvalues.h"
 #include "caml/platform.h"
 #include "caml/prims.h"
+#include "caml/signals.h"
 
 static int obj_tag (value arg)
 {

--- a/runtime/obj.c
+++ b/runtime/obj.c
@@ -158,6 +158,8 @@ CAMLprim value caml_obj_with_tag(value new_tag_v, value arg)
        and some of the "values" being copied are actually code pointers.
        That's because the new "value" does not point to the minor heap. */
     for (i = 0; i < sz; i++) caml_initialize(&Field(res, i), Field(arg, i));
+    /* Give gc a chance to run, and run memprof callbacks */
+    caml_process_pending_actions();
   }
 
   CAMLreturn (res);

--- a/runtime/signals.c
+++ b/runtime/signals.c
@@ -405,7 +405,7 @@ void caml_free_signal_stack(void)
      but OSX/Darwin fails if the size isn't set. */
   disable.ss_size = SIGSTKSZ;
   if (sigaltstack(&disable, &stk) < 0) {
-    caml_fatal_error_arg("Failed to reset signal stack: %s", strerror(errno));
+    caml_fatal_error("Failed to reset signal stack: %s", strerror(errno));
   }
   /* Memory was allocated with malloc directly; see caml_init_signal_stack */
   free(stk.ss_sp);

--- a/runtime/weak.c
+++ b/runtime/weak.c
@@ -26,6 +26,7 @@
 #include "caml/memory.h"
 #include "caml/mlvalues.h"
 #include "caml/shared_heap.h"
+#include "caml/signals.h"
 #include "caml/weak.h"
 
 value caml_dummy[] =

--- a/runtime/weak.c
+++ b/runtime/weak.c
@@ -64,7 +64,8 @@ CAMLprim value caml_ephe_create (value len)
   domain_state->ephe_info->live = res;
   for (i = CAML_EPHE_DATA_OFFSET; i < size; i++)
     Field(res, i) = caml_ephe_none;
-  return res;
+  /* run memprof callbacks */
+  return caml_process_pending_actions_with_root(res);
 }
 
 CAMLprim value caml_weak_create (value len)
@@ -253,6 +254,8 @@ static value ephe_get_field (value e, mlsize_t offset)
     res = caml_alloc_shr (1, Some_tag);
     caml_initialize(&Field(res, 0), elt);
   }
+  /* run GC and memprof callbacks */
+  caml_process_pending_actions();
   CAMLreturn (res);
 }
 
@@ -280,7 +283,10 @@ static value ephe_get_field_copy (value e, mlsize_t offset)
 
   clean_field(e, offset);
   v = Field(e, offset);
-  if (v == caml_ephe_none) CAMLreturn (None_val);
+  if (v == caml_ephe_none) {
+    res = None_val;
+    goto out;
+  }
 
   /** Don't copy custom_block #7279 */
   if (Is_block(v) && Tag_val(v) != Custom_tag) {
@@ -320,6 +326,9 @@ static value ephe_get_field_copy (value e, mlsize_t offset)
   }
   res = caml_alloc_shr (1, Some_tag);
   caml_initialize(&Field(res, 0), elt + infix_offs);
+ out:
+  /* run GC and memprof callbacks */
+  caml_process_pending_actions();
   CAMLreturn(res);
 }
 


### PR DESCRIPTION
This PR is best read commit-by-commit. I grouped them together because they are all minor changes coming from my review of the multicore PR and are expected to introduce no behaviour change (and I think will interest @kayceesrk and @sadiqj).

- As discussed, document `caml_modify`. Confusion stems from the fact that the PLDI paper describes a publication scheme based on the old concurrent collector design, so we document the difference with the paper. (As a side note, have the benchmarks from the paper been re-run with the release store instead of a relaxed store? If there is an impact then one could try optimizations based on the write barrier.)
- Remove some dead code.
- Make some currently-public APIs private.
- Simplify/restore the APIs for signals/actions. Regarding the public API this is necessary work for 5.0, it prepares trunk for a 5.0 release in case #10915 does not move fast enough. The rest is preliminary work to solving the issue.

I believe that this PR will not need too many discussions, but if you want me to split any part of it to a different PR do not hesitate to request it.

Each commit has a detailed commit log that gives more details.