### PR TITLE
Improve symtable API

### DIFF
--- a/Changes
+++ b/Changes
@@ -137,7 +137,8 @@ Working version
 - #11446: document switch compilation (lambda/switch.ml)
   (Gabriel Scherer, review by Luc Maranget and Vincent Laviron)
 
-- #11601, #11612: Clean up some global state handling in emitcode, spill.
+- #11601, #11612, #11623: Clean up some global state handling in
+  emitcode, bytesections, spill.
   (Hugo Heuzard, Stefan Muenzel review by Vincent Laviron and Gabriel Scherer)
 
 - #11627: use return values instead of globals for linear scan intervals

--- a/bytecomp/bytelink.ml
+++ b/bytecomp/bytelink.ml
@@ -354,7 +354,7 @@ let link_bytecode ?final_name tolink exec_name standalone =
          in
          output_string outchan runtime;
          output_char outchan '\n';
-         Bytesections.record toc_writer "RNTM"
+         Bytesections.record toc_writer Bytesections.Name.rntm
        end;
        (* The bytecode *)
        let start_code = pos_out outchan in
@@ -376,34 +376,34 @@ let link_bytecode ?final_name tolink exec_name standalone =
        (* The final STOP instruction *)
        output_byte outchan Opcodes.opSTOP;
        output_byte outchan 0; output_byte outchan 0; output_byte outchan 0;
-       Bytesections.record toc_writer "CODE";
+       Bytesections.record toc_writer Bytesections.Name.code;
        (* DLL stuff *)
        if standalone then begin
          (* The extra search path for DLLs *)
          output_stringlist outchan !Clflags.dllpaths;
-         Bytesections.record toc_writer "DLPT";
+         Bytesections.record toc_writer Bytesections.Name.dlpt;
          (* The names of the DLLs *)
          output_stringlist outchan sharedobjs;
-         Bytesections.record toc_writer "DLLS"
+         Bytesections.record toc_writer Bytesections.Name.dlls
        end;
        (* The names of all primitives *)
        Symtable.output_primitive_names outchan;
-       Bytesections.record toc_writer "PRIM";
+       Bytesections.record toc_writer Bytesections.Name.prim;
        (* The table of global data *)
        Emitcode.marshal_to_channel_with_possibly_32bit_compat
          ~filename:final_name ~kind:"bytecode executable"
          outchan (Symtable.initial_global_table());
-       Bytesections.record toc_writer "DATA";
+       Bytesections.record toc_writer Bytesections.Name.data;
        (* The map of global identifiers *)
        Symtable.output_global_map outchan;
-       Bytesections.record toc_writer "SYMB";
+       Bytesections.record toc_writer Bytesections.Name.symb;
        (* CRCs for modules *)
        output_value outchan (extract_crc_interfaces());
-       Bytesections.record toc_writer "CRCS";
+       Bytesections.record toc_writer Bytesections.Name.crcs;
        (* Debug info *)
        if !Clflags.debug then begin
          output_debug_info outchan;
-         Bytesections.record toc_writer "DBUG"
+         Bytesections.record toc_writer Bytesections.Name.dbug
        end;
        (* The table of contents and the trailer *)
        Bytesections.write_toc_and_trailer toc_writer;
@@ -457,10 +457,10 @@ let output_cds_file outfile =
        let toc_writer = Bytesections.init_record outchan in
        (* The map of global identifiers *)
        Symtable.output_global_map outchan;
-       Bytesections.record toc_writer "SYMB";
+       Bytesections.record toc_writer Bytesections.Name.symb;
        (* Debug info *)
        output_debug_info outchan;
-       Bytesections.record toc_writer "DBUG";
+       Bytesections.record toc_writer Bytesections.Name.dbug;
        (* The table of contents and the trailer *)
        Bytesections.write_toc_and_trailer toc_writer;
     )

--- a/bytecomp/bytelink.ml
+++ b/bytecomp/bytelink.ml
@@ -339,7 +339,7 @@ let link_bytecode ?final_name tolink exec_name standalone =
          | Not_found -> raise (Error (File_not_found header))
          | Sys_error msg -> raise (Error (Camlheader (header, msg)))
        end;
-       Bytesections.init_record outchan;
+       let toc_writer = Bytesections.init_record outchan in
        (* The path to the bytecode interpreter (in use_runtime mode) *)
        if String.length !Clflags.use_runtime > 0 && !Clflags.with_runtime then
        begin
@@ -354,7 +354,7 @@ let link_bytecode ?final_name tolink exec_name standalone =
          in
          output_string outchan runtime;
          output_char outchan '\n';
-         Bytesections.record outchan "RNTM"
+         Bytesections.record toc_writer "RNTM"
        end;
        (* The bytecode *)
        let start_code = pos_out outchan in
@@ -376,37 +376,37 @@ let link_bytecode ?final_name tolink exec_name standalone =
        (* The final STOP instruction *)
        output_byte outchan Opcodes.opSTOP;
        output_byte outchan 0; output_byte outchan 0; output_byte outchan 0;
-       Bytesections.record outchan "CODE";
+       Bytesections.record toc_writer "CODE";
        (* DLL stuff *)
        if standalone then begin
          (* The extra search path for DLLs *)
          output_stringlist outchan !Clflags.dllpaths;
-         Bytesections.record outchan "DLPT";
+         Bytesections.record toc_writer "DLPT";
          (* The names of the DLLs *)
          output_stringlist outchan sharedobjs;
-         Bytesections.record outchan "DLLS"
+         Bytesections.record toc_writer "DLLS"
        end;
        (* The names of all primitives *)
        Symtable.output_primitive_names outchan;
-       Bytesections.record outchan "PRIM";
+       Bytesections.record toc_writer "PRIM";
        (* The table of global data *)
        Emitcode.marshal_to_channel_with_possibly_32bit_compat
          ~filename:final_name ~kind:"bytecode executable"
          outchan (Symtable.initial_global_table());
-       Bytesections.record outchan "DATA";
+       Bytesections.record toc_writer "DATA";
        (* The map of global identifiers *)
        Symtable.output_global_map outchan;
-       Bytesections.record outchan "SYMB";
+       Bytesections.record toc_writer "SYMB";
        (* CRCs for modules *)
        output_value outchan (extract_crc_interfaces());
-       Bytesections.record outchan "CRCS";
+       Bytesections.record toc_writer "CRCS";
        (* Debug info *)
        if !Clflags.debug then begin
          output_debug_info outchan;
-         Bytesections.record outchan "DBUG"
+         Bytesections.record toc_writer "DBUG"
        end;
        (* The table of contents and the trailer *)
-       Bytesections.write_toc_and_trailer outchan;
+       Bytesections.write_toc_and_trailer toc_writer;
     )
 
 (* Output a string as a C array of unsigned ints *)
@@ -454,15 +454,15 @@ let output_cds_file outfile =
     ~always:(fun () -> close_out outchan)
     ~exceptionally:(fun () -> remove_file outfile)
     (fun () ->
-       Bytesections.init_record outchan;
+       let toc_writer = Bytesections.init_record outchan in
        (* The map of global identifiers *)
        Symtable.output_global_map outchan;
-       Bytesections.record outchan "SYMB";
+       Bytesections.record toc_writer "SYMB";
        (* Debug info *)
        output_debug_info outchan;
-       Bytesections.record outchan "DBUG";
+       Bytesections.record toc_writer "DBUG";
        (* The table of contents and the trailer *)
-       Bytesections.write_toc_and_trailer outchan;
+       Bytesections.write_toc_and_trailer toc_writer;
     )
 
 (* Output a bytecode executable as a C file *)

--- a/bytecomp/bytelink.ml
+++ b/bytecomp/bytelink.ml
@@ -292,11 +292,6 @@ let output_debug_info oc =
     !debug_info;
   debug_info := []
 
-(* Output a list of strings with 0-termination *)
-
-let output_stringlist oc l =
-  List.iter (fun s -> output_string oc s; output_byte oc 0) l
-
 (* Transform a file name into an absolute file name *)
 
 let make_absolute file =
@@ -380,10 +375,10 @@ let link_bytecode ?final_name tolink exec_name standalone =
        (* DLL stuff *)
        if standalone then begin
          (* The extra search path for DLLs *)
-         output_stringlist outchan !Clflags.dllpaths;
+         output_string outchan (concat_null_separated !Clflags.dllpaths);
          Bytesections.record toc_writer Bytesections.Name.dlpt;
          (* The names of the DLLs *)
-         output_stringlist outchan sharedobjs;
+         output_string outchan (concat_null_separated sharedobjs);
          Bytesections.record toc_writer Bytesections.Name.dlls
        end;
        (* The names of all primitives *)

--- a/bytecomp/bytesections.ml
+++ b/bytecomp/bytesections.ml
@@ -15,31 +15,42 @@
 
 (* Handling of sections in bytecode executable files *)
 
-(* List of all sections, in reverse order *)
+type section_entry = {
+  name : string;
+  pos  : int;
+  len  : int;
+}
 
