### PR TITLE
error messages: use de Bruijn indices for identifier disambiguation

### DIFF
--- a/Changes
+++ b/Changes
@@ -230,6 +230,10 @@ Working version
   and defining explicitly composition.
   (Jacques Garrigue, review by Gabriel Scherer)
 
+- #11286, #11515: disambiguate identifiers by using how recently they have
+  been bound in the current environment
+  (Florian Angeletti, review by Gabriel Scherer)
+
 - #11364: Allow `make -C testsuite promote` to take `TEST` and `LIST` variables
   (Antal Spector-Zabusky, review by Gabriel Scherer and David Allsopp)
 

--- a/testsuite/tests/generalized-open/gpr1506.ml
+++ b/testsuite/tests/generalized-open/gpr1506.ml
@@ -12,7 +12,7 @@ module M = struct
     type t = B of t * t' | C
 end
 [%%expect{|
-module M : sig type t = B of t/1 * t/2 | C end
+module M : sig type t = B of t * t/2 | C end
 |}]
 
 (* test *)

--- a/testsuite/tests/tool-toplevel/known-bugs/broken_rec_in_show.ml
+++ b/testsuite/tests/tool-toplevel/known-bugs/broken_rec_in_show.ml
@@ -54,8 +54,8 @@ type t = X of u | Y of [ f | `B ]  and u = Y of t;;
 [%%expect{|
 type t
 type f = [ `A of t ]
-type t = X of u | Y of [ `A of t/1 | `B ]
-and u = Y of t/2
+type t = X of u | Y of [ `A of t/2 | `B ]
+and u = Y of t
 |}];;
 
 #show t;;

--- a/testsuite/tests/tool-toplevel/redefinition_hints.compilers.reference
+++ b/testsuite/tests/tool-toplevel/redefinition_hints.compilers.reference
@@ -14,7 +14,7 @@ val y : (u * v * (module S)) M.t = M.X (A, B, <module>)
 Line 2, characters 4-5:
 2 | x = y;;
         ^
-Error: This expression has type (u/1 * v/1 * (module S/1)) M/1.t
+Error: This expression has type (u * v * (module S)) M.t
        but an expression was expected of type
          (u/2 * v/2 * (module S/2)) M/2.t
        Hint: The types v and u have been defined multiple times in this
@@ -30,11 +30,27 @@ type a = A
 val a : a = A
 type a = A
 val b : a = A
+type a = A
+val c : a = A
 Line 2, characters 4-5:
 2 | a = b;;
         ^
-Error: This expression has type a/1 but an expression was expected of type
-         a/2
+Error: This expression has type a/2 but an expression was expected of type
+         a/3
+       Hint: The type a has been defined multiple times in this toplevel
+         session. Some toplevel values still refer to old versions of this
+         type. Did you try to redefine them?
+Line 1, characters 4-5:
+1 | a = c;;
+        ^
+Error: This expression has type a but an expression was expected of type a/3
+       Hint: The type a has been defined multiple times in this toplevel
+         session. Some toplevel values still refer to old versions of this
+         type. Did you try to redefine them?
+Line 1, characters 4-5:
+1 | b = c;;
+        ^
+Error: This expression has type a but an expression was expected of type a/2
        Hint: The type a has been defined multiple times in this toplevel
          session. Some toplevel values still refer to old versions of this
          type. Did you try to redefine them?

--- a/testsuite/tests/tool-toplevel/redefinition_hints.ml
+++ b/testsuite/tests/tool-toplevel/redefinition_hints.ml
@@ -36,5 +36,11 @@ let a = A;;
 type a = A
 let b = A;;
 
+type a = A
+let c = A;;
+
 a = b;;
+a = c;;
+b = c;;
+
 exit 0;;

--- a/testsuite/tests/typing-extension-constructor/test.ocaml.reference
+++ b/testsuite/tests/typing-extension-constructor/test.ocaml.reference
@@ -6,6 +6,8 @@ module M : sig type extension_constructor = int end
 Line 2, characters 1-27:
 2 | ([%extension_constructor A] : extension_constructor);;
      ^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This expression has type extension_constructor
+Error: This expression has type extension_constructor/2
        but an expression was expected of type M.extension_constructor = int
+       File "_none_", line 1:
+         Definition of type extension_constructor/2
 

--- a/testsuite/tests/typing-misc-bugs/pr6303_bad.compilers.reference
+++ b/testsuite/tests/typing-misc-bugs/pr6303_bad.compilers.reference
@@ -3,4 +3,4 @@ File "pr6303_bad.ml", line 11, characters 22-23:
                            ^
 Error: This expression has type int foo
        but an expression was expected of type string foo
-       Type int is not compatible with type string 
+       Type int is not compatible with type string

--- a/testsuite/tests/typing-misc/pr6416.ml
+++ b/testsuite/tests/typing-misc/pr6416.ml
@@ -23,13 +23,13 @@ Error: Signature mismatch:
        is not included in
          sig val f : t -> unit end
        Values do not match:
-         val f : t/1 -> unit
+         val f : t -> unit
        is not included in
          val f : t/2 -> unit
-       The type t/1 -> unit is not compatible with the type t/2 -> unit
-       Type t/1 is not compatible with type t/2
+       The type t -> unit is not compatible with the type t/2 -> unit
+       Type t is not compatible with type t/2
        Line 6, characters 4-14:
-         Definition of type t/1
+         Definition of type t
        Line 2, characters 2-12:
          Definition of type t/2
 |}]
@@ -49,16 +49,16 @@ Error: Signature mismatch:
        is not included in
          sig type u = A of t end
        Type declarations do not match:
-         type u = A of t/1
+         type u = A of t
        is not included in
          type u = A of t/2
        Constructors do not match:
-         A of t/1
+         A of t
        is not the same as:
-         A of t/2
-       The type t/1 is not equal to the type t/2
+         A of t
+       The type t is not equal to the type t/2
        Line 4, characters 9-19:
-         Definition of type t/1
+         Definition of type t
        Line 2, characters 2-11:
          Definition of type t/2
 |}]
@@ -85,15 +85,15 @@ Error: Signature mismatch:
          sig module A : functor (X : s) -> sig end end
        In module A:
        Modules do not match:
-         functor (X : s/1) -> ...
+         functor (X : s) -> ...
        is not included in
          functor (X : s/2) -> ...
        Module types do not match:
-         s/1
+         s
        does not include
          s/2
        Line 5, characters 6-19:
-         Definition of module type s/1
+         Definition of module type s
        Line 2, characters 2-15:
          Definition of module type s/2
 |}]
@@ -118,16 +118,16 @@ Error: Signature mismatch:
        is not included in
          sig type t = A of T.t end
        Type declarations do not match:
-         type t = A of T/1.t
+         type t = A of T.t
        is not included in
          type t = A of T/2.t
        Constructors do not match:
-         A of T/1.t
+         A of T.t
        is not the same as:
-         A of T/2.t
-       The type T/1.t is not equal to the type T/2.t
+         A of T.t
+       The type T.t is not equal to the type T/2.t
        Line 5, characters 6-34:
-         Definition of module T/1
+         Definition of module T
        Line 2, characters 2-30:
          Definition of module T/2
 |}]
@@ -145,22 +145,22 @@ Line 5, characters 2-62:
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: Signature mismatch:
        Modules do not match:
-         sig module type s type t = B val f : (module s) -> t/2 -> t/1 end
+         sig module type s type t = B val f : (module s) -> t/2 -> t end
        is not included in
          sig val f : (module s) -> t -> t end
        Values do not match:
