### PR TITLE
Bytesections: cleanup API

### DIFF
--- a/.depend
+++ b/.depend
@@ -2138,12 +2138,15 @@ bytecomp/instruct.cmi : \
     typing/env.cmi
 bytecomp/meta.cmo : \
     bytecomp/instruct.cmi \
+    bytecomp/bytesections.cmi \
     bytecomp/meta.cmi
 bytecomp/meta.cmx : \
     bytecomp/instruct.cmx \
+    bytecomp/bytesections.cmx \
     bytecomp/meta.cmi
 bytecomp/meta.cmi : \
-    bytecomp/instruct.cmi
+    bytecomp/instruct.cmi \
+    bytecomp/bytesections.cmi
 bytecomp/opcodes.cmo : \
     bytecomp/opcodes.cmi
 bytecomp/opcodes.cmx : \

--- a/Changes
+++ b/Changes
@@ -475,8 +475,8 @@ Working version
 - #11569: Remove hash type encoding
   (Hyunggyu Jang, review by Gabriel Scherer and Florian Angeletti)
 
-- #11601, #11612, #11628, #11613: Clean up some global state handling
-  in emitcode, bytepackager, bytegen, spill.
+- #11601, #11612, #11628, #11613, #11623: Clean up some global state handling
+  in emitcode, bytepackager, bytegen, bytesections, spill.
   (Hugo Heuzard, Stefan Muenzel, review by Vincent Laviron, Gabriel Scherer
    and Nathanaëlle Courant)
 

--- a/bytecomp/bytelink.ml
+++ b/bytecomp/bytelink.ml
@@ -339,7 +339,7 @@ let link_bytecode ?final_name tolink exec_name standalone =
          | Not_found -> raise (Error (File_not_found header))
          | Sys_error msg -> raise (Error (Camlheader (header, msg)))
        end;
-       Bytesections.init_record outchan;
+       let toc_writer = Bytesections.init_record outchan in
        (* The path to the bytecode interpreter (in use_runtime mode) *)
        if String.length !Clflags.use_runtime > 0 && !Clflags.with_runtime then
        begin
@@ -354,7 +354,7 @@ let link_bytecode ?final_name tolink exec_name standalone =
          in
          output_string outchan runtime;
          output_char outchan '\n';
-         Bytesections.record outchan "RNTM"
+         Bytesections.record toc_writer Bytesections.Name.RNTM
        end;
        (* The bytecode *)
        let start_code = pos_out outchan in
@@ -376,37 +376,37 @@ let link_bytecode ?final_name tolink exec_name standalone =
        (* The final STOP instruction *)
        output_byte outchan Opcodes.opSTOP;
        output_byte outchan 0; output_byte outchan 0; output_byte outchan 0;
-       Bytesections.record outchan "CODE";
+       Bytesections.record toc_writer CODE;
        (* DLL stuff *)
        if standalone then begin
          (* The extra search path for DLLs *)
          output_string outchan (concat_null_terminated !Clflags.dllpaths);
-         Bytesections.record outchan "DLPT";
+         Bytesections.record toc_writer DLPT;
          (* The names of the DLLs *)
          output_string outchan (concat_null_terminated sharedobjs);
-         Bytesections.record outchan "DLLS"
+         Bytesections.record toc_writer DLLS
        end;
        (* The names of all primitives *)
        Symtable.output_primitive_names outchan;
-       Bytesections.record outchan "PRIM";
+       Bytesections.record toc_writer PRIM;
        (* The table of global data *)
        Emitcode.marshal_to_channel_with_possibly_32bit_compat
          ~filename:final_name ~kind:"bytecode executable"
          outchan (Symtable.initial_global_table());
-       Bytesections.record outchan "DATA";
+       Bytesections.record toc_writer DATA;
        (* The map of global identifiers *)
        Symtable.output_global_map outchan;
-       Bytesections.record outchan "SYMB";
+       Bytesections.record toc_writer SYMB;
        (* CRCs for modules *)
        output_value outchan (extract_crc_interfaces());
-       Bytesections.record outchan "CRCS";
+       Bytesections.record toc_writer CRCS;
        (* Debug info *)
        if !Clflags.debug then begin
          output_debug_info outchan;
-         Bytesections.record outchan "DBUG"
+         Bytesections.record toc_writer DBUG
        end;
        (* The table of contents and the trailer *)
