### PR TITLE
CI check for committing files in .gitignore

### DIFF
--- a/.github/workflows/hygiene.yml
+++ b/.github/workflows/hygiene.yml
@@ -62,6 +62,10 @@ jobs:
           '${{ github.event.after }}'
         if: ${{ always() }}
 
+      - name: Check that no ignored files have been committed
+        run: tools/ci/actions/check-no-ignored-files.sh
+        if: ${{ always() }}
+
       - name: check-typo revered
         run: >-
           tools/ci/actions/check-typo.sh

--- a/tools/ci/actions/check-no-ignored-files.sh
+++ b/tools/ci/actions/check-no-ignored-files.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+#**************************************************************************
+#*                                                                        *
+#*                                 OCaml                                  *
+#*                                                                        *
+#*                        David Allsopp, Tarides                          *
+#*                                                                        *
+#*   Copyright 2022 David Allsopp Ltd.                                    *
+#*                                                                        *
+#*   All rights reserved.  This file is distributed under the terms of    *
+#*   the GNU Lesser General Public License version 2.1, with the          *
+#*   special exception on linking described in the file LICENSE.          *
+#*                                                                        *
+#**************************************************************************
+
+if git ls-tree HEAD --name-only -r | git check-ignore --stdin --no-index; then
+  echo These files are matched by .gitignore and should not be committed
+  exit 1
+fi


### PR DESCRIPTION
This is a follow-on for #11343: if we stop committing `configure`, we should ensure that it doesn't accidentally (or nefariously) get recommitted.

~~There was one place in the testsuite where we commit a broken .cmi file which I've worked-around by using `copy` and there are `.gitignore` files in the manual's directories which had incorrect patterns.~~

An example of this test failing can be seen at https://github.com/dra27/ocaml/runs/7002042376?check_suite_focus=true#step:6:8.