### PR TITLE
Bump default maximum stack size

### DIFF
--- a/Changes
+++ b/Changes
@@ -64,6 +64,10 @@ Working version
   (Enguerrand Decorne, report by Jon Ludlam,
   review by Tom Kelly, KC Sivaramakrishnan and Gabriel Scherer)
 
+- #11238: Increase the default limit on the stack size to 128 Mi words,
+  i.e. 1 Gib for 64-bit platforms and 512 Mib for 32-bit platforms.
+  (Xavier Leroy, review by Sébastien Hinderer)
+
 ### Code generation and optimizations:
 
 - #10972: ARM64 multicore support: OCaml & C stack separation;

--- a/runtime/caml/config.h
+++ b/runtime/caml/config.h
@@ -212,7 +212,8 @@ typedef uint64_t uintnat;
 #define Stack_ctx_words 6
 
 /* Default maximum size of the stack (words). */
-#define Max_stack_def (1024 * 1024)
+/* (1 Gib for 64-bit platforms, 512 Mib for 32-bit platforms) */
+#define Max_stack_def (128 * 1024 * 1024)
 
 
 /* Maximum size of a block allocated in the young generation (words). */

--- a/testsuite/tests/tool-ocaml/t360-stacks-2.ml
+++ b/testsuite/tests/tool-ocaml/t360-stacks-2.ml
@@ -2,6 +2,7 @@
 include tool-ocaml-lib
 flags = "-w -a"
 ocaml_script_as_argument = "true"
+ocamlrunparam = "l=1000000"
 * setup-ocaml-build-env
 ** ocaml
 *)


### PR DESCRIPTION
Now that stack allocation is entirely under the control of the OCaml runtime system, it's time to use more generous stack limits than those provided by operating systems.

This commit sets the default maximum stack size to 128 Miwords, i.e. 1 Gib for 64-bit platforms and 512 Mib for 32-bit platforms.

See #10736 and #10954 for context.



