### PR TITLE
Implement quality treatment for asynchronous actions in multicore

### DIFF
--- a/otherlibs/systhreads/st_stubs.c
+++ b/otherlibs/systhreads/st_stubs.c
@@ -674,8 +674,7 @@ CAMLprim value caml_thread_yield(value unit)
   st_thread_yield(&Thread_main_lock);
   Current_thread = st_tls_get(caml_thread_key);
   caml_thread_restore_runtime_state();
-  if (caml_check_pending_signals())
-    caml_set_action_pending(Caml_state);
+  caml_set_action_pending(Caml_state);
 
   return Val_unit;
 }

--- a/otherlibs/systhreads/st_stubs.c
+++ b/otherlibs/systhreads/st_stubs.c
@@ -674,7 +674,7 @@ CAMLprim value caml_thread_yield(value unit)
   st_thread_yield(&Thread_main_lock);
   Current_thread = st_tls_get(caml_thread_key);
   caml_thread_restore_runtime_state();
-  if (Caml_state->action_pending || caml_check_pending_signals())
+  if (caml_check_pending_signals())
     caml_set_action_pending(Caml_state);
 
   return Val_unit;

--- a/runtime/amd64.S
+++ b/runtime/amd64.S
@@ -535,6 +535,15 @@ ENDFUNCTION(G(caml_allocN))
 /* Call a C function from OCaml */
 /******************************************************************************/
 
+/* Update [young_limit] when returning from C calls */
+#define RET_FROM_C_CALL                         \
+        cmpq    $0, Caml_state(action_pending); \
+        jne     1f;                             \
+        ret;                                    \
+1:                                              \
+        movq    $-1, Caml_state(young_limit);   \
+        ret
+
 FUNCTION(G(caml_c_call))
 CFI_STARTPROC
         CFI_SIGNAL_FRAME
@@ -553,7 +562,7 @@ LBL(caml_c_call):
     /* Load ocaml stack and restore global variables */
         SWITCH_C_TO_OCAML
     /* Return to OCaml caller */
-        ret
+        RET_FROM_C_CALL
 CFI_ENDPROC
 ENDFUNCTION(G(caml_c_call))
 
@@ -593,7 +602,7 @@ LBL(106):
     /* Load ocaml stack and restore global variables */
         SWITCH_C_TO_OCAML
     /* Return to OCaml caller */
-        ret
+        RET_FROM_C_CALL
 CFI_ENDPROC
 ENDFUNCTION(G(caml_c_call_stack_args))
 

--- a/runtime/arm64.S
+++ b/runtime/arm64.S
@@ -417,6 +417,17 @@ FUNCTION(caml_allocN)
 /* Call a C function from OCaml */
 /* Function to call is in ADDITIONAL_ARG */
 
+/* Update [young_limit] when returning from C calls. */
+.macro RET_FROM_C_CALL
+        ldr     TMP, Caml_state(action_pending)
+        cbnz    TMP, 1f
+        ret
+1:
+        mov     TMP, #-1
+        str     TMP, Caml_state(young_limit)
+        ret
+.endm
+
 FUNCTION(caml_c_call)
         CFI_STARTPROC
         CFI_OFFSET(29, -16)
@@ -437,9 +448,9 @@ FUNCTION(caml_c_call)
         SWITCH_C_TO_OCAML
     /* Return */
         ldp     x29, x30, [sp], 16
-        ret
+        RET_FROM_C_CALL
         CFI_ENDPROC
-        END_FUNCTION(caml_c_call)
+END_FUNCTION(caml_c_call)
 
 FUNCTION(caml_c_call_stack_args)
         CFI_STARTPROC
@@ -478,8 +489,9 @@ FUNCTION(caml_c_call_stack_args)
         SWITCH_C_TO_OCAML
     /* Return */
         ldp     x29, x30, [sp], 16
-        ret
-CFI_ENDPROC
+        RET_FROM_C_CALL
+        CFI_ENDPROC
+END_FUNCTION(caml_c_call_stack_args)
 
 /* Start the OCaml program */
 

--- a/runtime/callback.c
+++ b/runtime/callback.c
@@ -102,6 +102,7 @@ CAMLexport value caml_callbackN_exn(value closure, int narg, value args[])
 
   cont = save_and_clear_stack_parent(domain_state);
 
+  caml_update_young_limit_after_c_call(domain_state);
   res = caml_interprete(callback_code, sizeof(callback_code));
   if (Is_exception_result(res))
     domain_state->current_stack->sp += narg + 4; /* PR#3419 */
@@ -159,6 +160,7 @@ CAMLexport value caml_callback_exn(value closure, value arg)
     value res;
 
     cont = save_and_clear_stack_parent(domain_state);
+    caml_update_young_limit_after_c_call(domain_state);
     res = caml_callback_asm(domain_state, closure, &arg);
     restore_stack_parent(domain_state, cont);
 
@@ -180,6 +182,7 @@ CAMLexport value caml_callback2_exn(value closure, value arg1, value arg2)
     value res;
 
     cont = save_and_clear_stack_parent(domain_state);
