### PR TITLE
Remove an unused variable in alloc_async_stubs.c

### DIFF
--- a/testsuite/tests/c-api/alloc_async_stubs.c
+++ b/testsuite/tests/c-api/alloc_async_stubs.c
@@ -8,7 +8,7 @@ value stub(value ref)
 {
   CAMLparam1(ref);
   CAMLlocal2(x, y);
-  int i; char* s; intnat coll_before;
+  char* s; intnat coll_before;
 
   printf("C, before: %d\n", Int_val(Field(ref, 0)));
 


### PR DESCRIPTION
This fixes a test failure with the 4.13.1 release on an x86_64 Fedora Rawhide box, using the Fedora build flags:
```
Running tests from 'tests/c-api' ...
 ... testing 'alloc_async.ml' with 1 (native) => failed (The file /builddir/build/BUILD/ocaml-4.13.1/testsuite/_ocamltest/tests/c-api/alloc_async/ocamlopt.byte/ocamlopt.byte.output was expected to be empty because there is no reference file /builddir/build/BUILD/ocaml-4.13.1/testsuite/tests/c-api/alloc_async.compilers.reference but it is not:
========================================
alloc_async_stubs.c: In function 'stub':
alloc_async_stubs.c:11:7: warning: unused variable 'i' [-Wunused-variable]
   11 |   int i; char* s; intnat coll_before;
      |       ^
========================================

)
 ... testing 'alloc_async.ml' with 2 (bytecode) => failed (The file /builddir/build/BUILD/ocaml-4.13.1/testsuite/_ocamltest/tests/c-api/alloc_async/ocamlc.byte/ocamlc.byte.output was expected to be empty because there is no reference file /builddir/build/BUILD/ocaml-4.13.1/testsuite/tests/c-api/alloc_async.compilers.reference but it is not:
========================================
alloc_async_stubs.c: In function 'stub':
alloc_async_stubs.c:11:7: warning: unused variable 'i' [-Wunused-variable]
   11 |   int i; char* s; intnat coll_before;
      |       ^
========================================

)
```