### PR TITLE
Correct bootstrap versions of `MKDLL` and `MKMAINDLL`

### DIFF
--- a/configure
+++ b/configure
@@ -803,6 +803,7 @@ install_ocamlnat
 install_source_artifacts
 install_bytecode_programs
 mksharedlibrpath
+mkmaindll_exp
 mkmaindll
 mkdll_exp
 mkdll
@@ -3355,6 +3356,7 @@ OCAML_VERSION_SHORT=5.1
 
 
  # TODO: rename this variable
+
 
 
 
@@ -13799,12 +13801,8 @@ else $as_nop
   supports_shared_libraries=true
 fi
 
-# The flexlink command
-
-flexlink_cmd=flexlink
-flexlink_flags=''
-
 # Define flexlink chain and flags correctly for the different Windows ports
+flexlink_flags=''
 case $host in #(
   i686-*-cygwin) :
     flexdll_chain='cygwin'
@@ -14157,8 +14155,13 @@ esac
 
 mkexe_cmd_exp="$CC"
 
-boot_flexlink_cmd=\
+if $bootstrapping_flexdll
+then :
+  flexlink_cmd=\
 '$(ROOTDIR)/boot/ocamlruns.exe $(ROOTDIR)/boot/flexlink.byte.exe'
+else $as_nop
+  flexlink_cmd=flexlink
+fi
 
 case $cc_basename,$host in #(
   *,x86_64-*-darwin*) :
@@ -14175,13 +14178,7 @@ case $cc_basename,$host in #(
     if $supports_shared_libraries
 then :
   mkexe_cmd_exp="flexlink -exe -chain ${flexdll_chain} ${flexlink_flags}"
-      if $bootstrapping_flexdll
-then :
-  mkexe_cmd=\
-"$boot_flexlink_cmd -exe -chain ${flexdll_chain} ${flexlink_flags}"
-else $as_nop
-  mkexe_cmd="$mkexe_cmd_exp"
-fi
+      mkexe_cmd="${flexlink_cmd} -exe -chain ${flexdll_chain} ${flexlink_flags}"
       mkexe_cflags=''
       mkexe_ldflags_prefix='-link '
 else $as_nop
@@ -14200,13 +14197,7 @@ esac
     ostype="Win32"
     toolchain="mingw"
     mkexe_cmd_exp="flexlink -exe -chain ${flexdll_chain} ${flexlink_flags}"
-    if $bootstrapping_flexdll
-then :
-  mkexe_cmd=\
-"${boot_flexlink_cmd} -exe -chain ${flexdll_chain} ${flexlink_flags}"
-else $as_nop
-  mkexe_cmd="$mkexe_cmd_exp"
-fi
+    mkexe_cmd="${flexlink_cmd} -exe -chain ${flexdll_chain} ${flexlink_flags}"
     mkexe_cflags=''
     mkexe_ldflags_prefix='-link '
     oc_exe_ldflags='-municode'
@@ -14216,13 +14207,7 @@ fi
     toolchain=msvc
     ostype="Win32"
     mkexe_cmd_exp="flexlink -exe -chain ${flexdll_chain} ${flexlink_flags}"
-    if $bootstrapping_flexdll
-then :
-  mkexe_cmd=\
-"${boot_flexlink_cmd} -exe -chain ${flexdll_chain} ${flexlink_flags}"
-else $as_nop
-  mkexe_cmd="$mkexe_cmd_exp"
-fi
+    mkexe_cmd="${flexlink_cmd} -exe -chain ${flexdll_chain} ${flexlink_flags}"
     mkexe_cflags=''
     mkexe_ldflags_prefix='-link '
     mkexe_via_cc_ldflags_prefix='/link '
@@ -15121,9 +15106,9 @@ rpath=''
 mksharedlibrpath=''
 natdynlinkopts=""
 
-mkdll_ld=''
 if test x"$enable_shared" != "xno"
 then :
+  mkdll=''
   case $host in #(
   x86_64-apple-darwin*) :
     mkdll_flags=\
@@ -15132,20 +15117,12 @@ then :
   aarch64-apple-darwin*|arm64-apple-darwin*) :
     mkdll_flags='-shared -undefined dynamic_lookup -Wl,-w'
       supports_shared_libraries=true ;; #(
-  *-*-mingw32) :
-    mkdll_ld="${flexlink_cmd} -chain ${flexdll_chain} ${flexlink_flags}"
-      mkmaindll=\
-"${flexlink_cmd} -maindll -chain ${flexdll_chain} ${flexlink_flags}" ;; #(
-  *-pc-windows) :
-    mkdll_ld="${flexlink_cmd} -chain ${flexdll_chain} ${flexlink_flags}"
-      mkdll_flags=''
-      mkmaindll=\
-"${flexlink_cmd} -maindll -chain ${flexdll_chain} ${flexlink_flags}" ;; #(
-  *-*-cygwin*) :
-    mkdll_ld="${flexlink_cmd} -chain ${flexdll_chain} ${flexlink_flags}"
-      mkdll_flags=''
-      mkmaindll=\
-"${flexlink_cmd} -maindll -chain ${flexdll_chain} ${flexlink_flags}" ;; #(
+  *-*-mingw32|*-pc-windows|*-*-cygwin*) :
+    mkdll_flags="-chain ${flexdll_chain} ${flexlink_flags}"
+      mkdll_exp="flexlink ${mkdll_flags}"
+      mkdll="${flexlink_cmd} ${mkdll_flags}"
+      mkmaindll_exp="flexlink -maindll ${mkdll_flags}"
+      mkmaindll="${flexlink_cmd} -maindll ${mkdll_flags}" ;; #(
   powerpc-ibm-aix*) :
     case $ocaml_cv_cc_vendor in #(
   xlc*) :
