### PR TITLE
Assorted fixes found while restarting the Jenkins CI

### DIFF
--- a/configure
+++ b/configure
@@ -12775,10 +12775,8 @@ esac
 # - strict no-overflow conditions on signed integer arithmetic
 #   (the OCaml runtime assumes Java-style behavior of signed integer arith.)
 # Concerning optimization level, -O3 is somewhat risky, so take -O2.
-# Concerning language version, gnu99 is ISO C99 plus GNU extensions
-# that are often used in standard headers.  Older GCC versions
-# defaults to gnu89, which is not C99.  Clang defaults to gnu99 or
-# gnu11, which is fine.
+# Concerning language version, recent enough versions of GCC and Clang
+# default to gnu11 (C11 + GNU extensions) or gnu17, which is fine.
 
 # Note: the vendor macro can not recognize MinGW because it calls the
 # C preprocessor directly so no compiler specific macro like __MING32__
@@ -12806,32 +12804,12 @@ esac ;; #(
   clang-*) :
     common_cflags="-O2 -fno-strict-aliasing -fwrapv";
       internal_cflags="$cc_warnings -fno-common" ;; #(
-  gcc-[012]-*) :
-    # Some versions known to miscompile OCaml, e,g, 2.7.2.1, some 2.96.
-      # Plus: C99 support unknown.
-      as_fn_error $? "This version of GCC is too old. Please use GCC version 4.2 or above." "$LINENO" 5 ;; #(
-  gcc-3-*|gcc-4-[01]) :
-    # No -fwrapv option before GCC 3.4.
-      # Known problems with -fwrapv fixed in 4.2 only.
-      { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: This version of GCC is rather old. Reducing optimization level.\"" >&5
-$as_echo "$as_me: WARNING: This version of GCC is rather old. Reducing optimization level.\"" >&2;};
-      { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: Consider using GCC version 4.2 or above." >&5
-$as_echo "$as_me: WARNING: Consider using GCC version 4.2 or above." >&2;};
-      common_cflags="-std=gnu99 -O";
-      internal_cflags="$cc_warnings" ;; #(
-  gcc-4-[234]) :
-    # No -fexcess-precision option before GCC 4.5
-      common_cflags="-std=gnu99 -O2 -fno-strict-aliasing -fwrapv \
--fno-builtin-memcmp";
-      internal_cflags="$cc_warnings" ;; #(
-  gcc-4-*) :
-    common_cflags="-std=gnu99 -O2 -fno-strict-aliasing -fwrapv \
--fno-builtin-memcmp";
-      internal_cflags="$cc_warnings -fexcess-precision=standard" ;; #(
+  gcc-[0123]-*|gcc-4-[0-8]) :
+    # No C11 support
+      as_fn_error 69 "This version of GCC is too old. Please use GCC version 4.9 or above." "$LINENO" 5 ;; #(
   gcc-*) :
     common_cflags="-O2 -fno-strict-aliasing -fwrapv";
-      internal_cflags="$cc_warnings -fno-common \
--fexcess-precision=standard" ;; #(
+      internal_cflags="$cc_warnings -fno-common -fexcess-precision=standard" ;; #(
   msvc-*) :
     common_cflags="-nologo -O2 -Gy- -MD $cc_warnings"
       common_cppflags="-D_CRT_SECURE_NO_DEPRECATE"

--- a/configure
+++ b/configure
@@ -3104,6 +3104,23 @@ test -n "$target_alias" &&
     NONENONEs,x,x, &&
   program_prefix=${target_alias}-
 
+# Systems that are known not to work, even in bytecode only.
+
+case $host in #(
+  *-pc-windows) :
+    as_fn_error 69 "the MSVC compiler is not supported currently" "$LINENO" 5 ;; #(
+  *-*-cygwin*) :
+    as_fn_error 69 "Cygwin is not supported currently" "$LINENO" 5 ;; #(
+  i386-*-solaris*) :
+    as_fn_error $? "Building for 32 bits target is not supported. \
+If your host is 64 bits, you can try with './configure CC=\"gcc -m64\"' \
+(or \"cc -m64\" if you don't have GCC)." "$LINENO" 5 ;; #(
+  *) :
+     ;;
+esac
+
+# MSVC special case
+
 case $host in #(
   *-pc-windows) :
     CC=cl
@@ -3112,10 +3129,6 @@ case $host in #(
     SO=dll
     outputexe=-Fe
     syslib='$(1).lib' ;; #(
