### PR TITLE
Stop calling ranlib on created / installed libraries

### DIFF
--- a/Changes
+++ b/Changes
@@ -195,6 +195,9 @@ Working version
   (Sébastien Hinderer, review by David Allsopp, Florian Angeletti and
   Xavier Leroy)
 
+- #11184: Stop calling ranlib on created / installed libraries
+  (Sébastien Hinderer, review by Xavier Leroy)
+
 ### Internal/compiler-libs changes:
 
 - #10878, #10909: restore flambda after the Multicore merge.

--- a/INSTALL.adoc
+++ b/INSTALL.adoc
@@ -43,8 +43,8 @@
 * Under Cygwin, the `gcc-core` package is required. `flexdll` is also necessary
   for shared library support.
 
-* Binutils including `ar`, `ranlib`, and `strip` are required if your
-  distribution does not already provide them with the C compiler.
+* Binutils including `ar` and `strip` are required if your distribution
+  does not already provide them with the C compiler.
 
 == Configuration
 

--- a/Makefile
+++ b/Makefile
@@ -583,8 +583,6 @@ endif
 ifeq "$(INSTALL_OCAMLNAT)" "true"
 	  $(INSTALL_PROG) ocamlnat$(EXE) "$(INSTALL_BINDIR)"
 endif
-	cd "$(INSTALL_COMPLIBDIR)" && \
-	   $(RANLIB) ocamlcommon.$(A) ocamlbytecomp.$(A) ocamloptcomp.$(A)
 
 # Installation of the *.ml sources of compiler-libs
 .PHONY: install-compiler-sources

--- a/Makefile.build_config.in
+++ b/Makefile.build_config.in
@@ -20,7 +20,7 @@
 # $(ROOTDIR) has been defined.
 
 include $(ROOTDIR)/Makefile.config
-INSTALL ?= @INSTALL@
+INSTALL ?= @INSTALL@ -p
 INSTALL_DATA ?= @INSTALL_DATA@
 INSTALL_PROG ?= @INSTALL_PROGRAM@
 

--- a/Makefile.config.in
+++ b/Makefile.config.in
@@ -88,10 +88,6 @@ LDFLAGS?=@LDFLAGS@
 ### How to invoke the C preprocessor through the C compiler
 CPP=@CPP@
 
-### How to invoke ranlib
-RANLIB=@RANLIB@
-RANLIBCMD=@RANLIBCMD@
-
 ### How to invoke ar
 ARCMD=@AR@
 

--- a/configure
+++ b/configure
@@ -713,6 +713,7 @@ NMEDIT
 DSYMUTIL
 MANIFEST_TOOL
 AWK
+RANLIB
 STRIP
 ac_ct_AR
 DLLTOOL
@@ -795,8 +796,6 @@ natdynlinkopts
 natdynlink
 supports_shared_libraries
 mklib
-RANLIBCMD
-RANLIB
 AR
 shebangscripts
 long_shebang
@@ -2872,8 +2871,6 @@ OCAML_VERSION_SHORT=5.0
 # Note: This is present for the flexdll bootstrap where it exposed as the old
 # TOOLPREF variable. It would be better if flexdll where updated to require
 # WINDRES instead.
-
-
 
 
 
@@ -12525,27 +12522,17 @@ else
 fi ;;
 esac
 
-# Extracting information from libtool's configuration
-if test -n "$RANLIB" ; then :
-  RANLIBCMD="$RANLIB"
-else
-  RANLIB="$AR rs"; RANLIBCMD=""
-
-fi
-
 case $host in #(
   # In config/Makefile.mingw*, we had:
   # TARGET=i686-w64-mingw32 and x86_64-w64-mingw32
   # TOOLPREF=$(TARGET)-
   # ARCMD=$(TOOLPREF)ar
-  # RANLIB=$(TOOLPREF)ranlib
-  # RANLIBCMD=$(TOOLPREF)ranlib
-  # However autoconf and libtool seem to use ar and ranlib
+  # However autoconf and libtool seem to use ar
   # So we let them do, at the moment
   *-pc-windows) :
 
       libext=lib
-      AR=""; RANLIB=echo; RANLIBCMD=""
+      AR=""
       if test "$host_cpu" = "x86_64" ; then :
   machine="-machine:AMD64 "
 else
@@ -12555,7 +12542,7 @@ fi
      ;; #(
   *) :
 
-    mklib="rm -f \$(1) && ${AR} rc \$(1) \$(2) && ${RANLIB} \$(1)"
+    mklib="rm -f \$(1) && ${AR} rc \$(1) \$(2)"
    ;;
 esac
 

--- a/configure.ac
+++ b/configure.ac
@@ -120,8 +120,6 @@ AC_SUBST([bootstrapping_flexdll])
 AC_SUBST([long_shebang])
 AC_SUBST([shebangscripts])
 AC_SUBST([AR])
