### PR TITLE
testsuite: stabilize internal type identifiers in expect tests

### DIFF
--- a/testsuite/tests/basic/patmatch_for_multiple.ml
+++ b/testsuite/tests/basic/patmatch_for_multiple.ml
@@ -26,15 +26,15 @@ match (3, 2, 1) with
 | _ -> false
 ;;
 [%%expect{|
-(let (*match*/275 = 3 *match*/276 = 2 *match*/277 = 1)
+(let (*match*/294 = 3 *match*/295 = 2 *match*/296 = 1)
   (catch
     (catch
-      (catch (if (!= *match*/276 3) (exit 3) (exit 1)) with (3)
-        (if (!= *match*/275 1) (exit 2) (exit 1)))
+      (catch (if (!= *match*/295 3) (exit 3) (exit 1)) with (3)
+        (if (!= *match*/294 1) (exit 2) (exit 1)))
      with (2) 0)
    with (1) 1))
-(let (*match*/275 = 3 *match*/276 = 2 *match*/277 = 1)
-  (catch (if (!= *match*/276 3) (if (!= *match*/275 1) 0 (exit 1)) (exit 1))
+(let (*match*/294 = 3 *match*/295 = 2 *match*/296 = 1)
+  (catch (if (!= *match*/295 3) (if (!= *match*/294 1) 0 (exit 1)) (exit 1))
    with (1) 1))
 - : bool = false
 |}];;
@@ -47,26 +47,26 @@ match (3, 2, 1) with
 | _ -> false
 ;;
 [%%expect{|
-(let (*match*/280 = 3 *match*/281 = 2 *match*/282 = 1)
+(let (*match*/299 = 3 *match*/300 = 2 *match*/301 = 1)
   (catch
     (catch
       (catch
-        (if (!= *match*/281 3) (exit 6)
-          (let (x/284 =a (makeblock 0 *match*/280 *match*/281 *match*/282))
-            (exit 4 x/284)))
+        (if (!= *match*/300 3) (exit 6)
+          (let (x/303 =a (makeblock 0 *match*/299 *match*/300 *match*/301))
+            (exit 4 x/303)))
        with (6)
-        (if (!= *match*/280 1) (exit 5)
-          (let (x/283 =a (makeblock 0 *match*/280 *match*/281 *match*/282))
-            (exit 4 x/283))))
+        (if (!= *match*/299 1) (exit 5)
+          (let (x/302 =a (makeblock 0 *match*/299 *match*/300 *match*/301))
+            (exit 4 x/302))))
      with (5) 0)
-   with (4 x/278) (seq (ignore x/278) 1)))
-(let (*match*/280 = 3 *match*/281 = 2 *match*/282 = 1)
+   with (4 x/297) (seq (ignore x/297) 1)))
+(let (*match*/299 = 3 *match*/300 = 2 *match*/301 = 1)
   (catch
-    (if (!= *match*/281 3)
-      (if (!= *match*/280 1) 0
-        (exit 4 (makeblock 0 *match*/280 *match*/281 *match*/282)))
-      (exit 4 (makeblock 0 *match*/280 *match*/281 *match*/282)))
-   with (4 x/278) (seq (ignore x/278) 1)))
+    (if (!= *match*/300 3)
+      (if (!= *match*/299 1) 0
+        (exit 4 (makeblock 0 *match*/299 *match*/300 *match*/301)))
+      (exit 4 (makeblock 0 *match*/299 *match*/300 *match*/301)))
+   with (4 x/297) (seq (ignore x/297) 1)))
 - : bool = false
 |}];;
 
@@ -76,8 +76,8 @@ let _ = fun a b ->
   | ((true, _) as _g)
   | ((false, _) as _g) -> ()
 [%%expect{|
-(function a/285[int] b/286 : int 0)
-(function a/285[int] b/286 : int 0)
+(function a/304[int] b/305 : int 0)
+(function a/304[int] b/305 : int 0)
 - : bool -> 'a -> unit = <fun>
 |}];;
 
@@ -96,8 +96,8 @@ let _ = fun a b -> match a, b with
 | (false, _) as p -> p
 (* outside, trivial *)
 [%%expect {|
-(function a/289[int] b/290 (let (p/291 =a (makeblock 0 a/289 b/290)) p/291))
-(function a/289[int] b/290 (makeblock 0 a/289 b/290))
+(function a/308[int] b/309 (let (p/310 =a (makeblock 0 a/308 b/309)) p/310))
+(function a/308[int] b/309 (makeblock 0 a/308 b/309))
 - : bool -> 'a -> bool * 'a = <fun>
 |}]
 
