### PR TITLE
Fix data race on Windows file descriptors

### DIFF
--- a/Changes
+++ b/Changes
@@ -115,7 +115,7 @@ OCaml 5.0
   (Enguerrand Decorne, report by Jon Ludlam,
   review by Tom Kelly, KC Sivaramakrishnan and Gabriel Scherer)
 
-- #11238: Increase the default limit on the stack size to 128 Mi words,
+- #11238: Increase the default limit for the stack size to 128 Mi words,
   i.e. 1 Gib for 64-bit platforms and 512 Mib for 32-bit platforms.
   (Xavier Leroy, review by Sébastien Hinderer)
 
@@ -128,7 +128,11 @@ OCaml 5.0
   `caml_process_pending*` for multicore.
   (Guillaume Munch-Maccagnoni, review by Sadiq Jaffer and Gabriel Scherer)
 
-- #11337: pass 'flags' metadata to root scanners, to optimize stack
+- #11304: Fix data race on Windows file descriptors
+  (Olivier Nicole and Xavier Leroy, review by Xavier Leroy, David Allsopp,
+   and Sadiq Jaffer)
+
+* #11337: pass 'flags' metadata to root scanners, to optimize stack
   scanning in the bytecode interpreter.
   Changes the interface of user-provided root-scanning hooks.
   (Gabriel Scherer, review by Xavier Leroy,

--- a/otherlibs/unix/channels_win32.c
+++ b/otherlibs/unix/channels_win32.c
@@ -89,7 +89,7 @@ int caml_win32_CRT_fd_of_filedescr(value handle)
       break; /* try again */
     default:
       return fd;
-  }
+    }
   }
 }
 

--- a/otherlibs/unix/channels_win32.c
+++ b/otherlibs/unix/channels_win32.c
@@ -153,7 +153,7 @@ CAMLprim value caml_unix_filedescr_of_channel(value vchan)
     fd = caml_win32_alloc_socket((SOCKET) h);
   else
     fd = caml_win32_alloc_handle(h);
-  atomic_store_explicit(&CRT_fd_val(fd), chan->fd, memory_order_relaxed);
+  CRT_fd_val(fd) = chan->fd;
   CAMLreturn(fd);
 }
 
@@ -164,6 +164,6 @@ CAMLprim value caml_unix_filedescr_of_fd(value vfd)
      degradation and this function is only used with the standard
      handles 0, 1, 2, which are not sockets. */
   value res = caml_win32_alloc_handle((HANDLE) _get_osfhandle(crt_fd));
-  atomic_store_explicit(&CRT_fd_val(res), crt_fd, memory_order_relaxed);
+  CRT_fd_val(res) = crt_fd;
   return res;
 }

--- a/otherlibs/unix/channels_win32.c
+++ b/otherlibs/unix/channels_win32.c
@@ -60,6 +60,8 @@ static DWORD check_stream_semantics(value handle)
   }
 }
 
