### PR TITLE
Couple macros improvement on amd64 backend

### DIFF
--- a/runtime/amd64.S
+++ b/runtime/amd64.S
@@ -77,7 +77,7 @@
 #if defined(SYS_linux) || defined(SYS_gnu)
 #define ENDFUNCTION(name) \
 CFI_ENDPROC; \
-        .size name, . - name
+        .size G(name), . - G(name)
 #else
 #define ENDFUNCTION(name) \
 CFI_ENDPROC
@@ -481,7 +481,7 @@ CFI_STARTPROC
         LEA_VAR(caml_exn_Stack_overflow, %rax)
         add     $16, %rsp /* pop argument, retaddr */
         jmp     GCALL(caml_raise_exn)
-ENDFUNCTION(G(caml_call_realloc_stack))
+ENDFUNCTION(caml_call_realloc_stack)
 
 FUNCTION(G(caml_call_gc))
 CFI_STARTPROC
@@ -495,7 +495,7 @@ LBL(caml_call_gc):
         movq    Caml_state(gc_regs), %r15
         RESTORE_ALL_REGS
         ret
-ENDFUNCTION(G(caml_call_gc))
+ENDFUNCTION(caml_call_gc)
 
 FUNCTION(G(caml_alloc1))
 CFI_STARTPROC
@@ -503,7 +503,7 @@ CFI_STARTPROC
         cmpq    Caml_state(young_limit), %r15
         jb      LBL(caml_call_gc)
         ret
-ENDFUNCTION(G(caml_alloc1))
+ENDFUNCTION(caml_alloc1)
 
 FUNCTION(G(caml_alloc2))
 CFI_STARTPROC
@@ -511,7 +511,7 @@ CFI_STARTPROC
         cmpq    Caml_state(young_limit), %r15
         jb      LBL(caml_call_gc)
         ret
-ENDFUNCTION(G(caml_alloc2))
+ENDFUNCTION(caml_alloc2)
 
 FUNCTION(G(caml_alloc3))
 CFI_STARTPROC
@@ -519,14 +519,14 @@ CFI_STARTPROC
         cmpq    Caml_state(young_limit), %r15
         jb      LBL(caml_call_gc)
         ret
-ENDFUNCTION(G(caml_alloc3))
+ENDFUNCTION(caml_alloc3)
 
 FUNCTION(G(caml_allocN))
 CFI_STARTPROC
         cmpq    Caml_state(young_limit), %r15
         jb      LBL(caml_call_gc)
         ret
-ENDFUNCTION(G(caml_allocN))
+ENDFUNCTION(caml_allocN)
 
 /******************************************************************************/
 /* Call a C function from OCaml */
@@ -551,7 +551,7 @@ LBL(caml_c_call):
         SWITCH_C_TO_OCAML
     /* Return to OCaml caller */
         ret
-ENDFUNCTION(G(caml_c_call))
+ENDFUNCTION(caml_c_call)
 
 FUNCTION(G(caml_c_call_stack_args))
 CFI_STARTPROC
@@ -590,7 +590,7 @@ LBL(106):
         SWITCH_C_TO_OCAML
     /* Return to OCaml caller */
         ret
-ENDFUNCTION(G(caml_c_call_stack_args))
+ENDFUNCTION(caml_c_call_stack_args)
 
 /******************************************************************************/
 /* Start the OCaml program */
@@ -685,7 +685,7 @@ LBL(109):
         /* exn handler already popped here */
         movq    %rsp, %r10
         jmp     1b
-ENDFUNCTION(G(caml_start_program))
+ENDFUNCTION(caml_start_program)
 
 /******************************************************************************/
 /* Exceptions */
@@ -715,7 +715,7 @@ LBL(117):
         movq    %r12, %rax        /* Recover exception bucket */
         RESTORE_EXN_HANDLER_OCAML
         ret
-ENDFUNCTION(G(caml_raise_exn))
+ENDFUNCTION(caml_raise_exn)
 
 FUNCTION(G(caml_reraise_exn))
 CFI_STARTPROC
@@ -723,7 +723,7 @@ CFI_STARTPROC
         jne   LBL(117)
         RESTORE_EXN_HANDLER_OCAML
         ret
-ENDFUNCTION(G(caml_reraise_exn))
+ENDFUNCTION(caml_reraise_exn)
 
 /* Raise an exception from C */
 
@@ -737,7 +737,7 @@ CFI_STARTPROC
         movq    Caml_state(current_stack), %r10
         movq    Stack_sp(%r10), %rsp         /* FIXME: CFI */
         jmp LBL(caml_raise_exn)
-ENDFUNCTION(G(caml_raise_exception))
+ENDFUNCTION(caml_raise_exception)
 
 /******************************************************************************/
 /* Callback from C to OCaml */
@@ -755,7 +755,7 @@ CFI_STARTPROC
         movq    $0, %rdi           /* dummy */
         movq    $0, %rsi           /* dummy */
         jmp     LBL(caml_start_program)
-ENDFUNCTION(G(caml_callback_asm))
+ENDFUNCTION(caml_callback_asm)
 
 FUNCTION(G(caml_callback2_asm))
 CFI_STARTPROC
