### PR TITLE
#11560: typechecker internal error on missing gadts

### DIFF
--- a/Changes
+++ b/Changes
@@ -128,7 +128,8 @@ Working version
   (Xavier Leroy, report by Thierry Martinez, review by
    Anil Madhavapeddy, Nicolás Ojeda Bär, David Allsopp)
 
-- #10348: Expand GADT equations lazily during unification to avoid ambiguity
+- #10348, #10560, #11561: Expand GADT equations lazily during unification to
+  avoid ambiguity
   (Jacques Garrigue, review by Leo White)
 
 - #11436: Fix wrong stack backtrace for out-of-bound exceptions raised

--- a/testsuite/tests/typing-missing-cmi-3/middle.ml
+++ b/testsuite/tests/typing-missing-cmi-3/middle.ml
@@ -1,4 +1,5 @@
 type 'a t = 'a Original.t = T
+type 'a ti = 'a Original.t
 
 let f: (module Original.T with type t = int) -> unit = fun _ -> ()
 let x = (module struct type t end: Original.T )
@@ -13,3 +14,7 @@ let r = Original.r
 
 type s = Original.s = S
 let s = Original.s
+
+(* Check expansion in gadt *)
+type ('a,'b) gadt =
+| G: ('a, 'a ti) gadt

--- a/testsuite/tests/typing-missing-cmi-3/user.ml
+++ b/testsuite/tests/typing-missing-cmi-3/user.ml
@@ -99,3 +99,11 @@ let k = match Middle.s with Middle.S -> ()
 [%%expect {|
 val k : unit = ()
 |}]
+
+(* #11560: gadts and missing cmis *)
+
+let  f : type a b. (a Middle.ti -> unit) -> (a,b) Middle.gadt -> b -> unit =
+  fun call Middle.G x -> call x
+[%%expect {|
+val f : ('a Middle.ti -> unit) -> ('a, 'b) Middle.gadt -> 'b -> unit = <fun>
+|}]

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -2163,9 +2163,9 @@ let reify env t =
   iterator t
 
 let find_expansion_scope env path =
-  let decl = Env.find_type path env in
-  if decl.type_manifest = None then generic_level
-  else decl.type_expansion_scope
+  match Env.find_type path env with
+  | { type_manifest = None ; _ } | exception Not_found -> generic_level
+  | decl -> decl.type_expansion_scope
 
 let non_aliasable p decl =
   (* in_pervasives p ||  (subsumed by in_current_module) *)


### PR DESCRIPTION
This PR is a small tweak to #10348 that fixes the handling of missing type constructors due to missing cmis.

Close #11560 