### PR TITLE
Improve the error message about too many arguments

### DIFF
--- a/.depend
+++ b/.depend
@@ -1382,6 +1382,7 @@ typing/typecore.cmo : \
     typing/printpat.cmi \
     typing/primitive.cmi \
     typing/predef.cmi \
+    parsing/pprintast.cmi \
     typing/persistent_env.cmi \
     typing/path.cmi \
     parsing/parsetree.cmi \
@@ -1415,6 +1416,7 @@ typing/typecore.cmx : \
     typing/printpat.cmx \
     typing/primitive.cmx \
     typing/predef.cmx \
+    parsing/pprintast.cmx \
     typing/persistent_env.cmx \
     typing/path.cmx \
     parsing/parsetree.cmi \

--- a/Changes
+++ b/Changes
@@ -244,6 +244,9 @@ Working version
 
 ### Compiler user-interface and warnings:
 
+- #11679: Improve the error message about too many arguments to a function
+  (Jules Aguillon, review by Gabriel Scherer and Florian Angeletti)
+
 - #10009: Improve the error reported by mismatched struct/sig and =/: in module
   and module type bindings.
   (Jules Aguillon, review by Gabriel Scherer)

--- a/testsuite/tests/typing-misc/apply_non_function.ml
+++ b/testsuite/tests/typing-misc/apply_non_function.ml
@@ -14,9 +14,9 @@ Lines 4-5, characters 2-15:
 5 |   print_endline......
 Error: The function 'print_lines' has type string list -> unit
        It is applied to too many arguments
-Line 4, characters 56-57:
- |   print_lines (List.map string_of_int [ 1; 2; 3; 4; 5 ])
-                                                           ^
+Line 4, characters 55-57:
+4 |   print_lines (List.map string_of_int [ 1; 2; 3; 4; 5 ])
+                                                           ^^
   Hint: Did you forget a ';'?
 Line 5, characters 2-15:
 5 |   print_endline "foo"
@@ -35,9 +35,9 @@ Line 4, characters 2-9:
       ^^^^^^^
 Error: The function 't.f' has type int -> unit
        It is applied to too many arguments
-Line 4, characters 7-8:
+Line 4, characters 6-8:
 4 |   t.f 1 2
-           ^
+          ^^
   Hint: Did you forget a ';'?
 Line 4, characters 8-9:
 4 |   t.f 1 2
@@ -53,9 +53,9 @@ Line 2, characters 2-9:
       ^^^^^^^
 Error: The function 't#f' has type int -> unit
        It is applied to too many arguments
-Line 2, characters 7-8:
+Line 2, characters 6-8:
 2 |   t#f 1 2
-           ^
+          ^^
   Hint: Did you forget a ';'?
 Line 2, characters 8-9:
 2 |   t#f 1 2
@@ -74,9 +74,9 @@ Line 4, characters 15-20:
                    ^^^^^
 Error: The function 'a' has type 'a -> unit
        It is applied to too many arguments
-Line 4, characters 18-19:
+Line 4, characters 17-19:
 4 |     method b = a 1 2
-                      ^
+                     ^^
   Hint: Did you forget a ';'?
 Line 4, characters 19-20:
 4 |     method b = a 1 2

--- a/testsuite/tests/typing-misc/apply_non_function.ml
+++ b/testsuite/tests/typing-misc/apply_non_function.ml
@@ -1,0 +1,85 @@
+(* TEST
+   * expect
+*)
+
+let print_lines = List.iter print_endline
+
+let () =
+  print_lines (List.map string_of_int [ 1; 2; 3; 4; 5 ])
+  print_endline "foo"
+[%%expect{|
+val print_lines : string list -> unit = <fun>
+Lines 4-5, characters 2-15:
+4 | ..print_lines (List.map string_of_int [ 1; 2; 3; 4; 5 ])
+5 |   print_endline......
+Error: The function 'print_lines' has type string list -> unit
+       It is applied to too many arguments
+Line 4, characters 56-57:
+ |   print_lines (List.map string_of_int [ 1; 2; 3; 4; 5 ])
+                                                           ^
+  Hint: Did you forget a ';'?
+Line 5, characters 2-15:
+5 |   print_endline "foo"
+      ^^^^^^^^^^^^^
+  This extra argument is not expected.
+|}]
+
+type t = { f : int -> unit }
+
+let f (t : t) =
+  t.f 1 2
+[%%expect{|
+type t = { f : int -> unit; }
+Line 4, characters 2-9:
+4 |   t.f 1 2
+      ^^^^^^^
+Error: The function 't.f' has type int -> unit
+       It is applied to too many arguments
+Line 4, characters 7-8:
+4 |   t.f 1 2
+           ^
+  Hint: Did you forget a ';'?
+Line 4, characters 8-9:
+4 |   t.f 1 2
+            ^
+  This extra argument is not expected.
+|}]
+
+let f (t : < f : int -> unit >) =
+  t#f 1 2
+[%%expect{|
+Line 2, characters 2-9:
+2 |   t#f 1 2
+      ^^^^^^^
+Error: The function 't#f' has type int -> unit
+       It is applied to too many arguments
+Line 2, characters 7-8:
+2 |   t#f 1 2
+           ^
+  Hint: Did you forget a ';'?
+Line 2, characters 8-9:
+2 |   t#f 1 2
+            ^
+  This extra argument is not expected.
+|}]
+
+let () =
+  object
+    val a = fun _ -> ()
+    method b = a 1 2
+  end
+[%%expect{|
+Line 4, characters 15-20:
+4 |     method b = a 1 2
+                   ^^^^^
+Error: The function 'a' has type 'a -> unit
+       It is applied to too many arguments
+Line 4, characters 18-19:
+4 |     method b = a 1 2
+                      ^
+  Hint: Did you forget a ';'?
+Line 4, characters 19-20:
+4 |     method b = a 1 2
+                       ^
+  This extra argument is not expected.
+|}]

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -5644,16 +5644,20 @@ let report_this_function ppf funct =
 let report_too_many_arg_error ~funct ~func_ty ~previous_arg_loc
     ~extra_arg_loc loc =
   let open Location in
