### PR TITLE
Revised treatment of alternate stacks for signal handing

### DIFF
--- a/otherlibs/systhreads/st_stubs.c
+++ b/otherlibs/systhreads/st_stubs.c
@@ -509,6 +509,7 @@ static void * caml_thread_start(void * v)
   caml_thread_t th = (caml_thread_t) v;
   int dom_id = th->domain_id;
   value clos;
+  void * signal_stack;
 
   caml_init_domain_self(dom_id);
 
@@ -517,6 +518,7 @@ static void * caml_thread_start(void * v)
   thread_lock_acquire(dom_id);
   Active_thread = th;
   caml_thread_restore_runtime_state();
+  signal_stack = caml_init_signal_stack();
 
 #ifdef POSIX_SIGNALS
   /* restore the signal mask from the spawning thread, now it is safe for the
@@ -528,7 +530,7 @@ static void * caml_thread_start(void * v)
   caml_modify(&(Start_closure(Active_thread->descr)), Val_unit);
   caml_callback_exn(clos, Val_unit);
   caml_thread_stop();
-
+  caml_free_signal_stack(signal_stack);
   return 0;
 }
 

--- a/runtime/caml/signals.h
+++ b/runtime/caml/signals.h
@@ -74,8 +74,10 @@ value caml_process_pending_actions_with_root (value extra_root); // raises
 value caml_process_pending_actions_with_root_exn (value extra_root);
 
 void caml_init_signal_handling(void);
-int caml_init_signal_stack(void);
-void caml_free_signal_stack(void);
+void caml_init_signals();
+void caml_terminate_signals();
+void * caml_init_signal_stack(void);
+void caml_free_signal_stack(void *);
 
 /* These hooks are not modified after other threads are spawned. */
 CAMLextern void (*caml_enter_blocking_section_hook)(void);

--- a/runtime/fail_byt.c
+++ b/runtime/fail_byt.c
@@ -41,7 +41,10 @@ CAMLexport void caml_raise(value v)
   if (Is_exception_result(v))
     v = Extract_exception(v);
 
-  if (Caml_state->external_raise == NULL) caml_fatal_uncaught_exception(v);
+  if (Caml_state->external_raise == NULL) {
+    caml_terminate_signals();
+    caml_fatal_uncaught_exception(v);
+  }
   *Caml_state->external_raise->exn_bucket = v;
 
   Caml_state->local_roots = Caml_state->external_raise->local_roots;

--- a/runtime/fail_nat.c
+++ b/runtime/fail_nat.c
@@ -73,7 +73,10 @@ void caml_raise(value v)
 
   exception_pointer = (char*)Caml_state->c_stack;
 
-  if (exception_pointer == NULL) caml_fatal_uncaught_exception(v);
+  if (exception_pointer == NULL) {
+    caml_terminate_signals();
+    caml_fatal_uncaught_exception(v);
+  }
 
   while (Caml_state->local_roots != NULL &&
          (char *) Caml_state->local_roots < exception_pointer) {

--- a/runtime/signals.c
+++ b/runtime/signals.c
@@ -482,21 +482,6 @@ void * caml_init_signal_stack(void)
     free(stk.ss_sp);
     return NULL;
   }
-
-  /* gprof installs a signal handler for SIGPROF.
-     Make it run on the alternate signal stack, to prevent segfaults. */
-  {
-    struct sigaction act;
-    sigaction(SIGPROF, NULL, &act);
-    if ((act.sa_flags & SA_SIGINFO) ||
-        (act.sa_handler != SIG_IGN && act.sa_handler != SIG_DFL)) {
-      /* found a handler */
-      if ((act.sa_flags & SA_ONSTACK) == 0) {
-        act.sa_flags |= SA_ONSTACK;
-        sigaction(SIGPROF, &act, NULL);
-      }
-    }
-  }
   return stk.ss_sp;
 #else
   return NULL;
@@ -535,6 +520,21 @@ void caml_init_signals(void)
   caml_signal_stack_0 = caml_init_signal_stack();
   if (caml_signal_stack_0 == NULL) {
     caml_fatal_error("Failed to allocate signal stack for domain 0");
+  }
+
+  /* gprof installs a signal handler for SIGPROF.
+     Make it run on the alternate signal stack, to prevent segfaults. */
+  {
+    struct sigaction act;
+    sigaction(SIGPROF, NULL, &act);
+    if ((act.sa_flags & SA_SIGINFO) ||
+        (act.sa_handler != SIG_IGN && act.sa_handler != SIG_DFL)) {
+      /* found a handler */
+      if ((act.sa_flags & SA_ONSTACK) == 0) {
+        act.sa_flags |= SA_ONSTACK;
+        sigaction(SIGPROF, &act, NULL);
+      }
+    }
   }
 #endif
 }

