### PR TITLE
Disallow aliases of functor arguments in module types

### DIFF
--- a/Changes
+++ b/Changes
@@ -108,6 +108,11 @@ Working version
   by leaf functions.
   (Tom Kelly and Xavier Leroy, review by Mark Shinwell)
 
+- #11441, #11442: disallow module aliases on functor arguments in
+  module types
+  (Clément Blaudeau and Gabriel Scherer, report by Clément Blaudeau,
+   review by ???)
+
 OCaml 5.0
 ---------
 

--- a/testsuite/tests/typing-modules/pr11441.ml
+++ b/testsuite/tests/typing-modules/pr11441.ml
@@ -1,0 +1,20 @@
+(* TEST
+   * expect
+*)
+
+module F = functor (Y: sig end) -> struct
+  module type T = sig module X = Y end
+end
+[%%expect{|
+module F :
+  functor (Y : sig end) -> sig module type T = sig module X = Y end end
+|}]
+(* Inferring (module X = Y) above should not be allowed as Y is a functor argument.
+   This causes a crash below. *)
+
+module M = F(struct end)
+[%%expect{|
+>> Fatal error: nondep_supertype not included in original module type
+Uncaught exception: Misc.Fatal_error
+
+|}]

--- a/testsuite/tests/typing-modules/pr11441.ml
+++ b/testsuite/tests/typing-modules/pr11441.ml
@@ -7,14 +7,36 @@ module F = functor (Y: sig end) -> struct
 end
 [%%expect{|
 module F :
-  functor (Y : sig end) -> sig module type T = sig module X = Y end end
+  functor (Y : sig end) -> sig module type T = sig module X : sig end end end
 |}]
-(* Inferring (module X = Y) above should not be allowed as Y is a functor argument.
-   This causes a crash below. *)
+(* Notice that the signature of X above
+   has been inlined from (X = Y) to (X : sig end). *)
 
 module M = F(struct end)
 [%%expect{|
->> Fatal error: nondep_supertype not included in original module type
-Uncaught exception: Misc.Fatal_error
+module M : sig module type T = sig module X : sig end end end
+|}]
 
+module type T
+module type T1 = functor (Y:T) -> sig module X1 = Y module X2 = Y end
+module type T2 = functor (Y:T) -> sig module X1 : T module X2 = X1 end
+module TestSub(F:T1) = (F:T2)
+[%%expect{|
+module type T
+module type T1 = functor (Y : T) -> sig module X1 : T module X2 : T end
+module type T2 = functor (Y : T) -> sig module X1 : T module X2 = X1 end
+Line 4, characters 24-25:
+4 | module TestSub(F:T1) = (F:T2)
+                            ^
+Error: Signature mismatch:
+       Modules do not match:
+         functor (Y : T) -> sig module X1 : T module X2 : T end
+       is not included in
+         T2
+       Modules do not match:
+         sig module X1 : T module X2 : T end
+       is not included in
+         sig module X1 : T module X2 = X1 end
+       In module X2:
+       Modules do not match: T is not included in (module X1)
 |}]

--- a/typing/env.ml
+++ b/typing/env.ml
@@ -1417,14 +1417,15 @@ let find_modtype_expansion_lazy path env =
 let find_modtype_expansion path env =
   Subst.Lazy.force_modtype (find_modtype_expansion_lazy path env)
 
-let rec is_functor_arg path env =
+let rec is_aliasable path env =
   match path with
     Pident id ->
-      begin try Ident.find_same id env.functor_args; true
-      with Not_found -> false
+      begin match Ident.find_same id env.functor_args with
+      | exception Not_found -> true
+      | () -> false
       end
-  | Pdot (p, _s) -> is_functor_arg p env
-  | Papply _ -> true
+  | Pdot (p, _s) -> is_aliasable p env
+  | Papply _ -> false
 
 (* Copying types associated with values *)
 

--- a/typing/env.mli
+++ b/typing/env.mli
@@ -116,7 +116,7 @@ val shape_of_path:
   namespace:Shape.Sig_component_kind.t -> t -> Path.t -> Shape.t
 
 val add_functor_arg: Ident.t -> t -> t
