### PR TITLE
Extra types in path

### DIFF
--- a/Changes
+++ b/Changes
@@ -162,6 +162,8 @@ Working version
 
 - #11364: Allow `make -C testsuite promote` to take `TEST` and `LIST` variables
   (Antal Spector-Zabusky, review by Gabriel Scherer and David Allsopp)
+- #11315: Encode inline record types in Path.t
+  (Leo White and Hyunggyu Jang, review by ??)
 
 - #11446: document switch compilation (lambda/switch.ml)
   (Gabriel Scherer, review by Luc Maranget and Vincent Laviron)

--- a/Changes
+++ b/Changes
@@ -162,8 +162,6 @@ Working version
 
 - #11364: Allow `make -C testsuite promote` to take `TEST` and `LIST` variables
   (Antal Spector-Zabusky, review by Gabriel Scherer and David Allsopp)
-- #11315: Encode inline record types in Path.t
-  (Leo White and Hyunggyu Jang, review by ??)
 
 - #11446: document switch compilation (lambda/switch.ml)
   (Gabriel Scherer, review by Luc Maranget and Vincent Laviron)
@@ -180,6 +178,9 @@ Working version
 
 - #11569: Remove hash type encoding
   (Hyunggyu Jang, review by Gabriel Scherer and Florian Angeletti)
+
+- #11568: Encode inline record types in Path.t
+  (Leo White and Hyunggyu Jang, review by Gabriel Scherer)
 
 ### Build system:
 - #11590: Allow installing to a destination path containing spaces.

--- a/lambda/translprim.ml
+++ b/lambda/translprim.ml
@@ -97,7 +97,7 @@ let used_primitives = Hashtbl.create 7
 let add_used_primitive loc env path =
   match path with
     Some (Path.Pdot _ as path) ->
-      let path = Env.normalize_path_prefix (Some loc) env path in
+      let path = Env.normalize_value_path (Some loc) env path in
       let unit = Path.head path in
       if Ident.global unit && not (Hashtbl.mem used_primitives path)
       then Hashtbl.add used_primitives path loc

--- a/toplevel/genprintval.ml
+++ b/toplevel/genprintval.ml
@@ -209,12 +209,12 @@ module Make(O : OBJ)(EVP : EVALPATH with type valu = O.t) = struct
             | exception Not_found -> false
           then Oide_ident name
           else Oide_dot (Printtyp.tree_of_path p, Out_name.print name)
-      | Pcstr_ty _ | Pext_ty _ ->
+      | Papply _ ->
+          Printtyp.tree_of_path ty_path
+      | Pextra_ty _ ->
           (* These can only appear directly inside of the associated
              constructor so we can just drop the prefix *)
           Oide_ident name
-      | Papply _ ->
-          Printtyp.tree_of_path ty_path
 
     let tree_of_constr =
       tree_of_qualified

--- a/toplevel/genprintval.ml
+++ b/toplevel/genprintval.ml
@@ -209,6 +209,10 @@ module Make(O : OBJ)(EVP : EVALPATH with type valu = O.t) = struct
             | exception Not_found -> false
           then Oide_ident name
           else Oide_dot (Printtyp.tree_of_path p, Out_name.print name)
+      | Pcstr_ty _ | Pext_ty _ ->
+          (* These can only appear directly inside of the associated
+             constructor so we can just drop the prefix *)
+          Oide_ident name
       | Papply _ ->
           Printtyp.tree_of_path ty_path
 

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -266,9 +266,10 @@ let set_mode_pattern ~generate ~injective ~allow_recursive f =
 
 (*** Checks for type definitions ***)
 
-let in_current_module = function
+let rec in_current_module = function
   | Path.Pident _ -> true
   | Path.Pdot _ | Path.Papply _ -> false
+  | Path.Pextra_ty (p, _) -> in_current_module p
 
 let in_pervasives p =
   in_current_module p &&

--- a/typing/datarepr.ml
+++ b/typing/datarepr.ml
@@ -125,7 +125,7 @@ let constructor_descrs ~current_unit ty_path decl cstrs rep =
             | Variant_regular -> Record_inlined idx_nonconst
           in
           constructor_args ~current_unit decl.type_private cd_args cd_res
