### PR TITLE
runtime: introduce Debug_uninit_tmc in misc.h

### DIFF
--- a/lambda/tmc.ml
+++ b/lambda/tmc.ml
@@ -124,7 +124,7 @@ end = struct
 
   let tmc_placeholder =
     (* we choose a placeholder whose tagged representation will be
-       reconizable. *)
+       reconizable. When changed, edit it in misc.h as well. *)
     Lconst (Const_base (Const_int (0xBBBB / 2)))
 
   let with_placeholder constr (body : offset destination -> lambda) =

--- a/runtime/caml/misc.h
+++ b/runtime/caml/misc.h
@@ -531,6 +531,9 @@ int caml_runtime_warnings_active(void);
 
 #define Debug_uninit_stat    0xD7
 
+/* Placeholder value needs to be edited in lambda/tmc.ml as well. */
+#define Debug_uninit_tmc     0xBBBB
+
 #endif /* DEBUG */
 
 

--- a/runtime/memory.c
+++ b/runtime/memory.c
@@ -209,7 +209,8 @@ CAMLexport CAMLweakdef void caml_initialize (value *fp, value val)
 {
 #ifdef DEBUG
   if (Is_young((value)fp))
-    CAMLassert(*fp == Debug_uninit_minor || *fp == Val_unit);
+    CAMLassert(*fp == Debug_uninit_minor ||
+               *fp == Debug_uninit_tmc   || *fp == Val_unit);
   else
     CAMLassert(*fp == Debug_uninit_major || *fp == Val_unit);
 #endif


### PR DESCRIPTION
Currently the assertion in caml_initialize is not aware that TRMC may introduce a mutable placeholder for its own usage.
See: https://github.com/ocaml/ocaml/issues/11016#issuecomment-1041283696

This commit adds an extra check for it in the said assertion.

We discussed with @gasche a few possible routes to implement this: one we agreed on was to find a way to make already existing debug canaries available for `tmc.ml` to pick up.

However, the candidate at `Debug_uninit_minor` turned out to be a little complicated, as they involve some masks on integers, and are architecture dependent, see: https://github.com/ocaml/ocaml/blob/trunk/runtime/caml/misc.h#L494

This makes the simple solution of reusing such canary by copying it over to `tmc.ml` a bit flaky, in my opinion.

I decided to go with the simplest route, that is to define tmc's own canary (`Debug_uninit_tmc`), and add it as a an extra branch to the check in `caml_initialize`.

I think the one major drawback of this approach is the addition of another check in `caml_initialize` in the debug runtime.
I am unsure this is something we want, and I am open to suggestions on a possible way to implement the earlier design. (in which way we could then reuse the non-initialized minor heap canary.)