### PR TITLE
Downcase the argument to Invalid_argument in domain.ml

### DIFF
--- a/stdlib/domain.ml
+++ b/stdlib/domain.ml
@@ -148,7 +148,7 @@ let first_spawn_function = ref (fun () -> ())
 
 let before_first_spawn f =
   if Atomic.get first_domain_spawned then
-    raise (Invalid_argument "First domain already spawned")
+    raise (Invalid_argument "first domain already spawned")
   else begin
     let old_f = !first_spawn_function in
     let new_f () = old_f (); f () in


### PR DESCRIPTION
It seems the argument to `Invalid_argument` has been matching one of the following patterns:
```
(Module.)function
Module/function(s): lowercase English phrase
lowercase English phrase
```
This PR fixed a violation introduced in `stdlib/domain.ml`. If approved, it should probably be backported to the 5.0 branch.