### PR TITLE
Make sure ocamlopt recognizes the -cmi-file command-line option

### DIFF
--- a/Changes
+++ b/Changes
@@ -206,7 +206,7 @@ Working version
   invariant checks are enabled.
   (Vincent Laviron, review by Gabriel Scherer)
 
-- #10981: Implement a -cmi-file option for ocamlc and ocamlopt.
+- #10981, #11276: Implement a -cmi-file option for ocamlc and ocamlopt.
   (Sébastien Hinderer, review by Damien Doligez, Daniel Bünzli and
   Florian Angeletti)
 

--- a/driver/main_args.ml
+++ b/driver/main_args.ml
@@ -1185,6 +1185,7 @@ struct
     mk_cc F._cc;
     mk_cclib F._cclib;
     mk_ccopt F._ccopt;
+    mk_cmi_file F._cmi_file;
     mk_clambda_checks F._clambda_checks;
     mk_classic_inlining F._classic_inlining;
     mk_color F._color;


### PR DESCRIPTION
Before this PR, the -cmi-file option was recognized only by ocamlc.

This PR makes sure the option is also recognized by ocamlopt.

Fixes issue #11275.