### PR TITLE
Start the release of the `ocaml` command for other purposes

### DIFF
--- a/Changes
+++ b/Changes
@@ -225,9 +225,9 @@ Working version
 - #11184: Stop calling ranlib on created / installed libraries
   (Sébastien Hinderer, review by Xavier Leroy)
 
-- #11253: Deprecate `ocaml script` where `script` has no extension and is an
-  implicit basename.
-  (David Allsopp, review by Florian Angeletti)
+- #11253: Deprecate `ocaml script` and `ocamlnat` script where `script` has no
+  extension and is an implicit basename.
+  (David Allsopp, review by Florian Angeletti and Sébastien Hinderer)
 
 ### Internal/compiler-libs changes:
 

--- a/Changes
+++ b/Changes
@@ -225,6 +225,10 @@ Working version
 - #11184: Stop calling ranlib on created / installed libraries
   (Sébastien Hinderer, review by Xavier Leroy)
 
+- #11253: Deprecate `ocaml script` where `script` has no extension and is an
+  implicit basename.
+  (David Allsopp, review by Florian Angeletti)
+
 ### Internal/compiler-libs changes:
 
 - #10878, #10909: restore flambda after the Multicore merge.

--- a/parsing/location.ml
+++ b/parsing/location.ml
@@ -908,12 +908,12 @@ let auto_include_alert lib =
   in
   prerr_alert none alert
 
-let deprecated_script_alert () =
-  let message = "\
-    Running ocaml where the first argument is an implicit basename with no \
-    extension (e.g. ocaml script-file) is deprecated. Either rename the \
-    script (ocaml script-file.ml) or qualify the basename \
-    (ocaml ./script-file)"
+let deprecated_script_alert program =
+  let message = Printf.sprintf "\
+    Running %s where the first argument is an implicit basename with no \
+    extension (e.g. %s script-file) is deprecated. Either rename the script \
+    (%s script-file.ml) or qualify the basename (%s ./script-file)"
+    program program program program
   in
   let alert =
     {Warnings.kind="ocaml_deprecated_cli"; use=none; def=none;

--- a/parsing/location.ml
+++ b/parsing/location.ml
@@ -908,6 +908,19 @@ let auto_include_alert lib =
   in
   prerr_alert none alert
 
+let deprecated_script_alert () =
+  let message = "\
+    Running ocaml where the first argument is an implicit basename with no \
+    extension (e.g. ocaml script-file) is deprecated. Either rename the \
+    script (ocaml script-file.ml) or qualify the basename \
+    (ocaml ./script-file)"
+  in
+  let alert =
+    {Warnings.kind="ocaml_deprecated_cli"; use=none; def=none;
+     message = Format.asprintf "@[@\n%a@]" Format.pp_print_text message}
+  in
+  prerr_alert none alert
+
 (******************************************************************************)
 (* Reporting errors on exceptions *)
 

--- a/parsing/location.mli
+++ b/parsing/location.mli
@@ -247,9 +247,9 @@ val auto_include_alert: string -> unit
 (** Prints an alert that -I +lib has been automatically added to the load
     path *)
 
-val deprecated_script_alert: unit -> unit
-(** Prints an alert that [ocaml foo] has been deprecated in favour of
-    [ocaml ./foo] *)
+val deprecated_script_alert: string -> unit
+(** [deprecated_script_alert command] prints an alert that [command foo] has
+    been deprecated in favour of [command ./foo] *)
 
 (** {1 Reporting errors} *)
 

--- a/parsing/location.mli
+++ b/parsing/location.mli
@@ -244,8 +244,12 @@ val alert: ?def:t -> ?use:t -> kind:string -> t -> string -> unit
 (** Prints an arbitrary alert. *)
 
 val auto_include_alert: string -> unit
-(** Prints an alert that -I +lib has been automatically added ot the load
+(** Prints an alert that -I +lib has been automatically added to the load
     path *)
+
+val deprecated_script_alert: unit -> unit
+(** Prints an alert that [ocaml foo] has been deprecated in favour of
+    [ocaml ./foo] *)
 
 (** {1 Reporting errors} *)
 

--- a/toplevel/byte/topmain.ml
+++ b/toplevel/byte/topmain.ml
@@ -203,8 +203,13 @@ end)
 let main () =
   let ppf = Format.err_formatter in
   let program = "ocaml" in
+  let display_deprecated_script_alert =
+    Array.length !argv >= 2 && Topcommon.is_command_like_name !argv.(1)
+  in
   Topcommon.update_search_path_from_env ();
   Compenv.readenv ppf Before_args;
+  if display_deprecated_script_alert then
+    Location.deprecated_script_alert ();
   Clflags.add_arguments __LOC__ Options.list;
   Compenv.parse_arguments ~current argv file_argument program;
   Compenv.readenv ppf Before_link;

--- a/toplevel/byte/topmain.ml
+++ b/toplevel/byte/topmain.ml
@@ -209,7 +209,7 @@ let main () =
   Topcommon.update_search_path_from_env ();
   Compenv.readenv ppf Before_args;
   if display_deprecated_script_alert then
-    Location.deprecated_script_alert ();
+    Location.deprecated_script_alert program;
   Clflags.add_arguments __LOC__ Options.list;
   Compenv.parse_arguments ~current argv file_argument program;
   Compenv.readenv ppf Before_link;

--- a/toplevel/native/topmain.ml
+++ b/toplevel/native/topmain.ml
@@ -96,8 +96,13 @@ let main () =
   let ppf = Format.err_formatter in
   Clflags.native_code := true;
   let program = "ocamlnat" in
+  let display_deprecated_script_alert =
+    Array.length !argv >= 2 && Topcommon.is_command_like_name !argv.(1)
+  in
   Topcommon.update_search_path_from_env ();
   Compenv.readenv ppf Before_args;
+  if display_deprecated_script_alert then
+    Location.deprecated_script_alert program;
   Clflags.add_arguments __LOC__ Options.list;
   Compenv.parse_arguments ~current argv file_argument program;
   Compmisc.read_clflags_from_env ();

--- a/toplevel/topcommon.ml
+++ b/toplevel/topcommon.ml
@@ -301,6 +301,11 @@ let override_sys_argv new_argv =
   caml_sys_modify_argv new_argv;
   Arg.current := 0
 
+let is_command_like_name s =
+  not (String.length s = 0
+       || s.[0] = '-'
+       || Filename.basename s <> s
+       || Filename.extension s <> "")
 
 (* The table of toplevel directives.
    Filled by functions from module topdirs. *)

--- a/toplevel/topcommon.mli
+++ b/toplevel/topcommon.mli
@@ -218,6 +218,11 @@ val override_sys_argv : string array -> unit
    "script.ml args..." instead of the full command line:
    "ocamlrun unix.cma ... script.ml args...". *)
 
