### PR TITLE
Remove globals from asmcomp/linearize.ml

### DIFF
--- a/Changes
+++ b/Changes
@@ -226,7 +226,7 @@ Working version
   Gabriel Scherer)
 
 - #11615: remove global variables form asmcomp/linearize.ml
-  (Stefan Muenzel, review by ???)
+  (Stefan Muenzel, review by Nicolás Ojeda Bär)
 
 ### Build system:
 - #11590: Allow installing to a destination path containing spaces.

--- a/Changes
+++ b/Changes
@@ -225,6 +225,9 @@ Working version
   (Sébastien Hinderer, review by Florian Angeletti, Nicolás Ojeda Bär and
   Gabriel Scherer)
 
+- #11615: remove global variables form asmcomp/linearize.ml
+  (Stefan Muenzel, review by ???)
+
 ### Build system:
 - #11590: Allow installing to a destination path containing spaces.
    (Élie Brami, review by Sébastien Hinderer and David Allsopp)

--- a/asmcomp/linearize.ml
+++ b/asmcomp/linearize.ml
@@ -109,11 +109,11 @@ let add_branch lbl n =
     discard_dead_code n
 
 
-type exit_info =
-  { try_depth : int
-  ; exit_label : (int * (int * int)) list
+type exit_info = {
+  try_depth : int;
+  exit_label : (int * (int * int)) list ;
   (* Association list: exit handler -> (handler label, try-nesting factor) *)
-  }
+}
 
 let find_exit_label_try_depth exit_info k =
   try

--- a/asmcomp/linearize.ml
+++ b/asmcomp/linearize.ml
@@ -111,7 +111,7 @@ let add_branch lbl n =
 
 type exit_info = {
   try_depth : int;
-  exit_label : (int * (int * int)) list ;
+  exit_label : (int * (int * int)) list;
   (* Association list: exit handler -> (handler label, try-nesting factor) *)
 }
 

--- a/asmcomp/linearize.ml
+++ b/asmcomp/linearize.ml
@@ -282,7 +282,7 @@ let linear i n contains_calls =
 
     | Iraise k ->
         copy_instr (Lraise k) i (discard_dead_code n)
-  in linear { exit_label = []; try_depth = 0} i n
+  in linear { exit_label = []; try_depth = 0 } i n
 
 let add_prologue first_insn prologue_required =
   let tailrec_entry_point_label = Cmm.new_label () in

--- a/asmcomp/linearize.ml
+++ b/asmcomp/linearize.ml
@@ -109,47 +109,47 @@ let add_branch lbl n =
     discard_dead_code n
 
 
-type try_info =
+type exit_info =
   { try_depth : int
   ; exit_label : (int * (int * int)) list
   (* Association list: exit handler -> (handler label, try-nesting factor) *)
   }
 
-let find_exit_label_try_depth try_info k =
+let find_exit_label_try_depth exit_info k =
   try
-    List.assoc k try_info.exit_label
+    List.assoc k exit_info.exit_label
   with
   | Not_found -> Misc.fatal_error "Linearize.find_exit_label"
 
-let find_exit_label try_info k =
-  let (label, t) = find_exit_label_try_depth try_info k in
-  assert(t = try_info.try_depth);
+let find_exit_label exit_info k =
+  let (label, t) = find_exit_label_try_depth exit_info k in
+  assert(t = exit_info.try_depth);
   label
 
-let is_next_catch try_info n =
-  match try_info.exit_label with
-  | (n0,(_,t))::_  when n0=n && t = try_info.try_depth -> true
+let is_next_catch exit_info n =
+  match exit_info.exit_label with
+  | (n0,(_,t))::_  when n0=n && t = exit_info.try_depth -> true
   | _ -> false
 
-let local_exit try_info k =
-  snd (find_exit_label_try_depth try_info k) = try_info.try_depth
+let local_exit exit_info k =
+  snd (find_exit_label_try_depth exit_info k) = exit_info.try_depth
 
 (* Linearize an instruction [i]: add it in front of the continuation [n] *)
 let linear i n contains_calls =
