### PR TITLE
[code readability] update ctype instantiation comments and variable names

### DIFF
--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -1004,12 +1004,14 @@ let rec find_repr p1 =
 (*
    Generic nodes are duplicated, while non-generic nodes are left
    as-is.
-   During instantiation, the description of a generic node is first
-   replaced by a link to a stub ([Tsubst (newvar ())]). Once the
-   copy is made, it replaces the stub.
-   After instantiation, the description of generic node, which was
-   stored by [save_desc], must be put back, using [cleanup_types].
-*)
+
+   During instantiation, the result of copying a generic node is
+   "cached" in-place by temporarily mutating the node description by
+   a stub [Tsubst (newvar ())] using [For_copy.redirect_desc]. The
+   scope of this mutation is determined by the [copy_scope] parameter,
+   and the [For_copy.with_scope] helper is in charge of creating a new
+   scope and performing the necessary book-keeping -- in particular
+   reverting the in-place updates after the instantiation is done. *)
 
 let abbreviations = ref (ref Mnil)
   (* Abbreviation memorized. *)


### PR DESCRIPTION
This small PRs includes changes that would have made my life easier when trying to review #11600:
- update an outdated comment about how instantiation works
- consistently use `copy_scope` as a variable name for copy scopes instead of `cleanup_scope` (whose meaning is now hidden under the `Btype.For_copy` abstraction barrier) or `scope` (which usually means "scope level" rather than "copy scope").

(It conflicts with #11600 in minor ways but it will be trivial to rebase one if the other is merged.)

Who might volunteer to look at this small change? I guess @garrigue (this is a very small PR) or @Octachron or @lpw25 or @nojb or @t6s.