### PR TITLE
Fix [@deprecated_mutable], which couldn't be triggered.

### DIFF
--- a/Changes
+++ b/Changes
@@ -110,7 +110,7 @@ Working version
 ### Bug fixes:
 
 - #11516, #11524: Fix the `deprecated_mutable` attribute.
-  (Chris Casinghino, review by TBD)
+  (Chris Casinghino, review by Nicolás Ojeda Bär)
 
 - #11302, #11412: `ocamlc` and `ocamlopt` should not remove generated files
   when they are not regular files.

--- a/Changes
+++ b/Changes
@@ -109,6 +109,9 @@ Working version
 
 ### Bug fixes:
 
+- #11516, #11524: Fix the `deprecated_mutable` attribute.
+  (Chris Casinghino, review by TBD)
+
 - #11302, #11412: `ocamlc` and `ocamlopt` should not remove generated files
   when they are not regular files.
   (Xavier Leroy, report by Thierry Martinez, review by

--- a/Changes
+++ b/Changes
@@ -109,9 +109,6 @@ Working version
 
 ### Bug fixes:
 
-- #11516, #11524: Fix the `deprecated_mutable` attribute.
-  (Chris Casinghino, review by Nicolás Ojeda Bär)
-
 - #11302, #11412: `ocamlc` and `ocamlopt` should not remove generated files
   when they are not regular files.
   (Xavier Leroy, report by Thierry Martinez, review by
@@ -597,6 +594,9 @@ OCaml 5.0
   (Christiano Haesbaert and Gabriel Scherer,
    review by Xavier Leroy,
    report by Jan Midtgaard and Tom Kelly)
+
+- #11516, #11524: Fix the `deprecated_mutable` attribute.
+  (Chris Casinghino, review by Nicolás Ojeda Bär and Florian Angeletti)
 
 OCaml 4.14.0 (28 March 2022)
 ----------------------------

--- a/testsuite/tests/warnings/deprecated_mutable.compilers.reference
+++ b/testsuite/tests/warnings/deprecated_mutable.compilers.reference
@@ -1,0 +1,4 @@
+File "deprecated_mutable.ml", line 13, characters 11-12:
+13 | let () = y.x <- 42
+                ^
+Alert deprecated: mutating field x

--- a/testsuite/tests/warnings/deprecated_mutable.ml
+++ b/testsuite/tests/warnings/deprecated_mutable.ml
@@ -1,0 +1,13 @@
+(* TEST
+
+flags = "-w +A-70"
+
+* bytecode
+
+*)
+
+type t = {mutable x : int [@deprecated_mutable]}
+
+let y : t = {x = 5}
+
+let () = y.x <- 42

--- a/typing/env.ml
+++ b/typing/env.ml
@@ -104,7 +104,7 @@ let add_label_usage lu usage =
     lu.lu_mutation <- true;
     lu.lu_construct <- true
 
-let is_mutable_label_usage = function
+let is_mutating_label_usage = function
   | Mutation -> true
   | (Projection | Construct | Exported_private | Exported) -> false
 
@@ -2728,7 +2728,7 @@ let use_label ~use ~loc usage env lbl =
   if use then begin
     mark_label_description_used usage env lbl;
     Builtin_attributes.check_alerts loc lbl.lbl_attributes lbl.lbl_name;
-    if is_mutable_label_usage usage then
+    if is_mutating_label_usage usage then
       Builtin_attributes.check_deprecated_mutable loc lbl.lbl_attributes
         lbl.lbl_name
   end

--- a/typing/env.ml
+++ b/typing/env.ml
@@ -104,6 +104,10 @@ let add_label_usage lu usage =
     lu.lu_mutation <- true;
     lu.lu_construct <- true
 
+let is_mutable_label_usage = function
+  | Mutation -> true
+  | (Projection | Construct | Exported_private | Exported) -> false
+
 let label_usages () =
   {lu_projection = false; lu_mutation = false; lu_construct = false}
 
@@ -2723,7 +2727,10 @@ let use_cltype ~use ~loc path desc =
 let use_label ~use ~loc usage env lbl =
   if use then begin
     mark_label_description_used usage env lbl;
-    Builtin_attributes.check_alerts loc lbl.lbl_attributes lbl.lbl_name
+    Builtin_attributes.check_alerts loc lbl.lbl_attributes lbl.lbl_name;
+    if is_mutable_label_usage usage then
+      Builtin_attributes.check_deprecated_mutable loc lbl.lbl_attributes
+        lbl.lbl_name
   end
 
 let use_constructor_desc ~use ~loc usage env cstr =


### PR DESCRIPTION
This repairs the `deprecated_mutable` attribute, which is currently broken.  For example, the following program does not result in a warning, but did in OCaml 4.09.1:

```ocaml
type t = {mutable x : int [@deprecated_mutable]}

let y : t = {x = 5}

let () = y.x <- 42
```

It looks like the check for the warning was accidentally removed in #2127.  This PR restores the old behavior and adds a corresponding test case.

Fixes #11516.