### PR TITLE
Add equality witness type to the standard library

### DIFF
--- a/Changes
+++ b/Changes
@@ -122,7 +122,7 @@ Working version
 - #11581: Add type equality witness `type (_, _) eq = Equal: ('a, 'a) eq` in a
   new module Stdlib.Type.
   (Nicolás Ojeda Bär, review by Daniel Bünzli, Jacques Garrigue, Florian
-  Angeletti, Alain Frisch, Gabriel Scherer and Xavier Leroy)
+  Angeletti, Alain Frisch, Gabriel Scherer, Jeremy Yallop and Xavier Leroy)
 
 ### Other libraries:
 

--- a/Changes
+++ b/Changes
@@ -119,6 +119,11 @@ Working version
   (Simon Cruanes, review by Gabriel Scherer, Xavier Leroy,
    Guillaume Munch-Maccagnoni)
 
+- #11581: Add type equality witness `type (_, _) eq = Equal: ('a, 'a) eq` in a
+  new module Stdlib.Type.
+  (Nicolás Ojeda Bär, review by Daniel Bünzli, Jacques Garrigue, Florian
+  Angeletti, Alain Frisch, Gabriel Scherer and Xavier Leroy)
+
 ### Other libraries:
 
 - #11374: Remove pointer cast to a type with stricter alignment requirements

--- a/manual/src/library/stdlib-blurb.etex
+++ b/manual/src/library/stdlib-blurb.etex
@@ -178,7 +178,7 @@ be called from C \\
 \stddocitem{String}{string operations}
 \stddocitem{StringLabels}{string operations (with labels)}
 \stddocitem{Sys}{system interface}
-\stddocitem{Type}{type instrospection}
+\stddocitem{Type}{type introspection}
 \stddocitem{Uchar}{Unicode characters}
 \stddocitem{Unit}{unit values}
 \stddocitem{Weak}{arrays of weak pointers}

--- a/manual/src/library/stdlib-blurb.etex
+++ b/manual/src/library/stdlib-blurb.etex
@@ -117,6 +117,7 @@ be called from C \\
 \subsubsection*{sss:stdlib-misc}{Misc:}
 \begin{tabular}{lll}
 "Fun" & p.~\stdpageref{Fun} & function values \\
+"Type" & p.~\stdpageref{Type} & type introspection \\
 \end{tabular}
 \end{latexonly}
 
@@ -177,6 +178,7 @@ be called from C \\
 \stddocitem{String}{string operations}
 \stddocitem{StringLabels}{string operations (with labels)}
 \stddocitem{Sys}{system interface}
+\stddocitem{Type}{type instrospection}
 \stddocitem{Uchar}{Unicode characters}
 \stddocitem{Unit}{unit values}
 \stddocitem{Weak}{arrays of weak pointers}

--- a/stdlib/.depend
+++ b/stdlib/.depend
@@ -754,6 +754,11 @@ stdlib__Sys.cmo : sys.ml \
 stdlib__Sys.cmx : sys.ml \
     stdlib__Sys.cmi
 stdlib__Sys.cmi : sys.mli
+stdlib__Type.cmo : type.ml \
+    stdlib__Type.cmi
+stdlib__Type.cmx : type.ml \
+    stdlib__Type.cmi
+stdlib__Type.cmi : type.mli
 stdlib__Uchar.cmo : uchar.ml \
     stdlib.cmi \
     stdlib__Char.cmi \

--- a/stdlib/StdlibModules
+++ b/stdlib/StdlibModules
@@ -34,6 +34,7 @@
 # Basenames of the source files for the standard library (i.e. unprefixed and
 # with lowercase first letters). These must be listed in dependency order.
 STDLIB_MODULE_BASENAMES = \
+  type \
   camlinternalFormatBasics \
   stdlib \
   either \
@@ -97,8 +98,7 @@ STDLIB_MODULE_BASENAMES = \
   stdLabels \
   in_channel \
   out_channel \
-  effect \
-  type
+  effect
 
 STDLIB_PREFIXED_MODULES = \
   $(filter-out stdlib camlinternal%, $(STDLIB_MODULE_BASENAMES))

--- a/stdlib/StdlibModules
+++ b/stdlib/StdlibModules
@@ -34,9 +34,9 @@
 # Basenames of the source files for the standard library (i.e. unprefixed and
 # with lowercase first letters). These must be listed in dependency order.
 STDLIB_MODULE_BASENAMES = \
