### PR TITLE
manual: document the behavior of "with module"

### DIFF
--- a/Changes
+++ b/Changes
@@ -432,6 +432,10 @@ OCaml 5.0
 
 ### Manual and documentation:
 
+- #5514, ???: Document that `with module M = ...` might add components to the
+  signature of `M`.
+  (Florian Angeletti, review by ???)
+
 - #11058: runtime/HACKING.adoc tips on debugging the runtime
   (Gabriel Scherer, review by Enguerrand Decorne and Nicolás Ojeda Bär)
 

--- a/manual/src/refman/modtypes.etex
+++ b/manual/src/refman/modtypes.etex
@@ -280,14 +280,17 @@ one may use the abbreviated form
 Assuming @module-type@ denotes a signature, the expression
 @module-type 'with' mod-constraint@ @{ 'and' mod-constraint }@ denotes
 the same signature where type equations have been added to some of the
-type specifications, as described by the constraints following the
-"with" keyword. The constraint @'type' [type-parameters] typeconstr
+type specifications and some new components have been added to submodules,
+as described by the constraints following the "with" keyword.
+The constraint @'type' [type-parameters] typeconstr
 '=' typexpr@  adds the type equation @'=' typexpr@ to the specification
 of the type component named @typeconstr@ of the constrained signature.
 The constraint @'module' module-path '=' extended-module-path@ adds
 type equations to all type components of the sub-structure denoted by
 @module-path@, making them equivalent to the corresponding type
-components of the structure denoted by @extended-module-path@.
+components of the structure denoted by @extended-module-path@ and
+add the other components of the @extended-module-path@ structure to the
+@module-path@ substructure.
 
 For instance, if the module type name "S" is bound to the signature
 \begin{verbatim}


### PR DESCRIPTION
This small PR documents the fact that `with` constraints may add some components to the signature of submodules of the original module type.

For instance, the module type `t` in
```ocaml
module T = struct
  type t
end
module type S = sig
  module M:sig end
end
module type t =  end with module M = T
```
is equivalent to
```ocaml
module type t = sig
  module M: sig type t = T.t end
end
```

Lay #5514 to rest