### PR TITLE
Simplifications and fixes to multicore systhreads implementation

### DIFF
--- a/otherlibs/systhreads/st_pthreads.h
+++ b/otherlibs/systhreads/st_pthreads.h
@@ -71,25 +71,6 @@ static void st_thread_join(st_thread_id thr)
   /* best effort: ignore errors */
 }
 
-/* Thread-specific state */
-
-typedef pthread_key_t st_tlskey;
-
-static int st_tls_newkey(st_tlskey * res)
-{
-  return pthread_key_create(res, NULL);
-}
-
-Caml_inline void * st_tls_get(st_tlskey k)
-{
-  return pthread_getspecific(k);
-}
-
-Caml_inline void st_tls_set(st_tlskey k, void * v)
-{
-  pthread_setspecific(k, v);
-}
-
 /* The master lock.  This is a mutex that is held most of the time,
    so we implement it in a slightly convoluted way to avoid
    all risks of busy-waiting.  Also, we count the number of waiting

--- a/otherlibs/systhreads/st_stubs.c
+++ b/otherlibs/systhreads/st_stubs.c
@@ -93,8 +93,7 @@ st_tlskey caml_thread_key;
 
 /* overall table for threads across domains */
 struct caml_thread_table {
-  caml_thread_t all_threads;
-  caml_thread_t current_thread;
+  caml_thread_t active_thread;
   st_masterlock thread_lock;
   int tick_thread_running;
   st_thread_id tick_thread_id;
@@ -103,11 +102,10 @@ struct caml_thread_table {
 /* thread_table instance, up to Max_domains */
 static struct caml_thread_table thread_table[Max_domains];
 
-/* the "head" of the circular list of thread descriptors for this domain */
-#define All_threads thread_table[Caml_state->id].all_threads
-
-/* The descriptor for the currently executing thread for this domain */
-#define Current_thread thread_table[Caml_state->id].current_thread
+/* The descriptor for the currently executing thread for this domain;
+   also the head of a circular list of thread descriptors for this
+   domain. */
+#define Active_thread thread_table[Caml_state->id].active_thread
 
 /* The master lock protecting this domain's thread chaining */
 #define Thread_main_lock thread_table[Caml_state->id].thread_lock
@@ -136,20 +134,20 @@ static void caml_thread_scan_roots(scanning_action action,
 {
   caml_thread_t th;
 
-  th = Current_thread;
+  th = Active_thread;
 
-  /* GC could be triggered before [Current_thread] is initialized */
+  /* GC could be triggered before [Active_thread] is initialized */
   if (th != NULL) {
     do {
       (*action)(fdata, th->descr, &th->descr);
       (*action)(fdata, th->backtrace_last_exn, &th->backtrace_last_exn);
-      if (th != Current_thread) {
+      if (th != Active_thread) {
         if (th->current_stack != NULL)
           caml_do_local_roots(action, fdata, th->local_roots,
                               th->current_stack, th->gc_regs);
       }
       th = th->next;
-    } while (th != Current_thread);
+    } while (th != Active_thread);
 
   };
 
@@ -161,37 +159,37 @@ static void caml_thread_scan_roots(scanning_action action,
 
 void caml_thread_save_runtime_state(void)
 {
-  Current_thread->current_stack = Caml_state->current_stack;
-  Current_thread->c_stack = Caml_state->c_stack;
-  Current_thread->gc_regs = Caml_state->gc_regs;
-  Current_thread->gc_regs_buckets = Caml_state->gc_regs_buckets;
-  Current_thread->exn_handler = Caml_state->exn_handler;
-  Current_thread->local_roots = Caml_state->local_roots;
-  Current_thread->backtrace_pos = Caml_state->backtrace_pos;
-  Current_thread->backtrace_buffer = Caml_state->backtrace_buffer;
-  Current_thread->backtrace_last_exn = Caml_state->backtrace_last_exn;
+  Active_thread->current_stack = Caml_state->current_stack;
+  Active_thread->c_stack = Caml_state->c_stack;
+  Active_thread->gc_regs = Caml_state->gc_regs;
+  Active_thread->gc_regs_buckets = Caml_state->gc_regs_buckets;
+  Active_thread->exn_handler = Caml_state->exn_handler;
+  Active_thread->local_roots = Caml_state->local_roots;
+  Active_thread->backtrace_pos = Caml_state->backtrace_pos;
+  Active_thread->backtrace_buffer = Caml_state->backtrace_buffer;
+  Active_thread->backtrace_last_exn = Caml_state->backtrace_last_exn;
 #ifndef NATIVE_CODE
-  Current_thread->trap_sp_off = Caml_state->trap_sp_off;
-  Current_thread->trap_barrier_off = Caml_state->trap_barrier_off;
-  Current_thread->external_raise = Caml_state->external_raise;
+  Active_thread->trap_sp_off = Caml_state->trap_sp_off;
+  Active_thread->trap_barrier_off = Caml_state->trap_barrier_off;
+  Active_thread->external_raise = Caml_state->external_raise;
 #endif
 }
 
 void caml_thread_restore_runtime_state(void)
 {
-  Caml_state->current_stack = Current_thread->current_stack;
-  Caml_state->c_stack = Current_thread->c_stack;
-  Caml_state->gc_regs = Current_thread->gc_regs;
-  Caml_state->gc_regs_buckets = Current_thread->gc_regs_buckets;
-  Caml_state->exn_handler = Current_thread->exn_handler;
-  Caml_state->local_roots = Current_thread->local_roots;
-  Caml_state->backtrace_pos = Current_thread->backtrace_pos;
-  Caml_state->backtrace_buffer = Current_thread->backtrace_buffer;
-  Caml_state->backtrace_last_exn = Current_thread->backtrace_last_exn;
+  Caml_state->current_stack = Active_thread->current_stack;
+  Caml_state->c_stack = Active_thread->c_stack;
+  Caml_state->gc_regs = Active_thread->gc_regs;
+  Caml_state->gc_regs_buckets = Active_thread->gc_regs_buckets;
+  Caml_state->exn_handler = Active_thread->exn_handler;
+  Caml_state->local_roots = Active_thread->local_roots;
+  Caml_state->backtrace_pos = Active_thread->backtrace_pos;
+  Caml_state->backtrace_buffer = Active_thread->backtrace_buffer;
+  Caml_state->backtrace_last_exn = Active_thread->backtrace_last_exn;
 #ifndef NATIVE_CODE
-  Caml_state->trap_sp_off = Current_thread->trap_sp_off;
-  Caml_state->trap_barrier_off = Current_thread->trap_barrier_off;
-  Caml_state->external_raise = Current_thread->external_raise;
+  Caml_state->trap_sp_off = Active_thread->trap_sp_off;
+  Caml_state->trap_barrier_off = Active_thread->trap_barrier_off;
+  Caml_state->external_raise = Active_thread->external_raise;
 #endif
 }
 
@@ -210,9 +208,9 @@ static void caml_thread_leave_blocking_section(void)
 {
   /* Wait until the runtime is free */
   st_masterlock_acquire(&Thread_main_lock);
-  /* Update Current_thread to point to the thread descriptor corresponding to
+  /* Update Active_thread to point to the thread descriptor corresponding to
      the thread currently executing */
-  Current_thread = st_tls_get(caml_thread_key);
+  Active_thread = st_tls_get(caml_thread_key);
   /* Restore the runtime state from the curr_thread descriptor */
   caml_thread_restore_runtime_state();
 }
@@ -279,9 +277,9 @@ static value caml_thread_new_descriptor(value clos)
 static void caml_thread_remove_info(caml_thread_t th)
 {
   if (th->next == th)
-    All_threads = NULL; /* last OCaml thread exiting */
-  else if (All_threads == th)
-    All_threads = th->next;     /* PR#5295 */
+    Active_thread = NULL; /* last OCaml thread exiting */
+  else if (Active_thread == th)
+    Active_thread = th->next;     /* PR#5295 */
   th->next->prev = th->prev;
   th->prev->next = th->next;
   caml_free_stack(th->current_stack);
@@ -296,16 +294,15 @@ static void caml_thread_reinitialize(void)
 {
   caml_thread_t th, next;
 
-  th = Current_thread->next;
-  while (th != Current_thread) {
+  th = Active_thread->next;
+  while (th != Active_thread) {
     next = th->next;
     caml_free_stack(th->current_stack);
     caml_stat_free(th);
     th = next;
   }
-  Current_thread->next = Current_thread;
-  Current_thread->prev = Current_thread;
-  All_threads = Current_thread;
+  Active_thread->next = Active_thread;
+  Active_thread->prev = Active_thread;
 
   /* Within the child, the domain_lock needs to be reset and acquired. */
   caml_reset_domain_lock();
@@ -331,16 +328,15 @@ static void caml_thread_domain_stop_hook(void) {
      on its chain before wrapping up. */
   if (!caml_domain_alone()) {
 
-    while (Current_thread->next != Current_thread) {
-      caml_thread_join(Current_thread->next->descr);
+    while (Active_thread->next != Active_thread) {
+      caml_thread_join(Active_thread->next->descr);
     }
 
     /* another domain thread may be joining on this domain's descriptor */
-    caml_threadstatus_terminate(Terminated(Current_thread->descr));
+    caml_threadstatus_terminate(Terminated(Active_thread->descr));
 
-    caml_stat_free(Current_thread);
-    Current_thread = NULL;
-    All_threads = NULL;
+    caml_stat_free(Active_thread);
+    Active_thread = NULL;
   };
 }
 
@@ -365,8 +361,7 @@ CAMLprim value caml_thread_initialize_domain(value v)
 
   st_tls_set(caml_thread_key, new_thread);
 
-  All_threads = new_thread;
-  Current_thread = new_thread;
+  Active_thread = new_thread;
   Tick_thread_running = 0;
 
   CAMLreturn(Val_unit);
@@ -435,37 +430,27 @@ CAMLprim value caml_thread_cleanup(value unit)
 
 static void caml_thread_stop(void)
 {
-  caml_thread_t next;
-
   /* PR#5188, PR#7220: some of the global runtime state may have
      changed as the thread was running, so we save it in the
      curr_thread data to make sure that the cleanup logic
      below uses accurate information. */
   caml_thread_save_runtime_state();
 
-  next = Current_thread->next;
-
   /* The main domain thread does not go through [caml_thread_stop]. There is
      always one more thread in the chain at this point in time. */
-  CAMLassert(next != Current_thread);
+  CAMLassert(Active_thread->next != Active_thread);
 
-  caml_threadstatus_terminate(Terminated(Current_thread->descr));
-  caml_thread_remove_info(Current_thread);
+  caml_threadstatus_terminate(Terminated(Active_thread->descr));
 
-  /* FIXME: tricky bit with backup thread
-
-     Normally we expect the next thread to kick in and resume operation by
-     first setting Current_thread to the right TLS dec data. However it may
-     very well be that there's no runnable dec next (eg: next dec is
-     blocking.), so we set it to next for now to give a valid state to the
-     backup thread. */
-  Current_thread = next;
-
+  /* The following also sets Active_thread to a sane value in case the
+     backup thread does a GC before the domain lock is acquired
+     again. */
+  caml_thread_remove_info(Active_thread);
   caml_thread_restore_runtime_state();
 
   /* If no other OCaml thread remains, ask the tick thread to stop
      so that it does not prevent the whole process from exiting (#9971) */
-  if (All_threads == NULL) caml_thread_cleanup(Val_unit);
+  if (Active_thread == NULL) caml_thread_cleanup(Val_unit);
 
   st_masterlock_release(&Thread_main_lock);
 }
@@ -482,7 +467,7 @@ static void * caml_thread_start(void * v)
   st_tls_set(caml_thread_key, th);
 
   st_masterlock_acquire(&Thread_main_lock);
-  Current_thread = st_tls_get(caml_thread_key);
+  Active_thread = st_tls_get(caml_thread_key);
   caml_thread_restore_runtime_state();
 
 #ifdef POSIX_SIGNALS
@@ -491,8 +476,8 @@ static void * caml_thread_start(void * v)
   pthread_sigmask(SIG_SETMASK, &th->init_mask, NULL);
 #endif
 
-  clos = Start_closure(Current_thread->descr);
-  caml_modify(&(Start_closure(Current_thread->descr)), Val_unit);
+  clos = Start_closure(Active_thread->descr);
+  caml_modify(&(Start_closure(Active_thread->descr)), Val_unit);
   caml_callback_exn(clos, Val_unit);
   caml_thread_stop();
 
@@ -549,11 +534,11 @@ CAMLprim value caml_thread_new(value clos)
   th->init_mask = mask;
 #endif
 
-  th->next = Current_thread->next;
-  th->prev = Current_thread;
+  th->next = Active_thread->next;
+  th->prev = Active_thread;
 
-  Current_thread->next->prev = th;
-  Current_thread->next = th;
+  Active_thread->next->prev = th;
+  Active_thread->next = th;
 
   err = st_thread_create(NULL, caml_thread_start, (void *) th);
 
@@ -598,15 +583,15 @@ CAMLexport int caml_c_thread_register(void)
     return 0;
   }
   /* Add thread info block to the list of threads */
-  if (All_threads == NULL) {
+  if (Active_thread == NULL) {
     th->next = th;
     th->prev = th;
-    All_threads = th;
+    Active_thread = th;
   } else {
-    th->next = All_threads->next;
-    th->prev = All_threads;
-    All_threads->next->prev = th;
-    All_threads->next = th;
+    th->next = Active_thread->next;
+    th->prev = Active_thread;
+    Active_thread->next->prev = th;
+    Active_thread->next = th;
   }
   /* Associate the thread descriptor with the thread */
   st_tls_set(caml_thread_key, (void *) th);
@@ -644,11 +629,9 @@ CAMLexport int caml_c_thread_unregister(void)
   /* Remove thread info block from list of threads, and free it */
   caml_thread_remove_info(th);
 
-  Current_thread = All_threads;
-
   /* If no other OCaml thread remains, ask the tick thread to stop
      so that it does not prevent the whole process from exiting (#9971) */
-  if (All_threads == NULL)
+  if (Active_thread == NULL)
     caml_thread_cleanup(Val_unit);
   else
     caml_thread_restore_runtime_state();
@@ -662,7 +645,7 @@ CAMLexport int caml_c_thread_unregister(void)
 
 CAMLprim value caml_thread_self(value unit)
 {
-  return Current_thread->descr;
+  return Active_thread->descr;
 }
 
 /* Return the identifier of a thread */
@@ -678,7 +661,7 @@ CAMLprim value caml_thread_uncaught_exception(value exn)
 {
   char * msg = caml_format_exception(exn);
   fprintf(stderr, "Thread %d killed on uncaught exception %s\n",
-          Int_val(Ident(Current_thread->descr)), msg);
+          Int_val(Ident(Active_thread->descr)), msg);
   caml_stat_free(msg);
   if (Caml_state->backtrace_active) caml_print_exception_backtrace();
   fflush(stderr);
@@ -700,7 +683,7 @@ CAMLprim value caml_thread_yield(value unit)
   caml_raise_if_exception(caml_process_pending_signals_exn());
   caml_thread_save_runtime_state();
   st_thread_yield(&Thread_main_lock);
-  Current_thread = st_tls_get(caml_thread_key);
+  Active_thread = st_tls_get(caml_thread_key);
   caml_thread_restore_runtime_state();
   caml_raise_if_exception(caml_process_pending_signals_exn());
 

--- a/otherlibs/systhreads/st_stubs.c
+++ b/otherlibs/systhreads/st_stubs.c
@@ -376,6 +376,9 @@ CAMLprim value caml_thread_yield(value unit);
 
 void caml_thread_interrupt_hook(void)
 {
+  /* Do not attempt to yield from the backup thread */
+  if (caml_bt_is_self()) return;
+
   uintnat is_on = 1;
   atomic_uintnat* req_external_interrupt =
     &Caml_state->requested_external_interrupt;

--- a/otherlibs/systhreads/st_stubs.c
+++ b/otherlibs/systhreads/st_stubs.c
@@ -88,8 +88,8 @@ struct caml_thread_struct {
 
 typedef struct caml_thread_struct* caml_thread_t;
 
-/* Thread-local key for accessing the current thread's [caml_thread_t] */
-st_tlskey caml_thread_key;
+/* The current thread's [caml_thread_t] */
+static _Thread_local caml_thread_t this_thread;
 
 /* overall table for threads across domains */
 struct caml_thread_table {
@@ -102,19 +102,21 @@ struct caml_thread_table {
 /* thread_table instance, up to Max_domains */
 static struct caml_thread_table thread_table[Max_domains];
 
+#define Dom_id (this_thread->domain_id)
+
 /* The descriptor for the currently executing thread for this domain;
    also the head of a circular list of thread descriptors for this
    domain. */
-#define Active_thread thread_table[Caml_state->id].active_thread
+#define Active_thread thread_table[Dom_id].active_thread
 
 /* The master lock protecting this domain's thread chaining */
-#define Thread_main_lock thread_table[Caml_state->id].thread_lock
+#define Thread_main_lock thread_table[Dom_id].thread_lock
 
 /* Whether the "tick" thread is already running for this domain */
-#define Tick_thread_running thread_table[Caml_state->id].tick_thread_running
+#define Tick_thread_running thread_table[Dom_id].tick_thread_running
 
 /* The thread identifier of the "tick" thread for this domain */
-#define Tick_thread_id thread_table[Caml_state->id].tick_thread_id
+#define Tick_thread_id thread_table[Dom_id].tick_thread_id
 
 /* Identifier for next thread creation */
 static atomic_uintnat thread_next_id = 0;
@@ -132,24 +134,25 @@ static void caml_thread_scan_roots(scanning_action action,
                                    void *fdata,
                                    caml_domain_state *domain_state)
 {
-  caml_thread_t th;
+  caml_thread_t active, th;
 
-  th = Active_thread;
+  /* If we are called from the backup thread, we cannot access
+     [Active_thread] directly; luckily we are passed the domain_state. */
+  active = th = thread_table[domain_state->id].active_thread;
 
   /* GC could be triggered before [Active_thread] is initialized */
-  if (th != NULL) {
+  if (active != NULL) {
     do {
       (*action)(fdata, th->descr, &th->descr);
       (*action)(fdata, th->backtrace_last_exn, &th->backtrace_last_exn);
-      if (th != Active_thread) {
+      if (th != active) {
         if (th->current_stack != NULL)
           caml_do_local_roots(action, fdata, th->local_roots,
                               th->current_stack, th->gc_regs);
       }
       th = th->next;
-    } while (th != Active_thread);
-
-  };
+    } while (th != active);
+  }
 
   if (prev_scan_roots_hook != NULL)
     (*prev_scan_roots_hook)(action, fdata, domain_state);
@@ -210,7 +213,7 @@ static void caml_thread_leave_blocking_section(void)
   st_masterlock_acquire(&Thread_main_lock);
   /* Update Active_thread to point to the thread descriptor corresponding to
      the thread currently executing */
-  Active_thread = st_tls_get(caml_thread_key);
+  Active_thread = this_thread;
   /* Restore the runtime state from the curr_thread descriptor */
   caml_thread_restore_runtime_state();
 }
@@ -294,15 +297,15 @@ static void caml_thread_reinitialize(void)
 {
   caml_thread_t th, next;
 
-  th = Active_thread->next;
-  while (th != Active_thread) {
+  th = this_thread->next;
+  while (th != this_thread) {
     next = th->next;
     caml_free_stack(th->current_stack);
     caml_stat_free(th);
     th = next;
   }
-  Active_thread->next = Active_thread;
-  Active_thread->prev = Active_thread;
+  this_thread->next = this_thread;
+  this_thread->prev = this_thread;
 
   /* Within the child, the domain_lock needs to be reset and acquired. */
   caml_reset_domain_lock();
@@ -328,14 +331,14 @@ static void caml_thread_domain_stop_hook(void) {
      on its chain before wrapping up. */
   if (!caml_domain_alone()) {
 
-    while (Active_thread->next != Active_thread) {
-      caml_thread_join(Active_thread->next->descr);
+    while (this_thread->next != this_thread) {
+      caml_thread_join(this_thread->next->descr);
     }
 
     /* another domain thread may be joining on this domain's descriptor */
-    caml_threadstatus_terminate(Terminated(Active_thread->descr));
+    caml_threadstatus_terminate(Terminated(this_thread->descr));
 
-    caml_stat_free(Active_thread);
+    caml_stat_free(this_thread);
     Active_thread = NULL;
   };
 }
@@ -349,19 +352,20 @@ CAMLprim value caml_thread_initialize_domain(value v)
   /* OS-specific initialization */
   st_initialize();
 
-  st_masterlock_init(&Thread_main_lock);
-
   new_thread =
     (caml_thread_t) caml_stat_alloc(sizeof(struct caml_thread_struct));
 
+  new_thread->domain_id = Caml_state->id;
   new_thread->descr = caml_thread_new_descriptor(Val_unit);
   new_thread->next = new_thread;
   new_thread->prev = new_thread;
   new_thread->backtrace_last_exn = Val_unit;
 
-  st_tls_set(caml_thread_key, new_thread);
+  this_thread = new_thread;
 
+  /* Initialise the thread table entry */
   Active_thread = new_thread;
+  st_masterlock_init(&Thread_main_lock);
   Tick_thread_running = 0;
 
   CAMLreturn(Val_unit);
@@ -396,9 +400,6 @@ CAMLprim value caml_thread_initialize(value unit)
   if (!caml_domain_alone())
     caml_failwith("caml_thread_initialize: cannot initialize Thread "
                   "while several domains are running.");
-
-  /* Initialize the key to the [caml_thread_t] structure */
-  st_tls_newkey(&caml_thread_key);
 
   /* First initialise the systhread chain on this domain */
   caml_thread_initialize_domain(Val_unit);
@@ -438,14 +439,14 @@ static void caml_thread_stop(void)
 
   /* The main domain thread does not go through [caml_thread_stop]. There is
      always one more thread in the chain at this point in time. */
-  CAMLassert(Active_thread->next != Active_thread);
+  CAMLassert(this_thread->next != this_thread);
 
-  caml_threadstatus_terminate(Terminated(Active_thread->descr));
+  caml_threadstatus_terminate(Terminated(this_thread->descr));
 
   /* The following also sets Active_thread to a sane value in case the
      backup thread does a GC before the domain lock is acquired
      again. */
-  caml_thread_remove_info(Active_thread);
+  caml_thread_remove_info(this_thread);
   caml_thread_restore_runtime_state();
 
   /* If no other OCaml thread remains, ask the tick thread to stop
@@ -464,10 +465,10 @@ static void * caml_thread_start(void * v)
 
   caml_init_domain_self(th->domain_id);
 
-  st_tls_set(caml_thread_key, th);
+  this_thread = th;
 
   st_masterlock_acquire(&Thread_main_lock);
-  Active_thread = st_tls_get(caml_thread_key);
+  Active_thread = this_thread;
   caml_thread_restore_runtime_state();
 
 #ifdef POSIX_SIGNALS
@@ -476,8 +477,8 @@ static void * caml_thread_start(void * v)
   pthread_sigmask(SIG_SETMASK, &th->init_mask, NULL);
 #endif
 
-  clos = Start_closure(Active_thread->descr);
-  caml_modify(&(Start_closure(Active_thread->descr)), Val_unit);
+  clos = Start_closure(this_thread->descr);
+  caml_modify(&(Start_closure(this_thread->descr)), Val_unit);
   caml_callback_exn(clos, Val_unit);
   caml_thread_stop();
 
@@ -534,11 +535,11 @@ CAMLprim value caml_thread_new(value clos)
   th->init_mask = mask;
 #endif
 
-  th->next = Active_thread->next;
-  th->prev = Active_thread;
+  th->next = this_thread->next;
+  th->prev = this_thread;
 
-  Active_thread->next->prev = th;
-  Active_thread->next = th;
+  this_thread->next->prev = th;
+  this_thread->next = th;
 
   err = st_thread_create(NULL, caml_thread_start, (void *) th);
 
@@ -569,19 +570,22 @@ CAMLexport int caml_c_thread_register(void)
   st_retcode err;
 
   /* Already registered? */
-  if (Caml_state == NULL) {
-    caml_init_domain_self(0);
-  };
-  if (st_tls_get(caml_thread_key) != NULL) return 0;
+  if (this_thread != NULL) return 0;
+  CAMLassert(Caml_state == NULL);
+  caml_init_domain_self(0);
+
+  st_masterlock *thread_lock = &thread_table[0].thread_lock;
   /* Take master lock to protect access to the runtime */
-  st_masterlock_acquire(&Thread_main_lock);
+  st_masterlock_acquire(thread_lock);
   /* Create a thread info block */
   th = caml_thread_new_info();
   /* If it fails, we release the lock and return an error. */
   if (th == NULL) {
-    st_masterlock_release(&Thread_main_lock);
+    st_masterlock_release(thread_lock);
     return 0;
   }
+  /* Associate the thread descriptor with the thread */
+  this_thread = th;
   /* Add thread info block to the list of threads */
   if (Active_thread == NULL) {
     th->next = th;
@@ -593,8 +597,6 @@ CAMLexport int caml_c_thread_register(void)
     Active_thread->next->prev = th;
     Active_thread->next = th;
   }
-  /* Associate the thread descriptor with the thread */
-  st_tls_set(caml_thread_key, (void *) th);
   /* Allocate the thread descriptor on the heap */
   th->descr = caml_thread_new_descriptor(Val_unit);  /* no closure */
 
@@ -605,7 +607,7 @@ CAMLexport int caml_c_thread_register(void)
   }
 
   /* Release the master lock */
-  st_masterlock_release(&Thread_main_lock);
+  st_masterlock_release(thread_lock);
   return 1;
 }
 
@@ -614,18 +616,14 @@ CAMLexport int caml_c_thread_register(void)
 
 CAMLexport int caml_c_thread_unregister(void)
 {
-  caml_thread_t th;
+  caml_thread_t th = this_thread;
 
-  /* If Caml_state is not set, this thread was likely not registered */
-  if (Caml_state == NULL) return 0;
-
-  th = st_tls_get(caml_thread_key);
   /* Not registered? */
   if (th == NULL) return 0;
+
+  st_masterlock *thread_lock = &Thread_main_lock;
   /* Wait until the runtime is available */
-  st_masterlock_acquire(&Thread_main_lock);
-  /*  Forget the thread descriptor */
-  st_tls_set(caml_thread_key, NULL);
+  st_masterlock_acquire(thread_lock);
   /* Remove thread info block from list of threads, and free it */
   caml_thread_remove_info(th);
 
@@ -636,8 +634,10 @@ CAMLexport int caml_c_thread_unregister(void)
   else
     caml_thread_restore_runtime_state();
 
+  /*  Forget the thread descriptor */
+  this_thread = NULL;
   /* Release the runtime */
-  st_masterlock_release(&Thread_main_lock);
+  st_masterlock_release(thread_lock);
   return 1;
 }
 
@@ -645,7 +645,7 @@ CAMLexport int caml_c_thread_unregister(void)
 
 CAMLprim value caml_thread_self(value unit)
 {
-  return Active_thread->descr;
+  return this_thread->descr;
 }
 
 /* Return the identifier of a thread */
@@ -661,7 +661,7 @@ CAMLprim value caml_thread_uncaught_exception(value exn)
 {
   char * msg = caml_format_exception(exn);
   fprintf(stderr, "Thread %d killed on uncaught exception %s\n",
-          Int_val(Ident(Active_thread->descr)), msg);
+          Int_val(Ident(this_thread->descr)), msg);
   caml_stat_free(msg);
   if (Caml_state->backtrace_active) caml_print_exception_backtrace();
   fflush(stderr);
@@ -683,7 +683,7 @@ CAMLprim value caml_thread_yield(value unit)
   caml_raise_if_exception(caml_process_pending_signals_exn());
   caml_thread_save_runtime_state();
   st_thread_yield(&Thread_main_lock);
-  Active_thread = st_tls_get(caml_thread_key);
+  Active_thread = this_thread;
   caml_thread_restore_runtime_state();
   caml_raise_if_exception(caml_process_pending_signals_exn());
 

--- a/runtime/caml/domain.h
+++ b/runtime/caml/domain.h
@@ -70,6 +70,7 @@ void caml_reset_young_limit(caml_domain_state *);
 
 CAMLextern void caml_reset_domain_lock(void);
 CAMLextern int caml_bt_is_in_blocking_section(void);
+CAMLexport int caml_bt_is_self(void);
 CAMLextern intnat caml_domain_is_multicore (void);
 CAMLextern void caml_bt_enter_ocaml(void);
 CAMLextern void caml_bt_exit_ocaml(void);

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -1523,13 +1523,13 @@ void caml_handle_gc_interrupt(void)
 
 CAMLexport int caml_bt_is_in_blocking_section(void)
 {
-  dom_internal* self = domain_self;
-  uintnat status = atomic_load_acq(&self->backup_thread_msg);
-  if (status == BT_IN_BLOCKING_SECTION)
-    return 1;
-  else
-    return 0;
+  uintnat status = atomic_load_acq(&domain_self->backup_thread_msg);
+  return status == BT_IN_BLOCKING_SECTION;
+}
 
+CAMLexport int caml_bt_is_self(void)
+{
+  return pthread_equal(domain_self->backup_thread, pthread_self());
 }
 
 CAMLexport intnat caml_domain_is_multicore (void)

--- a/testsuite/Makefile
+++ b/testsuite/Makefile
@@ -164,6 +164,9 @@ default:
 	@echo "all*, parallel* and list can automatically re-run failed test"
 	@echo "directories if MAX_TESTSUITE_DIR_RETRIES permits"
 	@echo "(default value = $(MAX_TESTSUITE_DIR_RETRIES))"
+	@echo
+	@echo "Set the environment variable USE_RUNTIME to \"d\" or \"i\" to run"
+	@echo "the tests with the debug or the instrumented runtime."
 
 .PHONY: all
 all:


### PR DESCRIPTION
Here are various fixes and simplifications to the multicore systhreads implementation (cc @Engil).

From the commit logs:

---

### Do not run `caml_thread_yield` from the backup thread.
    
This behaviour was likely unintended given that `caml_thread_yield` runs
signal handlers, which can execute arbitrary OCaml code.

---

### Simplifications to multicore systhreads

1. Use a thread-local variable `this_thread` instead of explicit TLS;
   prefer using `this_thread` over `Current_thread`.
    
2. Remove redundant `All_threads` circular list and remove a FIXME.

3. Never access `Caml_state` while the domain lock is not held.

The main motivation is 3. (in preparation of #11272). But the
fact that this is done by simplifying the code is nice.

---

### Remove some dead code

Here, we are never the last thread of the domain.

---

### Fix some incorrect comment and restore some comments from pre-multicore systhreads implementation.

---

This is best reviewed commit-per-commit. No change entry needed.