### PR TITLE
#11194: fix an inconsistency in type variable names in error messages

### DIFF
--- a/Changes
+++ b/Changes
@@ -611,6 +611,11 @@ OCaml 5.0
 - #11186, #11188: Fix composition of coercions with aliases
   (Vincent Laviron, report and review by Leo White)
 
+- #11194, #11609: Fix inconsistent type variable names in "unbound type var"
+  messages
+  (Ulysse Gérard and Florian Angeletti, review Florian Angeletti and
+   Gabriel Scherer)
+
 - #11204: Fix regression introduced in 4.14.0 that would trigger Warning 17 when
   calling virtual methods introduced by constraining the self type from within
   the class definition.

--- a/testsuite/tests/typing-objects/Tests.ml
+++ b/testsuite/tests/typing-objects/Tests.ml
@@ -1405,3 +1405,16 @@ class virtual c = cv
 [%%expect {|
 class virtual c : cv
 |}];;
+
+(** Test classes abbreviations with a recursive type *)
+class ['a] c = object method m: (<x:'a; f:'b> as 'b) -> unit = fun _ -> () end
+class d = ['a] c
+[%%expect {|
+class ['a] c : object method m : (< f : 'b; x : 'a > as 'b) -> unit end
+Line 2, characters 0-16:
+2 | class d = ['a] c
+    ^^^^^^^^^^^^^^^^
+Error: Some type variables are unbound in this type: class d : ['a] c
+       The method m has type (< f : 'b; x : 'a > as 'b) -> unit where 'a
+       is unbound
+|}]

--- a/testsuite/tests/typing-objects/unbound-type-var.ml
+++ b/testsuite/tests/typing-objects/unbound-type-var.ml
@@ -15,5 +15,5 @@ Lines 1-4, characters 0-3:
 4 | end
 Error: Some type variables are unbound in this type:
          class test : 'a -> 'b -> object method b : 'b end
-       The method b has type 'a where 'a is unbound
+       The method b has type 'b where 'b is unbound
 |}]

--- a/testsuite/tests/typing-objects/unbound-type-var.ml
+++ b/testsuite/tests/typing-objects/unbound-type-var.ml
@@ -1,0 +1,19 @@
+(* TEST
+   * expect
+*)
+
+class test a c =
+object
+  method b = c
+end
+
+[%%expect{|
+Lines 1-4, characters 0-3:
+1 | class test a c =
+2 | object
+3 |   method b = c
+4 | end
+Error: Some type variables are unbound in this type:
+         class test : 'a -> 'b -> object method b : 'b end
+       The method b has type 'a where 'a is unbound
+|}]

--- a/typing/printtyp.ml
+++ b/typing/printtyp.ml
@@ -1058,7 +1058,10 @@ let reset () =
   reset_except_context ()
 
 let prepare_for_printing tyl =
-  reset_except_context (); List.iter prepare_type tyl
+  reset_except_context ();
+  List.iter prepare_type tyl
+
+let add_type_to_preparation = prepare_type
 
 (* Disabled in classic mode when printing an unification error *)
 let print_labels = ref true

--- a/typing/printtyp.mli
+++ b/typing/printtyp.mli
@@ -107,6 +107,12 @@ val type_expr: formatter -> type_expr -> unit
     Any type variables that are shared between multiple types in the input list
     will be given the same name when printed with [prepared_type_expr]. *)
 val prepare_for_printing: type_expr list -> unit
+
+(** [add_type_to_preparation ty] extend a previous type expression preparation
+    to the type expression [ty]
+*)
+val add_type_to_preparation: type_expr -> unit
+
 val prepared_type_expr: formatter -> type_expr -> unit
 (** The function [prepared_type_expr] is a less-safe but more-flexible version
     of [type_expr] that should only be called on [type_expr]s that have been

--- a/typing/typeclass.ml
+++ b/typing/typeclass.ml
@@ -1973,7 +1973,6 @@ let report_error env ppf = function
         (function ppf ->
            fprintf ppf "but is expected to have type")
   | Unexpected_field (ty, lab) ->
-      Printtyp.prepare_for_printing [ty];
       fprintf ppf
         "@[@[<2>This object is expected to have type :@ %a@]\
          @ This type does not have a method %s."

--- a/typing/typeclass.ml
+++ b/typing/typeclass.ml
@@ -2062,7 +2062,8 @@ let report_error env ppf = function
       let print_reason ppf (ty0, real, lab, ty) =
         let ty1 =
           if real then ty0 else Btype.newgenty(Tobject(ty0, ref None)) in
-        Printtyp.prepare_for_printing [ty; ty1];
+        Printtyp.add_type_to_preparation ty;
+        Printtyp.add_type_to_preparation ty1;
         fprintf ppf
           "The method %s@ has type@;<1 2>%a@ where@ %a@ is unbound"
           lab


### PR DESCRIPTION
Supersede #11194
Currently, the error message for unbound type variables in classes use inconsistent names for the offending type variable
in the class and method submessage:
```ocaml
class test a c =
object
  method b = c
end
```
```
Lines 1-4, characters 0-3:
1 | class test a c =
2 | object
3 |   method b = c
4 | end
Error: Some type variables are unbound in this type:
         class test : 'a -> 'b -> object method b : 'b end
       The method b has type 'a where 'a is unbound
```
This inconsistency is due to ill-timed reset of the naming context.
The previous attempt to fix this issue in #11194 erased by accident the marking of loops in the printed types, leading to a stack overflow of the type printer in
```ocaml
class ['a] c = object method m: (<x:'a; f:'b> as 'b) -> unit = fun _ -> () end
class d = ['a] c
```
This PR fixes this issue by adding one more expert function `Printtyp.add_type_to_preparation` for adding a type expression to the set of marked type exoressions without resetting the naming context. Using this new function fix both issues:
- the names for type variable are consistent between the class and  error submessages
- all loops in the type of the method are marked by the time we print the method type.