### PR TITLE
Implement quality treatment for asynchronous actions in multicore (3/3?)

### DIFF
--- a/Changes
+++ b/Changes
@@ -109,6 +109,16 @@ Working version
   (Stephen Dolan, report by Chris Casinghino, review by Jeremy Yallop
    and Xavier Leroy)
 
+- #11307: Finish adapting the implementation of asynchronous actions for
+  multicore: soundness, liveness, and performance issues.
+  Do not crash if a signal handler is  called from an unregistered C
+  thread, and other possible soundness issues. Prevent issues where join
+  on other domains could make the toplevel unresponsible to Ctrl-C. Avoid
+  needless repeated polling in C code when callbacks cannot run
+  immediately.
+  (Guillaume Munch-Maccagnoni, review by Enguerrand Decorne, Xavier
+  Leroy, and KC Sivaramakrishnan)
+
 ### Code generation and optimizations:
 
 - #11239: on x86-64 and RISC-V, reduce alignment of OCaml stacks from 16 to 8.

--- a/otherlibs/systhreads/st_stubs.c
+++ b/otherlibs/systhreads/st_stubs.c
@@ -757,7 +757,7 @@ CAMLprim value caml_thread_yield(value unit)
   save_runtime_state();
   st_thread_yield(m);
   restore_runtime_state(This_thread);
-  if (Caml_state->action_pending || caml_check_pending_signals())
+  if (caml_check_pending_signals())
     caml_set_action_pending(Caml_state);
 
   return Val_unit;

--- a/otherlibs/systhreads/st_stubs.c
+++ b/otherlibs/systhreads/st_stubs.c
@@ -95,10 +95,6 @@ struct caml_thread_struct {
   struct caml_exception_context* external_raise;
     /* saved value of Caml_state->external_raise */
 #endif
-
-#ifdef POSIX_SIGNALS
-  sigset_t init_mask;
-#endif
 };
 
 typedef struct caml_thread_struct* caml_thread_t;
@@ -575,12 +571,6 @@ static void * caml_thread_start(void * v)
   restore_runtime_state(th);
   signal_stack = caml_init_signal_stack();
 
-#ifdef POSIX_SIGNALS
-  /* restore the signal mask from the spawning thread, now it is safe for the
-     signal handler to run (as Caml_state is initialised) */
-  pthread_sigmask(SIG_SETMASK, &th->init_mask, NULL);
-#endif
-
   clos = Start_closure(Active_thread->descr);
   caml_modify(&(Start_closure(Active_thread->descr)), Val_unit);
   caml_callback_exn(clos, Val_unit);
@@ -595,8 +585,8 @@ static int create_tick_thread(void)
 #ifdef POSIX_SIGNALS
   sigset_t mask, old_mask;
 
-  /* Block all signals so that we don't try to execute an OCaml signal
-     handler in the new tick thread */
+  /* Block all signals, so that we do not try to execute a C signal
+     handler in the new tick thread. */
   sigfillset(&mask);
   pthread_sigmask(SIG_BLOCK, &mask, &old_mask);
 #endif
@@ -630,12 +620,6 @@ CAMLprim value caml_thread_new(value clos)
     Tick_thread_running = 1;
   }
 
-#ifdef POSIX_SIGNALS
-  sigset_t mask, old_mask;
-
-  sigfillset(&mask);
-  pthread_sigmask(SIG_BLOCK, &mask, &old_mask);
-#endif
 
   /* Create a thread info block */
   caml_thread_t th = caml_thread_new_info();
@@ -645,10 +629,6 @@ CAMLprim value caml_thread_new(value clos)
 
   th->descr = caml_thread_new_descriptor(clos);
 
-#ifdef POSIX_SIGNALS
-  th->init_mask = old_mask;
-#endif
-
   th->next = Active_thread->next;
   th->prev = Active_thread;
 
@@ -656,11 +636,6 @@ CAMLprim value caml_thread_new(value clos)
   Active_thread->next = th;
 
   err = st_thread_create(NULL, caml_thread_start, (void *) th);
