### PR TITLE
add `Buffer.unsafe_internal_buffer`

### DIFF
--- a/Changes
+++ b/Changes
@@ -55,7 +55,8 @@ Working version
   Unix.SO_ERROR.
   (Nicolás Ojeda Bär, review by Damien Doligez)
 
-* #10982: Add Buffer.unsafe_internal_buffer, to access the buffer's internal bytes.
+* #10982: Add Buffer.unsafe_internal_buffer, to access the
+  buffer's internal bytes.
   (Simon Cruanes)
 
 ### Other libraries:

--- a/Changes
+++ b/Changes
@@ -55,6 +55,9 @@ Working version
   Unix.SO_ERROR.
   (Nicolás Ojeda Bär, review by Damien Doligez)
 
+* #10982: Add Buffer.unsafe_internal_buffer, to access the buffer's internal bytes.
+  (Simon Cruanes)
+
 ### Other libraries:
 
 * #9071, #9100, #10935: Reimplement `Thread.exit()` as raising the

--- a/stdlib/buffer.ml
+++ b/stdlib/buffer.ml
@@ -36,6 +36,7 @@ let create n =
 
 let contents b = Bytes.sub_string b.buffer 0 b.position
 let to_bytes b = Bytes.sub b.buffer 0 b.position
+let unsafe_internal_buffer b = b.buffer
 
 let sub b ofs len =
   if ofs < 0 || len < 0 || ofs > b.position - len

--- a/stdlib/buffer.mli
+++ b/stdlib/buffer.mli
@@ -80,6 +80,17 @@ val nth : t -> int -> char
 val length : t -> int
 (** Return the number of characters currently contained in the buffer. *)
 
+val unsafe_internal_buffer : t -> bytes
+(** Access the internal byte buffer.
+
+    The content of [unsafe_internal_buffer b]
+    is only defined within [0 ... Buffer.length b-1], and is invalidated
+    as soon as any length-modifying function is called (e.g. {!add_char}, {!clear},
+    {!truncate}).
+
+    @since 4.14
+*)
+
 val clear : t -> unit
 (** Empty the buffer. *)
 

--- a/stdlib/buffer.mli
+++ b/stdlib/buffer.mli
@@ -85,8 +85,8 @@ val unsafe_internal_buffer : t -> bytes
 
     The content of [unsafe_internal_buffer b]
     is only defined within [0 ... Buffer.length b-1], and is invalidated
-    as soon as any length-modifying function is called (e.g. {!add_char}, {!clear},
-    {!truncate}).
+    as soon as any length-modifying function is called
+    (e.g. {!add_char}, {!clear}, {!truncate}).
 
     @since 4.14
 *)


### PR DESCRIPTION
This is something I've wanted to do for the past 8 years or so. Currently, Buffer.t is useful as a way to produce values of type `string` efficiently, but it falls short in other areas where access to the underlying byte buffer is required, because it provides no escape hatch at all. Functions like `output_buffer`, or `add_int64_ne` have to be hardcoded, and anything else will require an extra copy, which is problematic when the use of a buffer in the first place is to reduce allocation. If I wanted to _read_ an int64 from a buffer, I'd have to extract to `bytes` first. If I want to use a `Lwt_io` function to write bytes to some channel, or use gzip bindings to compress the content of a buffer, or any other form of C bindings, or search for a delimiter (like `\n`), I have to copy/sub.

This is "unsafe" in the sense of "I know what I'm doing", but it doesn't violate any OCaml invariant. It's less risky than `Bytes.unsafe_to_string`, so I'm not entirely sure it deserves the prefix.