### PR TITLE
Disable lib-dynlink-private testcase under the debug runtime

### DIFF
--- a/ocamltest/ocaml_actions.ml
+++ b/ocamltest/ocaml_actions.ml
@@ -1168,6 +1168,17 @@ let instrumented_runtime = make
     "instrumented runtime available"
     "instrumented runtime not available")
 
+let not_debug_runtime = Actions.make
+  "not-debug-runtime" @@ fun log env ->
+  let is_debug =
+    match Ocaml_files.runtime_variant () with
+    | Ocaml_files.Debug -> true
+    | _ -> false
+  in
+  Actions_helpers.pass_or_skip (not is_debug)
+    "Debug runtime is not being used"
+    "Debug runtime is being used" log env
+
 let csharp_compiler = Actions.make
   "csharp-compiler"
   (Actions_helpers.pass_or_skip (Ocamltest_config.csc<>"")
@@ -1383,6 +1394,7 @@ let _ =
     native_dynlink;
     debugger;
     instrumented_runtime;
+    not_debug_runtime;
     csharp_compiler;
     windows_unicode;
     afl_instrument;

--- a/testsuite/tests/lib-dynlink-private/test.ml
+++ b/testsuite/tests/lib-dynlink-private/test.ml
@@ -5,166 +5,166 @@ libraries = ""
 readonly_files = "sheep.mli sheep.ml pig.mli"
 subdirectories = "plugin1 plugin2 plugin2b plugin2c plugin3 plugin4 \
   plugin5 plugin6"
-
 * shared-libraries
-** setup-ocamlc.byte-build-env
-*** ocamlc.byte
-module = "sheep.mli"
+** not-debug-runtime
+*** setup-ocamlc.byte-build-env
 **** ocamlc.byte
-module = "sheep.ml"
+module = "sheep.mli"
 ***** ocamlc.byte
-module = "pig.mli"
+module = "sheep.ml"
 ****** ocamlc.byte
-module = "test.ml"
+module = "pig.mli"
 ******* ocamlc.byte
-module = "plugin1/sheep.mli"
+module = "test.ml"
 ******** ocamlc.byte
+module = "plugin1/sheep.mli"
+********* ocamlc.byte
 flags = "-I plugin1"
 module = "plugin1/sheep.ml"
-********* ocamlc.byte
+********** ocamlc.byte
 flags = ""
 module = "plugin2/cow.mli"
-********** ocamlc.byte
+*********** ocamlc.byte
 flags = "-I plugin2"
 module = "plugin2/cow.ml"
-*********** ocamlc.byte
+************ ocamlc.byte
 flags = ""
 module = "plugin2b/cow.mli"
-************ ocamlc.byte
+************* ocamlc.byte
 flags = "-I plugin2b"
 module = "plugin2b/cow.ml"
-************* ocamlc.byte
+************** ocamlc.byte
 flags = ""
 module = "plugin2c/cow.mli"
-************** ocamlc.byte
+*************** ocamlc.byte
 flags = "-I plugin2c"
 module = "plugin2c/cow.ml"
-*************** ocamlc.byte
+**************** ocamlc.byte
 flags = ""
 module = "plugin3/pig.mli"
-**************** ocamlc.byte
+***************** ocamlc.byte
 flags = "-I plugin3"
 module = "plugin3/pig.ml"
-***************** ocamlc.byte
+****************** ocamlc.byte
 flags = ""
 module = "plugin4/chicken.mli"
-****************** ocamlc.byte
+******************* ocamlc.byte
 flags = "-I plugin4"
 module = "plugin4/chicken.ml"
-******************* ocamlc.byte
+******************** ocamlc.byte
 flags = ""
 module = "plugin5/chicken.mli"
-******************** ocamlc.byte
+********************* ocamlc.byte
 flags = "-I plugin5"
 module = "plugin5/chicken.ml"
-********************* ocamlc.byte
+********************** ocamlc.byte
 flags = ""
 module = "plugin6/pheasant.mli"
-********************** ocamlc.byte
+*********************** ocamlc.byte
 flags = "-I plugin6"
 module = "plugin6/pheasant.ml"
-*********************** ocamlc.byte
+************************ ocamlc.byte
 flags = ""
 module = "plugin6/partridge.mli"
-************************ ocamlc.byte
+************************* ocamlc.byte
 flags = "-I plugin6"
 module = "plugin6/partridge.ml"
-************************* ocamlc.byte
+************************** ocamlc.byte
 flags = ""
 program = "./test.byte.exe"
 libraries = "dynlink"
 all_modules = "sheep.cmo test.cmo"
 module = ""
-************************** run
+*************************** run
 
-** native-dynlink
-*** setup-ocamlopt.byte-build-env
-**** ocamlopt.byte
-module = "sheep.mli"
+*** native-dynlink
+**** setup-ocamlopt.byte-build-env
 ***** ocamlopt.byte
-module = "sheep.ml"
+module = "sheep.mli"
 ****** ocamlopt.byte
-module = "pig.mli"
+module = "sheep.ml"
 ******* ocamlopt.byte
-module = "test.ml"
+module = "pig.mli"
 ******** ocamlopt.byte
+module = "test.ml"
+********* ocamlopt.byte
 flags = ""
 module = "plugin1/sheep.mli"
-********* ocamlopt.byte
+********** ocamlopt.byte
 program = "plugin1/sheep.cmxs"
 flags = "-I plugin1 -shared"
 module = ""
 all_modules = "plugin1/sheep.ml"
-********** ocamlopt.byte
+*********** ocamlopt.byte
 flags = ""
 module = "plugin2/cow.mli"
-*********** ocamlopt.byte
+************ ocamlopt.byte
 program = "plugin2/cow.cmxs"
 flags = "-I plugin2 -shared"
 module = ""
 all_modules = "plugin2/cow.ml"
-************ ocamlopt.byte
+************* ocamlopt.byte
 flags = ""
 module = "plugin2b/cow.mli"
-************* ocamlopt.byte
+************** ocamlopt.byte
 program = "plugin2b/cow.cmxs"
 flags = "-I plugin2b -shared"
 module = ""
 all_modules = "plugin2b/cow.ml"
-************** ocamlopt.byte
+*************** ocamlopt.byte
 flags = ""
 module = "plugin2c/cow.mli"
-*************** ocamlopt.byte
+**************** ocamlopt.byte
 program = "plugin2c/cow.cmxs"
 flags = "-I plugin2c -shared"
 module = ""
 all_modules = "plugin2c/cow.ml"
-**************** ocamlopt.byte
+***************** ocamlopt.byte
 flags = ""
 module = "plugin3/pig.mli"
-***************** ocamlopt.byte
+****************** ocamlopt.byte
 program = "plugin3/pig.cmxs"
 flags = "-I plugin3 -shared"
 module = ""
 all_modules = "plugin3/pig.ml"
-****************** ocamlopt.byte
+******************* ocamlopt.byte
 flags = ""
 module = "plugin4/chicken.mli"
-******************* ocamlopt.byte
+******************** ocamlopt.byte
 program = "plugin4/chicken.cmxs"
 flags = "-I plugin4 -shared"
 module = ""
 all_modules = "plugin4/chicken.ml"
-******************** ocamlopt.byte
+********************* ocamlopt.byte
 flags = ""
 module = "plugin5/chicken.mli"
-********************* ocamlopt.byte
+********************** ocamlopt.byte
 program = "plugin5/chicken.cmxs"
 flags = "-I plugin5 -shared"
 module = ""
 all_modules = "plugin5/chicken.ml"
-********************** ocamlopt.byte
+*********************** ocamlopt.byte
 flags = ""
 module = "plugin6/pheasant.mli"
-*********************** ocamlopt.byte
+************************ ocamlopt.byte
 program = "plugin6/pheasant.cmxs"
 flags = "-I plugin6 -shared"
 module = ""
 all_modules = "plugin6/pheasant.ml"
-************************ ocamlopt.byte
+************************* ocamlopt.byte
 flags = ""
 module = "plugin6/partridge.mli"
-************************* ocamlopt.byte
+************************** ocamlopt.byte
 program = "plugin6/partridge.cmxs"
 flags = "-I plugin6 -shared"
 module = ""
 all_modules = "plugin6/partridge.ml"
-************************** ocamlopt.byte
+*************************** ocamlopt.byte
 flags = ""
 program = "./test.opt.exe"
 libraries = "dynlink"
 all_modules = "sheep.cmx test.cmx"
-*************************** run
+**************************** run
 *)
 
 let () = Sheep.baa Sheep.s (* Use Sheep module *)