@@ -769,7 +769,7 @@ CFI_STARTPROC
         LEA_VAR(caml_apply2, %r12) /* code pointer */
         movq    $0, %rsi           /* dummy */
         jmp     LBL(caml_start_program)
-ENDFUNCTION(G(caml_callback2_asm))
+ENDFUNCTION(caml_callback2_asm)
 
 FUNCTION(G(caml_callback3_asm))
 CFI_STARTPROC
@@ -783,7 +783,7 @@ CFI_STARTPROC
         movq    16(C_ARG_3), %rdi  /* third argument */
         LEA_VAR(caml_apply3, %r12) /* code pointer */
         jmp     LBL(caml_start_program)
-ENDFUNCTION(G(caml_callback3_asm))
+ENDFUNCTION(caml_callback3_asm)
 
 /******************************************************************************/
 /* Fibers */
@@ -825,7 +825,7 @@ LBL(112):
     /* No parent stack. Raise Unhandled. */
         LEA_VAR(caml_exn_Unhandled, %rax)
         jmp LBL(caml_raise_exn)
-ENDFUNCTION(G(caml_perform))
+ENDFUNCTION(caml_perform)
 
 FUNCTION(G(caml_reperform))
 CFI_STARTPROC
@@ -837,7 +837,7 @@ CFI_STARTPROC
         movq    %rsi, Handler_parent(%r10)       /* Append to last_fiber */
         leaq    1(%rsi), %rdi  /* %rdi (last_fiber) := Val_ptr(old stack) */
         jmp     LBL(do_perform)
-ENDFUNCTION(G(caml_reperform))
+ENDFUNCTION(caml_reperform)
 
 FUNCTION(G(caml_resume))
 CFI_STARTPROC
@@ -859,7 +859,7 @@ CFI_STARTPROC
         jmp     *(%rbx)
 2:      LEA_VAR(caml_exn_Continuation_already_taken, %rax)
         jmp LBL(caml_raise_exn)
-ENDFUNCTION(G(caml_resume))
+ENDFUNCTION(caml_resume)
 
 /* Run a function on a new stack,
    then invoke either the value or exception handler */
@@ -930,13 +930,13 @@ LBL(fiber_exn_handler):
         leaq    16(%rsp), %r11
         movq    Handler_exception(%r11), %rbx
         jmp     1b
-ENDFUNCTION(G(caml_runstack))
+ENDFUNCTION(caml_runstack)
 
 FUNCTION(G(caml_ml_array_bound_error))
 CFI_STARTPROC
         LEA_VAR(caml_array_bound_error, %rax)
         jmp     LBL(caml_c_call)
-ENDFUNCTION(G(caml_ml_array_bound_error))
+ENDFUNCTION(caml_ml_array_bound_error)
 
 FUNCTION(G(caml_assert_stack_invariants))
 CFI_STARTPROC
@@ -949,7 +949,7 @@ CFI_STARTPROC
         jge     1f
         int3
 1:      ret
-ENDFUNCTION(G(caml_assert_stack_invariants))
+ENDFUNCTION(caml_assert_stack_invariants)
 
         TEXT_SECTION(caml_system__code_end)
         .globl  G(caml_system__code_end)

--- a/runtime/amd64.S
+++ b/runtime/amd64.S
@@ -85,6 +85,8 @@ CFI_ENDPROC; \
 CFI_ENDPROC
 #endif
 
+#define CAML_FUNCTION(name) FUNCTION(name)
+
 #ifdef ASM_CFI_SUPPORTED
 #define CFI_STARTPROC .cfi_startproc
 #define CFI_ENDPROC .cfi_endproc
@@ -467,7 +469,7 @@ G(caml_system__code_begin):
         movsd   (15+13)*8(%r15),%xmm15;                \
         movq    Caml_state(young_ptr), %r15
 
-FUNCTION(caml_call_realloc_stack)
+CAML_FUNCTION(caml_call_realloc_stack)
         CFI_SIGNAL_FRAME
         SAVE_ALL_REGS
         movq    8(%rsp), C_ARG_1 /* argument */
@@ -484,7 +486,7 @@ FUNCTION(caml_call_realloc_stack)
         jmp     GCALL(caml_raise_exn)
 ENDFUNCTION(caml_call_realloc_stack)
 
-FUNCTION(caml_call_gc)
+CAML_FUNCTION(caml_call_gc)
         CFI_SIGNAL_FRAME
 LBL(caml_call_gc):
         SAVE_ALL_REGS
@@ -497,28 +499,28 @@ LBL(caml_call_gc):
         ret
 ENDFUNCTION(caml_call_gc)
 
-FUNCTION(caml_alloc1)
+CAML_FUNCTION(caml_alloc1)
         subq    $16, %r15
         cmpq    Caml_state(young_limit), %r15
         jb      LBL(caml_call_gc)
         ret
 ENDFUNCTION(caml_alloc1)
 
-FUNCTION(caml_alloc2)
+CAML_FUNCTION(caml_alloc2)
         subq    $24, %r15
         cmpq    Caml_state(young_limit), %r15
         jb      LBL(caml_call_gc)
         ret
 ENDFUNCTION(caml_alloc2)
 
-FUNCTION(caml_alloc3)
+CAML_FUNCTION(caml_alloc3)
         subq    $32, %r15
         cmpq    Caml_state(young_limit), %r15
         jb      LBL(caml_call_gc)
         ret
 ENDFUNCTION(caml_alloc3)
 
