### PR TITLE
[2/3] Restructure LIBDIR: Remove duplicate topdirs.cmi

### DIFF
--- a/Changes
+++ b/Changes
@@ -219,6 +219,10 @@ Working version
 - #11058: basic debugging documentation in runtime/HACKING.adoc
   (Gabriel Scherer, review by ???)
 
+- #11199: Stop installing topdirs.cmi twice. The toplevel now reads topdirs.cmi
+  from +compiler-libs, as the debugger does.
+  (David Allsopp, review by Sébastien Hinderer)
+
 ### Build system:
 
 * #10893: Remove configuration options --disable-force-safe-string and

--- a/Makefile
+++ b/Makefile
@@ -364,7 +364,6 @@ endif # ifeq "$(BOOTSTRAPPING_FLEXDLL)" "false"
 
 INSTALL_COMPLIBDIR = $(DESTDIR)$(COMPLIBDIR)
 INSTALL_FLEXDLLDIR = $(INSTALL_LIBDIR)/flexdll
-INSTALL_LIBDIR_TOPLEVEL = $(INSTALL_LIBDIR)/toplevel
 FLEXDLL_MANIFEST = default$(filter-out _i386,_$(ARCH)).manifest
 
 DOC_FILES=\
@@ -380,7 +379,6 @@ install:
 	$(MKDIR) "$(INSTALL_LIBDIR)"
 	$(MKDIR) "$(INSTALL_STUBLIBDIR)"
 	$(MKDIR) "$(INSTALL_COMPLIBDIR)"
-	$(MKDIR) "$(INSTALL_LIBDIR_TOPLEVEL)"
 	$(MKDIR) "$(INSTALL_DOCDIR)"
 	$(MAKE) -C runtime install
 	$(INSTALL_PROG) ocaml$(EXE) "$(INSTALL_BINDIR)"
@@ -431,15 +429,6 @@ endif
 # If installing over a previous OCaml version, ensure the module is removed
 # from the previous installation.
 	rm -f "$(INSTALL_LIBDIR)"/topdirs.cm* "$(INSTALL_LIBDIR)/topdirs.mli"
-	$(INSTALL_DATA) \
-	   toplevel/topdirs.cmi \
-	   "$(INSTALL_LIBDIR_TOPLEVEL)"
-ifeq "$(INSTALL_SOURCE_ARTIFACTS)" "true"
-	$(INSTALL_DATA) \
-	   toplevel/topdirs.cmt \
-	   toplevel/topdirs.cmti toplevel/topdirs.mli \
-	   "$(INSTALL_LIBDIR_TOPLEVEL)"
-endif
 	$(MAKE) -C tools install
 ifeq "$(UNIX_OR_WIN32)" "unix" # Install manual pages only on Unix
 	$(MAKE) -C man install

--- a/Makefile
+++ b/Makefile
@@ -364,6 +364,7 @@ endif # ifeq "$(BOOTSTRAPPING_FLEXDLL)" "false"
 
 INSTALL_COMPLIBDIR = $(DESTDIR)$(COMPLIBDIR)
 INSTALL_FLEXDLLDIR = $(INSTALL_LIBDIR)/flexdll
+INSTALL_LIBDIR_TOPLEVEL = $(INSTALL_LIBDIR)/toplevel
 FLEXDLL_MANIFEST = default$(filter-out _i386,_$(ARCH)).manifest
 
 DOC_FILES=\
@@ -379,6 +380,7 @@ install:
 	$(MKDIR) "$(INSTALL_LIBDIR)"
 	$(MKDIR) "$(INSTALL_STUBLIBDIR)"
 	$(MKDIR) "$(INSTALL_COMPLIBDIR)"
+	$(MKDIR) "$(INSTALL_LIBDIR_TOPLEVEL)"
 	$(MKDIR) "$(INSTALL_DOCDIR)"
 	$(MAKE) -C runtime install
 	$(INSTALL_PROG) ocaml$(EXE) "$(INSTALL_BINDIR)"
@@ -426,14 +428,17 @@ endif
 	   $(BYTESTART) $(TOPLEVELSTART) \
 	   "$(INSTALL_COMPLIBDIR)"
 	$(INSTALL_PROG) $(expunge) "$(INSTALL_LIBDIR)"
+# If installing over a previous OCaml version, ensure the module is removed
+# from the previous installation.
+	rm -f "$(INSTALL_LIBDIR)"/topdirs.cm* "$(INSTALL_LIBDIR)/topdirs.mli"
 	$(INSTALL_DATA) \
 	   toplevel/topdirs.cmi \
