### PR TITLE
Add an empty type to the standard library

### DIFF
--- a/Changes
+++ b/Changes
@@ -60,6 +60,10 @@ Working version
   halving memory usage while remaining tail-recursive.
   (Nicolás Ojeda Bär, review by Xavier Leroy and Gabriel Scherer)
 
+- #9459, #10552, #11265: Add a built-in empty type Stdlib.empty and the Empty
+  module with t (alias of Stdlib.empty), equal, compare and to_string.
+  (Favonia)
+
 ### Other libraries:
 
 - #11475: Make Unix terminal interface bindings domain-safe

--- a/manual/src/library/stdlib-blurb.etex
+++ b/manual/src/library/stdlib-blurb.etex
@@ -41,6 +41,7 @@ Here is a short listing, by theme, of the standard library modules.
 "StdLabels" & p.~\stdpageref{StdLabels} & labelized versions of
 the above 4 modules \\
 "Unit" & p.~\stdpageref{Unit} & unit values \\
+"Empty" & p.~\stdpageref{Empty} & the empty type \\
 "Bool" & p.~\stdpageref{Bool} & boolean values \\
 "Char" & p.~\stdpageref{Char} & character operations \\
 "Uchar" & p.~\stdpageref{Uchar} & Unicode characters \\
@@ -179,6 +180,7 @@ be called from C \\
 \stddocitem{Sys}{system interface}
 \stddocitem{Uchar}{Unicode characters}
 \stddocitem{Unit}{unit values}
+\stddocitem{Empty}{the empty type}
 \stddocitem{Weak}{arrays of weak pointers}
 \ifouthtml\else
 \input{Ocaml_operators}

--- a/stdlib/.depend
+++ b/stdlib/.depend
@@ -759,6 +759,11 @@ stdlib__Unit.cmo : unit.ml \
 stdlib__Unit.cmx : unit.ml \
     stdlib__Unit.cmi
 stdlib__Unit.cmi : unit.mli
+stdlib__Empty.cmo : empty.ml \
+    stdlib__Empty.cmi
+stdlib__Empty.cmx : empty.ml \
+    stdlib__Empty.cmi
+stdlib__Empty.cmi : empty.mli
 stdlib__Weak.cmo : weak.ml \
     stdlib__Sys.cmi \
     stdlib__Obj.cmi \

--- a/stdlib/StdlibModules
+++ b/stdlib/StdlibModules
@@ -37,7 +37,7 @@ STDLIB_MODULE_BASENAMES = \
   camlinternalFormatBasics stdlib either \
   sys obj atomic camlinternalLazy lazy \
   seq option result bool char uchar \
-  list int bytes string unit marshal array float int32 int64 nativeint \
+  list int bytes string unit empty marshal array float int32 int64 nativeint \
   lexing parsing set map stack queue buffer \
   mutex condition semaphore domain \
   camlinternalFormat printf arg \

