### PR TITLE
Fix "inconsistent assumptions over interface Dynlink_compilerlibs" when working on the compiler

### DIFF
--- a/otherlibs/dynlink/Makefile
+++ b/otherlibs/dynlink/Makefile
@@ -189,10 +189,14 @@ $(LOCAL_SRC)/%.cmx: $(LOCAL_SRC)/%.ml
 # Rules for building the [Dynlink_compilerlibs] bytecode and native packs
 # from their components.
 
-byte/dynlink_compilerlibs.cmo: $(COMPILERLIBS_CMO)
-	$(OCAMLC) $(COMPFLAGS) -pack -o $@ $(COMPILERLIBS_CMO)
-
-byte/dynlink_compilerlibs.cmi: byte/dynlink_compilerlibs.cmo
+# A multi-target pattern rule can tell GNU make that the recipe simultaneously
+# produces both the cmo and cmi file for Dynlink_compilerlibs. GNU make 4.3+
+# would be required to do the same thing with a static rule (with its grouped
+# targets feature).
+byt%/dynlink_compilerlibs.cmo byt%/dynlink_compilerlibs.cmi: $(COMPILERLIBS_CMO)
+	@$(if $(filter-out e,$*),\
+        $(error Should only build byte/dynlink_compilerlibs.cmo!))
+	$(OCAMLC) $(COMPFLAGS) -pack -o byte/dynlink_compilerlibs.cmo $^
 
 native/dynlink_compilerlibs.cmx: $(COMPILERLIBS_CMX)
 	$(OCAMLOPT) $(COMPFLAGS) $(OPTCOMPFLAGS) -pack -o $@ $(COMPILERLIBS_CMX)


### PR DESCRIPTION
Problem:
- Start with a clean tree
- Configure with `./configure --disable-native-compiler --disable-ocamldoc --disable-debugger --disable-ocamltest`
- Build with `make -j`
- Apply this diff (for example):
```diff
--- a/utils/config.mli
+++ b/utils/config.mli
@@ -261,3 +261,5 @@ val config_var : string -> string option
 val merlin : bool

 (**/**)
+
+val answer : int
--- a/utils/config.mlp
+++ b/utils/config.mlp
@@ -246,3 +246,5 @@ let config_var x =
       Some s

 let merlin = false
+
+let answer = 42
```
- Run `make -j` again

As long as you enough cores, I guarantee you'll see:

```
File "/home/dra/ocaml/otherlibs/dynlink/_none_", line 1:
Error: Files /home/dra/ocaml/otherlibs/dynlink/dynlink_common.cmo
       and /home/dra/ocaml/otherlibs/dynlink/byte/dynlink_compilerlibs.cmo
       make inconsistent assumptions over interface Dynlink_compilerlibs
```

If you run `make -j` again, the build will almost certainly succeed. If you do the above procedure, but with a sequential `make` in the last step (i.e. no `-j`), it'll also work.