-	   "$(INSTALL_LIBDIR)"
+	   "$(INSTALL_LIBDIR_TOPLEVEL)"
 ifeq "$(INSTALL_SOURCE_ARTIFACTS)" "true"
 	$(INSTALL_DATA) \
 	   toplevel/topdirs.cmt \
 	   toplevel/topdirs.cmti toplevel/topdirs.mli \
-	   "$(INSTALL_LIBDIR)"
+	   "$(INSTALL_LIBDIR_TOPLEVEL)"
 endif
 	$(MAKE) -C tools install
 ifeq "$(UNIX_OR_WIN32)" "unix" # Install manual pages only on Unix

--- a/toplevel/byte/topeval.ml
+++ b/toplevel/byte/topeval.ml
@@ -297,5 +297,6 @@ and really_load_file recursive ppf name filename ic =
 let init () =
   let crc_intfs = Symtable.init_toplevel() in
   Compmisc.init_path ();
+  Topcommon.load_topdirs_signature ();
   Env.import_crcs ~source:Sys.executable_name crc_intfs;
   ()

--- a/toplevel/byte/topmain.ml
+++ b/toplevel/byte/topmain.ml
@@ -211,6 +211,7 @@ let main () =
   Compmisc.read_clflags_from_env ();
   if not (prepare ppf) then raise (Compenv.Exit_with_status 2);
   Compmisc.init_path ();
+  Topcommon.load_topdirs_signature ();
   Toploop.loop Format.std_formatter
 
 let main () =

--- a/toplevel/native/topeval.ml
+++ b/toplevel/native/topeval.ml
@@ -300,5 +300,6 @@ let load_file _ (* fixme *) ppf name0 =
 
 let init () =
   Compmisc.init_path ();
+  Topcommon.load_topdirs_signature ();
   Clflags.dlcode := true;
   ()

--- a/toplevel/native/topmain.ml
+++ b/toplevel/native/topmain.ml
@@ -103,6 +103,7 @@ let main () =
   Compmisc.read_clflags_from_env ();
   if not (prepare Format.err_formatter) then raise (Compenv.Exit_with_status 2);
   Compmisc.init_path ();
+  Topcommon.load_topdirs_signature ();
   Toploop.loop Format.std_formatter
 
 let main () =

--- a/toplevel/topcommon.ml
+++ b/toplevel/topcommon.ml
@@ -282,8 +282,15 @@ let update_search_path_from_env () =
     let env = Sys.getenv_opt "OCAMLTOP_INCLUDE_PATH" in
     Option.fold ~none:[] ~some:Misc.split_path_contents env
   in
-  Clflags.include_dirs :=
-    "+toplevel" :: List.rev_append extra_paths !Clflags.include_dirs
+  Clflags.include_dirs := List.rev_append extra_paths !Clflags.include_dirs
+
+let load_topdirs_signature () =
+  try ignore (Load_path.find "topdirs.cmi")
+  with Not_found ->
+    let compiler_libs =
+      Filename.concat Config.standard_library "compiler-libs" in
+    let topdirs_cmi = Filename.concat compiler_libs "topdirs.cmi" in
+    ignore (Env.read_signature "Topdirs" topdirs_cmi)
 
 let initialize_toplevel_env () =
   toplevel_env := Compmisc.initial_env()

--- a/toplevel/topcommon.ml
+++ b/toplevel/topcommon.ml
@@ -282,7 +282,8 @@ let update_search_path_from_env () =
     let env = Sys.getenv_opt "OCAMLTOP_INCLUDE_PATH" in
     Option.fold ~none:[] ~some:Misc.split_path_contents env
   in
-  Clflags.include_dirs := List.rev_append extra_paths !Clflags.include_dirs
+  Clflags.include_dirs :=
+    "+toplevel" :: List.rev_append extra_paths !Clflags.include_dirs
 
 let initialize_toplevel_env () =
   toplevel_env := Compmisc.initial_env()

--- a/toplevel/topcommon.ml
+++ b/toplevel/topcommon.ml
@@ -285,11 +285,10 @@ let update_search_path_from_env () =
   Clflags.include_dirs := List.rev_append extra_paths !Clflags.include_dirs
 
 let load_topdirs_signature () =
-  try ignore (Load_path.find "topdirs.cmi")
-  with Not_found ->
-    let compiler_libs =
-      Filename.concat Config.standard_library "compiler-libs" in
-    let topdirs_cmi = Filename.concat compiler_libs "topdirs.cmi" in
+  let compiler_libs =
+    Filename.concat Config.standard_library "compiler-libs" in
+  let topdirs_cmi = Filename.concat compiler_libs "topdirs.cmi" in
+  if Sys.file_exists topdirs_cmi then
     ignore (Env.read_signature "Topdirs" topdirs_cmi)
 
 let initialize_toplevel_env () =

