### PR TITLE
ocamldoc: thread-safety tags

### DIFF
--- a/ocamldoc/odoc_comments.ml
+++ b/ocamldoc/odoc_comments.ml
@@ -80,7 +80,15 @@ module Info_retriever =
                    (n, MyTexter.text_of_string s)) !Odoc_comments_global.raised_exceptions);
                  i_return_value =
                  (match !Odoc_comments_global.return_value with
-                   None -> None | Some s -> Some (MyTexter.text_of_string s)) ;
+                     None -> None | Some s -> Some (MyTexter.text_of_string s)) ;
+                   i_concurrency = (match !Odoc_comments_global.concurrency with
+                       | None -> None
+                       | Some "systhread-safe" -> Some Systhread_safe
+                       | Some "fiber-safe" -> Some Fiber_safe
+                       | Some "domain-safe" -> Some Domain_safe
+                       | Some "concurrent-unsafe" -> Some Concurrent_unsafe
+                       | Some s -> raise (Failure (Odoc_messages.not_a_valid_concurrency_tag s))
+                     );
                  i_custom = (List.map
                                (fun (tag, s) -> (tag, MyTexter.text_of_string s))
                                !Odoc_comments_global.customs)
@@ -229,6 +237,7 @@ let info_of_string s =
       i_params = [] ;
       i_raised_exceptions = [] ;
       i_return_value = None ;
+      i_concurrency = None;
       i_custom = [] ;
     }
   in

--- a/ocamldoc/odoc_comments_global.ml
+++ b/ocamldoc/odoc_comments_global.ml
@@ -35,6 +35,8 @@ let raised_exceptions = ref ([] : (string * string) list)
 
 let return_value = ref (None : string option)
 
+let concurrency = ref (None : string option)
+
 let customs = ref []
 
 let init () =
@@ -48,4 +50,5 @@ let init () =
   params := [];
   raised_exceptions := [];
   return_value := None ;
+  concurrency := None;
   customs := []

--- a/ocamldoc/odoc_comments_global.mli
+++ b/ocamldoc/odoc_comments_global.mli
@@ -45,6 +45,10 @@ val raised_exceptions : (string * string) list ref
 (** the description of the return value *)
 val return_value : string option ref
 
+
+(** the description of the return value *)
+val concurrency : string option ref
+
 (** the strings associated to custom tags. *)
 val customs : (string * string) list ref
 

--- a/ocamldoc/odoc_html.ml
+++ b/ocamldoc/odoc_html.ml
@@ -644,6 +644,17 @@ class virtual info =
           self#html_of_text b [Raw s];
           bs b "</li>\n"
 
+    (** Print html code for the concurrency safety information .*)
+    method html_of_concurrency b toplevel clevel =
+      match clevel with
+      | Some Domain_safe -> bp b "<li><b>Domain-safe</b></li>\n"
+      | Some Fiber_safe -> bp b "<li><b>Fiber-safe</b></li>\n"
+      | Some Systhread_safe -> bp b "<li><b>Systhread-safe</b></li>\n"
+      | Some Concurrent_unsafe -> bp b "<li><b>Concurrent-unsafe</b></li>\n"
+      | None ->
+          if toplevel then
+            bp b "<li><b>Concurrent-unsafe</b></li>\n"
+
     (** Print html code for the given "before" information.*)
     method html_of_before b l =
       let f (v, text) =
@@ -731,7 +742,7 @@ class virtual info =
        @param indent can be specified not to use the style of info comments;
        default is [true].
     *)
-    method html_of_info ?(cls="") ?(indent=true) b info_opt =
+    method html_of_info ?(cls="") ?(toplevel=false) ?(indent=true) b info_opt =
       match info_opt with
         None ->
           ()
@@ -767,6 +778,7 @@ class virtual info =
           self#html_of_raised_exceptions b' info.M.i_raised_exceptions;
           self#html_of_return_opt b' info.M.i_return_value;
           self#html_of_sees b' info.M.i_sees;
+          self#html_of_concurrency b' toplevel info.M.i_concurrency;
           self#html_of_custom b' info.M.i_custom;
           if Buffer.length b' > 0 then
             begin
@@ -2063,7 +2075,7 @@ class html =
       if info then
         (
          if complete then
-           self#html_of_info ~cls: "module top" ~indent: true
+           self#html_of_info ~cls: "module top" ~indent: true ~toplevel:true
          else
            self#html_of_info_first_sentence
         ) b m.m_info
