### PR TITLE
Add an environment variable to preserve runtime events after exit

### DIFF
--- a/Changes
+++ b/Changes
@@ -29,6 +29,12 @@ OCaml 5.0
 ### Language features:
 
 ### Runtime system:
+- #11308: Add environment variable to preserve runtime_events after exit
+  If the environment variable OCAML_RUNTIME_EVENTS_PRESERVE exists then the
+  runtime will not remove the runtime events ring buffers at exit. This
+  makes tracing very short running programs more reliable.
+  (Sadiq Jaffer, review by KC Sivaramakrishnan)
+
 - #10964: Ring-buffer based runtime tracing (runtime_events)
   Runtime_events is a very low overhead runtime tracing system designed for
   continuous monitoring of OCaml applications.

--- a/runtime/runtime_events.c
+++ b/runtime/runtime_events.c
@@ -100,6 +100,13 @@ static HANDLE ring_handle;
    caml_runtime_events_init */
 static int ring_size_words;
 
+/* This is set if the OCAML_RUNTIME_EVENTS_PRESERVE environment
+  variable is present and determines whether the ring buffer is
+  cleaned up on program exit or not. It may be preserved to allow
+  tooling to analyse very short running programs where there would
+  be a race to read their ring buffers. */
+static int preserve_ring = 0;
+
 static atomic_uintnat runtime_events_enabled = 0;
 static atomic_uintnat runtime_events_paused = 0;
 
@@ -113,6 +120,9 @@ void caml_runtime_events_init() {
   runtime_events_path = caml_secure_getenv(T("OCAML_RUNTIME_EVENTS_DIR"));
 
   ring_size_words = 1 << caml_params->runtime_events_log_wsize;
+
+  preserve_ring =
+            caml_secure_getenv(T("OCAML_RUNTIME_EVENTS_PRESERVE")) ? 1 : 0;
 
   if (caml_secure_getenv(T("OCAML_RUNTIME_EVENTS_START"))) {
     /* since [caml_runtime_events_init] can only be called from the startup code
@@ -198,8 +208,9 @@ void caml_runtime_events_destroy() {
   if (atomic_load_acq(&runtime_events_enabled)) {
     write_to_ring(EV_RUNTIME, EV_LIFECYCLE, EV_RING_STOP, 0, NULL, 0);
 
-    /* clean up runtime_events when we exit. */
-    int remove_file = 1;
+    /* clean up runtime_events when we exit if we haven't been instructed to
+      preserve the file. */
+    int remove_file = preserve_ring ? 0 : 1;
     do {
       caml_try_run_on_all_domains(&stw_teardown_runtime_events,
                                   &remove_file, NULL);

--- a/testsuite/tests/lib-runtime-events/test_external_preserve.ml
+++ b/testsuite/tests/lib-runtime-events/test_external_preserve.ml
@@ -1,0 +1,29 @@
+(* TEST
+  include runtime_events
+  include unix
+  set OCAML_RUNTIME_EVENTS_PRESERVE = "1"
+  * libunix
+  ** bytecode
+  ** native *)
+
+  (* this tests the preservation of ring buffers after termination *)
+
+  let () =
+    (* start runtime_events now to avoid a race *)
+    let parent_cwd = Sys.getcwd () in
+    let child_pid = Unix.fork () in
+    if child_pid == 0 then begin
+      (* we are in the child, so start Runtime_events *)
+      Runtime_events.start ();
+      (* this creates a ring buffer. Now exit. *)
+    end else begin
+      (* now wait for our child to finish *)
+      Unix.wait () |> ignore;
+      (* child has finished. Is the file there? *)
+      let cursor =
+          Runtime_events.create_cursor (Some (parent_cwd, child_pid)) in
+      Runtime_events.free_cursor cursor;
+      let ring_file =
+          Filename.concat parent_cwd (string_of_int child_pid ^ ".events") in
+      Unix.unlink ring_file
+    end


### PR DESCRIPTION
When tracing very short running programs (as we do in sandmark microbenchmarks) it's possible to race the child process and have the runtime events ring buffers deleted before we have time to open them.

This is a small change that adds an environment variable which prevents the runtime removing the ring buffers when exiting.