-FUNCTION(caml_allocN)
+CAML_FUNCTION(caml_allocN)
         cmpq    Caml_state(young_limit), %r15
         jb      LBL(caml_call_gc)
         ret
@@ -528,7 +530,7 @@ ENDFUNCTION(caml_allocN)
 /* Call a C function from OCaml */
 /******************************************************************************/
 
-FUNCTION(caml_c_call)
+CAML_FUNCTION(caml_c_call)
         CFI_SIGNAL_FRAME
 LBL(caml_c_call):
     /* Arguments:
@@ -548,7 +550,7 @@ LBL(caml_c_call):
         ret
 ENDFUNCTION(caml_c_call)
 
-FUNCTION(caml_c_call_stack_args)
+CAML_FUNCTION(caml_c_call_stack_args)
         CFI_SIGNAL_FRAME
     /* Arguments:
         C arguments         : %rdi, %rsi, %rdx, %rcx, %r8, and %r9
@@ -686,7 +688,7 @@ ENDFUNCTION(caml_start_program)
 
 /* Raise an exception from OCaml */
 
-FUNCTION(caml_raise_exn)
+CAML_FUNCTION(caml_raise_exn)
 LBL(caml_raise_exn):
         testq   $1, Caml_state(backtrace_active)
         jne   LBL(116)
@@ -709,7 +711,7 @@ LBL(117):
         ret
 ENDFUNCTION(caml_raise_exn)
 
-FUNCTION(caml_reraise_exn)
+CAML_FUNCTION(caml_reraise_exn)
         testq   $1, Caml_state(backtrace_active)
         jne   LBL(117)
         RESTORE_EXN_HANDLER_OCAML
@@ -782,7 +784,7 @@ ENDFUNCTION(caml_callback3_asm)
  */
 /******************************************************************************/
 
-FUNCTION(caml_perform)
+CAML_FUNCTION(caml_perform)
     /*  %rax: effect to perform
         %rbx: freshly allocated continuation */
         movq    Caml_state(current_stack), %rsi /* %rsi := old stack */
@@ -813,7 +815,7 @@ LBL(112):
         jmp LBL(caml_raise_exn)
 ENDFUNCTION(caml_perform)
 
-FUNCTION(caml_reperform)
+CAML_FUNCTION(caml_reperform)
     /*  %rax: effect to reperform
         %rbx: continuation
         %rdi: last_fiber */
@@ -824,7 +826,7 @@ FUNCTION(caml_reperform)
         jmp     LBL(do_perform)
 ENDFUNCTION(caml_reperform)
 
-FUNCTION(caml_resume)
+CAML_FUNCTION(caml_resume)
     /* %rax -> stack, %rbx -> fun, %rdi -> arg */
         leaq    -1(%rax), %r10  /* %r10 (new stack) = Ptr_val(%rax) */
         movq    %rdi, %rax      /* %rax := argument to function in %rbx */
@@ -847,7 +849,7 @@ ENDFUNCTION(caml_resume)
 
 /* Run a function on a new stack,
    then invoke either the value or exception handler */
-FUNCTION(caml_runstack)
+CAML_FUNCTION(caml_runstack)
         CFI_SIGNAL_FRAME
     /* %rax -> stack, %rbx -> fun, %rdi -> arg */
         andq    $-2, %rax       /* %rax = Ptr_val(%rax) */
@@ -915,12 +917,12 @@ LBL(fiber_exn_handler):
         jmp     1b
 ENDFUNCTION(caml_runstack)
 
-FUNCTION(caml_ml_array_bound_error)
+CAML_FUNCTION(caml_ml_array_bound_error)
         LEA_VAR(caml_array_bound_error, %rax)
         jmp     LBL(caml_c_call)
 ENDFUNCTION(caml_ml_array_bound_error)
 
-FUNCTION(caml_assert_stack_invariants)
+CAML_FUNCTION(caml_assert_stack_invariants)
 /*      CHECK_STACK_ALIGNMENT */
         movq    Caml_state(current_stack), %r11
         movq    %rsp, %r10

--- a/runtime/amd64.S
+++ b/runtime/amd64.S
@@ -76,9 +76,11 @@
 
 #if defined(SYS_linux) || defined(SYS_gnu)
 #define ENDFUNCTION(name) \
+CFI_ENDPROC; \
         .size name, . - name
 #else
-#define ENDFUNCTION(name)
+#define ENDFUNCTION(name) \
+CFI_ENDPROC
 #endif
 
 #ifdef ASM_CFI_SUPPORTED
@@ -479,7 +481,6 @@ CFI_STARTPROC
         LEA_VAR(caml_exn_Stack_overflow, %rax)
         add     $16, %rsp /* pop argument, retaddr */
         jmp     GCALL(caml_raise_exn)
-CFI_ENDPROC
 ENDFUNCTION(G(caml_call_realloc_stack))
 
 FUNCTION(G(caml_call_gc))
@@ -494,7 +495,6 @@ LBL(caml_call_gc):
         movq    Caml_state(gc_regs), %r15
         RESTORE_ALL_REGS
         ret
-CFI_ENDPROC
 ENDFUNCTION(G(caml_call_gc))
 
 FUNCTION(G(caml_alloc1))
