### PR TITLE
Remove utils/config.generated.ml during distclean

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -109,9 +109,9 @@ configure: configure.ac aclocal.m4 build-aux/ocaml_version.m4 tools/autogen
 
 .PHONY: partialclean
 partialclean::
-	rm -f utils/config.ml utils/config.generated.ml \
-	utils/config_main.ml utils/config_main.mli \
-	utils/config_boot.ml utils/config_boot.mli \
+	rm -f utils/config.ml \
+	      utils/config_main.ml utils/config_main.mli \
+	      utils/config_boot.ml utils/config_boot.mli \
         utils/domainstate.ml utils/domainstate.mli
 
 .PHONY: beforedepend
@@ -1424,6 +1424,7 @@ distclean: clean
 	$(MAKE) -C stdlib distclean
 	$(MAKE) -C testsuite distclean
 	$(MAKE) -C tools distclean
+	rm -f utils/config.generated.ml
 	rm -f compilerlibs/META
 	rm -f boot/ocamlrun boot/ocamlrun.exe boot/camlheader \
 	      boot/ocamlruns boot/ocamlruns.exe \


### PR DESCRIPTION
Addresses https://github.com/ocaml/ocaml/pull/11268#issuecomment-1253434134. The cleaning of `utils/config.generated.ml` should be being done in `distclean` now that it's generated by `configure`. Detected by the bootstrap cycle because that has to do a partial clean.