### PR TITLE
Add Int.clz function

### DIFF
--- a/asmcomp/amd64/CSE.ml
+++ b/asmcomp/amd64/CSE.ml
@@ -32,7 +32,7 @@ method! class_of_operation op =
     | Istore_int(_, _, is_asg) -> Op_store is_asg
     | Ioffset_loc(_, _) -> Op_store true
     | Ifloatarithmem _ | Ifloatsqrtf _ -> Op_load Mutable
-    | Ibswap _ | Isqrtf -> super#class_of_operation op
+    | Ibswap _ | Iclz | Isqrtf -> super#class_of_operation op
     end
   | _ -> super#class_of_operation op
 

--- a/asmcomp/amd64/arch.ml
+++ b/asmcomp/amd64/arch.ml
@@ -41,6 +41,7 @@ type specific_operation =
   | Ifloatarithmem of float_operation * addressing_mode
                                        (* Float arith operation with memory *)
   | Ibswap of int                      (* endianness conversion *)
+  | Iclz                               (* Number of leading zeros *)
   | Isqrtf                             (* Float square root *)
   | Ifloatsqrtf of addressing_mode     (* Float square root from memory *)
   | Isextend32                         (* 32 to 64 bit conversion with sign
@@ -130,6 +131,8 @@ let print_specific_operation printreg op ppf arg =
                    (Array.sub arg 1 (Array.length arg - 1))
   | Ibswap i ->
       fprintf ppf "bswap_%i %a" i printreg arg.(0)
+  | Iclz ->
+      fprintf ppf "clz %a" printreg arg.(0)
   | Isextend32 ->
       fprintf ppf "sextend32 %a" printreg arg.(0)
   | Izextend32 ->
@@ -145,7 +148,7 @@ let win64 =
 (* Specific operations that are pure *)
 
 let operation_is_pure = function
-  | Ilea _ | Ibswap _ | Isqrtf | Isextend32 | Izextend32 -> true
+  | Ilea _ | Ibswap _ | Iclz | Isqrtf | Isextend32 | Izextend32 -> true
   | Ifloatarithmem _ | Ifloatsqrtf _ -> true
   | _ -> false
 

--- a/asmcomp/amd64/emit.mlp
+++ b/asmcomp/amd64/emit.mlp
@@ -728,6 +728,12 @@ let emit_instr env fallthrough i =
       I.bswap (res i 0)
   | Lop(Ispecific(Ibswap _)) ->
       assert false
+  | Lop(Ispecific(Iclz)) ->
+      (* zero check not needed because the input is a tagged integer *)
+      if (arg i 0) <> (res i 0) then
+        I.xor (res32 i 0) (res32 i 0); (* avoid partial register stall *)
+      I.bsr (arg i 0) (res i 0);
+      I.xor (Imm 63L) (res i 0) (* convert BSR to CLZ *)
   | Lop(Ispecific Isqrtf) ->
       if arg i 0 <> res i 0 then
         I.xorpd (res i 0) (res i 0); (* avoid partial register stall *)

--- a/asmcomp/amd64/selection.ml
+++ b/asmcomp/amd64/selection.ml
@@ -229,6 +229,8 @@ method! select_operation op args dbg =
   | Cextcall("caml_int64_direct_bswap", _, _, _)
   | Cextcall("caml_nativeint_direct_bswap", _, _, _) ->
       (Ispecific (Ibswap 64), args)
+  | Cextcall ("caml_int_clz", _, _, _) ->
+      (Ispecific Iclz, args)
   (* Recognize sign extension *)
   | Casr ->
       begin match args with

--- a/asmcomp/x86_ast.mli
+++ b/asmcomp/x86_ast.mli
@@ -99,6 +99,7 @@ type instruction =
   | ADDSD of arg * arg
   | AND of arg * arg
   | ANDPD of arg * arg
+  | BSR of arg * arg
   | BSWAP of arg
   | CALL of arg
   | CDQ

--- a/asmcomp/x86_dsl.ml
+++ b/asmcomp/x86_dsl.ml
@@ -116,6 +116,7 @@ module I = struct
   let addsd x y = emit (ADDSD (x, y))
   let and_ x y= emit (AND (x, y))
   let andpd x y = emit (ANDPD (x, y))
+  let bsr x y = emit (BSR (x, y))
   let bswap x = emit (BSWAP x)
   let call x = emit (CALL x)
   let cdq () = emit CDQ

--- a/asmcomp/x86_dsl.mli
+++ b/asmcomp/x86_dsl.mli
@@ -109,6 +109,7 @@ module I : sig
   val addsd: arg -> arg -> unit
   val and_: arg -> arg -> unit
   val andpd: arg -> arg -> unit
+  val bsr: arg -> arg-> unit
   val bswap: arg -> unit
   val call: arg -> unit
   val cdq: unit -> unit

--- a/asmcomp/x86_gas.ml
+++ b/asmcomp/x86_gas.ml
@@ -119,6 +119,7 @@ let print_instr b = function
   | ADDSD (arg1, arg2) -> i2 b "addsd" arg1 arg2
   | AND (arg1, arg2) -> i2_s b "and" arg1 arg2
   | ANDPD (arg1, arg2) -> i2 b "andpd" arg1 arg2
+  | BSR (arg1, arg2) -> i2 b "bsr"  arg1 arg2
   | BSWAP arg -> i1 b "bswap" arg
   | CALL arg  -> i1_call_jmp b "call" arg
   | CDQ -> i0 b "cltd"

--- a/asmcomp/x86_masm.ml
+++ b/asmcomp/x86_masm.ml
@@ -119,6 +119,7 @@ let print_instr b = function
   | ADDSD (arg1, arg2) -> i2 b "addsd" arg1 arg2
   | AND (arg1, arg2) -> i2 b "and" arg1 arg2
   | ANDPD (arg1, arg2) -> i2 b "andpd" arg1 arg2
+  | BSR (arg1, arg2) -> i2 b "bsr" arg1 arg2
   | BSWAP arg -> i1 b "bswap" arg
   | CALL arg  -> i1_call_jmp b "call" arg
   | CDQ -> i0 b "cdq"

--- a/runtime/ints.c
+++ b/runtime/ints.c
@@ -139,6 +139,30 @@ CAMLprim value caml_int_of_string(value s)
     return Val_long(parse_intnat(s, 8 * sizeof(value) - 1, INT_ERRMSG));
 }
 
