### PR TITLE
Restore helpful error message when make is run before configure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -804,6 +804,10 @@ SAK_CC ?= $(CC)
 SAK_CFLAGS ?= $(OC_CFLAGS) $(CFLAGS) $(OC_CPPFLAGS) $(CPPFLAGS)
 SAK_LINK ?= $(MKEXE_VIA_CC)
 
+# Ensure that $(SAK) doesn't interfere with the "unconfigured system" error
+# message.
+runtime/sak.$(O): | config.status
+
 $(SAK): runtime/sak.$(O)
 	$(call SAK_LINK,$@,$^)
 


### PR DESCRIPTION
Prior to 4.13, running `make` in an empty tree displayed a helpful error message:
```
Please refer to the installation instructions:
- In file INSTALL for Unix systems.
- In file README.win32.adoc for Windows systems.
On Unix systems, if you've just unpacked the distribution,
something like
        ./configure
        make
        make install
should work.
Makefile.config_if_required:29: Makefile.build_config: No such file or directory
make: *** [Makefile:1095: config.status] Error 1
```

Since 4.13, an alternate, much less helpful, error has been displayed. This PR restores the error message by adding the missing dependency on `config.status` to the generation rule for `runtime/sak.$(O)`.