### PR TITLE
Prohibit using classes through recursive modules (fixes #6491)

### DIFF
--- a/Changes
+++ b/Changes
@@ -27,6 +27,13 @@ Working version
 - #11764: add prototypes to old-style C function definitions and declarations
   (Antonin Décimo, review by Xavier Leroy)
 
+### Type system:
+
+- #6941, #11187: prohibit using classes through recursive modules
+  inheriting or including a class belonging to a mutually-recursive module
+  would previous behave incorrectly, and now results in a clean error.
+  (Leo White, review by Gabriel Scherer and Florian Angeletti)
+
 ### Code generation and optimizations:
 
 - #8998, #11321, #11430: change mangling of OCaml long identifiers

--- a/testsuite/tests/typing-recmod/pr6491.ml
+++ b/testsuite/tests/typing-recmod/pr6491.ml
@@ -1,0 +1,32 @@
+(* TEST
+   * expect
+*)
+
+module rec Foo : sig class type c = object method x : int end end = Foo
+and Bar : sig class type c = object inherit Foo.c end end = Bar
+and Baz : sig class type c = object inherit Bar.c end end = Baz;;
+[%%expect {|
+module rec Foo : sig class type c = object method x : int end end
+and Bar : sig class type c = object method x : int end end
+and Baz : sig class type c = object  end end
+|}]
+
+module rec Foo : sig class type c = object method x : int end end = Foo
+and Bar : sig class type c = Foo.c end = Bar
+and Baz : sig class type c = Bar.c end = Baz
+
+let foo (x : Foo.c) = x#x
+let bar (x : Bar.c) = x#x
+let baz (x : Baz.c) = x#x;;
+[%%expect{|
+module rec Foo : sig class type c = object method x : int end end
+and Bar : sig class type c = Foo.c end
+and Baz : sig class type c = Bar.c end
+val foo : Foo.c -> int = <fun>
+val bar : Bar.c -> int = <fun>
+Line 7, characters 22-23:
+7 | let baz (x : Baz.c) = x#x;;
+                          ^
+Error: This expression has type Baz.c
+       It has no method x
+|}]

--- a/testsuite/tests/typing-recmod/pr6491.ml
+++ b/testsuite/tests/typing-recmod/pr6491.ml
@@ -6,9 +6,10 @@ module rec Foo : sig class type c = object method x : int end end = Foo
 and Bar : sig class type c = object inherit Foo.c end end = Bar
 and Baz : sig class type c = object inherit Bar.c end end = Baz;;
 [%%expect {|
-module rec Foo : sig class type c = object method x : int end end
-and Bar : sig class type c = object method x : int end end
-and Baz : sig class type c = object  end end
+Line 2, characters 44-49:
+2 | and Bar : sig class type c = object inherit Foo.c end end = Bar
+                                                ^^^^^
+Error: Illegal recursive module reference
 |}]
 
 module rec Foo : sig class type c = object method x : int end end = Foo
@@ -19,14 +20,8 @@ let foo (x : Foo.c) = x#x
 let bar (x : Bar.c) = x#x
 let baz (x : Baz.c) = x#x;;
 [%%expect{|
-module rec Foo : sig class type c = object method x : int end end
-and Bar : sig class type c = Foo.c end
-and Baz : sig class type c = Bar.c end
-val foo : Foo.c -> int = <fun>
-val bar : Bar.c -> int = <fun>
-Line 7, characters 22-23:
-7 | let baz (x : Baz.c) = x#x;;
-                          ^
-Error: This expression has type Baz.c
-       It has no method x
+Line 2, characters 29-34:
+2 | and Bar : sig class type c = Foo.c end = Bar
+                                 ^^^^^
+Error: Illegal recursive module reference
 |}]


### PR DESCRIPTION
Prohibits using classes through recursive modules because it doesn't work. From the tests:
```ocaml
module rec Foo : sig class type c = object method x : int end end = Foo
and Bar : sig class type c = object inherit Foo.c end end = Bar
and Baz : sig class type c = object inherit Bar.c end end = Baz;;
[%%expect {|
module rec Foo : sig class type c = object method x : int end end
and Bar : sig class type c = object method x : int end end
and Baz : sig class type c = object  end end
|}]
```
becomes:
```ocaml
module rec Foo : sig class type c = object method x : int end end = Foo
and Bar : sig class type c = object inherit Foo.c end end = Bar
and Baz : sig class type c = object inherit Bar.c end end = Baz;;
[%%expect {|
Line 2, characters 44-49:
2 | and Bar : sig class type c = object inherit Foo.c end end = Bar
                                                ^^^^^
Error: Illegal recursive module reference
|}]
```