### PR TITLE
A couple small clarifications in the documentation of Random

### DIFF
--- a/stdlib/random.mli
+++ b/stdlib/random.mli
@@ -141,7 +141,7 @@ module State : sig
   *)
 
   val split : t -> t
-  (** Draw a fresh PRNG state from the given PRNG state.
+  (** Draw a fresh PRNG state from the given PRNG state (which is modified).
       The new PRNG is statistically independent from the given PRNG.
       Data can be drawn from both PRNGs, in any order, without risk of
       correlation.  Both PRNGs can be split later, arbitrarily many times.
@@ -160,5 +160,7 @@ val set_state : State.t -> unit
 
 val split : unit -> State.t
 (** Draw a fresh PRNG state from the current state of the domain-local
-    generator used by the default functions.  See {!Random.State.split}.
+    generator used by the default functions.
+    (The state of the domain-local generator is modified.)
+    See {!Random.State.split}.
     @since 5.0.0 *)

--- a/stdlib/random.mli
+++ b/stdlib/random.mli
@@ -150,11 +150,13 @@ module State : sig
 end
 
 val get_state : unit -> State.t
-(** Return the current state of the domain-local generator used by the basic
-    functions. *)
+(** [get_state()] returns a fresh copy of the current state of the
+    domain-local generator (which is used by the basic functions). *)
 
 val set_state : State.t -> unit
-(** Set the state of the domain-local generator used by the basic functions. *)
+(** [set_state s] updates the current state of the domain-local
+    generator (which is used by the basic functions) by copying
+    the state [s] into it. *)
 
 val split : unit -> State.t
 (** Draw a fresh PRNG state from the current state of the domain-local

--- a/stdlib/random.mli
+++ b/stdlib/random.mli
@@ -141,7 +141,8 @@ module State : sig
   *)
 
   val split : t -> t
-  (** Draw a fresh PRNG state from the given PRNG state (which is modified).
+  (** Draw a fresh PRNG state from the given PRNG state.
+      (The given PRNG state is modified.)
       The new PRNG is statistically independent from the given PRNG.
       Data can be drawn from both PRNGs, in any order, without risk of
       correlation.  Both PRNGs can be split later, arbitrarily many times.


### PR DESCRIPTION
I have been seriously bit by my misunderstanding of the semantics of `Random.get_state()`, which I thought returned a pointer to the generator's internal state, not a pointer to a copy of the generator's internal state. Hence, I suggest this clarification (first commit). While I am at it, I also suggest clarifying that `split` affects the internal state of the generator (second commit).