### PR TITLE
Fix flexlink flags passed when creating DLLs

### DIFF
--- a/Makefile.config.in
+++ b/Makefile.config.in
@@ -83,6 +83,7 @@ AS_HAS_DEBUG_PREFIX_MAP=@as_has_debug_prefix_map@
 # our own symbols):
 OC_LDFLAGS=@oc_ldflags@
 OC_DLL_LDFLAGS=@oc_dll_ldflags@
+OC_EXE_LDFLAGS=@oc_exe_ldflags@
 
 LDFLAGS?=@LDFLAGS@
 
@@ -219,7 +220,8 @@ MKEXE=@mkexe@
 MKDLL=@mkdll@
 MKMAINDLL=@mkmaindll@
 MKEXEDEBUGFLAG=@mkexedebugflag@
-MKEXE_VIA_CC=$(CC) $(OC_CFLAGS) $(CFLAGS) @mkexe_via_cc_ldflags@
+MKEXE_VIA_CC=\
+  $(CC) $(OC_EXE_LDFLAGS) $(OC_CFLAGS) $(CFLAGS) @mkexe_via_cc_ldflags@
 
 RUNTIMED=@debug_runtime@
 INSTRUMENTED_RUNTIME=@instrumented_runtime@

--- a/Makefile.config.in
+++ b/Makefile.config.in
@@ -213,7 +213,7 @@ CMXS=@cmxs@
 # or OCAML_FLEXLINK overriding will not work (see utils/config.mlp)
 
 FLEXDLL_CHAIN=@flexdll_chain@
-FLEXLINK_FLAGS=@mkexe_extra_flags@
+FLEXLINK_FLAGS=@flexlink_flags@
 
 MKEXE=@mkexe@
 MKDLL=@mkdll@

--- a/configure
+++ b/configure
@@ -13382,7 +13382,8 @@ else
 fi
       mkexe_cflags=''
       mkexe_ldflags_prefix='-link '
-      mkexe_extra_flags=''
+else
+  mkexe_extra_flags=''
       oc_ldflags='-Wl,--stack,16777216'
 
 fi

--- a/configure
+++ b/configure
@@ -13410,7 +13410,7 @@ else
 fi
     mkexe_cflags=''
     mkexe_ldflags_prefix='-link '
-    oc_ldflags='-municode'
+    mkexe_extra_flags='-link -municode'
     SO="dll" ;; #(
   *,*-pc-windows) :
     toolchain=msvc
@@ -13425,7 +13425,7 @@ fi
     mkexe_cflags=''
     mkexe_ldflags_prefix='-link '
     mkexe_via_cc_ldflags_prefix='/link '
-    oc_ldflags='/ENTRY:wmainCRTStartup'
+    mkexe_extra_flags='-link /ENTRY:wmainCRTStartup'
     mkexedebugflag='' ;; #(
   *,x86_64-*-linux*) :
     $as_echo "#define HAS_ARCH_CODE32 1" >>confdefs.h

--- a/configure
+++ b/configure
@@ -819,6 +819,7 @@ mklib
 AR
 shebangscripts
 long_shebang
+flexlink_flags
 flexdll_dir
 bootstrapping_flexdll
 flexdir
@@ -2919,6 +2920,7 @@ OCAML_VERSION_SHORT=5.1
 # Note: This is present for the flexdll bootstrap where it exposed as the old
 # TOOLPREF variable. It would be better if flexdll where updated to require
 # WINDRES instead.
+
 
 
 
@@ -13027,29 +13029,30 @@ fi
 # The flexlink command
 
 flexlink_cmd=flexlink
+flexlink_flags=''
 
 # Define flexlink chain and flags correctly for the different Windows ports
 case $host in #(
   i686-*-cygwin) :
     flexdll_chain='cygwin'
-    mkexe_extra_flags='-merge-manifest -stack 16777216' ;; #(
+    flexlink_flags='-merge-manifest -stack 16777216' ;; #(
   x86_64-*-cygwin) :
     flexdll_chain='cygwin64'
