### PR TITLE
Factor out reading `OCAMLTOP_INCLUDE_PATH` in ocaml/ocamlnat

### DIFF
--- a/.depend
+++ b/.depend
@@ -6517,7 +6517,6 @@ toplevel/byte/topmain.cmo : \
     toplevel/topcommon.cmi \
     typing/printtyp.cmi \
     typing/path.cmi \
-    utils/misc.cmi \
     driver/main_args.cmi \
     parsing/location.cmi \
     typing/env.cmi \
@@ -6535,7 +6534,6 @@ toplevel/byte/topmain.cmx : \
     toplevel/topcommon.cmx \
     typing/printtyp.cmx \
     typing/path.cmx \
-    utils/misc.cmx \
     driver/main_args.cmx \
     parsing/location.cmx \
     typing/env.cmx \
@@ -6678,7 +6676,6 @@ toplevel/native/topmain.cmo : \
     toplevel/toploop.cmi \
     toplevel/native/topeval.cmi \
     toplevel/topcommon.cmi \
-    utils/misc.cmi \
     driver/main_args.cmi \
     parsing/location.cmi \
     driver/compmisc.cmi \
@@ -6689,7 +6686,6 @@ toplevel/native/topmain.cmx : \
     toplevel/toploop.cmx \
     toplevel/native/topeval.cmx \
     toplevel/topcommon.cmx \
-    utils/misc.cmx \
     driver/main_args.cmx \
     parsing/location.cmx \
     driver/compmisc.cmx \

--- a/toplevel/byte/topmain.ml
+++ b/toplevel/byte/topmain.ml
@@ -200,17 +200,10 @@ module Options = Main_args.Make_bytetop_options (struct
     let _eval s = input_argument (Toploop.String  s)
 end)
 
-let () =
-  let extra_paths =
-    match Sys.getenv "OCAMLTOP_INCLUDE_PATH" with
-    | exception Not_found -> []
-    | s -> Misc.split_path_contents s
-  in
-  Clflags.include_dirs := List.rev_append extra_paths !Clflags.include_dirs
-
 let main () =
   let ppf = Format.err_formatter in
   let program = "ocaml" in
+  Topcommon.update_search_path_from_env ();
   Compenv.readenv ppf Before_args;
   Clflags.add_arguments __LOC__ Options.list;
   Compenv.parse_arguments ~current argv file_argument program;

--- a/toplevel/native/topmain.ml
+++ b/toplevel/native/topmain.ml
@@ -92,18 +92,11 @@ module Options = Main_args.Make_opttop_options (struct
 
 end)
 
-let () =
-  let extra_paths =
-    match Sys.getenv "OCAMLTOP_INCLUDE_PATH" with
-    | exception Not_found -> []
-    | s -> Misc.split_path_contents s
-  in
-  Clflags.include_dirs := List.rev_append extra_paths !Clflags.include_dirs
-
 let main () =
   let ppf = Format.err_formatter in
   Clflags.native_code := true;
   let program = "ocamlnat" in
+  Topcommon.update_search_path_from_env ();
   Compenv.readenv ppf Before_args;
   Clflags.add_arguments __LOC__ Options.list;
   Compenv.parse_arguments ~current argv file_argument program;

--- a/toplevel/topcommon.ml
+++ b/toplevel/topcommon.ml
@@ -277,6 +277,13 @@ let set_paths () =
   Load_path.init load_path;
   Dll.add_path load_path
 
+let update_search_path_from_env () =
+  let extra_paths =
+    let env = Sys.getenv_opt "OCAMLTOP_INCLUDE_PATH" in
+    Option.fold ~none:[] ~some:Misc.split_path_contents env
+  in
+  Clflags.include_dirs := List.rev_append extra_paths !Clflags.include_dirs
+
 let initialize_toplevel_env () =
   toplevel_env := Compmisc.initial_env()
 

--- a/toplevel/topcommon.mli
+++ b/toplevel/topcommon.mli
@@ -31,6 +31,11 @@ open Format
 
 val set_paths : unit -> unit
 
+(* Add directories listed in OCAMLTOP_INCLUDE_PATH to the end of the search
+   path *)
+
+val update_search_path_from_env : unit -> unit
+
 (* Management and helpers for the execution *)
 
 val toplevel_env : Env.t ref


### PR DESCRIPTION
`ocaml` and `ocamlnat` both contain identical code for parsing `OCAMLTOP_INCLUDE_PATH`.

(This refactor is a precursor to another PR, but further deduplicating toplevel code stands in its own right)