### PR TITLE
Do not pass -no-pie to the C compiler on musl/arm64

### DIFF
--- a/Changes
+++ b/Changes
@@ -120,6 +120,9 @@ Working version
 
 ### Bug fixes:
 
+- #11025: Do not pass -no-pie to the C compiler on musl/arm64
+  (omni and Kate Deplaix, review by Xavier Leroy)
+
 OCaml 4.14.0
 ----------------
 

--- a/configure
+++ b/configure
@@ -14468,16 +14468,16 @@ fi
 # Disable PIE at link time when ocamlopt does not produce position-independent
 # code and the system produces PIE executables by default and demands PIC
 # object files to do so.
-# This issue does not affect amd64 (x86_64) and s390x (Z systems),
-# since ocamlopt produces PIC object files by default.
-# Currently the problem is known for Alpine Linux on platforms other
-# than amd64 and s390x (issue #7562), and probably affects all Linux
-# distributions that use the musl standard library and dynamic loader.
+# This issue does not affect amd64 (x86_64), aarch64 (arm64)
+# and s390x (Z systems), since ocamlopt produces PIC object files by default.
+# Currently the problem is known for Alpine Linux on other platforms
+# (issue #7562), and probably affects all Linux distributions that use
+# the musl standard library and dynamic loader.
 # Other systems have PIE by default but can cope with non-PIC object files,
 # e.g. Ubuntu >= 17.10 for i386, which uses the glibc dynamic loader.
 
 case $arch in #(
-  amd64|s390x|none) :
+  amd64|aarch64|s390x|none) :
     # ocamlopt generates PIC code or doesn't generate code at all
      ;; #(
   *) :

--- a/configure.ac
+++ b/configure.ac
@@ -1172,16 +1172,16 @@ AS_IF([test -z "$PARTIALLD"],
 # Disable PIE at link time when ocamlopt does not produce position-independent
 # code and the system produces PIE executables by default and demands PIC
 # object files to do so.
-# This issue does not affect amd64 (x86_64) and s390x (Z systems),
-# since ocamlopt produces PIC object files by default.
-# Currently the problem is known for Alpine Linux on platforms other
-# than amd64 and s390x (issue #7562), and probably affects all Linux
-# distributions that use the musl standard library and dynamic loader.
+# This issue does not affect amd64 (x86_64), aarch64 (arm64)
+# and s390x (Z systems), since ocamlopt produces PIC object files by default.
+# Currently the problem is known for Alpine Linux on other platforms
+# (issue #7562), and probably affects all Linux distributions that use
+# the musl standard library and dynamic loader.
 # Other systems have PIE by default but can cope with non-PIC object files,
 # e.g. Ubuntu >= 17.10 for i386, which uses the glibc dynamic loader.
 
 AS_CASE([$arch],
-  [amd64|s390x|none],
+  [amd64|aarch64|s390x|none],
     # ocamlopt generates PIC code or doesn't generate code at all
     [],
   [AS_CASE([$host],


### PR DESCRIPTION
This upstreams the last non-upstreamed patch present in Alpine.

Originally added to Alpine in https://gitlab.alpinelinux.org/alpine/aports/-/merge_requests/18213 by @omnivagant