### PR TITLE
Add a #reload directive

### DIFF
--- a/manual/src/cmds/top.etex
+++ b/manual/src/cmds/top.etex
@@ -206,6 +206,10 @@ will result in an ``unbound value "quit"'' error.
     Similar to "#use" but also wrap the code into a top-level module of the
     same name as capitalized file name without extensions, following
     semantics of the compiler.
+
+  \item["#reload;;"]
+    Reruns the most recent invocation of "#use"/"#load"-style directives,
+    without manually re-entering the file name.
   \end{options}
 
 For directives that take file names as arguments, if the given file

--- a/toplevel/toploop.ml
+++ b/toplevel/toploop.ml
@@ -22,7 +22,17 @@ type input =
   | File of string
   | String of string
 
+type loaded = Empty | Load : ('a -> bool) * 'a -> loaded
+
 let use_print_results = ref true
+let last_loaded = ref Empty
+
+let remember f args = last_loaded := Load(f, args); f args
+
+let reload () =
+  match !last_loaded with
+  | Empty -> true
+  | Load (f, args) -> f args
 
 let filename_of_input = function
   | File name -> name

--- a/toplevel/toploop.mli
+++ b/toplevel/toploop.mli
@@ -96,10 +96,15 @@ val use_output : formatter -> string -> bool
 val use_silently : formatter -> input -> bool
 val mod_use_input : formatter -> input -> bool
 val use_file : formatter -> string -> bool
+val reload : unit -> bool
+val remember : ('a -> bool) -> 'a -> bool
         (* Read and execute commands from a file.
            [use_input] prints the types and values of the results.
            [use_silently] does not print them.
-           [mod_use_input] wrap the file contents into a module. *)
+           [mod_use_input] wrap the file contents into a module.
+           [reload] rerun one of the above on the last loaded file this session.
+           [remember] saves a successful invocation in the module state.
+        *)
 val eval_module_path: Env.t -> Path.t -> Obj.t
 val eval_value_path: Env.t -> Path.t -> Obj.t
 val eval_extension_path: Env.t -> Path.t -> Obj.t


### PR DESCRIPTION
Hello! This is my first PR, sort of a scratch-your-own-itch thing. Please be gentle :')
I'm used to interactive repl sessions that go like this:
```
load file
edit
reload
edit
reload
...
```
I could do the `edit` part by opening a toplevel next to an editor, but the reload part was dearly missed. So I implemented it.
This patch adds a `#reload`  directive, allowing workflows such as the above to be more streamlined.

example usage:
repl pane:
```ocaml
# #use "somefile.ml";;
# (* do some tests with the module *)
```
editor pane: `[editing the file iteratively...]`
repl pane:
```ocaml
# #reload;;
# (* do more tests with the new modifications *)
```

rationale:
Making the toplevel itself support exploratory programming with as little friction as possible (without exploding complexity) should greatly improve the language's learnability regardless of the custom repl implementation built around it. Although I'd love to have invaluable things like down's ability to bring up docs inline with a keybinding, and utop's realtime completions, small things like this can also make quality of life much better consistently across the board.

NOTES:
- `#reload` targets `#use`, `#mod_use`, `#load`, and `#load_rec`.
- invoking `#reload` reinterprets/recompiles the files. file state is not preserved.
- `Toploop` already contains internal state (e.g. `use_print_results`). It felt right to put the reloading state there.
- exposing `remember f x` and `reload ()` in the `Toploop` API can further facilitate a future `#edit` mechanism.
- a manual entry is added