### PR TITLE
Make `caml_domain_stop_hook` a public timing hook

### DIFF
--- a/Changes
+++ b/Changes
@@ -23,9 +23,16 @@ Working version
 
 - #10965: `caml_fatal_error_hook`, GC timing hooks, and
   `caml_scan_roots_hook` are now atomic variables. Restore GC timing
-  hooks.
+  hooks in multicore.
   (Guillaume Munch-Maccagnoni, review by Enguerrand Decorne, Xavier
   Leroy, Gabriel Scherer, and KC Sivaramakrishnan)
+
+- #11209: Add a public and thread-safe timing hook running at domain
+  termination, after this domain has stopped running any OCaml code:
+  `caml_domain_terminated_hook`. This can be useful for implementing
+  domain-local state in C.
+  (Guillaume Munch-Maccagnoni, review by Xavier Leroy and Gabriel
+  Scherer)
 
 - #10875: Add option to allocate stacks with mmap(MAP_STACK) instead of malloc.
   This is exposed via a configure --enable-mmap-map-stack option, and is

--- a/runtime/caml/misc.h
+++ b/runtime/caml/misc.h
@@ -184,10 +184,17 @@ CAMLdeprecated_typedef(addr, char *);
 extern "C" {
 #endif
 
-/* GC timing hooks. These can be assigned by the user. These hooks
-   must not allocate, change any heap value, nor call OCaml code. They
-   can obtain the domain id with Caml_state->id. These functions must
-   be reentrant. */
+/* Timing hooks. These can be assigned by the user. The functions
+   registered with these hooks must not allocate on the OCaml heap,
+   change any heap value, nor call OCaml code.
+
+   The hooks should be assigned using [atomic_exchange], and the
+   previous function should be called in the new one.
+
+   Thread-safety: These functions can be called from several domains
+   at once. They must be reentrant. They can obtain an identifier of
+   the current domain with [Caml_state->id] or
+   [Caml_state->unique_id].  */
 typedef void (*caml_timing_hook) (void);
 extern _Atomic caml_timing_hook caml_major_slice_begin_hook;
 extern _Atomic caml_timing_hook caml_major_slice_end_hook;
@@ -195,6 +202,7 @@ extern _Atomic caml_timing_hook caml_minor_gc_begin_hook;
 extern _Atomic caml_timing_hook caml_minor_gc_end_hook;
 extern _Atomic caml_timing_hook caml_finalise_begin_hook;
 extern _Atomic caml_timing_hook caml_finalise_end_hook;
+extern _Atomic caml_timing_hook caml_domain_terminated_hook;
 
 #ifdef CAML_INTERNALS
 


### PR DESCRIPTION
This PR makes `caml_domain_stop_hook` a public and thread-safe hook like the current timing hook.

The stated purpose is to allow a rudimentary form of C-side _domain-local_ storage. Users would be able to declare a DLS variable as an array of size `Max_domains` of pointers allocated dynamically, and use `Caml_state->id` as an index (see the makeshift solution I [recommended here](https://discuss.ocaml.org/t/using-thread-local-memory-in-a-c-thread-invoked-from-multicore-ocaml/9552/5)). This PR makes it possible to call a clean-up function for this DLS after all OCaml code has stopped executing on this domain.

For instance, in ocaml-boxroot we would like to have per-domain pools of GC roots, and we will need to deal with the orphaning of pools on domain stop (they need to be given to foster by another domain). This needs to be done _after_ the domain has stopped running any OCaml code.

Now the boxroot project is ok for dealing with runtime internals, but I think that making it non-internal will benefit programmers.

cc @gasche

---

Frequently-asked (future) questions

Q: Do you not want a hook `caml_domain_start_hook` for symmetry?
A: This is a false symmetry. You do not use a `caml_domain_start_hook` for domain-local resource initialization because this does not initialise the DLS on _previous_ domains, and initializes it on domains where the resource is not used. Instead it should be initialized according to first usage. If someone comes up with some legitimate use for a `caml_domain_start_hook` then I can add it.

Q: Should this really be called a "timing hook" if the intended use is some serious stuff such as domain-local resource cleanup?
A: The documentation comment as well as the boilerplate (typedef, etc.) are the same as the current timing hooks, and the name `caml_timing_hook` is probably fixed for backwards-compatibility. The naming situation is not too bad, considering.