### PR TITLE
Make Unix.symlink domain-safe on Windows

### DIFF
--- a/Changes
+++ b/Changes
@@ -68,6 +68,9 @@ Working version
 - #11475: Make Unix terminal interface bindings domain-safe
   (Olivier Nicole and Xavier Leroy, review by Xavier Leroy)
 
+- #11479: Make Unix.symlink domain-safe on Windows
+  (Olivier Nicole, review by Xavier Leroy and David Allsopp)
+
 ### Tools:
 
 - #9290: Add a directive to switch off debugging in toplevel.

--- a/otherlibs/unix/symlink_win32.c
+++ b/otherlibs/unix/symlink_win32.c
@@ -32,7 +32,7 @@
 #define SYMBOLIC_LINK_FLAG_ALLOW_UNPRIVILEGED_CREATE (0x2)
 #endif
 
-static _Atomic DWORD additional_symlink_flags = 0;
+static _Atomic DWORD additional_symlink_flags = -1;
 
 // Developer Mode allows the creation of symlinks without elevation - see
 // https://docs.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-createsymboliclinkw
@@ -80,7 +80,7 @@ CAMLprim value caml_unix_symlink(value to_dir, value osource, value odest)
 
   additional_flags = atomic_load_explicit(&additional_symlink_flags,
       memory_order_relaxed);
