### PR TITLE
configure: fix Windows build when flexlink is not bootstrapped

### DIFF
--- a/configure
+++ b/configure
@@ -13255,7 +13255,7 @@ case $cc_basename,$host in #(
     common_cppflags="$common_cppflags -U_WIN32"
     if $supports_shared_libraries; then :
   mkexe_cmd_exp="flexlink -exe -chain ${flexdll_chain}"
-      if $bootstrapping_flexlink; then :
+      if $bootstrapping_flexdll; then :
   mkexe_cmd="$boot_flexlink_cmd -exe -chain ${flexdll_chain}"
 else
   mkexe_cmd="$mkexe_cmd_exp"
@@ -13277,7 +13277,7 @@ esac
     ostype="Win32"
     toolchain="mingw"
     mkexe_cmd_exp="flexlink -exe -chain ${flexdll_chain}"
-    if $bootstrapping_flexlink; then :
+    if $bootstrapping_flexdll; then :
   mkexe_cmd="${boot_flexlink_cmd} -exe -chain ${flexdll_chain}"
 else
   mkexe_cmd="$mkexe_cmd_exp"
@@ -13290,7 +13290,7 @@ fi
     toolchain=msvc
     ostype="Win32"
     mkexe_cmd_exp="flexlink -exe -chain ${flexdll_chain}"
-    if $bootstrapping_flexlink; then :
+    if $bootstrapping_flexdll; then :
   mkexe_cmd="${boot_flexlink_cmd} -exe -chain ${flexdll_chain}"
 else
   mkexe_cmd="$mkexe_cmd_exp"

--- a/configure.ac
+++ b/configure.ac
@@ -811,7 +811,7 @@ AS_CASE([$cc_basename,$host],
     [common_cppflags="$common_cppflags -U_WIN32"
     AS_IF([$supports_shared_libraries],
       [mkexe_cmd_exp="flexlink -exe -chain ${flexdll_chain}"
-      AS_IF([$bootstrapping_flexlink],
+      AS_IF([$bootstrapping_flexdll],
         [mkexe_cmd="$boot_flexlink_cmd -exe -chain ${flexdll_chain}"],
         [mkexe_cmd="$mkexe_cmd_exp"])
       mkexe_cflags=''
@@ -826,7 +826,7 @@ AS_CASE([$cc_basename,$host],
     ostype="Win32"
     toolchain="mingw"
     mkexe_cmd_exp="flexlink -exe -chain ${flexdll_chain}"
-    AS_IF([$bootstrapping_flexlink],
+    AS_IF([$bootstrapping_flexdll],
       [mkexe_cmd="${boot_flexlink_cmd} -exe -chain ${flexdll_chain}"],
       [mkexe_cmd="$mkexe_cmd_exp"])
     mkexe_cflags=''
@@ -837,7 +837,7 @@ AS_CASE([$cc_basename,$host],
     [toolchain=msvc
     ostype="Win32"
     mkexe_cmd_exp="flexlink -exe -chain ${flexdll_chain}"
-    AS_IF([$bootstrapping_flexlink],
+    AS_IF([$bootstrapping_flexdll],
       [mkexe_cmd="${boot_flexlink_cmd} -exe -chain ${flexdll_chain}"],
       [mkexe_cmd="$mkexe_cmd_exp"])
     mkexe_cflags=''


### PR DESCRIPTION
This is a follow-up to #11254.

This time let's use precheck, see [build #690](https://ci.inria.fr/ocaml/job/precheck/690/).


There was a typo in the name of variables.