+#define CRT_fd_val(v) (((struct filedescr *) Data_custom_val(v))->crt_fd)
+
 int caml_win32_get_CRT_fd(value handle)
 {
   int fd;

--- a/otherlibs/unix/channels_win32.c
+++ b/otherlibs/unix/channels_win32.c
@@ -63,38 +63,34 @@ static DWORD check_stream_semantics(value handle)
 int caml_win32_get_CRT_fd(value handle)
 {
   int fd;
-  do {
-    fd = (int)atomic_load(&CRT_fd_val(handle));
-  } while (fd == GETTING_CRT_FD);
-  return fd;
+  SPIN_WAIT {
+    fd = atomic_load(&CRT_fd_val(handle));
+    if (fd != GETTING_CRT_FD) return fd;
+  }
 }
 
 int caml_win32_CRT_fd_of_filedescr(value handle)
 {
-  int fd = (int)atomic_load(&CRT_fd_val(handle));
-  if (fd != NO_CRT_FD && fd != GETTING_CRT_FD) {
-    return fd;
-  } else if (fd == NO_CRT_FD) {
-    /* Attempt to take responsibility to allocate the C fd */
-    intnat expected_fd = (intnat)NO_CRT_FD;
-    if (atomic_compare_exchange_strong(&CRT_fd_val(handle), &expected_fd,
-        (intnat)GETTING_CRT_FD)) {
+  SPIN_WAIT {
+    int fd = atomic_load(&CRT_fd_val(handle));
+    switch (fd) {
+    case NO_CRT_FD:
+      if (! atomic_compare_exchange_strong(&CRT_fd_val(handle),
+                                           &fd, GETTING_CRT_FD))
+        break; /* try again */
       fd = _open_osfhandle((intptr_t) Handle_val(handle), O_BINARY);
       if (fd == -1) {
-        atomic_store(&CRT_fd_val(handle), (intnat)NO_CRT_FD);
+        atomic_store(&CRT_fd_val(handle), NO_CRT_FD);
         caml_uerror("channel_of_descr", Nothing);
       }
-      atomic_store(&CRT_fd_val(handle), (intnat)fd);
+      atomic_store(&CRT_fd_val(handle), fd);
       return fd;
-    }
-    else {
-      goto busywait;
-    }
+    case GETTING_CRT_FD:
+      break; /* try again */
+    default:
+      return fd;
   }
-
-busywait:
-  while ((int)atomic_load(&CRT_fd_val(handle)) == GETTING_CRT_FD) /* Nothing */;
-  return (int)atomic_load(&CRT_fd_val(handle));
+  }
 }
 
 CAMLprim value caml_unix_inchannel_of_filedescr(value handle)
@@ -157,8 +153,7 @@ CAMLprim value caml_unix_filedescr_of_channel(value vchan)
     fd = caml_win32_alloc_socket((SOCKET) h);
   else
     fd = caml_win32_alloc_handle(h);
-  atomic_store_explicit(&CRT_fd_val(fd), (intnat)chan->fd,
-                        memory_order_relaxed);
+  atomic_store_explicit(&CRT_fd_val(fd), chan->fd, memory_order_relaxed);
   CAMLreturn(fd);
 }
 
@@ -169,6 +164,6 @@ CAMLprim value caml_unix_filedescr_of_fd(value vfd)
      degradation and this function is only used with the standard
      handles 0, 1, 2, which are not sockets. */
   value res = caml_win32_alloc_handle((HANDLE) _get_osfhandle(crt_fd));
-  atomic_store_explicit(&CRT_fd_val(res), (intnat)crt_fd, memory_order_relaxed);
+  atomic_store_explicit(&CRT_fd_val(res), crt_fd, memory_order_relaxed);
   return res;
 }

--- a/otherlibs/unix/channels_win32.c
+++ b/otherlibs/unix/channels_win32.c
@@ -60,13 +60,13 @@ static DWORD check_stream_semantics(value handle)
   }
 }
 
-#define CRT_fd_val(v) (((struct filedescr *) Data_custom_val(v))->crt_fd)
+#define CRT_field_val(v) (((struct filedescr *) Data_custom_val(v))->crt_fd)
 
 int caml_win32_get_CRT_fd(value handle)
 {
   int fd;
   SPIN_WAIT {
-    fd = atomic_load(&CRT_fd_val(handle));
+    fd = atomic_load(&CRT_field_val(handle));
     if (fd != GETTING_CRT_FD) return fd;
   }
 }
