### PR TITLE
Make tests on boolean build variables more readable

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -192,14 +192,6 @@ tools/pre-commit-githook text eol=lf
 tools/markdown-add-pr-links.sh text eol=lf
 runtime/caml/sizeclasses.h typo.missing-header typo.white-at-eol
 
-# These are all Perl scripts, so may not actually require this
-manual/tools/caml-tex text eol=lf
-manual/tools/format-intf text eol=lf
-manual/tools/htmlcut text eol=lf
-manual/tools/htmltbl text eol=lf
-manual/tools/htmlthread text eol=lf
-manual/tools/texexpand text eol=lf
-
 # Tests which include references spanning multiple lines fail with \r\n
 # endings, so use \n endings only, even on Windows.
 testsuite/tests/backtrace/names.ml text eol=lf

--- a/.gitignore
+++ b/.gitignore
@@ -239,7 +239,7 @@ META
 /tools/stripdebug.opt
 /tools/make_opcodes
 /tools/make_opcodes.ml
-/tools/caml-tex
+/tools/ocamltex
 /tools/eventlog_metadata
 
 /toplevel/byte/topeval.mli

--- a/Makefile
+++ b/Makefile
@@ -729,7 +729,7 @@ runtime-all: \
   $(runtime_PROGRAMS) $(SAK)
 
 .PHONY: runtime-allopt
-ifneq "$(NATIVE_COMPILER)" "false"
+ifeq "$(NATIVE_COMPILER)" "true"
 runtime-allopt: \
   $(runtime_NATIVE_STATIC_LIBRARIES) $(runtime_NATIVE_SHARED_LIBRARIES)
 else
@@ -897,7 +897,7 @@ $(DEPDIR)/runtime/%.npic.$(D): \
 # that corresponds to the name of the generated object file
 # (without the extension, which is added by the macro)
 define COMPILE_C_FILE
-ifneq "$(COMPUTE_DEPS)" "false"
+ifeq "$(COMPUTE_DEPS)" "true"
 ifneq "$(1)" "%"
 # -MG would ensure that the dependencies are generated even if the files listed
 # in $$(runtime_BUILT_HEADERS) haven't been assembled yet. However,
@@ -915,7 +915,7 @@ else
 $(1).$(O): $(2).c \
   $(runtime_CONFIGURED_HEADERS) $(runtime_BUILT_HEADERS) \
   $(RUNTIME_HEADERS)
-endif # ifneq "$(COMPUTE_DEPS)" "false"
+endif # ifeq "$(COMPUTE_DEPS)" "true"
 	$$(CC) -c $$(OC_CFLAGS) $$(CFLAGS) $$(OC_CPPFLAGS) $$(CPPFLAGS) \
 	  $$(OUTPUTOBJ)$$@ $$<
 endef
@@ -924,7 +924,7 @@ $(DEPDIR)/runtime:
 	$(MKDIR) $@
 
 runtime_OBJECT_TYPES = % %.b %.bd %.bi %.bpic
-ifneq "$(NATIVE_COMPILER)" "false"
+ifeq "$(NATIVE_COMPILER)" "true"
 runtime_OBJECT_TYPES += %.n %.nd %.ni %.np %.npic
 endif
 
@@ -993,7 +993,7 @@ runtime/%_libasmrunpic.obj: runtime/%.asm
 
 runtime_DEP_FILES := $(addsuffix .b, \
   $(basename $(runtime_BYTECODE_C_SOURCES) runtime/instrtrace))
-ifneq "$(NATIVE_COMPILER)" "false"
+ifeq "$(NATIVE_COMPILER)" "true"
 runtime_DEP_FILES += $(addsuffix .n, $(basename $(runtime_NATIVE_C_SOURCES)))
 endif
 runtime_DEP_FILES += $(addsuffix d, $(runtime_DEP_FILES)) \
