### PR TITLE
Experimental id-based pthread names for domain, tick, backup threads

### DIFF
--- a/Changes
+++ b/Changes
@@ -124,6 +124,15 @@ OCaml 5.0
   `caml_process_pending*` for multicore.
   (Guillaume Munch-Maccagnoni, review by Sadiq Jaffer and Gabriel Scherer)
 
+- #11174: Implements `Domain.set_name` and `Domain.get_name` to assign and
+  read names of domains. With OCAMLRUNPARAM flag "T=1", the runtime propagates
+  the assigned domain names to the respective operating system threads.
+  Using OCAMLRUNPARAM "T=2", the runtime, in addition, decorates
+  the assigned OS thread names with the hexadecimal unique domain id
+  and flags that identify the domain, backup, and tick threads.
+  This is an experimental feature, for debugging purposes only.
+  (Sabine Schmaltz, review by ...)
+
 ### Code generation and optimizations:
 
 - #10972: ARM64 multicore support: OCaml & C stack separation;

--- a/man/ocamlrun.1
+++ b/man/ocamlrun.1
@@ -234,6 +234,14 @@ The size of the minor heap (in words).
 Set the trace level for the debug runtime (ignored by the standard
 runtime).
 .TP
+.B T \ (domain thread names)
+T=1: the runtime assigns the name of the domain as POSIX thread name
+for the domain threads, on operating systems that support this.
+T=2: The runtime additionally decorates the assigned domain thread names
+with the hexadecimal domain id and flags to identify backup threads (B),
+tick threads (T), and threads generated via `Thread.new` (N).
+This is an experimental feature, for debugging purposes only!
+.TP
 .BR v \ (verbose)
 What GC messages to print to stderr.  This is a sum of values selected
 from the following:

--- a/manual/src/cmds/runtime.etex
+++ b/manual/src/cmds/runtime.etex
@@ -172,6 +172,14 @@ The following environment variables are also consulted:
         This option takes no argument.
   \item[s] ("minor_heap_size")  Size of the minor heap. (in words)
   \item[t] Set the trace level for the debug runtime (ignored by the standard runtime).
+  \item[T] (domain thread names)
+            T=1: the runtime assigns the name of the domain as POSIX thread name
+            for the domain threads, on operating systems that support this.
+
+            T=2: The runtime additionally decorates the assigned domain thread names
+            with the hexadecimal domain id and flags to identify backup threads (B),
+            tick threads (T), and threads generated via `Thread.new` (N).
+            This is an experimental feature, for debugging purposes only!
   \item[v] ("verbose")  What GC messages to print to stderr.  This
   is a sum of values selected from the following:
   \begin{options}

--- a/otherlibs/systhreads/st_pthreads.h
+++ b/otherlibs/systhreads/st_pthreads.h
@@ -17,6 +17,7 @@
 
 #include <assert.h>
 #include <errno.h>
+#include "caml/startup.h"
 #include <string.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -288,6 +289,9 @@ static void * caml_thread_tick(void * arg)
   caml_init_domain_self(*domain_id);
   caml_domain_state *domain = Caml_state;
 
