### PR TITLE
Revert incorrect marking of `socketpair` as unimplemented on Windows

### DIFF
--- a/otherlibs/unix/unix.mli
+++ b/otherlibs/unix/unix.mli
@@ -1449,9 +1449,7 @@ val socketpair :
     file_descr * file_descr
 (** Create a pair of unnamed sockets, connected together.
    See {!set_close_on_exec} for documentation on the [cloexec]
-   optional argument.
-
-   @raise Invalid_argument on Windows *)
+   optional argument. *)
 
 val accept : ?cloexec: (* thwart tools/sync_stdlib_docs *) bool ->
              file_descr -> file_descr * sockaddr

--- a/otherlibs/unix/unixLabels.mli
+++ b/otherlibs/unix/unixLabels.mli
@@ -1449,9 +1449,7 @@ val socketpair :
     file_descr * file_descr
 (** Create a pair of unnamed sockets, connected together.
    See {!set_close_on_exec} for documentation on the [cloexec]
-   optional argument.
-
-   @raise Invalid_argument on Windows *)
+   optional argument. *)
 
 val accept : ?cloexec: (* thwart tools/sync_stdlib_docs *) bool ->
              file_descr -> file_descr * sockaddr


### PR DESCRIPTION
https://github.com/ocaml/ocaml/pull/10397 mistakedly marked this function as unimplemented on Windows, although it has been implemented since the merge of https://github.com/ocaml/ocaml/pull/10192.