-  let rec linear try_info i n =
+  let rec linear exit_info i n =
     match i.Mach.desc with
       Iend -> n
     | Iop(Itailcall_ind | Itailcall_imm _ as op) ->
         copy_instr (Lop op) i (discard_dead_code n)
     | Iop(Imove | Ireload | Ispill)
       when i.Mach.arg.(0).loc = i.Mach.res.(0).loc ->
-        linear try_info i.Mach.next n
+        linear exit_info i.Mach.next n
     | Iop((Ipoll { return_label = None; _ }) as op) ->
         (* If the poll call does not already specify where to jump to after
            the poll (the expected situation in the current implementation),
            absorb any branch after the poll call into the poll call itself.
            This, in particular, optimises polls at the back edges of loops. *)
-        let n = linear try_info i.Mach.next n in
+        let n = linear exit_info i.Mach.next n in
         let op, n =
           match n.desc with
           | Lbranch lbl ->
@@ -158,64 +158,62 @@ let linear i n contains_calls =
         in
         copy_instr (Lop op) i n
     | Iop op ->
-        copy_instr (Lop op) i (linear try_info i.Mach.next n)
+        copy_instr (Lop op) i (linear exit_info i.Mach.next n)
     | Ireturn ->
         let n1 = copy_instr Lreturn i (discard_dead_code n) in
         if contains_calls
         then cons_instr Lreloadretaddr n1
         else n1
     | Iifthenelse(test, ifso, ifnot) ->
-        let n1 = linear try_info i.Mach.next n in
+        let n1 = linear exit_info i.Mach.next n in
         begin match (ifso.Mach.desc, ifnot.Mach.desc, n1.desc) with
           Iend, _, Lbranch lbl ->
-            copy_instr (Lcondbranch(test, lbl)) i (linear try_info ifnot n1)
+            copy_instr (Lcondbranch(test, lbl)) i (linear exit_info ifnot n1)
         | _, Iend, Lbranch lbl ->
             copy_instr
               (Lcondbranch(invert_test test, lbl))
               i
-              (linear try_info ifso n1)
+              (linear exit_info ifso n1)
         | Iexit nfail1, Iexit nfail2, _
-          when is_next_catch try_info nfail1
-            && local_exit try_info nfail2 ->
-            let lbl2 = find_exit_label try_info nfail2 in
+          when is_next_catch exit_info nfail1
+            && local_exit exit_info nfail2 ->
+            let lbl2 = find_exit_label exit_info nfail2 in
             copy_instr
               (Lcondbranch (invert_test test, lbl2))
               i
-              (linear try_info ifso n1)
-        | Iexit nfail, _, _ when local_exit try_info nfail ->
-            let n2 = linear try_info ifnot n1
-            and lbl = find_exit_label try_info nfail in
+              (linear exit_info ifso n1)
+        | Iexit nfail, _, _ when local_exit exit_info nfail ->
+            let n2 = linear exit_info ifnot n1
+            and lbl = find_exit_label exit_info nfail in
             copy_instr (Lcondbranch(test, lbl)) i n2
-        | _,  Iexit nfail, _ when local_exit try_info nfail ->
-            let n2 = linear try_info ifso n1 in
-            let lbl = find_exit_label try_info nfail in
+        | _,  Iexit nfail, _ when local_exit exit_info nfail ->
+            let n2 = linear exit_info ifso n1 in
+            let lbl = find_exit_label exit_info nfail in
             copy_instr (Lcondbranch(invert_test test, lbl)) i n2
         | Iend, _, _ ->
             let (lbl_end, n2) = get_label n1 in
             copy_instr
               (Lcondbranch(test, lbl_end))
               i
-              (linear try_info ifnot n2)
+              (linear exit_info ifnot n2)
         | _,  Iend, _ ->
             let (lbl_end, n2) = get_label n1 in
             copy_instr (Lcondbranch(invert_test test, lbl_end)) i