@@ -2094,7 +2106,7 @@ class html =
       if info then
         (
          if complete then
-           self#html_of_info ~cls: "modtype top" ~indent: true
+           self#html_of_info ~cls: "modtype top" ~indent: true ~toplevel:true
          else
            self#html_of_info_first_sentence
         ) b mt.mt_info
@@ -2249,7 +2261,7 @@ class html =
       bs b "</pre>" ;
       (
        if complete then
-         self#html_of_info ~cls: "class top" ~indent: true
+         self#html_of_info ~cls: "class top" ~indent: true ~toplevel:false
        else
          self#html_of_info_first_sentence
       ) b c.cl_info
@@ -2292,7 +2304,7 @@ class html =
       bs b "</pre>";
       (
        if complete then
-         self#html_of_info ~cls: "classtype top" ~indent: true
+         self#html_of_info ~cls: "classtype top" ~indent: true ~toplevel:false
        else
          self#html_of_info_first_sentence
       ) b ct.clt_info

--- a/ocamldoc/odoc_info.ml
+++ b/ocamldoc/odoc_info.ml
@@ -71,6 +71,12 @@ type param = (string * text)
 
 type raised_exception = (string * text)
 
+type concurrency_safety_level = Odoc_types.concurrency_safety_level =
+  | Concurrent_unsafe
+  | Systhread_safe
+  | Fiber_safe
+  | Domain_safe
+
 type info = Odoc_types.info = {
     i_desc : text option;
     i_authors : string list;
@@ -82,6 +88,7 @@ type info = Odoc_types.info = {
     i_params : param list;
     i_raised_exceptions : raised_exception list;
     i_return_value : text option ;
+    i_concurrency: concurrency_safety_level option;
     i_custom : (string * text) list ;
   }
 

--- a/ocamldoc/odoc_info.mli
+++ b/ocamldoc/odoc_info.mli
@@ -84,6 +84,14 @@ type param = (string * text)
 (** Raised exception name and description. *)
 type raised_exception = (string * text)
 
+(** The safety level with respect to concurrent executions *)
+type concurrency_safety_level = Odoc_types.concurrency_safety_level =
+  | Concurrent_unsafe
+  | Systhread_safe
+  | Fiber_safe
+  | Domain_safe
+
+
 (** Information in a special comment
 @before 3.12.0 \@before information was not present.
 *)
@@ -98,6 +106,7 @@ type info = Odoc_types.info = {
     i_params : param list; (** The list of parameter descriptions. *)
     i_raised_exceptions : raised_exception list; (** The list of raised exceptions. *)
     i_return_value : text option; (** The description text of the return value. *)
+    i_concurrency: concurrency_safety_level option; (** The safety level for concurrent use *)
     i_custom : (string * text) list ; (** A text associated to a custom @-tag. *)
   }
 

--- a/ocamldoc/odoc_lexer.mll
+++ b/ocamldoc/odoc_lexer.mll
@@ -89,7 +89,7 @@ let remove_stars s =
   Str.global_replace (Str.regexp ("^"^blank^"*\\*")) "" s
 }
 
-let lowercase = ['a'-'z' '\223'-'\246' '\248'-'\255' '_']
+let lowercase = ['a'-'z' '\223'-'\246' '\248'-'\255' '_' '-']
 let uppercase = ['A'-'Z' '\192'-'\214' '\216'-'\222']
 let identchar =
   ['A'-'Z' 'a'-'z' '_' '\192'-'\214' '\216'-'\246' '\248'-'\255' '\'' '0'-'9']
@@ -319,6 +319,16 @@ and elements = parse
              T_RAISES
          | "return" ->
              T_RETURN
+         | "concurrency" ->
+             T_CONCURRENCY
+         | "systhread-safe" ->
+             T_SYSTHREAD_SAFE
+         | "fiber-safe" ->
+             T_FIBER_SAFE
+         | "domain-safe" ->
+             T_DOMAIN_SAFE
+         | "concurrent-unsafe"  ->
+             T_CONCURRENT_UNSAFE
          | s ->
              if !Odoc_global.no_custom_tags then
                raise (Failure (Odoc_messages.not_a_valid_tag s))

--- a/ocamldoc/odoc_merge.ml
+++ b/ocamldoc/odoc_merge.ml
@@ -46,159 +46,86 @@ let merge_before_tags l =
 
 let version_separators = Str.regexp "[\\.\\+]";;
 
