### PR TITLE
Bugfix for `caml_ba_alloc` GC work tracking

### DIFF
--- a/Changes
+++ b/Changes
@@ -47,6 +47,9 @@ Working version
   Windows.
   (Nicolás Ojeda Bär, review by Xavier Leroy and David Allsopp)
 
+- #11022: Track GC work for all managed bigarray allocations
+  (Stephen Dolan, report by Andrew Hunter, review by Damien Doligez)
+
 ### Code generation and optimizations:
 
 - #10972: ARM64 multicore support: OCaml & C stack separation;


### PR DESCRIPTION
When the `caml_ba_alloc` allocates memory for a bigarray, it calls `caml_alloc_custom_mem` with nonzero size, instructing the GC to speed up. When it is given preallocated memory, it uses `size = 0`, causing no GC speedup.

This criterion is slightly wrong: if given preallocated memory with the `CAML_BA_MANAGED` flag set, then the lifetime of this memory is managed by the GC, and the GC should speed up.

This patch passes the size when either `caml_ba_alloc` does the allocation itself, or `CAML_BA_MANAGED` flag was set. This means that the GC speeds up iff the GC now has more memory to manage.

cc @ahh (who reported the issue)