### PR TITLE
Make List.{map,mapi,map2} TRMC

### DIFF
--- a/Changes
+++ b/Changes
@@ -18,6 +18,10 @@ Working version
 - #10789: Add `Stack.drop`
   (Léo Andrès, review by Gabriel Scherer)
 
+- #11362: List.map, List.mapi and List.map2 are tail-recursive and faster on
+  typical workloads.
+  (Nicolás Ojeda Bär, review by Gabriel Scherer)
+
 ### Other libraries:
 
 ### Tools:

--- a/stdlib/list.ml
+++ b/stdlib/list.ml
@@ -141,10 +141,26 @@ let rec fold_right f l accu =
     [] -> accu
   | a::l -> f a (fold_right f l accu)
 
-let rec map2 f l1 l2 =
+let[@tail_mod_cons] rec map2 f l1 l2 =
   match (l1, l2) with
     ([], []) -> []
-  | (a1::l1, a2::l2) -> let r = f a1 a2 in r :: map2 f l1 l2
+  | ([a1], [b1]) ->
+      let r1 = f a1 b1 in
+      [r1]
+  | ([a1; a2], [b1; b2]) ->
+      let r1 = f a1 b1 in
+      let r2 = f a2 b2 in
+      [r1; r2]
+  | ([a1; a2; a3], [b1; b2; b3]) ->
+      let r1 = f a1 b1 in
+      let r2 = f a2 b2 in
+      let r3 = f a3 b3 in
+      [r1; r2; r3]
+  | (a1::a2::a3::l1, b1::b2::b3::l2) ->
+      let r1 = f a1 b1 in
+      let r2 = f a2 b2 in
+      let r3 = f a3 b3 in
+      r1::r2::r3::map2 f l1 l2
   | (_, _) -> invalid_arg "List.map2"
 
 let rev_map2 f l1 l2 =

--- a/stdlib/list.ml
+++ b/stdlib/list.ml
@@ -92,40 +92,20 @@ let[@tail_mod_cons] rec map f = function
   | [a1] ->
       let r1 = f a1 in
       [r1]
-  | [a1; a2] ->
+  | a1::a2::l ->
       let r1 = f a1 in
       let r2 = f a2 in
-      [r1; r2]
-  | [a1; a2; a3] ->
-      let r1 = f a1 in
-      let r2 = f a2 in
-      let r3 = f a3 in
-      [r1; r2; r3]
-  | a1::a2::a3::l ->
-      let r1 = f a1 in
-      let r2 = f a2 in
-      let r3 = f a3 in
-      r1 :: r2 :: r3 :: map f l
+      r1::r2::map f l
 
 let[@tail_mod_cons] rec mapi i f = function
     [] -> []
   | [a1] ->
       let r1 = f i a1 in
       [r1]
-  | [a1; a2] ->
+  | a1::a2::l ->
       let r1 = f i a1 in
       let r2 = f (i+1) a2 in
-      [r1; r2]
-  | [a1; a2; a3] ->
-      let r1 = f i a1 in
-      let r2 = f (i+1) a2 in
-      let r3 = f (i+2) a3 in
-      [r1; r2; r3]
-  | a1::a2::a3::l ->
-      let r1 = f i a1 in
-      let r2 = f (i+1) a2 in
-      let r3 = f (i+2) a3 in
-      r1::r2::r3::mapi (i+3) f l
+      r1::r2::mapi (i+2) f l
 
 let mapi f l = mapi 0 f l
 
@@ -163,20 +143,10 @@ let[@tail_mod_cons] rec map2 f l1 l2 =
   | ([a1], [b1]) ->
       let r1 = f a1 b1 in
       [r1]
-  | ([a1; a2], [b1; b2]) ->
+  | (a1::a2::l1, b1::b2::l2) ->
       let r1 = f a1 b1 in
       let r2 = f a2 b2 in
-      [r1; r2]
-  | ([a1; a2; a3], [b1; b2; b3]) ->
-      let r1 = f a1 b1 in
-      let r2 = f a2 b2 in
-      let r3 = f a3 b3 in
-      [r1; r2; r3]
-  | (a1::a2::a3::l1, b1::b2::b3::l2) ->
-      let r1 = f a1 b1 in
-      let r2 = f a2 b2 in
-      let r3 = f a3 b3 in
-      r1::r2::r3::map2 f l1 l2
+      r1::r2::map2 f l1 l2
   | (_, _) -> invalid_arg "List.map2"
 
 let rev_map2 f l1 l2 =

