### PR TITLE
Fixing typos

### DIFF
--- a/manual/src/cmds/unified-options.etex
+++ b/manual/src/cmds/unified-options.etex
@@ -122,7 +122,7 @@ Use the given interface file to type-check the ML source file to compile.
 When this option is not specified, the compiler looks for a \var{.mli} file
 with the same base name than the implementation it is compiling and in the
 same directory. If such a file is found, the compiler looks for a
-correspoinding \var{.cmi} file in the included directories and reports an
+corresponding \var{.cmi} file in the included directories and reports an
 error if it fails to find one.
 }%notop
 

--- a/middle_end/flambda/closure_conversion.ml
+++ b/middle_end/flambda/closure_conversion.ml
@@ -102,7 +102,7 @@ let tupled_function_call_stub original_params unboxed_version ~closure_bound_var
     ~body ~stub:true ~dbg:Debuginfo.none ~inline:Default_inline
     ~specialise:Default_specialise ~is_a_functor:false
     ~closure_origin:(Closure_origin.create (Closure_id.wrap closure_bound_var))
-    ~poll:Default_poll (* don't propogate attribute to wrappers *)
+    ~poll:Default_poll (* don't propagate attribute to wrappers *)
 
 let register_const t (constant:Flambda.constant_defining_value) name
     : Flambda.constant_defining_value_block_field * Internal_variable_names.t =

--- a/otherlibs/systhreads/st_stubs.c
+++ b/otherlibs/systhreads/st_stubs.c
@@ -86,7 +86,7 @@ struct caml_thread_struct {
 
 typedef struct caml_thread_struct* caml_thread_t;
 
-/* overall table for threads accross domains */
+/* overall table for threads across domains */
 struct caml_thread_table {
   caml_thread_t all_threads;
   caml_thread_t current_thread;

--- a/runtime/arm64.S
+++ b/runtime/arm64.S
@@ -734,7 +734,7 @@ FUNCTION(caml_callback3_asm)
         mov     sp, TMP
     /* restore exn_handler for new stack */
         ldr     TRAP_PTR, Stack_exception(\new_stack)
-    /* Restore frame pointer and reurn address for new_stack */
+    /* Restore frame pointer and return address for new_stack */
         ldp     x29, x30, [sp], 16
 .endm
 

--- a/runtime/caml/fiber.h
+++ b/runtime/caml/fiber.h
@@ -213,7 +213,7 @@ void caml_get_stack_sp_pc (struct stack_info* stack,
 
 value caml_continuation_use (value cont);
 
-/* Replace the stack of a continuation that was previouly removed
+/* Replace the stack of a continuation that was previously removed
    with caml_continuation_use. The GC must not be allowed to run
    between continuation_use and continuation_replace.
    Used for cloning continuations and continuation backtraces. */

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -397,7 +397,7 @@ int caml_reallocate_minor_heap(asize_t wsize)
   CAMLassert(domain_state->young_ptr == domain_state->young_end);
 
   CAMLassert(
-    (/* unitialized minor heap */
+    (/* uninitialized minor heap */
       domain_state->young_start == NULL
       && domain_state->young_end == NULL)
     ||

--- a/runtime/intern.c
+++ b/runtime/intern.c
@@ -794,7 +794,7 @@ CAMLprim value caml_input_value(value vchan)
 
 /* Reading from memory-resident blocks */
 
-/* XXX KC: Unused primitive. Remove with boostrap. */
+/* XXX KC: Unused primitive. Remove with bootstrap. */
 CAMLprim value caml_input_value_to_outside_heap(value vchan)
 {
   return caml_input_value(vchan);

--- a/runtime/lf_skiplist.c
+++ b/runtime/lf_skiplist.c
@@ -18,7 +18,7 @@
 #define CAML_INTERNALS
 
 /* A concurrent dictionary data structure implemented as skip lists. This
-    implementation is based on the sequential skip list implemetation in
+    implementation is based on the sequential skip list implementation in
     the runtime by Xavier Leroy but extends it to be safe under concurrent
     modification. It has the property that insert/remove are lock-free and
     contains is further wait-free. It is literally a textbook implementation
@@ -251,7 +251,7 @@ retry:
    marked nodes and does not snip them out. As a consequence, it is wait-free.
 
    This implementation differs from of the 'contains' in "The Art of
-   Multiprocessor Programming" to fix the erronous swap of pred and curr inside
+   Multiprocessor Programming" to fix the erroneous swap of pred and curr inside
    the while(marked) loop. It also uses [search_level] to avoid scanning the
    sentinels unnecessarily.
  */
@@ -490,7 +490,7 @@ int caml_lf_skiplist_remove(struct lf_skiplist *sk, uintnat key) {
         }
 
         /* If we end up here then we lost to a thread inserting a node directly
-           after the node we were removing. That's why we move on one sucessor.
+           after the node we were removing. That's why we move on one successor.
          */
       }
     }

--- a/runtime/memory.c
+++ b/runtime/memory.c
@@ -210,7 +210,7 @@ CAMLexport CAMLweakdef void caml_initialize (value *fp, value val)
 #ifdef DEBUG
   /* Previous value should not be a pointer.
      In the debug runtime, it can be either a TMC placeholder,
-     or an unitialized value canary (Debug_uninit_{major,minor}). */
+     or an uninitialized value canary (Debug_uninit_{major,minor}). */
   CAMLassert(Is_long(*fp));
 #endif
   *fp = val;

--- a/runtime/signals_nat.c
+++ b/runtime/signals_nat.c
@@ -87,7 +87,7 @@ void caml_garbage_collection(void)
 
     whsize = Whsize_wosize(allocsz);
 
-    /* Put the young pointer back to what is was before our tiggering
+    /* Put the young pointer back to what is was before our triggering
        allocation */
     Caml_state->young_ptr += whsize;
 

--- a/stdlib/bytes.ml
+++ b/stdlib/bytes.ml
@@ -537,7 +537,7 @@ let dec_invalid = Uchar.utf_decode_invalid
 let[@inline] dec_ret n u = Uchar.utf_decode n (Uchar.unsafe_of_int u)
 
 (* In case of decoding error, if we error on the first byte, we
-   consume the byte, otherwise we consume the [n] bytes preceeding
+   consume the byte, otherwise we consume the [n] bytes preceding
    the erroring byte.
 
    This means that if a client uses decodes without caring about

--- a/testsuite/tests/effects/test2.ml
+++ b/testsuite/tests/effects/test2.ml
@@ -15,7 +15,7 @@ let f () =
 
 let h : type a. a t -> ((a, 'b) continuation -> 'b) option = function
   | E v -> Some (fun k ->
-      printf "caught effect (E %d). continuting..\n%!" v;
+      printf "caught effect (E %d). continuing..\n%!" v;
       let v = continue k (v + 1) in
       printf "continue returns %d\n%!" v;
       v + 1)

--- a/testsuite/tests/effects/test2.reference
+++ b/testsuite/tests/effects/test2.reference
@@ -1,5 +1,5 @@
 perform effect (E 0)
-caught effect (E 0). continuting..
+caught effect (E 0). continuing..
 perform returns 1
 done 2
 continue returns 3

--- a/testsuite/tests/lib-random/parallel.ml
+++ b/testsuite/tests/lib-random/parallel.ml
@@ -20,7 +20,7 @@ let delays =
 (* Each domain will start by waiting a random amount, to ensure that
    the Random.int functions we are testing execute in
    non-deterministic order. The Random.int result should remain
-   deterministic, as domains are spawned in a determinstic order and
+   deterministic, as domains are spawned in a deterministic order and
    each domain state is obtaind by splitting the global Random state
    that was initialized with a fixed seed. *)
 let f delay () =

--- a/testsuite/tests/memory-model/opt.ml
+++ b/testsuite/tests/memory-model/opt.ml
@@ -32,7 +32,7 @@ module Make (N : sig val pgm : string end) =
           "-v",Set verbose,"be verbose";
           "-q",Clear verbose,"be silent";
           "-s",Int (fun i -> size :=i), doc_def "size of arrays" size ;
-          "-r",Int (fun i -> nruns :=i),doc_def "number of interations" nruns ;
+          "-r",Int (fun i -> nruns :=i),doc_def "number of iterations" nruns ;
           "-a",Int (fun i -> navail :=i),
           doc_def "number of cores available for tests" navail ;
         ]

--- a/testsuite/tests/memory-model/opt.mli
+++ b/testsuite/tests/memory-model/opt.mli
@@ -1,7 +1,7 @@
 (* Configuration:
  * the test can also be used as a program, with command line options.
  * In particular, option `-v` also runs allowed tests,
- * whose occurence is legal according to the memory model
+ * whose occurrence is legal according to the memory model
  * By contrast, option `-q` (default) does not runs
  * forbidden tests only, whose occurrence are not legal
  * according to the memory model.

--- a/testsuite/tests/memory-model/publish.ml
+++ b/testsuite/tests/memory-model/publish.ml
@@ -82,7 +82,7 @@ module Publish = struct
 
   (* Publication of string reference, with subsequent updates.
    * Notice that if publication is not properly protected,
-   * the test may crash by attemping to print junk *)
+   * the test may crash by attempting to print junk *)
   module String = struct
 
     let null = "*null*"

--- a/testsuite/tests/memory-model/run.ml
+++ b/testsuite/tests/memory-model/run.ml
@@ -45,7 +45,7 @@ module Make(C:Opt.Config)(T:Test) =
             (* Initialise memory and barrier *)
             T.Env.reinit env ;
             Barrier.reinit barrier ;
-            (* Performe on test round *)
+            (* Perform on test round *)
             let d0 = Domain.spawn f0 in
             let d1 = Domain.spawn f1 in
             let t0 = Domain.join d0 in

--- a/testsuite/tests/tool-ocamldoc/Alerts_impl.html.reference
+++ b/testsuite/tests/tool-ocamldoc/Alerts_impl.html.reference
@@ -20,7 +20,7 @@
 
 <pre><span id="MODULEAlerts_impl"><span class="keyword">module</span> Alerts_impl</span>: <code class="code"><span class="keyword">sig</span></code> <a href="Alerts_impl.html">..</a> <code class="code"><span class="keyword">end</span></code></pre><div class="info module top">
 <div class="info-desc">
-<p>Alerts from implentation.</p>
+<p>Alerts from implementation.</p>
 </div>
 </div>
 <hr width="100%">

--- a/testsuite/tests/tool-ocamldoc/Alerts_impl.ml
+++ b/testsuite/tests/tool-ocamldoc/Alerts_impl.ml
@@ -2,7 +2,7 @@
  * ocamldoc with html
  *)
 
-(** Alerts from implentation. *)
+(** Alerts from implementation. *)
 
 let x = 0
 [@@deprecated "foo"]

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -732,7 +732,7 @@ let solve_Ppat_construct ~refine env loc constr no_existentials
   generalize_structure ty_res;
   List.iter generalize_structure ty_args;
   if !Clflags.principal && refine = None then begin
-    (* Do not warn for couter examples *)
+    (* Do not warn for counter-examples *)
     let exception Warn_only_once in
     try
       TypePairs.iter
@@ -2572,14 +2572,14 @@ let check_statement exp =
    If [exp] has a function type, we check that it is not syntactically the
    result of a function application, as this is often a bug in certain contexts
    (eg the rhs of a let-binding or in the argument of [ignore]). For example,
-   [ignore (List.map print_int)] written by mistake instad of [ignore (List.map
+   [ignore (List.map print_int)] written by mistake instead of [ignore (List.map
    print_int li)].
 
    The check can be disabled by explicitly annotating the expression with a type
    constraint, eg [(e : _ -> _)].
 
    If [statement] is [true] and the [ignored-partial-application] is {em not}
-   triggered, then the [non-unit-statement] check is performaed (see
+   triggered, then the [non-unit-statement] check is performed (see
    [check_statement]).
 
    If the type of [exp] is not known at the time this function is called, the


### PR DESCRIPTION
Typos found with https://github.com/codespell-project/codespell