### PR TITLE
Remove outdated Visual Studio compatibility code

### DIFF
--- a/README.win32.adoc
+++ b/README.win32.adoc
@@ -108,13 +108,12 @@ C code (`ocamlc -custom`) require a Microsoft Visual C/C++ Compiler and the
 `flexlink` tool (see <<bmflex,above>>).
 
 Any edition (including Express/Community editions) of Microsoft Visual Studio
-2005 or later may be used to provide the required Windows headers and the C
+2008 or later may be used to provide the required Windows headers and the C
 compiler. Additionally, some older Microsoft Windows SDKs include the
 Visual C/C++ Compiler as well as the Build Tools for Visual Studio.
 
 |=====
 |                    | `cl` Version | Express                 | SDK/Build Tools
-| Visual Studio 2005 | 14.00.x.x    | 32-bit only <<vs1,(*)>> |
 | Visual Studio 2008 | 15.00.x.x    | 32-bit only             | Windows SDK 7.0 also provides 32/64-bit compilers
 | Visual Studio 2010 | 16.00.x.x    | 32-bit only             | Windows SDK 7.1 also provides 32/64-bit compilers
 | Visual Studio 2012 | 17.00.x.x    | 32/64-bit               |
@@ -123,11 +122,6 @@ Visual C/C++ Compiler as well as the Build Tools for Visual Studio.
 | Visual Studio 2017 | 19.10.x.x    | 32/64-bit               | Build Tools for Visual Studio 2017 also provides 32/64-bit compilers
 | Visual Studio 2019 | 19.20.x.x    | 32/64-bit               | Build Tools for Visual Studio 2019 also provides 32/64-bit compilers
 |=====
-
-[[vs1]]
-(*):: Visual C++ 2005 Express Edition does not provide an assembler; this can be
-      downloaded separately from
-      https://www.microsoft.com/en-gb/download/details.aspx?id=12654
 
 === COMPILATION FROM THE SOURCES
 
@@ -157,7 +151,7 @@ for 32-bit or:
 
   SetEnv /Release /x64
 
-for 64-bit. For Visual Studio 2005-2013, you need to use one of the shortcuts in
+for 64-bit. For Visual Studio 2008-2013, you need to use one of the shortcuts in
 the "Visual Studio Tools" program group under the main program group for the
 version of Visual Studio you installed. For Visual Studio 2015 and 2017, you
 need to use the shortcuts in the "Windows Desktop Command Prompts" (2015) or
@@ -166,7 +160,7 @@ need to use the shortcuts in the "Windows Desktop Command Prompts" (2015) or
 Unlike `SetEnv` for the Windows SDK, the architecture is selected by using a
 different shortcut, rather than by running a command.
 
-For Visual Studio 2005-2010, excluding version-specific prefixes, these are
+For Visual Studio 2008-2010, excluding version-specific prefixes, these are
 named "Command Prompt" for 32-bit and "x64 Cross Tools Command Prompt" or
 "x64 Win64 Command Prompt" for 64-bit. It does not matter whether you use a
 "Cross Tools" or "Win64" version for x64, this simply refers to whether the

--- a/otherlibs/unix/channels_win32.c
+++ b/otherlibs/unix/channels_win32.c
@@ -79,9 +79,6 @@ CAMLprim value caml_unix_inchannel_of_filedescr(value handle)
   struct channel * chan;
   DWORD err;
 
-#if defined(_MSC_VER) && _MSC_VER < 1400
-  fflush(stdin);
-#endif
   err = check_stream_semantics(handle);
   if (err != 0) {
     caml_win32_maperr(err);

--- a/otherlibs/unix/gettimeofday_win32.c
+++ b/otherlibs/unix/gettimeofday_win32.c
@@ -27,15 +27,7 @@ double caml_unix_gettimeofday_unboxed(value unit)
   FILETIME ft;
   double tm;
   GetSystemTimeAsFileTime(&ft);
-#if defined(_MSC_VER) && _MSC_VER < 1300
-  /* This compiler can't cast uint64_t to double! Fortunately, this doesn't
-     matter since SYSTEMTIME is only ever 63-bit (maximum value 31-Dec-30827
-     23:59:59.999, and it requires some skill to set the clock past 2099!)
-   */
-  tm = *(int64_t *)&ft - epoch_ft; /* shift to Epoch-relative time */
-#else
   tm = *(uint64_t *)&ft - epoch_ft; /* shift to Epoch-relative time */
-#endif
   return (tm * 1e-7);  /* tm is in 100ns */
 }
 