-
-#ifdef POSIX_SIGNALS
-  /* regardless of error, return our sigmask to the original state */
-  pthread_sigmask(SIG_SETMASK, &old_mask, NULL);
-#endif
 
   if (err != 0) {
     /* Creation failed, remove thread info block from list of threads */

--- a/runtime/amd64.S
+++ b/runtime/amd64.S
@@ -684,6 +684,31 @@ ENDFUNCTION(G(caml_allocN))
 /* Call a C function from OCaml */
 /******************************************************************************/
 
+/* Update [young_limit] when returning from non-noalloc extern calls.
+   Here is C code that can be used to generate RET_FROM_C_CALL for a
+   new back-end.
+
+     #include <stdatomic.h>
+     #include <stdint.h>
+
+     typedef struct { _Atomic(uint64_t) young_limit;
+                      _Bool action_pending; } caml_domain_state;
+
+     void ret_from_c_call(caml_domain_state *dom_st)
+     {
+       if (__builtin_expect(dom_st->action_pending, 0))
+         atomic_store_explicit(&dom_st->young_limit, (uint64_t)-1,
+                               memory_order_relaxed);
+     }
+
+*/
+#define RET_FROM_C_CALL                         \
+        cmpb    $0, Caml_state(action_pending); \
+        jne     1f;                             \
+        ret;                                    \
+1:      movq    $-1, Caml_state(young_limit);   \
+        ret
+
 FUNCTION(G(caml_c_call))
 CFI_STARTPROC
         CFI_SIGNAL_FRAME
@@ -716,7 +741,7 @@ LBL(caml_c_call):
 #endif
         LEAVE_FUNCTION
     /* Return to OCaml caller */
-        ret
+        RET_FROM_C_CALL
 CFI_ENDPROC
 ENDFUNCTION(G(caml_c_call))
 
@@ -764,7 +789,7 @@ LBL(106):
         SWITCH_C_TO_OCAML
     /* Return to OCaml caller */
         LEAVE_FUNCTION
-        ret
+        RET_FROM_C_CALL
 CFI_ENDPROC
 ENDFUNCTION(G(caml_c_call_stack_args))
 

--- a/runtime/arm64.S
+++ b/runtime/arm64.S
@@ -417,6 +417,15 @@ FUNCTION(caml_allocN)
 /* Call a C function from OCaml */
 /* Function to call is in ADDITIONAL_ARG */
 
+.macro RET_FROM_C_CALL
+        ldrb    w16, Caml_state(action_pending)
+        cbnz    w16, 1f
+        ret
+1:      mov     TMP, #-1
+        str     TMP, Caml_state(young_limit)
+        ret
+.endm
+
 FUNCTION(caml_c_call)
         CFI_STARTPROC
         CFI_OFFSET(29, -16)
@@ -437,9 +446,9 @@ FUNCTION(caml_c_call)
         SWITCH_C_TO_OCAML
     /* Return */
         ldp     x29, x30, [sp], 16
-        ret
+        RET_FROM_C_CALL
         CFI_ENDPROC
-        END_FUNCTION(caml_c_call)
+END_FUNCTION(caml_c_call)
 
 FUNCTION(caml_c_call_stack_args)
         CFI_STARTPROC
@@ -478,8 +487,9 @@ FUNCTION(caml_c_call_stack_args)
         SWITCH_C_TO_OCAML
     /* Return */
         ldp     x29, x30, [sp], 16
-        ret
-CFI_ENDPROC
+        RET_FROM_C_CALL
+        CFI_ENDPROC
+END_FUNCTION(caml_c_call_stack_args)
 
 /* Start the OCaml program */
 

--- a/runtime/callback.c
+++ b/runtime/callback.c
@@ -122,6 +122,7 @@ CAMLexport value caml_callbackN_exn(value closure, int narg, value args[])
      However, they are never used afterwards,
      as they were copied into the root [domain_state->current_stack]. */
 
+  caml_update_young_limit_after_c_call(domain_state);
   res = caml_interprete(callback_code, sizeof(callback_code));
   if (Is_exception_result(res))
     domain_state->current_stack->sp += narg + 4; /* PR#3419 */
@@ -187,6 +188,7 @@ CAMLexport value caml_callback_exn(value closure, value arg)
     End_roots();
 
     Begin_roots1(cont);
+    caml_update_young_limit_after_c_call(domain_state);
     res = caml_callback_asm(domain_state, closure, &arg);
     End_roots();
 
@@ -194,6 +196,7 @@ CAMLexport value caml_callback_exn(value closure, value arg)
 
     return res;
   } else {
+    caml_update_young_limit_after_c_call(domain_state);
     return caml_callback_asm(domain_state, closure, &arg);
   }
 }
