### PR TITLE
remove the -force-tmc flag

### DIFF
--- a/driver/main_args.ml
+++ b/driver/main_args.ml
@@ -471,9 +471,6 @@ let mk_no_unboxed_types f =
   "-no-unboxed-types", Arg.Unit f,
   " unannotated unboxable types will not be unboxed (default)"
 
-let mk_force_tmc f =
-  "-force-tmc", Arg.Unit f, " Rewrite all possible TMC calls"
-
 let mk_unsafe f =
   "-unsafe", Arg.Unit f,
   " Do not compile bounds checking on array and string access"
@@ -765,7 +762,6 @@ module type Common_options = sig
   val _no_strict_sequence : unit -> unit
   val _strict_formats : unit -> unit
   val _no_strict_formats : unit -> unit
-  val _force_tmc : unit -> unit
   val _unboxed_types : unit -> unit
   val _no_unboxed_types : unit -> unit
   val _version : unit -> unit
@@ -1061,7 +1057,6 @@ struct
     mk_strict_formats F._strict_formats;
     mk_no_strict_formats F._no_strict_formats;
     mk_thread F._thread;
-    mk_force_tmc F._force_tmc;
     mk_unboxed_types F._unboxed_types;
     mk_no_unboxed_types F._no_unboxed_types;
     mk_unsafe F._unsafe;
@@ -1267,7 +1262,6 @@ struct
     mk_strict_formats F._strict_formats;
     mk_no_strict_formats F._no_strict_formats;
     mk_thread F._thread;
-    mk_force_tmc F._force_tmc;
     mk_unbox_closures F._unbox_closures;
     mk_unbox_closures_factor F._unbox_closures_factor;
     mk_inline_max_unroll F._inline_max_unroll;
@@ -1469,7 +1463,6 @@ struct
     mk_strict_formats F._strict_formats;
     mk_no_strict_formats F._no_strict_formats;
     mk_thread F._thread;
-    mk_force_tmc F._force_tmc;
     mk_unboxed_types F._unboxed_types;
     mk_no_unboxed_types F._no_unboxed_types;
     mk_unsafe_string;
@@ -1773,7 +1766,6 @@ module Default = struct
     let _noprompt = set noprompt
     let _nopromptcont = set nopromptcont
     let _stdin () = (* placeholder: file_argument ""*) ()
-    let _force_tmc = set force_tmc
     let _version () = print_version ()
     let _vnum () = print_version_num ()
     let _eval (_:string) = ()
@@ -1810,7 +1802,6 @@ module Default = struct
         "Profiling with \"gprof\" (option `-p') is only supported up to \
          OCaml 4.08.0"
     let _shared () = shared := true; dlcode := true
-    let _force_tmc = set force_tmc
     let _v () = Compenv.print_version_and_library "native-code compiler"
   end
 
@@ -1831,7 +1822,6 @@ module Default = struct
     let _pp s = Clflags.preprocessor := (Some s)
     let _ppx s = Clflags.all_ppx := (s :: (!Clflags.all_ppx))
     let _thread = set Clflags.use_threads
-    let _force_tmc = set force_tmc
     let _v () = Compenv.print_version_and_library "documentation generator"
     let _verbose = set Clflags.verbose
     let _version = Compenv.print_version_string
@@ -1865,7 +1855,6 @@ third-party libraries such as Lwt, but with a different API."
     let _output_complete_exe () =
       _output_complete_obj (); output_complete_executable := true
     let _output_obj () = output_c_object := true; custom_runtime := true
-    let _force_tmc = set force_tmc
     let _use_prims s = use_prims := s
     let _use_runtime s = use_runtime := s
     let _v () = Compenv.print_version_and_library "compiler"

--- a/driver/main_args.mli
+++ b/driver/main_args.mli
@@ -40,7 +40,6 @@ module type Common_options = sig
   val _no_strict_sequence : unit -> unit
   val _strict_formats : unit -> unit
   val _no_strict_formats : unit -> unit
-  val _force_tmc : unit -> unit
   val _unboxed_types : unit -> unit
   val _no_unboxed_types : unit -> unit
   val _version : unit -> unit

--- a/utils/clflags.ml
+++ b/utils/clflags.ml
@@ -138,7 +138,6 @@ let profile_columns : Profile.column list ref = ref [] (* -dprofile/-dtimings *)
 
 let native_code = ref false             (* set to true under ocamlopt *)
 
-let force_tmc = ref false               (* -force-tmc *)
 let force_slash = ref false             (* for ocamldep *)
 let clambda_checks = ref false          (* -clambda-checks *)
 let cmm_invariants =

--- a/utils/clflags.mli
+++ b/utils/clflags.mli
@@ -191,7 +191,6 @@ val dlcode : bool ref
 val pic_code : bool ref
 val runtime_variant : string ref
 val with_runtime : bool ref
-val force_tmc : bool ref
 val force_slash : bool ref
 val keep_docs : bool ref
 val keep_locs : bool ref


### PR DESCRIPTION
-force-tmc was initially implemented by Frédéric Bour as a way to implement "automatic tmc optimization" on top of the default behavior which is "opt-in tmc optimization". We later decided to disable it, because its usage was in tension with the goals we were setting for the opt-in mode (in particular: have proper warnings and errors when something that could be unexpected is going on).

It was kept for debugging purposes, and apparently found a way to sneak in the final merge for TMC (very probably my mistake), but in a state where it is actually a no-op.

Note: this PR is against 5.0, it would have to be cherry-picked in trunk as well.