### PR TITLE
document and refactor the gc-stats code

### DIFF
--- a/Changes
+++ b/Changes
@@ -117,6 +117,8 @@ Working version
 - #10864, #10888: restore afl-fuzz mode for sequential programs.
   (Jan Midtgaard, review by Xavier Leroy and Gabriel Scherer)
 
+- #11008: rework GC statistics in the Multicore runtime
+  (Gabriel Scherer, review by Enguerrand Decorne)
 
 ### Build system:
 

--- a/runtime/Makefile
+++ b/runtime/Makefile
@@ -39,6 +39,7 @@ COMMON_C_SOURCES := $(addsuffix .c, \
   finalise \
   floats \
   gc_ctrl \
+  gc_stats \
   globroots \
   hash \
   intern \

--- a/runtime/caml/gc_stats.h
+++ b/runtime/caml/gc_stats.h
@@ -1,0 +1,85 @@
+/**************************************************************************/
+/*                                                                        */
+/*                                 OCaml                                  */
+/*                                                                        */
+/*             Gabriel Scherer, projet Partout, INRIA Saclay              */
+/*                                                                        */
+/*   Copyright 2022 Institut National de Recherche en Informatique et     */
+/*     en Automatique.                                                    */
+/*                                                                        */
+/*   All rights reserved.  This file is distributed under the terms of    */
+/*   the GNU Lesser General Public License version 2.1, with the          */
+/*   special exception on linking described in the file LICENSE.          */
+/*                                                                        */
+/**************************************************************************/
+
+#ifndef CAML_GC_STATS_H
+#define CAML_GC_STATS_H
+
+#ifdef CAML_INTERNALS
+
+#include "domain.h"
+
+/* The Gc module provides two kind of runtime statistics:
+   - Heap stats: statistics about heap memory, see shared_heap.c
+   - Allocation stats: statistics about past allocations and collections,
+     see major_gc.c
+
+   To avoid synchronization costs, each domain tracks its own statistics.
+   We never access the "live stats" of other domains running concurrently,
+   only their "sampled stats", a past version of the live stats saved
+   at a safepoint -- during stop-the-world minor collections and
+   on domain termination.
+*/
+
+struct heap_stats {
+  intnat pool_words;
+  intnat pool_max_words;
+  intnat pool_live_words;
+  intnat pool_live_blocks;
+  intnat pool_frag_words;
+  intnat large_words;
+  intnat large_max_words;
+  intnat large_blocks;
+};
+
+/* Note: accumulating stats then removing them is not a no-op, as
+   accumulating updates maximum values.
+
+   For example, if pool_words and pool_max_words are initially 0,
+   adding 10 then removing 10 will reset pool_words to 0 but leave
+   pool_max_words at 10. */
+void caml_accum_heap_stats(struct heap_stats* acc, const struct heap_stats* s);
+void caml_remove_heap_stats(struct heap_stats* acc, const struct heap_stats* s);
+
+struct alloc_stats {
+  uint64_t minor_words;
+  uint64_t promoted_words;
+  uint64_t major_words;
+  uint64_t minor_collections;
+  uint64_t forced_major_collections;
+};
+void caml_accum_alloc_stats(
+  struct alloc_stats* acc,
+  const struct alloc_stats* s);
+void caml_collect_alloc_stats_sample(
+  caml_domain_state *local,
+  struct alloc_stats *sample);
+
+struct gc_stats {
+  struct alloc_stats alloc_stats;
+  struct heap_stats heap_stats;
+};
+
+/* Update the sampled stats of a domain from its live stats. */
+void caml_collect_gc_stats_sample(caml_domain_state *domain);
+
+/* Compute global runtime stats.
+
+   The result is an approximation, it uses the live stats of the
+   current domain but the sampled stats of other domains. */
+void caml_compute_gc_stats(struct gc_stats* buf);
+
+#endif /* CAML_INTERNALS */
+
+#endif /* CAML_GC_STATS_H */

--- a/runtime/caml/major_gc.h
+++ b/runtime/caml/major_gc.h
@@ -94,13 +94,21 @@ struct heap_stats {
 void caml_accum_heap_stats(struct heap_stats* acc, const struct heap_stats* s);
 void caml_remove_heap_stats(struct heap_stats* acc, const struct heap_stats* s);
 
-struct gc_stats {
+struct alloc_stats {
   uint64_t minor_words;
   uint64_t promoted_words;
   uint64_t major_words;
   uint64_t minor_collections;
   uint64_t forced_major_collections;
-  struct heap_stats major_heap;
+};
+void caml_accum_alloc_stats(struct alloc_stats* acc, const struct alloc_stats* s);
+void caml_collect_alloc_stats_sample(
+  caml_domain_state *local,
+  struct alloc_stats *sample);
+
+struct gc_stats {
+  struct alloc_stats alloc_stats;
+  struct heap_stats heap_stats;
 };
 
 /* Update the sampled stats of a domain from its live stats. */

--- a/runtime/caml/major_gc.h
+++ b/runtime/caml/major_gc.h
@@ -104,13 +104,13 @@ struct gc_stats {
 };
 
 /* Update the sampled stats of a domain from its live stats. */
-void caml_sample_gc_collect(caml_domain_state *domain);
+void caml_collect_gc_stats_sample(caml_domain_state *domain);
 
 /* Compute global runtime stats.
 
    The result is an approximation, it uses the live stats of the
    current domain but the sampled stats of other domains. */
-void caml_sample_gc_stats(struct gc_stats* buf);
+void caml_compute_gc_stats(struct gc_stats* buf);
 
 
 /* Forces finalisation of all heap-allocated values,

--- a/runtime/caml/major_gc.h
+++ b/runtime/caml/major_gc.h
@@ -84,6 +84,13 @@ struct heap_stats {
   intnat large_max_words;
   intnat large_blocks;
 };
+
+/* Note: accumulating stats then removing them is not a no-op, as
+   accumulating updates maximum values.
+
+   For example, if pool_words and pool_max_words are initially 0,
+   adding 10 then removing 10 will reset pool_words to 0 but leave
+   pool_max_words at 10. */
 void caml_accum_heap_stats(struct heap_stats* acc, const struct heap_stats* s);
 void caml_remove_heap_stats(struct heap_stats* acc, const struct heap_stats* s);
 

--- a/runtime/caml/shared_heap.h
+++ b/runtime/caml/shared_heap.h
@@ -31,7 +31,8 @@ void caml_teardown_shared_heap(struct caml_heap_state* heap);
 
 value* caml_shared_try_alloc(struct caml_heap_state*, mlsize_t, tag_t, int);
 
-void caml_sample_heap_stats(struct caml_heap_state*, struct heap_stats*);
+/* Copy the domain-local heap stats into a heap stats sample. */
+void caml_sample_heap_stats(struct caml_heap_state* local, struct heap_stats *sample);
 
 uintnat caml_heap_size(struct caml_heap_state*);
 uintnat caml_top_heap_words(struct caml_heap_state*);

--- a/runtime/caml/shared_heap.h
+++ b/runtime/caml/shared_heap.h
@@ -32,7 +32,9 @@ void caml_teardown_shared_heap(struct caml_heap_state* heap);
 value* caml_shared_try_alloc(struct caml_heap_state*, mlsize_t, tag_t, int);
 
 /* Copy the domain-local heap stats into a heap stats sample. */
-void caml_sample_heap_stats(struct caml_heap_state* local, struct heap_stats *sample);
+void caml_collect_heap_stats_sample(
+  struct caml_heap_state* local,
+  struct heap_stats *sample);
 
 uintnat caml_heap_size(struct caml_heap_state*);
 uintnat caml_top_heap_words(struct caml_heap_state*);

--- a/runtime/caml/shared_heap.h
+++ b/runtime/caml/shared_heap.h
@@ -22,6 +22,7 @@
 #include "roots.h"
 #include "domain.h"
 #include "misc.h"
+#include "gc_stats.h"
 
 struct caml_heap_state;
 struct pool;

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -1404,7 +1404,7 @@ static void domain_terminate (void)
   }
   /* We can not touch domain_self->interruptor after here
      because it may be reused */
-  caml_sample_gc_collect(domain_state);
+  caml_collect_gc_stats_sample(domain_state);
   caml_remove_generational_global_root(&domain_state->dls_root);
   caml_remove_generational_global_root(&domain_state->backtrace_last_exn);
 

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -439,8 +439,15 @@ static void create_domain(uintnat initial_minor_heap_wsize) {
   domain_self = d;
 
   /* If the chosen domain slot has not been previously used, allocate a fresh
-   * domain state. Otherwise, reuse it. Reusing the slot ensures that the GC
-   * stats are not lost. */
+     domain state. Otherwise, reuse it.
+
+     Reusing the slot ensures that the GC stats are not lost:
+     - Heap stats are moved to the free list on domain termination,
+       so we don't reuse those stats (caml_init_shared_heap will reset them)
+     - But currently there is no orphaning process for allocation stats,
+       we just reuse the previous stats from the previous domain
+       with the same index.
+  */
   if (d->state == NULL) {
     /* FIXME: Never freed. Not clear when to. */
     domain_state = (caml_domain_state*)

--- a/runtime/gc_ctrl.c
+++ b/runtime/gc_ctrl.c
@@ -57,7 +57,7 @@ CAMLprim value caml_gc_quick_stat(value v)
   /* get a copy of these before allocating anything... */
   intnat majcoll;
   struct gc_stats s;
-  caml_sample_gc_stats(&s);
+  caml_compute_gc_stats(&s);
   majcoll = Caml_state->stat_major_collections;
 
   res = caml_alloc_tuple (17);

--- a/runtime/gc_ctrl.c
+++ b/runtime/gc_ctrl.c
@@ -61,29 +61,29 @@ CAMLprim value caml_gc_quick_stat(value v)
   majcoll = Caml_state->stat_major_collections;
 
   res = caml_alloc_tuple (17);
-  Store_field (res, 0, caml_copy_double ((double)s.minor_words));
-  Store_field (res, 1, caml_copy_double ((double)s.promoted_words));
-  Store_field (res, 2, caml_copy_double ((double)s.major_words));
-  Store_field (res, 3, Val_long (s.minor_collections));
+  Store_field (res, 0, caml_copy_double ((double)s.alloc_stats.minor_words));
+  Store_field (res, 1, caml_copy_double ((double)s.alloc_stats.promoted_words));
+  Store_field (res, 2, caml_copy_double ((double)s.alloc_stats.major_words));
+  Store_field (res, 3, Val_long (s.alloc_stats.minor_collections));
   Store_field (res, 4, Val_long (majcoll));
   Store_field (res, 5, Val_long (
-    s.major_heap.pool_words + s.major_heap.large_words));
+    s.heap_stats.pool_words + s.heap_stats.large_words));
   Store_field (res, 6, Val_long (0));
   Store_field (res, 7, Val_long (
-    s.major_heap.pool_live_words + s.major_heap.large_words));
+    s.heap_stats.pool_live_words + s.heap_stats.large_words));
   Store_field (res, 8, Val_long (
-    s.major_heap.pool_live_blocks + s.major_heap.large_blocks));
+    s.heap_stats.pool_live_blocks + s.heap_stats.large_blocks));
   Store_field (res, 9, Val_long (
-    s.major_heap.pool_words - s.major_heap.pool_live_words
-    - s.major_heap.pool_frag_words));
+    s.heap_stats.pool_words - s.heap_stats.pool_live_words
+    - s.heap_stats.pool_frag_words));
   Store_field (res, 10, Val_long (0));
   Store_field (res, 11, Val_long (0));