@@ -503,7 +503,6 @@ CFI_STARTPROC
         cmpq    Caml_state(young_limit), %r15
         jb      LBL(caml_call_gc)
         ret
-CFI_ENDPROC
 ENDFUNCTION(G(caml_alloc1))
 
 FUNCTION(G(caml_alloc2))
@@ -512,7 +511,6 @@ CFI_STARTPROC
         cmpq    Caml_state(young_limit), %r15
         jb      LBL(caml_call_gc)
         ret
-CFI_ENDPROC
 ENDFUNCTION(G(caml_alloc2))
 
 FUNCTION(G(caml_alloc3))
@@ -521,7 +519,6 @@ CFI_STARTPROC
         cmpq    Caml_state(young_limit), %r15
         jb      LBL(caml_call_gc)
         ret
-CFI_ENDPROC
 ENDFUNCTION(G(caml_alloc3))
 
 FUNCTION(G(caml_allocN))
@@ -529,7 +526,6 @@ CFI_STARTPROC
         cmpq    Caml_state(young_limit), %r15
         jb      LBL(caml_call_gc)
         ret
-CFI_ENDPROC
 ENDFUNCTION(G(caml_allocN))
 
 /******************************************************************************/
@@ -555,7 +551,6 @@ LBL(caml_c_call):
         SWITCH_C_TO_OCAML
     /* Return to OCaml caller */
         ret
-CFI_ENDPROC
 ENDFUNCTION(G(caml_c_call))
 
 FUNCTION(G(caml_c_call_stack_args))
@@ -595,7 +590,6 @@ LBL(106):
         SWITCH_C_TO_OCAML
     /* Return to OCaml caller */
         ret
-CFI_ENDPROC
 ENDFUNCTION(G(caml_c_call_stack_args))
 
 /******************************************************************************/
@@ -691,7 +685,6 @@ LBL(109):
         /* exn handler already popped here */
         movq    %rsp, %r10
         jmp     1b
-CFI_ENDPROC
 ENDFUNCTION(G(caml_start_program))
 
 /******************************************************************************/
@@ -722,7 +715,6 @@ LBL(117):
         movq    %r12, %rax        /* Recover exception bucket */
         RESTORE_EXN_HANDLER_OCAML
         ret
-CFI_ENDPROC
 ENDFUNCTION(G(caml_raise_exn))
 
 FUNCTION(G(caml_reraise_exn))
@@ -731,7 +723,6 @@ CFI_STARTPROC
         jne   LBL(117)
         RESTORE_EXN_HANDLER_OCAML
         ret
-CFI_ENDPROC
 ENDFUNCTION(G(caml_reraise_exn))
 
 /* Raise an exception from C */
@@ -746,7 +737,6 @@ CFI_STARTPROC
         movq    Caml_state(current_stack), %r10
         movq    Stack_sp(%r10), %rsp         /* FIXME: CFI */
         jmp LBL(caml_raise_exn)
-CFI_ENDPROC
 ENDFUNCTION(G(caml_raise_exception))
 
 /******************************************************************************/
@@ -765,7 +755,6 @@ CFI_STARTPROC
         movq    $0, %rdi           /* dummy */
         movq    $0, %rsi           /* dummy */
         jmp     LBL(caml_start_program)
-CFI_ENDPROC
 ENDFUNCTION(G(caml_callback_asm))
 
 FUNCTION(G(caml_callback2_asm))
@@ -780,7 +769,6 @@ CFI_STARTPROC
         LEA_VAR(caml_apply2, %r12) /* code pointer */
         movq    $0, %rsi           /* dummy */
         jmp     LBL(caml_start_program)
-CFI_ENDPROC
 ENDFUNCTION(G(caml_callback2_asm))
 
 FUNCTION(G(caml_callback3_asm))
@@ -795,7 +783,6 @@ CFI_STARTPROC
         movq    16(C_ARG_3), %rdi  /* third argument */
         LEA_VAR(caml_apply3, %r12) /* code pointer */
         jmp     LBL(caml_start_program)
-CFI_ENDPROC
 ENDFUNCTION(G(caml_callback3_asm))
 
 /******************************************************************************/
@@ -838,7 +825,6 @@ LBL(112):
     /* No parent stack. Raise Unhandled. */
         LEA_VAR(caml_exn_Unhandled, %rax)
         jmp LBL(caml_raise_exn)
-CFI_ENDPROC
 ENDFUNCTION(G(caml_perform))
 
 FUNCTION(G(caml_reperform))
@@ -851,7 +837,6 @@ CFI_STARTPROC
         movq    %rsi, Handler_parent(%r10)       /* Append to last_fiber */
         leaq    1(%rsi), %rdi  /* %rdi (last_fiber) := Val_ptr(old stack) */
         jmp     LBL(do_perform)
-CFI_ENDPROC
 ENDFUNCTION(G(caml_reperform))
 
 FUNCTION(G(caml_resume))
@@ -874,7 +859,6 @@ CFI_STARTPROC
         jmp     *(%rbx)
 2:      LEA_VAR(caml_exn_Continuation_already_taken, %rax)
         jmp LBL(caml_raise_exn)