-            (Path.Pdot (ty_path, cstr_name)) representation
+            (Path.Pcstr_ty (ty_path, cstr_name)) representation
         in
         let cstr =
           { cstr_name;
@@ -154,7 +154,7 @@ let extension_descr ~current_unit path_ext ext =
   in
   let existentials, cstr_args, cstr_inlined =
     constructor_args ~current_unit ext.ext_private ext.ext_args ext.ext_ret_type
-      path_ext (Record_extension path_ext)
+      (Path.Pext_ty path_ext) (Record_extension path_ext)
   in
     { cstr_name = Path.last path_ext;
       cstr_res = ty_res;

--- a/typing/datarepr.ml
+++ b/typing/datarepr.ml
@@ -125,7 +125,7 @@ let constructor_descrs ~current_unit ty_path decl cstrs rep =
             | Variant_regular -> Record_inlined idx_nonconst
           in
           constructor_args ~current_unit decl.type_private cd_args cd_res
-            (Path.Pcstr_ty (ty_path, cstr_name)) representation
+            Path.(Pextra_ty (ty_path, Pcstr_ty cstr_name)) representation
         in
         let cstr =
           { cstr_name;
@@ -154,7 +154,7 @@ let extension_descr ~current_unit path_ext ext =
   in
   let existentials, cstr_args, cstr_inlined =
     constructor_args ~current_unit ext.ext_private ext.ext_args ext.ext_ret_type
-      (Path.Pext_ty path_ext) (Record_extension path_ext)
+      Path.(Pextra_ty (path_ext, Pext_ty)) (Record_extension path_ext)
   in
     { cstr_name = Path.last path_ext;
       cstr_res = ty_res;

--- a/typing/env.ml
+++ b/typing/env.ml
@@ -1129,19 +1129,21 @@ let rec find_type_data path env =
       | Pextra_ty (p, extra) -> begin
           match extra with
           | Pcstr_ty s ->
-              let tda = find_type_data p env in
-              let cstr =
-                match tda.tda_descriptions with
-                | Type_variant (cstrs, _) ->
-                    List.find (fun cstr -> cstr.cstr_name = s) cstrs
-                | Type_record _ | Type_abstract | Type_open -> raise Not_found
-              in
+              let cstr = find_cstr p s env in
               type_of_cstr path cstr
           | Pext_ty ->
               let cda = find_extension_full p env in
               type_of_cstr path cda.cda_description
         end
     end
+and find_cstr path name env =
+  let tda = find_type_data path env in
+  match tda.tda_descriptions with
+  | Type_variant (cstrs, _) ->
+      List.find (fun cstr -> cstr.cstr_name = name) cstrs
+  | Type_record _ | Type_abstract | Type_open -> raise Not_found
+
+
 
 let find_modtype_lazy path env =
   match path with

--- a/typing/env.ml
+++ b/typing/env.ml
@@ -710,10 +710,6 @@ let is_in_signature env = env.flags land in_signature_flag <> 0
 let has_local_constraints env =
   not (Path.Map.is_empty env.local_constraints)
 
-let is_ident = function
-    Pident _ -> true
-  | Pdot _ | Papply _ -> false
-
 let is_ext cda =
   match cda.cda_description with
   | {cstr_tag = Cstr_extension _} -> true
@@ -721,7 +717,11 @@ let is_ext cda =
 
 let is_local_ext cda =
   match cda.cda_description with
-  | {cstr_tag = Cstr_extension(p, _)} -> is_ident p
+  | {cstr_tag = Cstr_extension(p, _)} -> begin
+      match p with
+      | Pident _ -> true
+      | Pdot _ | Papply _ | Pext_ty _ | Pcstr_ty _ -> false
+  end
   | _ -> false
 
 let diff env1 env2 =
@@ -795,7 +795,7 @@ end = struct
     Ident.persistent id && is (Ident.name id)
   let is_path = function
   | Pident id -> is_ident id
-  | Pdot _ | Papply _ -> false
+  | Pdot _ | Papply _ | Pcstr_ty _ | Pext_ty _ -> false
 end
 
 let set_unit_name = Current_unit_name.set
@@ -1020,6 +1020,7 @@ let rec find_module_components path env =
       let f_comp = find_functor_components f_path env in
       let loc = Location.(in_file !input_name) in
       !components_of_functor_appl' ~loc ~f_path ~f_comp ~arg env
+  | Pcstr_ty _ | Pext_ty _ -> raise Not_found
 
 and find_structure_components path env =
   match get_components (find_module_components path env) with
@@ -1044,6 +1045,7 @@ let find_module ~alias path env =
       let fc = find_functor_components p1 env in
       if alias then md (fc.fcomp_res)
       else md (modtype_of_functor_appl fc p1 p2)
+  | Pcstr_ty _ | Pext_ty _ -> raise Not_found
 
 let find_module_lazy ~alias path env =
   match path with
@@ -1061,6 +1063,7 @@ let find_module_lazy ~alias path env =
         else md (modtype_of_functor_appl fc p1 p2)
       in
       Subst.Lazy.of_module_decl md
+  | Pcstr_ty _ | Pext_ty _ -> raise Not_found
 
 let find_strengthened_module ~aliasable path env =
   let md = find_module_lazy ~alias:true path env in
@@ -1077,54 +1080,20 @@ let find_value_full path env =
   | Pdot(p, s) ->
       let sc = find_structure_components p env in
       NameMap.find s sc.comp_values
-  | Papply _ -> raise Not_found
+  | Papply _ | Pcstr_ty _ | Pext_ty _ -> raise Not_found
 
-let find_type_full path env =
+let find_extension path env =
   match path with
-  | Pident id -> IdTbl.find_same id env.types
-  | Pdot(p, s) ->
-      let sc = find_structure_components p env in
-      NameMap.find s sc.comp_types
-  | Papply _ -> raise Not_found
-
-let find_modtype_lazy path env =
-  match path with
-  | Pident id -> (IdTbl.find_same id env.modtypes).mtda_declaration
-  | Pdot(p, s) ->
-      let sc = find_structure_components p env in
-      (NameMap.find s sc.comp_modtypes).mtda_declaration
-  | Papply _ -> raise Not_found
-
-let find_modtype path env =
-  Subst.Lazy.force_modtype_decl (find_modtype_lazy path env)
-
-let find_class_full path env =
-  match path with
-  | Pident id -> IdTbl.find_same id env.classes
-  | Pdot(p, s) ->
-      let sc = find_structure_components p env in
-      NameMap.find s sc.comp_classes
-  | Papply _ -> raise Not_found
-
-let find_cltype path env =
-  match path with
-  | Pident id -> (IdTbl.find_same id env.cltypes).cltda_declaration
-  | Pdot(p, s) ->
-      let sc = find_structure_components p env in
-      (NameMap.find s sc.comp_cltypes).cltda_declaration
-  | Papply _ -> raise Not_found
-
-let find_value path env =
-  (find_value_full path env).vda_description
-
-let find_class path env =
-  (find_class_full path env).clda_declaration
-
-let find_ident_constructor id env =
-  (TycompTbl.find_same id env.constrs).cda_description
-
-let find_ident_label id env =
-  TycompTbl.find_same id env.labels
+  | Pident id -> TycompTbl.find_same id env.constrs
+  | Pdot(p, s) -> begin
+      let comps = find_structure_components p env in
+      let cstrs = NameMap.find s comps.comp_constrs in
+      let exts = List.filter is_ext cstrs in
+      match exts with
+      | [cda] -> cda
+      | _ -> raise Not_found
+    end
+  | Pcstr_ty _ | Pext_ty _ | Papply _ -> raise Not_found
 
 let type_of_cstr path = function
   | {cstr_inlined = Some decl; _} ->
@@ -1142,54 +1111,73 @@ let type_of_cstr path = function
       end
   | _ -> assert false
 
-let find_type_data path env =
-  match Path.constructor_typath path with
-  | Regular p -> begin
-      match Path.Map.find p env.local_constraints with
-      | decl ->
-          {
-            tda_declaration = decl;
-            tda_descriptions = Type_abstract;
-            tda_shape = Shape.leaf decl.type_uid;
-          }
-      | exception Not_found -> find_type_full p env
+let rec find_type_data path env =
+  match Path.Map.find path env.local_constraints with
+  | decl ->
+    {
+      tda_declaration = decl;
+      tda_descriptions = Type_abstract;
+      tda_shape = Shape.leaf decl.type_uid;
+    }
+  | exception Not_found -> begin
+      match path with
+      | Pident id -> IdTbl.find_same id env.types
+      | Pdot(p, s) ->
+          let sc = find_structure_components p env in
+          NameMap.find s sc.comp_types
+      | Pcstr_ty(p, s) ->
+          let tda = find_type_data p env in
+          let cstr =
+            match tda.tda_descriptions with
+            | Type_variant (cstrs, _) ->
+                List.find (fun cstr -> cstr.cstr_name = s) cstrs
+            | Type_record _ | Type_abstract | Type_open -> raise Not_found
+          in
+          type_of_cstr path cstr
+      | Pext_ty p ->
+          let cda = find_extension p env in
+          type_of_cstr path cda.cda_description
+      | Papply _ -> raise Not_found
     end
-  | Cstr (ty_path, s) ->
-      (* This case corresponds to an inlined record *)
-      let tda =
-        try find_type_full ty_path env
-        with Not_found -> assert false
-      in
-      let cstr =
-        begin match tda.tda_descriptions with
-        | Type_variant (cstrs, _) -> begin
-            try
-              List.find (fun cstr -> cstr.cstr_name = s) cstrs
-            with Not_found -> assert false
-          end
-        | Type_record _ | Type_abstract | Type_open -> assert false
-        end
-      in
-      type_of_cstr path cstr
-  | LocalExt id ->
-      let cstr =
-        try (TycompTbl.find_same id env.constrs).cda_description
-        with Not_found -> assert false
-      in
-      type_of_cstr path cstr
-  | Ext (mod_path, s) ->
-      let comps =
-        try find_structure_components mod_path env
-        with Not_found -> assert false
-      in
-      let cstrs =
-        try NameMap.find s comps.comp_constrs
-        with Not_found -> assert false
-      in
-      let exts = List.filter is_ext cstrs in
-      match exts with
-      | [cda] -> type_of_cstr path cda.cda_description
-      | _ -> assert false
+
+let find_modtype_lazy path env =
+  match path with
+  | Pident id -> (IdTbl.find_same id env.modtypes).mtda_declaration
+  | Pdot(p, s) ->
+      let sc = find_structure_components p env in
+      (NameMap.find s sc.comp_modtypes).mtda_declaration
+  | Papply _ | Pcstr_ty _ | Pext_ty _ -> raise Not_found
+
+let find_modtype path env =
+  Subst.Lazy.force_modtype_decl (find_modtype_lazy path env)
+
+let find_class_full path env =
+  match path with
+  | Pident id -> IdTbl.find_same id env.classes
+  | Pdot(p, s) ->
+      let sc = find_structure_components p env in
+      NameMap.find s sc.comp_classes
+  | Papply _ | Pcstr_ty _ | Pext_ty _ -> raise Not_found
+
+let find_cltype path env =
+  match path with
+  | Pident id -> (IdTbl.find_same id env.cltypes).cltda_declaration
+  | Pdot(p, s) ->
+      let sc = find_structure_components p env in
+      (NameMap.find s sc.comp_cltypes).cltda_declaration
+  | Papply _ | Pcstr_ty _ | Pext_ty _ -> raise Not_found
+
+let find_value path env =
+  (find_value_full path env).vda_description
+
+let find_class path env =
+  (find_class_full path env).clda_declaration
+
+let find_ident_constructor id env =
+  (TycompTbl.find_same id env.constrs).cda_description
+
+let find_ident_label id env =
+  TycompTbl.find_same id env.labels
 
 let find_type p env =
   (find_type_data p env).tda_declaration
@@ -1202,7 +1190,7 @@ let rec find_module_address path env =
   | Pdot(p, s) ->
       let c = find_structure_components p env in
       get_address (NameMap.find s c.comp_modules).mda_address
-  | Papply _ -> raise Not_found
+  | Papply _ | Pcstr_ty _ | Pext_ty _ -> raise Not_found
 
 and force_address = function
   | Projection { parent; pos } -> Adot(get_address parent, pos)
@@ -1235,8 +1223,7 @@ let find_constructor_address path env =
   | Pdot(p, s) ->
       let c = find_structure_components p env in
       get_constrs_address (NameMap.find s c.comp_constrs)
-  | Papply _ ->
-      raise Not_found
+  | Papply _ | Pcstr_ty _ | Pext_ty _ -> raise Not_found
 
 let find_hash_type path env =
   match path with
@@ -1250,7 +1237,7 @@ let find_hash_type path env =
       let c = find_structure_components p env in
       let cltda = NameMap.find name c.comp_cltypes in
       cltda.cltda_declaration.clty_hash_type
-  | Papply _ -> raise Not_found
+  | Papply _ | Pcstr_ty _ | Pext_ty _ -> raise Not_found
 
 let find_shape env (ns : Shape.Sig_component_kind.t) id =
   match ns with
@@ -1311,6 +1298,7 @@ let rec normalize_module_path lax env = function
       let p2' = normalize_module_path true env p2 in
       if p1 == p1' && p2 == p2' then expand_module_path lax env path
       else expand_module_path lax env (Papply(p1', p2'))
+  | Pcstr_ty _ | Pext_ty _ as path -> path
   | Pident _ as path ->
       expand_module_path lax env path
 
@@ -1338,32 +1326,29 @@ let normalize_module_path oloc env path =
 
 let normalize_path_prefix oloc env path =
   match path with
-    Pdot(p, s) ->
+  | Pdot(p, s) ->
       let p2 = normalize_module_path oloc env p in
       if p == p2 then path else Pdot(p2, s)
   | Pident _ ->
       path
-  | Papply _ ->
+  | Papply _ | Pcstr_ty _ | Pext_ty _ ->
       assert false
 
-let normalize_type_path oloc env path =
-  (* Inlined version of Path.is_constructor_typath:
-     constructor type paths (i.e. path pointing to an inline
-     record argument of a constructpr) are built as a regular
-     type path followed by a capitalized constructor name. *)
+let normalize_extension_path = normalize_path_prefix
+
+let rec normalize_type_path oloc env path =
   match path with
   | Pident _ ->
       path
   | Pdot(p, s) ->
-      let p2 =
-        if Path.is_uident s && not (Path.is_uident (Path.last p)) then
-          (* Cstr M.t.C *)
-          normalize_path_prefix oloc env p
-        else
-          (* Regular M.t, Ext M.C *)
-          normalize_module_path oloc env p
-      in
+      let p2 = normalize_module_path oloc env p in
       if p == p2 then path else Pdot (p2, s)
+  | Pcstr_ty(p, s) ->
+      let p2 = normalize_type_path oloc env p in
+      if p == p2 then path else Pcstr_ty (p2, s)
+  | Pext_ty p ->
+      let p2 = normalize_extension_path oloc env p in
+      if p == p2 then path else Pext_ty p2
   | Papply _ ->
       assert false
 
@@ -1425,7 +1410,7 @@ let rec is_functor_arg path env =
       begin try Ident.find_same id env.functor_args; true
       with Not_found -> false
       end
-  | Pdot (p, _s) -> is_functor_arg p env
+  | Pdot (p, _) | Pcstr_ty(p, _) | Pext_ty p -> is_functor_arg p env
   | Papply _ -> true
 
 (* Copying types associated with values *)
@@ -1560,7 +1545,7 @@ let rec find_shadowed_comps path env =
              (fun comps -> comps.comp_modules) s) l
       in
       List.flatten l'
-  | Papply _ -> []
+  | Papply _ | Pcstr_ty _ | Pext_ty _ -> []
 
 let find_shadowed wrap proj1 proj2 path env =
   match path with
@@ -1570,7 +1555,7 @@ let find_shadowed wrap proj1 proj2 path env =
       let l = find_shadowed_comps p env in
       let l' = List.map (find_all_comps wrap proj2 s) l in
       List.flatten l'
-  | Papply _ -> []
+  | Papply _ | Pcstr_ty _ | Pext_ty _ -> []
 
 let find_shadowed_types path env =
   List.map fst

--- a/typing/env.ml
+++ b/typing/env.ml
@@ -1082,7 +1082,7 @@ let find_value_full path env =
       NameMap.find s sc.comp_values
   | Papply _ | Pextra_ty _ -> raise Not_found
 
-let find_extension path env =
+let find_extension_full path env =
   match path with
   | Pident id -> TycompTbl.find_same id env.constrs
   | Pdot(p, s) -> begin
@@ -1138,7 +1138,7 @@ let rec find_type_data path env =
               in
               type_of_cstr path cstr
           | Pext_ty ->
-              let cda = find_extension p env in
+              let cda = find_extension_full p env in
               type_of_cstr path cda.cda_description
         end
     end

--- a/typing/env.mli
+++ b/typing/env.mli
@@ -127,9 +127,8 @@ val normalize_module_path: Location.t option -> t -> Path.t -> Path.t
 val normalize_type_path: Location.t option -> t -> Path.t -> Path.t
 (* Normalize the prefix part of the type path *)
 
-val normalize_path_prefix: Location.t option -> t -> Path.t -> Path.t
-(* Normalize the prefix part of other kinds of paths
-   (value/modtype/etc) *)
+val normalize_value_path: Location.t option -> t -> Path.t -> Path.t
+(* Normalize the prefix part of the value path *)
 
 val normalize_modtype_path: t -> Path.t -> Path.t
 (* Normalize a module type path *)

--- a/typing/includemod.ml
+++ b/typing/includemod.ml
@@ -905,7 +905,7 @@ and check_modtype_equiv ~in_eq ~loc env ~mark mty1 mty2 =
 let can_alias env path =
   let rec no_apply = function
     | Path.Pident _ -> true
-    | Path.Pdot(p, _) -> no_apply p
+    | Path.Pdot(p, _) | Path.Pcstr_ty(p, _) | Path.Pext_ty p -> no_apply p
     | Path.Papply _ -> false
   in
   no_apply path && not (Env.is_functor_arg path env)

--- a/typing/includemod.ml
+++ b/typing/includemod.ml
@@ -905,7 +905,7 @@ and check_modtype_equiv ~in_eq ~loc env ~mark mty1 mty2 =
 let can_alias env path =
   let rec no_apply = function
     | Path.Pident _ -> true
-    | Path.Pdot(p, _) | Path.Pcstr_ty(p, _) | Path.Pext_ty p -> no_apply p
+    | Path.Pdot(p, _) | Path.Pextra_ty (p, _) -> no_apply p
     | Path.Papply _ -> false
   in
   no_apply path && not (Env.is_functor_arg path env)

--- a/typing/mtype.ml
+++ b/typing/mtype.ml
@@ -411,12 +411,12 @@ let contains_type env mty =
 
 let rec get_prefixes = function
   | Pident _ -> Path.Set.empty
-  | Pdot (p, _)
-  | Papply (p, _) -> Path.Set.add p (get_prefixes p)
+  | Pdot (p, _) | Papply (p, _) -> Path.Set.add p (get_prefixes p)
+  | Pcstr_ty(p, _) | Pext_ty p -> get_prefixes p
 
 let rec get_arg_paths = function
   | Pident _ -> Path.Set.empty
-  | Pdot (p, _) -> get_arg_paths p
+  | Pdot (p, _) | Pcstr_ty(p, _) | Pext_ty p -> get_arg_paths p
   | Papply (p1, p2) ->
       Path.Set.add p2
         (Path.Set.union (get_prefixes p2)
@@ -426,7 +426,7 @@ let rec rollback_path subst p =
   try Pident (Path.Map.find p subst)
   with Not_found ->
     match p with
-      Pident _ | Papply _ -> p
+      Pident _ | Pcstr_ty _ | Pext_ty _ | Papply _ -> p
     | Pdot (p1, s) ->
         let p1' = rollback_path subst p1 in
         if Path.same p1 p1' then p else rollback_path subst (Pdot (p1', s))

--- a/typing/path.ml
+++ b/typing/path.ml
@@ -31,7 +31,11 @@ let rec same p1 p2 =
   | (Papply(fun1, arg1), Papply(fun2, arg2)) ->
       same fun1 fun2 && same arg1 arg2
   | (Pextra_ty (p1, t1), Pextra_ty (p2, t2)) ->
-      t1 = t2 && same p1 p2
+      let same_extra = match t1, t2 with
+        | (Pcstr_ty s1, Pcstr_ty s2) -> s1 = s2
+        | (Pext_ty, Pext_ty) -> true
+        | ((Pcstr_ty _ | Pext_ty), _) -> false
+      in same_extra && same p1 p2
   | (_, _) -> false
 
 let rec compare p1 p2 =

--- a/typing/path.ml
+++ b/typing/path.ml
@@ -16,6 +16,8 @@
 type t =
     Pident of Ident.t
   | Pdot of t * string
+  | Pcstr_ty of t * string
+  | Pext_ty of t
   | Papply of t * t
 
 let rec same p1 p2 =
@@ -23,6 +25,9 @@ let rec same p1 p2 =
   || match (p1, p2) with
     (Pident id1, Pident id2) -> Ident.same id1 id2
   | (Pdot(p1, s1), Pdot(p2, s2)) -> s1 = s2 && same p1 p2
+  | (Pcstr_ty(p1, s1), Pcstr_ty(p2, s2)) ->
+    s1 = s2 && same p1 p2
+  | (Pext_ty p1, Pext_ty p2) -> same p1 p2
   | (Papply(fun1, arg1), Papply(fun2, arg2)) ->
        same fun1 fun2 && same arg1 arg2
   | (_, _) -> false
@@ -34,19 +39,32 @@ let rec compare p1 p2 =
   | (Pdot(p1, s1), Pdot(p2, s2)) ->
       let h = compare p1 p2 in
       if h <> 0 then h else String.compare s1 s2
+  | (Pcstr_ty(p1, s1), Pcstr_ty(p2, s2)) ->
+      let h = compare p1 p2 in
+      if h <> 0 then h else String.compare s1 s2
+  | (Pext_ty p1, Pext_ty p2) -> compare p1 p2
   | (Papply(fun1, arg1), Papply(fun2, arg2)) ->
       let h = compare fun1 fun2 in
       if h <> 0 then h else compare arg1 arg2
-  | ((Pident _ | Pdot _), (Pdot _ | Papply _)) -> -1
-  | ((Pdot _ | Papply _), (Pident _ | Pdot _)) -> 1
+  | (Pident _, (Pdot _ | Pcstr_ty _ | Pext_ty _ | Papply _))
+  | (Pdot _, (Pcstr_ty _ | Pext_ty _ | Papply _ ))
+  | (Pcstr_ty _, (Pext_ty _ | Papply _))
+  | (Pext_ty _, Papply _)
+    -> -1
+  | ((Papply _ | Pext_ty _ | Pcstr_ty _ | Pdot _), Pident _)
+  | ((Papply _ | Pext_ty _ | Pcstr_ty _) , Pdot _)
+  | ((Papply _ | Pext_ty _), Pcstr_ty _)
+  | (Papply _, Pext_ty _)
+    -> 1
 
 let rec find_free_opt ids = function
     Pident id -> List.find_opt (Ident.same id) ids
-  | Pdot(p, _s) -> find_free_opt ids p
-  | Papply(p1, p2) ->
+  | Pdot(p, _) | Pcstr_ty(p, _) | Pext_ty p -> find_free_opt ids p
+  | Papply(p1, p2) -> begin
       match find_free_opt ids p1 with
       | None -> find_free_opt ids p2
       | Some _ as res -> res
+    end
 
 let exists_free ids p =
   match find_free_opt ids p with
@@ -55,31 +73,34 @@ let exists_free ids p =
 
 let rec scope = function
     Pident id -> Ident.scope id
-  | Pdot(p, _s) -> scope p
+  | Pdot(p, _) | Pcstr_ty(p, _) | Pext_ty p -> scope p
   | Papply(p1, p2) -> Int.max (scope p1) (scope p2)
 
 let kfalse _ = false
 
 let rec name ?(paren=kfalse) = function
     Pident id -> Ident.name id
-  | Pdot(p, s) ->
+  | Pdot(p, s) | Pcstr_ty(p, s) ->
       name ~paren p ^ if paren s then ".( " ^ s ^ " )" else "." ^ s
+  | Pext_ty p -> name ~paren p
   | Papply(p1, p2) -> name ~paren p1 ^ "(" ^ name ~paren p2 ^ ")"
 
 let rec print ppf = function
   | Pident id -> Ident.print_with_scope ppf id
-  | Pdot(p, s) -> Format.fprintf ppf "%a.%s" print p s
+  | Pdot(p, s) | Pcstr_ty(p, s) -> Format.fprintf ppf "%a.%s" print p s
+  | Pext_ty p -> print ppf p
   | Papply(p1, p2) -> Format.fprintf ppf "%a(%a)" print p1 print p2
 
 let rec head = function
     Pident id -> id
-  | Pdot(p, _s) -> head p
+  | Pdot(p, _) | Pcstr_ty(p, _) | Pext_ty p -> head p
   | Papply _ -> assert false
 
 let flatten =
   let rec flatten acc = function
     | Pident id -> `Ok (id, acc)
-    | Pdot (p, s) -> flatten (s :: acc) p
+    | Pdot (p, s) | Pcstr_ty(p, s) -> flatten (s :: acc) p
+    | Pext_ty p -> flatten acc p
     | Papply _ -> `Contains_apply
   in
   fun t -> flatten [] t
@@ -87,39 +108,20 @@ let flatten =
 let heads p =
   let rec heads p acc = match p with
     | Pident id -> id :: acc
-    | Pdot (p, _s) -> heads p acc
+    | Pdot (p, _) | Pcstr_ty(p, _) | Pext_ty p -> heads p acc
     | Papply(p1, p2) ->
         heads p1 (heads p2 acc)
   in heads p []
 
 let rec last = function
   | Pident id -> Ident.name id
-  | Pdot(_, s) -> s
-  | Papply(_, p) -> last p
-
-let is_uident s =
-  assert (s <> "");
-  match s.[0] with
-  | 'A'..'Z' -> true
-  | _ -> false
-
-type typath =
-  | Regular of t
-  | Ext of t * string
-  | LocalExt of Ident.t
-  | Cstr of t * string
-
-let constructor_typath = function
-  | Pident id when is_uident (Ident.name id) -> LocalExt id
-  | Pdot(ty_path, s) when is_uident s ->
-      if is_uident (last ty_path) then Ext (ty_path, s)
-      else Cstr (ty_path, s)
-  | p -> Regular p
+  | Pdot(_, s) | Pcstr_ty(_, s) -> s
+  | Papply(_, p) | Pext_ty p -> last p
 
 let is_constructor_typath p =
-  match constructor_typath p with
-  | Regular _ -> false
-  | _ -> true
+  match p with
+  | Pident _ | Pdot _ | Papply _ -> false
+  | Pcstr_ty _ | Pext_ty _ -> true
 
 module T = struct
   type nonrec t = t

--- a/typing/path.ml
+++ b/typing/path.ml
@@ -16,20 +16,22 @@
 type t =
     Pident of Ident.t
   | Pdot of t * string
-  | Pcstr_ty of t * string
-  | Pext_ty of t
   | Papply of t * t
+  | Pextra_ty of t * extra_ty
+and extra_ty =
+  | Pcstr_ty of string
+  | Pext_ty
 
 let rec same p1 p2 =
   p1 == p2
   || match (p1, p2) with
     (Pident id1, Pident id2) -> Ident.same id1 id2
-  | (Pdot(p1, s1), Pdot(p2, s2)) -> s1 = s2 && same p1 p2
-  | (Pcstr_ty(p1, s1), Pcstr_ty(p2, s2)) ->
-    s1 = s2 && same p1 p2
-  | (Pext_ty p1, Pext_ty p2) -> same p1 p2
+  | (Pdot(p1, s1), Pdot(p2, s2)) ->
+      s1 = s2 && same p1 p2
   | (Papply(fun1, arg1), Papply(fun2, arg2)) ->
-       same fun1 fun2 && same arg1 arg2
+      same fun1 fun2 && same arg1 arg2
+  | (Pextra_ty (p1, t1), Pextra_ty (p2, t2)) ->
+      t1 = t2 && same p1 p2
   | (_, _) -> false
 
 let rec compare p1 p2 =
@@ -39,27 +41,33 @@ let rec compare p1 p2 =
   | (Pdot(p1, s1), Pdot(p2, s2)) ->
       let h = compare p1 p2 in
       if h <> 0 then h else String.compare s1 s2
-  | (Pcstr_ty(p1, s1), Pcstr_ty(p2, s2)) ->
-      let h = compare p1 p2 in
-      if h <> 0 then h else String.compare s1 s2
-  | (Pext_ty p1, Pext_ty p2) -> compare p1 p2
   | (Papply(fun1, arg1), Papply(fun2, arg2)) ->
       let h = compare fun1 fun2 in
       if h <> 0 then h else compare arg1 arg2
-  | (Pident _, (Pdot _ | Pcstr_ty _ | Pext_ty _ | Papply _))
-  | (Pdot _, (Pcstr_ty _ | Pext_ty _ | Papply _ ))
-  | (Pcstr_ty _, (Pext_ty _ | Papply _))
-  | (Pext_ty _, Papply _)
+  | (Pextra_ty (p1, t1), Pextra_ty (p2, t2)) ->
+      let h = compare_extra t1 t2 in
+      if h <> 0 then h else compare p1 p2
+  | (Pident _, (Pdot _ | Papply _ | Pextra_ty _))
+  | (Pdot _, (Papply _ | Pextra_ty _))
+  | (Papply _, Pextra_ty _)
     -> -1
-  | ((Papply _ | Pext_ty _ | Pcstr_ty _ | Pdot _), Pident _)
-  | ((Papply _ | Pext_ty _ | Pcstr_ty _) , Pdot _)
-  | ((Papply _ | Pext_ty _), Pcstr_ty _)
-  | (Papply _, Pext_ty _)
+  | ((Pextra_ty _ | Papply _ | Pdot _), Pident _)
+  | ((Pextra_ty _ | Papply _) , Pdot _)
+  | (Pextra_ty _, Papply _)
+    -> 1
+and compare_extra t1 t2 =
+  match (t1, t2) with
+    Pcstr_ty s1, Pcstr_ty s2 -> String.compare s1 s2
+  | (Pext_ty, Pext_ty)
+    -> 0
+  | (Pcstr_ty _, Pext_ty)
+    -> -1
+  | (Pext_ty, Pcstr_ty _)
     -> 1
 
 let rec find_free_opt ids = function
     Pident id -> List.find_opt (Ident.same id) ids
-  | Pdot(p, _) | Pcstr_ty(p, _) | Pext_ty p -> find_free_opt ids p
+  | Pdot(p, _) | Pextra_ty (p, _) -> find_free_opt ids p
   | Papply(p1, p2) -> begin
       match find_free_opt ids p1 with
       | None -> find_free_opt ids p2
@@ -73,55 +81,56 @@ let exists_free ids p =
 
 let rec scope = function
     Pident id -> Ident.scope id
-  | Pdot(p, _) | Pcstr_ty(p, _) | Pext_ty p -> scope p
+  | Pdot(p, _) | Pextra_ty (p, _) -> scope p
   | Papply(p1, p2) -> Int.max (scope p1) (scope p2)
 
 let kfalse _ = false
 
 let rec name ?(paren=kfalse) = function
     Pident id -> Ident.name id
-  | Pdot(p, s) | Pcstr_ty(p, s) ->
+  | Pdot(p, s) | Pextra_ty (p, Pcstr_ty s) ->
       name ~paren p ^ if paren s then ".( " ^ s ^ " )" else "." ^ s
-  | Pext_ty p -> name ~paren p
   | Papply(p1, p2) -> name ~paren p1 ^ "(" ^ name ~paren p2 ^ ")"
+  | Pextra_ty (p, Pext_ty) -> name ~paren p
 
 let rec print ppf = function
   | Pident id -> Ident.print_with_scope ppf id
-  | Pdot(p, s) | Pcstr_ty(p, s) -> Format.fprintf ppf "%a.%s" print p s
-  | Pext_ty p -> print ppf p
+  | Pdot(p, s) | Pextra_ty (p, Pcstr_ty s) ->
+      Format.fprintf ppf "%a.%s" print p s
   | Papply(p1, p2) -> Format.fprintf ppf "%a(%a)" print p1 print p2
+  | Pextra_ty (p, Pext_ty) -> print ppf p
 
 let rec head = function
     Pident id -> id
-  | Pdot(p, _) | Pcstr_ty(p, _) | Pext_ty p -> head p
+  | Pdot(p, _) | Pextra_ty (p, _) -> head p
   | Papply _ -> assert false
 
 let flatten =
   let rec flatten acc = function
     | Pident id -> `Ok (id, acc)
-    | Pdot (p, s) | Pcstr_ty(p, s) -> flatten (s :: acc) p
-    | Pext_ty p -> flatten acc p
+    | Pdot (p, s) | Pextra_ty (p, Pcstr_ty s) -> flatten (s :: acc) p
     | Papply _ -> `Contains_apply
+    | Pextra_ty (p, Pext_ty) -> flatten acc p
   in
   fun t -> flatten [] t
 
 let heads p =
   let rec heads p acc = match p with
     | Pident id -> id :: acc
-    | Pdot (p, _) | Pcstr_ty(p, _) | Pext_ty p -> heads p acc
+    | Pdot (p, _) | Pextra_ty (p, _) -> heads p acc
     | Papply(p1, p2) ->
         heads p1 (heads p2 acc)
   in heads p []
 
 let rec last = function
   | Pident id -> Ident.name id
-  | Pdot(_, s) | Pcstr_ty(_, s) -> s
-  | Papply(_, p) | Pext_ty p -> last p
+  | Pdot(_, s) | Pextra_ty (_, Pcstr_ty s) -> s
+  | Papply(_, p) | Pextra_ty (p, Pext_ty) -> last p
 
 let is_constructor_typath p =
   match p with
   | Pident _ | Pdot _ | Papply _ -> false
-  | Pcstr_ty _ | Pext_ty _ -> true
+  | Pextra_ty _ -> true
 
 module T = struct
   type nonrec t = t

--- a/typing/path.mli
+++ b/typing/path.mli
@@ -16,14 +16,49 @@
 (* Access paths *)
 
 type t =
-    Pident of Ident.t
+  | Pident of Ident.t
+  (** Examples: x, List, int *)
   | Pdot of t * string
-  | Pcstr_ty of t * string
-  | Pext_ty of t
+  (** Examples: List.map, Float.Array *)
   | Papply of t * t
+  (** Examples: Set.Make(Int), Map.Make(Set.Make(Int)) *)
+  | Pextra_ty of t * extra_ty
+  (** [Pextra_ty (p, extra)] are additional paths of types
+      introduced by specific OCaml constructs. See below.
+  *)
+and extra_ty =
+  | Pcstr_ty of string
+  (** [Pextra_ty (p, Pcstr_ty c)] is the type of the inline record for
+      constructor [c] inside type [p].
+
+      For example, in
+      {[
+        type 'a t = Nil | Cons of {hd : 'a; tl : 'a t}
+      ]}
+
+      The inline record type [{hd : 'a; tl : 'a t}] cannot
+      be named by the user in the surface syntax, but internally
+      it has the path
+        [Pextra_ty (Pident `t`, Pcstr_ty "Cons")].
+  *)
+  | Pext_ty
+  (** [Pextra_ty (p, Pext_ty)] is the type of the inline record for
+      the extension constructor [p].
+
+      For example, in
+      {[
+        type exn += Error of {loc : loc; msg : string}
+      ]}
+
+      The inline record type [{loc : loc; msg : string}] cannot
+      be named by the user in the surface syntax, but internally
+      it has the path
+        [Pextra_ty (Pident `Error`, Pext_ty)].
+  *)
 
 val same: t -> t -> bool
 val compare: t -> t -> int
+val compare_extra: extra_ty -> extra_ty -> int
 val find_free_opt: Ident.t list -> t -> Ident.t option
 val exists_free: Ident.t list -> t -> bool
 val scope: t -> int

--- a/typing/path.mli
+++ b/typing/path.mli
@@ -18,6 +18,8 @@
 type t =
     Pident of Ident.t
   | Pdot of t * string
+  | Pcstr_ty of t * string
+  | Pext_ty of t
   | Papply of t * t
 
 val same: t -> t -> bool
@@ -37,15 +39,6 @@ val heads: t -> Ident.t list
 
 val last: t -> string
 
-val is_uident: string -> bool
-
-type typath =
-  | Regular of t
-  | Ext of t * string
-  | LocalExt of Ident.t
-  | Cstr of t * string
-
-val constructor_typath: t -> typath
 val is_constructor_typath: t -> bool
 
 module Map : Map.S with type key = t

--- a/typing/printtyped.ml
+++ b/typing/printtyped.ml
@@ -50,7 +50,8 @@ let fmt_modname f = function
 let rec fmt_path_aux f x =
   match x with
   | Path.Pident (s) -> fprintf f "%a" fmt_ident s
-  | Path.Pdot (y, s) -> fprintf f "%a.%s" fmt_path_aux y s
+  | Path.Pdot (y, s) | Path.Pcstr_ty (y, s) -> fprintf f "%a.%s" fmt_path_aux y s
+  | Path.Pext_ty y -> fmt_path_aux f y
   | Path.Papply (y, z) ->
       fprintf f "%a(%a)" fmt_path_aux y fmt_path_aux z
 

--- a/typing/printtyped.ml
+++ b/typing/printtyped.ml
@@ -50,10 +50,11 @@ let fmt_modname f = function
 let rec fmt_path_aux f x =
   match x with
   | Path.Pident (s) -> fprintf f "%a" fmt_ident s
-  | Path.Pdot (y, s) | Path.Pcstr_ty (y, s) -> fprintf f "%a.%s" fmt_path_aux y s
-  | Path.Pext_ty y -> fmt_path_aux f y
+  | Path.Pdot (y, s) | Path.(Pextra_ty (y, Pcstr_ty s)) ->
+      fprintf f "%a.%s" fmt_path_aux y s
   | Path.Papply (y, z) ->
       fprintf f "%a(%a)" fmt_path_aux y fmt_path_aux z
+  | Path.Pextra_ty (y, Pext_ty) -> fmt_path_aux f y
 
 let fmt_path f x = fprintf f "\"%a\"" fmt_path_aux x
 

--- a/typing/rec_check.ml
+++ b/typing/rec_check.ml
@@ -249,7 +249,7 @@ let classify_expression : Typedtree.expression -> sd =
             *)
             Dynamic
         end
-    | Path.Pdot _ | Path.Papply _ ->
+    | Path.Pdot _ | Path.Pcstr_ty _ | Path.Pext_ty _ | Path.Papply _ ->
         (* local modules could have such paths to local definitions;
             classify_expression could be extend to compute module
             shapes more precisely *)
@@ -909,6 +909,7 @@ and path : Path.t -> term_judg =
           path f << Dereference;
           path p << Dereference;
         ]
