### PR TITLE
CONTRIBUTING.md: list the maintainers

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -57,6 +57,7 @@ tools/mantis2gh_stripped.csv typo.missing-header
 /.github/**              typo.missing-header typo.long-line=may typo.very-long-line=may
 
 /.mailmap                typo.long-line typo.missing-header typo.non-ascii
+/CONTRIBUTING.md         typo.non-ascii=may
 /.merlin                 typo.missing-header
 /Changes                 typo.utf8 typo.missing-header
 /release-info/News       typo.utf8 typo.missing-header

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,6 +60,40 @@ https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-creat
 significantly delay the inclusion of an otherwise perfectly ok
 contribution.
 
+### Maintainers
+
+The current list of maintainers is as follows:
+
+- @alainfrisch Alain Frisch
+- @Armael Armaël Guéneau
+- @avsm Anil Madhavapeddy
+- @chambart Pierre Chambart
+- @damiendoligez Damien Doligez
+- @dra27 David Allsopp
+- @Engil Enguerrand
+- @garrigue Jacques Garrigue
+- @gasche Gabriel Scherer
+- @jhjourdan Jacques-Henri Jourdan
+- @kayceesrk KC Sivaramakrishnan
+- @let-def Frédéric Bour
+- @lpw25 Leo White
+- @lthls Vincent Laviron
+- @maranget Luc Maranget
+- @mshinwell Mark Shinwell
+- @nojb Nicolás Ojeda Bär
+- @Octachron Florian Angeletti
+- @sadiqj Sadiq Jaffer
+- @shindere Sébastien Hinderer
+- @stedolan Stephen Dolan
+- @trefis Thomas Refis
+- @xavierleroy Xavier Leroy
+- @yallop Jeremy Yallop
+
+<!-- Note: the list comes from [this Github
+page](https://github.com/orgs/ocaml/teams/ocaml-dev/members), plus
+Anil as co-owner of the github/ocaml/ organization. Oddly enough,
+Github does not make the page publicly accessible. -->
+
 
 ## Coding guidelines
 


### PR DESCRIPTION
The OCaml PR workflow attributes a special role to maintainers (people with commit rights), whose approval is necessary to merge a PR. It was recently remarked that the set of maintainers is not, in fact, publicly accessible. There is no good reason for this, and it gives the impression of a lack of transparency (completely unintended in this respect). The present PR includes the list of (current) maintainers in CONTRIBUTING.md.