### PR TITLE
Limit bit-rot in the disabled backends

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ include stdlib/StdlibModules
 
 CAMLC = $(BOOT_OCAMLC) $(BOOT_STDLIBFLAGS) -g -use-prims runtime/primitives
 CAMLOPT=$(OCAMLRUN) ./ocamlopt$(EXE) $(STDLIBFLAGS) -g -I otherlibs/dynlink
-ARCHES=amd64 i386 arm arm64 power s390x riscv
+ARCHES=amd64 arm64
 DIRS = utils parsing typing bytecomp file_formats lambda middle_end \
   middle_end/closure middle_end/flambda middle_end/flambda/base_types \
   asmcomp driver toplevel

--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ include stdlib/StdlibModules
 
 CAMLC = $(BOOT_OCAMLC) $(BOOT_STDLIBFLAGS) -g -use-prims runtime/primitives
 CAMLOPT=$(OCAMLRUN) ./ocamlopt$(EXE) $(STDLIBFLAGS) -g -I otherlibs/dynlink
-ARCHES=amd64 arm arm64 power s390x riscv
+ARCHES=amd64 i386 arm arm64 power s390x riscv
 DIRS = utils parsing typing bytecomp file_formats lambda middle_end \
   middle_end/closure middle_end/flambda middle_end/flambda/base_types \
   asmcomp driver toplevel

--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ include stdlib/StdlibModules
 
 CAMLC = $(BOOT_OCAMLC) $(BOOT_STDLIBFLAGS) -g -use-prims runtime/primitives
 CAMLOPT=$(OCAMLRUN) ./ocamlopt$(EXE) $(STDLIBFLAGS) -g -I otherlibs/dynlink
-ARCHES=amd64 arm64
+ARCHES=amd64 arm64 power s390x riscv
 DIRS = utils parsing typing bytecomp file_formats lambda middle_end \
   middle_end/closure middle_end/flambda middle_end/flambda/base_types \
   asmcomp driver toplevel

--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ include stdlib/StdlibModules
 
 CAMLC = $(BOOT_OCAMLC) $(BOOT_STDLIBFLAGS) -g -use-prims runtime/primitives
 CAMLOPT=$(OCAMLRUN) ./ocamlopt$(EXE) $(STDLIBFLAGS) -g -I otherlibs/dynlink
-ARCHES=amd64 arm64 power s390x riscv
+ARCHES=amd64 arm arm64 power s390x riscv
 DIRS = utils parsing typing bytecomp file_formats lambda middle_end \
   middle_end/closure middle_end/flambda middle_end/flambda/base_types \
   asmcomp driver toplevel

--- a/asmcomp/arm/emit.mlp
+++ b/asmcomp/arm/emit.mlp
@@ -530,12 +530,12 @@ let emit_instr env i =
         let ninstr = emit_stack_adjustment (-n) in
         env.stack_offset <- env.stack_offset + n;
         ninstr
-    | Lop(Iload(Single, addr, _mut)) when !fpu >= VFPv2 ->
-        `	flds	s14, {emit_addressing addr i.arg 0}\n`;
+    | Lop(Iload { memory_chunk = Single; addressing_mode ; _ }) when !fpu >= VFPv2 ->
+        `	flds	s14, {emit_addressing addressing_mode i.arg 0}\n`;
         `	fcvtds	{emit_reg i.res.(0)}, s14\n`; 2
-    | Lop(Iload(Double, addr, _mut)) when !fpu = Soft ->
+    | Lop(Iload { memory_chunk = Double; addressing_mode; _ }) when !fpu = Soft ->
         (* Use LDM or LDRD if possible *)
-        begin match i.res.(0), i.res.(1), addr with
+        begin match i.res.(0), i.res.(1), addressing_mode with
           {loc = Reg rt}, {loc = Reg rt2}, Iindexed 0
           when rt < rt2 ->
             `	ldm	{emit_reg i.arg.(0)}, \{{emit_reg i.res.(0)}, {emit_reg i.res.(1)}}\n`; 1
@@ -543,26 +543,26 @@ let emit_instr env i =
           when !arch >= ARMv5TE && rt mod 2 == 0 && rt2 = rt + 1 ->
             `	ldrd	{emit_reg i.res.(0)}, {emit_reg i.res.(1)}, {emit_addressing addr i.arg 0}\n`; 1
         | _ ->
