### PR TITLE
Tidy-up the sigmask code in domain.c

### DIFF
--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -923,7 +923,7 @@ struct domain_startup_params {
   struct domain_ml_values* ml_values; /* in */
   dom_internal* newdom; /* out */
   uintnat unique_id; /* out */
-#ifndef _WIN32
+#ifdef POSIX_SIGNALS
   /* signal mask to set after it is safe to do so */
   sigset_t* mask; /* in */
 #endif
@@ -998,7 +998,7 @@ static void* backup_thread_func(void* v)
 static void install_backup_thread (dom_internal* di)
 {
   int err;
-#ifndef _WIN32
+#ifdef POSIX_SIGNALS
   sigset_t mask, old_mask;
 #endif
 
@@ -1013,7 +1013,7 @@ static void install_backup_thread (dom_internal* di)
       caml_plat_lock (&di->domain_lock);
     }
 
-#ifndef _WIN32
+#ifdef POSIX_SIGNALS
     /* No signals on the backup thread */
     sigfillset(&mask);
     pthread_sigmask(SIG_BLOCK, &mask, &old_mask);
@@ -1022,7 +1022,7 @@ static void install_backup_thread (dom_internal* di)
     atomic_store_rel(&di->backup_thread_msg, BT_ENTERING_OCAML);
     err = pthread_create(&di->backup_thread, 0, backup_thread_func, (void*)di);
 
-#ifndef _WIN32
+#ifdef POSIX_SIGNALS
     pthread_sigmask(SIG_SETMASK, &old_mask, NULL);
 #endif
 
@@ -1055,7 +1055,7 @@ static void* domain_thread_func(void* v)
 {
   struct domain_startup_params* p = v;
   struct domain_ml_values *ml_values = p->ml_values;
-#ifndef _WIN32
+#ifdef POSIX_SIGNALS
   sigset_t mask = *(p->mask);
 #endif
 
@@ -1078,7 +1078,7 @@ static void* domain_thread_func(void* v)
   if (domain_self) {
     install_backup_thread(domain_self);
 
-#ifndef _WIN32
+#ifdef POSIX_SIGNALS
     /* It is now safe for us to handle signals */
     pthread_sigmask(SIG_SETMASK, &mask, NULL);
 #endif
@@ -1113,7 +1113,7 @@ CAMLprim value caml_domain_spawn(value callback, value mutex)
   struct domain_startup_params p;
   pthread_t th;
   int err;
-#ifndef _WIN32
+#ifdef POSIX_SIGNALS
   sigset_t mask, old_mask;
 #endif
 
@@ -1133,14 +1133,13 @@ CAMLprim value caml_domain_spawn(value callback, value mutex)
    pthread_create inherits the current signals set, and we want to avoid a
    signal handler being triggered in the new domain before the domain_state is
    fully populated. */
-#ifndef _WIN32
-  /* FIXME Spawning threads -> unix.c/win32.c */
+#ifdef POSIX_SIGNALS
   sigfillset(&mask);
   pthread_sigmask(SIG_BLOCK, &mask, &old_mask);
   p.mask = &old_mask;
 #endif
   err = pthread_create(&th, 0, domain_thread_func, (void*)&p);
-#ifndef _WIN32
+#ifdef POSIX_SIGNALS
   /* We can restore the signal mask we had initially now. */
   pthread_sigmask(SIG_SETMASK, &old_mask, NULL);
 #endif


### PR DESCRIPTION
The two commits are best reviewed separately - the second commit is optional.

Following conversation in https://github.com/ocaml/ocaml/pull/11214#discussion_r857171698, this switches the `#ifdef` for the signal masking code to check for our `POSIX_SIGNALS` macro rather than `#ifndef _WIN32`.

There are three places where this happens - `domain_thread_func` is subtle, and is best left as-is. The other two both require executing some code with all signals blocked, and the `#ifdef` soup is slightly lowered by having a macro which does this.