### PR TITLE
Refine Domain.{at_exit,at_startup,at_first_spawn,at_each_spawn} callback semantics

### DIFF
--- a/otherlibs/systhreads/thread.ml
+++ b/otherlibs/systhreads/thread.ml
@@ -86,7 +86,7 @@ let preempt_signal =
 
 let () =
   thread_initialize ();
-  Domain.at_startup thread_initialize_domain;
+  Domain.at_each_spawn thread_initialize_domain;
   Sys.set_signal preempt_signal (Sys.Signal_handle preempt);
   Callback.register "Thread.at_shutdown" (fun () ->
     thread_cleanup();

--- a/stdlib/domain.mli
+++ b/stdlib/domain.mli
@@ -38,28 +38,43 @@ val get_id : 'a t -> id
 val self : unit -> id
 (** [self ()] is the identifier of the currently running domain *)
 
-val at_first_spawn : (unit -> unit) -> unit
-(** Register the given function to be called before any domain is
-    spawned (except the initial domain) and before any function registered
-    with {!val:at_startup} is called. The functions registered with
-    [at_first_spawn] are called in 'last in, first out' order: the function
-    most recently added with [at_first_spawn] is called first.
+val before_first_spawn : (unit -> unit) -> unit
+(** [before_first_spawn f] registers [f] to be called before the first domain
+    is spawned by the program. The functions registered with
+    [before_first_spawn] are called on the main (initial) domain. The functions
+    registered with [before_first_spawn] are called in 'first in, first out'
+    order: the oldest function added with [before_first_spawn] is called first.
 
-    @raise Invalid_argument if the first domain has already been spawned. *)
+    @raise Invalid_argument if the program has already spawned a domain. *)
+
+val at_each_spawn : (unit -> unit) -> unit
+(** [at_each_spawn f] registers [f] to be called on the newly spawned domains.
+    The function [f] is executed before the callback [g] specified in [spawn g]
+    is executed. The registered functions are called in 'first in, first out'
+    order: the oldest function added with [at_each_spawn] is called first. *)
 
 val at_exit : (unit -> unit) -> unit
-(** Register the given function to be called at when a spawned domain exits.
-    This function is also registered with {!Stdlib.at_exit}. If the registered
-    function raises an exception, the exceptions are ignored. The registered
-    functions are called in 'last in, first out' order: the function most
-    recently added with [at_exit] is called first. *)
+(** [at_exit f] registers [f] to be called when the current domain exits. Note
+    that [at_exit] callbacks are domain-local and only apply to the calling
+    domain. The registered functions are called in 'last in, first out' order:
+    the function most recently added with [at_exit] is called first.
 
-val at_startup : (unit -> unit) -> unit
-(** Register the given function to be called when a domain starts. This
-    function is called before the callback specified to [spawn f] is
-    executed. The registered functions are called in 'last in, first out'
-    order: the function most recently added with [at_startup] is
-    called first. *)
+    The [at_exit] function can be used in combination with [at_each_spawn] to
+    clean up domain-local resources. Consider the following example:
+
+    {[
+let temp_file_key = Domain.DLS.new_key (fun _ ->
+  snd (Filename.open_temp_file "" ""))
+
+let _ = Domain.(at_each_spawn (fun _ ->
+  at_exit (fun _ -> close_out (DLS.get temp_file_key))))
+    ]}
+
+    The snippet above uses domain-local state ({!Domain.DLS}) to create a
+    temporary file for each domain. The [at_each_spawn] callback installs an
+    [at_exit] callback on each domain which closes the temporary file when the
+    domain terminates.
+    *)
 
 val cpu_relax : unit -> unit
 (** If busy-waiting, calling cpu_relax () between iterations
@@ -97,4 +112,4 @@ module DLS : sig
         the key [k] with value [v]. It overwrites any previous values associated
         to [k], which cannot be restored later. *)
 
-  end
+end

--- a/stdlib/format.ml
+++ b/stdlib/format.ml
@@ -1474,7 +1474,7 @@ let flush_standard_formatters () =
 
 let () = at_exit flush_standard_formatters
 
-let () = Domain.at_first_spawn (fun () ->
+let () = Domain.before_first_spawn (fun () ->
   flush_standard_formatters ();
 
   let fs = pp_get_formatter_out_functions std_formatter () in
@@ -1487,4 +1487,4 @@ let () = Domain.at_first_spawn (fun () ->
     {fs with out_string = buffered_out_string err_buf_key;
              out_flush = buffered_out_flush Stdlib.stderr err_buf_key};
 
-  Domain.at_exit flush_standard_formatters)
+  Domain.at_each_spawn (fun _ -> Domain.at_exit flush_standard_formatters))

--- a/stdlib/stdlib.ml
+++ b/stdlib/stdlib.ml
@@ -567,7 +567,11 @@ let rec at_exit f =
   let success = atomic_compare_and_set exit_function old_exit new_exit in
   if not success then at_exit f
 
-let do_at_exit () = (atomic_get exit_function) ()
+let do_domain_local_at_exit = ref (fun () -> ())
+
+let do_at_exit () =
+  (!do_domain_local_at_exit) ();
+  (atomic_get exit_function) ()
 
 let exit retcode =
   do_at_exit ();

--- a/stdlib/stdlib.mli
+++ b/stdlib/stdlib.mli
@@ -1336,13 +1336,15 @@ val ( ^^ ) :
 (** {1 Program termination} *)
 
 val exit : int -> 'a
-(** Terminate the process, returning the given status code
-   to the operating system: usually 0 to indicate no errors,
-   and a small positive integer to indicate failure.
-   All open output channels are flushed with [flush_all].
-   An implicit [exit 0] is performed each time a program
-   terminates normally.  An implicit [exit 2] is performed if the program
-   terminates early because of an uncaught exception. *)
+(** Terminate the process, returning the given status code to the operating
+    system: usually 0 to indicate no errors, and a small positive integer to
+    indicate failure. All open output channels are flushed with [flush_all].
+    The callbacks registered with {!Domain.at_exit} are called followed by
+    those registed with {!Stdlib.at_exit}.
+
+    An implicit [exit 0] is performed each time a program terminates normally.
+    An implicit [exit 2] is performed if the program terminates early because
+    of an uncaught exception. *)
 
 val at_exit : (unit -> unit) -> unit
 (** Register the given function to be called at program termination
@@ -1364,6 +1366,8 @@ val valid_float_lexem : string -> string
 val unsafe_really_input : in_channel -> bytes -> int -> int -> unit
 
 val do_at_exit : unit -> unit
+
+val do_domain_local_at_exit : (unit -> unit) ref
 
 (**/**)
 

--- a/testsuite/tests/basic/patmatch_for_multiple.ml
+++ b/testsuite/tests/basic/patmatch_for_multiple.ml
@@ -26,15 +26,15 @@ match (3, 2, 1) with
 | _ -> false
 ;;
 [%%expect{|
-(let (*match*/274 = 3 *match*/275 = 2 *match*/276 = 1)
+(let (*match*/275 = 3 *match*/276 = 2 *match*/277 = 1)
   (catch
     (catch
-      (catch (if (!= *match*/275 3) (exit 3) (exit 1)) with (3)
-        (if (!= *match*/274 1) (exit 2) (exit 1)))
+      (catch (if (!= *match*/276 3) (exit 3) (exit 1)) with (3)
+        (if (!= *match*/275 1) (exit 2) (exit 1)))
      with (2) 0)
    with (1) 1))
-(let (*match*/274 = 3 *match*/275 = 2 *match*/276 = 1)
-  (catch (if (!= *match*/275 3) (if (!= *match*/274 1) 0 (exit 1)) (exit 1))
+(let (*match*/275 = 3 *match*/276 = 2 *match*/277 = 1)
+  (catch (if (!= *match*/276 3) (if (!= *match*/275 1) 0 (exit 1)) (exit 1))
    with (1) 1))
 - : bool = false
 |}];;
@@ -47,26 +47,26 @@ match (3, 2, 1) with
 | _ -> false
 ;;
 [%%expect{|
-(let (*match*/279 = 3 *match*/280 = 2 *match*/281 = 1)
+(let (*match*/280 = 3 *match*/281 = 2 *match*/282 = 1)
   (catch
     (catch
       (catch
-        (if (!= *match*/280 3) (exit 6)
-          (let (x/283 =a (makeblock 0 *match*/279 *match*/280 *match*/281))
-            (exit 4 x/283)))
+        (if (!= *match*/281 3) (exit 6)
+          (let (x/284 =a (makeblock 0 *match*/280 *match*/281 *match*/282))
+            (exit 4 x/284)))
        with (6)
-        (if (!= *match*/279 1) (exit 5)
-          (let (x/282 =a (makeblock 0 *match*/279 *match*/280 *match*/281))
-            (exit 4 x/282))))
+        (if (!= *match*/280 1) (exit 5)
+          (let (x/283 =a (makeblock 0 *match*/280 *match*/281 *match*/282))
+            (exit 4 x/283))))
      with (5) 0)
-   with (4 x/277) (seq (ignore x/277) 1)))
-(let (*match*/279 = 3 *match*/280 = 2 *match*/281 = 1)
+   with (4 x/278) (seq (ignore x/278) 1)))
+(let (*match*/280 = 3 *match*/281 = 2 *match*/282 = 1)
   (catch
-    (if (!= *match*/280 3)
-      (if (!= *match*/279 1) 0
-        (exit 4 (makeblock 0 *match*/279 *match*/280 *match*/281)))
-      (exit 4 (makeblock 0 *match*/279 *match*/280 *match*/281)))
-   with (4 x/277) (seq (ignore x/277) 1)))
+    (if (!= *match*/281 3)
+      (if (!= *match*/280 1) 0
+        (exit 4 (makeblock 0 *match*/280 *match*/281 *match*/282)))
+      (exit 4 (makeblock 0 *match*/280 *match*/281 *match*/282)))
+   with (4 x/278) (seq (ignore x/278) 1)))
 - : bool = false
 |}];;
 
