### PR TITLE
Fix dumpobj crash due to naked pointer comparison

### DIFF
--- a/Changes
+++ b/Changes
@@ -167,6 +167,9 @@ Working version
   (David Allsopp, report by Xia Li-yao)
 
 
+- #11077: Make dumpobj compatible with absence of naked pointer support
+  (Olivier Nicole and Jan Midtgaard, review by Gabriel Scherer)
+
 OCaml 4.14.0
 ----------------
 

--- a/testsuite/tests/tool-dumpobj/test.ml
+++ b/testsuite/tests/tool-dumpobj/test.ml
@@ -1,0 +1,8 @@
+(* TEST
+  * setup-ocamlc.byte-build-env
+  ** ocamlc.byte
+    compile_only = "false"
+    all_modules = "test.ml"
+  *** run
+*)
+let x = 42

--- a/testsuite/tests/tool-dumpobj/test.run
+++ b/testsuite/tests/tool-dumpobj/test.run
@@ -1,0 +1,5 @@
+if ${ocamlsrcdir}/tools/dumpobj.opt ${program} > ${output}; then
+  exit ${TEST_SUCC}
+else
+  exit ${TEST_FAIL}
+fi

--- a/tools/dumpobj.ml
+++ b/tools/dumpobj.ml
@@ -110,7 +110,7 @@ let rec print_struct_const = function
 (* Print an obj *)
 
 let same_custom x y =
-  Obj.field x 0 = Obj.field (Obj.repr y) 0
+  Nativeint.equal (Obj.raw_field x 0) (Obj.raw_field (Obj.repr y) 0)
 
 let rec print_obj x =
   if Obj.is_block x then begin


### PR DESCRIPTION
This fixes #11061. `dumpobj` crashes because it calls `(=)` on the first field of two `int64` values, which are pointers to a C `custom_ops` struct (since `int64` values are implemented as custom blocks). This worked when the generic comparison function supported naked pointers, but that is no longer the case since the Multicore merge.
This was found with some help from @jmid, thanks to him!

Replacing `(=)` with `(==)` avoids the crash without changing the result.

I also added a test for `dumpobj` to detect its breakage in the future.