### PR TITLE
protect Max_domains with CAML_INTERNALS

### DIFF
--- a/runtime/caml/config.h
+++ b/runtime/caml/config.h
@@ -239,13 +239,6 @@ typedef uint64_t uintnat;
    total size of live objects. */
 #define Percent_free_def 120
 
-/* Maximum number of domains */
-#ifdef ARCH_SIXTYFOUR
-#define Max_domains 128
-#else
-#define Max_domains 16
-#endif
-
 /* Default setting for the major GC slice smoothing window: 1
    (i.e. no smoothing)
 */

--- a/runtime/caml/domain.h
+++ b/runtime/caml/domain.h
@@ -29,6 +29,14 @@ extern "C" {
 #include "domain_state.h"
 #include "platform.h"
 
+/* The runtime currently has a hard limit on the number of domains.
+   This hard limit may go away in the future. */
+#ifdef ARCH_SIXTYFOUR
+#define Max_domains 128
+#else
+#define Max_domains 16
+#endif
+
 /* is the minor heap full or an external interrupt has been triggered */
 Caml_inline int caml_check_gc_interrupt(caml_domain_state * dom_st)
 {


### PR DESCRIPTION
This PR, suggested by @gadmm, protects the definition of Max_domains with CAML_INTERNALS. As discussed in #10971, I think we should do away with the notion of Max_domains, so let's make the constant internal to avoid having users rely on it. Two arguments:

- if we move to an aesthetically-pleasing world where there is no Max_domains, users would be left in the cold
- if we don't, but we later increase Max_domains to a large number, then user (or runtime) code relying on the idea that it is "cheap" to preallocate Max_domains element for a per-domain array will become dubious

In both cases I think it is more robust to encourage people to use a resizable array instead of a fixed Max_domains value.