### PR TITLE
Fix CAML_INTERNALS guard in atomic_refcount.h

### DIFF
--- a/runtime/caml/atomic_refcount.h
+++ b/runtime/caml/atomic_refcount.h
@@ -16,9 +16,9 @@
 #ifndef CAML_ATOMIC_REFCOUNT_H
 #define CAML_ATOMIC_REFCOUNT_H
 
-#define CAML_INTERNALS
+#ifdef CAML_INTERNALS
+
 #include "camlatomic.h"
-#include "platform.h"
 
 Caml_inline void caml_atomic_refcount_init(atomic_uintnat* refc, uintnat n){
   atomic_store_rel(refc, n);
@@ -31,5 +31,7 @@ Caml_inline uintnat caml_atomic_refcount_decr(atomic_uintnat* refcount){
 Caml_inline uintnat caml_atomic_refcount_incr(atomic_uintnat* refcount){
   return atomic_fetch_add (refcount, 1);
 };
+
+#endif /* CAML_INTERNALS */
 
 #endif // CAML_ATOMIC_REFCOUNT_H


### PR DESCRIPTION
`CAML_INTERNALS` should never be defined from header files.
No change entry needed.