### PR TITLE
ARM64 CFI support

### DIFF
--- a/asmcomp/arm64/emit.mlp
+++ b/asmcomp/arm64/emit.mlp
@@ -1169,7 +1169,11 @@ let begin_assembly() =
   emit_named_text_section lbl_begin;
   `	.globl	{emit_symbol lbl_begin}\n`;
   `{emit_symbol lbl_begin}:\n`;
-  (* avoid collision for unwind test with code_begin symbol *)
+  (* we need to pad here to avoid collision for the unwind test between
+     the code_begin symbol and the first function. (See also #4690)
+     Alignment is needed to avoid linker warnings for
+     shared_startup__code_{begin,end} (e.g. tests/lib-dynlink-pr4839).
+   *)
   if macosx then ` nop\n .align 3\n`;
   ()
 

--- a/asmcomp/arm64/emit.mlp
+++ b/asmcomp/arm64/emit.mlp
@@ -742,12 +742,14 @@ let emit_instr env i =
              NB: no need to store previous x29 because OCaml frames don't
              maintain frame pointer *)
           ` mov x29, sp\n`;
+          cfi_remember_state ();
+          cfi_def_cfa_register ~reg:29;
           let offset = Domainstate.(idx_of_field Domain_c_stack) * 8 in
           ` ldr {emit_reg reg_tmp1}, [{emit_reg reg_domain_state_ptr}, {emit_int offset}]\n`;
           ` mov sp, {emit_reg reg_tmp1}\n`;
           ` bl {emit_symbol func}\n`;
-          ` mov sp, x29\n`
-          (* TODO: CFI for this *)
+          ` mov sp, x29\n`;
+          cfi_restore_state ()
         end
     | Lop(Istackoffset n) ->
         assert (n mod 16 = 0);
@@ -1166,7 +1168,10 @@ let begin_assembly() =
   let lbl_begin = Compilenv.make_symbol (Some "code_begin") in
   emit_named_text_section lbl_begin;
   `	.globl	{emit_symbol lbl_begin}\n`;
-  `{emit_symbol lbl_begin}:\n`
+  `{emit_symbol lbl_begin}:\n`;
+  (* avoid collision for unwind test with code_begin symbol *)
+  if macosx then ` nop\n .align 3\n`;
+  ()
 
 let end_assembly () =
   let lbl_end = Compilenv.make_symbol (Some "code_end") in

--- a/asmcomp/emitaux.ml
+++ b/asmcomp/emitaux.ml
@@ -340,6 +340,13 @@ let cfi_offset ~reg ~offset =
     emit_string "\n"
   end
 
+let cfi_def_cfa_register ~reg =
+  if is_cfi_enabled () then begin
+    emit_string "\t.cfi_def_cfa_register ";
+    emit_int reg;
+    emit_string "\n"
+  end
+
 (* Emit debug information *)
 
 (* This assoc list is expected to be very short *)

--- a/asmcomp/emitaux.mli
+++ b/asmcomp/emitaux.mli
@@ -73,6 +73,7 @@ val cfi_offset : reg:int -> offset:int -> unit
 val cfi_def_cfa_offset : int -> unit
 val cfi_remember_state : unit -> unit
 val cfi_restore_state : unit -> unit
+val cfi_def_cfa_register: reg:int -> unit
 
 val binary_backend_available: bool ref
     (** Is a binary backend available.  If yes, we don't need

--- a/configure
+++ b/configure
@@ -13230,8 +13230,11 @@ $as_echo "$as_me: WARNING: flexlink not found: shared library support disabled."
 esac
 
 case $cc_basename,$host in #(
-  *,*-*-darwin*) :
+  *,x86_64-*-darwin*) :
     mkexe="$mkexe -Wl,-no_compact_unwind";
+    $as_echo "#define HAS_ARCH_CODE32 1" >>confdefs.h
+ ;; #(
+  *,aarch64-*-darwin*|arm64-*-darwin*) :
     $as_echo "#define HAS_ARCH_CODE32 1" >>confdefs.h
  ;; #(
   *,*-*-haiku*) :
@@ -14079,10 +14082,14 @@ natdynlinkopts=""
 
 if test x"$enable_shared" != "xno"; then :
   case $host in #(
-  *-apple-darwin*) :
+  x86_64-apple-darwin*) :
     mksharedlib="$CC -shared \
                    -undefined dynamic_lookup -Wl,-no_compact_unwind \
                    \$(LDFLAGS)"
+      supports_shared_libraries=true ;; #(
+  aarch64-apple-darwin*|arm64-apple-darwin*) :
+    mksharedlib="$CC -shared \
+                   -undefined dynamic_lookup \$(LDFLAGS)"
       supports_shared_libraries=true ;; #(
   *-*-mingw32) :
     mksharedlib='$(FLEXLINK)'