-  i386-*-solaris*) :
-    as_fn_error $? "Building for 32 bits target is not supported. \
-If your host is 64 bits, you can try with './configure CC=\"gcc -m64\"' \
-(or \"cc -m64\" if you don't have GCC)." "$LINENO" 5 ;; #(
   *) :
     ccomptype=cc
   S=s

--- a/configure
+++ b/configure
@@ -14429,15 +14429,17 @@ else
 fi
 
 if test -z "$PARTIALLD"; then :
-  case "$arch,$cc_basename,$system,$model" in #(
-  amd64,*gcc*,macosx,*) :
+  case "$host,$cc_basename" in #(
+  x86_64-*-darwin*,*gcc*) :
     PACKLD_FLAGS=' -arch x86_64' ;; #(
-  power,*gcc*,elf,ppc) :
-    PACKLD_FLAGS=' -m elf32ppclinux' ;; #(
-  power,*gcc*,elf,ppc64) :
-    PACKLD_FLAGS=' -m elf64ppc' ;; #(
-  power,*gcc*,elf,ppc64le) :
+  powerpc64le*-*-linux*,*gcc*) :
     PACKLD_FLAGS=' -m elf64lppc' ;; #(
+  powerpc*-*-linux*,*gcc*) :
+    if $arch64; then :
+  PACKLD_FLAGS=' -m elf64ppc'
+else
+  PACKLD_FLAGS=' -m elf32ppclinux'
+fi ;; #(
   *) :
     PACKLD_FLAGS='' ;;
 esac

--- a/configure.ac
+++ b/configure.ac
@@ -197,6 +197,20 @@ AC_CANONICAL_BUILD
 AC_CANONICAL_HOST
 AC_CANONICAL_TARGET
 