--- a/stdlib/empty.ml
+++ b/stdlib/empty.ml
@@ -1,0 +1,20 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                         The OCaml programmers                          *)
+(*                                                                        *)
+(*   Copyright 2022 Institut National de Recherche en Informatique et     *)
+(*     en Automatique.                                                    *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+type t = empty = |
+
+let equal : t -> t -> bool = function _ -> .
+let compare : t -> t -> int = function _ -> .
+let to_string : t -> string = function _ -> .

--- a/stdlib/empty.mli
+++ b/stdlib/empty.mli
@@ -1,0 +1,32 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                         The OCaml programmers                          *)
+(*                                                                        *)
+(*   Copyright 2018 Institut National de Recherche en Informatique et     *)
+(*     en Automatique.                                                    *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+(** The empty type.
+
+    @since 5.0 *)
+
+(** {1:empty The empty type} *)
+
+type t = empty = |
+(** The empty type that has no values. *)
+
+val equal : t -> t -> bool
+(** [equal e1 e2] never returns. *)
+
+val compare : t -> t -> int
+(** [compare e1 e2] never returns. *)
+
+val to_string : t -> string
+(** [to_string e] never returns. *)

--- a/stdlib/stdlib.ml
+++ b/stdlib/stdlib.ml
@@ -245,6 +245,10 @@ external decr : int ref -> unit = "%decr"
 
 type ('a,'b) result = Ok of 'a | Error of 'b
 
+(* Empty type *)
+
+type empty = |
+
 (* String conversion functions *)
 
 external format_int : string -> int -> string = "caml_format_int"
@@ -597,6 +601,7 @@ module Digest         = Digest
 module Domain         = Domain
 module Effect         = Effect
 module Either         = Either
+module Empty          = Empty
 module Ephemeron      = Ephemeron
 module Filename       = Filename
 module Float          = Float

--- a/stdlib/stdlib.mli
+++ b/stdlib/stdlib.mli
@@ -1243,6 +1243,11 @@ external decr : int ref -> unit = "%decr"
 (** @since 4.03.0 *)
 type ('a,'b) result = Ok of 'a | Error of 'b
 
+(** {1 Empty type} *)
+
+(** @since 5.0.0 *)
+type empty = |
+
 (** {1 Operations on format strings} *)
 
 (** Format strings are character strings with special lexical conventions
@@ -1403,6 +1408,7 @@ module Digest         = Digest
 module Domain         = Domain
 module Effect         = Effect
 module Either         = Either
+module Empty          = Empty
 module Ephemeron      = Ephemeron
 module Filename       = Filename
 module Float          = Float

--- a/testsuite/tests/backtrace/pr2195-locs.byte.reference
+++ b/testsuite/tests/backtrace/pr2195-locs.byte.reference
@@ -1,4 +1,4 @@
 Fatal error: exception Stdlib.Exit
-Raised by primitive operation at Stdlib.open_in_gen in file "stdlib.ml", line 403, characters 28-54
+Raised by primitive operation at Stdlib.open_in_gen in file "stdlib.ml", line 407, characters 28-54
 Called from Pr2195 in file "pr2195.ml", line 24, characters 6-19
 Re-raised at Pr2195 in file "pr2195.ml", line 29, characters 4-41

--- a/testsuite/tests/backtrace/pr2195.opt.reference
+++ b/testsuite/tests/backtrace/pr2195.opt.reference
@@ -1,5 +1,5 @@
 Fatal error: exception Stdlib.Exit
-Raised by primitive operation at Stdlib.open_in_gen in file "stdlib.ml", line 403, characters 28-54
-Called from Stdlib.open_in in file "stdlib.ml" (inlined), line 408, characters 2-45
+Raised by primitive operation at Stdlib.open_in_gen in file "stdlib.ml", line 407, characters 28-54
+Called from Stdlib.open_in in file "stdlib.ml" (inlined), line 412, characters 2-45
 Called from Pr2195 in file "pr2195.ml", line 24, characters 6-19
 Re-raised at Pr2195 in file "pr2195.ml", line 29, characters 4-41

--- a/testsuite/tests/basic/patmatch_for_multiple.ml
+++ b/testsuite/tests/basic/patmatch_for_multiple.ml
@@ -26,15 +26,15 @@ match (3, 2, 1) with
 | _ -> false
 ;;
 [%%expect{|
-(let (*match*/275 = 3 *match*/276 = 2 *match*/277 = 1)
+(let (*match*/277 = 3 *match*/278 = 2 *match*/279 = 1)
   (catch
     (catch
-      (catch (if (!= *match*/276 3) (exit 3) (exit 1)) with (3)
-        (if (!= *match*/275 1) (exit 2) (exit 1)))
+      (catch (if (!= *match*/278 3) (exit 3) (exit 1)) with (3)
+        (if (!= *match*/277 1) (exit 2) (exit 1)))
      with (2) 0)
    with (1) 1))
-(let (*match*/275 = 3 *match*/276 = 2 *match*/277 = 1)
-  (catch (if (!= *match*/276 3) (if (!= *match*/275 1) 0 (exit 1)) (exit 1))
+(let (*match*/277 = 3 *match*/278 = 2 *match*/279 = 1)
+  (catch (if (!= *match*/278 3) (if (!= *match*/277 1) 0 (exit 1)) (exit 1))
    with (1) 1))
 - : bool = false
 |}];;
@@ -47,26 +47,26 @@ match (3, 2, 1) with
 | _ -> false
 ;;
 [%%expect{|
-(let (*match*/280 = 3 *match*/281 = 2 *match*/282 = 1)
+(let (*match*/282 = 3 *match*/283 = 2 *match*/284 = 1)
   (catch
     (catch
       (catch
-        (if (!= *match*/281 3) (exit 6)
-          (let (x/284 =a (makeblock 0 *match*/280 *match*/281 *match*/282))
-            (exit 4 x/284)))
+        (if (!= *match*/283 3) (exit 6)
+          (let (x/286 =a (makeblock 0 *match*/282 *match*/283 *match*/284))
+            (exit 4 x/286)))
        with (6)
-        (if (!= *match*/280 1) (exit 5)
-          (let (x/283 =a (makeblock 0 *match*/280 *match*/281 *match*/282))
-            (exit 4 x/283))))
+        (if (!= *match*/282 1) (exit 5)
+          (let (x/285 =a (makeblock 0 *match*/282 *match*/283 *match*/284))
+            (exit 4 x/285))))
      with (5) 0)
-   with (4 x/278) (seq (ignore x/278) 1)))
-(let (*match*/280 = 3 *match*/281 = 2 *match*/282 = 1)
+   with (4 x/280) (seq (ignore x/280) 1)))
+(let (*match*/282 = 3 *match*/283 = 2 *match*/284 = 1)
   (catch
-    (if (!= *match*/281 3)
-      (if (!= *match*/280 1) 0
-        (exit 4 (makeblock 0 *match*/280 *match*/281 *match*/282)))
-      (exit 4 (makeblock 0 *match*/280 *match*/281 *match*/282)))
-   with (4 x/278) (seq (ignore x/278) 1)))
+    (if (!= *match*/283 3)
+      (if (!= *match*/282 1) 0
+        (exit 4 (makeblock 0 *match*/282 *match*/283 *match*/284)))
+      (exit 4 (makeblock 0 *match*/282 *match*/283 *match*/284)))
+   with (4 x/280) (seq (ignore x/280) 1)))
 - : bool = false
 |}];;
 
@@ -76,8 +76,8 @@ let _ = fun a b ->
   | ((true, _) as _g)
   | ((false, _) as _g) -> ()
 [%%expect{|
-(function a/285[int] b/286 : int 0)
-(function a/285[int] b/286 : int 0)
+(function a/287[int] b/288 : int 0)
+(function a/287[int] b/288 : int 0)
 - : bool -> 'a -> unit = <fun>
 |}];;
 
@@ -96,8 +96,8 @@ let _ = fun a b -> match a, b with
 | (false, _) as p -> p
 (* outside, trivial *)
 [%%expect {|
-(function a/289[int] b/290 (let (p/291 =a (makeblock 0 a/289 b/290)) p/291))
-(function a/289[int] b/290 (makeblock 0 a/289 b/290))
+(function a/291[int] b/292 (let (p/293 =a (makeblock 0 a/291 b/292)) p/293))
+(function a/291[int] b/292 (makeblock 0 a/291 b/292))
 - : bool -> 'a -> bool * 'a = <fun>
 |}]
 
@@ -106,8 +106,8 @@ let _ = fun a b -> match a, b with
 | ((false, _) as p) -> p
 (* inside, trivial *)
 [%%expect{|
-(function a/293[int] b/294 (let (p/295 =a (makeblock 0 a/293 b/294)) p/295))
-(function a/293[int] b/294 (makeblock 0 a/293 b/294))
+(function a/295[int] b/296 (let (p/297 =a (makeblock 0 a/295 b/296)) p/297))
+(function a/295[int] b/296 (makeblock 0 a/295 b/296))
 - : bool -> 'a -> bool * 'a = <fun>
 |}];;
 
@@ -116,11 +116,11 @@ let _ = fun a b -> match a, b with
 | (false as x, _) as p -> x, p
 (* outside, simple *)
 [%%expect {|
-(function a/299[int] b/300
-  (let (x/301 =a[int] a/299 p/302 =a (makeblock 0 a/299 b/300))
-    (makeblock 0 (int,*) x/301 p/302)))
-(function a/299[int] b/300
-  (makeblock 0 (int,*) a/299 (makeblock 0 a/299 b/300)))
+(function a/301[int] b/302
+  (let (x/303 =a[int] a/301 p/304 =a (makeblock 0 a/301 b/302))
+    (makeblock 0 (int,*) x/303 p/304)))
+(function a/301[int] b/302
+  (makeblock 0 (int,*) a/301 (makeblock 0 a/301 b/302)))
 - : bool -> 'a -> bool * (bool * 'a) = <fun>
 |}]
 
@@ -129,11 +129,11 @@ let _ = fun a b -> match a, b with
 | ((false as x, _) as p) -> x, p
 (* inside, simple *)
 [%%expect {|
-(function a/305[int] b/306
-  (let (x/307 =a[int] a/305 p/308 =a (makeblock 0 a/305 b/306))
-    (makeblock 0 (int,*) x/307 p/308)))
-(function a/305[int] b/306
-  (makeblock 0 (int,*) a/305 (makeblock 0 a/305 b/306)))
+(function a/307[int] b/308
+  (let (x/309 =a[int] a/307 p/310 =a (makeblock 0 a/307 b/308))
+    (makeblock 0 (int,*) x/309 p/310)))
+(function a/307[int] b/308
+  (makeblock 0 (int,*) a/307 (makeblock 0 a/307 b/308)))
 - : bool -> 'a -> bool * (bool * 'a) = <fun>
 |}]
 