--- a/runtime/signals.c
+++ b/runtime/signals.c
@@ -463,7 +463,7 @@ CAMLexport int caml_rev_convert_signal_number(int signo)
   return signo;
 }
 
-int caml_init_signal_stack(void)
+void * caml_init_signal_stack(void)
 {
 #ifdef POSIX_SIGNALS
   stack_t stk;
@@ -476,11 +476,11 @@ int caml_init_signal_stack(void)
      nasty piece of undefined behaviour forced on the caller. */
   stk.ss_sp = malloc(stk.ss_size);
   if(stk.ss_sp == NULL) {
-    return -1;
+    return NULL;
   }
   if (sigaltstack(&stk, NULL) < 0) {
     free(stk.ss_sp);
-    return -1;
+    return NULL;
   }
 
   /* gprof installs a signal handler for SIGPROF.
@@ -497,23 +497,53 @@ int caml_init_signal_stack(void)
       }
     }
   }
+  return stk.ss_sp;
+#else
+  return NULL;
 #endif
-  return 0;
 }
 
-void caml_free_signal_stack(void)
+void caml_free_signal_stack(void * signal_stack)
 {
 #ifdef POSIX_SIGNALS
-  stack_t stk, disable = {0};
+  stack_t stk, disable;
   disable.ss_flags = SS_DISABLE;
-  /* POSIX says ss_size is ignored when SS_DISABLE is set,
-     but OSX/Darwin fails if the size isn't set. */
-  disable.ss_size = SIGSTKSZ;
+  disable.ss_sp = NULL;  /* not required but avoids a valgrind false alarm */
+  disable.ss_size = SIGSTKSZ; /* macOS wants a valid size here */
   if (sigaltstack(&disable, &stk) < 0) {
     caml_fatal_error("Failed to reset signal stack (err %d)", errno);
   }
+  /* Check whether someone else installed their own signal stack */
+  if (!(stk.ss_flags & SS_DISABLE) && stk.ss_sp != signal_stack) {
+    /* Re-activate their signal stack. */
+    sigaltstack(&stk, NULL);
+  }
   /* Memory was allocated with malloc directly; see caml_init_signal_stack */
-  free(stk.ss_sp);
+  free(signal_stack);
+#endif
+}
+
+/* This is the alternate signal stack block for domain 0 */
+static void * caml_signal_stack_0 = NULL;
+
+void caml_init_signals(void)
+{
+  /* Bound-check trap handling for Power and S390x will go here eventually. */
+
+  /* Set up alternate signal stack for domain 0 */
+#ifdef POSIX_SIGNALS
+  caml_signal_stack_0 = caml_init_signal_stack();
+  if (caml_signal_stack_0 == NULL) {
+    caml_fatal_error("Failed to allocate signal stack for domain 0");
+  }
+#endif
+}
+
+void caml_terminate_signals(void)
+{
+#ifdef POSIX_SIGNALS
+  caml_free_signal_stack(caml_signal_stack_0);
+  caml_signal_stack_0 = NULL;
 #endif
 }
 

--- a/runtime/signals.c
+++ b/runtime/signals.c
@@ -547,7 +547,7 @@ static int caml_set_signal_action(int signo, int action)
 #ifdef POSIX_SIGNALS
   sigact.sa_handler = act;
   sigemptyset(&sigact.sa_mask);
-  sigact.sa_flags = 0;
+  sigact.sa_flags = SA_ONSTACK;
   if (sigaction(signo, &sigact, &oldsigact) == -1) return -1;
   oldact = oldsigact.sa_handler;
 #else

--- a/runtime/startup_aux.c
+++ b/runtime/startup_aux.c
@@ -170,7 +170,7 @@ CAMLexport void caml_shutdown(void)
   caml_free_shared_libs();
 #endif
   caml_stat_destroy_pool();
-  caml_free_signal_stack();
+  caml_terminate_signals();
 #if defined(_WIN32) && defined(NATIVE_CODE)
   caml_win32_unregister_overflow_detection();
 #endif

