### PR TITLE
Tighten token permissions in GitHub actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,6 +28,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+        with:
+          persist-credentials: false
       - name: Check for manual changes
         id: manual
         run: >-
@@ -50,9 +52,7 @@ jobs:
         run: |
           MAKE_ARG=-j bash -xe tools/ci/actions/runner.sh build
       - name: Prepare Artifact
-        run: |
-          git config --local --unset http.https://github.com/.extraheader
-          tar --zstd -cf /tmp/sources.tar.zstd .
+        run: tar --zstd -cf /tmp/sources.tar.zstd .
       - name: Upload Artifact
         uses: actions/upload-artifact@v2
         with:
@@ -108,6 +108,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+        with:
+          persist-credentials: false
       - name: OS Dependencies
         if: runner.os == 'MacOS'
         run: brew install parallel

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,9 @@ on:
       - 'trunk'
   pull_request:
 
+# Restrict the GITHUB_TOKEN
+permissions: {}
+
 # List of test directories for the debug-s4096 and linux-O0 jobs.
 # These directories are selected because of their tendencies to reach corner
 # cases in the runtime system.

--- a/.github/workflows/hygiene.yml
+++ b/.github/workflows/hygiene.yml
@@ -27,6 +27,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 50
+          persist-credentials: false
 
       - name: Changes updated
         run: >-

--- a/.github/workflows/hygiene.yml
+++ b/.github/workflows/hygiene.yml
@@ -8,6 +8,9 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, labeled, unlabeled]
 
+# Restrict the GITHUB_TOKEN
+permissions: {}
+
 jobs:
   hygiene:
     name: Checks

--- a/.github/workflows/hygiene.yml
+++ b/.github/workflows/hygiene.yml
@@ -32,15 +32,16 @@ jobs:
       - name: Changes updated
         run: >-
           tools/ci/actions/check-changes-modified.sh
+          '${{ github.event.pull_request.issue_url }}'
           '${{ github.ref }}'
           'pull_request'
           '${{ github.event.pull_request.base.ref }}'
           '${{ github.event.pull_request.base.sha }}'
           '${{ github.event.pull_request.head.ref }}'
           '${{ github.event.pull_request.head.sha }}'
-        if: >-
-          !contains(github.event.pull_request.labels.*.name, 'no-change-entry-needed')
-          && github.event_name == 'pull_request'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        if: github.event_name == 'pull_request'
 
       - name: configure correctly generated
         run: >-


### PR DESCRIPTION
Tighter alternative to #11361. Tested on my fork, so opening a PR to ocaml/ocaml adds an additional test. In theory, this PR:

- Removes all privileges from the `GITHUB_TOKEN` in the GitHub Actions runners
- Disables `git` commands automatically using it in any subsequent (`actions/checkout@v2` does this)
- Tweaks the Changes check so that PRs which didn't have a `Changes` entry and then had the label added afterwards don't report "x - 1 of x checks passed" when merging

Closes: #11361 
