### PR TITLE
 Reimplementation of the `Reverse` macros from `<caml/reverse.h>`

### DIFF
--- a/runtime/caml/reverse.h
+++ b/runtime/caml/reverse.h
@@ -21,45 +21,32 @@
 #ifdef CAML_INTERNALS
 
 #define Reverse_16(dst,src) {                                               \
-  char * _p, * _q;                                                          \
-  char _a;                                                                  \
+  char * _p;                                                                \
+  char _a, _b;                                                              \
   _p = (char *) (src);                                                      \
-  _q = (char *) (dst);                                                      \
-  _a = _p[0];                                                               \
-  _q[0] = _p[1];                                                            \
-  _q[1] = _a;                                                               \
+  _a = _p[0]; _b = _p[1];                                                   \
+  _p = (char *) (dst);                                                      \
+  _p[0] = _b; _p[1] = _a;                                                   \
 }
 
 #define Reverse_32(dst,src) {                                               \
-  char * _p, * _q;                                                          \
-  char _a, _b;                                                              \
+  char * _p;                                                                \
+  char _a, _b, _c, _d;                                                      \
   _p = (char *) (src);                                                      \
-  _q = (char *) (dst);                                                      \
-  _a = _p[0];                                                               \
-  _b = _p[1];                                                               \
-  _q[0] = _p[3];                                                            \
-  _q[1] = _p[2];                                                            \
-  _q[3] = _a;                                                               \
-  _q[2] = _b;                                                               \
+  _a = _p[0]; _b = _p[1]; _c = _p[2]; _d = _p[3];                           \
+  _p = (char *) (dst);                                                      \
+  _p[0] = _d; _p[1] = _c; _p[2] = _b; _p[3] = _a;                           \
 }
 
 #define Reverse_64(dst,src) {                                               \
-  char * _p, * _q;                                                          \
-  char _a, _b;                                                              \
+  char * _p;                                                                \
+  char _a, _b, _c, _d, _e, _f, _g, _h;                                      \
   _p = (char *) (src);                                                      \
-  _q = (char *) (dst);                                                      \
-  _a = _p[0];                                                               \
-  _b = _p[1];                                                               \
-  _q[0] = _p[7];                                                            \
-  _q[1] = _p[6];                                                            \
-  _q[7] = _a;                                                               \
-  _q[6] = _b;                                                               \
-  _a = _p[2];                                                               \
-  _b = _p[3];                                                               \
-  _q[2] = _p[5];                                                            \
-  _q[3] = _p[4];                                                            \
-  _q[5] = _a;                                                               \
-  _q[4] = _b;                                                               \
+  _a = _p[0]; _b = _p[1]; _c = _p[2]; _d = _p[3];                           \
+  _e = _p[4]; _f = _p[5]; _g = _p[6]; _h = _p[7];                           \
+  _p = (char *) (dst);                                                      \
+  _p[0] = _h; _p[1] = _g; _p[2] = _f; _p[3] = _e;                           \
+  _p[4] = _d; _p[5] = _c; _p[6] = _b; _p[7] = _a;                           \
 }
 
 #define Perm_index(perm,i) ((perm >> (i * 4)) & 0xF)


### PR DESCRIPTION
These macros play an important role during marshaling and unmarshaling, see #11163.

With the new implementations, GCC can produce very nice (shall I say optimal?) instruction sequences:
-  loadword / bswap / storeword   for x86, ARM64
- loadword-reversed / storeword  for S390x
- loadword / storeword-reversed  for Power

Clang still produces byte-per-byte loads and stores, but it's no worse than before.

I'd rather not write the macros using `__builtin_bswap` and word-sized memory accesses explicitly, because alignment issues may come into play.  GCC knows better than us when it can do unaligned memory accesses.