--- a/runtime/startup_byt.c
+++ b/runtime/startup_byt.c
@@ -540,6 +540,8 @@ CAMLexport void caml_main(char_os **argv)
   CAML_RUNTIME_EVENTS_INIT();
 
   Caml_state->external_raise = NULL;
+  /* Setup signal handling */
+  caml_init_signals();
   /* Initialize the interpreter */
   caml_interprete(NULL, 0);
   /* Initialize the debugger, if needed */
@@ -587,6 +589,7 @@ CAMLexport void caml_main(char_os **argv)
     }
     caml_fatal_uncaught_exception(exn);
   }
+  caml_terminate_signals();
 }
 
 /* Main entry point when code is linked in as initialized data */
@@ -599,6 +602,7 @@ CAMLexport value caml_startup_code_exn(
            char_os **argv)
 {
   char_os * exe_name;
+  value res;
 
   /* Initialize the domain */
   CAML_INIT_DOMAIN_STATE;
@@ -638,6 +642,8 @@ CAMLexport value caml_startup_code_exn(
   Caml_state->external_raise = NULL;
   /* Initialize the interpreter */
   caml_interprete(NULL, 0);
+  /* Setup signal handling */
+  caml_init_signals();
   /* Initialize the debugger, if needed */
   caml_debugger_init();
   /* Load the code */
@@ -662,7 +668,9 @@ CAMLexport value caml_startup_code_exn(
   caml_load_main_debug_info();
   /* Execute the program */
   caml_debugger(PROGRAM_START, Val_unit);
-  return caml_interprete(caml_start_code, caml_code_size);
+  res = caml_interprete(caml_start_code, caml_code_size);
+  caml_terminate_signals();
+  return res;
 }
 
 CAMLexport void caml_startup_code(

--- a/runtime/startup_nat.c
+++ b/runtime/startup_nat.c
@@ -88,6 +88,7 @@ extern void caml_install_invalid_parameter_handler(void);
 value caml_startup_common(char_os **argv, int pooling)
 {
   char_os * exe_name, * proc_self_exe;
+  value res;
 
   /* Initialize the domain */
   CAML_INIT_DOMAIN_STATE;
@@ -117,6 +118,7 @@ value caml_startup_common(char_os **argv, int pooling)
   CAML_RUNTIME_EVENTS_INIT();
 
   init_segments();
+  caml_init_signals();
 #ifdef _WIN32
   caml_win32_overflow_detection();
 #endif
@@ -130,7 +132,9 @@ value caml_startup_common(char_os **argv, int pooling)
     exe_name = caml_search_exe_in_path(exe_name);
   caml_sys_init(exe_name, argv);
   caml_maybe_expand_stack();
-  return caml_start_program(Caml_state);
+  res = caml_start_program(Caml_state);
+  caml_terminate_signals();
+  return res;
 }
 
 value caml_startup_exn(char_os **argv)

--- a/runtime/sys.c
+++ b/runtime/sys.c
@@ -196,6 +196,7 @@ CAML_RUNTIME_EVENTS_DESTROY();
 #ifdef _WIN32
   caml_restore_win32_terminal();
 #endif
+  caml_terminate_signals();
   exit(retcode);
 }
 

--- a/testsuite/tests/unwind/unwind_test.reference
+++ b/testsuite/tests/unwind/unwind_test.reference
@@ -4,6 +4,7 @@ Mylib.baz
 Driver.entry
 caml_program
 caml_start_program
+caml_startup_common
 caml_main
 main
 ml_perform_stack_walk
@@ -12,5 +13,6 @@ Mylib.bob
 Driver.entry
 caml_program
 caml_start_program
+caml_startup_common
 caml_main
 main


### PR DESCRIPTION
This PR brings alternate signal stack handling in OCaml 5 up to date with what's in 4.14 or was proposed for 4.14:

* First commit makes sure that signal handlers are run on the alternate signal stack.  This is required since fiber stacks are generally too small to run signal handlers on.

* Second commit makes sure the alternate signal stack for domain 0 is turned off and freed when the main OCaml code stops. (Adaptation of #10726)
    
* Second commit also avoids a crash when other C libraries install their own alternate signal stack.  Don't try to free their stack, only the stack block we allocated. (Adaptation of #11496)

* Third commit makes sure that every thread created with `Thread.create` has its own alternate signal stack.  Currently, all threads created by a domain race to use the signal stack of this domain.

* Fourth commit (added later) moves the tweaking of the SIGPROF handler from "every time a domain or thread is created" to "once when the process starts", which is enough.

Cc @kayceesrk @Engil .
