### PR TITLE
Minor cleanups in effect.ml

### DIFF
--- a/stdlib/.depend
+++ b/stdlib/.depend
@@ -228,11 +228,9 @@ stdlib__Domain.cmx : domain.ml \
 stdlib__Domain.cmi : domain.mli
 stdlib__Effect.cmo : effect.ml \
     stdlib__Printexc.cmi \
-    stdlib__Obj.cmi \
     stdlib__Effect.cmi
 stdlib__Effect.cmx : effect.ml \
     stdlib__Printexc.cmx \
-    stdlib__Obj.cmx \
     stdlib__Effect.cmi
 stdlib__Effect.cmi : effect.mli \
     stdlib__Printexc.cmi

--- a/stdlib/effect.ml
+++ b/stdlib/effect.ml
@@ -93,7 +93,7 @@ module Shallow = struct
     let error _ = failwith "impossible" in
     let effc eff k _last_fiber =
       match eff with
-      | M.Initial_setup__ -> raise (E k)
+      | M.Initial_setup__ -> raise_notrace (E k)
       | _ -> error ()
     in
     let s = alloc_stack error error effc in

--- a/stdlib/effect.ml
+++ b/stdlib/effect.ml
@@ -97,7 +97,9 @@ module Shallow = struct
       | _ -> error ()
     in
     let s = alloc_stack error error effc in
-    try Obj.magic (runstack s f' ()) with E k -> k
+    match runstack s f' () with
+    | exception E k -> k
+    | _ -> error ()
 
   type ('a,'b) handler =
     { retc: 'a -> 'b;


### PR DESCRIPTION
cc @kayceesrk 

The first commit removes code duplication in Effect.Shallow

The second commit removes an `Obj.magic` in Shallow.fiber.

The third commit optimizes `Shallow.fiber` by avoiding useless backtrace collection.
(I wrote it to feel confident that the second commit could not be criticized on performance grounds: taken together they accelerate more than they slow down.)