### PR TITLE
READMEs: add note about 5.0 status

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -58,6 +58,8 @@ tools/mantis2gh_stripped.csv typo.missing-header
 
 /.mailmap                typo.long-line typo.missing-header typo.non-ascii
 /CONTRIBUTING.md         typo.non-ascii=may
+/README.adoc             typo.non-ascii=may
+/README.win32.adoc       typo.non-ascii=may
 /.merlin                 typo.missing-header
 /Changes                 typo.utf8 typo.missing-header
 /release-info/News       typo.utf8 typo.missing-header

--- a/README.adoc
+++ b/README.adoc
@@ -1,8 +1,9 @@
 === ⚠️ CAUTION
 
 The developer team is currently preparing the release of OCaml 5.0. This release
-sports a full rewrite of its runtime system in order to support thread-based
-parallelism and effect-based concurrency.
+sports a full rewrite of its runtime system for shared-memory parallel
+programming using domains and native support for concurrent programming using
+effect handlers.
 
 The initial release of OCaml 5.0 will only support the native compiler under
 ARM64 and x86-64 architectures under Linux. On Windows, only the Mingw-w64 port

--- a/README.adoc
+++ b/README.adoc
@@ -1,3 +1,22 @@
+=== ⚠️ CAUTION
+
+The developer team is currently preparing the release of OCaml 5.0. This release
+sports a full rewrite of its runtime system in order to support thread-based
+parallelism and effect-based concurrency.
+
+The initial release of OCaml 5.0 will only support the native compiler under
+ARM64 and x86-64 architectures under Linux. On Windows, only the Mingw-w64 port
+is supported.  Support for other 64-bit architectures and systems, including
+Windows, will be added back in later releases. On 32-bit systems, only the
+bytecode compiler is supported.  Native-code support for these systems is under
+discussion.
+
+Owing to the large number of changes, the initial 5.0 release will be more
+experimental than usual.  It is recommended that all users wanting a stable
+release use the 4.14 release which will continue to be supported and updated
+while 5.0 reaches feature and stability parity. Similarly, if you need one of
+the ports not yet supported in the 5.0 release you must use the 4.14 release.
+
 |=====
 | Branch `trunk` | Branch `4.14` | Branch `4.13` | Branch `4.12`
 

--- a/README.adoc
+++ b/README.adoc
@@ -6,11 +6,11 @@ programming using domains and native support for concurrent programming using
 effect handlers.
 
 The initial release of OCaml 5.0 will only support the native compiler under
-ARM64 and x86-64 architectures under Linux. On Windows, only the Mingw-w64 port
-is supported.  Support for other 64-bit architectures and systems, including
-Windows, will be added back in later releases. On 32-bit systems, only the
-bytecode compiler is supported.  Native-code support for these systems is under
-discussion.
+ARM64 and x86-64 architectures under Linux and macOS. On Windows, only the
+Mingw-w64 port is supported.  Support for other 64-bit architectures and
+systems, including Windows, will be added back in later releases. On 32-bit
+systems, only the bytecode compiler is supported.  Native-code support for these
+systems is under discussion.
 
 Owing to the large number of changes, the initial 5.0 release will be more
 experimental than usual.  It is recommended that all users wanting a stable

--- a/README.adoc
+++ b/README.adoc
@@ -5,18 +5,18 @@ sports a full rewrite of its runtime system for shared-memory parallel
 programming using domains and native support for concurrent programming using
 effect handlers.
 
+Owing to the large number of changes, the initial 5.0 release will be more
+experimental than usual.  It is recommended that all users wanting a stable
+release use the 4.14 release which will continue to be supported and updated
+while 5.0 reaches feature and stability parity. Similarly, if you need one of
+the ports not yet supported in the 5.0 release you must use the 4.14 release.
+
 The initial release of OCaml 5.0 will only support the native compiler under
 ARM64 and x86-64 architectures under Linux and macOS. On Windows, only the
 Mingw-w64 port is supported.  Support for other 64-bit architectures and systems
 will be added back in later releases. On 32-bit systems, only the bytecode
 compiler is supported.  Native-code support for these systems is under
 discussion.
-
-Owing to the large number of changes, the initial 5.0 release will be more
-experimental than usual.  It is recommended that all users wanting a stable
-release use the 4.14 release which will continue to be supported and updated
-while 5.0 reaches feature and stability parity. Similarly, if you need one of
-the ports not yet supported in the 5.0 release you must use the 4.14 release.
 
 |=====
 | Branch `trunk` | Branch `4.14` | Branch `4.13` | Branch `4.12`

--- a/README.adoc
+++ b/README.adoc
@@ -7,10 +7,10 @@ effect handlers.
 
 The initial release of OCaml 5.0 will only support the native compiler under
 ARM64 and x86-64 architectures under Linux and macOS. On Windows, only the
-Mingw-w64 port is supported.  Support for other 64-bit architectures and
-systems, including Windows, will be added back in later releases. On 32-bit
-systems, only the bytecode compiler is supported.  Native-code support for these
-systems is under discussion.
+Mingw-w64 port is supported.  Support for other 64-bit architectures and systems
+will be added back in later releases. On 32-bit systems, only the bytecode
+compiler is supported.  Native-code support for these systems is under
+discussion.
 
 Owing to the large number of changes, the initial 5.0 release will be more
 experimental than usual.  It is recommended that all users wanting a stable

