### PR TITLE
runtime: scan all native roots

### DIFF
--- a/runtime/dynlink_nat.c
+++ b/runtime/dynlink_nat.c
@@ -31,6 +31,8 @@
 
 #include "caml/hooks.h"
 
+intnat caml_globals_inited = 0;
+
 CAMLexport void (*caml_natdynlink_hook)(void* handle, const char* unit) = NULL;
 
 #include <stdio.h>

--- a/runtime/globroots.c
+++ b/runtime/globroots.c
@@ -196,7 +196,7 @@ static void scan_native_globals(scanning_action f, void* fdata)
   caml_plat_unlock(&roots_mutex);
 
   /* The global roots */
-  for (i = 0; i <= caml_globals_inited && caml_globals[i] != 0; i++) {
+  for (i = 0; caml_globals[i] != 0; i++) {
     for(glob = caml_globals[i]; *glob != 0; glob++) {
       for (j = 0; j < Wosize_val(*glob); j++){
         f(fdata, Field(*glob, j), &Field(*glob, j));

--- a/runtime/roots.c
+++ b/runtime/roots.c
@@ -29,19 +29,6 @@
 #include "caml/shared_heap.h"
 #include "caml/fiber.h"
 
-#ifdef NATIVE_CODE
-#include "caml/stack.h"
-/* Communication with [caml_start_program] and [caml_call_gc]. */
-
-/* The global roots.
-   FIXME: These should be promoted, and not scanned here.
-   FIXME: caml_globals_inited makes assumptions about store ordering.
-   XXX KC : What to do here?
-*/
-
-intnat caml_globals_inited = 0;
-#endif
-
 CAMLexport _Atomic scan_roots_hook caml_scan_roots_hook =
   (scan_roots_hook)NULL;
 


### PR DESCRIPTION
This  PR removes a FIXME in `runtime/roots.c` by scanning all native global roots without relying on the global mutable state
`caml_globals_inited`. (This global mutable state counts the number of compilation units that have run their initialization code.)

This PR also remove the (2016) comments referring to the old  state of the code and move the definition of the `caml_globals_inited` global to its last user `dynlink_nat.c`.