--- a/stdlib/list.ml
+++ b/stdlib/list.ml
@@ -107,9 +107,25 @@ let[@tail_mod_cons] rec map f = function
       let r3 = f a3 in
       r1 :: r2 :: r3 :: map f l
 
-let rec mapi i f = function
+let[@tail_mod_cons] rec mapi i f = function
     [] -> []
-  | a::l -> let r = f i a in r :: mapi (i + 1) f l
+  | [a1] ->
+      let r1 = f i a1 in
+      [r1]
+  | [a1; a2] ->
+      let r1 = f i a1 in
+      let r2 = f (i+1) a2 in
+      [r1; r2]
+  | [a1; a2; a3] ->
+      let r1 = f i a1 in
+      let r2 = f (i+1) a2 in
+      let r3 = f (i+2) a3 in
+      [r1; r2; r3]
+  | a1::a2::a3::l ->
+      let r1 = f i a1 in
+      let r2 = f (i+1) a2 in
+      let r3 = f (i+2) a3 in
+      r1::r2::r3::mapi (i+3) f l
 
 let mapi f l = mapi 0 f l
 

--- a/stdlib/list.ml
+++ b/stdlib/list.ml
@@ -87,9 +87,25 @@ let rec flatten = function
 
 let concat = flatten
 
-let rec map f = function
+let[@tail_mod_cons] rec map f = function
     [] -> []
-  | a::l -> let r = f a in r :: map f l
+  | [a1] ->
+      let r1 = f a1 in
+      [r1]
+  | [a1; a2] ->
+      let r1 = f a1 in
+      let r2 = f a2 in
+      [r1; r2]
+  | [a1; a2; a3] ->
+      let r1 = f a1 in
+      let r2 = f a2 in
+      let r3 = f a3 in
+      [r1; r2; r3]
+  | a1::a2::a3::l ->
+      let r1 = f a1 in
+      let r2 = f a2 in
+      let r3 = f a3 in
+      r1 :: r2 :: r3 :: map f l
 
 let rec mapi i f = function
     [] -> []

--- a/stdlib/list.mli
+++ b/stdlib/list.mli
@@ -178,7 +178,7 @@ val map : ('a -> 'b) -> 'a list -> 'b list
 val mapi : (int -> 'a -> 'b) -> 'a list -> 'b list
 (** Same as {!map}, but the function is applied to the index of
    the element as first argument (counting from 0), and the element
-   itself as second argument. Not tail-recursive.
+   itself as second argument.
    @since 4.00.0
  *)
 