-         val f : (module s/1) -> t/2 -> t/1
+         val f : (module s) -> t/2 -> t
        is not included in
          val f : (module s/2) -> t/2 -> t/2
-       The type (module s/1) -> t/2 -> t/1 is not compatible with the type
+       The type (module s) -> t/2 -> t is not compatible with the type
          (module s/2) -> t/2 -> t/2
-       Type (module s/1) is not compatible with type (module s/2)
+       Type (module s) is not compatible with type (module s/2)
        Line 5, characters 23-33:
-         Definition of type t/1
+         Definition of type t
        Line 3, characters 2-12:
          Definition of type t/2
        Line 5, characters 9-22:
-         Definition of module type s/1
+         Definition of module type s
        Line 2, characters 2-15:
          Definition of module type s/2
 |}]
@@ -178,18 +178,18 @@ Line 5, characters 5-41:
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: Signature mismatch:
        Modules do not match:
-         sig type a = B val f : a/2 -> 'a -> a/1 end
+         sig type a = B val f : a/2 -> 'a -> a end
        is not included in
          sig val f : a -> (module a) -> a end
        Values do not match:
-         val f : a/2 -> 'a -> a/1
+         val f : a/2 -> 'a -> a
        is not included in
          val f : a/2 -> (module a) -> a/2
-       The type a/2 -> (module a) -> a/1 is not compatible with the type
+       The type a/2 -> (module a) -> a is not compatible with the type
          a/2 -> (module a) -> a/2
-       Type a/1 is not compatible with type a/2
+       Type a is not compatible with type a/2
        Line 5, characters 12-22:
-         Definition of type a/1
+         Definition of type a
        Line 3, characters 2-12:
          Definition of type a/2
 |}]
@@ -222,7 +222,7 @@ Error: Signature mismatch:
        The public method c cannot be hidden
        The first class type has no method m
        Line 5, characters 4-74:
-         Definition of class type a/1
+         Definition of class type a
        Line 2, characters 2-36:
          Definition of class type a/2
 |}]
@@ -248,12 +248,12 @@ Error: Signature mismatch:
        is not included in
          sig class type b = a end
        Class type declarations do not match:
-         class type b = a/1
+         class type b = a
        does not match
          class type b = a/2
        The first class type has no method m
        Line 5, characters 4-29:
-         Definition of class type a/1
+         Definition of class type a
        Line 2, characters 2-42:
          Definition of class type a/2
 |}]
@@ -315,11 +315,11 @@ Error: Signature mismatch:
        Class type declarations do not match:
          class type c = object method m : t/2 end
        does not match
-         class type c = object method m : t/1 end
-       The method m has type t/2 but is expected to have type t/1
-       Type t/2 is not equal to type t/1 = K.t
+         class type c = object method m : t end
+       The method m has type t/2 but is expected to have type t
+       Type t/2 is not equal to type t = K.t
        Line 12, characters 4-10:
-         Definition of type t/1
+         Definition of type t
        Line 9, characters 2-8:
          Definition of type t/2
 |}]
@@ -338,12 +338,12 @@ Error: Signature mismatch:
        is not included in
          sig type t type a = M.t end
        Type declarations do not match:
-         type a = M/1.t
+         type a = M.t
        is not included in
          type a = M/2.t
-       The type M/1.t = M/2.M.t is not equal to the type M/2.t
+       The type M.t = M/2.M.t is not equal to the type M/2.t
        Line 2, characters 14-42:
-         Definition of module M/1
+         Definition of module M
        File "_none_", line 1:
          Definition of module M/2
 |}]
@@ -368,23 +368,23 @@ Lines 5-7, characters 44-3:
 7 | end..
 Error: Signature mismatch:
        Modules do not match:
-         sig val f : t/2 -> t/3 -> t/4 -> t/1 end
+         sig val f : t/4 -> t/3 -> t/2 -> t end
        is not included in
          sig val f : t -> t -> t -> t end
        Values do not match:
-         val f : t/2 -> t/3 -> t/4 -> t/1
+         val f : t/4 -> t/3 -> t/2 -> t
        is not included in
-         val f : t/1 -> t/1 -> t/1 -> t/1
-       The type t/2 -> t/3 -> t/4 -> t/1 is not compatible with the type
-         t/1 -> t/1 -> t/1 -> t/1
-       Type t/2 is not compatible with type t/1
+         val f : t -> t -> t -> t
+       The type t/4 -> t/3 -> t/2 -> t is not compatible with the type
+         t -> t -> t -> t
+       Type t/4 is not compatible with type t
        Line 4, characters 0-10:
-         Definition of type t/1
-       Line 1, characters 0-10:
+         Definition of type t
+       Line 3, characters 0-10:
          Definition of type t/2
        Line 2, characters 0-10:
          Definition of type t/3
-       Line 3, characters 0-10:
+       Line 1, characters 0-10:
          Definition of type t/4
 |}]
 

--- a/testsuite/tests/typing-misc/pr6634.ml
+++ b/testsuite/tests/typing-misc/pr6634.ml
@@ -18,16 +18,16 @@ Error: Signature mismatch:
        Modules do not match:
          sig type t = [ `T of t ] end
        is not included in
-         sig type t = [ `T of t ] end
+         sig type t = [ `T of t/2 ] end
        Type declarations do not match:
-         type t = [ `T of t/2 ]
+         type t = [ `T of t ]
        is not included in
-         type t = [ `T of t/1 ]
-       The type [ `T of t/1 ] is not equal to the type [ `T of t/2 ]
-       Type t/1 = [ `T of t/1 ] is not equal to type t/2 = int
+         type t = [ `T of t/3 ]
+       The type [ `T of t ] is not equal to the type [ `T of t/2 ]
+       Type t = [ `T of t ] is not equal to type t/2 = int
        Types for tag `T are incompatible
        Line 4, characters 2-20:
-         Definition of type t/1
+         Definition of type t
        Line 1, characters 0-12:
          Definition of type t/2
 |}]

--- a/testsuite/tests/typing-misc/unique_names_in_unification.ml
+++ b/testsuite/tests/typing-misc/unique_names_in_unification.ml
@@ -14,10 +14,9 @@ val x : t = A
 Line 5, characters 27-28:
 5 |   let f: t -> t = fun B -> x
                                ^
-Error: This expression has type t/2 but an expression was expected of type
-         t/1
+Error: This expression has type t/2 but an expression was expected of type t
        Line 4, characters 2-12:
-         Definition of type t/1
+         Definition of type t
        Line 1, characters 0-10:
          Definition of type t/2
 |}]
@@ -38,9 +37,9 @@ Line 7, characters 34-35:
 7 |   let f : M.t -> M.t = fun M.C -> y
                                       ^
 Error: This expression has type M/2.t but an expression was expected of type
-         M/1.t
+         M.t
        Lines 4-6, characters 2-5:
-         Definition of module M/1
+         Definition of module M
        Line 1, characters 0-32:
          Definition of module M/2
 |}]
@@ -54,10 +53,9 @@ type t = D
 Line 2, characters 25-26:
 2 | let f: t -> t = fun D -> x;;
                              ^
-Error: This expression has type t/2 but an expression was expected of type
-         t/1
+Error: This expression has type t/2 but an expression was expected of type t
        Line 1, characters 0-10:
-         Definition of type t/1
+         Definition of type t
        Line 1, characters 0-10:
          Definition of type t/2
 |}]
