### PR TITLE
Refactor the initialization of bytecode threading (trunk version)

### DIFF
--- a/Changes
+++ b/Changes
@@ -415,6 +415,9 @@ OCaml 5.0
   (David Allsopp and Nicolás Ojeda Bär, review by Nicolás Ojeda Bär and
    Sebastien Hinderer)
 
+- #11358, #11379: Refactor the initialization of bytecode threading,
+  This avoids a "dangling pointer" warning of GCC 12.1.
+  (Xavier Leroy, report by Armaël Guéneau, review by Gabriel Scherer)
 
 OCaml 4.14.0
 ----------------

--- a/runtime/caml/fix_code.h
+++ b/runtime/caml/fix_code.h
@@ -34,8 +34,7 @@ void caml_set_instruction (code_t pos, opcode_t instr);
 int caml_is_instruction (opcode_t instr1, opcode_t instr2);
 
 #ifdef THREADED_CODE
-extern char ** caml_instr_table;
-extern char * caml_instr_base;
+void caml_init_thread_code(void ** instr_table, void * instr_base);
 void caml_thread_code (code_t code, asize_t len);
 #endif
 

--- a/runtime/fix_code.c
+++ b/runtime/fix_code.c
@@ -82,8 +82,14 @@ void caml_fixup_endianness(code_t code, asize_t len)
 
 #ifdef THREADED_CODE
 
-char ** caml_instr_table;
-char * caml_instr_base;
+static char ** caml_instr_table;
+static char * caml_instr_base;
+
+void caml_init_thread_code(void ** instr_table, void * instr_base)
+{
+  caml_instr_table = (char **) instr_table;
+  caml_instr_base = (char *) instr_base;
+}
 
 static int* opcode_nargs = NULL;
 int* caml_init_opcode_nargs(void)

--- a/runtime/interp.c
+++ b/runtime/interp.c
@@ -54,9 +54,9 @@ sp is a local copy of the global variable Caml_state->extern_sp. */
 #ifdef THREADED_CODE
 #  define Instruct(name) lbl_##name
 #  if defined(ARCH_SIXTYFOUR) && !defined(ARCH_CODE32)
-#    define Jumptbl_base ((char *) &&lbl_ACC0)
+#    define Jumptbl_base &&lbl_ACC0
 #  else
-#    define Jumptbl_base ((char *) 0)
+#    define Jumptbl_base 0
 #    define jumptbl_base ((char *) 0)
 #  endif
 #  ifdef DEBUG
@@ -270,8 +270,7 @@ value caml_interprete(code_t prog, asize_t prog_size)
       (char *) raise_unhandled_code + sizeof(raise_unhandled_code),
       DIGEST_IGNORE, NULL);
 #ifdef THREADED_CODE
-    caml_instr_table = (char **) jumptable;
-    caml_instr_base = Jumptbl_base;
+    caml_init_thread_code(jumptable, Jumptbl_base);
     caml_thread_code(raise_unhandled_code,
                      sizeof(raise_unhandled_code));
 #endif


### PR DESCRIPTION
Use a function `caml_init_thread_code` instead of exposing global variables `caml_instr_table` and  `caml_instr_base`.

This should silence the GCC 12 "dangling-pointer" warning.

Fixes: #11358