### PR TITLE
[1/3] Restructure LIBDIR: Move Dynlink, Str and Unix to sub-directories

### DIFF
--- a/.depend
+++ b/.depend
@@ -6019,6 +6019,7 @@ driver/compmisc.cmx : \
     utils/clflags.cmx \
     driver/compmisc.cmi
 driver/compmisc.cmi : \
+    utils/load_path.cmi \
     typing/env.cmi \
     utils/clflags.cmi
 driver/errors.cmo : \

--- a/Changes
+++ b/Changes
@@ -267,6 +267,12 @@ Working version
   (Sébastien Hinderer, review by David Allsopp, Nicolás Ojeda Bär,
   Xavier Leroy, Vincent Laviron and Antonin Décimo)
 
+* #11198: Install the Dynlink, Str and Unix libraries to individual
+  subdirectories of LIBDIR. The compiler, debugger and toplevel automatically
+  add `-I +lib` if required, but display an alert.
+  (David Allsopp, review by Florian Angeletti, Nicolás Ojeda Bär,
+   Valentin Gatien-Baron and Sébastien Hinderer)
+
 - #11200: Install ocamlprof's Profiling runtime module to a +profiling,
   removing it from the default namespace.
   (David Allsopp, review by Sébastien Hinderer)

--- a/compilerlibs/Makefile.compilerlibs
+++ b/compilerlibs/Makefile.compilerlibs
@@ -31,10 +31,10 @@ UTILS = \
   utils/identifiable.cmo \
   utils/numbers.cmo \
   utils/arg_helper.cmo \
-  utils/clflags.cmo \
-  utils/profile.cmo \
   utils/local_store.cmo \
   utils/load_path.cmo \
+  utils/clflags.cmo \
+  utils/profile.cmo \
   utils/terminfo.cmo \
   utils/ccomp.cmo \
   utils/warnings.cmo \

--- a/debugger/.depend
+++ b/debugger/.depend
@@ -72,6 +72,7 @@ command_line.cmo : \
     debugger_lexer.cmi \
     debugger_config.cmi \
     debugcom.cmi \
+    ../driver/compmisc.cmi \
     checkpoints.cmi \
     breakpoints.cmi \
     command_line.cmi
@@ -109,6 +110,7 @@ command_line.cmx : \
     debugger_lexer.cmx \
     debugger_config.cmx \
     debugcom.cmx \
+    ../driver/compmisc.cmx \
     checkpoints.cmx \
     breakpoints.cmx \
     command_line.cmi
@@ -323,6 +325,7 @@ main.cmo : \
     exec.cmi \
     debugger_config.cmi \
     ../utils/config.cmi \
+    ../driver/compmisc.cmi \
     command_line.cmi \
     ../file_formats/cmi_format.cmi \
     ../utils/clflags.cmi \
@@ -345,6 +348,7 @@ main.cmx : \
     exec.cmx \
     debugger_config.cmx \
     ../utils/config.cmx \
+    ../driver/compmisc.cmx \
     command_line.cmx \
     ../file_formats/cmi_format.cmx \
     ../utils/clflags.cmx \
@@ -470,6 +474,7 @@ program_management.cmo : \
     history.cmi \
     ../typing/envaux.cmi \
     debugger_config.cmi \
+    ../driver/compmisc.cmi \
     breakpoints.cmi \
     program_management.cmi
 program_management.cmx : \
@@ -487,6 +492,7 @@ program_management.cmx : \
     history.cmx \
     ../typing/envaux.cmx \
     debugger_config.cmx \
+    ../driver/compmisc.cmx \
     breakpoints.cmx \
     program_management.cmi
 program_management.cmi :

--- a/debugger/command_line.ml
+++ b/debugger/command_line.ml
@@ -262,7 +262,7 @@ let instr_dir ppf lexbuf =
   let new_directory = argument_list_eol argument lexbuf in
     if new_directory = [] then begin
       if yes_or_no "Reinitialize directory list" then begin
