### PR TITLE
tools makefile: new target for secondary tools

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -270,7 +270,7 @@ endif
 	$(MAKE) ocamlopt.opt
 	$(MAKE) otherlibrariesopt
 	$(MAKE) ocamllex.opt ocamltoolsopt ocamltoolsopt.opt $(OCAMLDOC_OPT) \
-	  $(OCAMLTEST_OPT) ocamlnat
+	  $(OCAMLTEST_OPT) othertools ocamlnat
 ifeq "$(WITH_OCAMLDOC)-$(STDLIB_MANPAGES)" "ocamldoc-true"
 	$(MAKE) manpages
 endif
@@ -310,6 +310,7 @@ all: coreall
 	$(MAKE) ocaml
 	$(MAKE) otherlibraries $(WITH_DEBUGGER) $(WITH_OCAMLDOC) \
          $(WITH_OCAMLTEST)
+	$(MAKE) othertools
 ifeq "$(WITH_OCAMLDOC)-$(STDLIB_MANPAGES)" "ocamldoc-true"
 	$(MAKE) manpages
 endif
@@ -1267,6 +1268,11 @@ ocamltoolsopt: ocamlopt
 .PHONY: ocamltoolsopt.opt
 ocamltoolsopt.opt: ocamlc.opt ocamllex.opt compilerlibs/ocamlmiddleend.cmxa
 	$(MAKE) -C tools opt.opt
+
+# tools that require a full ocaml distribution: otherlibs and toplevel
+.PHONY:othertools
+othertools:
+	$(MAKE) -C tools othertools
 
 partialclean::
 	$(MAKE) -C tools clean

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -52,7 +52,7 @@ programs_byte := \
 install_files += $(filter $(installed_tools), $(programs_byte))
 programs_opt := $(programs_byte:%=%.opt)
 
-.PHONY: all allopt opt.opt # allopt and opt.opt are synonyms
+.PHONY: all allopt opt.opt othertools # allopt and opt.opt are synonyms
 all: $(programs_byte)
 opt.opt: $(programs_opt)
 allopt: opt.opt
@@ -144,8 +144,8 @@ OCAMLMKTOP=config.cmo build_path_prefix_map.cmo misc.cmo \
 
 ocamlmktop$(EXE): $(OCAMLMKTOP)
 ocamlmktop.opt$(EXE): $(call byte2native, $(OCAMLMKTOP))
-# opt.opt means "after the toplevel has been built" here
-opt.opt: ocamlmktop_init.cmo
+# othertools means "after the toplevel has been built" here
+othertools: ocamlmktop_init.cmo
 INSTALL_LIBDIR_OCAMLMKTOP = $(INSTALL_LIBDIR)/ocamlmktop
 install::
 	$(MKDIR) "$(INSTALL_LIBDIR_OCAMLMKTOP)"
@@ -328,9 +328,9 @@ $(caml_tex): $(caml_tex_files)
 	  $(LINKFLAGS) -linkall -o $@ -no-alias-deps $^
 
 # we need str and unix which depend on the bytecode version of other tools
-# thus we delay building caml-tex to the opt.opt stage
+# thus we use the othertools target
 ifneq "$(WITH_CAMLTEX)" ""
-opt.opt: $(caml_tex)
+othertools: $(caml_tex)
 endif
 clean::
 	rm -f -- caml-tex caml-tex.exe caml_tex.cm?


### PR DESCRIPTION
Few tools depend on the toplevel and/or the `unix` and `str` libraries and cannot be build as early as ocamlmklib which is used to build the `unix` and `str` library.

Before this PR, those tools were using the opt.opt target as a proxy target for "after the toplevel and otherlibs".

This works fine as long as those tools are not installed in bytecode-only mode.
However, this is no longer since we want to install the ocamlmktop runtime files even in bytecode-only mode.

This commit therefore introduces a proper Makefile target "othertools" for those late-stage tools.
Currently, this concerns only caml-tex (which is not installed) and the ocamlmktop runtime library, but it might be useful to move more tools out of the core system target in the future.