### PR TITLE
Fixes in makefiles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -934,8 +934,8 @@ $(foreach runtime_OBJECT_TYPE, $(runtime_OBJECT_TYPES), \
 runtime/$(UNIX_OR_WIN32)_non_shared.%.$(O): \
   OC_CPPFLAGS += -DBUILDING_LIBCAMLRUNS
 
-$(eval $(call COMPILE_C_FILE,\
-  runtime/$(UNIX_OR_WIN32)_non_shared.%, runtime/$(UNIX_OR_WIN32)))
+$(eval $(call COMPILE_C_FILE,runtime/$(UNIX_OR_WIN32)_non_shared.%, \
+  runtime/$(UNIX_OR_WIN32)))
 
 $(foreach runtime_OBJECT_TYPE,$(subst %,,$(runtime_OBJECT_TYPES)), \
   $(eval \

--- a/ocamltest/Makefile
+++ b/ocamltest/Makefile
@@ -20,11 +20,6 @@ ROOTDIR = ..
 include $(ROOTDIR)/Makefile.common
 include $(ROOTDIR)/Makefile.best_binaries
 
-# Enable debug info for C files
-ifneq "$(CCOMPTYPE)" "msvc"
-OC_CFLAGS += -g
-endif
-
 ifeq "$(filter str,$(OTHERLIBRARIES))" ""
   str := false
 else


### PR DESCRIPTION
This PR contains two fixes.

1. In the root Makefile, fix a warning due to the way make adds spaces when
a line is cut. Credit goes to @dra27 for having found the solution to this
problem.

2. `ocamltest/Makefile` was adding debug information when compiling C flags
but this is no longer necessary since it is now done globally for the
whole build system. In other words, when C source files in `ocamltest`
were comiled, the compiler received the `-g` option twice, which
this PR fixes.