### PR TITLE
Eliminate warning 40 (name-out-of-scope)

### DIFF
--- a/.depend
+++ b/.depend
@@ -573,6 +573,7 @@ typing/ctype.cmi : \
     parsing/asttypes.cmi
 typing/datarepr.cmo : \
     typing/types.cmi \
+    typing/type_immediacy.cmi \
     typing/path.cmi \
     parsing/location.cmi \
     typing/ident.cmi \
@@ -581,6 +582,7 @@ typing/datarepr.cmo : \
     typing/datarepr.cmi
 typing/datarepr.cmx : \
     typing/types.cmx \
+    typing/type_immediacy.cmx \
     typing/path.cmx \
     parsing/location.cmx \
     typing/ident.cmx \
@@ -730,6 +732,7 @@ typing/includecore.cmo : \
     typing/errortrace.cmi \
     typing/env.cmi \
     utils/diffing_with_keys.cmi \
+    utils/diffing.cmi \
     typing/ctype.cmi \
     parsing/builtin_attributes.cmi \
     typing/btype.cmi \
@@ -747,6 +750,7 @@ typing/includecore.cmx : \
     typing/errortrace.cmx \
     typing/env.cmx \
     utils/diffing_with_keys.cmx \
+    utils/diffing.cmx \
     typing/ctype.cmx \
     parsing/builtin_attributes.cmx \
     typing/btype.cmx \
@@ -884,11 +888,13 @@ typing/mtype.cmi : \
     typing/ident.cmi \
     typing/env.cmi
 typing/oprint.cmo : \
+    typing/type_immediacy.cmi \
     parsing/pprintast.cmi \
     typing/outcometree.cmi \
     parsing/asttypes.cmi \
     typing/oprint.cmi
 typing/oprint.cmx : \
+    typing/type_immediacy.cmx \
     parsing/pprintast.cmx \
     typing/outcometree.cmi \
     parsing/asttypes.cmi \
@@ -1298,6 +1304,7 @@ typing/typeclass.cmo : \
     typing/typedecl_variance.cmi \
     typing/typedecl.cmi \
     typing/typecore.cmi \
+    typing/type_immediacy.cmi \
     typing/subst.cmi \
     typing/printtyp.cmi \
     typing/predef.cmi \
@@ -1326,6 +1333,7 @@ typing/typeclass.cmx : \
     typing/typedecl_variance.cmx \
     typing/typedecl.cmx \
     typing/typecore.cmx \
+    typing/type_immediacy.cmx \
     typing/subst.cmx \
     typing/printtyp.cmx \
     typing/predef.cmx \
@@ -1560,6 +1568,7 @@ typing/typedecl_properties.cmi : \
 typing/typedecl_separability.cmo : \
     typing/types.cmi \
     typing/typedecl_properties.cmi \
+    typing/type_immediacy.cmi \
     parsing/location.cmi \
     typing/env.cmi \
     typing/ctype.cmi \
@@ -1569,6 +1578,7 @@ typing/typedecl_separability.cmo : \
 typing/typedecl_separability.cmx : \
     typing/types.cmx \
     typing/typedecl_properties.cmx \
+    typing/type_immediacy.cmx \
     parsing/location.cmx \
     typing/env.cmx \
     typing/ctype.cmx \
@@ -1670,6 +1680,7 @@ typing/typemod.cmo : \
     typing/typedecl.cmi \
     typing/typecore.cmi \
     typing/typeclass.cmi \
+    typing/type_immediacy.cmi \
     typing/subst.cmi \
     typing/signature_group.cmi \
     typing/shape.cmi \
@@ -1705,6 +1716,7 @@ typing/typemod.cmx : \
     typing/typedecl.cmx \
     typing/typecore.cmx \
     typing/typeclass.cmx \
+    typing/type_immediacy.cmx \
     typing/subst.cmx \
     typing/signature_group.cmx \
     typing/shape.cmx \
@@ -2186,11 +2198,13 @@ bytecomp/symtable.cmi : \
 asmcomp/CSE.cmo : \
     asmcomp/mach.cmi \
     asmcomp/CSEgen.cmi \
+    parsing/asttypes.cmi \
     asmcomp/arch.cmi \
     asmcomp/CSE.cmi
 asmcomp/CSE.cmx : \
     asmcomp/mach.cmx \
     asmcomp/CSEgen.cmx \
+    parsing/asttypes.cmi \
     asmcomp/arch.cmx \
     asmcomp/CSE.cmi
 asmcomp/CSE.cmi : \
@@ -2720,6 +2734,7 @@ asmcomp/emit.cmi : \
     asmcomp/linear.cmi \
     asmcomp/cmm.cmi
 asmcomp/emitaux.cmo : \
+    asmcomp/mach.cmi \
     asmcomp/linear.cmi \
     asmcomp/emitenv.cmi \
     lambda/debuginfo.cmi \
@@ -2729,6 +2744,7 @@ asmcomp/emitaux.cmo : \
     asmcomp/arch.cmi \
     asmcomp/emitaux.cmi
 asmcomp/emitaux.cmx : \
+    asmcomp/mach.cmx \
     asmcomp/linear.cmx \
     asmcomp/emitenv.cmi \
     lambda/debuginfo.cmx \
@@ -2868,6 +2884,7 @@ asmcomp/polling.cmo : \
     utils/misc.cmi \
     asmcomp/mach.cmi \
     parsing/location.cmi \
+    lambda/lambda.cmi \
     lambda/debuginfo.cmi \
     asmcomp/dataflow.cmi \
     asmcomp/cmm.cmi \
@@ -2877,6 +2894,7 @@ asmcomp/polling.cmx : \
     utils/misc.cmx \
     asmcomp/mach.cmx \
     parsing/location.cmx \
+    lambda/lambda.cmx \
     lambda/debuginfo.cmx \
     asmcomp/dataflow.cmx \
     asmcomp/cmm.cmx \
@@ -2933,6 +2951,7 @@ asmcomp/printmach.cmo : \
     lambda/debuginfo.cmi \
     asmcomp/cmm.cmi \
     utils/clflags.cmi \
+    parsing/asttypes.cmi \
     asmcomp/arch.cmi \
     asmcomp/printmach.cmi
 asmcomp/printmach.cmx : \
@@ -2945,6 +2964,7 @@ asmcomp/printmach.cmx : \
     lambda/debuginfo.cmx \
     asmcomp/cmm.cmx \
     utils/clflags.cmx \
+    parsing/asttypes.cmi \
     asmcomp/arch.cmx \
     asmcomp/printmach.cmi
 asmcomp/printmach.cmi : \
@@ -3021,6 +3041,7 @@ asmcomp/schedgen.cmo : \
     asmcomp/linear.cmi \
     asmcomp/cmm.cmi \
     utils/clflags.cmi \
+    parsing/asttypes.cmi \
     asmcomp/arch.cmi \
     asmcomp/schedgen.cmi
 asmcomp/schedgen.cmx : \
@@ -3030,6 +3051,7 @@ asmcomp/schedgen.cmx : \
     asmcomp/linear.cmx \
     asmcomp/cmm.cmx \
     utils/clflags.cmx \
+    parsing/asttypes.cmi \
     asmcomp/arch.cmx \
     asmcomp/schedgen.cmi
 asmcomp/schedgen.cmi : \
@@ -3699,6 +3721,7 @@ lambda/translclass.cmi : \
     lambda/debuginfo.cmi \
     parsing/asttypes.cmi
 lambda/translcore.cmo : \
+    utils/warnings.cmi \
     typing/types.cmi \
     typing/typeopt.cmi \
     typing/typedtree.cmi \
@@ -3726,6 +3749,7 @@ lambda/translcore.cmo : \
     parsing/asttypes.cmi \
     lambda/translcore.cmi
 lambda/translcore.cmx : \
+    utils/warnings.cmx \
     typing/types.cmx \
     typing/typeopt.cmx \
     typing/typedtree.cmx \
@@ -3817,6 +3841,7 @@ lambda/translobj.cmo : \
     lambda/lambda.cmi \
     typing/ident.cmi \
     typing/env.cmi \
+    lambda/debuginfo.cmi \
     utils/config.cmi \
     utils/clflags.cmi \
     typing/btype.cmi \
@@ -3828,6 +3853,7 @@ lambda/translobj.cmx : \
     lambda/lambda.cmx \
     typing/ident.cmx \
     typing/env.cmx \
+    lambda/debuginfo.cmx \
     utils/config.cmx \
     utils/clflags.cmx \
     typing/btype.cmx \
