### PR TITLE
Improve error message when unmarshalling using old custom block format

### DIFF
--- a/Changes
+++ b/Changes
@@ -268,6 +268,12 @@ OCaml 5.0
   (Guillaume Munch-Maccagnoni, review by Sadiq Jaffer, Xavier Leroy and
   Gabriel Scherer)
 
+- #11223: The serialization format of custom blocks changed in 4.08,
+  but the deserializer would still support the pre-4.08 format.  OCaml
+  5.x removed support for this old format; provide a clear error message
+  in this case.
+  (Hugo Heuzard, review by Gabriel Scherer)
+
 ### Code generation and optimizations:
 
 - #10972: ARM64 multicore support: OCaml & C stack separation;

--- a/runtime/caml/intext.h
+++ b/runtime/caml/intext.h
@@ -74,7 +74,7 @@
 #define CODE_DOUBLE_ARRAY64_LITTLE 0x17
 #define CODE_CODEPOINTER 0x10
 #define CODE_INFIXPOINTER 0x11
-/* #define CODE_CUSTOM 0x12  -- no longer supported */
+#define OLD_CODE_CUSTOM 0x12  // no longer supported
 #define CODE_CUSTOM_LEN 0x18
 #define CODE_CUSTOM_FIXED 0x19
 

--- a/runtime/intern.c
+++ b/runtime/intern.c
@@ -596,6 +596,11 @@ static void intern_rec(struct caml_intern_state* s,
         sp->arg = ofs;
         ReadItems(s, dest, 1);
         continue;  /* with next iteration of main loop, skipping *dest = v */
+      case OLD_CODE_CUSTOM:
+        intern_cleanup(s);
+        caml_failwith("input_value: custom blocks serialized with "
+                      "OCaml 4.08.0 (or prior) are no longer supported");
+        break;
       case CODE_CUSTOM_LEN:
       case CODE_CUSTOM_FIXED: {
         uintnat expected_size, temp_size;


### PR DESCRIPTION
One currently get `Failure "input_value: ill-formed message"` when un-marshaling  a custom block serialized with OCaml < 4.08. 