--- a/configure.ac
+++ b/configure.ac
@@ -791,9 +791,11 @@ AS_CASE([$flexdir,$supports_shared_libraries,$flexlink,$host],
     [AC_MSG_ERROR([flexlink is required for native Win32])])
 
 AS_CASE([$cc_basename,$host],
-  [*,*-*-darwin*],
+  [*,x86_64-*-darwin*],
     [mkexe="$mkexe -Wl,-no_compact_unwind";
     AC_DEFINE([HAS_ARCH_CODE32], [1])],
+  [*,aarch64-*-darwin*|arm64-*-darwin*],
+    AC_DEFINE([HAS_ARCH_CODE32], [1]),
   [*,*-*-haiku*], [mathlib=""],
   [*,*-*-cygwin*],
     [common_cppflags="$common_cppflags -U_WIN32"
@@ -932,10 +934,14 @@ natdynlinkopts=""
 
 AS_IF([test x"$enable_shared" != "xno"],
   [AS_CASE([$host],
-    [*-apple-darwin*],
+    [x86_64-apple-darwin*],
       [mksharedlib="$CC -shared \
                    -undefined dynamic_lookup -Wl,-no_compact_unwind \
                    \$(LDFLAGS)"
+      supports_shared_libraries=true],
+    [aarch64-apple-darwin*|arm64-apple-darwin*],
+      [mksharedlib="$CC -shared \
+                   -undefined dynamic_lookup \$(LDFLAGS)"
       supports_shared_libraries=true],
     [*-*-mingw32],
       [mksharedlib='$(FLEXLINK)'

--- a/runtime/amd64.S
+++ b/runtime/amd64.S
@@ -149,7 +149,6 @@
      https://github.com/hjl-tools/x86-psABI/wiki/x86-64-psABI-1.0.pdf */
 
 #define DW_CFA_def_cfa_expression 0x0f
-#define DW_CFA_val_offset         0x14
 #define DW_REG_rbp                6
 #define DW_REG_rsp                7
 #define DW_REG_r13                13

--- a/runtime/arm64.S
+++ b/runtime/arm64.S
@@ -44,13 +44,44 @@
 #define CFI_ADJUST(n) .cfi_adjust_cfa_offset n
 #define CFI_REGISTER(r1,r2) .cfi_register r1,r2
 #define CFI_OFFSET(r,n) .cfi_offset r,n
+#define CFI_DEF_CFA_REGISTER(r) .cfi_def_cfa_register r
+#define CFI_SIGNAL_FRAME .cfi_signal_frame
+#define CFI_REMEMBER_STATE .cfi_remember_state
+#define CFI_RESTORE_STATE .cfi_restore_state
 #else
 #define CFI_STARTPROC
 #define CFI_ENDPROC
 #define CFI_ADJUST(n)
 #define CFI_REGISTER(r1,r2)
 #define CFI_OFFSET(r,n)
+#define CFI_DEF_CFA_REGISTER(r)
+#define CFI_SIGNAL_FRAME
+#define CFI_REMEMBER_STATE
+#define CFI_RESTORE_STATE
 #endif
+
+/* DWARF
+
+   These constants are taken from:
+
+     DWARF Debugging Information Format, Version 3
+     http://dwarfstd.org/doc/Dwarf3.pdf
+
+   with the ARM64 specific register numbers coming from
+   Table 4 ("Mapping from DWARF register numbers to Arm
+   64-bit architecture registers") of:
+
+     https://developer.arm.com/documentation/ihi0057/latest
+
+ */
+
+#define DW_CFA_def_cfa_expression 0x0f
+#define DW_REG_x21                21
+#define DW_REG_sp                 31
+#define DW_OP_breg                0x70
+#define DW_OP_deref               0x06
+#define DW_OP_plus_uconst         0x23
+
 
         .set    domain_curr_field, 0
 #if defined(SYS_macosx)
@@ -158,6 +189,7 @@ G(name):
 
 /* struct stack_info */
 #define Stack_sp(reg)           [reg]
+#define Stack_sp_offset         0
 #define Stack_exception(reg)    [reg, #8]
 #define Stack_handler(reg)      [reg, #16]
 #define Stack_handler_from_cont(reg) [reg, #15]
@@ -165,6 +197,7 @@ G(name):
 /* struct c_stack_link */
 #define Cstack_stack(reg)       [reg]
 #define Cstack_sp(reg)          [reg, #8]
+#define Cstack_sp_offset        8
 #define Cstack_prev(reg)        [reg, #16]
 
 /* struct stack_handler */
@@ -172,6 +205,7 @@ G(name):
 #define Handler_exception(reg)  [reg, #8]
 #define Handler_effect(reg)     [reg, #16]
 #define Handler_parent(reg)     [reg, #24]
+#define Handler_parent_offset   24
 
 /* Switch from OCaml to C stack. */
 .macro SWITCH_OCAML_TO_C
@@ -186,12 +220,20 @@ G(name):
         str     TMP, Cstack_sp(TMP2)
     /* Switch to C stack */
         mov     sp, TMP2
+#ifdef ASM_CFI_SUPPORTED
+        CFI_REMEMBER_STATE
+    /* sp  points to the c_stack_link. */
+        .cfi_escape DW_CFA_def_cfa_expression, 5,                 \
+           DW_OP_breg + DW_REG_sp, Cstack_sp_offset, DW_OP_deref, \
+           DW_OP_plus_uconst, 16 /* fp + retaddr */
+#endif
 .endm
 
 /* Switch from C to OCaml stack. */
 .macro SWITCH_C_TO_OCAML
         ldr     TMP, Cstack_sp(sp)
         mov     sp, TMP
+        CFI_RESTORE_STATE
 .endm
 
 /* Save all of the registers that may be in use to a free gc_regs bucket
@@ -497,7 +539,16 @@ L(jump_to_caml):
     /* Switch stacks and call the OCaml code */
         mov     sp, x8
 #ifdef ASM_CFI_SUPPORTED
-    /* TODO: the CFI magic for the stack switch */
+        CFI_REMEMBER_STATE
+        .cfi_escape DW_CFA_def_cfa_expression, 3 + 2 + 2,             \
+            /* sp points to the exn handler on the OCaml stack */     \
+            /* sp + 16 contains the C_STACK_SP */                     \
+          DW_OP_breg + DW_REG_sp, 16 /* exn handler */, DW_OP_deref,  \
+            /* 32   struct c_stack_link + pad */                      \
+            /* 18*8 callee save regs */                               \
+            /* 16   fp + ret addr */                                  \
+            /* need to split to get under 127 limit */                \
+          DW_OP_plus_uconst, 96, DW_OP_plus_uconst, 96
 #endif
     /* Call the OCaml code */
         blr     TMP2
@@ -519,7 +570,7 @@ L(return_result):
         str     x9, Stack_sp(x8)
         ldr     x9, Caml_state(c_stack)
         mov     sp, x9
-        /* TODO: CFI_RESTORE_STATE */
+        CFI_RESTORE_STATE
     /* Pop the struct c_stack_link */
         ldr     x8, Cstack_prev(sp)
         add     sp, sp, 32
@@ -777,6 +828,8 @@ CFI_STARTPROC
     /*  x0: fiber
         x1: fun
         x2: arg */
+        CFI_OFFSET(29, -16)
+        CFI_OFFSET(30, -8)
         stp     x29, x30, [sp, -16]!
         CFI_ADJUST(16)
         add     x29, sp, #0
@@ -803,7 +856,17 @@ CFI_STARTPROC
         mov     TRAP_PTR, x9
     /* Switch to the new stack */
         mov     sp, x9
-        /* TODO: CFI for this */
+#ifdef ASM_CFI_SUPPORTED
+        CFI_REMEMBER_STATE
+        .cfi_escape DW_CFA_def_cfa_expression, 3+3+2,       \
+          DW_OP_breg + DW_REG_sp,                           \
+            16 /* exn */ +                                  \
+            8 /* gc_regs slot (unused) */ +                 \
+            8 /* C_STACK_SP for DWARF (unused) */           \
+            + Handler_parent_offset, DW_OP_deref,           \
+          DW_OP_plus_uconst, Stack_sp_offset, DW_OP_deref,  \
+          DW_OP_plus_uconst, 16 /* fp + ret addr */
+#endif
     /* Call the function on the new stack */
         mov     x0, x2
         blr     x3
@@ -821,6 +884,9 @@ L(frame_runstack):
     /* free old stack by switching directly to c_stack;
        is a no-alloc call */
         ldr     x21, Stack_sp(TMP) /* saved across C call */
+        CFI_RESTORE_STATE
+        CFI_REMEMBER_STATE
+        CFI_DEF_CFA_REGISTER(DW_REG_x21)
         ldr     TMP, Caml_state(c_stack)
         mov     sp, TMP
         bl      G(caml_free_stack)
@@ -828,9 +894,11 @@ L(frame_runstack):
         mov     x0, x20
         mov     x1, x19
         mov     sp, x21
+        CFI_RESTORE_STATE
         ldr     TMP, [x19]  /* code pointer */
     /* Invoke handle_value (or handle_exn) */
         ldp     x29, x30, [sp], 16
+        CFI_ADJUST(-16)
         br      TMP
 L(fiber_exn_handler):
         add     x8, sp, 16  /* x8 := stack_handler */


### PR DESCRIPTION
This PR fixes up the CFI commands to allow unwind on ARM64 that was left over from #10972. `tests/unwind` now passes on both MacOS x86_64 and ARM64. 

To get things working involved some trial-and-error to force the toolchain to give me DWARF information on MacOS ARM64. In my experience I had to remove the `-no_compact_unwind` link flag on ARM64 for `tests/unwind` to work. However on x86_64, I found that the `-no_compact_unwind` link flag was necessary to keep `tests/unwind` working. After attempts to try and find sanity by exploring past issues (e.g. #5921, #7120) and some time with a search engine trying to figure out what other languages do, I was not able to shed strong clarity on this. 

However I believe the CFI is correct in the PR, even if we ultimately decide to strip some of the CFI from MacOS ARM64 builds by retaining `-no_compact_unwind`. My feeling is we should drop `-no_compact_unwind` on MacOS ARM64 and keep `tests/unwind` running. 4.14 has disabled `tests/unwind` for ARM64 because there did not appear to be a way to emit unwind information; see https://github.com/ocaml/ocaml/commit/482b7feb3743e140fd79c2b1bf929f2b738d42eb.

