### PR TITLE
Fix 'caml_unregister_frametable(table)' when 'table' is the first element

### DIFF
--- a/Changes
+++ b/Changes
@@ -26,6 +26,9 @@ OCaml 4.14 maintenance version
   that causes very slow compaction.
   (Damien Doligez, report by Arseniy Alekseyev, review by Sadiq Jaffer)
 
+- #11633, #11636: bugfix in caml_unregister_frametable
+  (Frédéric Recoules, review by Gabriel Scherer)
+
 OCaml 4.14.1 (20 December 2022)
 ------------------------------
 

--- a/runtime/roots_nat.c
+++ b/runtime/roots_nat.c
@@ -218,13 +218,19 @@ void caml_unregister_frametable(intnat *table) {
     d = next_frame_descr(d);
   }
 
-  iter_list(frametables,lnk) {
-    if(lnk->data == table) {
-      previous->next = lnk->next;
-      caml_stat_free(lnk);
-      break;
+  if (frametables->data == table) {
+    lnk = frametables;
+    frametables = frametables->next;
+    caml_stat_free(lnk);
+  } else {
+    iter_list(frametables->next,lnk) {
+      if(lnk->data == table) {
+        previous->next = lnk->next;
+        caml_stat_free(lnk);
+        break;
+      }
+      previous = lnk;
     }
-    previous = lnk;
   }
 }
 


### PR DESCRIPTION
Closes #11633.