### PR TITLE
T(R)MC: only specialize explicitly-annotated calls

### DIFF
--- a/manual/src/cmds/tail-mod-cons.etex
+++ b/manual/src/cmds/tail-mod-cons.etex
@@ -43,7 +43,8 @@ implementation of "map" above becomes \emph{tail-recursive}, in the
 sense that it only consumes a constant amount of stack space. The
 OCaml compiler implements this transformation on demand, using the
 "[\@tail_mod_cons]" or "[\@ocaml.tail_mod_cons]" attribute on the
-function to transform.
+function to transform, and the "[\@tailcall]" or "[\@ocaml.tailcall]"
+attribute on calls in tail-modulo-cons position.
 
 \begin{caml_example*}{verbatim}
 let[@tail_mod_cons] rec map f l =
@@ -51,7 +52,7 @@ let[@tail_mod_cons] rec map f l =
   | [] -> []
   | x :: xs ->
     let y = f x in
-    y :: map f xs
+    y :: (map[@tailcall]) f xs
 \end{caml_example*}
 
 \begin{caml_example}{toplevel}
@@ -60,18 +61,19 @@ List.length (map Fun.id (List.init 1_000_000 Fun.id));;
 
 This transformation only improves calls in tail-modulo-cons position,
 it does not improve recursive calls that do not fit in this fragment:
-\begin{caml_example*}{verbatim}[warning=71]
+\begin{caml_example*}{verbatim}[warning=51,warning=71]
 (* does *not* work: addition is not a data constructor *)
 let[@tail_mod_cons] rec length l =
   match l with
   | [] -> 0
-  | _ :: xs -> 1 + length xs
+  | _ :: xs -> 1 + (length[@tailcall]) xs
 \end{caml_example*}
 
 It is of course possible to use the "[\@tail_mod_cons]" transformation
 on functions that contain some recursive calls in tail-modulo-cons
 position, and some calls in other, arbitrary positions. Only the tail
-calls and tail-modulo-cons calls will happen in constant stack space.
+calls and the annotated tail-modulo-cons calls will happen in constant
+stack space.
 
 \paragraph{General design} This feature is provided as an explicit
 program transformation, not an implicit optimization. It is
@@ -108,8 +110,8 @@ performance to the original version, even on small inputs.
 
 \paragraph{Evaluation order} Beware that the tail-modulo-cons
 transformation has an effect on evaluation order: the constructor
-argument that is transformed into tail-position will always be
-evaluated last. Consider the following example:
+argument that is transformed into tail-position (there is at most one)
+will always be evaluated last. Consider the following example:
 
 \begin{caml_example*}{verbatim}
 type 'a two_headed_list =
@@ -119,7 +121,7 @@ type 'a two_headed_list =
 let[@tail_mod_cons] rec map f = function
   | Nil -> Nil
   | Consnoc (front, body, rear) ->
-    Consnoc (f front, map f body, f rear)
+    Consnoc (f front, (map[@tailcall]) f body, f rear)
 \end{caml_example*}
 
 Due to the "[\@tail_mod_cons]" transformation, the calls to "f front"
@@ -150,63 +152,6 @@ tail-mod-cons are as follows:
   using a convenient monadic notation.
 \end{itemize}
 