@@ -76,8 +76,8 @@ let _ = fun a b ->
   | ((true, _) as _g)
   | ((false, _) as _g) -> ()
 [%%expect{|
-(function a/284[int] b/285 : int 0)
-(function a/284[int] b/285 : int 0)
+(function a/285[int] b/286 : int 0)
+(function a/285[int] b/286 : int 0)
 - : bool -> 'a -> unit = <fun>
 |}];;
 
@@ -96,8 +96,8 @@ let _ = fun a b -> match a, b with
 | (false, _) as p -> p
 (* outside, trivial *)
 [%%expect {|
-(function a/288[int] b/289 (let (p/290 =a (makeblock 0 a/288 b/289)) p/290))
-(function a/288[int] b/289 (makeblock 0 a/288 b/289))
+(function a/289[int] b/290 (let (p/291 =a (makeblock 0 a/289 b/290)) p/291))
+(function a/289[int] b/290 (makeblock 0 a/289 b/290))
 - : bool -> 'a -> bool * 'a = <fun>
 |}]
 
@@ -106,8 +106,8 @@ let _ = fun a b -> match a, b with
 | ((false, _) as p) -> p
 (* inside, trivial *)
 [%%expect{|
-(function a/292[int] b/293 (let (p/294 =a (makeblock 0 a/292 b/293)) p/294))
-(function a/292[int] b/293 (makeblock 0 a/292 b/293))
+(function a/293[int] b/294 (let (p/295 =a (makeblock 0 a/293 b/294)) p/295))
+(function a/293[int] b/294 (makeblock 0 a/293 b/294))
 - : bool -> 'a -> bool * 'a = <fun>
 |}];;
 
