### PR TITLE
Add a -nobanners option to dumpobj, enhance associated test

### DIFF
--- a/Changes
+++ b/Changes
@@ -125,6 +125,9 @@ Working version
   documentation.
   (Jules Aguillon, review by Florian Angeletti)
 
+- #11079: Add the -nobanners option to dumpobj.
+  (Sébastien Hinderer, review by Gabriel Scherer and Vincent Laviron)
+
 ### Manual and documentation:
 
 ### Compiler user-interface and warnings:

--- a/testsuite/tests/tool-dumpobj/test.ml
+++ b/testsuite/tests/tool-dumpobj/test.ml
@@ -1,8 +1,10 @@
 (* TEST
-  * setup-ocamlc.byte-build-env
-  ** ocamlc.byte
-    compile_only = "false"
-    all_modules = "test.ml"
-  *** run
+
+flags = "-nopervasives"
+
+* setup-ocamlc.byte-build-env
+** ocamlc.byte
+*** run
+**** check-program-output
 *)
-let x = 42
+let x = 42L

--- a/testsuite/tests/tool-dumpobj/test.reference
+++ b/testsuite/tests/tool-dumpobj/test.reference
@@ -1,0 +1,6 @@
+       0  GETGLOBAL 42L
+       2  PUSHACC0
+       3  MAKEBLOCK1 0
+       5  POP 1
+       7  SETGLOBAL Test
+       9  STOP

--- a/testsuite/tests/tool-dumpobj/test.run
+++ b/testsuite/tests/tool-dumpobj/test.run
@@ -1,5 +1,1 @@
-if ${ocamlsrcdir}/tools/dumpobj.opt ${program} > ${output}; then
-  exit ${TEST_SUCC}
-else
-  exit ${TEST_FAIL}
-fi
+${ocamlrun} ${ocamlsrcdir}/tools/dumpobj -nobanners ${program} > ${output}

--- a/tools/dumpobj.ml
+++ b/tools/dumpobj.ml
@@ -25,6 +25,7 @@ open Opnames
 open Cmo_format
 open Printf
 
+let print_banners = ref true
 let print_locations = ref true
 let print_reloc_info = ref false
 
@@ -547,6 +548,7 @@ let dump_exe ic =
   print_code ic code_size
 
 let arg_list = [
+  "-nobanners", Arg.Clear print_banners, " : don't print banners";
   "-noloc", Arg.Clear print_locations, " : don't print source information";
   "-reloc", Arg.Set print_reloc_info, " : print relocation information";
   "-args", Arg.Expand Arg.read_arg,
@@ -566,14 +568,14 @@ let arg_fun filename =
   let ic = open_in_bin filename in
   if not !first_file then print_newline ();
   first_file := false;
-  printf "## start of ocaml dump of %S\n%!" filename;
+  if !print_banners then printf "## start of ocaml dump of %S\n%!" filename;
   begin try
           objfile := false; dump_exe ic
     with Bytesections.Bad_magic_number ->
       objfile := true; seek_in ic 0; dump_obj ic
   end;
   close_in ic;
-  printf "## end of ocaml dump of %S\n%!" filename
+  if !print_banners then printf "## end of ocaml dump of %S\n%!" filename
 
 let main() =
   Arg.parse_expand arg_list arg_fun arg_usage;

--- a/tools/dumpobj.ml
+++ b/tools/dumpobj.ml
@@ -423,7 +423,7 @@ let print_instr ic =
   else print_string names_of_instructions.(op);
   begin try
     let shape = List.assoc op op_shapes in
-    if shape <> Nothing then print_string " ";
+    if shape <> Nothing && shape <> Switch then print_string " ";
     match shape with
     | Uint -> print_int (inputu ic)
     | Sint -> print_int (inputs ic)


### PR DESCRIPTION
This is a follow-up to #11077.

The `-nobanners` option avoids dumpobj surrounding the dumped
code with banners.

Asecond commit removes a spurious space in dumpobj's output.

Finally, the test introduced in #11077 in both enhanced and simplified.