### PR TITLE
Thwart FMA test optimization during configure

### DIFF
--- a/Changes
+++ b/Changes
@@ -496,6 +496,9 @@ OCaml 5.0
   (David Allsopp, report by William Hu, review by Xavier Leroy and
    Sébastien Hinderer)
 
+- #11???: Thwart FMA test optimization during configure
+  (William Hu, review by ???)
+
 ### Bug fixes:
 
 - #10768, #11340: Fix typechecking regression when combining first class

--- a/aclocal.m4
+++ b/aclocal.m4
@@ -464,7 +464,7 @@ int main (void) {
      broken implementations of Cygwin64, mingw-w64 (x86_64) and VS2013-2017.
      The static volatile variables aim to thwart GCC's constant folding. */
   static volatile double x, y, z;
-  double t264, t265, t266;
+  volatile double t264, t265, t266;
   x = 0x3.bd5b7dde5fddap-496;
   y = 0x3.bd5b7dde5fddap-496;
   z = -0xd.fc352bc352bap-992;

--- a/configure
+++ b/configure
@@ -14915,7 +14915,7 @@ int main (void) {
      broken implementations of Cygwin64, mingw-w64 (x86_64) and VS2013-2017.
      The static volatile variables aim to thwart GCC's constant folding. */
   static volatile double x, y, z;
-  double t264, t265, t266;
+  volatile double t264, t265, t266;
   x = 0x3.bd5b7dde5fddap-496;
   y = 0x3.bd5b7dde5fddap-496;
   z = -0xd.fc352bc352bap-992;


### PR DESCRIPTION
Configuring OCaml 4.14.0 when CFLAGS contains -O1 or -O2 on Cygwin32 causes the fma test to fail (and build cannot proceed).
```
configure:14872: result: no
configure:14894: error: fma does not work, enable emulation with --enable-imprecise-c99-float-ops
```
Adding `volatile` to the test variables fixes this error. I've followed CONTRIBUTING.md to the best of my knowledge - please let me know if I've missed anything.