### PR TITLE
Make empty types immediate

### DIFF
--- a/Changes
+++ b/Changes
@@ -3,6 +3,9 @@ Working version
 
 ### Language features:
 
+- #9975, #11365: Make empty types (`type t = |`) immediate.
+  (Antal Spector-Zabusky, review by Gabriel Scherer)
+
 ### Runtime system:
 
 ### Code generation and optimizations:

--- a/testsuite/tests/typing-immediate/immediate.ml
+++ b/testsuite/tests/typing-immediate/immediate.ml
@@ -57,16 +57,7 @@ module FM_valid : S
 (* Valid for empty types *)
 module Empty_valid : S = struct type t = | end;;
 [%%expect{|
-Line 1, characters 25-46:
-1 | module Empty_valid : S = struct type t = | end;;
-                             ^^^^^^^^^^^^^^^^^^^^^
-Error: Signature mismatch:
-       Modules do not match: sig type t = | end is not included in S
-       Type declarations do not match:
-         type t = |
-       is not included in
-         type t [@@immediate]
-       The first is not an immediate type.
+module Empty_valid : S
 |}];;
 
 (* Practical usage over modules *)

--- a/testsuite/tests/typing-immediate/immediate.ml
+++ b/testsuite/tests/typing-immediate/immediate.ml
@@ -54,6 +54,21 @@ module M_valid : S
 module FM_valid : S
 |}];;
 
+(* Valid for empty types *)
+module Empty_valid : S = struct type t = | end;;
+[%%expect{|
+Line 1, characters 25-46:
+1 | module Empty_valid : S = struct type t = | end;;
+                             ^^^^^^^^^^^^^^^^^^^^^
+Error: Signature mismatch:
+       Modules do not match: sig type t = | end is not included in S
+       Type declarations do not match:
+         type t = |
+       is not included in
+         type t [@@immediate]
+       The first is not an immediate type.
+|}];;
+
 (* Practical usage over modules *)
 module Foo : sig type t val x : t ref end = struct
   type t = int

--- a/typing/typedecl_immediacy.ml
+++ b/typing/typedecl_immediacy.ml
@@ -29,7 +29,7 @@ let compute_decl env tdecl =
     | None -> Type_immediacy.Unknown
     | Some argrepr -> Ctype.immediacy env argrepr
     end
-  | (Type_variant (_ :: _ as cstrs, _), _) ->
+  | (Type_variant (cstrs, _), _) ->
     if not (List.exists (fun c -> c.Types.cd_args <> Types.Cstr_tuple []) cstrs)
     then
       Type_immediacy.Always


### PR DESCRIPTION
Updates the logic for determining which types are immediate to include empty types such as `type t = |`.  This closes #9975.