### PR TITLE
Fix weaklifetime_par.ml

### DIFF
--- a/testsuite/tests/weak-ephe-final/weaklifetime.ml
+++ b/testsuite/tests/weak-ephe-final/weaklifetime.ml
@@ -3,7 +3,8 @@
 
 let () = Random.init 12345
 
-let size = 1000
+let size, num_gcs =
+  1000, 20
 
 type block = int array
 
@@ -70,7 +71,7 @@ let check_and_change i j =
 let dummy = ref [||]
 
 let () =
-  while gccount () < 20 do
+  while gccount () < num_gcs do
     dummy := Array.make (Random.int 300) 0;
     let i = Random.int size in
     let j = Random.int (Array.length data.(i).objs) in

--- a/testsuite/tests/weak-ephe-final/weaklifetime.ml
+++ b/testsuite/tests/weak-ephe-final/weaklifetime.ml
@@ -1,21 +1,21 @@
 (* TEST
 *)
 
-Random.init 12345;;
+let () = Random.init 12345
 
-let size = 1000;;
+let size = 1000
 
-type block = int array;;
+type block = int array
 
 type objdata =
   | Present of block
   | Absent of int  (* GC count at time of erase *)
-;;
+
 
 type bunch = {
   objs : objdata array;
   wp : block Weak.t;
-};;
+}
 
 let data =
   Array.init size (fun i ->
@@ -25,11 +25,10 @@ let data =
       wp = Weak.create n;
     }
   )
-;;
 
-let gccount () = (Gc.quick_stat ()).Gc.major_collections;;
+let gccount () = (Gc.quick_stat ()).Gc.major_collections
 
-type change = No_change | Fill | Erase;;
+type change = No_change | Fill | Erase
 
 (* Check the correctness condition on the data at (i,j):
    1. if the block is present, the weak pointer must be full
@@ -56,7 +55,7 @@ let check_and_change i j =
     | Present _, true ->
       if Random.int 10 = 0 then Erase else No_change
   in
-  match change with
+  begin match change with
   | No_change -> ()
   | Fill ->
     let x = Array.make (1 + Random.int 10) 42 in
@@ -66,13 +65,14 @@ let check_and_change i j =
     data.(i).objs.(j) <- Absent gc1;
     let gc2 = gccount () in
     if gc1 <> gc2 then data.(i).objs.(j) <- Absent gc2;
-;;
+  end
 
-let dummy = ref [||];;
+let dummy = ref [||]
 
-while gccount () < 20 do
-  dummy := Array.make (Random.int 300) 0;
-  let i = Random.int size in
-  let j = Random.int (Array.length data.(i).objs) in
-  check_and_change i j;
-done
+let () =
+  while gccount () < 20 do
+    dummy := Array.make (Random.int 300) 0;
+    let i = Random.int size in
+    let j = Random.int (Array.length data.(i).objs) in
+    check_and_change i j;
+  done

--- a/testsuite/tests/weak-ephe-final/weaklifetime_par.ml
+++ b/testsuite/tests/weak-ephe-final/weaklifetime_par.ml
@@ -1,9 +1,14 @@
 (* TEST
 *)
 
-let size = 1000
-let num_domains = 4
-let num_rounds = 4
+let size, num_domains, num_gcs, num_rounds =
+  let test_size =
+    try int_of_string (Sys.getenv "OCAML_TEST_SIZE")
+    with Not_found | Failure _ -> 0
+  in
+  if test_size >= 3
+  then (1000, 4, 5, 4)
+  else ( 400, 2, 5, 3)
 
 type block = int array
 
@@ -79,7 +84,7 @@ let run index () =
     }
   ) in
   let gc_start = gccount () in
-  while gccount () - gc_start < 5 do
+  while gccount () - gc_start < num_gcs do
     dummy := Array.make (Random.int 300) 0;
     let per_domain_size = size / num_domains in
     assert (index < num_domains);

--- a/testsuite/tests/weak-ephe-final/weaklifetime_par.ml
+++ b/testsuite/tests/weak-ephe-final/weaklifetime_par.ml
@@ -1,21 +1,20 @@
 (* TEST
 *)
 
-let size = 1000;;
-let num_domains = 4;;
-let num_rounds = 4;;
+let size = 1000
+let num_domains = 4
+let num_rounds = 4
 
-type block = int array;;
+type block = int array
 
 type objdata =
   | Present of block
   | Absent of int  (* GC count at time of erase *)
-;;
 
 type bunch = {
   objs : objdata array;
   wp : block Weak.t;
-};;
+}
 
 let data =
   Array.init size (fun i ->
@@ -25,13 +24,12 @@ let data =
       wp = Weak.create n;
     }
   )
-;;
 
 let gccount () =
   let res = (Gc.quick_stat ()).Gc.major_collections in
   res
 
