### PR TITLE
Implement a -cmi-file option

### DIFF
--- a/Changes
+++ b/Changes
@@ -94,6 +94,10 @@ Working version
   invariant checks are enabled.
   (Vincent Laviron, review by Gabriel Scherer)
 
+- #10981: Implement a -cmi-file option for ocamlc and ocamlopt.
+  (Sébastien Hinderer, review by Damien Doligez, Daniel Bünzli and
+  Florian   Angeletti)
+
 ### Internal/compiler-libs changes:
 
 - #10878, #10909: restore flambda after the Multicore merge.

--- a/driver/main_args.ml
+++ b/driver/main_args.ml
@@ -62,6 +62,11 @@ let mk_clambda_checks f =
     field access checks (for debugging the compiler)"
 ;;
 
+let mk_cmi_file f =
+  "-cmi-file", Arg.String f,
+    "<file>  Use the <file> interface file to type-check"
+;;
+
 let mk_compact f =
   "-compact", Arg.Unit f, " Optimize code size rather than speed"
 ;;
@@ -966,6 +971,7 @@ module type Compiler_options = sig
   val _cc : string -> unit
   val _cclib : string -> unit
   val _ccopt : string -> unit
+  val _cmi_file : string -> unit
   val _config : unit -> unit
   val _config_var : string -> unit
   val _for_pack : string -> unit
@@ -1160,6 +1166,7 @@ struct
     mk_cc F._cc;
     mk_cclib F._cclib;
     mk_ccopt F._ccopt;
+    mk_cmi_file F._cmi_file;
     mk_color F._color;
     mk_error_style F._error_style;
     mk_compat_32 F._compat_32;
@@ -1856,6 +1863,7 @@ module Default = struct
     let _cc s = c_compiler := (Some s)
     let _cclib s = Compenv.defer (ProcessObjects (Misc.rev_split_words s))
     let _ccopt s = Compenv.first_ccopts := (s :: (!Compenv.first_ccopts))
+    let _cmi_file s = cmi_file := (Some s)
     let _config = Misc.show_config_and_exit
     let _config_var = Misc.show_config_variable_and_exit
     let _dprofile () = profile_columns := Profile.all_columns

--- a/driver/main_args.mli
+++ b/driver/main_args.mli
@@ -78,6 +78,7 @@ module type Compiler_options = sig
   val _cc : string -> unit
   val _cclib : string -> unit
   val _ccopt : string -> unit
+  val _cmi_file : string -> unit
   val _config : unit -> unit
   val _config_var : string -> unit
   val _for_pack : string -> unit

--- a/man/ocamlc.1
+++ b/man/ocamlc.1
@@ -398,6 +398,10 @@ can help in writing an explicit interface (.mli file) for a file: just
 redirect the standard output of the compiler to a .mli file, and edit
 that file to remove all declarations of unexported names.
 .TP
+.B \-cmi-file \ filename
+Type-check the source implementation to be compiled against the
+specified interface file (by-passes the normal lookup for .mli and .cmi files).
+.TP
 .BI \-I \ directory
 Add the given directory to the list of directories searched for
 compiled interface files (.cmi), compiled object code files

--- a/man/ocamlopt.1
+++ b/man/ocamlopt.1
@@ -301,6 +301,10 @@ can help in writing an explicit interface (.mli file) for a file:
 just redirect the standard output of the compiler to a .mli file,
 and edit that file to remove all declarations of unexported names.
 .TP
+.B \-cmi-file \ filename
+Type-check the source implementation to be compiled against the
+specified interface file (by-passes the normal lookup for .mli and .cmi files).
+.TP
 .BI \-I \ directory
 Add the given directory to the list of directories searched for
 compiled interface files (.cmi), compiled object code files (.cmx),

--- a/manual/src/cmds/unified-options.etex
+++ b/manual/src/cmds/unified-options.etex
@@ -117,6 +117,16 @@ directory \var{dir}. \comp{(See the "-custom" option.)}
 }%notop
 
 \notop{%
+\item["-cmi-file" \var{filename}]
+Use the given interface file to type-check the ML source file to compile.
+When this option is not specified, the compiler looks for a \var{.mli} file
+with the same base name than the implementation it is compiling and in the
+same directory. If such a file is found, the compiler looks for a
+correspoinding \var{.cmi} file in the included directories and reports an
+error if it fails to find one.
+}%notop
+
+\notop{%
 \item["-color" \var{mode}]
 Enable or disable colors in compiler messages (especially warnings and errors).
 The following modes are supported:

--- a/utils/clflags.ml
+++ b/utils/clflags.ml
@@ -42,6 +42,8 @@ let objfiles = ref ([] : string list)   (* .cmo and .cma files *)
 and ccobjs = ref ([] : string list)     (* .o, .a, .so and -cclib -lxxx *)
 and dllibs = ref ([] : string list)     (* .so and -dllib -lxxx *)
 
+let cmi_file = ref None
+
 let compile_only = ref false            (* -c *)
 and output_name = ref (None : string option) (* -o *)
 and include_dirs = ref ([] : string list)(* -I *)

--- a/utils/clflags.mli
+++ b/utils/clflags.mli
@@ -71,6 +71,7 @@ val use_inlining_arguments_set : ?round:int -> inlining_arguments -> unit
 val objfiles : string list ref
 val ccobjs : string list ref
 val dllibs : string list ref
+val cmi_file : string option ref
 val compile_only : bool ref
 val output_name : string option ref
 val include_dirs : string list ref


### PR DESCRIPTION
This is an attempt at fixing issue #9717.

The provided fix consists in introducing a `-cmi-file` command-line
option that lets one specify against which binary interface file an
implementation should be compiled.

If the option is provided, the lookup for the source (.mli) interface
besides to the .ml module is skipped.

If the option is not specified the compiler behaves as before.

To follow-up on the example given in #9717, it is now possible to
compile `impl/a.ml` against `build/a.cmi` as follows:

```
ocamlc -c impl/a.ml -cmi-file build/a.cmi -o build/a.cmo
```

From a functional point of view, is such an implementation good enough for
clever build systems that can easily specify complete filenames rather than
just directories?

Would it also be good to be able to specify just the directory
where to look for .cmi files? IF so, dos that require a dedicated option,
or shall the normal include path be used? In that last case,
should there be a dedicated option to tell teh compiler to look
in the include dire for .cmi files, or should the default behaviour
simply be extended?

Assuming the feature is considered satisfactory, I must say I am not
very happy about its implementation because the pattern-matching on
`!Clflags.cmi_file`is done twice and because `sourceintf` is computed
even when not required. I wrote things that way because that looked the
less invasive way.