### PR TITLE
stdlib concurrency safety documentation, part two: global states

### DIFF
--- a/stdlib/arg.mli
+++ b/stdlib/arg.mli
@@ -71,6 +71,11 @@
     is called with an empty list.
 *)
 
+[@@@alert unsynchronized_access
+    "The Arg module relies on a mutable global state, parsing functions should \
+     only be called from a single domain."
+]
+
 type spec =
   | Unit of (unit -> unit)     (** Call the function with unit argument *)
   | Bool of (bool -> unit)     (** Call the function with a bool argument *)

--- a/stdlib/gc.mli
+++ b/stdlib/gc.mli
@@ -268,10 +268,16 @@ external minor_words : unit -> (float [@unboxed])
     @since 4.04 *)
 
 external get : unit -> control = "caml_gc_get"
+[@@alert unsynchronized_access
+    "GC parameters are a mutable global state."
+]
 (** Return the current values of the GC parameters in a [control] record. *)
 
 external set : control -> unit = "caml_gc_set"
-(** [set r] changes the GC parameters according to the [control] record [r].
+[@@alert unsynchronized_access
+    "GC parameters are a mutable global state."
+]
+ (** [set r] changes the GC parameters according to the [control] record [r].
    The normal usage is: [Gc.set { (Gc.get()) with Gc.verbose = 0x00d }] *)
 
 external minor : unit -> unit = "caml_gc_minor"

--- a/stdlib/sys.mli
+++ b/stdlib/sys.mli
@@ -126,7 +126,10 @@ external readdir : string -> string array = "caml_sys_read_directory"
    appear in alphabetical order. *)
 
 val interactive : bool ref
-(** This reference is initially set to [false] in standalone
+[@@alert unsynchronized_access
+    "The interactive status is a mutable global state."
+]
+ (** This reference is initially set to [false] in standalone
    programs and to [true] if the code is being executed under
    the interactive toplevel system [ocaml]. *)
 
@@ -367,6 +370,9 @@ type ocaml_release_info = {
 val ocaml_release : ocaml_release_info
 
 val enable_runtime_warnings: bool -> unit
+[@@alert unsynchronized_access
+    "The status of runtime warnings is a mutable global state."
+]
 (** Control whether the OCaml runtime system can emit warnings
     on stderr.  Currently, the only supported warning is triggered
     when a channel created by [open_*] functions is finalized without
@@ -375,7 +381,10 @@ val enable_runtime_warnings: bool -> unit
     @since 4.03 *)
 
 val runtime_warnings_enabled: unit -> bool
-(** Return whether runtime warnings are currently enabled.
+[@@alert unsynchronized_access
+    "The status of runtime warnings is a mutable global state."
+]
+ (** Return whether runtime warnings are currently enabled.
 
     @since 4.03 *)
 


### PR DESCRIPTION
Following #11193 and #11225, this PR adds a new alert in the standard library  for global mutable states that are expected to be fully handled by users. More precisely, this PR adds a alert for

- the whole `Arg` module: the arguments of the program should be parsed only once.
- the parameters of the `GC`, accessible through `Gc.get` and `Gc.set`
- the status of the runtime warnings, exposed by `Sys.enable_runtime_warnings`  and `Sys.runtime_warnings_enable`
- the interactive nature of the program, `Sys.interactive`

There is two other global states present in `Hashtbl` and `Filename`: one state tracks if hashtables are randomized by default, and another state stores the directory name for temporary files.  However, those two state seem to be a good enough fit for inheritable domain local state, I am thus proposing for now to change their implementation in #11228.