--- a/stdlib/list.mli
+++ b/stdlib/list.mli
@@ -172,7 +172,7 @@ val iteri : (int -> 'a -> unit) -> 'a list -> unit
 val map : ('a -> 'b) -> 'a list -> 'b list
 (** [map f [a1; ...; an]] applies function [f] to [a1, ..., an],
    and builds the list [[f a1; ...; f an]]
-   with the results returned by [f]. Not tail-recursive.
+   with the results returned by [f].
  *)
 
 val mapi : (int -> 'a -> 'b) -> 'a list -> 'b list
@@ -184,8 +184,7 @@ val mapi : (int -> 'a -> 'b) -> 'a list -> 'b list
 
 val rev_map : ('a -> 'b) -> 'a list -> 'b list
 (** [rev_map f l] gives the same result as
-   {!rev}[ (]{!map}[ f l)], but is tail-recursive and
-   more efficient.
+   {!rev}[ (]{!map}[ f l)], but is more efficient.
  *)
 
 val filter_map : ('a -> 'b option) -> 'a list -> 'b list

--- a/stdlib/list.mli
+++ b/stdlib/list.mli
@@ -232,13 +232,12 @@ val map2 : ('a -> 'b -> 'c) -> 'a list -> 'b list -> 'c list
 (** [map2 f [a1; ...; an] [b1; ...; bn]] is
    [[f a1 b1; ...; f an bn]].
    @raise Invalid_argument if the two lists are determined
-   to have different lengths. Not tail-recursive.
+   to have different lengths.
  *)
 
 val rev_map2 : ('a -> 'b -> 'c) -> 'a list -> 'b list -> 'c list
 (** [rev_map2 f l1 l2] gives the same result as
-   {!rev}[ (]{!map2}[ f l1 l2)], but is tail-recursive and
-   more efficient.
+   {!rev}[ (]{!map2}[ f l1 l2)], but is more efficient.
  *)
 
 val fold_left2 :

--- a/stdlib/listLabels.mli
+++ b/stdlib/listLabels.mli
@@ -232,13 +232,12 @@ val map2 : f:('a -> 'b -> 'c) -> 'a list -> 'b list -> 'c list
 (** [map2 ~f [a1; ...; an] [b1; ...; bn]] is
    [[f a1 b1; ...; f an bn]].
    @raise Invalid_argument if the two lists are determined
-   to have different lengths. Not tail-recursive.
+   to have different lengths.
  *)
 
 val rev_map2 : f:('a -> 'b -> 'c) -> 'a list -> 'b list -> 'c list
 (** [rev_map2 ~f l1 l2] gives the same result as
-   {!rev}[ (]{!map2}[ f l1 l2)], but is tail-recursive and
-   more efficient.
+   {!rev}[ (]{!map2}[ f l1 l2)], but is more efficient.
  *)
 
 val fold_left2 :

--- a/stdlib/listLabels.mli
+++ b/stdlib/listLabels.mli
@@ -172,7 +172,7 @@ val iteri : f:(int -> 'a -> unit) -> 'a list -> unit
 val map : f:('a -> 'b) -> 'a list -> 'b list
 (** [map ~f [a1; ...; an]] applies function [f] to [a1, ..., an],
    and builds the list [[f a1; ...; f an]]
-   with the results returned by [f]. Not tail-recursive.
+   with the results returned by [f].
  *)
 
 val mapi : f:(int -> 'a -> 'b) -> 'a list -> 'b list
@@ -184,8 +184,7 @@ val mapi : f:(int -> 'a -> 'b) -> 'a list -> 'b list
 
 val rev_map : f:('a -> 'b) -> 'a list -> 'b list
 (** [rev_map ~f l] gives the same result as
-   {!rev}[ (]{!map}[ f l)], but is tail-recursive and
-   more efficient.
+   {!rev}[ (]{!map}[ f l)], but is more efficient.
  *)
 
 val filter_map : f:('a -> 'b option) -> 'a list -> 'b list

--- a/stdlib/listLabels.mli
+++ b/stdlib/listLabels.mli
@@ -178,7 +178,7 @@ val map : f:('a -> 'b) -> 'a list -> 'b list
 val mapi : f:(int -> 'a -> 'b) -> 'a list -> 'b list
 (** Same as {!map}, but the function is applied to the index of
    the element as first argument (counting from 0), and the element
-   itself as second argument. Not tail-recursive.
+   itself as second argument.
    @since 4.00.0
  *)
 

--- a/testsuite/tests/backtrace/backtrace_dynlink.reference
+++ b/testsuite/tests/backtrace/backtrace_dynlink.reference
@@ -1,17 +1,17 @@
 Raised by primitive operation at Backtrace_dynlink_plugin in file "backtrace_dynlink_plugin.ml", line 6, characters 13-38
 Called from Dynlink.Native.run.(fun) in file "otherlibs/dynlink/native/dynlink.ml", line 85, characters 12-29
-Called from Stdlib__List.iter in file "list.ml", line 110, characters 12-15
+Called from Stdlib__List.iter in file "list.ml", line 122, characters 12-15
 Called from Dynlink_common.Make.load.(fun) in file "otherlibs/dynlink/dynlink_common.ml", line 363, characters 13-56
-Called from Stdlib__List.iter in file "list.ml", line 110, characters 12-15
+Called from Stdlib__List.iter in file "list.ml", line 122, characters 12-15
 Called from Dynlink_common.Make.load in file "otherlibs/dynlink/dynlink_common.ml", line 359, characters 8-392
 Called from Dynlink_common.Make.loadfile in file "otherlibs/dynlink/dynlink_common.ml" (inlined), line 374, characters 26-45
 Called from Backtrace_dynlink in file "backtrace_dynlink.ml", line 39, characters 4-52
 execution of module initializers in the shared library failed: Failure("SUCCESS")
 Raised by primitive operation at Dynlink.Native.run.(fun) in file "otherlibs/dynlink/native/dynlink.ml", line 85, characters 12-29
 Re-raised at Dynlink.Native.run.(fun) in file "otherlibs/dynlink/native/dynlink.ml", line 87, characters 10-149
-Called from Stdlib__List.iter in file "list.ml", line 110, characters 12-15
+Called from Stdlib__List.iter in file "list.ml", line 122, characters 12-15
 Called from Dynlink_common.Make.load.(fun) in file "otherlibs/dynlink/dynlink_common.ml", line 363, characters 13-56
-Called from Stdlib__List.iter in file "list.ml", line 110, characters 12-15
+Called from Stdlib__List.iter in file "list.ml", line 122, characters 12-15
 Called from Dynlink_common.Make.load in file "otherlibs/dynlink/dynlink_common.ml", line 359, characters 8-392
 Re-raised at Dynlink_common.Make.load in file "otherlibs/dynlink/dynlink_common.ml", line 372, characters 8-17
 Called from Dynlink_common.Make.loadfile in file "otherlibs/dynlink/dynlink_common.ml" (inlined), line 374, characters 26-45

--- a/testsuite/tests/lib-dynlink-initializers/test10_main.byte.reference
+++ b/testsuite/tests/lib-dynlink-initializers/test10_main.byte.reference
@@ -6,7 +6,7 @@ Called from Test10_plugin in file "test10_plugin.ml", line 10, characters 2-6
 Called from Dynlink.Bytecode.run in file "otherlibs/dynlink/dynlink.ml", line 149, characters 16-25
 Re-raised at Dynlink.Bytecode.run in file "otherlibs/dynlink/dynlink.ml", line 151, characters 6-137
 Called from Dynlink_common.Make.load.(fun) in file "otherlibs/dynlink/dynlink_common.ml", line 363, characters 13-56
-Called from Stdlib__List.iter in file "list.ml", line 110, characters 12-15
+Called from Stdlib__List.iter in file "list.ml", line 122, characters 12-15
 Called from Dynlink_common.Make.load in file "otherlibs/dynlink/dynlink_common.ml", line 359, characters 8-392
 Re-raised at Dynlink_common.Make.load in file "otherlibs/dynlink/dynlink_common.ml", line 372, characters 8-17
 Called from Test10_main in file "test10_main.ml", line 51, characters 13-69

--- a/testsuite/tests/lib-dynlink-initializers/test10_main.native.reference
+++ b/testsuite/tests/lib-dynlink-initializers/test10_main.native.reference
@@ -1,9 +1,9 @@
 Error: Failure("Plugin error")
 Raised by primitive operation at Dynlink.Native.run.(fun) in file "otherlibs/dynlink/native/dynlink.ml", line 85, characters 12-29
 Re-raised at Dynlink.Native.run.(fun) in file "otherlibs/dynlink/native/dynlink.ml", line 87, characters 10-149
-Called from Stdlib__List.iter in file "list.ml", line 110, characters 12-15
+Called from Stdlib__List.iter in file "list.ml", line 122, characters 12-15
 Called from Dynlink_common.Make.load.(fun) in file "otherlibs/dynlink/dynlink_common.ml", line 363, characters 13-56
-Called from Stdlib__List.iter in file "list.ml", line 110, characters 12-15
+Called from Stdlib__List.iter in file "list.ml", line 122, characters 12-15
 Called from Dynlink_common.Make.load in file "otherlibs/dynlink/dynlink_common.ml", line 359, characters 8-392
 Re-raised at Dynlink_common.Make.load in file "otherlibs/dynlink/dynlink_common.ml", line 372, characters 8-17
 Called from Dynlink_common.Make.loadfile in file "otherlibs/dynlink/dynlink_common.ml" (inlined), line 374, characters 26-45


### PR DESCRIPTION
Now that we have TRMC we can make `List.map` (and friends) tail-recursive without harming performance for short lists (the vast majority of uses). Note that owing to the heap-allocated stacks of 5.0, it is much harder to trigger a Stack Overflow even with the non-tail recursive version; however there seems to be a noticeable performance gain in the case of long lists (see below).

The initial version of this PR modifies only `List.map` for purposes of discussion. If there is consensus, we would also adapt other similar functions in the `List` module.

I did a micro-benchmark (https://github.com/nojb/list_trmc/blob/bc6e38cb7a23bb4653b3c36d236c1b821c3bc8a6/test.ml) with the current `trunk` (dd87ff57ea2eb72973ba76817551eecf68375448) on an AMD (Fedora) machine:

```
$ LD_LIBRARY_PATH=~/ocaml/local/lib/ocaml/stublibs PATH=~/ocaml/local/bin:$PATH make
./test.bc
       n    List.map   trmc map
      10    0.00       0.00
     100    0.00       0.00
    1000    0.00       0.00
   10000    0.02       0.03
  100000    0.37       0.39
 1000000    24.57       4.78
./test.exe
       n    List.map   trmc map
      10    0.00       0.00
     100    0.00       0.00
    1000    0.00       0.00
   10000    0.01       0.00
  100000    0.16       0.14
 1000000    6.03       2.37
```
(`.bc` is bytecode, `.exe` is native-code, `n` is the length of list being mapped, each list is averaged over 100 times.)

(EDIT: I edited out a note about not observing the above slowdown under WSL/Windows, but it turns out that I was comparing against an already patched version of OCaml -- doh!)

See also related discussion at #10388 #867 #2199 #7205 #8010.