### PR TITLE
Simplify Domain.join

### DIFF
--- a/stdlib/.depend
+++ b/stdlib/.depend
@@ -213,6 +213,7 @@ stdlib__Domain.cmo : domain.ml \
     stdlib__Obj.cmi \
     stdlib__Mutex.cmi \
     stdlib__List.cmi \
+    stdlib__Condition.cmi \
     stdlib__Atomic.cmi \
     stdlib__Array.cmi \
     stdlib__Domain.cmi
@@ -222,6 +223,7 @@ stdlib__Domain.cmx : domain.ml \
     stdlib__Obj.cmx \
     stdlib__Mutex.cmx \
     stdlib__List.cmx \
+    stdlib__Condition.cmx \
     stdlib__Atomic.cmx \
     stdlib__Array.cmx \
     stdlib__Domain.cmi

--- a/stdlib/domain.ml
+++ b/stdlib/domain.ml
@@ -19,7 +19,7 @@
 module Raw = struct
   (* Low-level primitives provided by the runtime *)
   type t = private int
-  external spawn : (unit -> unit) -> Mutex.t -> t
+  external spawn : (unit -> unit) -> t
     = "caml_domain_spawn"
   external self : unit -> t
     = "caml_ml_domain_id"
@@ -33,15 +33,14 @@ type id = Raw.t
 
 type 'a state =
 | Running
