### PR TITLE
Use snprintf instead of sprintf

### DIFF
--- a/runtime/misc.c
+++ b/runtime/misc.c
@@ -74,14 +74,16 @@ void caml_alloc_point_here(void)
 }
 #endif /* DEBUG */
 
+#define GC_LOG_LENGTH 512
+
 void caml_gc_log (char *msg, ...)
 {
   if ((caml_params->verb_gc & 0x800) != 0) {
-    char fmtbuf[512];
+    char fmtbuf[GC_LOG_LENGTH];
     va_list args;
     va_start (args, msg);
-    sprintf(fmtbuf, "[%02d] %s\n",
-            (Caml_state_opt != NULL) ? Caml_state->id : -1, msg);
+    snprintf(fmtbuf, GC_LOG_LENGTH, "[%02d] %s\n",
+             (Caml_state_opt != NULL) ? Caml_state->id : -1, msg);
     vfprintf(stderr, fmtbuf, args);
     va_end (args);
     fflush(stderr);


### PR DESCRIPTION
Noticed while porting ocaml-solo5 to OCaml 5.0. It looks more safe this way in case the message somehow gets bigger than 512 bytes.