### PR TITLE
Ensure Makefile.build_config is only loaded once

### DIFF
--- a/Makefile.build_config.in
+++ b/Makefile.build_config.in
@@ -19,6 +19,11 @@
 # OCaml's build system and so itself includes Makefile.config. It assumes that
 # $(ROOTDIR) has been defined.
 
+# This variable is added to prevent double-inclusion of this Makefile by
+# Makefile.config_if_required. override is used as this has highest $(origin )
+# priority (including over make BUILD_CONFIG_INCLUDED)
+override BUILD_CONFIG_INCLUDED =
+
 include $(ROOTDIR)/Makefile.config
 INSTALL ?= @INSTALL@ -p
 INSTALL_DATA ?= @INSTALL_DATA@

--- a/Makefile.config_if_required
+++ b/Makefile.config_if_required
@@ -24,5 +24,7 @@ REQUIRES_CONFIGURATION := $(strip \
   $(filter-out $(CLEAN_TARGET_NAMES) configure, $(MAKECMDGOALS)))
 
 ifneq "$(REQUIRES_CONFIGURATION)" ""
+ifneq "$(origin BUILD_CONFIG_INCLUDED)" "override"
 include $(ROOTDIR)/Makefile.build_config
+endif
 endif


### PR DESCRIPTION
This addresses a papercut I just got working on https://github.com/ocaml/ocaml/pull/10926/commits/ca6893199f0a0221fac225031a4e9603ba01b6da!

In the build system, we `include` `Makefile.build_config` (which `include`s `Makefile.config`) by `include`ing `Makefile.config_if_required`. At present, it is permitted for this to happen more than once. However, this has the surprising effect of resetting variables which a `Makefile` may have considered to have been updated. In this case, in `otherlibs/unix/Makefile`, changes to `OC_CPPFLAGS` were quietly erased before the build (as `otherlibs/Makefile.otherlibs.common` pulls in `Makefile.common`).

cc @shindere - this PR may end up being more of an "issue" holder than anything else, although perhaps it may be OK to merge this in the meantime even before the otherlibs Makefiles are merged into the root Makefile? The aim was that having loaded `Makefile.build_config`, it should be possible to add things to `OC_` variables and expect them not to be reset!

For the implementation, the use of `override` allows nefarious calls such as `make BUILD_CONFIG_INCLUDED=1` to be ignored. And, yes, I turned on my macbook to check...