### PR TITLE
RFC: Extend Lambda Representation with Metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -280,3 +280,5 @@ _build
 /yacc/ocamlyacc
 /yacc/version.h
 /yacc/.gdb_history
+
+_opam

--- a/bytecomp/bytegen.ml
+++ b/bytecomp/bytegen.ml
@@ -832,7 +832,7 @@ let rec comp_expr env exp sz cont =
       let l = comp_expr env body (sz+4) body_cont in
       try_blocks := List.tl !try_blocks;
       Kpushtrap lbl_handler :: l
-  | Lifthenelse(cond, ifso, ifnot) ->
+  | Lifthenelse(cond, ifso, ifnot, _meta) ->
       comp_binary_test env cond ifso ifnot sz cont
   | Lsequence(exp1, exp2) ->
       comp_expr env exp1 sz (comp_expr env exp2 sz cont)

--- a/bytecomp/bytegen.ml
+++ b/bytecomp/bytegen.ml
@@ -391,7 +391,7 @@ let comp_primitive p args =
   | Pcompare_ints -> Kccall("caml_int_compare", 2)
   | Pcompare_floats -> Kccall("caml_float_compare", 2)
   | Pcompare_bints bi -> comp_bint_primitive bi "compare" args
-  | Pfield n -> Kgetfield n
+  | Pfield (n, _meta) -> Kgetfield n
   | Pfield_computed -> Kgetvectitem
   | Psetfield(n, _ptr, _init) -> Ksetfield n
   | Psetfield_computed(_ptr, _init) -> Ksetvectitem
@@ -769,7 +769,7 @@ let rec comp_expr env exp sz cont =
         | CFnge -> Kccall("caml_ge_float", 2) :: Kboolnot :: cont
       in
       comp_args env args sz cont
-  | Lprim(Pmakeblock(tag, _mut, _), args, loc) ->
+  | Lprim(Pmakeblock(tag, _mut, _, _meta), args, loc) ->
       let cont = add_pseudo_event loc !compunit_name cont in
       comp_args env args sz (Kmakeblock(List.length args, tag) :: cont)
   | Lprim(Pfloatfield n, args, loc) ->

--- a/bytecomp/emitcode.ml
+++ b/bytecomp/emitcode.ml
@@ -239,7 +239,7 @@ let emit_instr = function
           else (out opCONSTINT; out_int i)
       | Const_base(Const_char c) ->
           out opCONSTINT; out_int (Char.code c)
-      | Const_block(t, []) ->
+      | Const_block(t, [], _metadata) ->
           if t = 0 then out opATOM0 else (out opATOM; out_int t)
       | _ ->
           out opGETGLOBAL; slot_for_literal sc
@@ -367,7 +367,7 @@ let rec emit = function
           else (out opPUSHCONSTINT; out_int i)
       | Const_base(Const_char c) ->
           out opPUSHCONSTINT; out_int(Char.code c)
-      | Const_block(t, []) ->
+      | Const_block(t, [], _metadata) ->
           if t = 0 then out opPUSHATOM0 else (out opPUSHATOM; out_int t)
       | _ ->
           out opPUSHGETGLOBAL; slot_for_literal sc

--- a/bytecomp/emitcode.ml
+++ b/bytecomp/emitcode.ml
@@ -75,8 +75,8 @@ let out opcode =
 exception AsInt
 
 let const_as_int = function
-  | Const_base(Const_int i) -> i
-  | Const_base(Const_char c) -> Char.code c
+  | Const_base(Const_int i, _metadata) -> i
+  | Const_base(Const_char c, _metadata) -> Char.code c
   | _ -> raise AsInt
 
 let is_immed i = immed_min <= i && i <= immed_max
@@ -233,11 +233,11 @@ let emit_instr = function
   | Ksetglobal q -> out opSETGLOBAL; slot_for_setglobal q
   | Kconst sc ->
       begin match sc with
-        Const_base(Const_int i) when is_immed i ->
+        Const_base(Const_int i, _metadata) when is_immed i ->
           if i >= 0 && i <= 3
           then out (opCONST0 + i)
           else (out opCONSTINT; out_int i)
-      | Const_base(Const_char c) ->
+      | Const_base(Const_char c, _metadata) ->
           out opCONSTINT; out_int (Char.code c)
       | Const_block(t, [], _metadata) ->
           if t = 0 then out opATOM0 else (out opATOM; out_int t)
@@ -361,11 +361,11 @@ let rec emit = function
       out opPUSHGETGLOBAL; slot_for_getglobal id; emit c
   | Kpush :: Kconst sc :: c ->
       begin match sc with
-        Const_base(Const_int i) when is_immed i ->
+        Const_base(Const_int i, _metadata) when is_immed i ->
           if i >= 0 && i <= 3
           then out (opPUSHCONST0 + i)
           else (out opPUSHCONSTINT; out_int i)
-      | Const_base(Const_char c) ->
+      | Const_base(Const_char c, _metadata) ->
           out opPUSHCONSTINT; out_int(Char.code c)
       | Const_block(t, [], _metadata) ->
           if t = 0 then out opPUSHATOM0 else (out opPUSHATOM; out_int t)

--- a/bytecomp/symtable.ml
+++ b/bytecomp/symtable.ml
@@ -158,8 +158,8 @@ let init () =
       let c = slot_for_setglobal id in
       let cst = Const_block
           (Obj.object_tag,
-           [Const_base(Const_string (name, Location.none,None));
-            Const_base(Const_int (-i-1))
+           [Const_base(Const_string (name, Location.none,None), None);
+            Const_base(Const_int (-i-1), None)
            ],
            None)
       in
@@ -218,13 +218,13 @@ let patch_object buff patchlist =
 (* Translate structured constants *)
 
 let rec transl_const = function
-    Const_base(Const_int i) -> Obj.repr i
-  | Const_base(Const_char c) -> Obj.repr c
-  | Const_base(Const_string (s, _, _)) -> Obj.repr s
-  | Const_base(Const_float f) -> Obj.repr (float_of_string f)
-  | Const_base(Const_int32 i) -> Obj.repr i
-  | Const_base(Const_int64 i) -> Obj.repr i
-  | Const_base(Const_nativeint i) -> Obj.repr i
+    Const_base(Const_int i, _metadata) -> Obj.repr i
+  | Const_base(Const_char c, _metadata) -> Obj.repr c
+  | Const_base(Const_string (s, _, _), _metadata) -> Obj.repr s
+  | Const_base(Const_float f, _metadata) -> Obj.repr (float_of_string f)
+  | Const_base(Const_int32 i, _metadata) -> Obj.repr i
+  | Const_base(Const_int64 i, _metadata) -> Obj.repr i
+  | Const_base(Const_nativeint i, _metadata) -> Obj.repr i
   | Const_immstring s -> Obj.repr s
   | Const_block(tag, fields, _metadata) ->
       let block = Obj.new_block tag (List.length fields) in

--- a/bytecomp/symtable.ml
+++ b/bytecomp/symtable.ml
@@ -160,7 +160,8 @@ let init () =
           (Obj.object_tag,
            [Const_base(Const_string (name, Location.none,None));
             Const_base(Const_int (-i-1))
-           ])
+           ],
+           None)
       in
       literal_table := (c, cst) :: !literal_table)
     Runtimedef.builtin_exceptions;
@@ -225,7 +226,7 @@ let rec transl_const = function
   | Const_base(Const_int64 i) -> Obj.repr i
   | Const_base(Const_nativeint i) -> Obj.repr i
   | Const_immstring s -> Obj.repr s
-  | Const_block(tag, fields) ->
+  | Const_block(tag, fields, _metadata) ->
       let block = Obj.new_block tag (List.length fields) in
       let pos = ref 0 in
       List.iter

--- a/lambda/lambda.ml
+++ b/lambda/lambda.ml
@@ -62,7 +62,9 @@ type block_metadata =
       representation: Types.record_representation
     }
   | Block_tuple
-  | Block_variant
+  | Block_variant of {
+      label: label
+    }
   | Block_module
 
 type field_metadata = unit

--- a/lambda/lambda.ml
+++ b/lambda/lambda.ml
@@ -39,6 +39,20 @@ type is_safe =
   | Safe
   | Unsafe
 
+type block_metadata =
+  | Block_construct
+  | Block_extension_constructor
+  | Block_lazy
+  | Block_record of {
+      fields: Types.label_description array;
+      representation: Types.record_representation
+    }
+  | Block_tuple
+  | Block_variant
+  | Block_module
+
+type field_metadata = unit
+
 type primitive =
   | Pbytes_to_string
   | Pbytes_of_string
@@ -47,8 +61,8 @@ type primitive =
   | Pgetglobal of Ident.t
   | Psetglobal of Ident.t
   (* Operations on heap blocks *)
-  | Pmakeblock of int * mutable_flag * block_shape
-  | Pfield of int
+  | Pmakeblock of int * mutable_flag * block_shape * block_metadata option
+  | Pfield of int * field_metadata option
   | Pfield_computed
   | Psetfield of int * immediate_or_pointer * initialization_or_assignment
   | Psetfield_computed of immediate_or_pointer * initialization_or_assignment
@@ -642,7 +656,7 @@ let rec transl_address loc = function
       then Lprim(Pgetglobal id, [], loc)
       else Lvar id
   | Env.Adot(addr, pos) ->
-      Lprim(Pfield pos, [transl_address loc addr], loc)
+      Lprim(Pfield (pos, None), [transl_address loc addr], loc)
 
 let transl_path find loc env path =
   match find path env with

--- a/lambda/lambda.ml
+++ b/lambda/lambda.ml
@@ -48,7 +48,13 @@ type block_record_field = {
 }
 
 type block_metadata =
