### PR TITLE
Eliminate $(BOOT_FLEXLINK_CMD)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,12 +83,8 @@ TOPINCLUDES=$(addprefix -I otherlibs/,$(filter-out %threads,$(OTHERLIBRARIES)))
 
 ifeq "$(BOOTSTRAPPING_FLEXDLL)" "false"
   COLDSTART_DEPS =
-  BOOT_FLEXLINK_CMD =
 else
   COLDSTART_DEPS = boot/ocamlruns$(EXE)
-  BOOT_FLEXLINK_CMD = \
-    FLEXLINK_CMD='$$(ROOTDIR)/boot/ocamlruns$(EXE) \
-      $$(ROOTDIR)/boot/flexlink.byte$(EXE)'
 endif
 
 expunge := expunge$(EXE)
@@ -184,7 +180,7 @@ else
 	$(MAKE) -C stdlib OCAMLRUN='$$(ROOTDIR)/boot/ocamlruns$(EXE)' \
     CAMLC='$$(BOOT_OCAMLC)' all
 	$(MAKE) boot/flexlink.byte$(EXE)
-	$(MAKE) $(BOOT_FLEXLINK_CMD) runtime-all
+	$(MAKE) runtime-all
 endif # ifeq "$(BOOTSTRAPPING_FLEXDLL)" "false"
 	cp runtime/ocamlrun$(EXE) boot/ocamlrun$(EXE)
 	cd boot; rm -f $(LIBFILES)
@@ -1021,8 +1017,7 @@ stdlib/flexdll:
 endif
 
 .PHONY: makeruntime
-makeruntime:
-	$(MAKE) $(BOOT_FLEXLINK_CMD) runtime-all
+makeruntime: runtime-all
 stdlib/libcamlrun.$(A): runtime-all
 	cd stdlib; $(LN) ../runtime/libcamlrun.$(A) .
 clean::
@@ -1040,8 +1035,7 @@ clean::
 runtimeopt: stdlib/libasmrun.$(A)
 
 .PHONY: makeruntimeopt
-makeruntimeopt:
-	$(MAKE) $(BOOT_FLEXLINK_CMD) runtime-allopt
+makeruntimeopt: runtime-allopt
 stdlib/libasmrun.$(A): runtime-allopt
 	cd stdlib; $(LN) ../runtime/libasmrun.$(A) .
 
@@ -1063,16 +1057,15 @@ alldepend: depend
 
 .PHONY: library
 library: ocamlc
-	$(MAKE) -C stdlib $(BOOT_FLEXLINK_CMD) all
+	$(MAKE) -C stdlib all
 
 .PHONY: library-cross
 library-cross:
-	$(MAKE) -C stdlib \
-	  $(BOOT_FLEXLINK_CMD) OCAMLRUN=../runtime/ocamlrun$(EXE) all
+	$(MAKE) -C stdlib OCAMLRUN=../runtime/ocamlrun$(EXE) all
 
 .PHONY: libraryopt
 libraryopt:
-	$(MAKE) -C stdlib $(BOOT_FLEXLINK_CMD) allopt
+	$(MAKE) -C stdlib allopt
 
 partialclean::
 	$(MAKE) -C stdlib clean
@@ -1101,8 +1094,7 @@ ocamlyacc_MODULES = $(ocamlyacc_WSTR_MODULE) $(ocamlyacc_OTHER_MODULES)
 ocamlyacc_OBJECTS = $(ocamlyacc_MODULES:=.$(O))
 
 .PHONY: ocamlyacc
-ocamlyacc:
-	$(MAKE) $(BOOT_FLEXLINK_CMD) $(ocamlyacc_PROGRAM)$(EXE)
+ocamlyacc: $(ocamlyacc_PROGRAM)$(EXE)
 
 $(ocamlyacc_PROGRAM)$(EXE): $(ocamlyacc_OBJECTS)
 	$(MKEXE) -o $@ $^
@@ -1245,7 +1237,7 @@ checkstack: tools/checkstack$(EXE)
 
 .INTERMEDIATE: tools/checkstack$(EXE) tools/checkstack.$(O)
 tools/checkstack$(EXE): tools/checkstack.$(O)
-	$(MAKE) -C tools $(BOOT_FLEXLINK_CMD) checkstack$(EXE)
+	$(MAKE) -C tools checkstack$(EXE)
 else
 checkstack:
 	@

--- a/Makefile.common
+++ b/Makefile.common
@@ -69,7 +69,6 @@ endif
 
 BOOT_OCAMLDEP = $(BOOT_OCAMLC) -depend
 
-FLEXLINK_CMD=flexlink
 ifeq "$(BOOTSTRAPPING_FLEXDLL)" "false"
   FLEXLINK_ENV =
   CAMLOPT_CMD = $(CAMLOPT)
