### PR TITLE
Fix ocamltest built without unix

### DIFF
--- a/configure
+++ b/configure
@@ -12804,6 +12804,8 @@ if test x"$enable_unix_lib" != "xno"; then :
   ocamltest_unix_name="unix"
   ocamltest_unix_path='$(ROOTDIR)/otherlibs/unix'
   ocamltest_unix_include='-I $(ROOTDIR)/otherlibs/unix '
+else
+  ocamltest_libunix="None"
 fi
 
 if test x"$enable_str_lib" != "xno"; then :

--- a/configure.ac
+++ b/configure.ac
@@ -627,7 +627,8 @@ AS_IF([test x"$enable_unix_lib" != "xno"],
   ocamltest_unix_impl="real"
   ocamltest_unix_name="unix"
   ocamltest_unix_path='$(ROOTDIR)/otherlibs/unix'
-  ocamltest_unix_include='-I $(ROOTDIR)/otherlibs/unix '])
+  ocamltest_unix_include='-I $(ROOTDIR)/otherlibs/unix '],
+  [ocamltest_libunix="None"])
 
 AS_IF([test x"$enable_str_lib" != "xno"],
   [otherlibraries="$otherlibraries str"

--- a/testsuite/tests/lib-filename/quotecommand.ml
+++ b/testsuite/tests/lib-filename/quotecommand.ml
@@ -20,7 +20,6 @@ program = "${test_build_directory}/quotecommand.opt"
 program = "${test_build_directory}/myecho.exe"
 all_modules = "myecho.ml"
 *** ocamlopt.byte
-include unix
 program = "${test_build_directory}/quotecommand.opt"
 all_modules= "quotecommand.ml"
 **** check-ocamlopt.byte-output

--- a/testsuite/tests/tool-caml-tex/ellipses.ml
+++ b/testsuite/tests/tool-caml-tex/ellipses.ml
@@ -5,8 +5,9 @@
    script = "${ocamlrun} ${ocamlsrcdir}/tools/caml-tex \
    -repo-root ${ocamlsrcdir} ${readonly_files} -o ${output}"
   * hasstr
-  ** native-compiler
-  *** shared-libraries
-  **** script with unix,str
-  ***** check-program-output
+  ** hasunix
+  *** native-compiler
+  **** shared-libraries
+  ***** script with unix,str
+  ****** check-program-output
 *)

--- a/testsuite/tests/tool-caml-tex/redirections.ml
+++ b/testsuite/tests/tool-caml-tex/redirections.ml
@@ -5,13 +5,14 @@
    script = "${ocamlrun} ${ocamlsrcdir}/tools/caml-tex \
    -repo-root ${ocamlsrcdir} ${readonly_files} -o ${output}"
   * hasstr
-  ** native-compiler
-  *** shared-libraries
-  **** script with unix,str
-  ***** check-program-output
-  *** no-shared-libraries
-  **** script with unix,str
+  ** hasunix
+  *** native-compiler
+  **** shared-libraries
+  ***** script with unix,str
+  ****** check-program-output
+  **** no-shared-libraries
+  ***** script with unix,str
    script = "${ocamlsrcdir}/tools/caml-tex \
    -repo-root ${ocamlsrcdir} ${readonly_files} -o ${output}"
-  ***** check-program-output
+  ****** check-program-output
 *)


### PR DESCRIPTION
A missing configuration case. The previous runs with everything switched off were hiding a couple of faulty test script headers which are fixed here, too.

cc @Octachron