### PR TITLE
Restore the Cygwin port of OCaml

### DIFF
--- a/Changes
+++ b/Changes
@@ -18,6 +18,11 @@ Working version
 
 ### Runtime system:
 
+- #11641: Add GC messages for address space reservations when OCAMLRUNPARAM
+  option v includes 0x1000.
+  (David Allsopp, review by Xavier Leroy, Guillaume Munch-Maccagnoni
+  and Gabriel Scherer)
+
 - #11743: Speed up weak array operations
   (KC Sivaramakrishnan, review by François Bobot and Sadiq Jaffer)
 

--- a/Changes
+++ b/Changes
@@ -18,8 +18,8 @@ Working version
 
 ### Runtime system:
 
-- #11641: Add GC messages for address space reservations when OCAMLRUNPARAM
-  option v includes 0x1000.
+- #11641: Restore Cygwin port. Add GC messages for address space reservations
+  when OCAMLRUNPARAM option v includes 0x1000.
   (David Allsopp, review by Xavier Leroy, Guillaume Munch-Maccagnoni
   and Gabriel Scherer)
 

--- a/configure
+++ b/configure
@@ -3568,8 +3568,6 @@ test -n "$target_alias" &&
 case $host in #(
   *-pc-windows) :
     as_fn_error 69 "the MSVC compiler is not supported currently" "$LINENO" 5 ;; #(
-  *-*-cygwin*) :
-    as_fn_error 69 "Cygwin is not supported currently" "$LINENO" 5 ;; #(
   i386-*-solaris*) :
     as_fn_error $? "Building for 32 bits target is not supported. \
 If your host is 64 bits, you can try with './configure CC=\"gcc -m64\"' \
@@ -15421,7 +15419,7 @@ fi; system=elf ;; #(
   aarch64-*-netbsd*) :
     has_native_backend=yes; arch=arm64; system=netbsd ;; #(
   x86_64-*-cygwin*) :
-    arch=amd64; system=cygwin ;; #(
+    has_native_backend=yes; arch=amd64; system=cygwin ;; #(
   riscv64-*-linux*) :
     has_native_backend=yes; arch=riscv; model=riscv64; system=linux
  ;; #(

