### PR TITLE
Fix typo in Unix.readlink stub

### DIFF
--- a/Changes
+++ b/Changes
@@ -158,6 +158,11 @@ Working version
 - #11025, #11036: Do not pass -no-pie to the C compiler on musl/arm64
   (omni, Kate Deplaix and Antonio Nuno Monteiro, review by Xavier Leroy)
 
+- #11068, #11070: Fix typo in function name given in Unix_error exception for
+  Unix.readlink on Windows.
+  (David Allsopp, report by Xia Li-yao)
+
+
 OCaml 4.14.0
 ----------------
 

--- a/otherlibs/win32unix/readlink.c
+++ b/otherlibs/win32unix/readlink.c
@@ -91,7 +91,7 @@ CAMLprim value unix_readlink(value opath)
         else {
           errno = EINVAL;
           CloseHandle(h);
-          uerror("readline", opath);
+          uerror("readlink", opath);
         }
       }
       else {


### PR DESCRIPTION
Correcting at least one of the errors of one's youth.