### PR TITLE
Implement quality treatment for asynchronous actions in multicore (2/N)

### DIFF
--- a/Changes
+++ b/Changes
@@ -85,6 +85,11 @@ Working version
   types, is now required to build the OCaml runtime system.
   (Xavier Leroy, review by David Allsopp and Sébastien Hinderer)
 
+- #10915, #11039, #11057, #11095, #11190: Implement quality treatment for
+  asynchronous actions in multicore. Reimplement the old behaviour of
+  `caml_process_pending*` for multicore.
+  (Guillaume Munch-Maccagnoni, review by Sadiq Jaffer and Gabriel Scherer)
+
 ### Code generation and optimizations:
 
 - #10972: ARM64 multicore support: OCaml & C stack separation;

--- a/runtime/array.c
+++ b/runtime/array.c
@@ -68,7 +68,7 @@ CAMLprim value caml_floatarray_get(value array, value index)
   if (idx < 0 || idx >= Wosize_val(array) / Double_wosize)
     caml_array_bound_error();
   d = Double_flat_field(array, idx);
-  Alloc_small(res, Double_wosize, Double_tag, { caml_handle_gc_interrupt(); });
+  Alloc_small(res, Double_wosize, Double_tag, Alloc_small_enter_GC);
   Store_double_val(res, d);
   return res;
 }
@@ -127,8 +127,7 @@ CAMLprim value caml_floatarray_unsafe_get(value array, value index)
 
   CAMLassert (Tag_val(array) == Double_array_tag);
   d = Double_flat_field(array, idx);
-  Alloc_small(res, Double_wosize, Double_tag,
-              { caml_handle_gc_interrupt(); });
+  Alloc_small(res, Double_wosize, Double_tag, Alloc_small_enter_GC);
   Store_double_val(res, d);
   return res;
 }
@@ -188,8 +187,7 @@ CAMLprim value caml_floatarray_create(value len)
     if (wosize == 0)
       return Atom(0);
     else
