### PR TITLE
Remove the useless injectivity test for Stdlib.Domain

### DIFF
--- a/testsuite/tests/lib-domain/type_injectivity.ml
+++ b/testsuite/tests/lib-domain/type_injectivity.ml
@@ -1,3 +1,0 @@
-(* TEST *)
-
-type !'a t = 'a Domain.t


### PR DESCRIPTION
Leftover from #11159.