### PR TITLE
Bytecomp.Dll: fix and cleanup

### DIFF
--- a/Changes
+++ b/Changes
@@ -140,6 +140,10 @@ Working version
 - #11627: use return values instead of globals for linear scan intervals
   (Stefan Muenzel, review by Nicolás Ojeda Bär)
 
+- #11634: Dll.open_dll now properly handle opening for execution while already
+  opened for checking
+  (Hugo Heuzard, review by Nicolás Ojeda Bär)
+
 ### Build system:
 
 ### Bug fixes:

--- a/bytecomp/dll.ml
+++ b/bytecomp/dll.ml
@@ -40,10 +40,7 @@ let dll_close = function
   | Execution dll -> dll_close dll
 
 (* DLLs currently opened *)
-let opened_dlls = ref ([] : opened_dll list)
-
-(* File names for those DLLs *)
-let names_of_opened_dlls = ref ([] : string list)
+let opened_dlls = ref ([] : (string * opened_dll) list)
 
 (* Add the given directories to the search path for DLLs. *)
 let add_path dirs =
@@ -74,26 +71,26 @@ let open_dll mode name =
         Filename.concat Filename.current_dir_name fullname
       else fullname
     with Not_found -> name in
-  if not (List.mem fullname !names_of_opened_dlls) then begin
-    let dll =
-      match mode with
-      | For_checking ->
-          begin match Binutils.read fullname with
-          | Ok t -> Checking t
-          | Error err ->
-              failwith (fullname ^ ": " ^ Binutils.error_to_string err)
-          end
-      | For_execution ->
-          begin match dll_open fullname with
-          | dll ->
-              Execution dll
-          | exception Failure msg ->
-              failwith (fullname ^ ": " ^ msg)
-          end
-    in
-    names_of_opened_dlls := fullname :: !names_of_opened_dlls;
-    opened_dlls := dll :: !opened_dlls
-  end
+  match List.assoc_opt fullname !opened_dlls, mode with
+  | Some (Execution _), (For_execution | For_checking) -> ()
+  | Some (Checking _), For_checking -> ()
+  | None, For_checking ->
+      begin match Binutils.read fullname with
+      | Ok t -> opened_dlls := (fullname, Checking t) :: !opened_dlls
+      | Error err ->
+          failwith (fullname ^ ": " ^ Binutils.error_to_string err)
+      end
+  | (None | Some (Checking _) as current), For_execution ->
+      begin match dll_open fullname with
+      | dll ->
+          let opened = match current with
+            | None -> List.remove_assoc fullname !opened_dlls
+            | Some _ -> !opened_dlls
+          in
+          opened_dlls := (fullname, Execution dll) :: opened
+      | exception Failure msg ->
+          failwith (fullname ^ ": " ^ msg)
+      end
 
 let open_dlls mode names =
   List.iter (open_dll mode) names
@@ -101,9 +98,8 @@ let open_dlls mode names =
 (* Close all DLLs *)
 
 let close_all_dlls () =
-  List.iter dll_close !opened_dlls;
+  List.iter (fun (_, dll) -> dll_close dll) !opened_dlls;
   opened_dlls := [];
-  names_of_opened_dlls := []
 
 (* Find a primitive in the currently opened DLLs. *)
 
@@ -115,13 +111,13 @@ let find_primitive prim_name =
   let rec find seen = function
     [] ->
       None
-  | Execution dll as curr :: rem ->
+  | (_,Execution dll) as curr :: rem ->
       let addr = dll_sym dll prim_name in
       if addr == Obj.magic () then find (curr :: seen) rem else begin
         if seen <> [] then opened_dlls := curr :: List.rev_append seen rem;
         Some (Prim_loaded addr)
       end
-  | Checking t as curr :: rem ->
+  | (_,Checking t) as curr :: rem ->
       if Binutils.defines_symbol t prim_name then
         Some Prim_exists
       else
@@ -186,13 +182,11 @@ let init_toplevel dllpath =
     split_dll_path dllpath @
     ld_conf_contents();
   opened_dlls :=
-    List.map (fun dll -> Execution dll)
+    List.map (fun dll -> "", Execution dll)
       (Array.to_list (get_current_dlls()));
-  names_of_opened_dlls := [];
   linking_in_core := true
 
 let reset () =
   search_path := [];
   opened_dlls :=[];
-  names_of_opened_dlls := [];
   linking_in_core := false

--- a/bytecomp/dll.ml
+++ b/bytecomp/dll.ml
@@ -19,7 +19,7 @@ type dll_handle
 type dll_address
 type dll_mode = For_checking | For_execution
 
-external dll_open: dll_mode -> string -> dll_handle = "caml_dynlink_open_lib"
+external dll_open: string -> dll_handle = "caml_dynlink_open_lib"
 external dll_close: dll_handle -> unit = "caml_dynlink_close_lib"
 external dll_sym: dll_handle -> string -> dll_address
                 = "caml_dynlink_lookup_symbol"
@@ -84,7 +84,7 @@ let open_dll mode name =
               failwith (fullname ^ ": " ^ Binutils.error_to_string err)
           end
       | For_execution ->
-          begin match dll_open mode fullname with
+          begin match dll_open fullname with
           | dll ->
               Execution dll
           | exception Failure msg ->

