### PR TITLE
documentation: str doesn't know about unicode

### DIFF
--- a/otherlibs/str/str.mli
+++ b/otherlibs/str/str.mli
@@ -18,6 +18,10 @@
 
 (** {1 Regular expressions} *)
 
+(**
+  The {!Str} library provides regular expressions on sequences of bytes.
+  It is, in general, unsuitable to match Unicode characters.
+*)
 
 type regexp
 (** The type of compiled regular expressions. *)


### PR DESCRIPTION
This PR proposes to add a warning in the documentation that the the `Str` library implements regular expressions for strings seen as sequence of `Char.t`, and is not aware of any unicode interpretation for the contents of strings.

Close #11269