@@ -15179,13 +15156,10 @@ esac
       natdynlinkopts="-Wl,-E"
       supports_shared_libraries=true ;; #(
   *) :
-     ;;
+    mkdll='shared-libs-not-available' ;;
 esac
-  if $supports_shared_libraries && test -n "$mkdll_ld"
+  if test -z "$mkdll"
 then :
-  mkdll="$mkdll_ld $mkdll_flags"
-    mkdll_exp="$mkdll"
-else $as_nop
   mkdll="\$(CC) $mkdll_flags"
     mkdll_exp="$CC $mkdll_flags"
 fi
@@ -15193,7 +15167,8 @@ fi
 
 if test -z "$mkmaindll"
 then :
-  mkmaindll=$mkdll_exp
+  mkmaindll_exp="$mkdll_exp"
+  mkmaindll="$mkdll"
 fi
 
 # Configure native dynlink

--- a/configure.ac
+++ b/configure.ac
@@ -189,6 +189,7 @@ AC_SUBST([rpath])
 AC_SUBST([mkdll])
 AC_SUBST([mkdll_exp])
 AC_SUBST([mkmaindll])
+AC_SUBST([mkmaindll_exp])
 AC_SUBST([mksharedlibrpath])
 AC_SUBST([install_bytecode_programs])
 AC_SUBST([install_source_artifacts])
@@ -782,12 +783,8 @@ AS_IF([test x"$enable_shared" = "xno"],
     [AC_MSG_ERROR([Cannot build native Win32 with --disable-shared])])],
   [supports_shared_libraries=true])
 
-# The flexlink command
-
-flexlink_cmd=flexlink
-flexlink_flags=''
-
 # Define flexlink chain and flags correctly for the different Windows ports
