### PR TITLE
Stop using integer comparison on potential pointers

### DIFF
--- a/Changes
+++ b/Changes
@@ -142,6 +142,9 @@ Working version
   by leaf functions.
   (Tom Kelly and Xavier Leroy, review by Mark Shinwell)
 
+- #?????: Prevent integer comparison from being used on pointers
+  (Vincent Laviron)
+
 OCaml 5.0
 ---------
 

--- a/Changes
+++ b/Changes
@@ -142,8 +142,8 @@ Working version
   by leaf functions.
   (Tom Kelly and Xavier Leroy, review by Mark Shinwell)
 
-- #?????: Prevent integer comparison from being used on pointers
-  (Vincent Laviron)
+- #11587: Prevent integer comparison from being used on pointers
+  (Vincent Laviron, review by Gabriel Scherer)
 
 OCaml 5.0
 ---------

--- a/lambda/matching.ml
+++ b/lambda/matching.ml
@@ -2947,8 +2947,14 @@ let combine_variant loc row arg partial ctx def (tag_lambda_list, total1, _pats)
         | [ (_, act1) ], [ (_, act2) ] when fail = None ->
             test_int_or_block arg act1 act2
         | _, [] ->
-            (* One can compare integers and pointers *)
-            make_test_sequence_variant_constant fail arg consts
+            begin match fail with
+            | None ->
+              make_test_sequence_variant_constant fail arg consts
+            | Some act ->
+              test_int_or_block arg
+                (make_test_sequence_variant_constant fail arg consts)
+                act
+            end
         | [], _ -> (
             let lam = call_switcher_variant_constr loc fail arg nonconsts in
             (* One must not dereference integers *)

--- a/lambda/matching.ml
+++ b/lambda/matching.ml
@@ -2946,15 +2946,14 @@ let combine_variant loc row arg partial ctx def (tag_lambda_list, total1, _pats)
         match (consts, nonconsts) with
         | [ (_, act1) ], [ (_, act2) ] when fail = None ->
             test_int_or_block arg act1 act2
-        | _, [] ->
-            begin match fail with
-            | None ->
-              make_test_sequence_variant_constant fail arg consts
-            | Some act ->
-              test_int_or_block arg
-                (make_test_sequence_variant_constant fail arg consts)
-                act
-            end
+        | _, [] -> (
+            let lam = make_test_sequence_variant_constant fail arg consts in
+            (* PR#11587: Switcher.test_sequence expects integer inputs, so
+               if the type allows pointers we must filter them away. *)
+            match fail with
+            | None -> lam
+            | Some fail -> test_int_or_block arg lam fail
+          )
         | [], _ -> (
             let lam = call_switcher_variant_constr loc fail arg nonconsts in
             (* One must not dereference integers *)


### PR DESCRIPTION
We detected with Flambda 2 that there were some case where the compiler generated `Lambda` terms using the integer-specific comparison on values that could contain pointers. This is forbidden in our model of the language, so we considered whether we needed to update our model or patch the compiler. It turns out that there's a potential bug anyway in the only place we're aware of that can generate such comparisons, so we've decided to keep our strict model and patch the compiler. This PR proposes the corresponding patch for trunk.

The following is an explanation of the bug, copied from the Flambda 2 PR (ocaml-flambda/flambda-backend#854).

Consider the following OCaml program:
```ocaml
type simple = [ `Black | `Blue | `Red | `Green | `Yellow ]

let[@inline never] compare_simple s1 s2 = Sys.opaque_identity 0

type t = [ simple | `RGB of int ]

let compare t1 t2 =
  match t1, t2 with
  | #simple as s1, #simple as s2 -> compare_simple s1 s2
  | `RGB i1, `RGB i2 -> Int.compare i1 i2
  | x, y -> compare x y

let example = `RGB 12345

let compare_spec t = (compare [@inlined]) t example
```
It is compiled to the following lambda term:
```
(let
  (compare_simple/262 = (function s1/264 s2/265 never_inline : int (opaque 0))
   compare/335 =
     (function t1/336 t2/337 : int
       (catch
         (catch
           (if (isint t1/336)
             (if (>= t1/336 82908052) (if (!= t1/336 737308346) (if (!= t1/336 756711075) (if (>= t1/336 82908053) (exit 1) (exit 2)) (exit 2)) (exit 2))
               (if (!= t1/336 -937474657) (if (!= t1/336 4100401) (exit 1) (exit 2)) (exit 2)))
             (if (!= (field 0 t1/336) 4093677) (exit 1) (if (isint t2/337) (exit 1) (if (!= (field 0 t2/337) 4093677) (exit 1) (apply (field 8 (global Stdlib__Int!)) (field 1 t1/336) (field 1 t2/337))))))
          with (2)
           (catch
(* --> *)    (if (>= t2/337 82908052) (if (!= t2/337 737308346) (if (!= t2/337 756711075) (if (>= t2/337 82908053) (exit 1) (exit 3)) (exit 3)) (exit 3))
               (if (!= t2/337 -937474657) (if (!= t2/337 4100401) (exit 1) (exit 3)) (exit 3)))
            with (3) (apply compare_simple/262 t1/336 (makeblock 0 t1/336 t2/337))))
        with (1) (caml_compare t1/336 t2/337)))
   example/371 = [0: 4093677 12345]
   compare_spec/372 = (function t/374 : int (apply compare/335 t/374 example/371 always_inline)))
  (makeblock 0 compare_simple/262 compare/335 example/371 compare_spec/372))
```
The line annotated with `(* --> *)` corresponds in the pattern-matching to the point where we know that `t1` matches `#simple`, and we're trying to see if `t2` matches `#simple` too. Crucially, we don't know whether `t2` is an integer or a pointer.
If we tested only for equality with the relevant integers this would work, as no pointer can be equal to an integer thanks to the tagging bit, but you can see that for the special case of `82908052` the test is decomposed into a first inequality `(>= t2/337 82908052)`, introduced for balancing the test tree, then a final `(>= t2/337 82908053)`. This works if we supposed that there is no valid input between `82908052` and  `82908053`. However, these constants represent to tagged versions of the integers; in practice the test on machine integers will test `t2 >= 165816105` and `t2 >= 165816107`. There's a spurious value `165816106` that can't be reached if the input is guaranteed to be an integer, but that might correspond to a pointer (in this case for alignment reasons this is unlikely, but with different constructors we could end up with the right alignment).

Of course, we've never noticed any occurrences of the bug in the wild, because it's very unlikely that a pointer will get exactly the wrong value, and if it did occur it would likely go completely unnoticed (we would take the wrong branch, but it wouldn't lead to any obvious error like reading from data with the wrong type).