### PR TITLE
named let syntax

### DIFF
--- a/parsing/lexer.mll
+++ b/parsing/lexer.mll
@@ -576,8 +576,10 @@ rule token = parse
   | '#' symbolchar_or_hash + as op
             { HASHOP op }
   | "let" kwdopchar dotsymbolchar * as op
+  | "let" kwdopchar? '.' lowercase identchar* as op
             { LETOP op }
   | "and" kwdopchar dotsymbolchar * as op
+  | "and" kwdopchar? '.' lowercase identchar* as op
             { ANDOP op }
   | eof { EOF }
   | (_ as illegal_char)

--- a/testsuite/tests/let-syntax/let_syntax.ml
+++ b/testsuite/tests/let-syntax/let_syntax.ml
@@ -729,3 +729,46 @@ Error: This pattern matches values of type GADT_ordering.point
        This instance of GADT_ordering.point is ambiguous:
        it would escape the scope of its equation
 |}];;
+
+module Named_let_syntax = struct
+  let (let.apply) = apply
+  let (and.pair) = pair
+  let nine =
+    let.apply four = 4
+    and.pair five = 5 in
+    4 + 5
+
+  let (let*.some) = Option.bind
+  let (let+.some) v f = Option.map f v
+  let some_four =
+    let*.some four = Some 4 in
+    Some four
+  let some_five =
+    let+.some four = Some 4 in
+    four + 1
+end;;
+[%%expect{|
+module Named_let_syntax :
+  sig
+    val ( let.apply ) : 'a -> ('a -> 'b) -> 'b
+    val ( and.pair ) : 'a -> 'b -> 'a * 'b
+    val nine : int
+    val ( let*.some ) : 'a option -> ('a -> 'b option) -> 'b option
+    val ( let+.some ) : 'a option -> ('a -> 'b) -> 'b option
+    val some_four : int option
+    val some_five : int option
+  end
+|}];;
+
+
+module Let_syntax_without_separator = struct
+  let (let+) x f = f x
+  let fourty_two =
+    (* intentionally no space*)
+    let+x = 40 in
+    40 + 2
+end
+[%%expect{|
+module Let_syntax_without_separator :
+  sig val ( let+ ) : 'a -> ('a -> 'b) -> 'b val fourty_two : int end
+|}];;


### PR DESCRIPTION
## What

ReasonML syntax in the past provide an additional feature to the current let syntax, where you could use alphanumeric.

This is a very useful feature if you're dealing with many monads at any point in time or just to have them available globally on a local stdlib. At work we use this under some bindings like `let.{some,ok,await}` but as we wanted to migrate to OCaml syntax we end up developing a ppx to workaround this.

## Problems

As pointed out by @Octachron this is actually a breaking change as `let+x = 1` is currently parsed as `let+ x = 1`

~~But it was also pointed out that this is not a breaking change without precedents, as that also happened for custom indexing operators  `< m: 'a.?x:int -> ... >`. I would argue that `let+x` working nowadays seems more like an artifact of the implementation than something desirable~~ .

The `.` on the other hand is a new character, so not a breaking changes and it fits kind of well with the remaining of the language as it gives this notion of `accessing` the content of the monad.

So this PR limits the patch to `let<symbol>(. <lident>)` and `let.<lident>` is allowed.

## Examples

```ocaml
let ( let.some ) = Option.bind
let some_five =
  let.some four = Some 4 in
  Some (four + 1)

let ( let.await ) = Lwt.bind
let ( and.await ) = Lwt.both

let () =
  let.await () = Lwt_unix.sleep 1
  and.await () = Lwt_unix.sleep 1  in
  (* both timers are executed in parallel *)
  print_endline "tuturu"
```