### PR TITLE
Add Scanf.{s,b,}scanf_opt

### DIFF
--- a/Changes
+++ b/Changes
@@ -55,6 +55,9 @@ Working version
   Unix.SO_ERROR.
   (Nicolás Ojeda Bär, review by Damien Doligez)
 
+- #10986: Add sscanf_opt, bscanf_opt and scanf_opt to the Scanf module.
+  (Nicolás Ojeda Bär, review by Florian Angeletti)
+
 ### Other libraries:
 
 * #9071, #9100, #10935: Reimplement `Thread.exit()` as raising the

--- a/Changes
+++ b/Changes
@@ -55,8 +55,8 @@ Working version
   Unix.SO_ERROR.
   (Nicolás Ojeda Bär, review by Damien Doligez)
 
-- #10986: Add sscanf_opt, bscanf_opt and scanf_opt to the Scanf module.
-  (Nicolás Ojeda Bär, review by Florian Angeletti)
+- #10986: Add Scqnf.sscanf_opt, Scanf.bscanf_opt and Scanf.scanf_opt.
+  (Nicolás Ojeda Bär, review by Florian Angeletti and Gabriel Scherer)
 
 ### Other libraries:
 

--- a/stdlib/scanf.mli
+++ b/stdlib/scanf.mli
@@ -253,7 +253,7 @@ val bscanf : Scanning.in_channel -> ('a, 'b, 'c, 'd) scanner
 val bscanf_opt : Scanning.in_channel -> ('a, 'b, 'c, 'd) scanner_opt
 (** Same as {!Scanf.bscanf}, but returns [None] in case of scanning failure.
 
-    @since 5.01.0 *)
+    @since 5.00.0 *)
 
 (** {1 Format string description} *)
 
@@ -474,7 +474,7 @@ val sscanf : string -> ('a, 'b, 'c, 'd) scanner
 val sscanf_opt : string -> ('a, 'b, 'c, 'd) scanner_opt
 (** Same as {!Scanf.sscanf}, but returns [None] in case of scanning failure.
 
-    @since 5.01.0 *)
+    @since 5.00.0 *)
 
 val scanf : ('a, 'b, 'c, 'd) scanner
 (** Same as {!Scanf.bscanf}, but reads from the predefined formatted input
@@ -484,7 +484,7 @@ val scanf : ('a, 'b, 'c, 'd) scanner
 val scanf_opt : ('a, 'b, 'c, 'd) scanner_opt
 (** Same as {!Scanf.scanf}, but returns [None] in case of scanning failure.
 
-    @since 5.01.0 *)
+    @since 5.00.0 *)
 
 val kscanf :
   Scanning.in_channel -> (Scanning.in_channel -> exn -> 'd) ->

--- a/stdlib/scanf.mli
+++ b/stdlib/scanf.mli
@@ -223,6 +223,9 @@ type ('a, 'b, 'c, 'd) scanner =
     @since 3.10.0
 *)
 
+type ('a, 'b, 'c, 'd) scanner_opt =
+     ('a, Scanning.in_channel, 'b, 'c, 'a -> 'd option, 'd) format6 -> 'c
+
 exception Scan_failure of string
 (** When the input can not be read according to the format string
     specification, formatted input functions typically raise exception
@@ -246,6 +249,11 @@ val bscanf : Scanning.in_channel -> ('a, 'b, 'c, 'd) scanner
     argument corresponding to the [%r] conversions specified in the format
     string.
 *)
+
+val bscanf_opt : Scanning.in_channel -> ('a, 'b, 'c, 'd) scanner_opt
+(** Same as {!Scanf.bscanf}, but returns [None] in case of scanning failure.
+
+    @since 5.01.0 *)
 
 (** {1 Format string description} *)
 
@@ -463,10 +471,20 @@ val bscanf : Scanning.in_channel -> ('a, 'b, 'c, 'd) scanner
 val sscanf : string -> ('a, 'b, 'c, 'd) scanner
 (** Same as {!Scanf.bscanf}, but reads from the given string. *)
 
+val sscanf_opt : string -> ('a, 'b, 'c, 'd) scanner_opt
+(** Same as {!Scanf.sscanf}, but returns [None] in case of scanning failure.
+
+    @since 5.01.0 *)
+
 val scanf : ('a, 'b, 'c, 'd) scanner
 (** Same as {!Scanf.bscanf}, but reads from the predefined formatted input
     channel {!Scanf.Scanning.stdin} that is connected to {!Stdlib.stdin}.
 *)
