### PR TITLE
Gc stats: major collections count

### DIFF
--- a/runtime/caml/domain_state.tbl
+++ b/runtime/caml/domain_state.tbl
@@ -131,7 +131,6 @@ DOMAIN_STATE(uintnat, stat_minor_words)
 DOMAIN_STATE(uintnat, stat_promoted_words)
 DOMAIN_STATE(uintnat, stat_major_words)
 DOMAIN_STATE(intnat, stat_minor_collections)
-DOMAIN_STATE(intnat, stat_major_collections)
 DOMAIN_STATE(intnat, stat_forced_major_collections)
 DOMAIN_STATE(uintnat, stat_blocks_marked)
 

--- a/runtime/caml/gc_ctrl.h
+++ b/runtime/caml/gc_ctrl.h
@@ -22,6 +22,7 @@
 
 extern uintnat caml_max_stack_wsize;
 extern uintnat caml_fiber_wsz;
+extern uintnat caml_major_cycles_completed;
 
 void caml_init_gc (void);
 value caml_gc_stat(value);
@@ -32,7 +33,7 @@ value caml_gc_major(value);
 #define caml_stat_compactions 0
 #define caml_stat_heap_wsz Wsize_bsize(caml_heap_size(Caml_state->shared_heap))
 #define caml_stat_heap_chunks caml_heap_blocks(Caml_state->shared_heap)
-#define caml_stat_major_collections Caml_state->stat_major_collections
+#define caml_stat_major_collections caml_major_cycles_completed
 #define caml_stat_minor_collections Caml_state->stat_minor_collections
 #define caml_stat_promoted_words Caml_state->stat_promoted_words
 #define caml_allocated_words Caml_state->allocated_words

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -464,7 +464,6 @@ static uintnat fresh_domain_unique_id(void) {
     return next;
 }
 
-
 /* must be run on the domain's thread */
 static void create_domain(uintnat initial_minor_heap_wsize) {
   dom_internal* d = 0;

--- a/runtime/gc_ctrl.c
+++ b/runtime/gc_ctrl.c
@@ -58,7 +58,7 @@ CAMLprim value caml_gc_quick_stat(value v)
   intnat majcoll;
   struct gc_stats s;
   caml_compute_gc_stats(&s);
-  majcoll = Caml_state->stat_major_collections;
+  majcoll = caml_major_cycles_completed;
 
   res = caml_alloc_tuple (17);
   Store_field (res, 0, caml_copy_double ((double)s.alloc_stats.minor_words));

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -1028,7 +1028,6 @@ static void cycle_all_domains_callback(caml_domain_state* domain, void* unused,
     caml_global_barrier();
   }
 
-  domain->stat_major_collections++;
   caml_cycle_heap(domain->shared_heap);
   domain->sweeping_done = 0;
 

--- a/runtime/sys.c
+++ b/runtime/sys.c
@@ -168,7 +168,7 @@ CAMLexport void caml_do_exit(int retcode)
           (intnat) s.alloc_stats.minor_collections);
       caml_gc_message(0x400,
           "major_collections: %"ARCH_INTNAT_PRINTF_FORMAT"d\n",
-          domain_state->stat_major_collections);
+          caml_major_cycles_completed);
       caml_gc_message(0x400,
           "forced_major_collections: %"ARCH_INTNAT_PRINTF_FORMAT"d\n",
           (intnat)s.alloc_stats.forced_major_collections);

--- a/testsuite/tests/c-api/alloc_async_stubs.c
+++ b/testsuite/tests/c-api/alloc_async_stubs.c
@@ -2,6 +2,8 @@
 #include <stdlib.h>
 #include "caml/alloc.h"
 #include "caml/memory.h"
+#define CAML_INTERNALS
+#include "caml/gc_ctrl.h"
 
 const char* strs[] = { "foo", "bar", 0 };
 value stub(value ref)
@@ -13,8 +15,8 @@ value stub(value ref)
   printf("C, before: %d\n", Int_val(Field(ref, 0)));
 
   /* First, do enough major allocations to do a full major collection cycle */
-  coll_before = Caml_state_field(stat_major_collections);
-  while (Caml_state_field(stat_major_collections) <= coll_before+1) {
+  coll_before = caml_stat_major_collections;
+  while (caml_stat_major_collections <= coll_before+1) {
     caml_alloc(10000, 0);
   }
 


### PR DESCRIPTION
Currently there are two different counters of major collection cycles:
- `caml_major_cycles_completed`, which is a global variable incremented at the completion of each GC cycle, used by the runtime system for various "check that at least one cycle has happened" conditions
- `Caml_state->stat_major_collections`, which is a per-domain count that is also incremented at the completion of each GC cycle, and is only used for statistics reporting (`(Gc.quick_stats()).major_collections`).

Unfortunately, `Caml_state->stat_major_collections` has a fairly weird behavior:
- during each GC cycle, all participating domains increment their `Caml_state->stat_major_collections` counter
- morally this means that this counter counts the "number of major cycles that this domain participated in"
- but because the `domain_state` data of terminated domain is reused when spawning new domains, the `stat_major_collections` count of a just-spawned domain may be non-zero.

This PR gets rid of `Caml_state->stat_major_collections` and uses the more principled `caml_major_cycles_completed` global value instead in reported statistics. The meaning of this value is clear, it is the number of major GC cycles completed since the program started -- this is exactly what the documentation says.

In local experiments I checked that during non-multicore runs (of the sequential test `weaklifetime.ml`), the value of `caml_major_cycles_completed` and `Caml_state->stat_major_collections` is the same on each `Gc.quick_stats()` call.

cc @Engil