-            let addr' = offset_addressing addr 4 in
+            let addressing_mode' = offset_addressing addressing_mode 4 in
             if i.res.(0).loc <> i.arg.(0).loc then begin
-              `	ldr	{emit_reg i.res.(0)}, {emit_addressing addr i.arg 0}\n`;
-              `	ldr	{emit_reg i.res.(1)}, {emit_addressing addr' i.arg 0}\n`
+              `	ldr	{emit_reg i.res.(0)}, {emit_addressing addressing_mode i.arg 0}\n`;
+              `	ldr	{emit_reg i.res.(1)}, {emit_addressing addressing_mode' i.arg 0}\n`
             end else begin
-              `	ldr	{emit_reg i.res.(1)}, {emit_addressing addr' i.arg 0}\n`;
-              `	ldr	{emit_reg i.res.(0)}, {emit_addressing addr i.arg 0}\n`
+              `	ldr	{emit_reg i.res.(1)}, {emit_addressing addressing_mode' i.arg 0}\n`;
+              `	ldr	{emit_reg i.res.(0)}, {emit_addressing addressing_mode i.arg 0}\n`
             end; 2
         end
-    | Lop(Iload(size, addr, _mut)) ->
+    | Lop(Iload { memory_chunk; addressing_mode; _ }) ->
         let r = i.res.(0) in
         let instr =
-          match size with
+          match memory_chunk with
             Byte_unsigned -> "ldrb"
           | Byte_signed -> "ldrsb"
           | Sixteen_unsigned -> "ldrh"
           | Sixteen_signed -> "ldrsh"
           | Double -> "fldd"
           | _ (* 32-bit quantities *) -> "ldr" in
-        `	{emit_string instr}	{emit_reg r}, {emit_addressing addr i.arg 0}\n`; 1
+        `	{emit_string instr}	{emit_reg r}, {emit_addressing addressing_mode i.arg 0}\n`; 1
     | Lop(Istore(Single, addr, _)) when !fpu >= VFPv2 ->
         `	fcvtsd	s14, {emit_reg i.arg.(0)}\n`;
         `	fsts	s14, {emit_addressing addr i.arg 1}\n`; 2

--- a/asmcomp/arm/emit.mlp
+++ b/asmcomp/arm/emit.mlp
@@ -730,6 +730,9 @@ let emit_instr env i =
         | _ ->
             assert false
         end
+    | Lop (Idls_get) ->
+        (* Here to maintain build *)
+        assert false
     | Lreloadretaddr ->
         let n = frame_size env in
         `	ldr	lr, [sp, #{emit_int(n-4)}]\n`; 1

--- a/asmcomp/arm/proc.ml
+++ b/asmcomp/arm/proc.ml
@@ -312,7 +312,7 @@ let destroyed_at_oper = function
     when !arch >= ARMv8 && !thumb ->
       [| phys_reg 3 |]  (* r3 destroyed *)
   | Iop(Iintoffloat | Ifloatofint
-  | Iload(Single, _, _) | Istore(Single, _, _)) ->
+  | Iload { memory_chunk = Single; _ } | Istore(Single, _, _)) ->
       [| phys_reg 107 |]            (* d7 (s14-s15) destroyed *)
   | _ -> [||]
 
@@ -336,7 +336,7 @@ let max_register_pressure = function
   | Ialloc _ -> if abi = EABI then [| 7; 0; 0 |] else [| 7; 8; 8 |]
   | Iconst_symbol _ when !Clflags.pic_code -> [| 7; 16; 32 |]
   | Iintoffloat | Ifloatofint
-  | Iload(Single, _, _) | Istore(Single, _, _) -> [| 9; 15; 31 |]
+  | Iload { memory_chunk = Single; _ } | Istore(Single, _, _) -> [| 9; 15; 31 |]
   | Iintop Imulh when !arch < ARMv6 -> [| 8; 16; 32 |]
   | _ -> [| 9; 16; 32 |]
 

--- a/asmcomp/arm/scheduling.ml
+++ b/asmcomp/arm/scheduling.ml
@@ -29,7 +29,7 @@ method oper_latency = function
   (* Loads have a latency of two cycles in general *)
     Iconst_symbol _
   | Iconst_float _
-  | Iload(_, _, _)
+  | Iload _
   | Ireload
   | Ifloatofint       (* mcr/mrc count as memory access *)
   | Iintoffloat -> 2

