### PR TITLE
Makefile: Add a missing dependency to the coldstart rule

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,7 @@ COMPLIBDIR=$(LIBDIR)/compiler-libs
 TOPINCLUDES=$(addprefix -I otherlibs/,$(filter-out %threads,$(OTHERLIBRARIES)))
 
 ifeq "$(BOOTSTRAPPING_FLEXDLL)" "false"
-  COLDSTART_DEPS =
+  COLDSTART_DEPS = runtime/primitives
 else
   COLDSTART_DEPS = boot/ocamlruns$(EXE)
 endif


### PR DESCRIPTION
When `BOOTSTRAPPING_FLEXDLL` is `false` the rule for `coldstart` uses `$(USE_RUNTIME_PRIMS)` which is defined as `-use-prims ../runtime/primitives`

For some reason, in ocaml-solo5 it will trigger the following failure:
```
make -C stdlib \
  OCAMLRUN='$(ROOTDIR)/runtime/ocamlrun' \
  CAMLC='$(BOOT_OCAMLC) -use-prims ../runtime/primitives' all
make[2]: Entering directory '/home/kit_ty_kate/work/ocaml-solo5/ocaml/stdlib'
make[2]: *** No rule to make target '../runtime/primitives', needed by 'camlinternalFormatBasics.cmo'.  Stop.
make[2]: Leaving directory '/home/kit_ty_kate/work/ocaml-solo5/ocaml/stdlib'
make[1]: *** [Makefile:176: coldstart] Error 2
make[1]: Leaving directory '/home/kit_ty_kate/work/ocaml-solo5/ocaml'
make: *** [Makefile:113: ocaml] Error 2
```

*to backport to 5.0*