### PR TITLE
runtime/domain.c: include pthread_np.h for HAS_GNU_GETAFFINITY_NP on …

### DIFF
--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -26,6 +26,9 @@
 #include <string.h>
 #ifdef HAS_GNU_GETAFFINITY_NP
 #include <sched.h>
+#ifdef __FreeBSD__
+#include <pthread_np.h>
+#endif
 #endif
 #ifdef HAS_BSD_GETAFFINITY_NP
 #include <pthread_np.h>


### PR DESCRIPTION
…FreeBSD

Recent FreeBSD implements the CPUSET API and cpu_set_t compatible with
that from Linux, which triggers HAS_GNU_GETAFFINITY_NP definition from
configure, instead of HAS_BSD_GETAFFINITY_NP. The difference affecting
domain.c is that on FreeBSD, same as before, pthread_getaffinity_np()
prototype is still provided by pthread_np.h.

Guard the inclusion of pthread_np.h under FreeBSD-specific define,
because glibc does not offer pthread_np.h.