### PR TITLE
Eliminate invalid pointer cast in Unix.gettimeofday along with some legacy code

### DIFF
--- a/Changes
+++ b/Changes
@@ -87,7 +87,8 @@ Working version
   in Windows implementation of Unix.gettimeofday. Windows implementations of
   caml_unix_map_file, caml_unix_lseek and caml_unix_lseek_64 now release the
   runtime lock. Windows implementation of caml_unix_lockf modernised and
-  simplified.
+  simplified. Where possible, 64 bit integers are used instead of LARGE_INTEGER
+  structs.
   (David Allsopp, review by Jonah Beckford and Xavier Leroy)
 
 - #11475: Make Unix terminal interface bindings domain-safe

--- a/Changes
+++ b/Changes
@@ -84,9 +84,10 @@ Working version
 ### Other libraries:
 
 - #11374: Remove pointer cast to a type with stricter alignment requirements
-  in Windows implementation of Unix.gettimeofday. Windows implementation of
-  caml_unix_map_file now releases the runtime lock while creating the map.
-  Windows implementation of caml_unix_lockf modernised and simplified.
+  in Windows implementation of Unix.gettimeofday. Windows implementations of
+  caml_unix_map_file, caml_unix_lseek and caml_unix_lseek_64 now release the
+  runtime lock. Windows implementation of caml_unix_lockf modernised and
+  simplified.
   (David Allsopp, review by Jonah Beckford and Xavier Leroy)
 
 - #11475: Make Unix terminal interface bindings domain-safe

--- a/Changes
+++ b/Changes
@@ -86,6 +86,7 @@ Working version
 - #11374: Remove pointer cast to a type with stricter alignment requirements
   in Windows implementation of Unix.gettimeofday. Windows implementation of
   caml_unix_map_file now releases the runtime lock while creating the map.
+  Windows implementation of caml_unix_lockf modernised and simplified.
   (David Allsopp, review by Jonah Beckford and Xavier Leroy)
 
 - #11475: Make Unix terminal interface bindings domain-safe

--- a/Changes
+++ b/Changes
@@ -83,6 +83,10 @@ Working version
 
 ### Other libraries:
 
+- #11374: Remove pointer cast to a type with stricter alignment requirements
+  in Windows implementation of Unix.gettimeofday.
+  (David Allsopp, review by Jonah Beckford and Xavier Leroy)
+
 - #11475: Make Unix terminal interface bindings domain-safe
   (Olivier Nicole and Xavier Leroy, review by Xavier Leroy)
 

--- a/Changes
+++ b/Changes
@@ -84,7 +84,8 @@ Working version
 ### Other libraries:
 
 - #11374: Remove pointer cast to a type with stricter alignment requirements
-  in Windows implementation of Unix.gettimeofday.
+  in Windows implementation of Unix.gettimeofday. Windows implementation of
+  caml_unix_map_file now releases the runtime lock while creating the map.
   (David Allsopp, review by Jonah Beckford and Xavier Leroy)
 
 - #11475: Make Unix terminal interface bindings domain-safe

--- a/otherlibs/unix/gettimeofday_win32.c
+++ b/otherlibs/unix/gettimeofday_win32.c
@@ -19,9 +19,6 @@
 
 #include "unixsupport.h"
 
-/* Unix epoch as a Windows timestamp in hundreds of ns */
-#define epoch_ft 116444736000000000.0;
-
 double caml_unix_gettimeofday_unboxed(value unit)
 {
   FILETIME ft;
@@ -30,7 +27,7 @@ double caml_unix_gettimeofday_unboxed(value unit)
   GetSystemTimeAsFileTime(&ft);
   utime.LowPart = ft.dwLowDateTime;
   utime.HighPart = ft.dwHighDateTime;
-  tm = utime.QuadPart - epoch_ft; /* shift to Epoch-relative time */
+  tm = utime.QuadPart - CAML_NT_EPOCH_100ns_TICKS;
   return (tm * 1e-7);  /* tm is in 100ns */
 }
 

