### PR TITLE
Fix bigarray 32bit interger overflow of offset in C imp.

### DIFF
--- a/Changes
+++ b/Changes
@@ -494,6 +494,9 @@ OCaml 4.14.0
 - #11101, #11109: A recursive type constraint fails on 4.14
   (Jacques Garrigue, report and review by Florian Angeletti)
 
+- #11118: Fix integer overflow on 64-bit Windows when indexing bigarrays (which
+  could lead to a segmentation fault).
+  (Roven Gabriel, review by Nicolás Ojeda Bär and Xavier Leroy)
 
 OCaml 4.13 maintenance branch
 -----------------------------

--- a/runtime/bigarray.c
+++ b/runtime/bigarray.c
@@ -524,7 +524,7 @@ CAMLprim value caml_ba_create(value vkind, value vlayout, value vdim)
    are within the bounds and return the offset of the corresponding
    array element in the data part of the array. */
 
-static long caml_ba_offset(struct caml_ba_array * b, intnat * index)
+static intnat caml_ba_offset(struct caml_ba_array * b, intnat * index)
 {
   intnat offset;
   int i;


### PR DESCRIPTION
FIx some missed migration from `long` to `intnat`. In practice this impacts programs compiled with the ocaml msvc distribution and that interacts with polymorphic bigarrays.

The reproduction case has been added as a test. 

This PR was based on `4.14` to be able to compile with msvc, this could easily fit on `trunk`. 