-      Alloc_small (result, wosize, Double_array_tag,
-                   { caml_handle_gc_interrupt(); });
+      Alloc_small (result, wosize, Double_array_tag, Alloc_small_enter_GC);
   }else if (wosize > Max_wosize)
     caml_invalid_argument("Float.Array.create");
   else {

--- a/runtime/caml/alloc.h
+++ b/runtime/caml/alloc.h
@@ -25,8 +25,7 @@ extern "C" {
 #endif
 
 /* It is guaranteed that these allocation functions will not trigger
-   any OCaml callback such as finalizers or signal handlers.
-   FIXME: Not implemented in OCaml 5.0. */
+   any OCaml callback such as finalizers or signal handlers. */
 
 CAMLextern value caml_alloc (mlsize_t, tag_t);
 CAMLextern value caml_alloc_N(mlsize_t, tag_t, ...);

--- a/runtime/caml/domain.h
+++ b/runtime/caml/domain.h
@@ -62,6 +62,7 @@ void caml_update_minor_heap_max(uintnat minor_heap_wsz);
 /* is there a STW interrupt queued that needs servicing */
 int caml_incoming_interrupts_queued(void);
 
+void caml_poll_gc_work(void);
 void caml_handle_gc_interrupt(void);
 void caml_handle_incoming_interrupts(void);
 

--- a/runtime/caml/domain.h
+++ b/runtime/caml/domain.h
@@ -41,8 +41,7 @@ extern "C" {
 Caml_inline int caml_check_gc_interrupt(caml_domain_state * dom_st)
 {
   CAMLalloc_point_here;
-  uintnat young_limit =
-    atomic_load_explicit(&dom_st->young_limit, memory_order_relaxed);
+  uintnat young_limit = atomic_load_relaxed(&dom_st->young_limit);
   if ((uintnat)dom_st->young_ptr < young_limit) {
     /* Synchronise for the case when [young_limit] was used to interrupt
        us. */

--- a/runtime/caml/domain_state.tbl
+++ b/runtime/caml/domain_state.tbl
@@ -34,6 +34,10 @@ DOMAIN_STATE(struct stack_info*, current_stack)
 DOMAIN_STATE(void*, exn_handler)
 /* Pointer into the current stack */
 
+DOMAIN_STATE(int, action_pending)
+/* Whether we are due to start the processing of delayable pending
+   actions. See runtime/signal.c. */
+
 DOMAIN_STATE(struct c_stack_link*, c_stack)
 /* The C stack associated with this domain.
  * Used by this domain to perform external calls. */

--- a/runtime/caml/memory.h
+++ b/runtime/caml/memory.h
@@ -27,6 +27,7 @@
 #include "domain.h"
 #include "misc.h"
 #include "mlvalues.h"
+#include "signals.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -195,17 +196,32 @@ Caml_inline void DEBUG_clear(value result, mlsize_t wosize) {
 #define DEBUG_clear(result, wosize)
 #endif
 
+enum caml_alloc_small_flags {
+  CAML_DONT_TRACK = 0, CAML_DO_TRACK = 1, // call memprof
+  CAML_FROM_C = 0,     CAML_FROM_CAML = 2 // call async callbacks
+};
+
+#define Alloc_small_enter_GC_flags(flags, dom_st, wosize) do {          \
+    (dom_st)->young_ptr += Whsize_wosize(wosize);                       \
+    if ((flags) & CAML_FROM_CAML)                                       \
+      caml_process_pending_actions();                                   \
+    else                                                                \
+      caml_handle_gc_interrupt();                                       \
+    (dom_st)->young_ptr -= Whsize_wosize(wosize);                       \
+  } while (0)
+
+// Do not call asynchronous callbacks from allocation functions
+#define Alloc_small_enter_GC(dom_st, wosize)    \
+  Alloc_small_enter_GC_flags(CAML_DO_TRACK | CAML_FROM_C, dom_st, wosize)
+
 #define Alloc_small_with_profinfo(result, wosize, tag, GC, profinfo) do{    \
-  caml_domain_state* dom_st;                                                \
                                                 CAMLassert ((wosize) >= 1); \
                                           CAMLassert ((tag_t) (tag) < 256); \
                                  CAMLassert ((wosize) <= Max_young_wosize); \
-  dom_st = Caml_state;                                                      \
+  caml_domain_state* dom_st = Caml_state;                                   \
   dom_st->young_ptr -=  Whsize_wosize(wosize);                              \
   while (Caml_check_gc_interrupt(dom_st)) {                                 \
-    dom_st->young_ptr += Whsize_wosize(wosize);                             \
-    { GC }                                                                  \
-    dom_st->young_ptr -= Whsize_wosize(wosize);                             \
+    GC(dom_st, wosize);                                                     \
   }                                                                         \
   Hd_hp (dom_st->young_ptr) =                                               \
     Make_header_with_profinfo ((wosize), (tag), 0, profinfo);               \

--- a/runtime/caml/minor_gc.h
+++ b/runtime/caml/minor_gc.h
@@ -68,7 +68,9 @@ extern void caml_empty_minor_heap_no_major_slice_from_stw
     caml_domain_state** participating); /* in STW */
 extern int caml_try_stw_empty_minor_heap_on_all_domains(void); /* out STW */
 extern void caml_empty_minor_heaps_once(void); /* out STW */
-CAMLextern void garbage_collection (void); /* def in asmrun/signals.c */
+void caml_alloc_small_dispatch (caml_domain_state* domain,
+                                intnat wosize, int flags,
+                                int nallocs, unsigned char* encoded_alloc_lens);
 header_t caml_get_header_val(value v);
 void caml_alloc_table (struct caml_ref_table *tbl, asize_t sz, asize_t rsv);
 extern void caml_realloc_ref_table (struct caml_ref_table *);

--- a/runtime/caml/platform.h
+++ b/runtime/caml/platform.h
@@ -48,12 +48,24 @@ Caml_inline void cpu_relax() {
 
 /* Loads and stores with acquire and release semantics respectively */
 
-Caml_inline uintnat atomic_load_acq(atomic_uintnat* p) {
+Caml_inline uintnat atomic_load_acq(atomic_uintnat* p)
+{
   return atomic_load_explicit(p, memory_order_acquire);
 }
 
-Caml_inline void atomic_store_rel(atomic_uintnat* p, uintnat v) {
+Caml_inline uintnat atomic_load_relaxed(atomic_uintnat* p)
+{
+  return atomic_load_explicit(p, memory_order_relaxed);
+}
+
+Caml_inline void atomic_store_rel(atomic_uintnat* p, uintnat v)
+{
   atomic_store_explicit(p, v, memory_order_release);
+}
+
+Caml_inline void atomic_store_relaxed(atomic_uintnat* p, uintnat v)
+{
+  atomic_store_explicit(p, v, memory_order_relaxed);
 }
 
 /* Spin-wait loops */

--- a/runtime/caml/signals.h
+++ b/runtime/caml/signals.h
@@ -69,6 +69,7 @@ value caml_execute_signal_exn(int signal_number, int in_signal_handler);
 CAMLextern void caml_record_signal(int signal_number);
 CAMLextern value caml_process_pending_signals_exn(void);
 void caml_set_action_pending (void);
+value caml_do_pending_actions_exn(void);
 value caml_process_pending_actions_with_root (value extra_root); // raises
 value caml_process_pending_actions_with_root_exn (value extra_root);
 

--- a/runtime/caml/signals.h
+++ b/runtime/caml/signals.h
@@ -33,17 +33,17 @@ CAMLextern void caml_leave_blocking_section (void);
 
 CAMLextern void caml_process_pending_actions (void);
 /* Checks for pending actions and executes them. This includes pending
-   minor and major collections, signal handlers, finalisers, and
-   Memprof callbacks. Assumes that the runtime lock is held. Can raise
-   exceptions asynchronously into OCaml code. */
+   minor and major collections, thread switching, signal handlers,
+   finalisers, and Memprof callbacks. Assumes that the runtime lock is
+   held. Can raise exceptions asynchronously into OCaml code. */
+
+CAMLextern value caml_process_pending_actions_exn (void);
+/* Same as [caml_process_pending_actions], but returns the encoded
+   exception (if any) instead of raising it directly (otherwise
+   returns [Val_unit]). */
 
 CAMLextern int caml_check_pending_actions (void);
 /* Returns 1 if there are pending actions, 0 otherwise. */
-
-// FIXME: Not implemented in OCaml 5.0.
-//CAMLextern value caml_process_pending_actions_exn (void);
-/* Same as [caml_process_pending_actions], but returns the exception
-   if any (otherwise returns [Val_unit]). */
 
 #ifdef CAML_INTERNALS
 
@@ -68,7 +68,7 @@ CAMLextern int caml_rev_convert_signal_number (int);
 value caml_execute_signal_exn(int signal_number, int in_signal_handler);
 CAMLextern void caml_record_signal(int signal_number);
 CAMLextern value caml_process_pending_signals_exn(void);
-void caml_set_action_pending (void);
+void caml_set_action_pending(caml_domain_state *);
 value caml_do_pending_actions_exn(void);
 value caml_process_pending_actions_with_root (value extra_root); // raises
 value caml_process_pending_actions_with_root_exn (value extra_root);

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -1233,7 +1233,6 @@ static void decrement_stw_domains_still_processing(void)
   }
 }
 
-static void caml_poll_gc_work(void);
 static void stw_handler(caml_domain_state* domain)
 {
   CAML_EV_BEGIN(EV_STW_HANDLER);
@@ -1481,7 +1480,7 @@ void caml_reset_young_limit(caml_domain_state * dom_st)
   }
 }
 
-static void caml_poll_gc_work(void)
+void caml_poll_gc_work(void)
 {
   CAMLalloc_point_here;
 

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -1474,7 +1474,8 @@ void caml_reset_young_limit(caml_domain_state * dom_st)
       || dom_st->requested_minor_gc
       || dom_st->requested_major_slice
       || atomic_load_explicit(&dom_st->requested_external_interrupt,
-                              memory_order_relaxed)) {
+                              memory_order_relaxed)
+      || caml_check_pending_signals()) {
     atomic_store_rel(&dom_st->young_limit, (uintnat)-1);
     CAMLassert(caml_check_gc_interrupt(dom_st));
   }

--- a/runtime/finalise.c
+++ b/runtime/finalise.c
@@ -74,6 +74,7 @@ static void generic_final_update
       - k : index in to_do_tl, next available slot.
   */
   if (todo_count > 0) {
+    caml_set_action_pending(d);
     alloc_todo (d, todo_count);
     j = k = 0;
     for (i = 0; i < final->old; i++){
@@ -252,6 +253,7 @@ static void generic_final_minor_update
       - k : index in to_do_tl, next available slot.
   */
   if (todo_count > 0) {
+    caml_set_action_pending(d);
     alloc_todo (d, todo_count);
     k = 0;
     j = final->old;

--- a/runtime/floats.c
+++ b/runtime/floats.c
@@ -153,7 +153,7 @@ CAMLexport value caml_copy_double(double d)
 {
   value res;
 
-  Alloc_small(res, Double_wosize, Double_tag, { caml_handle_gc_interrupt(); });
+  Alloc_small(res, Double_wosize, Double_tag, Alloc_small_enter_GC);
   Store_double_val(res, d);
   return res;
 }

--- a/runtime/gc_ctrl.c
+++ b/runtime/gc_ctrl.c
@@ -243,7 +243,7 @@ static value gc_major_exn(void)
   caml_gc_log ("Major GC cycle requested");
   caml_empty_minor_heaps_once();
   caml_finish_major_cycle();
-  exn = caml_final_do_calls_exn();
+  exn = caml_process_pending_actions_exn();
   CAML_EV_END(EV_EXPLICIT_GC_MAJOR);
   return exn;
 }
@@ -265,7 +265,7 @@ static value gc_full_major_exn(void)
   for (i = 0; i < 3; i++) {
     caml_empty_minor_heaps_once();
     caml_finish_major_cycle();
-    exn = caml_final_do_calls_exn ();
+    exn = caml_process_pending_actions_exn ();
     if (Is_exception_result(exn)) break;
   }
   ++ Caml_state->stat_forced_major_collections;

--- a/runtime/gc_ctrl.c
+++ b/runtime/gc_ctrl.c
@@ -232,18 +232,18 @@ CAMLprim value caml_gc_minor(value v)
   CAML_EV_BEGIN(EV_EXPLICIT_GC_MINOR);
   CAMLassert (v == Val_unit);
   caml_minor_collection ();
+  value exn = caml_process_pending_actions_exn();
   CAML_EV_END(EV_EXPLICIT_GC_MINOR);
-  return Val_unit;
+  return caml_raise_if_exception(exn);
 }
 
 static value gc_major_exn(void)
 {
-  value exn = Val_unit;
   CAML_EV_BEGIN(EV_EXPLICIT_GC_MAJOR);
   caml_gc_log ("Major GC cycle requested");
   caml_empty_minor_heaps_once();
   caml_finish_major_cycle();
-  exn = caml_process_pending_actions_exn();
+  value exn = caml_process_pending_actions_exn();
   CAML_EV_END(EV_EXPLICIT_GC_MAJOR);
   return exn;
 }
@@ -265,7 +265,7 @@ static value gc_full_major_exn(void)
   for (i = 0; i < 3; i++) {
     caml_empty_minor_heaps_once();
     caml_finish_major_cycle();
-    exn = caml_process_pending_actions_exn ();
+    exn = caml_process_pending_actions_exn();
     if (Is_exception_result(exn)) break;
   }
   ++ Caml_state->stat_forced_major_collections;
@@ -284,8 +284,9 @@ CAMLprim value caml_gc_major_slice (value v)
   CAML_EV_BEGIN(EV_EXPLICIT_GC_MAJOR_SLICE);
   CAMLassert (Is_long (v));
   caml_major_collection_slice(Long_val(v));
+  value exn = caml_process_pending_actions_exn();
   CAML_EV_END(EV_EXPLICIT_GC_MAJOR_SLICE);
-  return Val_long (0);
+  return caml_raise_if_exception(exn);
 }
 
 CAMLprim value caml_gc_compaction(value v)

--- a/runtime/interp.c
+++ b/runtime/interp.c
@@ -77,10 +77,12 @@ sp is a local copy of the global variable Caml_state->extern_sp. */
 #define Restore_after_gc \
   { sp = domain_state->current_stack->sp; accu = sp[0]; env = sp[1]; sp += 3; }
 /* Do call asynchronous callbacks from allocation functions */
-#define Enter_gc \
-  { Setup_for_gc; \
-    caml_process_pending_actions();         \
-    Restore_after_gc; }
+#define Enter_gc(dom_st, wosize) do {                            \
+    Setup_for_gc;                                                \
+    Alloc_small_enter_GC_flags(CAML_DO_TRACK | CAML_FROM_CAML,   \
+                               dom_st, wosize);                  \
+    Restore_after_gc;                                            \
+  } while (0)
 
 /* We store [pc+1] in the stack so that, in case of an exception, the
    first backtrace slot points to the event following the C call

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -687,10 +687,9 @@ static void mark_slice_darken(struct mark_stack* stk, value v, mlsize_t i,
                   goto again;
           }
         } else {
-          atomic_store_explicit(
+          atomic_store_relaxed(
             Hp_atomic_val(child),
-            With_status_hd(chd, caml_global_heap_state.MARKED),
-            memory_order_relaxed);
+            With_status_hd(chd, caml_global_heap_state.MARKED));
         }
         if(Tag_hd(chd) < No_scan_tag){
           mark_stack_push(stk, child, 0, work);
@@ -748,8 +747,7 @@ void caml_darken_cont(value cont)
   CAMLassert(Is_block(cont) && !Is_young(cont) && Tag_val(cont) == Cont_tag);
   {
     SPIN_WAIT {
-      header_t hd
-            = atomic_load_explicit(Hp_atomic_val(cont), memory_order_relaxed);
+      header_t hd = atomic_load_relaxed(Hp_atomic_val(cont));
       CAMLassert(!Has_status_hd(hd, caml_global_heap_state.GARBAGE));
       if (Has_status_hd(hd, caml_global_heap_state.MARKED))
         break;
@@ -786,10 +784,9 @@ void caml_darken(void* state, value v, value* ignored) {
     if (Tag_hd(hd) == Cont_tag) {
       caml_darken_cont(v);
     } else {
-      atomic_store_explicit(
+      atomic_store_relaxed(
          Hp_atomic_val(v),
-         With_status_hd(hd, caml_global_heap_state.MARKED),
-         memory_order_relaxed);
+         With_status_hd(hd, caml_global_heap_state.MARKED));
       if (Tag_hd(hd) < No_scan_tag) {
         mark_stack_push(Caml_state->mark_stack, v, 0, NULL);
       }

--- a/runtime/memprof.c
+++ b/runtime/memprof.c
@@ -568,7 +568,7 @@ static void check_action_pending(void)
 {
   if (local->suspended) return;
   if (callback_idx < entries_global.len || local->entries.len > 0)
-    caml_set_action_pending();
+    caml_set_action_pending(Caml_state);
 }
 
 void caml_memprof_set_suspended(int s)

--- a/runtime/minor_gc.c
+++ b/runtime/minor_gc.c
@@ -803,7 +803,6 @@ void caml_alloc_small_dispatch (caml_domain_state * dom_st,
          asynchronous callbacks. */
       caml_raise_if_exception(caml_do_pending_actions_exn());
     else {
-      // FIXME: do not call finalisers
       caml_handle_gc_interrupt();
       /* In the case of long-running C code that regularly polls with
          [caml_process_pending_actions], still force a query of all

--- a/runtime/minor_gc.c
+++ b/runtime/minor_gc.c
@@ -206,7 +206,7 @@ static int try_update_object_header(value v, value *p, value result,
         /* Success. Now we can write the forwarding pointer. */
         atomic_store_explicit(Op_atomic_val(v), result, memory_order_relaxed);
         /* And update header ('release' ensures after update of fwd pointer) */
-        atomic_store_explicit(Hp_atomic_val(v), 0, memory_order_release);
+        atomic_store_rel(Hp_atomic_val(v), 0);
         /* Let the caller know we were responsible for the update */
         success = 1;
       } else {

--- a/runtime/minor_gc.c
+++ b/runtime/minor_gc.c
@@ -783,6 +783,68 @@ void caml_empty_minor_heaps_once (void)
   } while (saved_minor_cycle == atomic_load(&caml_minor_cycles_started));
 }
 