+    caml_update_young_limit_after_c_call(domain_state);
     res = caml_callback2_asm(domain_state, closure, args);
     restore_stack_parent(domain_state, cont);
 
@@ -202,6 +205,7 @@ CAMLexport value caml_callback3_exn(value closure,
     value res;
 
     cont = save_and_clear_stack_parent(domain_state);
+    caml_update_young_limit_after_c_call(domain_state);
     res = caml_callback3_asm(domain_state, closure, args);
     restore_stack_parent(domain_state, cont);
 

--- a/runtime/caml/domain.h
+++ b/runtime/caml/domain.h
@@ -66,6 +66,7 @@ void caml_handle_gc_interrupt(void);
 void caml_handle_incoming_interrupts(void);
 
 CAMLextern void caml_interrupt_self(void);
+void caml_interrupt_all_for_signal(void);
 void caml_reset_young_limit(caml_domain_state *);
 
 CAMLextern void caml_reset_domain_lock(void);

--- a/runtime/caml/domain.h
+++ b/runtime/caml/domain.h
@@ -37,12 +37,13 @@ extern "C" {
 #define Max_domains 16
 #endif
 
-/* is the minor heap full or an external interrupt has been triggered */
-Caml_inline int caml_check_gc_interrupt(caml_domain_state * dom_st)
+/* is the minor heap full or has an external interrupt been triggered? */
+Caml_inline int caml_check_gc_interrupt(uintnat young_ptr,
+                                        caml_domain_state * dom_st)
 {
   CAMLalloc_point_here;
   uintnat young_limit = atomic_load_relaxed(&dom_st->young_limit);
-  if ((uintnat)dom_st->young_ptr < young_limit) {
+  if (young_ptr < young_limit) {
     /* Synchronise for the case when [young_limit] was used to interrupt
        us. */
     atomic_thread_fence(memory_order_acquire);
@@ -51,8 +52,13 @@ Caml_inline int caml_check_gc_interrupt(caml_domain_state * dom_st)
   return 0;
 }
 
-#define Caml_check_gc_interrupt(dom_st)           \
-  (CAMLunlikely(caml_check_gc_interrupt(dom_st)))
+/* Interrupt functions */
+#define INTERRUPT_EXTERNAL ((uintnat)-1)
+
+#define Caml_check_gc_interrupt(dom_st)                                 \
+  (CAMLunlikely(caml_check_gc_interrupt((uintnat)dom_st->young_ptr, dom_st)))
+#define Caml_check_gc_external_interrupt(dom_st)                        \
+  (CAMLunlikely(caml_check_gc_interrupt(INTERRUPT_EXTERNAL - 1, dom_st)))
 
 asize_t caml_norm_minor_heap_size (intnat);
 int caml_reallocate_minor_heap(asize_t);

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -123,7 +123,10 @@
 
 /* control of STW interrupts */
 struct interruptor {
-  atomic_uintnat* interrupt_word;
+  /* The outermost atomic is for synchronization with
+     caml_interrupt_all_for_signal. The innermost atomic is also for
+     cross-domain communication.*/
+  _Atomic(atomic_uintnat *) interrupt_word;
   caml_plat_mutex lock;
   caml_plat_cond cond;
 
@@ -187,7 +190,7 @@ static caml_plat_mutex all_domains_lock = CAML_PLAT_MUTEX_INITIALIZER;
 static caml_plat_cond all_domains_cond =
     CAML_PLAT_COND_INITIALIZER(&all_domains_lock);
 static atomic_uintnat /* dom_internal* */ stw_leader = 0;
-static struct dom_internal all_domains[Max_domains];
+static dom_internal all_domains[Max_domains];
 
 CAMLexport atomic_uintnat caml_num_domains_running;
 
@@ -286,7 +289,9 @@ CAMLexport __thread caml_domain_state* caml_state;
 
 Caml_inline void interrupt_domain(struct interruptor* s)
 {
-  atomic_store_rel(s->interrupt_word, (uintnat)(-1));
+  atomic_uintnat * interrupt_word =
+    atomic_load_explicit(&s->interrupt_word, memory_order_relaxed);
+  atomic_store_rel(interrupt_word, (uintnat)(-1));
 }
 
 int caml_incoming_interrupts_queued(void)
@@ -572,8 +577,14 @@ static void create_domain(uintnat initial_minor_heap_wsize) {
 
   SET_Caml_state((void*)domain_state);
 
+  domain_state->young_limit = 0;
+  /* Synchronized with [caml_interrupt_all_for_signal], so that the
+     initializing write of young_limit happens before any
+     interrupt. */
+  atomic_store_explicit(&s->interrupt_word, &domain_state->young_limit,
+                        memory_order_release);
+
   s->unique_id = fresh_domain_unique_id();
-  s->interrupt_word = &domain_state->young_limit;
   s->running = 1;
   atomic_fetch_add(&caml_num_domains_running, 1);
 
@@ -852,7 +863,7 @@ void caml_init_domains(uintnat minor_heap_wsz) {
 
     dom->id = i;
 
-    dom->interruptor.interrupt_word = 0;
+    dom->interruptor.interrupt_word = NULL;
     caml_plat_mutex_init(&dom->interruptor.lock);
     caml_plat_cond_init(&dom->interruptor.cond,
                         &dom->interruptor.lock);
@@ -1462,8 +1473,21 @@ int caml_try_run_on_all_domains(
                                                  leader_setup, 0, 0);
 }
 
-void caml_interrupt_self(void) {
+void caml_interrupt_self(void)
+{
   interrupt_domain(&domain_self->interruptor);
+}
+
+/* async-signal-safe */
+void caml_interrupt_all_for_signal(void)
+{
+  for (dom_internal *d = all_domains; d < &all_domains[Max_domains]; d++) {
+    atomic_uintnat * interrupt_word =
+      atomic_load_explicit(&d->interruptor.interrupt_word,
+                           memory_order_acquire);
+    if (interrupt_word == NULL) return;
+    interrupt_domain(&d->interruptor);
+  }
 }
 
 void caml_reset_young_limit(caml_domain_state * dom_st)

--- a/runtime/interp.c
+++ b/runtime/interp.c
@@ -91,7 +91,9 @@ sp is a local copy of the global variable Caml_state->extern_sp. */
   { sp -= 2; sp[0] = env; sp[1] = (value)(pc + 1); \
     domain_state->current_stack->sp = sp; }
 #define Restore_after_c_call \
-  { sp = domain_state->current_stack->sp; env = *sp; sp += 2; }
+  { sp = domain_state->current_stack->sp; env = *sp; sp += 2; \
+    caml_update_young_limit_after_c_call(domain_state);       \
+  }
 
 /* For VM threads purposes, an event frame must look like accu + a
    C_CALL frame + a RETURN 1 frame.

--- a/runtime/minor_gc.c
+++ b/runtime/minor_gc.c
@@ -804,9 +804,12 @@ void caml_alloc_small_dispatch (caml_domain_state * dom_st,
       caml_raise_if_exception(caml_do_pending_actions_exn());
     else {
       caml_handle_gc_interrupt();
-      /* In the case of long-running C code that regularly polls with
-         [caml_process_pending_actions], still force a query of all
-         callbacks at every minor collection or major slice. */
+      /* We might be here due to a recently-recorded signal, so we
+         need to remember that we must run signal handlers. In
+         addition, in the case of long-running C code that regularly
+         polls with caml_process_pending_actions, we want to force a
+         query of all callbacks at every minor collection or major
+         slice (similarly to OCaml behaviour). */
       dom_st->action_pending = 1;
     }
 

--- a/runtime/minor_gc.c
+++ b/runtime/minor_gc.c
@@ -802,16 +802,8 @@ void caml_alloc_small_dispatch (caml_domain_state * dom_st,
       /* In the case of allocations performed from OCaml, execute
          asynchronous callbacks. */
       caml_raise_if_exception(caml_do_pending_actions_exn());
-    else {
+    else
       caml_handle_gc_interrupt();
-      /* We might be here due to a recently-recorded signal, so we
-         need to remember that we must run signal handlers. In
-         addition, in the case of long-running C code that regularly
-         polls with caml_process_pending_actions, we want to force a
-         query of all callbacks at every minor collection or major
-         slice (similarly to OCaml behaviour). */
-      dom_st->action_pending = 1;
-    }
 
     /* Now, there might be enough room in the minor heap to do our
        allocation. */

--- a/runtime/signals.c
+++ b/runtime/signals.c
@@ -192,7 +192,8 @@ CAMLexport void caml_leave_blocking_section(void)
 
   /* Some other thread may have switched [Caml_state->action_pending]
      to 0 even though there are still pending actions, e.g. a signal
-     masked in the other thread.
+     masked in the other thread, or if the other thread was in the
+     middle of processing actions.
 
      Another case where this is necessary (even in a single threaded
      setting) is when the blocking section unmasks a pending signal:
@@ -201,10 +202,9 @@ CAMLexport void caml_leave_blocking_section(void)
      [Caml_state->action_pending] is 0 but the signal needs to be
      handled at this point.
 
-     So we force the examination of signals as soon as possible.
+     So we force the examination of all callbacks as soon as possible.
   */
-  if (caml_check_pending_signals())
-    caml_set_action_pending(Caml_state);
+  caml_set_action_pending(Caml_state);
 
   errno = saved_errno;
 }


### PR DESCRIPTION
Following the detailed action plan at #10915, here is the last step which will make the plan look like it was instructions for "how to draw an owl".

Fixes #10915, ocaml-multicore/ocaml-multicore#791, ocaml-multicore/ocaml-multicore#806, [some review comments in this series](https://github.com/ocaml/ocaml/pull/10831#pullrequestreview-847201882).

This PR is best reviewed commit-per-commit. Correctness concerns can be provided on a per-commit basis but for discussing design choices it is best to have the whole picture. I can split this PR in several parts, but the design makes sense as a whole.

Please refer to the individual commit logs for more description about what each one does.

I got impatient at the end so I stopped short of reimplementing StatMemprof.

(cc @sadiqj, @ctk21; I think this can also interest people with a very particular set of skills such as @jhjourdan and @stedolan.)