### PR TITLE
Fix composition of coercions with aliases

### DIFF
--- a/Changes
+++ b/Changes
@@ -381,6 +381,9 @@ OCaml 5.0
   socket and deadlock the parent.
   (Antonin Décimo, review by Xavier Leroy)
 
+- #11186, #11188: Fix composition of coercions with aliases
+  (Vincent Laviron, report and review by Leo White)
+
 - #11204: Fix regression introduced in 4.14.0 that would trigger Warning 17 when
   calling virtual methods introduced by constraining the self type from within
   the class definition.

--- a/testsuite/tests/basic-modules/pr11186.ml
+++ b/testsuite/tests/basic-modules/pr11186.ml
@@ -1,0 +1,18 @@
+(* TEST *)
+
+module M =
+  (((struct
+       module N = struct let s = "Hello" end
+       module A = N
+       module B = A
+       module C = B
+     end : sig
+       module A : sig val s : string end
+       module B = A
+       module C = B
+     end) : sig
+      module B : sig val s : string end
+      module C = B
+    end) : sig
+     module C : sig val s : string end
+   end)


### PR DESCRIPTION
Fixes #11186.

The patch introduces two changes:
- In `Translmod.compose_coercions`, when the source of the outer coercion `c1` (say, `M`) contains a module alias that needs to be concretised in the destination of `c1` (say, `Dst`), it will contain in its list of ids a negative position and a coercion that allows to compute the actual module from the alias. But then, the inner coercion `c2` does not have a runtime component for this module (since it is still an alias in `M`, which is the destination of `c2`), so we must not look it up in the `pc2`/`v2` structure. Instead, it is guaranteed to be defined in the source of `c2` (say, `Src`) as the same alias as in `M`, so we can just keep the same position and coercion.
- In `wrap_id_pos_list`, after the above patch we can now get into situations where the module allocation depends on some of the identifiers from `id_pos_list` indirectly: in the example from #11186 the allocation of `M` has access to the identifiers for `N`, `A` and `B`. It only needs one of them (`B`), but when adding the binding for `B` its definition needs `A`, and `A` itself needs `N`. I'm relying on the fact that the `id_pos_list` bindings are ordered (from the outermost coercion to the innermost coercion), so we always see the binding for any given ident after processing all the bindings that might depend on it. Given that, the only change is to augment the set of free variables along the way.
