### PR TITLE
Fix Markdown links in stdlib/CONTRIBUTING.md

### DIFF
--- a/stdlib/CONTRIBUTING.md
+++ b/stdlib/CONTRIBUTING.md
@@ -61,9 +61,9 @@ argument order.
 A good starting point for function names and API
 is checking if these functions are already contained in some of the
 popular alternative standard library function such as
-(Base)[https://github.com/janestreet/base],
-(OCaml Batteries)[https://github.com/ocaml-batteries-team/batteries-included],
-(ExtLib)[https://github.com/ygrek/ocaml-extlib] or
-(OCaml-containers)[https://github.com/c-cube/ocaml-containers].
+[Base](https://github.com/janestreet/base),
+[OCaml Batteries](https://github.com/ocaml-batteries-team/batteries-included),
+[ExtLib](https://github.com/ygrek/ocaml-extlib) or
+[OCaml-containers](https://github.com/c-cube/ocaml-containers).
 One can also take a look at the standard libraries from other
 programming languages for inspiration regarding names and API.


### PR DESCRIPTION
The correct Markdown syntax is `[text](url)`, not `(text)[url]`.