### PR TITLE
Runtime_events fix for compilation on omnios/illumos

### DIFF
--- a/otherlibs/runtime_events/runtime_events_consumer.c
+++ b/otherlibs/runtime_events/runtime_events_consumer.c
@@ -194,7 +194,8 @@ caml_runtime_events_create_cursor(const char_os* runtime_events_path, int pid,
 
   cursor->ring_file_size_bytes = tmp_stat.st_size;
 
-  cursor->metadata = mmap(NULL, cursor->ring_file_size_bytes, PROT_READ,
+  cursor->metadata = (struct runtime_events_metadata_header *)
+                      mmap(NULL, cursor->ring_file_size_bytes, PROT_READ,
                           MAP_SHARED, ring_fd, 0);
 
   if( cursor->metadata == MAP_FAILED ) {
@@ -282,7 +283,7 @@ void caml_runtime_events_free_cursor(struct caml_runtime_events_cursor *cursor){
     CloseHandle(cursor->ring_file_handle);
     CloseHandle(cursor->ring_handle);
 #else
-    munmap(cursor->metadata, cursor->ring_file_size_bytes);
+    munmap((void*)cursor->metadata, cursor->ring_file_size_bytes);
 #endif
     caml_stat_free(cursor->current_positions);
     caml_stat_free(cursor);

--- a/otherlibs/runtime_events/runtime_events_consumer.c
+++ b/otherlibs/runtime_events/runtime_events_consumer.c
@@ -194,6 +194,8 @@ caml_runtime_events_create_cursor(const char_os* runtime_events_path, int pid,
 
   cursor->ring_file_size_bytes = tmp_stat.st_size;
 
+  /* This cast is necessary for compatibility with Illumos' non-POSIX
+    mmap/munmap */
   cursor->metadata = (struct runtime_events_metadata_header *)
                       mmap(NULL, cursor->ring_file_size_bytes, PROT_READ,
                           MAP_SHARED, ring_fd, 0);
@@ -283,6 +285,8 @@ void caml_runtime_events_free_cursor(struct caml_runtime_events_cursor *cursor){
     CloseHandle(cursor->ring_file_handle);
     CloseHandle(cursor->ring_handle);
 #else
+    /* This cast is necessary for compatibility with Illumos' non-POSIX
+      mmap/munmap */
     munmap((void*)cursor->metadata, cursor->ring_file_size_bytes);
 #endif
     caml_stat_free(cursor->current_positions);

--- a/runtime/runtime_events.c
+++ b/runtime/runtime_events.c
@@ -135,7 +135,7 @@ static void runtime_events_teardown_raw(int remove_file) {
       DeleteFile(current_ring_loc);
     }
 #else
-    munmap(current_metadata, current_ring_total_size);
+    munmap((void*)current_metadata, current_ring_total_size);
 
     if( remove_file ) {
       unlink(current_ring_loc);
@@ -292,7 +292,8 @@ static void runtime_events_create_raw() {
       caml_fatal_error("Can't resize ring buffer");
     }
 
-    current_metadata = mmap(NULL, current_ring_total_size,
+    current_metadata = (struct runtime_events_metadata_header*)mmap
+                          (NULL, current_ring_total_size,
                             PROT_READ | PROT_WRITE, MAP_SHARED, ring_fd, 0);
 
     if (current_metadata == NULL) {

--- a/runtime/runtime_events.c
+++ b/runtime/runtime_events.c
@@ -135,6 +135,8 @@ static void runtime_events_teardown_raw(int remove_file) {
       DeleteFile(current_ring_loc);
     }
 #else
+    /* This cast is necessary for compatibility with Illumos' non-POSIX
+      mmap/munmap */
     munmap((void*)current_metadata, current_ring_total_size);
 
     if( remove_file ) {
@@ -292,8 +294,10 @@ static void runtime_events_create_raw() {
       caml_fatal_error("Can't resize ring buffer");
     }
 
-    current_metadata = (struct runtime_events_metadata_header*)mmap
-                          (NULL, current_ring_total_size,
+    /* This cast is necessary for compatibility with Illumos' non-POSIX
+      mmap/munmap */
+    current_metadata = (struct runtime_events_metadata_header*)
+                        mmap(NULL, current_ring_total_size,
                             PROT_READ | PROT_WRITE, MAP_SHARED, ring_fd, 0);
 
     if (current_metadata == NULL) {


### PR DESCRIPTION
https://github.com/ocaml/ocaml/pull/10964#issuecomment-1144566131 identifies the issue (mmap/munmap being non-posix on illumos).

There are defines that can be set to get POSIX-compliant headers but they then hide other functions we seem to rely on. https://github.com/sadiqj/ocaml/tree/runtime_events_omnios_fix was my attempt there.

This PR adds casts so things compile again and the testsuite runs. For some reason Inria CI's omnios worker dies at some point in the testsuite - I don't see any failed tests in the ones that were run.