### PR TITLE
Include kinds in kind mismatch error message

### DIFF
--- a/Changes
+++ b/Changes
@@ -84,6 +84,9 @@ Working version
 
 ### Compiler user-interface and warnings:
 
+- #11530: Include kinds in kind mismatch error message.
+  (Leonhard Markert, review by Gabriel Scherer and Florian Angeletti)
+
 - #10818: Preserve integer literal formatting in type hint.
   (Leonhard Markert, review by Gabriel Scherer and Florian Angeletti)
 

--- a/testsuite/tests/typing-extensions/open_types.ml
+++ b/testsuite/tests/typing-extensions/open_types.ml
@@ -82,7 +82,7 @@ Line 1, characters 0-19:
 1 | type baz = bar = ..
     ^^^^^^^^^^^^^^^^^^^
 Error: This variant or record definition does not match that of type bar
-       Their kinds differ.
+       The original is abstract, but this is an extensible variant.
 |}]
 
 (* Abbreviations need to match parameters *)
@@ -176,7 +176,7 @@ Error: Signature mismatch:
          type foo = M.foo
        is not included in
          type foo = ..
-       Their kinds differ.
+       The first is abstract, but the second is an extensible variant.
 |}]
 
 (* Check that signatures can make exstensibility private *)

--- a/testsuite/tests/typing-kind/kind_mismatch.ml
+++ b/testsuite/tests/typing-kind/kind_mismatch.ml
@@ -1,0 +1,27 @@
+(* TEST
+   * expect
+*)
+
+(** Error messages for kind mismatches. *)
+
+module T0 : sig type t end = struct type t = unit end
+type t0 = T0.t = { a0 : int };;
+[%%expect {|
+module T0 : sig type t end
+Line 4, characters 0-29:
+4 | type t0 = T0.t = { a0 : int };;
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This variant or record definition does not match that of type T0.t
+       The original is abstract, but this is a record.
+|}]
+
+type t2a = ..
+type t2b = t2a = A2 | B2;;
+[%%expect {|
+type t2a = ..
+Line 2, characters 0-24:
+2 | type t2b = t2a = A2 | B2;;
+    ^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This variant or record definition does not match that of type t2a
+       The original is an extensible variant, but this is a variant.
+|}]

--- a/testsuite/tests/typing-misc/enrich_typedecl.ml
+++ b/testsuite/tests/typing-misc/enrich_typedecl.ml
@@ -95,7 +95,7 @@ Error: Signature mismatch:
          type 'a t = 'a C.t = A of 'a | B
        is not included in
          type 'a t = { x : 'a; }
-       Their kinds differ.
+       The first is a variant, but the second is a record.
 |}];;
 
 

--- a/testsuite/tests/typing-misc/records.ml
+++ b/testsuite/tests/typing-misc/records.ml
@@ -208,7 +208,7 @@ Line 1, characters 0-59:
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This variant or record definition does not match that of type
          ('a, [> `A ]) def
-       Their kinds differ.
+       The original is a record, but this is a variant.
 |}]
 
 type d = { x:int; y : int }

--- a/testsuite/tests/typing-misc/variant.ml
+++ b/testsuite/tests/typing-misc/variant.ml
@@ -77,7 +77,7 @@ Line 1, characters 0-65:
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This variant or record definition does not match that of type
          ('a, [> `A ]) def
-       Their kinds differ.
+       The original is a variant, but this is a record.
 |}]
 
 type d = X of int | Y of int

--- a/testsuite/tests/typing-modules-bugs/pr6293_bad.compilers.reference
+++ b/testsuite/tests/typing-modules-bugs/pr6293_bad.compilers.reference
@@ -7,6 +7,6 @@ Error: In this `with' constraint, the new definition of t
          type t
        is not included in
          type t = { a : int; b : int; }
-       Their kinds differ.
+       The first is abstract, but the second is a record.
        File "pr6293_bad.ml", line 9, characters 20-50: Expected declaration
        File "pr6293_bad.ml", line 10, characters 18-37: Actual declaration

--- a/testsuite/tests/typing-modules/inclusion_errors.ml
+++ b/testsuite/tests/typing-modules/inclusion_errors.ml
@@ -1602,7 +1602,7 @@ Error: Signature mismatch:
          type t = private { x : int; y : bool; }
        is not included in
          type t = A | B
-       Their kinds differ.
+       The first is a record, but the second is a variant.
 |}];;
 
 module M : sig
@@ -1624,7 +1624,7 @@ Error: Signature mismatch:
          type t = private A | B
        is not included in
          type t = { x : int; y : bool; }
-       Their kinds differ.
+       The first is a variant, but the second is a record.
 |}];;
 
 module M : sig

--- a/typing/includecore.mli
+++ b/typing/includecore.mli
@@ -43,6 +43,14 @@ type privacy_mismatch =
   | Private_extensible_variant
   | Private_row_type
 
+type type_kind =
+  | Kind_abstract
+  | Kind_record
+  | Kind_variant
+  | Kind_open
+
+type kind_mismatch = type_kind * type_kind
+
 type label_mismatch =
   | Type of Errortrace.equality_error
   | Mutability of position
@@ -85,7 +93,7 @@ type private_object_mismatch =
 type type_mismatch =
   | Arity
   | Privacy of privacy_mismatch
-  | Kind
+  | Kind of kind_mismatch
   | Constraint of Errortrace.equality_error
   | Manifest of Errortrace.equality_error
   | Private_variant of type_expr * type_expr * private_variant_mismatch


### PR DESCRIPTION
Closes https://github.com/ocaml/ocaml/issues/11529.

# User-visible changes

For the following code:

```ocaml
module M : sig type t end = struct type t = { i : int } end
type t = M.t = { i : int };;
```

**Before**

```
2 | type t = M.t = { i : int };;
    ^^^^^^^^^^^^^^^^^^^^^^^^^^
Error: This variant or record definition does not match that of type M.t
       Their kinds differ.
```

**After**

```
2 | type t = M.t = { i : int };;
    ^^^^^^^^^^^^^^^^^^^^^^^^^^
Error: This variant or record definition does not match that of type M.t
       The original is abstract, but this is a record.
```

Similarly when one type is a record and the other is a variant or extensible variant.