@@ -79,9 +77,9 @@ Line 2, characters 32-33:
 2 | let x: ttt = let rec y = A y in y;;
                                     ^
 Error: This expression has type ttt/2 but an expression was expected of type
-         ttt/1
+         ttt
        Line 1, characters 0-26:
-         Definition of type ttt/1
+         Definition of type ttt
        Line 2, characters 0-30:
          Definition of type ttt/2
 |}]

--- a/testsuite/tests/typing-modules-bugs/pr10693_bad.compilers.reference
+++ b/testsuite/tests/typing-modules-bugs/pr10693_bad.compilers.reference
@@ -35,20 +35,20 @@ Error: Signature mismatch:
        In module M.M:
        Modules do not match:
          sig
-           val x : X/2.t option
-           module M : functor (Y : Dep) -> sig val x : X/2.t option end
+           val x : X.t option
+           module M : functor (Y : Dep) -> sig val x : X.t option end
          end
        is not included in
          sig val x : X.t option end
        In module M.M:
        Values do not match:
-         val x : X/1.t option
+         val x : X.t option
        is not included in
          val x : X/2.t option
-       The type X/1.t option is not compatible with the type X/2.t option
-       Type X/1.t is not compatible with type X/2.t 
+       The type X.t option is not compatible with the type X/2.t option
+       Type X.t is not compatible with type X/2.t 
        File "_none_", line 1:
-         Definition of module X/1
+         Definition of module X
        File "_none_", line 1:
          Definition of module X/2
        File "pr10693_bad.ml", line 17, characters 6-24: Expected declaration

--- a/testsuite/tests/typing-modules-bugs/pr10693_bad.compilers.reference
+++ b/testsuite/tests/typing-modules-bugs/pr10693_bad.compilers.reference
@@ -46,7 +46,7 @@ Error: Signature mismatch:
        is not included in
          val x : X/2.t option
        The type X.t option is not compatible with the type X/2.t option
-       Type X.t is not compatible with type X/2.t 
+       Type X.t is not compatible with type X/2.t
        File "_none_", line 1:
          Definition of module X
        File "_none_", line 1:

--- a/testsuite/tests/typing-modules-bugs/pr6992_bad.compilers.reference
+++ b/testsuite/tests/typing-modules-bugs/pr6992_bad.compilers.reference
@@ -3,4 +3,4 @@ File "pr6992_bad.ml", line 16, characters 69-71:
                                                                           ^^
 Error: This expression has type (a, a) eq
        but an expression was expected of type (a, b) eq
-       Type a is not compatible with type b 
+       Type a is not compatible with type b

--- a/testsuite/tests/typing-modules/functors.ml
+++ b/testsuite/tests/typing-modules/functors.ml
@@ -520,11 +520,11 @@ Error: The functor application is ill-typed.
          functor (X : x) (B : b/2) (Y : y) -> ...
        1. Module $S1 matches the expected module type x
        2. Modules do not match:
-            P.B : b/1
+            P.B : b
           is not included in
             b/2
           Line 5, characters 2-15:
-            Definition of module type b/1
+            Definition of module type b
           Line 2, characters 0-13:
             Definition of module type b/2
        3. Modules do not match: $S3 : sig type w end is not included in y
@@ -543,9 +543,9 @@ module F : functor (X : a) -> sig type t end
 Line 6, characters 13-19:
 6 |     type t = F(X).t
                  ^^^^^^
-Error: Modules do not match: a/1 is not included in a/2
+Error: Modules do not match: a is not included in a/2
      Line 3, characters 2-15:
-       Definition of module type a/1
+       Definition of module type a
      Line 1, characters 0-13:
        Definition of module type a/2
 |}]
@@ -576,16 +576,16 @@ Error: Signature mismatch:
          sig module F : functor (X : a) (Y : a) -> sig end end
        In module F:
        Modules do not match:
-         functor (X : aa) (Y : a/1) -> ...
+         functor (X : aa) (Y : a) -> ...
        is not included in
          functor (X : a/2) (Y : a/2) -> ...
        1. Module types aa and a/2 match
        2. Module types do not match:
-            a/1
+            a
           does not include
             a/2
           Line 4, characters 2-15:
-            Definition of module type a/1
+            Definition of module type a
           Line 1, characters 0-13:
             Definition of module type a/2
 |}]
@@ -1487,8 +1487,8 @@ Error: Signature mismatch:
        1. An extra argument is provided of module type
               $S1 = sig type wrong end
        2. Module types $S2 and $T2 match
-       3. Module types X/3.T and X/2.T match
-       4. Module types X/3.T and X/2.T match
+       3. Module types X.T and X.T match
+       4. Module types X.T and X.T match
 |}]
 
 
@@ -1561,9 +1561,9 @@ Error: Signature mismatch:
             sig end
           The type `wrong' is required but not provided
        2. Module types $S2 and $T2 match
-       3. An extra argument is provided of module type X/2.T
-       4. Module types X/2.T and X/2.T match
-       5. Module types X/2.T and X/2.T match
+       3. An extra argument is provided of module type X.T
+       4. Module types X.T and X.T match
+       5. Module types X.T and X.T match
 |}]
 
 
@@ -1596,7 +1596,7 @@ Error: The functor application is ill-typed.
        3. Modules do not match:
             Y : sig type t = Y.t = Y of int end
           is not included in
-            $T3 = sig type t = Y of X/2.t end
+            $T3 = sig type t = Y of X.t end
           Type declarations do not match:
             type t = Y.t = Y of int
           is not included in
@@ -1609,7 +1609,7 @@ Error: The functor application is ill-typed.
        4. Modules do not match:
             Z : sig type t = Z.t = Z of int end
           is not included in
-            $T4 = sig type t = Z of X/2.t end
+            $T4 = sig type t = Z of X.t end
           Type declarations do not match:
             type t = Z.t = Z of int
           is not included in

--- a/testsuite/tests/typing-modules/inclusion_errors.ml
+++ b/testsuite/tests/typing-modules/inclusion_errors.ml
@@ -552,14 +552,14 @@ Error: Signature mismatch:
        is not included in
          sig val f : (module s) -> unit end
        Values do not match:
-         val f : (module s/1) -> unit
+         val f : (module s) -> unit
        is not included in
          val f : (module s/2) -> unit
-       The type (module s/1) -> unit is not compatible with the type
+       The type (module s) -> unit is not compatible with the type
          (module s/2) -> unit
-       Type (module s/1) is not compatible with type (module s/2)
+       Type (module s) is not compatible with type (module s/2)
        Line 6, characters 4-17:
-         Definition of module type s/1
+         Definition of module type s
        Line 2, characters 2-15:
          Definition of module type s/2
 |}];;

--- a/testsuite/tests/typing-modules/merge_constraint.ml
+++ b/testsuite/tests/typing-modules/merge_constraint.ml
@@ -58,8 +58,8 @@ module VarianceEnv :
         type 'a user = Foo of 'a abstract
         module M :
           sig
-            type 'a abstract = 'a abstract
-            type 'a user = 'a user = Foo of 'a abstract
+            type 'a abstract = 'a abstract/2
+            type 'a user = 'a user/2 = Foo of 'a abstract
           end
         type 'a foo = 'a M.user
       end
@@ -93,8 +93,8 @@ module UnboxedEnv :
         type t = T : 'e ind -> t [@@unboxed]
         module type ReboundSig =
           sig
-            type 'a ind = 'a ind
-            type t = t/2 = T : 'a ind -> t/1 [@@unboxed]
+            type 'a ind = 'a ind/2
+            type t = t/2 = T : 'a ind -> t [@@unboxed]
           end
       end
   end
@@ -115,7 +115,7 @@ module ParamsUnificationEnv :
       sig type 'a u = 'a list type +'a t constraint 'a = 'b u end
     type +'a t = 'b constraint 'a = 'b list
     module type Sig2 =
-      sig type 'a u = 'a list type +'a t = 'a t constraint 'a = 'b u end
+      sig type 'a u = 'a list type +'a t = 'a t/2 constraint 'a = 'b u end
   end
 |}]
 
@@ -147,7 +147,7 @@ module CorrectEnvConstructionTest :
         and +'a abstract
         module M :
           sig
-            type 'a user = 'a user = Foo of 'a abstract/1
+            type 'a user = 'a user/2 = Foo of 'a abstract
             and 'a abstract = 'a abstract/2
           end
         type 'a foo = 'a M.user

--- a/testsuite/tests/typing-objects-bugs/pr3968_bad.compilers.reference
+++ b/testsuite/tests/typing-objects-bugs/pr3968_bad.compilers.reference
@@ -37,8 +37,8 @@ Error: The class type
          [> `App of [ `Abs of string * 'a | `App of expr * expr ] * exp ]
          as 'a
        is not compatible with type
