### PR TITLE
Support 'raw identifier' syntax

### DIFF
--- a/.depend
+++ b/.depend
@@ -437,6 +437,7 @@ parsing/pprintast.cmo : \
     parsing/parsetree.cmi \
     parsing/longident.cmi \
     parsing/location.cmi \
+    parsing/lexer.cmi \
     parsing/asttypes.cmi \
     parsing/ast_helper.cmi \
     parsing/pprintast.cmi
@@ -444,6 +445,7 @@ parsing/pprintast.cmx : \
     parsing/parsetree.cmi \
     parsing/longident.cmx \
     parsing/location.cmx \
+    parsing/lexer.cmx \
     parsing/asttypes.cmi \
     parsing/ast_helper.cmx \
     parsing/pprintast.cmi
@@ -888,11 +890,13 @@ typing/mtype.cmi : \
 typing/oprint.cmo : \
     parsing/pprintast.cmi \
     typing/outcometree.cmi \
+    parsing/lexer.cmi \
     parsing/asttypes.cmi \
     typing/oprint.cmi
 typing/oprint.cmx : \
     parsing/pprintast.cmx \
     typing/outcometree.cmi \
+    parsing/lexer.cmx \
     parsing/asttypes.cmi \
     typing/oprint.cmi
 typing/oprint.cmi : \
@@ -947,9 +951,11 @@ typing/parmatch.cmi : \
     typing/env.cmi \
     parsing/asttypes.cmi
 typing/path.cmo : \
+    parsing/lexer.cmi \
     typing/ident.cmi \
     typing/path.cmi
 typing/path.cmx : \
+    parsing/lexer.cmx \
     typing/ident.cmx \
     typing/path.cmi
 typing/path.cmi : \
@@ -1073,6 +1079,7 @@ typing/printtyp.cmo : \
     typing/signature_group.cmi \
     typing/primitive.cmi \
     typing/predef.cmi \
+    parsing/pprintast.cmi \
     typing/path.cmi \
     parsing/parsetree.cmi \
     typing/outcometree.cmi \
@@ -1095,6 +1102,7 @@ typing/printtyp.cmx : \
     typing/signature_group.cmx \
     typing/primitive.cmx \
     typing/predef.cmx \
+    parsing/pprintast.cmx \
     typing/path.cmx \
     parsing/parsetree.cmi \
     typing/outcometree.cmi \

--- a/Changes
+++ b/Changes
@@ -6,6 +6,9 @@ Working version
 - #9975, #11365: Make empty types (`type t = |`) immediate.
   (Antal Spector-Zabusky, review by Gabriel Scherer)
 
+- #11252, RFC 27: Support raw identifier syntax \#foo
+  (Stephen Dolan, review by David Allsopp)
+
 * #11694: Add short syntax for generative functor types `() -> ...`
   (Jeremy Yallop, review by Gabriel Scherer, Nicolás Ojeda Bär,
   Jacques Garrigue)
@@ -93,7 +96,7 @@ Working version
   (Stephen Dolan, review by Xavier Leroy)
 
 - #11418, #11708: RISC-V multicore support.
-  (Nicolás Ojeda Bär, review by KC Sivaramakrishnan)
+  (Nicolás Ojeda Bär, review by KuC Sivaramakrishnan)
 
 - #11686: Better spilling heuristic for the Linear Scan allocator for more
   efficient stack usage.

--- a/Makefile
+++ b/Makefile
@@ -1364,8 +1364,8 @@ ocamlprof_LIBRARIES =
 ocamlprof_MODULES = \
   config build_path_prefix_map misc identifiable numbers arg_helper \
   local_store load_path clflags terminfo warnings location longident \
-  docstrings syntaxerr ast_helper camlinternalMenhirLib parser pprintast \
-  lexer parse ocamlprof
+  docstrings syntaxerr ast_helper camlinternalMenhirLib parser \
+  lexer pprintast parse ocamlprof
 
 ocamlcp_ocamloptp_MODULES = \
   config build_path_prefix_map misc profile warnings identifiable numbers \

--- a/compilerlibs/Makefile.compilerlibs
+++ b/compilerlibs/Makefile.compilerlibs
@@ -55,10 +55,10 @@ PARSING = \
   parsing/docstrings.cmo \
   parsing/syntaxerr.cmo \
   parsing/ast_helper.cmo \
-  parsing/pprintast.cmo \
   parsing/camlinternalMenhirLib.cmo \
   parsing/parser.cmo \
   parsing/lexer.cmo \
+  parsing/pprintast.cmo \
   parsing/parse.cmo \
   parsing/printast.cmo \
   parsing/ast_mapper.cmo \

--- a/otherlibs/dynlink/Makefile
+++ b/otherlibs/dynlink/Makefile
@@ -93,6 +93,9 @@ COMPILERLIBS_SOURCES=\
   parsing/syntaxerr.ml \
   parsing/ast_helper.ml \
   parsing/ast_mapper.ml \
+  parsing/camlinternalMenhirLib.ml \
+  parsing/parser.ml \
+  parsing/lexer.ml \
   parsing/attr_helper.ml \
   parsing/builtin_attributes.ml \
   typing/ident.ml \

--- a/parsing/lexer.mli
+++ b/parsing/lexer.mli
@@ -41,6 +41,7 @@ exception Error of error * Location.t
 val in_comment : unit -> bool
 val in_string : unit -> bool
 
+val is_keyword : string -> bool
 
 val print_warnings : bool ref
 val handle_docstrings: bool ref

--- a/parsing/pprintast.ml
+++ b/parsing/pprintast.ml
@@ -95,15 +95,16 @@ let needs_parens txt =
 let needs_spaces txt =
   first_is '*' txt || last_is '*' txt
 
-let string_loc ppf x = fprintf ppf "%s" x.txt
-
 (* add parentheses to binders when they are in fact infix or prefix operators *)
 let protect_ident ppf txt =
   let format : (_, _, _) format =
