### PR TITLE
Add Filename.temp_dir function to create a temporary directory

### DIFF
--- a/Changes
+++ b/Changes
@@ -160,6 +160,10 @@ Working version
   (Greta Yorsh, review by Xavier Leroy, Guillaume Melquiond and
   Gabriel Scherer)
 
+- #10967: Add Filename.temp_dir.
+  (David Turner, review by Anil Madhavapeddy, Valentin Gatien-Baron, Nicolás
+  Ojeda Bär, Gabriel Scherer, and Daniel Bünzli)
+
 - #11026, #11667, #11858: Rename the type of the accumulator
   of fold functions to 'acc:
   fold_left : ('acc -> 'a -> 'acc) -> 'acc -> 'a list -> 'acc

--- a/stdlib/filename.ml
+++ b/stdlib/filename.ml
@@ -361,3 +361,14 @@ let open_temp_file ?(mode = [Open_text]) ?(perms = 0o600)
     with Sys_error _ as e ->
       if counter >= 20 then raise e else try_name (counter + 1)
   in try_name 0
+
+let temp_dir ?(temp_dir = Domain.DLS.get current_temp_dir_name)
+    ?(perms = 0o700) prefix suffix =
+  let rec try_name counter =
+    let name = temp_file_name temp_dir prefix suffix in
+    try
+      Sys.mkdir name perms;
+      name
+    with Sys_error _ as e ->
+      if counter >= 20 then raise e else try_name (counter + 1)
+  in try_name 0

--- a/stdlib/filename.ml
+++ b/stdlib/filename.ml
@@ -347,7 +347,7 @@ let temp_file ?(temp_dir = Domain.DLS.get current_temp_dir_name) prefix suffix =
       close_desc(open_desc name [Open_wronly; Open_creat; Open_excl] 0o600);
       name
     with Sys_error _ as e ->
-      if counter >= 1000 then raise e else try_name (counter + 1)
+      if counter >= 20 then raise e else try_name (counter + 1)
   in try_name 0
 
 let open_temp_file ?(mode = [Open_text]) ?(perms = 0o600)
@@ -359,5 +359,5 @@ let open_temp_file ?(mode = [Open_text]) ?(perms = 0o600)
       (name,
        open_out_gen (Open_wronly::Open_creat::Open_excl::mode) perms name)
     with Sys_error _ as e ->
-      if counter >= 1000 then raise e else try_name (counter + 1)
+      if counter >= 20 then raise e else try_name (counter + 1)
   in try_name 0

--- a/stdlib/filename.mli
+++ b/stdlib/filename.mli
@@ -159,6 +159,26 @@ val open_temp_file :
    @before 3.11.2 no ?temp_dir optional argument
 *)
 
+val temp_dir : ?temp_dir: string -> ?perms:int  -> string -> string -> string
+(** [temp_dir prefix suffix] creates and returns the name of a fresh
+   temporary directory with permissions [perms] (defaults to 0o700)
+   inside [temp_dir].  The base name of the temporary directory is
+   formed by concatenating [prefix], then a suitably chosen integer
+   number, then [suffix].  The optional argument [temp_dir] indicates
+   the temporary directory to use, defaulting to the current result of
+   {!Filename.get_temp_dir_name}.  The temporary directory is created
+   empty, with permissions [0o700] (readable, writable, and searchable
+   only by the file owner).  The directory is guaranteed to be
+   different from any other directory that existed when [temp_dir] was
+   called.
+
+   If temp_dir does not exist, this function does not create it.  Instead,
+   it raises Sys_error.
+
+   @raise Sys_error if the directory could not be created.
+   @since 5.1
+*)
+
 val get_temp_dir_name : unit -> string
 (** The name of the temporary directory:
     Under Unix, the value of the [TMPDIR] environment variable, or "/tmp"

--- a/testsuite/tests/lib-filename/temp.ml
+++ b/testsuite/tests/lib-filename/temp.ml
@@ -1,0 +1,16 @@
+(* TEST
+*)
+
+let () =
+ let tmpdir1 = ref "" in
+ let tmpdir2 = ref "" in
+ Fun.protect ~finally:(fun () ->
+   if !tmpdir1 <> "" then Sys.rmdir !tmpdir1;
+   if !tmpdir2 <> "" then Sys.rmdir !tmpdir2;
+ ) (fun () ->
+    tmpdir1 := Filename.temp_dir "morx" "fleem";
+    assert (Sys.is_directory !tmpdir1);
+    tmpdir2 := Filename.temp_dir "morx" "fleem" ;
+    assert (Sys.is_directory !tmpdir2);
+    assert (!tmpdir1 <> !tmpdir2);
+   )


### PR DESCRIPTION
We recently wanted this for [Tezos](https://gitlab.com/tezos/tezos/-/merge_requests/4320) and didn't find it in the standard library.  Prior art: POSIX has mkdtemp.