+    | Path.Pcstr_ty _ | Path.Pext_ty _ -> assert false
 
 (* G |- struct ... end : m *)
 and structure : Typedtree.structure -> term_judg =

--- a/typing/rec_check.ml
+++ b/typing/rec_check.ml
@@ -27,7 +27,7 @@ but some other are meaningless
 {[
   let rec x = x
   let rec x = x+1
-|}
+]}
 
 Intuitively, a recursive definition makes sense when the body of the
 definition can be evaluated without fully knowing what the recursive
@@ -249,7 +249,7 @@ let classify_expression : Typedtree.expression -> sd =
             *)
             Dynamic
         end
-    | Path.Pdot _ | Path.Pcstr_ty _ | Path.Pext_ty _ | Path.Papply _ ->
+    | Path.Pdot _ | Path.Papply _ | Path.Pextra_ty _ ->
         (* local modules could have such paths to local definitions;
             classify_expression could be extend to compute module
             shapes more precisely *)
@@ -909,7 +909,8 @@ and path : Path.t -> term_judg =
           path f << Dereference;
           path p << Dereference;
         ]
-    | Path.Pcstr_ty _ | Path.Pext_ty _ -> assert false
+    | Path.Pextra_ty (p, _extra) ->
+        path p
 
 (* G |- struct ... end : m *)
 and structure : Typedtree.structure -> term_judg =