+/* Called by minor allocations when [Caml_state->young_ptr] reaches
+   [Caml_state->young_limit]. We may have to either call memprof or
+   the gc. */
+void caml_alloc_small_dispatch (caml_domain_state * dom_st,
+                                intnat wosize, int flags,
+                                int nallocs, unsigned char* encoded_alloc_lens)
+{
+  intnat whsize = Whsize_wosize(wosize);
+
+  /* First, we un-do the allocation performed in [Alloc_small] */
+  dom_st->young_ptr += whsize;
+
+  while(1) {
+    /* We might be here because of an async callback / urgent GC
+       request. Take the opportunity to do what has been requested. */
+    if (flags & CAML_FROM_CAML)
+      /* In the case of allocations performed from OCaml, execute
+         asynchronous callbacks. */
+      caml_raise_if_exception(caml_do_pending_actions_exn());
+    else {
+      // FIXME: do not call finalisers
+      caml_handle_gc_interrupt();
+      /* In the case of long-running C code that regularly polls with
+         caml_process_pending_actions, force a query of all callbacks
+         at every minor collection or major slice. */
+      // FIXME
+      //caml_something_to_do = 1;
+    }
+
+    /* Now, there might be enough room in the minor heap to do our
+       allocation. */
+    if (dom_st->young_ptr - whsize >= dom_st->young_start)
+      break;
+
+    /* If not, then empty the minor heap, and check again for async
+       callbacks. */
+    CAML_EV_COUNTER(EV_C_FORCE_MINOR_ALLOC_SMALL, 1);
+    caml_poll_gc_work();
+  }
+
+  /* Re-do the allocation: we now have enough space in the minor heap. */
+  dom_st->young_ptr -= whsize;
+
+#if 0
+  /* Check if the allocated block has been sampled by memprof. */
+  if (dom_st->young_ptr < caml_memprof_young_trigger) {
+    if(flags & CAML_DO_TRACK) {
+      caml_memprof_track_young(wosize, flags & CAML_FROM_CAML,
+                               nallocs, encoded_alloc_lens);
+      /* Until the allocation actually takes place, the heap is in an invalid
+         state (see comments in [caml_memprof_track_young]). Hence, very little
+         heap operations are allowed before the actual allocation.
+
+         Moreover, [Caml_state->young_ptr] should not be modified before the
+         allocation, because its value has been used as the pointer to
+         the sampled block.
+      */
+    } else caml_memprof_renew_minor_sample();
+  }
+#endif
+}
+
 /* Request a minor collection and enter as if it were an interrupt.
 */
 CAMLexport void caml_minor_collection (void)