-CFI_ENDPROC
 ENDFUNCTION(G(caml_resume))
 
 /* Run a function on a new stack,
@@ -946,14 +930,12 @@ LBL(fiber_exn_handler):
         leaq    16(%rsp), %r11
         movq    Handler_exception(%r11), %rbx
         jmp     1b
-CFI_ENDPROC
 ENDFUNCTION(G(caml_runstack))
 
 FUNCTION(G(caml_ml_array_bound_error))
 CFI_STARTPROC
         LEA_VAR(caml_array_bound_error, %rax)
         jmp     LBL(caml_c_call)
-CFI_ENDPROC
 ENDFUNCTION(G(caml_ml_array_bound_error))
 
 FUNCTION(G(caml_assert_stack_invariants))
@@ -967,7 +949,6 @@ CFI_STARTPROC
         jge     1f
         int3
 1:      ret
-CFI_ENDPROC
 ENDFUNCTION(G(caml_assert_stack_invariants))
 
         TEXT_SECTION(caml_system__code_end)

--- a/runtime/amd64.S
+++ b/runtime/amd64.S
@@ -33,7 +33,8 @@
 #define FUNCTION(name) \
         .globl name; \
         .align FUNCTION_ALIGN; \
-        name:
+        name: \
+CFI_STARTPROC
 
 #elif defined(SYS_mingw64) || defined(SYS_cygwin)
 
@@ -49,7 +50,8 @@
         TEXT_SECTION(name); \
         .globl name; \
         .align FUNCTION_ALIGN; \
-        name:
+        name: \
+CFI_STARTPROC
 
 #else
 
@@ -70,8 +72,8 @@
         .globl name; \
         .type name,@function; \
         .align FUNCTION_ALIGN; \
-        name:
-
+        name: \
+CFI_STARTPROC
 #endif
 
 #if defined(SYS_linux) || defined(SYS_gnu)
@@ -466,7 +468,6 @@ G(caml_system__code_begin):
         movq    Caml_state(young_ptr), %r15
 
 FUNCTION(G(caml_call_realloc_stack))
-CFI_STARTPROC
         CFI_SIGNAL_FRAME
         SAVE_ALL_REGS
         movq    8(%rsp), C_ARG_1 /* argument */
@@ -484,7 +485,6 @@ CFI_STARTPROC
 ENDFUNCTION(caml_call_realloc_stack)
 
 FUNCTION(G(caml_call_gc))
-CFI_STARTPROC
         CFI_SIGNAL_FRAME
 LBL(caml_call_gc):
         SAVE_ALL_REGS
@@ -498,7 +498,6 @@ LBL(caml_call_gc):
 ENDFUNCTION(caml_call_gc)
 
 FUNCTION(G(caml_alloc1))
-CFI_STARTPROC
         subq    $16, %r15
         cmpq    Caml_state(young_limit), %r15
         jb      LBL(caml_call_gc)
@@ -506,7 +505,6 @@ CFI_STARTPROC
 ENDFUNCTION(caml_alloc1)
 
 FUNCTION(G(caml_alloc2))
-CFI_STARTPROC
         subq    $24, %r15
         cmpq    Caml_state(young_limit), %r15
         jb      LBL(caml_call_gc)
@@ -514,7 +512,6 @@ CFI_STARTPROC
 ENDFUNCTION(caml_alloc2)
 
 FUNCTION(G(caml_alloc3))
-CFI_STARTPROC
         subq    $32, %r15
         cmpq    Caml_state(young_limit), %r15
         jb      LBL(caml_call_gc)
@@ -522,7 +519,6 @@ CFI_STARTPROC
 ENDFUNCTION(caml_alloc3)
 
 FUNCTION(G(caml_allocN))
-CFI_STARTPROC
         cmpq    Caml_state(young_limit), %r15
         jb      LBL(caml_call_gc)
         ret
@@ -533,7 +529,6 @@ ENDFUNCTION(caml_allocN)
 /******************************************************************************/
 
 FUNCTION(G(caml_c_call))
-CFI_STARTPROC
         CFI_SIGNAL_FRAME
 LBL(caml_c_call):
     /* Arguments:
@@ -554,7 +549,6 @@ LBL(caml_c_call):
 ENDFUNCTION(caml_c_call)
 
 FUNCTION(G(caml_c_call_stack_args))
-CFI_STARTPROC
         CFI_SIGNAL_FRAME
     /* Arguments:
         C arguments         : %rdi, %rsi, %rdx, %rcx, %r8, and %r9
@@ -597,7 +591,6 @@ ENDFUNCTION(caml_c_call_stack_args)
 /******************************************************************************/
 
 FUNCTION(G(caml_start_program))
-CFI_STARTPROC
         CFI_SIGNAL_FRAME
     /* Save callee-save registers */
         PUSH_CALLEE_SAVE_REGS
@@ -694,7 +687,6 @@ ENDFUNCTION(caml_start_program)
 /* Raise an exception from OCaml */
 
 FUNCTION(G(caml_raise_exn))
-CFI_STARTPROC
 LBL(caml_raise_exn):
         testq   $1, Caml_state(backtrace_active)
         jne   LBL(116)
@@ -718,7 +710,6 @@ LBL(117):
 ENDFUNCTION(caml_raise_exn)
 
 FUNCTION(G(caml_reraise_exn))
