### PR TITLE
Env: clear uid_to_loc

### DIFF
--- a/Changes
+++ b/Changes
@@ -477,10 +477,10 @@ OCaml 4.14.0
   (David Allsopp and Nathan Rebours, review by Louis Gesbert,
   Nicolás Ojeda Bär and Gabriel Scherer)
 
-- #10718: Add "Shape" information to the cmt files. Shapes are an abstraction of
-  modules that can be used by external tooling to perform definition-aware
-  operations. (Ulysse Gérard, Thomas Refis and Leo White, review by Florian
-  Angeletti)
+- #10718, #11012: Add "Shape" information to the cmt files. Shapes are an
+  abstraction of modules that can be used by external tooling to perform
+  definition-aware operations.
+  (Ulysse Gérard, Thomas Refis and Leo White, review by Florian Angeletti)
 
 - #10742: strong call-by-need reduction for shapes
   (Gabriel Scherer and Nathanaëlle Courant,

--- a/typing/env.ml
+++ b/typing/env.ml
@@ -937,6 +937,7 @@ let reset_declaration_caches () =
   Types.Uid.Tbl.clear !module_declarations;
   Types.Uid.Tbl.clear !used_constructors;
   Types.Uid.Tbl.clear !used_labels;
+  Types.Uid.Tbl.clear !uid_to_loc;
   ()
 
 let reset_cache () =


### PR DESCRIPTION
#10718 introduced a new table in env, whose content gets stored in `.cmt` file. However, the "reset" code wasn't provided, so if one compiles several files with one compiler invocation (i.e. `ocamlc -bin-annot -c foo.ml bar.ml baz.ml`) the table only gets bigger with each file.