-        Load_path.init !default_load_path;
+        Load_path.init ~auto_include:Compmisc.auto_include !default_load_path;
         Envaux.reset_cache ();
         Hashtbl.clear Debugger_config.load_path_for;
         flush_buffer_list ()

--- a/debugger/main.ml
+++ b/debugger/main.ml
@@ -229,7 +229,7 @@ let main () =
     if !Parameters.version
     then printf "\tOCaml Debugger version %s@.@." Config.version;
     Loadprinter.init();
-    Load_path.init !default_load_path;
+    Load_path.init ~auto_include:Compmisc.auto_include !default_load_path;
     Clflags.recursive_types := true;    (* Allow recursive types. *)
     toplevel_loop ();                   (* Toplevel. *)
     kill_program ();

--- a/debugger/program_management.ml
+++ b/debugger/program_management.ml
@@ -128,7 +128,8 @@ let initialize_loading () =
   end;
   Symbols.clear_symbols ();
   Symbols.read_symbols 0 !program_name;
-  Load_path.init (Load_path.get_paths () @ !Symbols.program_source_dirs);
+  let dirs = Load_path.get_paths () @ !Symbols.program_source_dirs in
+  Load_path.init ~auto_include:Compmisc.auto_include dirs;
   Envaux.reset_cache ();
   if !debug_loading then
     prerr_endline "Opening a socket...";

--- a/driver/compmisc.ml
+++ b/driver/compmisc.ml
@@ -13,6 +13,12 @@
 (*                                                                        *)
 (**************************************************************************)
 