-       Bytesections.write_toc_and_trailer outchan;
+       Bytesections.write_toc_and_trailer toc_writer;
     )
 
 (* Output a string as a C array of unsigned ints *)
@@ -454,15 +454,15 @@ let output_cds_file outfile =
     ~always:(fun () -> close_out outchan)
     ~exceptionally:(fun () -> remove_file outfile)
     (fun () ->
-       Bytesections.init_record outchan;
+       let toc_writer = Bytesections.init_record outchan in
        (* The map of global identifiers *)
        Symtable.output_global_map outchan;
-       Bytesections.record outchan "SYMB";
+       Bytesections.record toc_writer SYMB;
        (* Debug info *)
        output_debug_info outchan;
-       Bytesections.record outchan "DBUG";
+       Bytesections.record toc_writer DBUG;
        (* The table of contents and the trailer *)
-       Bytesections.write_toc_and_trailer outchan;
+       Bytesections.write_toc_and_trailer toc_writer;
     )
 
 (* Output a bytecode executable as a C file *)
@@ -503,9 +503,9 @@ let link_bytecode_as_c tolink outfile with_main =
        output_string outchan "\n};\n\n";
        (* The sections *)
        let sections =
-         [ "SYMB", Symtable.data_global_map();
-           "PRIM", Obj.repr(Symtable.data_primitive_names());
-           "CRCS", Obj.repr(extract_crc_interfaces()) ] in
+         [ Bytesections.Name.SYMB, Symtable.data_global_map();
+           Bytesections.Name.PRIM, Obj.repr(Symtable.data_primitive_names());
+           Bytesections.Name.CRCS, Obj.repr(extract_crc_interfaces()) ] in
        output_string outchan "static char caml_sections[] = {\n";
        output_data_string outchan
          (Marshal.to_string sections []);

--- a/bytecomp/bytesections.ml
+++ b/bytecomp/bytesections.ml
@@ -15,31 +15,94 @@
 
 (* Handling of sections in bytecode executable files *)
 
-(* List of all sections, in reverse order *)
+module Name = struct
 
-let section_table = ref ([] : (string * int) list)
+  type raw_name = string
+
+  type t =
+    | CODE (** bytecode *)
+    | CRCS (** crcs for modules *)
+    | DATA (** global data (constant) *)
+    | DBUG (** debug info *)
+    | DLLS (** dll names *)
+    | DLPT (** dll paths *)
+    | PRIM (** primitives names *)
+    | RNTM (** The path to the bytecode interpreter (use_runtime mode) *)
+    | SYMB (** global identifiers *)
+    | Other of raw_name
+
+  let of_string name =
+    match name with
+    | "CODE" -> CODE
+    | "DLPT" -> DLPT
+    | "DLLS" -> DLLS
+    | "DATA" -> DATA
+    | "PRIM" -> PRIM
+    | "SYMB" -> SYMB
+    | "DBUG" -> DBUG
+    | "CRCS" -> CRCS
+    | "RNTM" -> RNTM
+    | name   ->
+        if String.length name <> 4 then
+          invalid_arg "Bytesections.Name.of_string: must be of size 4";
+        Other name
+
+  let to_string = function
+    | CODE -> "CODE"
+    | DLPT -> "DLPT"
+    | DLLS -> "DLLS"
+    | DATA -> "DATA"
+    | PRIM -> "PRIM"
+    | SYMB -> "SYMB"
+    | DBUG -> "DBUG"
+    | CRCS -> "CRCS"
+    | RNTM -> "RNTM"
+    | Other n -> n
+end
+
+type section_entry = {
+  name : Name.t;
+  pos  : int;
+  len  : int;
+}
+
+type section_table = {
+   sections : section_entry list;
+   first_pos : int
+}
 
 (* Recording sections *)
+type toc_writer = {
+  (* List of all sections, in reverse order *)
+  mutable section_table_rev : section_entry list;
+  mutable section_prev : int;
+  outchan : out_channel;
+}
 
-let section_beginning = ref 0
-
-let init_record outchan =
-  section_beginning := pos_out outchan;
-  section_table := []
-
-let record outchan name =
+let init_record outchan : toc_writer =
   let pos = pos_out outchan in
-  section_table := (name, pos - !section_beginning) :: !section_table;
-  section_beginning := pos
+  { section_prev = pos;
+    section_table_rev = [];
+    outchan }
 