--- a/otherlibs/unix/gettimeofday_win32.c
+++ b/otherlibs/unix/gettimeofday_win32.c
@@ -26,8 +26,11 @@ double caml_unix_gettimeofday_unboxed(value unit)
 {
   FILETIME ft;
   double tm;
+  ULARGE_INTEGER utime;
   GetSystemTimeAsFileTime(&ft);
-  tm = *(uint64_t *)&ft - epoch_ft; /* shift to Epoch-relative time */
+  utime.LowPart = ft.dwLowDateTime;
+  utime.HighPart = ft.dwHighDateTime;
+  tm = utime.QuadPart - epoch_ft; /* shift to Epoch-relative time */
   return (tm * 1e-7);  /* tm is in 100ns */
 }
 

--- a/otherlibs/unix/gettimeofday_win32.c
+++ b/otherlibs/unix/gettimeofday_win32.c
@@ -17,17 +17,17 @@
 #include <caml/alloc.h>
 #include <time.h>
 
+#define CAML_INTERNALS
+#include <caml/winsupport.h>
+
 #include "unixsupport.h"
 
 double caml_unix_gettimeofday_unboxed(value unit)
 {
-  FILETIME ft;
+  CAML_ULONGLONG_FILETIME utime;
   double tm;
-  ULARGE_INTEGER utime;
-  GetSystemTimeAsFileTime(&ft);
-  utime.LowPart = ft.dwLowDateTime;
-  utime.HighPart = ft.dwHighDateTime;
-  tm = utime.QuadPart - CAML_NT_EPOCH_100ns_TICKS;
+  GetSystemTimeAsFileTime(&utime.ft);
+  tm = utime.ul - CAML_NT_EPOCH_100ns_TICKS;
   return (tm * 1e-7);  /* tm is in 100ns */
 }
 

--- a/otherlibs/unix/lockf_win32.c
+++ b/otherlibs/unix/lockf_win32.c
@@ -54,21 +54,11 @@ CAMLprim value caml_unix_lockf(value fd, value cmd, value span)
   OVERLAPPED overlap;
   intnat l_len;
   HANDLE h;
-  OSVERSIONINFO version;
   LARGE_INTEGER cur_position;
   LARGE_INTEGER beg_position;
   LARGE_INTEGER lock_len;
   LARGE_INTEGER zero;
   DWORD err = NO_ERROR;
-
-  version.dwOSVersionInfoSize = sizeof(OSVERSIONINFO);
-  if(GetVersionEx(&version) == 0) {
-    caml_invalid_argument("lockf only supported on WIN32_NT platforms:"
-                     " could not determine current platform.");
-  }
-  if(version.dwPlatformId != VER_PLATFORM_WIN32_NT) {
-    caml_invalid_argument("lockf only supported on WIN32_NT platforms");
-  }
 
   h = Handle_val(fd);
 

--- a/otherlibs/unix/lseek_win32.c
+++ b/otherlibs/unix/lseek_win32.c
@@ -15,6 +15,7 @@
 
 #include <caml/mlvalues.h>
 #include <caml/alloc.h>
+#include <caml/signals.h>
 #include "unixsupport.h"
 
 #ifdef HAS_UNISTD