@@ -6635,10 +6661,12 @@ toplevel/native/topeval.cmo : \
     typing/includemod.cmi \
     typing/ident.cmi \
     typing/env.cmi \
+    lambda/debuginfo.cmi \
     utils/config.cmi \
     driver/compmisc.cmi \
     middle_end/compilenv.cmi \
     utils/clflags.cmi \
+    parsing/asttypes.cmi \
     asmcomp/asmlink.cmi \
     toplevel/native/topeval.cmi
 toplevel/native/topeval.cmx : \
@@ -6665,10 +6693,12 @@ toplevel/native/topeval.cmx : \
     typing/includemod.cmx \
     typing/ident.cmx \
     typing/env.cmx \
+    lambda/debuginfo.cmx \
     utils/config.cmx \
     driver/compmisc.cmx \
     middle_end/compilenv.cmx \
     utils/clflags.cmx \
+    parsing/asttypes.cmi \
     asmcomp/asmlink.cmx \
     toplevel/native/topeval.cmi
 toplevel/native/topeval.cmi : \

--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ DIRS = utils parsing typing bytecomp file_formats lambda middle_end \
 INCLUDES = $(addprefix -I ,$(DIRS))
 COMPFLAGS=-strict-sequence -principal -absname \
           -w +a-4-9-41-42-44-45-48-66 \
-          -warn-error +a-40 \
+          -warn-error +a \
           -bin-annot -safe-string -strict-formats $(INCLUDES)
 LINKFLAGS=
 

--- a/Makefile
+++ b/Makefile
@@ -43,8 +43,8 @@ DIRS = utils parsing typing bytecomp file_formats lambda middle_end \
   asmcomp driver toplevel
 INCLUDES = $(addprefix -I ,$(DIRS))
 COMPFLAGS=-strict-sequence -principal -absname \
-          -w +a-4-9-40-41-42-44-45-48-66 \
-          -warn-error +a \
+          -w +a-4-9-41-42-44-45-48-66 \
+          -warn-error +a-40 \
           -bin-annot -safe-string -strict-formats $(INCLUDES)
 LINKFLAGS=
 

--- a/asmcomp/CSEgen.ml
+++ b/asmcomp/CSEgen.ml
@@ -49,7 +49,7 @@ module Equations = struct
 
   let add op_class op v m =
     match op_class with
-    | Op_load Mutable ->
+    | Op_load Asttypes.Mutable ->
       { m with mutable_load_equations =
                  Rhs_map.add op v m.mutable_load_equations }
     | _ ->
@@ -57,7 +57,7 @@ module Equations = struct
 
   let find op_class op m =
     match op_class with
-    | Op_load Mutable ->
+    | Op_load Asttypes.Mutable ->
       Rhs_map.find op m.mutable_load_equations
     | _ ->
       Rhs_map.find op m.other_equations
@@ -236,7 +236,7 @@ method class_of_operation op =
   | Inegf | Iabsf | Iaddf | Isubf | Imulf | Idivf
   | Ifloatofint | Iintoffloat -> Op_pure
   | Ispecific _ -> Op_other