This PR fixes the build, with possibly the mostly profoundly complicated semicolon in our codebase's venerable history. What's going on is hideously subtle, but here's an attempt at explaining it (a similar scenario is argued over [in this old email thread](https://lists.gnu.org/archive/html/help-make/2012-04/msg00005.html) on GNU make's [help-make](https://lists.gnu.org/mailman/listinfo/help-make) list).

`dynlink_common.cmo` depends on `byte/dynlink_compilerlibs.cmi`. This file is produced as part of the pack, so we have a manual dependency `byte/dynlink_compilers.cmi: byte/dynlink_compiler_libs.cmo` at:
https://github.com/ocaml/ocaml/blob/949fdacd5f48d7a29c049d7f01590a95b1c3e090/otherlibs/dynlink/Makefile#L195

The problem is that while this gives GNU make the dependency, we haven't told GNU make how to build `byte/dynlink_compilerlibs.cmi`. From GNU make's perspective, `byte/dynlink_compilerlibs.cmi` is therefore created _outside the build system_, so all it will check is that its dependencies are not newer **_at the start of the build_**. This can be seen when `dynlink_common.cmo` is being considered (this snippet is extracted from the output of `make -dj -C otherlibs/dynlink all` from the final step above):

```
Considering target file 'dynlink.cma'.
  Considering target file 'byte/dynlink_compilerlibs.cmo'.
  File 'byte/dynlink_compilerlibs.cmo' was considered already.
  Considering target file 'dynlink_types.cmo'.
  File 'dynlink_types.cmo' was considered already.
  Considering target file 'dynlink_platform_intf.cmo'.
  File 'dynlink_platform_intf.cmo' was considered already.
  Considering target file 'dynlink_common.cmo'.
    Considering target file 'dynlink_common.ml'.
    File 'dynlink_common.ml' was considered already.
    Considering target file 'dynlink_types.cmi'.
    File 'dynlink_types.cmi' was considered already.
    Considering target file 'dynlink_platform_intf.cmi'.
    File 'dynlink_platform_intf.cmi' was considered already.
    Considering target file 'byte/dynlink_compilerlibs.cmi'.
      Pruning file 'byte/dynlink_compilerlibs.cmo'.
     Finished prerequisites of target file 'byte/dynlink_compilerlibs.cmi'.
     Prerequisite 'byte/dynlink_compilerlibs.cmo' is newer than target 'byte/dynlink_compilerlibs.cmi'.
    No recipe for 'byte/dynlink_compilerlibs.cmi' and no prerequisites actually changed.
    No need to remake target 'byte/dynlink_compilerlibs.cmi'.
    Considering target file 'dynlink_common.cmi'.
    File 'dynlink_common.cmi' was considered already.
   Finished prerequisites of target file 'dynlink_common.cmo'.
   Prerequisite 'dynlink_common.ml' is older than target 'dynlink_common.cmo'.
   Prerequisite 'dynlink_types.cmi' is older than target 'dynlink_common.cmo'.
   Prerequisite 'dynlink_platform_intf.cmi' is older than target 'dynlink_common.cmo'.
   Prerequisite 'byte/dynlink_compilerlibs.cmi' is older than target 'dynlink_common.cmo'.
   Prerequisite 'dynlink_common.cmi' is older than target 'dynlink_common.cmo'.
  No need to remake target 'dynlink_common.cmo'.
```

The key part is the "No recipe for 'byte/dynlink_compilerlibs.cmi' and no prerequisites actually changed.". The "no prerequisites actually changed" refers to the fact that _at the start of the invocation_ `byte/dynlink_compilerlibs.cmo` was _not_ newer than `byte/dynlink_compilerlibs.cmi`. Since GNU make doesn't have any commands which will produce `byte/dynlink_compilerlibs.cmi` it _knows_ that `byte/dynlink_compilerlibs.cmi` won't change, so there's no need to rebuild `dynlink_common.cmo`.

But this is a lie! In parallel, `byte/dynlink_compilerlibs.cmo` is going to be remade and `byte/dynlink_compilerlibs.cmi` will change - hence the inconsistent assumptions. On the next run, _at the start of the build_ `byte/dynlink_compilerlibs.cmi` is newer than `dynlink_common.cmo` and so it is rebuilt, as expected.

The fix in this PR is to change the dependency to be an empty recipe. Now this changes GNU make's view of the world, because now instead of just having a dependency for `byte/dynlink_compilerlibs.cmi`, GNU make now has commands it's supposed to run, so it no longer assumes that `byte/dynlink_compilerlibs.cmi` is unchanging throughout the build. This alters its conclusion for `dynlink.cma`:

```
Considering target file 'dynlink.cma'.
...
    Considering target file 'byte/dynlink_compilerlibs.cmi'.
      Pruning file 'byte/dynlink_compilerlibs.cmo'.
     Finished prerequisites of target file 'byte/dynlink_compilerlibs.cmi'.
     Prerequisite 'byte/dynlink_compilerlibs.cmo' is newer than target 'byte/dynlink_compilerlibs.cmi'.
    Must remake target 'byte/dynlink_compilerlibs.cmi'.
    Successfully remade target file 'byte/dynlink_compilerlibs.cmi'.
```

crucially that action now updates GNU make's _cached_ timestamp: it now knows that it must run the commands for `byte/dynlink_compilerlibs.cmi` and that this will produce an updated `byte/dynlink_compilerlibs.cmi`. It doesn't matter that it's actually producing the _dependency_ `byte/dynlink_compilerlibs.cmo` which will emit `byte/dynlink_compilerlibs.cmi`, the point is that it stops GNU make from assuming that `byte/dynlink_compilerlibs.cmi` is unchanging throughout the build which then causes the conclusion:

```
...
   Prerequisite 'dynlink_common.ml' is older than target 'dynlink_common.cmo'.
   Prerequisite 'dynlink_types.cmi' is older than target 'dynlink_common.cmo'.
   Prerequisite 'dynlink_platform_intf.cmi' is older than target 'dynlink_common.cmo'.
   Prerequisite 'byte/dynlink_compilerlibs.cmi' is newer than target 'dynlink_common.cmo'.
   Prerequisite 'dynlink_common.cmi' is older than target 'dynlink_common.cmo'.
  Must remake target 'dynlink_common.cmo'.
```

and we get the correct ordering with `dynlink_common.cmo` compiled _before_ `dynlink.cma`.

This doesn't affect native code, because the dependency is on the .cmx (which already has a recipe), not the .cmi.