### PR TITLE
Clarify docs for `Domain.recommended_domain_count`

### DIFF
--- a/stdlib/domain.mli
+++ b/stdlib/domain.mli
@@ -78,7 +78,10 @@ val is_main_domain : unit -> bool
 (** [is_main_domain ()] returns true if called from the initial domain. *)
 
 val recommended_domain_count : unit -> int
-(** The recommended maximum number of domains to be spawned. *)
+(** The recommended maximum number of domains which should be running
+    simultaneously (including domains already running).
+
+    The value returned is at least [1]. *)
 
 module DLS : sig
 (** Domain-local Storage *)


### PR DESCRIPTION
The documentation for `Domain.recommended_domain_count` refers to domains being spawned, but this is potentially unclear in two ways:
1. If it did refer to spawns, then the value returned should be 1 less, to account for the initial domain
2. It's not explicit that if a domain has terminated you can spawn another one

I've reworded it to refer to simultaneously running domains instead (which is what it's really about - you don't want domains fighting over CPU threads). I used "running" rather than "executing" because a domain could be blocked on I/O (and so possibly be interpreted as not "executing" because it's "blocked") but still be engaged in runtime activities (marking/sweeping, STW, etc.).

I've also explicitly document the fact that the value is guaranteed to be at least 1, to be clear that that property can be relied on (for example if using it as a default value - cf. ocaml-multicore/domainslib#91):
https://github.com/ocaml/ocaml/blob/28dfeb0f61e96ab7bf1aef77e99d65ae68863416/runtime/domain.c#L1810-L1812