### PR TITLE
Restrict local function optimisation

### DIFF
--- a/Changes
+++ b/Changes
@@ -135,7 +135,7 @@ Working version
 
 - #11383: Restrict the local function optimisation to forbid moving code
   inside a sub-function
-  (Vincent Laviron)
+  (Vincent Laviron, review by Gabriel Scherer)
 
 - #11418, #11708: RISC-V multicore support.
   (Nicolás Ojeda Bär, review by KC Sivaramakrishnan)

--- a/Changes
+++ b/Changes
@@ -133,6 +133,10 @@ Working version
 - #11102: Speed up register allocation by permanently spilling registers
   (Stephen Dolan, review by Xavier Leroy)
 
+- #11383: Restrict the local function optimisation to forbid moving code
+  inside a sub-function
+  (Vincent Laviron)
+
 - #11418, #11708: RISC-V multicore support.
   (Nicolás Ojeda Bär, review by KC Sivaramakrishnan)
 

--- a/lambda/simplif.ml
+++ b/lambda/simplif.ml
@@ -791,6 +791,8 @@ let simplify_local_functions lam =
      by the outermost lambda for which the the current lambda
      is in tail position. *)
   let current_scope = ref lam in
+  (* PR11383: We will only apply the transformation if we don't have to move
+     code across function boundaries *)
   let current_function_scope = ref lam in
   let check_static lf =
     if lf.attr.local = Always_local then

--- a/lambda/simplif.ml
+++ b/lambda/simplif.ml
@@ -773,6 +773,7 @@ let split_default_wrapper ~id:fun_id ~kind ~params ~return ~body ~attr ~loc =
 type slot =
   {
     func: lfunction;
+    function_scope: lambda;
     mutable scope: lambda option;
   }
 
@@ -790,6 +791,7 @@ let simplify_local_functions lam =
      by the outermost lambda for which the the current lambda
      is in tail position. *)
   let current_scope = ref lam in
+  let current_function_scope = ref lam in
   let check_static lf =
     if lf.attr.local = Always_local then
       Location.prerr_warning (to_location lf.loc)
@@ -807,7 +809,11 @@ let simplify_local_functions lam =
   in
   let rec tail = function
     | Llet (_str, _kind, id, Lfunction lf, cont) when enabled lf.attr ->
-        let r = {func = lf; scope = None} in
+        let r =
+          { func = lf;
+            function_scope = !current_function_scope;
+            scope = None }
+        in
         Hashtbl.add slots id r;
         tail cont;
         begin match Hashtbl.find_opt slots id with
@@ -826,7 +832,7 @@ let simplify_local_functions lam =
         | _ ->
             check_static lf;
             (* note: if scope = None, the function is unused *)
-            non_tail lf.body
+            function_definition lf
         end
     | Lapply {ap_func = Lvar id; ap_args; _} ->
         begin match Hashtbl.find_opt slots id with
@@ -837,6 +843,10 @@ let simplify_local_functions lam =
         | Some {scope = Some scope; _} when scope != !current_scope ->
             (* Different "tail scope" *)
             Hashtbl.remove slots id
+        | Some {function_scope = fscope; _}
+          when fscope != !current_function_scope ->
+            (* Non local function *)
+            Hashtbl.remove slots id
         | Some ({scope = None; _} as slot) ->
             (* First use of the function: remember the current tail scope *)
             slot.scope <- Some !current_scope
@@ -846,13 +856,18 @@ let simplify_local_functions lam =
         List.iter non_tail ap_args
     | Lvar id ->
         Hashtbl.remove slots id
-    | Lfunction lf as lam ->
+    | Lfunction lf ->
         check_static lf;
-        Lambda.shallow_iter ~tail ~non_tail lam
+        function_definition lf
     | lam ->
         Lambda.shallow_iter ~tail ~non_tail lam
   and non_tail lam =
     with_scope ~scope:lam lam
