### PR TITLE
Restore "Protect against repeated initialization (PR#3532)"

### DIFF
--- a/otherlibs/systhreads/st_stubs.c
+++ b/otherlibs/systhreads/st_stubs.c
@@ -437,7 +437,8 @@ void caml_thread_interrupt_hook(void)
    system. */
 CAMLprim value caml_thread_initialize(value unit)
 {
-  CAMLparam0();
+  /* Protect against repeated initialization (PR#3532) */
+  if (Active_thread != NULL) return Val_unit;
 
   if (!caml_domain_alone())
     caml_failwith("caml_thread_initialize: cannot initialize Thread "
@@ -458,7 +459,7 @@ CAMLprim value caml_thread_initialize(value unit)
 
   caml_atfork_hook = caml_thread_reinitialize;
 
-  CAMLreturn(Val_unit);
+  return Val_unit;
 }
 
 CAMLprim value caml_thread_cleanup(value unit)


### PR DESCRIPTION
This restores some bit left out from the previous systhreads implementation.

I would like to have this in 5.0. The ability to call `caml_thread_initialize` from Rust directly after calling `caml_startup` potentially avoids some initialization order pains. I give this advice to Rust users for OCaml 4 and it would be nice if my advice worked consistently between major OCaml versions (without this PR, it would crash when re-entering `caml_thread_initialize` from the `Thread` module). Since this functionality was there before, this is fixing an API discrepancy, so I think it is appropriate for 5.0.

No change entry needed.

(cc @Engil, @gasche)