--- a/typing/shape.ml
+++ b/typing/shape.ml
@@ -471,9 +471,12 @@ let of_path ~find_shape ~namespace =
   let rec aux : Sig_component_kind.t -> Path.t -> t = fun ns -> function
     | Pident id -> find_shape ns id
     | Pdot (path, name) -> proj (aux Module path) (name, ns)
-    | Pcstr_ty (path, _) -> aux Type path
-    | Pext_ty path -> aux Extension_constructor path
     | Papply (p1, p2) -> app (aux Module p1) ~arg:(aux Module p2)
+    | Pextra_ty (path, extra) -> begin
+        match extra with
+          Pcstr_ty _ -> aux Type path
+        | Pext_ty -> aux Extension_constructor path
+      end
   in
   aux namespace
 

--- a/typing/shape.ml
+++ b/typing/shape.ml
@@ -471,6 +471,8 @@ let of_path ~find_shape ~namespace =
   let rec aux : Sig_component_kind.t -> Path.t -> t = fun ns -> function
     | Pident id -> find_shape ns id
     | Pdot (path, name) -> proj (aux Module path) (name, ns)
+    | Pcstr_ty (path, _) -> aux Type path
+    | Pext_ty path -> aux Extension_constructor path
     | Papply (p1, p2) -> app (aux Module p1) ~arg:(aux Module p2)
   in
   aux namespace