@@ -142,15 +142,15 @@ let _ = fun a b -> match a, b with
 | (false, x) as p -> x, p
 (* outside, complex *)
 [%%expect{|
-(function a/315[int] b/316[int]
-  (if a/315
-    (let (x/317 =a[int] a/315 p/318 =a (makeblock 0 a/315 b/316))
-      (makeblock 0 (int,*) x/317 p/318))
-    (let (x/319 =a b/316 p/320 =a (makeblock 0 a/315 b/316))
-      (makeblock 0 (int,*) x/319 p/320))))
-(function a/315[int] b/316[int]
-  (if a/315 (makeblock 0 (int,*) a/315 (makeblock 0 a/315 b/316))
-    (makeblock 0 (int,*) b/316 (makeblock 0 a/315 b/316))))
+(function a/317[int] b/318[int]
+  (if a/317
+    (let (x/319 =a[int] a/317 p/320 =a (makeblock 0 a/317 b/318))
+      (makeblock 0 (int,*) x/319 p/320))
+    (let (x/321 =a b/318 p/322 =a (makeblock 0 a/317 b/318))
+      (makeblock 0 (int,*) x/321 p/322))))
+(function a/317[int] b/318[int]
+  (if a/317 (makeblock 0 (int,*) a/317 (makeblock 0 a/317 b/318))
+    (makeblock 0 (int,*) b/318 (makeblock 0 a/317 b/318))))
 - : bool -> bool -> bool * (bool * bool) = <fun>
 |}]
 
