### PR TITLE
Fix the type of umask to `file_perm -> file_perm`

### DIFF
--- a/Changes
+++ b/Changes
@@ -73,6 +73,9 @@ Working version
 - #9430, #11291: Document the general desugaring rules for binding operators.
   (Gabriel Scherer, review by Nicolás Ojeda Bär)
 
+- #11481: Fix the type of Unix.umask to Unix.file_perm -> Unix.file_perm
+  (Favonia, review by Sébastien Hinderer)
+
 ### Compiler user-interface and warnings:
 
 - #10818: Preserve integer literal formatting in type hint.

--- a/otherlibs/unix/unix.mli
+++ b/otherlibs/unix/unix.mli
@@ -681,7 +681,7 @@ val fchown : file_descr -> int -> int -> unit
 
     @raise Invalid_argument on Windows *)
 
-val umask : int -> int
+val umask : file_perm -> file_perm
 (** Set the process's file mode creation mask, and return the previous
     mask.
 

--- a/otherlibs/unix/unixLabels.mli
+++ b/otherlibs/unix/unixLabels.mli
@@ -681,7 +681,7 @@ val fchown : file_descr -> uid:int -> gid:int -> unit
 
     @raise Invalid_argument on Windows *)
 
-val umask : int -> int
+val umask : file_perm -> file_perm
 (** Set the process's file mode creation mask, and return the previous
     mask.
 


### PR DESCRIPTION
It seems `file_perm` should be used in the type of `Unix.umask`. (It's currently an alias of `int`, so this does not really change the API except for its documentation.)