### PR TITLE
Do not generate assignment to non-integer fields in Cmm and Mach.

### DIFF
--- a/asmcomp/amd64/emit.mlp
+++ b/asmcomp/amd64/emit.mlp
@@ -596,9 +596,10 @@ let emit_instr env fallthrough i =
       | Double ->
           I.movsd (addressing addressing_mode REAL8 i 0) dest
       end
-  | Lop(Istore(chunk, addr, _)) ->
+  | Lop(Istore(chunk, addr, is_assignment)) ->
       begin match chunk with
       | Word_int | Word_val ->
+          assert (not (chunk = Word_val && is_assignment));
           I.mov (arg i 0) (addressing addr QWORD i 1)
       | Byte_unsigned | Byte_signed ->
           I.mov (arg8 i 0) (addressing addr BYTE i 1)

--- a/asmcomp/amd64/selection.ml
+++ b/asmcomp/amd64/selection.ml
@@ -174,14 +174,14 @@ method select_addressing _chunk exp =
     | Ascaledadd(e1, e2, scale) ->
         (Iindexed2scaled(scale, d), Ctuple[e1; e2])
 
-method! select_store is_assign addr exp =
+method! select_store chunk is_assign addr exp =
   match exp with
     Cconst_int (n, _dbg) when is_immediate n ->
       (Ispecific(Istore_int(Nativeint.of_int n, addr, is_assign)), Ctuple [])
   | (Cconst_natint (n, _dbg)) when is_immediate_natint n ->
       (Ispecific(Istore_int(n, addr, is_assign)), Ctuple [])
   | _ ->
-      super#select_store is_assign addr exp
+      super#select_store chunk is_assign addr exp
 
 method! select_operation op args dbg =
   match op with

--- a/asmcomp/cmm_helpers.ml
+++ b/asmcomp/cmm_helpers.ml
@@ -640,9 +640,6 @@ let get_field_gen mutability ptr n dbg =
   Cop(Cload {memory_chunk=Word_val; mutability; is_atomic=false},
       [field_address ptr n dbg], dbg)
 
-let set_field ptr n newval init dbg =
-  Cop(Cstore (Word_val, init), [field_address ptr n dbg; newval], dbg)
-
 let non_profinfo_mask =
   if Config.profinfo
   then (1 lsl (64 - Config.profinfo_width)) - 1
@@ -2222,7 +2219,8 @@ let setfield n ptr init arg1 arg2 dbg =
              [field_address arg1 n dbg; arg2],
              dbg))
   | Simple ->
-      return_unit dbg (set_field arg1 n arg2 init dbg)
+      return_unit dbg
+        (Cop(Cstore (Word_int, init), [field_address arg1 n dbg; arg2], dbg))
 
 let setfloatfield n init arg1 arg2 dbg =
   return_unit dbg (

--- a/asmcomp/cmm_helpers.mli
+++ b/asmcomp/cmm_helpers.mli
@@ -204,12 +204,6 @@ val field_address : expression -> int -> Debuginfo.t -> expression
 val get_field_gen :
   Asttypes.mutable_flag -> expression -> int -> Debuginfo.t -> expression
 
-(** [set_field ptr n newval init dbg] returns an expression for setting the
-    [n]th field of the block pointed to by [ptr] to [newval] *)
-val set_field :
-  expression -> int -> expression -> Lambda.initialization_or_assignment ->
-  Debuginfo.t -> expression
-
 (** Load a block's header *)
 val get_header : expression -> Debuginfo.t -> expression
 

--- a/asmcomp/i386/selection.ml
+++ b/asmcomp/i386/selection.ml
@@ -196,7 +196,7 @@ method select_addressing _chunk exp =
   | (Ascaledadd(e1, e2, scale), d) ->
       (Iindexed2scaled(scale, d), Ctuple[e1; e2])
 
-method! select_store is_assign addr exp =
+method! select_store chunk is_assign addr exp =
   match exp with
     Cconst_int (n, _) ->
       (Ispecific(Istore_int(Nativeint.of_int n, addr, is_assign)), Ctuple [])
@@ -205,7 +205,7 @@ method! select_store is_assign addr exp =
   | Cconst_symbol (s, _) ->
       (Ispecific(Istore_symbol(s, addr, is_assign)), Ctuple [])
   | _ ->
-      super#select_store is_assign addr exp
+      super#select_store chunk is_assign addr exp
 
 method! select_operation op args dbg =
   match op with

--- a/asmcomp/selectgen.mli
+++ b/asmcomp/selectgen.mli
@@ -85,8 +85,8 @@ class virtual selector_generic : object
   method select_condition : Cmm.expression -> Mach.test * Cmm.expression
     (* Can be overridden to deal with special test instructions *)
   method select_store :
-    bool -> Arch.addressing_mode -> Cmm.expression ->
-                                         Mach.operation * Cmm.expression
+    Cmm.memory_chunk -> bool -> Arch.addressing_mode -> Cmm.expression ->
+    Mach.operation * Cmm.expression
     (* Can be overridden to deal with special store constant instructions *)
   method regs_for : Cmm.machtype -> Reg.t array
     (* Return an array of fresh registers of the given type.

--- a/testsuite/tools/parsecmm.mly
+++ b/testsuite/tools/parsecmm.mly
@@ -280,7 +280,7 @@ expr:
           Debuginfo.none) }
   | LPAREN ADDRASET expr expr expr RPAREN
       { let open Lambda in
-        Cop(Cstore (Word_val, Assignment),
+        Cop(Cstore (Word_int, Assignment),
             [access_array $3 $4 Arch.size_addr; $5], Debuginfo.none) }
   | LPAREN INTASET expr expr expr RPAREN
       { let open Lambda in


### PR DESCRIPTION
Non-initialising stores i.e, assignments to object fields that may hold pointers must go through `caml_modify` for the snapshot-at-the-beginning barrier and the memory model. Indeed, the compiler emits calls to `caml_modify` for these when Clambda is translated to Cmm.

However, the codegen may still emit assignments to non-integer fields by conflating `Word_int` and `Word_val`. This PR ensures that any such cases are not generated, and adds assertions to catch such cases at compile time.