### PR TITLE
Makefile: fix build failure when using LLVM ranlib

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -590,7 +590,9 @@ ifeq "$(INSTALL_OCAMLNAT)" "true"
 	  $(INSTALL_PROG) ocamlnat$(EXE) "$(INSTALL_BINDIR)"
 endif
 	cd "$(INSTALL_COMPLIBDIR)" && \
-	   $(RANLIB) ocamlcommon.$(A) ocamlbytecomp.$(A) ocamloptcomp.$(A)
+	   printf "ocamlcommon.$(A)\nocamlbytecomp.$(A)\nocamloptcomp.$(A)" |\
+	   xargs -I{} $(RANLIB) {}
+
 
 # Installation of the *.ml sources of compiler-libs
 .PHONY: install-compiler-sources

--- a/Makefile
+++ b/Makefile
@@ -590,9 +590,9 @@ ifeq "$(INSTALL_OCAMLNAT)" "true"
 	  $(INSTALL_PROG) ocamlnat$(EXE) "$(INSTALL_BINDIR)"
 endif
 	cd "$(INSTALL_COMPLIBDIR)" && \
-	   printf "ocamlcommon.$(A)\nocamlbytecomp.$(A)\nocamloptcomp.$(A)" |\
-	   xargs -I{} $(RANLIB) {}
-
+	   $(RANLIB) ocamlcommon.$(A) && \
+	   $(RANLIB) ocamlbytecomp.$(A) && \
+	   $(RANLIB) ocamloptcomp.$(A)
 
 # Installation of the *.ml sources of compiler-libs
 .PHONY: install-compiler-sources

--- a/Makefile
+++ b/Makefile
@@ -589,6 +589,8 @@ endif
 ifeq "$(INSTALL_OCAMLNAT)" "true"
 	  $(INSTALL_PROG) ocamlnat$(EXE) "$(INSTALL_BINDIR)"
 endif
+	# Libaries need to be passed separately, as non-GNU ranlib may not support
+	# running on multiple files, like llvm-ranlib.
 	cd "$(INSTALL_COMPLIBDIR)" && \
 	   $(RANLIB) ocamlcommon.$(A) && \
 	   $(RANLIB) ocamlbytecomp.$(A) && \


### PR DESCRIPTION
LLVM ranlib does not support running on multiple static archives.

To fix this, use xargs to run ranlib on each individual archive.