-  Store_field (res, 12, Val_long (s.major_heap.pool_frag_words));
+  Store_field (res, 12, Val_long (s.heap_stats.pool_frag_words));
   Store_field (res, 13, Val_long (0));
   Store_field (res, 14, Val_long (
-    s.major_heap.pool_max_words + s.major_heap.large_max_words));
+    s.heap_stats.pool_max_words + s.heap_stats.large_max_words));
   Store_field (res, 15, Val_long (0));
-  Store_field (res, 16, Val_long (s.forced_major_collections));
+  Store_field (res, 16, Val_long (s.alloc_stats.forced_major_collections));
   CAMLreturn (res);
 }
 

--- a/runtime/gc_stats.c
+++ b/runtime/gc_stats.c
@@ -1,0 +1,121 @@
+/**************************************************************************/
+/*                                                                        */
+/*                                 OCaml                                  */
+/*                                                                        */
+/*             Gabriel Scherer, projet Partout, INRIA Saclay              */
+/*                                                                        */
+/*   Copyright 2022 Institut National de Recherche en Informatique et     */
+/*     en Automatique.                                                    */
+/*                                                                        */
+/*   All rights reserved.  This file is distributed under the terms of    */
+/*   the GNU Lesser General Public License version 2.1, with the          */
+/*   special exception on linking described in the file LICENSE.          */
+/*                                                                        */
+/**************************************************************************/
+
+#define CAML_INTERNALS
+
+#include "caml/shared_heap.h"
+#include "caml/gc_stats.h"
+
+Caml_inline intnat intnat_max(intnat a, intnat b) {
+  return (a > b ? a : b);
+}
+
+void caml_accum_heap_stats(struct heap_stats* acc, const struct heap_stats* h)
+{
+  acc->pool_words += h->pool_words;
+  acc->pool_max_words = intnat_max(acc->pool_max_words, acc->pool_words);
+  acc->pool_max_words = intnat_max(acc->pool_max_words, h->pool_max_words);
+  acc->pool_live_words += h->pool_live_words;
+  acc->pool_live_blocks += h->pool_live_blocks;
+  acc->pool_frag_words += h->pool_frag_words;
+  acc->large_words += h->large_words;
+  acc->large_max_words = intnat_max(acc->large_max_words, acc->large_words);
+  acc->large_max_words = intnat_max(acc->large_max_words, h->large_max_words);
+  acc->large_blocks += h->large_blocks;
+}
+
+void caml_remove_heap_stats(struct heap_stats* acc, const struct heap_stats* h)
+{
+  acc->pool_words -= h->pool_words;
+  acc->pool_live_words -= h->pool_live_words;
+  acc->pool_live_blocks -= h->pool_live_blocks;
+  acc->pool_frag_words -= h->pool_frag_words;
+  acc->large_words -= h->large_words;
+  acc->large_blocks -= h->large_blocks;
+}
+
+void caml_accum_alloc_stats(
+  struct alloc_stats* acc,
+  const struct alloc_stats* s)
+{
+  acc->minor_words += s->minor_words;
+  acc->promoted_words += s->promoted_words;
+  acc->major_words += s->major_words;
+  acc->minor_collections += s->minor_collections;
+  acc->forced_major_collections += s->forced_major_collections;
+}
+
+void caml_collect_alloc_stats_sample(
+  caml_domain_state *local,
+  struct alloc_stats *sample)
+{
+  sample->minor_words = local->stat_minor_words;
+  sample->promoted_words = local->stat_promoted_words;
+  sample->major_words = local->stat_major_words;
+  sample->minor_collections = local->stat_minor_collections;
+  sample->forced_major_collections = local->stat_forced_major_collections;
+}
+
+/* The "sampled stats" of a domain are a recent copy of its
+   domain-local stats, accessed without synchronization and only
+   updated ("sampled") during stop-the-world events -- each minor
+   collection, and on domain termination. */
+static struct gc_stats sampled_gc_stats[Max_domains];
+
+/* Update the sampled stats for the given domain. */
+void caml_collect_gc_stats_sample(caml_domain_state* domain)
+{
+  struct gc_stats* stats = &sampled_gc_stats[domain->id];
+  caml_collect_alloc_stats_sample(domain, &stats->alloc_stats);
+  caml_collect_heap_stats_sample(domain->shared_heap, &stats->heap_stats);
+}
+
+/* Compute global stats for the whole runtime. */
+void caml_compute_gc_stats(struct gc_stats* buf)
+{
+  int i;
+  intnat pool_max = 0, large_max = 0;
+  int my_id = Caml_state->id;
+  memset(buf, 0, sizeof(*buf));
+
+  for (i=0; i<Max_domains; i++) {
+    /* For allocation stats, we use the live stats of the current domain
+       and the sampled stats of other domains.
+
+       For the heap stats, we always used the sampled stats. */
+    struct gc_stats* s = &sampled_gc_stats[i];
+    if (i != my_id) {
+      caml_accum_alloc_stats(&buf->alloc_stats, &s->alloc_stats);
+      caml_accum_heap_stats(&buf->heap_stats, &s->heap_stats);
+    }
+    else {
+      struct alloc_stats alloc_stats;
+      caml_collect_alloc_stats_sample(Caml_state, &alloc_stats);
+      caml_accum_alloc_stats(&buf->alloc_stats, &alloc_stats);
+      caml_accum_heap_stats(&buf->heap_stats, &s->heap_stats);
+      //FIXME use live heap stats instead of sampled heap stats below?
+    }
+    /* The instantaneous maximum heap size cannot be computed
+       from per-domain statistics, and would be very expensive
+       to maintain directly. Here, we just sum the per-domain
+       maxima, which is completely wrong.
+
+       FIXME: maybe maintain coarse global maxima? */
+    pool_max += s->heap_stats.pool_max_words;
+    large_max += s->heap_stats.large_max_words;
+  }
+  buf->heap_stats.pool_max_words = pool_max;
+  buf->heap_stats.large_max_words = large_max;
+}

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -942,7 +942,7 @@ void caml_remove_heap_stats(struct heap_stats* acc, const struct heap_stats* h)
 }
 
 /* Compute global stats for the whole runtime. */
