### PR TITLE
Make Hd_val a relaxed atomic load

### DIFF
--- a/runtime/caml/mlvalues.h
+++ b/runtime/caml/mlvalues.h
@@ -135,8 +135,12 @@ bits  63        (64-P) (63-P)        10 9     8 7   0
 #define Profinfo_hd(hd) NO_PROFINFO
 #endif /* WITH_PROFINFO */
 
-#define Hd_val(val) (((header_t *) (val)) [-1] + 0)
 #define Hp_atomic_val(val) ((atomic_uintnat *)(val) - 1)
+#define Hd_val(val) ((header_t) \
+  (atomic_load_explicit( \
+    (Hp_atomic_val(val)), \
+    memory_order_relaxed)))
+
 #define Hd_hp(hp) (* ((header_t *) (hp)))              /* Also an l-value. */
 #define Hp_val(val) (((header_t *) (val)) - 1)
 #define Hp_op(op) (Hp_val (op))

--- a/runtime/caml/mlvalues.h
+++ b/runtime/caml/mlvalues.h
@@ -137,9 +137,7 @@ bits  63        (64-P) (63-P)        10 9     8 7   0
 
 #define Hp_atomic_val(val) ((atomic_uintnat *)(val) - 1)
 #define Hd_val(val) ((header_t) \
-  (atomic_load_explicit( \
-    (Hp_atomic_val(val)), \
-    memory_order_relaxed)))
+  (atomic_load_explicit(Hp_atomic_val(val), memory_order_relaxed)))
 
 #define Hd_hp(hp) (* ((header_t *) (hp)))              /* Also an l-value. */
 #define Hp_val(val) (((header_t *) (val)) - 1)

--- a/runtime/shared_heap.c
+++ b/runtime/shared_heap.c
@@ -209,7 +209,8 @@ static void calc_pool_stats(pool* a, sizeclass sz, struct heap_stats* s) {
   s->pool_frag_words += Wsize_bsize(POOL_HEADER_SZ);
 
   while (p + wh <= end) {
-    header_t hd = (header_t)*p;
+    header_t hd = (header_t)atomic_load_explicit((atomic_uint*)p,
+                                                  memory_order_relaxed);
     if (hd) {
       s->pool_live_words += Whsize_hd(hd);
       s->pool_frag_words += wh - Whsize_hd(hd);
@@ -467,7 +468,8 @@ static intnat pool_sweep(struct caml_heap_state* local, pool** plist,
     struct heap_stats* s = &local->stats;
 
     while (p + wh <= end) {
-      header_t hd = (header_t)*p;
+      header_t hd = (header_t)atomic_load_explicit((atomic_uintnat*)p,
+                                                    memory_order_relaxed);
       if (hd == 0) {
         /* already on freelist */
         all_used = 0;
@@ -478,7 +480,7 @@ static intnat pool_sweep(struct caml_heap_state* local, pool** plist,
           if (final_fun != NULL) final_fun(Val_hp(p));
         }
         /* add to freelist */
-        p[0] = 0;
+        atomic_store_explicit((atomic_uintnat*)p, 0, memory_order_relaxed);
         p[1] = (value)a->next_obj;
         CAMLassert(Is_block((value)p));
 #ifdef DEBUG

--- a/runtime/shared_heap.c
+++ b/runtime/shared_heap.c
@@ -209,7 +209,7 @@ static void calc_pool_stats(pool* a, sizeclass sz, struct heap_stats* s) {
   s->pool_frag_words += Wsize_bsize(POOL_HEADER_SZ);
 
   while (p + wh <= end) {
-    header_t hd = (header_t)atomic_load_explicit((atomic_uint*)p,
+    header_t hd = (header_t)atomic_load_explicit((atomic_uintnat*)p,
                                                   memory_order_relaxed);
     if (hd) {
       s->pool_live_words += Whsize_hd(hd);


### PR DESCRIPTION
This is the first of the fixes for https://github.com/ocaml/ocaml/issues/11040 and fixes four of the warnings.

`Hd_val` is no longer an lvalue as of https://github.com/ocaml/ocaml/commit/c067f1efb140ab5d077b3f516a3e134a3270e346#diff-a706d8bf17ec6c4fd768c5196ed73aa163bee0fbe390ec91631392fbf4080d33R132 and so this is now possible.

cc @ctk21 @kayceesrk 