### PR TITLE
Fix dune file of the Unix library for Linux

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -1,2 +1,2 @@
-(lang dune 1.3)
+(lang dune 1.10)
 (using experimental_building_ocaml_compiler_with_dune 0.1)

--- a/otherlibs/unix/dune
+++ b/otherlibs/unix/dune
@@ -20,14 +20,16 @@
  (c_flags (-I %{project_root}/runtime))
  (libraries stdlib)
  (c_names
-   accept access addrofstr alarm bind channels chdir chmod chown chroot close
-   fsync closedir connect cst2constr cstringv dup dup2 envir errmsg execv execve
-   execvp exit fchmod fchown fcntl fork ftruncate getaddrinfo getcwd getegid
-   geteuid getgid getgr getgroups gethost gethostname getlogin getnameinfo
-   getpeername getpid getppid getproto getpw gettimeofday getserv getsockname
-   getuid gmtime initgroups isatty itimer kill link listen lockf lseek mkdir
-   mkfifo mmap mmap_ba nice open opendir pipe putenv read readdir readlink
-   rename rewinddir rmdir select sendrecv setgid setgroups setsid setuid
-   shutdown signals sleep socket socketaddr socketpair sockopt stat strofaddr
-   symlink termios time times truncate umask unixsupport unlink utimes wait
-   write))
+   accept_unix access addrofstr alarm bind_unix channels_unix chdir chmod chown
+   chroot close_unix fsync closedir connect_unix cst2constr cstringv dup_unix
+   dup2 envir_unix errmsg_unix execv execve execvp exit fchmod fchown fcntl
+   fork ftruncate getaddrinfo getcwd getegid geteuid getgid getgr getgroups
+   gethost gethostname getlogin getnameinfo getpeername_unix getpid_unix
+   getppid getproto getpw gettimeofday_unix getserv getsockname_unix getuid
+   gmtime initgroups isatty_unix itimer kill link_unix listen_unix lockf_unix
+   lseek_unix mkdir mkfifo mmap_unix mmap_ba nice open_unix opendir pipe_unix
+   putenv read_unix readdir readlink_unix realpath_unix rename_unix rewinddir
+   rmdir select_unix sendrecv_unix setgid setgroups setsid setuid shutdown_unix
+   signals sleep_unix socket_unix socketaddr socketpair_unix sockopt_unix
+   stat_unix strofaddr symlink_unix termios time times_unix truncate_unix umask
+   unixsupport_unix unlink utimes_unix wait write_unix))

