### PR TITLE
Explain mapping between OCaml memory model and C

### DIFF
--- a/runtime/memory.c
+++ b/runtime/memory.c
@@ -36,6 +36,8 @@
 
 /* Note [MM]: Enforcing the memory model.
 
+   FIXME: rewrite this
+
    Multicore OCaml implements the memory consistency model defined in
 
      Bounding Data Races in Space and Time (PLDI '18)


### PR DESCRIPTION
Evidently, the huge comment in `memory.c` isn't explaining much, and the `acquire; release` code sequence in `caml_modify` continues to mystify. Here's an attempt at a better explanation of the relationship between the OCaml memory model and C: if this one makes sense, I'll update the comment in `memory.c`. I hope this answers [@gadmm's questions](https://github.com/ocaml/ocaml/pull/10831#discussion_r782394362) and sheds some light on the [armv8 mappings](https://github.com/ocaml/ocaml/pull/10972).

## OCaml and C memory models

LIke C, the OCaml memory model distinguishes atomic and nonatomic memory accesses, so the natural approach is to map OCaml atomics to C SC atomics (`memory_order_seq_cst`, the default) and OCaml nonatomics to C relaxed atomics (`memory_order_relaxed`). (We cannot use C nonatomic accesses instead of relaxed here, because we want well-defined semantics even in the presence of races, which C nonatomics do not provide).

However, this simple mapping does not work, because OCaml's memory model is stronger than what this mapping to C provides in two particular ways, described below:

### 1. Stronger atomic happens-before

Both C and OCaml define _happens-before_, a partial order on events of a program which defines which orderings can be relied upon for synchronisation. For atomics, the relation is stronger in OCaml: with C (SC) atomics, happens-before only arises between a write and a read that reads from it. In particular, if two domains/threads both write to an atomic variable, in OCaml one of the writes definitely happens-before the other, which is not true in C, leading to some counterintuitive examples.

<details>
<summary>Example</summary>

Below,  `p` is an `int Atomic.t` and `q` is an `int ref`, both initially 0:

```ocaml
(* domain 1 *)
q := 1;
Atomic.set p 1;
Printf.printf "p=%d\n" (Atomic.get p)

(* domain 2 *)
Atomic.set p 2;
Printf.printf "q=%d\n" !q
```

Is it possible for this to print `p=2` and `q=0`? In OCaml, no. If it prints `p=2`, then `Atomic.set p 2` must have occurred right between `Atomic.set p 1` and `Atomic.get p`, which means that the `q := 1` happens-before the `set p 1` which happens-before the `set p 2`, which happens-before the `!q`, so we must see `q=1`.

In C, with SC atomics for `Atomic` and relaxed atomics for `ref`, it can print `p=2` and `q=0`. The `q := 1` happens-before `set p 1`, which is SC-before `set p 2`, which happens-before `!q`, but in C11 SC-before between two SC writes does not induce happens-before, so `q := 1` does *not* happen-before `!q` and `!q` may therefore return `0`.
</details>

The fix is to map an OCaml atomic store not to a C atomic store but to a C atomic _exchange_. Each atomic exchange reads from the previous one (even if it discards the answer), and this additional read is enough to induce happens-before in C, as the OCaml memory model requires.

### 2. Nonatomic reads are consistent with atomic operations

In C, the SC order (the total order on all SC atomic operations) is required to be consistent with happens-before, and the relaxed atomic reads-from relation (which specifies which write each read gets its value from) is also required to be consistent with happens-before. However, the SC order and the relaxed atomic reads-from relation are not required to be consistent with _each other_, which leads to weird effects where relaxed atomics reads can get their values from writes that are, by the SC order, in the future.

<details>
<summary>Example</summary>

Again, `p` is an `int Atomic.t` while `q` is an `int ref`.

```ocaml
(* domain 1 *)
Atomic.set p 1;
q := 1

(* domain 2 *)
let x = !q in
let y = Atomic.get p in
Printf.printf "x=%d y=%d\n" x y
```

Is it possible to see this print "x=1 y=0"? In OCaml, the answer is no. Consider which occurs earlier in the trace, the `Atomic.set p 1` or the `Atomic.get p`. If the `set` is earlier, we will see `y=1`, while if the `get` is earlier then the `!q` cannot see the `q := 1`, so we will see `x=0`.

However, in C11 (with SC for `Atomic.t` and relaxed for `ref`), the outcome `x=1 y=0` is possible. In C11 terms, the `Atomic.set` happens-before the `q := 1`, which is read-from by the `!q`, which happens-before the `Atomic.get`, which is SC-before the `Atomic.set`. This cycle of reads-from, SC-before and happens-before is permitted by the model, and actually occurs on e.g. ARM.
</details>

In OCaml, the nonatomic reads-from, happens-before and the order on atomics are all required to be consistent with each other. (It is this property, more than anything else, that makes the step-by-step operational semantics possible).

Achieving this is a bit tricky in C. The easiest way is to use release-acquire rather than relaxed atomics for OCaml nonatomics, as reads-from between release-acquire atomics forms part of happens-before in C, and must therefore be consistent with the SC order.

<br/>

**Mapping of operations to C**:
| OCaml operation | C operation |
|---|---:|
| Atomic load | `atomic_load_explicit(..., memory_order_seq_cst)`|
| Atomic store | `atomic_exchange_explicit(..., memory_order_seq_cst)` |
| Nonatomic load | `atomic_load_explicit(..., memory_order_acquire)` |
| Nonatomic store | `atomic_store_explicit(..., memory_order_release)` |

<br />

## Optimising the mapping, C version

The mapping above is correct but extremely costly on non-x86 platforms. (This model was benchmarked in the PLDI paper under the name "SRA", with 3x slowdowns on some benchmarks).

Much of the cost is because nonatomic loads require a fence due to the use of `memory_order_acquire`. However, this is much stronger than we need: OCaml places no ordering constraints between subsequent nonatomic loads, but `memory_order_acquire` on each load forces them all to go in order.

C allows explicit fences to replace memory ordering on operations, allowing one to turn:
```c
val = atomic_load_explicit(..., memory_order_acquire);
```
into:
```c
val = atomic_load_explicit(..., memory_order_relaxed);
atomic_thread_fence(memory_order_acquire);
```
Since we are only using `acquire` semantics to maintain consistency of nonatomic reads-from and atomic ordering, we only need this fence sometime before the next event that can be read-from or is atomic, that is, before the next nonatomic write or atomic operation. In fact, we can always delay the fence until the next such operation, giving us the optimised mapping below:

<br>

**Optimised mapping of operations to C**:
| OCaml operation | C operation |
|---|---:|
| Atomic load | `atomic_thread_fence(memory_order_acquire);` <br> `atomic_load_explicit(..., memory_order_seq_cst);`|
| Atomic store | `atomic_thread_fence(memory_order_acquire);` <br> `atomic_exchange_explicit(..., memory_order_seq_cst);` |
| Nonatomic load | `atomic_load_explicit(..., memory_order_relaxed);` |
| Nonatomic store | `atomic_thread_fence(memory_order_acquire);` <br> `atomic_store_explicit(..., memory_order_release);` |

<br/>

## Optimising the mapping, ARMv8 version

I think the above is about as far as we can go while remaining strictly within the letter of the C memory model. However, when compiling to ARMv8, better instruction sequences are possible than C compilers will produce with the above mapping.

The instruction sequences produced by the above on C compilers I've tried are:

| OCaml operation | ARMv8 operation |
|---|---:|
| Atomic load | `dmb ishld; ldar`|
| Atomic store | `dmb ishld; L: ldaxr; stlxr; cbnz L` |
| Nonatomic load | `ldr` |
| Nonatomic store | `dmb ishld; stlr` |

First, the `dmb ishld` in atomic stores does nothing: `dmb ishld` enforces ordering with respect to prior loads, which is subsumed by `stlxr` which enforced ordering with respect to prior _everything_. (The C compiler should really be able to elide this one, I think).

Second, the `dmb ishld; stlr` sequence is overly conservative. We need to ensure that nonatomic stores are ordered after prior atomic operations and nonatomic loads. (More precisely, we need happens-before between operations that synchronise with a prior atomic operator / write to a prior atomic load, and operations that read from this nonatomic store). Strictly, in C, the only way to do this is for this to be a release store (hence `stlr`), but the ARMv8 model is more forgiving and provides many way to ensure this ordering.

One of them is to use `dmb ishld` and `dmb ishst` and a plain `str` store. `dmb ishld` provides ordering with respect to prior reads (covering both nonatomic loads and atomic ones), while `dmb ishst` provides ordering with respect to prior writes. Since we only need the ordering with respect to prior _atomic_ writes, we can place the `dmb ishst` *after* each atomic write rather than before nonatomic writes, yielding the optimised compilation model from the PLDI paper:

| OCaml operation | ARMv8 operation |
|---|---:|
| Atomic load | `dmb ishld; ldar`|
| Atomic store | `L: ldaxr; stlxr; cbnz L; dmb st` |
| Nonatomic load | `ldr` |
| Nonatomic store | `dmb ishld; str` |

This is the model adopted in #10972.

There is one additional wrinkle, though, not covered by the discussion here or the PLDI paper: when there is a data race involving a newly-allocated object, then we must guarantee that all reads that see that object at least see the initialisation of that object. This can be done by upgrading the nonatomic store to an `stlr` or a `dmb ishst; str` when it might make a newly-allocated object visible, and relying on some slightly tricky reasoning about address dependencies on the reading end. This issue is being discussed separately in #10992.


<br />

## Proposed code changes

  - Since #10972 adopts the optimised ARMv8 model above, we must ensure that there is a suitable barrier after atomic stores. (The memory model requires ordering between atomic stores and subsequent nonatomic stores, and if we're using the optimised version of writes that only have `dmb ishld` then we need to provide this ordering on atomic stores. This is the inconsistency [@gadmm noticed on #10831](https://github.com/ocaml/ocaml/pull/10831#discussion_r782394362) - the code that's currently there is correct in isolation but requires an extra fence if used with optimised ARM stores).

  - The barriers on `caml_modify` are only necessary to order prior initialisations, nonatomic loads, and atomic operations. In particular, in a sequence of `caml_modify`, only the first one needs barriers. Perhaps we should provide optimised versions of blit and fill, for use with arrays.

  - `caml_modify` is implemented with an acquire fence / release store. As described above, on armv8 the release store subsumes the acquire fence. While the fence is necessary according to a strict reading of the C model, I'm not aware of any architecture where it actually does anything in this situation. We should at least run benchmarks with it commented out, to see if it has a noticeable cost.

  - I'll update the massive block comment in `memory.c` with something hopefully more readable.