### PR TITLE
Refactor GitHub actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,17 +67,17 @@ jobs:
         id: manual
         run: >-
          tools/ci/actions/check-manual-modified.sh
-          '${{ github.ref }}'
-          '${{ github.event_name }}'
-          '${{ github.event.pull_request.base.ref }}'
-          '${{ github.event.pull_request.base.sha }}'
-          '${{ github.event.pull_request.head.ref }}'
-          '${{ github.event.pull_request.head.sha }}'
-          '${{ github.event.ref }}'
-          '${{ github.event.before }}'
-          '${{ github.event.ref }}'
-          '${{ github.event.after }}'
-          '${{ github.event.repository.full_name }}'
+         '${{ github.ref }}'
+         '${{ github.event_name }}'
+         '${{ github.event.pull_request.base.ref }}'
+         '${{ github.event.pull_request.base.sha }}'
+         '${{ github.event.pull_request.head.ref }}'
+         '${{ github.event.pull_request.head.sha }}'
+         '${{ github.event.ref }}'
+         '${{ github.event.before }}'
+         '${{ github.event.ref }}'
+         '${{ github.event.after }}'
+         '${{ github.event.repository.full_name }}'
       - name: Build the manual
         run: |
           MAKE_ARG=-j OCAMLRUNPARAM=b,v=0 bash -xe tools/ci/actions/runner.sh manual

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ on:
       - 'trunk'
   pull_request:
 
-# List of test directories for the taskset, debug-s4096 and linux-O0 jobs.
+# List of test directories for the debug-s4096 and linux-O0 jobs.
 # These directories are selected because of their tendencies to reach corner
 # cases in the runtime system.
 env:
@@ -130,7 +130,6 @@ jobs:
 #        debug runtime and minor heap verification.
 # debug-s4086: select testsuite run with the debug runtime and a small
 #              minor heap.
-# taskset: run selected testsuite directories on only one core.
   extra:
     needs: build
     runs-on: ubuntu-latest
@@ -139,7 +138,6 @@ jobs:
         id:
           - debug
           - debug-s4096
-          - taskset
     steps:
       - name: Download artifact
         uses: actions/download-artifact@v2
@@ -163,12 +161,4 @@ jobs:
         run: |
           for dir in $PARALLEL_TESTS; do \
             bash -cxe "SHOW_TIMINGS=1 tools/ci/actions/runner.sh test_prefix $dir"; \
-          done
-      - name: Run the testsuite (taskset -c 0)
-        # TEST_SEQUENTIALLY=1 is used here as doing a parallel run on only one core is not useful.
-        # It means `make parellel-` won't be used, using `make one DIR=` instead.
-        if: ${{ matrix.id == 'taskset' }}
-        run: |
-          for dir in $PARALLEL_TESTS; do \
-             taskset -c 1 bash -cxe "SHOW_TIMINGS=1 TEST_SEQUENTIALLY=1 tools/ci/actions/runner.sh test_prefix $dir"; \
           done

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,6 +52,7 @@ jobs:
       - name: Unpack Artifact
         run: |
           tar --zstd -xf sources.tar.zstd
+          rm -f sources.tar.zstd
       - name: Packages
         run: |
           sudo apt-get update -y && sudo apt-get install -y texlive-latex-extra texlive-fonts-recommended hevea sass
@@ -146,6 +147,7 @@ jobs:
       - name: Unpack Artifact
         run: |
           tar --zstd -xf sources.tar.zstd
+          rm -f sources.tar.zstd
       - name: Run the testsuite (debug runtime)
         if: ${{ matrix.id == 'debug' }}
         env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,6 +31,7 @@ jobs:
           MAKE_ARG=-j bash -xe tools/ci/actions/runner.sh build
       - name: Prepare Artifact
         run: |
+          git config --local --unset http.https://github.com/.extraheader
           tar --zstd -cf /tmp/sources.tar.zstd .
       - name: Upload Artifact
         uses: actions/upload-artifact@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,30 +8,87 @@ on:
       - 'trunk'
   pull_request:
 
-jobs:
+# List of test directories for the taskset, debug-s4096 and linux-O0 jobs.
+# These directories are selected because of their tendencies to reach corner
+# cases in the runtime system.
+env:
+  PARALLEL_TESTS: parallel callback gc-roots weak-ephe-final
 
+jobs:
+# This job will do the initial build of the compiler (on linux), with flambda on.
+# We then upload the compiler tree as a build artifact to enable re-use in
+# subsequent jobs.
   build:
