### PR TITLE
Seq.uncons doc: remove mention of nonexistent head/tail functions

### DIFF
--- a/stdlib/seq.mli
+++ b/stdlib/seq.mli
@@ -142,14 +142,8 @@ val is_empty : 'a t -> bool
 val uncons : 'a t -> ('a * 'a t) option
 (** If [xs] is empty, then [uncons xs] is [None].
 
-    If [xs] is nonempty, then [uncons xs] is
-    [Some (head xs, tail xs)],
-    that is, a pair of the head and tail of the sequence [xs].
-
-    This equivalence holds if [xs] is persistent.
-    If [xs] is ephemeral, then [uncons] must be preferred
-    over separate calls to [head] and [tail],
-    which would cause [xs] to be queried twice.
+    If [xs] is nonempty, then [uncons xs] is [Some (x, ys)] where [x] is the
+    head of the sequence and [ys] its tail.
 
     @since 4.14 *)
 


### PR DESCRIPTION
The documentation of `Seq.uncons` currently specifies its behavior in term of `head` and `tail` functions, which apparently did not make it to the final API and thus do not exist.
I had a go at fixing the docs, but other suggestions are of course welcome.