### PR TITLE
Remove unused gc_regs_slot in domain_state

### DIFF
--- a/otherlibs/systhreads/st_stubs.c
+++ b/otherlibs/systhreads/st_stubs.c
@@ -76,7 +76,6 @@ struct caml_thread_struct {
     /* saved value of Caml_state->backtrace_last_exn (root) */
   value * gc_regs;           /* saved value of Caml_state->gc_regs */
   value * gc_regs_buckets;   /* saved value of Caml_state->gc_regs_buckets */
-  value ** gc_regs_slot;     /* saved value of Caml_state->gc_regs_slot */
   void * exn_handler;        /* saved value of Caml_state->exn_handler */
 
 #ifndef NATIVE_CODE
@@ -179,7 +178,6 @@ void caml_thread_save_runtime_state(void)
   Current_thread->c_stack = Caml_state->c_stack;
   Current_thread->gc_regs = Caml_state->gc_regs;
   Current_thread->gc_regs_buckets = Caml_state->gc_regs_buckets;
-  Current_thread->gc_regs_slot = Caml_state->gc_regs_slot;
   Current_thread->exn_handler = Caml_state->exn_handler;
   Current_thread->local_roots = Caml_state->local_roots;
   Current_thread->backtrace_pos = Caml_state->backtrace_pos;
@@ -198,7 +196,6 @@ void caml_thread_restore_runtime_state(void)
   Caml_state->c_stack = Current_thread->c_stack;
   Caml_state->gc_regs = Current_thread->gc_regs;
   Caml_state->gc_regs_buckets = Current_thread->gc_regs_buckets;
-  Caml_state->gc_regs_slot = Current_thread->gc_regs_slot;
   Caml_state->exn_handler = Current_thread->exn_handler;
   Caml_state->local_roots = Current_thread->local_roots;
   Caml_state->backtrace_pos = Current_thread->backtrace_pos;
@@ -273,7 +270,6 @@ static caml_thread_t caml_thread_new_info(void)
   th->backtrace_last_exn = Val_unit;
   th->gc_regs = NULL;
   th->gc_regs_buckets = NULL;
-  th->gc_regs_slot = NULL;
   th->exn_handler = NULL;
 
 #ifndef NATIVE_CODE

--- a/runtime/caml/domain_state.tbl
+++ b/runtime/caml/domain_state.tbl
@@ -45,8 +45,6 @@ DOMAIN_STATE(value*, gc_regs_buckets)
 
 DOMAIN_STATE(value*, gc_regs)
 
-DOMAIN_STATE(value**, gc_regs_slot)
-
 DOMAIN_STATE(struct caml_minor_tables*, minor_tables)
 
 DOMAIN_STATE(struct mark_stack*, mark_stack)

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -489,7 +489,6 @@ static void create_domain(uintnat initial_minor_heap_wsize) {
 
     domain_state->gc_regs_buckets = NULL;
     domain_state->gc_regs = NULL;
-    domain_state->gc_regs_slot = NULL;
 
     domain_state->allocated_words = 0;
     domain_state->swept_words = 0;


### PR DESCRIPTION
This PR cleans out `gc_regs_slot` in the domain state structure. The field is unused and not needed. 

`gc_regs_slots` was used in earlier revisions of multicore but got superseded by `gc_regs_buckets` introduced in https://github.com/ocaml-multicore/ocaml-multicore/pull/227.