### PR TITLE
Turn some partial application warnings into hints

### DIFF
--- a/Changes
+++ b/Changes
@@ -20,6 +20,9 @@ Working version
 
 ### Compiler user-interface and warnings:
 
+- #11338: Turn some partial application warnings into hints.
+  (Leo White, review by Stephen Dolan)
+
 ### Internal/compiler-libs changes:
 
 ### Build system:

--- a/testsuite/tests/typing-warnings/application.ml
+++ b/testsuite/tests/typing-warnings/application.ml
@@ -96,11 +96,8 @@ val g : int -> int = <fun>
 Line 2, characters 10-15:
 2 | let _ = g (f 1);;
               ^^^^^
-Warning 5 [ignored-partial-application]: this function application is partial,
-maybe some arguments are missing.
-Line 2, characters 10-15:
-2 | let _ = g (f 1);;
-              ^^^^^
 Error: This expression has type int -> int
        but an expression was expected of type int
+  Hint: This function application is partial,
+  maybe some arguments are missing.
 |}]


### PR DESCRIPTION
#9560 added some additional partial applications warnings when there is a type error. However, these would more naturally appear as a hint within the error message. This PR replaces those warnings with a hint.