-    if not (needs_parens txt) then "%s"
+    if Lexer.is_keyword txt then "\\#%s"
+    else if not (needs_parens txt) then "%s"
     else if needs_spaces txt then "(@;%s@;)"
     else "(%s)"
   in fprintf ppf format txt
+
+let protect_ident_loc ppf s = protect_ident ppf s.txt
 
 let protect_longident ppf print_longident longprefix txt =
   let format : (_, _, _) format =
@@ -134,11 +135,15 @@ type construct =
   | `nil
   | `normal
   | `simple of Longident.t
-  | `tuple ]
+  | `tuple
+  | `btrue
+  | `bfalse ]
 
 let view_expr x =
   match x.pexp_desc with
   | Pexp_construct ( {txt= Lident "()"; _},_) -> `tuple
+  | Pexp_construct ( {txt= Lident "true"; _},_) -> `btrue
+  | Pexp_construct ( {txt= Lident "false"; _},_) -> `bfalse
   | Pexp_construct ( {txt= Lident "[]";_},_) -> `nil
   | Pexp_construct ( {txt= Lident"::";_},Some _) ->
       let rec loop exp acc = match exp with
@@ -161,7 +166,7 @@ let view_expr x =
   | _ -> `normal
 
 let is_simple_construct :construct -> bool = function
-  | `nil | `tuple | `list _ | `simple _  -> true
+  | `nil | `tuple | `list _ | `simple _ | `btrue | `bfalse -> true
   | `cons _ | `normal -> false
 
 let pp = fprintf
@@ -268,16 +273,21 @@ let iter_loc f ctxt {txt; loc = _} = f ctxt txt
 
 let constant_string f s = pp f "%S" s
 
-let tyvar ppf s =
+let tyvar_name s =
   if String.length s >= 2 && s.[1] = '\'' then
     (* without the space, this would be parsed as
        a character literal *)
-    Format.fprintf ppf "' %s" s
+    "' " ^ s
+  else if Lexer.is_keyword s then
+    "'\\#" ^ s
   else
-    Format.fprintf ppf "'%s" s
+    "'" ^ s
+
+let tyvar ppf s =
+  Format.fprintf ppf "%s" (tyvar_name s)
 
 let tyvar_loc f str = tyvar f str.txt
-let string_quot f x = pp f "`%s" x
+let string_quot f x = pp f "`%a" protect_ident x
 
 (* c ['a,'b] *)
 let rec class_params_def ctxt f =  function
@@ -289,8 +299,8 @@ let rec class_params_def ctxt f =  function
 and type_with_label ctxt f (label, c) =
   match label with
   | Nolabel    -> core_type1 ctxt f c (* otherwise parenthesize *)
-  | Labelled s -> pp f "%s:%a" s (core_type1 ctxt) c
-  | Optional s -> pp f "?%s:%a" s (core_type1 ctxt) c
+  | Labelled s -> pp f "%a:%a" protect_ident s (core_type1 ctxt) c
+  | Optional s -> pp f "?%a:%a" protect_ident s (core_type1 ctxt) c
 
 and core_type ctxt f x =
   if x.ptyp_attributes <> [] then begin
@@ -363,7 +373,7 @@ and core_type1 ctxt f x =
         let core_field_type f x = match x.pof_desc with
           | Otag (l, ct) ->
             (* Cf #7200 *)
-            pp f "@[<hov2>%s: %a@ %a@ @]" l.txt
+            pp f "@[<hov2>%a: %a@ %a@ @]" protect_ident l.txt
               (core_type ctxt) ct (attributes ctxt) x.pof_attributes
           | Oinherit ct ->
             pp f "@[<hov2>%a@ @]" (core_type ctxt) ct
@@ -432,8 +442,8 @@ and pattern1 ctxt (f:Format.formatter) (x:pattern) : unit =
   if x.ppat_attributes <> [] then pattern ctxt f x
   else match x.ppat_desc with
     | Ppat_variant (l, Some p) ->
-        pp f "@[<2>`%s@;%a@]" l (simple_pattern ctxt) p
-    | Ppat_construct (({txt=Lident("()"|"[]");_}), _) ->
+        pp f "@[<2>`%a@;%a@]" protect_ident l (simple_pattern ctxt) p
+    | Ppat_construct (({txt=Lident("()"|"[]"|"true"|"false");_}), _) ->
         simple_pattern ctxt f x
     | Ppat_construct (({txt;_} as li), po) ->
         (* FIXME The third field always false *)
@@ -445,7 +455,7 @@ and pattern1 ctxt (f:Format.formatter) (x:pattern) : unit =
                pp f "%a@;%a"  longident_loc li (simple_pattern ctxt) x
            | Some (vl, x) ->
                pp f "%a@ (type %a)@;%a" longident_loc li
-                 (list ~sep:"@ " string_loc) vl
+                 (list ~sep:"@ " protect_ident_loc) vl
                  (simple_pattern ctxt) x
            | None -> pp f "%a" longident_loc li)
     | _ -> simple_pattern ctxt f x
@@ -453,7 +463,7 @@ and pattern1 ctxt (f:Format.formatter) (x:pattern) : unit =
 and simple_pattern ctxt (f:Format.formatter) (x:pattern) : unit =
   if x.ppat_attributes <> [] then pattern ctxt f x
   else match x.ppat_desc with
-    | Ppat_construct (({txt=Lident ("()"|"[]" as x);_}), None) ->
+    | Ppat_construct (({txt=Lident ("()"|"[]"|"true"|"false" as x);_}), None) ->
         pp f  "%s" x
     | Ppat_any -> pp f "_";
     | Ppat_var ({txt = txt;_}) -> protect_ident f txt
@@ -486,7 +496,7 @@ and simple_pattern ctxt (f:Format.formatter) (x:pattern) : unit =
         pp f "@[<1>(%a)@]" (list  ~sep:",@;" (pattern1 ctxt))  l (* level1*)
     | Ppat_constant (c) -> pp f "%a" constant c
     | Ppat_interval (c1, c2) -> pp f "%a..%a" constant c1 constant c2
