### PR TITLE
Do not use `Begin_roots` / `End_roots` in runtime

### DIFF
--- a/Changes
+++ b/Changes
@@ -42,7 +42,9 @@ Working version
 - #11010: Use strerror_r for reentrant error string conversion.
   (Anil Madhavapeddy and Xavier Leroy, review by same and Edwin Török)
 
-- #11002: Do not use Begin_roots/End_roots macros in the runtime system.
+- #11002: Do not use Begin_roots/End_roots macros in the runtime system.  Also
+  fix a missing root registration in the implementation of Unix.write on
+  Windows.
   (Nicolás Ojeda Bär, review by Xavier Leroy and David Allsopp)
 
 ### Code generation and optimizations:

--- a/Changes
+++ b/Changes
@@ -42,6 +42,9 @@ Working version
 - #11010: Use strerror_r for reentrant error string conversion.
   (Anil Madhavapeddy and Xavier Leroy, review by same and Edwin Török)
 
+- #11002: Do not use Begin_roots/End_roots macros in the runtime system.
+  (Nicolás Ojeda Bär, review by Xavier Leroy and David Allsopp)
+
 ### Code generation and optimizations:
 
 ### Standard library:

--- a/otherlibs/systhreads/st_posix.h
+++ b/otherlibs/systhreads/st_posix.h
@@ -356,19 +356,20 @@ static void st_decode_sigset(value vset, sigset_t * set)
 
 static value st_encode_sigset(sigset_t * set)
 {
-  value res = Val_int(0);
+  CAMLparam0();
+  CAMLlocal1(res);
   int i;
 
-  Begin_root(res)
-    for (i = 1; i < NSIG; i++)
-      if (sigismember(set, i) > 0) {
-        value newcons = caml_alloc_small(2, 0);
-        Field(newcons, 0) = Val_int(caml_rev_convert_signal_number(i));
-        Field(newcons, 1) = res;
-        res = newcons;
-      }
-  End_roots();
-  return res;
+  res = Val_emptylist;
+
+  for (i = 1; i < NSIG; i++)
+    if (sigismember(set, i) > 0) {
+      value newcons = caml_alloc_small(2, 0);
+      Field(newcons, 0) = Val_int(caml_rev_convert_signal_number(i));
+      Field(newcons, 1) = res;
+      res = newcons;
+    }
+  CAMLreturn(res);
 }
 
 static int sigmask_cmd[3] = { SIG_SETMASK, SIG_BLOCK, SIG_UNBLOCK };

--- a/otherlibs/systhreads/st_posix.h
+++ b/otherlibs/systhreads/st_posix.h
@@ -364,10 +364,7 @@ static value st_encode_sigset(sigset_t * set)
 
   for (i = 1; i < NSIG; i++)
     if (sigismember(set, i) > 0) {
-      value newcons = caml_alloc_small(2, 0);
-      Field(newcons, 0) = Val_int(caml_rev_convert_signal_number(i));
-      Field(newcons, 1) = res;
-      res = newcons;
+      res = caml_alloc_2(2, Val_int(caml_rev_convert_signal_number(i)), res);
     }
   CAMLreturn(res);
 }

--- a/otherlibs/systhreads/st_stubs.c
+++ b/otherlibs/systhreads/st_stubs.c
@@ -49,15 +49,9 @@
 
 /* The ML value describing a thread (heap-allocated) */
 
-struct caml_thread_descr {
-  value ident;                  /* Unique integer ID */
-  value start_closure;          /* The closure to start this thread */
-  value terminated;             /* Triggered event for thread termination */
-};
-
-#define Ident(v) (((struct caml_thread_descr *)(v))->ident)
-#define Start_closure(v) (((struct caml_thread_descr *)(v))->start_closure)
-#define Terminated(v) (((struct caml_thread_descr *)(v))->terminated)
+#define Ident(v) Field(v, 0)
+#define Start_closure(v) Field(v, 1)
+#define Terminated(v) Field(v, 2)
 
 /* The infos on threads (allocated via caml_stat_alloc()) */
 
@@ -282,10 +276,8 @@ static value caml_thread_new_descriptor(value clos)
   /* Create and initialize the termination semaphore */
   mu = caml_threadstatus_new();
   /* Create a descriptor for the new thread */
-  descr = caml_alloc_small(3, 0);
-  Ident(descr) = Val_long(atomic_fetch_add(&thread_next_id, +1));
-  Start_closure(descr) = clos;
-  Terminated(descr) = mu;
+  descr = caml_alloc_3(3, Val_long(atomic_fetch_add(&thread_next_id, +1)),
+                       clos, mu);
   CAMLreturn(descr);
 }
 

--- a/otherlibs/systhreads/st_stubs.c
+++ b/otherlibs/systhreads/st_stubs.c
@@ -276,18 +276,17 @@ static caml_thread_t caml_thread_new_info(void)
 
 static value caml_thread_new_descriptor(value clos)
 {
-  value mu = Val_unit;
+  CAMLparam1(clos);
+  CAMLlocal1(mu);
   value descr;
-  Begin_roots2 (clos, mu)
-    /* Create and initialize the termination semaphore */
-    mu = caml_threadstatus_new();
-    /* Create a descriptor for the new thread */
-    descr = caml_alloc_small(3, 0);
-    Ident(descr) = Val_long(atomic_fetch_add(&thread_next_id, +1));
-    Start_closure(descr) = clos;
-    Terminated(descr) = mu;
-  End_roots();
-  return descr;
+  /* Create and initialize the termination semaphore */
+  mu = caml_threadstatus_new();
+  /* Create a descriptor for the new thread */
+  descr = caml_alloc_small(3, 0);
+  Ident(descr) = Val_long(atomic_fetch_add(&thread_next_id, +1));
+  Start_closure(descr) = clos;
+  Terminated(descr) = mu;
+  CAMLreturn(descr);
 }
 
 /* Remove a thread info block from the list of threads.
@@ -781,14 +780,13 @@ static void caml_threadstatus_terminate (value wrapper)
 
 static st_retcode caml_threadstatus_wait (value wrapper)
 {
+  CAMLparam1(wrapper); /* prevent deallocation of ts */
   st_event ts = Threadstatus_val(wrapper);
   st_retcode retcode;
 
-  Begin_roots1(wrapper)         /* prevent deallocation of ts */
-    caml_enter_blocking_section();
-    retcode = st_event_wait(ts);
-    caml_leave_blocking_section();
-  End_roots();
+  caml_enter_blocking_section();
+  retcode = st_event_wait(ts);
+  caml_leave_blocking_section();
 
-  return retcode;
+  CAMLreturnT(st_retcode, retcode);
 }

--- a/otherlibs/unix/accept.c
+++ b/otherlibs/unix/accept.c
@@ -27,9 +27,10 @@
 
 CAMLprim value unix_accept(value cloexec, value sock)
 {
+  CAMLparam0();
+  CAMLlocal1(a);
   int retcode;
   value res;
-  value a;
   union sock_addr_union addr;
   socklen_param_type addr_len;
   int clo = unix_cloexec_p(cloexec);
@@ -48,12 +49,10 @@ CAMLprim value unix_accept(value cloexec, value sock)
   if (clo) unix_set_cloexec(retcode, "accept", Nothing);
 #endif
   a = alloc_sockaddr(&addr, addr_len, retcode);
-  Begin_root (a);
-    res = caml_alloc_small(2, 0);
-    Field(res, 0) = Val_int(retcode);
-    Field(res, 1) = a;
-  End_roots();
-  return res;
+  res = caml_alloc_small(2, 0);
+  Field(res, 0) = Val_int(retcode);
+  Field(res, 1) = a;
+  CAMLreturn(res);
 }
 
 #else

