### PR TITLE
dune: fix build of primitives

### DIFF
--- a/runtime/dune
+++ b/runtime/dune
@@ -16,15 +16,18 @@
  (targets primitives)
  (mode    fallback)
  (deps
-   ; matches the line structure of files in gen_primitives.sh
+   ; Keep in sync with gen_primitives.sh
    alloc.c array.c compare.c extern.c floats.c gc_ctrl.c hash.c intern.c
      interp.c ints.c io.c
    lexing.c md5.c meta.c memprof.c obj.c parsing.c signals.c str.c sys.c
      callback.c weak.c
-   finalise.c dynlink.c backtrace_byt.c backtrace.c
-     afl.c
-   bigarray.c runtime_events.c)
- (action  (with-stdout-to %{targets} (run %{dep:gen_primitives.sh}))))
+   finalise.c domain.c platform.c fiber.c memory.c startup_aux.c
+     runtime_events.c sync.c
+   dynlink.c backtrace_byt.c backtrace.c afl.c
+   bigarray.c prng.c)
+ (action
+   (with-stdout-to %{targets}
+                   (run %{dep:gen_primitives.sh} "RUNNING_FROM_RUNTIME_DIR"))))
 
 (rule
  (targets libcamlrun.a)
@@ -35,17 +38,15 @@
    ../Makefile.config_if_required
    ../Makefile.common Makefile
    (glob_files caml/*.h)
-   ; matches the line structure of files in Makefile/BYTECODE_C_SOURCES
-   interp.c misc.c fix_code.c startup_aux.c startup_byt.c freelist.c
-     major_gc.c
-   minor_gc.c memory.c alloc.c roots_byt.c globroots.c fail_byt.c signals.c
-   signals_byt.c printexc.c backtrace_byt.c backtrace.c compare.c ints.c
-   floats.c str.c array.c io.c extern.c intern.c hash.c sys.c meta.c parsing.c
-     gc_ctrl.c  md5.c obj.c
-   lexing.c callback.c debugger.c weak.c compact.c finalise.c custom.c dynlink.c
-   afl.c unix.c win32.c bigarray.c main.c memprof.c domain.c
-   skiplist.c codefrag.c
- )
+   ; Keep in sync Makefile/BYTECODE_C_SOURCES
+   addrmap.c afl.c alloc.c array.c backtrace.c bigarray.c callback.c codefrag.c
+   compare.c custom.c debugger.c domain.c dynlink.c extern.c fiber.c finalise.c
+   floats.c gc_ctrl.c gc_stats.c globroots.c hash.c intern.c ints.c io.c
+   lexing.c lf_skiplist.c main.c major_gc.c md5.c memory.c memprof.c meta.c
+   minor_gc.c misc.c obj.c parsing.c platform.c printexc.c prng.c roots.c
+   runtime_events.c shared_heap.c signals.c skiplist.c startup_aux.c str.c
+   sync.c sys.c unix.c ; or win32
+   weak.c backtrace_byt.c fail_byt.c fix_code.c interp.c startup_byt.c)
  (action
    (progn
      (bash "touch .depend") ; hack.

--- a/runtime/gen_primitives.sh
+++ b/runtime/gen_primitives.sh
@@ -28,9 +28,20 @@ export LC_ALL=C
       dynlink backtrace_byt backtrace afl \
       bigarray prng
   do
-      sed -n -e 's/^CAMLprim value \([a-z0-9_][a-z0-9_]*\).*/\1/p' \
-        "runtime/$prim.c"
+      if [[ $1 = "RUNNING_FROM_RUNTIME_DIR" ]]; then
+          output="$prim.c"
+      else
+          output="runtime/$prim.c"
+      fi
+
+      sed -n -e 's/^CAMLprim value \([a-z0-9_][a-z0-9_]*\).*/\1/p' $output
   done
+
+  if [[ $1 = "RUNNING_FROM_RUNTIME_DIR" ]]; then
+      output="ints.c"
+  else
+      output="runtime/ints.c"
+  fi
   sed -n -e 's/^CAMLprim_int64_[0-9](\([a-z0-9_][a-z0-9_]*\)).*/caml_int64_\1\
-caml_int64_\1_native/p' runtime/ints.c
+caml_int64_\1_native/p' $output
 ) | sort | uniq


### PR DESCRIPTION
Two things here:
- the list of files to consider wasn't up to date
- `gen_primitives.sh` had changed and assumed it was being run from the root of the repository; I decided to add "a flag" to change that behavior … pardon my bash.

cc @OlivierNicole 