-CFI_STARTPROC
         testq   $1, Caml_state(backtrace_active)
         jne   LBL(117)
         RESTORE_EXN_HANDLER_OCAML
@@ -728,7 +719,6 @@ ENDFUNCTION(caml_reraise_exn)
 /* Raise an exception from C */
 
 FUNCTION(G(caml_raise_exception))
-CFI_STARTPROC
         movq    C_ARG_1, %r14                /* Caml_state */
         movq    C_ARG_2, %rax
     /* Load young_ptr into %r15 */
@@ -744,7 +734,6 @@ ENDFUNCTION(caml_raise_exception)
 /******************************************************************************/
 
 FUNCTION(G(caml_callback_asm))
-CFI_STARTPROC
     /* Save callee-save registers */
         PUSH_CALLEE_SAVE_REGS
     /* Initial loading of arguments */
@@ -758,7 +747,6 @@ CFI_STARTPROC
 ENDFUNCTION(caml_callback_asm)
 
 FUNCTION(G(caml_callback2_asm))
-CFI_STARTPROC
     /* Save callee-save registers */
         PUSH_CALLEE_SAVE_REGS
     /* Initial loading of arguments */
@@ -772,7 +760,6 @@ CFI_STARTPROC
 ENDFUNCTION(caml_callback2_asm)
 
 FUNCTION(G(caml_callback3_asm))
-CFI_STARTPROC
     /* Save callee-save registers */
         PUSH_CALLEE_SAVE_REGS
     /* Initial loading of arguments */
@@ -796,7 +783,6 @@ ENDFUNCTION(caml_callback3_asm)
 /******************************************************************************/
 
 FUNCTION(G(caml_perform))
-CFI_STARTPROC
     /*  %rax: effect to perform
         %rbx: freshly allocated continuation */
         movq    Caml_state(current_stack), %rsi /* %rsi := old stack */
@@ -828,7 +814,6 @@ LBL(112):
 ENDFUNCTION(caml_perform)
 
 FUNCTION(G(caml_reperform))
-CFI_STARTPROC
     /*  %rax: effect to reperform
         %rbx: continuation
         %rdi: last_fiber */
@@ -840,7 +825,6 @@ CFI_STARTPROC
 ENDFUNCTION(caml_reperform)
 
 FUNCTION(G(caml_resume))
-CFI_STARTPROC
     /* %rax -> stack, %rbx -> fun, %rdi -> arg */
         leaq    -1(%rax), %r10  /* %r10 (new stack) = Ptr_val(%rax) */
         movq    %rdi, %rax      /* %rax := argument to function in %rbx */
@@ -864,7 +848,6 @@ ENDFUNCTION(caml_resume)
 /* Run a function on a new stack,
    then invoke either the value or exception handler */
 FUNCTION(G(caml_runstack))
-CFI_STARTPROC
         CFI_SIGNAL_FRAME
     /* %rax -> stack, %rbx -> fun, %rdi -> arg */
         andq    $-2, %rax       /* %rax = Ptr_val(%rax) */
@@ -933,13 +916,11 @@ LBL(fiber_exn_handler):
 ENDFUNCTION(caml_runstack)
 
 FUNCTION(G(caml_ml_array_bound_error))
-CFI_STARTPROC
         LEA_VAR(caml_array_bound_error, %rax)
         jmp     LBL(caml_c_call)
 ENDFUNCTION(caml_ml_array_bound_error)
 
 FUNCTION(G(caml_assert_stack_invariants))
-CFI_STARTPROC
 /*      CHECK_STACK_ALIGNMENT */
         movq    Caml_state(current_stack), %r11
         movq    %rsp, %r10

--- a/runtime/amd64.S
+++ b/runtime/amd64.S
@@ -86,6 +86,7 @@ CFI_ENDPROC
 #endif
 
 #define CAML_FUNCTION(name) FUNCTION(name)
+#define C_FUNCTION(name) FUNCTION(name)
 
 #ifdef ASM_CFI_SUPPORTED
 #define CFI_STARTPROC .cfi_startproc
@@ -592,7 +593,7 @@ ENDFUNCTION(caml_c_call_stack_args)
 /* Start the OCaml program */
 /******************************************************************************/
 
-FUNCTION(caml_start_program)
+C_FUNCTION(caml_start_program)
         CFI_SIGNAL_FRAME
     /* Save callee-save registers */
         PUSH_CALLEE_SAVE_REGS
@@ -720,7 +721,7 @@ ENDFUNCTION(caml_reraise_exn)
 
 /* Raise an exception from C */
 
-FUNCTION(caml_raise_exception)
+C_FUNCTION(caml_raise_exception)
         movq    C_ARG_1, %r14                /* Caml_state */
         movq    C_ARG_2, %rax
     /* Load young_ptr into %r15 */
@@ -735,7 +736,7 @@ ENDFUNCTION(caml_raise_exception)
 /* Callback from C to OCaml */
 /******************************************************************************/
 
-FUNCTION(caml_callback_asm)
+C_FUNCTION(caml_callback_asm)
     /* Save callee-save registers */
         PUSH_CALLEE_SAVE_REGS
     /* Initial loading of arguments */
@@ -748,7 +749,7 @@ FUNCTION(caml_callback_asm)
         jmp     LBL(caml_start_program)
 ENDFUNCTION(caml_callback_asm)
 