--- a/README.win32.adoc
+++ b/README.win32.adoc
@@ -1,8 +1,9 @@
 === ⚠️ CAUTION
 
 The developer team is currently preparing the release of OCaml 5.0. This release
-sports a full rewrite of its runtime system in order to support thread-based
-parallelism and effect-based concurrency.
+sports a full rewrite of its runtime system for shared-memory parallel
+programming using domains and native support for concurrent programming using
+effect handlers.
 
 The initial release of OCaml 5.0 will only support the native compiler under
 ARM64 and x86-64 architectures under Linux. On Windows, only the Mingw-w64 port

--- a/README.win32.adoc
+++ b/README.win32.adoc
@@ -5,16 +5,16 @@ sports a full rewrite of its runtime system for shared-memory parallel
 programming using domains and native support for concurrent programming using
 effect handlers.
 
-Only the Mingw-w64 port is supported. On 32-bit systems, only the bytecode
-compiler is supported.  Native-code support for these 32-bit systems is under
-discussion. Support for the MSVC and Cygwin ports will be added back in later
-releases.
-
 Owing to the large number of changes, the initial 5.0 release will be more
 experimental than usual.  It is recommended that all users wanting a stable
 release use the 4.14 release which will continue to be supported and updated
 while 5.0 reaches feature and stability parity. Similarly, if you need one of
 the ports not yet supported in the 5.0 release you must use the 4.14 release.
+
+Only the Mingw-w64 port is supported. On 32-bit systems, only the bytecode
+compiler is supported.  Native-code support for these 32-bit systems is under
+discussion. Support for the MSVC and Cygwin ports will be added back in later
+releases.
 
 = Release notes for the Microsoft Windows ports of OCaml =
 :toc: macro

--- a/README.win32.adoc
+++ b/README.win32.adoc
@@ -1,3 +1,22 @@
+=== ⚠️ CAUTION
+
+The developer team is currently preparing the release of OCaml 5.0. This release
+sports a full rewrite of its runtime system in order to support thread-based
+parallelism and effect-based concurrency.
+
+The initial release of OCaml 5.0 will only support the native compiler under
+ARM64 and x86-64 architectures under Linux. On Windows, only the Mingw-w64 port
+is supported.  Support for other 64-bit architectures and systems, including
+Windows, will be added back in later releases. On 32-bit systems, only the
+bytecode compiler is supported.  Native-code support for these systems is under
+discussion.
+
+Owing to the large number of changes, the initial 5.0 release will be more
+experimental than usual.  It is recommended that all users wanting a stable
+release use the 4.14 release which will continue to be supported and updated
+while 5.0 reaches feature and stability parity. Similarly, if you need one of
+the ports not yet supported in the 5.0 release you must use the 4.14 release.
+
 = Release notes for the Microsoft Windows ports of OCaml =
 :toc: macro
 

--- a/README.win32.adoc
+++ b/README.win32.adoc
@@ -6,11 +6,11 @@ programming using domains and native support for concurrent programming using
 effect handlers.
 
 The initial release of OCaml 5.0 will only support the native compiler under
-ARM64 and x86-64 architectures under Linux. On Windows, only the Mingw-w64 port
-is supported.  Support for other 64-bit architectures and systems, including
-Windows, will be added back in later releases. On 32-bit systems, only the
-bytecode compiler is supported.  Native-code support for these systems is under
-discussion.
+ARM64 and x86-64 architectures under Linux and macOS. On Windows, only the
+Mingw-w64 port is supported.  Support for other 64-bit architectures and
+systems, including Windows, will be added back in later releases. On 32-bit
+systems, only the bytecode compiler is supported.  Native-code support for these
+systems is under discussion.
 
 Owing to the large number of changes, the initial 5.0 release will be more
 experimental than usual.  It is recommended that all users wanting a stable

--- a/README.win32.adoc
+++ b/README.win32.adoc
@@ -5,12 +5,10 @@ sports a full rewrite of its runtime system for shared-memory parallel
 programming using domains and native support for concurrent programming using
 effect handlers.
 
-The initial release of OCaml 5.0 will only support the native compiler under
-ARM64 and x86-64 architectures under Linux and macOS. On Windows, only the
-Mingw-w64 port is supported.  Support for other 64-bit architectures and
-systems, including Windows, will be added back in later releases. On 32-bit
-systems, only the bytecode compiler is supported.  Native-code support for these
-systems is under discussion.
+Only the Mingw-w64 port is supported. On 32-bit systems, only the bytecode
+compiler is supported.  Native-code support for these 32-bit systems is under
+discussion. Support for the MSVC and Cygwin ports will be added back in later
+releases.
 
 Owing to the large number of changes, the initial 5.0 release will be more
 experimental than usual.  It is recommended that all users wanting a stable


### PR DESCRIPTION
Add a note about the fact that users wanting a stable release should use 4.14. The note is the same for both READMEs. Suggestions about wording welcome (in fact, feel free to push directly to my branch).

I used a ⚠️symbol in the heading; not sure if we have a policy against that, or if there is a way to do the same using markup...

See  the discussion in https://github.com/ocaml/ocaml/issues/11350#issuecomment-1164054452

Rendered view:
- https://github.com/nojb/ocaml/blob/readme_5.0/README.adoc
- https://github.com/nojb/ocaml/blob/readme_5.0/README.win32.adoc