### PR TITLE
Do we really need objects in ocamlopt ?

### DIFF
--- a/asmcomp/selectgen.mli
+++ b/asmcomp/selectgen.mli
@@ -59,72 +59,74 @@ module Effect_and_coeffect : sig
   val join_list_map : 'a list -> ('a -> t) -> t
 end
 
-class virtual selector_generic : object
+type selector_state
+
+type selector = {
   (* The following methods must or can be overridden by the processor
      description *)
-  method is_immediate : Mach.integer_operation -> int -> bool
+  is_immediate : selector -> Mach.integer_operation -> int -> bool;
     (* Must be overridden to indicate whether a constant is a suitable
        immediate operand to the given integer arithmetic instruction.
        The default implementation handles shifts by immediate amounts,
        but produces no immediate operations otherwise. *)
-  method virtual is_immediate_test : Mach.integer_comparison -> int -> bool
+  is_immediate_test : selector -> Mach.integer_comparison -> int -> bool;
     (* Must be defined to indicate whether a constant is a suitable
        immediate operand to the given integer test *)
-  method virtual select_addressing :
-    Cmm.memory_chunk -> Cmm.expression -> Arch.addressing_mode * Cmm.expression
+  select_addressing : selector ->
+    Cmm.memory_chunk -> Cmm.expression -> Arch.addressing_mode * Cmm.expression;
     (* Must be defined to select addressing modes *)
-  method is_simple_expr: Cmm.expression -> bool
-  method effects_of : Cmm.expression -> Effect_and_coeffect.t
+  is_simple_expr: selector -> Cmm.expression -> bool;
+  effects_of : selector -> Cmm.expression -> Effect_and_coeffect.t;
     (* Can be overridden to reflect special extcalls known to be pure *)
-  method select_operation :
+  select_operation : selector ->
     Cmm.operation ->
     Cmm.expression list ->
     Debuginfo.t ->
-    Mach.operation * Cmm.expression list
+    Mach.operation * Cmm.expression list;
     (* Can be overridden to deal with special arithmetic instructions *)
-  method select_condition : Cmm.expression -> Mach.test * Cmm.expression
+  select_condition : selector -> Cmm.expression -> Mach.test * Cmm.expression;
     (* Can be overridden to deal with special test instructions *)
-  method select_store :
+  select_store : selector ->
     bool -> Arch.addressing_mode -> Cmm.expression ->
-                                         Mach.operation * Cmm.expression
+                                         Mach.operation * Cmm.expression;
     (* Can be overridden to deal with special store constant instructions *)
-  method regs_for : Cmm.machtype -> Reg.t array
+  regs_for : selector -> Cmm.machtype -> Reg.t array;
     (* Return an array of fresh registers of the given type.
        Default implementation is like Reg.createv.
        Can be overridden if float values are stored as pairs of
        integer registers. *)
-  method insert_op :
-    environment -> Mach.operation -> Reg.t array -> Reg.t array -> Reg.t array
+  insert_op : selector ->
+    environment -> Mach.operation -> Reg.t array -> Reg.t array -> Reg.t array;
     (* Can be overridden to deal with 2-address instructions
        or instructions with hardwired input/output registers *)
-  method insert_op_debug :
+  insert_op_debug : selector ->
     environment -> Mach.operation -> Debuginfo.t -> Reg.t array
-      -> Reg.t array -> Reg.t array
+      -> Reg.t array -> Reg.t array;
     (* Can be overridden to deal with 2-address instructions
        or instructions with hardwired input/output registers *)
-  method insert_move_extcall_arg :
-    environment -> Cmm.exttype -> Reg.t array -> Reg.t array -> unit
+  insert_move_extcall_arg : selector ->
+    environment -> Cmm.exttype -> Reg.t array -> Reg.t array -> unit;
     (* Can be overridden to deal with unusual unboxed calling conventions,
        e.g. on a 64-bit platform, passing unboxed 32-bit arguments
        in 32-bit stack slots. *)
-  method emit_extcall_args :
-    environment -> Cmm.exttype list -> Cmm.expression list -> Reg.t array * int
+  emit_extcall_args : selector ->
+    environment -> Cmm.exttype list -> Cmm.expression list -> Reg.t array * int;
     (* Can be overridden to deal with stack-based calling conventions *)
-  method emit_stores :
-    environment -> Cmm.expression list -> Reg.t array -> unit
+  emit_stores : selector ->
+    environment -> Cmm.expression list -> Reg.t array -> unit;
     (* Fill a freshly allocated block.  Can be overridden for architectures
        that do not provide Arch.offset_addressing. *)
 
-  method mark_call : unit
+  mark_call : selector -> unit;
   (* informs the code emitter that the current function is non-leaf:
      it may perform a (non-tail) call; by default, sets
      [contains_calls := true] *)
 
-  method mark_tailcall : unit
+  mark_tailcall : selector -> unit;
   (* informs the code emitter that the current function may end with
      a tail-call; by default, does nothing *)
 
-  method mark_c_tailcall : unit
+  mark_c_tailcall : selector -> unit;
   (* informs the code emitter that the current function may call
      a C function that never returns; by default, does nothing.
 
@@ -134,39 +136,39 @@ class virtual selector_generic : object
      aligned when the C function is called. This is achieved by
      overloading this method to set [contains_calls := true] *)
 
-  method mark_instr : Mach.instruction_desc -> unit
+  mark_instr : selector -> Mach.instruction_desc -> unit;
   (* dispatches on instructions to call one of the marking function
      above; overloading this is useful if Ispecific instructions need
      marking *)
 
-  (* The following method is the entry point and should not be overridden *)
-  method emit_fundecl : future_funcnames:Misc.Stdlib.String.Set.t
-                                              -> Cmm.fundecl -> Mach.fundecl
-
-  (* The following methods should not be overridden.  They cannot be
-     declared "private" in the current implementation because they
-     are not always applied to "self", but ideally they should be private. *)
-  method extract_onto : Mach.instruction -> Mach.instruction
-  method extract : Mach.instruction
-  method insert :
-    environment -> Mach.instruction_desc -> Reg.t array -> Reg.t array -> unit
-  method insert_debug :
-    environment -> Mach.instruction_desc -> Debuginfo.t ->
-      Reg.t array -> Reg.t array -> unit
-  method insert_move : environment -> Reg.t -> Reg.t -> unit
-  method insert_move_args :
-    environment -> Reg.t array -> Reg.t array -> int -> unit
-  method insert_move_results :
-    environment -> Reg.t array -> Reg.t array -> int -> unit
-  method insert_moves : environment -> Reg.t array -> Reg.t array -> unit
-  method emit_expr :
-    environment -> Cmm.expression -> Reg.t array option
-  method emit_tail : environment -> Cmm.expression -> unit
-
   (* [contains_calls] is declared as a reference instance variable,
      instead of a mutable boolean instance variable,
      because the traversal uses functional object copies. *)
-  val contains_calls : bool ref
-end
+  contains_calls : bool ref;
+  mutable instr_seq : selector_state;
+}
+
+val default_selector : selector
+
+val extract_onto : selector -> Mach.instruction -> Mach.instruction
+val extract : selector -> Mach.instruction
+val insert : selector ->
+    environment -> Mach.instruction_desc -> Reg.t array -> Reg.t array -> unit
+val insert_debug : selector ->
+    environment -> Mach.instruction_desc -> Debuginfo.t ->
+      Reg.t array -> Reg.t array -> unit
+val insert_move : selector -> environment -> Reg.t -> Reg.t -> unit
+val insert_move_args : selector ->
+    environment -> Reg.t array -> Reg.t array -> int -> unit
+val insert_move_results : selector ->
+    environment -> Reg.t array -> Reg.t array -> int -> unit
+val insert_moves : selector -> environment -> Reg.t array -> Reg.t array -> unit
+val emit_expr : selector ->
+    environment -> Cmm.expression -> Reg.t array option
+val emit_tail : selector -> environment -> Cmm.expression -> unit
+
+(* Entry point *)
+val emit_fundecl : selector ->
+      future_funcnames:Misc.Stdlib.String.Set.t -> Cmm.fundecl -> Mach.fundecl
 
 val reset : unit -> unit