-    mkexe_extra_flags='-merge-manifest -stack 16777216' ;; #(
+    flexlink_flags='-merge-manifest -stack 16777216' ;; #(
   *-*-cygwin*) :
     as_fn_error $? "unknown cygwin variant" "$LINENO" 5 ;; #(
   i686-w64-mingw32) :
     flexdll_chain='mingw'
-    mkexe_extra_flags='-stack 16777216' ;; #(
+    flexlink_flags='-stack 16777216' ;; #(
   x86_64-w64-mingw32) :
     flexdll_chain='mingw64'
-    mkexe_extra_flags='-stack 33554432' ;; #(
+    flexlink_flags='-stack 33554432' ;; #(
   i686-pc-windows) :
     flexdll_chain='msvc'
-    mkexe_extra_flags='-merge-manifest -stack 16777216' ;; #(
+    flexlink_flags='-merge-manifest -stack 16777216' ;; #(
   x86_64-pc-windows) :
     flexdll_chain='msvc64'
-    mkexe_extra_flags='-merge-manifest -stack 33554432' ;; #(
+    flexlink_flags='-merge-manifest -stack 33554432' ;; #(
   *) :
     flexdll_chain='' ;;
 esac
@@ -13374,9 +13377,10 @@ case $cc_basename,$host in #(
   *,*-*-cygwin*) :
     common_cppflags="$common_cppflags -U_WIN32"
     if $supports_shared_libraries; then :
-  mkexe_cmd_exp="flexlink -exe -chain ${flexdll_chain}"
+  mkexe_cmd_exp="flexlink -exe -chain ${flexdll_chain} ${flexlink_flags}"
       if $bootstrapping_flexdll; then :
-  mkexe_cmd="$boot_flexlink_cmd -exe -chain ${flexdll_chain}"
+  mkexe_cmd=\
+"$boot_flexlink_cmd -exe -chain ${flexdll_chain} ${flexlink_flags}"
 else
   mkexe_cmd="$mkexe_cmd_exp"
 fi
@@ -13397,9 +13401,10 @@ fi
 esac
     ostype="Win32"
     toolchain="mingw"
-    mkexe_cmd_exp="flexlink -exe -chain ${flexdll_chain}"
+    mkexe_cmd_exp="flexlink -exe -chain ${flexdll_chain} ${flexlink_flags}"
     if $bootstrapping_flexdll; then :
-  mkexe_cmd="${boot_flexlink_cmd} -exe -chain ${flexdll_chain}"
+  mkexe_cmd=\
+"${boot_flexlink_cmd} -exe -chain ${flexdll_chain} ${flexlink_flags}"
 else
   mkexe_cmd="$mkexe_cmd_exp"
 fi
@@ -13410,9 +13415,10 @@ fi
   *,*-pc-windows) :
     toolchain=msvc
     ostype="Win32"
-    mkexe_cmd_exp="flexlink -exe -chain ${flexdll_chain}"
+    mkexe_cmd_exp="flexlink -exe -chain ${flexdll_chain} ${flexlink_flags}"
     if $bootstrapping_flexdll; then :
-  mkexe_cmd="${boot_flexlink_cmd} -exe -chain ${flexdll_chain}"
+  mkexe_cmd=\
+"${boot_flexlink_cmd} -exe -chain ${flexdll_chain} ${flexlink_flags}"
 else
   mkexe_cmd="$mkexe_cmd_exp"
 fi
@@ -14302,24 +14308,19 @@ if test x"$enable_shared" != "xno"; then :
     mkdll_flags='-shared -undefined dynamic_lookup'
       supports_shared_libraries=true ;; #(
   *-*-mingw32) :
