### PR TITLE
Add support for test sequences to ocamltest

### DIFF
--- a/ocamltest/tsl_ast.ml
+++ b/ocamltest/tsl_ast.ml
@@ -28,10 +28,15 @@ type environment_statement =
 
 type tsl_item =
   | Environment_statement of environment_statement located
-  | Test of
-    int (* test depth *) *
+  | Test of int (* test depth *) * test
+and test =
+  | Simple of
     string located (* test name *) *
     string located list (* environment modifiers *)
+  | Sequence of test_seq_item list
+and test_seq_item =
+  | Seq_env_statement of environment_statement located
+  | Test_name of string located
 
 type tsl_block = tsl_item list
 

--- a/ocamltest/tsl_ast.mli
+++ b/ocamltest/tsl_ast.mli
@@ -28,10 +28,15 @@ type environment_statement =
 
 type tsl_item =
   | Environment_statement of environment_statement located
-  | Test of
-    int (* test depth *) *
+  | Test of int (* test depth *) * test
+and test =
+  | Simple of
     string located (* test name *) *
     string located list (* environment modifiers *)
+  | Sequence of test_seq_item list
+and test_seq_item =
+  | Seq_env_statement of environment_statement located
+  | Test_name of string located
 
 type tsl_block = tsl_item list
 

--- a/ocamltest/tsl_lexer.mll
+++ b/ocamltest/tsl_lexer.mll
@@ -44,6 +44,9 @@ rule token = parse
   | "*" (num+ as n) { TEST_DEPTH (int_of_string n)}
   | "+=" { PLUSEQUAL }
   | "=" { EQUAL }
+  | "+" { PLUS }
+  | "{" { TEST_SEQ_BEGIN }
+  | "}" { TEST_SEQ_END }
   | identchar *
     { let s = Lexing.lexeme lexbuf in
       match s with

--- a/ocamltest/tsl_parser.mly
+++ b/ocamltest/tsl_parser.mly
@@ -27,7 +27,7 @@ let mkidentifier id = make_identifier ~loc:(symbol_rloc()) id
 let mkenvstmt envstmt =
   let located_env_statement =
     make_environment_statement ~loc:(symbol_rloc()) envstmt in
-  Environment_statement located_env_statement
+  located_env_statement
 
 %}
 
@@ -35,7 +35,8 @@ let mkenvstmt envstmt =
 %token TSL_BEGIN_OCAML_STYLE TSL_END_OCAML_STYLE
 %token COMMA
 %token <int> TEST_DEPTH
-%token EQUAL PLUSEQUAL
+%token EQUAL PLUS PLUSEQUAL
+%token TEST_SEQ_BEGIN TEST_SEQ_END
 %token INCLUDE SET UNSET WITH
 %token <string> IDENTIFIER
 %token <string> STRING
@@ -55,10 +56,24 @@ tsl_items:
 
 tsl_item:
 | test_item { $1 }
-| env_item { $1 }
+| env_item { Environment_statement $1 }
 
-test_item:
-  TEST_DEPTH identifier with_environment_modifiers { (Test ($1, $2, $3)) }
+test_item: TEST_DEPTH test { Test ($1, $2) }
+
+test:
+| identifier with_environment_modifiers { Simple ($1, $2) }
+| sequence { Sequence $1 }
+
+sequence:
+  TEST_SEQ_BEGIN test_seq_item opt_test_seq_items TEST_SEQ_END { $2::$3 }
+
+test_seq_item:
+| PLUS identifier { Test_name $2 }
+| env_item { Seq_env_statement $1 }
+
+opt_test_seq_items:
+| { [] }
+| test_seq_item opt_test_seq_items { $1::$2 }
 
 with_environment_modifiers:
 | { [] }

--- a/ocamltest/tsl_parser.mly
+++ b/ocamltest/tsl_parser.mly
@@ -36,7 +36,6 @@ let mkenvstmt envstmt =
 %token COMMA
 %token <int> TEST_DEPTH
 %token EQUAL PLUSEQUAL
-/* %token COLON */
 %token INCLUDE SET UNSET WITH
 %token <string> IDENTIFIER
 %token <string> STRING

--- a/ocamltest/tsl_semantics.mli
+++ b/ocamltest/tsl_semantics.mli
@@ -27,12 +27,18 @@ val interpret_environment_statements :
   Environments.t -> Tsl_ast.environment_statement Tsl_ast.located list ->
   Environments.t
 
+type test_node =
+| Simple_test of Tests.t * string located list
+| Sequence_test of
+  ((Tsl_ast.environment_statement located list) * Tests.t) list
+
 type test_tree =
   | Node of
     (Tsl_ast.environment_statement located list) *
