### PR TITLE
runtime/domain.c: include pthread_np.h for HAS_GNU_GETAFFINITY_NP on …

### DIFF
--- a/Changes
+++ b/Changes
@@ -255,9 +255,9 @@ OCaml 5.0
   Unix module.
   (Nicolás Ojeda Bär, review by Anil Madhavapeddy)
 
-- #11309: Add Domain.recommended_domain_count.
-  (Christiano Haesbaert, review by David Allsopp, KC Sivaramakrishnan,
-  Gabriel Scherer, Nicolas Ojeda Bar)
+- #11309, #11424, #11427: Add Domain.recommended_domain_count.
+  (Christiano Haesbaert, Konstantin Belousov, review by David Allsopp,
+  KC Sivaramakrishnan, Gabriel Scherer, Nicolas Ojeda Bar)
 
 ### Tools:
 

--- a/configure
+++ b/configure
@@ -13495,6 +13495,13 @@ if test "x$ac_cv_header_stdint_h" = xyes; then :
 fi
 
 
+ac_fn_c_check_header_mongrel "$LINENO" "pthread_np.h" "ac_cv_header_pthread_np_h" "$ac_includes_default"
+if test "x$ac_cv_header_pthread_np_h" = xyes; then :
+  $as_echo "#define HAS_PTHREAD_NP_H 1" >>confdefs.h
+
+fi
+
+
 ac_fn_c_check_header_compile "$LINENO" "dirent.h" "ac_cv_header_dirent_h" "#include <sys/types.h>
 "
 if test "x$ac_cv_header_dirent_h" = xyes; then :

--- a/configure.ac
+++ b/configure.ac
@@ -870,6 +870,7 @@ AS_IF([test "x$ac_cv_lib_m_cos" = xyes ], [mathlib="-lm"], [mathlib=""])
 AC_CHECK_HEADER([math.h])
 AC_CHECK_HEADERS([unistd.h],[AC_DEFINE([HAS_UNISTD])])
 AC_CHECK_HEADER([stdint.h],[AC_DEFINE([HAS_STDINT_H])])
+AC_CHECK_HEADER([pthread_np.h],[AC_DEFINE([HAS_PTHREAD_NP_H])])
 AC_CHECK_HEADER([dirent.h], [AC_DEFINE([HAS_DIRENT])], [],
   [#include <sys/types.h>])
 

--- a/runtime/caml/s.h.in
+++ b/runtime/caml/s.h.in
@@ -102,6 +102,8 @@
 
 #undef HAS_STDINT_H
 
+#undef HAS_PTHREAD_NP_H
+
 #undef HAS_UNISTD
 
 /* Define HAS_UNISTD if you have /usr/include/unistd.h. */

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -26,6 +26,9 @@
 #include <string.h>
 #ifdef HAS_GNU_GETAFFINITY_NP
 #include <sched.h>
+#ifdef HAS_PTHREAD_NP_H
+#include <pthread_np.h>
+#endif
 #endif
 #ifdef HAS_BSD_GETAFFINITY_NP
 #include <pthread_np.h>


### PR DESCRIPTION
…FreeBSD

Recent FreeBSD implements the CPUSET API and cpu_set_t compatible with
that from Linux, which triggers HAS_GNU_GETAFFINITY_NP definition from
configure, instead of HAS_BSD_GETAFFINITY_NP. The difference affecting
domain.c is that on FreeBSD, same as before, pthread_getaffinity_np()
prototype is still provided by pthread_np.h.

Guard the inclusion of pthread_np.h under FreeBSD-specific define,
because glibc does not offer pthread_np.h.

runtime/domain.c: include pthread_np.h for HAS_GNU_GETAFFINITY_NP on FreeBSD

Recent FreeBSD implements the CPUSET API and cpu_set_t compatible with
that from Linux, which triggers HAS_GNU_GETAFFINITY_NP definition from
configure, instead of HAS_BSD_GETAFFINITY_NP. The difference affecting
domain.c is that on FreeBSD, same as before, pthread_getaffinity_np()
prototype is still provided by pthread_np.h.

Guard the inclusion of pthread_np.h under HAS_PTHREAD_NP_H,
because glibc does not offer pthread_np.h.