### PR TITLE
Add C function `caml_thread_has_lock`

### DIFF
--- a/Changes
+++ b/Changes
@@ -128,6 +128,11 @@ Working version
 - #8878: Add String.hash and String.seeded_hash.
   (Tom Kelly, review by Alain Frisch and Nicolás Ojeda Bär)
 
+- #11138: Add C function `caml_thread_has_lock` which returns true if
+  and only if the current thread belongs to a domain, and holds the
+  lock of its domain.
+  (Guillaume Munch-Maccagnoni, review by Sadiq Jaffer and Xavier Leroy)
+
 ### Other libraries:
 
 * #9071, #9100, #10935: Reimplement `Thread.exit()` as raising the

--- a/runtime/caml/domain.h
+++ b/runtime/caml/domain.h
@@ -60,6 +60,7 @@ void caml_handle_incoming_interrupts(void);
 CAMLextern void caml_interrupt_self(void);
 void caml_reset_young_limit(caml_domain_state *);
 
+CAMLextern _Thread_local int caml_thread_has_domain_lock;
 CAMLextern void caml_reset_domain_lock(void);
 CAMLextern int caml_bt_is_in_blocking_section(void);
 CAMLextern intnat caml_domain_is_multicore (void);

--- a/runtime/caml/signals.h
+++ b/runtime/caml/signals.h
@@ -31,6 +31,12 @@ CAMLextern void caml_enter_blocking_section (void);
 CAMLextern void caml_enter_blocking_section_no_pending (void);
 CAMLextern void caml_leave_blocking_section (void);
 
