### PR TITLE
Manual chapters on parallelism and memory model

### DIFF
--- a/Changes
+++ b/Changes
@@ -183,6 +183,11 @@ Working version
 - #11192: Better documentation for condition variables.
   (François Pottier, review by Luc Maranget, Xavier Leroy, and Wiktor Kuchta)
 
+- #11093: Add tutorials on parallelism features and the relaxed memory model
+  (KC Sivaramakrishnan, review by Damien Doligez, Anil Madhavapeddy, Gabriel
+  Scherer, Thomas Leonard, Tom Ridge, Xavier Leroy, Luc Maranget, Fabrice
+  Buoro, Olivier Nicole, Guillaume Munch-Maccagnoni, Jacques-Henri Jourdan)
+
 ### Compiler user-interface and warnings:
 
 - #9140, #11131: New command-line flag -nocwd to not include implicit

--- a/driver/main_args.ml
+++ b/driver/main_args.ml
@@ -572,7 +572,7 @@ let mk_nopervasives f =
 
 let mk_match_context_rows f =
   "-match-context-rows", Arg.Int f,
-  let[@manual.ref "s:comp-options"] chapter, section = 11, 2 in
+  let[@manual.ref "s:comp-options"] chapter, section = 13, 2 in
   Printf.sprintf
   "<n>  (advanced, see manual section %d.%d.)" chapter section
 

--- a/lambda/translmod.ml
+++ b/lambda/translmod.ml
@@ -1698,7 +1698,7 @@ let explanation_submsg (id, unsafe_info) =
 
 let report_error loc = function
   | Circular_dependency cycle ->
-      let[@manual.ref "s:recursive-modules"] chapter, section = 10, 2 in
+      let[@manual.ref "s:recursive-modules"] chapter, section = 12, 2 in
       Location.errorf ~loc ~sub:(List.map explanation_submsg cycle)
         "Cannot safely evaluate the definition of the following cycle@ \
          of recursively-defined modules:@ %a.@ \

--- a/manual/src/allfiles.etex
+++ b/manual/src/allfiles.etex
@@ -49,6 +49,8 @@ and as a
 \input{polymorphism.tex}
 \input{gadtexamples.tex}
 \input{advexamples.tex}
+\input{parallelism.tex}
+\input{memorymodel.tex}
 
 \part{The OCaml language}
 \label{p:refman}

--- a/manual/src/library/libthreads.etex
+++ b/manual/src/library/libthreads.etex
@@ -2,20 +2,20 @@
 \label{c:threads}\cutname{threads.html}
 %HEVEA\cutname{libthreads.html}
 
-The "threads" library allows concurrent programming in OCaml.
-It provides multiple threads of control (also called lightweight
-processes) that execute concurrently in the same memory space. Threads
-communicate by in-place modification of shared data structures, or by
-sending and receiving data on communication channels.
+The "threads" library allows concurrent programming in OCaml. It provides
+multiple threads of control (also called lightweight processes) that execute
+concurrently in the same memory space. Threads communicate by in-place
+modification of shared data structures, or by sending and receiving data on
+communication channels.
 
-The "threads" library is implemented on top of the threading
-facilities provided by the operating system: POSIX 1003.1c threads for
-Linux, MacOS, and other Unix-like systems; Win32 threads for Windows.
-Only one thread at a time is allowed to run OCaml code, hence
-opportunities for parallelism are limited to the parts of the program
-that run system or C library code.  However, threads provide
-concurrency and can be used to structure programs as several
-communicating processes.  Threads also efficiently support concurrent,
+The "threads" library is implemented on top of the threading facilities
+provided by the operating system: POSIX 1003.1c threads for Linux, MacOS, and
+other Unix-like systems; Win32 threads for Windows. Only one thread at a time
+is allowed to run OCaml code on a particular
+domain~\ref{s:par_systhread_interaction}. Hence, opportunities for parallelism
+are limited to the parts of the program that run system or C library code.
+However, threads provide concurrency and can be used to structure programs as
+several communicating processes.  Threads also efficiently support concurrent,
 overlapping I/O operations.
 
 Programs that use threads must be linked as follows:

--- a/manual/src/tutorials/Makefile
+++ b/manual/src/tutorials/Makefile
@@ -11,7 +11,8 @@ TRANSF = $(OCAMLRUN) $(TOOLS)/transf
 
 
 FILES = coreexamples.tex lablexamples.tex polyvariant.tex objectexamples.tex \
-  gadtexamples.tex moduleexamples.tex advexamples.tex polymorphism.tex
+        gadtexamples.tex moduleexamples.tex advexamples.tex polymorphism.tex \
+        parallelism.tex memorymodel.tex
 
 
 etex-files: $(FILES)

--- a/manual/src/tutorials/memorymodel.etex
+++ b/manual/src/tutorials/memorymodel.etex
@@ -207,8 +207,7 @@ influenced by actions on other domains. There are several inter-domain actions:
   \item Operations on mutexes.
 \end{itemize}
 
-\emph{(TODO: Include semaphores and condition variables in the inter-domain
-actions.)}
+% TODO: Include semaphores and condition variables in the inter-domain actions.
 
 On the other hand, intra-domain actions can neither be observed nor influence
 the execution of other domains. Examples include evaluating an arithmetic