-  type \
   camlinternalFormatBasics \
   stdlib \
+  type \
   either \
   sys \
   obj \

--- a/stdlib/StdlibModules
+++ b/stdlib/StdlibModules
@@ -56,7 +56,8 @@ STDLIB_MODULE_BASENAMES = \
   unit \
   marshal \
   array \
-  float \ int32 \
+  float \
+  int32 \
   int64 \
   nativeint \
   lexing \

--- a/stdlib/StdlibModules
+++ b/stdlib/StdlibModules
@@ -34,17 +34,71 @@
 # Basenames of the source files for the standard library (i.e. unprefixed and
 # with lowercase first letters). These must be listed in dependency order.
 STDLIB_MODULE_BASENAMES = \
-  camlinternalFormatBasics stdlib either \
-  sys obj atomic camlinternalLazy lazy \
-  seq option result bool char uchar \
-  list int bytes string unit marshal array float int32 int64 nativeint \
-  lexing parsing set map stack queue buffer \
-  mutex condition semaphore domain \
-  camlinternalFormat printf arg printexc \
-  fun gc digest bigarray random hashtbl weak \
-  format scanf callback camlinternalOO oo camlinternalMod ephemeron \
-  filename complex arrayLabels listLabels bytesLabels stringLabels moreLabels \
-  stdLabels in_channel out_channel effect type
+  camlinternalFormatBasics \
+  stdlib \
+  either \
+  sys \
+  obj \
+  atomic \
+  camlinternalLazy \
+  lazy \
+  seq \
+  option \
+  result \
+  bool \
+  char \
+  uchar \
+  list \
+  int \
+  bytes \
+  string \
+  unit \
+  marshal \
+  array \
+  float \ int32 \
+  int64 \
+  nativeint \
+  lexing \
+  parsing \
+  set \
+  map \
+  stack \
+  queue \
+  buffer \
+  mutex \
+  condition \
+  semaphore \
+  domain \
+  camlinternalFormat \
+  printf \
+  arg \
+  printexc \
+  fun \
+  gc \
+  digest \
+  bigarray \
+  random \
+  hashtbl \
+  weak \
+  format \
+  scanf \
+  callback \
+  camlinternalOO \
+  oo \
+  camlinternalMod \
+  ephemeron \
+  filename \
+  complex \
+  arrayLabels \
+  listLabels \
+  bytesLabels \
+  stringLabels \
+  moreLabels \
+  stdLabels \
+  in_channel \
+  out_channel \
+  effect \
+  type
 
 STDLIB_PREFIXED_MODULES = \
   $(filter-out stdlib camlinternal%, $(STDLIB_MODULE_BASENAMES))

--- a/stdlib/StdlibModules
+++ b/stdlib/StdlibModules
@@ -44,7 +44,7 @@ STDLIB_MODULE_BASENAMES = \
   fun gc digest bigarray random hashtbl weak \
   format scanf callback camlinternalOO oo camlinternalMod ephemeron \
   filename complex arrayLabels listLabels bytesLabels stringLabels moreLabels \
-  stdLabels in_channel out_channel effect
+  stdLabels in_channel out_channel effect type
 
 STDLIB_PREFIXED_MODULES = \
   $(filter-out stdlib camlinternal%, $(STDLIB_MODULE_BASENAMES))

--- a/stdlib/stdlib.ml
+++ b/stdlib/stdlib.ml
@@ -636,6 +636,7 @@ module StdLabels      = StdLabels
 module String         = String
 module StringLabels   = StringLabels
 module Sys            = Sys
+module Type           = Type
 module Uchar          = Uchar
 module Unit           = Unit
 module Weak           = Weak

--- a/stdlib/stdlib.mli
+++ b/stdlib/stdlib.mli
@@ -1450,6 +1450,7 @@ module StdLabels      = StdLabels
 module String         = String
 module StringLabels   = StringLabels
 module Sys            = Sys
+module Type           = Type
 module Uchar          = Uchar
 module Unit           = Unit
 module Weak           = Weak