-let write_toc_and_trailer outchan =
+let record t name =
+  let pos = pos_out t.outchan in
+  if pos < t.section_prev then
+    invalid_arg "Bytesections.record: out_channel offset moved backward";
+  let entry = {name; pos = t.section_prev; len = pos - t.section_prev} in
+  t.section_table_rev <- entry :: t.section_table_rev;
+  t.section_prev <- pos
+
+let write_toc_and_trailer t =
+  let section_table = List.rev t.section_table_rev in
   List.iter
-    (fun (name, len) ->
-      output_string outchan name; output_binary_int outchan len)
-    (List.rev !section_table);
-  output_binary_int outchan (List.length !section_table);
-  output_string outchan Config.exec_magic_number;
-  section_table := [];
+    (fun {name; pos = _; len} ->
+       let name = Name.to_string name in
+       assert (String.length name = 4);
+      output_string t.outchan name; output_binary_int t.outchan len)
+    section_table;
+  output_binary_int t.outchan (List.length section_table);
+  output_string t.outchan Config.exec_magic_number
 
 (* Read the table of sections from a bytecode executable *)
 
@@ -53,49 +116,49 @@ let read_toc ic =
     really_input_string ic (String.length Config.exec_magic_number)
   in
   if header <> Config.exec_magic_number then raise Bad_magic_number;
-  seek_in ic (pos_trailer - 8 * num_sections);
-  section_table := [];
+  let toc_pos = pos_trailer - 8 * num_sections in
+  seek_in ic toc_pos;
+  let section_table_rev = ref [] in
   for _i = 1 to num_sections do
-    let name = really_input_string ic 4 in
+    let name = Name.of_string (really_input_string ic 4) in
     let len = input_binary_int ic in
-    section_table := (name, len) :: !section_table
-  done
+    section_table_rev := (name, len) :: !section_table_rev
+  done;
+  let first_pos, sections =
+    List.fold_left (fun (pos, l) (name, len) ->
+        let section = {name; pos = pos - len; len} in
+        (pos - len, section :: l)) (toc_pos, []) !section_table_rev
+  in
+  { sections; first_pos }
 
-(* Return the current table of contents *)
+let all t = t.sections
 
-let toc () = List.rev !section_table
+let pos_first_section t = t.first_pos
+
+let find_section t name =
+  let rec find = function
+    | [] -> raise Not_found
+    | {name = n; pos; len} :: rest ->
+        if n = name
+        then pos, len
+        else find rest
+  in find t.sections
 
 (* Position ic at the beginning of the section named "name",
    and return the length of that section.  Raise Not_found if no
    such section exists. *)
 
-let seek_section ic name =
-  let rec seek_sec curr_ofs = function
-    [] -> raise Not_found
-  | (n, len) :: rem ->
-      if n = name
-      then begin seek_in ic (curr_ofs - len); len end
-      else seek_sec (curr_ofs - len) rem in
-  seek_sec (in_channel_length ic - 16 - 8 * List.length !section_table)
-           !section_table
+let seek_section t ic name =
+  let pos, len = find_section t name in
+  seek_in ic pos; len
 
 (* Return the contents of a section, as a string *)
 
-let read_section_string ic name =
-  really_input_string ic (seek_section ic name)
+let read_section_string t ic name =
+  really_input_string ic (seek_section t ic name)
 
 (* Return the contents of a section, as marshalled data *)
 
-let read_section_struct ic name =
-  ignore (seek_section ic name);
+let read_section_struct t ic name =
+  ignore (seek_section t ic name);
   input_value ic
-
-(* Return the position of the beginning of the first section *)
-
-let pos_first_section ic =
-  in_channel_length ic - 16 - 8 * List.length !section_table -
-  List.fold_left (fun total (_name, len) -> total + len) 0 !section_table
-
-let reset () =
-  section_table := [];
-  section_beginning := 0

--- a/bytecomp/bytesections.mli
+++ b/bytecomp/bytesections.mli
@@ -15,43 +15,74 @@
 
 (* Handling of sections in bytecode executable files *)
 
