### PR TITLE
Reduced stack alignment for x86-64 

### DIFF
--- a/Changes
+++ b/Changes
@@ -27,6 +27,10 @@ Working version
 
 ### Code generation and optimizations:
 
+- #11239: on x86-64 and RISC-V, reduce alignment of OCaml stacks from 16 to 8.
+  This reduces stack usage.  It's only C stacks that require 16-alignment.
+  (Xavier Leroy, review by Gabriel Scherer and Stephen Dolan)
+
 ### Standard library:
 
 - #12217: Add `Array.shuffle`.

--- a/asmcomp/amd64/emit.mlp
+++ b/asmcomp/amd64/emit.mlp
@@ -79,14 +79,12 @@ let fp = Config.with_frame_pointers
 let stack_threshold_size = Config.stack_threshold * 8 (* bytes *)
 
 let frame_size env =                     (* includes return address *)
-  if env.f.fun_frame_required then begin
-    let sz =
-      (env.stack_offset
-       + 8 * (env.f.fun_num_stack_slots.(0) + env.f.fun_num_stack_slots.(1))
-       + 8
-       + (if fp then 8 else 0))
-    in Misc.align sz 16
-  end else
+  if env.f.fun_frame_required then
+    env.stack_offset
+    + 8 * (env.f.fun_num_stack_slots.(0) + env.f.fun_num_stack_slots.(1))
+    + 8
+    + (if fp then 8 else 0)
+  else
     env.stack_offset + 8
 
 let slot_offset env loc cl =

--- a/asmcomp/amd64/selection.ml
+++ b/asmcomp/amd64/selection.ml
@@ -278,9 +278,6 @@ method select_floatarith commutative regular_op mem_op args =
   | _ ->
       assert false
 
-method! mark_c_tailcall =
-  contains_calls := true
-
 (* Deal with register constraints *)
 
 method! insert_op_debug env op dbg rs rd =

--- a/asmcomp/riscv/emit.mlp
+++ b/asmcomp/riscv/emit.mlp
@@ -24,16 +24,14 @@ open Linear
 open Emitaux
 open Emitenv
 
-(* Layout of the stack.  The stack is kept 16-aligned. *)
+(* Layout of the stack.  The C stack must be 16-aligned, but 8-alignment
+   is enough for the OCaml stack. *)
 
 let frame_size env =
-  let size =
-    env.stack_offset +                     (* Trap frame, outgoing parameters *)
-    size_int * env.f.fun_num_stack_slots.(0) +    (* Local int variables *)
-    size_float * env.f.fun_num_stack_slots.(1) +  (* Local float variables *)
-    (if env.f.fun_contains_calls then size_addr else 0) (* Return address *)
-  in
-  Misc.align size 16
+  env.stack_offset +                     (* Trap frame, outgoing parameters *)
+  size_int * env.f.fun_num_stack_slots.(0) +    (* Local int variables *)
+  size_float * env.f.fun_num_stack_slots.(1) +  (* Local float variables *)
+  (if env.f.fun_contains_calls then size_addr else 0) (* Return address *)
 
 let slot_offset env loc cls =
   match loc with

--- a/runtime/amd64.S
+++ b/runtime/amd64.S
@@ -124,11 +124,8 @@
 
 
 #ifdef DEBUG
-#define CHECK_STACK_ALIGNMENT \
-        test $0xf, %rsp; jz 9f; int3; 9:
 #define IF_DEBUG(...) __VA_ARGS__
 #else
-#define CHECK_STACK_ALIGNMENT
 #define IF_DEBUG(...)
 #endif
 
@@ -377,7 +374,7 @@
 
 #endif
 
-#define C_call(target) CHECK_STACK_ALIGNMENT; call target
+#define C_call(target) call target
 
 /******************************************************************************/
 /* Registers holding arguments of C functions. */
@@ -687,7 +684,6 @@ LBL(caml_start_program):
         movq    Caml_state(c_stack), %r10
         movq    %r10, Cstack_prev(%rsp)
         movq    %rsp, Caml_state(c_stack)
-        CHECK_STACK_ALIGNMENT
     /* Load the OCaml stack. */
         movq    Caml_state(current_stack), %r11
         movq    Stack_sp(%r11), %r10
