### PR TITLE
ocamltest/run_win32.c: include caml/memory.h rather than defining CAML_INTERNALS

### DIFF
--- a/ocamltest/run_win32.c
+++ b/ocamltest/run_win32.c
@@ -18,8 +18,6 @@
 /* GetTickCount64() requires Windows Vista or Server 2008 */
 #define _WIN32_WINNT 0x0600
 
-#define CAML_INTERNALS
-
 #include <stdio.h>
 #include <stdlib.h>
 #include <wtypes.h>
@@ -31,6 +29,7 @@
 #include <stdarg.h>
 #include <sys/types.h>
 
+#include "caml/memory.h"
 #include "caml/osdeps.h"
 
 #include "run.h"


### PR DESCRIPTION
Follow-up to #11234 and @dra27's suggestion there.