--- a/asmcomp/arm/selection.ml
+++ b/asmcomp/arm/selection.ml
@@ -53,7 +53,6 @@ exception Use_default
 let r1 = phys_reg 1
 let r6 = phys_reg 6
 let r7 = phys_reg 7
-let r12 = phys_reg 8
 
 let pseudoregs_for_operation op arg res =
   match op with

--- a/asmcomp/arm/selection.ml
+++ b/asmcomp/arm/selection.ml
@@ -187,7 +187,7 @@ method select_shift_arith op dbg arithop arithrevop args =
       end
 
 method private iextcall func ty_res ty_args =
-  Iextcall { func; ty_res; ty_args; alloc = false; }
+  Iextcall { func; ty_res; ty_args; alloc = false; stack_ofs = 0 }
 
 method! select_operation op args dbg =
   match (op, args) with

--- a/asmcomp/i386/CSE.ml
+++ b/asmcomp/i386/CSE.ml
@@ -29,7 +29,7 @@ method! class_of_operation op =
   (* Operations that affect the floating-point stack cannot be factored *)
   | Iconst_float _ | Inegf | Iabsf | Iaddf | Isubf | Imulf | Idivf
   | Iintoffloat | Ifloatofint
-  | Iload((Single | Double), _, _) -> Op_other
+  | Iload { memory_chunk = (Single | Double); _ } -> Op_other
   (* Specific ops *)
   | Ispecific(Ilea _) -> Op_pure
   | Ispecific(Istore_int(_, _, is_asg)) -> Op_store is_asg

--- a/asmcomp/i386/emit.mlp
+++ b/asmcomp/i386/emit.mlp
@@ -784,6 +784,9 @@ let emit_instr env fallthrough i =
       if Array.length i.arg = 2 && is_tos i.arg.(1) then
         I.fxch st1;
       emit_floatspecial s
+  | Lop (Idls_get) ->
+      (* Here to maintain build *)
+      assert false
   | Lreloadretaddr ->
       ()
   | Lreturn ->

--- a/asmcomp/i386/emit.mlp
+++ b/asmcomp/i386/emit.mlp
@@ -549,23 +549,23 @@ let emit_instr env fallthrough i =
       else I.sub (int n) esp;
       cfi_adjust_cfa_offset n;
       env.stack_offset <- env.stack_offset + n
-  | Lop(Iload(chunk, addr, _mut)) ->
+  | Lop(Iload { memory_chunk; addressing_mode; _ }) ->
       let dest = i.res.(0) in
-      begin match chunk with
+      begin match memory_chunk with
       | Word_int | Word_val | Thirtytwo_signed | Thirtytwo_unsigned ->
-          I.mov (addressing addr DWORD i 0) (reg dest)
+          I.mov (addressing addressing_mode DWORD i 0) (reg dest)
       | Byte_unsigned ->
-          I.movzx (addressing addr BYTE i 0) (reg dest)
+          I.movzx (addressing addressing_mode BYTE i 0) (reg dest)
       | Byte_signed ->
-          I.movsx (addressing addr BYTE i 0) (reg dest)
+          I.movsx (addressing addressing_mode BYTE i 0) (reg dest)
       | Sixteen_unsigned ->
-          I.movzx (addressing addr WORD i 0) (reg dest)
+          I.movzx (addressing addressing_mode WORD i 0) (reg dest)
       | Sixteen_signed ->
-          I.movsx (addressing addr WORD i 0) (reg dest)
+          I.movsx (addressing addressing_mode WORD i 0) (reg dest)
       | Single ->
-          I.fld (addressing addr REAL4 i 0)
+          I.fld (addressing addressing_mode REAL4 i 0)
       | Double ->
-          I.fld (addressing addr REAL8 i 0)
+          I.fld (addressing addressing_mode REAL8 i 0)
       end
   | Lop(Istore(chunk, addr, _)) ->
       begin match chunk with

--- a/asmcomp/i386/emit.mlp
+++ b/asmcomp/i386/emit.mlp
@@ -859,14 +859,14 @@ let emit_instr env fallthrough i =
       if trap_frame_size > 8 then
         I.sub (int (trap_frame_size - 8)) esp;
       load_domain_state edx;
-      I.push (domain_field Domain_exception_pointer RDX);
+      I.push (domain_field Domain_exn_handler RDX);
       cfi_adjust_cfa_offset trap_frame_size;