-let section_table = ref ([] : (string * int) list)
+type section_table = section_entry list
 
 (* Recording sections *)
+type toc_writer = {
+  (* List of all sections, in reverse order *)
+  mutable section_table_rev : section_table;
+  mutable section_prev : int;
+  outchan : out_channel;
+}
 
-let section_beginning = ref 0
-
-let init_record outchan =
-  section_beginning := pos_out outchan;
-  section_table := []
-
-let record outchan name =
+let init_record outchan : toc_writer =
   let pos = pos_out outchan in
-  section_table := (name, pos - !section_beginning) :: !section_table;
-  section_beginning := pos
+  { section_prev = pos;
+    section_table_rev = [];
+    outchan }
 
-let write_toc_and_trailer outchan =
+let record t name =
+  let pos = pos_out t.outchan in
+  let entry = {name; pos = t.section_prev; len = pos - t.section_prev} in
+  t.section_table_rev <- entry :: t.section_table_rev;
+  t.section_prev <- pos
+
+let write_toc_and_trailer t =
+  let section_table = List.rev t.section_table_rev in
   List.iter
-    (fun (name, len) ->
-      output_string outchan name; output_binary_int outchan len)
-    (List.rev !section_table);
-  output_binary_int outchan (List.length !section_table);
-  output_string outchan Config.exec_magic_number;
-  section_table := [];
+    (fun {name; pos = _; len} ->
+      output_string t.outchan name; output_binary_int t.outchan len)
+    section_table;
+  output_binary_int t.outchan (List.length section_table);
+  output_string t.outchan Config.exec_magic_number
 
 (* Read the table of sections from a bytecode executable *)
 
@@ -53,49 +64,45 @@ let read_toc ic =
     really_input_string ic (String.length Config.exec_magic_number)
   in
   if header <> Config.exec_magic_number then raise Bad_magic_number;
-  seek_in ic (pos_trailer - 8 * num_sections);
-  section_table := [];
+  let toc_pos = (pos_trailer - 8 * num_sections) in
+  seek_in ic toc_pos;
+  let section_table_rev = ref [] in
   for _i = 1 to num_sections do
     let name = really_input_string ic 4 in
     let len = input_binary_int ic in
-    section_table := (name, len) :: !section_table
-  done
+    section_table_rev := (name, len) :: !section_table_rev
+  done;
+  let _first_section, sections =
+    List.fold_left (fun (pos, l) (name,len) ->
+        let section = {name; pos = pos - len; len} in
+        (pos - len, section :: l)) (toc_pos, []) !section_table_rev
+  in
+  sections
 
-(* Return the current table of contents *)
-
-let toc () = List.rev !section_table
+let find_section t name =
+  let rec find = function
+    | [] -> raise Not_found
+    | {name = n; pos; len} :: rest ->
+        if n = name
+        then pos, len
+        else find rest
+  in find t
 
 (* Position ic at the beginning of the section named "name",
    and return the length of that section.  Raise Not_found if no
    such section exists. *)
 
-let seek_section ic name =
-  let rec seek_sec curr_ofs = function
-    [] -> raise Not_found
-  | (n, len) :: rem ->
-      if n = name
-      then begin seek_in ic (curr_ofs - len); len end
-      else seek_sec (curr_ofs - len) rem in
-  seek_sec (in_channel_length ic - 16 - 8 * List.length !section_table)
-           !section_table
+let seek_section t ic name =
+  let pos, len = find_section t name in
+  seek_in ic pos; len
 
 (* Return the contents of a section, as a string *)
 
-let read_section_string ic name =
-  really_input_string ic (seek_section ic name)
+let read_section_string t ic name =
+  really_input_string ic (seek_section t ic name)
 
 (* Return the contents of a section, as marshalled data *)
 
-let read_section_struct ic name =
-  ignore (seek_section ic name);
+let read_section_struct t ic name =
+  ignore (seek_section t ic name);
   input_value ic
-
-(* Return the position of the beginning of the first section *)
-
-let pos_first_section ic =
-  in_channel_length ic - 16 - 8 * List.length !section_table -
-  List.fold_left (fun total (_name, len) -> total + len) 0 !section_table
-
-let reset () =
-  section_table := [];
-  section_beginning := 0

--- a/bytecomp/bytesections.ml
+++ b/bytecomp/bytesections.ml
@@ -15,6 +15,23 @@
 
 (* Handling of sections in bytecode executable files *)
 
+module Name = struct
+  type t = string
+  let of_string name =
+    if String.length name <> 4 then
+      invalid_arg "Bytesections.Name.of_string: must be of size 4";
+    name
+  let code = of_string "CODE"
+  let dlpt = of_string "DLPT"
+  let dlls = of_string "DLLS"
+  let data = of_string "DATA"
+  let prim = of_string "PRIM"
+  let symb = of_string "SYMB"
+  let dbug = of_string "DBUG"
+  let crcs = of_string "CRCS"
+  let rntm = of_string "RNTM"
+end
+
 type section_entry = {
   name : string;
   pos  : int;
@@ -38,8 +55,6 @@ let init_record outchan : toc_writer =
     outchan }
 
 let record t name =
-  if String.length name <> 4 then
-    invalid_arg "Bytesections.record: section name must be of size 4";
   let pos = pos_out t.outchan in
   if pos < t.section_prev then
     invalid_arg "Bytesections.record: out_channel offset moved backward";
@@ -98,8 +113,7 @@ let find_section t name =
    such section exists. *)
 
 let seek_section t ic name =
-  if String.length name <> 4 then
-    invalid_arg "Bytesections.seek_section: section name must be of size 4";
+  assert (String.length name = 4);
   let pos, len = find_section t name in
   seek_in ic pos; len
 

