### PR TITLE
Test 32-bit build in GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -126,6 +126,29 @@ jobs:
            bash -cxe "SHOW_TIMINGS=1 tools/ci/actions/runner.sh test_prefix $dir"; \
           done
 
+  i386:
+    runs-on: ubuntu-latest
+    container:
+      image: i386/ubuntu:18.04
+      options: --platform linux/i386 --user root
+    steps:
+      - name: OS Dependencies
+        run: |
+          apt-get update
+          apt-get install -y git gcc make parallel
+      - name: Checkout
+        # See https://github.com/actions/checkout/issues/334
+        uses: actions/checkout@v1
+      - name: configure tree
+        run: |
+          MAKE_ARG=-j XARCH=i386 bash -xe tools/ci/actions/runner.sh configure
+      - name: Build
+        run: |
+          MAKE_ARG=-j bash -xe tools/ci/actions/runner.sh build
+      - name: Run the testsuite
+        run: |
+          bash -xe tools/ci/actions/runner.sh test
+
 # "extra" testsuite runs, reusing the previously built compiler tree.
 # debug: running the full testsuite with the
 #        debug runtime and minor heap verification.

--- a/tools/ci/actions/runner.sh
+++ b/tools/ci/actions/runner.sh
@@ -56,7 +56,7 @@ EOF
 }
 
 Build () {
-  $MAKE world.opt
+  $MAKE
   echo Ensuring that all names are prefixed in the runtime
   ./tools/check-symbol-names runtime/*.a otherlibs/*/lib*.a
 }

--- a/tools/ci/actions/runner.sh
+++ b/tools/ci/actions/runner.sh
@@ -45,11 +45,7 @@ EOF
     ./configure $configure_flags
     ;;
   i386)
-    ./configure --build=x86_64-pc-linux-gnu --host=i386-linux \
-      CC='gcc -m32 -march=x86-64' \
-      AS='as --32' \
-      ASPP='gcc -m32 -march=x86-64 -c' \
-      PARTIALLD='ld -r -melf_i386' \
+    ./configure --build=x86_64-pc-linux-gnu --host=i386-pc-linux-gnu \
       $configure_flags
     ;;
   *)


### PR DESCRIPTION
A tiny part of #11082 broke the 32-bit builds of (Unix) OCaml[^1] which was caught by Jenkins and fixed in #11141.

This PR proposes adding a check in GitHub Actions - at present, this does a "full" build using an i386 Ubuntu 18.04 docker image. Being 32-bit, native code is not built or tested, so it's quite fast. We could limit this to just a "C" build (which AppVeyor used to do for msvc32):

https://github.com/ocaml/ocaml/blob/eb7b17fe3b09e0d45d3f7a5cf77d03ce6f6388e9/tools/ci/appveyor/appveyor_build.sh#L215-L219

[^1]: I'm not totally sure why mingw32 wasn't affected