### PR TITLE
Readability improvements around instance_constructor

### DIFF
--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -1189,12 +1189,16 @@ let existential_name cstr ty =
   | Tvar (Some name) -> "$" ^ cstr.cstr_name ^ "_'" ^ name
   | _ -> "$" ^ cstr.cstr_name
 
-let instance_constructor ?in_pattern cstr =
+type existential_treatment =
+  | Keep_existentials_flexible
+  | Make_existentials_abstract of { env: Env.t ref; scope: int }
+
+let instance_constructor existential_treatment cstr =
   For_copy.with_scope (fun scope ->
     let copy_existential =
-      match in_pattern with
-      | None -> copy scope
-      | Some (env, fresh_constr_scope) ->
+      match existential_treatment with
+      | Keep_existentials_flexible -> copy scope
+      | Make_existentials_abstract {env; scope = fresh_constr_scope} ->
           fun existential ->
             let decl = new_local_type () in
             let name = existential_name cstr existential in

--- a/typing/ctype.mli
+++ b/typing/ctype.mli
@@ -150,8 +150,12 @@ val new_local_type:
         ?loc:Location.t ->
         ?manifest_and_scope:(type_expr * int) -> unit -> type_declaration
 val existential_name: constructor_description -> type_expr -> string
-val instance_constructor:
-        ?in_pattern:Env.t ref * int ->
+
+type existential_treatment =
+  | Keep_existentials_flexible
+  | Make_existentials_abstract of { env: Env.t ref; scope: int }
+
+val instance_constructor: existential_treatment ->
         constructor_description -> type_expr list * type_expr * type_expr list
         (* Same, for a constructor. Also returns existentials. *)
 val instance_parameterized_type:

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -559,7 +559,9 @@ and build_as_type_aux ~refine (env : Env.t ref) p =
         vto <> None (* be lazy and keep the type for node constraints *) in
       if keep then p.pat_type else
       let tyl = List.map (build_as_type env) pl in
-      let ty_args, ty_res, _ = instance_constructor cstr in
+      let ty_args, ty_res, _ =
+        instance_constructor Keep_existentials_flexible cstr
+      in
       List.iter2 (fun (p,ty) -> unify_pat ~refine env {p with pat_type = ty})
         (List.combine pl tyl) ty_args;
       ty_res
@@ -700,17 +702,25 @@ let solve_Ppat_construct ~refine env loc constr no_existentials
     unify_pat_types_return_equated_pairs ~refine loc env ty_res expected_ty
   in
   let expansion_scope = get_gadt_equations_level () in
+  let default_existential_treatment =
+    Make_existentials_abstract { env; scope = expansion_scope }
+  in
   let ty_args, ty_res, equated_types, existential_ctyp =
     match existential_styp with
       None ->
         let ty_args, ty_res, _ =
-          instance_constructor ~in_pattern:(env, expansion_scope) constr in
+          instance_constructor default_existential_treatment constr
+        in
         ty_args, ty_res, unify_res ty_res, None
     | Some (name_list, sty) ->
-        let in_pattern =
-          if name_list = [] then Some (env, expansion_scope) else None in
+        let existential_treatment =
+          if name_list = []
+          then default_existential_treatment
+          else Keep_existentials_flexible
+        in
         let ty_args, ty_res, ty_ex =
-          instance_constructor ?in_pattern constr in
+          instance_constructor existential_treatment constr
+        in
         let equated_types = unify_res ty_res in
         let ty_args, existential_ctyp =
           solve_constructor_annotation env name_list sty ty_args ty_ex in
@@ -4730,7 +4740,9 @@ and type_construct env loc lid sarg ty_expected_explained attrs =
                             (lid.txt, constr.cstr_arity, List.length sargs)));
   let separate = !Clflags.principal || Env.has_local_constraints env in
   if separate then (begin_def (); begin_def ());
-  let (ty_args, ty_res, _) = instance_constructor constr in
+  let (ty_args, ty_res, _) =
+    instance_constructor Keep_existentials_flexible constr
+  in
   let texp =
     re {
       exp_desc = Texp_construct(lid, constr, []);

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -702,20 +702,18 @@ let solve_Ppat_construct ~refine env loc constr no_existentials
     unify_pat_types_return_equated_pairs ~refine loc env ty_res expected_ty
   in
   let expansion_scope = get_gadt_equations_level () in
-  let default_existential_treatment =
-    Make_existentials_abstract { env; scope = expansion_scope }
-  in
   let ty_args, ty_res, equated_types, existential_ctyp =
     match existential_styp with
       None ->
         let ty_args, ty_res, _ =
-          instance_constructor default_existential_treatment constr
+          instance_constructor
+            (Make_existentials_abstract { env; scope = expansion_scope }) constr
         in
         ty_args, ty_res, unify_res ty_res, None
     | Some (name_list, sty) ->
         let existential_treatment =
           if name_list = [] then
-            default_existential_treatment
+            Make_existentials_abstract { env; scope = expansion_scope }
           else
             (* we will unify them (in solve_constructor_annotation) with the
                local types provided by the user *)

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -714,9 +714,12 @@ let solve_Ppat_construct ~refine env loc constr no_existentials
         ty_args, ty_res, unify_res ty_res, None
     | Some (name_list, sty) ->
         let existential_treatment =
-          if name_list = []
-          then default_existential_treatment
-          else Keep_existentials_flexible
+          if name_list = [] then
+            default_existential_treatment
+          else
+            (* we will unify them (in solve_constructor_annotation) with the
+               local types provided by the user *)
+            Keep_existentials_flexible
         in
         let ty_args, ty_res, ty_ex =
           instance_constructor existential_treatment constr

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -1003,7 +1003,9 @@ let transl_extension_constructor ~scope env type_path type_params
           if priv = Public then Env.Exported else Env.Exported_private
         in
         let cdescr = Env.lookup_constructor ~loc:lid.loc usage lid.txt env in
-        let (args, cstr_res, _ex) = Ctype.instance_constructor cdescr in
+        let (args, cstr_res, _ex) =
+          Ctype.instance_constructor Keep_existentials_flexible cdescr
+        in
         let res, ret_type =
           if cdescr.cstr_generalized then
             let params = Ctype.instance_list type_params in


### PR DESCRIPTION
Sorry for the highly controversial PR which is neither related to multicore, nor fixing any bug.

As I said earlier, I was a bit confused (I'm easily confused) when trying to review #10959. The parts which confused me are actually related to #9584.
Anyway, I'm proposing 3 commits which shouldn't change at all the observable behavior of the compiler, but which make things slightly more readable in my opinion:
- 7d8a99b : when reading `instance_constructor` without being careful, it seemed like we were sometimes (when `in_pattern` is `Some`) turning existentials into local types, then taking a different instance of the existentials, and returning that, ignoring the abstract types.  
That's of course not what happens: everything lives in the same "copy scope", so the second instance actually encounter a `Tsubst` nodes and gets the local type from before. It was a bit too subtle for me though. So I changed the code to only take one obvious instance of the existentials.  
(That's of course not quite true: another instance will be taken when getting a copy of `ty_args` ... so I'll admit that it's debatable that this commit actually makes things more readable)
- c8404b1 and 3eba0b6 : I'm a lot more confident about the value of those! The criterion for turning existentials into local types was previously to be typing a pattern, justifying the `in_pattern` argument to `instance_constructor`. Now it's to be typing a pattern where the existentials haven't been explicitely named, so I feel justified in changing `in_pattern` for something indicating which behavior to adopt, rather than which context we were being called from a few versions of OCaml ago.

Please forgive me.