--- a/stdlib/type.ml
+++ b/stdlib/type.ml
@@ -1,0 +1,16 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                         The OCaml programmers                          *)
+(*                                                                        *)
+(*   Copyright 2022 Institut National de Recherche en Informatique et     *)
+(*     en Automatique.                                                    *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+type (_, _) eq = Equal: ('a, 'a) eq

--- a/stdlib/type.mli
+++ b/stdlib/type.mli
@@ -33,5 +33,5 @@ type (_, _) eq = Equal: ('a, 'a) eq
       let cast (type a) (type b) (Equal : (a, b) Type.eq) (a : a) : b = a
     ]}
 
-    At runtime, this function is just the identity.
+    At runtime, this function acts as the identity on [a].
 *)

--- a/stdlib/type.mli
+++ b/stdlib/type.mli
@@ -33,5 +33,5 @@ type (_, _) eq = Equal: ('a, 'a) eq
       let cast (type a) (type b) (Equal : (a, b) Type.eq) (a : a) : b = a
     ]}
 
-    At runtime, this function acts as the identity on [a].
+    At runtime, this function simply returns its second argument unchanged.
 *)

--- a/stdlib/type.mli
+++ b/stdlib/type.mli
@@ -20,5 +20,18 @@
 (** {1:witness Type equality witness} *)
 
 type (_, _) eq = Equal: ('a, 'a) eq
-(** A value of type [(a, b) eq] exists whenever [a] and [b] are the same
-    type. *)
+(** The purpose of [eq] is to represent type equalities that may not otherwise
+    be known by the type checker (eg because they may depend on dynamic data).
+
+    A value of type [(a, b) eq] represents the fact that types [a] and [b] are
+    equal.
+
+    If one has a value [eq : (a, b) eq] that proves types [a] and [b] are equal,
+    one can use it to convert a value of type [a] to a value of type [b] by
+    pattern matching on [Equal]:
+    {[
+      let cast (type a) (type b) (Equal : (a, b) Type.eq) (a : a) : b = a
+    ]}
+
+    At runtime, this function is just the identity.
+*)

--- a/stdlib/type.mli
+++ b/stdlib/type.mli
@@ -21,7 +21,7 @@
 
 type (_, _) eq = Equal: ('a, 'a) eq
 (** The purpose of [eq] is to represent type equalities that may not otherwise
-    be known by the type checker (eg because they may depend on dynamic data).
+    be known by the type checker (e.g. because they may depend on dynamic data).
 
     A value of type [(a, b) eq] represents the fact that types [a] and [b] are
     equal.

--- a/stdlib/type.mli
+++ b/stdlib/type.mli
@@ -17,7 +17,7 @@
 
     @since 5.1 *)
 