-void caml_sample_gc_stats(struct gc_stats* buf)
+void caml_compute_gc_stats(struct gc_stats* buf)
 {
   int i;
   intnat pool_max = 0, large_max = 0;
@@ -986,7 +986,7 @@ void caml_sample_gc_stats(struct gc_stats* buf)
 }
 
 /* Update the sampled stats for the given domain. */
-void caml_sample_gc_collect(caml_domain_state* domain)
+void caml_collect_gc_stats_sample(caml_domain_state* domain)
 {
   struct gc_stats* stats = &sampled_gc_stats[domain->id];
 
@@ -995,7 +995,7 @@ void caml_sample_gc_collect(caml_domain_state* domain)
   stats->major_words = domain->stat_major_words;
   stats->minor_collections = domain->stat_minor_collections;
   stats->forced_major_collections = domain->stat_forced_major_collections;
-  caml_sample_heap_stats(domain->shared_heap, &stats->major_heap);
+  caml_collect_heap_stats_sample(domain->shared_heap, &stats->major_heap);
 }
 
 static void cycle_all_domains_callback(caml_domain_state* domain, void* unused,
@@ -1034,7 +1034,7 @@ static void cycle_all_domains_callback(caml_domain_state* domain, void* unused,
         struct gc_stats s;
         intnat heap_words, not_garbage_words, swept_words;
 
-        caml_sample_gc_stats(&s);
+        caml_compute_gc_stats(&s);
         heap_words = s.major_heap.pool_words + s.major_heap.large_words;
         not_garbage_words = s.major_heap.pool_live_words
                             + s.major_heap.large_words;

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -986,7 +986,7 @@ void caml_sample_gc_stats(struct gc_stats* buf)
 }
 
 /* Update the sampled stats for the given domain. */
-inline void caml_sample_gc_collect(caml_domain_state* domain)
+void caml_sample_gc_collect(caml_domain_state* domain)
 {
   struct gc_stats* stats = &sampled_gc_stats[domain->id];
 

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -913,17 +913,21 @@ static intnat ephe_sweep (caml_domain_state* domain_state, intnat budget)
    collection, and on domain termination. */
 static struct gc_stats sampled_gc_stats[Max_domains];
 
+Caml_inline intnat intnat_max(intnat a, intnat b) {
+  return (a > b ? a : b);
+}
+
 void caml_accum_heap_stats(struct heap_stats* acc, const struct heap_stats* h)
 {
   acc->pool_words += h->pool_words;
-  if (acc->pool_max_words < h->pool_max_words)
-    acc->pool_max_words = h->pool_max_words;
+  acc->pool_max_words = intnat_max(acc->pool_max_words, acc->pool_words);
+  acc->pool_max_words = intnat_max(acc->pool_max_words, h->pool_max_words);
   acc->pool_live_words += h->pool_live_words;
   acc->pool_live_blocks += h->pool_live_blocks;
   acc->pool_frag_words += h->pool_frag_words;
   acc->large_words += h->large_words;
-  if (acc->large_max_words < h->large_max_words)
-    acc->large_max_words = h->large_max_words;
+  acc->large_max_words = intnat_max(acc->large_max_words, acc->large_words);
+  acc->large_max_words = intnat_max(acc->large_max_words, h->large_max_words);
   acc->large_blocks += h->large_blocks;
 }
 

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -27,6 +27,7 @@
 #include "caml/fiber.h"
 #include "caml/finalise.h"
 #include "caml/globroots.h"
+#include "caml/gc_stats.h"
 #include "caml/memory.h"
 #include "caml/mlvalues.h"
 #include "caml/platform.h"
@@ -907,104 +908,6 @@ static intnat ephe_sweep (caml_domain_state* domain_state, intnat budget)
   return budget;
 }
 
-/* The "sampled stats" of a domain are a recent copy of its
-   domain-local stats, accessed without synchronization and only
-   updated ("sampled") during stop-the-world events -- each minor
-   collection, and on domain termination. */
-static struct gc_stats sampled_gc_stats[Max_domains];
-
-Caml_inline intnat intnat_max(intnat a, intnat b) {
-  return (a > b ? a : b);
-}
-
-void caml_accum_heap_stats(struct heap_stats* acc, const struct heap_stats* h)
-{
-  acc->pool_words += h->pool_words;
-  acc->pool_max_words = intnat_max(acc->pool_max_words, acc->pool_words);
-  acc->pool_max_words = intnat_max(acc->pool_max_words, h->pool_max_words);
-  acc->pool_live_words += h->pool_live_words;
-  acc->pool_live_blocks += h->pool_live_blocks;
-  acc->pool_frag_words += h->pool_frag_words;
-  acc->large_words += h->large_words;
-  acc->large_max_words = intnat_max(acc->large_max_words, acc->large_words);
-  acc->large_max_words = intnat_max(acc->large_max_words, h->large_max_words);
-  acc->large_blocks += h->large_blocks;
-}
-
-void caml_remove_heap_stats(struct heap_stats* acc, const struct heap_stats* h)
-{
-  acc->pool_words -= h->pool_words;
-  acc->pool_live_words -= h->pool_live_words;
-  acc->pool_live_blocks -= h->pool_live_blocks;
-  acc->pool_frag_words -= h->pool_frag_words;
-  acc->large_words -= h->large_words;
-  acc->large_blocks -= h->large_blocks;
-}
-
-void caml_accum_alloc_stats(struct alloc_stats* acc, const struct alloc_stats* s) {
-  acc->minor_words += s->minor_words;
-  acc->promoted_words += s->promoted_words;
-  acc->major_words += s->major_words;
-  acc->minor_collections += s->minor_collections;
-  acc->forced_major_collections += s->forced_major_collections;
-}
-
-void caml_collect_alloc_stats_sample(
-  caml_domain_state *local,
-  struct alloc_stats *sample)
-{
-  sample->minor_words = local->stat_minor_words;
-  sample->promoted_words = local->stat_promoted_words;
-  sample->major_words = local->stat_major_words;
-  sample->minor_collections = local->stat_minor_collections;
-  sample->forced_major_collections = local->stat_forced_major_collections;
-}
-
-/* Compute global stats for the whole runtime. */
-void caml_compute_gc_stats(struct gc_stats* buf)
-{
-  int i;
-  intnat pool_max = 0, large_max = 0;
-  int my_id = Caml_state->id;
-  memset(buf, 0, sizeof(*buf));
-
-  for (i=0; i<Max_domains; i++) {
-    /* For allocation stats, we use the live stats of the current domain
-       and the sampled stats of other domains.
-
-       For the heap stats, we always used the sampled stats. */
-    struct gc_stats* s = &sampled_gc_stats[i];
-    if (i != my_id) {
-      caml_accum_alloc_stats(&buf->alloc_stats, &s->alloc_stats);
-      caml_accum_heap_stats(&buf->heap_stats, &s->heap_stats);
-    }
-    else {
-      struct alloc_stats alloc_stats;
-      caml_collect_alloc_stats_sample(Caml_state, &alloc_stats);
-      caml_accum_alloc_stats(&buf->alloc_stats, &alloc_stats);
-      caml_accum_heap_stats(&buf->heap_stats, &s->heap_stats);
-      //FIXME use live heap stats instead of sampled heap stats below?
-    }
-    /* The instantaneous maximum heap size cannot be computed
-       from per-domain statistics, and would be very expensive
-       to maintain directly. Here, we just sum the per-domain
-       maxima, which is completely wrong.
-
-       FIXME: maybe maintain coarse global maxima? */
-    pool_max += s->heap_stats.pool_max_words;
-    large_max += s->heap_stats.large_max_words;
-  }
-  buf->heap_stats.pool_max_words = pool_max;
-  buf->heap_stats.large_max_words = large_max;
-}
-
-/* Update the sampled stats for the given domain. */
-void caml_collect_gc_stats_sample(caml_domain_state* domain)
-{
-  struct gc_stats* stats = &sampled_gc_stats[domain->id];
-  caml_collect_alloc_stats_sample(domain, &stats->alloc_stats);
-  caml_collect_heap_stats_sample(domain->shared_heap, &stats->heap_stats);
-}
 
 static void cycle_all_domains_callback(caml_domain_state* domain, void* unused,
                                        int participating_count,

--- a/runtime/minor_gc.c
+++ b/runtime/minor_gc.c
@@ -688,7 +688,7 @@ static void caml_stw_empty_minor_heap_no_major_slice(caml_domain_state* domain,
   caml_empty_minor_heap_promote(domain, participating_count, participating);
 
   /* collect gc stats before leaving the barrier */
-  caml_sample_gc_collect(domain);
+  caml_collect_gc_stats_sample(domain);
 
   if( participating_count > 1 ) {
     CAML_EV_BEGIN(EV_MINOR_LEAVE_BARRIER);

--- a/runtime/shared_heap.c
+++ b/runtime/shared_heap.c
@@ -150,9 +150,9 @@ void caml_teardown_shared_heap(struct caml_heap_state* heap) {
               released, released_large);
 }
 
-void caml_sample_heap_stats(struct caml_heap_state* local, struct heap_stats* h)
+void caml_sample_heap_stats(struct caml_heap_state* local, struct heap_stats* sample)
 {
-  *h = local->stats;
+  *sample = local->stats;
 }
 
 
@@ -286,6 +286,8 @@ static pool* pool_global_adopt(struct caml_heap_state* local, sizeclass sz)
       }
       #endif
 
+      /* The stats for the adopted pool are moved from the
+         free pool stats to the heap stats of the adopting domain. */
       calc_pool_stats(r, sz, &tmp_stats);
       caml_accum_heap_stats(&local->stats, &tmp_stats);
       caml_remove_heap_stats(&pool_freelist.stats, &tmp_stats);
@@ -587,6 +589,8 @@ uintnat caml_heap_size(struct caml_heap_state* local) {
 }
 
 uintnat caml_top_heap_words(struct caml_heap_state* local) {
+  /* FIXME: summing two maximums computed at different points in time
+     returns an incorrect result. */
   return local->stats.pool_max_words + local->stats.large_max_words;
 }
 

--- a/runtime/shared_heap.c
+++ b/runtime/shared_heap.c
@@ -150,7 +150,9 @@ void caml_teardown_shared_heap(struct caml_heap_state* heap) {
               released, released_large);
 }
 
-void caml_sample_heap_stats(struct caml_heap_state* local, struct heap_stats* sample)
+void caml_collect_heap_stats_sample(
+  struct caml_heap_state* local,
+  struct heap_stats* sample)
 {
   *sample = local->stats;
 }

--- a/runtime/shared_heap.c
+++ b/runtime/shared_heap.c
@@ -264,10 +264,6 @@ static void pool_global_adopt_stats(struct caml_heap_state* local,
     calc_pool_stats(r, sz, &pool_stats);
     caml_accum_heap_stats(&local->stats, &pool_stats);
     caml_remove_heap_stats(&pool_freelist.stats, &pool_stats);
-
-    if (local->stats.pool_words > local->stats.pool_max_words) {
-        local->stats.pool_max_words = local->stats.pool_words;
-    }
 }
 
 /* Adopt pool from the pool_freelist avail and full pools

--- a/runtime/sys.c
+++ b/runtime/sys.c
@@ -136,14 +136,16 @@ CAMLexport void caml_do_exit(int retcode)
     caml_compute_gc_stats(&s);
     {
       /* cf caml_gc_counters */
-      double minwords = s.minor_words
+      double minwords = s.alloc_stats.minor_words
         + (double) (domain_state->young_end - domain_state->young_ptr);
-      double majwords = s.major_words + (double) domain_state->allocated_words;
-      double allocated_words = minwords + majwords - s.promoted_words;
+      double majwords = s.alloc_stats.major_words
+        + (double) domain_state->allocated_words;
+      double allocated_words = minwords + majwords
+        - s.alloc_stats.promoted_words;
       intnat heap_words =
-        s.major_heap.pool_words + s.major_heap.large_words;
+        s.heap_stats.pool_words + s.heap_stats.large_words;
       intnat top_heap_words =
-        s.major_heap.pool_max_words + s.major_heap.large_max_words;
+        s.heap_stats.pool_max_words + s.heap_stats.large_max_words;
 
       if (heap_words == 0) {
         heap_words = Wsize_bsize(caml_heap_size(Caml_state->shared_heap));
@@ -158,18 +160,18 @@ CAMLexport void caml_do_exit(int retcode)
       caml_gc_message(0x400, "minor_words: %"ARCH_INTNAT_PRINTF_FORMAT"d\n",
                       (intnat) minwords);
       caml_gc_message(0x400, "promoted_words: %"ARCH_INTNAT_PRINTF_FORMAT"d\n",
-                      (intnat) s.promoted_words);
+                      (intnat) s.alloc_stats.promoted_words);
       caml_gc_message(0x400, "major_words: %"ARCH_INTNAT_PRINTF_FORMAT"d\n",
                       (intnat) majwords);
       caml_gc_message(0x400,
           "minor_collections: %"ARCH_INTNAT_PRINTF_FORMAT"d\n",
-          (intnat) s.minor_collections);
+          (intnat) s.alloc_stats.minor_collections);
       caml_gc_message(0x400,
           "major_collections: %"ARCH_INTNAT_PRINTF_FORMAT"d\n",
           domain_state->stat_major_collections);
       caml_gc_message(0x400,
           "forced_major_collections: %"ARCH_INTNAT_PRINTF_FORMAT"d\n",
-          (intnat)s.forced_major_collections);
+          (intnat)s.alloc_stats.forced_major_collections);
       caml_gc_message(0x400, "heap_words: %"ARCH_INTNAT_PRINTF_FORMAT"d\n",
                       heap_words);
       caml_gc_message(0x400, "top_heap_words: %"ARCH_INTNAT_PRINTF_FORMAT"d\n",

--- a/runtime/sys.c
+++ b/runtime/sys.c
@@ -133,7 +133,7 @@ CAMLexport void caml_do_exit(int retcode)
   struct gc_stats s;
 
   if ((caml_params->verb_gc & 0x400) != 0) {
-    caml_sample_gc_stats(&s);
+    caml_compute_gc_stats(&s);
     {
       /* cf caml_gc_counters */
       double minwords = s.minor_words


### PR DESCRIPTION
This is a series of refactoring commits for the "gc stats" part of the runtime code, starting with a documentation commit. It is meant to be reviewed commit-by-commit.

My goal is to be able to discuss and understand well what is going on with a refactoring-only PR, and then solve issues in followup PRs:
- We want "orphaned allocation statistics" to remove the current constraint that we have to reuse domain states (see the introduction of #10950); in fact, currently, unless I'm missing something, the orphaned shared-heap stats (free_pools.stats) are also not counted in the printed statistics. I have a patchset fixing both issues on the way, on to of the present PR.
- The computation of maximum stats values is broken right now (it will sum the maximums on all domains, which does not make sense), and we should also fix this. This would be a follow-up PR with some discussion, because we have to decide which behavior we want. (My proposal is to compute "total" values at sampling time during the stop-the-world, and have global state to keep track of the maximum of these total values.)
 
(Note: I believe that the computation of `top_heap_words` is also incorrect.)

Github suggests as potential reviewers @sadiqj, @Engil and @kayceesrk, and that sounds about right.

P.S.: I believe that there are not much tests for GC statistics in the current testsuite, this PR probably needs some.