--- a/otherlibs/unix/getgr.c
+++ b/otherlibs/unix/getgr.c
@@ -24,22 +24,21 @@
 
 static value alloc_group_entry(struct group *entry)
 {
+  CAMLparam0();
+  CAMLlocal3(name, pass, mem);
   value res;
-  value name = Val_unit, pass = Val_unit, mem = Val_unit;
 
-  Begin_roots3 (name, pass, mem);
-    name = caml_copy_string(entry->gr_name);
-    /* on some platforms, namely Android, gr_passwd can be NULL,
-       hence this workaround */
-    pass = caml_copy_string(entry->gr_passwd ? entry->gr_passwd : "");
-    mem = caml_copy_string_array((const char**)entry->gr_mem);
-    res = caml_alloc_small(4, 0);
-    Field(res,0) = name;
-    Field(res,1) = pass;
-    Field(res,2) = Val_int(entry->gr_gid);
-    Field(res,3) = mem;
-  End_roots();
-  return res;
+  name = caml_copy_string(entry->gr_name);
+  /* on some platforms, namely Android, gr_passwd can be NULL,
+     hence this workaround */
+  pass = caml_copy_string(entry->gr_passwd ? entry->gr_passwd : "");
+  mem = caml_copy_string_array((const char**)entry->gr_mem);
+  res = caml_alloc_small(4, 0);
+  Field(res,0) = name;
+  Field(res,1) = pass;
+  Field(res,2) = Val_int(entry->gr_gid);
+  Field(res,3) = mem;
+  CAMLreturn(res);
 }
 
 CAMLprim value unix_getgrnam(value name)

--- a/otherlibs/unix/gethost.c
+++ b/otherlibs/unix/gethost.c
@@ -56,32 +56,30 @@ static value alloc_one_addr(char const *a)
 
 static value alloc_host_entry(struct hostent *entry)
 {
+  CAMLparam0();
+  CAMLlocal4(name, aliases, addr_list, adr);
   value res;
-  value name = Val_unit, aliases = Val_unit;
-  value addr_list = Val_unit, adr = Val_unit;
 
-  Begin_roots4 (name, aliases, addr_list, adr);
-    name = caml_copy_string((char *)(entry->h_name));
-    /* PR#4043: protect against buggy implementations of gethostbyname()
-       that return a NULL pointer in h_aliases */
-    if (entry->h_aliases)
-      aliases = caml_copy_string_array((const char**)entry->h_aliases);
-    else
-      aliases = Atom(0);
-    entry_h_length = entry->h_length;
-    addr_list =
-      caml_alloc_array(alloc_one_addr, (const char**)entry->h_addr_list);
-    res = caml_alloc_small(4, 0);
-    Field(res, 0) = name;
-    Field(res, 1) = aliases;
-    switch (entry->h_addrtype) {
-    case PF_UNIX:          Field(res, 2) = Val_int(0); break;
-    case PF_INET:          Field(res, 2) = Val_int(1); break;
-    default: /*PF_INET6 */ Field(res, 2) = Val_int(2); break;
-    }
-    Field(res, 3) = addr_list;
-  End_roots();
-  return res;
+  name = caml_copy_string((char *)(entry->h_name));
+  /* PR#4043: protect against buggy implementations of gethostbyname()
+     that return a NULL pointer in h_aliases */
+  if (entry->h_aliases)
+    aliases = caml_copy_string_array((const char**)entry->h_aliases);
+  else
+    aliases = Atom(0);
+  entry_h_length = entry->h_length;
+  addr_list =
+    caml_alloc_array(alloc_one_addr, (const char**)entry->h_addr_list);
+  res = caml_alloc_small(4, 0);
+  Field(res, 0) = name;
+  Field(res, 1) = aliases;
+  switch (entry->h_addrtype) {
+  case PF_UNIX:          Field(res, 2) = Val_int(0); break;
+  case PF_INET:          Field(res, 2) = Val_int(1); break;
+  default: /*PF_INET6 */ Field(res, 2) = Val_int(2); break;
+  }
+  Field(res, 3) = addr_list;
+  CAMLreturn(res);
 }
 
 CAMLprim value unix_gethostbyaddr(value a)

--- a/otherlibs/unix/getproto.c
+++ b/otherlibs/unix/getproto.c
@@ -27,18 +27,17 @@
 
 static value alloc_proto_entry(struct protoent *entry)
 {
+  CAMLparam0();
+  CAMLlocal2(name, aliases);
   value res;
-  value name = Val_unit, aliases = Val_unit;
 
-  Begin_roots2 (name, aliases);
-    name = caml_copy_string(entry->p_name);
-    aliases = caml_copy_string_array((const char**)entry->p_aliases);
-    res = caml_alloc_small(3, 0);
-    Field(res,0) = name;
-    Field(res,1) = aliases;
-    Field(res,2) = Val_int(entry->p_proto);
-  End_roots();
-  return res;
+  name = caml_copy_string(entry->p_name);
+  aliases = caml_copy_string_array((const char**)entry->p_aliases);
+  res = caml_alloc_small(3, 0);
+  Field(res,0) = name;
+  Field(res,1) = aliases;
+  Field(res,2) = Val_int(entry->p_proto);
+  CAMLreturn(res);
 }
 
 CAMLprim value unix_getprotobyname(value name)

--- a/otherlibs/unix/getpw.c
+++ b/otherlibs/unix/getpw.c
@@ -23,30 +23,28 @@
 
 static value alloc_passwd_entry(struct passwd *entry)
 {
+  CAMLparam0();
+  CAMLlocal5(name, passwd, gecos, dir, shell);
   value res;
-  value name = Val_unit, passwd = Val_unit, gecos = Val_unit;
-  value dir = Val_unit, shell = Val_unit;
 
-  Begin_roots5 (name, passwd, gecos, dir, shell);
-    name = caml_copy_string(entry->pw_name);
-    passwd = caml_copy_string(entry->pw_passwd);
+  name = caml_copy_string(entry->pw_name);
+  passwd = caml_copy_string(entry->pw_passwd);
 #if !defined(__BEOS__) && !defined(__ANDROID__)
-    gecos = caml_copy_string(entry->pw_gecos);
+  gecos = caml_copy_string(entry->pw_gecos);
 #else
-    gecos = caml_copy_string("");
+  gecos = caml_copy_string("");
 #endif
-    dir = caml_copy_string(entry->pw_dir);
-    shell = caml_copy_string(entry->pw_shell);
-    res = caml_alloc_small(7, 0);
-    Field(res,0) = name;
-    Field(res,1) = passwd;
-    Field(res,2) = Val_int(entry->pw_uid);
-    Field(res,3) = Val_int(entry->pw_gid);
-    Field(res,4) = gecos;
-    Field(res,5) = dir;
-    Field(res,6) = shell;
-  End_roots();
-  return res;
+  dir = caml_copy_string(entry->pw_dir);
+  shell = caml_copy_string(entry->pw_shell);
+  res = caml_alloc_small(7, 0);
+  Field(res,0) = name;
+  Field(res,1) = passwd;
+  Field(res,2) = Val_int(entry->pw_uid);
+  Field(res,3) = Val_int(entry->pw_gid);
+  Field(res,4) = gecos;
+  Field(res,5) = dir;
+  Field(res,6) = shell;
+  CAMLreturn(res);
 }
 
 CAMLprim value unix_getpwnam(value name)

