### PR TITLE
documentation: runtime events library

### DIFF
--- a/api_docgen/Makefile.docfiles
+++ b/api_docgen/Makefile.docfiles
@@ -30,7 +30,7 @@ define sort
 $(shell $(OCAMLDEP) -sort $(1))
 endef
 
-
+runtime_events_MLIS := runtime_events.mli
 str_MLIS := str.mli
 unix_MLIS := unix.mli unixLabels.mli
 dynlink_MLIS := dynlink.mli
@@ -53,6 +53,10 @@ endif
 
 ifneq "$(filter systhreads,$(OTHERLIBRARIES))" ""
 otherlibref += $(thread_MLIS:%.mli=%)
+endif
+
+ifneq "$(filter runtime_events,$(OTHERLIBRARIES))" ""
+otherlibref += $(runtime_events_MLIS:%.mli=%)
 endif
 
 libref_TEXT=Ocaml_operators Format_tutorial

--- a/api_docgen/alldoc.tex
+++ b/api_docgen/alldoc.tex
@@ -78,11 +78,8 @@
 \chapter{Str}
 \docitem{libref}{Str.tex}
 \chapter{Thread}
-\docitem{libref}{Condition.tex}
 \docitem{libref}{Event.tex}
-\docitem{libref}{Mutex.tex}
 \docitem{libref}{Thread.tex}
-\docitem{libref}{Semaphore.tex}
 \chapter{Unix}
 \docitem{libref}{UnixLabels.tex}
 \docitem{libref}{Unix.tex}


### PR DESCRIPTION
This PR adds the `Runtime_events` library to the targets for the documentation generator. This restores the manual build process. However, note that the library is still included in the standard library part of the manual. We will need to fix this point before the release.

The second commit fixes an issue with the latex preview target which was still including the `Mutex`, `Condition` and `Semaphore` modules as if there were part of the `threads` library.