### PR TITLE
Make <caml/sync.h> more abstract and refactor implementation of sync.c

### DIFF
--- a/otherlibs/systhreads/st_posix.h
+++ b/otherlibs/systhreads/st_posix.h
@@ -23,11 +23,12 @@
 #include <pthread.h>
 #include <signal.h>
 #include <time.h>
-#include <caml/sync.h>
 #include <sys/time.h>
 #ifdef __linux__
 #include <unistd.h>
 #endif
+
+#include "../../runtime/sync_posix.h"
 
 typedef int st_retcode;
 

--- a/otherlibs/systhreads/st_stubs.c
+++ b/otherlibs/systhreads/st_stubs.c
@@ -30,6 +30,7 @@
 #include "caml/printexc.h"
 #include "caml/roots.h"
 #include "caml/signals.h"
+#include "caml/sync.h"
 #include "caml/sys.h"
 #include "caml/memprof.h"
 

--- a/runtime/caml/sync.h
+++ b/runtime/caml/sync.h
@@ -13,7 +13,7 @@
 /*                                                                        */
 /**************************************************************************/
 
-/* Operations on mutexes and condition variables from the OCaml stdlib */
+/* Operations on mutexes from the OCaml stdlib */
 
 #ifndef CAML_SYNC_H
 #define CAML_SYNC_H
@@ -22,23 +22,12 @@
 
 #include "mlvalues.h"
 
-/* Mutex.lock: Mutex.t -> unit */
-CAMLextern value caml_ml_mutex_lock(value mut);
+typedef pthread_mutex_t * sync_mutex;
 
-/* Mutex.unlock: Mutex.t -> unit */
-CAMLextern value caml_ml_mutex_unlock(value mut);
+#define Mutex_val(v) (* ((sync_mutex *) Data_custom_val(v)))
 
-/* Mutex.try_lock: Mutex.t -> bool */
-CAMLextern value caml_ml_mutex_try_lock(value mut);
-
-/* Condition.wait: Condition.t -> Mutex.t -> unit */
-CAMLextern value caml_ml_condition_wait(value cond, value mut);
-
-/* Condition.signal: Condition.t -> unit */
-CAMLextern value caml_ml_condition_signal(value cond);
-
-/* Condition.broadcast: Condition.t -> unit */
-CAMLextern value caml_ml_condition_broadcast(value cond);
+CAMLextern int caml_mutex_lock(sync_mutex mut);
+CAMLextern int caml_mutex_unlock(sync_mutex mut);
 
 #endif /* CAML_INTERNALS */
 

--- a/runtime/caml/sync.h
+++ b/runtime/caml/sync.h
@@ -13,83 +13,33 @@
 /*                                                                        */
 /**************************************************************************/
 
-/* POSIX thread implementation of the user facing Mutex and Condition */
+/* Operations on mutexes and condition variables from the OCaml stdlib */
 
 #ifndef CAML_SYNC_H
 #define CAML_SYNC_H
 
-#include "alloc.h"
-#include "custom.h"
-#include "fail.h"
-#include "memory.h"
+#ifdef CAML_INTERNALS
 
-#include <pthread.h>
+#include "mlvalues.h"
 
-typedef int sync_retcode;
+/* Mutex.lock: Mutex.t -> unit */
+CAMLextern value caml_ml_mutex_lock(value mut);
 
-/* Mutexes */
+/* Mutex.unlock: Mutex.t -> unit */
+CAMLextern value caml_ml_mutex_unlock(value mut);
 
-typedef pthread_mutex_t * sync_mutex;
+/* Mutex.try_lock: Mutex.t -> bool */
+CAMLextern value caml_ml_mutex_try_lock(value mut);
 
-#define Mutex_val(v) (* ((sync_mutex *) Data_custom_val(v)))
+/* Condition.wait: Condition.t -> Mutex.t -> unit */
+CAMLextern value caml_ml_condition_wait(value cond, value mut);
 