### PR DESCRIPTION
(Note: this is a PR for discussion, not reviewing)

### Context

I tried earlier this week to compile the Flambda 2 compiler with aggressive inlining (to try to find bugs in our code), and found a bug with the compilation of objects (long story short, not enough opaque identities), which resulted in all of the compiler building but `ocamlopt.opt` failing on startup.
This made me think that maybe we don't really need to have objects in the compiler's code, and today I took some time to see what would happen if we removed them.

### The offending code

The native compiler currently uses objects (and classes) in the native backend to allow a generic implementation that performs all the work that is similar between architectures, and each architecture only needs to provide implementations for the non-generic parts (plus some architecture specific tweaks to the generic parts).
Concretely, the `Selectgen`, `Reloadgen` and `CSEgen` modules provides the generic implementations as classes, with virtual methods for the parts that cannot be generic, and each architecture implements `Selection`, `Reload` and `CSE` by inheriting from the generic class.

### What I propose

I'm proposing to replace the generic classes with records of functions, each function taking as first argument such a record (classical implementation of open recursion, like what we have for the AST iterators for example). In addition, since the classes in `Selectgen` and `Reloadgen` contain mutable instance variables not exposed in the interface, this will be reflected by a mutable field whose type will be exported as abstract (there are other alternatives that would work too, but this one looked like a minimal amount of code changes).

### The consequences

Not having objects in the compiler means that we're not potentially generating wrong code because we messed up some tricky part of the compilation of objects. But on the other hand, sometimes it helps to have our own code break if we mess up, as it makes it less likely that a bug will go unfixed (or even unnoticed) for a long period of time.

The performance impact is probably irrelevant here. The object-free code is going to be obviously much faster than the object code, but it's not in a part of the compiler that is usually a bottleneck so I doubt we will notice any significant difference.
As an anecdote, when running `ocamlopt.opt` on `typing/typecore.ml`, it takes around 1.4s to compile, with 0.017s spent in `Selection` (according to `-dprofile`). The same command without this patch spends 0.024s in `Selection`.

### What this PR contains

So far, I've patched only `Selectgen` and `amd64/selection.ml` (this still passes the Github CI apparently, maybe we should restore `check_all_arches`). I think it is enough to get an idea of what the code would look like if we decide to go this way.
I'm expecting to keep this PR around as a draft until we reach a decision, at which point I'll either close it or write the remaining code.


Comments welcome!