### PR TITLE
ocamltest: compressed format for TSL

### DIFF
--- a/ocamltest/tsl_lexer.mll
+++ b/ocamltest/tsl_lexer.mll
@@ -28,6 +28,7 @@ let lexer_error message =
 let newline = ('\013'* '\010')
 let blank = [' ' '\009' '\012']
 let identchar = ['A'-'Z' 'a'-'z' '_' '.' '-' '\'' '0'-'9']
+let num = ['0'-'9']
 
 rule token = parse
   | blank * { token lexbuf }
@@ -40,6 +41,7 @@ rule token = parse
   | "*)" { TSL_END_OCAML_STYLE }
   | "," { COMMA }
   | '*'+ { TEST_DEPTH (String.length (Lexing.lexeme lexbuf)) }
+  | "*" (num+ as n) { TEST_DEPTH (int_of_string n)}
   | "+=" { PLUSEQUAL }
   | "=" { EQUAL }
   | identchar *


### PR DESCRIPTION
This purely contingent PR tunes the syntax of  the test specification language to allow to replace

```
************************** ocamlopt.byte
flags = ""
program = "./test.opt.exe"
libraries = "dynlink"
all_modules = "sheep.cmx test.cmx"
*************************** run
```
with
```
*26 ocamlopt.byte
flags = ""
program = "./test.opt.exe"
libraries = "dynlink"
all_modules = "sheep.cmx test.cmx"
*27 run
```
because I prefer avoid writing or reading number greater than 8 in unary.

As an illustration of the new syntax, this PR converts one test in the testsuite that was using 728 `*` in its test specification.

cc @shindere  