@@ -74,18 +74,18 @@ int caml_win32_get_CRT_fd(value handle)
 int caml_win32_CRT_fd_of_filedescr(value handle)
 {
   SPIN_WAIT {
-    int fd = atomic_load(&CRT_fd_val(handle));
+    int fd = atomic_load(&CRT_field_val(handle));
     switch (fd) {
     case NO_CRT_FD:
-      if (! atomic_compare_exchange_strong(&CRT_fd_val(handle),
+      if (! atomic_compare_exchange_strong(&CRT_field_val(handle),
                                            &fd, GETTING_CRT_FD))
         break; /* try again */
       fd = _open_osfhandle((intptr_t) Handle_val(handle), O_BINARY);
       if (fd == -1) {
-        atomic_store(&CRT_fd_val(handle), NO_CRT_FD);
+        atomic_store(&CRT_field_val(handle), NO_CRT_FD);
         caml_uerror("channel_of_descr", Nothing);
       }
-      atomic_store(&CRT_fd_val(handle), fd);
+      atomic_store(&CRT_field_val(handle), fd);
       return fd;
     case GETTING_CRT_FD:
       break; /* try again */
@@ -155,7 +155,7 @@ CAMLprim value caml_unix_filedescr_of_channel(value vchan)
     fd = caml_win32_alloc_socket((SOCKET) h);
   else
     fd = caml_win32_alloc_handle(h);
-  CRT_fd_val(fd) = chan->fd;
+  CRT_field_val(fd) = chan->fd;
   CAMLreturn(fd);
 }
 
@@ -166,6 +166,6 @@ CAMLprim value caml_unix_filedescr_of_fd(value vfd)
      degradation and this function is only used with the standard
      handles 0, 1, 2, which are not sockets. */
   value res = caml_win32_alloc_handle((HANDLE) _get_osfhandle(crt_fd));
-  CRT_fd_val(res) = crt_fd;
+  CRT_field_val(res) = crt_fd;
   return res;
 }

--- a/otherlibs/unix/close_win32.c
+++ b/otherlibs/unix/close_win32.c
@@ -28,8 +28,9 @@ CAMLprim value caml_unix_close(value fd)
     /* If we have an fd then closing it also closes
      * the underlying handle. Also, closing only
      * the handle and not the fd leads to fd leaks. */
-    if (CRT_fd_val(fd) != NO_CRT_FD) {
-      if (_close(CRT_fd_val(fd)) != 0)
+    int crt_fd = caml_win32_get_CRT_fd(fd);
+    if (crt_fd != NO_CRT_FD) {
+      if (_close(crt_fd) != 0)
          caml_uerror("close", Nothing);
     } else {
       if (! CloseHandle(Handle_val(fd))) {

--- a/otherlibs/unix/dup_win32.c
+++ b/otherlibs/unix/dup_win32.c
@@ -109,7 +109,8 @@ CAMLprim value caml_unix_dup2(value cloexec, value fd1, value fd2)
   }
 
   /* Reflect the dup2 on the CRT fds, if any */
-  if (CRT_fd_val(fd1) != NO_CRT_FD || CRT_fd_val(fd2) != NO_CRT_FD)
+  if (caml_win32_get_CRT_fd(fd1) != NO_CRT_FD ||
+      caml_win32_get_CRT_fd(fd2) != NO_CRT_FD)
     _dup2(caml_win32_CRT_fd_of_filedescr(fd1),
           caml_win32_CRT_fd_of_filedescr(fd2));
   CAMLreturn(Val_unit);

--- a/otherlibs/unix/unixsupport.h
+++ b/otherlibs/unix/unixsupport.h
@@ -79,6 +79,9 @@ extern int caml_win32_CRT_fd_of_filedescr(value handle);
    win_CRT_fd_of_filedescr. */
 extern int caml_win32_get_CRT_fd(value handle);
 
+// Export this macro as an alias for the getter function, for compatibility
+#define CRT_fd_val caml_win32_get_CRT_fd
+
 extern SOCKET caml_win32_socket(int domain, int type, int protocol,
                                 LPWSAPROTOCOL_INFO info,
                                 BOOL inherit);

--- a/otherlibs/unix/unixsupport.h
+++ b/otherlibs/unix/unixsupport.h
@@ -46,7 +46,7 @@ struct filedescr {
     SOCKET socket;
   } fd;                   /* Real windows handle */
   enum { KIND_HANDLE, KIND_SOCKET } kind;
-  atomic_intnat crt_fd;             /* C runtime descriptor */
+  _Atomic int crt_fd;     /* C runtime descriptor */
   unsigned int flags_fd;  /* See FLAGS_FD_* */
 };
 

--- a/otherlibs/unix/unixsupport.h
+++ b/otherlibs/unix/unixsupport.h
@@ -61,7 +61,6 @@ struct filedescr {
 #define Handle_val(v) (((struct filedescr *) Data_custom_val(v))->fd.handle)
 #define Socket_val(v) (((struct filedescr *) Data_custom_val(v))->fd.socket)
 #define Descr_kind_val(v) (((struct filedescr *) Data_custom_val(v))->kind)
-#define CRT_fd_val(v) (((struct filedescr *) Data_custom_val(v))->crt_fd)
 #define Flags_fd_val(v) (((struct filedescr *) Data_custom_val(v))->flags_fd)
 
 extern value caml_win32_alloc_handle(HANDLE);

--- a/otherlibs/unix/unixsupport.h
+++ b/otherlibs/unix/unixsupport.h
@@ -46,7 +46,7 @@ struct filedescr {
     SOCKET socket;
   } fd;                   /* Real windows handle */
   enum { KIND_HANDLE, KIND_SOCKET } kind;
-  int crt_fd;             /* C runtime descriptor */
+  atomic_intnat crt_fd;             /* C runtime descriptor */
   unsigned int flags_fd;  /* See FLAGS_FD_* */
 };
 
@@ -66,13 +66,23 @@ struct filedescr {
 
 extern value caml_win32_alloc_handle(HANDLE);
 extern value caml_win32_alloc_socket(SOCKET);
+
+#define NO_CRT_FD (-1)
+#define GETTING_CRT_FD (-2)
+
+/* Returns the C file descriptor associated with the handle, allocating it if
+   necessary. */
 extern int caml_win32_CRT_fd_of_filedescr(value handle);
+
+/* Returns the C file descriptor associated with the handle, or NO_CRT_FD
+   if none was allocated. The crt_fd field should only be accessed through this
+   function and not directly, to avoid race conditions with
+   win_CRT_fd_of_filedescr. */
+extern int caml_win32_get_CRT_fd(value handle);
 
 extern SOCKET caml_win32_socket(int domain, int type, int protocol,
                                 LPWSAPROTOCOL_INFO info,
                                 BOOL inherit);
-
-#define NO_CRT_FD (-1)
 
 extern void caml_win32_maperr(DWORD errcode);
 #define win32_maperr caml_win32_maperr

--- a/otherlibs/unix/unixsupport_win32.c
+++ b/otherlibs/unix/unixsupport_win32.c
@@ -55,8 +55,7 @@ value caml_win32_alloc_handle(HANDLE h)
     caml_alloc_custom(&handle_ops, sizeof(struct filedescr), 0, 1);
   Handle_val(res) = h;
   Descr_kind_val(res) = KIND_HANDLE;
-  atomic_store_explicit(&CRT_fd_val(res), (intnat)NO_CRT_FD,
-                        memory_order_relaxed);
+  CRT_fd_val(res) = NO_CRT_FD;
   Flags_fd_val(res) = FLAGS_FD_IS_BLOCKING;
   return res;
 }
@@ -67,8 +66,7 @@ value caml_win32_alloc_socket(SOCKET s)
     caml_alloc_custom(&handle_ops, sizeof(struct filedescr), 0, 1);
   Socket_val(res) = s;
   Descr_kind_val(res) = KIND_SOCKET;
-  atomic_store_explicit(&CRT_fd_val(res), (intnat)NO_CRT_FD,
-                        memory_order_relaxed);
+  CRT_fd_val(res) = NO_CRT_FD;
   Flags_fd_val(res) = FLAGS_FD_IS_BLOCKING;
   return res;
 }

--- a/otherlibs/unix/unixsupport_win32.c
+++ b/otherlibs/unix/unixsupport_win32.c
@@ -55,7 +55,7 @@ value caml_win32_alloc_handle(HANDLE h)
     caml_alloc_custom(&handle_ops, sizeof(struct filedescr), 0, 1);
   Handle_val(res) = h;
   Descr_kind_val(res) = KIND_HANDLE;
-  CRT_fd_val(res) = NO_CRT_FD;
+  ((struct filedescr *) Data_custom_val(res))->crt_fd = NO_CRT_FD;
   Flags_fd_val(res) = FLAGS_FD_IS_BLOCKING;
   return res;
 }
@@ -66,7 +66,7 @@ value caml_win32_alloc_socket(SOCKET s)
     caml_alloc_custom(&handle_ops, sizeof(struct filedescr), 0, 1);
   Socket_val(res) = s;
   Descr_kind_val(res) = KIND_SOCKET;
-  CRT_fd_val(res) = NO_CRT_FD;
+  ((struct filedescr *) Data_custom_val(res))->crt_fd = NO_CRT_FD;
   Flags_fd_val(res) = FLAGS_FD_IS_BLOCKING;
   return res;
 }

--- a/otherlibs/unix/unixsupport_win32.c
+++ b/otherlibs/unix/unixsupport_win32.c
@@ -55,7 +55,8 @@ value caml_win32_alloc_handle(HANDLE h)
     caml_alloc_custom(&handle_ops, sizeof(struct filedescr), 0, 1);
   Handle_val(res) = h;
   Descr_kind_val(res) = KIND_HANDLE;
-  CRT_fd_val(res) = NO_CRT_FD;
+  atomic_store_explicit(&CRT_fd_val(res), (intnat)NO_CRT_FD,
+                        memory_order_relaxed);
   Flags_fd_val(res) = FLAGS_FD_IS_BLOCKING;
   return res;
 }
