### PR TITLE
Use -linscan for module entry functions

### DIFF
--- a/asmcomp/asmgen.ml
+++ b/asmcomp/asmgen.ml
@@ -111,7 +111,8 @@ let rec regalloc ~ppf_dump round fd =
                 ": function too complex, cannot complete register allocation");
   dump_if ppf_dump dump_live "Liveness analysis" fd;
   let num_stack_slots =
-    if !use_linscan then begin
+    if !use_linscan ||
+       List.mem Cmm.Use_linscan_regalloc fd.Mach.fun_codegen_options then begin
       (* Linear Scan *)
       Interval.build_intervals fd;
       if !dump_interval then Printmach.intervals ppf_dump ();

--- a/asmcomp/cmm.ml
+++ b/asmcomp/cmm.ml
@@ -201,6 +201,7 @@ type expression =
 type codegen_option =
   | Reduce_code_size
   | No_CSE
+  | Use_linscan_regalloc
 
 type fundecl =
   { fun_name: string;

--- a/asmcomp/cmm.mli
+++ b/asmcomp/cmm.mli
@@ -203,6 +203,7 @@ and expression =
 type codegen_option =
   | Reduce_code_size
   | No_CSE
+  | Use_linscan_regalloc
 
 type fundecl =
   { fun_name: string;

--- a/asmcomp/cmmgen.ml
+++ b/asmcomp/cmmgen.ml
@@ -1532,8 +1532,9 @@ let compunit (ulam, preallocated_blocks, constants) =
                          if Config.flambda then [
                            Reduce_code_size;
                            No_CSE;
+                           Use_linscan_regalloc;
                          ]
-                         else [ Reduce_code_size ];
+                         else [ Reduce_code_size; Use_linscan_regalloc ];
                        fun_poll = Default_poll;
                        fun_dbg  = Debuginfo.none }] in
   let c2 = transl_clambda_constants constants c1 in


### PR DESCRIPTION
Linscan is much faster on large functions, and module entry functions are large and not performance sensitive (they only run once, to initialise things), so this can speed compilation a lot.

This patch makes register allocation time on some large files go from minutes to seconds - [see comment here](https://github.com/ocaml/ocaml/pull/11102#issuecomment-1063357023)