### PR TITLE
Expand more variables at configure time

### DIFF
--- a/Makefile.build_config.in
+++ b/Makefile.build_config.in
@@ -56,6 +56,9 @@ PACKAGE_TARNAME = @PACKAGE_TARNAME@
 datarootdir = @datarootdir@
 DOCDIR=@docdir@
 
+# Flexlink command
+FLEXLINK_CMD=@flexlink_cmd@
+
 # Platform-dependent assembler files to use to build the runtime
 runtime_ASM_OBJECTS = $(addprefix runtime/,@runtime_asm_objects@)
 

--- a/Makefile.build_config.in
+++ b/Makefile.build_config.in
@@ -56,8 +56,9 @@ PACKAGE_TARNAME = @PACKAGE_TARNAME@
 datarootdir = @datarootdir@
 DOCDIR=@docdir@
 
-# Flexlink command
-FLEXLINK_CMD=@flexlink_cmd@
+# Expanded form of MKEXE_EXP and MKDLL_EXP _with host flexlink command_
+MKEXE_EXP=@mkexe_exp@
+MKDLL_EXP=@mkdll_exp@
 
 # Platform-dependent assembler files to use to build the runtime
 runtime_ASM_OBJECTS = $(addprefix runtime/,@runtime_asm_objects@)

--- a/Makefile.common
+++ b/Makefile.common
@@ -76,7 +76,6 @@ ifeq "$(BOOTSTRAPPING_FLEXDLL)" "false"
   MKLIB_CMD = $(MKLIB)
   ocamlc_cmd = $(ocamlc)
   ocamlopt_cmd = $(ocamlopt)
-  FLEXLINK_CMD=flexlink
 else
 ifeq "$(wildcard $(ROOTDIR)/flexlink.opt$(EXE))" ""
   FLEXLINK_ENV = \
@@ -91,8 +90,6 @@ endif # ifeq "$(wildcard $(ROOTDIR)/flexlink.opt$(EXE))" ""
   MKLIB_CMD = $(FLEXLINK_ENV) $(MKLIB)
   ocamlc_cmd = $(FLEXLINK_ENV) $(ocamlc)
   ocamlopt_cmd = $(FLEXLINK_ENV) $(ocamlopt)
-  FLEXLINK_CMD=$(ROOTDIR)/boot/ocamlruns$(EXE) \
-               $(ROOTDIR)/boot/flexlink.byte$(EXE)
 endif # ifeq "$(BOOTSTRAPPING_FLEXDLL)" "false"
 
 # List of other libraries

--- a/Makefile.config.in
+++ b/Makefile.config.in
@@ -216,7 +216,7 @@ FLEXDLL_CHAIN=@flexdll_chain@
 FLEXLINK_FLAGS=@mkexe_extra_flags@
 
 MKEXE=@mkexe@
-MKDLL=@mksharedlib@
+MKDLL=@mkdll@
 MKMAINDLL=@mkmaindll@
 MKEXEDEBUGFLAG=@mkexedebugflag@
 MKEXE_VIA_CC=$(CC) $(OC_CFLAGS) $(CFLAGS) @mkexe_via_cc_ldflags@

--- a/Makefile.config.in
+++ b/Makefile.config.in
@@ -209,7 +209,7 @@ TOOLCHAIN=@toolchain@
 CMXS=@cmxs@
 
 # On Windows, MKDLL, MKEXE and MKMAINDLL must ultimately be equivalent to
-#   $(FLEXLINK_CMD) $(FLEXLINK_FLAGS) [-exe|-maindll]
+#   flexlink $(FLEXLINK_FLAGS) [-exe|-maindll]
 # or OCAML_FLEXLINK overriding will not work (see utils/config.mlp)
 
 FLEXDLL_CHAIN=@flexdll_chain@

--- a/configure
+++ b/configure
@@ -772,7 +772,7 @@ install_source_artifacts
 install_bytecode_programs
 mksharedlibrpath
 mkmaindll
-mksharedlib
+mkdll
 rpath
 sharedlib_cflags
 asm_cfi_supported
@@ -14080,7 +14080,7 @@ fi
 # Shared library support
 
 sharedlib_cflags=''
-mksharedlib='shared-libs-not-available'
+mkdll='shared-libs-not-available'
 rpath=''
 mksharedlibrpath=''
 natdynlinkopts=""
@@ -14088,37 +14088,37 @@ natdynlinkopts=""
 if test x"$enable_shared" != "xno"; then :
   case $host in #(
   x86_64-apple-darwin*) :
-    mksharedlib='$(CC) -shared '\
+    mkdll='$(CC) -shared '\
 '-undefined dynamic_lookup -Wl,-no_compact_unwind'
       supports_shared_libraries=true ;; #(
   aarch64-apple-darwin*|arm64-apple-darwin*) :
-    mksharedlib='$(CC) -shared -undefined dynamic_lookup'
+    mkdll='$(CC) -shared -undefined dynamic_lookup'
       supports_shared_libraries=true ;; #(
   *-*-mingw32) :
-    mksharedlib="${flexlink_cmd} -chain ${flexdll_chain}"
+    mkdll="${flexlink_cmd} -chain ${flexdll_chain}"
       mkmaindll="${flexlink_cmd} -maindll -chain ${flexdll_chain}"
       if test -n "$oc_dll_ldflags"; then :
 
-        mksharedlib="$mksharedlib -link \"$oc_dll_ldflags\""
+        mkdll="$mkdll -link \"$oc_dll_ldflags\""
         mkmaindll="$mkmaindll -link \"$oc_dll_ldflags\""
 fi ;; #(
   *-pc-windows) :
-    mksharedlib="${flexlink_cmd} -chain ${flexdll_chain}"
+    mkdll="${flexlink_cmd} -chain ${flexdll_chain}"
       mkmaindll="${flexlink_cmd} -maindll -chain ${flexdll_chain}" ;; #(
   *-*-cygwin*) :
-    mksharedlib="${flexlink_cmd} -chain ${flexdll_chain}"
+    mkdll="${flexlink_cmd} -chain ${flexdll_chain}"
       mkmaindll="${flexlink_cmd} -maindll -chain ${flexdll_chain}" ;; #(
   powerpc-ibm-aix*) :
     case $ocaml_cv_cc_vendor in #(
   xlc*) :
-    mksharedlib='$(CC) -qmkshrobj -G'
+    mkdll='$(CC) -qmkshrobj -G'
                 supports_shared_libraries=true ;; #(
   *) :
      ;;
 esac ;; #(
   *-*-solaris*) :
     sharedlib_cflags="-fPIC"
-      mksharedlib='$(CC) -shared'
+      mkdll='$(CC) -shared'
       rpath="-Wl,-rpath,"
       mksharedlibrpath="-Wl,-rpath,"
       supports_shared_libraries=true ;; #(