+  and function_definition lf =
+    let old_function_scope = !current_function_scope in
+    current_function_scope := lf.body;
+    non_tail lf.body;
+    current_function_scope := old_function_scope
   and with_scope ~scope lam =
     let old_scope = !current_scope in
     current_scope := scope;

--- a/testsuite/tests/backtrace/backtrace_dynlink.flambda.reference
+++ b/testsuite/tests/backtrace/backtrace_dynlink.flambda.reference
@@ -2,7 +2,7 @@ Raised by primitive operation at Backtrace_dynlink_plugin in file "backtrace_dyn
 Called from Dynlink.Native.run.(fun) in file "otherlibs/dynlink/native/dynlink.ml", line 87, characters 12-29
 Called from Stdlib__List.iter in file "list.ml" (inlined), line 112, characters 12-15
 Called from Dynlink.Native.run in file "otherlibs/dynlink/native/dynlink.ml", line 86, characters 4-273
-Called from Dynlink_common.Make.load.(fun) in file "otherlibs/dynlink/dynlink_common.ml" (inlined), line 363, characters 13-56
+Called from Dynlink_common.Make.load.(fun) in file "otherlibs/dynlink/dynlink_common.ml", line 363, characters 13-56
 Called from Stdlib__List.iter in file "list.ml" (inlined), line 112, characters 12-15
 Called from Dynlink_common.Make.load in file "otherlibs/dynlink/dynlink_common.ml", line 359, characters 8-392
 Called from Dynlink_common.Make.loadfile in file "otherlibs/dynlink/dynlink_common.ml" (inlined), line 374, characters 26-45
@@ -12,7 +12,7 @@ Raised by primitive operation at Dynlink.Native.run.(fun) in file "otherlibs/dyn
 Re-raised at Dynlink.Native.run.(fun) in file "otherlibs/dynlink/native/dynlink.ml", line 89, characters 10-149
 Called from Stdlib__List.iter in file "list.ml" (inlined), line 112, characters 12-15
 Called from Dynlink.Native.run in file "otherlibs/dynlink/native/dynlink.ml", line 86, characters 4-273
-Called from Dynlink_common.Make.load.(fun) in file "otherlibs/dynlink/dynlink_common.ml" (inlined), line 363, characters 13-56
+Called from Dynlink_common.Make.load.(fun) in file "otherlibs/dynlink/dynlink_common.ml", line 363, characters 13-56
 Called from Stdlib__List.iter in file "list.ml" (inlined), line 112, characters 12-15
 Called from Dynlink_common.Make.load in file "otherlibs/dynlink/dynlink_common.ml", line 359, characters 8-392
 Re-raised at Dynlink_common.Make.load in file "otherlibs/dynlink/dynlink_common.ml", line 372, characters 8-17

--- a/testsuite/tests/backtrace/lazy.flambda.reference
+++ b/testsuite/tests/backtrace/lazy.flambda.reference
@@ -1,12 +1,12 @@
 Uncaught exception Not_found
-Raised at Lazy.l1 in file "lazy.ml", line 13, characters 28-45
+Raised at Lazy.l1 in file "lazy.ml", line 3, characters 28-45
 Called from CamlinternalLazy.do_force_block in file "camlinternalLazy.ml", line 49, characters 17-27
 Re-raised at CamlinternalLazy.do_force_block in file "camlinternalLazy.ml", line 56, characters 4-11
-Called from Lazy.test1 in file "lazy.ml", line 16, characters 11-24
-Called from Lazy.run in file "lazy.ml", line 25, characters 4-11
+Called from Lazy.test1 in file "lazy.ml", line 6, characters 11-24
+Called from Lazy.run in file "lazy.ml", line 15, characters 4-11
 Uncaught exception Not_found
-Raised at Lazy.l2 in file "lazy.ml", line 18, characters 28-45
+Raised at Lazy.l2 in file "lazy.ml", line 8, characters 28-45
 Called from CamlinternalLazy.do_force_block in file "camlinternalLazy.ml", line 49, characters 17-27
 Re-raised at CamlinternalLazy.do_force_block in file "camlinternalLazy.ml", line 56, characters 4-11
