### PR TITLE
Stop passing -safe-string when building the compiler and in the testsuite

### DIFF
--- a/Makefile.build_config.in
+++ b/Makefile.build_config.in
@@ -93,7 +93,7 @@ DEFAULT_BUILD_TARGET = @default_build_target@
 
 OC_COMMON_CFLAGS = -g -strict-sequence -principal -absname \
   -w +a-4-9-40-41-42-44-45-48 -warn-error +a -bin-annot \
-  -safe-string -strict-formats
+  -strict-formats
 OC_COMMON_LDFLAGS = -g
 
 OC_NATIVE_CFLAGS = @oc_native_cflags@

--- a/debugger/Makefile
+++ b/debugger/Makefile
@@ -23,7 +23,7 @@ UNIXDIR=$(ROOTDIR)/otherlibs/unix
 
 CAMLC=$(BEST_OCAMLC) $(STDLIBFLAGS) -g
 COMPFLAGS=$(INCLUDES) -absname -w +a-4-9-41-42-44-45-48-70 -warn-error +A \
-          -safe-string -strict-sequence -strict-formats
+          -strict-sequence -strict-formats
 LINKFLAGS=-linkall -I $(UNIXDIR) -I $(DYNLINKDIR)
 OC_OCAMLDEPDIRS = $(DIRECTORIES)
 

--- a/manual/src/cmds/intf-c.etex
+++ b/manual/src/cmds/intf-c.etex
@@ -727,8 +727,7 @@ $\hbox{"string_length"}(v)-1$.
 or byte sequence \var{v}, with type "unsigned char". Bytes are
 numbered from 0 to $\hbox{"string_length"}(v)-1$.
 \item "String_val("\var{v}")" returns a pointer to the first byte of the string
-\var{v}, with type "char *" or, when OCaml is configured with
-"-force-safe-string", with type "const char *".
+\var{v}, with type "const char *".
 This pointer is a valid C string: there is a null byte after the last
 byte in the string. However, OCaml strings can contain embedded null bytes,
 which will confuse the usual C functions over strings.

--- a/ocamldoc/Makefile
+++ b/ocamldoc/Makefile
@@ -65,7 +65,7 @@ INCLUDES=$(INCLUDES_DEP) $(INCLUDES_NODEP)
 
 COMPFLAGS = \
   -g $(INCLUDES) -absname -w +a-4-9-41-42-44-45-48 -warn-error +A \
-  -safe-string -strict-sequence -strict-formats -bin-annot -principal
+  -strict-sequence -strict-formats -bin-annot -principal
 
 LINKFLAGS = -g $(INCLUDES)
 

