### PR TITLE
Tests: use int_size instead of word_size when appropriate

### DIFF
--- a/testsuite/tests/lib-format/tformat.ml
+++ b/testsuite/tests/lib-format/tformat.ml
@@ -51,10 +51,10 @@ try
   test (sprintf "%*u" (-4) 42 = "42  ");
 
   say "\nu negative\n%!";
-  begin match Sys.word_size with
-  | 32 ->
+  begin match Sys.int_size with
+  | 31 ->
      test (sprintf "%u" (-1) = "2147483647");
-  | 64 ->
+  | 63 ->
      test (sprintf "%u" (-1) = "9223372036854775807");
   | _ -> test false
   end;
@@ -75,10 +75,10 @@ try
   test (sprintf "%-0+ #*x" 5 42 = "0x2a ");
 
   say "\nx negative\n%!";
-  begin match Sys.word_size with
-  | 32 ->
+  begin match Sys.int_size with
+  | 31 ->
      test (sprintf "%x" (-42) = "7fffffd6");
-  | 64 ->
+  | 63 ->
      test (sprintf "%x" (-42) = "7fffffffffffffd6");
   | _ -> test false
   end;
@@ -95,10 +95,10 @@ try
   test (sprintf "%-0+ #*X" 5 42 = "0X2A ");
 
   say "\nx negative\n%!";
-  begin match Sys.word_size with
-  | 32 ->
+  begin match Sys.int_size with
+  | 31 ->
      test (sprintf "%X" (-42) = "7FFFFFD6");
-  | 64 ->
+  | 63 ->
      test (sprintf "%X" (-42) = "7FFFFFFFFFFFFFD6");
   | _ -> test false
   end;
@@ -115,10 +115,10 @@ try
   test (sprintf "%-0+ #*o" 5 42 = "052  ");
 
   say "\no negative\n%!";
-  begin match Sys.word_size with
-  | 32 ->
+  begin match Sys.int_size with
+  | 31 ->
      test (sprintf "%o" (-42) = "17777777726");
-  | 64 ->
+  | 63 ->
      test (sprintf "%o" (-42) = "777777777777777777726");
   | _ -> test false
   end;

--- a/testsuite/tests/lib-printf/tprintf.ml
+++ b/testsuite/tests/lib-printf/tprintf.ml
@@ -75,11 +75,11 @@ try
   test (sprintf "%*u" (-4) 42 = "42  ");
 
   printf "\nu negative\n%!";
-  begin match Sys.word_size with
-  | 32 ->
+  begin match Sys.int_size with
+  | 31 ->
      test (sprintf "%u" (-1) = "2147483647");
      test (sprintf "%#u" (-1) = "2_147_483_647");
-  | 64 ->
+  | 63 ->
      test (sprintf "%u" (-1) = "9223372036854775807");
      test (sprintf "%#u" (-1) = "9_223_372_036_854_775_807");
   | _ -> test false
@@ -103,10 +103,10 @@ try
   test (sprintf "%-0+ #*x" 5 42 = "0x2a ");
 
   printf "\nx negative\n%!";
-  begin match Sys.word_size with
-  | 32 ->
+  begin match Sys.int_size with
+  | 31 ->
      test (sprintf "%x" (-42) = "7fffffd6");
-  | 64 ->
+  | 63 ->
      test (sprintf "%x" (-42) = "7fffffffffffffd6");
   | _ -> test false
   end;
@@ -126,10 +126,10 @@ try
     (* >> '-' is incompatible with '0' *)
 
   printf "\nx negative\n%!";
-  begin match Sys.word_size with
-  | 32 ->
+  begin match Sys.int_size with
+  | 31 ->
      test (sprintf "%X" (-42) = "7FFFFFD6");
-  | 64 ->
+  | 63 ->
      test (sprintf "%X" (-42) = "7FFFFFFFFFFFFFD6");
   | _ -> test false
   end;
@@ -149,10 +149,10 @@ try
     (* >> '-' is incompatible with 'o' *)
 
   printf "\no negative\n%!";
-  begin match Sys.word_size with
-  | 32 ->
+  begin match Sys.int_size with
+  | 31 ->
      test (sprintf "%o" (-42) = "17777777726");
-  | 64 ->
+  | 63 ->
      test (sprintf "%o" (-42) = "777777777777777777726");
   | _ -> test false
   end;


### PR DESCRIPTION
Some tests currently match on `Sys.word_size` where `Sys.int_size` would be more correct. (Allowing tests to run in context where `word_size - 1  <> int_size`)

Js_of_ocaml runs part of the ocaml testsuite in javascript. A bunch of test needs to be adapted for this.

With this MR, adapting some of the tests becomes easier. One just need to add a new branch to pattern matching.
(Note that jsoo uses 32bit intergers)

```diff
  | 31 ->
     test (sprintf "%u" (-1) = "2147483647");
+ | 32 ->
+    test (sprintf "%u" (-1) = "4294967295");
  | 64 ->		  | 63 ->
     test (sprintf "%u" (-1) = "9223372036854775807");
  | _ -> test false		  | _ -> test false
```