### PR TITLE
Ensure that GC is not invoked from bounds check failures

### DIFF
--- a/Changes
+++ b/Changes
@@ -149,6 +149,9 @@ OCaml 5.0
   `caml_process_pending*` for multicore.
   (Guillaume Munch-Maccagnoni, review by Sadiq Jaffer and Gabriel Scherer)
 
+- #11303: Ensure that GC is not invoked from bounds check failures
+  (Stephen Dolan, review by Sadiq Jaffer and Xavier Leroy)
+
 - #11304: Fix data race on Windows file descriptors
   (Olivier Nicole and Xavier Leroy, review by Xavier Leroy, David Allsopp,
    and Sadiq Jaffer)

--- a/runtime/amd64.S
+++ b/runtime/amd64.S
@@ -1024,8 +1024,7 @@ ENDFUNCTION(G(caml_runstack))
 
 FUNCTION(G(caml_ml_array_bound_error))
 CFI_STARTPROC
-        ENTER_FUNCTION
-        LEA_VAR(caml_array_bound_error, %rax)
+        LEA_VAR(caml_array_bound_error_asm, %rax)
         jmp     LBL(caml_c_call)
 CFI_ENDPROC
 ENDFUNCTION(G(caml_ml_array_bound_error))

--- a/runtime/amd64nt.asm
+++ b/runtime/amd64nt.asm
@@ -24,7 +24,7 @@
         EXTRN  caml_apply2: NEAR
         EXTRN  caml_apply3: NEAR
         EXTRN  caml_program: NEAR
-        EXTRN  caml_array_bound_error: NEAR
+        EXTRN  caml_array_bound_error_asm: NEAR
        EXTRN  caml_stash_backtrace: NEAR
 
 INCLUDE domain_state64.inc
@@ -420,7 +420,7 @@ caml_callback3_asm:
         PUBLIC  caml_ml_array_bound_error
         ALIGN   16
 caml_ml_array_bound_error:
-        lea     rax, caml_array_bound_error
+        lea     rax, caml_array_bound_error_asm
         jmp     caml_c_call
 
         PUBLIC caml_system__code_end

--- a/runtime/arm.S
+++ b/runtime/arm.S
@@ -418,8 +418,8 @@ FUNCTION(caml_callback3_asm)
 
 FUNCTION(caml_ml_array_bound_error)
         CFI_STARTPROC
-    /* Load address of [caml_array_bound_error] in r7 */
-        ldr     r7, =caml_array_bound_error
+    /* Load address of [caml_array_bound_error_asm] in r7 */
+        ldr     r7, =caml_array_bound_error_asm
     /* Call that function */
         b       caml_c_call
         CFI_ENDPROC

--- a/runtime/arm64.S
+++ b/runtime/arm64.S
@@ -909,8 +909,8 @@ L(fiber_exn_handler):
 
 FUNCTION(caml_ml_array_bound_error)
         CFI_STARTPROC
-    /* Load address of [caml_array_bound_error] in ADDITIONAL_ARG */
-        ADDRGLOBAL(ADDITIONAL_ARG, caml_array_bound_error)
+    /* Load address of [caml_array_bound_error_asm] in ADDITIONAL_ARG */
+        ADDRGLOBAL(ADDITIONAL_ARG, caml_array_bound_error_asm)
     /* Call that function */
         b       G(caml_c_call)
         CFI_ENDPROC

--- a/runtime/fail_nat.c
+++ b/runtime/fail_nat.c
@@ -58,9 +58,6 @@ CAMLnoreturn_start
   extern void caml_raise_exception (caml_domain_state* state, value bucket)
 CAMLnoreturn_end;
 
-/* Used by the stack overflow handler -> deactivate ASAN (see
-   segv_handler in signals_nat.c). */
-CAMLno_asan
 void caml_raise(value v)
 {
   char* exception_pointer;

--- a/runtime/fail_nat.c
+++ b/runtime/fail_nat.c
@@ -214,7 +214,10 @@ void caml_array_bound_error(void)
     }
     atomic_store_rel(&exn_cache, (uintnat)exn);
   }