--- a/otherlibs/unix/dune
+++ b/otherlibs/unix/dune
@@ -20,16 +20,184 @@
  (c_flags (-I %{project_root}/runtime))
  (libraries stdlib)
  (c_names
-   accept_unix access addrofstr alarm bind_unix channels_unix chdir chmod chown
-   chroot close_unix fsync closedir connect_unix cst2constr cstringv dup_unix
-   dup2 envir_unix errmsg_unix execv execve execvp exit fchmod fchown fcntl
-   fork ftruncate getaddrinfo getcwd getegid geteuid getgid getgr getgroups
-   gethost gethostname getlogin getnameinfo getpeername_unix getpid_unix
-   getppid getproto getpw gettimeofday_unix getserv getsockname_unix getuid
-   gmtime initgroups isatty_unix itimer kill link_unix listen_unix lockf_unix
-   lseek_unix mkdir mkfifo mmap_unix mmap_ba nice open_unix opendir pipe_unix
-   putenv read_unix readdir readlink_unix realpath_unix rename_unix rewinddir
-   rmdir select_unix sendrecv_unix setgid setgroups setsid setuid shutdown_unix
-   signals sleep_unix socket_unix socketaddr socketpair_unix sockopt_unix
-   stat_unix strofaddr symlink_unix termios time times_unix truncate_unix umask
-   unixsupport_unix unlink utimes_unix wait write_unix))
+   accept access addrofstr alarm bind channels chdir chmod chown chroot close
+   fsync closedir connect cst2constr cstringv dup dup2 envir errmsg execv execve
+   execvp exit fchmod fchown fcntl fork ftruncate getaddrinfo getcwd getegid
+   geteuid getgid getgr getgroups gethost gethostname getlogin getnameinfo
+   getpeername getpid getppid getproto getpw gettimeofday getserv getsockname
+   getuid gmtime initgroups isatty itimer kill link listen lockf lseek mkdir
+   mkfifo mmap mmap_ba nice open opendir pipe putenv read readdir readlink
+   realpath rename rewinddir rmdir select sendrecv setgid setgroups setsid
+   setuid shutdown signals sleep socket socketaddr socketpair sockopt stat
+   strofaddr symlink termios time times truncate umask unixsupport unlink utimes
+   wait write))
+
+(rule
+ (action (copy accept_unix.c accept.c))
+ (enabled_if (<> %{os_type} "Win32")))
+(rule (action (copy bind_unix.c bind.c)) (enabled_if (<> %{os_type} "Win32")))
+(rule
+ (action (copy channels_unix.c channels.c))
+ (enabled_if (<> %{os_type} "Win32")))
+(rule (action (copy close_unix.c close.c)) (enabled_if (<> %{os_type} "Win32")))
+(rule
+ (action (copy connect_unix.c connect.c))
+ (enabled_if (<> %{os_type} "Win32")))
+(rule (action (copy dup_unix.c dup.c)) (enabled_if (<> %{os_type} "Win32")))
+(rule (action (copy envir_unix.c envir.c)) (enabled_if (<> %{os_type} "Win32")))
+(rule
+ (action (copy errmsg_unix.c errmsg.c))
+ (enabled_if (<> %{os_type} "Win32")))
+(rule
+ (action (copy getpeername_unix.c getpeername.c))
+ (enabled_if (<> %{os_type} "Win32")))
+(rule
+ (action (copy getpid_unix.c getpid.c))
+ (enabled_if (<> %{os_type} "Win32")))
+(rule
+ (action (copy gettimeofday_unix.c gettimeofday.c))
+ (enabled_if (<> %{os_type} "Win32")))
+(rule
+ (action (copy getsockname_unix.c getsockname.c))
+ (enabled_if (<> %{os_type} "Win32")))
+(rule
+ (action (copy isatty_unix.c isatty.c))
+ (enabled_if (<> %{os_type} "Win32")))
+(rule (action (copy link_unix.c link.c)) (enabled_if (<> %{os_type} "Win32")))
+(rule
+ (action (copy listen_unix.c listen.c))
+ (enabled_if (<> %{os_type} "Win32")))
+(rule (action (copy lockf_unix.c lockf.c)) (enabled_if (<> %{os_type} "Win32")))
+(rule (action (copy lseek_unix.c lseek.c)) (enabled_if (<> %{os_type} "Win32")))
+(rule (action (copy mmap_unix.c mmap.c)) (enabled_if (<> %{os_type} "Win32")))
+(rule (action (copy open_unix.c open.c)) (enabled_if (<> %{os_type} "Win32")))
+(rule (action (copy pipe_unix.c pipe.c)) (enabled_if (<> %{os_type} "Win32")))
+(rule (action (copy read_unix.c read.c)) (enabled_if (<> %{os_type} "Win32")))
+(rule
+ (action (copy readlink_unix.c readlink.c))
+ (enabled_if (<> %{os_type} "Win32")))
+(rule
+ (action (copy realpath_unix.c realpath.c))
+ (enabled_if (<> %{os_type} "Win32")))
+(rule
+ (action (copy rename_unix.c rename.c))
+ (enabled_if (<> %{os_type} "Win32")))
+(rule
+ (action (copy select_unix.c select.c))
+ (enabled_if (<> %{os_type} "Win32")))
+(rule
+ (action (copy sendrecv_unix.c sendrecv.c))
+ (enabled_if (<> %{os_type} "Win32")))
+(rule
+ (action (copy shutdown_unix.c shutdown.c))
+ (enabled_if (<> %{os_type} "Win32")))
+(rule (action (copy sleep_unix.c sleep.c)) (enabled_if (<> %{os_type} "Win32")))
+(rule
+ (action (copy socket_unix.c socket.c))
+ (enabled_if (<> %{os_type} "Win32")))
+(rule
+ (action (copy socketpair_unix.c socketpair.c))
+ (enabled_if (<> %{os_type} "Win32")))
+(rule
+ (action (copy sockopt_unix.c sockopt.c))
+ (enabled_if (<> %{os_type} "Win32")))
+(rule (action (copy stat_unix.c stat.c)) (enabled_if (<> %{os_type} "Win32")))
+(rule
+ (action (copy symlink_unix.c symlink.c))
+ (enabled_if (<> %{os_type} "Win32")))
+(rule (action (copy times_unix.c times.c)) (enabled_if (<> %{os_type} "Win32")))
+(rule
+ (action (copy truncate_unix.c truncate.c))
+ (enabled_if (<> %{os_type} "Win32")))
+(rule
+ (action (copy unixsupport_unix.c unixsupport.c))
+ (enabled_if (<> %{os_type} "Win32")))
+(rule
+ (action (copy utimes_unix.c utimes.c))
+ (enabled_if (<> %{os_type} "Win32")))
+(rule (action (copy write_unix.c write.c)) (enabled_if (<> %{os_type} "Win32")))
+
+(rule
+ (action (copy accept_win32.c accept.c))
+ (enabled_if (= %{os_type} "Win32")))
+(rule (action (copy bind_win32.c bind.c)) (enabled_if (= %{os_type} "Win32")))
+(rule
+ (action (copy channels_win32.c channels.c))
+ (enabled_if (= %{os_type} "Win32")))
+(rule (action (copy close_win32.c close.c)) (enabled_if (= %{os_type} "Win32")))
+(rule
+ (action (copy connect_win32.c connect.c))
+ (enabled_if (= %{os_type} "Win32")))
+(rule (action (copy dup_win32.c dup.c)) (enabled_if (= %{os_type} "Win32")))
+(rule (action (copy envir_win32.c envir.c)) (enabled_if (= %{os_type} "Win32")))
+(rule
+ (action (copy errmsg_win32.c errmsg.c))
+ (enabled_if (= %{os_type} "Win32")))
+(rule
+ (action (copy getpeername_win32.c getpeername.c))
+ (enabled_if (= %{os_type} "Win32")))
+(rule
+ (action (copy getpid_win32.c getpid.c))
+ (enabled_if (= %{os_type} "Win32")))
+(rule
+ (action (copy gettimeofday_win32.c gettimeofday.c))
+ (enabled_if (= %{os_type} "Win32")))
+(rule
+ (action (copy getsockname_win32.c getsockname.c))
+ (enabled_if (= %{os_type} "Win32")))
+(rule
+ (action (copy isatty_win32.c isatty.c))
+ (enabled_if (= %{os_type} "Win32")))
+(rule (action (copy link_win32.c link.c)) (enabled_if (= %{os_type} "Win32")))
+(rule
+ (action (copy listen_win32.c listen.c))
+ (enabled_if (= %{os_type} "Win32")))
+(rule (action (copy lockf_win32.c lockf.c)) (enabled_if (= %{os_type} "Win32")))
+(rule (action (copy lseek_win32.c lseek.c)) (enabled_if (= %{os_type} "Win32")))
+(rule (action (copy mmap_win32.c mmap.c)) (enabled_if (= %{os_type} "Win32")))
+(rule (action (copy open_win32.c open.c)) (enabled_if (= %{os_type} "Win32")))
+(rule (action (copy pipe_win32.c pipe.c)) (enabled_if (= %{os_type} "Win32")))
+(rule (action (copy read_win32.c read.c)) (enabled_if (= %{os_type} "Win32")))
+(rule
+ (action (copy readlink_win32.c readlink.c))
+ (enabled_if (= %{os_type} "Win32")))
+(rule
+ (action (copy realpath_win32.c realpath.c))
+ (enabled_if (= %{os_type} "Win32")))
+(rule
+ (action (copy rename_win32.c rename.c))
+ (enabled_if (= %{os_type} "Win32")))
+(rule
+ (action (copy select_win32.c select.c))
+ (enabled_if (= %{os_type} "Win32")))
+(rule
+ (action (copy sendrecv_win32.c sendrecv.c))
+ (enabled_if (= %{os_type} "Win32")))
+(rule
+ (action (copy shutdown_win32.c shutdown.c))
+ (enabled_if (= %{os_type} "Win32")))
+(rule (action (copy sleep_win32.c sleep.c)) (enabled_if (= %{os_type} "Win32")))
+(rule
+ (action (copy socket_win32.c socket.c))
+ (enabled_if (= %{os_type} "Win32")))
+(rule
+ (action (copy socketpair_win32.c socketpair.c))
+ (enabled_if (= %{os_type} "Win32")))
+(rule
+ (action (copy sockopt_win32.c sockopt.c))
+ (enabled_if (= %{os_type} "Win32")))
+(rule (action (copy stat_win32.c stat.c)) (enabled_if (= %{os_type} "Win32")))
+(rule
+ (action (copy symlink_win32.c symlink.c))
+ (enabled_if (= %{os_type} "Win32")))
+(rule (action (copy times_win32.c times.c)) (enabled_if (= %{os_type} "Win32")))
+(rule
+ (action (copy truncate_win32.c truncate.c))
+ (enabled_if (= %{os_type} "Win32")))
+(rule
+ (action (copy unixsupport_win32.c unixsupport.c))
+ (enabled_if (= %{os_type} "Win32")))
+(rule
+ (action (copy utimes_win32.c utimes.c))
+ (enabled_if (= %{os_type} "Win32")))
+(rule (action (copy write_win32.c write.c)) (enabled_if (= %{os_type} "Win32")))


### PR DESCRIPTION
This updates the dune file of the Unix library, assuming a Linux build. It makes `dune build @libs` work again on my machine, up to a gcc warning about `runtime/domain_state.tbl` not being considered for linking.