-    | Ppat_variant (l,None) ->  pp f "`%s" l
+    | Ppat_variant (l,None) ->  pp f "`%a" protect_ident l
     | Ppat_constraint (p, ct) ->
         pp f "@[<2>(%a@;:@;%a)@]" (pattern1 ctxt) p (core_type ctxt) ct
     | Ppat_lazy p ->
@@ -498,7 +508,8 @@ and simple_pattern ctxt (f:Format.formatter) (x:pattern) : unit =
         let with_paren =
         match p.ppat_desc with
         | Ppat_array _ | Ppat_record _
-        | Ppat_construct (({txt=Lident ("()"|"[]");_}), None) -> false
+        | Ppat_construct (({txt=Lident ("()"|"[]"|"true"|"false");_}), None) ->
+            false
         | _ -> true in
         pp f "@[<2>%a.%a @]" longident_loc lid
           (paren with_paren @@ pattern1 ctxt) p
@@ -514,20 +525,21 @@ and label_exp ctxt f (l,opt,p) =
       | {ppat_desc = Ppat_var {txt;_}; ppat_attributes = []}
         when txt = rest ->
           (match opt with
-           | Some o -> pp f "?(%s=@;%a)@;" rest  (expression ctxt) o
-           | None -> pp f "?%s@ " rest)
+           | Some o ->
+              pp f "?(%a=@;%a)@;" protect_ident rest  (expression ctxt) o
+           | None -> pp f "?%a@ " protect_ident rest)
       | _ ->
           (match opt with
            | Some o ->
-               pp f "?%s:(%a=@;%a)@;"
-                 rest (pattern1 ctxt) p (expression ctxt) o
-           | None -> pp f "?%s:%a@;" rest (simple_pattern ctxt) p)
+               pp f "?%a:(%a=@;%a)@;"
+                 protect_ident rest (pattern1 ctxt) p (expression ctxt) o
+           | None -> pp f "?%a:%a@;" protect_ident rest (simple_pattern ctxt) p)
       end
   | Labelled l -> match p with
     | {ppat_desc  = Ppat_var {txt;_}; ppat_attributes = []}
       when txt = l ->
-        pp f "~%s@;" l
-    | _ ->  pp f "~%s:%a@;" l (simple_pattern ctxt) p
+        pp f "~%a@;" protect_ident l
+    | _ ->  pp f "~%a:%a@;" protect_ident l (simple_pattern ctxt) p
 
 and sugar_expr ctxt f e =
   if e.pexp_attributes <> [] then false
@@ -625,7 +637,7 @@ and expression ctxt f x =
           (label_exp ctxt) (l, e0, p)
           (expression ctxt) e
     | Pexp_newtype (lid, e) ->
-        pp f "@[<2>fun@;(type@;%s)@;->@;%a@]" lid.txt
+        pp f "@[<2>fun@;(type@;%a)@;->@;%a@]" protect_ident lid.txt
           (expression ctxt) e
     | Pexp_function l ->
         pp f "@[<hv>function%a@]" (case_list ctxt) l
@@ -716,10 +728,10 @@ and expression ctxt f x =
     | Pexp_new (li) ->
         pp f "@[<hov2>new@ %a@]" longident_loc li;
     | Pexp_setinstvar (s, e) ->
-        pp f "@[<hov2>%s@ <-@ %a@]" s.txt (expression ctxt) e
+        pp f "@[<hov2>%a@ <-@ %a@]" protect_ident s.txt (expression ctxt) e
     | Pexp_override l -> (* FIXME *)
         let string_x_expression f (s, e) =
-          pp f "@[<hov2>%s@ =@ %a@]" s.txt (expression ctxt) e in
+          pp f "@[<hov2>%a@ =@ %a@]" protect_ident s.txt (expression ctxt) e in
         pp f "@[<hov2>{<%a>}@]"
           (list string_x_expression  ~sep:";"  )  l;
     | Pexp_letmodule (s, me, e) ->
@@ -746,7 +758,7 @@ and expression ctxt f x =
           (override o.popen_override) (module_expr ctxt) o.popen_expr
           (expression ctxt) e
     | Pexp_variant (l,Some eo) ->
-        pp f "@[<2>`%s@;%a@]" l (simple_expr ctxt) eo
+        pp f "@[<2>`%a@;%a@]" protect_ident l (simple_expr ctxt) eo
     | Pexp_letop {let_; ands; body} ->
         pp f "@[<2>@[<v>%a@,%a@] in@;<1 -2>%a@]"
           (binding_op ctxt) let_
@@ -768,7 +780,8 @@ and expression2 ctxt f x =
   else match x.pexp_desc with
     | Pexp_field (e, li) ->
         pp f "@[<hov2>%a.%a@]" (simple_expr ctxt) e longident_loc li
-    | Pexp_send (e, s) -> pp f "@[<hov2>%a#%s@]" (simple_expr ctxt) e s.txt
+    | Pexp_send (e, s) ->
+        pp f "@[<hov2>%a#%a@]" (simple_expr ctxt) e protect_ident s.txt
 
     | _ -> simple_expr ctxt f x
 
