### PR TITLE
gc stats: properly orphan allocation stats

### DIFF
--- a/Changes
+++ b/Changes
@@ -147,7 +147,7 @@ Working version
 - #10864, #10888: restore afl-fuzz mode for sequential programs.
   (Jan Midtgaard, review by Xavier Leroy and Gabriel Scherer)
 
-- #11008: rework GC statistics in the Multicore runtime
+- #11008, #11047: rework GC statistics in the Multicore runtime
   (Gabriel Scherer, review by Enguerrand Decorne)
 
 ### Build system:

--- a/runtime/caml/gc_stats.h
+++ b/runtime/caml/gc_stats.h
@@ -71,8 +71,13 @@ struct gc_stats {
   struct heap_stats heap_stats;
 };
 
+void caml_orphan_alloc_stats(caml_domain_state *);
+
 /* Update the sampled stats of a domain from its live stats. */
 void caml_collect_gc_stats_sample(caml_domain_state *domain);
+
+/* Clear the sampled stats on domain termination. */
+void caml_clear_gc_stats_sample(caml_domain_state *domain);
 
 /* Compute global runtime stats.
 

--- a/runtime/caml/shared_heap.h
+++ b/runtime/caml/shared_heap.h
@@ -37,6 +37,9 @@ void caml_collect_heap_stats_sample(
   struct caml_heap_state* local,
   struct heap_stats *sample);
 
+/* Add the global orphaned heap stats into an accumulator. */
+void caml_accum_orphan_heap_stats(struct heap_stats *acc);
+
 uintnat caml_heap_size(struct caml_heap_state*);
 uintnat caml_top_heap_words(struct caml_heap_state*);
 uintnat caml_heap_blocks(struct caml_heap_state*);


### PR DESCRIPTION
A small implementation issue with the Multicore runtime is that currently, the domain state structures are allocated once and forall in an array of size Max_domains, and never freed. The reason given for this choice is given as a comment:

https://github.com/ocaml/ocaml/blob/96238307de0415223d7662485da52fbc44df0264/runtime/domain.c#L441-L450

This PR, a follow-up to #11008, implements an orphaning process for allocation statistics:
- "orphan stats" are stored a global `structure alloc_stats` variable in gc_stats.c, protected by a lock
- on domain termination, the stats of the current domain are added to the "orphan stats"
- when the GC stats are compted, these "orphan stats" are added to the total

(This follows the same general approach as the "orphan heap stats", which are heap statistics "owned" by the free pools.)
