### PR TITLE
Remove unused `#define Context_needs_padding` from `stack.h`

### DIFF
--- a/runtime/caml/stack.h
+++ b/runtime/caml/stack.h
@@ -68,7 +68,6 @@
 #define Wosize_gc_regs (2 + 24 /* int regs */ + 24 /* float regs */)
 #define Saved_return_address(sp) *((intnat *)((sp) - 8))
 #define Pop_frame_pointer(sp) sp += sizeof(value)
-#define Context_needs_padding /* keep stack 16-byte aligned */
 #endif
 
 #ifdef TARGET_riscv


### PR DESCRIPTION
Follows-up a point in #10831. `Context_needs_padding` no longer has meaning (and wasn't needed in #10972 for the arm64 backend). The use of the macro itself was completely removed in #11059 as part of the documentation updates.