### PR TITLE
Fix incorrect size in `unreserve_minor_heaps`

### DIFF
--- a/Changes
+++ b/Changes
@@ -18,6 +18,10 @@ Working version
 
 ### Runtime system:
 
+- #11645: Add GC messages for address space reservations when OCAMLRUNPARAM
+  option v includes 0x1000.
+  (David Allsopp, review by ???)
+
 ### Code generation and optimizations:
 
 - #8998, #11321, #11430: change mangling of OCaml long identifiers

--- a/man/ocamlrun.1
+++ b/man/ocamlrun.1
@@ -271,6 +271,13 @@ Computation of compaction-triggering condition.
 
 .BR 0x400
 Output GC statistics at program exit, in the same format as Gc.print_stat.
+
+.BR 0x800
+GC debugging messages.
+
+.BR 0x1000
+Address space reservation changes.
+
 .TP
 .BR w \ (window_size)
 Set size of the window used by major GC for smoothing out variations in

--- a/manual/src/cmds/runtime.etex
+++ b/manual/src/cmds/runtime.etex
@@ -190,6 +190,8 @@ The following environment variables are also consulted:
            executable file, resolving shared libraries).
         \item[512 (= 0x200)] Computation of compaction-triggering condition.
         \item[1024 (= 0x400)] Output GC statistics at program exit.
+        \item[2048 (= 0x800)] GC debugging messages.
+        \item[4096 (= 0x1000)] Address space reservation changes.
   \end{options}
   \item[V] ("verify_heap") runs an integrity check on the heap just after
     the completion of a major GC cycle

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -777,7 +777,7 @@ static void unreserve_minor_heaps() {
 
   size = caml_minor_heaps_end - caml_minor_heaps_start;
   CAMLassert (Bsize_wsize(caml_minor_heap_max_wsz) * Max_domains == size);
-  caml_mem_unmap((void *) caml_minor_heaps_start, size);
+  caml_mem_unmap((void *) caml_minor_heaps_start, size + caml_sys_pagesize);
 }
 
 static void stw_resize_minor_heap_reservation(caml_domain_state* domain,

--- a/runtime/platform.c
+++ b/runtime/platform.c
@@ -216,7 +216,7 @@ again:
   munmap((void*)aligned_end, (base + alloc_sz) - aligned_end);
 #endif
 #ifdef DEBUG
-  caml_lf_skiplist_insert(&mmap_blocks, aligned_start, size);
+  caml_lf_skiplist_insert(&mmap_blocks, aligned_start, alloc_sz);
 #endif
   return (void*)aligned_start;
 }


### PR DESCRIPTION
@gasche commented in https://github.com/ocaml/ocaml/pull/11632#pullrequestreview-1143922816:
> Can we make assertions about the amount of memory used/mmapped/committed after the runtime ends?

For this particular bug, it turns out there was such code (written by me in #10908). However, as per https://github.com/ocaml/ocaml/pull/11632#issuecomment-1280716058:
> I expect the book-keeping might itself be bug-prone

It turns out it is, and the bug in the book-keeping masked a bug in the runtime. The first commit in this PR fixes the book-keeping for the debug runtime. At this point, the bug affecting the Cygwin port should now trigger an assertion failure on _all_ platforms. When the minor arena is initialised, an extra page is effectively added to the total:
https://github.com/ocaml/ocaml/blob/dfe956891288c304e1a4530d05ce5f256db0fff3/runtime/domain.c#L727-L728
combining with:
https://github.com/ocaml/ocaml/blob/dfe956891288c304e1a4530d05ce5f256db0fff3/runtime/platform.c#L157

However, this is not accounted for in `unreserve_minor_heaps`, and so the size passed to `munmap` is in fact one page short of the total amount. Correcting this fixes the Cygwin port (possibly just by avoiding a bug in its malloc implementation).

There are two things I'm wondering:
1. The 0x1000 log level for memory operations seems potentially useful in future, so I've completed the commit (it was borrowed from #11642) and also documented the new 0x800 debugging level.
2. (more importantly) Why do we add an extra page to the minor arena? Or rather, is the bug actually in one of the three lines of code above?