### PR TITLE
Delete ocamlrun before copying (for Mac M1)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -182,6 +182,7 @@ else
 	$(MAKE) boot/flexlink.byte$(EXE)
 	$(MAKE) runtime-all
 endif # ifeq "$(BOOTSTRAPPING_FLEXDLL)" "false"
+	rm -f boot/ocamlrun$(EXE)
 	cp runtime/ocamlrun$(EXE) boot/ocamlrun$(EXE)
 	cd boot; rm -f $(LIBFILES)
 	cd stdlib; cp $(LIBFILES) ../boot
@@ -241,6 +242,7 @@ promote-cross: promote-common
 .PHONY: promote
 promote: PROMOTE = $(OCAMLRUN) tools/stripdebug
 promote: promote-common
+	rm -f boot/ocamlrun$(EXE)
 	cp runtime/ocamlrun$(EXE) boot/ocamlrun$(EXE)
 
 # Compile the native-code compiler


### PR DESCRIPTION
I was experiencing frequent  errors on a Mac M1 (process killed 9), which only disappeared after a reboot.
Having seen that this was probably caused by overwriting an executable, I added these two lines that delete `boot/ocamlrun` before overwriting it.
This is safe, and it seems to solve the problem for me.