-Called from Lazy.test2 in file "lazy.ml", line 21, characters 6-15
-Called from Lazy.run in file "lazy.ml", line 25, characters 4-11
+Called from Lazy.test2 in file "lazy.ml", line 11, characters 6-15
+Called from Lazy.run in file "lazy.ml", line 15, characters 4-11

--- a/testsuite/tests/backtrace/lazy.flambda.reference
+++ b/testsuite/tests/backtrace/lazy.flambda.reference
@@ -2,13 +2,11 @@ Uncaught exception Not_found
 Raised at Lazy.l1 in file "lazy.ml", line 13, characters 28-45
 Called from CamlinternalLazy.do_force_block in file "camlinternalLazy.ml", line 49, characters 17-27
 Re-raised at CamlinternalLazy.do_force_block in file "camlinternalLazy.ml", line 56, characters 4-11
-Called from CamlinternalLazy.force_lazy_block in file "camlinternalLazy.ml" (inlined), line 78, characters 27-67
 Called from Lazy.test1 in file "lazy.ml", line 16, characters 11-24
 Called from Lazy.run in file "lazy.ml", line 25, characters 4-11
 Uncaught exception Not_found
 Raised at Lazy.l2 in file "lazy.ml", line 18, characters 28-45
 Called from CamlinternalLazy.do_force_block in file "camlinternalLazy.ml", line 49, characters 17-27
 Re-raised at CamlinternalLazy.do_force_block in file "camlinternalLazy.ml", line 56, characters 4-11
-Called from CamlinternalLazy.force_lazy_block in file "camlinternalLazy.ml" (inlined), line 78, characters 27-67
 Called from Lazy.test2 in file "lazy.ml", line 21, characters 6-15
 Called from Lazy.run in file "lazy.ml", line 25, characters 4-11

--- a/testsuite/tests/backtrace/lazy.ml
+++ b/testsuite/tests/backtrace/lazy.ml
@@ -1,14 +1,4 @@
-(* TEST
-
-flags = "-g"
-* no-flambda
-** native
-* flambda
-reference = "${test_source_directory}/lazy.flambda.reference"
-** native
-
-*)
-
+(* TEST_BELOW *)
 
 let l1 : unit lazy_t = lazy (raise Not_found)
 
@@ -31,3 +21,15 @@ let () =
   Printexc.record_backtrace true;
   run test1;
   run test2
+
+
+(* TEST
+
+flags = "-g"
+* no-flambda
+** native
+* flambda
+reference = "${test_source_directory}/lazy.flambda.reference"
+** native
+
+*)

--- a/testsuite/tests/backtrace/lazy.ml
+++ b/testsuite/tests/backtrace/lazy.ml
@@ -1,6 +1,12 @@
 (* TEST
-   flags = "-g"
-   * native
+
+flags = "-g"
+* no-flambda
+** native
+* flambda
+reference = "${test_source_directory}/lazy.flambda.reference"
+** native
+
 *)
 
 

--- a/testsuite/tests/backtrace/lazy.reference
+++ b/testsuite/tests/backtrace/lazy.reference
@@ -1,14 +1,14 @@
 Uncaught exception Not_found
-Raised at Lazy.l1 in file "lazy.ml", line 13, characters 28-45
+Raised at Lazy.l1 in file "lazy.ml", line 3, characters 28-45
 Called from CamlinternalLazy.do_force_block in file "camlinternalLazy.ml", line 49, characters 17-27
 Re-raised at CamlinternalLazy.do_force_block in file "camlinternalLazy.ml", line 56, characters 4-11
 Called from CamlinternalLazy.force_lazy_block in file "camlinternalLazy.ml" (inlined), line 78, characters 27-67
-Called from Lazy.test1 in file "lazy.ml", line 16, characters 11-24
-Called from Lazy.run in file "lazy.ml", line 25, characters 4-11
+Called from Lazy.test1 in file "lazy.ml", line 6, characters 11-24
+Called from Lazy.run in file "lazy.ml", line 15, characters 4-11
 Uncaught exception Not_found
