### PR TITLE
Comment hash function in `pos_initial`

### DIFF
--- a/runtime/addrmap.c
+++ b/runtime/addrmap.c
@@ -23,6 +23,8 @@
 Caml_inline uintnat pos_initial(struct addrmap* t, value key)
 {
   uintnat pos = (uintnat)key;
+  /* Fast hash (but not especially good). Ensures each output bit depends on at
+     least 17 bits of input. */
   pos *= 0xcc9e2d51;
   pos ^= (pos >> 17);
 


### PR DESCRIPTION
Addresses a comment from the multicore merge in #10861.

It may be possible/desirable to improve on this in a future release.