### PR TITLE
Add the -no-absname option to ocamlc, ocamlopt and ocamldep 

### DIFF
--- a/Changes
+++ b/Changes
@@ -122,6 +122,9 @@ Working version
   modules with mismatching -for-pack
   (Pierre Chambart and Vincent Laviron, review by Mark Shinwell)
 
+- #11653: Add the -no-absname option to ocamlc, ocamlopt and ocamldep.
+  (Abiola Abdulsalam, review by Sébastien Hinderer and Florian Angeletti)
+
 ### Internal/compiler-libs changes:
 - #11027: Separate typing counter-examples from type_pat into retype_pat;
   type_pat is no longer in CPS.

--- a/driver/main_args.ml
+++ b/driver/main_args.ml
@@ -30,6 +30,10 @@ let mk_alert f =
 let mk_absname f =
   "-absname", Arg.Unit f, " Show absolute filenames in error messages"
 
+let mk_no_absname f =
+    "-no-absname", Arg.Unit f,
+    " Do not try to show absolute filenames in error messages (default)"
+
 let mk_annot f =
   "-annot", Arg.Unit f, " (deprecated) Save information in <filename>.annot"
 
@@ -747,6 +751,7 @@ let mk__ f =
 
 module type Common_options = sig
   val _absname : unit -> unit
+  val _no_absname : unit -> unit
   val _alert : string -> unit
   val _I : string -> unit
   val _labels : unit -> unit
@@ -997,6 +1002,7 @@ struct
     mk_a F._a;
     mk_alert F._alert;
     mk_absname F._absname;
+    mk_no_absname F._no_absname;
     mk_annot F._annot;
     mk_binannot F._binannot;
     mk_c F._c;
@@ -1114,6 +1120,7 @@ module Make_bytetop_options (F : Bytetop_options) =
 struct
   let list = [
     mk_absname F._absname;
+    mk_no_absname F._no_absname;
     mk_alert F._alert;
     mk_I F._I;
     mk_init F._init;
@@ -1183,6 +1190,7 @@ struct
     mk_a F._a;
     mk_alert F._alert;
     mk_absname F._absname;
+    mk_no_absname F._no_absname;
     mk_afl_instrument F._afl_instrument;
     mk_afl_inst_ratio F._afl_inst_ratio;
     mk_annot F._annot;
@@ -1343,6 +1351,7 @@ end;;
 module Make_opttop_options (F : Opttop_options) = struct
   let list = [
     mk_absname F._absname;
+    mk_no_absname F._no_absname;
     mk_alert F._alert;
     mk_compact F._compact;
     mk_I F._I;
@@ -1448,6 +1457,7 @@ module Make_ocamldoc_options (F : Ocamldoc_options) =
 struct
   let list = [
     mk_absname F._absname;
+    mk_no_absname F._no_absname;
     mk_alert F._alert;
     mk_I F._I;
     mk_impl F._impl;
@@ -1549,6 +1559,7 @@ module Default = struct
     let _alias_deps = clear transparent_modules
     let _app_funct = set applicative_functors
     let _labels = clear classic
+    let _no_absname = clear Clflags.absname
     let _no_alias_deps = set transparent_modules
     let _no_app_funct = clear applicative_functors
     let _no_principal = clear principal

--- a/driver/main_args.mli
+++ b/driver/main_args.mli
@@ -18,6 +18,7 @@
 
 module type Common_options = sig
   val _absname : unit -> unit
+  val _no_absname : unit -> unit
   val _alert : string -> unit
   val _I : string -> unit
   val _labels : unit -> unit

--- a/driver/makedepend.ml
+++ b/driver/makedepend.ml
@@ -593,6 +593,8 @@ let run_main argv =
     Clflags.add_arguments __LOC__ [
       "-absname", Arg.Set Clflags.absname,
         " Show absolute filenames in error messages";
+      "-no-absname", Arg.Clear Clflags.absname,
+        " Do not try to show absolute filenames in error messages (default)";
       "-all", Arg.Set all_dependencies,
         " Generate dependencies on all files";
       "-allow-approx", Arg.Set allow_approximation,

--- a/man/ocaml.1
+++ b/man/ocaml.1
@@ -70,6 +70,9 @@ The following command-line options are recognized by
 .B \-absname
 Show absolute filenames in error messages.
 .TP
+.B \-no-absname
+Do not try to show absolute filenames in error messages.
+.TP
 .BI \-I \ directory
 Add the given directory to the list of directories searched for
 source and compiled files. By default, the current directory is

--- a/man/ocamlc.1
+++ b/man/ocamlc.1
@@ -203,6 +203,9 @@ excluding the filename.
 .B \-absname
 Show absolute filenames in error messages.
 .TP
+.B \-no-absname
+Do not try to show absolute filenames in error messages.
+.TP
 .B \-annot
 Deprecated since 4.11. Please use
 .BR \-bin-annot

--- a/man/ocamldep.1
+++ b/man/ocamldep.1
@@ -60,6 +60,9 @@ The following command-line options are recognized by
 .B \-absname
 Show absolute filenames in error messages.
 .TP
+.B \-no-absname
+Do not try to show absolute filenames in error messages (default).
+.TP
 .B \-all
 Generate dependencies on all required files, rather than assuming
 implicit dependencies.

--- a/man/ocamlopt.1
+++ b/man/ocamlopt.1
@@ -166,6 +166,9 @@ excluding the filename.
 .B \-absname
 Show absolute filenames in error messages.
 .TP
+.B \-no-absname
+Do not try to show absolute filenames in error messages.
+.TP
 .B \-annot
 Deprecated since OCaml 4.11. Please use
 .BR \-bin-annot

--- a/manual/src/cmds/unified-options.etex
+++ b/manual/src/cmds/unified-options.etex
@@ -60,6 +60,9 @@ command line, unless the "-noautolink" option is given.
 \item["-absname"]
 Force error messages to show absolute paths for file names.
 
+\item["-no-absname"]
+Do not try to show absolute filenames in error messages.
+
 \notop{\item["-annot"]
 Deprecated since OCaml 4.11. Please use "-bin-annot" instead.
 }%notop


### PR DESCRIPTION
Addressing #5561 
I am adding a -no-absname #counterpart to the -absname flag that matches the current default of the compiler.