### PR TITLE
Make `Caml_state` `NULL` while the domain lock is not held

### DIFF
--- a/Changes
+++ b/Changes
@@ -186,6 +186,13 @@ OCaml 5.0
   Guillaume Munch-Maccagnoni, additional discussions with Stephen
   Dolan and Luc Maranget)
 
+- #5299, #4787, #11138, #11272: `Caml_state` is `NULL` when the domain lock is
+  not held. This allows to test if the current thread holds the lock of its
+  domain, and it makes it simpler to debug when one forgets to acquire
+  the lock.
+  (Guillaume Munch-Maccagnoni, review by Sadiq Jaffer, Xavier Leroy and
+  Gabriel Scherer)
+
 ### Code generation and optimizations:
 
 - #10972: ARM64 multicore support: OCaml & C stack separation;

--- a/manual/src/cmds/intf-c.etex
+++ b/manual/src/cmds/intf-c.etex
@@ -2500,6 +2500,10 @@ CAMLprim stub_gethostbyname(value vname)
 }
 \end{verbatim}
 
+During the time the domain lock is released, the thread-local variable
+"Caml_state" is set to "NULL". This can be used to determine if the
+thread currently holds its domain lock.
+
 Callbacks from C to OCaml must be performed while holding the master
 lock to the OCaml run-time system.  This is naturally the case if the
 callback is performed by a C primitive that did not release the

--- a/otherlibs/systhreads/st_stubs.c
+++ b/otherlibs/systhreads/st_stubs.c
@@ -470,6 +470,7 @@ static void caml_thread_stop(void)
 
 /* Create a thread */
 
