### PR TITLE
applied unused field/constructor to individual field/constructor

### DIFF
--- a/typing/env.ml
+++ b/typing/env.ml
@@ -1968,6 +1968,8 @@ and store_label ~check type_decl type_id lbl_id lbl env =
       if not (ty_name = "" || ty_name.[0] = '_' || name.[0] = '_')
       then !add_delayed_check_forward
           (fun () ->
+            let attrs = lbl.lbl_attributes in                                              
+            attrs |> List.iter (Builtin_attributes.warning_attribute) ;   
             Option.iter
               (fun complaint ->
                  if not (is_in_signature env) then


### PR DESCRIPTION
Fixes (#11235). I applied warning labels to individual unused fields/constructors by creating new scope that took the warnings into account. @Octachron please review🙂