### PR TITLE
Fix two undefined usages of `caml_secure_getenv`

### DIFF
--- a/runtime/runtime_events.c
+++ b/runtime/runtime_events.c
@@ -119,6 +119,11 @@ static void runtime_events_create_raw();
 void caml_runtime_events_init() {
   runtime_events_path = caml_secure_getenv(T("OCAML_RUNTIME_EVENTS_DIR"));
 
+  if (runtime_events_path) {
+    /* caml_secure_getenv's return shouldn't be cached */
+    runtime_events_path = caml_stat_strdup_os(runtime_events_path);
+  }
+
   ring_size_words = 1 << caml_params->runtime_events_log_wsize;
 
   preserve_ring =

--- a/runtime/startup_aux.c
+++ b/runtime/startup_aux.c
@@ -85,10 +85,9 @@ static void scanmult (char_os *opt, uintnat *var)
 
 void caml_parse_ocamlrunparam(void)
 {
-  char_os *opt = caml_secure_getenv (T("OCAMLRUNPARAM"));
-
   init_startup_params();
 
+  char_os *opt = caml_secure_getenv (T("OCAMLRUNPARAM"));
   if (opt == NULL) opt = caml_secure_getenv (T("CAMLRUNPARAM"));
 
   if (opt != NULL){


### PR DESCRIPTION
`getenv` is one of those somewhat strange historical functions which is allowed to return a buffer which may change following a subsequent call to `getenv`.

There are two places which have started doing this - the introduction of `init_startup_params` to `caml_parse_ocamlrunparam` caused the value of `OCAMLRUNPARAM` to be used possibly after `CAML_DEBUG_FILE` has been read (fixed just by moving the call) and the value of `OCAML_RUNTIME_EVENTS_DIR` is cached in a new global variable (fixed by `caml_stat_strdup_os`ing the value).

As both of these changes were in 5.0, I don't think a Changes entry is necessary.