--- a/typing/subst.ml
+++ b/typing/subst.ml
@@ -94,7 +94,7 @@ let rec module_path s path =
        Pdot(module_path s p, n)
     | Papply(p1, p2) ->
        Papply(module_path s p1, module_path s p2)
-    | Pcstr_ty _ | Pext_ty _ ->
+    | Pextra_ty _ ->
        fatal_error "Subst.module_path"
 
 let modtype_path s path =
@@ -106,15 +106,16 @@ let modtype_path s path =
          match path with
          | Pdot(p, n) ->
             Pdot(module_path s p, n)
-         | Papply _ | Pcstr_ty _ | Pext_ty _ ->
+         | Papply _ | Pextra_ty _ ->
             fatal_error "Subst.modtype_path"
          | Pident _ -> path
 
-let extension_path s path =
+(* For values, extension constructors, classes and class types *)
+let value_path s path =
   match path with
   | Pident _ -> path
   | Pdot(p, n) -> Pdot(module_path s p, n)
-  | Papply _ | Pcstr_ty _ | Pext_ty _ -> fatal_error "Subst.extension_path"
+  | Papply _ | Pextra_ty _ -> fatal_error "Subst.value_path"
 
 let rec type_path s path =
   match Path.Map.find path s.types with
@@ -125,10 +126,12 @@ let rec type_path s path =
      | Pident _ -> path
      | Pdot(p, n) ->
         Pdot(module_path s p, n)