--- a/bytecomp/bytesections.mli
+++ b/bytecomp/bytesections.mli
@@ -24,7 +24,9 @@ val init_record: out_channel -> toc_writer
 
 val record: toc_writer -> string -> unit
 (** Record the current position in the out_channel as the end of
-    the section with the given name *)
+    the section with the given name.
+
+   @raise Invalid_argument if the name is not of size 4. *)
 
 val write_toc_and_trailer: toc_writer -> unit
 (** Write the table of contents and the standard trailer for bytecode
@@ -32,11 +34,12 @@ val write_toc_and_trailer: toc_writer -> unit
 
 (** Reading sections from a bytecode executable file *)
 
-type section_entry = {
-  name : string;
-  pos  : int;
-  len  : int;
+type section_entry = private {
+  name : string; (** name of the section. *)
+  pos  : int;    (** byte offset at which the section starts. *)
+  len  : int;    (** length of the section. *)
 }
+
 type section_table = section_entry list
 
 exception Bad_magic_number
@@ -48,10 +51,16 @@ val read_toc: in_channel -> section_table
 val seek_section: section_table -> in_channel -> string -> int
 (** Position the input channel at the beginning of the section named "name",
     and return the length of that section.  Raise Not_found if no
-    such section exists. *)
+    such section exists.
+
+   @raise Invalid_argument if the name is not of size 4. *)
 
 val read_section_string: section_table -> in_channel -> string -> string
-(** Return the contents of a section, as a string *)
+(** Return the contents of a section, as a string.
+
+    @raise Invalid_argument if the name is not of size 4. *)
 
 val read_section_struct: section_table -> in_channel -> string -> 'a
-(** Return the contents of a section, as marshalled data *)
+(** Return the contents of a section, as marshalled data
+
+    @raise Invalid_argument if the name is not of size 4. *)

--- a/bytecomp/bytesections.mli
+++ b/bytecomp/bytesections.mli
@@ -17,41 +17,41 @@
 
 (** Recording sections written to a bytecode executable file *)
 
-val init_record: out_channel -> unit
-    (* Start recording sections from the current position in out_channel *)
+type toc_writer
 
-val record: out_channel -> string -> unit
-    (* Record the current position in the out_channel as the end of
-       the section with the given name *)
+val init_record: out_channel -> toc_writer
+(** Start recording sections from the current position in out_channel *)
 
-val write_toc_and_trailer: out_channel -> unit
-    (* Write the table of contents and the standard trailer for bytecode
-       executable files *)
+val record: toc_writer -> string -> unit
+(** Record the current position in the out_channel as the end of
+    the section with the given name *)
+
+val write_toc_and_trailer: toc_writer -> unit
+(** Write the table of contents and the standard trailer for bytecode
+    executable files *)
 
 (** Reading sections from a bytecode executable file *)
 
-val read_toc: in_channel -> unit
-    (* Read the table of sections from a bytecode executable *)
+type section_entry = {
+  name : string;
+  pos  : int;
+  len  : int;
+}
+type section_table = section_entry list
 
 exception Bad_magic_number
-    (* Raised by [read_toc] if magic number doesn't match *)
 
-val toc: unit -> (string * int) list
-    (* Return the current table of contents as a list of
-       (section name, section length) pairs. *)
+val read_toc: in_channel -> section_table
+(** Read the table of sections from a bytecode executable.
+    Raise [Bad_magic_number] if magic number doesn't match *)
 
-val seek_section: in_channel -> string -> int
-    (* Position the input channel at the beginning of the section named "name",
-       and return the length of that section.  Raise Not_found if no
-       such section exists. *)
+val seek_section: section_table -> in_channel -> string -> int
+(** Position the input channel at the beginning of the section named "name",
+    and return the length of that section.  Raise Not_found if no
+    such section exists. *)
 
-val read_section_string: in_channel -> string -> string
-    (* Return the contents of a section, as a string *)
+val read_section_string: section_table -> in_channel -> string -> string
+(** Return the contents of a section, as a string *)
 
-val read_section_struct: in_channel -> string -> 'a
-    (* Return the contents of a section, as marshalled data *)
-
-val pos_first_section: in_channel -> int
-   (* Return the position of the beginning of the first section *)
-
-val reset: unit -> unit
+val read_section_struct: section_table -> in_channel -> string -> 'a
+(** Return the contents of a section, as marshalled data *)

--- a/bytecomp/bytesections.mli
+++ b/bytecomp/bytesections.mli
@@ -15,6 +15,34 @@
 
 (* Handling of sections in bytecode executable files *)
 
+
+module Name : sig
+
+  type t = private string
+
+  val of_string : string -> t
+  (** @raise Invalid_argument if the input is not of size 4 *)
+
+  val code : t (** bytecode *)
+
+  val crcs : t (** crcs for modules *)
+
+  val data : t (** global data (constant) *)
+
+  val dbug : t (** debug info *)
+
+  val dlls : t (** dll names *)
+
+  val dlpt : t (** dll paths *)
+
+  val prim : t (** primitives names *)
+
+  val rntm : t (** The path to the bytecode interpreter (use_runtime mode) *)
+
+  val symb : t (** global identifiers *)
+
+end
+
 (** Recording sections written to a bytecode executable file *)
 
 type toc_writer
@@ -22,11 +50,9 @@ type toc_writer
 val init_record: out_channel -> toc_writer
 (** Start recording sections from the current position in out_channel *)
 
-val record: toc_writer -> string -> unit
+val record: toc_writer -> Name.t -> unit
 (** Record the current position in the out_channel as the end of
-    the section with the given name.
-
-   @raise Invalid_argument if the name is not of size 4. *)
+    the section with the given name. *)
 
 val write_toc_and_trailer: toc_writer -> unit
 (** Write the table of contents and the standard trailer for bytecode
@@ -35,7 +61,7 @@ val write_toc_and_trailer: toc_writer -> unit
 (** Reading sections from a bytecode executable file *)
 
 type section_entry = private {
-  name : string; (** name of the section. *)
+  name : Name.t; (** name of the section. *)
   pos  : int;    (** byte offset at which the section starts. *)
   len  : int;    (** length of the section. *)
 }
@@ -48,19 +74,13 @@ val read_toc: in_channel -> section_table
 (** Read the table of sections from a bytecode executable.
     Raise [Bad_magic_number] if magic number doesn't match *)
 
-val seek_section: section_table -> in_channel -> string -> int
+val seek_section: section_table -> in_channel -> Name.t -> int
 (** Position the input channel at the beginning of the section named "name",
     and return the length of that section.  Raise Not_found if no
-    such section exists.
+    such section exists. *)
 
-   @raise Invalid_argument if the name is not of size 4. *)
+val read_section_string: section_table -> in_channel -> Name.t -> string
+(** Return the contents of a section, as a string. *)
 
-val read_section_string: section_table -> in_channel -> string -> string
-(** Return the contents of a section, as a string.
-
-    @raise Invalid_argument if the name is not of size 4. *)
-
-val read_section_struct: section_table -> in_channel -> string -> 'a
-(** Return the contents of a section, as marshalled data
-
-    @raise Invalid_argument if the name is not of size 4. *)
+val read_section_struct: section_table -> in_channel -> Name.t -> 'a
+(** Return the contents of a section, as marshalled data. *)

--- a/bytecomp/symtable.ml
+++ b/bytecomp/symtable.ml
@@ -294,9 +294,9 @@ let read_sections () =
         (fun () -> ()) }
   with Not_found ->
     let ic = open_in_bin Sys.executable_name in
-    Bytesections.read_toc ic;
-    { read_string = Bytesections.read_section_string ic;
-      read_struct = Bytesections.read_section_struct ic;
+    let section_table = Bytesections.read_toc ic in
+    { read_string = Bytesections.read_section_string section_table ic;
+      read_struct = Bytesections.read_section_struct section_table ic;
       close_reader = fun () -> close_in ic }
 
 (* Initialize the linker for toplevel use *)

--- a/bytecomp/symtable.ml
+++ b/bytecomp/symtable.ml
@@ -127,25 +127,6 @@ let data_primitive_names () =
 let output_primitive_names outchan =
   output_string outchan (data_primitive_names())
 
-open Printf
-
-let output_primitive_table outchan =
-  let prim = all_primitives() in
-  for i = 0 to Array.length prim - 1 do
-    fprintf outchan "extern value %s();\n" prim.(i)
-  done;
-  fprintf outchan "typedef value (*primitive)();\n";
-  fprintf outchan "primitive caml_builtin_cprim[] = {\n";
-  for i = 0 to Array.length prim - 1 do
-    fprintf outchan "  %s,\n" prim.(i)
-  done;
-  fprintf outchan "  (primitive) 0 };\n";
-  fprintf outchan "const char * caml_names_of_builtin_cprim[] = {\n";
-  for i = 0 to Array.length prim - 1 do
-    fprintf outchan "  \"%s\",\n" prim.(i)
-  done;
-  fprintf outchan "  (char *) 0 };\n"
-
 (* Initialization for batch linking *)
 
 let init () =

--- a/bytecomp/symtable.ml
+++ b/bytecomp/symtable.ml
@@ -34,7 +34,18 @@ type error =
 
 exception Error of error
 
-module Num_tbl (M : Map.S) = struct
+module Num_tbl (M : Map.S) : sig
+  type t
+  val empty : t
+  val find : t -> M.key -> int
+  val mem : t -> M.key -> bool
+  val filter : (M.key -> bool) -> t -> t
+  val iter : (M.key -> int -> unit) -> t -> unit
+  val enter : t ref -> M.key -> int
+  val incr : t ref -> int
+  val length : t -> int
+  val extend : t -> int -> t option
+end = struct
 
   type t = {
     cnt: int; (* The next number *)
@@ -46,6 +57,8 @@ module Num_tbl (M : Map.S) = struct
   let find nt key =
     M.find key nt.tbl
 
+  let mem nt key = M.mem key nt.tbl
+
   let enter nt key =
     let n = !nt.cnt in
     nt := { cnt = n + 1; tbl = M.add key n !nt.tbl };
@@ -56,91 +69,114 @@ module Num_tbl (M : Map.S) = struct
     nt := { cnt = n + 1; tbl = !nt.tbl };
     n
 
+  let filter p nt =
+    let newtbl = ref M.empty in
+    M.iter
+      (fun id num -> if p id then newtbl := M.add id num !newtbl)
+      nt.tbl;
+    {cnt = nt.cnt; tbl = !newtbl}
+
+  let iter f nt =
+    M.iter f nt.tbl
+
+  let length nt = nt.cnt
+
+  let extend nt size =
+    if size < nt.cnt
+    then None
+    else Some { nt with cnt = size }
+
 end
 module GlobalMap = Num_tbl(Ident.Map)
 module PrimMap = Num_tbl(Misc.Stdlib.String.Map)
 
-(* Global variables *)
+type state = {
+  global_table : GlobalMap.t ref;
+  mutable literal_table : (int * structured_constant) list;
+  c_prim_table : PrimMap.t ref;
+}
 
-let global_table = ref GlobalMap.empty
-and literal_table = ref([] : (int * structured_constant) list)
+let create_empty () = {
+  global_table = ref GlobalMap.empty;
+  literal_table = [];
+  c_prim_table = ref PrimMap.empty;
+}
 
-let is_global_defined id =
-  Ident.Map.mem id (!global_table).tbl
+let get_globalmap t = !(t.global_table)
 
-let slot_for_getglobal id =
+let set_globalmap t table = t.global_table := table
+
+let is_global_defined t id =
+  GlobalMap.mem !(t.global_table) id
+
+let slot_for_getglobal t id =
   try
-    GlobalMap.find !global_table id
+    GlobalMap.find !(t.global_table) id
   with Not_found ->
     raise(Error(Undefined_global(Ident.name id)))
 
-let slot_for_setglobal id =
-  GlobalMap.enter global_table id
+let slot_for_setglobal t id =
+  GlobalMap.enter t.global_table id
 
-let slot_for_literal cst =
-  let n = GlobalMap.incr global_table in
-  literal_table := (n, cst) :: !literal_table;
+let slot_for_literal t cst =
+  let n = GlobalMap.incr t.global_table in
+  t.literal_table <- (n, cst) :: t.literal_table;
   n
+
+
+let get_global_position state id =
+  slot_for_getglobal state id
 
 (* The C primitives *)
 
-let c_prim_table = ref PrimMap.empty
+let set_prim_table t name =
+  ignore(PrimMap.enter t.c_prim_table name)
 
-let set_prim_table name =
-  ignore(PrimMap.enter c_prim_table name)
-
-let of_prim name =
+let of_prim t name =
   try
-    PrimMap.find !c_prim_table name
+    PrimMap.find !(t.c_prim_table) name
   with Not_found ->
     if !Clflags.custom_runtime || Config.host <> Config.target
        || !Clflags.no_check_prims
     then
-      PrimMap.enter c_prim_table name
+      PrimMap.enter t.c_prim_table name
     else begin
       match Dll.find_primitive name with
       | None -> raise(Error(Unavailable_primitive name))
       | Some Prim_exists ->
-          PrimMap.enter c_prim_table name
+          PrimMap.enter t.c_prim_table name
       | Some (Prim_loaded symb) ->
-          let num = PrimMap.enter c_prim_table name in
+          let num = PrimMap.enter t.c_prim_table name in
           Dll.synchronize_primitive num symb;
           num
     end
 
-let require_primitive name =
-  if name.[0] <> '%' then ignore(of_prim name)
+let require_primitive t name =
+  if name.[0] <> '%' then ignore(of_prim t name)
 
-let all_primitives () =
-  let prim = Array.make !c_prim_table.cnt "" in
-  String.Map.iter (fun name number -> prim.(number) <- name) !c_prim_table.tbl;
-  prim
-
-let data_primitive_names () =
-  all_primitives()
-  |> Array.to_list
-  |> concat_null_separated
-
-let output_primitive_names outchan =
-  output_string outchan (data_primitive_names())
+let all_primitives t =
+  let a = Array.make (PrimMap.length !(t.c_prim_table)) "" in
+  PrimMap.iter (fun key number -> a.(number) <- key) !(t.c_prim_table);
+  Array.to_list a
 
 (* Initialization for batch linking *)
 
-let init () =
-  (* Enter the predefined exceptions *)
+let create_for_linker () =
+  let t = create_empty () in
+  (* Enter the predefined values *)
   Array.iteri
     (fun i name ->
       let id =
         try List.assoc name Predef.builtin_values
         with Not_found -> fatal_error "Symtable.init" in
-      let c = slot_for_setglobal id in
+      let c = slot_for_setglobal t id in
       let cst = Const_block
           (Obj.object_tag,
            [Const_base(Const_string (name, Location.none,None));
             Const_base(Const_int (-i-1))
            ])
       in
-      literal_table := (c, cst) :: !literal_table)
+      t.literal_table <- (c, cst) :: t.literal_table)
     Runtimedef.builtin_exceptions;
   (* Initialize the known C primitives *)
   let set_prim_table_from_file primfile =
@@ -150,7 +186,7 @@ let init () =
       (fun () ->
          try
            while true do
-             set_prim_table (input_line ic)
+             set_prim_table t (input_line ic)
            done
          with End_of_file -> ()
       )
@@ -173,8 +209,9 @@ let init () =
          set_prim_table_from_file primfile
       )
   end else begin
-    Array.iter set_prim_table Runtimedef.builtin_primitives
-  end
+    Array.iter (set_prim_table t) Runtimedef.builtin_primitives
+  end;
+  t
 
 (* Relocate a block of object bytecode *)
 
@@ -184,17 +221,17 @@ let patch_int buff pos n =
   LongString.set buff (pos + 2) (Char.unsafe_chr (n asr 16));
   LongString.set buff (pos + 3) (Char.unsafe_chr (n asr 24))
 
-let patch_object buff patchlist =
+let patch_object t buff patchlist =
   List.iter
     (function
         (Reloc_literal sc, pos) ->
-          patch_int buff pos (slot_for_literal sc)
+          patch_int buff pos (slot_for_literal t sc)
       | (Reloc_getglobal id, pos) ->
-          patch_int buff pos (slot_for_getglobal id)
+          patch_int buff pos (slot_for_getglobal t id)
       | (Reloc_setglobal id, pos) ->
-          patch_int buff pos (slot_for_setglobal id)
+          patch_int buff pos (slot_for_setglobal t id)
       | (Reloc_primitive name, pos) ->
-          patch_int buff pos (of_prim name))
+          patch_int buff pos (of_prim t name))
     patchlist
 
 (* Translate structured constants *)
@@ -223,106 +260,12 @@ let rec transl_const = function
 
 (* Build the initial table of globals *)
 
-let initial_global_table () =
-  let glob = Array.make !global_table.cnt (Obj.repr 0) in
+let initial_global_table t =
+  let glob = Array.make (GlobalMap.length !(t.global_table)) (Obj.repr 0) in
   List.iter
     (fun (slot, cst) -> glob.(slot) <- transl_const cst)
-    !literal_table;
-  literal_table := [];
+    t.literal_table;
   glob
-
-(* Save the table of globals *)
-
-let output_global_map oc =
-  output_value oc !global_table
-
-let data_global_map () =
-  Obj.repr !global_table
-
-(* Functions for toplevel use *)
-
-(* Update the in-core table of globals *)
-
-let update_global_table () =
-  let ng = !global_table.cnt in
-  if ng > Array.length(Meta.global_data()) then Meta.realloc_global_data ng;
-  let glob = Meta.global_data() in
-  List.iter
-    (fun (slot, cst) -> glob.(slot) <- transl_const cst)
-    !literal_table;
-  literal_table := []
-
-(* Recover data for toplevel initialization.  Data can come either from
-   executable file (normal case) or from linked-in data (-output-obj). *)
-
-type section_reader = {
-  read_string: Bytesections.Name.t -> string;
-  read_struct: Bytesections.Name.t -> Obj.t;
-  close_reader: unit -> unit
-}
-
-let read_sections () =
-  try
-    let sections = Meta.get_section_table () in
-    { read_string =
-        (fun name ->
-           (Obj.magic(List.assoc (name :> string) sections) : string));
-      read_struct =
-        (fun name -> List.assoc (name :> string) sections);
-      close_reader =
-        (fun () -> ()) }
-  with Not_found ->
-    let ic = open_in_bin Sys.executable_name in
-    let section_table = Bytesections.read_toc ic in
-    { read_string = Bytesections.read_section_string section_table ic;
-      read_struct = Bytesections.read_section_struct section_table ic;
-      close_reader = fun () -> close_in ic }
-
-(* Initialize the linker for toplevel use *)
-
-let init_toplevel () =
-  try
-    let sect = read_sections () in
-    (* Locations of globals *)
-    global_table :=
-      (Obj.magic (sect.read_struct Bytesections.Name.symb) : GlobalMap.t);
-    (* Primitives *)
-    let prims = sect.read_string Bytesections.Name.prim in
-    c_prim_table := PrimMap.empty;
-    let pos = ref 0 in
-    while !pos < String.length prims do
-      let i = String.index_from prims !pos '\000' in
-      set_prim_table (String.sub prims !pos (i - !pos));
-      pos := i + 1
-    done;
-    (* DLL initialization *)
-    let dllpath =
-      try sect.read_string Bytesections.Name.dlpt
-      with Not_found -> "" in
-    Dll.init_toplevel dllpath;
-    (* Recover CRC infos for interfaces *)
-    let crcintfs =
-      try
-        (Obj.magic (sect.read_struct Bytesections.Name.crcs)
-         : (string * Digest.t option) list)
-      with Not_found -> [] in
-    (* Done *)
-    sect.close_reader();
-    crcintfs
-  with Bytesections.Bad_magic_number | Not_found | Failure _ ->
-    fatal_error "Toplevel bytecode executable is corrupted"
-
-(* Find the value of a global identifier *)
-
-let get_global_position id = slot_for_getglobal id
-
-let get_global_value id =
-  (Meta.global_data()).(slot_for_getglobal id)
-let assign_global_value id v =
-  (Meta.global_data()).(slot_for_getglobal id) <- v
-
-(* Check that all globals referenced in the given patch list
-   have been initialized already *)
 
 let defined_globals patchlist =
   List.fold_left (fun accu rel ->
@@ -340,51 +283,145 @@ let required_globals patchlist =
     []
     patchlist
 
-let check_global_initialized patchlist =
-  (* First determine the globals we will define *)
-  let defined_globals = defined_globals patchlist in
-  (* Then check that all referenced, not defined globals have a value *)
-  let check_reference = function
-      (Reloc_getglobal id, _pos) ->
-        if not (List.mem id defined_globals)
-        && Obj.is_int (get_global_value id)
-        then raise (Error(Uninitialized_global(Ident.name id)))
-    | _ -> () in
-  List.iter check_reference patchlist
 
-(* Save and restore the current state *)
+module Toplevel = struct
+  (* For toplevel and dynlink use *)
 
-type global_map = GlobalMap.t
+  type status =
+    | Uninitialized
+    | Initializing
+    | Initialized of state
 
-let current_state () = !global_table
+  let the_one = ref Uninitialized
 
-let restore_state st = global_table := st
+  let get_state () =
+    match !the_one with
+    | Uninitialized
+    | Initializing -> failwith "Symtable.Toplevel.get_state: not initialized"
+    | Initialized state -> state
 
-let hide_additions (st : global_map) =
-  if st.cnt > !global_table.cnt then
-    fatal_error "Symtable.hide_additions";
-  global_table :=
-    {GlobalMap.
-      cnt = !global_table.cnt;
-      tbl = st.tbl }
+  let get_globalmap () =
+    let state = get_state () in
+    get_globalmap state
 
-(* "Filter" the global map according to some predicate.
-   Used to expunge the global map for the toplevel. *)
+  let restore_globalmap gmap =
+    let state = get_state () in
+    set_globalmap state gmap
 
-let filter_global_map p (gmap : global_map) =
-  let newtbl = ref Ident.Map.empty in
-  Ident.Map.iter
-    (fun id num -> if p id then newtbl := Ident.Map.add id num !newtbl)
-    gmap.tbl;
-  {GlobalMap. cnt = gmap.cnt; tbl = !newtbl}
+  (* Recover data for toplevel initialization.  Data can come either from
+     executable file (normal case) or from linked-in data (-output-obj). *)
 
-let iter_global_map f (gmap : global_map) =
-  Ident.Map.iter f gmap.tbl
+  type section_reader = {
+    read_string: Bytesections.Name.t -> string;
+    read_struct: Bytesections.Name.t -> Obj.t;
+    close_reader: unit -> unit
+  }
 
-let is_defined_in_global_map (gmap : global_map) id =
-  Ident.Map.mem id gmap.tbl
+  let read_sections () =
+    try
+      let sections = Meta.get_section_table () in
+      { read_string =
+          (fun name -> (Obj.magic(List.assoc (name :> string) sections) : string));
+        read_struct =
+          (fun name -> List.assoc (name :> string) sections);
+        close_reader =
+          (fun () -> ()) }
+    with Not_found ->
+      let ic = open_in_bin Sys.executable_name in
+      let section_table = Bytesections.read_toc ic in
+      { read_string = Bytesections.read_section_string section_table ic;
+        read_struct = Bytesections.read_section_struct section_table ic;
+        close_reader = fun () -> close_in ic }
 
-let empty_global_map = GlobalMap.empty
+  (* Initialize the linker for toplevel use *)
+
+  let init () =
+    match !the_one with
+    | Initialized _ | Initializing -> failwith "Symtable.Toplevel.init: already initialized"
+    | Uninitialized ->
+        the_one := Initializing;
+        let state = create_empty () in
+        try
+          let sect = read_sections () in
+          (* Locations of globals *)
+          state.global_table := (Obj.magic (sect.read_struct Bytesections.Name.symb) : GlobalMap.t);
+          (* Primitives *)
+          let prims = split_null_separated (sect.read_string Bytesections.Name.prim) in
+          List.iter (set_prim_table state) prims;
+          (* DLL initialization *)
+          let dllpath = try sect.read_string Bytesections.Name.dlpt with Not_found -> "" in
+          Dll.init_toplevel dllpath;
+          (* Recover CRC infos for interfaces *)
+          let crcintfs =
+            try
+              (Obj.magic (sect.read_struct Bytesections.Name.crcs) : (string * Digest.t option) list)
+            with Not_found -> [] in
+          (* Done *)
+          sect.close_reader();
+          the_one := Initialized state;
+          crcintfs
+        with Bytesections.Bad_magic_number | Not_found | Failure _ ->
+          the_one := Uninitialized;
+          fatal_error "Toplevel bytecode executable is corrupted"
+
+  (* Find the value of a global identifier *)
+
+  let get_global_value id =
+    let state = get_state () in
+    (Meta.global_data()).(slot_for_getglobal state id)
+
+  let is_global_defined id =
+    let state = get_state () in
+    is_global_defined state id
+
+  let assign_global_value id v =
+    let state = get_state () in
+    (Meta.global_data()).(slot_for_getglobal state id) <- v
+
+  let hide_additions (st : GlobalMap.t) =
+    let state = get_state () in
+    let len = GlobalMap.length !(state.global_table) in
+    match GlobalMap.extend st len with
+    | None -> fatal_error "Symtable.hide_additions"
+    | Some st -> state.global_table := st
+
+  (* Check that all globals referenced in the given patch list
+     have been initialized already *)
+
+  let check_global_initialized patchlist =
+    (* First determine the globals we will define *)
+    let defined_globals = defined_globals patchlist in
+    (* Then check that all referenced, not defined globals have a value *)
+    let check_reference = function
+        (Reloc_getglobal id, _pos) ->
+          if not (List.mem id defined_globals)
+          && Obj.is_int (get_global_value id)
+          then raise (Error(Uninitialized_global(Ident.name id)))
+      | _ -> () in
+    List.iter check_reference patchlist
+
+  (* Update the in-core table of globals *)
+
+  let update_global_table state =
+    let ng = GlobalMap.length !(state.global_table) in
+    let glob =
+      let glob = Meta.global_data() in
+      if ng > Array.length(Meta.global_data())
+      then (Meta.realloc_global_data ng;Meta.global_data())
+      else glob
+    in
+    List.iter
+      (fun (slot, cst) -> glob.(slot) <- transl_const cst)
+      state.literal_table;
+    state.literal_table <- []
+
+  let patch_code_and_update_global_table buff patchlist =
+    let state = get_state () in
+    patch_object state buff patchlist;
+    check_global_initialized patchlist;
+    update_global_table state
+
+end
 
 (* Error report *)
 
@@ -406,8 +443,3 @@ let () =
       | Error err -> Some (Location.error_of_printer_file report_error err)
       | _ -> None
     )
-
-let reset () =
-  global_table := GlobalMap.empty;
-  literal_table := [];
-  c_prim_table := PrimMap.empty

--- a/bytecomp/symtable.ml
+++ b/bytecomp/symtable.ml
@@ -117,12 +117,9 @@ let all_primitives () =
   prim
 
 let data_primitive_names () =
-  let prim = all_primitives() in
-  let b = Buffer.create 512 in
-  for i = 0 to Array.length prim - 1 do
-    Buffer.add_string b prim.(i); Buffer.add_char b '\000'
-  done;
-  Buffer.contents b
+  all_primitives()
+  |> Array.to_list
+  |> concat_null_separated
 
 let output_primitive_names outchan =
   output_string outchan (data_primitive_names())

--- a/bytecomp/symtable.mli
+++ b/bytecomp/symtable.mli
@@ -25,7 +25,7 @@ val require_primitive: string -> unit
 val initial_global_table: unit -> Obj.t array
 val output_global_map: out_channel -> unit
 val output_primitive_names: out_channel -> unit
-val output_primitive_table: out_channel -> unit
+val all_primitives : unit -> string array
 val data_global_map: unit -> Obj.t
 val data_primitive_names: unit -> string
 val transl_const: Lambda.structured_constant -> Obj.t

--- a/debugger/eval.ml
+++ b/debugger/eval.ml
@@ -44,7 +44,7 @@ let rec address path event = function
   | Env.Aident id ->
       if Ident.global id then
         try
-          Debugcom.Remote_value.global (Symtable.get_global_position id)
+          Debugcom.Remote_value.global (Symtable.get_global_position !Symbols.symtable id)
         with Symtable.Error _ -> raise(Error(Unbound_identifier id))
       else
         begin match event with

--- a/debugger/printval.ml
+++ b/debugger/printval.ml
@@ -52,7 +52,7 @@ module EvalPath =
     let rec eval_address = function
     | Env.Aident id ->
         begin try
-          Debugcom.Remote_value.global (Symtable.get_global_position id)
+          Debugcom.Remote_value.global (Symtable.get_global_position !Symbols.symtable id)
         with Symtable.Error _ ->
           raise Error
         end

--- a/debugger/program_management.ml
+++ b/debugger/program_management.ml
@@ -126,8 +126,7 @@ let initialize_loading () =
     prerr_endline "Program not found.";
     raise Toplevel;
   end;
-  Symbols.clear_symbols ();
-  Symbols.read_symbols Debugcom.main_frag !program_name;
+  Symbols.init_read_symbols Debugcom.main_frag !program_name;
   let dirs = Load_path.get_paths () @ !Symbols.program_source_dirs in
   Load_path.init ~auto_include:Compmisc.auto_include dirs;
   Envaux.reset_cache ();

--- a/debugger/symbols.ml
+++ b/debugger/symbols.ml
@@ -56,16 +56,16 @@ let relocate_event orig ev =
 
 let read_symbols' bytecode_file =
   let ic = open_in_bin bytecode_file in
+  let toc = Bytesections.read_toc ic in
   begin try
-    Bytesections.read_toc ic;
-    ignore(Bytesections.seek_section ic "SYMB");
+    ignore(Bytesections.seek_section toc ic "SYMB");
   with Bytesections.Bad_magic_number | Not_found ->
     prerr_string bytecode_file; prerr_endline " is not a bytecode file.";
     raise Toplevel
   end;
   Symtable.restore_state (input_value ic);
   begin try
-    ignore (Bytesections.seek_section ic "DBUG")
+    ignore (Bytesections.seek_section toc ic "DBUG")
   with Not_found ->
     prerr_string bytecode_file; prerr_endline " has no debugging info.";
     raise Toplevel
@@ -84,7 +84,7 @@ let read_symbols' bytecode_file =
       List.fold_left (fun s e -> String.Set.add e s) !dirs (input_value ic)
   done;
   begin try
-    ignore (Bytesections.seek_section ic "CODE")
+    ignore (Bytesections.seek_section toc ic "CODE")
   with Not_found ->
     (* The file contains only debugging info,
        loading mode is forced to "manual" *)

--- a/debugger/symbols.ml
+++ b/debugger/symbols.ml
@@ -57,13 +57,12 @@ let relocate_event orig ev =
 let read_symbols' bytecode_file =
   let ic = open_in_bin bytecode_file in
   let toc = Bytesections.read_toc ic in
-  begin try
-    ignore(Bytesections.seek_section toc ic Bytesections.Name.symb);
-  with Bytesections.Bad_magic_number | Not_found ->
-    prerr_string bytecode_file; prerr_endline " is not a bytecode file.";
-    raise Toplevel
-  end;
-  Symtable.restore_state (input_value ic);
+  let symb = try
+      (Bytesections.read_section_struct toc ic Bytesections.Name.symb : Symtable.global_map);
+    with Bytesections.Bad_magic_number | Not_found ->
+      prerr_string bytecode_file; prerr_endline " is not a bytecode file.";
+      raise Toplevel in
+  Symtable.restore_state symb;
   begin try
     ignore (Bytesections.seek_section toc ic Bytesections.Name.dbug)
   with Not_found ->

--- a/debugger/symbols.ml
+++ b/debugger/symbols.ml
@@ -58,14 +58,14 @@ let read_symbols' bytecode_file =
   let ic = open_in_bin bytecode_file in
   let toc = Bytesections.read_toc ic in
   begin try
-    ignore(Bytesections.seek_section toc ic "SYMB");
+    ignore(Bytesections.seek_section toc ic Bytesections.Name.symb);
   with Bytesections.Bad_magic_number | Not_found ->
     prerr_string bytecode_file; prerr_endline " is not a bytecode file.";
     raise Toplevel
   end;
   Symtable.restore_state (input_value ic);
   begin try
-    ignore (Bytesections.seek_section toc ic "DBUG")
+    ignore (Bytesections.seek_section toc ic Bytesections.Name.dbug)
   with Not_found ->
     prerr_string bytecode_file; prerr_endline " has no debugging info.";
     raise Toplevel
@@ -84,7 +84,7 @@ let read_symbols' bytecode_file =
       List.fold_left (fun s e -> String.Set.add e s) !dirs (input_value ic)
   done;
   begin try
-    ignore (Bytesections.seek_section toc ic "CODE")
+    ignore (Bytesections.seek_section toc ic Bytesections.Name.code)
   with Not_found ->
     (* The file contains only debugging info,
        loading mode is forced to "manual" *)

--- a/debugger/symbols.mli
+++ b/debugger/symbols.mli
@@ -16,6 +16,8 @@
 
 open Events
 
+val symtable : Symtable.state ref
+
 (* Modules used by the program. *)
 val modules : string list ref
 
@@ -23,12 +25,9 @@ val modules : string list ref
  * compiled *)
 val program_source_dirs : string list ref
 
