### PR TITLE
Do not pass `-no-pie` to the C compiler on musl/arm64 part 2

### DIFF
--- a/Changes
+++ b/Changes
@@ -127,8 +127,8 @@ Working version
 
 ### Bug fixes:
 
-- #11025: Do not pass -no-pie to the C compiler on musl/arm64
-  (omni and Kate Deplaix, review by Xavier Leroy)
+- #11025, #11036: Do not pass -no-pie to the C compiler on musl/arm64
+  (omni, Kate Deplaix and Antonio Nuno Monteiro, review by Xavier Leroy)
 
 OCaml 4.14.0
 ----------------

--- a/configure
+++ b/configure
@@ -14477,7 +14477,7 @@ fi
 # e.g. Ubuntu >= 17.10 for i386, which uses the glibc dynamic loader.
 
 case $arch in #(
-  amd64|aarch64|s390x|none) :
+  amd64|aarch64|arm64|s390x|none) :
     # ocamlopt generates PIC code or doesn't generate code at all
      ;; #(
   *) :

--- a/configure
+++ b/configure
@@ -14477,7 +14477,7 @@ fi
 # e.g. Ubuntu >= 17.10 for i386, which uses the glibc dynamic loader.
 
 case $arch in #(
-  amd64|aarch64|arm64|s390x|none) :
+  amd64|arm64|s390x|none) :
     # ocamlopt generates PIC code or doesn't generate code at all
      ;; #(
   *) :

--- a/configure.ac
+++ b/configure.ac
@@ -1181,7 +1181,7 @@ AS_IF([test -z "$PARTIALLD"],
 # e.g. Ubuntu >= 17.10 for i386, which uses the glibc dynamic loader.
 
 AS_CASE([$arch],
-  [amd64|aarch64|arm64|s390x|none],
+  [amd64|arm64|s390x|none],
     # ocamlopt generates PIC code or doesn't generate code at all
     [],
   [AS_CASE([$host],

--- a/configure.ac
+++ b/configure.ac
@@ -1181,7 +1181,7 @@ AS_IF([test -z "$PARTIALLD"],
 # e.g. Ubuntu >= 17.10 for i386, which uses the glibc dynamic loader.
 
 AS_CASE([$arch],
-  [amd64|aarch64|s390x|none],
+  [amd64|aarch64|arm64|s390x|none],
     # ocamlopt generates PIC code or doesn't generate code at all
     [],
   [AS_CASE([$host],


### PR DESCRIPTION
This is a follow-up to #11025. When trying to build my cross-compiler the configure file seems to detect my `$arch` as `arm64` and not `aarch64`. It didn't compile without this patch.

cc @kit-ty-kate 