### PR TITLE
Provide a default definition of cpu_relax

### DIFF
--- a/runtime/caml/platform.h
+++ b/runtime/caml/platform.h
@@ -28,17 +28,22 @@
 #define MAP_ANONYMOUS MAP_ANON
 #endif
 
-/* Loads and stores with acquire and release semantics respectively */
+/* Hint for busy-waiting loops */
 
 Caml_inline void cpu_relax() {
+#ifdef __GNUC__
 #if defined(__x86_64__) || defined(__i386__)
   asm volatile("pause" ::: "memory");
 #elif defined(__aarch64__)
   asm volatile ("yield" ::: "memory");
 #else
-  #warning "cpu_relax() undefined for this architecture!"
+  /* Just a compiler barrier */
+  asm volatile ("" ::: "memory");
+#endif
 #endif
 }
+
+/* Loads and stores with acquire and release semantics respectively */
 
 Caml_inline uintnat atomic_load_acq(atomic_uintnat* p) {
   return atomic_load_explicit(p, memory_order_acquire);


### PR DESCRIPTION
Currently, the trunk doesn't compile on platforms other than x86 and AArch64 because `cpu_relax` is not defined.  This makes our friends at IBM feel sad, and my leftover 32-bit Raspberry Pi  feel useless.

This PR provides a default definition of `cpu_relax` as a plain compiler barrier, just like in the Linux kernel.  It also handles the case where GNU inline asm is not available.