-    mkdll_ld="${flexlink_cmd} -chain ${flexdll_chain}"
-      mkmaindll="${flexlink_cmd} -maindll -chain ${flexdll_chain}"
-      if test -n "$oc_dll_ldflags"; then :
-
-        mkdll_flags=" -link \"$oc_dll_ldflags\""
-        mkmaindll="$mkmaindll -link \"$oc_dll_ldflags\""
-else
-
-        mkdll_flags=''
-fi ;; #(
+    mkdll_ld="${flexlink_cmd} -chain ${flexdll_chain} ${flexlink_flags}"
+      mkmaindll=\
+"${flexlink_cmd} -maindll -chain ${flexdll_chain} ${flexlink_flags}" ;; #(
   *-pc-windows) :
-    mkdll_ld="${flexlink_cmd} -chain ${flexdll_chain}"
+    mkdll_ld="${flexlink_cmd} -chain ${flexdll_chain} ${flexlink_flags}"
       mkdll_flags=''
-      mkmaindll="${flexlink_cmd} -maindll -chain ${flexdll_chain}" ;; #(
+      mkmaindll=\
+"${flexlink_cmd} -maindll -chain ${flexdll_chain} ${flexlink_flags}" ;; #(
   *-*-cygwin*) :
-    mkdll_ld="${flexlink_cmd} -chain ${flexdll_chain}"
+    mkdll_ld="${flexlink_cmd} -chain ${flexdll_chain} ${flexlink_flags}"
       mkdll_flags=''
-      mkmaindll="${flexlink_cmd} -maindll -chain ${flexdll_chain}" ;; #(
+      mkmaindll=\
+"${flexlink_cmd} -maindll -chain ${flexdll_chain} ${flexlink_flags}" ;; #(
   powerpc-ibm-aix*) :
     case $ocaml_cv_cc_vendor in #(
   xlc*) :

--- a/configure
+++ b/configure
@@ -827,6 +827,7 @@ ocamlc_cppflags
 ocamlc_cflags
 nativecclibs
 bytecclibs
+oc_exe_ldflags
 oc_dll_ldflags
 oc_ldflags
 oc_cppflags
@@ -2831,6 +2832,7 @@ ocamlc_cflags=""
 ocamlc_cppflags=""
 oc_ldflags=""
 oc_dll_ldflags=""
+oc_exe_ldflags=""
 
 # The C# compiler and its flags
 CSC=""
@@ -2920,6 +2922,7 @@ OCAML_VERSION_SHORT=5.1
 # Note: This is present for the flexdll bootstrap where it exposed as the old
 # TOOLPREF variable. It would be better if flexdll where updated to require
 # WINDRES instead.
+
 
 
 
@@ -13410,7 +13413,8 @@ else
 fi
     mkexe_cflags=''
     mkexe_ldflags_prefix='-link '
-    mkexe_extra_flags='-link -municode'
+    oc_exe_ldflags='-municode'
+    mkexe_extra_flags="$mkexe_ldflags_prefix$oc_exe_ldflags"
     SO="dll" ;; #(
   *,*-pc-windows) :
     toolchain=msvc
@@ -13425,7 +13429,8 @@ fi
     mkexe_cflags=''
     mkexe_ldflags_prefix='-link '
     mkexe_via_cc_ldflags_prefix='/link '
-    mkexe_extra_flags='-link /ENTRY:wmainCRTStartup'
+    oc_exe_ldflags='/ENTRY:wmainCRTStartup'
+    mkexe_extra_flags="$mkexe_ldflags_prefix$oc_exe_ldflags"
     mkexedebugflag='' ;; #(
   *,x86_64-*-linux*) :
     $as_echo "#define HAS_ARCH_CODE32 1" >>confdefs.h
@@ -18377,7 +18382,7 @@ unset ac_cv_header_flexdll_h
 # $mkdll - the full linking command for DLLs
 # $mkdll_exp: same as above but expanded
 # $mkmaindll - the full linking command for main program in DLL
-# $oc_ldflags and $oc_dll_ldflags are handled as $(OC_LDFLAGS) and
+# $oc_ldflags $oc_dll_ldflags are handled as $(OC_LDFLAGS) and
 # $(OC_DLL_LDFLAGS) and can be overidden in the build.
 
 

