### PR TITLE
Fix gethostbyaddr for IPv6 arguments, continued

### DIFF
--- a/Changes
+++ b/Changes
@@ -345,9 +345,9 @@ OCaml 5.0
   (Christiano Haesbaert, Konstantin Belousov, review by David Allsopp,
   KC Sivaramakrishnan, Gabriel Scherer, Nicolas Ojeda Bar)
 
-- #11461: Fix gethostbyaddr for IPv6 arguments and make it domain-safe
-  (Olivier Nicole, Nicolás Ojeda Bär and David Allsopp, review by Nicolás Ojeda
-  Bär, David Allsopp and Xavier Leroy)
+- #11461, #11466: Fix gethostbyaddr for IPv6 arguments and make it domain-safe
+  (Olivier Nicole, Nicolás Ojeda Bär, David Allsopp and Xavier Leroy,
+   review by the same)
 
 ### Tools:
 

--- a/testsuite/tests/lib-unix/common/gethostbyaddr.ml
+++ b/testsuite/tests/lib-unix/common/gethostbyaddr.ml
@@ -7,9 +7,18 @@ include unix
 
 (* Checks that gethostbyaddr supports both IPv4 and IPv6 (see #11461) *)
 let check a ty =
-  let addr = Unix.inet_addr_of_string a in
-  let host = Unix.gethostbyaddr addr in
-  assert (host.Unix.h_addrtype = ty)
+  match Unix.inet_addr_of_string a with
+  | exception (Failure _) ->
+      (* IPv6 addresses not supported on this platform, just ignore *)
+      ()
+  | addr ->
+      match Unix.gethostbyaddr addr with
+      | exception Not_found ->
+          (* Name resolver badly configured? (observed on OmniOS).
+             Just ignore *)
+          ()
+      | host ->
+          assert (host.Unix.h_addrtype = ty)
 
 let () =
   check "127.0.0.1" Unix.PF_INET;


### PR DESCRIPTION
#11461 doesn't work if `HAS_IPV6` is not defined.