-  | Idls_get -> Op_load Mutable
+  | Idls_get -> Op_load Asttypes.Mutable
 
 (* Operations that are so cheap that it isn't worth factoring them. *)
 method is_cheap_operation op =

--- a/asmcomp/amd64/CSE.ml
+++ b/asmcomp/amd64/CSE.ml
@@ -31,7 +31,7 @@ method! class_of_operation op =
     | Ilea _ | Isextend32 | Izextend32 -> Op_pure
     | Istore_int(_, _, is_asg) -> Op_store is_asg
     | Ioffset_loc(_, _) -> Op_store true
-    | Ifloatarithmem _ | Ifloatsqrtf _ -> Op_load Mutable
+    | Ifloatarithmem _ | Ifloatsqrtf _ -> Op_load Asttypes.Mutable
     | Ibswap _ | Isqrtf -> super#class_of_operation op
     end
   | _ -> super#class_of_operation op

--- a/asmcomp/arm64/reload.ml
+++ b/asmcomp/arm64/reload.ml
@@ -24,7 +24,7 @@ inherit Reloadgen.reload_generic as super
 
 method! reload_operation op arg res =
   match op with
-  | Ispecific Imove32 ->
+  | Mach.Ispecific Arch.Imove32 ->
       (* Like Imove: argument or result can be on stack but not both *)
       begin match arg.(0), res.(0) with
       | {loc = Stack s1}, {loc = Stack s2} when s1 <> s2 ->

--- a/asmcomp/emitaux.ml
+++ b/asmcomp/emitaux.ml
@@ -407,6 +407,7 @@ let report_error ppf = function
       Format.fprintf ppf "stack frame too large (%d bytes)" n
 
 let mk_env f : Emitenv.per_function_env =
+  let open Emitenv in
   {
     f;
     stack_offset = 0;
@@ -430,6 +431,7 @@ type preproc_stack_check_result =
 
 let preproc_stack_check ~fun_body ~frame_size ~trap_size =
   let rec loop (i:Linear.instruction) fs max_fs nontail_flag =
+    let open Linear in
     match i.desc with
       | Lend -> { max_frame_size = max_fs;
                   contains_nontail_calls = nontail_flag}
@@ -441,10 +443,10 @@ let preproc_stack_check ~fun_body ~frame_size ~trap_size =
         loop i.next s (max s max_fs) nontail_flag
       | Lpoptrap ->
         loop i.next (fs - trap_size) max_fs nontail_flag
-      | Lop (Istackoffset n) ->
+      | Lop (Mach.Istackoffset n) ->
         let s = fs + n in
         loop i.next s (max s max_fs) nontail_flag
-      | Lop (Icall_ind | Icall_imm _ ) ->
+      | Lop (Mach.Icall_ind | Mach.Icall_imm _ ) ->
         loop i.next fs max_fs true
       | Lprologue | Lop _ | Lreloadretaddr | Lreturn | Llabel _
       | Lbranch _ | Lcondbranch _ | Lcondbranch3 _ | Lswitch _

--- a/asmcomp/i386/emit.mlp
+++ b/asmcomp/i386/emit.mlp
@@ -597,10 +597,10 @@ let emit_instr env fallthrough i =
   | Lop(Ialloc { bytes = n; dbginfo }) ->
       if env.f.fun_fast then begin
         load_domain_state ebx;
-        I.mov (domain_field Domain_young_ptr RBX) eax;
+        I.mov (domain_field Domainstate.Domain_young_ptr RBX) eax;
         I.sub (int n) eax;
-        I.mov eax (domain_field Domain_young_ptr RBX);
-        I.cmp (domain_field Domain_young_limit RBX) eax;
+        I.mov eax (domain_field Domainstate.Domain_young_ptr RBX);
+        I.cmp (domain_field Domainstate.Domain_young_limit RBX) eax;
         let lbl_call_gc = new_label() in
         let lbl_frame =
           record_frame_label env i.live (Dbg_alloc dbginfo) in
@@ -858,14 +858,14 @@ let emit_instr env fallthrough i =
       if trap_frame_size > 8 then
         I.sub (int (trap_frame_size - 8)) esp;
       load_domain_state edx;
-      I.push (domain_field Domain_exn_handler RDX);
+      I.push (domain_field Domainstate.Domain_exn_handler RDX);
       cfi_adjust_cfa_offset trap_frame_size;
-      I.mov esp (domain_field Domain_exn_handler RDX);
+      I.mov esp (domain_field Domainstate.Domain_exn_handler RDX);
       env.stack_offset <- env.stack_offset + trap_frame_size
   | Lpoptrap ->
       I.mov edx (mem32 DWORD 4 RSP);
       load_domain_state edx;
-      I.pop (domain_field Domain_exn_handler RDX);
+      I.pop (domain_field Domainstate.Domain_exn_handler RDX);
       I.pop edx;
       if trap_frame_size > 8 then
         I.add (int (trap_frame_size - 8)) esp;
@@ -875,16 +875,15 @@ let emit_instr env fallthrough i =
       begin match k with
       | Lambda.Raise_regular ->
           load_domain_state ebx;
-          I.mov (int 0) (domain_field Domain_backtrace_pos RBX);
+          I.mov (int 0) (domain_field Domainstate.Domain_backtrace_pos RBX);
           emit_call "caml_raise_exn";
           record_frame env Reg.Set.empty (Dbg_raise i.dbg)
       | Lambda.Raise_reraise ->
           emit_call "caml_raise_exn";
           record_frame env Reg.Set.empty (Dbg_raise i.dbg)
       | Lambda.Raise_notrace ->
-          load_domain_state ebx;
-          I.mov (domain_field Domain_exn_handler RBX) esp;
-          I.pop (domain_field Domain_exn_handler RBX);
+          load_domain_state ebx;          I.mov (domain_field Domainstate.Domain_exn_handler RBX) esp;
+          I.pop (domain_field Domainstate.Domain_exn_handler RBX);
           if trap_frame_size > 8 then
             I.add (int (trap_frame_size - 8)) esp;
           I.pop ebx;

--- a/asmcomp/polling.ml
+++ b/asmcomp/polling.ml
@@ -279,12 +279,12 @@ let instrument_fundecl ~future_funcnames:_ (f : Mach.fundecl) : Mach.fundecl =
     contains_polls := false;
     let new_body = instr_body handler_needs_poll f.fun_body in
     begin match f.fun_poll with
-    | Error_poll -> begin
+    | Lambda.Error_poll -> begin
         match find_poll_alloc_or_calls new_body with
         | [] -> ()
         | poll_error_instrs -> raise (Error(Poll_error poll_error_instrs))
       end
-    | Default_poll -> () end;
+    | Lambda.Default_poll -> () end;
     let new_contains_calls = f.fun_contains_calls || !contains_polls in
     { f with fun_body = new_body; fun_contains_calls = new_contains_calls }
   end

--- a/asmcomp/printmach.ml
+++ b/asmcomp/printmach.ml
@@ -106,6 +106,7 @@ let test tst ppf arg =
 
 let operation op arg ppf res =
   if Array.length res > 0 then fprintf ppf "%a := " regs res;
+  let open Asttypes in
   match op with
   | Imove -> regs ppf arg
   | Ispill -> fprintf ppf "%a (spill)" regs arg

--- a/asmcomp/schedgen.ml
+++ b/asmcomp/schedgen.ml
@@ -139,7 +139,7 @@ let some_load =
   Iload {
     memory_chunk = Cmm.Word_int;
     addressing_mode = Arch.identity_addressing;
-    mutability = Mutable;
+    mutability = Asttypes.Mutable;
     is_atomic = false }
 
 (* The generic scheduler *)

--- a/asmcomp/selectgen.ml
+++ b/asmcomp/selectgen.ml
@@ -732,6 +732,7 @@ method emit_expr (env:environment) exp =
               let bytes = size_expr env (Ctuple new_args) in
               assert (bytes mod Arch.size_addr = 0);
               let alloc_words = bytes / Arch.size_addr in
+              let open Debuginfo in
               let op =
                 Ialloc { bytes; dbginfo = [{alloc_words; alloc_dbg = dbg}] }
               in
@@ -864,7 +865,7 @@ method private bind_let_mut (env:environment) v k r1 =
   let rv = self#regs_for k in
   name_regs v rv;
   self#insert_moves env r1 rv;
-  env_add ~mut:Mutable v rv env
+  env_add ~mut:Asttypes.Mutable v rv env
 
 (* The following two functions, [emit_parts] and [emit_parts_list], force
    right-to-left evaluation order as required by the Flambda [Un_anf] pass

--- a/asmcomp/x86_proc.ml
+++ b/asmcomp/x86_proc.ml
@@ -230,7 +230,7 @@ let string_of_rounding = function
 let internal_assembler = ref None
 let register_internal_assembler f = internal_assembler := Some f
 let with_internal_assembler assemble k =
-  Misc.protect_refs [ R (internal_assembler, Some assemble) ] k
+  Misc.protect_refs [ Misc.R (internal_assembler, Some assemble) ] k
 
 (* Which asm conventions to use *)
 let masm =

--- a/boot/menhir/parser.ml
+++ b/boot/menhir/parser.ml
@@ -593,7 +593,7 @@ let lapply ~loc p1 p2 =
 let loc_map (f : 'a -> 'b) (x : 'a Location.loc) : 'b Location.loc =
   { x with txt = f x.txt }
 
-let make_ghost x = { x with loc = { x.loc with loc_ghost = true }}
+let make_ghost x = { x with loc = { x.loc with Location.loc_ghost = true }}
 
 let loc_last (id : Longident.t Location.loc) : string Location.loc =
   loc_map Longident.last id

--- a/driver/compile.ml
+++ b/driver/compile.ml
@@ -61,6 +61,7 @@ let implementation ~start_from ~source_file ~output_prefix =
   in
   with_info ~source_file ~output_prefix ~dump_ext:"cmo" @@ fun info ->
   match (start_from : Clflags.Compiler_pass.t) with
-  | Parsing -> Compile_common.implementation info ~backend
+  | Clflags.Compiler_pass.Parsing ->
+    Compile_common.implementation info ~backend
   | _ -> Misc.fatal_errorf "Cannot start from %s"
            (Clflags.Compiler_pass.to_string start_from)

--- a/driver/compile_common.ml
+++ b/driver/compile_common.ml
@@ -67,7 +67,7 @@ let typecheck_intf info ast =
         Format.(fprintf std_formatter) "%a@."
           (Printtyp.printed_signature info.source_file)
           sg);
-  ignore (Includemod.signatures info.env ~mark:Mark_both sg sg);
+  ignore (Includemod.signatures info.env ~mark:Includemod.Mark_both sg sg);
   Typecore.force_delayed_checks ();
   Warnings.check_fatal ();
   tsg

--- a/driver/maindriver.ml
+++ b/driver/maindriver.ml
@@ -25,7 +25,7 @@ let main argv ppf =
     ["-depend", Arg.Unit Makedepend.main_from_option,
      "<options> Compute dependencies (use 'ocamlc -depend -help' for details)"];
   match
-    Compenv.readenv ppf Before_args;
+    Compenv.readenv ppf Compenv.Before_args;
     Compenv.parse_arguments (ref argv) Compenv.anonymous program;
     Compmisc.read_clflags_from_env ();
     if !Clflags.plugin then
@@ -44,7 +44,7 @@ let main argv ppf =
         exit 2
       end
     end;
-    Compenv.readenv ppf Before_link;
+    Compenv.readenv ppf Compenv.Before_link;
     if
       List.length
         (List.filter (fun x -> !x)

--- a/driver/makedepend.ml
+++ b/driver/makedepend.ml
@@ -403,7 +403,7 @@ let mli_file_dependencies source_file =
   files := (source_file, MLI, extracted_deps, !Depend.pp_deps) :: !files
 
 let process_file_as process_fun def source_file =
-  Compenv.readenv ppf (Before_compile source_file);
+  Compenv.readenv ppf (Compenv.Before_compile source_file);
   load_path := [];
   let cwd = if !nocwd then [] else [Filename.current_dir_name] in
   List.iter add_to_load_path (
@@ -588,7 +588,7 @@ let run_main argv =
   let add_dep_arg f s = dep_args_rev := (f s) :: !dep_args_rev in
   Clflags.classic := false;
   try
-    Compenv.readenv ppf Before_args;
+    Compenv.readenv ppf Compenv.Before_args;
     Clflags.reset_arguments (); (* reset arguments from ocamlc/ocamlopt *)
     Clflags.add_arguments __LOC__ [
       "-absname", Arg.Set Clflags.absname,
@@ -656,7 +656,7 @@ let run_main argv =
     Compenv.parse_arguments (ref argv)
       (add_dep_arg (fun f -> Src (f, None))) program;
     process_dep_args (List.rev !dep_args_rev);
-    Compenv.readenv ppf Before_link;
+    Compenv.readenv ppf Compenv.Before_link;
     if !sort_files then sort_files_by_dependencies !files
     else List.iter print_file_dependencies (List.sort compare !files);
     (if Error_occurred.get () then 2 else 0)

--- a/driver/optcompile.ml
+++ b/driver/optcompile.ml
@@ -96,7 +96,8 @@ let implementation ~backend ~start_from ~source_file ~output_prefix =
     else clambda info backend typed
   in
   with_info ~source_file ~output_prefix ~dump_ext:"cmx" @@ fun info ->
-  match (start_from:Clflags.Compiler_pass.t) with
+  let open Clflags.Compiler_pass in
+  match start_from with
   | Parsing -> Compile_common.implementation info ~backend
   | Emit -> emit info
   | _ -> Misc.fatal_errorf "Cannot start from %s"

--- a/driver/optmaindriver.ml
+++ b/driver/optmaindriver.ml
@@ -39,7 +39,7 @@ let main argv ppf =
   native_code := true;
   let program = "ocamlopt" in
   match
-    Compenv.readenv ppf Before_args;
+    Compenv.readenv ppf Compenv.Before_args;
     Clflags.add_arguments __LOC__ (Arch.command_line_options @ Options.list);
     Clflags.add_arguments __LOC__
       ["-depend", Arg.Unit Makedepend.main_from_option,
@@ -63,7 +63,7 @@ let main argv ppf =
         exit 2
       end
     end;
-    Compenv.readenv ppf Before_link;
+    Compenv.readenv ppf Compenv.Before_link;
     if
       List.length (List.filter (fun x -> !x)
                      [make_package; make_archive; shared;

--- a/lambda/lambda.ml
+++ b/lambda/lambda.ml
@@ -356,6 +356,8 @@ type program =
     required_globals : Ident.Set.t;
     code : lambda }
 
+let loc_unknown = Debuginfo.Scoped_location.Loc_unknown
+
 let const_int n = Const_base (Const_int n)
 
 let const_unit = const_int 0
@@ -414,7 +416,7 @@ let make_key e =
     | Lapply ap ->
         Lapply {ap with ap_func = tr_rec env ap.ap_func;
                         ap_args = tr_recs env ap.ap_args;
-                        ap_loc = Loc_unknown}
+                        ap_loc = loc_unknown}
     | Llet (Alias,_k,x,ex,e) -> (* Ignore aliases -> substitute *)
         let ex = tr_rec env ex in
         tr_rec (Ident.add x ex env) e
@@ -430,7 +432,7 @@ let make_key e =
         let y = make_key x in
         Lmutlet (k,y,ex,tr_rec (Ident.add x (Lmutvar y) env) e)
     | Lprim (p,es,_) ->
-        Lprim (p,tr_recs env es, Loc_unknown)
+        Lprim (p,tr_recs env es, loc_unknown)
     | Lswitch (e,sw,loc) ->
         Lswitch (tr_rec env e,tr_sw env sw,loc)
     | Lstringswitch (e,sw,d,_) ->
@@ -438,7 +440,7 @@ let make_key e =
           (tr_rec env e,
            List.map (fun (s,e) -> s,tr_rec env e) sw,
            tr_opt env d,
-          Loc_unknown)
+          loc_unknown)
     | Lstaticraise (i,es) ->
         Lstaticraise (i,tr_recs env es)
     | Lstaticcatch (e1,xs,e2) ->
@@ -452,7 +454,7 @@ let make_key e =
     | Lassign (x,e) ->
         Lassign (x,tr_rec env e)
     | Lsend (m,e1,e2,es,_loc) ->
-        Lsend (m,tr_rec env e1,tr_rec env e2,tr_recs env es,Loc_unknown)
+        Lsend (m,tr_rec env e1,tr_rec env e2,tr_recs env es,loc_unknown)
     | Lifused (id,e) -> Lifused (id,tr_rec env e)
     | Lletrec _|Lfunction _
     | Lfor _ | Lwhile _
@@ -697,7 +699,7 @@ let transl_prim mod_name name =
   let env = Env.add_persistent_structure pers Env.empty in
   let lid = Longident.Ldot (Longident.Lident mod_name, name) in
   match Env.find_value_by_name lid env with
-  | path, _ -> transl_value_path Loc_unknown env path
+  | path, _ -> transl_value_path loc_unknown env path
   | exception Not_found ->
       fatal_error ("Primitive " ^ name ^ " not found.")
 

--- a/lambda/matching.ml
+++ b/lambda/matching.ml
@@ -98,6 +98,8 @@ open Printpat
 
 module Scoped_location = Debuginfo.Scoped_location
 
+let loc_unknown = Scoped_location.Loc_unknown
+
 let dbg = false
 
 (*
@@ -532,7 +534,7 @@ end = struct
 
   let empty = []
 
-  let start n : t = [ { left = []; right = Patterns.omegas n } ]
+  let start n : t = [ { Row.left = []; Row.right = Patterns.omegas n } ]
 
   let is_empty = function
     | [] -> true
@@ -1186,7 +1188,7 @@ let rec omega_like p =
 
 let simple_omega_like p =
   match (Simple.head p).pat_desc with
-  | Any -> true
+  | Patterns.Head.Any -> true
   | _ -> false
 
 let equiv_pat p q = le_pat p q && le_pat q p
@@ -1872,7 +1874,7 @@ let get_mod_field modname field =
          match Env.find_value_by_name (Longident.Lident field) env with
          | exception Not_found ->
              fatal_error ("Primitive " ^ modname ^ "." ^ field ^ " not found.")
-         | path, _ -> transl_value_path Loc_unknown env path
+         | path, _ -> transl_value_path loc_unknown env path
        ))
 
 let code_force_lazy_block = get_mod_field "CamlinternalLazy" "force_lazy_block"
@@ -2340,12 +2342,12 @@ module SArg = struct
   type test = Lambda.lambda
   type act = Lambda.lambda
 
-  let make_prim p args = Lprim (p, args, Loc_unknown)
+  let make_prim p args = Lprim (p, args, loc_unknown)
 
   let make_offset arg n =
     match n with
     | 0 -> arg
-    | _ -> Lprim (Poffsetint n, [ arg ], Loc_unknown)
+    | _ -> Lprim (Poffsetint n, [ arg ], loc_unknown)
 
   let bind arg body =
     let newvar, newarg =
@@ -2359,15 +2361,15 @@ module SArg = struct
 
   let make_const i = Lconst (Const_base (Const_int i))
 
-  let make_isout h arg = Lprim (Pisout, [ h; arg ], Loc_unknown)
+  let make_isout h arg = Lprim (Pisout, [ h; arg ], loc_unknown)
 
-  let make_isin h arg = Lprim (Pnot, [ make_isout h arg ], Loc_unknown)
+  let make_isin h arg = Lprim (Pnot, [ make_isout h arg ], loc_unknown)
 
   let make_is_nonzero arg =
     if !Clflags.native_code then
       Lprim (Pintcomp Cne,
              [arg; Lconst (Const_base (Const_int 0))],
-             Loc_unknown)
+             loc_unknown)
     else
       arg
 
@@ -3437,7 +3439,7 @@ type failer_kind =
 let failure_handler ~scopes loc ~failer () =
   match failer with
   | Reraise_noloc exn_lam ->
-    Lprim (Praise Raise_reraise, [ exn_lam ], Scoped_location.Loc_unknown)
+    Lprim (Praise Raise_reraise, [ exn_lam ], loc_unknown)
   | Raise_match_failure ->
     let sloc = Scoped_location.of_location ~scopes loc in
     let slot =

--- a/lambda/printlambda.ml
+++ b/lambda/printlambda.ml
@@ -680,12 +680,14 @@ let rec lam ppf = function
          the end-user goal when using -dno-locations), as it strongly
          reduces the nesting level of subterms. *)
       if not !Clflags.locations then lam ppf expr
-      else begin match ev.lev_loc with
+      else begin
+      let open Debuginfo.Scoped_location in
+      match ev.lev_loc with
       | Loc_unknown ->
         fprintf ppf "@[<2>(%s <unknown location>@ %a)@]" kind lam expr
       | Loc_known {scopes; loc} ->
         fprintf ppf "@[<2>(%s %s %s(%i)%s:%i-%i@ %a)@]" kind
-                (Debuginfo.Scoped_location.string_of_scopes scopes)
+                (string_of_scopes scopes)
                 loc.Location.loc_start.Lexing.pos_fname
                 loc.Location.loc_start.Lexing.pos_lnum
                 (if loc.Location.loc_ghost then "<ghost>" else "")

--- a/lambda/tmc.ml
+++ b/lambda/tmc.ml
@@ -124,14 +124,16 @@ end = struct
 
   let tmc_placeholder =
     (* we choose a placeholder whose tagged representation will be
-       reconizable. *)
-    Lconst (Const_base (Const_int (0xBBBB / 2)))
+       recognizable. *)
+    Lconst (Const_base (Asttypes.Const_int (0xBBBB / 2)))
 
   let with_placeholder constr (body : offset destination -> lambda) =
     let k_with_placeholder =
-      apply { constr with flag = Mutable } tmc_placeholder in
+      apply { constr with flag = Asttypes.Mutable } tmc_placeholder in
     let placeholder_pos = List.length constr.before in
-    let placeholder_pos_lam = Lconst (Const_base (Const_int placeholder_pos)) in
+    let placeholder_pos_lam =
+      Lconst (Const_base (Asttypes.Const_int placeholder_pos))
+    in
     let block_var = Ident.create_local "block" in
     Llet (Strict, Pgenval, block_var, k_with_placeholder,
           body {
@@ -731,7 +733,7 @@ let rec choice ctx t =
         in
         { apply with ap_tailcall } in
       { (Choice.lambda (Lapply apply)) with
-        direct = (fun () -> Lapply apply_no_bailout);
+        Choice.direct = (fun () -> Lapply apply_no_bailout);
       }
 
   and choice_makeblock ctx ~tail:_ (tag, flag, shape) blockargs loc =
@@ -781,7 +783,7 @@ let rec choice ctx t =
           Choice.dps = Dps.make (fun ~tail:_ ~dst:_ ->
             let arguments =
               let info (t : lambda Choice.t) : subterm_information = {
-                tmc_calls = t.tmc_calls;
+                tmc_calls = t.Choice.tmc_calls;
               } in
               {
                 explicit;
@@ -801,6 +803,7 @@ let rec choice ctx t =
             after;
             loc;
         } in
+        let open Choice in
         assert (choice.tmc_calls <> []);
         {
           Choice.direct = (fun () ->

--- a/lambda/translcore.ml
+++ b/lambda/translcore.ml
@@ -785,7 +785,7 @@ and transl_curried_function
         begin match partial with
         | Total ->
           Location.prerr_warning pat.pat_loc
-            Match_on_mutable_state_prevent_uncurry
+            Warnings.Match_on_mutable_state_prevent_uncurry
         | Partial -> ()
         end;
         transl_tupled_function ~scopes ~arity

--- a/lambda/translobj.ml
+++ b/lambda/translobj.ml
@@ -16,6 +16,8 @@
 open Asttypes
 open Lambda
 
+let loc_unknown = Debuginfo.Scoped_location.Loc_unknown
+
 (* Get oo primitives identifiers *)
 
 let oo_prim = Lambda.transl_prim "CamlinternalOO"
@@ -117,7 +119,7 @@ let transl_label_init_flambda f =
       Llet (Strict, Pgenval, method_cache_id,
         Lprim (Pccall prim_makearray,
                [int !method_count; int 0],
-               Loc_unknown),
+               loc_unknown),
         expr)
   in
   transl_label_init_general (fun () -> expr, size)
@@ -127,19 +129,19 @@ let transl_store_label_init glob size f arg =
   assert(!Clflags.native_code);
   method_cache := Lprim(Pfield (size, Pointer, Mutable),
                         (* XXX KC: conservative *)
-                        [Lprim(Pgetglobal glob, [], Loc_unknown)],
-                        Loc_unknown);
+                        [Lprim(Pgetglobal glob, [], loc_unknown)],
+                        loc_unknown);
   let expr = f arg in
   let (size, expr) =
     if !method_count = 0 then (size, expr) else
     (size+1,
      Lsequence(
      Lprim(Psetfield(size, Pointer, Root_initialization),
-           [Lprim(Pgetglobal glob, [], Loc_unknown);
+           [Lprim(Pgetglobal glob, [], loc_unknown);
             Lprim (Pccall prim_makearray,
                    [int !method_count; int 0],
-                   Loc_unknown)],
-           Loc_unknown),
+                   loc_unknown)],
+           loc_unknown),
      expr))
   in
   let lam, size = transl_label_init_general (fun () -> (expr, size)) in
@@ -181,7 +183,7 @@ let oo_wrap env req f x =
                 Llet(StrictOpt, Pgenval, id,
                      Lprim(Pmakeblock(0, Mutable, None),
                            [lambda_unit; lambda_unit; lambda_unit],
-                           Loc_unknown),
+                           loc_unknown),
                      lambda))
              lambda !classes
          in

