### PR TITLE
Fix tool-dumpobj test on Windows

### DIFF
--- a/testsuite/tests/tool-dumpobj/test.run
+++ b/testsuite/tests/tool-dumpobj/test.run
@@ -1,1 +1,4 @@
-${ocamlrun} ${ocamlsrcdir}/tools/dumpobj -nobanners ${program} > ${output}
+if [ ${os_type} = 'Win32' ]; then
+  ocamlrun=$(cygpath "${ocamlrun}")
+fi
+"${ocamlrun}" "${ocamlsrcdir}/tools/dumpobj" -nobanners "${program}" > "${output}"


### PR DESCRIPTION
Combined with #10908, this fixes the mingw-w64 runs on Inria's CI (see [precheck#667](https://ci.inria.fr/ocaml/job/precheck/667/), which tests this, #10908 and #11115).