@@ -116,11 +116,11 @@ let _ = fun a b -> match a, b with
 | (false as x, _) as p -> x, p
 (* outside, simple *)
 [%%expect {|
-(function a/298[int] b/299
-  (let (x/300 =a[int] a/298 p/301 =a (makeblock 0 a/298 b/299))
-    (makeblock 0 (int,*) x/300 p/301)))
-(function a/298[int] b/299
-  (makeblock 0 (int,*) a/298 (makeblock 0 a/298 b/299)))
+(function a/299[int] b/300
+  (let (x/301 =a[int] a/299 p/302 =a (makeblock 0 a/299 b/300))
+    (makeblock 0 (int,*) x/301 p/302)))
+(function a/299[int] b/300
+  (makeblock 0 (int,*) a/299 (makeblock 0 a/299 b/300)))
 - : bool -> 'a -> bool * (bool * 'a) = <fun>
 |}]
 
@@ -129,11 +129,11 @@ let _ = fun a b -> match a, b with
 | ((false as x, _) as p) -> x, p
 (* inside, simple *)
 [%%expect {|
-(function a/304[int] b/305
-  (let (x/306 =a[int] a/304 p/307 =a (makeblock 0 a/304 b/305))
-    (makeblock 0 (int,*) x/306 p/307)))
-(function a/304[int] b/305
-  (makeblock 0 (int,*) a/304 (makeblock 0 a/304 b/305)))
+(function a/305[int] b/306
+  (let (x/307 =a[int] a/305 p/308 =a (makeblock 0 a/305 b/306))
+    (makeblock 0 (int,*) x/307 p/308)))
+(function a/305[int] b/306
+  (makeblock 0 (int,*) a/305 (makeblock 0 a/305 b/306)))
 - : bool -> 'a -> bool * (bool * 'a) = <fun>
 |}]
 
