### PR TITLE
Correct CAMLextern in headers

### DIFF
--- a/runtime/caml/backtrace_prim.h
+++ b/runtime/caml/backtrace_prim.h
@@ -81,7 +81,7 @@ void caml_debuginfo_location(debuginfo dbg, /*out*/ struct caml_loc_info * li);
 /* Allocate Caml_state->backtrace_buffer. Returns 0 on success, -1 otherwise */
 int caml_alloc_backtrace_buffer(void);
 
-void caml_free_backtrace_buffer(backtrace_slot *backtrace_buffer);
+CAMLextern void caml_free_backtrace_buffer(backtrace_slot *backtrace_buffer);
 
 #ifndef NATIVE_CODE
 /* These two functions are used by the bytecode runtime when loading

--- a/runtime/caml/fiber.h
+++ b/runtime/caml/fiber.h
@@ -248,7 +248,7 @@ void caml_maybe_expand_stack(void);
 CAMLextern void caml_free_stack(struct stack_info* stk);
 
 /* gc_regs_buckets is allocated on-demand by [maybe_expand_stack]. */
-void caml_free_gc_regs_buckets(value *gc_regs_buckets);
+CAMLextern void caml_free_gc_regs_buckets(value *gc_regs_buckets);
 
 #ifdef NATIVE_CODE
 void caml_get_stack_sp_pc (struct stack_info* stack,

--- a/runtime/caml/signals.h
+++ b/runtime/caml/signals.h
@@ -76,8 +76,8 @@ value caml_process_pending_actions_with_root_exn (value extra_root);
 void caml_init_signal_handling(void);
 void caml_init_signals();
 void caml_terminate_signals();
-void * caml_init_signal_stack(void);
-void caml_free_signal_stack(void *);
+CAMLextern void * caml_init_signal_stack(void);
+CAMLextern void caml_free_signal_stack(void *);
 
 /* These hooks are not modified after other threads are spawned. */
 CAMLextern void (*caml_enter_blocking_section_hook)(void);

--- a/testsuite/tests/lf_skiplist/stubs.c
+++ b/testsuite/tests/lf_skiplist/stubs.c
@@ -5,7 +5,7 @@
 #include <assert.h>
 #define FMT ARCH_INTNAT_PRINTF_FORMAT
 
-CAMLextern value test_skiplist_serial(value val) {
+CAMLprim value test_skiplist_serial(value val) {
   CAMLparam0();
 
   struct lf_skiplist list;
@@ -39,7 +39,7 @@ CAMLextern value test_skiplist_serial(value val) {
 
 static struct lf_skiplist the_list;
 
-CAMLextern value init_skiplist(value val) {
+CAMLprim value init_skiplist(value val) {
   CAMLparam0();
 
   caml_lf_skiplist_init(&the_list);
@@ -47,7 +47,7 @@ CAMLextern value init_skiplist(value val) {
   CAMLreturn(Val_unit);
 }
 
-CAMLextern value cardinal_skiplist(value val) {
+CAMLprim value cardinal_skiplist(value val) {
   CAMLparam0();
   uintnat r = 0;
   FOREACH_LF_SKIPLIST_ELEMENT(p,&the_list,r++);
@@ -77,7 +77,7 @@ static uintnat count_marks(struct lf_skiplist *sk) {
   return r;
 }
 
-CAMLextern value clean_skiplist(value val) {
+CAMLprim value clean_skiplist(value val) {
   CAMLparam1(val);
   intnat v = Long_val(val) ;
 
@@ -96,7 +96,7 @@ CAMLextern value clean_skiplist(value val) {
   CAMLreturn(Val_unit);
 }
 
-CAMLextern value hammer_skiplist(value domain_id_val) {
+CAMLprim value hammer_skiplist(value domain_id_val) {
   CAMLparam1(domain_id_val);
 
   uintnat domain_id = Long_val(domain_id_val);
@@ -132,7 +132,7 @@ inline static uintnat calc_value(uintnat id) { return id; }
 inline static uintnat calc_key(uintnat id,uintnat turn) { return 1024*id+turn+1; }
 inline static uintnat calc_right(uintnat id,uintnat turn,uintnat ndoms) { return (id+turn) % ndoms; }
 
-CAMLextern value insert_skiplist(value turn_val,value ndoms_val,value domain_id_val) {
+CAMLprim value insert_skiplist(value turn_val,value ndoms_val,value domain_id_val) {
   CAMLparam3(turn_val,ndoms_val,domain_id_val);
   uintnat domain_id = Long_val(domain_id_val);
   uintnat ndoms = Long_val(ndoms_val);
@@ -145,7 +145,7 @@ CAMLextern value insert_skiplist(value turn_val,value ndoms_val,value domain_id_
   CAMLreturn(Val_unit);
 }
 
-CAMLextern value find_skiplist(value turn_val,value ndoms_val,value domain_id_val) {
+CAMLprim value find_skiplist(value turn_val,value ndoms_val,value domain_id_val) {
   CAMLparam3(turn_val,ndoms_val,domain_id_val);
   uintnat domain_id = Long_val(domain_id_val);
   uintnat ndoms = Long_val(ndoms_val);


### PR DESCRIPTION
Two fixes:
- Several functions which aren't marked `CAMLextern` and which therefore can fail to be relocated by flexdll
- While checking that, I noticed that the lf_skiplist tests were using the wrong macro in the C sources

I've resurrected some of my previous work on fvisibility to test that these are the only functions remaining which need `CAMLextern` decorations. Fully resurrecting that is for another day, though...