-                       (linear try_info ifso n2)
+                       (linear exit_info ifso n2)
         | _, _, _ ->
           (* Should attempt branch prediction here *)
             let (lbl_end, n2) = get_label n1 in
-            let (lbl_else, nelse) =
-              get_label (linear try_info ifnot n2) in
+            let (lbl_else, nelse) = get_label (linear exit_info ifnot n2) in
             copy_instr (Lcondbranch(invert_test test, lbl_else)) i
-              (linear try_info ifso (add_branch lbl_end nelse))
+              (linear exit_info ifso (add_branch lbl_end nelse))
         end
     | Iswitch(index, cases) ->
         let lbl_cases = Array.make (Array.length cases) 0 in
-        let (lbl_end, n1) =
-          get_label(linear try_info i.Mach.next n) in
+        let (lbl_end, n1) = get_label(linear exit_info i.Mach.next n) in
         let n2 = ref (discard_dead_code n1) in
         for i = Array.length cases - 1 downto 0 do
           let case_linear =
-            linear try_info cases.(i) (add_branch lbl_end !n2) in
+            linear exit_info cases.(i) (add_branch lbl_end !n2) in
           let (lbl_case, ncase) = get_label case_linear in
           lbl_cases.(i) <- lbl_case;
           n2 := discard_dead_code ncase
@@ -232,8 +230,7 @@ let linear i n contains_calls =
         end else
           copy_instr (Lswitch(Array.map (fun n -> lbl_cases.(n)) index)) i !n2
     | Icatch(_rec_flag, handlers, body) ->
-        let (lbl_end, n1) =
-          get_label(linear try_info i.Mach.next n) in
+        let (lbl_end, n1) = get_label(linear exit_info i.Mach.next n) in
         (* CR mshinwell for pchambart:
            1. rename "io"
            2. Make sure the test cases cover the "Iend" cases too *)
@@ -243,43 +240,41 @@ let linear i n contains_calls =
             | _ -> Cmm.new_label ())
             handlers in
         let exit_label_add = List.map2
-            (fun (nfail, _) lbl -> (nfail, (lbl, try_info.try_depth)))
+            (fun (nfail, _) lbl -> (nfail, (lbl, exit_info.try_depth)))
             handlers labels_at_entry_to_handlers in
-        let try_info =
-          { try_info with exit_label = exit_label_add @ try_info.exit_label }
+        let exit_info =
+          { exit_info with exit_label = exit_label_add @ exit_info.exit_label }
         in
         let n2 = List.fold_left2 (fun n (_nfail, handler) lbl_handler ->
             match handler.Mach.desc with
             | Iend -> n
             | _ ->
                 cons_instr (Llabel lbl_handler)
-                  (linear try_info handler (add_branch lbl_end n)))
+                  (linear exit_info handler (add_branch lbl_end n)))
             n1 handlers labels_at_entry_to_handlers
         in
-        let n3 = linear try_info body (add_branch lbl_end n2) in
+        let n3 = linear exit_info body (add_branch lbl_end n2) in
         n3
     | Iexit nfail ->
-        let lbl, t = find_exit_label_try_depth try_info nfail in
+        let lbl, t = find_exit_label_try_depth exit_info nfail in
         assert (i.Mach.next.desc = Mach.Iend);
-        let delta_traps = try_info.try_depth - t in
+        let delta_traps = exit_info.try_depth - t in
         let n1 = adjust_trap_depth delta_traps n in
         let rec loop i tt =
           if t = tt then i
           else loop (cons_instr Lpoptrap i) (tt - 1)
         in
-        loop (add_branch lbl n1) try_info.try_depth
+        loop (add_branch lbl n1) exit_info.try_depth
     | Itrywith(body, handler) ->
-        let (lbl_join, n1) =
-          get_label (linear try_info i.Mach.next n) in
+        let (lbl_join, n1) = get_label (linear exit_info i.Mach.next n) in
         let (lbl_handler, n2) =