@@ -106,8 +106,8 @@ let _ = fun a b -> match a, b with
 | ((false, _) as p) -> p
 (* inside, trivial *)
 [%%expect{|
-(function a/293[int] b/294 (let (p/295 =a (makeblock 0 a/293 b/294)) p/295))
-(function a/293[int] b/294 (makeblock 0 a/293 b/294))
+(function a/312[int] b/313 (let (p/314 =a (makeblock 0 a/312 b/313)) p/314))
+(function a/312[int] b/313 (makeblock 0 a/312 b/313))
 - : bool -> 'a -> bool * 'a = <fun>
 |}];;
 
@@ -116,11 +116,11 @@ let _ = fun a b -> match a, b with
 | (false as x, _) as p -> x, p
 (* outside, simple *)
 [%%expect {|
-(function a/299[int] b/300
-  (let (x/301 =a[int] a/299 p/302 =a (makeblock 0 a/299 b/300))
-    (makeblock 0 (int,*) x/301 p/302)))
-(function a/299[int] b/300
-  (makeblock 0 (int,*) a/299 (makeblock 0 a/299 b/300)))
+(function a/318[int] b/319
+  (let (x/320 =a[int] a/318 p/321 =a (makeblock 0 a/318 b/319))
+    (makeblock 0 (int,*) x/320 p/321)))
+(function a/318[int] b/319
+  (makeblock 0 (int,*) a/318 (makeblock 0 a/318 b/319)))
 - : bool -> 'a -> bool * (bool * 'a) = <fun>
 |}]
 
@@ -129,11 +129,11 @@ let _ = fun a b -> match a, b with
 | ((false as x, _) as p) -> x, p
 (* inside, simple *)
 [%%expect {|
-(function a/305[int] b/306
-  (let (x/307 =a[int] a/305 p/308 =a (makeblock 0 a/305 b/306))
-    (makeblock 0 (int,*) x/307 p/308)))
-(function a/305[int] b/306
-  (makeblock 0 (int,*) a/305 (makeblock 0 a/305 b/306)))
+(function a/324[int] b/325
+  (let (x/326 =a[int] a/324 p/327 =a (makeblock 0 a/324 b/325))
+    (makeblock 0 (int,*) x/326 p/327)))
+(function a/324[int] b/325
+  (makeblock 0 (int,*) a/324 (makeblock 0 a/324 b/325)))
 - : bool -> 'a -> bool * (bool * 'a) = <fun>
 |}]
 
@@ -142,15 +142,15 @@ let _ = fun a b -> match a, b with
 | (false, x) as p -> x, p
 (* outside, complex *)
 [%%expect{|
-(function a/315[int] b/316[int]
-  (if a/315
-    (let (x/317 =a[int] a/315 p/318 =a (makeblock 0 a/315 b/316))
-      (makeblock 0 (int,*) x/317 p/318))
-    (let (x/319 =a b/316 p/320 =a (makeblock 0 a/315 b/316))
-      (makeblock 0 (int,*) x/319 p/320))))
-(function a/315[int] b/316[int]
-  (if a/315 (makeblock 0 (int,*) a/315 (makeblock 0 a/315 b/316))
-    (makeblock 0 (int,*) b/316 (makeblock 0 a/315 b/316))))
+(function a/334[int] b/335[int]
+  (if a/334
+    (let (x/336 =a[int] a/334 p/337 =a (makeblock 0 a/334 b/335))
+      (makeblock 0 (int,*) x/336 p/337))
+    (let (x/338 =a b/335 p/339 =a (makeblock 0 a/334 b/335))
+      (makeblock 0 (int,*) x/338 p/339))))
+(function a/334[int] b/335[int]
+  (if a/334 (makeblock 0 (int,*) a/334 (makeblock 0 a/334 b/335))
+    (makeblock 0 (int,*) b/335 (makeblock 0 a/334 b/335))))
 - : bool -> bool -> bool * (bool * bool) = <fun>
 |}]
 