+let auto_include find_in_dir fn =
+  if !Clflags.no_std_include then
+    raise Not_found
+  else
+    Load_path.auto_include_otherlibs Location.auto_include_alert find_in_dir fn
+
 (* Initialize the search path.
    [dir] (default: the current directory)
    is always searched first  unless -nocwd is specified,

--- a/driver/compmisc.ml
+++ b/driver/compmisc.ml
@@ -17,7 +17,8 @@ let auto_include find_in_dir fn =
   if !Clflags.no_std_include then
     raise Not_found
   else
-    Load_path.auto_include_otherlibs Location.auto_include_alert find_in_dir fn
+    let alert = Location.auto_include_alert in
+    Load_path.auto_include_otherlibs alert find_in_dir fn
 
 (* Initialize the search path.
    [dir] (default: the current directory)
@@ -43,7 +44,7 @@ let init_path ?(dir="") () =
     (if !Clflags.no_cwd then [] else [dir])
     @ List.rev_append exp_dirs (Clflags.std_include_dir ())
   in
-  Load_path.init(dirs);
+  Load_path.init ~auto_include dirs;
   Env.reset_cache ()
 
 (* Return the initial environment in which compilation proceeds. *)

--- a/driver/compmisc.mli
+++ b/driver/compmisc.mli
@@ -21,3 +21,9 @@ val set_from_env : 'a option ref -> 'a Clflags.env_reader -> unit
 val read_clflags_from_env : unit -> unit
 
 val with_ppf_dump : file_prefix:string -> (Format.formatter -> 'a) -> 'a
+
+val auto_include :
+  (Load_path.Dir.t -> string -> string option) -> string -> string
+(** [auto_include find_in_dir fn] is a callback function to be passed to
+    {!Load_path.init} and automatically adds [-I +lib] to the load path after
+    displaying an alert. *)

--- a/otherlibs/Makefile.otherlibs.common
+++ b/otherlibs/Makefile.otherlibs.common
@@ -85,6 +85,8 @@ $(LIBNAME).cmxs: $(LIBNAME).cmxa $(STUBSLIB)
 lib$(CLIBNAME).$(A): $(COBJS)
 	$(MKLIB_CMD) -oc $(CLIBNAME) $(COBJS) $(LDOPTS)
 
+INSTALL_LIBDIR_LIBNAME = $(INSTALL_LIBDIR)/$(LIBNAME)
+
 install::
 	if test -f dll$(CLIBNAME)$(EXT_DLL); then \
 	  $(INSTALL_PROG) \
@@ -93,15 +95,21 @@ install::
 ifneq "$(STUBSLIB)" ""
 	$(INSTALL_DATA) $(STUBSLIB) "$(INSTALL_LIBDIR)/"
 endif
-
+# If installing over a previous OCaml version, ensure the library is removed
+# from the previous installation.
+	rm -f $(addprefix "$(INSTALL_LIBDIR)"/, \
+          $(LIBNAME).cma $(CMIFILES) \
+          $(CMIFILES:.cmi=.mli) $(CMIFILES:.cmi=.cmti) \
+          $(CAMLOBJS_NAT) $(LIBNAME).cmxa $(LIBNAME).cmxs $(LIBNAME).$(A))
+	$(MKDIR) "$(INSTALL_LIBDIR_LIBNAME)"
 	$(INSTALL_DATA) \
 	  $(LIBNAME).cma $(CMIFILES) \
-	  "$(INSTALL_LIBDIR)/"
+	  "$(INSTALL_LIBDIR_LIBNAME)/"
 ifeq "$(INSTALL_SOURCE_ARTIFACTS)" "true"
 	$(INSTALL_DATA) \
 	  $(CMIFILES:.cmi=.mli) \
           $(CMIFILES:.cmi=.cmti) \
-	  "$(INSTALL_LIBDIR)/"
+	  "$(INSTALL_LIBDIR_LIBNAME)/"
 endif
 	if test -n "$(HEADERS)"; then \
 	  $(INSTALL_DATA) $(HEADERS) "$(INSTALL_INCDIR)/"; \
@@ -110,9 +118,9 @@ endif
 installopt:
 	$(INSTALL_DATA) \
 	   $(CAMLOBJS_NAT) $(LIBNAME).cmxa $(LIBNAME).$(A) \
-	   "$(INSTALL_LIBDIR)/"
+	   "$(INSTALL_LIBDIR_LIBNAME)/"
 	if test -f $(LIBNAME).cmxs; then \
-	  $(INSTALL_PROG) $(LIBNAME).cmxs "$(INSTALL_LIBDIR)"; \
+	  $(INSTALL_PROG) $(LIBNAME).cmxs "$(INSTALL_LIBDIR_LIBNAME)"; \
 	fi
 
 partialclean:

--- a/otherlibs/dynlink/Makefile
+++ b/otherlibs/dynlink/Makefile
@@ -79,13 +79,13 @@ COMPILERLIBS_SOURCES=\
   utils/identifiable.ml \
   utils/numbers.ml \
   utils/arg_helper.ml \
+  utils/local_store.ml \
+  utils/load_path.ml \
   utils/clflags.ml \
   utils/profile.ml \
   utils/consistbl.ml \
   utils/terminfo.ml \
   utils/warnings.ml \
-  utils/local_store.ml \
-  utils/load_path.ml \
   utils/int_replace_polymorphic_compare.ml \
   utils/lazy_backtrack.ml \
   parsing/location.ml \

--- a/otherlibs/dynlink/Makefile
+++ b/otherlibs/dynlink/Makefile
@@ -242,21 +242,29 @@ $(eval $(call PROGRAM_SYNONYM,extract_crc))
 $(extract_crc): dynlink.cma byte/dynlink_compilerlibs.cmo extract_crc.cmo
 	$(OCAMLC) -o $@ $^
 
+INSTALL_LIBDIR_DYNLINK = $(INSTALL_LIBDIR)/dynlink
+
 install:
+# If installing over a previous OCaml version, ensure dynlink is removed from
+# the previous installation.
+	rm -f "$(INSTALL_LIBDIR)"/dynlink.cm* "$(INSTALL_LIBDIR)/dynlink.mli" \
+        "$(INSTALL_LIBDIR)/dynlink.$(A)" \
+        $(addprefix "$(INSTALL_LIBDIR)/", $(notdir $(NATOBJS)))
+	$(MKDIR) "$(INSTALL_LIBDIR_DYNLINK)"
 	$(INSTALL_DATA) \
 	  dynlink.cmi dynlink.cma \
-	  "$(INSTALL_LIBDIR)"
+	  "$(INSTALL_LIBDIR_DYNLINK)"
 ifeq "$(INSTALL_SOURCE_ARTIFACTS)" "true"
 	$(INSTALL_DATA) \
 	  dynlink.cmti dynlink.mli \
-	  "$(INSTALL_LIBDIR)"
+	  "$(INSTALL_LIBDIR_DYNLINK)"
 endif
 
 installopt:
 ifeq "$(strip $(NATDYNLINK))" "true"
 	$(INSTALL_DATA) \
 	  $(NATOBJS) dynlink.cmxa dynlink.$(A) \
-	  "$(INSTALL_LIBDIR)"
+	  "$(INSTALL_LIBDIR_DYNLINK)"
 endif
 
 partialclean:

--- a/parsing/ast_mapper.ml
+++ b/parsing/ast_mapper.ml
@@ -903,7 +903,16 @@ module PpxContext = struct
       | "include_dirs" ->
           Clflags.include_dirs := get_list get_string payload
       | "load_path" ->
-          Load_path.init (get_list get_string payload)
+          (* Duplicates Compmisc.auto_include, since we can't reference Compmisc
+             from this module. *)
+          let auto_include find_in_dir fn =
+            if !Clflags.no_std_include then
+              raise Not_found
+            else
+              let alert = Location.auto_include_alert in
+              Load_path.auto_include_otherlibs alert find_in_dir fn
+          in
+          Load_path.init ~auto_include (get_list get_string payload)
       | "open_modules" ->
           Clflags.open_modules := get_list get_string payload
       | "for_package" ->

--- a/parsing/location.ml
+++ b/parsing/location.ml
@@ -895,6 +895,19 @@ let alert ?(def = none) ?(use = none) ~kind loc message =
 let deprecated ?def ?use loc message =
   alert ?def ?use ~kind:"deprecated" loc message
 
+let auto_include_alert lib =
+  let message = Printf.sprintf "\
+    OCaml's lib directory layout changed in 5.0. The %s subdirectory has been \
+    automatically added to the search path, but you should add -I +%s to the \
+    command-line to silence this alert (e.g. by adding %s to the list of \
+    libraries in your dune file, or adding use_%s to your _tags file for \
+    ocamlbuild, or using -package %s for ocamlfind)." lib lib lib lib lib in
+  let alert =
+    {Warnings.kind="ocaml_deprecated_auto_include"; use=none; def=none;
+     message = Format.asprintf "@[@\n%a@]" Format.pp_print_text message}
+  in
+  prerr_alert none alert
+
 (******************************************************************************)
 (* Reporting errors on exceptions *)
 

--- a/parsing/location.ml
+++ b/parsing/location.ml
@@ -18,9 +18,7 @@ open Lexing
 type t = Warnings.loc =
   { loc_start: position; loc_end: position; loc_ghost: bool }
 
-let in_file name =
-  let loc = { dummy_pos with pos_fname = name } in
-  { loc_start = loc; loc_end = loc; loc_ghost = true }
+let in_file = Warnings.ghost_loc_in_file
 
 let none = in_file "_none_"
 let is_none l = (l = none)

--- a/parsing/location.mli
+++ b/parsing/location.mli
@@ -243,6 +243,9 @@ val deprecated: ?def:t -> ?use:t -> t -> string -> unit
 val alert: ?def:t -> ?use:t -> kind:string -> t -> string -> unit
 (** Prints an arbitrary alert. *)
 
+val auto_include_alert: string -> unit
+(** Prints an alert that -I +lib has been automatically added ot the load
+    path *)
 
 (** {1 Reporting errors} *)
 

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -84,8 +84,8 @@ ocamldep.opt$(EXE): $(call byte2native, $(ocamldep_objects))
 # The profiler
 
 OCAMLPROF=config.cmo build_path_prefix_map.cmo misc.cmo identifiable.cmo \
-  numbers.cmo arg_helper.cmo clflags.cmo terminfo.cmo \
-  warnings.cmo location.cmo longident.cmo docstrings.cmo \
+  numbers.cmo arg_helper.cmo local_store.cmo load_path.cmo clflags.cmo \
+  terminfo.cmo warnings.cmo location.cmo longident.cmo docstrings.cmo \
   syntaxerr.cmo ast_helper.cmo \
   camlinternalMenhirLib.cmo parser.cmo \
   pprintast.cmo \
@@ -98,8 +98,8 @@ opt.opt: profiling.cmx
 
 OCAMLCP = config.cmo build_path_prefix_map.cmo misc.cmo profile.cmo \
           warnings.cmo identifiable.cmo numbers.cmo arg_helper.cmo \
-          clflags.cmo local_store.cmo \
-          terminfo.cmo location.cmo load_path.cmo ccomp.cmo compenv.cmo \
+          local_store.cmo load_path.cmo clflags.cmo \
+          terminfo.cmo location.cmo ccomp.cmo compenv.cmo \
           main_args.cmo ocamlcp_common.cmo
 
 ocamlcp$(EXE): $(OCAMLCP) ocamlcp.cmo
@@ -139,8 +139,8 @@ ocamlmklib.opt$(EXE): $(call byte2native, $(OCAMLMKLIB))
 # To make custom toplevels
 
 OCAMLMKTOP=config.cmo build_path_prefix_map.cmo misc.cmo \
-       identifiable.cmo numbers.cmo arg_helper.cmo clflags.cmo \
-       local_store.cmo load_path.cmo profile.cmo ccomp.cmo ocamlmktop.cmo
+       identifiable.cmo numbers.cmo arg_helper.cmo local_store.cmo \
+       load_path.cmo clflags.cmo profile.cmo ccomp.cmo ocamlmktop.cmo
 
 ocamlmktop$(EXE): $(OCAMLMKTOP)
 ocamlmktop.opt$(EXE): $(call byte2native, $(OCAMLMKTOP))

--- a/toplevel/topcommon.ml
+++ b/toplevel/topcommon.ml
@@ -274,7 +274,7 @@ let set_paths () =
       [expand "+camlp4"];
     ]
   in
-  Load_path.init load_path;
+  Load_path.init ~auto_include:Compmisc.auto_include load_path;
   Dll.add_path load_path
 
 let update_search_path_from_env () =

--- a/utils/load_path.ml
+++ b/utils/load_path.ml
@@ -85,7 +85,7 @@ let prepend_add dir =
       STbl.replace !files_uncap (String.uncapitalize_ascii base) fn
     ) dir.Dir.files
 
-let init ?(auto_include=default_auto_include_callback) l =
+let init ~auto_include l =
   reset ();
   dirs := List.rev_map Dir.create l;
   List.iter prepend_add !dirs;

--- a/utils/load_path.ml
+++ b/utils/load_path.ml
@@ -31,6 +31,22 @@ module Dir = struct
   let path t = t.path
   let files t = t.files
 
+  let find t fn =
+    if List.mem fn t.files then
+      Some (Filename.concat t.path fn)
+    else
+      None
+
+  let find_uncap t fn =
+    let fn = String.uncapitalize_ascii fn in
+    let search base =
+      if String.uncapitalize_ascii base = fn then
+        Some (Filename.concat t.path base)
+      else
+        None
+    in
+    List.find_map search t.files
+
   (* For backward compatibility reason, simulate the behavior of
      [Misc.find_in_path]: silently ignore directories that don't exist
      + treat [""] as the current directory. *)
@@ -45,12 +61,15 @@ module Dir = struct
 end
 
 let dirs = s_ref []
+let default_auto_include_callback _ _ = raise Not_found
+let auto_include_callback = ref default_auto_include_callback
 
 let reset () =
   assert (not Config.merlin || Local_store.is_bound ());
   STbl.clear !files;
   STbl.clear !files_uncap;
-  dirs := []
+  dirs := [];
+  auto_include_callback := default_auto_include_callback
 
 let get () = List.rev !dirs
 let get_paths () = List.rev_map Dir.path !dirs
@@ -66,10 +85,11 @@ let prepend_add dir =
       STbl.replace !files_uncap (String.uncapitalize_ascii base) fn
     ) dir.Dir.files
 