+  let cnum_offset off (pos : Lexing.position) =
+    { pos with pos_cnum = pos.pos_cnum + off }
+  in
   let app_loc =
     (* Span the application, including the extra argument. *)
     { loc_start = loc.loc_start;
       loc_end = extra_arg_loc.loc_end;
       loc_ghost = false }
   and tail_loc =
-    (* Possible location for a ';'. *)
-    let loc_start = previous_arg_loc.loc_end in
-    { loc_start;
-      loc_end = { loc_start with pos_cnum = loc_start.pos_cnum + 1 };
+    (* Possible location for a ';'. The location is widened to overlap the end
+       of the argument. *)
+    let arg_end = previous_arg_loc.loc_end in
+    { loc_start = cnum_offset ~-1 arg_end;
+      loc_end = cnum_offset ~+1 arg_end;
       loc_ghost = false }
   in
   let sub = [

--- a/typing/typecore.mli
+++ b/typing/typecore.mli
@@ -155,7 +155,11 @@ type error =
   | Expr_type_clash of
       Errortrace.unification_error * type_forcing_context option
       * Parsetree.expression_desc option
-  | Apply_non_function of type_expr
+  | Apply_non_function of {
+      func_ty : type_expr;
+      previous_arg_loc : Location.t;
+      extra_arg_loc : Location.t;
+    }
   | Apply_wrong_label of arg_label * type_expr * bool
   | Label_multiply_defined of string
   | Label_missing of Ident.t list

--- a/typing/typecore.mli
+++ b/typing/typecore.mli
@@ -156,6 +156,7 @@ type error =
       Errortrace.unification_error * type_forcing_context option
       * Parsetree.expression_desc option
   | Apply_non_function of {
+      funct : Typedtree.expression;
       func_ty : type_expr;
       previous_arg_loc : Location.t;
       extra_arg_loc : Location.t;

--- a/typing/typedtree.ml
+++ b/typing/typedtree.ml
@@ -844,3 +844,19 @@ let split_pattern pat =
         combine_opts (into cpat) exns1 exns2
   in
   split_pattern pat
+
+(* Expressions are considered nominal if they can be used as the subject of a
+   sentence or action. In practice, we consider that an expression is nominal
+   if they satisfy one of:
+   - Similar to an identifier: words separated by '.' or '#'.
+   - Do not contain spaces when printed.
+  *)
+let rec exp_is_nominal exp =
+  match exp.exp_desc with
+  | _ when exp.exp_attributes <> [] -> false
+  | Texp_ident _ | Texp_instvar _ | Texp_constant _
+  | Texp_variant (_, None)
+  | Texp_construct (_, _, []) ->
+      true
+  | Texp_field (parent, _, _) | Texp_send (parent, _) -> exp_is_nominal parent
+  | _ -> false

--- a/typing/typedtree.mli
+++ b/typing/typedtree.mli
@@ -823,3 +823,7 @@ val pat_bound_idents_full:
 (** Splits an or pattern into its value (left) and exception (right) parts. *)
 val split_pattern:
   computation general_pattern -> pattern option * pattern option
+
+(** Whether an expression looks nice as the subject of a sentence in a error
+    message. *)
+val exp_is_nominal : expression -> bool


### PR DESCRIPTION
The "applied to too many arguments" error message confuses me every time I see even though it often has a trivial to fix cause.
The message highlights the function but not the whole application, which can be useful to understand which argument is problematic and where I should add the suggested `;`.

This PR change the location of the main message to span the whole application and adds two sub-messages:
- Where to put the missing `;`, for which the location extends outside the range of the line.
- The extra argument, which helps understand whether it's really about a missing `;` or if I should remove an argument.

The multi-line highlighting is not easy to read, I have a suggestion in https://github.com/ocaml/ocaml/pull/11678

Before:

```
File "./test.ml", line 4, characters 2-13:
4 |   print_lines (List.map string_of_int [ 1; 2; 3; 4; 5 ])
      ^^^^^^^^^^^
Error: This function has type string list -> unit
       It is applied to too many arguments; maybe you forgot a `;'.
```

After:

```
File "./test.ml", lines 4-5, characters 2-15:
4 | ..print_lines (List.map string_of_int [ 1; 2; 3; 4; 5 ])
5 |   print_endline......
Error: This function has type string list -> unit
       It is applied to too many arguments
File "./test.ml", line 4, characters 56-57:
 |   print_lines (List.map string_of_int [ 1; 2; 3; 4; 5 ])
                                                           ^
  Maybe you forgot a ';'.
File "./test.ml", line 5, characters 2-15:
5 |   print_endline "foo"
      ^^^^^^^^^^^^^
  This argument is not expected.
```