@@ -160,19 +160,19 @@ let _ = fun a b -> match a, b with
   -> x, p
 (* inside, complex *)
 [%%expect{|
-(function a/321[int] b/322[int]
+(function a/340[int] b/341[int]
   (catch
-    (if a/321
-      (let (x/329 =a[int] a/321 p/330 =a (makeblock 0 a/321 b/322))
-        (exit 10 x/329 p/330))
-      (let (x/327 =a b/322 p/328 =a (makeblock 0 a/321 b/322))
-        (exit 10 x/327 p/328)))
-   with (10 x/323[int] p/324) (makeblock 0 (int,*) x/323 p/324)))
-(function a/321[int] b/322[int]
+    (if a/340
+      (let (x/348 =a[int] a/340 p/349 =a (makeblock 0 a/340 b/341))
+        (exit 10 x/348 p/349))
+      (let (x/346 =a b/341 p/347 =a (makeblock 0 a/340 b/341))
+        (exit 10 x/346 p/347)))
+   with (10 x/342[int] p/343) (makeblock 0 (int,*) x/342 p/343)))
+(function a/340[int] b/341[int]
   (catch
-    (if a/321 (exit 10 a/321 (makeblock 0 a/321 b/322))
-      (exit 10 b/322 (makeblock 0 a/321 b/322)))
-   with (10 x/323[int] p/324) (makeblock 0 (int,*) x/323 p/324)))
+    (if a/340 (exit 10 a/340 (makeblock 0 a/340 b/341))
+      (exit 10 b/341 (makeblock 0 a/340 b/341)))
+   with (10 x/342[int] p/343) (makeblock 0 (int,*) x/342 p/343)))
 - : bool -> bool -> bool * (bool * bool) = <fun>
 |}]
 
@@ -185,15 +185,15 @@ let _ = fun a b -> match a, b with
 | (false as x, _) as p -> x, p
 (* outside, onecase *)
 [%%expect {|
-(function a/331[int] b/332[int]
-  (if a/331
-    (let (x/333 =a[int] a/331 _p/334 =a (makeblock 0 a/331 b/332))
-      (makeblock 0 (int,*) x/333 [0: 1 1]))
-    (let (x/335 =a[int] a/331 p/336 =a (makeblock 0 a/331 b/332))
-      (makeblock 0 (int,*) x/335 p/336))))
-(function a/331[int] b/332[int]
-  (if a/331 (makeblock 0 (int,*) a/331 [0: 1 1])
-    (makeblock 0 (int,*) a/331 (makeblock 0 a/331 b/332))))
+(function a/350[int] b/351[int]
+  (if a/350
+    (let (x/352 =a[int] a/350 _p/353 =a (makeblock 0 a/350 b/351))
+      (makeblock 0 (int,*) x/352 [0: 1 1]))
+    (let (x/354 =a[int] a/350 p/355 =a (makeblock 0 a/350 b/351))
+      (makeblock 0 (int,*) x/354 p/355))))
+(function a/350[int] b/351[int]
+  (if a/350 (makeblock 0 (int,*) a/350 [0: 1 1])
+    (makeblock 0 (int,*) a/350 (makeblock 0 a/350 b/351))))
 - : bool -> bool -> bool * (bool * bool) = <fun>
 |}]
 
@@ -202,11 +202,11 @@ let _ = fun a b -> match a, b with
 | ((false as x, _) as p) -> x, p
 (* inside, onecase *)
 [%%expect{|
-(function a/337[int] b/338
-  (let (x/339 =a[int] a/337 p/340 =a (makeblock 0 a/337 b/338))
-    (makeblock 0 (int,*) x/339 p/340)))
-(function a/337[int] b/338
-  (makeblock 0 (int,*) a/337 (makeblock 0 a/337 b/338)))
+(function a/356[int] b/357
+  (let (x/358 =a[int] a/356 p/359 =a (makeblock 0 a/356 b/357))
+    (makeblock 0 (int,*) x/358 p/359)))
+(function a/356[int] b/357
+  (makeblock 0 (int,*) a/356 (makeblock 0 a/356 b/357)))
 - : bool -> 'a -> bool * (bool * 'a) = <fun>
 |}]
 
