### PR TITLE
Don't automatically unlock/lock I/O channels managed from C

### DIFF
--- a/runtime/backtrace_byt.c
+++ b/runtime/backtrace_byt.c
@@ -461,7 +461,6 @@ static void read_main_debug_info(struct debug_info *di)
   if (caml_seek_optional_section(fd, &trail, "DBUG") != -1) {
     chan = caml_open_descriptor_in(fd);
 
-    Lock(chan);
     num_events = caml_getword(chan);
     events = caml_alloc(num_events, 0);
 
@@ -477,7 +476,6 @@ static void read_main_debug_info(struct debug_info *di)
       /* Record event list */
       Store_field(events, i, evl);
     }
-    Unlock(chan);
 
     caml_close_channel(chan);
 

--- a/runtime/io.c
+++ b/runtime/io.c
@@ -116,10 +116,13 @@ static void check_pending(struct channel *channel)
 {
   if (caml_check_pending_actions()) {
     /* Temporarily unlock the channel, to ensure locks are not held
-       while any signal handlers (or finalisers, etc) are running */
-    Unlock(channel);
+       while any signal handlers (or finalisers, etc) are running.
+       Don't do this for channels allocated and used from C,
+       as their locks may or may not be taken depending on the
+       usage pattern in the C code. */
+    if (channel->flags & CHANNEL_FLAG_MANAGED_BY_GC) Unlock(channel);
     caml_process_pending_actions();
-    Lock(channel);
+    if (channel->flags & CHANNEL_FLAG_MANAGED_BY_GC) Lock(channel);
   }
 }
 

--- a/runtime/startup_byt.c
+++ b/runtime/startup_byt.c
@@ -560,9 +560,7 @@ CAMLexport void caml_main(char_os **argv)
   /* Load the globals */
   caml_seek_section(fd, &trail, "DATA");
   chan = caml_open_descriptor_in(fd);
-  Lock(chan);
   value global_data = caml_input_val(chan);
-  Unlock(chan);
   caml_modify_generational_global_root(&caml_global_data, global_data);
   caml_close_channel(chan); /* this also closes fd */
   caml_stat_free(trail.section);


### PR DESCRIPTION
I/O channels allocated from C are entirely managed by the C code, including locking and unlocking, so no automatic unlock/lock should take place in `check_pending`.
    
Currently, all channels allocated from C are used in a single-threaded manner and don't need to be locked.  However, they need to be locked in advance to avoid run-time errors when unlocking in check_pending. This is unpleasant and a source of potential errors, as in #11065 .

This PR turns off the unlock/lock dance in `check_pending` for channels allocated from C.  I don't think there's any adverse effect since these channels are not accessible to OCaml code that could be run by finalizers or signal handlers.  As a consequence we can remove a few `Lock`/`Unlock` pairs that were introduced just to please `check_pending`.

Cc: @damiendoligez @sadiqj @stedolan 