### PR TITLE
Documentation improvements for native stack switching functions

### DIFF
--- a/runtime/amd64.S
+++ b/runtime/amd64.S
@@ -856,7 +856,7 @@ ENDFUNCTION(G(caml_reperform))
 
 FUNCTION(G(caml_resume))
 CFI_STARTPROC
-    /* %rax -> stack, %rbx -> fun, %rdi -> arg */
+    /* %rax -> fiber, %rbx -> fun, %rdi -> arg */
         leaq    -1(%rax), %r10  /* %r10 (new stack) = Ptr_val(%rax) */
         movq    %rdi, %rax      /* %rax := argument to function in %rbx */
     /*  check if stack null, then already used */
@@ -882,7 +882,7 @@ ENDFUNCTION(G(caml_resume))
 FUNCTION(G(caml_runstack))
 CFI_STARTPROC
         CFI_SIGNAL_FRAME
-    /* %rax -> stack, %rbx -> fun, %rdi -> arg */
+    /* %rax -> fiber, %rbx -> fun, %rdi -> arg */
         andq    $-2, %rax       /* %rax = Ptr_val(%rax) */
     /* save old stack pointer and exception handler */
         movq    Caml_state(current_stack), %rcx

--- a/runtime/arm64.S
+++ b/runtime/arm64.S
@@ -687,6 +687,14 @@ FUNCTION(caml_callback3_asm)
         ldp     x29, x30, [sp], 16
 .endm
 
+
+/*
+ * A continuation is a one word object that points to a fiber. A fiber [f] will
+ * point to its parent at Handler_parent(Stack_handler(f)). In the following,
+ * the [last_fiber] refers to the last fiber in the linked-list formed by the
+ * parent pointer.
+ */
+
 FUNCTION(caml_perform)
         CFI_STARTPROC
     /*  x0: effect to perform
@@ -709,7 +717,7 @@ L(do_perform):
         str     xzr, Handler_parent(x9) /* Set parent of performer to NULL */
         ldr     TMP, Handler_effect(x9)
         mov     x2, x3                 /* x2 := last_fiber */
-        mov     x3, TMP                /* x2 := effect handler */
+        mov     x3, TMP                /* x3 := effect handler */
         b       G(caml_apply3)
 1:
     /*  switch back to original performer before raising Unhandled
@@ -739,7 +747,7 @@ FUNCTION(caml_reperform)
 
 FUNCTION(caml_resume)
 CFI_STARTPROC
-    /*  x0: new stack
+    /*  x0: new fiber
         x1: fun
         x2: arg */
         sub     x0, x0, 1 /* x0 = Ptr_val(x0) */
@@ -766,7 +774,7 @@ CFI_STARTPROC
    return the value or invoke exception handler */
 FUNCTION(caml_runstack)
 CFI_STARTPROC
-    /*  x0: stack
+    /*  x0: fiber
         x1: fun
         x2: arg */
         stp     x29, x30, [sp, -16]!

--- a/runtime/caml/stack.h
+++ b/runtime/caml/stack.h
@@ -71,16 +71,6 @@
 #define Saved_return_address(sp) *((intnat *)((sp) - 8))
 #endif
 
-/* Structure of OCaml callback contexts */
-
-struct caml_context {
-  uintnat exception_ptr;        /* exception pointer */
-  value * gc_regs;              /* pointer to register block */
-#ifdef Context_needs_padding
-  value padding;
-#endif
-};
-
 /* Declaration of variables used in the asm code */
 extern value * caml_globals[];
 extern intnat caml_globals_inited;

--- a/runtime/fiber.c
+++ b/runtime/fiber.c
@@ -60,6 +60,8 @@ void caml_change_max_stack_size (uintnat new_max_size)
   caml_max_stack_size = new_max_size;
 }
 
+#define NUM_STACK_SIZE_CLASSES 5
+
 struct stack_info** caml_alloc_stack_cache (void)
 {
   int i;


### PR DESCRIPTION
This PR adds comments to `fiber.h` for the native code specifications of `caml_runstack`, `caml_perform`, `caml_reperform`, `caml_resume`.

The PR also adds more comments for the data structures (`struct stack_info`, `struct stack_handler`) representing an OCaml stack. 

I decided the stack switching documentation belongs in `fiber.h` alongside the data structures because a reader of the assembly files will need to see both of these. However I'm open to other locations for the documentation.