+  if(caml_params->assign_domain_thread_names) {
+    caml_set_domain_thread_name("T");
+  }
   while(! atomic_load_acq(&Tick_thread_stop)) {
     st_msleep(Thread_timeout);
 

--- a/otherlibs/systhreads/st_stubs.c
+++ b/otherlibs/systhreads/st_stubs.c
@@ -478,6 +478,10 @@ static void * caml_thread_start(void * v)
 
   st_tls_set(caml_thread_key, th);
 
+  if(caml_params->assign_domain_thread_names) {
+    caml_set_domain_thread_name("N");
+  }
+
   st_masterlock_acquire(&Thread_main_lock);
   Current_thread = st_tls_get(caml_thread_key);
   caml_thread_restore_runtime_state();

--- a/runtime/caml/domain.h
+++ b/runtime/caml/domain.h
@@ -120,6 +120,8 @@ int caml_global_barrier_num_domains(void);
 
 int caml_domain_is_terminating(void);
 
+CAMLextern void caml_set_domain_thread_name(char*);
+
 #endif /* CAML_INTERNALS */
 
 #ifdef __cplusplus

--- a/runtime/caml/domain_state.tbl
+++ b/runtime/caml/domain_state.tbl
@@ -109,6 +109,7 @@ DOMAIN_STATE(struct caml_heap_state*, shared_heap)
 DOMAIN_STATE(int, id)
 
 DOMAIN_STATE(int, unique_id)
+DOMAIN_STATE(char*, name)
 
 DOMAIN_STATE(struct pool**, pools_to_rescan)
 DOMAIN_STATE(int, pools_to_rescan_len)

--- a/runtime/caml/misc.h
+++ b/runtime/caml/misc.h
@@ -560,6 +560,11 @@ CAMLextern int caml_snwprintf(wchar_t * buf,
 #define snprintf_os snprintf
 #endif
 
+/* platform dependent best-effort thread naming */
+#define MAX_THREAD_NAME_LENGTH 16
+extern void caml_thread_getname(char* name);
+extern void caml_thread_setname(const char* name);
+
 /* Macro used to deactivate thread and address sanitizers on some
    functions. */
 #define CAMLno_tsan

--- a/runtime/caml/startup_aux.h
+++ b/runtime/caml/startup_aux.h
@@ -41,6 +41,7 @@ struct caml_params {
   uintnat verify_heap;
   uintnat print_magic;
   uintnat print_config;
+  uintnat assign_domain_thread_names;
 
   uintnat init_percent_free;
   uintnat init_minor_heap_wsz;

--- a/runtime/startup_aux.c
+++ b/runtime/startup_aux.c
@@ -64,6 +64,7 @@ static void init_startup_params(void)
   }
 #endif
   params.trace_level = 0;
+  params.assign_domain_thread_names = 0;
   params.cleanup_on_exit = 0;
   params.print_magic = 0;
   params.print_config = 0;
@@ -106,6 +107,7 @@ void caml_parse_ocamlrunparam(void)
       case 'R': break; /*  see stdlib/hashtbl.mli */
       case 's': scanmult (opt, &params.init_minor_heap_wsz); break;
       case 't': scanmult (opt, &params.trace_level); break;
+      case 'T': scanmult (opt, &params.assign_domain_thread_names); break;
       case 'v': scanmult (opt, &params.verb_gc); break;
       case 'V': scanmult (opt, &params.verify_heap); break;
       case 'W': scanmult (opt, &caml_runtime_warnings); break;

--- a/runtime/unix.c
+++ b/runtime/unix.c
@@ -475,6 +475,30 @@ int caml_num_rows_fd(int fd)
 #endif
 }
 
+void caml_thread_getname(char* name)
+{
+  pthread_t self = pthread_self();
+#if defined(__OpenBSD__) || defined(__FreeBSD__)
+  pthread_get_name_np(self, name, MAX_THREAD_NAME_LENGTH);
+#else /* linux glibc/musl or NetBSD or apple */
+  pthread_getname_np(self, name, MAX_THREAD_NAME_LENGTH);
+#endif
+}
+
+void caml_thread_setname(const char* name)
+{
+#if defined(__APPLE__)
+  pthread_setname_np(name);
+#else /* not apple */
+  pthread_t self = pthread_self();
+#if defined(__OpenBSD__) || defined(__FreeBSD__)
+  pthread_set_name_np(self, name);
+#else /* linux glibc/musl or NetBSD */
+  pthread_setname_np(self, name);
+#endif
+#endif /* __APPLE__ */
+}
+
 void caml_init_os_params(void)
 {
   caml_sys_pagesize = sysconf(_SC_PAGESIZE);

--- a/stdlib/domain.ml
+++ b/stdlib/domain.ml
@@ -275,3 +275,6 @@ let join { term_mutex; term_condition; term_state; _ } =
   match loop () with
   | Ok x -> x
   | Error ex -> raise ex
+
+external get_name : unit -> string = "caml_ml_domain_get_name"
+external set_name : string -> unit = "caml_ml_domain_set_name"

--- a/stdlib/domain.mli
+++ b/stdlib/domain.mli
@@ -83,6 +83,14 @@ val cpu_relax : unit -> unit
 val is_main_domain : unit -> bool
 (** [is_main_domain ()] returns true if called from the initial domain. *)
 
+val get_name : unit -> string
+(** [get_name] get the domain's name. *)
+
+val set_name : string -> unit
+(** [set_name s] set the domain's name to [s]. [s] should not be longer
+    than 15 characters. If [s] is longer than 15 characters,
+    raise Invalid_argument. *)
+    
 module DLS : sig
 (** Domain-local Storage *)
 

--- a/testsuite/tests/parallel/domain_name_and_assign_thread_names.ml
+++ b/testsuite/tests/parallel/domain_name_and_assign_thread_names.ml
@@ -1,0 +1,48 @@
+(* TEST
+  modules = "domain_name_and_assign_thread_names_cstubs.c"
+  ocamlrunparam += ",T=1"
+* hasunix
+include unix
+** bytecode
+** native
+*)
+
+open Domain
+
+external thread_getname : unit -> string = "thread_getname"
+
+let check_get_name () =
+  let domain_name = Domain.get_name () in
+  let thread_name = thread_getname () in
+  if compare domain_name thread_name == 0 then
+    (Printf.printf "ok\n")
+  else
+    (Printf.printf "%s != %s\n" thread_name domain_name)
+
+
+let spawn_and_print () =
+  check_get_name ();
+  let d = Domain.spawn check_get_name in
+  join d
+
+let set_name_and_spawn () =
+  check_get_name ();
+  Domain.set_name "foo";
+  check_get_name ();
+  let d = Domain.spawn check_get_name in
+  join d
+
+let set_name_and_double_spawn () =
+  Domain.set_name "bar";
+  check_get_name ();
+  let d = Domain.spawn spawn_and_print in
+  join d
+
+let () =
+  spawn_and_print ();
+
+  let d = Domain.spawn set_name_and_spawn in
+  join d;
+
+  let d = Domain.spawn set_name_and_double_spawn in
+  join d

--- a/testsuite/tests/parallel/domain_name_and_assign_thread_names.reference
+++ b/testsuite/tests/parallel/domain_name_and_assign_thread_names.reference
@@ -1,0 +1,8 @@
+ok
+ok
+ok
+ok
+ok
+ok
+ok
+ok

--- a/testsuite/tests/parallel/domain_name_and_assign_thread_names_cstubs.c
+++ b/testsuite/tests/parallel/domain_name_and_assign_thread_names_cstubs.c
@@ -1,0 +1,16 @@
+#define CAML_INTERNALS
+#include "caml/domain.h"
+#include "caml/memory.h"
+#include "caml/misc.h"
+#include "caml/alloc.h"
+#include <stdio.h>
+
+CAMLprim value thread_getname()
+{
+  CAMLparam0();
+  CAMLlocal1(result);
+  char tmp[MAX_THREAD_NAME_LENGTH];
+  caml_thread_getname(tmp);
+  result = caml_copy_string(tmp);
+  CAMLreturn(result);
+}


### PR DESCRIPTION
By default, the runtime does not rename pthreads anymore.

When OCAMLRUNPARAM `T` is set, adjust pthread names to be based on the program's pthread name:
1) obtain the process thread name from the underlying OS and
2) assign names to domain, tick (T) and backup (B) threads, decorated with a suffix based on the hexadecimal unique domain id that allows to identify domain, backup, and tick threads.

There's a new function `Domain.get_name` to give the user access to the process thread name of the current domain (which, incidentally, I needed to write a meaningful testcase).

This resolves #11090 in such a way that we keep "process thread names for debugging purposes" for the domain threads behind an experimental runtime flag. The alternative would have been to remove the existing, rudimentary debug names implementation (`Domain0`, `Domain1`, etc.). If we, in the future, find that we do not need this feature (anymore), it's possible to remove it as there is no entanglement with other features.