-          get_label
-            (cons_instr Lentertrap (linear try_info handler n1))
+          get_label (cons_instr Lentertrap (linear exit_info handler n1))
         in
-        let try_info =
-          { try_info with try_depth = try_info.try_depth + 1 } in
+        let exit_info =
+          { exit_info with try_depth = exit_info.try_depth + 1 } in
         assert (i.Mach.arg = [| |]);
         let n3 = cons_instr (Lpushtrap { lbl_handler; })
-                   (linear try_info body
+                   (linear exit_info body
                       (cons_instr
                          Lpoptrap
                          (add_branch lbl_join n2))) in

--- a/asmcomp/linearize.ml
+++ b/asmcomp/linearize.ml
@@ -108,46 +108,44 @@ let add_branch lbl n =
   else
     discard_dead_code n
 
-let try_depth = ref 0
 
 (* Association list: exit handler -> (handler label, try-nesting factor) *)
 
-let exit_label = ref []
-
-let find_exit_label_try_depth k =
+let find_exit_label_try_depth ~exit_label k =
   try
-    List.assoc k !exit_label
+    List.assoc k exit_label
   with
   | Not_found -> Misc.fatal_error "Linearize.find_exit_label"
 
-let find_exit_label k =
-  let (label, t) = find_exit_label_try_depth k in
-  assert(t = !try_depth);
+let find_exit_label ~exit_label ~try_depth k =
+  let (label, t) = find_exit_label_try_depth ~exit_label k in
+  assert(t = try_depth);
   label
 
-let is_next_catch n = match !exit_label with
-| (n0,(_,t))::_  when n0=n && t = !try_depth -> true
-| _ -> false
+let is_next_catch ~exit_label ~try_depth n =
+  match exit_label with
+  | (n0,(_,t))::_  when n0=n && t = try_depth -> true
+  | _ -> false
 
-let local_exit k =
-  snd (find_exit_label_try_depth k) = !try_depth
+let local_exit ~exit_label ~try_depth k =
+  snd (find_exit_label_try_depth ~exit_label k) = try_depth
 
 (* Linearize an instruction [i]: add it in front of the continuation [n] *)
 let linear i n contains_calls =
-  let rec linear i n =
+  let rec linear ~exit_label ~try_depth i n =
     match i.Mach.desc with
       Iend -> n
     | Iop(Itailcall_ind | Itailcall_imm _ as op) ->
         copy_instr (Lop op) i (discard_dead_code n)
     | Iop(Imove | Ireload | Ispill)
       when i.Mach.arg.(0).loc = i.Mach.res.(0).loc ->
-        linear i.Mach.next n
+        linear ~exit_label ~try_depth i.Mach.next n
     | Iop((Ipoll { return_label = None; _ }) as op) ->
         (* If the poll call does not already specify where to jump to after
            the poll (the expected situation in the current implementation),
            absorb any branch after the poll call into the poll call itself.
            This, in particular, optimises polls at the back edges of loops. *)
-        let n = linear i.Mach.next n in
+        let n = linear ~exit_label ~try_depth i.Mach.next n in
         let op, n =
           match n.desc with
           | Lbranch lbl ->
@@ -156,53 +154,68 @@ let linear i n contains_calls =
         in
         copy_instr (Lop op) i n
     | Iop op ->
-        copy_instr (Lop op) i (linear i.Mach.next n)
+        copy_instr (Lop op) i (linear ~exit_label ~try_depth i.Mach.next n)
     | Ireturn ->
         let n1 = copy_instr Lreturn i (discard_dead_code n) in
         if contains_calls
         then cons_instr Lreloadretaddr n1
         else n1
     | Iifthenelse(test, ifso, ifnot) ->
-        let n1 = linear i.Mach.next n in
+        let n1 = linear ~exit_label ~try_depth i.Mach.next n in
         begin match (ifso.Mach.desc, ifnot.Mach.desc, n1.desc) with
           Iend, _, Lbranch lbl ->
-            copy_instr (Lcondbranch(test, lbl)) i (linear ifnot n1)
-        | _, Iend, Lbranch lbl ->
-            copy_instr (Lcondbranch(invert_test test, lbl)) i (linear ifso n1)
-        | Iexit nfail1, Iexit nfail2, _
-              when is_next_catch nfail1 && local_exit nfail2 ->
-            let lbl2 = find_exit_label nfail2 in
             copy_instr
-              (Lcondbranch (invert_test test, lbl2)) i (linear ifso n1)
-        | Iexit nfail, _, _ when local_exit nfail ->
-            let n2 = linear ifnot n1
-            and lbl = find_exit_label nfail in
+              (Lcondbranch(test, lbl))
+              i
+              (linear ~exit_label ~try_depth ifnot n1)
+        | _, Iend, Lbranch lbl ->
+            copy_instr
+              (Lcondbranch(invert_test test, lbl))
+              i
+              (linear ~exit_label ~try_depth ifso n1)
+        | Iexit nfail1, Iexit nfail2, _
+          when is_next_catch ~exit_label ~try_depth nfail1
+            && local_exit ~exit_label ~try_depth nfail2 ->
+            let lbl2 = find_exit_label ~exit_label ~try_depth nfail2 in
+            copy_instr
+              (Lcondbranch (invert_test test, lbl2))
+              i
+              (linear ~exit_label ~try_depth ifso n1)
+        | Iexit nfail, _, _ when local_exit ~exit_label ~try_depth nfail ->
+            let n2 = linear ~exit_label ~try_depth ifnot n1
+            and lbl = find_exit_label ~exit_label ~try_depth nfail in
             copy_instr (Lcondbranch(test, lbl)) i n2
-        | _,  Iexit nfail, _ when local_exit nfail ->
-            let n2 = linear ifso n1 in
-            let lbl = find_exit_label nfail in
+        | _,  Iexit nfail, _ when local_exit ~exit_label ~try_depth nfail ->
+            let n2 = linear ~exit_label ~try_depth ifso n1 in
+            let lbl = find_exit_label ~exit_label ~try_depth nfail in
             copy_instr (Lcondbranch(invert_test test, lbl)) i n2
         | Iend, _, _ ->
             let (lbl_end, n2) = get_label n1 in
-            copy_instr (Lcondbranch(test, lbl_end)) i (linear ifnot n2)
+            copy_instr
+              (Lcondbranch(test, lbl_end))
+              i
+              (linear ~exit_label ~try_depth ifnot n2)
         | _,  Iend, _ ->
             let (lbl_end, n2) = get_label n1 in
             copy_instr (Lcondbranch(invert_test test, lbl_end)) i
-                       (linear ifso n2)
+                       (linear ~exit_label ~try_depth ifso n2)
         | _, _, _ ->
           (* Should attempt branch prediction here *)
             let (lbl_end, n2) = get_label n1 in
-            let (lbl_else, nelse) = get_label (linear ifnot n2) in
+            let (lbl_else, nelse) =
+              get_label (linear ~exit_label ~try_depth ifnot n2) in
             copy_instr (Lcondbranch(invert_test test, lbl_else)) i
-              (linear ifso (add_branch lbl_end nelse))
+              (linear ~exit_label ~try_depth ifso (add_branch lbl_end nelse))
         end
     | Iswitch(index, cases) ->
         let lbl_cases = Array.make (Array.length cases) 0 in
-        let (lbl_end, n1) = get_label(linear i.Mach.next n) in
+        let (lbl_end, n1) =
+          get_label(linear ~exit_label ~try_depth i.Mach.next n) in
         let n2 = ref (discard_dead_code n1) in
         for i = Array.length cases - 1 downto 0 do
-          let (lbl_case, ncase) =
-                  get_label(linear cases.(i) (add_branch lbl_end !n2)) in
+          let case_linear =
+            linear ~exit_label ~try_depth cases.(i) (add_branch lbl_end !n2) in
+          let (lbl_case, ncase) = get_label case_linear in
           lbl_cases.(i) <- lbl_case;
           n2 := discard_dead_code ncase
         done;
@@ -218,7 +231,8 @@ let linear i n contains_calls =
         end else
           copy_instr (Lswitch(Array.map (fun n -> lbl_cases.(n)) index)) i !n2
     | Icatch(_rec_flag, handlers, body) ->
-        let (lbl_end, n1) = get_label(linear i.Mach.next n) in
+        let (lbl_end, n1) =
+          get_label(linear ~exit_label ~try_depth i.Mach.next n) in
         (* CR mshinwell for pchambart:
            1. rename "io"
            2. Make sure the test cases cover the "Iend" cases too *)
@@ -228,48 +242,48 @@ let linear i n contains_calls =
             | _ -> Cmm.new_label ())
             handlers in
         let exit_label_add = List.map2