+
+module Name : sig
+
+  type raw_name = private string
+
+  type t =
+    | CODE (** bytecode *)
+    | CRCS (** crcs for modules *)
+    | DATA (** global data (constant) *)
+    | DBUG (** debug info *)
+    | DLLS (** dll names *)
+    | DLPT (** dll paths *)
+    | PRIM (** primitives names *)
+    | RNTM (** The path to the bytecode interpreter (use_runtime mode) *)
+    | SYMB (** global identifiers *)
+    | Other of raw_name
+
+  val of_string : string -> t
+  (** @raise Invalid_argument if the input is not of size 4 *)
+
+  val to_string : t -> string
+end
+
 (** Recording sections written to a bytecode executable file *)
 
-val init_record: out_channel -> unit
-    (* Start recording sections from the current position in out_channel *)
+type toc_writer
 
-val record: out_channel -> string -> unit
-    (* Record the current position in the out_channel as the end of
-       the section with the given name *)
+val init_record: out_channel -> toc_writer
+(** Start recording sections from the current position in out_channel *)
 
-val write_toc_and_trailer: out_channel -> unit
-    (* Write the table of contents and the standard trailer for bytecode
-       executable files *)
+val record: toc_writer -> Name.t -> unit
+(** Record the current position in the out_channel as the end of
+    the section with the given name. *)
+
+val write_toc_and_trailer: toc_writer -> unit
+(** Write the table of contents and the standard trailer for bytecode
+    executable files *)
 
 (** Reading sections from a bytecode executable file *)
 
-val read_toc: in_channel -> unit
-    (* Read the table of sections from a bytecode executable *)
+type section_entry = {
+  name : Name.t; (** name of the section. *)
+  pos  : int;    (** byte offset at which the section starts. *)
+  len  : int;    (** length of the section. *)
+}
+
+type section_table
 
 exception Bad_magic_number