-  caml_raise(*exn);
+  /* This exception is raised directly from OCaml, not C,
+     so we should not do the C-specific processing in caml_raise.
+     (In particular, we must not invoke GC, even if signals are pending) */
+  caml_raise_exception(Caml_state, *exn);
 }
 
 int caml_is_special_exception(value exn) {

--- a/runtime/i386.S
+++ b/runtime/i386.S
@@ -412,8 +412,8 @@ FUNCTION(caml_ml_array_bound_error)
         movl    %edx, CAML_STATE(bottom_of_stack, %ebx)
     /* Re-align the stack */
         andl    $-16, %esp
-    /* Branch to [caml_array_bound_error] (never returns) */
-        call    G(caml_array_bound_error)
+    /* Branch to [caml_array_bound_error_asm] (never returns) */
+        call    G(caml_array_bound_error_asm)
         CFI_ENDPROC
         ENDFUNCTION(caml_ml_array_bound_error)
 

--- a/runtime/i386nt.asm
+++ b/runtime/i386nt.asm
@@ -22,7 +22,7 @@
         EXTERN  _caml_apply2: PROC
         EXTERN  _caml_apply3: PROC
         EXTERN  _caml_program: PROC
-        EXTERN  _caml_array_bound_error: PROC
+        EXTERN  _caml_array_bound_error_asm: PROC
         EXTERN  _caml_stash_backtrace: PROC
         EXTERN  _Caml_state: DWORD
 
@@ -293,8 +293,8 @@ _caml_ml_array_bound_error:
         ffree   st(5)
         ffree   st(6)
         ffree   st(7)
-    ; Branch to caml_array_bound_error
-        mov     eax, offset _caml_array_bound_error
+    ; Branch to caml_array_bound_error_asm
+        mov     eax, offset _caml_array_bound_error_asm
         jmp     _caml_c_call
 
         PUBLIC _caml_system__code_end

--- a/runtime/riscv.S
+++ b/runtime/riscv.S
@@ -429,8 +429,8 @@ FUNCTION(caml_callback3_asm)
 END_FUNCTION(caml_callback3_asm)
 
 FUNCTION(caml_ml_array_bound_error)
-        /* Load address of [caml_array_bound_error] in ARG */
-        la      ARG, caml_array_bound_error
+        /* Load address of [caml_array_bound_error_asm] in ARG */
+        la      ARG, caml_array_bound_error_asm
         /* Call that function */
         tail    caml_c_call
 END_FUNCTION(caml_ml_array_bound_error)

--- a/runtime/s390x.S
+++ b/runtime/s390x.S
@@ -333,7 +333,7 @@ caml_ml_array_bound_error:
            the frame descriptor for the call site is not correct */
         stg     %r15, Caml_state(bottom_of_stack)
         lay     %r15, -160(%r15)    /* Reserve stack space for C call */
-        Addrglobal(%r7, caml_array_bound_error)
+        Addrglobal(%r7, caml_array_bound_error_asm)
         j       .L101
         .globl  caml_system__code_end
 caml_system__code_end:

--- a/testsuite/tests/lib-systhreads/boundscheck.ml
+++ b/testsuite/tests/lib-systhreads/boundscheck.ml
@@ -2,9 +2,8 @@
 
 include systhreads
 * hassysthreads
-** not-windows
-*** bytecode
-*** native
+** bytecode
+** native
 
 *)
 

--- a/testsuite/tests/lib-systhreads/boundscheck.ml
+++ b/testsuite/tests/lib-systhreads/boundscheck.ml
@@ -1,0 +1,39 @@
+(* TEST
+
+include systhreads
+* hassysthreads
+** not-windows
+*** bytecode
+*** native
+
+*)
+
+
+module Atomic = struct
+  let make = ref
+  let set = (:=)
+  let get = (!)
+end
+
+let arr = [| 1; 2; 3 |]
+
+let[@inline never] bounds r =
+  (* r is live across a bounds check failure *)
+  try arr.(42) with
+  | _ -> !r
+
+let glob = ref (ref 0)
+let () =
+  let go = Atomic.make true in
+  let gcthread =
+    Thread.create (fun () ->
+      while Atomic.get go do Thread.yield (); Gc.minor (); done) ()
+  in
+  while (Gc.quick_stat ()).minor_collections < 1000 do
+    let r = ref 42 in
+    glob := r; (* force promotion *)
+    let n = bounds r in
+    if n <> 42 then Printf.printf "%x <> 42!\n%!" n;
+  done;
+  Atomic.set go false;
+  Thread.join gcthread


### PR DESCRIPTION
Since 4.12, there's a subtle bug in how array/string/bigarrray bounds checks failures are handled, which can lead to corruption or segfaults in programs that catch the exceptions arising from bounds check failures.

Different invariants apply for exceptions from C versus OCaml. Exceptions raised from C are assumed to be at a safe point: all live values are registered on the stack, `caml_local_roots` is in a sensible state, and so on. In particular, the GC may run if asynchronous actions are pending. Exceptions raised from OCaml, by contrast, do not have these requirements. Instead, the stack is simply cut to the point of the exception handler (possibly after collecting a backtrace).

In order to make it possible to collect a backtrace, raise sites of OCaml exceptions have a frame table entry, but this frame table entry only contains debuginfo and has an invalid set of live registers. (This shouldn't matter when raising exceptions from OCaml, as this data is not used).

However, the current implementation of bounds check failures does not raise an exception from OCaml: instead, it switches to C and calls `caml_raise`. This function has stronger requirements, and in particular may invoke GC if actions are pending (see #9722). If this occurs, the GC can use the invalid frame table of the bounds check error. This can cause problems if there are in fact live values, particularly when an array bounds check is raised and caught in the same function. The attached testcase demonstrates this, going wrong on all versions of OCaml since 4.12.

The fix here is to skip the C-specific processing when raising a bounds check failure in `caml_array_bound_error`. (Other potential fixes are to update the assembly stub to avoid ever entering C in this case, or to generate correct frame table entries detailing the live registers for all bounds check points. This change seemed simplest)

