### PR TITLE
Add ?auto_include to Toploop.set_paths

### DIFF
--- a/.depend
+++ b/.depend
@@ -6343,6 +6343,7 @@ toplevel/topcommon.cmi : \
     typing/outcometree.cmi \
     parsing/longident.cmi \
     parsing/location.cmi \
+    utils/load_path.cmi \
     typing/ident.cmi \
     toplevel/genprintval.cmi \
     typing/env.cmi
@@ -6439,6 +6440,7 @@ toplevel/toploop.cmi : \
     typing/outcometree.cmi \
     parsing/longident.cmi \
     parsing/location.cmi \
+    utils/load_path.cmi \
     typing/env.cmi
 toplevel/topmain.cmi :
 toplevel/topstart.cmo : \

--- a/Changes
+++ b/Changes
@@ -274,7 +274,7 @@ Working version
   (Sébastien Hinderer, review by David Allsopp, Nicolás Ojeda Bär,
   Xavier Leroy, Vincent Laviron and Antonin Décimo)
 
-* #11198: Install the Dynlink, Str and Unix libraries to individual
+* #11198, #11298: Install the Dynlink, Str and Unix libraries to individual
   subdirectories of LIBDIR. The compiler, debugger and toplevel automatically
   add `-I +lib` if required, but display an alert.
   (David Allsopp, review by Florian Angeletti, Nicolás Ojeda Bär,

--- a/driver/compmisc.ml
+++ b/driver/compmisc.ml
@@ -27,7 +27,7 @@ let auto_include find_in_dir fn =
    then the standard library directory (unless the -nostdlib option is given).
  *)
 
-let init_path ?(dir="") () =
+let init_path ?(auto_include=auto_include) ?(dir="") () =
   let dirs =
     if !Clflags.use_threads then "+threads" :: !Clflags.include_dirs
     else

--- a/driver/compmisc.mli
+++ b/driver/compmisc.mli
@@ -22,8 +22,7 @@ val read_clflags_from_env : unit -> unit
 
 val with_ppf_dump : file_prefix:string -> (Format.formatter -> 'a) -> 'a
 
-val auto_include :
-  (Load_path.Dir.t -> string -> string option) -> string -> string
+val auto_include : Load_path.auto_include_callback
 (** [auto_include find_in_dir fn] is a callback function to be passed to
     {!Load_path.init} and automatically adds [-I +lib] to the load path after
     displaying an alert. *)

--- a/driver/compmisc.mli
+++ b/driver/compmisc.mli
@@ -13,7 +13,8 @@
 (*                                                                        *)
 (**************************************************************************)
 
-val init_path : ?dir:string -> unit -> unit
+val init_path :
+  ?auto_include:Load_path.auto_include_callback -> ?dir:string -> unit -> unit
 val initial_env : unit -> Env.t
 
 (* Support for flags that can also be set from an environment variable *)

--- a/testsuite/tools/expect_test.ml
+++ b/testsuite/tools/expect_test.ml
@@ -334,7 +334,7 @@ let main fname =
         Clflags.no_std_include := true;
         Compenv.last_include_dirs := [Filename.concat dir "stdlib"]
   end;
-  Compmisc.init_path ();
+  Compmisc.init_path ~auto_include:Load_path.no_auto_include ();
   Toploop.initialize_toplevel_env ();
   (* We are in interactive mode and should record directive error on stdout *)
   Sys.interactive := true;

--- a/tools/.depend
+++ b/tools/.depend
@@ -5,6 +5,7 @@ caml_tex.cmo : \
     ../parsing/parse.cmi \
     ../utils/misc.cmi \
     ../parsing/location.cmi \
+    ../utils/load_path.cmi \
     ../parsing/lexer.cmi \
     ../driver/compmisc.cmi \
     ../driver/compenv.cmi \
@@ -18,6 +19,7 @@ caml_tex.cmx : \
     ../parsing/parse.cmx \
     ../utils/misc.cmx \
     ../parsing/location.cmx \
+    ../utils/load_path.cmx \
     ../parsing/lexer.cmx \
     ../driver/compmisc.cmx \
     ../driver/compenv.cmx \

--- a/tools/caml_tex.ml
+++ b/tools/caml_tex.ml
@@ -182,7 +182,7 @@ module Toplevel = struct
     Clflags.color := Some Misc.Color.Never;
     Clflags.no_std_include := true;
     Compenv.last_include_dirs := [Filename.concat !repo_root "stdlib"];
-    Compmisc.init_path ();
+    Compmisc.init_path ~auto_include:Load_path.no_auto_include ();
     try
       Toploop.initialize_toplevel_env ();
       Sys.interactive := false

--- a/toplevel/topcommon.ml
+++ b/toplevel/topcommon.ml
@@ -259,7 +259,7 @@ let refill_lexbuf buffer len =
       len
   end
 
-let set_paths () =
+let set_paths ?(auto_include=Compmisc.auto_include) () =
   (* Add whatever -I options have been specified on the command line,
      but keep the directories that user code linked in with ocamlmktop
      may have added to load_path. *)
@@ -274,7 +274,7 @@ let set_paths () =
       [expand "+camlp4"];
     ]
   in