--- a/runtime/minor_gc.c
+++ b/runtime/minor_gc.c
@@ -806,10 +806,9 @@ void caml_alloc_small_dispatch (caml_domain_state * dom_st,
       // FIXME: do not call finalisers
       caml_handle_gc_interrupt();
       /* In the case of long-running C code that regularly polls with
-         caml_process_pending_actions, force a query of all callbacks
-         at every minor collection or major slice. */
-      // FIXME
-      //caml_something_to_do = 1;
+         [caml_process_pending_actions], still force a query of all
+         callbacks at every minor collection or major slice. */
+      dom_st->action_pending = 1;
     }
 
     /* Now, there might be enough room in the minor heap to do our

--- a/runtime/shared_heap.c
+++ b/runtime/shared_heap.c
@@ -209,8 +209,7 @@ static void calc_pool_stats(pool* a, sizeclass sz, struct heap_stats* s) {
   s->pool_frag_words += Wsize_bsize(POOL_HEADER_SZ);
 
   while (p + wh <= end) {
-    header_t hd = (header_t)atomic_load_explicit((atomic_uintnat*)p,
-                                                  memory_order_relaxed);
+    header_t hd = (header_t)atomic_load_relaxed((atomic_uintnat*)p);
     if (hd) {
       s->pool_live_words += Whsize_hd(hd);
       s->pool_frag_words += wh - Whsize_hd(hd);
@@ -457,8 +456,7 @@ static intnat pool_sweep(struct caml_heap_state* local, pool** plist,
     struct heap_stats* s = &local->stats;
 
     while (p + wh <= end) {
-      header_t hd = (header_t)atomic_load_explicit((atomic_uintnat*)p,
-                                                    memory_order_relaxed);
+      header_t hd = (header_t)atomic_load_relaxed((atomic_uintnat*)p);
       if (hd == 0) {
         /* already on freelist */
         all_used = 0;