@@ -160,19 +160,19 @@ let _ = fun a b -> match a, b with
   -> x, p
 (* inside, complex *)
 [%%expect{|
-(function a/321[int] b/322[int]
+(function a/323[int] b/324[int]
   (catch
-    (if a/321
-      (let (x/329 =a[int] a/321 p/330 =a (makeblock 0 a/321 b/322))
-        (exit 10 x/329 p/330))
-      (let (x/327 =a b/322 p/328 =a (makeblock 0 a/321 b/322))
-        (exit 10 x/327 p/328)))
-   with (10 x/323[int] p/324) (makeblock 0 (int,*) x/323 p/324)))
-(function a/321[int] b/322[int]
+    (if a/323
+      (let (x/331 =a[int] a/323 p/332 =a (makeblock 0 a/323 b/324))
+        (exit 10 x/331 p/332))
+      (let (x/329 =a b/324 p/330 =a (makeblock 0 a/323 b/324))
+        (exit 10 x/329 p/330)))
+   with (10 x/325[int] p/326) (makeblock 0 (int,*) x/325 p/326)))
+(function a/323[int] b/324[int]
   (catch
-    (if a/321 (exit 10 a/321 (makeblock 0 a/321 b/322))
-      (exit 10 b/322 (makeblock 0 a/321 b/322)))
-   with (10 x/323[int] p/324) (makeblock 0 (int,*) x/323 p/324)))
+    (if a/323 (exit 10 a/323 (makeblock 0 a/323 b/324))
+      (exit 10 b/324 (makeblock 0 a/323 b/324)))
+   with (10 x/325[int] p/326) (makeblock 0 (int,*) x/325 p/326)))
 - : bool -> bool -> bool * (bool * bool) = <fun>
 |}]
 