+let merge_opt cond x y merge = match x, y with
+  | None, None -> None
+  | Some _ as x, None | None, (Some _ as x) -> x
+  | Some x, Some y ->
+      if cond then
+        Some (merge x y)
+      else Some x
+
+let merge_lists cond x y merge = match x, y with
+  | [], [] -> []
+  | _ :: _ as x, [] | [], ( _ :: _ as x) -> x
+  | _ :: _ as x, (_ :: _ as y) ->
+      if cond then
+        merge x y
+      else x
+
+let merge_assoc l1 l2 =
+  let l_in_m1_and_m2, l_in_m2_only = List.partition
+      (fun (param2, _) -> List.mem_assoc param2 l1)
+      l2
+  in
+  let rec iter = function
+      [] -> []
+    | (param2, desc2) :: q ->
+        let desc1 = List.assoc param2 l1 in
+        (param2, desc1 @ (Newline :: desc2)) :: (iter q)
+  in
+  let l1_completed = iter l_in_m1_and_m2 in
+  l1_completed @ l_in_m2_only
+
+
 (** Merge two Odoctypes.info structures, completing the information of
    the first one with the information in the second one.
    The merge treatment depends on a given merge_option list.
    @return the new info structure.*)
 let merge_info merge_options (m1 : info) (m2 : info) =
   let new_desc_opt =
-    match m1.i_desc, m2.i_desc with
-      None, None -> None
-    | None, Some d
-    | Some d, None -> Some d
-    | Some d1, Some d2 ->
-        if List.mem Merge_description merge_options then
-          Some (d1 @ (Newline :: d2))
-        else
-          Some d1
+    let merge d1 d2 = d1 @ (Newline :: d2) in
+    merge_opt (List.mem Merge_description merge_options) m1.i_desc m2.i_desc merge
   in
   let new_authors =
-    match m1.i_authors, m2.i_authors with
-      [], [] -> []
-    | l, []
-    | [], l -> l
-    | l1, l2 ->
-        if List.mem Merge_author merge_options then
-          l1 @ l2
-        else
-          l1
+    merge_lists (List.mem Merge_author merge_options) m1.i_authors m2.i_authors (@)
   in
   let new_version =
-    match m1.i_version , m2.i_version with
-      None, None -> None
-    | Some v, None
-    | None, Some v -> Some v
-    | Some v1, Some v2 ->
-        if List.mem Merge_version merge_options then
-          Some (v1^" "^v2)
-        else
-          Some v1
+    merge_opt (List.mem Merge_version merge_options) m1.i_version m2.i_version
+      (fun v1 v2 -> v1^" "^v2)
   in
   let new_sees =
-    match m1.i_sees, m2.i_sees with
-      [], [] -> []
-    | l, []
-    | [], l -> l
-    | l1, l2 ->
-        if List.mem Merge_see merge_options then
-          l1 @ l2
-        else
-          l1
+    merge_lists (List.mem Merge_see merge_options) m1.i_sees m2.i_sees (@)
   in
   let new_since =
-    match m1.i_since, m2.i_since with
-      None, None -> None
-    | Some v, None
-    | None, Some v -> Some v
-    | Some v1, Some v2 ->
-        if List.mem Merge_since merge_options then
-          Some (v1^" "^v2)
-        else
-          Some v1
+    merge_opt (List.mem Merge_since merge_options) m1.i_since m2.i_since (fun v1 v2 ->
+        v1^" "^v2
+      )
   in
   let new_before =
-    match m1.i_before, m2.i_before with
-      [], [] -> []
-    | l, []
-    | [], l -> l
-    | l1, _ ->
-        if List.mem Merge_before merge_options then
-          merge_before_tags (m1.i_before @ m2.i_before)
-        else
-          l1 in
+    merge_lists (List.mem Merge_before merge_options) m1.i_before m2.i_before (fun b1 b2 ->
+        merge_before_tags (b1 @ b2)
+      )
+  in
   let new_before = List.map (fun (v, t) -> (Str.split version_separators v, v, t)) new_before in
   let new_before = List.sort Stdlib.compare new_before in
   let new_before = List.map (fun (_, v, t) -> (v, t)) new_before in
   let new_dep =
-    match m1.i_deprecated, m2.i_deprecated with
-      None, None -> None
-    | None, Some t
-    | Some t, None -> Some t
-    | Some t1, Some t2 ->
-        if List.mem Merge_deprecated merge_options then
-          Some (t1 @ (Newline :: t2))
-        else
-          Some t1
+    merge_opt (List.mem Merge_deprecated merge_options)
+      m1.i_deprecated m2.i_deprecated (fun t1 t2 -> t1 @ (Newline :: t2))
   in
   let new_params =