@@ -223,14 +223,14 @@ let _ =fun a b -> match a, b with
 | (_, _) as p -> p
 (* outside, tuplist *)
 [%%expect {|
-(function a/350[int] b/351
+(function a/369[int] b/370
   (catch
-    (if a/350 (if b/351 (let (p/352 =a (field_imm 0 b/351)) p/352) (exit 12))
+    (if a/369 (if b/370 (let (p/371 =a (field_imm 0 b/370)) p/371) (exit 12))
       (exit 12))
-   with (12) (let (p/353 =a (makeblock 0 a/350 b/351)) p/353)))
-(function a/350[int] b/351
-  (catch (if a/350 (if b/351 (field_imm 0 b/351) (exit 12)) (exit 12))
-   with (12) (makeblock 0 a/350 b/351)))
+   with (12) (let (p/372 =a (makeblock 0 a/369 b/370)) p/372)))
+(function a/369[int] b/370
+  (catch (if a/369 (if b/370 (field_imm 0 b/370) (exit 12)) (exit 12))
+   with (12) (makeblock 0 a/369 b/370)))
 - : bool -> bool tuplist -> bool * bool tuplist = <fun>
 |}]
 
@@ -239,20 +239,20 @@ let _ = fun a b -> match a, b with
 | ((_, _) as p) -> p
 (* inside, tuplist *)
 [%%expect{|
-(function a/354[int] b/355
+(function a/373[int] b/374
   (catch
     (catch
-      (if a/354
-        (if b/355 (let (p/359 =a (field_imm 0 b/355)) (exit 13 p/359))
+      (if a/373
+        (if b/374 (let (p/378 =a (field_imm 0 b/374)) (exit 13 p/378))
           (exit 14))
         (exit 14))
-     with (14) (let (p/358 =a (makeblock 0 a/354 b/355)) (exit 13 p/358)))
-   with (13 p/356) p/356))
-(function a/354[int] b/355
+     with (14) (let (p/377 =a (makeblock 0 a/373 b/374)) (exit 13 p/377)))
+   with (13 p/375) p/375))
+(function a/373[int] b/374
   (catch
     (catch
-      (if a/354 (if b/355 (exit 13 (field_imm 0 b/355)) (exit 14)) (exit 14))
-     with (14) (exit 13 (makeblock 0 a/354 b/355)))
-   with (13 p/356) p/356))
+      (if a/373 (if b/374 (exit 13 (field_imm 0 b/374)) (exit 14)) (exit 14))
+     with (14) (exit 13 (makeblock 0 a/373 b/374)))
+   with (13 p/375) p/375))
 - : bool -> bool tuplist -> bool * bool tuplist = <fun>
 |}]

--- a/testsuite/tests/basic/patmatch_split_no_or.ml
+++ b/testsuite/tests/basic/patmatch_split_no_or.ml
@@ -15,13 +15,13 @@ let last_is_anys = function
 ;;
 [%%expect{|
 (let
-  (last_is_anys/11 =
-     (function param/13 : int
+  (last_is_anys/30 =
+     (function param/32 : int
        (catch
-         (if (field_imm 0 param/13) (if (field_imm 1 param/13) (exit 1) 1)
-           (if (field_imm 1 param/13) (exit 1) 2))
+         (if (field_imm 0 param/32) (if (field_imm 1 param/32) (exit 1) 1)
+           (if (field_imm 1 param/32) (exit 1) 2))
         with (1) 3)))
-  (apply (field_mut 1 (global Toploop!)) "last_is_anys" last_is_anys/11))
+  (apply (field_mut 1 (global Toploop!)) "last_is_anys" last_is_anys/30))
 val last_is_anys : bool * bool -> int = <fun>
 |}]
 
@@ -32,13 +32,13 @@ let last_is_vars = function
 ;;
 [%%expect{|
 (let
-  (last_is_vars/18 =
-     (function param/22 : int
+  (last_is_vars/37 =
+     (function param/41 : int
        (catch
-         (if (field_imm 0 param/22) (if (field_imm 1 param/22) (exit 3) 1)
-           (if (field_imm 1 param/22) (exit 3) 2))
+         (if (field_imm 0 param/41) (if (field_imm 1 param/41) (exit 3) 1)
+           (if (field_imm 1 param/41) (exit 3) 2))
         with (3) 3)))
-  (apply (field_mut 1 (global Toploop!)) "last_is_vars" last_is_vars/18))
+  (apply (field_mut 1 (global Toploop!)) "last_is_vars" last_is_vars/37))
 val last_is_vars : bool * bool -> int = <fun>
 |}]
 
@@ -52,12 +52,12 @@ type t += A | B of unit | C of bool * int;;
 0
 type t = ..
 (let
-  (A/26 = (makeblock 248 "A" (caml_fresh_oo_id 0))
-   B/27 = (makeblock 248 "B" (caml_fresh_oo_id 0))
-   C/28 = (makeblock 248 "C" (caml_fresh_oo_id 0)))
-  (seq (apply (field_mut 1 (global Toploop!)) "A/26" A/26)
-    (apply (field_mut 1 (global Toploop!)) "B/27" B/27)
-    (apply (field_mut 1 (global Toploop!)) "C/28" C/28)))
+  (A/45 = (makeblock 248 "A" (caml_fresh_oo_id 0))
+   B/46 = (makeblock 248 "B" (caml_fresh_oo_id 0))
+   C/47 = (makeblock 248 "C" (caml_fresh_oo_id 0)))
+  (seq (apply (field_mut 1 (global Toploop!)) "A/45" A/45)
+    (apply (field_mut 1 (global Toploop!)) "B/46" B/46)
+    (apply (field_mut 1 (global Toploop!)) "C/47" C/47)))
 type t += A | B of unit | C of bool * int
 |}]
 
