### PR TITLE
Introduce run-time checks that the domain lock is held

### DIFF
--- a/Changes
+++ b/Changes
@@ -264,12 +264,15 @@ OCaml 5.0
   Guillaume Munch-Maccagnoni, additional discussions with Stephen
   Dolan and Luc Maranget)
 
-- #5299, #4787, #11138, #11272: `Caml_state` is `NULL` when the domain lock is
-  not held. This allows to test if the current thread holds the lock of its
-  domain, and it makes it simpler to debug when one forgets to acquire
-  the lock.
-  (Guillaume Munch-Maccagnoni, review by Sadiq Jaffer, Xavier Leroy and
-  Gabriel Scherer)
+- #5299, #4787, #11138, #11272, #11506: To help debugging, `Caml_state`
+  now dynamically checks that the domain lock is held, and fails
+  otherwise (with a fatal error at most entry points of the C API, or
+  systematically in debug mode). A new variable `Caml_state_opt` is
+  introduced, and is `NULL` when the domain lock is not held. This
+  allows to test from C code if the current thread holds the lock of
+  its domain.
+  (Guillaume Munch-Maccagnoni, review by Florian Angeletti, Damien
+  Doligez, Sadiq Jaffer, Xavier Leroy, and Gabriel Scherer)
 
 - #11223: The serialization format of custom blocks changed in 4.08,
   but the deserializer would still support the pre-4.08 format.  OCaml

--- a/manual/src/cmds/intf-c.etex
+++ b/manual/src/cmds/intf-c.etex
@@ -2500,9 +2500,15 @@ CAMLprim stub_gethostbyname(value vname)
 }
 \end{verbatim}
 
-During the time the domain lock is released, the thread-local variable
-"Caml_state" is set to "NULL". This can be used to determine if the
-thread currently holds its domain lock.
+The macro "Caml_state" evaluates to the domain state variable, and
+checks in debug mode that the domain lock is held. Such a check is
+also placed in normal mode at key entry points of the C API; this is
+why calling some of the runtime functions and macros without correctly
+owning the domain lock can result in a fatal error: "no domain lock
+held". The variant "Caml_state_opt" does not perform any check but
+evaluates to "NULL" when the domain lock is not held. This lets you
+determine whether a thread belonging to a domain currently holds its
+domain lock, for various purposes.
 
 Callbacks from C to OCaml must be performed while holding the master
 lock to the OCaml run-time system.  This is naturally the case if the

--- a/otherlibs/systhreads/st_stubs.c
+++ b/otherlibs/systhreads/st_stubs.c
@@ -622,7 +622,7 @@ CAMLexport int caml_c_thread_register(void)
   /* Already registered? */
   if (st_tls_get(caml_thread_key) != NULL) return 0;
 
-  CAMLassert(Caml_state == NULL);
+  CAMLassert(Caml_state_opt == NULL);
   caml_init_domain_self(Dom_c_threads);
 
   /* Take master lock to protect access to the runtime */

