### PR TITLE
Avoid pushing untagged code pointers to the bytecode stack

### DIFF
--- a/Changes
+++ b/Changes
@@ -64,6 +64,9 @@ Working version
   (Enguerrand Decorne, report by Jon Ludlam,
   review by Tom Kelly, KC Sivaramakrishnan and Gabriel Scherer)
 
+- #??: Optimise bytecode stack scanning by tagging code pointers
+  (Stephen Dolan, review by ??)
+
 ### Code generation and optimizations:
 
 - #10972: ARM64 multicore support: OCaml & C stack separation;

--- a/runtime/backtrace_byt.c
+++ b/runtime/backtrace_byt.c
@@ -287,8 +287,8 @@ void caml_stash_backtrace(value exn, value * sp, int reraise)
   trap_sp = Stack_high(Caml_state->current_stack) + Caml_state->trap_sp_off;
   for (/*nothing*/; sp < trap_sp; sp++) {
     code_t p;
-    if (Is_long(*sp)) continue;
-    p = (code_t) *sp;
+    if (Is_block(*sp)) continue;
+    p = Ptr_val(*sp);
     if (Caml_state->backtrace_pos >= BACKTRACE_BUFFER_SIZE) break;
     if (find_debug_info(p) != NULL)
       Caml_state->backtrace_buffer[Caml_state->backtrace_pos++] = p;
@@ -304,16 +304,17 @@ code_t caml_next_frame_pointer(value* stack_high, value ** sp,
 {
   while (*sp < stack_high) {
     value *spv = (*sp)++;
-    code_t *p;
-    if (Is_long(*spv)) continue;
-    p = (code_t*) spv;
-    if((code_t*)&Trap_pc(stack_high + *trap_spoff) == p) {
+    code_t pc;
+    if (Is_block(*spv)) continue;
+    if(&Trap_pc(stack_high + *trap_spoff) == spv) {
       *trap_spoff = Trap_link(stack_high + *trap_spoff);
       continue;
     }
 
-    if (find_debug_info(*p) != NULL)
-      return *p;
+    pc = Ptr_val(*spv);
+
+    if (find_debug_info(pc) != NULL)
+      return pc;
   }
   return NULL;
 }

--- a/runtime/callback.c
+++ b/runtime/callback.c
@@ -95,7 +95,7 @@ CAMLexport value caml_callbackN_exn(value closure, int narg, value args[])
   callback_code[3] = narg;
 
   domain_state->current_stack->sp[narg] =
-                     (value)(callback_code + 4); /* return address */
+                     Val_ptr(callback_code + 4); /* return address */
   domain_state->current_stack->sp[narg + 1] = Val_unit;    /* environment */
   domain_state->current_stack->sp[narg + 2] = Val_long(0); /* extra args */
   domain_state->current_stack->sp[narg + 3] = closure;

--- a/runtime/caml/fiber.h
+++ b/runtime/caml/fiber.h
@@ -191,7 +191,7 @@ struct c_stack_link {
 /* The table of global identifiers */
 extern value caml_global_data;
 
-#define Trap_pc(tp) (((code_t *)(tp))[0])
+#define Trap_pc(tp) ((tp)[0])
 #define Trap_link(tp) ((tp)[1])
 
 struct stack_info** caml_alloc_stack_cache (void);

--- a/runtime/debugger.c
+++ b/runtime/debugger.c
@@ -346,7 +346,7 @@ void caml_debugger_code_unloaded(int index)
   })
 }
 
-#define Pc(sp) ((code_t)((sp)[0]))
+#define Pc(sp) (Ptr_val((sp)[0]))
 #define Env(sp) ((sp)[1])
 #define Extra_args(sp) (Long_val(((sp)[2])))
 #define Locals(sp) ((sp) + 3)

--- a/runtime/fiber.c
+++ b/runtime/fiber.c
@@ -347,7 +347,11 @@ CAMLprim value caml_ensure_stack_capacity(value required_space)
 */
 
 Caml_inline int is_block_and_not_code_frag(value v) {
-  return Is_block(v) && caml_find_code_fragment_by_pc((char *) v) == NULL;
+  if (!Is_block(v)) return 0;
+
+  /* Bytecode code pointers should always be tagged */
+  CAMLassert (caml_find_code_fragment_by_pc((char *) v) == NULL);
+  return 1;
 }
 
 void caml_scan_stack(scanning_action f, void* fdata,

--- a/runtime/meta.c
+++ b/runtime/meta.c
@@ -222,7 +222,7 @@ CAMLprim value caml_invoke_traced_function(value codeptr, value env, value arg)
   Caml_state->current_stack->sp -= 4;
   nsp = Caml_state->current_stack->sp;
   for (i = 0; i < 7; i++) nsp[i] = osp[i];
-  nsp[7] = (value) Nativeint_val(codeptr);
+  nsp[7] = Val_ptr( (code_t) Nativeint_val(codeptr) );
   nsp[8] = env;
   nsp[9] = Val_int(0);
   nsp[10] = arg;


### PR DESCRIPTION
In bytecode mode, the GC can spends a lot of time examing the code fragments table to determine whether a word on the stack is a code pointer or not. This patch changes the bytecode interpreter to ensure code pointers are always tagged, making this check unnecessary.

This change makes the [stacks benchmark from sandmark](https://github.com/ocaml-bench/sandmark/blob/main/benchmarks/simple-tests/stacks.ml) go from ~50% slower than 4.13 to ~20% faster.