@@ -469,7 +467,7 @@ static intnat pool_sweep(struct caml_heap_state* local, pool** plist,
           if (final_fun != NULL) final_fun(Val_hp(p));
         }
         /* add to freelist */
-        atomic_store_explicit((atomic_uintnat*)p, 0, memory_order_relaxed);
+        atomic_store_relaxed((atomic_uintnat*)p, 0);
         p[1] = (value)a->next_obj;
         CAMLassert(Is_block((value)p));
 #ifdef DEBUG

--- a/runtime/signals.c
+++ b/runtime/signals.c
@@ -231,20 +231,25 @@ CAMLexport int caml_check_pending_actions(void)
           caml_check_pending_signals());
 }
 
-CAMLexport void caml_process_pending_actions(void)
+value caml_do_pending_actions_exn(void)
 {
   caml_handle_gc_interrupt();
-  caml_raise_if_exception(caml_process_pending_signals_exn());
+  return caml_process_pending_signals_exn();
 }
 
 value caml_process_pending_actions_with_root(value root)
 {
   if (caml_check_pending_actions()) {
     CAMLparam1(root);
-    caml_process_pending_actions();
+    caml_raise_if_exception(caml_do_pending_actions_exn());
     CAMLdrop;
   }
   return root;
+}
+
+CAMLexport void caml_process_pending_actions(void)
+{
+  caml_process_pending_actions_with_root(Val_unit);
 }
 
 value caml_process_pending_actions_with_root_exn(value root)

