### PR TITLE
Rename `Hashtbl.SeededHashedType.{hash => seeded_hash}`

### DIFF
--- a/Changes
+++ b/Changes
@@ -116,6 +116,11 @@ Working version
 - #10986: Add Scanf.sscanf_opt, Scanf.bscanf_opt and Scanf.scanf_opt.
   (Nicolás Ojeda Bär, review by Florian Angeletti and Gabriel Scherer)
 
+* #11157: Rename "hash" in the "Hashtbl.SeededHashedType" signature to
+  "seeded_hash". This allows defining both seeded and unseeded hash functions in
+  the same module.
+  (Nicolás Ojeda Bär, review by Gabriel Scherer and Xavier Leroy)
+
 ### Other libraries:
 
 * #9071, #9100, #10935: Reimplement `Thread.exit()` as raising the

--- a/stdlib/hashtbl.ml
+++ b/stdlib/hashtbl.ml
@@ -284,7 +284,7 @@ module type SeededHashedType =
   sig
     type t
     val equal: t -> t -> bool
-    val hash: int -> t -> int
+    val seeded_hash: int -> t -> int
   end
 
 module type S =
@@ -354,7 +354,7 @@ module MakeSeeded(H: SeededHashedType): (SeededS with type key = H.t) =
     let copy = copy
 
     let key_index h key =
-      (H.hash h.seed key) land (Array.length h.data - 1)
+      (H.seeded_hash h.seed key) land (Array.length h.data - 1)
 
     let add h key data =
       let i = key_index h key in
@@ -481,7 +481,7 @@ module Make(H: HashedType): (S with type key = H.t) =
     include MakeSeeded(struct
         type t = H.t
         let equal = H.equal
-        let hash (_seed: int) x = H.hash x
+        let seeded_hash (_seed: int) x = H.hash x
       end)
     let create sz = create ~random:false sz
     let of_seq i =

--- a/stdlib/hashtbl.mli
+++ b/stdlib/hashtbl.mli
@@ -396,11 +396,11 @@ module type SeededHashedType =
     val equal: t -> t -> bool
     (** The equality predicate used to compare keys. *)
 
-    val hash: int -> t -> int
+    val seeded_hash: int -> t -> int
       (** A seeded hashing function on keys.  The first argument is
           the seed.  It must be the case that if [equal x y] is true,
-          then [hash seed x = hash seed y] for any value of [seed].
-          A suitable choice for [hash] is the function
+          then [seeded_hash seed x = seeded_hash seed y] for any value of
+          [seed].  A suitable choice for [seeded_hash] is the function
           {!Hashtbl.seeded_hash} below. *)
   end
 (** The input signature of the functor {!MakeSeeded}.

--- a/stdlib/moreLabels.mli
+++ b/stdlib/moreLabels.mli
@@ -415,11 +415,11 @@ module Hashtbl : sig
       val equal: t -> t -> bool
       (** The equality predicate used to compare keys. *)
 
-      val hash: int -> t -> int
+      val seeded_hash: int -> t -> int
         (** A seeded hashing function on keys.  The first argument is
             the seed.  It must be the case that if [equal x y] is true,
-            then [hash seed x = hash seed y] for any value of [seed].
-            A suitable choice for [hash] is the function
+            then [seeded_hash seed x = seeded_hash seed y] for any value of
+            [seed].  A suitable choice for [seeded_hash] is the function
             {!Hashtbl.seeded_hash} below. *)
     end
   (** The input signature of the functor {!MakeSeeded}.

--- a/stdlib/templates/hashtbl.template.mli
+++ b/stdlib/templates/hashtbl.template.mli
@@ -396,11 +396,11 @@ module type SeededHashedType =
     val equal: t -> t -> bool
     (** The equality predicate used to compare keys. *)
 
-    val hash: int -> t -> int
+    val seeded_hash: int -> t -> int
       (** A seeded hashing function on keys.  The first argument is
           the seed.  It must be the case that if [equal x y] is true,
-          then [hash seed x = hash seed y] for any value of [seed].
-          A suitable choice for [hash] is the function
+          then [seeded_hash seed x = seeded_hash seed y] for any value of
+          [seed].  A suitable choice for [seeded_hash] is the function
           {!Hashtbl.seeded_hash} below. *)
   end
 (** The input signature of the functor {!MakeSeeded}.


### PR DESCRIPTION
With this change it is possible to define both seeded and unseeded hash functions in the same module. This breaks code instantianting the `Hashtbl.MakeSeeded` functor, but an OPAM-wide grep shows that not too many packages would be affected:

- distributed
- extlib
- h2
- lru
- memtrace
- ocaml-in-python
- stdcompat
- tezos-lwt-result-stdlib

The list only contain the packages directly affected; other packages which vendor one of the previous ones would be affected by transitivity:

- coccinelle (stdcompat)
- dream (h2)
- piaf (h2)
- ocaml-gist (h2)
- tezos (all packages) (tezos-lwt-result-stdlib)

Unblocks #8878 #10259