-| Joining of ('a, exn) result option ref
 | Finished of ('a, exn) result
-| Joined
 
 type 'a t = {
   domain : Raw.t;
-  termination_mutex: Mutex.t;
-  state: 'a state Atomic.t }
-
+  term_mutex: Mutex.t;
+  term_condition: Condition.t;
+  term_state: 'a state ref (* protected by [term_mutex] *)
+}
 
 module DLS = struct
 
@@ -178,22 +177,16 @@ let rec at_startup f =
   else
     at_startup f
 
-(* Spawn and join functionality *)
-exception Retry
-let rec spin f =
-  try f () with Retry ->
-      cpu_relax ();
-      spin f
-
-let cas r vold vnew =
-  if not (Atomic.compare_and_set r vold vnew) then raise Retry
-
 let spawn f =
   do_at_first_spawn ();
   let pk = DLS.get_initial_keys () in
-  (* the termination_mutex is used to block a joining thread *)
-  let termination_mutex = Mutex.create () in
-  let state = Atomic.make Running in
+
+  (* The [term_mutex] and [term_condition] are used to
+     synchronize with the joining domains *)
+  let term_mutex = Mutex.create () in
+  let term_condition = Condition.create () in
+  let term_state = ref Running in
+
   let at_startup = Atomic.get startup_function in
   let body () =
     let result =
@@ -207,45 +200,35 @@ let spawn f =
       | exception ex -> Error ex
     in
     do_at_exit ();
-    spin (fun () ->
-      match Atomic.get state with
-      | Running ->
-         cas state Running (Finished result)
-      | Joining x as old ->
-         cas state old Joined;
-         x := Some result
-      | Joined | Finished _ ->
-         failwith "internal error: I'm already finished?")
-  in
-  { domain = Raw.spawn body termination_mutex; termination_mutex; state }
 
-let termination_wait termination_mutex =
-  (* Raw.spawn returns with the mutex locked, so this will block if the
-     domain has not terminated yet *)
-  Mutex.lock termination_mutex;
-  Mutex.unlock termination_mutex
-
-let join { termination_mutex; state; _ } =
-  let res = spin (fun () ->
-    match Atomic.get state with
-    | Running -> begin
-      let x = ref None in
-      cas state Running (Joining x);
-      termination_wait termination_mutex;
-      match !x with
-      | None ->
-          failwith "internal error: termination signaled but result not passed"
-      | Some r -> r
-    end
-    | Finished x as old ->
-      cas state old Joined;
-      termination_wait termination_mutex;
-      x
-    | Joining _ | Joined ->
-      raise (Invalid_argument "This domain has already been joined")
-    )
+    (* Synchronize with joining domains *)
+    Mutex.lock term_mutex;
+    match !term_state with
+    | Running ->
+        term_state := Finished result;
+        Condition.broadcast term_condition;
+        Mutex.unlock term_mutex
+    | Finished _ ->
+        Mutex.unlock term_mutex;
+        failwith "internal error: Am I already finished?"
   in
-  match res with
+  { domain = Raw.spawn body;
+    term_mutex;
+    term_condition;
+    term_state }
+
+let join { term_mutex; term_condition; term_state; _ } =
+  Mutex.lock term_mutex;
+  let rec loop () =
+    match !term_state with
+    | Running ->
+        Condition.wait term_condition term_mutex;
+        loop ()
+    | Finished res ->
+        Mutex.unlock term_mutex;
+        res
+  in
+  match loop () with
   | Ok x -> x
   | Error ex -> raise ex
 

--- a/stdlib/domain.mli
+++ b/stdlib/domain.mli
@@ -25,12 +25,9 @@ val spawn : (unit -> 'a) -> 'a t
     current domain. *)
 
 val join : 'a t -> 'a
-(** [join d] blocks until domain [d] runs to completion.
-    If [d] results in a value, then that is returned by [join d].
-    If [d] raises an uncaught exception, then that is re-raised by [join d].
-
-    @raise Invalid_argument if the domain was already joined.
-    Domains may only be joined once. *)
+(** [join d] blocks until domain [d] runs to completion. If [d] results in a
+    value, then that is returned by [join d]. If [d] raises an uncaught
+    exception, then that is re-raised by [join d]. *)
 
 type id = private int
 (** Domains have unique integer identifiers *)

--- a/testsuite/tests/parallel/join.ml
+++ b/testsuite/tests/parallel/join.ml
@@ -29,30 +29,35 @@ let rec other_join flags n domain =
   else
     Domain.join domain
 
+let join2 () =
+  let r = ref false in
+  let t = Domain.spawn (fun () -> r := true; true) in
+  assert (Domain.join t);
+  assert !r;
+  assert (Domain.join t)
+
 exception Ex of string
 let join_exn () =
   match Domain.(join (spawn (fun () -> raise (Ex (String.make 5 '!'))))) with
   | _ -> assert false
   | exception (Ex "!!!!!") -> ()
 
-let join_slow () =
-  let rec burn l =
+let burn () =
+  let rec loop l =
     if List.hd l > 14 then ()
-  else
-    burn (l @ l |> List.map (fun x -> x + 1)) in
-  assert (Domain.(join (spawn (fun () -> burn [0]; 42))) = 42)
+    else loop (l @ l |> List.map (fun x -> x + 1))
+  in
+  loop [0];
+  42
 
+let join_slow () =
+  assert (Domain.(join (spawn burn)) = 42)
 
-let join2 () =
-  let r = ref false in
-  let t = Domain.spawn (fun () -> r := true) in
-  Domain.join t;
-  assert !r;
-  try
-    Domain.join t;
-    assert false
-  with Invalid_argument _ ->
-    assert !r
+let join3 () =
+  let d1 = Domain.spawn burn in
+  let d2 = Domain.(spawn (fun _ -> Domain.join d1)) in
+  assert (Domain.join d1 = 42);
+  assert (Domain.join d2 = 42)
 
 let () =
   main_join num_domains;
@@ -62,5 +67,6 @@ let () =
   join2 ();
   join_exn ();
   join_slow ();
+  join3 ();
   Gc.full_major ();
   Gc.full_major ()


### PR DESCRIPTION
This PR simplifies `Domain.join` by using mutex and condition variables, and avoids the more complicated logic used currently on `trunk`. The termination mutex is no longer shared with the runtime which makes the reasoning simpler. 

The PR also introduces a user-visible change -- joining more than once on a domain no longer raises an exception. The proposed semantics for `Domain.join` returns the result of `Domain.spawn` if the computation ran to completion normally and raises the same exception if the computation had raised an exception, irrespective of the number of times `Domain.join` is called on a domain. It was unclear to me why the current "exactly-once" restriction was introduced in the first place. I assume that it may have to do with the lack of Mutex and Condition modules in the previous implementations of multicore.

Alternative semantics for the handling of uncaught exceptions is discussed in #11074. This PR aims to only introduce the minimal change in semantics. 