### PR TITLE
Fix detection of IPv6 on mingw-w64 i686

### DIFF
--- a/Changes
+++ b/Changes
@@ -571,6 +571,10 @@ OCaml 5.0
 - #11417: Fix regression allowing virtual methods in non-virtual classes.
   (Leo White, review by Florian Angeletti)
 
+- #11468: Fix regression from #10186 (OCaml 4.13) detecting IPv6 on Windows for
+  mingw-w64 i686 port.
+  (David Allsopp, review by Xavier Leroy and Sébastien Hinderer)
+
 OCaml 4.14.0 (28 March 2022)
 ----------------------------
 

--- a/configure
+++ b/configure
@@ -18215,6 +18215,8 @@ case $host in #(
 
     $as_echo "#define HAS_STRERROR 1" >>confdefs.h
 
+    $as_echo "#define HAS_IPV6 1" >>confdefs.h
+
     $as_echo "#define HAS_NICE 1" >>confdefs.h
  ;; #(
   *-pc-windows) :

--- a/configure.ac
+++ b/configure.ac
@@ -2117,6 +2117,7 @@ AS_CASE([$host],
   [*-*-mingw32],
     [AC_DEFINE([HAS_BROKEN_PRINTF])
     AC_DEFINE([HAS_STRERROR])
+    AC_DEFINE([HAS_IPV6])
     AC_DEFINE([HAS_NICE])],
   [*-pc-windows],
     [AC_DEFINE([HAS_BROKEN_PRINTF])


### PR DESCRIPTION
#10186 added detection for IPv6 to the Windows ports. Unfortunately it doesn't take it account stdcall name mangling. On x64 this makes no difference since `socket` remains `socket`, but the symbol is `_socket@12` on 32-bit.

This didn't affect MSVC because it includes a manual define of `HAS_IPV6` but mingw doesn't have this, so IPv6 has been effectively disabled since 4.13 on 32-bit mingw-w64.

This is known issue for `AC_SEARCH_LIBS` as it affects C++ mangling as well - I've gone for the simplest fix here, given the intention to adopt #10505 by 5.1, as this allows the regression to be fixed in 4.14.1 and 5.0.0