### PR TITLE
Allow `make -C testuite promote` to take `TEST` and `LIST` variables

### DIFF
--- a/Changes
+++ b/Changes
@@ -25,6 +25,9 @@ Working version
 
 ### Internal/compiler-libs changes:
 
+- #11364: Allow `make -C testsuite promote` to take `TEST` and `LIST` variables
+  (Antal Spector-Zabusky, review by Gabriel Scherer and David Allsopp)
+
 ### Build system:
 
 ### Bug fixes:

--- a/testsuite/HACKING.adoc
+++ b/testsuite/HACKING.adoc
@@ -3,31 +3,52 @@
 == Useful Makefile targets
 
 `make parallel`::
-  runs the tests in parallel using the
+  Runs the tests in parallel using the
   link:https://www.gnu.org/software/parallel/[GNU parallel] tool: tests run
   twice as fast with no difference in output order.
 
 `make all-foo`, `make parallel-foo`::
-  runs only the tests in the directories whose name starts with `foo`:
+  Runs only the tests in the directories whose name starts with `foo`:
   `parallel-typing`, `all-lib`, etc.
 
 `make one DIR=tests/foo`::
-  runs only the tests in the directory `tests/foo`. This is often equivalent to
+  Runs only the tests in the directory `tests/foo`. This is often equivalent to
   `cd tests/foo && make`, but sometimes the latter breaks the test makefile if
   it contains fragile relative filesystem paths. Such errors should be fixed if
   you find them, but `make one DIR=...` is the more reliable option as it runs
   exactly as `make all` which is heavily tested.
 
-`make promote DIR=tests/foo`::
-  Most tests run a program and compare the result of the program, store in a file
-  `foo.result`, with a reference output stored in `foo.reference` -- the test
-  fails if the two output differ. Sometimes a change in result is innocuous, it
-  comes from an intended change in output instead of a regression.
-  `make promote` copies the new result file into the reference file, making the
-  test pass again. Whenever you use this rule please check carefully, using
-  `git diff`, that the change really corresponds to an intended output
-  difference, and not to a regression. You then need to commit the change to
-  reference file, and your commit message should explain why the output changed.
+`make one TEST=tests/foo/bar.ml`::
+  Runs only the specific test `tests/foo/bar.ml`.
+
+`make one LIST=tests.txt`::
+  Runs only the tests in the directories listed in the file `tests.txt`.  The
+  file should contain one directory per line; for instance, if the contents of
+  `tests.txt` are:
++
+....
+tests/foo
+tests/bar
+tests/baz
+....
++
+then this will run all the tests in those three directories.
+
+`make promote DIR=tests/foo`, `make promote TEST=tests/foo/bar.ml`, `make promote LIST=file.txt`::
+  Most tests run a program and compare the result of the program, stored in a
+  file `foo.result`, with a reference output, stored in `foo.reference`; the
+  test fails if the two outputs differ. Similarly, many other tests are expect
+  tests, with the expected output following the code inline in the test file. In
+  both cases, sometimes a change in the result is innocuous, as it comes from an
+  intended change in output instead of a regression. `make promote` is like
+  `make one`, but for each failing test, it copies the new results into the
+  reference files (or into the expect test expected output), making the failing
+  test pass again. Whenever you use this rule please check carefully, using `git
+  diff`, that the changes really correspond to an intended output difference,
+  and not to a regression. You then need to commit the changes to the reference
+  files (or expect test output), and your commit message should explain why the
+  output changed. `make promote` takes the same variables as `make one` to
+  determine which tests to run (there is no analog to `make all`).
 
 == Creating a new test
 

--- a/testsuite/Makefile
+++ b/testsuite/Makefile
@@ -155,7 +155,10 @@ default:
 	@echo "  one TEST=f      launch just this single test"
 	@echo "  one DIR=p       launch the tests located in path p"
 	@echo "  one LIST=f      launch the tests listed in f (one per line)"
-	@echo "  promote DIR=p   promote the reference files for the tests in p"
+	@echo "  promote TEST=f  promote the output for this single test"
+	@echo "  promote DIR=p   promote the output for the tests located in path p"
+	@echo "  promote LIST=f  promote the output for the tests listed in f (one \
+	per line)"
 	@echo "  lib             build library modules"
 	@echo "  tools           build test tools"
 	@echo "  clean           delete generated files"
@@ -253,7 +256,7 @@ one: lib tools
 	@case "$(words $(DIR) $(LIST) $(TEST))" in \
    0) echo 'No value set for variable DIR, LIST or TEST'>&2; exit 1;; \
    1) exit 0;; \
