### PR TITLE
Avoid Fun.id and use "fun" if no pattern matching

### DIFF
--- a/manual/src/cmds/tail-mod-cons.etex
+++ b/manual/src/cmds/tail-mod-cons.etex
@@ -26,7 +26,7 @@ operating systems with limited stack space -- the dreaded
 "Stack_overflow" exception.
 
 \begin{caml_example}{toplevel}
-List.length (map Fun.id (List.init 1_000_000 Fun.id));;
+List.length (map (fun x -> x) (List.init 1_000_000 (fun i -> i)));;
 \end{caml_example}
 
 In this implementation of "map", the recursive call happens in
@@ -55,7 +55,7 @@ let[@tail_mod_cons] rec map f l =
 \end{caml_example*}
 
 \begin{caml_example}{toplevel}
-List.length (map Fun.id (List.init 1_000_000 Fun.id));;
+List.length (map (fun x -> x) (List.init 1_000_000 (fun i -> i)));;
 \end{caml_example}
 
 This transformation only improves calls in tail-modulo-cons position,

--- a/manual/src/cmds/tail-mod-cons.etex
+++ b/manual/src/cmds/tail-mod-cons.etex
@@ -26,7 +26,7 @@ operating systems with limited stack space -- the dreaded
 "Stack_overflow" exception.
 
 \begin{caml_example}{toplevel}
-List.length (map (fun x -> x) (List.init 1_000_000 (fun i -> i)));;
+List.length (map Fun.id (List.init 1_000_000 Fun.id));;
 \end{caml_example}
 
 In this implementation of "map", the recursive call happens in
@@ -55,7 +55,7 @@ let[@tail_mod_cons] rec map f l =
 \end{caml_example*}
 
 \begin{caml_example}{toplevel}
-List.length (map (fun x -> x) (List.init 1_000_000 (fun i -> i)));;
+List.length (map Fun.id (List.init 1_000_000 Fun.id));;
 \end{caml_example}
 
 This transformation only improves calls in tail-modulo-cons position,

--- a/manual/src/tutorials/coreexamples.etex
+++ b/manual/src/tutorials/coreexamples.etex
@@ -139,13 +139,13 @@ piece of data. For instance, here is a "deriv" function that takes any
 float function as argument and returns an approximation of its
 derivative function:
 \begin{caml_example}{toplevel}
-let deriv f dx = function x -> (f (x +. dx) -. f x) /. dx;;
+let deriv f dx = fun x -> (f (x +. dx) -. f x) /. dx;;
 let sin' = deriv sin 1e-6;;
 sin' pi;;
 \end{caml_example}
 Even function composition is definable:
 \begin{caml_example}{toplevel}
-let compose f g = function x -> f (g x);;
+let compose f g = fun x -> f (g x);;
 let cos2 = compose square cos;;
 \end{caml_example}
 
@@ -156,7 +156,7 @@ over a data structure. For instance, the standard OCaml library
 provides a "List.map" functional that applies a given function to each
 element of a list, and returns the list of the results:
 \begin{caml_example}{toplevel}
-List.map (function n -> n * 2 + 1) [0;1;2;3;4];;
+List.map (fun n -> n * 2 + 1) [0;1;2;3;4];;
 \end{caml_example}
 This functional, along with a number of other list and array
 functionals, is predefined because it is often useful, but there is

--- a/manual/src/tutorials/objectexamples.etex
+++ b/manual/src/tutorials/objectexamples.etex
@@ -752,7 +752,7 @@ points.
 % Conversely, the class "int_comparable" inherits from class
 %"comparable", but type "int_comparable" is not a subtype of "comparable".
 %\begin{caml_example}{toplevel}
-%function x -> (x : int_comparable :> comparable);;
+%fun x -> (x : int_comparable :> comparable);;
 %\end{caml_example}
 
 The domain of a coercion can often be omitted. For instance, one can
@@ -832,7 +832,7 @@ abbreviation not being completely defined yet, and so its subtypes are not
 clearly known.  Then, a coercion "(_ :> c)" or "(_ : #c :> c)" is taken to be
 the identity function, as in
 \begin{caml_example}{toplevel}
-function x -> (x :> 'a);;
+fun x -> (x :> 'a);;
 \end{caml_example}
 As a consequence, if the coercion is applied to "self", as in the
 following example, the type of "self" is unified with the closed type

--- a/stdlib/stdLabels.mli
+++ b/stdlib/stdLabels.mli
@@ -24,7 +24,7 @@
      open StdLabels
 
      let to_upper = String.map ~f:Char.uppercase_ascii
-     let seq len = List.init ~f:(function i -> i) ~len
+     let seq len = List.init ~f:(fun i -> i) ~len
      let everything = Array.create_matrix ~dimx:42 ~dimy:42 42
    ]}
 


### PR DESCRIPTION
This is my impression from #11145. Feel free to adjust the PR.