### PR TITLE
stdlib audit: inheritable DLS for configurable options

### DIFF
--- a/stdlib/filename.mli
+++ b/stdlib/filename.mli
@@ -172,6 +172,8 @@ val get_temp_dir_name : unit -> string
 val set_temp_dir_name : string -> unit
 (** Change the temporary directory returned by {!Filename.get_temp_dir_name}
     and used by {!Filename.temp_file} and {!Filename.open_temp_file}.
+    The temporary directory is a domain-local value which is inherited
+    by child domains.
     @since 4.00.0
 *)
 

--- a/stdlib/hashtbl.mli
+++ b/stdlib/hashtbl.mli
@@ -186,7 +186,7 @@ val randomize : unit -> unit
     It is recommended that applications or Web frameworks that need to
     protect themselves against the denial-of-service attack described
     in {!create} call [Hashtbl.randomize()] at initialization
-    time.
+    time before any domains are created.
 
     Note that once [Hashtbl.randomize()] was called, there is no way
     to revert to the non-randomized default behavior of {!create}.

--- a/stdlib/moreLabels.mli
+++ b/stdlib/moreLabels.mli
@@ -203,7 +203,7 @@ module Hashtbl : sig
       It is recommended that applications or Web frameworks that need to
       protect themselves against the denial-of-service attack described
       in {!create} call [Hashtbl.randomize()] at initialization
-      time.
+      time before any domains are created.
 
       Note that once [Hashtbl.randomize()] was called, there is no way
       to revert to the non-randomized default behavior of {!create}.

--- a/stdlib/templates/hashtbl.template.mli
+++ b/stdlib/templates/hashtbl.template.mli
@@ -186,7 +186,7 @@ val randomize : unit -> unit
     It is recommended that applications or Web frameworks that need to
     protect themselves against the denial-of-service attack described
     in {!create} call [Hashtbl.randomize()] at initialization
-    time.
+    time before any domains are created.
 
     Note that once [Hashtbl.randomize()] was called, there is no way
     to revert to the non-randomized default behavior of {!create}.


### PR DESCRIPTION
The `Hashtbl` and `Filename` modules expose two configurable default options as global mutable states: the state in `Hashtbl`  tracks if hash tables are randomized by default, whereas the one in `Filename` stores the default directory name for temporary files.

The expected use case for both options is that they will be set during the initialization part of the program and then left alone.

This PR proposes to make this policy more explicit by storing those configurable options as domain-local states which are inherited by children domains. With this change, the behavior of concurrent mutation of those state is more specified and it is no longer possible to use those global variables for synchronization purpose.

Another option would be to document the expected policy for updating those variables in #11227. 