-    match m1.i_params, m2.i_params with
-      [], [] -> []
-    | l, []
-    | [], l -> l
-    | l1, l2 ->
-        if List.mem Merge_param merge_options then
-          (
-           let l_in_m1_and_m2, l_in_m2_only = List.partition
-               (fun (param2, _) -> List.mem_assoc param2 l1)
-               l2
-           in
-           let rec iter = function
-               [] -> []
-             | (param2, desc2) :: q ->
-                 let desc1 = List.assoc param2 l1 in
-                 (param2, desc1 @ (Newline :: desc2)) :: (iter q)
-           in
-           let l1_completed = iter l_in_m1_and_m2 in
-           l1_completed @ l_in_m2_only
-          )
-        else
-          l1
+    merge_lists (List.mem Merge_param merge_options) m1.i_params m2.i_params merge_assoc
   in
   let new_raised_exceptions =
-    match m1.i_raised_exceptions, m2.i_raised_exceptions with
-      [], [] -> []
-    | l, []
-    | [], l -> l
-    | l1, l2 ->
-        if List.mem Merge_raised_exception merge_options then
-          (
-           let l_in_m1_and_m2, l_in_m2_only = List.partition
-               (fun (exc2, _) -> List.mem_assoc exc2 l1)
-               l2
-           in
-           let rec iter = function
-               [] -> []
-             | (exc2, desc2) :: q ->
-                 let desc1 = List.assoc exc2 l1 in
-                 (exc2, desc1 @ (Newline :: desc2)) :: (iter q)
-           in
-           let l1_completed = iter l_in_m1_and_m2 in
-           l1_completed @ l_in_m2_only
-          )
-        else
-          l1
+    merge_lists (List.mem Merge_raised_exception merge_options)
+      m1.i_raised_exceptions m2.i_raised_exceptions merge_assoc
   in
   let new_rv =
-    match m1.i_return_value, m2.i_return_value with
-      None, None -> None
-    | None, Some t
-    | Some t, None -> Some t
-    | Some t1, Some t2 ->
-        if List.mem Merge_return_value merge_options then
-          Some (t1 @ (Newline :: t2))
-        else
-          Some t1
+    merge_opt (List.mem Merge_return_value merge_options)
+      m1.i_return_value m2.i_return_value (fun t1 t2 -> t1 @ (Newline :: t2))
   in
-  let new_custom =
-    match m1.i_custom, m2.i_custom with
-      [], [] -> []
-    | [], l
-    | l, [] -> l
-    | l1, l2 ->
-        if List.mem Merge_custom merge_options then
-          l1 @ l2
-        else
-          l1
+  let new_custom = merge_lists (List.mem Merge_return_value merge_options)
+      m1.i_custom m2.i_custom (@)
   in
   {
     Odoc_types.i_desc = new_desc_opt ;

--- a/ocamldoc/odoc_merge.ml
+++ b/ocamldoc/odoc_merge.ml
@@ -124,6 +124,9 @@ let merge_info merge_options (m1 : info) (m2 : info) =
     merge_opt (List.mem Merge_return_value merge_options)
       m1.i_return_value m2.i_return_value (fun t1 t2 -> t1 @ (Newline :: t2))
   in
+  let new_concurrency =
+    merge_opt false m1.i_concurrency m2.i_concurrency (fun x _ -> x)
+  in
   let new_custom = merge_lists (List.mem Merge_return_value merge_options)
       m1.i_custom m2.i_custom (@)
   in
@@ -138,6 +141,7 @@ let merge_info merge_options (m1 : info) (m2 : info) =
     Odoc_types.i_params = new_params ;
     Odoc_types.i_raised_exceptions = new_raised_exceptions ;
     Odoc_types.i_return_value = new_rv ;
+    Odoc_types.i_concurrency = new_concurrency;
     Odoc_types.i_custom = new_custom ;
   }
 

--- a/ocamldoc/odoc_messages.ml
+++ b/ocamldoc/odoc_messages.ml
@@ -281,6 +281,8 @@ let should_escape_at_sign = "The character @ has a special meaning in ocamldoc c
 If you want to write a single @, you must escape it as \\@."
 let bad_tree = "Incorrect tree structure."
 let not_a_valid_tag s = s^" is not a valid tag."