@@ -779,6 +792,8 @@ and simple_expr ctxt f x =
         (match view_expr x with
          | `nil -> pp f "[]"
          | `tuple -> pp f "()"
+         | `btrue -> pp f "true"
+         | `bfalse -> pp f "false"
          | `list xs ->
              pp f "@[<hv0>[%a]@]"
                (list (expression (under_semi ctxt)) ~sep:";@;") xs
@@ -800,7 +815,7 @@ and simple_expr ctxt f x =
         pp f "(%a%a :> %a)" (expression ctxt) e
           (option (core_type ctxt) ~first:" : " ~last:" ") cto1 (* no sep hint*)
           (core_type ctxt) ct
-    | Pexp_variant (l, None) -> pp f "`%s" l
+    | Pexp_variant (l, None) -> pp f "`%a" protect_ident l
     | Pexp_record (l, eo) ->
         let longident_x_expression f ( li, e) =
           match e with
@@ -868,12 +883,14 @@ and class_type_field ctxt f x =
       pp f "@[<2>inherit@ %a@]%a" (class_type ctxt) ct
         (item_attributes ctxt) x.pctf_attributes
   | Pctf_val (s, mf, vf, ct) ->
-      pp f "@[<2>val @ %a%a%s@ :@ %a@]%a"
-        mutable_flag mf virtual_flag vf s.txt (core_type ctxt) ct
+      pp f "@[<2>val @ %a%a%a@ :@ %a@]%a"
+        mutable_flag mf virtual_flag vf
+        protect_ident s.txt (core_type ctxt) ct
         (item_attributes ctxt) x.pctf_attributes
   | Pctf_method (s, pf, vf, ct) ->
-      pp f "@[<2>method %a %a%s :@;%a@]%a"
-        private_flag pf virtual_flag vf s.txt (core_type ctxt) ct
+      pp f "@[<2>method %a %a%a :@;%a@]%a"
+        private_flag pf virtual_flag vf
+        protect_ident s.txt (core_type ctxt) ct
         (item_attributes ctxt) x.pctf_attributes
   | Pctf_constraint (ct1, ct2) ->
       pp f "@[<2>constraint@ %a@ =@ %a@]%a"
@@ -920,9 +937,10 @@ and class_type ctxt f x =
 and class_type_declaration_list ctxt f l =
   let class_type_declaration kwd f x =
     let { pci_params=ls; pci_name={ txt; _ }; _ } = x in
-    pp f "@[<2>%s %a%a%s@ =@ %a@]%a" kwd
+    pp f "@[<2>%s %a%a%a@ =@ %a@]%a" kwd
       virtual_flag x.pci_virt
-      (class_params_def ctxt) ls txt
+      (class_params_def ctxt) ls
+      protect_ident txt
       (class_type ctxt) x.pci_expr
       (item_attributes ctxt) x.pci_attributes
   in
@@ -941,21 +959,24 @@ and class_field ctxt f x =
         (class_expr ctxt) ce
         (fun f so -> match so with
            | None -> ();
-           | Some (s) -> pp f "@ as %s" s.txt ) so
+           | Some (s) -> pp f "@ as %a" protect_ident s.txt ) so
         (item_attributes ctxt) x.pcf_attributes
   | Pcf_val (s, mf, Cfk_concrete (ovf, e)) ->
-      pp f "@[<2>val%s %a%s =@;%a@]%a" (override ovf)
-        mutable_flag mf s.txt
+      pp f "@[<2>val%s %a%a =@;%a@]%a" (override ovf)
+        mutable_flag mf
+        protect_ident s.txt
         (expression ctxt) e
         (item_attributes ctxt) x.pcf_attributes
   | Pcf_method (s, pf, Cfk_virtual ct) ->
-      pp f "@[<2>method virtual %a %s :@;%a@]%a"
-        private_flag pf s.txt
+      pp f "@[<2>method virtual %a %a :@;%a@]%a"
+        private_flag pf
+        protect_ident s.txt
         (core_type ctxt) ct
         (item_attributes ctxt) x.pcf_attributes
   | Pcf_val (s, mf, Cfk_virtual ct) ->
-      pp f "@[<2>val virtual %a%s :@ %a@]%a"
-        mutable_flag mf s.txt
+      pp f "@[<2>val virtual %a%a :@ %a@]%a"
+        mutable_flag mf
+        protect_ident s.txt
         (core_type ctxt) ct
         (item_attributes ctxt) x.pcf_attributes
   | Pcf_method (s, pf, Cfk_concrete (ovf, e)) ->
@@ -976,8 +997,8 @@ and class_field ctxt f x =
         private_flag pf
         (fun f -> function
            | {pexp_desc=Pexp_poly (e, Some ct); pexp_attributes=[]; _} ->
-               pp f "%s :@;%a=@;%a"
-                 s.txt (core_type ctxt) ct (expression ctxt) e
+               pp f "%a :@;%a=@;%a"
+                 protect_ident s.txt (core_type ctxt) ct (expression ctxt) e
            | {pexp_desc=Pexp_poly (e, None); pexp_attributes=[]; _} ->
                bind e
            | _ -> bind e) e
@@ -1121,9 +1142,10 @@ and signature_item ctxt f x : unit =
       exception_declaration ctxt f ed
   | Psig_class l ->
       let class_description kwd f ({pci_params=ls;pci_name={txt;_};_} as x) =
-        pp f "@[<2>%s %a%a%s@;:@;%a@]%a" kwd
+        pp f "@[<2>%s %a%a%a@;:@;%a@]%a" kwd
           virtual_flag x.pci_virt
-          (class_params_def ctxt) ls txt
+          (class_params_def ctxt) ls
+          protect_ident txt
           (class_type ctxt) x.pci_expr
           (item_attributes ctxt) x.pci_attributes
       in begin
@@ -1255,7 +1277,7 @@ and binding ctxt f {pvb_pat=p; pvb_expr=x; _} =
             pp f "%a@ %a"
               (label_exp ctxt) (label,eo,p) pp_print_pexp_function e
       | Pexp_newtype (str,e) ->
-          pp f "(type@ %s)@ %a" str.txt pp_print_pexp_function e
+          pp f "(type@ %a)@ %a" protect_ident str.txt pp_print_pexp_function e
       | _ -> pp f "=@;%a" (expression ctxt) x
   in
   let tyvars_str tyvars = List.map (fun v -> v.txt) tyvars in
@@ -1420,9 +1442,10 @@ and structure_item ctxt f x =
       let class_declaration kwd f
           ({pci_params=ls; pci_name={txt;_}; _} as x) =
         let args, constr, cl = extract_class_args x.pci_expr in
-        pp f "@[<2>%s %a%a%s %a%a=@;%a@]%a" kwd
+        pp f "@[<2>%s %a%a%a %a%a=@;%a@]%a" kwd
           virtual_flag x.pci_virt
-          (class_params_def ctxt) ls txt
+          (class_params_def ctxt) ls
+          protect_ident txt
           (list (label_exp ctxt)) args
           (option class_constraint) constr
           (class_expr ctxt) cl