@@ -66,7 +67,8 @@ value caml_win32_alloc_socket(SOCKET s)
     caml_alloc_custom(&handle_ops, sizeof(struct filedescr), 0, 1);
   Socket_val(res) = s;
   Descr_kind_val(res) = KIND_SOCKET;
-  CRT_fd_val(res) = NO_CRT_FD;
+  atomic_store_explicit(&CRT_fd_val(res), (intnat)NO_CRT_FD,
+                        memory_order_relaxed);
   Flags_fd_val(res) = FLAGS_FD_IS_BLOCKING;
   return res;
 }

--- a/testsuite/tests/lib-unix/win-channel-of/fd_of_channel.c
+++ b/testsuite/tests/lib-unix/win-channel-of/fd_of_channel.c
@@ -1,0 +1,8 @@
+#define CAML_INTERNALS
+#include <caml/mlvalues.h>
+#include <caml/io.h>
+
+CAMLprim value caml_fd_of_channel(value vchan)
+{
+  return Val_int(Channel(vchan)->fd);
+}

--- a/testsuite/tests/lib-unix/win-channel-of/parallel_channel_of.ml
+++ b/testsuite/tests/lib-unix/win-channel-of/parallel_channel_of.ml
@@ -1,0 +1,36 @@
+(* TEST
+modules = "fd_of_channel.c"
+* libwin32unix
+include unix
+** bytecode
+** native
+*)
+
+external fd_of_in_channel: in_channel -> int = "caml_fd_of_channel"
+
+let getfd barrier descr () =
+  while not (Atomic.get barrier) do Domain.cpu_relax() done;
+  fd_of_in_channel (Unix.in_channel_of_descr descr)
+
+let getfd_parallel descr =
+  let barrier = Atomic.make false in
+  let d1 = Domain.spawn (getfd barrier descr)
+  and d2 = Domain.spawn (getfd barrier descr) in
+  Unix.sleepf 0.05;
+  Atomic.set barrier true;
+  let fd1 = Domain.join d1
+  and fd2 = Domain.join d2 in
+  (fd1, fd2)
+
+let test () =
+  let descr = Unix.(openfile "tmp.txt" [O_RDWR; O_CREAT; O_TRUNC] 0o600) in
+  let (fd1, fd2) = getfd_parallel descr in
+  let (fd3, fd4) = getfd_parallel descr in
+  Unix.close descr;
+  Sys.remove "tmp.txt";
+  assert (fd1 = fd2);
+  assert (fd3 = fd4);
+  assert (fd3 = fd1)
+
+let _ =
+  for _i = 1 to 50 do test() done


### PR DESCRIPTION
On Windows, the function `win_CRT_fd_of_filedescr` is called by several functions of the Unix module, to wit:
- `Unix.in_channel_of_descr`
- `Unix.out_channel_of_descr`
- `Unix.fsync`
- `Unix.dup2`
- `Unix.isatty`

This function can cause races on the `crt_fd` field of the `filedescr` structure. This PR removes the data race itself by making the field atomic.

Currently not equipped with a Windows machine, I have not been able to test these changes.

## Not fixed by this PR

This PR does not change the fact that concurrent calls to to this function can call the Windows API function `_open_osfhandle` several times on the same handle (as doing so would require some form of locking). [Microsoft's documentation](https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/open-osfhandle?view=msvc-170) is unclear about the possible consequences of this (no consequences, file descriptor leaks, or error).

In addition, concurrent calls to `win_CRT_fd_of_filedescr` and `Unix.close` can still lead to fd leaks.