### PR TITLE
Minor improvements to "named values" handling

### DIFF
--- a/otherlibs/unix/unixsupport.c
+++ b/otherlibs/unix/unixsupport.c
@@ -283,22 +283,28 @@ int code_of_unix_error (value error)
   }
 }
 
+static const value * _Atomic unix_error_exn = NULL;
+
 void unix_error(int errcode, const char *cmdname, value cmdarg)
 {
   CAMLparam0();
   CAMLlocal3(name, err, arg);
   value res;
-  const value * unix_error_exn;
+  const value * exn;
 
+  exn = atomic_load_explicit(&unix_error_exn, memory_order_acquire);
+  if (exn == NULL) {
+    exn = caml_named_value("Unix.Unix_error");
+    if (exn == NULL)
+      caml_invalid_argument("Exception Unix.Unix_error not initialized,"
+                            " please link unix.cma");
+    atomic_store(&unix_error_exn, exn);
+  }
   arg = cmdarg == Nothing ? caml_copy_string("") : cmdarg;
   name = caml_copy_string(cmdname);
   err = unix_error_of_code (errcode);
-  unix_error_exn = caml_named_value("Unix.Unix_error");
-  if (unix_error_exn == NULL)
-    caml_invalid_argument("Exception Unix.Unix_error not initialized,"
-                     " please link unix.cma");
   res = caml_alloc_small(4, 0);
-  Field(res, 0) = *unix_error_exn;
+  Field(res, 0) = *exn;
   Field(res, 1) = err;
   Field(res, 2) = name;
   Field(res, 3) = arg;

--- a/runtime/callback.c
+++ b/runtime/callback.c
@@ -342,10 +342,12 @@ CAMLexport const value* caml_named_value(char const *name)
 CAMLexport void caml_iterate_named_values(caml_named_action f)
 {
   int i;
+  caml_plat_lock(&named_value_lock);
   for(i = 0; i < Named_value_size; i++){
     struct named_value * nv;
     for (nv = named_value_table[i]; nv != NULL; nv = nv->next) {
       f( Op_val(nv->val), nv->name );
     }
   }
+  caml_plat_unlock(&named_value_lock);
 }

--- a/runtime/callback.c
+++ b/runtime/callback.c
@@ -290,7 +290,8 @@ void caml_init_callbacks(void)
 static unsigned int hash_value_name(char const *name)
 {
   unsigned int h;
-  for (h = 0; *name != 0; name++) h = h * 19 + *name;
+  /* "djb2" hash function */
+  for (h = 5381; *name != 0; name++) h = h * 33 + *name;
   return h % Named_value_size;
 }
 


### PR DESCRIPTION
Three commits that address some of the outstanding review comments (#10861):

- c17f75c0b In unix_error, cache the result of caml_named_value("Unix.Unix_error"). Addresses https://github.com/ocaml/ocaml/pull/10831#discussion_r774700458
- ebd2c5eb2 Use the "djb2" hash function for the table of named values
- bc7a9f678 Add locking to caml_iterate_named_values.  Addresses https://github.com/ocaml/ocaml/pull/10831#discussion_r778332227