--- a/otherlibs/unix/getserv.c
+++ b/otherlibs/unix/getserv.c
@@ -31,20 +31,19 @@
 
 static value alloc_service_entry(struct servent *entry)
 {
+  CAMLparam0();
+  CAMLlocal3(name, aliases, proto);
   value res;
-  value name = Val_unit, aliases = Val_unit, proto = Val_unit;
 
-  Begin_roots3 (name, aliases, proto);
-    name = caml_copy_string(entry->s_name);
-    aliases = caml_copy_string_array((const char**)entry->s_aliases);
-    proto = caml_copy_string(entry->s_proto);
-    res = caml_alloc_small(4, 0);
-    Field(res,0) = name;
-    Field(res,1) = aliases;
-    Field(res,2) = Val_int(ntohs(entry->s_port));
-    Field(res,3) = proto;
-  End_roots();
-  return res;
+  name = caml_copy_string(entry->s_name);
+  aliases = caml_copy_string_array((const char**)entry->s_aliases);
+  proto = caml_copy_string(entry->s_proto);
+  res = caml_alloc_small(4, 0);
+  Field(res,0) = name;
+  Field(res,1) = aliases;
+  Field(res,2) = Val_int(ntohs(entry->s_port));
+  Field(res,3) = proto;
+  CAMLreturn(res);
 }
 
 CAMLprim value unix_getservbyname(value name, value proto)

--- a/otherlibs/unix/gmtime.c
+++ b/otherlibs/unix/gmtime.c
@@ -61,30 +61,29 @@ CAMLprim value unix_localtime(value t)
 
 CAMLprim value unix_mktime(value t)
 {
+  CAMLparam0();
+  CAMLlocal2(tmval, clkval);
   struct tm tm;
   time_t clock;
   value res;
-  value tmval = Val_unit, clkval = Val_unit;
 
-  Begin_roots2(tmval, clkval);
-    tm.tm_sec = Int_val(Field(t, 0));
-    tm.tm_min = Int_val(Field(t, 1));
-    tm.tm_hour = Int_val(Field(t, 2));
-    tm.tm_mday = Int_val(Field(t, 3));
-    tm.tm_mon = Int_val(Field(t, 4));
-    tm.tm_year = Int_val(Field(t, 5));
-    tm.tm_wday = Int_val(Field(t, 6));
-    tm.tm_yday = Int_val(Field(t, 7));
-    tm.tm_isdst = -1; /* tm.tm_isdst = Bool_val(Field(t, 8)); */
-    clock = mktime(&tm);
-    if (clock == (time_t) -1) unix_error(ERANGE, "mktime", Nothing);
-    tmval = alloc_tm(&tm);
-    clkval = caml_copy_double((double) clock);
-    res = caml_alloc_small(2, 0);
-    Field(res, 0) = clkval;
-    Field(res, 1) = tmval;
-  End_roots ();
-  return res;
+  tm.tm_sec = Int_val(Field(t, 0));
+  tm.tm_min = Int_val(Field(t, 1));
+  tm.tm_hour = Int_val(Field(t, 2));
+  tm.tm_mday = Int_val(Field(t, 3));
+  tm.tm_mon = Int_val(Field(t, 4));
+  tm.tm_year = Int_val(Field(t, 5));
+  tm.tm_wday = Int_val(Field(t, 6));
+  tm.tm_yday = Int_val(Field(t, 7));
+  tm.tm_isdst = -1; /* tm.tm_isdst = Bool_val(Field(t, 8)); */
+  clock = mktime(&tm);
+  if (clock == (time_t) -1) unix_error(ERANGE, "mktime", Nothing);
+  tmval = alloc_tm(&tm);
+  clkval = caml_copy_double((double) clock);
+  res = caml_alloc_small(2, 0);
+  Field(res, 0) = clkval;
+  Field(res, 1) = tmval;
+  CAMLreturn(res);
 }
 
 #else

--- a/otherlibs/unix/read.c
+++ b/otherlibs/unix/read.c
@@ -21,18 +21,17 @@
 
 CAMLprim value unix_read(value fd, value buf, value ofs, value len)
 {
+  CAMLparam1(buf);
   long numbytes;
   int ret;
   char iobuf[UNIX_BUFFER_SIZE];
 
-  Begin_root (buf);
-    numbytes = Long_val(len);
-    if (numbytes > UNIX_BUFFER_SIZE) numbytes = UNIX_BUFFER_SIZE;
-    caml_enter_blocking_section();
-    ret = read(Int_val(fd), iobuf, (int) numbytes);
-    caml_leave_blocking_section();
-    if (ret == -1) uerror("read", Nothing);
-    memmove (&Byte(buf, Long_val(ofs)), iobuf, ret);
-  End_roots();
-  return Val_int(ret);
+  numbytes = Long_val(len);
+  if (numbytes > UNIX_BUFFER_SIZE) numbytes = UNIX_BUFFER_SIZE;
+  caml_enter_blocking_section();
+  ret = read(Int_val(fd), iobuf, (int) numbytes);
+  caml_leave_blocking_section();
+  if (ret == -1) uerror("read", Nothing);
+  memmove (&Byte(buf, Long_val(ofs)), iobuf, ret);
+  CAMLreturn(Val_int(ret));
 }

