### PR TITLE
Speed up register allocation by permanently spilling registers

### DIFF
--- a/Changes
+++ b/Changes
@@ -27,6 +27,9 @@ Working version
   useful if you need extra security with GADTs.
   (Jacques Garrigue, review by Gabriel Scherer)
 
+- #11102: Speed up register allocation by permanently spilling registers
+  (Stephen Dolan, review by Xavier Leroy)
+
 ### Standard library:
 
 - #11128: Add In_channel.isatty, Out_channel.isatty.

--- a/asmcomp/coloring.ml
+++ b/asmcomp/coloring.ml
@@ -198,6 +198,9 @@ let allocate_registers() =
           best_slot := n
         end
       done;
+      (* Mark this register as spilled so that we don't waste time trying
+         to put in in a register if we have to redo regalloc due to Reload *)
+      reg.spill <- true;
       (* Found one? *)
       if !best_slot >= 0 then
         reg.loc <- Stack(Local !best_slot)


### PR DESCRIPTION
In functions with high register pressure, register allocation may need to be iterated multiple times to find a solution compatible with the instruction constraints enforced by Reload.

Currently, this can end up iterating many times, each time choosing a slightly different set of registers to spill. For instance, the two functions [in this example](https://gist.github.com/stedolan/ca1096fd06c74de9cba5c3fa43c13cca) take 13 iterations to converge. (Check with `ocamlopt -dalloc` and see how many times it prints `After register allocation`). With large functions, this can be extremely time-consuming.

The fix here is to set `reg.spill` to true whenever `Coloring` puts a register in a stack slot. This ensures that if register allocation is redone, this register will definitely be spilled next time around as well. In other words, if register allocation needs multiple passes, then the set of spilled registers grows monotonically, rather than searching for a new allocation from scratch each time. This makes the two functions above converge after 3 iterations.

(thanks to @gretay-js @lpw25 @mshinwell @xclerc for helping to work out what's going on here and how to fix it)