### PR TITLE
Manually unbox closure in `Hashtbl.mem`

### DIFF
--- a/Changes
+++ b/Changes
@@ -48,6 +48,9 @@ Working version
 - #11354: Hashtbl.find_all is now tail-recursive.
   (Fermín Reig, review by Gabriel Scherer)
 
+- #11500: Make Hashtbl.mem non-allocating.
+  (Simmo Saan, review by Nicolás Ojeda Bär)
+
 - #11362: Rewrite List.map, List.mapi and List.map2 using TRMC, making them
   faster as well as tail-recursive.
   (Nicolás Ojeda Bär, review by Gabriel Scherer)

--- a/stdlib/hashtbl.ml
+++ b/stdlib/hashtbl.ml
@@ -447,13 +447,14 @@ module MakeSeeded(H: SeededHashedType): (SeededS with type key = H.t) =
         if h.size > Array.length h.data lsl 1 then resize key_index h
       end
 
-    let mem h key =
-      let rec mem_in_bucket = function
+    let rec mem_in_bucket key = function
       | Empty ->
           false
       | Cons{key=k; next} ->
-          H.equal k key || mem_in_bucket next in
-      mem_in_bucket h.data.(key_index h key)
+          H.equal k key || mem_in_bucket key next
+
+    let mem h key =
+      mem_in_bucket key h.data.(key_index h key)
 
     let add_seq tbl i =
       Seq.iter (fun (k,v) -> add tbl k v) i
@@ -597,13 +598,14 @@ let replace h key data =
     if h.size > Array.length h.data lsl 1 then resize key_index h
   end
 
-let mem h key =
-  let rec mem_in_bucket = function
+let rec mem_in_bucket key = function
   | Empty ->
       false
   | Cons{key=k; next} ->
-      compare k key = 0 || mem_in_bucket next in
-  mem_in_bucket h.data.(key_index h key)
+      compare k key = 0 || mem_in_bucket key next
+
+let mem h key =
+  mem_in_bucket key h.data.(key_index h key)
 
 let add_seq tbl i =
   Seq.iter (fun (k,v) -> add tbl k v) i

--- a/testsuite/tests/backtrace/backtrace2.reference
+++ b/testsuite/tests/backtrace/backtrace2.reference
@@ -35,7 +35,7 @@ Uncaught exception Invalid_argument("index out of bounds")
 Raised by primitive operation at Backtrace2.run in file "backtrace2.ml", line 62, characters 14-22
 test_Not_found
 Uncaught exception Not_found
-Raised at Stdlib__Hashtbl.find in file "hashtbl.ml", line 541, characters 13-28
+Raised at Stdlib__Hashtbl.find in file "hashtbl.ml", line 542, characters 13-28
 Called from Backtrace2.test_Not_found in file "backtrace2.ml", line 43, characters 9-42
 Re-raised at Backtrace2.test_Not_found in file "backtrace2.ml", line 43, characters 61-70
 Called from Backtrace2.run in file "backtrace2.ml", line 62, characters 11-23
@@ -50,7 +50,7 @@ Called from CamlinternalLazy.do_force_block in file "camlinternalLazy.ml", line 
 Re-raised at CamlinternalLazy.do_force_block in file "camlinternalLazy.ml", line 56, characters 4-11
 Called from Backtrace2.run in file "backtrace2.ml", line 62, characters 11-23
 Uncaught exception Not_found
-Raised at Stdlib__Hashtbl.find in file "hashtbl.ml", line 541, characters 13-28
+Raised at Stdlib__Hashtbl.find in file "hashtbl.ml", line 542, characters 13-28
 Called from Backtrace2.test_lazy.exception_raised_internally in file "backtrace2.ml", line 50, characters 8-41
 Re-raised at CamlinternalLazy.do_force_block.(fun) in file "camlinternalLazy.ml", line 54, characters 43-50
 Called from CamlinternalLazy.do_force_block in file "camlinternalLazy.ml", line 49, characters 17-27


### PR DESCRIPTION
This avoids closure allocation and the associated GC call in `mem`. Numerous other `Hashtbl` functions (`remove`, `find`, `find_opt`, `replace`) are already like this. In particular, this was done to `find` for non-allocation reasons way back in d48c6cfaea74da36e8268888cce3429a883a8395.

I don't have any data for performance change one way or another. A while back while `perf`-ing some `Hashtbl` heavy code, I noticed GC calls in `mem`, which was unexpected as this lookup shouldn't need any allocation, and after some digging realized it's the `mem_in_bucket` closure causing that.