### PR TITLE
Consistently guard unistd.h via HAS_UNISTD

### DIFF
--- a/ocamltest/run_unix.c
+++ b/ocamltest/run_unix.c
@@ -17,12 +17,15 @@
 
 #define CAML_INTERNALS
 
+#include "caml/config.h"
 #include <stdio.h>
 #include <limits.h>
 #include <stdlib.h>
 #include <sys/types.h>
 #include <sys/wait.h>
+#ifdef HAS_UNISTD
 #include <unistd.h>
+#endif
 #include <fcntl.h>
 #include <string.h>
 #include <errno.h>

--- a/otherlibs/unix/link_unix.c
+++ b/otherlibs/unix/link_unix.c
@@ -23,7 +23,9 @@
 #include "unixsupport.h"
 
 #include <fcntl.h>
+#ifdef HAS_UNISTD
 #include <unistd.h>
+#endif
 #include <errno.h>
 
 CAMLprim value unix_link(value follow, value path1, value path2)

--- a/otherlibs/unix/select_unix.c
+++ b/otherlibs/unix/select_unix.c
@@ -28,7 +28,9 @@
 #include <sys/select.h>
 #endif
 #include <string.h>
+#ifdef HAS_UNISTD
 #include <unistd.h>
+#endif
 #include <errno.h>
 
 static int fdlist_to_fdset(value fdlist, fd_set *fdset, int *maxfd)

--- a/runtime/afl.c
+++ b/runtime/afl.c
@@ -38,7 +38,9 @@ CAMLexport value caml_setup_afl(value unit)
 
 #else
 
+#ifdef HAS_UNISTD
 #include <unistd.h>
+#endif
 #include <sys/types.h>
 #include <signal.h>
 #include <sys/shm.h>

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -18,8 +18,11 @@
 
 #define CAML_INTERNALS
 
+#include "caml/config.h"
 #include <stdio.h>
+#ifdef HAS_UNISTD
 #include <unistd.h>
+#endif
 #include <pthread.h>
 #include <string.h>
 #include "caml/alloc.h"

--- a/runtime/fiber.c
+++ b/runtime/fiber.c
@@ -18,8 +18,11 @@
 
 #define CAML_INTERNALS
 
+#include "caml/config.h"
 #include <string.h>
+#ifdef HAS_UNISTD
 #include <unistd.h>
+#endif
 #include "caml/alloc.h"
 #include "caml/codefrag.h"
 #include "caml/fail.h"

--- a/runtime/platform.c
+++ b/runtime/platform.c
@@ -15,8 +15,11 @@
 /**************************************************************************/
 #define CAML_INTERNALS
 
+#include "caml/config.h"
 #include <string.h>
+#ifdef HAS_UNISTD
 #include <unistd.h>
+#endif
 #include <errno.h>
 #include <sys/time.h>
 #include "caml/platform.h"

--- a/testsuite/tests/lib-unix/common/fdstatus_aux.c
+++ b/testsuite/tests/lib-unix/common/fdstatus_aux.c
@@ -32,12 +32,15 @@ void process_fd(const char * s)
 
 #else
 
+#include "caml/config.h"
 #include <limits.h>
 #include <string.h>
 #include <errno.h>
 #include <sys/types.h>
 #include <sys/stat.h>
+#ifdef HAS_UNISTD
 #include <unistd.h>
+#endif
 
 void process_fd(const char * s)
 {


### PR DESCRIPTION
This is missing in some spots, no functional changes.