-  if(additional_flags == -1) {
+  if (additional_flags == -1) {
     additional_flags = IsDeveloperModeEnabled() ?
       SYMBOLIC_LINK_FLAG_ALLOW_UNPRIVILEGED_CREATE : 0;
     atomic_store_explicit(&additional_symlink_flags, additional_flags,

--- a/otherlibs/unix/symlink_win32.c
+++ b/otherlibs/unix/symlink_win32.c
@@ -32,19 +32,7 @@
 #define SYMBOLIC_LINK_FLAG_ALLOW_UNPRIVILEGED_CREATE (0x2)
 #endif
 
-typedef BOOLEAN (WINAPI *LPFN_CREATESYMBOLICLINK) (LPWSTR, LPWSTR, DWORD);
-
-static LPFN_CREATESYMBOLICLINK pCreateSymbolicLink = NULL;
-
-typedef enum {
-  to_be_queried = -2,
-  querying_symlink = -1,
-  no_symlink = 0,
-  symlink_present = 1
-} symlink_st;
-static _Atomic symlink_st symlink_state = no_symlink;
-
-static DWORD additional_symlink_flags = 0;
+static _Atomic DWORD additional_symlink_flags = 0;
 
 // Developer Mode allows the creation of symlinks without elevation - see
 // https://docs.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-createsymboliclinkw
@@ -80,55 +68,34 @@ static BOOL IsDeveloperModeEnabled()
   return developerModeRegistryValue != 0;
 }
 
-/* Returns either no_symlink or symlink_present */
-static symlink_st get_symlink_state()
-{
-  SPIN_WAIT {
-    int cond = atomic_load(&symlink_state);
-    switch (cond) {
-    case to_be_queried:
-      if (! atomic_compare_exchange_strong(&symlink_state, &cond,
-              querying_symlink))
-        break; /* try again */
-      if (! (pCreateSymbolicLink = (LPFN_CREATESYMBOLICLINK)GetProcAddress(
-              GetModuleHandle(L"kernel32"), "CreateSymbolicLinkW"))) {
-        atomic_store(&symlink_state, no_symlink);
-        return no_symlink;
-      }
-      if(IsDeveloperModeEnabled())
-        additional_symlink_flags = SYMBOLIC_LINK_FLAG_ALLOW_UNPRIVILEGED_CREATE;
-      atomic_store(&symlink_state, symlink_present);
-      return symlink_present;
-    case querying_symlink:
-      break; /* try again */
-    default:
-      return cond;
-    }
-  }
-}
-
 CAMLprim value caml_unix_symlink(value to_dir, value osource, value odest)
 {
   CAMLparam3(to_dir, osource, odest);
-  DWORD flags;
+  DWORD flags, additional_flags;
   BOOLEAN result;
   LPWSTR source;
   LPWSTR dest;
   caml_unix_check_path(osource, "symlink");
   caml_unix_check_path(odest, "symlink");
 
-  if (get_symlink_state() == no_symlink) {
-    caml_invalid_argument("symlink not available");
+  additional_flags = atomic_load_explicit(&additional_symlink_flags,
+      memory_order_relaxed);
+  if(additional_flags == -1) {
+    additional_flags = IsDeveloperModeEnabled() ?
+      SYMBOLIC_LINK_FLAG_ALLOW_UNPRIVILEGED_CREATE : 0;
+    atomic_store_explicit(&additional_symlink_flags, additional_flags,
+        memory_order_relaxed);
   }
 
-  flags = (Bool_val(to_dir) ? SYMBOLIC_LINK_FLAG_DIRECTORY : 0) | additional_symlink_flags;
+  flags =
+    (Bool_val(to_dir) ? SYMBOLIC_LINK_FLAG_DIRECTORY : 0) | additional_flags;
 
   /* Copy source and dest outside the OCaml heap */
   source = caml_stat_strdup_to_utf16(String_val(osource));
   dest = caml_stat_strdup_to_utf16(String_val(odest));
 
   caml_enter_blocking_section();
-  result = pCreateSymbolicLink(dest, source, flags);
+  result = CreateSymbolicLink(dest, source, flags);
   caml_leave_blocking_section();
 
   caml_stat_free(source);

--- a/testsuite/tests/lib-unix/win-symlink/parallel_symlink.ml
+++ b/testsuite/tests/lib-unix/win-symlink/parallel_symlink.ml
@@ -1,0 +1,39 @@
+(* TEST
+* libwin32unix
+include unix
+** bytecode
+** native
+*)
+
+let create_symlink barrier src dst () =
+  while not (Atomic.get barrier) do Domain.cpu_relax() done;
+  Unix.symlink ~to_dir:false src dst
+
+let create_symlink_parallel src name1 name2 =
+  let barrier = Atomic.make false in
+  let d1 = Domain.spawn (create_symlink barrier src name1)
+  and d2 = Domain.spawn (create_symlink barrier src name2) in
+  Unix.sleepf 0.05;
+  Atomic.set barrier true;
+  Domain.join d1;
+  Domain.join d2
+
+let test () =
+  let descr = Unix.(openfile "tmp.txt" [O_RDWR; O_CREAT; O_TRUNC] 0o600) in
+  create_symlink_parallel "tmp.txt" "link1.txt" "link2.txt";
+  create_symlink_parallel "tmp.txt" "link3.txt" "link4.txt";
+  assert (Unix.write_substring descr "test" 0 4 = 4);
+  let in_ = In_channel.open_text "link4.txt" in
+  assert (In_channel.input_all in_ = "test");
+  In_channel.close in_;
+  Unix.close descr;
+  Sys.remove "tmp.txt";
+  Sys.remove "link1.txt";
+  Sys.remove "link2.txt";
+  Sys.remove "link3.txt";
+  Sys.remove "link4.txt";
+;;
+
+let _ =
+  if Unix.has_symlink () then
+    for _ = 1 to 50 do test () done

--- a/testsuite/tests/lib-unix/win-symlink/parallel_symlink.ml
+++ b/testsuite/tests/lib-unix/win-symlink/parallel_symlink.ml
@@ -1,8 +1,9 @@
 (* TEST
 * libwin32unix
 include unix
-** bytecode
-** native
+** has_symlink
+*** bytecode
+*** native
 *)
 
 let create_symlink barrier src dst () =


### PR DESCRIPTION
The C stub uses three global variable to cache the results of querying the symlink capability. This synchronizes accesses to the globals using an atomic value and a busy-waiting loop (the loop can block at most once for each thread in the worst case).