+let not_a_valid_concurrency_tag s =
+  Printf.sprintf "%S is not a valid concurrency safety level." s
 let fun_without_param f = "Function "^f^" has no parameter.";;
 let method_without_param f = "Method "^f^" has no parameter.";;
 let anonymous_parameters f = "Function "^f^" has anonymous parameters."

--- a/ocamldoc/odoc_parser.mly
+++ b/ocamldoc/odoc_parser.mly
@@ -37,6 +37,11 @@ let blank = "[ \010\013\009\012]"
 %token T_DEPRECATED
 %token T_RAISES
 %token T_RETURN
+%token T_CONCURRENT_UNSAFE
+%token T_SYSTHREAD_SAFE
+%token T_FIBER_SAFE
+%token T_DOMAIN_SAFE
+%token T_CONCURRENCY
 %token <string> T_CUSTOM
 
 %token EOF
@@ -85,6 +90,7 @@ element:
 | deprecated { () }
 | raise_exc { () }
 | return { () }
+| concurrency { () }
 | custom { () }
 ;
 
@@ -160,7 +166,18 @@ raise_exc:
 return:
     T_RETURN Desc { return_value := Some $2 }
 ;
+concurrency:
+  | T_CONCURRENCY Desc { concurrency := Some $2 }
+  | T_CONCURRENT_UNSAFE Desc { concurrency := Some "concurrent-unsafe" }
+  | T_SYSTHREAD_SAFE Desc { concurrency := Some "systhread-safe" }
+  | T_FIBER_SAFE Desc { concurrency := Some "fiber-safe" }
+  | T_DOMAIN_SAFE Desc { concurrency := Some "domain-safe" }
+  | T_CONCURRENT_UNSAFE { concurrency := Some "concurrent-unsafe" }
+  | T_SYSTHREAD_SAFE { concurrency := Some "systhread-safe" }
+  | T_FIBER_SAFE { concurrency := Some "fiber-safe" }
+  | T_DOMAIN_SAFE { concurrency := Some "domain-safe" }
 
+;
 custom:
     T_CUSTOM Desc { customs := !customs @ [($1, $2)] }
 ;

--- a/ocamldoc/odoc_types.ml
+++ b/ocamldoc/odoc_types.ml
@@ -67,6 +67,12 @@ type param = (string * text)
 
 type raised_exception = (string * text)
 