@@ -77,6 +76,7 @@ ifeq "$(BOOTSTRAPPING_FLEXDLL)" "false"
   MKLIB_CMD = $(MKLIB)
   ocamlc_cmd = $(ocamlc)
   ocamlopt_cmd = $(ocamlopt)
+  FLEXLINK_CMD=flexlink
 else
 ifeq "$(wildcard $(ROOTDIR)/flexlink.opt$(EXE))" ""
   FLEXLINK_ENV = \
@@ -91,6 +91,8 @@ endif # ifeq "$(wildcard $(ROOTDIR)/flexlink.opt$(EXE))" ""
   MKLIB_CMD = $(FLEXLINK_ENV) $(MKLIB)
   ocamlc_cmd = $(FLEXLINK_ENV) $(ocamlc)
   ocamlopt_cmd = $(FLEXLINK_ENV) $(ocamlopt)
+  FLEXLINK_CMD=$(ROOTDIR)/boot/ocamlruns$(EXE) \
+               $(ROOTDIR)/boot/flexlink.byte$(EXE)
 endif # ifeq "$(BOOTSTRAPPING_FLEXDLL)" "false"
 
 # List of other libraries

--- a/ocamltest/Makefile
+++ b/ocamltest/Makefile
@@ -69,7 +69,6 @@ else
   CSC :=
   CSCFLAGS :=
 endif
-mkexe := $(MKEXE)
 
 ifeq "$(TOOLCHAIN)" "msvc"
 CPP := $(CPP) 2> nul
@@ -236,6 +235,9 @@ ocamltest_unix.ml: ocamltest_unix_$(ocamltest_unix).ml
 	echo '# 1 "$^"' > $@
 	cat $^ >> $@
 
+# This value should stay the same, regardless of bootstrapping, to cause
+# MKEXE, MKDLL and MKMAINDLL to be written correctly.
+ocamltest_config.ml: FLEXLINK_CMD=flexlink
 ocamltest_config.ml: ocamltest_config.ml.in Makefile ../Makefile.config
 	sed $(call SUBST,AFL_INSTRUMENT) \
 	    $(call SUBST,INSTRUMENTED_RUNTIME) \
@@ -262,7 +264,7 @@ ocamltest_config.ml: ocamltest_config.ml.in Makefile ../Makefile.config
 	    $(call SUBST_STRING,CSCFLAGS) \
 	    $(call SUBST_STRING,EXE) \
 	    $(call SUBST_STRING,MKDLL) \
-	    $(call SUBST_STRING,mkexe) \
+	    $(call SUBST_STRING,MKEXE) \
 	    $(call SUBST_STRING,BYTECCLIBS) \
 	    $(call SUBST_STRING,NATIVECCLIBS) \
 	    $(call SUBST_STRING,ASM) \

--- a/ocamltest/ocamltest_config.ml.in
+++ b/ocamltest/ocamltest_config.ml.in
@@ -76,7 +76,7 @@ let csc_flags = "%%CSCFLAGS%%"
 let exe = "%%EXE%%"
 
 let mkdll = "%%MKDLL%%"
-let mkexe = "%%mkexe%%"
+let mkexe = "%%MKEXE%%"
 
 let bytecc_libs = "%%BYTECCLIBS%%"
 

--- a/utils/Makefile
+++ b/utils/Makefile
@@ -19,6 +19,10 @@ ROOTDIR = ..
 
 include $(ROOTDIR)/Makefile.common
 
+# This value should stay the same, regardless of bootstrapping, to cause
+# MKEXE, MKDLL and MKMAINDLL to be written correctly.
+FLEXLINK_CMD=flexlink
+
 ifeq "$(BOOTSTRAPPING_FLEXDLL)" "false"
   FLEXDLL_DIR =
 else


### PR DESCRIPTION
When compiling OCaml configured with `--with-flexdll`, the build system needs to call `$(ROOTDIR)/boot/ocamlruns.exe $(ROOTDIR)/boot/flexlink.byte.exe` instead of just `flexlink`. This is done by overriding the value of `FLEXLINK_CMD` which amends `MKEXE` and `MKDLL` as needed. In #388 (4.03.0), that was done by defining a variable `BOOT_FLEXLINK_CMD` in the root `Makefile.nt` which allowed that change to be communicated to the other `Makefile.nt` files.

When `Makefile.common` was introduced in #1680 (4.07.0), and especially since #9527 (4.12.0) made `Makefile.common` responsible for loading `Makefile.config`, it would have been possible to remove this and remove this mechanism and simply override `FLEXLINK_CMD` in `Makefile.common` when bootstrapping. For some reason, when overhauling the bootstrap in #10135 (4.13.0) I missed this.

I've now noticed it, and this PR simplifies the build by removing it completely. There's a temporary shim needed in `utils/Makefile` and `ocamltest/Makefile` to write `utils/config.ml` and `ocamltest/ocamltest_config.ml` correctly, but these get removed as part of #11254