--- a/otherlibs/dynlink/Makefile
+++ b/otherlibs/dynlink/Makefile
@@ -29,7 +29,7 @@ OCAMLOPT=$(BEST_OCAMLOPT) $(STDLIBFLAGS) -g
 
 # COMPFLAGS should be in sync with the toplevel Makefile's COMPFLAGS.
 COMPFLAGS=-strict-sequence -principal -absname \
-          -w +a-4-9-41-42-44-45-48-66 -warn-error +A-40 \
+          -w +a-4-9-41-42-44-45-48-66 -warn-error +A \
           -bin-annot -safe-string -strict-formats
 ifeq "$(FLAMBDA)" "true"
 OPTCOMPFLAGS += -O3

--- a/otherlibs/dynlink/Makefile
+++ b/otherlibs/dynlink/Makefile
@@ -29,7 +29,7 @@ OCAMLOPT=$(BEST_OCAMLOPT) $(STDLIBFLAGS) -g
 
 # COMPFLAGS should be in sync with the toplevel Makefile's COMPFLAGS.
 COMPFLAGS=-strict-sequence -principal -absname \
-          -w +a-4-9-40-41-42-44-45-48-66 -warn-error +A \
+          -w +a-4-9-41-42-44-45-48-66 -warn-error +A-40 \
           -bin-annot -safe-string -strict-formats
 ifeq "$(FLAMBDA)" "true"
 OPTCOMPFLAGS += -O3