--- a/runtime/signals.c
+++ b/runtime/signals.c
@@ -227,8 +227,7 @@ void caml_request_minor_gc (void)
 
 CAMLexport int caml_check_pending_actions(void)
 {
-  return (Caml_check_gc_interrupt(Caml_state) ||
-          caml_check_pending_signals());
+  return Caml_check_gc_interrupt(Caml_state);
 }
 
 value caml_do_pending_actions_exn(void)

--- a/runtime/signals.c
+++ b/runtime/signals.c
@@ -104,12 +104,11 @@ CAMLexport value caml_process_pending_signals_exn(void)
 
 /* Record the delivery of a signal, and arrange for it to be processed
    as soon as possible:
-   - via the pending signal bitvector, processed in
-     caml_process_pending_signals_exn.
+   - via Caml_state->action_pending, processed in
+     caml_process_pending_actions.
    - by playing with the allocation limit, processed in
-     caml_garbage_collection
+     caml_alloc_small_dispatch.
 */
-
 CAMLexport void caml_record_signal(int signal_number)
 {
   unsigned int i;
@@ -117,6 +116,7 @@ CAMLexport void caml_record_signal(int signal_number)
   i = signal_number - 1;
   atomic_fetch_or(&caml_pending_signals[i / BITS_PER_WORD],
                   (uintnat)1 << (i % BITS_PER_WORD));
+  // FIXME: the TLS variable is not thread-safe
   caml_interrupt_self();
 }
 
@@ -147,6 +147,9 @@ CAMLexport void caml_enter_blocking_section(void)
     caml_enter_blocking_section_hook ();
     /* Check again for pending signals.
        If none, done; otherwise, try again */
+    // FIXME: does this become very slow if a signal is recorded but
+    // is masked for everybody in capacity of running signals at this
+    // point?
     if (!caml_check_pending_signals()) break;
     caml_leave_blocking_section_hook ();
   }
@@ -163,6 +166,22 @@ CAMLexport void caml_leave_blocking_section(void)
   /* Save the value of errno (PR#5982). */
   saved_errno = errno;
   caml_leave_blocking_section_hook ();
+
+  /* Some other thread may have switched [Caml_state->action_pending]
+     to 0 even though there are still pending actions, e.g. a signal
+     masked in the other thread.
+
+     Another case where this is necessary (even in a single threaded
+     setting) is when the blocking section unmasks a pending signal:
+     If the signal is pending and masked but signals have already been
+     examined by [caml_process_pending_actions], then
+     [Caml_state->action_pending] is 0 but the signal needs to be
+     handled at this point.
+
+     So we force the examination of signals as soon as possible.
+  */
+  if (Caml_state->action_pending || caml_check_pending_signals())
+    caml_set_action_pending();
 
   errno = saved_errno;
 }