-    (* Raised by [read_toc] if magic number doesn't match *)
 
-val toc: unit -> (string * int) list
-    (* Return the current table of contents as a list of
-       (section name, section length) pairs. *)
+val read_toc: in_channel -> section_table
+(** Read the table of sections from a bytecode executable.
+    Raise [Bad_magic_number] if magic number doesn't match *)
 
-val seek_section: in_channel -> string -> int
-    (* Position the input channel at the beginning of the section named "name",
-       and return the length of that section.  Raise Not_found if no
-       such section exists. *)
+val seek_section: section_table -> in_channel -> Name.t -> int
+(** Position the input channel at the beginning of the section named "name",
+    and return the length of that section.  Raise Not_found if no
+    such section exists. *)
 
-val read_section_string: in_channel -> string -> string
-    (* Return the contents of a section, as a string *)
+val read_section_string: section_table -> in_channel -> Name.t -> string
+(** Return the contents of a section, as a string. *)
 
-val read_section_struct: in_channel -> string -> 'a
-    (* Return the contents of a section, as marshalled data *)
+val read_section_struct: section_table -> in_channel -> Name.t -> 'a
+(** Return the contents of a section, as marshalled data. *)
 
-val pos_first_section: in_channel -> int
-   (* Return the position of the beginning of the first section *)
+val all : section_table -> section_entry list
+(** Returns all [section_entry] from a [section_table] in increasing
+   position order. *)
 
-val reset: unit -> unit
+val pos_first_section : section_table -> int
+(** Return the position of the beginning of the first section *)

--- a/bytecomp/meta.ml
+++ b/bytecomp/meta.ml
@@ -25,5 +25,5 @@ external release_bytecode : bytecode -> unit
                                  = "caml_static_release_bytecode"
 external invoke_traced_function : Obj.raw_data -> Obj.t -> Obj.t -> Obj.t
                                 = "caml_invoke_traced_function"
-external get_section_table : unit -> (string * Obj.t) list
+external get_section_table : unit -> (Bytesections.Name.t * Obj.t) list
                            = "caml_get_section_table"

--- a/bytecomp/meta.mli
+++ b/bytecomp/meta.mli
@@ -27,5 +27,5 @@ external release_bytecode : bytecode -> unit
                                  = "caml_static_release_bytecode"
 external invoke_traced_function : Obj.raw_data -> Obj.t -> Obj.t -> Obj.t
                                 = "caml_invoke_traced_function"
-external get_section_table : unit -> (string * Obj.t) list
+external get_section_table : unit -> (Bytesections.Name.t * Obj.t) list
                            = "caml_get_section_table"

--- a/debugger/symbols.ml
+++ b/debugger/symbols.ml
@@ -56,16 +56,18 @@ let relocate_event orig ev =
 
 let read_symbols' bytecode_file =
   let ic = open_in_bin bytecode_file in
-  begin try
-    Bytesections.read_toc ic;
-    ignore(Bytesections.seek_section ic "SYMB");
-  with Bytesections.Bad_magic_number | Not_found ->
-    prerr_string bytecode_file; prerr_endline " is not a bytecode file.";
-    raise Toplevel
-  end;
+  let toc =
+    try
+      let toc = Bytesections.read_toc ic in
+      ignore(Bytesections.seek_section toc ic Bytesections.Name.SYMB);
+      toc
+    with Bytesections.Bad_magic_number | Not_found ->
+      prerr_string bytecode_file; prerr_endline " is not a bytecode file.";
+      raise Toplevel
+  in
   Symtable.restore_state (input_value ic);
   begin try
-    ignore (Bytesections.seek_section ic "DBUG")
+    ignore (Bytesections.seek_section toc ic Bytesections.Name.DBUG)
   with Not_found ->
     prerr_string bytecode_file; prerr_endline " has no debugging info.";
     raise Toplevel
@@ -84,7 +86,7 @@ let read_symbols' bytecode_file =
       List.fold_left (fun s e -> String.Set.add e s) !dirs (input_value ic)
   done;
   begin try
-    ignore (Bytesections.seek_section ic "CODE")
+    ignore (Bytesections.seek_section toc ic Bytesections.Name.CODE)
   with Not_found ->
     (* The file contains only debugging info,
        loading mode is forced to "manual" *)

--- a/tools/cmpbyt.ml
+++ b/tools/cmpbyt.ml
@@ -18,10 +18,6 @@
 
 open Printf
 
-let readtoc ic =
-  Bytesections.read_toc ic;
-  (Bytesections.toc(), Bytesections.pos_first_section ic)
-
 type cmpresult = Same | Differ of int
 
 let rec cmpbytes ic1 ic2 len ofs =
@@ -30,25 +26,24 @@ let rec cmpbytes ic1 ic2 len ofs =
     if c1 = c2 then cmpbytes ic1 ic2 (len - 1) (ofs + 1) else Differ ofs
   end
 
-let skip_section name =
-  name = "DBUG"
+let skip_section (name : Bytesections.Name.t) =
+  match name with
+  | DBUG -> true
+  | _ -> false
 
 let cmpbyt file1 file2 =
+  let open Bytesections in
   let ic1 = open_in_bin file1 in
-  let (toc1, pos1) = readtoc ic1 in
+  let toc1 = Bytesections.read_toc ic1 |> Bytesections.all in
   let ic2 = open_in_bin file2 in
-  let (toc2, pos2) = readtoc ic2 in
-  seek_in ic1 pos1;
-  seek_in ic2 pos2;
+  let toc2 = Bytesections.read_toc ic2 |> Bytesections.all in
   let rec cmpsections t1 t2 =
     match t1, t2 with
     | [], [] ->
         true
-    | (name1, len1) :: t1, t2  when skip_section name1 ->
-        seek_in ic1 (pos_in ic1 + len1);
-         cmpsections t1 t2
-    | t1, (name2, len2) :: t2  when skip_section name2 ->
-        seek_in ic2 (pos_in ic2 + len2);
+    | s1 :: t1, t2  when skip_section s1.name ->
+        cmpsections t1 t2
+    | t1, s2 :: t2  when skip_section s2.name ->
         cmpsections t1 t2
     | [], _  ->
         eprintf "%s has more sections than %s\n" file2 file1;
@@ -56,17 +51,21 @@ let cmpbyt file1 file2 =
     | _,  [] ->
         eprintf "%s has more sections than %s\n" file1 file2;
         false
-    | (name1, len1) :: t1, (name2, len2) :: t2 ->
+    | s1 :: t1, s2 :: t2 ->
+        let name1 = Bytesections.Name.to_string s1.name
+        and name2 = Bytesections.Name.to_string s2.name in
         if name1 <> name2 then begin
           eprintf "Section mismatch: %s (in %s) / %s (in %s)\n"
                   name1 file1 name2 file2;
           false
-        end else if len1 <> len2 then begin
+        end else if s1.len <> s2.len then begin
           eprintf "Length of section %s differ: %d (in %s) / %d (in %s)\n"
-                  name1 len1 file1 len2 file2;
+                  name1 s1.len file1 s2.len file2;
           false
         end else begin
-          match cmpbytes ic1 ic2 len1 0 with
+          seek_in ic1 s1.pos;
+          seek_in ic2 s2.pos;
+          match cmpbytes ic1 ic2 s1.len 0 with
           | Differ ofs ->
               eprintf "Files %s and %s differ: section %s, offset %d\n"
                       file1 file2 name1 ofs;

--- a/tools/dumpobj.ml
+++ b/tools/dumpobj.ml
@@ -47,7 +47,6 @@ let inputs ic =
 (* Global variables *)
 
 type global_table_entry =
-    Empty
   | Global of Ident.t
   | Constant of Obj.t
 
@@ -152,7 +151,6 @@ let print_getglobal_name ic =
     else match !globals.(n) with
            Global id -> print_string(Ident.name id)
          | Constant obj -> print_obj obj
-         | _ -> print_string "???"
   end
 
 let print_setglobal_name ic =
@@ -480,32 +478,31 @@ let dump_obj ic =
 (* Print an executable file *)
 
 let dump_exe ic =
-  Bytesections.read_toc ic;
-  (* Read the primitive table from an executable *)
-  let prims = Bytesections.read_section_string ic "PRIM" in
+  let toc = Bytesections.read_toc ic in
+(* Read the primitive table from an executable *)
+  let prims = Bytesections.read_section_string toc ic Bytesections.Name.PRIM in
   primitives := Array.of_list (Misc.split_null_terminated prims);
-  ignore(Bytesections.seek_section ic "DATA");
-  let init_data = (input_value ic : Obj.t array) in
-  globals := Array.make (Array.length init_data) Empty;
-  for i = 0 to Array.length init_data - 1 do
-    !globals.(i) <- Constant (init_data.(i))
-  done;
-  ignore(Bytesections.seek_section ic "SYMB");
-  let sym_table = (input_value ic : Symtable.global_map) in
+  let init_data : Obj.t array =
+    Bytesections.read_section_struct toc ic Bytesections.Name.DATA in
+  globals := Array.map (fun x -> Constant x) init_data;
+  let sym_table : Symtable.global_map =
+    Bytesections.read_section_struct toc ic Bytesections.Name.SYMB in
   Symtable.iter_global_map
     (fun id pos -> !globals.(pos) <- Global id) sym_table;
-  begin try
-    ignore (Bytesections.seek_section ic "DBUG");
-    let num_eventlists = input_binary_int ic in
-    for _i = 1 to num_eventlists do
-      let orig = input_binary_int ic in
-      let evl = (input_value ic : debug_event list) in
-      ignore (input_value ic); (* Skip the list of absolute directory names *)
-      record_events orig evl
-    done
-  with Not_found -> ()
+  begin
+    match Bytesections.seek_section toc ic Bytesections.Name.DBUG with
+    | exception Not_found -> ()
+    | (_ : int) ->
+        let num_eventlists = input_binary_int ic in
+        for _i = 1 to num_eventlists do
+          let orig = input_binary_int ic in
+          let evl = (input_value ic : debug_event list) in
+          (* Skip the list of absolute directory names *)
+          ignore (input_value ic);
+          record_events orig evl
+        done
   end;
-  let code_size = Bytesections.seek_section ic "CODE" in
+  let code_size = Bytesections.seek_section toc ic Bytesections.Name.CODE in
   print_code ic code_size
 
 let arg_list = [


### PR DESCRIPTION
- Writting and reading `bytesections` no longer interfere (global states are removed) 
- Reading a `bytesections` now returns more information (a `section_table`). In particular, users now have access to the starting position of the sections and no longer have to compute it by accumulating individual section lengths.  
```ocaml
type section_entry = {
  name : string;
  pos  : int;
  len  : int;
}

type section_table = section_entry list
```
- Introduce a new module `Bytesections.Name` that expose all the section names used in the codebase. It reduces the risk of typos and gives a natural location to document all sections. 
- remove `toc` (`read_toc` now return the `section_table`)
- ~~remove `pos_first_section` which was mainly used to recompute section positions.~~
- remove `reset` as we no longer use global state
- fix the codebase accordingly
- ~~fix a bug in tools/stripdebug.ml (the bug doesn't cause problem because of the order in which the sections are encountered)~~