--- a/parsing/parser.mly
+++ b/parsing/parser.mly
@@ -386,7 +386,7 @@ let lapply ~loc p1 p2 =
 let loc_map (f : 'a -> 'b) (x : 'a Location.loc) : 'b Location.loc =
   { x with txt = f x.txt }
 
-let make_ghost x = { x with loc = { x.loc with loc_ghost = true }}
+let make_ghost x = { x with loc = { x.loc with Location.loc_ghost = true }}
 
 let loc_last (id : Longident.t Location.loc) : string Location.loc =
   loc_map Longident.last id

--- a/toplevel/byte/topeval.ml
+++ b/toplevel/byte/topeval.ml
@@ -47,7 +47,7 @@ module EvalBase = struct
     if Ident.persistent id || Ident.global id then begin
       try
         Symtable.get_global_value id
-      with Symtable.Error (Undefined_global name) ->
+      with Symtable.Error (Symtable.Undefined_global name) ->
         raise (Undefined_global name)
     end else begin
       let name = Translmod.toplevel_name id in
@@ -125,7 +125,8 @@ let execute_phrase print_outcome ppf phr =
       in
       if !Clflags.dump_typedtree then Printtyped.implementation ppf str;
       let sg' = Typemod.Signature_names.simplify newenv sn sg in
-      ignore (Includemod.signatures ~mark:Mark_positive oldenv sg sg');
+      ignore
+        (Includemod.signatures ~mark:Includemod.Mark_positive oldenv sg sg');
       Typecore.force_delayed_checks ();
       let shape = Shape.local_reduce shape in
       if !Clflags.dump_shape then Shape.print ppf shape;

--- a/toplevel/byte/topmain.ml
+++ b/toplevel/byte/topmain.ml
@@ -28,6 +28,7 @@ let dir_trace ppf lid =
   match Env.find_value_by_name lid !Topcommon.toplevel_env with
   | (path, desc) -> begin
       (* Check if this is a primitive *)
+      let open Types in
       match desc.val_kind with
       | Val_prim _ ->
           Format.fprintf ppf
@@ -94,7 +95,9 @@ let dir_untrace_all ppf () =
     !traced_functions;
   traced_functions := []
 
-let _ = Topcommon.add_directive "trace"
+let _ =
+  let open Topcommon in
+  add_directive "trace"
     (Directive_ident (dir_trace Format.std_formatter))
     {
       section = Topdirs.section_trace;
@@ -102,14 +105,18 @@ let _ = Topcommon.add_directive "trace"
           named function-name will be traced.";
     }
 
-let _ = Topcommon.add_directive "untrace"
+let _ =
+  let open Topcommon in
+  add_directive "untrace"
     (Directive_ident (dir_untrace Format.std_formatter))
     {
       section = Topdirs.section_trace;
       doc = "Stop tracing the given function.";
     }
 
-let _ = Topcommon.add_directive "untrace_all"
+let _ =
+  let open Topcommon in
+  add_directive "untrace_all"
     (Directive_none (dir_untrace_all Format.std_formatter))
     {
       section = Topdirs.section_trace;
@@ -176,7 +183,7 @@ let input_argument name =
       let newargs = Array.sub !argv !current
                               (Array.length !argv - !current)
       in
-      Compenv.readenv ppf Before_link;
+      Compenv.readenv ppf Compenv.Before_link;
       Compmisc.read_clflags_from_env ();
       if prepare ppf && Toploop.run_script ppf name newargs
       then raise (Compenv.Exit_with_status 0)
@@ -207,12 +214,12 @@ let main () =
     Array.length !argv >= 2 && Topcommon.is_command_like_name !argv.(1)
   in
   Topcommon.update_search_path_from_env ();
-  Compenv.readenv ppf Before_args;
+  Compenv.readenv ppf Compenv.Before_args;
   if display_deprecated_script_alert then
     Location.deprecated_script_alert program;
   Clflags.add_arguments __LOC__ Options.list;
   Compenv.parse_arguments ~current argv file_argument program;
-  Compenv.readenv ppf Before_link;
+  Compenv.readenv ppf Compenv.Before_link;
   Compmisc.read_clflags_from_env ();
   if not (prepare ppf) then raise (Compenv.Exit_with_status 2);
   Compmisc.init_path ();

--- a/toplevel/native/topeval.ml
+++ b/toplevel/native/topeval.ml
@@ -52,10 +52,11 @@ let close_phrase lam =
   let open Lambda in
   Ident.Set.fold (fun id l ->
     let glb, pos = toplevel_value id in
+    let loc_unknown = Debuginfo.Scoped_location.Loc_unknown in
     let glob =
-      Lprim (Pfield (pos, Pointer, Mutable),
-             [Lprim (Pgetglobal glb, [], Loc_unknown)],
-             Loc_unknown)
+      Lprim (Pfield (pos, Pointer, Asttypes.Mutable),
+             [Lprim (Pgetglobal glb, [], loc_unknown)],
+             loc_unknown)
     in
     Llet(Strict, Pgenval, id, glob, l)
   ) (free_variables lam) lam
@@ -141,7 +142,7 @@ let name_expression ~loc ~attrs exp =
        vb_loc = loc; }
    in
    let item =
-     { str_desc = Tstr_value(Nonrecursive, [vb]);
+     { str_desc = Tstr_value(Asttypes.Nonrecursive, [vb]);
        str_loc = loc;
        str_env = exp.exp_env; }
    in
@@ -166,7 +167,8 @@ let execute_phrase print_outcome ppf phr =
       in
       if !Clflags.dump_typedtree then Printtyped.implementation ppf str;
       let sg' = Typemod.Signature_names.simplify newenv names sg in
-      ignore (Includemod.signatures oldenv ~mark:Mark_positive sg sg');
+      ignore
+        (Includemod.signatures oldenv ~mark:Includemod.Mark_positive sg sg');
       Typecore.force_delayed_checks ();
       let shape = Shape.local_reduce shape in
       if !Clflags.dump_shape then Shape.print ppf shape;

--- a/toplevel/native/topmain.ml
+++ b/toplevel/native/topmain.ml
@@ -100,7 +100,7 @@ let main () =
     Array.length !argv >= 2 && Topcommon.is_command_like_name !argv.(1)
   in
   Topcommon.update_search_path_from_env ();
-  Compenv.readenv ppf Before_args;
+  Compenv.readenv ppf Compenv.Before_args;
   if display_deprecated_script_alert then
     Location.deprecated_script_alert program;
   Clflags.add_arguments __LOC__ Options.list;

--- a/toplevel/topdirs.ml
+++ b/toplevel/topdirs.ml
@@ -425,10 +425,11 @@ let is_nonrec_type id td =
           nonrecursive_use:= true
     | _ -> ()
   in
-  let it =  Btype.{type_iterators with it_path } in
+  let open Btype in
+  let it = {type_iterators with it_path } in
   let () =
     it.it_type_declaration it td;
-    Btype.unmark_iterators.it_type_declaration Btype.unmark_iterators td
+    unmark_iterators.it_type_declaration unmark_iterators td
   in
   match !recursive_use, !nonrecursive_use with
   | false, true -> Trec_not
@@ -440,7 +441,7 @@ let () =
     (fun env loc id lid ->
        let path, desc = Env.lookup_type ~loc lid env in
        let id, rs = match path with
-         | Pident id -> id, is_nonrec_type id desc
+         | Path.Pident id -> id, is_nonrec_type id desc
          | _ -> id, Trec_first
        in
        [ Sig_type (id, desc, rs, Exported) ]
@@ -527,12 +528,13 @@ let is_rec_module id md =
     | Path.Pident id' -> if (Ident.same id id') then raise Exit
     | _ -> ()
   in
-  let it =  Btype.{type_iterators with it_path } in
+  let open Btype in
+  let it = {type_iterators with it_path } in
   let rs = match it.it_module_declaration it md with
     | () -> Trec_not
     | exception Exit -> Trec_first
   in
-  Btype.unmark_iterators.it_module_declaration Btype.unmark_iterators md;
+  unmark_iterators.it_module_declaration unmark_iterators md;
   rs
 
 
@@ -541,7 +543,7 @@ let () =
     (fun env loc id lid ->
        let path, md = Env.lookup_module ~loc lid env in
        let id = match path with
-         | Pident id -> id
+         | Path.Pident id -> id
          | _ -> id
        in
        let rec accum_aliases md acc =

--- a/toplevel/toploop.ml
+++ b/toplevel/toploop.ml
@@ -34,8 +34,8 @@ let use_lexbuf ppf ~wrap_in_module lb name filename =
   (* Skip initial #! line if any *)
   Lexer.skip_hash_bang lb;
   Misc.protect_refs
-    [ R (Location.input_name, filename);
-      R (Location.input_lexbuf, Some lb); ]
+    [ Misc.R (Location.input_name, filename);
+      Misc.R (Location.input_lexbuf, Some lb); ]
     (fun () ->
     try
       List.iter
@@ -101,7 +101,7 @@ let use_file ppf name =
 
 let use_silently ppf name =
   Misc.protect_refs
-    [ R (use_print_results, false) ]
+    [ Misc.R (use_print_results, false) ]
     (fun () -> use_input ppf name)
 
 let load_file = load_file false

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -1183,7 +1183,7 @@ let new_local_type ?(loc = Location.none) ?manifest_and_scope () =
     type_expansion_scope = expansion_scope;
     type_loc = loc;
     type_attributes = [];
-    type_immediate = Unknown;
+    type_immediate = Type_immediacy.Unknown;
     type_unboxed_default = false;
     type_uid = Uid.mk ~current_unit:(Env.get_unit_name ());
   }

--- a/typing/datarepr.ml
+++ b/typing/datarepr.ml
@@ -82,7 +82,7 @@ let constructor_args ~current_unit priv cd_args cd_res path rep =
           type_expansion_scope = Btype.lowest_level;
           type_loc = Location.none;
           type_attributes = [];
-          type_immediate = Unknown;
+          type_immediate = Type_immediacy.Unknown;
           type_unboxed_default = false;
           type_uid = Uid.mk ~current_unit;
         }

--- a/typing/envaux.ml
+++ b/typing/envaux.ml
@@ -49,10 +49,10 @@ let rec env_from_summary sum subst =
             (env_from_summary s subst)
       | Env_module(s, id, pres, desc) ->
           Env.add_module_declaration ~check:false id pres
-            (Subst.module_declaration Keep subst desc)
+            (Subst.module_declaration Subst.Keep subst desc)
             (env_from_summary s subst)
       | Env_modtype(s, id, desc) ->
-          Env.add_modtype id (Subst.modtype_declaration Keep subst desc)
+          Env.add_modtype id (Subst.modtype_declaration Subst.Keep subst desc)
                           (env_from_summary s subst)
       | Env_class(s, id, desc) ->
           Env.add_class id (Subst.class_declaration subst desc)
@@ -71,7 +71,7 @@ let rec env_from_summary sum subst =
       | Env_functor_arg(Env_module(s, id, pres, desc), id')
             when Ident.same id id' ->
           Env.add_module_declaration ~check:false
-            id pres (Subst.module_declaration Keep subst desc)
+            id pres (Subst.module_declaration Subst.Keep subst desc)
             ~arg:true (env_from_summary s subst)
       | Env_functor_arg _ -> assert false
       | Env_constraints(s, map) ->

--- a/typing/mtype.ml
+++ b/typing/mtype.ml
@@ -33,11 +33,12 @@ let rec scrape_lazy env mty =
 let scrape env mty =
   match mty with
     Mty_ident p ->
-     Subst.Lazy.force_modtype (scrape_lazy env (MtyL_ident p))
+     Subst.Lazy.force_modtype (scrape_lazy env (Subst.Lazy.MtyL_ident p))
   | _ -> mty
 
 let freshen ~scope mty =
-  Subst.modtype (Rescope scope) Subst.identity mty
+  let open Subst in
+  modtype (Rescope scope) identity mty
 
 let rec strengthen_lazy ~aliasable env mty p =
   let open Subst.Lazy in

--- a/typing/oprint.ml
+++ b/typing/oprint.ml
@@ -676,6 +676,7 @@ and print_out_type_decl kwd ppf td =
   | Asttypes.Public -> ()
   in
   let print_immediate ppf =
+    let open Type_immediacy in
     match td.otype_immediate with
     | Unknown -> ()
     | Always -> fprintf ppf " [%@%@immediate]"

--- a/typing/parmatch.ml
+++ b/typing/parmatch.ml
@@ -1179,7 +1179,7 @@ let rec list_satisfying_vectors pss qs =
                   in
                   if full_match false constrs then for_constrs () else
                   begin match p.pat_desc with
-                  | Construct _ ->
+                  | Patterns.Head.Construct _ ->
                       (* activate this code
                          for checking non-gadt constructors *)
                       wild default (build_other_constrs constrs p)
@@ -1435,7 +1435,7 @@ let rec pressure_variants tdefs = function
               | _, None -> ()
               | (d, _) :: _, Some env ->
                 match d.pat_desc with
-                | Variant { type_row; _ } ->
+                | Patterns.Head.Variant { type_row; _ } ->
                   let row = type_row () in
                   if Btype.has_fixed_explanation row
                   || pressure_variants None default then ()

--- a/typing/predef.ml
+++ b/typing/predef.ml
@@ -177,7 +177,7 @@ let build_initial_env add_type add_extension empty_env =
        type_is_newtype = false;
        type_expansion_scope = lowest_level;
        type_attributes = [];
-       type_immediate = Unknown;
+       type_immediate = Type_immediacy.Unknown;
        type_unboxed_default = false;
        type_uid = Uid.of_predef_id type_ident;
       }
@@ -205,14 +205,14 @@ let build_initial_env add_type add_extension empty_env =
        ~variance:Variance.full
        ~separability:Separability.Ind
   |> add_type ident_bool
-       ~immediate:Always
+       ~immediate:Type_immediacy.Always
        ~kind:(variant [cstr ident_false []; cstr ident_true []])
-  |> add_type ident_char ~immediate:Always
+  |> add_type ident_char ~immediate:Type_immediacy.Always
   |> add_type ident_exn ~kind:Type_open
   |> add_type ident_extension_constructor
   |> add_type ident_float
   |> add_type ident_floatarray
-  |> add_type ident_int ~immediate:Always
+  |> add_type ident_int ~immediate:Type_immediacy.Always
   |> add_type ident_int32
   |> add_type ident_int64
   |> add_type1 ident_lazy_t
@@ -232,7 +232,7 @@ let build_initial_env add_type add_extension empty_env =
   |> add_type ident_string
   |> add_type ident_bytes
   |> add_type ident_unit
-       ~immediate:Always
+       ~immediate:Type_immediacy.Always
        ~kind:(variant [cstr ident_void []])
   (* Predefined exceptions - alphabetical order *)
   |> add_extension ident_assert_failure

--- a/typing/shape.ml
+++ b/typing/shape.ml
@@ -456,10 +456,12 @@ let local_reduce shape =
 let dummy_mod = { uid = None; desc = Struct Item.Map.empty }
 
 let of_path ~find_shape ~namespace =
-  let rec aux : Sig_component_kind.t -> Path.t -> t = fun ns -> function
-    | Pident id -> find_shape ns id
-    | Pdot (path, name) -> proj (aux Module path) (name, ns)
-    | Papply (p1, p2) -> app (aux Module p1) ~arg:(aux Module p2)
+  let module SigCompKind = Sig_component_kind in
+  let rec aux : SigCompKind.t -> Path.t -> t = fun ns -> function
+    | Path.Pident id -> find_shape ns id
+    | Path.Pdot (path, name) -> proj (aux SigCompKind.Module path) (name, ns)
+    | Path.Papply (p1, p2) ->
+      app (aux SigCompKind.Module p1) ~arg:(aux SigCompKind.Module p2)
   in
   aux namespace
 

--- a/typing/signature_group.ml
+++ b/typing/signature_group.ml
@@ -109,9 +109,9 @@ let update_rec_next rs rem =
   | Types.Trec_next -> rem
   | Types.(Trec_first | Trec_not) ->
       match rem with
-      | Types.Sig_type (id, decl, Trec_next, priv) :: rem ->
+      | Types.Sig_type (id, decl, Types.Trec_next, priv) :: rem ->
           Types.Sig_type (id, decl, rs, priv) :: rem
-      | Types.Sig_module (id, pres, mty, Trec_next, priv) :: rem ->
+      | Types.Sig_module (id, pres, mty, Types.Trec_next, priv) :: rem ->
           Types.Sig_module (id, pres, mty, rs, priv) :: rem
       | _ -> rem
 

--- a/typing/subst.ml
+++ b/typing/subst.ml
@@ -632,7 +632,7 @@ and force_modtype_decl mtd =
 
 and subst_lazy_signature scoping s sg =
   match Lazy_backtrack.get_contents sg with
-  | Left (scoping', s', sg) ->
+  | Either.Left (scoping', s', sg) ->
      let scoping =
        match scoping', scoping with
        | sc, Keep -> sc
@@ -640,7 +640,7 @@ and subst_lazy_signature scoping s sg =
      in
      let s = compose s' s in
      Lazy_backtrack.create (scoping, s, sg)
-  | Right sg ->
+  | Either.Right sg ->
      Lazy_backtrack.create (scoping, s, sg)
 
 and force_signature sg =

--- a/typing/typeclass.ml
+++ b/typing/typeclass.ml
@@ -443,13 +443,13 @@ let class_type env virt self_scope scty =
 (*******************************)
 
 let enter_ancestor_val name val_env =
-  Env.enter_unbound_value name Val_unbound_ancestor val_env
+  Env.enter_unbound_value name Env.Val_unbound_ancestor val_env
 
 let enter_self_val name val_env =
-  Env.enter_unbound_value name Val_unbound_self val_env
+  Env.enter_unbound_value name Env.Val_unbound_self val_env
 
 let enter_instance_var_val name val_env =
-  Env.enter_unbound_value name Val_unbound_instance_variable val_env
+  Env.enter_unbound_value name Env.Val_unbound_instance_variable val_env
 
 let enter_ancestor_met ~loc name ~sign ~meths ~cl_num ~ty ~attrs met_env =
   let check s = Warnings.Unused_ancestor s in
@@ -1445,7 +1445,7 @@ let temp_abbrev loc env id arity uid =
        type_expansion_scope = Btype.lowest_level;
        type_loc = loc;
        type_attributes = []; (* or keep attrs from the class decl? *)
-       type_immediate = Unknown;
+       type_immediate = Type_immediacy.Unknown;
        type_unboxed_default = false;
        type_uid = uid;
       }
@@ -1680,7 +1680,7 @@ let class_infos define_class kind
      type_expansion_scope = Btype.lowest_level;
      type_loc = cl.pci_loc;
      type_attributes = []; (* or keep attrs from cl? *)
-     type_immediate = Unknown;
+     type_immediate = Type_immediacy.Unknown;
      type_unboxed_default = false;
      type_uid = dummy_class.cty_uid;
     }
@@ -1703,7 +1703,7 @@ let class_infos define_class kind
      type_expansion_scope = Btype.lowest_level;
      type_loc = cl.pci_loc;
      type_attributes = []; (* or keep attrs from cl? *)
-     type_immediate = Unknown;
+     type_immediate = Type_immediacy.Unknown;
      type_unboxed_default = false;
      type_uid = dummy_class.cty_uid;
     }
@@ -2007,9 +2007,9 @@ let report_error env ppf = function
       Printtyp.prepare_for_printing [abbrev; actual; expected];
       fprintf ppf "@[The abbreviation@ %a@ expands to type@ %a@ \
        but is used with type@ %a@]"
-        !Oprint.out_type (Printtyp.tree_of_typexp Type abbrev)
-        !Oprint.out_type (Printtyp.tree_of_typexp Type actual)
-        !Oprint.out_type (Printtyp.tree_of_typexp Type expected)
+        !Oprint.out_type (Printtyp.tree_of_typexp Printtyp.Type abbrev)
+        !Oprint.out_type (Printtyp.tree_of_typexp Printtyp.Type actual)
+        !Oprint.out_type (Printtyp.tree_of_typexp Printtyp.Type expected)
   | Constructor_type_mismatch (c, err) ->
       Printtyp.report_unification_error ppf env err
         (function ppf ->
@@ -2052,10 +2052,10 @@ let report_error env ppf = function
         "@[The abbreviation %a@ is used with parameters@ %a@ \
            which are incompatible with constraints@ %a@]"
         Printtyp.ident id
-        !Oprint.out_type (Printtyp.tree_of_typexp Type params)
-        !Oprint.out_type (Printtyp.tree_of_typexp Type cstrs)
+        !Oprint.out_type (Printtyp.tree_of_typexp Printtyp.Type params)
+        !Oprint.out_type (Printtyp.tree_of_typexp Printtyp.Type cstrs)
   | Class_match_failure error ->
-      Includeclass.report_error Type ppf error
+      Includeclass.report_error Printtyp.Type ppf error
   | Unbound_val lab ->
       fprintf ppf "Unbound instance variable %s" lab
   | Unbound_type_var (printer, reason) ->
@@ -2066,8 +2066,8 @@ let report_error env ppf = function
         fprintf ppf
           "The method %s@ has type@;<1 2>%a@ where@ %a@ is unbound"
           lab
-          !Oprint.out_type (Printtyp.tree_of_typexp Type ty)
-          !Oprint.out_type (Printtyp.tree_of_typexp Type ty0)
+          !Oprint.out_type (Printtyp.tree_of_typexp Printtyp.Type ty)
+          !Oprint.out_type (Printtyp.tree_of_typexp Printtyp.Type ty0)
       in
       fprintf ppf
         "@[<v>@[Some type variables are unbound in this type:@;<1 2>%t@]@ \

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -117,7 +117,7 @@ let enter_type rec_flag env sdecl (id, uid) =
       type_expansion_scope = Btype.lowest_level;
       type_loc = sdecl.ptype_loc;
       type_attributes = sdecl.ptype_attributes;
-      type_immediate = Unknown;
+      type_immediate = Type_immediacy.Unknown;
       type_unboxed_default = false;
       type_uid = uid;
     }
@@ -447,7 +447,7 @@ let transl_declaration env sdecl (id, uid) =
         type_expansion_scope = Btype.lowest_level;
         type_loc = sdecl.ptype_loc;
         type_attributes = sdecl.ptype_attributes;
-        type_immediate = Unknown;
+        type_immediate = Type_immediacy.Unknown;
         type_unboxed_default = unboxed_default;
         type_uid = uid;
       } in
@@ -1004,7 +1004,7 @@ let transl_extension_constructor ~scope env type_path type_params
         in
         let cdescr = Env.lookup_constructor ~loc:lid.loc usage lid.txt env in
         let (args, cstr_res, _ex) =
-          Ctype.instance_constructor Keep_existentials_flexible cdescr
+          Ctype.instance_constructor Ctype.Keep_existentials_flexible cdescr
         in
         let res, ret_type =
           if cdescr.cstr_generalized then
@@ -1515,7 +1515,7 @@ let transl_with_constraint id ?fixed_row_path ~sig_env ~sig_decl ~outer_env
       type_expansion_scope = Btype.lowest_level;
       type_loc = loc;
       type_attributes = sdecl.ptype_attributes;
-      type_immediate = Unknown;
+      type_immediate = Type_immediacy.Unknown;
       type_unboxed_default;
       type_uid = Uid.mk ~current_unit:(Env.get_unit_name ());
     }
@@ -1594,7 +1594,7 @@ let abstract_type_decl ~injective arity =
       type_expansion_scope = Btype.lowest_level;
       type_loc = Location.none;
       type_attributes = [];
-      type_immediate = Unknown;
+      type_immediate = Type_immediacy.Unknown;
       type_unboxed_default = false;
       type_uid = Uid.internal_not_actually_unique;
      } in
@@ -1723,8 +1723,8 @@ let report_error ppf = function
              All uses need to match the definition for the recursive type \
              to be regular.@]"
             (Path.name definition)