@@ -214,6 +217,7 @@ CAMLexport value caml_callback2_exn(value closure, value arg1, value arg2)
 
     Begin_roots1(cont);
     value args[] = {arg1, arg2};
+    caml_update_young_limit_after_c_call(domain_state);
     res = caml_callback2_asm(domain_state, closure, args);
     End_roots();
 
@@ -222,6 +226,7 @@ CAMLexport value caml_callback2_exn(value closure, value arg1, value arg2)
     return res;
   } else {
     value args[] = {arg1, arg2};
+    caml_update_young_limit_after_c_call(domain_state);
     return caml_callback2_asm(domain_state, closure, args);
   }
 }
@@ -243,6 +248,7 @@ CAMLexport value caml_callback3_exn(value closure,
 
     Begin_root(cont);
     value args[] = {arg1, arg2, arg3};
+    caml_update_young_limit_after_c_call(domain_state);
     res = caml_callback3_asm(domain_state, closure, args);
     End_roots();
 
@@ -251,6 +257,7 @@ CAMLexport value caml_callback3_exn(value closure,
     return res;
   } else {
     value args[] = {arg1, arg2, arg3};
+    caml_update_young_limit_after_c_call(domain_state);
     return caml_callback3_asm(domain_state, closure, args);
   }
 }

--- a/runtime/caml/domain.h
+++ b/runtime/caml/domain.h
@@ -66,6 +66,7 @@ void caml_handle_gc_interrupt(void);
 void caml_handle_incoming_interrupts(void);
 
 CAMLextern void caml_interrupt_self(void);
+void caml_interrupt_all_for_signal(void);
 void caml_reset_young_limit(caml_domain_state *);
 
 CAMLextern void caml_reset_domain_lock(void);

--- a/runtime/caml/domain.h
+++ b/runtime/caml/domain.h
@@ -68,6 +68,7 @@ void caml_handle_incoming_interrupts(void);
 CAMLextern void caml_interrupt_self(void);
 void caml_interrupt_all_for_signal(void);
 void caml_reset_young_limit(caml_domain_state *);
+void caml_update_young_limit_after_c_call(caml_domain_state *);
 
 CAMLextern void caml_reset_domain_lock(void);
 CAMLextern int caml_bt_is_in_blocking_section(void);

--- a/runtime/caml/domain_state.tbl
+++ b/runtime/caml/domain_state.tbl
@@ -37,7 +37,7 @@ DOMAIN_STATE(struct stack_info*, current_stack)
 DOMAIN_STATE(void*, exn_handler)
 /* Pointer into the current stack */
 
-DOMAIN_STATE(int, action_pending)
+DOMAIN_STATE(_Bool, action_pending)
 /* Whether we are due to start the processing of delayable pending
    actions. See runtime/signal.c. */
 

--- a/runtime/caml/signals.h
+++ b/runtime/caml/signals.h
@@ -60,7 +60,7 @@ CAMLextern atomic_uintnat caml_pending_signals[NSIG_WORDS];
 #define caml_requested_major_slice (Caml_state_field(requested_major_slice))
 #define caml_requested_minor_gc (Caml_state_field(requested_minor_gc))
 
-int caml_check_pending_signals(void);
+CAMLextern int caml_check_pending_signals(void);
 void caml_request_major_slice (int global);
 void caml_request_minor_gc (void);
 CAMLextern int caml_convert_signal_number (int);