-let init l =
+let init ?(auto_include=default_auto_include_callback) l =
   reset ();
   dirs := List.rev_map Dir.create l;
-  List.iter prepend_add !dirs
+  List.iter prepend_add !dirs;
+  auto_include_callback := auto_include
 
 let remove_dir dir =
   assert (not Config.merlin || Local_store.is_bound ());
@@ -109,16 +129,45 @@ let prepend_dir dir =
 
 let is_basename fn = Filename.basename fn = fn
 
+let auto_include_libs libs alert find_in_dir fn =
+  let scan (lib, lazy dir) =
+    let file = find_in_dir dir fn in
+    let alert_and_add_dir _ =
+      alert lib;
+      append_dir dir
+    in
+    Option.iter alert_and_add_dir file;
+    file
+  in
+  match List.find_map scan libs with
+  | Some base -> base
+  | None -> raise Not_found
+
+let auto_include_otherlibs =
+  (* Ensure directories are only ever scanned once *)
+  let expand = Misc.expand_directory Config.standard_library in
+  let otherlibs =
+    let read_lib lib = lazy (Dir.create (expand ("+" ^ lib))) in
+    List.map (fun lib -> (lib, read_lib lib)) ["dynlink"; "str"; "unix"] in
+  auto_include_libs otherlibs
+
 let find fn =
   assert (not Config.merlin || Local_store.is_bound ());