-     | Pcstr_ty(p, n) -> Pcstr_ty(type_path s p, n)
-     | Pext_ty p -> Pext_ty (extension_path s p)
      | Papply _ ->
         fatal_error "Subst.type_path"
+     | Pextra_ty (p, extra) ->
+         match extra with
+         | Pcstr_ty _ -> Pextra_ty (type_path s p, extra)
+         | Pext_ty -> Pextra_ty (value_path s p, extra)
 
 let to_subst_by_type_function s p =
   match Path.Map.find p s.types with
@@ -585,7 +588,7 @@ and subst_lazy_modtype scoping s = function
           | Pident _ -> MtyL_ident p
           | Pdot(p, n) ->
              MtyL_ident(Pdot(module_path s p, n))
-          | Papply _ | Pcstr_ty _ | Pext_ty _ ->
+          | Papply _ | Pextra_ty _ ->
              fatal_error "Subst.modtype"
           end
       end

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -84,9 +84,8 @@ let rec path_concat head p =
   match p with
     Pident tail -> Pdot (Pident head, Ident.name tail)
   | Pdot (pre, s) -> Pdot (path_concat head pre, s)
-  | Pcstr_ty (pre, s) -> Pcstr_ty (path_concat head pre, s)
-  | Pext_ty p -> Pext_ty (path_concat head p)
   | Papply _ -> assert false
