### PR TITLE
[3/3] Restructure LIBDIR: Move the Profiling module to a sub-directory

### DIFF
--- a/Changes
+++ b/Changes
@@ -244,6 +244,10 @@ Working version
   (Sébastien Hinderer, review by David Allsopp, Nicolás Ojeda Bär,
   Xavier Leroy, Vincent Laviron and Antonin Décimo)
 
+- #11200: Install ocamlprof's Profiling runtime module to a +profiling,
+  removing it from the default namespace.
+  (David Allsopp, review by Sébastien Hinderer)
+
 ### Bug fixes:
 
 - #11167: Fix memory leak from signal stack.

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -109,20 +109,26 @@ ocamloptp.opt$(EXE): $(call byte2native, $(OCAMLCP) ocamloptp.cmo)
 
 opt:: profiling.cmx
 
+INSTALL_LIBDIR_PROFILING = $(INSTALL_LIBDIR)/profiling
+
 install::
+# If installing over a previous OCaml version, ensure the module is removed
+# from the previous installation.
+	rm -f "$(INSTALL_LIBDIR)"/profiling.cm* "$(INSTALL_LIBDIR)/profiling.$(O)"
+	$(MKDIR) "$(INSTALL_LIBDIR_PROFILING)"
 	$(INSTALL_DATA) \
 	  profiling.cmi profiling.cmo \
-	  "$(INSTALL_LIBDIR)"
+	  "$(INSTALL_LIBDIR_PROFILING)"
 ifeq "$(INSTALL_SOURCE_ARTIFACTS)" "true"
 	$(INSTALL_DATA) \
 	  profiling.cmt profiling.cmti \
-	  "$(INSTALL_LIBDIR)"
+	  "$(INSTALL_LIBDIR_PROFILING)"
 endif
 
 installopt::
 	$(INSTALL_DATA) \
           profiling.cmx profiling.$(O) \
-	  "$(INSTALL_LIBDIR)"
+	  "$(INSTALL_LIBDIR_PROFILING)"
 
 # To help building mixed-mode libraries (OCaml + C)
 OCAMLMKLIB = config.cmo build_path_prefix_map.cmo misc.cmo ocamlmklib.cmo

--- a/tools/ocamlcp.ml
+++ b/tools/ocamlcp.ml
@@ -84,10 +84,10 @@ end;
 if !with_impl then rev_profargs := "-impl" :: !rev_profargs;
 if !with_intf then rev_profargs := "-intf" :: !rev_profargs;
 let status =
-  Sys.command
-    (Printf.sprintf "ocamlc -pp \"ocamlprof -instrument %s\" %s %s"
-        (String.concat " " (List.rev !rev_profargs))
-        (if !make_archive then "" else "profiling.cmo")
-        (String.concat " " (List.rev !rev_compargs)))
+  ksprintf Sys.command
+    "ocamlc -pp \"ocamlprof -instrument %s\" -I +profiling %s %s"
+      (String.concat " " (List.rev !rev_profargs))
+      (if !make_archive then "" else "profiling.cmo")
+      (String.concat " " (List.rev !rev_compargs))
 in
 exit status

--- a/tools/ocamloptp.ml
+++ b/tools/ocamloptp.ml
@@ -85,10 +85,10 @@ end;
 if !with_impl then rev_profargs := "-impl" :: !rev_profargs;
 if !with_intf then rev_profargs := "-intf" :: !rev_profargs;
 let status =
-  Sys.command
-    (Printf.sprintf "ocamlopt -pp \"ocamlprof -instrument %s\" %s %s"
-        (String.concat " " (List.rev !rev_profargs))
-        (if !make_archive then "" else "profiling.cmx")
-        (String.concat " " (List.rev !rev_compargs)))
+  ksprintf Sys.command
+    "ocamlopt -pp \"ocamlprof -instrument %s\" -I +profiling %s %s"
+      (String.concat " " (List.rev !rev_profargs))
+      (if !make_archive then "" else "profiling.cmx")
+      (String.concat " " (List.rev !rev_compargs))
 in
 exit status


### PR DESCRIPTION
This is the third PR in a series starting with #11198 which seek to separate the components in OCaml's `$LIBDIR`.

The profiling versions of the compiler (`ocamlcp` and `ocamloptp`) require a runtime module `Profiling` which is installed in `$LIBDIR` and therefore at present visible all the time. This PR moves `profiling.*` from `$LIBDIR` to `$LIBDIR/profiling` and updates the two tools to add `-I +profiling` to the command line. It remains the case that the user must avoid using a module called `Profiling` if they wish to use `ocamlprof`, but the already quite slim chance of inadvertently referring to `Profiling` without linking with it is now reduced to zero.

Note that this PR actually hardens the use of `Profiling` within `ocamlprof`, as using `-I +profiling` as the first `-I` directory ensures that `Profiling` always refers to `ocamlprof`'s module.