-            !Oprint.out_type (Printtyp.tree_of_typexp Type defined_as)
-            !Oprint.out_type (Printtyp.tree_of_typexp Type used_as)
+            !Oprint.out_type (Printtyp.tree_of_typexp Printtyp.Type defined_as)
+            !Oprint.out_type (Printtyp.tree_of_typexp Printtyp.Type used_as)
       | _ :: _ ->
           fprintf ppf
             "@[<hv>This recursive type is not regular.@ \
@@ -1734,8 +1734,8 @@ let report_error ppf = function
              All uses need to match the definition for the recursive type \
              to be regular.@]"
             (Path.name definition)
-            !Oprint.out_type (Printtyp.tree_of_typexp Type defined_as)
-            !Oprint.out_type (Printtyp.tree_of_typexp Type used_as)
+            !Oprint.out_type (Printtyp.tree_of_typexp Printtyp.Type defined_as)
+            !Oprint.out_type (Printtyp.tree_of_typexp Printtyp.Type used_as)
             pp_expansions expansions
       end
   | Inconsistent_constraint (env, err) ->
@@ -1825,6 +1825,7 @@ let report_error ppf = function
         | false, true  -> inj ^ "contravariant"
         | false, false -> if inj = "" then "unrestricted" else inj
       in
+      let open Typedecl_variance in
       (match n with
        | Variance_not_reflected ->
            fprintf ppf "@[%s@ %s@ It"

--- a/typing/typedecl_separability.ml
+++ b/typing/typedecl_separability.ml
@@ -473,6 +473,7 @@ let worst_msig decl = List.map (fun _ -> Deepsep) decl.type_params
     Note: this differs from {!Types.Separability.default_signature},
     which does not have access to the declaration and its immediacy. *)
 let msig_of_external_type decl =
