### PR TITLE
unix library: flush Windows channels at exit too

### DIFF
--- a/otherlibs/unix/channels_win32.c
+++ b/otherlibs/unix/channels_win32.c
@@ -99,6 +99,8 @@ CAMLprim value caml_unix_inchannel_of_filedescr(value handle)
 {
   CAMLparam1(handle);
   CAMLlocal1(vchan);
+  int flags = 0;
+  int fd;
   struct channel * chan;
   DWORD err;
 
@@ -107,12 +109,10 @@ CAMLprim value caml_unix_inchannel_of_filedescr(value handle)
     caml_win32_maperr(err);
     caml_uerror("in_channel_of_descr", Nothing);
   }
-  chan = caml_open_descriptor_in(caml_win32_CRT_fd_of_filedescr(handle));
-  chan->flags |= CHANNEL_FLAG_MANAGED_BY_GC;
-                 /* as in caml_ml_open_descriptor_in() */
+  fd = caml_win32_CRT_fd_of_filedescr(handle);
   if (Descr_kind_val(handle) == KIND_SOCKET)
-    chan->flags |= CHANNEL_FLAG_FROM_SOCKET;
-  vchan = caml_alloc_channel(chan);
+    flags |= CHANNEL_FLAG_FROM_SOCKET;
+  vchan = caml_ml_open_descriptor_in_with_flags(fd, flags);
   CAMLreturn(vchan);
 }
 
@@ -121,6 +121,7 @@ CAMLprim value caml_unix_outchannel_of_filedescr(value handle)
   CAMLparam1(handle);
   CAMLlocal1(vchan);
   int fd;
+  int flags = 0;
   struct channel * chan;
   DWORD err;
 
@@ -129,12 +130,10 @@ CAMLprim value caml_unix_outchannel_of_filedescr(value handle)
     caml_win32_maperr(err);
     caml_uerror("out_channel_of_descr", Nothing);
   }
-  chan = caml_open_descriptor_out(caml_win32_CRT_fd_of_filedescr(handle));
-  chan->flags |= CHANNEL_FLAG_MANAGED_BY_GC;
-                 /* as in caml_ml_open_descriptor_out() */
+  fd = caml_win32_CRT_fd_of_filedescr(handle);
   if (Descr_kind_val(handle) == KIND_SOCKET)
-    chan->flags |= CHANNEL_FLAG_FROM_SOCKET;
-  vchan = caml_alloc_channel(chan);
+    flags |= CHANNEL_FLAG_FROM_SOCKET;
+  vchan = caml_ml_open_descriptor_out_with_flags(fd, flags);
   CAMLreturn(vchan);
 }
 

--- a/runtime/caml/io.h
+++ b/runtime/caml/io.h
@@ -123,6 +123,8 @@ CAMLextern struct channel * caml_all_opened_channels;
 /* Primitives required by the Unix library */
 CAMLextern value caml_ml_open_descriptor_in(value fd);
 CAMLextern value caml_ml_open_descriptor_out(value fd);
+CAMLextern value caml_ml_open_descriptor_in_with_flags(int fd, int flags);
+CAMLextern value caml_ml_open_descriptor_out_with_flags(int fd, int flags);
 
 #endif /* CAML_INTERNALS */
 

--- a/runtime/io.c
+++ b/runtime/io.c
@@ -571,10 +571,10 @@ CAMLexport value caml_alloc_channel(struct channel *chan)
   return res;
 }
 
-CAMLprim value caml_ml_open_descriptor_in(value fd)
+CAMLprim value caml_ml_open_descriptor_in_with_flags(int fd, int flags)
 {
-  struct channel * chan = caml_open_descriptor_in(Int_val(fd));
-  chan->flags |= CHANNEL_FLAG_MANAGED_BY_GC;
+  struct channel * chan = caml_open_descriptor_in(fd);
+  chan->flags |= flags | CHANNEL_FLAG_MANAGED_BY_GC;
   chan->refcount = 1;
   caml_plat_lock (&caml_all_opened_channels_mutex);
   link_channel (chan);
@@ -582,15 +582,23 @@ CAMLprim value caml_ml_open_descriptor_in(value fd)
   return caml_alloc_channel(chan);
 }
 
-CAMLprim value caml_ml_open_descriptor_out(value fd)
+CAMLprim value caml_ml_open_descriptor_in(value fd) {
+  return caml_ml_open_descriptor_in_with_flags(Int_val(fd), 0);
+}
+
+CAMLprim value caml_ml_open_descriptor_out_with_flags(int fd, int flags)
 {
-  struct channel * chan = caml_open_descriptor_out(Int_val(fd));
-  chan->flags |= CHANNEL_FLAG_MANAGED_BY_GC;
+  struct channel * chan = caml_open_descriptor_out(fd);
+  chan->flags |= flags | CHANNEL_FLAG_MANAGED_BY_GC;
   chan->refcount = 1;
   caml_plat_lock (&caml_all_opened_channels_mutex);
   link_channel (chan);
   caml_plat_unlock (&caml_all_opened_channels_mutex);
   return caml_alloc_channel(chan);
+}
+
+CAMLprim value caml_ml_open_descriptor_out(value fd) {
+  return caml_ml_open_descriptor_out_with_flags(Int_val(fd), 0);
 }
 
 CAMLprim value caml_ml_set_channel_name(value vchannel, value vname)


### PR DESCRIPTION
When updating the handling of C-managed channels, I had forgotten that the Windows code that builds channels from file descriptors (`channels_win32.c`) creates OCaml-managed channels too. Consequently, on Windows, channels created with the `Unix` library were no longer flushed.

Since it looks like it was at least the second time that this code path was forgotten, I have moved the corresponding initialization code to `runtime/io.c`. With this change, only `runtime/io.c` creates OCaml-side channel, and there is no longer any room to forget to register OCaml-side channels for flushing at exit.