-  if is_basename fn && not !Sys.interactive then
-    STbl.find !files fn
-  else
-    Misc.find_in_path (get_paths ()) fn
+  try
+    if is_basename fn && not !Sys.interactive then
+      STbl.find !files fn
+    else
+      Misc.find_in_path (get_paths ()) fn
+  with Not_found ->
+    !auto_include_callback Dir.find fn
 
 let find_uncap fn =
   assert (not Config.merlin || Local_store.is_bound ());
-  if is_basename fn && not !Sys.interactive then
-    STbl.find !files_uncap (String.uncapitalize_ascii fn)
-  else
-    Misc.find_in_path_uncap (get_paths ()) fn
+  try
+    if is_basename fn && not !Sys.interactive then
+      STbl.find !files_uncap (String.uncapitalize_ascii fn)
+    else
+      Misc.find_in_path_uncap (get_paths ()) fn
+  with Not_found ->
+    let fn_uncap = String.uncapitalize_ascii fn in
+    !auto_include_callback Dir.find_uncap fn_uncap

--- a/utils/load_path.mli
+++ b/utils/load_path.mli
@@ -52,7 +52,7 @@ module Dir : sig
 end
 
 val init :
-  ?auto_include:((Dir.t -> string -> string option) -> string -> string) ->
+  auto_include:((Dir.t -> string -> string option) -> string -> string) ->
   string list -> unit
 (** [init l] is the same as [reset (); List.iter add_dir (List.rev l)] *)
 

