### PR TITLE
fix `fork()` usage in ocamltest

### DIFF
--- a/Changes
+++ b/Changes
@@ -181,9 +181,14 @@ Working version
   Unix.readlink on Windows.
   (David Allsopp, report by Xia Li-yao)
 
-
 - #11077: Make dumpobj compatible with absence of naked pointer support
   (Olivier Nicole and Jan Midtgaard, review by Gabriel Scherer)
+
+- #11111: fix fork() usage in ocamltest C code.
+  When calling fork() from C code with the Multicore runtime active,
+  one needs to call caml_atfork_hook() on the forked child before it
+  can use the OCaml runtime.
+  (Gabriel Scherer, review by Xavier Leroy, report by Brahima Dibassi)
 
 OCaml 4.14.0
 ----------------

--- a/ocamltest/Makefile
+++ b/ocamltest/Makefile
@@ -17,6 +17,9 @@
 
 ROOTDIR = ..
 
+# enable debug info for run_*.c
+CFLAGS=-g
+
 include $(ROOTDIR)/Makefile.common
 include $(ROOTDIR)/Makefile.best_binaries
 

--- a/ocamltest/run_unix.c
+++ b/ocamltest/run_unix.c
@@ -29,6 +29,7 @@
 
 #include "run.h"
 #include "run_common.h"
+#include <caml/domain.h>
 
 #define COREFILENAME "core"
 
@@ -346,6 +347,7 @@ int run_command(const command_settings *settings)
       myperror("fork");
       return -1;
     case 0: /* child process */
+      caml_atfork_hook();
       exit( run_command_child(settings) );
     default:
       return run_command_parent(settings, child_pid);


### PR DESCRIPTION
The error-reporting code in ocamltest's `run_unix.c` is incorrect with respect to the new Multicore runtime, because it tries to use the OCaml runtime (to write to an OCaml channel) without calling `caml_atfork_hook` first.

### reproduction information

Add

```c
child_error("boom");
```

at the entry of run_command_child in ocamltest/run_unix.c, then run

```
make -C ocamltest
./ocamltest/ocamltest testsuite/tests/lib-queue/test.ml
```

Observed output contains:

```
 ... testing 'test.ml' with 2 (bytecode) => Fatal error: Fatal error during unlock: Operation not permitted
Process 1228576 got signal 6(Aborted), core dumped
```

On my system, the core dump has the following backtrace:

```
(gdb) #0  0x00007f18a664e2a2 in raise () from /lib64/libc.so.6
#1  0x00007f18a66378a4 in abort () from /lib64/libc.so.6
#2  0x00000000004377e1 in caml_fatal_error (msg=msg@entry=0x4496e8 "Fatal error during %s: %s\n") at misc.c:117
#3  0x00000000004389bc in caml_plat_fatal_error (action=action@entry=0x44a63b "unlock", err=<optimized out>) at platform.c:36
#4  0x0000000000424b0e in check_err (err=<optimized out>, action=0x44a63b "unlock") at caml/platform.h:130
#5  caml_plat_unlock (m=<optimized out>) at caml/platform.h:163
#6  caml_release_domain_lock () at domain.c:1322
#7  0x000000000043ddb5 in caml_write_fd (fd=3, flags=<optimized out>, buf=buf@entry=0x23c3dbc, n=n@entry=16) at unix.c:97
#8  0x000000000042feb7 in caml_flush_partial (channel=channel@entry=0x23c3d50) at io.c:257
#9  0x000000000042ff60 in caml_flush (channel=0x23c3d50) at io.c:272
#10 0x000000000041b2d7 in logToChannel ()
#11 0x000000000041ac59 in mylog ()
#12 0x000000000041ad29 in myperror_with_location.constprop ()
#13 0x000000000041b227 in run_command ()
#14 0x000000000041b4b8 in caml_run_command ()
#15 0x0000000000441bcd in caml_interprete (prog=<optimized out>, prog_size=<optimized out>) at interp.c:1012
#16 0x0000000000443572 in caml_main (argv=0x7ffce74a5da8) at startup_byt.c:578
#17 0x000000000041401c in main (argc=<optimized out>, argv=<optimized out>) at main.c:37
```

The problem comes from trying to use the OCaml runtime from a forked
child, without calling the new Multicore-OCaml function
`caml_atfork_hook` from domain.h. At this point the forked child has
its domain lock in an incoherent state, and calling `caml_write_fd`
fails. (Compare the ceremony around fork() in ocamltest/run_unix.c and
in otherlibs/unix/unix_fork.c)

Note: the backtrace also shows that C files in ocamltest were not
compiled with debug information. The PR also adds CFLAGS=-g in
ocamlest/Makefile to fix this.