@@ -1496,10 +1519,11 @@ and type_def_list ctxt f (rf, exported, l) =
       else if exported then " ="
       else " :="
     in
-    pp f "@[<2>%s %a%a%s%s%a@]%a" kwd
+    pp f "@[<2>%s %a%a%a%s%a@]%a" kwd
       nonrec_flag rf
       (type_params ctxt) x.ptype_params
-      x.ptype_name.txt eq
+      protect_ident x.ptype_name.txt
+      eq
       (type_declaration ctxt) x
       (item_attributes ctxt) x.ptype_attributes
   in
@@ -1512,9 +1536,9 @@ and type_def_list ctxt f (rf, exported, l) =
 
 and record_declaration ctxt f lbls =
   let type_record_field f pld =
-    pp f "@[<2>%a%s:@;%a@;%a@]"
+    pp f "@[<2>%a%a:@;%a@;%a@]"
       mutable_flag pld.pld_mutable
-      pld.pld_name.txt
+      protect_ident pld.pld_name.txt
       (core_type ctxt) pld.pld_type
       (attributes ctxt) pld.pld_attributes
   in
@@ -1646,14 +1670,14 @@ and label_x_expression_param ctxt f (l,e) =
   | Nolabel  -> expression2 ctxt f e (* level 2*)
   | Optional str ->
       if Some str = simple_name then
-        pp f "?%s" str
+        pp f "?%a" protect_ident str
       else
-        pp f "?%s:%a" str (simple_expr ctxt) e
+        pp f "?%a:%a" protect_ident str (simple_expr ctxt) e
   | Labelled lbl ->
       if Some lbl = simple_name then
-        pp f "~%s" lbl
+        pp f "~%a" protect_ident lbl
       else
-        pp f "~%s:%a" lbl (simple_expr ctxt) e
+        pp f "~%a:%a" protect_ident lbl (simple_expr ctxt) e
 
 and directive_argument f x =
   match x.pdira_desc with

--- a/parsing/pprintast.mli
+++ b/parsing/pprintast.mli
@@ -50,6 +50,7 @@ val signature_item: Format.formatter -> Parsetree.signature_item -> unit
 val binding: Format.formatter -> Parsetree.value_binding -> unit
 val payload: Format.formatter -> Parsetree.payload -> unit
 
+val tyvar_name : string -> string
 val tyvar: Format.formatter -> string -> unit
   (** Print a type variable name, taking care of the special treatment
       required for the single quote character in second position. *)

--- a/testsuite/tests/let-syntax/let_syntax.ml
+++ b/testsuite/tests/let-syntax/let_syntax.ml
@@ -146,7 +146,7 @@ let let_unbound =
 Line 3, characters 4-8:
 3 |     let+ x = 1 in
         ^^^^
-Error: Unbound value let+
+Error: Unbound value (let+)
 |}];;
 
 module And_unbound = struct
@@ -166,7 +166,7 @@ let and_unbound =
 Line 4, characters 4-8:
 4 |     and+ y = 2 in
         ^^^^
-Error: Unbound value and+
+Error: Unbound value (and+)
 |}];;
 
 module Ill_typed_1 = struct

--- a/testsuite/tests/parsetree/source.ml
+++ b/testsuite/tests/parsetree/source.ml
@@ -7450,3 +7450,21 @@ let goober a = match a with C (type a b) y -> y
 module type s = sig type ('a,'b) t end with type (-!'a, !+'b) t = 'b -> 'a list
 module type s = sig type ('a,'b) t end with type (!-'a, +!'b) t := 'b -> 'a list
 module type s = sig type ('a,'b) t end with type ('a,'b) t := 'b -> 'a list
