### PR TITLE
Make the documentation of `string_of_float` more precise

### DIFF
--- a/stdlib/stdlib.mli
+++ b/stdlib/stdlib.mli
@@ -764,7 +764,9 @@ external int_of_string : string -> int = "caml_int_of_string"
    [Failure "int_of_string"] instead of returning [None]. *)
 
 val string_of_float : float -> string
-(** Return the string representation of a floating-point number. *)
+(** Return a string representation of a floating-point number in decimal
+   notation. For numbers that can't be accurately represented a loss in
+   precision is possible. *)
 
 val float_of_string_opt: string -> float option
 (** Convert the given string to a float.  The string is read in decimal


### PR DESCRIPTION
This PR is inspired by a recent [discussion on caml-list](https://inbox.ocaml.org/caml-list/57A2C5E8-34C7-4B90-9FEF-607B8236E379@mpi-sws.org/T/#mc3caf1db92a3a4bf7de5e92c1cd038f28595af7b) where there was confusion what `string_of_float` does.

The proposal is to change the wording since the output of the function is not "the" string representation of a float but rather "a" string representation. In fact a very specific one.

I would say it is safe to state that `string_of_float` will always return a decimal notation, but the precision of it is probably an implementation detail hence more detail is left out.

I've been debating internally whether it would make sense to point the user to other ways to convert a float to a string with more user control and I'd enjoy to hear your thoughts on it, for now the patch is just a rather conservative wording change.