+  let open Type_immediacy in
   match decl.type_immediate with
   | Always | Always_on_64bits -> best_msig decl
   | Unknown -> worst_msig decl

--- a/utils/clflags.ml
+++ b/utils/clflags.ml
@@ -521,7 +521,7 @@ module Compiler_pass = struct
 
   let of_input_filename name =
     match Compiler_ir.extract_extension_with_pass name with
-    | Some (Linear, _) -> Some Emit
+    | Some (Compiler_ir.Linear, _) -> Some Emit
     | None -> None
 end
 

--- a/utils/diffing.ml
+++ b/utils/diffing.ml
@@ -238,9 +238,10 @@ end
 *)
 
 let select_final_state m0 =
+  let module M = Matrix in
   let maybe_final i j =
-    match Matrix.shape_at m0 i j with
-    | Some shape_here -> shape_here.l = i && shape_here.c = j
+    match M.shape_at m0 i j with
+    | Some shape_here -> shape_here.M.l = i && shape_here.M.c = j
     | None -> false
   in
   let best_state (i0,j0,weigth0) (i,j) =
@@ -249,8 +250,8 @@ let select_final_state m0 =
   in
   let res = ref (0,0,max_int) in
   let shape = Matrix.shape m0 in
-  for i = 0 to shape.l do
-    for j = 0 to shape.c do
+  for i = 0 to shape.M.l do
+    for j = 0 to shape.M.c do
       if maybe_final i j then
         res := best_state !res (i,j)
     done
