### PR TITLE
harden -use-runtime against spaces in paths

### DIFF
--- a/Changes
+++ b/Changes
@@ -181,6 +181,9 @@ Working version
 
 ### Bug fixes:
 
+- #11112: harden -use-runtime against spaces or quotes in the provided path
+  (Gabriel Scherer, report by Brahima Dibassi, review by David Allsopp)
+
 - #11025, #11036: Do not pass -no-pie to the C compiler on musl/arm64
   (omni, Kate Deplaix and Antonio Nuno Monteiro, review by Xavier Leroy)
 

--- a/bytecomp/bytelink.ml
+++ b/bytecomp/bytelink.ml
@@ -344,7 +344,7 @@ let link_bytecode ?final_name tolink exec_name standalone =
          let runtime = make_absolute !Clflags.use_runtime in
          let runtime =
            (* shebang mustn't exceed 128 including the #! and \0 *)
-           if String.length runtime > 125 then
+           if String.length runtime > 125 || String.contains runtime ' ' then
              "/bin/sh\n\
               exec \"" ^ runtime ^ "\" \"$0\" \"$@\""
            else

--- a/bytecomp/bytelink.ml
+++ b/bytecomp/bytelink.ml
@@ -346,7 +346,7 @@ let link_bytecode ?final_name tolink exec_name standalone =
            (* shebang mustn't exceed 128 including the #! and \0 *)
            if String.length runtime > 125 || String.contains runtime ' ' then
              "/bin/sh\n\
-              exec \"" ^ runtime ^ "\" \"$0\" \"$@\""
+              exec " ^ Filename.quote runtime ^ " \"$0\" \"$@\""
            else
              runtime
          in

--- a/bytecomp/symtable.ml
+++ b/bytecomp/symtable.ml
@@ -184,8 +184,13 @@ let init () =
     Misc.try_finally
       ~always:(fun () -> remove_file primfile)
       (fun () ->
-         if Sys.command(Printf.sprintf "%s -p > %s"
-                          !Clflags.use_runtime primfile) <> 0
+         let cmd =
+           Filename.quote_command
+             !Clflags.use_runtime
+             ~stdout:primfile
+             ["-p"]
+         in
+         if Sys.command cmd <> 0
          then raise(Error(Wrong_vm !Clflags.use_runtime));
          set_prim_table_from_file primfile
       )


### PR DESCRIPTION
This PR ensures that `-use-runtime <path>` works as intended even when the path contains spaces.

## reproduction

(from a built compiler repository)

```
$ mkdir "foo bar"
$ cp runtime/ocamlrun "foo bar/"
$ echo 'print_endline "Hello World"' > test.ml
$ ./ocamlc.opt -nostdlib -I stdlib -use-runtime "foo bar/ocamlrun" test.ml -o test
sh: line 1: foo: command not found
File "test.ml", line 1:
Error: Cannot find or execute the runtime system foo bar/ocamlrun
```
