### PR TITLE
Cut polling of pending signals vector in bytecode interpreter

### DIFF
--- a/runtime/caml/domain.h
+++ b/runtime/caml/domain.h
@@ -28,6 +28,7 @@ extern "C" {
 #include "domain_state.h"
 #include "platform.h"
 
+/* is the minor heap full or an external interrupt has been triggered */
 #define Caml_check_gc_interrupt(dom_st)   \
   (CAMLalloc_point_here, \
    CAMLunlikely( \
@@ -37,9 +38,9 @@ extern "C" {
 asize_t caml_norm_minor_heap_size (intnat);
 int caml_reallocate_minor_heap(asize_t);
 
+/* is there a STW interrupt queued that needs servicing */
 int caml_incoming_interrupts_queued(void);
 
-int caml_check_pending_interrupt(void);
 void caml_handle_gc_interrupt(void);
 void caml_handle_incoming_interrupts(void);
 

--- a/runtime/interp.c
+++ b/runtime/interp.c
@@ -912,8 +912,7 @@ value caml_interprete(code_t prog, asize_t prog_size)
       Next;
 
     Instruct(POPTRAP):
-      if (Caml_check_gc_interrupt(domain_state) ||
-          caml_check_pending_signals()) {
+      if (Caml_check_gc_interrupt(domain_state)) {
         /* We must check here so that if a signal is pending and its
            handler triggers an exception, the exception is trapped
            by the current try...with, not the enclosing one. */
@@ -996,8 +995,7 @@ value caml_interprete(code_t prog, asize_t prog_size)
 /* Signal handling */
 
     Instruct(CHECK_SIGNALS):    /* accu not preserved */
-      if (Caml_check_gc_interrupt(domain_state) ||
-          caml_check_pending_signals())
+      if (Caml_check_gc_interrupt(domain_state))
         goto process_signal;
       Next;
 

--- a/runtime/signals.c
+++ b/runtime/signals.c
@@ -234,7 +234,7 @@ void caml_request_minor_gc (void)
 
 CAMLexport int caml_check_pending_actions(void)
 {
-  return (caml_check_pending_interrupt() ||
+  return (Caml_check_gc_interrupt(Caml_state) ||
           caml_check_pending_signals());
 }
 


### PR DESCRIPTION
This PR cuts out polling using `caml_check_pending_signals` in the bytecode interpreter. It instead relies on `Caml_check_gc_interrupt`; this check will catch pending signals via the update of `young_limit` to `INTERRUPT_MAGIC` from `caml_record_signal` calling `caml_interrupt_self`. The argument for this PR is the simplification and alignment between bytecode & native of polling behaviour; the performance improvement is ~1%.

There are two commits:
 - 2b28a1e which moves to `Caml_check_gc_interrupt`. 
 - a0220b4 I believe is a good thing. We rely on the sequence in `Caml_check_gc_interrupt` to catch signals correctly in native code and so it should be enough. 
 
The history of this:
 - it was noticed that bytecode was probably polling more than necessary: https://github.com/ocaml/ocaml/pull/10880#issuecomment-1011081098
 - at the time signal polling was added: https://github.com/ocaml-multicore/ocaml-multicore/pull/722, it was noted that the polling might be overdone. I've dug into this, I believe the fix is this change:
```diff
#define Enter_gc \
-  { Setup_for_gc; caml_handle_gc_interrupt(); Restore_after_gc; }
+  { Setup_for_gc; caml_handle_gc_interrupt(); \
+    caml_check_for_pending_signals();         \
+    Restore_after_gc; }
```

The performance improvement is small (but not unexpected as perf reports ~1% of runtime in `caml_check_pending_signals`). My performance results using `time make -C testsuite all` (Linux 4.15, Xeon E5-2695):
```
Before this PR:
real    15m22.675s
user    16m20.094s
sys     2m24.541s

After this PR:
real    15m11.318s
user    16m14.501s
sys     2m25.550s
```

@gadmm @Engil @sadiqj 