### PR TITLE
stdlib audit: make gc alarms atomic

### DIFF
--- a/stdlib/gc.ml
+++ b/stdlib/gc.ml
@@ -102,23 +102,23 @@ external finalise_last : (unit -> unit) -> 'a -> unit =
 external finalise_release : unit -> unit = "caml_final_release"
 
 
-type alarm = bool ref
+type alarm = bool Atomic.t
 type alarm_rec = {active : alarm; f : unit -> unit}
 
 let rec call_alarm arec =
-  if !(arec.active) then begin
+  if Atomic.get arec.active then begin
     finalise call_alarm arec;
     arec.f ();
   end
 
 
 let create_alarm f =
-  let arec = { active = ref true; f = f } in
+  let arec = { active = Atomic.make true; f = f } in
   finalise call_alarm arec;
   arec.active
 
 
-let delete_alarm a = a := false
+let delete_alarm a = Atomic.set a false
 
 module Memprof =
   struct


### PR DESCRIPTION
This PR makes the inner state of gc alarms atomic in order to make it possible to delete alarms from any domains.

This is required since without atomics there is no guarantee that write to a reference become visible to other domains after a finite time.