### PR TITLE
Promise that Array.init calls function in order

### DIFF
--- a/stdlib/array.mli
+++ b/stdlib/array.mli
@@ -72,7 +72,7 @@ val init : int -> (int -> 'a) -> 'a array
 (** [init n f] returns a fresh array of length [n],
    with element number [i] initialized to the result of [f i].
    In other terms, [init n f] tabulates the results of [f]
-   applied to the integers [0] to [n-1].
+   applied in order to the integers [0] to [n-1].
 
    @raise Invalid_argument if [n < 0] or [n > Sys.max_array_length].
    If the return type of [f] is [float], then the maximum

--- a/stdlib/arrayLabels.mli
+++ b/stdlib/arrayLabels.mli
@@ -72,7 +72,7 @@ val init : int -> f:(int -> 'a) -> 'a array
 (** [init n ~f] returns a fresh array of length [n],
    with element number [i] initialized to the result of [f i].
    In other terms, [init n ~f] tabulates the results of [f]
-   applied to the integers [0] to [n-1].
+   applied in order to the integers [0] to [n-1].
 
    @raise Invalid_argument if [n < 0] or [n > Sys.max_array_length].
    If the return type of [f] is [float], then the maximum


### PR DESCRIPTION
The function `Array.init` does not promise to call the given function on each element in order, left to right. I think it should. The implementation already conforms, but the documentation does not mention it. `List.init` does specify evaluation order, by contrast.

The motivation is this: imagine we are using a stateful function to read some equal-sized fields of binary data from a source of data (this example is from TrueType fonts):

```
let endCodes = Array.make segCount 0 in
  for x = 0 to segCount - 1 do
    endCodes.(x) <- read_ushort b
  done
```

If we had to do this many times, we could write an ancillary function, of course, But it would be nicer to simply write:

```
let endCodes = Array.init segCount (fun _ -> read_ushort b) in ...
```

We cannot however - according to the current documentation, the values read could come out in any order.

(In fact, searching my existing code, it looks like I've been relying on this undocumented left-to-right order for years... maybe others have too.)