### PR TITLE
documentation: fixes and improved signal/noise ratio

### DIFF
--- a/api_docgen/ocamldoc/Makefile
+++ b/api_docgen/ocamldoc/Makefile
@@ -44,20 +44,20 @@ $(libref:%=build/libref/%.odoc): build/libref/%.odoc: %.mli | build/libref
 	$(OCAMLDOC_RUN) -nostdlib -hide Stdlib -lib Stdlib \
 	-pp \
 "$(AWK) -v ocamldoc=true -f ../../stdlib/expand_module_aliases.awk" \
-	$(DOC_STDLIB_INCLUDES) $< -dump  $@
+	$(DOC_STDLIB_INCLUDES) -hide-warnings  $< -dump  $@
 
 $(compilerlibref:%=build/compilerlibref/%.odoc):\
 build/compilerlibref/%.odoc: %.mli | build/compilerlibref
 	$(OCAMLDOC_RUN) -nostdlib -hide Stdlib \
-	$(DOC_ALL_INCLUDES) $< -dump  $@
+	$(DOC_ALL_INCLUDES) -hide-warnings $< -dump  $@
 
 $(compilerlibref_TEXT:%=build/compilerlibref/%.odoc):\
 build/compilerlibref/%.odoc: build/%.mld | build/compilerlibref
-	$(OCAMLDOC_RUN) $(DOC_ALL_INCLUDES) -text $< -dump  $@
+	$(OCAMLDOC_RUN)  -hide-warnings $(DOC_ALL_INCLUDES) -text $< -dump  $@
 
 $(libref_TEXT:%=build/libref/%.odoc):\
 build/libref/%.odoc: build/%.mld | build/libref
-	$(OCAMLDOC_RUN) $(DOC_STDLIB_INCLUDES) -text $< -dump  $@
+	$(OCAMLDOC_RUN) -hide-warnings $(DOC_STDLIB_INCLUDES) -text $< -dump  $@
 
 ALL_COMPILED_DOC=$(ALL_DOC:%=build/%.odoc)
 build/man/Stdlib.3o: $(ALL_COMPILED_DOC) | build/man

--- a/stdlib/hashtbl.mli
+++ b/stdlib/hashtbl.mli
@@ -401,7 +401,7 @@ module type SeededHashedType =
           the seed.  It must be the case that if [equal x y] is true,
           then [hash seed x = hash seed y] for any value of [seed].
           A suitable choice for [hash] is the function
-          {!Stdlib.Hashtbl.seeded_hash} below. *)
+          {!Hashtbl.seeded_hash} below. *)
   end
 (** The input signature of the functor {!MakeSeeded}.
     @since 4.00.0 *)

--- a/stdlib/map.mli
+++ b/stdlib/map.mli
@@ -220,7 +220,7 @@ module type S =
     (** Return the list of all bindings of the given map.
        The returned list is sorted in increasing order of keys with respect
        to the ordering [Ord.compare], where [Ord] is the argument
-       given to {!Stdlib.Map.Make}.
+       given to {!Map.Make}.
         @since 3.12.0
      *)
 

--- a/stdlib/moreLabels.mli
+++ b/stdlib/moreLabels.mli
@@ -420,7 +420,7 @@ module Hashtbl : sig
             the seed.  It must be the case that if [equal x y] is true,
             then [hash seed x = hash seed y] for any value of [seed].
             A suitable choice for [hash] is the function
-            {!Stdlib.Hashtbl.seeded_hash} below. *)
+            {!Hashtbl.seeded_hash} below. *)
     end
   (** The input signature of the functor {!MakeSeeded}.
       @since 4.00.0 *)
@@ -735,7 +735,7 @@ module Map : sig
       (** Return the list of all bindings of the given map.
          The returned list is sorted in increasing order of keys with respect
          to the ordering [Ord.compare], where [Ord] is the argument
-         given to {!Stdlib.Map.Make}.
+         given to {!Map.Make}.
           @since 3.12.0
        *)
 
