### PR TITLE
Clear error when the ocaml working directory path contains spaces

### DIFF
--- a/testsuite/Makefile
+++ b/testsuite/Makefile
@@ -15,7 +15,11 @@
 
 .NOTPARALLEL:
 
-BASEDIR := $(shell pwd)
+BASEDIR := "$(shell pwd)"
+ifneq "$(shell echo $(BASEDIR) | grep ' ')" ""
+$(error The Testsuite does not handle spaces\
+   in the ocaml working directory path: $(BASEDIR))
+endif
 
 ROOTDIR = ..
 include $(ROOTDIR)/Makefile.common

--- a/testsuite/Makefile
+++ b/testsuite/Makefile
@@ -16,7 +16,7 @@
 .NOTPARALLEL:
 
 BASEDIR := "$(shell pwd)"
-ifneq "$(shell echo $(BASEDIR) | grep ' ')" ""
+ifneq "$(words |$(BASEDIR)|)" "1"
 $(error The Testsuite does not handle spaces\
    in the ocaml working directory path: $(BASEDIR))
 endif

--- a/testsuite/Makefile
+++ b/testsuite/Makefile
@@ -15,7 +15,7 @@
 
 .NOTPARALLEL:
 
-BASEDIR := "$(shell pwd)"
+BASEDIR := $(shell pwd)
 ifneq "$(words |$(BASEDIR)|)" "1"
 $(error The Testsuite does not handle spaces\
    in the ocaml working directory path: $(BASEDIR))


### PR DESCRIPTION
Hello, I'm a student in IT.
I would like to make my first pull request to an open project.

As discussed with @gasche we discovered that the dev testsuite doesn't handle spaces in the ocaml working directory path.

While building and setting up,
I've noticed that i wasn't able to use the dev testsuite.

This is what happens :
```sh
bimac@BiMac ocaml % make tests
gmake -C testsuite all
gmake[1]: Entering directory '/Users/bimac/Licence_3/Log Libre/ocaml/testsuite'
gmake[3]: *** No rule to make target 'Libre/ocaml/testsuite'.  Stop.
gmake[2]: *** [Makefile:339: tools] Error 2
gmake[1]: *** [Makefile:166: all] Error 2
gmake[1]: Leaving directory '/Users/bimac/Licence_3/Log Libre/ocaml/testsuite'
gmake: *** [Makefile:611: tests] Error 2
```

Since it is common to use spaces on file directory,
I've tried to work on the testsuite makefile, but the issue also take root further away in ocamltest

Until the problem is solved I propose a pull request in order to generate a clean error message, so that others newcomers can find out quickly the issue

