### PR TITLE
fix build of trunk with dune

### DIFF
--- a/runtime/dune
+++ b/runtime/dune
@@ -21,7 +21,7 @@
      interp.c ints.c io.c
    lexing.c md5.c meta.c memprof.c obj.c parsing.c signals.c str.c sys.c
      callback.c weak.c
-   finalise.c stacks.c dynlink.c backtrace_byt.c backtrace.c
+   finalise.c dynlink.c backtrace_byt.c backtrace.c
      afl.c
    bigarray.c eventlog.c)
  (action  (with-stdout-to %{targets} (run %{dep:gen_primitives.sh}))))
@@ -36,7 +36,7 @@
    ../Makefile.common Makefile
    (glob_files caml/*.h)
    ; matches the line structure of files in Makefile/BYTECODE_C_SOURCES
-   interp.c misc.c stacks.c fix_code.c startup_aux.c startup_byt.c freelist.c
+   interp.c misc.c fix_code.c startup_aux.c startup_byt.c freelist.c
      major_gc.c
    minor_gc.c memory.c alloc.c roots_byt.c globroots.c fail_byt.c signals.c
    signals_byt.c printexc.c backtrace_byt.c backtrace.c compare.c ints.c

--- a/stdlib/dune
+++ b/stdlib/dune
@@ -23,7 +23,23 @@
  (flags (:standard -w -9 -nolabels))
  (preprocess
    (per_module
-     ((action
-          (run awk -f %{dep:expand_module_aliases.awk} %{input-file}))
+     ((action (run awk -f %{dep:expand_module_aliases.awk} %{input-file}))
       stdlib)
+     ;; AWFUL HACKS: remove once 5.00 is release
+     ;; (this is needed because we're building with a compiler which doesn't
+     ;; know these primitives yet)
+     ;; It's especially ugly because the compiler insists on checking arity...
+     ((action
+        (progn
+          (run sed -i s/%atomic_load/%identity/ %{input-file})
+          (run sed -i s/%atomic_cas/%obj_set_field/ %{input-file})
+          (run sed s/%atomic_[a-z_]*/%addint/ %{input-file})))
+      camlinternalAtomic)
+     ((action (run sed s/%dls_get/%identity/ %{input-file}))
+      domain)
+     ((action
+        (progn
+          (run sed -i s/%perform/%identity/ %{input-file})
+          (run sed s/%r[a-z]*/%obj_set_field/ %{input-file})))
+      effect)
      )))


### PR DESCRIPTION
This is ugly, but I can build (though not run) trunk with dune+ocaml 4.14, allowing me to use merlin on the codebase.

Creating a PR so those who care (@dra27, @gasche ?) know.