--- a/runtime/alloc.c
+++ b/runtime/alloc.c
@@ -41,6 +41,7 @@ CAMLexport value caml_alloc (mlsize_t wosize, tag_t tag)
     if (wosize == 0){
       result = Atom (tag);
     }else{
+      Caml_check_caml_state();
       Alloc_small (result, wosize, tag, Alloc_small_enter_GC);
       if (tag < No_scan_tag){
         for (i = 0; i < wosize; i++) Field (result, i) = Val_unit;
@@ -58,6 +59,7 @@ CAMLexport value caml_alloc (mlsize_t wosize, tag_t tag)
 
 Caml_inline value do_alloc_small(mlsize_t wosize, tag_t tag, value* vals)
 {
+  Caml_check_caml_state();
   value v;
   mlsize_t i;
   CAMLassert (tag < 256);
@@ -181,6 +183,7 @@ CAMLexport value caml_alloc_string (mlsize_t len)
   mlsize_t wosize = (len + sizeof (value)) / sizeof (value);
 
   if (wosize <= Max_young_wosize) {
+    Caml_check_caml_state();
     Alloc_small (result, wosize, String_tag, Alloc_small_enter_GC);
   }else{
     result = caml_alloc_shr (wosize, String_tag);
@@ -244,6 +247,7 @@ CAMLexport value caml_alloc_array(value (*funct)(char const *),
 value caml_alloc_float_array(mlsize_t len)
 {
 #ifdef FLAT_FLOAT_ARRAY
+  Caml_check_caml_state();
   mlsize_t wosize = len * Double_wosize;
   value result;
   /* For consistency with [caml_make_vect], which can't tell whether it should

--- a/runtime/callback.c
+++ b/runtime/callback.c
@@ -152,6 +152,7 @@ callback_stub caml_callback_asm, caml_callback2_asm, caml_callback3_asm;
 
 CAMLexport value caml_callback_exn(value closure, value arg)
 {
+  Caml_check_caml_state();
   caml_domain_state* domain_state = Caml_state;
   caml_maybe_expand_stack();
 
@@ -172,6 +173,7 @@ CAMLexport value caml_callback_exn(value closure, value arg)
 
 CAMLexport value caml_callback2_exn(value closure, value arg1, value arg2)
 {
+  Caml_check_caml_state();
   value args[] = {arg1, arg2};
   caml_domain_state* domain_state = Caml_state;
   caml_maybe_expand_stack();
@@ -194,6 +196,7 @@ CAMLexport value caml_callback2_exn(value closure, value arg1, value arg2)
 CAMLexport value caml_callback3_exn(value closure,
                                     value arg1, value arg2, value arg3)
 {
+  Caml_check_caml_state();
   value args[] = {arg1, arg2, arg3};
   caml_domain_state* domain_state = Caml_state;
   caml_maybe_expand_stack();

--- a/runtime/caml/domain_state.h
+++ b/runtime/caml/domain_state.h
@@ -68,7 +68,17 @@ CAML_STATIC_ASSERT(
 
 #define Caml_state (CAMLassert(Caml_state_opt != NULL), Caml_state_opt)
 
+CAMLnoreturn_start
+CAMLextern void caml_bad_caml_state(void)
+CAMLnoreturn_end;
 
+/* This check is performed regardless of debug mode. It is placed once
+   at every code path starting from entry points of the public C API,
+   whenever the load of Caml_state_opt can be eliminated by CSE (or if
+   the function is not performance-sensitive). */
+#define Caml_check_caml_state()                                         \
+  (CAMLlikely(Caml_state_opt != NULL) ? (void)0 :                       \
+   caml_bad_caml_state())
 
 #define Caml_state_field(field) (Caml_state->field)
 

--- a/runtime/caml/domain_state.h
+++ b/runtime/caml/domain_state.h
@@ -55,16 +55,20 @@ CAML_STATIC_ASSERT(
   CAMLextern pthread_key_t caml_domain_state_key;
   CAMLextern void caml_init_domain_state_key(void);
   #define CAML_INIT_DOMAIN_STATE caml_init_domain_state_key()
-  #define Caml_state \
+  #define Caml_state_opt \
       ((caml_domain_state*) pthread_getspecific(caml_domain_state_key))
   #define SET_Caml_state(x) \
       (pthread_setspecific(caml_domain_state_key, x))
 #else
   CAMLextern __thread caml_domain_state* caml_state;
-  #define Caml_state caml_state
+  #define Caml_state_opt caml_state
   #define CAML_INIT_DOMAIN_STATE
-  #define SET_Caml_state(x) (Caml_state = (x))
+  #define SET_Caml_state(x) (caml_state = (x))
 #endif
+
+#define Caml_state (CAMLassert(Caml_state_opt != NULL), Caml_state_opt)
+
+
 
 #define Caml_state_field(field) (Caml_state->field)
 

--- a/runtime/caml/memory.h
+++ b/runtime/caml/memory.h
@@ -237,6 +237,14 @@ struct caml__roots_block {
 
 #define CAML_LOCAL_ROOTS (Caml_state->local_roots)
 
+/* Emit a call to `Caml_check_caml_state`, but only for user
+   programs. */
+#ifdef CAML_INTERNALS
+#define DO_CHECK_CAML_STATE 0
+#else
+#define DO_CHECK_CAML_STATE 1
+#endif
+
 /* The following macros are used to declare C local variables and
    function parameters of type [value].
 
@@ -268,8 +276,10 @@ struct caml__roots_block {
    union tags, macros, etc.)
 */
 
-#define CAMLparam0() \
-  struct caml__roots_block** caml_local_roots_ptr = &CAML_LOCAL_ROOTS;\
+#define CAMLparam0()                                                    \
+  struct caml__roots_block** caml_local_roots_ptr =                     \
+    (DO_CHECK_CAML_STATE ? Caml_check_caml_state() : (void)0,           \
+     &CAML_LOCAL_ROOTS);                                                \
   struct caml__roots_block *caml__frame = *caml_local_roots_ptr
 
 #define CAMLparam1(x) \

--- a/runtime/caml/misc.h
+++ b/runtime/caml/misc.h
@@ -242,7 +242,7 @@ typedef char char_os;
 #endif
 
 #define CAMLassert(x) \
-  ((x) ? (void) 0 : caml_failed_assert ( #x , __OSFILE__, __LINE__))
+  (CAMLlikely(x) ? (void) 0 : caml_failed_assert ( #x , __OSFILE__, __LINE__))
 CAMLnoreturn_start
 CAMLextern void caml_failed_assert (char *, char_os *, int)
 CAMLnoreturn_end;
@@ -250,15 +250,15 @@ CAMLnoreturn_end;
 #define CAMLassert(x) ((void) 0)
 #endif
 
-#ifdef CAML_INTERNALS
-
 #ifdef __GNUC__
-#define CAMLlikely(e)   __builtin_expect((e), 1)
-#define CAMLunlikely(e) __builtin_expect((e), 0)
+#define CAMLlikely(e)   __builtin_expect(!!(e), 1)
+#define CAMLunlikely(e) __builtin_expect(!!(e), 0)
 #else
 #define CAMLlikely(e) (e)
 #define CAMLunlikely(e) (e)
 #endif
+
+#ifdef CAML_INTERNALS
 
 /* GC status assertions.
 

--- a/runtime/extern.c
+++ b/runtime/extern.c
@@ -118,6 +118,7 @@ struct caml_extern_state {
 
 static struct caml_extern_state* get_extern_state (void)
 {
+  Caml_check_caml_state();
   struct caml_extern_state* extern_state;
 
   if (Caml_state->extern_state != NULL)

--- a/runtime/fail_byt.c
+++ b/runtime/fail_byt.c
@@ -33,6 +33,7 @@
 
 CAMLexport void caml_raise(value v)
 {
+  Caml_check_caml_state();
   Unlock_exn();
   CAMLassert(!Is_exception_result(v));
 

--- a/runtime/fail_nat.c
+++ b/runtime/fail_nat.c
@@ -60,6 +60,7 @@ CAMLnoreturn_end;
 
 void caml_raise(value v)
 {
+  Caml_check_caml_state();
   char* exception_pointer;
 
   Unlock_exn();

--- a/runtime/floats.c
+++ b/runtime/floats.c
@@ -151,6 +151,7 @@ void caml_free_locale(void)
 
 CAMLexport value caml_copy_double(double d)
 {
+  Caml_check_caml_state();
   value res;
 
   Alloc_small(res, Double_wosize, Double_tag, Alloc_small_enter_GC);

--- a/runtime/gc_ctrl.c
+++ b/runtime/gc_ctrl.c
@@ -229,6 +229,7 @@ CAMLprim value caml_gc_set(value v)
 
 CAMLprim value caml_gc_minor(value v)
 {
+  Caml_check_caml_state();
   CAML_EV_BEGIN(EV_EXPLICIT_GC_MINOR);
   CAMLassert (v == Val_unit);
   caml_minor_collection ();
@@ -250,6 +251,7 @@ static value gc_major_exn(void)
 
 CAMLprim value caml_gc_major(value v)
 {
+  Caml_check_caml_state();
   CAMLassert (v == Val_unit);
   return caml_raise_if_exception(gc_major_exn());
 }
@@ -275,6 +277,7 @@ static value gc_full_major_exn(void)
 
 CAMLprim value caml_gc_full_major(value v)
 {
+  Caml_check_caml_state();
   CAMLassert (v == Val_unit);
   return caml_raise_if_exception(gc_full_major_exn());
 }
@@ -291,6 +294,7 @@ CAMLprim value caml_gc_major_slice (value v)
 
 CAMLprim value caml_gc_compaction(value v)
 {
+  Caml_check_caml_state();
   value exn = Val_unit;
   CAML_EV_BEGIN(EV_EXPLICIT_GC_COMPACT);
   CAMLassert (v == Val_unit);

--- a/runtime/globroots.c
+++ b/runtime/globroots.c
@@ -94,6 +94,7 @@ static enum gc_root_class classify_gc_root(value v)
 
 CAMLexport void caml_register_generational_global_root(value *r)
 {
+  Caml_check_caml_state();
   CAMLassert (((intnat) r & 3) == 0);  /* compact.c demands this (for now) */
 
   switch(classify_gc_root(*r)) {

--- a/runtime/intern.c
+++ b/runtime/intern.c
@@ -88,6 +88,7 @@ struct caml_intern_state {
 /* Allocates the domain local intern state if needed */
 static struct caml_intern_state* get_intern_state (void)
 {
+  Caml_check_caml_state();
   struct caml_intern_state* s;
 
   if (Caml_state->intern_state != NULL)

--- a/runtime/memory.c
+++ b/runtime/memory.c
@@ -330,6 +330,7 @@ CAMLexport void caml_set_fields (value obj, value v)
 
 Caml_inline value alloc_shr(mlsize_t wosize, tag_t tag, int noexc)
 {
+  Caml_check_caml_state();
   caml_domain_state *dom_st = Caml_state;
   value *v = caml_shared_try_alloc(dom_st->shared_heap, wosize, tag, 0);
   if (v == NULL) {

--- a/runtime/misc.c
+++ b/runtime/misc.c
@@ -241,3 +241,8 @@ int caml_runtime_warnings_active(void)
   }
   return 1;
 }
+
+void caml_bad_caml_state(void)
+{
+  caml_fatal_error("no domain lock held");
+}

--- a/runtime/misc.c
+++ b/runtime/misc.c
@@ -50,7 +50,7 @@ void caml_failed_assert (char * expr, char_os * file_os, int line)
 {
   char* file = caml_stat_strdup_of_os(file_os);
   fprintf(stderr, "[%02d] file %s; line %d ### Assertion failed: %s\n",
-          Caml_state ? Caml_state->id : -1, file, line, expr);
+          (Caml_state_opt != NULL) ? Caml_state->id : -1, file, line, expr);
   fflush(stderr);
   caml_stat_free(file);
   abort();
@@ -80,7 +80,8 @@ void caml_gc_log (char *msg, ...)
     char fmtbuf[512];
     va_list args;
     va_start (args, msg);
-    sprintf(fmtbuf, "[%02d] %s\n", Caml_state ? Caml_state->id : -1, msg);
+    sprintf(fmtbuf, "[%02d] %s\n",
+            (Caml_state_opt != NULL) ? Caml_state->id : -1, msg);
     vfprintf(stderr, fmtbuf, args);
     va_end (args);
     fflush(stderr);

--- a/runtime/printexc.c
+++ b/runtime/printexc.c
@@ -51,6 +51,7 @@ static void add_string(struct stringbuf *buf, const char *s)
 
 CAMLexport char * caml_format_exception(value exn)
 {
+  Caml_check_caml_state();
   mlsize_t start, i;
   value bucket, v;
   struct stringbuf buf;

--- a/runtime/signals.c
+++ b/runtime/signals.c
@@ -166,6 +166,7 @@ CAMLexport void caml_leave_blocking_section(void)
   /* Save the value of errno (PR#5982). */
   saved_errno = errno;
   caml_leave_blocking_section_hook ();
+  Caml_check_caml_state();
 
   /* Some other thread may have switched [Caml_state->action_pending]
      to 0 even though there are still pending actions, e.g. a signal
@@ -286,6 +287,7 @@ void caml_set_action_pending(caml_domain_state * dom_st)
 
 CAMLexport int caml_check_pending_actions(void)
 {
+  Caml_check_caml_state();
   return Caml_check_gc_interrupt(Caml_state) || Caml_state->action_pending;
 }
 

--- a/runtime/startup_aux.c
+++ b/runtime/startup_aux.c
@@ -152,6 +152,7 @@ static void call_registered_value(char* name)
 
 CAMLexport void caml_shutdown(void)
 {
+  Caml_check_caml_state();
   if (startup_count <= 0)
     caml_fatal_error("a call to caml_shutdown has no "
                      "corresponding call to caml_startup");

--- a/testsuite/tests/c-api/test_c_thread_has_lock_cstubs.c
+++ b/testsuite/tests/c-api/test_c_thread_has_lock_cstubs.c
@@ -4,14 +4,14 @@
 
 value with_lock(value unit)
 {
-  return Val_bool(Caml_state != NULL);
+  return Val_bool(Caml_state_opt != NULL);
 }
 
 value without_lock(value unit)
 {
   int res;
   caml_enter_blocking_section();
-  res = (Caml_state != NULL);
+  res = (Caml_state_opt != NULL);
   caml_leave_blocking_section();
   return Val_bool(res);
 }


### PR DESCRIPTION
Following #11485, this PR makes it simpler to find out why the user's program crashes when the domain lock is incorrectly acquired from C code.

- Add an assertion that `Caml_state` is not `NULL` (in debug mode)
- Add a check in public entry points of the C API (always)

For instance, when calling `CAMLparam()` without the domain lock, instead of a segfault, one gets a fatal error with message `f: no domain lock held` where `f` is the name of the function.

cc @gasche