-AC_SUBST([RANLIB])
-AC_SUBST([RANLIBCMD])
 AC_SUBST([mklib])
 AC_SUBST([supports_shared_libraries])
 AC_SUBST([natdynlink])
@@ -472,32 +470,24 @@ AS_CASE([$enable_dependency_generation],
       [compute_deps=true])],
     [compute_deps=false])])
 
-# Extracting information from libtool's configuration
-AS_IF([test -n "$RANLIB" ],
-  [RANLIBCMD="$RANLIB"],
-  [RANLIB="$AR rs"; RANLIBCMD=""]
-)
-
 AS_CASE([$host],
   # In config/Makefile.mingw*, we had:
   # TARGET=i686-w64-mingw32 and x86_64-w64-mingw32
   # TOOLPREF=$(TARGET)-
   # ARCMD=$(TOOLPREF)ar
-  # RANLIB=$(TOOLPREF)ranlib
-  # RANLIBCMD=$(TOOLPREF)ranlib
-  # However autoconf and libtool seem to use ar and ranlib
+  # However autoconf and libtool seem to use ar
   # So we let them do, at the moment
   [*-pc-windows],
     [
       libext=lib
-      AR=""; RANLIB=echo; RANLIBCMD=""
+      AR=""
       AS_IF([test "$host_cpu" = "x86_64" ],
         [machine="-machine:AMD64 "],
         [machine=""])
       mklib="link -lib -nologo $machine /out:\$(1) \$(2)"
     ],
   [
-    mklib="rm -f \$(1) && ${AR} rc \$(1) \$(2) && ${RANLIB} \$(1)"
+    mklib="rm -f \$(1) && ${AR} rc \$(1) \$(2)"
   ])
 
 ## Find vendor of the C compiler

--- a/otherlibs/Makefile.otherlibs.common
+++ b/otherlibs/Makefile.otherlibs.common
@@ -95,7 +95,6 @@ install::
 	fi
 ifneq "$(STUBSLIB)" ""
 	$(INSTALL_DATA) $(STUBSLIB) "$(INSTALL_LIBDIR)/"
-	cd "$(INSTALL_LIBDIR)"; $(RANLIB) lib$(CLIBNAME).$(A)
 endif
 
 	$(INSTALL_DATA) \
@@ -115,7 +114,6 @@ installopt:
 	$(INSTALL_DATA) \
 	   $(CAMLOBJS_NAT) $(LIBNAME).cmxa $(LIBNAME).$(A) \
 	   "$(INSTALL_LIBDIR)/"
-	cd "$(INSTALL_LIBDIR)"; $(RANLIB) $(LIBNAME).a
 	if test -f $(LIBNAME).cmxs; then \
 	  $(INSTALL_PROG) $(LIBNAME).cmxs "$(INSTALL_LIBDIR)"; \
 	fi

--- a/otherlibs/dynlink/Makefile
+++ b/otherlibs/dynlink/Makefile
@@ -249,12 +249,11 @@ ifeq "$(INSTALL_SOURCE_ARTIFACTS)" "true"
 endif
 
 installopt:
-	if $(NATDYNLINK); then \
-	  $(INSTALL_DATA) \
-	    $(NATOBJS) dynlink.cmxa dynlink.$(A) \
-	    "$(INSTALL_LIBDIR)" && \
-	  cd "$(INSTALL_LIBDIR)" && $(RANLIB) dynlink.$(A); \
-	fi
+ifeq "$(strip $(NATDYNLINK))" "true"
+	$(INSTALL_DATA) \
+	  $(NATOBJS) dynlink.cmxa dynlink.$(A) \
+	  "$(INSTALL_LIBDIR)"
+endif
 
 partialclean:
 	rm -f $(extract_crc) *.cm[ioaxt] *.cmti *.cmxa \

--- a/otherlibs/systhreads/Makefile
+++ b/otherlibs/systhreads/Makefile
@@ -124,7 +124,6 @@ install:
 	  $(INSTALL_PROG) dllthreads$(EXT_DLL) "$(INSTALL_STUBLIBDIR)"; \
 	fi
 	$(INSTALL_DATA) libthreads.$(A) "$(INSTALL_LIBDIR)"
-	cd "$(INSTALL_LIBDIR)"; $(RANLIB) libthreads.$(A)
 	mkdir -p "$(INSTALL_THREADSLIBDIR)"
 	$(INSTALL_DATA) \
 	  $(CMIFILES) threads.cma \
@@ -139,11 +138,9 @@ endif
 
 installopt:
 	$(INSTALL_DATA) libthreadsnat.$(A) "$(INSTALL_LIBDIR)"