@@ -68,7 +68,7 @@ CAMLextern int caml_rev_convert_signal_number (int);
 value caml_execute_signal_exn(int signal_number, int in_signal_handler);
 CAMLextern void caml_record_signal(int signal_number);
 CAMLextern value caml_process_pending_signals_exn(void);
-void caml_set_action_pending(caml_domain_state *);
+CAMLextern void caml_set_action_pending(caml_domain_state *);
 value caml_do_pending_actions_exn(void);
 value caml_process_pending_actions_with_root (value extra_root); // raises
 value caml_process_pending_actions_with_root_exn (value extra_root);

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -954,10 +954,6 @@ struct domain_startup_params {
   struct domain_ml_values* ml_values; /* in */
   dom_internal* newdom; /* out */
   uintnat unique_id; /* out */
-#ifndef _WIN32
-  /* signal mask to set after it is safe to do so */
-  sigset_t* mask; /* in */
-#endif
 };
 
 static void* backup_thread_func(void* v)
@@ -1129,11 +1125,9 @@ static void* domain_thread_func(void* v)
 {
   struct domain_startup_params* p = v;
   struct domain_ml_values *ml_values = p->ml_values;
-#ifndef _WIN32
-  sigset_t mask = *(p->mask);
-  void * signal_stack;
 
-  signal_stack = caml_init_signal_stack();
+#ifndef _WIN32
+  void * signal_stack = caml_init_signal_stack();
   if (signal_stack == NULL) {
     caml_fatal_error("Failed to create domain: signal stack");
   }
@@ -1157,11 +1151,6 @@ static void* domain_thread_func(void* v)
 
   if (domain_self) {
     install_backup_thread(domain_self);
-
-#ifndef _WIN32
-    /* It is now safe for us to handle signals */
-    pthread_sigmask(SIG_SETMASK, &mask, NULL);
-#endif
 
     caml_gc_log("Domain starting (unique_id = %"ARCH_INTNAT_PRINTF_FORMAT"u)",
                 domain_self->interruptor.unique_id);
@@ -1211,9 +1200,6 @@ CAMLprim value caml_domain_spawn(value callback, value term_sync)
   struct domain_startup_params p;
   pthread_t th;
   int err;
-#ifndef _WIN32
-  sigset_t mask, old_mask;
-#endif
 
 #ifndef NATIVE_CODE
   if (caml_debugger_in_use)
@@ -1227,20 +1213,7 @@ CAMLprim value caml_domain_spawn(value callback, value term_sync)
                                     sizeof(struct domain_ml_values));
   init_domain_ml_values(p.ml_values, callback, term_sync);
 
-/* We block all signals while we spawn the new domain. This is because
-   pthread_create inherits the current signals set, and we want to avoid a
-   signal handler being triggered in the new domain before the domain_state is
-   fully populated. */
-#ifndef _WIN32
-  sigfillset(&mask);
-  pthread_sigmask(SIG_BLOCK, &mask, &old_mask);
-  p.mask = &old_mask;
-#endif
   err = pthread_create(&th, 0, domain_thread_func, (void*)&p);
-#ifndef _WIN32
-  /* We can restore the signal mask we had initially now. */
-  pthread_sigmask(SIG_SETMASK, &old_mask, NULL);
-#endif
 
   if (err) {
     caml_failwith("failed to create domain thread");

--- a/runtime/interp.c
+++ b/runtime/interp.c
@@ -91,7 +91,9 @@ sp is a local copy of the global variable Caml_state->extern_sp. */
   { sp -= 2; sp[0] = env; sp[1] = (value)(pc + 1); \
     domain_state->current_stack->sp = sp; }
 #define Restore_after_c_call \
-  { sp = domain_state->current_stack->sp; env = *sp; sp += 2; }
+  { sp = domain_state->current_stack->sp; env = *sp; sp += 2; \
+    caml_update_young_limit_after_c_call(domain_state);       \
+  }
 
 /* For VM threads purposes, an event frame must look like accu + a
    C_CALL frame + a RETURN 1 frame.

--- a/runtime/minor_gc.c
+++ b/runtime/minor_gc.c
@@ -822,13 +822,6 @@ void caml_alloc_small_dispatch (caml_domain_state * dom_st,
       /* In the case of allocations performed from C, only perform
          non-delayable actions. */
       caml_handle_gc_interrupt();
-      /* We might be here due to a recently-recorded signal, so we
-         need to remember that we must run signal handlers. In
-         addition, in the case of long-running C code that regularly
-         polls with caml_process_pending_actions, we want to force a
-         query of all callbacks at every minor collection or major
-         slice (similarly to OCaml behaviour). */
-      caml_set_action_pending(dom_st);
     }
 
     /* Now, there might be enough room in the minor heap to do our

--- a/runtime/minor_gc.c
+++ b/runtime/minor_gc.c
@@ -819,6 +819,8 @@ void caml_alloc_small_dispatch (caml_domain_state * dom_st,
          asynchronous callbacks. */
       caml_raise_if_exception(caml_do_pending_actions_exn());
     else {
+      /* In the case of allocations performed from C, only perform
+         non-delayable actions. */
       caml_handle_gc_interrupt();
       /* We might be here due to a recently-recorded signal, so we
          need to remember that we must run signal handlers. In
@@ -826,7 +828,7 @@ void caml_alloc_small_dispatch (caml_domain_state * dom_st,
          polls with caml_process_pending_actions, we want to force a
          query of all callbacks at every minor collection or major
          slice (similarly to OCaml behaviour). */
-      dom_st->action_pending = 1;
+      caml_set_action_pending(dom_st);
     }
 
     /* Now, there might be enough room in the minor heap to do our

--- a/runtime/minor_gc.c
+++ b/runtime/minor_gc.c
@@ -820,9 +820,12 @@ void caml_alloc_small_dispatch (caml_domain_state * dom_st,
       caml_raise_if_exception(caml_do_pending_actions_exn());
     else {
       caml_handle_gc_interrupt();
-      /* In the case of long-running C code that regularly polls with
-         [caml_process_pending_actions], still force a query of all
-         callbacks at every minor collection or major slice. */
+      /* We might be here due to a recently-recorded signal, so we
+         need to remember that we must run signal handlers. In
+         addition, in the case of long-running C code that regularly
+         polls with caml_process_pending_actions, we want to force a
+         query of all callbacks at every minor collection or major
+         slice (similarly to OCaml behaviour). */
       dom_st->action_pending = 1;
     }
 