--- a/otherlibs/unix/select.c
+++ b/otherlibs/unix/select.c
@@ -35,7 +35,7 @@ static int fdlist_to_fdset(value fdlist, fd_set *fdset, int *maxfd)
 {
   value l;
   FD_ZERO(fdset);
-  for (l = fdlist; l != Val_int(0); l = Field(l, 1)) {
+  for (l = fdlist; l != Val_emptylist; l = Field(l, 1)) {
     long fd = Long_val(Field(l, 0));
     /* PR#5563: harden against bad fds */
     if (fd < 0 || fd >= FD_SETSIZE) return -1;
@@ -50,7 +50,7 @@ static value fdset_to_fdlist(value fdlist, fd_set *fdset)
   CAMLparam0();
   CAMLlocal2(l, res);
 
-  for (l = fdlist; l != Val_int(0); l = Field(l, 1)) {
+  for (l = fdlist; l != Val_emptylist; l = Field(l, 1)) {
     int fd = Int_val(Field(l, 0));
     if (FD_ISSET(fd, fdset)) {
       value newres = caml_alloc_small(2, 0);

--- a/otherlibs/unix/select.c
+++ b/otherlibs/unix/select.c
@@ -47,26 +47,25 @@ static int fdlist_to_fdset(value fdlist, fd_set *fdset, int *maxfd)
 
 static value fdset_to_fdlist(value fdlist, fd_set *fdset)
 {
-  value l;
-  value res = Val_int(0);
+  CAMLparam0();
+  CAMLlocal2(l, res);
 
-  Begin_roots2(l, res);
-    for (l = fdlist; l != Val_int(0); l = Field(l, 1)) {
-      int fd = Int_val(Field(l, 0));
-      if (FD_ISSET(fd, fdset)) {
-        value newres = caml_alloc_small(2, 0);
-        Field(newres, 0) = Val_int(fd);
-        Field(newres, 1) = res;
-        res = newres;
-      }
+  for (l = fdlist; l != Val_int(0); l = Field(l, 1)) {
+    int fd = Int_val(Field(l, 0));
+    if (FD_ISSET(fd, fdset)) {
+      value newres = caml_alloc_small(2, 0);
+      Field(newres, 0) = Val_int(fd);
+      Field(newres, 1) = res;
+      res = newres;
     }
-  End_roots();
-  return res;
+  }
+  CAMLreturn(res);
 }
 
 CAMLprim value unix_select(value readfds, value writefds, value exceptfds,
                            value timeout)
 {
+  CAMLparam3(readfds, writefds, exceptfds);
   fd_set read, write, except;
   int maxfd;
   double tm;
@@ -75,34 +74,32 @@ CAMLprim value unix_select(value readfds, value writefds, value exceptfds,
   int retcode;
   value res;
 
-  Begin_roots3 (readfds, writefds, exceptfds);
-    maxfd = -1;
-    retcode  = fdlist_to_fdset(readfds, &read, &maxfd);
-    retcode += fdlist_to_fdset(writefds, &write, &maxfd);
-    retcode += fdlist_to_fdset(exceptfds, &except, &maxfd);
-    /* PR#5563: if a bad fd was encountered, report EINVAL error */
-    if (retcode != 0) unix_error(EINVAL, "select", Nothing);
-    tm = Double_val(timeout);
-    if (tm < 0.0)
-      tvp = (struct timeval *) NULL;
-    else {
-      tv.tv_sec = (int) tm;
-      tv.tv_usec = (int) (1e6 * (tm - tv.tv_sec));
-      tvp = &tv;
-    }
-    caml_enter_blocking_section();
-    retcode = select(maxfd + 1, &read, &write, &except, tvp);
-    caml_leave_blocking_section();
-    if (retcode == -1) uerror("select", Nothing);
-    readfds = fdset_to_fdlist(readfds, &read);
-    writefds = fdset_to_fdlist(writefds, &write);
-    exceptfds = fdset_to_fdlist(exceptfds, &except);
-    res = caml_alloc_small(3, 0);
-    Field(res, 0) = readfds;
-    Field(res, 1) = writefds;
-    Field(res, 2) = exceptfds;
-  End_roots();
-  return res;
+  maxfd = -1;
+  retcode  = fdlist_to_fdset(readfds, &read, &maxfd);
+  retcode += fdlist_to_fdset(writefds, &write, &maxfd);
+  retcode += fdlist_to_fdset(exceptfds, &except, &maxfd);
+  /* PR#5563: if a bad fd was encountered, report EINVAL error */
+  if (retcode != 0) unix_error(EINVAL, "select", Nothing);
+  tm = Double_val(timeout);
+  if (tm < 0.0)
+    tvp = (struct timeval *) NULL;
+  else {
+    tv.tv_sec = (int) tm;
+    tv.tv_usec = (int) (1e6 * (tm - tv.tv_sec));
+    tvp = &tv;
+  }
+  caml_enter_blocking_section();
+  retcode = select(maxfd + 1, &read, &write, &except, tvp);
+  caml_leave_blocking_section();
+  if (retcode == -1) uerror("select", Nothing);
+  readfds = fdset_to_fdlist(readfds, &read);
+  writefds = fdset_to_fdlist(writefds, &write);
+  exceptfds = fdset_to_fdlist(exceptfds, &except);
+  res = caml_alloc_small(3, 0);
+  Field(res, 0) = readfds;
+  Field(res, 1) = writefds;
+  Field(res, 2) = exceptfds;
+  CAMLreturn(res);
 }
 
 #else

--- a/otherlibs/unix/signals.c
+++ b/otherlibs/unix/signals.c
@@ -39,19 +39,18 @@ static void decode_sigset(value vset, sigset_t * set)
 
 static value encode_sigset(sigset_t * set)
 {
-  value res = Val_int(0);
+  CAMLparam0();
+  CAMLlocal1(res);
   int i;
 
-  Begin_root(res)
-    for (i = 1; i < NSIG; i++)
-      if (sigismember(set, i) > 0) {
-        value newcons = caml_alloc_2(0,
-          Val_int(caml_rev_convert_signal_number(i)),
-          res);
-        res = newcons;
-      }
-  End_roots();
-  return res;
+  for (i = 1; i < NSIG; i++)
+    if (sigismember(set, i) > 0) {
+      value newcons = caml_alloc_2(0,
+        Val_int(caml_rev_convert_signal_number(i)),
+        res);
+      res = newcons;
+    }
+  CAMLreturn(res);
 }
 
 static int sigprocmask_cmd[3] = { SIG_SETMASK, SIG_BLOCK, SIG_UNBLOCK };

--- a/otherlibs/unix/socketaddr.c
+++ b/otherlibs/unix/socketaddr.c
@@ -111,6 +111,8 @@ value alloc_unix_sockaddr(value path) {
 value alloc_sockaddr(union sock_addr_union * adr /*in*/,
                      socklen_param_type adr_len, int close_on_error)
 {
+  CAMLparam0();
+  CAMLlocal1(a);
   value res;
   if (adr_len < offsetof(struct sockaddr, sa_data)) {
     // Only possible for an unnamed AF_UNIX socket, in
@@ -143,22 +145,18 @@ value alloc_sockaddr(union sock_addr_union * adr /*in*/,
       break;
     }
   case AF_INET:
-    { value a = alloc_inet_addr(&adr->s_inet.sin_addr);
-      Begin_root (a);
-        res = caml_alloc_small(2, 1);
-        Field(res,0) = a;
-        Field(res,1) = Val_int(ntohs(adr->s_inet.sin_port));
-      End_roots();
+    { a = alloc_inet_addr(&adr->s_inet.sin_addr);
+      res = caml_alloc_small(2, 1);
+      Field(res,0) = a;
+      Field(res,1) = Val_int(ntohs(adr->s_inet.sin_port));
       break;
     }
 #ifdef HAS_IPV6
   case AF_INET6:
-    { value a = alloc_inet6_addr(&adr->s_inet6.sin6_addr);
-      Begin_root (a);
-        res = caml_alloc_small(2, 1);
-        Field(res,0) = a;
-        Field(res,1) = Val_int(ntohs(adr->s_inet6.sin6_port));
-      End_roots();
+    { a = alloc_inet6_addr(&adr->s_inet6.sin6_addr);
+      res = caml_alloc_small(2, 1);
+      Field(res,0) = a;
+      Field(res,1) = Val_int(ntohs(adr->s_inet6.sin6_port));
       break;
     }
 #endif
@@ -166,7 +164,7 @@ value alloc_sockaddr(union sock_addr_union * adr /*in*/,
     if (close_on_error != -1) close (close_on_error);
     unix_error(EAFNOSUPPORT, "", Nothing);
   }
-  return res;
+  CAMLreturn(res);
 }
 
 #endif

--- a/otherlibs/unix/sockopt.c
+++ b/otherlibs/unix/sockopt.c
@@ -177,6 +177,9 @@ unix_getsockopt_aux(char * name,
                     enum option_type ty, int level, int option,
                     value socket)
 {
+  CAMLparam0();
+  CAMLlocal1(err);
+  value res;
   union option_value optval;
   socklen_param_type optsize;
 
@@ -200,32 +203,29 @@ unix_getsockopt_aux(char * name,
 
   switch (ty) {
   case TYPE_BOOL:
-    return Val_bool(optval.i);
+    res = Val_bool(optval.i);
   case TYPE_INT:
-    return Val_int(optval.i);
+    res = Val_int(optval.i);
   case TYPE_LINGER:
     if (optval.lg.l_onoff == 0) {
-      return Val_none;
+      res = Val_none;
     } else {
-      return caml_alloc_some(Val_int(optval.lg.l_linger));
+      res = caml_alloc_some(Val_int(optval.lg.l_linger));
     }
   case TYPE_TIMEVAL:
-    return caml_copy_double((double) optval.tv.tv_sec
-                       + (double) optval.tv.tv_usec / 1e6);
+    res = caml_copy_double((double) optval.tv.tv_sec
+                           + (double) optval.tv.tv_usec / 1e6);
   case TYPE_UNIX_ERROR:
     if (optval.i == 0) {
-      return Val_none;
+      res = Val_none;
     } else {
-      value err, res;
       err = unix_error_of_code(optval.i);
-      Begin_root(err);
-        res = caml_alloc_some(err);
-      End_roots();
-      return res;
+      res = caml_alloc_some(err);
     }
   default:
     unix_error(EINVAL, name, Nothing);
   }
+  CAMLreturn(res);
 }
 
 CAMLexport value

--- a/otherlibs/unix/unixsupport.c
+++ b/otherlibs/unix/unixsupport.c
@@ -285,25 +285,25 @@ int code_of_unix_error (value error)
 
 void unix_error(int errcode, const char *cmdname, value cmdarg)
 {
+  CAMLparam0();
+  CAMLlocal3(name, err, arg);
   value res;
   const value * unix_error_exn;
-  value name = Val_unit, err = Val_unit, arg = Val_unit;
 
-  Begin_roots3 (name, err, arg);
-    arg = cmdarg == Nothing ? caml_copy_string("") : cmdarg;
-    name = caml_copy_string(cmdname);
-    err = unix_error_of_code (errcode);
-    unix_error_exn = caml_named_value("Unix.Unix_error");
-    if (unix_error_exn == NULL)
-      caml_invalid_argument("Exception Unix.Unix_error not initialized,"
-                       " please link unix.cma");
-    res = caml_alloc_small(4, 0);
-    Field(res, 0) = *unix_error_exn;
-    Field(res, 1) = err;
-    Field(res, 2) = name;
-    Field(res, 3) = arg;
-  End_roots();
+  arg = cmdarg == Nothing ? caml_copy_string("") : cmdarg;
+  name = caml_copy_string(cmdname);
+  err = unix_error_of_code (errcode);
+  unix_error_exn = caml_named_value("Unix.Unix_error");
+  if (unix_error_exn == NULL)
+    caml_invalid_argument("Exception Unix.Unix_error not initialized,"
+                     " please link unix.cma");
+  res = caml_alloc_small(4, 0);
+  Field(res, 0) = *unix_error_exn;
+  Field(res, 1) = err;
+  Field(res, 2) = name;
+  Field(res, 3) = arg;
   caml_raise(res);
+  CAMLnoreturn;
 }
 
 void uerror(const char *cmdname, value cmdarg)

--- a/otherlibs/unix/wait.c
+++ b/otherlibs/unix/wait.c
@@ -41,7 +41,9 @@
 
 static value alloc_process_status(int pid, int status)
 {
-  value st, res;
+  CAMLparam0();
+  CAMLlocal1(st);
+  value res;
 
   // status is undefined when pid is zero so we set a default value.
   if (pid == 0) status = 0;
@@ -58,12 +60,10 @@ static value alloc_process_status(int pid, int status)
     st = caml_alloc_small(1, TAG_WSIGNALED);
     Field(st, 0) = Val_int(caml_rev_convert_signal_number(WTERMSIG(status)));
   }
-  Begin_root (st);
-    res = caml_alloc_small(2, 0);
-    Field(res, 0) = Val_int(pid);
-    Field(res, 1) = st;
-  End_roots();
-  return res;
+  res = caml_alloc_small(2, 0);
+  Field(res, 0) = Val_int(pid);
+  Field(res, 1) = st;
+  CAMLreturn(res);
 }
 
 CAMLprim value unix_wait(value unit)

--- a/otherlibs/unix/write.c
+++ b/otherlibs/unix/write.c
@@ -29,30 +29,29 @@
 
 CAMLprim value unix_write(value fd, value buf, value vofs, value vlen)
 {
+  CAMLparam1(buf);
   long ofs, len, written;
   int numbytes, ret;
   char iobuf[UNIX_BUFFER_SIZE];
 
-  Begin_root (buf);
-    ofs = Long_val(vofs);
-    len = Long_val(vlen);
-    written = 0;
-    while (len > 0) {
-      numbytes = len > UNIX_BUFFER_SIZE ? UNIX_BUFFER_SIZE : len;
-      memmove (iobuf, &Byte(buf, ofs), numbytes);
-      caml_enter_blocking_section();
-      ret = write(Int_val(fd), iobuf, numbytes);
-      caml_leave_blocking_section();
-      if (ret == -1) {
-        if ((errno == EAGAIN || errno == EWOULDBLOCK) && written > 0) break;
-        uerror("write", Nothing);
-      }
-      written += ret;
-      ofs += ret;
-      len -= ret;
+  ofs = Long_val(vofs);
+  len = Long_val(vlen);
+  written = 0;
+  while (len > 0) {
+    numbytes = len > UNIX_BUFFER_SIZE ? UNIX_BUFFER_SIZE : len;
+    memmove (iobuf, &Byte(buf, ofs), numbytes);
+    caml_enter_blocking_section();
+    ret = write(Int_val(fd), iobuf, numbytes);
+    caml_leave_blocking_section();
+    if (ret == -1) {
+      if ((errno == EAGAIN || errno == EWOULDBLOCK) && written > 0) break;
+      uerror("write", Nothing);
     }
-  End_roots();
-  return Val_long(written);
+    written += ret;
+    ofs += ret;
+    len -= ret;
+  }
+  CAMLreturn(Val_long(written));
 }
 
 /* When an error occurs after the first loop, unix_write reports the
@@ -65,22 +64,21 @@ CAMLprim value unix_write(value fd, value buf, value vofs, value vlen)
 
 CAMLprim value unix_single_write(value fd, value buf, value vofs, value vlen)
 {
+  CAMLparam1(buf);
   long ofs, len;
   int numbytes, ret;
   char iobuf[UNIX_BUFFER_SIZE];
 
-  Begin_root (buf);
-    ofs = Long_val(vofs);
-    len = Long_val(vlen);
-    ret = 0;
-    if (len > 0) {
-      numbytes = len > UNIX_BUFFER_SIZE ? UNIX_BUFFER_SIZE : len;
-      memmove (iobuf, &Byte(buf, ofs), numbytes);
-      caml_enter_blocking_section();
-      ret = write(Int_val(fd), iobuf, numbytes);
-      caml_leave_blocking_section();
-      if (ret == -1) uerror("single_write", Nothing);
-    }
-  End_roots();
-  return Val_int(ret);
+  ofs = Long_val(vofs);
+  len = Long_val(vlen);
+  ret = 0;
+  if (len > 0) {
+    numbytes = len > UNIX_BUFFER_SIZE ? UNIX_BUFFER_SIZE : len;
+    memmove (iobuf, &Byte(buf, ofs), numbytes);
+    caml_enter_blocking_section();
+    ret = write(Int_val(fd), iobuf, numbytes);
+    caml_leave_blocking_section();
+    if (ret == -1) uerror("single_write", Nothing);
+  }
+  CAMLreturn(Val_int(ret));
 }

--- a/otherlibs/win32unix/accept.c
+++ b/otherlibs/win32unix/accept.c
@@ -22,9 +22,11 @@
 
 CAMLprim value unix_accept(value cloexec, value sock)
 {
+  CAMLparam0();
+  CAMLlocal2(fd, adr);
   SOCKET sconn = Socket_val(sock);
   SOCKET snew;
-  value fd = Val_unit, adr = Val_unit, res;
+  value res;
   union sock_addr_union addr;
   socklen_param_type addr_len;
   DWORD err = 0;
@@ -39,12 +41,10 @@ CAMLprim value unix_accept(value cloexec, value sock)
     uerror("accept", Nothing);
   }
   win_set_cloexec((HANDLE) snew, cloexec);
-  Begin_roots2 (fd, adr)
-    fd = win_alloc_socket(snew);
-    adr = alloc_sockaddr(&addr, addr_len, snew);
-    res = caml_alloc_small(2, 0);
-    Field(res, 0) = fd;
-    Field(res, 1) = adr;
-  End_roots();
-  return res;
+  fd = win_alloc_socket(snew);
+  adr = alloc_sockaddr(&addr, addr_len, snew);
+  res = caml_alloc_small(2, 0);
+  Field(res, 0) = fd;
+  Field(res, 1) = adr;
+  CAMLreturn(res);
 }

--- a/otherlibs/win32unix/pipe.c
+++ b/otherlibs/win32unix/pipe.c
@@ -24,9 +24,11 @@
 
 CAMLprim value unix_pipe(value cloexec, value unit)
 {
+  CAMLparam0();
+  CAMLlocal2(readfd, writefd);
   SECURITY_ATTRIBUTES attr;
   HANDLE readh, writeh;
-  value readfd = Val_unit, writefd = Val_unit, res;
+  value res;
 
   attr.nLength = sizeof(attr);
   attr.lpSecurityDescriptor = NULL;
@@ -35,12 +37,10 @@ CAMLprim value unix_pipe(value cloexec, value unit)
     win32_maperr(GetLastError());
     uerror("pipe", Nothing);
   }
-  Begin_roots2(readfd, writefd)
-    readfd = win_alloc_handle(readh);
-    writefd = win_alloc_handle(writeh);
-    res = caml_alloc_small(2, 0);
-    Field(res, 0) = readfd;
-    Field(res, 1) = writefd;
-  End_roots();
-  return res;
+  readfd = win_alloc_handle(readh);
+  writefd = win_alloc_handle(writeh);
+  res = caml_alloc_small(2, 0);
+  Field(res, 0) = readfd;
+  Field(res, 1) = writefd;
+  CAMLreturn(res);
 }

--- a/otherlibs/win32unix/read.c
+++ b/otherlibs/win32unix/read.c
@@ -21,41 +21,40 @@
 
 CAMLprim value unix_read(value fd, value buf, value ofs, value vlen)
 {
+  CAMLparam1(buf);
   intnat len;
   DWORD numbytes, numread;
   char iobuf[UNIX_BUFFER_SIZE];
   DWORD err = 0;
 
-  Begin_root (buf);
-    len = Long_val(vlen);
-    numbytes = len > UNIX_BUFFER_SIZE ? UNIX_BUFFER_SIZE : len;
-    if (Descr_kind_val(fd) == KIND_SOCKET) {
-      int ret;
-      SOCKET s = Socket_val(fd);
-      caml_enter_blocking_section();
-      ret = recv(s, iobuf, numbytes, 0);
-      if (ret == SOCKET_ERROR) err = WSAGetLastError();
-      caml_leave_blocking_section();
-      numread = ret;
+  len = Long_val(vlen);
+  numbytes = len > UNIX_BUFFER_SIZE ? UNIX_BUFFER_SIZE : len;
+  if (Descr_kind_val(fd) == KIND_SOCKET) {
+    int ret;
+    SOCKET s = Socket_val(fd);
+    caml_enter_blocking_section();
+    ret = recv(s, iobuf, numbytes, 0);
+    if (ret == SOCKET_ERROR) err = WSAGetLastError();
+    caml_leave_blocking_section();
+    numread = ret;
+  } else {
+    HANDLE h = Handle_val(fd);
+    caml_enter_blocking_section();
+    if (! ReadFile(h, iobuf, numbytes, &numread, NULL))
+      err = GetLastError();
+    caml_leave_blocking_section();
+  }
+  if (err) {
+    if (err == ERROR_BROKEN_PIPE) {
+      // The write handle for an anonymous pipe has been closed. We match the
+      // Unix behavior, and treat this as a zero-read instead of a Unix_error.
+      err = 0;
+      numread = 0;
     } else {
-      HANDLE h = Handle_val(fd);
-      caml_enter_blocking_section();
-      if (! ReadFile(h, iobuf, numbytes, &numread, NULL))
-        err = GetLastError();
-      caml_leave_blocking_section();
+      win32_maperr(err);
+      uerror("read", Nothing);
     }
-    if (err) {
-      if (err == ERROR_BROKEN_PIPE) {
-        // The write handle for an anonymous pipe has been closed. We match the
-        // Unix behavior, and treat this as a zero-read instead of a Unix_error.
-        err = 0;
-        numread = 0;
-      } else {
-        win32_maperr(err);
-        uerror("read", Nothing);
-      }
-    }
-    memmove (&Byte(buf, Long_val(ofs)), iobuf, numread);
-  End_roots();
-  return Val_int(numread);
+  }
+  memmove (&Byte(buf, Long_val(ofs)), iobuf, numread);
+  CAMLreturn(Val_int(numread));
 }

--- a/otherlibs/win32unix/sendrecv.c
+++ b/otherlibs/win32unix/sendrecv.c
@@ -27,6 +27,7 @@ static int msg_flag_table[] = {
 CAMLprim value unix_recv(value sock, value buff, value ofs, value len,
                          value flags)
 {
+  CAMLparam1(buff);
   SOCKET s = Socket_val(sock);
   int flg = caml_convert_flag_list(flags, msg_flag_table);
   int ret;
@@ -34,55 +35,52 @@ CAMLprim value unix_recv(value sock, value buff, value ofs, value len,
   char iobuf[UNIX_BUFFER_SIZE];
   DWORD err = 0;
 
-  Begin_root (buff);
-    numbytes = Long_val(len);
-    if (numbytes > UNIX_BUFFER_SIZE) numbytes = UNIX_BUFFER_SIZE;
-    caml_enter_blocking_section();
-    ret = recv(s, iobuf, (int) numbytes, flg);
-    if (ret == -1) err = WSAGetLastError();
-    caml_leave_blocking_section();
-    if (ret == -1) {
-      win32_maperr(err);
-      uerror("recv", Nothing);
-    }
-    memmove (&Byte(buff, Long_val(ofs)), iobuf, ret);
-  End_roots();
-  return Val_int(ret);
+  numbytes = Long_val(len);
+  if (numbytes > UNIX_BUFFER_SIZE) numbytes = UNIX_BUFFER_SIZE;
+  caml_enter_blocking_section();
+  ret = recv(s, iobuf, (int) numbytes, flg);
+  if (ret == -1) err = WSAGetLastError();
+  caml_leave_blocking_section();
+  if (ret == -1) {
+    win32_maperr(err);
+    uerror("recv", Nothing);
+  }
+  memmove (&Byte(buff, Long_val(ofs)), iobuf, ret);
+  CAMLreturn(Val_int(ret));
 }
 
 CAMLprim value unix_recvfrom(value sock, value buff, value ofs, value len,
                              value flags)
 {
+  CAMLparam1(buff);
+  CAMLlocal1(adr);
   SOCKET s = Socket_val(sock);
   int flg = caml_convert_flag_list(flags, msg_flag_table);
   int ret;
   intnat numbytes;
   char iobuf[UNIX_BUFFER_SIZE];
   value res;
-  value adr = Val_unit;
   union sock_addr_union addr;
   socklen_param_type addr_len;
   DWORD err = 0;
 
-  Begin_roots2 (buff, adr);
-    numbytes = Long_val(len);
-    if (numbytes > UNIX_BUFFER_SIZE) numbytes = UNIX_BUFFER_SIZE;
-    addr_len = sizeof(addr);
-    caml_enter_blocking_section();
-    ret = recvfrom(s, iobuf, (int) numbytes, flg, &addr.s_gen, &addr_len);
-    if (ret == -1) err = WSAGetLastError();
-    caml_leave_blocking_section();
-    if (ret == -1) {
-      win32_maperr(err);
-      uerror("recvfrom", Nothing);
-    }
-    memmove (&Byte(buff, Long_val(ofs)), iobuf, ret);
-    adr = alloc_sockaddr(&addr, addr_len, -1);
-    res = caml_alloc_small(2, 0);
-    Field(res, 0) = Val_int(ret);
-    Field(res, 1) = adr;
-  End_roots();
-  return res;
+  numbytes = Long_val(len);
+  if (numbytes > UNIX_BUFFER_SIZE) numbytes = UNIX_BUFFER_SIZE;
+  addr_len = sizeof(addr);
+  caml_enter_blocking_section();
+  ret = recvfrom(s, iobuf, (int) numbytes, flg, &addr.s_gen, &addr_len);
+  if (ret == -1) err = WSAGetLastError();
+  caml_leave_blocking_section();
+  if (ret == -1) {
+    win32_maperr(err);
+    uerror("recvfrom", Nothing);
+  }
+  memmove (&Byte(buff, Long_val(ofs)), iobuf, ret);
+  adr = alloc_sockaddr(&addr, addr_len, -1);
+  res = caml_alloc_small(2, 0);
+  Field(res, 0) = Val_int(ret);
+  Field(res, 1) = adr;
+  CAMLreturn(res);
 }
 
 CAMLprim value unix_send(value sock, value buff, value ofs, value len,

--- a/otherlibs/win32unix/sockopt.c
+++ b/otherlibs/win32unix/sockopt.c
@@ -115,9 +115,11 @@ unix_getsockopt_aux(char * name,
                     enum option_type ty, int level, int option,
                     value socket)
 {
+  CAMLparam0();
+  CAMLlocal1(err);
   union option_value optval;
   socklen_param_type optsize;
-
+  value res;
 
   switch (ty) {
   case TYPE_BOOL:
@@ -141,31 +143,27 @@ unix_getsockopt_aux(char * name,
   switch (ty) {
   case TYPE_BOOL:
   case TYPE_INT:
-    return Val_int(optval.i);
+    res = Val_int(optval.i);
   case TYPE_LINGER:
     if (optval.lg.l_onoff == 0) {
-      return Val_none;
+      res = Val_none;
     } else {
-      return caml_alloc_some(Val_int(optval.lg.l_linger));
+      res = caml_alloc_some(Val_int(optval.lg.l_linger));
     }
   case TYPE_TIMEVAL:
-    return caml_copy_double((double) optval.tv.tv_sec
-                       + (double) optval.tv.tv_usec / 1e6);
+    res = caml_copy_double((double) optval.tv.tv_sec
+                           + (double) optval.tv.tv_usec / 1e6);
   case TYPE_UNIX_ERROR:
     if (optval.i == 0) {
-      return Val_none;
+      res = Val_none;
     } else {
-      value err, res;
       err = unix_error_of_code(optval.i);
-      Begin_root(err);
-        res = caml_alloc_some(err);
-      End_roots();
-      return res;
+      res = caml_alloc_some(err);
     }
   default:
     unix_error(EINVAL, name, Nothing);
-    return Val_unit; /* Avoid warning */
   }
+  CAMLreturn(res);
 }
 
 CAMLexport value

--- a/otherlibs/win32unix/unixsupport.c
+++ b/otherlibs/win32unix/unixsupport.c
@@ -290,27 +290,27 @@ int code_of_unix_error (value error)
 
 void unix_error(int errcode, const char *cmdname, value cmdarg)
 {
+  CAMLparam0();
+  CAMLlocal3(name, err, arg);
   value res;
-  value name = Val_unit, err = Val_unit, arg = Val_unit;
   int errconstr;
 
-  Begin_roots3 (name, err, arg);
-    arg = cmdarg == Nothing ? caml_copy_string("") : cmdarg;
-    name = caml_copy_string(cmdname);
-    err = unix_error_of_code (errcode);
-    if (unix_error_exn == NULL) {
-      unix_error_exn = caml_named_value("Unix.Unix_error");
-      if (unix_error_exn == NULL)
-        caml_invalid_argument("Exception Unix.Unix_error not initialized,"
-                         " please link unix.cma");
-    }
-    res = caml_alloc_small(4, 0);
-    Field(res, 0) = *unix_error_exn;
-    Field(res, 1) = err;
-    Field(res, 2) = name;
-    Field(res, 3) = arg;
-  End_roots();
+  arg = cmdarg == Nothing ? caml_copy_string("") : cmdarg;
+  name = caml_copy_string(cmdname);
+  err = unix_error_of_code (errcode);
+  if (unix_error_exn == NULL) {
+    unix_error_exn = caml_named_value("Unix.Unix_error");
+    if (unix_error_exn == NULL)
+      caml_invalid_argument("Exception Unix.Unix_error not initialized,"
+                       " please link unix.cma");
+  }
+  res = caml_alloc_small(4, 0);
+  Field(res, 0) = *unix_error_exn;
+  Field(res, 1) = err;
+  Field(res, 2) = name;
+  Field(res, 3) = arg;
   caml_raise(res);
+  CAMLnoreturn;
 }
 
 void uerror(const char * cmdname, value cmdarg)

--- a/otherlibs/win32unix/windir.c
+++ b/otherlibs/win32unix/windir.c
@@ -25,34 +25,32 @@
 
 CAMLprim value win_findfirst(value name)
 {
+  CAMLparam0();
+  CAMLlocal2(valname, valh);
   HANDLE h;
   value v;
   WIN32_FIND_DATAW fileinfo;
-  value valname = Val_unit;
-  value valh = Val_unit;
   wchar_t * wname;
 
   caml_unix_check_path(name, "opendir");
-  Begin_roots2 (valname,valh);
-    wname = caml_stat_strdup_to_utf16(String_val(name));
-    h = FindFirstFile(wname,&fileinfo);
-    caml_stat_free(wname);
-    if (h == INVALID_HANDLE_VALUE) {
-      DWORD err = GetLastError();
-      if (err == ERROR_NO_MORE_FILES)
-        caml_raise_end_of_file();
-      else {
-        win32_maperr(err);
-        uerror("opendir", Nothing);
-      }
+  wname = caml_stat_strdup_to_utf16(String_val(name));
+  h = FindFirstFile(wname,&fileinfo);
+  caml_stat_free(wname);
+  if (h == INVALID_HANDLE_VALUE) {
+    DWORD err = GetLastError();
+    if (err == ERROR_NO_MORE_FILES)
+      caml_raise_end_of_file();
+    else {
+      win32_maperr(err);
+      uerror("opendir", Nothing);
     }
-    valname = caml_copy_string_of_utf16(fileinfo.cFileName);
-    valh = win_alloc_handle(h);
-    v = caml_alloc_small(2, 0);
-    Field(v,0) = valname;
-    Field(v,1) = valh;
-  End_roots();
-  return v;
+  }
+  valname = caml_copy_string_of_utf16(fileinfo.cFileName);
+  valh = win_alloc_handle(h);
+  v = caml_alloc_small(2, 0);
+  Field(v,0) = valname;
+  Field(v,1) = valh;
+  CAMLreturn(v);
 }
 
 CAMLprim value win_findnext(value valh)

--- a/otherlibs/win32unix/winwait.c
+++ b/otherlibs/win32unix/winwait.c
@@ -23,16 +23,16 @@
 
 static value alloc_process_status(HANDLE pid, int status)
 {
-  value res, st;
+  CAMLparam0();
+  CAMLlocal1(st);
+  value res;
 
   st = caml_alloc(1, 0);
   Field(st, 0) = Val_int(status);
-  Begin_root (st);
-    res = caml_alloc_small(2, 0);
-    Field(res, 0) = Val_long((intnat) pid);
-    Field(res, 1) = st;
-  End_roots();
-  return res;
+  res = caml_alloc_small(2, 0);
+  Field(res, 0) = Val_long((intnat) pid);
+  Field(res, 1) = st;
+  CAMLreturn(res);
 }
 
 enum { CAML_WNOHANG = 1, CAML_WUNTRACED = 2 };

--- a/otherlibs/win32unix/winwait.c
+++ b/otherlibs/win32unix/winwait.c
@@ -27,8 +27,7 @@ static value alloc_process_status(HANDLE pid, int status)
   CAMLlocal1(st);
   value res;
 
-  st = caml_alloc(1, 0);
-  Field(st, 0) = Val_int(status);
+  st = caml_alloc_boxed(Val_int(status));
   res = caml_alloc_small(2, 0);
   Field(res, 0) = Val_long((intnat) pid);
   Field(res, 1) = st;

--- a/otherlibs/win32unix/write.c
+++ b/otherlibs/win32unix/write.c
@@ -22,80 +22,78 @@
 
 CAMLprim value unix_write(value fd, value buf, value vofs, value vlen)
 {
+  CAMLparam1(buf);
   intnat ofs, len, written;
   DWORD numbytes, numwritten;
   char iobuf[UNIX_BUFFER_SIZE];
   DWORD err = 0;
 
-  Begin_root (buf);
-    ofs = Long_val(vofs);
-    len = Long_val(vlen);
-    written = 0;
-    while (len > 0) {
-      numbytes = len > UNIX_BUFFER_SIZE ? UNIX_BUFFER_SIZE : len;
-      memmove (iobuf, &Byte(buf, ofs), numbytes);
-      if (Descr_kind_val(fd) == KIND_SOCKET) {
-        int ret;
-        SOCKET s = Socket_val(fd);
-        caml_enter_blocking_section();
-        ret = send(s, iobuf, numbytes, 0);
-        if (ret == SOCKET_ERROR) err = WSAGetLastError();
-        caml_leave_blocking_section();
-        numwritten = ret;
-      } else {
-        HANDLE h = Handle_val(fd);
-        caml_enter_blocking_section();
-        if (! WriteFile(h, iobuf, numbytes, &numwritten, NULL))
-          err = GetLastError();
-        caml_leave_blocking_section();
-      }
-      if (err) {
-        win32_maperr(err);
-        uerror("write", Nothing);
-      }
-      written += numwritten;
-      ofs += numwritten;
-      len -= numwritten;
+  ofs = Long_val(vofs);
+  len = Long_val(vlen);
+  written = 0;
+  while (len > 0) {
+    numbytes = len > UNIX_BUFFER_SIZE ? UNIX_BUFFER_SIZE : len;
+    memmove (iobuf, &Byte(buf, ofs), numbytes);
+    if (Descr_kind_val(fd) == KIND_SOCKET) {
+      int ret;
+      SOCKET s = Socket_val(fd);
+      caml_enter_blocking_section();
+      ret = send(s, iobuf, numbytes, 0);
+      if (ret == SOCKET_ERROR) err = WSAGetLastError();
+      caml_leave_blocking_section();
+      numwritten = ret;
+    } else {
+      HANDLE h = Handle_val(fd);
+      caml_enter_blocking_section();
+      if (! WriteFile(h, iobuf, numbytes, &numwritten, NULL))
+        err = GetLastError();
+      caml_leave_blocking_section();
     }
-  End_roots();
-  return Val_long(written);
+    if (err) {
+      win32_maperr(err);
+      uerror("write", Nothing);
+    }
+    written += numwritten;
+    ofs += numwritten;
+    len -= numwritten;
+  }
+  CAMLreturn(Val_long(written));
 }
 
 CAMLprim value unix_single_write(value fd, value buf, value vofs, value vlen)
 {
+  CAMLparam1(buf);
   intnat ofs, len, written;
   DWORD numbytes, numwritten;
   char iobuf[UNIX_BUFFER_SIZE];
   DWORD err = 0;
 
-  Begin_root (buf);
-    ofs = Long_val(vofs);
-    len = Long_val(vlen);
-    written = 0;
-    if (len > 0) {
-      numbytes = len > UNIX_BUFFER_SIZE ? UNIX_BUFFER_SIZE : len;
-      memmove (iobuf, &Byte(buf, ofs), numbytes);
-      if (Descr_kind_val(fd) == KIND_SOCKET) {
-        int ret;
-        SOCKET s = Socket_val(fd);
-        caml_enter_blocking_section();
-        ret = send(s, iobuf, numbytes, 0);
-        if (ret == SOCKET_ERROR) err = WSAGetLastError();
-        caml_leave_blocking_section();
-        numwritten = ret;
-      } else {
-        HANDLE h = Handle_val(fd);
-        caml_enter_blocking_section();
-        if (! WriteFile(h, iobuf, numbytes, &numwritten, NULL))
-          err = GetLastError();
-        caml_leave_blocking_section();
-      }
-      if (err) {
-        win32_maperr(err);
-        uerror("single_write", Nothing);
-      }
-      written = numwritten;
+  ofs = Long_val(vofs);
+  len = Long_val(vlen);
+  written = 0;
+  if (len > 0) {
+    numbytes = len > UNIX_BUFFER_SIZE ? UNIX_BUFFER_SIZE : len;
+    memmove (iobuf, &Byte(buf, ofs), numbytes);
+    if (Descr_kind_val(fd) == KIND_SOCKET) {
+      int ret;
+      SOCKET s = Socket_val(fd);
+      caml_enter_blocking_section();
+      ret = send(s, iobuf, numbytes, 0);
+      if (ret == SOCKET_ERROR) err = WSAGetLastError();
+      caml_leave_blocking_section();
+      numwritten = ret;
+    } else {
+      HANDLE h = Handle_val(fd);
+      caml_enter_blocking_section();
+      if (! WriteFile(h, iobuf, numbytes, &numwritten, NULL))
+        err = GetLastError();
+      caml_leave_blocking_section();
     }
-  End_roots();
-  return Val_long(written);
+    if (err) {
+      win32_maperr(err);
+      uerror("single_write", Nothing);
+    }
+    written = numwritten;
+  }
+  CAMLreturn(Val_long(written));
 }

--- a/otherlibs/win32unix/write.c
+++ b/otherlibs/win32unix/write.c
@@ -22,7 +22,7 @@
 
 CAMLprim value unix_write(value fd, value buf, value vofs, value vlen)
 {
-  CAMLparam1(buf);
+  CAMLparam2(fd, buf);
   intnat ofs, len, written;
   DWORD numbytes, numwritten;
   char iobuf[UNIX_BUFFER_SIZE];

--- a/testsuite/tests/callback/callbackprim.c
+++ b/testsuite/tests/callback/callbackprim.c
@@ -53,10 +53,9 @@ value mycallback4(value fun, value arg1, value arg2, value arg3, value arg4)
 
 value mypushroot(value v, value fun, value arg)
 {
-  Begin_root(v)
-    caml_callback(fun, arg);
-  End_roots();
-  return v;
+  CAMLparam1(v);
+  caml_callback(fun, arg);
+  CAMLreturn(v);
 }
 
 value mycamlparam (value v, value fun, value arg)

--- a/testsuite/tests/callback/test1_.c
+++ b/testsuite/tests/callback/test1_.c
@@ -52,10 +52,9 @@ value mycallback4(value fun, value arg1, value arg2, value arg3, value arg4)
 
 value mypushroot(value v, value fun, value arg)
 {
-  Begin_root(v)
-    caml_callback(fun, arg);
-  End_roots();
-  return v;
+  CAMLparam1(v);
+  caml_callback(fun, arg);
+  CAMLreturn(v);
 }
 
 value mycamlparam (value v, value fun, value arg)

--- a/testsuite/tests/callback/test_signalhandler_.c
+++ b/testsuite/tests/callback/test_signalhandler_.c
@@ -57,10 +57,9 @@ value mycallback4(value fun, value arg1, value arg2, value arg3, value arg4)
 
 value mypushroot(value v, value fun, value arg)
 {
-  Begin_root(v)
-    caml_callback(fun, arg);
-  End_roots();
-  return v;
+  CAMLparam1(v);
+  caml_callback(fun, arg);
+  CAMLreturn(v);
 }
 
 value mycamlparam (value v, value fun, value arg)


### PR DESCRIPTION
The first commit adds a deprecation warning to these macros. The second commit adapts the compiler codebase not to use them anymore.

The deprecation warning message location is not ideal, but I wasn't able to do better:
```
gcc -c -O2 -fno-strict-aliasing -fwrapv -pthread -Wall -Wdeclaration-after-statement -Werror -fno-common -fexcess-precision=standard -fno-tree-vrp -ffunction-sections -g  -D_FILE_OFFSET_BITS=64  -DCAMLDLLIMPORT= -DDEBUG  -o startup_aux.bd.o startup_aux.c
sync.c: In function ‘caml_ml_condition_wait’:
sync.c:169:13: error: "Begin_roots2" is deprecated: use "CAMLparamX or CAMLlocalX" instead [-Werror]
   Begin_roots2(wcond, wmut)
             ^~~~~~~~~~~~~~~
sync.c:173:13: error: "End_roots" is deprecated: use "CAMLreturn or CAMLdrop" instead [-Werror]
   End_roots();
             ^~
```

I suggest looking at the diff modulo whitespace.