### PR TITLE
Make Domain.t injective

### DIFF
--- a/stdlib/domain.mli
+++ b/stdlib/domain.mli
@@ -16,7 +16,7 @@
 (*                                                                        *)
 (**************************************************************************)
 
-type 'a t
+type !'a t
 (** A domain of type ['a t] runs independently, eventually producing a
     result of type 'a, or an exception *)
 

--- a/testsuite/tests/lib-domain/type_injectivity.ml
+++ b/testsuite/tests/lib-domain/type_injectivity.ml
@@ -1,0 +1,3 @@
+(* TEST *)
+
+type !'a t = 'a Domain.t


### PR DESCRIPTION
I would like to make `Domain.t` injective in its parameter. This is useful for defining effects that return a domain without using wrappers, and it seems natural to expect that the domain type to be injective in the return type. Here is an example of such effects:
```ocaml
type _ Effect.t += Spawn : (unit -> 'a) -> 'a Domain.t Effect.t
```