-\section{sec:disambiguation}{Disambiguation}
-
-It may happen that several arguments of a constructor are recursive
-calls to a tail-modulo-cons function. The transformation can only turn
-one of these calls into a tail call. The compiler will not make an
-implicit choice, but ask the user to provide an explicit
-disambiguation.
-
-Consider this type of syntactic expressions (assuming some
-pre-existing type "var" of expression variables):
-\begin{caml_example*}{verbatim}
-type var (* some pre-existing type of variables *)
-
-type exp =
-  | Var of var
-  | Let of binding * exp
-and binding = var * exp
-\end{caml_example*}
-
-Consider a "map" function on variables. The direct definition has two
-recursive calls inside arguments of the "Let" constructor, so it gets
-rejected as ambiguous.
-\begin{caml_example*}{verbatim}[error]
-let[@tail_mod_cons] rec map_vars f exp =
-  match exp with
-  | Var v -> Var (f v)
-  | Let ((v, def), body) ->
-    Let ((f v, map_vars f def), map_vars f body)
-\end{caml_example*}
-
-To disambiguate, the user should add a "[\@tailcall]" attribute to the
-recursive call that should be transformed to tail position:
-\begin{caml_example*}{verbatim}
-let[@tail_mod_cons] rec map_vars f exp =
-  match exp with
-  | Var v -> Var (f v)
-  | Let ((v, def), body) ->
-    Let ((f v, map_vars f def), (map_vars[@tailcall]) f body)
-\end{caml_example*}
-Be aware that the resulting function is \emph{not} tail-recursive, the
-recursive call on "def" will consume stack space. However, expression
-trees tend to be right-leaning (lots of "Let" in sequence,
-rather than nested inside each other), so putting the call on "body"
-in tail position is an interesting improvement over the naive
-definition: it gives bounded stack space consumption if we assume
-a bound on the nesting depth of "Let" constructs.
-
-One would also get an error when using conflicting annotations, asking
-for two of the constructor arguments to be put in tail position:
-\begin{caml_example*}{verbatim}[error]
-let[@tail_mod_cons] rec map_vars f exp =
-  match exp with
-  | Var v -> Var (f v)
-  | Let ((v, def), body) ->
-    Let ((f v, (map_vars[@tailcall]) f def), (map_vars[@tailcall]) f body)
-\end{caml_example*}
-
 \section{sec:out-of-tmc}{Danger: getting out of tail-mod-cons}
 
 Due to the nature of the tail-mod-cons transformation
@@ -215,7 +160,8 @@ Due to the nature of the tail-mod-cons transformation
 \item Calls from a tail-mod-cons function to another tail-mod-cons
   function declared in the same recursive-binding group are
   transformed into tail calls, as soon as they occur in tail position
-  or tail-modulo-cons position in the source function.
+  or in explicitly-annotated tail-modulo-cons position in the source
+  function.
 \item Calls from a function \emph{not} annotated tail-mod-cons to
   a tail-mod-cons function or, conversely, from a tail-mod-cons
   function to a non-tail-mod-cons function are transformed into
@@ -250,7 +196,7 @@ let[@tail_mod_cons] rec flatten = function
     let[@tail_mod_cons] rec append_flatten xs xss =
       match xs with
       | [] -> flatten xss
-      | x :: xs -> x :: append_flatten xs xss
+      | x :: xs -> x :: (append_flatten[@tailcall]) xs xss
     in append_flatten xs xss
 \end{caml_example*}
 
@@ -278,30 +224,28 @@ let[@tail_mod_cons] rec flatten = function
 and[@tail_mod_cons] append_flatten xs xss =
   match xs with
   | [] -> flatten xss
-  | x :: xs -> x :: append_flatten xs xss
+  | x :: xs -> x :: (append_flatten[@tailcall]) xs xss
 \end{caml_example*}
 
 Non-recursive functions can also be annotated "[\@tail_mod_cons]"; this is
 typically useful for local bindings to recursive functions.
 
 Incorrect version:
-\begin{caml_example*}{verbatim}[warning=51,warning=71]
-let[@tail_mod_cons] rec map_vars f exp =
-  let self exp = map_vars f exp in
-  match exp with
-  | Var v -> Var (f v)
-  | Let ((v, def), body) ->
-    Let ((f v, self def), (self[@tailcall]) body)
+\begin{caml_example*}{verbatim}[warning=71]
+let[@tail_mod_cons] rec map f li =
+  let self xs = map f xs in
+  match li with
+  | [] -> []
+  | x :: xs -> f x :: (self[@tailcall]) xs
 \end{caml_example*}
 
 Recommended fix:
 \begin{caml_example*}{verbatim}
