### PR TITLE
Add all renamed symbols to unixsupport.h

### DIFF
--- a/Changes
+++ b/Changes
@@ -544,7 +544,8 @@ OCaml 4.14.0
   WSADuplicateSocket on sockets instead of DuplicateHandle.
   (Antonin Décimo, review by Xavier Leroy and Nicolás Ojeda Bär)
 
-* #10926: Ensure all C functions in the Unix library are prefixed with `caml_`.
+* #10926, #11336: Ensure all C functions in the Unix library are prefixed with
+  `caml_`.
   (David Allsopp, review by Kate Deplaix, Damien Doligez and Xavier Leroy)
 
 - #10951: Introduce the Thread.Exit exception as an alternative way to

--- a/otherlibs/unix/socket_win32.c
+++ b/otherlibs/unix/socket_win32.c
@@ -57,7 +57,7 @@ SOCKET caml_win32_socket(int domain, int type, int protocol,
   return s;
 
 err:
-  win32_maperr(WSAGetLastError());
+  caml_win32_maperr(WSAGetLastError());
   return INVALID_SOCKET;
 }
 

--- a/otherlibs/unix/unixsupport.h
+++ b/otherlibs/unix/unixsupport.h
@@ -75,7 +75,6 @@ extern SOCKET caml_win32_socket(int domain, int type, int protocol,
 #define NO_CRT_FD (-1)
 
 extern void caml_win32_maperr(DWORD errcode);
-#define win32_maperr caml_win32_maperr
 #endif /* _WIN32 */
 
 #define Nothing ((value) 0)

--- a/otherlibs/unix/unixsupport.h
+++ b/otherlibs/unix/unixsupport.h
@@ -83,12 +83,6 @@ extern void caml_win32_maperr(DWORD errcode);
 extern value caml_unix_error_of_code (int errcode);
 extern int caml_unix_code_of_unix_error (value error);
 
-/* Compatibility definitions for the pre-5.0 names of these functions */
-#ifndef CAML_BUILDING_UNIX
-#define unix_error_of_code caml_unix_error_of_code
-#define code_of_unix_error caml_unix_code_of_unix_error
-#endif /* CAML_BUILDING_UNIX */
-
 CAMLnoreturn_start
 extern void caml_unix_error (int errcode, const char * cmdname, value arg)
 CAMLnoreturn_end;
@@ -96,12 +90,6 @@ CAMLnoreturn_end;
 CAMLnoreturn_start
 extern void caml_uerror (const char * cmdname, value arg)
 CAMLnoreturn_end;
-
-/* Compatibility definitions for the pre-5.0 names of these functions */
-#ifndef CAML_BUILDING_UNIX
-#define uerror caml_uerror
-#define unix_error caml_unix_error
-#endif /* CAML_BUILDING_UNIX */
 
 extern void caml_unix_check_path(value path, const char * cmdname);
 
@@ -115,15 +103,6 @@ extern void caml_unix_cstringvect_free(char_os **);
 extern int caml_unix_cloexec_default;
 extern int caml_unix_cloexec_p(value cloexec);
 
-/* Compatibility definitions for the pre-5.0 names of these functions */
-#ifndef CAML_BUILDING_UNIX
-#define cstringvect caml_unix_cstringvect
-#define cstringvect_free caml_unix_cstringvect_free
-
-#define unix_cloexec_default caml_unix_cloexec_default
-#define unix_cloexec_p caml_unix_cloexec_p
-#endif /* CAML_BUILDING_UNIX */
-
 #ifdef _WIN32
 extern int caml_win32_set_inherit(HANDLE fd, BOOL inherit);
 /* This is a best effort, not guaranteed to work, so don't fail on error */
@@ -132,13 +111,27 @@ extern int caml_win32_set_inherit(HANDLE fd, BOOL inherit);
 #else
 extern void caml_unix_set_cloexec(int fd, char * cmdname, value arg);
 extern void caml_unix_clear_cloexec(int fd, char * cmdname, value arg);
+#endif /* _WIN32 */
 
 /* Compatibility definitions for the pre-5.0 names of these functions */
 #ifndef CAML_BUILDING_UNIX
+#define unix_error_of_code caml_unix_error_of_code
+#define code_of_unix_error caml_unix_code_of_unix_error
+
+#define uerror caml_uerror
+#define unix_error caml_unix_error
+
+#define cstringvect caml_unix_cstringvect
+#define cstringvect_free caml_unix_cstringvect_free
+
+#define unix_cloexec_default caml_unix_cloexec_default
+#define unix_cloexec_p caml_unix_cloexec_p
+
+#ifndef _WIN32
 #define unix_set_cloexec caml_unix_set_cloexec
 #define unix_clear_cloexec caml_unix_clear_cloexec
+#endif /* ! _WIN32 */
 #endif /* CAML_BUILDING_UNIX */
-#endif /* _WIN32 */
 
 #ifdef __cplusplus
 }