@@ -1240,7 +1240,7 @@ partialclean::
 # Check that the native-code compiler is supported
 .PHONY: checknative
 checknative:
-ifneq "$(NATIVE_COMPILER)" "true"
+ifeq "$(NATIVE_COMPILER)" "false"
 	$(error The source tree was configured with --disable-native-compiler!)
 else
 ifeq "$(ARCH)" "none"

--- a/Makefile
+++ b/Makefile
@@ -1508,7 +1508,7 @@ endif
 	for i in $(OTHERLIBRARIES); do \
 	  $(MAKE) -C otherlibs/$$i install || exit $$?; \
 	done
-ifneq "$(WITH_OCAMLDOC)" ""
+ifeq "$(build_ocamldoc)" "true"
 	$(MAKE) -C ocamldoc install
 endif
 ifeq "$(WITH_OCAMLDOC)-$(STDLIB_MANPAGES)" "ocamldoc-true"
@@ -1596,7 +1596,7 @@ endif
 	$(INSTALL_DATA) \
 	    $(OPTSTART) \
 	    "$(INSTALL_COMPLIBDIR)"
-ifneq "$(WITH_OCAMLDOC)" ""
+ifeq "$(build_ocamldoc)" "true"
 	$(MAKE) -C ocamldoc installopt
 endif
 	for i in $(OTHERLIBRARIES); do \

--- a/Makefile.build_config.in
+++ b/Makefile.build_config.in
@@ -31,6 +31,10 @@ INSTALL_PROG ?= @INSTALL_PROGRAM@
 
 # Whether to build certain libraries and tools
 
+build_ocamldebug = @build_ocamldebug@
+
+build_ocamldoc = @build_ocamldoc@
+
 lib_dynlink = @lib_dynlink@
 lib_runtime_events = @lib_runtime_events@
 lib_str = @lib_str@

--- a/Makefile.build_config.in
+++ b/Makefile.build_config.in
@@ -35,6 +35,8 @@ build_ocamldebug = @build_ocamldebug@
 
 build_ocamldoc = @build_ocamldoc@
 
+build_ocamltex = @build_ocamltex@
+
 lib_dynlink = @lib_dynlink@
 lib_runtime_events = @lib_runtime_events@
 lib_str = @lib_str@

--- a/Makefile.build_config.in
+++ b/Makefile.build_config.in
@@ -29,8 +29,13 @@ INSTALL ?= @INSTALL@ -p
 INSTALL_DATA ?= @INSTALL_DATA@
 INSTALL_PROG ?= @INSTALL_PROGRAM@
 
-# Whether to build the runtime_events library
+# Whether to build certain libraries and tools
+
+lib_dynlink = @lib_dynlink@
 lib_runtime_events = @lib_runtime_events@
+lib_str = @lib_str@
+lib_systhreads = @lib_systhreads@
+lib_unix = @lib_unix@
 
 # Whether to install the native toplevel (ocamlnat)
 INSTALL_OCAMLNAT = @install_ocamlnat@

--- a/Makefile.build_config.in
+++ b/Makefile.build_config.in
@@ -29,6 +29,9 @@ INSTALL ?= @INSTALL@ -p
 INSTALL_DATA ?= @INSTALL_DATA@
 INSTALL_PROG ?= @INSTALL_PROGRAM@
 
+# Whether to build the runtime_events library
+lib_runtime_events = @lib_runtime_events@
+
 # Whether to install the native toplevel (ocamlnat)
 INSTALL_OCAMLNAT = @install_ocamlnat@
 

--- a/Makefile.common
+++ b/Makefile.common
@@ -115,7 +115,7 @@ endif
 # This rule is similar to GNU make's implicit rule, except that it is more
 # general (it supports both .o and .obj)
 
-ifneq "$(COMPUTE_DEPS)" "false"
+ifeq "$(COMPUTE_DEPS)" "true"
 RUNTIME_HEADERS :=
 REQUIRED_HEADERS :=
 else

