### PR TITLE
configure: check support for C11 _Atomic types and operations

### DIFF
--- a/Changes
+++ b/Changes
@@ -81,6 +81,10 @@ Working version
   i.e. 1 Gib for 64-bit platforms and 512 Mib for 32-bit platforms.
   (Xavier Leroy, review by Sébastien Hinderer)
 
+* #11295: An ISO C 2011 compliant compiler, including full support for atomic
+  types, is now required to build the OCaml runtime system.
+  (Xavier Leroy, review by David Allsopp and Sébastien Hinderer)
+
 ### Code generation and optimizations:
 
 - #10972: ARM64 multicore support: OCaml & C stack separation;

--- a/aclocal.m4
+++ b/aclocal.m4
@@ -533,3 +533,27 @@ AC_DEFUN([OCAML_QUOTED_STRING_ID], [
     fi
   done
 ])
+
+AC_DEFUN([OCAML_CC_SUPPORTS_ATOMIC], [
+  AC_MSG_CHECKING([whether the C compiler supports _Atomic types])
+  saved_LIBS="$LIBS"
+  LIBS="$LIBS $1"
+  AC_LINK_IFELSE([AC_LANG_SOURCE([[
+    #include <stdint.h>
+    #include <stdatomic.h>
+    int main(void)
+    {
+      _Atomic int64_t n;
+      int m;
+      int * _Atomic p = &m;
+      atomic_store_explicit(&n, 123, memory_order_release);
+      * atomic_exchange(&p, 0) = 45;
+      return atomic_load_explicit(&n, memory_order_acquire);
+    }
+    ]])],
+  [cc_supports_atomic=true
+   AC_MSG_RESULT([yes])],
+  [cc_supports_atomic=false
+   AC_MSG_RESULT([no])])
+  LIBS="$saved_LIBS"
+])

--- a/configure
+++ b/configure
@@ -14110,6 +14110,51 @@ if ! $arch64; then :
 esac
 fi
 
+# Support for C11 atomic types
+
+
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether the C compiler supports _Atomic types" >&5
+$as_echo_n "checking whether the C compiler supports _Atomic types... " >&6; }
+  saved_LIBS="$LIBS"
+  LIBS="$LIBS $cclibs"
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+    #include <stdint.h>
+    #include <stdatomic.h>
+    int main(void)
+    {
+      _Atomic int64_t n;
+      int m;
+      int * _Atomic p = &m;
+      atomic_store_explicit(&n, 123, memory_order_release);
+      * atomic_exchange(&p, 0) = 45;
+      return atomic_load_explicit(&n, memory_order_acquire);
+    }
+
+_ACEOF
+if ac_fn_c_try_link "$LINENO"; then :
+  cc_supports_atomic=true
+   { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
+else
+  cc_supports_atomic=false
+   { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+fi
+rm -f core conftest.err conftest.$ac_objext \
+    conftest$ac_exeext conftest.$ac_ext
+  LIBS="$saved_LIBS"
+
+if $cc_supports_atomic; then :
+
+else
+  { { $as_echo "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
+$as_echo "$as_me: error: in \`$ac_pwd':" >&2;}
+as_fn_error $? "C11 atomic support is required, use another C compiler
+See \`config.log' for more details" "$LINENO" 5; }
+fi
+
 # Shared library support
 
 sharedlib_cflags=''

--- a/configure
+++ b/configure
@@ -14146,9 +14146,7 @@ rm -f core conftest.err conftest.$ac_objext \
     conftest$ac_exeext conftest.$ac_ext
   LIBS="$saved_LIBS"
 
-if $cc_supports_atomic; then :
-
-else
+if ! $cc_supports_atomic; then :
   { { $as_echo "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
 $as_echo "$as_me: error: in \`$ac_pwd':" >&2;}
 as_fn_error $? "C11 atomic support is required, use another C compiler

--- a/configure.ac
+++ b/configure.ac
@@ -953,8 +953,7 @@ AS_IF([! $arch64],
 # Support for C11 atomic types
 
 OCAML_CC_SUPPORTS_ATOMIC([$cclibs])
-AS_IF([$cc_supports_atomic],
-  [],
+AS_IF([! $cc_supports_atomic],
   [AC_MSG_FAILURE([C11 atomic support is required, use another C compiler])])
 
 # Shared library support

--- a/configure.ac
+++ b/configure.ac
@@ -950,6 +950,13 @@ AS_IF([! $arch64],
   [AS_CASE([$ocaml_cv_cc_vendor],
     [gcc-*], [cclibs="$cclibs -latomic"])])
 
+# Support for C11 atomic types
+
+OCAML_CC_SUPPORTS_ATOMIC([$cclibs])
+AS_IF([$cc_supports_atomic],
+  [],
+  [AC_MSG_FAILURE([C11 atomic support is required, use another C compiler])])
+
 # Shared library support
 
 sharedlib_cflags=''


### PR DESCRIPTION
As mentioned in #10940.

Early detection at configure-time is better than a mysterious failure when compiling or linking the runtime system.
