### PR TITLE
List.mli: 'acc is the type of an accumulator

### DIFF
--- a/stdlib/list.mli
+++ b/stdlib/list.mli
@@ -201,18 +201,18 @@ val concat_map : ('a -> 'b list) -> 'a list -> 'b list
 *)
 
 val fold_left_map :
-  ('a -> 'b -> 'a * 'c) -> 'a -> 'b list -> 'a * 'c list
+  ('acc -> 'b -> 'acc * 'c) -> 'acc -> 'b list -> 'acc * 'c list
 (** [fold_left_map] is  a combination of [fold_left] and [map] that threads an
     accumulator through calls to [f].
     @since 4.11.0
 *)
 
-val fold_left : ('a -> 'b -> 'a) -> 'a -> 'b list -> 'a
+val fold_left : ('acc -> 'b -> 'acc) -> 'acc -> 'b list -> 'acc
 (** [fold_left f init [b1; ...; bn]] is
    [f (... (f (f init b1) b2) ...) bn].
  *)
 
-val fold_right : ('a -> 'b -> 'b) -> 'a list -> 'b -> 'b
+val fold_right : ('a -> 'acc -> 'acc) -> 'a list -> 'acc -> 'acc
 (** [fold_right f [a1; ...; an] init] is
    [f a1 (f a2 (... (f an init) ...))]. Not tail-recursive.
  *)
@@ -241,7 +241,7 @@ val rev_map2 : ('a -> 'b -> 'c) -> 'a list -> 'b list -> 'c list
  *)
 
 val fold_left2 :
-  ('a -> 'b -> 'c -> 'a) -> 'a -> 'b list -> 'c list -> 'a
+  ('acc -> 'b -> 'c -> 'acc) -> 'acc -> 'b list -> 'c list -> 'acc
 (** [fold_left2 f init [a1; ...; an] [b1; ...; bn]] is
    [f (... (f (f init a1 b1) a2 b2) ...) an bn].
    @raise Invalid_argument if the two lists are determined
@@ -249,7 +249,7 @@ val fold_left2 :
  *)
 
 val fold_right2 :
-  ('a -> 'b -> 'c -> 'c) -> 'a list -> 'b list -> 'c -> 'c
+  ('a -> 'b -> 'acc -> 'acc) -> 'a list -> 'b list -> 'acc -> 'acc
 (** [fold_right2 f [a1; ...; an] [b1; ...; bn] init] is
    [f a1 b1 (f a2 b2 (... (f an bn init) ...))].
    @raise Invalid_argument if the two lists are determined

--- a/stdlib/list.mli
+++ b/stdlib/list.mli
@@ -201,13 +201,13 @@ val concat_map : ('a -> 'b list) -> 'a list -> 'b list
 *)
 
 val fold_left_map :
-  ('acc -> 'b -> 'acc * 'c) -> 'acc -> 'b list -> 'acc * 'c list
+  ('acc -> 'a -> 'acc * 'b) -> 'acc -> 'a list -> 'acc * 'b list
 (** [fold_left_map] is  a combination of [fold_left] and [map] that threads an
     accumulator through calls to [f].
     @since 4.11.0
 *)
 
-val fold_left : ('acc -> 'b -> 'acc) -> 'acc -> 'b list -> 'acc
+val fold_left : ('acc -> 'a -> 'acc) -> 'acc -> 'a list -> 'acc
 (** [fold_left f init [b1; ...; bn]] is
    [f (... (f (f init b1) b2) ...) bn].
  *)
@@ -241,7 +241,7 @@ val rev_map2 : ('a -> 'b -> 'c) -> 'a list -> 'b list -> 'c list
  *)
 
 val fold_left2 :
-  ('acc -> 'b -> 'c -> 'acc) -> 'acc -> 'b list -> 'c list -> 'acc
+  ('acc -> 'a -> 'b -> 'acc) -> 'acc -> 'a list -> 'b list -> 'acc
 (** [fold_left2 f init [a1; ...; an] [b1; ...; bn]] is
    [f (... (f (f init a1 b1) a2 b2) ...) an bn].
    @raise Invalid_argument if the two lists are determined

--- a/stdlib/listLabels.mli
+++ b/stdlib/listLabels.mli
@@ -201,18 +201,18 @@ val concat_map : f:('a -> 'b list) -> 'a list -> 'b list
 *)
 
 val fold_left_map :
-  f:('a -> 'b -> 'a * 'c) -> init:'a -> 'b list -> 'a * 'c list
+  f:('acc -> 'b -> 'acc * 'c) -> init:'acc -> 'b list -> 'acc * 'c list
 (** [fold_left_map] is  a combination of [fold_left] and [map] that threads an
     accumulator through calls to [f].
     @since 4.11.0
 *)
 
-val fold_left : f:('a -> 'b -> 'a) -> init:'a -> 'b list -> 'a
+val fold_left : f:('acc -> 'b -> 'acc) -> init:'acc -> 'b list -> 'acc
 (** [fold_left ~f ~init [b1; ...; bn]] is
    [f (... (f (f init b1) b2) ...) bn].
  *)
 
-val fold_right : f:('a -> 'b -> 'b) -> 'a list -> init:'b -> 'b
+val fold_right : f:('a -> 'acc -> 'acc) -> 'a list -> init:'acc -> 'acc
 (** [fold_right ~f [a1; ...; an] ~init] is
    [f a1 (f a2 (... (f an init) ...))]. Not tail-recursive.
  *)
@@ -241,7 +241,7 @@ val rev_map2 : f:('a -> 'b -> 'c) -> 'a list -> 'b list -> 'c list
  *)
 
 val fold_left2 :
-  f:('a -> 'b -> 'c -> 'a) -> init:'a -> 'b list -> 'c list -> 'a
+  f:('acc -> 'b -> 'c -> 'acc) -> init:'acc -> 'b list -> 'c list -> 'acc
 (** [fold_left2 ~f ~init [a1; ...; an] [b1; ...; bn]] is
    [f (... (f (f init a1 b1) a2 b2) ...) an bn].
    @raise Invalid_argument if the two lists are determined
@@ -249,7 +249,7 @@ val fold_left2 :
  *)
 
 val fold_right2 :
-  f:('a -> 'b -> 'c -> 'c) -> 'a list -> 'b list -> init:'c -> 'c
+  f:('a -> 'b -> 'acc -> 'acc) -> 'a list -> 'b list -> init:'acc -> 'acc
 (** [fold_right2 ~f [a1; ...; an] [b1; ...; bn] ~init] is
    [f a1 b1 (f a2 b2 (... (f an bn init) ...))].
    @raise Invalid_argument if the two lists are determined

--- a/stdlib/listLabels.mli
+++ b/stdlib/listLabels.mli
@@ -201,13 +201,13 @@ val concat_map : f:('a -> 'b list) -> 'a list -> 'b list
 *)
 
 val fold_left_map :
-  f:('acc -> 'b -> 'acc * 'c) -> init:'acc -> 'b list -> 'acc * 'c list
+  f:('acc -> 'a -> 'acc * 'b) -> init:'acc -> 'a list -> 'acc * 'b list
 (** [fold_left_map] is  a combination of [fold_left] and [map] that threads an
     accumulator through calls to [f].
     @since 4.11.0
 *)
 
-val fold_left : f:('acc -> 'b -> 'acc) -> init:'acc -> 'b list -> 'acc
+val fold_left : f:('acc -> 'a -> 'acc) -> init:'acc -> 'a list -> 'acc
 (** [fold_left ~f ~init [b1; ...; bn]] is
    [f (... (f (f init b1) b2) ...) bn].
  *)
@@ -241,7 +241,7 @@ val rev_map2 : f:('a -> 'b -> 'c) -> 'a list -> 'b list -> 'c list
  *)
 
 val fold_left2 :
-  f:('acc -> 'b -> 'c -> 'acc) -> init:'acc -> 'b list -> 'c list -> 'acc
+  f:('acc -> 'a -> 'b -> 'acc) -> init:'acc -> 'a list -> 'b list -> 'acc
 (** [fold_left2 ~f ~init [a1; ...; an] [b1; ...; bn]] is
    [f (... (f (f init a1 b1) a2 b2) ...) an bn].
    @raise Invalid_argument if the two lists are determined

--- a/testsuite/tests/tool-toplevel/tracing.compilers.reference
+++ b/testsuite/tests/tool-toplevel/tracing.compilers.reference
@@ -1,4 +1,4 @@
-- : ('a -> 'b -> 'a) -> 'a -> 'b list -> 'a = <fun>
+- : ('acc -> 'a -> 'acc) -> 'acc -> 'a list -> 'acc = <fun>
 List.fold_left is now traced.
 - : int = 0
 List.fold_left <-- <fun>


### PR DESCRIPTION
so that it's more obvious how to use a function when reading it's type signature