### PR TITLE
Limit GHA to pushes to maintenance branches

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,12 @@
 name: Build
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - '4.**'
+      - '5.**'
+      - 'trunk'
+  pull_request:
 
 jobs:
 

--- a/.github/workflows/hygiene.yml
+++ b/.github/workflows/hygiene.yml
@@ -1,6 +1,10 @@
 name: Hygiene
 on:
   push:
+    branches:
+      - '4.**'
+      - '5.**'
+      - 'trunk'
   pull_request:
     types: [opened, synchronize, reopened, labeled, unlabeled]
 


### PR DESCRIPTION
There's an [open request to GitHub](https://github.com/orgs/github-community/discussions/9098) to address this properly, but apropos https://github.com/ocaml/ocaml/pull/11330#issuecomment-1159438471 we can limit the "push" testing to our maintenance branches only, which should reduce the noise.

CI golf can still be played on one's own fork by opening self pull requests (which is something I don't wish to lose). A fork still runs GHA if you push an update to trunk or one of the top branches, but I expect that's OK?