### PR TITLE
Improvements to compiler's META files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -42,7 +42,7 @@
 # the lines involved in the conflict, which is arguably worse
 #/Changes                 merge=union
 
-# No header for text files (would be too obtrusive).
+# No header for text and META files (would be too obtrusive).
 *.md                     typo.missing-header
 README*                  typo.missing-header
 VERSION                  typo.missing-header
@@ -50,7 +50,7 @@ VERSION                  typo.missing-header
 api_docgen/*.mld                typo.missing-header
 api_docgen/alldoc.tex           typo.missing-header
 tools/mantis2gh_stripped.csv typo.missing-header
-META                     typo.missing-header
+META.in                  typo.missing-header
 
 *.adoc                   typo.long-line=may typo.very-long-line=may
 

--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ _ocamltestd
 *.odoc
 .merlin
 _build
+META
 
 # local to root directory
 
@@ -135,7 +136,6 @@ _build
 
 /otherlibs/*/.dep
 /otherlibs/dynlink/extract_crc
-/otherlibs/dynlink/META
 /otherlibs/dynlink/dynlink_platform_intf.mli
 /otherlibs/dynlink/byte/dynlink.mli
 /otherlibs/dynlink/native/dynlink.mli

--- a/Changes
+++ b/Changes
@@ -372,9 +372,9 @@ OCaml 5.0
   from +compiler-libs, as the debugger does.
   (David Allsopp, review by Sébastien Hinderer)
 
-- #11007: META files for the stdlib, compiler-libs and other libraries (unix,
-  dynlink, str, runtime_events, threads, ocamldoc) are now installed along with
-  the compiler.
+- #11007, #11399: META files for the stdlib, compiler-libs and other libraries
+  (unix, dynlink, str, runtime_events, threads, ocamldoc) are now installed
+  along with the compiler.
   (David Allsopp, Florian Angeletti, Nicolás Ojeda Bär and Sébastien Hinderer,
    review by Daniel Bünzli, Kate Deplaix, Anil Madhavapeddy and Gabriel Scherer)
 

--- a/Makefile
+++ b/Makefile
@@ -1407,6 +1407,7 @@ distclean: clean
 	$(MAKE) -C stdlib distclean
 	$(MAKE) -C testsuite distclean
 	$(MAKE) -C tools distclean
+	rm -f compilerlibs/META
 	rm -f boot/ocamlrun boot/ocamlrun.exe boot/camlheader \
 	      boot/ocamlruns boot/ocamlruns.exe \
 	      boot/flexlink.byte boot/flexlink.byte.exe \

--- a/compilerlibs/META.in
+++ b/compilerlibs/META.in
@@ -1,4 +1,5 @@
 # @configure_input@
+
 version = "@VERSION@"
 description = "compiler-libs support library"
 

--- a/compilerlibs/META.in
+++ b/compilerlibs/META.in
@@ -1,7 +1,6 @@
 # @configure_input@
 version = "@VERSION@"
 description = "compiler-libs support library"
