### PR TITLE
stdlib concurrency-safety documentation, part three: arrays

### DIFF
--- a/stdlib/array.mli
+++ b/stdlib/array.mli
@@ -320,6 +320,78 @@ val of_seq : 'a Seq.t -> 'a array
 (** Create an array from the generator
     @since 4.07 *)
 
+(** {1:array_concurrency Arrays and concurrency safety}
+
+    Care must be taken when concurrently accessing arrays from multiple
+    domains: accessing an array will never crash a program, but unsynchronized
+    accesses might yield surprising (non-sequentially-consistent) results.
+
+    {2:array_atomicity Atomicity}
+
+    Every array operation that accesses more than one array element is not
+    atomic. This includes iteration, scanning, sorting, splitting and
+    combining arrays.
+
+    For example, consider the following program:
+{[let size = 100_000_000
+let a = Array.make size 1
+let d1 = Domain.spawn (fun () ->
+   Array.iteri (fun i x -> a.(i) <- x + 1) a
+)
+let d2 = Domain.spawn (fun () ->
+  Array.iteri (fun i x -> a.(i) <- 2 * x + 1) a
+)
+let () = Domain.join d1; Domain.join d2
+]}
+
+    After executing this code, each field of the array [a] is either [2], [3],
+    [4] or [5]. If atomicity is required, then the user must implement their own
+    synchronization (for example, using {!Mutex.t}).
+
+    {2:array_data_race Data races}
+
+    If two domains only access disjoint parts of the array, then the
+    observed behaviour is the equivalent to some sequential interleaving of the
+    operations from the two domains.
+
+    A data race is said to occur when two domains access the same array element
+    without synchronization and at least one of the accesses is a write.
+    In the absence of data races, the observed behaviour is equivalent to some
+    sequential interleaving of the operations from different domains.
+
+    Whenever possible, data races should be avoided by using synchronization to
+    mediate the accesses to the array elements.
+
+    Indeed, in the presence of data races, programs will not crash but the
+    observed behaviour may not be equivalent to any sequential interleaving of
+    operations from different domains. Nevertheless, even in the presence of
+    data races, a read operation will return the value of some prior write to
+    that location (with a few exceptions for float arrays).
+
+    {2:array_data_race_exceptions Float arrays}
+
+    Float arrays have two supplementary caveats in the presence of data races.
+
+    First, the blit operation might copy an array byte-by-byte. Data races
+    between such a blit operation and another operation might produce surprising
+    values due to tearing: partial writes interleaved with other operations can
+    create float values that would not exist with a sequential execution.
+
+    For instance, at the end of
+ {[let zeros = Array.make size 0.
+let max_floats = Array.make size Float.max_float
+let res = Array.copy zeros
+let d1 = Domain.spawn (fun () -> Array.blit zeros 0 res 0 size)
+let d2 = Domain.spawn (fun () -> Array.blit max_floats 0 res 0 size)
+let () = Domain.join d1; Domain.join d2
+]}
+    the [res] array might contain values that are neither [0.] nor [max_float].
+
+    Second, on 32-bit architectures, getting or setting a field involves two
+    separate memory accesses. In the presence of data races, the user may
+    observe tearing on any operation.
+*)
+
 (**/**)
 
 (** {1 Undocumented functions} *)

--- a/stdlib/arrayLabels.mli
+++ b/stdlib/arrayLabels.mli
@@ -320,6 +320,78 @@ val of_seq : 'a Seq.t -> 'a array
 (** Create an array from the generator
     @since 4.07 *)
 
+(** {1:array_concurrency Arrays and concurrency safety}
+
+    Care must be taken when concurrently accessing arrays from multiple
+    domains: accessing an array will never crash a program, but unsynchronized
+    accesses might yield surprising (non-sequentially-consistent) results.
+
+    {2:array_atomicity Atomicity}
+
+    Every array operation that accesses more than one array element is not
+    atomic. This includes iteration, scanning, sorting, splitting and
+    combining arrays.
+
+    For example, consider the following program:
+{[let size = 100_000_000
+let a = ArrayLabels.make size 1
+let d1 = Domain.spawn (fun () ->
+   ArrayLabels.iteri ~f:(fun i x -> a.(i) <- x + 1) a
+)
+let d2 = Domain.spawn (fun () ->
+  ArrayLabels.iteri ~f:(fun i x -> a.(i) <- 2 * x + 1) a
+)
+let () = Domain.join d1; Domain.join d2
+]}
+
+    After executing this code, each field of the array [a] is either [2], [3],
+    [4] or [5]. If atomicity is required, then the user must implement their own
+    synchronization (for example, using {!Mutex.t}).
+
+    {2:array_data_race Data races}
+
+    If two domains only access disjoint parts of the array, then the
+    observed behaviour is the equivalent to some sequential interleaving of the
+    operations from the two domains.
+
+    A data race is said to occur when two domains access the same array element
+    without synchronization and at least one of the accesses is a write.
+    In the absence of data races, the observed behaviour is equivalent to some
+    sequential interleaving of the operations from different domains.
+
+    Whenever possible, data races should be avoided by using synchronization to
+    mediate the accesses to the array elements.
+
+    Indeed, in the presence of data races, programs will not crash but the
+    observed behaviour may not be equivalent to any sequential interleaving of
+    operations from different domains. Nevertheless, even in the presence of
+    data races, a read operation will return the value of some prior write to
+    that location (with a few exceptions for float arrays).
+
+    {2:array_data_race_exceptions Float arrays}
+
+    Float arrays have two supplementary caveats in the presence of data races.
+
+    First, the blit operation might copy an array byte-by-byte. Data races
+    between such a blit operation and another operation might produce surprising
+    values due to tearing: partial writes interleaved with other operations can
+    create float values that would not exist with a sequential execution.
+
+    For instance, at the end of
+ {[let zeros = Array.make size 0.
+let max_floats = Array.make size Float.max_float
+let res = Array.copy zeros
+let d1 = Domain.spawn (fun () -> Array.blit zeros 0 res 0 size)
+let d2 = Domain.spawn (fun () -> Array.blit max_floats 0 res 0 size)
+let () = Domain.join d1; Domain.join d2
+]}
+    the [res] array might contain values that are neither [0.] nor [max_float].
+
+    Second, on 32-bit architectures, getting or setting a field involves two
+    separate memory accesses. In the presence of data races, the user may
+    observe tearing on any operation.
+*)
+
 (**/**)
 
 (** {1 Undocumented functions} *)

