### PR TITLE
fix #11508: Bytes.escaped is memory-unsafe in presence of concurrent updates

### DIFF
--- a/Changes
+++ b/Changes
@@ -584,6 +584,11 @@ OCaml 5.0
   mingw-w64 i686 port.
   (David Allsopp, review by Xavier Leroy and Sébastien Hinderer)
 
+- #11508, #11509: make Bytes.escaped domain-safe
+  (Christiano Haesbaert and Gabriel Scherer,
+   review by Xavier Leroy,
+   report by Jan Midtgaard and Tom Kelly)
+
 OCaml 4.14.0 (28 March 2022)
 ----------------------------
 

--- a/stdlib/bytes.ml
+++ b/stdlib/bytes.ml
@@ -167,7 +167,20 @@ let trim s =
   else
     empty
 
-let escaped s =
+let unsafe_escape s =
+  (* We perform two passes on the input sequence, one to compute the
+     result size and one to write the result.
+
+     #11508, #11509: This logic would be incorrect in presence of
+     concurrent modification to the input, making the use of
+     [unsafe_set] below memory-unsafe.
+
+     Precondition: This function may be safely called on:
+     - an immutable byte sequence
+     - a uniquely-owned byte sequence (the function takes ownership)
+
+     In either case we return a uniquely-owned byte sequence.
+  *)
   let n = ref 0 in
   for i = 0 to length s - 1 do
     n := !n +
@@ -176,7 +189,8 @@ let escaped s =
        | ' ' .. '~' -> 1
        | _ -> 4)
   done;
-  if !n = length s then copy s else begin
+  if !n = length s then s
+  else begin
     let s' = create !n in
     n := 0;
     for i = 0 to length s - 1 do
@@ -206,6 +220,12 @@ let escaped s =
     done;
     s'
   end
+
+let escaped b =
+  let b = copy b in
+  (* We copy our input to obtain a uniquely-owned byte sequence [b]
+     to satisfy [unsafe_escape]'s precondition *)
+  unsafe_escape b
 
 let map f s =
   let l = length s in

--- a/stdlib/bytes.mli
+++ b/stdlib/bytes.mli
@@ -753,3 +753,5 @@ external unsafe_blit_string :
   = "caml_blit_string" [@@noalloc]
 external unsafe_fill :
   bytes -> int -> int -> char -> unit = "caml_fill_bytes" [@@noalloc]
+
+val unsafe_escape : bytes -> bytes

--- a/stdlib/bytesLabels.mli
+++ b/stdlib/bytesLabels.mli
@@ -753,3 +753,5 @@ external unsafe_blit_string :
   = "caml_blit_string" [@@noalloc]
 external unsafe_fill :
   bytes -> pos:int -> len:int -> char -> unit = "caml_fill_bytes" [@@noalloc]
+
+val unsafe_escape : bytes -> bytes

--- a/stdlib/string.ml
+++ b/stdlib/string.ml
@@ -105,14 +105,10 @@ let trim s =
   else s
 
 let escaped s =
-  let rec escape_if_needed s n i =
-    if i >= n then s else
-      match unsafe_get s i with
-      | '\"' | '\\' | '\000'..'\031' | '\127'.. '\255' ->
-          bts (B.escaped (bos s))
-      | _ -> escape_if_needed s n (i+1)
-  in
-  escape_if_needed s (length s) 0
+  let b = bos s in
+  (* We satisfy [unsafe_escape]'s precondition by passing an
+     immutable byte sequence [b]. *)
+  bts (B.unsafe_escape b)
 
 (* duplicated in bytes.ml *)
 let rec index_rec s lim i c =


### PR DESCRIPTION
Fix for #11508 