-Caml_inline int sync_mutex_lock(sync_mutex m)
-{
-  return pthread_mutex_lock(m);
-}
+/* Condition.signal: Condition.t -> unit */
+CAMLextern value caml_ml_condition_signal(value cond);
 
-#define MUTEX_PREVIOUSLY_UNLOCKED 0
-#define MUTEX_ALREADY_LOCKED EBUSY
+/* Condition.broadcast: Condition.t -> unit */
+CAMLextern value caml_ml_condition_broadcast(value cond);
 
-Caml_inline int sync_mutex_trylock(sync_mutex m)
-{
-  return pthread_mutex_trylock(m);
-}
-
-Caml_inline int sync_mutex_unlock(sync_mutex m)
-{
-  return pthread_mutex_unlock(m);
-}
-
-/* Condition variables */
-
-typedef pthread_cond_t * sync_condvar;
-
-#define Condition_val(v) (* (sync_condvar *) Data_custom_val(v))
-
-Caml_inline int sync_condvar_signal(sync_condvar c)
-{
- return pthread_cond_signal(c);
-}
-
-Caml_inline int sync_condvar_broadcast(sync_condvar c)
-{
-    return pthread_cond_broadcast(c);
-}
-
-Caml_inline int sync_condvar_wait(sync_condvar c, sync_mutex m)
-{
-  return pthread_cond_wait(c, m);
-}
-
-/* Reporting errors */
-
-Caml_inline void sync_check_error(int retcode, char * msg)
-{
-  char * err;
-  int errlen, msglen;
-  value str;
-
-  if (retcode == 0) return;
-  if (retcode == ENOMEM) caml_raise_out_of_memory();
-  err = strerror(retcode);
-  msglen = strlen(msg);
-  errlen = strlen(err);
-  str = caml_alloc_string(msglen + 2 + errlen);
-  memcpy (&Byte(str, 0), msg, msglen);
-  memcpy (&Byte(str, msglen), ": ", 2);
-  memcpy (&Byte(str, msglen + 2), err, errlen);
-  caml_raise_sys_error(str);
-}
+#endif /* CAML_INTERNALS */
 
 #endif /* CAML_SYNC_H */

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -850,7 +850,11 @@ static void* domain_thread_func(void* v)
     /* this domain is part of STW sections, so can read ml_values */
     terminate_mutex = Mutex_val(ml_values->mutex);
     /* we lock terminate_mutex here and unlock when the domain is torn down
-      this provides a simple block for domains attempting to join */
+      this provides a simple block for domains attempting to join 
+      NB: terminate_mutex will not be moved by the garbage collector
+      as it is not an OCaml block. ml_values->mutex is registered as
+      a global root and keeps the mutex custom memory alive with 
+      the garbage collector. 
     caml_mutex_lock(terminate_mutex);
     p->status = Dom_started;
     p->unique_id = domain_self->interruptor.unique_id;

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -875,6 +875,10 @@ static void* domain_thread_func(void* v)
     domain_terminate();
     /* Joining domains will lock/unlock the terminate_mutex so this unlock will
        release them if any domains are waiting. */
