### PR TITLE
Appveyor tests

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,7 +16,7 @@
 platform:
   - x64
 
-image: Visual Studio 2015
+image: Visual Studio 2022
 
 # Do a shallow clone of the repo to speed up the build
 clone_depth: 1

--- a/ocamltest/ocaml_tests.ml
+++ b/ocamltest/ocaml_tests.ml
@@ -36,7 +36,7 @@ let bytecode =
   test_name = "bytecode";
   test_run_by_default = true;
   test_actions =
-  (if Sys.win32 && Ocamltest_config.arch<>"none" then
+  (if Sys.win32 && Ocamltest_config.native_compiler then
     opt_build
   else
     byte_build) @

--- a/testsuite/Makefile
+++ b/testsuite/Makefile
@@ -228,6 +228,13 @@ all-%: lib tools
 # I chose to keep the previous behavior exactly unchanged,
 # but the demangling separation is arguably nicer behavior that we might
 # want to implement at the exec-one level to also have it in the 'all' target.
+
+# If make has been invoked with "-j n", pass this on to GNU parallel. parallel
+# does not support -j without an argument, hence the double-filter. Note that
+# GNU make normalises -j in $(MAKEFLAGS) so it will either be -j alone or -jn
+# (i.e. with no space).
+J_ARGUMENT = $(filter-out -j,$(filter -j%,$(MAKEFLAGS)))
+
 .PHONY: parallel-%
 parallel-%: lib tools
 	@echo | parallel >/dev/null 2>/dev/null \
@@ -239,7 +246,7 @@ parallel-%: lib tools
 	     echo "This target requires GNU parallel.";\
 	     exit 1)
 	@for dir in tests/$**; do echo $$dir; done \
-	 | parallel --gnu --no-notice --keep-order \
+	 | parallel --gnu --no-notice --keep-order $(J_ARGUMENT) \
 	     "$(MAKE) --no-print-directory exec-one DIR={} 2>&1" \
 	 | tee $(TESTLOG)
 	@$(MAKE) report

--- a/testsuite/Makefile
+++ b/testsuite/Makefile
@@ -65,7 +65,8 @@ else
   # The testsuite needs an absolute path to the runtime, so override the
   # definition in Makefile.common
   FLEXLINK_DLL_LDFLAGS=$(if $(OC_DLL_LDFLAGS), -link "$(OC_DLL_LDFLAGS)")
-  FLEXLINK_EXE_LDFLAGS=$(if $(OC_LDFLAGS), -link "$(OC_LDFLAGS)")
+  FLEXLINK_EXE_LDFLAGS=$(if $(OC_LDFLAGS), -link "$(OC_LDFLAGS)") \
+                       $(if $(OC_EXE_LDFLAGS), -link "$(OC_EXE_LDFLAGS)")
 ifeq "$(wildcard $(ROOTDIR_HOST)/flexlink.opt$(EXE))" ""
   FLEXLINK_ENV = \
     OCAML_FLEXLINK="$(ROOTDIR_HOST)/boot/ocamlrun$(EXE) \

--- a/tools/ci/appveyor/appveyor_build.sh
+++ b/tools/ci/appveyor/appveyor_build.sh
@@ -149,6 +149,15 @@ case "$1" in
           $FULL_BUILD_PREFIX-$PORT/runtime/*.a \
           $FULL_BUILD_PREFIX-$PORT/otherlibs/*/lib*.a
     fi
+    # The testsuite is too slow to run on AppVeyor in full. Run the dynlink
+    # tests now (to include natdynlink)
+    run "test dynlink $PORT" \
+        $MAKE -C "$FULL_BUILD_PREFIX-$PORT/testsuite" parallel-lib-dynlink
+    # Now reconfigure ocamltest to run in bytecode-only mode
+    sed -i '/native_/s/true/false/' \
+           "$FULL_BUILD_PREFIX-$PORT/ocamltest/ocamltest_config.ml"
+    $MAKE -C "$FULL_BUILD_PREFIX-$PORT/ocamltest" -j all allopt
+    # And run the entire testsuite, skipping all the native-code tests
     run "test $PORT" \
         $MAKE -C "$FULL_BUILD_PREFIX-$PORT/testsuite" SHOW_TIMINGS=1 parallel
     run "install $PORT" $MAKE -C "$FULL_BUILD_PREFIX-$PORT" install

--- a/tools/ci/appveyor/appveyor_build.sh
+++ b/tools/ci/appveyor/appveyor_build.sh
@@ -159,7 +159,7 @@ case "$1" in
     $MAKE -C "$FULL_BUILD_PREFIX-$PORT/ocamltest" -j all allopt
     # And run the entire testsuite, skipping all the native-code tests
     run "test $PORT" \
-        $MAKE -C "$FULL_BUILD_PREFIX-$PORT/testsuite" SHOW_TIMINGS=1 parallel
+        make -C "$FULL_BUILD_PREFIX-$PORT/testsuite" SHOW_TIMINGS=1 all
     run "install $PORT" $MAKE -C "$FULL_BUILD_PREFIX-$PORT" install
     if [[ $PORT = 'msvc64' ]] ; then
       run "$MAKE check_all_arches" \

--- a/tools/ci/appveyor/appveyor_build.sh
+++ b/tools/ci/appveyor/appveyor_build.sh
@@ -149,9 +149,8 @@ case "$1" in
           $FULL_BUILD_PREFIX-$PORT/runtime/*.a \
           $FULL_BUILD_PREFIX-$PORT/otherlibs/*/lib*.a
     fi
-    # FIXME At present, running the testsuite takes too long
-    #run "test $PORT" \
-    #    $MAKE -C "$FULL_BUILD_PREFIX-$PORT/testsuite" SHOW_TIMINGS=1 parallel
+    run "test $PORT" \
+        $MAKE -C "$FULL_BUILD_PREFIX-$PORT/testsuite" SHOW_TIMINGS=1 parallel
     run "install $PORT" $MAKE -C "$FULL_BUILD_PREFIX-$PORT" install
     if [[ $PORT = 'msvc64' ]] ; then
       run "$MAKE check_all_arches" \


### PR DESCRIPTION
There've been a couple of PRs recently where the lack of Windows CI has hurt a bit. With the number of things going on in the runtime, it's particularly useful to run with some dynamic loading of C libraries (when headers haven't been updated, the easiest way to debug is `make runtop` and `#load "unix.cma"`, etc. - or run any test in the testsuite which uses `unix.cma`).

The testsuite still takes too long on AppVeyor's runners, but this PR proposes a half-way house. The `lib-dynlink-*` tests are run first (to exercise natdynlink) and then `ocamltest` is reconfigured in bytecode-only mode and the testsuite is run in full in bytecode-only mode.

This would have caught the small header error in #11304 and would have been a canary for some of the problems still in #11271.

There are clearly better things to do to `ocamltest` to run in bytecode-only mode, but I propose this could do for now.