### PR TITLE
[minor] fix multicore merge error in minor_gc.c:reallloc_generic_table

### DIFF
--- a/runtime/minor_gc.c
+++ b/runtime/minor_gc.c
@@ -805,7 +805,8 @@ CAMLexport value caml_check_urgent_gc (value extra_root)
 
 static void realloc_generic_table
 (struct generic_table *tbl, asize_t element_size,
- char * msg_intr_int, char *msg_threshold, char *msg_growing, char *msg_error)
+ ev_gc_counter ev_counter_name,
+ char *msg_threshold, char *msg_growing, char *msg_error)
 {
   CAMLassert (tbl->ptr == tbl->limit);
   CAMLassert (tbl->limit <= tbl->end);
@@ -815,6 +816,7 @@ static void realloc_generic_table
     alloc_generic_table (tbl, Caml_state->minor_heap_wsz / 8, 256,
                          element_size);
   }else if (tbl->limit == tbl->threshold){
+    CAML_EV_COUNTER (ev_counter_name, 1);
     caml_gc_message (0x08, msg_threshold, 0);
     tbl->limit = tbl->end;
     caml_request_minor_gc ();
@@ -840,7 +842,7 @@ void caml_realloc_ref_table (struct caml_ref_table *tbl)
 {
   realloc_generic_table
     ((struct generic_table *) tbl, sizeof (value *),
-     "request_minor/realloc_ref_table@",
+     EV_C_REQUEST_MINOR_REALLOC_REF_TABLE,
      "ref_table threshold crossed\n",
      "Growing ref_table to %" ARCH_INTNAT_PRINTF_FORMAT "dk bytes\n",
      "ref_table overflow");
@@ -850,7 +852,7 @@ void caml_realloc_ephe_ref_table (struct caml_ephe_ref_table *tbl)
 {
   realloc_generic_table
     ((struct generic_table *) tbl, sizeof (struct caml_ephe_ref_elt),
-     "request_minor/realloc_ephe_ref_table@",
+     EV_C_REQUEST_MINOR_REALLOC_EPHE_REF_TABLE,
      "ephe_ref_table threshold crossed\n",
      "Growing ephe_ref_table to %" ARCH_INTNAT_PRINTF_FORMAT "dk bytes\n",
      "ephe_ref_table overflow");
@@ -860,7 +862,7 @@ void caml_realloc_custom_table (struct caml_custom_table *tbl)
 {
   realloc_generic_table
     ((struct generic_table *) tbl, sizeof (struct caml_custom_elt),
-     "request_minor/realloc_custom_table@",
+     EV_C_REQUEST_MINOR_REALLOC_CUSTOM_TABLE,
      "custom_table threshold crossed\n",
      "Growing custom_table to %" ARCH_INTNAT_PRINTF_FORMAT "dk bytes\n",
      "custom_table overflow");


### PR DESCRIPTION
`realloc_generic_table` from minor_gc.c has the following prototype in trunk:

```
void realloc_generic_table (struct generic_table *tbl, asize_t element_size,
 char * msg_intr_int, char *msg_threshold, char *msg_growing, char *msg_error);
```

The `char*` arguments correspond to strings passed to
`caml_gc_message` and other GC-monitoring machinery at various point
during the resize.

The `msg_intr_int` argument comes from old version of OCaml (up to
4.10 included) which handle it by calling the CAML_INSTR_INT macro.

Since the Eventlog merge before 4.11, the `msg_intr_int` parameter was
replaced by an `ev_counter_name`
parameter (see commit b7f0494df52f758f88b723b881a606660f4672cc)
handled by calling the CAML_EV_COUNTER macro.

A Multicore merge commit from March
2021 ( a9d9d03d7de7f561fbba5c75f307c186745553bd ) mistakenly got rid
of the `ev_counter_name` parameter, and replaced it with
`msg_intr_int` again, but this parameter is now
unused (the CAML_INSTR_INT macro does not exist anymore).

The present commit reverts the code to the pre-multicore-merge state.

(cc @Engil @ctk21)