@@ -71,20 +71,20 @@ let f = function
 ;;
 [%%expect{|
 (let
-  (C/28 = (apply (field_mut 0 (global Toploop!)) "C/28")
-   B/27 = (apply (field_mut 0 (global Toploop!)) "B/27")
-   A/26 = (apply (field_mut 0 (global Toploop!)) "A/26")
-   f/29 =
-     (function param/31 : int
-       (let (*match*/32 =a (field_imm 0 param/31))
+  (C/47 = (apply (field_mut 0 (global Toploop!)) "C/47")
+   B/46 = (apply (field_mut 0 (global Toploop!)) "B/46")
+   A/45 = (apply (field_mut 0 (global Toploop!)) "A/45")
+   f/48 =
+     (function param/50 : int
+       (let (*match*/51 =a (field_imm 0 param/50))
          (catch
-           (if (== *match*/32 A/26) (if (field_imm 1 param/31) 1 (exit 8))
+           (if (== *match*/51 A/45) (if (field_imm 1 param/50) 1 (exit 8))
              (exit 8))
           with (8)
-           (if (field_imm 1 param/31)
-             (if (== (field_imm 0 *match*/32) B/27) 2
-               (if (== (field_imm 0 *match*/32) C/28) 3 4))
-             (if (field_imm 2 param/31) 12 11))))))
-  (apply (field_mut 1 (global Toploop!)) "f" f/29))
+           (if (field_imm 1 param/50)
+             (if (== (field_imm 0 *match*/51) B/46) 2
+               (if (== (field_imm 0 *match*/51) C/47) 3 4))
+             (if (field_imm 2 param/50) 12 11))))))
+  (apply (field_mut 1 (global Toploop!)) "f" f/48))
 val f : t * bool * bool -> int = <fun>
 |}]

--- a/testsuite/tests/generalized-open/gpr1506.ml
+++ b/testsuite/tests/generalized-open/gpr1506.ml
@@ -103,9 +103,9 @@ include struct open struct type t = T end let x = T end
 Line 1, characters 15-41:
 1 | include struct open struct type t = T end let x = T end
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The type t/338 introduced by this open appears in the signature
+Error: The type t/357 introduced by this open appears in the signature
        Line 1, characters 46-47:
-         The value x has no valid type if t/338 is hidden
+         The value x has no valid type if t/357 is hidden
 |}];;
 
 module A = struct
@@ -123,9 +123,9 @@ Lines 3-6, characters 4-7:
 4 |       type t = T
 5 |       let x = T
 6 |     end
-Error: The type t/343 introduced by this open appears in the signature
+Error: The type t/362 introduced by this open appears in the signature
        Line 7, characters 8-9:
-         The value y has no valid type if t/343 is hidden
+         The value y has no valid type if t/362 is hidden
 |}];;
 
 module A = struct
@@ -142,9 +142,9 @@ Lines 3-5, characters 4-7:
 3 | ....open struct
 4 |       type t = T
 5 |     end
-Error: The type t/348 introduced by this open appears in the signature
+Error: The type t/367 introduced by this open appears in the signature
        Line 6, characters 8-9:
