### PR TITLE
Makefile: Make the runtime_asm_objects variable rely on $(ARCH) to simplify ad-hoc modifications

### DIFF
--- a/configure
+++ b/configure
@@ -15444,9 +15444,9 @@ esac
 
 case $ccomptype in #(
   msvc) :
-    runtime_asm_objects=${arch}nt.${OBJEXT} ;; #(
+    runtime_asm_objects="\$(ARCH)nt.${OBJEXT}" ;; #(
   *) :
-    runtime_asm_objects=${arch}.${OBJEXT} ;;
+    runtime_asm_objects="\$(ARCH).${OBJEXT}" ;;
 esac
 
 case $enable_native_compiler,$has_native_backend in #(

--- a/configure.ac
+++ b/configure.ac
@@ -1273,8 +1273,8 @@ AS_CASE([$host],
 
 AS_CASE([$ccomptype],
   [msvc],
-    [runtime_asm_objects=${arch}nt.${OBJEXT}],
-  [runtime_asm_objects=${arch}.${OBJEXT}])
+    [runtime_asm_objects="\$(ARCH)nt.${OBJEXT}"],
+  [runtime_asm_objects="\$(ARCH).${OBJEXT}"])
 
 AS_CASE([$enable_native_compiler,$has_native_backend],
   [no,*],


### PR DESCRIPTION
This makes the configuration of ocaml-solo5 (which modifies some files such as `Makefile.config` after the configure script has been called) a little easier