-         expr = [ `Abs of string * expr | `App of expr * expr ] 
+         expr = [ `Abs of string * expr | `App of expr * expr ]
        Type exp = < eval : (string, exp) Hashtbl.t -> expr >
        is not compatible with type
-         expr = [ `Abs of string * expr | `App of expr * expr ] 
+         expr = [ `Abs of string * expr | `App of expr * expr ]
        Types for tag `App are incompatible

--- a/testsuite/tests/typing-objects-bugs/pr4018_bad.compilers.reference
+++ b/testsuite/tests/typing-objects-bugs/pr4018_bad.compilers.reference
@@ -13,10 +13,10 @@ Error: This type entity = < destroy_subject : id subject; entity_id : id >
        is not compatible with type
          < add_observer : < destroy_subject : 'c; .. > entity_container -> 'b;
            .. >
-         as 'c 
+         as 'c
        Type (id subject, id) observer = < notify : id subject -> id -> unit >
        is not compatible with type
          (< destroy_subject : < add_observer : 'd -> 'b; .. >; .. > as 'a)
          entity_container as 'd =
-           < add_entity : 'a -> 'b; notify : 'a -> id -> unit > 
+           < add_entity : 'a -> 'b; notify : 'a -> id -> unit >
        Types for method add_observer are incompatible

--- a/testsuite/tests/typing-ocamlc-i/pervasives_leitmotiv.compilers.reference
+++ b/testsuite/tests/typing-ocamlc-i/pervasives_leitmotiv.compilers.reference
@@ -3,11 +3,11 @@ Warning 63 [erroneous-printed-signature]: The printed interface differs from the
 The inferred interface contained items which could not be printed
 properly due to name collisions between identifiers.
 File "pervasives_leitmotiv.ml", lines 10-12, characters 0-3:
-  Definition of module Stdlib/1
+  Definition of module Stdlib
 File "_none_", line 1:
   Definition of module Stdlib/2
 Beware that this warning is purely informational and will not catch
 all instances of erroneous printed interface.
 type fpclass = A
 module Stdlib : sig type fpclass = B end
-val f : fpclass -> Stdlib/1.fpclass -> Stdlib/2.fpclass
+val f : fpclass -> Stdlib.fpclass -> Stdlib/2.fpclass

--- a/testsuite/tests/typing-ocamlc-i/pr4791.compilers.reference
+++ b/testsuite/tests/typing-ocamlc-i/pr4791.compilers.reference
@@ -3,10 +3,10 @@ Warning 63 [erroneous-printed-signature]: The printed interface differs from the
 The inferred interface contained items which could not be printed
 properly due to name collisions between identifiers.
 File "pr4791.ml", line 11, characters 2-12:
-  Definition of type t/1
+  Definition of type t
 File "pr4791.ml", line 8, characters 0-10:
   Definition of type t/2
 Beware that this warning is purely informational and will not catch
 all instances of erroneous printed interface.
 type t = A
-module B : sig type t = B val f : t/2 -> t/1 end
+module B : sig type t = B val f : t/2 -> t end

--- a/testsuite/tests/typing-ocamlc-i/pr6323.compilers.reference
+++ b/testsuite/tests/typing-ocamlc-i/pr6323.compilers.reference
@@ -3,7 +3,7 @@ Warning 63 [erroneous-printed-signature]: The printed interface differs from the
 The inferred interface contained items which could not be printed
 properly due to name collisions between identifiers.
 File "pr6323.ml", line 15, characters 2-24:
-  Definition of type t/1
+  Definition of type t
 File "pr6323.ml", line 8, characters 0-26:
   Definition of type t/2
 Beware that this warning is purely informational and will not catch

--- a/testsuite/tests/typing-ocamlc-i/pr7402.compilers.reference
+++ b/testsuite/tests/typing-ocamlc-i/pr7402.compilers.reference
@@ -3,7 +3,7 @@ Warning 63 [erroneous-printed-signature]: The printed interface differs from the
 The inferred interface contained items which could not be printed
 properly due to name collisions between identifiers.
 File "pr7402.ml", lines 14-16, characters 0-5:
-  Definition of module M/1
+  Definition of module M
 File "pr7402.ml", lines 8-11, characters 0-3:
   Definition of module M/2
 Beware that this warning is purely informational and will not catch

--- a/testsuite/tests/typing-signatures/els.ocaml.reference
+++ b/testsuite/tests/typing-signatures/els.ocaml.reference
@@ -79,12 +79,16 @@ module type WEAPON_LIB =
   sig
     type t = Weapon.t
     module T :
-      sig type t = t val eq : t -> t -> bool val to_string : t -> string end
+      sig
+        type t = t/2
+        val eq : t -> t -> bool
+        val to_string : t -> string
+      end
     module Make :
       functor
         (TV : sig
                 type combined
-                type t = t
+                type t = t/2
                 val map : (combined -> t) * (t -> combined)
               end)
         -> USERCODE(TV).F

--- a/testsuite/tests/typing-sigsubst/test_locations.compilers.reference
+++ b/testsuite/tests/typing-sigsubst/test_locations.compilers.reference
@@ -48,7 +48,7 @@ Error: Signature mismatch:
        is not included in
          val create : unit -> t
        The type elt -> t is not compatible with the type unit -> t
-       Type elt = string is not compatible with type unit 
+       Type elt = string is not compatible with type unit
        File "test_loc_type_subst.ml", line 1, characters 11-47:
          Expected declaration
        File "test_functor.ml", line 5, characters 2-23: Actual declaration
@@ -69,7 +69,7 @@ Error: Signature mismatch:
        is not included in
          val create : unit -> t
        The type elt -> t is not compatible with the type unit -> t
-       Type elt = string is not compatible with type unit 
+       Type elt = string is not compatible with type unit
        File "test_loc_modtype_type_subst.ml", line 1, characters 16-52:
          Expected declaration
        File "test_functor.ml", line 5, characters 2-23: Actual declaration

--- a/typing/env.ml
+++ b/typing/env.ml
@@ -3182,7 +3182,7 @@ let find_label_by_name lid env =
 let find_index_tbl ident tbl  =
   let lbs = IdTbl.find_all_idents (Ident.name ident) tbl in
   let find_ident (n,p) = match p with
-    | Some i -> if Ident.same ident i then Some n else None
+    | Some id -> if Ident.same ident id then Some n else None
     | _ -> None
   in
   Seq.find_map find_ident @@ Seq.mapi (fun i x -> i,x) lbs

--- a/typing/env.ml
+++ b/typing/env.ml
@@ -435,6 +435,19 @@ module IdTbl =
           List.map (fun (p, desc) -> (p, f desc))
             (find_all wrap name next)
 
+    let rec find_all_idents name tbl =
+      List.map
+        (fun (id, _) -> Some id)
+        (Ident.find_all name tbl.current) @
+      match tbl.layer with
+      | Nothing -> []
+      | Open { next; components; _ } ->
+          if NameMap.mem name components then
+            None :: find_all_idents name next
+          else
+            find_all_idents name next
+      | Map {next; _ } -> find_all_idents name next
+
     let rec fold_name wrap f tbl acc =
       let acc =
         Ident.fold_name
@@ -3159,6 +3172,23 @@ let find_constructor_by_name lid env =
 let find_label_by_name lid env =
   let loc = Location.(in_file !input_name) in
   lookup_label ~errors:false ~use:false ~loc Projection lid env
+
+(* Stable name lookup for printing *)
+
+let find_index_tbl ident tbl  =
+  let lbs = IdTbl.find_all_idents (Ident.name ident) tbl in
+  let find_ident (n,p) = match p with
+    | Some i -> if Ident.same ident i then Some n else None
+    | _ -> None
+  in
+  Seq.find_map find_ident @@ Seq.mapi (fun i x -> i,x) @@ List.to_seq lbs
+
+let find_value_index id env = find_index_tbl id env.values
+let find_type_index id env = find_index_tbl id env.types
+let find_module_index id env = find_index_tbl id env.modules
+let find_modtype_index id env = find_index_tbl id env.modtypes
+let find_class_index id env = find_index_tbl id env.classes
+let find_cltype_index id env = find_index_tbl id env.cltypes
 
 (* Ordinary lookup functions *)
 

--- a/typing/env.mli
+++ b/typing/env.mli
@@ -267,6 +267,18 @@ val find_constructor_by_name:
 val find_label_by_name:
   Longident.t -> t -> label_description
 
+(** The [find_*_index] functions computes a "namespaced" De Bruijn index
+    of an identifier in a given environment. In other words, it returns how many
+    times an identifier has been shadowed by a more recent identifiers with the
+    same name in a given environment.
+*)
+val find_value_index:   Ident.t -> t -> int option
+val find_type_index:    Ident.t -> t -> int option
+val find_module_index:  Ident.t -> t -> int option
+val find_modtype_index: Ident.t -> t -> int option
+val find_class_index:   Ident.t -> t -> int option
+val find_cltype_index:  Ident.t -> t -> int option
+
 (* Check if a name is bound *)
 
 val bound_value: string -> t -> bool

--- a/typing/env.mli
+++ b/typing/env.mli
@@ -271,6 +271,9 @@ val find_label_by_name:
     of an identifier in a given environment. In other words, it returns how many
     times an identifier has been shadowed by a more recent identifiers with the
     same name in a given environment.
+    Those functions return [None] when the identifier is not bound in the
+    environment. This behavior is there to facilitate the detection of
+    inconsistent printing environment, but should disappear in the long term.
 *)
 val find_value_index:   Ident.t -> t -> int option
 val find_type_index:    Ident.t -> t -> int option

--- a/typing/ident.ml
+++ b/typing/ident.ml
@@ -297,6 +297,21 @@ let rec find_all n = function
       else
         find_all n (if c < 0 then l else r)
 
+let get_all_seq k () =
+  Seq.unfold (Option.map (fun k -> (k.ident, k.data), k.previous))
+    k ()
+
+let rec find_all_seq n tbl () =
+  match tbl with
+  | Empty -> Seq.Nil
+  | Node(l, k, r, _) ->
+      let c = String.compare n (name k.ident) in
+      if c = 0 then
+        Seq.Cons((k.ident, k.data), get_all_seq k.previous)
+      else
+        find_all_seq n (if c < 0 then l else r) ()
+
+
 let rec fold_aux f stack accu = function
     Empty ->
       begin match stack with

--- a/typing/ident.mli
+++ b/typing/ident.mli
@@ -99,6 +99,7 @@ val add: t -> 'a -> 'a tbl -> 'a tbl
 val find_same: t -> 'a tbl -> 'a
 val find_name: string -> 'a tbl -> t * 'a
 val find_all: string -> 'a tbl -> (t * 'a) list
+val find_all_seq: string -> 'a tbl -> (t * 'a) Seq.t
 val fold_name: (t -> 'a -> 'b -> 'b) -> 'a tbl -> 'b -> 'b
 val fold_all: (t -> 'a -> 'b -> 'b) -> 'a tbl -> 'b -> 'b
 val iter: (t -> 'a -> unit) -> 'a tbl -> unit

--- a/typing/printtyp.ml
+++ b/typing/printtyp.ml
@@ -243,6 +243,18 @@ let with_hidden ids f =
   let updated = List.fold_left update !bound_in_recursion ids in
   protect_refs [ R(bound_in_recursion, updated )] f
 
+let human_id id index =
+  if index = 0 then
+    Ident.name id
+  else
+  (* We print the most k-time overshadowed identifier as `name/(k+1)`.
+     This naming scheme has the advantage of creating a non-ambiguous gap
+     between the identifier in scope, which is printed as `name`, and the
+     most recent shadowed identifier, printed as `name/2`.
+  *)
+    let ordinal = index + 1 in
+    String.concat "/" [Ident.name id; string_of_int ordinal]
+
 let indexed_name namespace id =
   let find namespace id env = match namespace with
     | Type -> Env.find_type_index id env
@@ -268,9 +280,8 @@ let indexed_name namespace id =
       if Ident.same p id then
         Ident.name id
       else
-        String.concat "/" [Ident.name id; string_of_int (2 + n)]
-  | Some n, None ->
-      String.concat "/" [Ident.name id; string_of_int (1 + n)]
+        human_id id (1 + n)
+  | Some n, None -> human_id id n
 
 let ident_name namespace id =
   if not !enabled || fuzzy_id namespace id then

--- a/typing/printtyp.ml
+++ b/typing/printtyp.ml
@@ -379,6 +379,7 @@ let rewrite_double_underscore_paths env p =
     rewrite_double_underscore_paths env p
 
 let rec tree_of_path ?(disambiguation=true) namespace p =
+  let tree_of_path namespace p = tree_of_path ~disambiguation namespace p in
   let namespace = if disambiguation then namespace else Other in
   match p with
   | Pident id ->
@@ -386,10 +387,10 @@ let rec tree_of_path ?(disambiguation=true) namespace p =
   | Pdot(_, s) as path when non_shadowed_stdlib namespace path ->
       Oide_ident (Out_name.create s)
   | Pdot(p, s) ->
-      Oide_dot (tree_of_path ~disambiguation Module p, s)
+      Oide_dot (tree_of_path Module p, s)
   | Papply(p1, p2) ->
-      let t1 = tree_of_path ~disambiguation Module p1 in
-      let t2 = tree_of_path ~disambiguation Module p2 in
+      let t1 = tree_of_path Module p1 in
+      let t2 = tree_of_path Module p2 in
       Oide_apply (t1, t2)
   | Pextra_ty (p, extra) -> begin
       (* inline record types are syntactically prevented from escaping their

--- a/typing/printtyp.ml
+++ b/typing/printtyp.ml
@@ -2007,7 +2007,7 @@ let type_path_expansion ppf = function
 let rec trace fst txt ppf = function
   | {Errortrace.got; expected} :: rem ->
       if not fst then fprintf ppf "@,";
-      fprintf ppf "@[Type@;<1 2>%a@ %s@;<1 2>%a@] %a"
+      fprintf ppf "@[Type@;<1 2>%a@ %s@;<1 2>%a@]%a"
        type_expansion got txt type_expansion expected
        (trace false txt) rem
   | _ -> ()

--- a/typing/printtyp.ml
+++ b/typing/printtyp.ml
@@ -41,7 +41,6 @@ let () = Env.print_longident := longident
 module Out_name = struct
   let create x = { printed_name = x }
   let print x = x.printed_name
-  let set out_name x = out_name.printed_name <- x
 end
 
 (** Some identifiers may require hiding when printing *)
@@ -55,7 +54,6 @@ let printing_env = ref Env.empty
    cmi present on the file system *)
 let in_printing_env f = Env.without_cmis f !printing_env
 
-let human_unique n id = Printf.sprintf "%s/%d" (Ident.name id) n
 
 type namespace =
   | Type
@@ -134,15 +132,26 @@ module Conflicts = struct
   type explanation =
     { kind: namespace; name:string; root_name:string; location:Location.t}
   let explanations = ref M.empty
-  let collect_explanation namespace n id =
-    let name = human_unique n id in
+
+  let add namespace name id =
+    match Namespace.location namespace id with
+    | None -> ()
+    | Some location ->
+        let explanation =
+          { kind = namespace; location; name; root_name=Ident.name id}
+        in
+        explanations := M.add name explanation !explanations
+
+  let collect_explanation namespace id ~name =
     let root_name = Ident.name id in
-    if not (M.mem name !explanations) then
-      match Namespace.location namespace id with
-      | None -> ()
-      | Some location ->
-          let explanation = { kind = namespace; location; name; root_name } in
-          explanations := M.add name explanation !explanations
+    if root_name != name && not (M.mem name !explanations) then
+      begin
+        add namespace name id;
+        if not (M.mem root_name !explanations) then
+          match Namespace.lookup namespace root_name with
+          | Pident root_id -> add namespace root_name root_id
+          | exception Not_found | _ -> ()
+      end
 
   let pp_explanation ppf r=
     Format.fprintf ppf "@[<v 2>%a:@,Definition of %s %s@]"
@@ -216,43 +225,9 @@ module S = String.Set
 let enabled = ref true
 let enable b = enabled := b
 
-(** Name mapping *)
-type mapping =
-  | Need_unique_name of int Ident.Map.t
-  (** The same name has already been attributed to multiple types.
-      The [map] argument contains the specific binding time attributed to each
-      types.
-  *)
-  | Uniquely_associated_to of Ident.t * out_name
-    (** For now, the name [Ident.name id] has been attributed to [id],
-        [out_name] is used to expand this name if a conflict arises
-        at a later point
-    *)
-  | Associated_to_pervasives of out_name
-  (** [Associated_to_pervasives out_name] is used when the item
-      [Stdlib.$name] has been associated to the name [$name].
-      Upon a conflict, this name will be expanded to ["Stdlib." ^ name ] *)
-
-let hid_start = 0
-
-let add_hid_id id map =
-  let new_id = 1 + Ident.Map.fold (fun _ -> Int.max) map hid_start in
-  new_id, Ident.Map.add id new_id  map
-
-let find_hid id map =
-  try Ident.Map.find id map, map with
-  Not_found -> add_hid_id id map
-
-let pervasives name = "Stdlib." ^ name
-
-let map = Array.make Namespace.size M.empty
-let get namespace = map.(Namespace.id namespace)
-let set namespace x = map.(Namespace.id namespace) <- x
-
-(* Names used in recursive definitions are not considered when determining
-   if a name is already attributed in the current environment.
-   This is a complementary version of hidden_rec_items used by short-path. *)
-let protected = ref S.empty
+(* Names bound in recursive definitions should be considered as bound
+   in the environment when printing identifiers *)
+let bound_in_recursion = ref M.empty
 
 (* When dealing with functor arguments, identity becomes fuzzy because the same
    syntactic argument may be represented by different identifiers during the
@@ -264,99 +239,61 @@ let with_arg id f =
 let fuzzy_id namespace id = namespace = Module && S.mem (Ident.name id) !fuzzy
 
 let with_hidden ids f =
-  let update m id = S.add (Ident.name id.ident) m in
-  protect_refs [ R(protected, List.fold_left update !protected ids)] f
+  let update m id = M.add (Ident.name id.ident) id.ident m in
+  let updated = List.fold_left update !bound_in_recursion ids in
+  protect_refs [ R(bound_in_recursion, updated )] f
 
-let pervasives_name namespace name =
-  if not !enabled then Out_name.create name else
-  match M.find name (get namespace) with
-  | Associated_to_pervasives r -> r
-  | Need_unique_name _ -> Out_name.create (pervasives name)
-  | Uniquely_associated_to (id',r) ->
-      let hid, map = add_hid_id id' Ident.Map.empty in
-      Out_name.set r (human_unique hid id');
-      Conflicts.collect_explanation namespace hid id';
-      set namespace @@ M.add name (Need_unique_name map) (get namespace);
-      Out_name.create (pervasives name)
-  | exception Not_found ->
-      let r = Out_name.create name in
-      set namespace @@ M.add name (Associated_to_pervasives r) (get namespace);
-      r
+let indexed_name namespace id =
+  let find namespace id env = match namespace with
+    | Type -> Env.find_type_index id env
+    | Module -> Env.find_module_index id env
+    | Module_type -> Env.find_modtype_index id env
+    | Class -> Env.find_class_index id env
+    | Class_type-> Env.find_cltype_index id env
+    | Other -> None
+  in
+  let rec_bound = M.find_opt (Ident.name id) !bound_in_recursion in
+  match in_printing_env (find namespace id), rec_bound with
+  | None, None
+    (* This case is potentially problematic, it might indicate that
+       the identifier id is not defined in the environment, while there
+       are other identifiers in scope that share the same name.
+       Currently, this kind of partially incoherent environment happens
+       within functor error messages where the left and right hand side
+       have a different views of the environment at the source level.
+       Printing the source-level name seems like a reasonable compromise
+       in this situation however.*)
+  | None, Some _ | Some 0, None -> Ident.name id
+  | Some n, Some p ->
+      if Ident.same p id then
+        Ident.name id
+      else
+        String.concat "/" [Ident.name id; string_of_int (2 + n)]
+  | Some n, None ->
+      String.concat "/" [Ident.name id; string_of_int (1 + n)]
 
-(** Lookup for preexisting named item within the current {!printing_env} *)
-let env_ident namespace name =
-  if S.mem name !protected then None else
-  match Namespace.lookup namespace name with
-  | Pident id -> Some id
-  | _ -> None
-  | exception Not_found -> None
-
-(** Associate a name to the identifier [id] within [namespace] *)
-let ident_name_simple namespace id =
+let ident_name namespace id =
   if not !enabled || fuzzy_id namespace id then
     Out_name.create (Ident.name id)
   else
-  let name = Ident.name id in
-  match M.find name (get namespace) with
-  | Uniquely_associated_to (id',r) when Ident.same id id' ->
-      r
-  | Need_unique_name map ->
-      let hid, m = find_hid id map in
-      Conflicts.collect_explanation namespace hid id;
-      set namespace @@ M.add name (Need_unique_name m) (get namespace);
-      Out_name.create (human_unique hid id)
-  | Uniquely_associated_to (id',r) ->
-      let hid', m = find_hid id' Ident.Map.empty in
-      let hid, m = find_hid id m in
-      Out_name.set r (human_unique hid' id');
-      List.iter (fun (id,hid) -> Conflicts.collect_explanation namespace hid id)
-        [id, hid; id', hid' ];
-      set namespace @@ M.add name (Need_unique_name m) (get namespace);
-      Out_name.create (human_unique hid id)
-  | Associated_to_pervasives r ->
-      Out_name.set r ("Stdlib." ^ Out_name.print r);
-      let hid, m = find_hid id Ident.Map.empty in
-      set namespace @@ M.add name (Need_unique_name m) (get namespace);
-      Out_name.create (human_unique hid id)
-  | exception Not_found ->
-      let r = Out_name.create name in
-      set namespace
-      @@ M.add name (Uniquely_associated_to (id,r) ) (get namespace);
-      r
-
-(** Same as {!ident_name_simple} but lookup to existing named identifiers
-    in the current {!printing_env} *)
-let ident_name namespace id =
-  begin match env_ident namespace (Ident.name id) with
-  | Some id' -> ignore (ident_name_simple namespace id')
-  | None -> ()
-  end;
-  ident_name_simple namespace id
-
-let reset () =
-  Array.iteri ( fun i _ -> map.(i) <- M.empty ) map
-
-let with_ctx f =
-  let old = Array.copy map in
-  try_finally f
-    ~always:(fun () -> Array.blit old 0 map 0 (Array.length map))
-
+    let name = indexed_name namespace id in
+    Conflicts.collect_explanation namespace id ~name;
+    Out_name.create name
 end
 let ident_name = Naming_context.ident_name
-let reset_naming_context = Naming_context.reset
 
 let ident ppf id = pp_print_string ppf
-    (Out_name.print (Naming_context.ident_name_simple Other id))
+    (Out_name.print (Naming_context.ident_name Other id))
 
 (* Print a path *)
 
 let ident_stdlib = Ident.create_persistent "Stdlib"
 
-let non_shadowed_pervasive = function
+let non_shadowed_stdlib namespace = function
   | Pdot(Pident id, s) as path ->
       Ident.same id ident_stdlib &&
-      (match in_printing_env (Env.find_type_by_name (Lident s)) with
-       | (path', _) -> Path.same path path'
+      (match Namespace.lookup namespace s with
+       | path' -> Path.same path path'
        | exception Not_found -> true)
   | _ -> false
 
@@ -416,15 +353,19 @@ let rewrite_double_underscore_paths env p =
   else
     rewrite_double_underscore_paths env p
 
-let rec tree_of_path namespace = function
+let rec tree_of_path ?(disambiguation=true) namespace p =
+  let namespace = if disambiguation then namespace else Other in
+  match p with
   | Pident id ->
       Oide_ident (ident_name namespace id)
-  | Pdot(_, s) as path when non_shadowed_pervasive path ->
-      Oide_ident (Naming_context.pervasives_name namespace s)
+  | Pdot(_, s) as path when non_shadowed_stdlib namespace path ->
+      Oide_ident (Out_name.create s)
   | Pdot(p, s) ->
-      Oide_dot (tree_of_path Module p, s)
+      Oide_dot (tree_of_path ~disambiguation Module p, s)
   | Papply(p1, p2) ->
-      Oide_apply (tree_of_path Module p1, tree_of_path Module p2)
+      let t1 = tree_of_path ~disambiguation Module p1 in
+      let t2 = tree_of_path ~disambiguation Module p2 in
+      Oide_apply (t1, t2)
   | Pextra_ty (p, extra) -> begin
       (* inline record types are syntactically prevented from escaping their
          binding scope, and are never shown to users. *)
@@ -435,8 +376,13 @@ let rec tree_of_path namespace = function
           tree_of_path Other p
     end
 
-let tree_of_path namespace p =
-  tree_of_path namespace (rewrite_double_underscore_paths !printing_env p)
+let tree_of_path ?disambiguation namespace p =
+  tree_of_path ?disambiguation namespace
+    (rewrite_double_underscore_paths !printing_env p)
+
+let best_tree_of_type_path p p' =
+  if p == p' then tree_of_path Type p'
+  else tree_of_path ~disambiguation:false Other p'
 
 let path ppf p =
   !Oprint.out_ident ppf (tree_of_path Other p)
@@ -445,7 +391,6 @@ let string_of_path p =
   Format.asprintf "%a" path p
 
 let strings_of_paths namespace p =
-  reset_naming_context ();
   let trees = List.map (tree_of_path namespace) p in
   List.map (Format.asprintf "%a" !Oprint.out_ident) trees
 
@@ -711,7 +656,7 @@ let set_printing_env env =
   end
 
 let wrap_printing_env env f =
-  set_printing_env env; reset_naming_context ();
+  set_printing_env env;
   try_finally f ~always:(fun () -> set_printing_env Env.empty)
 
 let wrap_printing_env ~error env f =
@@ -1064,7 +1009,7 @@ let reset_except_context () =
   Names.reset_names (); reset_loop_marks ()
 
 let reset () =
-  reset_naming_context (); Conflicts.reset ();
+  Conflicts.reset ();
   reset_except_context ()
 
 let prepare_for_printing tyl =
@@ -1115,7 +1060,9 @@ let rec tree_of_typexp mode ty =
         let tyl' = apply_subst s tyl in
         if is_nth s && not (tyl'=[])
         then tree_of_typexp mode (List.hd tyl')
-        else Otyp_constr (tree_of_path Type p', tree_of_typlist mode tyl')
+        else
+          let tpath = best_tree_of_type_path p p' in
+          Otyp_constr (tpath, tree_of_typlist mode tyl')
     | Tvariant row ->
         let Row {fields; name; closed} = row_repr row in
         let fields =
@@ -1134,7 +1081,7 @@ let rec tree_of_typexp mode ty =
         begin match name with
         | Some(p, tyl) when nameable_row row ->
             let (p', s) = best_type_path p in
-            let id = tree_of_path Type p' in
+            let id = best_tree_of_type_path p p' in
             let args = tree_of_typlist mode (apply_subst s tyl) in
             let out_variant =
               if is_nth s then List.hd args else Otyp_constr (id, args) in
@@ -1234,7 +1181,7 @@ and tree_of_typobject mode fi nm =
       let args = tree_of_typlist mode tyl in
       let (p', s) = best_type_path p in
       assert (s = Id);
-      Otyp_class (non_gen, tree_of_path Type p', args)
+      Otyp_class (non_gen, best_tree_of_type_path p p', args)
   | _ ->
       fatal_error "Printtyp.tree_of_typobject"
   end
@@ -1282,8 +1229,8 @@ let type_scheme ppf ty =
 
 let type_path ppf p =
   let (p', s) = best_type_path p in
-  let p = if (s = Id) then p' else p in
-  let t = tree_of_path Type p in
+  let p'' = if (s = Id) then p' else p in
+  let t = best_tree_of_type_path p p'' in
   !Oprint.out_ident ppf t
 
 let tree_of_type_scheme ty =
@@ -1878,8 +1825,7 @@ and tree_of_signature_rec env' sg =
   let collect_trees_of_rec_group group =
     let env = !printing_env in
     let env', group_trees =
-      Naming_context.with_ctx
-        (fun () -> trees_of_recursive_sigitem_group env group)
+       trees_of_recursive_sigitem_group env group
     in
     set_printing_env env';
     (env, group_trees) in
@@ -1957,7 +1903,6 @@ let modtype_declaration id ppf decl =
 
 let print_items showval env x =
   Names.refresh_weak();
-  reset_naming_context ();
   Conflicts.reset ();
   let extend_val env (sigitem,outcome) = outcome, showval env sigitem in
   let post_process (env,l) = List.map (extend_val env) l in
@@ -1975,7 +1920,6 @@ let signature ppf sg =
 let printed_signature sourcefile ppf sg =
   (* we are tracking any collision event for warning 63 *)
   Conflicts.reset ();
-  reset_naming_context ();
   let t = tree_of_signature sg in
   if Warnings.(is_active @@ Erroneous_printed_signature "")
   && Conflicts.exists ()

--- a/typing/printtyp.ml
+++ b/typing/printtyp.ml
@@ -271,14 +271,13 @@ let with_hidden ids f =
   protect_refs [ R(bound_in_recursion, updated )] f
 
 let human_id id index =
+  (* The identifier with index [k] is the (k+1)-th most recent identifier in
+     the printing environment. We print them as [name/(k+1)] except for [k=0]
+     which is printed as [name] rather than [name/1].
+  *)
   if index = 0 then
     Ident.name id
   else
-  (* We print the most k-time overshadowed identifier as `name/(k+1)`.
-     This naming scheme has the advantage of creating a non-ambiguous gap
-     between the identifier in scope, which is printed as `name`, and the
-     most recent shadowed identifier, printed as `name/2`.
-  *)
     let ordinal = index + 1 in
     String.concat "/" [Ident.name id; string_of_int ordinal]
 

--- a/typing/printtyp.ml
+++ b/typing/printtyp.ml
@@ -305,7 +305,7 @@ let indexed_name namespace id =
         in_printing_env (find namespace id)
   in
   let index =
-    (* The  [None] case is potentially problematic, it might indicate that
+    (* If [index] is [None] at this point, it might indicate that
        the identifier id is not defined in the environment, while there
        are other identifiers in scope that share the same name.
        Currently, this kind of partially incoherent environment happens

--- a/typing/printtyp.ml
+++ b/typing/printtyp.ml
@@ -144,10 +144,16 @@ module Conflicts = struct
 
   let collect_explanation namespace id ~name =
     let root_name = Ident.name id in
+    (* if [name] is of the form "root_name/%d", we register both
+      [id] and the identifier in scope for [root_name].
+     *)
     if root_name <> name && not (M.mem name !explanations) then
       begin
         add namespace name id;
         if not (M.mem root_name !explanations) then
+          (* lookup the identifier in scope with name [root_name] and
+             add it too
+           *)
           match Namespace.lookup namespace root_name with
           | Pident root_id -> add namespace root_name root_id
           | exception Not_found | _ -> ()

--- a/typing/printtyp.ml
+++ b/typing/printtyp.ml
@@ -240,9 +240,9 @@ let enable b = enabled := b
      type t = A
    end
    type t = X
-   type u = t * t
+   type u = [` A of t * t ]
    module M = struct
