### PR TITLE
Fix ./configure --disable-instrumented-runtime never disabling the instrumented runtime

### DIFF
--- a/configure
+++ b/configure
@@ -3237,7 +3237,7 @@ SO="so"
 toolchain="cc"
 profinfo=false
 profinfo_width=0
-instrumented_runtime=true
+instrumented_runtime=false
 force_instrumented_runtime=false
 instrumented_runtime_libs=""
 bootstrapping_flexdll=false
@@ -16312,8 +16312,6 @@ but no proper monotonic clock source was found." "$LINENO" 5
 esac
      ;;
 esac
-else $as_nop
-  instrumented_runtime=false
 
 fi
 

--- a/configure
+++ b/configure
@@ -16312,6 +16312,8 @@ but no proper monotonic clock source was found." "$LINENO" 5
 esac
      ;;
 esac
+else $as_nop
+  instrumented_runtime=false
 
 fi
 

--- a/configure.ac
+++ b/configure.ac
@@ -1563,7 +1563,8 @@ but clock_gettime is missing.])
 but no proper monotonic clock source was found.])
           ]
       )]
-    )]
+    )],
+    [instrumented_runtime=false]
 )
 
 ## Sockets

--- a/configure.ac
+++ b/configure.ac
@@ -63,7 +63,7 @@ SO="so"
 toolchain="cc"
 profinfo=false
 profinfo_width=0
-instrumented_runtime=true
+instrumented_runtime=false
 force_instrumented_runtime=false
 instrumented_runtime_libs=""
 bootstrapping_flexdll=false
@@ -1563,8 +1563,7 @@ but clock_gettime is missing.])
 but no proper monotonic clock source was found.])
           ]
       )]
-    )],
-    [instrumented_runtime=false]
+    )]
 )
 
 ## Sockets


### PR DESCRIPTION
Calling the configure script with `--disable-instrumented-runtime` would never actually disable the instrumented runtime.
This should also be backported to the `5.0` branch.