+
+(* Raw identifiers *)
+
+module type A = sig
+  type ('\#let, '\#a) \#virtual = ('\#let * '\#a) as '\#mutable
+  val foo : '\#let '\#a . '\#a -> '\#let -> unit
+  type \#foo = { \#let : int }
+end
+
+module M = struct
+  let (\#let,\#foo) as \#val = (\#mutable,\#baz)
+  let _ = fun (type \#let) (type \#foo) -> 1
+  let f g ~\#let ?\#and ?(\#for = \#and) () =
+    g ~\#let ?\#and ()
+  class \#let = object
+    inherit \#val \#let as \#mutable
+  end
+end

--- a/testsuite/tests/parsing/rawidents.ml
+++ b/testsuite/tests/parsing/rawidents.ml
@@ -1,0 +1,100 @@
+(* TEST
+   * expect
+*)
+
+module M : sig
+  class \#and : object
+    val mutable \#and : int
+    method \#and : int
+  end
+end = struct
+  class \#and =
+    let \#and = 1 in
+    object
+      val mutable \#and = \#and
+      method \#and = 2
+    end
+end
+let obj = new M.\#and
+[%%expect{|
+module M :
+  sig class \#and : object val mutable \#and : int method \#and : int end end
+val obj : M.\#and = <obj>
+|}]
+
+module M : sig type \#and = int end = struct type \#and = string end
+[%%expect{|
+Line 1, characters 38-68:
+1 | module M : sig type \#and = int end = struct type \#and = string end
+                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: Signature mismatch:
+       Modules do not match:
+         sig type \#and = string end
+       is not included in
+         sig type \#and = int end
+       Type declarations do not match:
+         type \#and = string
+       is not included in
+         type \#and = int
+       The type string is not equal to the type int
+|}]
+
+let x = (`\#let `\#and : [ `\#let of [ `\#and ] ])
+let `\#let \#rec = x
+[%%expect{|
+val x : [ `\#let of [ `\#and ] ] = `\#let `\#and
+val \#rec : [ `\#and ] = `\#and
+|}]
+
+
+let f g ~\#let ?\#and ?(\#for = \#and) () =
+  g ~\#let ?\#and ()
+[%%expect{|
+val f :
+  (\#let:'a -> ?\#and:'b -> unit -> 'c) ->
+  \#let:'a -> ?\#and:'b -> ?\#for:'b option -> unit -> 'c = <fun>
+|}]
+
+
+type t = '\#let
+[%%expect{|
+Line 1, characters 9-15:
+1 | type t = '\#let
+             ^^^^^^
+Error: The type variable '\#let is unbound in this type declaration.
+|}]
+
+type \#mutable = { mutable \#mutable : \#mutable }
+let rec \#rec = { \#mutable = \#rec }
+[%%expect{|
+type \#mutable = { mutable \#mutable : \#mutable; }
+val \#rec : \#mutable = {\#mutable = <cycle>}
+|}]
+
+type \#and = ..
+type \#and += Foo
+[%%expect{|
+type \#and = ..
+type \#and += Foo
+|}]
+
+let x = (++);;
+[%%expect{|
+Line 1, characters 8-12:
+1 | let x = (++);;
+            ^^^^
+Error: Unbound value (++)
+|}]
+
+let x = \#let;;
+[%%expect{|
+Line 1, characters 8-13:
+1 | let x = \#let;;
+            ^^^^^
+Error: Unbound value \#let
+|}]
+
+let f ~\#let ?\#and () = 1
+[%%expect{|
+val f : \#let:'a -> ?\#and:'b -> unit -> int = <fun>
+|}]

--- a/toplevel/genprintval.ml
+++ b/toplevel/genprintval.ml
@@ -378,7 +378,7 @@ module Make(O : OBJ)(EVP : EVALPATH with type valu = O.t) = struct
                    then nest tree_of_val depth forced_obj ty_arg
                    else      tree_of_val depth forced_obj ty_arg
                  in
-                 Oval_constr (Oide_ident (Out_name.create "lazy"), [v])
+                 Oval_lazy v
                end
           | Tconstr(path, ty_list, _) -> begin
               try

--- a/typing/oprint.ml
+++ b/typing/oprint.ml
@@ -24,6 +24,7 @@ let cautious f ppf arg =
 
 let print_lident ppf = function
   | "::" -> pp_print_string ppf "(::)"
+  | s when Lexer.is_keyword s -> fprintf ppf "\\#%s" s
   | s -> pp_print_string ppf s
 
 let rec print_ident ppf =
@@ -62,6 +63,8 @@ let parenthesized_ident name =
 let value_ident ppf name =
   if parenthesized_ident name then
     fprintf ppf "( %s )" name
+  else if Lexer.is_keyword name then
+    fprintf ppf "\\#%s" name
   else
     pp_print_string ppf name
 
@@ -153,16 +156,26 @@ let print_out_string ppf s =
   else
     fprintf ppf "%S" s
 
+let print_constr ppf name =
+  match name with
+  | Oide_ident {printed_name = ("true" | "false") as c} ->
+    (* despite being keywords, these are constructor names
+       and should not be escaped *)
+    fprintf ppf "%s" c
+  | _ -> print_ident ppf name
+
 let print_out_value ppf tree =
   let rec print_tree_1 ppf =
     function
     | Oval_constr (name, [param]) ->
-        fprintf ppf "@[<1>%a@ %a@]" print_ident name print_constr_param param
+        fprintf ppf "@[<1>%a@ %a@]" print_constr name print_constr_param param
     | Oval_constr (name, (_ :: _ as params)) ->
-        fprintf ppf "@[<1>%a@ (%a)@]" print_ident name
+        fprintf ppf "@[<1>%a@ (%a)@]" print_constr name
           (print_tree_list print_tree_1 ",") params
     | Oval_variant (name, Some param) ->
-        fprintf ppf "@[<2>`%s@ %a@]" name print_constr_param param
+        fprintf ppf "@[<2>`%a@ %a@]" print_lident name print_constr_param param
+    | Oval_lazy param ->
+        fprintf ppf "@[<2>lazy@ %a@]" print_constr_param param
     | tree -> print_simple_tree ppf tree
   and print_constr_param ppf = function
     | Oval_int i -> parenthesize_if_neg ppf "%i" i (i < 0)
@@ -205,8 +218,8 @@ let print_out_value ppf tree =
         fprintf ppf "@[<1>[%a]@]" (print_tree_list print_tree_1 ";") tl
     | Oval_array tl ->
         fprintf ppf "@[<2>[|%a|]@]" (print_tree_list print_tree_1 ";") tl
-    | Oval_constr (name, []) -> print_ident ppf name
-    | Oval_variant (name, None) -> fprintf ppf "`%s" name
+    | Oval_constr (name, []) -> print_constr ppf name
+    | Oval_variant (name, None) -> fprintf ppf "`%a" print_lident name
     | Oval_stuff s -> pp_print_string ppf s
     | Oval_record fel ->
         fprintf ppf "@[<1>{%a}@]" (cautious (print_fields true)) fel
@@ -259,6 +272,12 @@ let pr_var = Pprintast.tyvar
 let pr_vars =
   print_list pr_var (fun ppf -> fprintf ppf "@ ")
 
+let print_arg_label ppf (lbl : Asttypes.arg_label) =
+  match lbl with
+  | Nolabel -> ()
+  | Labelled s -> fprintf ppf "%a:" print_lident s
+  | Optional s -> fprintf ppf "?%a:" print_lident s
+
 let rec print_out_type ppf =
   function
   | Otyp_alias (ty, s) ->
@@ -274,7 +293,7 @@ and print_out_type_1 ppf =
   function
     Otyp_arrow (lab, ty1, ty2) ->
       pp_open_box ppf 0;
-      if lab <> "" then (pp_print_string ppf lab; pp_print_char ppf ':');
+      print_arg_label ppf lab;
       print_out_type_2 ppf ty1;
       pp_print_string ppf " ->";
       pp_print_space ppf ();
@@ -352,7 +371,7 @@ and print_fields rest ppf =
       | None -> ()
       end
   | [s, t] ->
-      fprintf ppf "%s : %a" s print_out_type t;
+      fprintf ppf "%a : %a" print_lident s print_out_type t;
       begin match rest with
         Some _ -> fprintf ppf ";@ "
       | None -> ()
@@ -366,7 +385,8 @@ and print_row_field ppf (l, opt_amp, tyl) =
     else if tyl <> [] then fprintf ppf " of@ "
     else fprintf ppf ""
   in
-  fprintf ppf "@[<hv 2>`%s%t%a@]" l pr_of (print_typlist print_out_type " &")
+  fprintf ppf "@[<hv 2>`%a%t%a@]" print_lident l pr_of
+    (print_typlist print_out_type " &")
     tyl
 and print_typlist print_elem sep ppf =
   function
@@ -389,7 +409,8 @@ and print_typargs ppf =
       pp_close_box ppf ();
       pp_print_space ppf ()
 and print_out_label ppf (name, mut, arg) =
-  fprintf ppf "@[<2>%s%s :@ %a@];" (if mut then "mutable " else "") name
+  fprintf ppf "@[<2>%s%a :@ %a@];" (if mut then "mutable " else "")
+    print_lident name
     print_out_type arg
 
 let out_label = ref print_out_label
@@ -429,7 +450,7 @@ let rec print_out_class_type ppf =
       in
       fprintf ppf "@[%a%a@]" pr_tyl tyl print_ident id
   | Octy_arrow (lab, ty, cty) ->
-      fprintf ppf "@[%s%a ->@ %a@]" (if lab <> "" then lab ^ ":" else "")
+      fprintf ppf "@[%a%a ->@ %a@]" print_arg_label lab
         print_out_type_2 ty print_out_class_type cty
   | Octy_signature (self_ty, csil) ->
       let pr_param ppf =
@@ -446,14 +467,14 @@ and print_out_class_sig_item ppf =
       fprintf ppf "@[<2>constraint %a =@ %a@]" !out_type ty1
         !out_type ty2
   | Ocsg_method (name, priv, virt, ty) ->
-      fprintf ppf "@[<2>method %s%s%s :@ %a@]"
+      fprintf ppf "@[<2>method %s%s%a :@ %a@]"
         (if priv then "private " else "") (if virt then "virtual " else "")
-        name !out_type ty
+        print_lident name !out_type ty
   | Ocsg_value (name, mut, vr, ty) ->
-      fprintf ppf "@[<2>val %s%s%s :@ %a@]"
+      fprintf ppf "@[<2>val %s%s%a :@ %a@]"
         (if mut then "mutable " else "")
         (if vr then "virtual " else "")
-        name !out_type ty
+        print_lident name !out_type ty
 
 let out_class_type = ref print_out_class_type
 
@@ -593,15 +614,15 @@ and print_out_signature ppf =
 and print_out_sig_item ppf =
   function
     Osig_class (vir_flag, name, params, clt, rs) ->
-      fprintf ppf "@[<2>%s%s@ %a%s@ :@ %a@]"
+      fprintf ppf "@[<2>%s%s@ %a%a@ :@ %a@]"
         (if rs = Orec_next then "and" else "class")
         (if vir_flag then " virtual" else "") print_out_class_params params
-        name !out_class_type clt
+        print_lident name !out_class_type clt
   | Osig_class_type (vir_flag, name, params, clt, rs) ->
-      fprintf ppf "@[<2>%s%s@ %a%s@ =@ %a@]"
+      fprintf ppf "@[<2>%s%s@ %a%a@ =@ %a@]"
         (if rs = Orec_next then "and" else "class type")
         (if vir_flag then " virtual" else "") print_out_class_params params
-        name !out_class_type clt
+        print_lident name !out_class_type clt
   | Osig_typext (ext, Oext_exception) ->
       fprintf ppf "@[<2>exception %a@]"
         print_out_constr (constructor_of_extension_constructor ext)
@@ -652,13 +673,15 @@ and print_out_type_decl kwd ppf td =
   in
   let type_defined ppf =
     match td.otype_params with
-      [] -> pp_print_string ppf td.otype_name
-    | [param] -> fprintf ppf "@[%a@ %s@]" type_parameter param td.otype_name
+      [] -> print_lident ppf td.otype_name
+    | [param] ->
+        fprintf ppf "@[%a@ %a@]" type_parameter param
+          print_lident td.otype_name
     | _ ->
-        fprintf ppf "@[(@[%a)@]@ %s@]"
+        fprintf ppf "@[(@[%a)@]@ %a@]"
           (print_list type_parameter (fun ppf -> fprintf ppf ",@ "))
           td.otype_params
-          td.otype_name
+          print_lident td.otype_name
   in
   let print_manifest ppf =
     function
@@ -747,17 +770,17 @@ and print_out_constr ppf constr =
 and print_out_extension_constructor ppf ext =
   let print_extended_type ppf =
       match ext.oext_type_params with
-        [] -> fprintf ppf "%s" ext.oext_type_name
+        [] -> fprintf ppf "%a" print_lident ext.oext_type_name
       | [ty_param] ->
-        fprintf ppf "@[%a@ %s@]"
+        fprintf ppf "@[%a@ %a@]"
           print_type_parameter
           ty_param
-          ext.oext_type_name
+          print_lident ext.oext_type_name
       | _ ->
-        fprintf ppf "@[(@[%a)@]@ %s@]"
+        fprintf ppf "@[(@[%a)@]@ %a@]"
           (print_list print_type_parameter (fun ppf -> fprintf ppf ",@ "))
           ext.oext_type_params
-          ext.oext_type_name
+          print_lident ext.oext_type_name
   in
   fprintf ppf "@[<hv 2>type %t +=%s@;<1 2>%a@]"
     print_extended_type
@@ -768,16 +791,16 @@ and print_out_extension_constructor ppf ext =
 and print_out_type_extension ppf te =
   let print_extended_type ppf =
     match te.otyext_params with
-      [] -> fprintf ppf "%s" te.otyext_name
+      [] -> fprintf ppf "%a" print_lident te.otyext_name
     | [param] ->
-      fprintf ppf "@[%a@ %s@]"
+      fprintf ppf "@[%a@ %a@]"
         print_type_parameter param
-        te.otyext_name
+        print_lident te.otyext_name
     | _ ->
-        fprintf ppf "@[(@[%a)@]@ %s@]"
+        fprintf ppf "@[(@[%a)@]@ %a@]"
           (print_list print_type_parameter (fun ppf -> fprintf ppf ",@ "))
           te.otyext_params
-          te.otyext_name
+          print_lident te.otyext_name
   in
   fprintf ppf "@[<hv 2>type %t +=%s@;<1 2>%a@]"
     print_extended_type

--- a/typing/outcometree.mli
+++ b/typing/outcometree.mli
@@ -55,6 +55,7 @@ type out_value =
   | Oval_stuff of string
   | Oval_tuple of out_value list
   | Oval_variant of string * out_value option
+  | Oval_lazy of out_value
 
 type out_type_param = string * (Asttypes.variance * Asttypes.injectivity)
 
@@ -62,7 +63,7 @@ type out_type =
   | Otyp_abstract
   | Otyp_open
   | Otyp_alias of out_type * string
-  | Otyp_arrow of string * out_type * out_type
+  | Otyp_arrow of Asttypes.arg_label * out_type * out_type
   | Otyp_class of bool * out_ident * out_type list
   | Otyp_constr of out_ident * out_type list
   | Otyp_manifest of out_type * out_type
@@ -90,7 +91,7 @@ and out_variant =
 
 type out_class_type =
   | Octy_constr of out_ident * out_type list
-  | Octy_arrow of string * out_type * out_class_type
+  | Octy_arrow of Asttypes.arg_label * out_type * out_class_type
   | Octy_signature of out_type option * out_class_sig_item list
 and out_class_sig_item =
   | Ocsg_constraint of out_type * out_type

--- a/typing/path.ml
+++ b/typing/path.ml
@@ -90,9 +90,13 @@ let rec scope = function
 
 let kfalse _ = false
 
+let maybe_escape s =
+  if Lexer.is_keyword s then "\\#" ^ s else s
+
 let rec name ?(paren=kfalse) = function
-    Pident id -> Ident.name id
+    Pident id -> maybe_escape (Ident.name id)
   | Pdot(p, s) | Pextra_ty (p, Pcstr_ty s) ->
+      let s = maybe_escape s in
       name ~paren p ^ if paren s then ".( " ^ s ^ " )" else "." ^ s
   | Papply(p1, p2) -> name ~paren p1 ^ "(" ^ name ~paren p2 ^ ")"
   | Pextra_ty (p, Pext_ty) -> name ~paren p

--- a/typing/printtyp.ml
+++ b/typing/printtyp.ml
@@ -28,11 +28,7 @@ open Outcometree
 module String = Misc.Stdlib.String
 
 (* Print a long identifier *)
-
-let rec longident ppf = function
-  | Lident s -> pp_print_string ppf s
-  | Ldot(p, s) -> fprintf ppf "%a.%s" longident p s
-  | Lapply(p1, p2) -> fprintf ppf "%a(%a)" longident p1 longident p2
+let longident = Pprintast.longident
 
 let () = Env.print_longident := longident
 
@@ -1091,7 +1087,7 @@ let rec tree_of_typexp mode ty =
         Otyp_var (non_gen, Names.name_of_type name_gen tty)
     | Tarrow(l, ty1, ty2, _) ->
         let lab =
-          if !print_labels || is_optional l then string_of_label l else ""
+          if !print_labels || is_optional l then l else Nolabel
         in
         let t1 =
           if is_optional l then
@@ -1672,7 +1668,7 @@ let rec tree_of_class_type mode params =
       Octy_signature (self_ty, List.rev csil)
   | Cty_arrow (l, ty, cty) ->
       let lab =
-        if !print_labels || is_optional l then string_of_label l else ""
+        if !print_labels || is_optional l then l else Nolabel
       in
       let tr =
        if is_optional l then

--- a/typing/typetexp.ml
+++ b/typing/typetexp.ml
@@ -126,7 +126,8 @@ let type_variable loc name =
   try
     TyVarMap.find name !type_variables
   with Not_found ->
-    raise(Error(loc, Env.empty, Unbound_type_variable ("'" ^ name)))
+    raise(Error(loc, Env.empty,
+                Unbound_type_variable (Pprintast.tyvar_name name)))
 
 let valid_tyvar_name name =
   name <> "" && name.[0] <> '_'
@@ -586,7 +587,8 @@ let globalize_used_variables env fixed =
         r := (loc, v,  TyVarMap.find name !type_variables) :: !r
       with Not_found ->
         if fixed && Btype.is_Tvar ty then
-          raise(Error(loc, env, Unbound_type_variable ("'"^name)));
+          raise(Error(loc, env,
+                      Unbound_type_variable (Pprintast.tyvar_name name)));
         let v2 = new_global_var () in
         r := (loc, v, v2) :: !r;
         type_variables := TyVarMap.add name v2 !type_variables)
@@ -684,7 +686,8 @@ open Printtyp
 
 let report_error env ppf = function
   | Unbound_type_variable name ->
-      let add_name name _ l = if name = "_" then l else ("'" ^ name) :: l in
+      let add_name name _ l =
+        if name = "_" then l else Pprintast.tyvar_name name :: l in
       let names = TyVarMap.fold add_name !type_variables [] in
     fprintf ppf "The type variable %s is unbound in this type declaration.@ %a"
       name


### PR DESCRIPTION
This PR implements part of [RFC 27](https://github.com/ocaml/RFCs/pull/27) by adding support for 'raw identifiers' `\#foo`. The syntax `\#foo` means the same thing as `foo`, but is always an identifier even when `foo` is a keyword. This allows future versions of the language to introduce new keywords in a backwards-compatible way (see the RFC for full details).

The important part of this patch is the small patch to `lexer.mll` which adds the new concrete syntax. The entire rest of the patch is changes to various pretty-printers, to ensure that keywords are printed in appropriately escaped form should they ever occur as variable names, in types, in error messages, and the like.