### PR TITLE
stdlib: Add Bytes.replace and String.replace

### DIFF
--- a/Changes
+++ b/Changes
@@ -127,7 +127,7 @@ Working version
 
 - #8878: Add String.hash and String.seeded_hash.
   (Tom Kelly, review by Alain Frisch and Nicolás Ojeda Bär)
-  
+
 * #11258: Add Bytes.replace and String.replace.
   (Boning Dong, review by )
 

--- a/Changes
+++ b/Changes
@@ -127,6 +127,9 @@ Working version
 
 - #8878: Add String.hash and String.seeded_hash.
   (Tom Kelly, review by Alain Frisch and Nicolás Ojeda Bär)
+  
+* #11258: Add Bytes.replace and String.replace.
+  (Boning Dong, review by )
 
 ### Other libraries:
 

--- a/stdlib/bytes.ml
+++ b/stdlib/bytes.ml
@@ -252,6 +252,11 @@ let for_all p s =
     else if p (unsafe_get s i) then loop (succ i)
     else false in
   loop 0
+  
+let replace a b =
+  map (function
+    | x when x = a -> b 
+    | x -> x)
 
 let uppercase_ascii s = map Char.uppercase_ascii s
 let lowercase_ascii s = map Char.lowercase_ascii s

--- a/stdlib/bytes.ml
+++ b/stdlib/bytes.ml
@@ -252,7 +252,7 @@ let for_all p s =
     else if p (unsafe_get s i) then loop (succ i)
     else false in
   loop 0
-  
+
 let replace a b =
   map (function
     | x when x = a -> b 

--- a/stdlib/bytes.mli
+++ b/stdlib/bytes.mli
@@ -197,11 +197,11 @@ val fold_right : (char -> 'a -> 'a) -> bytes -> 'a -> 'a
 val for_all : (char -> bool) -> bytes -> bool
 (** [for_all p s] checks if all characters in [s] satisfy the predicate [p].
     @since 4.13.0 *)
-    
+
 val replace : char -> char -> bytes -> bytes
 (** [replace a b s] replaces all instances of character [a] inside [s] to [b]. 
     @since 5.0 *)
-    
+
 val exists : (char -> bool) -> bytes -> bool
 (** [exists p s] checks if at least one character of [s] satisfies the predicate
     [p].

--- a/stdlib/bytes.mli
+++ b/stdlib/bytes.mli
@@ -197,7 +197,11 @@ val fold_right : (char -> 'a -> 'a) -> bytes -> 'a -> 'a
 val for_all : (char -> bool) -> bytes -> bool
 (** [for_all p s] checks if all characters in [s] satisfy the predicate [p].
     @since 4.13.0 *)
-
+    
+val replace : char -> char -> bytes -> bytes
+(** [replace a b s] replaces all instances of character [a] inside [s] to [b]. 
+    @since 5.0 *)
+    
 val exists : (char -> bool) -> bytes -> bool
 (** [exists p s] checks if at least one character of [s] satisfies the predicate
     [p].

--- a/stdlib/bytesLabels.mli
+++ b/stdlib/bytesLabels.mli
@@ -203,7 +203,7 @@ val exists : f:(char -> bool) -> bytes -> bool
     [p].
     @since 4.13.0 *)
 
-val replace : char -> char -> string -> string
+val replace : char -> char -> bytes -> bytes
 (** [replace a b s] replaces all instances of character [a] inside [s] to [b]. 
     @since 5.0 *)
 

--- a/stdlib/bytesLabels.mli
+++ b/stdlib/bytesLabels.mli
@@ -203,6 +203,10 @@ val exists : f:(char -> bool) -> bytes -> bool
     [p].
     @since 4.13.0 *)
 
+val replace : char -> char -> string -> string
+(** [replace a b s] replaces all instances of character [a] inside [s] to [b]. 
+    @since 5.0 *)
+
 val trim : bytes -> bytes
 (** Return a copy of the argument, without leading and trailing
     whitespace. The bytes regarded as whitespace are the ASCII

--- a/stdlib/string.ml
+++ b/stdlib/string.ml
@@ -89,6 +89,9 @@ let exists f s =
   B.exists f (bos s)
 let for_all f s =
   B.for_all f (bos s)
+  
+let replace a b s =
+  B.replace a b (bos s) |> bts
 
 (* Beware: we cannot use B.trim or B.escape because they always make a
    copy, but String.mli spells out some cases where we are not allowed

--- a/stdlib/string.ml
+++ b/stdlib/string.ml
@@ -89,7 +89,7 @@ let exists f s =
   B.exists f (bos s)
 let for_all f s =
   B.for_all f (bos s)
-  
+
 let replace a b s =
   B.replace a b (bos s) |> bts
 

--- a/stdlib/string.mli
+++ b/stdlib/string.mli
@@ -243,7 +243,7 @@ val exists : (char -> bool) -> string -> bool
     @since 4.13.0 *)
     
 val replace : char -> char -> string -> string
-(** [replace a b s] replaces all instance of character [a] inside [s] to [b]. 
+(** [replace a b s] replaces all instances of character [a] inside [s] to [b]. 
     @since 5.0 *)
 
 val trim : string -> string

--- a/stdlib/string.mli
+++ b/stdlib/string.mli
@@ -241,7 +241,7 @@ val exists : (char -> bool) -> string -> bool
 (** [exists p s] checks if at least one character of [s] satisfies the predicate
     [p].
     @since 4.13.0 *)
-    
+
 val replace : char -> char -> string -> string
 (** [replace a b s] replaces all instances of character [a] inside [s] to [b]. 
     @since 5.0 *)

--- a/stdlib/string.mli
+++ b/stdlib/string.mli
@@ -241,6 +241,10 @@ val exists : (char -> bool) -> string -> bool
 (** [exists p s] checks if at least one character of [s] satisfies the predicate
     [p].
     @since 4.13.0 *)
+    
+val replace : char -> char -> string -> string
+(** [replace a b s] replaces all instance of character [a] inside [s] to [b]. 
+    @since 5.0 *)
 
 val trim : string -> string
 (** [trim s] is [s] without leading and trailing whitespace. Whitespace

--- a/stdlib/stringLabels.mli
+++ b/stdlib/stringLabels.mli
@@ -242,6 +242,10 @@ val exists : f:(char -> bool) -> string -> bool
     [p].
     @since 4.13.0 *)
 
+val replace : char -> char -> string -> string
+(** [replace a b s] replaces all instances of character [a] inside [s] to [b]. 
+    @since 5.0 *)
+
 val trim : string -> string
 (** [trim s] is [s] without leading and trailing whitespace. Whitespace
     characters are: [' '], ['\x0C'] (form feed), ['\n'], ['\r'], and ['\t'].

--- a/testsuite/tests/lib-bytes/test_bytes.ml
+++ b/testsuite/tests/lib-bytes/test_bytes.ml
@@ -131,6 +131,14 @@ let () =
        && check result 0 "abcde");
 
     (*
+       test replace
+    *)
+    Testing.test
+      (let result = replace 'a' 'f' abcde in
+      length result = 5
+      && check result 0 "fbcde");
+
+    (*
        test exists and for_all
     *)
     Testing.test


### PR DESCRIPTION
I found myself rewriting this function way too often. I believe this could be very handy in stdlib.