### PR TITLE
Make Field macro a volatile cast

### DIFF
--- a/Changes
+++ b/Changes
@@ -162,6 +162,14 @@ OCaml 5.0
 - #11144: Restore frame-pointers support for amd64
   (Fabrice Buoro, review by Frederic Bour and KC Sivaramakrishnan)
 
+* #11255: in the C interface, `&Field(v, i)` now has type `volatile value *`
+  instead of `value *` in OCaml 4.  This makes the memory model
+  for mixed OCaml/C code better defined, but can cause warnings or type
+  errors in user C code.
+  (KC Sivaramakrishnan, review by Xavier Leroy, Gabriel Scherer and
+  Guillaume Munch-Maccagnoni, additional discussions with Stephen
+  Dolan and Luc Maranget)
+
 ### Code generation and optimizations:
 
 - #10972: ARM64 multicore support: OCaml & C stack separation;

--- a/otherlibs/str/strstubs.c
+++ b/otherlibs/str/strstubs.c
@@ -160,7 +160,7 @@ static value re_match(value re,
   value normtable;
   int numgroups;
   /* Currently-executing instruction */
-  register value * pc;
+  register volatile value * pc;
   intnat instr;
   unsigned char c;
   /* Backtracking */

--- a/otherlibs/unix/termios.c
+++ b/otherlibs/unix/termios.c
@@ -192,7 +192,7 @@ static struct {
 
 #define NSPEEDS (sizeof(speedtable) / sizeof(speedtable[0]))
 
-static void encode_terminal_status(value *dst)
+static void encode_terminal_status(volatile value *dst)
 {
   long * pc;
   int i;
@@ -242,7 +242,7 @@ static void encode_terminal_status(value *dst)
   }
 }
 
-static void decode_terminal_status(value *src)
+static void decode_terminal_status(volatile value *src)
 {
   long * pc;
   int i;

--- a/runtime/array.c
+++ b/runtime/array.c
@@ -315,13 +315,14 @@ CAMLprim value caml_make_array(value init)
    sufficient to prevent smart compilers from coalesing the writes into vector
    writes, and hence prevent mixed-mode accesses. [MM].
    */
-static void wo_memmove (value* const dst, const value* const src,
+static void wo_memmove (volatile value* const dst,
+                        volatile const value* const src,
                         mlsize_t nvals)
 {
   mlsize_t i;
 
   if (caml_domain_alone ()) {
-    memmove (dst, src, nvals * sizeof (value));
+    memmove ((value*)dst, (value*)src, nvals * sizeof (value));
   } else {
     /* See memory model [MM] notes in memory.c */
     atomic_thread_fence(memory_order_acquire);
@@ -356,7 +357,7 @@ CAMLprim value caml_floatarray_blit(value a1, value ofs1, value a2, value ofs2,
 CAMLprim value caml_array_blit(value a1, value ofs1, value a2, value ofs2,
                                value n)
 {
-  value * src, * dst;
+  volatile value * src, * dst;
   intnat count;
 
 #ifdef FLAT_FLOAT_ARRAY
@@ -413,7 +414,7 @@ static value caml_array_gather(intnat num_arrays,
   mlsize_t wsize;
 #endif
   mlsize_t i, size, count, pos;
-  value * src;
+  volatile value * src;
 
   /* Determine total size and whether result array is an array of floats */
   size = 0;
@@ -452,8 +453,8 @@ static value caml_array_gather(intnat num_arrays,
     for (i = 0, pos = 0; i < num_arrays; i++) {
       /* [res] is freshly allocated, and no other domain has a reference to it.
          Hence, a plain [memcpy] is sufficient. */
-      memcpy(&Field(res, pos),
-             &Field(arrays[i], offsets[i]),
+      memcpy((value*)&Field(res, pos),
+             (value*)&Field(arrays[i], offsets[i]),
              lengths[i] * sizeof(value));
       pos += lengths[i];
     }
@@ -553,7 +554,7 @@ CAMLprim value caml_array_fill(value array,
 {
   intnat ofs = Long_val(v_ofs);
   intnat len = Long_val(v_len);
-  value* fp;
+  volatile value* fp;
 
   /* This duplicates the logic of caml_modify.  Please refer to the
      implementation of that function for a description of GC
@@ -581,7 +582,7 @@ CAMLprim value caml_array_fill(value array,
         caml_darken(NULL, old, NULL);
       }
       if (is_val_young_block)
-        Ref_table_add(&Caml_state->minor_tables->major_ref, fp);
+        Ref_table_add(&Caml_state->minor_tables->major_ref, (value*)fp);
     }
     if (is_val_young_block) caml_check_urgent_gc (Val_unit);
   }

--- a/runtime/array.c
+++ b/runtime/array.c
@@ -582,7 +582,7 @@ CAMLprim value caml_array_fill(value array,
         caml_darken(NULL, old, NULL);
       }
       if (is_val_young_block)
-        Ref_table_add(&Caml_state->minor_tables->major_ref, (value*)fp);
+        Ref_table_add(&Caml_state->minor_tables->major_ref, fp);
     }
     if (is_val_young_block) caml_check_urgent_gc (Val_unit);
   }

--- a/runtime/bigarray.c
+++ b/runtime/bigarray.c
@@ -561,7 +561,7 @@ static value copy_two_doubles(double d0, double d1)
 
 /* Generic code to read from a big array */
 
-value caml_ba_get_N(value vb, value * vind, int nind)
+value caml_ba_get_N(value vb, volatile value * vind, int nind)
 {
   struct caml_ba_array * b = Caml_ba_array_val(vb);
   intnat index[CAML_BA_MAX_NUM_DIMS];
@@ -631,7 +631,7 @@ CAMLprim value caml_ba_get_3(value vb, value vind1, value vind2, value vind3)
 
 CAMLprim value caml_ba_get_generic(value vb, value vind)
 {
-  return caml_ba_get_N(vb, (value*)&Field(vind, 0), Wosize_val(vind));
+  return caml_ba_get_N(vb, &Field(vind, 0), Wosize_val(vind));
 }
 
 
@@ -702,7 +702,8 @@ CAMLprim value caml_ba_uint8_get64(value vb, value vind)
 
 /* Generic write to a big array */
 
-static value caml_ba_set_aux(value vb, value * vind, intnat nind, value newval)
+static value caml_ba_set_aux(value vb, volatile value * vind,
+                             intnat nind, value newval)
 {
   struct caml_ba_array * b = Caml_ba_array_val(vb);
   intnat index[CAML_BA_MAX_NUM_DIMS];
@@ -780,7 +781,7 @@ value caml_ba_set_N(value vb, value * vind, int nargs)
 
 CAMLprim value caml_ba_set_generic(value vb, value vind, value newval)
 {
-  return caml_ba_set_aux(vb, (value*)&Field(vind, 0), Wosize_val(vind), newval);
+  return caml_ba_set_aux(vb, &Field(vind, 0), Wosize_val(vind), newval);
 }
 
 CAMLprim value caml_ba_uint8_set16(value vb, value vind, value newval)

--- a/runtime/bigarray.c
+++ b/runtime/bigarray.c
@@ -631,7 +631,7 @@ CAMLprim value caml_ba_get_3(value vb, value vind1, value vind2, value vind3)
 
 CAMLprim value caml_ba_get_generic(value vb, value vind)
 {
-  return caml_ba_get_N(vb, &Field(vind, 0), Wosize_val(vind));
+  return caml_ba_get_N(vb, (value*)&Field(vind, 0), Wosize_val(vind));
 }
 
 
@@ -780,7 +780,7 @@ value caml_ba_set_N(value vb, value * vind, int nargs)
 
 CAMLprim value caml_ba_set_generic(value vb, value vind, value newval)
 {
-  return caml_ba_set_aux(vb, &Field(vind, 0), Wosize_val(vind), newval);
+  return caml_ba_set_aux(vb, (value*)&Field(vind, 0), Wosize_val(vind), newval);
 }
 
 CAMLprim value caml_ba_uint8_set16(value vb, value vind, value newval)

--- a/runtime/caml/major_gc.h
+++ b/runtime/caml/major_gc.h
@@ -49,7 +49,7 @@ void caml_finish_sweeping(void);
 void caml_finish_marking (void);
 int caml_init_major_gc(caml_domain_state*);
 void caml_teardown_major_gc(void);
-void caml_darken(void*, value, value* ignored);
+void caml_darken(void*, value, volatile value* ignored);
 void caml_darken_cont(value);
 void caml_mark_root(value, value*);
 void caml_empty_mark_stack(void);

--- a/runtime/caml/memory.h
+++ b/runtime/caml/memory.h
@@ -49,8 +49,8 @@ CAMLextern value caml_alloc_shr_preserving_profinfo (mlsize_t, tag_t,
 CAMLextern void caml_adjust_gc_speed (mlsize_t, mlsize_t);
 CAMLextern void caml_alloc_dependent_memory (mlsize_t bsz);
 CAMLextern void caml_free_dependent_memory (mlsize_t bsz);
-CAMLextern void caml_modify (value *, value);
-CAMLextern void caml_initialize (value *, value);
+CAMLextern void caml_modify (volatile value *, value);
+CAMLextern void caml_initialize (volatile value *, value);
 CAMLextern int caml_atomic_cas_field (value, intnat, value, value);
 CAMLextern value caml_check_urgent_gc (value);
 #ifdef CAML_INTERNALS

--- a/runtime/caml/minor_gc.h
+++ b/runtime/caml/minor_gc.h
@@ -95,7 +95,7 @@ extern int caml_debug_is_major(value val);
   } while (0)
 
 Caml_inline void add_to_ephe_ref_table (struct caml_ephe_ref_table *tbl,
-                                          value ar, mlsize_t offset)
+                                        value ar, mlsize_t offset)
 {
   struct caml_ephe_ref_elt *ephe_ref;
   if (tbl->ptr >= tbl->limit){

--- a/runtime/caml/minor_gc.h
+++ b/runtime/caml/minor_gc.h
@@ -91,7 +91,7 @@ extern int caml_debug_is_major(value val);
       CAMLassert (ref->ptr == ref->limit);                              \
       caml_realloc_ref_table (ref);                                     \
     }                                                                   \
-    *ref->ptr++ = (x);                                                  \
+    *ref->ptr++ = (value*)(x);                                          \
   } while (0)
 
 Caml_inline void add_to_ephe_ref_table (struct caml_ephe_ref_table *tbl,

--- a/runtime/caml/mlvalues.h
+++ b/runtime/caml/mlvalues.h
@@ -205,7 +205,7 @@ bits  63        (64-P) (63-P)        10 9     8 7   0
 #define Op_val(x) ((value *) (x))
 #define Op_atomic_val(x) ((atomic_value *) (x))
 /* Fields are numbered from 0. */
-#define Field(x, i) (((value *)(x)) [i])           /* Also an l-value. */
+#define Field(x, i) (((volatile value *)(x)) [i]) /* Also an l-value. */
 
 /* Is_young(val) is true iff val is in the reserved area for minor heaps */
 

--- a/runtime/caml/mlvalues.h
+++ b/runtime/caml/mlvalues.h
@@ -206,8 +206,6 @@ bits  63        (64-P) (63-P)        10 9     8 7   0
 #define Op_atomic_val(x) ((atomic_value *) (x))
 /* Fields are numbered from 0. */
 #define Field(x, i) (((volatile value *)(x)) [i]) /* Also an l-value. */
-#define Load_field(x, i) \
-  (atomic_load_explicit(Op_atomic_val(x) + i, memory_order_acquire))
 
 /* Is_young(val) is true iff val is in the reserved area for minor heaps */
 

--- a/runtime/caml/mlvalues.h
+++ b/runtime/caml/mlvalues.h
@@ -206,6 +206,8 @@ bits  63        (64-P) (63-P)        10 9     8 7   0
 #define Op_atomic_val(x) ((atomic_value *) (x))
 /* Fields are numbered from 0. */
 #define Field(x, i) (((volatile value *)(x)) [i]) /* Also an l-value. */
+#define Load_field(x, i) \
+  (atomic_load_explicit(Op_atomic_val(x) + i, memory_order_acquire))
 
 /* Is_young(val) is true iff val is in the reserved area for minor heaps */
 

--- a/runtime/caml/roots.h
+++ b/runtime/caml/roots.h
@@ -25,9 +25,10 @@ typedef enum {
   SCANNING_ONLY_YOUNG_VALUES = 1, // action is a no-op outside the minor heap
 } scanning_action_flags;
 
-typedef void (*scanning_action) (void*, value, value *);
+typedef void (*scanning_action) (void*, value, volatile value *);
 typedef void (*scan_roots_hook) (scanning_action, scanning_action_flags,
                                  void*, caml_domain_state*);
+
 CAMLextern _Atomic scan_roots_hook caml_scan_roots_hook;
 
 CAMLextern void caml_do_roots (

--- a/runtime/compare.c
+++ b/runtime/compare.c
@@ -25,7 +25,7 @@
 
 /* Structural comparison on trees. */
 
-struct compare_item { value * v1, * v2; mlsize_t count; };
+struct compare_item { volatile value * v1, * v2; mlsize_t count; };
 
 #define COMPARE_STACK_INIT_SIZE 8
 #define COMPARE_STACK_MIN_ALLOC_SIZE 32
@@ -280,8 +280,8 @@ static intnat do_compare_val(struct compare_stack* stk,
       if (sz1 > 1) {
         sp++;
         if (sp >= stk->limit) sp = compare_resize_stack(stk, sp);
-        sp->v1 = (value*)&Field(v1, 1);
-        sp->v2 = (value*)&Field(v2, 1);
+        sp->v1 = &Field(v1, 1);
+        sp->v2 = &Field(v2, 1);
         sp->count = sz1 - 1;
       }
       /* Continue comparison with first field */

--- a/runtime/compare.c
+++ b/runtime/compare.c
@@ -280,8 +280,8 @@ static intnat do_compare_val(struct compare_stack* stk,
       if (sz1 > 1) {
         sp++;
         if (sp >= stk->limit) sp = compare_resize_stack(stk, sp);
-        sp->v1 = &Field(v1, 1);
-        sp->v2 = &Field(v2, 1);
+        sp->v1 = (value*)&Field(v1, 1);
+        sp->v2 = (value*)&Field(v2, 1);
         sp->count = sz1 - 1;
       }
       /* Continue comparison with first field */

--- a/runtime/extern.c
+++ b/runtime/extern.c
@@ -845,7 +845,7 @@ static void extern_rec(struct caml_extern_state* s, value v)
         sp++;
         if (sp >= s->extern_stack_limit)
           sp = extern_resize_stack(s, sp);
-        sp->v = &Field(v, i + 1);
+        sp->v = (value*)&Field(v, i + 1);
         sp->count = sz - i - 1;
       }
       /* Continue serialization with the first environment field */
@@ -862,7 +862,7 @@ static void extern_rec(struct caml_extern_state* s, value v)
         sp++;
         if (sp >= s->extern_stack_limit)
           sp = extern_resize_stack(s, sp);
-        sp->v = &Field(v, 1);
+        sp->v = (value*)&Field(v, 1);
         sp->count = sz - 1;
       }
       /* Continue serialization with the first field */
@@ -1244,7 +1244,7 @@ CAMLprim value caml_obj_reachable_words(value v)
             sp++;
             if (sp >= s->extern_stack_limit)
               sp = extern_resize_stack(s, sp);
-            sp->v = &Field(v, i + 1);
+            sp->v = (value*)&Field(v, i + 1);
             sp->count = sz - i - 1;
           }
           /* Continue with field i */

--- a/runtime/extern.c
+++ b/runtime/extern.c
@@ -48,7 +48,7 @@ enum {
 #define EXTERN_STACK_INIT_SIZE 256
 #define EXTERN_STACK_MAX_SIZE (1024*1024*100)
 
-struct extern_item { value * v; mlsize_t count; };
+struct extern_item { volatile value * v; mlsize_t count; };
 
 /* Hash table to record already-marshaled objects and their positions */
 
@@ -845,7 +845,7 @@ static void extern_rec(struct caml_extern_state* s, value v)
         sp++;
         if (sp >= s->extern_stack_limit)
           sp = extern_resize_stack(s, sp);
-        sp->v = (value*)&Field(v, i + 1);
+        sp->v = &Field(v, i + 1);
         sp->count = sz - i - 1;
       }
       /* Continue serialization with the first environment field */
@@ -862,7 +862,7 @@ static void extern_rec(struct caml_extern_state* s, value v)
         sp++;
         if (sp >= s->extern_stack_limit)
           sp = extern_resize_stack(s, sp);
-        sp->v = (value*)&Field(v, 1);
+        sp->v = &Field(v, 1);
         sp->count = sz - 1;
       }
       /* Continue serialization with the first field */
@@ -1244,7 +1244,7 @@ CAMLprim value caml_obj_reachable_words(value v)
             sp++;
             if (sp >= s->extern_stack_limit)
               sp = extern_resize_stack(s, sp);
-            sp->v = (value*)&Field(v, i + 1);
+            sp->v = &Field(v, i + 1);
             sp->count = sz - i - 1;
           }
           /* Continue with field i */

--- a/runtime/globroots.c
+++ b/runtime/globroots.c
@@ -199,7 +199,7 @@ static void scan_native_globals(scanning_action f, void* fdata)
   for (i = 0; caml_globals[i] != 0; i++) {
     for(glob = caml_globals[i]; *glob != 0; glob++) {
       for (j = 0; j < Wosize_val(*glob); j++){
-        f(fdata, Field(*glob, j), &Field(*glob, j));
+        f(fdata, Field(*glob, j), (value*)&Field(*glob, j));
       }
     }
   }
@@ -208,7 +208,7 @@ static void scan_native_globals(scanning_action f, void* fdata)
   iter_list(dyn_globals, lnk) {
     for(glob = (value *) lnk->data; *glob != 0; glob++) {
       for (j = 0; j < Wosize_val(*glob); j++){
-        f(fdata, Field(*glob, j), &Field(*glob, j));
+        f(fdata, Field(*glob, j), (value*)&Field(*glob, j));
       }
     }
   }

--- a/runtime/globroots.c
+++ b/runtime/globroots.c
@@ -199,7 +199,7 @@ static void scan_native_globals(scanning_action f, void* fdata)
   for (i = 0; caml_globals[i] != 0; i++) {
     for(glob = caml_globals[i]; *glob != 0; glob++) {
       for (j = 0; j < Wosize_val(*glob); j++){
-        f(fdata, Field(*glob, j), (value*)&Field(*glob, j));
+        f(fdata, Field(*glob, j), &Field(*glob, j));
       }
     }
   }
@@ -208,7 +208,7 @@ static void scan_native_globals(scanning_action f, void* fdata)
   iter_list(dyn_globals, lnk) {
     for(glob = (value *) lnk->data; *glob != 0; glob++) {
       for (j = 0; j < Wosize_val(*glob); j++){
-        f(fdata, Field(*glob, j), (value*)&Field(*glob, j));
+        f(fdata, Field(*glob, j), &Field(*glob, j));
       }
     }
   }

--- a/runtime/intern.c
+++ b/runtime/intern.c
@@ -328,7 +328,7 @@ static struct intern_item * intern_resize_stack(struct caml_intern_state* s,
     if (_n > 0) {                                                       \
       PushItem(s);                                                      \
       sp->op = OReadItems;                                              \
-      sp->dest = _dest;                                                 \
+      sp->dest = (value*)_dest;                                         \
       sp->arg = _n;                                                     \
     }                                                                   \
   } while(0)

--- a/runtime/intern.c
+++ b/runtime/intern.c
@@ -40,7 +40,7 @@
 
 /* Item on the stack with defined operation */
 struct intern_item {
-  value * dest;
+  volatile value * dest;
   intnat arg;
   enum {
     OReadItems, /* read arg items and store them in dest[0], dest[1], ... */
@@ -328,7 +328,7 @@ static struct intern_item * intern_resize_stack(struct caml_intern_state* s,
     if (_n > 0) {                                                       \
       PushItem(s);                                                      \
       sp->op = OReadItems;                                              \
-      sp->dest = (value*)_dest;                                         \
+      sp->dest = _dest;                                                 \
       sp->arg = _n;                                                     \
     }                                                                   \
   } while(0)
@@ -390,7 +390,7 @@ static value intern_alloc_obj(struct caml_intern_state* s, caml_domain_state* d,
 }
 
 static void intern_rec(struct caml_intern_state* s,
-                       value *dest)
+                       volatile value *dest)
 {
   unsigned int code;
   tag_t tag;

--- a/runtime/interp.c
+++ b/runtime/interp.c
@@ -661,21 +661,21 @@ value caml_interprete(code_t prog, asize_t prog_size)
       if (nvars > 0) *--sp = accu;
       if (blksize <= Max_young_wosize) {
         Alloc_small(accu, blksize, Closure_tag, Enter_gc);
-        p = &Field(accu, envofs);
+        p = (value*)&Field(accu, envofs);
         for (i = 0; i < nvars; i++, p++) *p = sp[i];
       } else {
         /* PR#6385: must allocate in major heap */
         /* caml_alloc_shr and caml_initialize never trigger a GC,
            so no need to Setup_for_gc */
         accu = caml_alloc_shr(blksize, Closure_tag);
-        p = &Field(accu, envofs);
+        p = (value*)&Field(accu, envofs);
         for (i = 0; i < nvars; i++, p++) caml_initialize(p, sp[i]);
       }
       sp += nvars;
       /* The code pointers and infix headers are not in the heap,
          so no need to go through caml_initialize. */
       *--sp = accu;
-      p = &Field(accu, 0);
+      p = (value*)&Field(accu, 0);
       *p++ = (value) (pc + pc[0]);
       *p++ = Make_closinfo(0, envofs);
       for (i = 1; i < nfuncs; i++) {

--- a/runtime/interp.c
+++ b/runtime/interp.c
@@ -657,25 +657,25 @@ value caml_interprete(code_t prog, asize_t prog_size)
       mlsize_t envofs = nfuncs * 3 - 1;
       mlsize_t blksize = envofs + nvars;
       int i;
-      value * p;
+      volatile value * p;
       if (nvars > 0) *--sp = accu;
       if (blksize <= Max_young_wosize) {
         Alloc_small(accu, blksize, Closure_tag, Enter_gc);
-        p = (value*)&Field(accu, envofs);
+        p = &Field(accu, envofs);
         for (i = 0; i < nvars; i++, p++) *p = sp[i];
       } else {
         /* PR#6385: must allocate in major heap */
         /* caml_alloc_shr and caml_initialize never trigger a GC,
            so no need to Setup_for_gc */
         accu = caml_alloc_shr(blksize, Closure_tag);
-        p = (value*)&Field(accu, envofs);
+        p = &Field(accu, envofs);
         for (i = 0; i < nvars; i++, p++) caml_initialize(p, sp[i]);
       }
       sp += nvars;
       /* The code pointers and infix headers are not in the heap,
          so no need to go through caml_initialize. */
       *--sp = accu;
-      p = (value*)&Field(accu, 0);
+      p = &Field(accu, 0);
       *p++ = (value) (pc + pc[0]);
       *p++ = Make_closinfo(0, envofs);
       for (i = 1; i < nfuncs; i++) {

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -628,7 +628,7 @@ static void mark_stack_push(struct mark_stack* stk, value block,
 }
 
 /* to fit scanning_action */
-static void mark_stack_push_act(void* state, value v, value* ignored)
+static void mark_stack_push_act(void* state, value v, volatile value* ignored)
 {
   if (Tag_val(v) < No_scan_tag && Tag_val(v) != Cont_tag)
     mark_stack_push(Caml_state->mark_stack, v, 0, NULL);
@@ -770,7 +770,7 @@ void caml_darken_cont(value cont)
   }
 }
 
-void caml_darken(void* state, value v, value* ignored) {
+void caml_darken(void* state, value v, volatile value* ignored) {
   header_t hd;
   if (!Is_markable (v)) return; /* foreign stack, at least */
 

--- a/runtime/memory.c
+++ b/runtime/memory.c
@@ -146,7 +146,7 @@ Caml_inline void write_barrier(
    }
 }
 
-CAMLexport CAMLweakdef void caml_modify (value *fp, value val)
+CAMLexport CAMLweakdef void caml_modify (volatile value *fp, value val)
 {
   write_barrier((value)fp, 0, *fp, val);
 
@@ -205,7 +205,7 @@ CAMLexport void caml_adjust_gc_speed (mlsize_t res, mlsize_t max)
 
    [caml_initialize] never calls the GC, so you may call it while a block is
    unfinished (i.e. just after a call to [caml_alloc_shr].) */
-CAMLexport CAMLweakdef void caml_initialize (value *fp, value val)
+CAMLexport CAMLweakdef void caml_initialize (volatile value *fp, value val)
 {
 #ifdef DEBUG
   /* Previous value should not be a pointer.
@@ -223,7 +223,7 @@ CAMLexport int caml_atomic_cas_field (
 {
   if (caml_domain_alone()) {
     /* non-atomic CAS since only this thread can access the object */
-    value* p = &Field(obj, field);
+    volatile value* p = &Field(obj, field);
     if (*p == oldval) {
       *p = newval;
       write_barrier(obj, field, oldval, newval);

--- a/runtime/minor_gc.c
+++ b/runtime/minor_gc.c
@@ -179,8 +179,8 @@ header_t caml_get_header_val(value v) {
 }
 
 
-static int try_update_object_header(value v, value *p, value result,
-                                      mlsize_t infix_offset) {
+static int try_update_object_header(value v, volatile value *p, value result,
+                                    mlsize_t infix_offset) {
   int success = 0;
 
   if( caml_domain_alone() ) {
@@ -228,7 +228,7 @@ static scanning_action_flags oldify_scanning_flags =
 
 /* Note that the tests on the tag depend on the fact that Infix_tag,
    Forward_tag, and No_scan_tag are contiguous. */
-static void oldify_one (void* st_v, value v, value *p)
+static void oldify_one (void* st_v, value v, volatile value *p)
 {
   struct oldify_state* st = st_v;
   value result;
@@ -416,9 +416,9 @@ again:
   if( do_ephemerons ) {
     for (re = ephe_ref_table.base;
          re < ephe_ref_table.ptr; re++) {
-      value *data = re->offset == CAML_EPHE_DATA_OFFSET
-              ? &Ephe_data(re->ephe)
-              : (value*)&Field(re->ephe, re->offset);
+      volatile value *data = re->offset == CAML_EPHE_DATA_OFFSET
+                           ? &Ephe_data(re->ephe)
+                           : &Field(re->ephe, re->offset);
       value v = *data;
       if (v != caml_ephe_none && Is_block(v) && Is_young(v) ) {
         mlsize_t offs = Tag_val(v) == Infix_tag ? Infix_offset_val(v) : 0;

--- a/runtime/minor_gc.c
+++ b/runtime/minor_gc.c
@@ -418,7 +418,7 @@ again:
          re < ephe_ref_table.ptr; re++) {
       value *data = re->offset == CAML_EPHE_DATA_OFFSET
               ? &Ephe_data(re->ephe)
-              :  &Field(re->ephe, re->offset);
+              : (value*)&Field(re->ephe, re->offset);
       value v = *data;
       if (v != caml_ephe_none && Is_block(v) && Is_young(v) ) {
         mlsize_t offs = Tag_val(v) == Infix_tag ? Infix_offset_val(v) : 0;

--- a/runtime/shared_heap.c
+++ b/runtime/shared_heap.c
@@ -710,7 +710,7 @@ struct heap_verify_state* caml_verify_begin (void)
   return st;
 }
 
-static void verify_push (void* st_v, value v, value* p)
+static void verify_push (void* st_v, value v, volatile value* ignored)
 {
   struct heap_verify_state* st = st_v;
   if (!Is_block(v)) return;
@@ -723,7 +723,7 @@ static void verify_push (void* st_v, value v, value* p)
   st->stack[st->sp++] = v;
 }
 
-void caml_verify_root(void* state, value v, value* p)
+void caml_verify_root(void* state, value v, volatile value* p)
 {
   verify_push(state, v, p);
 }


### PR DESCRIPTION
The PR addresses the issue with C FFI and the OCaml memory model. For context see, #10992. 

The first commit make `Field` macro a volatile cast, and the second commit introduces `Load_field` macro that is not an l-value and performs an acquire load of the given field. 

## Goal

The comment at https://github.com/ocaml/ocaml/issues/10992#issuecomment-1112394309 gives a detailed description of the aim of the PR. I shall try to summarize the issue and the aim of the PR. 

The PR https://github.com/ocaml/ocaml/pull/10972 performs a compilation of the OCaml memory model to C11 (`caml_modify`, `caml_atomic_*`, etc) and hardware models (x86 and ARMv8). This compilation covers all of the FFI functions except `Field`, which is the focus on #10992. `Field` macro on trunk performs non-atomic reads. Since this is C, data races using the `Field` macro will have catch fire semantics. 

Can we make `Field` macro an `_Atomic` cast to avoid catch-fire semantics? No. `Field` macro is also an l-value and making `Field` and `_Atomic` cast will make it not be an l-value. Our previous experience with the concurrent major GC shows that making `Field` not an l-value breaks an awful lot of packages. Hence, we make `Field` a volatile cast, which, in practice, avoids catch-fire semantics. See Linux kernel memory model https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2020/p0124r7.html#Variable%20Access. 

We also introduce `Load_field` macro which does an acquire load. The aim of the `Load_field` macro is to provide a mechanism for users to read fields in C11 compatible fashion  (and not "in practice" assumptions that comes with `volatile` fields) that also preserves the ordering necessary for OCaml memory model. We shall encourage our users to start using `Load_field` in places where `Field` is used as an r-value. Technically, `Load_field` is only necessary for mutable fields, and immutable fields can be accessed using `Field` macro. However, for users, it will be easier to switch to `Load_field` unconditionally. 

## Possible backwards compatibility concern

Given that `Field` has been made volatile, the uses of `&Field(..)` will have the type `volatile value *`. This will cause C compiler to raise a warning about discarded quantifiers when functions that take a `value *` argument are passed `volatile value *` value.

```c
error: passing argument 1 of ‘foo’ discards ‘volatile’ qualifier from pointer target type [-Werror=discarded-qualifiers]
```

The PR includes changes to the types of certain functions (`caml_modify`, `caml_initialize`, ...) to make the C compiler happy. 

## Todo

- [x] Performance benchmarking -- Run Sandmark on this branch to measure the impact of the change.
- [x] Assess the impact of backwards `&Field(..)` using opam health check. 

CC @gadmm @stedolan. 