@@ -142,15 +142,15 @@ let _ = fun a b -> match a, b with
 | (false, x) as p -> x, p
 (* outside, complex *)
 [%%expect{|
-(function a/314[int] b/315[int]
-  (if a/314
-    (let (x/316 =a[int] a/314 p/317 =a (makeblock 0 a/314 b/315))
-      (makeblock 0 (int,*) x/316 p/317))
-    (let (x/318 =a b/315 p/319 =a (makeblock 0 a/314 b/315))
-      (makeblock 0 (int,*) x/318 p/319))))
-(function a/314[int] b/315[int]
-  (if a/314 (makeblock 0 (int,*) a/314 (makeblock 0 a/314 b/315))
-    (makeblock 0 (int,*) b/315 (makeblock 0 a/314 b/315))))
+(function a/315[int] b/316[int]
+  (if a/315
+    (let (x/317 =a[int] a/315 p/318 =a (makeblock 0 a/315 b/316))
+      (makeblock 0 (int,*) x/317 p/318))
+    (let (x/319 =a b/316 p/320 =a (makeblock 0 a/315 b/316))
+      (makeblock 0 (int,*) x/319 p/320))))
+(function a/315[int] b/316[int]
+  (if a/315 (makeblock 0 (int,*) a/315 (makeblock 0 a/315 b/316))
+    (makeblock 0 (int,*) b/316 (makeblock 0 a/315 b/316))))
 - : bool -> bool -> bool * (bool * bool) = <fun>
 |}]
 
@@ -160,19 +160,19 @@ let _ = fun a b -> match a, b with
   -> x, p
 (* inside, complex *)
 [%%expect{|
-(function a/320[int] b/321[int]
+(function a/321[int] b/322[int]
   (catch
-    (if a/320
-      (let (x/328 =a[int] a/320 p/329 =a (makeblock 0 a/320 b/321))
-        (exit 10 x/328 p/329))
-      (let (x/326 =a b/321 p/327 =a (makeblock 0 a/320 b/321))
-        (exit 10 x/326 p/327)))
-   with (10 x/322[int] p/323) (makeblock 0 (int,*) x/322 p/323)))
-(function a/320[int] b/321[int]
+    (if a/321
+      (let (x/329 =a[int] a/321 p/330 =a (makeblock 0 a/321 b/322))
+        (exit 10 x/329 p/330))
+      (let (x/327 =a b/322 p/328 =a (makeblock 0 a/321 b/322))
+        (exit 10 x/327 p/328)))
+   with (10 x/323[int] p/324) (makeblock 0 (int,*) x/323 p/324)))
+(function a/321[int] b/322[int]
   (catch
-    (if a/320 (exit 10 a/320 (makeblock 0 a/320 b/321))
-      (exit 10 b/321 (makeblock 0 a/320 b/321)))
-   with (10 x/322[int] p/323) (makeblock 0 (int,*) x/322 p/323)))
+    (if a/321 (exit 10 a/321 (makeblock 0 a/321 b/322))
+      (exit 10 b/322 (makeblock 0 a/321 b/322)))
+   with (10 x/323[int] p/324) (makeblock 0 (int,*) x/323 p/324)))
 - : bool -> bool -> bool * (bool * bool) = <fun>
 |}]
 
