### PR TITLE
ocamltest: keep debug information for all C files

### DIFF
--- a/ocamltest/Makefile
+++ b/ocamltest/Makefile
@@ -17,11 +17,13 @@
 
 ROOTDIR = ..
 
-# enable debug info for run_*.c
-CFLAGS=-g
-
 include $(ROOTDIR)/Makefile.common
 include $(ROOTDIR)/Makefile.best_binaries
+
+# Enable debug info for C files
+ifneq "$(CCOMPTYPE)" "msvc"
+OC_CFLAGS += -g
+endif
 
 ifeq "$(filter str,$(OTHERLIBRARIES))" ""
   str := false


### PR DESCRIPTION
This is a follow-up to #11111 by @gasche.

What 9ee4c07c75b9290cfad8d0542a1ecda5009210c5 does is not correct because
`CFLAGS` and the like are for the *user*. Then should be used by the
build-system where appropriate, but never ever should they be defined.