### PR TITLE
minor simplification in lambda/switch.ml

### DIFF
--- a/lambda/switch.ml
+++ b/lambda/switch.ml
@@ -266,25 +266,19 @@ let pret chan = function
           for i = 0 to len1-2 do
             r.(i) <- c1.(i)
           done ;
-
           let l =
-            if len1-2 >= 0 then begin
+            if len1 < 2 then l1
+            else begin (* 0 <= len1 - 2 < len1 *)
               let _,h,_ = r.(len1-2) in
-              if h+1 < l1 then
-                h+1
-              else
-                l1
-            end else
-              l1
+              min (h + 1) l1
+            end
           and h =
-            if 1 < len2-1 then begin
+            if len2 < 2 then h2
+            else begin (* 0 <= 1 < len2 *)
               let l,_,_ = c2.(1) in
-              if h2+1 < l then
-                l-1
-              else
-                h2
-            end else
-              h2 in
+              max h2 (l - 1)
+            end
+          in
           r.(len1-1) <- (l,h,act1) ;
           for i=1 to len2-1  do
             r.(len1-1+i) <- c2.(i)


### PR DESCRIPTION
The change fixes a small bug (that would lead to missed optimization
opportunities, not miscompilation I believe) in lambda/switch.ml,
where a test that should be equivalent to (len1 < 2) was in fact
written in a form equivalent to (len1 <= 2), missing an improvement
opportunity for the case len1=2.

The use of min/max is an additional simplification in this exact same
part of the code.

closes #10465

(cc @maranget, with whom I discussed the change this morning)

Suggested by Michael Rose.