@@ -185,15 +185,15 @@ let _ = fun a b -> match a, b with
 | (false as x, _) as p -> x, p
 (* outside, onecase *)
 [%%expect {|
-(function a/330[int] b/331[int]
-  (if a/330
-    (let (x/332 =a[int] a/330 _p/333 =a (makeblock 0 a/330 b/331))
-      (makeblock 0 (int,*) x/332 [0: 1 1]))
-    (let (x/334 =a[int] a/330 p/335 =a (makeblock 0 a/330 b/331))
-      (makeblock 0 (int,*) x/334 p/335))))
-(function a/330[int] b/331[int]
-  (if a/330 (makeblock 0 (int,*) a/330 [0: 1 1])
-    (makeblock 0 (int,*) a/330 (makeblock 0 a/330 b/331))))
+(function a/331[int] b/332[int]
+  (if a/331
+    (let (x/333 =a[int] a/331 _p/334 =a (makeblock 0 a/331 b/332))
+      (makeblock 0 (int,*) x/333 [0: 1 1]))
+    (let (x/335 =a[int] a/331 p/336 =a (makeblock 0 a/331 b/332))
+      (makeblock 0 (int,*) x/335 p/336))))
+(function a/331[int] b/332[int]
+  (if a/331 (makeblock 0 (int,*) a/331 [0: 1 1])
+    (makeblock 0 (int,*) a/331 (makeblock 0 a/331 b/332))))
 - : bool -> bool -> bool * (bool * bool) = <fun>
 |}]
 
@@ -202,11 +202,11 @@ let _ = fun a b -> match a, b with
 | ((false as x, _) as p) -> x, p
 (* inside, onecase *)
 [%%expect{|
-(function a/336[int] b/337
-  (let (x/338 =a[int] a/336 p/339 =a (makeblock 0 a/336 b/337))
-    (makeblock 0 (int,*) x/338 p/339)))
-(function a/336[int] b/337
-  (makeblock 0 (int,*) a/336 (makeblock 0 a/336 b/337)))
+(function a/337[int] b/338
+  (let (x/339 =a[int] a/337 p/340 =a (makeblock 0 a/337 b/338))
+    (makeblock 0 (int,*) x/339 p/340)))
+(function a/337[int] b/338
+  (makeblock 0 (int,*) a/337 (makeblock 0 a/337 b/338)))
 - : bool -> 'a -> bool * (bool * 'a) = <fun>
 |}]
 
@@ -223,14 +223,14 @@ let _ =fun a b -> match a, b with
 | (_, _) as p -> p
 (* outside, tuplist *)
 [%%expect {|
-(function a/349[int] b/350
+(function a/350[int] b/351
   (catch
-    (if a/349 (if b/350 (let (p/351 =a (field_imm 0 b/350)) p/351) (exit 12))
+    (if a/350 (if b/351 (let (p/352 =a (field_imm 0 b/351)) p/352) (exit 12))
       (exit 12))
-   with (12) (let (p/352 =a (makeblock 0 a/349 b/350)) p/352)))
-(function a/349[int] b/350
-  (catch (if a/349 (if b/350 (field_imm 0 b/350) (exit 12)) (exit 12))
-   with (12) (makeblock 0 a/349 b/350)))
+   with (12) (let (p/353 =a (makeblock 0 a/350 b/351)) p/353)))
+(function a/350[int] b/351
+  (catch (if a/350 (if b/351 (field_imm 0 b/351) (exit 12)) (exit 12))
+   with (12) (makeblock 0 a/350 b/351)))
 - : bool -> bool tuplist -> bool * bool tuplist = <fun>
 |}]
 