@@ -223,15 +242,87 @@ void caml_request_minor_gc (void)
   caml_interrupt_self();
 }
 
+
+/* Pending asynchronous actions ([Caml_state->action_pending])
+   ===
+
+   There are two kinds of asynchronous actions:
+
+   - Those that cannot be delayed but never call OCaml code (STW
+     interrupts, requested minor or major GC, forced systhread yield).
+
+   - Those that may raise OCaml exceptions but can be delayed
+     (asynchronous callbacks, finalisers, memprof callbacks).
+
+   [Caml_state->action_pending] records whether an action of the
+   second kind is currently pending, and is reset _at the beginning_
+   of processing all actions.
+
+   Hence, when a delayable action is pending, either
+   [Caml_state->action_pending] is 1, or there is a function currently
+   running which is executing all actions.
+
+   This is used to ensure [Caml_state->young_limit] is always set
+   appropriately.
+
+   In case there are two different callbacks (say, a signal and a
+   finaliser) arriving at the same time, then the processing of one
+   awaits the return of the other. In case of long-running callbacks,
+   we may want to run the second one without waiting the end of the
+   first one. We do this by provoking an additional polling every
+   minor collection and every major slice. To guarantee a low latency
+   for signals, we avoid delaying signal handlers in that case by
+   calling them first.
+*/
+
+CAMLno_tsan /* When called from [caml_record_signal], these memory
+               accesses may not be synchronized. */
+void caml_set_action_pending(void)
+{
+  Caml_state->action_pending = 1;
+  caml_interrupt_self();
+}
+
 CAMLexport int caml_check_pending_actions(void)
 {
-  return Caml_check_gc_interrupt(Caml_state);
+  return Caml_check_gc_interrupt(Caml_state) || Caml_state->action_pending;
 }
 
 value caml_do_pending_actions_exn(void)
 {
+  Caml_state->action_pending = 0;
+
+  /* 1. Non-delayable actions that do not run OCaml code. */
+
+  /* Do any pending STW interrupt, minor collection or major slice */
   caml_handle_gc_interrupt();
-  return caml_process_pending_signals_exn();
+  /* [young_limit] has now been reset. */
+
+  /* 2. Delayable actions that may raise OCaml exceptions. */
+
+  /* Call signal handlers first */
+  value exn = caml_process_pending_signals_exn();
+  if (Is_exception_result(exn)) goto exception;
+
+#if 0
+  /* Call memprof callbacks */
+  exn = caml_memprof_handle_postponed_exn();
+  if (Is_exception_result(exn)) goto exception;
+#endif
+
+  /* Call finalisers */
+  exn = caml_final_do_calls_exn();
+  if (Is_exception_result(exn)) goto exception;
+
+  return Val_unit;
+
+exception:
+  /* If an exception is raised during an asynchronous callback, then
+     it might be the case that we did not run all the callbacks we
+     needed. Therefore, we set [Caml_state->action_pending] again in
+     order to force reexamination of callbacks. */
+  caml_set_action_pending();
+  return exn;
 }
 
 value caml_process_pending_actions_with_root(value root)

