### PR TITLE
Two Windows post-10831 clean-ups

### DIFF
--- a/configure
+++ b/configure
@@ -19417,8 +19417,8 @@ fi
 
 case $host in #(
   *-*-mingw32) :
-    bytecclibs="-lws2_32 -lversion -l:libpthread.a -lgcc_eh -lDbgHelp"
-    nativecclibs="-lws2_32 -lversion -l:libpthread.a -lgcc_eh -lDbgHelp" ;; #(
+    bytecclibs="-lws2_32 -lversion -l:libpthread.a -lgcc_eh"
+    nativecclibs="-lws2_32 -lversion -l:libpthread.a -lgcc_eh" ;; #(
   *-pc-windows) :
     bytecclibs="advapi32.lib ws2_32.lib version.lib"
     nativecclibs="advapi32.lib ws2_32.lib version.lib" ;; #(

--- a/configure.ac
+++ b/configure.ac
@@ -2182,8 +2182,8 @@ AC_CHECK_LIB(execinfo, backtrace, cclibs="$cclibs -lexecinfo",[])
 
 AS_CASE([$host],
   [*-*-mingw32],
-    [bytecclibs="-lws2_32 -lversion -l:libpthread.a -lgcc_eh -lDbgHelp"
-    nativecclibs="-lws2_32 -lversion -l:libpthread.a -lgcc_eh -lDbgHelp"],
+    [bytecclibs="-lws2_32 -lversion -l:libpthread.a -lgcc_eh"
+    nativecclibs="-lws2_32 -lversion -l:libpthread.a -lgcc_eh"],
   [*-pc-windows],
     [bytecclibs="advapi32.lib ws2_32.lib version.lib"
     nativecclibs="advapi32.lib ws2_32.lib version.lib"],

--- a/runtime/win32.c
+++ b/runtime/win32.c
@@ -39,9 +39,6 @@
 #include <errno.h>
 #include <string.h>
 #include <signal.h>
-#if defined(DEBUG) || defined(NATIVE_CODE)
-#include <dbghelp.h>
-#endif
 #include "caml/alloc.h"
 #include "caml/codefrag.h"
 #include "caml/fail.h"

--- a/runtime/win32.c
+++ b/runtime/win32.c
@@ -1106,12 +1106,10 @@ int64_t caml_time_counter(void)
 
   if (clock_freq == 0) {
     LARGE_INTEGER f;
-    if (!QueryPerformanceFrequency(&f))
-      return 0;
+    QueryPerformanceFrequency(&f);
     clock_freq = (1000000000.0 / f.QuadPart);
   };
 
-  if (!QueryPerformanceCounter(&now))
-    return 0;
+  QueryPerformanceCounter(&now);
   return (int64_t)(now.QuadPart * clock_freq);
 }

--- a/runtime/win32.c
+++ b/runtime/win32.c
@@ -1090,26 +1090,26 @@ CAMLexport clock_t caml_win32_clock(void)
   return (clock_t)(total / clocks_per_sec);
 }
 
+static double clock_period = 0;
+
 void caml_init_os_params(void)
 {
   SYSTEM_INFO si;
+  LARGE_INTEGER frequency;
 
   /* Get the system page size */
   GetSystemInfo(&si);
   caml_sys_pagesize = si.dwPageSize;
+
+  /* Get the number of nanoseconds for each tick in QueryPerformanceCounter */
+  QueryPerformanceFrequency(&frequency);
+  clock_period = (1000000000.0 / frequency.QuadPart);
 }
 
 int64_t caml_time_counter(void)
 {
-  static double clock_freq = 0;
   LARGE_INTEGER now;
 
-  if (clock_freq == 0) {
-    LARGE_INTEGER f;
-    QueryPerformanceFrequency(&f);
-    clock_freq = (1000000000.0 / f.QuadPart);
-  };
-
   QueryPerformanceCounter(&now);
-  return (int64_t)(now.QuadPart * clock_freq);
+  return (int64_t)(now.QuadPart * clock_period);
 }

--- a/runtime/win32.c
+++ b/runtime/win32.c
@@ -1102,7 +1102,7 @@ void caml_init_os_params(void)
 int64_t caml_time_counter(void)
 {
   static double clock_freq = 0;
-  static LARGE_INTEGER now;
+  LARGE_INTEGER now;
 
   if (clock_freq == 0) {
     LARGE_INTEGER f;


### PR DESCRIPTION
905d17c95ddadfc919d34ef156f656bde8939b55 removed `caml_print_trace`, but left the references to `DbgHelp`. 666a1f27165ac2be1febfed28a66e403fd787745 removed `caml_time_counter`, but not the associated support code for it in `caml_init_os_params`.

The version of `caml_time_counter` added in #10964 is then updated to take advantage of the `frequency` already computed in `caml_init_os_params`.