--- a/otherlibs/unix/stat_win32.c
+++ b/otherlibs/unix/stat_win32.c
@@ -167,7 +167,7 @@ static int convert_time(FILETIME* time, __time64_t* result, __time64_t def)
     /* There are 11644473600 seconds between 1 January 1601 (the NT Epoch) and 1
      * January 1970 (the Unix Epoch). FILETIME is measured in 100ns ticks.
      */
-    *result = (utime.QuadPart - INT64_LITERAL(116444736000000000U));
+    *result = (utime.QuadPart - 116444736000000000ULL);
   }
   else {
     *result = def;

--- a/otherlibs/unix/times_win32.c
+++ b/otherlibs/unix/times_win32.c
@@ -20,15 +20,7 @@
 
 
 static double to_sec(FILETIME ft) {
-#if defined(_MSC_VER) && _MSC_VER < 1300
-  /* See gettimeofday.c - it is not possible for these values to be 64-bit, so
-     there's no worry about using a signed struct in order to work around the
-     lack of support for casting int64_t to double.
-   */
-  LARGE_INTEGER tmp;
-#else
   ULARGE_INTEGER tmp;
-#endif
 
   tmp.u.LowPart = ft.dwLowDateTime;
   tmp.u.HighPart = ft.dwHighDateTime;

--- a/otherlibs/unix/utimes_win32.c
+++ b/otherlibs/unix/utimes_win32.c
@@ -31,7 +31,7 @@ static void convert_time(double unixTime, FILETIME* ft)
    * January 1970 (the Unix Epoch). FILETIME is measured in 100ns ticks.
    */
   u.QuadPart =
-    (ULONGLONG)(unixTime * 10000000.0) + INT64_LITERAL(116444736000000000U);
+    (ULONGLONG)(unixTime * 10000000.0) + 116444736000000000ULL;
   ft->dwLowDateTime = u.LowPart;
   ft->dwHighDateTime = u.HighPart;
 }

--- a/otherlibs/unix/windbug.h
+++ b/otherlibs/unix/windbug.h
@@ -37,16 +37,6 @@
 /* Test if we are in dbug mode */
 int  caml_win32_debug_test    (void);
 
-#elif defined(_MSC_VER) && _MSC_VER < 1300
-
-#define DEBUG_PRINT(fmt)
-
-/* __pragma wasn't added until Visual C++ .NET 2002, so simply disable the
-   warning entirely
- */
-
-#pragma warning (disable:4002)
-
 #elif defined(_MSC_VER) && _MSC_VER <= 1400
 
 /* Not all versions of the Visual Studio 2005 C Compiler (Version 14) support

--- a/otherlibs/unix/windbug.h
+++ b/otherlibs/unix/windbug.h
@@ -37,21 +37,6 @@
 /* Test if we are in dbug mode */
 int  caml_win32_debug_test    (void);
 
-#elif defined(_MSC_VER) && _MSC_VER <= 1400
-
-/* Not all versions of the Visual Studio 2005 C Compiler (Version 14) support
-   variadic macros, hence the test for this branch being <= 1400 rather than
-   < 1400.
-   This convoluted pair of macros allow DEBUG_PRINT to remain while temporarily
-   suppressing the warning displayed for a macro called with too many
-   parameters.
- */
-#define DEBUG_PRINT_S(fmt) __pragma(warning(pop))
-#define DEBUG_PRINT \
-  __pragma(warning(push)) \
-  __pragma(warning(disable:4002)) \
-  DEBUG_PRINT_S
-
 #else
 
 /* Visual Studio supports variadic macros in all versions from 2008 (CL 15). */

--- a/runtime/caml/config.h
+++ b/runtime/caml/config.h
@@ -35,6 +35,7 @@
 #endif /* __PIC__ */
 #endif /* HAS_ARCH_CODE32 */
 
+/* No longer used in the codebase, but kept because it was exported */
 #define INT64_LITERAL(s) s ## LL
 
 #if defined(_MSC_VER) && !defined(__cplusplus)

--- a/runtime/caml/config.h
+++ b/runtime/caml/config.h
@@ -35,12 +35,7 @@
 #endif /* __PIC__ */
 #endif /* HAS_ARCH_CODE32 */
 
-/* Microsoft introduced the LL integer literal suffix in Visual C++ .NET 2003 */
-#if defined(_MSC_VER) && _MSC_VER < 1400
-#define INT64_LITERAL(s) s ## i64
-#else
 #define INT64_LITERAL(s) s ## LL
-#endif
 
 #if defined(_MSC_VER) && !defined(__cplusplus)
 #define Caml_inline static __inline

--- a/runtime/caml/misc.h
+++ b/runtime/caml/misc.h
@@ -34,8 +34,7 @@
   /* Supported since at least GCC 3.1 */
   #define CAMLdeprecated_typedef(name, type) \
     typedef type name __attribute ((deprecated))
-#elif defined(_MSC_VER) && _MSC_VER >= 1310
-  /* NB deprecated("message") only supported from _MSC_VER >= 1400 */
+#elif defined(_MSC_VER)
   #define CAMLdeprecated_typedef(name, type) \
     typedef __declspec(deprecated) type name
 #else
@@ -90,7 +89,7 @@ CAMLdeprecated_typedef(addr, char *);
   #define CAMLnoreturn_start
   #define CAMLnoreturn_end __attribute__ ((noreturn))
   #define Noreturn __attribute__ ((noreturn))
-#elif defined(_MSC_VER) && _MSC_VER >= 1500
+#elif defined(_MSC_VER)
   #define CAMLnoreturn_start __declspec(noreturn)
   #define CAMLnoreturn_end
   #define Noreturn
@@ -143,7 +142,7 @@ CAMLdeprecated_typedef(addr, char *);
 #define CAMLalign(n) alignas(n)
 #elif defined(SUPPORTS_ALIGNED_ATTRIBUTE)
 #define CAMLalign(n) __attribute__((aligned(n)))
-#elif defined(_MSC_VER) && _MSC_VER >= 1500
+#elif defined(_MSC_VER)
 #define CAMLalign(n) __declspec(align(n))
 #else
 #error "How do I align values on this platform?"
@@ -171,7 +170,7 @@ CAMLdeprecated_typedef(addr, char *);
   #define CAMLunused_start __attribute__ ((unused))
   #define CAMLunused_end
   #define CAMLunused __attribute__ ((unused))
-#elif defined(_MSC_VER) && _MSC_VER >= 1500
+#elif defined(_MSC_VER)
   #define CAMLunused_start  __pragma( warning (push) )           \
     __pragma( warning (disable:4189 ) )
   #define CAMLunused_end __pragma( warning (pop))

--- a/runtime/caml/misc.h
+++ b/runtime/caml/misc.h
@@ -497,16 +497,13 @@ int caml_runtime_warnings_active(void);
 
 #ifdef DEBUG
 #ifdef ARCH_SIXTYFOUR
-#define Debug_tag(x) (INT64_LITERAL(0xD700D7D7D700D6D7u) \
+#define Debug_tag(x) (0xD700D7D7D700D6D7ull \
                       | ((uintnat) (x) << 16) \
                       | ((uintnat) (x) << 48))
