### PR TITLE
stdlib audit: fix race on channel list

### DIFF
--- a/runtime/io.c
+++ b/runtime/io.c
@@ -136,18 +136,15 @@ Caml_inline int descriptor_is_in_binary_mode(int fd)
 
 static void link_channel (struct channel* channel)
 {
-  caml_plat_lock (&caml_all_opened_channels_mutex);
   channel->next = caml_all_opened_channels;
   CAMLassert(channel->prev == NULL);
   if (caml_all_opened_channels != NULL)
     caml_all_opened_channels->prev = channel;
   caml_all_opened_channels = channel;
-  caml_plat_unlock (&caml_all_opened_channels_mutex);
 }
 
 static void unlink_channel(struct channel *channel)
 {
-  caml_plat_lock (&caml_all_opened_channels_mutex);
   if (channel->prev == NULL) {
     CAMLassert (channel == caml_all_opened_channels);
     caml_all_opened_channels = caml_all_opened_channels->next;
@@ -159,7 +156,6 @@ static void unlink_channel(struct channel *channel)
   }
   channel->next = NULL;
   channel->prev = NULL;
-  caml_plat_unlock (&caml_all_opened_channels_mutex);
 }
 
 CAMLexport struct channel * caml_open_descriptor_in(int fd)
@@ -179,7 +175,9 @@ CAMLexport struct channel * caml_open_descriptor_in(int fd)
   channel->name = NULL;
   channel->flags = descriptor_is_in_binary_mode(fd) ? 0 : CHANNEL_TEXT_MODE;
 
+  caml_plat_lock (&caml_all_opened_channels_mutex);
   link_channel (channel);
+  caml_plat_unlock (&caml_all_opened_channels_mutex);
 
   return channel;
 }
@@ -196,13 +194,15 @@ CAMLexport struct channel * caml_open_descriptor_out(int fd)
 CAMLexport void caml_close_channel(struct channel *channel)
 {
   close(channel->fd);
-
+  caml_plat_lock (&caml_all_opened_channels_mutex);
   unlink_channel(channel);
     if (atomic_load_acq(&channel->refcount) > 0) {
     /* [caml_ml_out_channels_list] may have a reference to this channel. */
     link_channel (channel);
+    caml_plat_unlock (&caml_all_opened_channels_mutex);
     return;
   }
+  caml_plat_unlock (&caml_all_opened_channels_mutex);
   if (caml_channel_mutex_free != NULL) (*caml_channel_mutex_free)(channel);
   caml_stat_free(channel->name);
   caml_stat_free(channel);
@@ -509,12 +509,15 @@ void caml_finalize_channel(value vchan)
 {
   struct channel * chan = Channel(vchan);
   if ((chan->flags & CHANNEL_FLAG_MANAGED_BY_GC) == 0) return;
+  caml_plat_lock (&caml_all_opened_channels_mutex);
   unlink_channel(chan);
   if (atomic_fetch_add (&chan->refcount, -1) > 1) {
     /* [caml_ml_out_channels_list] may have a reference to this channel. */
     link_channel (chan);
+    caml_plat_unlock (&caml_all_opened_channels_mutex);
     return;
   }
+  caml_plat_unlock (&caml_all_opened_channels_mutex);
   if (caml_channel_mutex_free != NULL) (*caml_channel_mutex_free)(chan);
 
   if (chan->fd != -1 && chan->name && caml_runtime_warnings_active())

--- a/testsuite/tests/lib-channels/refcounting.ml
+++ b/testsuite/tests/lib-channels/refcounting.ml
@@ -1,0 +1,32 @@
+(* TEST
+   * expect
+*)
+
+(* Test the behavior of channel refcounting. *)
+
+(* out_channels_list is the only function that increases the number of reference
+  to a channel in the standard library *)
+external out_channels_list : unit -> out_channel list = "caml_ml_out_channels_list"
+
+let duplicate_and_close () =
+  let l = out_channels_list () in
+  List.iter Stdlib.close_out l
+
+let rec loop n () =
+  if n <> 0 then
+    begin
+      duplicate_and_close ();
+      loop (n-1) ()
+    end
+
+
+let dls = List.map Domain.spawn (List.init 4 (fun _ -> loop 100))
+let () = List.iter Domain.join dls
+
+[%%expect{|
+external out_channels_list : unit -> out_channel list
+  = "caml_ml_out_channels_list"
+val duplicate_and_close : unit -> unit = <fun>
+val loop : int -> unit -> unit = <fun>
+val dls : unit Domain.t list = [<abstr>; <abstr>; <abstr>; <abstr>]
+|}]


### PR DESCRIPTION
This PR fixes a race when updating the list of opened channels in the OCaml runtime:
```C
unlink_channel(channel);
 if (atomic_load_acq(&channel->refcount) > 0) {
  link_channel (channel);
```
Before this PR, two domains owning a copy of the same channel `channel` could perform two `link_channel` in sequence  which created a cyclic list of opened channels.

This PR fixes this issue by holding the lock for the list of opened channels until the channel is re-linked in the list.

This is also has the  positive side-effect that channel refcounters are now only decremented to zero when holding the lock for this opened channel list. Thus the result of  `atomic_load_acq(&channel->refcount) > 0` is held constant by the lock.