### PR TITLE
ocamltest: fix test result reporting to avoid split messages

### DIFF
--- a/Changes
+++ b/Changes
@@ -132,6 +132,10 @@ Working version
 - #11079: Add the -nobanners option to dumpobj.
   (Sébastien Hinderer, review by Gabriel Scherer and Vincent Laviron)
 
+- #11100: Fix ocamltest to make sure failed tests are not counted as
+  "unexpected error".
+  (Damien Doligez, review by xxx)
+
 ### Manual and documentation:
 
 ### Compiler user-interface and warnings:

--- a/ocamltest/main.ml
+++ b/ocamltest/main.ml
@@ -85,9 +85,9 @@ let join_summaries sa sb =
 
 let rec run_test log common_prefix path behavior = function
   Node (testenvspec, test, env_modifiers, subtrees) ->
-  Printf.printf "%s %s (%s) => %!" common_prefix path test.Tests.test_name;
+  Printf.printf "%s %s (%s) %!" common_prefix path test.Tests.test_name;
   let (msg, children_behavior, result) = match behavior with
-    | Skip_all_tests -> "n/a", Skip_all_tests, Result.skip
+    | Skip_all_tests -> "=> n/a", Skip_all_tests, Result.skip
     | Run env ->
       let testenv0 = interpret_environment_statements env testenvspec in
       let testenv = List.fold_left apply_modifiers testenv0 env_modifiers in

--- a/ocamltest/result.ml
+++ b/ocamltest/result.ml
@@ -39,9 +39,9 @@ let skip_with_reason r = result_with_reason Skip r
 let fail_with_reason r = result_with_reason Fail r
 
 let string_of_status = function
-  | Pass -> "passed"
-  | Skip -> "skipped"
-  | Fail -> "failed"
+  | Pass -> "=> passed"
+  | Skip -> "=> skipped"
+  | Fail -> "=> failed"
 
 let string_of_reason = function
   | None -> ""


### PR DESCRIPTION
The strings`=> n/a`, `=> failed`, `=> skipped`, `=> passed` are keywords of the interface with `summarize.awk` and should not be split under any circumstance.