+flexlink_flags=''
 AS_CASE([$host],
   [i686-*-cygwin],
     [flexdll_chain='cygwin'
@@ -887,8 +884,10 @@ AS_CASE([$flexdir,$supports_shared_libraries,$flexlink,$host],
 
 mkexe_cmd_exp="$CC"
 
-boot_flexlink_cmd=\
-'$(ROOTDIR)/boot/ocamlruns.exe $(ROOTDIR)/boot/flexlink.byte.exe'
+AS_IF([$bootstrapping_flexdll],
+  [flexlink_cmd=\
+'$(ROOTDIR)/boot/ocamlruns.exe $(ROOTDIR)/boot/flexlink.byte.exe'],
+  [flexlink_cmd=flexlink])
 
 AS_CASE([$cc_basename,$host],
   [*,x86_64-*-darwin*],
@@ -901,10 +900,7 @@ AS_CASE([$cc_basename,$host],
     [common_cppflags="$common_cppflags -U_WIN32"
     AS_IF([$supports_shared_libraries],
       [mkexe_cmd_exp="flexlink -exe -chain ${flexdll_chain} ${flexlink_flags}"
-      AS_IF([$bootstrapping_flexdll],
-        [mkexe_cmd=\
-"$boot_flexlink_cmd -exe -chain ${flexdll_chain} ${flexlink_flags}"],
-        [mkexe_cmd="$mkexe_cmd_exp"])
+      mkexe_cmd="${flexlink_cmd} -exe -chain ${flexdll_chain} ${flexlink_flags}"
       mkexe_cflags=''
       mkexe_ldflags_prefix='-link '],
       [mkexe_extra_flags=''
@@ -917,10 +913,7 @@ AS_CASE([$cc_basename,$host],
     ostype="Win32"
     toolchain="mingw"
     mkexe_cmd_exp="flexlink -exe -chain ${flexdll_chain} ${flexlink_flags}"
-    AS_IF([$bootstrapping_flexdll],
-      [mkexe_cmd=\
-"${boot_flexlink_cmd} -exe -chain ${flexdll_chain} ${flexlink_flags}"],
-      [mkexe_cmd="$mkexe_cmd_exp"])
+    mkexe_cmd="${flexlink_cmd} -exe -chain ${flexdll_chain} ${flexlink_flags}"
     mkexe_cflags=''
     mkexe_ldflags_prefix='-link '
     oc_exe_ldflags='-municode'
@@ -930,10 +923,7 @@ AS_CASE([$cc_basename,$host],
     [toolchain=msvc
     ostype="Win32"
     mkexe_cmd_exp="flexlink -exe -chain ${flexdll_chain} ${flexlink_flags}"
-    AS_IF([$bootstrapping_flexdll],
-      [mkexe_cmd=\
-"${boot_flexlink_cmd} -exe -chain ${flexdll_chain} ${flexlink_flags}"],
-      [mkexe_cmd="$mkexe_cmd_exp"])
+    mkexe_cmd="${flexlink_cmd} -exe -chain ${flexdll_chain} ${flexlink_flags}"
     mkexe_cflags=''
     mkexe_ldflags_prefix='-link '
     mkexe_via_cc_ldflags_prefix='/link '
@@ -1070,9 +1060,9 @@ rpath=''
 mksharedlibrpath=''
 natdynlinkopts=""
 
-mkdll_ld=''
 AS_IF([test x"$enable_shared" != "xno"],
-  [AS_CASE([$host],
+  [mkdll=''
+  AS_CASE([$host],
     [x86_64-apple-darwin*],
       [mkdll_flags=\
 '-shared -undefined dynamic_lookup -Wl,-no_compact_unwind -Wl,-w'
@@ -1080,20 +1070,12 @@ AS_IF([test x"$enable_shared" != "xno"],
     [aarch64-apple-darwin*|arm64-apple-darwin*],
       [mkdll_flags='-shared -undefined dynamic_lookup -Wl,-w'
       supports_shared_libraries=true],
-    [*-*-mingw32],
-      [mkdll_ld="${flexlink_cmd} -chain ${flexdll_chain} ${flexlink_flags}"
-      mkmaindll=\
-"${flexlink_cmd} -maindll -chain ${flexdll_chain} ${flexlink_flags}"],
-    [*-pc-windows],
-      [mkdll_ld="${flexlink_cmd} -chain ${flexdll_chain} ${flexlink_flags}"
-      mkdll_flags=''
-      mkmaindll=\
-"${flexlink_cmd} -maindll -chain ${flexdll_chain} ${flexlink_flags}"],
-    [*-*-cygwin*],
-      [mkdll_ld="${flexlink_cmd} -chain ${flexdll_chain} ${flexlink_flags}"
-      mkdll_flags=''
-      mkmaindll=\
-"${flexlink_cmd} -maindll -chain ${flexdll_chain} ${flexlink_flags}"],
+    [*-*-mingw32|*-pc-windows|*-*-cygwin*],
+      [mkdll_flags="-chain ${flexdll_chain} ${flexlink_flags}"
+      mkdll_exp="flexlink ${mkdll_flags}"
+      mkdll="${flexlink_cmd} ${mkdll_flags}"
+      mkmaindll_exp="flexlink -maindll ${mkdll_flags}"
+      mkmaindll="${flexlink_cmd} -maindll ${mkdll_flags}"],
     [powerpc-ibm-aix*],
       [AS_CASE([$ocaml_cv_cc_vendor],
                [xlc*],
@@ -1120,14 +1102,15 @@ AS_IF([test x"$enable_shared" != "xno"],
       rpath="-Wl,-rpath,"
       mksharedlibrpath="-Wl,-rpath,"
       natdynlinkopts="-Wl,-E"
-      supports_shared_libraries=true])
-  AS_IF([$supports_shared_libraries && test -n "$mkdll_ld"],
-    [mkdll="$mkdll_ld $mkdll_flags"
-    mkdll_exp="$mkdll"],
+      supports_shared_libraries=true],
+      [mkdll='shared-libs-not-available'])
+  AS_IF([test -z "$mkdll"],
     [mkdll="\$(CC) $mkdll_flags"
     mkdll_exp="$CC $mkdll_flags"])])
 
-AS_IF([test -z "$mkmaindll"], [mkmaindll=$mkdll_exp])
+AS_IF([test -z "$mkmaindll"],
+  [mkmaindll_exp="$mkdll_exp"
+  mkmaindll="$mkdll"])
 
 # Configure native dynlink
 

--- a/utils/config.generated.ml.in
+++ b/utils/config.generated.ml.in
@@ -70,7 +70,9 @@ let mkdll, mkexe, mkmaindll =
       ^ {@QS@| @mkexe_extra_flags@|@QS@} ^ {@QS@|@mkexe_ldflags_exp@|@QS@},
     flexlink ^ " -maindll" ^ flags ^ {@QS@|@mkdll_ldflags_exp@|@QS@}
   else
-    {@QS@|@mkdll_exp@|@QS@}, {@QS@|@mkexe_exp@|@QS@}, {@QS@|@mkmaindll@|@QS@}
+    {@QS@|@mkdll_exp@|@QS@},
+    {@QS@|@mkexe_exp@|@QS@},
+    {@QS@|@mkmaindll_exp@|@QS@}
 
 let flambda = @flambda@
 let with_flambda_invariants = @flambda_invariants@


### PR DESCRIPTION
`MKDLL` and `MKMAINDLL` have become hard-coded to assume an external `flexlink`. This doesn't cause a problem with the `mingw-w64` port because it never actually uses them, but it does affect flexdll-bootstrapped Cygwin.

Pleasingly, for a change, this PR deletes more code than it adds!