### PR TITLE
Simplifications and fixes to multicore systhreads implementation (2.5/3)

### DIFF
--- a/otherlibs/systhreads/st_pthreads.h
+++ b/otherlibs/systhreads/st_pthreads.h
@@ -71,25 +71,6 @@ static void st_thread_join(st_thread_id thr)
   /* best effort: ignore errors */
 }
 
-/* Thread-specific state */
-
-typedef pthread_key_t st_tlskey;
-
-static int st_tls_newkey(st_tlskey * res)
-{
-  return pthread_key_create(res, NULL);
-}
-
-Caml_inline void * st_tls_get(st_tlskey k)
-{
-  return pthread_getspecific(k);
-}
-
-Caml_inline void st_tls_set(st_tlskey k, void * v)
-{
-  pthread_setspecific(k, v);
-}
-
 /* The master lock.  This is a mutex that is held most of the time,
    so we implement it in a slightly convoluted way to avoid
    all risks of busy-waiting.  Also, we count the number of waiting

--- a/otherlibs/systhreads/st_stubs.c
+++ b/otherlibs/systhreads/st_stubs.c
@@ -88,8 +88,8 @@ struct caml_thread_struct {
 
 typedef struct caml_thread_struct* caml_thread_t;
 
-/* Thread-local key for accessing the current thread's [caml_thread_t] */
-st_tlskey caml_thread_key;
+/* The current thread's [caml_thread_t] */
+static _Thread_local caml_thread_t this_thread;
 
 /* overall table for threads across domains */
 struct caml_thread_table {
@@ -102,20 +102,22 @@ struct caml_thread_table {
 /* thread_table instance, up to Max_domains */
 static struct caml_thread_table thread_table[Max_domains];
 
+#define Dom_id (this_thread->domain_id)
+
 /* The descriptor for the currently executing thread for this domain;
    also the head of a circular list of thread descriptors for this
    domain. Invariant: at every safe point, it is either NULL or
    Caml_state refers to this thread. */
-#define Active_thread thread_table[Caml_state->id].active_thread
+#define Active_thread thread_table[Dom_id].active_thread
 
 /* The master lock protecting this domain's thread chaining */
-#define Thread_main_lock thread_table[Caml_state->id].thread_lock
+#define Thread_main_lock thread_table[Dom_id].thread_lock
 
 /* Whether the "tick" thread is already running for this domain */
-#define Tick_thread_running thread_table[Caml_state->id].tick_thread_running
+#define Tick_thread_running thread_table[Dom_id].tick_thread_running
 
 /* The thread identifier of the "tick" thread for this domain */
-#define Tick_thread_id thread_table[Caml_state->id].tick_thread_id
+#define Tick_thread_id thread_table[Dom_id].tick_thread_id
 
 /* Identifier for next thread creation */
 static atomic_uintnat thread_next_id = 0;
@@ -133,24 +135,25 @@ static void caml_thread_scan_roots(
   scanning_action action, scanning_action_flags fflags, void *fdata,
   caml_domain_state *domain_state)
 {
-  caml_thread_t th;
+  caml_thread_t active, th;
 
-  th = Active_thread;
+  /* If we are called from the backup thread, we cannot access
+     [Active_thread] directly; luckily we are passed the domain_state. */
+  active = th = thread_table[domain_state->id].active_thread;
 
   /* GC could be triggered before [Active_thread] is initialized */
-  if (th != NULL) {
+  if (active != NULL) {
     do {
       (*action)(fdata, th->descr, &th->descr);
       (*action)(fdata, th->backtrace_last_exn, &th->backtrace_last_exn);
-      if (th != Active_thread) {
+      if (th != active) {
         if (th->current_stack != NULL)
           caml_do_local_roots(action, fflags, fdata,
                               th->local_roots, th->current_stack, th->gc_regs);
       }
       th = th->next;
-    } while (th != Active_thread);
-
-  };
+    } while (th != active);
+  }
 
   if (prev_scan_roots_hook != NULL)
     (*prev_scan_roots_hook)(action, fflags, fdata, domain_state);
@@ -160,19 +163,19 @@ static void caml_thread_scan_roots(
 
 static void save_runtime_state(void)
 {
-  Active_thread->current_stack = Caml_state->current_stack;
-  Active_thread->c_stack = Caml_state->c_stack;
-  Active_thread->gc_regs = Caml_state->gc_regs;
-  Active_thread->gc_regs_buckets = Caml_state->gc_regs_buckets;
-  Active_thread->exn_handler = Caml_state->exn_handler;
-  Active_thread->local_roots = Caml_state->local_roots;
-  Active_thread->backtrace_pos = Caml_state->backtrace_pos;
-  Active_thread->backtrace_buffer = Caml_state->backtrace_buffer;
-  Active_thread->backtrace_last_exn = Caml_state->backtrace_last_exn;
+  this_thread->current_stack = Caml_state->current_stack;
+  this_thread->c_stack = Caml_state->c_stack;
+  this_thread->gc_regs = Caml_state->gc_regs;
+  this_thread->gc_regs_buckets = Caml_state->gc_regs_buckets;
+  this_thread->exn_handler = Caml_state->exn_handler;
+  this_thread->local_roots = Caml_state->local_roots;
+  this_thread->backtrace_pos = Caml_state->backtrace_pos;
+  this_thread->backtrace_buffer = Caml_state->backtrace_buffer;
+  this_thread->backtrace_last_exn = Caml_state->backtrace_last_exn;
 #ifndef NATIVE_CODE
-  Active_thread->trap_sp_off = Caml_state->trap_sp_off;
-  Active_thread->trap_barrier_off = Caml_state->trap_barrier_off;
-  Active_thread->external_raise = Caml_state->external_raise;
+  this_thread->trap_sp_off = Caml_state->trap_sp_off;
+  this_thread->trap_barrier_off = Caml_state->trap_barrier_off;
+  this_thread->external_raise = Caml_state->external_raise;
 #endif
 }
 
@@ -225,7 +228,7 @@ static void caml_thread_leave_blocking_section(void)
   /* Update Active_thread to point to the thread descriptor
      corresponding to the thread currently executing and restore the
      runtime state */
-  set_active(st_tls_get(caml_thread_key));
+  set_active(this_thread);
 }
 
 /* Create and setup a new thread info block.
@@ -307,15 +310,15 @@ static void caml_thread_reinitialize(void)
 {
   caml_thread_t th, next;
 
-  th = Active_thread->next;
-  while (th != Active_thread) {
+  th = this_thread->next;
+  while (th != this_thread) {
     next = th->next;
     caml_free_stack(th->current_stack);
     caml_stat_free(th);
     th = next;
   }
-  Active_thread->next = Active_thread;
-  Active_thread->prev = Active_thread;
+  this_thread->next = this_thread;
+  this_thread->prev = this_thread;
 
   /* Within the child, the domain_lock needs to be reset and acquired. */
   caml_reset_domain_lock();
@@ -341,18 +344,18 @@ static void caml_thread_domain_stop_hook(void) {
      on its chain before wrapping up. */
   if (!caml_domain_alone()) {
 
-    while (Active_thread->next != Active_thread) {
-      caml_thread_join(Active_thread->next->descr);
+    while (this_thread->next != this_thread) {
+      caml_thread_join(this_thread->next->descr);
     }
 
     /* another domain thread may be joining on this domain's descriptor */
-    caml_threadstatus_terminate(Terminated(Active_thread->descr));
+    caml_threadstatus_terminate(Terminated(this_thread->descr));
 
     /* Stop tick thread */
     set_active(NULL);
 
-    caml_stat_free(st_tls_get(caml_thread_key));
-    st_tls_set(caml_thread_key, NULL);
+    caml_stat_free(this_thread);
+    this_thread = NULL;
   };
 }
 
@@ -365,19 +368,20 @@ CAMLprim value caml_thread_initialize_domain(value v)
   /* OS-specific initialization */
   st_initialize();
 
-  st_masterlock_init(&Thread_main_lock);
-
   new_thread =
     (caml_thread_t) caml_stat_alloc(sizeof(struct caml_thread_struct));
 
+  new_thread->domain_id = Caml_state->id;
   new_thread->descr = caml_thread_new_descriptor(Val_unit);
   new_thread->next = new_thread;
   new_thread->prev = new_thread;
   new_thread->backtrace_last_exn = Val_unit;
 
-  st_tls_set(caml_thread_key, new_thread);
+  this_thread = new_thread;
 
+  /* Initialise the thread table entry */
   Active_thread = new_thread;
+  st_masterlock_init(&Thread_main_lock);
   Tick_thread_running = 0;
 
   CAMLreturn(Val_unit);
@@ -389,7 +393,7 @@ void caml_thread_interrupt_hook(void)
 {
   /* Do not attempt to yield from the backup thread or during domain
      shutdown. */
-  if (st_tls_get(caml_thread_key) == NULL) return;
+  if (this_thread == NULL) return;
 
   uintnat is_on = 1;
   atomic_uintnat* req_external_interrupt =
@@ -413,9 +417,6 @@ CAMLprim value caml_thread_initialize(value unit)
   if (!caml_domain_alone())
     caml_failwith("caml_thread_initialize: cannot initialize Thread "
                   "while several domains are running.");
-
-  /* Initialize the key to the [caml_thread_t] structure */
-  st_tls_newkey(&caml_thread_key);
 
   /* First initialise the systhread chain on this domain */
   caml_thread_initialize_domain(Val_unit);
@@ -454,15 +455,16 @@ static void caml_thread_stop(void)
 
   /* The main domain thread does not go through [caml_thread_stop]. There is
      always one more thread in the chain at this point in time. */
-  CAMLassert(Active_thread->next != Active_thread);
+  CAMLassert(this_thread->next != this_thread);
 
-  caml_threadstatus_terminate(Terminated(Active_thread->descr));
+  caml_threadstatus_terminate(Terminated(this_thread->descr));
 
-  /* The following also sets Active_thread to a sane value in case the
-     backup thread does a GC before the domain lock is acquired
-     again. */
-  caml_thread_remove_info(Active_thread);
-  st_masterlock_release(&Thread_main_lock);
+  st_masterlock *thread_lock = &Thread_main_lock;
+  /* Remove this_thread and free its data. This also sets
+     Active_thread to a sane value in case the backup thread does a GC
+     before the domain lock is acquired again. */
+  caml_thread_remove_info(this_thread);
+  st_masterlock_release(thread_lock);
 }
 
 /* Create a thread */
@@ -474,10 +476,10 @@ static void * caml_thread_start(void * v)
 
   caml_init_domain_self(th->domain_id);
 
-  st_tls_set(caml_thread_key, th);
+  this_thread = th;
 
   st_masterlock_acquire(&Thread_main_lock);
-  set_active(st_tls_get(caml_thread_key));
+  set_active(this_thread);
 
 #ifdef POSIX_SIGNALS
   /* restore the signal mask from the spawning thread, now it is safe for the
@@ -485,8 +487,8 @@ static void * caml_thread_start(void * v)
   pthread_sigmask(SIG_SETMASK, &th->init_mask, NULL);
 #endif
 
-  clos = Start_closure(Active_thread->descr);
-  caml_modify(&(Start_closure(Active_thread->descr)), Val_unit);
+  clos = Start_closure(this_thread->descr);
+  caml_modify(&(Start_closure(this_thread->descr)), Val_unit);
   caml_callback_exn(clos, Val_unit);
   caml_thread_stop();
 
@@ -543,11 +545,11 @@ CAMLprim value caml_thread_new(value clos)
   th->init_mask = mask;
 #endif
 
-  th->next = Active_thread->next;
-  th->prev = Active_thread;
+  th->next = this_thread->next;
+  th->prev = this_thread;
 
-  Active_thread->next->prev = th;
-  Active_thread->next = th;
+  this_thread->next->prev = th;
+  this_thread->next = th;
 
   err = st_thread_create(NULL, caml_thread_start, (void *) th);
 
@@ -579,19 +581,22 @@ CAMLexport int caml_c_thread_register(void)
   st_retcode err;
 
   /* Already registered? */
-  if (Caml_state == NULL) {
-    caml_init_domain_self(0);
-  };
-  if (st_tls_get(caml_thread_key) != NULL) return 0;
+  if (this_thread != NULL) return 0;
+  CAMLassert(Caml_state == NULL);
+  caml_init_domain_self(0);
+
+  st_masterlock *thread_lock = &thread_table[0].thread_lock;
   /* Take master lock to protect access to the runtime */
-  st_masterlock_acquire(&Thread_main_lock);
+  st_masterlock_acquire(thread_lock);
   /* Create a thread info block */
   th = caml_thread_new_info();
   /* If it fails, we release the lock and return an error. */
   if (th == NULL) {
-    st_masterlock_release(&Thread_main_lock);
+    st_masterlock_release(thread_lock);
     return 0;
   }
+  /* Associate the thread descriptor with the thread */
+  this_thread = th;
   /* Add thread info block to the list of threads */
   if (Active_thread == NULL) {
     th->next = th;
@@ -603,8 +608,6 @@ CAMLexport int caml_c_thread_register(void)
     Active_thread->next->prev = th;
     Active_thread->next = th;
   }
-  /* Associate the thread descriptor with the thread */
-  st_tls_set(caml_thread_key, (void *) th);
   /* Allocate the thread descriptor on the heap */
   th->descr = caml_thread_new_descriptor(Val_unit);  /* no closure */
 
@@ -615,7 +618,7 @@ CAMLexport int caml_c_thread_register(void)
   }
 
   /* Release the master lock */
-  st_masterlock_release(&Thread_main_lock);
+  st_masterlock_release(thread_lock);
   return 1;
 }
 
@@ -624,22 +627,18 @@ CAMLexport int caml_c_thread_register(void)
 
 CAMLexport int caml_c_thread_unregister(void)
 {
-  caml_thread_t th;
-
-  /* If Caml_state is not set, this thread was likely not registered */
-  if (Caml_state == NULL) return 0;
-
-  th = st_tls_get(caml_thread_key);
   /* Not registered? */
-  if (th == NULL) return 0;
+  if (this_thread == NULL) return 0;
+
+  st_masterlock *thread_lock = &Thread_main_lock;
   /* Wait until the runtime is available */
-  st_masterlock_acquire(&Thread_main_lock);
-  /*  Forget the thread descriptor */
-  st_tls_set(caml_thread_key, NULL);
+  st_masterlock_acquire(thread_lock);
   /* Remove thread info block from list of threads, and free it */
-  caml_thread_remove_info(th);
+  caml_thread_remove_info(this_thread);
+  /* Reset this_thread in case the C thread gets registered again */
+  this_thread = NULL;
   /* Release the runtime */
-  st_masterlock_release(&Thread_main_lock);
+  st_masterlock_release(thread_lock);
   return 1;
 }
 
@@ -647,7 +646,7 @@ CAMLexport int caml_c_thread_unregister(void)
 
 CAMLprim value caml_thread_self(value unit)
 {
-  return Active_thread->descr;
+  return this_thread->descr;
 }
 
 /* Return the identifier of a thread */
@@ -663,7 +662,7 @@ CAMLprim value caml_thread_uncaught_exception(value exn)
 {
   char * msg = caml_format_exception(exn);
   fprintf(stderr, "Thread %d killed on uncaught exception %s\n",
-          Int_val(Ident(Active_thread->descr)), msg);
+          Int_val(Ident(this_thread->descr)), msg);
   caml_stat_free(msg);
   if (Caml_state->backtrace_active) caml_print_exception_backtrace();
   fflush(stderr);
@@ -685,7 +684,7 @@ CAMLprim value caml_thread_yield(value unit)
   caml_raise_if_exception(caml_process_pending_signals_exn());
   save_runtime_state();
   st_thread_yield(&Thread_main_lock);
-  set_active(st_tls_get(caml_thread_key));
+  set_active(this_thread);
   caml_raise_if_exception(caml_process_pending_signals_exn());
 
   return Val_unit;

--- a/otherlibs/systhreads/st_stubs.c
+++ b/otherlibs/systhreads/st_stubs.c
@@ -447,11 +447,6 @@ static void caml_thread_stop(void)
      again. */
   caml_thread_remove_info(Active_thread);
   caml_thread_restore_runtime_state();
-
-  /* If no other OCaml thread remains, ask the tick thread to stop
-     so that it does not prevent the whole process from exiting (#9971) */
-  if (Active_thread == NULL) caml_thread_cleanup(Val_unit);
-
   st_masterlock_release(&Thread_main_lock);
 }
 

--- a/otherlibs/systhreads/st_stubs.c
+++ b/otherlibs/systhreads/st_stubs.c
@@ -352,6 +352,7 @@ static void caml_thread_domain_stop_hook(void) {
     set_active(NULL);
 
     caml_stat_free(st_tls_get(caml_thread_key));
+    st_tls_set(caml_thread_key, NULL);
   };
 }
 
