### PR TITLE
fix a top_heap_words bug in GC statistics

### DIFF
--- a/runtime/gc_stats.c
+++ b/runtime/gc_stats.c
@@ -133,6 +133,18 @@ void caml_compute_gc_stats(struct gc_stats* buf)
   caml_accum_orphan_heap_stats(&buf->heap_stats);
   caml_accum_orphan_alloc_stats(&buf->alloc_stats);
 
+  /* The instantaneous maximum heap size cannot be computed
+     from per-domain statistics, and would be very expensive
+     to maintain directly. Here, we just sum the per-domain
+     maxima, which is completely wrong.
+
+     FIXME: maybe maintain coarse global maxima?
+
+     The summation starts here from the orphan-heap maxima.
+  */
+  pool_max = buf->heap_stats.pool_max_words;
+  large_max = buf->heap_stats.large_max_words;
+
   for (i=0; i<Max_domains; i++) {
     /* For allocation stats, we use the live stats of the current domain
        and the sampled stats of other domains.
@@ -150,12 +162,6 @@ void caml_compute_gc_stats(struct gc_stats* buf)
       caml_accum_heap_stats(&buf->heap_stats, &s->heap_stats);
       //FIXME use live heap stats instead of sampled heap stats below?
     }
-    /* The instantaneous maximum heap size cannot be computed
-       from per-domain statistics, and would be very expensive
-       to maintain directly. Here, we just sum the per-domain
-       maxima, which is completely wrong.
-
-       FIXME: maybe maintain coarse global maxima? */
     pool_max += s->heap_stats.pool_max_words;
     large_max += s->heap_stats.large_max_words;
   }


### PR DESCRIPTION
This small change exactly follows @lthls's analysis in #11663, and fixes the repro case in the issue report.

For reference, Vincent's analysis of the bug:

>  If you look at the code of caml_compute_gc_stats, pool_max_words is very coarsely approximated by taking the sum of the maximums of all the currently domains... but not the orphaned stats.
So you have two domains, one of them terminates and orphans its shared heap, and the program terminates without any other domain adopting the pools. The result is that the reported heap words represent the words from both the main domain and the orphaned pools, while the reported max heap words only takes into account the words from the main domain..
I suspect this can be fixed by adding the orphaned heap stats' max words to the accumulators before looping on the domains.