### PR TITLE
`odoc`ify the parsetree comments

### DIFF
--- a/Changes
+++ b/Changes
@@ -426,6 +426,9 @@ OCaml 4.14.0
   CSS for coloring bullets
   (Wiktor Kuchta, review by Florian Angeletti)
 
+- #11107: Lifted comments in the Parsetree module into actual documentation.
+  (Paul-Elliot Anglès d'Auriac, review by Florian Angeletti)
+
 ### Compiler user-interface and warnings:
 
 - #10328, #10780: Give more precise error when disambiguation could not

--- a/parsing/asttypes.mli
+++ b/parsing/asttypes.mli
@@ -48,8 +48,8 @@ type label = string
 
 type arg_label =
     Nolabel
-  | Labelled of string (*  label:T -> ... *)
-  | Optional of string (* ?label:T -> ... *)
+  | Labelled of string (** [label:T -> ...] *)
+  | Optional of string (** [?label:T -> ...] *)
 
 type 'a loc = 'a Location.loc = {
   txt : 'a;

--- a/parsing/parsetree.mli
+++ b/parsing/parsetree.mli
@@ -104,13 +104,13 @@ and core_type_desc =
            Invariant: [n >= 2].
         *)
   | Ptyp_constr of Longident.t loc * core_type list
-        (** [Ptyp_constr(loc, l)] represents:
+        (** [Ptyp_constr(lident, l)] represents:
             - [tconstr]               when [l=[]],
             - [T tconstr]             when [l=[T]],
             - [(T1, ..., Tn) tconstr] when [l=[T1 ; ... ; Tn]].
          *)
   | Ptyp_object of object_field list * closed_flag
-        (** [Ptyp_object([ l1:T1; ...; ln:Tn ], flag)] Represents:
+        (** [Ptyp_object([ l1:T1; ...; ln:Tn ], flag)] represents:
             - [< l1:T1; ...; ln:Tn >]
                                     when [flag] is {{!Asttypes.Closed}[Closed]},
             - [< l1:T1; ...; ln:Tn; .. >]
@@ -125,19 +125,19 @@ and core_type_desc =
   | Ptyp_alias of core_type * string
         (** Represents [T as 'a]. *)
   | Ptyp_variant of row_field list * closed_flag * label list option
-        (** [Ptyp_variant([`A;`B], flag, labels)]Represents:
+        (** [Ptyp_variant([`A;`B], flag, labels)] represents:
             - [[ `A|`B ]]
-                 when [flag]   is {{!Asttypes.Closed}[Closed]}
-                  and [labels] is [None],
+                 when [flag],                       [labels]
+                   is {{!Asttypes.Closed}[Closed]}, [None],
             - [[> `A|`B ]]
-                 when [flag]   is {{!Asttypes.Open}[Open]}
-                  and [labels] is [None],
+                 when [flag],                       [labels]
+                   is {{!Asttypes.Open}[Open]},     [None],
             - [[< `A|`B ]]
-                 when [flag]   is {{!Asttypes.Closed}[Closed]}
-                  and [labels] is [Some []],
+                 when [flag],                       [labels]
+                   is {{!Asttypes.Closed}[Closed]}, [Some []],
             - [[< `A|`B > `X `Y ]]
-                 when [flag] is {{!Asttypes.Closed}[Closed]}
-                  and [labels] is [Some ["X";"Y"]].
+                 when [flag],                       [labels]
+                   is {{!Asttypes.Closed}[Closed]}, [Some ["X";"Y"]].
          *)
   | Ptyp_poly of string loc list * core_type
         (** Represents ['a1 ... 'an. T]

--- a/parsing/parsetree.mli
+++ b/parsing/parsetree.mli
@@ -477,7 +477,7 @@ and type_declaration =
     {
      ptype_name: string loc;
      ptype_params: (core_type * (variance * injectivity)) list;
-           (** [('a1,...'an) t; None] represents  [_]*)
+           (** [('a1,...'an) t] *)
      ptype_cstrs: (core_type * core_type * Location.t) list;
            (** [... constraint T1=T1'  ... constraint Tn=Tn'] *)
      ptype_kind: type_kind;

--- a/parsing/parsetree.mli
+++ b/parsing/parsetree.mli
@@ -313,8 +313,8 @@ and expression_desc =
                        and [exp0] is [Some E0]
 
            Notes:
-           - If [E0] is provided, only {{!Asttypes.arg_label.Optional}[Optional]}
-             is allowed.
+           - If [E0] is provided, only
+             {{!Asttypes.arg_label.Optional}[Optional]} is allowed.
            - [fun P1 P2 .. Pn -> E1] is represented as nested
              {{!expression_desc.Pexp_fun}[Pexp_fun]}.
            - [let f P = E] is represented using
@@ -897,7 +897,7 @@ and 'a open_infos =
      popen_loc: Location.t;
      popen_attributes: attributes;
     }
-(** Values of type [’a open_infos] represents:
+(** Values of type ['a open_infos] represents:
     - [open! X] when {{!open_infos.popen_override}[popen_override]}
                   is {{!Asttypes.override_flag.Override}[Override]}
     (silences the "used identifier shadowing" warning)

--- a/parsing/parsetree.mli
+++ b/parsing/parsetree.mli
@@ -582,22 +582,22 @@ and type_exception =
 
 and extension_constructor_kind =
   | Pext_decl of string loc list * constructor_arguments * core_type option
-      (** [Pext_decl(l_vars, c_args, t_opt)]
+      (** [Pext_decl(existentials, c_args, t_opt)]
           describes a new extension constructor. It can be:
           - [C of T1 * ... * Tn] when:
-               {ul {- [l_vars] is [[]],}
+               {ul {- [existentials] is [[]],}
                    {- [c_args] is [[T1; ...; Tn]],}
                    {- [t_opt] is [None]}.}
           - [C: T0] when
-               {ul {- [l_vars] is [[]],}
+               {ul {- [existentials] is [[]],}
                    {- [c_args] is [[]],}
                    {- [t_opt] is [Some T0].}}
           - [C: T1 * ... * Tn -> T0] when
-               {ul {- [l_vars] is [[]],}
+               {ul {- [existentials] is [[]],}
                    {- [c_args] is [[T1; ...; Tn]],}
                    {- [t_opt] is [Some T0].}}
           - [C: 'a... . T1 * ... * Tn -> T0] when
-               {ul {- [l_vars] is [['a;...]],}
+               {ul {- [existentials] is [['a;...]],}
                    {- [c_args] is [[T1; ... ; Tn]],}
                    {- [t_opt] is [Some T0].}}
        *)

--- a/parsing/parsetree.mli
+++ b/parsing/parsetree.mli
@@ -24,20 +24,20 @@ open Asttypes
 
 type constant =
     Pconst_integer of string * char option
-  (** Represents integer constants such as [3] [3l] [3L] [3n].
+  (** Integer constants such as [3] [3l] [3L] [3n].
 
      Suffixes [[g-z][G-Z]] are accepted by the parser.
      Suffixes except ['l'], ['L'] and ['n'] are rejected by the typechecker
   *)
   | Pconst_char of char
-  (** Represents a character such as ['c']. *)
+  (** Character such as ['c']. *)
   | Pconst_string of string * Location.t * string option
-  (** Represents a constant string such as ["constant"] or [{delim|other constant|delim}].
+  (** Constant string such as ["constant"] or [{delim|other constant|delim}].
 
      The location span the content of the string, without the delimiters.
   *)
   | Pconst_float of string * char option
-  (** Represents a float constant such as [3.4], [2e5] or [1.4e-4].
+  (** Float constant such as [3.4], [2e5] or [1.4e-4].
 
      Suffixes [g-z][G-Z] are accepted by the parser.
      Suffixes are rejected by the typechecker.
@@ -52,14 +52,14 @@ type attribute = {
     attr_payload : payload;
     attr_loc : Location.t;
   }
-       (** Represents attributes such as [[\@id ARG]] and [[\@\@id ARG]].
+       (** Attributes such as [[\@id ARG]] and [[\@\@id ARG]].
 
           Metadata containers passed around within the AST.
           The compiler ignores unknown attributes.
        *)
 
 and extension = string loc * payload
-      (** Represents extension points such as [[%id ARG] and [%%id ARG]].
+      (** Extension points such as [[%id ARG] and [%%id ARG]].
 
          Sub-language placeholder -- rejected by the typechecker.
       *)
@@ -69,11 +69,11 @@ and attributes = attribute list
 and payload =
   | PStr of structure
   | PSig of signature
-      (** Represents [: SIG] in an attribute or an extension point *)
+      (** [: SIG] in an attribute or an extension point *)
   | PTyp of core_type
-      (** Represents [: T] in an attribute or an extension point *)
+      (** [: T] in an attribute or an extension point *)
   | PPat of pattern * expression option
-      (** Represents [? P]  or  [? P when E], in an attribute or an extension point *)
+      (** [? P]  or  [? P when E], in an attribute or an extension point *)
 
 (** {1 Core language} *)
 
@@ -89,9 +89,9 @@ and core_type =
 
 and core_type_desc =
   | Ptyp_any
-        (** Represents [_] *)
+        (** [_] *)
   | Ptyp_var of string
-        (** Represents a type var such as ['a] *)
+        (** A type var such as ['a] *)
   | Ptyp_arrow of arg_label * core_type * core_type
         (** [Ptyp_arrow(lbl, T1, T2)] represents:
             - [T1 -> T2]    when [lbl] is  {{!Asttypes.Nolabel}[Nolabel]},
@@ -123,7 +123,7 @@ and core_type_desc =
             - [(T1, ..., Tn) #tconstr] when [l=[T1 ; ... ; Tn]].
          *)
   | Ptyp_alias of core_type * string
-        (** Represents [T as 'a]. *)
+        (** [T as 'a]. *)
   | Ptyp_variant of row_field list * closed_flag * label list option
         (** [Ptyp_variant([`A;`B], flag, labels)] represents:
             - [[ `A|`B ]]
@@ -140,7 +140,7 @@ and core_type_desc =
                    is {{!Asttypes.Closed}[Closed]}, [Some ["X";"Y"]].
          *)
   | Ptyp_poly of string loc list * core_type
-        (** Represents ['a1 ... 'an. T]
+        (** ['a1 ... 'an. T]
 
            Can only appear in the following context:
 
@@ -161,9 +161,9 @@ and core_type_desc =
            - As the {!pval_type} field of a {!value_description}.
          *)
   | Ptyp_package of package_type
-        (** Represents [(module S)]. *)
+        (** [(module S)]. *)
   | Ptyp_extension of extension
-        (** Represents [[%id]]. *)
+        (** [[%id]]. *)
 
 and package_type = Longident.t loc * (Longident.t loc * core_type) list
       (** As {!package_type} typed values:
@@ -192,7 +192,7 @@ and row_field_desc =
             (see 4.2 in the manual)
         *)
   | Rinherit of core_type
-        (** Represents [[ | t ]] *)
+        (** [[ | t ]] *)
 
 and object_field = {
   pof_desc : object_field_desc;
@@ -216,21 +216,20 @@ and pattern =
 
 and pattern_desc =
   | Ppat_any
-        (** Represents the pattern [_]. *)
+        (** The pattern [_]. *)
   | Ppat_var of string loc
-        (** Represents the variable pattern such as [x] *)
+        (** The variable pattern such as [x] *)
   | Ppat_alias of pattern * string loc
         (** [Ppat_alias] represents patterns such as [P as 'a] *)
   | Ppat_constant of constant
-        (** Represents patterns
-            such as [1], ['a'], ["true"], [1.0], [1l], [1L], [1n] *)
+        (** Patterns such as [1], ['a'], ["true"], [1.0], [1l], [1L], [1n] *)
   | Ppat_interval of constant * constant
-        (** Represents patterns such as ['a'..'z'].
+        (** Patterns such as ['a'..'z'].
 
            Other forms of interval are recognized by the parser
            but rejected by the type-checker. *)
   | Ppat_tuple of pattern list
-        (** Represents patterns [(P1, ..., Pn)].
+        (** Patterns [(P1, ..., Pn)].
 
            Invariant: [n >= 2]
         *)
@@ -257,15 +256,15 @@ and pattern_desc =
            Invariant: [n > 0]
          *)
   | Ppat_array of pattern list
-        (** Represents pattern [[| P1; ...; Pn |]] *)
+        (** Pattern [[| P1; ...; Pn |]] *)
   | Ppat_or of pattern * pattern
-        (** Represents pattern [P1 | P2] *)
+        (** Pattern [P1 | P2] *)
   | Ppat_constraint of pattern * core_type
-        (** Represents pattern [(P : T)] *)
+        (** Pattern [(P : T)] *)
   | Ppat_type of Longident.t loc
-        (** Represents pattern [#tconst] *)
+        (** Pattern [#tconst] *)
   | Ppat_lazy of pattern
-        (** Represents pattern [lazy P] *)
+        (** Pattern [lazy P] *)
   | Ppat_unpack of string option loc
         (** [Ppat_unpack(s)] represents:
             - [(module P)] when [s] is [Some "P"]
@@ -275,11 +274,11 @@ and pattern_desc =
            [Ppat_constraint(Ppat_unpack(Some "P"), Ptyp_package S)]
          *)
   | Ppat_exception of pattern
-        (** Represents pattern [exception P] *)
+        (** Pattern [exception P] *)
   | Ppat_extension of extension
-        (** Represents pattern [[%id]] *)
+        (** Pattern [[%id]] *)
   | Ppat_open of Longident.t loc * pattern
-        (** Represents pattern [M.(P)] *)
+        (** Pattern [M.(P)] *)
 
 (** {2 Value expressions} *)
 
@@ -293,11 +292,11 @@ and expression =
 
 and expression_desc =
   | Pexp_ident of Longident.t loc
-        (** Represents identifiers such as [x] and [M.x]
+        (** Identifiers such as [x] and [M.x]
          *)
   | Pexp_constant of constant
-        (** Represents expressions constant
-            such as [1], ['a'], ["true"], [1.0], [1l], [1L], [1n] *)
+        (** Expressions constant such as [1], ['a'], ["true"], [1.0], [1l],
+            [1L], [1n] *)
   | Pexp_let of rec_flag * value_binding list * expression
         (** [Pexp_let(flag, [(P1,E1) ; ... ; (Pn,En)], E)] represents:
             - [let P1 = E1 and ... and Pn = EN in E]
@@ -306,7 +305,7 @@ and expression_desc =
                  when [flag] is {{!Asttypes.Recursive}[Recursive]}.
          *)
   | Pexp_function of case list
-        (** Represents [function P1 -> E1 | ... | Pn -> En] *)
+        (** [function P1 -> E1 | ... | Pn -> En] *)
   | Pexp_fun of arg_label * expression option * pattern * expression
         (** [Pexp_fun(lbl, exp1, pat, expr2)] represents:
             - [fun P -> E1]     when [lbl] is {{!Asttypes.Nolabel}[Nolabel]}
@@ -336,11 +335,11 @@ and expression_desc =
            Invariant: [n > 0]
          *)
   | Pexp_match of expression * case list
-        (** Represents [match E0 with P1 -> E1 | ... | Pn -> En] *)
+        (** [match E0 with P1 -> E1 | ... | Pn -> En] *)
   | Pexp_try of expression * case list
-        (** Represents [try E0 with P1 -> E1 | ... | Pn -> En] *)
+        (** [try E0 with P1 -> E1 | ... | Pn -> En] *)
   | Pexp_tuple of expression list
-        (** Represents expressions [(E1, ..., En)]
+        (** Expressions [(E1, ..., En)]
 
            Invariant: [n >= 2]
         *)
@@ -363,78 +362,76 @@ and expression_desc =
            Invariant: [n > 0]
          *)
   | Pexp_field of expression * Longident.t loc
-        (** Represents [E.l] *)
+        (** [E.l] *)
   | Pexp_setfield of expression * Longident.t loc * expression
-        (** Represents [E1.l <- E2] *)
+        (** [E1.l <- E2] *)
   | Pexp_array of expression list
-        (** Represents [[| E1; ...; En |]] *)
+        (** [[| E1; ...; En |]] *)
   | Pexp_ifthenelse of expression * expression * expression option
-        (** Represents [if E1 then E2 else E3] *)
+        (** [if E1 then E2 else E3] *)
   | Pexp_sequence of expression * expression
-        (** Represents [E1; E2] *)
+        (** [E1; E2] *)
   | Pexp_while of expression * expression
-        (** Represents [while E1 do E2 done] *)
+        (** [while E1 do E2 done] *)
   | Pexp_for of
       pattern * expression * expression * direction_flag * expression
-        (** Represents:
+        (** [Pexp_for(i, E1, E2, direction, E3)] represents:
             - [for i = E1 to E2 do E3 done]
-                                     when [flag] is {{!Asttypes.Upto}[Upto]}
+                                when [direction] is {{!Asttypes.Upto}[Upto]}
             - [for i = E1 downto E2 do E3 done]
-                                     when [flag] is {{!Asttypes.Downto}[Downto]}
+                                when [direction] is {{!Asttypes.Downto}[Downto]}
          *)
   | Pexp_constraint of expression * core_type
-        (** Represents [(E : T)] *)
+        (** [(E : T)] *)
   | Pexp_coerce of expression * core_type option * core_type
         (** [Pexp_coerce(E, from, T)] represents
             - [(E :> T)]      when [from] is [None],
             - [(E : T0 :> T)] when [from] is [Some T0].
          *)
   | Pexp_send of expression * label loc
-        (** Represents [E # m] *)
+        (** [E # m] *)
   | Pexp_new of Longident.t loc
-        (** Represents [new M.c] *)
+        (** [new M.c] *)
   | Pexp_setinstvar of label loc * expression
-        (** Represents [x <- 2] *)
+        (** [x <- 2] *)
   | Pexp_override of (label loc * expression) list
-        (** Represents [{< x1 = E1; ...; Xn = En >}] *)
+        (** [{< x1 = E1; ...; Xn = En >}] *)
   | Pexp_letmodule of string option loc * module_expr * expression
-        (** Represents [let module M = ME in E] *)
+        (** [let module M = ME in E] *)
   | Pexp_letexception of extension_constructor * expression
-        (** Represents [let exception C in E] *)
+        (** [let exception C in E] *)
   | Pexp_assert of expression
-        (** Represents [assert E].
+        (** [assert E].
 
            Note: [assert false] is treated in a special way by the
            type-checker. *)
   | Pexp_lazy of expression
-        (** Represents [lazy E] *)
+        (** [lazy E] *)
   | Pexp_poly of expression * core_type option
         (** Used for method bodies.
 
            Can only be used as the expression under {!Cfk_concrete}
            for methods (not values). *)
   | Pexp_object of class_structure
-        (** Represents [object ... end] *)
+        (** [object ... end] *)
   | Pexp_newtype of string loc * expression
-        (** Represents [fun (type t) -> E] *)
+        (** [fun (type t) -> E] *)
   | Pexp_pack of module_expr
-        (** Represents [(module ME)].
+        (** [(module ME)].
 
            [(module ME : S)] is represented as
            [Pexp_constraint(Pexp_pack ME, Ptyp_package S)] *)
   | Pexp_open of open_declaration * expression
-        (** Represents:
-            - [M.(E)]
+        (** - [M.(E)]
             - [let open M in E]
             - [let open! M in E] *)
   | Pexp_letop of letop
-        (** Represents:
-            - [let* P = E0 in E1]
+        (** - [let* P = E0 in E1]
             - [let* P0 = E00 and* P1 = E01 in E1] *)
   | Pexp_extension of extension
-        (** Represents [[%id]] *)
+        (** [[%id]] *)
   | Pexp_unreachable
-        (** Represents [.] *)
+        (** [.] *)
 
 and case =
     {
@@ -482,7 +479,7 @@ and type_declaration =
      ptype_params: (core_type * (variance * injectivity)) list;
            (** [('a1,...'an) t; None] represents  [_]*)
      ptype_cstrs: (core_type * core_type * Location.t) list;
-           (** Represents [... constraint T1=T1'  ... constraint Tn=Tn'] *)
+           (** [... constraint T1=T1'  ... constraint Tn=Tn'] *)
      ptype_kind: type_kind;
      ptype_private: private_flag;
            (** for [= private ...] *)
@@ -631,11 +628,10 @@ and class_type =
 
 and class_type_desc =
   | Pcty_constr of Longident.t loc * core_type list
-        (** Represents:
-      - [c]
-      - [['a1, ..., 'an] c] *)
+        (** - [c]
+            - [['a1, ..., 'an] c] *)
   | Pcty_signature of class_signature
-        (** Represents [object ... end] *)
+        (** [object ... end] *)
   | Pcty_arrow of arg_label * core_type * class_type
         (** [Pcty_arrow(lbl, T, CT)] represents:
             - [T -> CT]    when [lbl] is {{!Asttypes.Nolabel}[Nolabel]},
@@ -643,9 +639,9 @@ and class_type_desc =
             - [?l:T -> CT] when [lbl] is {{!Asttypes.Optional}[Optional l]}.
          *)
   | Pcty_extension of extension
-        (** Represents [%id] *)
+        (** [%id] *)
   | Pcty_open of open_description * class_type
-        (** Represents [let open M in CT] *)
+        (** [let open M in CT] *)
 
 and class_signature =
     {
@@ -666,20 +662,20 @@ and class_type_field =
 
 and class_type_field_desc =
   | Pctf_inherit of class_type
-        (** Represents [inherit CT] *)
+        (** [inherit CT] *)
   | Pctf_val of (label loc * mutable_flag * virtual_flag * core_type)
-        (** Represents [val x: T] *)
+        (** [val x: T] *)
   | Pctf_method of (label loc * private_flag * virtual_flag * core_type)
-        (** Represents [method x: T]
+        (** [method x: T]
 
             Note: [T] can be a {!Ptyp_poly}.
         *)
   | Pctf_constraint of (core_type * core_type)
-        (** Represents [constraint T1 = T2] *)
+        (** [constraint T1 = T2] *)
   | Pctf_attribute of attribute
-        (** Represents [[\@\@\@id]] *)
+        (** [[\@\@\@id]] *)
   | Pctf_extension of extension
-        (** Represents [[%%id]] *)
+        (** [[%%id]] *)
 
 and 'a class_infos =
     {
@@ -713,9 +709,9 @@ and class_expr =
 
 and class_expr_desc =
   | Pcl_constr of Longident.t loc * core_type list
-        (** Represents [c] and [['a1, ..., 'an] c] *)
+        (** [c] and [['a1, ..., 'an] c] *)
   | Pcl_structure of class_structure
-        (** Represents [object ... end] *)
+        (** [object ... end] *)
   | Pcl_fun of arg_label * expression option * pattern * class_expr
         (** [Pcl_fun(lbl, exp, P, CE)] represents:
             - [fun P -> CE]     when [lbl] is {{!Asttypes.Nolabel}[Nolabel]}
@@ -737,18 +733,18 @@ and class_expr_desc =
             Invariant: [n > 0]
         *)
   | Pcl_let of rec_flag * value_binding list * class_expr
-        (** Represents:
+        (** [Pcl_let(rec, [(P1, E1); ... ; (Pn, En)], CE)] represents:
             - [let P1 = E1 and ... and Pn = EN in CE]
-                        when [flag] is {{!Asttypes.Nonrecursive}[Nonrecursive]},
+                         when [rec] is {{!Asttypes.Nonrecursive}[Nonrecursive]},
             - [let rec P1 = E1 and ... and Pn = EN in CE]
-                        when [flag] is {{!Asttypes.Recursive}[Recursive]}.
+                         when [rec] is {{!Asttypes.Recursive}[Recursive]}.
         *)
   | Pcl_constraint of class_expr * class_type
-        (** Represents [(CE : CT)] *)
+        (** [(CE : CT)] *)
   | Pcl_extension of extension
-        (** Represents [[%id]] *)
+        (** [[%id]] *)
   | Pcl_open of open_description * class_expr
-        (** Represents [let open M in CE] *)
+        (** [let open M in CE] *)
 
 and class_structure =
     {
@@ -795,18 +791,17 @@ and class_field_desc =
                          and [kind] is {{!Cfk_concrete}[Cfk_virtual(T)]}
   *)
   | Pcf_method of (label loc * private_flag * class_field_kind)
-        (** Represents:
-            - [method x = E]            ([E] can be a {!Pexp_poly})
+        (** - [method x = E]            ([E] can be a {!Pexp_poly})
             - [method virtual x: T]     ([T] can be a {!Ptyp_poly})
   *)
   | Pcf_constraint of (core_type * core_type)
-        (** Represents [constraint T1 = T2] *)
+        (** [constraint T1 = T2] *)
   | Pcf_initializer of expression
-        (** Represents [initializer E] *)
+        (** [initializer E] *)
   | Pcf_attribute of attribute
-        (** Represents [[\@\@\@id]] *)
+        (** [[\@\@\@id]] *)
   | Pcf_extension of extension
-        (** Represents [[%%id]] *)
+        (** [[%%id]] *)
 
 and class_field_kind =
   | Cfk_virtual of core_type
@@ -829,21 +824,21 @@ and module_type_desc =
   | Pmty_ident of Longident.t loc
         (** [Pmty_ident(S)] represents [S] *)
   | Pmty_signature of signature
-        (** Represents [sig ... end] *)
+        (** [sig ... end] *)
   | Pmty_functor of functor_parameter * module_type
-        (** Represents [functor(X : MT1) -> MT2] *)
+        (** [functor(X : MT1) -> MT2] *)
   | Pmty_with of module_type * with_constraint list
-        (** Represents [MT with ...] *)
+        (** [MT with ...] *)
   | Pmty_typeof of module_expr
-        (** Represents [module type of ME] *)
+        (** [module type of ME] *)
   | Pmty_extension of extension
-        (** Represents [[%id]] *)
+        (** [[%id]] *)
   | Pmty_alias of Longident.t loc
-        (** Represents [(module M)] *)
+        (** [(module M)] *)
 
 and functor_parameter =
   | Unit
-        (** Represents [()] *)
+        (** [()] *)
   | Named of string option loc * module_type
         (** [Named(name, MT)] represents:
             - [(X : MT)] when [name] is [Some X],
@@ -859,40 +854,39 @@ and signature_item =
 
 and signature_item_desc =
   | Psig_value of value_description
-        (** Represents:
-            - [val x: T]
+        (** - [val x: T]
             - [external x: T = "s1" ... "sn"]
          *)
   | Psig_type of rec_flag * type_declaration list
-        (** Represents [type t1 = ... and ... and tn  = ...] *)
+        (** [type t1 = ... and ... and tn  = ...] *)
   | Psig_typesubst of type_declaration list
-        (** Represents [type t1 := ... and ... and tn := ...]  *)
+        (** [type t1 := ... and ... and tn := ...]  *)
   | Psig_typext of type_extension
-        (** Represents [type t1 += ...] *)
+        (** [type t1 += ...] *)
   | Psig_exception of type_exception
-        (** Represents [exception C of T] *)
+        (** [exception C of T] *)
   | Psig_module of module_declaration
-        (** Represents [module X = M] and [module X : MT] *)
+        (** [module X = M] and [module X : MT] *)
   | Psig_modsubst of module_substitution
-        (** Represents [module X := M] *)
+        (** [module X := M] *)
   | Psig_recmodule of module_declaration list
-        (** Represents [module rec X1 : MT1 and ... and Xn : MTn] *)
+        (** [module rec X1 : MT1 and ... and Xn : MTn] *)
   | Psig_modtype of module_type_declaration
-        (** Represents [module type S = MT] and [module type S] *)
+        (** [module type S = MT] and [module type S] *)
   | Psig_modtypesubst of module_type_declaration
-        (** Represents [module type S :=  ...]  *)
+        (** [module type S :=  ...]  *)
   | Psig_open of open_description
-        (** Represents [open X] *)
+        (** [open X] *)
   | Psig_include of include_description
-        (** Represents [include MT] *)
+        (** [include MT] *)
   | Psig_class of class_description list
-        (** Represents [class c1 : ... and ... and cn : ...] *)
+        (** [class c1 : ... and ... and cn : ...] *)
   | Psig_class_type of class_type_declaration list
-        (** Represents [class type ct1 = ... and ... and ctn = ...] *)
+        (** [class type ct1 = ... and ... and ctn = ...] *)
   | Psig_attribute of attribute
-        (** Represents [[\@\@\@id]] *)
+        (** [[\@\@\@id]] *)
   | Psig_extension of extension * attributes
-        (** Represents [[%%id]] *)
+        (** [[%%id]] *)
 
 and module_declaration =
     {
@@ -963,20 +957,20 @@ and include_declaration = module_expr include_infos
 
 and with_constraint =
   | Pwith_type of Longident.t loc * type_declaration
-        (** Represents [with type X.t = ...]
+        (** [with type X.t = ...]
 
             Note: the last component of the longident must match
             the name of the type_declaration. *)
   | Pwith_module of Longident.t loc * Longident.t loc
-        (** Represents [with module X.Y = Z] *)
+        (** [with module X.Y = Z] *)
   | Pwith_modtype of Longident.t loc * module_type
-        (** Represents [with module type X.Y = Z] *)
+        (** [with module type X.Y = Z] *)
   | Pwith_modtypesubst of Longident.t loc * module_type
-        (** Represents [with module type X.Y := sig end] *)
+        (** [with module type X.Y := sig end] *)
   | Pwith_typesubst of Longident.t loc * type_declaration
-        (** Represents [with type X.t := ..., same format as [Pwith_type]] *)
+        (** [with type X.t := ..., same format as [Pwith_type]] *)
   | Pwith_modsubst of Longident.t loc * Longident.t loc
-        (** Represents [with module X.Y := Z] *)
+        (** [with module X.Y := Z] *)
 
 (** {2 Value expressions for the module language} *)
 
@@ -989,19 +983,19 @@ and module_expr =
 
 and module_expr_desc =
   | Pmod_ident of Longident.t loc
-        (** Represents [X] *)
+        (** [X] *)
   | Pmod_structure of structure
-        (** Represents [struct ... end] *)
+        (** [struct ... end] *)
   | Pmod_functor of functor_parameter * module_expr
-        (** Represents [functor(X : MT1) -> ME] *)
+        (** [functor(X : MT1) -> ME] *)
   | Pmod_apply of module_expr * module_expr
-        (** Represents [ME1(ME2)] *)
+        (** [ME1(ME2)] *)
   | Pmod_constraint of module_expr * module_type
-        (** Represents [(ME : MT)] *)
+        (** [(ME : MT)] *)
   | Pmod_unpack of expression
-        (** Represents [(val E)] *)
+        (** [(val E)] *)
   | Pmod_extension of extension
-        (** Represents [[%id]] *)
+        (** [[%id]] *)
 
 and structure = structure_item list
 
@@ -1013,44 +1007,42 @@ and structure_item =
 
 and structure_item_desc =
   | Pstr_eval of expression * attributes
-        (** Represents [E] *)
+        (** [E] *)
   | Pstr_value of rec_flag * value_binding list
-        (** Represents:
+        (** [Pstr_value(rec, [(P1, E1 ; ... ; (Pn, En))])] represents:
             - [let P1 = E1 and ... and Pn = EN]
-                        when [flag] is {{!Asttypes.Nonrecursive}[Nonrecursive]},
+                         when [rec] is {{!Asttypes.Nonrecursive}[Nonrecursive]},
             - [let rec P1 = E1 and ... and Pn = EN ]
-                        when [flag] is {{!Asttypes.Recursive}[Recursive]}.
+                         when [rec] is {{!Asttypes.Recursive}[Recursive]}.
         *)
   | Pstr_primitive of value_description
-        (** Represents:
-            - [val x: T]
+        (** - [val x: T]
             - [external x: T = "s1" ... "sn" ]*)
   | Pstr_type of rec_flag * type_declaration list
-        (** Represents [type t1 = ... and ... and tn = ...] *)
+        (** [type t1 = ... and ... and tn = ...] *)
   | Pstr_typext of type_extension
-        (** Represents [type t1 += ...] *)
+        (** [type t1 += ...] *)
   | Pstr_exception of type_exception
-        (** Represents:
-            - [exception C of T]
+        (** - [exception C of T]
             - [exception C = M.X] *)
   | Pstr_module of module_binding
-        (** Represents [module X = ME] *)
+        (** [module X = ME] *)
   | Pstr_recmodule of module_binding list
-        (** Represents [module rec X1 = ME1 and ... and Xn = MEn] *)
+        (** [module rec X1 = ME1 and ... and Xn = MEn] *)
   | Pstr_modtype of module_type_declaration
-        (** Represents [module type S = MT] *)
+        (** [module type S = MT] *)
   | Pstr_open of open_declaration
-        (** Represents [open X] *)
+        (** [open X] *)
   | Pstr_class of class_declaration list
-        (** Represents [class c1 = ... and ... and cn = ...] *)
+        (** [class c1 = ... and ... and cn = ...] *)
   | Pstr_class_type of class_type_declaration list
-        (** Represents [class type ct1 = ... and ... and ctn = ...] *)
+        (** [class type ct1 = ... and ... and ctn = ...] *)
   | Pstr_include of include_declaration
-        (** Represents [include ME] *)
+        (** [include ME] *)
   | Pstr_attribute of attribute
-        (** Represents [[\@\@\@id]] *)
+        (** [[\@\@\@id]] *)
   | Pstr_extension of extension * attributes
-        (** Represents [[%%id]] *)
+        (** [[%%id]] *)
 
 and value_binding =
   {
@@ -1076,7 +1068,7 @@ and module_binding =
 type toplevel_phrase =
   | Ptop_def of structure
   | Ptop_dir of toplevel_directive
-     (** Represents [#use], [#load] ... *)
+     (** [#use], [#load] ... *)
 
 and toplevel_directive =
   {

--- a/parsing/parsetree.mli
+++ b/parsing/parsetree.mli
@@ -24,21 +24,20 @@ open Asttypes
 
 type constant =
     Pconst_integer of string * char option
-  (* 3 3l 3L 3n
+  (** Represents integer constants such as [3] [3l] [3L] [3n].
 
-     Suffixes [g-z][G-Z] are accepted by the parser.
-     Suffixes except 'l', 'L' and 'n' are rejected by the typechecker
+     Suffixes [[g-z][G-Z]] are accepted by the parser.
+     Suffixes except ['l'], ['L'] and ['n'] are rejected by the typechecker
   *)
   | Pconst_char of char
-  (* 'c' *)
+  (** Represents a character such as ['c']. *)
   | Pconst_string of string * Location.t * string option
-  (* "constant"
-     {delim|other constant|delim}
+  (** Represents a constant string such as ["constant"] or [{delim|other constant|delim}].
 
      The location span the content of the string, without the delimiters.
   *)
   | Pconst_float of string * char option
-  (* 3.4 2e5 1.4e-4
+  (** Represents a float constant such as [3.4], [2e5] or [1.4e-4].
 
      Suffixes [g-z][G-Z] are accepted by the parser.
      Suffixes are rejected by the typechecker.
@@ -53,16 +52,14 @@ type attribute = {
     attr_payload : payload;
     attr_loc : Location.t;
   }
-       (* [@id ARG]
-          [@@id ARG]
+       (** Represents attributes such as [[\@id ARG]] and [[\@\@id ARG]].
 
           Metadata containers passed around within the AST.
           The compiler ignores unknown attributes.
        *)
 
 and extension = string loc * payload
-      (* [%id ARG]
-         [%%id ARG]
+      (** Represents extension points such as [[%id ARG] and [%%id ARG]].
 
          Sub-language placeholder -- rejected by the typechecker.
       *)
@@ -71,90 +68,108 @@ and attributes = attribute list
 
 and payload =
   | PStr of structure
-  | PSig of signature (* : SIG *)
-  | PTyp of core_type  (* : T *)
-  | PPat of pattern * expression option  (* ? P  or  ? P when E *)
+  | PSig of signature
+      (** Represents [: SIG] in an attribute or an extension point *)
+  | PTyp of core_type
+      (** Represents [: T] in an attribute or an extension point *)
+  | PPat of pattern * expression option
+      (** Represents [? P]  or  [? P when E], in an attribute or an extension point *)
 
 (** {1 Core language} *)
 
-(* Type expressions *)
+(** {2 Type expressions} *)
 
 and core_type =
     {
      ptyp_desc: core_type_desc;
      ptyp_loc: Location.t;
      ptyp_loc_stack: location_stack;
-     ptyp_attributes: attributes; (* ... [@id1] [@id2] *)
+     ptyp_attributes: attributes;  (** [... [\@id1] [\@id2]] *)
     }
 
 and core_type_desc =
   | Ptyp_any
-        (*  _ *)
+        (** Represents [_] *)
   | Ptyp_var of string
-        (* 'a *)
+        (** Represents a type var such as ['a] *)
   | Ptyp_arrow of arg_label * core_type * core_type
-        (* T1 -> T2       Simple
-           ~l:T1 -> T2    Labelled
-           ?l:T1 -> T2    Optional
+        (** [Ptyp_arrow(lbl, T1, T2)] represents:
+            - [T1 -> T2]    when [lbl] is  {{!Asttypes.Nolabel}[Nolabel]},
+            - [~l:T1 -> T2] when [lbl] is {{!Asttypes.Labelled}[Labelled]},
+            - [?l:T1 -> T2] when [lbl] is {{!Asttypes.Optional}[Optional]}.
          *)
   | Ptyp_tuple of core_type list
-        (* T1 * ... * Tn
+        (** [Ptyp_tuple([T1 ; ... ; Tn])] represents a product type [T1 * ... * Tn].
 
-           Invariant: n >= 2
+           Invariant: [n >= 2].
         *)
   | Ptyp_constr of Longident.t loc * core_type list
-        (* tconstr
-           T tconstr
-           (T1, ..., Tn) tconstr
+        (** [Ptyp_constr(loc, l)] represents:
+            - [tconstr]               when [l=[]],
+            - [T tconstr]             when [l=[T]],
+            - [(T1, ..., Tn) tconstr] when [l=[T1 ; ... ; Tn]].
          *)
   | Ptyp_object of object_field list * closed_flag
-        (* < l1:T1; ...; ln:Tn >     (flag = Closed)
-           < l1:T1; ...; ln:Tn; .. > (flag = Open)
+        (** [Ptyp_object([ l1:T1; ...; ln:Tn ], flag)] Represents:
+            - [< l1:T1; ...; ln:Tn >]
+                                    when [flag] is {{!Asttypes.Closed}[Closed]},
+            - [< l1:T1; ...; ln:Tn; .. >]
+                                    when [flag] is   {{!Asttypes.Open}[Open]}.
          *)
   | Ptyp_class of Longident.t loc * core_type list
-        (* #tconstr
-           T #tconstr
-           (T1, ..., Tn) #tconstr
+        (** [Ptyp_class(tconstr, l)] represents:
+            - [#tconstr]               when [l=[]],
+            - [T #tconstr]             when [l=[T]],
+            - [(T1, ..., Tn) #tconstr] when [l=[T1 ; ... ; Tn]].
          *)
   | Ptyp_alias of core_type * string
-        (* T as 'a *)
+        (** Represents [T as 'a]. *)
   | Ptyp_variant of row_field list * closed_flag * label list option
-        (* [ `A|`B ]         (flag = Closed; labels = None)
-           [> `A|`B ]        (flag = Open;   labels = None)
-           [< `A|`B ]        (flag = Closed; labels = Some [])
-           [< `A|`B > `X `Y ](flag = Closed; labels = Some ["X";"Y"])
+        (** [Ptyp_variant([`A;`B], flag, labels)]Represents:
+            - [[ `A|`B ]]
+                 when [flag]   is {{!Asttypes.Closed}[Closed]}
+                  and [labels] is [None],
+            - [[> `A|`B ]]
+                 when [flag]   is {{!Asttypes.Open}[Open]}
+                  and [labels] is [None],
+            - [[< `A|`B ]]
+                 when [flag]   is {{!Asttypes.Closed}[Closed]}
+                  and [labels] is [Some []],
+            - [[< `A|`B > `X `Y ]]
+                 when [flag] is {{!Asttypes.Closed}[Closed]}
+                  and [labels] is [Some ["X";"Y"]].
          *)
   | Ptyp_poly of string loc list * core_type
-        (* 'a1 ... 'an. T
+        (** Represents ['a1 ... 'an. T]
 
            Can only appear in the following context:
 
-           - As the core_type of a Ppat_constraint node corresponding
-             to a constraint on a let-binding: let x : 'a1 ... 'an. T
-             = e ...
+           - As the {!core_type} of a {!Ppat_constraint} node corresponding
+             to a constraint on a let-binding:
+            {[let x : 'a1 ... 'an. T = e ...]}
 
-           - Under Cfk_virtual for methods (not values).
+           - Under {!Cfk_virtual} for methods (not values).
 
-           - As the core_type of a Pctf_method node.
+           - As the {!core_type} of a {!Pctf_method} node.
 
-           - As the core_type of a Pexp_poly node.
+           - As the {!core_type} of a {!Pexp_poly} node.
 
-           - As the pld_type field of a label_declaration.
+           - As the {!pld_type} field of a {!label_declaration}.
 
-           - As a core_type of a Ptyp_object node.
+           - As a {!core_type} of a {!Ptyp_object} node.
 
-           - As the pval_type field of a value_description.
+           - As the {!pval_type} field of a {!value_description}.
          *)
-
   | Ptyp_package of package_type
-        (* (module S) *)
+        (** Represents [(module S)]. *)
   | Ptyp_extension of extension
-        (* [%id] *)
+        (** Represents [[%id]]. *)
 
 and package_type = Longident.t loc * (Longident.t loc * core_type) list
-      (*
-        (module S)
-        (module S with type t1 = T1 and ... and tn = Tn)
+      (** As {!package_type} typed values:
+         - [(S, [])] represents [(module S)],
+         - [(S, [(t1, T1) ; ... ; (tn, Tn)])]
+          represents [(module S with type t1 = T1 and ... and tn = Tn)].
        *)
 
 and row_field = {
@@ -165,18 +180,19 @@ and row_field = {
 
 and row_field_desc =
   | Rtag of label loc * bool * core_type list
-        (* [`A]                   ( true,  [] )
-           [`A of T]              ( false, [T] )
-           [`A of T1 & .. & Tn]   ( false, [T1;...Tn] )
-           [`A of & T1 & .. & Tn] ( true,  [T1;...Tn] )
+        (** [Rtag(`A, b, l)] represents:
+           - [`A]                   when [b] is [true]  and [l] is [[]],
+           - [`A of T]              when [b] is [false] and [l] is [[T]],
+           - [`A of T1 & .. & Tn]   when [b] is [false] and [l] is [[T1;...Tn]],
+           - [`A of & T1 & .. & Tn] when [b] is [true]  and [l] is [[T1;...Tn]].
 
-          - The 'bool' field is true if the tag contains a
+          - The [bool] field is true if the tag contains a
             constant (empty) constructor.
-          - '&' occurs when several types are used for the same constructor
+          - [&] occurs when several types are used for the same constructor
             (see 4.2 in the manual)
         *)
   | Rinherit of core_type
-        (* [ | t ] *)
+        (** Represents [[ | t ]] *)
 
 and object_field = {
   pof_desc : object_field_desc;
@@ -188,214 +204,245 @@ and object_field_desc =
   | Otag of label loc * core_type
   | Oinherit of core_type
 
-(* Patterns *)
+(** {2 Patterns} *)
 
 and pattern =
     {
      ppat_desc: pattern_desc;
      ppat_loc: Location.t;
      ppat_loc_stack: location_stack;
-     ppat_attributes: attributes; (* ... [@id1] [@id2] *)
+     ppat_attributes: attributes;  (** [... [\@id1] [\@id2]] *)
     }
 
 and pattern_desc =
   | Ppat_any
-        (* _ *)
+        (** Represents the pattern [_]. *)
   | Ppat_var of string loc
-        (* x *)
+        (** Represents the variable pattern such as [x] *)
   | Ppat_alias of pattern * string loc
-        (* P as 'a *)
+        (** [Ppat_alias] represents patterns such as [P as 'a] *)
   | Ppat_constant of constant
-        (* 1, 'a', "true", 1.0, 1l, 1L, 1n *)
+        (** Represents patterns
+            such as [1], ['a'], ["true"], [1.0], [1l], [1L], [1n] *)
   | Ppat_interval of constant * constant
-        (* 'a'..'z'
+        (** Represents patterns such as ['a'..'z'].
 
            Other forms of interval are recognized by the parser
            but rejected by the type-checker. *)
   | Ppat_tuple of pattern list
-        (* (P1, ..., Pn)
+        (** Represents patterns [(P1, ..., Pn)].
 
-           Invariant: n >= 2
+           Invariant: [n >= 2]
         *)
   | Ppat_construct of
       Longident.t loc * (string loc list * pattern) option
-        (* C                    None
-           C P                  Some ([], P)
-           C (P1, ..., Pn)      Some ([], Ppat_tuple [P1; ...; Pn])
-           C (type a b) P       Some ([a; b], P)
+        (** [Ppat_construct(loc, c)] represents:
+            - [C]               when [c] is [None],
+            - [C P]             when [c] is [Some ([], P)]
+            - [C (P1, ..., Pn)] when [c] is [Some ([], Ppat_tuple [P1; ...; Pn])]
+            - [C (type a b) P]  when [c] is [Some ([a; b], P)]
          *)
   | Ppat_variant of label * pattern option
-        (* `A             (None)
-           `A P           (Some P)
+        (** [Ppat_variant(lbl, pat)] represents:
+            - [`A]   when [pat] is [None],
+            - [`A P] when [pat] is [Some P]
          *)
   | Ppat_record of (Longident.t loc * pattern) list * closed_flag
-        (* { l1=P1; ...; ln=Pn }     (flag = Closed)
-           { l1=P1; ...; ln=Pn; _}   (flag = Open)
+        (** [Ppat_record([(l1, P1) ; ... ; (ln, Pn)], flag)] represents:
+            - [{ l1=P1; ...; ln=Pn }]
+                 when [flag] is {{!Asttypes.Closed}[Closed]}
+            - [{ l1=P1; ...; ln=Pn; _}]
+                 when [flag] is {{!Asttypes.Open}[Open]}
 
-           Invariant: n > 0
+           Invariant: [n > 0]
          *)
   | Ppat_array of pattern list
-        (* [| P1; ...; Pn |] *)
+        (** Represents pattern [[| P1; ...; Pn |]] *)
   | Ppat_or of pattern * pattern
-        (* P1 | P2 *)
+        (** Represents pattern [P1 | P2] *)
   | Ppat_constraint of pattern * core_type
-        (* (P : T) *)
+        (** Represents pattern [(P : T)] *)
   | Ppat_type of Longident.t loc
-        (* #tconst *)
+        (** Represents pattern [#tconst] *)
   | Ppat_lazy of pattern
-        (* lazy P *)
+        (** Represents pattern [lazy P] *)
   | Ppat_unpack of string option loc
-        (* (module P)        Some "P"
-           (module _)        None
+        (** [Ppat_unpack(s)] represents:
+            - [(module P)] when [s] is [Some "P"]
+            - [(module _)] when [s] is [None]
 
-           Note: (module P : S) is represented as
-           Ppat_constraint(Ppat_unpack, Ptyp_package)
+           Note: [(module P : S)] is represented as
+           [Ppat_constraint(Ppat_unpack(Some "P"), Ptyp_package S)]
          *)
   | Ppat_exception of pattern
-        (* exception P *)
+        (** Represents pattern [exception P] *)
   | Ppat_extension of extension
-        (* [%id] *)
+        (** Represents pattern [[%id]] *)
   | Ppat_open of Longident.t loc * pattern
-        (* M.(P) *)
+        (** Represents pattern [M.(P)] *)
 
-(* Value expressions *)
+(** {2 Value expressions} *)
 
 and expression =
     {
      pexp_desc: expression_desc;
      pexp_loc: Location.t;
      pexp_loc_stack: location_stack;
-     pexp_attributes: attributes; (* ... [@id1] [@id2] *)
+     pexp_attributes: attributes;  (** [... [\@id1] [\@id2]] *)
     }
 
 and expression_desc =
   | Pexp_ident of Longident.t loc
-        (* x
-           M.x
+        (** Represents identifiers such as [x] and [M.x]
          *)
   | Pexp_constant of constant
-        (* 1, 'a', "true", 1.0, 1l, 1L, 1n *)
+        (** Represents expressions constant
+            such as [1], ['a'], ["true"], [1.0], [1l], [1L], [1n] *)
   | Pexp_let of rec_flag * value_binding list * expression
-        (* let P1 = E1 and ... and Pn = EN in E       (flag = Nonrecursive)
-           let rec P1 = E1 and ... and Pn = EN in E   (flag = Recursive)
+        (** [Pexp_let(flag, [(P1,E1) ; ... ; (Pn,En)], E)] represents:
+            - [let P1 = E1 and ... and Pn = EN in E]
+                 when [flag] is {{!Asttypes.Nonrecursive}[Nonrecursive]},
+            - [let rec P1 = E1 and ... and Pn = EN in E]
+                 when [flag] is {{!Asttypes.Recursive}[Recursive]}.
          *)
   | Pexp_function of case list
-        (* function P1 -> E1 | ... | Pn -> En *)
+        (** Represents [function P1 -> E1 | ... | Pn -> En] *)
   | Pexp_fun of arg_label * expression option * pattern * expression
-        (* fun P -> E1                          (Simple, None)
-           fun ~l:P -> E1                       (Labelled l, None)
-           fun ?l:P -> E1                       (Optional l, None)
-           fun ?l:(P = E0) -> E1                (Optional l, Some E0)
+        (** [Pexp_fun(lbl, exp1, pat, expr2)] represents:
+            - [fun P -> E1]     when [lbl] is {{!Asttypes.Nolabel}[Nolabel]}
+                                 and [exp1] is [None]
+            - [fun ~l:P -> E1]  when [lbl] is {{!Asttypes.Labelled}[Labelled l]}
+                                 and [exp1] is [None]
+            - [fun ?l:P -> E1]  when [lbl] is {{!Asttypes.Optional}[Optional l]}
+                                 and [exp1] is [None]
+            - [fun ?l:(P = E0) -> E1]
+                                when [lbl] is {{!Asttypes.Optional}[Optional l]}
+                                 and [exp1] is [Some E0]
 
            Notes:
-           - If E0 is provided, only Optional is allowed.
-           - "fun P1 P2 .. Pn -> E1" is represented as nested Pexp_fun.
-           - "let f P = E" is represented using Pexp_fun.
+           - If [E0] is provided, only {{!Asttypes.Optional}[Optional]} is
+            allowed.
+           - [fun P1 P2 .. Pn -> E1] is represented as nested {!Pexp_fun}.
+           - [let f P = E] is represented using {!Pexp_fun}.
          *)
   | Pexp_apply of expression * (arg_label * expression) list
-        (* E0 ~l1:E1 ... ~ln:En
-           li can be empty (non labeled argument) or start with '?'
-           (optional argument).
+        (** [Pexp_apply(E0, [(l1, E1) ; ... ; (ln, En)])]
+            represents [E0 ~l1:E1 ... ~ln:En]
 
-           Invariant: n > 0
+            [li] can be {{!Asttypes.Nolabel}[Nolabel]}   (non labeled argument),
+                        {{!Asttypes.Labelled}[Labelled]} (labelled arguments) or
+                        {{!Asttypes.Optional}[Optional]} (optional argument).
+
+           Invariant: [n > 0]
          *)
   | Pexp_match of expression * case list
-        (* match E0 with P1 -> E1 | ... | Pn -> En *)
+        (** Represents [match E0 with P1 -> E1 | ... | Pn -> En] *)
   | Pexp_try of expression * case list
-        (* try E0 with P1 -> E1 | ... | Pn -> En *)
+        (** Represents [try E0 with P1 -> E1 | ... | Pn -> En] *)
   | Pexp_tuple of expression list
-        (* (E1, ..., En)
+        (** Represents expressions [(E1, ..., En)]
 
-           Invariant: n >= 2
+           Invariant: [n >= 2]
         *)
   | Pexp_construct of Longident.t loc * expression option
-        (* C                None
-           C E              Some E
-           C (E1, ..., En)  Some (Pexp_tuple[E1;...;En])
+        (** [Pexp_construct(C, exp)] represents:
+           - [C]               when [exp] is [None],
+           - [C E]             when [exp] is [Some E],
+           - [C (E1, ..., En)] when [exp] is [Some (Pexp_tuple[E1;...;En])]
         *)
   | Pexp_variant of label * expression option
-        (* `A             (None)
-           `A E           (Some E)
+        (** [Pexp_variant(`A, exp)] represents
+            - [`A]   when [exp] is [None]
+            - [`A E] when [exp] is [Some E]
          *)
   | Pexp_record of (Longident.t loc * expression) list * expression option
-        (* { l1=P1; ...; ln=Pn }     (None)
-           { E0 with l1=P1; ...; ln=Pn }   (Some E0)
+        (** [Pexp_record([(l1,P1) ; ... ; (ln,Pn)], exp)] represents
+            - [{ l1=P1; ...; ln=Pn }]         when [exp] is [None]
+            - [{ E0 with l1=P1; ...; ln=Pn }] when [exp] is [Some E0]
 
-           Invariant: n > 0
+           Invariant: [n > 0]
          *)
   | Pexp_field of expression * Longident.t loc
-        (* E.l *)
+        (** Represents [E.l] *)
   | Pexp_setfield of expression * Longident.t loc * expression
-        (* E1.l <- E2 *)
+        (** Represents [E1.l <- E2] *)
   | Pexp_array of expression list
-        (* [| E1; ...; En |] *)
+        (** Represents [[| E1; ...; En |]] *)
   | Pexp_ifthenelse of expression * expression * expression option
-        (* if E1 then E2 else E3 *)
+        (** Represents [if E1 then E2 else E3] *)
   | Pexp_sequence of expression * expression
-        (* E1; E2 *)
+        (** Represents [E1; E2] *)
   | Pexp_while of expression * expression
-        (* while E1 do E2 done *)
+        (** Represents [while E1 do E2 done] *)
   | Pexp_for of
-      pattern *  expression * expression * direction_flag * expression
-        (* for i = E1 to E2 do E3 done      (flag = Upto)
-           for i = E1 downto E2 do E3 done  (flag = Downto)
+      pattern * expression * expression * direction_flag * expression
+        (** Represents:
+            - [for i = E1 to E2 do E3 done]
+                                     when [flag] is {{!Asttypes.Upto}[Upto]}
+            - [for i = E1 downto E2 do E3 done]
+                                     when [flag] is {{!Asttypes.Downto}[Downto]}
          *)
   | Pexp_constraint of expression * core_type
-        (* (E : T) *)
+        (** Represents [(E : T)] *)
   | Pexp_coerce of expression * core_type option * core_type
-        (* (E :> T)        (None, T)
-           (E : T0 :> T)   (Some T0, T)
+        (** [Pexp_coerce(E, from, T)] represents
+            - [(E :> T)]      when [from] is [None],
+            - [(E : T0 :> T)] when [from] is [Some T0].
          *)
   | Pexp_send of expression * label loc
-        (*  E # m *)
+        (** Represents [E # m] *)
   | Pexp_new of Longident.t loc
-        (* new M.c *)
+        (** Represents [new M.c] *)
   | Pexp_setinstvar of label loc * expression
-        (* x <- 2 *)
+        (** Represents [x <- 2] *)
   | Pexp_override of (label loc * expression) list
-        (* {< x1 = E1; ...; Xn = En >} *)
+        (** Represents [{< x1 = E1; ...; Xn = En >}] *)
   | Pexp_letmodule of string option loc * module_expr * expression
-        (* let module M = ME in E *)
+        (** Represents [let module M = ME in E] *)
   | Pexp_letexception of extension_constructor * expression
-        (* let exception C in E *)
+        (** Represents [let exception C in E] *)
   | Pexp_assert of expression
-        (* assert E
-           Note: "assert false" is treated in a special way by the
+        (** Represents [assert E].
+
+           Note: [assert false] is treated in a special way by the
            type-checker. *)
   | Pexp_lazy of expression
-        (* lazy E *)
+        (** Represents [lazy E] *)
   | Pexp_poly of expression * core_type option
-        (* Used for method bodies.
+        (** Used for method bodies.
 
-           Can only be used as the expression under Cfk_concrete
+           Can only be used as the expression under {!Cfk_concrete}
            for methods (not values). *)
   | Pexp_object of class_structure
-        (* object ... end *)
+        (** Represents [object ... end] *)
   | Pexp_newtype of string loc * expression
-        (* fun (type t) -> E *)
+        (** Represents [fun (type t) -> E] *)
   | Pexp_pack of module_expr
-        (* (module ME)
+        (** Represents [(module ME)].
 
-           (module ME : S) is represented as
-           Pexp_constraint(Pexp_pack, Ptyp_package S) *)
+           [(module ME : S)] is represented as
+           [Pexp_constraint(Pexp_pack ME, Ptyp_package S)] *)
   | Pexp_open of open_declaration * expression
-        (* M.(E)
-           let open M in E
-           let open! M in E *)
+        (** Represents:
+            - [M.(E)]
+            - [let open M in E]
+            - [let open! M in E] *)
   | Pexp_letop of letop
-        (* let* P = E in E
-           let* P = E and* P = E in E *)
+        (** Represents:
+            - [let* P = E0 in E1]
+            - [let* P0 = E00 and* P1 = E01 in E1] *)
   | Pexp_extension of extension
-        (* [%id] *)
+        (** Represents [[%id]] *)
   | Pexp_unreachable
-        (* . *)
+        (** Represents [.] *)
 
-and case =   (* (P -> E) or (P when E0 -> E) *)
+and case =
     {
      pc_lhs: pattern;
      pc_guard: expression option;
      pc_rhs: expression;
-   }
+    }
+(** Values of type {!case} represents [(P -> E)] or [(P when E0 -> E)] *)
 
 and letop =
   {
@@ -412,53 +459,63 @@ and binding_op =
     pbop_loc : Location.t;
   }
 
-(* Value descriptions *)
+(** {2 Value descriptions} *)
 
 and value_description =
     {
      pval_name: string loc;
      pval_type: core_type;
      pval_prim: string list;
-     pval_attributes: attributes;  (* ... [@@id1] [@@id2] *)
+     pval_attributes: attributes;  (** [... [\@\@id1] [\@\@id2]] *)
      pval_loc: Location.t;
     }
-
-(*
-  val x: T                            (prim = [])
-  external x: T = "s1" ... "sn"       (prim = ["s1";..."sn"])
+(** Values of type {!value_description} represents:
+    - [val x: T],                     when {!pval_prim} is [[]]
+    - [external x: T = "s1" ... "sn"] when {!pval_prim} is [["s1";..."sn"]]
 *)
 
-(* Type declarations *)
+(** {2 Type declarations} *)
 
 and type_declaration =
     {
      ptype_name: string loc;
      ptype_params: (core_type * (variance * injectivity)) list;
-           (* ('a1,...'an) t; None represents  _*)
+           (** [('a1,...'an) t; None] represents  [_]*)
      ptype_cstrs: (core_type * core_type * Location.t) list;
-           (* ... constraint T1=T1'  ... constraint Tn=Tn' *)
+           (** Represents [... constraint T1=T1'  ... constraint Tn=Tn'] *)
      ptype_kind: type_kind;
-     ptype_private: private_flag;   (* = private ... *)
-     ptype_manifest: core_type option;  (* = T *)
-     ptype_attributes: attributes;   (* ... [@@id1] [@@id2] *)
+     ptype_private: private_flag;
+           (** for [= private ...] *)
+     ptype_manifest: core_type option;
+           (** represents [= T] *)
+     ptype_attributes: attributes;
+           (** [... [\@\@id1] [\@\@id2]] *)
      ptype_loc: Location.t;
     }
-
-(*
-  type t                     (abstract, no manifest)
-  type t = T0                (abstract, manifest=T0)
-  type t = C of T | ...      (variant,  no manifest)
-  type t = T0 = C of T | ... (variant,  manifest=T0)
-  type t = {l: T; ...}       (record,   no manifest)
-  type t = T0 = {l : T; ...} (record,   manifest=T0)
-  type t = ..                (open,     no manifest)
+(**
+   Here are type declarations and their representation,
+   for various {!ptype_kind} and {!ptype_manifest} values:
+ - [type t]                     when [type_kind] is {!Ptype_abstract},
+                                 and [manifest]  is [None],
+ - [type t = T0]                when [type_kind] is {!Ptype_abstract},
+                                 and [manifest]  is [Some T0],
+ - [type t = C of T | ...]      when [type_kind] is {!Ptype_variant},
+                                 and [manifest]  is [None],
+ - [type t = T0 = C of T | ...] when [type_kind] is {!Ptype_variant},
+                                 and [manifest]  is [Some T0],
+ - [type t = {l: T; ...}]       when [type_kind] is {!Ptype_record},
+                                 and [manifest]  is [None],
+ - [type t = T0 = {l : T; ...}] when [type_kind] is {!Ptype_record},
+                                 and [manifest]  is [Some T0],
+ - [type t = ..]                when [type_kind] is {!Ptype_open},
+                                 and [manifest]  is [None].
 *)
 
 and type_kind =
   | Ptype_abstract
   | Ptype_variant of constructor_declaration list
   | Ptype_record of label_declaration list
-        (* Invariant: non-empty list *)
+        (** Invariant: non-empty list *)
   | Ptype_open
 
 and label_declaration =
@@ -467,13 +524,15 @@ and label_declaration =
      pld_mutable: mutable_flag;
      pld_type: core_type;
      pld_loc: Location.t;
-     pld_attributes: attributes; (* l : T [@id1] [@id2] *)
+     pld_attributes: attributes; (** [l : T [\@id1] [\@id2]] *)
     }
+(**
+   - [{ ...; l: T; ... }]
+                      when {!pld_mutable} is {{!Asttypes.Immutable}[Immutable]},
+   - [{ ...; mutable l: T; ... }]
+                      when {!pld_mutable} is {{!Asttypes.Mutable}[Mutable]}.
 
-(*  { ...; l: T; ... }            (mutable=Immutable)
-    { ...; mutable l: T; ... }    (mutable=Mutable)
-
-    Note: T can be a Ptyp_poly.
+   Note: [T] can be a {!Ptyp_poly}.
 *)
 
 and constructor_declaration =
@@ -483,20 +542,26 @@ and constructor_declaration =
      pcd_args: constructor_arguments;
      pcd_res: core_type option;
      pcd_loc: Location.t;
-     pcd_attributes: attributes; (* C of ... [@id1] [@id2] *)
+     pcd_attributes: attributes;  (** [C of ... [\@id1] [\@id2]] *)
     }
 
 and constructor_arguments =
   | Pcstr_tuple of core_type list
   | Pcstr_record of label_declaration list
-
-(*
-  | C of T1 * ... * Tn     (res = None,    args = Pcstr_tuple [])
-  | C: T0                  (res = Some T0, args = [])
-  | C: T1 * ... * Tn -> T0 (res = Some T0, args = Pcstr_tuple)
-  | C of {...}             (res = None,    args = Pcstr_record)
-  | C: {...} -> T0         (res = Some T0, args = Pcstr_record)
-  | C of {...} as t        (res = None,    args = Pcstr_record)
+(** Values of type {!constructor_declaration}
+    represents the constructor arguments of:
+  - [C of T1 * ... * Tn]     when [res = None],
+                              and [args = Pcstr_tuple [T1; ... ; Tn]],
+  - [C: T0]                  when [res = Some T0],
+                              and [args = Pcstr_tuple []],
+  - [C: T1 * ... * Tn -> T0] when [res = Some T0],
+                              and [args = Pcstr_tuple [T1; ... ; Tn]],
+  - [C of {...}]             when [res = None],
+                              and [args = Pcstr_record [...]],
+  - [C: {...} -> T0]         when [res = Some T0],
+                              and [args = Pcstr_record [...]],
+  - [C of {...} as t]        when [res = None],
+                              and [args = Pcstr_record [...]].
 *)
 
 and type_extension =
@@ -506,10 +571,10 @@ and type_extension =
      ptyext_constructors: extension_constructor list;
      ptyext_private: private_flag;
      ptyext_loc: Location.t;
-     ptyext_attributes: attributes;   (* ... [@@id1] [@@id2] *)
+     ptyext_attributes: attributes;  (** ... [\@\@id1] [\@\@id2] *)
     }
-(*
-  type t += ...
+(**
+  Values of type [type_extension] represents [type t += ...].
 *)
 
 and extension_constructor =
@@ -517,89 +582,104 @@ and extension_constructor =
      pext_name: string loc;
      pext_kind : extension_constructor_kind;
      pext_loc : Location.t;
-     pext_attributes: attributes; (* C of ... [@id1] [@id2] *)
+     pext_attributes: attributes;  (** [C of ... [\@id1] [\@id2]] *)
    }
 
-(* exception E *)
 and type_exception =
   {
     ptyexn_constructor: extension_constructor;
     ptyexn_loc: Location.t;
-    ptyexn_attributes: attributes; (* ... [@@id1] [@@id2] *)
+    ptyexn_attributes: attributes;  (** [... [\@\@id1] [\@\@id2]] *)
   }
+(** Values of type [type_exception] represents [exception E] *)
 
 and extension_constructor_kind =
-    Pext_decl of string loc list * constructor_arguments * core_type option
-      (*
-         | C of T1 * ... * Tn     ([], [T1; ...; Tn], None)
-         | C: T0                  ([], [], Some T0)
-         | C: T1 * ... * Tn -> T0 ([], [T1; ...; Tn], Some T0)
-         | C: 'a... . T1... -> T0 (['a;...]; [T1;...], Some T0)
+  | Pext_decl of string loc list * constructor_arguments * core_type option
+      (** [Pext_decl(l, c_args, t_opt)]
+          represents the new construtor description of:
+          - [C of T1 * ... * Tn] when:
+               {ul {- [l] is [[]],}
+                   {- [c_args] is [[T1; ...; Tn]],}
+                   {- [t_opt] is [None]}.}
+          - [C: T0] when
+               {ul {- [l] is [[]],}
+                   {- [c_args] is [[]],}
+                   {- [t_opt] is [Some T0].}}
+          - [C: T1 * ... * Tn -> T0] when
+               {ul {- [l] is [[]],}
+                   {- [c_args] is [[T1; ...; Tn]],}
+                   {- [t_opt] is [Some T0].}}
+          - [C: 'a... . T1 * ... * Tn -> T0] when
+               {ul {- [l] is [['a;...]],}
+                   {- [c_args] is [[T1; ... ; Tn]],}
+                   {- [t_opt] is [Some T0].}}
        *)
   | Pext_rebind of Longident.t loc
-      (*
-         | C = D
-       *)
+        (** [Pext_rebind(D)]
+            represents the new constructor description of [C = D] *)
 
 (** {1 Class language} *)
 
-(* Type expressions for the class language *)
+(** {2 Type expressions for the class language} *)
 
 and class_type =
     {
      pcty_desc: class_type_desc;
      pcty_loc: Location.t;
-     pcty_attributes: attributes; (* ... [@id1] [@id2] *)
+     pcty_attributes: attributes; (** [... [\@id1] [\@id2]] *)
     }
 
 and class_type_desc =
   | Pcty_constr of Longident.t loc * core_type list
-        (* c
-           ['a1, ..., 'an] c *)
+        (** Represents:
+      - [c]
+      - [['a1, ..., 'an] c] *)
   | Pcty_signature of class_signature
-        (* object ... end *)
+        (** Represents [object ... end] *)
   | Pcty_arrow of arg_label * core_type * class_type
-        (* T -> CT       Simple
-           ~l:T -> CT    Labelled l
-           ?l:T -> CT    Optional l
+        (** [Pcty_arrow(lbl, T, CT)] represents:
+            - [T -> CT]    when [lbl] is {{!Asttypes.Nolabel}[Nolabel]},
+            - [~l:T -> CT] when [lbl] is {{!Asttypes.Labelled}[Labelled l]},
+            - [?l:T -> CT] when [lbl] is {{!Asttypes.Optional}[Optional l]}.
          *)
   | Pcty_extension of extension
-        (* [%id] *)
+        (** Represents [%id] *)
   | Pcty_open of open_description * class_type
-        (* let open M in CT *)
+        (** Represents [let open M in CT] *)
 
 and class_signature =
     {
      pcsig_self: core_type;
      pcsig_fields: class_type_field list;
     }
-(* object('selfpat) ... end
-   object ... end             (self = Ptyp_any)
- *)
+(** Values of type [class_signature] represents:
+    - [object('selfpat) ... end]
+    - [object ... end] when {!psig_self} is {!Ptyp_any}
+*)
 
 and class_type_field =
     {
      pctf_desc: class_type_field_desc;
      pctf_loc: Location.t;
-     pctf_attributes: attributes; (* ... [@@id1] [@@id2] *)
+     pctf_attributes: attributes;  (** [... [\@\@id1] [\@\@id2]] *)
     }
 
 and class_type_field_desc =
   | Pctf_inherit of class_type
-        (* inherit CT *)
+        (** Represents [inherit CT] *)
   | Pctf_val of (label loc * mutable_flag * virtual_flag * core_type)
-        (* val x: T *)
-  | Pctf_method  of (label loc * private_flag * virtual_flag * core_type)
-        (* method x: T
+        (** Represents [val x: T] *)
+  | Pctf_method of (label loc * private_flag * virtual_flag * core_type)
+        (** Represents [method x: T]
 
-           Note: T can be a Ptyp_poly.
-         *)
-  | Pctf_constraint  of (core_type * core_type)
-        (* constraint T1 = T2 *)
+            Note: [T] can be a {!Ptyp_poly}.
+        *)
+  | Pctf_constraint of (core_type * core_type)
+        (** Represents [constraint T1 = T2] *)
   | Pctf_attribute of attribute
-        (* [@@@id] *)
+        (** Represents [[\@\@\@id]] *)
   | Pctf_extension of extension
-        (* [%%id] *)
+        (** Represents [[%%id]] *)
 
 and 'a class_infos =
     {
@@ -608,98 +688,125 @@ and 'a class_infos =
      pci_name: string loc;
      pci_expr: 'a;
      pci_loc: Location.t;
-     pci_attributes: attributes;  (* ... [@@id1] [@@id2] *)
-    }
-(* class c = ...
-   class ['a1,...,'an] c = ...
-   class virtual c = ...
+     pci_attributes: attributes;  (** [... [\@\@id1] [\@\@id2]] *)
+   }
+(** Values of type [class_expr class_infos] represents:
+    - [class c = ...]
+    - [class ['a1,...,'an] c = ...]
+    - [class virtual c = ...]
 
-   Also used for "class type" declaration.
+   They are also used for "class type" declaration.
 *)
 
 and class_description = class_type class_infos
 
 and class_type_declaration = class_type class_infos
 
-(* Value expressions for the class language *)
+(** {2 Value expressions for the class language} *)
 
 and class_expr =
     {
      pcl_desc: class_expr_desc;
      pcl_loc: Location.t;
-     pcl_attributes: attributes; (* ... [@id1] [@id2] *)
+     pcl_attributes: attributes;  (** [... [\@id1] [\@id2]] *)
     }
 
 and class_expr_desc =
   | Pcl_constr of Longident.t loc * core_type list
-        (* c
-           ['a1, ..., 'an] c *)
+        (** Represents [c] and [['a1, ..., 'an] c] *)
   | Pcl_structure of class_structure
-        (* object ... end *)
+        (** Represents [object ... end] *)
   | Pcl_fun of arg_label * expression option * pattern * class_expr
-        (* fun P -> CE                          (Simple, None)
-           fun ~l:P -> CE                       (Labelled l, None)
-           fun ?l:P -> CE                       (Optional l, None)
-           fun ?l:(P = E0) -> CE                (Optional l, Some E0)
-         *)
+        (** [Pcl_fun(lbl, exp, P, CE)] represents:
+            - [fun P -> CE]     when [lbl] is {{!Asttypes.Nolabel}[Nolabel]}
+                                 and [exp] is [None],
+            - [fun ~l:P -> CE]  when [lbl] is {{!Asttypes.Labelled}[Labelled l]}
+                                 and [exp] is [None],
+            - [fun ?l:P -> CE]  when [lbl] is {{!Asttypes.Optional}[Optional l]}
+                                 and [exp] is [None],
+            - [fun ?l:(P = E0) -> CE]
+                                when [lbl] is {{!Asttypes.Optional}[Optional l]}
+                                 and [exp] is [Some E0].
+        *)
   | Pcl_apply of class_expr * (arg_label * expression) list
-        (* CE ~l1:E1 ... ~ln:En
-           li can be empty (non labeled argument) or start with '?'
-           (optional argument).
+        (** [Pcl_apply(CE, [(l1,E1) ; ... ; (ln,En)])]
+            represents [CE ~l1:E1 ... ~ln:En].
+            [li] can be empty (non labeled argument) or start with [?]
+            (optional argument).
 
-           Invariant: n > 0
-         *)
+            Invariant: [n > 0]
+        *)
   | Pcl_let of rec_flag * value_binding list * class_expr
-        (* let P1 = E1 and ... and Pn = EN in CE      (flag = Nonrecursive)
-           let rec P1 = E1 and ... and Pn = EN in CE  (flag = Recursive)
-         *)
+        (** Represents:
+            - [let P1 = E1 and ... and Pn = EN in CE]
+                        when [flag] is {{!Asttypes.Nonrecursive}[Nonrecursive]},
+            - [let rec P1 = E1 and ... and Pn = EN in CE]
+                        when [flag] is {{!Asttypes.Recursive}[Recursive]}.
+        *)
   | Pcl_constraint of class_expr * class_type
-        (* (CE : CT) *)
+        (** Represents [(CE : CT)] *)
   | Pcl_extension of extension
-  (* [%id] *)
+        (** Represents [[%id]] *)
   | Pcl_open of open_description * class_expr
-  (* let open M in CE *)
-
+        (** Represents [let open M in CE] *)
 
 and class_structure =
     {
      pcstr_self: pattern;
      pcstr_fields: class_field list;
     }
-(* object(selfpat) ... end
-   object ... end           (self = Ppat_any)
- *)
+(** Values of type {!class_structure} represents:
+    - [object(selfpat) ... end]
+    - [object ... end] when {!pcstr_self} is {!Ppat_any}
+*)
 
 and class_field =
     {
      pcf_desc: class_field_desc;
      pcf_loc: Location.t;
-     pcf_attributes: attributes; (* ... [@@id1] [@@id2] *)
+     pcf_attributes: attributes;  (** [... [\@\@id1] [\@\@id2]] *)
     }
 
 and class_field_desc =
   | Pcf_inherit of override_flag * class_expr * string loc option
-        (* inherit CE
-           inherit CE as x
-           inherit! CE
-           inherit! CE as x
-         *)
+        (** [Pcf_inherit(flag, CE, s)] represents:
+            - [inherit CE]       when [flag] is {{!Asttypes.Fresh}[Fresh]}
+                                  and [s] is [None],
+            - [inherit CE as x]  when [flag] is {{!Asttypes.Fresh}[Fresh]}
+                                  and [s] is [Some x],
+            - [inherit! CE]      when [flag] is {{!Asttypes.Override}[Override]}
+                                  and [s] is [None],
+            - [inherit! CE as x] when [flag] is {{!Asttypes.Override}[Override]}
+                                  and [s] is [Some x]
+  *)
   | Pcf_val of (label loc * mutable_flag * class_field_kind)
-        (* val x = E
-           val virtual x: T
-         *)
+        (** [Pcf_val(x,flag, kind)] represents:
+            - [val x = E]
+                        when [flag] is {{!Asttypes.Immutable}[Immutable]}
+                         and [kind] is {{!Cfk_concrete}[Cfk_concrete(Fresh, E)]}
+            - [val virtual x: T]
+                        when [flag] is {{!Asttypes.Immutable}[Immutable]}
+                         and [kind] is {{!Cfk_concrete}[Cfk_virtual(T)]}
+            - [val mutable x = E]
+                        when [flag] is {{!Asttypes.Mutable}[Mutable]}
+                         and [kind] is {{!Cfk_concrete}[Cfk_concrete(Fresh, E)]}
+            - [val mutable virtual x: T]
+                        when [flag] is {{!Asttypes.Mutable}[Mutable]}
+                         and [kind] is {{!Cfk_concrete}[Cfk_virtual(T)]}
+  *)
   | Pcf_method of (label loc * private_flag * class_field_kind)
-        (* method x = E            (E can be a Pexp_poly)
-           method virtual x: T     (T can be a Ptyp_poly)
-         *)
+        (** Represents:
+            - [method x = E]            ([E] can be a {!Pexp_poly})
+            - [method virtual x: T]     ([T] can be a {!Ptyp_poly})
+  *)
   | Pcf_constraint of (core_type * core_type)
-        (* constraint T1 = T2 *)
+        (** Represents [constraint T1 = T2] *)
   | Pcf_initializer of expression
-        (* initializer E *)
+        (** Represents [initializer E] *)
   | Pcf_attribute of attribute
-        (* [@@@id] *)
+        (** Represents [[\@\@\@id]] *)
   | Pcf_extension of extension
-        (* [%%id] *)
+        (** Represents [[%%id]] *)
 
 and class_field_kind =
   | Cfk_virtual of core_type
@@ -709,37 +816,38 @@ and class_declaration = class_expr class_infos
 
 (** {1 Module language} *)
 
-(* Type expressions for the module language *)
+(** {2 Type expressions for the module language} *)
 
 and module_type =
     {
      pmty_desc: module_type_desc;
      pmty_loc: Location.t;
-     pmty_attributes: attributes; (* ... [@id1] [@id2] *)
+     pmty_attributes: attributes;  (** [... [\@id1] [\@id2]] *)
     }
 
 and module_type_desc =
   | Pmty_ident of Longident.t loc
-        (* S *)
+        (** [Pmty_ident(S)] represents [S] *)
   | Pmty_signature of signature
-        (* sig ... end *)
+        (** Represents [sig ... end] *)
   | Pmty_functor of functor_parameter * module_type
-        (* functor(X : MT1) -> MT2 *)
+        (** Represents [functor(X : MT1) -> MT2] *)
   | Pmty_with of module_type * with_constraint list
-        (* MT with ... *)
+        (** Represents [MT with ...] *)
   | Pmty_typeof of module_expr
-        (* module type of ME *)
+        (** Represents [module type of ME] *)
   | Pmty_extension of extension
-        (* [%id] *)
+        (** Represents [[%id]] *)
   | Pmty_alias of Longident.t loc
-        (* (module M) *)
+        (** Represents [(module M)] *)
 
 and functor_parameter =
   | Unit
-        (* () *)
+        (** Represents [()] *)
   | Named of string option loc * module_type
-        (* (X : MT)          Some X, MT
-           (_ : MT)          None, MT *)
+        (** [Named(name, MT)] represents:
+            - [(X : MT)] when [name] is [Some X],
+            - [(_ : MT)] when [name] is [None] *)
 
 and signature = signature_item list
 
@@ -751,70 +859,69 @@ and signature_item =
 
 and signature_item_desc =
   | Psig_value of value_description
-        (*
-          val x: T
-          external x: T = "s1" ... "sn"
+        (** Represents:
+            - [val x: T]
+            - [external x: T = "s1" ... "sn"]
          *)
   | Psig_type of rec_flag * type_declaration list
-        (* type t1 = ... and ... and tn  = ... *)
+        (** Represents [type t1 = ... and ... and tn  = ...] *)
   | Psig_typesubst of type_declaration list
-        (* type t1 := ... and ... and tn := ...  *)
+        (** Represents [type t1 := ... and ... and tn := ...]  *)
   | Psig_typext of type_extension
-        (* type t1 += ... *)
+        (** Represents [type t1 += ...] *)
   | Psig_exception of type_exception
-        (* exception C of T *)
+        (** Represents [exception C of T] *)
   | Psig_module of module_declaration
-        (* module X = M
-           module X : MT *)
+        (** Represents [module X = M] and [module X : MT] *)
   | Psig_modsubst of module_substitution
-        (* module X := M *)
+        (** Represents [module X := M] *)
   | Psig_recmodule of module_declaration list
-        (* module rec X1 : MT1 and ... and Xn : MTn *)
+        (** Represents [module rec X1 : MT1 and ... and Xn : MTn] *)
   | Psig_modtype of module_type_declaration
-        (* module type S = MT
-           module type S *)
+        (** Represents [module type S = MT] and [module type S] *)
   | Psig_modtypesubst of module_type_declaration
-        (* module type S :=  ...  *)
+        (** Represents [module type S :=  ...]  *)
   | Psig_open of open_description
-        (* open X *)
+        (** Represents [open X] *)
   | Psig_include of include_description
-        (* include MT *)
+        (** Represents [include MT] *)
   | Psig_class of class_description list
-        (* class c1 : ... and ... and cn : ... *)
+        (** Represents [class c1 : ... and ... and cn : ...] *)
   | Psig_class_type of class_type_declaration list
-        (* class type ct1 = ... and ... and ctn = ... *)
+        (** Represents [class type ct1 = ... and ... and ctn = ...] *)
   | Psig_attribute of attribute
-        (* [@@@id] *)
+        (** Represents [[\@\@\@id]] *)
   | Psig_extension of extension * attributes
-        (* [%%id] *)
+        (** Represents [[%%id]] *)
 
 and module_declaration =
     {
      pmd_name: string option loc;
      pmd_type: module_type;
-     pmd_attributes: attributes; (* ... [@@id1] [@@id2] *)
+     pmd_attributes: attributes;  (** [... [\@\@id1] [\@\@id2]] *)
      pmd_loc: Location.t;
     }
-(* S : MT *)
+(** Values of type [module_declaration] represents [S : MT] *)
 
 and module_substitution =
     {
      pms_name: string loc;
      pms_manifest: Longident.t loc;
-     pms_attributes: attributes; (* ... [@@id1] [@@id2] *)
+     pms_attributes: attributes;  (** [... [\@\@id1] [\@\@id2]] *)
      pms_loc: Location.t;
     }
-(* S := M *)
+(** Values of type [module_substitution] represents [S := M] *)
 
 and module_type_declaration =
     {
      pmtd_name: string loc;
      pmtd_type: module_type option;
-     pmtd_attributes: attributes; (* ... [@@id1] [@@id2] *)
+     pmtd_attributes: attributes;  (** [... [\@\@id1] [\@\@id2]] *)
      pmtd_loc: Location.t;
     }
-(* S = MT
-   S       (abstract module type declaration, pmtd_type = None)
+(** Values of type [module_type_declaration] represents:
+   - [S = MT],
+   - [S]  for abstract module type declaration, when {!pmtd_type} is [None].
 *)
 
 and 'a open_infos =
@@ -824,19 +931,22 @@ and 'a open_infos =
      popen_loc: Location.t;
      popen_attributes: attributes;
     }
-(* open! X - popen_override = Override (silences the 'used identifier
-                              shadowing' warning)
-   open  X - popen_override = Fresh
- *)
+(** Values of type [’a open_infos] represents:
+    - [open! X] when {!popen_override} is {{!Asttypes.Override}[Override]}
+    (silences the "used identifier shadowing" warning)
+    - [open  X] when {!popen_override} is {{!Asttypes.Fresh}[Fresh]}
+*)
 
 and open_description = Longident.t loc open_infos
-(* open M.N
-   open M(N).O *)
+(** Values of type [open_description] represents:
+    - [open M.N]
+    - [open M(N).O] *)
 
 and open_declaration = module_expr open_infos
-(* open M.N
-   open M(N).O
-   open struct ... end *)
+(** Values of type [open_declaration] represents:
+    - [open M.N]
+    - [open M(N).O]
+    - [open struct ... end] *)
 
 and 'a include_infos =
     {
@@ -846,52 +956,52 @@ and 'a include_infos =
     }
 
 and include_description = module_type include_infos
-(* include MT *)
+(** Values of type [include_description] represents [include MT] *)
 
 and include_declaration = module_expr include_infos
-(* include ME *)
+(** Values of type [include_declaration] represents [include ME] *)
 
 and with_constraint =
   | Pwith_type of Longident.t loc * type_declaration
-        (* with type X.t = ...
+        (** Represents [with type X.t = ...]
 
-           Note: the last component of the longident must match
-           the name of the type_declaration. *)
+            Note: the last component of the longident must match
+            the name of the type_declaration. *)
   | Pwith_module of Longident.t loc * Longident.t loc
-        (* with module X.Y = Z *)
+        (** Represents [with module X.Y = Z] *)
   | Pwith_modtype of Longident.t loc * module_type
-        (* with module type X.Y = Z *)
+        (** Represents [with module type X.Y = Z] *)
   | Pwith_modtypesubst of Longident.t loc * module_type
-        (* with module type X.Y := sig end *)
+        (** Represents [with module type X.Y := sig end] *)
   | Pwith_typesubst of Longident.t loc * type_declaration
-        (* with type X.t := ..., same format as [Pwith_type] *)
+        (** Represents [with type X.t := ..., same format as [Pwith_type]] *)
   | Pwith_modsubst of Longident.t loc * Longident.t loc
-        (* with module X.Y := Z *)
+        (** Represents [with module X.Y := Z] *)
 
-(* Value expressions for the module language *)
+(** {2 Value expressions for the module language} *)
 
 and module_expr =
     {
      pmod_desc: module_expr_desc;
      pmod_loc: Location.t;
-     pmod_attributes: attributes; (* ... [@id1] [@id2] *)
+     pmod_attributes: attributes;  (** [... [\@id1] [\@id2]] *)
     }
 
 and module_expr_desc =
   | Pmod_ident of Longident.t loc
-        (* X *)
+        (** Represents [X] *)
   | Pmod_structure of structure
-        (* struct ... end *)
+        (** Represents [struct ... end] *)
   | Pmod_functor of functor_parameter * module_expr
-        (* functor(X : MT1) -> ME *)
+        (** Represents [functor(X : MT1) -> ME] *)
   | Pmod_apply of module_expr * module_expr
-        (* ME1(ME2) *)
+        (** Represents [ME1(ME2)] *)
   | Pmod_constraint of module_expr * module_type
-        (* (ME : MT) *)
+        (** Represents [(ME : MT)] *)
   | Pmod_unpack of expression
-        (* (val E) *)
+        (** Represents [(val E)] *)
   | Pmod_extension of extension
-        (* [%id] *)
+        (** Represents [[%id]] *)
 
 and structure = structure_item list
 
@@ -903,39 +1013,44 @@ and structure_item =
 
 and structure_item_desc =
   | Pstr_eval of expression * attributes
-        (* E *)
+        (** Represents [E] *)
   | Pstr_value of rec_flag * value_binding list
-        (* let P1 = E1 and ... and Pn = EN       (flag = Nonrecursive)
-           let rec P1 = E1 and ... and Pn = EN   (flag = Recursive)
-         *)
+        (** Represents:
+            - [let P1 = E1 and ... and Pn = EN]
+                        when [flag] is {{!Asttypes.Nonrecursive}[Nonrecursive]},
+            - [let rec P1 = E1 and ... and Pn = EN ]
+                        when [flag] is {{!Asttypes.Recursive}[Recursive]}.
+        *)
   | Pstr_primitive of value_description
-        (*  val x: T
-            external x: T = "s1" ... "sn" *)
+        (** Represents:
+            - [val x: T]
+            - [external x: T = "s1" ... "sn" ]*)
   | Pstr_type of rec_flag * type_declaration list
-        (* type t1 = ... and ... and tn = ... *)
+        (** Represents [type t1 = ... and ... and tn = ...] *)
   | Pstr_typext of type_extension
-        (* type t1 += ... *)
+        (** Represents [type t1 += ...] *)
   | Pstr_exception of type_exception
-        (* exception C of T
-           exception C = M.X *)
+        (** Represents:
+            - [exception C of T]
+            - [exception C = M.X] *)
   | Pstr_module of module_binding
-        (* module X = ME *)
+        (** Represents [module X = ME] *)
   | Pstr_recmodule of module_binding list
-        (* module rec X1 = ME1 and ... and Xn = MEn *)
+        (** Represents [module rec X1 = ME1 and ... and Xn = MEn] *)
   | Pstr_modtype of module_type_declaration
-        (* module type S = MT *)
+        (** Represents [module type S = MT] *)
   | Pstr_open of open_declaration
-        (* open X *)
+        (** Represents [open X] *)
   | Pstr_class of class_declaration list
-        (* class c1 = ... and ... and cn = ... *)
+        (** Represents [class c1 = ... and ... and cn = ...] *)
   | Pstr_class_type of class_type_declaration list
-        (* class type ct1 = ... and ... and ctn = ... *)
+        (** Represents [class type ct1 = ... and ... and ctn = ...] *)
   | Pstr_include of include_declaration
-        (* include ME *)
+        (** Represents [include ME] *)
   | Pstr_attribute of attribute
-        (* [@@@id] *)
+        (** Represents [[\@\@\@id]] *)
   | Pstr_extension of extension * attributes
-        (* [%%id] *)
+        (** Represents [[%%id]] *)
 
 and value_binding =
   {
@@ -952,16 +1067,16 @@ and module_binding =
      pmb_attributes: attributes;
      pmb_loc: Location.t;
     }
-(* X = ME *)
+(** Values of type [module_binding] represents [module X = ME] *)
 
 (** {1 Toplevel} *)
 
-(* Toplevel phrases *)
+(** {2 Toplevel phrases} *)
 
 type toplevel_phrase =
   | Ptop_def of structure
   | Ptop_dir of toplevel_directive
-     (* #use, #load ... *)
+     (** Represents [#use], [#load] ... *)
 
 and toplevel_directive =
   {

--- a/parsing/parsetree.mli
+++ b/parsing/parsetree.mli
@@ -124,17 +124,17 @@ and core_type_desc =
   | Ptyp_variant of row_field list * closed_flag * label list option
       (** [Ptyp_variant([`A;`B], flag, labels)] represents:
             - [[ `A|`B ]]
-                when [flag],                                   [labels]
-                  is {{!Asttypes.closed_flag.Closed}[Closed]}, [None],
+                      when [flag]   is {{!Asttypes.closed_flag.Closed}[Closed]},
+                       and [labels] is [None],
             - [[> `A|`B ]]
-                when [flag],                                   [labels]
-                  is {{!Asttypes.closed_flag.Open}[Open]},     [None],
+                      when [flag]   is {{!Asttypes.closed_flag.Open}[Open]},
+                       and [labels] is [None],
             - [[< `A|`B ]]
-                when [flag],                                   [labels]
-                  is {{!Asttypes.closed_flag.Closed}[Closed]}, [Some []],
+                      when [flag]   is {{!Asttypes.closed_flag.Closed}[Closed]},
+                       and [labels] is [Some []],
             - [[< `A|`B > `X `Y ]]
-                when [flag],                                   [labels]
-                  is {{!Asttypes.closed_flag.Closed}[Closed]}, [Some ["X";"Y"]].
+                      when [flag]   is {{!Asttypes.closed_flag.Closed}[Closed]},
+                       and [labels] is [Some ["X";"Y"]].
          *)
   | Ptyp_poly of string loc list * core_type
       (** ['a1 ... 'an. T]

--- a/parsing/parsetree.mli
+++ b/parsing/parsetree.mli
@@ -23,21 +23,21 @@
 open Asttypes
 
 type constant =
-    Pconst_integer of string * char option
-  (** Integer constants such as [3] [3l] [3L] [3n].
+  | Pconst_integer of string * char option
+      (** Integer constants such as [3] [3l] [3L] [3n].
 
      Suffixes [[g-z][G-Z]] are accepted by the parser.
      Suffixes except ['l'], ['L'] and ['n'] are rejected by the typechecker
   *)
-  | Pconst_char of char
-  (** Character such as ['c']. *)
+  | Pconst_char of char  (** Character such as ['c']. *)
   | Pconst_string of string * Location.t * string option
-  (** Constant string such as ["constant"] or [{delim|other constant|delim}].
+      (** Constant string such as ["constant"] or
+          [{delim|other constant|delim}].
 
      The location span the content of the string, without the delimiters.
   *)
   | Pconst_float of string * char option
-  (** Float constant such as [3.4], [2e5] or [1.4e-4].
+      (** Float constant such as [3.4], [2e5] or [1.4e-4].
 
      Suffixes [g-z][G-Z] are accepted by the parser.
      Suffixes are rejected by the typechecker.
@@ -48,18 +48,18 @@ type location_stack = Location.t list
 (** {1 Extension points} *)
 
 type attribute = {
-    attr_name : string loc;
-    attr_payload : payload;
-    attr_loc : Location.t;
-  }
-       (** Attributes such as [[\@id ARG]] and [[\@\@id ARG]].
+  attr_name : string loc;
+  attr_payload : payload;
+  attr_loc : Location.t;
+}
+(** Attributes such as [[\@id ARG]] and [[\@\@id ARG]].
 
           Metadata containers passed around within the AST.
           The compiler ignores unknown attributes.
        *)
 
 and extension = string loc * payload
-      (** Extension points such as [[%id ARG] and [%%id ARG]].
+(** Extension points such as [[%id ARG] and [%%id ARG]].
 
          Sub-language placeholder -- rejected by the typechecker.
       *)
@@ -68,105 +68,107 @@ and attributes = attribute list
 
 and payload =
   | PStr of structure
-  | PSig of signature
-      (** [: SIG] in an attribute or an extension point *)
-  | PTyp of core_type
-      (** [: T] in an attribute or an extension point *)
+  | PSig of signature  (** [: SIG] in an attribute or an extension point *)
+  | PTyp of core_type  (** [: T] in an attribute or an extension point *)
   | PPat of pattern * expression option
       (** [? P]  or  [? P when E], in an attribute or an extension point *)
 
 (** {1 Core language} *)
-
 (** {2 Type expressions} *)
 
-and core_type =
-    {
-     ptyp_desc: core_type_desc;
-     ptyp_loc: Location.t;
-     ptyp_loc_stack: location_stack;
-     ptyp_attributes: attributes;  (** [... [\@id1] [\@id2]] *)
-    }
+and core_type = {
+  ptyp_desc : core_type_desc;
+  ptyp_loc : Location.t;
+  ptyp_loc_stack : location_stack;
+  ptyp_attributes : attributes;  (** [... [\@id1] [\@id2]] *)
+}
 
 and core_type_desc =
-  | Ptyp_any
-        (** [_] *)
-  | Ptyp_var of string
-        (** A type var such as ['a] *)
+  | Ptyp_any  (** [_] *)
+  | Ptyp_var of string  (** A type variable such as ['a] *)
   | Ptyp_arrow of arg_label * core_type * core_type
-        (** [Ptyp_arrow(lbl, T1, T2)] represents:
-            - [T1 -> T2]    when [lbl] is  {{!Asttypes.Nolabel}[Nolabel]},
-            - [~l:T1 -> T2] when [lbl] is {{!Asttypes.Labelled}[Labelled]},
-            - [?l:T1 -> T2] when [lbl] is {{!Asttypes.Optional}[Optional]}.
+      (** [Ptyp_arrow(lbl, T1, T2)] represents:
+            - [T1 -> T2]    when [lbl] is
+                                     {{!Asttypes.arg_label.Nolabel}[Nolabel]},
+            - [~l:T1 -> T2] when [lbl] is
+                                     {{!Asttypes.arg_label.Labelled}[Labelled]},
+            - [?l:T1 -> T2] when [lbl] is
+                                     {{!Asttypes.arg_label.Optional}[Optional]}.
          *)
   | Ptyp_tuple of core_type list
-        (** [Ptyp_tuple([T1 ; ... ; Tn])] represents a product type [T1 * ... * Tn].
+      (** [Ptyp_tuple([T1 ; ... ; Tn])]
+          represents a product type [T1 * ... * Tn].
 
            Invariant: [n >= 2].
         *)
   | Ptyp_constr of Longident.t loc * core_type list
-        (** [Ptyp_constr(lident, l)] represents:
+      (** [Ptyp_constr(lident, l)] represents:
             - [tconstr]               when [l=[]],
             - [T tconstr]             when [l=[T]],
             - [(T1, ..., Tn) tconstr] when [l=[T1 ; ... ; Tn]].
          *)
   | Ptyp_object of object_field list * closed_flag
-        (** [Ptyp_object([ l1:T1; ...; ln:Tn ], flag)] represents:
-            - [< l1:T1; ...; ln:Tn >]
-                                    when [flag] is {{!Asttypes.Closed}[Closed]},
-            - [< l1:T1; ...; ln:Tn; .. >]
-                                    when [flag] is   {{!Asttypes.Open}[Open]}.
+      (** [Ptyp_object([ l1:T1; ...; ln:Tn ], flag)] represents:
+            - [< l1:T1; ...; ln:Tn >]     when [flag] is
+                                       {{!Asttypes.closed_flag.Closed}[Closed]},
+            - [< l1:T1; ...; ln:Tn; .. >] when [flag] is
+                                           {{!Asttypes.closed_flag.Open}[Open]}.
          *)
   | Ptyp_class of Longident.t loc * core_type list
-        (** [Ptyp_class(tconstr, l)] represents:
+      (** [Ptyp_class(tconstr, l)] represents:
             - [#tconstr]               when [l=[]],
             - [T #tconstr]             when [l=[T]],
             - [(T1, ..., Tn) #tconstr] when [l=[T1 ; ... ; Tn]].
          *)
-  | Ptyp_alias of core_type * string
-        (** [T as 'a]. *)
+  | Ptyp_alias of core_type * string  (** [T as 'a]. *)
   | Ptyp_variant of row_field list * closed_flag * label list option
-        (** [Ptyp_variant([`A;`B], flag, labels)] represents:
+      (** [Ptyp_variant([`A;`B], flag, labels)] represents:
             - [[ `A|`B ]]
-                 when [flag],                       [labels]
-                   is {{!Asttypes.Closed}[Closed]}, [None],
+                when [flag],                                   [labels]
+                  is {{!Asttypes.closed_flag.Closed}[Closed]}, [None],
             - [[> `A|`B ]]
-                 when [flag],                       [labels]
-                   is {{!Asttypes.Open}[Open]},     [None],
+                when [flag],                                   [labels]
+                  is {{!Asttypes.closed_flag.Open}[Open]},     [None],
             - [[< `A|`B ]]
-                 when [flag],                       [labels]
-                   is {{!Asttypes.Closed}[Closed]}, [Some []],
+                when [flag],                                   [labels]
+                  is {{!Asttypes.closed_flag.Closed}[Closed]}, [Some []],
             - [[< `A|`B > `X `Y ]]
-                 when [flag],                       [labels]
-                   is {{!Asttypes.Closed}[Closed]}, [Some ["X";"Y"]].
+                when [flag],                                   [labels]
+                  is {{!Asttypes.closed_flag.Closed}[Closed]}, [Some ["X";"Y"]].
          *)
   | Ptyp_poly of string loc list * core_type
-        (** ['a1 ... 'an. T]
+      (** ['a1 ... 'an. T]
 
            Can only appear in the following context:
 
-           - As the {!core_type} of a {!Ppat_constraint} node corresponding
+           - As the {!core_type} of a
+          {{!pattern_desc.Ppat_constraint}[Ppat_constraint]} node corresponding
              to a constraint on a let-binding:
             {[let x : 'a1 ... 'an. T = e ...]}
 
-           - Under {!Cfk_virtual} for methods (not values).
+           - Under {{!class_field_kind.Cfk_virtual}[Cfk_virtual]} for methods
+          (not values).
 
-           - As the {!core_type} of a {!Pctf_method} node.
+           - As the {!core_type} of a
+           {{!class_type_field_desc.Pctf_method}[Pctf_method]} node.
 
-           - As the {!core_type} of a {!Pexp_poly} node.
+           - As the {!core_type} of a {{!expression_desc.Pexp_poly}[Pexp_poly]}
+           node.
 
-           - As the {!pld_type} field of a {!label_declaration}.
+           - As the {{!label_declaration.pld_type}[pld_type]} field of a
+           {!label_declaration}.
 
-           - As a {!core_type} of a {!Ptyp_object} node.
+           - As a {!core_type} of a {{!core_type_desc.Ptyp_object}[Ptyp_object]}
+           node.
 
-           - As the {!pval_type} field of a {!value_description}.
+           - As the {{!value_description.pval_type}[pval_type]} field of a
+           {!value_description}.
          *)
-  | Ptyp_package of package_type
-        (** [(module S)]. *)
-  | Ptyp_extension of extension
-        (** [[%id]]. *)
+  | Ptyp_package of package_type  (** [(module S)]. *)
+  | Ptyp_extension of extension  (** [[%id]]. *)
 
 and package_type = Longident.t loc * (Longident.t loc * core_type) list
-      (** As {!package_type} typed values:
+(** As {!package_type} typed values:
          - [(S, [])] represents [(module S)],
          - [(S, [(t1, T1) ; ... ; (tn, Tn)])]
           represents [(module S with type t1 = T1 and ... and tn = Tn)].
@@ -180,7 +182,7 @@ and row_field = {
 
 and row_field_desc =
   | Rtag of label loc * bool * core_type list
-        (** [Rtag(`A, b, l)] represents:
+      (** [Rtag(`A, b, l)] represents:
            - [`A]                   when [b] is [true]  and [l] is [[]],
            - [`A of T]              when [b] is [false] and [l] is [[T]],
            - [`A of T1 & .. & Tn]   when [b] is [false] and [l] is [[T1;...Tn]],
@@ -191,8 +193,7 @@ and row_field_desc =
           - [&] occurs when several types are used for the same constructor
             (see 4.2 in the manual)
         *)
-  | Rinherit of core_type
-        (** [[ | t ]] *)
+  | Rinherit of core_type  (** [[ | t ]] *)
 
 and object_field = {
   pof_desc : object_field_desc;
@@ -200,352 +201,325 @@ and object_field = {
   pof_attributes : attributes;
 }
 
-and object_field_desc =
-  | Otag of label loc * core_type
-  | Oinherit of core_type
+and object_field_desc = Otag of label loc * core_type | Oinherit of core_type
 
 (** {2 Patterns} *)
 
-and pattern =
-    {
-     ppat_desc: pattern_desc;
-     ppat_loc: Location.t;
-     ppat_loc_stack: location_stack;
-     ppat_attributes: attributes;  (** [... [\@id1] [\@id2]] *)
-    }
+and pattern = {
+  ppat_desc : pattern_desc;
+  ppat_loc : Location.t;
+  ppat_loc_stack : location_stack;
+  ppat_attributes : attributes;  (** [... [\@id1] [\@id2]] *)
+}
 
 and pattern_desc =
-  | Ppat_any
-        (** The pattern [_]. *)
-  | Ppat_var of string loc
-        (** The variable pattern such as [x] *)
+  | Ppat_any  (** The pattern [_]. *)
+  | Ppat_var of string loc  (** A variable pattern such as [x] *)
   | Ppat_alias of pattern * string loc
-        (** [Ppat_alias] represents patterns such as [P as 'a] *)
+      (** An alias pattern such as [P as 'a] *)
   | Ppat_constant of constant
-        (** Patterns such as [1], ['a'], ["true"], [1.0], [1l], [1L], [1n] *)
+      (** Patterns such as [1], ['a'], ["true"], [1.0], [1l], [1L], [1n] *)
   | Ppat_interval of constant * constant
-        (** Patterns such as ['a'..'z'].
+      (** Patterns such as ['a'..'z'].
 
            Other forms of interval are recognized by the parser
            but rejected by the type-checker. *)
   | Ppat_tuple of pattern list
-        (** Patterns [(P1, ..., Pn)].
+      (** Patterns [(P1, ..., Pn)].
 
            Invariant: [n >= 2]
         *)
-  | Ppat_construct of
-      Longident.t loc * (string loc list * pattern) option
-        (** [Ppat_construct(loc, c)] represents:
+  | Ppat_construct of Longident.t loc * (string loc list * pattern) option
+      (** [Ppat_construct(loc, c)] represents:
             - [C]               when [c] is [None],
             - [C P]             when [c] is [Some ([], P)]
             - [C (P1, ..., Pn)] when [c] is [Some ([], Ppat_tuple [P1; ...; Pn])]
             - [C (type a b) P]  when [c] is [Some ([a; b], P)]
          *)
   | Ppat_variant of label * pattern option
-        (** [Ppat_variant(lbl, pat)] represents:
+      (** [Ppat_variant(lbl, pat)] represents:
             - [`A]   when [pat] is [None],
             - [`A P] when [pat] is [Some P]
          *)
   | Ppat_record of (Longident.t loc * pattern) list * closed_flag
-        (** [Ppat_record([(l1, P1) ; ... ; (ln, Pn)], flag)] represents:
+      (** [Ppat_record([(l1, P1) ; ... ; (ln, Pn)], flag)] represents:
             - [{ l1=P1; ...; ln=Pn }]
-                 when [flag] is {{!Asttypes.Closed}[Closed]}
+                 when [flag] is {{!Asttypes.closed_flag.Closed}[Closed]}
             - [{ l1=P1; ...; ln=Pn; _}]
-                 when [flag] is {{!Asttypes.Open}[Open]}
+                 when [flag] is {{!Asttypes.closed_flag.Open}[Open]}
 
            Invariant: [n > 0]
          *)
-  | Ppat_array of pattern list
-        (** Pattern [[| P1; ...; Pn |]] *)
-  | Ppat_or of pattern * pattern
-        (** Pattern [P1 | P2] *)
-  | Ppat_constraint of pattern * core_type
-        (** Pattern [(P : T)] *)
-  | Ppat_type of Longident.t loc
-        (** Pattern [#tconst] *)
-  | Ppat_lazy of pattern
-        (** Pattern [lazy P] *)
+  | Ppat_array of pattern list  (** Pattern [[| P1; ...; Pn |]] *)
+  | Ppat_or of pattern * pattern  (** Pattern [P1 | P2] *)
+  | Ppat_constraint of pattern * core_type  (** Pattern [(P : T)] *)
+  | Ppat_type of Longident.t loc  (** Pattern [#tconst] *)
+  | Ppat_lazy of pattern  (** Pattern [lazy P] *)
   | Ppat_unpack of string option loc
-        (** [Ppat_unpack(s)] represents:
+      (** [Ppat_unpack(s)] represents:
             - [(module P)] when [s] is [Some "P"]
             - [(module _)] when [s] is [None]
 
            Note: [(module P : S)] is represented as
            [Ppat_constraint(Ppat_unpack(Some "P"), Ptyp_package S)]
          *)
-  | Ppat_exception of pattern
-        (** Pattern [exception P] *)
-  | Ppat_extension of extension
-        (** Pattern [[%id]] *)
-  | Ppat_open of Longident.t loc * pattern
-        (** Pattern [M.(P)] *)
+  | Ppat_exception of pattern  (** Pattern [exception P] *)
+  | Ppat_extension of extension  (** Pattern [[%id]] *)
+  | Ppat_open of Longident.t loc * pattern  (** Pattern [M.(P)] *)
 
 (** {2 Value expressions} *)
 
-and expression =
-    {
-     pexp_desc: expression_desc;
-     pexp_loc: Location.t;
-     pexp_loc_stack: location_stack;
-     pexp_attributes: attributes;  (** [... [\@id1] [\@id2]] *)
-    }
+and expression = {
+  pexp_desc : expression_desc;
+  pexp_loc : Location.t;
+  pexp_loc_stack : location_stack;
+  pexp_attributes : attributes;  (** [... [\@id1] [\@id2]] *)
+}
 
 and expression_desc =
   | Pexp_ident of Longident.t loc
-        (** Identifiers such as [x] and [M.x]
+      (** Identifiers such as [x] and [M.x]
          *)
   | Pexp_constant of constant
-        (** Expressions constant such as [1], ['a'], ["true"], [1.0], [1l],
+      (** Expressions constant such as [1], ['a'], ["true"], [1.0], [1l],
             [1L], [1n] *)
   | Pexp_let of rec_flag * value_binding list * expression
-        (** [Pexp_let(flag, [(P1,E1) ; ... ; (Pn,En)], E)] represents:
+      (** [Pexp_let(flag, [(P1,E1) ; ... ; (Pn,En)], E)] represents:
             - [let P1 = E1 and ... and Pn = EN in E]
-                 when [flag] is {{!Asttypes.Nonrecursive}[Nonrecursive]},
+               when [flag] is {{!Asttypes.rec_flag.Nonrecursive}[Nonrecursive]},
             - [let rec P1 = E1 and ... and Pn = EN in E]
-                 when [flag] is {{!Asttypes.Recursive}[Recursive]}.
+               when [flag] is {{!Asttypes.rec_flag.Recursive}[Recursive]}.
          *)
-  | Pexp_function of case list
-        (** [function P1 -> E1 | ... | Pn -> En] *)
+  | Pexp_function of case list  (** [function P1 -> E1 | ... | Pn -> En] *)
   | Pexp_fun of arg_label * expression option * pattern * expression
-        (** [Pexp_fun(lbl, exp1, pat, expr2)] represents:
-            - [fun P -> E1]     when [lbl] is {{!Asttypes.Nolabel}[Nolabel]}
-                                 and [exp1] is [None]
-            - [fun ~l:P -> E1]  when [lbl] is {{!Asttypes.Labelled}[Labelled l]}
-                                 and [exp1] is [None]
-            - [fun ?l:P -> E1]  when [lbl] is {{!Asttypes.Optional}[Optional l]}
-                                 and [exp1] is [None]
+      (** [Pexp_fun(lbl, exp1, pat, expr2)] represents:
+            - [fun P -> E1]
+                      when [lbl] is {{!Asttypes.arg_label.Nolabel}[Nolabel]}
+                       and [exp1] is [None]
+            - [fun ~l:P -> E1]
+                      when [lbl] is {{!Asttypes.arg_label.Labelled}[Labelled l]}
+                       and [exp1] is [None]
+            - [fun ?l:P -> E1]
+                      when [lbl] is {{!Asttypes.arg_label.Optional}[Optional l]}
+                       and [exp1] is [None]
             - [fun ?l:(P = E0) -> E1]
-                                when [lbl] is {{!Asttypes.Optional}[Optional l]}
-                                 and [exp1] is [Some E0]
+                      when [lbl] is {{!Asttypes.arg_label.Optional}[Optional l]}
+                       and [exp1] is [Some E0]
 
            Notes:
-           - If [E0] is provided, only {{!Asttypes.Optional}[Optional]} is
-            allowed.
-           - [fun P1 P2 .. Pn -> E1] is represented as nested {!Pexp_fun}.
-           - [let f P = E] is represented using {!Pexp_fun}.
+           - If [E0] is provided, only {{!Asttypes.arg_label.Optional}[Optional]}
+             is allowed.
+           - [fun P1 P2 .. Pn -> E1] is represented as nested
+             {{!expression_desc.Pexp_fun}[Pexp_fun]}.
+           - [let f P = E] is represented using
+             {{!expression_desc.Pexp_fun}[Pexp_fun]}.
          *)
   | Pexp_apply of expression * (arg_label * expression) list
-        (** [Pexp_apply(E0, [(l1, E1) ; ... ; (ln, En)])]
+      (** [Pexp_apply(E0, [(l1, E1) ; ... ; (ln, En)])]
             represents [E0 ~l1:E1 ... ~ln:En]
 
-            [li] can be {{!Asttypes.Nolabel}[Nolabel]}   (non labeled argument),
-                        {{!Asttypes.Labelled}[Labelled]} (labelled arguments) or
-                        {{!Asttypes.Optional}[Optional]} (optional argument).
+            [li] can be
+              {{!Asttypes.arg_label.Nolabel}[Nolabel]}   (non labeled argument),
+              {{!Asttypes.arg_label.Labelled}[Labelled]} (labelled arguments) or
+              {{!Asttypes.arg_label.Optional}[Optional]} (optional argument).
 
            Invariant: [n > 0]
          *)
   | Pexp_match of expression * case list
-        (** [match E0 with P1 -> E1 | ... | Pn -> En] *)
+      (** [match E0 with P1 -> E1 | ... | Pn -> En] *)
   | Pexp_try of expression * case list
-        (** [try E0 with P1 -> E1 | ... | Pn -> En] *)
+      (** [try E0 with P1 -> E1 | ... | Pn -> En] *)
   | Pexp_tuple of expression list
-        (** Expressions [(E1, ..., En)]
+      (** Expressions [(E1, ..., En)]
 
            Invariant: [n >= 2]
         *)
   | Pexp_construct of Longident.t loc * expression option
-        (** [Pexp_construct(C, exp)] represents:
+      (** [Pexp_construct(C, exp)] represents:
            - [C]               when [exp] is [None],
            - [C E]             when [exp] is [Some E],
            - [C (E1, ..., En)] when [exp] is [Some (Pexp_tuple[E1;...;En])]
         *)
   | Pexp_variant of label * expression option
-        (** [Pexp_variant(`A, exp)] represents
+      (** [Pexp_variant(`A, exp)] represents
             - [`A]   when [exp] is [None]
             - [`A E] when [exp] is [Some E]
          *)
   | Pexp_record of (Longident.t loc * expression) list * expression option
-        (** [Pexp_record([(l1,P1) ; ... ; (ln,Pn)], exp)] represents
+      (** [Pexp_record([(l1,P1) ; ... ; (ln,Pn)], exp)] represents
             - [{ l1=P1; ...; ln=Pn }]         when [exp] is [None]
             - [{ E0 with l1=P1; ...; ln=Pn }] when [exp] is [Some E0]
 
            Invariant: [n > 0]
          *)
-  | Pexp_field of expression * Longident.t loc
-        (** [E.l] *)
+  | Pexp_field of expression * Longident.t loc  (** [E.l] *)
   | Pexp_setfield of expression * Longident.t loc * expression
-        (** [E1.l <- E2] *)
-  | Pexp_array of expression list
-        (** [[| E1; ...; En |]] *)
+      (** [E1.l <- E2] *)
+  | Pexp_array of expression list  (** [[| E1; ...; En |]] *)
   | Pexp_ifthenelse of expression * expression * expression option
-        (** [if E1 then E2 else E3] *)
-  | Pexp_sequence of expression * expression
-        (** [E1; E2] *)
-  | Pexp_while of expression * expression
-        (** [while E1 do E2 done] *)
-  | Pexp_for of
-      pattern * expression * expression * direction_flag * expression
-        (** [Pexp_for(i, E1, E2, direction, E3)] represents:
+      (** [if E1 then E2 else E3] *)
+  | Pexp_sequence of expression * expression  (** [E1; E2] *)
+  | Pexp_while of expression * expression  (** [while E1 do E2 done] *)
+  | Pexp_for of pattern * expression * expression * direction_flag * expression
+      (** [Pexp_for(i, E1, E2, direction, E3)] represents:
             - [for i = E1 to E2 do E3 done]
-                                when [direction] is {{!Asttypes.Upto}[Upto]}
+                 when [direction] is {{!Asttypes.direction_flag.Upto}[Upto]}
             - [for i = E1 downto E2 do E3 done]
-                                when [direction] is {{!Asttypes.Downto}[Downto]}
+                 when [direction] is {{!Asttypes.direction_flag.Downto}[Downto]}
          *)
-  | Pexp_constraint of expression * core_type
-        (** [(E : T)] *)
+  | Pexp_constraint of expression * core_type  (** [(E : T)] *)
   | Pexp_coerce of expression * core_type option * core_type
-        (** [Pexp_coerce(E, from, T)] represents
+      (** [Pexp_coerce(E, from, T)] represents
             - [(E :> T)]      when [from] is [None],
             - [(E : T0 :> T)] when [from] is [Some T0].
          *)
-  | Pexp_send of expression * label loc
-        (** [E # m] *)
-  | Pexp_new of Longident.t loc
-        (** [new M.c] *)
-  | Pexp_setinstvar of label loc * expression
-        (** [x <- 2] *)
+  | Pexp_send of expression * label loc  (** [E # m] *)
+  | Pexp_new of Longident.t loc  (** [new M.c] *)
+  | Pexp_setinstvar of label loc * expression  (** [x <- 2] *)
   | Pexp_override of (label loc * expression) list
-        (** [{< x1 = E1; ...; Xn = En >}] *)
+      (** [{< x1 = E1; ...; Xn = En >}] *)
   | Pexp_letmodule of string option loc * module_expr * expression
-        (** [let module M = ME in E] *)
+      (** [let module M = ME in E] *)
   | Pexp_letexception of extension_constructor * expression
-        (** [let exception C in E] *)
+      (** [let exception C in E] *)
   | Pexp_assert of expression
-        (** [assert E].
+      (** [assert E].
 
            Note: [assert false] is treated in a special way by the
            type-checker. *)
-  | Pexp_lazy of expression
-        (** [lazy E] *)
+  | Pexp_lazy of expression  (** [lazy E] *)
   | Pexp_poly of expression * core_type option
-        (** Used for method bodies.
+      (** Used for method bodies.
 
-           Can only be used as the expression under {!Cfk_concrete}
-           for methods (not values). *)
-  | Pexp_object of class_structure
-        (** [object ... end] *)
-  | Pexp_newtype of string loc * expression
-        (** [fun (type t) -> E] *)
+           Can only be used as the expression under
+           {{!class_field_kind.Cfk_concrete}[Cfk_concrete]} for methods (not
+           values). *)
+  | Pexp_object of class_structure  (** [object ... end] *)
+  | Pexp_newtype of string loc * expression  (** [fun (type t) -> E] *)
   | Pexp_pack of module_expr
-        (** [(module ME)].
+      (** [(module ME)].
 
            [(module ME : S)] is represented as
            [Pexp_constraint(Pexp_pack ME, Ptyp_package S)] *)
   | Pexp_open of open_declaration * expression
-        (** - [M.(E)]
+      (** - [M.(E)]
             - [let open M in E]
             - [let open! M in E] *)
   | Pexp_letop of letop
-        (** - [let* P = E0 in E1]
+      (** - [let* P = E0 in E1]
             - [let* P0 = E00 and* P1 = E01 in E1] *)
-  | Pexp_extension of extension
-        (** [[%id]] *)
-  | Pexp_unreachable
-        (** [.] *)
+  | Pexp_extension of extension  (** [[%id]] *)
+  | Pexp_unreachable  (** [.] *)
 
-and case =
-    {
-     pc_lhs: pattern;
-     pc_guard: expression option;
-     pc_rhs: expression;
-    }
+and case = {
+  pc_lhs : pattern;
+  pc_guard : expression option;
+  pc_rhs : expression;
+}
 (** Values of type {!case} represents [(P -> E)] or [(P when E0 -> E)] *)
 
-and letop =
-  {
-    let_ : binding_op;
-    ands : binding_op list;
-    body : expression;
-  }
+and letop = { let_ : binding_op; ands : binding_op list; body : expression }
 
-and binding_op =
-  {
-    pbop_op : string loc;
-    pbop_pat : pattern;
-    pbop_exp : expression;
-    pbop_loc : Location.t;
-  }
+and binding_op = {
+  pbop_op : string loc;
+  pbop_pat : pattern;
+  pbop_exp : expression;
+  pbop_loc : Location.t;
+}
 
 (** {2 Value descriptions} *)
 
-and value_description =
-    {
-     pval_name: string loc;
-     pval_type: core_type;
-     pval_prim: string list;
-     pval_attributes: attributes;  (** [... [\@\@id1] [\@\@id2]] *)
-     pval_loc: Location.t;
-    }
+and value_description = {
+  pval_name : string loc;
+  pval_type : core_type;
+  pval_prim : string list;
+  pval_attributes : attributes;  (** [... [\@\@id1] [\@\@id2]] *)
+  pval_loc : Location.t;
+}
 (** Values of type {!value_description} represents:
-    - [val x: T],                     when {!pval_prim} is [[]]
-    - [external x: T = "s1" ... "sn"] when {!pval_prim} is [["s1";..."sn"]]
+    - [val x: T],
+            when {{!value_description.pval_prim}[pval_prim]} is [[]]
+    - [external x: T = "s1" ... "sn"]
+            when {{!value_description.pval_prim}[pval_prim]} is [["s1";..."sn"]]
 *)
 
 (** {2 Type declarations} *)
 
-and type_declaration =
-    {
-     ptype_name: string loc;
-     ptype_params: (core_type * (variance * injectivity)) list;
-           (** [('a1,...'an) t] *)
-     ptype_cstrs: (core_type * core_type * Location.t) list;
-           (** [... constraint T1=T1'  ... constraint Tn=Tn'] *)
-     ptype_kind: type_kind;
-     ptype_private: private_flag;
-           (** for [= private ...] *)
-     ptype_manifest: core_type option;
-           (** represents [= T] *)
-     ptype_attributes: attributes;
-           (** [... [\@\@id1] [\@\@id2]] *)
-     ptype_loc: Location.t;
-    }
+and type_declaration = {
+  ptype_name : string loc;
+  ptype_params : (core_type * (variance * injectivity)) list;
+      (** [('a1,...'an) t] *)
+  ptype_cstrs : (core_type * core_type * Location.t) list;
+      (** [... constraint T1=T1'  ... constraint Tn=Tn'] *)
+  ptype_kind : type_kind;
+  ptype_private : private_flag;  (** for [= private ...] *)
+  ptype_manifest : core_type option;  (** represents [= T] *)
+  ptype_attributes : attributes;  (** [... [\@\@id1] [\@\@id2]] *)
+  ptype_loc : Location.t;
+}
 (**
    Here are type declarations and their representation,
-   for various {!ptype_kind} and {!ptype_manifest} values:
- - [type t]                     when [type_kind] is {!Ptype_abstract},
-                                 and [manifest]  is [None],
- - [type t = T0]                when [type_kind] is {!Ptype_abstract},
-                                 and [manifest]  is [Some T0],
- - [type t = C of T | ...]      when [type_kind] is {!Ptype_variant},
-                                 and [manifest]  is [None],
- - [type t = T0 = C of T | ...] when [type_kind] is {!Ptype_variant},
-                                 and [manifest]  is [Some T0],
- - [type t = {l: T; ...}]       when [type_kind] is {!Ptype_record},
-                                 and [manifest]  is [None],
- - [type t = T0 = {l : T; ...}] when [type_kind] is {!Ptype_record},
-                                 and [manifest]  is [Some T0],
- - [type t = ..]                when [type_kind] is {!Ptype_open},
-                                 and [manifest]  is [None].
+   for various {{!type_declaration.ptype_kind}[ptype_kind]}
+           and {{!type_declaration.ptype_manifest}[ptype_manifest]} values:
+ - [type t]   when [type_kind] is {{!type_kind.Ptype_abstract}[Ptype_abstract]},
+               and [manifest]  is [None],
+ - [type t = T0]
+              when [type_kind] is {{!type_kind.Ptype_abstract}[Ptype_abstract]},
+               and [manifest]  is [Some T0],
+ - [type t = C of T | ...]
+              when [type_kind] is {{!type_kind.Ptype_variant}[Ptype_variant]},
+               and [manifest]  is [None],
+ - [type t = T0 = C of T | ...]
+              when [type_kind] is {{!type_kind.Ptype_variant}[Ptype_variant]},
+               and [manifest]  is [Some T0],
+ - [type t = {l: T; ...}]
+              when [type_kind] is {{!type_kind.Ptype_record}[Ptype_record]},
+               and [manifest]  is [None],
+ - [type t = T0 = {l : T; ...}]
+              when [type_kind] is {{!type_kind.Ptype_record}[Ptype_record]},
+               and [manifest]  is [Some T0],
+ - [type t = ..]
+              when [type_kind] is {{!type_kind.Ptype_open}[Ptype_open]},
+               and [manifest]  is [None].
 *)
 
 and type_kind =
   | Ptype_abstract
   | Ptype_variant of constructor_declaration list
-  | Ptype_record of label_declaration list
-        (** Invariant: non-empty list *)
+  | Ptype_record of label_declaration list  (** Invariant: non-empty list *)
   | Ptype_open
 
-and label_declaration =
-    {
-     pld_name: string loc;
-     pld_mutable: mutable_flag;
-     pld_type: core_type;
-     pld_loc: Location.t;
-     pld_attributes: attributes; (** [l : T [\@id1] [\@id2]] *)
-    }
+and label_declaration = {
+  pld_name : string loc;
+  pld_mutable : mutable_flag;
+  pld_type : core_type;
+  pld_loc : Location.t;
+  pld_attributes : attributes;  (** [l : T [\@id1] [\@id2]] *)
+}
 (**
    - [{ ...; l: T; ... }]
-                      when {!pld_mutable} is {{!Asttypes.Immutable}[Immutable]},
+                           when {{!label_declaration.pld_mutable}[pld_mutable]}
+                             is {{!Asttypes.mutable_flag.Immutable}[Immutable]},
    - [{ ...; mutable l: T; ... }]
-                      when {!pld_mutable} is {{!Asttypes.Mutable}[Mutable]}.
+                           when {{!label_declaration.pld_mutable}[pld_mutable]}
+                             is {{!Asttypes.mutable_flag.Mutable}[Mutable]}.
 
-   Note: [T] can be a {!Ptyp_poly}.
+   Note: [T] can be a {{!core_type_desc.Ptyp_poly}[Ptyp_poly]}.
 *)
 
-and constructor_declaration =
-    {
-     pcd_name: string loc;
-     pcd_vars: string loc list;
-     pcd_args: constructor_arguments;
-     pcd_res: core_type option;
-     pcd_loc: Location.t;
-     pcd_attributes: attributes;  (** [C of ... [\@id1] [\@id2]] *)
-    }
+and constructor_declaration = {
+  pcd_name : string loc;
+  pcd_vars : string loc list;
+  pcd_args : constructor_arguments;
+  pcd_res : core_type option;
+  pcd_loc : Location.t;
+  pcd_attributes : attributes;  (** [C of ... [\@id1] [\@id2]] *)
+}
 
 and constructor_arguments =
   | Pcstr_tuple of core_type list
   | Pcstr_record of label_declaration list
-(** Values of type {!constructor_declaration}
+      (** Values of type {!constructor_declaration}
     represents the constructor arguments of:
   - [C of T1 * ... * Tn]     when [res = None],
                               and [args = Pcstr_tuple [T1; ... ; Tn]],
@@ -561,33 +535,30 @@ and constructor_arguments =
                               and [args = Pcstr_record [...]].
 *)
 
-and type_extension =
-    {
-     ptyext_path: Longident.t loc;
-     ptyext_params: (core_type * (variance * injectivity)) list;
-     ptyext_constructors: extension_constructor list;
-     ptyext_private: private_flag;
-     ptyext_loc: Location.t;
-     ptyext_attributes: attributes;  (** ... [\@\@id1] [\@\@id2] *)
-    }
+and type_extension = {
+  ptyext_path : Longident.t loc;
+  ptyext_params : (core_type * (variance * injectivity)) list;
+  ptyext_constructors : extension_constructor list;
+  ptyext_private : private_flag;
+  ptyext_loc : Location.t;
+  ptyext_attributes : attributes;  (** ... [\@\@id1] [\@\@id2] *)
+}
 (**
   Values of type [type_extension] represents [type t += ...].
 *)
 
-and extension_constructor =
-    {
-     pext_name: string loc;
-     pext_kind : extension_constructor_kind;
-     pext_loc : Location.t;
-     pext_attributes: attributes;  (** [C of ... [\@id1] [\@id2]] *)
-   }
+and extension_constructor = {
+  pext_name : string loc;
+  pext_kind : extension_constructor_kind;
+  pext_loc : Location.t;
+  pext_attributes : attributes;  (** [C of ... [\@id1] [\@id2]] *)
+}
 
-and type_exception =
-  {
-    ptyexn_constructor: extension_constructor;
-    ptyexn_loc: Location.t;
-    ptyexn_attributes: attributes;  (** [... [\@\@id1] [\@\@id2]] *)
-  }
+and type_exception = {
+  ptyexn_constructor : extension_constructor;
+  ptyexn_loc : Location.t;
+  ptyexn_attributes : attributes;  (** [... [\@\@id1] [\@\@id2]] *)
+}
 (** Values of type [type_exception] represents [exception E] *)
 
 and extension_constructor_kind =
@@ -612,80 +583,72 @@ and extension_constructor_kind =
                    {- [t_opt] is [Some T0].}}
        *)
   | Pext_rebind of Longident.t loc
-        (** [Pext_rebind(D)]
+      (** [Pext_rebind(D)]
             represents the new constructor description of [C = D] *)
 
 (** {1 Class language} *)
-
 (** {2 Type expressions for the class language} *)
 
-and class_type =
-    {
-     pcty_desc: class_type_desc;
-     pcty_loc: Location.t;
-     pcty_attributes: attributes; (** [... [\@id1] [\@id2]] *)
-    }
+and class_type = {
+  pcty_desc : class_type_desc;
+  pcty_loc : Location.t;
+  pcty_attributes : attributes;  (** [... [\@id1] [\@id2]] *)
+}
 
 and class_type_desc =
   | Pcty_constr of Longident.t loc * core_type list
-        (** - [c]
+      (** - [c]
             - [['a1, ..., 'an] c] *)
-  | Pcty_signature of class_signature
-        (** [object ... end] *)
+  | Pcty_signature of class_signature  (** [object ... end] *)
   | Pcty_arrow of arg_label * core_type * class_type
-        (** [Pcty_arrow(lbl, T, CT)] represents:
-            - [T -> CT]    when [lbl] is {{!Asttypes.Nolabel}[Nolabel]},
-            - [~l:T -> CT] when [lbl] is {{!Asttypes.Labelled}[Labelled l]},
-            - [?l:T -> CT] when [lbl] is {{!Asttypes.Optional}[Optional l]}.
+      (** [Pcty_arrow(lbl, T, CT)] represents:
+            - [T -> CT]
+                     when [lbl] is {{!Asttypes.arg_label.Nolabel}[Nolabel]},
+            - [~l:T -> CT]
+                     when [lbl] is {{!Asttypes.arg_label.Labelled}[Labelled l]},
+            - [?l:T -> CT]
+                     when [lbl] is {{!Asttypes.arg_label.Optional}[Optional l]}.
          *)
-  | Pcty_extension of extension
-        (** [%id] *)
-  | Pcty_open of open_description * class_type
-        (** [let open M in CT] *)
+  | Pcty_extension of extension  (** [%id] *)
+  | Pcty_open of open_description * class_type  (** [let open M in CT] *)
 
-and class_signature =
-    {
-     pcsig_self: core_type;
-     pcsig_fields: class_type_field list;
-    }
+and class_signature = {
+  pcsig_self : core_type;
+  pcsig_fields : class_type_field list;
+}
 (** Values of type [class_signature] represents:
     - [object('selfpat) ... end]
-    - [object ... end] when {!psig_self} is {!Ptyp_any}
+    - [object ... end] when {{!class_signature.pcsig_self}[pcsig_self]}
+                         is {{!core_type_desc.Ptyp_any}[Ptyp_any]}
 *)
 
-and class_type_field =
-    {
-     pctf_desc: class_type_field_desc;
-     pctf_loc: Location.t;
-     pctf_attributes: attributes;  (** [... [\@\@id1] [\@\@id2]] *)
-    }
+and class_type_field = {
+  pctf_desc : class_type_field_desc;
+  pctf_loc : Location.t;
+  pctf_attributes : attributes;  (** [... [\@\@id1] [\@\@id2]] *)
+}
 
 and class_type_field_desc =
-  | Pctf_inherit of class_type
-        (** [inherit CT] *)
+  | Pctf_inherit of class_type  (** [inherit CT] *)
   | Pctf_val of (label loc * mutable_flag * virtual_flag * core_type)
-        (** [val x: T] *)
+      (** [val x: T] *)
   | Pctf_method of (label loc * private_flag * virtual_flag * core_type)
-        (** [method x: T]
+      (** [method x: T]
 
-            Note: [T] can be a {!Ptyp_poly}.
+            Note: [T] can be a {{!core_type_desc.Ptyp_poly}[Ptyp_poly]}.
         *)
-  | Pctf_constraint of (core_type * core_type)
-        (** [constraint T1 = T2] *)
-  | Pctf_attribute of attribute
-        (** [[\@\@\@id]] *)
-  | Pctf_extension of extension
-        (** [[%%id]] *)
+  | Pctf_constraint of (core_type * core_type)  (** [constraint T1 = T2] *)
+  | Pctf_attribute of attribute  (** [[\@\@\@id]] *)
+  | Pctf_extension of extension  (** [[%%id]] *)
 
-and 'a class_infos =
-    {
-     pci_virt: virtual_flag;
-     pci_params: (core_type * (variance * injectivity)) list;
-     pci_name: string loc;
-     pci_expr: 'a;
-     pci_loc: Location.t;
-     pci_attributes: attributes;  (** [... [\@\@id1] [\@\@id2]] *)
-   }
+and 'a class_infos = {
+  pci_virt : virtual_flag;
+  pci_params : (core_type * (variance * injectivity)) list;
+  pci_name : string loc;
+  pci_expr : 'a;
+  pci_loc : Location.t;
+  pci_attributes : attributes;  (** [... [\@\@id1] [\@\@id2]] *)
+}
 (** Values of type [class_expr class_infos] represents:
     - [class c = ...]
     - [class ['a1,...,'an] c = ...]
@@ -695,37 +658,37 @@ and 'a class_infos =
 *)
 
 and class_description = class_type class_infos
-
 and class_type_declaration = class_type class_infos
 
 (** {2 Value expressions for the class language} *)
 
-and class_expr =
-    {
-     pcl_desc: class_expr_desc;
-     pcl_loc: Location.t;
-     pcl_attributes: attributes;  (** [... [\@id1] [\@id2]] *)
-    }
+and class_expr = {
+  pcl_desc : class_expr_desc;
+  pcl_loc : Location.t;
+  pcl_attributes : attributes;  (** [... [\@id1] [\@id2]] *)
+}
 
 and class_expr_desc =
   | Pcl_constr of Longident.t loc * core_type list
-        (** [c] and [['a1, ..., 'an] c] *)
-  | Pcl_structure of class_structure
-        (** [object ... end] *)
+      (** [c] and [['a1, ..., 'an] c] *)
+  | Pcl_structure of class_structure  (** [object ... end] *)
   | Pcl_fun of arg_label * expression option * pattern * class_expr
-        (** [Pcl_fun(lbl, exp, P, CE)] represents:
-            - [fun P -> CE]     when [lbl] is {{!Asttypes.Nolabel}[Nolabel]}
-                                 and [exp] is [None],
-            - [fun ~l:P -> CE]  when [lbl] is {{!Asttypes.Labelled}[Labelled l]}
-                                 and [exp] is [None],
-            - [fun ?l:P -> CE]  when [lbl] is {{!Asttypes.Optional}[Optional l]}
-                                 and [exp] is [None],
+      (** [Pcl_fun(lbl, exp, P, CE)] represents:
+            - [fun P -> CE]
+                      when [lbl] is {{!Asttypes.arg_label.Nolabel}[Nolabel]}
+                       and [exp] is [None],
+            - [fun ~l:P -> CE]
+                      when [lbl] is {{!Asttypes.arg_label.Labelled}[Labelled l]}
+                       and [exp] is [None],
+            - [fun ?l:P -> CE]
+                      when [lbl] is {{!Asttypes.arg_label.Optional}[Optional l]}
+                       and [exp] is [None],
             - [fun ?l:(P = E0) -> CE]
-                                when [lbl] is {{!Asttypes.Optional}[Optional l]}
-                                 and [exp] is [Some E0].
+                      when [lbl] is {{!Asttypes.arg_label.Optional}[Optional l]}
+                       and [exp] is [Some E0].
         *)
   | Pcl_apply of class_expr * (arg_label * expression) list
-        (** [Pcl_apply(CE, [(l1,E1) ; ... ; (ln,En)])]
+      (** [Pcl_apply(CE, [(l1,E1) ; ... ; (ln,En)])]
             represents [CE ~l1:E1 ... ~ln:En].
             [li] can be empty (non labeled argument) or start with [?]
             (optional argument).
@@ -733,75 +696,70 @@ and class_expr_desc =
             Invariant: [n > 0]
         *)
   | Pcl_let of rec_flag * value_binding list * class_expr
-        (** [Pcl_let(rec, [(P1, E1); ... ; (Pn, En)], CE)] represents:
+      (** [Pcl_let(rec, [(P1, E1); ... ; (Pn, En)], CE)] represents:
             - [let P1 = E1 and ... and Pn = EN in CE]
-                         when [rec] is {{!Asttypes.Nonrecursive}[Nonrecursive]},
+                when [rec] is {{!Asttypes.rec_flag.Nonrecursive}[Nonrecursive]},
             - [let rec P1 = E1 and ... and Pn = EN in CE]
-                         when [rec] is {{!Asttypes.Recursive}[Recursive]}.
+                when [rec] is {{!Asttypes.rec_flag.Recursive}[Recursive]}.
         *)
-  | Pcl_constraint of class_expr * class_type
-        (** [(CE : CT)] *)
-  | Pcl_extension of extension
-        (** [[%id]] *)
-  | Pcl_open of open_description * class_expr
-        (** [let open M in CE] *)
+  | Pcl_constraint of class_expr * class_type  (** [(CE : CT)] *)
+  | Pcl_extension of extension  (** [[%id]] *)
+  | Pcl_open of open_description * class_expr  (** [let open M in CE] *)
 
-and class_structure =
-    {
-     pcstr_self: pattern;
-     pcstr_fields: class_field list;
-    }
+and class_structure = { pcstr_self : pattern; pcstr_fields : class_field list }
 (** Values of type {!class_structure} represents:
     - [object(selfpat) ... end]
-    - [object ... end] when {!pcstr_self} is {!Ppat_any}
+    - [object ... end] when {{!class_structure.pcstr_self}[pcstr_self]}
+                         is {{!pattern_desc.Ppat_any}[Ppat_any]}
 *)
 
-and class_field =
-    {
-     pcf_desc: class_field_desc;
-     pcf_loc: Location.t;
-     pcf_attributes: attributes;  (** [... [\@\@id1] [\@\@id2]] *)
-    }
+and class_field = {
+  pcf_desc : class_field_desc;
+  pcf_loc : Location.t;
+  pcf_attributes : attributes;  (** [... [\@\@id1] [\@\@id2]] *)
+}
 
 and class_field_desc =
   | Pcf_inherit of override_flag * class_expr * string loc option
-        (** [Pcf_inherit(flag, CE, s)] represents:
-            - [inherit CE]       when [flag] is {{!Asttypes.Fresh}[Fresh]}
-                                  and [s] is [None],
-            - [inherit CE as x]  when [flag] is {{!Asttypes.Fresh}[Fresh]}
-                                  and [s] is [Some x],
-            - [inherit! CE]      when [flag] is {{!Asttypes.Override}[Override]}
-                                  and [s] is [None],
-            - [inherit! CE as x] when [flag] is {{!Asttypes.Override}[Override]}
-                                  and [s] is [Some x]
+      (** [Pcf_inherit(flag, CE, s)] represents:
+            - [inherit CE]
+                    when [flag] is {{!Asttypes.override_flag.Fresh}[Fresh]}
+                     and [s] is [None],
+            - [inherit CE as x]
+                   when [flag] is {{!Asttypes.override_flag.Fresh}[Fresh]}
+                    and [s] is [Some x],
+            - [inherit! CE]
+                   when [flag] is {{!Asttypes.override_flag.Override}[Override]}
+                    and [s] is [None],
+            - [inherit! CE as x]
+                   when [flag] is {{!Asttypes.override_flag.Override}[Override]}
+                    and [s] is [Some x]
   *)
   | Pcf_val of (label loc * mutable_flag * class_field_kind)
-        (** [Pcf_val(x,flag, kind)] represents:
+      (** [Pcf_val(x,flag, kind)] represents:
             - [val x = E]
-                        when [flag] is {{!Asttypes.Immutable}[Immutable]}
-                         and [kind] is {{!Cfk_concrete}[Cfk_concrete(Fresh, E)]}
+       when [flag] is {{!Asttypes.mutable_flag.Immutable}[Immutable]}
+        and [kind] is {{!class_field_kind.Cfk_concrete}[Cfk_concrete(Fresh, E)]}
             - [val virtual x: T]
-                        when [flag] is {{!Asttypes.Immutable}[Immutable]}
-                         and [kind] is {{!Cfk_concrete}[Cfk_virtual(T)]}
+       when [flag] is {{!Asttypes.mutable_flag.Immutable}[Immutable]}
+        and [kind] is {{!class_field_kind.Cfk_virtual}[Cfk_virtual(T)]}
             - [val mutable x = E]
-                        when [flag] is {{!Asttypes.Mutable}[Mutable]}
-                         and [kind] is {{!Cfk_concrete}[Cfk_concrete(Fresh, E)]}
+       when [flag] is {{!Asttypes.mutable_flag.Mutable}[Mutable]}
+        and [kind] is {{!class_field_kind.Cfk_concrete}[Cfk_concrete(Fresh, E)]}
             - [val mutable virtual x: T]
-                        when [flag] is {{!Asttypes.Mutable}[Mutable]}
-                         and [kind] is {{!Cfk_concrete}[Cfk_virtual(T)]}
+       when [flag] is {{!Asttypes.mutable_flag.Mutable}[Mutable]}
+        and [kind] is {{!class_field_kind.Cfk_virtual}[Cfk_virtual(T)]}
   *)
   | Pcf_method of (label loc * private_flag * class_field_kind)
-        (** - [method x = E]            ([E] can be a {!Pexp_poly})
-            - [method virtual x: T]     ([T] can be a {!Ptyp_poly})
+      (** - [method x = E]
+                        ([E] can be a {{!expression_desc.Pexp_poly}[Pexp_poly]})
+            - [method virtual x: T]
+                        ([T] can be a {{!core_type_desc.Ptyp_poly}[Ptyp_poly]})
   *)
-  | Pcf_constraint of (core_type * core_type)
-        (** [constraint T1 = T2] *)
-  | Pcf_initializer of expression
-        (** [initializer E] *)
-  | Pcf_attribute of attribute
-        (** [[\@\@\@id]] *)
-  | Pcf_extension of extension
-        (** [[%%id]] *)
+  | Pcf_constraint of (core_type * core_type)  (** [constraint T1 = T2] *)
+  | Pcf_initializer of expression  (** [initializer E] *)
+  | Pcf_attribute of attribute  (** [[\@\@\@id]] *)
+  | Pcf_extension of extension  (** [[%%id]] *)
 
 and class_field_kind =
   | Cfk_virtual of core_type
@@ -810,125 +768,102 @@ and class_field_kind =
 and class_declaration = class_expr class_infos
 
 (** {1 Module language} *)
-
 (** {2 Type expressions for the module language} *)
 
-and module_type =
-    {
-     pmty_desc: module_type_desc;
-     pmty_loc: Location.t;
-     pmty_attributes: attributes;  (** [... [\@id1] [\@id2]] *)
-    }
+and module_type = {
+  pmty_desc : module_type_desc;
+  pmty_loc : Location.t;
+  pmty_attributes : attributes;  (** [... [\@id1] [\@id2]] *)
+}
 
 and module_type_desc =
-  | Pmty_ident of Longident.t loc
-        (** [Pmty_ident(S)] represents [S] *)
-  | Pmty_signature of signature
-        (** [sig ... end] *)
+  | Pmty_ident of Longident.t loc  (** [Pmty_ident(S)] represents [S] *)
+  | Pmty_signature of signature  (** [sig ... end] *)
   | Pmty_functor of functor_parameter * module_type
-        (** [functor(X : MT1) -> MT2] *)
-  | Pmty_with of module_type * with_constraint list
-        (** [MT with ...] *)
-  | Pmty_typeof of module_expr
-        (** [module type of ME] *)
-  | Pmty_extension of extension
-        (** [[%id]] *)
-  | Pmty_alias of Longident.t loc
-        (** [(module M)] *)
+      (** [functor(X : MT1) -> MT2] *)
+  | Pmty_with of module_type * with_constraint list  (** [MT with ...] *)
+  | Pmty_typeof of module_expr  (** [module type of ME] *)
+  | Pmty_extension of extension  (** [[%id]] *)
+  | Pmty_alias of Longident.t loc  (** [(module M)] *)
 
 and functor_parameter =
-  | Unit
-        (** [()] *)
+  | Unit  (** [()] *)
   | Named of string option loc * module_type
-        (** [Named(name, MT)] represents:
+      (** [Named(name, MT)] represents:
             - [(X : MT)] when [name] is [Some X],
             - [(_ : MT)] when [name] is [None] *)
 
 and signature = signature_item list
-
-and signature_item =
-    {
-     psig_desc: signature_item_desc;
-     psig_loc: Location.t;
-    }
+and signature_item = { psig_desc : signature_item_desc; psig_loc : Location.t }
 
 and signature_item_desc =
   | Psig_value of value_description
-        (** - [val x: T]
+      (** - [val x: T]
             - [external x: T = "s1" ... "sn"]
          *)
   | Psig_type of rec_flag * type_declaration list
-        (** [type t1 = ... and ... and tn  = ...] *)
+      (** [type t1 = ... and ... and tn  = ...] *)
   | Psig_typesubst of type_declaration list
-        (** [type t1 := ... and ... and tn := ...]  *)
-  | Psig_typext of type_extension
-        (** [type t1 += ...] *)
-  | Psig_exception of type_exception
-        (** [exception C of T] *)
-  | Psig_module of module_declaration
-        (** [module X = M] and [module X : MT] *)
-  | Psig_modsubst of module_substitution
-        (** [module X := M] *)
+      (** [type t1 := ... and ... and tn := ...]  *)
+  | Psig_typext of type_extension  (** [type t1 += ...] *)
+  | Psig_exception of type_exception  (** [exception C of T] *)
+  | Psig_module of module_declaration  (** [module X = M] and [module X : MT] *)
+  | Psig_modsubst of module_substitution  (** [module X := M] *)
   | Psig_recmodule of module_declaration list
-        (** [module rec X1 : MT1 and ... and Xn : MTn] *)
+      (** [module rec X1 : MT1 and ... and Xn : MTn] *)
   | Psig_modtype of module_type_declaration
-        (** [module type S = MT] and [module type S] *)
+      (** [module type S = MT] and [module type S] *)
   | Psig_modtypesubst of module_type_declaration
-        (** [module type S :=  ...]  *)
-  | Psig_open of open_description
-        (** [open X] *)
-  | Psig_include of include_description
-        (** [include MT] *)
+      (** [module type S :=  ...]  *)
+  | Psig_open of open_description  (** [open X] *)
+  | Psig_include of include_description  (** [include MT] *)
   | Psig_class of class_description list
-        (** [class c1 : ... and ... and cn : ...] *)
+      (** [class c1 : ... and ... and cn : ...] *)
   | Psig_class_type of class_type_declaration list
-        (** [class type ct1 = ... and ... and ctn = ...] *)
-  | Psig_attribute of attribute
-        (** [[\@\@\@id]] *)
-  | Psig_extension of extension * attributes
-        (** [[%%id]] *)
+      (** [class type ct1 = ... and ... and ctn = ...] *)
+  | Psig_attribute of attribute  (** [[\@\@\@id]] *)
+  | Psig_extension of extension * attributes  (** [[%%id]] *)
 
-and module_declaration =
-    {
-     pmd_name: string option loc;
-     pmd_type: module_type;
-     pmd_attributes: attributes;  (** [... [\@\@id1] [\@\@id2]] *)
-     pmd_loc: Location.t;
-    }
+and module_declaration = {
+  pmd_name : string option loc;
+  pmd_type : module_type;
+  pmd_attributes : attributes;  (** [... [\@\@id1] [\@\@id2]] *)
+  pmd_loc : Location.t;
+}
 (** Values of type [module_declaration] represents [S : MT] *)
 
-and module_substitution =
-    {
-     pms_name: string loc;
-     pms_manifest: Longident.t loc;
-     pms_attributes: attributes;  (** [... [\@\@id1] [\@\@id2]] *)
-     pms_loc: Location.t;
-    }
+and module_substitution = {
+  pms_name : string loc;
+  pms_manifest : Longident.t loc;
+  pms_attributes : attributes;  (** [... [\@\@id1] [\@\@id2]] *)
+  pms_loc : Location.t;
+}
 (** Values of type [module_substitution] represents [S := M] *)
 
-and module_type_declaration =
-    {
-     pmtd_name: string loc;
-     pmtd_type: module_type option;
-     pmtd_attributes: attributes;  (** [... [\@\@id1] [\@\@id2]] *)
-     pmtd_loc: Location.t;
-    }
+and module_type_declaration = {
+  pmtd_name : string loc;
+  pmtd_type : module_type option;
+  pmtd_attributes : attributes;  (** [... [\@\@id1] [\@\@id2]] *)
+  pmtd_loc : Location.t;
+}
 (** Values of type [module_type_declaration] represents:
    - [S = MT],
-   - [S]  for abstract module type declaration, when {!pmtd_type} is [None].
+   - [S] for abstract module type declaration,
+     when {{!module_type_declaration.pmtd_type}[pmtd_type]} is [None].
 *)
 
-and 'a open_infos =
-    {
-     popen_expr: 'a;
-     popen_override: override_flag;
-     popen_loc: Location.t;
-     popen_attributes: attributes;
-    }
+and 'a open_infos = {
+  popen_expr : 'a;
+  popen_override : override_flag;
+  popen_loc : Location.t;
+  popen_attributes : attributes;
+}
 (** Values of type [’a open_infos] represents:
-    - [open! X] when {!popen_override} is {{!Asttypes.Override}[Override]}
+    - [open! X] when {{!open_infos.popen_override}[popen_override]}
+                  is {{!Asttypes.override_flag.Override}[Override]}
     (silences the "used identifier shadowing" warning)
-    - [open  X] when {!popen_override} is {{!Asttypes.Fresh}[Fresh]}
+    - [open  X] when {{!open_infos.popen_override}[popen_override]}
+                  is {{!Asttypes.override_flag.Fresh}[Fresh]}
 *)
 
 and open_description = Longident.t loc open_infos
@@ -942,12 +877,11 @@ and open_declaration = module_expr open_infos
     - [open M(N).O]
     - [open struct ... end] *)
 
-and 'a include_infos =
-    {
-     pincl_mod: 'a;
-     pincl_loc: Location.t;
-     pincl_attributes: attributes;
-    }
+and 'a include_infos = {
+  pincl_mod : 'a;
+  pincl_loc : Location.t;
+  pincl_attributes : attributes;
+}
 
 and include_description = module_type include_infos
 (** Values of type [include_description] represents [include MT] *)
@@ -957,108 +891,86 @@ and include_declaration = module_expr include_infos
 
 and with_constraint =
   | Pwith_type of Longident.t loc * type_declaration
-        (** [with type X.t = ...]
+      (** [with type X.t = ...]
 
             Note: the last component of the longident must match
             the name of the type_declaration. *)
   | Pwith_module of Longident.t loc * Longident.t loc
-        (** [with module X.Y = Z] *)
+      (** [with module X.Y = Z] *)
   | Pwith_modtype of Longident.t loc * module_type
-        (** [with module type X.Y = Z] *)
+      (** [with module type X.Y = Z] *)
   | Pwith_modtypesubst of Longident.t loc * module_type
-        (** [with module type X.Y := sig end] *)
+      (** [with module type X.Y := sig end] *)
   | Pwith_typesubst of Longident.t loc * type_declaration
-        (** [with type X.t := ..., same format as [Pwith_type]] *)
+      (** [with type X.t := ..., same format as [Pwith_type]] *)
   | Pwith_modsubst of Longident.t loc * Longident.t loc
-        (** [with module X.Y := Z] *)
+      (** [with module X.Y := Z] *)
 
 (** {2 Value expressions for the module language} *)
 
-and module_expr =
-    {
-     pmod_desc: module_expr_desc;
-     pmod_loc: Location.t;
-     pmod_attributes: attributes;  (** [... [\@id1] [\@id2]] *)
-    }
+and module_expr = {
+  pmod_desc : module_expr_desc;
+  pmod_loc : Location.t;
+  pmod_attributes : attributes;  (** [... [\@id1] [\@id2]] *)
+}
 
 and module_expr_desc =
-  | Pmod_ident of Longident.t loc
-        (** [X] *)
-  | Pmod_structure of structure
-        (** [struct ... end] *)
+  | Pmod_ident of Longident.t loc  (** [X] *)
+  | Pmod_structure of structure  (** [struct ... end] *)
   | Pmod_functor of functor_parameter * module_expr
-        (** [functor(X : MT1) -> ME] *)
-  | Pmod_apply of module_expr * module_expr
-        (** [ME1(ME2)] *)
-  | Pmod_constraint of module_expr * module_type
-        (** [(ME : MT)] *)
-  | Pmod_unpack of expression
-        (** [(val E)] *)
-  | Pmod_extension of extension
-        (** [[%id]] *)
+      (** [functor(X : MT1) -> ME] *)
+  | Pmod_apply of module_expr * module_expr  (** [ME1(ME2)] *)
+  | Pmod_constraint of module_expr * module_type  (** [(ME : MT)] *)
+  | Pmod_unpack of expression  (** [(val E)] *)
+  | Pmod_extension of extension  (** [[%id]] *)
 
 and structure = structure_item list
-
-and structure_item =
-    {
-     pstr_desc: structure_item_desc;
-     pstr_loc: Location.t;
-    }
+and structure_item = { pstr_desc : structure_item_desc; pstr_loc : Location.t }
 
 and structure_item_desc =
-  | Pstr_eval of expression * attributes
-        (** [E] *)
+  | Pstr_eval of expression * attributes  (** [E] *)
   | Pstr_value of rec_flag * value_binding list
-        (** [Pstr_value(rec, [(P1, E1 ; ... ; (Pn, En))])] represents:
+      (** [Pstr_value(rec, [(P1, E1 ; ... ; (Pn, En))])] represents:
             - [let P1 = E1 and ... and Pn = EN]
-                         when [rec] is {{!Asttypes.Nonrecursive}[Nonrecursive]},
+                when [rec] is {{!Asttypes.rec_flag.Nonrecursive}[Nonrecursive]},
             - [let rec P1 = E1 and ... and Pn = EN ]
-                         when [rec] is {{!Asttypes.Recursive}[Recursive]}.
+                when [rec] is {{!Asttypes.rec_flag.Recursive}[Recursive]}.
         *)
   | Pstr_primitive of value_description
-        (** - [val x: T]
+      (** - [val x: T]
             - [external x: T = "s1" ... "sn" ]*)
   | Pstr_type of rec_flag * type_declaration list
-        (** [type t1 = ... and ... and tn = ...] *)
-  | Pstr_typext of type_extension
-        (** [type t1 += ...] *)
+      (** [type t1 = ... and ... and tn = ...] *)
+  | Pstr_typext of type_extension  (** [type t1 += ...] *)
   | Pstr_exception of type_exception
-        (** - [exception C of T]
+      (** - [exception C of T]
             - [exception C = M.X] *)
-  | Pstr_module of module_binding
-        (** [module X = ME] *)
+  | Pstr_module of module_binding  (** [module X = ME] *)
   | Pstr_recmodule of module_binding list
-        (** [module rec X1 = ME1 and ... and Xn = MEn] *)
-  | Pstr_modtype of module_type_declaration
-        (** [module type S = MT] *)
-  | Pstr_open of open_declaration
-        (** [open X] *)
+      (** [module rec X1 = ME1 and ... and Xn = MEn] *)
+  | Pstr_modtype of module_type_declaration  (** [module type S = MT] *)
+  | Pstr_open of open_declaration  (** [open X] *)
   | Pstr_class of class_declaration list
-        (** [class c1 = ... and ... and cn = ...] *)
+      (** [class c1 = ... and ... and cn = ...] *)
   | Pstr_class_type of class_type_declaration list
-        (** [class type ct1 = ... and ... and ctn = ...] *)
-  | Pstr_include of include_declaration
-        (** [include ME] *)
-  | Pstr_attribute of attribute
-        (** [[\@\@\@id]] *)
-  | Pstr_extension of extension * attributes
-        (** [[%%id]] *)
+      (** [class type ct1 = ... and ... and ctn = ...] *)
+  | Pstr_include of include_declaration  (** [include ME] *)
+  | Pstr_attribute of attribute  (** [[\@\@\@id]] *)
+  | Pstr_extension of extension * attributes  (** [[%%id]] *)
 
-and value_binding =
-  {
-    pvb_pat: pattern;
-    pvb_expr: expression;
-    pvb_attributes: attributes;
-    pvb_loc: Location.t;
-  }
+and value_binding = {
+  pvb_pat : pattern;
+  pvb_expr : expression;
+  pvb_attributes : attributes;
+  pvb_loc : Location.t;
+}
 
-and module_binding =
-    {
-     pmb_name: string option loc;
-     pmb_expr: module_expr;
-     pmb_attributes: attributes;
-     pmb_loc: Location.t;
-    }
+and module_binding = {
+  pmb_name : string option loc;
+  pmb_expr : module_expr;
+  pmb_attributes : attributes;
+  pmb_loc : Location.t;
+}
 (** Values of type [module_binding] represents [module X = ME] *)
 
 (** {1 Toplevel} *)
@@ -1067,21 +979,18 @@ and module_binding =
 
 type toplevel_phrase =
   | Ptop_def of structure
-  | Ptop_dir of toplevel_directive
-     (** [#use], [#load] ... *)
+  | Ptop_dir of toplevel_directive  (** [#use], [#load] ... *)
 
-and toplevel_directive =
-  {
-    pdir_name : string loc;
-    pdir_arg : directive_argument option;
-    pdir_loc : Location.t;
-  }
+and toplevel_directive = {
+  pdir_name : string loc;
+  pdir_arg : directive_argument option;
+  pdir_loc : Location.t;
+}
 
-and directive_argument =
-  {
-    pdira_desc : directive_argument_desc;
-    pdira_loc : Location.t;
-  }
+and directive_argument = {
+  pdira_desc : directive_argument_desc;
+  pdira_loc : Location.t;
+}
 
 and directive_argument_desc =
   | Pdir_string of string


### PR DESCRIPTION
This PR odocifies the comments in `parsetree.mli`.

Here are a few comments:
- I tried to keep the "ascii" readability in the code for people to read comments in the file
- `odoc` and `ocamldoc` seem to have a difference in their handling of the `@` character inside code blocks. `[@]` is accepted and rendered well by `odoc`, but refused by `ocamldoc` which interprets it as a tag. I escaped the `@` character to have both doc generator work, with the drawback that `odoc` displays `\@` instead of `@`.
- Some comments were not up to date, I updated and/or completed them when I felt sure of myself (for instance, `Simple` was often used instead of `Nolabel`). However, I could not understand the `ptype_params` fields of the `type_declaration` type, and the old comment do not corresponds to the type, and I was not sure how to change the comment... I'll need to a hint to produce a good documentation!

To have a quick view of what it will look like with the most recent odoc layout, I uploaded the generated documentation [here](https://choum.net/panglesd/parsetree_with_comments/html/compilerlibref/Parsetree/index.html).