--- a/Makefile.config.in
+++ b/Makefile.config.in
@@ -227,7 +227,6 @@ RUNTIMED=@debug_runtime@
 INSTRUMENTED_RUNTIME=@instrumented_runtime@
 INSTRUMENTED_RUNTIME_LIBS=@instrumented_runtime_libs@
 WITH_DEBUGGER=@with_debugger@
-WITH_CAMLTEX=@with_camltex@
 WITH_OCAMLDOC=@ocamldoc@
 WITH_OCAMLTEST=@ocamltest@
 ASM_CFI_SUPPORTED=@asm_cfi_supported@

--- a/api_docgen/Makefile.docfiles
+++ b/api_docgen/Makefile.docfiles
@@ -43,15 +43,15 @@ stdlib_UNPREFIXED=$(STDLIB_MODULE_BASENAMES)
 
 otherlibref := $(dynlink_MLIS:%.mli=%)
 
-ifneq "$(filter str,$(OTHERLIBRARIES))" ""
+ifeq "$(lib_str)" "true"
 otherlibref += $(str_MLIS:%.mli=%)
 endif
 
-ifneq "$(filter %unix,$(OTHERLIBRARIES))" ""
+ifeq "$(lib_unix)" "true"
 otherlibref += $(unix_MLIS:%.mli=%)
 endif
 
-ifneq "$(filter systhreads,$(OTHERLIBRARIES))" ""
+ifeq "$(lib_systhreads)" "true"
 otherlibref += $(thread_MLIS:%.mli=%)
 endif
 

--- a/api_docgen/Makefile.docfiles
+++ b/api_docgen/Makefile.docfiles
@@ -55,7 +55,7 @@ ifneq "$(filter systhreads,$(OTHERLIBRARIES))" ""
 otherlibref += $(thread_MLIS:%.mli=%)
 endif
 
-ifneq "$(filter runtime_events,$(OTHERLIBRARIES))" ""
+ifeq "$(lib_runtime_events)" "true"
 otherlibref += $(runtime_events_MLIS:%.mli=%)
 endif
 

--- a/configure
+++ b/configure
@@ -790,7 +790,7 @@ documentation_tool_cmd
 documentation_tool
 build_ocamldoc
 ocamldoc
-with_camltex
+build_ocamltex
 build_ocamldebug
 with_debugger
 as_has_debug_prefix_map
@@ -3534,10 +3534,10 @@ if test x"$enable_unix_lib" = "xno" || test x"$enable_str_lib" = "xno"; then :
   as_fn_error $? "ocamldoc requires the unix and str libraries" "$LINENO" 5
 else
   enable_ocamldoc="no"
-     with_camltex=""
+     build_ocamltex=false
 fi
 else
-  with_camltex="true"
+  build_ocamltex=true
 fi
 
 # Initialization of libtool

--- a/configure
+++ b/configure
@@ -804,6 +804,7 @@ ocamltest_CPP
 lib_unix
 lib_systhreads
 lib_str
+lib_runtime_events
 lib_dynlink
 otherlibraries
 has_monotonic_clock
@@ -2922,6 +2923,7 @@ OCAML_VERSION_SHORT=5.1
 # Note: This is present for the flexdll bootstrap where it exposed as the old
 # TOOLPREF variable. It would be better if flexdll where updated to require
 # WINDRES instead.
+
 
 
 
@@ -12794,6 +12796,7 @@ esac
 
 otherlibraries="dynlink runtime_events"
 lib_dynlink=true
+lib_runtime_events=true
 if test x"$enable_unix_lib" != "xno"; then :
   enable_unix_lib=yes
   ac_config_files="$ac_config_files otherlibs/unix/META"

--- a/configure
+++ b/configure
@@ -788,10 +788,10 @@ ASPP
 ocamltest
 documentation_tool_cmd
 documentation_tool
-ocamltest_ocamldoc
+build_ocamldoc
 ocamldoc
 with_camltex
