### PR TITLE
Fix ARM64 bounds exception backtraces

### DIFF
--- a/.depend
+++ b/.depend
@@ -3053,6 +3053,7 @@ asmcomp/selectgen.cmo : \
     lambda/lambda.cmi \
     lambda/debuginfo.cmi \
     asmcomp/cmm.cmi \
+    utils/clflags.cmi \
     middle_end/backend_var.cmi \
     parsing/asttypes.cmi \
     asmcomp/arch.cmi \
@@ -3067,6 +3068,7 @@ asmcomp/selectgen.cmx : \
     lambda/lambda.cmx \
     lambda/debuginfo.cmx \
     asmcomp/cmm.cmx \
+    utils/clflags.cmx \
     middle_end/backend_var.cmx \
     parsing/asttypes.cmi \
     asmcomp/arch.cmx \

--- a/Changes
+++ b/Changes
@@ -49,9 +49,9 @@ Working version
 - #10348: Expand GADT equations lazily during unification to avoid ambiguity
   (Jacques Garrigue, review by Leo White)
 
-- #11463: Fix bounds check exception backtraces when compiling with -g;
-  reported on ARM64, but ensures unwind across works across all platforms.
-  (Tom Kelly, Xavier Leroy, review by xxx)
+- #11436: Fix wrong stack backtrace for out-of-bound exceptions raised
+  by leaf functions.
+  (Tom Kelly and Xavier Leroy, review by Mark Shinwell)
 
 
 OCaml 5.0

--- a/Changes
+++ b/Changes
@@ -49,6 +49,10 @@ Working version
 - #10348: Expand GADT equations lazily during unification to avoid ambiguity
   (Jacques Garrigue, review by Leo White)
 
+- #11463: Fix bounds check exception backtraces when compiling with -g;
+  reported on ARM64, but ensures unwind across works across all platforms.
+  (Tom Kelly, Xavier Leroy, review by xxx)
+
 
 OCaml 5.0
 ---------

--- a/asmcomp/arm64/selection.ml
+++ b/asmcomp/arm64/selection.ml
@@ -216,9 +216,6 @@ method! insert_move_extcall_arg env ty_arg src dst =
   if macosx && ty_arg = XInt32 && is_stack_slot dst
   then self#insert env (Iop (Ispecific Imove32)) src dst
   else self#insert_moves env src dst
-
-method! mark_c_tailcall =
-  if !Clflags.debug then contains_calls := true
 end
 
 let fundecl ~future_funcnames f = (new selector)#emit_fundecl

--- a/asmcomp/arm64/selection.ml
+++ b/asmcomp/arm64/selection.ml
@@ -216,6 +216,9 @@ method! insert_move_extcall_arg env ty_arg src dst =
   if macosx && ty_arg = XInt32 && is_stack_slot dst
   then self#insert env (Iop (Ispecific Imove32)) src dst
   else self#insert_moves env src dst
+
+method! mark_c_tailcall =
+  if !Clflags.debug then contains_calls := true
 end
 
 let fundecl ~future_funcnames f = (new selector)#emit_fundecl

--- a/asmcomp/selectgen.ml
+++ b/asmcomp/selectgen.ml
@@ -411,7 +411,8 @@ method mark_call =
 
 method mark_tailcall = ()
 
-method mark_c_tailcall = ()
+method mark_c_tailcall =
+  if !Clflags.debug then contains_calls := true
 
 method mark_instr = function
   | Iop (Icall_ind | Icall_imm _ | Iextcall _) ->

--- a/asmcomp/selectgen.mli
+++ b/asmcomp/selectgen.mli
@@ -126,13 +126,17 @@ class virtual selector_generic : object
 
   method mark_c_tailcall : unit
   (* informs the code emitter that the current function may call
-     a C function that never returns; by default, does nothing.
+     a C function that never returns; by default, sets
+     [contains_calls := true] in [-g] mode and does nothing otherwise.
 
-     It is unnecessary to save the stack pointer in this situation
-     (which is the main purpose of tracking leaf functions) but some
-     architectures still need to ensure that the stack is properly
-     aligned when the C function is called. This is achieved by
-     overloading this method to set [contains_calls := true] *)
+     It is unnecessary to save the stack pointer in this situation,
+     unless we need to produce exact stack backtraces, hence the default
+     definition.
+
+     Some architectures still need to ensure that the stack is properly
+     aligned when the C function is called, regardless of [-g].
+     This is achieved by overloading this method to set
+     [contains_calls := true]. *)
 
   method mark_instr : Mach.instruction_desc -> unit
   (* dispatches on instructions to call one of the marking function

--- a/testsuite/tests/backtrace/backtrace_bounds_exn.ml
+++ b/testsuite/tests/backtrace/backtrace_bounds_exn.ml
@@ -3,11 +3,11 @@
    ocamlrunparam += ",b=1"
 *)
 
-(* bad bounds exception *)
+(* #11436: bad backtrace for out-of-bounds exception *)
 
 let xs = [| 0; 1; 2 |]
 
-let bad_bound_fn x =
+let [@inline never] bad_bound_fn x =
   !x + xs.(100)
 
 let _ =

--- a/testsuite/tests/backtrace/backtrace_bounds_exn.ml
+++ b/testsuite/tests/backtrace/backtrace_bounds_exn.ml
@@ -1,0 +1,20 @@
+(* TEST
+   flags = "-g"
+   ocamlrunparam += ",b=1"
+*)
+
+(* bad bounds exception *)
+
+let xs = [| 0; 1; 2 |]
+
+let bad_bound_fn x =
+  !x + xs.(100)
+
+let _ =
+  try
+    ignore (Sys.opaque_identity (bad_bound_fn (ref 0)));
+  with exn ->
+    Printf.printf "Uncaught exception %s\n" (Printexc.to_string exn);
+    Printexc.print_backtrace stdout;
+
+  print_endline "OK"

--- a/testsuite/tests/backtrace/backtrace_bounds_exn.reference
+++ b/testsuite/tests/backtrace/backtrace_bounds_exn.reference
@@ -1,0 +1,4 @@
+Uncaught exception Invalid_argument("index out of bounds")
+Raised by primitive operation at Backtrace_bounds_exn.bad_bound_fn in file "backtrace_bounds_exn.ml", line 11, characters 7-15
+Called from Backtrace_bounds_exn in file "backtrace_bounds_exn.ml", line 15, characters 32-54
+OK


### PR DESCRIPTION
This PR fixes the ARM64 backend to correctly handle backtraces in leaf functions that throw bounds check exceptions. This ARM64 bug in the testcase is present in the 5.0 series and at least 4.14.

This PR implements `mark_c_tailcall` for the ARM64 backend and marks the function as not a leaf call if in debug mode. This is already done on AMD64 but for alignment purposes (see https://github.com/ocaml/ocaml/issues/6239#issuecomment-473022877). In this PR we are doing this to save the ARM64 link register `x30` to the stack such that `caml_stash_backtrace` can correctly walk the stack when the bounds exception is raised. 

(This PR fixes the issue observed [here](https://github.com/ocaml/ocaml/pull/11303#issuecomment-1181503482))

