### PR TITLE
Adjust mmap alignment of minor heap space

### DIFF
--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -593,7 +593,7 @@ void caml_init_domains(uintnat minor_heap_wsz) {
 
   /* reserve memory space for minor heaps */
   size = (uintnat)Bsize_wsize(Minor_heap_max) * Max_domains;
-  heaps_base = caml_mem_map(size, size, 1 /* reserve_only */);
+  heaps_base = caml_mem_map(size, caml_sys_pagesize, 1 /* reserve_only */);
   if (heaps_base == NULL)
     caml_fatal_error("Not enough heap memory to start up");
 


### PR DESCRIPTION
This small PR adjusts the alignment for `mmap`ing the minor heap space.
It currently uses a 256GB reservation with a 256GB alignment
  https://github.com/ocaml/ocaml/blob/2beaad2e3503eae9e67b5d4b6ed8680bca0c38ca/runtime/domain.c#L596

This causes an initial 512GB `mmap` with two subsequent `munmap`s:
  ```
  $ cat hello.ml
  print_endline "hello world!"
  $ ocamlopt -o hello hello.ml
  $ strace ./hello
  execve("./hello", ["./hello"], 0x7fffe41146d0 /* 59 vars */) = 0
  ...
  mmap(NULL, 549755813888, PROT_NONE, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0) = 0x7ea70d4a3000
  munmap(0x7ea70d4a3000, 107151216640)    = 0
  munmap(0x7f0000000000, 167726690304)    = 0
  ...
```

I suspect that this is a left-over from the old concurrent minor GC, which had stronger alignment requirements to allow a fast read barrier (see https://kcsrk.info/papers/retro-parallel_icfp_20.pdf Sec.4.3.2).
With the patch, the `mmap` reservation drops to 256GB.

This can make a difference:

Installing the new ARM64 backend https://github.com/ocaml/ocaml/pull/10972 on my Raspberry Pi 4 with 2GB RAM (it was the only one in stock!) 
fails with: `# Fatal error: Not enough heap memory to start up` because of a failing `mmap` (see below). 
This prompted me to have a look at `caml_mem_map`.
A crude binary search revealed that `mmap` fails reservations of sizes larger than ~341GB on this machine.
With the patch it runs out-of-the-box.


(I'm aware that Xavier's proposal from https://github.com/ocaml/ocaml/issues/10971 is also being worked on)


```
#=== ERROR while compiling ocaml-variants.5.00.0+trunk ========================#
# context     2.1.2 | linux/arm64 |  | pinned(file:///home/pi/software/ocaml)
# path        ~/software/ocaml
# command     ~/.opam/opam-init/hooks/sandbox.sh build make -j3
# exit-code   2
# env-file    ~/.opam/log/ocaml-variants-15076-009446.env
# output-file ~/.opam/log/ocaml-variants-15076-009446.out
### output ###
# [...]
# make[2]: Leaving directory '/home/pi/software/ocaml/runtime'
# make -C stdlib \
#   OCAMLRUN='$(ROOTDIR)/runtime/ocamlrun' \
#   CAMLC='$(BOOT_OCAMLC) -use-prims ../runtime/primitives' all
# make[2]: Entering directory '/home/pi/software/ocaml/stdlib'
# ../runtime/ocamlrun ../boot/ocamlc -use-prims ../runtime/primitives -strict-sequence -absname -w +a-4-9-41-42-44-45-48-70 -g -warn-error +A -bin-annot -nostdlib -principal -safe-string -strict-formats  -nopervasives -c camlinternalFormatBasics.mli
# Fatal error: Not enough heap memory to start up
# make[2]: *** [Makefile:214: camlinternalFormatBasics.cmi] Aborted
# make[2]: Leaving directory '/home/pi/software/ocaml/stdlib'
# make[1]: *** [Makefile:164: coldstart] Error 2
# make[1]: Leaving directory '/home/pi/software/ocaml'
# make: *** [Makefile:311: world.opt] Error 2
```