### PR TITLE
Use zstd for CI artifacts upload and download

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,11 +18,11 @@ jobs:
           MAKE_ARG=-j bash -xe tools/ci/actions/runner.sh build
       - name: Prepare Artifact
         run: |
-          tar -czf /tmp/sources.tar.gz .
+          tar --zstd -cf /tmp/sources.tar.zstd .
       - uses: actions/upload-artifact@v2
         with:
           name: compiler
-          path: /tmp/sources.tar.gz
+          path: /tmp/sources.tar.zstd
           retention-days: 1
 
   build-misc:
@@ -80,7 +80,7 @@ jobs:
           name: compiler
       - name: Unpack Artifact
         run: |
-          tar xf sources.tar.gz
+          tar --zstd -xf sources.tar.zstd
       - name: Run the testsuite
         if: ${{ matrix.id == 'normal' }}
         run: |


### PR DESCRIPTION
This PR introduce the use of zstd to compress and decompress the build artifacts.
From my initial runs it seems to be performing vastly faster and allows us to cut a minute and a half of CI run.