--- a/stdlib/templates/floatarraylabeled.template.mli
+++ b/stdlib/templates/floatarraylabeled.template.mli
@@ -224,6 +224,80 @@ val map_from_array : f:('a -> float) -> 'a array -> t
 (** [map_from_array ~f a] applies function [f] to all the elements of [a],
     and builds a floatarray with the results returned by [f]. *)
 
+(** {1:floatarray_concurrency Arrays and concurrency safety}
+
+    Care must be taken when concurrently accessing float arrays from multiple
+    domains: accessing an array will never crash a program, but unsynchronized
+    accesses might yield surprising (non-sequentially-consistent) results.
+
+    {2:floatarray_atomicity Atomicity}
+
+    Every float array operation that accesses more than one array element is
+    not atomic. This includes iteration, scanning, sorting, splitting and
+    combining arrays.
+
+    For example, consider the following program:
+{[let size = 100_000_000
+let a = Float.ArrayLabels.make size 1.
+let update a f () =
+   Float.ArrayLabels.iteri ~f:(fun i x -> Float.Array.set a i (f x)) a
+let d1 = Domain.spawn (update a (fun x -> x +. 1.))
+let d2 = Domain.spawn (update a (fun x ->  2. *. x +. 1.))
+let () = Domain.join d1; Domain.join d2
+]}
+
+    After executing this code, each field of the float array [a] is either
+    [2.], [3.], [4.] or [5.]. If atomicity is required, then the user must
+    implement their own synchronization (for example, using {!Mutex.t}).
+
+    {2:floatarray_data_race Data races}
+
+    If two domains only access disjoint parts of the array, then the
+    observed behaviour is the equivalent to some sequential interleaving of
+    the operations from the two domains.
+
+    A data race is said to occur when two domains access the same array
+    element without synchronization and at least one of the accesses is a
+    write. In the absence of data races, the observed behaviour is equivalent
+    to some sequential interleaving of the operations from different domains.
+
+    Whenever possible, data races should be avoided by using synchronization
+    to mediate the accesses to the array elements.
+
+    Indeed, in the presence of data races, programs will not crash but the
+    observed behaviour may not be equivalent to any sequential interleaving of
+    operations from different domains. Nevertheless, even in the presence of
+    data races, a read operation will return the value of some prior write to
+    that location with a few exceptions.
+
+
+    {2:floatarray_datarace_tearing Tearing }
+
+    Float arrays have two supplementary caveats in the presence of data races.
+
+    First, the blit operation might copy an array byte-by-byte. Data races
+    between such a blit operation and another operation might produce
+    surprising values due to tearing: partial writes interleaved with other
+    operations can create float values that would not exist with a sequential
+    execution.
+
+    For instance, at the end of
+{[let zeros = Float.Array.make size 0.
+let max_floats = Float.Array.make size Float.max_float
+let res = Float.Array.copy zeros
+let d1 = Domain.spawn (fun () -> Float.Array.blit zeros 0 res 0 size)
+let d2 = Domain.spawn (fun () -> Float.Array.blit max_floats 0 res 0 size)
+let () = Domain.join d1; Domain.join d2
+]}
+
+    the [res] float array might contain values that are neither [0.]
+    nor [max_float].
+
+    Second, on 32-bit architectures, getting or setting a field involves two
+    separate memory accesses. In the presence of data races, the user may
+    observe tearing on any operation.
+*)
+
 (**/**)
 
 (** {2 Undocumented functions} *)

--- a/tools/sync_stdlib_docs
+++ b/tools/sync_stdlib_docs
@@ -37,6 +37,14 @@ TILDEREGEX="s/ ~([a-z_]+(?=[ \]]))/ \1/g"
 #Indent a non-blank line by two characters, for moreLabels templates
 INDENTREGEX="s/^(.+)$/  \1/m"
 
+#Remove Labels suffix in examples
+
+
+LABELSDOTARGREGEX="s/([A-Z][a-z_]*)Labels\.(.*)~[a-z]+:/\1Labels.\2/g"
+LABELSDOTREGEX="s/([A-Z][a-z_]*)Labels\./\1./g"
+
+
+
 #Stdlib
 perl -p -e "$LABREGEX" stdlib/listLabels.mli > stdlib/list.temp.mli
 perl -p -e "$LABREGEX" stdlib/arrayLabels.mli > stdlib/array.temp.mli
@@ -45,9 +53,14 @@ perl -p -e "$LABREGEX" stdlib/bytesLabels.mli > stdlib/bytes.temp.mli
 
 #Stdlib tildes
 perl -p -e "$TILDEREGEX" stdlib/list.temp.mli > stdlib/list.mli
-perl -p -e "$TILDEREGEX" stdlib/array.temp.mli > stdlib/array.mli
+perl -p -e "$TILDEREGEX" stdlib/array.temp.mli > stdlib/array.2temp.mli
 perl -p -e "$TILDEREGEX" stdlib/string.temp.mli > stdlib/string.mli
 perl -p -e "$TILDEREGEX" stdlib/bytes.temp.mli > stdlib/bytes.mli
+
+# Array
+
+perl -p -e "$LABELSDOTARGREGEX" stdlib/array.2temp.mli > stdlib/array.3temp.mli
+perl -p -e "$LABELSDOTREGEX" stdlib/array.3temp.mli > stdlib/array.mli
 
 #FloatArrayLabels
 perl -p -e "$LABREGEX" \
@@ -55,9 +68,14 @@ perl -p -e "$LABREGEX" \
   stdlib/templates/floatarrayunlabeled.temp.mli
 perl -p -e "$TILDEREGEX" stdlib/templates/floatarrayunlabeled.temp.mli > \
   stdlib/templates/floatarrayunlabeled.2temp.mli
+perl -p -e "$LABELSDOTARGREGEX" \
+  stdlib/templates/floatarrayunlabeled.2temp.mli > \
+  stdlib/templates/floatarrayunlabeled.3temp.mli
+perl -p -e "$LABELSDOTREGEX" stdlib/templates/floatarrayunlabeled.3temp.mli > \
+  stdlib/templates/floatarrayunlabeled.4temp.mli
 perl -p -e "$INDENTREGEX" stdlib/templates/floatarraylabeled.template.mli > \
   stdlib/templates/fal.indented.temp.mli
-perl -p -e "$INDENTREGEX" stdlib/templates/floatarrayunlabeled.2temp.mli > \
+perl -p -e "$INDENTREGEX" stdlib/templates/floatarrayunlabeled.4temp.mli > \
   stdlib/templates/fau.indented.temp.mli
 perl -p -e\
   's/FLOATARRAYLAB/`tail -n +17 stdlib\/templates\/fal.indented.temp.mli`/e' \


### PR DESCRIPTION
This PRs adds a section about concurrency-safety to the documentation of all four kind of mutable arrays in the standard library: arrays, byte sequences, bigarrays and Float.Array.t.

All sections follows the same uniform template with some optional subsections.

- Arrays are safe in OCaml even in presence of data races
- *(bigarray only)* Arrays are not safe in C in presence of data races
- Data races should be avoided as much as possible
- In case of data races, beware of:
  - non-linearizability
  - *(float arrays and bigarrays only)* tearing
  - *(byte sequences only)* mixed-size access are unspecified
 
with a concrete example for each case in the "beware of data races" subsection.