-    name: 'linux'
     runs-on: 'ubuntu-latest'
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: configure tree
+      - name: Configure tree
         run: |
-          MAKE_ARG=-j XARCH=x64 bash -xe tools/ci/actions/runner.sh configure
+          MAKE_ARG=-j XARCH=x64 CONFIG_ARG='--enable-flambda --enable-cmm-invariants --enable-dependency-generation --enable-native-toplevel' OCAMLRUNPARAM=b,v=0 bash -xe tools/ci/actions/runner.sh configure
       - name: Build
         run: |
           MAKE_ARG=-j bash -xe tools/ci/actions/runner.sh build
       - name: Prepare Artifact
         run: |
           tar --zstd -cf /tmp/sources.tar.zstd .
-      - uses: actions/upload-artifact@v2
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v2
         with:
           name: compiler
           path: /tmp/sources.tar.zstd
           retention-days: 1
 
-  build-misc:
+# Full testsuite run, and other sanity checks
+  normal:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download Artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: compiler
+      - name: Unpack Artifact
+        run: |
+          tar --zstd -xf sources.tar.zstd
+      - name: Packages
+        run: |
+          sudo apt-get update -y && sudo apt-get install -y texlive-latex-extra texlive-fonts-recommended hevea sass
+      - name: Run the testsuite
+        run: |
+          MAKE_ARG=-j OCAMLRUNPARAM=b,v=0 bash -xe tools/ci/actions/runner.sh test
+      - name: Build API Documentation
+        run: |
+          MAKE_ARG=-j OCAMLRUNPARAM=b,v=0 bash -xe tools/ci/actions/runner.sh api-docs
+      - name: Install
+        run: |
+         MAKE_ARG=-j OCAMLRUNPARAM=b,v=0 bash -xe tools/ci/actions/runner.sh install
+      - name: Check for manual changes
+        id: manual
+        run: >-
+         tools/ci/actions/check-manual-modified.sh
+          '${{ github.ref }}'
+          '${{ github.event_name }}'
+          '${{ github.event.pull_request.base.ref }}'
+          '${{ github.event.pull_request.base.sha }}'
+          '${{ github.event.pull_request.head.ref }}'
+          '${{ github.event.pull_request.head.sha }}'
+          '${{ github.event.ref }}'
+          '${{ github.event.before }}'
+          '${{ github.event.ref }}'
+          '${{ github.event.after }}'
+          '${{ github.event.repository.full_name }}'
+      - name: Build the manual
+        run: |
+          MAKE_ARG=-j OCAMLRUNPARAM=b,v=0 bash -xe tools/ci/actions/runner.sh manual
+       # Temporarily disabled 23-Apr-2021 while Dune isn't building
+        if: steps.manual.outputs.changed == 'disabled'
+      - name: Other checks
+        run: |
+          MAKE_ARG=-j OCAMLRUNPARAM=b,v=0 bash -xe tools/ci/actions/runner.sh other-checks
+
+# MacOS build+testsuite run, and Linux O0 run.
+  others:
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
     strategy:
@@ -40,9 +97,6 @@ jobs:
           - name: linux-O0
             os: ubuntu-latest
             config_arg: CFLAGS='-O0'
-          - name: linux-debug
-            os: ubuntu-latest
-            env: OCAMLRUNPARAM=v=0,V=1 USE_RUNTIME=d
           - name: macos
             os: macos-latest
     steps:
@@ -61,52 +115,60 @@ jobs:
         if: ${{ matrix.name != 'linux-O0' }}
         run: |
           bash -c 'SHOW_TIMINGS=1 tools/ci/actions/runner.sh test'
-      - name: Run the testsuite (linux-O0, parallel)
+      - name: Run the testsuite (linux-O0)
         if: ${{ matrix.name == 'linux-O0' }}
         env:
           OCAMLRUNPARAM: v=0,V=1
           USE_RUNTIME: d
         run: |
-          bash -xe tools/ci/actions/runner.sh test_multicore 1 "parallel" "lib-threads" "lib-systhreads"
+          for dir in $PARALLEL_TESTS; do \
+           bash -cxe "SHOW_TIMINGS=1 tools/ci/actions/runner.sh test_prefix $dir"; \
+          done
 
-  testsuite:
+# "extra" testsuite runs, reusing the previously built compiler tree.
+# debug: running the full testsuite with the
+#        debug runtime and minor heap verification.
+# debug-s4086: select testsuite run with the debug runtime and a small
+#              minor heap.
+# taskset: run selected testsuite directories on only one core.
+  extra:
     needs: build
