### PR TITLE
Fix rooting logic in testsuite

### DIFF
--- a/testsuite/tests/parallel/test_c_thread_register_cstubs.c
+++ b/testsuite/tests/parallel/test_c_thread_register_cstubs.c
@@ -6,10 +6,28 @@
 #include "caml/callback.h"
 #include "threads.h"
 
-void *thread_func(void *fn) {
+void *create_root(value v)
+{
+  value *root = malloc(sizeof(value));
+  *root = v;
+  caml_register_generational_global_root(root);
+  return (void*)root;
+}
+
+value consume_root(void *r)
+{
+  value *root = (value *)r;
+  value v = *root;
+  caml_remove_generational_global_root(root);
+  free(root);
+  return v;
+}
+
+void *thread_func(void *root)
+{
   caml_c_thread_register();
   caml_acquire_runtime_system();
-  caml_callback((value) fn, Val_unit);
+  caml_callback(consume_root(root), Val_unit);
   caml_release_runtime_system();
   caml_c_thread_unregister();
   return 0;
@@ -19,9 +37,9 @@ value spawn_thread(value clos)
 {
   pthread_t thr;
   pthread_attr_t attr;
-
+  void *root = create_root(clos);
   pthread_attr_init(&attr);
   pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_DETACHED);
-  pthread_create(&thr, &attr, thread_func, (void *) clos);
+  pthread_create(&thr, &attr, thread_func, root);
   return Val_unit;
 }


### PR DESCRIPTION
This PR makes a test program (`test_c_thread_register.ml`) more correct by correctly rooting a value. Note that this has nothing to do with a failing test; as far as I can tell the program accidentally works because the value in question is static. But in a real/future program this could explode.

In addition I find an interest in showing how to correctly deal with this pattern of acquire/release_runtime_lock in C functions, which I have not seen explained yet (this reminded me of a limitation of the documented API showed in https://github.com/ocaml/ocaml/issues/10094, which somehow has been marked as stale and closed though it is not clear why). So this can also be helpful as a code example for future documentation.

No change entry needed.

(Sorry for the spam lately but I think this can interest @gasche.)