### PR TITLE
Fix regression allowing virtual methods in non-virtual classes

### DIFF
--- a/Changes
+++ b/Changes
@@ -455,6 +455,9 @@ OCaml 5.0
 - #11392, #11392: assertion failure with -rectypes and external definitions
   (Gabriel Scherer, review by Florian Angeletti, report by Dmitrii Kosarev)
 
+- #11417: Fix regression allowing virtual methods in non-virtual classes.
+  (Leo White, review by Florian Angeletti)
+
 OCaml 4.14.0 (28 March 2022)
 ----------------------------
 

--- a/testsuite/tests/typing-objects/Tests.ml
+++ b/testsuite/tests/typing-objects/Tests.ml
@@ -1344,3 +1344,64 @@ let _ = (new foo)#f true
 class foo : object method f : bool -> bool end
 - : bool = true
 |}];;
+
+
+class c : object
+    method virtual m : int
+end = object
+    method m = 9
+  end
+[%%expect {|
+Lines 1-3, characters 10-3:
+1 | ..........object
+2 |     method virtual m : int
+3 | end.........
+Error: This non-virtual class type has virtual methods.
+       The following methods are virtual : m
+|}];;
+
+class virtual c : object
+    method virtual m : int
+end = object
+    method m = 42
+  end
+[%%expect {|
+class virtual c : object method virtual m : int end
+|}];;
+
+class virtual cv = object
+    method virtual m : int
+  end
+
+class c : cv = object
+    method m = 42
+  end
+[%%expect {|
+class virtual cv : object method virtual m : int end
+Line 5, characters 10-12:
+5 | class c : cv = object
+              ^^
+Error: This non-virtual class type has virtual methods.
+       The following methods are virtual : m
+|}];;
+
+class virtual c : cv = object
+    method m = 41
+  end
+[%%expect {|
+class virtual c : cv
+|}];;
+
+class c = cv
+[%%expect {|
+Line 1, characters 10-12:
+1 | class c = cv
+              ^^
+Error: This non-virtual class has virtual methods.
+       The following methods are virtual : m
+|}];;
+
+class virtual c = cv
+[%%expect {|
+class virtual c : cv
+|}];;


### PR DESCRIPTION
This fixes the regression from #8516 that I mentioned in https://github.com/ocaml/ocaml/issues/11195#issuecomment-1100603481.

Named classes and class types weren't being checked for unexpected virtual methods.