### PR TITLE
Add missing @since annotation to Gc.eventlog_resume / Fix annotation @since to Effect to 5.0.0 rather than 5.00.0

### DIFF
--- a/stdlib/effect.mli
+++ b/stdlib/effect.mli
@@ -14,7 +14,7 @@
 
 (** Effects.
 
-    @since 5.00.0 *)
+    @since 5.0 *)
 
 type _ t = ..
 (** The type of effects. *)

--- a/stdlib/gc.mli
+++ b/stdlib/gc.mli
@@ -428,7 +428,10 @@ external eventlog_resume : unit -> unit = "caml_eventlog_resume"
    and started with the environment variable OCAML_EVENTLOG_ENABLED.
    This call can be used after calling [eventlog_pause], or if the program
    was started with OCAML_EVENTLOG_ENABLED=p. (which pauses the collection of
-   traces before the first event.) *)
+   traces before the first event.)
+
+   @since 5.0
+  *)
 
 
 (** [Memprof] is a sampling engine for allocated memory words. Every


### PR DESCRIPTION
This PR is for #10996.