### PR TITLE
manual: mention the new location for otherlibs

### DIFF
--- a/manual/src/library/Makefile
+++ b/manual/src/library/Makefile
@@ -1,6 +1,8 @@
 ROOTDIR = ../../..
 
 TEXQUOTE = $(ROOTDIR)/runtime/ocamlrun ../../tools/texquote2
+CAMLLATEX = CAML_LD_LIBRARY_PATH="" $(OCAMLRUN) $(addprefix -I ,$(LD_PATH)) \
+  $(ROOTDIR)/tools/caml-tex -repo-root $(ROOTDIR) -n 80 -v false
 
 FILES = core.tex builtin.tex stdlib-blurb.tex compilerlibs.tex \
   libunix.tex libstr.tex old.tex libthreads.tex libdynlink.tex
@@ -8,7 +10,10 @@ FILES = core.tex builtin.tex stdlib-blurb.tex compilerlibs.tex \
 etex-files: $(FILES)
 all: etex-files
 
-%.tex: %.etex
+%.gen.tex: %.etex
+	$(CAMLLATEX) $< -o $@
+
+%.tex: %.gen.tex
 	$(TEXQUOTE) < $< > $*.texquote_error.tex
 	mv $*.texquote_error.tex $@
 

--- a/manual/src/library/libdynlink.etex
+++ b/manual/src/library/libdynlink.etex
@@ -14,7 +14,8 @@ might be useful to hide ".cmx" files when building native plugins so
 that they remain independent of the implementation of modules in the
 main program.
 
-Programs that use the "dynlink" library simply need to link
+Programs that use the "dynlink" library simply need to include
+the dynlink library directory with "-I +dynlink" and link
 "dynlink.cma" or "dynlink.cmxa" with their object files and other libraries.
 
 \textbf{Note:} in order to insure that the dynamically-loaded modules have

--- a/manual/src/library/libstr.etex
+++ b/manual/src/library/libstr.etex
@@ -8,8 +8,8 @@ such as "awk", "perl" or "sed".
 
 Programs that use the "str" library must be linked as follows:
 \begin{alltt}
-        ocamlc \var{other options} str.cma \var{other files}
-        ocamlopt \var{other options} str.cmxa \var{other files}
+        ocamlc \var{other options} -I +str str.cma \var{other files}
+        ocamlopt \var{other options}  -I +str str.cmxa \var{other files}
 \end{alltt}
 For interactive use of the "str" library, do:
 \begin{alltt}
@@ -17,7 +17,11 @@ For interactive use of the "str" library, do:
         ./mytop
 \end{alltt}
 or (if dynamic linking of C libraries is supported on your platform),
-start "ocaml" and type "#load \"str.cma\";;".
+start "ocaml" and type
+\begin{caml_example*}{toplevel}
+#directory "+str";;
+#load  "str.cma";;
+\end{caml_example*}
 
 \begin{linklist}
 \libdocitem{Str}{regular expressions and string processing}

--- a/manual/src/library/libthreads.etex
+++ b/manual/src/library/libthreads.etex
@@ -20,8 +20,8 @@ overlapping I/O operations.
 
 Programs that use threads must be linked as follows:
 \begin{alltt}
-        ocamlc -I +threads \var{other options} unix.cma threads.cma \var{other files}
-        ocamlopt -I +threads \var{other options} unix.cmxa threads.cmxa \var{other files}
+        ocamlc -I +unix -I +threads \var{other options} unix.cma threads.cma \var{other files}
+        ocamlopt -I +unix -I +threads \var{other options} unix.cmxa threads.cmxa \var{other files}
 \end{alltt}
 Compilation units that use the "threads" library must also be compiled with
 the "-I +threads" option (see chapter~\ref{c:camlc}).

--- a/manual/src/library/libunix.etex
+++ b/manual/src/library/libunix.etex
@@ -20,16 +20,21 @@ are not available, they will raise "Invalid_arg" when called.
 
 Programs that use the "unix" library must be linked as follows:
 \begin{alltt}
-        ocamlc \var{other options} unix.cma \var{other files}
-        ocamlopt \var{other options} unix.cmxa \var{other files}
+        ocamlc \var{other options} -I +unix unix.cma \var{other files}
+        ocamlopt \var{other options}  -I +unix unix.cmxa \var{other files}
 \end{alltt}
 For interactive use of the "unix" library, do:
 \begin{alltt}
-        ocamlmktop -o mytop unix.cma
+        ocamlmktop -o mytop -I +unix unix.cma
         ./mytop
 \end{alltt}
 or (if dynamic linking of C libraries is supported on your platform),
-start "ocaml" and type "#load \"unix.cma\";;".
+start "ocaml" and type
+
+\begin{caml_example*}{toplevel}
+#directory "+unix";;
+#load "unix.cma";;
+\end{caml_example*}
 
 \begin{latexonly}
 \begin{windows}


### PR DESCRIPTION
This PR updates the presentation of the otherlibs library in the manual to take in account the new locations of those library (and thus the need of including their directory with `-I +$lib`.