+# Systems that are known not to work, even in bytecode only.
+
+AS_CASE([$host],
+  [*-pc-windows],
+    [AC_MSG_ERROR([the MSVC compiler is not supported currently], 69)],
+  [*-*-cygwin*],
+    [AC_MSG_ERROR([Cygwin is not supported currently], 69)],
+  [i386-*-solaris*],
+    [AC_MSG_ERROR([Building for 32 bits target is not supported. \
+If your host is 64 bits, you can try with './configure CC="gcc -m64"' \
+(or "cc -m64" if you don't have GCC).])])
+
+# MSVC special case
+
 AS_CASE([$host],
   [*-pc-windows],
     [CC=cl
@@ -205,10 +219,6 @@ AS_CASE([$host],
     SO=dll
     outputexe=-Fe
     syslib='$(1).lib'],
-  [i386-*-solaris*],
-    [AC_MSG_ERROR([Building for 32 bits target is not supported. \
-If your host is 64 bits, you can try with './configure CC="gcc -m64"' \
-(or "cc -m64" if you don't have GCC).])],
   [ccomptype=cc
   S=s
   SO=so

--- a/configure.ac
+++ b/configure.ac
@@ -605,10 +605,8 @@ AS_CASE([$enable_warn_error,OCAML__DEVELOPMENT_VERSION],
 # - strict no-overflow conditions on signed integer arithmetic
 #   (the OCaml runtime assumes Java-style behavior of signed integer arith.)
 # Concerning optimization level, -O3 is somewhat risky, so take -O2.
-# Concerning language version, gnu99 is ISO C99 plus GNU extensions
-# that are often used in standard headers.  Older GCC versions
-# defaults to gnu89, which is not C99.  Clang defaults to gnu99 or
-# gnu11, which is fine.
+# Concerning language version, recent enough versions of GCC and Clang
+# default to gnu11 (C11 + GNU extensions) or gnu17, which is fine.
 
 # Note: the vendor macro can not recognize MinGW because it calls the
 # C preprocessor directly so no compiler specific macro like __MING32__
@@ -634,32 +632,13 @@ AS_CASE([$host],
     [clang-*],
       [common_cflags="-O2 -fno-strict-aliasing -fwrapv";
       internal_cflags="$cc_warnings -fno-common"],
-    [gcc-[[012]]-*],
-      # Some versions known to miscompile OCaml, e,g, 2.7.2.1, some 2.96.
-      # Plus: C99 support unknown.
+    [gcc-[[0123]]-*|gcc-4-[[0-8]]],
+      # No C11 support
       [AC_MSG_ERROR(m4_normalize([This version of GCC is too old.
-        Please use GCC version 4.2 or above.]))],
-    [gcc-3-*|gcc-4-[[01]]],
-      # No -fwrapv option before GCC 3.4.
-      # Known problems with -fwrapv fixed in 4.2 only.
-      [AC_MSG_WARN(m4_normalize([This version of GCC is rather old.
-        Reducing optimization level."]));
-      AC_MSG_WARN([Consider using GCC version 4.2 or above.]);
-      common_cflags="-std=gnu99 -O";
-      internal_cflags="$cc_warnings"],
-    [gcc-4-[[234]]],
-      # No -fexcess-precision option before GCC 4.5
-      [common_cflags="-std=gnu99 -O2 -fno-strict-aliasing -fwrapv \
--fno-builtin-memcmp";
-      internal_cflags="$cc_warnings"],
-    [gcc-4-*],
-      [common_cflags="-std=gnu99 -O2 -fno-strict-aliasing -fwrapv \
--fno-builtin-memcmp";
-      internal_cflags="$cc_warnings -fexcess-precision=standard"],
+        Please use GCC version 4.9 or above.]), 69)],
     [gcc-*],
       [common_cflags="-O2 -fno-strict-aliasing -fwrapv";
-      internal_cflags="$cc_warnings -fno-common \
--fexcess-precision=standard"],
+      internal_cflags="$cc_warnings -fno-common -fexcess-precision=standard"],
     [msvc-*],
       [common_cflags="-nologo -O2 -Gy- -MD $cc_warnings"
       common_cppflags="-D_CRT_SECURE_NO_DEPRECATE"

--- a/configure.ac
+++ b/configure.ac
@@ -1141,11 +1141,13 @@ AC_DEFINE_UNQUOTED([OCAML_OS_TYPE], ["$ostype"])
 
 AC_CHECK_TOOL([DIRECT_LD],[ld])
 AS_IF([test -z "$PARTIALLD"],
-  [AS_CASE(["$arch,$cc_basename,$system,$model"],
-    [amd64,*gcc*,macosx,*], [PACKLD_FLAGS=' -arch x86_64'],
-    [power,*gcc*,elf,ppc], [PACKLD_FLAGS=' -m elf32ppclinux'],
-    [power,*gcc*,elf,ppc64], [PACKLD_FLAGS=' -m elf64ppc'],
-    [power,*gcc*,elf,ppc64le], [PACKLD_FLAGS=' -m elf64lppc'],
+  [AS_CASE(["$host,$cc_basename"],
+    [x86_64-*-darwin*,*gcc*], [PACKLD_FLAGS=' -arch x86_64'],
+    [powerpc64le*-*-linux*,*gcc*], [PACKLD_FLAGS=' -m elf64lppc'],
+    [powerpc*-*-linux*,*gcc*],
+       [AS_IF([$arch64],
+              [PACKLD_FLAGS=' -m elf64ppc'],
+              [PACKLD_FLAGS=' -m elf32ppclinux'])],
     [PACKLD_FLAGS=''])
   # The string for PACKLD must be capable of being concatenated with the
   # output filename. Don't assume that all C compilers understand GNU -ofoo

--- a/runtime/caml/config.h
+++ b/runtime/caml/config.h
@@ -228,7 +228,7 @@ typedef uint64_t uintnat;
 /* Maximum size of the minor zone (words).
    Must be greater than or equal to [Minor_heap_min].
 */
-#define Minor_heap_max (1 << 28)
+#define Minor_heap_max (1 << 20)
 
 /* Default size of the minor zone. (words)  */
 #define Minor_heap_def 262144
@@ -245,7 +245,11 @@ typedef uint64_t uintnat;
 #define Percent_free_def 120
 
 /* Maximum number of domains */
+#ifdef ARCH_SIXTYFOUR
 #define Max_domains 128
+#else
+#define Max_domains 16
+#endif
 
 /* Default setting for the major GC slice smoothing window: 1
    (i.e. no smoothing)

--- a/runtime/gc_ctrl.c
+++ b/runtime/gc_ctrl.c
@@ -199,7 +199,7 @@ CAMLprim value caml_gc_set(value v)
   newminwsz = caml_norm_minor_heap_size (Long_val (Field (v, 0)));
   if (newminwsz != Caml_state->minor_heap_wsz){
     caml_gc_message (0x20, "New minor heap size: %"
-                     ARCH_SIZET_PRINTF_FORMAT "uk words\n", newminwsz / 1024);
+                     ARCH_INTNAT_PRINTF_FORMAT "uk words\n", newminwsz / 1024);
     caml_set_minor_heap_size (newminwsz);
   }
   CAML_EV_END(EV_EXPLICIT_GC_SET);

--- a/testsuite/HACKING.adoc
+++ b/testsuite/HACKING.adoc
@@ -1,7 +1,5 @@
 == Running the testsuite
 
-== Creating a new test
-
 == Useful Makefile targets
 
 `make parallel`::
@@ -30,3 +28,27 @@
   `git diff`, that the change really corresponds to an intended output
   difference, and not to a regression. You then need to commit the change to
   reference file, and your commit message should explain why the output changed.
+
+== Creating a new test
+
+== Dimensioning the tests
+
+By default, tests should run well on small virtual machines (2 cores,
+2 Gb RAM, 64 or 32 bits), taking at most one minute, and preferably
+less than 10 seconds, to run on such a machine.
+
+Some machines used for continuous integration are more capable than
+that.  They use the `OCAML_TEST_SIZE` environment variable to report
+the available resources:
+
+|====
+| `OCAML_TEST_SIZE`  |  Resources          | Word size
+
+| `1` or unset       | 2 cores, 2 Gb RAM   | 32 or 64 bits
+| `2`                | 4 cores, 4 Gb RAM   | 64 bits
+| `3`                | 8 cores, 8 Gb RAM   | 64 bits
+|=====
+
+Tests, then, can check the `OCAML_TEST_SIZE` environment variable and
+increase the number of cores or the amount of memory used.  The
+default should always be 2 cores and 2 Gb RAM.

--- a/testsuite/tests/callback/test2.reference
+++ b/testsuite/tests/callback/test2.reference
@@ -1,8 +1,8 @@
 [Caml] Call caml_to_c
-[Caml] Enter c_to_caml
-[Caml] Leave c_to_caml
-[Caml] Return from caml_to_c
 [C] Enter caml_to_c
 [C] Call c_to_caml
+[Caml] Enter c_to_caml
+[Caml] Leave c_to_caml
 [C] Return from c_to_caml
 [C] Leave caml_to_c
+[Caml] Return from caml_to_c

--- a/testsuite/tests/callback/test2_.c
+++ b/testsuite/tests/callback/test2_.c
@@ -13,9 +13,11 @@ value caml_to_c (value unit) {
     c_to_caml_closure = caml_named_value("c_to_caml");
 
   printf ("[C] Call c_to_caml\n");
+  fflush(stdout);
   caml_callback(*c_to_caml_closure, Val_unit);
   printf ("[C] Return from c_to_caml\n");
 
   printf ("[C] Leave caml_to_c\n");
+  fflush(stdout);
   CAMLreturn (Val_unit);
 }

--- a/testsuite/tests/callback/test3.ml
+++ b/testsuite/tests/callback/test3.ml
@@ -24,7 +24,9 @@ let c_to_caml () =
   let l = mk_list 1000 [] in
   Printf.printf "%d\n" (List.hd l);
   (* Stack overflow *)
-  Printf.printf "%d\n" (sum 100000);
+  let s = sum 100000 in
+  Printf.printf "%s\n"
+    (if s = Int64.to_int 5000050000L then "ok" else "error");
   printf "[Caml] Leave c_to_caml\n%!"
 
 let _ = Callback.register "c_to_caml" c_to_caml

--- a/testsuite/tests/callback/test3.reference
+++ b/testsuite/tests/callback/test3.reference
@@ -1,10 +1,10 @@
 [Caml] Call caml_to_c
+[C] Enter caml_to_c
+[C] Call c_to_caml
 [Caml] Enter c_to_caml
 0
 ok
 [Caml] Leave c_to_caml
-[Caml] Return from caml_to_c
-[C] Enter caml_to_c
-[C] Call c_to_caml
 [C] Return from c_to_caml
 [C] Leave caml_to_c
+[Caml] Return from caml_to_c

--- a/testsuite/tests/callback/test3.reference
+++ b/testsuite/tests/callback/test3.reference
@@ -1,7 +1,7 @@
 [Caml] Call caml_to_c
 [Caml] Enter c_to_caml
 0
-5000050000
+ok
 [Caml] Leave c_to_caml
 [Caml] Return from caml_to_c
 [C] Enter caml_to_c

--- a/testsuite/tests/callback/test3_.c
+++ b/testsuite/tests/callback/test3_.c
@@ -13,9 +13,11 @@ value caml_to_c (value unit) {
     c_to_caml_closure = caml_named_value("c_to_caml");
 
   printf ("[C] Call c_to_caml\n");
+  fflush(stdout);
   caml_callback(*c_to_caml_closure, Val_unit);
   printf ("[C] Return from c_to_caml\n");
 
   printf ("[C] Leave caml_to_c\n");
+  fflush(stdout);
   CAMLreturn (Val_unit);
 }

--- a/testsuite/tests/callback/test4.reference
+++ b/testsuite/tests/callback/test4.reference
@@ -1,6 +1,6 @@
 [Caml] Call caml_to_c
+[C] Enter caml_to_c
+[C] Call c_to_caml
 [Caml] Enter c_to_caml
 [Caml] c_to_caml: raise exception
 [Caml] Caught exception
-[C] Enter caml_to_c
-[C] Call c_to_caml

--- a/testsuite/tests/callback/test4_.c
+++ b/testsuite/tests/callback/test4_.c
@@ -13,9 +13,11 @@ value caml_to_c (value unit) {
     c_to_caml_closure = caml_named_value("c_to_caml");
 
   printf ("[C] Call c_to_caml\n");
+  fflush(stdout);
   caml_callback(*c_to_caml_closure, Val_unit);
   printf ("[C] Return from c_to_caml\n");
 
   printf ("[C] Leave caml_to_c\n");
+  fflush(stdout);
   CAMLreturn (Val_unit);
 }

--- a/testsuite/tests/callback/test5.reference
+++ b/testsuite/tests/callback/test5.reference
@@ -1,9 +1,9 @@
 [Caml] Call caml_to_c
+[C] Enter caml_to_c
+[C] Call c_to_caml
 [Caml] Enter c_to_caml
 c_to_caml: n=66
 [Caml] Leave c_to_caml
-[Caml] Return from caml_to_c
-[C] Enter caml_to_c
-[C] Call c_to_caml
 [C] Return from c_to_caml
 [C] Leave caml_to_c
+[Caml] Return from caml_to_c

--- a/testsuite/tests/callback/test5_.c
+++ b/testsuite/tests/callback/test5_.c
@@ -21,10 +21,12 @@ value caml_to_c_native (value a1, value a2, value a3, value a4, value a5,
     + Long_val (a9) + Long_val (a10) + Long_val (a11);
 
   printf ("[C] Call c_to_caml\n");
+  fflush(stdout);
   caml_callback(*c_to_caml_closure, Val_long(l));
   printf ("[C] Return from c_to_caml\n");
 
   printf ("[C] Leave caml_to_c\n");
+  fflush(stdout);
   CAMLreturn (Val_unit);
 }
 

--- a/testsuite/tests/callback/test6.reference
+++ b/testsuite/tests/callback/test6.reference
@@ -1,12 +1,12 @@
 [Caml] Call caml_to_c
+[C] Enter caml_to_c
+[C] Call c_to_caml
 [Caml] Enter c_to_caml
 [Caml] c_to_caml: raise exception
 [Caml] Caught exception
+[C] Enter caml_to_c
+[C] Call c_to_caml
 [Caml] Enter c_to_caml
 [Caml] c_to_caml: raise exception
 [Caml] Caught exceception again
 [Caml] Done
-[C] Enter caml_to_c
-[C] Call c_to_caml
-[C] Enter caml_to_c
-[C] Call c_to_caml

--- a/testsuite/tests/callback/test6_.c
+++ b/testsuite/tests/callback/test6_.c
@@ -13,9 +13,11 @@ value caml_to_c (value unit) {
     c_to_caml_closure = caml_named_value("c_to_caml");
 
   printf ("[C] Call c_to_caml\n");
+  fflush(stdout);
   caml_callback(*c_to_caml_closure, Val_unit);
   printf ("[C] Return from c_to_caml\n");
 
   printf ("[C] Leave caml_to_c\n");
+  fflush(stdout);
   CAMLreturn (Val_unit);
 }

--- a/testsuite/tests/callback/test7.reference
+++ b/testsuite/tests/callback/test7.reference
@@ -1,7 +1,7 @@
 [Caml] Call caml_to_c
+[C] Enter caml_to_c
+[C] Call c_to_caml
 [Caml] Enter c_to_caml
 [Caml] c_to_caml: perform effect
 [Caml] Caught Unhandled, perform effect
 [Caml] Caught effect
-[C] Enter caml_to_c
-[C] Call c_to_caml

--- a/testsuite/tests/callback/test7_.c
+++ b/testsuite/tests/callback/test7_.c
@@ -13,9 +13,11 @@ value caml_to_c (value unit) {
     c_to_caml_closure = caml_named_value("c_to_caml");
 
   printf ("[C] Call c_to_caml\n");
+  fflush(stdout);
   caml_callback(*c_to_caml_closure, Val_unit);
   printf ("[C] Return from c_to_caml\n");
 
   printf ("[C] Leave caml_to_c\n");
+  fflush(stdout);
   CAMLreturn (Val_unit);
 }

--- a/testsuite/tests/memory-model/opt.ml
+++ b/testsuite/tests/memory-model/opt.ml
@@ -1,8 +1,16 @@
 (** Parse command line options *)
+
+let test_size =
+  try int_of_string (Sys.getenv "OCAML_TEST_SIZE")
+  with Not_found | Failure _ -> 0
+
+let default_avail =
+  if test_size >= 3 then 8 else if test_size = 2 then 4 else 2
+
 let verbose = ref false
 and size = ref 5000
 and nruns = ref 20
-and navail = ref 2
+and navail = ref default_avail
 
 module type Config = sig
   val verbose : bool

--- a/testsuite/tests/parallel/domain_parallel_spawn_burn.ml
+++ b/testsuite/tests/parallel/domain_parallel_spawn_burn.ml
@@ -10,17 +10,22 @@ open Domain
 (* This test looks to spawn domains while doing a bunch of explicit minor and major GC calls
    from parallel domains *)
 
+let test_size =
+  try int_of_string (Sys.getenv "OCAML_TEST_SIZE")
+  with Not_found | Failure _ -> 0
+
+let (list_size, num_domains) =
+  if test_size >= 2 then (14, 25) else (13, 12)
+
 let rec burn l =
-  if List.hd l > 13 then ()
+  if List.hd l > list_size then ()
   else
     burn (l @ l |> List.map (fun x -> x + 1))
 
 let test_parallel_spawn () =
   for i = 1 to 20 do
-    let a = Array.init 12 (fun _ -> Domain.spawn (fun () -> burn [0])) in
-    for j = 0 to 11 do
-      join a.(j)
-    done
+    Array.init num_domains (fun _ -> Domain.spawn (fun () -> burn [0]))
+    |> Array.iter join
   done
 
 let () =

--- a/testsuite/tests/parallel/domain_parallel_spawn_burn.ml
+++ b/testsuite/tests/parallel/domain_parallel_spawn_burn.ml
@@ -11,14 +11,14 @@ open Domain
    from parallel domains *)
 
 let rec burn l =
-  if List.hd l > 14 then ()
+  if List.hd l > 13 then ()
   else
     burn (l @ l |> List.map (fun x -> x + 1))
 
 let test_parallel_spawn () =
   for i = 1 to 20 do
-    let a = Array.init 25 (fun _ -> Domain.spawn (fun () -> burn [0])) in
-    for j = 0 to 24 do
+    let a = Array.init 12 (fun _ -> Domain.spawn (fun () -> burn [0])) in
+    for j = 0 to 11 do
       join a.(j)
     done
   done

--- a/testsuite/tests/parallel/domain_serial_spawn_burn.ml
+++ b/testsuite/tests/parallel/domain_serial_spawn_burn.ml
@@ -11,7 +11,7 @@ open Domain
    from parallel domains *)
 
 let rec burn l =
-  if List.hd l > 14 then ()
+  if List.hd l > 13 then ()
   else
     burn (l @ l |> List.map (fun x -> x + 1))
 
@@ -19,14 +19,6 @@ let test_serial_domain_spawn () =
   for i = 1 to 250 do
     let d = Domain.spawn (fun () -> burn [0]) in
     join d
-  done
-
-let test_parallel_spawn () =
-  for i = 1 to 10 do
-    let a = Array.init 25 (fun _ -> Domain.spawn (fun () -> burn [0])) in
-    for j = 0 to 24 do
-      join a.(j)
-    done
   done
 
 let () =

--- a/testsuite/tests/parallel/domain_serial_spawn_burn.ml
+++ b/testsuite/tests/parallel/domain_serial_spawn_burn.ml
@@ -7,11 +7,18 @@ include unix
 
 open Domain
 
+let test_size =
+  try int_of_string (Sys.getenv "OCAML_TEST_SIZE")
+  with Not_found | Failure _ -> 0
+
+let list_size =
+  if test_size >= 2 then 14 else 13
+
 (* This test looks to spawn domains while doing a bunch of explicit minor and major GC calls
    from parallel domains *)
 
 let rec burn l =
-  if List.hd l > 13 then ()
+  if List.hd l > test_size then ()
   else
     burn (l @ l |> List.map (fun x -> x + 1))
 

--- a/testsuite/tests/parallel/join.ml
+++ b/testsuite/tests/parallel/join.ml
@@ -48,8 +48,8 @@ let join2 () =
     assert !r
 
 let () =
-  main_join 100;
-  let flags = Array.make 100 false in
+  main_join 15;
+  let flags = Array.make 14 false in
   other_join flags (Array.length flags) (Domain.spawn ignore);
   assert (Array.for_all (fun x -> x) flags);
   join2 ();

--- a/testsuite/tests/parallel/join.ml
+++ b/testsuite/tests/parallel/join.ml
@@ -5,6 +5,13 @@ include unix
 ** native
 *)
 
+let test_size =
+  try int_of_string (Sys.getenv "OCAML_TEST_SIZE")
+  with Not_found | Failure _ -> 0
+
+let num_domains =
+  if test_size >= 2 then 100 else 14
+
 let main_join n =
   let a = Array.init n (fun _ -> false) in
   Array.init n (fun i -> Domain.spawn (fun () ->
@@ -48,8 +55,8 @@ let join2 () =
     assert !r
 
 let () =
-  main_join 15;
-  let flags = Array.make 14 false in
+  main_join num_domains;
+  let flags = Array.make num_domains false in
   other_join flags (Array.length flags) (Domain.spawn ignore);
   assert (Array.for_all (fun x -> x) flags);
   join2 ();

--- a/tools/ci/inria/main
+++ b/tools/ci/inria/main
@@ -246,6 +246,13 @@ fi
 
 eval ./configure "$CCOMP" $build $host --prefix='$instdir' $confoptions
 
+grep -q '^ARCH=none' Makefile.config && make_native=false
+
+if test "$flambda" = "true" && test "$make_native" = "false"; then
+  echo "No need to test flambda in a bytecode-only system; skipping the test."
+  exit 0
+fi
+
 if $bootstrap; then
   $make $jobs --warn-undefined-variables core
   $make $jobs --warn-undefined-variables coreboot

--- a/tools/ci/inria/main
+++ b/tools/ci/inria/main
@@ -169,6 +169,8 @@ case "${OCAML_ARCH}" in
     instdir='C:/ocamlmgw'
     cleanup=true
     check_make_alldepend=true
+    # This is needed until the winpthreads support is implemented directly
+    export PATH="$PATH:/usr/i686-w64-mingw32/sys-root/mingw/bin"
   ;;
   mingw64)
     build='--build=x86_64-pc-cygwin'


### PR DESCRIPTION
This PR is best reviewed commit by commit.  Here is a summary:

## Runtime system
- c28aa813d: Select smaller max minor heap size and max domains for 32-bit architectures.  (This is a temporary workaround until #10971 is resolved.)
- 3cea3ab55: Wrong printf format for "New minor heap size" message.  (Breaks on 32-bit platforms.)

## configure tweaks
- 1ba11188d: Report the MSVC, Cygwin, ~~and Mingw-32~~ ports as not supported currently.  (This way, the Jenkins Web interface can show them as "unstable" in tasteful yellow rather than as "failed" in stress-inducing red.)  (Edit: Mingw-32 almost works, in bytecode-only mode, so let's keep it supported for the moment.)
- b7a12dbbb: GCC < 4.9 is not supported by lack of C11 atomics.
- bf1593f3d: Revised determination of PACKLD_FLAGS for bytecode-only builds.  (Affects the Power ports.)

## Jenkins scripts
- 1a89babb2: Update the Jenkins CI "main" script to handle bytecode-only builds better

## Fixing the test suite
- 1a09e47cd: Make tests/callback/test3.ml work in 32 bits too
- c9e846c4c:  Scale down some tests in tests/parallel
- 69a0a8cc8: tests/callback: fix interleaving of C and OCaml outputs