-let[@tail_mod_cons] rec map_vars f exp =
-  let[@tail_mod_cons] self exp = map_vars f exp in
-  match exp with
-  | Var v -> Var (f v)
-  | Let ((v, def), body) ->
-    Let ((f v, self def), (self[@tailcall]) body)
+let[@tail_mod_cons] rec map f li =
+  let[@tail_mod_cons] self xs = map f xs in
+  match li with
+  | [] -> []
+  | x :: xs -> f x :: (self[@tailcall]) xs
 \end{caml_example*}
 
 In other cases, there is either no benefit in making the called function
@@ -446,7 +390,7 @@ let[@tail_mod_cons] rec map f li =
     let y = f x in
     y ::
       (* this call is in TMC position *)
-      map f xs
+      (map[@tailcall]) f xs
 \end{caml_example*}
 
 \begin{caml_example*}{verbatim}[warning=71]
@@ -458,7 +402,7 @@ let[@tail_mod_cons] rec map f li =
     let y = f x in
     let ys =
       (* this call is not in TMC position anymore *)
-      map f xs in
+      (map[@taillcall]) f xs in
     y :: ys
 \end{caml_example*}
 

--- a/testsuite/tests/tmc/partial_application.ml
+++ b/testsuite/tests/tmc/partial_application.ml
@@ -7,7 +7,7 @@ type t = Ret of (unit -> unit) | Next of t
 let[@tail_mod_cons] rec f () () = ()
 
 and[@tail_mod_cons] g ~first:b =
-  if b then Next (g ~first:false)
+  if b then Next ((g[@tailcall]) ~first:false)
   else
     (* The call below is in TMC position but partially-applied;
        we should not compile it like a TMC call. *)

--- a/testsuite/tests/tmc/readable_output.ml
+++ b/testsuite/tests/tmc/readable_output.ml
@@ -5,7 +5,7 @@
 (* Check that the code produced by TMC reads reasonably well. *)
 let[@tail_mod_cons] rec map f = function
   | [] -> []