--- a/runtime/signals.c
+++ b/runtime/signals.c
@@ -46,7 +46,7 @@ int caml_check_pending_signals(void)
 {
   int i;
   for (i = 0; i < NSIG_WORDS; i++) {
-    if (atomic_load_explicit(&caml_pending_signals[i], memory_order_relaxed))
+    if (atomic_load_relaxed(&caml_pending_signals[i]))
       return 1;
   }
   return 0;
@@ -73,8 +73,7 @@ CAMLexport value caml_process_pending_signals_exn(void)
 #endif
 
   for (i = 0; i < NSIG_WORDS; i++) {
-    curr = atomic_load_explicit(&caml_pending_signals[i],
-                                memory_order_relaxed);
+    curr = atomic_load_relaxed(&caml_pending_signals[i]);
     if (curr == 0) goto next_word;
     /* Scan curr for bits set */
     for (j = 0; j < BITS_PER_WORD; j++) {
@@ -94,8 +93,7 @@ CAMLexport value caml_process_pending_signals_exn(void)
       if (Is_exception_result(exn)) return exn;
       /* curr probably changed during the evaluation of the signal handler;
          refresh it from memory */
-      curr = atomic_load_explicit(&caml_pending_signals[i],
-                                  memory_order_relaxed);
+      curr = atomic_load_relaxed(&caml_pending_signals[i]);
       if (curr == 0) goto next_word;
     next_bit: /* skip */;
     }

--- a/runtime/signals_nat.c
+++ b/runtime/signals_nat.c
@@ -42,17 +42,13 @@
 void caml_garbage_collection(void)
 {
   frame_descr* d;
-  intnat allocsz = 0;
-  char *sp;
-  uintnat retaddr;
-  intnat whsize;
-
+  caml_domain_state * dom_st = Caml_state;
   caml_frame_descrs fds = caml_get_frame_descrs();
-  struct stack_info* stack = Caml_state->current_stack;
+  struct stack_info* stack = dom_st->current_stack;
 
-  sp = (char*)stack->sp;
+  char * sp = (char*)stack->sp;
   Pop_frame_pointer(sp);
-  retaddr = *(uintnat*)sp;
+  uintnat retaddr = *(uintnat*)sp;
 
   /* Synchronise for the case when [young_limit] was used to interrupt
      us. */
@@ -73,6 +69,7 @@ void caml_garbage_collection(void)
        including allocations combined by Comballoc */
     unsigned char* alloc_len = (unsigned char*)(&d->live_ofs[d->num_live]);
     int i, nallocs = *alloc_len++;
+    intnat allocsz = 0;
 
     if (nallocs == 0) {
       /* This is a poll */
@@ -89,24 +86,7 @@ void caml_garbage_collection(void)
       allocsz -= 1;
     }
 
-    whsize = Whsize_wosize(allocsz);
-
-    /* Put the young pointer back to what is was before our triggering
-       allocation */
-    Caml_state->young_ptr += whsize;
-
-    /* When caml_garbage_collection returns, we assume there is enough space in
-      the minor heap for the triggering allocation. Due to finalisers in the
-      major heap, it is possible for there to be a sequence of events where a
-      single call to caml_handle_gc_interrupt does not lead to that. We do it
-      in a loop to ensure it. */
-    do {
-      caml_process_pending_actions();
-    } while
-       ( (uintnat)(Caml_state->young_ptr - whsize) <=
-         atomic_load_explicit(&Caml_state->young_limit, memory_order_acquire) );
-
-    /* Re-do the allocation: we now have enough space in the minor heap. */
-    Caml_state->young_ptr -= whsize;
+    caml_alloc_small_dispatch(dom_st, allocsz, CAML_DO_TRACK | CAML_FROM_CAML,
+                              nallocs, alloc_len);
   }
 }

--- a/testsuite/tests/callback/test_signalhandler_.c
+++ b/testsuite/tests/callback/test_signalhandler_.c
@@ -15,11 +15,11 @@
 
 #include <signal.h>
 
+#define CAML_INTERNALS
+
 #include "caml/mlvalues.h"
 #include "caml/memory.h"
 #include "caml/callback.h"
-
-#define CAML_INTERNALS
 #include "caml/signals.h"
 
 value mycallback1(value fun, value arg)

--- a/yacc/closure.c
+++ b/yacc/closure.c
@@ -164,7 +164,7 @@ void closure(short int *nucleus, int n)
     {
         word = *rsp;
         if (word == 0)
-            ruleno += BITS_PER_WORD;
+            ruleno += BITS_PER_INT;
         else
         {
             mask = 1;

--- a/yacc/defs.h
+++ b/yacc/defs.h
@@ -42,7 +42,7 @@
 /*  MAXSHORT is the largest value of a C short                 */
 /*  MINSHORT is the most negative value of a C short           */
 /*  MAXTABLE is the maximum table size                         */
-/*  BITS_PER_WORD is the number of bits in a C unsigned        */
+/*  BITS_PER_INT is the number of bits in a C unsigned         */
 /*  WORDSIZE computes the number of words needed to            */
 /*        store n bits                                         */
 /*  BIT returns the value of the n-th bit starting             */
@@ -54,10 +54,10 @@
 #define MINSHORT        SHRT_MIN
 #define MAXTABLE        32500
 
-#define BITS_PER_WORD        (8*sizeof(unsigned))
-#define        WORDSIZE(n)        (((n)+(BITS_PER_WORD-1))/BITS_PER_WORD)
-#define        BIT(r, n)        ((((r)[(n)/BITS_PER_WORD])>>((n)%BITS_PER_WORD))&1)
-#define        SETBIT(r, n)        ((r)[(n)/BITS_PER_WORD]|=(1<<((n)%BITS_PER_WORD)))
+#define BITS_PER_INT    (8*sizeof(unsigned))
+#define WORDSIZE(n)     (((n)+(BITS_PER_INT-1))/BITS_PER_INT)
+#define BIT(r, n)       ((((r)[(n)/BITS_PER_INT])>>((n)%BITS_PER_INT))&1)
+#define SETBIT(r, n)    ((r)[(n)/BITS_PER_INT]|=(1<<((n)%BITS_PER_INT)))
 
 /*  character names  */
 


### PR DESCRIPTION
This PR is another part of #11057 and comes after #11095.

This restores the polling behaviour in C code of OCaml 4 by delaying finalisers until the next suitable safe point.

This also removes races whereby signals can be forgotten.

Reviewing is a bit more involved than going commit-per-commit, see https://github.com/ocaml/ocaml/pull/11095#issuecomment-1095154311. In particular, some FIXME comments are added about existing bugs, and not fixed in this PR but later ones.

cc @sadiqj, @gasche. (I think @stedolan, @jhjourdan can also be interested.)