+  | Pextra_ty (p, extra) -> Pextra_ty (path_concat head p, extra)
 
 (* Extract a signature from a module type *)
 
@@ -238,11 +237,12 @@ let make_variance p n i =
 let rec iter_path_apply p ~f =
   match p with
   | Pident _ -> ()
-  | Pdot (p, _) | Pcstr_ty (p, _) | Pext_ty p -> iter_path_apply p ~f
+  | Pdot (p, _) -> iter_path_apply p ~f
   | Papply (p1, p2) ->
      iter_path_apply p1 ~f;
      iter_path_apply p2 ~f;
      f p1 p2 (* after recursing, so we know both paths are well typed *)
+  | Pextra_ty _ -> assert false
 
 let path_is_strict_prefix =
   let rec list_is_strict_prefix l ~prefix =

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -84,6 +84,8 @@ let rec path_concat head p =
   match p with
     Pident tail -> Pdot (Pident head, Ident.name tail)
   | Pdot (pre, s) -> Pdot (path_concat head pre, s)
+  | Pcstr_ty (pre, s) -> Pcstr_ty (path_concat head pre, s)
+  | Pext_ty p -> Pext_ty (path_concat head p)
   | Papply _ -> assert false
 
 (* Extract a signature from a module type *)
@@ -236,7 +238,7 @@ let make_variance p n i =
 let rec iter_path_apply p ~f =
   match p with
   | Pident _ -> ()