@@ -239,20 +239,20 @@ let _ = fun a b -> match a, b with
 | ((_, _) as p) -> p
 (* inside, tuplist *)
 [%%expect{|
-(function a/353[int] b/354
+(function a/354[int] b/355
   (catch
     (catch
-      (if a/353
-        (if b/354 (let (p/358 =a (field_imm 0 b/354)) (exit 13 p/358))
+      (if a/354
+        (if b/355 (let (p/359 =a (field_imm 0 b/355)) (exit 13 p/359))
           (exit 14))
         (exit 14))
-     with (14) (let (p/357 =a (makeblock 0 a/353 b/354)) (exit 13 p/357)))
-   with (13 p/355) p/355))
-(function a/353[int] b/354
+     with (14) (let (p/358 =a (makeblock 0 a/354 b/355)) (exit 13 p/358)))
+   with (13 p/356) p/356))
+(function a/354[int] b/355
   (catch
     (catch
-      (if a/353 (if b/354 (exit 13 (field_imm 0 b/354)) (exit 14)) (exit 14))
-     with (14) (exit 13 (makeblock 0 a/353 b/354)))
-   with (13 p/355) p/355))
+      (if a/354 (if b/355 (exit 13 (field_imm 0 b/355)) (exit 14)) (exit 14))
+     with (14) (exit 13 (makeblock 0 a/354 b/355)))
+   with (13 p/356) p/356))
 - : bool -> bool tuplist -> bool * bool tuplist = <fun>
 |}]

--- a/testsuite/tests/generalized-open/gpr1506.ml
+++ b/testsuite/tests/generalized-open/gpr1506.ml
@@ -103,9 +103,9 @@ include struct open struct type t = T end let x = T end
 Line 1, characters 15-41:
 1 | include struct open struct type t = T end let x = T end
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The type t/337 introduced by this open appears in the signature
+Error: The type t/338 introduced by this open appears in the signature
        Line 1, characters 46-47:
-         The value x has no valid type if t/337 is hidden
+         The value x has no valid type if t/338 is hidden
 |}];;
 
 module A = struct
@@ -123,9 +123,9 @@ Lines 3-6, characters 4-7:
 4 |       type t = T
 5 |       let x = T
 6 |     end
-Error: The type t/342 introduced by this open appears in the signature
+Error: The type t/343 introduced by this open appears in the signature
        Line 7, characters 8-9:
-         The value y has no valid type if t/342 is hidden
+         The value y has no valid type if t/343 is hidden
 |}];;
 
 module A = struct
@@ -142,9 +142,9 @@ Lines 3-5, characters 4-7:
 3 | ....open struct
 4 |       type t = T
 5 |     end
-Error: The type t/347 introduced by this open appears in the signature
+Error: The type t/348 introduced by this open appears in the signature
        Line 6, characters 8-9:
-         The value y has no valid type if t/347 is hidden
+         The value y has no valid type if t/348 is hidden
 |}]
 
 (* It was decided to not allow this anymore. *)

--- a/testsuite/tests/shapes/comp_units.ml
+++ b/testsuite/tests/shapes/comp_units.ml
@@ -25,7 +25,7 @@ module Mproj = Unit
 module F (X : sig type t end) = X
 [%%expect{|
 {
- "F"[module] -> Abs<.4>(X/277, X/277<.3>);
+ "F"[module] -> Abs<.4>(X/278, X/278<.3>);
  }
 module F : functor (X : sig type t end) -> sig type t = X.t end
 |}]

--- a/testsuite/tests/shapes/functors.ml
+++ b/testsuite/tests/shapes/functors.ml
@@ -17,7 +17,7 @@ module type S = sig type t val x : t end
 module Falias (X : S) = X
 [%%expect{|
 {
- "Falias"[module] -> Abs<.4>(X/279, X/279<.3>);
+ "Falias"[module] -> Abs<.4>(X/280, X/280<.3>);
  }
 module Falias : functor (X : S) -> sig type t = X.t val x : t end
 |}]