-(* Clear loaded symbols *)
-val clear_symbols : unit -> unit
-
 (* Read debugging info from executable or dynlinkable file
    and associate with given code fragment *)
-val read_symbols : int -> string -> unit
+val init_read_symbols : int -> string -> unit
 
 (* Add debugging info from memory and associate with given
    code fragment *)

--- a/otherlibs/dynlink/dynlink_common.ml
+++ b/otherlibs/dynlink/dynlink_common.ml
@@ -120,10 +120,10 @@ module Make (P : Dynlink_platform_intf.S) = struct
       failwith msg
     end
 
-  let default_available_units global =
+  let default_available_units state global =
     let exe = Sys.executable_name in
     let ifaces, implems, defined_symbols =
-      P.fold_initial_units
+      P.fold_initial_units state
         ~init:(String.Map.empty, String.Map.empty, String.Set.empty)
         ~f:(fun (ifaces, implems, defined_symbols)
                 ~comp_unit ~interface ~implementation
@@ -164,8 +164,8 @@ module Make (P : Dynlink_platform_intf.S) = struct
   let init () =
     with_lock (fun global ->
     if not global.inited then begin
-      P.init ();
-      default_available_units global;
+      let state = P.init () in
+      default_available_units state global;
       global.inited <- true
     end)
 

--- a/otherlibs/dynlink/dynlink_platform_intf.ml
+++ b/otherlibs/dynlink/dynlink_platform_intf.ml
@@ -37,7 +37,9 @@ module type S = sig
     val unsafe_module : t -> bool
   end
 
-  val init : unit -> unit
+  type initial_state
+
+  val init : unit -> initial_state
 
   val is_native : bool
 
@@ -46,7 +48,8 @@ module type S = sig
   val num_globals_inited : unit -> int
 
   val fold_initial_units
-     : init:'a
+    : initial_state
+    -> init:'a
     -> f:('a
       -> comp_unit:string
       -> interface:Digest.t option

--- a/otherlibs/dynlink/native/dynlink.ml
+++ b/otherlibs/dynlink/native/dynlink.ml
@@ -55,6 +55,8 @@ module Native = struct
     let unsafe_module _t = false
   end
 
+  type initial_state = unit
+
   let init () = ()
 
   let is_native = true
@@ -62,7 +64,7 @@ module Native = struct
 
   let num_globals_inited () = ndl_globals_inited ()
 
-  let fold_initial_units ~init ~f =
+  let fold_initial_units () ~init ~f =
     let rank = ref 0 in
     List.fold_left (fun acc { name; crc_intf; crc_impl; syms; } ->
         rank := !rank + List.length syms;

--- a/testsuite/tests/backtrace/backtrace_dynlink.reference
+++ b/testsuite/tests/backtrace/backtrace_dynlink.reference
@@ -1,5 +1,5 @@
 Raised by primitive operation at Backtrace_dynlink_plugin in file "backtrace_dynlink_plugin.ml", line 6, characters 13-38
-Called from Dynlink.Native.run.(fun) in file "otherlibs/dynlink/native/dynlink.ml", line 85, characters 12-29
+Called from Dynlink.Native.run.(fun) in file "otherlibs/dynlink/native/dynlink.ml", line 87, characters 12-29
 Called from Stdlib__List.iter in file "list.ml", line 112, characters 12-15
 Called from Dynlink_common.Make.load.(fun) in file "otherlibs/dynlink/dynlink_common.ml", line 363, characters 13-56
 Called from Stdlib__List.iter in file "list.ml", line 112, characters 12-15
@@ -7,8 +7,8 @@ Called from Dynlink_common.Make.load in file "otherlibs/dynlink/dynlink_common.m
 Called from Dynlink_common.Make.loadfile in file "otherlibs/dynlink/dynlink_common.ml" (inlined), line 374, characters 26-45
 Called from Backtrace_dynlink in file "backtrace_dynlink.ml", line 39, characters 4-52
 execution of module initializers in the shared library failed: Failure("SUCCESS")
-Raised by primitive operation at Dynlink.Native.run.(fun) in file "otherlibs/dynlink/native/dynlink.ml", line 85, characters 12-29
-Re-raised at Dynlink.Native.run.(fun) in file "otherlibs/dynlink/native/dynlink.ml", line 87, characters 10-149
+Raised by primitive operation at Dynlink.Native.run.(fun) in file "otherlibs/dynlink/native/dynlink.ml", line 87, characters 12-29
+Re-raised at Dynlink.Native.run.(fun) in file "otherlibs/dynlink/native/dynlink.ml", line 89, characters 10-149
 Called from Stdlib__List.iter in file "list.ml", line 112, characters 12-15
 Called from Dynlink_common.Make.load.(fun) in file "otherlibs/dynlink/dynlink_common.ml", line 363, characters 13-56
 Called from Stdlib__List.iter in file "list.ml", line 112, characters 12-15

--- a/testsuite/tests/lib-dynlink-initializers/test10_main.byte.reference
+++ b/testsuite/tests/lib-dynlink-initializers/test10_main.byte.reference
@@ -3,8 +3,8 @@ Raised at Stdlib.failwith in file "stdlib.ml", line 29, characters 17-33
 Called from Test10_plugin.g in file "test10_plugin.ml", line 3, characters 2-21
 Called from Test10_plugin.f in file "test10_plugin.ml", line 6, characters 2-6
 Called from Test10_plugin in file "test10_plugin.ml", line 10, characters 2-6
-Called from Dynlink.Bytecode.run in file "otherlibs/dynlink/dynlink.ml", line 149, characters 16-25
-Re-raised at Dynlink.Bytecode.run in file "otherlibs/dynlink/dynlink.ml", line 151, characters 6-137
+Called from Dynlink.Bytecode.run in file "otherlibs/dynlink/dynlink.ml", line 147, characters 16-25
+Re-raised at Dynlink.Bytecode.run in file "otherlibs/dynlink/dynlink.ml", line 149, characters 6-137
 Called from Dynlink_common.Make.load.(fun) in file "otherlibs/dynlink/dynlink_common.ml", line 363, characters 13-56
 Called from Stdlib__List.iter in file "list.ml", line 112, characters 12-15
 Called from Dynlink_common.Make.load in file "otherlibs/dynlink/dynlink_common.ml", line 359, characters 8-392

--- a/testsuite/tests/lib-dynlink-initializers/test10_main.native.reference
+++ b/testsuite/tests/lib-dynlink-initializers/test10_main.native.reference
@@ -1,6 +1,6 @@
 Error: Failure("Plugin error")
-Raised by primitive operation at Dynlink.Native.run.(fun) in file "otherlibs/dynlink/native/dynlink.ml", line 85, characters 12-29
-Re-raised at Dynlink.Native.run.(fun) in file "otherlibs/dynlink/native/dynlink.ml", line 87, characters 10-149
+Raised by primitive operation at Dynlink.Native.run.(fun) in file "otherlibs/dynlink/native/dynlink.ml", line 87, characters 12-29
+Re-raised at Dynlink.Native.run.(fun) in file "otherlibs/dynlink/native/dynlink.ml", line 89, characters 10-149
 Called from Stdlib__List.iter in file "list.ml", line 112, characters 12-15
 Called from Dynlink_common.Make.load.(fun) in file "otherlibs/dynlink/dynlink_common.ml", line 363, characters 13-56
 Called from Stdlib__List.iter in file "list.ml", line 112, characters 12-15

--- a/testsuite/tests/tool-toplevel/pr6468.compilers.reference
+++ b/testsuite/tests/tool-toplevel/pr6468.compilers.reference
@@ -8,5 +8,5 @@ val g : unit -> int = <fun>
 Exception: Not_found.
 Raised at f in file "//toplevel//", line 2, characters 11-26
 Called from g in file "//toplevel//", line 1, characters 11-15
-Called from Topeval.load_lambda in file "toplevel/byte/topeval.ml", line 89, characters 4-14
+Called from Topeval.load_lambda in file "toplevel/byte/topeval.ml", line 87, characters 4-14
 

--- a/testsuite/tests/tool-toplevel/pr9701.compilers.reference
+++ b/testsuite/tests/tool-toplevel/pr9701.compilers.reference
@@ -1,4 +1,4 @@
 Exception: Failure "test".
 Raised at Stdlib.failwith in file "stdlib.ml", line 29, characters 17-33
 Called from <unknown> in file "pr9701.ml", line 5, characters 9-16
-Called from Topeval.load_lambda in file "toplevel/byte/topeval.ml", line 89, characters 4-14
+Called from Topeval.load_lambda in file "toplevel/byte/topeval.ml", line 87, characters 4-14

--- a/tools/cmpbyt.ml
+++ b/tools/cmpbyt.ml
@@ -18,10 +18,6 @@
 
 open Printf
 
-let readtoc ic =
-  Bytesections.read_toc ic;
-  (Bytesections.toc(), Bytesections.pos_first_section ic)
-
 type cmpresult = Same | Differ of int
 
 let rec cmpbytes ic1 ic2 len ofs =
@@ -34,21 +30,18 @@ let skip_section name =
   name = "DBUG"
 
 let cmpbyt file1 file2 =
+  let open Bytesections in
   let ic1 = open_in_bin file1 in
-  let (toc1, pos1) = readtoc ic1 in
+  let toc1 = Bytesections.read_toc ic1 in
   let ic2 = open_in_bin file2 in
-  let (toc2, pos2) = readtoc ic2 in
-  seek_in ic1 pos1;
-  seek_in ic2 pos2;
+  let toc2 = Bytesections.read_toc ic2 in
   let rec cmpsections t1 t2 =
     match t1, t2 with
     | [], [] ->
         true
-    | (name1, len1) :: t1, t2  when skip_section name1 ->
-        seek_in ic1 (pos_in ic1 + len1);
-         cmpsections t1 t2
-    | t1, (name2, len2) :: t2  when skip_section name2 ->
-        seek_in ic2 (pos_in ic2 + len2);
+    | s1 :: t1, t2  when skip_section s1.name ->
+        cmpsections t1 t2
+    | t1, s2 :: t2  when skip_section s2.name ->
         cmpsections t1 t2
     | [], _  ->
         eprintf "%s has more sections than %s\n" file2 file1;
@@ -56,20 +49,22 @@ let cmpbyt file1 file2 =
     | _,  [] ->
         eprintf "%s has more sections than %s\n" file1 file2;
         false
-    | (name1, len1) :: t1, (name2, len2) :: t2 ->
-        if name1 <> name2 then begin
+    | s1 :: t1, s2 :: t2 ->
+        if s1.name <> s2.name then begin
           eprintf "Section mismatch: %s (in %s) / %s (in %s)\n"
-                  name1 file1 name2 file2;
+                  s1.name file1 s2.name file2;
           false
-        end else if len1 <> len2 then begin
+        end else if s1.len <> s2.len then begin
           eprintf "Length of section %s differ: %d (in %s) / %d (in %s)\n"
-                  name1 len1 file1 len2 file2;
+                  s1.name s1.len file1 s2.len file2;
           false
         end else begin
-          match cmpbytes ic1 ic2 len1 0 with
+          seek_in ic1 s1.pos;
+          seek_in ic2 s2.pos;
+          match cmpbytes ic1 ic2 s1.len 0 with
           | Differ ofs ->
               eprintf "Files %s and %s differ: section %s, offset %d\n"
-                      file1 file2 name1 ofs;
+                      file1 file2 s1.name ofs;
               false
           | Same ->
               cmpsections t1 t2

--- a/tools/dumpobj.ml
+++ b/tools/dumpobj.ml
@@ -511,17 +511,13 @@ let dump_obj ic =
   seek_in ic cu.cu_pos;
   print_code ic cu.cu_codesize
 
-(* Read the primitive table from an executable *)
-
-let split_primitive_table p =
-  String.split_on_char '\000' p |> List.filter ((<>) "") |> Array.of_list
-
 (* Print an executable file *)
 
 let dump_exe ic =
   let toc = Bytesections.read_toc ic in
+  (* Read the primitive table from an executable *)
   let prims = Bytesections.read_section_string toc ic Bytesections.Name.prim in
-  primitives := split_primitive_table prims;
+  primitives := Misc.split_null_separated prims |> Array.of_list;
   let init_data : Obj.t array =
     Bytesections.read_section_struct toc ic Bytesections.Name.data in
   globals := Array.map (fun x -> Constant x) init_data;

--- a/tools/dumpobj.ml
+++ b/tools/dumpobj.ml
@@ -515,6 +515,7 @@ let dump_obj ic =
 
 let dump_exe ic =
   let toc = Bytesections.read_toc ic in
+  (* Read the primitive table from an executable *)
   let prims = Bytesections.read_section_string toc ic Bytesections.Name.prim in
   primitives := Array.of_list (Misc.split_null_separated prims);
   let init_data = (Bytesections.read_section_struct toc ic Bytesections.Name.data : Obj.t array) in
@@ -523,7 +524,7 @@ let dump_exe ic =
     !globals.(i) <- Constant (init_data.(i))
   done;
   let sym_table = (Bytesections.read_section_struct toc ic Bytesections.Name.symb : Symtable.global_map) in
-  Symtable.iter_global_map
+  Symtable.GlobalMap.iter
     (fun id pos -> !globals.(pos) <- Global id) sym_table;
   begin
     match Bytesections.seek_section toc ic Bytesections.Name.dbug with

--- a/tools/dumpobj.ml
+++ b/tools/dumpobj.ml
@@ -520,17 +520,17 @@ let split_primitive_table p =
 
 let dump_exe ic =
   let toc = Bytesections.read_toc ic in
-  let prims = Bytesections.read_section_string toc ic "PRIM" in
+  let prims = Bytesections.read_section_string toc ic Bytesections.Name.prim in
   primitives := split_primitive_table prims;
   let init_data : Obj.t array =
-    Bytesections.read_section_struct toc ic "DATA" in
+    Bytesections.read_section_struct toc ic Bytesections.Name.data in
   globals := Array.map (fun x -> Constant x) init_data;
   let sym_table : Symtable.global_map =
-    Bytesections.read_section_struct toc ic "SYMB" in
+    Bytesections.read_section_struct toc ic Bytesections.Name.symb in
   Symtable.iter_global_map
     (fun id pos -> !globals.(pos) <- Global id) sym_table;
   begin
-    match Bytesections.seek_section toc ic "DBUG" with
+    match Bytesections.seek_section toc ic Bytesections.Name.dbug with
     | exception Not_found -> ()
     | (_ : int) ->
         let num_eventlists = input_binary_int ic in
@@ -542,7 +542,7 @@ let dump_exe ic =
           record_events orig evl
         done
   end;
-  let code_size = Bytesections.seek_section toc ic "CODE" in
+  let code_size = Bytesections.seek_section toc ic Bytesections.Name.code in
   print_code ic code_size
 
 let arg_list = [

--- a/tools/objinfo.ml
+++ b/tools/objinfo.ml
@@ -224,7 +224,7 @@ let dump_byte ic =
   List.iter
     (fun {Bytesections.name = section; len; _} ->
        try
-         if len > 0 then match section with
+         if len > 0 then match (section :> string) with
            | "CRCS" ->
                let imported_units : (string * Digest.t option) list =
                  Bytesections.read_section_struct toc ic section in

--- a/tools/objinfo.ml
+++ b/tools/objinfo.ml
@@ -122,7 +122,7 @@ let print_general_infos name crc defines cmi cmx =
 
 let print_global_table table =
   printf "Globals defined:\n";
-  Symtable.iter_global_map
+  Symtable.GlobalMap.iter
     (fun id _ -> print_line (Ident.name id))
     table
 

--- a/tools/objinfo.ml
+++ b/tools/objinfo.ml
@@ -32,18 +32,6 @@ let shape = ref false
 
 module Magic_number = Misc.Magic_number
 
-let to_stringlist sect =
-  let get_string_list sect len =
-    let rec fold s e acc =
-      if e != len then
-        if sect.[e] = '\000' then
-          fold (e+1) (e+1) (String.sub sect s (e-s) :: acc)
-        else fold s (e+1) acc
-      else acc
-    in fold 0 0 []
-  in
-  get_string_list sect (String.length sect)
-
 let dummy_crc = String.make 32 '-'
 let null_crc = String.make 32 '0'
 
@@ -232,17 +220,17 @@ let dump_byte ic =
            | "DLLS" ->
                let dlls =
                  Bytesections.read_section_string toc ic section
-                 |> to_stringlist in
+                 |> split_null_separated in
                p_list "Used DLLs" print_line dlls
            | "DLPT" ->
                let dll_paths =
                  Bytesections.read_section_string toc ic section
-                 |> to_stringlist in
+                 |> split_null_separated in
                p_list "Additional DLL paths" print_line dll_paths
            | "PRIM" ->
                let prims =
                  Bytesections.read_section_string toc ic section
-                 |> to_stringlist in
+                 |> split_null_separated in
                p_list "Primitives used" print_line prims
            | "SYMB" ->
                let symb = Bytesections.read_section_struct toc ic section in

--- a/tools/stripdebug.ml
+++ b/tools/stripdebug.ml
@@ -32,12 +32,13 @@ let stripdebug infile outfile =
   let toc_writer = Bytesections.init_record oc in
   List.iter
     (fun {Bytesections.name; pos; len} ->
-       if name = "DBUG" || name = "CRCS" then ()
-       else begin
-        seek_in ic pos;
-        copy_file_chunk ic oc len;
-        Bytesections.record toc_writer name
-      end)
+       match (name :> string) with
+       | "DBUG" | "CRCS" -> ()
+       | _ ->
+           seek_in ic pos;
+           copy_file_chunk ic oc len;
+           Bytesections.record toc_writer name
+    )
     toc;
   (* Rewrite the toc and trailer *)
   Bytesections.write_toc_and_trailer toc_writer;

--- a/toplevel/expunge.ml
+++ b/toplevel/expunge.ml
@@ -66,7 +66,7 @@ let main () =
         List.iter
           (fun {Bytesections.name; pos; len} ->
              seek_in ic pos;
-             begin match name with
+             begin match (name :> string) with
                "SYMB" ->
                  let global_map : Symtable.global_map = input_value ic in
                  output_value oc (expunge_map global_map)

--- a/toplevel/expunge.ml
+++ b/toplevel/expunge.ml
@@ -45,34 +45,43 @@ let main () =
     to_keep := String.Set.add (String.capitalize_ascii Sys.argv.(i)) !to_keep
   done;
   let ic = open_in_bin input_name in
-  Bytesections.read_toc ic;
-  let toc = Bytesections.toc() in
-  let pos_first_section = Bytesections.pos_first_section ic in
+  let toc = Bytesections.read_toc ic in
+  seek_in ic 0;
   let oc =
     open_out_gen [Open_wronly; Open_creat; Open_trunc; Open_binary] 0o777
-                 output_name in
-  (* Copy the file up to the symbol section as is *)
-  seek_in ic 0;
-  copy_file_chunk ic oc pos_first_section;
-  (* Copy each section, modifying the symbol section in passing *)
-  Bytesections.init_record oc;
-  List.iter
-    (fun (name, len) ->
-      begin match name with
-        "SYMB" ->
-          let global_map = (input_value ic : Symtable.global_map) in
-          output_value oc (expunge_map global_map)
-      | "CRCS" ->
-          let crcs = (input_value ic : (string * Digest.t option) list) in
-          output_value oc (expunge_crcs crcs)
-      | _ ->
-          copy_file_chunk ic oc len
-      end;
-      Bytesections.record oc name)
-    toc;
-  (* Rewrite the toc and trailer *)
-  Bytesections.write_toc_and_trailer oc;
-  (* Done *)
+      output_name in
+  begin
+    match toc with
+    | [] ->
+        (* nothing to rewrite, just copy the file *)
+        copy_file_chunk ic oc (in_channel_length ic)
+    | entry :: _ ->
+        (* Copy the file up to the first section as is *)
+        let min_pos =
+          List.fold_left (fun acc s -> min acc s.Bytesections.pos)
+            entry.Bytesections.pos toc in
+        copy_file_chunk ic oc min_pos;
+        (* Copy each section, modifying the symbol section in passing *)
+        let toc_writer = Bytesections.init_record oc in
+        List.iter
+          (fun {Bytesections.name; pos; len} ->
+             seek_in ic pos;
+             begin match name with
+               "SYMB" ->
+                 let global_map : Symtable.global_map = input_value ic in
+                 output_value oc (expunge_map global_map)
+             | "CRCS" ->
+                 let crcs : (string * Digest.t option) list = input_value ic in
+                 output_value oc (expunge_crcs crcs)
+             | _ ->
+                 copy_file_chunk ic oc len
+             end;
+             Bytesections.record toc_writer name)
+          toc;
+        (* Rewrite the toc and trailer *)
+        Bytesections.write_toc_and_trailer toc_writer;
+        (* Done *)
+  end;
   close_in ic;
   close_out oc
 

--- a/toplevel/expunge.ml
+++ b/toplevel/expunge.ml
@@ -33,7 +33,7 @@ let keep =
   else fun name -> is_exn name || (String.Set.mem name !to_keep)
 
 let expunge_map tbl =
-  Symtable.filter_global_map (fun id -> keep (Ident.name id)) tbl
+  Symtable.GlobalMap.filter (fun id -> keep (Ident.name id)) tbl
 
 let expunge_crcs tbl =
   List.filter (fun (unit, _crc) -> keep unit) tbl
@@ -68,7 +68,7 @@ let main () =
              seek_in ic pos;
              begin match (name :> string) with
                "SYMB" ->
-                 let global_map : Symtable.global_map = input_value ic in
+                 let global_map : Symtable.GlobalMap.t = input_value ic in
                  output_value oc (expunge_map global_map)
              | "CRCS" ->
                  let crcs : (string * Digest.t option) list = input_value ic in

--- a/utils/misc.ml
+++ b/utils/misc.ml
@@ -397,6 +397,25 @@ end
 
 (* String operations *)
 
+let split_null_separated str =
+  let len = String.length str in
+  let rec fold s e acc =
+    if e != len then
+      if str.[e] = '\000' then
+        fold (e+1) (e+1) (String.sub str s (e-s) :: acc)
+      else fold s (e+1) acc
+    else
+      let acc = if s <> e
+        then (String.sub str s (e-s) :: acc)
+        else acc
+      in List.rev acc
+  in fold 0 0 []
+
+let concat_null_separated l =
+  match l with
+  | [] -> ""
+  | l -> String.concat "\000" l ^ "\000"
+
 let chop_extensions file =
   let dirname = Filename.dirname file and basename = Filename.basename file in
   try

--- a/utils/misc.mli
+++ b/utils/misc.mli
@@ -256,6 +256,9 @@ module Int_literal_converter : sig
   val nativeint : string -> nativeint
 end
 
+val concat_null_separated : string list -> string
+val split_null_separated : string -> string list
+
 val chop_extensions: string -> string
         (* Return the given file name without its extensions. The extensions
            is the longest suffix starting with a period and not including


### PR DESCRIPTION
Based on #11623 

- Split the api to isolate the part that needs a global state (for toplevel and dynlink).
- `Bytelink` and the debugger not longer depend on the global state inside symtable. They use their own local state.