### PR TITLE
Do not pass -ccopt flags to linker

### DIFF
--- a/utils/ccomp.ml
+++ b/utils/ccomp.ml
@@ -184,7 +184,7 @@ let call_linker mode output_name files extra =
           (quote_files (remove_Wl files))
           extra
       else
-        Printf.sprintf "%s -o %s %s %s %s %s %s"
+        Printf.sprintf "%s -o %s %s %s %s %s"
           (match !Clflags.c_compiler, mode with
           | Some cc, _ -> cc
           | None, Exe -> Config.mkexe
@@ -195,7 +195,6 @@ let call_linker mode output_name files extra =
           (Filename.quote output_name)
           ""  (*(Clflags.std_include_flag "-I")*)
           (quote_prefixed "-L" (Load_path.get_paths ()))
-          (String.concat " " (List.rev !Clflags.all_ccopts))
           (quote_files files)
           extra
     in


### PR DESCRIPTION
Currently `-ccopt` arguments are passed to the linker. This is less visible on Unix because `gcc` is used as linker and so it doesn't complain about compilation flags being passed at the linking step. But on Windows this causes a fatal error with `flexlink`.

The fix seems to work in small-scale testing, but am not sure if this could break something...

Fixes #11370