### PR TITLE
stdlib: add an experimental alert to the Effect and Domain modules

### DIFF
--- a/stdlib/domain.mli
+++ b/stdlib/domain.mli
@@ -16,6 +16,10 @@
 (*                                                                        *)
 (**************************************************************************)
 
+[@@@alert unstable
+    "The Domain interface may change in incompatible ways in the future."
+]
+
 type !'a t
 (** A domain of type ['a t] runs independently, eventually producing a
     result of type 'a, or an exception *)

--- a/stdlib/effect.mli
+++ b/stdlib/effect.mli
@@ -12,6 +12,10 @@
 (*                                                                        *)
 (**************************************************************************)
 
+[@@@alert unstable
+    "The Effect interface may change in incompatible ways in the future."
+]
+
 (** Effects.
 
     @since 5.0 *)

--- a/stdlib/format.mli
+++ b/stdlib/format.mli
@@ -963,6 +963,7 @@ val formatter_of_out_channel : out_channel -> formatter
 
 val synchronized_formatter_of_out_channel :
   out_channel -> formatter Domain.DLS.key
+[@@alert unstable][@@alert "-unstable"]
 (** [synchronized_formatter_of_out_channel oc] returns the key to the
     domain-local state that holds the domain-local formatter for writing to the
     corresponding output channel [oc].
@@ -1041,6 +1042,7 @@ val make_formatter :
 
 val make_synchronized_formatter :
   (string -> int -> int -> unit) -> (unit -> unit) -> formatter Domain.DLS.key
+[@@alert unstable][@@alert "-unstable"]
 (** [make_synchronized_formatter out flush] returns the key to the domain-local
     state that holds the domain-local formatter that outputs with function
     [out], and flushes with function [flush].

--- a/stdlib/stdlib.mli
+++ b/stdlib/stdlib.mli
@@ -1401,7 +1401,15 @@ module Complex        = Complex
 module Condition      = Condition
 module Digest         = Digest
 module Domain         = Domain
+[@@alert "-unstable"]
+[@@alert unstable
+    "The Domain interface may change in incompatible ways in the future."
+]
 module Effect         = Effect
+[@@alert "-unstable"]
+[@@alert unstable
+    "The Effect interface may change in incompatible ways in the future."
+]
 module Either         = Either
 module Ephemeron      = Ephemeron
 module Filename       = Filename

--- a/utils/warnings.ml
+++ b/utils/warnings.ml
@@ -856,9 +856,12 @@ let parse_options errflag s =
 (* If you change these, don't forget to change them in man/ocamlc.m *)
 let defaults_w = "+a-4-7-9-27-29-30-32..42-44-45-48-50-60-66..70"
 let defaults_warn_error = "-a+31"
+let default_disabled_alerts = [ "unstable" ]
 
 let () = ignore @@ parse_options false defaults_w
 let () = ignore @@ parse_options true defaults_warn_error
+let () =
+  List.iter (set_alert ~error:false ~enable:false) default_disabled_alerts
 
 let ref_manual_explanation () =
   (* manual references are checked a posteriori by the manual


### PR DESCRIPTION
As discussed in #11074, this PR proposes to add an `experimental` alert to the `Effect` and `Domain` module to make it extra-explicit that the interface of those modules might change in later versions.

The alert is disabled by default.

For now, I am using `ocaml5_experimental` to emphasize the point that those modules are experimental feature in OCaml 5 and make it easier to selectively enable (or disable) this alert.