-ocamltest_ocamldebug
+build_ocamldebug
 with_debugger
 as_has_debug_prefix_map
 cc_has_debug_prefix_map
@@ -16889,18 +16889,18 @@ rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 case $enable_debugger in #(
   no) :
     with_debugger=""
-    ocamltest_ocamldebug=false
+    build_ocamldebug=false
     { $as_echo "$as_me:${as_lineno-$LINENO}: replay debugger disabled" >&5
 $as_echo "$as_me: replay debugger disabled" >&6;} ;; #(
   *) :
     if $sockets; then :
   with_debugger="ocamldebugger"
-    ocamltest_ocamldebug=true
+    build_ocamldebug=true
     { $as_echo "$as_me:${as_lineno-$LINENO}: replay debugger supported" >&5
 $as_echo "$as_me: replay debugger supported" >&6;}
 else
   with_debugger=""
-    ocamltest_ocamldebug=false
+    build_ocamldebug=false
     { $as_echo "$as_me:${as_lineno-$LINENO}: replay debugger not supported" >&5
 $as_echo "$as_me: replay debugger not supported" >&6;}
 fi
@@ -17955,10 +17955,10 @@ fi
 
 if test x"$enable_ocamldoc" = "xno"; then :
   ocamldoc=""
-  ocamltest_ocamldoc=false
+  build_ocamldoc=false
 else
   ocamldoc=ocamldoc
-  ocamltest_ocamldoc=true
+  build_ocamldoc=true
   ac_config_files="$ac_config_files ocamldoc/META"
 
 fi

--- a/configure.ac
+++ b/configure.ac
@@ -174,7 +174,7 @@ AC_SUBST([cc_has_debug_prefix_map])
 AC_SUBST([as_has_debug_prefix_map])
 AC_SUBST([with_debugger]) # TODO: rename this variable
 AC_SUBST([build_ocamldebug])
-AC_SUBST([with_camltex])
+AC_SUBST([build_ocamltex])
 AC_SUBST([ocamldoc])
 AC_SUBST([build_ocamldoc])
 AC_SUBST([documentation_tool])
@@ -492,8 +492,8 @@ AS_IF([test x"$enable_unix_lib" = "xno" || test x"$enable_str_lib" = "xno"],
   [AS_IF([test x"$enable_ocamldoc" = "xyes"],
     [AC_MSG_ERROR([ocamldoc requires the unix and str libraries])],
     [enable_ocamldoc="no"
-     with_camltex=""])],
-  [with_camltex="true"])
+     build_ocamltex=false])],
+  [build_ocamltex=true])
 
 # Initialization of libtool
 # Allow the MSVC linker to be found even if ld isn't installed.

--- a/configure.ac
+++ b/configure.ac
@@ -160,6 +160,7 @@ AC_SUBST([instrumented_runtime_libs])
 AC_SUBST([has_monotonic_clock])
 AC_SUBST([otherlibraries])
 AC_SUBST([lib_dynlink])
+AC_SUBST([lib_runtime_events])
 AC_SUBST([lib_str])
 AC_SUBST([lib_systhreads])
 AC_SUBST([lib_unix])