@@ -185,15 +185,15 @@ let _ = fun a b -> match a, b with
 | (false as x, _) as p -> x, p
 (* outside, onecase *)
 [%%expect {|
-(function a/331[int] b/332[int]
-  (if a/331
-    (let (x/333 =a[int] a/331 _p/334 =a (makeblock 0 a/331 b/332))
-      (makeblock 0 (int,*) x/333 [0: 1 1]))
-    (let (x/335 =a[int] a/331 p/336 =a (makeblock 0 a/331 b/332))
-      (makeblock 0 (int,*) x/335 p/336))))
-(function a/331[int] b/332[int]
-  (if a/331 (makeblock 0 (int,*) a/331 [0: 1 1])
-    (makeblock 0 (int,*) a/331 (makeblock 0 a/331 b/332))))
+(function a/333[int] b/334[int]
+  (if a/333
+    (let (x/335 =a[int] a/333 _p/336 =a (makeblock 0 a/333 b/334))
+      (makeblock 0 (int,*) x/335 [0: 1 1]))
+    (let (x/337 =a[int] a/333 p/338 =a (makeblock 0 a/333 b/334))
+      (makeblock 0 (int,*) x/337 p/338))))
+(function a/333[int] b/334[int]
+  (if a/333 (makeblock 0 (int,*) a/333 [0: 1 1])
+    (makeblock 0 (int,*) a/333 (makeblock 0 a/333 b/334))))
 - : bool -> bool -> bool * (bool * bool) = <fun>
 |}]
 
@@ -202,11 +202,11 @@ let _ = fun a b -> match a, b with
 | ((false as x, _) as p) -> x, p
 (* inside, onecase *)
 [%%expect{|
-(function a/337[int] b/338
-  (let (x/339 =a[int] a/337 p/340 =a (makeblock 0 a/337 b/338))
-    (makeblock 0 (int,*) x/339 p/340)))
-(function a/337[int] b/338
-  (makeblock 0 (int,*) a/337 (makeblock 0 a/337 b/338)))
+(function a/339[int] b/340
+  (let (x/341 =a[int] a/339 p/342 =a (makeblock 0 a/339 b/340))
+    (makeblock 0 (int,*) x/341 p/342)))
+(function a/339[int] b/340
+  (makeblock 0 (int,*) a/339 (makeblock 0 a/339 b/340)))
 - : bool -> 'a -> bool * (bool * 'a) = <fun>
 |}]
 
@@ -223,14 +223,14 @@ let _ =fun a b -> match a, b with
 | (_, _) as p -> p
 (* outside, tuplist *)
 [%%expect {|
-(function a/350[int] b/351
+(function a/352[int] b/353
   (catch
-    (if a/350 (if b/351 (let (p/352 =a (field_imm 0 b/351)) p/352) (exit 12))
+    (if a/352 (if b/353 (let (p/354 =a (field_imm 0 b/353)) p/354) (exit 12))
       (exit 12))
-   with (12) (let (p/353 =a (makeblock 0 a/350 b/351)) p/353)))
-(function a/350[int] b/351
-  (catch (if a/350 (if b/351 (field_imm 0 b/351) (exit 12)) (exit 12))
-   with (12) (makeblock 0 a/350 b/351)))
+   with (12) (let (p/355 =a (makeblock 0 a/352 b/353)) p/355)))
+(function a/352[int] b/353
+  (catch (if a/352 (if b/353 (field_imm 0 b/353) (exit 12)) (exit 12))
+   with (12) (makeblock 0 a/352 b/353)))
 - : bool -> bool tuplist -> bool * bool tuplist = <fun>
 |}]
 
