### PR TITLE
Add ability to bootstrap flexdll on Jenkins Windows workers

### DIFF
--- a/tools/ci/inria/main
+++ b/tools/ci/inria/main
@@ -144,6 +144,7 @@ cleanup=false
 check_make_alldepend=false
 jobs=''
 bootstrap=false
+init_submodule=false
 
 case "${OCAML_ARCH}" in
   bsd|solaris)
@@ -216,6 +217,12 @@ fi
 
 pwd
 cd "$jenkinsdir"
+
+if $init_submodule; then
+  git submodule update --init flexdll
+elif [ -f flexdll/Makefile ]; then
+  git submodule deinit --force flexdll
+fi
 
 #########################################################################
 # parse optional command-line arguments (has to be done after the "cd")


### PR DESCRIPTION
The Jenkins Windows workers have flexdll preinstalled and don't usually test the `--with-flexdll`/bootstrap mode of flexlink (this gets tested on AppVeyor instead). A forthcoming PR of mine at present needs an unreleased version of flexdll, so I added this commit to a precheck branch in order to test it.

Unfortunately, I forgot that the Jenkins workers aren't stateless, so running that branch through precheck had the unintended effect of _leaving_ the workers with the `flexdll` submodule initialised and therefore running in "bootstrap" mode.

The primary purpose of this commit is so that one can temporarily add `init_submodule=true` to cases like: https://github.com/ocaml/ocaml/blob/96df8e8e09242ab55645ddfa387d49dcb2197a58/tools/ci/inria/main#L175-L183

When `init_submodule` is `false`, the script ensures that the `flexdll` submodule is deinited.