+CAMLprim intnat caml_int_clz(value v)
+{
+#if defined(__has_builtin) && __has_builtin(__builtin_clzl)
+  if (sizeof(v) == sizeof(long))
+    /* v is never zero due to the tagging bit. */
+    return __builtin_clzl(v);
+#endif
+
+  int count = 0;
+  uintnat bit = (uintnat) 1 << (8 * sizeof(uintnat) - 1);
+  uintnat u = v;
+  /* The loop stops at the tagging bit. */
+  while (!(u & bit)) {
+    ++count;
+    bit >>= 1;
+  }
+  return count;
+}
+
+CAMLprim value caml_int_clz_bytecode(value v)
+{
+  return Val_long(caml_int_clz(v));
+}
+
 #define FORMAT_BUFFER_SIZE 32
 
 static char parse_format(value fmt,

--- a/stdlib/int.ml
+++ b/stdlib/int.ml
@@ -36,6 +36,8 @@ let lognot x = logxor x (-1)
 external shift_left : int -> int -> int = "%lslint"
 external shift_right : int -> int -> int = "%asrint"
 external shift_right_logical : int -> int -> int = "%lsrint"
+external clz : int -> (int[@untagged]) =
+  "caml_int_clz_bytecode" "caml_int_clz" [@@noalloc]
 let equal : int -> int -> bool = ( = )
 let compare : int -> int -> int = Stdlib.compare
 let min x y : t = if x <= y then x else y

--- a/stdlib/int.mli
+++ b/stdlib/int.mli
@@ -100,6 +100,13 @@ external shift_right_logical : int -> int -> int = "%lsrint"
     of the sign of [x]. The result is unspecified if [n < 0] or
     [n > ]{!Sys.int_size}. *)
 
+external clz : int -> (int[@untagged]) =
+  "caml_int_clz_bytecode" "caml_int_clz" [@@noalloc]
+(** [clz n] counts the number of leading zero bit in [n].  If [n]
+    is negative, the result is [0]. [clz 0] is equal to {!Sys.int_size}.
+    @since 5.0.0
+*)
+
 (** {1:preds Predicates and comparisons} *)
 
 val equal : int -> int -> bool

--- a/testsuite/tests/lib-int/test.ml
+++ b/testsuite/tests/lib-int/test.ml
@@ -61,6 +61,15 @@ let test_min_max () =
   assert (Int.max 2 3 = 3);
   assert (Int.min 2 3 = 2)
 
+let test_clz () =
+  assert (Int.clz 0 = Sys.int_size);
+  assert (Int.clz (-1) = 0);
+  assert (Int.clz Int.min_int = 0);
+  assert (Int.clz Int.max_int = 1);
+  assert (Int.clz (Int.max_int / 2) = 2);
+  assert (Int.clz 1 = Sys.int_size - 1);
+  assert (Int.clz 2 = Sys.int_size - 2);
+  assert (Int.clz 3 = Sys.int_size - 2)
 
 let tests () =
   test_consts ();
@@ -71,6 +80,7 @@ let tests () =
   test_float_conv ();
   test_string_conv ();
   test_min_max ();
+  test_clz ();
   ()
 
 let () =


### PR DESCRIPTION
This PR adds an `Int.clz` function for computing the number of leading zeros in an integer. The native code compiler for amd64 is updated so that the function is compiled to a `bsr` instruction. The speed-up can be quite significant because a manual implementation requires a loop instead of single instruction.

An alternative implementation approach would add a new primitive integer operation. The advantage would be that the `bsr` result would not have to be tagged unconditionally.

**EDIT** I should have said that if this approach is fine in principle, I can try to add comprehensive tests.