-(** {1 Type equality witness} *)
+(** {1:witness Type equality witness} *)
 
 type (_, _) eq = Equal: ('a, 'a) eq
 (** A value of type [(a, b) eq] exists whenever [a] and [b] are the same

--- a/stdlib/type.mli
+++ b/stdlib/type.mli
@@ -1,0 +1,24 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                         The OCaml programmers                          *)
+(*                                                                        *)
+(*   Copyright 2022 Institut National de Recherche en Informatique et     *)
+(*     en Automatique.                                                    *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+(** Type introspection.
+
+    @since 5.1 *)
+
+(** {1 Type equality witness} *)
+
+type (_, _) eq = Equal: ('a, 'a) eq
+(** A value of type [(a, b) eq] exists whenever [a] and [b] are the same
+    type. *)

--- a/testsuite/tests/basic/patmatch_for_multiple.ml
+++ b/testsuite/tests/basic/patmatch_for_multiple.ml
@@ -26,15 +26,15 @@ match (3, 2, 1) with
 | _ -> false
 ;;
 [%%expect{|
-(let (*match*/275 = 3 *match*/276 = 2 *match*/277 = 1)
+(let (*match*/276 = 3 *match*/277 = 2 *match*/278 = 1)
   (catch
     (catch
-      (catch (if (!= *match*/276 3) (exit 3) (exit 1)) with (3)
-        (if (!= *match*/275 1) (exit 2) (exit 1)))
+      (catch (if (!= *match*/277 3) (exit 3) (exit 1)) with (3)
+        (if (!= *match*/276 1) (exit 2) (exit 1)))
      with (2) 0)
    with (1) 1))
-(let (*match*/275 = 3 *match*/276 = 2 *match*/277 = 1)
-  (catch (if (!= *match*/276 3) (if (!= *match*/275 1) 0 (exit 1)) (exit 1))
+(let (*match*/276 = 3 *match*/277 = 2 *match*/278 = 1)
+  (catch (if (!= *match*/277 3) (if (!= *match*/276 1) 0 (exit 1)) (exit 1))
    with (1) 1))
 - : bool = false
 |}];;
@@ -47,26 +47,26 @@ match (3, 2, 1) with
 | _ -> false
 ;;
 [%%expect{|
-(let (*match*/280 = 3 *match*/281 = 2 *match*/282 = 1)
+(let (*match*/281 = 3 *match*/282 = 2 *match*/283 = 1)
   (catch
     (catch
       (catch
-        (if (!= *match*/281 3) (exit 6)
-          (let (x/284 =a (makeblock 0 *match*/280 *match*/281 *match*/282))
-            (exit 4 x/284)))
+        (if (!= *match*/282 3) (exit 6)
+          (let (x/285 =a (makeblock 0 *match*/281 *match*/282 *match*/283))
+            (exit 4 x/285)))
        with (6)
-        (if (!= *match*/280 1) (exit 5)
-          (let (x/283 =a (makeblock 0 *match*/280 *match*/281 *match*/282))
-            (exit 4 x/283))))
+        (if (!= *match*/281 1) (exit 5)
+          (let (x/284 =a (makeblock 0 *match*/281 *match*/282 *match*/283))
+            (exit 4 x/284))))
      with (5) 0)
-   with (4 x/278) (seq (ignore x/278) 1)))
-(let (*match*/280 = 3 *match*/281 = 2 *match*/282 = 1)
+   with (4 x/279) (seq (ignore x/279) 1)))
+(let (*match*/281 = 3 *match*/282 = 2 *match*/283 = 1)
   (catch
-    (if (!= *match*/281 3)
-      (if (!= *match*/280 1) 0
-        (exit 4 (makeblock 0 *match*/280 *match*/281 *match*/282)))
-      (exit 4 (makeblock 0 *match*/280 *match*/281 *match*/282)))
-   with (4 x/278) (seq (ignore x/278) 1)))
+    (if (!= *match*/282 3)
+      (if (!= *match*/281 1) 0
+        (exit 4 (makeblock 0 *match*/281 *match*/282 *match*/283)))
+      (exit 4 (makeblock 0 *match*/281 *match*/282 *match*/283)))
+   with (4 x/279) (seq (ignore x/279) 1)))
 - : bool = false
 |}];;
 
@@ -76,8 +76,8 @@ let _ = fun a b ->
   | ((true, _) as _g)
   | ((false, _) as _g) -> ()
 [%%expect{|
-(function a/285[int] b/286 : int 0)
-(function a/285[int] b/286 : int 0)
+(function a/286[int] b/287 : int 0)
+(function a/286[int] b/287 : int 0)
 - : bool -> 'a -> unit = <fun>
 |}];;
 
@@ -96,8 +96,8 @@ let _ = fun a b -> match a, b with
 | (false, _) as p -> p
 (* outside, trivial *)
 [%%expect {|
-(function a/289[int] b/290 (let (p/291 =a (makeblock 0 a/289 b/290)) p/291))
-(function a/289[int] b/290 (makeblock 0 a/289 b/290))
+(function a/290[int] b/291 (let (p/292 =a (makeblock 0 a/290 b/291)) p/292))
+(function a/290[int] b/291 (makeblock 0 a/290 b/291))
 - : bool -> 'a -> bool * 'a = <fun>
 |}]
 
@@ -106,8 +106,8 @@ let _ = fun a b -> match a, b with
 | ((false, _) as p) -> p
 (* inside, trivial *)
 [%%expect{|
-(function a/293[int] b/294 (let (p/295 =a (makeblock 0 a/293 b/294)) p/295))
-(function a/293[int] b/294 (makeblock 0 a/293 b/294))
+(function a/294[int] b/295 (let (p/296 =a (makeblock 0 a/294 b/295)) p/296))
+(function a/294[int] b/295 (makeblock 0 a/294 b/295))
 - : bool -> 'a -> bool * 'a = <fun>
 |}];;
 
@@ -116,11 +116,11 @@ let _ = fun a b -> match a, b with
 | (false as x, _) as p -> x, p
 (* outside, simple *)
 [%%expect {|
-(function a/299[int] b/300
-  (let (x/301 =a[int] a/299 p/302 =a (makeblock 0 a/299 b/300))
-    (makeblock 0 (int,*) x/301 p/302)))
-(function a/299[int] b/300
-  (makeblock 0 (int,*) a/299 (makeblock 0 a/299 b/300)))
+(function a/300[int] b/301
+  (let (x/302 =a[int] a/300 p/303 =a (makeblock 0 a/300 b/301))
+    (makeblock 0 (int,*) x/302 p/303)))
+(function a/300[int] b/301
+  (makeblock 0 (int,*) a/300 (makeblock 0 a/300 b/301)))
 - : bool -> 'a -> bool * (bool * 'a) = <fun>
 |}]
 