@@ -184,6 +184,10 @@ let test_sheep () =
       Dynlink.Module_already_loaded "Sheep") -> ()
 
 (* Test repeated loading of a privately-loaded module. *)
+(* This section is the reason why this testcase is disabled
+   when run with the debug runtime, because reloading multiple
+   times a module can cause an already initialized block to be
+   overwritten. See https://github.com/ocaml/ocaml/issues/11016 *)
 let test_cow_repeated () =
   if Dynlink.is_native then
     Dynlink.loadfile_private "plugin2/cow.cmxs"


### PR DESCRIPTION
As discussed earlier this week, this commit disables the `lib-dynlink-private` testcase under the debug runtime until #11016 advances toward a solution to this problem.

To recap #11016, this testcase fails the assertion at `caml_initialize`, because `test_cow_repeated` will re-load a module a second time, causing a call to `caml_initialize` to be issued against a value already initialized during the first load of this module.

While this seems to be a problematic behavior, it was suggested that for the time being we may disable the test with the debug runtime, until time is spent on understanding the deeper implications of the issue.

This commit introduces a new `ocamltest` action to check if we are running with the debug runtime or not (using the `USE_RUNTIME` environment variable.), and we check upfront in the testcase if it is the case.

(paging @shindere and @Octachron as I am about to introduce more things to `ocamltest`. :-))