-directory= "+compiler-libs"
 
 package "common" (
   requires = "compiler-libs"

--- a/compilerlibs/META.in
+++ b/compilerlibs/META.in
@@ -1,10 +1,11 @@
-version = "[distributed with OCaml]"
+# @configure_input@
+version = "@VERSION@"
 description = "compiler-libs support library"
 directory= "+compiler-libs"
 
 package "common" (
   requires = "compiler-libs"
-  version = "[distributed with OCaml]"
+  version = "@VERSION@"
   description = "Common compiler routines"
   archive(byte) = "ocamlcommon.cma"
   archive(native) = "ocamlcommon.cmxa"
@@ -12,7 +13,7 @@ package "common" (
 
 package "bytecomp" (
   requires = "compiler-libs.common"
-  version = "[distributed with OCaml]"
+  version = "@VERSION@"
   description = "Bytecode compiler"
   archive(byte) = "ocamlbytecomp.cma"
   archive(native) = "ocamlbytecomp.cmxa"
@@ -20,7 +21,7 @@ package "bytecomp" (
 
 package "optcomp" (
   requires = "compiler-libs.common"
-  version = "[distributed with OCaml]"
+  version = "@VERSION@"
   description = "Native-code compiler"
   archive(byte) = "ocamloptcomp.cma"
   archive(native) = "ocamloptcomp.cmxa"
@@ -29,14 +30,14 @@ package "optcomp" (
 
 package "toplevel" (
   requires = "compiler-libs.bytecomp"
-  version = "[distributed with OCaml]"
+  version = "@VERSION@"
   description = "Toplevel interactions"
   archive(byte) = "ocamltoplevel.cma"
 )
 
 package "native-toplevel" (
   requires = "compiler-libs.optcomp dynlink"
-  version = "[distributed with OCaml]"
+  version = "@VERSION@"
   description = "Toplevel interactions"
   archive(native) = "ocamltoplevel.cmxa"
   exists_if = "ocamltoplevel.cmxa"

--- a/configure
+++ b/configure
@@ -2977,8 +2977,6 @@ ac_config_files="$ac_config_files Makefile.config"
 
 ac_config_files="$ac_config_files stdlib/sys.ml"
 
-ac_config_files="$ac_config_files otherlibs/dynlink/META"
-
 ac_config_files="$ac_config_files manual/src/version.tex"
 
 ac_config_files="$ac_config_files manual/src/html_processing/src/common.ml"
@@ -2988,6 +2986,14 @@ ac_config_headers="$ac_config_headers runtime/caml/m.h"
 ac_config_headers="$ac_config_headers runtime/caml/s.h"
 
 ac_config_headers="$ac_config_headers runtime/caml/version.h"
+
+ac_config_files="$ac_config_files compilerlibs/META"
+
+ac_config_files="$ac_config_files otherlibs/dynlink/META"
+
+ac_config_files="$ac_config_files otherlibs/runtime_events/META"
+
+ac_config_files="$ac_config_files stdlib/META"
 
 
 # Definitions related to the version of OCaml
@@ -12688,10 +12694,14 @@ esac
 otherlibraries="dynlink runtime_events"
 if test x"$enable_unix_lib" != "xno"; then :
   enable_unix_lib=yes
-   otherlibraries="$otherlibraries unix"
+  ac_config_files="$ac_config_files otherlibs/unix/META"
+
+  otherlibraries="$otherlibraries unix"
 fi
 if test x"$enable_str_lib" != "xno"; then :
   otherlibraries="$otherlibraries str"
+  ac_config_files="$ac_config_files otherlibs/str/META"
+
 fi
 
 # Checks for system services
@@ -17532,6 +17542,8 @@ case $enable_systhreads,$enable_unix_lib in #(
 $as_echo "$as_me: the threads library is disabled" >&6;} ;; #(
   *) :
     systhread_support=true
+  ac_config_files="$ac_config_files otherlibs/systhreads/META"
+
   otherlibraries="$otherlibraries systhreads"
   { $as_echo "$as_me:${as_lineno-$LINENO}: the threads library is supported" >&5
 $as_echo "$as_me: the threads library is supported" >&6;} ;;
@@ -17817,6 +17829,8 @@ if test x"$enable_ocamldoc" = "xno"; then :
   ocamldoc=""
 else
   ocamldoc=ocamldoc
+  ac_config_files="$ac_config_files ocamldoc/META"
+
 fi
 
 documentation_tool_cmd=''
@@ -19326,13 +19340,20 @@ do
     "Makefile.build_config") CONFIG_FILES="$CONFIG_FILES Makefile.build_config" ;;
     "Makefile.config") CONFIG_FILES="$CONFIG_FILES Makefile.config" ;;
     "stdlib/sys.ml") CONFIG_FILES="$CONFIG_FILES stdlib/sys.ml" ;;
-    "otherlibs/dynlink/META") CONFIG_FILES="$CONFIG_FILES otherlibs/dynlink/META" ;;
     "manual/src/version.tex") CONFIG_FILES="$CONFIG_FILES manual/src/version.tex" ;;
     "manual/src/html_processing/src/common.ml") CONFIG_FILES="$CONFIG_FILES manual/src/html_processing/src/common.ml" ;;
     "runtime/caml/m.h") CONFIG_HEADERS="$CONFIG_HEADERS runtime/caml/m.h" ;;
     "runtime/caml/s.h") CONFIG_HEADERS="$CONFIG_HEADERS runtime/caml/s.h" ;;
     "runtime/caml/version.h") CONFIG_HEADERS="$CONFIG_HEADERS runtime/caml/version.h" ;;
