### PR TITLE
Simpler handling of `caml_state` on macOS and MinGW

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -717,7 +717,7 @@ libasmrunpic_OBJECTS = $(runtime_NATIVE_C_SOURCES:.c=.npic.$(O)) \
 
 ## General (non target-specific) assembler and compiler flags
 
-runtime_CPPFLAGS = -DCAMLDLLIMPORT=
+runtime_CPPFLAGS = -DCAMLDLLIMPORT= -DIN_CAML_RUNTIME
 ocamlrund_CPPFLAGS = -DDEBUG
 ocamlruni_CPPFLAGS = -DCAML_INSTR
 

--- a/configure
+++ b/configure
@@ -15100,6 +15100,18 @@ as_fn_error $? "C11 atomic support is required, use another C compiler
 See \`config.log' for more details" "$LINENO" 5; }
 fi
 
+# Full support for C11 __thread variables
+# macOS and MinGW-64 have problems with __thread variables accessed from DLLs
+
+case $host in #(
+  *-apple-darwin*|*-mingw32) :
+     ;; #(
+  *) :
+    printf "%s\n" "#define HAS_FULL_THREAD_VARIABLES 1" >>confdefs.h
+
+ ;;
+esac
+
 # Shared library support
 
 sharedlib_cflags=''

--- a/configure.ac
+++ b/configure.ac
@@ -1053,6 +1053,14 @@ OCAML_CC_SUPPORTS_ATOMIC([$cclibs])
 AS_IF([! $cc_supports_atomic],
   [AC_MSG_FAILURE([C11 atomic support is required, use another C compiler])])
 
+# Full support for C11 __thread variables
+# macOS and MinGW-64 have problems with __thread variables accessed from DLLs
+
+AS_CASE([$host],
+  [*-apple-darwin*|*-mingw32], [],
+  [AC_DEFINE([HAS_FULL_THREAD_VARIABLES])]
+)
+
 # Shared library support
 
 sharedlib_cflags=''

--- a/runtime/caml/domain_state.h
+++ b/runtime/caml/domain_state.h
@@ -48,7 +48,7 @@ CAML_STATIC_ASSERT(
     offsetof(caml_domain_state, LAST_DOMAIN_STATE_MEMBER) ==
     (Domain_state_num_fields - 1) * 8);
 
-#if defined(HAS_FULL_THREAD_VARIABLES)
+#if defined(HAS_FULL_THREAD_VARIABLES) || defined(IN_CAML_RUNTIME)
   CAMLextern __thread caml_domain_state* caml_state;
   #define Caml_state_opt caml_state
 #else

--- a/runtime/caml/s.h.in
+++ b/runtime/caml/s.h.in
@@ -42,6 +42,12 @@
 /* Define SUPPORT_DYNAMIC_LINKING if dynamic loading of C stub code
    via dlopen() is available. */
 
+#undef HAS_FULL_THREAD_VARIABLES
+
+/* Define HAS_FULL_THREAD_VARIABLES if C11 __thread variables are fully
+   supported, including across DLLs.  This is not the case with
+   macOS and with Windows + MinGW-64. */
+
 #undef HAS_C99_FLOAT_OPS
 
 /* Define HAS_C99_FLOAT_OPS if <math.h> conforms to ISO C99.

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -282,24 +282,14 @@ static dom_internal* next_free_domain() {
   return stw_domains.domains[stw_domains.participating_domains];
 }
 
-#ifdef __APPLE__
-/* OSX has issues with dynamic loading + exported TLS.
-   This is slower but works */
-CAMLexport pthread_key_t caml_domain_state_key;
-static pthread_once_t key_once = PTHREAD_ONCE_INIT;
-
-static void caml_make_domain_state_key (void)
-{
-  (void) pthread_key_create (&caml_domain_state_key, NULL);
-}
-
-void caml_init_domain_state_key (void)
-{
-  pthread_once(&key_once, caml_make_domain_state_key);
-}
-
-#else
 CAMLexport __thread caml_domain_state* caml_state;
+
+#ifndef HAS_FULL_THREAD_VARIABLES
+/* Export a getter for caml_state, to be used in DLLs */
+CAMLexport caml_domain_state* caml_get_domain_state(void)
+{
+  return caml_state;
+}
 #endif
 
 Caml_inline void interrupt_domain(struct interruptor* s)
@@ -588,7 +578,7 @@ static void domain_create(uintnat initial_minor_heap_wsize) {
     domain_state = d->state;
   }
 
-  SET_Caml_state((void*)domain_state);
+  caml_state = domain_state;
 
   s->unique_id = fresh_domain_unique_id();
   s->interrupt_word = &domain_state->young_limit;
@@ -890,7 +880,7 @@ void caml_init_domains(uintnat minor_heap_wsz) {
 void caml_init_domain_self(int domain_id) {
   CAMLassert (domain_id >= 0 && domain_id < Max_domains);
   domain_self = &all_domains[domain_id];
-  SET_Caml_state(domain_self->state);
+  caml_state = domain_self->state;
 }
 
 enum domain_status { Dom_starting, Dom_started, Dom_failed };
@@ -940,7 +930,7 @@ static void* backup_thread_func(void* v)
   struct interruptor* s = &di->interruptor;
 
   domain_self = di;
-  SET_Caml_state((void*)(di->state));
+  caml_state = di->state;
 
   msg = atomic_load_acq (&di->backup_thread_msg);
   while (msg != BT_TERMINATE) {
@@ -1568,7 +1558,7 @@ CAMLexport void caml_acquire_domain_lock(void)
 {
   dom_internal* self = domain_self;
   caml_plat_lock(&self->domain_lock);
-  SET_Caml_state(self->state);
+  caml_state = self->state;
 }
 
 CAMLexport void caml_bt_enter_ocaml(void)
@@ -1585,7 +1575,7 @@ CAMLexport void caml_bt_enter_ocaml(void)
 CAMLexport void caml_release_domain_lock(void)
 {
   dom_internal* self = domain_self;
-  SET_Caml_state(NULL);
+  caml_state = NULL;
   caml_plat_unlock(&self->domain_lock);
 }
 

--- a/runtime/startup_byt.c
+++ b/runtime/startup_byt.c
@@ -460,9 +460,6 @@ CAMLexport void caml_main(char_os **argv)
   char_os * shared_lib_path, * shared_libs;
   char_os * exe_name, * proc_self_exe;
 
-  /* Initialize the domain */
-  CAML_INIT_DOMAIN_STATE;
-
   /* Determine options */
   caml_parse_ocamlrunparam();
 
@@ -603,9 +600,6 @@ CAMLexport value caml_startup_code_exn(
 {
   char_os * exe_name;
   value res;
-
-  /* Initialize the domain */
-  CAML_INIT_DOMAIN_STATE;
 
   /* Determine options */
   caml_parse_ocamlrunparam();

--- a/runtime/startup_nat.c
+++ b/runtime/startup_nat.c
@@ -90,9 +90,6 @@ value caml_startup_common(char_os **argv, int pooling)
   char_os * exe_name, * proc_self_exe;
   value res;
 
-  /* Initialize the domain */
-  CAML_INIT_DOMAIN_STATE;
-
   /* Determine options */
   caml_parse_ocamlrunparam();
 


### PR DESCRIPTION
Currently, `caml_state` is defined as a C11 `__thread` variable, except on macOS because it doesn't allow a DLL to access a `__thread` variable defined in the main program.  MinGW with static linking of  libwinpthread has the same limitation, see #11586 .  

The current workaround for macOS, based on `pthread_getspecific`, is costly, and the proposed workarounds for MinGW are complicated.

This PR offers a simpler and more efficient solution to this problem.  It starts with the assumption that `caml_state` can always be defined with `__thread` and directly used within the runtime system. The only restriction is that on macOS and MinGW, DLLs must not access `caml_state` directly, so we make them go through a getter function defined in the main program instead.  (No setter function because DLLs don't need to set `caml_state`.)

The getter function is declared `pure` so that GCC and Clang can perform CSE on repeated calls to the getter (see https://gcc.gnu.org/onlinedocs/gcc/Common-Function-Attributes.html).

The resulting code is quite simple and should be faster than the existing code on macOS (no `pthread_getspecific` calls) ~~and at least as fast as the Win32 code proposed earlier in #11586.~~