@@ -129,11 +129,11 @@ let _ = fun a b -> match a, b with
 | ((false as x, _) as p) -> x, p
 (* inside, simple *)
 [%%expect {|
-(function a/305[int] b/306
-  (let (x/307 =a[int] a/305 p/308 =a (makeblock 0 a/305 b/306))
-    (makeblock 0 (int,*) x/307 p/308)))
-(function a/305[int] b/306
-  (makeblock 0 (int,*) a/305 (makeblock 0 a/305 b/306)))
+(function a/306[int] b/307
+  (let (x/308 =a[int] a/306 p/309 =a (makeblock 0 a/306 b/307))
+    (makeblock 0 (int,*) x/308 p/309)))
+(function a/306[int] b/307
+  (makeblock 0 (int,*) a/306 (makeblock 0 a/306 b/307)))
 - : bool -> 'a -> bool * (bool * 'a) = <fun>
 |}]
 
@@ -142,15 +142,15 @@ let _ = fun a b -> match a, b with
 | (false, x) as p -> x, p
 (* outside, complex *)
 [%%expect{|
-(function a/315[int] b/316[int]
-  (if a/315
-    (let (x/317 =a[int] a/315 p/318 =a (makeblock 0 a/315 b/316))
-      (makeblock 0 (int,*) x/317 p/318))
-    (let (x/319 =a b/316 p/320 =a (makeblock 0 a/315 b/316))
-      (makeblock 0 (int,*) x/319 p/320))))
-(function a/315[int] b/316[int]
-  (if a/315 (makeblock 0 (int,*) a/315 (makeblock 0 a/315 b/316))
-    (makeblock 0 (int,*) b/316 (makeblock 0 a/315 b/316))))
+(function a/316[int] b/317[int]
+  (if a/316
+    (let (x/318 =a[int] a/316 p/319 =a (makeblock 0 a/316 b/317))
+      (makeblock 0 (int,*) x/318 p/319))
+    (let (x/320 =a b/317 p/321 =a (makeblock 0 a/316 b/317))
+      (makeblock 0 (int,*) x/320 p/321))))
+(function a/316[int] b/317[int]
+  (if a/316 (makeblock 0 (int,*) a/316 (makeblock 0 a/316 b/317))
+    (makeblock 0 (int,*) b/317 (makeblock 0 a/316 b/317))))
 - : bool -> bool -> bool * (bool * bool) = <fun>
 |}]
 
@@ -160,19 +160,19 @@ let _ = fun a b -> match a, b with
   -> x, p
 (* inside, complex *)
 [%%expect{|
-(function a/321[int] b/322[int]
+(function a/322[int] b/323[int]
   (catch
-    (if a/321
-      (let (x/329 =a[int] a/321 p/330 =a (makeblock 0 a/321 b/322))
-        (exit 10 x/329 p/330))
-      (let (x/327 =a b/322 p/328 =a (makeblock 0 a/321 b/322))
-        (exit 10 x/327 p/328)))
-   with (10 x/323[int] p/324) (makeblock 0 (int,*) x/323 p/324)))
-(function a/321[int] b/322[int]
+    (if a/322
+      (let (x/330 =a[int] a/322 p/331 =a (makeblock 0 a/322 b/323))
+        (exit 10 x/330 p/331))
+      (let (x/328 =a b/323 p/329 =a (makeblock 0 a/322 b/323))
+        (exit 10 x/328 p/329)))
+   with (10 x/324[int] p/325) (makeblock 0 (int,*) x/324 p/325)))
+(function a/322[int] b/323[int]
   (catch
-    (if a/321 (exit 10 a/321 (makeblock 0 a/321 b/322))
-      (exit 10 b/322 (makeblock 0 a/321 b/322)))
-   with (10 x/323[int] p/324) (makeblock 0 (int,*) x/323 p/324)))
+    (if a/322 (exit 10 a/322 (makeblock 0 a/322 b/323))
+      (exit 10 b/323 (makeblock 0 a/322 b/323)))
+   with (10 x/324[int] p/325) (makeblock 0 (int,*) x/324 p/325)))
 - : bool -> bool -> bool * (bool * bool) = <fun>
 |}]
 