@@ -14127,13 +14127,13 @@ esac ;; #(
     sharedlib_cflags="-fPIC"
        case $cc_basename,$host in #(
   *gcc*,powerpc-*-linux*) :
-    mksharedlib='$(CC) -shared -mbss-plt' ;; #(
+    mkdll='$(CC) -shared -mbss-plt' ;; #(
   *,i[3456]86-*) :
     # Disable DT_TEXTREL warnings on Linux and BSD i386
            # See https://github.com/ocaml/ocaml/issues/9800
-           mksharedlib='$(CC) -shared -Wl,-z,notext' ;; #(
+           mkdll='$(CC) -shared -Wl,-z,notext' ;; #(
   *) :
-    mksharedlib='$(CC) -shared' ;;
+    mkdll='$(CC) -shared' ;;
 esac
       oc_ldflags="$oc_ldflags -Wl,-E"
       rpath="-Wl,-rpath,"
@@ -14146,7 +14146,7 @@ esac
 fi
 
 if test -z "$mkmaindll"; then :
-  mkmaindll=$mksharedlib
+  mkmaindll=$mkdll
 fi
 
 # Configure native dynlink
@@ -18089,7 +18089,7 @@ unset ac_cv_header_flexdll_h
 # Just before config.status is generated, determine the final values for MKEXE,
 # MKDLL, MKMAINDLL and MKEXE_VIA_CC. The final variables controlling these are:
 # $mkexe - the linking commmand and munged CFLAGS + any extra flexlink flags
-# $mksharedlib - the full linking command for DLLs
+# $mkdll - the full linking command for DLLs
 # $mkmaindll - the full linking command for main program in DLL
 # $oc_ldflags and $oc_dll_ldflags are handled as $(OC_LDFLAGS) and
 # $(OC_DLL_LDFLAGS) and can be overidden in the build.
@@ -18254,7 +18254,7 @@ else
     mkexe="${mkexe} \$(OC_LDFLAGS) \$(LDFLAGS)"
 
 fi
-  mksharedlib="$mksharedlib $mkdll_ldflags"
+  mkdll="$mkdll $mkdll_ldflags"
   mkmaindll="$mkmaindll $mkdll_ldflags"
   # Do similarly with $mkexe_via_cc_ldflags_prefix, but this is only needed for
   # the msvc ports.

--- a/configure
+++ b/configure
@@ -13244,7 +13244,7 @@ case $cc_basename,$host in #(
   *,*-*-cygwin*) :
     common_cppflags="$common_cppflags -U_WIN32"
     if $supports_shared_libraries; then :
-  mkexe_cmd='$(FLEXLINK_CMD) -exe -chain $(FLEXDLL_CHAIN)'
+  mkexe_cmd="${flexlink_cmd} -exe -chain ${flexdll_chain}"
       mkexe_cflags=''
       mkexe_ldflags_prefix='-link '
       mkexe_extra_flags=''
@@ -13261,7 +13261,7 @@ fi
 esac
     ostype="Win32"
     toolchain="mingw"
-    mkexe_cmd='$(FLEXLINK_CMD) -exe -chain $(FLEXDLL_CHAIN)'
+    mkexe_cmd="${flexlink_cmd} -exe -chain ${flexdll_chain}"
     mkexe_cflags=''
     mkexe_ldflags_prefix='-link '
     oc_ldflags='-municode'
@@ -13269,7 +13269,7 @@ esac
   *,*-pc-windows) :
     toolchain=msvc
     ostype="Win32"
-    mkexe_cmd='$(FLEXLINK_CMD) -exe -chain $(FLEXDLL_CHAIN)'
+    mkexe_cmd="${flexlink_cmd} -exe -chain ${flexdll_chain}"
     mkexe_cflags=''
     mkexe_ldflags_prefix='-link '
     mkexe_via_cc_ldflags_prefix='/link '
@@ -14095,19 +14095,19 @@ if test x"$enable_shared" != "xno"; then :
     mksharedlib='$(CC) -shared -undefined dynamic_lookup'
       supports_shared_libraries=true ;; #(
   *-*-mingw32) :
-    mksharedlib='$(FLEXLINK_CMD) -chain $(FLEXDLL_CHAIN)'
-      mkmaindll='$(FLEXLINK_CMD) -maindll -chain $(FLEXDLL_CHAIN)'
+    mksharedlib="${flexlink_cmd} -chain ${flexdll_chain}"
+      mkmaindll="${flexlink_cmd} -maindll -chain ${flexdll_chain}"
       if test -n "$oc_dll_ldflags"; then :
 
         mksharedlib="$mksharedlib -link \"$oc_dll_ldflags\""
         mkmaindll="$mkmaindll -link \"$oc_dll_ldflags\""
 fi ;; #(
   *-pc-windows) :
-    mksharedlib='$(FLEXLINK_CMD) -chain $(FLEXDLL_CHAIN)'
-      mkmaindll='$(FLEXLINK_CMD) -maindll -chain $(FLEXDLL_CHAIN)' ;; #(
+    mksharedlib="${flexlink_cmd} -chain ${flexdll_chain}"
+      mkmaindll="${flexlink_cmd} -maindll -chain ${flexdll_chain}" ;; #(
   *-*-cygwin*) :
-    mksharedlib='$(FLEXLINK_CMD) -chain $(FLEXDLL_CHAIN)'
-      mkmaindll='$(FLEXLINK_CMD) -maindll -chain $(FLEXDLL_CHAIN)' ;; #(
+    mksharedlib="${flexlink_cmd} -chain ${flexdll_chain}"
+      mkmaindll="${flexlink_cmd} -maindll -chain ${flexdll_chain}" ;; #(
   powerpc-ibm-aix*) :
     case $ocaml_cv_cc_vendor in #(
   xlc*) :

--- a/configure
+++ b/configure
@@ -756,6 +756,7 @@ compute_deps
 stdlib_manpages
 PACKLD
 flexdll_chain
+flexlink_cmd
 afl
 function_sections
 flat_float_array
@@ -12899,6 +12900,10 @@ esac
 else
   supports_shared_libraries=true
 fi
+
+# The flexlink command
+
+flexlink_cmd=flexlink
 
 # Define flexlink chain and flags correctly for the different Windows ports
 case $host in #(

--- a/configure
+++ b/configure
@@ -772,6 +772,7 @@ install_source_artifacts
 install_bytecode_programs
 mksharedlibrpath
 mkmaindll
+mkdll_exp
 mkdll
 rpath
 sharedlib_cflags
@@ -815,6 +816,7 @@ ccomptype
 mkexe_via_cc_ldflags
 mkexe_extra_flags
 mkexedebugflag
+mkexe_exp
 mkexe
 fpic
 syslib
@@ -2925,7 +2927,10 @@ OCAML_VERSION_SHORT=5.0
 
 
 
