### PR TITLE
Header cleanup: mlvalues.h include domain_state.h once & minimise cross-header includes

### DIFF
--- a/runtime/callback.c
+++ b/runtime/callback.c
@@ -18,6 +18,7 @@
 /* Callbacks from C to OCaml */
 
 #include <string.h>
+#include "caml/alloc.h"
 #include "caml/callback.h"
 #include "caml/codefrag.h"
 #include "caml/fail.h"

--- a/runtime/caml/memory.h
+++ b/runtime/caml/memory.h
@@ -27,7 +27,6 @@
 #include "domain.h"
 #include "misc.h"
 #include "mlvalues.h"
-#include "alloc.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/runtime/caml/mlvalues.h
+++ b/runtime/caml/mlvalues.h
@@ -19,14 +19,6 @@
 #include "config.h"
 #include "misc.h"
 
-/* Needed here for domain_state */
-typedef intnat value;
-typedef atomic_intnat atomic_value;
-typedef int32_t opcode_t;
-typedef opcode_t * code_t;
-
-#include "domain_state.h"
-
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -62,11 +54,15 @@ extern "C" {
          This is for use only by the GC.
 */
 
+typedef intnat value;
 typedef uintnat header_t;
 typedef uintnat mlsize_t;
 typedef unsigned int tag_t;             /* Actually, an unsigned char */
 typedef uintnat color_t;
 typedef uintnat mark_t;
+typedef atomic_intnat atomic_value;
+typedef int32_t opcode_t;
+typedef opcode_t * code_t;
 
 #include "domain_state.h"
 

--- a/runtime/caml/roots.h
+++ b/runtime/caml/roots.h
@@ -19,7 +19,7 @@
 #ifdef CAML_INTERNALS
 
 #include "misc.h"
-#include "memory.h"
+#include "domain.h"
 
 typedef void (*scanning_action) (void*, value, value *);
 typedef void (*scan_roots_hook) (scanning_action, void*, caml_domain_state*);

--- a/runtime/gc_ctrl.c
+++ b/runtime/gc_ctrl.c
@@ -24,6 +24,7 @@
 #include "caml/minor_gc.h"
 #include "caml/shared_heap.h"
 #include "caml/misc.h"
+#include "caml/memory.h"
 #include "caml/mlvalues.h"
 #ifdef NATIVE_CODE
 #include "caml/stack.h"
@@ -34,7 +35,6 @@
 #include "caml/globroots.h"
 #include "caml/signals.h"
 #include "caml/startup.h"
-#include "caml/domain.h"
 #include "caml/eventlog.h"
 #include "caml/fail.h"
 

--- a/runtime/globroots.c
+++ b/runtime/globroots.c
@@ -18,6 +18,7 @@
 /* Registration of global memory roots */
 
 #include "caml/mlvalues.h"
+#include "caml/memory.h"
 #include "caml/roots.h"
 #include "caml/globroots.h"
 #include "caml/skiplist.h"


### PR DESCRIPTION
This PR:
- b57640a: includes `domain_state.h` once in `mlvalues.h`; it also removes the inclusion of `domain_state.h` outside the `extern "C" {` block. 
- 38dac36: minimises cross-inclusion between headers. In particular: it removes `alloc.h` from `memory.h` which matches pre multicore; it goes for the direct `domain.h` include for `roots.h`.
