### PR TITLE
summarize.awk: should fail when ocamltest result is not understood

### DIFF
--- a/testsuite/summarize.awk
+++ b/testsuite/summarize.awk
@@ -134,12 +134,9 @@ function record_unexp() {
     record_unexp();
 }
 
-# Record anything else seen on a test result as a failure
-/=> .* / {
-    if (in_test) record_unexp();
-}
-
 END {
+    if (in_test) record_unexp();
+
     if (errored){
         printf ("\n#### Some fatal error occurred during testing.\n\n");
         exit (3);

--- a/testsuite/summarize.awk
+++ b/testsuite/summarize.awk
@@ -138,6 +138,10 @@ function record_unexp() {
     record_unexp();
 }
 
+# Record anything else seen on a test result as a failure
+/=> .* / {
+    if (in_test) record_unexp();
+}
 
 END {
     if (errored){

--- a/testsuite/summarize.awk
+++ b/testsuite/summarize.awk
@@ -138,15 +138,6 @@ function record_unexp() {
     record_unexp();
 }
 
-/^re-ran / {
-    if (in_test){
-        printf("error at line %d: found re-ran inside a test\n", NR);
-        errored = 1;
-    }else{
-        RERAN[substr($0, 8, length($0)-7)] += 1;
-        ++ reran;
-    }
-}
 
 END {
     if (errored){

--- a/testsuite/summarize.awk
+++ b/testsuite/summarize.awk
@@ -49,14 +49,10 @@ function record_na() {
     clear();
 }
 
-# The output cares only if the test passes at least once so if a test passes,
-# but then fails in a re-run triggered by a different test, ignore it.
 function record_fail() {
     check();
-    if (!(key in RESULTS) || RESULTS[key] == "s"){
-        if (!(key in RESULTS)) ++nresults;
-        RESULTS[key] = "f";
-    }
+    if (!(key in RESULTS)) ++nresults;
+    RESULTS[key] = "f";
     delete SKIPPED[curdir];
     clear();
 }
@@ -214,9 +210,6 @@ END {
             for (i=0; i < slowcount; i++) printf("    %s\n", slow[i]);
         }
         printf ("\n");
-        if (reran != 0){
-            printf("  %3d test dir re-runs\n", reran);
-        }
         if (failed || unexped){
             printf("#### Something failed. Exiting with error status.\n\n");
             exit 4;


### PR DESCRIPTION
This PR _attempts_ to fix `summarize.awk`'s handling of unexpected results from an ocamltest run.
This addresses issue #10953

The gist of #10953 is that `ocamltest` may produce lines such as:

```
... testing 'partial_application.ml' with 2 (native) => Process 746304 got signal 6(Aborted), core dumped                                                                
Could not find core file.                                                                                                                                                 
failed (Running program /home/engil/Documents/Dev/ocaml/testsuite/_ocamltest/tests/tmc/partial_application/ocamlopt.byte/partial_application.opt without any argument: command
```

Which means that `summarize.awk` will not recognize `=> Process` as a failure condition, but will rather skip through all possible candidates and will not report a failure.

This very naive attempt involves introduce a sort of catch-all clause that will record an expected failure when all options were exhausted.
It relies on checking if we are indeed processing a properly formatted test line, thus with a set `in_test`, which gets us closer to catching this specific scenario.
Since this match comes last, and we checked every expected outcome before (each of them resetting the `in_test` variable through `clear()` in case they did match), the behavior should be correct.

This is likely not the best answer to this problem (one could argue that we should not allow such a ill formatted line to happen, but how to avoid this is unclear to me!), and I went with this simple solution, with my very meager knowledge of `awk`.

Suggestions are much welcome (I think @damiendoligez and @dra27 may be the ones with the better understanding of this script?).

Side note:
This PR also removes the `re-ran` handling in the script, @dra27 pointed out to me that this was not needed anymore and is a leftover from previous oddities with the Windows CI runs and `lib-threads`.