### PR TITLE
Fix comment about Hashtbl resizing

### DIFF
--- a/stdlib/hashtbl.ml
+++ b/stdlib/hashtbl.ml
@@ -16,7 +16,7 @@
 (* Hash tables *)
 
 (* We do dynamic hashing, and resize the table and rehash the elements
-   when buckets become too long. *)
+   when the load factor becomes too high. *)
 
 type ('a, 'b) t =
   { mutable size: int;                        (* number of entries *)


### PR DESCRIPTION
The comment has been wrong for 20 years, since: 1a1d67bb95ad0d7d73ff1c95e2bd12be8950572d.