### PR TITLE
domain.c: use an atomic counter for domain unique ids

### DIFF
--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -665,15 +665,21 @@ static void free_domain_ml_values(struct domain_ml_values* ml_values) {
   caml_stat_free(ml_values);
 }
 
+/* This is the structure of the data exchanged between the parent
+   domain and child domain during domain_spawn. Some fields are 'in'
+   parameters, passed from the parent to the child, others are 'out'
+   parameters returned to the parent by the child.
+*/
 struct domain_startup_params {
-  struct interruptor* parent;
-  enum domain_status status;
-  struct domain_ml_values* ml_values;
-  dom_internal* newdom;
-  uintnat unique_id;
+  struct interruptor* parent; /* in */
+  enum domain_status status; /* in+out:
+                                parent and child synchronize on this value. */
+  struct domain_ml_values* ml_values; /* in */
+  dom_internal* newdom; /* out */
+  uintnat unique_id; /* out */
 #ifndef _WIN32
   /* signal mask to set after it is safe to do so */
-  sigset_t* mask;
+  sigset_t* mask; /* in */
 #endif
 };
 

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -428,6 +428,7 @@ static void create_domain(uintnat initial_minor_heap_wsize) {
       s->interrupt_word = young_limit;
       atomic_store_rel(young_limit, (uintnat)domain_state->young_start);
     }
+    s->unique_id = fresh_domain_unique_id();
     s->running = 1;
     atomic_fetch_add(&caml_num_domains_running, 1);
   }
@@ -604,7 +605,7 @@ void caml_init_domains(uintnat minor_heap_wsz) {
                         &dom->interruptor.lock);
     dom->interruptor.running = 0;
     dom->interruptor.terminating = 0;
-    dom->interruptor.unique_id = fresh_domain_unique_id();
+    dom->interruptor.unique_id = 0;
     dom->interruptor.interrupt_pending = 0;
 
     caml_plat_mutex_init(&dom->domain_lock);
@@ -1385,7 +1386,6 @@ static void domain_terminate (void)
       finished = 1;
       s->terminating = 0;
       s->running = 0;
-      s->unique_id = fresh_domain_unique_id();
 
       /* Remove this domain from stw_domains */
       remove_from_stw_domains(domain_self);

--- a/testsuite/tests/parallel/domain_id.ml
+++ b/testsuite/tests/parallel/domain_id.ml
@@ -7,33 +7,18 @@ include unix
 
 open Domain
 
-let id () = ()
+let test_main_domain () =
+  assert ((Domain.self () :> int) = 0);
+  assert (Domain.is_main_domain ());
+  ()
 
+let id () = ()
 
 let newdom_id () =
   let d = Domain.spawn id in
   let n = Domain.get_id d in
   join d;
   (n :> int)
-
-let test_domain_reuse () =
-  (* checks that domain slots are getting reused quickly,
-     by checking that subsequent domain IDs are an arithmetic
-     progression (implies that you're getting the same domain
-     over and over, but its ID increases by Max_domains.
-
-     this test has to run first, since it makes assumptions
-     about domain IDs *)
-  let first = newdom_id () in
-  let curr = ref (newdom_id ()) in
-  let delta = !curr - first in
-  assert (delta > 0);
-  for i = 1 to 10000 do
-    let next = newdom_id () in
-    assert (next - !curr = delta);
-    curr := next
-  done
-
 
 let test_different_ids () =
   let d1 = Domain.spawn id in
@@ -45,6 +30,6 @@ let test_different_ids () =
 
 
 let () =
-  test_domain_reuse ();
+  test_main_domain ();
   test_different_ids ();
   print_endline "ok"


### PR DESCRIPTION
The previous implementation would increment each domain's identifier
by Max_domain. We want to remove the dependence on a fixed Max_domains
setting, to be able to reconfigure it during program execution (see 
https://github.com/ocaml/ocaml/issues/10971#issuecomment-1025507893).
    
Note: the previous low-level domain-synchronization code would
use `unique_id % Max_domains` to efficiently compute the domain index:
  9e9eb7972489c557d3c214dc0398a7a3e81ce2c3
but this logic was entirely removed by
  d5694dade56e912fa6d4574c6387c2f12aafa331
