### PR TITLE
runtime_events.h: fix RUNTIME_EVENTS_ITEM_IS_RUNTIME and RUNTIME_EVENTS_ITEM_IS_USER macros

### DIFF
--- a/runtime/caml/runtime_events.h
+++ b/runtime/caml/runtime_events.h
@@ -181,8 +181,8 @@ struct runtime_events_metadata_header {
 
 #define RUNTIME_EVENTS_ITEM_LENGTH(header) \
         (((header) >> 54) & ((1UL << 10) - 1))
-#define RUNTIME_EVENTS_ITEM_IS_RUNTIME(header) !((header) | (1UL << 53))
-#define RUNTIME_EVENTS_ITEM_IS_USER(header) ((header) | (1UL << 53))
+#define RUNTIME_EVENTS_ITEM_IS_RUNTIME(header) !((header) & (1UL << 53))
+#define RUNTIME_EVENTS_ITEM_IS_USER(header) ((header) & (1UL << 53))
 #define RUNTIME_EVENTS_ITEM_TYPE(header) (((header) >> 49) & ((1UL << 4) - 1))
 #define RUNTIME_EVENTS_ITEM_ID(header) (((header) >> 36) & ((1UL << 13) - 1))
 


### PR DESCRIPTION
The '&' operator has to be used to check if a specific bit is set. These macros are currently unused but I'm working on adding support for custom events in eventring, that's how I encountered the issue.