### PR TITLE
Temporarily disable the lib-dynlink-domains test on Windows

### DIFF
--- a/testsuite/tests/lib-dynlink-domains/main.ml
+++ b/testsuite/tests/lib-dynlink-domains/main.ml
@@ -4,57 +4,58 @@ include dynlink
 libraries = ""
 readonly_files = "store.ml main.ml Plugin_0.ml Plugin_0_0.ml Plugin_0_0_0.ml Plugin_0_0_0_0.ml Plugin_0_0_0_1.ml Plugin_0_0_0_2.ml Plugin_1.ml Plugin_1_0.ml Plugin_1_0_0.ml Plugin_1_0_0_0.ml Plugin_1_1.ml Plugin_1_2.ml Plugin_1_2_0.ml Plugin_1_2_0_0.ml Plugin_1_2_1.ml Plugin_1_2_2.ml Plugin_1_2_2_0.ml Plugin_1_2_3.ml Plugin_1_2_3_0.ml"
 
-*01 shared-libraries
-*02 setup-ocamlc.byte-build-env
-*03 ocamlc.byte
-module = "store.ml"
+*01 not-windows
+*02 shared-libraries
+*03 setup-ocamlc.byte-build-env
 *04 ocamlc.byte
-module = "Plugin_0.ml"
+module = "store.ml"
 *05 ocamlc.byte
-module = "Plugin_0_0.ml"
+module = "Plugin_0.ml"
 *06 ocamlc.byte
-module = "Plugin_0_0_0.ml"
+module = "Plugin_0_0.ml"
 *07 ocamlc.byte
-module = "Plugin_0_0_0_0.ml"
+module = "Plugin_0_0_0.ml"
 *08 ocamlc.byte
-module = "Plugin_0_0_0_1.ml"
+module = "Plugin_0_0_0_0.ml"
 *09 ocamlc.byte
-module = "Plugin_0_0_0_2.ml"
+module = "Plugin_0_0_0_1.ml"
 *10 ocamlc.byte
-module = "Plugin_1.ml"
+module = "Plugin_0_0_0_2.ml"
 *11 ocamlc.byte
-module = "Plugin_1_0.ml"
+module = "Plugin_1.ml"
 *12 ocamlc.byte
-module = "Plugin_1_0_0.ml"
+module = "Plugin_1_0.ml"
 *13 ocamlc.byte
-module = "Plugin_1_0_0_0.ml"
+module = "Plugin_1_0_0.ml"
 *14 ocamlc.byte
-module = "Plugin_1_1.ml"
+module = "Plugin_1_0_0_0.ml"
 *15 ocamlc.byte
-module = "Plugin_1_2.ml"
+module = "Plugin_1_1.ml"
 *16 ocamlc.byte
-module = "Plugin_1_2_0.ml"
+module = "Plugin_1_2.ml"
 *17 ocamlc.byte
-module = "Plugin_1_2_0_0.ml"
+module = "Plugin_1_2_0.ml"
 *18 ocamlc.byte
-module = "Plugin_1_2_1.ml"
+module = "Plugin_1_2_0_0.ml"
 *19 ocamlc.byte
-module = "Plugin_1_2_2.ml"
+module = "Plugin_1_2_1.ml"
 *20 ocamlc.byte
-module = "Plugin_1_2_2_0.ml"
+module = "Plugin_1_2_2.ml"
 *21 ocamlc.byte
-module = "Plugin_1_2_3.ml"
+module = "Plugin_1_2_2_0.ml"
 *22 ocamlc.byte
-module = "Plugin_1_2_3_0.ml"
+module = "Plugin_1_2_3.ml"
 *23 ocamlc.byte
-module = "main.ml"
+module = "Plugin_1_2_3_0.ml"
 *24 ocamlc.byte
+module = "main.ml"
+*25 ocamlc.byte
 program = "./main.byte.exe"
 libraries= "dynlink"
 all_modules = "store.cmo main.cmo"
 module = ""
-*25 run
-*26 check-program-output
+*26 run
+*27 check-program-output
 
 *02 native-dynlink
 *03 setup-ocamlopt.byte-build-env

--- a/testsuite/tests/lib-dynlink-domains/test_generator.ml
+++ b/testsuite/tests/lib-dynlink-domains/test_generator.ml
@@ -515,9 +515,10 @@ include dynlink
 libraries = ""
 readonly_files = "@[<h>store.ml main.ml%a@]"
 
-*01 shared-libraries
-*02 setup-ocamlc.byte-build-env
-*03 ocamlc.byte
+*01 not-windows
+*02 shared-libraries
+*03 setup-ocamlc.byte-build-env
+*04 ocamlc.byte
 module = "store.ml"@ @]|}
       files node;
     let bytecode_compilation i node =
@@ -528,7 +529,7 @@ module = "store.ml"@ @]|}
       i + 1
       end
     in
-    let stars = fold bytecode_compilation 4 node in
+    let stars = fold bytecode_compilation 5 node in
     Format.fprintf ppf
       "@[<v>%a ocamlc.byte@ \
        module = \"main.ml\"@ \


### PR DESCRIPTION
Since turning AppVeyor back on, we've been seeing frequent failures in the `lib-dynlink-domains` test from #11032.

This test is correctly revealing that FlexDLL is not thread-safe. It's very easy to reproduce the problem - even if the test succeeds, running `main.exe` from the `ocamlopt.byte` test output directory a few times will reveal one or other of various corruptions! I've verified with a quickly hacked patch that fixing `flexdll_wdlopen` and `flexdll_dlsym` for multi-threaded access eliminates the crash. The lock used in bytecode to protect the `Symtable` machinery will be also protecting flexlink when this is executed in bytecode, so this is a native code problem (AppVeyor does run all the dynlink tests in native code for, um, this very reason apparently!)

This test fails more regularly than it passes, so until I've patched flexdll, I suggest we disable it on Windows. 