+type concurrency_safety_level =
+  | Concurrent_unsafe
+  | Systhread_safe
+  | Fiber_safe
+  | Domain_safe
+
 type info = {
     i_desc : text option;
     i_authors : string list;
@@ -78,6 +84,7 @@ type info = {
     i_params : param list;
     i_raised_exceptions : raised_exception list;
     i_return_value : text option ;
+    i_concurrency : concurrency_safety_level option;
     i_custom : (string * text) list ;
   }
 
@@ -92,6 +99,7 @@ let dummy_info = {
   i_params = [] ;
   i_raised_exceptions = [] ;
   i_return_value = None ;
+  i_concurrency = None;
   i_custom = [] ;
 }
 

--- a/ocamldoc/odoc_types.mli
+++ b/ocamldoc/odoc_types.mli
@@ -79,6 +79,13 @@ type param = (string * text)
 (** Raised exception name and description. *)
 type raised_exception = (string * text)
 
+(** The safety level with respect to concurrent executions *)
+type concurrency_safety_level =
+  | Concurrent_unsafe
+  | Systhread_safe
+  | Fiber_safe
+  | Domain_safe
+
 (** Information in a special comment. *)
 type info = {
     i_desc : text option; (** The description text. *)
@@ -91,6 +98,7 @@ type info = {
     i_params : param list; (** The list of parameter descriptions. *)
     i_raised_exceptions : raised_exception list; (** The list of raised exceptions. *)
     i_return_value : text option ; (** The description text of the return value. *)
+    i_concurrency: concurrency_safety_level option; (** The safety level for concurrent use *)
     i_custom : (string * text) list ; (** A text associated to a custom @-tag. *)
   }
 

--- a/testsuite/tests/tool-ocamldoc/Documentation_tags.html.reference
+++ b/testsuite/tests/tool-ocamldoc/Documentation_tags.html.reference
@@ -19,6 +19,9 @@
 <div class="info-desc">
 <p>Test the html rendering of ocamldoc documentation tags</p>
 </div>
+<ul class="info-attributes">
+<li><b>Concurrent-unsafe</b></li>
+</ul>
 </div>
 <hr width="100%">
 
@@ -31,6 +34,7 @@
 <li><b>Since</b> Now</li>
 <li><b>Returns</b> ()</li>
 <li><b>See also</b> <i>Documentation_tags.mli</i> Self reference</li>
+<li><b>Domain-safe</b></li>
 </ul>
 </div>
 

--- a/testsuite/tests/tool-ocamldoc/Documentation_tags.mli
+++ b/testsuite/tests/tool-ocamldoc/Documentation_tags.mli
@@ -14,6 +14,7 @@ val heterological: unit
  @see "Documentation_tags.mli" Self reference
  @since Now
  @before Time not implemented
+ @domain-safe
 *)
 
 val noop: unit

--- a/testsuite/tests/tool-ocamldoc/Include_module_type_of.html.reference
+++ b/testsuite/tests/tool-ocamldoc/Include_module_type_of.html.reference
@@ -19,6 +19,9 @@
 <div class="info-desc">
 <p>Test <code class="code"><span class="keyword">include</span>&nbsp;<span class="keyword">module</span>&nbsp;<span class="keyword">type</span>&nbsp;<span class="keyword">of</span>...</code> variants</p>
 </div>
+<ul class="info-attributes">
+<li><b>Concurrent-unsafe</b></li>
+</ul>
 </div>
 <hr width="100%">
 

--- a/testsuite/tests/tool-ocamldoc/Inline_records.html.reference
+++ b/testsuite/tests/tool-ocamldoc/Inline_records.html.reference
@@ -22,6 +22,9 @@
 <p>This test focuses on the printing of documentation for inline record
   within the latex generator.</p>
 </div>
+<ul class="info-attributes">
+<li><b>Concurrent-unsafe</b></li>
+</ul>
 </div>
 <hr width="100%">
 

--- a/testsuite/tests/tool-ocamldoc/Item_ids.html.reference
+++ b/testsuite/tests/tool-ocamldoc/Item_ids.html.reference
@@ -25,6 +25,9 @@
 <div class="info-desc">
 <p>Check that all toplevel items are given a unique id.</p>
 </div>
+<ul class="info-attributes">
+<li><b>Concurrent-unsafe</b></li>
+</ul>
 </div>
 <hr width="100%">
 

--- a/testsuite/tests/tool-ocamldoc/Linebreaks.html.reference
+++ b/testsuite/tests/tool-ocamldoc/Linebreaks.html.reference
@@ -47,6 +47,9 @@
    For instance with the following type definitions,</li>
 </ul>
 </div>
+<ul class="info-attributes">
+<li><b>Concurrent-unsafe</b></li>
+</ul>
 </div>
 <hr width="100%">
 

--- a/testsuite/tests/tool-ocamldoc/Paragraph.html.reference
+++ b/testsuite/tests/tool-ocamldoc/Paragraph.html.reference
@@ -49,6 +49,7 @@
 <ul class="info-attributes">
 <li><b>Author(s):</b> : Florian Angeletti</li>
 <li><b>Version:</b> : 1</li>
+<li><b>Concurrent-unsafe</b></li>
 </ul>
 </div>
 <hr width="100%">

--- a/testsuite/tests/tool-ocamldoc/Variants.html.reference
+++ b/testsuite/tests/tool-ocamldoc/Variants.html.reference
@@ -19,6 +19,9 @@
 <div class="info-desc">
 <p>This test is here to check the latex code generated for variants</p>
 </div>
+<ul class="info-attributes">
+<li><b>Concurrent-unsafe</b></li>
+</ul>
 </div>
 <hr width="100%">
 


### PR DESCRIPTION
This PR adds basic support for the following ocamldoc documentation tags intended to be used to document thread-safety in OCaml 5:

* `@domain-safe`
* `@systhread-safe`
* `@fiber-safe`
* `@concurrent-unsafe`

or equivalently

* `@concurrency {domain-safe,systhread-safe,fiber-safe,concurrent-unsafe}`

Those new tags are currently only displayed in the html backend, while waiting for discussion on the design. In particular, I hope that having a PR open will help to synchronize the design between both `ocamldoc` and `odoc` (cc @ocaml/odoc-dev)

In particular, currently a default `@concurrent-unsafe` tag is displayed for modules and module types if there are not annotated with an explicit thread-safety tag.

There is also the question if we want those tags to be displayed as ordinary documentation tags or have some more custom rendering at least on the html backend.