+CAMLextern int caml_thread_has_lock(void);
+/* [caml_thread_has_lock] returns 1 if the thread belongs to a domain
+   and it holds the lock of its domain, otherwise it returns 0. This
+   function can be called from any thread including unregistered C
+   threads. */
+
 CAMLextern void caml_process_pending_actions (void);
 /* Checks for pending actions and executes them. This includes pending
    minor and major collections, signal handlers, finalisers, and

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -1555,10 +1555,13 @@ CAMLexport intnat caml_domain_is_multicore (void)
   return (!caml_domain_alone() || self->backup_thread_running);
 }
 
+CAMLexport _Thread_local int caml_thread_has_domain_lock = 0;
+
 CAMLexport void caml_acquire_domain_lock(void)
 {
   dom_internal* self = domain_self;
   caml_plat_lock(&self->domain_lock);
+  caml_thread_has_domain_lock = 1;
 }
 
 CAMLexport void caml_bt_enter_ocaml(void)
@@ -1575,6 +1578,7 @@ CAMLexport void caml_bt_enter_ocaml(void)
 CAMLexport void caml_release_domain_lock(void)
 {
   dom_internal* self = domain_self;
+  caml_thread_has_domain_lock = 0;
   caml_plat_unlock(&self->domain_lock);
 }
 

--- a/runtime/signals.c
+++ b/runtime/signals.c
@@ -169,6 +169,11 @@ CAMLexport void caml_leave_blocking_section(void)
   errno = saved_errno;
 }
 
+CAMLexport int caml_thread_has_lock(void)
+{
+  return caml_thread_has_domain_lock;
+}
+
 static value caml_signal_handlers;
 
 void caml_init_signal_handling(void) {

--- a/testsuite/tests/c-api/test_c_thread_has_lock.ml
+++ b/testsuite/tests/c-api/test_c_thread_has_lock.ml
@@ -1,0 +1,17 @@
+(* TEST
+   modules = "test_c_thread_has_lock_cstubs.c"
+   * bytecode
+   * native
+*)
+
+external test_with_lock : unit -> bool = "with_lock"
+external test_without_lock : unit -> bool = "without_lock"
+
+let passed b = Printf.printf (if b then "passed\n" else "failed\n")
+
+let f () =
+  passed (not (test_without_lock ())) ;
+  passed (test_with_lock ())
+
+let _ =
+  f ();

--- a/testsuite/tests/c-api/test_c_thread_has_lock.reference
+++ b/testsuite/tests/c-api/test_c_thread_has_lock.reference
@@ -1,0 +1,2 @@
+passed
+passed

--- a/testsuite/tests/c-api/test_c_thread_has_lock_cstubs.c
+++ b/testsuite/tests/c-api/test_c_thread_has_lock_cstubs.c
@@ -1,0 +1,16 @@
+#include "caml/mlvalues.h"
+#include "caml/signals.h"
+
+value with_lock(value unit)
+{
+  return Val_bool(caml_thread_has_lock());
+}
+
+value without_lock(value unit)
+{
+  int res;
+  caml_enter_blocking_section();
+  res = caml_thread_has_lock();
+  caml_leave_blocking_section();
+  return Val_bool(res);
+}

--- a/testsuite/tests/c-api/test_c_thread_has_lock_systhread.ml
+++ b/testsuite/tests/c-api/test_c_thread_has_lock_systhread.ml
@@ -1,0 +1,21 @@
+(* TEST
+   modules = "test_c_thread_has_lock_cstubs.c"
+   * hassysthreads
+   include systhreads
+   ** bytecode
+   ** native
+*)
+
+external test_with_lock : unit -> bool = "with_lock"
+external test_without_lock : unit -> bool = "without_lock"
+
+let passed b = Printf.printf (if b then "passed\n" else "failed\n")
+
+let f () =
+  passed (not (test_without_lock ())) ;
+  passed (test_with_lock ())
+
+let _ =
+  f ();
+  let t = Thread.create f () in
+  Thread.join t

--- a/testsuite/tests/c-api/test_c_thread_has_lock_systhread.reference
+++ b/testsuite/tests/c-api/test_c_thread_has_lock_systhread.reference
@@ -1,0 +1,4 @@
+passed
+passed
+passed
+passed


### PR DESCRIPTION
From the commit log:

The function `caml_thread_has_lock` can be called from any C thread and returns true if the thread belongs to a domain and holds the lock of its domain.

It necessary for implementing C functions which are generic on whether the domain lock is held or not. In case `caml_thread_has_lock` returns false, the programmer can for instance:
- report an error
- try to acquire the domain lock
- do something else (e.g. delay an operation until the lock is acquired)

One application is for the OCaml-Rust FFI: in some situations, it is not possible to enforce with static typing that some function runs only when the runtime lock is held (notably destructors). This function lets us implement:
- a dynamic check of whether the lock is held (which plays well with the lifetime-based GC safety),
- a way to acquire the domain lock only if it is not already held.

In OCaml 4, it is possible to implement this feature on the programmer-side (using internals) by customizing the enter/leave runtime hooks. Alas, this strategy does not work in OCaml 5. One would have to somehow install hooks after systhread is loaded, but before the second domain is spawned (after which hooks can no longer be modified), and this is very hard to do. So we need a native solution for OCaml 5.

---

### Use-cases

- We would use it as described above in the OCaml-Rust FFI. We suspect that this function has not appeared before in the C FFI because of a difference in code scale, and Rust poses unique challenges (the type system does not always lets us track the lock ownership, notably in destructors).

- We would like to use it in the implementation of [ocaml-boxroot](https://gitlab.com/ocaml-rust/ocaml-boxroot) to implement lock-free deallocation. If the lock is held, deallocation of a boxroot from the same domain is immediate and cheap, otherwise it is a "remote" deallocation involving a lock-free auxiliary freelist.

- An old discussion already inquired about the existence of this function: https://discuss.ocaml.org/t/determining-if-the-runtime-system-is-currently-acquired-from-c/6934.

### Notes

- For OCaml 4, we can use the solution sketched above, but I can also backport the feature upon popular request.

- No pressure, but having it in OCaml _5.0_ would avoid a gap in the availability of the feature, assuming we implement it for OCaml 4 using internals.

- This implementation adds a field to the domain state. It is a simple implementation. I experimented with an implementation that recycles internals and avoids a new field (see https://github.com/gadmm/ocaml/commit/4cff734b5), but the strategy did not work without systhreads. I just thought of another implementation that stores the info in a thread-local variable, not sure which one is best (edit: it's more complicated due to OSX TLS issues and the separate compilation of systhreads).

(cc @gasche, @jhjourdan)