-Raised at Lazy.l2 in file "lazy.ml", line 18, characters 28-45
+Raised at Lazy.l2 in file "lazy.ml", line 8, characters 28-45
 Called from CamlinternalLazy.do_force_block in file "camlinternalLazy.ml", line 49, characters 17-27
 Re-raised at CamlinternalLazy.do_force_block in file "camlinternalLazy.ml", line 56, characters 4-11
 Called from CamlinternalLazy.force_lazy_block in file "camlinternalLazy.ml" (inlined), line 78, characters 27-67
-Called from Lazy.test2 in file "lazy.ml", line 21, characters 6-15
-Called from Lazy.run in file "lazy.ml", line 25, characters 4-11
+Called from Lazy.test2 in file "lazy.ml", line 11, characters 6-15
+Called from Lazy.run in file "lazy.ml", line 15, characters 4-11

--- a/testsuite/tests/functors/functors.compilers.reference
+++ b/testsuite/tests/functors/functors.compilers.reference
@@ -20,9 +20,10 @@
        (module-defn(F1) Functors functors.ml(31):516-632
          (function X Y is_a_functor always_inline
            (let
-             (sheep =
+             (cow =
                 (function x[int] : int
-                  (+ 1 (apply (field_imm 0 Y) (apply (field_imm 0 X) x)))))
+                  (apply (field_imm 0 Y) (apply (field_imm 0 X) x)))
+              sheep = (function x[int] : int (+ 1 (apply cow x))))
              (makeblock 0 sheep))))
      F2 =
        (module-defn(F2) Functors functors.ml(36):634-784
@@ -30,9 +31,10 @@
            (let
              (X =a (makeblock 0 (field_mut 1 X))
               Y =a (makeblock 0 (field_mut 1 Y))
-              sheep =
+              cow =
                 (function x[int] : int
-                  (+ 1 (apply (field_imm 0 Y) (apply (field_imm 0 X) x)))))
+                  (apply (field_imm 0 Y) (apply (field_imm 0 X) x)))
+              sheep = (function x[int] : int (+ 1 (apply cow x))))
              (makeblock 0 sheep))))
      M =
        (module-defn(M) Functors functors.ml(41):786-970

--- a/testsuite/tests/local-functions/non_local.compilers.reference
+++ b/testsuite/tests/local-functions/non_local.compilers.reference
@@ -1,0 +1,4 @@
+File "non_local.ml", line 21, characters 16-25:
+21 |   let[@local] f y = x + y in
+                     ^^^^^^^^^
+Warning 55 [inlining-impossible]: Cannot inline: This function cannot be compiled into a static continuation

--- a/testsuite/tests/local-functions/non_local.ml
+++ b/testsuite/tests/local-functions/non_local.ml
@@ -1,0 +1,22 @@
+(* TEST *)
+
+(* Basic case: local optimisation works *)
+let local_direct x =
+  let[@local] f y = x + y in
+  f 0
+
+(* Multiple calls in the same tail context work *)
+let local_multiple x b =
+  let[@local] f y = x + y in
+  if b then f 0 else f 1
+
+(* Calls in an inner scope work *)
+let local_inner_scope x =
+  let[@local] f y = x + y in
+  (f 0, 1)
+
+(* Calls inside another function should not be optimised,
+   and produce a warning *)
+let local_in_function x =
+  let[@local] f y = x + y in
+  List.map (fun x -> f (succ x)) [0]


### PR DESCRIPTION
This PR disables the local function optimisation when it would move code inside a different function. This seems coherent with the purpose of the transformation, which is to generate static catches (which cannot cross function boundaries).

The testsuite changes (apart from the new test) are either benign cases where the optimisation used to apply but doesn't anymore (the `functors` test) or backtrace changes due to different inlining decisions.

Fixes #8563, #10993.