@@ -367,15 +368,16 @@ let compute_cell  m i j =
    and repeat the process
 *)
 let compute_matrix state0 =
-  let m0 = Matrix.make { l = 0 ; c = 0 } in
-  Matrix.set m0 0 0 ~weight:0 ~state:state0 ~diff:None;
+  let module M = Matrix in
+  let m0 = M.make { M.l = 0 ; c = 0 } in
+  M.set m0 0 0 ~weight:0 ~state:state0 ~diff:None;
   let rec loop m =
-    let shape = Matrix.shape m in
-    let new_shape = Matrix.real_shape m in
-    if new_shape.l > shape.l || new_shape.c > shape.c then
-      let m = Matrix.reshape new_shape m in
-      for i = 0 to new_shape.l do
-        for j = 0 to new_shape.c do
+    let shape = M.shape m in
+    let new_shape = M.real_shape m in
+    if new_shape.M.l > shape.M.l || new_shape.M.c > shape.M.c then
+      let m = M.reshape new_shape m in
+      for i = 0 to new_shape.M.l do
+        for j = 0 to new_shape.M.c do
           compute_cell m i j
         done
       done;

--- a/utils/warnings.ml
+++ b/utils/warnings.ml
@@ -687,7 +687,8 @@ type token =
   | Num of int * int * modifier
 
 let ghost_loc_in_file name =
-  let pos = { Lexing.dummy_pos with pos_fname = name } in
+  let open Lexing in
+  let pos = { dummy_pos with pos_fname = name } in
   { loc_start = pos; loc_end = pos; loc_ghost = true }
 
 let letter_alert tokens =


### PR DESCRIPTION
This PR enables warning 40 (name-out-of-scope), makes sure building
the compiler does not trigger it and finally turns it into an error.

It's in the same vein as #11498 and is expected to be that last PR
of this kind, at least for the time being.