### PR TITLE
Probable bug in runtime/debugger interface + some C cleanups

### DIFF
--- a/runtime/caml/atomic_refcount.h
+++ b/runtime/caml/atomic_refcount.h
@@ -22,7 +22,7 @@
 
 Caml_inline void caml_atomic_refcount_init(atomic_uintnat* refc, uintnat n){
   atomic_store_rel(refc, n);
-};
+}
 
 Caml_inline uintnat caml_atomic_refcount_decr(atomic_uintnat* refcount){
   return atomic_fetch_add (refcount, -1);
@@ -30,7 +30,7 @@ Caml_inline uintnat caml_atomic_refcount_decr(atomic_uintnat* refcount){
 
 Caml_inline uintnat caml_atomic_refcount_incr(atomic_uintnat* refcount){
   return atomic_fetch_add (refcount, 1);
-};
+}
 
 #endif /* CAML_INTERNALS */
 

--- a/runtime/debugger.c
+++ b/runtime/debugger.c
@@ -266,7 +266,9 @@ static void putval(struct channel *chan, value val)
 static void safe_output_value(struct channel *chan, value val)
 {
   struct longjmp_buffer raise_buf;
-  struct caml_exception_context exception_ctx = {&raise_buf, CAML_LOCAL_ROOTS};
+  volatile value raise_exn_bucket;
+  struct caml_exception_context exception_ctx =
+    {&raise_buf, CAML_LOCAL_ROOTS, &raise_exn_bucket};
   struct caml_exception_context* saved_external_raise;
 
   /* Catch exceptions raised by [caml_output_val] */

--- a/runtime/shared_heap.c
+++ b/runtime/shared_heap.c
@@ -832,7 +832,7 @@ static void verify_large(large_alloc* a, struct mem_stats* s) {
 
 static void verify_swept (struct caml_heap_state* local) {
   int i;
-  struct mem_stats pool_stats = {}, large_stats = {};
+  struct mem_stats pool_stats = {0,}, large_stats = {0,};
 
   /* sweeping should be done by this point */
   CAMLassert(local->next_to_sweep == NUM_SIZECLASSES);


### PR DESCRIPTION
Found using `clang -Wall -Wextra -Wpedantic`.  See individual commits for descriptions.