-FUNCTION(caml_callback2_asm)
+C_FUNCTION(caml_callback2_asm)
     /* Save callee-save registers */
         PUSH_CALLEE_SAVE_REGS
     /* Initial loading of arguments */
@@ -761,7 +762,7 @@ FUNCTION(caml_callback2_asm)
         jmp     LBL(caml_start_program)
 ENDFUNCTION(caml_callback2_asm)
 
-FUNCTION(caml_callback3_asm)
+C_FUNCTION(caml_callback3_asm)
     /* Save callee-save registers */
         PUSH_CALLEE_SAVE_REGS
     /* Initial loading of arguments */

--- a/runtime/amd64.S
+++ b/runtime/amd64.S
@@ -31,9 +31,9 @@
 #define EIGHT_ALIGN 3
 #define SIXTEEN_ALIGN 4
 #define FUNCTION(name) \
-        .globl name; \
+        .globl G(name); \
         .align FUNCTION_ALIGN; \
-        name: \
+        G(name): \
 CFI_STARTPROC
 
 #elif defined(SYS_mingw64) || defined(SYS_cygwin)
@@ -47,10 +47,10 @@ CFI_STARTPROC
 #define EIGHT_ALIGN 8
 #define SIXTEEN_ALIGN 16
 #define FUNCTION(name) \
-        TEXT_SECTION(name); \
-        .globl name; \
+        TEXT_SECTION(G(name)); \
+        .globl G(name); \
         .align FUNCTION_ALIGN; \
-        name: \
+        G(name): \
 CFI_STARTPROC
 
 #else
@@ -68,11 +68,11 @@ CFI_STARTPROC
 #define EIGHT_ALIGN 8
 #define SIXTEEN_ALIGN 16
 #define FUNCTION(name) \
-        TEXT_SECTION(name); \
-        .globl name; \
-        .type name,@function; \
+        TEXT_SECTION(G(name)); \
+        .globl G(name); \
+        .type G(name),@function; \
         .align FUNCTION_ALIGN; \
-        name: \
+        G(name): \
 CFI_STARTPROC
 #endif
 
@@ -467,7 +467,7 @@ G(caml_system__code_begin):
         movsd   (15+13)*8(%r15),%xmm15;                \
         movq    Caml_state(young_ptr), %r15
 
-FUNCTION(G(caml_call_realloc_stack))
+FUNCTION(caml_call_realloc_stack)
         CFI_SIGNAL_FRAME
         SAVE_ALL_REGS
         movq    8(%rsp), C_ARG_1 /* argument */
@@ -484,7 +484,7 @@ FUNCTION(G(caml_call_realloc_stack))
         jmp     GCALL(caml_raise_exn)
 ENDFUNCTION(caml_call_realloc_stack)
 
-FUNCTION(G(caml_call_gc))
+FUNCTION(caml_call_gc)
         CFI_SIGNAL_FRAME
 LBL(caml_call_gc):
         SAVE_ALL_REGS
@@ -497,28 +497,28 @@ LBL(caml_call_gc):
         ret
 ENDFUNCTION(caml_call_gc)
 
-FUNCTION(G(caml_alloc1))
+FUNCTION(caml_alloc1)
         subq    $16, %r15
         cmpq    Caml_state(young_limit), %r15
         jb      LBL(caml_call_gc)
         ret
 ENDFUNCTION(caml_alloc1)
 
-FUNCTION(G(caml_alloc2))
+FUNCTION(caml_alloc2)
         subq    $24, %r15
         cmpq    Caml_state(young_limit), %r15
         jb      LBL(caml_call_gc)
         ret
 ENDFUNCTION(caml_alloc2)
 
-FUNCTION(G(caml_alloc3))
+FUNCTION(caml_alloc3)
         subq    $32, %r15
         cmpq    Caml_state(young_limit), %r15
         jb      LBL(caml_call_gc)
         ret
 ENDFUNCTION(caml_alloc3)
 
-FUNCTION(G(caml_allocN))
+FUNCTION(caml_allocN)
         cmpq    Caml_state(young_limit), %r15
         jb      LBL(caml_call_gc)
         ret
@@ -528,7 +528,7 @@ ENDFUNCTION(caml_allocN)
 /* Call a C function from OCaml */
 /******************************************************************************/
 
-FUNCTION(G(caml_c_call))
+FUNCTION(caml_c_call)
         CFI_SIGNAL_FRAME
 LBL(caml_c_call):
     /* Arguments:
@@ -548,7 +548,7 @@ LBL(caml_c_call):
         ret
 ENDFUNCTION(caml_c_call)
 
-FUNCTION(G(caml_c_call_stack_args))
+FUNCTION(caml_c_call_stack_args)
         CFI_SIGNAL_FRAME
     /* Arguments:
         C arguments         : %rdi, %rsi, %rdx, %rcx, %r8, and %r9
@@ -590,7 +590,7 @@ ENDFUNCTION(caml_c_call_stack_args)
 /* Start the OCaml program */
 /******************************************************************************/
 
-FUNCTION(G(caml_start_program))
+FUNCTION(caml_start_program)
         CFI_SIGNAL_FRAME
     /* Save callee-save registers */
         PUSH_CALLEE_SAVE_REGS