-type change = No_change | Fill | Erase;;
+type change = No_change | Fill | Erase
 
 (* Check the correctness condition on the data at (i,j):
    1. if the block is present, the weak pointer must be full
@@ -57,7 +55,7 @@ let check_and_change data i j =
     | Present _, true ->
       if Random.int 10 = 0 then Erase else No_change
   in
-  match change with
+  begin match change with
   | No_change -> ()
   | Fill ->
     let x = Array.make (1 + Random.int 10) 42 in
@@ -67,10 +65,10 @@ let check_and_change data i j =
     data.(i).objs.(j) <- Absent gc1;
     let gc2 = gccount () in
     if gc1 <> gc2 then data.(i).objs.(j) <- Absent gc2;
-;;
+  end
 
-let dummy = ref [||];;
 
+let dummy = ref [||]
 
 let run index () =
   let domain_data = Array.init 100 (fun i ->

--- a/testsuite/tests/weak-ephe-final/weaklifetime_par.ml
+++ b/testsuite/tests/weak-ephe-final/weaklifetime_par.ml
@@ -80,7 +80,8 @@ let run index () =
       wp = Weak.create n;
     }
   ) in
-  while gccount () < 5 do
+  let gc_start = gccount () in
+  while gccount () - gc_start < 5 do
     dummy := Array.make (Random.int 300) 0;
     let per_domain_size = size / num_domains in
     assert (index < num_domains);

--- a/testsuite/tests/weak-ephe-final/weaklifetime_par.ml
+++ b/testsuite/tests/weak-ephe-final/weaklifetime_par.ml
@@ -3,12 +3,6 @@
 
 let size = 1000;;
 let num_domains = 4;;
-let random_state =
-  Domain.DLS.new_key
-    ~split_from_parent:Random.State.split
-    Random.State.make_self_init
-
-let random_int = Random.State.int (Domain.DLS.get random_state)
 
 type block = int array;;
 
@@ -24,7 +18,7 @@ type bunch = {
 
 let data =
   Array.init size (fun i ->
-    let n = 1 + random_int size in
+    let n = 1 + Random.int size in
     {
       objs = Array.make n (Absent 0);
       wp = Weak.create n;
@@ -60,12 +54,12 @@ let check_and_change data i j =
     | Absent n, true -> assert (gc1 <= n+2); No_change
     | Absent _, false -> Fill
     | Present _, true ->
-      if random_int 10 = 0 then Erase else No_change
+      if Random.int 10 = 0 then Erase else No_change
   in
   match change with
   | No_change -> ()
   | Fill ->
-    let x = Array.make (1 + random_int 10) 42 in
+    let x = Array.make (1 + Random.int 10) 42 in
     data.(i).objs.(j) <- Present x;
     Weak.set data.(i).wp j (Some x);
   | Erase ->
@@ -78,19 +72,19 @@ let dummy = ref [||];;
 
 let run index () =
   let domain_data = Array.init 100 (fun i ->
-    let n = 1 + random_int 100 in
+    let n = 1 + Random.int 100 in
     {
       objs = Array.make n (Absent 0);
       wp = Weak.create n;
     }
   ) in
   while gccount () < 5 do
-    dummy := Array.make (random_int 300) 0;
-    let i = (random_int (size/num_domains)) + index * size/num_domains in
-    let j = random_int (Array.length data.(i).objs) in
+    dummy := Array.make (Random.int 300) 0;
+    let i = (Random.int (size/num_domains)) + index * size/num_domains in
+    let j = Random.int (Array.length data.(i).objs) in
     check_and_change data i j;
-    let ix = random_int 100 in
-    let jx = random_int (Array.length domain_data.(ix).objs) in
+    let ix = Random.int 100 in
+    let jx = Random.int (Array.length domain_data.(ix).objs) in
     check_and_change domain_data ix jx
   done
 


### PR DESCRIPTION
`weaklifetime_par.ml` was introduced in https://github.com/ocaml-multicore/ocaml-multicore/pull/543/, but it appears to be fragile in its current implementation, see for example #11121. In local testing I have observed that the test can fail with "index out of bounds" errors due to erroneous indexing code. (The fragility of the implementation will also make it much harder to parametrize the test to have versions that run quicker.)

The present PR is a series of fixes to the test implementation. It is built on top of #11123. Being on top of #11123 is necessary, because the previous way that major collections were counted in `Gc.quick_stats` would break the test:

https://github.com/ocaml/ocaml/blob/aa60eefeb70ec6f20ec88d72adbde645223a0469/testsuite/tests/weak-ephe-final/weaklifetime_par.ml#L60

The scenario where this assertion is broken in absence of #11123 (that is, with the weird "current" behavior of `Caml_state->stat_major_collections` explained in #11123) is as follows:
- a domain A with a domain-local major-collection count of `na` writes `Absent na` in a slot.
- then `A` is terminated/joined, along with other domains, and another round of the `for index` loop starts
- a new domain B is spawned that will work over the slots previously used by `A`; it calls  `check_and_change_data`, and gets to the `assert (gc1 <= n+2)` line. At this point `gc1` is the domain-local major collections count of B, while `n+2` is `na+2`.
- but A had reused statistics from a very old domain, while B reused statistics from a recent domain, so `gc1` (from B) is much bigger than `na+2` (from A).
