### PR TITLE
#11314: do not elide the whole module type error message

### DIFF
--- a/Changes
+++ b/Changes
@@ -494,6 +494,9 @@ OCaml 5.0
   (Fabrice Buoro, Enguerrand Decorne, Gabriel Scherer,
    review by Xavier Leroy and Florian Angeletti, report by Romain Beauxis)
 
+- #11314, #11416: fix non-informative error message for module inclusion
+  (Florian Angeletti, report by Thierry Martinez, review by Gabriel Scherer)
+
 - #11358, #11379: Refactor the initialization of bytecode threading,
   This avoids a "dangling pointer" warning of GCC 12.1.
   (Xavier Leroy, report by Armaël Guéneau, review by Gabriel Scherer)

--- a/testsuite/tests/typing-modules/inclusion_errors_elision.ml
+++ b/testsuite/tests/typing-modules/inclusion_errors_elision.ml
@@ -1,0 +1,93 @@
+(* TEST
+   flags ="-keep-original-error-size"
+   * expect
+  *)
+
+
+module A = struct
+  type a and b and c and d
+end
+
+module type S = sig
+  module B = A
+end
+
+module C : S = struct
+  module B = struct
+    type a and b and c and d and e and f and g and h
+  end
+end
+[%%expect {|
+module A : sig type a and b and c and d end
+module type S = sig module B = A end
+Lines 9-13, characters 15-3:
+ 9 | ...............struct
+10 |   module B = struct
+11 |     type a and b and c and d and e and f and g and h
+12 |   end
+13 | end
+Error: Signature mismatch:
+       ...
+       In module B:
+       Modules do not match:
+         sig
+           type a = B.a
+           and b = B.b
+           and c = B.c
+           and d = B.d
+           and e = B.e
+           and f = B.f
+           and g = B.g
+           and h = B.h
+         end
+       is not included in
+         (module A)
+|}]
+
+module A = struct
+  type a and b and c and d
+end
+
+module type S = sig
+  module type B = sig
+    module C = A
+  end
+end
+
+module D : S = struct
+  module type B = sig
+    module C: sig
+      type a and b and c and d and e and f and g and h
+    end
+  end
+end
+[%%expect{|
+module A : sig type a and b and c and d end
+module type S = sig module type B = sig module C = A end end
+Lines 11-17, characters 15-3:
+11 | ...............struct
+12 |   module type B = sig
+13 |     module C: sig
+14 |       type a and b and c and d and e and f and g and h
+15 |     end
+16 |   end
+17 | end
+Error: Signature mismatch:
+       ...
+       ...
+       ...
+       At position module type B = sig module C : <here> end
+       Modules do not match:
+         sig
+           type a = C.a
+           and b = C.b
+           and c = C.c
+           and d = C.d
+           and e = C.e
+           and f = C.f
+           and g = C.g
+           and h = C.h
+         end
+       is not included in
+         (module A)
+|}]

--- a/typing/includemod_errorprinter.ml
+++ b/typing/includemod_errorprinter.ml
@@ -709,7 +709,16 @@ let rec module_type ~expansion_token ~eqmode ~env ~before ~ctx diff =
       functor_params ~expansion_token ~env ~before ~ctx d
   | _ ->
       let inner = if eqmode then eq_module_types else module_types in
-      let next = dwith_context_and_elision ctx inner diff in
+      let next =
+        match diff.symptom with
+        | Mt_core _ ->
+            (* In those cases, the refined error messages for the current error
+               will at most add some minor comments on the current error.
+               It is thus better to avoid eliding the current error message.
+            *)
+            dwith_context ctx (inner diff)
+        | _ -> dwith_context_and_elision ctx inner diff
+      in
       let before = next :: before in
       module_type_symptom ~eqmode ~expansion_token ~env ~before ~ctx
         diff.symptom


### PR DESCRIPTION
Since OCaml 4.13 when printing error message for module type inclusion, it was possible that the whole error message ended up elided, for instance:
```ocaml
Error: Signature mismatch:
       ...
       ...
```
This PR fixes this issue by making sure that the last difference between module types in an inclusion error trace is always printed when there are no more meaningful refinement available in the error trace.

Close #11314  