@@ -239,20 +239,20 @@ let _ = fun a b -> match a, b with
 | ((_, _) as p) -> p
 (* inside, tuplist *)
 [%%expect{|
-(function a/354[int] b/355
+(function a/356[int] b/357
   (catch
     (catch
-      (if a/354
-        (if b/355 (let (p/359 =a (field_imm 0 b/355)) (exit 13 p/359))
+      (if a/356
+        (if b/357 (let (p/361 =a (field_imm 0 b/357)) (exit 13 p/361))
           (exit 14))
         (exit 14))
-     with (14) (let (p/358 =a (makeblock 0 a/354 b/355)) (exit 13 p/358)))
-   with (13 p/356) p/356))
-(function a/354[int] b/355
+     with (14) (let (p/360 =a (makeblock 0 a/356 b/357)) (exit 13 p/360)))
+   with (13 p/358) p/358))
+(function a/356[int] b/357
   (catch
     (catch
-      (if a/354 (if b/355 (exit 13 (field_imm 0 b/355)) (exit 14)) (exit 14))
-     with (14) (exit 13 (makeblock 0 a/354 b/355)))
-   with (13 p/356) p/356))
+      (if a/356 (if b/357 (exit 13 (field_imm 0 b/357)) (exit 14)) (exit 14))
+     with (14) (exit 13 (makeblock 0 a/356 b/357)))
+   with (13 p/358) p/358))
 - : bool -> bool tuplist -> bool * bool tuplist = <fun>
 |}]

--- a/testsuite/tests/generalized-open/gpr1506.ml
+++ b/testsuite/tests/generalized-open/gpr1506.ml
@@ -103,9 +103,9 @@ include struct open struct type t = T end let x = T end
 Line 1, characters 15-41:
 1 | include struct open struct type t = T end let x = T end
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The type t/338 introduced by this open appears in the signature
+Error: The type t/340 introduced by this open appears in the signature
        Line 1, characters 46-47:
-         The value x has no valid type if t/338 is hidden
+         The value x has no valid type if t/340 is hidden
 |}];;
 
 module A = struct
@@ -123,9 +123,9 @@ Lines 3-6, characters 4-7:
 4 |       type t = T
 5 |       let x = T
 6 |     end
-Error: The type t/343 introduced by this open appears in the signature
+Error: The type t/345 introduced by this open appears in the signature
        Line 7, characters 8-9:
-         The value y has no valid type if t/343 is hidden
+         The value y has no valid type if t/345 is hidden
 |}];;
 
 module A = struct
@@ -142,9 +142,9 @@ Lines 3-5, characters 4-7:
 3 | ....open struct
 4 |       type t = T
 5 |     end
-Error: The type t/348 introduced by this open appears in the signature
+Error: The type t/350 introduced by this open appears in the signature
        Line 6, characters 8-9:
-         The value y has no valid type if t/348 is hidden
+         The value y has no valid type if t/350 is hidden
 |}]
 
 (* It was decided to not allow this anymore. *)

--- a/testsuite/tests/shapes/comp_units.ml
+++ b/testsuite/tests/shapes/comp_units.ml
@@ -25,7 +25,7 @@ module Mproj = Unit
 module F (X : sig type t end) = X
 [%%expect{|
 {
- "F"[module] -> Abs<.4>(X/278, X/278<.3>);
+ "F"[module] -> Abs<.4>(X/280, X/280<.3>);
  }
 module F : functor (X : sig type t end) -> sig type t = X.t end
 |}]

--- a/testsuite/tests/shapes/functors.ml
+++ b/testsuite/tests/shapes/functors.ml
@@ -17,7 +17,7 @@ module type S = sig type t val x : t end
 module Falias (X : S) = X
 [%%expect{|
 {
- "Falias"[module] -> Abs<.4>(X/280, X/280<.3>);
+ "Falias"[module] -> Abs<.4>(X/282, X/282<.3>);
  }
 module Falias : functor (X : S) -> sig type t = X.t val x : t end
 |}]
