### PR TITLE
Fix finaliser2.ml test again

### DIFF
--- a/testsuite/tests/weak-ephe-final/finaliser2.ml
+++ b/testsuite/tests/weak-ephe-final/finaliser2.ml
@@ -1,4 +1,9 @@
-(* TEST *)
+(* TEST
+* hasunix
+include unix
+** bytecode
+** native
+*)
 
 let () = Out_channel.set_buffered stdout false
 
@@ -41,6 +46,7 @@ let[@inline never][@local never] test3 () =
       print_endline "test3: child.finalise") r)
   in
   Domain.join d;
+  Unix.sleep 1;
   (* Now this domain takes over the finalisers from d *)
   Gc.full_major();
   assert (!c = 2)


### PR DESCRIPTION
The PR #11201 proposed a fix for the flaky `finaliser2.ml` test. While the PR fixed the problem, the concurrent PR #11196 broke the test since `finaliser2.ml` made some assumptions about the implementation details of `Domain.join` which was broken by #11196. This PR fixes `finaliser2.ml` test again. 

## Diagnosis

Here is the summary of how #11196 broke the assumptions made by `finaliser2.ml`. The function `test3` in `finaliser2.ml` in `trunk` is as follows:

https://github.com/ocaml/ocaml/blob/f27d671b23f5246d37d91571eeccb802d5399a0b/testsuite/tests/weak-ephe-final/finaliser2.ml#L29-L46

The finalisers are created in the child domain. The parent domain waits for the child domain to run to completion using `Domain.join`, and then does a `Gc.full_major`. If the finalisers installed by the child domain don't get to run by the end of its execution, the runtime hands them over to a global pool of finalisers from terminated domains. At the end of the next major GC cycle, the orphaned finalisers are adopted by a running domain, which ensures that they are not dropped on the floor. Since the reference cells on which the finalisers are attached to are no longer reachable, the `Gc.full_major` ensures that the finalisers are run. 

Importantly, this makes an implicit assumption that when a `Domain.join d` returns, the finalisers of `d` have been handed over. This was ensured before PR #11196 since the joining domains are woken up **after** the finalizers are handed over. See the following snippet before PR #11196. 

https://github.com/ocaml/ocaml/blob/949e2626c22b5fe8159cb29d47207d5621eabf90/runtime/domain.c#L1104-L1108

In the above, `domain_terminate` hands over the pending finalisers.

In PR #11196, `Doamin.join` simplified such that the waiting domains are woken up in the OCaml code, **before** calling `domain_terminate`. `Domain.join` logic is part of the `ml_values->callback`. Now, there is a possibility that `Gc.full_major` can finish before the child has had a chance to call `domain_terminate` and hand over finalisers. Since the finalisers have not executed yet, this causes the assertion on line number 46 to fail.

My diagnosis is that `finaliser2.ml` was making an implicit assumption about the undocumented implementation detail of `Domain.join`, which was broken by PR #11196. 

## Fix

Since there is no way to know when the child domain has completed the `domain_terminate` where finalisers are handed over, the fix is to `Unix.sleep` for one second after `Domain.join` on the parent domain. The `Unix.sleep 1` maximizes the chance of the child domain completing `domain_terminate` and makes the test more robust. 

I was not able to recreate the CI failure on any of my machines. But I was able to recreate the failure repeatedly by accessing the CI machine. I tested the fix for 1000 runs and I didn't observe any failures of this test.

I understand that the fix may not be to everyone's liking since there is still a minuscule chance that the child domain just doesn't get scheduled for a whole second. I am of the opinion that the test itself is worth keeping since this is the only test that ensures that finalisers from the terminated domains are not dropped on the floor.

The higher-level question is, now that we have scheduler non-determinism, do we think about a way of marking certain tests as `may fail` and rerun them on failure, possibly a fixed number of times? Of course, we could change the test itself to run the function `test3` a fixed number of times and then report failure only if none of the runs pass? I can split this discussion into its own issue if there is interest (and isn't a desk reject). 

(CC @gasche @gadmm) 