### PR TITLE
List: replace rev-based tail recursion with TRMC

### DIFF
--- a/Changes
+++ b/Changes
@@ -42,6 +42,11 @@ Working version
 - #11412: Add Sys.is_regular_file
   (Xavier Leroy, review by Anil Madhavapeddy, Nicolás Ojeda Bär, David Allsopp)
 
+- #11402: List.init, List.filter, List.filteri, List.filter_map, List.of_seq are
+  rewritten to use TRMC instead of an accumulator, making them faster and
+  halving their memory usage while remaining tail-recursive.
+  (Nicolás Ojeda Bär, review by Xavier Leroy and Gabriel Scherer)
+
 ### Other libraries:
 
 ### Tools:

--- a/stdlib/list.ml
+++ b/stdlib/list.ml
@@ -60,7 +60,7 @@ let rec rev_append l1 l2 =
 let rev l = rev_append l []
 
 let[@tail_mod_cons] rec init i n f =
-  if i >= n then []
+  if i > n then []
   else if i = n then [f i]
   else
     let r1 = f i in

--- a/stdlib/list.ml
+++ b/stdlib/list.ml
@@ -59,13 +59,13 @@ let rec rev_append l1 l2 =
 
 let rev l = rev_append l []
 
-let[@tail_mod_cons] rec init i n f =
-  if i > n then []
-  else if i = n then [f i]
+let[@tail_mod_cons] rec init i last f =
+  if i > last then []
+  else if i = last then [f i]
   else
     let r1 = f i in
     let r2 = f (i+1) in
-    r1 :: r2 :: init (i+2) n f
+    r1 :: r2 :: init (i+2) last f
 
 let init len f =
   if len < 0 then invalid_arg "List.init" else

--- a/testsuite/tests/backtrace/backtrace_dynlink.reference
+++ b/testsuite/tests/backtrace/backtrace_dynlink.reference
@@ -1,17 +1,17 @@
 Raised by primitive operation at Backtrace_dynlink_plugin in file "backtrace_dynlink_plugin.ml", line 6, characters 13-38
 Called from Dynlink.Native.run.(fun) in file "otherlibs/dynlink/native/dynlink.ml", line 85, characters 12-29
-Called from Stdlib__List.iter in file "list.ml", line 122, characters 12-15
+Called from Stdlib__List.iter in file "list.ml", line 112, characters 12-15
 Called from Dynlink_common.Make.load.(fun) in file "otherlibs/dynlink/dynlink_common.ml", line 363, characters 13-56
-Called from Stdlib__List.iter in file "list.ml", line 122, characters 12-15
+Called from Stdlib__List.iter in file "list.ml", line 112, characters 12-15
 Called from Dynlink_common.Make.load in file "otherlibs/dynlink/dynlink_common.ml", line 359, characters 8-392
 Called from Dynlink_common.Make.loadfile in file "otherlibs/dynlink/dynlink_common.ml" (inlined), line 374, characters 26-45
 Called from Backtrace_dynlink in file "backtrace_dynlink.ml", line 39, characters 4-52
 execution of module initializers in the shared library failed: Failure("SUCCESS")
 Raised by primitive operation at Dynlink.Native.run.(fun) in file "otherlibs/dynlink/native/dynlink.ml", line 85, characters 12-29
 Re-raised at Dynlink.Native.run.(fun) in file "otherlibs/dynlink/native/dynlink.ml", line 87, characters 10-149
-Called from Stdlib__List.iter in file "list.ml", line 122, characters 12-15
+Called from Stdlib__List.iter in file "list.ml", line 112, characters 12-15
 Called from Dynlink_common.Make.load.(fun) in file "otherlibs/dynlink/dynlink_common.ml", line 363, characters 13-56
-Called from Stdlib__List.iter in file "list.ml", line 122, characters 12-15
+Called from Stdlib__List.iter in file "list.ml", line 112, characters 12-15
 Called from Dynlink_common.Make.load in file "otherlibs/dynlink/dynlink_common.ml", line 359, characters 8-392
 Re-raised at Dynlink_common.Make.load in file "otherlibs/dynlink/dynlink_common.ml", line 372, characters 8-17
 Called from Dynlink_common.Make.loadfile in file "otherlibs/dynlink/dynlink_common.ml" (inlined), line 374, characters 26-45

--- a/testsuite/tests/lib-dynlink-initializers/test10_main.byte.reference
+++ b/testsuite/tests/lib-dynlink-initializers/test10_main.byte.reference
@@ -6,7 +6,7 @@ Called from Test10_plugin in file "test10_plugin.ml", line 10, characters 2-6
 Called from Dynlink.Bytecode.run in file "otherlibs/dynlink/dynlink.ml", line 149, characters 16-25
 Re-raised at Dynlink.Bytecode.run in file "otherlibs/dynlink/dynlink.ml", line 151, characters 6-137
 Called from Dynlink_common.Make.load.(fun) in file "otherlibs/dynlink/dynlink_common.ml", line 363, characters 13-56
-Called from Stdlib__List.iter in file "list.ml", line 122, characters 12-15
+Called from Stdlib__List.iter in file "list.ml", line 112, characters 12-15
 Called from Dynlink_common.Make.load in file "otherlibs/dynlink/dynlink_common.ml", line 359, characters 8-392
 Re-raised at Dynlink_common.Make.load in file "otherlibs/dynlink/dynlink_common.ml", line 372, characters 8-17
 Called from Test10_main in file "test10_main.ml", line 51, characters 13-69

--- a/testsuite/tests/lib-dynlink-initializers/test10_main.native.reference
+++ b/testsuite/tests/lib-dynlink-initializers/test10_main.native.reference
@@ -1,9 +1,9 @@
 Error: Failure("Plugin error")
 Raised by primitive operation at Dynlink.Native.run.(fun) in file "otherlibs/dynlink/native/dynlink.ml", line 85, characters 12-29
 Re-raised at Dynlink.Native.run.(fun) in file "otherlibs/dynlink/native/dynlink.ml", line 87, characters 10-149
-Called from Stdlib__List.iter in file "list.ml", line 122, characters 12-15
+Called from Stdlib__List.iter in file "list.ml", line 112, characters 12-15
 Called from Dynlink_common.Make.load.(fun) in file "otherlibs/dynlink/dynlink_common.ml", line 363, characters 13-56
-Called from Stdlib__List.iter in file "list.ml", line 122, characters 12-15
+Called from Stdlib__List.iter in file "list.ml", line 112, characters 12-15
 Called from Dynlink_common.Make.load in file "otherlibs/dynlink/dynlink_common.ml", line 359, characters 8-392
 Re-raised at Dynlink_common.Make.load in file "otherlibs/dynlink/dynlink_common.ml", line 372, characters 8-17
 Called from Dynlink_common.Make.loadfile in file "otherlibs/dynlink/dynlink_common.ml" (inlined), line 374, characters 26-45


### PR DESCRIPTION
This is a follow-up to #11362: we replace `rev`-based tail recursion in `List` by TRMC. I did the same type of benchmarks as in #11362 and the TRMC version is uniformly faster and, as can be expected, the difference increases as the length of the list increases.

The functions in question are:

- `List.init`
- `List.filter` and `List.filteri`
- `List.filter_map`
- `List.of_seq`

Note that `List.init` and `List.of_seq` have a fast path for short lists. I didn't remove this existing fast path because otherwise we would be end up with worse performance for short lists, as was seen at length in #11362.