@@ -185,15 +185,15 @@ let _ = fun a b -> match a, b with
 | (false as x, _) as p -> x, p
 (* outside, onecase *)
 [%%expect {|
-(function a/331[int] b/332[int]
-  (if a/331
-    (let (x/333 =a[int] a/331 _p/334 =a (makeblock 0 a/331 b/332))
-      (makeblock 0 (int,*) x/333 [0: 1 1]))
-    (let (x/335 =a[int] a/331 p/336 =a (makeblock 0 a/331 b/332))
-      (makeblock 0 (int,*) x/335 p/336))))
-(function a/331[int] b/332[int]
-  (if a/331 (makeblock 0 (int,*) a/331 [0: 1 1])
-    (makeblock 0 (int,*) a/331 (makeblock 0 a/331 b/332))))
+(function a/332[int] b/333[int]
+  (if a/332
+    (let (x/334 =a[int] a/332 _p/335 =a (makeblock 0 a/332 b/333))
+      (makeblock 0 (int,*) x/334 [0: 1 1]))
+    (let (x/336 =a[int] a/332 p/337 =a (makeblock 0 a/332 b/333))
+      (makeblock 0 (int,*) x/336 p/337))))
+(function a/332[int] b/333[int]
+  (if a/332 (makeblock 0 (int,*) a/332 [0: 1 1])
+    (makeblock 0 (int,*) a/332 (makeblock 0 a/332 b/333))))
 - : bool -> bool -> bool * (bool * bool) = <fun>
 |}]
 
@@ -202,11 +202,11 @@ let _ = fun a b -> match a, b with
 | ((false as x, _) as p) -> x, p
 (* inside, onecase *)
 [%%expect{|
-(function a/337[int] b/338
-  (let (x/339 =a[int] a/337 p/340 =a (makeblock 0 a/337 b/338))
-    (makeblock 0 (int,*) x/339 p/340)))
-(function a/337[int] b/338
-  (makeblock 0 (int,*) a/337 (makeblock 0 a/337 b/338)))
+(function a/338[int] b/339
+  (let (x/340 =a[int] a/338 p/341 =a (makeblock 0 a/338 b/339))
+    (makeblock 0 (int,*) x/340 p/341)))
+(function a/338[int] b/339
+  (makeblock 0 (int,*) a/338 (makeblock 0 a/338 b/339)))
 - : bool -> 'a -> bool * (bool * 'a) = <fun>
 |}]
 
@@ -223,14 +223,14 @@ let _ =fun a b -> match a, b with
 | (_, _) as p -> p
 (* outside, tuplist *)
 [%%expect {|
-(function a/350[int] b/351
+(function a/351[int] b/352
   (catch
-    (if a/350 (if b/351 (let (p/352 =a (field_imm 0 b/351)) p/352) (exit 12))
+    (if a/351 (if b/352 (let (p/353 =a (field_imm 0 b/352)) p/353) (exit 12))
       (exit 12))
-   with (12) (let (p/353 =a (makeblock 0 a/350 b/351)) p/353)))
-(function a/350[int] b/351
-  (catch (if a/350 (if b/351 (field_imm 0 b/351) (exit 12)) (exit 12))
-   with (12) (makeblock 0 a/350 b/351)))
+   with (12) (let (p/354 =a (makeblock 0 a/351 b/352)) p/354)))
+(function a/351[int] b/352
+  (catch (if a/351 (if b/352 (field_imm 0 b/352) (exit 12)) (exit 12))
+   with (12) (makeblock 0 a/351 b/352)))
 - : bool -> bool tuplist -> bool * bool tuplist = <fun>
 |}]
 
