### PR TITLE
Add missing @since annotation to Gc.eventlog_pause

### DIFF
--- a/stdlib/gc.mli
+++ b/stdlib/gc.mli
@@ -419,7 +419,10 @@ external eventlog_pause : unit -> unit = "caml_eventlog_pause"
    Traces are collected if the program is linked to the instrumented runtime
    and started with the environment variable OCAML_EVENTLOG_ENABLED.
    Events are flushed to disk after pausing, and no new events will be
-   recorded until [eventlog_resume] is called. *)
+   recorded until [eventlog_resume] is called.
+
+   @since 4.11
+  *)
 
 external eventlog_resume : unit -> unit = "caml_eventlog_resume"
 (** [eventlog_resume ()] will resume the collection of traces in the

--- a/stdlib/gc.mli
+++ b/stdlib/gc.mli
@@ -433,7 +433,7 @@ external eventlog_resume : unit -> unit = "caml_eventlog_resume"
    was started with OCAML_EVENTLOG_ENABLED=p. (which pauses the collection of
    traces before the first event.)
 
-   @since 5.0
+   @since 4.11
   *)
 
 


### PR DESCRIPTION
I forgot to add the annotation in #11212. This PR can finally close #10996.