-   *) echo 'Please specify just one of DIR, LIST or TEST'>&2; exit 1;; \
+   *) echo 'Please specify exactly one of DIR, LIST or TEST'>&2; exit 1;; \
    esac
 	@if [ -n '$(DIR)' ] && [ ! -d '$(DIR)' ]; then \
     echo "Directory '$(DIR)' does not exist."; exit 1; \
@@ -317,22 +320,8 @@ clean-one:
 	fi
 
 .PHONY: promote
-promote:
-	@if [ -z "$(DIR)" ]; then \
-	  echo "No value set for variable 'DIR'."; \
-	  exit 1; \
-	fi
-	@if [ ! -d $(DIR) ]; then \
-	  echo "Directory '$(DIR)' does not exist."; \
-	  exit 1; \
-	fi
-	@if $(ocamltest) -list-tests $(DIR) >/dev/null 2>&1; then \
-	  $(MAKE) exec-ocamltest DIR=$(DIR) \
-	    OCAMLTESTENV="OCAMLTESTDIR=$(OCAMLTESTDIR)" \
-	    PROMOTE="true"; \
-	else \
-	  cd $(DIR) && $(MAKE) TERM=dumb BASEDIR=$(BASEDIR) promote; \
-	fi
+promote: lib tools
+	@$(MAKE) one PROMOTE=true
 
 .PHONY: lib
 lib:

--- a/testsuite/Makefile
+++ b/testsuite/Makefile
@@ -147,22 +147,22 @@ endif
 .PHONY: default
 default:
 	@echo "Available targets:"
-	@echo "  all             launch all tests"
-	@echo "  all-foo         launch all tests beginning with foo"
-	@echo "  parallel        launch all tests using GNU parallel"
-	@echo "  parallel-foo    launch all tests beginning with foo using \
+	@echo "  all                        launch all tests"
+	@echo "  all-foo                    launch all tests beginning with foo"
+	@echo "  parallel                   launch all tests using GNU parallel"
+	@echo "  parallel-foo               launch all tests beginning with foo using \
 	GNU parallel"
-	@echo "  one TEST=f      launch just this single test"
-	@echo "  one DIR=p       launch the tests located in path p"
-	@echo "  one LIST=f      launch the tests listed in f (one per line)"
-	@echo "  promote TEST=f  promote the output for this single test"
-	@echo "  promote DIR=p   promote the output for the tests located in path p"
-	@echo "  promote LIST=f  promote the output for the tests listed in f (one \
+	@echo "  one (TEST|DIR|LIST)=x      launch the specified tests ..."
+	@echo "  promote (TEST|DIR|LIST)=x  promote the output for the specified \
+	tests ..."
+	@echo "    ... TEST=f                 ... the single test in the file f"
+	@echo "    ... DIR=d                  ... the tests located in the directory d"
+	@echo "    ... LIST=f                 ... the tests listed in the file f (one \
 	per line)"
-	@echo "  lib             build library modules"
-	@echo "  tools           build test tools"
-	@echo "  clean           delete generated files"
-	@echo "  report          print the report for the last execution"
+	@echo "  lib                        build library modules"
+	@echo "  tools                      build test tools"
+	@echo "  clean                      delete generated files"
+	@echo "  report                     print the report for the last execution"
 	@echo
 	@echo "all*, parallel* and list can automatically re-run failed test"
 	@echo "directories if MAX_TESTSUITE_DIR_RETRIES permits"


### PR DESCRIPTION
The status quo is that you can run any of

```
make -C testsuite one DIR=tests/typing-modules
make -C testsuite one TEST=tests/typing-modules/printing.ml
make -C testsuite one LIST=file
```

if you want to run tests, but you have to run

```
make -C testsuite promote DIR=tests/typing-modules
```

if you want to promote new test output.  This PR attempts to update the machinery for `promote` to be the same as the machinery for `one`, so you can now say

```
make -C testsuite promote TEST=tests/typing-modules/printing.ml
make -C testsuite promote LIST=file
```

as well.

This also fixes an issue where `promote` didn't correctly depend on (`lib` and?) `tools`.

---

I believe this code preserves the existing behavior, as `one` was already checking for a `PROMOTE` variable, except that we change the fallback case to no longer try to `make promote` in the given directory; however, this fallback is currently unused, as the only `Makefile` in `testsuite/tests` is `testsuite/tests/memory-model/Makefile`, which doesn't do any promotion.

(It's not clear to me if this is the sort of change that needs a `Changes` entry, but I'm happy to write one if it does)