### PR TITLE
Fix or document concurrency issues on channels in Multicore

### DIFF
--- a/stdlib/in_channel.mli
+++ b/stdlib/in_channel.mli
@@ -128,16 +128,25 @@ val really_input : t -> bytes -> int -> int -> unit option
     Returns [None] if the end of file is reached before [len] characters have
     been read.
 
+    If the same channel is read concurrently by multiple threads, the bytes
+    read by [really_input] are not guaranteed to be contiguous.
+
     @raise Invalid_argument if [pos] and [len] do not designate a valid range of
     [buf]. *)
 
 val really_input_string : t -> int -> string option
 (** [really_input_string ic len] reads [len] characters from channel [ic] and
     returns them in a new string.  Returns [None] if the end of file is reached
-    before [len] characters have been read. *)
+    before [len] characters have been read.
+
+    If the same channel is read concurrently by multiple threads, the returned
+    string is not guaranteed to contain contiguous characters from the input. *)
 
 val input_all : t -> string
-(** [input_all ic] reads all remaining data from [ic]. *)
+(** [input_all ic] reads all remaining data from [ic].
+
+    If the same channel is read concurrently by multiple threads, the returned
+    string is not guaranteed to contain contiguous characters from the input. *)
 
 val set_binary_mode : t -> bool -> unit
 (** [set_binary_mode ic true] sets the channel [ic] to binary mode: no


### PR DESCRIPTION
This fixes a few channel-related concurrency issues, mentioned in https://github.com/ocaml/ocaml/issues/10960#issuecomment-1087660763, and proposes to document the thread-unsafety or possibly surprising behavior of a few other IO functions.

- Lock the channel in runtime functions `caml_ml_close_channel` and `caml_ml_pos_{in,out}`. Lock it earlier in `caml_ml_flush`. Without this, these functions show non sequentially consistent behaviour, unexpected `Sys_error` exceptions and even segfaults in multicore.
- Document the fact that `really_input`, `really_input_string` and `input_all`, because they read by chunks and release the channel lock between chunks, may not read contiguous chunks when there are multiple concurrent readers.
- Document the fact that `Scanf` is thread-unsafe.