### PR TITLE
Respect user provided maximum stack space value, and fix debug run of tmp/stack_space.ml test.

### DIFF
--- a/Changes
+++ b/Changes
@@ -57,6 +57,13 @@ Working version
 - #11105: Fix handling of fiber stack cache with multiple domains
   (Jon Ludlam, KC Sivaramakrishnan and Tom Kelly)
 
+- #11054: Respect user provided maximum stack space
+  Make sure the stack we initially request is sized accordingly to
+  the user provided settings. tmc/stack_space is also updated by
+  this PR in order to account for this change.
+  (Enguerrand Decorne, report by Jon Ludlam,
+  review by Tom Kelly, KC Sivaramakrishnan and Gabriel Scherer)
+
 ### Code generation and optimizations:
 
 - #10972: ARM64 multicore support: OCaml & C stack separation;

--- a/otherlibs/systhreads/st_stubs.c
+++ b/otherlibs/systhreads/st_stubs.c
@@ -234,6 +234,7 @@ static caml_thread_t caml_thread_new_info(void)
 {
   caml_thread_t th;
   caml_domain_state *domain_state;
+  uintnat stack_wsize = caml_get_init_stack_wsize();
 
   domain_state = Caml_state;
   th = NULL;
@@ -243,7 +244,7 @@ static caml_thread_t caml_thread_new_info(void)
   th->next = NULL;
   th->prev = NULL;
   th->domain_id = domain_state->id;
-  th->current_stack = caml_alloc_main_stack(Stack_size / sizeof(value));
+  th->current_stack = caml_alloc_main_stack(stack_wsize);
   if (th->current_stack == NULL) {
     caml_stat_free(th);
     return NULL;

--- a/runtime/caml/config.h
+++ b/runtime/caml/config.h
@@ -198,9 +198,9 @@ typedef uint64_t uintnat;
 
 /* Initial size of stack (bytes). */
 #ifdef DEBUG
-#define Stack_size (64 * sizeof(value))
+#define Stack_init_bsize (64 * sizeof(value))
 #else
-#define Stack_size (4096 * sizeof(value))
+#define Stack_init_bsize (4096 * sizeof(value))
 #endif
 
 /* Minimum free size of stack (bytes); below that, it is reallocated. */

--- a/runtime/caml/fiber.h
+++ b/runtime/caml/fiber.h
@@ -195,13 +195,14 @@ extern value caml_global_data;
 #define Trap_link(tp) ((tp)[1])
 
 struct stack_info** caml_alloc_stack_cache (void);
-CAMLextern struct stack_info* caml_alloc_main_stack (uintnat init_size);
+CAMLextern struct stack_info* caml_alloc_main_stack (uintnat init_wsize);
 void caml_scan_stack(scanning_action f, void* fdata,
                      struct stack_info* stack, value* v_gc_regs);
 /* try to grow the stack until at least required_size words are available.
    returns nonzero on success */
-int caml_try_realloc_stack (asize_t required_size);
-void caml_change_max_stack_size (uintnat new_max_size);
+CAMLextern int caml_try_realloc_stack (asize_t required_wsize);
+CAMLextern uintnat caml_get_init_stack_wsize(void);
+void caml_change_max_stack_size (uintnat new_max_wsize);
 void caml_maybe_expand_stack(void);
 CAMLextern void caml_free_stack(struct stack_info* stk);
 

--- a/runtime/caml/gc_ctrl.h
+++ b/runtime/caml/gc_ctrl.h
@@ -20,7 +20,7 @@
 
 #include "misc.h"
 
-extern uintnat caml_max_stack_size;
+extern uintnat caml_max_stack_wsize;
 extern uintnat caml_fiber_wsz;
 
 void caml_init_gc (void);

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -456,6 +456,7 @@ static void create_domain(uintnat initial_minor_heap_wsize) {
   dom_internal* d = 0;
   caml_domain_state* domain_state;
   struct interruptor* s;
+  uintnat stack_wsize = caml_get_init_stack_wsize();
 
   CAMLassert (domain_self == 0);
 
@@ -557,7 +558,7 @@ static void create_domain(uintnat initial_minor_heap_wsize) {
   domain_state->intern_state = NULL;
 
   domain_state->current_stack =
-      caml_alloc_main_stack(Stack_size / sizeof(value));
+      caml_alloc_main_stack(stack_wsize);
   if(domain_state->current_stack == NULL) {
     goto alloc_main_stack_failure;
   }

--- a/runtime/gc_ctrl.c
+++ b/runtime/gc_ctrl.c
@@ -38,7 +38,7 @@
 #include "caml/eventlog.h"
 #include "caml/fail.h"
 
-uintnat caml_max_stack_size;
+uintnat caml_max_stack_wsize;
 uintnat caml_fiber_wsz;
 
 extern uintnat caml_major_heap_increment; /* percent or words; see major_gc.c */
@@ -129,7 +129,7 @@ CAMLprim value caml_gc_get(value v)
   Store_field (res, 0, Val_long (Caml_state->minor_heap_wsz));  /* s */
   Store_field (res, 2, Val_long (caml_percent_free));           /* o */
   Store_field (res, 3, Val_long (caml_params->verb_gc));        /* v */
-  Store_field (res, 5, Val_long (caml_max_stack_size));         /* l */
+  Store_field (res, 5, Val_long (caml_max_stack_wsize));        /* l */
   Store_field (res, 8, Val_long (caml_custom_major_ratio));     /* M */
   Store_field (res, 9, Val_long (caml_custom_minor_ratio));     /* m */
   Store_field (res, 10, Val_long (caml_custom_minor_max_bsz));  /* n */
@@ -299,12 +299,12 @@ CAMLprim value caml_get_minor_free (value v)
 
 void caml_init_gc (void)
 {
-  caml_max_stack_size = caml_params->init_max_stack_wsz;
+  caml_max_stack_wsize = caml_params->init_max_stack_wsz;
   caml_fiber_wsz = (Stack_threshold * 2) / sizeof(value);
   caml_percent_free = norm_pfree (caml_params->init_percent_free);
   caml_gc_log ("Initial stack limit: %"
                ARCH_INTNAT_PRINTF_FORMAT "uk bytes",
-               caml_max_stack_size / 1024 * sizeof (value));
+               caml_max_stack_wsize / 1024 * sizeof (value));
 
   caml_custom_major_ratio =
       norm_custom_maj (caml_params->init_custom_major_ratio);

--- a/testsuite/tests/tmc/stack_space.ml
+++ b/testsuite/tests/tmc/stack_space.ml
@@ -1,10 +1,17 @@
 (* TEST
-   ocamlrunparam += ",l=10"
-   * bytecode
+   * setup-ocamlc.byte-build-env
+   ** ocamlc.byte
+   module = "stack_space.ml"
+   *** ocamlc.byte
+   program = "./test.byte.exe"
+   all_modules = "stack_space.cmo"
+   module = ""
+   **** run
+   ocamlrunparam += ",l=300"
 *)
 
-(* large with respect to the stack-size=10 setting above *)
-let large = 1000
+(* large with respect to the stack-size=300 setting above *)
+let large = 30000
 
 let init n f =
   let[@tail_mod_cons] rec init_aux i n f =


### PR DESCRIPTION
@jonludlam investigated extensively a strange failure in the testsuite, when running it with the debug runtime, and found a few issues with how the stack sizes are handled in the runtime.
I address here a few of these issues.

There are three related issues, one per commit, and a last commit asking a naming question.

## Honor `OCAMLRUNPARAM=l` in the initial stack size
The first issues is addressed by f295d91ad53480730ce3a17a76d71aefc723b3ca

The idea behind is that we do not currently honor the user's request for a different maximum stack size (with `OCAMLRUNPARAM=l`) when we first boot a domain: we instead set it to the default `Stack_size`.
This commit addresses it by making sure we do.

Besides this, all code growing the stack seems to be honoring the user provided limit.

## `tmc/stack_space.ml `should only apply stack restriction during the running stage
Second commit at 91fc6621f832512433ca60432e403b7e8f735d7a plays a bit of a trick to ensure that we apply the stack size restriction only when running the incriminated testcase.
This testcase currently fail to compile on the debug runtime. (to _compile_ and not to _run_)
The core idea here is that the testcase applies `ocamlrunparam` even to the compiler lines, which means they fail to compile the testcase under such harsh conditions.

To note that my `ocamltest`-fu is yet to improve, so there's maybe a shorter way around this specific issue. :-)

One more thing: I had to tweak the test's stack size for it to work on this branch. The minimum number that would allow it to run was `300` (and I bumped as such the `large` value, following the commented code.).

This is related to the fact that now we have different behavior on trunk vs 4.14:

On 4.14, the stack-size parameter is only checked when the stack is grown, it is initialized to `Stack_size` until then. (https://github.com/ocaml/ocaml/blob/4.14/runtime/stacks.c#L33)
On Multicore, user-specificed stack size is effective from the start.

@gasche may need to double check nothing was broken here. :-)

## Make stack size on the default and debug runtime uniform

_Edit: This has been removed after some feedbacks._

Now, there's a bit more to this:
If the first commit fixes a bug where we do not honor user's request for a specific stack size, why does it matter in the second commit?

The catch is in the third commit at 1ebeb583c33959cd33d33c7ffba21d3dcaf2b609
The Multicore runtime introduced a specific stack size for the debug runtime only:
https://github.com/ocaml/ocaml/blob/trunk/runtime/caml/config.h#L201

@kayceesrk mentioned it proved itself useful to exercise stack overflow handling, but the discrepancy between the two runtime could cause more harm than good in investigating so called heisenbugs in the future, that would vanish when not run in the debug runtime.

This commit removes the discrepancy.

## Naming (byte size vs word size)

`Stack_size` is defined in `bytes`: https://github.com/ocaml/ocaml/blob/trunk/runtime/caml/config.h#L199
A bit lower, `Max_stack_def` is a word size. `caml_max_stack_size` is word sized, `OCAMLRUNPARAM=l` and `Gc.set` speaks words.
`caml_change_max_stack_size` implicitly speaks in words.

I'm thinking that this code induce a bit too many jumps to check if the math around the sizes is correct, I would advocate (and candidate to implement) a more consistent style when naming sizes for stack size related variables. (`_size` arguments and names should be explicitly `_wsz` or `_bsz` instead.)

This could be addressed in a follow-up PR (or in this one, if preferable.)