### PR TITLE
Lower the level of ty_res rather than funct

### DIFF
--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -3051,7 +3051,8 @@ and type_expect_
       begin_def ();
       let (args, ty_res) = type_application env funct sargs in
       end_def ();
-      unify_var env (newvar()) funct.exp_type;
+      (* Ensure that ty_res is at current level *)
+      unify_var env (newvar()) ty_res;
       rue {
         exp_desc = Texp_apply(funct, args);
         exp_loc = loc; exp_extra = [];


### PR DESCRIPTION
Some old code was lowering the level on the wrong type.
I.e., when we return a typedtree node, we should ensure that its type is at `current_level`, but we don't need to ensure that on children.

This was probably a bug, but it was not detected by the testsuite.