### PR TITLE
Keep generalized structure from patterns when typing let

### DIFF
--- a/testsuite/tests/typing-poly/pr11544.ml
+++ b/testsuite/tests/typing-poly/pr11544.ml
@@ -1,0 +1,18 @@
+(* TEST
+   * expect
+*)
+
+module M = struct type t = T end
+let poly3 : 'b. M.t -> 'b -> 'b =
+  fun T x -> x
+[%%expect {|
+module M : sig type t = T end
+val poly3 : M.t -> 'b -> 'b = <fun>
+|}, Principal{|
+module M : sig type t = T end
+Line 3, characters 6-7:
+3 |   fun T x -> x
+          ^
+Warning 18 [not-principal]: this type-based constructor disambiguation is not principal.
+val poly3 : M.t -> 'b -> 'b = <fun>
+|}];;

--- a/testsuite/tests/typing-poly/pr11544.ml
+++ b/testsuite/tests/typing-poly/pr11544.ml
@@ -8,11 +8,4 @@ let poly3 : 'b. M.t -> 'b -> 'b =
 [%%expect {|
 module M : sig type t = T end
 val poly3 : M.t -> 'b -> 'b = <fun>
-|}, Principal{|
-module M : sig type t = T end
-Line 3, characters 6-7:
-3 |   fun T x -> x
-          ^
-Warning 18 [not-principal]: this type-based constructor disambiguation is not principal.
-val poly3 : M.t -> 'b -> 'b = <fun>
 |}];;

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -2516,7 +2516,7 @@ let check_univars env kind exp ty_expected vars =
 
 let generalize_and_check_univars env kind exp ty_expected vars =
   generalize exp.exp_type;
-  generalize ty_expected;
+  generalize_structure ty_expected;
   List.iter generalize vars;
   check_univars env kind exp ty_expected vars
 
@@ -5140,11 +5140,13 @@ and type_let
       end_def ();
       iter_pattern_variables_type generalize_structure pvs;
       List.map (fun pat ->
-        generalize_structure pat.pat_type;
-        {pat with pat_type = instance pat.pat_type}
+        let ty = pat.pat_type in
+        generalize_structure ty;
+        {pat with pat_type = instance ty}, ty
       ) pat_list
-    end else
-      pat_list
+    end else begin
+      List.map (fun pat -> (pat, pat.pat_type)) pat_list
+    end
   in
   (* Only bind pattern variables after generalizing *)
   List.iter (fun f -> f()) force;
@@ -5183,7 +5185,7 @@ and type_let
            || (is_recursive && (Warnings.is_active Warnings.Unused_rec_flag))))
       attrs_list
   in
-  let pat_slot_list =
+  let typ_slot_list =
     (* Algorithm to detect unused declarations in recursive bindings:
        - During type checking of the definitions, we capture the 'value_used'
          events on the bound identifiers and record them in a slot corresponding
@@ -5201,9 +5203,9 @@ and type_let
        warning is 26, not 27.
      *)
     List.map2
-      (fun attrs pat ->
+      (fun attrs (pat, expected_ty) ->
          Builtin_attributes.warning_scope ~ppwarning:false attrs (fun () ->
-           if not warn_about_unused_bindings then pat, None
+           if not warn_about_unused_bindings then expected_ty, None
            else
              let some_used = ref false in
              (* has one of the identifier of this pattern been used? *)
@@ -5235,16 +5237,16 @@ and type_let
                     )
                )
                (Typedtree.pat_bound_idents pat);
-             pat, Some slot
+             expected_ty, Some slot
          ))
       attrs_list
       pat_list
   in
   let exp_list =
     List.map2
-      (fun {pvb_expr=sexp; pvb_attributes; _} (pat, slot) ->
+      (fun {pvb_expr=sexp; pvb_attributes; _} (expected_ty, slot) ->
         if is_recursive then current_slot := slot;
-        match get_desc pat.pat_type with
+        match get_desc expected_ty with
         | Tpoly (ty, tl) ->
             if !Clflags.principal then begin_def ();
             let vars, ty' = instance_poly ~keep_names:true true tl ty in
@@ -5265,12 +5267,13 @@ and type_let
             let exp =
               Builtin_attributes.warning_scope pvb_attributes (fun () ->
                   if rec_flag = Recursive then
-                    type_unpacks exp_env unpacks sexp (mk_expected pat.pat_type)
+                    type_unpacks exp_env unpacks
+                      sexp (mk_expected expected_ty)
                   else
-                    type_expect exp_env sexp (mk_expected pat.pat_type))
+                    type_expect exp_env sexp (mk_expected expected_ty))
             in
             exp, None)
-      spat_sexp_list pat_slot_list in
+      spat_sexp_list typ_slot_list in
   current_slot := None;
   if is_recursive && not !rec_needed then begin
     let {pvb_pat; pvb_attributes} = List.hd spat_sexp_list in
@@ -5281,7 +5284,7 @@ and type_let
       )
   end;
   List.iter2
-    (fun pat (attrs, exp) ->
+    (fun (pat, _) (attrs, exp) ->
        Builtin_attributes.warning_scope ~ppwarning:false attrs
          (fun () ->
             ignore(check_partial env pat.pat_type pat.pat_loc
@@ -5293,13 +5296,13 @@ and type_let
   let pvs = List.map (fun pv -> { pv with pv_type = instance pv.pv_type}) pvs in
   end_def();
   List.iter2
-    (fun pat (exp, _) ->
+    (fun (pat, _) (exp, _) ->
        if maybe_expansive exp then
          lower_contravariant env pat.pat_type)
     pat_list exp_list;
   iter_pattern_variables_type generalize pvs;
   List.iter2
-    (fun pat (exp, vars) ->
+    (fun (_, expected_ty) (exp, vars) ->
        match vars with
        | None ->
          (* We generalize expressions even if they are not bound to a variable
@@ -5315,12 +5318,12 @@ and type_let
        | Some vars ->
            if maybe_expansive exp then
              lower_contravariant env exp.exp_type;
-           generalize_and_check_univars env "definition" exp pat.pat_type vars)
+           generalize_and_check_univars env "definition" exp expected_ty vars)
     pat_list exp_list;
   let l = List.combine pat_list exp_list in
   let l =
     List.map2
-      (fun (p, (e, _)) pvb ->
+      (fun ((p, _), (e, _)) pvb ->
         {vb_pat=p; vb_expr=e; vb_attributes=pvb.pvb_attributes;
          vb_loc=pvb.pvb_loc;
         })


### PR DESCRIPTION
The following example gives a warning in `-principal` mode:
```ocaml
module M = struct type t = T end
let poly3 : 'b. M.t -> 'b -> 'b =
  fun T x -> x
```
because the type from the pattern is not being considered principal when typing the expression. This appears to just be an oversight in `type_let`. This PR fixes it.