### PR TITLE
Fix `stat_has_ns_precision` configure check

### DIFF
--- a/configure
+++ b/configure
@@ -16012,6 +16012,8 @@ esac
 
 ## Does stat support nanosecond precision
 
+stat_has_ns_precision=false
+
 ac_fn_c_check_member "$LINENO" "struct stat" "st_atim.tv_nsec" "ac_cv_member_struct_stat_st_atim_tv_nsec" "
     $ac_includes_default
     #include <sys/stat.h>

--- a/configure.ac
+++ b/configure.ac
@@ -1673,6 +1673,8 @@ AS_CASE([$ocaml_cv_cc_vendor,$host],
 
 ## Does stat support nanosecond precision
 
+stat_has_ns_precision=false
+
 AC_CHECK_MEMBER([struct stat.st_atim.tv_nsec],
   [stat_has_ns_precision=true
   AC_DEFINE([HAS_NANOSECOND_STAT], [1])],


### PR DESCRIPTION
`struct stat` provides access and modification time as integer seconds, but
there are OS-specific extensions that provide it in nanoseconds.  The
configure script attempts to test for three of them:

    - `st_atim` (Linux)
    - `st_atimespec` (newer BSDs/Darwin)
    - `st_atimensec` (older BSDs/Darwin)

Each of the three tests, if it succeeds, sets `stat_has_ns_precision` to
`true`.  The second and third tests are guarded by

    AS_IF([! $stat_has_ns_precision]

so that they don't run if an a previous test already succeeded.  This
expands to:

    if ! $stat_has_ns_precision; then

This approach to handling 'boolean' variables differs from the more common
autoconf pattern of representing them as either `yes` or `no`.  But the
same approach used elsewhere in the configure script, and it works
correctly as long as the variable is either `false` or `true`.  `if !
$stat_has_ns_precision` will expand to either `if ! false` or `if !
true`, i.e. run the command `false` or `true` and flip its exit status.

However, `stat_has_ns_precision` is never initialized to `false`.  It
starts out unset, and is set to `true` if one of the tests pass.

If it's unset, the `if` expands to:

    if !; then

Running `!` by itself (apparently) returns a failing exit code, so the
`if` condition fails.  In other words, the unset state acts like `true`,
not `false`.

Therefore, the second and third tests will never run under any
circumstances.  Nanosecond precision works on Linux, but on BSDs and
Darwin it's incorrectly detected as unsupported, causing `Unix.stat` to
only provide times in seconds.

(However, due to the same bug, the configure script will always print
"stat supports nanosecond precision" regardless of whether any test
succeeded.)

Fix this by initializing `stat_has_ns_precision` to false.