### PR TITLE
make sure a MAP_STACK signal stack gets unmapped

### DIFF
--- a/Changes
+++ b/Changes
@@ -229,11 +229,11 @@ OCaml 5.0
   (Guillaume Munch-Maccagnoni, review by Xavier Leroy and Gabriel
   Scherer)
 
-- #10875: Add option to allocate stacks with mmap(MAP_STACK) instead of malloc.
+- #10875, #11091: Add option to allocate stacks with mmap instead of malloc.
   This is exposed via a configure --enable-mmap-map-stack option, and is
-  enabled by default on OpenBSD where it is mandatory.
-  (Anil Madhavapeddy, review by Gabriel Scherer, Tom Kelly,
-   Michael Hendricks and KC Sivaramakrishnan).
+  enabled by default on OpenBSD where it is mandatory to use MAP_STACK.
+  (Anil Madhavapeddy and Christopher Zimmerman, review by Gabriel Scherer,
+   Tom Kelly, Michael Hendricks and KC Sivaramakrishnan).
 
 - #10950: Do not use mmap to allocate Caml_state.
   In order to reduce virtual memory usage, we dynamically allocate

--- a/runtime/caml/signals.h
+++ b/runtime/caml/signals.h
@@ -76,8 +76,8 @@ value caml_process_pending_actions_with_root_exn (value extra_root);
 void caml_init_signal_handling(void);
 void caml_init_signals();
 void caml_terminate_signals();
-CAMLextern void * caml_init_signal_stack(void);
-CAMLextern void caml_free_signal_stack(void *);
+CAMLextern stack_t * caml_init_signal_stack(void);
+CAMLextern void caml_free_signal_stack(stack_t *);
 
 /* These hooks are not modified after other threads are spawned. */
 CAMLextern void (*caml_enter_blocking_section_hook)(void);


### PR DESCRIPTION
The `MAP_STACK` bit won't be cleared by `sigaltstack(SS_DISABLE...)`
or `free()`. Therefore `mmap()` / `munmap()` the signal stack instead of `free()`.
See [sigaltstack](https://man.openbsd.org/sigaltstack)