### PR TITLE
Shapes: Add an option to share memo tables accros reductions

### DIFF
--- a/typing/shape.ml
+++ b/typing/shape.ml
@@ -437,7 +437,7 @@ end) = struct
     let reduce_memo_table, read_back_memo_table =
       match shared_memo_tables with
       | Some tables -> tables
-      | None -> Hashtbl.(create 42, create 42)
+      | None -> Hashtbl.create 42, Hashtbl.create 42
     in
     let local_env = Ident.Map.empty in
     let env = {

--- a/typing/shape.mli
+++ b/typing/shape.mli
@@ -147,6 +147,8 @@ module Make_reduce(Context : sig
 
     val fuel : int
 
+    val share_memo : bool
+
     val read_unit_shape : unit_name:string -> t option
 
     val find_shape : env -> Ident.t -> t


### PR DESCRIPTION
While developing a new tool that indexes uids from cmt files we realised that performing so many shapes reductions would benefit from a shared memo table. (In the current implementation a new memo table is created for each call to `reduce`.)

In this PR I propose a new option that is passed during the functor instantiation to choose to use persistent memo tables instead of reduce-bound ones. In that case the memo tables are created during the functor instantiation and are thus shared by all subsequent `reduce` calls.

This led to a nice performance improvement when indexing the cmts of functor-hungry projects: on Irmin the indexing time for all the cmts of the main lib drops from 14.5s to 1.3s.