### PR TITLE
Remove dependency on libwinpthread-1.dll and GCC runtime library for mingw-w64 ports

### DIFF
--- a/Makefile.config.in
+++ b/Makefile.config.in
@@ -172,12 +172,6 @@ INSTALL_BYTECODE_PROGRAMS=@install_bytecode_programs@
 #       systhreads        Same as threads, requires POSIX threads
 OTHERLIBRARIES=@otherlibraries@
 
-### Link-time options to ocamlc or ocamlopt for linking with POSIX threads
-# Needed for the "systhreads" package
-PTHREAD_LIBS=@PTHREAD_LIBS@
-PTHREAD_CAML_LIBS=$(addprefix -cclib ,$(PTHREAD_LIBS))
-PTHREAD_CFLAGS=@PTHREAD_CFLAGS@
-
 UNIX_OR_WIN32=@unix_or_win32@
 INSTALL_SOURCE_ARTIFACTS=@install_source_artifacts@
 
@@ -262,13 +256,3 @@ UNIXLIB=unix
 ## Variables renamed in OCaml 4.13
 
 RUNTIMEI=$(INSTRUMENTED_RUNTIME)
-
-### pthread-related variables
-
-PTHREAD_LINK=$(PTHREAD_LIBS)
-PTHREAD_CAML_LINK=$(PTHREAD_CAML_LIBS)
-
-### It is expected that the value of PTHREAD_LINK changes between OCaml
-### 4.12 and 4.13. Indeed, for OCaml 4.12 most of the time the variable
-### contained -lpthread. From 4.13 onward it will most of the time be
-### empty since we have -pthread in CFLAGS which implies -lpthread.

--- a/configure
+++ b/configure
@@ -17985,7 +17985,7 @@ esac
 
 case $host in #(
   *-*-mingw32|*-pc-windows) :
-    PTHREAD_LIBS="-lpthread" ;; #(
+    PTHREAD_LIBS="-l:libpthread.a" ;; #(
   *) :
 
 
@@ -19417,8 +19417,8 @@ fi
 
 case $host in #(
   *-*-mingw32) :
-    bytecclibs="-lws2_32 -lversion -lpthread -lgcc_eh -lDbgHelp"
-    nativecclibs="-lws2_32 -lversion -lpthread -lgcc_eh -lDbgHelp" ;; #(
+    bytecclibs="-lws2_32 -lversion -l:libpthread.a -lgcc_eh -lDbgHelp"
+    nativecclibs="-lws2_32 -lversion -l:libpthread.a -lgcc_eh -lDbgHelp" ;; #(
   *-pc-windows) :
     bytecclibs="advapi32.lib ws2_32.lib version.lib"
     nativecclibs="advapi32.lib ws2_32.lib version.lib" ;; #(

