### PR TITLE
Fix: Inconsistent type vars in "unbound type var" message

### DIFF
--- a/Changes
+++ b/Changes
@@ -239,6 +239,9 @@ Working version
 
 ### Bug fixes:
 
+- #11194: Fix inconsitent type-vars names in "unbound type var" messages
+  (Ulysse Gérard, ?)
+
 - #11167: Fix memory leak from signal stack.
   (Antoni Żewierżejew, review by Gabriel Scherer and Enguerrand Decorne)
 

--- a/testsuite/tests/typing-unbound-type-var/unbound-type-var.ml
+++ b/testsuite/tests/typing-unbound-type-var/unbound-type-var.ml
@@ -15,5 +15,5 @@ Lines 1-4, characters 0-3:
 4 | end
 Error: Some type variables are unbound in this type:
          class test : 'a -> 'b -> object method b : 'b end
-       The method b has type 'a where 'a is unbound
+       The method b has type 'b where 'b is unbound
 |}]

--- a/testsuite/tests/typing-unbound-type-var/unbound-type-var.ml
+++ b/testsuite/tests/typing-unbound-type-var/unbound-type-var.ml
@@ -1,0 +1,19 @@
+(* TEST
+   * expect
+*)
+
+class test a c =
+object
+  method b = c
+end
+
+[%%expect{|
+Lines 1-4, characters 0-3:
+1 | class test a c =
+2 | object
+3 |   method b = c
+4 | end
+Error: Some type variables are unbound in this type:
+         class test : 'a -> 'b -> object method b : 'b end
+       The method b has type 'a where 'a is unbound
+|}]

--- a/typing/typeclass.ml
+++ b/typing/typeclass.ml
@@ -2057,11 +2057,12 @@ let report_error env ppf = function
       Includeclass.report_error Type ppf error
   | Unbound_val lab ->
       fprintf ppf "Unbound instance variable %s" lab
-  | Unbound_type_var (printer, reason) ->
-      let print_reason ppf (ty0, real, lab, ty) =
-        let ty1 =
-          if real then ty0 else Btype.newgenty(Tobject(ty0, ref None)) in
-        Printtyp.prepare_for_printing [ty; ty1];
+  | Unbound_type_var (printer, (ty0, real, lab, ty)) ->
+      let ty1 =
+        if real then ty0 else Btype.newgenty(Tobject(ty0, ref None))
+      in
+      Printtyp.prepare_for_printing [ty; ty1];
+      let print_reason ppf (ty0, lab, ty) =
         fprintf ppf
           "The method %s@ has type@;<1 2>%a@ where@ %a@ is unbound"
           lab
@@ -2071,7 +2072,7 @@ let report_error env ppf = function
       fprintf ppf
         "@[<v>@[Some type variables are unbound in this type:@;<1 2>%t@]@ \
               @[%a@]@]"
-       printer print_reason reason
+       printer print_reason (ty0, lab, ty)
   | Non_generalizable_class (id, clty) ->
       fprintf ppf
         "@[The type of this class,@ %a,@ \


### PR DESCRIPTION
When upgrading Merlin for 4.14 our test-suite catched the following issue:

```ocaml
class test a c =
object
  method b = c
end

[%%expect{|
Lines 1-4, characters 0-3:
1 | class test a c =
2 | object
3 |   method b = c
4 | end
Error: Some type variables are unbound in this type:
         class test : 'a -> 'b -> object method b : 'b end
       The method b has type 'a where 'a is unbound
|}]
```

In this example the printed type for `method b` is inconsistent.
This is due to an extraneous reset of the printer introduced in #10488

This PR add a test illustrating the issue and a fix proposition.