-            (fun (nfail, _) lbl -> (nfail, (lbl, !try_depth)))
+            (fun (nfail, _) lbl -> (nfail, (lbl, try_depth)))
             handlers labels_at_entry_to_handlers in
-        let previous_exit_label = !exit_label in
-        exit_label := exit_label_add @ !exit_label;
+        let exit_label = exit_label_add @ exit_label in
         let n2 = List.fold_left2 (fun n (_nfail, handler) lbl_handler ->
             match handler.Mach.desc with
             | Iend -> n
-            | _ -> cons_instr (Llabel lbl_handler)
-                     (linear handler (add_branch lbl_end n)))
+            | _ ->
+                cons_instr (Llabel lbl_handler)
+                  (linear ~exit_label ~try_depth handler (add_branch lbl_end n)))
             n1 handlers labels_at_entry_to_handlers
         in
-        let n3 = linear body (add_branch lbl_end n2) in
-        exit_label := previous_exit_label;
+        let n3 = linear ~exit_label ~try_depth body (add_branch lbl_end n2) in
         n3
     | Iexit nfail ->
-        let lbl, t = find_exit_label_try_depth nfail in
+        let lbl, t = find_exit_label_try_depth ~exit_label nfail in
         assert (i.Mach.next.desc = Mach.Iend);
