### PR TITLE
doc: abs does not return absolute value on min_int

### DIFF
--- a/stdlib/int32.mli
+++ b/stdlib/int32.mli
@@ -86,7 +86,8 @@ val pred : int32 -> int32
 (** Predecessor.  [Int32.pred x] is [Int32.sub x Int32.one]. *)
 
 val abs : int32 -> int32
-(** Return the absolute value of its argument. *)
+(** [abs x] is the absolute value of [x]. On [min_int] this
+   is [min_int] itself and thus remains negative. *)
 
 val max_int : int32
 (** The greatest representable 32-bit integer, 2{^31} - 1. *)

--- a/stdlib/int64.mli
+++ b/stdlib/int64.mli
@@ -86,7 +86,8 @@ val pred : int64 -> int64
 (** Predecessor.  [Int64.pred x] is [Int64.sub x Int64.one]. *)
 
 val abs : int64 -> int64
-(** Return the absolute value of its argument. *)
+(** [abs x] is the absolute value of [x]. On [min_int] this
+   is [min_int] itself and thus remains negative. *)
 
 val max_int : int64
 (** The greatest representable 64-bit integer, 2{^63} - 1. *)

--- a/stdlib/nativeint.mli
+++ b/stdlib/nativeint.mli
@@ -94,7 +94,8 @@ val pred : nativeint -> nativeint
    [Nativeint.pred x] is [Nativeint.sub x Nativeint.one]. *)
 
 val abs : nativeint -> nativeint
-(** Return the absolute value of its argument. *)
+(** [abs x] is the absolute value of [x]. On [min_int] this
+   is [min_int] itself and thus remains negative. *)
 
 val size : int
 (** The size in bits of a native integer.  This is equal to [32]

--- a/stdlib/stdlib.mli
+++ b/stdlib/stdlib.mli
@@ -371,8 +371,8 @@ external ( mod ) : int -> int -> int = "%modint"
 *)
 
 val abs : int -> int
-(** Return the absolute value of the argument.  Note that this may be
-  negative if the argument is [min_int]. *)
+(** [abs x] is the absolute value of [x]. On [min_int] this
+   is [min_int] itself and thus remains negative. *)
 
 val max_int : int
 (** The greatest representable integer. *)

--- a/utils/targetint.mli
+++ b/utils/targetint.mli
@@ -83,7 +83,8 @@ val pred : t -> t
    [Targetint.pred x] is [Targetint.sub x Targetint.one]. *)
 
 val abs : t -> t
-(** Return the absolute value of its argument. *)
+(** [abs x] is the absolute value of [x]. On [min_int] this
+   is [min_int] itself and thus remains negative. *)
 
 val size : int
 (** The size in bits of a target native integer. *)


### PR DESCRIPTION
The doc is not explicit about the behavior of `Stdlib.abs` on `min_int`. This is an attempt to improve that.