### PR TITLE
Fix dune stanza for stdlib: change of name

### DIFF
--- a/stdlib/dune
+++ b/stdlib/dune
@@ -22,7 +22,11 @@
  (flags (:standard -w -9 -nolabels))
  (preprocess
    (per_module
-     ((action (run awk -f %{dep:expand_module_aliases.awk} %{input-file}))
+    ((action
+      (progn
+       (run sed -i s/%atomic_load/%identity/ %{input-file})
+       (run sed -i s/%atomic_cas/%obj_set_field/ %{input-file})
+       (run awk -f %{dep:expand_module_aliases.awk} %{input-file})))
       stdlib)
      ;; AWFUL HACKS: remove once 5.0 is released
      ;; (this is needed because we're building with a compiler which doesn't
@@ -33,7 +37,7 @@
           (run sed -i s/%atomic_load/%identity/ %{input-file})
           (run sed -i s/%atomic_cas/%obj_set_field/ %{input-file})
           (run sed s/%atomic_[a-z_]*/%addint/ %{input-file})))
-      camlinternalAtomic)
+      atomic)
      ((action (run sed s/%dls_get/%identity/ %{input-file}))
       domain)
      ((action


### PR DESCRIPTION
With the commit of 44c9929fa988d3ba43ce5ffe6e124c35da3580b8, the file `camlinternalAtomic.ml` is removed. Hence, dune file also has to be updated properly.

I added necessary amend to the `stdlib/dune`.