### PR TITLE
 riscv: move frametable to data section to improve code relocatability

### DIFF
--- a/Changes
+++ b/Changes
@@ -127,6 +127,12 @@ Working version
 
 ### Bug fixes:
 
+- #10688: Move frame descriptor table from `rodata` to `data` section on
+  RISC-V.  Improves support for building DLLs and PIEs. In particular, this
+  applies to all binaries in distributions that build PIEs by default (eg
+  Gentoo and Alpine).
+  (Alex Fan, review by Gabriel Scherer)
+
 - #11025: Do not pass -no-pie to the C compiler on musl/arm64
   (omni and Kate Deplaix, review by Xavier Leroy)
 

--- a/asmcomp/riscv/emit.mlp
+++ b/asmcomp/riscv/emit.mlp
@@ -645,7 +645,7 @@ let end_assembly() =
   `{emit_symbol lbl_end}:\n`;
   `	.quad	0\n`;
   (* Emit the frame descriptors *)
-  `	{emit_string rodata_space}\n`;
+  `	{emit_string data_space}\n`; (* not rodata because relocations inside *)
   let lbl = Compilenv.make_symbol (Some "frametable") in
   declare_global_data lbl;
   `{emit_symbol lbl}:\n`;


### PR DESCRIPTION
This fixes https://github.com/ocaml/ocaml/issues/10688 and passes all tests on Gentoo riscv64.

I find out the issue is somehow frame descriptor table contains relocations.  A simple example is otherlibs/str. This little pr moves frametable to .data section

`objdump -D -R otherlibs/str.cmxs` shows
```
Disassembly of section .rodata:

000000000000ef98 <caml_shared_startup__frametable>:
    ef98:       0006                    c.slli  zero,0x1
        ...
                        efa0: R_RISCV_RELATIVE  *ABS*+0x9098
    efa6:       0000                    unimp
    efa8:       0012                    c.slli  zero,0x4
    efaa:       0002                    c.slli64        zero
    efac:       00070003                lb      zero,0(a4)
        ...
...
000000000000f030 <camlStr__frametable>:
    f030:       0195                    addi    gp,gp,5
        ...
                        f038: R_RISCV_RELATIVE  *ABS*+0xe668
    f03e:       0000                    unimp
    f040:       00000013                nop
    f044:       0001                    nop
    f046:       0000                    unimp
    f048:       35f0                    fld     fa2,232(a1)
        ...
                        f050: R_RISCV_RELATIVE  *ABS*+0xe618
    f056:       0000                    unimp
    f058:       0011                    c.nop   4
    f05a:       0000                    unimp
    f05c:       35ac                    fld     fa1,104(a1)
        ...
                        f060: R_RISCV_RELATIVE  *ABS*+0xe608
    f066:       0000                    unimp
    f068:       0011                    c.nop   4
    f06a:       0000                    unimp
    f06c:       26fc                    fld     fa5,200(a3)
        ...
...
```
https://github.com/ocaml/ocaml/issues/10688 happens with both gcc 11.2.0 and gcc-11.2.1_p20220115.  But, I heard fedora and debian don't have that issue with same gcc & binutils versions. I have no idea what makes the difference.
