### PR TITLE
Reintroduce caml_final_do_calls_exn

### DIFF
--- a/runtime/caml/finalise.h
+++ b/runtime/caml/finalise.h
@@ -71,7 +71,7 @@ void caml_final_merge_finalisable (struct finalisable *source,
                                    struct finalisable *target);
 int caml_final_update_first (caml_domain_state* d);
 int caml_final_update_last (caml_domain_state* d);
-void caml_final_do_calls (void);
+value caml_final_do_calls_exn (void);
 void caml_final_do_roots (scanning_action f, void* fdata,
                           caml_domain_state* domain, int do_val);
 void caml_final_do_young_roots (scanning_action f, void* fdata,

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -1191,7 +1191,7 @@ static void caml_poll_gc_work(void)
       thread.
       */
     CAML_EV_BEGIN(EV_MINOR_FINALIZED);
-    caml_final_do_calls();
+    caml_raise_if_exception(caml_final_do_calls_exn());
     CAML_EV_END(EV_MINOR_FINALIZED);
   }
 


### PR DESCRIPTION
Reintroduce fix to minor bugs in `Gc.{major,full_major,compact}`.

This essentially completes the side-by-side review of `runtime/finalise.c`, a task of #10915.

