### PR TITLE
Add Fun.with_ref

### DIFF
--- a/stdlib/fun.ml
+++ b/stdlib/fun.ml
@@ -36,3 +36,10 @@ let protect ~(finally : unit -> unit) work =
       let work_bt = Printexc.get_raw_backtrace () in
       finally_no_exn () ;
       Printexc.raise_with_backtrace work_exn work_bt
+
+let with_ref r v f =
+  let old = !r in
+  r := v;
+  match f () with
+  | x -> r := old; x
+  | exception e -> r := old; raise e

--- a/stdlib/fun.mli
+++ b/stdlib/fun.mli
@@ -61,3 +61,9 @@ exception Finally_raised of exn
     an unexpected exception or a programming error. As a general rule,
     one should not catch a [Finally_raised] exception except as part of
     a catch-all handler. *)
+
+val with_ref: 'a ref -> 'a -> (unit -> 'b) -> 'b
+(** [with_ref r v f] sets [r] to [v], calls [f ()] and sets [r] back to its
+    original value when [f] returns, either normally or by raising an exception.
+
+    @since 5.1.0 *)


### PR DESCRIPTION
See the docstring for the specification. This pattern is a relatively common special case of `Fun.protect`. Opinions?