### PR TITLE
Alternative approach to using strerror_r for reentrant error string conversion

### DIFF
--- a/Changes
+++ b/Changes
@@ -4,6 +4,7 @@ Working version
 ### Language features:
 
 ### Runtime system:
+
 - #10831: Multicore OCaml
   (The multicore team, caml-devel and more)
 
@@ -34,6 +35,9 @@ Working version
   the domain_state structure.
   (Enguerrand Decorne, KC Sivaramakrishnan and Tom Kelly,
   review by Anil Madhavapeddy and Gabriel Scherer)
+
+- #11010: Use strerror_r for reentrant error string conversion.
+  (Anil Madhavapeddy and Xavier Leroy, review by same and Edwin Török)
 
 ### Code generation and optimizations:
 

--- a/otherlibs/unix/errmsg.c
+++ b/otherlibs/unix/errmsg.c
@@ -13,13 +13,17 @@
 /*                                                                        */
 /**************************************************************************/
 
+#define CAML_INTERNALS
+
 #include <errno.h>
 #include <string.h>
 #include <caml/alloc.h>
+#include <caml/sys.h>
 #include "unixsupport.h"
 
 CAMLprim value unix_error_message(value err)
 {
+  char buf[1024];
   int errnum = code_of_unix_error(err);
-  return caml_copy_string(strerror(errnum));
+  return caml_copy_string(caml_strerror(errnum, buf, sizeof(buf)));
 }

--- a/runtime/caml/platform.h
+++ b/runtime/caml/platform.h
@@ -121,13 +121,13 @@ void caml_mem_decommit(void* mem, uintnat size);
 void caml_mem_unmap(void* mem, uintnat size);
 
 
+CAMLnoreturn_start
+void caml_plat_fatal_error(char * action, int err)
+CAMLnoreturn_end;
+
 Caml_inline void check_err(char* action, int err)
 {
-  if (err) {
-    char buf[1024];
-    caml_fatal_error("Fatal error during %s: %s\n",
-                     action, caml_strerror(err, buf, sizeof(buf)));
-  }
+  if (err) caml_plat_fatal_error(action, err);
 }
 
 #ifdef DEBUG

--- a/runtime/caml/platform.h
+++ b/runtime/caml/platform.h
@@ -25,6 +25,7 @@
 #include <string.h>
 #include "config.h"
 #include "mlvalues.h"
+#include "sys.h"
 
 #if defined(MAP_ANON) && !defined(MAP_ANONYMOUS)
 #define MAP_ANONYMOUS MAP_ANON
@@ -123,7 +124,9 @@ void caml_mem_unmap(void* mem, uintnat size);
 Caml_inline void check_err(char* action, int err)
 {
   if (err) {
-    caml_fatal_error("Fatal error during %s: %s\n", action, strerror(err));
+    char buf[1024];
+    caml_fatal_error("Fatal error during %s: %s\n",
+                     action, caml_strerror(err, buf, sizeof(buf)));
   }
 }
 

--- a/runtime/caml/sys.h
+++ b/runtime/caml/sys.h
@@ -24,6 +24,8 @@
 extern "C" {
 #endif
 
+CAMLextern char * caml_strerror(int errnum, char * buf, size_t buflen);
+
 #define NO_ARG Val_int(0)
 
 CAMLnoreturn_start

--- a/runtime/debugger.c
+++ b/runtime/debugger.c
@@ -31,6 +31,7 @@
 #include "caml/memory.h"
 #include "caml/osdeps.h"
 #include "caml/skiplist.h"
+#include "caml/sys.h"
 
 int caml_debugger_in_use = 0;
 uintnat caml_event_count;
@@ -110,6 +111,7 @@ static struct skiplist event_points_table = SKIPLIST_STATIC_INITIALIZER;
 
 static void open_connection(void)
 {
+  char buf[1024];
 #ifdef _WIN32
   /* Set socket to synchronous mode (= non-overlapped) so that file
      descriptor-oriented functions (read()/write() etc.) can be
@@ -133,7 +135,7 @@ static void open_connection(void)
     caml_fatal_error("cannot connect to debugger at %s\n"
                      "error: %s",
                      (dbg_addr ? dbg_addr : "(none)"),
-                     strerror (errno));
+                     caml_strerror(errno, buf, sizeof(buf)));
   dbg_in = caml_open_descriptor_in(dbg_socket);
   dbg_out = caml_open_descriptor_out(dbg_socket);
   /* The code in this file does not bracket channel I/O operations with

--- a/runtime/platform.c
+++ b/runtime/platform.c
@@ -28,6 +28,15 @@
 #include <windows.h>
 #endif
 
+/* Error reporting */
+
+void caml_plat_fatal_error(char * action, int err)
+{
+  char buf[1024];
+  caml_fatal_error("Fatal error during %s: %s\n",
+                   action, caml_strerror(err, buf, sizeof(buf)));
+}
+
 /* Mutexes */
 
 void caml_plat_mutex_init(caml_plat_mutex * m)

--- a/runtime/signals.c
+++ b/runtime/signals.c
@@ -430,7 +430,7 @@ void caml_free_signal_stack(void)
      but OSX/Darwin fails if the size isn't set. */
   disable.ss_size = SIGSTKSZ;
   if (sigaltstack(&disable, &stk) < 0) {
-    caml_fatal_error("Failed to reset signal stack: %s", strerror(errno));
+    caml_fatal_error("Failed to reset signal stack (err %d)", errno);
   }
   /* Memory was allocated with malloc directly; see caml_init_signal_stack */
   free(stk.ss_sp);

--- a/runtime/sync.c
+++ b/runtime/sync.c
@@ -23,6 +23,7 @@
 
 #include "caml/signals.h"
 #include "caml/sync.h"
+#include "caml/sys.h"
 #include "caml/eventlog.h"
 
 /* System-dependent part */

--- a/runtime/sync_posix.h
+++ b/runtime/sync_posix.h
@@ -124,12 +124,13 @@ Caml_inline int sync_condvar_wait(sync_condvar c, sync_mutex m)
 static void sync_check_error(int retcode, char * msg)
 {
   char * err;
+  char buf[1024];
   int errlen, msglen;
   value str;
 
   if (retcode == 0) return;
   if (retcode == ENOMEM) caml_raise_out_of_memory();
-  err = strerror(retcode);
+  err = caml_strerror(retcode, buf, sizeof(buf));
   msglen = strlen(msg);
   errlen = strlen(err);
   str = caml_alloc_string(msglen + 2 + errlen);


### PR DESCRIPTION
This is a variant of #10969 that does not use thread-local storage.  Instead, `caml_strerror` is given the same interface as the GNU nonstandard `strerror_r` function: it takes a buffer as argument, which it may use or not, and returns a `char *` pointing to the error message, which can be in the buffer or not.
