### PR TITLE
More systhreads fixes for 5.0

### DIFF
--- a/otherlibs/systhreads/st_pthreads.h
+++ b/otherlibs/systhreads/st_pthreads.h
@@ -96,6 +96,8 @@ Caml_inline void st_tls_set(st_tlskey k, void * v)
    threads. */
 
 typedef struct {
+  int init;                       /* have the mutex and the cond been
+                                     initialized already? */
   pthread_mutex_t lock;           /* to protect contents */
   uintnat busy;                   /* 0 = free, 1 = taken */
   atomic_uintnat waiters;         /* number of threads waiting on master lock */
@@ -104,9 +106,12 @@ typedef struct {
 
 static void st_masterlock_init(st_masterlock * m)
 {
-
-  pthread_mutex_init(&m->lock, NULL);
-  pthread_cond_init(&m->is_free, NULL);
+  if (!m->init) {
+    // FIXME: check errors
+    pthread_mutex_init(&m->lock, NULL);
+    pthread_cond_init(&m->is_free, NULL);
+    m->init = 1;
+  }
   m->busy = 1;
   atomic_store_rel(&m->waiters, 0);
 

--- a/otherlibs/systhreads/st_stubs.c
+++ b/otherlibs/systhreads/st_stubs.c
@@ -354,7 +354,9 @@ static void caml_thread_reinitialize(void)
   /* The master lock needs to be initialized again. This process will also be
      the effective owner of the lock. So there is no need to run
      st_masterlock_acquire (busy = 1) */
-  st_masterlock_init(Thread_lock(Caml_state->id));
+  st_masterlock *m = Thread_lock(Caml_state->id);
+  m->init = 0; /* force initialization */
+  st_masterlock_init(m);
 }
 
 CAMLprim value caml_thread_join(value th);

--- a/otherlibs/systhreads/st_stubs.c
+++ b/otherlibs/systhreads/st_stubs.c
@@ -407,7 +407,6 @@ CAMLprim value caml_thread_initialize_domain(value v)
   st_tls_set(caml_thread_key, new_thread);
 
   Active_thread = new_thread;
-  Tick_thread_running = 0;
 
   CAMLreturn(Val_unit);
 }


### PR DESCRIPTION
Through digging into the new systhreads implementation here are a few more fixes to look into for 5.0:

1. Replace explicit tls with thread_local: an already-accepted change from a previous PR, done first for rebasing convenience.
2. Guard against arbitrary code running before threads init: the domain threads initialization code runs from OCaml code. Thus there is an interval during which arbitrary OCaml code can run before initialization (e.g. GC, async callbacks and at_each_spawn callbacks).
3. Quick fix for the multiplication of tick threads: fixes one problem reported at https://github.com/ocaml/ocaml/pull/11385#issuecomment-1175098577
4. Do not reinitialize mutex and cond var: removes needless initializations which cause UB.

Bugs fixed at 2. and 4. are likely sources of UB (deadlocks or crashes) in practice, which might explain some CI failures on other systhreads PRs, though it is unclear yet.

No change entry needed.

(cc @Engil, @kayceesrk, @gasche)