-    Tests.t *
-    string located list *
+    test_node *
     (test_tree list)
+
+
 
 val test_trees_of_tsl_block :
   Tsl_ast.tsl_block ->

--- a/testsuite/tests/backtrace/backtrace_dynlink.ml
+++ b/testsuite/tests/backtrace/backtrace_dynlink.ml
@@ -11,13 +11,17 @@ libraries = ""
   + native-dynlink
   + setup-ocamlopt.byte-build-env
   }
-** ocamlopt.byte
+** {
    module = "backtrace_dynlink.ml"
    flags = "-g"
-** ocamlopt.byte
+   + ocamlopt.byte
+   }
+** {
    program = "backtrace_dynlink_plugin.cmxs"
    flags = "-shared -g"
    all_modules = "backtrace_dynlink_plugin.ml"
+   + ocamlopt.byte
+   }
 ** {
    program = "${test_build_directory}/main.exe"
    libraries = "dynlink"
@@ -33,8 +37,6 @@ libraries = ""
     + flambda
     + check-program-output
     }
-
-
 
 *)
 

--- a/testsuite/tests/backtrace/backtrace_dynlink.ml
+++ b/testsuite/tests/backtrace/backtrace_dynlink.ml
@@ -6,27 +6,36 @@ readonly_files = "backtrace_dynlink_plugin.ml"
 
 libraries = ""
 
-* shared-libraries
-** native-dynlink
-*** setup-ocamlopt.byte-build-env
-**** ocamlopt.byte
-module = "backtrace_dynlink.ml"
-flags = "-g"
-**** ocamlopt.byte
-program = "backtrace_dynlink_plugin.cmxs"
-flags = "-shared -g"
-all_modules = "backtrace_dynlink_plugin.ml"
-**** ocamlopt.byte
-program = "${test_build_directory}/main.exe"
-libraries = "dynlink"
-all_modules = "backtrace_dynlink.cmx"
-***** run
-ocamlrunparam += ",b=1"
-****** no-flambda
-******* check-program-output
-****** flambda
-reference = "${test_source_directory}/backtrace_dynlink.flambda.reference"
-******* check-program-output
+* {
+  + shared-libraries
+  + native-dynlink
+  + setup-ocamlopt.byte-build-env
+  }
+** ocamlopt.byte
+   module = "backtrace_dynlink.ml"
+   flags = "-g"
+** ocamlopt.byte
+   program = "backtrace_dynlink_plugin.cmxs"
+   flags = "-shared -g"
+   all_modules = "backtrace_dynlink_plugin.ml"
+** {
+   program = "${test_build_directory}/main.exe"
+   libraries = "dynlink"
+   all_modules = "backtrace_dynlink.cmx"
+   + ocamlopt.byte
+   + run
+   }
+*** {
+    + no-flambda
+    + check-program-output
+    }
+*** {
+    + flambda
+    + check-program-output
+    }
+
+
+
 *)
 
 (* test for backtrace and stack unwinding with dynlink. *)

--- a/testsuite/tests/tool-dumpobj/test.ml
+++ b/testsuite/tests/tool-dumpobj/test.ml
@@ -2,9 +2,11 @@
 
 flags = "-nopervasives"
 
-* setup-ocamlc.byte-build-env
-** ocamlc.byte
-*** run
-**** check-program-output
+* {
+  + setup-ocamlc.byte-build-env
+  + ocamlc.byte
+  + run
+  + check-program-output
+}
 *)
 let x = 42L


### PR DESCRIPTION
This is a proposal to solve a weel known problem of ocmaltest, i.e.
that it is not really possible to write long test sequences,
given that the structure of a test block is essentially a tree.

With this PR, it becomes possible to include at each node of the tree
a sequence of tests.

To make things concrete, here is the content of the test block
for the dumpobj test before the PR:

```
(* TEST

flags = "-nopervasives"

* setup-ocamlc.byte-build-env
** ocamlc.byte
*** run
**** check-program-output
*)
```

Here is how it can be rewritten with this PR:

```
(* TEST

flags = "-nopervasives"

* {
  + setup-ocamlc.byte-build-env
  + ocamlc.byte
  + run
  + check-program-output
}
*)
```

Perhaps not as spectacular as for bigger tests, but it lets one understand
how things work, hopefully.

The `*` before the `{` represents the position of the test block in the test
tree, as it did before.

If there is agreement on the feature at the language level, I'd be happy to
port the tests, perhaps in another
PR so that this one can be integrated and be used by others.