--- a/runtime/power.S
+++ b/runtime/power.S
@@ -291,7 +291,7 @@ ENDFUNCTION caml_call_gc
 .macro RET_FROM_C_CALL
         lbz     TMP, Caml_state(action_pending)
         cmplwi  TMP, 0
-        beqlr   0
+        beqlr+  0
         li      TMP, -1
         std     TMP, Caml_state(young_limit)
         blr

--- a/runtime/power.S
+++ b/runtime/power.S
@@ -288,6 +288,15 @@ ENDFUNCTION caml_call_gc
 
 /* Call a C function from OCaml.  Function to call is in C_CALL_FUN */
 
+.macro RET_FROM_C_CALL
+        lbz     TMP, Caml_state(action_pending)
+        cmplwi  TMP, 0
+        beqlr   0
+        li      TMP, -1
+        std     TMP, Caml_state(young_limit)
+        blr
+.endm
+
 FUNCTION caml_c_call
 .Lcaml_c_call:
    /* Save return address in caller's frame AND in a callee-save register */
@@ -311,7 +320,7 @@ FUNCTION caml_c_call
     /* Switch from C to OCaml */
         SWITCH_C_TO_OCAML
     /* Return to caller */
-        blr
+        RET_FROM_C_CALL
 ENDFUNCTION caml_c_call
 
 FUNCTION caml_c_call_stack_args
@@ -351,7 +360,7 @@ FUNCTION caml_c_call_stack_args
     /* Switch from C to OCaml */
         SWITCH_C_TO_OCAML
     /* Return to caller */
-        blr
+        RET_FROM_C_CALL
 ENDFUNCTION caml_c_call_stack_args
 
 /* Raise an exception from OCaml */