-#define Is_debug_tag(x) \
-  (((x) & \
-      INT64_LITERAL(0xff00ffffff00ffffu)) == INT64_LITERAL(0xD700D7D7D700D6D7u))
+#define Is_debug_tag(x) (((x) & 0xff00ffffff00ffffull) == 0xD700D7D7D700D6D7ull)
 #else
 #define Debug_tag(x) (0xD700D6D7ul | ((uintnat) (x) << 16))
-#define Is_debug_tag(x) \
-  (((x) & 0xff00fffful) == 0xD700D6D7ul)
+#define Is_debug_tag(x) (((x) & 0xff00fffful) == 0xD700D6D7ul)
 #endif /* ARCH_SIXTYFOUR */
 
 /*

--- a/runtime/interp.c
+++ b/runtime/interp.c
@@ -1370,7 +1370,7 @@ do_resume: {
 
 #ifndef THREADED_CODE
     default:
-#if _MSC_VER >= 1200
+#ifdef _MSC_VER
       __assume(0);
 #else
       caml_fatal_error("bad opcode (%"

--- a/runtime/ints.c
+++ b/runtime/ints.c
@@ -524,14 +524,14 @@ CAMLprim value caml_int64_bswap(value v)
 {
   int64_t x = Int64_val(v);
   return caml_copy_int64
-    (((x & INT64_LITERAL(0x00000000000000FFU)) << 56) |
-     ((x & INT64_LITERAL(0x000000000000FF00U)) << 40) |
-     ((x & INT64_LITERAL(0x0000000000FF0000U)) << 24) |
-     ((x & INT64_LITERAL(0x00000000FF000000U)) << 8) |
-     ((x & INT64_LITERAL(0x000000FF00000000U)) >> 8) |
-     ((x & INT64_LITERAL(0x0000FF0000000000U)) >> 24) |
-     ((x & INT64_LITERAL(0x00FF000000000000U)) >> 40) |
-     ((x & INT64_LITERAL(0xFF00000000000000U)) >> 56));
+    (((x & 0x00000000000000FFULL) << 56) |
+     ((x & 0x000000000000FF00ULL) << 40) |
+     ((x & 0x0000000000FF0000ULL) << 24) |
+     ((x & 0x00000000FF000000ULL) << 8) |
+     ((x & 0x000000FF00000000ULL) >> 8) |
+     ((x & 0x0000FF0000000000ULL) >> 24) |
+     ((x & 0x00FF000000000000ULL) >> 40) |
+     ((x & 0xFF00000000000000ULL) >> 56));
 }
 
 CAMLprim value caml_int64_of_int(value v)

--- a/runtime/startup_byt.c
+++ b/runtime/startup_byt.c
@@ -441,7 +441,7 @@ static void do_print_config(void)
 extern void caml_signal_thread(void * lpParam);
 #endif
 
-#if defined(_MSC_VER) && __STDC_SECURE_LIB__ >= 200411L
+#ifdef _MSC_VER
 
 /* PR 4887: avoid crash box of windows runtime on some system calls */
 extern void caml_install_invalid_parameter_handler(void);
