### PR TITLE
fix gfortran test on Macos

### DIFF
--- a/testsuite/tests/lib-bigarray-2/has-gfortran.sh
+++ b/testsuite/tests/lib-bigarray-2/has-gfortran.sh
@@ -5,6 +5,9 @@ if ! which gfortran > /dev/null 2>&1; then
 elif ! grep -q '^CC=gcc' ${ocamlsrcdir}/Makefile.config; then
   echo "OCaml was not compiled with gcc" > ${ocamltest_response}
   test_result=${TEST_SKIP}
+elif gcc --version 2>&1 | grep 'Apple clang version'; then
+  echo "OCaml was not compiled with gcc" > ${ocamltest_response}
+  test_result=${TEST_SKIP}
 else
   test_result=${TEST_PASS}
 fi


### PR DESCRIPTION
On Macos, `clang` pretends to be `gcc` but doesn't handle the `-lgfortran` option. This makes the `testsuite/tests/lib-bigarray-2/has-gfortran.sh` script return the wrong result.
