### PR TITLE
Updated Documentation For Since Annotations

### DIFF
--- a/Changes
+++ b/Changes
@@ -157,6 +157,9 @@ Working version
 - #11481: Fix the type of Unix.umask to Unix.file_perm -> Unix.file_perm
   (Favonia, review by Sébastien Hinderer)
 
+- #11676: Fix missing since annotation in the `Sys` and `Format` modules
+  (Github user Bukolab99, review by Florian Angeletti)
+
 ### Compiler user-interface and warnings:
 
 - #10009: Improve the error reported by mismatched struct/sig and =/: in module

--- a/stdlib/format.mli
+++ b/stdlib/format.mli
@@ -493,9 +493,11 @@ coupled variables, margin and maximum indentation limit.
 *)
 
 type geometry = { max_indent:int; margin: int}
+(** @since 4.08.0 *)
 
 val check_geometry: geometry -> bool
-(** Check if the formatter geometry is valid: [1 < max_indent < margin] *)
+(** Check if the formatter geometry is valid: [1 < max_indent < margin] 
+     @since 4.14.0 *)
 
 val pp_set_geometry : formatter -> max_indent:int -> margin:int -> unit
 val set_geometry : max_indent:int -> margin:int -> unit
@@ -983,6 +985,7 @@ val std_formatter : formatter
 val get_std_formatter : unit -> formatter
 (** [get_std_formatter ()] returns the current domain's standard formatter used
     to write to standard output.
+    @since 5.0
 *)
 
 val err_formatter : formatter
@@ -992,8 +995,9 @@ val err_formatter : formatter
 *)
 
 val get_err_formatter : unit -> formatter
-(* [get_err_formatter ()] returns the current domain's formatter used to write
+(** [get_err_formatter ()] returns the current domain's formatter used to write
    to standard error.
+   @since 5.0
 *)
 
 val formatter_of_buffer : Buffer.t -> formatter
@@ -1008,7 +1012,8 @@ val stdbuf : Buffer.t
 
 val get_stdbuf : unit -> Buffer.t
 (** [get_stdbuf ()] returns the current domain's string buffer in which the
-    current domain's string formatter writes. *)
+    current domain's string formatter writes.
+    @since 5.0 *)
 
 val str_formatter : formatter
 (** The initial domain's formatter to output to the {!stdbuf} string buffer.
@@ -1019,6 +1024,7 @@ val str_formatter : formatter
 val get_str_formatter : unit -> formatter
 (** The current domain's formatter to output to the current domains string
     buffer.
+    @since 5.0
 *)
 
 val flush_str_formatter : unit -> string
@@ -1050,6 +1056,7 @@ val make_synchronized_formatter :
     When the formatter is used with multiple domains, the output from the
     domains will be interleaved with each other at points where the formatter
     is flushed, such as with {!print_flush}.
+    @since 5.0
 *)
 
 val formatter_of_out_functions :

--- a/stdlib/format.mli
+++ b/stdlib/format.mli
@@ -497,7 +497,7 @@ type geometry = { max_indent:int; margin: int}
 
 val check_geometry: geometry -> bool
 (** Check if the formatter geometry is valid: [1 < max_indent < margin] 
-     @since 4.14.0 *)
+     @since 4.08.0 *)
 
 val pp_set_geometry : formatter -> max_indent:int -> margin:int -> unit
 val set_geometry : max_indent:int -> margin:int -> unit

--- a/stdlib/format.mli
+++ b/stdlib/format.mli
@@ -493,11 +493,11 @@ coupled variables, margin and maximum indentation limit.
 *)
 
 type geometry = { max_indent:int; margin: int}
-(** @since 4.08.0 *)
+(** @since 4.08 *)
 
 val check_geometry: geometry -> bool
-(** Check if the formatter geometry is valid: [1 < max_indent < margin] 
-    @since 4.08.0 *)
+(** Check if the formatter geometry is valid: [1 < max_indent < margin]
+    @since 4.08 *)
 
 val pp_set_geometry : formatter -> max_indent:int -> margin:int -> unit
 val set_geometry : max_indent:int -> margin:int -> unit

--- a/stdlib/format.mli
+++ b/stdlib/format.mli
@@ -497,7 +497,7 @@ type geometry = { max_indent:int; margin: int}
 
 val check_geometry: geometry -> bool
 (** Check if the formatter geometry is valid: [1 < max_indent < margin] 
-     @since 4.08.0 *)
+    @since 4.08.0 *)
 
 val pp_set_geometry : formatter -> max_indent:int -> margin:int -> unit
 val set_geometry : max_indent:int -> margin:int -> unit

--- a/stdlib/sys.mli
+++ b/stdlib/sys.mli
@@ -357,10 +357,10 @@ val development_version : bool
 *)
 
 type extra_prefix = Plus | Tilde
-(** @since 4.14.0 *)
+(** @since 4.14 *)
 
 type extra_info = extra_prefix * string
-(** @since 4.14.0 *)
+(** @since 4.14 *)
 
 type ocaml_release_info = {
   major : int;
@@ -368,11 +368,11 @@ type ocaml_release_info = {
   patchlevel : int;
   extra : extra_info option
 }
-(** @since 4.14.0 *)
+(** @since 4.14 *)
 
 val ocaml_release : ocaml_release_info
 (** [ocaml_release] is the version of OCaml.
-    @since 4.14.0
+    @since 4.14
 *)
 
 val enable_runtime_warnings: bool -> unit

--- a/stdlib/sys.mli
+++ b/stdlib/sys.mli
@@ -359,7 +359,7 @@ val development_version : bool
 type extra_prefix = Plus | Tilde
 (** @since 4.14.0 *)
 
-type extra_info = extra_prefix * string 
+type extra_info = extra_prefix * string
 (** @since 4.14.0 *)
 
 type ocaml_release_info = {
@@ -371,7 +371,9 @@ type ocaml_release_info = {
 (** @since 4.14.0 *)
 
 val ocaml_release : ocaml_release_info
-(** @since 4.14.0 *)
+(** [ocaml_release] is the version of OCaml.
+    @since 4.14.0
+*)
 
 val enable_runtime_warnings: bool -> unit
 [@@alert unsynchronized_access

--- a/stdlib/sys.mli
+++ b/stdlib/sys.mli
@@ -357,8 +357,10 @@ val development_version : bool
 *)
 
 type extra_prefix = Plus | Tilde
+(** @since 4.14.0 *)
 
-type extra_info = extra_prefix * string
+type extra_info = extra_prefix * string 
+(** @since 4.14.0 *)
 
 type ocaml_release_info = {
   major : int;
@@ -366,8 +368,10 @@ type ocaml_release_info = {
   patchlevel : int;
   extra : extra_info option
 }
+(** @since 4.14.0 *)
 
 val ocaml_release : ocaml_release_info
+(** @since 4.14.0 *)
 
 val enable_runtime_warnings: bool -> unit
 [@@alert unsynchronized_access


### PR DESCRIPTION
Updated the documentation for missing `since` annotations in the standard library, fixes (#11666). 