-val is_functor_arg: Path.t -> t -> bool
+val is_aliasable: Path.t -> t -> bool
 
 val normalize_module_path: Location.t option -> t -> Path.t -> Path.t
 (* Normalize the path to a concrete module.

--- a/typing/mtype.ml
+++ b/typing/mtype.ml
@@ -499,6 +499,18 @@ let rec remove_aliases_mty env args pres mty =
     pres, mty
   end
 
+and remove_aliases_mtd env args mtd =
+  match mtd.mtd_type with
+  | None -> mtd
+  | Some mty ->
+      let args' = {args with modified = false} in
+      let _pres, mty' = remove_aliases_mty env args' Mp_absent mty in
+      if mty' = mty then mtd
+      else begin
+        args.modified <- true;
+        { mtd with mtd_type = Some mty' }
+      end
+
 and remove_aliases_sig env args sg =
   match sg with
     [] -> []
@@ -513,6 +525,7 @@ and remove_aliases_sig env args sg =
       Sig_module(id, pres, {md with md_type = mty} , rs, priv) ::
       remove_aliases_sig (Env.add_module id pres mty env) args rem
   | Sig_modtype(id, mtd, priv) :: rem ->
+      let mtd = remove_aliases_mtd env args mtd in
       Sig_modtype(id, mtd, priv) ::
       remove_aliases_sig (Env.add_modtype id mtd env) args rem
   | it :: rem ->

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -1282,7 +1282,14 @@ and transl_modtype_aux env smty =
         smty.pmty_attributes
   | Pmty_alias lid ->
       let path = transl_module_alias loc env lid.txt in
-      mkmty (Tmty_alias (path, lid)) (Mty_alias path) env loc
+      let aliasable = Env.is_aliasable path env in
+      let mty =
+        if aliasable then
+          Mty_alias path
+        else
+          Env.find_strengthened_module ~aliasable path env
+      in
+      mkmty (Tmty_alias (path, lid)) mty env loc
         smty.pmty_attributes
   | Pmty_signature ssg ->
       let sg = transl_signature env ssg in

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -609,7 +609,7 @@ let merge_constraint initial_env loc sg lid constr =
     | Sig_module(id, _, md, _rs, _), [s], With_modsubst (lid',path,md')
       when Ident.name id = s ->
         let sig_env = Env.add_signature sg_for_env outer_sig_env in
-        let aliasable = not (Env.is_functor_arg path sig_env) in
+        let aliasable = Env.is_aliasable path sig_env in
         ignore
           (Includemod.strengthened_module_decl ~loc ~mark:Mark_both
              ~aliasable sig_env md' path md);
@@ -1499,7 +1499,7 @@ and transl_signature env sg =
               Env.lookup_module ~loc:pms.pms_manifest.loc
                 pms.pms_manifest.txt env
             in
-            let aliasable = not (Env.is_functor_arg path env) in
+            let aliasable = Env.is_aliasable path env in
             let md =
               if not aliasable then
                 md
@@ -2129,7 +2129,7 @@ and type_module_aux ~alias sttn funct_body anchor env smod =
                  mod_env = env;
                  mod_attributes = smod.pmod_attributes;
                  mod_loc = smod.pmod_loc } in
-      let aliasable = not (Env.is_functor_arg path env) in
+      let aliasable = Env.is_aliasable path env in
       let shape =
         Env.shape_of_path ~namespace:Shape.Sig_component_kind.Module env path
       in


### PR DESCRIPTION
This PR is a proposed fix for #11441 and #11442, co-written with @clementblaudeau.

For signatures of the form

```ocaml
module F(M : S) =
  ...
  module type T = sig
    module N = M
  end
end
```

we weaken `module N = M` into `module N : S`, following the logic in the typing of structures.

Another possible approach would be to check at functor-application time to remove aliases to unnamed arguments; this may accept more definitions but it is different from the approach taken for aliases of functor arguments in module expressions.

cc @garrigue, @lpw25: what do you think?