-  | Pdot (p, _) -> iter_path_apply p ~f
+  | Pdot (p, _) | Pcstr_ty (p, _) | Pext_ty p -> iter_path_apply p ~f
   | Papply (p1, p2) ->
      iter_path_apply p1 ~f;
      iter_path_apply p2 ~f;

--- a/typing/types.mli
+++ b/typing/types.mli
@@ -497,6 +497,7 @@ and record_representation =
   | Record_unboxed of bool    (* Unboxed single-field record, inlined or not *)
   | Record_inlined of int               (* Inlined record *)
   | Record_extension of Path.t          (* Inlined record under extension *)
+                             (* The argument is the path of the extension *)
 
 and variant_representation =
     Variant_regular          (* Constant or boxed constructors *)

--- a/typing/untypeast.ml
+++ b/typing/untypeast.ml
@@ -97,7 +97,8 @@ let string_is_prefix sub str =
 
 let rec lident_of_path = function
   | Path.Pident id -> Longident.Lident (Ident.name id)
-  | Path.Pdot (p, s) -> Longident.Ldot (lident_of_path p, s)
+  | Path.Pdot (p, s) | Path.Pcstr_ty (p, s) -> Longident.Ldot (lident_of_path p, s)
+  | Path.Pext_ty p -> lident_of_path p
   | Path.Papply (p1, p2) ->
       Longident.Lapply (lident_of_path p1, lident_of_path p2)
 

--- a/typing/untypeast.ml
+++ b/typing/untypeast.ml
@@ -97,10 +97,11 @@ let string_is_prefix sub str =
 
 let rec lident_of_path = function
   | Path.Pident id -> Longident.Lident (Ident.name id)
-  | Path.Pdot (p, s) | Path.Pcstr_ty (p, s) -> Longident.Ldot (lident_of_path p, s)
-  | Path.Pext_ty p -> lident_of_path p
   | Path.Papply (p1, p2) ->
       Longident.Lapply (lident_of_path p1, lident_of_path p2)
+  | Path.Pdot (p, s) | Path.Pextra_ty (p, Pcstr_ty s) ->
+      Longident.Ldot (lident_of_path p, s)
+  | Path.Pextra_ty (p, _) -> lident_of_path p
 
 let map_loc sub {loc; txt} = {loc = sub.location sub loc; txt}
 


### PR DESCRIPTION
This PR replaces #11315.
Encodes inline record types in Path.t
- adds Pextra_ty in Path.t
- Pext_ty is added by @lpw25 for inline records in variant constructors and extension constructors
  They replace the decoding through Path.typath used before

The goal of the changes is to remove encodings through names that were used before:
- inline records in variant constructors were represented by a path finished by a lower case name followed by an upper case name
- inline records in extension constructors were represented by a path finished by two upper case names

Hash types will be removed by a separate PR.

The only remaining such encoding is for abstract row types.

Written with @garrigue and @t6s 