### PR TITLE
Optimise "include struct ... end" in more cases

### DIFF
--- a/Changes
+++ b/Changes
@@ -560,6 +560,9 @@ OCaml 5.0
   (emitted for Linux in #8805)
   (Hannes Mehnert, review by Nicolás Ojeda Bär)
 
+- #11134: Optimise 'include struct' in more cases
+  (Stephen Dolan, review by Leo White and Vincent Laviron)
+
 ### Standard library:
 
 - #10742: Use LXM as the pseudo-random number generator for module Random.

--- a/lambda/translmod.ml
+++ b/lambda/translmod.ml
@@ -931,10 +931,10 @@ and all_idents = function
       List.map (fun (ci, _) -> ci.ci_id_class) cl_list @ all_idents rem
     | Tstr_class_type _ -> all_idents rem
 
-    | Tstr_include{incl_type; incl_mod={mod_desc =
-                              ( Tmod_constraint ({mod_desc = Tmod_structure str},
-                                              _, _, _)
-                              | Tmod_structure str ) }} ->
+    | Tstr_include{incl_type;
+                   incl_mod={mod_desc =
+                     ( Tmod_constraint({mod_desc=Tmod_structure str}, _, _, _)
+                     | Tmod_structure str )}} ->
         bound_value_identifiers incl_type
         @ all_idents str.str_items
         @ all_idents rem

--- a/lambda/translmod.ml
+++ b/lambda/translmod.ml
@@ -888,7 +888,8 @@ let rec more_idents = function
     | Tstr_class_type _ -> more_idents rem
     | Tstr_include{incl_mod={mod_desc =
                              Tmod_constraint ({mod_desc = Tmod_structure str},
-                                              _, _, _)}} ->
+                                              _, _, _)
+                            | Tmod_structure str }} ->
         all_idents str.str_items @ more_idents rem
     | Tstr_include _ -> more_idents rem
     | Tstr_module
@@ -1161,15 +1162,16 @@ let transl_store_structure ~scopes glob map prims aliases str =
                       transl_store ~scopes rootpath (add_idents false ids subst)
                         cont rem)
 
-        | Tstr_include{
+        | Tstr_include({
             incl_loc=loc;
             incl_mod= {
               mod_desc = Tmod_constraint (
                   ({mod_desc = Tmod_structure str} as mexp), _, _,
-                  (Tcoerce_structure (map, _)))};
+                  (Tcoerce_structure _ | Tcoerce_none))}
+            | ({ mod_desc = Tmod_structure str} as mexp);
             incl_attributes;
             incl_type;
-          } ->
+          } as incl) ->
             List.iter (Translattribute.check_attribute_on_module mexp)
               incl_attributes;
             (* Shouldn't we use mod_attributes instead of incl_attributes?
@@ -1196,8 +1198,16 @@ let transl_store_structure ~scopes glob map prims aliases str =
                                  loop ids args))
               | _ -> assert false
             in
+            let map =
+              match incl.incl_mod.mod_desc with
+              | Tmod_constraint (_, _, _, Tcoerce_structure (map, _)) ->
+                 map
+              | Tmod_structure _
+              | Tmod_constraint (_, _, _, Tcoerce_none) ->
+                 List.init (List.length ids0) (fun i -> i, Tcoerce_none)
+              | _ -> assert false
+            in
             Lsequence(lam, loop ids0 map)
-
 
         | Tstr_include incl ->
             let ids = bound_value_identifiers incl.incl_type in

--- a/lambda/translmod.ml
+++ b/lambda/translmod.ml
@@ -932,8 +932,9 @@ and all_idents = function
     | Tstr_class_type _ -> all_idents rem
 
     | Tstr_include{incl_type; incl_mod={mod_desc =
-                             Tmod_constraint ({mod_desc = Tmod_structure str},
-                                              _, _, _)}} ->
+                              ( Tmod_constraint ({mod_desc = Tmod_structure str},
+                                              _, _, _)
+                              | Tmod_structure str ) }} ->
         bound_value_identifiers incl_type
         @ all_idents str.str_items
         @ all_idents rem