--- a/manual/src/tutorials/memorymodel.etex
+++ b/manual/src/tutorials/memorymodel.etex
@@ -1,0 +1,757 @@
+\chapter{Memory model: The hard bits}
+%HEVEA\cutname{memorymodel.html}
+\label{c:memorymodel}
+
+This chapter describes the details of OCaml relaxed memory model. The relaxed
+memory model describes what values an OCaml program is allowed to witness when
+reading a memory location. If you are interested in high-level parallel
+programming in OCaml, please have a look at the parallel programming chapter
+\ref{c:parallelism}.
+
+This chapter is aimed at experts who would like to understand the details of
+the OCaml memory model from a practitioner's perspective. For a formal
+definition of the OCaml memory model, its guarantees and the compilation to
+hardware memory models, please have a look at the PLDI 2018 paper on
+\href{https://doi.org/10.1145/3192366.3192421}{Bounding Data Races in Space and
+Time}. The memory model presented in this chapter is an extension of the one
+presented in the PLDI 2018 paper. This chapter also covers some pragmatic
+aspects of the memory model that are not covered in the paper.
+
+\section{s:why_relaxed_memory}{Why weakly consistent memory?}
+
+The simplest memory model that we could give to our programs is sequential
+consistency. Under sequential consistency, the values observed by the program
+can be explained through some interleaving of the operations from different
+domains in the program. For example, consider the following program with two
+domains "d1" and "d2" executing in parallel:
+
+\begin{caml_example*}{verbatim}
+let d1 a b =
+  let r1 = !a * 2 in
+  let r2 = !b in
+  let r3 = !a * 2 in
+  (r1, r2, r3)
+
+let d2 b = b := 0
+
+let main () =
+  let a = ref 1 in
+  let b = ref 1 in
+  let h = Domain.spawn (fun _ ->
+    let r1, r2, r3 = d1 a b in
+    Printf.printf "r1 = %d, r2 = %d, r3 = %d\n" r1 r2 r3)
+  in
+  d2 b;
+  Domain.join h
+\end{caml_example*}
+
+The reference cells "a" and "b" are initially "1". The user may observe "r1 =
+2, r2 = 0, r3 = 2" if the write to "b" in "d2" occurred before the read of "b"
+in "d1". Here, the observed behaviour can be explained in terms of interleaving
+of the operations from different domains.
+
+Let us now assume that "a" and "b" are aliases of each other.
+
+\begin{caml_example*}{verbatim}
+let d1 a b =
+  let r1 = !a * 2 in
+  let r2 = !b in
+  let r3 = !a * 2 in
+  (r1, r2, r3)
+
+let d2 b = b := 0
+
+let main () =
+  let ab = ref 1 in
+  let h = Domain.spawn (fun _ ->
+    let r1, r2, r3 = d1 ab ab in
+    assert (not (r1 = 2 && r2 = 0 && r3 = 2)))
+  in
+  d2 ab;
+  Domain.join h
+\end{caml_example*}
+
+In the above program, the variables "ab", "a" and "b" refer to the same
+reference cell. One would expect that the assertion in the main function will
+never fail. The reasoning is that if "r2" is "0", then the write in "d2"
+occurred before the read of "b" in "d1". Given that "a" and "b" are aliases,
+the second read of "a" in "d1" should also return "0".
+
+\subsection{ss:mm_comp_opt}{Compiler optimisations}
+
+Surprisingly, this assertion may fail in OCaml due to compiler optimisations.
+The OCaml compiler observes the common sub-expression "!a * 2" in "d1" and
+optimises the program to:
+
+\begin{caml_example*}{verbatim}
+let d1 a b =
+  let r1 = !a * 2 in
+  let r2 = !b in
+  let r3 = r1 in (* CSE: !a * 2 ==> r1 *)
+  (r1, r2, r3)
+
+let d2 b = b := 0
+
+let main () =
+  let ab = ref 1 in
+  let h = Domain.spawn (fun _ ->
+    let r1, r2, r3 = d1 ab ab in
+    assert (not (r1 = 2 && r2 = 0 && r3 = 2)))
+  in
+  d2 ab;
+  Domain.join h
+\end{caml_example*}
+
+This optimisation is known as the common sub-expression elimination (CSE). Such
+optimisations are valid and necessary for good performance, and do not change
+the sequential meaning of the program. However, CSE breaks sequential
+reasoning.
+
+In the optimized program above, even if the write to "b" in "d2" occurs between
+the first and the second reads in "d1", the program will observe the value "2"
+for "r3", causing the assertion to fail. The observed behaviour cannot be
+explained by interleaving of operations from different domains in the source
+program. Thus, CSE optimization is said to be invalid under sequential
+consistency.
+
+One way to explain the observed behaviour is as if the operations performed on
+a domain were reordered. For example, if the second and the third reads from
+"d2" were reordered,
+
+\begin{caml_example*}{verbatim}
+let d1 a b =
+  let r1 = !a * 2 in
+  let r3 = !a * 2 in
+  let r2 = !b in
+  (r1, r2, r3)
+\end{caml_example*}
+
+\noindent then we can explain the observed behaviour "(2,0,2)" returned by
+"d1".
+
+\subsection{ss:mm_hw_opt}{Hardware optimisations}
+
+The other source of reordering is by the hardware. Modern hardware
+architectures have complex cache hierarchies with multiple levels of cache.
+While cache coherence ensures that reads and writes to a single memory
+location respect sequential consistency, the guarantees on programs that
+operate on different memory locations are much weaker. Consider the following
+program:
+
+\begin{caml_example*}{verbatim}
+let a = ref 0
+and b = ref 0
+
+let d1 () =
+  a := 1;
+  !b
+
+let d2 () =
+  b := 1;
+  !a
+
+let main () =
+  let h = Domain.spawn d2 in
+  let r1 = d1 () in
+  let r2 = Domain.join h in
+  assert (not (r1 = 0 && r2 = 0))
+\end{caml_example*}
+
+Under sequential consistency, we would never expect the assertion to fail.
+However, even on x86, which offers much stronger guarantees than ARM, the
+writes performed at a CPU core are not immediately published to all of the
+other cores. Since "a" and "b" are different memory locations, the reads of "a"
+and "b" may both witness the initial values, leading to the assertion failure.
+
+This behaviour can be explained if a load is allowed to be reordered before a
+preceding store to a different memory location. This reordering can happen due
+to the presence of in-core store-buffers on modern processors. Each core
+effectively has a FIFO buffer of pending writes to avoid the need to block
+while a write completes. The writes to "a" and "b" may be in the store-buffers
+of cores "c1" and "c2" running the domains "d1" and "d2", respectively. The
+reads of "b" and "a" running on the cores "c1" and "c2", respectively, will not
+see the writes if the writes have not propagated from the buffers to the main
+memory.
+
+\section{s:drf_sc}{Data race freedom implies sequential consistency}
+
+The aim of the OCaml relaxed memory model is to precisely describe which orders
+are preserved by the OCaml program. The compiler and the hardware are free to
+optimize the program as long as they respect the ordering guarantees of the
+memory model. While programming directly under the relaxed memory model is
+difficult, the memory model also describes the conditions under which a program
+will only exhibit sequentially consistent behaviours. This guarantee is known
+as \emph{data race freedom implies sequential consistency} (DRF-SC). In this
+section, we shall describe this guarantee. In order to do this, we first need a
+number of definitions.
+
+\subsection{s:atomics}{Memory locations}
+
+OCaml classifies memory locations into \emph{atomic} and \emph{non-atomic}
+locations. Reference cells, array fields and mutable record fields are
+non-atomic memory locations. Immutable objects are non-atomic locations with an
+initialising write but no further updates. Atomic memory locations are those
+that are created using the \stdmoduleref{Atomic} module.
+
+\subsection{s:happens_before}{Happens-before relation}
+
+Let us imagine that the OCaml programs are executed by an abstract machine that
+executes one action at a time, arbitrarily picking one of the available domains
+at each step. We classify actions into two: \emph{inter-domain} and
+\emph{intra-domain}. An inter-domain action is one which can be observed and be
+influenced by actions on other domains. There are several inter-domain actions:
+
+\begin{itemize}
+  \item Reads and writes of atomic and non-atomic locations.
+  \item Spawn and join of domains.
+  \item Operations on mutexes.
+\end{itemize}
+
+\emph{(TODO: Include semaphores and condition variables in the inter-domain
+actions.)}
+
+On the other hand, intra-domain actions can neither be observed nor influence
+the execution of other domains. Examples include evaluating an arithmetic
+expression, calling a function, etc. The memory model specification ignores
+such intra-domain actions. In the sequel, we use the term action to indicate
+inter-domain actions.
+
+A totally ordered list of actions executed by the abstract machine is called an
+\emph{execution trace}. There might be several possible execution traces for a
+given program due to non-determinism.
+
+For a given execution trace, we define an irreflexive, transitive
+\emph{happens-before relation} that captures the causality between actions in
+the OCaml program. The happens-before relation is defined as the smallest
+transitive relation satisfying the following properties:
+
+\begin{itemize}
+  \item We define the order in which a domain executes its actions as the
+    \emph{program order}. If an action "x" precedes another action "y" in
+    program order, then "x" precedes "y" in happens-before order.
+  \item If "x" is a write to an atomic location and "y" is a subsequent read or
+    write to that memory location in the execution trace, then "x" precedes "y"
+    in happens-before order. For atomic locations, "compare_and_set",
+    "fetch_and_add", "exchange", "incr" and "decr" are considered to perform
+    both a read and a write.
+  \item If "x" is "Domain.spawn f" and "y" is the first action in the newly
+    spawned domain executing "f", then "x" precedes "y" in happens-before
+    order.
+  \item If "x" is the last action in a domain "d" and "y" is "Domain.join
+    d", then "x" precedes "y" in happens-before order.
+  \item If "x" is an unlock operation on a mutex, and "y" is any subsequent
+    operation on the mutex in the execution trace, then "x" precedes "y" in
+    happens-before order.
+\end{itemize}
+
+\subsection{s:datarace}{Data race}
+
+In a given trace, two actions are said to be \emph{conflicting} if they access
+the same non-atomic location, at least one is a write and neither is an
+initialising write to that location.
+
+We say that a program has a \emph{data race} if there exists some execution
+trace of the program with two conflicting actions and there does not exist a
+happens-before relationship between the conflicting accesses. A program without
+data races is said to be \emph{correctly synchronised}.
+
+\subsection{ss:drf_sc}{DRF-SC}
+
+\textbf{DRF-SC guarantee:} A program without data races will only exhibit
+sequentially consistent behaviours.
+
+DRF-SC is a strong guarantee for the programmers. Programmers can use
+\emph{sequential reasoning} i.e., reasoning by executing one inter-domain
+action after the other, to identify whether their program has a data race. In
+particular, they do not need to reason about reorderings described in
+section~\ref{s:why_relaxed_memory} in order to determine whether their program
+has a data race. Once the determination that a particular program is data race
+free is made, they do not need to worry about reorderings in their code.
+
+\section{s:drf_reasoning}{Reasoning with DRF-SC}
+
+In this section, we will look at examples of using DRF-SC for program
+reasoning. In this section, we will use the functions with names "dN" to
+represent domains executing in parallel with other domains. That is, we assume
+that there is a "main" function that runs the "dN" functions in parallel as
+follows:
+
+\begin{verbatim}
+let main () =
+  let h1 = Domain.spawn d1 in
+  let h2 = Domain.spawn d2 in
+  ...
+  ignore @@ Domain.join h1;
+  ignore @@ Domain.join h2
+\end{verbatim}
+
+Here is a simple example with a data race:
+
+\begin{caml_example*}{verbatim}
+(* Has data race *)
+let r = ref 0
+let d1 () = r := 1
+let d2 () = !r
+\end{caml_example*}
+
+"r" is a non-atomic reference. The two domains race to access the reference,
+and "d1" is a write. Since there is no happens-before relationship between the
+conflicting accesses, there is a data race.
+
+Both of the programs that we had seen in the section~\ref{s:why_relaxed_memory}
+have data races. It is no surprise that they exhibit non sequentially
+consistent behaviours.
+
+Accessing disjoint array indices and fields of a record in parallel is not a
+data race. For example,
+
+\begin{caml_example*}{verbatim}
+(* No data race *)
+let a = [| 0; 1 |]
+let d1 () = a.(0) <- 42
+let d2 () = a.(1) <- 42
+\end{caml_example*}
+
+\begin{caml_example*}{verbatim}
+(* No data race *)
+type t = {
+  mutable a : int;
+  mutable b : int
+}
+let r = {a = 0; b = 1}
+let d1 () = r.a <- 42
+let d2 () = r.b <- 42
+\end{caml_example*}
+
+\noindent do not have data races.
+
+Races on atomic locations do not lead to a data race.
+
+\begin{caml_example*}{verbatim}
+(* No data race *)
+let r = Atomic.make 0
+let d1 () = Atomic.set r 1
+let d2 () = Atomic.get r
+\end{caml_example*}
+
+\subsubsection{s:mm_msg_passing}{Message-passing}
+
+Atomic variables may be used for implementing non-blocking communication
+between domains.
+
+\begin{caml_example*}{verbatim}
+(* No data race *)
+let msg = ref 0
+let flag = Atomic.make false
+let d1 () =
+  msg := 42; (* a *)
+  Atomic.set flag true (* b *)
+let d2 () =
+  if Atomic.get flag (* c *) then
+    !msg (* d *)
+  else 0
+\end{caml_example*}
+
+Observe that the actions "a" and "d" write and read from the same non-atomic
+location "msg", respectively, and hence are conflicting. We need to establish
+that "a" and "d" have a happens-before relationship in order to show that this
+program does not have a data race.
+
+The action "a" precedes "b" in program order, and hence, "a" happens-before
+"b". Similarly, "c" happens-before "d". If "d2" observes the atomic variable
+"flag" to be "true", then "b" precedes "c" in happens-before order. Since
+happens-before is transitive, the conflicting actions "a" and "d" are in
+happens-before order. If "d2" observes the "flag" to be "false", then the read
+of "msg" is not done. Hence, there is no conflicting access in this execution
+trace. Hence, the program does not have a data race.
+
+The following modified version of the message passing program does have a data
+race.
+
+\begin{caml_example*}{verbatim}
+(* Has data race *)
+let msg = ref 0
+let flag = Atomic.make false
+let d1 () =
+  msg := 42; (* a *)
+  Atomic.set flag true (* b *)
+let d2 () =
+  ignore (Atomic.get flag); (* c *)
+  !msg (* d *)
+\end{caml_example*}
+
+The domain "d2" now unconditionally reads the non-atomic reference "msg".
+Consider the execution trace:
+
+\begin{verbatim}
+Atomic.get flag; (* c *)
+!msg; (* d *)
+msg := 42; (* a *)
+Atomic.set flag true (* b *)
+\end{verbatim}
+
+In this trace, "d" and "a" are conflicting operations. But there is no
+happens-before relationship between them. Hence, this program has a data race.
+
+\section{s:local_drf}{Local data race freedom}
+
+The OCaml memory model offers strong guarantees even for programs with data
+races. It offers what is known as \emph{local data race freedom sequential
+consistency (LDRF-SC)} guarantee. A formal definition of this property is beyond
+the scope of this manual chapter. Interested readers are encouraged to read the
+PLDI 2018 paper on \href{https://doi.org/10.1145/3192366.3192421}{Bounding Data
+Races in Space and Time}.
+
+Informally, LDRF-SC says that the data race free parts of the program remain
+sequentially consistent. That is, even if the program has data races, those
+parts of the program that are disjoint from the parts with data races are
+amenable to sequential reasoning.
+
+Consider the following snippet:
+
+\begin{caml_example*}{verbatim}
+let snippet () =
+  let c = ref 0 in
+  c := 42;
+  let a = !c in
+  (a, c)
+\end{caml_example*}
+
+Observe that "c" is a newly allocated reference. Can the read of "c" return a
+value which is not 42? That is, can "a" ever be not "42"? Surprisingly, in the
+C++ and Java memory models, the answer is yes. With the C++ memory model, if
+the program has a data race, even in unrelated parts, then the semantics is
+undefined. If this snippet were linked with a library that had a data race,
+then, under the C++ memory model, the read may return any value. Since data
+races on unrelated locations can affect program behaviour, we say that C++
+memory model is not bounded in space.
+
+Unlike C++, Java memory model is bounded in space. But Java memory model is not
+bounded in time; data races in the future will affect the past behaviour. For
+example, consider the translation of this example to Java. We assume a prior
+definition of "Class c {int x;}" and a shared \emph{non-volatile} variable "C
+g". Now the snippet may be part of a larger program with parallel threads:
+
+\begin{verbatim}
+(* Thread 1 *)
+C c = new C();
+c.x = 42;
+a = c.x;
+g = c;
+
+(* Thread 2 *)
+g.x = 7;
+\end{verbatim}
+
+The read of "c.x" and the write of "g" in the first thread are done on separate
+memory locations. Hence, the Java memory model allows them to be reordered. As
+a result, the write in the second thread may occur before the read of "c.x",
+and hence, "c.x" returns "7".
+
+The OCaml equivalent of the Java code above is:
+
+\begin{caml_example*}{verbatim}
+let g = ref None
+
+let snippet () =
+  let c = ref 0 in
+  c := 42;
+  let a = !c in
+  (a, c)
+
+let d1 () =
+  let (a,c) = snippet () in
+  g := Some c;
+  a
+
+let d2 () =
+  match !g with
+  | None -> ()
+  | Some c -> c := 7
+\end{caml_example*}
+
+Observe that there is a data race on both "g" and "c". Consider only the first
+three instructions in "snippet":
+
+\begin{verbatim}
+let c = ref 0 in
+c := 42;
+let a = !c in
+...
+\end{verbatim}
+
+The OCaml memory model is bounded both in space and time. The only memory
+location here is "c". Reasoning only about this snippet, there is neither the
+data race in space (the race on "g") nor in time (the future race on "c").
+Hence, the snippet will have sequentially consistent behaviour, and the value
+returned by "!c" will be "42".
+
+The OCaml memory model guarantees that even for programs with data races,
+memory safety is preserved. While programs with data races may observe
+non-sequentially consistent behaviours, they will not crash.
+
+\section{s:mm_semantics}{An operational view of the memory model}
+
+In this section, we describe the semantics of the OCaml memory model. A formal
+definition of the operational view of the memory model is presented in section
+3 of the PLDI 2018 paper on
+\href{https://doi.org/10.1145/3192366.3192421}{Bounding Data Races in Space and
+Time}. This section presents an informal description of the memory model with
+the help of an example.
+
+Given an OCaml program, which may possibly contain data races, the operational
+semantics tells you the values that may be observed by the read of a memory
+location. For simplicity, we restrict the intra-thread actions to just the
+accesses to atomic and non-atomic locations, ignoring domain spawn and join
+operations, and the operations on mutexes.
+
+We describe the semantics of the OCaml memory model in a straightforward
+small-step operational manner. That is, the semantics is described by an
+abstract machine that executes one action at a time, arbitrarily picking one of
+the available domains at each step. This is similar to the abstract machine
+that we had used to describe the happens-before relationship in
+section~\ref{s:happens_before}.
+
+\subsection{ss:mm_non_atomic}{Non-atomic locations}
+
+In the semantics, we model non-atomic locations as finite maps from timestamps
+"t" to values "v". We take timestamps to be rational numbers. The timestamps
+are totally ordered but dense; there is a timestamp between any two others.
+
+For example,
+
+\begin{verbatim}
+a: [t1 -> 1; t2 -> 2]
+b: [t3 -> 3; t4 -> 4; t5 -> 5]
+c: [t6 -> 5; t7 -> 6; t8 -> 7]
+\end{verbatim}
+
+\noindent represents three non-atomic locations "a", "b" and "c" and their
+histories. The location "a" has two writes at timestamps "t1" and "t2" with
+values "1" and "2", respectively. When we write "a: [t1 -> 1; t2 -> 2]", we
+assume that "t1 < t2". We assume that the locations are initialised with a
+history that has a single entry at timestamp 0 that maps to the initial value.
+
+\subsection{ss:mm_domains}{Domains}
+
+Each domain is equipped with a \emph{frontier}, which is a map from non-atomic
+locations to timestamps. Intuitively, each domain's frontier records, for each
+non-atomic location, the latest write known to the thread. More recent writes
+may have occurred, but are not guaranteed to be visible.
+
+For example,
+
+\begin{verbatim}
+d1: [a -> t1; b -> t3; c -> t7]
+d2: [a -> t1; b -> t4; c -> t7]
+\end{verbatim}
+
+\noindent represents two domains "d1" and "d2" and their frontiers.
+
+\subsection{ss:mm_na_access}{Non-atomic accesses}
+
+Let us now define the semantics of non-atomic reads and writes. Suppose domain
+"d1" performs the read of "b". For non-atomic reads, the domains may read an
+arbitrary element of the history for that location, as long as it is not older
+than the timestamp in the domains's frontier. In this case, since "d1" frontier
+at "b" is at "t3", the read may return the value "3", "4" or "5". A non-atomic
+read does not change the frontier of the current domain.
+
+Suppose domain "d2" writes the value "10" to "c" ("c := 10"). We pick a new
+timestamp "t9" for this write such that it is later than "d2"'s frontier at
+"c". Note a subtlety here: this new timestamp might not be later than everything
+else in the history, but merely later than any other write known to the writing
+domain. Hence, "t9" may be inserted in "c"'s history either (a) between "t7"
+and "t8" or (b) after "t8". Let us pick the former option for our discussion.
+Since the new write appears after all the writes known by the domain "d2" to
+the location "c", "d2"'s frontier at "c" is also updated. The new state of the
+abstract machine is:
+
+\begin{verbatim}
+(* Non-atomic locations *)
+a: [t1 -> 1; t2 -> 2]
+b: [t3 -> 3; t4 -> 4; t5 -> 5]
+c: [t6 -> 5; t7 -> 6; t9 -> 10; t8 -> 7] (* new write at t9 *)
+
+(* Domains *)
+d1: [a -> t1; b -> t3; c -> t7]
+d2: [a -> t1; b -> t4; c -> t9] (* frontier updated at c *)
+\end{verbatim}
+
+\subsection{ss:mm_at_access}{Atomic accesses}
+
+Atomic locations carry not only values but also synchronization information. We
+model atomic locations as a pair of the value held by that location and a
+frontier. The frontier models the synchronization information, which is merged
+with the frontiers of threads that operate on the location. In this way,
+non-atomic writes made by one thread can become known to another by
+communicating via an atomic location.
+
+For example,
+
+\begin{verbatim}
+(* Atomic locations *)
+A: 10, [a -> t1; b -> t5; c -> t7]
+B: 5,  [a -> t2; b -> t4; c -> t6]
+\end{verbatim}
+
+\noindent shows two atomic variables "A" and "B" with values "10" and "5",
+respectively, and frontiers of their own. We use upper-case variable names to
+indicate atomic locations.
+
+During atomic reads, the frontier of the location is merged into that of the
+domain performing the read. For example, suppose "d1" reads "B". The read
+returns "5", and "d1"'s frontier updated by merging it with "B"'s frontier,
+choosing the later timestamp for each location. The abstract machine state
+before the atomic read is:
+
+\begin{verbatim}
+(* Non-atomic locations *)
+a: [t1 -> 1; t2 -> 2]
+b: [t3 -> 3; t4 -> 4; t5 -> 5]
+c: [t6 -> 5; t7 -> 6; t9 -> 10; t8 -> 7]
+
+(* Domains *)
+d1: [a -> t1; b -> t3; c -> t7]
+d2: [a -> t1; b -> t4; c -> t9]
+
+(* Atomic locations *)
+A: 10, [a -> t1; b -> t5; c -> t7]
+B: 5,  [a -> t2; b -> t4; c -> t6]
+\end{verbatim}
+
+As a result of the atomic read, the abstract machine state is updated to:
+
+\begin{verbatim}
+(* Non-atomic locations *)
+a: [t1 -> 1; t2 -> 2]
+b: [t3 -> 3; t4 -> 4; t5 -> 5]
+c: [t6 -> 5; t7 -> 6; t9 -> 10; t8 -> 7]
+
+(* Domains *)
+d1: [a -> t2; b -> t4; c -> t7] (* frontier updated at a and b *)
+d2: [a -> t1; b -> t4; c -> t9]
+
+(* Atomic locations *)
+A: 10, [a -> t1; b -> t5; c -> t7]
+B: 5,  [a -> t2; b -> t4; c -> t6]
+\end{verbatim}
+
+During atomic writes, the value held by the atomic location is updated. The
+frontiers of both the writing domain and that of the location being written to
+are updated to the merge of the two frontiers. For example, if "d2" writes "20"
+to "A" in the current machine state, the machine state is updated to:
+
+\begin{verbatim}
+(* Non-atomic locations *)
+a: [t1 -> 1; t2 -> 2]
+b: [t3 -> 3; t4 -> 4; t5 -> 5]
+c: [t6 -> 5; t7 -> 6; t9 -> 10; t8 -> 7]
+
+(* Domains *)
+d1: [a -> t2; b -> t4; c -> t7]
+d2: [a -> t1; b -> t5; c -> t9] (* frontier updated at b *)
+
+(* Atomic locations *)
+A: 20, [a -> t1; b -> t5; c -> t9] (* value updated. frontier updated at c. *)
+B: 5,  [a -> t2; b -> t4; c -> t6]
+\end{verbatim}
+
+\subsection{s:mm_semantics_reasoning}{Reasoning with the semantics}
+
+Let us revisit an example from earlier (section \ref{s:why_relaxed_memory}).
+
+\begin{caml_example*}{verbatim}
+let a = ref 0
+and b = ref 0
+
+let d1 () =
+  a := 1;
+  !b
+
+let d2 () =
+  b := 1;
+  !a
+
+let main () =
+  let h = Domain.spawn d2 in
+  let r1 = d1 () in
+  let r2 = Domain.join h in
+  assert (not (r1 = 0 && r2 = 0))
+\end{caml_example*}
+
+This program has a data race on "a" and "b", and hence, the program may exhibit
+non sequentially consistent behaviour. Let us use the semantics to show that
+the program may exhibit "r1 = 0 && r2 = 0".
+
+The initial state of the abstract machine is:
+
+\begin{verbatim}
+(* Non-atomic locations *)
+a: [t0 -> 0]
+b: [t1 -> 0]
+
+(* Domains *)
+d1: [a -> t0; b -> t1]
+d2: [a -> t0; b -> t1]
+\end{verbatim}
+
+There are several possible schedules for executing this program. Let us
+consider the following schedule:
+
+\begin{verbatim}
+1: a := 1 @ d1
+2: b := 1 @ d2
+3: !b     @ d1
+4: !a     @ d2
+\end{verbatim}
+
+After the first action "a:=1" by "d1", the machine state is:
+
+\begin{verbatim}
+(* Non-atomic locations *)
+a: [t0 -> 0; t2 -> 1] (* new write at t2 *)
+b: [t1 -> 0]
+
+(* Domains *)
+d1: [a -> t2; b -> t1] (* frontier updated at a *)
+d2: [a -> t0; b -> t1]
+\end{verbatim}
+
+After the second action "b:=1" by "d2", the machine state is:
+
+\begin{verbatim}
+(* Non-atomic locations *)
+a: [t0 -> 0; t2 -> 1]
+b: [t1 -> 0; t3 -> 1] (* new write at t3 *)
+
+(* Domains *)
+d1: [a -> t2; b -> t1]
+d2: [a -> t0; b -> t3] (* frontier updated at b *)
+\end{verbatim}
+
+Now, for the third action "!b" by "d1", observe that "d1"'s frontier at "b"
+is at "t1". Hence, the read may return either "0" or "1". Let us assume that it
+returns "0". The machine state is not updated by the non-atomic read.
+
+Similarly, for the fourth action "!a" by "d2", "d2"'s frontier at "a" is at
+"t0". Hence, this read may also return either "0" or "1". Let us assume that it
+returns "0". Hence, the assertion in the original program, "assert (not (r1 = 0
+&& r2 = 0))", will fail for this particular execution.
+
+\section{s:mm_tearing}{Non-compliant operations}
+
+There are certain operations which are not memory model compliant.
+
+\begin{itemize}
+  \item "Array.blit" function on float arrays may cause \emph{tearing}. When an
+    unsynchronized blit operation runs concurrently with some overlapping write
+    to the fields of the same float array, the field may end up with bits from
+    either of the writes.
+  \item With flat-float arrays or records with only float fields on 32-bit
+    architectures, getting or setting a field involves two separate memory
+    accesses. In the presence of data races, the user may observe tearing.
+  \item The "Bytes" module~\stdmoduleref{Bytes} permits mixed-mode accesses
+    where reads and writes may be of different sizes. Unsynchronized mixed-mode
+    accesses lead to tearing.
+\end{itemize}

