### PR TITLE
Fix leftover TODO in `runtime/startup_byt.c`

### DIFF
--- a/runtime/startup_byt.c
+++ b/runtime/startup_byt.c
@@ -556,9 +556,10 @@ CAMLexport void caml_main(char_os **argv)
   /* Load the globals */
   caml_seek_section(fd, &trail, "DATA");
   chan = caml_open_descriptor_in(fd);
-  /* TODO: do we need multicore Lock here */
-  caml_modify_generational_global_root(&caml_global_data, caml_input_val(chan));
-  /* TODO: do we need multicore Unlock here */
+  Lock(chan);
+  value global_data = caml_input_val(chan);
+  Unlock(chan);
+  caml_modify_generational_global_root(&caml_global_data, global_data);
   caml_close_channel(chan); /* this also closes fd */
   caml_stat_free(trail.section);
   /* Initialize system libraries */


### PR DESCRIPTION
Fixes the following:
```
../runtime/ocamlrun ../boot/ocamlc -use-prims ../runtime/primitives -strict-sequence -absname -w +a-4-9-41-42-44-45-48-70 -g -warn-error +A -bin-annot -nostdlib -principal -safe-string -strict-formats  -nopervasives -c camlinternalFormatBasics.mli
Fatal error: Fatal error during unlock: Operation not permitted

Program received signal SIGABRT, Aborted.
__GI_raise (sig=sig@entry=6) at ../sysdeps/unix/sysv/linux/raise.c:49
49	../sysdeps/unix/sysv/linux/raise.c: Aucun fichier ou dossier de ce type.
(gdb) bt
0  __GI_raise (sig=sig@entry=6) at ../sysdeps/unix/sysv/linux/raise.c:49
1  0x00007ffff7c61864 in __GI_abort () at abort.c:79
2  0x00005555555890b2 in caml_fatal_error (msg=msg@entry=0x55555559c224 "Fatal error during %s: %s\n") at misc.c:117
3  0x000055555558a4d5 in caml_plat_fatal_error (action=action@entry=0x55555559d04b "unlock", err=<optimized out>)
    at platform.c:36
4  0x0000555555580765 in check_err (err=<optimized out>, action=0x55555559d04b "unlock") at caml/platform.h:130
5  caml_plat_unlock (m=<optimized out>) at caml/platform.h:163
6  channel_mutex_unlock_default (chan=<optimized out>) at io.c:86
7  0x0000555555581217 in check_pending (channel=0x5555555ea5e0) at io.c:120
8  check_pending (channel=0x5555555ea5e0) at io.c:115
9  caml_getblock (channel=channel@entry=0x5555555ea5e0, p=p@entry=0x7fffffffda30 "\240\332\377\377\002",
    len=len@entry=20) at io.c:400
10 0x0000555555581309 in caml_really_getblock (chan=chan@entry=0x5555555ea5e0,
    p=p@entry=0x7fffffffda30 "\240\332\377\377\002", n=n@entry=20) at io.c:430
11 0x000055555557d9c3 in caml_input_val (chan=chan@entry=0x5555555ea5e0) at intern.c:752
12 0x000055555559667f in caml_main (argv=0x7fffffffdbf8) at startup_byt.c:560
13 0x000055555556b2b2 in main (argc=<optimized out>, argv=<optimized out>) at main.c:37
```

(obtained on a private branch while working on signals, so it is normal that you do not see it by yourself when compiling)

Please review my solution thoroughly, I am not sure what difficulty the TODO comment was alluding to.

Is there any other TODO/FIXME left in the code that should be fixed before 5.0?