### PR TITLE
Make finaliser2 test deterministic

### DIFF
--- a/testsuite/tests/weak-ephe-final/finaliser2.ml
+++ b/testsuite/tests/weak-ephe-final/finaliser2.ml
@@ -1,5 +1,9 @@
 (* TEST *)
 
+let () = Out_channel.set_buffered stdout false
+
+(* If minor heap values are finalised on a domain, then the callbacks are run
+   at the end of a minor collection triggered by that domain. *)
 let[@inline never][@local never] test1 () =
   let r' = ref 0 in
   let rec foo () =
@@ -10,30 +14,36 @@ let[@inline never][@local never] test1 () =
   Gc.minor();
   assert (!r' = 1)
 
+(* Check that the finalisation functions will be called in the reverse order of
+   the corresponding calls to finalise. *)
 let[@inline never][@local never] test2 () =
   let r = ref 0 in
-  Gc.finalise (fun r -> assert (!r = 1); print_endline "test2: 1") r;
-  Gc.finalise (fun r -> assert (!r = 0); print_endline "test2: 2"; r := 1) r;
+  Gc.finalise (fun r ->
+    assert (!r = 1); print_endline "test2: installed 1st") r;
+  Gc.finalise (fun r ->
+    assert (!r = 0); r := 1; print_endline "test2: installed 2nd") r;
   Gc.full_major()
 
+(* The finalisation functions attached with Gc.finalise are always called
+   before the finalisation functions attached with Gc.finalise_last. *)
 let[@inline never][@local never] test3 () =
   Gc.full_major ();
-  let rec foo () =
-    let r = ref 0 in
-    Gc.finalise (fun r -> print_endline "test3: parent.1") r;
-  in
-  foo ();
+  let c = ref 0 in
   let d = Domain.spawn (fun _ ->
     let r = ref 0 in
     let r' = ref 0 in
     Gc.full_major ();
-    Gc.finalise (fun r -> print_endline "test3: child.1") r;
-    Gc.finalise_last (fun r -> print_endline "test3: child.2") r')
+    Gc.finalise_last (fun r ->
+      assert (!c = 1); c := 2;
+      print_endline "test3: child.finalise_last") r';
+    Gc.finalise (fun r ->
+      assert (!c = 0); c := 1;
+      print_endline "test3: child.finalise") r)
   in
   Domain.join d;
-  print_endline "test3: joined";
   (* Now this domain takes over the finalisers from d *)
-  Gc.full_major()
+  Gc.full_major();
+  assert (!c = 2)
 
 let _ =
   test1 ();

--- a/testsuite/tests/weak-ephe-final/finaliser2.reference
+++ b/testsuite/tests/weak-ephe-final/finaliser2.reference
@@ -1,7 +1,5 @@
 test1
-test2: 2
-test2: 1
-test3: joined
-test3: parent.1
-test3: child.1
-test3: child.2
+test2: installed 2nd
+test2: installed 1st
+test3: child.finalise
+test3: child.finalise_last


### PR DESCRIPTION
The `weak-ephe-final/finaliser2` test has been observed to fail due to scheduler non-determinism. See

* https://github.com/ocaml/ocaml/issues/10878#issuecomment-1010195188
* https://github.com/ocaml/ocaml/pull/11190#issuecomment-1099312515
* https://github.com/ocaml/ocaml/pull/11057#issuecomment-1073300087

The PR makes the test deterministic and adds comments that clarify what the intention of each of the sub-tests is. The guarantees tested are documented in the API docs of [Gc.finalise](https://ocaml.org/api/Gc.html#VALfinalise) and [Gc.finalise_last](https://ocaml.org/api/Gc.html#VALfinalise_last). 