--- a/runtime/riscv.S
+++ b/runtime/riscv.S
@@ -336,6 +336,15 @@ END_FUNCTION(caml_allocN)
 /* Call a C function from OCaml */
 /* Function to call is in ADDITIONAL_ARG */
 
+.macro RET_FROM_C_CALL
+        lbu     TMP, Caml_state(action_pending)
+        bnez    TMP, 1f
+        ret
+1:      li      TMP, -1
+        sd      TMP, Caml_state(young_limit)
+        ret
+.endm
+
 FUNCTION(caml_c_call)
 L(caml_c_call):
         CFI_OFFSET(ra, -8)
@@ -356,7 +365,7 @@ L(caml_c_call):
     /* Return */
         ld      ra, 8(sp)
         addi    sp, sp, 16
-        ret
+        RET_FROM_C_CALL
 END_FUNCTION(caml_c_call)
 
 FUNCTION(caml_c_call_stack_args)
@@ -398,7 +407,7 @@ FUNCTION(caml_c_call_stack_args)
     /* Return */
         ld      ra, 8(sp)
         addi    sp, sp, 16
-        ret
+        RET_FROM_C_CALL
 END_FUNCTION(caml_c_call_stack_args)
 
 /* Start the OCaml program */

--- a/runtime/s390x.S
+++ b/runtime/s390x.S
@@ -385,6 +385,13 @@ ENDFUNCTION(G(caml_allocN))
 /* Call a C function from OCaml */
 /******************************************************************************/
 
+#define RET_FROM_C_CALL                           \
+        cli     Caml_state(action_pending), 0;    \
+        ber     %r14;                             \
+        lghi    TMP, -1;                          \
+        stg     TMP, Caml_state(young_limit);     \
+        br      %r14
+
 FUNCTION(G(caml_c_call))
 CFI_STARTPROC
         CFI_SIGNAL_FRAME
@@ -418,7 +425,7 @@ LBL(caml_c_call):
         lg      %r14, 0(%r15)
         CFI_RESTORE(14)
         la      %r15, 8(%r15)
-        br      %r14
+        RET_FROM_C_CALL
 CFI_ENDPROC
 ENDFUNCTION(G(caml_c_call))
 
@@ -471,7 +478,7 @@ LBL(106):
         lg      %r14, 0(%r15)
         CFI_RESTORE(14)
         la      %r15, 8(%r15)
-        br      %r14
+        RET_FROM_C_CALL
 CFI_ENDPROC
 ENDFUNCTION(G(caml_c_call_stack_args))
 

--- a/runtime/signals.c
+++ b/runtime/signals.c
@@ -45,7 +45,7 @@ CAMLexport atomic_uintnat caml_pending_signals[NSIG_WORDS];
 
 static caml_plat_mutex signal_install_mutex = CAML_PLAT_MUTEX_INITIALIZER;
 
-int caml_check_pending_signals(void)
+CAMLexport int caml_check_pending_signals(void)
 {
   int i;
   for (i = 0; i < NSIG_WORDS; i++) {
@@ -300,7 +300,7 @@ void caml_request_minor_gc (void)
 */
 
 /* We assume that we have unique access to dom_st. */
-void caml_set_action_pending(caml_domain_state * dom_st)
+CAMLexport void caml_set_action_pending(caml_domain_state * dom_st)
 {
   dom_st->action_pending = 1;
   atomic_store_release(&dom_st->young_limit, (uintnat)-1);

--- a/runtime/signals.c
+++ b/runtime/signals.c
@@ -306,7 +306,8 @@ void caml_request_minor_gc (void)
    [caml_process_pending_actions], [caml_leave_blocking_section], or
    it returns to OCaml. When returning to OCaml, we set again
    [Caml_state->young_limit] to a high value if
-   [Caml_state->action_pending] is set.
+   [Caml_state->action_pending] is set, to execute asynchronous
+   actions as soon as possible when back in OCaml code.
 
    [Caml_state->action_pending] is then reset _at the beginning_ of
    processing all actions. Hence, when a delayable action is pending,

--- a/stdlib/sys.mli
+++ b/stdlib/sys.mli
@@ -331,7 +331,7 @@ val sigxfsz : int
 
 exception Break
 (** Exception raised on interactive interrupt if {!Sys.catch_break}
-   is on. *)
+   is enabled. *)
 
 
 val catch_break : bool -> unit
@@ -339,7 +339,13 @@ val catch_break : bool -> unit
    terminates the program or raises the [Break] exception.
    Call [catch_break true] to enable raising [Break],
    and [catch_break false] to let the system
-   terminate the program on user interrupt. *)
+   terminate the program on user interrupt.
+
+   Inside multi-threaded programs, the [Break] exception will arise in
+   any one of the active threads, and will keep arising on further
+   interactive interrupt until all threads are terminated. Use
+   signal masks from [Thread.sigmask] to direct the interrupt towards a
+   specific thread. *)
 
 
 val ocaml_version : string