-  | x :: xs -> f x :: map f xs
+  | x :: xs -> f x :: (map[@tailcall]) f xs
 ;;
 [%%expect{|
 (letrec
@@ -39,7 +39,7 @@ and 'a rec_list = 'a cell option
 
 let[@tail_mod_cons] rec rec_map f = function
   | None -> None
-  | Some {hd; tl} -> Some { hd = f hd; tl = rec_map f tl }
+  | Some {hd; tl} -> Some { hd = f hd; tl = (rec_map[@tailcall]) f tl }
 ;;
 [%%expect{|
 (letrec
@@ -72,7 +72,7 @@ val rec_map : ('a -> 'b) -> 'a rec_list -> 'b rec_list = <fun>
    for each constructor.  *)
 let[@tail_mod_cons] rec trip = function
   | [] -> []
-  | x :: xs -> (x, 0) :: (x, 1) :: (x, 2) :: trip xs
+  | x :: xs -> (x, 0) :: (x, 1) :: (x, 2) :: (trip[@tailcall]) xs
 ;;
 [%%expect{|
 (letrec
@@ -108,7 +108,7 @@ val trip : 'a list -> ('a * int) list = <fun>
    (ideally, only in the DPS version) *)
 let[@tail_mod_cons] rec effects f = function
   | [] -> []
-  | (x, y) :: xs -> f x :: f y :: effects f xs
+  | (x, y) :: xs -> f x :: f y :: (effects[@tailcall]) f xs
 ;;
 [%%expect{|
 (letrec
@@ -144,7 +144,7 @@ let[@tail_mod_cons] rec map_stutter f xs =
   f None :: (
     match xs with
     | [] -> []
-    | x :: xs -> f (Some x) :: map_stutter f xs
+    | x :: xs -> f (Some x) :: (map_stutter[@tailcall]) f xs
   )
 ;;
 [%%expect{|
@@ -185,7 +185,7 @@ let[@tail_mod_cons] rec smap_stutter f xs n =
   if n = 0 then []
   else f None :: (
     let v = f (Some xs.hd) in
-    v :: smap_stutter f (xs.tl ()) (n - 1)
+    v :: (smap_stutter[@tailcall]) f (xs.tl ()) (n - 1)
   )
 ;;
 [%%expect{|

--- a/testsuite/tests/tmc/semantic.ml
+++ b/testsuite/tests/tmc/semantic.ml
@@ -30,14 +30,16 @@
 let [@tail_mod_cons] rec verbose_map n f xs =
   match xs with
   | [] -> Format.printf "nil %d@." n; []
-  | x :: xs -> (Format.printf "hd %d@." n; f x) :: (Format.printf "tl %d@." n; verbose_map (n + 1)f xs)
+  | x :: xs ->
+      (Format.printf "hd %d@." n; f x)
+      :: (Format.printf "tl %d@." n; (verbose_map[@tailcall]) (n + 1)f xs)
 
 let _ =
   assert (verbose_map 0 (fun x -> x + 1) [1; 2; 3] = [2; 3; 4])
 
 (* Test that delayed constructors are properly restored inside non-TMC contexts *)
 let[@tail_mod_cons] rec weird xs =
-  () :: match xs with [] -> [] | x :: xs -> x :: weird xs
+  () :: match xs with [] -> [] | x :: xs -> x :: (weird[@tailcall]) xs
 
 let _ =
   assert (weird [] = [()]);

--- a/testsuite/tests/tmc/stack_space.ml
+++ b/testsuite/tests/tmc/stack_space.ml
@@ -9,7 +9,7 @@ let large = 1000
 let init n f =
   let[@tail_mod_cons] rec init_aux i n f =
     if i = n then []
-    else f i :: init_aux (i + 1) n f
+    else f i :: (init_aux[@tailcall]) (i + 1) n f
   in init_aux 0 n f
 
 module ListMap = struct
@@ -17,7 +17,7 @@ module ListMap = struct
     | [] -> []
     | x :: xs ->
         (* Note: tail-mod-cons guarantees that 'map f xs' is evaluated last *)
-        f x :: map f xs
+        f x :: (map[@tailcall]) f xs
 
   let _ =
     init large Fun.id

--- a/testsuite/tests/tmc/tupled_function_calls.ml
+++ b/testsuite/tests/tmc/tupled_function_calls.ml
@@ -7,7 +7,7 @@
 let[@tail_mod_cons] rec tupled_map (f, li) =
   match li with
   | [] -> []
-  | x :: xs -> f x :: tupled_map (f, xs)
+  | x :: xs -> f x :: (tupled_map[@tailcall]) (f, xs)
 
 (* The recursive call here is not "direct" for the
    Tupled calling convention (which is only used by the native compiler),


### PR DESCRIPTION
This PR (against 4.14) implements a restriction to the tail-modulo-cons specialization: we only specialize tail-modulo-cons calls that are explicitly annotated with the `[@tailcall]` attribute.

Before:

```ocaml
let[@tail_mod_cons] rec map f = function
| [] -> []
| x :: xs -> f x :: map f xs
```

After:

```ocaml
let[@tail_mod_cons] rec map f = function
| [] -> []
| x :: xs -> f x :: (map[@tailcall]) f xs
```

This restriction has been suggested by @gadmm, see https://github.com/ocaml/ocaml/pull/10740#issuecomment-980452400. Personally, I am rather in favor of the previous behavior, where non-ambiguous calls in TMC positions (there is only one callsite that could be optimized in this branch) are implicitly specialized. However, the reasoning is that it will be easy to relax the restriction in the future, should people agree that it is desirable, whereas it would be harder to impose it later once the feature is released.


Unfortunately, it may be too late in the 4.14 release lifecycle for this change. (cc @Octachron) Arguments in favor:
1. The implementation change is minimal and we had good testsuite coverage.
2. This feature is not currently used in the wild, at it was never released yet.


I have not updated the TMC manual yet.


With this change, we could in theory simplify away sizeable parts of the TMC codebase, that take care of producing good warnings based on whether the TMC specializations are implicit or explicit. (Now they are always explicit.) However this would make the diff much larger, risk introducing other issues, and it would make it difficult to revert to the previous behavior later. I would be in favor of waiting until (we are not in release-hurry and) we receive a first batch of feedback from TMC users.