-    # https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idneeds    strategy:
     runs-on: ubuntu-latest
     strategy:
       matrix:
         id:
+          - debug
           - debug-s4096
           - taskset
-          - normal
-          - super
     steps:
-      - uses: actions/download-artifact@v2
+      - name: Download artifact
+        uses: actions/download-artifact@v2
         with:
           name: compiler
       - name: Unpack Artifact
         run: |
           tar --zstd -xf sources.tar.zstd
-      - name: Run the testsuite
-        if: ${{ matrix.id == 'normal' }}
+      - name: Run the testsuite (debug runtime)
+        if: ${{ matrix.id == 'debug' }}
+        env:
+          OCAMLRUNPARAM: v=0,V=1
+          USE_RUNTIME: d
         run: |
-          bash -xe tools/ci/actions/runner.sh test
-      - name: Run the testsuite (Super Charged)
-        if: ${{ matrix.id == 'super' }}
-        run: |
-          bash -xe tools/ci/actions/runner.sh test_multicore 3 "parallel" \
-          "callback" "gc-roots" "lib-threads" "lib-systhreads" \
-          "weak-ephe-final"
+          bash -cxe "SHOW_TIMINGS=1 tools/ci/actions/runner.sh test"
       - name: Run the testsuite (s=4096, debug runtime)
+        if: ${{ matrix.id == 'debug-s4096' }}
         env:
           OCAMLRUNPARAM: s=4096,v=0
           USE_RUNTIME: d
-        if: ${{ matrix.id == 'debug-s4096' }}
         run: |
-          bash -xe tools/ci/actions/runner.sh test_multicore 1 "parallel" \
-          "lib-threads" "lib-systhreads" "weak-ephe-final"
+          for dir in $PARALLEL_TESTS; do \
+            bash -cxe "SHOW_TIMINGS=1 tools/ci/actions/runner.sh test_prefix $dir"; \
+          done
       - name: Run the testsuite (taskset -c 0)
+        # TEST_SEQUENTIALLY=1 is used here as doing a parallel run on only one core is not useful.
+        # It means `make parellel-` won't be used, using `make one DIR=` instead.
         if: ${{ matrix.id == 'taskset' }}
         run: |
-          bash -xe tools/ci/actions/runner.sh test_multicore 1 "parallel" \
-          "lib-threads" "lib-systhreads" "weak-ephe-final"
+          for dir in $PARALLEL_TESTS; do \
+             taskset -c 1 bash -cxe "SHOW_TIMINGS=1 TEST_SEQUENTIALLY=1 tools/ci/actions/runner.sh test_prefix $dir"; \
+          done

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -82,8 +82,7 @@ jobs:
       - name: Build the manual
         run: |
           MAKE_ARG=-j OCAMLRUNPARAM=b,v=0 bash -xe tools/ci/actions/runner.sh manual
-       # Temporarily disabled 23-Apr-2021 while Dune isn't building
-        if: steps.manual.outputs.changed == 'disabled'
+        if: steps.manual.outputs.changed == 'true'
       - name: Other checks
         run: |
           MAKE_ARG=-j OCAMLRUNPARAM=b,v=0 bash -xe tools/ci/actions/runner.sh other-checks

--- a/asmcomp/riscv/emit.mlp
+++ b/asmcomp/riscv/emit.mlp
@@ -53,7 +53,7 @@ let slot_offset env loc cls =
 (* Output a symbol *)
 
 let emit_symbol s =
-  emit_symbol '$' s
+  emit_symbol s
 
 let emit_jump op s =
   if !Clflags.dlcode || !Clflags.pic_code

--- a/manual/src/html_processing/.gitignore
+++ b/manual/src/html_processing/.gitignore
@@ -1,3 +1,4 @@
+camlp-streams
 dune
 markup.ml
 uchar

--- a/manual/src/html_processing/Makefile
+++ b/manual/src/html_processing/Makefile
@@ -88,14 +88,15 @@ distclean::
 	rm -rf .sass-cache
 
 # We need Dune and Lambda Soup; Markup.ml and Uutf are dependencies
-DUNE_TAG = 2.6.2
-LAMBDASOUP_TAG = 0.7.1
-MARKUP_TAG = 0.8.2
-UUTF_TAG = v1.0.2
-RE_TAG = 1.9.0
+DUNE_TAG = 3.4.0
+LAMBDASOUP_TAG = 0.7.3
+MARKUP_TAG = 1.0.3
+UUTF_TAG = v1.0.3
+RE_TAG = 1.10.4
+CAMLP_STREAMS_TAG = v5.0.1
 
 # Duniverse rules - set-up dune and the dependencies in-tree for CI
