### PR TITLE
Remove old polymorphic variant type syntax

### DIFF
--- a/Changes
+++ b/Changes
@@ -10,6 +10,9 @@ Working version
   construct.
   (Nicolás Ojeda Bär)
 
+- #11457: Remove old polymorphic variant syntax.
+  (Stefan Muenzel, review by Gabriel Scherer and Jacques Garrigue)
+
 ### Runtime system:
 
 ### Code generation and optimizations:
@@ -104,7 +107,6 @@ Working version
 - #11436: Fix wrong stack backtrace for out-of-bound exceptions raised
   by leaf functions.
   (Tom Kelly and Xavier Leroy, review by Mark Shinwell)
-
 
 OCaml 5.0
 ---------

--- a/manual/src/refman/types.etex
+++ b/manual/src/refman/types.etex
@@ -228,11 +228,6 @@ type @'#' classtype-path '->' '#' classtype-path@ is usually not the same as
 type @('#' classtype-path 'as' "'" ident) '->' "'" ident@.
 %
 
-Use of \#-types to abbreviate polymorphic variant types is deprecated.
-If @@t@@ is an exact variant type then @"#"@t@@ translates to @"[<" @t@"]"@,
-and @"#"@t@"[>" "`"tag_1 \dots"`"tag_k"]"@ translates to
-@"[<" @t@ ">" "`"tag_1 \dots"`"tag_k"]"@
-
 \subsubsection*{sss:typexpr-variant-record}{Variant and record types}
 
 There are no type expressions describing (defined) variant types nor

--- a/testsuite/tests/typing-warnings/open_warnings.ml
+++ b/testsuite/tests/typing-warnings/open_warnings.ml
@@ -178,26 +178,6 @@ Warning 37 [unused-constructor]: unused constructor A.
 module T5_bis : sig end
 |}]
 
-
-module T6 : sig end = struct
-  (* GPR9170 *)
-  module M = struct
-    type t = [`A | `B]
-  end
-  module type S = sig
-    open M
-    val f: #t -> unit
-  end
-  let _ = fun ((module S : S)) -> S.f `A
-end;;
-[%%expect {|
-Line 8, characters 11-13:
-8 |     val f: #t -> unit
-               ^^
-Alert deprecated: old syntax for polymorphic variant type
-module T6 : sig end
-|}]
-
 module T7 : sig end = struct
   (* GPR9170 *)
   module M = struct


### PR DESCRIPTION
Instead of having two code paths for polymorphic variant types in `Typetexp`, map the old syntax to its equivalent new syntax.

Fixes #11261