### PR TITLE
Restore helpful error message when make is run before configure (#11347 revisited)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,11 +25,7 @@ OCAMLLEX ?= $(BOOT_OCAMLLEX)
 include Makefile.common
 
 .PHONY: defaultentry
-ifeq "$(NATIVE_COMPILER)" "true"
-defaultentry: world.opt
-else
-defaultentry: world
-endif
+defaultentry: $(DEFAULT_BUILD_TARGET)
 
 ifeq "$(UNIX_OR_WIN32)" "win32"
 LN = cp

--- a/Makefile.build_config.in
+++ b/Makefile.build_config.in
@@ -65,6 +65,11 @@ DOCDIR=@docdir@
 MKEXE_EXP=@mkexe_exp@
 MKDLL_EXP=@mkdll_exp@
 
+# Which make target to build, depending on whether the native compiler
+# has been enabled or not during the configuration stage
+
+DEFAULT_BUILD_TARGET = @default_build_target@
+
 # Platform-dependent assembler files to use to build the runtime
 runtime_ASM_OBJECTS = $(addprefix runtime/,@runtime_asm_objects@)
 

--- a/Makefile.common
+++ b/Makefile.common
@@ -207,7 +207,9 @@ $(ROOTDIR)/%/sak$(EXE):
 	$(MAKE) -C $(ROOTDIR)/$* sak$(EXE)
 
 ifneq "$(REQUIRES_CONFIGURATION)" ""
+ifneq "$(wildcard $(ROOTDIR)/Makefile.config)" ""
 $(ROOTDIR)/%/StdlibModules: $(SAK) ;
+endif
 endif
 
 # Used with the Microsoft toolchain to merge generated manifest files into

--- a/configure
+++ b/configure
@@ -846,6 +846,7 @@ OCAML_VERSION_MAJOR
 OCAML_RELEASE_EXTRA
 OCAML_DEVELOPMENT_VERSION
 VERSION
+default_build_target
 native_compiler
 CONFIGURE_ARGS
 target_alias
@@ -2854,6 +2855,7 @@ ac_configure="$SHELL $ac_aux_dir/configure"  # Please don't use this var.
 
 
 ## Output variables
+
 
 
 
@@ -14445,11 +14447,16 @@ $as_echo "$as_me: the native compiler is disabled" >&6;} ;; #(
     { $as_echo "$as_me:${as_lineno-$LINENO}: the native compiler is not supported on this platform" >&5
 $as_echo "$as_me: the native compiler is not supported on this platform" >&6;} ;; #(
   *,*) :
-    native_compiler=true
- ;; #(
+    native_compiler=true ;; #(
   *) :
      ;;
 esac
+
+if $native_compiler; then :
+  default_build_target=world.opt
+else
+  default_build_target=world
+fi
 
 if ! $native_compiler; then :
   natdynlink=false

--- a/configure.ac
+++ b/configure.ac
@@ -74,6 +74,7 @@ AC_CONFIG_AUX_DIR([build-aux])
 
 AC_SUBST([CONFIGURE_ARGS])
 AC_SUBST([native_compiler])
+AC_SUBST([default_build_target])
 AC_SUBST([VERSION], [AC_PACKAGE_VERSION])
 AC_SUBST([OCAML_DEVELOPMENT_VERSION], [OCAML__DEVELOPMENT_VERSION])
 AC_SUBST([OCAML_RELEASE_EXTRA], [OCAML__RELEASE_EXTRA])
@@ -1194,8 +1195,11 @@ AS_CASE([$enable_native_compiler,$arch],
     [native_compiler=false
     AC_MSG_NOTICE([the native compiler is not supported on this platform])],
   [*,*],
-    [native_compiler=true]
-)
+    [native_compiler=true])
+
+AS_IF([$native_compiler],
+  [default_build_target=world.opt],
+  [default_build_target=world])
 
 AS_IF([! $native_compiler], [natdynlink=false])
 


### PR DESCRIPTION
As the title suggests, this is an alternative proposal to #11347.

The idea is to "hide" a dependency rule that prevents our error message
from being displayed if the tree has not been configured.

It feels a pity though that we have to use such tricks, but I couldn't
find a better way at the moment.

I like this better than #11347 because, to solve the problem, it
*removes* a dependency, rather than adding an (IMO) not-so-legitimate one.