### PR TITLE
Separate typing of counter-examples from `type_pat`

### DIFF
--- a/.depend
+++ b/.depend
@@ -900,7 +900,6 @@ typing/outcometree.cmi : \
     parsing/asttypes.cmi
 typing/parmatch.cmo : \
     utils/warnings.cmi \
-    typing/untypeast.cmi \
     typing/types.cmi \
     typing/typedtree.cmi \
     typing/tast_iterator.cmi \
@@ -918,11 +917,9 @@ typing/parmatch.cmo : \
     typing/ctype.cmi \
     typing/btype.cmi \
     parsing/asttypes.cmi \
-    parsing/ast_helper.cmi \
     typing/parmatch.cmi
 typing/parmatch.cmx : \
     utils/warnings.cmx \
-    typing/untypeast.cmx \
     typing/types.cmx \
     typing/typedtree.cmx \
     typing/tast_iterator.cmx \
@@ -940,12 +937,10 @@ typing/parmatch.cmx : \
     typing/ctype.cmx \
     typing/btype.cmx \
     parsing/asttypes.cmi \
-    parsing/ast_helper.cmx \
     typing/parmatch.cmi
 typing/parmatch.cmi : \
     typing/types.cmi \
     typing/typedtree.cmi \
-    parsing/parsetree.cmi \
     parsing/location.cmi \
     typing/env.cmi \
     parsing/asttypes.cmi
@@ -1359,6 +1354,7 @@ typing/typeclass.cmi : \
     parsing/asttypes.cmi
 typing/typecore.cmo : \
     utils/warnings.cmi \
+    typing/untypeast.cmi \
     typing/typetexp.cmi \
     typing/types.cmi \
     typing/typedtree.cmi \
@@ -1391,6 +1387,7 @@ typing/typecore.cmo : \
     typing/typecore.cmi
 typing/typecore.cmx : \
     utils/warnings.cmx \
+    typing/untypeast.cmx \
     typing/typetexp.cmx \
     typing/types.cmx \
     typing/typedtree.cmx \

--- a/Changes
+++ b/Changes
@@ -94,6 +94,9 @@ Working version
   (Fabian Hemmer, review by Gabriel Scherer)
 
 ### Internal/compiler-libs changes:
+- #11027: Separate typing counter-examples from type_pat into retype_pat;
+  type_pat is no longer in CPS.
+  (Jacques Garrigue and Takafumi Saikawa, review by Gabriel Scherer)
 
 - #11018: Clean up Types.Variance, adding a description of the lattice used,
   and defining explicitly composition.

--- a/typing/parmatch.mli
+++ b/typing/parmatch.mli
@@ -71,28 +71,18 @@ val complete_constrs :
     constructor_description list ->
     constructor_description list
 
-(** [ppat_of_type] builds an untyped pattern from its expected type,
+(** [pats_of_type] builds a list of patterns from a given expected type,
     for explosion of wildcard patterns in Typecore.type_pat.
 
     There are four interesting cases:
-    - the type is empty ([PT_empty])
-    - no further explosion is necessary ([PT_any])
+    - the type is empty ([])
+    - no further explosion is necessary ([Pat_any])
     - a single pattern is generated, from a record or tuple type
-      or a single-variant type ([PE_single])
-    - an or-pattern is generated, in the case that all branches
-      are GADT constructors ([PE_gadt_cases]).
+      or a single-variant type ([tp])
+    - a list of patterns, in the case that all branches
+      are GADT constructors ([tp1; ..; tpn]).
  *)
-type pat_explosion = PE_single | PE_gadt_cases
-type ppat_of_type =
-  | PT_empty
-  | PT_any
-  | PT_pattern of
-      pat_explosion *
-      Parsetree.pattern *
-      (string, constructor_description) Hashtbl.t *
-      (string, label_description) Hashtbl.t
-
-val ppat_of_type: Env.t -> type_expr -> ppat_of_type
+val pats_of_type : Env.t -> type_expr -> pattern list
 
 val pressure_variants:
   Env.t -> pattern list -> unit
@@ -107,16 +97,9 @@ val pressure_variants_in_computation_pattern:
     [refute] indicates that [check_unused] was called on a refutation clause.
  *)
 val check_partial:
-    ((string, constructor_description) Hashtbl.t ->
-     (string, label_description) Hashtbl.t ->
-     Parsetree.pattern -> pattern option) ->
-    Location.t -> value case list -> partial
+    (pattern -> pattern option) -> Location.t -> value case list -> partial
 val check_unused:
-    (bool ->
-     (string, constructor_description) Hashtbl.t ->
-     (string, label_description) Hashtbl.t ->
-     Parsetree.pattern -> pattern option) ->
-    value case list -> unit
+    (bool -> pattern -> pattern option) -> value case list -> unit
 
 (* Irrefutability tests *)
 val irrefutable : pattern -> bool


### PR DESCRIPTION
`Typecore.type_pat` had two modes, one for typing patterns from programs, and another for retyping potential counter-examples generated by `Parmatch`.

This mixture of purposes resulted in several complexities:
1. In order to be passed to `type_pat`, the counter-examples had to be converted back to syntactic patterns using `Parmatch.Conv`, requiring auxiliary data structures to avoid ambiguities.
2. Patterns generated by `Parmatch` are much simpler than those from programs, which may even contain exceptions (computation patterns).
3. Retyping counter-examples needs to be written in CPS for backtracking, while ordinary typing does not.

The accumulation of these complexities in a single function resulted in heavily typed and obfuscated code.

This PR separates these two functionalities and solves the complexities by:
i. creating a much simpler `retype_pat` function which takes `Typedtree.pattern` as its input, and
ii. converting back `type_pat` into direct style (without continuations).
Both functions have simpler types than before.

Thanks to PR #10311 , the actual constraint solving part could be shared and the total amount of code decreases with this separation.

However, there is one downside: because of this separation, one now has to carefully synchronize `type_pat` and `retype_pat`
when changing the typing of patterns.

We mark this PR as a draft because we had to base it on 4.14, waiting for 5.00 to stabilize.
This PR obsoletes #10826.

Coauthored by @garrigue