--- a/configure.ac
+++ b/configure.ac
@@ -256,8 +256,6 @@ AC_CANONICAL_TARGET
 AS_CASE([$host],
   [*-pc-windows],
     [AC_MSG_ERROR([the MSVC compiler is not supported currently], 69)],
-  [*-*-cygwin*],
-    [AC_MSG_ERROR([Cygwin is not supported currently], 69)],
   [i386-*-solaris*],
     [AC_MSG_ERROR([Building for 32 bits target is not supported. \
 If your host is 64 bits, you can try with './configure CC="gcc -m64"' \
@@ -1260,7 +1258,7 @@ AS_CASE([$host],
   [aarch64-*-netbsd*],
     [has_native_backend=yes; arch=arm64; system=netbsd],
   [x86_64-*-cygwin*],
-    [arch=amd64; system=cygwin],
+    [has_native_backend=yes; arch=amd64; system=cygwin],
   [riscv64-*-linux*],
     [has_native_backend=yes; arch=riscv; model=riscv64; system=linux]
 )

--- a/man/ocamlrun.1
+++ b/man/ocamlrun.1
@@ -275,6 +275,9 @@ Output GC statistics at program exit, in the same format as Gc.print_stat.
 .BR 0x800
 GC debugging messages.
 
+.BR 0x1000
+Address space reservation changes.
+
 .TP
 .BR w \ (window_size)
 Set size of the window used by major GC for smoothing out variations in

--- a/manual/src/cmds/runtime.etex
+++ b/manual/src/cmds/runtime.etex
@@ -191,6 +191,7 @@ The following environment variables are also consulted:
         \item[512 (= 0x200)] Computation of compaction-triggering condition.
         \item[1024 (= 0x400)] Output GC statistics at program exit.
         \item[2048 (= 0x800)] GC debugging messages.
+        \item[4096 (= 0x1000)] Address space reservation changes.
   \end{options}
   \item[V] ("verify_heap") runs an integrity check on the heap just after
     the completion of a major GC cycle

--- a/runtime/caml/config.h
+++ b/runtime/caml/config.h
@@ -182,11 +182,6 @@ typedef uint64_t uintnat;
 #define THREADED_CODE
 #endif
 
-#if defined(_WIN32) || defined(__CYGWIN__)
-/* On Windows and Cygwin (which both ultimately use VirtualAlloc), memory
-   allocations will be returned aligned to the value of caml_sys_pagesize */
-#define MMAP_ALIGNS_TO_PAGESIZE
-#endif
 
 /* Memory model parameters */
 

--- a/runtime/caml/config.h
+++ b/runtime/caml/config.h
@@ -182,6 +182,11 @@ typedef uint64_t uintnat;
 #define THREADED_CODE
 #endif
 
+#if defined(_WIN32) || defined(__CYGWIN__)
+/* On Windows and Cygwin (which both ultimately use VirtualAlloc), memory
+   allocations will be returned aligned to the value of caml_sys_pagesize */
+#define MMAP_ALIGNS_TO_PAGESIZE
+#endif
 
 /* Memory model parameters */
 

--- a/runtime/caml/osdeps.h
+++ b/runtime/caml/osdeps.h
@@ -103,6 +103,13 @@ extern char_os *caml_secure_getenv(char_os const *var);
    cannot be determined, return -1. */
 extern int caml_num_rows_fd(int fd);
 
+/* Memory management platform-specific operations */
+
+void *caml_plat_mem_map(uintnat, uintnat, int);
+void *caml_plat_mem_commit(void *, uintnat);
+void caml_plat_mem_decommit(void *, uintnat);
+void caml_plat_mem_unmap(void *, uintnat);
+
 #ifdef _WIN32
 
 extern int caml_win32_rename(const wchar_t *, const wchar_t *);

--- a/runtime/caml/platform.h
+++ b/runtime/caml/platform.h
@@ -131,8 +131,9 @@ void caml_plat_cond_free(caml_plat_cond*);
 
 uintnat caml_mem_round_up_pages(uintnat size);
 /* The size given to caml_mem_map and caml_mem_commit must be a multiple of
-   caml_sys_pagesize. The size given to caml_mem_unmap and caml_mem_decommit
-   must match the size given to caml_mem_map/caml_mem_commit for mem. */
+   caml_plat_mmap_granularity. The size given to caml_mem_unmap and
+   caml_mem_decommit must match the size given to caml_mem_map/caml_mem_commit
+   for mem. */
 void* caml_mem_map(uintnat size, uintnat alignment, int reserve_only);
 void* caml_mem_commit(void* mem, uintnat size);
 void caml_mem_decommit(void* mem, uintnat size);
@@ -183,7 +184,7 @@ Caml_inline void caml_plat_unlock(caml_plat_mutex* m)
 
 /* On Windows, the SYSTEM_INFO.dwPageSize is a DWORD (32-bit), but conveniently
    long is also 32-bit */
-extern intnat caml_sys_pagesize;
+extern intnat caml_plat_mmap_granularity;
 
 #endif /* CAML_INTERNALS */
 

--- a/runtime/caml/platform.h
+++ b/runtime/caml/platform.h
@@ -131,9 +131,14 @@ void caml_plat_cond_free(caml_plat_cond*);
 
 uintnat caml_mem_round_up_pages(uintnat size);
 /* The size given to caml_mem_map and caml_mem_commit must be a multiple of
-   caml_plat_mmap_granularity. The size given to caml_mem_unmap and
-   caml_mem_decommit must match the size given to caml_mem_map/caml_mem_commit
-   for mem. */
+   caml_plat_pagesize. The size given to caml_mem_unmap and caml_mem_decommit
+   must match the size given to caml_mem_map/caml_mem_commit for mem.
+
+   The Windows and Cygwin implementations do not support arbitrary alignment
+   and will fail for alignment values greater than caml_plat_mmap_alignment.
+   Luckily, this value is rather large on those platforms: 64KiB. This is enough
+   for all alignments used in the runtime system so far, the larger being the
+   major heap pools aligned on 32KiB boundaries. */
 void* caml_mem_map(uintnat size, uintnat alignment, int reserve_only);
 void* caml_mem_commit(void* mem, uintnat size);
 void caml_mem_decommit(void* mem, uintnat size);
@@ -182,9 +187,8 @@ Caml_inline void caml_plat_unlock(caml_plat_mutex* m)
   check_err("unlock", pthread_mutex_unlock(m));
 }
 
-/* On Windows, the SYSTEM_INFO.dwPageSize is a DWORD (32-bit), but conveniently
-   long is also 32-bit */
-extern intnat caml_plat_mmap_granularity;
+extern intnat caml_plat_pagesize;
+extern intnat caml_plat_mmap_alignment;
 
 #endif /* CAML_INTERNALS */
 

--- a/runtime/caml/platform.h
+++ b/runtime/caml/platform.h
@@ -130,6 +130,9 @@ void caml_plat_cond_free(caml_plat_cond*);
 /* Memory management primitives (mmap) */
 
 uintnat caml_mem_round_up_pages(uintnat size);
+/* The size given to caml_mem_map and caml_mem_commit must be a multiple of
+   caml_sys_pagesize. The size given to caml_mem_unmap and caml_mem_decommit
+   must match the size given to caml_mem_map/caml_mem_commit for mem. */
 void* caml_mem_map(uintnat size, uintnat alignment, int reserve_only);
 void* caml_mem_commit(void* mem, uintnat size);
 void caml_mem_decommit(void* mem, uintnat size);

--- a/runtime/caml/platform.h
+++ b/runtime/caml/platform.h
@@ -183,7 +183,7 @@ Caml_inline void caml_plat_unlock(caml_plat_mutex* m)
 
 /* On Windows, the SYSTEM_INFO.dwPageSize is a DWORD (32-bit), but conveniently
    long is also 32-bit */
-extern long caml_sys_pagesize;
+extern intnat caml_sys_pagesize;
 
 #endif /* CAML_INTERNALS */
 

--- a/runtime/caml/runtime_events.h
+++ b/runtime/caml/runtime_events.h
@@ -216,17 +216,20 @@ void caml_runtime_events_destroy(void);
 
 /* Handle safely re-initialising the runtime_events structures
    in a forked child */
-void caml_runtime_events_post_fork(void);
+CAMLextern void caml_runtime_events_post_fork(void);
 
 /* Returns the location of the runtime_events for the current process if started
    or NULL otherwise */
 CAMLextern char_os* caml_runtime_events_current_location(void);
 
-/* Functions for putting runtime data on to the runtime_events */
+/* Functions for putting runtime data on to the runtime_events. These are all
+   internal to the runtime, except for caml_ev_lifecycle which is needed in
+   otherlibs/unix/fork.c so must be declared CAMLextern in order to work on
+   Cygwin. */
 void caml_ev_begin(ev_runtime_phase phase);
 void caml_ev_end(ev_runtime_phase phase);
 void caml_ev_counter(ev_runtime_counter counter, uint64_t val);
-void caml_ev_lifecycle(ev_lifecycle lifecycle, int64_t data);
+CAMLextern void caml_ev_lifecycle(ev_lifecycle lifecycle, int64_t data);
 
 /* caml_ev_alloc records the (bucketed) size of allocations into the major heap.
    It appears only in alloc_shr and caml_shared_try_alloc. These buckets are

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -724,8 +724,8 @@ static void reserve_minor_heaps(void) {
   minor_heap_reservation_bsize = minor_heap_max_bsz * Max_domains;
 
   /* reserve memory space for minor heaps */
-  heaps_base = caml_mem_map(minor_heap_reservation_bsize,
-                            caml_plat_mmap_granularity, 1 /* reserve_only */);
+  heaps_base = caml_mem_map(minor_heap_reservation_bsize, caml_plat_pagesize,
+                1 /* reserve_only */);
   if (heaps_base == NULL)
     caml_fatal_error("Not enough heap memory to reserve minor heaps");
 

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -724,8 +724,8 @@ static void reserve_minor_heaps(void) {
   minor_heap_reservation_bsize = minor_heap_max_bsz * Max_domains;
 
   /* reserve memory space for minor heaps */
-  heaps_base = caml_mem_map(minor_heap_reservation_bsize, caml_sys_pagesize,
-                1 /* reserve_only */);
+  heaps_base = caml_mem_map(minor_heap_reservation_bsize,
+                            caml_plat_mmap_granularity, 1 /* reserve_only */);
   if (heaps_base == NULL)
     caml_fatal_error("Not enough heap memory to reserve minor heaps");
 

--- a/runtime/platform.c
+++ b/runtime/platform.c
@@ -138,14 +138,15 @@ static uintnat round_up(uintnat size, uintnat align) {
   return (size + align - 1) & ~(align - 1);
 }
 
-intnat caml_plat_mmap_granularity = 0;
+intnat caml_plat_pagesize = 0;
+intnat caml_plat_mmap_alignment = 0;
 
 uintnat caml_mem_round_up_pages(uintnat size)
 {
-  return round_up(size, caml_plat_mmap_granularity);
+  return round_up(size, caml_plat_pagesize);
 }
 
-#define Is_page_aligned(size) ((size & (caml_plat_mmap_granularity - 1)) == 0)
+#define Is_page_aligned(size) ((size & (caml_plat_pagesize - 1)) == 0)
 
 #ifdef DEBUG
 static struct lf_skiplist mmap_blocks = {NULL};
@@ -158,7 +159,7 @@ void* caml_mem_map(uintnat size, uintnat alignment, int reserve_only)
 {
   CAMLassert(Is_power_of_2(alignment));
   CAMLassert(Is_page_aligned(size));
-  alignment = caml_mem_round_up_pages(alignment);
+  alignment = round_up(alignment, caml_plat_mmap_alignment);
 
 #ifdef DEBUG
   if (mmap_blocks.head == NULL) {

--- a/runtime/unix.c
+++ b/runtime/unix.c
@@ -478,7 +478,7 @@ int caml_num_rows_fd(int fd)
 
 void caml_init_os_params(void)
 {
-  caml_plat_mmap_granularity = sysconf(_SC_PAGESIZE);
+  caml_plat_mmap_alignment = caml_plat_pagesize = sysconf(_SC_PAGESIZE);
   return;
 }
 
@@ -541,7 +541,7 @@ void *caml_plat_mem_map(uintnat size, uintnat alignment, int reserve_only)
 {
   void* mem;
 
-  if (alignment > caml_sys_pagesize)
+  if (alignment > caml_plat_mmap_alignment)
     caml_fatal_error("Cannot align memory to %lx on this platform", alignment);
 
   mem = mmap(0, size, reserve_only ? PROT_NONE : (PROT_READ | PROT_WRITE),

--- a/runtime/win32.c
+++ b/runtime/win32.c
@@ -1094,7 +1094,13 @@ void caml_init_os_params(void)
 
   /* Get the system page size */
   GetSystemInfo(&si);
-  caml_sys_pagesize = si.dwPageSize;
+  /* Use the Allocation Granularity rather than the Page Size. Page Size only
+     applies when committing a previous reservation, which for OCaml only occurs
+     when committing a minor heap, which will necessarily be larger than both
+     page size and granularity. This simplifies caml_mem_map, since we can
+     guarantee that trimming will not be required. */
+  CAMLassert(si.dwAllocationGranularity >= si.dwPageSize);
+  caml_sys_pagesize = si.dwAllocationGranularity;
 
   /* Get the number of nanoseconds for each tick in QueryPerformanceCounter */
   QueryPerformanceFrequency(&frequency);

--- a/tools/ci/appveyor/appveyor_build.sh
+++ b/tools/ci/appveyor/appveyor_build.sh
@@ -100,13 +100,19 @@ OCAMLROOT=$(echo "$OCAMLROOT" | cygpath -f - -m)
 
 if [[ $BOOTSTRAP_FLEXDLL = 'false' ]] ; then
   case "$PORT" in
-    cygwin*) ;;
-    *) export PATH="$FLEXDLLROOT:$PATH";;
+    cygwin*)
+      install_flexdll='false';;
+    *)
+      export PATH="$FLEXDLLROOT:$PATH"
+      install_flexdll='true';;
   esac
+else
+  install_flexdll='false'
 fi
 
 case "$1" in
   install)
+    mkdir -p "$CACHE_DIRECTORY"
     if [ ! -e "$CACHE_DIRECTORY/parallel-source" ] || \
        [ "$PARALLEL_URL" != "$(cat "$CACHE_DIRECTORY/parallel-source")" ] ; then
       # Download latest version directly from the repo
@@ -116,7 +122,7 @@ case "$1" in
     cp "$CACHE_DIRECTORY/parallel" /usr/bin
     chmod +x /usr/bin/parallel
     parallel --version
-    if [[ $BOOTSTRAP_FLEXDLL = 'false' ]] ; then
+    if [[ $install_flexdll = 'true' ]] ; then
       mkdir -p "$FLEXDLLROOT"
       cd "$APPVEYOR_BUILD_FOLDER/../flexdll"
       # The objects are always built from the sources
@@ -180,7 +186,7 @@ case "$1" in
       run "$MAKE distclean" $MAKE distclean
     fi
 
-    if [[ $BOOTSTRAP_FLEXDLL = 'false' ]] ; then
+    if [[ $install_flexdll = 'true' ]] ; then
       tar -xzf "$APPVEYOR_BUILD_FOLDER/flexdll.tar.gz"
       cd "flexdll-$FLEXDLL_VERSION"
       $MAKE MSVC_DETECT=0 CHAINS=${PORT%32} support

--- a/tools/ci/inria/main
+++ b/tools/ci/inria/main
@@ -278,8 +278,9 @@ rm -rf "$instdir"
 
 cd testsuite
 if test -n "$jobs" && test -x /usr/bin/parallel
-then PARALLEL="$jobs $PARALLEL" $make --warn-undefined-variables parallel
-else $make --warn-undefined-variables all
+then PARALLEL="$jobs $PARALLEL" $make --warn-undefined-variables \
+                                      SHOW_TIMINGS=1 parallel
+else $make --warn-undefined-variables SHOW_TIMINGS=1 all
 fi
 
 if $bootstrap; then

--- a/tools/ci/inria/main
+++ b/tools/ci/inria/main
@@ -146,6 +146,9 @@ jobs=''
 bootstrap=false
 init_submodule=false
 
+memory_model_tests="tests/memory-model/forbidden.ml \
+tests/memory-model/publish.ml"
+
 case "${OCAML_ARCH}" in
   bsd|solaris)
     make=gmake
@@ -159,10 +162,12 @@ case "${OCAML_ARCH}" in
   cygwin)
     cleanup=true
     check_make_alldepend=true
+    export OCAMLTEST_SKIP_TESTS="$memory_model_tests"
   ;;
   cygwin64)
     cleanup=true
     check_make_alldepend=true
+    export OCAMLTEST_SKIP_TESTS="$memory_model_tests"
   ;;
   mingw)
     build='--build=i686-pc-cygwin'


### PR DESCRIPTION
The first three commits restore the Cygwin port and ready for feedback. In particular, Cygwin's `mmap` cannot be used in the same way as other Unix systems both because it's ultimately backed by `VirtualAlloc` (so can't be used to trim existing regions) and also because there's an unimplemented feature. The reservation part of the minor arena therefore uses `mprotect` instead. These functions in `platform.c` are becoming just a little `#ifdef`-y, though.

With those first three commits, the entire testsuite passes _except_ for `tests/regression/pr9326/gc_set.ml` - i.e. the one test which resizes the minor arena. The fourth commit temporarily works around this problem by having it that on minor arena resize, we decommit the minor heaps but don't `munmap` the memory itself. I've tried debugging this a bit (see [this cygwin list message](https://cygwin.com/pipermail/cygwin/2022-October/252326.html)).

The remaining commits temporarily allow for testing in this PR and are not intended to be merged. While debugging this, I added GC log level for 0x1000 for the memory mapping subsystem - if this sounds useful, I'd be happy to complete that with the Windows side and put it in a separate PR.