+    "compilerlibs/META") CONFIG_FILES="$CONFIG_FILES compilerlibs/META" ;;
+    "otherlibs/dynlink/META") CONFIG_FILES="$CONFIG_FILES otherlibs/dynlink/META" ;;
+    "otherlibs/runtime_events/META") CONFIG_FILES="$CONFIG_FILES otherlibs/runtime_events/META" ;;
+    "stdlib/META") CONFIG_FILES="$CONFIG_FILES stdlib/META" ;;
     "libtool") CONFIG_COMMANDS="$CONFIG_COMMANDS libtool" ;;
+    "otherlibs/unix/META") CONFIG_FILES="$CONFIG_FILES otherlibs/unix/META" ;;
+    "otherlibs/str/META") CONFIG_FILES="$CONFIG_FILES otherlibs/str/META" ;;
+    "otherlibs/systhreads/META") CONFIG_FILES="$CONFIG_FILES otherlibs/systhreads/META" ;;
+    "ocamldoc/META") CONFIG_FILES="$CONFIG_FILES ocamldoc/META" ;;
 
   *) as_fn_error $? "invalid argument: \`$ac_config_target'" "$LINENO" 5;;
   esac

--- a/configure.ac
+++ b/configure.ac
@@ -181,12 +181,15 @@ AC_SUBST([QS])
 AC_CONFIG_FILES([Makefile.build_config])
 AC_CONFIG_FILES([Makefile.config])
 AC_CONFIG_FILES([stdlib/sys.ml])
-AC_CONFIG_FILES([otherlibs/dynlink/META])
 AC_CONFIG_FILES([manual/src/version.tex])
 AC_CONFIG_FILES([manual/src/html_processing/src/common.ml])
 AC_CONFIG_HEADERS([runtime/caml/m.h])
 AC_CONFIG_HEADERS([runtime/caml/s.h])
 AC_CONFIG_HEADERS([runtime/caml/version.h])
+AC_CONFIG_FILES([compilerlibs/META])
+AC_CONFIG_FILES([otherlibs/dynlink/META])
+AC_CONFIG_FILES([otherlibs/runtime_events/META])
+AC_CONFIG_FILES([stdlib/META])
 
 # Definitions related to the version of OCaml
 AC_DEFINE([OCAML_VERSION_MAJOR], [OCAML__VERSION_MAJOR])
@@ -547,9 +550,11 @@ AS_CASE([$host],
 otherlibraries="dynlink runtime_events"
 AS_IF([test x"$enable_unix_lib" != "xno"],
   [enable_unix_lib=yes
-   otherlibraries="$otherlibraries unix"])
+  AC_CONFIG_FILES([otherlibs/unix/META])
+  otherlibraries="$otherlibraries unix"])
 AS_IF([test x"$enable_str_lib" != "xno"],
-  [otherlibraries="$otherlibraries str"])
+  [otherlibraries="$otherlibraries str"
+  AC_CONFIG_FILES([otherlibs/str/META])])
 
 # Checks for system services
 
@@ -1900,6 +1905,7 @@ AS_CASE([$enable_systhreads,$enable_unix_lib],
     [systhread_support=false
     AC_MSG_NOTICE([the threads library is disabled])],
   [systhread_support=true
+  AC_CONFIG_FILES([otherlibs/systhreads/META])
   otherlibraries="$otherlibraries systhreads"
   AC_MSG_NOTICE([the threads library is supported])])
 