@@ -475,7 +475,7 @@ CAMLexport void caml_main(char_os **argv)
   caml_init_codefrag();
 
   caml_init_locale();
-#if defined(_MSC_VER) && __STDC_SECURE_LIB__ >= 200411L
+#ifdef _MSC_VER
   caml_install_invalid_parameter_handler();
 #endif
   caml_init_custom_operations();
@@ -619,7 +619,7 @@ CAMLexport value caml_startup_code_exn(
   caml_init_codefrag();
 
   caml_init_locale();
-#if defined(_MSC_VER) && __STDC_SECURE_LIB__ >= 200411L
+#ifdef _MSC_VER
   caml_install_invalid_parameter_handler();
 #endif
   caml_init_custom_operations();

--- a/runtime/startup_nat.c
+++ b/runtime/startup_nat.c
@@ -75,7 +75,7 @@ extern value caml_start_program (caml_domain_state*);
 extern void caml_win32_overflow_detection (void);
 #endif
 
-#if defined(_MSC_VER) && __STDC_SECURE_LIB__ >= 200411L
+#ifdef _MSC_VER
 
 /* PR 4887: avoid crash box of windows runtime on some system calls */
 extern void caml_install_invalid_parameter_handler(void);
@@ -102,7 +102,7 @@ value caml_startup_common(char_os **argv, int pooling)
 
   caml_init_codefrag();
   caml_init_locale();
-#if defined(_MSC_VER) && __STDC_SECURE_LIB__ >= 200411L
+#ifdef _MSC_VER
   caml_install_invalid_parameter_handler();
 #endif
   caml_init_custom_operations();

--- a/runtime/win32.c
+++ b/runtime/win32.c
@@ -638,7 +638,7 @@ int caml_win32_random_seed (intnat data[16])
 }
 
 
