### PR TITLE
Add `Sys.is regular file` and use it to address #11302

### DIFF
--- a/Changes
+++ b/Changes
@@ -22,6 +22,9 @@ Working version
   typical workloads.
   (Nicolás Ojeda Bär, review by Gabriel Scherer)
 
+- #11412: Add Sys.is_regular_file
+  (Xavier Leroy, review by Anil Madhavapeddy, Nicolás Ojeda Bär, David Allsopp)
+
 ### Other libraries:
 
 ### Tools:

--- a/Changes
+++ b/Changes
@@ -45,6 +45,10 @@ Working version
 
 ### Bug fixes:
 
+- #11302, #11412: `ocamlc` and `ocamlopt` should not remove generated files
+  when they are not regular files.
+  (Xavier Leroy, report by Thierry Martinez, review by
+   Anil Madhavapeddy, Nicolás Ojeda Bär, David Allsopp)
 - #10348: Expand GADT equations lazily during unification to avoid ambiguity
   (Jacques Garrigue, review by Leo White)
 

--- a/bytecomp/bytelink.ml
+++ b/bytecomp/bytelink.ml
@@ -314,7 +314,9 @@ let link_bytecode ?final_name tolink exec_name standalone =
     | Link_object(file_name, _) when file_name = exec_name ->
       raise (Error (Wrong_object_name exec_name));
     | _ -> ()) tolink;
-  Misc.remove_file exec_name; (* avoid permission problems, cf PR#8354 *)
+  (* Remove the output file if it exists to avoid permission problems (PR#8354),
+     but don't risk removing a special file (PR#11302). *)
+  Misc.remove_file exec_name;
   let outperm = if !Clflags.with_runtime then 0o777 else 0o666 in
   let outchan =
     open_out_gen [Open_wronly; Open_trunc; Open_creat; Open_binary]

--- a/runtime/sys.c
+++ b/runtime/sys.c
@@ -265,7 +265,7 @@ CAMLprim value caml_sys_close(value fd_v)
   return Val_unit;
 }
 
-CAMLprim value caml_sys_file_exists(value name)
+static int caml_sys_file_mode(value name)
 {
 #ifdef _WIN32
   struct _stati64 st;
@@ -275,39 +275,42 @@ CAMLprim value caml_sys_file_exists(value name)
   char_os * p;
   int ret;
 
-  if (! caml_string_is_c_safe(name)) return Val_false;
+  if (! caml_string_is_c_safe(name)) { errno = ENOENT; return -1; }
   p = caml_stat_strdup_to_os(String_val(name));
   caml_enter_blocking_section();
   ret = stat_os(p, &st);
   caml_leave_blocking_section();
   caml_stat_free(p);
+  if (ret == -1) return -1; else return st.st_mode;
+}
 
-  return Val_bool(ret == 0);
+CAMLprim value caml_sys_file_exists(value name)
+{
+  int mode = caml_sys_file_mode(name);
+  return (Val_bool(mode != -1));
 }
 
 CAMLprim value caml_sys_is_directory(value name)
 {
   CAMLparam1(name);
-#ifdef _WIN32
-  struct _stati64 st;
-#else
-  struct stat st;
-#endif
-  char_os * p;
-  int ret;
-
-  caml_sys_check_path(name);
-  p = caml_stat_strdup_to_os(String_val(name));
-  caml_enter_blocking_section();
-  ret = stat_os(p, &st);
-  caml_leave_blocking_section();
-  caml_stat_free(p);
-
-  if (ret == -1) caml_sys_error(name);
+  int mode = caml_sys_file_mode(name);
+  if (mode == -1) caml_sys_error(name);
 #ifdef S_ISDIR
-  CAMLreturn(Val_bool(S_ISDIR(st.st_mode)));
+  CAMLreturn(Val_bool(S_ISDIR(mode)));
 #else
-  CAMLreturn(Val_bool(st.st_mode & S_IFDIR));
+  CAMLreturn(Val_bool(mode & S_IFDIR));
+#endif
+}
+
+CAMLprim value caml_sys_is_regular_file(value name)
+{
+  CAMLparam1(name);
+  int mode = caml_sys_file_mode(name);
+  if (mode == -1) caml_sys_error(name);
+#ifdef S_ISREG
+  CAMLreturn(Val_bool(S_ISREG(mode)));
+#else
+  CAMLreturn(Val_bool(mode & S_IFREG));
 #endif
 }
 

--- a/stdlib/sys.ml.in
+++ b/stdlib/sys.ml.in
@@ -50,6 +50,7 @@ external runtime_parameters : unit -> string = "caml_runtime_parameters"
 
 external file_exists: string -> bool = "caml_sys_file_exists"
 external is_directory : string -> bool = "caml_sys_is_directory"
+external is_regular_file : string -> bool = "caml_sys_is_regular_file"
 external remove: string -> unit = "caml_sys_remove"
 external rename : string -> string -> unit = "caml_sys_rename"
 external getenv: string -> string = "caml_sys_getenv"

--- a/stdlib/sys.mli
+++ b/stdlib/sys.mli
@@ -42,6 +42,13 @@ external is_directory : string -> bool = "caml_sys_is_directory"
     @since 3.10.0
 *)
 
+external is_regular_file : string -> bool = "caml_sys_is_regular_file"
+(** Returns [true] if the given name refers to a regular file,
+    [false] if it refers to another kind of file.
+    @raise Sys_error if no file exists with the given name.
+    @since 5.1
+*)
+
 external remove : string -> unit = "caml_sys_remove"
 (** Remove the given file name from the file system. *)
 

--- a/utils/misc.ml
+++ b/utils/misc.ml
@@ -276,7 +276,7 @@ let find_in_path_uncap path name =
 
 let remove_file filename =
   try
-    if Sys.file_exists filename
+    if Sys.is_regular_file filename
     then Sys.remove filename
   with Sys_error _msg ->
     ()

--- a/utils/misc.mli
+++ b/utils/misc.mli
@@ -185,7 +185,9 @@ val find_in_path_uncap: string list -> string -> string
            if name is Foo.ml, allow /path/Foo.ml and /path/foo.ml
            to match. *)
 val remove_file: string -> unit
-        (* Delete the given file if it exists. Never raise an error. *)
+        (* Delete the given file if it exists and is a regular file.
+           Does nothing for other kinds of files.
+           Never raises an error. *)
 val expand_directory: string -> string -> string
         (* [expand_directory alt file] eventually expands a [+] at the
            beginning of file into [alt] (an alternate root directory) *)


### PR DESCRIPTION
This PR introduces the function `Sys.is_regular_file` and uses it in ocamlc to avoid removing the target executable file if it's not a regular file.  If we're root and the target is e.g. `/dev/null`, bad things happen.

Fixes: #11302.