+/* the thread lock is not held when entering */
 static void * caml_thread_start(void * v)
 {
   caml_thread_t th = (caml_thread_t) v;
@@ -579,6 +580,7 @@ CAMLprim value caml_thread_new(value clos)
 
 #define Dom_c_threads 0
 
+/* the thread lock is not held when entering */
 CAMLexport int caml_c_thread_register(void)
 {
   /* Already registered? */
@@ -626,6 +628,7 @@ CAMLexport int caml_c_thread_register(void)
 /* Unregister a thread that was created from C and registered with
    the function above */
 
+/* the thread lock is not held when entering */
 CAMLexport int caml_c_thread_unregister(void)
 {
   caml_thread_t th = st_tls_get(caml_thread_key);

--- a/otherlibs/systhreads/st_stubs.c
+++ b/otherlibs/systhreads/st_stubs.c
@@ -102,13 +102,24 @@ struct caml_thread_table {
 /* thread_table instance, up to Max_domains */
 static struct caml_thread_table thread_table[Max_domains];
 
+#define Thread_lock(dom_id) &thread_table[dom_id].thread_lock
+
+static void thread_lock_acquire(int dom_id)
+{
+  st_masterlock_acquire(Thread_lock(dom_id));
+}
+
+static void thread_lock_release(int dom_id)
+{
+  st_masterlock_release(Thread_lock(dom_id));
+}
+
+/* The remaining fields are accessed while holding the domain lock */
+
 /* The descriptor for the currently executing thread for this domain;
    also the head of a circular list of thread descriptors for this
    domain. */
 #define Active_thread thread_table[Caml_state->id].active_thread
-
-/* The master lock protecting this domain's thread chaining */
-#define Thread_main_lock thread_table[Caml_state->id].thread_lock
 
 /* Whether the "tick" thread is already running for this domain */
 #define Tick_thread_running thread_table[Caml_state->id].tick_thread_running
@@ -201,17 +212,18 @@ static void caml_thread_enter_blocking_section(void)
      of the current thread */
   caml_thread_save_runtime_state();
   /* Tell other threads that the runtime is free */
-  st_masterlock_release(&Thread_main_lock);
+  thread_lock_release(Caml_state->id);
 }
 
 static void caml_thread_leave_blocking_section(void)
 {
+  caml_thread_t th = st_tls_get(caml_thread_key);
   /* Wait until the runtime is free */
-  st_masterlock_acquire(&Thread_main_lock);
+  thread_lock_acquire(th->domain_id);
   /* Update Active_thread to point to the thread descriptor corresponding to
      the thread currently executing */
-  Active_thread = st_tls_get(caml_thread_key);
-  /* Restore the runtime state from the curr_thread descriptor */
+  Active_thread = th;
+  /* Restore the runtime state from the Active_thread descriptor */
   caml_thread_restore_runtime_state();
 }
 
@@ -310,7 +322,7 @@ static void caml_thread_reinitialize(void)
   /* The master lock needs to be initialized again. This process will also be
      the effective owner of the lock. So there is no need to run
      st_masterlock_acquire (busy = 1) */
-  st_masterlock_init(&Thread_main_lock);
+  st_masterlock_init(Thread_lock(Caml_state->id));
 }
 
 CAMLprim value caml_thread_join(value th);
@@ -349,11 +361,12 @@ CAMLprim value caml_thread_initialize_domain(value v)
   /* OS-specific initialization */
   st_initialize();
 
-  st_masterlock_init(&Thread_main_lock);
+  st_masterlock_init(Thread_lock(Caml_state->id));
 
   new_thread =
     (caml_thread_t) caml_stat_alloc(sizeof(struct caml_thread_struct));
 
+  new_thread->domain_id = Caml_state->id;
   new_thread->descr = caml_thread_new_descriptor(Val_unit);
   new_thread->next = new_thread;
   new_thread->prev = new_thread;
@@ -452,7 +465,7 @@ static void caml_thread_stop(void)
      so that it does not prevent the whole process from exiting (#9971) */
   if (Active_thread == NULL) caml_thread_cleanup(Val_unit);
 
-  st_masterlock_release(&Thread_main_lock);
+  thread_lock_release(Caml_state->id);
 }
 
 /* Create a thread */
@@ -460,14 +473,15 @@ static void caml_thread_stop(void)
 static void * caml_thread_start(void * v)
 {
   caml_thread_t th = (caml_thread_t) v;
+  int dom_id = th->domain_id;
   value clos;
 
-  caml_init_domain_self(th->domain_id);
+  caml_init_domain_self(dom_id);
 
   st_tls_set(caml_thread_key, th);
 
-  st_masterlock_acquire(&Thread_main_lock);
-  Active_thread = st_tls_get(caml_thread_key);
+  thread_lock_acquire(dom_id);
+  Active_thread = th;
   caml_thread_restore_runtime_state();
 
 #ifdef POSIX_SIGNALS
@@ -563,23 +577,23 @@ CAMLprim value caml_thread_new(value clos)
 
 /* Register a thread already created from C */
 
+#define Dom_c_threads 0
+
 CAMLexport int caml_c_thread_register(void)
 {
-  caml_thread_t th;
-  st_retcode err;
-
   /* Already registered? */
-  if (Caml_state == NULL) {
-    caml_init_domain_self(0);
-  };
   if (st_tls_get(caml_thread_key) != NULL) return 0;
+
+  CAMLassert(Caml_state == NULL);
+  caml_init_domain_self(Dom_c_threads);
+
   /* Take master lock to protect access to the runtime */
-  st_masterlock_acquire(&Thread_main_lock);
+  thread_lock_acquire(Dom_c_threads);
   /* Create a thread info block */
-  th = caml_thread_new_info();
+  caml_thread_t th = caml_thread_new_info();
   /* If it fails, we release the lock and return an error. */
   if (th == NULL) {
-    st_masterlock_release(&Thread_main_lock);
+    thread_lock_release(Dom_c_threads);
     return 0;
   }
   /* Add thread info block to the list of threads */
@@ -599,13 +613,13 @@ CAMLexport int caml_c_thread_register(void)
   th->descr = caml_thread_new_descriptor(Val_unit);  /* no closure */
 
   if (! Tick_thread_running) {
-    err = create_tick_thread();
+    st_retcode err = create_tick_thread();
     sync_check_error(err, "caml_register_c_thread");
     Tick_thread_running = 1;
   }
 
   /* Release the master lock */
-  st_masterlock_release(&Thread_main_lock);
+  thread_lock_release(Dom_c_threads);
   return 1;
 }
 
@@ -614,16 +628,12 @@ CAMLexport int caml_c_thread_register(void)
 
 CAMLexport int caml_c_thread_unregister(void)
 {
-  caml_thread_t th;
+  caml_thread_t th = st_tls_get(caml_thread_key);
 
-  /* If Caml_state is not set, this thread was likely not registered */
-  if (Caml_state == NULL) return 0;
-
-  th = st_tls_get(caml_thread_key);
-  /* Not registered? */
+  /* If this thread is not set, then it was not registered */
   if (th == NULL) return 0;
   /* Wait until the runtime is available */
-  st_masterlock_acquire(&Thread_main_lock);
+  thread_lock_acquire(Dom_c_threads);
   /*  Forget the thread descriptor */
   st_tls_set(caml_thread_key, NULL);
   /* Remove thread info block from list of threads, and free it */
@@ -637,7 +647,7 @@ CAMLexport int caml_c_thread_unregister(void)
     caml_thread_restore_runtime_state();
 
   /* Release the runtime */
-  st_masterlock_release(&Thread_main_lock);
+  thread_lock_release(Dom_c_threads);
   return 1;
 }
 
@@ -672,7 +682,9 @@ CAMLprim value caml_thread_uncaught_exception(value exn)
 
 CAMLprim value caml_thread_yield(value unit)
 {
-  if (atomic_load_acq(&Thread_main_lock.waiters) == 0) return Val_unit;
+  st_masterlock *m = Thread_lock(Caml_state->id);
+  if (st_masterlock_waiters(m) == 0)
+    return Val_unit;
 
   /* Do all the parts of a blocking section enter/leave except lock
      manipulation, which we'll do more efficiently in st_thread_yield. (Since
@@ -682,7 +694,7 @@ CAMLprim value caml_thread_yield(value unit)
 
   caml_raise_if_exception(caml_process_pending_signals_exn());
   caml_thread_save_runtime_state();
-  st_thread_yield(&Thread_main_lock);
+  st_thread_yield(m);
   Active_thread = st_tls_get(caml_thread_key);
   caml_thread_restore_runtime_state();
   caml_raise_if_exception(caml_process_pending_signals_exn());

--- a/otherlibs/systhreads/threads.h
+++ b/otherlibs/systhreads/threads.h
@@ -56,11 +56,12 @@ CAMLextern int caml_c_thread_unregister(void);
 /* If a thread is created by C code (instead of by OCaml itself),
    it must be registered with the OCaml runtime system before
    being able to call back into OCaml code or use other runtime system
-   functions.  Just call [caml_c_thread_register] once.
-   Before the thread finishes, it must call [caml_c_thread_unregister].
+   functions.  Just call [caml_c_thread_register] once. The domain lock
+   is not held when [caml_c_thread_register] returns.
+   Before the thread finishes, it must call [caml_c_thread_unregister]
+   (without holding the domain lock).
    Both functions return 1 on success, 0 on error.
-   In multicore OCaml, note that threads created by C code will be registered
-   to the domain 0 threads chaining.
+   Note that threads registered by C code belong to the domain 0.
 */
 
 #ifdef __cplusplus

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -1564,6 +1564,7 @@ CAMLexport void caml_acquire_domain_lock(void)
 {
   dom_internal* self = domain_self;
   caml_plat_lock(&self->domain_lock);
+  SET_Caml_state(self->state);
 }
 
 CAMLexport void caml_bt_enter_ocaml(void)
@@ -1580,6 +1581,7 @@ CAMLexport void caml_bt_enter_ocaml(void)
 CAMLexport void caml_release_domain_lock(void)
 {
   dom_internal* self = domain_self;
+  SET_Caml_state(NULL);
   caml_plat_unlock(&self->domain_lock);
 }
 

--- a/testsuite/tests/c-api/test_c_thread_has_lock.ml
+++ b/testsuite/tests/c-api/test_c_thread_has_lock.ml
@@ -1,0 +1,17 @@
+(* TEST
+   modules = "test_c_thread_has_lock_cstubs.c"
+   * bytecode
+   * native
+*)
+
+external test_with_lock : unit -> bool = "with_lock"
+external test_without_lock : unit -> bool = "without_lock"
+
+let passed b = Printf.printf (if b then "passed\n" else "failed\n")
+
+let f () =
+  passed (not (test_without_lock ())) ;
+  passed (test_with_lock ())
+
+let _ =
+  f ();

--- a/testsuite/tests/c-api/test_c_thread_has_lock.reference
+++ b/testsuite/tests/c-api/test_c_thread_has_lock.reference
@@ -1,0 +1,2 @@
+passed
+passed

--- a/testsuite/tests/c-api/test_c_thread_has_lock_cstubs.c
+++ b/testsuite/tests/c-api/test_c_thread_has_lock_cstubs.c
@@ -1,0 +1,17 @@
+#include "caml/mlvalues.h"
+#include "caml/domain_state.h"
+#include "caml/signals.h"
+
+value with_lock(value unit)
+{
+  return Val_bool(Caml_state != NULL);
+}
+
+value without_lock(value unit)
+{
+  int res;
+  caml_enter_blocking_section();
+  res = (Caml_state != NULL);
+  caml_leave_blocking_section();
+  return Val_bool(res);
+}

--- a/testsuite/tests/c-api/test_c_thread_has_lock_systhread.ml
+++ b/testsuite/tests/c-api/test_c_thread_has_lock_systhread.ml
@@ -1,0 +1,21 @@
+(* TEST
+   modules = "test_c_thread_has_lock_cstubs.c"
+   * hassysthreads
+   include systhreads
+   ** bytecode
+   ** native
+*)
+
+external test_with_lock : unit -> bool = "with_lock"
+external test_without_lock : unit -> bool = "without_lock"
+
+let passed b = Printf.printf (if b then "passed\n" else "failed\n")
+
+let f () =
+  passed (not (test_without_lock ())) ;
+  passed (test_with_lock ())
+
+let _ =
+  f ();
+  let t = Thread.create f () in
+  Thread.join t

--- a/testsuite/tests/c-api/test_c_thread_has_lock_systhread.reference
+++ b/testsuite/tests/c-api/test_c_thread_has_lock_systhread.reference
@@ -1,0 +1,4 @@
+passed
+passed
+passed
+passed


### PR DESCRIPTION
Here is an alternative 2-line solution, with added benefits, to the problem of checking if the runtime lock is held. See previous discussion at #11138. (cc who took part in previous discussion: @sadiqj, @xavierleroy.)

We set `Caml_state` to `NULL` inside of blocking sections, with the added benefit that unprotected access to `Caml_state` (such as by running some runtime functions without holding the domain lock) is easier to debug.

This PR lives on top of #11271, only the two topmost commits belong to this PR.

From the commit-log:

---

Caml_state is NULL while the domain lock is not held

- The domain lock protects access to the domain state. By setting
  Caml_state to NULL inside blocking sections, one increases the
  chances that an incorrect manipulation of the runtime causes an
  early failure, as well as making such bugs easier to debug.

  (Drawback: some unprotected accesses to Caml_state are safe, such as
  accessing Caml_state->id inside blocking sections. Little is lost
  because the programmer who needs it can store the domain ID in a
  thread-local variable.)

- In addition, this change makes it possible to test whether a thread
  belonging to a domain holds the lock of its domain. This is
  necessary for implementing C functions which are generic on whether
  the domain lock is held or not. By testing whether Caml_state is
  NULL, the programmer can for instance:
  - report a programming error
  - try to acquire the domain lock
  - do something else (e.g. delay an operation until the lock is
    acquired)

  One application is for the OCaml-Rust FFI: in some situations, it is
  not possible to enforce with static typing that some function runs
  only when the runtime lock is held (notably destructors). For these
  situations, this function lets us implement:
  - a dynamic check of whether the lock is held (which plays well with
    the lifetime-based GC safety),
  - a way to acquire the domain lock only if it is not already held.

  In OCaml 4, it is possible to implement this feature on the
  programmer-side (using internals) by customizing the enter/leave
  runtime hooks. Alas, this strategy does not work in OCaml 5. One
  would have to somehow install hooks after systhread is loaded, but
  before the second domain is spawned (after which hooks can no longer
  be modified), and this is very hard to do. So we need a native
  solution for OCaml 5.