@@ -1050,7 +1050,7 @@ module Set : sig
       (** Return the list of all elements of the given set.
          The returned list is sorted in increasing order with respect
          to the ordering [Ord.compare], where [Ord] is the argument
-         given to {!Stdlib.Set.Make}. *)
+         given to {!Set.Make}. *)
 
       val min_elt: t -> elt
       (** Return the smallest element of the given set

--- a/stdlib/obj.mli
+++ b/stdlib/obj.mli
@@ -131,40 +131,28 @@ module Ephemeron: sig
   (** return the number of keys *)
 
   val get_key: t -> int -> obj_t option
-  (** Same as {!Stdlib.Ephemeron.K1.get_key} *)
 
   val get_key_copy: t -> int -> obj_t option
-  (** Same as {!Stdlib.Ephemeron.K1.get_key_copy} *)
 
   val set_key: t -> int -> obj_t -> unit
-  (** Same as {!Stdlib.Ephemeron.K1.set_key} *)
 
   val unset_key: t -> int -> unit
-  (** Same as {!Stdlib.Ephemeron.K1.unset_key} *)
 
   val check_key: t -> int -> bool
-  (** Same as {!Stdlib.Ephemeron.K1.check_key} *)
 
   val blit_key : t -> int -> t -> int -> int -> unit
-  (** Same as {!Stdlib.Ephemeron.K1.blit_key} *)
 
   val get_data: t -> obj_t option
-  (** Same as {!Stdlib.Ephemeron.K1.get_data} *)
 
   val get_data_copy: t -> obj_t option
-  (** Same as {!Stdlib.Ephemeron.K1.get_data_copy} *)
 
   val set_data: t -> obj_t -> unit
-  (** Same as {!Stdlib.Ephemeron.K1.set_data} *)
 
   val unset_data: t -> unit
-  (** Same as {!Stdlib.Ephemeron.K1.unset_data} *)
 
   val check_data: t -> bool
-  (** Same as {!Stdlib.Ephemeron.K1.check_data} *)
 
   val blit_data : t -> t -> unit
-  (** Same as {!Stdlib.Ephemeron.K1.blit_data} *)
 
   val max_ephe_length: int
   (** Maximum length of an ephemeron, ie the maximum number of keys an

--- a/stdlib/random.mli
+++ b/stdlib/random.mli
@@ -60,7 +60,7 @@ val full_int : int -> int
      If [bound] is less than 2{^30}, [Random.full_int bound] is equal to
      {!Random.int}[ bound]. If [bound] is greater than 2{^30} (on 64-bit systems
      or non-standard environments, such as JavaScript), [Random.full_int]
-     returns a value, where {!Random.int} raises {!Invalid_argument}.
+     returns a value, where {!Random.int} raises {!Stdlib.Invalid_argument}.
 
     @since 4.13.0 *)
 

--- a/stdlib/set.mli
+++ b/stdlib/set.mli
@@ -186,7 +186,7 @@ module type S =
     (** Return the list of all elements of the given set.
        The returned list is sorted in increasing order with respect
        to the ordering [Ord.compare], where [Ord] is the argument
-       given to {!Stdlib.Set.Make}. *)
+       given to {!Set.Make}. *)
 
     val min_elt: t -> elt
     (** Return the smallest element of the given set

--- a/stdlib/string.mli
+++ b/stdlib/string.mli
@@ -60,7 +60,7 @@ v}
     Unicode character U+1F42B.
 
     {b Past mutability.} OCaml strings used to be modifiable in place,
-    for instance via the {!String.set} and {!String.blit}
+    for instance via the [String.set] and [String.blit]
     functions. This use is nowadays only possible when the compiler is
     put in "unsafe-string" mode by giving the [-unsafe-string]
     command-line option. This compatibility mode makes the types

--- a/stdlib/stringLabels.mli
+++ b/stdlib/stringLabels.mli
@@ -60,7 +60,7 @@ v}
     Unicode character U+1F42B.
 
     {b Past mutability.} OCaml strings used to be modifiable in place,
-    for instance via the {!String.set} and {!String.blit}
+    for instance via the [String.set] and [String.blit]
     functions. This use is nowadays only possible when the compiler is
     put in "unsafe-string" mode by giving the [-unsafe-string]
     command-line option. This compatibility mode makes the types

--- a/stdlib/templates/hashtbl.template.mli
+++ b/stdlib/templates/hashtbl.template.mli
@@ -401,7 +401,7 @@ module type SeededHashedType =
           the seed.  It must be the case that if [equal x y] is true,
           then [hash seed x = hash seed y] for any value of [seed].
           A suitable choice for [hash] is the function
-          {!Stdlib.Hashtbl.seeded_hash} below. *)
+          {!Hashtbl.seeded_hash} below. *)
   end
 (** The input signature of the functor {!MakeSeeded}.
     @since 4.00.0 *)

--- a/stdlib/templates/map.template.mli
+++ b/stdlib/templates/map.template.mli
@@ -220,7 +220,7 @@ module type S =
     (** Return the list of all bindings of the given map.
        The returned list is sorted in increasing order of keys with respect
        to the ordering [Ord.compare], where [Ord] is the argument
-       given to {!Stdlib.Map.Make}.
+       given to {!Map.Make}.
         @since 3.12.0
      *)
 

--- a/stdlib/templates/set.template.mli
+++ b/stdlib/templates/set.template.mli
@@ -186,7 +186,7 @@ module type S =
     (** Return the list of all elements of the given set.
        The returned list is sorted in increasing order with respect
        to the ordering [Ord.compare], where [Ord] is the argument
-       given to {!Stdlib.Set.Make}. *)
+       given to {!Set.Make}. *)
 
     val min_elt: t -> elt
     (** Return the smallest element of the given set

--- a/utils/local_store.mli
+++ b/utils/local_store.mli
@@ -23,8 +23,8 @@
 (** {1 Creators} *)
 
 val s_ref : 'a -> 'a ref
-(** Similar to {!val:ref}, except the allocated reference is registered into
-    the store. *)
+(** Similar to {!val:Stdlib.ref}, except the allocated reference is registered
+    into the store. *)
 
 val s_table : ('a -> 'b) -> 'a -> 'b ref
 (** Used to register hash tables. Those also need to be placed into refs to be


### PR DESCRIPTION
This PR removes some invalid cross-references in `Ephemeron.Obj` and `String` that were trying to link to removed functions.
The PR also reduces the noise during the compilation of documentation by strategically disabling warnings to make it easier to spot such dead cross-references in the future.

The removed links in `Ephemeron.Obj` were referencing function in the `Ephemeron` that are no longer part of the public API.

Similarly, the `String` module introduction was trying to link to the non-existent `String.set` and `String.blit` functions.

Finally, with the current documentation compilation scheme with ocamldoc, cross-modules references are only resolved when building the whole documentation and not during the build of individual modules. Therefore it is better to turn off warnings when building individual `*.odoc` files.