--- a/testsuite/tests/c-api/alloc_async.ml
+++ b/testsuite/tests/c-api/alloc_async.ml
@@ -1,19 +1,26 @@
 (* TEST
  modules = "alloc_async_stubs.c";
- reason = "alloc async changes: https://github.com/ocaml/ocaml/pull/8897";
- skip;
 *)
 
 external test : int ref -> unit = "stub"
+external print_status : string -> int -> unit = "print_status_caml" [@@noalloc]
+
+(* This tests checks that the finaliser does not run during various
+   allocations from C, but runs at the first polling location in OCaml
+   code after that.
+
+   See in particular RET_FROM_C_CALL from runtime/amd64.S.
+
+*)
 
 let f () =
   let r = ref 42 in
   Gc.finalise (fun s -> r := !s) (ref 17);
-  Printf.printf "OCaml, before: %d\n%!" !r;
+  print_status "OCaml, before" !r;
   test r;
-  Printf.printf "OCaml, after: %d\n%!" !r;
+  print_status "OCaml, after" !r;
   ignore (Sys.opaque_identity (ref 100));
-  Printf.printf "OCaml, after alloc: %d\n%!" !r;
+  print_status "OCaml, after alloc" !r;
   ()
 
 let () = (f [@inlined never]) ()

--- a/testsuite/tests/c-api/alloc_async.ml
+++ b/testsuite/tests/c-api/alloc_async.ml
@@ -7,11 +7,10 @@ external print_status : string -> int -> unit = "print_status_caml" [@@noalloc]
 
 (* This tests checks that the finaliser does not run during various
    allocations from C, but runs at the first polling location in OCaml
-   code after that.
-
-   See in particular RET_FROM_C_CALL from runtime/amd64.S.
-
-*)
+   code after that. For native backends, something like
+   RET_FROM_C_CALL from runtime/amd64.S is necessary, see its
+   description there and the documentation of
+   [Caml_state->action_pending] in runtime.signals.c. *)
 
 let f () =
   let r = ref 42 in

--- a/testsuite/tests/c-api/alloc_async_stubs.c
+++ b/testsuite/tests/c-api/alloc_async_stubs.c
@@ -5,6 +5,19 @@
 #define CAML_INTERNALS
 #include "caml/gc_ctrl.h"
 
+
+void print_status(const char *str, int n)
+{
+  printf("%s: %d\n", str, n);
+  fflush(stdout);
+}
+
+value print_status_caml(value str, value n)
+{
+  print_status(String_val(str), Int_val(n));
+  return Val_unit;
+}
+
 const char* strs[] = { "foo", "bar", 0 };
 value stub(value ref)
 {
@@ -12,7 +25,7 @@ value stub(value ref)
   CAMLlocal2(x, y);
   char* s; intnat coll_before;
 
-  printf("C, before: %d\n", Int_val(Field(ref, 0)));
+  print_status("C, before", Int_val(Field(ref, 0)));
 
   /* First, do enough major allocations to do a full major collection cycle */
   coll_before = caml_stat_major_collections;
@@ -50,7 +63,6 @@ value stub(value ref)
   free(s);
 
 
-  printf("C, after: %d\n", Int_val(Field(ref, 0)));
-  fflush(stdout);
+  print_status("C, after", Int_val(Field(ref, 0)));
   CAMLreturn (Val_unit);
 }

