### PR TITLE
Fixed memory leak from sigaltstack.

### DIFF
--- a/Changes
+++ b/Changes
@@ -220,6 +220,9 @@ Working version
 
 ### Bug fixes:
 
+- #11167: Fix memory leak from signal stack.
+  (Antoni Żewierżejew)
+
 - #11112: harden -use-runtime against spaces or quotes in the provided path
   (Gabriel Scherer, report by Brahima Dibassi, review by David Allsopp)
 

--- a/Changes
+++ b/Changes
@@ -221,7 +221,7 @@ Working version
 ### Bug fixes:
 
 - #11167: Fix memory leak from signal stack.
-  (Antoni Żewierżejew)
+  (Antoni Żewierżejew, review by Gabriel Scherer and Enguerrand Decorne)
 
 - #11112: harden -use-runtime against spaces or quotes in the provided path
   (Gabriel Scherer, report by Brahima Dibassi, review by David Allsopp)

--- a/runtime/startup_aux.c
+++ b/runtime/startup_aux.c
@@ -29,6 +29,7 @@
 #include "caml/osdeps.h"
 #include "caml/startup_aux.h"
 #include "caml/prims.h"
+#include "caml/signals.h"
 
 #ifdef _WIN32
 extern void caml_win32_unregister_overflow_detection (void);
@@ -166,6 +167,7 @@ CAMLexport void caml_shutdown(void)
   caml_free_shared_libs();
 #endif
   caml_stat_destroy_pool();
+  caml_free_signal_stack();
 #if defined(_WIN32) && defined(NATIVE_CODE)
   caml_win32_unregister_overflow_detection();
 #endif


### PR DESCRIPTION
Currently stack for handling signals on the first domain always leaks.
As far as I have read the code extra spawned domains have their stacks cleared on exit.
The following fix clears the stack on the original domain.

It wouldn't free data if `caml_shutdown` was called on different thread than `caml_startup_pooled`.
It wouldn't break anything either way (as the function would do nothing).
But I don't know whether calling those functions from different threads is allowed.