--- a/utils/load_path.mli
+++ b/utils/load_path.mli
@@ -31,8 +31,36 @@ val remove_dir : string -> unit
 val reset : unit -> unit
 (** Remove all directories *)
 
-val init : string list -> unit
+module Dir : sig
+  type t
+  (** Represent one directory in the load path. *)
+
+  val create : string -> t
+
+  val path : t -> string
+
+  val files : t -> string list
+  (** All the files in that directory. This doesn't include files in
+      sub-directories of this directory. *)
+
+  val find : t -> string -> string option
+  (** [find dir fn] returns the full path to [fn] in [dir]. *)
+
+  val find_uncap : t -> string -> string option
+  (** As {!find}, but search also for uncapitalized name, i.e. if name is
+      Foo.ml, either /path/Foo.ml or /path/foo.ml may be returned. *)
+end
+
+val init :
+  ?auto_include:((Dir.t -> string -> string option) -> string -> string) ->
+  string list -> unit
 (** [init l] is the same as [reset (); List.iter add_dir (List.rev l)] *)
+
+val auto_include_otherlibs :
+  (string -> unit) -> (Dir.t -> string -> string option) -> string -> string
+(** [auto_include_otherlibs alert] is a callback function to be passed to
+    {!Load_path.init} and automatically adds [-I +lib] to the load path after
+    calling [alert lib]. *)
 
 val get_paths : unit -> string list
 (** Return the list of directories passed to [add_dir] so far. *)