@@ -686,7 +686,7 @@ ENDFUNCTION(caml_start_program)
 
 /* Raise an exception from OCaml */
 
-FUNCTION(G(caml_raise_exn))
+FUNCTION(caml_raise_exn)
 LBL(caml_raise_exn):
         testq   $1, Caml_state(backtrace_active)
         jne   LBL(116)
@@ -709,7 +709,7 @@ LBL(117):
         ret
 ENDFUNCTION(caml_raise_exn)
 
-FUNCTION(G(caml_reraise_exn))
+FUNCTION(caml_reraise_exn)
         testq   $1, Caml_state(backtrace_active)
         jne   LBL(117)
         RESTORE_EXN_HANDLER_OCAML
@@ -718,7 +718,7 @@ ENDFUNCTION(caml_reraise_exn)
 
 /* Raise an exception from C */
 
-FUNCTION(G(caml_raise_exception))
+FUNCTION(caml_raise_exception)
         movq    C_ARG_1, %r14                /* Caml_state */
         movq    C_ARG_2, %rax
     /* Load young_ptr into %r15 */
@@ -733,7 +733,7 @@ ENDFUNCTION(caml_raise_exception)
 /* Callback from C to OCaml */
 /******************************************************************************/
 
-FUNCTION(G(caml_callback_asm))
+FUNCTION(caml_callback_asm)
     /* Save callee-save registers */
         PUSH_CALLEE_SAVE_REGS
     /* Initial loading of arguments */
@@ -746,7 +746,7 @@ FUNCTION(G(caml_callback_asm))
         jmp     LBL(caml_start_program)
 ENDFUNCTION(caml_callback_asm)
 
-FUNCTION(G(caml_callback2_asm))
+FUNCTION(caml_callback2_asm)
     /* Save callee-save registers */
         PUSH_CALLEE_SAVE_REGS
     /* Initial loading of arguments */
@@ -759,7 +759,7 @@ FUNCTION(G(caml_callback2_asm))
         jmp     LBL(caml_start_program)
 ENDFUNCTION(caml_callback2_asm)
 
-FUNCTION(G(caml_callback3_asm))
+FUNCTION(caml_callback3_asm)
     /* Save callee-save registers */
         PUSH_CALLEE_SAVE_REGS
     /* Initial loading of arguments */
@@ -782,7 +782,7 @@ ENDFUNCTION(caml_callback3_asm)
  */
 /******************************************************************************/
 
-FUNCTION(G(caml_perform))
+FUNCTION(caml_perform)
     /*  %rax: effect to perform
         %rbx: freshly allocated continuation */
         movq    Caml_state(current_stack), %rsi /* %rsi := old stack */
@@ -813,7 +813,7 @@ LBL(112):
         jmp LBL(caml_raise_exn)
 ENDFUNCTION(caml_perform)
 
-FUNCTION(G(caml_reperform))
+FUNCTION(caml_reperform)
     /*  %rax: effect to reperform
         %rbx: continuation
         %rdi: last_fiber */
@@ -824,7 +824,7 @@ FUNCTION(G(caml_reperform))
         jmp     LBL(do_perform)
 ENDFUNCTION(caml_reperform)
 
-FUNCTION(G(caml_resume))
+FUNCTION(caml_resume)
     /* %rax -> stack, %rbx -> fun, %rdi -> arg */
         leaq    -1(%rax), %r10  /* %r10 (new stack) = Ptr_val(%rax) */
         movq    %rdi, %rax      /* %rax := argument to function in %rbx */
@@ -847,7 +847,7 @@ ENDFUNCTION(caml_resume)
 
 /* Run a function on a new stack,
    then invoke either the value or exception handler */
-FUNCTION(G(caml_runstack))
+FUNCTION(caml_runstack)
         CFI_SIGNAL_FRAME
     /* %rax -> stack, %rbx -> fun, %rdi -> arg */
         andq    $-2, %rax       /* %rax = Ptr_val(%rax) */
@@ -915,12 +915,12 @@ LBL(fiber_exn_handler):
         jmp     1b
 ENDFUNCTION(caml_runstack)
 
-FUNCTION(G(caml_ml_array_bound_error))
+FUNCTION(caml_ml_array_bound_error)
         LEA_VAR(caml_array_bound_error, %rax)
         jmp     LBL(caml_c_call)
 ENDFUNCTION(caml_ml_array_bound_error)
 
-FUNCTION(G(caml_assert_stack_invariants))
+FUNCTION(caml_assert_stack_invariants)
 /*      CHECK_STACK_ALIGNMENT */
         movq    Caml_state(current_stack), %r11
         movq    %rsp, %r10


### PR DESCRIPTION
This is a very opinionated change and should have zero actual change to the runtime, but I'm hoping we can merge it. To make my life a bit easier.

## Problem

I'm currently working on ARM64 for Multicore and it's very annoying the small differences between the backends and also that I need to keep track of which context every function will be called from.

## Solution

Here I just introduce a couple macros to give a bit more context, so `CAML_FUNCTION` and `C_FUNCTION` are actually alias to `FUNCTION` but for the reader they actually help a bit.

Also some of the CFI macros are moved to inside of `FUNCTION` and `ENDFUNCTION` as they're only used in this scenarios.