### PR TITLE
Remove unnecessary linking on unix library in parallel tests

### DIFF
--- a/testsuite/tests/parallel/atomics.ml
+++ b/testsuite/tests/parallel/atomics.ml
@@ -1,8 +1,4 @@
 (* TEST
-* hasunix
-include unix
-** bytecode
-** native
 *)
 
 type u = U of unit

--- a/testsuite/tests/parallel/constpromote.ml
+++ b/testsuite/tests/parallel/constpromote.ml
@@ -1,8 +1,4 @@
 (* TEST
-* hasunix
-include unix
-** bytecode
-** native
 *)
 
 (* when run with the bytecode debug runtime, this test

--- a/testsuite/tests/parallel/deadcont.ml
+++ b/testsuite/tests/parallel/deadcont.ml
@@ -1,8 +1,4 @@
 (* TEST
-* hasunix
-include unix
-** bytecode
-** native
 *)
 
 (*

--- a/testsuite/tests/parallel/domain_dls.ml
+++ b/testsuite/tests/parallel/domain_dls.ml
@@ -1,8 +1,4 @@
 (* TEST
-* hasunix
-include unix
-** bytecode
-** native
 *)
 
 let check_dls () =

--- a/testsuite/tests/parallel/domain_dls2.ml
+++ b/testsuite/tests/parallel/domain_dls2.ml
@@ -1,8 +1,4 @@
 (* TEST
-* hasunix
-include unix
-** bytecode
-** native
 *)
 
 let _ =

--- a/testsuite/tests/parallel/domain_id.ml
+++ b/testsuite/tests/parallel/domain_id.ml
@@ -1,8 +1,4 @@
 (* TEST
-* hasunix
-include unix
-** bytecode
-** native
 *)
 
 open Domain

--- a/testsuite/tests/parallel/domain_parallel_spawn_burn.ml
+++ b/testsuite/tests/parallel/domain_parallel_spawn_burn.ml
@@ -1,8 +1,4 @@
 (* TEST
-* hasunix
-include unix
-** bytecode
-** native
 *)
 
 open Domain

--- a/testsuite/tests/parallel/domain_parallel_spawn_burn_gc_set.ml
+++ b/testsuite/tests/parallel/domain_parallel_spawn_burn_gc_set.ml
@@ -1,8 +1,4 @@
 (* TEST
-* hasunix
-include unix
-** bytecode
-** native
 *)
 
 open Domain

--- a/testsuite/tests/parallel/join.ml
+++ b/testsuite/tests/parallel/join.ml
@@ -1,8 +1,4 @@
 (* TEST
-* hasunix
-include unix
-** bytecode
-** native
 *)
 
 let test_size =

--- a/testsuite/tests/parallel/pingpong.ml
+++ b/testsuite/tests/parallel/pingpong.ml
@@ -1,8 +1,4 @@
 (* TEST
-* hasunix
-include unix
-** bytecode
-** native
 *)
 
 let r = ref (Some 0)

--- a/testsuite/tests/parallel/prodcons_domains.ml
+++ b/testsuite/tests/parallel/prodcons_domains.ml
@@ -1,10 +1,4 @@
 (* TEST
-
-* hassysthreads
-include systhreads
-** bytecode
-** native
-
 *)
 
 (* Classic producer-consumer *)


### PR DESCRIPTION
Many tests in tests/parallel link the Unix library. The PR removes the unnecessary ocamltest stanzas from those tests that do not use the Unix library. 

Old versions of the multicore compiler used `Unix.select` as a way to sleep in a spin-wait loop. We have better ways of doing this now. 