### PR TITLE
Use `Float.atan2` instead of `atan2` in stdlib/complex.ml

### DIFF
--- a/stdlib/complex.ml
+++ b/stdlib/complex.ml
@@ -50,7 +50,7 @@ let norm2 x = x.re *. x.re +. x.im *. x.im
 
 let norm x = Float.hypot x.re x.im
 
-let arg x = atan2 x.im x.re
+let arg x = Float.atan2 x.im x.re
 
 let polar n a = { re = cos a *. n; im = sin a *. n }
 


### PR DESCRIPTION
This PR changes 
```ocaml
let arg x = atan2 x.im x.re
```
to 
```ocaml
let arg x = Float.atan2 x.im x.re
```
so consistency can be improved in the stdlib. 