### PR TITLE
caml_make_float_vect in no-flat-float array: use static allocation

### DIFF
--- a/Changes
+++ b/Changes
@@ -286,6 +286,10 @@ OCaml 5.0
   in this case.
   (Hugo Heuzard, review by Gabriel Scherer)
 
+- #11504, #11522: Use static allocation in `caml_make_float_vect` in
+  no-flat-float-array mode, it's more efficient and avoids a a race condition
+  (Xavier Leroy, report by Guillaume Munch-Maccagnoni, review by ??)
+
 ### Code generation and optimizations:
 
 - #10972: ARM64 multicore support: OCaml & C stack separation;

--- a/Changes
+++ b/Changes
@@ -288,7 +288,7 @@ OCaml 5.0
 
 - #11504, #11522: Use static allocation in `caml_make_float_vect` in
   no-flat-float-array mode, it's more efficient and avoids a a race condition
-  (Xavier Leroy, report by Guillaume Munch-Maccagnoni, review by ??)
+  (Xavier Leroy, report by Guillaume Munch-Maccagnoni, review by David Allsopp)
 
 ### Code generation and optimizations:
 


### PR DESCRIPTION
Allocate the initializing float block statically and outside the heap, rather than dynamically at first use.  Not only it's more efficient, but it also avoids the race condition reported in #11504.

Fixes: #11504