### PR TITLE
Runtime events size runparams fix

### DIFF
--- a/Changes
+++ b/Changes
@@ -36,6 +36,11 @@ OCaml 5.0
 
 ### Runtime system:
 
+- #11368: Runtime events buffer size OCAMLRUNPARAMS fix
+  The runtime events buffer size can now be set via the 'e' OCAMLRUNPARAM.
+  This is previously mistakenly enabled/disabled tracing instead.
+  (Sadiq Jaffer, review by ?)
+
 - #11308: Add environment variable to preserve runtime_events after exit
   If the environment variable OCAML_RUNTIME_EVENTS_PRESERVE exists then the
   runtime will not remove the runtime events ring buffers at exit. This

--- a/runtime/caml/startup_aux.h
+++ b/runtime/caml/startup_aux.h
@@ -36,7 +36,6 @@ struct caml_params {
   uintnat verb_gc;
   uintnat parser_trace;
   uintnat trace_level;
-  uintnat runtime_events_enabled;
   uintnat runtime_events_log_wsize;
   uintnat verify_heap;
   uintnat print_magic;

--- a/runtime/startup_aux.c
+++ b/runtime/startup_aux.c
@@ -96,7 +96,7 @@ void caml_parse_ocamlrunparam(void)
       switch (*opt++){
       case 'b': scanmult (opt, &params.backtrace_enabled); break;
       case 'c': scanmult (opt, &params.cleanup_on_exit); break;
-      case 'e': scanmult (opt, &params.runtime_events_enabled); break;
+      case 'e': scanmult (opt, &params.runtime_events_log_wsize); break;
       case 'l': scanmult (opt, &params.init_max_stack_wsz); break;
       case 'M': scanmult (opt, &params.init_custom_major_ratio); break;
       case 'm': scanmult (opt, &params.init_custom_minor_ratio); break;

--- a/testsuite/tests/lib-runtime-events/test_caml_runparams.ml
+++ b/testsuite/tests/lib-runtime-events/test_caml_runparams.ml
@@ -1,0 +1,25 @@
+(* TEST
+include runtime_events
+ocamlrunparam += ",e=4"
+*)
+
+(* We set the ring buffer size smaller and witness that we do indeed
+   lose events. *)
+open Runtime_events
+
+let lost_any_events = ref false
+
+let lost_events _domain_id num =
+    if num > 0 then
+        lost_any_events := true
+
+let () =
+    start ();
+    let cursor = create_cursor None in
+    let callbacks = Callbacks.create ~lost_events ()
+    in
+    for epoch = 1 to 20 do
+        Gc.full_major ()
+    done;
+    ignore(read_poll cursor callbacks None);
+    assert(!lost_any_events)


### PR DESCRIPTION
The `OCAMLRUNPARAM` `e` was mistakenly set to control eventring's enabling/disabling in the original PR when instead it should control the ring's size. Enabling/disabling happens via `OCAML_RUNTIME_EVENTS_START` instead.

This PR consists of two commits, the fix https://github.com/ocaml/ocaml/commit/fc6d9c4094a7920facb4219adc9e1c0220349768 and a test https://github.com/ocaml/ocaml/commit/26d99fe236a8ea1341f3a59c80b5d81cd6729d36