### PR TITLE
Location: Highlight multi-line locations

### DIFF
--- a/Changes
+++ b/Changes
@@ -17,6 +17,9 @@ Working version
 
 ### Compiler user-interface and warnings:
 
+- #11678: Highlight multi-line locations in error messages.
+  (Jules Aguillon, review by ?)
+
 ### Internal/compiler-libs changes:
 
 ### Build system:

--- a/testsuite/tests/basic-modules/recursive_module_evaluation_errors.ml
+++ b/testsuite/tests/basic-modules/recursive_module_evaluation_errors.ml
@@ -64,10 +64,14 @@ end
 and B: sig val value: unit end = struct let value = A.f () end
 [%%expect {|
 Lines 4-7, characters 6-3:
-4 | ......struct
+4 | end = struct
+          ^^^^^^
 5 |   module F(X:sig end) = struct end
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 6 |   let f () = B.value
+      ^^^^^^^^^^^^^^^^^^
 7 | end
+    ^^^
 Error: Cannot safely evaluate the definition of the following cycle
        of recursively-defined modules: A -> B -> A.
        There are no safe modules in this cycle (see manual section 12.2).
@@ -94,10 +98,14 @@ module F(X: sig module type t module M: t end) = struct
 end
 [%%expect {|
 Lines 5-8, characters 8-5:
-5 | ........struct
+5 |   end = struct
+            ^^^^^^
 6 |     module M = X.M
+        ^^^^^^^^^^^^^^
 7 |     let f () = B.value
+        ^^^^^^^^^^^^^^^^^^
 8 |   end
+      ^^^
 Error: Cannot safely evaluate the definition of the following cycle
        of recursively-defined modules: A -> B -> A.
        There are no safe modules in this cycle (see manual section 12.2).

--- a/testsuite/tests/basic-more/morematch.compilers.reference
+++ b/testsuite/tests/basic-more/morematch.compilers.reference
@@ -54,10 +54,14 @@ File "morematch.ml", line 456, characters 2-7:
 Warning 11 [redundant-case]: this match case is unused.
 
 File "morematch.ml", lines 1050-1053, characters 8-10:
-1050 | ........function
+1050 | let f = function
+               ^^^^^^^^
 1051 |   | A (`A|`C) -> 0
+         ^^^^^^^^^^^^^^^^
 1052 |   | B (`B,`D) -> 1
+         ^^^^^^^^^^^^^^^^
 1053 |   | C -> 2
+         ^^^^^^^^
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 A `D

--- a/testsuite/tests/basic-more/robustmatch.compilers.reference
+++ b/testsuite/tests/basic-more/robustmatch.compilers.reference
@@ -1,232 +1,326 @@
 File "robustmatch.ml", lines 33-37, characters 6-23:
-33 | ......match t1, t2, x with
+33 |       match t1, t2, x with
+           ^^^^^^^^^^^^^^^^^^^^
 34 |       | AB, AB, A -> ()
+           ^^^^^^^^^^^^^^^^^
 35 |       | MAB, _, A -> ()
+           ^^^^^^^^^^^^^^^^^
 36 |       | _,  AB, B -> ()
+           ^^^^^^^^^^^^^^^^^
 37 |       | _, MAB, B -> ()
+           ^^^^^^^^^^^^^^^^^
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 (AB, MAB, A)
 
 File "robustmatch.ml", lines 43-47, characters 4-21:
-43 | ....match t1, t2, x with
+43 |     match t1, t2, x with
+         ^^^^^^^^^^^^^^^^^^^^
 44 |     | AB,  AB, A -> ()
+         ^^^^^^^^^^^^^^^^^^
 45 |     | MAB, _, A -> ()
+         ^^^^^^^^^^^^^^^^^
 46 |     | _,  AB, B -> ()
+         ^^^^^^^^^^^^^^^^^
 47 |     | _, MAB, B -> ()
+         ^^^^^^^^^^^^^^^^^
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 (AB, MAB, A)
 
 File "robustmatch.ml", lines 54-56, characters 4-27:
-54 | ....match r1, r2, a with
+54 |     match r1, r2, a with
+         ^^^^^^^^^^^^^^^^^^^^
 55 |     | R1, _, 0 -> ()
+         ^^^^^^^^^^^^^^^^
 56 |     | _, R2, "coucou" -> ()
+         ^^^^^^^^^^^^^^^^^^^^^^^
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 (R1, R1, 1)
 
 File "robustmatch.ml", lines 64-66, characters 4-27:
-64 | ....match r1, r2, a with
+64 |     match r1, r2, a with
+         ^^^^^^^^^^^^^^^^^^^^
 65 |     | R1, _, A -> ()
+         ^^^^^^^^^^^^^^^^
 66 |     | _, R2, "coucou" -> ()
+         ^^^^^^^^^^^^^^^^^^^^^^^
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 (R1, R1, (B|C))
 
 File "robustmatch.ml", lines 69-71, characters 4-20:
-69 | ....match r1, r2, a with
+69 |     match r1, r2, a with
+         ^^^^^^^^^^^^^^^^^^^^
 70 |     | _, R2, "coucou" -> ()
+         ^^^^^^^^^^^^^^^^^^^^^^^
 71 |     | R1, _, A -> ()
+         ^^^^^^^^^^^^^^^^
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 (R1, R1, (B|C))
 
 File "robustmatch.ml", lines 74-76, characters 4-20:
-74 | ....match r1, r2, a with
+74 |     match r1, r2, a with
+         ^^^^^^^^^^^^^^^^^^^^
 75 |     | _, R2, "coucou" -> ()
+         ^^^^^^^^^^^^^^^^^^^^^^^
 76 |     | R1, _, _ -> ()
+         ^^^^^^^^^^^^^^^^
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 (R2, R2, "")
 
 File "robustmatch.ml", lines 85-87, characters 4-20:
-85 | ....match r1, r2, a with
+85 |     match r1, r2, a with
+         ^^^^^^^^^^^^^^^^^^^^
 86 |     | R1, _, A -> ()
+         ^^^^^^^^^^^^^^^^
 87 |     | _, R2, X -> ()
+         ^^^^^^^^^^^^^^^^
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 (R1, R1, (B|C))
 
 File "robustmatch.ml", lines 90-93, characters 4-20:
-90 | ....match r1, r2, a with
+90 |     match r1, r2, a with
+         ^^^^^^^^^^^^^^^^^^^^
 91 |     | R1, _, A -> ()
+         ^^^^^^^^^^^^^^^^
 92 |     | _, R2, X -> ()
+         ^^^^^^^^^^^^^^^^
 93 |     | R1, _, _ -> ()
+         ^^^^^^^^^^^^^^^^
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 (R2, R2, (Y|Z))
 
 File "robustmatch.ml", lines 96-98, characters 4-20:
-96 | ....match r1, r2, a with
+96 |     match r1, r2, a with
+         ^^^^^^^^^^^^^^^^^^^^
 97 |     | R1, _, _ -> ()
+         ^^^^^^^^^^^^^^^^
 98 |     | _, R2, X -> ()
+         ^^^^^^^^^^^^^^^^
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 (R2, R2, (Y|Z))
 
 File "robustmatch.ml", lines 107-109, characters 4-20:
-107 | ....match r1, r2, a with
+107 |     match r1, r2, a with
+          ^^^^^^^^^^^^^^^^^^^^
 108 |     | R1, _, A -> ()
+          ^^^^^^^^^^^^^^^^
 109 |     | _, R2, X -> ()
+          ^^^^^^^^^^^^^^^^
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 (R1, R1, (B|C))
 
 File "robustmatch.ml", lines 129-131, characters 4-20:
-129 | ....match r1, r2, a with
+129 |     match r1, r2, a with
+          ^^^^^^^^^^^^^^^^^^^^
 130 |     | R1, _, A -> ()
+          ^^^^^^^^^^^^^^^^
 131 |     | _, R2, X -> ()
+          ^^^^^^^^^^^^^^^^
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 (R1, R1, B)
 
 File "robustmatch.ml", lines 151-153, characters 4-20:
-151 | ....match r1, r2, a with
+151 |     match r1, r2, a with
+          ^^^^^^^^^^^^^^^^^^^^
 152 |     | R1, _, A -> ()
+          ^^^^^^^^^^^^^^^^
 153 |     | _, R2, X -> ()
+          ^^^^^^^^^^^^^^^^
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 (R1, R1, B)
 
 File "robustmatch.ml", lines 156-159, characters 4-20:
-156 | ....match r1, r2, a with
+156 |     match r1, r2, a with
+          ^^^^^^^^^^^^^^^^^^^^
 157 |     | R1, _, A -> ()
+          ^^^^^^^^^^^^^^^^
 158 |     | _, R2, X -> ()
+          ^^^^^^^^^^^^^^^^
 159 |     | R1, _, _ -> ()
+          ^^^^^^^^^^^^^^^^
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 (R2, R2, Y)
 
 File "robustmatch.ml", lines 162-164, characters 4-20:
-162 | ....match r1, r2, a with
+162 |     match r1, r2, a with
+          ^^^^^^^^^^^^^^^^^^^^
 163 |     | R1, _, _ -> ()
+          ^^^^^^^^^^^^^^^^
 164 |     | _, R2, X -> ()
+          ^^^^^^^^^^^^^^^^
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 (R2, R2, Y)
 
 File "robustmatch.ml", lines 167-169, characters 4-20:
-167 | ....match r1, r2, a with
+167 |     match r1, r2, a with
+          ^^^^^^^^^^^^^^^^^^^^
 168 |     | R1, _, C -> ()
+          ^^^^^^^^^^^^^^^^
 169 |     | _, R2, Y -> ()
+          ^^^^^^^^^^^^^^^^
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 (R1, R1, A)
 
 File "robustmatch.ml", lines 176-179, characters 4-20:
-176 | ....match r1, r2, a with
+176 |     match r1, r2, a with
+          ^^^^^^^^^^^^^^^^^^^^
 177 |     | _, R1, 0 -> ()
+          ^^^^^^^^^^^^^^^^
 178 |     | R2, _, [||] -> ()
+          ^^^^^^^^^^^^^^^^^^^
 179 |     | _, R1, 1 -> ()
+          ^^^^^^^^^^^^^^^^
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 (R2, R2, [| _ |])
 
 File "robustmatch.ml", lines 182-184, characters 4-23:
-182 | ....match r1, r2, a with
+182 |     match r1, r2, a with
+          ^^^^^^^^^^^^^^^^^^^^
 183 |     | R1, _, _ -> ()
+          ^^^^^^^^^^^^^^^^
 184 |     | _, R2, [||] -> ()
+          ^^^^^^^^^^^^^^^^^^^
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 (R2, R2, [| _ |])
 
 File "robustmatch.ml", lines 187-190, characters 4-20:
-187 | ....match r1, r2, a with
+187 |     match r1, r2, a with
+          ^^^^^^^^^^^^^^^^^^^^
 188 |     | _, R2, [||] -> ()
+          ^^^^^^^^^^^^^^^^^^^
 189 |     | R1, _, 0 -> ()
+          ^^^^^^^^^^^^^^^^
 190 |     | R1, _, _ -> ()
+          ^^^^^^^^^^^^^^^^
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 (R2, R2, [| _ |])
 
 File "robustmatch.ml", lines 200-203, characters 4-19:
-200 | ....match r1, r2, a with
+200 |     match r1, r2, a with
+          ^^^^^^^^^^^^^^^^^^^^
 201 |     | _, R2, [||] -> ()
+          ^^^^^^^^^^^^^^^^^^^
 202 |     | R1, _, 0 -> ()
+          ^^^^^^^^^^^^^^^^
 203 |     | _, _, _ -> ()
+          ^^^^^^^^^^^^^^^
 Warning 4 [fragile-match]: this pattern-matching is fragile.
 It will remain exhaustive when constructors are added to type repr.
 
 File "robustmatch.ml", lines 210-212, characters 4-27:
-210 | ....match r1, r2, a with
+210 |     match r1, r2, a with
+          ^^^^^^^^^^^^^^^^^^^^
 211 |     | R1, _, 'c' -> ()
+          ^^^^^^^^^^^^^^^^^^
 212 |     | _, R2, "coucou" -> ()
+          ^^^^^^^^^^^^^^^^^^^^^^^
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 (R1, R1, 'a')
 
 File "robustmatch.ml", lines 219-221, characters 4-27:
-219 | ....match r1, r2, a with
+219 |     match r1, r2, a with
+          ^^^^^^^^^^^^^^^^^^^^
 220 |     | R1, _, `A -> ()
+          ^^^^^^^^^^^^^^^^^
 221 |     | _, R2, "coucou" -> ()
+          ^^^^^^^^^^^^^^^^^^^^^^^
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 (R1, R1, `B)
 
 File "robustmatch.ml", lines 228-230, characters 4-37:
-228 | ....match r1, r2, a with
+228 |     match r1, r2, a with
+          ^^^^^^^^^^^^^^^^^^^^
 229 |     | R1, _, (3, "") -> ()
+          ^^^^^^^^^^^^^^^^^^^^^^
 230 |     | _, R2, (1, "coucou", 'a') -> ()
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 (R1, R1, (3, "*"))
 
 File "robustmatch.ml", lines 239-241, characters 4-51:
-239 | ....match r1, r2, a with
+239 |     match r1, r2, a with
+          ^^^^^^^^^^^^^^^^^^^^
 240 |     | R1, _, { x = 3; y = "" } -> ()
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 241 |     | _, R2, { a = 1; b = "coucou"; c = 'a' } -> ()
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 (R1, R1, {x=3; y="*"})
 
 File "robustmatch.ml", lines 244-246, characters 4-36:
-244 | ....match r1, r2, a with
+244 |     match r1, r2, a with
+          ^^^^^^^^^^^^^^^^^^^^
 245 |     | R2, _, { a = 1; b = "coucou"; c = 'a' } -> ()
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 246 |     | _, R1, { x = 3; y = "" } -> ()
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 (R2, R2, {a=1; b="coucou"; c='b'})
 
 File "robustmatch.ml", lines 253-255, characters 4-20:
-253 | ....match r1, r2, a with
+253 |     match r1, r2, a with
+          ^^^^^^^^^^^^^^^^^^^^
 254 |     | R1, _, (3, "") -> ()
+          ^^^^^^^^^^^^^^^^^^^^^^
 255 |     | _, R2, 1 -> ()
+          ^^^^^^^^^^^^^^^^
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 (R1, R1, (3, "*"))
 
 File "robustmatch.ml", lines 263-265, characters 4-20:
-263 | ....match r1, r2, a with
+263 |     match r1, r2, a with
+          ^^^^^^^^^^^^^^^^^^^^
 264 |     | R1, _, { x = 3; y = "" } -> ()
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 265 |     | _, R2, 1 -> ()
+          ^^^^^^^^^^^^^^^^
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 (R1, R1, {x=3; y="*"})
 
 File "robustmatch.ml", lines 272-274, characters 4-20:
-272 | ....match r1, r2, a with
+272 |     match r1, r2, a with
+          ^^^^^^^^^^^^^^^^^^^^
 273 |     | R1, _, lazy 1 -> ()
+          ^^^^^^^^^^^^^^^^^^^^^
 274 |     | _, R2, 1 -> ()
+          ^^^^^^^^^^^^^^^^
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 (R1, R1, lazy 0)
 
 File "robustmatch.ml", lines 281-284, characters 4-24:
-281 | ....match r1, r2, a with
+281 |     match r1, r2, a with
+          ^^^^^^^^^^^^^^^^^^^^
 282 |     | R1, _, () -> ()
+          ^^^^^^^^^^^^^^^^^
 283 |     | _, R2, "coucou" -> ()
+          ^^^^^^^^^^^^^^^^^^^^^^^
 284 |     | _, R2, "foo" -> ()
+          ^^^^^^^^^^^^^^^^^^^^
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 (R2, R2, "")

--- a/testsuite/tests/basic/patmatch_incoherence.ml
+++ b/testsuite/tests/basic/patmatch_incoherence.ml
@@ -37,8 +37,11 @@ match { x = assert false } with
 [%%expect{|
 Lines 1-3, characters 0-20:
 1 | match { x = assert false } with
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 2 | | { x = 3 } -> ()
+    ^^^^^^^^^^^^^^^^^
 3 | | { x = None } -> ()
+    ^^^^^^^^^^^^^^^^^^^^
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 {x=Some _}
@@ -53,8 +56,11 @@ match { x = assert false } with
 [%%expect{|
 Lines 1-3, characters 0-18:
 1 | match { x = assert false } with
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 2 | | { x = None } -> ()
+    ^^^^^^^^^^^^^^^^^^^^
 3 | | { x = "" } -> ()
+    ^^^^^^^^^^^^^^^^^^
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 {x="*"}
@@ -69,8 +75,11 @@ match { x = assert false } with
 [%%expect{|
 Lines 1-3, characters 0-18:
 1 | match { x = assert false } with
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 2 | | { x = None } -> ()
+    ^^^^^^^^^^^^^^^^^^^^
 3 | | { x = `X } -> ()
+    ^^^^^^^^^^^^^^^^^^
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 {x=`AnyOtherTag}
@@ -85,8 +94,11 @@ match { x = assert false } with
 [%%expect{|
 Lines 1-3, characters 0-17:
 1 | match { x = assert false } with
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 2 | | { x = [||] } -> ()
+    ^^^^^^^^^^^^^^^^^^^^
 3 | | { x = 3 } -> ()
+    ^^^^^^^^^^^^^^^^^
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 {x=0}
@@ -101,8 +113,11 @@ match { x = assert false } with
 [%%expect{|
 Lines 1-3, characters 0-17:
 1 | match { x = assert false } with
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 2 | | { x = `X } -> ()
+    ^^^^^^^^^^^^^^^^^^
 3 | | { x = 3 } -> ()
+    ^^^^^^^^^^^^^^^^^
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 {x=0}
@@ -117,8 +132,11 @@ match { x = assert false } with
 [%%expect{|
 Lines 1-3, characters 0-17:
 1 | match { x = assert false } with
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 2 | | { x = `X "lol" } -> ()
+    ^^^^^^^^^^^^^^^^^^^^^^^^
 3 | | { x = 3 } -> ()
+    ^^^^^^^^^^^^^^^^^
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 {x=0}
@@ -134,9 +152,13 @@ match { x = assert false } with
 [%%expect{|
 Lines 1-4, characters 0-17:
 1 | match { x = assert false } with
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 2 | | { x = (2., "") } -> ()
+    ^^^^^^^^^^^^^^^^^^^^^^^^
 3 | | { x = None } -> ()
+    ^^^^^^^^^^^^^^^^^^^^
 4 | | { x = 3 } -> ()
+    ^^^^^^^^^^^^^^^^^
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 {x=0}

--- a/testsuite/tests/generalized-open/gpr1506.ml
+++ b/testsuite/tests/generalized-open/gpr1506.ml
@@ -121,10 +121,14 @@ module A = struct
 end
 [%%expect{|
 Lines 3-6, characters 4-7:
-3 | ....open struct
+3 |     open struct
+        ^^^^^^^^^^^
 4 |       type t = T
+          ^^^^^^^^^^
 5 |       let x = T
+          ^^^^^^^^^
 6 |     end
+        ^^^
 Error: The type t introduced by this open appears in the signature.
 Line 7, characters 8-9:
 7 |     let y = x
@@ -143,9 +147,12 @@ module A = struct
 end
 [%%expect{|
 Lines 3-5, characters 4-7:
-3 | ....open struct
+3 |     open struct
+        ^^^^^^^^^^^
 4 |       type t = T
+          ^^^^^^^^^^
 5 |     end
+        ^^^
 Error: The type t introduced by this open appears in the signature.
 Line 6, characters 8-9:
 6 |     let y = T

--- a/testsuite/tests/let-syntax/let_syntax.ml
+++ b/testsuite/tests/let-syntax/let_syntax.ml
@@ -291,9 +291,12 @@ let ill_typed_5 =
   );;
 [%%expect{|
 Lines 3-5, characters 9-14:
-3 | .........x = 1
+3 |     let+ x = 1
+             ^^^^^
 4 |     and+ y = 2
-5 |     and+ z = 3...
+        ^^^^^^^^^^
+5 |     and+ z = 3 in
+        ^^^^^^^^^^
 Error: These bindings have type (int * int) * int
        but bindings were expected of type bool
 |}];;
@@ -321,8 +324,10 @@ let ill_typed_6 =
   );;
 [%%expect{|
 Lines 3-4, characters 9-14:
-3 | .........x = 1
+3 |     let+ x = 1
+             ^^^^^
 4 |     and+ y = 2
+        ^^^^^^^^^^
 Error: These bindings have type int * int but bindings were expected of type
          int
 |}];;
@@ -513,8 +518,10 @@ let indexed_monad4 =
   );;
 [%%expect{|
 Lines 6-7, characters 4-29:
-6 | ....let* second = read in
+6 |     let* second = read in
+        ^^^^^^^^^^^^^^^^^^^^^
 7 |       return (first ^ second)
+          ^^^^^^^^^^^^^^^^^^^^^^^
 Error: This expression has type
          (Indexed_monad.opened, Indexed_monad.opened, string) Indexed_monad.t
        but an expression was expected of type

--- a/testsuite/tests/letrec-check/basic.ml
+++ b/testsuite/tests/letrec-check/basic.ml
@@ -176,9 +176,12 @@ let rec x =
 and y = x; ();;
 [%%expect{|
 Lines 2-4, characters 2-6:
-2 | ..for i = 0 to 1 do
+2 |   for i = 0 to 1 do
+      ^^^^^^^^^^^^^^^^^
 3 |     let z = y in ignore z
+        ^^^^^^^^^^^^^^^^^^^^^
 4 |   done
+      ^^^^
 Error: This kind of expression is not allowed as right-hand side of `let rec'
 |}];;
 
@@ -189,9 +192,12 @@ let rec x =
 and y = 10;;
 [%%expect{|
 Lines 2-4, characters 2-6:
-2 | ..for i = 0 to y do
+2 |   for i = 0 to y do
+      ^^^^^^^^^^^^^^^^^
 3 |     ()
+        ^^
 4 |   done
+      ^^^^
 Error: This kind of expression is not allowed as right-hand side of `let rec'
 |}];;
 
@@ -202,9 +208,12 @@ let rec x =
 and y = 0;;
 [%%expect{|
 Lines 2-4, characters 2-6:
-2 | ..for i = y to 10 do
+2 |   for i = y to 10 do
+      ^^^^^^^^^^^^^^^^^^
 3 |     ()
+        ^^
 4 |   done
+      ^^^^
 Error: This kind of expression is not allowed as right-hand side of `let rec'
 |}];;
 
@@ -215,9 +224,12 @@ let rec x =
 and y = x; ();;
 [%%expect{|
 Lines 2-4, characters 2-6:
-2 | ..while false do
+2 |   while false do
+      ^^^^^^^^^^^^^^
 3 |     let y = x in ignore y
+        ^^^^^^^^^^^^^^^^^^^^^
 4 |   done
+      ^^^^
 Error: This kind of expression is not allowed as right-hand side of `let rec'
 |}];;
 
@@ -228,9 +240,12 @@ let rec x =
 and y = false;;
 [%%expect{|
 Lines 2-4, characters 2-6:
-2 | ..while y do
+2 |   while y do
+      ^^^^^^^^^^
 3 |     ()
+        ^^
 4 |   done
+      ^^^^
 Error: This kind of expression is not allowed as right-hand side of `let rec'
 |}];;
 
@@ -241,9 +256,12 @@ let rec x =
 and y = false;;
 [%%expect{|
 Lines 2-4, characters 2-6:
-2 | ..while y do
+2 |   while y do
+      ^^^^^^^^^^
 3 |     let y = x in ignore y
+        ^^^^^^^^^^^^^^^^^^^^^
 4 |   done
+      ^^^^
 Error: This kind of expression is not allowed as right-hand side of `let rec'
 |}];;
 
@@ -324,9 +342,12 @@ and y = match x with
   z -> ("y", z);;
 [%%expect{|
 Lines 2-4, characters 2-30:
-2 | ..match let _ = y in raise Not_found with
+2 |   match let _ = y in raise Not_found with
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 3 |     _ -> "x"
+        ^^^^^^^^
 4 |   | exception Not_found -> "z"
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This kind of expression is not allowed as right-hand side of `let rec'
 |}];;
 
@@ -350,9 +371,12 @@ let rec wrong =
   in ref ("foo" ^ ! ! !x);;
 [%%expect{|
 Lines 10-12, characters 2-25:
-10 | ..let rec x = ref y
+10 |   let rec x = ref y
+       ^^^^^^^^^^^^^^^^^
 11 |   and y = ref wrong
-12 |   in ref ("foo" ^ ! ! !x)..
+       ^^^^^^^^^^^^^^^^^
+12 |   in ref ("foo" ^ ! ! !x);;
+       ^^^^^^^^^^^^^^^^^^^^^^^
 Error: This kind of expression is not allowed as right-hand side of `let rec'
 |}]
 

--- a/testsuite/tests/letrec-check/extension_constructor.ml
+++ b/testsuite/tests/letrec-check/extension_constructor.ml
@@ -19,7 +19,9 @@ and (m : (module T)) =
   (module (struct exception A of int end) : T);;
 [%%expect{|
 Lines 2-3, characters 2-8:
-2 | ..let module M = (val m) in
+2 |   let module M = (val m) in
+      ^^^^^^^^^^^^^^^^^^^^^^^^^
 3 |   M.A 42
+      ^^^^^^
 Error: This kind of expression is not allowed as right-hand side of `let rec'
 |}];;

--- a/testsuite/tests/letrec-check/modules.ml
+++ b/testsuite/tests/letrec-check/modules.ml
@@ -46,9 +46,12 @@ let rec x =
   end in M.N.y;;
 [%%expect{|
 Lines 2-4, characters 2-14:
-2 | ..let module M = struct
+2 |   let module M = struct
+      ^^^^^^^^^^^^^^^^^^^^^
 3 |     module N = struct let y = x end
-4 |   end in M.N.y..
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+4 |   end in M.N.y;;
+      ^^^^^^^^^^^^
 Error: This kind of expression is not allowed as right-hand side of `let rec'
 |}];;
 

--- a/testsuite/tests/letrec-check/pr7706.ocaml.reference
+++ b/testsuite/tests/letrec-check/pr7706.ocaml.reference
@@ -1,6 +1,8 @@
 Lines 5-6, characters 2-3:
-5 | ..let y = if false then (fun z -> 1) else (fun z -> x 4 + 1) in
-6 |   y..
+5 |   let y = if false then (fun z -> 1) else (fun z -> x 4 + 1) in
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+6 |   y;;
+      ^
 Error: This kind of expression is not allowed as right-hand side of `let rec'
 Line 2, characters 17-18:
 2 | let () = ignore (x 42);;

--- a/testsuite/tests/letrec-check/unboxed.ml
+++ b/testsuite/tests/letrec-check/unboxed.ml
@@ -60,11 +60,16 @@ let rec a =
 type a = { a : b; } [@@unboxed]
 and b = X of a | Y
 Lines 5-9, characters 2-10:
-5 | ..{a=
+5 |   {a=
+      ^^^
 6 |     (if Sys.opaque_identity true then
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 7 |        X a
+           ^^^
 8 |      else
-9 |        Y)}..
+         ^^^^
+9 |        Y)};;
+           ^^^
 Error: This kind of expression is not allowed as right-hand side of `let rec'
 |}];;
 
@@ -100,10 +105,15 @@ let rec d =
 type d = D of e [@@unboxed]
 and e = V of d | W
 Lines 5-9, characters 2-9:
-5 | ..D
+5 |   D
+      ^
 6 |     (if Sys.opaque_identity true then
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 7 |        V d
+           ^^^
 8 |      else
-9 |        W)..
+         ^^^^
+9 |        W);;
+           ^^
 Error: This kind of expression is not allowed as right-hand side of `let rec'
 |}];;

--- a/testsuite/tests/match-exception-warnings/exhaustiveness_warnings.ml
+++ b/testsuite/tests/match-exception-warnings/exhaustiveness_warnings.ml
@@ -17,10 +17,14 @@ let test_match_exhaustiveness () =
 
 [%%expect{|
 Lines 8-11, characters 4-16:
- 8 | ....match None with
+ 8 |     match None with
+         ^^^^^^^^^^^^^^^
  9 |     | exception e -> ()
+         ^^^^^^^^^^^^^^^^^^^
 10 |     | Some false -> ()
+         ^^^^^^^^^^^^^^^^^^
 11 |     | None -> ()
+         ^^^^^^^^^^^^
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 Some true
@@ -37,9 +41,12 @@ let test_match_exhaustiveness_nest1 () =
 
 [%%expect{|
 Lines 2-4, characters 4-30:
-2 | ....match None with
+2 |     match None with
+        ^^^^^^^^^^^^^^^
 3 |     | Some false -> ()
+        ^^^^^^^^^^^^^^^^^^
 4 |     | None | exception _ -> ()
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 Some true
@@ -56,9 +63,12 @@ let test_match_exhaustiveness_nest2 () =
 
 [%%expect{|
 Lines 2-4, characters 4-16:
-2 | ....match None with
+2 |     match None with
+        ^^^^^^^^^^^^^^^
 3 |     | Some false | exception _ -> ()
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 4 |     | None -> ()
+        ^^^^^^^^^^^^
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 Some true
@@ -76,10 +86,14 @@ let test_match_exhaustiveness_full () =
 
 [%%expect{|
 Lines 2-5, characters 4-30:
-2 | ....match None with
+2 |     match None with
+        ^^^^^^^^^^^^^^^
 3 |     | exception e -> ()
+        ^^^^^^^^^^^^^^^^^^^
 4 |     | Some false | exception _ -> ()
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 5 |     | None | exception _ -> ()
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 Some true

--- a/testsuite/tests/shadow_include/shadow_all.ml
+++ b/testsuite/tests/shadow_include/shadow_all.ml
@@ -508,10 +508,14 @@ Line 8, characters 2-8:
       ^^^^^^
 Error: Illegal shadowing of included type t/4 by t.
 Lines 2-5, characters 2-5:
-2 | ..include struct
+2 |   include struct
+      ^^^^^^^^^^^^^^
 3 |     type t = A
+        ^^^^^^^^^^
 4 |     let x = A
+        ^^^^^^^^^
 5 |   end
+      ^^^
   Type t/4 came from this include.
 Line 4, characters 8-9:
 4 |     let x = A

--- a/testsuite/tests/tmc/ambiguities.ml
+++ b/testsuite/tests/tmc/ambiguities.ml
@@ -194,14 +194,22 @@ module Disjunctions_ambiguous = struct
 end
 [%%expect {|
 Lines 13-20, characters 8-9:
-13 | ........Node (
+13 |         Node (
+             ^^^^^^
 14 |           (if flip
+               ^^^^^^^^
 15 |            then shift ~flip (- k) left
+                ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 16 |            else shift ~flip k left),
+                ^^^^^^^^^^^^^^^^^^^^^^^^^
 17 |           (if flip
+               ^^^^^^^^
 18 |            then shift ~flip (- k) right
+                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 19 |            else shift ~flip k right)
+                ^^^^^^^^^^^^^^^^^^^^^^^^^
 20 |         )
+             ^
 Error: [@tail_mod_cons]: this constructor application may be TMC-transformed
        in several different ways. Please disambiguate by adding an explicit
        [@tailcall] attribute to the call that should be made tail-recursive,
@@ -265,14 +273,22 @@ module Disjunctions_ambiguous_again = struct
 end
 [%%expect {|
 Lines 7-14, characters 8-9:
- 7 | ........Node (
+ 7 |         Node (
+             ^^^^^^
  8 |           (if flip
+               ^^^^^^^^
  9 |            then (shift[@tailcall]) ~flip (- k) left
+                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 10 |            else shift ~flip k left),
+                ^^^^^^^^^^^^^^^^^^^^^^^^^
 11 |           (if flip
+               ^^^^^^^^
 12 |            then shift ~flip (- k) right
+                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 13 |            else (shift[@tailcall]) ~flip k right)
+                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 14 |         )
+             ^
 Error: [@tail_mod_cons]: this constructor application may be TMC-transformed
        in several different ways. Only one of the arguments may become a TMC
        call, but several arguments contain calls that are explicitly marked

--- a/testsuite/tests/tmc/other_features.ml
+++ b/testsuite/tests/tmc/other_features.ml
@@ -15,12 +15,18 @@ module Non_recursive_let_bad = struct
 end
 [%%expect {|
 Lines 6-11, characters 30-40:
- 6 | ..............................f l =
+ 6 |   let[@tail_mod_cons] rec map f l =
+                                   ^^^^^
  7 |     match l with
+         ^^^^^^^^^^^^
  8 |     | N v -> N (f v)
+         ^^^^^^^^^^^^^^^^
  9 |     | C (a, b) ->
+         ^^^^^^^^^^^^^
 10 |         let map' l = map f l in
+             ^^^^^^^^^^^^^^^^^^^^^^^
 11 |         C (map' a, (map' [@tailcall]) b)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 71 [unused-tmc-attribute]: This function is marked @tail_mod_cons
 but is never applied in TMC position.
 

--- a/testsuite/tests/tmc/tupled_function_calls.native.reference
+++ b/testsuite/tests/tmc/tupled_function_calls.native.reference
@@ -1,10 +1,16 @@
 File "tupled_function_calls.ml", lines 16-21, characters 46-57:
-16 | ..............................................(f, li) =
+16 | let[@tail_mod_cons] rec tupled_map_not_direct (f, li) =
+                                                   ^^^^^^^^^
 17 |   match li with
+       ^^^^^^^^^^^^^
 18 |   | [] -> []
+       ^^^^^^^^^^
 19 |   | x :: xs ->
+       ^^^^^^^^^^^^
 20 |       let pair = (f, xs) in
+           ^^^^^^^^^^^^^^^^^^^^^
 21 |       f x :: (tupled_map_not_direct[@tailcall true]) pair
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 71 [unused-tmc-attribute]: This function is marked @tail_mod_cons
 but is never applied in TMC position.
 

--- a/testsuite/tests/tmc/usage_warnings.ml
+++ b/testsuite/tests/tmc/usage_warnings.ml
@@ -27,9 +27,12 @@ attribute, or mark this call with the [@tailcall false] attribute
 to make its non-tailness explicit.
 
 Lines 1-3, characters 34-40:
-1 | ..................................function
+1 | let[@tail_mod_cons] rec flatten = function
+                                      ^^^^^^^^
 2 |   | [] -> []
+      ^^^^^^^^^^
 3 |   | xs :: xss -> append xs (flatten xss)
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 71 [unused-tmc-attribute]: This function is marked @tail_mod_cons
 but is never applied in TMC position.
 
@@ -73,16 +76,26 @@ attribute, or mark this call with the [@tailcall false] attribute
 to make its non-tailness explicit.
 
 Lines 1-10, characters 34-30:
- 1 | ..................................function
+ 1 | let[@tail_mod_cons] rec flatten = function
+                                       ^^^^^^^^
  2 |   | [] -> []
+       ^^^^^^^^^^
  3 |   | xs :: xss ->
+       ^^^^^^^^^^^^^^
  4 |       let rec append_flatten xs xss =
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  5 |         match xs with
+             ^^^^^^^^^^^^^
  6 |         | [] -> flatten xss
+             ^^^^^^^^^^^^^^^^^^^
  7 |         | x :: xs ->
+             ^^^^^^^^^^^^
  8 |             (* incorrect: this call to append_flatten is not transformed *)
+                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  9 |             x :: append_flatten xs xss
+                 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 10 |       in append_flatten xs xss
+           ^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 71 [unused-tmc-attribute]: This function is marked @tail_mod_cons
 but is never applied in TMC position.
 
@@ -161,10 +174,14 @@ module Tail_calls_to_non_specialized_functions = struct
 end
 [%%expect {|
 Lines 20-23, characters 10-27:
-20 | ..........list_id
+20 |           list_id
+               ^^^^^^^
 21 |             (* no [@tailcall false]: this should warn that
+                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 22 |                the call becomes non-tailcall in the TMC version. *)
+                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 23 |             (filter_1 f xs)
+                 ^^^^^^^^^^^^^^^
 Warning 72 [tmc-breaks-tailcall]: This call
 is in tail-modulo-cons position in a TMC function,
 but the function called is not itself specialized for TMC,

--- a/testsuite/tests/tool-toplevel/error_highlighting.compilers.reference
+++ b/testsuite/tests/tool-toplevel/error_highlighting.compilers.reference
@@ -34,9 +34,12 @@ Line 2, characters 8-9:
             ^
   This '(' might be unmatched
 Lines 2-4, characters 8-2:
-2 | ........(1
+2 | let x = (1
+            ^^
 3 |   +
-4 | 2)...
+      ^
+4 | 2) +.
+    ^^
 Error: This expression has type int but an expression was expected of type
          float
 Line 2, characters 12-17:
@@ -66,9 +69,12 @@ File "error_highlighting_use3.ml", line 1, characters 8-9:
             ^
   This '(' might be unmatched
 File "error_highlighting_use4.ml", lines 1-3, characters 8-2:
-1 | ........(1
+1 | let x = (1
+            ^^
 2 |   +
-3 | 2)...
+      ^
+3 | 2) +.
+    ^^
 Error: This expression has type int but an expression was expected of type
          float
 

--- a/testsuite/tests/typing-extensions/extensions.ml
+++ b/testsuite/tests/typing-extensions/extensions.ml
@@ -308,9 +308,12 @@ end = struct
 end
 [%%expect {|
 Lines 3-5, characters 6-3:
-3 | ......struct
+3 | end = struct
+          ^^^^^^
 4 |   type ('a, 'b) bar += A of float
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 5 | end
+    ^^^
 Error: Signature mismatch:
        Modules do not match:
          sig type ('a, 'b) bar += A of float end
@@ -334,9 +337,12 @@ end = struct
 end
 [%%expect {|
 Lines 3-5, characters 6-3:
-3 | ......struct
+3 | end = struct
+          ^^^^^^
 4 |   type ('a, 'b) bar += A of 'b
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 5 | end
+    ^^^
 Error: Signature mismatch:
        Modules do not match:
          sig type ('a, 'b) bar += A of 'b end
@@ -360,9 +366,12 @@ end = struct
 end;;
 [%%expect {|
 Lines 3-5, characters 6-3:
-3 | ......struct
+3 | end = struct
+          ^^^^^^
 4 |   type ('b, 'a) bar = A of 'a
-5 | end..
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+5 | end;;
+    ^^^
 Error: Signature mismatch:
        Modules do not match:
          sig type ('b, 'a) bar = A of 'a end
@@ -387,9 +396,12 @@ end = struct
 end
 [%%expect {|
 Lines 3-5, characters 6-3:
-3 | ......struct
+3 | end = struct
+          ^^^^^^
 4 |   type ('a, 'b) bar += A : 'd -> ('c, 'd) bar
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 5 | end
+    ^^^
 Error: Signature mismatch:
        Modules do not match:
          sig type ('a, 'b) bar += A : 'd -> ('c, 'd) bar end

--- a/testsuite/tests/typing-extensions/open_types.ml
+++ b/testsuite/tests/typing-extensions/open_types.ml
@@ -325,10 +325,14 @@ let f = function
 ;;
 [%%expect {|
 Lines 1-4, characters 8-11:
-1 | ........function
+1 | let f = function
+            ^^^^^^^^
 2 |   | [Foo] -> 1
+      ^^^^^^^^^^^^
 3 |   | _::_::_ -> 3
+      ^^^^^^^^^^^^^^
 4 |   | [] -> 2
+      ^^^^^^^^^
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 *extension*::[]

--- a/testsuite/tests/typing-fstclassmod/scope_escape.ml
+++ b/testsuite/tests/typing-fstclassmod/scope_escape.ml
@@ -17,10 +17,14 @@ in
 [%%expect{|
 module type S = sig type t end
 Lines 6-9, characters 2-22:
-6 | ..(module struct
+6 |   (module struct
+      ^^^^^^^^^^^^^^
 7 |     type t = M.t
+        ^^^^^^^^^^^^
 8 |   end : S
+      ^^^^^^^
 9 |     with type t = M.t)
+        ^^^^^^^^^^^^^^^^^^
 Error: This expression has type (module S with type t = M.t)
        but an expression was expected of type (module S)
 |}];;
@@ -41,29 +45,44 @@ in
 ();;
 [%%expect{|
 Lines 2-6, characters 2-22:
-2 | ..let (module K : S with type t = A.t) = k in
+2 |   let (module K : S with type t = A.t) = k in
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 3 |   (module struct
+      ^^^^^^^^^^^^^^
 4 |     type t = K.t
+        ^^^^^^^^^^^^
 5 |   end : S
+      ^^^^^^^
 6 |     with type t = K.t)
+        ^^^^^^^^^^^^^^^^^^
 Error: This expression has type (module S with type t = A.t)
        but an expression was expected of type 'a
        The type constructor A.t would escape its scope
 |}, Principal{|
 Lines 8-12, characters 2-6:
- 8 | ..(module struct
+ 8 |   (module struct
+       ^^^^^^^^^^^^^^
  9 |     type t = unit
+         ^^^^^^^^^^^^^
 10 |
+     ^
 11 |     let x = ()
+         ^^^^^^^^^^
 12 |   end)
+       ^^^^
 Warning 18 [not-principal]: this module packing is not principal.
 
 Lines 2-6, characters 2-22:
-2 | ..let (module K : S with type t = A.t) = k in
+2 |   let (module K : S with type t = A.t) = k in
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 3 |   (module struct
+      ^^^^^^^^^^^^^^
 4 |     type t = K.t
+        ^^^^^^^^^^^^
 5 |   end : S
+      ^^^^^^^
 6 |     with type t = K.t)
+        ^^^^^^^^^^^^^^^^^^
 Error: This expression has type (module S with type t = A.t)
        but an expression was expected of type 'a
        The type constructor A.t would escape its scope
@@ -122,11 +141,16 @@ Error: This expression has type unit but an expression was expected of type
 |}, Principal{|
 module type S = sig type t val x : t end
 Lines 8-12, characters 4-8:
- 8 | ....(module struct
+ 8 |     (module struct
+         ^^^^^^^^^^^^^^
  9 |       type t = unit
+           ^^^^^^^^^^^^^
 10 |
+     ^
 11 |       let x = ()
+           ^^^^^^^^^^
 12 |     end)
+         ^^^^
 Warning 18 [not-principal]: this module packing is not principal.
 
 Line 15, characters 8-10:

--- a/testsuite/tests/typing-gadts/didier.ml
+++ b/testsuite/tests/typing-gadts/didier.ml
@@ -13,8 +13,10 @@ let fbool (type t) (x : t) (tag : t ty) =
 [%%expect{|
 type 'a ty = Int : int ty | Bool : bool ty
 Lines 6-7, characters 2-13:
-6 | ..match tag with
+6 |   match tag with
+      ^^^^^^^^^^^^^^
 7 |   | Bool -> x
+      ^^^^^^^^^^^
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 Int
@@ -30,8 +32,10 @@ let fint (type t) (x : t) (tag : t ty) =
 ;;
 [%%expect{|
 Lines 2-3, characters 2-16:
-2 | ..match tag with
+2 |   match tag with
+      ^^^^^^^^^^^^^^
 3 |   | Int -> x > 0
+      ^^^^^^^^^^^^^^
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 Bool

--- a/testsuite/tests/typing-gadts/or_patterns.ml
+++ b/testsuite/tests/typing-gadts/or_patterns.ml
@@ -528,8 +528,10 @@ let extract_merged_annotated (type a) (t2 : a t2) : a =
 
 [%%expect{|
 Lines 3-4, characters 4-10:
-3 | ....Int x
-4 |   | Bool x.....
+3 |   | Int x
+        ^^^^^
+4 |   | Bool x -> x
+      ^^^^^^^^
 Error: The variable x on the left-hand side of this or-pattern has type
        int but on the right-hand side it has type bool
 |}]
@@ -552,8 +554,10 @@ let extract_merged_too_lightly_annotated (type a) (t2 : a t2) : a =
 
 [%%expect{|
 Lines 3-4, characters 4-10:
-3 | ....Int (x : a)
-4 |   | Bool x.....
+3 |   | Int (x : a)
+        ^^^^^^^^^^^
+4 |   | Bool x -> x
+      ^^^^^^^^
 Error: The variable x on the left-hand side of this or-pattern has type
        a but on the right-hand side it has type bool
 |}]
@@ -586,8 +590,10 @@ let rambiguity (type a) (t2 : a t2) =
 
 [%%expect{|
 Lines 3-4, characters 4-23:
-3 | ....Int (_ as x)
-4 |   | Bool ((_ : a) as x).....
+3 |   | Int (_ as x)
+        ^^^^^^^^^^^^
+4 |   | Bool ((_ : a) as x) -> x
+      ^^^^^^^^^^^^^^^^^^^^^
 Error: The variable x on the left-hand side of this or-pattern has type
        int but on the right-hand side it has type a
 |}]
@@ -702,8 +708,10 @@ let f_amb (type a) (t : a t) (a : bool ref) (b : a ref) =
 ;;
 [%%expect{|
 Lines 3-4, characters 4-65:
-3 | ....IntLit,  ({ contents = true } as x), _
-4 |   | BoolLit,  _,                        ({ contents = true} as x)............
+3 |   | IntLit,  ({ contents = true } as x), _
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+4 |   | BoolLit,  _,                        ({ contents = true} as x) -> ignore x
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The variable x on the left-hand side of this or-pattern has type
          bool ref
        but on the right-hand side it has type a ref

--- a/testsuite/tests/typing-gadts/pr10907.ml
+++ b/testsuite/tests/typing-gadts/pr10907.ml
@@ -46,8 +46,10 @@ let unsound_cast : 'a 'b. 'a -> 'b = fun x ->
   match t with Iso (g, h) -> h (g x)
 [%%expect{|
 Lines 1-2, characters 37-36:
-1 | .....................................fun x ->
+1 | let unsound_cast : 'a 'b. 'a -> 'b = fun x ->
+                                         ^^^^^^^^
 2 |   match t with Iso (g, h) -> h (g x)
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This definition has type 'c. 'c -> 'c which is less general than
          'a 'b. 'a -> 'b
 |}]

--- a/testsuite/tests/typing-gadts/pr11888.ml
+++ b/testsuite/tests/typing-gadts/pr11888.ml
@@ -15,9 +15,13 @@ type z
 type 'a s
 Lines 3-6, characters 0-27:
 3 | type _ nat =
+    ^^^^^^^^^^^^
 4 |   | Nz : z -> z nat
+      ^^^^^^^^^^^^^^^^^
 5 |   | Nss : 'd nat -> 'd s s nat
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 6 |   | Ns : 'a nat -> 'a s nat
+      ^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: In the GADT constructor
          Nss : 'd nat -> 'd s s nat
        the type variable 'd cannot be deduced from the type parameters.

--- a/testsuite/tests/typing-gadts/pr5785.ml
+++ b/testsuite/tests/typing-gadts/pr5785.ml
@@ -14,9 +14,12 @@ struct
 end;;
 [%%expect{|
 Lines 7-9, characters 43-24:
-7 | ...........................................function
+7 |   let add (type a) : a t * a t -> string = function
+                                               ^^^^^^^^
 8 |     | One, One -> "two"
+        ^^^^^^^^^^^^^^^^^^^
 9 |     | Two, Two -> "four"
+        ^^^^^^^^^^^^^^^^^^^^
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 (One, Two)

--- a/testsuite/tests/typing-gadts/pr5906.ml
+++ b/testsuite/tests/typing-gadts/pr5906.ml
@@ -28,11 +28,16 @@ type (_, _, _) binop =
   | Leq : ('a, 'a, bool) binop
   | Add : (int, int, int) binop
 Lines 12-16, characters 2-36:
-12 | ..match bop, x, y with
+12 |   match bop, x, y with
+       ^^^^^^^^^^^^^^^^^^^^
 13 |   | Eq, Bool x, Bool y -> Bool (if x then y else not y)
+       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 14 |   | Leq, Int x, Int y -> Bool (x <= y)
+       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 15 |   | Leq, Bool x, Bool y -> Bool (x <= y)
+       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 16 |   | Add, Int x, Int y -> Int (x + y)
+       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 (Eq, Int _, _)

--- a/testsuite/tests/typing-gadts/pr5981.ml
+++ b/testsuite/tests/typing-gadts/pr5981.ml
@@ -13,8 +13,10 @@ module F(S : sig type 'a t end) = struct
 end;;
 [%%expect{|
 Lines 7-8, characters 47-21:
-7 | ...............................................match l, r with
+7 |     fun (l : int S.t ab) (r : float S.t ab) -> match l, r with
+                                                   ^^^^^^^^^^^^^^^
 8 |     | A, B -> "f A B"
+        ^^^^^^^^^^^^^^^^^
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 (A, A)
@@ -41,8 +43,10 @@ module F(S : sig type 'a t end) = struct
 end;;
 [%%expect{|
 Lines 10-11, characters 15-21:
-10 | ...............match l, r with
+10 |     fun l r -> match l, r with
+                    ^^^^^^^^^^^^^^^
 11 |     | A, B -> "f A B"
+         ^^^^^^^^^^^^^^^^^
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 (A, A)

--- a/testsuite/tests/typing-gadts/pr5985.ml
+++ b/testsuite/tests/typing-gadts/pr5985.ml
@@ -39,8 +39,10 @@ module F(T:sig type 'a t end) = struct
 end;; (* fail *)
 [%%expect{|
 Lines 2-3, characters 2-67:
-2 | ..class ['a] c x =
+2 |   class ['a] c x =
+      ^^^^^^^^^^^^^^^^
 3 |     object constraint 'a = 'b T.t val x' : 'b = x method x = x' end
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: In the definition
          type 'a c = < x : 'b > constraint 'a = 'b T.t
        the type variable 'b cannot be deduced from the type parameters.

--- a/testsuite/tests/typing-gadts/pr5989.ml
+++ b/testsuite/tests/typing-gadts/pr5989.ml
@@ -26,8 +26,10 @@ let () = print_endline (f M.eq) ;;
 type (_, _) t = Any : ('a, 'b) t | Eq : ('a, 'a) t
 module M : sig type s = private [> `A ] val eq : (s, [ `A | `B ]) t end
 Lines 16-17, characters 39-16:
-16 | .......................................function
+16 | let f : (M.s, [`A | `B]) t -> string = function
+                                            ^^^^^^^^
 17 |   | Any -> "Any"
+       ^^^^^^^^^^^^^^
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 Eq
@@ -57,8 +59,10 @@ module N :
     val eq : (s, < a : int; b : bool >) t
   end
 Lines 12-13, characters 49-16:
-12 | .................................................function
+12 | let f : (N.s, <a : int; b : bool>) t -> string = function
+                                                      ^^^^^^^^
 13 |   | Any -> "Any"
+       ^^^^^^^^^^^^^^
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 Eq

--- a/testsuite/tests/typing-gadts/pr6241.ml
+++ b/testsuite/tests/typing-gadts/pr6241.ml
@@ -22,8 +22,10 @@ let x = N.f A;;
 [%%expect{|
 type (_, _) t = A : ('a, 'a) t | B : string -> ('a, 'b) t
 Lines 8-9, characters 52-13:
-8 | ....................................................function
+8 |  let f : ((module A.T), (module B.T)) t -> string = function
+                                                        ^^^^^^^^
 9 |    | B s -> s
+       ^^^^^^^^^^
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 A

--- a/testsuite/tests/typing-gadts/pr7160.ml
+++ b/testsuite/tests/typing-gadts/pr7160.ml
@@ -16,7 +16,9 @@ type _ t =
 val f : int t -> int = <fun>
 Lines 4-5, characters 0-77:
 4 | type 'a tt = 'a t =
-5 |   Int : int -> int tt | String : string -> string tt | Same : 'l1 t -> 'l2 tt..
+    ^^^^^^^^^^^^^^^^^^^
+5 |   Int : int -> int tt | String : string -> string tt | Same : 'l1 t -> 'l2 tt;;
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This variant or record definition does not match that of type 'a t
        Constructors do not match:
          Same : 'l t -> 'l t

--- a/testsuite/tests/typing-gadts/pr7260.ml
+++ b/testsuite/tests/typing-gadts/pr7260.ml
@@ -20,11 +20,16 @@ type bar = < bar : unit >
 type _ ty = Int : int ty
 type dyn = Dyn : 'a ty -> dyn
 Lines 8-12, characters 2-5:
- 8 | ..object (this)
+ 8 |   object (this)
+       ^^^^^^^^^^^^^
  9 |     method foo (Dyn ty) =
+         ^^^^^^^^^^^^^^^^^^^^^
 10 |       match ty with
+           ^^^^^^^^^^^^^
 11 |       | Int -> (this :> bar)
-12 |   end.................................
+           ^^^^^^^^^^^^^^^^^^^^^^
+12 |   end;;  (* fail, but not for scope *)
+       ^^^
 Error: This non-virtual class has undeclared virtual methods.
        The following methods were not declared : bar
 |}];;

--- a/testsuite/tests/typing-gadts/pr7378.ml
+++ b/testsuite/tests/typing-gadts/pr7378.ml
@@ -16,8 +16,10 @@ module Y = struct
 end;; (* should fail *)
 [%%expect{|
 Lines 2-3, characters 2-37:
-2 | ..type t = X.t =
+2 |   type t = X.t =
+      ^^^^^^^^^^^^^^
 3 |     | A : 'a * 'b * ('b -> unit) -> t
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This variant or record definition does not match that of type X.t
        Constructors do not match:
          A : 'a * 'b * ('a -> unit) -> X.t

--- a/testsuite/tests/typing-gadts/pr9019.ml
+++ b/testsuite/tests/typing-gadts/pr9019.ml
@@ -31,11 +31,16 @@ let f (type x) (t1 : x t) (t2 : x t) (x : x) =
   | _, MAB, B -> 4
 [%%expect{|
 Lines 4-8, characters 2-18:
-4 | ..match t1, t2, x with
+4 |   match t1, t2, x with
+      ^^^^^^^^^^^^^^^^^^^^
 5 |   | AB,  AB, A -> 1
+      ^^^^^^^^^^^^^^^^^
 6 |   | MAB, _, A -> 2
+      ^^^^^^^^^^^^^^^^
 7 |   | _,  AB, B -> 3
+      ^^^^^^^^^^^^^^^^
 8 |   | _, MAB, B -> 4
+      ^^^^^^^^^^^^^^^^
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 (AB, MAB, A)
@@ -166,9 +171,12 @@ let f (type x) (a : x a) (a_or_b : x a_or_b) (x : x) =
 type _ a_or_b = A_or_B : [< `A of string | `B of int ] a_or_b
 type _ a = A : [> `A of string ] a | Not_A : 'a a
 Lines 9-11, characters 2-37:
- 9 | ..match a, a_or_b, x with
+ 9 |   match a, a_or_b, x with
+       ^^^^^^^^^^^^^^^^^^^^^^^
 10 |   | Not_A, A_or_B, `B i -> print_int i
+       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 11 |   | _, A_or_B, `A s -> print_string s
+       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 (A, A_or_B, `B _)
@@ -198,9 +206,12 @@ let f (type x) (type y) (b : (x, y ty) b) (x : x) (y : y) =
 type (_, _) b = A : ([< `A ], 'a) b | B : ([< `B of 'a ], 'a) b
 type _ ty = String_option : string option ty
 Lines 9-11, characters 2-18:
- 9 | ..match b, x, y with
+ 9 |   match b, x, y with
+       ^^^^^^^^^^^^^^^^^^
 10 |   | B, `B String_option, Some s -> print_string s
+       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 11 |   | A, `A, _ -> ()
+       ^^^^^^^^^^^^^^^^
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 (B, `B String_option, None)

--- a/testsuite/tests/typing-gadts/test.ml
+++ b/testsuite/tests/typing-gadts/test.ml
@@ -104,16 +104,21 @@ module Nonexhaustive =
 ;;
 [%%expect{|
 Lines 11-12, characters 6-19:
-11 | ......function
+11 |       function
+           ^^^^^^^^
 12 |         | C2 x -> x
+             ^^^^^^^^^^^
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 C1 _
 
 Lines 24-26, characters 6-30:
-24 | ......function
+24 |       function
+           ^^^^^^^^
 25 |         | Foo _ , Foo _ -> true
+             ^^^^^^^^^^^^^^^^^^^^^^^
 26 |         | Bar _, Bar _ -> true
+             ^^^^^^^^^^^^^^^^^^^^^^
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 (Foo _, Bar _)
@@ -266,8 +271,10 @@ module PR6801 = struct
 end;;
 [%%expect{|
 Lines 8-9, characters 4-33:
-8 | ....match x with
-9 |     | String s -> print_endline s.................
+8 |     match x with
+        ^^^^^^^^^^^^
+9 |     | String s -> print_endline s (* warn : Any *)
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 Any
@@ -802,8 +809,10 @@ let f : type a b. (a,b) eq -> [< `A of a | `B] -> [< `A of b | `B] =
   fun Eq o -> o ;; (* fail *)
 [%%expect{|
 Lines 1-2, characters 4-15:
-1 | ....f : type a b. (a,b) eq -> [< `A of a | `B] -> [< `A of b | `B] =
-2 |   fun Eq o -> o..............
+1 | let f : type a b. (a,b) eq -> [< `A of a | `B] -> [< `A of b | `B] =
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+2 |   fun Eq o -> o ;; (* fail *)
+      ^^^^^^^^^^^^^
 Error: This expression has type
          ('a, 'b) eq -> ([< `A of 'b & 'a | `B ] as 'c) -> 'c
        but an expression was expected of type
@@ -831,11 +840,16 @@ let f : type a b. (a,b) eq -> [> `A of a | `B] -> [`A of b | `B] =
     r;;
 [%%expect{|
 Lines 1-5, characters 4-5:
-1 | ....f : type a b. (a,b) eq -> [> `A of a | `B] -> [`A of b | `B] =
+1 | let f : type a b. (a,b) eq -> [> `A of a | `B] -> [`A of b | `B] =
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 2 |   fun eq o ->
+      ^^^^^^^^^^^
 3 |     ignore (o : [< `A of a | `B]);
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 4 |     let r : [`A of b | `B] = match eq with Eq -> o in (* fail with principal *)
-5 |     r..
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+5 |     r;;
+        ^
 Error: This expression has type
          ('a, 'b) eq -> [ `A of 'a | `B ] -> [ `A of 'b | `B ]
        but an expression was expected of type
@@ -916,13 +930,20 @@ let f : type a. a ty -> a t -> int = fun x y ->
 ;; (* warn *)
 [%%expect{|
 Lines 2-8, characters 2-16:
-2 | ..match x, y with
+2 |   match x, y with
+      ^^^^^^^^^^^^^^^
 3 |   | _, A z -> z
+      ^^^^^^^^^^^^^
 4 |   | _, B z -> if z then 1 else 2
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 5 |   | _, C z -> truncate z
+      ^^^^^^^^^^^^^^^^^^^^^^
 6 |   | TE TC, D [|1.0|] -> 14
+      ^^^^^^^^^^^^^^^^^^^^^^^^
 7 |   | TA, D 0 -> -1
+      ^^^^^^^^^^^^^^^
 8 |   | TA, D z -> z
+      ^^^^^^^^^^^^^^
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 (TE TC, D [| 0. |])
@@ -981,13 +1002,20 @@ let f : type a. a ty -> a t -> int = fun x y ->
 [%%expect{|
 type ('a, 'b) pair = { left : 'a; right : 'b; }
 Lines 4-10, characters 2-29:
- 4 | ..match {left=x; right=y} with
+ 4 |   match {left=x; right=y} with
+       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  5 |   | {left=_; right=A z} -> z
+       ^^^^^^^^^^^^^^^^^^^^^^^^^^
  6 |   | {left=_; right=B z} -> if z then 1 else 2
+       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  7 |   | {left=_; right=C z} -> truncate z
+       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  8 |   | {left=TE TC; right=D [|1.0|]} -> 14
+       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  9 |   | {left=TA; right=D 0} -> -1
+       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 10 |   | {left=TA; right=D z} -> z
+       ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 {left=TE TC; right=D [| 0. |]}

--- a/testsuite/tests/typing-gadts/yallop_bugs.ml
+++ b/testsuite/tests/typing-gadts/yallop_bugs.ml
@@ -57,9 +57,12 @@ let check : type s . s t * s -> bool = function
 [%%expect{|
 type _ t = IntLit : int t | BoolLit : bool t
 Lines 5-7, characters 39-23:
-5 | .......................................function
+5 | let check : type s . s t * s -> bool = function
+                                           ^^^^^^^^
 6 |   | BoolLit, false -> false
+      ^^^^^^^^^^^^^^^^^^^^^^^^^
 7 |   | IntLit , 6 -> false
+      ^^^^^^^^^^^^^^^^^^^^^
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 (BoolLit, true)
@@ -76,9 +79,12 @@ let check : type s . (s t, s) pair -> bool = function
 [%%expect{|
 type ('a, 'b) pair = { fst : 'a; snd : 'b; }
 Lines 3-5, characters 45-38:
-3 | .............................................function
+3 | let check : type s . (s t, s) pair -> bool = function
+                                                 ^^^^^^^^
 4 |   | {fst = BoolLit; snd = false} -> false
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 5 |   | {fst = IntLit ; snd =  6} -> false
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 {fst=BoolLit; snd=true}

--- a/testsuite/tests/typing-immediate/immediate.ml
+++ b/testsuite/tests/typing-immediate/immediate.ml
@@ -138,9 +138,12 @@ module D : sig type t [@@immediate] end = struct
 end;;
 [%%expect{|
 Lines 1-3, characters 42-3:
-1 | ..........................................struct
+1 | module D : sig type t [@@immediate] end = struct
+                                              ^^^^^^
 2 |   type t = string
-3 | end..
+      ^^^^^^^^^^^^^^^
+3 | end;;
+    ^^^
 Error: Signature mismatch:
        Modules do not match:
          sig type t = string end

--- a/testsuite/tests/typing-misc/apply_non_function.ml
+++ b/testsuite/tests/typing-misc/apply_non_function.ml
@@ -10,13 +10,15 @@ let () =
 [%%expect{|
 val print_lines : string list -> unit = <fun>
 Lines 4-5, characters 2-15:
-4 | ..print_lines (List.map string_of_int [ 1; 2; 3; 4; 5 ])
-5 |   print_endline......
+4 |   print_lines (List.map string_of_int [ 1; 2; 3; 4; 5 ])
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+5 |   print_endline "foo"
+      ^^^^^^^^^^^^^
 Error: The function 'print_lines' has type string list -> unit
        It is applied to too many arguments
 Line 4, characters 55-57:
 4 |   print_lines (List.map string_of_int [ 1; 2; 3; 4; 5 ])
-                                                           ^^
+                                                           ^
   Hint: Did you forget a ';'?
 Line 5, characters 2-15:
 5 |   print_endline "foo"

--- a/testsuite/tests/typing-misc/build_as_type.ml
+++ b/testsuite/tests/typing-misc/build_as_type.ml
@@ -69,9 +69,12 @@ let f = function
   | `B -> ();;
 [%%expect{|
 Lines 5-7, characters 4-7:
-5 | ....begin match x with
+5 |     begin match x with
+        ^^^^^^^^^^^^^^^^^^
 6 |     | `A -> ()
+        ^^^^^^^^^^
 7 |     end
+        ^^^
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 `B
@@ -126,9 +129,12 @@ let f = function
   | `B -> ();;
 [%%expect{|
 Lines 5-7, characters 4-7:
-5 | ....begin match x with
+5 |     begin match x with
+        ^^^^^^^^^^^^^^^^^^
 6 |     | `A -> ()
+        ^^^^^^^^^^
 7 |     end
+        ^^^
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 `B
@@ -147,9 +153,12 @@ let f = function
 
 [%%expect{|
 Lines 5-7, characters 4-7:
-5 | ....begin match x with
+5 |     begin match x with
+        ^^^^^^^^^^^^^^^^^^
 6 |     | `A -> ()
+        ^^^^^^^^^^
 7 |     end
+        ^^^
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 `B

--- a/testsuite/tests/typing-misc/deep.ml
+++ b/testsuite/tests/typing-misc/deep.ml
@@ -9,9 +9,12 @@ end = struct
 end
 [%%expect{|
 Lines 3-5, characters 6-3:
-3 | ......struct
+3 | end = struct
+          ^^^^^^
 4 |   let x = false , "not an int"
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 5 | end
+    ^^^
 Error: Signature mismatch:
        Modules do not match:
          sig val x : bool * string end
@@ -32,9 +35,12 @@ end = struct
 end
 [%%expect{|
 Lines 3-5, characters 6-3:
-3 | ......struct
+3 | end = struct
+          ^^^^^^
 4 |   let f x = x + List.length [0.0, Some true]
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 5 | end
+    ^^^
 Error: Signature mismatch:
        Modules do not match:
          sig val f : int -> int end
@@ -57,9 +63,12 @@ end = struct
 end
 [%%expect{|
 Lines 3-5, characters 6-3:
-3 | ......struct
+3 | end = struct
+          ^^^^^^
 4 |   let f : ('c list * 'd option  -> int) = assert false
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 5 | end
+    ^^^
 Error: Signature mismatch:
        Modules do not match:
          sig val f : 'c list * 'd option -> int end
@@ -81,9 +90,12 @@ end = struct
 end
 [%%expect{|
 Lines 3-5, characters 6-3:
-3 | ......struct
+3 | end = struct
+          ^^^^^^
 4 |   type t = bool * float
+      ^^^^^^^^^^^^^^^^^^^^^
 5 | end
+    ^^^
 Error: Signature mismatch:
        Modules do not match:
          sig type t = bool * float end

--- a/testsuite/tests/typing-misc/disambiguate_principality.ml
+++ b/testsuite/tests/typing-misc/disambiguate_principality.ml
@@ -567,9 +567,12 @@ let t = function
 ;;
 [%%expect{|
 Lines 1-3, characters 8-10:
-1 | ........function
+1 | let t = function
+            ^^^^^^^^
 2 |   | ({ contents = M.A } : M.t ref) as x ->
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 3 |     x := B
+        ^^^^^^
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 {contents=B}
@@ -582,9 +585,12 @@ Line 3, characters 9-10:
 Warning 18 [not-principal]: this type-based constructor disambiguation is not principal.
 
 Lines 1-3, characters 8-10:
-1 | ........function
+1 | let t = function
+            ^^^^^^^^
 2 |   | ({ contents = M.A } : M.t ref) as x ->
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 3 |     x := B
+        ^^^^^^
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 {contents=B}

--- a/testsuite/tests/typing-misc/distant_errors.ml
+++ b/testsuite/tests/typing-misc/distant_errors.ml
@@ -17,10 +17,14 @@ end
 
 [%%expect{|
 Lines 9-12, characters 6-3:
- 9 | ......struct
+ 9 | end = struct
+           ^^^^^^
 10 |   type _ t
+       ^^^^^^^^
 11 |   let f _ = ()
+       ^^^^^^^^^^^^
 12 | end
+     ^^^
 Error: Signature mismatch:
        Modules do not match:
          sig type _ t val f : 'a -> unit end

--- a/testsuite/tests/typing-misc/empty_variant.ml
+++ b/testsuite/tests/typing-misc/empty_variant.ml
@@ -55,8 +55,10 @@ type nothing = |
 type ('a, 'b, 'c) t = A of 'a | B of 'b | C of 'c
 module Runner : sig val ac : f:((unit, 'a, unit) t -> unit) -> unit end
 Lines 16-17, characters 8-18:
-16 | ........match abc with
+16 |         match abc with
+             ^^^^^^^^^^^^^^
 17 |         | A _ -> 1
+             ^^^^^^^^^^
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 C ()

--- a/testsuite/tests/typing-misc/enrich_typedecl.ml
+++ b/testsuite/tests/typing-misc/enrich_typedecl.ml
@@ -14,14 +14,22 @@ end = struct
 end;;
 [%%expect{|
 Lines 3-10, characters 6-3:
- 3 | ......struct
+ 3 | end = struct
+           ^^^^^^
  4 |   type t = A | B
+       ^^^^^^^^^^^^^^
  5 |
+     ^
  6 |   let f (x : t) =
+       ^^^^^^^^^^^^^^^
  7 |     match x with
+         ^^^^^^^^^^^^
  8 |     | A -> ()
+         ^^^^^^^^^
  9 |     | B -> ()
-10 | end..
+         ^^^^^^^^^
+10 | end;;
+     ^^^
 Error: Signature mismatch:
        Modules do not match:
          sig type t = A.t = A | B val f : t -> unit end
@@ -46,14 +54,22 @@ end = struct
 end;;
 [%%expect{|
 Lines 3-10, characters 6-3:
- 3 | ......struct
+ 3 | end = struct
+           ^^^^^^
  4 |   type 'a t = A of 'a | B
+       ^^^^^^^^^^^^^^^^^^^^^^^
  5 |
+     ^
  6 |   let f (x : _ t) =
+       ^^^^^^^^^^^^^^^^^
  7 |     match x with
+         ^^^^^^^^^^^^
  8 |     | A _ -> ()
+         ^^^^^^^^^^^
  9 |     | B -> ()
-10 | end..
+         ^^^^^^^^^
+10 | end;;
+     ^^^
 Error: Signature mismatch:
        Modules do not match:
          sig type 'a t = 'a B.t = A of 'a | B val f : 'a t -> unit end
@@ -78,14 +94,22 @@ end = struct
 end;;
 [%%expect{|
 Lines 3-10, characters 6-3:
- 3 | ......struct
+ 3 | end = struct
+           ^^^^^^
  4 |   type 'a t = A of 'a | B
+       ^^^^^^^^^^^^^^^^^^^^^^^
  5 |
+     ^
  6 |   let f (x : _ t) =
+       ^^^^^^^^^^^^^^^^^
  7 |     match x with
+         ^^^^^^^^^^^^
  8 |     | A _ -> ()
+         ^^^^^^^^^^^
  9 |     | B -> ()
-10 | end..
+         ^^^^^^^^^
+10 | end;;
+     ^^^
 Error: Signature mismatch:
        Modules do not match:
          sig type 'a t = 'a C.t = A of 'a | B val f : 'a t -> unit end
@@ -111,14 +135,22 @@ end = struct
 end;;
 [%%expect{|
 Lines 3-10, characters 6-3:
- 3 | ......struct
+ 3 | end = struct
+           ^^^^^^
  4 |   type 'a t = A of 'a | B
+       ^^^^^^^^^^^^^^^^^^^^^^^
  5 |
+     ^
  6 |   let f (x : _ t) =
+       ^^^^^^^^^^^^^^^^^
  7 |     match x with
+         ^^^^^^^^^^^^
  8 |     | A _ -> ()
+         ^^^^^^^^^^^
  9 |     | B -> ()
-10 | end..
+         ^^^^^^^^^
+10 | end;;
+     ^^^
 Error: Signature mismatch:
        Modules do not match:
          sig type 'a t = 'a D.t = A of 'a | B val f : 'a t -> unit end
@@ -143,14 +175,22 @@ end = struct
 end;;
 [%%expect{|
 Lines 3-10, characters 6-3:
- 3 | ......struct
+ 3 | end = struct
+           ^^^^^^
  4 |   type 'a t = A of 'a | B
+       ^^^^^^^^^^^^^^^^^^^^^^^
  5 |
+     ^
  6 |   let f (x : _ t) =
+       ^^^^^^^^^^^^^^^^^
  7 |     match x with
+         ^^^^^^^^^^^^
  8 |     | A _ -> ()
+         ^^^^^^^^^^^
  9 |     | B -> ()
-10 | end..
+         ^^^^^^^^^
+10 | end;;
+     ^^^
 Error: Signature mismatch:
        Modules do not match:
          sig type 'a t = 'a E.t = A of 'a | B val f : 'a t -> unit end
@@ -175,14 +215,22 @@ end = struct
 end;;
 [%%expect{|
 Lines 3-10, characters 6-3:
- 3 | ......struct
+ 3 | end = struct
+           ^^^^^^
  4 |   type 'a t = A of 'a | B
+       ^^^^^^^^^^^^^^^^^^^^^^^
  5 |
+     ^
  6 |   let f (x : _ t) =
+       ^^^^^^^^^^^^^^^^^
  7 |     match x with
+         ^^^^^^^^^^^^
  8 |     | A _ -> ()
+         ^^^^^^^^^^^
  9 |     | B -> ()
-10 | end..
+         ^^^^^^^^^
+10 | end;;
+     ^^^
 Error: Signature mismatch:
        Modules do not match:
          sig type 'a t = 'a E2.t = A of 'a | B val f : 'a t -> unit end
@@ -207,14 +255,22 @@ end = struct
 end;;
 [%%expect{|
 Lines 3-10, characters 6-3:
- 3 | ......struct
+ 3 | end = struct
+           ^^^^^^
  4 |   type 'a t = A of 'a | B
+       ^^^^^^^^^^^^^^^^^^^^^^^
  5 |
+     ^
  6 |   let f (x : _ t) =
+       ^^^^^^^^^^^^^^^^^
  7 |     match x with
+         ^^^^^^^^^^^^
  8 |     | A _ -> ()
+         ^^^^^^^^^^^
  9 |     | B -> ()
-10 | end..
+         ^^^^^^^^^
+10 | end;;
+     ^^^
 Error: Signature mismatch:
        Modules do not match:
          sig type 'a t = 'a E3.t = A of 'a | B val f : 'a t -> unit end
@@ -239,13 +295,20 @@ end = struct
 end;;
 [%%expect{|
 Lines 3-9, characters 6-3:
-3 | ......struct
+3 | end = struct
+          ^^^^^^
 4 |   type ('a, 'b) t = Foo of 'b
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 5 |
+    ^
 6 |   (* this function typechecks properly, which means that we've added the
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 7 |      manisfest. *)
+         ^^^^^^^^^^^^^
 8 |   let coerce : 'a 'b. ('a, 'b) t -> ('a, 'b) F.t = fun x -> x
-9 | end..
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+9 | end;;
+    ^^^
 Error: Signature mismatch:
        Modules do not match:
          sig

--- a/testsuite/tests/typing-misc/includeclass_errors.ml
+++ b/testsuite/tests/typing-misc/includeclass_errors.ml
@@ -16,9 +16,12 @@ end
 [%%expect{|
 class type foo_t = object method foo : string end
 Lines 8-10, characters 6-3:
- 8 | ......struct
+ 8 | end = struct
+           ^^^^^^
  9 |   class type ct = object end
+       ^^^^^^^^^^^^^^^^^^^^^^^^^^
 10 | end
+     ^^^
 Error: Signature mismatch:
        Modules do not match:
          sig class type ct = object  end end
@@ -43,11 +46,16 @@ end
 ;;
 [%%expect{|
 Lines 5-9, characters 6-3:
-5 | ......struct
+5 | end = struct
+          ^^^^^^
 6 |   class virtual c = object
+      ^^^^^^^^^^^^^^^^^^^^^^^^
 7 |     method virtual a: string
+        ^^^^^^^^^^^^^^^^^^^^^^^^
 8 |   end
+      ^^^
 9 | end
+    ^^^
 Error: Signature mismatch:
        Modules do not match:
          sig class virtual c : object method virtual a : string end end
@@ -72,9 +80,12 @@ end
 [%%expect{|
 class type ['a] ct = object val x : 'a end
 Lines 5-7, characters 6-3:
-5 | ......struct
+5 | end = struct
+          ^^^^^^
 6 |   class type c = object end
+      ^^^^^^^^^^^^^^^^^^^^^^^^^
 7 | end
+    ^^^
 Error: Signature mismatch:
        Modules do not match:
          sig class type c = object  end end
@@ -95,9 +106,12 @@ end
 ;;
 [%%expect{|
 Lines 3-5, characters 6-3:
-3 | ......struct
+3 | end = struct
+          ^^^^^^
 4 |   class ['a] c = object end
+      ^^^^^^^^^^^^^^^^^^^^^^^^^
 5 | end
+    ^^^
 Error: Signature mismatch:
        Modules do not match:
          sig class ['a] c : object  end end
@@ -118,9 +132,12 @@ end
 ;;
 [%%expect{|
 Lines 3-5, characters 6-3:
-3 | ......struct
+3 | end = struct
+          ^^^^^^
 4 |   class c (x : float) = object end
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 5 | end
+    ^^^
 Error: Signature mismatch:
        Modules do not match:
          sig class c : float -> object  end end
@@ -142,10 +159,14 @@ class virtual foo: foo_t =
 
 [%%expect{|
 Lines 2-5, characters 4-7:
-2 | ....object
+2 |     object
+        ^^^^^^
 3 |         method foo = "foo"
+            ^^^^^^^^^^^^^^^^^^
 4 |         method private virtual cast: int
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 5 |     end
+        ^^^
 Error: The class type
          object method private virtual cast : int method foo : string end
        is not matched by the class type foo_t
@@ -165,9 +186,12 @@ class foo: foo_t2 =
 [%%expect{|
 class type foo_t2 = object method private foo : string end
 Lines 7-9, characters 4-7:
-7 | ....object
+7 |     object
+        ^^^^^^
 8 |         method foo = "foo"
+            ^^^^^^^^^^^^^^^^^^
 9 |     end
+        ^^^
 Error: The class type object method foo : string end
        is not matched by the class type foo_t2
        The public method foo cannot become private
@@ -180,9 +204,12 @@ class virtual foo: foo_t =
 ;;
 [%%expect{|
 Lines 2-4, characters 4-7:
-2 | ....object
+2 |     object
+        ^^^^^^
 3 |         method virtual foo: string
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^
 4 |     end
+        ^^^
 Error: The class type object method virtual foo : string end
        is not matched by the class type foo_t
        The virtual method foo cannot become concrete
@@ -201,9 +228,12 @@ class foo: foo_t3 =
 [%%expect{|
 class type foo_t3 = object val mutable x : int end
 Lines 7-9, characters 4-7:
-7 | ....object
+7 |     object
+        ^^^^^^
 8 |         val x = 1
+            ^^^^^^^^^
 9 |     end
+        ^^^
 Error: The class type object val x : int end is not matched by the class type
          foo_t3
        The non-mutable instance variable x cannot become mutable
@@ -222,9 +252,12 @@ class virtual foo: foo_t4 =
 [%%expect{|
 class type foo_t4 = object val x : int end
 Lines 7-9, characters 4-7:
-7 | ....object
+7 |     object
+        ^^^^^^
 8 |         val virtual x : int
+            ^^^^^^^^^^^^^^^^^^^
 9 |     end
+        ^^^
 Error: The class type object val virtual x : int end
        is not matched by the class type foo_t4
        The virtual instance variable x cannot become concrete
@@ -238,9 +271,12 @@ end
 ;;
 [%%expect{|
 Lines 3-5, characters 6-3:
-3 | ......struct
+3 | end = struct
+          ^^^^^^
 4 |   class type c = object method private m: string end
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 5 | end
+    ^^^
 Error: Signature mismatch:
        Modules do not match:
          sig class type c = object method private m : string end end

--- a/testsuite/tests/typing-misc/pr6416.ml
+++ b/testsuite/tests/typing-misc/pr6416.ml
@@ -13,10 +13,14 @@ module M = struct
 end;;
 [%%expect{|
 Lines 5-8, characters 8-5:
-5 | ........struct
+5 |   end = struct
+            ^^^^^^
 6 |     type t = B
+        ^^^^^^^^^^
 7 |     let f B = ()
+        ^^^^^^^^^^^^
 8 |   end
+      ^^^
 Error: Signature mismatch:
        Modules do not match:
          sig type t = B val f : t -> unit end
@@ -74,10 +78,14 @@ end;;
 
 [%%expect{|
 Lines 4-7, characters 4-7:
-4 | ....struct
+4 |     struct
+        ^^^^^^
 5 |       module type s
+          ^^^^^^^^^^^^^
 6 |       module A(X:s) =struct end
+          ^^^^^^^^^^^^^^^^^^^^^^^^^
 7 |     end
+        ^^^
 Error: Signature mismatch:
        Modules do not match:
          sig module type s module A : functor (X : s) -> sig end end
@@ -108,10 +116,14 @@ module L = struct
 end;;
       [%%expect {|
 Lines 4-7, characters 4-7:
-4 | ....struct
+4 |     struct
+        ^^^^^^
 5 |       module T = struct type t end
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 6 |       type t = A of T.t
+          ^^^^^^^^^^^^^^^^^
 7 |     end
+        ^^^
 Error: Signature mismatch:
        Modules do not match:
          sig module T : sig type t end type t = A of T.t end
@@ -206,10 +218,14 @@ end;;
 
 [%%expect{|
 Lines 4-7, characters 2-5:
-4 | ..struct
+4 |   struct
+      ^^^^^^
 5 |     class a = object method c = let module X = struct type t end in () end
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 6 |     class b = a
+        ^^^^^^^^^^^
 7 |   end
+      ^^^
 Error: Signature mismatch:
        Modules do not match:
          sig class a : object method c : unit end class b : a end
@@ -238,10 +254,14 @@ end;;
 
 [%%expect{|
 Lines 4-7, characters 2-5:
-4 | ..struct
+4 |   struct
+      ^^^^^^
 5 |     class type a = object end
+        ^^^^^^^^^^^^^^^^^^^^^^^^^
 6 |     class type b = a
+        ^^^^^^^^^^^^^^^^
 7 |   end
+      ^^^
 Error: Signature mismatch:
        Modules do not match:
          sig class type a = object  end class type b = a end
@@ -285,14 +305,22 @@ end;;
 
 [%%expect{|
 Lines 8-15, characters 6-3:
- 8 | ......struct
+ 8 | end = struct
+           ^^^^^^
  9 |   type t
+       ^^^^^^
 10 |   class type a = object method m:t end
+       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 11 |   module K = struct
+       ^^^^^^^^^^^^^^^^^
 12 |     type t
+         ^^^^^^
 13 |     class type c = object inherit a end
+         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 14 |   end
-15 | end..
+       ^^^
+15 | end;;
+     ^^^
 Error: Signature mismatch:
        Modules do not match:
          sig
@@ -363,9 +391,12 @@ type t = B
 type t = C
 type t = D
 Lines 5-7, characters 44-3:
-5 | ............................................struct
+5 | module M: sig val f: t -> t -> t -> t end = struct
+                                                ^^^^^^
 6 |   let f A B C = D
-7 | end..
+      ^^^^^^^^^^^^^^^
+7 | end;;
+    ^^^
 Error: Signature mismatch:
        Modules do not match:
          sig val f : t/4 -> t/3 -> t/2 -> t end

--- a/testsuite/tests/typing-misc/pr6634.ml
+++ b/testsuite/tests/typing-misc/pr6634.ml
@@ -12,8 +12,11 @@ end;;
 type t = int
 Lines 3-5, characters 0-3:
 3 | struct
+    ^^^^^^
 4 |   type t = [`T of t]
-5 | end..
+      ^^^^^^^^^^^^^^^^^^
+5 | end;;
+    ^^^
 Error: Signature mismatch:
        Modules do not match:
          sig type t = [ `T of t ] end

--- a/testsuite/tests/typing-misc/pr7668_bad.ml
+++ b/testsuite/tests/typing-misc/pr7668_bad.ml
@@ -21,8 +21,10 @@ val partition_map :
   ('a -> [< `Left of 'b | `Right of 'c ]) -> 'a list -> 'b list * 'c list =
   <fun>
 Lines 12-13, characters 35-18:
-12 | ...................................partition_map (fun x -> if x then `Left ()
+12 | let f xs : (int list * int list) = partition_map (fun x -> if x then `Left ()
+                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 13 | else `Right ()) xs
+     ^^^^^^^^^^^^^^^^^^
 Error: This expression has type unit list * unit list
        but an expression was expected of type int list * int list
        Type unit is not compatible with type int
@@ -58,16 +60,25 @@ end
 ;;
 [%%expect{|
 Lines 8-27, characters 6-3:
- 8 | ......struct
+ 8 | end = struct
+           ^^^^^^
  9 |   type t = [
+       ^^^^^^^^^^
 10 |     | `A of int
+         ^^^^^^^^^^^
 11 |     | `B of [ `BA | `BB of unit list ]
+         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 12 |     | `C of unit ]
-...
+         ^^^^^^^^^^^^^^
+     ...
 24 |         end
+             ^^^
 25 |       | _ -> assert false)
+           ^^^^^^^^^^^^^^^^^^^^
 26 |
+     ^
 27 | end
+     ^^^
 Error: Signature mismatch:
        Modules do not match:
          sig

--- a/testsuite/tests/typing-misc/variant.ml
+++ b/testsuite/tests/typing-misc/variant.ml
@@ -12,10 +12,14 @@ end = struct
 end;;
 [%%expect{|
 Lines 3-6, characters 6-3:
-3 | ......struct
+3 | end = struct
+          ^^^^^^
 4 |  type t = A | B
+     ^^^^^^^^^^^^^^
 5 |  let f = function A | B -> 0
-6 | end..
+     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+6 | end;;
+    ^^^
 Error: Signature mismatch:
        Modules do not match:
          sig type t = X.t = A | B val f : t -> int end
@@ -134,9 +138,12 @@ end = struct
 end;;
 [%%expect{|
 Lines 3-5, characters 6-3:
-3 | ......struct
+3 | end = struct
+          ^^^^^^
 4 |   type t = Foo : int -> t
-5 | end..
+      ^^^^^^^^^^^^^^^^^^^^^^^
+5 | end;;
+    ^^^
 Error: Signature mismatch:
        Modules do not match:
          sig type t = Foo : int -> t end

--- a/testsuite/tests/typing-modules/Test.ml
+++ b/testsuite/tests/typing-modules/Test.ml
@@ -193,9 +193,12 @@ end = struct
 end;;
 [%%expect{|
 Lines 3-5, characters 6-3:
-3 | ......struct
+3 | end = struct
+          ^^^^^^
 4 |   type t += E of int
-5 | end..
+      ^^^^^^^^^^^^^^^^^^
+5 | end;;
+    ^^^
 Error: Signature mismatch:
        Modules do not match:
          sig type t += E of int end

--- a/testsuite/tests/typing-modules/functors.ml
+++ b/testsuite/tests/typing-modules/functors.ml
@@ -92,9 +92,12 @@ module M : sig module F: functor (X:sig end) -> sig end end =
   end
 [%%expect {|
 Lines 2-4, characters 2-5:
-2 | ..struct
+2 |   struct
+      ^^^^^^
 3 |     module F(X:sig type t end) = struct end
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 4 |   end
+      ^^^
 Error: Signature mismatch:
        Modules do not match:
          sig module F : functor (X : sig type t end) -> sig end end
@@ -168,9 +171,12 @@ end = struct
 end
 [%%expect {|
 Lines 3-5, characters 6-3:
-3 | ......struct
+3 | end = struct
+          ^^^^^^
 4 |  module F(X:sig type y end) = struct end
+     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 5 | end
+    ^^^
 Error: Signature mismatch:
        Modules do not match:
          sig module F : functor (X : sig type y end) -> sig end end
@@ -284,10 +290,14 @@ module M =
     (struct type yy = K.y end)
 [%%expect {|
 Lines 2-5, characters 2-30:
-2 | ..F
+2 |   F
+      ^
 3 |     (struct include X include Y end)
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 4 |     (struct type x = K.x end)
+        ^^^^^^^^^^^^^^^^^^^^^^^^^
 5 |     (struct type yy = K.y end)
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The functor application is ill-typed.
        These arguments:
          $S1 $S2 $S3
@@ -446,9 +456,12 @@ end = struct
 end;;
 [%%expect {|
 Lines 5-7, characters 6-3:
-5 | ......struct
+5 | end = struct
+          ^^^^^^
 6 |   module type S = sig type s type t end
-7 | end..
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+7 | end;;
+    ^^^
 Error: Signature mismatch:
        Modules do not match:
          sig module type S = sig type s type t end end
@@ -475,9 +488,12 @@ end = struct
 end;;
   [%%expect {|
 Lines 3-5, characters 6-3:
-3 | ......struct
+3 | end = struct
+          ^^^^^^
 4 |   module type S = sig type t end
-5 | end..
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+5 | end;;
+    ^^^
 Error: Signature mismatch:
        Modules do not match:
          sig module type S = sig type t end end
@@ -560,11 +576,16 @@ module M: sig module F: functor(X:a)(Y:a) -> sig end end =
 end
 [%%expect {|
 Lines 2-6, characters 1-3:
-2 | .struct
+2 |  struct
+     ^^^^^^
 3 |   module type aa = a
+      ^^^^^^^^^^^^^^^^^^
 4 |   module type a
+      ^^^^^^^^^^^^^
 5 |   module F(X:aa)(Y:a) = struct end
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 6 | end
+    ^^^
 Error: Signature mismatch:
        Modules do not match:
          sig
@@ -639,16 +660,25 @@ end = struct
 end
 [%%expect {|
 Lines 15-27, characters 6-3:
-15 | ......struct
+15 | end = struct
+           ^^^^^^
 16 |   module F
+       ^^^^^^^^
 17 |       (X:
+           ^^^
 18 |          functor (A: sig type xa end)(B:sig type xz end) -> sig end
+              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 19 |       )
-...
+           ^
+     ...
 24 |          functor (A: sig type za end)(B:sig type zbb end) -> sig end
+              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 25 |       )
+           ^
 26 |   = struct end
+       ^^^^^^^^^^^^
 27 | end
+     ^^^
 Error: Signature mismatch:
        Modules do not match:
          sig
@@ -732,16 +762,26 @@ end = struct
 end
 [%%expect {|
 Lines 12-21, characters 6-3:
-12 | ......struct
+12 | end = struct
+           ^^^^^^
 13 |   module F
+       ^^^^^^^^
 14 |       (X:
+           ^^^
 15 |          functor (A: sig type xa end)(B:sig type xz end) -> sig end
+              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 16 |       )
+           ^
 17 |       (Y:
+           ^^^
 18 |          functor (A: sig type ya end)(B:sig type yb end) -> sig end
+              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 19 |       )
+           ^
 20 |   = struct end
+       ^^^^^^^^^^^^
 21 | end
+     ^^^
 Error: Signature mismatch:
        Modules do not match:
          sig
@@ -803,16 +843,25 @@ end = struct
 end
 [%%expect {|
 Lines 12-24, characters 6-3:
-12 | ......struct
+12 | end = struct
+           ^^^^^^
 13 |   module F
+       ^^^^^^^^
 14 |       (X:
+           ^^^
 15 |          functor (A: sig type xaa end)(B:sig type xz end) -> sig end
+              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 16 |       )
-...
+           ^
+     ...
 21 |          functor (A: sig type za end)(B:sig type zbb end) -> sig end
+              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 22 |       )
+           ^
 23 |   = struct end
+       ^^^^^^^^^^^^
 24 | end
+     ^^^
 Error: Signature mismatch:
        Modules do not match:
          sig
@@ -906,16 +955,25 @@ end = struct
 end
 [%%expect {|
 Lines 12-23, characters 6-3:
-12 | ......struct
+12 | end = struct
+           ^^^^^^
 13 |   module B = struct
+       ^^^^^^^^^^^^^^^^^
 14 |     module C = struct
+         ^^^^^^^^^^^^^^^^^
 15 |       module D = struct
+           ^^^^^^^^^^^^^^^^^
 16 |         module E = struct
-...
+             ^^^^^^^^^^^^^^^^^
+     ...
 20 |       end
+           ^^^
 21 |     end
+         ^^^
 22 |   end
+       ^^^
 23 | end
+     ^^^
 Error: Signature mismatch:
        Modules do not match:
          sig
@@ -1122,14 +1180,22 @@ module type s =
     (S : sig type where type the type place end)
     (R : sig type upon type the type heath end) -> sig end
 Lines 11-18, characters 2-15:
-11 | ..(X: sig type when_ type shall type we type tree type meet type again end)
+11 |   (X: sig type when_ type shall type we type tree type meet type again end)
+       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 12 |   (Y:sig type in_ val thunder:in_ val lightning: in_ type pain end)
+       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 13 |   (Z:sig type when_ type the type hurlyburly's type gone  end)
+       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 14 |   (Z:sig type when_ type the type battle's type last type and_ type won end)
+       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 15 |   (W:sig type that type will type be type the type era type set type of_ type sun end)
+       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 16 |   (S: sig type where type the type lace end)
+       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 17 |   (R: sig type upon type the type heart end)
+       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 18 |   -> struct end
+       ^^^^^^^^^^^^^
 Error: Signature mismatch:
        Modules do not match:
          functor (X : $S1) (Y : $S2) (Z : $S3) (Z : $S4) (W : $S5) (S : $S6)
@@ -1382,9 +1448,12 @@ end
 end
 [%%expect {|
 Lines 14-16, characters 2-3:
-14 | ..struct
+14 | = struct
+       ^^^^^^
 15 |   module F(X:sig type x end)(Z:sig type z end) = struct end
+       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 16 | end
+     ^^^
 Error: Signature mismatch:
        Modules do not match:
          sig
@@ -1431,13 +1500,20 @@ end = struct
 end
 [%%expect {|
 Lines 8-14, characters 6-3:
- 8 | ......struct
+ 8 | end = struct
+           ^^^^^^
  9 |   module F (Wrong: sig type wrong end)
+       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 10 |       (X: sig
+           ^^^^^^^
 11 |          module type t
+              ^^^^^^^^^^^^^
 12 |          module M: t
+              ^^^^^^^^^^^
 13 |        end)  = (X.M : X.t)
+            ^^^^^^^^^^^^^^^^^^^
 14 | end
+     ^^^
 Error: Signature mismatch:
        Modules do not match:
          sig
@@ -1492,11 +1568,16 @@ end = struct
 end
 [%%expect {|
 Lines 17-21, characters 6-3:
-17 | ......struct
+17 | end = struct
+           ^^^^^^
 18 |   module F(_:sig type wrong end) (X:
+       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 19 |              sig  module type T end
+                  ^^^^^^^^^^^^^^^^^^^^^^
 20 |           )(Res: X.T)(Res: X.T)(Res: X.T) = Res
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 21 | end
+     ^^^
 Error: Signature mismatch:
        Modules do not match:
          sig
@@ -1801,13 +1882,20 @@ module F :
   functor (A : sig type 'a t end)
     (B : sig type 'a t val f : 'a A.t -> 'a t end) -> sig end
 Lines 15-21, characters 2-8:
-15 | ..F
+15 |   F
+       ^
 16 |     (struct
+         ^^^^^^^
 17 |       type t = unit   (* this is bogus! *)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 18 |     end)
+         ^^^^
 19 |     (struct
+         ^^^^^^^
 20 |       let f x = x   (* this is bogus! *)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 21 |     end)
+         ^^^^
 Error: The functor application is ill-typed.
        These arguments:
          $S1 $S2
@@ -1873,13 +1961,20 @@ module With_expansion :
   functor (A : sig module type t module M : t end)
     (B : sig module type t = A.t end) -> B.t
 Lines 5-11, characters 11-6:
- 5 | ...........With_expansion(struct
+ 5 | module R = With_expansion(struct
+                ^^^^^^^^^^^^^^^^^^^^^
  6 |     module M()() = struct end
+         ^^^^^^^^^^^^^^^^^^^^^^^^^
  7 |     module type t = module type of M
+         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  8 |   end)
+       ^^^^
  9 |     ()
+         ^^
 10 |     ()
+         ^^
 11 |     ()
+         ^^
 Error: The functor application is ill-typed.
        These arguments:
          $S1 () () ()
@@ -1900,12 +1995,18 @@ module R' = With_expansion(struct
     ()
 [%%expect {|
 Lines 1-6, characters 12-6:
-1 | ............With_expansion(struct
+1 | module R' = With_expansion(struct
+                ^^^^^^^^^^^^^^^^^^^^^
 2 |     module M()() = struct end
+        ^^^^^^^^^^^^^^^^^^^^^^^^^
 3 |     module type t = module type of M
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 4 |   end)
+      ^^^^
 5 |     ()
+        ^^
 6 |     ()
+        ^^
 Error: The functor application is ill-typed.
        These arguments:
          $S1 () ()
@@ -1949,14 +2050,22 @@ module H :
   functor (X : sig type 'a t type 'a s end)
     (Y : sig val f : 'a X.s -> 'a end) -> sig end
 Lines 18-25, characters 2-8:
-18 | ..H
+18 |   H
+       ^
 19 |     (struct
+         ^^^^^^^
 20 |       type t (** this is wrong*)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^
 21 |       type 'a s = 'a (** this matches the expected type *)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 22 |     end)
+         ^^^^
 23 |     (struct
+         ^^^^^^^
 24 |       let f x = x   (* this is fine *)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 25 |     end)
+         ^^^^
 Error: The functor application is ill-typed.
        These arguments:
          $S1 $S2
@@ -1992,9 +2101,12 @@ end = struct
 end
 [%%expect {|
 Lines 3-5, characters 6-3:
-3 | ......struct
+3 | end = struct
+          ^^^^^^
 4 |   module F(X: sig type 'a t = 'a list end)(Y: sig type 'a t = ('a * 'a) * 'a X.t end) = struct end
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 5 | end
+    ^^^
 Error: Signature mismatch:
        Modules do not match:
          sig

--- a/testsuite/tests/typing-modules/illegal_permutation.ml
+++ b/testsuite/tests/typing-modules/illegal_permutation.ml
@@ -102,15 +102,24 @@ end = struct
 end
 [%%expect {|
 Lines 9-17, characters 6-3:
- 9 | ......struct
+ 9 | end = struct
+           ^^^^^^
 10 |   module type x = sig
+       ^^^^^^^^^^^^^^^^^^^
 11 |     val a:int
+         ^^^^^^^^^
 12 |     val b:int
+         ^^^^^^^^^
 13 |     val e:int
+         ^^^^^^^^^
 14 |     val d:int
+         ^^^^^^^^^
 15 |     val c:int
+         ^^^^^^^^^
 16 |   end
+       ^^^
 17 | end
+     ^^^
 Error: Signature mismatch:
        Modules do not match:
          sig
@@ -172,12 +181,18 @@ end = struct
 end
 [%%expect {|
 Lines 6-11, characters 6-3:
- 6 | ......struct
+ 6 | end = struct
+           ^^^^^^
  7 |   module type x= sig
+       ^^^^^^^^^^^^^^^^^^
  8 |     val x:int
+         ^^^^^^^^^
  9 |     class x:ct
+         ^^^^^^^^^^
 10 |   end
+       ^^^
 11 | end
+     ^^^
 Error: Signature mismatch:
        Modules do not match:
          sig module type x = sig val x : int class x : ct end end
@@ -211,14 +226,22 @@ end = struct
 end
 [%%expect {|
 Lines 8-15, characters 6-3:
- 8 | ......struct
+ 8 | end = struct
+           ^^^^^^
  9 |   module type a = sig
+       ^^^^^^^^^^^^^^^^^^^
 10 |     module type b = sig
+         ^^^^^^^^^^^^^^^^^^^
 11 |       val y:int
+           ^^^^^^^^^
 12 |       val x:int
+           ^^^^^^^^^
 13 |     end
+         ^^^
 14 |   end
+       ^^^
 15 | end
+     ^^^
 Error: Signature mismatch:
        Modules do not match:
          sig
@@ -268,12 +291,18 @@ end
 [%%expect{|
 class type ct = object  end
 Lines 7-12, characters 6-3:
- 7 | ......struct
+ 7 | end = struct
+           ^^^^^^
  8 |   module type x = sig
+       ^^^^^^^^^^^^^^^^^^^
  9 |     class b: ct
+         ^^^^^^^^^^^
 10 |     class a: ct
+         ^^^^^^^^^^^
 11 |   end
+       ^^^
 12 | end
+     ^^^
 Error: Signature mismatch:
        Modules do not match:
          sig module type x = sig class b : ct class a : ct end end
@@ -303,12 +332,18 @@ end = struct
 end
 [%%expect{|
 Lines 6-11, characters 6-3:
- 6 | ......struct
+ 6 | end = struct
+           ^^^^^^
  7 |   module type x = sig
+       ^^^^^^^^^^^^^^^^^^^
  8 |     type exn+=B
+         ^^^^^^^^^^^
  9 |     type exn+=A
+         ^^^^^^^^^^^
 10 |   end
+       ^^^
 11 | end
+     ^^^
 Error: Signature mismatch:
        Modules do not match:
          sig module type x = sig type exn += B type exn += A end end
@@ -393,8 +428,11 @@ end
 [%%expect {|
 Lines 2-4, characters 0-3:
 2 | struct
+    ^^^^^^
 3 |   module type x = functor(X:c12) -> s
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 4 | end
+    ^^^
 Error: Signature mismatch:
        Modules do not match:
          sig module type x = functor (X : c12) -> s end
@@ -418,8 +456,11 @@ end
 [%%expect {|
 Lines 2-4, characters 0-3:
 2 | struct
+    ^^^^^^
 3 |   module type x = functor(X:s) -> c12
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 4 | end
+    ^^^
 Error: Signature mismatch:
        Modules do not match:
          sig module type x = functor (X : s) -> c12 end
@@ -481,16 +522,25 @@ end=struct
 end
 [%%expect {|
 Lines 22-43, characters 4-3:
-22 | ....struct
+22 | end=struct
+         ^^^^^^
 23 |   module type x = sig
+       ^^^^^^^^^^^^^^^^^^^
 24 |     module A: sig
+         ^^^^^^^^^^^^^
 25 |       module B: sig
+           ^^^^^^^^^^^^^
 26 |         module C: functor(X:sig end)(Y:sig end)
-...
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+     ...
 40 |       end
+           ^^^
 41 |     end
+         ^^^
 42 |   end
+       ^^^
 43 | end
+     ^^^
 Error: Signature mismatch:
        Modules do not match:
          sig

--- a/testsuite/tests/typing-modules/inclusion_errors.ml
+++ b/testsuite/tests/typing-modules/inclusion_errors.ml
@@ -11,9 +11,12 @@ end = struct
 end;;
 [%%expect{|
 Lines 3-5, characters 6-3:
-3 | ......struct
+3 | end = struct
+          ^^^^^^
 4 |   type ('a, 'b) t = 'a * 'a
-5 | end..
+      ^^^^^^^^^^^^^^^^^^^^^^^^^
+5 | end;;
+    ^^^
 Error: Signature mismatch:
        Modules do not match:
          sig type ('a, 'b) t = 'a * 'a end
@@ -34,9 +37,12 @@ end = struct
 end;;
 [%%expect{|
 Lines 3-5, characters 6-3:
-3 | ......struct
+3 | end = struct
+          ^^^^^^
 4 |   type ('a, 'b) t = 'a * 'b
-5 | end..
+      ^^^^^^^^^^^^^^^^^^^^^^^^^
+5 | end;;
+    ^^^
 Error: Signature mismatch:
        Modules do not match:
          sig type ('a, 'b) t = 'a * 'b end
@@ -59,9 +65,12 @@ end
 [%%expect{|
 type 'a x
 Lines 4-6, characters 6-3:
-4 | ......struct
+4 | end = struct
+          ^^^^^^
 5 |   type ('b,'c,'a) t = ('b * 'c * 'a * 'c * 'a) x
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 6 | end
+    ^^^
 Error: Signature mismatch:
        Modules do not match:
          sig type ('b, 'c, 'a) t = ('b * 'c * 'a * 'c * 'a) x end
@@ -83,9 +92,12 @@ end = struct
 end;;
 [%%expect{|
 Lines 3-5, characters 6-3:
-3 | ......struct
+3 | end = struct
+          ^^^^^^
 4 |   type t = <m : 'a. 'a * ('a * 'foo)> as 'foo
-5 | end..
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+5 | end;;
+    ^^^
 Error: Signature mismatch:
        Modules do not match:
          sig type t = < m : 'a. 'a * ('a * 'b) > as 'b end
@@ -114,9 +126,12 @@ end = struct
 end;;
 [%%expect{|
 Lines 3-5, characters 6-3:
-3 | ......struct
+3 | end = struct
+          ^^^^^^
 4 |   type t = <m : int>
-5 | end..
+      ^^^^^^^^^^^^^^^^^^
+5 | end;;
+    ^^^
 Error: Signature mismatch:
        Modules do not match:
          sig type t = < m : int > end
@@ -137,9 +152,12 @@ end = struct
 end;;
 [%%expect{|
 Lines 3-5, characters 6-3:
-3 | ......struct
+3 | end = struct
+          ^^^^^^
 4 |   type t = s
-5 | end..
+      ^^^^^^^^^^
+5 | end;;
+    ^^^
 Error: Signature mismatch:
        Modules do not match:
          sig type t = s end
@@ -162,10 +180,14 @@ end = struct
 end;;
 [%%expect{|
 Lines 4-7, characters 6-3:
-4 | ......struct
+4 | end = struct
+          ^^^^^^
 5 |   type t =
+      ^^^^^^^^
 6 |     | Foo of (int*int)*float
-7 | end..
+        ^^^^^^^^^^^^^^^^^^^^^^^^
+7 | end;;
+    ^^^
 Error: Signature mismatch:
        Modules do not match:
          sig type t = Foo of (int * int) * float end
@@ -189,9 +211,12 @@ end = struct
 end;;
 [%%expect{|
 Lines 3-5, characters 6-3:
-3 | ......struct
+3 | end = struct
+          ^^^^^^
 4 |   type t = (int * float * int)
-5 | end..
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+5 | end;;
+    ^^^
 Error: Signature mismatch:
        Modules do not match:
          sig type t = int * float * int end
@@ -211,9 +236,12 @@ end = struct
 end;;
 [%%expect{|
 Lines 3-5, characters 6-3:
-3 | ......struct
+3 | end = struct
+          ^^^^^^
 4 |   type t = <n : int; f : float>
-5 | end..
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+5 | end;;
+    ^^^
 Error: Signature mismatch:
        Modules do not match:
          sig type t = < f : float; n : int > end
@@ -235,9 +263,12 @@ end = struct
 end;;
 [%%expect{|
 Lines 3-5, characters 6-3:
-3 | ......struct
+3 | end = struct
+          ^^^^^^
 4 |   type t = <n : int>
-5 | end..
+      ^^^^^^^^^^^^^^^^^^
+5 | end;;
+    ^^^
 Error: Signature mismatch:
        Modules do not match:
          sig type t = < n : int > end
@@ -258,9 +289,12 @@ end = struct
 end;;
 [%%expect{|
 Lines 3-5, characters 6-3:
-3 | ......struct
+3 | end = struct
+          ^^^^^^
 4 |   type t = <n : int; m : int>
-5 | end..
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+5 | end;;
+    ^^^
 Error: Signature mismatch:
        Modules do not match:
          sig type t = < m : int; n : int > end
@@ -284,10 +318,14 @@ end = struct
 end;;
 [%%expect{|
 Lines 4-7, characters 6-3:
-4 | ......struct
+4 | end = struct
+          ^^^^^^
 5 |   type t =
+      ^^^^^^^^
 6 |     | Foo of [`Bar of string]
-7 | end..
+        ^^^^^^^^^^^^^^^^^^^^^^^^^
+7 | end;;
+    ^^^
 Error: Signature mismatch:
        Modules do not match:
          sig type t = Foo of [ `Bar of string ] end
@@ -313,9 +351,12 @@ end = struct
 end;;
 [%%expect{|
 Lines 3-5, characters 6-3:
-3 | ......struct
+3 | end = struct
+          ^^^^^^
 4 |   type t = private [`C]
-5 | end..
+      ^^^^^^^^^^^^^^^^^^^^^
+5 | end;;
+    ^^^
 Error: Signature mismatch:
        Modules do not match:
          sig type t = private [ `C ] end
@@ -336,9 +377,12 @@ end = struct
 end;;
 [%%expect{|
 Lines 3-5, characters 6-3:
-3 | ......struct
+3 | end = struct
+          ^^^^^^
 4 |   type t = private [`C of int]
-5 | end..
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+5 | end;;
+    ^^^
 Error: Signature mismatch:
        Modules do not match:
          sig type t = private [ `C of int ] end
@@ -368,9 +412,12 @@ end = struct
 end;;
 [%%expect{|
 Lines 3-5, characters 6-3:
-3 | ......struct
+3 | end = struct
+          ^^^^^^
 4 |   type t = private [`A of int]
-5 | end..
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+5 | end;;
+    ^^^
 Error: Signature mismatch:
        Modules do not match:
          sig type t = private [ `A of int ] end
@@ -391,9 +438,12 @@ end = struct
 end;;
 [%%expect{|
 Lines 3-5, characters 6-3:
-3 | ......struct
+3 | end = struct
+          ^^^^^^
 4 |   type t = private [> `A of int]
-5 | end..
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+5 | end;;
+    ^^^
 Error: Signature mismatch:
        Modules do not match:
          sig type t = private [> `A of int ] end
@@ -414,9 +464,12 @@ end = struct
 end;;
 [%%expect{|
 Lines 3-5, characters 6-3:
-3 | ......struct
+3 | end = struct
+          ^^^^^^
 4 |   type 'a t =  [> `A of int] as 'a
-5 | end..
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+5 | end;;
+    ^^^
 Error: Signature mismatch:
        Modules do not match:
          sig type 'a t = 'a constraint 'a = [> `A of int ] end
@@ -438,9 +491,12 @@ end = struct
 end;;
 [%%expect{|
 Lines 3-5, characters 6-3:
-3 | ......struct
+3 | end = struct
+          ^^^^^^
 4 |   type 'a t =  [> `A of int | `C of float] as 'a
-5 | end..
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+5 | end;;
+    ^^^
 Error: Signature mismatch:
        Modules do not match:
          sig type 'a t = 'a constraint 'a = [> `A of int | `C of float ] end
@@ -471,9 +527,12 @@ end = struct
 end;;
 [%%expect{|
 Lines 3-5, characters 6-3:
-3 | ......struct
+3 | end = struct
+          ^^^^^^
 4 |   type t = private [< `C of int&float]
-5 | end..
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+5 | end;;
+    ^^^
 Error: Signature mismatch:
        Modules do not match:
          sig type t = private [< `C of int & float ] end
@@ -542,10 +601,14 @@ module O = struct
 end;;
 [%%expect{|
 Lines 5-8, characters 8-5:
-5 | ........struct
+5 |   end = struct
+            ^^^^^^
 6 |     module type s
+        ^^^^^^^^^^^^^
 7 |     let f (module X:s) = ()
+        ^^^^^^^^^^^^^^^^^^^^^^^
 8 |   end
+      ^^^
 Error: Signature mismatch:
        Modules do not match:
          sig module type s val f : (module s) -> unit end
@@ -571,9 +634,12 @@ end = struct
 end;;
 [%%expect{|
 Lines 3-5, characters 6-3:
-3 | ......struct
+3 | end = struct
+          ^^^^^^
 4 |   let f (x : <m : 'a. ('a * 'foo)> as 'foo) = ()
-5 | end..
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+5 | end;;
+    ^^^
 Error: Signature mismatch:
        Modules do not match:
          sig val f : (< m : 'a. 'a * 'b > as 'b) -> unit end
@@ -601,9 +667,12 @@ end;;
 [%%expect{|
 type s = private < m : int; .. >
 Lines 5-7, characters 6-3:
-5 | ......struct
+5 | end = struct
+          ^^^^^^
 6 |   let f (x : <m : int>) = x
-7 | end..
+      ^^^^^^^^^^^^^^^^^^^^^^^^^
+7 | end;;
+    ^^^
 Error: Signature mismatch:
        Modules do not match:
          sig val f : < m : int > -> < m : int > end
@@ -626,9 +695,12 @@ end = struct
 end;;
 [%%expect{|
 Lines 3-5, characters 6-3:
-3 | ......struct
+3 | end = struct
+          ^^^^^^
 4 |   let f : 'b -> int = fun _ -> 0
-5 | end..
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+5 | end;;
+    ^^^
 Error: Signature mismatch:
        Modules do not match:
          sig val f : 'b -> int end
@@ -649,9 +721,12 @@ end = struct
 end;;
 [%%expect{|
 Lines 3-5, characters 6-3:
-3 | ......struct
+3 | end = struct
+          ^^^^^^
 4 |   let x = ref []
-5 | end..
+      ^^^^^^^^^^^^^^
+5 | end;;
+    ^^^
 Error: Signature mismatch:
        Modules do not match:
          sig val x : '_weak2 list ref end
@@ -738,9 +813,12 @@ end = struct
 end;;
 [%%expect{|
 Lines 3-5, characters 6-3:
-3 | ......struct
+3 | end = struct
+          ^^^^^^
 4 |   let f (x : 'a) = x
-5 | end..
+      ^^^^^^^^^^^^^^^^^^
+5 | end;;
+    ^^^
 Error: Signature mismatch:
        Modules do not match:
          sig val f : 'a -> 'a end
@@ -761,9 +839,12 @@ end = struct
 end;;
 [%%expect{|
 Lines 3-5, characters 6-3:
-3 | ......struct
+3 | end = struct
+          ^^^^^^
 4 |   let f (x : (int * int)) = x
-5 | end..
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+5 | end;;
+    ^^^
 Error: Signature mismatch:
        Modules do not match:
          sig val f : int * int -> int * int end
@@ -785,9 +866,12 @@ end = struct
 end;;
 [%%expect{|
 Lines 3-5, characters 6-3:
-3 | ......struct
+3 | end = struct
+          ^^^^^^
 4 |   let f (x : <m : int; f : float>) = x
-5 | end..
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+5 | end;;
+    ^^^
 Error: Signature mismatch:
        Modules do not match:
          sig val f : < f : float; m : int > -> < f : float; m : int > end
@@ -810,9 +894,12 @@ end = struct
 end;;
 [%%expect{|
 Lines 3-5, characters 6-3:
-3 | ......struct
+3 | end = struct
+          ^^^^^^
 4 |   let f (x : [ `Foo | `Bar]) = ()
-5 | end..
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+5 | end;;
+    ^^^
 Error: Signature mismatch:
        Modules do not match:
          sig val f : [ `Bar | `Foo ] -> unit end
@@ -834,9 +921,12 @@ end = struct
 end;;
 [%%expect{|
 Lines 3-5, characters 6-3:
-3 | ......struct
+3 | end = struct
+          ^^^^^^
 4 |   let f (x : [< `Foo]) = ()
-5 | end..
+      ^^^^^^^^^^^^^^^^^^^^^^^^^
+5 | end;;
+    ^^^
 Error: Signature mismatch:
        Modules do not match:
          sig val f : [< `Foo ] -> unit end
@@ -858,9 +948,12 @@ end = struct
 end;;
 [%%expect{|
 Lines 3-5, characters 6-3:
-3 | ......struct
+3 | end = struct
+          ^^^^^^
 4 |   let f (x : [< `Foo]) = ()
-5 | end..
+      ^^^^^^^^^^^^^^^^^^^^^^^^^
+5 | end;;
+    ^^^
 Error: Signature mismatch:
        Modules do not match:
          sig val f : [< `Foo ] -> unit end
@@ -882,9 +975,12 @@ end = struct
 end;;
 [%%expect{|
 Lines 3-5, characters 6-3:
-3 | ......struct
+3 | end = struct
+          ^^^^^^
 4 |   let f (x : < m : 'a. [< `Foo] as 'a >) = ()
-5 | end..
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+5 | end;;
+    ^^^
 Error: Signature mismatch:
        Modules do not match:
          sig val f : < m : 'a. [< `Foo ] as 'a > -> unit end
@@ -906,9 +1002,12 @@ end = struct
 end;;
 [%%expect{|
 Lines 3-5, characters 6-3:
-3 | ......struct
+3 | end = struct
+          ^^^^^^
 4 |   let f (x : < m : [`Foo]>) = ()
-5 | end..
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+5 | end;;
+    ^^^
 Error: Signature mismatch:
        Modules do not match:
          sig val f : < m : [ `Foo ] > -> unit end
@@ -930,9 +1029,12 @@ end = struct
 end;;
 [%%expect{|
 Lines 3-5, characters 6-3:
-3 | ......struct
+3 | end = struct
+          ^^^^^^
 4 |   let f (x : [< `C of int&float]) = ()
-5 | end..
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+5 | end;;
+    ^^^
 Error: Signature mismatch:
        Modules do not match:
          sig val f : [< `C of int & float ] -> unit end
@@ -954,9 +1056,12 @@ end = struct
 end;;
 [%%expect{|
 Lines 3-5, characters 6-3:
-3 | ......struct
+3 | end = struct
+          ^^^^^^
 4 |   let f (x : [`Foo of int]) = ()
-5 | end..
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+5 | end;;
+    ^^^
 Error: Signature mismatch:
        Modules do not match:
          sig val f : [ `Foo of int ] -> unit end
@@ -978,9 +1083,12 @@ end = struct
 end;;
 [%%expect{|
 Lines 3-5, characters 6-3:
-3 | ......struct
+3 | end = struct
+          ^^^^^^
 4 |   let f (x : [`Foo]) = ()
-5 | end..
+      ^^^^^^^^^^^^^^^^^^^^^^^
+5 | end;;
+    ^^^
 Error: Signature mismatch:
        Modules do not match:
          sig val f : [ `Foo ] -> unit end
@@ -1011,9 +1119,12 @@ end = struct
 end;;
 [%%expect{|
 Lines 3-5, characters 6-3:
-3 | ......struct
+3 | end = struct
+          ^^^^^^
 4 |   let f (x : [> `Foo | `Bar]) = ()
-5 | end..
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+5 | end;;
+    ^^^
 Error: Signature mismatch:
        Modules do not match:
          sig val f : [> `Bar | `Foo ] -> unit end
@@ -1038,9 +1149,12 @@ end = struct
 end;;
 [%%expect{|
 Lines 3-5, characters 6-3:
-3 | ......struct
+3 | end = struct
+          ^^^^^^
 4 |   type t = [`C]
-5 | end..
+      ^^^^^^^^^^^^^
+5 | end;;
+    ^^^
 Error: Signature mismatch:
        Modules do not match:
          sig type t = [ `C ] end
@@ -1060,9 +1174,12 @@ end = struct
 end;;
 [%%expect{|
 Lines 3-5, characters 6-3:
-3 | ......struct
+3 | end = struct
+          ^^^^^^
 4 |   type t = private [> `A]
-5 | end..
+      ^^^^^^^^^^^^^^^^^^^^^^^
+5 | end;;
+    ^^^
 Error: Signature mismatch:
        Modules do not match:
          sig type t = private [> `A ] end
@@ -1082,9 +1199,12 @@ end = struct
 end;;
 [%%expect{|
 Lines 3-5, characters 6-3:
-3 | ......struct
+3 | end = struct
+          ^^^^^^
 4 |   type t = [`B]
-5 | end..
+      ^^^^^^^^^^^^^
+5 | end;;
+    ^^^
 Error: Signature mismatch:
        Modules do not match:
          sig type t = [ `B ] end
@@ -1104,9 +1224,12 @@ end = struct
 end;;
 [%%expect{|
 Lines 3-5, characters 6-3:
-3 | ......struct
+3 | end = struct
+          ^^^^^^
 4 |   type t = [`A]
-5 | end..
+      ^^^^^^^^^^^^^
+5 | end;;
+    ^^^
 Error: Signature mismatch:
        Modules do not match:
          sig type t = [ `A ] end
@@ -1126,9 +1249,12 @@ end = struct
 end;;
 [%%expect{|
 Lines 3-5, characters 6-3:
-3 | ......struct
+3 | end = struct
+          ^^^^^^
 4 |    type t = private [< `A of & int]
-5 | end..
+       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+5 | end;;
+    ^^^
 Error: Signature mismatch:
        Modules do not match:
          sig type t = private [< `A of & int ] end
@@ -1149,9 +1275,12 @@ end = struct
 end;;
 [%%expect{|
 Lines 3-5, characters 6-3:
-3 | ......struct
+3 | end = struct
+          ^^^^^^
 4 |   type t = private [< `A]
-5 | end..
+      ^^^^^^^^^^^^^^^^^^^^^^^
+5 | end;;
+    ^^^
 Error: Signature mismatch:
        Modules do not match:
          sig type t = private [< `A ] end
@@ -1172,9 +1301,12 @@ end = struct
 end;;
 [%%expect{|
 Lines 3-5, characters 6-3:
-3 | ......struct
+3 | end = struct
+          ^^^^^^
 4 |   type t = private [< `A]
-5 | end..
+      ^^^^^^^^^^^^^^^^^^^^^^^
+5 | end;;
+    ^^^
 Error: Signature mismatch:
        Modules do not match:
          sig type t = private [< `A ] end
@@ -1194,9 +1326,12 @@ end = struct
 end;;
 [%%expect{|
 Lines 3-5, characters 6-3:
-3 | ......struct
+3 | end = struct
+          ^^^^^^
 4 |   type t = [`A of float]
-5 | end..
+      ^^^^^^^^^^^^^^^^^^^^^^
+5 | end;;
+    ^^^
 Error: Signature mismatch:
        Modules do not match:
          sig type t = [ `A of float ] end
@@ -1216,9 +1351,12 @@ end = struct
 end;;
 [%%expect{|
 Lines 3-5, characters 6-3:
-3 | ......struct
+3 | end = struct
+          ^^^^^^
 4 |   type t = private [`A | `B]
-5 | end..
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^
+5 | end;;
+    ^^^
 Error: Signature mismatch:
        Modules do not match:
          sig type t = private [ `A | `B ] end
@@ -1240,9 +1378,12 @@ end = struct
 end;;
 [%%expect{|
 Lines 3-5, characters 6-3:
-3 | ......struct
+3 | end = struct
+          ^^^^^^
 4 |   type t = private [`A | `B]
-5 | end..
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^
+5 | end;;
+    ^^^
 Error: Signature mismatch:
        Modules do not match:
          sig type t = private [ `A | `B ] end
@@ -1262,9 +1403,12 @@ end = struct
 end;;
 [%%expect{|
 Lines 3-5, characters 6-3:
-3 | ......struct
+3 | end = struct
+          ^^^^^^
 4 |   type t = private [< `A | `B]
-5 | end..
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+5 | end;;
+    ^^^
 Error: Signature mismatch:
        Modules do not match:
          sig type t = private [< `A | `B ] end
@@ -1285,9 +1429,12 @@ end = struct
 end;;
 [%%expect{|
 Lines 3-5, characters 6-3:
-3 | ......struct
+3 | end = struct
+          ^^^^^^
 4 |   type t = <b : int>
-5 | end..
+      ^^^^^^^^^^^^^^^^^^
+5 | end;;
+    ^^^
 Error: Signature mismatch:
        Modules do not match:
          sig type t = < b : int > end
@@ -1307,9 +1454,12 @@ end = struct
 end;;
 [%%expect{|
 Lines 3-5, characters 6-3:
-3 | ......struct
+3 | end = struct
+          ^^^^^^
 4 |   type t = <a : int>
-5 | end..
+      ^^^^^^^^^^^^^^^^^^
+5 | end;;
+    ^^^
 Error: Signature mismatch:
        Modules do not match:
          sig type t = < a : int > end
@@ -1336,9 +1486,12 @@ type w = private float
 type q = private int * w
 type u = private int * q
 Lines 6-8, characters 6-3:
-6 | ......struct
+6 | end = struct
+          ^^^^^^
 7 |   type t = private u
-8 | end..
+      ^^^^^^^^^^^^^^^^^^
+8 | end;;
+    ^^^
 Error: Signature mismatch:
        Modules do not match:
          sig type t = private u end
@@ -1365,9 +1518,12 @@ type w = float
 type q = int * w
 type u = private int * q
 Lines 6-8, characters 6-3:
-6 | ......struct
+6 | end = struct
+          ^^^^^^
 7 |   type t = private u
-8 | end..
+      ^^^^^^^^^^^^^^^^^^
+8 | end;;
+    ^^^
 Error: Signature mismatch:
        Modules do not match:
          sig type t = private u end
@@ -1392,9 +1548,12 @@ end;;
 [%%expect{|
 type s = private int
 Lines 5-7, characters 6-3:
-5 | ......struct
+5 | end = struct
+          ^^^^^^
 6 |   type t = private s
-7 | end..
+      ^^^^^^^^^^^^^^^^^^
+7 | end;;
+    ^^^
 Error: Signature mismatch:
        Modules do not match:
          sig type t = private s end
@@ -1414,9 +1573,12 @@ end = struct
 end;;
 [%%expect{|
 Lines 3-5, characters 6-3:
-3 | ......struct
+3 | end = struct
+          ^^^^^^
 4 |   type t = private A
-5 | end..
+      ^^^^^^^^^^^^^^^^^^
+5 | end;;
+    ^^^
 Error: Signature mismatch:
        Modules do not match:
          sig type t = private A end
@@ -1436,9 +1598,12 @@ end = struct
 end;;
 [%%expect{|
 Lines 3-5, characters 6-3:
-3 | ......struct
+3 | end = struct
+          ^^^^^^
 4 |   type t = private A | B
-5 | end..
+      ^^^^^^^^^^^^^^^^^^^^^^
+5 | end;;
+    ^^^
 Error: Signature mismatch:
        Modules do not match:
          sig type t = private A | B end
@@ -1458,9 +1623,12 @@ end = struct
 end;;
 [%%expect{|
 Lines 3-5, characters 6-3:
-3 | ......struct
+3 | end = struct
+          ^^^^^^
 4 |   type t = private A of { x : int; y : bool }
-5 | end..
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+5 | end;;
+    ^^^
 Error: Signature mismatch:
        Modules do not match:
          sig type t = private A of { x : int; y : bool; } end
@@ -1480,9 +1648,12 @@ end = struct
 end;;
 [%%expect{|
 Lines 3-5, characters 6-3:
-3 | ......struct
+3 | end = struct
+          ^^^^^^
 4 |   type t = private { x : int; y : bool }
-5 | end..
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+5 | end;;
+    ^^^
 Error: Signature mismatch:
        Modules do not match:
          sig type t = private { x : int; y : bool; } end
@@ -1502,9 +1673,12 @@ end = struct
 end;;
 [%%expect{|
 Lines 3-5, characters 6-3:
-3 | ......struct
+3 | end = struct
+          ^^^^^^
 4 |   type t = private A | B
-5 | end..
+      ^^^^^^^^^^^^^^^^^^^^^^
+5 | end;;
+    ^^^
 Error: Signature mismatch:
        Modules do not match:
          sig type t = private A | B end
@@ -1524,9 +1698,12 @@ end = struct
 end;;
 [%%expect{|
 Lines 3-5, characters 6-3:
-3 | ......struct
+3 | end = struct
+          ^^^^^^
 4 |   type t = private A
-5 | end..
+      ^^^^^^^^^^^^^^^^^^
+5 | end;;
+    ^^^
 Error: Signature mismatch:
        Modules do not match:
          sig type t = private A end
@@ -1546,9 +1723,12 @@ end = struct
 end;;
 [%%expect{|
 Lines 3-5, characters 6-3:
-3 | ......struct
+3 | end = struct
+          ^^^^^^
 4 |   type t = private { x : int; y : bool }
-5 | end..
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+5 | end;;
+    ^^^
 Error: Signature mismatch:
        Modules do not match:
          sig type t = private { x : int; y : bool; } end
@@ -1568,9 +1748,12 @@ end = struct
 end;;
 [%%expect{|
 Lines 3-5, characters 6-3:
-3 | ......struct
+3 | end = struct
+          ^^^^^^
 4 |   type t = private { x : int }
-5 | end..
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+5 | end;;
+    ^^^
 Error: Signature mismatch:
        Modules do not match:
          sig type t = private { x : int; } end
@@ -1590,9 +1773,12 @@ end = struct
 end;;
 [%%expect{|
 Lines 3-5, characters 6-3:
-3 | ......struct
+3 | end = struct
+          ^^^^^^
 4 |   type t = private { x : int; y : bool }
-5 | end..
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+5 | end;;
+    ^^^
 Error: Signature mismatch:
        Modules do not match:
          sig type t = private { x : int; y : bool; } end
@@ -1612,9 +1798,12 @@ end = struct
 end;;
 [%%expect{|
 Lines 3-5, characters 6-3:
-3 | ......struct
+3 | end = struct
+          ^^^^^^
 4 |   type t = private A | B
-5 | end..
+      ^^^^^^^^^^^^^^^^^^^^^^
+5 | end;;
+    ^^^
 Error: Signature mismatch:
        Modules do not match:
          sig type t = private A | B end
@@ -1634,9 +1823,12 @@ end = struct
 end;;
 [%%expect{|
 Lines 3-5, characters 6-3:
-3 | ......struct
+3 | end = struct
+          ^^^^^^
 4 |   type t = private [> `A | `B]
-5 | end..
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+5 | end;;
+    ^^^
 Error: Signature mismatch:
        Modules do not match:
          sig type t = private [> `A | `B ] end
@@ -1656,9 +1848,12 @@ end = struct
 end;;
 [%%expect{|
 Lines 3-5, characters 6-3:
-3 | ......struct
+3 | end = struct
+          ^^^^^^
 4 |   type t = private [< `A | `B]
-5 | end..
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+5 | end;;
+    ^^^
 Error: Signature mismatch:
        Modules do not match:
          sig type t = private [< `A | `B ] end
@@ -1678,9 +1873,12 @@ end = struct
 end;;
 [%%expect{|
 Lines 3-5, characters 6-3:
-3 | ......struct
+3 | end = struct
+          ^^^^^^
 4 |   type t = private [< `A | `B > `A]
-5 | end..
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+5 | end;;
+    ^^^
 Error: Signature mismatch:
        Modules do not match:
          sig type t = private [< `A | `B > `A ] end
@@ -1700,9 +1898,12 @@ end = struct
 end;;
 [%%expect{|
 Lines 3-5, characters 6-3:
-3 | ......struct
+3 | end = struct
+          ^^^^^^
 4 |   type t = private < m : int; .. >
-5 | end..
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+5 | end;;
+    ^^^
 Error: Signature mismatch:
        Modules do not match:
          sig type t = private < m : int; .. > end
@@ -1724,9 +1925,12 @@ end = struct
 end
 [%%expect {|
 Lines 3-5, characters 6-3:
-3 | ......struct
+3 | end = struct
+          ^^^^^^
 4 |   type _ t = A : (<x:'a * 'a> as 'a) -> (<y:'b> as 'b) t
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 5 | end
+    ^^^
 Error: Signature mismatch:
        Modules do not match:
          sig
@@ -1753,9 +1957,12 @@ end = struct
 end
 [%%expect {|
 Lines 3-5, characters 6-3:
-3 | ......struct
+3 | end = struct
+          ^^^^^^
 4 |   type t = { a: (<x:'a * 'a> as 'a) }
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 5 | end
+    ^^^
 Error: Signature mismatch:
        Modules do not match:
          sig type t = { a : < x : 'a * 'a > as 'a; } end
@@ -1782,9 +1989,12 @@ end
 [%%expect {|
 type _ ext = ..
 Lines 4-6, characters 6-3:
-4 | ......struct
+4 | end = struct
+          ^^^^^^
 5 |   type _ ext  += A : (<x:'a * 'a> as 'a) -> (<y:'b> as 'b) ext
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 6 | end
+    ^^^
 Error: Signature mismatch:
        Modules do not match:
          sig

--- a/testsuite/tests/typing-modules/inclusion_errors_elision.ml
+++ b/testsuite/tests/typing-modules/inclusion_errors_elision.ml
@@ -21,11 +21,16 @@ end
 module A : sig type a and b and c and d end
 module type S = sig module B = A end
 Lines 9-13, characters 15-3:
- 9 | ...............struct
+ 9 | module C : S = struct
+                    ^^^^^^
 10 |   module B = struct
+       ^^^^^^^^^^^^^^^^^
 11 |     type a and b and c and d and e and f and g and h
+         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 12 |   end
+       ^^^
 13 | end
+     ^^^
 Error: Signature mismatch:
        ...
        In module B:
@@ -65,13 +70,20 @@ end
 module A : sig type a and b and c and d end
 module type S = sig module type B = sig module C = A end end
 Lines 11-17, characters 15-3:
-11 | ...............struct
+11 | module D : S = struct
+                    ^^^^^^
 12 |   module type B = sig
+       ^^^^^^^^^^^^^^^^^^^
 13 |     module C: sig
+         ^^^^^^^^^^^^^
 14 |       type a and b and c and d and e and f and g and h
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 15 |     end
+         ^^^
 16 |   end
+       ^^^
 17 | end
+     ^^^
 Error: Signature mismatch:
        ...
        ...

--- a/testsuite/tests/typing-modules/nondep_private_abbrev.ml
+++ b/testsuite/tests/typing-modules/nondep_private_abbrev.ml
@@ -113,9 +113,12 @@ end = struct
 end;;
 [%%expect{|
 Lines 3-5, characters 6-3:
-3 | ......struct
+3 | end = struct
+          ^^^^^^
 4 |   type s = t
-5 | end..
+      ^^^^^^^^^^
+5 | end;;
+    ^^^
 Error: Signature mismatch:
        Modules do not match:
          sig type s = t end

--- a/testsuite/tests/typing-modules/pr10399.ml
+++ b/testsuite/tests/typing-modules/pr10399.ml
@@ -20,13 +20,20 @@ end
 
 [%%expect{|
 Lines 7-13, characters 6-3:
- 7 | ......struct
+ 7 | end = struct
+           ^^^^^^
  8 |   type t = < x : int >
+       ^^^^^^^^^^^^^^^^^^^^
  9 |
+     ^
 10 |   class c = object method x = 3 method y = true end
+       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 11 |
+     ^
 12 |   let o = new c
+       ^^^^^^^^^^^^^
 13 | end
+     ^^^
 Error: Signature mismatch:
        Modules do not match:
          sig

--- a/testsuite/tests/typing-modules/pr6394.ml
+++ b/testsuite/tests/typing-modules/pr6394.ml
@@ -11,10 +11,14 @@ end = struct
 end;;
 [%%expect{|
 Lines 4-7, characters 6-3:
-4 | ......struct
+4 | end = struct
+          ^^^^^^
 5 |   type t = A | B
+      ^^^^^^^^^^^^^^
 6 |   let f = function A | B -> 0
-7 | end..
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+7 | end;;
+    ^^^
 Error: Signature mismatch:
        Modules do not match:
          sig type t = X.t = A | B val f : t -> int end

--- a/testsuite/tests/typing-modules/pr7818.ml
+++ b/testsuite/tests/typing-modules/pr7818.ml
@@ -111,10 +111,14 @@ module Make2 (T' : S) : sig module Id : sig end module Id2 = Id end
 end;;
 [%%expect{|
 Lines 2-5, characters 57-3:
-2 | .........................................................struct
+2 |                         with module Id := T'.Term0.Id  = struct
+                                                             ^^^^^^
 3 |   module Id = T'.T.Id
+      ^^^^^^^^^^^^^^^^^^^
 4 |   module Id2 = Id
-5 | end..
+      ^^^^^^^^^^^^^^^
+5 | end;;
+    ^^^
 Error: Signature mismatch:
        Modules do not match:
          sig module Id : sig end module Id2 = Id end

--- a/testsuite/tests/typing-modules/records_errors_test.ml
+++ b/testsuite/tests/typing-modules/records_errors_test.ml
@@ -11,10 +11,14 @@ end = struct
 end;;
 [%%expect{|
 Lines 4-7, characters 6-3:
-4 | ......struct
+4 | end = struct
+          ^^^^^^
 5 |   type t = {f0 : unit * unit * unit * float* unit * unit * unit;
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 6 |             f1 : unit * unit * unit * string * unit * unit * unit}
-7 | end..
+                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+7 | end;;
+    ^^^
 Error: Signature mismatch:
        Modules do not match:
          sig
@@ -66,10 +70,14 @@ end = struct
 end;;
 [%%expect{|
 Lines 4-7, characters 6-3:
-4 | ......struct
+4 | end = struct
+          ^^^^^^
 5 |   type t = {f0 : unit * unit * unit * float* unit * unit * unit;
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 6 |             f1 : unit * unit * unit * string * unit * unit * unit}
-7 | end..
+                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+7 | end;;
+    ^^^
 Error: Signature mismatch:
        Modules do not match:
          sig
@@ -116,9 +124,12 @@ end = struct
 end;;
 [%%expect{|
 Lines 3-5, characters 6-3:
-3 | ......struct
+3 | end = struct
+          ^^^^^^
 4 |   type t = {f1 : unit}
-5 | end..
+      ^^^^^^^^^^^^^^^^^^^^
+5 | end;;
+    ^^^
 Error: Signature mismatch:
        Modules do not match:
          sig type t = { f1 : unit; } end
@@ -138,9 +149,12 @@ end = struct
 end;;
 [%%expect{|
 Lines 3-5, characters 6-3:
-3 | ......struct
+3 | end = struct
+          ^^^^^^
 4 |   type t = {f0 : unit}
-5 | end..
+      ^^^^^^^^^^^^^^^^^^^^
+5 | end;;
+    ^^^
 Error: Signature mismatch:
        Modules do not match:
          sig type t = { f0 : unit; } end
@@ -163,9 +177,12 @@ end = struct
 end
 [%%expect {|
 Lines 5-7, characters 6-3:
-5 | ......struct
+5 | end = struct
+          ^^^^^^
 6 |   type t = {a : unit; b : unit; beta : unit; c : unit; d: unit}
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 7 | end
+    ^^^
 Error: Signature mismatch:
        Modules do not match:
          sig
@@ -188,9 +205,12 @@ end = struct
 end
 [%%expect {|
 Lines 3-5, characters 6-3:
-3 | ......struct
+3 | end = struct
+          ^^^^^^
 4 |   type t = {a : unit; c : unit; d : unit}
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 5 | end
+    ^^^
 Error: Signature mismatch:
        Modules do not match:
          sig type t = { a : unit; c : unit; d : unit; } end
@@ -229,16 +249,25 @@ end
 
 [%%expect {|
 Lines 11-22, characters 6-3:
-11 | ......struct
+11 | end = struct
+           ^^^^^^
 12 |   type t = {
+       ^^^^^^^^^^
 13 |     a : unit;
+         ^^^^^^^^^
 14 |     b : unit;
+         ^^^^^^^^^
 15 |     beta: int;
-...
+         ^^^^^^^^^^
+     ...
 19 |     g : unit;
+         ^^^^^^^^^
 20 |     phi : unit;
+         ^^^^^^^^^^^
 21 |   }
+       ^
 22 | end
+     ^^^
 Error: Signature mismatch:
        Modules do not match:
          sig
@@ -301,9 +330,12 @@ end = struct
 end
 [%%expect {|
 Lines 5-7, characters 6-3:
-5 | ......struct
+5 | end = struct
+          ^^^^^^
 6 |   type t = { alpha:int; b:int; c:int; d:int; e:int }
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 7 | end
+    ^^^
 Error: Signature mismatch:
        Modules do not match:
          sig
@@ -329,8 +361,11 @@ end
 [%%expect {|
 Lines 4-6, characters 0-3:
 4 | struct
+    ^^^^^^
 5 |   type t = { b:int; c:int; d:int; e:int; a:int; f:int }
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 6 | end
+    ^^^
 Error: Signature mismatch:
        Modules do not match:
          sig
@@ -371,9 +406,12 @@ end = struct
 end
 [%%expect {|
 Lines 8-10, characters 6-3:
- 8 | ......struct
+ 8 | end = struct
+           ^^^^^^
  9 |   type t = A: { a:'a; b:'b; x:'x } -> t
+       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 10 | end
+     ^^^
 Error: Signature mismatch:
        Modules do not match:
          sig type t = A : { a : 'a; b : 'b; x : 'x; } -> t end
@@ -402,9 +440,12 @@ end = struct
 end
 [%%expect {|
 Lines 3-5, characters 6-3:
-3 | ......struct
+3 | end = struct
+          ^^^^^^
 4 |   type t = A: { y:'a; a:'a; b:'b; x:'b} -> t
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 5 | end
+    ^^^
 Error: Signature mismatch:
        Modules do not match:
          sig type t = A : { y : 'a; a : 'a; b : 'b; x : 'b; } -> t end
@@ -429,9 +470,12 @@ end = struct
 end
 [%%expect {|
 Lines 3-5, characters 6-3:
-3 | ......struct
+3 | end = struct
+          ^^^^^^
 4 |   type t = A: { y:'b; a:'a; b:'b; x:'a} -> t
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 5 | end
+    ^^^
 Error: Signature mismatch:
        Modules do not match:
          sig type t = A : { y : 'b; a : 'a; b : 'b; x : 'a; } -> t end
@@ -456,9 +500,12 @@ end = struct
 end
 [%%expect {|
 Lines 3-5, characters 6-3:
-3 | ......struct
+3 | end = struct
+          ^^^^^^
 4 |   type t = A: { x:'a; a:'a; b:'b} -> t
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 5 | end
+    ^^^
 Error: Signature mismatch:
        Modules do not match:
          sig type t = A : { x : 'a; a : 'a; b : 'b; } -> t end
@@ -484,9 +531,12 @@ end = struct
 end
 [%%expect {|
 Lines 3-5, characters 6-3:
-3 | ......struct
+3 | end = struct
+          ^^^^^^
 4 |   type t = A: { x:'b; a:'a; b:'b} -> t
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 5 | end
+    ^^^
 Error: Signature mismatch:
        Modules do not match:
          sig type t = A : { x : 'b; a : 'a; b : 'b; } -> t end

--- a/testsuite/tests/typing-modules/variants_errors_test.ml
+++ b/testsuite/tests/typing-modules/variants_errors_test.ml
@@ -11,10 +11,14 @@ end = struct
 end;;
 [%%expect{|
 Lines 4-7, characters 6-3:
-4 | ......struct
+4 | end = struct
+          ^^^^^^
 5 |   type t =
+      ^^^^^^^^
 6 |     | Foo of float * int
-7 | end..
+        ^^^^^^^^^^^^^^^^^^^^
+7 | end;;
+    ^^^
 Error: Signature mismatch:
        Modules do not match:
          sig type t = Foo of float * int end
@@ -40,10 +44,14 @@ end = struct
 end;;
 [%%expect{|
 Lines 4-7, characters 6-3:
-4 | ......struct
+4 | end = struct
+          ^^^^^^
 5 |   type t =
+      ^^^^^^^^
 6 |     | Foo of float
-7 | end..
+        ^^^^^^^^^^^^^^
+7 | end;;
+    ^^^
 Error: Signature mismatch:
        Modules do not match:
          sig type t = Foo of float end
@@ -69,10 +77,14 @@ end = struct
 end;;
 [%%expect{|
 Lines 4-7, characters 6-3:
-4 | ......struct
+4 | end = struct
+          ^^^^^^
 5 |   type t =
+      ^^^^^^^^
 6 |     | Foo of {x : float; y : int}
-7 | end..
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+7 | end;;
+    ^^^
 Error: Signature mismatch:
        Modules do not match:
          sig type t = Foo of { x : float; y : int; } end
@@ -102,10 +114,14 @@ end = struct
 end;;
 [%%expect{|
 Lines 4-7, characters 6-3:
-4 | ......struct
+4 | end = struct
+          ^^^^^^
 5 |   type t =
+      ^^^^^^^^
 6 |     | Foo of float
-7 | end..
+        ^^^^^^^^^^^^^^
+7 | end;;
+    ^^^
 Error: Signature mismatch:
        Modules do not match:
          sig type t = Foo of float end
@@ -131,10 +147,14 @@ end = struct
 end;;
 [%%expect{|
 Lines 4-7, characters 6-3:
-4 | ......struct
+4 | end = struct
+          ^^^^^^
 5 |   type 'a t =
+      ^^^^^^^^^^^
 6 |     | Foo of 'a
-7 | end..
+        ^^^^^^^^^^^
+7 | end;;
+    ^^^
 Error: Signature mismatch:
        Modules do not match:
          sig type 'a t = Foo of 'a end
@@ -158,9 +178,12 @@ end = struct
 end;;
 [%%expect {|
 Lines 3-5, characters 6-3:
-3 | ......struct
+3 | end = struct
+          ^^^^^^
 4 |   type ('a, 'b) t = A of 'b
-5 | end..
+      ^^^^^^^^^^^^^^^^^^^^^^^^^
+5 | end;;
+    ^^^
 Error: Signature mismatch:
        Modules do not match:
          sig type ('a, 'b) t = A of 'b end
@@ -184,9 +207,12 @@ end = struct
 end;;
 [%%expect {|
 Lines 3-5, characters 6-3:
-3 | ......struct
+3 | end = struct
+          ^^^^^^
 4 |   type ('b, 'a) t = A of 'a
-5 | end..
+      ^^^^^^^^^^^^^^^^^^^^^^^^^
+5 | end;;
+    ^^^
 Error: Signature mismatch:
        Modules do not match:
          sig type ('b, 'a) t = A of 'a end
@@ -223,14 +249,22 @@ end = struct
 end
 [%%expect {|
 Lines 9-16, characters 6-3:
- 9 | ......struct
+ 9 | end = struct
+           ^^^^^^
 10 |   type t =
+       ^^^^^^^^
 11 |     | A
+         ^^^
 12 |     | B
+         ^^^
 13 |     | Beta
+         ^^^^^^
 14 |     | C
+         ^^^
 15 |     | D
+         ^^^
 16 | end
+     ^^^
 Error: Signature mismatch:
        Modules do not match:
          sig type t = A | B | Beta | C | D end
@@ -258,12 +292,18 @@ end = struct
 end
 [%%expect {|
 Lines 7-12, characters 6-3:
- 7 | ......struct
+ 7 | end = struct
+           ^^^^^^
  8 |   type t =
+       ^^^^^^^^
  9 |     | A
+         ^^^
 10 |     | B
+         ^^^
 11 |     | D
+         ^^^
 12 | end
+     ^^^
 Error: Signature mismatch:
        Modules do not match:
          sig type t = A | B | D end
@@ -300,16 +340,25 @@ end
 
 [%%expect {|
 Lines 10-20, characters 6-3:
-10 | ......struct
+10 | end = struct
+           ^^^^^^
 11 |   type t =
+       ^^^^^^^^
 12 |     | A
+         ^^^
 13 |     | B
+         ^^^
 14 |     | Beta
-...
+         ^^^^^^
+     ...
 17 |     | F
+         ^^^
 18 |     | G
+         ^^^
 19 |     | Phi
+         ^^^^^
 20 | end
+     ^^^
 Error: Signature mismatch:
        Modules do not match:
          sig type t = A | B | Beta | C | D | F | G | Phi end
@@ -344,14 +393,22 @@ end = struct
 end
 [%%expect {|
 Lines 10-17, characters 6-3:
-10 | ......struct
+10 | end = struct
+           ^^^^^^
 11 |   type t =
+       ^^^^^^^^
 12 |     | Alpha
+         ^^^^^^^
 13 |     | B
+         ^^^
 14 |     | C
+         ^^^
 15 |     | D
+         ^^^
 16 |     | E
+         ^^^
 17 | end
+     ^^^
 Error: Signature mismatch:
        Modules do not match:
          sig type t = Alpha | B | C | D | E end
@@ -385,15 +442,24 @@ end = struct
 end
 [%%expect {|
 Lines 9-17, characters 6-3:
- 9 | ......struct
+ 9 | end = struct
+           ^^^^^^
 10 |   type t =
+       ^^^^^^^^
 11 |     | A of float
+         ^^^^^^^^^^^^
 12 |     | B
+         ^^^
 13 |     | D
+         ^^^
 14 |     | E
+         ^^^
 15 |     | F
+         ^^^
 16 |     | C
+         ^^^
 17 | end
+     ^^^
 Error: Signature mismatch:
        Modules do not match:
          sig type t = A of float | B | D | E | F | C end

--- a/testsuite/tests/typing-modules/with_ghosts.ml
+++ b/testsuite/tests/typing-modules/with_ghosts.ml
@@ -12,9 +12,12 @@ module type s = sig
 end with type c := <m : int >
 [%%expect {|
 Lines 6-8, characters 16-29:
-6 | ................sig
+6 | module type s = sig
+                    ^^^
 7 |   class type c = object method m: int end
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 8 | end with type c := <m : int >
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The signature constrained by `with' has no component named c
 |}]
 
@@ -24,9 +27,12 @@ module type s = sig
 end with type ct := <m : int >
 [%%expect {|
 Lines 1-3, characters 16-30:
-1 | ................sig
+1 | module type s = sig
+                    ^^^
 2 |   class type ct = object method m: int end
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 3 | end with type ct := <m : int >
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The signature constrained by `with' has no component named ct
 |}]
 

--- a/testsuite/tests/typing-objects-bugs/pr3968_bad.compilers.reference
+++ b/testsuite/tests/typing-objects-bugs/pr3968_bad.compilers.reference
@@ -1,14 +1,24 @@
 File "pr3968_bad.ml", lines 20-29, characters 0-3:
 20 | object
+     ^^^^^^
 21 |   val l = e1
+       ^^^^^^^^^^
 22 |   val r = e2
+       ^^^^^^^^^^
 23 |   method eval env =
+       ^^^^^^^^^^^^^^^^^
 24 |       match l with
+           ^^^^^^^^^^^^
 25 |     | `Abs(var,body) ->
+         ^^^^^^^^^^^^^^^^^^^
 26 |         Hashtbl.add env var r;
+             ^^^^^^^^^^^^^^^^^^^^^^
 27 |         body
+             ^^^^
 28 |     | _ -> `App(l,r);
+         ^^^^^^^^^^^^^^^^^
 29 | end
+     ^^^
 Error: The class type
          object
            val l :

--- a/testsuite/tests/typing-objects/Exemples.ml
+++ b/testsuite/tests/typing-objects/Exemples.ml
@@ -97,10 +97,15 @@ end;;
 [%%expect{|
 Lines 1-5, characters 0-3:
 1 | class ref x_init = object
+    ^^^^^^^^^^^^^^^^^^^^^^^^^
 2 |   val mutable x = x_init
+      ^^^^^^^^^^^^^^^^^^^^^^
 3 |   method get = x
+      ^^^^^^^^^^^^^^
 4 |   method set y = x <- y
-5 | end..
+      ^^^^^^^^^^^^^^^^^^^^^
+5 | end;;
+    ^^^
 Error: Some type variables are unbound in this type:
          class ref :
            'a ->

--- a/testsuite/tests/typing-objects/Tests.ml
+++ b/testsuite/tests/typing-objects/Tests.ml
@@ -32,9 +32,12 @@ end and d () = object
 end;;
 [%%expect{|
 Lines 3-5, characters 4-3:
-3 | ....and d () = object
+3 | end and d () = object
+        ^^^^^^^^^^^^^^^^^
 4 |   inherit ['a] c ()
-5 | end..
+      ^^^^^^^^^^^^^^^^^
+5 | end;;
+    ^^^
 Error: Some type variables are unbound in this type:
          class d : unit -> object method f : 'a -> unit end
        The method f has type 'a -> unit where 'a is unbound
@@ -104,9 +107,12 @@ class x () = object
 end;;
 [%%expect{|
 Lines 1-3, characters 13-3:
-1 | .............object
+1 | class x () = object
+                 ^^^^^^
 2 |   method virtual f : int
-3 | end..
+      ^^^^^^^^^^^^^^^^^^^^^^
+3 | end;;
+    ^^^
 Error: This non-virtual class has virtual methods.
        The following methods are virtual : f
 |}];;
@@ -134,9 +140,13 @@ end;;
 [%%expect{|
 Lines 1-4, characters 0-3:
 1 | class ['a] c () = object
+    ^^^^^^^^^^^^^^^^^^^^^^^^
 2 |   constraint 'a = int
+      ^^^^^^^^^^^^^^^^^^^
 3 |   method f x = (x : bool c)
-4 | end..
+      ^^^^^^^^^^^^^^^^^^^^^^^^^
+4 | end;;
+    ^^^
 Error: The abbreviation c is used with parameter(s) bool
        which are incompatible with constraint(s) int
 |}];;
@@ -180,8 +190,11 @@ end;;
 [%%expect{|
 Lines 1-3, characters 0-3:
 1 | class ['a] c () = object
+    ^^^^^^^^^^^^^^^^^^^^^^^^
 2 |   method f = (x : 'a)
-3 | end..
+      ^^^^^^^^^^^^^^^^^^^
+3 | end;;
+    ^^^
 Error: The type of this class,
        class ['a] c :
          unit -> object constraint 'a = '_weak1 list ref method f : 'a end,
@@ -653,9 +666,13 @@ end;;
 [%%expect{|
 Lines 1-4, characters 0-3:
 1 | class virtual ['a] matrix (sz, init : int * 'a) = object
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 2 |   val m = Array.make_matrix sz sz init
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 3 |   method add (mtx : 'a matrix) = (mtx#m.(0).(0) : 'a)
-4 | end..
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+4 | end;;
+    ^^^
 Error: The abbreviation 'a matrix expands to type < add : 'a matrix -> 'a >
        but is used with type < m : 'a array array; .. >
 |}];;
@@ -701,9 +718,12 @@ end : sig
 end);;
 [%%expect{|
 Lines 1-3, characters 12-3:
-1 | ............struct
+1 | module S = (struct
+                ^^^^^^
 2 |   let f (x : #c) = x
-3 | end......
+      ^^^^^^^^^^^^^^^^^^
+3 | end : sig
+    ^^^
 Error: Signature mismatch:
        Modules do not match:
          sig val f : (#c as 'a) -> 'a end
@@ -1040,9 +1060,12 @@ class c : object
 end;;
 [%%expect {|
 Lines 3-5, characters 8-3:
-3 | ........object (self)
+3 |   end = object (self)
+            ^^^^^^^^^^^^^
 4 |   method m = self
-5 | end..
+      ^^^^^^^^^^^^^^^
+5 | end;;
+    ^^^
 Error: The class type object ('a) method m : < m : 'a; .. > as 'a end
        is not matched by the class type
          object method m : < m : 'a > as 'a end
@@ -1060,9 +1083,12 @@ class c :
   end;;
 [%%expect {|
 Lines 5-7, characters 2-5:
-5 | ..object
+5 |   object
+      ^^^^^^
 6 |     method foo : 'a. (< foo : int; .. > as 'a) -> 'a -> unit = assert false
-7 |   end..
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+7 |   end;;
+      ^^^
 Error: The class type
          object method foo : (< foo : int; .. > as 'a) -> 'a -> unit end
        is not matched by the class type
@@ -1370,9 +1396,12 @@ end = object
   end
 [%%expect {|
 Lines 1-3, characters 10-3:
-1 | ..........object
+1 | class c : object
+              ^^^^^^
 2 |     method virtual m : int
-3 | end.........
+        ^^^^^^^^^^^^^^^^^^^^^^
+3 | end = object
+    ^^^
 Error: This non-virtual class type has virtual methods.
        The following methods are virtual : m
 |}];;

--- a/testsuite/tests/typing-objects/dummy.ml
+++ b/testsuite/tests/typing-objects/dummy.ml
@@ -140,10 +140,14 @@ class leading_up_to = object(self : 'a)
 end;;
 [%%expect{|
 Lines 4-7, characters 4-7:
-4 | ....object
+4 |     object
+        ^^^^^^
 5 |       inherit child1 self
+          ^^^^^^^^^^^^^^^^^^^
 6 |       inherit child2
+          ^^^^^^^^^^^^^^
 7 |     end
+        ^^^
 Error: This object has undeclared virtual methods.
        The following methods were not declared : previous child
 |}]
@@ -161,13 +165,20 @@ class assertion_failure = object(self : 'a)
 end;;
 [%%expect{|
 Lines 4-10, characters 4-7:
- 4 | ....object
+ 4 |     object
+         ^^^^^^
  5 |       inherit child1 self
+           ^^^^^^^^^^^^^^^^^^^
  6 |       inherit child2
+           ^^^^^^^^^^^^^^
  7 |
+     ^
  8 |       method previous = None
+           ^^^^^^^^^^^^^^^^^^^^^^
  9 |       method child = assert false
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 10 |     end
+         ^^^
 Error: Cannot close type of object literal:
        < child : '_weak2; previous : '_weak1 option; .. > as '_weak1
        it has been unified with the self type of a class that is not yet

--- a/testsuite/tests/typing-objects/errors.ml
+++ b/testsuite/tests/typing-objects/errors.ml
@@ -24,9 +24,12 @@ end
 [%%expect{|
 class type ct = object method x : int end
 Lines 5-7, characters 32-3:
-5 | ................................object
+5 | class c (y : 'a * float) : ct = object
+                                    ^^^^^^
 6 |   method x = y
+      ^^^^^^^^^^^^
 7 | end
+    ^^^
 Error: The class type object method x : 'a * float end
        is not matched by the class type ct
        The class type object method x : 'a * float end

--- a/testsuite/tests/typing-objects/field_kind.ml
+++ b/testsuite/tests/typing-objects/field_kind.ml
@@ -25,10 +25,14 @@ let o' =
 let aargh = assert (o'#m Int o' = 3);;
 [%%expect{|
 Lines 2-5, characters 2-5:
-2 | ..object (self : 's)
+2 |   object (self : 's)
+      ^^^^^^^^^^^^^^^^^^
 3 |     method private x = 3
+        ^^^^^^^^^^^^^^^^^^^^
 4 |     method m : type a. a t -> 's -> a = fun Int other -> (other#x : int)
-5 |   end..
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+5 |   end;;
+      ^^^
 Warning 15 [implicit-public-methods]: the following private methods were made public implicitly:
  x.
 
@@ -43,10 +47,14 @@ let o2 =
   end;;
 [%%expect{|
 Lines 2-5, characters 2-5:
-2 | ..object (self : 's)
+2 |   object (self : 's)
+      ^^^^^^^^^^^^^^^^^^
 3 |     method private x = 3
+        ^^^^^^^^^^^^^^^^^^^^
 4 |     method m : 's -> int = fun other -> (other#x : int)
-5 |   end..
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+5 |   end;;
+      ^^^
 Warning 15 [implicit-public-methods]: the following private methods were made public implicitly:
  x.
 
@@ -63,11 +71,16 @@ let o3 =
 let aargh = assert (o3#m o3 = 3);;
 [%%expect{|
 Lines 2-6, characters 2-5:
-2 | ..object (self : 's)
+2 |   object (self : 's)
+      ^^^^^^^^^^^^^^^^^^
 3 |     method private x = 3
+        ^^^^^^^^^^^^^^^^^^^^
 4 |     method m : 's -> int = fun other ->
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 5 |       let module M = struct let other = other end in (M.other#x : int)
-6 |   end..
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+6 |   end;;
+      ^^^
 Warning 15 [implicit-public-methods]: the following private methods were made public implicitly:
  x.
 

--- a/testsuite/tests/typing-objects/nongen.ml
+++ b/testsuite/tests/typing-objects/nongen.ml
@@ -13,9 +13,13 @@ end
 val x : '_weak1 option ref = {contents = None}
 Lines 3-6, characters 0-3:
 3 | class test =
+    ^^^^^^^^^^^^
 4 | object
+    ^^^^^^
 5 |   method b v = x := Some v
+      ^^^^^^^^^^^^^^^^^^^^^^^^
 6 | end
+    ^^^
 Error: The type of this class,
        class test : object method b : '_weak1 -> unit end,
        contains the non-generalizable type variable(s): '_weak1.

--- a/testsuite/tests/typing-objects/pr5619_bad.ml
+++ b/testsuite/tests/typing-objects/pr5619_bad.ml
@@ -41,13 +41,20 @@ class foo: foo_t =
 ;;
 [%%expect{|
 Lines 2-8, characters 2-5:
-2 | ..object(self)
+2 |   object(self)
+      ^^^^^^^^^^^^
 3 |     method foo = "foo"
+        ^^^^^^^^^^^^^^^^^^
 4 |     method cast: type a. a name -> a =
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 5 |       function
+          ^^^^^^^^
 6 |           Foo -> (self :> foo_t)
+              ^^^^^^^^^^^^^^^^^^^^^^
 7 |         | _ -> raise Exit
+            ^^^^^^^^^^^^^^^^^
 8 |   end
+      ^^^
 Error: The class type
          object method cast : 'a name -> 'a method foo : string end
        is not matched by the class type foo_t

--- a/testsuite/tests/typing-objects/unbound-type-var.ml
+++ b/testsuite/tests/typing-objects/unbound-type-var.ml
@@ -10,9 +10,13 @@ end
 [%%expect{|
 Lines 1-4, characters 0-3:
 1 | class test a c =
+    ^^^^^^^^^^^^^^^^
 2 | object
+    ^^^^^^
 3 |   method b = c
+      ^^^^^^^^^^^^
 4 | end
+    ^^^
 Error: Some type variables are unbound in this type:
          class test : 'a -> 'b -> object method b : 'b end
        The method b has type 'b where 'b is unbound

--- a/testsuite/tests/typing-poly/error_messages.ml
+++ b/testsuite/tests/typing-poly/error_messages.ml
@@ -55,9 +55,12 @@ let _ = f (object
 class type t_a = object method f : 'a -> int end
 val f : t_a -> int = <fun>
 Lines 5-7, characters 10-5:
-5 | ..........(object
+5 | let _ = f (object
+              ^^^^^^^
 6 |     method f _ = 0
-7 |  end)..
+        ^^^^^^^^^^^^^^
+7 |  end);;
+     ^^^^
 Error: This expression has type < f : 'b -> int >
        but an expression was expected of type t_a
        The method f has type 'b -> int, but the expected method type was

--- a/testsuite/tests/typing-poly/poly.ml
+++ b/testsuite/tests/typing-poly/poly.ml
@@ -49,9 +49,13 @@ match px with
 [%%expect {|
 Lines 1-4, characters 0-24:
 1 | match px with
+    ^^^^^^^^^^^^^
 2 | | {pv=[]} -> "OK"
+    ^^^^^^^^^^^^^^^^^
 3 | | {pv=5::_} -> "int"
+    ^^^^^^^^^^^^^^^^^^^^
 4 | | {pv=true::_} -> "bool"
+    ^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 {pv=false::_}
@@ -67,9 +71,13 @@ match px with
 [%%expect {|
 Lines 1-4, characters 0-20:
 1 | match px with
+    ^^^^^^^^^^^^^
 2 | | {pv=[]} -> "OK"
+    ^^^^^^^^^^^^^^^^^
 3 | | {pv=true::_} -> "bool"
+    ^^^^^^^^^^^^^^^^^^^^^^^^
 4 | | {pv=5::_} -> "int"
+    ^^^^^^^^^^^^^^^^^^^^
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 {pv=0::_}
@@ -559,10 +567,14 @@ end
 ;;
 [%%expect {|
 Lines 4-7, characters 12-17:
-4 | ............x =
+4 |   method id x =
+                ^^^
 5 |     match r with
+        ^^^^^^^^^^^^
 6 |       None -> r <- Some x; x
+          ^^^^^^^^^^^^^^^^^^^^^^
 7 |     | Some y -> y
+        ^^^^^^^^^^^^^
 Error: This method has type 'b -> 'b which is less general than 'a. 'a -> 'a
 |}];;
 
@@ -1259,8 +1271,10 @@ let f6 x =
   (x : <m:'a. [< `A of < > ] as 'a> :> <m:'a. [< `A of <p:int> ] as 'a>);;
 [%%expect {|
 Lines 2-3, characters 2-47:
-2 | ..(x : <m:'a. (<p:int;..> as 'a) -> int>
-3 |     :> <m:'b. (<p:int;q:int;..> as 'b) -> int>)..
+2 |   (x : <m:'a. (<p:int;..> as 'a) -> int>
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+3 |     :> <m:'b. (<p:int;q:int;..> as 'b) -> int>);;
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: Type < m : 'a. (< p : int; .. > as 'a) -> int > is not a subtype of
          < m : 'b. (< p : int; q : int; .. > as 'b) -> int >
        Type < p : int; q : int; .. > is not a subtype of < p : int; .. >
@@ -1880,9 +1894,12 @@ let x : 'a c = object
 end
 [%%expect{|
 Lines 1-3, characters 15-3:
-1 | ...............object
+1 | let x : 'a c = object
+                   ^^^^^^
 2 |   method x : 'b . 'b s list = [S]
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 3 | end
+    ^^^
 Error: This expression has type < x : 'b. 'b s list >
        but an expression was expected of type 'a c
        The method x has type 'b. 'b s list, but the expected method type was
@@ -1916,9 +1933,12 @@ let x : 'a c = object
 end
 [%%expect{|
 Lines 1-3, characters 15-3:
-1 | ...............object
+1 | let x : 'a c = object
+                   ^^^^^^
 2 |   method x : 'b . 'b s list = []
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 3 | end
+    ^^^
 Error: This expression has type < x : 'b. 'b s list >
        but an expression was expected of type 'a c
        The method x has type 'b. 'b s list, but the expected method type was

--- a/testsuite/tests/typing-polyvariants-bugs/pr10664a.ml
+++ b/testsuite/tests/typing-polyvariants-bugs/pr10664a.ml
@@ -148,8 +148,10 @@ let o =
   end;;
 [%%expect{|
 Lines 3-4, characters 4-34:
-3 | ....method m : 'a. < n : [< `A of 'a] -> 'b > =
+3 |     method m : 'a. < n : [< `A of 'a] -> 'b > =
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 4 |       object method n _ = self end
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The method m has type 'b but is expected to have type
          < n : ([< `A of 'a ] as 'c) ->
                (< m : 'a. < n : 'c -> 'd >; .. > as 'd) >

--- a/testsuite/tests/typing-polyvariants-bugs/pr7817_bad.ml
+++ b/testsuite/tests/typing-polyvariants-bugs/pr7817_bad.ml
@@ -13,10 +13,14 @@ end
 [%%expect{|
 val r : '_weak1 option ref = {contents = None}
 Lines 5-8, characters 6-3:
-5 | ......struct
+5 | end = struct
+          ^^^^^^
 6 |   let write x =
+      ^^^^^^^^^^^^^
 7 |     match x with `A _ | `B _ -> r := Some x
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 8 | end
+    ^^^
 Error: Signature mismatch:
        Modules do not match:
          sig

--- a/testsuite/tests/typing-polyvariants-bugs/pr7824.ml
+++ b/testsuite/tests/typing-polyvariants-bugs/pr7824.ml
@@ -38,8 +38,10 @@ let f x =
 ;;
 [%%expect{|
 Lines 4-5, characters 2-38:
-4 | ..match [] with
+4 |   match [] with
+      ^^^^^^^^^^^^^
 5 |   | _::_ -> (x :> [`A | `C] Element.t)
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 []

--- a/testsuite/tests/typing-recmod/t07bad.compilers.reference
+++ b/testsuite/tests/typing-recmod/t07bad.compilers.reference
@@ -1,6 +1,8 @@
 File "t07bad.ml", lines 10-11, characters 0-54:
 10 | module rec A : sig type 'a t = <m: 'a list A.t> end
-11 |              = struct type 'a t = <m: 'a list A.t> end..
+     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+11 |              = struct type 'a t = <m: 'a list A.t> end;;
+                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This recursive type is not regular.
        The type constructor A.t is defined as
          type 'a A.t

--- a/testsuite/tests/typing-recmod/t08bad.compilers.reference
+++ b/testsuite/tests/typing-recmod/t08bad.compilers.reference
@@ -1,6 +1,8 @@
 File "t08bad.ml", lines 10-11, characters 0-71:
 10 | module rec A : sig type 'a t = <m: 'a list B.t; n: 'a array B.t> end
+     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 11 |              = struct type 'a t = <m: 'a list B.t; n: 'a array B.t> end
+                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This recursive type is not regular.
        The type constructor A.t is defined as
          type 'a A.t

--- a/testsuite/tests/typing-recmod/t09bad.compilers.reference
+++ b/testsuite/tests/typing-recmod/t09bad.compilers.reference
@@ -1,6 +1,8 @@
 File "t09bad.ml", lines 10-11, characters 0-44:
 10 | module rec A : sig type 'a t = 'a B.t end
+     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 11 |              = struct type 'a t = 'a B.t end
+                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This recursive type is not regular.
        The type constructor A.t is defined as
          type 'a A.t

--- a/testsuite/tests/typing-recmod/t11bad.compilers.reference
+++ b/testsuite/tests/typing-recmod/t11bad.compilers.reference
@@ -1,6 +1,8 @@
 File "t11bad.ml", lines 12-13, characters 7-55:
-12 | .......and B : sig type 'a t = <m: 'a array B.t> end
-13 |              = struct type 'a t = <m: 'a array B.t> end..
+12 |        and B : sig type 'a t = <m: 'a array B.t> end
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+13 |              = struct type 'a t = <m: 'a array B.t> end;;
+                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This recursive type is not regular.
        The type constructor B.t is defined as
          type 'a B.t

--- a/testsuite/tests/typing-recmod/t12bad.compilers.reference
+++ b/testsuite/tests/typing-recmod/t12bad.compilers.reference
@@ -1,14 +1,23 @@
 File "t12bad.ml", lines 10-21, characters 0-7:
 10 | module rec M :
+     ^^^^^^^^^^^^^^
 11 |     sig
+         ^^^
 12 |       class ['a] c : 'a -> object
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 13 |         method map : ('a -> 'b) -> 'b M.c
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 14 |       end
-...
+           ^^^
+     ...
 18 |         method map : 'b. ('a -> 'b) -> 'b M.c
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 19 |           = fun f -> new M.c (f x)
+               ^^^^^^^^^^^^^^^^^^^^^^^^
 20 |       end
-21 |     end..
+           ^^^
+21 |     end;;
+         ^^^
 Error: This recursive type is not regular.
        The type constructor M.c is defined as
          type 'a M.c

--- a/testsuite/tests/typing-safe-linking/b_bad.compilers.reference
+++ b/testsuite/tests/typing-safe-linking/b_bad.compilers.reference
@@ -1,6 +1,8 @@
 File "b_bad.ml", lines 13-14, characters 29-28:
-13 | .............................function
+13 | let f : string A.t -> unit = function
+                                  ^^^^^^^^
 14 |     A.X s -> print_endline s
+         ^^^^^^^^^^^^^^^^^^^^^^^^
 Error (warning 8 [partial-match]): this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 Y

--- a/testsuite/tests/typing-sigsubst/sigsubst.ml
+++ b/testsuite/tests/typing-sigsubst/sigsubst.ml
@@ -157,11 +157,16 @@ end with type 'a t2 := 'a t * bool
 [%%expect {|
 type 'a t constraint 'a = 'b list
 Lines 2-6, characters 16-34:
-2 | ................sig
+2 | module type S = sig
+                    ^^^
 3 |   type 'a t2 constraint 'a = 'b list
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 4 |   type 'a mylist = 'a list
+      ^^^^^^^^^^^^^^^^^^^^^^^^
 5 |   val x : int mylist t2
+      ^^^^^^^^^^^^^^^^^^^^^
 6 | end with type 'a t2 := 'a t * bool
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: Destructive substitutions are not supported for constrained
        types (other than when replacing a type constructor with
        a type constructor with the same arguments).
@@ -262,10 +267,14 @@ module type S = sig
 end with type M.t := float
 [%%expect {|
 Lines 1-4, characters 16-26:
-1 | ................sig
+1 | module type S = sig
+                    ^^^
 2 |   module M : sig type t end
+      ^^^^^^^^^^^^^^^^^^^^^^^^^
 3 |   module A = M
+      ^^^^^^^^^^^^
 4 | end with type M.t := float
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This `with' constraint on M.t changes M, which is aliased
        in the constrained signature (as A).
 |}]
@@ -324,10 +333,14 @@ end with type M2.t := int
 [%%expect {|
 module Id : functor (X : sig type t end) -> sig type t = X.t end
 Lines 2-5, characters 17-25:
-2 | .................sig
+2 | module type S3 = sig
+                     ^^^
 3 |   module rec M : sig type t = A of Id(M2).t end
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 4 |   and M2 : sig type t end
+      ^^^^^^^^^^^^^^^^^^^^^^^
 5 | end with type M2.t := int
+    ^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This `with' constraint on M2.t makes the applicative functor
        type Id(M2).t ill-typed in the constrained signature:
        Modules do not match: sig end is not included in sig type t end
@@ -367,16 +380,26 @@ module type S = sig
 end with module M.N := A
 [%%expect {|
 Lines 1-10, characters 16-24:
- 1 | ................sig
+ 1 | module type S = sig
+                     ^^^
  2 |   module M : sig
+       ^^^^^^^^^^^^^^
  3 |     module N : sig
+         ^^^^^^^^^^^^^^
  4 |       module P : sig
+           ^^^^^^^^^^^^^^
  5 |         type t
+             ^^^^^^
  6 |       end
+           ^^^
  7 |     end
+         ^^^
  8 |   end
+       ^^^
  9 |   module Alias = M
+       ^^^^^^^^^^^^^^^^
 10 | end with module M.N := A
+     ^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This `with' constraint on M.N changes M, which is aliased
        in the constrained signature (as Alias).
 |}]

--- a/testsuite/tests/typing-unboxed-types/test.ml
+++ b/testsuite/tests/typing-unboxed-types/test.ml
@@ -112,9 +112,12 @@ end = struct
 end;;
 [%%expect{|
 Lines 3-5, characters 6-3:
-3 | ......struct
+3 | end = struct
+          ^^^^^^
 4 |   type t = A of string [@@ocaml.unboxed]
-5 | end..
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+5 | end;;
+    ^^^
 Error: Signature mismatch:
        Modules do not match:
          sig type t = A of string [@@unboxed] end
@@ -135,9 +138,12 @@ end = struct
 end;;
 [%%expect{|
 Lines 3-5, characters 6-3:
-3 | ......struct
+3 | end = struct
+          ^^^^^^
 4 |   type t = A of string
-5 | end..
+      ^^^^^^^^^^^^^^^^^^^^
+5 | end;;
+    ^^^
 Error: Signature mismatch:
        Modules do not match:
          sig type t = A of string end
@@ -158,9 +164,12 @@ end = struct
 end;;
 [%%expect{|
 Lines 3-5, characters 6-3:
-3 | ......struct
+3 | end = struct
+          ^^^^^^
 4 |   type t = { f : string } [@@ocaml.unboxed]
-5 | end..
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+5 | end;;
+    ^^^
 Error: Signature mismatch:
        Modules do not match:
          sig type t = { f : string; } [@@unboxed] end
@@ -181,9 +190,12 @@ end = struct
 end;;
 [%%expect{|
 Lines 3-5, characters 6-3:
-3 | ......struct
+3 | end = struct
+          ^^^^^^
 4 |   type t = { f : string }
-5 | end..
+      ^^^^^^^^^^^^^^^^^^^^^^^
+5 | end;;
+    ^^^
 Error: Signature mismatch:
        Modules do not match:
          sig type t = { f : string; } end
@@ -204,9 +216,12 @@ end = struct
 end;;
 [%%expect{|
 Lines 3-5, characters 6-3:
-3 | ......struct
+3 | end = struct
+          ^^^^^^
 4 |   type t = A of { f : string } [@@ocaml.unboxed]
-5 | end..
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+5 | end;;
+    ^^^
 Error: Signature mismatch:
        Modules do not match:
          sig type t = A of { f : string; } [@@unboxed] end
@@ -227,9 +242,12 @@ end = struct
 end;;
 [%%expect{|
 Lines 3-5, characters 6-3:
-3 | ......struct
+3 | end = struct
+          ^^^^^^
 4 |   type t = A of { f : string }
-5 | end..
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+5 | end;;
+    ^^^
 Error: Signature mismatch:
        Modules do not match:
          sig type t = A of { f : string; } end
@@ -293,10 +311,14 @@ end = struct
 end;;
 [%%expect{|
 Lines 4-7, characters 6-3:
-4 | ......struct
+4 | end = struct
+          ^^^^^^
 5 |   type t = A of float [@@ocaml.unboxed]
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 6 |   type u = { f1 : t; f2 : t }
-7 | end..
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+7 | end;;
+    ^^^
 Error: Signature mismatch:
        Modules do not match:
          sig type t = A of float [@@unboxed] type u = { f1 : t; f2 : t; } end

--- a/testsuite/tests/typing-unboxed/test.ml
+++ b/testsuite/tests/typing-unboxed/test.ml
@@ -111,9 +111,12 @@ end;;
 
 [%%expect{|
 Lines 3-5, characters 6-3:
-3 | ......struct
+3 | end = struct
+          ^^^^^^
 4 |   external f : int -> (int [@untagged]) = "f" "f_nat"
-5 | end..
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+5 | end;;
+    ^^^
 Error: Signature mismatch:
        Modules do not match:
          sig external f : int -> (int [@untagged]) = "f" "f_nat" end
@@ -134,9 +137,12 @@ end;;
 
 [%%expect{|
 Lines 3-5, characters 6-3:
-3 | ......struct
+3 | end = struct
+          ^^^^^^
 4 |   external f : (int [@untagged]) -> int = "f" "f_nat"
-5 | end..
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+5 | end;;
+    ^^^
 Error: Signature mismatch:
        Modules do not match:
          sig external f : (int [@untagged]) -> int = "f" "f_nat" end
@@ -157,9 +163,12 @@ end;;
 
 [%%expect{|
 Lines 3-5, characters 6-3:
-3 | ......struct
+3 | end = struct
+          ^^^^^^
 4 |   external f : (int [@untagged]) -> int = "f" "f_nat"
-5 | end..
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+5 | end;;
+    ^^^
 Error: Signature mismatch:
        Modules do not match:
          sig external f : (int [@untagged]) -> int = "f" "f_nat" end
@@ -180,9 +189,12 @@ end;;
 
 [%%expect{|
 Lines 3-5, characters 6-3:
-3 | ......struct
+3 | end = struct
+          ^^^^^^
 4 |   external f : float -> (float [@unboxed]) = "f" "f_nat"
-5 | end..
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+5 | end;;
+    ^^^
 Error: Signature mismatch:
        Modules do not match:
          sig external f : float -> (float [@unboxed]) = "f" "f_nat" end
@@ -203,9 +215,12 @@ end;;
 
 [%%expect{|
 Lines 3-5, characters 6-3:
-3 | ......struct
+3 | end = struct
+          ^^^^^^
 4 |   external f : (float [@unboxed]) -> float = "f" "f_nat"
-5 | end..
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+5 | end;;
+    ^^^
 Error: Signature mismatch:
        Modules do not match:
          sig external f : (float [@unboxed]) -> float = "f" "f_nat" end
@@ -226,9 +241,12 @@ end;;
 
 [%%expect{|
 Lines 3-5, characters 6-3:
-3 | ......struct
+3 | end = struct
+          ^^^^^^
 4 |   external f : (float [@unboxed]) -> float = "f" "f_nat"
-5 | end..
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+5 | end;;
+    ^^^
 Error: Signature mismatch:
        Modules do not match:
          sig external f : (float [@unboxed]) -> float = "f" "f_nat" end
@@ -249,9 +267,12 @@ end;;
 
 [%%expect{|
 Lines 3-5, characters 6-3:
-3 | ......struct
+3 | end = struct
+          ^^^^^^
 4 |   external f : int -> int = "f" "f_nat" [@@noalloc]
-5 | end..
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+5 | end;;
+    ^^^
 Error: Signature mismatch:
        Modules do not match:
          sig external f : int -> int = "f" "f_nat" [@@noalloc] end
@@ -274,9 +295,12 @@ end;;
 
 [%%expect{|
 Lines 3-5, characters 6-3:
-3 | ......struct
+3 | end = struct
+          ^^^^^^
 4 |   external f : int -> int = "f" "f_nat"
-5 | end..
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+5 | end;;
+    ^^^
 Error: Signature mismatch:
        Modules do not match:
          sig external f : int -> int = "f" "f_nat" end
@@ -297,9 +321,12 @@ end;;
 
 [%%expect{|
 Lines 3-5, characters 6-3:
-3 | ......struct
+3 | end = struct
+          ^^^^^^
 4 |   external f : int -> int = "f" "f_nat"
-5 | end..
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+5 | end;;
+    ^^^
 Error: Signature mismatch:
        Modules do not match:
          sig external f : int -> int = "f" "f_nat" end
@@ -320,9 +347,12 @@ end;;
 
 [%%expect{|
 Lines 3-5, characters 6-3:
-3 | ......struct
+3 | end = struct
+          ^^^^^^
 4 |   external f : int -> int = "a" "a_nat"
-5 | end..
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+5 | end;;
+    ^^^
 Error: Signature mismatch:
        Modules do not match:
          sig external f : int -> int = "a" "a_nat" end
@@ -343,9 +373,12 @@ end;;
 
 [%%expect{|
 Lines 3-5, characters 6-3:
-3 | ......struct
+3 | end = struct
+          ^^^^^^
 4 |   external f : float -> float = "f" "f_nat"
-5 | end..
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+5 | end;;
+    ^^^
 Error: Signature mismatch:
        Modules do not match:
          sig external f : float -> float = "f" "f_nat" end
@@ -366,9 +399,12 @@ end;;
 
 [%%expect{|
 Lines 3-5, characters 6-3:
-3 | ......struct
+3 | end = struct
+          ^^^^^^
 4 |   external f : float -> float = "f" "f_nat"
-5 | end..
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+5 | end;;
+    ^^^
 Error: Signature mismatch:
        Modules do not match:
          sig external f : float -> float = "f" "f_nat" end
@@ -389,9 +425,12 @@ end;;
 
 [%%expect{|
 Lines 3-5, characters 6-3:
-3 | ......struct
+3 | end = struct
+          ^^^^^^
 4 |   external f : float -> float = "a" "a_nat"
-5 | end..
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+5 | end;;
+    ^^^
 Error: Signature mismatch:
        Modules do not match:
          sig external f : float -> float = "a" "a_nat" end
@@ -412,9 +451,12 @@ end;;
 
 [%%expect{|
 Lines 3-5, characters 6-3:
-3 | ......struct
+3 | end = struct
+          ^^^^^^
 4 |   external f : int -> int = "f" "f_nat"
-5 | end..
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+5 | end;;
+    ^^^
 Error: Signature mismatch:
        Modules do not match:
          sig external f : int -> int = "f" "f_nat" end
@@ -437,9 +479,12 @@ end
 
 [%%expect{|
 Lines 3-5, characters 6-3:
-3 | ......struct
+3 | end = struct
+          ^^^^^^
 4 |   let f x = x + 1
+      ^^^^^^^^^^^^^^^
 5 | end
+    ^^^
 Error: Signature mismatch:
        Modules do not match:
          sig val f : int -> int end
@@ -477,9 +522,12 @@ end
 
 [%%expect{|
 Lines 3-5, characters 6-3:
-3 | ......struct
+3 | end = struct
+          ^^^^^^
 4 |   external f : int -> int = "gg" "f_nat"
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 5 | end
+    ^^^
 Error: Signature mismatch:
        Modules do not match:
          sig external f : int -> int = "gg" "f_nat" end
@@ -500,9 +548,12 @@ end
 
 [%%expect{|
 Lines 3-5, characters 6-3:
-3 | ......struct
+3 | end = struct
+          ^^^^^^
 4 |   external f : int -> int = "f" "gg_nat"
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 5 | end
+    ^^^
 Error: Signature mismatch:
        Modules do not match:
          sig external f : int -> int = "f" "gg_nat" end
@@ -523,9 +574,12 @@ end
 
 [%%expect{|
 Lines 3-5, characters 6-3:
-3 | ......struct
+3 | end = struct
+          ^^^^^^
 4 |   external f : int -> int = "gg" "gg_nat"
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 5 | end
+    ^^^
 Error: Signature mismatch:
        Modules do not match:
          sig external f : int -> int = "gg" "gg_nat" end
@@ -554,9 +608,12 @@ end
 
 [%%expect{|
 Lines 4-6, characters 6-3:
-4 | ......struct
+4 | end = struct
+          ^^^^^^
 5 |   external f : int -> int -> int = "f" "f_nat"
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 6 | end
+    ^^^
 Error: Signature mismatch:
        Modules do not match:
          sig external f : int -> int -> int = "f" "f_nat" end
@@ -579,10 +636,14 @@ end
 
 [%%expect{|
 Lines 3-6, characters 6-3:
-3 | ......struct
+3 | end = struct
+          ^^^^^^
 4 |   type int_int = int -> int
+      ^^^^^^^^^^^^^^^^^^^^^^^^^
 5 |   external f : int -> int_int = "f" "f_nat"
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 6 | end
+    ^^^
 Error: Signature mismatch:
        Modules do not match:
          sig
@@ -608,9 +669,12 @@ end
 
 [%%expect{|
 Lines 3-5, characters 6-3:
-3 | ......struct
+3 | end = struct
+          ^^^^^^
 4 |   external f : int -> int -> int = "f" "f_nat"
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 5 | end
+    ^^^
 Error: Signature mismatch:
        Modules do not match:
          sig external f : int -> int -> int = "f" "f_nat" end

--- a/testsuite/tests/typing-warnings/ambiguous_guarded_disjunction.ml
+++ b/testsuite/tests/typing-warnings/ambiguous_guarded_disjunction.ml
@@ -213,8 +213,10 @@ let ambiguous__first_orpat = function
 ;;
 [%%expect {|
 Lines 2-3, characters 4-58:
-2 | ....`A ((`B (Some x, _) | `B (_, Some x)),
-3 |         (`C (Some y, Some _, _) | `C (Some y, _, Some _))).................
+2 |   | `A ((`B (Some x, _) | `B (_, Some x)),
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+3 |         (`C (Some y, Some _, _) | `C (Some y, _, Some _))) when x < y -> ()
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 57 [ambiguous-var-in-pattern-guard]: Ambiguous or-pattern variables under guard;
 variable x appears in different places in different or-pattern alternatives.
 Only the first match will be used to evaluate the guard expression.
@@ -234,8 +236,10 @@ let ambiguous__second_orpat = function
 ;;
 [%%expect {|
 Lines 2-3, characters 4-42:
-2 | ....`A ((`B (Some x, Some _, _) | `B (Some x, _, Some _)),
-3 |         (`C (Some y, _) | `C (_, Some y))).................
+2 |   | `A ((`B (Some x, Some _, _) | `B (Some x, _, Some _)),
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+3 |         (`C (Some y, _) | `C (_, Some y))) when x < y -> ()
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 57 [ambiguous-var-in-pattern-guard]: Ambiguous or-pattern variables under guard;
 variable y appears in different places in different or-pattern alternatives.
 Only the first match will be used to evaluate the guard expression.
@@ -330,8 +334,10 @@ let ambiguous__amoi a = match a with
 ;;
 [%%expect {|
 Lines 2-3, characters 2-17:
-2 | ..X (Z x,Y (y,0))
+2 | | X (Z x,Y (y,0))
+      ^^^^^^^^^^^^^^^
 3 | | X (Z y,Y (x,_))
+    ^^^^^^^^^^^^^^^^^
 Warning 57 [ambiguous-var-in-pattern-guard]: Ambiguous or-pattern variables under guard;
 variables x, y appear in different places in different or-pattern alternatives.
 Only the first match will be used to evaluate the guard expression.
@@ -353,8 +359,10 @@ let ambiguous__module_variable x b =  match x with
 ;;
 [%%expect {|
 Lines 2-3, characters 4-24:
-2 | ....(module M:S),_,(1,_)
-3 |   | _,(module M:S),(_,1)...................
+2 |   | (module M:S),_,(1,_)
+        ^^^^^^^^^^^^^^^^^^^^
+3 |   | _,(module M:S),(_,1) when M.b && b -> 1
+      ^^^^^^^^^^^^^^^^^^^^^^
 Warning 57 [ambiguous-var-in-pattern-guard]: Ambiguous or-pattern variables under guard;
 variable M appears in different places in different or-pattern alternatives.
 Only the first match will be used to evaluate the guard expression.
@@ -399,9 +407,12 @@ Warning 41 [ambiguous-name]: A belongs to several types: t2 t
 The first one was selected. Please disambiguate if this is wrong.
 
 Lines 1-3, characters 41-10:
-1 | .........................................function
+1 | let ambiguous_xy_but_not_ambiguous_z g = function
+                                             ^^^^^^^^
 2 |   | A (x as z,(0 as y))|A (0 as y as z,x)|B (x,(y as z)) when g x (y+z) -> 1
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 3 |   | _ -> 2
+      ^^^^^^^^
 Warning 4 [fragile-match]: this pattern-matching is fragile.
 It will remain exhaustive when constructors are added to type t2.
 
@@ -435,9 +446,12 @@ Warning 41 [ambiguous-name]: B belongs to several types: t2 t
 The first one was selected. Please disambiguate if this is wrong.
 
 Lines 1-3, characters 41-10:
-1 | .........................................function
+1 | let ambiguous_xy_but_not_ambiguous_z g = function
+                                             ^^^^^^^^
 2 |   | A (x as z,(0 as y))|A (0 as y as z,x)|B (x,(y as z)) when g x (y+z) -> 1
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 3 |   | _ -> 2
+      ^^^^^^^^
 Warning 4 [fragile-match]: this pattern-matching is fragile.
 It will remain exhaustive when constructors are added to type t2.
 

--- a/testsuite/tests/typing-warnings/exhaustiveness.ml
+++ b/testsuite/tests/typing-warnings/exhaustiveness.ml
@@ -8,9 +8,12 @@ let f = function
   | Some _, Some _ -> 2;;
 [%%expect {|
 Lines 1-3, characters 8-23:
-1 | ........function
+1 | let f = function
+            ^^^^^^^^
 2 |     None, None -> 1
-3 |   | Some _, Some _ -> 2..
+        ^^^^^^^^^^^^^^^
+3 |   | Some _, Some _ -> 2;;
+      ^^^^^^^^^^^^^^^^^^^^^
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 (None, Some _)
@@ -346,10 +349,14 @@ let f = function
 ;;
 [%%expect {|
 Lines 1-4, characters 8-28:
-1 | ........function
+1 | let f = function
+            ^^^^^^^^
 2 |   | None -> ()
+      ^^^^^^^^^^^^
 3 |   | Some x when x > 0 -> ()
+      ^^^^^^^^^^^^^^^^^^^^^^^^^
 4 |   | Some x when x <= 0 -> ()
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 Some _
@@ -384,9 +391,12 @@ let non_exhaustive : t * t * t * t -> unit = function
 end;;
 [%%expect {|
 Lines 20-22, characters 45-49:
-20 | .............................................function
+20 | let non_exhaustive : t * t * t * t -> unit = function
+                                                  ^^^^^^^^
 21 | | A, A, A, A -> ()
+     ^^^^^^^^^^^^^^^^^^
 22 | | (A|B), (A|B), (A|B), A (*missing B here*) -> ()
+     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 ((A|B), (A|B), (A|B), B)

--- a/testsuite/tests/typing-warnings/pr6587.ml
+++ b/testsuite/tests/typing-warnings/pr6587.ml
@@ -24,9 +24,12 @@ module B: sig val f: fpclass -> fpclass end =
     ;;
 [%%expect {|
 Lines 2-4, characters 2-5:
-2 | ..struct
+2 |   struct
+      ^^^^^^
 3 |     let f A = FP_normal
+        ^^^^^^^^^^^^^^^^^^^
 4 |   end
+      ^^^
 Error: Signature mismatch:
        Modules do not match:
          sig val f : fpclass -> Stdlib.fpclass end

--- a/testsuite/tests/warnings/w04.compilers.reference
+++ b/testsuite/tests/warnings/w04.compilers.reference
@@ -1,6 +1,9 @@
 File "w04.ml", lines 21-23, characters 10-8:
-21 | ..........match x with
+21 | let g x = match x with
+               ^^^^^^^^^^^^
 22 | | A -> 0
+     ^^^^^^^^
 23 | | _ -> 1
+     ^^^^^^^^
 Warning 4 [fragile-match]: this pattern-matching is fragile.
 It will remain exhaustive when constructors are added to type t.

--- a/testsuite/tests/warnings/w04_failure.compilers.reference
+++ b/testsuite/tests/warnings/w04_failure.compilers.reference
@@ -1,23 +1,35 @@
 File "w04_failure.ml", lines 20-23, characters 2-17:
-20 | ..match r1, r2, t with
+20 |   match r1, r2, t with
+       ^^^^^^^^^^^^^^^^^^^^
 21 |   | AB, _, A -> ()
+       ^^^^^^^^^^^^^^^^
 22 |   | _, XY, X -> ()
+       ^^^^^^^^^^^^^^^^
 23 |   | _, _, _ -> ()
+       ^^^^^^^^^^^^^^^
 Warning 4 [fragile-match]: this pattern-matching is fragile.
 It will remain exhaustive when constructors are added to type repr.
 
 File "w04_failure.ml", lines 20-23, characters 2-17:
-20 | ..match r1, r2, t with
+20 |   match r1, r2, t with
+       ^^^^^^^^^^^^^^^^^^^^
 21 |   | AB, _, A -> ()
+       ^^^^^^^^^^^^^^^^
 22 |   | _, XY, X -> ()
+       ^^^^^^^^^^^^^^^^
 23 |   | _, _, _ -> ()
+       ^^^^^^^^^^^^^^^
 Warning 4 [fragile-match]: this pattern-matching is fragile.
 It will remain exhaustive when constructors are added to type ab.
 
 File "w04_failure.ml", lines 20-23, characters 2-17:
-20 | ..match r1, r2, t with
+20 |   match r1, r2, t with
+       ^^^^^^^^^^^^^^^^^^^^
 21 |   | AB, _, A -> ()
+       ^^^^^^^^^^^^^^^^
 22 |   | _, XY, X -> ()
+       ^^^^^^^^^^^^^^^^
 23 |   | _, _, _ -> ()
+       ^^^^^^^^^^^^^^^
 Warning 4 [fragile-match]: this pattern-matching is fragile.
 It will remain exhaustive when constructors are added to type xy.

--- a/testsuite/tests/warnings/w32.compilers.reference
+++ b/testsuite/tests/warnings/w32.compilers.reference
@@ -74,14 +74,23 @@ Warning 32 [unused-value-declaration]: unused value k.
 
 File "w32.ml", lines 52-60, characters 0-3:
 52 | module M = struct
+     ^^^^^^^^^^^^^^^^^
 53 |   [@@@warning "-32"]
+       ^^^^^^^^^^^^^^^^^^
 54 |   let f x = x
+       ^^^^^^^^^^^
 55 |   let[@warning "+32"] g x = x
+       ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 56 |   let[@warning "+32"] h x = x
+       ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 57 |   and i x = x
+       ^^^^^^^^^^^
 58 |   let j x = x
+       ^^^^^^^^^^^
 59 |   and[@warning "+32"] k x = x
+       ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 60 | end
+     ^^^
 Warning 60 [unused-module]: unused module M.
 
 File "w32.ml", line 63, characters 18-29:

--- a/utils/misc.mli
+++ b/utils/misc.mli
@@ -521,22 +521,29 @@ val print_if :
   Format.formatter -> bool ref -> (Format.formatter -> 'a -> unit) -> 'a -> 'a
 (** [print_if ppf flag fmt x] prints [x] with [fmt] on [ppf] if [b] is true. *)
 
+val ellipse : ellipsis:'a -> max_lines:int -> 'a list -> 'a list
+(** [ellipse ~ellipsis ~max_lines lines] returns [lines] if its length is less
+    than [max_lines], otherwise, remove the middle lines until its length is
+    equal to [max_lines]. If a line has been removed, [ellipsis] is inserted in
+    the middle and is counted as a line. *)
+
 val pp_two_columns :
-  ?sep:string -> ?max_lines:int ->
-  Format.formatter -> (string * string) list -> unit
-(** [pp_two_columns ?sep ?max_lines ppf l] prints the lines in [l] as two
-   columns separated by [sep] ("|" by default). [max_lines] can be used to
-   indicate a maximum number of lines to print -- an ellipsis gets inserted at
-   the middle if the input has too many lines.
+  ?sep:string -> Format.formatter ->
+  (string * (Format.formatter -> unit)) list -> unit
+(** [pp_two_columns ?sep ppf l] prints the lines in [l] as two columns
+    separated by [sep] ("|" by default).
 
    Example:
 
-    {v pp_two_columns ~max_lines:3 Format.std_formatter [
-      "abc", "hello";
-      "def", "zzz";
-      "a"  , "bllbl";
-      "bb" , "dddddd";
-    ] v}
+    {v
+    let pp str ppf = Format.pp_print_string ppf str in
+    pp_two_columns Format.std_formatter [
+      "abc", pp "hello";
+      "def", pp "zzz";
+      "a"  , pp "bllbl";
+      "bb" , pp "dddddd";
+    ]
+    v}
 
     prints
 


### PR DESCRIPTION
This PR changes the code highlighting in error messages to highlight several lines using the red underline made of `^`. Previously, this was disabled as soon as the location spanned more than one line and was replaced with an echo of the code with the part outside of range replaced with dots (`.`).

I find the dots delimiting the code to look at to be very confusing. Code around is hidden and it's hard to recognise the original code. The dots stick to my mind and distract me from even remembering what was the error.

The new messages are more sparse but the regularity of the highlighting helps skip the code to the error message and back.

Before:
```
File "./test.ml", lines 4-5, characters 2-15:
4 | ..print_lines (List.map string_of_int [ 1; 2; 3; 4; 5 ])
5 |   print_endline......
```

After:
```
File "./test.ml", lines 4-5, characters 2-15:
4 |   print_lines (List.map string_of_int [ 1; 2; 3; 4; 5 ])
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
5 |   print_endline "foo"
      ^^^^^^^^^^^^^
```