--- a/ocamltest/Makefile
+++ b/ocamltest/Makefile
@@ -109,7 +109,7 @@ directories := $(addprefix $(ROOTDIR)/,utils bytecomp parsing \
 include_directories := $(addprefix -I , $(directories))
 
 flags := $(STDLIBFLAGS) -g $(include_directories) \
-  -strict-sequence -safe-string -strict-formats \
+  -strict-sequence -strict-formats \
   -w +a-4-9-41-42-44-45-48 -warn-error +A
 
 ocamlc = $(BEST_OCAMLC) $(flags)

--- a/otherlibs/Makefile.otherlibs.common
+++ b/otherlibs/Makefile.otherlibs.common
@@ -30,7 +30,7 @@ OC_CFLAGS += $(SHAREDLIB_CFLAGS)
 
 # Compilation options
 COMPFLAGS=-absname -w +a-4-9-41-42-44-45-48 -warn-error +A -bin-annot -g \
-          -safe-string -strict-sequence -strict-formats $(EXTRACAMLFLAGS)
+          -strict-sequence -strict-formats $(EXTRACAMLFLAGS)
 ifeq "$(FLAMBDA)" "true"
 OPTCOMPFLAGS += -O3
 endif

--- a/otherlibs/dynlink/Makefile
+++ b/otherlibs/dynlink/Makefile
@@ -30,7 +30,7 @@ OCAMLOPT=$(BEST_OCAMLOPT) $(STDLIBFLAGS) -g
 # COMPFLAGS should be in sync with the toplevel Makefile's COMPFLAGS.
 COMPFLAGS=-strict-sequence -principal -absname \
           -w +a-4-9-40-41-42-44-45-48 -warn-error +A \
-          -bin-annot -safe-string -strict-formats
+          -bin-annot -strict-formats
 ifeq "$(FLAMBDA)" "true"
 OPTCOMPFLAGS += -O3
 endif

--- a/otherlibs/systhreads/Makefile
+++ b/otherlibs/systhreads/Makefile
@@ -30,7 +30,7 @@ CAMLC=$(BEST_OCAMLC) $(LIBS)
 CAMLOPT=$(BEST_OCAMLOPT) $(LIBS)
 
 MKLIB=$(OCAMLRUN) $(ROOTDIR)/tools/ocamlmklib$(EXE)
-COMPFLAGS=-w +33..39 -warn-error +A -g -bin-annot -safe-string
+COMPFLAGS=-w +33..39 -warn-error +A -g -bin-annot
 ifeq "$(FLAMBDA)" "true"
 OPTCOMPFLAGS += -O3
 endif

--- a/testsuite/tests/lib-unix/win-env/test_env.ml
+++ b/testsuite/tests/lib-unix/win-env/test_env.ml
@@ -2,7 +2,7 @@
 unset FOO
 unset FOO2
 include unix
-flags += "-strict-sequence -safe-string -w +A-70 -warn-error +A"
+flags += "-strict-sequence -w +A-70 -warn-error +A"
 modules = "stubs.c"
 * libwin32unix
 ** bytecode

--- a/testsuite/tests/typing-safe-linking/b_bad.ml
+++ b/testsuite/tests/typing-safe-linking/b_bad.ml
@@ -5,7 +5,7 @@ readonly_files = "a.ml"
 module = "a.ml"
 *** ocamlc.byte
 module = "b_bad.ml"
-flags = "-safe-string -warn-error +8"
+flags = "-warn-error +8"
 ocamlc_byte_exit_status = "2"
 **** check-ocamlc.byte-output
 *)

--- a/testsuite/tests/win-unicode/mltest.ml
+++ b/testsuite/tests/win-unicode/mltest.ml
@@ -1,6 +1,6 @@
 (* TEST
 include unix
-flags += "-strict-sequence -safe-string -w +A -warn-error +A"
+flags += "-strict-sequence -w +A -warn-error +A"
 * windows-unicode
 ** toplevel
 *)

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -41,7 +41,7 @@ DIRS = $(addprefix $(ROOTDIR)/,utils parsing typing bytecomp \
                    file_formats lambda)
 INCLUDES = $(addprefix -I ,$(DIRS))
 COMPFLAGS = -absname -w +a-4-9-41-42-44-45-48-70 -strict-sequence \
--warn-error +A -principal -safe-string -strict-formats -bin-annot $(INCLUDES)
+-warn-error +A -principal -strict-formats -bin-annot $(INCLUDES)
 LINKFLAGS = $(INCLUDES)
 VPATH := $(filter-out -I,$(INCLUDES))
 

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -2182,7 +2182,6 @@ let is_instantiable env p =
   with Not_found -> false
 
 
-(* PR#7113: -safe-string should be a global property *)
 let compatible_paths p1 p2 =
   let open Predef in
   Path.same p1 p2 ||


### PR DESCRIPTION
This PR is a follow-up to a suggestion by @dra27 in
https://github.com/ocaml/ocaml/pull/11420#discussion_r918727738

PR #1252 has made the safe-string mode the default so passing -safe-string
explicitly has become useless since this PR has been merged, even more
useless since support for mutable strings was removed in OCaml 5.0.