+
+val scanf_opt : ('a, 'b, 'c, 'd) scanner_opt
+(** Same as {!Scanf.scanf}, but returns [None] in case of scanning failure.
+
+    @since 5.01.0 *)
 
 val kscanf :
   Scanning.in_channel -> (Scanning.in_channel -> exn -> 'd) ->

--- a/stdlib/scanf.mli
+++ b/stdlib/scanf.mli
@@ -253,7 +253,7 @@ val bscanf : Scanning.in_channel -> ('a, 'b, 'c, 'd) scanner
 val bscanf_opt : Scanning.in_channel -> ('a, 'b, 'c, 'd) scanner_opt
 (** Same as {!Scanf.bscanf}, but returns [None] in case of scanning failure.
 
-    @since 5.00.0 *)
+    @since 5.0 *)
 
 (** {1 Format string description} *)
 
@@ -474,7 +474,7 @@ val sscanf : string -> ('a, 'b, 'c, 'd) scanner
 val sscanf_opt : string -> ('a, 'b, 'c, 'd) scanner_opt
 (** Same as {!Scanf.sscanf}, but returns [None] in case of scanning failure.
 
-    @since 5.00.0 *)
+    @since 5.0 *)
 
 val scanf : ('a, 'b, 'c, 'd) scanner
 (** Same as {!Scanf.bscanf}, but reads from the predefined formatted input
@@ -484,7 +484,7 @@ val scanf : ('a, 'b, 'c, 'd) scanner
 val scanf_opt : ('a, 'b, 'c, 'd) scanner_opt
 (** Same as {!Scanf.scanf}, but returns [None] in case of scanning failure.
 
-    @since 5.00.0 *)
+    @since 5.0 *)
 
 val kscanf :
   Scanning.in_channel -> (Scanning.in_channel -> exn -> 'd) ->

--- a/testsuite/tests/lib-scanf/tscanf.ml
+++ b/testsuite/tests/lib-scanf/tscanf.ml
@@ -1562,5 +1562,6 @@ let test62 () =
   sscanf_opt "Hello" "%d" id = None &&
   sscanf_opt "" "%d" id = None &&
   sscanf_opt "Hello 123" "%s %d" (fun s n -> s, n) = Some ("Hello", 123) &&
-  sscanf_opt "Hello 123" "%s %r" (fun ib -> Scanf.bscanf_opt ib "%d" Fun.id) (fun s n -> s, n) = Some ("Hello", Some 123)
+  sscanf_opt "Hello 123" "%s %r" (fun ib -> Scanf.bscanf_opt ib "%d" Fun.id) (fun s n -> s, n) = Some ("Hello", Some 123) &&
+  sscanf_opt "Hello world" "%s %r" (fun ib -> Scanf.bscanf_opt ib "%d" Fun.id) (fun s n -> s, n) = None
 ;;

--- a/testsuite/tests/lib-scanf/tscanf.ml
+++ b/testsuite/tests/lib-scanf/tscanf.ml
@@ -1555,3 +1555,12 @@ let test61 () =
 
 test (test61 ())
 ;;
+
+(* Tests for the option-returning variants *)
+let test62 () =
+  sscanf_opt "Hello" "%s" id = Some "Hello" &&
+  sscanf_opt "Hello" "%d" id = None &&
+  sscanf_opt "" "%d" id = None &&
+  sscanf_opt "Hello 123" "%s %d" (fun s n -> s, n) = Some ("Hello", 123) &&
+  sscanf_opt "Hello 123" "%s %r" (fun ib -> Scanf.bscanf_opt ib "%d" Fun.id) (fun s n -> s, n) = Some ("Hello", Some 123)
+;;


### PR DESCRIPTION
This PR adds option-returning variants to `Scanf.sscanf` and friends. This function can raise no fewer than 4 exceptions, three of which correspond to scanning failure. The new variants return `None` in this case. `Invalid_argument` (corresponding to an invalid format string) continues to be raised, as usual.

Tests will be added in due course, assuming the proposal is well-received. **EDIT:** Some tests have been added.

Not sure that the type signature (using the new `_ scanner_opt`) is the most efficient one: I was forced to add an extra type variable, can this be avoided? Suggestions welcome. **EDIT:** The signature has been fixed.