-         The value y has no valid type if t/348 is hidden
+         The value y has no valid type if t/367 is hidden
 |}]
 
 (* It was decided to not allow this anymore. *)

--- a/testsuite/tests/shadow_include/shadow_all.ml
+++ b/testsuite/tests/shadow_include/shadow_all.ml
@@ -100,11 +100,11 @@ end
 Line 4, characters 2-11:
 4 |   include S
       ^^^^^^^^^
-Error: Illegal shadowing of included type t/147 by t/164
+Error: Illegal shadowing of included type t/166 by t/183
        Line 2, characters 2-11:
-         Type t/147 came from this include
+         Type t/166 came from this include
        Line 3, characters 2-24:
-         The value ignore has no valid type if t/147 is shadowed
+         The value ignore has no valid type if t/166 is shadowed
 |}]
 
 module type Module = sig
@@ -140,11 +140,11 @@ end
 Line 4, characters 2-11:
 4 |   include S
       ^^^^^^^^^
-Error: Illegal shadowing of included module M/237 by M/254
+Error: Illegal shadowing of included module M/256 by M/273
        Line 2, characters 2-11:
-         Module M/237 came from this include
+         Module M/256 came from this include
        Line 3, characters 2-26:
-         The value ignore has no valid type if M/237 is shadowed
+         The value ignore has no valid type if M/256 is shadowed
 |}]
 
 
@@ -181,11 +181,11 @@ end
 Line 4, characters 2-11:
 4 |   include S
       ^^^^^^^^^
-Error: Illegal shadowing of included module type T/323 by T/340
+Error: Illegal shadowing of included module type T/342 by T/359
        Line 2, characters 2-11:
-         Module type T/323 came from this include
+         Module type T/342 came from this include
        Line 3, characters 2-39:
-         The module F has no valid type if T/323 is shadowed
+         The module F has no valid type if T/342 is shadowed
 |}]
 
 module type Extension = sig
@@ -198,11 +198,11 @@ end
 Line 4, characters 2-11:
 4 |   include S
       ^^^^^^^^^
-Error: Illegal shadowing of included type ext/358 by ext/375
+Error: Illegal shadowing of included type ext/377 by ext/394
        Line 2, characters 2-11:
-         Type ext/358 came from this include
+         Type ext/377 came from this include
        Line 3, characters 14-16:
-         The extension constructor C2 has no valid type if ext/358 is shadowed
+         The extension constructor C2 has no valid type if ext/377 is shadowed
 |}]
 
 module type Class = sig

--- a/testsuite/tests/shapes/comp_units.ml
+++ b/testsuite/tests/shapes/comp_units.ml
@@ -25,7 +25,7 @@ module Mproj = Unit
 module F (X : sig type t end) = X
 [%%expect{|
 {
- "F"[module] -> Abs<.4>(X/278, X/278<.3>);
+ "F"[module] -> Abs<.4>(X/297, X/297<.3>);
  }
 module F : functor (X : sig type t end) -> sig type t = X.t end
 |}]

--- a/testsuite/tests/shapes/functors.ml
+++ b/testsuite/tests/shapes/functors.ml
@@ -17,7 +17,7 @@ module type S = sig type t val x : t end
 module Falias (X : S) = X
 [%%expect{|
 {
- "Falias"[module] -> Abs<.4>(X/280, X/280<.3>);
+ "Falias"[module] -> Abs<.4>(X/299, X/299<.3>);
  }
 module Falias : functor (X : S) -> sig type t = X.t val x : t end
 |}]