-  | Block_construct
+  | Block_construct of {
+      name: string;
+      arity: int;
+      loc: Location.t;
+      attributes: Parsetree.attributes;
+      tag: Types.constructor_tag;
+    }
   | Block_extension_constructor
   | Block_lazy
   | Block_record of {

--- a/lambda/lambda.ml
+++ b/lambda/lambda.ml
@@ -39,12 +39,22 @@ type is_safe =
   | Safe
   | Unsafe
 
+type block_record_field = {
+  brf_name: string;
+  brf_mut: Types.mutable_flag;
+  brf_pos: int;
+  brf_loc: Location.t;
+  brf_attributes: Parsetree.attributes;
+  brf_uid: Uid.t;
+}
+
 type block_metadata =
   | Block_construct
   | Block_extension_constructor
   | Block_lazy
   | Block_record of {
-      fields: Types.label_description array;
+      fields: block_record_field array;
+      representation: Types.record_representation
     }
   | Block_tuple
   | Block_variant

--- a/lambda/lambda.ml
+++ b/lambda/lambda.ml
@@ -227,7 +227,7 @@ let equal_value_kind x y =
 
 type structured_constant =
     Const_base of constant
-  | Const_block of int * structured_constant list
+  | Const_block of int * structured_constant list * block_metadata option
   | Const_float_array of string list
   | Const_immstring of string
 

--- a/lambda/lambda.ml
+++ b/lambda/lambda.ml
@@ -49,10 +49,10 @@ type block_record_field = {
 
 type block_metadata =
   | Block_construct of {
-      name: string;
       arity: int;
-      loc: Location.t;
       attributes: Parsetree.attributes;
+      loc: Location.t;
+      name: string;
       tag: Types.constructor_tag;
     }
   | Block_extension_constructor

--- a/lambda/lambda.ml
+++ b/lambda/lambda.ml
@@ -74,12 +74,19 @@ type block_metadata =
       label: label
     }
 
-type field_metadata = {
-  fm_attributes: Parsetree.attributes;
-  fm_loc: Location.t;
-  fm_name : string;
-  fm_pos : int;
-}
+type field_metadata =
+  | Field_constructor of {
+      attributes: Parsetree.attributes;
+      loc: Location.t;
+      name : string;
+      arity : int;
+    }
+  | Field_record of {
+      attributes: Parsetree.attributes;
+      loc: Location.t;
+      name : string;
+      pos : int;
+    }
 
 type constructor_metadata = {
   cm_kind: [ `block | `const ];

--- a/lambda/lambda.ml
+++ b/lambda/lambda.ml
@@ -711,7 +711,12 @@ let rec transl_address loc metadata = function
       then Lprim(Pgetglobal id, [], loc)
       else Lvar id
   | Env.Adot(addr, pos) ->
-      Lprim(Pfield (pos, metadata), [transl_address loc metadata addr], loc)
+      let metadata' = match metadata with
+      | Some (Field_module { mod_name; _ }) ->
+        Some (Field_module { mod_name; field_name = "WHAT"; })
+      | _ -> None
+      in
+      Lprim(Pfield (pos, metadata'), [transl_address loc metadata addr], loc)
 
 let transl_path find loc metadata env path =
   match find path env with

--- a/lambda/lambda.ml
+++ b/lambda/lambda.ml
@@ -45,7 +45,6 @@ type block_record_field = {
   brf_pos: int;
   brf_loc: Location.t;
   brf_attributes: Parsetree.attributes;
-  brf_uid: Uid.t;
 }
 
 type block_metadata =

--- a/lambda/lambda.ml
+++ b/lambda/lambda.ml
@@ -47,6 +47,9 @@ type block_record_field = {
   brf_attributes: Parsetree.attributes;
 }
 
+type const_metadata =
+  | Const_variant of { label: label }
+
 type block_metadata =
   | Block_construct of {
       arity: int;
@@ -55,8 +58,6 @@ type block_metadata =
       name: string;
       tag: Types.constructor_tag;
     }
-  | Block_extension_constructor
-  | Block_lazy
   | Block_record of {
       fields: block_record_field array;
       representation: Types.record_representation
@@ -65,7 +66,6 @@ type block_metadata =
   | Block_variant of {
       label: label
     }
-  | Block_module
 
 type field_metadata = unit
 
@@ -226,7 +226,7 @@ let equal_value_kind x y =
 
 
 type structured_constant =
-    Const_base of constant
+    Const_base of constant * const_metadata option
   | Const_block of int * structured_constant list * block_metadata option
   | Const_float_array of string list
   | Const_immstring of string
@@ -369,7 +369,7 @@ type program =
     required_globals : Ident.Set.t;
     code : lambda }
 
-let const_int n = Const_base (Const_int n)
+let const_int ?(meta=None) n = Const_base (Const_int n, meta)
 
 let const_unit = const_int 0
 
@@ -410,7 +410,7 @@ let make_key e =
         try Ident.find_same id env
         with Not_found -> e
       end
-    | Lconst  (Const_base (Const_string _)) ->
+    | Lconst  (Const_base ((Const_string _), _meta)) ->
         (* Mutable constants are not shared *)
         raise Not_simple
     | Lconst _ -> e

--- a/lambda/lambda.ml
+++ b/lambda/lambda.ml
@@ -45,7 +45,6 @@ type block_metadata =
   | Block_lazy
   | Block_record of {
       fields: Types.label_description array;
-      representation: Types.record_representation
     }
   | Block_tuple
   | Block_variant

--- a/lambda/lambda.ml
+++ b/lambda/lambda.ml
@@ -49,6 +49,13 @@ type block_record_field = {
 
 type const_metadata =
   | Const_variant of { label: label }
+  | Const_construct of {
+      arity: int;
+      attributes: Parsetree.attributes;
+      loc: Location.t;
+      name: string;
+      tag: Types.constructor_tag;
+    }
 
 type block_metadata =
   | Block_construct of {

--- a/lambda/lambda.ml
+++ b/lambda/lambda.ml
@@ -81,10 +81,16 @@ type field_metadata = {
   fm_pos : int;
 }
 
-type switch_metadata =
-  | Switch_construct of { name : string; arity : int }
+type constructor_metadata = {
+  cm_kind: [ `block | `const ];
+  cm_name: Ident.t;
+  cm_arity: int;
+}
 
-type ifthenelse_metadata = | List 
+type switch_metadata =
+  | Switch_construct of constructor_metadata list 
+
+type ifthenelse_metadata = | List
 
 type primitive =
   | Pbytes_to_string

--- a/lambda/lambda.ml
+++ b/lambda/lambda.ml
@@ -67,7 +67,12 @@ type block_metadata =
       label: label
     }
 
-type field_metadata = unit
+type field_metadata = {
+  fm_attributes: Parsetree.attributes;
+  fm_loc: Location.t;
+  fm_name : string;
+  fm_pos : int;
+}
 
 type primitive =
   | Pbytes_to_string

--- a/lambda/lambda.ml
+++ b/lambda/lambda.ml
@@ -101,10 +101,9 @@ type constructor_metadata = {
   cm_arity: int;
 }
 
-type switch_metadata =
-  | Switch_construct of constructor_metadata list 
+type switch_metadata = constructor_metadata list
 
-type ifthenelse_metadata = | List
+type ifthenelse_metadata = constructor_metadata list
 
 type primitive =
   | Pbytes_to_string

--- a/lambda/lambda.ml
+++ b/lambda/lambda.ml
@@ -41,7 +41,7 @@ type is_safe =
 
 type block_record_field = {
   brf_name: string;
-  brf_mut: Types.mutable_flag;
+  brf_mut: mutable_flag;
   brf_pos: int;
   brf_loc: Location.t;
   brf_attributes: Parsetree.attributes;

--- a/lambda/lambda.ml
+++ b/lambda/lambda.ml
@@ -81,6 +81,9 @@ type field_metadata = {
   fm_pos : int;
 }
 
+type switch_metadata =
+  | Switch_construct of { name : string; arity : int }
+
 type primitive =
   | Pbytes_to_string
   | Pbytes_of_string
@@ -360,6 +363,7 @@ and lambda_switch =
     sw_consts: (int * lambda) list;
     sw_numblocks: int;
     sw_blocks: (int * lambda) list;
+    sw_metadata: switch_metadata option;
     sw_failaction : lambda option}
 
 and lambda_event =
@@ -899,6 +903,7 @@ let shallow_map f = function
                  sw_numblocks = sw.sw_numblocks;
                  sw_blocks = List.map (fun (n, e) -> (n, f e)) sw.sw_blocks;
                  sw_failaction = Option.map f sw.sw_failaction;
+                 sw_metadata = sw.sw_metadata;
                },
                loc)
   | Lstringswitch (e, sw, default, loc) ->

--- a/lambda/lambda.ml
+++ b/lambda/lambda.ml
@@ -88,8 +88,7 @@ type field_metadata =
       pos : int;
     }
   | Field_module of {
-      mod_name : string;
-      field_name : string;
+      address: Env.address
     }
   | Field_primitive of {
       mod_name : string;
@@ -711,11 +710,7 @@ let rec transl_address loc metadata = function
       then Lprim(Pgetglobal id, [], loc)
       else Lvar id
   | Env.Adot(addr, pos) ->
-      let metadata' = match metadata with
-      | Some (Field_module { mod_name; _ }) ->
-        Some (Field_module { mod_name; field_name = "WHAT"; })
-      | _ -> None
-      in
+      let metadata' = Some (Field_module {  address = addr; }) in
       Lprim(Pfield (pos, metadata'), [transl_address loc metadata addr], loc)
 
 let transl_path find loc metadata env path =

--- a/lambda/lambda.mli
+++ b/lambda/lambda.mli
@@ -73,7 +73,12 @@ type block_metadata =
       label: label
     }
 
-type field_metadata = unit
+type field_metadata = {
+  fm_attributes: Parsetree.attributes;
+  fm_loc: Location.t;
+  fm_name : string;
+  fm_pos : int;
+}
 
 type primitive =
   | Pbytes_to_string

--- a/lambda/lambda.mli
+++ b/lambda/lambda.mli
@@ -90,6 +90,8 @@ type field_metadata = {
 type switch_metadata =
   | Switch_construct of { name : string; arity : int }
 
+type ifthenelse_metadata = | List 
+
 type primitive =
   | Pbytes_to_string
   | Pbytes_of_string
@@ -323,7 +325,7 @@ type lambda =
   | Ltrywith of lambda * Ident.t * lambda
 (* Lifthenelse (e, t, f) evaluates t if e evaluates to 0, and
    evaluates f if e evaluates to any other value *)
-  | Lifthenelse of lambda * lambda * lambda
+  | Lifthenelse of lambda * lambda * lambda * ifthenelse_metadata option
   | Lsequence of lambda * lambda
   | Lwhile of lambda * lambda
   | Lfor of Ident.t * lambda * lambda * direction_flag * lambda

--- a/lambda/lambda.mli
+++ b/lambda/lambda.mli
@@ -55,6 +55,13 @@ type block_record_field = {
 
 type const_metadata =
   | Const_variant of { label: label }
+  | Const_construct of {
+      arity: int;
+      attributes: Parsetree.attributes;
+      loc: Location.t;
+      name: string;
+      tag: Types.constructor_tag;
+    }
 
 type block_metadata =
   | Block_construct of {

--- a/lambda/lambda.mli
+++ b/lambda/lambda.mli
@@ -93,6 +93,14 @@ type field_metadata =
       name : string;
       pos : int;
     }
+  | Field_module of {
+      mod_name : string;
+      field_name : string;
+    }
+  | Field_primitive of {
+      mod_name : string;
+      prim_name : string;
+    }
 
 type constructor_metadata = {
   cm_kind: [ `block | `const ];
@@ -433,10 +441,10 @@ val transl_prim: string -> string -> lambda
 
 val free_variables: lambda -> Ident.Set.t
 
-val transl_module_path: scoped_location -> Env.t -> Path.t -> lambda
-val transl_value_path: scoped_location -> Env.t -> Path.t -> lambda
-val transl_extension_path: scoped_location -> Env.t -> Path.t -> lambda
-val transl_class_path: scoped_location -> Env.t -> Path.t -> lambda
+val transl_module_path: scoped_location -> field_metadata option -> Env.t -> Path.t -> lambda
+val transl_value_path: scoped_location -> field_metadata option -> Env.t -> Path.t -> lambda
+val transl_extension_path: scoped_location -> field_metadata option -> Env.t -> Path.t -> lambda
+val transl_class_path: scoped_location -> field_metadata option -> Env.t -> Path.t -> lambda
 
 val make_sequence: ('a -> lambda) -> 'a list -> lambda
 

--- a/lambda/lambda.mli
+++ b/lambda/lambda.mli
@@ -225,7 +225,7 @@ val equal_boxed_integer : boxed_integer -> boxed_integer -> bool
 
 type structured_constant =
     Const_base of constant
-  | Const_block of int * structured_constant list
+  | Const_block of int * structured_constant list * block_metadata option
   | Const_float_array of string list
   | Const_immstring of string
 

--- a/lambda/lambda.mli
+++ b/lambda/lambda.mli
@@ -45,6 +45,20 @@ type is_safe =
   | Safe
   | Unsafe
 
+type block_metadata =
+  | Block_construct
+  | Block_extension_constructor
+  | Block_lazy
+  | Block_record of {
+      fields: Types.label_description array;
+      representation: Types.record_representation
+    }
+  | Block_tuple
+  | Block_variant
+  | Block_module
+
+type field_metadata = unit
+
 type primitive =
   | Pbytes_to_string
   | Pbytes_of_string
@@ -53,8 +67,8 @@ type primitive =
   | Pgetglobal of Ident.t
   | Psetglobal of Ident.t
   (* Operations on heap blocks *)
-  | Pmakeblock of int * mutable_flag * block_shape
-  | Pfield of int
+  | Pmakeblock of int * mutable_flag * block_shape * block_metadata option
+  | Pfield of int * field_metadata option
   | Pfield_computed
   | Psetfield of int * immediate_or_pointer * initialization_or_assignment
   | Psetfield_computed of immediate_or_pointer * initialization_or_assignment

--- a/lambda/lambda.mli
+++ b/lambda/lambda.mli
@@ -87,10 +87,16 @@ type field_metadata = {
   fm_pos : int;
 }
 
-type switch_metadata =
-  | Switch_construct of { name : string; arity : int }
+type constructor_metadata = {
+  cm_kind: [ `block | `const ];
+  cm_name: Ident.t;
+  cm_arity: int;
+}
 
-type ifthenelse_metadata = | List 
+type switch_metadata =
+  | Switch_construct of constructor_metadata list
+
+type ifthenelse_metadata = | List
 
 type primitive =
   | Pbytes_to_string

--- a/lambda/lambda.mli
+++ b/lambda/lambda.mli
@@ -54,7 +54,13 @@ type block_record_field = {
 }
 
 type block_metadata =
-  | Block_construct
+  | Block_construct of {
+      arity: int;
+      attributes: Parsetree.attributes;
+      loc: Location.t;
+      name: string;
+      tag: Types.constructor_tag;
+    }
   | Block_extension_constructor
   | Block_lazy
   | Block_record of {

--- a/lambda/lambda.mli
+++ b/lambda/lambda.mli
@@ -80,12 +80,19 @@ type block_metadata =
       label: label
     }
 
-type field_metadata = {
-  fm_attributes: Parsetree.attributes;
-  fm_loc: Location.t;
-  fm_name : string;
-  fm_pos : int;
-}
+type field_metadata =
+  | Field_constructor of {
+      attributes: Parsetree.attributes;
+      loc: Location.t;
+      name : string;
+      arity : int;
+    }
+  | Field_record of {
+      attributes: Parsetree.attributes;
+      loc: Location.t;
+      name : string;
+      pos : int;
+    }
 
 type constructor_metadata = {
   cm_kind: [ `block | `const ];

--- a/lambda/lambda.mli
+++ b/lambda/lambda.mli
@@ -94,8 +94,7 @@ type field_metadata =
       pos : int;
     }
   | Field_module of {
-      mod_name : string;
-      field_name : string;
+      address: Env.address
     }
   | Field_primitive of {
       mod_name : string;

--- a/lambda/lambda.mli
+++ b/lambda/lambda.mli
@@ -45,12 +45,20 @@ type is_safe =
   | Safe
   | Unsafe
 
+type block_record_field = {
+  brf_name: string;
+  brf_mut: mutable_flag;
+  brf_pos: int;
+  brf_loc: Location.t;
+  brf_attributes: Parsetree.attributes;
+}
+
 type block_metadata =
   | Block_construct
   | Block_extension_constructor
   | Block_lazy
   | Block_record of {
-      fields: Types.label_description array;
+      fields: block_record_field array;
       representation: Types.record_representation
     }
   | Block_tuple

--- a/lambda/lambda.mli
+++ b/lambda/lambda.mli
@@ -68,7 +68,9 @@ type block_metadata =
       representation: Types.record_representation
     }
   | Block_tuple
-  | Block_variant
+  | Block_variant of {
+      label: label
+    }
   | Block_module
 
 type field_metadata = unit

--- a/lambda/lambda.mli
+++ b/lambda/lambda.mli
@@ -107,10 +107,9 @@ type constructor_metadata = {
   cm_arity: int;
 }
 
-type switch_metadata =
-  | Switch_construct of constructor_metadata list
+type switch_metadata = constructor_metadata list
 
-type ifthenelse_metadata = | List
+type ifthenelse_metadata = constructor_metadata list
 
 type primitive =
   | Pbytes_to_string

--- a/lambda/lambda.mli
+++ b/lambda/lambda.mli
@@ -87,6 +87,9 @@ type field_metadata = {
   fm_pos : int;
 }
 
+type switch_metadata =
+  | Switch_construct of { name : string; arity : int }
+
 type primitive =
   | Pbytes_to_string
   | Pbytes_of_string
@@ -350,6 +353,7 @@ and lambda_switch =
     sw_consts: (int * lambda) list;     (* Integer cases *)
     sw_numblocks: int;                  (* Number of tag block cases *)
     sw_blocks: (int * lambda) list;     (* Tag block cases *)
+    sw_metadata: switch_metadata option;(* Metadata about the switch *)
     sw_failaction : lambda option}      (* Action to take if failure *)
 and lambda_event =
   { lev_loc: scoped_location;

--- a/lambda/lambda.mli
+++ b/lambda/lambda.mli
@@ -53,6 +53,9 @@ type block_record_field = {
   brf_attributes: Parsetree.attributes;
 }
 
+type const_metadata =
+  | Const_variant of { label: label }
+
 type block_metadata =
   | Block_construct of {
       arity: int;
@@ -61,8 +64,6 @@ type block_metadata =
       name: string;
       tag: Types.constructor_tag;
     }
-  | Block_extension_constructor
-  | Block_lazy
   | Block_record of {
       fields: block_record_field array;
       representation: Types.record_representation
@@ -71,7 +72,6 @@ type block_metadata =
   | Block_variant of {
       label: label
     }
-  | Block_module
 
 type field_metadata = unit
 
@@ -224,7 +224,7 @@ val equal_value_kind : value_kind -> value_kind -> bool
 val equal_boxed_integer : boxed_integer -> boxed_integer -> bool
 
 type structured_constant =
-    Const_base of constant
+    Const_base of constant * const_metadata option
   | Const_block of int * structured_constant list * block_metadata option
   | Const_float_array of string list
   | Const_immstring of string
@@ -374,7 +374,7 @@ type program =
 val make_key: lambda -> lambda option
 
 val const_unit: structured_constant
-val const_int : int -> structured_constant
+val const_int : ?meta:const_metadata option -> int -> structured_constant
 val lambda_unit: lambda
 val name_lambda: let_kind -> lambda -> (Ident.t -> lambda) -> lambda
 val name_lambda_list: lambda list -> (lambda list -> lambda) -> lambda

--- a/lambda/matching.ml
+++ b/lambda/matching.ml
@@ -1884,8 +1884,7 @@ let get_mod_field modname field =
              fatal_error ("Primitive " ^ modname ^ "." ^ field ^ " not found.")
          | path, _ -> 
              let metadata = Some (Field_module {
-               mod_name = modname;
-               field_name = field;
+               address = Env.find_value_address path env 
              }) in
              transl_value_path Loc_unknown metadata env path
        ))

--- a/lambda/matching.ml
+++ b/lambda/matching.ml
@@ -1913,14 +1913,14 @@ let inline_lazy_force_cond arg loc =
             (* if (tag == Obj.forward_tag) then varg.(0) else ... *)
             ( Lprim
                 ( Pintcomp Ceq,
-                  [ tag_var; Lconst (Const_base (Const_int Obj.forward_tag)) ],
+                  [ tag_var; Lconst (Const_base ((Const_int Obj.forward_tag), None)) ],
                   loc ),
               Lprim (Pfield (0, None), [ varg ], loc),
               Lifthenelse
                 (* if (tag == Obj.lazy_tag) then Lazy.force varg else ... *)
                 ( Lprim
                     ( Pintcomp Ceq,
-                      [ tag_var; Lconst (Const_base (Const_int Obj.lazy_tag)) ],
+                      [ tag_var; Lconst (Const_base (Const_int Obj.lazy_tag, None)) ],
                       loc ),
                   Lapply
                     { ap_tailcall = Default_tailcall;
@@ -2108,7 +2108,7 @@ let get_expr_args_array ~scopes kind head (arg, _mut) rem =
       rem
     else
       ( Lprim
-          (Parrayrefu kind, [ arg; Lconst (Const_base (Const_int pos)) ], loc),
+          (Parrayrefu kind, [ arg; Lconst (Const_base (Const_int pos, None)) ], loc),
         StrictOpt )
       :: make_args (pos + 1)
   in
@@ -2184,7 +2184,7 @@ let rec split k xs =
         let xs, y0, ys = split (k - 2) xs in
         (x0 :: xs, y0, ys)
 
-let zero_lam = Lconst (Const_base (Const_int 0))
+let zero_lam = Lconst (Const_base (Const_int 0, None))
 
 let tree_way_test loc arg lt eq gt =
   Lifthenelse
@@ -2283,7 +2283,7 @@ let rec do_tests_fail loc fail tst arg = function
   | [] -> fail
   | (c, act) :: rem ->
       Lifthenelse
-        ( Lprim (tst, [ arg; Lconst (Const_base c) ], loc),
+        ( Lprim (tst, [ arg; Lconst (Const_base (c, None)) ], loc),
           do_tests_fail loc fail tst arg rem,
           act )
 
@@ -2292,7 +2292,7 @@ let rec do_tests_nofail loc tst arg = function
   | [ (_, act) ] -> act
   | (c, act) :: rem ->
       Lifthenelse
-        ( Lprim (tst, [ arg; Lconst (Const_base c) ], loc),
+        ( Lprim (tst, [ arg; Lconst (Const_base (c, None)) ], loc),
           do_tests_nofail loc tst arg rem,
           act )
 
@@ -2313,7 +2313,7 @@ let make_test_sequence loc fail tst lt_tst arg const_lambda_list =
       rev_split_at (List.length const_lambda_list / 2) const_lambda_list
     in
     Lifthenelse
-      ( Lprim (lt_tst, [ arg; Lconst (Const_base (fst (List.hd list2))) ], loc),
+      ( Lprim (lt_tst, [ arg; Lconst (Const_base (fst (List.hd list2), None)) ], loc),
         make_test_sequence list1,
         make_test_sequence list2 )
   in
@@ -2355,7 +2355,7 @@ module SArg = struct
     in
     bind Alias newvar arg (body newarg)
 
-  let make_const i = Lconst (Const_base (Const_int i))
+  let make_const i = Lconst (Const_base (Const_int i, None))
 
   let make_isout h arg = Lprim (Pisout, [ h; arg ], Loc_unknown)
 
@@ -3437,9 +3437,9 @@ let failure_handler ~scopes loc ~failer () =
                 Lconst
                   (Const_block
                      ( 0,
-                       [ Const_base (Const_string (fname, loc, None));
-                         Const_base (Const_int line);
-                         Const_base (Const_int char)
+                       [ Const_base (Const_string (fname, loc, None), None);
+                         Const_base (Const_int line, None);
+                         Const_base (Const_int char, None)
                        ],
                        None ))
               ],

--- a/lambda/matching.ml
+++ b/lambda/matching.ml
@@ -2848,7 +2848,7 @@ let combine_constructor loc metadata arg pat_env cstr partial ctx def
             | 1, 1, [ (0, act1) ], [ (0, act2) ] ->
                 (* Typically, match on lists, will avoid isint primitive in that
               case *)
-                Lifthenelse (arg, act2, act1, Some List)
+                Lifthenelse (arg, act2, act1, metadata)
             | n, 0, _, [] ->
                 (* The type defines constant constructors only *)
                 call_switcher loc metadata fail_opt arg 0 (n - 1) consts 
@@ -3283,7 +3283,7 @@ and do_compile_matching ~scopes repr partial ctx pmh =
 
 
       (* NOTE: we need to dereference the type in case its a link *)
-      let metadata = match (Btype.repr ph.pat_type).desc with
+      let metadata: Lambda.constructor_metadata list option = match (Btype.repr ph.pat_type).desc with
       | Tconstr (path, _, _) ->
           (match (Env.find_type path ph.pat_env) with
           | { type_kind = Type_variant (cstrs, _repr); _ } ->
@@ -3300,7 +3300,7 @@ and do_compile_matching ~scopes repr partial ctx pmh =
                     | Cstr_record fields -> List.length fields);
                 }
               ) cstrs in
-              Some (Switch_construct meta)
+              Some (meta)
           | _ -> None)
       | _ -> None
       in

--- a/lambda/matching.ml
+++ b/lambda/matching.ml
@@ -2894,7 +2894,7 @@ let call_switcher_variant_constr loc sw_metadata fail arg int_lambda_list =
     ( Alias,
       Pgenval,
       v,
-      Lprim (Pfield (0, None), [ arg ], loc),
+      Lprim (Pfield (0, sw_metadata), [ arg ], loc),
       call_switcher loc sw_metadata fail (Lvar v) min_int max_int int_lambda_list )
 
 let combine_variant loc sw_metadata row arg partial ctx def (tag_lambda_list, total1, _pats)

--- a/lambda/matching.ml
+++ b/lambda/matching.ml
@@ -1882,7 +1882,12 @@ let get_mod_field modname field =
          match Env.find_value_by_name (Longident.Lident field) env with
          | exception Not_found ->
              fatal_error ("Primitive " ^ modname ^ "." ^ field ^ " not found.")
-         | path, _ -> transl_value_path Loc_unknown env path
+         | path, _ -> 
+             let metadata = Some (Field_module {
+               mod_name = modname;
+               field_name = field;
+             }) in
+             transl_value_path Loc_unknown metadata env path
        ))
 
 let code_force_lazy_block = get_mod_field "CamlinternalLazy" "force_lazy_block"
@@ -2803,7 +2808,7 @@ let combine_constructor loc metadata arg pat_env cstr partial ctx def
               let tests =
                 List.fold_right
                   (fun (path, act) rem ->
-                    let ext = transl_extension_path loc pat_env path in
+                    let ext = transl_extension_path loc None pat_env path in
                     Lifthenelse
                       (Lprim (Pintcomp Ceq, [ Lvar tag; ext ], loc), act, rem, None))
                   nonconsts default
@@ -2812,7 +2817,7 @@ let combine_constructor loc metadata arg pat_env cstr partial ctx def
         in
         List.fold_right
           (fun (path, act) rem ->
-            let ext = transl_extension_path loc pat_env path in
+            let ext = transl_extension_path loc None pat_env path in
             Lifthenelse (Lprim (Pintcomp Ceq, [ arg; ext ], loc), act, rem, None))
           consts nonconst_lambda
       in
@@ -3463,7 +3468,7 @@ let failure_handler ~scopes loc ~failer () =
   | Raise_match_failure ->
     let sloc = Scoped_location.of_location ~scopes loc in
     let slot =
-      transl_extension_path sloc
+      transl_extension_path sloc None
         Env.initial_safe_string Predef.path_match_failure
     in
     let fname, line, char =

--- a/lambda/matching.ml
+++ b/lambda/matching.ml
@@ -3440,7 +3440,8 @@ let failure_handler ~scopes loc ~failer () =
                        [ Const_base (Const_string (fname, loc, None));
                          Const_base (Const_int line);
                          Const_base (Const_int char)
-                       ] ))
+                       ],
+                       None ))
               ],
               sloc )
         ],
