### PR TITLE
fix #11482: random crash in large closure allocation

### DIFF
--- a/Changes
+++ b/Changes
@@ -119,6 +119,7 @@ Working version
   when they are not regular files.
   (Xavier Leroy, report by Thierry Martinez, review by
    Anil Madhavapeddy, Nicolás Ojeda Bär, David Allsopp)
+
 - #10348: Expand GADT equations lazily during unification to avoid ambiguity
   (Jacques Garrigue, review by Leo White)
 
@@ -601,6 +602,10 @@ OCaml 5.0
 - #11468: Fix regression from #10186 (OCaml 4.13) detecting IPv6 on Windows for
   mingw-w64 i686 port.
   (David Allsopp, review by Xavier Leroy and Sébastien Hinderer)
+
+- #11482, #11542: Fix random crash in large closure allocation
+  (Damien Doligez, report by Thierry Martinez and Vincent Laviron, review by
+   Xavier Leroy)
 
 - #11508, #11509: make Bytes.escaped domain-safe
   (Christiano Haesbaert and Gabriel Scherer,

--- a/asmcomp/cmm_helpers.ml
+++ b/asmcomp/cmm_helpers.ml
@@ -816,7 +816,7 @@ let make_alloc_generic set_fn dbg tag wordsize args =
     | e1::el -> Csequence(set_fn (Cvar id) (Cconst_int (idx, dbg)) e1 dbg,
                           fill_fields (idx + 2) el) in
     Clet(VP.create id,
-         Cop(Cextcall("caml_alloc", typ_val, [], true),
+         Cop(Cextcall("caml_alloc_shr_check_gc", typ_val, [], true),
                  [Cconst_int (wordsize, dbg); Cconst_int (tag, dbg)], dbg),
          fill_fields 1 args)
   end

--- a/runtime/alloc.c
+++ b/runtime/alloc.c
@@ -56,6 +56,13 @@ CAMLexport value caml_alloc (mlsize_t wosize, tag_t tag)
   return result;
 }
 
+/* This is used by the native compiler for large block allocations. */
+CAMLexport value caml_alloc_shr_check_gc (mlsize_t wosize, tag_t tag)
+{
+  caml_check_urgent_gc (Val_unit);
+  return caml_alloc_shr (wosize, tag);
+}
+
 Caml_inline value do_alloc_small(mlsize_t wosize, tag_t tag, value* vals)
 {
   value v;

--- a/runtime/caml/alloc.h
+++ b/runtime/caml/alloc.h
@@ -44,6 +44,7 @@ CAMLextern value caml_alloc_8(tag_t, value, value, value, value,
 CAMLextern value caml_alloc_9(tag_t, value, value, value, value,
                               value, value, value, value, value);
 CAMLextern value caml_alloc_small (mlsize_t, tag_t);
+CAMLextern value caml_alloc_shr_check_gc (mlsize_t, tag_t);
 CAMLextern value caml_alloc_tuple (mlsize_t);
 CAMLextern value caml_alloc_float_array (mlsize_t len);
 CAMLextern value caml_alloc_string (mlsize_t len);  /* len in bytes (chars) */


### PR DESCRIPTION
Note: this is still a draft, I still want to check that it does make the bug disappear.

Fixes #11482 