-      I.mov esp (domain_field Domain_exception_pointer RDX);
+      I.mov esp (domain_field Domain_exn_handler RDX);
       env.stack_offset <- env.stack_offset + trap_frame_size
   | Lpoptrap ->
       I.mov edx (mem32 DWORD 4 RSP);
       load_domain_state edx;
-      I.pop (domain_field Domain_exception_pointer RDX);
+      I.pop (domain_field Domain_exn_handler RDX);
       I.pop edx;
       if trap_frame_size > 8 then
         I.add (int (trap_frame_size - 8)) esp;
@@ -884,8 +884,8 @@ let emit_instr env fallthrough i =
           record_frame env Reg.Set.empty (Dbg_raise i.dbg)
       | Lambda.Raise_notrace ->
           load_domain_state ebx;
-          I.mov (domain_field Domain_exception_pointer RBX) esp;
-          I.pop (domain_field Domain_exception_pointer RBX);
+          I.mov (domain_field Domain_exn_handler RBX) esp;
+          I.pop (domain_field Domain_exn_handler RBX);
           if trap_frame_size > 8 then
             I.add (int (trap_frame_size - 8)) esp;
           I.pop ebx;

--- a/asmcomp/i386/selection.ml
+++ b/asmcomp/i386/selection.ml
@@ -133,7 +133,7 @@ let pseudoregs_for_operation op arg res =
   (* For floating-point operations and floating-point loads,
      the result is always left at the top of the floating-point stack *)
   | Iconst_float _ | Inegf | Iabsf | Iaddf | Isubf | Imulf | Idivf
