### PR TITLE
Mixing declarations and statements is C11

### DIFF
--- a/configure
+++ b/configure
@@ -12760,7 +12760,7 @@ case $ocaml_cv_cc_vendor in #(
   *) :
     outputobj='-o $(EMPTY)'
   warn_error_flag='-Werror'
-  cc_warnings='-Wall -Wdeclaration-after-statement' ;;
+  cc_warnings='-Wall' ;;
 esac
 
 case $enable_warn_error,true in #(

--- a/configure.ac
+++ b/configure.ac
@@ -594,7 +594,7 @@ AS_CASE([$ocaml_cv_cc_vendor],
     cc_warnings=''],
   [outputobj='-o $(EMPTY)'
   warn_error_flag='-Werror'
-  cc_warnings='-Wall -Wdeclaration-after-statement'])
+  cc_warnings='-Wall'])
 
 AS_CASE([$enable_warn_error,OCAML__DEVELOPMENT_VERSION],
   [yes,*|,true],


### PR DESCRIPTION
This PR enables mixing declarations and statements. The motivation is the bump in supported compiler versions coming with 5.0.

The question is whether support for too old version of MSVC goes away. Here, too old means older than VS2013 (MSVC v18.0), which supports mixing declarations and statements.