+
  # TODO: rename this variable
+
+
 
 
 
@@ -13231,6 +13236,11 @@ $as_echo "$as_me: WARNING: flexlink not found: shared library support disabled."
      ;;
 esac
 
+mkexe_cmd_exp="$CC"
+
+boot_flexlink_cmd=\
+'$(ROOTDIR)/boot/ocamlruns.exe $(ROOTDIR)/boot/flexlink.byte.exe'
+
 case $cc_basename,$host in #(
   *,x86_64-*-darwin*) :
     oc_ldflags='-Wl,-no_compact_unwind';
@@ -13244,7 +13254,12 @@ case $cc_basename,$host in #(
   *,*-*-cygwin*) :
     common_cppflags="$common_cppflags -U_WIN32"
     if $supports_shared_libraries; then :
-  mkexe_cmd="${flexlink_cmd} -exe -chain ${flexdll_chain}"
+  mkexe_cmd_exp="flexlink -exe -chain ${flexdll_chain}"
+      if $bootstrapping_flexlink; then :
+  mkexe_cmd="$boot_flexlink_cmd -exe -chain ${flexdll_chain}"
+else
+  mkexe_cmd="$mkexe_cmd_exp"
+fi
       mkexe_cflags=''
       mkexe_ldflags_prefix='-link '
       mkexe_extra_flags=''
@@ -13261,7 +13276,12 @@ fi
 esac
     ostype="Win32"
     toolchain="mingw"
-    mkexe_cmd="${flexlink_cmd} -exe -chain ${flexdll_chain}"
+    mkexe_cmd_exp="flexlink -exe -chain ${flexdll_chain}"
+    if $bootstrapping_flexlink; then :
+  mkexe_cmd="${boot_flexlink_cmd} -exe -chain ${flexdll_chain}"
+else
+  mkexe_cmd="$mkexe_cmd_exp"
+fi
     mkexe_cflags=''
     mkexe_ldflags_prefix='-link '
     oc_ldflags='-municode'
@@ -13269,7 +13289,12 @@ esac
   *,*-pc-windows) :
     toolchain=msvc
     ostype="Win32"
-    mkexe_cmd="${flexlink_cmd} -exe -chain ${flexdll_chain}"
+    mkexe_cmd_exp="flexlink -exe -chain ${flexdll_chain}"
+    if $bootstrapping_flexlink; then :
+  mkexe_cmd="${boot_flexlink_cmd} -exe -chain ${flexdll_chain}"
+else
+  mkexe_cmd="$mkexe_cmd_exp"
+fi
     mkexe_cflags=''
     mkexe_ldflags_prefix='-link '
     mkexe_via_cc_ldflags_prefix='/link '
@@ -13287,7 +13312,6 @@ esac
   *) :
      ;;
 esac
-
 
 ## Program to use to install files
 # Find a good install program.  We prefer a C program (faster),
@@ -14081,44 +14105,50 @@ fi
 
 sharedlib_cflags=''
 mkdll='shared-libs-not-available'
+mkdll_exp='shared-libs-not-available'
 rpath=''
 mksharedlibrpath=''
 natdynlinkopts=""
 
+mkdll_ld=''
 if test x"$enable_shared" != "xno"; then :
   case $host in #(
   x86_64-apple-darwin*) :
-    mkdll='$(CC) -shared '\
-'-undefined dynamic_lookup -Wl,-no_compact_unwind'
+    mkdll_flags='-shared -undefined dynamic_lookup -Wl,-no_compact_unwind'
       supports_shared_libraries=true ;; #(
   aarch64-apple-darwin*|arm64-apple-darwin*) :
-    mkdll='$(CC) -shared -undefined dynamic_lookup'
+    mkdll_flags='-shared -undefined dynamic_lookup'
       supports_shared_libraries=true ;; #(
   *-*-mingw32) :
-    mkdll="${flexlink_cmd} -chain ${flexdll_chain}"
+    mkdll_ld="${flexlink_cmd} -chain ${flexdll_chain}"
       mkmaindll="${flexlink_cmd} -maindll -chain ${flexdll_chain}"
       if test -n "$oc_dll_ldflags"; then :
 
-        mkdll="$mkdll -link \"$oc_dll_ldflags\""
+        mkdll_flags=" -link \"$oc_dll_ldflags\""
         mkmaindll="$mkmaindll -link \"$oc_dll_ldflags\""
+else
+
+        mkdll_flags=''
 fi ;; #(
   *-pc-windows) :
-    mkdll="${flexlink_cmd} -chain ${flexdll_chain}"
+    mkdll_ld="${flexlink_cmd} -chain ${flexdll_chain}"
+      mkdll_flags=''
       mkmaindll="${flexlink_cmd} -maindll -chain ${flexdll_chain}" ;; #(
   *-*-cygwin*) :
-    mkdll="${flexlink_cmd} -chain ${flexdll_chain}"
+    mkdll_ld="${flexlink_cmd} -chain ${flexdll_chain}"
+      mkdll_flags=''
       mkmaindll="${flexlink_cmd} -maindll -chain ${flexdll_chain}" ;; #(
   powerpc-ibm-aix*) :
     case $ocaml_cv_cc_vendor in #(
   xlc*) :
-    mkdll='$(CC) -qmkshrobj -G'
+    mkdll_flags='-qmkshrobj -G'
                 supports_shared_libraries=true ;; #(
   *) :
      ;;
 esac ;; #(
   *-*-solaris*) :
     sharedlib_cflags="-fPIC"
-      mkdll='$(CC) -shared'
+      mkdll_flags='-shared'
       rpath="-Wl,-rpath,"
       mksharedlibrpath="-Wl,-rpath,"
       supports_shared_libraries=true ;; #(
@@ -14127,13 +14157,13 @@ esac ;; #(
     sharedlib_cflags="-fPIC"
        case $cc_basename,$host in #(
   *gcc*,powerpc-*-linux*) :
-    mkdll='$(CC) -shared -mbss-plt' ;; #(
+    mkdll_flags='-shared -mbss-plt' ;; #(
   *,i[3456]86-*) :
     # Disable DT_TEXTREL warnings on Linux and BSD i386
            # See https://github.com/ocaml/ocaml/issues/9800
-           mkdll='$(CC) -shared -Wl,-z,notext' ;; #(
+           mkdll_flags='-shared -Wl,-z,notext' ;; #(
   *) :
-    mkdll='$(CC) -shared' ;;
+    mkdll_flags='-shared' ;;
 esac
       oc_ldflags="$oc_ldflags -Wl,-E"
       rpath="-Wl,-rpath,"
@@ -14143,10 +14173,17 @@ esac
   *) :
      ;;
 esac
