### PR TITLE
ocamlmklib: use `ar rcs` instead of `ar rc`

### DIFF
--- a/Changes
+++ b/Changes
@@ -502,8 +502,8 @@ OCaml 5.0
   (Sébastien Hinderer, review by David Allsopp, Florian Angeletti and
   Xavier Leroy)
 
-- #11184: Stop calling ranlib on created / installed libraries
-  (Sébastien Hinderer, review by Xavier Leroy)
+- #11184, #11670: Stop calling ranlib on created / installed libraries
+  (Sébastien Hinderer and Xavier Leroy, review by the same)
 
 - #11253: Deprecate `ocaml script` and `ocamlnat` script where `script` has no
   extension and is an implicit basename.

--- a/tools/ocamlmklib.ml
+++ b/tools/ocamlmklib.ml
@@ -26,7 +26,7 @@ let mklib out files opts =
     else ""
   in
   Printf.sprintf "link -lib -nologo %s-out:%s %s %s" machine out opts files
-  else Printf.sprintf "%s rc %s %s %s" Config.ar out opts files
+  else Printf.sprintf "%s rcs %s %s %s" Config.ar out opts files
 
 (* PR#4783: under Windows, don't use absolute paths because we do
    not know where the binary distribution will be installed. *)


### PR DESCRIPTION
Follow-up to #11184 .

Under macOS at least, `ar rc` on an empty list of files produces an archive with no table of contents, which triggers an error when linked.

This PR uses `ar rcs` instead, so as to force the creation of a table of contents.  macOS prints a warning, but the resulting archive causes no errors during linking.  The GNU `ar` and `ld` are silent.

The `s` option to `ar` is specified as "an XSI extension" in IEEE Std 1003.1-2017, but seems supported by all the toolchains we care about.

The call to `ar rc` in utils/ccomp.ml is unchanged because the list of object files is never empty, and IEEE Std 1003.1 says that `ar rc` must create a symbol table in this case, so the `s` option is redundant.
