### PR TITLE
Introduce Unsafe_store_tag_val(dst, val) and use it in the runtime

### DIFF
--- a/Changes
+++ b/Changes
@@ -37,6 +37,11 @@ Working version
   the hashing work.
   (Gabriel Scherer, review by Xavier Leroy, report by Olivier Nicole)
 
+- #11137: new `Unsafe_store_tag(val, new_tag)` macro to stop using
+  `Tag_val(val)` as lvalue.
+  (Gabriel Scherer, review by Xavier Leroy, Guillaume Munch-Maccagnoni
+   and Nicolás Ojeda Bär)
+
 ### Type system:
 
 - #6941, #11187: prohibit using classes through recursive modules

--- a/runtime/alloc.c
+++ b/runtime/alloc.c
@@ -324,7 +324,7 @@ CAMLprim value caml_update_dummy(value dummy, value newval)
   if (tag == Double_array_tag){
     CAMLassert (Wosize_val(newval) == Wosize_val(dummy));
     CAMLassert (Tag_val(dummy) != Infix_tag);
-    Tag_val(dummy) = Double_array_tag;
+    Unsafe_store_tag_val(dummy, Double_array_tag);
     size = Wosize_val (newval) / Double_wosize;
     for (i = 0; i < size; i++) {
       Store_double_flat_field (dummy, i, Double_flat_field (newval, i));
@@ -347,7 +347,7 @@ CAMLprim value caml_update_dummy(value dummy, value newval)
   } else {
     CAMLassert (tag < No_scan_tag);
     CAMLassert (Tag_val(dummy) != Infix_tag);
-    Tag_val(dummy) = tag;
+    Unsafe_store_tag_val(dummy, tag);
     size = Wosize_val(newval);
     CAMLassert (size == Wosize_val(dummy));
     /* See comment above why this is safe even if [tag == Closure_tag]

--- a/runtime/caml/mlvalues.h
+++ b/runtime/caml/mlvalues.h
@@ -195,6 +195,14 @@ bits  63        (64-P) (63-P)        10 9     8 7   0
                                                  /* Also an l-value. */
 #endif
 
+#define Unsafe_store_tag_val(dst, val) (Tag_val(dst) = val)
+/* Currently [Tag_val(dst)] is an lvalue, but in the future we may
+   have to break this property by using explicit (relaxed) atomics to
+   avoid undefined behaviors. [Unsafe_store_tag_val(dst, val)] is
+   provided to avoid direct uses of [Tag_val(dst)] on the left of an
+   assignment. The use of [Unsafe] emphasizes that the function
+   may result in unsafe data races in a concurrent setting. */
+
 /* The lowest tag for blocks containing no value. */
 #define No_scan_tag 251
 

--- a/runtime/obj.c
+++ b/runtime/obj.c
@@ -206,7 +206,7 @@ static int obj_update_tag (value blk, int old_tag, int new_tag)
 
     if (tag != old_tag) return 0;
     if (caml_domain_alone()) {
-      Tag_val (blk) = new_tag;
+      Unsafe_store_tag_val(blk, new_tag);
       return 1;
     }
 


### PR DESCRIPTION
As discusseed in
  https://github.com/ocaml/ocaml/issues/11040
we may want to break the property that `Tag_val` is an lvalue.

With the present (small) change, the runtime codebase does not depend anymore
on the fact that `Tag_val` is an lvalue.

(cc @sadiqj @gadmm @xavierleroy)