@@ -29,10 +29,10 @@ end
 {
  "Finclude"[module] ->
      Abs<.6>
-        (X/284,
+        (X/303,
          {
-          "t"[type] -> X/284<.5> . "t"[type];
-          "x"[value] -> X/284<.5> . "x"[value];
+          "t"[type] -> X/303<.5> . "t"[type];
+          "x"[value] -> X/303<.5> . "x"[value];
           });
  }
 module Finclude : functor (X : S) -> sig type t = X.t val x : t end
@@ -45,7 +45,7 @@ end
 [%%expect{|
 {
  "Fredef"[module] ->
-     Abs<.10>(X/291, {
+     Abs<.10>(X/310, {
                       "t"[type] -> <.8>;
                       "x"[value] -> <.9>;
                       });
@@ -223,8 +223,8 @@ module Big_to_small1 : B2S = functor (X : Big) -> X
 [%%expect{|
 {
  "Big_to_small1"[module] ->
-     Abs<.40>(X/386, {<.39>
-                      "t"[type] -> X/386<.39> . "t"[type];
+     Abs<.40>(X/405, {<.39>
+                      "t"[type] -> X/405<.39> . "t"[type];
                       });
  }
 module Big_to_small1 : B2S
@@ -234,8 +234,8 @@ module Big_to_small2 : B2S = functor (X : Big) -> struct include X end
 [%%expect{|
 {
  "Big_to_small2"[module] ->
-     Abs<.42>(X/389, {
-                      "t"[type] -> X/389<.41> . "t"[type];
+     Abs<.42>(X/408, {
+                      "t"[type] -> X/408<.41> . "t"[type];
                       });
  }
 module Big_to_small2 : B2S

--- a/testsuite/tests/shapes/open_arg.ml
+++ b/testsuite/tests/shapes/open_arg.ml
@@ -22,7 +22,7 @@ end = struct end
 
 [%%expect{|
 {
- "Make"[module] -> Abs<.3>(I/280, {
+ "Make"[module] -> Abs<.3>(I/299, {
                                    });
  }
 module Make : functor (I : sig end) -> sig end

--- a/testsuite/tests/shapes/recmodules.ml
+++ b/testsuite/tests/shapes/recmodules.ml
@@ -43,8 +43,8 @@ and B : sig
 end = B
 [%%expect{|
 {
- "A"[module] -> A/303<.11>;
- "B"[module] -> B/304<.12>;
+ "A"[module] -> A/322<.11>;
+ "B"[module] -> B/323<.12>;
  }
 module rec A : sig type t = Leaf of B.t end
 and B : sig type t = int end
@@ -82,13 +82,13 @@ end = Set.Make(A)
  "ASet"[module] ->
      {
       "compare"[value] ->
-          CU Stdlib . "Set"[module] . "Make"[module](A/325<.19>) .
+          CU Stdlib . "Set"[module] . "Make"[module](A/344<.19>) .
           "compare"[value];
       "elt"[type] ->
-          CU Stdlib . "Set"[module] . "Make"[module](A/325<.19>) .
+          CU Stdlib . "Set"[module] . "Make"[module](A/344<.19>) .
           "elt"[type];
       "t"[type] ->
-          CU Stdlib . "Set"[module] . "Make"[module](A/325<.19>) . "t"[type];
+          CU Stdlib . "Set"[module] . "Make"[module](A/344<.19>) . "t"[type];
       };
  }
 module rec A :

--- a/testsuite/tests/shapes/rotor_example.ml
+++ b/testsuite/tests/shapes/rotor_example.ml
@@ -26,7 +26,7 @@ end
 {
  "Pair"[module] ->
      Abs<.9>
-        (X/280, Abs(Y/281, {
+        (X/299, Abs(Y/300, {
                             "t"[type] -> <.5>;
                             "to_string"[value] -> <.6>;
                             }));

--- a/testsuite/tests/typing-sigsubst/sigsubst.ml
+++ b/testsuite/tests/typing-sigsubst/sigsubst.ml
@@ -24,11 +24,11 @@ end
 Line 3, characters 2-36:
 3 |   include Comparable with type t = t
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: Illegal shadowing of included type t/285 by t/290
+Error: Illegal shadowing of included type t/304 by t/309
        Line 2, characters 2-19:
-         Type t/285 came from this include
+         Type t/304 came from this include
        Line 3, characters 2-23:
-         The value print has no valid type if t/285 is shadowed
+         The value print has no valid type if t/304 is shadowed
 |}]
 
 module type Sunderscore = sig


### PR DESCRIPTION
Currently, the testsuite fails after a `make install` due to a shift in internal type identifiers in a handful of expect tests.

This is a subtle "bug" introduced by #11199 which made the toplevel reads the compiler-libs version of `Topdirs` when available in the installation directory of the compiler.  Unfortunately, reading or not a cmi file modifies the internal type identifiers used by the typechecker. Consequently, the tests in the testsuite that were relying on those internal identifiers had their result dependent on the installation status of the compiler.

This PR fixes this issue by ensuring that `expect_test` reads `topdirs.cmi` a fixed number of time, independently of the installation status of the compiler.