-duniverse: dune/dune.exe re markup.ml uutf lambdasoup
+duniverse: dune/dune.exe re markup.ml uutf lambdasoup camlp-streams
 
 dune/dune.exe: dune
 	cd dune; ocaml bootstrap.ml
@@ -112,6 +113,7 @@ distclean::
 re:
 	git clone https://github.com/ocaml/ocaml-re.git -n -o upstream
 	cd ocaml-re; $(GIT_CHECKOUT) $(RE_TAG)
+	sed -i.bak -e '/(libraries seq)/d' ocaml-re/lib/dune
 
 distclean::
 	rm -rf ocaml-re
@@ -141,5 +143,12 @@ uutf:
 
 distclean::
 	rm -rf uutf
+
+camlp-streams:
+	git clone https://github.com/ocaml/camlp-streams.git -n -o upstream
+	cd camlp-streams; $(GIT_CHECKOUT) $(CAMLP_STREAMS_TAG)
+
+distclean::
+	rm -rf camlp-streams
 
 .PHONY: css js img duniverse

--- a/manual/src/html_processing/Makefile
+++ b/manual/src/html_processing/Makefile
@@ -89,7 +89,7 @@ distclean::
 
 # We need Dune and Lambda Soup; Markup.ml and Uutf are dependencies
 DUNE_TAG = 3.4.0
-LAMBDASOUP_TAG = 0.7.3
+LAMBDASOUP_TAG = 500
 MARKUP_TAG = 1.0.3
 UUTF_TAG = v1.0.3
 RE_TAG = 1.10.4
@@ -119,7 +119,7 @@ distclean::
 	rm -rf ocaml-re
 
 lambdasoup:
-	git clone https://github.com/aantron/lambdasoup.git -n -o upstream
+	git clone https://github.com/dra27/lambdasoup.git -n -o dra27
 	cd lambdasoup; $(GIT_CHECKOUT) $(LAMBDASOUP_TAG)
 
 distclean::