@@ -3603,7 +3604,7 @@ let assign_pat ~scopes opt nraise catch_ids loc pat lam =
     | Tpat_tuple patl, Lprim (Pmakeblock _, lams, _) ->
         opt := true;
         List.fold_left2 collect acc patl lams
-    | Tpat_tuple patl, Lconst (Const_block (_, scl)) ->
+    | Tpat_tuple patl, Lconst (Const_block (_, scl, _metadata)) ->
         opt := true;
         let collect_const acc pat sc = collect acc pat (Lconst sc) in
         List.fold_left2 collect_const acc patl scl

--- a/lambda/matching.ml
+++ b/lambda/matching.ml
@@ -1766,7 +1766,8 @@ let get_expr_args_constr ~scopes head (arg, _mut) rem =
       if pos > last_pos then
         argl
       else
-        (Lprim (Pfield pos, [ arg ], loc), binding_kind) :: make_args (pos + 1)
+        (Lprim (Pfield (pos, None), [ arg ], loc), binding_kind)
+          :: make_args (pos + 1)
     in
     make_args first_pos
   in
@@ -1794,7 +1795,7 @@ let get_expr_args_variant_constant = drop_expr_arg
 
 let get_expr_args_variant_nonconst ~scopes head (arg, _mut) rem =
   let loc = head_loc ~scopes head in
-  (Lprim (Pfield 1, [ arg ], loc), Alias) :: rem
+  (Lprim (Pfield (1, None), [ arg ], loc), Alias) :: rem
 
 let divide_variant ~scopes row ctx { cases = cl; args; default = def } =
   let row = Btype.row_repr row in
@@ -1914,7 +1915,7 @@ let inline_lazy_force_cond arg loc =
                 ( Pintcomp Ceq,
                   [ tag_var; Lconst (Const_base (Const_int Obj.forward_tag)) ],
                   loc ),