+  if $supports_shared_libraries && test -n "$mkdll_ld"; then :
+  mkdll="$mkdll_ld $mkdll_flags"
+    mkdll_exp="$mkdll"
+else
+  mkdll="\$(CC) $mkdll_flags"
+    mkdll_exp="$CC $mkdll_flags"
+fi
 fi
 
 if test -z "$mkmaindll"; then :
-  mkmaindll=$mkdll
+  mkmaindll=$mkdll_exp
 fi
 
 # Configure native dynlink
@@ -18089,7 +18126,9 @@ unset ac_cv_header_flexdll_h
 # Just before config.status is generated, determine the final values for MKEXE,
 # MKDLL, MKMAINDLL and MKEXE_VIA_CC. The final variables controlling these are:
 # $mkexe - the linking commmand and munged CFLAGS + any extra flexlink flags
+# $mkexe_exp: same as above but expanded
 # $mkdll - the full linking command for DLLs
+# $mkdll_exp: same as above but expanded
 # $mkmaindll - the full linking command for main program in DLL
 # $oc_ldflags and $oc_dll_ldflags are handled as $(OC_LDFLAGS) and
 # $(OC_DLL_LDFLAGS) and can be overidden in the build.
@@ -18227,11 +18266,14 @@ LTLIBOBJS=$ac_ltlibobjs
 
   # Construct $mkexe
   mkexe="$mkexe_cmd"
+  mkexe_exp="$mkexe_cmd_exp"
   if test -n "$mkexe_cflags"; then :
   mkexe="$mkexe $mkexe_cflags"
+    mkexe_exp="$mkexe_exp $oc_cflags $CFLAGS"
 fi
   if test -n "$mkexe_extra_flags"; then :
   mkexe="$mkexe $mkexe_extra_flags"
+    mkexe_exp="$mkexe_exp $mkexe_extra_flags"
 fi
   # If $mkexe_ldflags_prefix is given, apply it to $oc_ldflags and $oc_dllflags
   # and ensure that LDFLAGS is passed using it. This is used for flexlink. where
@@ -18241,21 +18283,44 @@ fi
     if test -n "$mkexedebugflag"; then :
   mkexedebugflag="${mkexe_ldflags_prefix}${mkexedebugflag}"
 fi
-    mkdll_ldflags="\$(if \$(LDFLAGS), \
-\$(addprefix ${mkexe_ldflags_prefix},\$(LDFLAGS)))"
+    mkdll_ldflags=""
+    if test -n "${LDFLAGS}"; then :
+  for flag in ${LDFLAGS}; do
+        mkdll_ldflags="${mkdll_ldflags} ${mkexe_ldflags_prefix}${flag}"
+      done
+fi
+    tmp_oc_ldflags=""
+    if test -n "${oc_ldflags}"; then :
+  for flag in ${oc_ldflags}; do
+        tmp_oc_ldflags="$tmp_oc_ldflags ${mkexe_ldflags_prefix}${flag}"
+      done
+fi
+    tmp_oc_dll_ldflags=""
+    if test -n "${oc_dll_ldflags}"; then :
+  for flag in ${oc_dll_ldflags}; do
+        tmp_oc_dll_ldflags="$tmp_oc_dll_ldflags ${mkexe_ldflags_prefix}${flag}"
+      done
+fi
+    mkdll_ldflags_exp="$mkdll_ldflags $tmp_oc_ldflags $tmp_oc_dll_ldflags"
     mkexe=\
 "${mkexe} \$(addprefix ${mkexe_ldflags_prefix},\$(OC_LDFLAGS))${mkdll_ldflags}"
+    mkexe_exp=\
+"${mkexe_exp} ${tmp_oc_ldflags} ${mkdll_ldflags}"
+
     mkdll_ldflags="\$(addprefix ${mkexe_ldflags_prefix},\$(OC_DLL_LDFLAGS)) \
 ${mkdll_ldflags}"
 
 else
 
     mkdll_ldflags='$(OC_DLL_LDFLAGS) $(LDFLAGS)'
+    mkdll_ldflags_exp="${oc_dll_ldflags} ${LDFLAGS}"
     mkexe="${mkexe} \$(OC_LDFLAGS) \$(LDFLAGS)"
+    mkexe_exp="${mkexe_exp} ${oc_ldflags} ${LDFLAGS}"
 
 fi
   mkdll="$mkdll $mkdll_ldflags"
-  mkmaindll="$mkmaindll $mkdll_ldflags"
+  mkdll_exp="$mkdll_exp $mkdll_ldflags_exp"
+  mkmaindll="$mkmaindll $mkdll_ldflags_exp"
   # Do similarly with $mkexe_via_cc_ldflags_prefix, but this is only needed for
   # the msvc ports.
   if test -n "$mkexe_via_cc_ldflags_prefix"; then :