@@ -33,41 +34,44 @@ static DWORD seek_command_table[] = {
 #define INVALID_SET_FILE_POINTER (-1)
 #endif
 
-static __int64 caml_set_file_pointer(HANDLE h, __int64 dist, DWORD mode)
-{
-  LARGE_INTEGER i;
-  DWORD err;
-
-  i.QuadPart = dist;
-  i.LowPart = SetFilePointer(h, i.LowPart, &i.HighPart, mode);
-  if (i.LowPart == INVALID_SET_FILE_POINTER) {
-    err = GetLastError();
-    if (err != NO_ERROR) {
-      caml_win32_maperr(err);
-      caml_uerror("lseek", Nothing);
-    }
-  }
-  return i.QuadPart;
-}
-
 CAMLprim value caml_unix_lseek(value fd, value ofs, value cmd)
 {
-  __int64 ret;
+  LARGE_INTEGER i;
+  HANDLE h = Handle_val(fd);
+  BOOL success;
 
-  ret = caml_set_file_pointer(Handle_val(fd), Long_val(ofs),
-                              seek_command_table[Int_val(cmd)]);
-  if (ret > Max_long) {
+  i.QuadPart = Long_val(ofs);
+
+  caml_enter_blocking_section();
+  success = SetFilePointerEx(h, i, &i, seek_command_table[Int_val(cmd)]);
+  caml_leave_blocking_section();
+
+  if (!success) {
+    caml_win32_maperr(GetLastError());
+    caml_uerror("lseek", Nothing);
+  }
+  if (i.QuadPart > Max_long) {
     caml_win32_maperr(ERROR_ARITHMETIC_OVERFLOW);
     caml_uerror("lseek", Nothing);
   }
-  return Val_long(ret);
+  return Val_long(i.QuadPart);
 }
 
 CAMLprim value caml_unix_lseek_64(value fd, value ofs, value cmd)
 {
-  __int64 ret;
+  LARGE_INTEGER i;
+  HANDLE h = Handle_val(fd);
+  BOOL success;
 
-  ret = caml_set_file_pointer(Handle_val(fd), Int64_val(ofs),
-                              seek_command_table[Int_val(cmd)]);
-  return caml_copy_int64(ret);
+  i.QuadPart = Long_val(ofs);
+
+  caml_enter_blocking_section();
+  success = SetFilePointerEx(h, i, &i, seek_command_table[Int_val(cmd)]);
+  caml_leave_blocking_section();
+
+  if (!success) {
+    caml_win32_maperr(GetLastError());
+    caml_uerror("lseek", Nothing);
+  }
+  return caml_copy_int64(i.QuadPart);
 }

--- a/otherlibs/unix/mmap_win32.c
+++ b/otherlibs/unix/mmap_win32.c
@@ -140,29 +140,3 @@ void caml_ba_unmap_file(void * addr, uintnat len)
   delta = (uintnat) addr % sysinfo.dwAllocationGranularity;
   UnmapViewOfFile((void *)((uintnat)addr - delta));
 }
-
-#ifdef IN_OCAML_BIGARRAY
-
-/* This function reports a Win32 error as a Sys_error exception.
-   It is included for backward compatibility with the old
-   Bigarray.*.map_file implementation.  */
-
-static void caml_ba_sys_error(void)
-{
-  wchar_t buffer[512];
-  DWORD errnum;
-
-  errnum = GetLastError();
-  if (!FormatMessage(FORMAT_MESSAGE_FROM_SYSTEM|FORMAT_MESSAGE_IGNORE_INSERTS,
-                     NULL,
-                     errnum,
-                     0,
-                     buffer,
-                     sizeof(buffer)/sizeof(wchar_t),
-                     NULL))
-    swprintf(buffer, sizeof(buffer)/sizeof(wchar_t),
-             L"Unknown error %ld\n", errnum);
-  caml_raise_sys_error(caml_copy_string_of_utf16(buffer));
-}
-
-#endif

--- a/otherlibs/unix/stat_win32.c
+++ b/otherlibs/unix/stat_win32.c
@@ -164,10 +164,7 @@ static void convert_time(FILETIME* time, __time64_t* result, __time64_t def)
   ULARGE_INTEGER utime = {{time->dwLowDateTime, time->dwHighDateTime}};
 
   if (utime.QuadPart) {
-    /* There are 11644473600 seconds between 1 January 1601 (the NT Epoch) and 1
-     * January 1970 (the Unix Epoch). FILETIME is measured in 100ns ticks.
-     */
-    *result = (utime.QuadPart - 116444736000000000ULL);
+    *result = (utime.QuadPart - CAML_NT_EPOCH_100ns_TICKS);
   }
   else {
     *result = def;

--- a/otherlibs/unix/stat_win32.c
+++ b/otherlibs/unix/stat_win32.c
@@ -155,7 +155,7 @@ static value stat_aux(int use_64, __int64 st_ino, struct _stat64 *buf)
  * Microsoft CRT given in Microsoft Visual Studio 2013 Express
  */
 
-static int convert_time(FILETIME* time, __time64_t* result, __time64_t def)
+static void convert_time(FILETIME* time, __time64_t* result, __time64_t def)
 {
   /* Tempting though it may be, MSDN prohibits casting FILETIME directly
    * to __int64 for alignment concerns. While this doesn't affect our supported
@@ -172,8 +172,6 @@ static int convert_time(FILETIME* time, __time64_t* result, __time64_t def)
   else {
     *result = def;
   }
-
-  return 1;
 }
 
 /* path allocated outside the OCaml heap */
@@ -294,12 +292,9 @@ static int safe_do_stat(int do_lstat, int use_64, wchar_t* path, HANDLE fstat, _
       return 0;
     }
 
-    if (!convert_time(&info.ftLastWriteTime, &res->st_mtime, 0) ||
-        !convert_time(&info.ftLastAccessTime, &res->st_atime, res->st_mtime) ||
-        !convert_time(&info.ftCreationTime, &res->st_ctime, res->st_mtime)) {
-      caml_win32_maperr(GetLastError());
-      return 0;
-    }
+    convert_time(&info.ftLastWriteTime, &res->st_mtime, 0);
+    convert_time(&info.ftLastAccessTime, &res->st_atime, res->st_mtime);
+    convert_time(&info.ftCreationTime, &res->st_ctime, res->st_mtime);
 
     /*
      * Note MS CRT (still) puts st_nlink = 1 and gives st_ino = 0

--- a/otherlibs/unix/times_win32.c
+++ b/otherlibs/unix/times_win32.c
@@ -20,10 +20,7 @@
 
 
 static double to_sec(FILETIME ft) {
-  ULARGE_INTEGER tmp;
-
-  tmp.u.LowPart = ft.dwLowDateTime;
-  tmp.u.HighPart = ft.dwHighDateTime;
+  ULARGE_INTEGER tmp = {{ft.dwLowDateTime, ft.dwHighDateTime}};
 
   /* convert to seconds:
      GetProcessTimes returns number of 100-nanosecond intervals */

--- a/otherlibs/unix/unixsupport.h
+++ b/otherlibs/unix/unixsupport.h
@@ -87,6 +87,12 @@ extern SOCKET caml_win32_socket(int domain, int type, int protocol,
                                 BOOL inherit);
 
 extern void caml_win32_maperr(DWORD errcode);
+
+/* There are 11644473600 seconds between 1 January 1601 (the NT Epoch) and 1
+ * January 1970 (the Unix Epoch). FILETIME is measured in 100ns ticks.
+ */
+#define CAML_NT_EPOCH_100ns_TICKS 116444736000000000ULL
+
 #endif /* _WIN32 */
 
 #define Nothing ((value) 0)

--- a/otherlibs/unix/utimes_win32.c
+++ b/otherlibs/unix/utimes_win32.c
@@ -27,11 +27,8 @@
 static void convert_time(double unixTime, FILETIME* ft)
 {
   ULARGE_INTEGER u;
-  /* There are 11644473600 seconds between 1 January 1601 (the NT Epoch) and 1
-   * January 1970 (the Unix Epoch). FILETIME is measured in 100ns ticks.
-   */
   u.QuadPart =
-    (ULONGLONG)(unixTime * 10000000.0) + 116444736000000000ULL;
+    (ULONGLONG)(unixTime * 10000000.0) + CAML_NT_EPOCH_100ns_TICKS;
   ft->dwLowDateTime = u.LowPart;
   ft->dwHighDateTime = u.HighPart;
 }

--- a/runtime/caml/winsupport.h
+++ b/runtime/caml/winsupport.h
@@ -60,6 +60,11 @@ typedef struct _REPARSE_DATA_BUFFER
 } REPARSE_DATA_BUFFER, *PREPARSE_DATA_BUFFER;
 #endif
 
+typedef union {
+  FILETIME ft;
+  ULONGLONG ul;
+} CAML_ULONGLONG_FILETIME;
+
 #endif
 
 #endif /* CAML_WINSUPPORT_H */

--- a/runtime/win32.c
+++ b/runtime/win32.c
@@ -1073,24 +1073,19 @@ int caml_num_rows_fd(int fd)
 /* UCRT clock function returns wall-clock time */
 CAMLexport clock_t caml_win32_clock(void)
 {
-  FILETIME c, e, stime, utime;
+  FILETIME _creation, _exit;
+  CAML_ULONGLONG_FILETIME stime, utime;
   ULARGE_INTEGER tmp;
-  ULONGLONG total, clocks_per_sec;
+  ULONGLONG clocks_per_sec;
 
-  if (!(GetProcessTimes(GetCurrentProcess(), &c, &e, &stime, &utime))) {
+  if (!(GetProcessTimes(GetCurrentProcess(), &_creation, &_exit,
+                        &stime.ft, &utime.ft))) {
     return (clock_t)(-1);
   }
 
-  tmp.LowPart = stime.dwLowDateTime;
-  tmp.HighPart = stime.dwHighDateTime;
-  total = tmp.QuadPart;
-  tmp.LowPart = utime.dwLowDateTime;
-  tmp.HighPart = utime.dwHighDateTime;
-  total += tmp.QuadPart;
-
   /* total in 100-nanosecond intervals (1e7 / CLOCKS_PER_SEC) */
   clocks_per_sec = 10000000ULL / (ULONGLONG)CLOCKS_PER_SEC;
-  return (clock_t)(total / clocks_per_sec);
+  return (clock_t)((stime.ul + utime.ul) / clocks_per_sec);
 }
 
 static LARGE_INTEGER frequency;

--- a/runtime/win32.c
+++ b/runtime/win32.c
@@ -1081,11 +1081,11 @@ CAMLexport clock_t caml_win32_clock(void)
     return (clock_t)(-1);
   }
 
-  tmp.u.LowPart = stime.dwLowDateTime;
-  tmp.u.HighPart = stime.dwHighDateTime;
+  tmp.LowPart = stime.dwLowDateTime;
+  tmp.HighPart = stime.dwHighDateTime;
   total = tmp.QuadPart;
-  tmp.u.LowPart = utime.dwLowDateTime;
-  tmp.u.HighPart = utime.dwHighDateTime;
+  tmp.LowPart = utime.dwLowDateTime;
+  tmp.HighPart = utime.dwHighDateTime;
   total += tmp.QuadPart;
 
   /* total in 100-nanosecond intervals (1e7 / CLOCKS_PER_SEC) */


### PR DESCRIPTION
`Unix.gettimeofoday` on Windows presently does this:
https://github.com/ocaml/ocaml/blob/118ab53717e7b01ff8078f84350e013f0517d0f1/otherlibs/unix/gettimeofday_win32.c#L27-L30

`uint64_t *` has stricter alignment requirements than `FILETIME *`, so this pointer cast is illegal. The rabbit-hole then begins. Interestingly, this is the version added in 4.02 for #6671, but the original version of the patch (in #122) did this cast the other way around _which is legal_. This caused me to go and audit our other uses of both `FILETIME` and `LARGE_INTEGER` and hence this somewhat tightly coupled set of commits.

The over-arching thing which joins them altogether is that, as of yesterday and #11369, we can guarantee having a C compiler which properly supports 64-bit arithmetic. A cast from `unsigned __int64 *` to `FILETIME *` is perfectly legal and it simplifies quite a few bits of code as we now longer have to dance around converting high and low order `DWORD`s, etc. While cleaning that up, there are several functions in what used to be known as win32unix which are showing their age and which become a lot simpler by using "modern" (= Windows XP+) functions. In particular, `SetFilePointerEx` is a considerably easier to use and is now recommended over `SetFilePointer`. Similarly, in `caml_unix_map_file`, it's now easier to use `GetFileSizeEx` (which is closer to the `fstat` call done in the Unix implementation). Finally, several of these functions were holding the master lock, unlike their Unix counterparts, and I've fixed that while there.

A version of this based on the 4.14 branch has [passed precheck](https://ci.inria.fr/ocaml/job/precheck/725/).