--- a/configure.ac
+++ b/configure.ac
@@ -52,6 +52,7 @@ ocamlc_cflags=""
 ocamlc_cppflags=""
 oc_ldflags=""
 oc_dll_ldflags=""
+oc_exe_ldflags=""
 
 # The C# compiler and its flags
 CSC=""
@@ -135,6 +136,7 @@ AC_SUBST([oc_cflags])
 AC_SUBST([oc_cppflags])
 AC_SUBST([oc_ldflags])
 AC_SUBST([oc_dll_ldflags])
+AC_SUBST([oc_exe_ldflags])
 AC_SUBST([bytecclibs])
 AC_SUBST([nativecclibs])
 AC_SUBST([ocamlc_cflags])
@@ -918,7 +920,8 @@ AS_CASE([$cc_basename,$host],
       [mkexe_cmd="$mkexe_cmd_exp"])
     mkexe_cflags=''
     mkexe_ldflags_prefix='-link '
-    mkexe_extra_flags='-link -municode'
+    oc_exe_ldflags='-municode'
+    mkexe_extra_flags="$mkexe_ldflags_prefix$oc_exe_ldflags"
     SO="dll"],
   [*,*-pc-windows],
     [toolchain=msvc
@@ -931,7 +934,8 @@ AS_CASE([$cc_basename,$host],
     mkexe_cflags=''
     mkexe_ldflags_prefix='-link '
     mkexe_via_cc_ldflags_prefix='/link '
-    mkexe_extra_flags='-link /ENTRY:wmainCRTStartup'
+    oc_exe_ldflags='/ENTRY:wmainCRTStartup'
+    mkexe_extra_flags="$mkexe_ldflags_prefix$oc_exe_ldflags"
     mkexedebugflag=''],
   [*,x86_64-*-linux*],
     AC_DEFINE([HAS_ARCH_CODE32], [1]),
@@ -2247,7 +2251,7 @@ AC_CONFIG_COMMANDS_PRE([
 # $mkdll - the full linking command for DLLs
 # $mkdll_exp: same as above but expanded
 # $mkmaindll - the full linking command for main program in DLL
-# $oc_ldflags and $oc_dll_ldflags are handled as $(OC_LDFLAGS) and
+# $oc_ldflags $oc_dll_ldflags are handled as $(OC_LDFLAGS) and
 # $(OC_DLL_LDFLAGS) and can be overidden in the build.
 AC_CONFIG_COMMANDS_PRE([
   # Construct $mkexe

--- a/configure.ac
+++ b/configure.ac
@@ -918,7 +918,7 @@ AS_CASE([$cc_basename,$host],
       [mkexe_cmd="$mkexe_cmd_exp"])
     mkexe_cflags=''
     mkexe_ldflags_prefix='-link '
-    oc_ldflags='-municode'
+    mkexe_extra_flags='-link -municode'
     SO="dll"],
   [*,*-pc-windows],
     [toolchain=msvc
@@ -931,7 +931,7 @@ AS_CASE([$cc_basename,$host],
     mkexe_cflags=''
     mkexe_ldflags_prefix='-link '
     mkexe_via_cc_ldflags_prefix='/link '
-    oc_ldflags='/ENTRY:wmainCRTStartup'
+    mkexe_extra_flags='-link /ENTRY:wmainCRTStartup'
     mkexedebugflag=''],
   [*,x86_64-*-linux*],
     AC_DEFINE([HAS_ARCH_CODE32], [1]),

--- a/configure.ac
+++ b/configure.ac
@@ -898,7 +898,7 @@ AS_CASE([$cc_basename,$host],
         [mkexe_cmd="$boot_flexlink_cmd -exe -chain ${flexdll_chain}"],
         [mkexe_cmd="$mkexe_cmd_exp"])
       mkexe_cflags=''
-      mkexe_ldflags_prefix='-link ']
+      mkexe_ldflags_prefix='-link '],
       [mkexe_extra_flags=''
       oc_ldflags='-Wl,--stack,16777216']
     )

--- a/configure.ac
+++ b/configure.ac
@@ -142,6 +142,7 @@ AC_SUBST([ocamlc_cppflags])
 AC_SUBST([flexdir])
 AC_SUBST([bootstrapping_flexdll])
 AC_SUBST([flexdll_dir])
+AC_SUBST([flexlink_flags])
 AC_SUBST([long_shebang])
 AC_SUBST([shebangscripts])
 AC_SUBST([AR])
@@ -779,29 +780,30 @@ AS_IF([test x"$enable_shared" = "xno"],
 # The flexlink command
 
 flexlink_cmd=flexlink
+flexlink_flags=''
 
 # Define flexlink chain and flags correctly for the different Windows ports
 AS_CASE([$host],
   [i686-*-cygwin],
     [flexdll_chain='cygwin'
-    mkexe_extra_flags='-merge-manifest -stack 16777216'],
+    flexlink_flags='-merge-manifest -stack 16777216'],
   [x86_64-*-cygwin],
     [flexdll_chain='cygwin64'
-    mkexe_extra_flags='-merge-manifest -stack 16777216'],
+    flexlink_flags='-merge-manifest -stack 16777216'],
   [*-*-cygwin*],
     [AC_MSG_ERROR([unknown cygwin variant])],
   [i686-w64-mingw32],
     [flexdll_chain='mingw'
-    mkexe_extra_flags='-stack 16777216'],
+    flexlink_flags='-stack 16777216'],
   [x86_64-w64-mingw32],
     [flexdll_chain='mingw64'
-    mkexe_extra_flags='-stack 33554432'],
+    flexlink_flags='-stack 33554432'],
   [i686-pc-windows],
     [flexdll_chain='msvc'
-    mkexe_extra_flags='-merge-manifest -stack 16777216'],
+    flexlink_flags='-merge-manifest -stack 16777216'],
   [x86_64-pc-windows],
     [flexdll_chain='msvc64'
-    mkexe_extra_flags='-merge-manifest -stack 33554432'],
+    flexlink_flags='-merge-manifest -stack 33554432'],
   [flexdll_chain=''])
 
 AS_IF([test x"$supports_shared_libraries" != 'xfalse'], [
@@ -893,9 +895,10 @@ AS_CASE([$cc_basename,$host],
   [*,*-*-cygwin*],
     [common_cppflags="$common_cppflags -U_WIN32"
     AS_IF([$supports_shared_libraries],
-      [mkexe_cmd_exp="flexlink -exe -chain ${flexdll_chain}"
+      [mkexe_cmd_exp="flexlink -exe -chain ${flexdll_chain} ${flexlink_flags}"
       AS_IF([$bootstrapping_flexdll],
-        [mkexe_cmd="$boot_flexlink_cmd -exe -chain ${flexdll_chain}"],
+        [mkexe_cmd=\
+"$boot_flexlink_cmd -exe -chain ${flexdll_chain} ${flexlink_flags}"],
         [mkexe_cmd="$mkexe_cmd_exp"])
       mkexe_cflags=''
       mkexe_ldflags_prefix='-link '],
@@ -908,9 +911,10 @@ AS_CASE([$cc_basename,$host],
       [i686-*-*], [oc_dll_ldflags="-static-libgcc"])
     ostype="Win32"
     toolchain="mingw"
-    mkexe_cmd_exp="flexlink -exe -chain ${flexdll_chain}"
+    mkexe_cmd_exp="flexlink -exe -chain ${flexdll_chain} ${flexlink_flags}"
     AS_IF([$bootstrapping_flexdll],
-      [mkexe_cmd="${boot_flexlink_cmd} -exe -chain ${flexdll_chain}"],
+      [mkexe_cmd=\
+"${boot_flexlink_cmd} -exe -chain ${flexdll_chain} ${flexlink_flags}"],
       [mkexe_cmd="$mkexe_cmd_exp"])
     mkexe_cflags=''
     mkexe_ldflags_prefix='-link '
@@ -919,9 +923,10 @@ AS_CASE([$cc_basename,$host],
   [*,*-pc-windows],
     [toolchain=msvc
     ostype="Win32"
-    mkexe_cmd_exp="flexlink -exe -chain ${flexdll_chain}"
+    mkexe_cmd_exp="flexlink -exe -chain ${flexdll_chain} ${flexlink_flags}"
     AS_IF([$bootstrapping_flexdll],
-      [mkexe_cmd="${boot_flexlink_cmd} -exe -chain ${flexdll_chain}"],
+      [mkexe_cmd=\
+"${boot_flexlink_cmd} -exe -chain ${flexdll_chain} ${flexlink_flags}"],
       [mkexe_cmd="$mkexe_cmd_exp"])
     mkexe_cflags=''
     mkexe_ldflags_prefix='-link '
@@ -1060,20 +1065,19 @@ AS_IF([test x"$enable_shared" != "xno"],
       [mkdll_flags='-shared -undefined dynamic_lookup'
       supports_shared_libraries=true],
     [*-*-mingw32],
-      [mkdll_ld="${flexlink_cmd} -chain ${flexdll_chain}"
-      mkmaindll="${flexlink_cmd} -maindll -chain ${flexdll_chain}"
-      AS_IF([test -n "$oc_dll_ldflags"],[
-        mkdll_flags=" -link \"$oc_dll_ldflags\""
-        mkmaindll="$mkmaindll -link \"$oc_dll_ldflags\""],[
-        mkdll_flags=''])],
+      [mkdll_ld="${flexlink_cmd} -chain ${flexdll_chain} ${flexlink_flags}"
+      mkmaindll=\
+"${flexlink_cmd} -maindll -chain ${flexdll_chain} ${flexlink_flags}"],
     [*-pc-windows],
-      [mkdll_ld="${flexlink_cmd} -chain ${flexdll_chain}"
+      [mkdll_ld="${flexlink_cmd} -chain ${flexdll_chain} ${flexlink_flags}"
       mkdll_flags=''
-      mkmaindll="${flexlink_cmd} -maindll -chain ${flexdll_chain}"],
+      mkmaindll=\
+"${flexlink_cmd} -maindll -chain ${flexdll_chain} ${flexlink_flags}"],
     [*-*-cygwin*],
-      [mkdll_ld="${flexlink_cmd} -chain ${flexdll_chain}"
+      [mkdll_ld="${flexlink_cmd} -chain ${flexdll_chain} ${flexlink_flags}"
       mkdll_flags=''
-      mkmaindll="${flexlink_cmd} -maindll -chain ${flexdll_chain}"],
+      mkmaindll=\
+"${flexlink_cmd} -maindll -chain ${flexdll_chain} ${flexlink_flags}"],
     [powerpc-ibm-aix*],
       [AS_CASE([$ocaml_cv_cc_vendor],
                [xlc*],

--- a/utils/config.generated.ml.in
+++ b/utils/config.generated.ml.in
@@ -63,10 +63,11 @@ let mkdll, mkexe, mkmaindll =
       String.init (String.length flexlink) f
     in
     let flexdll_chain = {@QS@|@flexdll_chain@|@QS@} in
-    let flexlink_flags = {@QS@|@mkexe_extra_flags@|@QS@} in
+    let flexlink_flags = {@QS@|@flexlink_flags@|@QS@} in
     let flags = " -chain " ^ flexdll_chain ^ " " ^ flexlink_flags in
     flexlink ^ flags ^ {@QS@|@mkdll_ldflags_exp@|@QS@},
-    flexlink ^ " -exe" ^ flags ^ {@QS@|@mkexe_ldflags_exp@|@QS@},
+    flexlink ^ " -exe" ^ flags
+      ^ {@QS@| @mkexe_extra_flags@|@QS@} ^ {@QS@|@mkexe_ldflags_exp@|@QS@},
     flexlink ^ " -maindll" ^ flags ^ {@QS@|@mkdll_ldflags_exp@|@QS@}
   else
     {@QS@|@mkdll_exp@|@QS@}, {@QS@|@mkexe_exp@|@QS@}, {@QS@|@mkmaindll@|@QS@}


### PR DESCRIPTION
Follow-up to #10413, found while reviewing #11268.

The first commit is a simple missing comma in `configure.ac`, which causes a set of wrong flags to get added when building Cygwin (we can't compile Cygwin at the moment, so this is non-critical).

The second commit restores the passing of the `-stack` argument for `MKDLL` and `MKMAINDLL` (and their `Config.mkdll` and `Config.mkmaindll` counterparts).

The third commit then ensure that `-municode` is only passed for `MKEXE`. Post #10413 it was inadvertently being passed to all three. This is innocuous for mingw-w64, because it's ignored, but for MSVC (which we can't compile at the moment), it actually specifies an invalid entry point for a DLL.

The diffs in i686-mingw32 in `Makefile.config`:

```diff
-OC_LDFLAGS=-municode
+OC_LDFLAGS=

-MKEXE=$(ROOTDIR)/boot/ocamlruns.exe $(ROOTDIR)/boot/flexlink.byte.exe -exe -chain mingw -stack 16777216 $(addprefix -link ,$(OC_LDFLAGS))
+MKEXE=$(ROOTDIR)/boot/ocamlruns.exe $(ROOTDIR)/boot/flexlink.byte.exe -exe -chain mingw -stack 16777216 -link -municode $(addprefix -link ,$(OC_LDFLAGS))
-MKDLL=flexlink -chain mingw  -link "-static-libgcc" $(addprefix -link ,$(OC_DLL_LDFLAGS))
+MKDLL=flexlink -chain mingw -stack 16777216  $(addprefix -link ,$(OC_DLL_LDFLAGS))
-MKMAINDLL=flexlink -maindll -chain mingw -link "-static-libgcc"   -link -municode  -link -static-libgcc
+MKMAINDLL=flexlink -maindll -chain mingw -stack 16777216   -link -static-libgcc
```

and in `utils/config.generated.ml.in` (note removal of the duplicated `-link -static-libgcc` as well):

```diff
--- utils/config.generated.ml   2022-09-09 15:50:00.643696500 +0100
+++ utils/config.generated.ml.mingw32   2022-09-09 15:49:05.419248700 +0100
@@ -65,11 +65,11 @@
     let flexdll_chain = {|mingw|} in
     let flexlink_flags = {|-stack 16777216|} in
     let flags = " -chain " ^ flexdll_chain ^ " " ^ flexlink_flags in
-    flexlink ^ flags ^ {|  -link -municode  -link -static-libgcc|},
+    flexlink ^ flags ^ {|  -link -static-libgcc|},
-    flexlink ^ " -exe" ^ flags ^ {| -link -municode |},
+    flexlink ^ " -exe" ^ flags ^ {| -link -municode|} ^ {| |},
-    flexlink ^ " -maindll" ^ flags ^ {|  -link -municode  -link -static-libgcc|}
+    flexlink ^ " -maindll" ^ flags ^ {|  -link -static-libgcc|}
   else
-    {|flexlink -chain mingw  -link "-static-libgcc"   -link -municode  -link -static-libgcc|},
+    {|flexlink -chain mingw -stack 16777216    -link -static-libgcc|},
-    {|flexlink -exe -chain mingw -stack 16777216  -link -municode |},
+    {|flexlink -exe -chain mingw -stack 16777216 -link -municode  |},
-    {|flexlink -maindll -chain mingw -link "-static-libgcc"   -link -municode  -link -static-libgcc|}
+    {|flexlink -maindll -chain mingw -stack 16777216   -link -static-libgcc|}
```