### PR TITLE
Relax caml_initialize assertion in the debug runtime

### DIFF
--- a/runtime/memory.c
+++ b/runtime/memory.c
@@ -211,7 +211,7 @@ CAMLexport CAMLweakdef void caml_initialize (value *fp, value val)
   /* Previous value should not be a pointer.
      In the debug runtime, it can be either a TMC placeholder,
      or an unitialized value canary (Debug_uninit_{major,minor}). */
-  CAMLassert(Is_long(*fp) || *fp == Val_unit);
+  CAMLassert(Is_long(*fp));
 #endif
   *fp = val;
   if (!Is_young((value)fp) && Is_block_and_young (val))

--- a/runtime/memory.c
+++ b/runtime/memory.c
@@ -208,10 +208,10 @@ CAMLexport void caml_adjust_gc_speed (mlsize_t res, mlsize_t max)
 CAMLexport CAMLweakdef void caml_initialize (value *fp, value val)
 {
 #ifdef DEBUG
-  if (Is_young((value)fp))
-    CAMLassert(*fp == Debug_uninit_minor || *fp == Val_unit);
-  else
-    CAMLassert(*fp == Debug_uninit_major || *fp == Val_unit);
+  /* Previous value should not be a pointer.
+     In the debug runtime, it can be either a TMC placeholder,
+     or an unitialized value canary (Debug_uninit_{major,minor}). */
+  CAMLassert(Is_long(*fp) || *fp == Val_unit);
 #endif
   *fp = val;
   if (!Is_young((value)fp) && Is_block_and_young (val))


### PR DESCRIPTION
This PR is a follow up to #11055 and #11016

As suggested by @xavierleroy, here we relax the assertion in `caml_initialize` to check if the previous value of a supposedly uninitiated value is a pointer or an integer. (by checking the lower bit).
This effectively relaxes slightly the assertion, because it make the possible values to be more than `Caml_uninit_{major,minor}` or the TMC placeholder, but still assert that we do not have any pointer the GC might follow.

This sounds like a reasonable tradeoff to me and keep the check fast enough to not impede the debug runtime throughput.

I think it is sane and should allow us to catch the same kind of bugs we used to catch with this assertion.

Careful ponder upon this change would be welcome. (@ctk21 @xavierleroy @gasche)