@@ -1942,7 +1948,8 @@ AS_IF([test x"$enable_installing_source_artifacts" = "xno"],
 
 AS_IF([test x"$enable_ocamldoc" = "xno"],
   [ocamldoc=""],
-  [ocamldoc=ocamldoc])
+  [ocamldoc=ocamldoc
+  AC_CONFIG_FILES([ocamldoc/META])])
 
 documentation_tool_cmd=''
 AC_ARG_WITH([odoc],

--- a/ocamldoc/META.in
+++ b/ocamldoc/META.in
@@ -3,4 +3,3 @@
 requires = "compiler-libs"
 version = "@VERSION@"
 description = "ocamldoc plugin interface"
-directory= "+ocamldoc"

--- a/ocamldoc/META.in
+++ b/ocamldoc/META.in
@@ -1,4 +1,6 @@
+# @configure_input@
+
 requires = "compiler-libs"
-version = "[distributed with OCaml]"
+version = "@VERSION@"
 description = "ocamldoc plugin interface"
 directory= "+ocamldoc"

--- a/ocamldoc/META.in
+++ b/ocamldoc/META.in
@@ -1,5 +1,5 @@
 # @configure_input@
 
-requires = "compiler-libs"
 version = "@VERSION@"
 description = "ocamldoc plugin interface"
+requires = "compiler-libs"

--- a/ocamldoc/Makefile
+++ b/ocamldoc/Makefile
@@ -339,6 +339,7 @@ clean:
 
 .PHONY: distclean
 distclean: clean
+	rm -f META
 
 .PHONY: depend
 depend: $(DEPEND_PREREQS)

--- a/otherlibs/Makefile.otherlibs.common
+++ b/otherlibs/Makefile.otherlibs.common
@@ -132,6 +132,7 @@ clean:: partialclean
 
 .PHONY: distclean
 distclean:: clean
+	rm -f META
 
 %.cmi: %.mli
 	$(CAMLC) -c $(COMPFLAGS) $<

--- a/otherlibs/dynlink/META.in
+++ b/otherlibs/dynlink/META.in
@@ -1,4 +1,5 @@
 # @configure_input@
+
 version = "@VERSION@"
 description = "Dynamic loading and linking of object files"
 archive(byte) = "dynlink.cma"

--- a/otherlibs/dynlink/META.in
+++ b/otherlibs/dynlink/META.in
@@ -1,5 +1,5 @@
 # @configure_input@
-version = "[distributed with OCaml]"
+version = "@VERSION@"
 description = "Dynamic loading and linking of object files"
 directory = "+dynlink"
 archive(byte) = "dynlink.cma"

--- a/otherlibs/dynlink/META.in
+++ b/otherlibs/dynlink/META.in
@@ -1,6 +1,5 @@
 # @configure_input@
 version = "@VERSION@"
 description = "Dynamic loading and linking of object files"
-directory = "+dynlink"
 archive(byte) = "dynlink.cma"
 archive(native) = "@natdynlink_archive@"

--- a/otherlibs/runtime_events/META.in
+++ b/otherlibs/runtime_events/META.in
@@ -2,7 +2,6 @@
 
 description = "Ring buffer-based runtime tracing"
 version = "@VERSION@"
-directory = "+runtime_events"
 archive(byte) = "runtime_events.cma"
 archive(native) = "runtime_events.cmxa"
 plugin(byte) = "runtime_events.cma"

--- a/otherlibs/runtime_events/META.in
+++ b/otherlibs/runtime_events/META.in
@@ -1,5 +1,7 @@
+# @configure_input@
+
 description = "Ring buffer-based runtime tracing"
-version = "[distributed with OCaml]"
+version = "@VERSION@"
 directory = "+runtime_events"
 archive(byte) = "runtime_events.cma"
 archive(native) = "runtime_events.cmxa"

--- a/otherlibs/runtime_events/META.in
+++ b/otherlibs/runtime_events/META.in
@@ -1,7 +1,7 @@
 # @configure_input@
 
-description = "Ring buffer-based runtime tracing"
 version = "@VERSION@"
+description = "Ring buffer-based runtime tracing"
 archive(byte) = "runtime_events.cma"
 archive(native) = "runtime_events.cmxa"
 plugin(byte) = "runtime_events.cma"

--- a/otherlibs/str/META.in
+++ b/otherlibs/str/META.in
@@ -1,7 +1,7 @@
 # @configure_input@
 
-description = "Regular expressions and string processing"
 version = "@VERSION@"
+description = "Regular expressions and string processing"
 archive(byte) = "str.cma"
 archive(native) = "str.cmxa"
 plugin(byte) = "str.cma"

--- a/otherlibs/str/META.in
+++ b/otherlibs/str/META.in
@@ -2,7 +2,6 @@
 
 description = "Regular expressions and string processing"
 version = "@VERSION@"
-directory = "+str"
 archive(byte) = "str.cma"
 archive(native) = "str.cmxa"
 plugin(byte) = "str.cma"

--- a/otherlibs/str/META.in
+++ b/otherlibs/str/META.in
@@ -1,5 +1,7 @@
+# @configure_input@
+
 description = "Regular expressions and string processing"
-version = "[distributed with OCaml]"
+version = "@VERSION@"
 directory = "+str"
 archive(byte) = "str.cma"
 archive(native) = "str.cmxa"

--- a/otherlibs/systhreads/META.in
+++ b/otherlibs/systhreads/META.in
@@ -2,19 +2,12 @@
 
 version = "@VERSION@"
 description = "Multi-threading"
-requires(mt,mt_posix) = "threads.posix"
-directory = "+"
+requires = "unix"
+archive(byte) = "threads.cma"
+archive(native) = "threads.cmxa"
 type_of_threads = "posix"
 
 package "posix" (
-  requires = "unix"
-  exists_if = "threads.cma"
-  archive(byte,mt,mt_posix) = "threads.cma"
-  archive(native,mt,mt_posix) = "threads.cmxa"
-  version = "[internal]"
-)
-
-package "none" (
-  error = "threading is not supported on this platform"
+  requires = "threads"
   version = "[internal]"
 )

--- a/otherlibs/systhreads/META.in
+++ b/otherlibs/systhreads/META.in
@@ -8,7 +8,6 @@ type_of_threads = "posix"
 
 package "posix" (
   requires = "unix"
-  directory = "+threads"
   exists_if = "threads.cma"
   archive(byte,mt,mt_posix) = "threads.cma"
   archive(native,mt,mt_posix) = "threads.cmxa"

--- a/otherlibs/systhreads/META.in
+++ b/otherlibs/systhreads/META.in
@@ -1,4 +1,6 @@
-version = "[distributed with OCaml]"
+# @configure_input@
+
+version = "@VERSION@"
 description = "Multi-threading"
 requires(mt,mt_posix) = "threads.posix"
 directory = "+"

--- a/otherlibs/systhreads/Makefile
+++ b/otherlibs/systhreads/Makefile
@@ -111,6 +111,7 @@ clean: partialclean
 
 .PHONY: distclean
 distclean: clean
+	rm -f META
 
 INSTALL_THREADSLIBDIR=$(INSTALL_LIBDIR)/$(LIBNAME)
 

--- a/otherlibs/unix/META.in
+++ b/otherlibs/unix/META.in
@@ -1,7 +1,7 @@
 # @configure_input@
 
-description = "Unix system calls"
 version = "@VERSION@"
+description = "Unix system calls"
 archive(byte) = "unix.cma"
 archive(native) = "unix.cmxa"
 plugin(byte) = "unix.cma"

--- a/otherlibs/unix/META.in
+++ b/otherlibs/unix/META.in
@@ -2,7 +2,6 @@
 
 description = "Unix system calls"
 version = "@VERSION@"
-directory = "+unix"
 archive(byte) = "unix.cma"
 archive(native) = "unix.cmxa"
 plugin(byte) = "unix.cma"

--- a/otherlibs/unix/META.in
+++ b/otherlibs/unix/META.in
@@ -1,5 +1,7 @@
+# @configure_input@
+
 description = "Unix system calls"
-version = "[distributed with OCaml]"
+version = "@VERSION@"
 directory = "+unix"
 archive(byte) = "unix.cma"
 archive(native) = "unix.cmxa"

--- a/stdlib/META.in
+++ b/stdlib/META.in
@@ -1,3 +1,5 @@
+# @configure_input@
+
 description = "Standard library"
-version = "[distributed with OCaml]"
+version = "@VERSION@"
 directory = "+"

--- a/stdlib/META.in
+++ b/stdlib/META.in
@@ -1,5 +1,5 @@
 # @configure_input@
 
-description = "Standard library"
 version = "@VERSION@"
+description = "Standard library"
 directory = "+"

--- a/stdlib/Makefile
+++ b/stdlib/Makefile
@@ -204,7 +204,7 @@ stdlib.cmxa: $(OBJS:.cmo=.cmx)
 
 .PHONY: distclean
 distclean: clean
-	rm -f sys.ml
+	rm -f sys.ml META
 
 .PHONY: clean
 clean::


### PR DESCRIPTION
This PR (which includes changes from @shindere) follows on from #11007, which integrated findlib's `META` files for the compiler into the codebase with some cosmetic changes:
- The packages now report the version of OCaml instead of "Distributed with OCaml"
- Redundant directory fields are removed, now that the `META` files are in the same directory as the package itself (except for `stdlib`)
- The order of the lines in the files is standardised (that's a prerequisite for a subsequent PR to eliminate `exists_if`)

Two changes are also made:
- The distinction of `compiler-libs.toplevel` for bytecode and `compiler-libs.native-toplevel` for native is awkward. The recent efforts have been to try to make these two libraries equivalent, from a code perspective. `compiler-libs.toplevel` now supports native mode and `compiler-libs.native-toplevel` is left as a compatible name (we _could_ remove it completely???)
- The `META` file for threads contained a lot of `vmthreads` legacy. This is gone - in particular the unused `threads.none` package. I've left `threads.posix` because I know that name is used in the wild, but the only threads are posix (which includes the Windows ones, in this context).