-  | Ifloatofint | Iload((Single | Double ), _, _)
+  | Ifloatofint | Iload { memory_chunk = ( Single | Double ); _ }
   | Ispecific(Isubfrev | Idivfrev | Ifloatarithmem _ | Ifloatspecial _) ->
       (arg, [| tos |], false)           (* don't move it immediately *)
   (* For storing a byte, the argument must be in eax...edx.
@@ -249,13 +249,13 @@ method! select_operation op args dbg =
 
 method select_floatarith regular_op reversed_op mem_op mem_rev_op args =
   match args with
-    [arg1; Cop(Cload (chunk, _), [loc2], _)] ->
-      let (addr, arg2) = self#select_addressing chunk loc2 in
-      (Ispecific(Ifloatarithmem(chunk_double chunk, mem_op, addr)),
+    [arg1; Cop(Cload { memory_chunk; _ }, [loc2], _)] ->
+      let (addr, arg2) = self#select_addressing memory_chunk loc2 in
+      (Ispecific(Ifloatarithmem(chunk_double memory_chunk, mem_op, addr)),
                  [arg1; arg2])
-  | [Cop(Cload (chunk, _), [loc1], _); arg2] ->
-      let (addr, arg1) = self#select_addressing chunk loc1 in
-      (Ispecific(Ifloatarithmem(chunk_double chunk, mem_rev_op, addr)),
+  | [Cop(Cload { memory_chunk; _ }, [loc1], _); arg2] ->
+      let (addr, arg1) = self#select_addressing memory_chunk loc1 in
+      (Ispecific(Ifloatarithmem(chunk_double memory_chunk, mem_rev_op, addr)),
                  [arg2; arg1])
   | [arg1; arg2] ->
       (* Evaluate bigger subexpression first to minimize stack usage.
@@ -289,10 +289,10 @@ method select_push exp =
     Cconst_int (n, _) -> (Ispecific(Ipush_int(Nativeint.of_int n)), Ctuple [])
   | Cconst_natint (n, _) -> (Ispecific(Ipush_int n), Ctuple [])
   | Cconst_symbol (s, _) -> (Ispecific(Ipush_symbol s), Ctuple [])
-  | Cop(Cload ((Word_int | Word_val as chunk), _), [loc], _) ->
+  | Cop(Cload { memory_chunk = (Word_int | Word_val as chunk); _ }, [loc], _) ->
       let (addr, arg) = self#select_addressing chunk loc in
       (Ispecific(Ipush_load addr), arg)
-  | Cop(Cload (Double, _), [loc], _) ->
+  | Cop(Cload { memory_chunk = Double; _ }, [loc], _) ->
       let (addr, arg) = self#select_addressing Double loc in
       (Ispecific(Ipush_load_float addr), arg)
   | _ -> (Ispecific(Ipush), exp)

--- a/asmcomp/power/emit.mlp
+++ b/asmcomp/power/emit.mlp
@@ -470,10 +470,10 @@ module BR = Branch_relaxation.Make (struct
       size 3 (2 + tocload_size()) (2 + tocload_size())
     | Lop(Iextcall { alloc = false; _}) -> size 1 2 2
     | Lop(Istackoffset _) -> 1
-    | Lop(Iload(chunk, addr, _mut)) ->
-      if chunk = Byte_signed
-      then load_store_size addr + 1
-      else load_store_size addr
+    | Lop(Iload {memory_chunk; addressing_mode; _ }) ->
+      if memory_chunk = Byte_signed
+      then load_store_size addressing_mode + 1
+      else load_store_size addressing_mode
     | Lop(Istore(_chunk, addr, _)) -> load_store_size addr
     | Lop(Ialloc _) -> 5
     | Lop(Ispecific(Ialloc_far _)) -> 6
@@ -775,9 +775,9 @@ let emit_instr env i =
     | Lop(Istackoffset n) ->
         `	addi	1, 1, {emit_int (-n)}\n`;
         adjust_stack_offset env n
-    | Lop(Iload(chunk, addr, _mut)) ->
+    | Lop(Iload { memory_chunk; addressing_mode; _ }) ->
         let loadinstr =
-          match chunk with
+          match memory_chunk with
           | Byte_unsigned -> "lbz"
           | Byte_signed -> "lbz"
           | Sixteen_unsigned -> "lhz"
@@ -787,8 +787,8 @@ let emit_instr env i =
 	  | Word_int | Word_val -> lg
           | Single -> "lfs"
           | Double -> "lfd" in
-        emit_load_store loadinstr addr i.arg 0 i.res.(0);
-        if chunk = Byte_signed then
+        emit_load_store loadinstr addressing_mode i.arg 0 i.res.(0);
+        if memory_chunk = Byte_signed then
           `	extsb	{emit_reg i.res.(0)}, {emit_reg i.res.(0)}\n`
     | Lop(Istore(chunk, addr, _)) ->
         let storeinstr =

--- a/asmcomp/power/emit.mlp
+++ b/asmcomp/power/emit.mlp
@@ -491,6 +491,9 @@ module BR = Branch_relaxation.Make (struct
     | Lop(Iintoffloat) -> 4
     | Lop(Iopaque) -> 0
     | Lop(Ispecific _) -> 1
+    | Lop (Idls_get) ->
+        (* Here to maintain build *)
+        assert false
     | Lreloadretaddr -> 2
     | Lreturn -> 2
     | Llabel _ -> 0
@@ -890,6 +893,9 @@ let emit_instr env i =
     | Lop(Ispecific sop) ->
         let instr = name_for_specific sop in
         `	{emit_string instr}	{emit_reg i.res.(0)}, {emit_reg i.arg.(0)}, {emit_reg i.arg.(1)}, {emit_reg i.arg.(2)}\n`
+    | Lop (Idls_get) ->
+        (* Here to maintain build *)
+        assert false
     | Lreloadretaddr ->
         `	{emit_string lg}	11, {emit_int(retaddr_offset env)}(1)\n`;
         `	mtlr	11\n`

--- a/asmcomp/power/scheduling.ml
+++ b/asmcomp/power/scheduling.ml
@@ -26,7 +26,7 @@ inherit Schedgen.scheduler_generic
 
 method oper_latency = function
     Ireload -> 2
-  | Iload(_, _, _) -> 2
+  | Iload _ -> 2
   | Iconst_float _ -> 2 (* turned into a load *)
   | Iconst_symbol _ -> 1
   | Iintop(Imul | Imulh) -> 9
@@ -46,7 +46,7 @@ method! reload_retaddr_latency = 12
 
 method oper_issue_cycles = function
     Iconst_float _ | Iconst_symbol _ -> 2
-  | Iload(_, Ibased(_, _), _) -> 2
+  | Iload { addressing_mode = Ibased(_, _); _ } -> 2
   | Istore(_, Ibased(_, _), _) -> 2
   | Ialloc _ -> 4
   | Iintop(Imod) -> 40 (* assuming full stall *)

--- a/asmcomp/riscv/emit.mlp
+++ b/asmcomp/riscv/emit.mlp
@@ -438,6 +438,9 @@ let emit_instr env i =
   | Lop(Ispecific sop) ->
       let instr = name_for_specific sop in
       `	{emit_string instr}	{emit_reg i.res.(0)}, {emit_reg i.arg.(0)}, {emit_reg i.arg.(1)}, {emit_reg i.arg.(2)}\n`
+  | Lop (Idls_get) ->
+      (* Here to maintain build *)
+      assert false
   | Lreloadretaddr ->
       let n = frame_size env in
       reload_ra n

--- a/asmcomp/riscv/emit.mlp
+++ b/asmcomp/riscv/emit.mlp
@@ -313,12 +313,12 @@ let emit_instr env i =
       assert (n mod 16 = 0);
       emit_stack_adjustment (-n);
       adjust_stack_offset env n
-  | Lop(Iload(Single, Iindexed ofs, _mut)) ->
+  | Lop(Iload { memory_chunk = Single; addressing_mode = Iindexed ofs; _ } ) ->
       `	flw	{emit_reg i.res.(0)}, {emit_int ofs}({emit_reg i.arg.(0)})\n`;
       `	fcvt.d.s	{emit_reg i.res.(0)}, {emit_reg i.res.(0)}\n`
-  | Lop(Iload(chunk, Iindexed ofs, _mut)) ->
+  | Lop(Iload { memory_chunk; addressing_mode = Iindexed ofs } ) ->
       let instr =
-        match chunk with
+        match memory_chunk with
         | Byte_unsigned -> "lbu"
         | Byte_signed -> "lb"
         | Sixteen_unsigned -> "lhu"

--- a/asmcomp/s390x/emit.mlp
+++ b/asmcomp/s390x/emit.mlp
@@ -540,6 +540,9 @@ let emit_instr env i =
         assert (i.arg.(2).loc = i.res.(0).loc);
         let instr = name_for_specific sop in
         `	{emit_string instr}	{emit_reg i.res.(0)}, {emit_reg i.arg.(0)}, {emit_reg i.arg.(1)}\n`
+    | Lop (Idls_get) ->
+        (* Here to maintain build *)
+        assert false
     | Lreloadretaddr ->
         let n = frame_size env in
         `	lg	%r14, {emit_int(n - size_addr)}(%r15)\n`

--- a/asmcomp/s390x/emit.mlp
+++ b/asmcomp/s390x/emit.mlp
@@ -364,9 +364,9 @@ let emit_instr env i =
         emit_stack_adjust n;
         env.stack_offset <- env.stack_offset + n
 
-     | Lop(Iload(chunk, addr, _mut)) ->
+     | Lop(Iload { memory_chunk; addressing_mode; _ }) ->
         let loadinstr =
-          match chunk with
+          match memory_chunk with
             Byte_unsigned -> "llgc"
           | Byte_signed -> "lgb"
           | Sixteen_unsigned -> "llgh"
@@ -376,8 +376,8 @@ let emit_instr env i =
           | Word_int | Word_val -> "lg"
           | Single -> "ley"
           | Double -> "ldy" in
-        emit_load_store loadinstr addr i.arg 0 i.res.(0);
-        if chunk = Single then
+        emit_load_store loadinstr addressing_mode i.arg 0 i.res.(0);
+        if memory_chunk = Single then
           `	ldebr	{emit_reg i.res.(0)}, {emit_reg i.res.(0)}\n`
 
     | Lop(Istore(Single, addr, _)) ->

--- a/asmcomp/s390x/scheduling.ml
+++ b/asmcomp/s390x/scheduling.ml
@@ -35,7 +35,7 @@ inherit Schedgen.scheduler_generic
 
 method oper_latency = function
     Ireload -> 4
-  | Iload(_, _, _) -> 4
+  | Iload _ -> 4
   | Iconst_float _ -> 4 (* turned into a load *)
   | Iintop(Imul) -> 10
   | Iintop_imm(Imul, _) -> 10


### PR DESCRIPTION
While getting the other-checks stage to pass again in #11183, I disabled the CI checks for the presently disabled native code backends. While they may not be working, I think it's probably worth having `make check_all_arches` at least limit the bit-rot by ensuring that they continue to be compile, even if the code they produce is nonsense.

This PR:
- Refactors uses of `Iload` for the changes in #10943 in all the disabled backends
- Removes a rebase artefact that accidentally reverted part of #502 in the arm backend
- Fixes the use of `Iextcall` in the arm emitter for (type) compatibility with multicore
- Applies the renaming of `Domainstate.Domain_exception_pointer` to `Domainstate.Domain_exn_handler` between #8713 and the multicore merge to the i386 backend
- Adds `assert false` placeholders for `Idls_get` to all the disabled backends

Together, these changes restore `make check_all_arches`