### PR TITLE
Optimize bytecode root scanning

### DIFF
--- a/Changes
+++ b/Changes
@@ -32,6 +32,7 @@ OCaml 5.0
 ### Language features:
 
 ### Runtime system:
+
 - #11308: Add environment variable to preserve runtime_events after exit
   If the environment variable OCAML_RUNTIME_EVENTS_PRESERVE exists then the
   runtime will not remove the runtime events ring buffers at exit. This
@@ -123,6 +124,12 @@ OCaml 5.0
   asynchronous actions in multicore. Reimplement the old behaviour of
   `caml_process_pending*` for multicore.
   (Guillaume Munch-Maccagnoni, review by Sadiq Jaffer and Gabriel Scherer)
+
+- #11337: pass 'flags' metadata to root scanners, to optimize stack
+  scanning in the bytecode interpreter.
+  Changes the interface of user-provided root-scanning hooks.
+  (Gabriel Scherer, review by Xavier Leroy,
+   Guillaume Munch-Maccagnoni, Sadiq Jaffer and Tom Kelly)
 
 ### Code generation and optimizations:
 

--- a/otherlibs/systhreads/st_stubs.c
+++ b/otherlibs/systhreads/st_stubs.c
@@ -130,9 +130,9 @@ static st_retcode caml_threadstatus_wait (value);
 
 static scan_roots_hook prev_scan_roots_hook;
 
-static void caml_thread_scan_roots(scanning_action action,
-                                   void *fdata,
-                                   caml_domain_state *domain_state)
+static void caml_thread_scan_roots(
+  scanning_action action, scanning_action_flags fflags, void *fdata,
+  caml_domain_state *domain_state)
 {
   caml_thread_t th;
 
@@ -145,8 +145,8 @@ static void caml_thread_scan_roots(scanning_action action,
       (*action)(fdata, th->backtrace_last_exn, &th->backtrace_last_exn);
       if (th != Current_thread) {
         if (th->current_stack != NULL)
-          caml_do_local_roots(action, fdata, th->local_roots,
-                              th->current_stack, th->gc_regs);
+          caml_do_local_roots(action, fflags, fdata,
+                              th->local_roots, th->current_stack, th->gc_regs);
       }
       th = th->next;
     } while (th != Current_thread);
@@ -154,7 +154,7 @@ static void caml_thread_scan_roots(scanning_action action,
   };
 
   if (prev_scan_roots_hook != NULL)
-    (*prev_scan_roots_hook)(action, fdata, domain_state);
+    (*prev_scan_roots_hook)(action, fflags, fdata, domain_state);
 
   return;
 }

--- a/runtime/caml/fiber.h
+++ b/runtime/caml/fiber.h
@@ -197,8 +197,11 @@ extern value caml_global_data;
 
 struct stack_info** caml_alloc_stack_cache (void);
 CAMLextern struct stack_info* caml_alloc_main_stack (uintnat init_wsize);
-void caml_scan_stack(scanning_action f, void* fdata,
-                     struct stack_info* stack, value* v_gc_regs);
+
+void caml_scan_stack(
+  scanning_action f, scanning_action_flags fflags, void* fdata,
+  struct stack_info* stack, value* v_gc_regs);
+
 /* try to grow the stack until at least required_size words are available.
    returns nonzero on success */
 CAMLextern int caml_try_realloc_stack (asize_t required_wsize);