--- a/ocamldoc/Makefile
+++ b/ocamldoc/Makefile
@@ -335,7 +335,7 @@ clean:
 	rm -f odoc_lexer.ml odoc_text_lexer.ml odoc_see_lexer.ml odoc_ocamlhtml.ml
 	rm -f odoc_parser.ml odoc_parser.mli odoc_text_parser.ml odoc_text_parser.mli
 	rm -f generators/*.cm[taiox] generators/*.a generators/*.lib generators/*.o generators/*.obj \
-        generators/*.cmx[as]
+        generators/*.cmx[as] generators/*.cmti
 
 .PHONY: distclean
 distclean: clean

--- a/testsuite/tests/backtrace/backtrace_dynlink.flambda.reference
+++ b/testsuite/tests/backtrace/backtrace_dynlink.flambda.reference
@@ -1,19 +1,19 @@
 Raised by primitive operation at Backtrace_dynlink_plugin in file "backtrace_dynlink_plugin.ml", line 6, characters 13-38
 Called from Dynlink.Native.run.(fun) in file "otherlibs/dynlink/native/dynlink.ml", line 85, characters 12-29
-Called from Stdlib__List.iter in file "list.ml" (inlined), line 122, characters 12-15
+Called from Stdlib__List.iter in file "list.ml" (inlined), line 112, characters 12-15
 Called from Dynlink.Native.run in file "otherlibs/dynlink/native/dynlink.ml", line 84, characters 4-273
 Called from Dynlink_common.Make.load.(fun) in file "otherlibs/dynlink/dynlink_common.ml" (inlined), line 363, characters 13-56
-Called from Stdlib__List.iter in file "list.ml" (inlined), line 122, characters 12-15
+Called from Stdlib__List.iter in file "list.ml" (inlined), line 112, characters 12-15
 Called from Dynlink_common.Make.load in file "otherlibs/dynlink/dynlink_common.ml", line 359, characters 8-392
 Called from Dynlink_common.Make.loadfile in file "otherlibs/dynlink/dynlink_common.ml" (inlined), line 374, characters 26-45
 Called from Backtrace_dynlink in file "backtrace_dynlink.ml", line 39, characters 4-52
 execution of module initializers in the shared library failed: Failure("SUCCESS")
 Raised by primitive operation at Dynlink.Native.run.(fun) in file "otherlibs/dynlink/native/dynlink.ml", line 85, characters 12-29
 Re-raised at Dynlink.Native.run.(fun) in file "otherlibs/dynlink/native/dynlink.ml", line 87, characters 10-149
-Called from Stdlib__List.iter in file "list.ml" (inlined), line 122, characters 12-15
+Called from Stdlib__List.iter in file "list.ml" (inlined), line 112, characters 12-15
 Called from Dynlink.Native.run in file "otherlibs/dynlink/native/dynlink.ml", line 84, characters 4-273
 Called from Dynlink_common.Make.load.(fun) in file "otherlibs/dynlink/dynlink_common.ml" (inlined), line 363, characters 13-56
-Called from Stdlib__List.iter in file "list.ml" (inlined), line 122, characters 12-15
+Called from Stdlib__List.iter in file "list.ml" (inlined), line 112, characters 12-15
 Called from Dynlink_common.Make.load in file "otherlibs/dynlink/dynlink_common.ml", line 359, characters 8-392
 Re-raised at Dynlink_common.Make.load in file "otherlibs/dynlink/dynlink_common.ml", line 372, characters 8-17
 Called from Dynlink_common.Make.loadfile in file "otherlibs/dynlink/dynlink_common.ml" (inlined), line 374, characters 26-45

--- a/testsuite/tests/misc/pr7168.ml
+++ b/testsuite/tests/misc/pr7168.ml
@@ -1,6 +1,6 @@
 (* TEST
 
-ocamlrunparam = "l=100000"
+ocamlrunparam += "l=100000"
 *)
 
 let rec f x =

--- a/testsuite/tests/runtime-errors/stackoverflow.ml
+++ b/testsuite/tests/runtime-errors/stackoverflow.ml
@@ -1,6 +1,6 @@
 (* TEST
 flags = "-w -a"
-ocamlrunparam = "l=100000"
+ocamlrunparam += "l=100000"
 *)
 
 let rec f x =

--- a/tools/ci/actions/check-manual-modified.sh
+++ b/tools/ci/actions/check-manual-modified.sh
@@ -31,4 +31,5 @@ else
   fi
 fi
 
+echo "Manual altered: $result"
 echo "::set-output name=changed::$result"

--- a/tools/ci/actions/runner.sh
+++ b/tools/ci/actions/runner.sh
@@ -20,7 +20,6 @@ PREFIX=~/local
 
 MAKE="make $MAKE_ARG"
 SHELL=dash
-TEST_SEQUENTIALLY=$TEST_SEQUENTIALLY
 
 export PATH=$PREFIX/bin:$PATH
 
@@ -74,15 +73,9 @@ Test () {
 
 # By default, TestPrefix will attempt to run the tests
 # in the given directory in parallel.
-# Setting $TEST_SEQUENTIALLY will avoid this behaviour.
 TestPrefix () {
-  if [[ -z "${TEST_SEQUENTIALLY}" ]]; then
-    TO_RUN=parallel-"$1"
-  else
-    TO_RUN="one DIR=tests/$1"
-  fi
+  TO_RUN=parallel-"$1"
   echo Running single testsuite directory with $TO_RUN
-
   $MAKE -C testsuite $TO_RUN
   cd ..
 }

--- a/tools/ci/actions/runner.sh
+++ b/tools/ci/actions/runner.sh
@@ -20,6 +20,7 @@ PREFIX=~/local
 
 MAKE="make $MAKE_ARG"
 SHELL=dash
+TEST_SEQUENTIALLY=$TEST_SEQUENTIALLY
 
 export PATH=$PREFIX/bin:$PATH
 
@@ -71,17 +72,18 @@ Test () {
   cd ..
 }
 
-TestLoop () {
-  echo Running testsuite for "$@"
-  rm -f to_test.txt
-  for test in "$@"
-  do
-      echo tests/$test >> to_test.txt
-  done
-  for it in {1..$2}
-  do
-      $MAKE -C testsuite one LIST=../to_test.txt || exit 1
-  done || exit 1
+# By default, TestPrefix will attempt to run the tests
+# in the given directory in parallel.
+# Setting $TEST_SEQUENTIALLY will avoid this behaviour.
+TestPrefix () {
+  if [[ -z "${TEST_SEQUENTIALLY}" ]]; then
+    TO_RUN=parallel-"$1"
+  else
+    TO_RUN="one DIR=tests/$1"
+  fi
+  echo Running single testsuite directory with $TO_RUN
+
+  $MAKE -C testsuite $TO_RUN
   cd ..
 }
 
@@ -170,7 +172,7 @@ case $1 in
 configure) Configure;;
 build) Build;;
 test) Test;;
-test_multicore) TestLoop "${@:3}";;
+test_prefix) TestPrefix $2;;
 api-docs) API_Docs;;
 install) Install;;
 manual) BuildManual;;


### PR DESCRIPTION
## Refactoring and cleaning up Github Actions

This PR is a follow up to #10980
The Multicore merge greatly altered the workflow of Github Actions on ocaml/ocaml.
Multicore OCaml diverged greatly from it on multiple occasion during its lifespan.

This PR goals are manyfold:
- Clean up and refactor the current workflow: the new test matrices introduced by Multicore are messy and hard to navigate.
- Bring back features and test scenarios from the 4.X branch (namely the `full-flambda` run, as well as the `other-checks` runner pass.)
- Comment the current test matrix as introduced by Multicore OCaml, and discuss whether or not these addition to `ocaml/ocaml` are worthwhile.

This PR itself is a bit lengthy, a lost of meaning was lost in the history tree, and it ended up being squashed.

I think the better way to review it would be to compare this tree to the `4.14` equivalent. @dra27 may be interested by this PR.

### Cleanup and refactor

This PR introduces a few simplification:

- Removal of the `super` testsuite run: I have never been convinced of the usefulness of this run and the code added to `runner.sh` specifically to support this usecase is quite ugly.
Historically, this run was introduced to run multiple time the `parallel` testsuite and catch possibly intermittent failures, in practice I do not think this is valuable as if such failures exists they will be catched eventually in another run on either CI system.
- `TestLoop` was simplified to `TestPrefix` in `runner.sh`. `TestLoop` is not needed in its current form since `super` is gone. `TestPrefix` also opts to run tests in parallel (to follow suit with `Test`).
- `build.yml` has now four main jobs:
    - normal: does a full testsuite run, builds the doc, attempts to `make install`, runs `other-checks`, check for changes in the manual.
    - others:
        - `macos`: Compile OCaml and run the full testsuite on MacOS
        - `linux-O0`: Compile OCaml with `CFLAGS='-O0'` and run a selection of test directories.
    - extra:
        - `debug`: Does a full run of the testsuite in with the debug runtime.
        - `debug-s4096`: Runs a selection of test directories with the debug runtime and a minor heap of 4096 words.
    - build: t the `normal`, `debug`,  `debug-s4096` "jobs" all share the same compiler build.
    This build is compiled during the initial `build` job. The freshly built directory is then uploaded as a build artifact to be reused by the aforementioned steps.

To be noted: the `macos` and `linux-O0` sub-jobs cannot reuse the compiler built during the `build` job, because they either run on a different OS, or rely specific on different `configure` parameters when building the OCaml distribution.

### Bring back the features lost after the merge

The `normal` job is a mirror copy of what the GHA runs do on the 4.14 branch.
One major difference from previous Multicore runs: as for `4.X`, the "main" testsuite run is now a full flambda run.
The same applies for every subsequent jobs reusing the compiler artifact built during the `build` job.
One omission from this, is that I did not reimport the `i386-static` run in the workflow: is it something desireable?

### Discussions

The current draft is an attempt at merging what used to be done in trunk before the merge and the various tweaks introduced by the Multicore team.
The both `debug` runs proved to be especially useful to the team when developping the Multicore runtime.
We tried to strike a nice balance in running time by only running a few select directories (that historically proved useful for us to insist on.) when adequate.

I think the removal of the `super` job (which aimed to re-run select directories three times without further adjustements) is fine and spare us from burning more CPU cycles.

Two runs I think are worth discussing about:
- `taskset-c0` (which was left out of this PR) was used to catch some synchronization issues within the Multicore runtime. It does not involve a full build of the compiler (as it can reuse the cached build of the `normal` testsuite run.), but proves to be problematic in some instances. `parallel/pingpong.ml` is for instance *very* *very* slow in this run.
(which, looking at the testcase makes sense to me). Do we want to bring it back?
- `linux-O0` (which was left in this PR) caught a few times some issues in the Multicore runtime, catching some problems when optimizations were removed. I could not trace back such scenarios. It involves a full, separate compiler build, as well as running some parts of the testsuite (a full run would be prohibitively slow.)

One more thing worth pondering upon, the Github Actions runner does not use `OCAML_TEST_SIZE` to provide hints to the runners on the number of cores available: Should this be added as well?