### PR TITLE
Gc.set now changes the minor heap size of all domains

### DIFF
--- a/Changes
+++ b/Changes
@@ -64,6 +64,11 @@ Working version
   (Enguerrand Decorne, report by Jon Ludlam,
   review by Tom Kelly, KC Sivaramakrishnan and Gabriel Scherer)
 
+- #11082, #11142: Changing the minor heap size via Gc.set applies
+  to all domains.
+  (Sabine Schmaltz, Gabriel Scherer, review by Xavier Leroy,
+  KC Sivaramakrishnan, Enguerrand Decorne, Tom Kelly, ???)
+
 ### Code generation and optimizations:
 
 - #10972: ARM64 multicore support: OCaml & C stack separation;

--- a/runtime/caml/domain.h
+++ b/runtime/caml/domain.h
@@ -35,9 +35,10 @@ extern "C" {
      (uintnat)(dom_st)->young_ptr < \
      atomic_load_explicit(&((dom_st)->young_limit), memory_order_relaxed)))
 
-asize_t caml_norm_minor_heap_size (intnat);
-int caml_reallocate_minor_heap(asize_t);
-void caml_update_minor_heap_max(uintnat minor_heap_wsz);
+asize_t caml_norm_minor_heap_wsize (intnat);
+void caml_stw_resize_minor_heaps(caml_domain_state*, void*, int,
+                                     caml_domain_state**);
+void caml_check_minor_heap();
 
 /* is there a STW interrupt queued that needs servicing */
 int caml_incoming_interrupts_queued(void);
@@ -60,10 +61,10 @@ CAMLextern void (*caml_atfork_hook)(void);
 CAMLextern void (*caml_domain_stop_hook)(void);
 CAMLextern void (*caml_domain_external_interrupt_hook)(void);
 
-CAMLextern void caml_init_domains(uintnat minor_heap_wsz);
+CAMLextern void caml_init_domains();
 CAMLextern void caml_init_domain_self(int);
 
-CAMLextern uintnat caml_minor_heap_max_wsz;
+CAMLextern uintnat caml_minor_heap_wsz;
 
 CAMLextern atomic_uintnat caml_num_domains_running;
 CAMLextern uintnat caml_minor_heaps_start;

--- a/runtime/caml/domain_state.tbl
+++ b/runtime/caml/domain_state.tbl
@@ -98,8 +98,6 @@ DOMAIN_STATE(uintnat, requested_external_interrupt)
 DOMAIN_STATE(int, parser_trace)
 /* See parsing.c */
 
-DOMAIN_STATE(asize_t, minor_heap_wsz)
-
 DOMAIN_STATE(struct caml_heap_state*, shared_heap)
 
 DOMAIN_STATE(int, id)

--- a/runtime/caml/minor_gc.h
+++ b/runtime/caml/minor_gc.h
@@ -25,7 +25,6 @@
 #define caml_young_limit Caml_state->young_limit
 #define caml_young_alloc_start Caml_state->young_start
 #define caml_young_alloc_end Caml_state->young_end
-#define caml_minor_heap_wsz Caml_state->minor_heap_wsz
 
 
 #define CAML_TABLE_STRUCT(t) { \
@@ -62,7 +61,7 @@ struct caml_minor_tables {
 CAMLextern void caml_minor_collection (void);
 
 #ifdef CAML_INTERNALS
-extern void caml_set_minor_heap_size (asize_t); /* size in bytes */
+extern void caml_set_minor_heap_wsz (asize_t);
 extern void caml_empty_minor_heap_no_major_slice_from_stw
   (caml_domain_state* domain, void* unused, int participating_count,
     caml_domain_state** participating); /* in STW */

--- a/runtime/custom.c
+++ b/runtime/custom.c
@@ -105,7 +105,7 @@ CAMLexport value caml_alloc_custom_mem(const struct custom_operations * ops,
        [heap_size / 150] is really [heap_size * (2/3) / 100] (but faster). */
     caml_heap_size(Caml_state->shared_heap) / 150 * caml_custom_major_ratio;
   mlsize_t max_minor =
-    Bsize_wsize (Caml_state->minor_heap_wsz) / 100 * caml_custom_minor_ratio;
+    Bsize_wsize (caml_minor_heap_wsz) / 100 * caml_custom_minor_ratio;
   value v = alloc_custom_gen (ops, bsz, mem, max_major, mem_minor, max_minor);
   return v;
 }

--- a/runtime/memory.c
+++ b/runtime/memory.c
@@ -339,7 +339,7 @@ Caml_inline value alloc_shr(mlsize_t wosize, tag_t tag, int noexc)
   }
   CAML_EV_ALLOC(wosize);
   dom_st->allocated_words += Whsize_wosize(wosize);
-  if (dom_st->allocated_words > dom_st->minor_heap_wsz) {
+  if (dom_st->allocated_words > caml_minor_heap_wsz) {
     CAML_EV_COUNTER (EV_C_REQUEST_MAJOR_ALLOC_SHR, 1);
     caml_request_major_slice();
   }

--- a/stdlib/gc.mli
+++ b/stdlib/gc.mli
@@ -105,9 +105,8 @@ type stat =
 type control =
   { minor_heap_size : int;
     (** The size (in words) of the minor heap.  Changing
-       this parameter will trigger a minor collection. The total size of the
-       minor heap used by this program is the sum of the heap sizes of the
-       active domains. Default: 256k. *)
+       this parameter will trigger a minor collection and change the
+       minor heap size of all domains. Default: 256k. *)
 
     major_heap_increment : int;
     (** How much to add to the major heap when increasing it. If this


### PR DESCRIPTION
Currently, every domain has its own minor heap size that it can modify within the boundary of the minor heap reservation. However, this semantics of `Gc.set` may be confusing to the user.

This PR proposes to adjust the semantics of `Gc.set` and simplify the minor heap allocation code (with the intent of keeping minor heap allocation code complexity as low as we can for the 5.00 release):

1. `Gc.set` updates the minor heap size for all domains.
2. Consequently: the minor heap size of all domains is identical. So, instead of maintaining it in `Caml_state`, we make the minor heap size global.
3. As the minor heap reservation is split into equal parts of the same size (as established in #11082), we do not need to keep track of `minor_heap_area_start` and `minor_heap_area_end` in `dom_internal`. Since access to these boundaries is not performance-critical, we can compute them from the minor heap size and domain index instead.
4. We add the missing freeing (decommitting) of the minor heap on `domain_terminate()` under the protection of the domain lock. This establishes the invariant that only active domains have a minor heap allocated (committed) within the minor heap reservation of all domains.

In contrast to #11082, setting a smaller minor heap size also stops the world and makes a new minor heap reservation, as we adjust the minor heap size of all domains.

This patch resolves the FIXME from #11082 relating to the duplicate reallocation of the leader domain's minor heap.

As this patch implements the user-visible extension of `Gc.set` semantics for 5.00, we propose a shared `Changes` entry for #11082 and this PR.