### PR TITLE
Fix the size of the domain_id passed by tick thread to caml_init_domain_self

### DIFF
--- a/otherlibs/systhreads/st_pthreads.h
+++ b/otherlibs/systhreads/st_pthreads.h
@@ -291,7 +291,7 @@ static int st_event_wait(st_event e)
 
 static void * caml_thread_tick(void * arg)
 {
-  uintnat *domain_id = (uintnat *) arg;
+  int *domain_id = (int *) arg;
 
   caml_init_domain_self(*domain_id);
   caml_domain_state *domain = Caml_state;


### PR DESCRIPTION
While investigating the _s390x_ test suite failure at #11385, I found this error I introduced while porting the tick thread to Multicore.

The fix is pretty straightforward, and the deadlock we could see on the precheck run was caused by `caml_thread_tick` assuming the wrong size for `domain_id` (`uintnat` instead of `int`).
The compiled code would then truncate it with a (64 <- 32) load, meaning that the tick thread would initialise itself to domain 0.
This would not lead to a crash, however the way we request the tick thread to stop is by setting an integer in a domain_id indexed array:

```#define Tick_thread_stop tick_thread_stop[Caml_state->id]```

So if domain 1 starts up, the tick thread will see itself as being part of domain 0, and will not answer to a termination request, leading to a the main thread waiting on the join forever.

I am sorry for this mishap.