### PR TITLE
Better documentation for condition variables.

### DIFF
--- a/Changes
+++ b/Changes
@@ -128,6 +128,9 @@ Working version
 - #8878: Add String.hash and String.seeded_hash.
   (Tom Kelly, review by Alain Frisch and Nicolás Ojeda Bär)
 
+- #11192: Better documentation for condition variables.
+  (François Pottier, review by Luc Maranget, Xavier Leroy, and Wiktor Kuchta)
+
 ### Other libraries:
 
 * #9071, #9100, #10935: Reimplement `Thread.exit()` as raising the

--- a/Changes
+++ b/Changes
@@ -128,9 +128,6 @@ Working version
 - #8878: Add String.hash and String.seeded_hash.
   (Tom Kelly, review by Alain Frisch and Nicolás Ojeda Bär)
 
-- #11192: Better documentation for condition variables.
-  (François Pottier, review by Luc Maranget, Xavier Leroy, and Wiktor Kuchta)
-
 ### Other libraries:
 
 * #9071, #9100, #10935: Reimplement `Thread.exit()` as raising the
@@ -179,6 +176,9 @@ Working version
 - #11093: Add an effect handlers tutorial
   (KC Sivaramakrishnan, review by François Pottier, Gabriel Scherer, François
   Bobot and Wiktor Kuchta)
+
+- #11192: Better documentation for condition variables.
+  (François Pottier, review by Luc Maranget, Xavier Leroy, and Wiktor Kuchta)
 
 ### Compiler user-interface and warnings:
 

--- a/stdlib/condition.mli
+++ b/stdlib/condition.mli
@@ -43,11 +43,11 @@
    condition variable is used for this purpose.
 
    In short, a condition variable [c] is used to convey the information
-   that a certain property [P] about a shared data structure [D],
+   that a certain property {i P} about a shared data structure {i D},
    protected by a mutex [m], may be true.
 
    Condition variables provide an efficient alternative to busy-waiting.
-   When one wishes to wait for the property [P] to be true,
+   When one wishes to wait for the property {i P} to be true,
    instead of writing a busy-waiting loop:
    {[
      Mutex.lock m;
@@ -81,24 +81,24 @@
    used to indicate that the queue is nonempty, and another condition
    variable is used to indicate that the queue is not full.
 
-   With a condition variable [c], exactly one logical property [P]
+   With a condition variable [c], exactly one logical property {i P}
    should be associated. Examples of such properties
    include "the queue is nonempty" and "the queue is not full".
    It is up to the programmer to keep track, for each condition
-   variable, of the corresponding property [P].
+   variable, of the corresponding property {i P}.
    A signal is sent on the condition variable [c]
-   as an indication that the property [P] is true, or may be true.
+   as an indication that the property {i P} is true, or may be true.
    On the receiving end, however, a thread that is woken up
-   cannot assume that [P] is true;
+   cannot assume that {i P} is true;
    after a call to {!wait} terminates,
-   one must explicitly test whether [P] is true.
+   one must explicitly test whether {i P} is true.
    There are several reasons why this is so.
    One reason is that,
    between the moment when the signal is sent
    and the moment when a waiting thread receives the signal
    and is scheduled,
-   the property [P] may be falsified by some other thread
-   that is able to acquire the mutex [m] and alter the data structure [D].
+   the property {i P} may be falsified by some other thread
+   that is able to acquire the mutex [m] and alter the data structure {i D}.
    Another reason is that {i spurious wakeups} may occur:
    a waiting thread can be woken up even if no signal was sent.
 
@@ -145,7 +145,7 @@ type t
 val create : unit -> t
 (**[create()] creates and returns a new condition variable.
    This condition variable should be associated (in the programmer's mind)
-   with a certain mutex [m] and with a certain property [P] of the data
+   with a certain mutex [m] and with a certain property {i P} of the data
    structure that is protected by the mutex [m]. *)
 
 val wait : t -> Mutex.t -> unit
@@ -156,9 +156,9 @@ val wait : t -> Mutex.t -> unit
    later be woken up after the condition variable [c] has been signaled
    via {!signal} or {!broadcast}; however, it can also be woken up for
    no reason. The mutex [m] is locked again before [wait] returns. One
-   cannot assume that the property [P] associated with the condition
+   cannot assume that the property {i P} associated with the condition
    variable [c] holds when [wait] returns; one must explicitly test
-   whether [P] holds after calling [wait]. *)
+   whether {i P} holds after calling [wait]. *)
 
 val signal : t -> unit
 (**[signal c] wakes up one of the threads waiting on the condition

--- a/stdlib/condition.mli
+++ b/stdlib/condition.mli
@@ -57,12 +57,15 @@
    only when the property [P] is definitely true.
    When a signal is received, however, one cannot assume that [P] is
    definitely true; one must explicitly test whether [P] is true.
-   The reason is that,
+   There are several reasons why this is so.
+   One reason is that,
    between the moment when the signal is sent
    and the moment when a waiting thread receives the signal
    and is scheduled,
    the property [P] may be falsified by some other thread
    that is able to acquire the mutex [m] and alter the data structure [D].
+   Another reason is that {i spurious wakeups} may occur:
+   a waiting thread can be woken up even if no signal was sent.
 
    Assuming that [D] is a shared data structure
    protected by the mutex [m],

--- a/stdlib/condition.mli
+++ b/stdlib/condition.mli
@@ -123,7 +123,7 @@
      let take q =
        Mutex.lock q.mutex;
        while Queue.is_empty q.queue do Condition.wait q.nonempty q.mutex done;
-       let v = Queue.take q.queue in (* cannot fail because queue is nonempty *)
+       let v = Queue.take q.queue in (* cannot fail since queue is nonempty *)
        Mutex.unlock q.mutex;
        v
    ]}


### PR DESCRIPTION
The specification has been made more precise:
- exactly one mutex per condition variable;
- [signal] and [broadcast] can be called only when the mutex is locked.
Furthermore, a longer high-level explanation of condition variables
has been added.