### PR TITLE
Move `Is_young` back to `<caml/address_class.h>` and export it

### DIFF
--- a/runtime/caml/address_class.h
+++ b/runtime/caml/address_class.h
@@ -43,7 +43,19 @@
 #include "misc.h"
 #include "mlvalues.h"
 
-/* These definitions are retained for backwards compatibility */
+CAMLextern uintnat caml_minor_heaps_start;
+CAMLextern uintnat caml_minor_heaps_end;
+
+/* Is_young(val) is true iff val is in the reserved area for minor heaps */
+
+#define Is_young(val) \
+  (CAMLassert (Is_block (val)), \
+   (char *)(val) < (char *)caml_minor_heaps_end && \
+   (char *)(val) > (char *)caml_minor_heaps_start)
+
+#define Is_block_and_young(val) (Is_block(val) && Is_young(val))
+
+/* These definitions are retained for backwards compatibility with OCaml 4 */
 #define Is_in_heap_or_young(a) 1
 #define Is_in_value_area(a) 1
 

--- a/runtime/caml/domain.h
+++ b/runtime/caml/domain.h
@@ -88,8 +88,6 @@ CAMLextern void caml_init_domain_self(int);
 CAMLextern uintnat caml_minor_heap_max_wsz;
 
 CAMLextern atomic_uintnat caml_num_domains_running;
-CAMLextern uintnat caml_minor_heaps_start;
-CAMLextern uintnat caml_minor_heaps_end;
 
 Caml_inline intnat caml_domain_alone(void)
 {

--- a/runtime/caml/minor_gc.h
+++ b/runtime/caml/minor_gc.h
@@ -16,6 +16,7 @@
 #ifndef CAML_MINOR_GC_H
 #define CAML_MINOR_GC_H
 
+#include "address_class.h"
 #include "misc.h"
 #include "config.h"
 

--- a/runtime/caml/mlvalues.h
+++ b/runtime/caml/mlvalues.h
@@ -207,15 +207,6 @@ bits  63        (64-P) (63-P)        10 9     8 7   0
 /* Fields are numbered from 0. */
 #define Field(x, i) (((volatile value *)(x)) [i]) /* Also an l-value. */
 
-/* Is_young(val) is true iff val is in the reserved area for minor heaps */
-
-#define Is_young(val) \
-  (CAMLassert (Is_block (val)), \
-   (char *)(val) < (char *)caml_minor_heaps_end && \
-   (char *)(val) > (char *)caml_minor_heaps_start)
-
-#define Is_block_and_young(val) (Is_block(val) && Is_young(val))
-
 /* NOTE: [Forward_tag] and [Infix_tag] must be just under
    [No_scan_tag], with [Infix_tag] the lower one.
    See [caml_oldify_one] in minor_gc.c for more details.


### PR DESCRIPTION
For backward compatibility with OCaml 4.  See #11464 for why the current definition is problematic.

Fixes: #11464
