### PR TITLE
stdlib documentation: strings are always immutable in OCaml 5

### DIFF
--- a/stdlib/string.mli
+++ b/stdlib/string.mli
@@ -59,19 +59,12 @@ v}
     example the string ["\u{1F42B}"] is the UTF-8 encoding of the
     Unicode character U+1F42B.
 
-    {b Past mutability.} OCaml strings used to be modifiable in place,
-    for instance via the [String.set] and [String.blit]
-    functions. This use is nowadays only possible when the compiler is
-    put in "unsafe-string" mode by giving the [-unsafe-string]
-    command-line option. This compatibility mode makes the types
-    [string] and [bytes] (see {!Bytes.t}) interchangeable so that
-    functions expecting byte sequences can also accept strings as
-    arguments and modify them.
-
-    The distinction between [bytes] and [string] was introduced in
-    OCaml 4.02, and the "unsafe-string" compatibility mode was the
-    default until OCaml 4.05. Starting with 4.06, the compatibility
-    mode is opt-in; we intend to remove the option in the future.
+    {b Past mutability.} Before OCaml 4.02, strings used to be modifiable in
+    place like {!Bytes.t} mutable sequences of bytes.
+    OCaml 4 had various compiler flags and configuration options to support the
+    transition period from mutable to immutable strings.
+    Those options are no longer available, and strings are now always
+    immutable.
 
     The labeled version of this module can be used as described in the
     {!StdLabels} module.

--- a/stdlib/stringLabels.mli
+++ b/stdlib/stringLabels.mli
@@ -59,19 +59,12 @@ v}
     example the string ["\u{1F42B}"] is the UTF-8 encoding of the
     Unicode character U+1F42B.
 
-    {b Past mutability.} OCaml strings used to be modifiable in place,
-    for instance via the [String.set] and [String.blit]
-    functions. This use is nowadays only possible when the compiler is
-    put in "unsafe-string" mode by giving the [-unsafe-string]
-    command-line option. This compatibility mode makes the types
-    [string] and [bytes] (see {!Bytes.t}) interchangeable so that
-    functions expecting byte sequences can also accept strings as
-    arguments and modify them.
-
-    The distinction between [bytes] and [string] was introduced in
-    OCaml 4.02, and the "unsafe-string" compatibility mode was the
-    default until OCaml 4.05. Starting with 4.06, the compatibility
-    mode is opt-in; we intend to remove the option in the future.
+    {b Past mutability.} Before OCaml 4.02, strings used to be modifiable in
+    place like {!Bytes.t} mutable sequences of bytes.
+    OCaml 4 had various compiler flags and configuration options to support the
+    transition period from mutable to immutable strings.
+    Those options are no longer available, and strings are now always
+    immutable.
 
     The labeled version of this module can be used as described in the
     {!StdLabels} module.


### PR DESCRIPTION
This PR rewords the paragraph on the foregone mutability of strings in the documentation for the `String` module.

Unsafe strings and all related configuration options and compiler flags are gone in OCaml 5.
It is probably still useful to document the transition period between mutable string and immutable strings as an historical event but nothing more.