-#if defined(_MSC_VER) && __STDC_SECURE_LIB__ >= 200411L
+#ifdef _MSC_VER
 
 static void invalid_parameter_handler(const wchar_t* expression,
    const wchar_t* function,

--- a/runtime/win32.c
+++ b/runtime/win32.c
@@ -1089,7 +1089,7 @@ CAMLexport clock_t caml_win32_clock(void)
   total += tmp.QuadPart;
 
   /* total in 100-nanosecond intervals (1e7 / CLOCKS_PER_SEC) */
-  clocks_per_sec = INT64_LITERAL(10000000U) / (ULONGLONG)CLOCKS_PER_SEC;
+  clocks_per_sec = 10000000ULL / (ULONGLONG)CLOCKS_PER_SEC;
   return (clock_t)(total / clocks_per_sec);
 }
 
@@ -1135,7 +1135,7 @@ void caml_init_os_params(void)
   /* Convert a FILETIME in 100ns ticks since 1 January 1601 to
      ns since 1 Jan 1970. */
   clock_offset.QuadPart =
-    ((now.QuadPart - INT64_LITERAL(0x19DB1DED53E8000U)) * 100);
+    ((now.QuadPart - 0x19DB1DED53E8000ULL) * 100);
 
   /* Get the offset between QueryPerformanceCounter and
      GetSystemTimePreciseAsFileTime in order to return a true timestamp, rather

--- a/stdlib/headernt.c
+++ b/stdlib/headernt.c
@@ -34,7 +34,7 @@
 char * default_runtime_name = RUNTIME_NAME;
 
 static
-#if _MSC_VER >= 1200
+#ifdef _MSC_VER
 __forceinline
 #else
 __inline
@@ -124,7 +124,7 @@ static __inline void __declspec(noreturn) run_runtime(wchar_t * runtime,
     write_console(errh, runtime);
     write_console(errh, L"\r\n");
     ExitProcess(2);
-#if _MSC_VER >= 1200
+#ifdef _MSC_VER
     __assume(0); /* Not reached */
 #endif
   }
@@ -147,7 +147,7 @@ static __inline void __declspec(noreturn) run_runtime(wchar_t * runtime,
     write_console(errh, runtime);
     write_console(errh, L"\r\n");
     ExitProcess(2);
-#if _MSC_VER >= 1200
+#ifdef _MSC_VER
     __assume(0); /* Not reached */
 #endif
   }
@@ -156,7 +156,7 @@ static __inline void __declspec(noreturn) run_runtime(wchar_t * runtime,
   GetExitCodeProcess(procinfo.hProcess , &retcode);
   CloseHandle(procinfo.hProcess);
   ExitProcess(retcode);
-#if _MSC_VER >= 1200
+#ifdef _MSC_VER
     __assume(0); /* Not reached */
 #endif
 }
@@ -179,7 +179,7 @@ int wmain(void)
     write_console(errh, truename);
     write_console(errh, L" not found or is not a bytecode executable file\r\n");
     ExitProcess(2);
-#if _MSC_VER >= 1200
+#ifdef _MSC_VER
     __assume(0); /* Not reached */
 #endif
   }
@@ -187,7 +187,7 @@ int wmain(void)
   MultiByteToWideChar(CP, 0, runtime_path, -1, wruntime_path,
                       sizeof(wruntime_path)/sizeof(wchar_t));
   run_runtime(wruntime_path , cmdline);
-#if _MSC_VER >= 1200
+#ifdef _MSC_VER
     __assume(0); /* Not reached */
 #endif
 #ifdef __MINGW32__


### PR DESCRIPTION
This is a prerequisite for a (non-critical) bug fix, but the fix would have to be made twice. This PR drops support for Visual Studio 2005 (!!) and earlier.

I haven't done a Changes entry because MSVC remains broken - I did however test this PR rebased onto 4.14 in precheck. More versions of Visual Studio are obviously due for the chop, but this removes virtually all of the alternate C code, so I'd prefer to leave further chopping to another day.