--- a/otherlibs/unix/unixsupport.h
+++ b/otherlibs/unix/unixsupport.h
@@ -115,6 +115,15 @@ extern void caml_unix_cstringvect_free(char_os **);
 extern int caml_unix_cloexec_default;
 extern int caml_unix_cloexec_p(value cloexec);
 
+/* Compatibility definitions for the pre-5.0 names of these functions */
+#ifndef CAML_BUILDING_UNIX
+#define cstringvect caml_unix_cstringvect
+#define cstringvect_free caml_unix_cstringvect_free
+
+#define unix_cloexec_default caml_unix_cloexec_default
+#define unix_cloexec_p caml_unix_cloexec_p
+#endif /* CAML_BUILDING_UNIX */
+
 #ifdef _WIN32
 extern int caml_win32_set_inherit(HANDLE fd, BOOL inherit);
 /* This is a best effort, not guaranteed to work, so don't fail on error */
@@ -123,7 +132,13 @@ extern int caml_win32_set_inherit(HANDLE fd, BOOL inherit);
 #else
 extern void caml_unix_set_cloexec(int fd, char * cmdname, value arg);
 extern void caml_unix_clear_cloexec(int fd, char * cmdname, value arg);
-#endif
+
+/* Compatibility definitions for the pre-5.0 names of these functions */
+#ifndef CAML_BUILDING_UNIX
+#define unix_set_cloexec caml_unix_set_cloexec
+#define unix_clear_cloexec caml_unix_clear_cloexec
+#endif /* CAML_BUILDING_UNIX */
+#endif /* _WIN32 */
 
 #ifdef __cplusplus
 }

--- a/otherlibs/unix/unixsupport.h
+++ b/otherlibs/unix/unixsupport.h
@@ -115,6 +115,13 @@ extern void caml_unix_clear_cloexec(int fd, char * cmdname, value arg);
 
 /* Compatibility definitions for the pre-5.0 names of these functions */
 #ifndef CAML_BUILDING_UNIX
+#ifdef _WIN32
+#define win_alloc_handle caml_win32_alloc_handle
+#define win_alloc_socket caml_win32_alloc_socket
+#define win_CRT_fd_of_filedescr caml_win32_CRT_fd_of_filedescr
+#define win32_maperr caml_win32_maperr
+#endif /* _WIN32 */
+
 #define unix_error_of_code caml_unix_error_of_code
 #define code_of_unix_error caml_unix_code_of_unix_error
 
@@ -127,10 +134,13 @@ extern void caml_unix_clear_cloexec(int fd, char * cmdname, value arg);
 #define unix_cloexec_default caml_unix_cloexec_default
 #define unix_cloexec_p caml_unix_cloexec_p
 
-#ifndef _WIN32
+#ifdef _WIN32
+#define win_set_inherit caml_win32_set_inherit
+#define win_set_cloexec caml_win32_set_cloexec
+#else
 #define unix_set_cloexec caml_unix_set_cloexec
 #define unix_clear_cloexec caml_unix_clear_cloexec
-#endif /* ! _WIN32 */
+#endif /* _WIN32 */
 #endif /* CAML_BUILDING_UNIX */
 
 #ifdef __cplusplus


### PR DESCRIPTION
Small follow-on from #10926, spotted in https://github.com/ocsigen/lwt/pull/953. Most of the functions declared in `unixsupport.h` which were renamed had compatibility macros added as part of the original PR, but a few got missed.

This PR tidies `unixsupport.h` slightly to put them in one place and adds `#define` for all of the symbols which were renamed.

The only other public header from the unix library is `socketaddr.h` which already has all of these handled.