@@ -239,20 +239,20 @@ let _ = fun a b -> match a, b with
 | ((_, _) as p) -> p
 (* inside, tuplist *)
 [%%expect{|
-(function a/354[int] b/355
+(function a/355[int] b/356
   (catch
     (catch
-      (if a/354
-        (if b/355 (let (p/359 =a (field_imm 0 b/355)) (exit 13 p/359))
+      (if a/355
+        (if b/356 (let (p/360 =a (field_imm 0 b/356)) (exit 13 p/360))
           (exit 14))
         (exit 14))
-     with (14) (let (p/358 =a (makeblock 0 a/354 b/355)) (exit 13 p/358)))
-   with (13 p/356) p/356))
-(function a/354[int] b/355
+     with (14) (let (p/359 =a (makeblock 0 a/355 b/356)) (exit 13 p/359)))
+   with (13 p/357) p/357))
+(function a/355[int] b/356
   (catch
     (catch
-      (if a/354 (if b/355 (exit 13 (field_imm 0 b/355)) (exit 14)) (exit 14))
-     with (14) (exit 13 (makeblock 0 a/354 b/355)))
-   with (13 p/356) p/356))
+      (if a/355 (if b/356 (exit 13 (field_imm 0 b/356)) (exit 14)) (exit 14))
+     with (14) (exit 13 (makeblock 0 a/355 b/356)))
+   with (13 p/357) p/357))
 - : bool -> bool tuplist -> bool * bool tuplist = <fun>
 |}]

--- a/testsuite/tests/generalized-open/gpr1506.ml
+++ b/testsuite/tests/generalized-open/gpr1506.ml
@@ -103,9 +103,9 @@ include struct open struct type t = T end let x = T end
 Line 1, characters 15-41:
 1 | include struct open struct type t = T end let x = T end
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The type t/338 introduced by this open appears in the signature
+Error: The type t/339 introduced by this open appears in the signature
        Line 1, characters 46-47:
-         The value x has no valid type if t/338 is hidden
+         The value x has no valid type if t/339 is hidden
 |}];;
 
 module A = struct
@@ -123,9 +123,9 @@ Lines 3-6, characters 4-7:
 4 |       type t = T
 5 |       let x = T
 6 |     end
-Error: The type t/343 introduced by this open appears in the signature
+Error: The type t/344 introduced by this open appears in the signature
        Line 7, characters 8-9:
-         The value y has no valid type if t/343 is hidden
+         The value y has no valid type if t/344 is hidden
 |}];;
 
 module A = struct
@@ -142,9 +142,9 @@ Lines 3-5, characters 4-7:
 3 | ....open struct
 4 |       type t = T
 5 |     end
-Error: The type t/348 introduced by this open appears in the signature
+Error: The type t/349 introduced by this open appears in the signature
        Line 6, characters 8-9:
-         The value y has no valid type if t/348 is hidden
+         The value y has no valid type if t/349 is hidden
 |}]
 
 (* It was decided to not allow this anymore. *)

--- a/testsuite/tests/shapes/comp_units.ml
+++ b/testsuite/tests/shapes/comp_units.ml
@@ -25,7 +25,7 @@ module Mproj = Unit
 module F (X : sig type t end) = X
 [%%expect{|
 {
- "F"[module] -> Abs<.4>(X/278, X/278<.3>);
+ "F"[module] -> Abs<.4>(X/279, X/279<.3>);
  }
 module F : functor (X : sig type t end) -> sig type t = X.t end
 |}]

--- a/testsuite/tests/shapes/functors.ml
+++ b/testsuite/tests/shapes/functors.ml
@@ -17,7 +17,7 @@ module type S = sig type t val x : t end
 module Falias (X : S) = X
 [%%expect{|
 {
- "Falias"[module] -> Abs<.4>(X/280, X/280<.3>);
+ "Falias"[module] -> Abs<.4>(X/281, X/281<.3>);
  }
 module Falias : functor (X : S) -> sig type t = X.t val x : t end
 |}]