-	cd "$(INSTALL_LIBDIR)"; $(RANLIB) libthreadsnat.$(A)
 	$(INSTALL_DATA) \
 	  $(THREADS_NCOBJS) threads.cmxa threads.$(A) \
 	  "$(INSTALL_THREADSLIBDIR)"
-	cd "$(INSTALL_THREADSLIBDIR)" && $(RANLIB) threads.$(A)
 
 %.cmi: %.mli
 	$(CAMLC) -c $(COMPFLAGS) $<

--- a/stdlib/Makefile
+++ b/stdlib/Makefile
@@ -107,7 +107,6 @@ installopt-default::
 	$(INSTALL_DATA) \
 	  stdlib.cmxa stdlib.$(A) std_exit.$(O) *.cmx \
 	  "$(INSTALL_LIBDIR)"
-	cd "$(INSTALL_LIBDIR)"; $(RANLIB) stdlib.$(A)
 
 ifeq "$(UNIX_OR_WIN32)" "unix"
 HEADERPROGRAM = header

--- a/tools/ocamlmklib.ml
+++ b/tools/ocamlmklib.ml
@@ -25,10 +25,8 @@ let mklib out files opts =
     then "-machine:AMD64 "
     else ""
   in
-  Printf.sprintf "link -lib -nologo %s-out:%s %s %s"
-                 machine out opts files
-  else Printf.sprintf "%s rcs %s %s %s && %s %s"
-                      Config.ar out opts files Config.ranlib out
+  Printf.sprintf "link -lib -nologo %s-out:%s %s %s" machine out opts files
+  else Printf.sprintf "%s rc %s %s %s" Config.ar out opts files
 
 (* PR#4783: under Windows, don't use absolute paths because we do
    not know where the binary distribution will be installed. *)

--- a/utils/Makefile
+++ b/utils/Makefile
@@ -73,7 +73,6 @@ config.ml: config.mlp $(ROOTDIR)/Makefile.config Makefile
 	    $(call SUBST_STRING,OCAMLOPT_CPPFLAGS) \
 	    $(call SUBST_STRING,PACKLD) \
 	    $(call SUBST,PROFINFO_WIDTH) \
-	    $(call SUBST_STRING,RANLIBCMD) \
 	    $(call SUBST_STRING,RPATH) \
 	    $(call SUBST_STRING,MKSHAREDLIBRPATH) \
 	    $(call SUBST,WINDOWS_UNICODE) \

--- a/utils/ccomp.ml
+++ b/utils/ccomp.ml
@@ -140,12 +140,8 @@ let create_archive archive file_list =
                                quoted_archive (quote_files file_list))
     | _ ->
         assert(String.length Config.ar > 0);
-        let r1 =
-          command(Printf.sprintf "%s rc %s %s"
-                  Config.ar quoted_archive (quote_files file_list)) in
-        if r1 <> 0 || String.length Config.ranlib = 0
-        then r1
-        else command(Config.ranlib ^ " " ^ quoted_archive)
+        command(Printf.sprintf "%s rc %s %s"
+                Config.ar quoted_archive (quote_files file_list))
 
 let expand_libname cclibs =
   cclibs |> List.map (fun cclib ->

--- a/utils/config.mli
+++ b/utils/config.mli
@@ -82,9 +82,6 @@ val mkexe: string
 val mkmaindll: string
 (** The linker command line to build main programs as dlls. *)
 
-val ranlib: string
-(** Command to randomize a library, or "" if not needed *)
-
 val default_rpath: string
 (** Option to add a directory to be searched for libraries at runtime
     (used by ocamlmklib) *)

--- a/utils/config.mlp
+++ b/utils/config.mlp
@@ -54,7 +54,6 @@ let native_c_compiler =
   c_compiler ^ " " ^ ocamlopt_cflags ^ " " ^ ocamlopt_cppflags
 let native_c_libraries = "%%NATIVECCLIBS%%"
 let native_pack_linker = "%%PACKLD%%"
-let ranlib = "%%RANLIBCMD%%"
 let default_rpath = "%%RPATH%%"
 let mksharedlibrpath = "%%MKSHAREDLIBRPATH%%"
 let ar = "%%ARCMD%%"
@@ -178,7 +177,6 @@ let configuration_variables =
   p "bytecomp_c_libraries" bytecomp_c_libraries;
   p "native_c_libraries" native_c_libraries;
   p "native_pack_linker" native_pack_linker;
-  p "ranlib" ranlib;
   p "architecture" architecture;
   p "model" model;
   p_int "int_size" Sys.int_size;


### PR DESCRIPTION
This PR is a follow-up to the discussion started in https://github.com/ocaml/ocaml/pull/11172#issuecomment-1092641466

It removes the calls to ranlib, both when libraries are installed and when they are created by ocamlmklib.

To make sure the timestamps of installed libraries match those of the object files they contain, we call the `install` program with the `-p` flag to preserve the timestamps when installing a file. This flag seems to be widely supported.