### PR TITLE
Careful minor heap clear in DEBUG

### DIFF
--- a/runtime/caml/memory.h
+++ b/runtime/caml/memory.h
@@ -185,13 +185,12 @@ CAMLextern wchar_t* caml_stat_wcsconcat(int n, ...);
 #endif
 
 #ifdef DEBUG
-#define DEBUG_clear(result, wosize) do{                                     \
-  uintnat caml__DEBUG_i;                                                    \
-  for (caml__DEBUG_i = 0; caml__DEBUG_i < (wosize); ++ caml__DEBUG_i) {     \
-    CAMLassert(Field((result), caml__DEBUG_i) == Debug_free_minor);         \
-    Field ((result), caml__DEBUG_i) = Debug_uninit_minor;                   \
-  }                                                                         \
-}while(0)
+Caml_inline void DEBUG_clear(value result, mlsize_t wosize) {
+  for (mlsize_t i=0; i<wosize; ++i) {
+    CAMLassert(Field(result, i) == Debug_free_minor);
+    Field(result, i) = Debug_uninit_minor;
+  }
+}
 #else
 #define DEBUG_clear(result, wosize)
 #endif

--- a/runtime/caml/memory.h
+++ b/runtime/caml/memory.h
@@ -185,11 +185,12 @@ CAMLextern wchar_t* caml_stat_wcsconcat(int n, ...);
 #endif
 
 #ifdef DEBUG
-#define DEBUG_clear(result, wosize) do{ \
-  uintnat caml__DEBUG_i; \
-  for (caml__DEBUG_i = 0; caml__DEBUG_i < (wosize); ++ caml__DEBUG_i){ \
-    Field ((result), caml__DEBUG_i) = Debug_uninit_minor; \
-  } \
+#define DEBUG_clear(result, wosize) do{                                     \
+  uintnat caml__DEBUG_i;                                                    \
+  for (caml__DEBUG_i = 0; caml__DEBUG_i < (wosize); ++ caml__DEBUG_i) {     \
+    CAMLassert(Field((result), caml__DEBUG_i) == Debug_free_minor);         \
+    Field ((result), caml__DEBUG_i) = Debug_uninit_minor;                   \
+  }                                                                         \
 }while(0)
 #else
 #define DEBUG_clear(result, wosize)

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -371,7 +371,7 @@ int caml_reallocate_minor_heap(asize_t wsize)
     for (;
          p < (uintnat*)(domain_self->minor_heap_area + Bsize_wsize(wsize));
          p++)
-      *p = Debug_uninit_align;
+      *p = Debug_free_minor;
   }
 #endif
 

--- a/runtime/minor_gc.c
+++ b/runtime/minor_gc.c
@@ -676,7 +676,7 @@ static void caml_stw_empty_minor_heap_no_major_slice(caml_domain_state* domain,
                                             caml_domain_state** participating)
 {
 #ifdef DEBUG
-  int minor_words_used = domain->young_end - domain->young_ptr;
+  uintnat* initial_young_ptr = (uintnat*)domain->young_ptr;
   CAMLassert(caml_domain_is_in_stw());
 #endif
 
@@ -712,8 +712,8 @@ static void caml_stw_empty_minor_heap_no_major_slice(caml_domain_state* domain,
   caml_empty_minor_heap_domain_clear(domain);
 #ifdef DEBUG
   {
-    uintnat* p = ((uintnat*)(domain->young_end)) - minor_words_used;
-    for (int i=0; i<minor_words_used; ++i) p[i] = Debug_free_minor;
+    for (uintnat* p = initial_young_ptr; p < (uintnat*)domain->young_end; ++p)
+      *p = Debug_free_minor;
   }
 #endif
 


### PR DESCRIPTION
This PR alters the DEBUG runtime to:
- ensure `Debug_free_minor` is used to clear the minor heap at the end of a minor collection.
- only write `Debug_free_minor` in the portion of the minor heap that has been used to allocate objects in this cycle (i.e. write only `[young_ptr, young_end)`). This makes a performance difference in multi-domain programs and tests explicitly calling `Gc.minor` by speeding up DEBUG collection times. 
- check the transition from `Debug_free_minor` -> `Debug_uninit_minor` when using `Alloc_small`. 

The PR is motivated by getting testsuite timeouts when running:
 `USE_RUNTIME=d make -C testsuite one DIR=tests/parallel`

On a Linux x86 machine I saw: `domain_parallel_spawn_burn.ml` take in excess of 10mins with a DEBUG build and get killed. After this PR the same test ran in ~40s. 