@@ -386,8 +387,9 @@ CAMLprim value caml_thread_yield(value unit);
 
 void caml_thread_interrupt_hook(void)
 {
-  /* Do not attempt to yield from the backup thread */
-  if (caml_bt_is_self()) return;
+  /* Do not attempt to yield from the backup thread or during domain
+     shutdown. */
+  if (st_tls_get(caml_thread_key) == NULL) return;
 
   uintnat is_on = 1;
   atomic_uintnat* req_external_interrupt =

--- a/runtime/caml/domain.h
+++ b/runtime/caml/domain.h
@@ -70,7 +70,6 @@ void caml_reset_young_limit(caml_domain_state *);
 
 CAMLextern void caml_reset_domain_lock(void);
 CAMLextern int caml_bt_is_in_blocking_section(void);
-CAMLextern int caml_bt_is_self(void);
 CAMLextern intnat caml_domain_is_multicore (void);
 CAMLextern void caml_bt_enter_ocaml(void);
 CAMLextern void caml_bt_exit_ocaml(void);

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -1533,11 +1533,6 @@ CAMLexport int caml_bt_is_in_blocking_section(void)
   return status == BT_IN_BLOCKING_SECTION;
 }
 
-CAMLexport int caml_bt_is_self(void)
-{
-  return pthread_equal(domain_self->backup_thread, pthread_self());
-}
-
 CAMLexport intnat caml_domain_is_multicore (void)
 {
   dom_internal *self = domain_self;


### PR DESCRIPTION
This PR lives on top of #11385 and it fixes the 3rd commit of #11271 (cc @Engil, @kayceesrk, @gasche). It targets 5.0 because it is a dependency of #11272.

Note that only the two topmost commits belongs to it. It was better on top of #11385 because that one already did some of the changes needed to fix the bug, and is itself needed for 5.0.

It was not possible to produce a meaningful history but for your convenience here is essentially the diff of the bugfix:
```diff
--- a/otherlibs/systhreads/st_stubs.c
+++ b/otherlibs/systhreads/st_stubs.c
@@ -351,10 +351,11 @@ static void caml_thread_domain_stop_hook(void) {
     /* another domain thread may be joining on this domain's descriptor */
     caml_threadstatus_terminate(Terminated(this_thread->descr));
 
-    caml_stat_free(this_thread);
-
     /* Stop tick thread */
     set_active(NULL);
+
+    caml_stat_free(this_thread);
+    this_thread = NULL;
   };
 }
 
@@ -390,8 +391,9 @@ CAMLprim value caml_thread_yield(value unit);
 
 void caml_thread_interrupt_hook(void)
 {
-  /* Do not attempt to yield from the backup thread */
-  if (caml_bt_is_self()) return;
+  /* Do not attempt to yield from the backup thread or during domain
+     shutdown. */
+  if (this_thread == NULL) return;
 
   uintnat is_on = 1;
   atomic_uintnat* req_external_interrupt =
@@ -457,11 +459,12 @@ static void caml_thread_stop(void)
 
   caml_threadstatus_terminate(Terminated(this_thread->descr));
 
-  /* The following also sets Active_thread to a sane value in case the
-     backup thread does a GC before the domain lock is acquired
-     again. */
-  caml_thread_remove_info(Active_thread);
-  st_masterlock_release(&Thread_main_lock);
+  st_masterlock *thread_lock = &Thread_main_lock;
+  /* Remove this_thread and free its data. This also sets
+     Active_thread to a sane value in case the backup thread does a GC
+     before the domain lock is acquired again. */
+  caml_thread_remove_info(this_thread);
+  st_masterlock_release(thread_lock);
 }
 ```