### PR TITLE
Disable warning 66 (unused-open-bang) locally rather than globally

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ DIRS = utils parsing typing bytecomp file_formats lambda middle_end \
 INCLUDES = $(addprefix -I ,$(DIRS))
 COMPFLAGS=-strict-sequence -principal -absname \
           -w +a-4-9-40-41-42-44-45-48 \
-          -warn-error +a-66 \
+          -warn-error +a \
           -bin-annot -safe-string -strict-formats $(INCLUDES)
 LINKFLAGS=
 

--- a/Makefile
+++ b/Makefile
@@ -43,8 +43,8 @@ DIRS = utils parsing typing bytecomp file_formats lambda middle_end \
   asmcomp driver toplevel
 INCLUDES = $(addprefix -I ,$(DIRS))
 COMPFLAGS=-strict-sequence -principal -absname \
-          -w +a-4-9-40-41-42-44-45-48-66 \
-          -warn-error +a \
+          -w +a-4-9-40-41-42-44-45-48 \
+          -warn-error +a-66 \
           -bin-annot -safe-string -strict-formats $(INCLUDES)
 LINKFLAGS=
 

--- a/asmcomp/amd64/scheduling.ml
+++ b/asmcomp/amd64/scheduling.ml
@@ -14,7 +14,15 @@
 (*                                                                        *)
 (**************************************************************************)
 
-open! Schedgen (* to create a dependency *)
+(* The "open!" directive below is necessary because, although
+   this module does not actually depend on Schedgen in this backend, the
+   dependency exists in other backends and our build system requires
+   that all the backends have the same dependencies.
+   We thus have to use "open!" and disable the corresponding warning
+   only for this compilation unit.
+*)
+
+open! Schedgen [@@warning "-66"]
 
 (* Scheduling is turned off because the processor schedules dynamically
    much better than what we could do. *)

--- a/asmcomp/arm64/scheduling.ml
+++ b/asmcomp/arm64/scheduling.ml
@@ -14,7 +14,15 @@
 (*                                                                        *)
 (**************************************************************************)
 
-open! Schedgen (* to create a dependency *)
+(* The "open!" directive below is necessary because, although
+   this module does not actually depend on Schedgen in this backend, the
+   dependency exists in other backends and our build system requires
+   that all the backends have the same dependencies.
+   We thus have to use "open!" and disable the corresponding warning
+   only for this compilation unit.
+*)
+
+open! Schedgen [@@warning "-66"]
 
 (* Scheduling is turned off because the processor schedules dynamically
    much better than what we could do. *)

--- a/asmcomp/i386/scheduling.ml
+++ b/asmcomp/i386/scheduling.ml
@@ -14,7 +14,15 @@
 (*                                                                        *)
 (**************************************************************************)
 
-open! Schedgen (* to create a dependency *)
+(* The "open!" directive below is necessary because, although
+   this module does not actually depend on Schedgen in this backend, the
+   dependency exists in other backends and our build system requires
+   that all the backends have the same dependencies.
+   We thus have to use "open!" and disable the corresponding warning
+   only for this compilation unit.
+*)
+
+open! Schedgen [@@warning "-66"]
 
 (* Scheduling is turned off because our model does not fit the 486
    nor the Pentium very well. In particular, it messes up with the

--- a/asmcomp/riscv/scheduling.ml
+++ b/asmcomp/riscv/scheduling.ml
@@ -16,7 +16,15 @@
 
 (* Instruction scheduling for the RISC-V *)
 
-open! Schedgen (* to create a dependency *)
+(* The "open!" directive below is necessary because, although
+   this module does not actually depend on Schedgen in this backend, the
+   dependency exists in other backends and our build system requires
+   that all the backends have the same dependencies.
+   We thus have to use "open!" and disable the corresponding warning
+   only for this compilation unit.
+*)
+
+open! Schedgen [@@warning "-66"]
 
 (* Scheduling is turned off. *)
 

--- a/otherlibs/dynlink/Makefile
+++ b/otherlibs/dynlink/Makefile
@@ -29,7 +29,7 @@ OCAMLOPT=$(BEST_OCAMLOPT) $(STDLIBFLAGS) -g
 
 # COMPFLAGS should be in sync with the toplevel Makefile's COMPFLAGS.
 COMPFLAGS=-strict-sequence -principal -absname \
-          -w +a-4-9-40-41-42-44-45-48 -warn-error +A-66 \
+          -w +a-4-9-40-41-42-44-45-48 -warn-error +A \
           -bin-annot -safe-string -strict-formats
 ifeq "$(FLAMBDA)" "true"
 OPTCOMPFLAGS += -O3

--- a/otherlibs/dynlink/Makefile
+++ b/otherlibs/dynlink/Makefile
@@ -29,7 +29,7 @@ OCAMLOPT=$(BEST_OCAMLOPT) $(STDLIBFLAGS) -g
 
 # COMPFLAGS should be in sync with the toplevel Makefile's COMPFLAGS.
 COMPFLAGS=-strict-sequence -principal -absname \
-          -w +a-4-9-40-41-42-44-45-48-66 -warn-error +A \
+          -w +a-4-9-40-41-42-44-45-48 -warn-error +A-66 \
           -bin-annot -safe-string -strict-formats
 ifeq "$(FLAMBDA)" "true"
 OPTCOMPFLAGS += -O3


### PR DESCRIPTION
At the moment, our build system imposes that the dependencies computed
by ocamldep for the native backends must be exactly the same for
all backends, although the dependencies are actually different.

To circumvent this limitation, four backends (amd64, arm64, i386
and riscv) need to introduce a dependency that does not really exist:
these backends don't have instruction scheduling enabled, but still, their
`scheduling.ml` module must
`open! Schedgen` to cope with the requirements of our build system.

On top of that, when it is enabled, the warning 66 (unused-open-bang)
rightly reports that the above mentionned directives are not necessary.

In the current codebase, this warning is disabled at the level
of the build system, so for the whole compiler's codebase.

The purpose of this PR is to disable the warning locally rather than
globally, only at those places where it is known that, for the moment,
it is necessary to do so.

The PR is not an ultimate fix. The ultimate fix would consist in
having a build system which tolerates that each backend has its own
dependencies, which does not necessarily entail that the dependencies
can not be stored statically. But that's a bit too ambitious, which
would likely require more invasive changes and so this PR proposes
an intermediate solution, a middle way so to speak, which can be summed
up as follows: we are still hiding the dust under a carpet but this
PR makes the carpet smaller than it was before, with the hope that, one day,
it will become possible to remove both carpet and dust.

the other purpose of this PR is to reduce the difference between the
warnings WHICH NEED TO BE disabled to compile the compiler and
those which need to be disabled to compile ocamllex, to make
the merge of `lex/Makefile` into the root `Makefile` proposed in
#11420 easier.

Of course, in theory it could make sense to different different lists of
warnings to compile the compiler and ocamllex. But, in the particular
case addressed by this PR, it does not sound insane to turn a global
warning into a local one. The Pr also clarifies the situation in
the codebase itself, thanks to the comments and to an attribute,
which is of course also a form of documentation.