### PR TITLE
Document `gc_regs` and `gc_regs_buckets`

### DIFF
--- a/runtime/callback.c
+++ b/runtime/callback.c
@@ -136,7 +136,9 @@ CAMLexport value caml_callback3_exn(value closure,
   return caml_callbackN_exn(closure, 3, arg);
 }
 
-#else /* Nativecode callbacks */
+#else
+
+/* Native-code callbacks.  caml_callback[123]_asm are implemented in asm. */
 
 static void init_callback_code(void)
 {
@@ -210,8 +212,6 @@ CAMLexport value caml_callback3_exn(value closure,
     return caml_callback3_asm(domain_state, closure, args);
   }
 }
-
-/* Native-code callbacks.  caml_callback[123]_asm are implemented in asm. */
 
 CAMLexport value caml_callbackN_exn(value closure, int narg, value args[])
 {

--- a/runtime/caml/domain_state.tbl
+++ b/runtime/caml/domain_state.tbl
@@ -46,8 +46,12 @@ DOMAIN_STATE(struct stack_info**, stack_cache)
 /* This is a list of freelist buckets of stacks */
 
 DOMAIN_STATE(value*, gc_regs_buckets)
+/* Cache of free gc_regs buckets.
+   Documented in fiber.h. */
 
 DOMAIN_STATE(value*, gc_regs)
+/* Pointer to currently-used register bucket, or NULL.
+   Documented in fiber.h. */
 
 DOMAIN_STATE(struct caml_minor_tables*, minor_tables)
 

--- a/runtime/fiber.c
+++ b/runtime/fiber.c
@@ -308,8 +308,8 @@ void caml_maybe_expand_stack (void)
       caml_raise_stack_overflow();
 
   if (Caml_state->gc_regs_buckets == NULL) {
-    /* ensure there is at least one gc_regs bucket available before
-       running any OCaml code */
+    /* Ensure there is at least one gc_regs bucket available before
+       running any OCaml code. See fiber.h for documentation. */
     value* bucket = caml_stat_alloc(sizeof(value) * Wosize_gc_regs);
     bucket[0] = 0; /* no next bucket */
     Caml_state->gc_regs_buckets = bucket;


### PR DESCRIPTION
This PR was motivated by the discussion of #11406. cc @fabbing @Engil @Octachron @xavierleroy.

I realized while writing the documentation that there are things I don't understand.

- [ ] @xavierleroy asks why the `gc_regs` buckets are now allocated on the C stack, rather than being stack-allocated as with the 4.x runtime. I don't know! I thought of the following possible explanations:
  + maybe it's easier to write the runtime code if the size of the "stack metadata" (that previously contained gc_regs) has the same size on all architectures?
   + maybe there is a small performance advantage in not growing the stack by so many registers? (the stack is copied by the `realloc_stack` logic at the beginning, and it starts small at 64 words)
- [ ] I'm not sure which functions need to save all registers in `gc_regs` and why. Obviously `caml_call_gc` does, because the GC needs to walk the OCaml registers for roots. But if I read the assembly code correctly, the (only) other runtime function doing this is `caml_call_realloc_stack`, and I don't know why. As far as I can tell, this function never transfers control back to OCaml code, and it does not call the GC (stacks are allocated by fiber.c:alloc_for_stack on the C heap).