--- a/configure.ac
+++ b/configure.ac
@@ -803,7 +803,7 @@ AS_CASE([$cc_basename,$host],
   [*,*-*-cygwin*],
     [common_cppflags="$common_cppflags -U_WIN32"
     AS_IF([$supports_shared_libraries],
-      [mkexe_cmd='$(FLEXLINK_CMD) -exe -chain $(FLEXDLL_CHAIN)'
+      [mkexe_cmd="${flexlink_cmd} -exe -chain ${flexdll_chain}"
       mkexe_cflags=''
       mkexe_ldflags_prefix='-link ']
       [mkexe_extra_flags=''
@@ -815,7 +815,7 @@ AS_CASE([$cc_basename,$host],
       [i686-*-*], [oc_dll_ldflags="-static-libgcc"])
     ostype="Win32"
     toolchain="mingw"
-    mkexe_cmd='$(FLEXLINK_CMD) -exe -chain $(FLEXDLL_CHAIN)'
+    mkexe_cmd="${flexlink_cmd} -exe -chain ${flexdll_chain}"
     mkexe_cflags=''
     mkexe_ldflags_prefix='-link '
     oc_ldflags='-municode'
@@ -823,7 +823,7 @@ AS_CASE([$cc_basename,$host],
   [*,*-pc-windows],
     [toolchain=msvc
     ostype="Win32"
-    mkexe_cmd='$(FLEXLINK_CMD) -exe -chain $(FLEXDLL_CHAIN)'
+    mkexe_cmd="${flexlink_cmd} -exe -chain ${flexdll_chain}"
     mkexe_cflags=''
     mkexe_ldflags_prefix='-link '
     mkexe_via_cc_ldflags_prefix='/link '
@@ -949,17 +949,17 @@ AS_IF([test x"$enable_shared" != "xno"],
       [mksharedlib='$(CC) -shared -undefined dynamic_lookup'
       supports_shared_libraries=true],
     [*-*-mingw32],
-      [mksharedlib='$(FLEXLINK_CMD) -chain $(FLEXDLL_CHAIN)'
-      mkmaindll='$(FLEXLINK_CMD) -maindll -chain $(FLEXDLL_CHAIN)'
+      [mksharedlib="${flexlink_cmd} -chain ${flexdll_chain}"
+      mkmaindll="${flexlink_cmd} -maindll -chain ${flexdll_chain}"
       AS_IF([test -n "$oc_dll_ldflags"],[
         mksharedlib="$mksharedlib -link \"$oc_dll_ldflags\""
         mkmaindll="$mkmaindll -link \"$oc_dll_ldflags\""])],
     [*-pc-windows],
-      [mksharedlib='$(FLEXLINK_CMD) -chain $(FLEXDLL_CHAIN)'
-      mkmaindll='$(FLEXLINK_CMD) -maindll -chain $(FLEXDLL_CHAIN)'],
+      [mksharedlib="${flexlink_cmd} -chain ${flexdll_chain}"
+      mkmaindll="${flexlink_cmd} -maindll -chain ${flexdll_chain}"],
     [*-*-cygwin*],
-      [mksharedlib='$(FLEXLINK_CMD) -chain $(FLEXDLL_CHAIN)'
-      mkmaindll='$(FLEXLINK_CMD) -maindll -chain $(FLEXDLL_CHAIN)'],
+      [mksharedlib="${flexlink_cmd} -chain ${flexdll_chain}"
+      mkmaindll="${flexlink_cmd} -maindll -chain ${flexdll_chain}"],
     [powerpc-ibm-aix*],
       [AS_CASE([$ocaml_cv_cc_vendor],
                [xlc*],

--- a/configure.ac
+++ b/configure.ac
@@ -164,6 +164,7 @@ AC_SUBST([windows_unicode])
 AC_SUBST([flat_float_array])
 AC_SUBST([function_sections])
 AC_SUBST([afl])
+AC_SUBST([flexlink_cmd])
 AC_SUBST([flexdll_chain])
 AC_SUBST([PACKLD])
 AC_SUBST([stdlib_manpages])
@@ -690,6 +691,10 @@ AS_IF([test x"$enable_shared" = "xno"],
     [*-pc-windows|*-w64-mingw32],
     [AC_MSG_ERROR([Cannot build native Win32 with --disable-shared])])],
   [supports_shared_libraries=true])
+
+# The flexlink command
+
+flexlink_cmd=flexlink
 
 # Define flexlink chain and flags correctly for the different Windows ports
 AS_CASE([$host],

--- a/configure.ac
+++ b/configure.ac
@@ -148,7 +148,7 @@ AC_SUBST([AS])
 AC_SUBST([asm_cfi_supported])
 AC_SUBST([sharedlib_cflags])
 AC_SUBST([rpath])
-AC_SUBST([mksharedlib])
+AC_SUBST([mkdll])
 AC_SUBST([mkmaindll])
 AC_SUBST([mksharedlibrpath])
 AC_SUBST([install_bytecode_programs])
@@ -934,7 +934,7 @@ AS_IF([! $arch64],
 # Shared library support
 
 sharedlib_cflags=''
-mksharedlib='shared-libs-not-available'
+mkdll='shared-libs-not-available'
 rpath=''
 mksharedlibrpath=''
 natdynlinkopts=""
@@ -942,32 +942,32 @@ natdynlinkopts=""
 AS_IF([test x"$enable_shared" != "xno"],
   [AS_CASE([$host],
     [x86_64-apple-darwin*],
-      [mksharedlib='$(CC) -shared '\
+      [mkdll='$(CC) -shared '\
 '-undefined dynamic_lookup -Wl,-no_compact_unwind'
       supports_shared_libraries=true],
     [aarch64-apple-darwin*|arm64-apple-darwin*],
-      [mksharedlib='$(CC) -shared -undefined dynamic_lookup'
+      [mkdll='$(CC) -shared -undefined dynamic_lookup'
       supports_shared_libraries=true],
     [*-*-mingw32],
-      [mksharedlib="${flexlink_cmd} -chain ${flexdll_chain}"
+      [mkdll="${flexlink_cmd} -chain ${flexdll_chain}"
       mkmaindll="${flexlink_cmd} -maindll -chain ${flexdll_chain}"
       AS_IF([test -n "$oc_dll_ldflags"],[
-        mksharedlib="$mksharedlib -link \"$oc_dll_ldflags\""
+        mkdll="$mkdll -link \"$oc_dll_ldflags\""
         mkmaindll="$mkmaindll -link \"$oc_dll_ldflags\""])],
     [*-pc-windows],
-      [mksharedlib="${flexlink_cmd} -chain ${flexdll_chain}"
+      [mkdll="${flexlink_cmd} -chain ${flexdll_chain}"
       mkmaindll="${flexlink_cmd} -maindll -chain ${flexdll_chain}"],
     [*-*-cygwin*],
-      [mksharedlib="${flexlink_cmd} -chain ${flexdll_chain}"
+      [mkdll="${flexlink_cmd} -chain ${flexdll_chain}"
       mkmaindll="${flexlink_cmd} -maindll -chain ${flexdll_chain}"],
     [powerpc-ibm-aix*],
       [AS_CASE([$ocaml_cv_cc_vendor],
                [xlc*],
-               [mksharedlib='$(CC) -qmkshrobj -G'
+               [mkdll='$(CC) -qmkshrobj -G'
                 supports_shared_libraries=true])],
     [*-*-solaris*],
       [sharedlib_cflags="-fPIC"
-      mksharedlib='$(CC) -shared'
+      mkdll='$(CC) -shared'
       rpath="-Wl,-rpath,"
       mksharedlibrpath="-Wl,-rpath,"
       supports_shared_libraries=true],
@@ -976,19 +976,19 @@ AS_IF([test x"$enable_shared" != "xno"],
       [sharedlib_cflags="-fPIC"
        AS_CASE([$cc_basename,$host],
            [*gcc*,powerpc-*-linux*],
-           [mksharedlib='$(CC) -shared -mbss-plt'],
+           [mkdll='$(CC) -shared -mbss-plt'],
            [[*,i[3456]86-*]],
            # Disable DT_TEXTREL warnings on Linux and BSD i386
            # See https://github.com/ocaml/ocaml/issues/9800
-           [mksharedlib='$(CC) -shared -Wl,-z,notext'],
-           [mksharedlib='$(CC) -shared'])
+           [mkdll='$(CC) -shared -Wl,-z,notext'],
+           [mkdll='$(CC) -shared'])
       oc_ldflags="$oc_ldflags -Wl,-E"
       rpath="-Wl,-rpath,"
       mksharedlibrpath="-Wl,-rpath,"
       natdynlinkopts="-Wl,-E"
       supports_shared_libraries=true])])
 
-AS_IF([test -z "$mkmaindll"], [mkmaindll=$mksharedlib])
+AS_IF([test -z "$mkmaindll"], [mkmaindll=$mkdll])
 
 # Configure native dynlink
 
@@ -2074,7 +2074,7 @@ unset ac_cv_header_flexdll_h
 # Just before config.status is generated, determine the final values for MKEXE,
 # MKDLL, MKMAINDLL and MKEXE_VIA_CC. The final variables controlling these are:
 # $mkexe - the linking commmand and munged CFLAGS + any extra flexlink flags
-# $mksharedlib - the full linking command for DLLs
+# $mkdll - the full linking command for DLLs
 # $mkmaindll - the full linking command for main program in DLL
 # $oc_ldflags and $oc_dll_ldflags are handled as $(OC_LDFLAGS) and
 # $(OC_DLL_LDFLAGS) and can be overidden in the build.
@@ -2101,7 +2101,7 @@ ${mkdll_ldflags}"
     mkdll_ldflags='$(OC_DLL_LDFLAGS) $(LDFLAGS)'
     mkexe="${mkexe} \$(OC_LDFLAGS) \$(LDFLAGS)"
   ])
-  mksharedlib="$mksharedlib $mkdll_ldflags"
+  mkdll="$mkdll $mkdll_ldflags"
   mkmaindll="$mkmaindll $mkdll_ldflags"
   # Do similarly with $mkexe_via_cc_ldflags_prefix, but this is only needed for
   # the msvc ports.

--- a/configure.ac
+++ b/configure.ac
@@ -106,6 +106,7 @@ AC_SUBST([outputobj])
 AC_SUBST([syslib])
 AC_SUBST([fpic])
 AC_SUBST([mkexe])
+AC_SUBST([mkexe_exp])
 AC_SUBST([mkexedebugflag])
 AC_SUBST([mkexe_extra_flags])
 AC_SUBST([mkexe_via_cc_ldflags])
@@ -149,6 +150,7 @@ AC_SUBST([asm_cfi_supported])
 AC_SUBST([sharedlib_cflags])
 AC_SUBST([rpath])
 AC_SUBST([mkdll])
+AC_SUBST([mkdll_exp])
 AC_SUBST([mkmaindll])
 AC_SUBST([mksharedlibrpath])
 AC_SUBST([install_bytecode_programs])
@@ -793,6 +795,11 @@ AS_CASE([$flexdir,$supports_shared_libraries,$flexlink,$host],
   [,*,,*-w64-mingw32|,*,,*-pc-windows],
     [AC_MSG_ERROR([flexlink is required for native Win32])])
 
+mkexe_cmd_exp="$CC"
+
+boot_flexlink_cmd=\
+'$(ROOTDIR)/boot/ocamlruns.exe $(ROOTDIR)/boot/flexlink.byte.exe'
+
 AS_CASE([$cc_basename,$host],
   [*,x86_64-*-darwin*],
     [oc_ldflags='-Wl,-no_compact_unwind';
@@ -803,7 +810,10 @@ AS_CASE([$cc_basename,$host],
   [*,*-*-cygwin*],
     [common_cppflags="$common_cppflags -U_WIN32"
     AS_IF([$supports_shared_libraries],
-      [mkexe_cmd="${flexlink_cmd} -exe -chain ${flexdll_chain}"
+      [mkexe_cmd_exp="flexlink -exe -chain ${flexdll_chain}"
+      AS_IF([$bootstrapping_flexlink],
+        [mkexe_cmd="$boot_flexlink_cmd -exe -chain ${flexdll_chain}"],
+        [mkexe_cmd="$mkexe_cmd_exp"])
       mkexe_cflags=''
       mkexe_ldflags_prefix='-link ']
       [mkexe_extra_flags=''
@@ -815,7 +825,10 @@ AS_CASE([$cc_basename,$host],
       [i686-*-*], [oc_dll_ldflags="-static-libgcc"])
     ostype="Win32"
     toolchain="mingw"
-    mkexe_cmd="${flexlink_cmd} -exe -chain ${flexdll_chain}"
+    mkexe_cmd_exp="flexlink -exe -chain ${flexdll_chain}"
+    AS_IF([$bootstrapping_flexlink],
+      [mkexe_cmd="${boot_flexlink_cmd} -exe -chain ${flexdll_chain}"],
+      [mkexe_cmd="$mkexe_cmd_exp"])
     mkexe_cflags=''
     mkexe_ldflags_prefix='-link '
     oc_ldflags='-municode'
@@ -823,7 +836,10 @@ AS_CASE([$cc_basename,$host],
   [*,*-pc-windows],
     [toolchain=msvc
     ostype="Win32"
-    mkexe_cmd="${flexlink_cmd} -exe -chain ${flexdll_chain}"
+    mkexe_cmd_exp="flexlink -exe -chain ${flexdll_chain}"
+    AS_IF([$bootstrapping_flexlink],
+      [mkexe_cmd="${boot_flexlink_cmd} -exe -chain ${flexdll_chain}"],
+      [mkexe_cmd="$mkexe_cmd_exp"])
     mkexe_cflags=''
     mkexe_ldflags_prefix='-link '
     mkexe_via_cc_ldflags_prefix='/link '
@@ -835,9 +851,7 @@ AS_CASE([$cc_basename,$host],
     [oc_ldflags='-brtl -bexpfull'
     AC_DEFINE([HAS_ARCH_CODE32], [1])],
   [gcc*,powerpc-*-linux*],
-    [oc_ldflags="-mbss-plt"],
-)
-
+    [oc_ldflags="-mbss-plt"])
 
 ## Program to use to install files
 AC_PROG_INSTALL
@@ -935,39 +949,43 @@ AS_IF([! $arch64],
 
 sharedlib_cflags=''
 mkdll='shared-libs-not-available'
+mkdll_exp='shared-libs-not-available'
 rpath=''
 mksharedlibrpath=''
 natdynlinkopts=""
 
+mkdll_ld=''
 AS_IF([test x"$enable_shared" != "xno"],
   [AS_CASE([$host],
     [x86_64-apple-darwin*],
-      [mkdll='$(CC) -shared '\
-'-undefined dynamic_lookup -Wl,-no_compact_unwind'
+      [mkdll_flags='-shared -undefined dynamic_lookup -Wl,-no_compact_unwind'
       supports_shared_libraries=true],
     [aarch64-apple-darwin*|arm64-apple-darwin*],
-      [mkdll='$(CC) -shared -undefined dynamic_lookup'
+      [mkdll_flags='-shared -undefined dynamic_lookup'
       supports_shared_libraries=true],
     [*-*-mingw32],
-      [mkdll="${flexlink_cmd} -chain ${flexdll_chain}"
+      [mkdll_ld="${flexlink_cmd} -chain ${flexdll_chain}"
       mkmaindll="${flexlink_cmd} -maindll -chain ${flexdll_chain}"
       AS_IF([test -n "$oc_dll_ldflags"],[
-        mkdll="$mkdll -link \"$oc_dll_ldflags\""
-        mkmaindll="$mkmaindll -link \"$oc_dll_ldflags\""])],
+        mkdll_flags=" -link \"$oc_dll_ldflags\""
+        mkmaindll="$mkmaindll -link \"$oc_dll_ldflags\""],[
+        mkdll_flags=''])],
     [*-pc-windows],
-      [mkdll="${flexlink_cmd} -chain ${flexdll_chain}"
+      [mkdll_ld="${flexlink_cmd} -chain ${flexdll_chain}"
+      mkdll_flags=''
       mkmaindll="${flexlink_cmd} -maindll -chain ${flexdll_chain}"],
     [*-*-cygwin*],
-      [mkdll="${flexlink_cmd} -chain ${flexdll_chain}"
+      [mkdll_ld="${flexlink_cmd} -chain ${flexdll_chain}"
+      mkdll_flags=''
       mkmaindll="${flexlink_cmd} -maindll -chain ${flexdll_chain}"],
     [powerpc-ibm-aix*],
       [AS_CASE([$ocaml_cv_cc_vendor],
                [xlc*],
-               [mkdll='$(CC) -qmkshrobj -G'
+               [mkdll_flags='-qmkshrobj -G'
                 supports_shared_libraries=true])],
     [*-*-solaris*],
       [sharedlib_cflags="-fPIC"
-      mkdll='$(CC) -shared'
+      mkdll_flags='-shared'
       rpath="-Wl,-rpath,"
       mksharedlibrpath="-Wl,-rpath,"
       supports_shared_libraries=true],
@@ -976,19 +994,24 @@ AS_IF([test x"$enable_shared" != "xno"],
       [sharedlib_cflags="-fPIC"
        AS_CASE([$cc_basename,$host],
            [*gcc*,powerpc-*-linux*],
-           [mkdll='$(CC) -shared -mbss-plt'],
+           [mkdll_flags='-shared -mbss-plt'],
            [[*,i[3456]86-*]],
            # Disable DT_TEXTREL warnings on Linux and BSD i386
            # See https://github.com/ocaml/ocaml/issues/9800
-           [mkdll='$(CC) -shared -Wl,-z,notext'],
-           [mkdll='$(CC) -shared'])
+           [mkdll_flags='-shared -Wl,-z,notext'],
+           [mkdll_flags='-shared'])
       oc_ldflags="$oc_ldflags -Wl,-E"
       rpath="-Wl,-rpath,"
       mksharedlibrpath="-Wl,-rpath,"
       natdynlinkopts="-Wl,-E"
-      supports_shared_libraries=true])])
+      supports_shared_libraries=true])
+  AS_IF([$supports_shared_libraries && test -n "$mkdll_ld"],
+    [mkdll="$mkdll_ld $mkdll_flags"
+    mkdll_exp="$mkdll"],
+    [mkdll="\$(CC) $mkdll_flags"
+    mkdll_exp="$CC $mkdll_flags"])])
 
-AS_IF([test -z "$mkmaindll"], [mkmaindll=$mkdll])
+AS_IF([test -z "$mkmaindll"], [mkmaindll=$mkdll_exp])
 
 # Configure native dynlink
 
@@ -2074,35 +2097,60 @@ unset ac_cv_header_flexdll_h
 # Just before config.status is generated, determine the final values for MKEXE,
 # MKDLL, MKMAINDLL and MKEXE_VIA_CC. The final variables controlling these are:
 # $mkexe - the linking commmand and munged CFLAGS + any extra flexlink flags
+# $mkexe_exp: same as above but expanded
 # $mkdll - the full linking command for DLLs
+# $mkdll_exp: same as above but expanded
 # $mkmaindll - the full linking command for main program in DLL
 # $oc_ldflags and $oc_dll_ldflags are handled as $(OC_LDFLAGS) and
 # $(OC_DLL_LDFLAGS) and can be overidden in the build.
 AC_CONFIG_COMMANDS_PRE([
   # Construct $mkexe
   mkexe="$mkexe_cmd"
+  mkexe_exp="$mkexe_cmd_exp"
   AS_IF([test -n "$mkexe_cflags"],
-    [mkexe="$mkexe $mkexe_cflags"])
+    [mkexe="$mkexe $mkexe_cflags"
+    mkexe_exp="$mkexe_exp $oc_cflags $CFLAGS"])
   AS_IF([test -n "$mkexe_extra_flags"],
-    [mkexe="$mkexe $mkexe_extra_flags"])
+    [mkexe="$mkexe $mkexe_extra_flags"
+    mkexe_exp="$mkexe_exp $mkexe_extra_flags"])
   # If $mkexe_ldflags_prefix is given, apply it to $oc_ldflags and $oc_dllflags
   # and ensure that LDFLAGS is passed using it. This is used for flexlink. where
   # linker flags need to be prefixed with -link.
   AS_IF([test -n "$mkexe_ldflags_prefix"],[
     AS_IF([test -n "$mkexedebugflag"],
       [mkexedebugflag="${mkexe_ldflags_prefix}${mkexedebugflag}"])
-    mkdll_ldflags="\$(if \$(LDFLAGS), \
-\$(addprefix ${mkexe_ldflags_prefix},\$(LDFLAGS)))"
+    mkdll_ldflags=""
+    AS_IF([test -n "${LDFLAGS}"],
+      [for flag in ${LDFLAGS}; do
+        mkdll_ldflags="${mkdll_ldflags} ${mkexe_ldflags_prefix}${flag}"
+      done])
+    tmp_oc_ldflags=""
+    AS_IF([test -n "${oc_ldflags}"],
+      [for flag in ${oc_ldflags}; do
+        tmp_oc_ldflags="$tmp_oc_ldflags ${mkexe_ldflags_prefix}${flag}"
+      done])
+    tmp_oc_dll_ldflags=""
+    AS_IF([test -n "${oc_dll_ldflags}"],
+      [for flag in ${oc_dll_ldflags}; do
+        tmp_oc_dll_ldflags="$tmp_oc_dll_ldflags ${mkexe_ldflags_prefix}${flag}"
+      done])
+    mkdll_ldflags_exp="$mkdll_ldflags $tmp_oc_ldflags $tmp_oc_dll_ldflags"
     mkexe=\
 "${mkexe} \$(addprefix ${mkexe_ldflags_prefix},\$(OC_LDFLAGS))${mkdll_ldflags}"
+    mkexe_exp=\
+"${mkexe_exp} ${tmp_oc_ldflags} ${mkdll_ldflags}"
+
     mkdll_ldflags="\$(addprefix ${mkexe_ldflags_prefix},\$(OC_DLL_LDFLAGS)) \
 ${mkdll_ldflags}"
   ],[
     mkdll_ldflags='$(OC_DLL_LDFLAGS) $(LDFLAGS)'
+    mkdll_ldflags_exp="${oc_dll_ldflags} ${LDFLAGS}"
     mkexe="${mkexe} \$(OC_LDFLAGS) \$(LDFLAGS)"
+    mkexe_exp="${mkexe_exp} ${oc_ldflags} ${LDFLAGS}"
   ])
   mkdll="$mkdll $mkdll_ldflags"
-  mkmaindll="$mkmaindll $mkdll_ldflags"
+  mkdll_exp="$mkdll_exp $mkdll_ldflags_exp"
+  mkmaindll="$mkmaindll $mkdll_ldflags_exp"
   # Do similarly with $mkexe_via_cc_ldflags_prefix, but this is only needed for
   # the msvc ports.
   AS_IF([test -n "$mkexe_via_cc_ldflags_prefix"],[

--- a/ocamltest/Makefile
+++ b/ocamltest/Makefile
@@ -230,9 +230,6 @@ ocamltest_unix.ml: ocamltest_unix_$(ocamltest_unix).ml
 	echo '# 1 "$^"' > $@
 	cat $^ >> $@
 
-# This value should stay the same, regardless of bootstrapping, to cause
-# MKEXE, MKDLL and MKMAINDLL to be written correctly.
-ocamltest_config.ml: FLEXLINK_CMD=flexlink
 ocamltest_config.ml: ocamltest_config.ml.in Makefile ../Makefile.config
 	sed $(call SUBST,AFL_INSTRUMENT) \
 	    $(call SUBST,INSTRUMENTED_RUNTIME) \
@@ -258,8 +255,8 @@ ocamltest_config.ml: ocamltest_config.ml.in Makefile ../Makefile.config
 	    $(call SUBST_STRING,CSC) \
 	    $(call SUBST_STRING,CSCFLAGS) \
 	    $(call SUBST_STRING,EXE) \
-	    $(call SUBST_STRING,MKDLL) \
-	    $(call SUBST_STRING,MKEXE) \
+	    $(call SUBST_STRING,MKDLL_EXP) \
+	    $(call SUBST_STRING,MKEXE_EXP) \
 	    $(call SUBST_STRING,BYTECCLIBS) \
 	    $(call SUBST_STRING,NATIVECCLIBS) \
 	    $(call SUBST_STRING,ASM) \

--- a/ocamltest/ocamltest_config.ml.in
+++ b/ocamltest/ocamltest_config.ml.in
@@ -75,8 +75,8 @@ let csc_flags = "%%CSCFLAGS%%"
 
 let exe = "%%EXE%%"
 
-let mkdll = "%%MKDLL%%"
-let mkexe = "%%MKEXE%%"
+let mkdll = "%%MKDLL_EXP%%"
+let mkexe = "%%MKEXE_EXP%%"
 
 let bytecc_libs = "%%BYTECCLIBS%%"
 

--- a/tools/ocamlmklib.ml
+++ b/tools/ocamlmklib.ml
@@ -36,14 +36,14 @@ let compiler_path name =
 let bytecode_objs = ref []  (* .cmo,.cma,.ml,.mli files to pass to ocamlc *)
 and native_objs = ref []    (* .cmx,.ml,.mli files to pass to ocamlopt *)
 and c_objs = ref []         (* .o, .a, .obj, .lib, .dll, .dylib, .so files to
-                               pass to mksharedlib and ar *)
+                               pass to mkdll and ar *)
 and caml_libs = ref []      (* -cclib to pass to ocamlc, ocamlopt *)
 and caml_opts = ref []      (* -ccopt to pass to ocamlc, ocamlopt *)
 and dynlink = ref Config.supports_shared_libraries
 and failsafe = ref false    (* whether to fall back on static build only *)
-and c_libs = ref []         (* libs to pass to mksharedlib and ocamlc -cclib *)
-and c_Lopts = ref []      (* options to pass to mksharedlib and ocamlc -cclib *)
-and c_opts = ref []       (* options to pass to mksharedlib and ocamlc -ccopt *)
+and c_libs = ref []         (* libs to pass to mkdll and ocamlc -cclib *)
+and c_Lopts = ref []      (* options to pass to mkdll and ocamlc -cclib *)
+and c_opts = ref []       (* options to pass to mkdll and ocamlc -ccopt *)
 and ld_opts = ref []        (* options to pass only to the linker *)
 and ocamlc = ref (compiler_path "ocamlc")
 and ocamlc_opts = ref []    (* options to pass only to ocamlc *)

--- a/utils/Makefile
+++ b/utils/Makefile
@@ -19,10 +19,6 @@ ROOTDIR = ..
 
 include $(ROOTDIR)/Makefile.common
 
-# This value should stay the same, regardless of bootstrapping, to cause
-# MKEXE, MKDLL and MKMAINDLL to be written correctly.
-FLEXLINK_CMD=flexlink
-
 ifeq "$(BOOTSTRAPPING_FLEXDLL)" "false"
   FLEXDLL_DIR =
 else
@@ -67,8 +63,8 @@ config_main.ml: config.mlp $(ROOTDIR)/Makefile.config Makefile config.common.ml
 	    $(call SUBST,HOST) \
 	    $(call SUBST_STRING,BINDIR) \
 	    $(call SUBST_STRING,LIBDIR) \
-	    $(call SUBST_STRING,MKDLL) \
-	    $(call SUBST_STRING,MKEXE) \
+	    $(call SUBST_STRING,MKDLL_EXP) \
+	    $(call SUBST_STRING,MKEXE_EXP) \
 	    $(call SUBST_STRING,FLEXLINK_LDFLAGS) \
 	    $(call SUBST_STRING,FLEXLINK_DLL_LDFLAGS) \
 	    $(call SUBST_STRING,MKMAINDLL) \

--- a/utils/config.mlp
+++ b/utils/config.mlp
@@ -63,7 +63,7 @@ let mkdll, mkexe, mkmaindll =
     flexlink ^ " -exe" ^ flags ^ "%%FLEXLINK_LDFLAGS%%",
     flexlink ^ " -maindll" ^ flags ^ "%%FLEXLINK_DLL_LDFLAGS%%"
   else
-    "%%MKDLL%%", "%%MKEXE%%", "%%MKMAINDLL%%"
+    "%%MKDLL_EXP%%", "%%MKEXE_EXP%%", "%%MKMAINDLL%%"
 
 let flambda = %%FLAMBDA%%
 let with_flambda_invariants = %%WITH_FLAMBDA_INVARIANTS%%


### PR DESCRIPTION
This PR prepares the removal of `utils/Makefile` by expanding
more variables during the configuration stage.

The variables that are affected by this PR are the flexlink related ones
and the MKEXE, MKDLL and MKMAINDLL ones.
 