@@ -29,10 +29,10 @@ end
 {
  "Finclude"[module] ->
    Abs<.6>
-      (X/284,
+      (X/285,
        {
-        "t"[type] -> X/284<.5> . "t"[type];
-        "x"[value] -> X/284<.5> . "x"[value];
+        "t"[type] -> X/285<.5> . "t"[type];
+        "x"[value] -> X/285<.5> . "x"[value];
         });
  }
 module Finclude : functor (X : S) -> sig type t = X.t val x : t end
@@ -45,7 +45,7 @@ end
 [%%expect{|
 {
  "Fredef"[module] ->
-   Abs<.10>(X/291, {
+   Abs<.10>(X/292, {
                     "t"[type] -> <.8>;
                     "x"[value] -> <.9>;
                     });
@@ -223,8 +223,8 @@ module Big_to_small1 : B2S = functor (X : Big) -> X
 [%%expect{|
 {
  "Big_to_small1"[module] ->
-   Abs<.40>(X/386, {<.39>
-                    "t"[type] -> X/386<.39> . "t"[type];
+   Abs<.40>(X/387, {<.39>
+                    "t"[type] -> X/387<.39> . "t"[type];
                     });
  }
 module Big_to_small1 : B2S
@@ -234,8 +234,8 @@ module Big_to_small2 : B2S = functor (X : Big) -> struct include X end
 [%%expect{|
 {
  "Big_to_small2"[module] ->
-   Abs<.42>(X/389, {
-                    "t"[type] -> X/389<.41> . "t"[type];
+   Abs<.42>(X/390, {
+                    "t"[type] -> X/390<.41> . "t"[type];
                     });
  }
 module Big_to_small2 : B2S

--- a/testsuite/tests/shapes/open_arg.ml
+++ b/testsuite/tests/shapes/open_arg.ml
@@ -22,7 +22,7 @@ end = struct end
 
 [%%expect{|
 {
- "Make"[module] -> Abs<.3>(I/280, {
+ "Make"[module] -> Abs<.3>(I/281, {
                                    });
  }
 module Make : functor (I : sig end) -> sig end

--- a/testsuite/tests/shapes/recmodules.ml
+++ b/testsuite/tests/shapes/recmodules.ml
@@ -43,8 +43,8 @@ and B : sig
 end = B
 [%%expect{|
 {
- "A"[module] -> A/303<.11>;
- "B"[module] -> B/304<.12>;
+ "A"[module] -> A/304<.11>;
+ "B"[module] -> B/305<.12>;
  }
 module rec A : sig type t = Leaf of B.t end
 and B : sig type t = int end
@@ -82,12 +82,12 @@ end = Set.Make(A)
  "ASet"[module] ->
    {
     "compare"[value] ->
-      CU Stdlib . "Set"[module] . "Make"[module](A/325<.19>) .
+      CU Stdlib . "Set"[module] . "Make"[module](A/326<.19>) .
       "compare"[value];
     "elt"[type] ->
-      CU Stdlib . "Set"[module] . "Make"[module](A/325<.19>) . "elt"[type];
+      CU Stdlib . "Set"[module] . "Make"[module](A/326<.19>) . "elt"[type];
     "t"[type] ->
-      CU Stdlib . "Set"[module] . "Make"[module](A/325<.19>) . "t"[type];
+      CU Stdlib . "Set"[module] . "Make"[module](A/326<.19>) . "t"[type];
     };
  }
 module rec A :

--- a/testsuite/tests/shapes/rotor_example.ml
+++ b/testsuite/tests/shapes/rotor_example.ml
@@ -25,7 +25,7 @@ end
 [%%expect{|
 {
  "Pair"[module] ->
-   Abs<.9>(X/280, Y/281, {
+   Abs<.9>(X/281, Y/282, {
                           "t"[type] -> <.5>;
                           "to_string"[value] -> <.6>;
                           });

--- a/testsuite/tests/typing-sigsubst/sigsubst.ml
+++ b/testsuite/tests/typing-sigsubst/sigsubst.ml
@@ -24,11 +24,11 @@ end
 Line 3, characters 2-36:
 3 |   include Comparable with type t = t
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: Illegal shadowing of included type t/285 by t/290
+Error: Illegal shadowing of included type t/286 by t/291
        Line 2, characters 2-19:
-         Type t/285 came from this include
+         Type t/286 came from this include
        Line 3, characters 2-23:
-         The value print has no valid type if t/285 is shadowed
+         The value print has no valid type if t/286 is shadowed
 |}]
 
 module type Sunderscore = sig


### PR DESCRIPTION
See discussion in #11564. It is argued there that this type is fundamental enough to go in `Stdlib`. Further constructions based on this type would go into their own module (but this can be done in a separate PR).

cc @garrigue @yallop 