@@ -46,19 +74,6 @@ val find : string -> string
 val find_uncap : string -> string
 (** Same as [find], but search also for uncapitalized name, i.e.  if
     name is Foo.ml, allow /path/Foo.ml and /path/foo.ml to match. *)
-
-module Dir : sig
-  type t
-  (** Represent one directory in the load path. *)
-
-  val create : string -> t
-
-  val path : t -> string
-
-  val files : t -> string list
-  (** All the files in that directory. This doesn't include files in
-      sub-directories of this directory. *)
-end
 
 val[@deprecated] add : Dir.t -> unit
 (** Old name for {!append_dir} *)

--- a/utils/warnings.ml
+++ b/utils/warnings.ml
@@ -686,6 +686,10 @@ type token =
   | Letter of char * modifier option
   | Num of int * int * modifier
 
+let ghost_loc_in_file name =
+  let pos = { Lexing.dummy_pos with pos_fname = name } in
+  { loc_start = pos; loc_end = pos; loc_ghost = true }
+
 let letter_alert tokens =
   let print_warning_char ppf c =
     let lowercase = Char.lowercase_ascii c = c in
@@ -724,8 +728,7 @@ let letter_alert tokens =
   match consecutive_letters with
   | [] -> None
   | example :: _  ->
-      let pos = { Lexing.dummy_pos with pos_fname = "_none_" } in
-      let nowhere = { loc_start=pos; loc_end=pos; loc_ghost=true } in
+      let nowhere = ghost_loc_in_file "_none_" in
       let spelling_hint ppf =
         let max_seq_len =
           List.fold_left (fun l x -> Int.max l (List.length x))

--- a/utils/warnings.mli
+++ b/utils/warnings.mli
@@ -26,6 +26,9 @@ type loc = {
   loc_ghost: bool;
 }
 
+val ghost_loc_in_file : string -> loc
+(** Return an empty ghost range located in a given file *)
+
 type field_usage_warning =
   | Unused
   | Not_read


### PR DESCRIPTION
This PR is the first and main PR of a brave (in the Apple sense) series of changes which seek to separate the components in OCaml's `$LIBDIR`. This PR specifically moves the Dynlink, Str and Unix libraries into sub-directories of `$LIBDIR`. The idea of the change was provisionally agreed at the last developers' meeting.

The motivation for this change is hygiene in build systems: at present, it is very difficult to impossible for Dune (for example) to ensure that a library specifies its dependency on the Unix library.

The change itself is quite simple, and in the first commit. A small tweak to two `Makefile`s ensures the libraries are installed to their new locations. Any previous artefacts are removed (cf. #1724, #1728 and  #10301, noting that the removal of artefacts is "precise" w.r.t. basenames).

That change on its own is very breaking, of course. 

The rest of the commits relate to backwards compatibility. The compilers, toplevel and debugger will all automatically add the required include path to the load path, but display an alert for each directory as this happens. For example:

```
$ ocaml unix.cma
File "_none_", line 1:
Alert ocaml_auto_include: OCaml's lib directory layout changed in 5.0. The unix
subdirectory has been automatically added to the search path, but you should add
-I +unix to the command-line to silence this alert.
OCaml version 5.0.0+dev0-2021-11-05
Enter #help;; for help.
```

or similarly with:

```
$ ocaml
OCaml version 5.0.0+dev0-2021-11-05
Enter #help;; for help.

# type t = Unix.file_descr;;
Alert ocaml_auto_include: OCaml's lib directory layout changed in 5.0. The unix
subdirectory has been automatically added to the search path, but you should add
-I +unix to the command-line to silence this alert.
type t = Unix.file_descr
```

In implementing this alert, I've attempted to avoid penalising code which has specified the appropriate include directories, especially as we know that the load path is a relatively "hot" part of the build for some users. The mechanism I've gone for is to add an extra attempt around `Load_path.find` and `Load_path.find_uncap` for the case when there is an actual miss on the load path. In almost all cases, a miss on the load path is fatal. The exceptions are `#remove_directory` in the toplevel and gaining inlining information from `.cmx` files when linking in `ocamlopt`, so at less critical stages. The toplevel, compilers and debugger add `"+dynlink"`, `"+str"` and `"+unix"` to a "secondary" load path which is lazily scanned on the first miss on the normal load path. If the file being searched (say `unix.cma` and `unix.cmi`) is found, then that directory's entries are promoted to the main load path, and the fact that this took place is recorded. From the user's perspective in, say, the toplevel what happens at `#load "unix.cma"` is as if the user issued `#directory "+unix"` and then tried the `#load` again.

`Load_path` is very low-down the dependency graph of compiler-libs, so rather than displaying alerts itself, it simply maintains a list of directories which have been automatically added. This list is queried by functions added with the other alert functions in, ahem, `Location`.

The initialisation code is a duplicated between the debugger, driver and toplevel. It's not huge, but I'm not sure exactly where to put a function to do that - how averse are we to adding modules to ocamlcommon?

Another option might be to install the files in both places, but this isn't a silver bullet either - including the new directory can cause warnings in some tools (`ocamlfind` doesn't like finding `.cmi` files in multiple directories, for one) and it seems to be harder to record the need to display an alert without altering main load path data structure, which is a much more intimidating prospect than altering an error path.