--- a/manual/src/tutorials/parallelism.etex
+++ b/manual/src/tutorials/parallelism.etex
@@ -1,0 +1,731 @@
+\chapter{Parallel programming}
+%HEVEA\cutname{parallelism.html}
+\label{c:parallelism}
+
+In this chapter, we shall look at the parallel programming facilities in OCaml.
+The OCaml standard library exposes low-level primitives for parallel
+programming. We recommend the users to utilise higher-level parallel
+programming libraries such as
+\href{https://github.com/ocaml-multicore/domainslib}{domainslib}. This
+tutorial will first cover the high-level parallel programming using domainslib
+followed by low-level primitives exposed by the compiler.
+
+OCaml distinguishes concurrency and parallelism and provides distinct
+mechanisms for expressing them. Concurrency is overlapped execution of tasks
+(section \ref{s:effects-concurrency}) whereas parallelism is simultaneous
+execution of tasks. In particular, parallel tasks overlap in time but
+concurrent tasks may or may not overlap in time. Tasks may execute concurrently
+by yielding control to each other. While concurrency is a program structuring
+mechanism, parallelism is a mechanism to make your programs run faster. If you
+are interested in the concurrent programming mechanisms in OCaml, please refer
+to the section \ref{s:effect-handlers} on effect handlers and the chapter
+\ref{c:threads} on the threads library.
+
+\section{s:par_domains}{Domains}
+
+Domains are the units of parallelism in OCaml. The module \stdmoduleref{Domain}
+provides the primitives to create and manage domains. New domains can be
+spawned using the "spawn" function.
+
+\begin{caml_example}{verbatim}
+Domain.spawn (fun _ -> print_endline "I ran in parallel")
+\end{caml_example}
+
+The "spawn" function executes the given computation in parallel with
+the calling domain.
+
+Domains are heavy-weight entities. Each domain maps 1:1 to an operating system
+thread. Each domain also has its own runtime state, which includes domain-local
+structures for allocating memory. Hence, they are relatively expensive to
+create and tear down.
+
+\emph{\textbf{It is recommended that the programs do not spawn more domains
+than cores available}}.
+
+In this tutorial, we shall be implementing, running and measuring the
+performance of parallel programs. The results observed are dependent on the
+number of cores available on the target machine. This tutorial is being written
+on a 2.3 GHz Quad-Core Intel Core i7 MacBook Pro with 4 cores and 8 hardware
+threads. It is reasonable to expect roughly 4x performance on 4 domains for
+parallel programs with little coordination between the domains, and when the
+machine is not under load. Beyond 4 domains, the speedup is likely to be less
+than linear. We shall also use the command-line benchmarking tool
+\href{https://github.com/sharkdp/hyperfine}{hyperfine} for benchmarking our
+programs.
+
+\subsection{s:par_join}{Joining domains}
+
+We shall use the program to compute the nth Fibonacci number using recursion as
+a running example. The sequential program for computing the nth Fibonacci
+number is given below.
+
+\begin{caml_example*}{verbatim}
+(* fib.ml *)
+let n = try int_of_string Sys.argv.(1) with _ -> 1
+
+let rec fib n = if n < 2 then 1 else fib (n - 1) + fib (n - 2)
+
+let main () =
+  let r = fib n in
+  Printf.printf "fib(%d) = %d\n%!" n r
+
+let _ = main ()
+\end{caml_example*}
+
+The program can be compiled and benchmarked as follows.
+
+\begin{verbatim}
+$ ocamlopt -o fib.exe fib.ml
+$ ./fib.exe 42
+fib(42) = 433494437
+$ hyperfine './fib.exe 42' # Benchmarking
+Benchmark 1: ./fib.exe 42
+  Time (mean ± sd):     1.193 s ±  0.006 s    [User: 1.186 s, System: 0.003 s]
+  Range (min … max):    1.181 s …  1.202 s    10 runs
+\end{verbatim}
+
+We see that it takes around 1.2 seconds to compute the 42nd Fibonacci number.
+
+Spawned domains can be joined using the "join" function to get their results.
+The "join" function waits for target domain to terminate. The following program
+computes the nth Fibonacci number twice in parallel.
+
+\begin{caml_example*}{verbatim}
+(* fib_twice.ml *)
+let n = int_of_string Sys.argv.(1)
+
+let rec fib n = if n < 2 then 1 else fib (n - 1) + fib (n - 2)
+
+let main () =
+  let d1 = Domain.spawn (fun _ -> fib n) in
+  let d2 = Domain.spawn (fun _ -> fib n) in
+  let r1 = Domain.join d1 in
+  Printf.printf "fib(%d) = %d\n%!" n r1;
+  let r2 = Domain.join d2 in
+  Printf.printf "fib(%d) = %d\n%!" n r2
+
+let _ = main ()
+\end{caml_example*}
+
+The program spawns two domains which compute the nth Fibonacci number. The
+"spawn" function returns a "Domain.t" value which can be joined to get the
+result of the parallel computation. The "join" function blocks until the
+computation runs to completion.
+
+\begin{verbatim}
+$ ocamlopt -o fib_twice.exe fib_twice.ml
+$ ./fib_twice.exe 42
+fib(42) = 433494437
+fib(42) = 433494437
+$ hyperfine './fib_twice.exe 42'
+Benchmark 1: ./fib_twice.exe 42
+  Time (mean ± sd):     1.249 s ±  0.025 s    [User: 2.451 s, System: 0.012 s]
+  Range (min … max):    1.221 s …  1.290 s    10 runs
+\end{verbatim}
+
+As one can see that computing the nth Fibonacci number twice almost took the
+same time as computing it once thanks to parallelism.
+
+\section{s:par_parfib}{Domainslib: A library for nested-parallel programming}
+
+Let us attempt to parallelise the Fibonacci function. The two recursive calls
+may be executed in parallel. However, naively parallelising the recursive calls
+by spawning domains for each one will not work as it spawns too many domains.
+
+\begin{caml_example}{verbatim}
+(* fib_par1.ml *)
+let n = try int_of_string Sys.argv.(1) with _ -> 1
+
+let rec fib n =
+  if n < 2 then 1 else begin
+    let d1 = Domain.spawn (fun _ -> fib (n - 1)) in
+    let d2 = Domain.spawn (fun _ -> fib (n - 2)) in
+    Domain.join d1 + Domain.join d2
+  end
+
+let main () =
+  let r = fib n in
+  Printf.printf "fib(%d) = %d\n%!" n r
+
+let _ = main ()
+\end{caml_example}
+
+\begin{verbatim}
+$ ocamlopt -o fib_par1.exe fib_par1.ml
+$ ./fib_par1.exe 42
+Fatal error: exception Failure("failed to allocate domain")
+\end{verbatim}
+
+OCaml has a limit of 128 domains that can be active at the same time. An
+attempt to spawn more domains will raise an exception. How then can we
+parallelise the Fibonacci function?
+
+\subsection{s:par_parfib_domainslib}{Parallelising Fibonacci using domainslib}
+
+The OCaml standard library provides only low-level primitives for concurrent
+and parallel programming, leaving high-level programming libraries to be
+developed and distributed outside the core compiler distribution.
+\href{https://github.com/ocaml-multicore/domainslib}{Domainslib} is such a
+library for nested-parallel programming, which is epitomised by the parallelism
+available in the recursive Fibonacci computation. Let us use domainslib to
+parallelise the recursive Fibonacci program. It is recommended that you install
+domainslib using the \href{https://opam.ocaml.org/}{opam} package manager. This
+tutorial uses domainslib version 0.4.2.
+
+Domainslib provides an async/await mechanism for spawning parallel tasks and
+awaiting their results. On top of this mechanism, domainslib provides parallel
+iterators. At its core, domainslib has an efficient implementation of
+work-stealing queue in order to efficiently share tasks with other domains. A
+parallel implementation of the Fibonacci program is given below.
+
+\begin{verbatim}
+(* fib_par2.ml *)
+let num_domains = int_of_string Sys.argv.(1)
+let n = int_of_string Sys.argv.(2)
+
+let rec fib n = if n < 2 then 1 else fib (n - 1) + fib (n - 2)
+
+module T = Domainslib.Task
+
+let rec fib_par pool n =
+  if n > 20 then begin
+    let a = T.async pool (fun _ -> fib_par pool (n-1)) in
+    let b = T.async pool (fun _ -> fib_par pool (n-2)) in
+    T.await pool a + T.await pool b
+  end else fib n
+
+let main () =
+  let pool = T.setup_pool ~num_additional_domains:(num_domains - 1) () in
+  let res = T.run pool (fun _ -> fib_par pool n) in
+  T.teardown_pool pool;
+  Printf.printf "fib(%d) = %d\n" n res
+
+let _ = main ()
+\end{verbatim}
+
+The program takes the number of domains and the input to the Fibonacci function
+as the first and the second command-line arguments respectively.
+
+Let us start with the main function. First, we set up a pool of domains on which
+the nested parallel tasks will run. The domain invoking the "run" function will
+also participate in executing the tasks submitted to the pool. We invoke the
+parallel Fibonacci function "fib_par" in the "run" function. Finally, we tear
+down the pool and print the result.
+
+For sufficiently large inputs ("n > 20"), the "fib_par" function spawns the
+left and the right recursive calls asynchronously in the pool using the "async"
+function. The "async" function returns a promise for the result. The result of
+an asynchronous computation is obtained by awaiting the promise using the
+"await" function. The "await" function call blocks until the promise is
+resolved.
+
+For small inputs, the "fib_par" function simply calls the sequential Fibonacci
+function "fib". It is important to switch to sequential mode for small problem
+sizes. If not, the cost of parallelisation will outweigh the work available.
+
+For simplicity, we use "ocamlfind" to compile this program. It is recommended
+that the users use \href{https://github.com/ocaml/dune}{dune} to build their
+programs that utilise libraries installed through
+\href{https://opam.ocaml.org/}{opam}.
+
+\begin{verbatim}
+$ ocamlfind ocamlopt -package domainslib -linkpkg -o fib_par2.exe fib_par2.ml
+$ ./fib_par2.exe 1 42
+fib(42) = 433494437
+$ hyperfine './fib.exe 42' './fib_par2.exe 2 42' \
+            './fib_par2.exe 4 42' './fib_par2.exe 8 42'
+Benchmark 1: ./fib.exe 42
+  Time (mean ± sd):     1.217 s ±  0.018 s    [User: 1.203 s, System: 0.004 s]
+  Range (min … max):    1.202 s …  1.261 s    10 runs
+
+Benchmark 2: ./fib_par2.exe 2 42
+  Time (mean ± sd):    628.2 ms ±   2.9 ms    [User: 1243.1 ms, System: 4.9 ms]
+  Range (min … max):   625.7 ms … 634.5 ms    10 runs
+
+Benchmark 3: ./fib_par2.exe 4 42
+  Time (mean ± sd):    337.6 ms ±  23.4 ms    [User: 1321.8 ms, System: 8.4 ms]
+  Range (min … max):   318.5 ms … 377.6 ms    10 runs
+
+Benchmark 4: ./fib_par2.exe 8 42
+  Time (mean ± sd):    250.0 ms ±   9.4 ms    [User: 1877.1 ms, System: 12.6 ms]
+  Range (min … max):   242.5 ms … 277.3 ms    11 runs
+
+Summary
+  './fib_par2.exe 8 42' ran
+    1.35 ± 0.11 times faster than './fib_par2.exe 4 42'
+    2.51 ± 0.10 times faster than './fib_par2.exe 2 42'
+    4.87 ± 0.20 times faster than './fib.exe 42'
+\end{verbatim}
+
+The results show that, with 8 domains, the parallel Fibonacci program runs 4.87
+times faster than the sequential version.
+
+\subsection{s:par_iterators}{Parallel iteration constructs}
+
+Many numerical algorithms use for-loops. The parallel-for primitive provides a
+straight-forward way to parallelise such code. Let us take the
+\href{https://benchmarksgame-team.pages.debian.net/benchmarksgame/description/spectralnorm.html#spectralnorm}{spectral-norm}
+benchmark from the computer language benchmarks game and parallelise it. The
+sequential version of the program is given below.
+
+\begin{caml_example*}{verbatim}
+(* spectralnorm.ml *)
+let n = try int_of_string Sys.argv.(1) with _ -> 32
+
+let eval_A i j = 1. /. float((i+j)*(i+j+1)/2+i+1)
+
+let eval_A_times_u u v =
+  let n = Array.length v - 1 in
+  for i = 0 to  n do
+    let vi = ref 0. in
+    for j = 0 to n do vi := !vi +. eval_A i j *. u.(j) done;
+    v.(i) <- !vi
+  done
+
+let eval_At_times_u u v =
+  let n = Array.length v - 1 in
+  for i = 0 to n do
+    let vi = ref 0. in
+    for j = 0 to n do vi := !vi +. eval_A j i *. u.(j) done;
+    v.(i) <- !vi
+  done
+
+let eval_AtA_times_u u v =
+  let w = Array.make (Array.length u) 0.0 in
+  eval_A_times_u u w; eval_At_times_u w v
+
+let () =
+  let u = Array.make n 1.0  and  v = Array.make n 0.0 in
+  for _i = 0 to 9 do
+    eval_AtA_times_u u v; eval_AtA_times_u v u
+  done;
+
+  let vv = ref 0.0  and  vBv = ref 0.0 in
+  for i=0 to n-1 do
+    vv := !vv +. v.(i) *. v.(i);
+    vBv := !vBv +. u.(i) *. v.(i)
+  done;
+  Printf.printf "%0.9f\n" (sqrt(!vBv /. !vv))
+\end{caml_example*}
+
+Observe that the program has nested loops in "eval_A_times_u" and
+"eval_At_times_u". Each iteration of the outer loop body reads from "u" but
+writes to disjoint memory locations in "v". Hence, the iterations of the outer
+loop are not dependent on each other and can be executed in parallel.
+
+The parallel version of spectral norm is shown below.
+
+\begin{verbatim}
+(* spectralnorm_par.ml *)
+let num_domains = try int_of_string Sys.argv.(1) with _ -> 1
+let n = try int_of_string Sys.argv.(2) with _ -> 32
+
+let eval_A i j = 1. /. float((i+j)*(i+j+1)/2+i+1)
+
+module T = Domainslib.Task
+
+let eval_A_times_u pool u v =
+  let n = Array.length v - 1 in
+  T.parallel_for pool ~start:0 ~finish:n ~body:(fun i ->
+    let vi = ref 0. in
+    for j = 0 to n do vi := !vi +. eval_A i j *. u.(j) done;
+    v.(i) <- !vi
+  )
+
+let eval_At_times_u pool u v =
+  let n = Array.length v - 1 in
+  T.parallel_for pool ~start:0 ~finish:n ~body:(fun i ->
+    let vi = ref 0. in
+    for j = 0 to n do vi := !vi +. eval_A j i *. u.(j) done;
+    v.(i) <- !vi
+  )
+
+let eval_AtA_times_u pool u v =
+  let w = Array.make (Array.length u) 0.0 in
+  eval_A_times_u pool u w; eval_At_times_u pool w v
+
+let () =
+  let pool = T.setup_pool ~num_additional_domains:(num_domains - 1) () in
+  let u = Array.make n 1.0  and  v = Array.make n 0.0 in
+  T.run pool (fun _ ->
+  for _i = 0 to 9 do
+    eval_AtA_times_u pool u v; eval_AtA_times_u pool v u
+  done);
+
+  let vv = ref 0.0  and  vBv = ref 0.0 in
+  for i=0 to n-1 do
+    vv := !vv +. v.(i) *. v.(i);
+    vBv := !vBv +. u.(i) *. v.(i)
+  done;
+  T.teardown_pool pool;
+  Printf.printf "%0.9f\n" (sqrt(!vBv /. !vv))
+\end{verbatim}
+
+Observe that the "parallel_for" function is isomorphic to the for-loop in the
+sequential version. No other change is required except for the boiler plate
+code to set up and tear down the pools.
+
+\begin{verbatim}
+$ ocamlopt -o spectralnorm.exe spectralnorm.ml
+$ ocamlfind ocamlopt -package domainslib -linkpkg -o spectralnorm_par.exe \
+  spectralnorm_par.ml
+$ hyperfine './spectralnorm.exe 4096' './spectralnorm_par.exe 2 4096' \
+            './spectralnorm_par.exe 4 4096' './spectralnorm_par.exe 8 4096'
+Benchmark 1: ./spectralnorm.exe 4096
+  Time (mean ± sd):     1.989 s ±  0.013 s    [User: 1.972 s, System: 0.007 s]
+  Range (min … max):    1.975 s …  2.018 s    10 runs
+
+Benchmark 2: ./spectralnorm_par.exe 2 4096
+  Time (mean ± sd):     1.083 s ±  0.015 s    [User: 2.140 s, System: 0.009 s]
+  Range (min … max):    1.064 s …  1.102 s    10 runs
+
+Benchmark 3: ./spectralnorm_par.exe 4 4096
+  Time (mean ± sd):    698.7 ms ±  10.3 ms    [User: 2730.8 ms, System: 18.3 ms]
+  Range (min … max):   680.9 ms … 721.7 ms    10 runs
+
+Benchmark 4: ./spectralnorm_par.exe 8 4096
+  Time (mean ± sd):    921.8 ms ±  52.1 ms    [User: 6711.6 ms, System: 51.0 ms]
+  Range (min … max):   838.6 ms … 989.2 ms    10 runs
+
+Summary
+  './spectralnorm_par.exe 4 4096' ran
+    1.32 ± 0.08 times faster than './spectralnorm_par.exe 8 4096'
+    1.55 ± 0.03 times faster than './spectralnorm_par.exe 2 4096'
+    2.85 ± 0.05 times faster than './spectralnorm.exe 4096'
+\end{verbatim}
+
+On the author's machine, the program scales reasonably well up to 4 domains but
+performs worse with 8 domains. Recall that the machine only has 4 physical
+cores. Debugging and fixing this performance issue is beyond the scope of this
+tutorial.
+
+\section{s:par_gc}{Parallel garbage collection}
+
+An important aspect of the scalability of parallel OCaml programs is the
+scalability of the garbage collector (GC). The OCaml GC is designed to have
+both low latency and good parallel scalability. OCaml has a generational
+garbage collector with a small minor heap and a large major heap. New objects
+(upto a certain size) are allocated in the minor heap. Each domain has its own
+domain-local minor heap arena into which new objects are allocated without
+synchronising with the other domains. When a domain exhausts its minor heap
+arena, it calls for a stop-the-world collection of the minor heaps. In the
+stop-the-world section, all the domains collect their minor heap arenas in
+parallel evacuating the survivors to the major heap.
+
+For the major heap, each domain maintains domain-local, size-segmented pools of
+memory into which large objects and survivors from the minor collection are
+allocated. Having domain-local pools avoids synchronisation for most major heap
+allocations. The major heap is collected by a concurrent mark-and-sweep
+algorithm that involves a few short stop-the-world pauses for each major cycle.
+
+Overall, the users should expect the garbage collector to scale well with
+increasing number of domains, with the latency remaining low. For more
+information on the design and evaluation of the garbage collector, please have
+a look at the ICFP 2020 paper on
+\href{https://arxiv.org/abs/2004.11663}{"Retrofitting Parallelism onto OCaml"}.
+
+\section{s:par_mm_easy}{Memory model: The easy bits}
+
+Modern processors and compilers aggressively optimise programs. These
+optimisations accelerate without otherwise affecting sequential programs, but
+cause surprising behaviours to be visible in parallel programs. To benefit from
+these optimisations, OCaml adopts a \textit{relaxed memory model} that precisely
+specifies which of these \emph{relaxed behaviours} programs may observe. While
+these models are difficult to program against directly, the OCaml memory model
+provides recipes that retain the simplicity of sequential reasoning.
+
+Firstly, immutable values may be freely shared between multiple domains and may
+be accessed in parallel. For mutable data structures such as reference cells,
+arrays and mutable record fields, programmers should avoid \emph{data races}.
+Reference cells, arrays and mutable record fields are said to be
+\emph{non-atomic} data structures. A data race is said to occur when two
+domains concurrently access a non-atomic memory location without
+\emph{synchronisation} and at least one of the accesses is a write. OCaml
+provides a number of ways to introduce synchronisation including atomic
+variables (section \ref{s:par_atomics}) and mutexes (section \ref{s:par_sync}).
+
+Importantly, \textbf{for data race free (DRF) programs, OCaml provides
+sequentially consistent (SC) semantics} -- the observed behaviour of such
+programs can be explained by the interleaving of operations from different
+domains. This property is known as DRF-SC guarantee. Moreover, in OCaml, DRF-SC
+guarantee is modular -- if a part of a program is data race free, then the
+OCaml memory model ensures that those parts have sequential consistency despite
+other parts of the program having data races. Even for programs with data
+races, OCaml provides strong guarantees. While the user may observe non
+sequentially consistent behaviours, there are no crashes.
+
+For more details on the relaxed behaviours in the presence of data races,
+please have a look at the chapter on the hard bits of the memory model
+(chapter \ref{c:memorymodel}).
+
+\section{s:par_sync}{Blocking synchronisation}
+
+Domains may perform blocking synchronisation with the help of
+\stdmoduleref{Mutex}, \stdmoduleref{Condition} and \stdmoduleref{Semaphore}
+modules. These modules are the same as those used to synchronise threads
+created by the threads library (chapter \ref{c:threads}). For clarity, in the
+rest of this chapter, we shall call the threads created by the threads library
+as \emph{systhreads}. The following program implements a concurrent stack using
+mutex and condition variables.
+
+\begin{caml_example*}{verbatim}
+module Blocking_stack : sig
+  type 'a t
+  val make : unit -> 'a t
+  val push : 'a t -> 'a -> unit
+  val pop  : 'a t -> 'a
+end = struct
+  type 'a t = {
+    mutable contents: 'a list;
+    mutex : Mutex.t;
+    nonempty : Condition.t
+  }
+
+  let make () = {
+    contents = [];
+    mutex = Mutex.create ();
+    nonempty = Condition.create ()
+  }
+
+  let push r v =
+    Mutex.lock r.mutex;
+    r.contents <- v::r.contents;
+    Condition.signal r.nonempty;
+    Mutex.unlock r.mutex
+
+  let pop r =
+    Mutex.lock r.mutex;
+    let rec loop () =
+      match r.contents with
+      | [] ->
+          Condition.wait r.nonempty r.mutex;
+          loop ()
+      | x::xs -> r.contents <- xs; x
+    in
+    let res = loop () in
+    Mutex.unlock r.mutex;
+    res
+end
+\end{caml_example*}
+
+The concurrent stack is implemented using a record with three fields: a mutable
+field "contents" which stores the elements in the stack, a "mutex" to control
+access to the "contents" field, and a condition variable "nonempty", which is
+used to signal blocked domains waiting for the stack to become non-empty.
+
+The "push" operation locks the mutex, updates the "contents" field with a new
+list whose head is the element being pushed and the tail is the old list. The
+condition variable "nonempty" is signalled while the lock is held in order to
+wake up any domains waiting on this condition. If there are waiting domains,
+one of the domains is woken up. If there are none, then the "signal" operation
+has no effect.
+
+The "pop" operation locks the mutex and checks whether the stack is empty. If
+so, the calling domain waits on the condition variable "nonempty" using the
+"wait" primitive. The "wait" call atomically suspends the execution of the
+current domain and unlocks the "mutex". When this domain is woken up again
+(when the "wait" call returns), it holds the lock on "mutex". The domain tries
+to read the contents of the stack again. If the "pop" operation sees that the
+stack is non-empty, it updates the "contents" to the tail of the old list, and
+returns the head.
+
+The use of "mutex" to control access to the shared resource "contents"
+introduces sufficient synchronisation between multiple domains using the stack.
+Hence, there are no data races when multiple domains use the stack in parallel.
+
+\subsection{s:par_systhread_interaction}{Interaction with systhreads}
+
+How do systhreads interact with domains? The systhreads created on a particular
+domain remain pinned to that domain. Only one systhread at a time is allowed to
+run OCaml code on a particular domain. However, systhreads belonging to a
+particular domain may run C library or system code in parallel. Systhreads
+belonging to different domains may execute in parallel.
+
+When using systhreads, the thread created for executing the computation given
+to "Domain.spawn" is also treated as a systhread. For example, the following
+program creates in total two domains (including the initial domain) with two
+systhreads each (including the initial systhread for each of the domains).
+
+\begin{verbatim}
+(* dom_thr.ml *)
+let m = Mutex.create ()
+let r = ref None (* protected by m *)
+
+let task () =
+  let my_thr_id = Thread.(id (self ())) in
+  let my_dom_id :> int = Domain.self () in
+  Mutex.lock m;
+  begin match !r with
+  | None ->
+      Printf.printf "Thread %d running on domain %d saw initial write\n%!"
+        my_thr_id my_dom_id
+  | Some their_thr_id ->
+      Printf.printf "Thread %d running on domain %d saw the write by thread %d\n%!"
+        my_thr_id my_dom_id their_thr_id;
+  end;
+  r := Some my_thr_id;
+  Mutex.unlock m
+
+let task' () =
+  let t = Thread.create task () in
+  task ();
+  Thread.join t
+
+let main () =
+  let d = Domain.spawn task' in
+  task' ();
+  Domain.join d
+
+let _ = main ()
+\end{verbatim}
+
+\begin{verbatim}
+$ ocamlopt -I +threads unix.cmxa threads.cmxa -o dom_thr.exe dom_thr.ml
+$ ./dom_thr.exe
+Thread 1 running on domain 1 saw initial write
+Thread 0 running on domain 0 saw the write by thread 1
+Thread 2 running on domain 1 saw the write by thread 0
+Thread 3 running on domain 0 saw the write by thread 2
+\end{verbatim}
+
+This program uses a shared reference cell protected by a mutex to communicate
+between the different systhreads running on two different domains. The
+systhread identifiers uniquely identify systhreads in the program. The initial
+domain gets the domain id and the thread id as 0. The newly spawned domain gets
+domain id as 1.
+
+\section{s:par_atomics}{Atomics}
+
+Mutex, condition variables and semaphores are used to implement blocking
+synchronisation between domains. For non-blocking synchronisation, OCaml
+provides \stdmoduleref{Atomic} variables. As the name suggests, non-blocking
+synchronisation does not provide mechanisms for suspending and waking up
+domains. On the other hand, primitives used in non-blocking synchronisation are
+often compiled to atomic read-modify-write primitives that the hardware
+provides. As an example, the following program increments a non-atomic counter
+and an atomic counter in parallel.
+
+\begin{caml_example*}{verbatim}
+(* incr.ml *)
+let twice_in_parallel f =
+  let d1 = Domain.spawn f in
+  let d2 = Domain.spawn f in
+  Domain.join d1;
+  Domain.join d2
+
+let plain_ref n =
+  let r = ref 0 in
+  let f () = for _i=1 to n do incr r done in
+  twice_in_parallel f;
+  Printf.printf "Non-atomic ref count: %d\n" !r
+
+let atomic_ref n =
+  let r = Atomic.make 0 in
+  let f () = for _i=1 to n do Atomic.incr r done in
+  twice_in_parallel f;
+  Printf.printf "Atomic ref count: %d\n" (Atomic.get r)
+
+let main () =
+  let n = try int_of_string Sys.argv.(1) with _ -> 1 in
+  plain_ref n;
+  atomic_ref n
+
+let _ = main ()
+\end{caml_example*}
+
+\begin{verbatim}
+$ ocamlopt -o incr.exe incr.ml
+$ ./incr.exe 1_000_000
+Non-atomic ref count: 1187193
+Atomic ref count: 2000000
+\end{verbatim}
+
+Observe that the result from using the non-atomic counter is lower than what
+one would naively expect. This is because the non-atomic "incr" function is
+equivalent to:
+
+\begin{caml_example*}{verbatim}
+let incr r =
+  let curr = !r in
+	r := curr + 1
+\end{caml_example*}
+
+Observe that the load and the store are two separate operations, and the
+increment operation as a whole is not performed atomically. When two domains
+execute this code in parallel, both of them may read the same value of the
+counter "curr" and update it to "curr + 1". Hence, instead of two increments,
+the effect will be that of a single increment. On the other hand, the atomic
+counter performs the load and the store atomically with the help of hardware
+support for atomicity. The atomic counter returns the expected result.
+
+The atomic variables can be used for low-level synchronisation between the
+domains. The following example uses an atomic variable to exchange a message
+between two domains.
+
+\begin{caml_example}{verbatim}
+let r = Atomic.make None
+
+let sender () = Atomic.set r (Some "Hello")
+
+let rec receiver () =
+  match Atomic.get r with
+  | None -> Domain.cpu_relax (); receiver ()
+  | Some m -> print_endline m
+
+let main () =
+  let s = Domain.spawn sender in
+  let d = Domain.spawn receiver in
+  Domain.join s;
+  Domain.join d
+
+let _ = main ()
+\end{caml_example}
+
+While the sender and the receiver compete to access "r", this is not a data
+race since "r" is an atomic reference.
+
+\subsection{s:par_lockfree_stack}{Lock-free stack}
+
+The Atomic module is used to implement non-blocking, lock-free data structures.
+The following program implements a lock-free stack.
+
+\begin{caml_example*}{verbatim}
+module Lockfree_stack : sig
+  type 'a t
+  val make : unit -> 'a t
+  val push : 'a t -> 'a -> unit
+  val pop  : 'a t -> 'a option
+end = struct
+  type 'a t = 'a list Atomic.t
+
+  let make () = Atomic.make []
+
+  let rec push r v =
+    let s = Atomic.get r in
+    if Atomic.compare_and_set r s (v::s) then ()
+    else (Domain.cpu_relax (); push r v)
+
+  let rec pop r =
+    let s = Atomic.get r in
+    match s with
+    | [] -> None
+    | x::xs ->
+        if Atomic.compare_and_set r s xs then Some x
+        else (Domain.cpu_relax (); pop r)
+end
+\end{caml_example*}
+
+The atomic stack is represented by an atomic reference that holds a list. The
+"push" and "pop" operations use the "compare_and_set" primitive to attempt to
+atomically update the atomic reference. The expression "compare_and_set r seen
+v" sets the value of "r" to "v" if and only if its current value is physically
+equal to "seen". Importantly, the comparison and the update occur atomically.
+The expression evaluates to "true" if the comparison succeeded (and the update
+happened) and "false" otherwise.
+
+If the "compare_and_set" fails, then some other domain is also attempting to
+update the atomic reference at the same time. In this case, the "push" and
+"pop" operations call "Domain.cpu_relax" to back off for a short duration
+allowing competing domains to make progress before retrying the failed
+operation. This lock-free stack implementation is also known as Treiber
+stack.

--- a/testsuite/tests/basic-modules/recursive_module_evaluation_errors.ml
+++ b/testsuite/tests/basic-modules/recursive_module_evaluation_errors.ml
@@ -13,7 +13,7 @@ Line 2, characters 27-49:
                                ^^^^^^^^^^^^^^^^^^^^^^
 Error: Cannot safely evaluate the definition of the following cycle
        of recursively-defined modules: B -> E -> D -> C -> B.
-       There are no safe modules in this cycle (see manual section 10.2).
+       There are no safe modules in this cycle (see manual section 12.2).
 Line 2, characters 10-20:
 2 | and B:sig val x: int end = struct let x = E.y end
               ^^^^^^^^^^
@@ -42,7 +42,7 @@ Line 2, characters 36-64:
                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: Cannot safely evaluate the definition of the following cycle
        of recursively-defined modules: A -> B -> A.
-       There are no safe modules in this cycle (see manual section 10.2).
+       There are no safe modules in this cycle (see manual section 12.2).
 Line 2, characters 28-29:
 2 | module rec A: sig type t += A end = struct type t += A = B.A end
                                 ^
@@ -70,7 +70,7 @@ Lines 4-7, characters 6-3:
 7 | end
 Error: Cannot safely evaluate the definition of the following cycle
        of recursively-defined modules: A -> B -> A.
-       There are no safe modules in this cycle (see manual section 10.2).
+       There are no safe modules in this cycle (see manual section 12.2).
 Line 2, characters 2-41:
 2 |   module F: functor(X:sig end) -> sig end
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -100,7 +100,7 @@ Lines 5-8, characters 8-5:
 8 |   end
 Error: Cannot safely evaluate the definition of the following cycle
        of recursively-defined modules: A -> B -> A.
-       There are no safe modules in this cycle (see manual section 10.2).
+       There are no safe modules in this cycle (see manual section 12.2).
 Line 3, characters 4-17:
 3 |     module M: X.t
         ^^^^^^^^^^^^^

--- a/testsuite/tests/typing-warnings/ambiguous_guarded_disjunction.ml
+++ b/testsuite/tests/typing-warnings/ambiguous_guarded_disjunction.ml
@@ -30,7 +30,7 @@ Line 2, characters 4-29:
 Warning 57 [ambiguous-var-in-pattern-guard]: Ambiguous or-pattern variables under guard;
 variable x appears in different places in different or-pattern alternatives.
 Only the first match will be used to evaluate the guard expression.
-(See manual section 11.5)
+(See manual section 13.5)
 val ambiguous_typical_example : expr * expr -> unit = <fun>
 |}]
 
@@ -99,7 +99,7 @@ Line 2, characters 4-43:
 Warning 57 [ambiguous-var-in-pattern-guard]: Ambiguous or-pattern variables under guard;
 variable y appears in different places in different or-pattern alternatives.
 Only the first match will be used to evaluate the guard expression.
-(See manual section 11.5)
+(See manual section 13.5)
 val ambiguous__y : [> `B of 'a * bool option * bool option ] -> unit = <fun>
 |}]
 
@@ -132,7 +132,7 @@ Line 2, characters 4-43:
 Warning 57 [ambiguous-var-in-pattern-guard]: Ambiguous or-pattern variables under guard;
 variable y appears in different places in different or-pattern alternatives.
 Only the first match will be used to evaluate the guard expression.
-(See manual section 11.5)
+(See manual section 13.5)
 val ambiguous__x_y : [> `B of 'a * 'a option * 'a option ] -> unit = <fun>
 |}]
 
@@ -147,7 +147,7 @@ Line 2, characters 4-43:
 Warning 57 [ambiguous-var-in-pattern-guard]: Ambiguous or-pattern variables under guard;
 variables y, z appear in different places in different or-pattern alternatives.
 Only the first match will be used to evaluate the guard expression.
-(See manual section 11.5)
+(See manual section 13.5)
 val ambiguous__x_y_z : [> `B of 'a * 'a option * 'a option ] -> unit = <fun>
 |}]
 
@@ -180,7 +180,7 @@ Line 2, characters 4-40:
 Warning 57 [ambiguous-var-in-pattern-guard]: Ambiguous or-pattern variables under guard;
 variable x appears in different places in different or-pattern alternatives.
 Only the first match will be used to evaluate the guard expression.
-(See manual section 11.5)
+(See manual section 13.5)
 val ambiguous__in_depth :
   [> `A of [> `B of bool option * bool option ] ] -> unit = <fun>
 |}]
@@ -213,7 +213,7 @@ Lines 2-3, characters 4-58:
 Warning 57 [ambiguous-var-in-pattern-guard]: Ambiguous or-pattern variables under guard;
 variable x appears in different places in different or-pattern alternatives.
 Only the first match will be used to evaluate the guard expression.
-(See manual section 11.5)
+(See manual section 13.5)
 val ambiguous__first_orpat :
   [> `A of
        [> `B of 'a option * 'a option ] *
@@ -233,7 +233,7 @@ Lines 2-3, characters 4-42:
 Warning 57 [ambiguous-var-in-pattern-guard]: Ambiguous or-pattern variables under guard;
 variable y appears in different places in different or-pattern alternatives.
 Only the first match will be used to evaluate the guard expression.
-(See manual section 11.5)
+(See manual section 13.5)
 val ambiguous__second_orpat :
   [> `A of
        [> `B of 'a option * 'b option * 'c option ] *
@@ -328,7 +328,7 @@ Lines 2-3, characters 2-17:
 Warning 57 [ambiguous-var-in-pattern-guard]: Ambiguous or-pattern variables under guard;
 variables x, y appear in different places in different or-pattern alternatives.
 Only the first match will be used to evaluate the guard expression.
-(See manual section 11.5)
+(See manual section 13.5)
 val ambiguous__amoi : amoi -> int = <fun>
 |}]
 
@@ -350,7 +350,7 @@ Lines 2-3, characters 4-24:
 Warning 57 [ambiguous-var-in-pattern-guard]: Ambiguous or-pattern variables under guard;
 variable M appears in different places in different or-pattern alternatives.
 Only the first match will be used to evaluate the guard expression.
-(See manual section 11.5)
+(See manual section 13.5)
 val ambiguous__module_variable :
   (module S) * (module S) * (int * int) -> bool -> int = <fun>
 |}]
@@ -399,7 +399,7 @@ Line 2, characters 4-56:
 Warning 57 [ambiguous-var-in-pattern-guard]: Ambiguous or-pattern variables under guard;
 variables x, y appear in different places in different or-pattern alternatives.
 Only the first match will be used to evaluate the guard expression.
-(See manual section 11.5)
+(See manual section 13.5)
 val ambiguous_xy_but_not_ambiguous_z : (int -> int -> bool) -> t2 -> int =
   <fun>
 |}, Principal{|
@@ -430,7 +430,7 @@ Line 2, characters 4-56:
 Warning 57 [ambiguous-var-in-pattern-guard]: Ambiguous or-pattern variables under guard;
 variables x, y appear in different places in different or-pattern alternatives.
 Only the first match will be used to evaluate the guard expression.
-(See manual section 11.5)
+(See manual section 13.5)
 val ambiguous_xy_but_not_ambiguous_z : (int -> int -> bool) -> t2 -> int =
   <fun>
 |}]
@@ -491,7 +491,7 @@ Line 3, characters 4-29:
 Warning 57 [ambiguous-var-in-pattern-guard]: Ambiguous or-pattern variables under guard;
 variable y appears in different places in different or-pattern alternatives.
 Only the first match will be used to evaluate the guard expression.
-(See manual section 11.5)
+(See manual section 13.5)
 val guarded_ambiguity : expr * expr -> unit = <fun>
 |}]
 
@@ -522,7 +522,7 @@ Line 4, characters 4-29:
 Warning 57 [ambiguous-var-in-pattern-guard]: Ambiguous or-pattern variables under guard;
 variable x appears in different places in different or-pattern alternatives.
 Only the first match will be used to evaluate the guard expression.
-(See manual section 11.5)
+(See manual section 13.5)
 val cmp : (a -> bool) -> a alg -> a alg -> unit = <fun>
 |}]
 

--- a/testsuite/tests/warnings/w52.ml
+++ b/testsuite/tests/warnings/w52.ml
@@ -10,7 +10,7 @@ Line 1, characters 38-43:
                                           ^^^^^
 Warning 52 [fragile-literal-pattern]: Code should not depend on the actual values of
 this constructor's arguments. They are only for information
-and may change in future versions. (See manual section 11.5)
+and may change in future versions. (See manual section 13.5)
 |}];;
 
 let () = try () with Match_failure ("Any",_,_) -> ();;
@@ -20,7 +20,7 @@ Line 1, characters 35-46:
                                        ^^^^^^^^^^^
 Warning 52 [fragile-literal-pattern]: Code should not depend on the actual values of
 this constructor's arguments. They are only for information
-and may change in future versions. (See manual section 11.5)
+and may change in future versions. (See manual section 13.5)
 |}];;
 
 let () = try () with Match_failure (_,0,_) -> ();;
@@ -30,7 +30,7 @@ Line 1, characters 35-42:
                                        ^^^^^^^
 Warning 52 [fragile-literal-pattern]: Code should not depend on the actual values of
 this constructor's arguments. They are only for information
-and may change in future versions. (See manual section 11.5)
+and may change in future versions. (See manual section 13.5)
 |}];;
 
 type t =
@@ -55,7 +55,7 @@ Line 2, characters 7-17:
            ^^^^^^^^^^
 Warning 52 [fragile-literal-pattern]: Code should not depend on the actual values of
 this constructor's arguments. They are only for information
-and may change in future versions. (See manual section 11.5)
+and may change in future versions. (See manual section 13.5)
 val f : t -> unit = <fun>
 |}];;
 
@@ -68,7 +68,7 @@ Line 2, characters 8-10:
             ^^
 Warning 52 [fragile-literal-pattern]: Code should not depend on the actual values of
 this constructor's arguments. They are only for information
-and may change in future versions. (See manual section 11.5)
+and may change in future versions. (See manual section 13.5)
 val g : t -> unit = <fun>
 |}];;
 
@@ -95,6 +95,6 @@ Line 2, characters 7-34:
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 52 [fragile-literal-pattern]: Code should not depend on the actual values of
 this constructor's arguments. They are only for information
-and may change in future versions. (See manual section 11.5)
+and may change in future versions. (See manual section 13.5)
 val j : t -> unit = <fun>
 |}];;

--- a/utils/warnings.ml
+++ b/utils/warnings.ml
@@ -860,7 +860,7 @@ let () = ignore @@ parse_options true defaults_warn_error
 let ref_manual_explanation () =
   (* manual references are checked a posteriori by the manual
      cross-reference consistency check in manual/tests*)
-  let[@manual.ref "s:comp-warnings"] chapter, section = 11, 5 in
+  let[@manual.ref "s:comp-warnings"] chapter, section = 13, 5 in
   Printf.sprintf "(See manual section %d.%d)" chapter section
 
 let message = function


### PR DESCRIPTION
This PR adds a manual chapter on parallelism features in OCaml. ~Many sections are yet to be written, but I thought it might be a good idea to open the PR to get some early feedback.~

The rendered HTML pages are at:
* Parallelism -- https://kcsrk.info/webman/manual/parallelism.html
* Memory model: the hard bits -- https://kcsrk.info/webman/manual/memorymodel.html

- [x] (Section) Memory model: the easy bits. The aim is to cover only DRF-SC.
- [x] (Chapter) Memory model: the hard bits. Cover non-SC behaviours and features that do not respect the memory model.
- [x] (Section) Atomics
- [x] (Section) Blocking synchronization
- [x] Update the chapter on [the threads library](https://v2.ocaml.org/manual/libthreads.html) and its interaction with domains. 