--- a/testsuite/tests/parallel/catch_break.ml
+++ b/testsuite/tests/parallel/catch_break.ml
@@ -1,0 +1,65 @@
+(* TEST
+hassysthreads;
+include systhreads;
+not-windows;
+{
+  bytecode;
+}{
+  native;
+}
+*)
+
+let verbose = false
+
+(* Expected when verbose (depending on scheduling and platform):
+
+[Sys.Break caught]
+Domain 1
+[Sys.Break caught]
+Domain 0 - 1
+[Sys.Break caught]
+Domain 0 - 2
+Success.
+
+*)
+
+let print = if verbose then print_endline else fun _ -> ()
+
+let break_trap s =
+  begin
+    try while true do () done
+    with Sys.Break -> print "[Sys.Break caught]";
+  end;
+  print s
+
+let run () =
+  (* Goal: joining the domain [d] must be achievable by Ctrl-C *)
+  let d = Domain.spawn (fun () -> break_trap "Domain 1")
+  in
+  let finished = ref false in
+  (* Simulate repeated Ctrl-C *)
+  let d2 = Domain.spawn (fun () ->
+    ignore (Thread.sigmask Unix.SIG_BLOCK [Sys.sigint]);
+    let pid = Unix.getpid () in
+    let rec kill n =
+      if n = 0 then (
+        print "[Kill thread reached max attempts without succeeding]";
+        Unix._exit 1
+      );
+      Unix.sleepf 0.05;
+      Unix.kill pid Sys.sigint;
+      if not !finished then kill (n - 1)
+    in
+    kill 10)
+  in
+  break_trap "Domain 0 - 1";
+  Domain.join d;
+  break_trap "Domain 0 - 2";
+  finished := true;
+  Domain.join d2
+
+let () =
+  Sys.catch_break true;
+  (try run () with Sys.Break -> ());
+  (try print "Success." with Sys.Break -> ());
+  exit 0


### PR DESCRIPTION
Here is for your consideration a simplification of the remaining commits at #11057 (after #11095 and #11190).

This PR includes various fixes for soundness and performance of async actions.

In particular there is a bug whereby `caml_enter_blocking_section` can loop waiting for another domain to process its signals (since `caml_check_pending_signals` is shared between all domains). The PR #11057 proposed two different ways to fix this:
- One was to introduce a distinction between "external" and "internal" interrupts (https://github.com/ocaml/ocaml/pull/11057/commits/4fbd1225ec at #11057). (_External Interrupts_)
- One is to delay the setting of `young_limit` in case action are pending until one returns to OCaml code (this PR, https://github.com/ocaml/ocaml/pull/11307/commits/93dd8f28db). (_Optimal Polling_)

Optimal Polling fixes more things than External Interrupts, and while the resulting implementation is simpler to understand, it is more invasive (e.g. changes to `.S` files). So I originally intended it for a part 4/4 of this PR series not needed for 5.0.

While rebasing this PR, I realised that the simplifications Optimal Polling brought were greater than thought (also, there might be a bug in the current implementation of External Interrupts, so I would have to look at it again). So I decided in a first time to skip the External Interrupts design, so that you do not have to review two separate designs (where the second one undoes the changes of the first one), and go directly for the "nice" design. (For explanations of the "nice" design, see the lengthy documentation comments and commit logs.)

If you prefer starting with External Interrupts first, then we can delay the review of Optimal Polling until 5.1. If you like the Optimal Polling approach, then I will write a test to ensure that any future architecture implements the necessary code when returning from C to OCaml.

Commit logs have been updated to reflect previous discussions (cc @xavierleroy).

The commits are best reviewed separately. In case of the "Optimal Polling" commit, looking at the resulting implementation (and checking that it matches the description in the comments) might make more sense than looking only at the diff.

(cc @sadiqj, @gasche, @kayceesrk.)