@@ -619,6 +620,7 @@ AS_CASE([$host],
 
 otherlibraries="dynlink runtime_events"
 lib_dynlink=true
+lib_runtime_events=true
 AS_IF([test x"$enable_unix_lib" != "xno"],
   [enable_unix_lib=yes
   AC_CONFIG_FILES([otherlibs/unix/META])

--- a/configure.ac
+++ b/configure.ac
@@ -173,10 +173,10 @@ AC_SUBST([ocamltest_unix_include])
 AC_SUBST([cc_has_debug_prefix_map])
 AC_SUBST([as_has_debug_prefix_map])
 AC_SUBST([with_debugger]) # TODO: rename this variable
-AC_SUBST([ocamltest_ocamldebug])
+AC_SUBST([build_ocamldebug])
 AC_SUBST([with_camltex])
 AC_SUBST([ocamldoc])
-AC_SUBST([ocamltest_ocamldoc])
+AC_SUBST([build_ocamldoc])
 AC_SUBST([documentation_tool])
 AC_SUBST([documentation_tool_cmd])
 AC_SUBST([ocamltest])
@@ -1955,14 +1955,14 @@ AC_COMPILE_IFELSE(
 AS_CASE([$enable_debugger],
   [no],
     [with_debugger=""
-    ocamltest_ocamldebug=false
+    build_ocamldebug=false
     AC_MSG_NOTICE([replay debugger disabled])],
   [AS_IF([$sockets],
     [with_debugger="ocamldebugger"
-    ocamltest_ocamldebug=true
+    build_ocamldebug=true
     AC_MSG_NOTICE([replay debugger supported])],
     [with_debugger=""
-    ocamltest_ocamldebug=false
+    build_ocamldebug=false
     AC_MSG_NOTICE([replay debugger not supported])])
   ])
 
@@ -2042,9 +2042,9 @@ AS_IF([test x"$enable_installing_source_artifacts" = "xno"],
 
 AS_IF([test x"$enable_ocamldoc" = "xno"],
   [ocamldoc=""
-  ocamltest_ocamldoc=false],
+  build_ocamldoc=false],
   [ocamldoc=ocamldoc
-  ocamltest_ocamldoc=true
+  build_ocamldoc=true
   AC_CONFIG_FILES([ocamldoc/META])])
 
 documentation_tool_cmd=''

--- a/manual/README.md
+++ b/manual/README.md
@@ -128,7 +128,7 @@ A similar macro, `\lparagraph`, is provided for paragraphs.
 
 ### Caml environments
 
-The tool `tools/caml-tex` is used to generate the LaTeX code for the examples
+The tool `tools/ocamltex` is used to generate the LaTeX code for the examples
 in the introduction and language extension parts of the manual. It implements
 two pseudo-environments: `caml_example` and `caml_eval`.
 
@@ -162,10 +162,10 @@ val none : 'a option
 \end{caml_example*}
 ```
 
-By default, `caml-tex` raises an error and stops if the output of one the
+By default, `ocamltex` raises an error and stops if the output of one the
 `caml_example` environment contains an unexpected error or warning. If such an
 error or warning is, in fact, expected, it is necessary to indicate the expected
-output status to `caml-tex` by adding either an option to the `caml_example`
+output status to `ocamltex` by adding either an option to the `caml_example`
 environment:
 ```latex
 \begin{caml_example}{toplevel}[error]

--- a/manual/src/cmds/Makefile
+++ b/manual/src/cmds/Makefile
@@ -5,7 +5,7 @@ LD_PATH = $(ROOTDIR)/otherlibs/str $(ROOTDIR)/otherlibs/unix
 
 TOOLS = ../../tools
 CAMLLATEX = $(OCAMLRUN) $(addprefix -I ,$(LD_PATH)) \
-  $(ROOTDIR)/tools/caml-tex -repo-root $(ROOTDIR) -n 80 -v false
+  $(ROOTDIR)/tools/ocamltex -repo-root $(ROOTDIR) -n 80 -v false
 TEXQUOTE = $(OCAMLRUN) $(TOOLS)/texquote2
 TRANSF = $(OCAMLRUN) $(TOOLS)/transf
 

--- a/manual/src/refman/Makefile
+++ b/manual/src/refman/Makefile
@@ -5,7 +5,7 @@ LD_PATH = $(ROOTDIR)/otherlibs/str $(ROOTDIR)/otherlibs/unix
 
 TOOLS = ../../tools
 CAMLLATEX = $(OCAMLRUN) $(addprefix -I ,$(LD_PATH)) \
-  $(ROOTDIR)/tools/caml-tex -repo-root $(ROOTDIR) -n 80 -v false
+  $(ROOTDIR)/tools/ocamltex -repo-root $(ROOTDIR) -n 80 -v false
 TEXQUOTE = $(OCAMLRUN) $(TOOLS)/texquote2
 TRANSF = $(OCAMLRUN) $(TOOLS)/transf
 

--- a/manual/src/tutorials/Makefile
+++ b/manual/src/tutorials/Makefile
@@ -5,7 +5,7 @@ LD_PATH = $(ROOTDIR)/otherlibs/str $(ROOTDIR)/otherlibs/unix
 
 TOOLS = ../../tools
 CAMLLATEX = $(OCAMLRUN) $(addprefix -I ,$(LD_PATH)) \
-  $(ROOTDIR)/tools/caml-tex -repo-root $(ROOTDIR) -n 80 -v false
+  $(ROOTDIR)/tools/ocamltex -repo-root $(ROOTDIR) -n 80 -v false
 TEXQUOTE = $(OCAMLRUN) $(TOOLS)/texquote2
 TRANSF = $(OCAMLRUN) $(TOOLS)/transf
 

--- a/ocamltest/ocamltest_config.ml.in
+++ b/ocamltest/ocamltest_config.ml.in
@@ -59,9 +59,9 @@ let ocamlopt_default_flags = ""
 
 let flat_float_array = @flat_float_array@
 
-let ocamldoc = @ocamltest_ocamldoc@
+let ocamldoc = @build_ocamldoc@
 
-let ocamldebug = @ocamltest_ocamldebug@
+let ocamldebug = @build_ocamldebug@
 
 let native_compiler = @native_compiler@
 

--- a/otherlibs/systhreads/Makefile
+++ b/otherlibs/systhreads/Makefile
@@ -92,7 +92,7 @@ $(LIBNAME).cmxa: $(THREADS_NCOBJS)
 
 st_stubs.n.$(O): OC_CPPFLAGS += $(OC_NATIVE_CPPFLAGS)
 
-ifneq "$(COMPUTE_DEPS)" "false"
+ifeq "$(COMPUTE_DEPS)" "true"
 st_stubs.%.$(O): st_stubs.c
 else
 st_stubs.%.$(O): st_stubs.c $(RUNTIME_HEADERS) $(wildcard *.h)
@@ -148,7 +148,7 @@ installopt:
 	$(CAMLOPT) -c $(COMPFLAGS) $(OPTCOMPFLAGS) $<
 
 DEP_FILES := st_stubs.b.$(D)
-ifneq "$(NATIVE_COMPILER)" "false"
+ifeq "$(NATIVE_COMPILER)" "true"
 DEP_FILES += st_stubs.n.$(D)
 endif
 

--- a/testsuite/tests/tool-caml-tex/ellipses.ml
+++ b/testsuite/tests/tool-caml-tex/ellipses.ml
@@ -2,7 +2,7 @@
    reference="${test_source_directory}/ellipses.reference"
    output="ellipses.output"
    readonly_files = "${test_source_directory}/ellipses.input"
-   script = "${ocamlrun} ${ocamlsrcdir}/tools/caml-tex \
+   script = "${ocamlrun} ${ocamlsrcdir}/tools/ocamltex \
    -repo-root ${ocamlsrcdir} ${readonly_files} -o ${output}"
   * hasstr
   ** hasunix

--- a/testsuite/tests/tool-caml-tex/redirections.ml
+++ b/testsuite/tests/tool-caml-tex/redirections.ml
@@ -2,7 +2,7 @@
    reference="${test_source_directory}/redirections.reference"
    output="redirections.output"
    readonly_files = "${test_source_directory}/redirections.input"
-   script = "${ocamlrun} ${ocamlsrcdir}/tools/caml-tex \
+   script = "${ocamlrun} ${ocamlsrcdir}/tools/ocamltex \
    -repo-root ${ocamlsrcdir} ${readonly_files} -o ${output}"
   * hasstr
   ** hasunix
@@ -12,7 +12,7 @@
   ****** check-program-output
   **** no-shared-libraries
   ***** script with unix,str
-   script = "${ocamlsrcdir}/tools/caml-tex \
+   script = "${ocamlsrcdir}/tools/ocamltex \
    -repo-root ${ocamlsrcdir} ${readonly_files} -o ${output}"
   ****** check-program-output
 *)

--- a/tools/.depend
+++ b/tools/.depend
@@ -1,31 +1,3 @@
-caml_tex.cmo : \
-    ../toplevel/toploop.cmi \
-    ../parsing/syntaxerr.cmi \
-    ../parsing/parsetree.cmi \
-    ../parsing/parse.cmi \
-    ../utils/misc.cmi \
-    ../parsing/location.cmi \
-    ../utils/load_path.cmi \
-    ../parsing/lexer.cmi \
-    ../driver/compmisc.cmi \
-    ../driver/compenv.cmi \
-    ../utils/clflags.cmi \
-    ../parsing/ast_iterator.cmi \
-    ../parsing/ast_helper.cmi
-caml_tex.cmx : \
-    ../toplevel/toploop.cmx \
-    ../parsing/syntaxerr.cmx \
-    ../parsing/parsetree.cmi \
-    ../parsing/parse.cmx \
-    ../utils/misc.cmx \
-    ../parsing/location.cmx \
-    ../utils/load_path.cmx \
-    ../parsing/lexer.cmx \
-    ../driver/compmisc.cmx \
-    ../driver/compenv.cmx \
-    ../utils/clflags.cmx \
-    ../parsing/ast_iterator.cmx \
-    ../parsing/ast_helper.cmx
 cmpbyt.cmo : \
     ../bytecomp/bytesections.cmi
 cmpbyt.cmx : \
@@ -194,6 +166,34 @@ ocamlprof.cmx : \
     ../parsing/parsetree.cmi \
     ../parsing/parse.cmx \
     ../parsing/location.cmx
+ocamltex.cmo : \
+    ../toplevel/toploop.cmi \
+    ../parsing/syntaxerr.cmi \
+    ../parsing/parsetree.cmi \
+    ../parsing/parse.cmi \
+    ../utils/misc.cmi \
+    ../parsing/location.cmi \
+    ../utils/load_path.cmi \
+    ../parsing/lexer.cmi \
+    ../driver/compmisc.cmi \
+    ../driver/compenv.cmi \
+    ../utils/clflags.cmi \
+    ../parsing/ast_iterator.cmi \
+    ../parsing/ast_helper.cmi
+ocamltex.cmx : \
+    ../toplevel/toploop.cmx \
+    ../parsing/syntaxerr.cmx \
+    ../parsing/parsetree.cmi \
+    ../parsing/parse.cmx \
+    ../utils/misc.cmx \
+    ../parsing/location.cmx \
+    ../utils/load_path.cmx \
+    ../parsing/lexer.cmx \
+    ../driver/compmisc.cmx \
+    ../driver/compenv.cmx \
+    ../utils/clflags.cmx \
+    ../parsing/ast_iterator.cmx \
+    ../parsing/ast_helper.cmx
 opnames.cmo :
 opnames.cmx :
 primreq.cmo : \

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -329,7 +329,7 @@ $(caml_tex): $(caml_tex_files)
 
 # we need str and unix which depend on the bytecode version of other tools
 # thus we use the othertools target
-ifneq "$(WITH_CAMLTEX)" ""
+ifeq "$(WITH_CAMLTEX)" "true"
 othertools: $(caml_tex)
 endif
 clean::

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -301,13 +301,13 @@ CMPBYT=$(ROOTDIR)/compilerlibs/ocamlcommon.cma \
 cmpbyt$(EXE): $(CMPBYT)
 cmpbyt.opt$(EXE): $(call byte2native, $(CMPBYT))
 
-caml_tex_files := \
+ocamltex_files := \
   $(ROOTDIR)/compilerlibs/ocamlcommon.cma \
   $(ROOTDIR)/compilerlibs/ocamlbytecomp.cma \
   $(ROOTDIR)/compilerlibs/ocamltoplevel.cma \
   $(ROOTDIR)/otherlibs/str/str.cma \
   $(ROOTDIR)/otherlibs/unix/unix.cma \
-  caml_tex.ml
+  ocamltex.ml
 
 # checkstack tool
 
@@ -316,24 +316,24 @@ checkstack$(EXE): checkstack.$(O)
 
 #Scan latex files, and run ocaml code examples
 
-caml_tex := caml-tex$(EXE)
+ocamltex := ocamltex$(EXE)
 
-# caml-tex uses str.cma and unix.cma and so must be compiled with
+# ocamltex uses str.cma and unix.cma and so must be compiled with
 # $(ROOTDIR)/ocamlc not $(ROOTDIR)/boot/ocamlc since the boot
 # compiler does not necessarily have the correct shared library
 # configuration.
-$(caml_tex): INCLUDES += $(addprefix -I $(ROOTDIR)/otherlibs/,str unix)
-$(caml_tex): $(caml_tex_files)
+$(ocamltex): INCLUDES += $(addprefix -I $(ROOTDIR)/otherlibs/,str unix)
+$(ocamltex): $(ocamltex_files)
 	$(OCAMLRUN) $(ROOTDIR)/ocamlc$(EXE) $(STDLIBFLAGS) \
 	  $(LINKFLAGS) -linkall -o $@ -no-alias-deps $^
 
 # we need str and unix which depend on the bytecode version of other tools
 # thus we use the othertools target
-ifeq "$(WITH_CAMLTEX)" "true"
-othertools: $(caml_tex)
+ifeq "$(build_ocamltex)" "true"
+othertools: $(ocamltex)
 endif
 clean::
-	rm -f -- caml-tex caml-tex.exe caml_tex.cm?
+	rm -f -- ocamltex ocamltex.exe ocamltex.cm?
 
 # Common stuff
 

--- a/tools/ocamltex.ml
+++ b/tools/ocamltex.ml
@@ -251,7 +251,7 @@ let () =
              "-v", Arg.Bool (fun b -> verbose := b ), "output result on stderr"
             ]
     (fun s -> files := s :: !files)
-    "caml-tex: ";
+    "ocamltex: ";
   Toplevel.init ()
 
 


### PR DESCRIPTION
We have several boolean configuration variables to specify whether
a feature is enabled or not. `NATIVE_COMPILER` is an example of such a
variable.

In our build system, we have several instances of tests like this:

```
ifneq "$(NATIVE_COMPILER)" "false"
```

Since it is so easy to misread such tests and to overlook the `n`,
the only purpose of this PR is to replace such tests by their more
readable equivalent:

```
ifeq "$(NATIVE_COMPILER)" "true"
```

Snce not all the poorly written tests were on an explicit boolean
variable, it was necessary to introduce a one, `lib_runtime_events` and
to make a few others more widely available within the build system, namely
the boolean variables introduced to let `ocamltest` know whether
the libraries and ocamldebug/ocamldoc are there.

One thing could still be improved: the current definition of `with_camltex`
is odd: it's true when the tool needs to be built but the empty string
(rather than false) when it is not necessary to build the tool.

The rewriting described above still works so the definition can be left
untouched. We could also fix it, but since `with_camltex` is defined in
`Makefile.config` there is a risk of breaking external tools that assume
the variable is the empty string when the tool is not available.
In looks unlikely to me that anyone even uses cmaltex outside of the
compiler's codebase, but I may be wrong on this. @Octachron?

One other possibility would be to introduce a second, sibbling
variable, `build_camltex` which would be defined correctly and which would
be used internally, while `with_camltex` would be left untouched.