--- a/configure.ac
+++ b/configure.ac
@@ -1984,7 +1984,7 @@ AS_CASE([$enable_debug_runtime],
 
 AS_CASE([$host],
   [*-*-mingw32|*-pc-windows],
-    [PTHREAD_LIBS="-lpthread"],
+    [PTHREAD_LIBS="-l:libpthread.a"],
   [AX_PTHREAD(
     [common_cflags="$common_cflags $PTHREAD_CFLAGS"
     saved_CFLAGS="$CFLAGS"
@@ -2182,8 +2182,8 @@ AC_CHECK_LIB(execinfo, backtrace, cclibs="$cclibs -lexecinfo",[])
 
 AS_CASE([$host],
   [*-*-mingw32],
-    [bytecclibs="-lws2_32 -lversion -lpthread -lgcc_eh -lDbgHelp"
-    nativecclibs="-lws2_32 -lversion -lpthread -lgcc_eh -lDbgHelp"],
+    [bytecclibs="-lws2_32 -lversion -l:libpthread.a -lgcc_eh -lDbgHelp"
+    nativecclibs="-lws2_32 -lversion -l:libpthread.a -lgcc_eh -lDbgHelp"],
   [*-pc-windows],
     [bytecclibs="advapi32.lib ws2_32.lib version.lib"
     nativecclibs="advapi32.lib ws2_32.lib version.lib"],

--- a/otherlibs/str/Makefile
+++ b/otherlibs/str/Makefile
@@ -24,8 +24,6 @@ include ../Makefile.otherlibs.common
 str.cmo: str.cmi
 str.cmx: str.cmi
 
-LDOPTS = $(PTHREAD_LINK)
-
 .PHONY: depend
 depend:
 	$(OCAMLRUN) $(ROOTDIR)/boot/ocamlc -depend -slash *.mli *.ml > .depend

--- a/otherlibs/systhreads/Makefile
+++ b/otherlibs/systhreads/Makefile
@@ -22,7 +22,7 @@ ifneq "$(CCOMPTYPE)" "msvc"
 OC_CFLAGS += -g
 endif
 
-OC_CFLAGS += $(SHAREDLIB_CFLAGS) $(PTHREAD_CFLAGS)
+OC_CFLAGS += $(SHAREDLIB_CFLAGS)
 
 LIBS = $(STDLIBFLAGS) -I $(ROOTDIR)/otherlibs/unix
 
@@ -59,27 +59,25 @@ all: lib$(LIBNAME).$(A) $(LIBNAME).cma $(CMIFILES)
 allopt: lib$(LIBNAME)nat.$(A) $(LIBNAME).cmxa $(CMIFILES)
 
 lib$(LIBNAME).$(A): $(BYTECODE_C_OBJS)
-	$(MKLIB_CMD) -o $(LIBNAME) $(BYTECODE_C_OBJS) $(PTHREAD_LIBS)
+	$(MKLIB_CMD) -o $(LIBNAME) $(BYTECODE_C_OBJS)
 
 lib$(LIBNAME)nat.$(A): $(NATIVECODE_C_OBJS)
 	$(MKLIB_CMD) -o $(LIBNAME)nat $^
 
 $(LIBNAME).cma: $(THREADS_BCOBJS)
 ifeq "$(UNIX_OR_WIN32)" "unix"
-	$(MKLIB) -o $(LIBNAME) -ocamlc '$(CAMLC)' -cclib -lunix -linkall \
-	  $(PTHREAD_CAML_LIBS) $^
+	$(MKLIB) -o $(LIBNAME) -ocamlc '$(CAMLC)' -cclib -lunix -linkall $^
 # TODO: Figure out why -cclib -lunix is used here.
 # It may be because of the threadsUnix module which is deprecated.
 # It may hence be good to figure out whether this module shouldn't be
 # removed, and then -cclib -lunix arguments.
 else # Windows
-	$(MKLIB) -o $(LIBNAME) -ocamlc "$(CAMLC)" -linkall \
-	  $(PTHREAD_CAML_LIBS) $^
+	$(MKLIB) -o $(LIBNAME) -ocamlc "$(CAMLC)" -linkall $^
 endif
 
 # See remark above: force static linking of libthreadsnat.a
 $(LIBNAME).cmxa: $(THREADS_NCOBJS)
-	$(CAMLOPT) -linkall -a -cclib -lthreadsnat $(PTHREAD_CAML_LIBS) -o $@ $^
+	$(CAMLOPT) -linkall -a -cclib -lthreadsnat -o $@ $^
 
 # Note: I removed "-cclib -lunix" from the line above.
 # Indeed, if we link threads.cmxa, then we must also link unix.cmxa,

--- a/otherlibs/systhreads/st_stubs.c
+++ b/otherlibs/systhreads/st_stubs.c
@@ -15,6 +15,12 @@
 
 #define CAML_INTERNALS
 
+#if defined(_WIN32) && !defined(NATIVE_CODE)
+/* Ensure that pthread.h marks symbols __declspec(dllimport) so that they can be
+   picked up from the runtime (which will have loaded libwinpthread-1.dll) */
+#define DLL_EXPORT
+#endif
+
 #include "caml/alloc.h"
 #include "caml/backtrace.h"
 #include "caml/backtrace_prim.h"

--- a/otherlibs/systhreads/st_stubs.c
+++ b/otherlibs/systhreads/st_stubs.c
@@ -17,7 +17,7 @@
 
 #if defined(_WIN32) && !defined(NATIVE_CODE)
 /* Ensure that pthread.h marks symbols __declspec(dllimport) so that they can be
-   picked up from the runtime (which will have loaded libwinpthread-1.dll) */
+   picked up from the runtime (which will have linked winpthreads statically) */
 #define DLL_EXPORT
 #endif
 

--- a/tools/ci/appveyor/appveyor_build.sh
+++ b/tools/ci/appveyor/appveyor_build.sh
@@ -105,15 +105,6 @@ if [[ $BOOTSTRAP_FLEXDLL = 'false' ]] ; then
   esac
 fi
 
-# This is needed at all stages while winpthreads is in use for 5.0
-# This step can be moved back to the test phase (or removed entirely?) when
-# winpthreads stops being used.
-if [[ $PORT = 'mingw64' ]] ; then
-  export PATH="$PATH:/usr/x86_64-w64-mingw32/sys-root/mingw/bin"
-elif [[ $PORT = 'mingw32' ]] ; then
-  export PATH="$PATH:/usr/i686-w64-mingw32/sys-root/mingw/bin"
-fi
-
 case "$1" in
   install)
     if [ ! -e "$CACHE_DIRECTORY/parallel-source" ] || \

--- a/tools/ci/inria/main
+++ b/tools/ci/inria/main
@@ -170,8 +170,6 @@ case "${OCAML_ARCH}" in
     instdir='C:/ocamlmgw'
     cleanup=true
     check_make_alldepend=true
-    # This is needed until the winpthreads support is implemented directly
-    export PATH="$PATH:/usr/i686-w64-mingw32/sys-root/mingw/bin"
   ;;
   mingw64)
     build='--build=x86_64-pc-cygwin'
@@ -179,8 +177,6 @@ case "${OCAML_ARCH}" in
     instdir='C:/ocamlmgw64'
     cleanup=true
     check_make_alldepend=true
-    # This is needed until the winpthreads support is implemented directly
-    export PATH="$PATH:/usr/x86_64-w64-mingw32/sys-root/mingw/bin"
   ;;
   msvc)
     build='--build=i686-pc-cygwin'

--- a/tools/ci/inria/main
+++ b/tools/ci/inria/main
@@ -170,6 +170,7 @@ case "${OCAML_ARCH}" in
     instdir='C:/ocamlmgw'
     cleanup=true
     check_make_alldepend=true
+    init_submodule=true
   ;;
   mingw64)
     build='--build=x86_64-pc-cygwin'
@@ -177,6 +178,7 @@ case "${OCAML_ARCH}" in
     instdir='C:/ocamlmgw64'
     cleanup=true
     check_make_alldepend=true
+    init_submodule=true
   ;;
   msvc)
     build='--build=i686-pc-cygwin'


### PR DESCRIPTION
This PR alters the mingw-w64 build to link the winpthreads library statically, removing the need for additional runtime DLLs (or, another way, restoring the OCaml 4.x lack of need for additional runtime DLLs).

Doing this proved slightly more complicated than I'd expected, as it turns out that GCC's implementation of implicit TLS (`__thread`) pulls in both its runtime library and also dynamically links the winpthreads library when building DLLs. This is something we've avoided in the past in the i686 port by using `-static-libgcc` but not only is that slightly worrying to have to do for the 64-bit port as well, but it also doesn't work for the pthreads linking.

This PR consists of three very closely linked parts:

- The `PTHREAD_` machinery from `otherlibs/systhreads/Makefile` is removed as pthreads is now always linked as part of the runtime and it would result in double-linking when switching to static winpthreads.
- On Windows, `Caml_state` now uses a similar technique to `pthread_getspecific` on macOS, rather than implicit TLS via `__thread`. As a very minor aside, the `SET_Caml_state` macro is shifted inside a `CAML_INTERNALS` block, since it's only used in `domain.c` where we can actually load the required Windows headers to use `TlsSetValue` (more on this below).
- winpthreads is then linked statically, which requires https://github.com/ocaml/flexdll/pull/106 (this PR teaches flexlink to understand `-l:` syntax).

For background, there is no better explanation of Windows TLS than Ken Johnson's [Nynaeve _Adventures in Windows debugging_ blog](http://www.nynaeve.net/?p=180) (one should also, of course, read Raymond Chen [on the same subject](https://devblogs.microsoft.com/oldnewthing/20101122-00/?p=12233)).

The way I propose implementing `Caml_state` warrants (considerable) further explanation. The problem with `Caml_state` is that it's in a public header. Our headers and codebase do not interoperate well with `windows.h` (cf. the trickery required around `ATOM`) and it seems best to keep it that way, as it's likely that user code suffers the same problem. This already means that the macro implementation of `Caml_state` wants to avoid using Windows API functions and types, because we have to declare compatible versions in the header, and it's _really_ awkward. Coupled with that is the fact that `TlsGetValue` somewhat inexplicably insists on clearing `GetLastError` (see the related previous fix in #10220), I've elected here to expand the macro definitions from `winternl.h` for `NtCurrentTeb` and then have `caml_make_domain_state_key` both reserve a TLS slot and also compute the offset in the TEB where that TLS slot will be.

I did implement a version which instead included `windows.h`, but this involves some really ugly pre-processor mucking with symbol names in various other files (both in the debugger and in the interpreter). I also looked at the alternative with manual declarations for `TlsGetValue`, `SetLastError` and `GetLastError` and it's similarly hideous and, frankly, looks more brittle than just computing the TEB offset for the TLS slot. It's also fundamentally upsetting to have to make 4 system calls and 2 branches just to dereference a single pointer! I also experimented just doing it the macOS way and using winpthread's `pthread_getspecific` but _this_ also suffers from the fact that we're in a public header and directly exposing pthreads in this way makes linking potentially awkward for user C code. The stub DLL for systhreads has to jump through a minor hoop to do this, but that seems acceptable for that _one_ library. For Windows, winpthreads provides a nice abstraction for simpler code in most of the runtime, but I don't think it's a good idea for the fact we do this to be exposed in the API (the sync module, etc. hides the implementation of the primitives).

Back in Windows 9x days, manually reading the TEB would have been utter madness - the 16 bit implementations of TLS have actually changed between versions of 16-bit Windows. However, since the very beginning of Windows NT, both the C compiler and loader have colluded on the "internal" format of the TEB in order to implement implicit TLS (with quite a few infamous limitations along the way, which is why GCC uses some emulation). A side-effect of this collusion is that the TLS layout in the TEB pretty much cannot change (but you of course read all 8 parts of Nynaeve and therefore have already read that!). So what I'm proposing here is actually what the C compiler should be doing (and, when MSVC gets resurrected, is possibly what the MSVC port will actually do, although I confess I'll be surprised if it actually works across DLL loading and flexdll). I have chosen to restrict the implementation to the first 64 TLS slots only (later in the TEB is a pointer to the other 1024 slots added with Windows Vista).  This should be no problem at all for ocamlopt-compiled programs (I think there are 3 other TLS slots in use before this one gets allocated); some particularly strange "OCaml called from C" implementation should hopefully be able to call `caml_make_domain_state_key` before allocating gazillions of TLS slots.

Given the DLL hell which can arise on mingw-w64 (see all the fun in [opam](https://github.com/ocaml/opam/tree/master/src/manifest) for manifesting the C++ mingw-w64 runtime DLLs), I hope that one slightly hairy macro definition and a bit of dirty pointer arithmetic is an acceptable cost. As it happens, the combined facts the the TLS slot is _set_ using `TlsSetValue` and then _retrieved_ directly from the TEB coupled with quite how fundamental `Caml_state` is to the runtime means that this all gets quite severely tested just building the compiler, let alone running the testsuite!

This PR is marked as Draft only to prevent merging before the FlexDLL PR is merged. This branch has been through [precheck#778](https://ci.inria.fr/ocaml/job/precheck/778/).