-  Load_path.init ~auto_include:Compmisc.auto_include load_path;
+  Load_path.init ~auto_include load_path;
   Dll.add_path load_path
 
 let update_search_path_from_env () =

--- a/toplevel/topcommon.mli
+++ b/toplevel/topcommon.mli
@@ -29,7 +29,7 @@ open Format
 
 (* Set the load paths, before running anything *)
 
-val set_paths : unit -> unit
+val set_paths : ?auto_include:Load_path.auto_include_callback -> unit -> unit
 
 (* Add directories listed in OCAMLTOP_INCLUDE_PATH to the end of the search
    path *)

--- a/toplevel/toploop.mli
+++ b/toplevel/toploop.mli
@@ -32,7 +32,7 @@ val filename_of_input: input -> string
 
 (* Set the load paths, before running anything *)
 
-val set_paths : unit -> unit
+val set_paths : ?auto_include:Load_path.auto_include_callback -> unit -> unit
 
 (* The interactive toplevel loop *)
 

--- a/utils/load_path.ml
+++ b/utils/load_path.ml
@@ -64,15 +64,15 @@ type auto_include_callback =
   (Dir.t -> string -> string option) -> string -> string
 
 let dirs = s_ref []
-let default_auto_include_callback _ _ = raise Not_found
-let auto_include_callback = ref default_auto_include_callback
+let no_auto_include _ _ = raise Not_found
+let auto_include_callback = ref no_auto_include
 
 let reset () =
   assert (not Config.merlin || Local_store.is_bound ());
   STbl.clear !files;
   STbl.clear !files_uncap;
   dirs := [];
-  auto_include_callback := default_auto_include_callback
+  auto_include_callback := no_auto_include
 
 let get () = List.rev !dirs
 let get_paths () = List.rev_map Dir.path !dirs

--- a/utils/load_path.ml
+++ b/utils/load_path.ml
@@ -60,6 +60,9 @@ module Dir = struct
     { path; files = Array.to_list (readdir_compat path) }
 end
 
+type auto_include_callback =
+  (Dir.t -> string -> string option) -> string -> string
+
 let dirs = s_ref []
 let default_auto_include_callback _ _ = raise Not_found
 let auto_include_callback = ref default_auto_include_callback

--- a/utils/load_path.mli
+++ b/utils/load_path.mli
@@ -51,13 +51,15 @@ module Dir : sig
       Foo.ml, either /path/Foo.ml or /path/foo.ml may be returned. *)
 end
 
-val init :
-  auto_include:((Dir.t -> string -> string option) -> string -> string) ->
-  string list -> unit
+type auto_include_callback =
+  (Dir.t -> string -> string option) -> string -> string
+(** The type of callback functions on for [init ~auto_include] *)
+
+val init : auto_include:auto_include_callback -> string list -> unit
 (** [init l] is the same as [reset (); List.iter add_dir (List.rev l)] *)
 
 val auto_include_otherlibs :
-  (string -> unit) -> (Dir.t -> string -> string option) -> string -> string
+  (string -> unit) -> auto_include_callback
 (** [auto_include_otherlibs alert] is a callback function to be passed to
     {!Load_path.init} and automatically adds [-I +lib] to the load path after
     calling [alert lib]. *)

--- a/utils/load_path.mli
+++ b/utils/load_path.mli
@@ -55,6 +55,10 @@ type auto_include_callback =
   (Dir.t -> string -> string option) -> string -> string
 (** The type of callback functions on for [init ~auto_include] *)
 
+val no_auto_include : auto_include_callback
+(** No automatic directory inclusion: misses in the load path raise [Not_found]
+    as normal. *)
+
 val init : auto_include:auto_include_callback -> string list -> unit
 (** [init l] is the same as [reset (); List.iter add_dir (List.rev l)] *)
 


### PR DESCRIPTION
This is a tweak to #11198 providing the toplevel with an easier API for disabling the automatic inclusion mechanism to aid alternate toplevels, such as utop (see https://github.com/ocaml-community/utop/pull/377)