### PR TITLE
Make runtime_events test more robust

### DIFF
--- a/testsuite/tests/lib-runtime-events/test_caml.ml
+++ b/testsuite/tests/lib-runtime-events/test_caml.ml
@@ -25,7 +25,7 @@ let lifecycle domain_id ts lifecycle_event data =
 
 let runtime_begin domain_id ts phase =
     match phase with
-    | EV_MAJOR_SLICE ->
+    | EV_MAJOR_FINISH_CYCLE ->
         begin
             assert(!major == 0);
             major := 1
@@ -39,7 +39,7 @@ let runtime_begin domain_id ts phase =
 
 let runtime_end domain_id ts phase =
     match phase with
-    | EV_MAJOR_SLICE ->
+    | EV_MAJOR_FINISH_CYCLE ->
         begin
             assert(!major == 1);
             major := 0;
@@ -76,4 +76,4 @@ let () =
         ignore(read_poll cursor callbacks None)
     done;
     assert(!got_start);
-    Printf.printf "minors: %d, majors: %d\n" !minors !majors
+    Printf.printf "minors: %d, major cycles: %d\n" !minors !majors

--- a/testsuite/tests/lib-runtime-events/test_caml.reference
+++ b/testsuite/tests/lib-runtime-events/test_caml.reference
@@ -1,1 +1,1 @@
-minors: 18000, majors: 8000
+minors: 18000, major cycles: 6000


### PR DESCRIPTION
One of the of the runtime_events tests uses a count of major slices and as we have observed in https://github.com/ocaml/ocaml/pull/11190#issuecomment-1149448015 this ends up not being robust to changing environments.

This PR changes it from major slices to major cycles, where we are guaranteed three major cycles per `Gc.full_major`.

cc @kayceesrk @gadmm 