--- a/runtime/caml/osdeps.h
+++ b/runtime/caml/osdeps.h
@@ -71,15 +71,10 @@ extern char_os * caml_search_dll_in_path(struct ext_table * path,
                                          const char_os * name);
 
 /* Open a shared library and return a handle on it.
-   If [for_execution] is true, perform full symbol resolution and
-   execute initialization code so that functions from the shared library
-   can be called.  If [for_execution] is false, functions from this
-   shared library will not be called, but just checked for presence,
-   so symbol resolution can be skipped.
    If [global] is true, symbols from the shared library can be used
    to resolve for other libraries to be opened later on.
    Return [NULL] on error. */
-extern void * caml_dlopen(char_os * libname, int for_execution, int global);
+extern void * caml_dlopen(char_os * libname, int global);
 
 /* Close a shared library handle */
 extern void caml_dlclose(void * handle);

--- a/runtime/dynlink.c
+++ b/runtime/dynlink.c
@@ -143,7 +143,7 @@ static void open_shared_lib(char_os * name)
   caml_gc_message(0x100, "Loading shared library %s\n", u8);
   caml_stat_free(u8);
   caml_enter_blocking_section();
-  handle = caml_dlopen(realname, 1, 1);
+  handle = caml_dlopen(realname, 1);
   caml_leave_blocking_section();
   if (handle == NULL)
     caml_fatal_error
@@ -235,7 +235,7 @@ void caml_free_shared_libs(void)
 
 #define Handle_val(v) (*((void **) (v)))
 
-CAMLprim value caml_dynlink_open_lib(value mode, value filename)
+CAMLprim value caml_dynlink_open_lib(value filename)
 {
   void * handle;
   value result;
@@ -245,7 +245,7 @@ CAMLprim value caml_dynlink_open_lib(value mode, value filename)
                   String_val(filename));
   p = caml_stat_strdup_to_os(String_val(filename));
   caml_enter_blocking_section();
-  handle = caml_dlopen(p, Int_val(mode), 1);
+  handle = caml_dlopen(p, 1);
   caml_leave_blocking_section();
   caml_stat_free(p);
   if (handle == NULL) caml_failwith(caml_dlerror());

--- a/runtime/dynlink_nat.c
+++ b/runtime/dynlink_nat.c
@@ -79,7 +79,7 @@ CAMLprim value caml_natdynlink_open(value filename, value global)
 
   p = caml_stat_strdup_to_os(String_val(filename));
   caml_enter_blocking_section();
-  dlhandle = caml_dlopen(p, 1, Int_val(global));
+  dlhandle = caml_dlopen(p, Int_val(global));
   caml_leave_blocking_section();
   caml_stat_free(p);
 
@@ -147,7 +147,7 @@ CAMLprim value caml_natdynlink_run_toplevel(value filename, value symbol)
 
   p = caml_stat_strdup_to_os(String_val(filename));
   caml_enter_blocking_section();
-  handle = caml_dlopen(p, 1, 1);
+  handle = caml_dlopen(p, 1);
   caml_leave_blocking_section();
   caml_stat_free(p);
 

--- a/runtime/unix.c
+++ b/runtime/unix.c
@@ -238,10 +238,9 @@ caml_stat_string caml_search_dll_in_path(struct ext_table * path,
 #ifdef __CYGWIN__
 /* Use flexdll */
 
-void * caml_dlopen(char * libname, int for_execution, int global)
+void * caml_dlopen(char * libname, int global)
 {
   int flags = (global ? FLEXDLL_RTLD_GLOBAL : 0);
-  if (!for_execution) flags |= FLEXDLL_RTLD_NOEXEC;
   return flexdll_dlopen(libname, flags);
 }
 
@@ -275,10 +274,9 @@ char * caml_dlerror(void)
 #define RTLD_LOCAL 0
 #endif
 
-void * caml_dlopen(char * libname, int for_execution, int global)
+void * caml_dlopen(char * libname, int global)
 {
   return dlopen(libname, RTLD_NOW | (global ? RTLD_GLOBAL : RTLD_LOCAL));
-  /* Could use RTLD_LAZY if for_execution == 0, but needs testing */
 }
 
 void caml_dlclose(void * handle)
@@ -308,7 +306,7 @@ char * caml_dlerror(void)
 #endif /* __CYGWIN__ */
 #else
 
-void * caml_dlopen(char * libname, int for_execution, int global)
+void * caml_dlopen(char * libname, int global)
 {
   return NULL;
 }

--- a/runtime/win32.c
+++ b/runtime/win32.c
@@ -229,11 +229,10 @@ wchar_t * caml_search_dll_in_path(struct ext_table * path, const wchar_t * name)
 
 #ifdef WITH_DYNAMIC_LINKING
 
-void * caml_dlopen(wchar_t * libname, int for_execution, int global)
+void * caml_dlopen(wchar_t * libname, int global)
 {
   void *handle;
   int flags = (global ? FLEXDLL_RTLD_GLOBAL : 0);
-  if (!for_execution) flags |= FLEXDLL_RTLD_NOEXEC;
   handle = flexdll_wdlopen(libname, flags);
   if ((handle != NULL) && ((caml_params->verb_gc & 0x100) != 0)) {
     flexdll_dump_exports(handle);
@@ -264,7 +263,7 @@ char * caml_dlerror(void)
 
 #else
 
-void * caml_dlopen(wchar_t * libname, int for_execution, int global)
+void * caml_dlopen(wchar_t * libname, int global)
 {
   return NULL;
 }


### PR DESCRIPTION
This PR is a preliminary cleanup identified while preparing a PR to remove global state in Dll. 

- the `dll_mode` argument of `dll_open` is now always `For_execution` (since #9551, cc @nojb).
- opening a dll for execution while it's already opened for checking would do nothing.