### PR TITLE
Add missing "TEST" to float_compare

### DIFF
--- a/Changes
+++ b/Changes
@@ -151,7 +151,7 @@ Working version
 - #11590: Allow installing to a destination path containing spaces.
    (Élie Brami, review by Sébastien Hinderer and David Allsopp)
 
-- #?????: Add missing test declaration to float_compare test, so that it will
+- #11643: Add missing test declaration to float_compare test, so that it will
   run.
   (Stefan Muenzel, review by ????)
 

--- a/Changes
+++ b/Changes
@@ -151,6 +151,10 @@ Working version
 - #11590: Allow installing to a destination path containing spaces.
    (Élie Brami, review by Sébastien Hinderer and David Allsopp)
 
+- #?????: Add missing test declaration to float_compare test, so that it will
+  run.
+  (Stefan Muenzel, review by ????)
+
 ### Bug fixes:
 
 - #11302, #11412: `ocamlc` and `ocamlopt` should not remove generated files

--- a/Changes
+++ b/Changes
@@ -151,10 +151,6 @@ Working version
 - #11590: Allow installing to a destination path containing spaces.
    (Élie Brami, review by Sébastien Hinderer and David Allsopp)
 
-- #11643: Add missing test declaration to float_compare test, so that it will
-  run.
-  (Stefan Muenzel, review by ????)
-
 ### Bug fixes:
 
 - #11302, #11412: `ocamlc` and `ocamlopt` should not remove generated files
@@ -168,6 +164,10 @@ Working version
 - #11436: Fix wrong stack backtrace for out-of-bound exceptions raised
   by leaf functions.
   (Tom Kelly and Xavier Leroy, review by Mark Shinwell)
+
+- #11643: Add missing test declaration to float_compare test, so that it will
+  run.
+  (Stefan Muenzel, review by David Allsopp)
 
 OCaml 5.0
 ---------

--- a/testsuite/tests/basic-float/float_compare.ml
+++ b/testsuite/tests/basic-float/float_compare.ml
@@ -1,3 +1,4 @@
+(* TEST *)
 
 let equal (x : float) (y : float) =
   x, "=", y, (x = y)


### PR DESCRIPTION
In #9945, we observed that the float_compare test in the testsuite isn't run. Since that PR won't be merged very quickly (it's currently at ~2 years), this PR splits out the testsuite changes so that other changes to float comparison will be tested.