Very similar work was previously attempted and abandoned in #1569. This work differs both in implementation and timing in a few ways which hopefully means we can reach a consensus on merging it this time. The key differences:
- OCaml 5.0 already breaks quite a few older packages, which means that this change is not as sensitive as it was in 2018.
- We have superior testing systems in place to assess the impact of this change. For OCaml 5, accepting that both ocamlfind and dune require patching, only **one** other package is broken in the whole of opam-repository by this PR, and that's an old release of that particular package, the current release using Dune and being unaffected.
- No changes are made to compiler-libs.
- Rather than implementing new compiler flags, this PR displays an alert

I have tested this change quite extensively on 4.14 - in many cases, the packages affected are already lying to their build systems. Dune and ocamlbuild users, for example, should not use `Unix` without having `unix` in their `libraries` stanza or `use_unix` in their `_tags` file. Even packages building directly with `ocamlfind` should include `-package unix` in the command-line. These packages can be fixed regardless of whether this PR is merged. Given a flurry of PRs now with this change (these packages can merge these updates regardless of whether this PR is accepted), I imagine that by OCaml 5.2, the number of packages still displaying this alert will be close to zero and the entire mechanism can then be reverted - at which point this change lives entirely in the build system.

There are other packages which contain commands of the form `ocaml unix.cma` which want to become `ocaml -I +unix unix.cma` - PRs are opened for these as well.

There are three possible pieces of future work which I haven't done yet, mainly because they are more philosophical (separating the otherlibs out mitigates actual issues):
1. C stubs for otherlibs are still installed to `$LIBDIR` (this is already the case for systhreads, so this is partially done to stay consistent). This could be trivially fixed for all these, but it could be viewed as separate. Note that at present we're saying that `-L /usr/lib/ocaml` is all you need to give to link _in C_. I can't remember the reference, but there's at least one application in the wild which links manually with our C stub libraries, because I remember dealing with a bug report relating to it...
2. `std_exit.cmo` and `std_exit.cmx` remain, despite the fact these are really part of the compiler, and not the Standard Library. The compilers impose a requirement that a standard library replacement implements a function called do_at_exit, but the actual implementation of std_exit is part of the compiler, not the stdlib. Indeed, in many ways there's no need for a module called `Std_exit` at all, we could generate a temporary file.
3. The runtime and stdlib still share the same directory. This is also a more principled matter, than actually causing issue: there's an open question for whether the runtime should go in `+runtime` or the stdlib in `+stdlib`. FWIW, I would advocate the latter - `lib/ocaml` now reflects the files of the OCaml _runtime_ and _compiler_ with the sub-directories all being libraries. But that can readily be for another day and another release...