### PR TITLE
documentation: fix typos

### DIFF
--- a/otherlibs/unix/unix.mli
+++ b/otherlibs/unix/unix.mli
@@ -995,11 +995,11 @@ val close_process_full :
 val symlink : ?to_dir: (* thwart tools/sync_stdlib_docs *) bool ->
               string -> string -> unit
 (** [symlink ?to_dir src dst] creates the file [dst] as a symbolic link
-   to the file [src]. On Windows, [to_dir] indicates if the symbolic link
+   to the file [src]. On Windows, [~to_dir] indicates if the symbolic link
    points to a directory or a file; if omitted, [symlink] examines [src]
    using [stat] and picks appropriately, if [src] does not exist then [false]
-   is assumed (for this reason, it is recommended that the [to_dir] parameter
-   be specified in new code). On Unix, [to_dir] is ignored.
+   is assumed (for this reason, it is recommended that the [~to_dir] parameter
+   be specified in new code). On Unix, [~to_dir] is ignored.
 
    Windows symbolic links are available in Windows Vista onwards. There are some
    important differences between Windows symlinks and their POSIX counterparts.

--- a/stdlib/string.mli
+++ b/stdlib/string.mli
@@ -151,14 +151,14 @@ val compare : t -> t -> int
 
 val starts_with :
   prefix (* comment thwarts tools/sync_stdlib_docs *) :string -> string -> bool
-(** [starts_with ][~][prefix s] is [true] if and only if [s] starts with
+(** [starts_with ][~prefix s] is [true] if and only if [s] starts with
     [prefix].
 
     @since 4.13.0 *)
 
 val ends_with :
   suffix (* comment thwarts tools/sync_stdlib_docs *) :string -> string -> bool
-(** [ends_with suffix s] is [true] if and only if [s] ends with [suffix].
+(** [ends_with ][~suffix s] is [true] if and only if [s] ends with [suffix].
 
     @since 4.13.0 *)
 

--- a/stdlib/stringLabels.mli
+++ b/stdlib/stringLabels.mli
@@ -151,14 +151,14 @@ val compare : t -> t -> int
 
 val starts_with :
   prefix (* comment thwarts tools/sync_stdlib_docs *) :string -> string -> bool
-(** [starts_with ][~][prefix s] is [true] if and only if [s] starts with
+(** [starts_with ][~prefix s] is [true] if and only if [s] starts with
     [prefix].
 
     @since 4.13.0 *)
 
 val ends_with :
   suffix (* comment thwarts tools/sync_stdlib_docs *) :string -> string -> bool
-(** [ends_with ~suffix s] is [true] if and only if [s] ends with [suffix].
+(** [ends_with ][~suffix s] is [true] if and only if [s] ends with [suffix].
 
     @since 4.13.0 *)
 

--- a/tools/sync_stdlib_docs
+++ b/tools/sync_stdlib_docs
@@ -32,7 +32,7 @@ LABLABREGEX="s/\([a-z_]+:([a-z\('])/\(\1/g"
 
 #Remove a tilde if it is followed by a label name and a space or closing
 #OCamldoc code section with ]
-TILDEREGEX="s/~([a-z_]+[ \]])/\1/g"
+TILDEREGEX="s/ ~([a-z_]+(?=[ \]]))/ \1/g"
 
 #Indent a non-blank line by two characters, for moreLabels templates
 INDENTREGEX="s/^(.+)$/  \1/m"


### PR DESCRIPTION
Fix typo in the docstring of `starts_with` and `ends_with`.