-        let delta_traps = !try_depth - t in
+        let delta_traps = try_depth - t in
         let n1 = adjust_trap_depth delta_traps n in
         let rec loop i tt =
           if t = tt then i
           else loop (cons_instr Lpoptrap i) (tt - 1)
         in
-        loop (add_branch lbl n1) !try_depth
+        loop (add_branch lbl n1) try_depth
     | Itrywith(body, handler) ->
-        let (lbl_join, n1) = get_label (linear i.Mach.next n) in
+        let (lbl_join, n1) =
+          get_label (linear ~exit_label ~try_depth i.Mach.next n) in
         let (lbl_handler, n2) =
-          get_label (cons_instr Lentertrap (linear handler n1))
+          get_label
+            (cons_instr Lentertrap (linear ~exit_label ~try_depth handler n1))
         in
-        incr try_depth;
+        let try_depth = succ try_depth in
         assert (i.Mach.arg = [| |]);
         let n3 = cons_instr (Lpushtrap { lbl_handler; })
-                   (linear body
+                   (linear ~exit_label ~try_depth body
                       (cons_instr
                          Lpoptrap
                          (add_branch lbl_join n2))) in
-        decr try_depth;
         n3
 
     | Iraise k ->
         copy_instr (Lraise k) i (discard_dead_code n)
-  in linear i n
+  in linear ~exit_label:[] ~try_depth:0 i n
 
 let add_prologue first_insn prologue_required =
   let tailrec_entry_point_label = Cmm.new_label () in


### PR DESCRIPTION
Remove two global variables from linearize (`try_depth` and `exit_label`). Instead we pass them as a new record `exit_info` into the recursive structure of linearize.

This means we no longer maintain the hidden invariant that upon exit from `linear`, `try_depth` and `exit_label` are reset to their initial values.