@@ -29,10 +29,10 @@ end
 {
  "Finclude"[module] ->
      Abs<.6>
-        (X/284,
+        (X/286,
          {
-          "t"[type] -> X/284<.5> . "t"[type];
-          "x"[value] -> X/284<.5> . "x"[value];
+          "t"[type] -> X/286<.5> . "t"[type];
+          "x"[value] -> X/286<.5> . "x"[value];
           });
  }
 module Finclude : functor (X : S) -> sig type t = X.t val x : t end
@@ -45,7 +45,7 @@ end
 [%%expect{|
 {
  "Fredef"[module] ->
-     Abs<.10>(X/291, {
+     Abs<.10>(X/293, {
                       "t"[type] -> <.8>;
                       "x"[value] -> <.9>;
                       });
@@ -223,8 +223,8 @@ module Big_to_small1 : B2S = functor (X : Big) -> X
 [%%expect{|
 {
  "Big_to_small1"[module] ->
-     Abs<.40>(X/386, {<.39>
-                      "t"[type] -> X/386<.39> . "t"[type];
+     Abs<.40>(X/388, {<.39>
+                      "t"[type] -> X/388<.39> . "t"[type];
                       });
  }
 module Big_to_small1 : B2S
@@ -234,8 +234,8 @@ module Big_to_small2 : B2S = functor (X : Big) -> struct include X end
 [%%expect{|
 {
  "Big_to_small2"[module] ->
-     Abs<.42>(X/389, {
-                      "t"[type] -> X/389<.41> . "t"[type];
+     Abs<.42>(X/391, {
+                      "t"[type] -> X/391<.41> . "t"[type];
                       });
  }
 module Big_to_small2 : B2S

--- a/testsuite/tests/shapes/open_arg.ml
+++ b/testsuite/tests/shapes/open_arg.ml
@@ -22,7 +22,7 @@ end = struct end
 
 [%%expect{|
 {
- "Make"[module] -> Abs<.3>(I/280, {
+ "Make"[module] -> Abs<.3>(I/282, {
                                    });
  }
 module Make : functor (I : sig end) -> sig end

--- a/testsuite/tests/shapes/recmodules.ml
+++ b/testsuite/tests/shapes/recmodules.ml
@@ -43,8 +43,8 @@ and B : sig
 end = B
 [%%expect{|
 {
- "A"[module] -> A/303<.11>;
- "B"[module] -> B/304<.12>;
+ "A"[module] -> A/305<.11>;
+ "B"[module] -> B/306<.12>;
  }
 module rec A : sig type t = Leaf of B.t end
 and B : sig type t = int end
@@ -82,13 +82,13 @@ end = Set.Make(A)
  "ASet"[module] ->
      {
       "compare"[value] ->
-          CU Stdlib . "Set"[module] . "Make"[module](A/325<.19>) .
+          CU Stdlib . "Set"[module] . "Make"[module](A/327<.19>) .
           "compare"[value];
       "elt"[type] ->
-          CU Stdlib . "Set"[module] . "Make"[module](A/325<.19>) .
+          CU Stdlib . "Set"[module] . "Make"[module](A/327<.19>) .
           "elt"[type];
       "t"[type] ->
-          CU Stdlib . "Set"[module] . "Make"[module](A/325<.19>) . "t"[type];
+          CU Stdlib . "Set"[module] . "Make"[module](A/327<.19>) . "t"[type];
       };
  }
 module rec A :

--- a/testsuite/tests/shapes/rotor_example.ml
+++ b/testsuite/tests/shapes/rotor_example.ml
@@ -26,7 +26,7 @@ end
 {
  "Pair"[module] ->
      Abs<.9>
-        (X/280, Abs(Y/281, {
+        (X/282, Abs(Y/283, {
                             "t"[type] -> <.5>;
                             "to_string"[value] -> <.6>;
                             }));

--- a/testsuite/tests/typing-sigsubst/sigsubst.ml
+++ b/testsuite/tests/typing-sigsubst/sigsubst.ml
@@ -24,11 +24,11 @@ end
 Line 3, characters 2-36:
 3 |   include Comparable with type t = t
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: Illegal shadowing of included type t/285 by t/290
+Error: Illegal shadowing of included type t/287 by t/292
        Line 2, characters 2-19:
-         Type t/285 came from this include
+         Type t/287 came from this include
        Line 3, characters 2-23:
-         The value print has no valid type if t/285 is shadowed
+         The value print has no valid type if t/287 is shadowed
 |}]
 
 module type Sunderscore = sig


### PR DESCRIPTION
~~This PR is a draft because some tests were skipped (and thus the expected outputs were not updated)---most related to `no-flat-float-array` and `flambda`. I hope the CI will pick up all skipped tests. It is expected that the compiler will output different error messages due to the introduction of a new type.~~ Magically, the CI passed---even though I did not update those test cases. I suppose it's ready for review.

Closes #11265. Related: #9459 and #10552. 

---

About copyrights: If this PR is protected by copyright (not sure), I intend to assign the copyright of my contribution to the GitHub repository ocaml/ocaml to INRIA and/or whatever "OCaml programmers" refer to. Is that okay? If this is not possible, I am using [CC0 1.0 Universal](https://creativecommons.org/publicdomain/zero/1.0/) to waive all my rights to the extent allowed by law. Should I still sign the CLA?