@@ -1034,7 +1030,6 @@ ENDFUNCTION(G(caml_ml_array_bound_error))
 
 FUNCTION(G(caml_assert_stack_invariants))
 CFI_STARTPROC
-/*      CHECK_STACK_ALIGNMENT */
         movq    Caml_state(current_stack), %r11
         movq    %rsp, %r10
         subq    %r11, %r10      /* %r10: number of bytes left on stack */

--- a/runtime/riscv.S
+++ b/runtime/riscv.S
@@ -377,7 +377,7 @@ FUNCTION(caml_c_call_stack_args)
     /* Store sp to restore after call */
         mv      s2, sp
     /* Copy arguments from OCaml to C stack
-       NB: STACK_ARG_{BEGIN,END} are 16-byte aligned */
+       NB: STACK_ARG_END - STACK_ARG_BEGIN is a multiple of 16 */
 1:      addi    STACK_ARG_END, STACK_ARG_END, -16
         bltu    STACK_ARG_END, STACK_ARG_BEGIN, 2f
         ld      TMP, 0(STACK_ARG_END)

--- a/runtime/s390x.S
+++ b/runtime/s390x.S
@@ -88,7 +88,6 @@
 #define ENTER_FUNCTION
 #define LEAVE_FUNCTION
 
-#define CHECK_STACK_ALIGNMENT
 #define PREPARE_FOR_C_CALL      CFI_REMEMBER_STATE
 #define CLEANUP_AFTER_C_CALL    CFI_RESTORE_STATE
 
@@ -302,7 +301,6 @@ CFI_STARTPROC
         .cfi_escape DW_CFA_def_cfa_expression, 4, DW_OP_breg + DW_REG_r15, \
           Cstack_sp_plus_160_sleb128_2byte, DW_OP_deref
 #endif
-        CHECK_STACK_ALIGNMENT
         brasl %r14, GCALL(caml_try_realloc_stack)
         CLEANUP_AFTER_C_CALL
         SWITCH_C_TO_OCAML
@@ -337,7 +335,6 @@ LBL(caml_call_gc):
         .cfi_escape DW_CFA_def_cfa_expression, 4, DW_OP_breg + DW_REG_r15, \
           Cstack_sp_plus_160_sleb128_2byte, DW_OP_deref
 #endif
-        CHECK_STACK_ALIGNMENT
         brasl %r14, GCALL(caml_garbage_collection)
         CLEANUP_AFTER_C_CALL
         SWITCH_C_TO_OCAML
@@ -629,7 +626,6 @@ LBL(caml_reraise_exn_stash):
         lg      %r15, Caml_state(c_stack)
         PREPARE_FOR_C_CALL
         CFI_ADJUST(160)
-        CHECK_STACK_ALIGNMENT
         brasl %r14, GCALL(caml_stash_backtrace)
         CLEANUP_AFTER_C_CALL
     /* Restore exception bucket and raise */
@@ -867,7 +863,6 @@ LBL(caml_runstack_1):
         lg      %r15, Caml_state(c_stack)
         PREPARE_FOR_C_CALL
         CFI_ADJUST(160)
-        CHECK_STACK_ALIGNMENT
         brasl %r14, GCALL(caml_free_stack)
         CLEANUP_AFTER_C_CALL
     /* switch directly to parent stack with correct return */


### PR DESCRIPTION
The x86-64 ABIs require that the C stack pointer is 16-aligned.  In particular, this enables C compilers to emit SSE load and store instructions that require 16-alignment.

However, starting with OCaml 5, the x86-64 code generated by ocamlopt runs in its own stack, not on the C stack.  Moreover, ocamlopt generates only 8-byte memory accesses for which 8-alignment is enough to get maximal performance.

So, there is no longer a need to align every ocamlopt-generated stack frame to a multiple of 16 bytes.  This PR just removes this alignment.

The net result is a decrease in stack usage.  For a silly example,
```
let rec f () = incr depth; 1 + f ()
```
now uses 8 bytes of stack per call instead of 16, hence can run TWICE AS LONG before overflowing the stack :-)

For a less silly example, `List.mapi` uses 20% less stack space, so it can process a list of length 217000 before overflowing the default 1 Miword stack, instead of 175000 before.

Smaller stack frames also mean even more locality in stack accesses and even better utilization of the caches.
