### PR TITLE
Fix ephemeron assertion by allowing for data values that are in the minor heap

### DIFF
--- a/runtime/weak.c
+++ b/runtime/weak.c
@@ -160,9 +160,15 @@ void caml_ephe_clean (value v) {
   if (child != caml_ephe_none) {
     if (release_data) {
       Field(v, CAML_EPHE_DATA_OFFSET) = caml_ephe_none;
-    } else {
-      CAMLassert (!Is_block(child) || !is_unmarked(child) || Is_young(child));
     }
+#ifdef DEBUG
+    else if (Is_block (child) && !Is_young (child)) {
+      if (Tag_val (child) == Infix_tag) child -= Infix_offset_val (child);
+      /* If we scanned all the keys and the data field remains filled,
+         then the mark phase must have marked it */
+      CAMLassert( is_marked (child) );
+    }
+#endif
   }
 }
 

--- a/runtime/weak.c
+++ b/runtime/weak.c
@@ -161,7 +161,7 @@ void caml_ephe_clean (value v) {
     if (release_data) {
       Field(v, CAML_EPHE_DATA_OFFSET) = caml_ephe_none;
     } else {
-      CAMLassert (!Is_block(child) || !is_unmarked(child));
+      CAMLassert (!Is_block(child) || !is_unmarked(child) || Is_young(child));
     }
   }
 }


### PR DESCRIPTION
The assertion on https://github.com/ocaml/ocaml/blob/trunk/runtime/weak.c#L164 is overly restrictive. Currently we assert that if we're not releasing an ephemeron's data (because all of it's keys are alive) then it is marked - it may however be in the minor heap.

I've used the reproduction in #11503 and the test no longer aborts. This will need to be cherry-picked to 5.0.

Fixes https://github.com/ocaml/ocaml/issues/11503

