### PR TITLE
Fix off-by-one in Windows `caml_mem_map`

### DIFF
--- a/Changes
+++ b/Changes
@@ -328,6 +328,9 @@ OCaml 5.0
   no-flat-float-array mode, it's more efficient and avoids a a race condition
   (Xavier Leroy, report by Guillaume Munch-Maccagnoni, review by David Allsopp)
 
+- #11652: Fix benign off-by-one error in Windows implementation of caml_mem_map.
+  (David Allsopp, review by Gabriel Scherer)
+
 ### Code generation and optimizations:
 
 - #10972: ARM64 multicore support: OCaml & C stack separation;

--- a/man/ocamlrun.1
+++ b/man/ocamlrun.1
@@ -271,6 +271,10 @@ Computation of compaction-triggering condition.
 
 .BR 0x400
 Output GC statistics at program exit, in the same format as Gc.print_stat.
+
+.BR 0x800
+GC debugging messages.
+
 .TP
 .BR w \ (window_size)
 Set size of the window used by major GC for smoothing out variations in

--- a/manual/src/cmds/runtime.etex
+++ b/manual/src/cmds/runtime.etex
@@ -190,6 +190,7 @@ The following environment variables are also consulted:
            executable file, resolving shared libraries).
         \item[512 (= 0x200)] Computation of compaction-triggering condition.
         \item[1024 (= 0x400)] Output GC statistics at program exit.
+        \item[2048 (= 0x800)] GC debugging messages.
   \end{options}
   \item[V] ("verify_heap") runs an integrity check on the heap just after
     the completion of a major GC cycle

--- a/runtime/platform.c
+++ b/runtime/platform.c
@@ -194,7 +194,7 @@ again:
      time specify the address. */
   VirtualFree(mem, 0, MEM_RELEASE);
   mem = VirtualAlloc((void*)aligned_start,
-                     aligned_end - aligned_start + 1,
+                     aligned_end - aligned_start,
                      MEM_RESERVE | (reserve_only ? 0 : MEM_COMMIT),
                      reserve_only ? PAGE_NOACCESS : PAGE_READWRITE);
   if (mem == NULL) {
@@ -216,7 +216,8 @@ again:
   munmap((void*)aligned_end, (base + alloc_sz) - aligned_end);
 #endif
 #ifdef DEBUG
-  caml_lf_skiplist_insert(&mmap_blocks, aligned_start, size);
+  caml_lf_skiplist_insert(&mmap_blocks,
+                          aligned_start, aligned_end - aligned_start);
 #endif
   return (void*)aligned_start;
 }


### PR DESCRIPTION
Following on from #11645, there is an actual error in the Windows implementation of `caml_mem_map`.

The error is benign, because the size isn't actually passed to `VirtualFree`. The size computation before was accidentally acting as though `aligned_end` pointed to the last byte of the block pointed to by `aligned_start` (hence the `+ 1`), but it actually points to the first byte _after_ the block (which is also aligned). Both the off-by-one, and the dodgy use of `size` in the debug book-keeping is fixed.

While here, as it's for 5.0, I also cherry-picked the `0x800` addition to the man{page,ual}.