--- a/toplevel/topcommon.mli
+++ b/toplevel/topcommon.mli
@@ -36,6 +36,10 @@ val set_paths : unit -> unit
 
 val update_search_path_from_env : unit -> unit
 
+(* Load topdirs.cmi directly from +compiler-libs if not found in include dirs *)
+
+val load_topdirs_signature : unit -> unit
+
 (* Management and helpers for the execution *)
 
 val toplevel_env : Env.t ref

--- a/toplevel/toploop.ml
+++ b/toplevel/toploop.ml
@@ -114,6 +114,7 @@ let run_script ppf name args =
   let filename = filename_of_input name in
   Compmisc.init_path ~dir:(Filename.dirname filename) ();
                    (* Note: would use [Filename.abspath] here, if we had it. *)
+  Topcommon.load_topdirs_signature ();
   begin
     try toplevel_env := Compmisc.initial_env()
     with Env.Error _ | Typetexp.Error _ as exn ->


### PR DESCRIPTION
This is the second PR in a series starting with #11198 which seek to separate the components in OCaml's `$LIBDIR`.

In OCaml 4.00.0, the compiler's libraries started to be installed in `$LIBDIR/compiler-libs`. This created a small conundrum for `topdirs.cmi` as the toplevel and the debugger both require this signature to be available.

Curiously, the debugger and toplevel were fixed in different ways. In #5647, the debugger directly enriches the environment with `topdirs.cmi` read from `compiler-libs` (see https://github.com/ocaml/ocaml/commit/fa0e0b6ba740c13798ea7306ece93a590c84fff4). This avoids having to add the whole of `+compiler-libs` to the load path. However, 10 days later the toplevel was fixed with a slightly different sledgehammer in #5691 by putting a second copy of `topdirs.cmi` into `$LIBDIR`, keeping the copy which used to be there in 3.12 and earlier (https://github.com/ocaml/ocaml/commit/f786ea843dcb90f5042de072ee3ada2a8b5e47d4). #827 somewhat needlessly duplicates `topdirs.cmt`, `topdirs.cmti` and `topdirs.mli` in `$LIBDIR` as well.

The duplication of these files are in themselves something a smell (in fact, the presence of two identically named .cmi files upsets `ocamlfind`). This PR changes the toplevel to adopt the debugger's approach and enriches the environment with `topdirs.cmi` loaded from `+compiler-libs`.

This is done immediately after `Compmisc.init_path` for which are three cases:
1. Running a script (`ocaml script.ml` or `ocamlnat script.ml`) in `Toploop.run_script`
2. Running an interactive toplevel, in `Topmain.main`
3. In the curiously obscure `Topeval.init` which is called at the initialisation of `Toploop`. This, as the comment in `toploop.ml` explains, is necessary or code linked together with `ocamlmktop` can't use `Topdirs.dir_install_printer`

At present, this PR requires a small patch to `utop` (to call `Topcommon.load_topdirs_signature`) and, when it's updated for OCaml 5, Coq will require a similar patch for the `Drop.` instruction in `coqtop.byte`.

It's tempting to move `Compmisc.init_path` out of `Topmain.main` and into `Toploop.loop`, and so also put the `Topcommon.load_topdirs_signature` there too. This would eliminate the need for patching Coq, certainly, but the code in utop serves as a reminder of why this (I think) is not a sound course of action: utop, for example, will drop into `Toploop.loop` only on some code paths, so where it has (or at least should have) setup up the paths itself - and it would still need to call `Topcommon.load_topdirs_signature` for the other code paths which don't go via the toplevel's own interactive loop.

This PR includes two earlier commits: the first simply adds `+toplevel` and gets the toplevel to include that directory. Simple, but it doesn't fix the smell! The second commit assumes that `topdirs.cmi` will be in the load path and falls back to loading it manually otherwise and then the final commit goes all-in on the manual enrichment approach.

The effect of this PR on the installation directory is that `topdirs.cmi`, `topdirs.cmt`, `topdirs.cmti` and `topdirs.mli` are no longer installed to `$LIBDIR`. This change has no visible check in opam-health-check _on OCaml 5.0 packages_. A version of it in OCaml 4.14 revealed some problems with older packages, but all of those packages already require updating for OCaml 5.0.