### PR TITLE
 #11387: clean up envs inside Twith_modtype(subst)

### DIFF
--- a/Changes
+++ b/Changes
@@ -432,6 +432,10 @@ OCaml 5.0
   This avoids a "dangling pointer" warning of GCC 12.1.
   (Xavier Leroy, report by Armaël Guéneau, review by Gabriel Scherer)
 
+- #11387, module type with constraints no longer crash the compiler in presence
+  of both shadowing warnings and the `-bin-annot` compiler flag.
+  (Florian Angeletti, report by Christophe Raffalli, review by Gabriel Scherer)
+
 OCaml 4.14.0
 ----------------
 

--- a/typing/tast_mapper.ml
+++ b/typing/tast_mapper.ml
@@ -458,10 +458,10 @@ let module_type sub x =
 let with_constraint sub = function
   | Twith_type decl -> Twith_type (sub.type_declaration sub decl)
   | Twith_typesubst decl -> Twith_typesubst (sub.type_declaration sub decl)
+  | Twith_modtype mty -> Twith_modtype (sub.module_type sub mty)
+  | Twith_modtypesubst mty -> Twith_modtypesubst (sub.module_type sub mty)
   | Twith_module _
-  | Twith_modsubst _
-  | Twith_modtype _
-  | Twith_modtypesubst _ as d -> d
+  | Twith_modsubst _ as d -> d
 
 let open_description sub od =
   {od with open_env = sub.env sub od.open_env}


### PR DESCRIPTION
This PR updates the typedtree ast mapper to update the module type node that is part of the Twith_moduletype and Twith_moduletypesubst nodes.

This change ensures that the environment within those nodes is stripped down before being writing to a cmt file, avoiding the crash of the marshaller reported in #11387.