-     type t = A of u
+     type t = A of [ u | `B ]
      type r = Avoid__me.t
    end
   }]

--- a/typing/printtyp.ml
+++ b/typing/printtyp.ml
@@ -232,7 +232,28 @@ let enabled = ref true
 let enable b = enabled := b
 
 (* Names bound in recursive definitions should be considered as bound
-   in the environment when printing identifiers *)
+   in the environment when printing identifiers but not when trying
+   to find shortest path.
+   For instance, if we define
+   [{
+   module Avoid__me = struct
+     type t = A
+   end
+   type t = X
+   type u = t * t
+   module M = struct
+     type t = A of u
+     type r = Avoid__me.t
+   end
+  }]
+  It is is important that in the definition of [t] that the outer type [t] is
+  printed as [t/2] reserving the name [t] to the type being defined in the
+  current recursive definition.
+     Contrarily, in the definition of [r], one should not shorten the
+  path [Avoid__me.t] to [r] until the end of the definition of [r].
+  The [bound_in_recursion] bridges the gap between those two slightly different
+  notions of printing environment.
+*)
 let bound_in_recursion = ref M.empty
 
 (* When dealing with functor arguments, identity becomes fuzzy because the same

--- a/typing/printtyp.ml
+++ b/typing/printtyp.ml
@@ -144,7 +144,7 @@ module Conflicts = struct
 
   let collect_explanation namespace id ~name =
     let root_name = Ident.name id in
-    if root_name != name && not (M.mem name !explanations) then
+    if root_name <> name && not (M.mem name !explanations) then
       begin
         add namespace name id;
         if not (M.mem root_name !explanations) then

--- a/typing/printtyp.mli
+++ b/typing/printtyp.mli
@@ -58,9 +58,6 @@ module Naming_context: sig
   val enable: bool -> unit
   (** When contextual names are enabled, the mapping between identifiers
       and names is ensured to be one-to-one. *)
-
-  val reset: unit -> unit
-  (** Reset the naming context *)
 end
 
 (** The [Conflicts] module keeps track of conflicts arising when attributing

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -1799,7 +1799,6 @@ let report_error ppf = function
       let reaching_path = Reaching_path.simplify reaching_path in
       Printtyp.prepare_for_printing [used_as; defined_as];
       Reaching_path.add_to_preparation reaching_path;
-      Printtyp.Naming_context.reset ();
       fprintf ppf
         "@[<hv>This recursive type is not regular.@ \
          The type constructor %s is defined as@;<1 2>type %a@ \


### PR DESCRIPTION
Following the discussion in #11286, this PR proposes to have a simple and clear specification for disambiguated identifiers (t/2, t/3, ...) by using De Bruijn indice to disambiguate identifiers that share the same name. 

Currently, path disambiguation in error message has a complex and hard to document behavior.
For instance, if we define
```ocaml
type t = A;;
type t = B;;
type t = C;;
```
then if the type of `A` appears in an error message it might displayed as `t/2` or `t/3` depending on previous part of the error message.
For instance, both
```ocaml
let x, y = A, B in y = x;;
```
and
```ocaml
let x, y = A, B in x = y;;
```
prints the same error message
```
Error: This expression has type t/2 but an expression was expected of type
         t/3
```
while pointing to the right-hand side of the equality because they attribute the same disambiguated name to different identifiers.

With this PR, an identifier that has been shadowed `n` (n ≥ 1) time in the current scope will be displayed as `name/(n+1)`.
Consequently, the displayed name of identifiers is stable as long as one does not introduce a new identifier with the same name.

In the previous example, this means that the type of A is consistently displayed as `t/3`
```ocaml
A;;
```
```
- : t/3 = A
```

With this specification, it is no longer necessary to keep track of the naming decision for identifiers in the `Printtyp` module.
This reduces the complexity of the `Printtyp` module by removing one layer of global state. It would be also easier reuse this naming scheme for the illegal shadowing error messages which currently use the inner identifier stamp to avoid dealing with the complexity in `Printtyp`.

One potential drawback of this approach is that bad printing environment might fail to provide enough information to disambiguate some identifiers. This can currently happens in the functor error message. Indeed, the printing environment is not updated when we are printing the argument-by-argument suberror message. However, in the context of a functor error message, we often end up with a divergent environment between the left-hand side and right-hand side of the functor comparison. In this situation, it might be *better* to not over-eagerly disambiguate identifiers.
Morever, bad printing environment are already problematic for the short-paths. It thus seem reasonable to commit to having good printing environment.