@@ -29,10 +29,10 @@ end
 {
  "Finclude"[module] ->
      Abs<.6>
-        (X/283,
+        (X/284,
          {
-          "t"[type] -> X/283<.5> . "t"[type];
-          "x"[value] -> X/283<.5> . "x"[value];
+          "t"[type] -> X/284<.5> . "t"[type];
+          "x"[value] -> X/284<.5> . "x"[value];
           });
  }
 module Finclude : functor (X : S) -> sig type t = X.t val x : t end
@@ -45,7 +45,7 @@ end
 [%%expect{|
 {
  "Fredef"[module] ->
-     Abs<.10>(X/290, {
+     Abs<.10>(X/291, {
                       "t"[type] -> <.8>;
                       "x"[value] -> <.9>;
                       });
@@ -223,8 +223,8 @@ module Big_to_small1 : B2S = functor (X : Big) -> X
 [%%expect{|
 {
  "Big_to_small1"[module] ->
-     Abs<.40>(X/385, {<.39>
-                      "t"[type] -> X/385<.39> . "t"[type];
+     Abs<.40>(X/386, {<.39>
+                      "t"[type] -> X/386<.39> . "t"[type];
                       });
  }
 module Big_to_small1 : B2S
@@ -234,8 +234,8 @@ module Big_to_small2 : B2S = functor (X : Big) -> struct include X end
 [%%expect{|
 {
  "Big_to_small2"[module] ->
-     Abs<.42>(X/388, {
-                      "t"[type] -> X/388<.41> . "t"[type];
+     Abs<.42>(X/389, {
+                      "t"[type] -> X/389<.41> . "t"[type];
                       });
  }
 module Big_to_small2 : B2S

--- a/testsuite/tests/shapes/open_arg.ml
+++ b/testsuite/tests/shapes/open_arg.ml
@@ -22,7 +22,7 @@ end = struct end
 
 [%%expect{|
 {
- "Make"[module] -> Abs<.3>(I/279, {
+ "Make"[module] -> Abs<.3>(I/280, {
                                    });
  }
 module Make : functor (I : sig end) -> sig end

--- a/testsuite/tests/shapes/recmodules.ml
+++ b/testsuite/tests/shapes/recmodules.ml
@@ -43,8 +43,8 @@ and B : sig
 end = B
 [%%expect{|
 {
- "A"[module] -> A/302<.11>;
- "B"[module] -> B/303<.12>;
+ "A"[module] -> A/303<.11>;
+ "B"[module] -> B/304<.12>;
  }
 module rec A : sig type t = Leaf of B.t end
 and B : sig type t = int end
@@ -82,13 +82,13 @@ end = Set.Make(A)
  "ASet"[module] ->
      {
       "compare"[value] ->
-          CU Stdlib . "Set"[module] . "Make"[module](A/324<.19>) .
+          CU Stdlib . "Set"[module] . "Make"[module](A/325<.19>) .
           "compare"[value];
       "elt"[type] ->
-          CU Stdlib . "Set"[module] . "Make"[module](A/324<.19>) .
+          CU Stdlib . "Set"[module] . "Make"[module](A/325<.19>) .
           "elt"[type];
       "t"[type] ->
-          CU Stdlib . "Set"[module] . "Make"[module](A/324<.19>) . "t"[type];
+          CU Stdlib . "Set"[module] . "Make"[module](A/325<.19>) . "t"[type];
       };
  }
 module rec A :

--- a/testsuite/tests/shapes/rotor_example.ml
+++ b/testsuite/tests/shapes/rotor_example.ml
@@ -26,7 +26,7 @@ end
 {
  "Pair"[module] ->
      Abs<.9>
-        (X/279, Abs(Y/280, {
+        (X/280, Abs(Y/281, {
                             "t"[type] -> <.5>;
                             "to_string"[value] -> <.6>;
                             }));

--- a/testsuite/tests/typing-sigsubst/sigsubst.ml
+++ b/testsuite/tests/typing-sigsubst/sigsubst.ml
@@ -24,11 +24,11 @@ end
 Line 3, characters 2-36:
 3 |   include Comparable with type t = t
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: Illegal shadowing of included type t/284 by t/289
+Error: Illegal shadowing of included type t/285 by t/290
        Line 2, characters 2-19:
-         Type t/284 came from this include
+         Type t/285 came from this include
        Line 3, characters 2-23:
-         The value print has no valid type if t/284 is shadowed
+         The value print has no valid type if t/285 is shadowed
 |}]
 
 module type Sunderscore = sig


### PR DESCRIPTION
This PR addresses issues pointed out in #11176 and #11178. It makes the following changes:

* `Domain.at_exit` is now domain-local.
* `Domain.at_exit` also used to ignore exceptions. Now, these exceptions are surfaced as the result of domain execution (similar to how `Stdlib.at_exit` works).
* `Domain.at_startup` is renamed to `Domain.at_each_spawn`.
* `Domain.at_first_spawn` is renamed to `Domain.before_first_spawn`.
* `Domain.before_first_spawn` and `Domain.at_each_spawn` run the callbacks in FIFO order (as requested in #11178). 

The PR also adds tests to the test suite. 