### PR TITLE
Don't use CFLAGS when testing flexlink

### DIFF
--- a/Changes
+++ b/Changes
@@ -482,6 +482,10 @@ OCaml 5.0
   removing it from the default namespace.
   (David Allsopp, review by Sébastien Hinderer)
 
+- #11370, #11373: Don't pass CFLAGS to flexlink during configure.
+  (David Allsopp, report by William Hu, review by Xavier Leroy and
+   Sébastien Hinderer)
+
 ### Bug fixes:
 
 - #10768, #11340: Fix typechecking regression when combining first class

--- a/aclocal.m4
+++ b/aclocal.m4
@@ -352,6 +352,7 @@ AC_DEFUN([OCAML_TEST_FLEXLINK], [
     CC="$1 -chain $2 -exe"
     LIBS="conftest2.$ac_objext"
     CPPFLAGS="$3 $CPPFLAGS"
+    CFLAGS=""
     AC_LINK_IFELSE(
       [AC_LANG_SOURCE([int main() { return 0; }])],
       [AC_MSG_RESULT([yes])],

--- a/configure
+++ b/configure
@@ -13083,6 +13083,7 @@ esac
     CC="$flexlink -chain $flexdll_chain -exe"
     LIBS="conftest2.$ac_objext"
     CPPFLAGS="$internal_cppflags $CPPFLAGS"
+    CFLAGS=""
     cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 int main() { return 0; }


### PR DESCRIPTION
#10413 ensures that `CFLAGS` never makes it as far as `flexlink` - we should be doing the same thing with it when testing `flexlink` it in `configure`.

`flexlink` contains support for ignoring some options both for the C compiler and for the C pre-processor - `$CPPFLAGS` is still allowed through because it may include `-I` options necessary for linking.