--- a/testsuite/tests/typing-modules/struct_include_optimisation.ml
+++ b/testsuite/tests/typing-modules/struct_include_optimisation.ml
@@ -1,0 +1,49 @@
+(* TEST
+   * native *)
+type alloc_count = { mutable total: float }
+let allocs = Sys.opaque_identity { total = 0. }
+let[@inline never] set_allocs () =
+  allocs.total <- Gc.minor_words ()
+
+let[@inline never] count txt =
+  let now = int_of_float (Gc.minor_words () -. allocs.total) in
+  Printf.printf "%20s: %d\n" txt now;
+  set_allocs ()
+
+let v = Sys.opaque_identity (ref 0)
+
+let next () =
+  let r = !v in incr v; r
+
+let () = set_allocs ()
+
+include struct
+  let x = next ()
+  let y = next ()
+end
+
+let () = count "no signature"
+
+include (struct
+  let a = next ()
+  let b = next ()
+end : sig val a : int val b : int end)
+
+let () = count "trivial coercion"
+
+include (struct
+  let c = next ()
+  let d = next ()
+end : sig val c : int end)
+
+let () = count "prefix coercion"
+
+include (struct
+  let c = next ()
+  let d = next ()
+end : sig val d : int end)
+
+let () = count "reordering coercion"
+
+let () =
+  Printf.printf "%20s: %d%d%d%d%d%d\n" "outputs" x y a b c d

--- a/testsuite/tests/typing-modules/struct_include_optimisation.ml
+++ b/testsuite/tests/typing-modules/struct_include_optimisation.ml
@@ -45,5 +45,20 @@ end : sig val d : int end)
 
 let () = count "reordering coercion"
 
+module Outer = struct
+  include (struct
+    module Inner = struct
+      include (struct
+        let e = next ()
+      end)
+    end
+  end)
+end
+
 let () =
-  Printf.printf "%20s: %d%d%d%d%d%d\n" "outputs" x y a b c d
+  (* The above might actually allocate the module blocks Outer and Inner,
+     but should not allocate more than 4 words (2 each) *)
+  assert (Gc.minor_words () -. allocs.total <= 4.)
+
+let () =
+  Printf.printf "%20s: %d%d%d%d%d%d%d\n" "outputs" x y a b c d Outer.Inner.e

--- a/testsuite/tests/typing-modules/struct_include_optimisation.reference
+++ b/testsuite/tests/typing-modules/struct_include_optimisation.reference
@@ -1,0 +1,5 @@
+        no signature: 0
+    trivial coercion: 0
+     prefix coercion: 0
+ reordering coercion: 0
+             outputs: 012347

--- a/testsuite/tests/typing-modules/struct_include_optimisation.reference
+++ b/testsuite/tests/typing-modules/struct_include_optimisation.reference
@@ -2,4 +2,4 @@
     trivial coercion: 0
      prefix coercion: 0
  reordering coercion: 0
-             outputs: 012347
+             outputs: 0123478


### PR DESCRIPTION
The patch in #832 introduced a more efficient compilation scheme for the pattern

```ocaml
include (struct ... end : sig ... end)
```

which avoids creating many local variables and an intermediate module block, speeding compilation time (and runtime too, not that it matters much for initialisation).

However, that patch omits two cases:

  1. When the coercion is trivial (i.e. the `sig ... end` mentions all runtime components of the module)
  2. When there is no coercion at all (i.e. `include struct ... end`)

Such cases were considered when #832 was written:

> The trick is currently not applied to include (struct .... end); it would not be difficult to do so, but there is no real reason to use that form anyway (except perhaps to simplify code generators, or to customize warnings locally in a section),

This exact use case has indeed come up: various ppx generators use the `include struct ... end` pattern to customize warnings locally in a section.

This patch extends the existing optimisation to cover those cases as well.