-              Lprim (Pfield 0, [ varg ], loc),
+              Lprim (Pfield (0, None), [ varg ], loc),
               Lifthenelse
                 (* if (tag == Obj.lazy_tag) then Lazy.force varg else ... *)
                 ( Lprim
@@ -1951,7 +1952,7 @@ let inline_lazy_force_switch arg loc =
                 sw_numblocks = 256;
                 (* PR#6033 - tag ranges from 0 to 255 *)
                 sw_blocks =
-                  [ (Obj.forward_tag, Lprim (Pfield 0, [ varg ], loc));
+                  [ (Obj.forward_tag, Lprim (Pfield (0, None), [ varg ], loc));
                     ( Obj.lazy_tag,
                       Lapply
                         { ap_tailcall = Default_tailcall;
@@ -2013,7 +2014,7 @@ let get_expr_args_tuple ~scopes head (arg, _mut) rem =
     if pos >= arity then
       rem
     else
-      (Lprim (Pfield pos, [ arg ], loc), Alias) :: make_args (pos + 1)
+      (Lprim (Pfield (pos, None), [ arg ], loc), Alias) :: make_args (pos + 1)
   in
   make_args 0
 
@@ -2057,10 +2058,10 @@ let get_expr_args_record ~scopes head (arg, _mut) rem =
         match lbl.lbl_repres with
         | Record_regular
         | Record_inlined _ ->
-            Lprim (Pfield lbl.lbl_pos, [ arg ], loc)
+            Lprim (Pfield (lbl.lbl_pos, None), [ arg ], loc)
         | Record_unboxed _ -> arg
         | Record_float -> Lprim (Pfloatfield lbl.lbl_pos, [ arg ], loc)
-        | Record_extension _ -> Lprim (Pfield (lbl.lbl_pos + 1), [ arg ], loc)
+        | Record_extension _ -> Lprim (Pfield (lbl.lbl_pos + 1, None), [ arg ], loc)
       in
       let str =
         match lbl.lbl_mut with
@@ -2795,7 +2796,7 @@ let combine_constructor loc arg pat_env cstr partial ctx def
                       (Lprim (Pintcomp Ceq, [ Lvar tag; ext ], loc), act, rem))
                   nonconsts default
               in
-              Llet (Alias, Pgenval, tag, Lprim (Pfield 0, [ arg ], loc), tests)
+              Llet (Alias, Pgenval, tag, Lprim (Pfield (0, None), [ arg ], loc), tests)
         in
         List.fold_right
           (fun (path, act) rem ->
@@ -2885,7 +2886,7 @@ let call_switcher_variant_constr loc fail arg int_lambda_list =
     ( Alias,
       Pgenval,
       v,
-      Lprim (Pfield 0, [ arg ], loc),
+      Lprim (Pfield (0, None), [ arg ], loc),
       call_switcher loc fail (Lvar v) min_int max_int int_lambda_list )
 
 let combine_variant loc row arg partial ctx def (tag_lambda_list, total1, _pats)
@@ -3431,7 +3432,7 @@ let failure_handler ~scopes loc ~failer () =
     Lprim
       ( Praise Raise_regular,
         [ Lprim
-            ( Pmakeblock (0, Immutable, None),
+            ( Pmakeblock (0, Immutable, None, None),
               [ slot;
                 Lconst
                   (Const_block
@@ -3750,7 +3751,7 @@ let do_for_multiple_match ~scopes loc paraml pat_act_list partial =
   let repr = None in
   let arg =
     let sloc = Scoped_location.of_location ~scopes loc in
-    Lprim (Pmakeblock (0, Immutable, None), paraml, sloc) in
+    Lprim (Pmakeblock (0, Immutable, None, None), paraml, sloc) in
   let handler =
     let partial = check_partial pat_act_list partial in
     let rows = map_on_rows (fun p -> (p, [])) pat_act_list in

--- a/lambda/printlambda.ml
+++ b/lambda/printlambda.ml
@@ -152,11 +152,11 @@ let primitive ppf = function
   | Pignore -> fprintf ppf "ignore"
   | Pgetglobal id -> fprintf ppf "global %a" Ident.print id
   | Psetglobal id -> fprintf ppf "setglobal %a" Ident.print id
-  | Pmakeblock(tag, Immutable, shape) ->
+  | Pmakeblock(tag, Immutable, shape, _metadata) ->
       fprintf ppf "makeblock %i%a" tag block_shape shape
-  | Pmakeblock(tag, Mutable, shape) ->
+  | Pmakeblock(tag, Mutable, shape, _metadata) ->
       fprintf ppf "makemutable %i%a" tag block_shape shape
-  | Pfield n -> fprintf ppf "field %i" n
+  | Pfield (n, _metadata) -> fprintf ppf "field %i" n
   | Pfield_computed -> fprintf ppf "field_computed"
   | Psetfield(n, ptr, init) ->
       let instr =

--- a/lambda/printlambda.ml
+++ b/lambda/printlambda.ml
@@ -21,14 +21,14 @@ open Lambda
 
 
 let rec struct_const ppf = function
-  | Const_base(Const_int n) -> fprintf ppf "%i" n
-  | Const_base(Const_char c) -> fprintf ppf "%C" c
-  | Const_base(Const_string (s, _, _)) -> fprintf ppf "%S" s
+  | Const_base(Const_int n, _metadata) -> fprintf ppf "%i" n
+  | Const_base(Const_char c, _metadata) -> fprintf ppf "%C" c
+  | Const_base(Const_string (s, _, _), _metadata) -> fprintf ppf "%S" s
   | Const_immstring s -> fprintf ppf "#%S" s
-  | Const_base(Const_float f) -> fprintf ppf "%s" f
-  | Const_base(Const_int32 n) -> fprintf ppf "%lil" n
-  | Const_base(Const_int64 n) -> fprintf ppf "%LiL" n
-  | Const_base(Const_nativeint n) -> fprintf ppf "%nin" n
+  | Const_base(Const_float f, _metadata) -> fprintf ppf "%s" f
+  | Const_base(Const_int32 n, _metadata) -> fprintf ppf "%lil" n
+  | Const_base(Const_int64 n, _metadata) -> fprintf ppf "%LiL" n
+  | Const_base(Const_nativeint n, _metadata) -> fprintf ppf "%nin" n
   | Const_block(tag, [], _metadata) ->
       fprintf ppf "[%i]" tag
   | Const_block(tag, sc1::scl, _metadata) ->

--- a/lambda/printlambda.ml
+++ b/lambda/printlambda.ml
@@ -610,7 +610,7 @@ let rec lam ppf = function
   | Ltrywith(lbody, param, lhandler) ->
       fprintf ppf "@[<2>(try@ %a@;<1 -1>with %a@ %a)@]"
         lam lbody Ident.print param lam lhandler
-  | Lifthenelse(lcond, lif, lelse) ->
+  | Lifthenelse(lcond, lif, lelse, _meta) ->
       fprintf ppf "@[<2>(if@ %a@ %a@ %a)@]" lam lcond lam lif lam lelse
   | Lsequence(l1, l2) ->
       fprintf ppf "@[<2>(seq@ %a@ %a)@]" lam l1 sequence l2

--- a/lambda/printlambda.ml
+++ b/lambda/printlambda.ml
@@ -29,9 +29,9 @@ let rec struct_const ppf = function
   | Const_base(Const_int32 n) -> fprintf ppf "%lil" n
   | Const_base(Const_int64 n) -> fprintf ppf "%LiL" n
   | Const_base(Const_nativeint n) -> fprintf ppf "%nin" n
-  | Const_block(tag, []) ->
+  | Const_block(tag, [], _metadata) ->
       fprintf ppf "[%i]" tag
-  | Const_block(tag, sc1::scl) ->
+  | Const_block(tag, sc1::scl, _metadata) ->
       let sconsts ppf scl =
         List.iter (fun sc -> fprintf ppf "@ %a" struct_const sc) scl in
       fprintf ppf "@[<1>[%i:@ @[%a%a@]]@]" tag struct_const sc1 sconsts scl

--- a/lambda/simplif.ml
+++ b/lambda/simplif.ml
@@ -42,7 +42,7 @@ let rec eliminate_ref id = function
   | Lletrec(idel, e2) ->
       Lletrec(List.map (fun (v, e) -> (v, eliminate_ref id e)) idel,
               eliminate_ref id e2)
-  | Lprim(Pfield 0, [Lvar v], _) when Ident.same v id ->
+  | Lprim(Pfield (0, _metadata), [Lvar v], _) when Ident.same v id ->
       Lmutvar id
   | Lprim(Psetfield(0, _, _), [Lvar v; e], _) when Ident.same v id ->
       Lassign(id, eliminate_ref id e)
@@ -234,8 +234,8 @@ let simplify_exits lam =
         (* Simplify Obj.with_tag *)
       | Pccall { Primitive.prim_name = "caml_obj_with_tag"; _ },
         [Lconst (Const_base (Const_int tag));
-         Lprim (Pmakeblock (_, mut, shape), fields, loc)] ->
-         Lprim (Pmakeblock(tag, mut, shape), fields, loc)
+         Lprim (Pmakeblock (_, mut, shape, metadata), fields, loc)] ->
+         Lprim (Pmakeblock(tag, mut, shape, metadata), fields, loc)
       | Pccall { Primitive.prim_name = "caml_obj_with_tag"; _ },
         [Lconst (Const_base (Const_int tag));
          Lconst (Const_block (_, fields))] ->
@@ -543,7 +543,7 @@ let simplify_lets lam =
       Hashtbl.add subst v (simplif (Lvar w));
       simplif l2
   | Llet(Strict, kind, v,
-         Lprim(Pmakeblock(0, Mutable, kind_ref) as prim, [linit], loc), lbody)
+         Lprim(Pmakeblock(0, Mutable, kind_ref, _metadata) as prim, [linit], loc), lbody)
     when optimize ->
       let slinit = simplif linit in
       let slbody = simplif lbody in

--- a/lambda/simplif.ml
+++ b/lambda/simplif.ml
@@ -73,10 +73,11 @@ let rec eliminate_ref id = function
       Lstaticcatch(eliminate_ref id e1, i, eliminate_ref id e2)
   | Ltrywith(e1, v, e2) ->
       Ltrywith(eliminate_ref id e1, v, eliminate_ref id e2)
-  | Lifthenelse(e1, e2, e3) ->
+  | Lifthenelse(e1, e2, e3, meta) ->
       Lifthenelse(eliminate_ref id e1,
                   eliminate_ref id e2,
-                  eliminate_ref id e3)
+                  eliminate_ref id e3,
+                  meta)
   | Lsequence(e1, e2) ->
       Lsequence(eliminate_ref id e1, eliminate_ref id e2)
   | Lwhile(e1, e2) ->
@@ -166,7 +167,7 @@ let simplify_exits lam =
   | Ltrywith(l1, _v, l2) ->
       count ~try_depth:(try_depth+1) l1;
       count ~try_depth l2;
-  | Lifthenelse(l1, l2, l3) ->
+  | Lifthenelse(l1, l2, l3, _meta) ->
       count ~try_depth l1;
       count ~try_depth l2;
       count ~try_depth l3
@@ -309,8 +310,8 @@ let simplify_exits lam =
   | Ltrywith(l1, v, l2) ->
       let l1 = simplif ~try_depth:(try_depth + 1) l1 in
       Ltrywith(l1, v, simplif ~try_depth l2)
-  | Lifthenelse(l1, l2, l3) -> Lifthenelse(simplif ~try_depth l1,
-    simplif ~try_depth l2, simplif ~try_depth l3)
+  | Lifthenelse(l1, l2, l3, meta) -> Lifthenelse(simplif ~try_depth l1,
+    simplif ~try_depth l2, simplif ~try_depth l3, meta)
   | Lsequence(l1, l2) -> Lsequence(simplif ~try_depth l1, simplif ~try_depth l2)
   | Lwhile(l1, l2) -> Lwhile(simplif ~try_depth l1, simplif ~try_depth l2)
   | Lfor(v, l1, l2, dir, l3) ->
@@ -455,7 +456,7 @@ let simplify_lets lam =
   | Lstaticraise (_i,ls) -> List.iter (count bv) ls
   | Lstaticcatch(l1, _, l2) -> count bv l1; count bv l2
   | Ltrywith(l1, _v, l2) -> count bv l1; count bv l2
-  | Lifthenelse(l1, l2, l3) -> count bv l1; count bv l2; count bv l3
+  | Lifthenelse(l1, l2, l3, _meta) -> count bv l1; count bv l2; count bv l3
   | Lsequence(l1, l2) -> count bv l1; count bv l2
   | Lwhile(l1, l2) -> count Ident.Map.empty l1; count Ident.Map.empty l2
   | Lfor(_, l1, l2, _dir, l3) ->
@@ -593,7 +594,7 @@ let simplify_lets lam =
   | Lstaticcatch(l1, (i,args), l2) ->
       Lstaticcatch (simplif l1, (i,args), simplif l2)
   | Ltrywith(l1, v, l2) -> Ltrywith(simplif l1, v, simplif l2)
-  | Lifthenelse(l1, l2, l3) -> Lifthenelse(simplif l1, simplif l2, simplif l3)
+  | Lifthenelse(l1, l2, l3, meta) -> Lifthenelse(simplif l1, simplif l2, simplif l3, meta)
   | Lsequence(Lifused(v, l1), l2) ->
       if count_var v > 0
       then Lsequence(simplif l1, simplif l2)
@@ -674,7 +675,7 @@ let rec emit_tail_infos is_tail lambda =
   | Ltrywith (body, _, handler) ->
       emit_tail_infos false body;
       emit_tail_infos is_tail handler
-  | Lifthenelse (cond, ifso, ifno) ->
+  | Lifthenelse (cond, ifso, ifno, _meta) ->
       emit_tail_infos false cond;
       emit_tail_infos is_tail ifso;
       emit_tail_infos is_tail ifno
@@ -713,7 +714,7 @@ and list_emit_tail_infos is_tail =
 
 let split_default_wrapper ~id:fun_id ~kind ~params ~return ~body ~attr ~loc =
   let rec aux map = function
-    | Llet(Strict, k, id, (Lifthenelse(Lvar optparam, _, _) as def), rest) when
+    | Llet(Strict, k, id, (Lifthenelse(Lvar optparam, _, _, _) as def), rest) when
         Ident.name optparam = "*opt*" && List.mem_assoc optparam params
           && not (List.mem_assoc optparam map)
       ->

--- a/lambda/simplif.ml
+++ b/lambda/simplif.ml
@@ -238,8 +238,8 @@ let simplify_exits lam =
          Lprim (Pmakeblock(tag, mut, shape, metadata), fields, loc)
       | Pccall { Primitive.prim_name = "caml_obj_with_tag"; _ },
         [Lconst (Const_base (Const_int tag));
-         Lconst (Const_block (_, fields))] ->
-         Lconst (Const_block (tag, fields))
+         Lconst (Const_block (_, fields, metadata))] ->
+         Lconst (Const_block (tag, fields, metadata))
 
       | _ -> Lprim(p, ll, loc)
      end
@@ -344,7 +344,7 @@ let exact_application {kind; params; _} args =
           if List.length params <> List.length tupled_args
           then None
           else Some tupled_args
-      | [Lconst(Const_block (_, const_args))] ->
+      | [Lconst(Const_block (_, const_args, _metadata))] ->
           if List.length params <> List.length const_args
           then None
           else Some (List.map (fun cst -> Lconst cst) const_args)

--- a/lambda/simplif.ml
+++ b/lambda/simplif.ml
@@ -59,7 +59,8 @@ let rec eliminate_ref id = function
          sw_blocks =
             List.map (fun (n, e) -> (n, eliminate_ref id e)) sw.sw_blocks;
          sw_failaction =
-            Option.map (eliminate_ref id) sw.sw_failaction; },
+            Option.map (eliminate_ref id) sw.sw_failaction;
+         sw_metadata = sw.sw_metadata; },
         loc)
   | Lstringswitch(e, sw, default, loc) ->
       Lstringswitch

--- a/lambda/simplif.ml
+++ b/lambda/simplif.ml
@@ -233,11 +233,11 @@ let simplify_exits lam =
     match p, ll with
         (* Simplify Obj.with_tag *)
       | Pccall { Primitive.prim_name = "caml_obj_with_tag"; _ },
-        [Lconst (Const_base (Const_int tag));
+        [Lconst (Const_base (Const_int tag, None));
          Lprim (Pmakeblock (_, mut, shape, metadata), fields, loc)] ->
          Lprim (Pmakeblock(tag, mut, shape, metadata), fields, loc)
       | Pccall { Primitive.prim_name = "caml_obj_with_tag"; _ },
-        [Lconst (Const_base (Const_int tag));
+        [Lconst (Const_base (Const_int tag, None));
          Lconst (Const_block (_, fields, metadata))] ->
          Lconst (Const_block (tag, fields, metadata))
 

--- a/lambda/translclass.ml
+++ b/lambda/translclass.ml
@@ -920,7 +920,7 @@ let transl_class ~scopes ids cl_id pub_meths cl vflag =
          so that the program's behaviour does not change between runs *)
       lupdate_cache
     else
-      Lifthenelse(lfield cached 0, lambda_unit, lupdate_cache) in
+      Lifthenelse(lfield cached 0, lambda_unit, lupdate_cache, None) in
   llets (
   lcache (
   Lsequence(lcheck_cache,

--- a/lambda/translclass.ml
+++ b/lambda/translclass.ml
@@ -69,7 +69,7 @@ let transl_label l = share (Const_immstring l)
 let transl_meth_list lst =
   if lst = [] then Lconst (const_int 0) else
   share (Const_block
-            (0, List.map (fun lab -> Const_immstring lab) lst))
+            (0, List.map (fun lab -> Const_immstring lab) lst, None))
 
 let set_inst_var ~scopes obj id expr =
   Lprim(Psetfield_computed (Typeopt.maybe_pointer expr, Assignment),

--- a/lambda/translclass.ml
+++ b/lambda/translclass.ml
@@ -138,7 +138,7 @@ let rec build_object_init ~scopes cl_table obj params inh_init obj_init cl =
                    Loc_unknown)]
       in
       let loc = of_location ~scopes cl.cl_loc in
-      let path_lam = transl_class_path loc cl.cl_env path in
+      let path_lam = transl_class_path loc None cl.cl_env path in
       ((envs, (path, path_lam, obj_init) :: inh_init),
        mkappl(Lvar obj_init, env @ [obj]))
   | Tcl_structure str ->
@@ -433,7 +433,7 @@ let rec transl_class_rebind ~scopes obj_init cl vf =
         with Not_found -> raise Exit
       end;
       let cl_loc = of_location ~scopes cl.cl_loc in
-      let path_lam = transl_class_path cl_loc cl.cl_env path in
+      let path_lam = transl_class_path cl_loc None cl.cl_env path in
       (path, path_lam, obj_init)
   | Tcl_fun (_, pat, _, cl, partial) ->
       let path, path_lam, obj_init =

--- a/lambda/translclass.ml
+++ b/lambda/translclass.ml
@@ -62,7 +62,7 @@ let mkappl (func, args) =
 let lsequence l1 l2 =
   if l2 = lambda_unit then l1 else Lsequence(l1, l2)
 
-let lfield v i = Lprim(Pfield i, [Lvar v], Loc_unknown)
+let lfield v i = Lprim(Pfield (i, None), [Lvar v], Loc_unknown)
 
 let transl_label l = share (Const_immstring l)
 
@@ -133,7 +133,7 @@ let rec build_object_init ~scopes cl_table obj params inh_init obj_init cl =
       let env =
         match envs with None -> []
         | Some envs ->
-            [Lprim(Pfield (List.length inh_init + 1),
+            [Lprim(Pfield (List.length inh_init + 1, None),
                    [Lvar envs],
                    Loc_unknown)]
       in
@@ -254,7 +254,7 @@ let output_methods tbl methods lam =
       lsequence (mkappl(oo_prim "set_method", [Lvar tbl; lab; code])) lam
   | _ ->
       lsequence (mkappl(oo_prim "set_methods",
-                        [Lvar tbl; Lprim(Pmakeblock(0,Immutable,None),
+                        [Lvar tbl; Lprim(Pmakeblock(0,Immutable,None, None),
                                          methods, Loc_unknown)]))
         lam
 
@@ -278,8 +278,8 @@ let rec build_class_init ~scopes cla cstr super inh_init cl_init msubst top cl =
       | (_, path_lam, obj_init)::inh_init ->
           (inh_init,
            Llet (Strict, Pgenval, obj_init,
-                 mkappl(Lprim(Pfield 1, [path_lam], Loc_unknown), Lvar cla ::
-                        if top then [Lprim(Pfield 3, [path_lam], Loc_unknown)]
+                 mkappl(Lprim(Pfield (1, None), [path_lam], Loc_unknown), Lvar cla ::
+                        if top then [Lprim(Pfield (3, None), [path_lam], Loc_unknown)]
                         else []),
                  bind_super cla super cl_init))
       | _ ->
@@ -513,7 +513,7 @@ let transl_class_rebind ~scopes cl vf =
     Strict, Pgenval, new_init, lfunction [obj_init, Pgenval] obj_init',
     Llet(
     Alias, Pgenval, cla, path_lam,
-    Lprim(Pmakeblock(0, Immutable, None),
+    Lprim(Pmakeblock(0, Immutable, None, None),
           [mkappl(Lvar new_init, [lfield cla 0]);
            lfunction [table, Pgenval]
              (Llet(Strict, Pgenval, env_init,
@@ -551,7 +551,7 @@ let rec builtin_meths self env env2 body =
     | p when const_path p -> "const", [p]
     | Lprim(Parrayrefu _, [Lvar s; Lvar n], _) when List.mem s self ->
         "var", [Lvar n]
-    | Lprim(Pfield n, [Lvar e], _) when Ident.same e env ->
+    | Lprim(Pfield (n, _metadata), [Lvar e], _) when Ident.same e env ->
         "env", [Lvar env2; Lconst(const_int n)]
     | Lsend(Self, met, Lvar s, [], _) when List.mem s self ->
         "meth", [met]
@@ -811,12 +811,12 @@ let transl_class ~scopes ids cl_id pub_meths cl vflag =
       Strict, Pgenval, env_init, mkappl (Lvar class_init, [Lvar table]),
       Lsequence(
       mkappl (oo_prim "init_class", [Lvar table]),
-      Lprim(Pmakeblock(0, Immutable, None),
+      Lprim(Pmakeblock(0, Immutable, None, None),
             [mkappl (Lvar env_init, [lambda_unit]);
              Lvar class_init; Lvar env_init; lambda_unit],
             Loc_unknown))))
   and lbody_virt lenvs =
-    Lprim(Pmakeblock(0, Immutable, None),
+    Lprim(Pmakeblock(0, Immutable, None, None),
           [lambda_unit; Lfunction{kind = Curried;
                                   attr = default_function_attribute;
                                   loc = Loc_unknown;
@@ -839,22 +839,22 @@ let transl_class ~scopes ids cl_id pub_meths cl vflag =
   let lenv =
     let menv =
       if !new_ids_meths = [] then lambda_unit else
-      Lprim(Pmakeblock(0, Immutable, None),
+      Lprim(Pmakeblock(0, Immutable, None, None),
             List.map (fun id -> Lvar id) !new_ids_meths,
             Loc_unknown) in
     if !new_ids_init = [] then menv else
-    Lprim(Pmakeblock(0, Immutable, None),
+    Lprim(Pmakeblock(0, Immutable, None, None),
           menv :: List.map (fun id -> Lvar id) !new_ids_init,
           Loc_unknown)
   and linh_envs =
     List.map
-      (fun (_, path_lam, _) -> Lprim(Pfield 3, [path_lam], Loc_unknown))
+      (fun (_, path_lam, _) -> Lprim(Pfield (3, None), [path_lam], Loc_unknown))
       (List.rev inh_init)
   in
   let make_envs lam =
     Llet(StrictOpt, Pgenval, envs,
          (if linh_envs = [] then lenv else
-         Lprim(Pmakeblock(0, Immutable, None),
+         Lprim(Pmakeblock(0, Immutable, None, None),
                lenv :: linh_envs, Loc_unknown)),
          lam)
   and def_ids cla lam =
@@ -868,7 +868,7 @@ let transl_class ~scopes ids cl_id pub_meths cl vflag =
   in
   let inh_keys =
     List.map
-      (fun (_, path_lam, _) -> Lprim(Pfield 1, [path_lam], Loc_unknown))
+      (fun (_, path_lam, _) -> Lprim(Pfield (1, None), [path_lam], Loc_unknown))
       inh_paths
   in
   let lclass lam =
@@ -882,7 +882,7 @@ let transl_class ~scopes ids cl_id pub_meths cl vflag =
     if inh_keys = [] then Llet(Alias, Pgenval, cached, Lvar tables, lam) else
     Llet(Strict, Pgenval, cached,
          mkappl (oo_prim "lookup_tables",
-                [Lvar tables; Lprim(Pmakeblock(0, Immutable, None),
+                [Lvar tables; Lprim(Pmakeblock(0, Immutable, None, None),
                                     inh_keys, Loc_unknown)]),
          lam)
   and lset cached i lam =
@@ -926,7 +926,7 @@ let transl_class ~scopes ids cl_id pub_meths cl vflag =
   Lsequence(lcheck_cache,
   make_envs (
   if ids = [] then mkappl (lfield cached 0, [lenvs]) else
-  Lprim(Pmakeblock(0, Immutable, None),
+  Lprim(Pmakeblock(0, Immutable, None, None),
         (if concrete then
           [mkappl (lfield cached 0, [lenvs]);
            lfield cached 1;

--- a/lambda/translcore.ml
+++ b/lambda/translcore.ml
@@ -931,10 +931,6 @@ and transl_setinstvar ~scopes loc self var expr =
 
 and transl_record ~scopes loc env fields repres opt_init_expr =
   let size = Array.length fields in
-  let metadata = Block_record {
-    fields = Array.map (fun (f,_) -> f) fields;
-    representation = repres
-  } in
   (* Determine if there are "enough" fields (only relevant if this is a
      functional-style record update *)
   let no_init = match opt_init_expr with None -> true | _ -> false in
@@ -984,7 +980,7 @@ and transl_record ~scopes loc env fields repres opt_init_expr =
         let loc = of_location ~scopes loc in
         match repres with
           Record_regular ->
-            Lprim(Pmakeblock(0, mut, Some shape, Some metadata), ll, loc)
+            Lprim(Pmakeblock(0, mut, Some shape, None), ll, loc)
         | Record_inlined tag ->
             Lprim(Pmakeblock(tag, mut, Some shape, None), ll, loc)
         | Record_unboxed _ -> (match ll with [v] -> v | _ -> assert false)

--- a/lambda/translcore.ml
+++ b/lambda/translcore.ml
@@ -933,7 +933,6 @@ and transl_record ~scopes loc env fields repres opt_init_expr =
   let size = Array.length fields in
   let metadata = Block_record {
     fields = Array.map (fun (f,_) -> f) fields;
-    representation = repres
   } in
   (* Determine if there are "enough" fields (only relevant if this is a
      functional-style record update *)

--- a/lambda/translcore.ml
+++ b/lambda/translcore.ml
@@ -340,7 +340,14 @@ and transl_exp0 ~in_new_scope ~scopes e =
         | _ -> assert false
       end else begin match cstr.cstr_tag with
         Cstr_constant n ->
-          Lconst(const_int n)
+          let metadata = Const_construct {
+            name = cstr.cstr_name;
+            arity = cstr.cstr_arity;
+            loc = cstr.cstr_loc;
+            attributes = cstr.cstr_attributes;
+            tag = cstr.cstr_tag;
+          } in
+          Lconst(const_int ~meta:(Some metadata) n)
       | Cstr_unboxed ->
           (match ll with [v] -> v | _ -> assert false)
       | Cstr_block n ->

--- a/lambda/translcore.ml
+++ b/lambda/translcore.ml
@@ -956,16 +956,6 @@ and transl_setinstvar ~scopes loc self var expr =
 
 and transl_record ~scopes loc env fields repres opt_init_expr =
   let size = Array.length fields in
-  let metadata = Block_record {
-    fields = Array.map (fun (f,_) -> Lambda.{
-     brf_name = f.lbl_name;
-     brf_mut = f.lbl_mut;
-     brf_pos = f.lbl_pos;
-     brf_loc = f.lbl_loc;
-     brf_attributes = f.lbl_attributes;
-    }) fields;
-    representation = repres
-  } in
   (* Determine if there are "enough" fields (only relevant if this is a
      functional-style record update *)
   let no_init = match opt_init_expr with None -> true | _ -> false in
@@ -1000,6 +990,16 @@ and transl_record ~scopes loc env fields repres opt_init_expr =
       then Mutable
       else Immutable in
     let lam =
+      let metadata = Block_record {
+        fields = Array.map (fun (f,_) -> Lambda.{
+         brf_name = f.lbl_name;
+         brf_mut = f.lbl_mut;
+         brf_pos = f.lbl_pos;
+         brf_loc = f.lbl_loc;
+         brf_attributes = f.lbl_attributes;
+        }) fields;
+        representation = repres
+      } in
       try
         if mut = Mutable then raise Not_constant;
         let cl = List.map extract_constant ll in

--- a/lambda/translcore.ml
+++ b/lambda/translcore.ml
@@ -322,10 +322,17 @@ and transl_exp0 ~in_new_scope ~scopes e =
       begin try
         Lconst(Const_block(0, List.map extract_constant ll))
       with Not_constant ->
-        Lprim(Pmakeblock(0, Immutable, Some shape, None), ll,
+        Lprim(Pmakeblock(0, Immutable, Some shape, Some Block_tuple), ll,
               (of_location ~scopes e.exp_loc))
       end
   | Texp_construct(_, cstr, args) ->
+      let metadata = Block_construct {
+        name = cstr_name;
+        arity = cstr_arity;
+        loc = cstr_loc;
+        attributes = cstr_attributes;
+        tag = cstr_tag;
+      }
       let ll, shape = transl_list_with_shape ~scopes args in
       if cstr.cstr_inlined <> None then begin match ll with
         | [x] -> x

--- a/lambda/translcore.ml
+++ b/lambda/translcore.ml
@@ -931,6 +931,10 @@ and transl_setinstvar ~scopes loc self var expr =
 
 and transl_record ~scopes loc env fields repres opt_init_expr =
   let size = Array.length fields in
+  let metadata = Block_record {
+    fields = Array.map (fun (f,_) -> f) fields;
+    representation = repres
+  } in
   (* Determine if there are "enough" fields (only relevant if this is a
      functional-style record update *)
   let no_init = match opt_init_expr with None -> true | _ -> false in
@@ -980,7 +984,7 @@ and transl_record ~scopes loc env fields repres opt_init_expr =
         let loc = of_location ~scopes loc in
         match repres with
           Record_regular ->
-            Lprim(Pmakeblock(0, mut, Some shape, None), ll, loc)
+            Lprim(Pmakeblock(0, mut, Some shape, Some metadata), ll, loc)
         | Record_inlined tag ->
             Lprim(Pmakeblock(tag, mut, Some shape, None), ll, loc)
         | Record_unboxed _ -> (match ll with [v] -> v | _ -> assert false)

--- a/lambda/translcore.ml
+++ b/lambda/translcore.ml
@@ -389,11 +389,11 @@ and transl_exp0 ~in_new_scope ~scopes e =
         fields representation extended_expression
   | Texp_field(arg, _, lbl) ->
       let targ = transl_exp ~scopes arg in
-      let metadata = Lambda.{
-        fm_attributes = lbl.lbl_attributes;
-        fm_loc = lbl.lbl_loc;
-        fm_name = lbl.lbl_name;
-        fm_pos = lbl.lbl_pos;
+      let metadata = Lambda.Field_record {
+        attributes = lbl.lbl_attributes;
+        loc = lbl.lbl_loc;
+        name = lbl.lbl_name;
+        pos = lbl.lbl_pos;
       } in
       begin match lbl.lbl_repres with
           Record_regular | Record_inlined _ ->

--- a/lambda/translcore.ml
+++ b/lambda/translcore.ml
@@ -932,7 +932,15 @@ and transl_setinstvar ~scopes loc self var expr =
 and transl_record ~scopes loc env fields repres opt_init_expr =
   let size = Array.length fields in
   let metadata = Block_record {
-    fields = Array.map (fun (f,_) -> f) fields;
+    fields = Array.map (fun (f,_) -> Lambda.{
+     brf_name = f.lbl_name;
+     brf_mut = f.lbl_mut;
+     brf_pos = f.lbl_pos;
+     brf_loc = f.lbl_loc;
+     brf_attributes = f.lbl_attributes;
+     brf_uid = f.lbl_uid
+    }) fields;
+    representation = repres
   } in
   (* Determine if there are "enough" fields (only relevant if this is a
      functional-style record update *)

--- a/lambda/translcore.ml
+++ b/lambda/translcore.ml
@@ -327,12 +327,12 @@ and transl_exp0 ~in_new_scope ~scopes e =
       end
   | Texp_construct(_, cstr, args) ->
       let metadata = Block_construct {
-        name = cstr_name;
-        arity = cstr_arity;
-        loc = cstr_loc;
-        attributes = cstr_attributes;
-        tag = cstr_tag;
-      }
+        name = cstr.cstr_name;
+        arity = cstr.cstr_arity;
+        loc = cstr.cstr_loc;
+        attributes = cstr.cstr_attributes;
+        tag = cstr.cstr_tag;
+      } in
       let ll, shape = transl_list_with_shape ~scopes args in
       if cstr.cstr_inlined <> None then begin match ll with
         | [x] -> x
@@ -346,7 +346,7 @@ and transl_exp0 ~in_new_scope ~scopes e =
           begin try
             Lconst(Const_block(n, List.map extract_constant ll))
           with Not_constant ->
-            Lprim(Pmakeblock(n, Immutable, Some shape, None), ll,
+            Lprim(Pmakeblock(n, Immutable, Some shape, Some metadata), ll,
                   of_location ~scopes e.exp_loc)
           end
       | Cstr_extension(path, is_const) ->
@@ -354,7 +354,7 @@ and transl_exp0 ~in_new_scope ~scopes e =
                       (of_location ~scopes e.exp_loc) e.exp_env path in
           if is_const then lam
           else
-            Lprim(Pmakeblock(0, Immutable, Some (Pgenval :: shape), None),
+            Lprim(Pmakeblock(0, Immutable, Some (Pgenval :: shape), Some metadata),
                   lam :: ll, of_location ~scopes e.exp_loc)
       end
   | Texp_extension_constructor (_, path) ->

--- a/lambda/translcore.ml
+++ b/lambda/translcore.ml
@@ -369,7 +369,10 @@ and transl_exp0 ~in_new_scope ~scopes e =
             Lconst(Const_block(0, [const_int tag;
                                    extract_constant lam]))
           with Not_constant ->
-            Lprim(Pmakeblock(0, Immutable, None, None),
+            let metadata = Block_variant {
+              label = l;
+            } in
+            Lprim(Pmakeblock(0, Immutable, None, Some metadata),
                   [Lconst(const_int tag); lam],
                   of_location ~scopes e.exp_loc)
       end

--- a/lambda/translcore.ml
+++ b/lambda/translcore.ml
@@ -382,9 +382,15 @@ and transl_exp0 ~in_new_scope ~scopes e =
         fields representation extended_expression
   | Texp_field(arg, _, lbl) ->
       let targ = transl_exp ~scopes arg in
+      let metadata = Lambda.{
+        fm_attributes = lbl.lbl_attributes;
+        fm_loc = lbl.lbl_loc;
+        fm_name = lbl.lbl_name;
+        fm_pos = lbl.lbl_pos;
+      } in
       begin match lbl.lbl_repres with
           Record_regular | Record_inlined _ ->
-          Lprim (Pfield (lbl.lbl_pos, None), [targ],
+          Lprim (Pfield (lbl.lbl_pos, Some metadata), [targ],
                  of_location ~scopes e.exp_loc)
         | Record_unboxed _ -> targ
         | Record_float ->

--- a/lambda/translcore.ml
+++ b/lambda/translcore.ml
@@ -404,7 +404,7 @@ and transl_exp0 ~in_new_scope ~scopes e =
           Lprim (Pfloatfield lbl.lbl_pos, [targ],
                  of_location ~scopes e.exp_loc)
         | Record_extension _ ->
-          Lprim (Pfield (lbl.lbl_pos + 1, None), [targ],
+          Lprim (Pfield (lbl.lbl_pos + 1, Some metadata), [targ],
                  of_location ~scopes e.exp_loc)
       end
   | Texp_setfield(arg, _, lbl, newval) ->

--- a/lambda/translcore.ml
+++ b/lambda/translcore.ml
@@ -938,7 +938,6 @@ and transl_record ~scopes loc env fields repres opt_init_expr =
      brf_pos = f.lbl_pos;
      brf_loc = f.lbl_loc;
      brf_attributes = f.lbl_attributes;
-     brf_uid = f.lbl_uid
     }) fields;
     representation = repres
   } in

--- a/lambda/translcore.ml
+++ b/lambda/translcore.ml
@@ -992,13 +992,13 @@ and transl_record ~scopes loc env fields repres opt_init_expr =
           Record_regular ->
             Lprim(Pmakeblock(0, mut, Some shape, Some metadata), ll, loc)
         | Record_inlined tag ->
-            Lprim(Pmakeblock(tag, mut, Some shape, None), ll, loc)
+            Lprim(Pmakeblock(tag, mut, Some shape, Some metadata), ll, loc)
         | Record_unboxed _ -> (match ll with [v] -> v | _ -> assert false)
         | Record_float ->
             Lprim(Pmakearray (Pfloatarray, mut), ll, loc)
         | Record_extension path ->
             let slot = transl_extension_path loc env path in
-            Lprim(Pmakeblock(0, mut, Some (Pgenval :: shape), None), slot :: ll, loc)
+            Lprim(Pmakeblock(0, mut, Some (Pgenval :: shape), Some metadata), slot :: ll, loc)
     in
     begin match opt_init_expr with
       None -> lam

--- a/lambda/translcore.ml
+++ b/lambda/translcore.ml
@@ -472,11 +472,12 @@ and transl_exp0 ~in_new_scope ~scopes e =
   | Texp_ifthenelse(cond, ifso, Some ifnot) ->
       Lifthenelse(transl_exp ~scopes cond,
                   event_before ~scopes ifso (transl_exp ~scopes ifso),
-                  event_before ~scopes ifnot (transl_exp ~scopes ifnot))
+                  event_before ~scopes ifnot (transl_exp ~scopes ifnot),
+                  None)
   | Texp_ifthenelse(cond, ifso, None) ->
       Lifthenelse(transl_exp ~scopes cond,
                   event_before ~scopes ifso (transl_exp ~scopes ifso),
-                  lambda_unit)
+                  lambda_unit, None)
   | Texp_sequence(expr1, expr2) ->
       Lsequence(transl_exp ~scopes expr1,
                 event_before ~scopes expr2 (transl_exp ~scopes expr2))
@@ -569,7 +570,7 @@ and transl_exp0 ~in_new_scope ~scopes e =
       if !Clflags.noassert
       then lambda_unit
       else Lifthenelse (transl_exp ~scopes cond, lambda_unit,
-                        assert_failed ~scopes e)
+                        assert_failed ~scopes e, None)
   | Texp_lazy e ->
       (* when e needs no computation (constants, identifiers, ...), we
          optimize the translation just as Lazy.lazy_from_val would
@@ -670,7 +671,7 @@ and transl_guard ~scopes guard rhs =
   | None -> expr
   | Some cond ->
       event_before ~scopes cond
-        (Lifthenelse(transl_exp ~scopes cond, expr, staticfail))
+        (Lifthenelse(transl_exp ~scopes cond, expr, staticfail, None))
 
 and transl_case ~scopes {c_lhs; c_guard; c_rhs} =
   c_lhs, transl_guard ~scopes c_guard c_rhs

--- a/lambda/translmod.ml
+++ b/lambda/translmod.ml
@@ -220,7 +220,8 @@ let undefined_location loc =
   Lconst(Const_block(0,
                      [Const_base(Const_string (fname, loc, None));
                       const_int line;
-                      const_int char]))
+                      const_int char],
+                     None))
 
 exception Initialization_failure of unsafe_info
 
@@ -232,7 +233,7 @@ let init_shape id modl =
         raise (Initialization_failure
                 (Unsafe {reason=Unsafe_module_binding;loc;subid}))
     | Mty_signature sg ->
-        Const_block(0, [Const_block(0, init_shape_struct env sg)])
+        Const_block(0, [Const_block(0, init_shape_struct env sg, None)], None)
     | Mty_functor _ ->
         (* can we do better? *)
         raise (Initialization_failure

--- a/lambda/translmod.ml
+++ b/lambda/translmod.ml
@@ -218,7 +218,7 @@ let mod_prim = Lambda.transl_prim "CamlinternalMod"
 let undefined_location loc =
   let (fname, line, char) = Location.get_pos_info loc.Location.loc_start in
   Lconst(Const_block(0,
-                     [Const_base(Const_string (fname, loc, None));
+                     [Const_base(Const_string (fname, loc, None), None);
                       const_int line;
                       const_int char],
                      None))
@@ -1427,7 +1427,7 @@ let toploop_getvalue id =
                   [Lprim(Pgetglobal toploop_ident, [], Loc_unknown)],
                   Loc_unknown);
     ap_args=[Lconst(Const_base(
-      Const_string (toplevel_name id, Location.none, None)))];
+      Const_string (toplevel_name id, Location.none, None), None))];
     ap_tailcall=Default_tailcall;
     ap_inlined=Default_inline;
     ap_specialised=Default_specialise;
@@ -1441,7 +1441,7 @@ let toploop_setvalue id lam =
                   Loc_unknown);
     ap_args=
       [Lconst(Const_base(
-         Const_string(toplevel_name id, Location.none, None)));
+         Const_string(toplevel_name id, Location.none, None), None));
        lam];
     ap_tailcall=Default_tailcall;
     ap_inlined=Default_inline;

--- a/lambda/translmod.ml
+++ b/lambda/translmod.ml
@@ -98,7 +98,7 @@ let rec apply_coercion loc strict restr arg =
   | Tcoerce_primitive { pc_loc = _; pc_desc; pc_env; pc_type; } ->
       Translprim.transl_primitive loc pc_desc pc_env pc_type None
   | Tcoerce_alias (env, path, cc) ->
-      let lam = transl_module_path loc env path in
+      let lam = transl_module_path loc None env path in
       name_lambda strict arg
         (fun _ -> apply_coercion loc Alias cc lam)
 
@@ -508,7 +508,7 @@ and transl_module ~scopes cc rootpath mexp =
   match mexp.mod_desc with
   | Tmod_ident (path,_) ->
       apply_coercion loc Strict cc
-        (transl_module_path loc mexp.mod_env path)
+        (transl_module_path loc None mexp.mod_env path)
   | Tmod_structure str ->
       fst (transl_struct ~scopes loc [] cc rootpath str)
   | Tmod_functor _ ->
@@ -979,7 +979,7 @@ let field_of_str loc str =
     | Tcoerce_primitive { pc_loc = _; pc_desc; pc_env; pc_type; } ->
         Translprim.transl_primitive loc pc_desc pc_env pc_type None
     | Tcoerce_alias (env, path, cc) ->
-        let lam = transl_module_path loc env path in
+        let lam = transl_module_path loc None env path in
         apply_coercion loc Alias cc lam
     | _ -> apply_coercion loc Strict cc (Lvar ids.(pos))
 
@@ -1305,7 +1305,7 @@ let transl_store_structure ~scopes glob map prims aliases str =
               cont)
 
   and store_alias (pos, env, path, cc) =
-    let path_lam = transl_module_path Loc_unknown env path in
+    let path_lam = transl_module_path Loc_unknown None env path in
     let init_val = apply_coercion Loc_unknown Strict cc path_lam in
     Lprim(Psetfield(pos, Pointer, Root_initialization),
           [Lprim(Pgetglobal glob, [], Loc_unknown);

--- a/lambda/translmod.ml
+++ b/lambda/translmod.ml
@@ -83,10 +83,10 @@ let rec apply_coercion loc strict restr arg =
       name_lambda strict arg (fun id ->
         let get_field pos =
           if pos < 0 then lambda_unit
-          else Lprim(Pfield pos,[Lvar id], loc)
+          else Lprim(Pfield (pos, None),[Lvar id], loc)
         in
         let lam =
-          Lprim(Pmakeblock(0, Immutable, None),
+          Lprim(Pmakeblock(0, Immutable, None, None),
                 List.map (apply_coercion_field loc get_field) pos_cc_list,
                 loc)
         in
@@ -542,7 +542,7 @@ and transl_structure ~scopes loc fields cc rootpath final_env = function
       let body, size =
         match cc with
           Tcoerce_none ->
-            Lprim(Pmakeblock(0, Immutable, None),
+            Lprim(Pmakeblock(0, Immutable, None, None),
                   List.map (fun id -> Lvar id) (List.rev fields), loc),
               List.length fields
         | Tcoerce_structure(pos_cc_list, id_pos_list) ->
@@ -558,7 +558,7 @@ and transl_structure ~scopes loc fields cc rootpath final_env = function
             in
             let ids = List.fold_right Ident.Set.add fields Ident.Set.empty in
             let lam =
-              Lprim(Pmakeblock(0, Immutable, None),
+              Lprim(Pmakeblock(0, Immutable, None, None),
                   List.map
                     (fun (pos, cc) ->
                       match cc with
@@ -718,7 +718,7 @@ and transl_structure ~scopes loc fields cc rootpath final_env = function
                   rebind_idents (pos + 1) (id :: newfields) ids
                 in
                 Llet(Alias, Pgenval, id,
-                     Lprim(Pfield pos, [Lvar mid],
+                     Lprim(Pfield (pos, None), [Lvar mid],
                            of_location ~scopes incl.incl_loc), body),
                 size
           in
@@ -747,7 +747,7 @@ and transl_structure ~scopes loc fields cc rootpath final_env = function
                     rebind_idents (pos + 1) (id :: newfields) ids
                   in
                   Llet(Alias, Pgenval, id,
-                      Lprim(Pfield pos, [Lvar mid],
+                      Lprim(Pfield (pos, None), [Lvar mid],
                             of_location ~scopes od.open_loc), body),
                   size
               in
@@ -966,7 +966,7 @@ let transl_store_subst = ref Ident.Map.empty
 
 let nat_toplevel_name id =
   try match Ident.Map.find id !transl_store_subst with
-    | Lprim(Pfield pos, [Lprim(Pgetglobal glob, [], _)], _) -> (glob,pos)
+    | Lprim(Pfield (pos, _metadata), [Lprim(Pgetglobal glob, [], _)], _) -> (glob,pos)
     | _ -> raise Not_found
   with Not_found ->
     fatal_error("Translmod.nat_toplevel_name: " ^ Ident.unique_name id)
@@ -1065,7 +1065,7 @@ let transl_store_structure ~scopes glob map prims aliases str =
             Lsequence(lam,
                       Llet(Strict, Pgenval, id,
                            Lambda.subst no_env_update subst
-                             (Lprim(Pmakeblock(0, Immutable, None),
+                             (Lprim(Pmakeblock(0, Immutable, None, None),
                                     List.map (fun id -> Lvar id)
                                       (defined_idents str.str_items), loc)),
                            Lsequence(store_ident loc id,
@@ -1097,7 +1097,7 @@ let transl_store_structure ~scopes glob map prims aliases str =
             Lsequence(lam,
                       Llet(Strict, Pgenval, id,
                            Lambda.subst no_env_update subst
-                             (Lprim(Pmakeblock(0, Immutable, None),
+                             (Lprim(Pmakeblock(0, Immutable, None, None),
                                     List.map field map, loc)),
                            Lsequence(store_ident loc id,
                                      transl_store ~scopes rootpath
@@ -1202,7 +1202,7 @@ let transl_store_structure ~scopes glob map prims aliases str =
               | [] -> transl_store
                         ~scopes rootpath (add_idents true ids subst) cont rem
               | id :: idl ->
-                  Llet(Alias, Pgenval, id, Lprim(Pfield pos, [Lvar mid],
+                  Llet(Alias, Pgenval, id, Lprim(Pfield (pos, None), [Lvar mid],
                                                  of_location ~scopes loc),
                        Lsequence(store_ident (of_location ~scopes loc) id,
                                  store_idents (pos + 1) idl))
@@ -1248,7 +1248,7 @@ let transl_store_structure ~scopes glob map prims aliases str =
                         [] -> transl_store ~scopes rootpath
                                 (add_idents true ids subst) cont rem
                       | id :: idl ->
-                          Llet(Alias, Pgenval, id, Lprim(Pfield pos, [Lvar mid],
+                          Llet(Alias, Pgenval, id, Lprim(Pfield (pos, None), [Lvar mid],
                                                          loc),
                                Lsequence(store_ident loc id,
                                          store_idents (pos + 1) idl))
@@ -1283,7 +1283,7 @@ let transl_store_structure ~scopes glob map prims aliases str =
       match cc with
         Tcoerce_none ->
           Ident.Map.add id
-            (Lprim(Pfield pos,
+            (Lprim(Pfield (pos, None),
                    [Lprim(Pgetglobal glob, [], Loc_unknown)],
                    Loc_unknown))
             subst
@@ -1422,7 +1422,7 @@ let toplevel_name id =
 let toploop_getvalue id =
   Lapply{
     ap_loc=Loc_unknown;
-    ap_func=Lprim(Pfield toploop_getvalue_pos,
+    ap_func=Lprim(Pfield (toploop_getvalue_pos, None),
                   [Lprim(Pgetglobal toploop_ident, [], Loc_unknown)],
                   Loc_unknown);
     ap_args=[Lconst(Const_base(
@@ -1435,7 +1435,7 @@ let toploop_getvalue id =
 let toploop_setvalue id lam =
   Lapply{
     ap_loc=Loc_unknown;
-    ap_func=Lprim(Pfield toploop_setvalue_pos,
+    ap_func=Lprim(Pfield (toploop_setvalue_pos, None),
                   [Lprim(Pgetglobal toploop_ident, [], Loc_unknown)],
                   Loc_unknown);
     ap_args=
@@ -1520,7 +1520,7 @@ let transl_toplevel_item ~scopes item =
           lambda_unit
       | id :: ids ->
           Lsequence(toploop_setvalue id
-                      (Lprim(Pfield pos, [Lvar mid], Loc_unknown)),
+                      (Lprim(Pfield (pos, None), [Lvar mid], Loc_unknown)),
                     set_idents (pos + 1) ids) in
       Llet(Strict, Pgenval, mid,
            transl_module ~scopes Tcoerce_none None modl, set_idents 0 ids)
@@ -1543,7 +1543,7 @@ let transl_toplevel_item ~scopes item =
                 lambda_unit
             | id :: ids ->
                 Lsequence(toploop_setvalue id
-                            (Lprim(Pfield pos, [Lvar mid], Loc_unknown)),
+                            (Lprim(Pfield (pos, None), [Lvar mid], Loc_unknown)),
                           set_idents (pos + 1) ids)
           in
           Llet(pure, Pgenval, mid,
@@ -1590,13 +1590,13 @@ let transl_package_flambda component_names coercion =
   in
   size,
   apply_coercion Loc_unknown Strict coercion
-    (Lprim(Pmakeblock(0, Immutable, None),
+    (Lprim(Pmakeblock(0, Immutable, None, None),
            List.map get_component component_names,
            Loc_unknown))
 
 let transl_package component_names target_name coercion =
   let components =
-    Lprim(Pmakeblock(0, Immutable, None),
+    Lprim(Pmakeblock(0, Immutable, None, None),
           List.map get_component component_names, Loc_unknown) in
   Lprim(Psetglobal target_name,
         [apply_coercion Loc_unknown Strict coercion components],
@@ -1634,7 +1634,7 @@ let transl_store_package component_names target_name coercion =
          0 component_names)
   | Tcoerce_structure (pos_cc_list, _id_pos_list) ->
       let components =
-        Lprim(Pmakeblock(0, Immutable, None),
+        Lprim(Pmakeblock(0, Immutable, None, None),
               List.map get_component component_names,
               Loc_unknown)
       in
@@ -1646,7 +1646,7 @@ let transl_store_package component_names target_name coercion =
                (fun pos _id ->
                  Lprim(Psetfield(pos, Pointer, Root_initialization),
                        [Lprim(Pgetglobal target_name, [], Loc_unknown);
-                        Lprim(Pfield pos, [Lvar blk], Loc_unknown)],
+                        Lprim(Pfield (pos, None), [Lvar blk], Loc_unknown)],
                        Loc_unknown))
                0 pos_cc_list))
   (*

--- a/lambda/translobj.ml
+++ b/lambda/translobj.ml
@@ -26,7 +26,7 @@ let consts : (structured_constant, Ident.t) Hashtbl.t = Hashtbl.create 17
 
 let share c =
   match c with
-    Const_block (_n, l) when l <> [] ->
+    Const_block (_n, l, _metadata) when l <> [] ->
       begin try
         Lvar (Hashtbl.find consts c)
       with Not_found ->

--- a/lambda/translobj.ml
+++ b/lambda/translobj.ml
@@ -43,12 +43,12 @@ let method_cache = ref lambda_unit
 let method_count = ref 0
 let method_table = ref []
 
-let meth_tag s = Lconst(Const_base(Const_int(Btype.hash_variant s)))
+let meth_tag s = Lconst(Const_base(Const_int(Btype.hash_variant s), None))
 
 let next_cache tag =
   let n = !method_count in
   incr method_count;
-  (tag, [!method_cache; Lconst(Const_base(Const_int n))])
+  (tag, [!method_cache; Lconst(Const_base(Const_int n, None))])
 
 let rec is_path = function
     Lvar _ | Lprim (Pgetglobal _, [], _) | Lconst _ -> true
@@ -81,7 +81,7 @@ let reset_labels () =
 
 (* Insert labels *)
 
-let int n = Lconst (Const_base (Const_int n))
+let int n = Lconst (Const_base (Const_int n, None))
 
 let prim_makearray =
   Primitive.simple ~name:"caml_make_vect" ~arity:2 ~alloc:true

--- a/lambda/translobj.ml
+++ b/lambda/translobj.ml
@@ -125,7 +125,7 @@ let transl_label_init_flambda f =
 let transl_store_label_init glob size f arg =
   assert(not Config.flambda);
   assert(!Clflags.native_code);
-  method_cache := Lprim(Pfield size,
+  method_cache := Lprim(Pfield (size, None),
                         [Lprim(Pgetglobal glob, [], Loc_unknown)],
                         Loc_unknown);
   let expr = f arg in
@@ -178,7 +178,7 @@ let oo_wrap env req f x =
            List.fold_left
              (fun lambda id ->
                 Llet(StrictOpt, Pgenval, id,
-                     Lprim(Pmakeblock(0, Mutable, None),
+                     Lprim(Pmakeblock(0, Mutable, None, None),
                            [lambda_unit; lambda_unit; lambda_unit],
                            Loc_unknown),
                      lambda))

--- a/lambda/translprim.ml
+++ b/lambda/translprim.ml
@@ -614,9 +614,9 @@ let lambda_of_loc kind sloc =
   | Loc_POS ->
     Lconst (Const_block (0, [
           Const_immstring file;
-          Const_base (Const_int lnum);
-          Const_base (Const_int cnum);
-          Const_base (Const_int enum);
+          Const_base (Const_int lnum, None);
+          Const_base (Const_int cnum, None);
+          Const_base (Const_int enum, None);
         ], None))
   | Loc_FILE -> Lconst (Const_immstring file)
   | Loc_MODULE ->
@@ -628,7 +628,7 @@ let lambda_of_loc kind sloc =
     let loc = Printf.sprintf "File %S, line %d, characters %d-%d"
         file lnum cnum enum in
     Lconst (Const_immstring loc)
-  | Loc_LINE -> Lconst (Const_base (Const_int lnum))
+  | Loc_LINE -> Lconst (Const_base (Const_int lnum, None))
   | Loc_FUNCTION ->
     let scope_name = Debuginfo.Scoped_location.string_of_scoped_location sloc in
     Lconst (Const_immstring scope_name)

--- a/lambda/translprim.ml
+++ b/lambda/translprim.ml
@@ -127,11 +127,11 @@ let primitives_table =
     "%loc_POS", Loc Loc_POS;
     "%loc_MODULE", Loc Loc_MODULE;
     "%loc_FUNCTION", Loc Loc_FUNCTION;
-    "%field0", Primitive ((Pfield 0), 1);
-    "%field1", Primitive ((Pfield 1), 1);
+    "%field0", Primitive (Pfield (0, None), 1);
+    "%field1", Primitive (Pfield (1, None), 1);
     "%setfield0", Primitive ((Psetfield(0, Pointer, Assignment)), 2);
-    "%makeblock", Primitive ((Pmakeblock(0, Immutable, None)), 1);
-    "%makemutable", Primitive ((Pmakeblock(0, Mutable, None)), 1);
+    "%makeblock", Primitive ((Pmakeblock(0, Immutable, None, None)), 1);
+    "%makemutable", Primitive ((Pmakeblock(0, Mutable, None, None)), 1);
     "%raise", Raise Raise_regular;
     "%reraise", Raise Raise_reraise;
     "%raise_notrace", Raise Raise_notrace;
@@ -466,10 +466,10 @@ let specialize_primitive env ty ~has_constant_constructor prim =
       | Pbigarray_unknown, Pbigarray_unknown_layout -> None
       | _, _ -> Some (Primitive (Pbigarrayset(unsafe, n, k, l), arity))
     end
-  | Primitive (Pmakeblock(tag, mut, None), arity), fields -> begin
+  | Primitive (Pmakeblock(tag, mut, None, _metadata), arity), fields -> begin
       let shape = List.map (Typeopt.value_kind env) fields in
       let useful = List.exists (fun knd -> knd <> Pgenval) shape in
-      if useful then Some (Primitive (Pmakeblock(tag, mut, Some shape), arity))
+      if useful then Some (Primitive (Pmakeblock(tag, mut, Some shape, None), arity))
       else None
     end
   | Comparison(comp, Compare_generic), p1 :: _ ->
@@ -689,7 +689,7 @@ let lambda_of_prim prim_name prim loc args arg_exps =
       lambda_of_loc kind loc
   | Loc kind, [arg] ->
       let lam = lambda_of_loc kind loc in
-      Lprim(Pmakeblock(0, Immutable, None), [lam; arg], loc)
+      Lprim(Pmakeblock(0, Immutable, None, None), [lam; arg], loc)
   | Send, [obj; meth] ->
       Lsend(Public, meth, obj, [], loc)
   | Send_self, [obj; meth] ->

--- a/lambda/translprim.ml
+++ b/lambda/translprim.ml
@@ -617,7 +617,7 @@ let lambda_of_loc kind sloc =
           Const_base (Const_int lnum);
           Const_base (Const_int cnum);
           Const_base (Const_int enum);
-        ]))
+        ], None))
   | Loc_FILE -> Lconst (Const_immstring file)
   | Loc_MODULE ->
     let filename = Filename.basename file in

--- a/middle_end/closure/closure.ml
+++ b/middle_end/closure/closure.ml
@@ -1152,7 +1152,7 @@ let rec close ({ backend; fenv; cenv ; mutable_vars } as env) lam =
       let (ubody, _) = close env body in
       let (uhandler, _) = close env handler in
       (Utrywith(ubody, VP.create id, uhandler), Value_unknown)
-  | Lifthenelse(arg, ifso, ifnot) ->
+  | Lifthenelse(arg, ifso, ifnot, _meta) ->
       begin match close env arg with
         (uarg, Value_const (Uconst_int n)) ->
           sequence_constant_expr uarg

--- a/middle_end/closure/closure.ml
+++ b/middle_end/closure/closure.ml
@@ -874,7 +874,7 @@ let rec close ({ backend; fenv; cenv ; mutable_vars } as env) lam =
       let rec transl = function
         | Const_base(Const_int n) -> Uconst_int n
         | Const_base(Const_char c) -> Uconst_int (Char.code c)
-        | Const_block (tag, fields) ->
+        | Const_block (tag, fields, _metadata) ->
             str (Uconst_block (tag, List.map transl fields))
         | Const_float_array sl ->
             (* constant float arrays are really immutable *)

--- a/middle_end/closure/closure.ml
+++ b/middle_end/closure/closure.ml
@@ -872,8 +872,8 @@ let rec close ({ backend; fenv; cenv ; mutable_vars } as env) lam =
         Uconst_ref (name, Some cst)
       in
       let rec transl = function
-        | Const_base(Const_int n) -> Uconst_int n
-        | Const_base(Const_char c) -> Uconst_int (Char.code c)
+        | Const_base(Const_int n, _metadata) -> Uconst_int n
+        | Const_base(Const_char c, _metadata) -> Uconst_int (Char.code c)
         | Const_block (tag, fields, _metadata) ->
             str (Uconst_block (tag, List.map transl fields))
         | Const_float_array sl ->
@@ -881,7 +881,7 @@ let rec close ({ backend; fenv; cenv ; mutable_vars } as env) lam =
             str (Uconst_float_array (List.map float_of_string sl))
         | Const_immstring s ->
             str (Uconst_string s)
-        | Const_base (Const_string (s, _, _)) ->
+        | Const_base (Const_string (s, _, _), _metadata) ->
               (* Strings (even literal ones) must be assumed to be mutable...
                  except when OCaml has been configured with
                  -safe-string.  Passing -safe-string at compilation
@@ -889,10 +889,10 @@ let rec close ({ backend; fenv; cenv ; mutable_vars } as env) lam =
                  with another one compiled without -safe-string, and
                  that one could modify our string literal.  *)
             str ~shared:Config.safe_string (Uconst_string s)
-        | Const_base(Const_float x) -> str (Uconst_float (float_of_string x))
-        | Const_base(Const_int32 x) -> str (Uconst_int32 x)
-        | Const_base(Const_int64 x) -> str (Uconst_int64 x)
-        | Const_base(Const_nativeint x) -> str (Uconst_nativeint x)
+        | Const_base(Const_float x, _metadata) -> str (Uconst_float (float_of_string x))
+        | Const_base(Const_int32 x, _metadata) -> str (Uconst_int32 x)
+        | Const_base(Const_int64 x, _metadata) -> str (Uconst_int64 x)
+        | Const_base(Const_nativeint x, _metadata) -> str (Uconst_nativeint x)
       in
       make_const (transl cst)
   | Lfunction _ as funct ->

--- a/middle_end/closure/closure.ml
+++ b/middle_end/closure/closure.ml
@@ -1072,7 +1072,7 @@ let rec close ({ backend; fenv; cenv ; mutable_vars } as env) lam =
       let dbg = Debuginfo.from_location loc in
       check_constant_result (getglobal dbg id)
                             (Compilenv.global_approx id)
-  | Lprim(Pfield n, [lam], loc) ->
+  | Lprim(Pfield (n, _meta), [lam], loc) ->
       let (ulam, approx) = close env lam in
       let dbg = Debuginfo.from_location loc in
       check_constant_result (Uprim(P.Pfield n, [ulam], dbg))

--- a/middle_end/convert_primitives.ml
+++ b/middle_end/convert_primitives.ml
@@ -24,9 +24,9 @@ let convert_unsafety is_unsafe : Clambda_primitives.is_safe =
 
 let convert (prim : Lambda.primitive) : Clambda_primitives.primitive =
   match prim with
-  | Pmakeblock (tag, mutability, shape) ->
+  | Pmakeblock (tag, mutability, shape, _meta) ->
       Pmakeblock (tag, mutability, shape)
-  | Pfield field -> Pfield field
+  | Pfield (field, _meta) -> Pfield field
   | Pfield_computed -> Pfield_computed
   | Psetfield (field, imm_or_pointer, init_or_assign) ->
       Psetfield (field, imm_or_pointer, init_or_assign)

--- a/middle_end/flambda/closure_conversion.ml
+++ b/middle_end/flambda/closure_conversion.ml
@@ -143,7 +143,7 @@ let rec declare_const t (const : Lambda.structured_constant)
     register_const t
       (Allocated_const (Immutable_float_array (List.map float_of_string c)))
       Names.const_float_array
-  | Const_block (tag, consts) ->
+  | Const_block (tag, consts, _metadata) ->
     let const : Flambda.constant_defining_value =
       Block (Tag.create_exn tag,
              List.map (fun c -> fst (declare_const t c)) consts)

--- a/middle_end/flambda/closure_conversion.ml
+++ b/middle_end/flambda/closure_conversion.ml
@@ -112,9 +112,9 @@ let register_const t (constant:Flambda.constant_defining_value) name
 let rec declare_const t (const : Lambda.structured_constant)
     : Flambda.constant_defining_value_block_field * Internal_variable_names.t =
   match const with
-  | Const_base (Const_int c) -> (Const (Int c), Names.const_int)
-  | Const_base (Const_char c) -> (Const (Char c), Names.const_char)
-  | Const_base (Const_string (s, _, _)) ->
+  | Const_base (Const_int c, _metadata) -> (Const (Int c), Names.const_int)
+  | Const_base (Const_char c, _metadata) -> (Const (Char c), Names.const_char)
+  | Const_base (Const_string (s, _, _), _metadata) ->
     let const, name =
       if Config.safe_string then
         (Flambda.Allocated_const (Immutable_string s),
@@ -124,17 +124,17 @@ let rec declare_const t (const : Lambda.structured_constant)
          Names.const_string)
     in
     register_const t const name
-  | Const_base (Const_float c) ->
+  | Const_base (Const_float c, _metadata) ->
     register_const t
       (Allocated_const (Float (float_of_string c)))
       Names.const_float
-  | Const_base (Const_int32 c) ->
+  | Const_base (Const_int32 c, _metadata) ->
     register_const t (Allocated_const (Int32 c))
       Names.const_int32
-  | Const_base (Const_int64 c) ->
+  | Const_base (Const_int64 c, _metadata) ->
     register_const t (Allocated_const (Int64 c))
       Names.const_int64
-  | Const_base (Const_nativeint c) ->
+  | Const_base (Const_nativeint c, _metadata) ->
     register_const t (Allocated_const (Nativeint c)) Names.const_nativeint
   | Const_immstring c ->
     register_const t (Allocated_const (Immutable_string c))
@@ -165,7 +165,7 @@ let lambda_const_bool b : Lambda.structured_constant =
     Lambda.const_int 0
 
 let lambda_const_int i : Lambda.structured_constant =
-  Const_base (Const_int i)
+  Const_base (Const_int i, None)
 
 let rec close t env (lam : Lambda.lambda) : Flambda.t =
   match lam with

--- a/middle_end/flambda/closure_conversion.ml
+++ b/middle_end/flambda/closure_conversion.ml
@@ -515,7 +515,7 @@ let rec close t env (lam : Lambda.lambda) : Flambda.t =
   | Ltrywith (body, id, handler) ->
     let var = Variable.create_with_same_name_as_ident id in
     Try_with (close t env body, var, close t (Env.add_var env id var) handler)
-  | Lifthenelse (cond, ifso, ifnot) ->
+  | Lifthenelse (cond, ifso, ifnot, _meta) ->
     let cond = close t env cond in
     let cond_var = Variable.create Names.cond in
     Flambda.create_let cond_var (Expr cond)

--- a/parsing/ast_helper.ml
+++ b/parsing/ast_helper.ml
@@ -236,6 +236,14 @@ module Exp = struct
       popen_loc = loc;
       popen_attributes = attrs;
     }
+
+  let open_declaration ?(loc = !default_loc) ?(override_flag=Fresh) ?(attrs=[]) expr =
+    {
+      popen_expr = expr;
+      popen_override = override_flag;
+      popen_loc = loc;
+      popen_attributes = attrs;
+    }
 end
 
 module Mty = struct

--- a/parsing/ast_helper.ml
+++ b/parsing/ast_helper.ml
@@ -229,12 +229,12 @@ module Exp = struct
       pbop_loc = loc;
     }
 
-  let open_description expr override loc attributes=
+  let open_description ?(loc = !default_loc) ?(override_flag=Fresh) ?(attrs=[]) expr =
     {
       popen_expr = expr;
-      popen_override = override;
+      popen_override = override_flag;
       popen_loc = loc;
-      popen_attributes = attributes;
+      popen_attributes = attrs;
     }
 end
 

--- a/parsing/ast_helper.ml
+++ b/parsing/ast_helper.ml
@@ -228,6 +228,14 @@ module Exp = struct
       pbop_exp = exp;
       pbop_loc = loc;
     }
+
+  let open_description expr override loc attributes=
+    {
+      popen_expr = expr;
+      popen_override = override;
+      popen_loc = loc;
+      popen_attributes = attributes;
+    }
 end
 
 module Mty = struct

--- a/parsing/ast_helper.ml
+++ b/parsing/ast_helper.ml
@@ -257,6 +257,15 @@ let mk ?(loc = !default_loc) ?(attrs = []) d =
   let constraint_ ?loc ?attrs m mty = mk ?loc ?attrs (Pmod_constraint (m, mty))
   let unpack ?loc ?attrs e = mk ?loc ?attrs (Pmod_unpack e)
   let extension ?loc ?attrs a = mk ?loc ?attrs (Pmod_extension a)
+
+
+  let mod_desc_ident loc = Pmod_ident loc
+  let mod_desc_structure s = Pmod_structure s
+  let mod_desc_functor fp mexp = Pmod_functor (fp, mexp)
+  let mod_desc_apply mexp1 mexp2 = Pmod_apply (mexp1, mexp2)
+  let mod_desc_constraint mexp mtyp  = Pmod_constraint (mexp, mtyp)
+  let mod_desc_unpack exp = Pmod_unpack exp
+  let mod_desc_extension exp = Pmod_extension exp
 end
 
 module Sig = struct

--- a/parsing/ast_helper.ml
+++ b/parsing/ast_helper.ml
@@ -548,6 +548,9 @@ module Type = struct
      pld_attributes = add_info_attrs info attrs;
     }
 
+  let tuple_constructor_argument cts = Pcstr_tuple cts
+
+  let record_constructor_argument lds = Pcstr_record lds
 end
 
 (** Type extensions *)

--- a/parsing/ast_helper.mli
+++ b/parsing/ast_helper.mli
@@ -193,8 +193,9 @@ module Exp:
     val case: pattern -> ?guard:expression -> expression -> case
     val binding_op: str -> pattern -> expression -> loc -> binding_op
 
-    val open_description : Longident.t Asttypes.loc -> override_flag -> Location.t ->
-      attributes -> open_description
+    val open_description : ?loc:loc -> ?override_flag:override_flag
+                           -> ?attrs:attrs -> Longident.t Asttypes.loc
+                           -> open_description
 
   end
 

--- a/parsing/ast_helper.mli
+++ b/parsing/ast_helper.mli
@@ -215,6 +215,11 @@ module Type:
       constructor_declaration
     val field: ?loc:loc -> ?attrs:attrs -> ?info:info ->
       ?mut:mutable_flag -> str -> core_type -> label_declaration
+
+
+    val tuple_constructor_argument : core_type list -> constructor_arguments
+
+    val record_constructor_argument : label_declaration list -> constructor_arguments
   end
 
 (** Type extensions *)

--- a/parsing/ast_helper.mli
+++ b/parsing/ast_helper.mli
@@ -277,6 +277,14 @@ module Mod:
       module_expr
     val unpack: ?loc:loc -> ?attrs:attrs -> expression -> module_expr
     val extension: ?loc:loc -> ?attrs:attrs -> extension -> module_expr
+
+    val mod_desc_ident : Longident.t Asttypes.loc -> module_expr_desc
+    val mod_desc_structure : structure -> module_expr_desc
+    val mod_desc_functor : functor_parameter -> module_expr -> module_expr_desc
+    val mod_desc_apply : module_expr -> module_expr -> module_expr_desc
+    val mod_desc_constraint : module_expr -> module_type -> module_expr_desc
+    val mod_desc_unpack : expression -> module_expr_desc
+    val mod_desc_extension : extension -> module_expr_desc
   end
 
 (** Signature items *)

--- a/parsing/ast_helper.mli
+++ b/parsing/ast_helper.mli
@@ -192,6 +192,10 @@ module Exp:
 
     val case: pattern -> ?guard:expression -> expression -> case
     val binding_op: str -> pattern -> expression -> loc -> binding_op
+
+    val open_description : Longident.t Asttypes.loc -> override_flag -> Location.t ->
+      attributes -> open_description
+
   end
 
 (** Value declarations *)

--- a/parsing/ast_helper.mli
+++ b/parsing/ast_helper.mli
@@ -197,6 +197,10 @@ module Exp:
                            -> ?attrs:attrs -> Longident.t Asttypes.loc
                            -> open_description
 
+    val open_declaration : ?loc:loc -> ?override_flag:override_flag
+                           -> ?attrs:attrs -> module_expr
+                           -> open_declaration
+
   end
 
 (** Value declarations *)

--- a/tools/dumpobj.ml
+++ b/tools/dumpobj.ml
@@ -92,7 +92,7 @@ let rec print_struct_const = function
   | Const_base(Const_int32 i) -> printf "%ldl" i
   | Const_base(Const_nativeint i) -> printf "%ndn" i
   | Const_base(Const_int64 i) -> printf "%LdL" i
-  | Const_block(tag, args) ->
+  | Const_block(tag, args, _metadata) ->
       printf "<%d>" tag;
       begin match args with
         [] -> ()

--- a/tools/dumpobj.ml
+++ b/tools/dumpobj.ml
@@ -84,14 +84,14 @@ let print_float f =
 ;;
 
 let rec print_struct_const = function
-    Const_base(Const_int i) -> printf "%d" i
-  | Const_base(Const_float f) -> print_float f
-  | Const_base(Const_string (s, _, _)) -> printf "%S" s
+    Const_base(Const_int i, _metadata) -> printf "%d" i
+  | Const_base(Const_float f, _metadata) -> print_float f
+  | Const_base(Const_string (s, _, _), _metadata) -> printf "%S" s
   | Const_immstring s -> printf "%S" s
-  | Const_base(Const_char c) -> printf "%C" c
-  | Const_base(Const_int32 i) -> printf "%ldl" i
-  | Const_base(Const_nativeint i) -> printf "%ndn" i
-  | Const_base(Const_int64 i) -> printf "%LdL" i
+  | Const_base(Const_char c, _metadata) -> printf "%C" c
+  | Const_base(Const_int32 i, _metadata) -> printf "%ldl" i
+  | Const_base(Const_nativeint i, _metadata) -> printf "%ndn" i
+  | Const_base(Const_int64 i, _metadata) -> printf "%LdL" i
   | Const_block(tag, args, _metadata) ->
       printf "<%d>" tag;
       begin match args with

--- a/toplevel/native/topeval.ml
+++ b/toplevel/native/topeval.ml
@@ -76,7 +76,7 @@ let close_phrase lam =
   Ident.Set.fold (fun id l ->
     let glb, pos = toplevel_value id in
     let glob =
-      Lprim (Pfield pos,
+      Lprim (Pfield (pos, None),
              [Lprim (Pgetglobal glb, [], Loc_unknown)],
              Loc_unknown)
     in


### PR DESCRIPTION
Hello folks! 👋🏽  

Hope this PR finds you well, I'm just here to ask a few questions since the code is not yet in a state where I'd ask for a proper review, but I still wanted to have some code to frame a portion of the discussion around a specific implementation approach.

By the end of last year, I started rewriting the Caramel compiler (an OCaml to Erlang copmiler) to target the Core Erlang language. This is essentially the Erlang VM's equivalent to OCaml Lambda.

In my effort to do this, I realized that it would be terribly simpler to just translate from OCaml Lambda rather than the Typedtree, but also that the Lambda language was missing several pieces of information that would be needed for me to build something that made any sense for the Erlang VM. 

For example, variant constructors being replaced with integers doesn't help a lot in creating idiomatic Core Erlang, but passing around constructor metadata allows me to turn those integers into Erlang atoms instead. You could argue that the Erlang VM will turn those atoms into integers _anyways_, but the quality of life improvement of a pattern-match error on an `'None'` is considerably better than just seeing a `0`.

So I made some changes throughout the compiler to thread in metadata for the use-cases I needed and would like to request some comments from you on a few things.

1. Is this something that I could work on to upstream that would be welcomed into the compiler? -- there are several languages being built by forking off OCaml, that are struggling to keep up with the progress happening here. That effort could be spent in the main compiler instead. 4 examples right now are Melange, ReScript, Caramel, and Grain (although this one is primarily interested in the type-checker).

2. What would be an approach for adding metadata that would have the least impact on backends that do not need it? -- I opted for a naive extension of the lambda constructors with optional values, but perhaps this would lead to a lot of duplication when we are using the metadata. Perhaps it is okay to have a configurable flag to bypass adding the metadata everywhere, so it'll just be carrying around an additional None value.

3. Would it be interesting to extend the bytecode compiler to make use of this metadata somehow? -- For example, I can imagine Js_of_ocaml being able to use some of this data to provide more expressive errors.

4. Would it make sense to start with a small subset of the metadata and grow this on a need-basis or would you rather spend some time collecting all the metadata available first? -- the proposed subset is enough for my current needs for Caramel, but I can imagine extending it to support use-cases in Melange and ReScript, potentially helping those drop their forks entirely.

If the answers are that Yes, this is worth spending time on, and Yes, this is worth upstreaming, then I'd be thrilled to write a proper RFC and start porting this to trunk.

In any case, thanks for making an awesome language ❤️  and let me know what you think!

🙌🏽 

/ Leandro
