### PR TITLE
[issue] commit a known-broken testcase for a parsing bug

### DIFF
--- a/testsuite/tests/parsing/typedecl_with_arrow.compilers.reference
+++ b/testsuite/tests/parsing/typedecl_with_arrow.compilers.reference
@@ -1,0 +1,4 @@
+File "typedecl_with_arrow.ml", line 10, characters 35-37:
+10 | type wrongly_rejected = Foo of int -> int
+                                        ^^
+Error: Syntax error

--- a/testsuite/tests/parsing/typedecl_with_arrow.ml
+++ b/testsuite/tests/parsing/typedecl_with_arrow.ml
@@ -1,0 +1,10 @@
+(* TEST
+   ocamlc_byte_exit_status = "2"
+   * setup-ocamlc.byte-build-env
+   ** ocamlc.byte
+   *** check-ocamlc.byte-output
+*)
+
+type accepted = Foo of (int -> int)
+
+type wrongly_rejected = Foo of int -> int


### PR DESCRIPTION
I found what I believe to be a parsing bug. The following is rejected, but should be accepted:

```ocaml
type t = Foo of int -> int
```

The present PR is a "known-broken" testcase for this bug. (It does not fix the bug, but it stores us in our testsuite. If the parser changes, we may notice that the bug has gone away.)