### PR TITLE
remove unncessary Current_thread restore in caml_thread_enter_blocking_section

### DIFF
--- a/otherlibs/systhreads/st_stubs.c
+++ b/otherlibs/systhreads/st_stubs.c
@@ -207,7 +207,6 @@ static void caml_thread_enter_blocking_section(void)
 {
   /* Save the current runtime state in the thread descriptor
      of the current thread */
-  Current_thread = st_tls_get(Thread_key);
   caml_thread_save_runtime_state();
   /* Tell other threads that the runtime is free */
   st_masterlock_release(&Thread_main_lock);


### PR DESCRIPTION
Identified by @gadmm in https://github.com/ocaml/ocaml/pull/10966#discussion_r802147781 it seems we're doing an unnecessary restore of `Current_thread` in Systhreads' `caml_thread_enter_blocking_section`.

4.14's `caml_thread_enter_blocking_section` for reference: https://github.com/ocaml/ocaml/blob/4.14/otherlibs/systhreads/st_stubs.c#L230

cc @Engil 