+    /* The domain has left the STW set, but all minor heaps will have been
+       collected in domain_terminate.
+       So ml_values->mutex is in the major heap and will not be moved */
+    CAMLassert(!Is_young(ml_values->mutex));
     caml_ml_mutex_unlock(ml_values->mutex);
     free_domain_ml_values(ml_values);
   } else {

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -829,10 +829,11 @@ CAMLexport void (*caml_domain_stop_hook)(void) =
 CAMLexport void (*caml_domain_external_interrupt_hook)(void) =
    caml_domain_external_interrupt_hook_default;
 
-static void domain_terminate(struct domain_ml_values * ml_values);
+static void domain_terminate();
 
 static void* domain_thread_func(void* v)
 {
+  sync_mutex terminate_mutex = NULL;
   struct domain_startup_params* p = v;
   struct domain_ml_values *ml_values = p->ml_values;
 #ifndef _WIN32
@@ -847,10 +848,10 @@ static void* domain_thread_func(void* v)
   caml_plat_lock(&p->parent->lock);
   if (domain_self) {
     /* this domain is part of STW sections, so can read ml_values */
-    /* we lock the termination mutex here and unlock in domain_terminate,
-       when the domain is torn down.
-       This provides a simple block for domains attempting to join */
-    caml_ml_mutex_lock(ml_values->mutex);
+    terminate_mutex = Mutex_val(ml_values->mutex);
+    /* we lock terminate_mutex here and unlock when the domain is torn down
+      this provides a simple block for domains attempting to join */
+    caml_mutex_lock(terminate_mutex);
     p->status = Dom_started;
     p->unique_id = domain_self->interruptor.unique_id;
   } else {
@@ -873,7 +874,10 @@ static void* domain_thread_func(void* v)
     caml_domain_set_name("Domain");
     caml_domain_start_hook();
     caml_callback(ml_values->callback, Val_unit);
-    domain_terminate(ml_values); /* will unlock the termination mutex */
+    domain_terminate();
+    /* Joining domains will lock/unlock the terminate_mutex so this unlock will
+       release them if any domains are waiting. */
+    caml_mutex_unlock(terminate_mutex);
     free_domain_ml_values(ml_values);
   } else {
     caml_gc_log("Failed to create domain");
@@ -1363,7 +1367,7 @@ int caml_domain_is_terminating (void)
   return s->terminating;
 }
 
-static void domain_terminate (struct domain_ml_values * ml_values)
+static void domain_terminate (void)
 {
   caml_domain_state* domain_state = domain_self->state;
   struct interruptor* s = &domain_self->interruptor;
@@ -1406,13 +1410,6 @@ static void domain_terminate (struct domain_ml_values * ml_values)
       finished = 1;
       s->terminating = 0;
       s->running = 0;
-
-      /* Unlock the termination mutex so that other domains waiting
-         for the termination of this domain are woken up.
-         This needs to be done while we're still part of the STW group,
-         to be sure that ml_values->mutex (a heap-allocated Custom block)
-         is not being moved by a concurrent GC. */
-      caml_ml_mutex_unlock(ml_values->mutex);
 
       /* Remove this domain from stw_domains */
       remove_from_stw_domains(domain_self);

--- a/runtime/sync.c
+++ b/runtime/sync.c
@@ -58,6 +58,16 @@ static const struct custom_operations caml_mutex_ops = {
   custom_fixed_length_default
 };
 
+CAMLexport int caml_mutex_lock(sync_mutex mut)
+{
+  return sync_mutex_lock(mut);
+}
+
+CAMLexport int caml_mutex_unlock(sync_mutex mut)
+{
+  return sync_mutex_unlock(mut);
+}
+
 CAMLprim value caml_ml_mutex_new(value unit)        /* ML */
 {
   sync_mutex mut = NULL;

--- a/runtime/sync.c
+++ b/runtime/sync.c
@@ -15,10 +15,6 @@
 
 #define CAML_INTERNALS
 
-#include <pthread.h>
-#include <signal.h>
-#include <stdio.h>
-
 #include "caml/alloc.h"
 #include "caml/custom.h"
 #include "caml/domain_state.h"
@@ -29,40 +25,10 @@
 #include "caml/sync.h"
 #include "caml/eventlog.h"
 
+/* System-dependent part */
+#include "sync_posix.h"
+
 /* Mutex operations */
-
-static int sync_mutex_create(sync_mutex * res)
-{
-  int rc;
-  pthread_mutexattr_t attr;
-  sync_mutex m;
-
-  rc = pthread_mutexattr_init(&attr);
-  if (rc != 0) goto error1;
-  rc = pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_ERRORCHECK);
-  if (rc != 0) goto error2;
-  m = caml_stat_alloc_noexc(sizeof(pthread_mutex_t));
-  if (m == NULL) { rc = ENOMEM; goto error2; }
-  rc = pthread_mutex_init(m, &attr);
-  if (rc != 0) goto error3;
-  pthread_mutexattr_destroy(&attr);
-  *res = m;
-  return 0;
-error3:
-  caml_stat_free(m);
-error2:
-  pthread_mutexattr_destroy(&attr);
-error1:
-  return rc;
-}
-
-static int sync_mutex_destroy(sync_mutex m)
-{
-  int rc;
-  rc = pthread_mutex_destroy(m);
-  caml_stat_free(m);
-  return rc;
-}
 
 static void caml_mutex_finalize(value wrapper)
 {
@@ -141,27 +107,7 @@ CAMLprim value caml_ml_mutex_try_lock(value wrapper)           /* ML */
   return Val_true;
 }
 
-
-/* Conditions operations */
-
-static int sync_condvar_create(sync_condvar * res)
-{
-  int rc;
-  sync_condvar c = caml_stat_alloc_noexc(sizeof(pthread_cond_t));
-  if (c == NULL) return ENOMEM;
-  rc = pthread_cond_init(c, NULL);
-  if (rc != 0) { caml_stat_free(c); return rc; }
-  *res = c;
-  return 0;
-}
-
-static int sync_condvar_destroy(sync_condvar c)
-{
-  int rc;
-  rc = pthread_cond_destroy(c);
-  caml_stat_free(c);
-  return rc;
-}
+/* Condition variables operations */
 
 static void caml_condition_finalize(value wrapper)
 {

--- a/runtime/sync_posix.h
+++ b/runtime/sync_posix.h
@@ -24,9 +24,9 @@ typedef int sync_retcode;
 
 /* Mutexes */
 
-typedef pthread_mutex_t * sync_mutex;
-
-#define Mutex_val(v) (* ((sync_mutex *) Data_custom_val(v)))
+/* Already defined in <caml/sync.h> */
+/* typedef pthread_mutex_t * sync_mutex; */
+/* #define Mutex_val(v) (* ((sync_mutex *) Data_custom_val(v))) */
 
 Caml_inline int sync_mutex_create(sync_mutex * res)
 {

--- a/runtime/sync_posix.h
+++ b/runtime/sync_posix.h
@@ -1,0 +1,140 @@
+/**************************************************************************/
+/*                                                                        */
+/*                                 OCaml                                  */
+/*                                                                        */
+/*          Xavier Leroy and Damien Doligez, INRIA Rocquencourt           */
+/*                                                                        */
+/*   Copyright 1996 Institut National de Recherche en Informatique et     */
+/*     en Automatique.                                                    */
+/*                                                                        */
+/*   All rights reserved.  This file is distributed under the terms of    */
+/*   the GNU Lesser General Public License version 2.1, with the          */
+/*   special exception on linking described in the file LICENSE.          */
+/*                                                                        */
+/**************************************************************************/
+
+/* POSIX thread implementation of the user facing Mutex and Condition */
+/* To be included in runtime/sync.c */
+
+#include <errno.h>
+#include <pthread.h>
+#include <string.h>
+
+typedef int sync_retcode;
+
+/* Mutexes */
+
+typedef pthread_mutex_t * sync_mutex;
+
+#define Mutex_val(v) (* ((sync_mutex *) Data_custom_val(v)))
+
+Caml_inline int sync_mutex_create(sync_mutex * res)
+{
+  int rc;
+  pthread_mutexattr_t attr;
+  sync_mutex m;
+
+  rc = pthread_mutexattr_init(&attr);
+  if (rc != 0) goto error1;
+  rc = pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_ERRORCHECK);
+  if (rc != 0) goto error2;
+  m = caml_stat_alloc_noexc(sizeof(pthread_mutex_t));
+  if (m == NULL) { rc = ENOMEM; goto error2; }
+  rc = pthread_mutex_init(m, &attr);
+  if (rc != 0) goto error3;
+  pthread_mutexattr_destroy(&attr);
+  *res = m;
+  return 0;
+error3:
+  caml_stat_free(m);
+error2:
+  pthread_mutexattr_destroy(&attr);
+error1:
+  return rc;
+}
+
+Caml_inline int sync_mutex_destroy(sync_mutex m)
+{
+  int rc;
+  rc = pthread_mutex_destroy(m);
+  caml_stat_free(m);
+  return rc;
+}
+
+Caml_inline int sync_mutex_lock(sync_mutex m)
+{
+  return pthread_mutex_lock(m);
+}
+
+#define MUTEX_PREVIOUSLY_UNLOCKED 0
+#define MUTEX_ALREADY_LOCKED EBUSY
+
+Caml_inline int sync_mutex_trylock(sync_mutex m)
+{
+  return pthread_mutex_trylock(m);
+}
+
+Caml_inline int sync_mutex_unlock(sync_mutex m)
+{
+  return pthread_mutex_unlock(m);
+}
+
+/* Condition variables */
+
+typedef pthread_cond_t * sync_condvar;
+
+#define Condition_val(v) (* (sync_condvar *) Data_custom_val(v))
+
+Caml_inline int sync_condvar_create(sync_condvar * res)
+{
+  int rc;
+  sync_condvar c = caml_stat_alloc_noexc(sizeof(pthread_cond_t));
+  if (c == NULL) return ENOMEM;
+  rc = pthread_cond_init(c, NULL);
+  if (rc != 0) { caml_stat_free(c); return rc; }
+  *res = c;
+  return 0;
+}
+
+Caml_inline int sync_condvar_destroy(sync_condvar c)
+{
+  int rc;
+  rc = pthread_cond_destroy(c);
+  caml_stat_free(c);
+  return rc;
+}
+
+Caml_inline int sync_condvar_signal(sync_condvar c)
+{
+ return pthread_cond_signal(c);
+}
+
+Caml_inline int sync_condvar_broadcast(sync_condvar c)
+{
+    return pthread_cond_broadcast(c);
+}
+
+Caml_inline int sync_condvar_wait(sync_condvar c, sync_mutex m)
+{
+  return pthread_cond_wait(c, m);
+}
+
+/* Reporting errors */
+
+static void sync_check_error(int retcode, char * msg)
+{
+  char * err;
+  int errlen, msglen;
+  value str;
+
+  if (retcode == 0) return;
+  if (retcode == ENOMEM) caml_raise_out_of_memory();
+  err = strerror(retcode);
+  msglen = strlen(msg);
+  errlen = strlen(err);
+  str = caml_alloc_string(msglen + 2 + errlen);
+  memcpy (&Byte(str, 0), msg, msglen);
+  memcpy (&Byte(str, msglen), ": ", 2);
+  memcpy (&Byte(str, msglen + 2), err, errlen);
+  caml_raise_sys_error(str);
+}


### PR DESCRIPTION
## Current situation
- <caml/sync.h> defines some operations over the POSIX implementation of mutexes and condition variables
- These operations are used in sync.c to provide the full POSIX implementation of mutexes and condition variables
- They are also used in domain.c to lock and unlock the termination mutex associated with a domain
- They are also used in otherlibs/systhreads/st_posix.h for the POSIX implementation of the threads library.

## The problem
- <caml/sync.h> is installed along with the other <caml/*> headers, yet it's not protected by `CAML_INTERNALS` and doesn't follow the `caml_` naming convention for exported things.
- <caml/sync.h> and its users are (too?) specific to POSIX threads, which will cause issues if we ever decide to provide a pure Win32 implementation of mutexes and condition variables.

## The proposed solution
- <caml/sync.h> declares only the high-level, platform-agnostic mutex and condition variable operations that operate on OCaml values.  The declarations are currently made `CAML_INTERNALS` but we could envision other C/OCaml interface code to use them.
- domain.c is adjusted to use these high-level operations when acting on domain termination mutexes.  It is as GC-safe as the previous implementation, since `ml_values->mutex` is registered as a root.
- The POSIX implementation of mutexes and condition variables that used to be in <caml/sync.h> is moved to sync_posix.h (an unexported header, included in sync.c only) and extended with all POSIX-specific operations.
- A future Win32 implementation could, then, go in sync_win32.h.
- sync.c and otherlibs/systhreads/st_posix.h are adjusted accordingly.

This was discussed briefly with @ctk21 beforehand.