--- a/runtime/caml/finalise.h
+++ b/runtime/caml/finalise.h
@@ -72,10 +72,12 @@ void caml_final_merge_finalisable (struct finalisable *source,
 int caml_final_update_first (caml_domain_state* d);
 int caml_final_update_last (caml_domain_state* d);
 value caml_final_do_calls_exn (void);
-void caml_final_do_roots (scanning_action f, void* fdata,
-                          caml_domain_state* domain, int do_val);
-void caml_final_do_young_roots (scanning_action f, void* fdata,
-                                caml_domain_state* d, int do_last_val);
+void caml_final_do_roots (
+  scanning_action f, scanning_action_flags fflags, void* fdata,
+  caml_domain_state* domain, int do_val);
+void caml_final_do_young_roots (
+  scanning_action f, scanning_action_flags fflags, void* fdata,
+  caml_domain_state* d, int do_last_val);
 void caml_final_empty_young (caml_domain_state* d);
 void caml_final_update_last_minor (caml_domain_state* d);
 struct caml_final_info* caml_alloc_final_info(void);

--- a/runtime/caml/roots.h
+++ b/runtime/caml/roots.h
@@ -21,16 +21,25 @@
 #include "misc.h"
 #include "domain.h"
 
+typedef enum {
+  SCANNING_ONLY_YOUNG_VALUES = 1, // action is a no-op outside the minor heap
+} scanning_action_flags;
+
 typedef void (*scanning_action) (void*, value, value *);
-typedef void (*scan_roots_hook) (scanning_action, void*, caml_domain_state*);
+typedef void (*scan_roots_hook) (scanning_action, scanning_action_flags,
+                                 void*, caml_domain_state*);
 CAMLextern _Atomic scan_roots_hook caml_scan_roots_hook;
 
-CAMLextern void caml_do_roots (scanning_action f, void* data,
-                               caml_domain_state* d, int do_final_val);
-CAMLextern void caml_do_local_roots(scanning_action f, void* data,
-                                    struct caml__roots_block* local_roots,
-                                    struct stack_info *current_stack,
-                                    value * v_gc_regs);
+CAMLextern void caml_do_roots (
+  scanning_action f, scanning_action_flags,
+  void* data, caml_domain_state* d, int do_final_val);
+
+CAMLextern void caml_do_local_roots(
+  scanning_action f, scanning_action_flags,
+  void* data,
+  struct caml__roots_block* local_roots,
+  struct stack_info *current_stack,
+  value * v_gc_regs);
 
 #endif /* CAML_INTERNALS */
 

--- a/runtime/caml/shared_heap.h
+++ b/runtime/caml/shared_heap.h
@@ -93,10 +93,8 @@ void caml_cycle_heap(struct caml_heap_state*);
 
 /* Heap invariant verification (for debugging) */
 
-/* caml_verify_begin must only be called while all domains are paused */
-struct heap_verify_state* caml_verify_begin(void);
-void caml_verify_root(void*, value, value*);
-void caml_verify_heap(struct heap_verify_state*); /* deallocates arg */
+/* caml_verify_heap must only be called while all domains are paused */
+void caml_verify_heap(caml_domain_state *domain);
 
 #ifdef DEBUG
 /* [is_garbage(v)] returns true if [v] is a garbage value */

--- a/runtime/finalise.c
+++ b/runtime/finalise.c
@@ -179,7 +179,8 @@ value caml_final_do_calls_exn(void)
 
 /* Called my major_gc for marking roots */
 void caml_final_do_roots
-  (scanning_action act, void* fdata, caml_domain_state* d, int do_val)
+  (scanning_action act, scanning_action_flags fflags, void* fdata,
+   caml_domain_state* d, int do_val)
 {
   uintnat i;
   struct final_todo *todo;
@@ -209,7 +210,8 @@ void caml_final_do_roots
 
 /* Called by minor gc for marking roots */
 void caml_final_do_young_roots
-  (scanning_action act, void* fdata, caml_domain_state* d, int do_last_val)
+  (scanning_action act, scanning_action_flags fflags, void* fdata,
+   caml_domain_state* d, int do_last_val)
 {
   uintnat i;
   struct caml_final_info *f = d->final_info;

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -742,6 +742,8 @@ static intnat mark(intnat budget) {
   return budget;
 }
 
+static scanning_action_flags darken_scanning_flags = 0;
+
 void caml_darken_cont(value cont)
 {
   CAMLassert(Is_block(cont) && !Is_young(cont) && Tag_val(cont) == Cont_tag);
@@ -757,7 +759,8 @@ void caml_darken_cont(value cont)
               With_status_hd(hd, NOT_MARKABLE))) {
         value stk = Field(cont, 0);
         if (Ptr_val(stk) != NULL)
-          caml_scan_stack(&caml_darken, 0, Ptr_val(stk), 0);
+          caml_scan_stack(&caml_darken, darken_scanning_flags, 0,
+                          Ptr_val(stk), 0);
         atomic_store_explicit(
           Hp_atomic_val(cont),
           With_status_hd(hd, caml_global_heap_state.MARKED),
@@ -1032,7 +1035,7 @@ static void cycle_all_domains_callback(caml_domain_state* domain, void* unused,
   domain->major_gc_clock = 0.0;
 
   CAML_EV_BEGIN(EV_MAJOR_MARK_ROOTS);
-  caml_do_roots (&caml_darken, NULL, domain, 0);
+  caml_do_roots (&caml_darken, darken_scanning_flags, NULL, domain, 0);
   {
     uintnat work_unstarted = WORK_UNSTARTED;
     if(atomic_compare_exchange_strong(&domain_global_roots_started,

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -1017,10 +1017,7 @@ static void cycle_all_domains_callback(caml_domain_state* domain, void* unused,
   /* If the heap is to be verified, do it before the domains continue
      running OCaml code. */
   if (caml_params->verify_heap) {
-    struct heap_verify_state* ver = caml_verify_begin();
-    caml_do_roots (&caml_verify_root, ver, domain, 1);
-    caml_scan_global_roots(&caml_verify_root, ver);
-    caml_verify_heap(ver);
+    caml_verify_heap(domain);
     caml_gc_log("Heap verified");
     caml_global_barrier();
   }

--- a/runtime/minor_gc.c
+++ b/runtime/minor_gc.c
@@ -222,6 +222,10 @@ static int try_update_object_header(value v, value *p, value result,
   return success;
 }
 
+/* oldify_one is a no-op outside the minor heap. */
+static scanning_action_flags oldify_scanning_flags =
+  SCANNING_ONLY_YOUNG_VALUES;
+
 /* Note that the tests on the tag depend on the fact that Infix_tag,
    Forward_tag, and No_scan_tag are contiguous. */
 static void oldify_one (void* st_v, value v, value *p)
@@ -266,7 +270,8 @@ static void oldify_one (void* st_v, value v, value *p)
       struct stack_info* stk = Ptr_val(stack_value);
       Field(result, 0) = Val_ptr(stk);
       if (stk != NULL) {
-        caml_scan_stack(&oldify_one, st, stk, 0);
+        caml_scan_stack(&oldify_one, oldify_scanning_flags, st,
+                        stk, 0);
       }
     }
     else
@@ -575,7 +580,8 @@ void caml_empty_minor_heap_promote(caml_domain_state* domain,
 
   CAML_EV_BEGIN(EV_MINOR_FINALIZERS_OLDIFY);
   /* promote the finalizers unconditionally as we want to avoid barriers */
-  caml_final_do_young_roots (&oldify_one, &st, domain, 0);
+  caml_final_do_young_roots (&oldify_one, oldify_scanning_flags, &st,
+                             domain, 0);
   CAML_EV_END(EV_MINOR_FINALIZERS_OLDIFY);
 
   CAML_EV_BEGIN(EV_MINOR_REMEMBERED_SET_PROMOTE);
@@ -610,12 +616,13 @@ void caml_empty_minor_heap_promote(caml_domain_state* domain,
 #endif
 
   CAML_EV_BEGIN(EV_MINOR_LOCAL_ROOTS);
-  caml_do_local_roots(&oldify_one, &st, domain->local_roots,
-                      domain->current_stack, domain->gc_regs);
+  caml_do_local_roots(
+    &oldify_one, oldify_scanning_flags, &st,
+    domain->local_roots, domain->current_stack, domain->gc_regs);
 
   scan_roots_hook = atomic_load(&caml_scan_roots_hook);
   if (scan_roots_hook != NULL)
-    (*scan_roots_hook)(&oldify_one, &st, domain);
+    (*scan_roots_hook)(&oldify_one, oldify_scanning_flags, &st, domain);
 
   CAML_EV_BEGIN(EV_MINOR_LOCAL_ROOTS_PROMOTE);
   oldify_mopup (&st, 0);

--- a/runtime/roots.c
+++ b/runtime/roots.c
@@ -32,21 +32,25 @@
 CAMLexport _Atomic scan_roots_hook caml_scan_roots_hook =
   (scan_roots_hook)NULL;
 
-void caml_do_roots (scanning_action f, void* fdata, caml_domain_state* d,
-                    int do_final_val)
+void caml_do_roots (
+  scanning_action f, scanning_action_flags fflags, void* fdata,
+  caml_domain_state* d,
+  int do_final_val)
 {
   scan_roots_hook hook;
-  caml_do_local_roots(f, fdata, d->local_roots, d->current_stack, d->gc_regs);
+  caml_do_local_roots(f, fflags, fdata,
+                      d->local_roots, d->current_stack, d->gc_regs);
   hook = atomic_load(&caml_scan_roots_hook);
-  if (hook != NULL) (*hook)(f, fdata, d);
-  caml_final_do_roots(f, fdata, d, do_final_val);
+  if (hook != NULL) (*hook)(f, fflags, fdata, d);
+  caml_final_do_roots(f, fflags, fdata, d, do_final_val);
 
 }
 
-CAMLexport void caml_do_local_roots (scanning_action f, void* fdata,
-                                     struct caml__roots_block *local_roots,
-                                     struct stack_info *current_stack,
-                                     value * v_gc_regs)
+CAMLexport void caml_do_local_roots (
+  scanning_action f, scanning_action_flags fflags, void* fdata,
+  struct caml__roots_block *local_roots,
+  struct stack_info *current_stack,
+  value * v_gc_regs)
 {
   struct caml__roots_block *lr;
   int i, j;
@@ -62,5 +66,5 @@ CAMLexport void caml_do_local_roots (scanning_action f, void* fdata,
       }
     }
   }
-  caml_scan_stack(f, fdata, current_stack, v_gc_regs);
+  caml_scan_stack(f, fflags, fdata, current_stack, v_gc_regs);
 }

--- a/runtime/shared_heap.c
+++ b/runtime/shared_heap.c
@@ -765,7 +765,11 @@ static void verify_object(struct heap_verify_state* st, value v) {
   }
 }
 
-void caml_verify_heap(struct heap_verify_state* st) {
+void caml_verify_heap(caml_domain_state *domain) {
+  struct heap_verify_state* st = caml_verify_begin();
+  caml_do_roots (&caml_verify_root, st, domain, 1);
+  caml_scan_global_roots(&caml_verify_root, st);
+
   while (st->sp) verify_object(st, st->stack[--st->sp]);
 
   caml_addrmap_clear(&st->seen);


### PR DESCRIPTION
This PR is a follow-up to #11169

@kayceesrk noticed a bytecode-interpreter performance regression in OCaml 5, with a large performance regression on the [Sandmarks stacks.ml benchmark](https://github.com/ocaml-bench/sandmark/blob/main/benchmarks/simple-tests/stacks.ml) (try with parameters `./bench 4000 floats-large`), where the bytecode-compiled version is 50% slower than the 4.13 one.

What is slow in trunk on this program is root scanning in the minor GC. The bytecode stack contains "naked" code pointers, and so during root scanning the runtime needs to check whether a pointer is a code pointer. This queries the code-fragments skiplist, which is slow for a very frequent operation.

#11169 is based on representing naked code pointers as immediates, but this makes backtraces imprecise so it did not gather consensus.

The present PR is based on the following remark from the 4.13 codebase:

https://github.com/ocaml/ocaml/blob/bfc5de586cfd3d8e28e99473c80c5e1c9d13de6f/runtime/roots_byt.c#L45-L51

In general, root scanning requires a code-fragment check, but in the specific case of `oldify_one` we don't need a check, because `oldify_one` itself checks for "being in the minor heap", which in particular implies "not being a code fragment".

By disabling the code-fragment check in this case, the present PR recovers exactly the 4.13 performance.

The current implementation is an ugly hack, mostly meant to generate discussion from more knowledgeable people: I optimize the code-fragment check away by checking whether the `scanning_action` pointer is exactly `&oldify_one`. Ugly! But it is not clear how to do better. We could make `scanning_action` a structure with metadata along the code pointer, the metadata being (for now) a flag "are you oldify_one?" or, more generally, "do you support naked pointers?".