### PR TITLE
fix: Migrate to integrated assembler for Darwin

### DIFF
--- a/Changes
+++ b/Changes
@@ -20,6 +20,9 @@ Working version
 
 ### Code generation and optimizations:
 
+- #11658: Migrate to integrated assembler for Darwin
+  extern assembler is deprecated (Élie BRAMI, review by I hope someone)
+
 - #8998, #11321, #11430: change mangling of OCaml long identifiers
   from `camlModule__name_NNN` to `camlModule.name_NNN`.  The previous
   mangling schema, using `__`, was ambiguous.

--- a/configure
+++ b/configure
@@ -15702,9 +15702,6 @@ esac ;; #(
   x86_64-pc-windows,*) :
     default_as="ml64 -nologo -Cp -c -Fo"
     default_aspp="$default_as" ;; #(
-  *-*-darwin*,clang-*) :
-    default_as="$default_as -Wno-trigraphs"
-    default_aspp="$default_as" ;; #(
   *) :
      ;;
 esac

--- a/configure.ac
+++ b/configure.ac
@@ -1382,9 +1382,6 @@ AS_CASE([$as_target,$ocaml_cv_cc_vendor],
   [x86_64-pc-windows,*],
     [default_as="ml64 -nologo -Cp -c -Fo"
     default_aspp="$default_as"],
-  [*-*-darwin*,clang-*],
-    [default_as="$default_as -Wno-trigraphs"
-    default_aspp="$default_as"],
   [])
 
 AS_IF([test "$with_pic"],


### PR DESCRIPTION
A small PR not related to space in path.

This is linked to https://github.com/ocaml/ocaml/pull/10176 A similar issue appeared with clang in cctools (Darwin):
```
as: this system assembler is deprecated. Please migrate to the clang integrated assembler (`as -q').
```
https://developer.apple.com/documentation/xcode-release-notes/xcode-12-release-notes#Deprecations