### PR TITLE
Add a unique identifier for fibers

### DIFF
--- a/runtime/caml/config.h
+++ b/runtime/caml/config.h
@@ -209,7 +209,7 @@ typedef uint64_t uintnat;
 
 /* Number of words used in the control structure at the start of a stack
    (see fiber.h) */
-#define Stack_ctx_words 6
+#define Stack_ctx_words 7
 
 /* Default maximum size of the stack (words). */
 /* (1 Gib for 64-bit platforms, 512 Mib for 32-bit platforms) */

--- a/runtime/caml/fiber.h
+++ b/runtime/caml/fiber.h
@@ -57,6 +57,7 @@ struct stack_info {
    * [caml_fiber_wsz] or the stack is bigger than pooled sizes. */
   int cache_bucket;
   size_t size; /* only used when USE_MMAP_MAP_STACK is defined */
+  int64_t id;
   uintnat magic;
 };
 


### PR DESCRIPTION
# Introduction
Currently, there is no obvious way to identify a fiber among others, even for the runtime itself.
There is no unique information in the fiber and when a fiber stack needs to be reallocated, the whole fiber is reallocated so a pointer to the current `struct stack_info` of the fiber is invalided.

In some cases it may be convenient to identify a specific fiber: 
- For the runtime/debugger to place a `trap barrier` in a specific fiber ([11065](https://github.com/ocaml/ocaml/pull/11065))
- For users: to use a profiler that instruments code and wouldn't be able to differentiate a function entry/exit per fiber; to log information per fiber...

# Changes
An unique `int64_t` is added to the `struct stack_info` to identify a fiber globally.
The `id` 0 is used for the first fiber, subsequent one got an increasing `id` number.

An `Effect.fiber_id` function is added for users to access this information.

# Example
```ocaml
open Printf
open Effect
open Effect.Deep

type _ t += E : int -> int t

let[@inline never][@local never] f x = x

let[@inline never] consume_stack () =
  let size = 128 in
  let allocated = 2 * 2 (* 2 spilled registers *) + 1 (* saved rbp *) in
  let count = size / allocated in
  let[@inline never] rec gobbler i =
    (* Force spilling of x0 and x1 *)
    let x0 = Sys.opaque_identity 42 in
    let x1 = Sys.opaque_identity 42 in
    let _ = f x0 in
    let _ = f x1 in
    let _ = Sys.opaque_identity x0 in
    let _ = Sys.opaque_identity x1 in
    let v = if i = 1 then 42 (* dummy *) else gobbler (i - 1) in
    v - 1 (* dummy *)
  in
  ignore (gobbler count)

let fiber domain =
  let comp () =
    printf "[%c %Ld] perform effect (E 0)\n%!" domain (fiber_id ());
    consume_stack ();
    let v = perform (E 0) in
    printf "[%c %Ld] perform returns %d\n%!" domain (fiber_id ()) v;
    v + 1
  in
  let effc (type a) (eff : a t) : ((a, 'b) continuation -> 'b) option =
    let effect_e v k =
      printf "[%c %Ld] caught effect (E %d). continuing...\n%!" domain (fiber_id ()) v;
      consume_stack ();
      let v = continue k (v + 1) in
      printf "[%c %Ld] continue returns %d\n%!" domain (fiber_id ()) v;
      v + 1
    in
    match eff with
    | E v -> Some (effect_e v)
    | e -> None
  in
  let retc v =
    consume_stack ();
    printf "[%c %Ld] done %d\n%!" 'A' (fiber_id ()) v;
    v + 1
  in
  match_with comp ()
  { retc = retc;
    exnc = (fun e -> raise e);
    effc = effc }

let () =
  printf "Hello from main, fiber = %Ld\n" (fiber_id ());
  let dA = Domain.spawn (fun _ -> fiber 'A') in
  let dB = Domain.spawn (fun _ -> fiber 'B') in
  ignore @@ Domain.join dA;
  ignore @@ Domain.join dB
```
This example gives the following output:
```
### OCaml runtime: debug mode ###
Hello from main, fiber = 0
[A 2] perform effect (E 0)
[A 1] caught effect (E 0). continuing...
[A 2] perform returns 1
[A 1] done 2
[A 1] continue returns 3
[B 4] perform effect (E 0)
[B 3] caught effect (E 0). continuing...
[B 4] perform returns 1
[A 3] done 2
[B 3] continue returns 3
```
---
@TheLortex 