+(** [is_command_like_name s] is [true] if [s] is an implicit basename with no
+    file extension and which doesn't begin with a hyphen. Basically, if it looks
+    like a sub-command name (e.g. ocaml help). *)
+val is_command_like_name : string -> bool
+
 (**/**)
 
 (* internal functions used by [Topeval] *)


### PR DESCRIPTION
This was discussed at a core devs' meeting before 4.14 was branched, but I didn't write the commit until too close to the branching date.

Two (semi-distant) future possibilities:
- It might be nice if the two toplevels (`ocaml` and `ocamlnat`) agreed on a name and were `name.byte` and `name.opt`
- It might also be nice if `ocaml` could have sub-commands, or other meanings than invoking the bytecode interpreter (especially as these days a significant portion of the community actually consume the toplevel via `dune utop`). `cargo`, `drom`, etc.

Both of those are difficult and bike-sheddy discussions for another day, but to be even possible, the latter requires a small tweak to the existing bytecode toplevel which is what this PR addresses. We need `ocaml command` to stop meaning "run the file called `command` from the current directory".

This PR - for consideration for 5.0 - deprecates that syntax (it presently also includes a minor refactor commit from #11198). If you have a script called `hello`, with this PR it will now display:
```
dra@thor:~/ocaml$ PATH=~/ocaml/install/bin:$PATH ocaml hello
File "_none_", line 1:
Alert ocaml_deprecated_cli: Running ocaml where the first argument
is an implicit basename with no extension (e.g. ocaml script-file) is
deprecated. Either rename the script (ocaml script-file.ml) or qualify
the basename (ocaml ./script-file)
Hello, world
```
This alert may be silenced in three ways:
1. Rename the file to include an extension (e.g. `hello.ml`)
2. Make the filename explicit (i.e. `./hello`)
3. Use the `-` argument to stop it from being the first parameter (i.e. `ocaml - hello`)

Note in particular that the third form provides an escape hatch if there are any Unix systems still out there which don't pass absolute path to the script when used in a shebang, e.g. `hello`:

```
#!/usr/bin/ocaml
print_endline "Hello, world"
```
On modern Unix systems, the path to the script is passed either as a full path (e.g. `/home/dra/ocaml/hello`) or at least as a `/dev/fd/N` but the shebang could be changed to `#!/usr/bin/ocaml -` for a system which chooses to pass the script name verbatim (i.e. if you run `hello`, and `hello` is resolved and in the current directory, there have been Unix systems which passed `hello` instead of `./hello` as the script filename; most now prepend the `./` or give the absolute path.
