### PR TITLE
Remove all ".0" revision numbers from `@since`, `@before` and `@after`

### DIFF
--- a/ocamldoc/odoc_info.mli
+++ b/ocamldoc/odoc_info.mli
@@ -90,7 +90,7 @@ type alert = Odoc_types.alert = {
 }
 
 (** Information in a special comment
-@before 3.12.0 \@before information was not present.
+@before 3.12 \@before information was not present.
 *)
 type info = Odoc_types.info = {
     i_desc : text option; (** The description text. *)

--- a/otherlibs/unix/unix.mli
+++ b/otherlibs/unix/unix.mli
@@ -152,7 +152,7 @@ val unsafe_environment : unit -> string array
     privileges.  See the documentation for {!unsafe_getenv} for more
     details.
 
-    @since 4.06.0 (4.12.0 in UnixLabels) *)
+    @since 4.06 (4.12 in UnixLabels) *)
 
 val getenv : string -> string
 (** Return the value associated to a variable in the process
@@ -174,7 +174,7 @@ val unsafe_getenv : string -> string
    like.
 
    @raise Not_found if the variable is unbound.
-   @since 4.06.0  *)
+   @since 4.06  *)
 
 val putenv : string -> string -> unit
 (** [putenv name value] sets the value associated to a
@@ -280,7 +280,7 @@ val _exit : int -> 'a
    process may flush them again later, resulting in duplicate
    output.
 
-   @since 4.12.0 *)
+   @since 4.12 *)
 
 val getpid : unit -> int
 (** Return the pid of the process. *)
@@ -355,7 +355,7 @@ val close : file_descr -> unit
 val fsync : file_descr -> unit
 (** Flush file buffers to disk.
 
-    @since 4.08.0 (4.12.0 in UnixLabels) *)
+    @since 4.08 (4.12 in UnixLabels) *)
 
 val read : file_descr -> bytes -> int -> int -> int
 (** [read fd buf pos len] reads [len] bytes from descriptor [fd],
@@ -377,13 +377,13 @@ val single_write : file_descr -> bytes -> int -> int -> int
 val write_substring : file_descr -> string -> int -> int -> int
 (** Same as {!write}, but take the data from a string instead of a byte
     sequence.
-    @since 4.02.0 *)
+    @since 4.02 *)
 
 val single_write_substring :
   file_descr -> string -> int -> int -> int
 (** Same as {!single_write}, but take the data from a string instead of
     a byte sequence.
-    @since 4.02.0 *)
+    @since 4.02 *)
 
 (** {1 Interfacing with the standard input/output library} *)
 
@@ -608,7 +608,7 @@ val map_file :
 
   [Invalid_argument] or [Failure] may be raised in cases where argument
   validation fails.
-  @since 4.06.0 *)
+  @since 4.06 *)
 
 (** {1 Operations on file names} *)
 
@@ -650,7 +650,7 @@ val realpath : string -> string
 (** [realpath p] is an absolute pathname for [p] obtained by resolving
     all extra [/] characters, relative path segments and symbolic links.
 
-    @since 4.13.0 *)
+    @since 4.13 *)
 
 (** {1 File permissions and ownership} *)
 
@@ -914,7 +914,7 @@ val open_process_args_in : string -> string array -> in_channel
 
     The new process has the same environment as the current process.
 
-    @since 4.08.0 *)
+    @since 4.08 *)
 
 val open_process_args_out : string -> string array -> out_channel
 (** Same as {!open_process_args_in}, but redirect the standard input of the new
@@ -923,7 +923,7 @@ val open_process_args_out : string -> string array -> out_channel
     buffered, hence be careful to call {!Stdlib.flush} at the right times to
     ensure correct synchronization.
 
-    @since 4.08.0 *)
+    @since 4.08 *)
 
 val open_process_args : string -> string array -> in_channel * out_channel
 (** Same as {!open_process_args_out}, but redirects both the standard input and
@@ -931,7 +931,7 @@ val open_process_args : string -> string array -> in_channel * out_channel
     channels.  The input channel is connected to the output of the program, and
     the output channel to the input of the program.
 
-    @since 4.08.0 *)
+    @since 4.08 *)
 
 val open_process_args_full :
   string -> string array -> string array ->
@@ -941,31 +941,31 @@ val open_process_args_full :
     connected respectively to the standard output, standard input, and standard
     error of the program.
 
-    @since 4.08.0 *)
+    @since 4.08 *)
 
 val process_in_pid : in_channel -> int
 (** Return the pid of a process opened via {!open_process_in} or
    {!open_process_args_in}.
 
-    @since 4.08.0 (4.12.0 in UnixLabels) *)
+    @since 4.08 (4.12 in UnixLabels) *)
 
 val process_out_pid : out_channel -> int
 (** Return the pid of a process opened via {!open_process_out} or
    {!open_process_args_out}.
 
-    @since 4.08.0 (4.12.0 in UnixLabels) *)
+    @since 4.08 (4.12 in UnixLabels) *)
 
 val process_pid : in_channel * out_channel -> int
 (** Return the pid of a process opened via {!open_process} or
    {!open_process_args}.
 
-    @since 4.08.0 (4.12.0 in UnixLabels) *)
+    @since 4.08 (4.12 in UnixLabels) *)
 
 val process_full_pid : in_channel * out_channel * in_channel -> int
 (** Return the pid of a process opened via {!open_process_full} or
    {!open_process_args_full}.
 
-    @since 4.08.0 (4.12.0 in UnixLabels) *)
+    @since 4.08 (4.12 in UnixLabels) *)
 
 val close_process_in : in_channel -> process_status
 (** Close channels opened by {!open_process_in},
@@ -1030,7 +1030,7 @@ val has_symlink : unit -> bool
    this indicates that the user not only has the SeCreateSymbolicLinkPrivilege
    but is also running elevated, if necessary. On other platforms, this is
    simply indicates that the symlink system call is available.
-   @since 4.03.0 *)
+   @since 4.03 *)
 
 val readlink : string -> string
 (** Read the contents of a symbolic link. *)
@@ -1216,7 +1216,7 @@ val sleepf : float -> unit
 (** Stop execution for the given number of seconds.  Like [sleep],
     but fractions of seconds are supported.
 
-    @since 4.03.0 (4.12.0 in UnixLabels) *)
+    @since 4.03 (4.12 in UnixLabels) *)
 
 val times : unit -> process_times
 (** Return the execution times of the process.
@@ -1397,7 +1397,7 @@ val inet6_addr_loopback : inet_addr
 
 val is_inet6_addr : inet_addr -> bool
 (** Whether the given [inet_addr] is an IPv6 address.
-    @since 4.12.0 *)
+    @since 4.12 *)
 
 (** {1 Sockets} *)
 
@@ -1512,7 +1512,7 @@ val send_substring :
   file_descr -> string -> int -> int -> msg_flag list -> int
 (** Same as [send], but take the data from a string instead of a byte
     sequence.
-    @since 4.02.0 *)
+    @since 4.02 *)
 
 val sendto :
   file_descr -> bytes -> int -> int -> msg_flag list ->
@@ -1524,7 +1524,7 @@ val sendto_substring :
   -> sockaddr -> int
 (** Same as [sendto], but take the data from a string instead of a
     byte sequence.
-    @since 4.02.0 *)
+    @since 4.02 *)
 
 
 

--- a/otherlibs/unix/unixLabels.mli
+++ b/otherlibs/unix/unixLabels.mli
@@ -152,7 +152,7 @@ val unsafe_environment : unit -> string array
     privileges.  See the documentation for {!unsafe_getenv} for more
     details.
 
-    @since 4.06.0 (4.12.0 in UnixLabels) *)
+    @since 4.06 (4.12 in UnixLabels) *)
 
 val getenv : string -> string
 (** Return the value associated to a variable in the process
@@ -174,7 +174,7 @@ val unsafe_getenv : string -> string
    like.
 
    @raise Not_found if the variable is unbound.
-   @since 4.06.0  *)
+   @since 4.06  *)
 
 val putenv : string -> string -> unit
 (** [putenv name value] sets the value associated to a
@@ -280,7 +280,7 @@ val _exit : int -> 'a
    process may flush them again later, resulting in duplicate
    output.
 
-   @since 4.12.0 *)
+   @since 4.12 *)
 
 val getpid : unit -> int
 (** Return the pid of the process. *)
@@ -355,7 +355,7 @@ val close : file_descr -> unit
 val fsync : file_descr -> unit
 (** Flush file buffers to disk.
 
-    @since 4.08.0 (4.12.0 in UnixLabels) *)
+    @since 4.08 (4.12 in UnixLabels) *)
 
 val read : file_descr -> buf:bytes -> pos:int -> len:int -> int
 (** [read fd ~buf ~pos ~len] reads [len] bytes from descriptor [fd],
@@ -377,13 +377,13 @@ val single_write : file_descr -> buf:bytes -> pos:int -> len:int -> int
 val write_substring : file_descr -> buf:string -> pos:int -> len:int -> int
 (** Same as {!write}, but take the data from a string instead of a byte
     sequence.
-    @since 4.02.0 *)
+    @since 4.02 *)
 
 val single_write_substring :
   file_descr -> buf:string -> pos:int -> len:int -> int
 (** Same as {!single_write}, but take the data from a string instead of
     a byte sequence.
-    @since 4.02.0 *)
+    @since 4.02 *)
 
 (** {1 Interfacing with the standard input/output library} *)
 
@@ -608,7 +608,7 @@ val map_file :
 
   [Invalid_argument] or [Failure] may be raised in cases where argument
   validation fails.
-  @since 4.06.0 *)
+  @since 4.06 *)
 
 (** {1 Operations on file names} *)
 
@@ -650,7 +650,7 @@ val realpath : string -> string
 (** [realpath p] is an absolute pathname for [p] obtained by resolving
     all extra [/] characters, relative path segments and symbolic links.
 
-    @since 4.13.0 *)
+    @since 4.13 *)
 
 (** {1 File permissions and ownership} *)
 
@@ -914,7 +914,7 @@ val open_process_args_in : string -> string array -> in_channel
 
     The new process has the same environment as the current process.
 
-    @since 4.08.0 *)
+    @since 4.08 *)
 
 val open_process_args_out : string -> string array -> out_channel
 (** Same as {!open_process_args_in}, but redirect the standard input of the new
@@ -923,7 +923,7 @@ val open_process_args_out : string -> string array -> out_channel
     buffered, hence be careful to call {!Stdlib.flush} at the right times to
     ensure correct synchronization.
 
-    @since 4.08.0 *)
+    @since 4.08 *)
 
 val open_process_args : string -> string array -> in_channel * out_channel
 (** Same as {!open_process_args_out}, but redirects both the standard input and
@@ -931,7 +931,7 @@ val open_process_args : string -> string array -> in_channel * out_channel
     channels.  The input channel is connected to the output of the program, and
     the output channel to the input of the program.
 
-    @since 4.08.0 *)
+    @since 4.08 *)
 
 val open_process_args_full :
   string -> string array -> string array ->
@@ -941,31 +941,31 @@ val open_process_args_full :
     connected respectively to the standard output, standard input, and standard
     error of the program.
 
-    @since 4.08.0 *)
+    @since 4.08 *)
 
 val process_in_pid : in_channel -> int
 (** Return the pid of a process opened via {!open_process_in} or
    {!open_process_args_in}.
 
-    @since 4.08.0 (4.12.0 in UnixLabels) *)
+    @since 4.08 (4.12 in UnixLabels) *)
 
 val process_out_pid : out_channel -> int
 (** Return the pid of a process opened via {!open_process_out} or
    {!open_process_args_out}.
 
-    @since 4.08.0 (4.12.0 in UnixLabels) *)
+    @since 4.08 (4.12 in UnixLabels) *)
 
 val process_pid : in_channel * out_channel -> int
 (** Return the pid of a process opened via {!open_process} or
    {!open_process_args}.
 
-    @since 4.08.0 (4.12.0 in UnixLabels) *)
+    @since 4.08 (4.12 in UnixLabels) *)
 
 val process_full_pid : in_channel * out_channel * in_channel -> int
 (** Return the pid of a process opened via {!open_process_full} or
    {!open_process_args_full}.
 
-    @since 4.08.0 (4.12.0 in UnixLabels) *)
+    @since 4.08 (4.12 in UnixLabels) *)
 
 val close_process_in : in_channel -> process_status
 (** Close channels opened by {!open_process_in},
@@ -1030,7 +1030,7 @@ val has_symlink : unit -> bool
    this indicates that the user not only has the SeCreateSymbolicLinkPrivilege
    but is also running elevated, if necessary. On other platforms, this is
    simply indicates that the symlink system call is available.
-   @since 4.03.0 *)
+   @since 4.03 *)
 
 val readlink : string -> string
 (** Read the contents of a symbolic link. *)
@@ -1216,7 +1216,7 @@ val sleepf : float -> unit
 (** Stop execution for the given number of seconds.  Like [sleep],
     but fractions of seconds are supported.
 
-    @since 4.03.0 (4.12.0 in UnixLabels) *)
+    @since 4.03 (4.12 in UnixLabels) *)
 
 val times : unit -> process_times
 (** Return the execution times of the process.
@@ -1397,7 +1397,7 @@ val inet6_addr_loopback : inet_addr
 
 val is_inet6_addr : inet_addr -> bool
 (** Whether the given [inet_addr] is an IPv6 address.
-    @since 4.12.0 *)
+    @since 4.12 *)
 
 (** {1 Sockets} *)
 
@@ -1512,7 +1512,7 @@ val send_substring :
   file_descr -> buf:string -> pos:int -> len:int -> mode:msg_flag list -> int
 (** Same as [send], but take the data from a string instead of a byte
     sequence.
-    @since 4.02.0 *)
+    @since 4.02 *)
 
 val sendto :
   file_descr -> buf:bytes -> pos:int -> len:int -> mode:msg_flag list ->
@@ -1524,7 +1524,7 @@ val sendto_substring :
   -> sockaddr -> int
 (** Same as [sendto], but take the data from a string instead of a
     byte sequence.
-    @since 4.02.0 *)
+    @since 4.02 *)
 
 
 

--- a/stdlib/arg.mli
+++ b/stdlib/arg.mli
@@ -143,7 +143,7 @@ val parse_dynamic :
     is to parse command lines of the form:
 -     command subcommand [options]
     where the list of options depends on the value of the subcommand argument.
-    @since 4.01.0
+    @since 4.01
 *)
 
 val parse_argv : ?current: int ref -> string array ->
@@ -164,7 +164,7 @@ val parse_argv_dynamic : ?current:int ref -> string array ->
 (** Same as {!Arg.parse_argv}, except that the [speclist] argument is a
     reference and may be updated during the parsing.
     See {!Arg.parse_dynamic}.
-    @since 4.01.0
+    @since 4.01
 *)
 
 val parse_and_expand_argv_dynamic : int ref -> string array ref ->
@@ -172,14 +172,14 @@ val parse_and_expand_argv_dynamic : int ref -> string array ref ->
 (** Same as {!Arg.parse_argv_dynamic}, except that the [argv] argument is a
     reference and may be updated during the parsing of [Expand] arguments.
     See {!Arg.parse_argv_dynamic}.
-    @since 4.05.0
+    @since 4.05
 *)
 
 val parse_expand:
   (key * spec * doc) list -> anon_fun -> usage_msg -> unit
 (** Same as {!Arg.parse}, except that the [Expand] arguments are allowed and
     the {!current} reference is not updated.
-    @since 4.05.0
+    @since 4.05
 *)
 
 exception Help of string
@@ -219,21 +219,21 @@ val current : int ref
 val read_arg: string -> string array
 (** [Arg.read_arg file] reads newline-terminated command line arguments from
     file [file].
-    @since 4.05.0 *)
+    @since 4.05 *)
 
 val read_arg0: string -> string array
 (** Identical to {!Arg.read_arg} but assumes null character terminated command
     line arguments.
-    @since 4.05.0 *)
+    @since 4.05 *)
 
 
 val write_arg: string -> string array -> unit
 (** [Arg.write_arg file args] writes the arguments [args] newline-terminated
     into the file [file]. If the any of the arguments in [args] contains a
     newline, use {!Arg.write_arg0} instead.
-    @since 4.05.0 *)
+    @since 4.05 *)
 
 val write_arg0: string -> string array -> unit
 (** Identical to {!Arg.write_arg} but uses the null character for terminator
     instead of newline.
-    @since 4.05.0 *)
+    @since 4.05 *)

--- a/stdlib/array.mli
+++ b/stdlib/array.mli
@@ -174,7 +174,7 @@ val fold_left_map :
   ('a -> 'b -> 'a * 'c) -> 'a -> 'b array -> 'a * 'c array
 (** [fold_left_map] is a combination of {!fold_left} and {!map} that threads an
     accumulator through calls to [f].
-    @since 4.13.0 *)
+    @since 4.13 *)
 
 val fold_right : ('b -> 'a -> 'a) -> 'b array -> 'a -> 'a
 (** [fold_right f a init] computes
@@ -189,7 +189,7 @@ val iter2 : ('a -> 'b -> unit) -> 'a array -> 'b array -> unit
 (** [iter2 f a b] applies function [f] to all the elements of [a]
    and [b].
    @raise Invalid_argument if the arrays are not the same size.
-   @since 4.03.0 (4.05.0 in ArrayLabels)
+   @since 4.03 (4.05 in ArrayLabels)
    *)
 
 val map2 : ('a -> 'b -> 'c) -> 'a array -> 'b array -> 'c array
@@ -197,7 +197,7 @@ val map2 : ('a -> 'b -> 'c) -> 'a array -> 'b array -> 'c array
    and [b], and builds an array with the results returned by [f]:
    [[| f a.(0) b.(0); ...; f a.(length a - 1) b.(length b - 1)|]].
    @raise Invalid_argument if the arrays are not the same size.
-   @since 4.03.0 (4.05.0 in ArrayLabels) *)
+   @since 4.03 (4.05 in ArrayLabels) *)
 
 
 (** {1 Array scanning} *)
@@ -206,60 +206,60 @@ val for_all : ('a -> bool) -> 'a array -> bool
 (** [for_all f [|a1; ...; an|]] checks if all elements
    of the array satisfy the predicate [f]. That is, it returns
    [(f a1) && (f a2) && ... && (f an)].
-   @since 4.03.0 *)
+   @since 4.03 *)
 
 val exists : ('a -> bool) -> 'a array -> bool
 (** [exists f [|a1; ...; an|]] checks if at least one element of
     the array satisfies the predicate [f]. That is, it returns
     [(f a1) || (f a2) || ... || (f an)].
-    @since 4.03.0 *)
+    @since 4.03 *)
 
 val for_all2 : ('a -> 'b -> bool) -> 'a array -> 'b array -> bool
 (** Same as {!for_all}, but for a two-argument predicate.
    @raise Invalid_argument if the two arrays have different lengths.
-   @since 4.11.0 *)
+   @since 4.11 *)
 
 val exists2 : ('a -> 'b -> bool) -> 'a array -> 'b array -> bool
 (** Same as {!exists}, but for a two-argument predicate.
    @raise Invalid_argument if the two arrays have different lengths.
-   @since 4.11.0 *)
+   @since 4.11 *)
 
 val mem : 'a -> 'a array -> bool
 (** [mem a set] is true if and only if [a] is structurally equal
     to an element of [l] (i.e. there is an [x] in [l] such that
     [compare a x = 0]).
-    @since 4.03.0 *)
+    @since 4.03 *)
 
 val memq : 'a -> 'a array -> bool
 (** Same as {!mem}, but uses physical equality
    instead of structural equality to compare list elements.
-   @since 4.03.0 *)
+   @since 4.03 *)
 
 val find_opt : ('a -> bool) -> 'a array -> 'a option
 (** [find_opt f a] returns the first element of the array [a] that satisfies
     the predicate [f], or [None] if there is no value that satisfies [f] in the
     array [a].
 
-    @since 4.13.0 *)
+    @since 4.13 *)
 
 val find_map : ('a -> 'b option) -> 'a array -> 'b option
 (** [find_map f a] applies [f] to the elements of [a] in order, and returns the
     first result of the form [Some v], or [None] if none exist.
 
-    @since 4.13.0 *)
+    @since 4.13 *)
 
 (** {1 Arrays of pairs} *)
 
 val split : ('a * 'b) array -> 'a array * 'b array
 (** [split [|(a1,b1); ...; (an,bn)|]] is [([|a1; ...; an|], [|b1; ...; bn|])].
 
-    @since 4.13.0 *)
+    @since 4.13 *)
 
 val combine : 'a array -> 'b array -> ('a * 'b) array
 (** [combine [|a1; ...; an|] [|b1; ...; bn|]] is [[|(a1,b1); ...; (an,bn)|]].
     Raise [Invalid_argument] if the two arrays have different lengths.
 
-    @since 4.13.0 *)
+    @since 4.13 *)
 
 (** {1 Sorting} *)
 

--- a/stdlib/arrayLabels.mli
+++ b/stdlib/arrayLabels.mli
@@ -174,7 +174,7 @@ val fold_left_map :
   f:('a -> 'b -> 'a * 'c) -> init:'a -> 'b array -> 'a * 'c array
 (** [fold_left_map] is a combination of {!fold_left} and {!map} that threads an
     accumulator through calls to [f].
-    @since 4.13.0 *)
+    @since 4.13 *)
 
 val fold_right : f:('b -> 'a -> 'a) -> 'b array -> init:'a -> 'a
 (** [fold_right ~f a ~init] computes
@@ -189,7 +189,7 @@ val iter2 : f:('a -> 'b -> unit) -> 'a array -> 'b array -> unit
 (** [iter2 ~f a b] applies function [f] to all the elements of [a]
    and [b].
    @raise Invalid_argument if the arrays are not the same size.
-   @since 4.03.0 (4.05.0 in ArrayLabels)
+   @since 4.03 (4.05 in ArrayLabels)
    *)
 
 val map2 : f:('a -> 'b -> 'c) -> 'a array -> 'b array -> 'c array
@@ -197,7 +197,7 @@ val map2 : f:('a -> 'b -> 'c) -> 'a array -> 'b array -> 'c array
    and [b], and builds an array with the results returned by [f]:
    [[| f a.(0) b.(0); ...; f a.(length a - 1) b.(length b - 1)|]].
    @raise Invalid_argument if the arrays are not the same size.
-   @since 4.03.0 (4.05.0 in ArrayLabels) *)
+   @since 4.03 (4.05 in ArrayLabels) *)
 
 
 (** {1 Array scanning} *)
@@ -206,60 +206,60 @@ val for_all : f:('a -> bool) -> 'a array -> bool
 (** [for_all ~f [|a1; ...; an|]] checks if all elements
    of the array satisfy the predicate [f]. That is, it returns
    [(f a1) && (f a2) && ... && (f an)].
-   @since 4.03.0 *)
+   @since 4.03 *)
 
 val exists : f:('a -> bool) -> 'a array -> bool
 (** [exists ~f [|a1; ...; an|]] checks if at least one element of
     the array satisfies the predicate [f]. That is, it returns
     [(f a1) || (f a2) || ... || (f an)].
-    @since 4.03.0 *)
+    @since 4.03 *)
 
 val for_all2 : f:('a -> 'b -> bool) -> 'a array -> 'b array -> bool
 (** Same as {!for_all}, but for a two-argument predicate.
    @raise Invalid_argument if the two arrays have different lengths.
-   @since 4.11.0 *)
+   @since 4.11 *)
 
 val exists2 : f:('a -> 'b -> bool) -> 'a array -> 'b array -> bool
 (** Same as {!exists}, but for a two-argument predicate.
    @raise Invalid_argument if the two arrays have different lengths.
-   @since 4.11.0 *)
+   @since 4.11 *)
 
 val mem : 'a -> set:'a array -> bool
 (** [mem a ~set] is true if and only if [a] is structurally equal
     to an element of [l] (i.e. there is an [x] in [l] such that
     [compare a x = 0]).
-    @since 4.03.0 *)
+    @since 4.03 *)
 
 val memq : 'a -> set:'a array -> bool
 (** Same as {!mem}, but uses physical equality
    instead of structural equality to compare list elements.
-   @since 4.03.0 *)
+   @since 4.03 *)
 
 val find_opt : f:('a -> bool) -> 'a array -> 'a option
 (** [find_opt ~f a] returns the first element of the array [a] that satisfies
     the predicate [f], or [None] if there is no value that satisfies [f] in the
     array [a].
 
-    @since 4.13.0 *)
+    @since 4.13 *)
 
 val find_map : f:('a -> 'b option) -> 'a array -> 'b option
 (** [find_map ~f a] applies [f] to the elements of [a] in order, and returns the
     first result of the form [Some v], or [None] if none exist.
 
-    @since 4.13.0 *)
+    @since 4.13 *)
 
 (** {1 Arrays of pairs} *)
 
 val split : ('a * 'b) array -> 'a array * 'b array
 (** [split [|(a1,b1); ...; (an,bn)|]] is [([|a1; ...; an|], [|b1; ...; bn|])].
 
-    @since 4.13.0 *)
+    @since 4.13 *)
 
 val combine : 'a array -> 'b array -> ('a * 'b) array
 (** [combine [|a1; ...; an|] [|b1; ...; bn|]] is [[|(a1,b1); ...; (an,bn)|]].
     Raise [Invalid_argument] if the two arrays have different lengths.
 
-    @since 4.13.0 *)
+    @since 4.13 *)
 
 (** {1 Sorting} *)
 

--- a/stdlib/bigarray.mli
+++ b/stdlib/bigarray.mli
@@ -87,7 +87,7 @@
    [*_elt] types defined below (defined with a single constructor instead
    of abstract types for technical injectivity reasons).
 
-   @since 4.07.0 Moved from otherlibs to stdlib.
+   @since 4.07 Moved from otherlibs to stdlib.
 *)
 
 type float32_elt = Float32_elt
@@ -205,7 +205,7 @@ val kind_size_in_bytes : ('a, 'b) kind -> int
 (** [kind_size_in_bytes k] is the number of bytes used to store
    an element of type [k].
 
-   @since 4.03.0 *)
+   @since 4.03 *)
 
 (** {1 Array layouts} *)
 
@@ -324,7 +324,7 @@ module Genarray :
       is not in the range 0 to 16 inclusive, or if one of the dimensions
       is negative.
 
-      @since 4.12.0 *)
+      @since 4.12 *)
 
   external num_dims: ('a, 'b, 'c) t -> int = "caml_ba_num_dims"
   (** Return the number of dimensions of the given Bigarray. *)
@@ -356,14 +356,14 @@ module Genarray :
       The dimensions are reversed, such that [get v [| a; b |]] in
       C layout becomes [get v [| b+1; a+1 |]] in Fortran layout.
 
-      @since 4.04.0
+      @since 4.04
   *)
 
   val size_in_bytes : ('a, 'b, 'c) t -> int
   (** [size_in_bytes a] is the number of elements in [a] multiplied
     by [a]'s {!kind_size_in_bytes}.
 
-    @since 4.03.0 *)
+    @since 4.03 *)
 
   external get: ('a, 'b, 'c) t -> int array -> 'a = "caml_ba_get_generic"
   (** Read an element of a generic Bigarray.
@@ -503,7 +503,7 @@ module Genarray :
    of zero-dimensional arrays that only contain a single scalar value.
    Statically knowing the number of dimensions of the array allows
    faster operations, and more precise static type-checking.
-   @since 4.05.0 *)
+   @since 4.05 *)
 module Array0 : sig
   type (!'a, !'b, !'c) t
   (** The type of zero-dimensional Bigarrays whose elements have
@@ -518,7 +518,7 @@ module Array0 : sig
   (** [Array0.init kind layout v] behaves like [Array0.create kind layout]
      except that the element is additionally initialized to the value [v].
 
-     @since 4.12.0 *)
+     @since 4.12 *)
 
   external kind: ('a, 'b, 'c) t -> ('a, 'b) kind = "caml_ba_kind"
   (** Return the kind of the given Bigarray. *)
@@ -532,7 +532,7 @@ module Array0 : sig
       is involved: the new array and the original array share the same
       storage space.
 
-      @since 4.06.0
+      @since 4.06
   *)
 
   val size_in_bytes : ('a, 'b, 'c) t -> int
@@ -593,7 +593,7 @@ module Array1 : sig
      the results of [f] applied to the indices of a new Bigarray whose
      layout is described by [kind], [layout] and [dim].
 
-     @since 4.12.0 *)
+     @since 4.12 *)
 
   external dim: ('a, 'b, 'c) t -> int = "%caml_ba_dim_1"
   (** Return the size (dimension) of the given one-dimensional
@@ -611,7 +611,7 @@ module Array1 : sig
       the same dimension as [a]). No copying of elements is involved: the
       new array and the original array share the same storage space.
 
-      @since 4.06.0
+      @since 4.06
   *)
 
 
@@ -619,7 +619,7 @@ module Array1 : sig
   (** [size_in_bytes a] is the number of elements in [a]
     multiplied by [a]'s {!kind_size_in_bytes}.
 
-    @since 4.03.0 *)
+    @since 4.03 *)
 
   external get: ('a, 'b, 'c) t -> int -> 'a = "%caml_ba_ref_1"
   (** [Array1.get a x], or alternatively [a.{x}],
@@ -646,7 +646,7 @@ module Array1 : sig
      Bigarray.  The integer parameter is the index of the scalar to
      extract.  See {!Bigarray.Genarray.slice_left} and
      {!Bigarray.Genarray.slice_right} for more details.
-     @since 4.05.0 *)
+     @since 4.05 *)
 
   external blit: ('a, 'b, 'c) t -> ('a, 'b, 'c) t -> unit
       = "caml_ba_blit"
@@ -708,7 +708,7 @@ module Array2 :
      the results of [f] applied to the indices of a new Bigarray whose
      layout is described by [kind], [layout], [dim1] and [dim2].
 
-     @since 4.12.0 *)
+     @since 4.12 *)
 
   external dim1: ('a, 'b, 'c) t -> int = "%caml_ba_dim_1"
   (** Return the first dimension of the given two-dimensional Bigarray. *)
@@ -730,7 +730,7 @@ module Array2 :
       The dimensions are reversed, such that [get v [| a; b |]] in
       C layout becomes [get v [| b+1; a+1 |]] in Fortran layout.
 
-      @since 4.06.0
+      @since 4.06
   *)
 
 
@@ -738,7 +738,7 @@ module Array2 :
   (** [size_in_bytes a] is the number of elements in [a]
     multiplied by [a]'s {!kind_size_in_bytes}.
 
-    @since 4.03.0 *)
+    @since 4.03 *)
 
   external get: ('a, 'b, 'c) t -> int -> int -> 'a = "%caml_ba_ref_2"
   (** [Array2.get a x y], also written [a.{x,y}],
@@ -841,7 +841,7 @@ module Array3 :
      the results of [f] applied to the indices of a new Bigarray whose
      layout is described by [kind], [layout], [dim1], [dim2] and [dim3].
 
-     @since 4.12.0 *)
+     @since 4.12 *)
 
   external dim1: ('a, 'b, 'c) t -> int = "%caml_ba_dim_1"
   (** Return the first dimension of the given three-dimensional Bigarray. *)
@@ -867,14 +867,14 @@ module Array3 :
       The dimensions are reversed, such that [get v [| a; b; c |]] in
       C layout becomes [get v [| c+1; b+1; a+1 |]] in Fortran layout.
 
-      @since 4.06.0
+      @since 4.06
   *)
 
   val size_in_bytes : ('a, 'b, 'c) t -> int
   (** [size_in_bytes a] is the number of elements in [a]
     multiplied by [a]'s {!kind_size_in_bytes}.
 
-    @since 4.03.0 *)
+    @since 4.03 *)
 
   external get: ('a, 'b, 'c) t -> int -> int -> int -> 'a = "%caml_ba_ref_3"
   (** [Array3.get a x y z], also written [a.{x,y,z}],
@@ -972,7 +972,7 @@ external genarray_of_array0 :
   ('a, 'b, 'c) Array0.t -> ('a, 'b, 'c) Genarray.t = "%identity"
 (** Return the generic Bigarray corresponding to the given zero-dimensional
     Bigarray.
-    @since 4.05.0 *)
+    @since 4.05 *)
 
 external genarray_of_array1 :
   ('a, 'b, 'c) Array1.t -> ('a, 'b, 'c) Genarray.t = "%identity"
@@ -994,7 +994,7 @@ val array0_of_genarray : ('a, 'b, 'c) Genarray.t -> ('a, 'b, 'c) Array0.t
    generic Bigarray.
    @raise Invalid_argument if the generic Bigarray
    does not have exactly zero dimension.
-   @since 4.05.0 *)
+   @since 4.05 *)
 
 val array1_of_genarray : ('a, 'b, 'c) Genarray.t -> ('a, 'b, 'c) Array1.t
 (** Return the one-dimensional Bigarray corresponding to the given
@@ -1036,7 +1036,7 @@ val reshape : ('a, 'b, 'c) Genarray.t -> int array -> ('a, 'b, 'c) Genarray.t
 val reshape_0 : ('a, 'b, 'c) Genarray.t -> ('a, 'b, 'c) Array0.t
 (** Specialized version of {!Bigarray.reshape} for reshaping to
    zero-dimensional arrays.
-   @since 4.05.0 *)
+   @since 4.05 *)
 
 val reshape_1 : ('a, 'b, 'c) Genarray.t -> int -> ('a, 'b, 'c) Array1.t
 (** Specialized version of {!Bigarray.reshape} for reshaping to

--- a/stdlib/bool.mli
+++ b/stdlib/bool.mli
@@ -72,11 +72,11 @@ val seeded_hash : int -> bool -> int
     {!Hashtbl.seeded_hash}. This function allows this module to be passed as
     argument to the functor {!Hashtbl.MakeSeeded}.
 
-    @since 5.1.0 *)
+    @since 5.1 *)
 
 val hash : bool -> int
 (** An unseeded hash function for booleans, with the same output value as
     {!Hashtbl.hash}. This function allows this module to be passed as argument
     to the functor {!Hashtbl.Make}.
 
-    @since 5.1.0 *)
+    @since 5.1 *)

--- a/stdlib/buffer.mli
+++ b/stdlib/buffer.mli
@@ -98,7 +98,7 @@ val truncate : t -> int -> unit
 (** [truncate b len] truncates the length of [b] to [len]
   Note: the internal byte sequence is not shortened.
   @raise Invalid_argument if [len < 0] or [len > length b].
-  @since 4.05.0 *)
+  @since 4.05 *)
 
 (** {1 Appending} *)
 
@@ -113,21 +113,21 @@ val add_utf_8_uchar : t -> Uchar.t -> unit
 (** [add_utf_8_uchar b u] appends the {{:https://tools.ietf.org/html/rfc3629}
     UTF-8} encoding of [u] at the end of buffer [b].
 
-    @since 4.06.0 *)
+    @since 4.06 *)
 
 val add_utf_16le_uchar : t -> Uchar.t -> unit
 (** [add_utf_16le_uchar b u] appends the
     {{:https://tools.ietf.org/html/rfc2781}UTF-16LE} encoding of [u]
     at the end of buffer [b].
 
-    @since 4.06.0 *)
+    @since 4.06 *)
 
 val add_utf_16be_uchar : t -> Uchar.t -> unit
 (** [add_utf_16be_uchar b u] appends the
     {{:https://tools.ietf.org/html/rfc2781}UTF-16BE} encoding of [u]
     at the end of buffer [b].
 
-    @since 4.06.0 *)
+    @since 4.06 *)
 
 val add_string : t -> string -> unit
 (** [add_string b s] appends the string [s] at the end of buffer [b]. *)

--- a/stdlib/bytes.mli
+++ b/stdlib/bytes.mli
@@ -50,7 +50,7 @@
    The labeled version of this module can be used as described in the
    {!StdLabels} module.
 
-   @since 4.02.0
+   @since 4.02
 
    *)
 
@@ -116,7 +116,7 @@ val extend : bytes -> int -> int -> bytes
     the corresponding side of [s].
     @raise Invalid_argument if the result length is negative or
     longer than {!Sys.max_string_length} bytes.
-    @since 4.05.0 in BytesLabels *)
+    @since 4.05 in BytesLabels *)
 
 val fill : bytes -> int -> int -> char -> unit
 (** [fill s pos len c] modifies [s] in place, replacing [len]
@@ -145,7 +145,7 @@ val blit_string :
     @raise Invalid_argument if [src_pos] and [len] do not
     designate a valid range of [src], or if [dst_pos] and [len]
     do not designate a valid range of [dst].
-    @since 4.05.0 in BytesLabels *)
+    @since 4.05 in BytesLabels *)
 
 val concat : bytes -> bytes list -> bytes
 (** [concat sep sl] concatenates the list of byte sequences [sl],
@@ -160,7 +160,7 @@ val cat : bytes -> bytes -> bytes
     as a new byte sequence.
     @raise Invalid_argument if the result is longer than
     {!Sys.max_string_length} bytes.
-    @since 4.05.0 in BytesLabels *)
+    @since 4.05 in BytesLabels *)
 
 val iter : (char -> unit) -> bytes -> unit
 (** [iter f s] applies function [f] in turn to all the bytes of [s].
@@ -186,22 +186,22 @@ val fold_left : ('a -> char -> 'a) -> 'a -> bytes -> 'a
 (** [fold_left f x s] computes
     [f (... (f (f x (get s 0)) (get s 1)) ...) (get s (n-1))],
     where [n] is the length of [s].
-    @since 4.13.0 *)
+    @since 4.13 *)
 
 val fold_right : (char -> 'a -> 'a) -> bytes -> 'a -> 'a
 (** [fold_right f s x] computes
     [f (get s 0) (f (get s 1) ( ... (f (get s (n-1)) x) ...))],
     where [n] is the length of [s].
-    @since 4.13.0 *)
+    @since 4.13 *)
 
 val for_all : (char -> bool) -> bytes -> bool
 (** [for_all p s] checks if all characters in [s] satisfy the predicate [p].
-    @since 4.13.0 *)
+    @since 4.13 *)
 
 val exists : (char -> bool) -> bytes -> bool
 (** [exists p s] checks if at least one character of [s] satisfies the predicate
     [p].
-    @since 4.13.0 *)
+    @since 4.13 *)
 
 val trim : bytes -> bytes
 (** Return a copy of the argument, without leading and trailing
@@ -284,22 +284,22 @@ val rcontains_from : bytes -> int -> char -> bool
 val uppercase_ascii : bytes -> bytes
 (** Return a copy of the argument, with all lowercase letters
    translated to uppercase, using the US-ASCII character set.
-   @since 4.03.0 (4.05.0 in BytesLabels) *)
+   @since 4.03 (4.05 in BytesLabels) *)
 
 val lowercase_ascii : bytes -> bytes
 (** Return a copy of the argument, with all uppercase letters
    translated to lowercase, using the US-ASCII character set.
-   @since 4.03.0 (4.05.0 in BytesLabels) *)
+   @since 4.03 (4.05 in BytesLabels) *)
 
 val capitalize_ascii : bytes -> bytes
 (** Return a copy of the argument, with the first character set to uppercase,
    using the US-ASCII character set.
-   @since 4.03.0 (4.05.0 in BytesLabels) *)
+   @since 4.03 (4.05 in BytesLabels) *)
 
 val uncapitalize_ascii : bytes -> bytes
 (** Return a copy of the argument, with the first character set to lowercase,
    using the US-ASCII character set.
-   @since 4.03.0 (4.05.0 in BytesLabels) *)
+   @since 4.03 (4.05 in BytesLabels) *)
 
 type t = bytes
 (** An alias for the type of byte sequences. *)
@@ -312,20 +312,20 @@ val compare: t -> t -> int
 
 val equal: t -> t -> bool
 (** The equality function for byte sequences.
-    @since 4.03.0 (4.05.0 in BytesLabels) *)
+    @since 4.03 (4.05 in BytesLabels) *)
 
 val starts_with :
   prefix (* comment thwarts tools/sync_stdlib_docs *) :bytes -> bytes -> bool
 (** [starts_with ][~prefix s] is [true] if and only if [s] starts with
     [prefix].
 
-    @since 4.13.0 *)
+    @since 4.13 *)
 
 val ends_with :
   suffix (* comment thwarts tools/sync_stdlib_docs *) :bytes -> bytes -> bool
 (** [ends_with ][~suffix s] is [true] if and only if [s] ends with [suffix].
 
-    @since 4.13.0 *)
+    @since 4.13 *)
 
 (** {1:unsafe Unsafe conversions (for advanced users)}
 
@@ -469,7 +469,7 @@ val split_on_char: char -> bytes -> bytes list
       (Bytes.split_on_char sep s) = s]).
     - No byte sequence in the result contains the [sep] character.
 
-    @since 4.13.0
+    @since 4.13
 *)
 
 (** {1 Iterators} *)

--- a/stdlib/bytesLabels.mli
+++ b/stdlib/bytesLabels.mli
@@ -50,7 +50,7 @@
    The labeled version of this module can be used as described in the
    {!StdLabels} module.
 
-   @since 4.02.0
+   @since 4.02
 
    *)
 
@@ -116,7 +116,7 @@ val extend : bytes -> left:int -> right:int -> bytes
     the corresponding side of [s].
     @raise Invalid_argument if the result length is negative or
     longer than {!Sys.max_string_length} bytes.
-    @since 4.05.0 in BytesLabels *)
+    @since 4.05 in BytesLabels *)
 
 val fill : bytes -> pos:int -> len:int -> char -> unit
 (** [fill s ~pos ~len c] modifies [s] in place, replacing [len]
@@ -145,7 +145,7 @@ val blit_string :
     @raise Invalid_argument if [src_pos] and [len] do not
     designate a valid range of [src], or if [dst_pos] and [len]
     do not designate a valid range of [dst].
-    @since 4.05.0 in BytesLabels *)
+    @since 4.05 in BytesLabels *)
 
 val concat : sep:bytes -> bytes list -> bytes
 (** [concat ~sep sl] concatenates the list of byte sequences [sl],
@@ -160,7 +160,7 @@ val cat : bytes -> bytes -> bytes
     as a new byte sequence.
     @raise Invalid_argument if the result is longer than
     {!Sys.max_string_length} bytes.
-    @since 4.05.0 in BytesLabels *)
+    @since 4.05 in BytesLabels *)
 
 val iter : f:(char -> unit) -> bytes -> unit
 (** [iter ~f s] applies function [f] in turn to all the bytes of [s].
@@ -186,22 +186,22 @@ val fold_left : f:('a -> char -> 'a) -> init:'a -> bytes -> 'a
 (** [fold_left f x s] computes
     [f (... (f (f x (get s 0)) (get s 1)) ...) (get s (n-1))],
     where [n] is the length of [s].
-    @since 4.13.0 *)
+    @since 4.13 *)
 
 val fold_right : f:(char -> 'a -> 'a) -> bytes -> init:'a -> 'a
 (** [fold_right f s x] computes
     [f (get s 0) (f (get s 1) ( ... (f (get s (n-1)) x) ...))],
     where [n] is the length of [s].
-    @since 4.13.0 *)
+    @since 4.13 *)
 
 val for_all : f:(char -> bool) -> bytes -> bool
 (** [for_all p s] checks if all characters in [s] satisfy the predicate [p].
-    @since 4.13.0 *)
+    @since 4.13 *)
 
 val exists : f:(char -> bool) -> bytes -> bool
 (** [exists p s] checks if at least one character of [s] satisfies the predicate
     [p].
-    @since 4.13.0 *)
+    @since 4.13 *)
 
 val trim : bytes -> bytes
 (** Return a copy of the argument, without leading and trailing
@@ -284,22 +284,22 @@ val rcontains_from : bytes -> int -> char -> bool
 val uppercase_ascii : bytes -> bytes
 (** Return a copy of the argument, with all lowercase letters
    translated to uppercase, using the US-ASCII character set.
-   @since 4.03.0 (4.05.0 in BytesLabels) *)
+   @since 4.03 (4.05 in BytesLabels) *)
 
 val lowercase_ascii : bytes -> bytes
 (** Return a copy of the argument, with all uppercase letters
    translated to lowercase, using the US-ASCII character set.
-   @since 4.03.0 (4.05.0 in BytesLabels) *)
+   @since 4.03 (4.05 in BytesLabels) *)
 
 val capitalize_ascii : bytes -> bytes
 (** Return a copy of the argument, with the first character set to uppercase,
    using the US-ASCII character set.
-   @since 4.03.0 (4.05.0 in BytesLabels) *)
+   @since 4.03 (4.05 in BytesLabels) *)
 
 val uncapitalize_ascii : bytes -> bytes
 (** Return a copy of the argument, with the first character set to lowercase,
    using the US-ASCII character set.
-   @since 4.03.0 (4.05.0 in BytesLabels) *)
+   @since 4.03 (4.05 in BytesLabels) *)
 
 type t = bytes
 (** An alias for the type of byte sequences. *)
@@ -312,20 +312,20 @@ val compare: t -> t -> int
 
 val equal: t -> t -> bool
 (** The equality function for byte sequences.
-    @since 4.03.0 (4.05.0 in BytesLabels) *)
+    @since 4.03 (4.05 in BytesLabels) *)
 
 val starts_with :
   prefix (* comment thwarts tools/sync_stdlib_docs *) :bytes -> bytes -> bool
 (** [starts_with ][~prefix s] is [true] if and only if [s] starts with
     [prefix].
 
-    @since 4.13.0 *)
+    @since 4.13 *)
 
 val ends_with :
   suffix (* comment thwarts tools/sync_stdlib_docs *) :bytes -> bytes -> bool
 (** [ends_with ][~suffix s] is [true] if and only if [s] ends with [suffix].
 
-    @since 4.13.0 *)
+    @since 4.13 *)
 
 (** {1:unsafe Unsafe conversions (for advanced users)}
 
@@ -469,7 +469,7 @@ val split_on_char: sep:char -> bytes -> bytes list
       (Bytes.split_on_char sep s) = s]).
     - No byte sequence in the result contains the [sep] character.
 
-    @since 4.13.0
+    @since 4.13
 *)
 
 (** {1 Iterators} *)

--- a/stdlib/char.mli
+++ b/stdlib/char.mli
@@ -33,12 +33,12 @@ val escaped : char -> string
 val lowercase_ascii : char -> char
 (** Convert the given character to its equivalent lowercase character,
    using the US-ASCII character set.
-   @since 4.03.0 *)
+   @since 4.03 *)
 
 val uppercase_ascii : char -> char
 (** Convert the given character to its equivalent uppercase character,
    using the US-ASCII character set.
-   @since 4.03.0 *)
+   @since 4.03 *)
 
 type t = char
 (** An alias for the type of characters. *)
@@ -51,21 +51,21 @@ val compare: t -> t -> int
 
 val equal: t -> t -> bool
 (** The equal function for chars.
-    @since 4.03.0 *)
+    @since 4.03 *)
 
 val seeded_hash : int -> t -> int
 (** A seeded hash function for characters, with the same output value as
     {!Hashtbl.seeded_hash}. This function allows this module to be passed as
     argument to the functor {!Hashtbl.MakeSeeded}.
 
-    @since 5.1.0 *)
+    @since 5.1 *)
 
 val hash : t -> int
 (** An unseeded hash function for characters, with the same output value as
     {!Hashtbl.hash}. This function allows this module to be passed as argument
     to the functor {!Hashtbl.Make}.
 
-    @since 5.1.0 *)
+    @since 5.1 *)
 
 (**/**)
 

--- a/stdlib/digest.mli
+++ b/stdlib/digest.mli
@@ -33,18 +33,18 @@ val compare : t -> t -> int
     shared with {!String.compare}. Along with the type [t], this
     function [compare] allows the module [Digest] to be passed as
     argument to the functors {!Set.Make} and {!Map.Make}.
-    @since 4.00.0 *)
+    @since 4.00 *)
 
 val equal : t -> t -> bool
 (** The equal function for 16-character digest.
-    @since 4.03.0 *)
+    @since 4.03 *)
 
 val string : string -> t
 (** Return the digest of the given string. *)
 
 val bytes : bytes -> t
 (** Return the digest of the given byte sequence.
-    @since 4.02.0 *)
+    @since 4.02 *)
 
 val substring : string -> int -> int -> t
 (** [Digest.substring s ofs len] returns the digest of the substring
@@ -53,7 +53,7 @@ val substring : string -> int -> int -> t
 val subbytes : bytes -> int -> int -> t
 (** [Digest.subbytes s ofs len] returns the digest of the subsequence
     of [s] starting at index [ofs] and containing [len] bytes.
-    @since 4.02.0 *)
+    @since 4.02 *)
 
 external channel : in_channel -> int -> t = "caml_md5_chan"
 (** If [len] is nonnegative, [Digest.channel ic len] reads [len]
@@ -81,4 +81,4 @@ val from_hex : string -> t
 (** Convert a hexadecimal representation back into the corresponding digest.
     @raise Invalid_argument if the argument is not exactly 32 hexadecimal
    characters.
-   @since 4.00.0 *)
+   @since 4.00 *)

--- a/stdlib/ephemeron.mli
+++ b/stdlib/ephemeron.mli
@@ -62,7 +62,7 @@
     Ephemerons are defined in a language agnostic way in this paper:
     B. Hayes, Ephemerons: A New Finalization Mechanism, OOPSLA'97
 
-    @since 4.03.0
+    @since 4.03
 *)
 
 module type S = sig

--- a/stdlib/filename.mli
+++ b/stdlib/filename.mli
@@ -123,7 +123,7 @@ val null : string
 (** [null] is ["/dev/null"] on POSIX and ["NUL"] on Windows. It represents a
     file on the OS that discards all writes and returns end of file on reads.
 
-    @since 4.10.0 *)
+    @since 4.10 *)
 
 val temp_file : ?temp_dir: string -> string -> string -> string
 (** [temp_file prefix suffix] returns the name of a
@@ -155,7 +155,7 @@ val open_temp_file :
    writable only by the file owner, [0o600]).
 
    @raise Sys_error if the file could not be opened.
-   @before 4.03.0 no ?perms optional argument
+   @before 4.03 no ?perms optional argument
    @before 3.11.2 no ?temp_dir optional argument
 *)
 
@@ -166,7 +166,7 @@ val get_temp_dir_name : unit -> string
     Under Windows, the value of the [TEMP] environment variable, or "."
     if the variable is not set.
     The temporary directory can be changed with {!Filename.set_temp_dir_name}.
-    @since 4.00.0
+    @since 4.00
 *)
 
 val set_temp_dir_name : string -> unit
@@ -174,7 +174,7 @@ val set_temp_dir_name : string -> unit
     and used by {!Filename.temp_file} and {!Filename.open_temp_file}.
     The temporary directory is a domain-local value which is inherited
     by child domains.
-    @since 4.00.0
+    @since 4.00
 *)
 
 val quote : string -> string
@@ -214,5 +214,5 @@ val quote_command :
     Under Win32, additional quoting is performed as required by the
     [cmd.exe] shell that is called by {!Sys.command}.
     @raise Failure if the command cannot be escaped on the current platform.
-    @since 4.10.0
+    @since 4.10
 *)

--- a/stdlib/float.mli
+++ b/stdlib/float.mli
@@ -35,20 +35,20 @@
     [1.0 /. infinity] is [0.0], basic arithmetic operations
     ([+.], [-.], [*.], [/.]) with [nan] as an argument return [nan], ...
 
-    @since 4.07.0
+    @since 4.07
 *)
 
 val zero : float
 (** The floating point 0.
-   @since 4.08.0 *)
+   @since 4.08 *)
 
 val one : float
 (** The floating-point 1.
-   @since 4.08.0 *)
+   @since 4.08 *)
 
 val minus_one : float
 (** The floating-point -1.
-   @since 4.08.0 *)
+   @since 4.08 *)
 
 external neg : float -> float = "%negfloat"
 (** Unary negation. *)
@@ -77,7 +77,7 @@ external fma : float -> float -> float -> float =
    Note: since software emulation of the fma is costly, make sure that you are
    using hardware fma support if performance matters.
 
-   @since 4.08.0 *)
+   @since 4.08 *)
 
 external rem : float -> float -> float = "caml_fmod_float" "fmod"
 [@@unboxed] [@@noalloc]
@@ -89,13 +89,13 @@ val succ : float -> float
 (** [succ x] returns the floating point number right after [x] i.e.,
    the smallest floating-point number greater than [x].  See also
    {!next_after}.
-   @since 4.08.0 *)
+   @since 4.08 *)
 
 val pred : float -> float
 (** [pred x] returns the floating-point number right before [x] i.e.,
    the greatest floating-point number smaller than [x].  See also
    {!next_after}.
-   @since 4.08.0 *)
+   @since 4.08 *)
 
 external abs : float -> float = "%absfloat"
 (** [abs f] returns the absolute value of [f]. *)
@@ -145,23 +145,23 @@ val is_finite : float -> bool
 (** [is_finite x] is [true] if and only if [x] is finite i.e., not infinite and
    not {!nan}.
 
-   @since 4.08.0 *)
+   @since 4.08 *)
 
 val is_infinite : float -> bool
 (** [is_infinite x] is [true] if and only if [x] is {!infinity} or
     {!neg_infinity}.
 
-   @since 4.08.0 *)
+   @since 4.08 *)
 
 val is_nan : float -> bool
 (** [is_nan x] is [true] if and only if [x] is not a number (see {!nan}).
 
-   @since 4.08.0 *)
+   @since 4.08 *)
 
 val is_integer : float -> bool
 (** [is_integer x] is [true] if and only if [x] is an integer.
 
-   @since 4.08.0 *)
+   @since 4.08 *)
 
 external of_int : int -> float = "%floatofint"
 (** Convert an integer to floating-point. *)
@@ -225,7 +225,7 @@ external cbrt : float -> float = "caml_cbrt_float" "caml_cbrt"
   [@@unboxed] [@@noalloc]
 (** Cube root.
 
-    @since 4.13.0
+    @since 4.13
 *)
 
 external exp : float -> float = "caml_exp_float" "exp" [@@unboxed] [@@noalloc]
@@ -235,7 +235,7 @@ external exp2 : float -> float = "caml_exp2_float" "caml_exp2"
   [@@unboxed] [@@noalloc]
 (** Base 2 exponential function.
 
-    @since 4.13.0
+    @since 4.13
 *)
 
 external log : float -> float = "caml_log_float" "log" [@@unboxed] [@@noalloc]
@@ -249,7 +249,7 @@ external log2 : float -> float = "caml_log2_float" "caml_log2"
   [@@unboxed] [@@noalloc]
 (** Base 2 logarithm.
 
-    @since 4.13.0
+    @since 4.13
 *)
 
 external expm1 : float -> float = "caml_expm1_float" "caml_expm1"
@@ -318,7 +318,7 @@ external acosh : float -> float = "caml_acosh_float" "caml_acosh"
     [[1.0, inf]].
     Result is in radians and is between [0.0] and [inf].
 
-    @since 4.13.0
+    @since 4.13
 *)
 
 external asinh : float -> float = "caml_asinh_float" "caml_asinh"
@@ -327,7 +327,7 @@ external asinh : float -> float = "caml_asinh_float" "caml_asinh"
     real line.
     Result is in radians.
 
-    @since 4.13.0
+    @since 4.13
 *)
 
 external atanh : float -> float = "caml_atanh_float" "caml_atanh"
@@ -336,7 +336,7 @@ external atanh : float -> float = "caml_atanh_float" "caml_atanh"
     [[-1.0, 1.0]].
     Result is in radians and ranges over the entire real line.
 
-    @since 4.13.0
+    @since 4.13
 *)
 
 external erf : float -> float = "caml_erf_float" "caml_erf"
@@ -344,7 +344,7 @@ external erf : float -> float = "caml_erf_float" "caml_erf"
 (** Error function.  The argument ranges over the entire real line.
     The result is always within [[-1.0, 1.0]].
 
-    @since 4.13.0
+    @since 4.13
 *)
 
 external erfc : float -> float = "caml_erfc_float" "caml_erfc"
@@ -353,7 +353,7 @@ external erfc : float -> float = "caml_erfc_float" "caml_erfc"
     The argument ranges over the entire real line.
     The result is always within [[-1.0, 1.0]].
 
-    @since 4.13.0
+    @since 4.13
 *)
 
 external trunc : float -> float = "caml_trunc_float" "caml_trunc"
@@ -361,7 +361,7 @@ external trunc : float -> float = "caml_trunc_float" "caml_trunc"
 (** [trunc x] rounds [x] to the nearest integer whose absolute value is
    less than or equal to [x].
 
-   @since 4.08.0 *)
+   @since 4.08 *)
 
 external round : float -> float = "caml_round_float" "caml_round"
                                     [@@unboxed] [@@noalloc]
@@ -373,7 +373,7 @@ external round : float -> float = "caml_round_float" "caml_round"
    On 64-bit mingw-w64, this function may be emulated owing to a bug in the
    C runtime library (CRT) on this platform.
 
-   @since 4.08.0 *)
+   @since 4.08 *)
 
 external ceil : float -> float = "caml_ceil_float" "ceil"
 [@@unboxed] [@@noalloc]
@@ -401,7 +401,7 @@ external next_after : float -> float -> float
    If [x] is the smallest denormalized positive number,
    [next_after x 0. = 0.]
 
-   @since 4.08.0 *)
+   @since 4.08 *)
 
 external copy_sign : float -> float -> float
   = "caml_copysign_float" "caml_copysign"
@@ -417,7 +417,7 @@ external sign_bit : (float [@unboxed]) -> bool
     For example [sign_bit 1.] and [signbit 0.] are [false] while
     [sign_bit (-1.)] and [sign_bit (-0.)] are [true].
 
-    @since 4.08.0 *)
+    @since 4.08 *)
 
 external frexp : float -> float * int = "caml_frexp_float"
 (** [frexp f] returns the pair of the significant
@@ -451,46 +451,46 @@ val min : t -> t -> t
 (** [min x y] returns the minimum of [x] and [y].  It returns [nan]
    when [x] or [y] is [nan].  Moreover [min (-0.) (+0.) = -0.]
 
-   @since 4.08.0 *)
+   @since 4.08 *)
 
 val max : float -> float -> float
 (** [max x y] returns the maximum of [x] and [y].  It returns [nan]
    when [x] or [y] is [nan].  Moreover [max (-0.) (+0.) = +0.]
 
-   @since 4.08.0 *)
+   @since 4.08 *)
 
 val min_max : float -> float -> float * float
 (** [min_max x y] is [(min x y, max x y)], just more efficient.
 
-   @since 4.08.0 *)
+   @since 4.08 *)
 
 val min_num : t -> t -> t
 (** [min_num x y] returns the minimum of [x] and [y] treating [nan] as
    missing values.  If both [x] and [y] are [nan], [nan] is returned.
    Moreover [min_num (-0.) (+0.) = -0.]
 
-   @since 4.08.0 *)
+   @since 4.08 *)
 
 val max_num : t -> t -> t
 (** [max_num x y] returns the maximum of [x] and [y] treating [nan] as
    missing values.  If both [x] and [y] are [nan] [nan] is returned.
    Moreover [max_num (-0.) (+0.) = +0.]
 
-   @since 4.08.0 *)
+   @since 4.08 *)
 
 val min_max_num : float -> float -> float * float
 (** [min_max_num x y] is [(min_num x y, max_num x y)], just more
    efficient.  Note that in particular [min_max_num x nan = (x, x)]
    and [min_max_num nan y = (y, y)].
 
-   @since 4.08.0 *)
+   @since 4.08 *)
 
 val seeded_hash : int -> t -> int
 (** A seeded hash function for floats, with the same output value as
     {!Hashtbl.seeded_hash}. This function allows this module to be passed as
     argument to the functor {!Hashtbl.MakeSeeded}.
 
-    @since 5.1.0 *)
+    @since 5.1 *)
 
 val hash : t -> int
 (** An unseeded hash function for floats, with the same output value as
@@ -500,7 +500,7 @@ val hash : t -> int
 module Array : sig
   type t = floatarray
   (** The type of float arrays with packed representation.
-      @since 4.08.0
+      @since 4.08
     *)
 
   val length : t -> int
@@ -722,7 +722,7 @@ end
 module ArrayLabels : sig
   type t = floatarray
   (** The type of float arrays with packed representation.
-      @since 4.08.0
+      @since 4.08
     *)
 
   val length : t -> int

--- a/stdlib/format.mli
+++ b/stdlib/format.mli
@@ -238,7 +238,7 @@ val print_string : string -> unit
 val pp_print_bytes : formatter -> bytes -> unit
 val print_bytes : bytes -> unit
 (** [pp_print_bytes ppf b] prints [b] in the current pretty-printing box.
-    @since 4.13.0
+    @since 4.13
 *)
 
 val pp_print_as : formatter -> int -> string -> unit
@@ -351,7 +351,7 @@ printf "@[<v 0>[@;<0 2>@[<v 0>a;@,b;@,c@]%t]@]@\n"
   (pp_print_custom_break ~fits:("", 0, "") ~breaks:(";", 0, ""))
    ]}
 
-  @since 4.08.0
+  @since 4.08
 *)
 
 val pp_force_newline : formatter -> unit -> unit
@@ -515,7 +515,7 @@ val safe_set_geometry : max_indent:int -> margin:int -> unit
    Outside of this domain, [pp_set_geometry] raises an invalid argument
    exception whereas [pp_safe_set_geometry] does nothing.
 
-   @since 4.08.0
+   @since 4.08
 *)
 
 (**
@@ -526,7 +526,7 @@ val safe_set_geometry : max_indent:int -> margin:int -> unit
    Raises an invalid argument exception if the returned geometry
    does not satisfy {!check_geometry}.
 
-   @since 4.11.0
+   @since 4.11
 *)
 val pp_update_geometry : formatter -> (geometry -> geometry) -> unit
 val update_geometry : (geometry -> geometry) -> unit
@@ -535,7 +535,7 @@ val pp_get_geometry: formatter -> unit -> geometry
 val get_geometry: unit -> geometry
 (** Return the current geometry of the formatter
 
-    @since 4.08.0
+    @since 4.08
 *)
 
 
@@ -727,7 +727,7 @@ type stag += RGB of {r:int;g:int;b:int}
   Tag-marking operations may be set on or off with {!set_mark_tags}.
   Tag-printing operations may be set on or off with {!set_print_tags}.
 
-  @since 4.08.0
+  @since 4.08
 *)
 
 type tag = string
@@ -736,7 +736,7 @@ type stag += String_tag of tag
     by explicitly using the constructor [String_tag] or by using the dedicated
     format syntax ["@{<s> ... @}"].
 
-    @since 4.08.0
+    @since 4.08
 *)
 
 val pp_open_stag : formatter -> stag -> unit
@@ -747,7 +747,7 @@ val open_stag : stag -> unit
   [t] as argument; then the opening tag marker for [t], as given by
   [mark_open_stag t], is written into the output device of the formatter.
 
-  @since 4.08.0
+  @since 4.08
 *)
 
 val pp_close_stag : formatter -> unit -> unit
@@ -758,7 +758,7 @@ val close_stag : unit -> unit
   output device of the formatter; then the [print_close_stag] tag-printing
   function of the formatter is called with [t] as argument.
 
-  @since 4.08.0
+  @since 4.08
 *)
 
 val pp_set_tags : formatter -> bool -> unit
@@ -834,7 +834,7 @@ type formatter_out_functions = {
   out_flush : unit -> unit;
   out_newline : unit -> unit;
   out_spaces : int -> unit;
-  out_indent : int -> unit;(** @since 4.06.0 *)
+  out_indent : int -> unit;(** @since 4.06 *)
 }
 (** The set of output functions specific to a formatter:
 - the [out_string] function performs all the pretty-printer string output.
@@ -858,7 +858,7 @@ type formatter_out_functions = {
 - field [out_newline] is equivalent to [out_string "\n" 0 1];
 - fields [out_spaces] and [out_indent] are equivalent to
   [out_string (String.make n ' ') 0 n].
-  @since 4.01.0
+  @since 4.01
 *)
 
 val pp_set_formatter_out_functions :
@@ -876,7 +876,7 @@ val set_formatter_out_functions : formatter_out_functions -> unit
   Reasonable defaults for functions [out_spaces] and [out_newline] are
   respectively [out_funs.out_string (String.make n ' ') 0 n] and
   [out_funs.out_string "\n" 0 1].
-  @since 4.01.0
+  @since 4.01
 *)
 
 val pp_get_formatter_out_functions :
@@ -885,7 +885,7 @@ val get_formatter_out_functions : unit -> formatter_out_functions
 (** Return the current output functions of the pretty-printer,
   including line splitting and indentation functions. Useful to record the
   current setting and restore it afterwards.
-  @since 4.01.0
+  @since 4.01
 *)
 
 (** {1:tagsmeaning Redefining semantic tag operations} *)
@@ -903,7 +903,7 @@ type formatter_stag_functions = {
   [print] versions are the 'tag-printing' functions that can perform
   regular printing when a tag is closed or opened.
 
-  @since 4.08.0
+  @since 4.08
 *)
 
 val pp_set_formatter_stag_functions :
@@ -925,7 +925,7 @@ val set_formatter_stag_functions : formatter_stag_functions -> unit
   are called at tag opening and tag closing time, to output regular material
   in the pretty-printer queue.
 
-  @since 4.08.0
+  @since 4.08
 *)
 
 val pp_get_formatter_stag_functions :
@@ -934,7 +934,7 @@ val get_formatter_stag_functions : unit -> formatter_stag_functions
 (** Return the current semantic tag operation functions of the standard
     pretty-printer.
 
-    @since 4.08.0 *)
+    @since 4.08 *)
 
 (** {1:formatter Defining formatters}
 
@@ -1058,7 +1058,7 @@ val formatter_of_out_functions :
   See definition of type {!formatter_out_functions} for the meaning of argument
   [out_funs].
 
-  @since 4.06.0
+  @since 4.06
 *)
 
 
@@ -1095,34 +1095,34 @@ type symbolic_output_item =
   | Output_indent of int
   (** [Output_indent i]: symbolic indentation of size [i] *)
 (** Items produced by symbolic pretty-printers
-    @since 4.06.0
+    @since 4.06
 *)
 
 type symbolic_output_buffer
 (**
   The output buffer of a symbolic pretty-printer.
 
-  @since 4.06.0
+  @since 4.06
 *)
 
 val make_symbolic_output_buffer : unit -> symbolic_output_buffer
 (** [make_symbolic_output_buffer ()] returns a fresh buffer for
   symbolic output.
 
-  @since 4.06.0
+  @since 4.06
 *)
 
 val clear_symbolic_output_buffer : symbolic_output_buffer -> unit
 (** [clear_symbolic_output_buffer sob] resets buffer [sob].
 
-  @since 4.06.0
+  @since 4.06
 *)
 
 val get_symbolic_output_buffer :
   symbolic_output_buffer -> symbolic_output_item list
 (** [get_symbolic_output_buffer sob] returns the contents of buffer [sob].
 
-  @since 4.06.0
+  @since 4.06
 *)
 
 val flush_symbolic_output_buffer :
@@ -1133,21 +1133,21 @@ val flush_symbolic_output_buffer :
   [let items = get_symbolic_output_buffer sob in
    clear_symbolic_output_buffer sob; items]
 
-  @since 4.06.0
+  @since 4.06
 *)
 
 val add_symbolic_output_item :
   symbolic_output_buffer -> symbolic_output_item -> unit
 (** [add_symbolic_output_item sob itm] adds item [itm] to buffer [sob].
 
-  @since 4.06.0
+  @since 4.06
 *)
 
 val formatter_of_symbolic_output_buffer : symbolic_output_buffer -> formatter
 (** [formatter_of_symbolic_output_buffer sob] returns a symbolic formatter
   that outputs to [symbolic_output_buffer] [sob].
 
-  @since 4.06.0
+  @since 4.06
 *)
 
 (** {1 Convenience formatting functions.} *)
@@ -1160,7 +1160,7 @@ val pp_print_iter :
   [iter] over a collection [v] of values using [pp_v]. Iterations are
   separated by [pp_sep] (defaults to {!pp_print_cut}).
 
-  @since 5.1.0
+  @since 5.1
 *)
 
 val pp_print_list:
@@ -1171,7 +1171,7 @@ val pp_print_list:
   between items ([pp_sep] defaults to {!pp_print_cut}).
   Does nothing on empty lists.
 
-  @since 4.02.0
+  @since 4.02
 *)
 
 val pp_print_array:
@@ -1186,7 +1186,7 @@ val pp_print_array:
   may not be what is expected because [Format] can delay the printing.
   This can be avoided by flushing [ppf].
 
-  @since 5.1.0
+  @since 5.1
 *)
 
 val pp_print_seq:
@@ -1206,7 +1206,7 @@ val pp_print_text : formatter -> string -> unit
 (** [pp_print_text ppf s] prints [s] with spaces and newlines respectively
   printed using {!pp_print_space} and {!pp_force_newline}.
 
-  @since 4.02.0
+  @since 4.02
 *)
 
 val pp_print_option :
@@ -1364,7 +1364,7 @@ val asprintf : ('a, formatter, unit, string) format4 -> 'a
   The type of [asprintf] is general enough to interact nicely with [%a]
   conversions.
 
-  @since 4.01.0
+  @since 4.01
 *)
 
 val dprintf :
@@ -1386,7 +1386,7 @@ val dprintf :
   Format.printf "@[<v>%t@]" t
 ]}
 
-  @since 4.08.0
+  @since 4.08
 *)
 
 
@@ -1394,7 +1394,7 @@ val ifprintf : formatter -> ('a, formatter, unit) format -> 'a
 (** Same as [fprintf] above, but does not print anything.
   Useful to ignore some material when conditionally printing.
 
-  @since 3.10.0
+  @since 3.10
 *)
 
 (** Formatted Pretty-Printing with continuations. *)
@@ -1411,7 +1411,7 @@ val kdprintf :
 (** Same as {!dprintf} above, but instead of returning immediately,
   passes the suspended printer to its first argument at the end of printing.
 
-  @since 4.08.0
+  @since 4.08
 *)
 
 val ikfprintf :
@@ -1420,7 +1420,7 @@ val ikfprintf :
 (** Same as [kfprintf] above, but does not print anything.
   Useful to ignore some material when conditionally printing.
 
-  @since 3.12.0
+  @since 3.12
 *)
 
 val ksprintf : (string -> 'a) -> ('b, unit, string, 'a) format4 -> 'b

--- a/stdlib/gc.mli
+++ b/stdlib/gc.mli
@@ -86,12 +86,12 @@ type stat =
 
     stack_size: int;
     (** Current size of the stack, in words.
-        @since 3.12.0 *)
+        @since 3.12 *)
 
     forced_major_collections: int;
     (** Number of forced full major collections completed since the program
         was started.
-        @since 4.12.0 *)
+        @since 4.12 *)
 }
 (** The memory management counters are returned in a [stat] record. These
    counters give values for the whole program.
@@ -191,14 +191,14 @@ type control =
 
         Default: 2.
 
-        @since 3.11.0 *)
+        @since 3.11 *)
 
     window_size : int;
     (** The size of the window used by the major GC for smoothing
         out variations in its workload. This is an integer between
         1 and 50.
         Default: 1.
-        @since 4.03.0 *)
+        @since 4.03 *)
 
     custom_major_ratio : int;
     (** Target ratio of floating garbage to major heap size for
@@ -211,7 +211,7 @@ type control =
         Note: this only applies to values allocated with
         [caml_alloc_custom_mem] (e.g. bigarrays).
         Default: 44.
-        @since 4.08.0 *)
+        @since 4.08 *)
 
     custom_minor_ratio : int;
     (** Bound on floating garbage for out-of-heap memory held by
@@ -221,7 +221,7 @@ type control =
         Note: this only applies to values allocated with
         [caml_alloc_custom_mem] (e.g. bigarrays).
         Default: 100.
-        @since 4.08.0 *)
+        @since 4.08 *)
 
     custom_minor_max_size : int;
     (** Maximum amount of out-of-heap memory for each custom value
@@ -232,7 +232,7 @@ type control =
         Note: this only applies to values allocated with
         [caml_alloc_custom_mem] (e.g. bigarrays).
         Default: 8192 bytes.
-        @since 4.08.0 *)
+        @since 4.08 *)
   }
 (** The GC parameters are given as a [control] record.  Note that
     these parameters can also be initialised by setting the
@@ -310,7 +310,7 @@ external get_minor_free : unit -> int = "caml_get_minor_free"
 (** Return the current size of the free space inside the minor heap of this
    domain.
 
-    @since 4.03.0 *)
+    @since 4.03 *)
 
 val finalise : ('a -> unit) -> 'a -> unit
 (** [finalise f v] registers [f] as a finalisation function for [v].

--- a/stdlib/hashtbl.mli
+++ b/stdlib/hashtbl.mli
@@ -84,7 +84,7 @@ val create : ?random: (* thwart tools/sync_stdlib_docs *) bool ->
    either programmatically by calling {!randomize} or by
    setting the [R] flag in the [OCAMLRUNPARAM] environment variable.
 
-   @before 4.00.0 the [~random] parameter was not present and all
+   @before 4.00 the [~random] parameter was not present and all
    hash tables were created in non-randomized mode. *)
 
 val clear : ('a, 'b) t -> unit
@@ -94,7 +94,7 @@ val clear : ('a, 'b) t -> unit
 val reset : ('a, 'b) t -> unit
 (** Empty a hash table and shrink the size of the bucket table
     to its initial size.
-    @since 4.00.0 *)
+    @since 4.00 *)
 
 val copy : ('a, 'b) t -> ('a, 'b) t
 (** Return a copy of the given hashtable. *)
@@ -170,7 +170,7 @@ val filter_map_inplace: ('a -> 'b -> 'b option) -> ('a, 'b) t ->
     to [new_val].
 
     Other comments for {!iter} apply as well.
-    @since 4.03.0 *)
+    @since 4.03 *)
 
 val fold : ('a -> 'b -> 'c -> 'c) -> ('a, 'b) t -> 'c -> 'c
 (** [Hashtbl.fold f tbl init] computes
@@ -217,12 +217,12 @@ val randomize : unit -> unit
     This is intentional.  Non-randomized hash tables can still be
     created using [Hashtbl.create ~random:false].
 
-    @since 4.00.0 *)
+    @since 4.00 *)
 
 val is_randomized : unit -> bool
 (** Return [true] if the tables are currently created in randomized mode
     by default, [false] otherwise.
-    @since 4.03.0 *)
+    @since 4.03 *)
 
 val rebuild : ?random (* thwart tools/sync_stdlib_docs *) :bool ->
     ('a, 'b) t -> ('a, 'b) t
@@ -239,9 +239,9 @@ val rebuild : ?random (* thwart tools/sync_stdlib_docs *) :bool ->
     to produce a hash table for the current version of the {!Hashtbl}
     module.
 
-    @since 4.12.0 *)
+    @since 4.12 *)
 
-(** @since 4.00.0 *)
+(** @since 4.00 *)
 type statistics = {
   num_bindings: int;
     (** Number of bindings present in the table.
@@ -260,7 +260,7 @@ val stats : ('a, 'b) t -> statistics
 (** [Hashtbl.stats tbl] returns statistics about the table [tbl]:
    number of buckets, size of the biggest bucket, distribution of
    buckets by size.
-   @since 4.00.0 *)
+   @since 4.00 *)
 
 (** {1 Hash tables and Sequences} *)
 
@@ -359,14 +359,14 @@ module type S =
     type !'a t
     val create : int -> 'a t
     val clear : 'a t -> unit
-    val reset : 'a t -> unit (** @since 4.00.0 *)
+    val reset : 'a t -> unit (** @since 4.00 *)
 
     val copy : 'a t -> 'a t
     val add : 'a t -> key -> 'a -> unit
     val remove : 'a t -> key -> unit
     val find : 'a t -> key -> 'a
     val find_opt : 'a t -> key -> 'a option
-    (** @since 4.05.0 *)
+    (** @since 4.05 *)
 
     val find_all : 'a t -> key -> 'a list
     val replace : 'a t -> key -> 'a -> unit
@@ -374,11 +374,11 @@ module type S =
     val iter : (key -> 'a -> unit) -> 'a t -> unit
     val filter_map_inplace: (key -> 'a -> 'a option) -> 'a t ->
       unit
-    (** @since 4.03.0 *)
+    (** @since 4.03 *)
 
     val fold : (key -> 'a -> 'b -> 'b) -> 'a t -> 'b -> 'b
     val length : 'a t -> int
-    val stats: 'a t -> statistics (** @since 4.00.0 *)
+    val stats: 'a t -> statistics (** @since 4.00 *)
 
     val to_seq : 'a t -> (key * 'a) Seq.t
     (** @since 4.07 *)
@@ -428,7 +428,7 @@ module type SeededHashedType =
           {!Hashtbl.seeded_hash} below. *)
   end
 (** The input signature of the functor {!MakeSeeded}.
-    @since 4.00.0 *)
+    @since 4.00 *)
 
 module type SeededS =
   sig
@@ -442,7 +442,7 @@ module type SeededS =
     val add : 'a t -> key -> 'a -> unit
     val remove : 'a t -> key -> unit
     val find : 'a t -> key -> 'a
-    val find_opt : 'a t -> key -> 'a option (** @since 4.05.0 *)
+    val find_opt : 'a t -> key -> 'a option (** @since 4.05 *)
 
     val find_all : 'a t -> key -> 'a list
     val replace : 'a t -> key -> 'a -> unit
@@ -450,7 +450,7 @@ module type SeededS =
     val iter : (key -> 'a -> unit) -> 'a t -> unit
     val filter_map_inplace: (key -> 'a -> 'a option) -> 'a t ->
       unit
-    (** @since 4.03.0 *)
+    (** @since 4.03 *)
 
     val fold : (key -> 'a -> 'b -> 'b) -> 'a t -> 'b -> 'b
     val length : 'a t -> int
@@ -475,7 +475,7 @@ module type SeededS =
     (** @since 4.07 *)
   end
 (** The output signature of the functor {!MakeSeeded}.
-    @since 4.00.0 *)
+    @since 4.00 *)
 
 module MakeSeeded (H : SeededHashedType) : SeededS with type key = H.t
 (** Functor building an implementation of the hashtable structure.
@@ -489,7 +489,7 @@ module MakeSeeded (H : SeededHashedType) : SeededS with type key = H.t
     result structure supports the [~random] optional parameter
     and returns randomized hash tables if [~random:true] is passed
     or if randomization is globally on (see {!Hashtbl.randomize}).
-    @since 4.00.0 *)
+    @since 4.00 *)
 
 
 (** {1 The polymorphic hash functions} *)
@@ -504,7 +504,7 @@ val hash : 'a -> int
 val seeded_hash : int -> 'a -> int
 (** A variant of {!hash} that is further parameterized by
    an integer seed.
-   @since 4.00.0 *)
+   @since 4.00 *)
 
 val hash_param : int -> int -> 'a -> int
 (** [Hashtbl.hash_param meaningful total x] computes a hash value for [x],
@@ -529,7 +529,7 @@ val seeded_hash_param : int -> int -> int -> 'a -> int
 (** A variant of {!hash_param} that is further parameterized by
    an integer seed.  Usage:
    [Hashtbl.seeded_hash_param meaningful total seed x].
-   @since 4.00.0 *)
+   @since 4.00 *)
 
 (** {1:examples Examples}
 

--- a/stdlib/in_channel.mli
+++ b/stdlib/in_channel.mli
@@ -15,7 +15,7 @@
 
 (** Input channels.
 
-    @since 4.14.0 *)
+    @since 4.14 *)
 
 type t = in_channel
 (** The type of input channel. *)
@@ -164,4 +164,4 @@ val isatty : t -> bool
 (** [isatty ic] is [true] if [ic] refers to a terminal or console window,
     [false] otherwise.
 
-    @since 5.1.0 *)
+    @since 5.1 *)

--- a/stdlib/int.mli
+++ b/stdlib/int.mli
@@ -110,12 +110,12 @@ val compare : int -> int -> int
 
 val min : int -> int -> int
 (** Return the smaller of the two arguments.
-    @since 4.13.0
+    @since 4.13
 *)
 
 val max : int -> int -> int
 (** Return the greater of the two arguments.
-    @since 4.13.0
+    @since 4.13
  *)
 
 (** {1:convert Converting} *)
@@ -158,11 +158,11 @@ val seeded_hash : int -> int -> int
     {!Hashtbl.seeded_hash}. This function allows this module to be passed as
     argument to the functor {!Hashtbl.MakeSeeded}.
 
-    @since 5.1.0 *)
+    @since 5.1 *)
 
 val hash : int -> int
 (** An unseeded hash function for ints, with the same output value as
     {!Hashtbl.hash}. This function allows this module to be passed as argument
     to the functor {!Hashtbl.Make}.
 
-    @since 5.1.0 *)
+    @since 5.1 *)

--- a/stdlib/int32.mli
+++ b/stdlib/int32.mli
@@ -65,7 +65,7 @@ val unsigned_div : int32 -> int32 -> int32
 (** Same as {!div}, except that arguments and result are interpreted as {e
     unsigned} 32-bit integers.
 
-    @since 4.08.0 *)
+    @since 4.08 *)
 
 external rem : int32 -> int32 -> int32 = "%int32_mod"
 (** Integer remainder.  If [y] is not zero, the result
@@ -77,7 +77,7 @@ val unsigned_rem : int32 -> int32 -> int32
 (** Same as {!rem}, except that arguments and result are interpreted as {e
     unsigned} 32-bit integers.
 
-    @since 4.08.0 *)
+    @since 4.08 *)
 
 val succ : int32 -> int32
 (** Successor.  [Int32.succ x] is [Int32.add x Int32.one]. *)
@@ -141,7 +141,7 @@ val unsigned_to_int : int32 -> int option
     Returns [None] if the unsigned value of the argument cannot fit into an
     [int].
 
-    @since 4.08.0 *)
+    @since 4.08 *)
 
 external of_float : float -> int32
   = "caml_int32_of_float" "caml_int32_of_float_unboxed"
@@ -211,20 +211,20 @@ val unsigned_compare: t -> t -> int
 (** Same as {!compare}, except that arguments are interpreted as {e unsigned}
     32-bit integers.
 
-    @since 4.08.0 *)
+    @since 4.08 *)
 
 val equal: t -> t -> bool
 (** The equal function for int32s.
-    @since 4.03.0 *)
+    @since 4.03 *)
 
 val min: t -> t -> t
 (** Return the smaller of the two arguments.
-    @since 4.13.0
+    @since 4.13
 *)
 
 val max: t -> t -> t
 (** Return the greater of the two arguments.
-    @since 4.13.0
+    @since 4.13
  *)
 
 val seeded_hash : int -> t -> int
@@ -232,11 +232,11 @@ val seeded_hash : int -> t -> int
     {!Hashtbl.seeded_hash}. This function allows this module to be passed as
     argument to the functor {!Hashtbl.MakeSeeded}.
 
-    @since 5.1.0 *)
+    @since 5.1 *)
 
 val hash : t -> int
 (** An unseeded hash function for 32-bit ints, with the same output value as
     {!Hashtbl.hash}. This function allows this module to be passed as argument
     to the functor {!Hashtbl.Make}.
 
-    @since 5.1.0 *)
+    @since 5.1 *)

--- a/stdlib/int64.mli
+++ b/stdlib/int64.mli
@@ -65,7 +65,7 @@ val unsigned_div : int64 -> int64 -> int64
 (** Same as {!div}, except that arguments and result are interpreted as {e
     unsigned} 64-bit integers.
 
-    @since 4.08.0 *)
+    @since 4.08 *)
 
 external rem : int64 -> int64 -> int64 = "%int64_mod"
 (** Integer remainder.  If [y] is not zero, the result
@@ -77,7 +77,7 @@ val unsigned_rem : int64 -> int64 -> int64
 (** Same as {!rem}, except that arguments and result are interpreted as {e
     unsigned} 64-bit integers.
 
-    @since 4.08.0 *)
+    @since 4.08 *)
 
 val succ : int64 -> int64
 (** Successor.  [Int64.succ x] is [Int64.add x Int64.one]. *)
@@ -140,7 +140,7 @@ val unsigned_to_int : int64 -> int option
     Returns [None] if the unsigned value of the argument cannot fit into an
     [int].
 
-    @since 4.08.0 *)
+    @since 4.08 *)
 
 external of_float : float -> int64
   = "caml_int64_of_float" "caml_int64_of_float_unboxed"
@@ -230,20 +230,20 @@ val unsigned_compare: t -> t -> int
 (** Same as {!compare}, except that arguments are interpreted as {e unsigned}
     64-bit integers.
 
-    @since 4.08.0 *)
+    @since 4.08 *)
 
 val equal: t -> t -> bool
 (** The equal function for int64s.
-    @since 4.03.0 *)
+    @since 4.03 *)
 
 val min: t -> t -> t
 (** Return the smaller of the two arguments.
-    @since 4.13.0
+    @since 4.13
 *)
 
 val max: t -> t -> t
 (** Return the greater of the two arguments.
-    @since 4.13.0
+    @since 4.13
  *)
 
 val seeded_hash : int -> t -> int
@@ -251,11 +251,11 @@ val seeded_hash : int -> t -> int
     {!Hashtbl.seeded_hash}. This function allows this module to be passed as
     argument to the functor {!Hashtbl.MakeSeeded}.
 
-    @since 5.1.0 *)
+    @since 5.1 *)
 
 val hash : t -> int
 (** An unseeded hash function for 64-bit ints, with the same output value as
     {!Hashtbl.hash}. This function allows this module to be passed as argument
     to the functor {!Hashtbl.Make}.
 
-    @since 5.1.0 *)
+    @since 5.1 *)

--- a/stdlib/lazy.mli
+++ b/stdlib/lazy.mli
@@ -79,7 +79,7 @@ val map : ('a -> 'b) -> 'a t -> 'b t
 
     It is equivalent to [lazy (f (Lazy.force x))].
 
-    @since 4.13.0
+    @since 4.13
 *)
 
 (** {1 Reasoning on already-forced suspensions} *)
@@ -87,14 +87,14 @@ val map : ('a -> 'b) -> 'a t -> 'b t
 val is_val : 'a t -> bool
 (** [is_val x] returns [true] if [x] has already been forced and
     did not raise an exception.
-    @since 4.00.0 *)
+    @since 4.00 *)
 
 val from_val : 'a -> 'a t
 (** [from_val v] evaluates [v] first (as any function would) and returns
     an already-forced suspension of its result.
     It is the same as [let x = v in lazy x], but uses dynamic tests
     to optimize suspension creation in some cases.
-    @since 4.00.0 *)
+    @since 4.00 *)
 
 val map_val : ('a -> 'b) -> 'a t -> 'b t
 (** [map_val f x] applies [f] directly if [x] is already forced,
@@ -110,7 +110,7 @@ val map_val : ('a -> 'b) -> 'a t -> 'b t
    If [map_val f x] does not raise an exception, then
    [is_val (map_val f x)] is equal to [is_val x].
 
-    @since 4.13.0 *)
+    @since 4.13 *)
 
 
 (** {1 Advanced}
@@ -125,7 +125,7 @@ val from_fun : (unit -> 'a) -> 'a t
     In particular it is always less efficient to write
     [from_fun (fun () -> expr)] than [lazy expr].
 
-    @since 4.00.0 *)
+    @since 4.00 *)
 
 val force_val : 'a t -> 'a
 (** [force_val x] forces the suspension [x] and returns its result.  If [x]

--- a/stdlib/lexing.mli
+++ b/stdlib/lexing.mli
@@ -175,7 +175,7 @@ val new_line : lexbuf -> unit
     of a new line.  You can call this function in the semantic action
     of the rule that matches the end-of-line character.  The function
     does nothing when position tracking is disabled.
-    @since 3.11.0
+    @since 3.11
 *)
 
 (** {1 Miscellaneous functions} *)

--- a/stdlib/list.mli
+++ b/stdlib/list.mli
@@ -47,19 +47,19 @@ val compare_lengths : 'a list -> 'b list -> int
 (** Compare the lengths of two lists. [compare_lengths l1 l2] is
    equivalent to [compare (length l1) (length l2)], except that
    the computation stops after reaching the end of the shortest list.
-   @since 4.05.0
+   @since 4.05
  *)
 
 val compare_length_with : 'a list -> int -> int
 (** Compare the length of a list to an integer. [compare_length_with l len] is
    equivalent to [compare (length l) len], except that the computation stops
    after at most [len] iterations on the list.
-   @since 4.05.0
+   @since 4.05
  *)
 
 val cons : 'a -> 'a list -> 'a list
 (** [cons x xs] is [x :: xs]
-    @since 4.03.0 (4.05.0 in ListLabels)
+    @since 4.03 (4.05 in ListLabels)
  *)
 
 val hd : 'a list -> 'a
@@ -93,7 +93,7 @@ val rev : 'a list -> 'a list
 val init : int -> (int -> 'a) -> 'a list
 (** [init len f] is [[f 0; f 1; ...; f (len-1)]], evaluated left to right.
     @raise Invalid_argument if [len < 0].
-    @since 4.06.0
+    @since 4.06
  *)
 
 val append : 'a list -> 'a list -> 'a list
@@ -134,7 +134,7 @@ val equal : ('a -> 'a -> bool) -> 'a list -> 'a list -> bool
     function is costly, you may want to check {!compare_lengths}
     first.
 
-    @since 4.12.0
+    @since 4.12
 *)
 
 val compare : ('a -> 'a -> int) -> 'a list -> 'a list -> int
@@ -150,7 +150,7 @@ val compare : ('a -> 'a -> int) -> 'a list -> 'a list -> int
     Note: the [cmp] function will be called even if the lists have
     different lengths.
 
-    @since 4.12.0
+    @since 4.12
 *)
 
 (** {1 Iterators} *)
@@ -166,7 +166,7 @@ val iteri : (int -> 'a -> unit) -> 'a list -> unit
 (** Same as {!iter}, but the function is applied to the index of
    the element as first argument (counting from 0), and the element
    itself as second argument.
-   @since 4.00.0
+   @since 4.00
  *)
 
 val map : ('a -> 'b) -> 'a list -> 'b list
@@ -179,7 +179,7 @@ val mapi : (int -> 'a -> 'b) -> 'a list -> 'b list
 (** Same as {!map}, but the function is applied to the index of
    the element as first argument (counting from 0), and the element
    itself as second argument.
-   @since 4.00.0
+   @since 4.00
  *)
 
 val rev_map : ('a -> 'b) -> 'a list -> 'b list
@@ -191,20 +191,20 @@ val filter_map : ('a -> 'b option) -> 'a list -> 'b list
 (** [filter_map f l] applies [f] to every element of [l], filters
     out the [None] elements and returns the list of the arguments of
     the [Some] elements.
-    @since 4.08.0
+    @since 4.08
  *)
 
 val concat_map : ('a -> 'b list) -> 'a list -> 'b list
 (** [concat_map f l] gives the same result as
     {!concat}[ (]{!map}[ f l)]. Tail-recursive.
-    @since 4.10.0
+    @since 4.10
 *)
 
 val fold_left_map :
   ('a -> 'b -> 'a * 'c) -> 'a -> 'b list -> 'a * 'c list
 (** [fold_left_map] is  a combination of [fold_left] and [map] that threads an
     accumulator through calls to [f].
-    @since 4.11.0
+    @since 4.11
 *)
 
 val fold_left : ('a -> 'b -> 'a) -> 'a -> 'b list -> 'a
@@ -319,7 +319,7 @@ val find_map : ('a -> 'b option) -> 'a list -> 'b option
 (** [find_map f l] applies [f] to the elements of [l] in order,
     and returns the first result of the form [Some v], or [None]
     if none exist.
-    @since 4.10.0
+    @since 4.10
 *)
 
 val filter : ('a -> bool) -> 'a list -> 'a list
@@ -336,7 +336,7 @@ val filteri : (int -> 'a -> bool) -> 'a list -> 'a list
 (** Same as {!filter}, but the predicate is applied to the index of
    the element as first argument (counting from 0), and the element
    itself as second argument.
-   @since 4.11.0
+   @since 4.11
 *)
 
 val partition : ('a -> bool) -> 'a list -> 'a list * 'a list
@@ -359,7 +359,7 @@ val partition_map : ('a -> ('b, 'c) Either.t) -> 'a list -> 'b list * 'c list
     In particular, [partition_map (fun x -> if f x then Left x else Right x) l]
     is equivalent to [partition f l].
 
-    @since 4.12.0
+    @since 4.12
 *)
 
 
@@ -393,7 +393,7 @@ val assq : 'a -> ('a * 'b) list -> 'b
 val assq_opt : 'a -> ('a * 'b) list -> 'b option
 (** Same as {!assoc_opt}, but uses physical equality instead of
    structural equality to compare keys.
-   @since 4.05.0
+   @since 4.05
  *)
 
 val mem_assoc : 'a -> ('a * 'b) list -> bool
@@ -471,7 +471,7 @@ val fast_sort : ('a -> 'a -> int) -> 'a list -> 'a list
 
 val sort_uniq : ('a -> 'a -> int) -> 'a list -> 'a list
 (** Same as {!sort}, but also remove duplicates.
-    @since 4.02.0 (4.03.0 in ListLabels)
+    @since 4.02 (4.03 in ListLabels)
  *)
 
 val merge : ('a -> 'a -> int) -> 'a list -> 'a list -> 'a list

--- a/stdlib/listLabels.mli
+++ b/stdlib/listLabels.mli
@@ -47,19 +47,19 @@ val compare_lengths : 'a list -> 'b list -> int
 (** Compare the lengths of two lists. [compare_lengths l1 l2] is
    equivalent to [compare (length l1) (length l2)], except that
    the computation stops after reaching the end of the shortest list.
-   @since 4.05.0
+   @since 4.05
  *)
 
 val compare_length_with : 'a list -> len:int -> int
 (** Compare the length of a list to an integer. [compare_length_with l len] is
    equivalent to [compare (length l) len], except that the computation stops
    after at most [len] iterations on the list.
-   @since 4.05.0
+   @since 4.05
  *)
 
 val cons : 'a -> 'a list -> 'a list
 (** [cons x xs] is [x :: xs]
-    @since 4.03.0 (4.05.0 in ListLabels)
+    @since 4.03 (4.05 in ListLabels)
  *)
 
 val hd : 'a list -> 'a
@@ -93,7 +93,7 @@ val rev : 'a list -> 'a list
 val init : len:int -> f:(int -> 'a) -> 'a list
 (** [init ~len ~f] is [[f 0; f 1; ...; f (len-1)]], evaluated left to right.
     @raise Invalid_argument if [len < 0].
-    @since 4.06.0
+    @since 4.06
  *)
 
 val append : 'a list -> 'a list -> 'a list
@@ -134,7 +134,7 @@ val equal : eq:('a -> 'a -> bool) -> 'a list -> 'a list -> bool
     function is costly, you may want to check {!compare_lengths}
     first.
 
-    @since 4.12.0
+    @since 4.12
 *)
 
 val compare : cmp:('a -> 'a -> int) -> 'a list -> 'a list -> int
@@ -150,7 +150,7 @@ val compare : cmp:('a -> 'a -> int) -> 'a list -> 'a list -> int
     Note: the [cmp] function will be called even if the lists have
     different lengths.
 
-    @since 4.12.0
+    @since 4.12
 *)
 
 (** {1 Iterators} *)
@@ -166,7 +166,7 @@ val iteri : f:(int -> 'a -> unit) -> 'a list -> unit
 (** Same as {!iter}, but the function is applied to the index of
    the element as first argument (counting from 0), and the element
    itself as second argument.
-   @since 4.00.0
+   @since 4.00
  *)
 
 val map : f:('a -> 'b) -> 'a list -> 'b list
@@ -179,7 +179,7 @@ val mapi : f:(int -> 'a -> 'b) -> 'a list -> 'b list
 (** Same as {!map}, but the function is applied to the index of
    the element as first argument (counting from 0), and the element
    itself as second argument.
-   @since 4.00.0
+   @since 4.00
  *)
 
 val rev_map : f:('a -> 'b) -> 'a list -> 'b list
@@ -191,20 +191,20 @@ val filter_map : f:('a -> 'b option) -> 'a list -> 'b list
 (** [filter_map ~f l] applies [f] to every element of [l], filters
     out the [None] elements and returns the list of the arguments of
     the [Some] elements.
-    @since 4.08.0
+    @since 4.08
  *)
 
 val concat_map : f:('a -> 'b list) -> 'a list -> 'b list
 (** [concat_map ~f l] gives the same result as
     {!concat}[ (]{!map}[ f l)]. Tail-recursive.
-    @since 4.10.0
+    @since 4.10
 *)
 
 val fold_left_map :
   f:('a -> 'b -> 'a * 'c) -> init:'a -> 'b list -> 'a * 'c list
 (** [fold_left_map] is  a combination of [fold_left] and [map] that threads an
     accumulator through calls to [f].
-    @since 4.11.0
+    @since 4.11
 *)
 
 val fold_left : f:('a -> 'b -> 'a) -> init:'a -> 'b list -> 'a
@@ -319,7 +319,7 @@ val find_map : f:('a -> 'b option) -> 'a list -> 'b option
 (** [find_map ~f l] applies [f] to the elements of [l] in order,
     and returns the first result of the form [Some v], or [None]
     if none exist.
-    @since 4.10.0
+    @since 4.10
 *)
 
 val filter : f:('a -> bool) -> 'a list -> 'a list
@@ -336,7 +336,7 @@ val filteri : f:(int -> 'a -> bool) -> 'a list -> 'a list
 (** Same as {!filter}, but the predicate is applied to the index of
    the element as first argument (counting from 0), and the element
    itself as second argument.
-   @since 4.11.0
+   @since 4.11
 *)
 
 val partition : f:('a -> bool) -> 'a list -> 'a list * 'a list
@@ -359,7 +359,7 @@ val partition_map : f:('a -> ('b, 'c) Either.t) -> 'a list -> 'b list * 'c list
     In particular, [partition_map (fun x -> if f x then Left x else Right x) l]
     is equivalent to [partition f l].
 
-    @since 4.12.0
+    @since 4.12
 *)
 
 
@@ -393,7 +393,7 @@ val assq : 'a -> ('a * 'b) list -> 'b
 val assq_opt : 'a -> ('a * 'b) list -> 'b option
 (** Same as {!assoc_opt}, but uses physical equality instead of
    structural equality to compare keys.
-   @since 4.05.0
+   @since 4.05
  *)
 
 val mem_assoc : 'a -> map:('a * 'b) list -> bool
@@ -471,7 +471,7 @@ val fast_sort : cmp:('a -> 'a -> int) -> 'a list -> 'a list
 
 val sort_uniq : cmp:('a -> 'a -> int) -> 'a list -> 'a list
 (** Same as {!sort}, but also remove duplicates.
-    @since 4.02.0 (4.03.0 in ListLabels)
+    @since 4.02 (4.03 in ListLabels)
  *)
 
 val merge : cmp:('a -> 'a -> int) -> 'a list -> 'a list -> 'a list

--- a/stdlib/map.mli
+++ b/stdlib/map.mli
@@ -89,7 +89,7 @@ module type S =
     (** [add_to_list key data m] is [m] with [key] mapped to [l] such
         that [l] is [data :: Map.find key m] if [key] was bound in
         [m] and [[v]] otherwise.
-        @since 5.1.0 *)
+        @since 5.1 *)
 
     val update: key -> ('a option -> 'a option) -> 'a t -> 'a t
     (** [update key f m] returns a map containing the same bindings as
@@ -101,12 +101,12 @@ module type S =
         bound in [m] to a value that is physically equal to [z], [m]
         is returned unchanged (the result of the function is then
         physically equal to [m]).
-        @since 4.06.0 *)
+        @since 4.06 *)
 
     val singleton: key -> 'a -> 'a t
     (** [singleton x y] returns the one-element map that contains a binding
         [y] for [x].
-        @since 3.12.0 *)
+        @since 3.12 *)
 
     val remove: key -> 'a t -> 'a t
     (** [remove x m] returns a map containing the same bindings as
@@ -124,7 +124,7 @@ module type S =
         In terms of the [find_opt] operation, we have
         [find_opt x (merge f m1 m2) = f x (find_opt x m1) (find_opt x m2)]
         for any key [x], provided that [f x None None = None].
-        @since 3.12.0 *)
+        @since 3.12 *)
 
     val union: (key -> 'a -> 'a -> 'a option) -> 'a t -> 'a t -> 'a t
     (** [union f m1 m2] computes a map whose keys are a subset of the keys
@@ -137,11 +137,11 @@ module type S =
         - [f' _key None (Some v) = Some v]
         - [f' key (Some v1) (Some v2) = f key v1 v2]
 
-        @since 4.03.0 *)
+        @since 4.03 *)
 
     val cardinal: 'a t -> int
     (** Return the number of bindings of a map.
-        @since 3.12.0 *)
+        @since 3.12 *)
 
     (** {1:bindings Bindings} *)
 
@@ -150,13 +150,13 @@ module type S =
         The returned list is sorted in increasing order of keys with respect
         to the ordering [Ord.compare], where [Ord] is the argument
         given to {!Map.Make}.
-        @since 3.12.0 *)
+        @since 3.12 *)
 
     val min_binding: 'a t -> (key * 'a)
     (** Return the binding with the smallest key in a given map
         (with respect to the [Ord.compare] ordering), or raise
         [Not_found] if the map is empty.
-        @since 3.12.0 *)
+        @since 3.12 *)
 
     val min_binding_opt: 'a t -> (key * 'a) option
     (** Return the binding with the smallest key in the given map
@@ -167,7 +167,7 @@ module type S =
     val max_binding: 'a t -> (key * 'a)
     (** Same as {!min_binding}, but returns the binding with
         the largest key in the given map.
-        @since 3.12.0 *)
+        @since 3.12 *)
 
     val max_binding_opt: 'a t -> (key * 'a) option
     (** Same as {!min_binding_opt}, but returns the binding with
@@ -178,7 +178,7 @@ module type S =
     (** Return one binding of the given map, or raise [Not_found] if
         the map is empty. Which binding is chosen is unspecified,
         but equal bindings will be chosen for equal maps.
-        @since 3.12.0 *)
+        @since 3.12 *)
 
     val choose_opt: 'a t -> (key * 'a) option
     (** Return one binding of the given map, or [None] if
@@ -259,7 +259,7 @@ module type S =
         that satisfy predicate [p]. If every binding in [m] satisfies [f],
         [m] is returned unchanged (the result of the function is then
         physically equal to [m])
-        @since 3.12.0
+        @since 3.12
         @before 4.03 Physical equality was not ensured. *)
 
     val filter_map: (key -> 'a -> 'b option) -> 'a t -> 'b t
@@ -279,14 +279,14 @@ module type S =
         drops all bindings of [m] whose value is an empty list, and pops
         the first element of each value that is non-empty.
 
-        @since 4.11.0 *)
+        @since 4.11 *)
 
     val partition: (key -> 'a -> bool) -> 'a t -> 'a t * 'a t
     (** [partition f m] returns a pair of maps [(m1, m2)], where
         [m1] contains all the bindings of [m] that satisfy the
         predicate [f], and [m2] is the map with all the bindings of
         [m] that do not satisfy [f].
-        @since 3.12.0 *)
+        @since 3.12 *)
 
     val split: key -> 'a t -> 'a t * 'a option * 'a t
     (** [split x m] returns a triple [(l, data, r)], where
@@ -296,7 +296,7 @@ module type S =
         is strictly greater than [x];
           [data] is [None] if [m] contains no binding for [x],
           or [Some v] if [m] binds [v] to [x].
-        @since 3.12.0 *)
+        @since 3.12 *)
 
     (** {1:predicates Predicates and comparisons} *)
 
@@ -320,24 +320,24 @@ module type S =
     val for_all: (key -> 'a -> bool) -> 'a t -> bool
     (** [for_all f m] checks if all the bindings of the map
         satisfy the predicate [f].
-        @since 3.12.0 *)
+        @since 3.12 *)
 
     val exists: (key -> 'a -> bool) -> 'a t -> bool
     (** [exists f m] checks if at least one binding of the map
         satisfies the predicate [f].
-        @since 3.12.0 *)
+        @since 3.12 *)
 
     (** {1:converting Converting} *)
 
     val to_list : 'a t -> (key * 'a) list
     (** [to_list m] is {!bindings}[ m].
-        @since 5.1.0 *)
+        @since 5.1 *)
 
     val of_list : (key * 'a) list -> 'a t
     (** [of_list bs] adds the bindings of [bs] to the empty map,
         in list order (if a key is bound twice in [bs] the last one
         takes over).
-        @since 5.1.0 *)
+        @since 5.1 *)
 
     val to_seq : 'a t -> (key * 'a) Seq.t
     (** Iterate on the whole map, in ascending order of keys

--- a/stdlib/marshal.mli
+++ b/stdlib/marshal.mli
@@ -118,7 +118,7 @@ external to_bytes :
    the representation of [v].
    The [flags] argument has the same meaning as for
    {!Marshal.to_channel}.
-   @since 4.02.0 *)
+   @since 4.02 *)
 
 external to_string :
   'a -> extern_flags list -> string = "caml_output_value_to_string"
@@ -151,7 +151,7 @@ val from_bytes : bytes -> int -> 'a
    representation is not read from a channel, but taken from
    the byte sequence [buff], starting at position [ofs].
    The byte sequence is not mutated.
-   @since 4.02.0 *)
+   @since 4.02 *)
 
 val from_string : string -> int -> 'a
 (** Same as [from_bytes] but take a string as argument instead of a

--- a/stdlib/moreLabels.mli
+++ b/stdlib/moreLabels.mli
@@ -101,7 +101,7 @@ module Hashtbl : sig
      either programmatically by calling {!randomize} or by
      setting the [R] flag in the [OCAMLRUNPARAM] environment variable.
 
-     @before 4.00.0 the [~random] parameter was not present and all
+     @before 4.00 the [~random] parameter was not present and all
      hash tables were created in non-randomized mode. *)
 
   val clear : ('a, 'b) t -> unit
@@ -111,7 +111,7 @@ module Hashtbl : sig
   val reset : ('a, 'b) t -> unit
   (** Empty a hash table and shrink the size of the bucket table
       to its initial size.
-      @since 4.00.0 *)
+      @since 4.00 *)
 
   val copy : ('a, 'b) t -> ('a, 'b) t
   (** Return a copy of the given hashtable. *)
@@ -187,7 +187,7 @@ module Hashtbl : sig
       to [new_val].
 
       Other comments for {!iter} apply as well.
-      @since 4.03.0 *)
+      @since 4.03 *)
 
   val fold : f:(key:'a -> data:'b -> 'c -> 'c) -> ('a, 'b) t -> init:'c -> 'c
   (** [Hashtbl.fold ~f tbl ~init] computes
@@ -234,12 +234,12 @@ module Hashtbl : sig
       This is intentional.  Non-randomized hash tables can still be
       created using [Hashtbl.create ~random:false].
 
-      @since 4.00.0 *)
+      @since 4.00 *)
 
   val is_randomized : unit -> bool
   (** Return [true] if the tables are currently created in randomized mode
       by default, [false] otherwise.
-      @since 4.03.0 *)
+      @since 4.03 *)
 
   val rebuild : ?random (* thwart tools/sync_stdlib_docs *) :bool ->
       ('a, 'b) t -> ('a, 'b) t
@@ -256,9 +256,9 @@ module Hashtbl : sig
       to produce a hash table for the current version of the {!Hashtbl}
       module.
 
-      @since 4.12.0 *)
+      @since 4.12 *)
 
-  (** @since 4.00.0 *)
+  (** @since 4.00 *)
   type statistics = Hashtbl.statistics = {
     num_bindings: int;
       (** Number of bindings present in the table.
@@ -277,7 +277,7 @@ module Hashtbl : sig
   (** [Hashtbl.stats tbl] returns statistics about the table [tbl]:
      number of buckets, size of the biggest bucket, distribution of
      buckets by size.
-     @since 4.00.0 *)
+     @since 4.00 *)
 
   (** {1 Hash tables and Sequences} *)
 
@@ -376,14 +376,14 @@ module Hashtbl : sig
       type !'a t
       val create : int -> 'a t
       val clear : 'a t -> unit
-      val reset : 'a t -> unit (** @since 4.00.0 *)
+      val reset : 'a t -> unit (** @since 4.00 *)
 
       val copy : 'a t -> 'a t
       val add : 'a t -> key:key -> data:'a -> unit
       val remove : 'a t -> key -> unit
       val find : 'a t -> key -> 'a
       val find_opt : 'a t -> key -> 'a option
-      (** @since 4.05.0 *)
+      (** @since 4.05 *)
 
       val find_all : 'a t -> key -> 'a list
       val replace : 'a t -> key:key -> data:'a -> unit
@@ -391,11 +391,11 @@ module Hashtbl : sig
       val iter : f:(key:key -> data:'a -> unit) -> 'a t -> unit
       val filter_map_inplace: f:(key:key -> data:'a -> 'a option) -> 'a t ->
         unit
-      (** @since 4.03.0 *)
+      (** @since 4.03 *)
 
       val fold : f:(key:key -> data:'a -> 'b -> 'b) -> 'a t -> init:'b -> 'b
       val length : 'a t -> int
-      val stats: 'a t -> statistics (** @since 4.00.0 *)
+      val stats: 'a t -> statistics (** @since 4.00 *)
 
       val to_seq : 'a t -> (key * 'a) Seq.t
       (** @since 4.07 *)
@@ -447,7 +447,7 @@ module Hashtbl : sig
             {!Hashtbl.seeded_hash} below. *)
     end
   (** The input signature of the functor {!MakeSeeded}.
-      @since 4.00.0 *)
+      @since 4.00 *)
 
   module type SeededS =
     sig
@@ -461,7 +461,7 @@ module Hashtbl : sig
       val add : 'a t -> key:key -> data:'a -> unit
       val remove : 'a t -> key -> unit
       val find : 'a t -> key -> 'a
-      val find_opt : 'a t -> key -> 'a option (** @since 4.05.0 *)
+      val find_opt : 'a t -> key -> 'a option (** @since 4.05 *)
 
       val find_all : 'a t -> key -> 'a list
       val replace : 'a t -> key:key -> data:'a -> unit
@@ -469,7 +469,7 @@ module Hashtbl : sig
       val iter : f:(key:key -> data:'a -> unit) -> 'a t -> unit
       val filter_map_inplace: f:(key:key -> data:'a -> 'a option) -> 'a t ->
         unit
-      (** @since 4.03.0 *)
+      (** @since 4.03 *)
 
       val fold : f:(key:key -> data:'a -> 'b -> 'b) -> 'a t -> init:'b -> 'b
       val length : 'a t -> int
@@ -494,7 +494,7 @@ module Hashtbl : sig
       (** @since 4.07 *)
     end
   (** The output signature of the functor {!MakeSeeded}.
-      @since 4.00.0 *)
+      @since 4.00 *)
 
     module MakeSeeded (H : SeededHashedType) : SeededS
     with type key = H.t
@@ -510,7 +510,7 @@ module Hashtbl : sig
       result structure supports the [~random] optional parameter
       and returns randomized hash tables if [~random:true] is passed
       or if randomization is globally on (see {!Hashtbl.randomize}).
-      @since 4.00.0 *)
+      @since 4.00 *)
 
 
   (** {1 The polymorphic hash functions} *)
@@ -525,7 +525,7 @@ module Hashtbl : sig
   val seeded_hash : int -> 'a -> int
   (** A variant of {!hash} that is further parameterized by
      an integer seed.
-     @since 4.00.0 *)
+     @since 4.00 *)
 
   val hash_param : int -> int -> 'a -> int
   (** [Hashtbl.hash_param meaningful total x] computes a hash value for [x],
@@ -550,7 +550,7 @@ module Hashtbl : sig
   (** A variant of {!hash_param} that is further parameterized by
      an integer seed.  Usage:
      [Hashtbl.seeded_hash_param meaningful total seed x].
-     @since 4.00.0 *)
+     @since 4.00 *)
 
   (** {1:examples Examples}
 
@@ -722,7 +722,7 @@ module Map : sig
       (** [add_to_list ~key ~data m] is [m] with [key] mapped to [l] such
           that [l] is [data :: Map.find key m] if [key] was bound in
           [m] and [[v]] otherwise.
-          @since 5.1.0 *)
+          @since 5.1 *)
 
       val update: key:key -> f:('a option -> 'a option) -> 'a t -> 'a t
       (** [update ~key ~f m] returns a map containing the same bindings as
@@ -734,12 +734,12 @@ module Map : sig
           bound in [m] to a value that is physically equal to [z], [m]
           is returned unchanged (the result of the function is then
           physically equal to [m]).
-          @since 4.06.0 *)
+          @since 4.06 *)
 
       val singleton: key -> 'a -> 'a t
       (** [singleton x y] returns the one-element map that contains a binding
           [y] for [x].
-          @since 3.12.0 *)
+          @since 3.12 *)
 
       val remove: key -> 'a t -> 'a t
       (** [remove x m] returns a map containing the same bindings as
@@ -757,7 +757,7 @@ module Map : sig
           In terms of the [find_opt] operation, we have
           [find_opt x (merge f m1 m2) = f x (find_opt x m1) (find_opt x m2)]
           for any key [x], provided that [f x None None = None].
-          @since 3.12.0 *)
+          @since 3.12 *)
 
       val union: f:(key -> 'a -> 'a -> 'a option) -> 'a t -> 'a t -> 'a t
       (** [union ~f m1 m2] computes a map whose keys are a subset of the keys
@@ -770,11 +770,11 @@ module Map : sig
           - [f' _key None (Some v) = Some v]
           - [f' key (Some v1) (Some v2) = f key v1 v2]
 
-          @since 4.03.0 *)
+          @since 4.03 *)
 
       val cardinal: 'a t -> int
       (** Return the number of bindings of a map.
-          @since 3.12.0 *)
+          @since 3.12 *)
 
       (** {1:bindings Bindings} *)
 
@@ -783,13 +783,13 @@ module Map : sig
           The returned list is sorted in increasing order of keys with respect
           to the ordering [Ord.compare], where [Ord] is the argument
           given to {!Map.Make}.
-          @since 3.12.0 *)
+          @since 3.12 *)
 
       val min_binding: 'a t -> (key * 'a)
       (** Return the binding with the smallest key in a given map
           (with respect to the [Ord.compare] ordering), or raise
           [Not_found] if the map is empty.
-          @since 3.12.0 *)
+          @since 3.12 *)
 
       val min_binding_opt: 'a t -> (key * 'a) option
       (** Return the binding with the smallest key in the given map
@@ -800,7 +800,7 @@ module Map : sig
       val max_binding: 'a t -> (key * 'a)
       (** Same as {!min_binding}, but returns the binding with
           the largest key in the given map.
-          @since 3.12.0 *)
+          @since 3.12 *)
 
       val max_binding_opt: 'a t -> (key * 'a) option
       (** Same as {!min_binding_opt}, but returns the binding with
@@ -811,7 +811,7 @@ module Map : sig
       (** Return one binding of the given map, or raise [Not_found] if
           the map is empty. Which binding is chosen is unspecified,
           but equal bindings will be chosen for equal maps.
-          @since 3.12.0 *)
+          @since 3.12 *)
 
       val choose_opt: 'a t -> (key * 'a) option
       (** Return one binding of the given map, or [None] if
@@ -892,7 +892,7 @@ module Map : sig
           that satisfy predicate [p]. If every binding in [m] satisfies [f],
           [m] is returned unchanged (the result of the function is then
           physically equal to [m])
-          @since 3.12.0
+          @since 3.12
           @before 4.03 Physical equality was not ensured. *)
 
       val filter_map: f:(key -> 'a -> 'b option) -> 'a t -> 'b t
@@ -912,14 +912,14 @@ module Map : sig
           drops all bindings of [m] whose value is an empty list, and pops
           the first element of each value that is non-empty.
 
-          @since 4.11.0 *)
+          @since 4.11 *)
 
       val partition: f:(key -> 'a -> bool) -> 'a t -> 'a t * 'a t
       (** [partition ~f m] returns a pair of maps [(m1, m2)], where
           [m1] contains all the bindings of [m] that satisfy the
           predicate [f], and [m2] is the map with all the bindings of
           [m] that do not satisfy [f].
-          @since 3.12.0 *)
+          @since 3.12 *)
 
       val split: key -> 'a t -> 'a t * 'a option * 'a t
       (** [split x m] returns a triple [(l, data, r)], where
@@ -929,7 +929,7 @@ module Map : sig
           is strictly greater than [x];
             [data] is [None] if [m] contains no binding for [x],
             or [Some v] if [m] binds [v] to [x].
-          @since 3.12.0 *)
+          @since 3.12 *)
 
       (** {1:predicates Predicates and comparisons} *)
 
@@ -953,24 +953,24 @@ module Map : sig
       val for_all: f:(key -> 'a -> bool) -> 'a t -> bool
       (** [for_all ~f m] checks if all the bindings of the map
           satisfy the predicate [f].
-          @since 3.12.0 *)
+          @since 3.12 *)
 
       val exists: f:(key -> 'a -> bool) -> 'a t -> bool
       (** [exists ~f m] checks if at least one binding of the map
           satisfies the predicate [f].
-          @since 3.12.0 *)
+          @since 3.12 *)
 
       (** {1:converting Converting} *)
 
       val to_list : 'a t -> (key * 'a) list
       (** [to_list m] is {!bindings}[ m].
-          @since 5.1.0 *)
+          @since 5.1 *)
 
       val of_list : (key * 'a) list -> 'a t
       (** [of_list bs] adds the bindings of [bs] to the empty map,
           in list order (if a key is bound twice in [bs] the last one
           takes over).
-          @since 5.1.0 *)
+          @since 5.1 *)
 
       val to_seq : 'a t -> (key * 'a) Seq.t
       (** Iterate on the whole map, in ascending order of keys
@@ -1088,7 +1088,7 @@ module Set : sig
 
       val disjoint: t -> t -> bool
       (** Test if two sets are disjoint.
-          @since 4.08.0 *)
+          @since 4.08 *)
 
       val diff: t -> t -> t
       (** Set difference: [diff s1 s2] contains the elements of [s1]
@@ -1142,7 +1142,7 @@ module Set : sig
       (** [find x s] returns the element of [s] equal to [x] (according
           to [Ord.compare]), or raise [Not_found] if no such element
           exists.
-          @since 4.01.0 *)
+          @since 4.01 *)
 
       val find_opt: elt -> t -> elt option
       (** [find_opt x s] returns the element of [s] equal to [x] (according
@@ -1204,7 +1204,7 @@ module Set : sig
           If no element of [s] is changed by [f], [s] is returned
           unchanged. (If each output of [f] is physically equal to its
           input, the returned set is physically equal to [s].)
-          @since 4.04.0 *)
+          @since 4.04 *)
 
       val filter: f:(elt -> bool) -> t -> t
       (** [filter ~f s] returns the set of all elements in [s]
@@ -1226,7 +1226,7 @@ module Set : sig
           [s] is returned unchanged: the result of the function
           is then physically equal to [s].
 
-          @since 4.11.0 *)
+          @since 4.11 *)
 
       val partition: f:(elt -> bool) -> t -> t * t
       (** [partition ~f s] returns a pair of sets [(s1, s2)], where
@@ -1275,13 +1275,13 @@ module Set : sig
 
       val to_list : t -> elt list
       (** [to_list s] is {!elements}[ s].
-          @since 5.1.0 *)
+          @since 5.1 *)
 
       val of_list: elt list -> t
       (** [of_list l] creates a set from a list of elements.
           This is usually more efficient than folding [add] over the list,
           except perhaps for lists with many duplicated elements.
-          @since 4.02.0 *)
+          @since 4.02 *)
 
       val to_seq_from : elt -> t -> elt Seq.t
       (** [to_seq_from x s] iterates on a subset of the elements of [s]

--- a/stdlib/nativeint.mli
+++ b/stdlib/nativeint.mli
@@ -69,7 +69,7 @@ val unsigned_div : nativeint -> nativeint -> nativeint
 (** Same as {!div}, except that arguments and result are interpreted as {e
     unsigned} native integers.
 
-    @since 4.08.0 *)
+    @since 4.08 *)
 
 external rem : nativeint -> nativeint -> nativeint = "%nativeint_mod"
 (** Integer remainder.  If [y] is not zero, the result
@@ -83,7 +83,7 @@ val unsigned_rem : nativeint -> nativeint -> nativeint
 (** Same as {!rem}, except that arguments and result are interpreted as {e
     unsigned} native integers.
 
-    @since 4.08.0 *)
+    @since 4.08 *)
 
 val succ : nativeint -> nativeint
 (** Successor.
@@ -158,7 +158,7 @@ val unsigned_to_int : nativeint -> int option
     Returns [None] if the unsigned value of the argument cannot fit into an
     [int].
 
-    @since 4.08.0 *)
+    @since 4.08 *)
 
 external of_float : float -> nativeint
   = "caml_nativeint_of_float" "caml_nativeint_of_float_unboxed"
@@ -220,20 +220,20 @@ val unsigned_compare: t -> t -> int
 (** Same as {!compare}, except that arguments are interpreted as {e unsigned}
     native integers.
 
-    @since 4.08.0 *)
+    @since 4.08 *)
 
 val equal: t -> t -> bool
 (** The equal function for native ints.
-    @since 4.03.0 *)
+    @since 4.03 *)
 
 val min: t -> t -> t
 (** Return the smaller of the two arguments.
-    @since 4.13.0
+    @since 4.13
 *)
 
 val max: t -> t -> t
 (** Return the greater of the two arguments.
-    @since 4.13.0
+    @since 4.13
  *)
 
 val seeded_hash : int -> t -> int
@@ -241,11 +241,11 @@ val seeded_hash : int -> t -> int
     {!Hashtbl.seeded_hash}. This function allows this module to be passed as
     argument to the functor {!Hashtbl.MakeSeeded}.
 
-    @since 5.1.0 *)
+    @since 5.1 *)
 
 val hash : t -> int
 (** An unseeded hash function for native ints, with the same output value as
     {!Hashtbl.hash}. This function allows this module to be passed as argument
     to the functor {!Hashtbl.Make}.
 
-    @since 5.1.0 *)
+    @since 5.1 *)

--- a/stdlib/obj.mli
+++ b/stdlib/obj.mli
@@ -70,9 +70,9 @@ external set_raw_field : t -> int -> raw_data -> unit
 external new_block : int -> int -> t = "caml_obj_block"
 external dup : t -> t = "caml_obj_dup"
 external add_offset : t -> Int32.t -> t = "caml_obj_add_offset"
-         (* @since 3.12.0 *)
+         (* @since 3.12 *)
 external with_tag : int -> t -> t = "caml_obj_with_tag"
-  (* @since 4.09.0 *)
+  (* @since 4.09 *)
 
 val first_non_constant_constructor_tag : int
 val last_non_constant_constructor_tag : int
@@ -93,7 +93,7 @@ val custom_tag : int
 
 val int_tag : int
 val out_of_heap_tag : int
-val unaligned_tag : int   (* should never happen @since 3.11.0 *)
+val unaligned_tag : int   (* should never happen @since 3.11 *)
 
 module Closure : sig
   type info = {

--- a/stdlib/out_channel.mli
+++ b/stdlib/out_channel.mli
@@ -15,7 +15,7 @@
 
 (** Output channels.
 
-    @since 4.14.0 *)
+    @since 4.14 *)
 
 type t = out_channel
 (** The type of output channel. *)
@@ -163,4 +163,4 @@ val isatty : t -> bool
 (** [isatty oc] is [true] if [oc] refers to a terminal or console window,
     [false] otherwise.
 
-    @since 5.1.0 *)
+    @since 5.1 *)

--- a/stdlib/parsing.mli
+++ b/stdlib/parsing.mli
@@ -66,7 +66,7 @@ val set_trace: bool -> bool
     shifting a state, reducing by a rule) on standard output.
     [Parsing.set_trace false] turns this debugging trace off.
     The boolean returned is the previous state of the trace flag.
-    @since 3.11.0
+    @since 3.11
 *)
 
 (**/**)

--- a/stdlib/printexc.mli
+++ b/stdlib/printexc.mli
@@ -59,14 +59,14 @@ val print_backtrace: out_channel -> unit
     during the matching of the exception handler), the backtrace may
     correspond to a later exception than the handled one.
 
-    @since 3.11.0
+    @since 3.11
 *)
 
 val get_backtrace: unit -> string
 (** [Printexc.get_backtrace ()] returns a string containing the
     same exception backtrace that [Printexc.print_backtrace] would
     print. Same restriction usage than {!print_backtrace}.
-    @since 3.11.0
+    @since 3.11
 *)
 
 val record_backtrace: bool -> unit
@@ -74,13 +74,13 @@ val record_backtrace: bool -> unit
     on (if [b = true]) or off (if [b = false]).  Initially, backtraces
     are not recorded, unless the [b] flag is given to the program
     through the [OCAMLRUNPARAM] variable.
-    @since 3.11.0
+    @since 3.11
 *)
 
 val backtrace_status: unit -> bool
 (** [Printexc.backtrace_status()] returns [true] if exception
     backtraces are currently recorded, [false] if not.
-    @since 3.11.0
+    @since 3.11
 *)
 
 val register_printer: (exn -> string option) -> unit
@@ -123,7 +123,7 @@ type raw_backtrace
     should use the array returned by the [backtrace_slots] function of
     the next section.
 
-    @since 4.01.0
+    @since 4.01
 *)
 
 type raw_backtrace_entry = private int
@@ -145,31 +145,31 @@ type raw_backtrace_entry = private int
     [raw_backtrace_entry]s are equal as integers, then they represent the same
     [backtrace_slot]s.
 
-    @since 4.12.0 *)
+    @since 4.12 *)
 
 val raw_backtrace_entries : raw_backtrace -> raw_backtrace_entry array
-(** @since 4.12.0 *)
+(** @since 4.12 *)
 
 val get_raw_backtrace: unit -> raw_backtrace
 (** [Printexc.get_raw_backtrace ()] returns the same exception
     backtrace that [Printexc.print_backtrace] would print, but in
     a raw format. Same restriction usage than {!print_backtrace}.
 
-    @since 4.01.0
+    @since 4.01
 *)
 
 val print_raw_backtrace: out_channel -> raw_backtrace -> unit
 (** Print a raw backtrace in the same format
     [Printexc.print_backtrace] uses.
 
-    @since 4.01.0
+    @since 4.01
 *)
 
 val raw_backtrace_to_string: raw_backtrace -> string
 (** Return a string from a raw backtrace, in the same format
     [Printexc.get_backtrace] uses.
 
-    @since 4.01.0
+    @since 4.01
 *)
 
 external raise_with_backtrace: exn -> raw_backtrace -> 'a
@@ -177,7 +177,7 @@ external raise_with_backtrace: exn -> raw_backtrace -> 'a
 (** Reraise the exception using the given raw_backtrace for the
     origin of the exception
 
-    @since 4.05.0
+    @since 4.05
 *)
 
 (** {1 Current call stack} *)
@@ -188,7 +188,7 @@ external get_callstack: int -> raw_backtrace = "caml_get_current_callstack"
     with at most [n] entries.  (Note: this function is not related to
     exceptions at all, despite being part of the [Printexc] module.)
 
-    @since 4.01.0
+    @since 4.01
 *)
 
 (** {1 Uncaught exceptions} *)
@@ -215,7 +215,7 @@ val set_uncaught_exception_handler: (exn -> raw_backtrace -> unit) -> unit
     If [fn] raises an exception, both the exceptions passed to [fn] and raised
     by [fn] will be printed with their respective backtrace.
 
-    @since 4.02.0
+    @since 4.02
 *)
 
 
@@ -246,7 +246,7 @@ val backtrace_slots : raw_backtrace -> backtrace_slot array option
     - the program is a bytecode program that has not been linked with
     debug information enabled ([ocamlc -g])
 
-    @since 4.02.0
+    @since 4.02
 *)
 
 val backtrace_slots_of_raw_entry :
@@ -275,7 +275,7 @@ type location = {
     @since 4.02
 *)
 
-(** @since 4.02.0 *)
+(** @since 4.02 *)
 module Slot : sig
   type t = backtrace_slot
 
@@ -292,7 +292,7 @@ module Slot : sig
       that got inlined by the compiler, and [false] when it comes from
       any other context.
 
-      @since 4.04.0
+      @since 4.04
   *)
 
   val location : t -> location option
@@ -346,7 +346,7 @@ type raw_backtrace_slot
     are equal, then they represent the same source location (the converse is not
     necessarily true in presence of inlining, for example).
 
-    @since 4.02.0
+    @since 4.02
 *)
 
 val raw_backtrace_length : raw_backtrace -> int
@@ -391,7 +391,7 @@ val get_raw_backtrace_next_slot :
         done
     ]}
 
-    @since 4.04.0
+    @since 4.04
 *)
 
 (** {1 Exception slots} *)
@@ -401,14 +401,14 @@ val exn_slot_id: exn -> int
     the constructor used to create the exception value [exn]
     (in the current runtime).
 
-    @since 4.02.0
+    @since 4.02
 *)
 
 val exn_slot_name: exn -> string
 (** [Printexc.exn_slot_name exn] returns the internal name of the constructor
     used to create the exception value [exn].
 
-    @since 4.02.0
+    @since 4.02
 *)
 
 (**/**)

--- a/stdlib/printf.mli
+++ b/stdlib/printf.mli
@@ -144,13 +144,13 @@ val bprintf : Buffer.t -> ('a, Buffer.t, unit) format -> 'a
 val ifprintf : 'b -> ('a, 'b, 'c, unit) format4 -> 'a
 (** Same as {!Printf.fprintf}, but does not print anything.
     Useful to ignore some material when conditionally printing.
-    @since 3.10.0
+    @since 3.10
 *)
 
 val ibprintf : Buffer.t -> ('a, Buffer.t, unit) format -> 'a
 (** Same as {!Printf.bprintf}, but does not print anything.
     Useful to ignore some material when conditionally printing.
-    @since 4.11.0
+    @since 4.11
 *)
 
 (** Formatted output functions with continuations. *)
@@ -159,33 +159,33 @@ val kfprintf : (out_channel -> 'd) -> out_channel ->
               ('a, out_channel, unit, 'd) format4 -> 'a
 (** Same as [fprintf], but instead of returning immediately,
    passes the out channel to its first argument at the end of printing.
-   @since 3.09.0
+   @since 3.09
 *)
 
 val ikfprintf : ('b -> 'd) -> 'b -> ('a, 'b, 'c, 'd) format4 -> 'a
 (** Same as [kfprintf] above, but does not print anything.
    Useful to ignore some material when conditionally printing.
-   @since 4.01.0
+   @since 4.01
 *)
 
 val ksprintf : (string -> 'd) -> ('a, unit, string, 'd) format4 -> 'a
 (** Same as [sprintf] above, but instead of returning the string,
    passes it to the first argument.
-   @since 3.09.0
+   @since 3.09
 *)
 
 val kbprintf : (Buffer.t -> 'd) -> Buffer.t ->
               ('a, Buffer.t, unit, 'd) format4 -> 'a
 (** Same as [bprintf], but instead of returning immediately,
    passes the buffer to its first argument at the end of printing.
-   @since 3.10.0
+   @since 3.10
 *)
 
 val ikbprintf : (Buffer.t -> 'd) -> Buffer.t ->
                ('a, Buffer.t, unit, 'd) format4 -> 'a
 (** Same as [kbprintf] above, but does not print anything.
    Useful to ignore some material when conditionally printing.
-   @since 4.11.0
+   @since 4.11
 *)
 
 (** Deprecated *)

--- a/stdlib/random.mli
+++ b/stdlib/random.mli
@@ -44,8 +44,7 @@ val self_init : unit -> unit
 
 val bits : unit -> int
 (** Return 30 random bits in a nonnegative integer.
-    @before 5.0.0 used a different algorithm
-                   (affects all the following functions)
+    @before 5.0 used a different algorithm (affects all the following functions)
 *)
 
 val int : int -> int
@@ -62,7 +61,7 @@ val full_int : int -> int
      or non-standard environments, such as JavaScript), [Random.full_int]
      returns a value, where {!Random.int} raises {!Stdlib.Invalid_argument}.
 
-    @since 4.13.0 *)
+    @since 4.13 *)
 
 val int32 : Int32.t -> Int32.t
 (** [Random.int32 bound] returns a random integer between 0 (inclusive)
@@ -88,18 +87,18 @@ val bool : unit -> bool
 val bits32 : unit -> Int32.t
 (** [Random.bits32 ()] returns 32 random bits as an integer between
     {!Int32.min_int} and {!Int32.max_int}.
-    @since 4.14.0 *)
+    @since 4.14 *)
 
 val bits64 : unit -> Int64.t
 (** [Random.bits64 ()] returns 64 random bits as an integer between
     {!Int64.min_int} and {!Int64.max_int}.
-    @since 4.14.0 *)
+    @since 4.14 *)
 
 val nativebits : unit -> Nativeint.t
 (** [Random.nativebits ()] returns 32 or 64 random bits (depending on
     the bit width of the platform) as an integer between
     {!Nativeint.min_int} and {!Nativeint.max_int}.
-    @since 4.14.0 *)
+    @since 4.14 *)
 
 (** {1 Advanced functions} *)
 
@@ -146,7 +145,7 @@ module State : sig
       The new PRNG is statistically independent from the given PRNG.
       Data can be drawn from both PRNGs, in any order, without risk of
       correlation.  Both PRNGs can be split later, arbitrarily many times.
-      @since 5.0.0 *)
+      @since 5.0 *)
 
 end
 
@@ -164,4 +163,4 @@ val split : unit -> State.t
     generator used by the default functions.
     (The state of the domain-local generator is modified.)
     See {!Random.State.split}.
-    @since 5.0.0 *)
+    @since 5.0 *)

--- a/stdlib/scanf.mli
+++ b/stdlib/scanf.mli
@@ -100,7 +100,7 @@ type in_channel
    The type {!Scanning.scanbuf} below is an alias for [Scanning.in_channel].
    Note that a [Scanning.in_channel] is not concurrency-safe: concurrent use
    may produce arbitrary values or exceptions.
-   @since 3.12.0
+   @since 3.12
 *)
 
 type scanbuf = in_channel
@@ -125,12 +125,12 @@ val stdin : in_channel
     part of the input; thus, the scanning specifications must properly skip
     this additional newline character (for instance, simply add a ['\n'] as
     the last character of the format string).
-    @since 3.12.0
+    @since 3.12
 *)
 
 type file_name = string
 (** A convenient alias to designate a file name.
-    @since 4.00.0
+    @since 4.00
 *)
 
 val open_in : file_name -> in_channel
@@ -142,19 +142,19 @@ val open_in : file_name -> in_channel
     characters in large chunks; in contrast, [from_channel] below returns
     formatted input channels that must read one character at a time, leading
     to a much slower scanning rate.
-    @since 3.12.0
+    @since 3.12
 *)
 
 val open_in_bin : file_name -> in_channel
 (** [Scanning.open_in_bin fname] returns a {!Scanning.in_channel} formatted
     input channel for bufferized reading in binary mode from file [fname].
-    @since 3.12.0
+    @since 3.12
 *)
 
 val close_in : in_channel -> unit
 (** Closes the {!Stdlib.in_channel} associated with the given
   {!Scanning.in_channel} formatted input channel.
-  @since 3.12.0
+  @since 3.12
 *)
 
 val from_file : file_name -> in_channel
@@ -200,7 +200,7 @@ val beginning_of_input : in_channel -> bool
 val name_of_input : in_channel -> string
 (** [Scanning.name_of_input ic] returns the name of the character source
     for the given {!Scanning.in_channel} formatted input channel.
-    @since 3.09.0
+    @since 3.09
 *)
 
 end
@@ -228,7 +228,7 @@ type ('a, 'b, 'c, 'd) scanner =
     [f]. For instance, if [read_elem] is an input function for values of type
     [t], then [bscanf ic "%r;" read_elem f] reads a value [v] of type [t]
     followed by a [';'] character, and returns [f v].
-    @since 3.10.0
+    @since 3.10
 *)
 
 type ('a, 'b, 'c, 'd) scanner_opt =
@@ -509,7 +509,7 @@ val ksscanf :
   string -> (Scanning.in_channel -> exn -> 'd) ->
     ('a, 'b, 'c, 'd) scanner
 (** Same as {!Scanf.kscanf} but reads from the given string.
-    @since 4.02.0 *)
+    @since 4.02 *)
 
 (** {1 Reading format strings from input} *)
 
@@ -521,14 +521,14 @@ val bscanf_format :
     applies [f] to the resulting format string value.
     @raise Scan_failure if the format string value read does not have the
     same type as [fmt].
-    @since 3.09.0
+    @since 3.09
 *)
 
 val sscanf_format :
   string -> ('a, 'b, 'c, 'd, 'e, 'f) format6 ->
     (('a, 'b, 'c, 'd, 'e, 'f) format6 -> 'g) -> 'g
 (** Same as {!Scanf.bscanf_format}, but reads from the given string.
-    @since 3.09.0
+    @since 3.09
 *)
 
 val format_from_string :
@@ -538,7 +538,7 @@ val format_from_string :
     according to the given format string [fmt].
     @raise Scan_failure if [s], considered as a format string, does not
     have the same type as [fmt].
-    @since 3.10.0
+    @since 3.10
 *)
 
 val unescaped : string -> string
@@ -553,5 +553,5 @@ val unescaped : string -> string
     @raise Scan_failure if [s] is not properly escaped (i.e. [s] has invalid
     escape sequences or special characters that are not properly escaped).
     For instance, [Scanf.unescaped "\""] will fail.
-    @since 4.00.0
+    @since 4.00
 *)

--- a/stdlib/set.mli
+++ b/stdlib/set.mli
@@ -100,7 +100,7 @@ module type S =
 
     val disjoint: t -> t -> bool
     (** Test if two sets are disjoint.
-        @since 4.08.0 *)
+        @since 4.08 *)
 
     val diff: t -> t -> t
     (** Set difference: [diff s1 s2] contains the elements of [s1]
@@ -154,7 +154,7 @@ module type S =
     (** [find x s] returns the element of [s] equal to [x] (according
         to [Ord.compare]), or raise [Not_found] if no such element
         exists.
-        @since 4.01.0 *)
+        @since 4.01 *)
 
     val find_opt: elt -> t -> elt option
     (** [find_opt x s] returns the element of [s] equal to [x] (according
@@ -216,7 +216,7 @@ module type S =
         If no element of [s] is changed by [f], [s] is returned
         unchanged. (If each output of [f] is physically equal to its
         input, the returned set is physically equal to [s].)
-        @since 4.04.0 *)
+        @since 4.04 *)
 
     val filter: (elt -> bool) -> t -> t
     (** [filter f s] returns the set of all elements in [s]
@@ -238,7 +238,7 @@ module type S =
         [s] is returned unchanged: the result of the function
         is then physically equal to [s].
 
-        @since 4.11.0 *)
+        @since 4.11 *)
 
     val partition: (elt -> bool) -> t -> t * t
     (** [partition f s] returns a pair of sets [(s1, s2)], where
@@ -287,13 +287,13 @@ module type S =
 
     val to_list : t -> elt list
     (** [to_list s] is {!elements}[ s].
-        @since 5.1.0 *)
+        @since 5.1 *)
 
     val of_list: elt list -> t
     (** [of_list l] creates a set from a list of elements.
         This is usually more efficient than folding [add] over the list,
         except perhaps for lists with many duplicated elements.
-        @since 4.02.0 *)
+        @since 4.02 *)
 
     val to_seq_from : elt -> t -> elt Seq.t
     (** [to_seq_from x s] iterates on a subset of the elements of [s]

--- a/stdlib/stack.mli
+++ b/stdlib/stack.mli
@@ -43,7 +43,7 @@ val pop_opt : 'a t -> 'a option
 val drop : 'a t -> unit
 (** [drop s] removes the topmost element in stack [s],
    or raises {!Empty} if the stack is empty.
-   @since 5.1.0 *)
+   @since 5.1 *)
 
 val top : 'a t -> 'a
 (** [top s] returns the topmost element in stack [s],

--- a/stdlib/stdlib.mli
+++ b/stdlib/stdlib.mli
@@ -32,7 +32,7 @@ external raise : exn -> 'a = "%raise"
 
 external raise_notrace : exn -> 'a = "%raise_notrace"
 (** A faster version [raise] which does not record the backtrace.
-    @since 4.02.0
+    @since 4.02
 *)
 
 val invalid_arg : string -> 'a
@@ -231,25 +231,25 @@ external __LOC__ : string = "%loc_LOC"
 (** [__LOC__] returns the location at which this expression appears in
     the file currently being parsed by the compiler, with the standard
     error format of OCaml: "File %S, line %d, characters %d-%d".
-    @since 4.02.0
+    @since 4.02
 *)
 
 external __FILE__ : string = "%loc_FILE"
 (** [__FILE__] returns the name of the file currently being
     parsed by the compiler.
-    @since 4.02.0
+    @since 4.02
 *)
 
 external __LINE__ : int = "%loc_LINE"
 (** [__LINE__] returns the line number at which this expression
     appears in the file currently being parsed by the compiler.
-    @since 4.02.0
+    @since 4.02
 *)
 
 external __MODULE__ : string = "%loc_MODULE"
 (** [__MODULE__] returns the module name of the file being
     parsed by the compiler.
-    @since 4.02.0
+    @since 4.02
 *)
 
 external __POS__ : string * int * int * int = "%loc_POS"
@@ -258,28 +258,28 @@ external __POS__ : string * int * int * int = "%loc_POS"
     currently being parsed by the compiler. [file] is the current
     filename, [lnum] the line number, [cnum] the character position in
     the line and [enum] the last character position in the line.
-    @since 4.02.0
+    @since 4.02
  *)
 
 external __FUNCTION__ : string = "%loc_FUNCTION"
 (** [__FUNCTION__] returns the name of the current function or method, including
     any enclosing modules or classes.
 
-    @since 4.12.0 *)
+    @since 4.12 *)
 
 external __LOC_OF__ : 'a -> string * 'a = "%loc_LOC"
 (** [__LOC_OF__ expr] returns a pair [(loc, expr)] where [loc] is the
     location of [expr] in the file currently being parsed by the
     compiler, with the standard error format of OCaml: "File %S, line
     %d, characters %d-%d".
-    @since 4.02.0
+    @since 4.02
 *)
 
 external __LINE_OF__ : 'a -> int * 'a = "%loc_LINE"
 (** [__LINE_OF__ expr] returns a pair [(line, expr)], where [line] is the
     line number at which the expression [expr] appears in the file
     currently being parsed by the compiler.
-    @since 4.02.0
+    @since 4.02
  *)
 
 external __POS_OF__ : 'a -> (string * int * int * int) * 'a = "%loc_POS"
@@ -289,7 +289,7 @@ external __POS_OF__ : 'a -> (string * int * int * int) * 'a = "%loc_POS"
     parsed by the compiler. [file] is the current filename, [lnum] the
     line number, [cnum] the character position in the line and [enum]
     the last character position in the line.
-    @since 4.02.0
+    @since 4.02
  *)
 
 (** {1 Composition operators} *)
@@ -323,7 +323,7 @@ external ( ~- ) : int -> int = "%negint"
 external ( ~+ ) : int -> int = "%identity"
 (** Unary addition. You can also write [+ e] instead of [~+ e].
     Unary operator, see {!Ocaml_operators} for more information.
-    @since 3.12.0
+    @since 3.12
 *)
 
 external succ : int -> int = "%succint"
@@ -444,7 +444,7 @@ external ( ~-. ) : float -> float = "%negfloat"
 external ( ~+. ) : float -> float = "%identity"
 (** Unary addition. You can also write [+. e] instead of [~+. e].
     Unary operator, see {!Ocaml_operators} for more information.
-    @since 3.12.0
+    @since 3.12
 *)
 
 external ( +. ) : float -> float -> float = "%addfloat"
@@ -491,14 +491,14 @@ external expm1 : float -> float = "caml_expm1_float" "caml_expm1"
   [@@unboxed] [@@noalloc]
 (** [expm1 x] computes [exp x -. 1.0], giving numerically-accurate results
     even if [x] is close to [0.0].
-    @since 3.12.0
+    @since 3.12
 *)
 
 external log1p : float -> float = "caml_log1p_float" "caml_log1p"
   [@@unboxed] [@@noalloc]
 (** [log1p x] computes [log(1.0 +. x)] (natural logarithm),
     giving numerically-accurate results even if [x] is close to [0.0].
-    @since 3.12.0
+    @since 3.12
 *)
 
 external cos : float -> float = "caml_cos_float" "cos" [@@unboxed] [@@noalloc]
@@ -538,7 +538,7 @@ external hypot : float -> float -> float = "caml_hypot_float" "caml_hypot"
   [x] and [y], or, equivalently, the distance of the point [(x,y)]
   to origin.  If one of [x] or [y] is infinite, returns [infinity]
   even if the other is [nan].
-  @since 4.00.0  *)
+  @since 4.00  *)
 
 external cosh : float -> float = "caml_cosh_float" "cosh"
   [@@unboxed] [@@noalloc]
@@ -558,7 +558,7 @@ external acosh : float -> float = "caml_acosh_float" "caml_acosh"
     [[1.0, inf]].
     Result is in radians and is between [0.0] and [inf].
 
-    @since 4.13.0
+    @since 4.13
 *)
 
 external asinh : float -> float = "caml_asinh_float" "caml_asinh"
@@ -567,7 +567,7 @@ external asinh : float -> float = "caml_asinh_float" "caml_asinh"
     real line.
     Result is in radians.
 
-    @since 4.13.0
+    @since 4.13
 *)
 
 external atanh : float -> float = "caml_atanh_float" "caml_atanh"
@@ -576,7 +576,7 @@ external atanh : float -> float = "caml_atanh_float" "caml_atanh"
     [[-1.0, 1.0]].
     Result is in radians and ranges over the entire real line.
 
-    @since 4.13.0
+    @since 4.13
 *)
 
 external ceil : float -> float = "caml_ceil_float" "ceil"
@@ -602,7 +602,7 @@ external copysign : float -> float -> float
   and whose sign is that of [y].  If [x] is [nan], returns [nan].
   If [y] is [nan], returns either [x] or [-. x], but it is not
   specified which.
-  @since 4.00.0  *)
+  @since 4.00  *)
 
 external mod_float : float -> float -> float = "caml_fmod_float" "fmod"
   [@@unboxed] [@@noalloc]
@@ -849,7 +849,7 @@ val print_string : string -> unit
 
 val print_bytes : bytes -> unit
 (** Print a byte sequence on standard output.
-   @since 4.02.0 *)
+   @since 4.02 *)
 
 val print_int : int -> unit
 (** Print an integer, in decimal, on standard output. *)
@@ -880,7 +880,7 @@ val prerr_string : string -> unit
 
 val prerr_bytes : bytes -> unit
 (** Print a byte sequence on standard error.
-   @since 4.02.0 *)
+   @since 4.02 *)
 
 val prerr_int : int -> unit
 (** Print an integer, in decimal, on standard error. *)
@@ -931,7 +931,7 @@ val read_float_opt: unit -> float option
 
    Return [None] if the line read is not a valid representation of a
    floating-point number.
-   @since 4.05.0
+   @since 4.05
 *)
 
 val read_float : unit -> float
@@ -991,7 +991,7 @@ val output_string : out_channel -> string -> unit
 
 val output_bytes : out_channel -> bytes -> unit
 (** Write the byte sequence on the given output channel.
-   @since 4.02.0 *)
+   @since 4.02 *)
 
 val output : out_channel -> bytes -> int -> int -> unit
 (** [output oc buf pos len] writes [len] characters from byte sequence [buf],
@@ -1002,7 +1002,7 @@ val output : out_channel -> bytes -> int -> int -> unit
 val output_substring : out_channel -> string -> int -> int -> unit
 (** Same as [output] but take a string as argument instead of
    a byte sequence.
-   @since 4.02.0 *)
+   @since 4.02 *)
 
 val output_byte : out_channel -> int -> unit
 (** Write one 8-bit integer (as the single character with that code)
@@ -1129,7 +1129,7 @@ val really_input_string : in_channel -> int -> string
    and returns them in a new string.
    @raise End_of_file if the end of file is reached before [len]
    characters have been read.
-   @since 4.02.0 *)
+   @since 4.02 *)
 
 val input_byte : in_channel -> int
 (** Same as {!Stdlib.input_char}, but return the 8-bit integer representing
@@ -1240,7 +1240,7 @@ external decr : int ref -> unit = "%decr"
 
 (** {1 Result type} *)
 
-(** @since 4.03.0 *)
+(** @since 4.03 *)
 type ('a,'b) result = Ok of 'a | Error of 'b
 
 (** {1 Operations on format strings} *)

--- a/stdlib/string.mli
+++ b/stdlib/string.mli
@@ -86,26 +86,26 @@ val init : int -> (int -> char) -> string
     [i] holding the character [f i] (called in increasing index order).
 
     @raise Invalid_argument if [n < 0] or [n > ]{!Sys.max_string_length}.
-    @since 4.02.0 *)
+    @since 4.02 *)
 
 val empty : string
 (** The empty string.
 
-    @since 4.13.0
+    @since 4.13
 *)
 
 val of_bytes : bytes -> string
 (** Return a new string that contains the same bytes as the given byte
     sequence.
 
-    @since 4.13.0
+    @since 4.13
 *)
 
 val to_bytes : string -> bytes
 (** Return a new byte sequence that contains the same bytes as the given
     string.
 
-    @since 4.13.0
+    @since 4.13
 *)
 
 external length : string -> int = "%string_length"
@@ -135,7 +135,7 @@ val cat : string -> string -> string
     @raise Invalid_argument if the result is longer then
     than {!Sys.max_string_length} bytes.
 
-    @since 4.13.0
+    @since 4.13
 *)
 
 (** {1:predicates Predicates and comparisons} *)
@@ -143,7 +143,7 @@ val cat : string -> string -> string
 val equal : t -> t -> bool
 (** [equal s0 s1] is [true] if and only if [s0] and [s1] are character-wise
     equal.
-    @since 4.03.0 (4.05.0 in StringLabels) *)
+    @since 4.03 (4.05 in StringLabels) *)
 
 val compare : t -> t -> int
 (** [compare s0 s1] sorts [s0] and [s1] in lexicographical order. [compare]
@@ -154,13 +154,13 @@ val starts_with :
 (** [starts_with ][~prefix s] is [true] if and only if [s] starts with
     [prefix].
 
-    @since 4.13.0 *)
+    @since 4.13 *)
 
 val ends_with :
   suffix (* comment thwarts tools/sync_stdlib_docs *) :string -> string -> bool
 (** [ends_with ][~suffix s] is [true] if and only if [s] ends with [suffix].
 
-    @since 4.13.0 *)
+    @since 4.13 *)
 
 val contains_from : string -> int -> char -> bool
 (** [contains_from s start c] is [true] if and only if [c] appears in [s]
@@ -200,7 +200,7 @@ val split_on_char : char -> string -> string list
       (split_on_char sep s) = s]).}
     {- No string in the result contains the [sep] character.}}
 
-    @since 4.04.0 (4.05.0 in StringLabels) *)
+    @since 4.04 (4.05 in StringLabels) *)
 
 (** {1:transforming Transforming} *)
 
@@ -208,38 +208,38 @@ val map : (char -> char) -> string -> string
 (** [map f s] is the string resulting from applying [f] to all the
     characters of [s] in increasing order.
 
-    @since 4.00.0 *)
+    @since 4.00 *)
 
 val mapi : (int -> char -> char) -> string -> string
 (** [mapi f s] is like {!map} but the index of the character is also
     passed to [f].
 
-    @since 4.02.0 *)
+    @since 4.02 *)
 
 val fold_left : ('a -> char -> 'a) -> 'a -> string -> 'a
 (** [fold_left f x s] computes [f (... (f (f x s.[0]) s.[1]) ...) s.[n-1]],
     where [n] is the length of the string [s].
-    @since 4.13.0 *)
+    @since 4.13 *)
 
 val fold_right : (char -> 'a -> 'a) -> string -> 'a -> 'a
 (** [fold_right f s x] computes [f s.[0] (f s.[1] ( ... (f s.[n-1] x) ...))],
     where [n] is the length of the string [s].
-    @since 4.13.0 *)
+    @since 4.13 *)
 
 val for_all : (char -> bool) -> string -> bool
 (** [for_all p s] checks if all characters in [s] satisfy the predicate [p].
-    @since 4.13.0 *)
+    @since 4.13 *)
 
 val exists : (char -> bool) -> string -> bool
 (** [exists p s] checks if at least one character of [s] satisfies the predicate
     [p].
-    @since 4.13.0 *)
+    @since 4.13 *)
 
 val trim : string -> string
 (** [trim s] is [s] without leading and trailing whitespace. Whitespace
     characters are: [' '], ['\x0C'] (form feed), ['\n'], ['\r'], and ['\t'].
 
-    @since 4.00.0 *)
+    @since 4.00 *)
 
 val escaped : string -> string
 (** [escaped s] is [s] with special characters represented by escape
@@ -259,25 +259,25 @@ val uppercase_ascii : string -> string
 (** [uppercase_ascii s] is [s] with all lowercase letters
     translated to uppercase, using the US-ASCII character set.
 
-    @since 4.03.0 (4.05.0 in StringLabels) *)
+    @since 4.03 (4.05 in StringLabels) *)
 
 val lowercase_ascii : string -> string
 (** [lowercase_ascii s] is [s] with all uppercase letters translated
     to lowercase, using the US-ASCII character set.
 
-    @since 4.03.0 (4.05.0 in StringLabels) *)
+    @since 4.03 (4.05 in StringLabels) *)
 
 val capitalize_ascii : string -> string
 (** [capitalize_ascii s] is [s] with the first character set to
     uppercase, using the US-ASCII character set.
 
-    @since 4.03.0 (4.05.0 in StringLabels) *)
+    @since 4.03 (4.05 in StringLabels) *)
 
 val uncapitalize_ascii : string -> string
 (** [uncapitalize_ascii s] is [s] with the first character set to lowercase,
     using the US-ASCII character set.
 
-    @since 4.03.0 (4.05.0 in StringLabels) *)
+    @since 4.03 (4.05 in StringLabels) *)
 
 (** {1:traversing Traversing} *)
 
@@ -289,7 +289,7 @@ val iteri : (int -> char -> unit) -> string -> unit
 (** [iteri] is like {!iter}, but the function is also given the
     corresponding character index.
 
-    @since 4.00.0 *)
+    @since 4.00 *)
 
 (** {1:searching Searching} *)
 
@@ -427,63 +427,63 @@ val get_uint8 : string -> int -> int
 (** [get_uint8 b i] is [b]'s unsigned 8-bit integer starting at character
     index [i].
 
-    @since 4.13.0
+    @since 4.13
 *)
 
 val get_int8 : string -> int -> int
 (** [get_int8 b i] is [b]'s signed 8-bit integer starting at character
     index [i].
 
-    @since 4.13.0
+    @since 4.13
 *)
 
 val get_uint16_ne : string -> int -> int
 (** [get_uint16_ne b i] is [b]'s native-endian unsigned 16-bit integer
     starting at character index [i].
 
-    @since 4.13.0
+    @since 4.13
 *)
 
 val get_uint16_be : string -> int -> int
 (** [get_uint16_be b i] is [b]'s big-endian unsigned 16-bit integer
     starting at character index [i].
 
-    @since 4.13.0
+    @since 4.13
 *)
 
 val get_uint16_le : string -> int -> int
 (** [get_uint16_le b i] is [b]'s little-endian unsigned 16-bit integer
     starting at character index [i].
 
-    @since 4.13.0
+    @since 4.13
 *)
 
 val get_int16_ne : string -> int -> int
 (** [get_int16_ne b i] is [b]'s native-endian signed 16-bit integer
     starting at character index [i].
 
-    @since 4.13.0
+    @since 4.13
 *)
 
 val get_int16_be : string -> int -> int
 (** [get_int16_be b i] is [b]'s big-endian signed 16-bit integer
     starting at character index [i].
 
-    @since 4.13.0
+    @since 4.13
 *)
 
 val get_int16_le : string -> int -> int
 (** [get_int16_le b i] is [b]'s little-endian signed 16-bit integer
     starting at character index [i].
 
-    @since 4.13.0
+    @since 4.13
 *)
 
 val get_int32_ne : string -> int -> int32
 (** [get_int32_ne b i] is [b]'s native-endian 32-bit integer
     starting at character index [i].
 
-    @since 4.13.0
+    @since 4.13
 *)
 
 val hash : t -> int
@@ -491,48 +491,48 @@ val hash : t -> int
     {!Hashtbl.hash}. This function allows this module to be passed as argument
     to the functor {!Hashtbl.Make}.
 
-    @since 5.0.0 *)
+    @since 5.0 *)
 
 val seeded_hash : int -> t -> int
 (** A seeded hash function for strings, with the same output value as
     {!Hashtbl.seeded_hash}. This function allows this module to be passed as
     argument to the functor {!Hashtbl.MakeSeeded}.
 
-    @since 5.0.0 *)
+    @since 5.0 *)
 
 val get_int32_be : string -> int -> int32
 (** [get_int32_be b i] is [b]'s big-endian 32-bit integer
     starting at character index [i].
 
-    @since 4.13.0
+    @since 4.13
 *)
 
 val get_int32_le : string -> int -> int32
 (** [get_int32_le b i] is [b]'s little-endian 32-bit integer
     starting at character index [i].
 
-    @since 4.13.0
+    @since 4.13
 *)
 
 val get_int64_ne : string -> int -> int64
 (** [get_int64_ne b i] is [b]'s native-endian 64-bit integer
     starting at character index [i].
 
-    @since 4.13.0
+    @since 4.13
 *)
 
 val get_int64_be : string -> int -> int64
 (** [get_int64_be b i] is [b]'s big-endian 64-bit integer
     starting at character index [i].
 
-    @since 4.13.0
+    @since 4.13
 *)
 
 val get_int64_le : string -> int -> int64
 (** [get_int64_le b i] is [b]'s little-endian 64-bit integer
     starting at character index [i].
 
-    @since 4.13.0
+    @since 4.13
 *)
 
 (**/**)

--- a/stdlib/stringLabels.mli
+++ b/stdlib/stringLabels.mli
@@ -86,26 +86,26 @@ val init : int -> f:(int -> char) -> string
     [i] holding the character [f i] (called in increasing index order).
 
     @raise Invalid_argument if [n < 0] or [n > ]{!Sys.max_string_length}.
-    @since 4.02.0 *)
+    @since 4.02 *)
 
 val empty : string
 (** The empty string.
 
-    @since 4.13.0
+    @since 4.13
 *)
 
 val of_bytes : bytes -> string
 (** Return a new string that contains the same bytes as the given byte
     sequence.
 
-    @since 4.13.0
+    @since 4.13
 *)
 
 val to_bytes : string -> bytes
 (** Return a new byte sequence that contains the same bytes as the given
     string.
 
-    @since 4.13.0
+    @since 4.13
 *)
 
 external length : string -> int = "%string_length"
@@ -135,7 +135,7 @@ val cat : string -> string -> string
     @raise Invalid_argument if the result is longer then
     than {!Sys.max_string_length} bytes.
 
-    @since 4.13.0
+    @since 4.13
 *)
 
 (** {1:predicates Predicates and comparisons} *)
@@ -143,7 +143,7 @@ val cat : string -> string -> string
 val equal : t -> t -> bool
 (** [equal s0 s1] is [true] if and only if [s0] and [s1] are character-wise
     equal.
-    @since 4.03.0 (4.05.0 in StringLabels) *)
+    @since 4.03 (4.05 in StringLabels) *)
 
 val compare : t -> t -> int
 (** [compare s0 s1] sorts [s0] and [s1] in lexicographical order. [compare]
@@ -154,13 +154,13 @@ val starts_with :
 (** [starts_with ][~prefix s] is [true] if and only if [s] starts with
     [prefix].
 
-    @since 4.13.0 *)
+    @since 4.13 *)
 
 val ends_with :
   suffix (* comment thwarts tools/sync_stdlib_docs *) :string -> string -> bool
 (** [ends_with ][~suffix s] is [true] if and only if [s] ends with [suffix].
 
-    @since 4.13.0 *)
+    @since 4.13 *)
 
 val contains_from : string -> int -> char -> bool
 (** [contains_from s start c] is [true] if and only if [c] appears in [s]
@@ -200,7 +200,7 @@ val split_on_char : sep:char -> string -> string list
       (split_on_char sep s) = s]).}
     {- No string in the result contains the [sep] character.}}
 
-    @since 4.04.0 (4.05.0 in StringLabels) *)
+    @since 4.04 (4.05 in StringLabels) *)
 
 (** {1:transforming Transforming} *)
 
@@ -208,38 +208,38 @@ val map : f:(char -> char) -> string -> string
 (** [map f s] is the string resulting from applying [f] to all the
     characters of [s] in increasing order.
 
-    @since 4.00.0 *)
+    @since 4.00 *)
 
 val mapi : f:(int -> char -> char) -> string -> string
 (** [mapi ~f s] is like {!map} but the index of the character is also
     passed to [f].
 
-    @since 4.02.0 *)
+    @since 4.02 *)
 
 val fold_left : f:('a -> char -> 'a) -> init:'a -> string -> 'a
 (** [fold_left f x s] computes [f (... (f (f x s.[0]) s.[1]) ...) s.[n-1]],
     where [n] is the length of the string [s].
-    @since 4.13.0 *)
+    @since 4.13 *)
 
 val fold_right : f:(char -> 'a -> 'a) -> string -> init:'a -> 'a
 (** [fold_right f s x] computes [f s.[0] (f s.[1] ( ... (f s.[n-1] x) ...))],
     where [n] is the length of the string [s].
-    @since 4.13.0 *)
+    @since 4.13 *)
 
 val for_all : f:(char -> bool) -> string -> bool
 (** [for_all p s] checks if all characters in [s] satisfy the predicate [p].
-    @since 4.13.0 *)
+    @since 4.13 *)
 
 val exists : f:(char -> bool) -> string -> bool
 (** [exists p s] checks if at least one character of [s] satisfies the predicate
     [p].
-    @since 4.13.0 *)
+    @since 4.13 *)
 
 val trim : string -> string
 (** [trim s] is [s] without leading and trailing whitespace. Whitespace
     characters are: [' '], ['\x0C'] (form feed), ['\n'], ['\r'], and ['\t'].
 
-    @since 4.00.0 *)
+    @since 4.00 *)
 
 val escaped : string -> string
 (** [escaped s] is [s] with special characters represented by escape
@@ -259,25 +259,25 @@ val uppercase_ascii : string -> string
 (** [uppercase_ascii s] is [s] with all lowercase letters
     translated to uppercase, using the US-ASCII character set.
 
-    @since 4.03.0 (4.05.0 in StringLabels) *)
+    @since 4.03 (4.05 in StringLabels) *)
 
 val lowercase_ascii : string -> string
 (** [lowercase_ascii s] is [s] with all uppercase letters translated
     to lowercase, using the US-ASCII character set.
 
-    @since 4.03.0 (4.05.0 in StringLabels) *)
+    @since 4.03 (4.05 in StringLabels) *)
 
 val capitalize_ascii : string -> string
 (** [capitalize_ascii s] is [s] with the first character set to
     uppercase, using the US-ASCII character set.
 
-    @since 4.03.0 (4.05.0 in StringLabels) *)
+    @since 4.03 (4.05 in StringLabels) *)
 
 val uncapitalize_ascii : string -> string
 (** [uncapitalize_ascii s] is [s] with the first character set to lowercase,
     using the US-ASCII character set.
 
-    @since 4.03.0 (4.05.0 in StringLabels) *)
+    @since 4.03 (4.05 in StringLabels) *)
 
 (** {1:traversing Traversing} *)
 
@@ -289,7 +289,7 @@ val iteri : f:(int -> char -> unit) -> string -> unit
 (** [iteri] is like {!iter}, but the function is also given the
     corresponding character index.
 
-    @since 4.00.0 *)
+    @since 4.00 *)
 
 (** {1:searching Searching} *)
 
@@ -427,63 +427,63 @@ val get_uint8 : string -> int -> int
 (** [get_uint8 b i] is [b]'s unsigned 8-bit integer starting at character
     index [i].
 
-    @since 4.13.0
+    @since 4.13
 *)
 
 val get_int8 : string -> int -> int
 (** [get_int8 b i] is [b]'s signed 8-bit integer starting at character
     index [i].
 
-    @since 4.13.0
+    @since 4.13
 *)
 
 val get_uint16_ne : string -> int -> int
 (** [get_uint16_ne b i] is [b]'s native-endian unsigned 16-bit integer
     starting at character index [i].
 
-    @since 4.13.0
+    @since 4.13
 *)
 
 val get_uint16_be : string -> int -> int
 (** [get_uint16_be b i] is [b]'s big-endian unsigned 16-bit integer
     starting at character index [i].
 
-    @since 4.13.0
+    @since 4.13
 *)
 
 val get_uint16_le : string -> int -> int
 (** [get_uint16_le b i] is [b]'s little-endian unsigned 16-bit integer
     starting at character index [i].
 
-    @since 4.13.0
+    @since 4.13
 *)
 
 val get_int16_ne : string -> int -> int
 (** [get_int16_ne b i] is [b]'s native-endian signed 16-bit integer
     starting at character index [i].
 
-    @since 4.13.0
+    @since 4.13
 *)
 
 val get_int16_be : string -> int -> int
 (** [get_int16_be b i] is [b]'s big-endian signed 16-bit integer
     starting at character index [i].
 
-    @since 4.13.0
+    @since 4.13
 *)
 
 val get_int16_le : string -> int -> int
 (** [get_int16_le b i] is [b]'s little-endian signed 16-bit integer
     starting at character index [i].
 
-    @since 4.13.0
+    @since 4.13
 *)
 
 val get_int32_ne : string -> int -> int32
 (** [get_int32_ne b i] is [b]'s native-endian 32-bit integer
     starting at character index [i].
 
-    @since 4.13.0
+    @since 4.13
 *)
 
 val hash : t -> int
@@ -491,48 +491,48 @@ val hash : t -> int
     {!Hashtbl.hash}. This function allows this module to be passed as argument
     to the functor {!Hashtbl.Make}.
 
-    @since 5.0.0 *)
+    @since 5.0 *)
 
 val seeded_hash : int -> t -> int
 (** A seeded hash function for strings, with the same output value as
     {!Hashtbl.seeded_hash}. This function allows this module to be passed as
     argument to the functor {!Hashtbl.MakeSeeded}.
 
-    @since 5.0.0 *)
+    @since 5.0 *)
 
 val get_int32_be : string -> int -> int32
 (** [get_int32_be b i] is [b]'s big-endian 32-bit integer
     starting at character index [i].
 
-    @since 4.13.0
+    @since 4.13
 *)
 
 val get_int32_le : string -> int -> int32
 (** [get_int32_le b i] is [b]'s little-endian 32-bit integer
     starting at character index [i].
 
-    @since 4.13.0
+    @since 4.13
 *)
 
 val get_int64_ne : string -> int -> int64
 (** [get_int64_ne b i] is [b]'s native-endian 64-bit integer
     starting at character index [i].
 
-    @since 4.13.0
+    @since 4.13
 *)
 
 val get_int64_be : string -> int -> int64
 (** [get_int64_be b i] is [b]'s big-endian 64-bit integer
     starting at character index [i].
 
-    @since 4.13.0
+    @since 4.13
 *)
 
 val get_int64_le : string -> int -> int64
 (** [get_int64_le b i] is [b]'s little-endian 64-bit integer
     starting at character index [i].
 
-    @since 4.13.0
+    @since 4.13
 *)
 
 (**/**)

--- a/stdlib/sys.mli
+++ b/stdlib/sys.mli
@@ -39,7 +39,7 @@ external is_directory : string -> bool = "caml_sys_is_directory"
 (** Returns [true] if the given name refers to a directory,
     [false] if it refers to another kind of file.
     @raise Sys_error if no file exists with the given name.
-    @since 3.10.0
+    @since 3.10
 *)
 
 external is_regular_file : string -> bool = "caml_sys_is_regular_file"
@@ -104,13 +104,13 @@ external chdir : string -> unit = "caml_sys_chdir"
 external mkdir : string -> int -> unit = "caml_sys_mkdir"
 (** Create a directory with the given permissions.
 
-    @since 4.12.0
+    @since 4.12
 *)
 
 external rmdir : string -> unit = "caml_sys_rmdir"
 (** Remove an empty directory.
 
-    @since 4.12.0
+    @since 4.12
 *)
 
 external getcwd : unit -> string = "caml_sys_getcwd"
@@ -144,25 +144,25 @@ type backend_type =
     [Bytecode], but it can be other backends with alternative
     compilers, for example, javascript.
 
-    @since 4.04.0
+    @since 4.04
 *)
 
 val backend_type : backend_type
 (** Backend type  currently executing the OCaml program.
-    @since 4.04.0
+    @since 4.04
  *)
 
 val unix : bool
 (** True if [Sys.os_type = "Unix"].
-    @since 4.01.0 *)
+    @since 4.01 *)
 
 val win32 : bool
 (** True if [Sys.os_type = "Win32"].
-    @since 4.01.0 *)
+    @since 4.01 *)
 
 val cygwin : bool
 (** True if [Sys.os_type = "Cygwin"].
-    @since 4.01.0 *)
+    @since 4.01 *)
 
 val word_size : int
 (** Size of one word on the machine currently executing the OCaml
@@ -172,11 +172,11 @@ val int_size : int
 (** Size of [int], in bits. It is 31 (resp. 63) when using OCaml on a
     32-bit (resp. 64-bit) platform. It may differ for other implementations,
     e.g. it can be 32 bits when compiling to JavaScript.
-    @since 4.03.0 *)
+    @since 4.03 *)
 
 val big_endian : bool
 (** Whether the machine currently executing the Caml program is big-endian.
-    @since 4.00.0 *)
+    @since 4.00 *)
 
 val max_string_length : int
 (** Maximum length of strings and byte sequences. *)
@@ -197,12 +197,12 @@ external runtime_variant : unit -> string = "caml_runtime_variant"
 (** Return the name of the runtime variant the program is running on.
     This is normally the argument given to [-runtime-variant] at compile
     time, but for byte-code it can be changed after compilation.
-    @since 4.03.0 *)
+    @since 4.03 *)
 
 external runtime_parameters : unit -> string = "caml_runtime_parameters"
 (** Return the value of the runtime parameters, in the same format
     as the contents of the [OCAMLRUNPARAM] environment variable.
-    @since 4.03.0 *)
+    @since 4.03 *)
 
 
 (** {1 Signal handling} *)
@@ -350,7 +350,7 @@ val ocaml_version : string
 
 val development_version : bool
 (** [true] if this is a development version, [false] otherwise.
-    @since 4.14.0
+    @since 4.14
 *)
 
 type extra_prefix = Plus | Tilde
@@ -372,12 +372,12 @@ val enable_runtime_warnings: bool -> unit
     when a channel created by [open_*] functions is finalized without
     being closed.  Runtime warnings are disabled by default.
 
-    @since 4.03.0 *)
+    @since 4.03 *)
 
 val runtime_warnings_enabled: unit -> bool
 (** Return whether runtime warnings are currently enabled.
 
-    @since 4.03.0 *)
+    @since 4.03 *)
 
 (** {1 Optimization} *)
 
@@ -395,7 +395,7 @@ external opaque_identity : 'a -> 'a = "%opaque"
       done
     ]}
 
-    @since 4.03.0
+    @since 4.03
 *)
 
 module Immediate64 : sig
@@ -404,7 +404,7 @@ module Immediate64 : sig
       bit architectures. On other architectures, it might or might not
       be immediate.
 
-      @since 4.10.0
+      @since 4.10
   *)
 
   module type Non_immediate = sig

--- a/stdlib/templates/float.template.mli
+++ b/stdlib/templates/float.template.mli
@@ -35,20 +35,20 @@
     [1.0 /. infinity] is [0.0], basic arithmetic operations
     ([+.], [-.], [*.], [/.]) with [nan] as an argument return [nan], ...
 
-    @since 4.07.0
+    @since 4.07
 *)
 
 val zero : float
 (** The floating point 0.
-   @since 4.08.0 *)
+   @since 4.08 *)
 
 val one : float
 (** The floating-point 1.
-   @since 4.08.0 *)
+   @since 4.08 *)
 
 val minus_one : float
 (** The floating-point -1.
-   @since 4.08.0 *)
+   @since 4.08 *)
 
 external neg : float -> float = "%negfloat"
 (** Unary negation. *)
@@ -77,7 +77,7 @@ external fma : float -> float -> float -> float =
    Note: since software emulation of the fma is costly, make sure that you are
    using hardware fma support if performance matters.
 
-   @since 4.08.0 *)
+   @since 4.08 *)
 
 external rem : float -> float -> float = "caml_fmod_float" "fmod"
 [@@unboxed] [@@noalloc]
@@ -89,13 +89,13 @@ val succ : float -> float
 (** [succ x] returns the floating point number right after [x] i.e.,
    the smallest floating-point number greater than [x].  See also
    {!next_after}.
-   @since 4.08.0 *)
+   @since 4.08 *)
 
 val pred : float -> float
 (** [pred x] returns the floating-point number right before [x] i.e.,
    the greatest floating-point number smaller than [x].  See also
    {!next_after}.
-   @since 4.08.0 *)
+   @since 4.08 *)
 
 external abs : float -> float = "%absfloat"
 (** [abs f] returns the absolute value of [f]. *)
@@ -145,23 +145,23 @@ val is_finite : float -> bool
 (** [is_finite x] is [true] if and only if [x] is finite i.e., not infinite and
    not {!nan}.
 
-   @since 4.08.0 *)
+   @since 4.08 *)
 
 val is_infinite : float -> bool
 (** [is_infinite x] is [true] if and only if [x] is {!infinity} or
     {!neg_infinity}.
 
-   @since 4.08.0 *)
+   @since 4.08 *)
 
 val is_nan : float -> bool
 (** [is_nan x] is [true] if and only if [x] is not a number (see {!nan}).
 
-   @since 4.08.0 *)
+   @since 4.08 *)
 
 val is_integer : float -> bool
 (** [is_integer x] is [true] if and only if [x] is an integer.
 
-   @since 4.08.0 *)
+   @since 4.08 *)
 
 external of_int : int -> float = "%floatofint"
 (** Convert an integer to floating-point. *)
@@ -225,7 +225,7 @@ external cbrt : float -> float = "caml_cbrt_float" "caml_cbrt"
   [@@unboxed] [@@noalloc]
 (** Cube root.
 
-    @since 4.13.0
+    @since 4.13
 *)
 
 external exp : float -> float = "caml_exp_float" "exp" [@@unboxed] [@@noalloc]
@@ -235,7 +235,7 @@ external exp2 : float -> float = "caml_exp2_float" "caml_exp2"
   [@@unboxed] [@@noalloc]
 (** Base 2 exponential function.
 
-    @since 4.13.0
+    @since 4.13
 *)
 
 external log : float -> float = "caml_log_float" "log" [@@unboxed] [@@noalloc]
@@ -249,7 +249,7 @@ external log2 : float -> float = "caml_log2_float" "caml_log2"
   [@@unboxed] [@@noalloc]
 (** Base 2 logarithm.
 
-    @since 4.13.0
+    @since 4.13
 *)
 
 external expm1 : float -> float = "caml_expm1_float" "caml_expm1"
@@ -318,7 +318,7 @@ external acosh : float -> float = "caml_acosh_float" "caml_acosh"
     [[1.0, inf]].
     Result is in radians and is between [0.0] and [inf].
 
-    @since 4.13.0
+    @since 4.13
 *)
 
 external asinh : float -> float = "caml_asinh_float" "caml_asinh"
@@ -327,7 +327,7 @@ external asinh : float -> float = "caml_asinh_float" "caml_asinh"
     real line.
     Result is in radians.
 
-    @since 4.13.0
+    @since 4.13
 *)
 
 external atanh : float -> float = "caml_atanh_float" "caml_atanh"
@@ -336,7 +336,7 @@ external atanh : float -> float = "caml_atanh_float" "caml_atanh"
     [[-1.0, 1.0]].
     Result is in radians and ranges over the entire real line.
 
-    @since 4.13.0
+    @since 4.13
 *)
 
 external erf : float -> float = "caml_erf_float" "caml_erf"
@@ -344,7 +344,7 @@ external erf : float -> float = "caml_erf_float" "caml_erf"
 (** Error function.  The argument ranges over the entire real line.
     The result is always within [[-1.0, 1.0]].
 
-    @since 4.13.0
+    @since 4.13
 *)
 
 external erfc : float -> float = "caml_erfc_float" "caml_erfc"
@@ -353,7 +353,7 @@ external erfc : float -> float = "caml_erfc_float" "caml_erfc"
     The argument ranges over the entire real line.
     The result is always within [[-1.0, 1.0]].
 
-    @since 4.13.0
+    @since 4.13
 *)
 
 external trunc : float -> float = "caml_trunc_float" "caml_trunc"
@@ -361,7 +361,7 @@ external trunc : float -> float = "caml_trunc_float" "caml_trunc"
 (** [trunc x] rounds [x] to the nearest integer whose absolute value is
    less than or equal to [x].
 
-   @since 4.08.0 *)
+   @since 4.08 *)
 
 external round : float -> float = "caml_round_float" "caml_round"
                                     [@@unboxed] [@@noalloc]
@@ -373,7 +373,7 @@ external round : float -> float = "caml_round_float" "caml_round"
    On 64-bit mingw-w64, this function may be emulated owing to a bug in the
    C runtime library (CRT) on this platform.
 
-   @since 4.08.0 *)
+   @since 4.08 *)
 
 external ceil : float -> float = "caml_ceil_float" "ceil"
 [@@unboxed] [@@noalloc]
@@ -401,7 +401,7 @@ external next_after : float -> float -> float
    If [x] is the smallest denormalized positive number,
    [next_after x 0. = 0.]
 
-   @since 4.08.0 *)
+   @since 4.08 *)
 
 external copy_sign : float -> float -> float
   = "caml_copysign_float" "caml_copysign"
@@ -417,7 +417,7 @@ external sign_bit : (float [@unboxed]) -> bool
     For example [sign_bit 1.] and [signbit 0.] are [false] while
     [sign_bit (-1.)] and [sign_bit (-0.)] are [true].
 
-    @since 4.08.0 *)
+    @since 4.08 *)
 
 external frexp : float -> float * int = "caml_frexp_float"
 (** [frexp f] returns the pair of the significant
@@ -451,46 +451,46 @@ val min : t -> t -> t
 (** [min x y] returns the minimum of [x] and [y].  It returns [nan]
    when [x] or [y] is [nan].  Moreover [min (-0.) (+0.) = -0.]
 
-   @since 4.08.0 *)
+   @since 4.08 *)
 
 val max : float -> float -> float
 (** [max x y] returns the maximum of [x] and [y].  It returns [nan]
    when [x] or [y] is [nan].  Moreover [max (-0.) (+0.) = +0.]
 
-   @since 4.08.0 *)
+   @since 4.08 *)
 
 val min_max : float -> float -> float * float
 (** [min_max x y] is [(min x y, max x y)], just more efficient.
 
-   @since 4.08.0 *)
+   @since 4.08 *)
 
 val min_num : t -> t -> t
 (** [min_num x y] returns the minimum of [x] and [y] treating [nan] as
    missing values.  If both [x] and [y] are [nan], [nan] is returned.
    Moreover [min_num (-0.) (+0.) = -0.]
 
-   @since 4.08.0 *)
+   @since 4.08 *)
 
 val max_num : t -> t -> t
 (** [max_num x y] returns the maximum of [x] and [y] treating [nan] as
    missing values.  If both [x] and [y] are [nan] [nan] is returned.
    Moreover [max_num (-0.) (+0.) = +0.]
 
-   @since 4.08.0 *)
+   @since 4.08 *)
 
 val min_max_num : float -> float -> float * float
 (** [min_max_num x y] is [(min_num x y, max_num x y)], just more
    efficient.  Note that in particular [min_max_num x nan = (x, x)]
    and [min_max_num nan y = (y, y)].
 
-   @since 4.08.0 *)
+   @since 4.08 *)
 
 val seeded_hash : int -> t -> int
 (** A seeded hash function for floats, with the same output value as
     {!Hashtbl.seeded_hash}. This function allows this module to be passed as
     argument to the functor {!Hashtbl.MakeSeeded}.
 
-    @since 5.1.0 *)
+    @since 5.1 *)
 
 val hash : t -> int
 (** An unseeded hash function for floats, with the same output value as

--- a/stdlib/templates/floatarraylabeled.template.mli
+++ b/stdlib/templates/floatarraylabeled.template.mli
@@ -16,7 +16,7 @@
 
 type t = floatarray
 (** The type of float arrays with packed representation.
-    @since 4.08.0
+    @since 4.08
   *)
 
 val length : t -> int

--- a/stdlib/templates/hashtbl.template.mli
+++ b/stdlib/templates/hashtbl.template.mli
@@ -84,7 +84,7 @@ val create : ?random: (* thwart tools/sync_stdlib_docs *) bool ->
    either programmatically by calling {!randomize} or by
    setting the [R] flag in the [OCAMLRUNPARAM] environment variable.
 
-   @before 4.00.0 the [~random] parameter was not present and all
+   @before 4.00 the [~random] parameter was not present and all
    hash tables were created in non-randomized mode. *)
 
 val clear : ('a, 'b) t -> unit
@@ -94,7 +94,7 @@ val clear : ('a, 'b) t -> unit
 val reset : ('a, 'b) t -> unit
 (** Empty a hash table and shrink the size of the bucket table
     to its initial size.
-    @since 4.00.0 *)
+    @since 4.00 *)
 
 val copy : ('a, 'b) t -> ('a, 'b) t
 (** Return a copy of the given hashtable. *)
@@ -170,7 +170,7 @@ val filter_map_inplace: f:(key:'a -> data:'b -> 'b option) -> ('a, 'b) t ->
     to [new_val].
 
     Other comments for {!iter} apply as well.
-    @since 4.03.0 *)
+    @since 4.03 *)
 
 val fold : f:(key:'a -> data:'b -> 'c -> 'c) -> ('a, 'b) t -> init:'c -> 'c
 (** [Hashtbl.fold ~f tbl ~init] computes
@@ -217,12 +217,12 @@ val randomize : unit -> unit
     This is intentional.  Non-randomized hash tables can still be
     created using [Hashtbl.create ~random:false].
 
-    @since 4.00.0 *)
+    @since 4.00 *)
 
 val is_randomized : unit -> bool
 (** Return [true] if the tables are currently created in randomized mode
     by default, [false] otherwise.
-    @since 4.03.0 *)
+    @since 4.03 *)
 
 val rebuild : ?random (* thwart tools/sync_stdlib_docs *) :bool ->
     ('a, 'b) t -> ('a, 'b) t
@@ -239,9 +239,9 @@ val rebuild : ?random (* thwart tools/sync_stdlib_docs *) :bool ->
     to produce a hash table for the current version of the {!Hashtbl}
     module.
 
-    @since 4.12.0 *)
+    @since 4.12 *)
 
-(** @since 4.00.0 *)
+(** @since 4.00 *)
 type statistics = {
   num_bindings: int;
     (** Number of bindings present in the table.
@@ -260,7 +260,7 @@ val stats : ('a, 'b) t -> statistics
 (** [Hashtbl.stats tbl] returns statistics about the table [tbl]:
    number of buckets, size of the biggest bucket, distribution of
    buckets by size.
-   @since 4.00.0 *)
+   @since 4.00 *)
 
 (** {1 Hash tables and Sequences} *)
 
@@ -359,14 +359,14 @@ module type S =
     type !'a t
     val create : int -> 'a t
     val clear : 'a t -> unit
-    val reset : 'a t -> unit (** @since 4.00.0 *)
+    val reset : 'a t -> unit (** @since 4.00 *)
 
     val copy : 'a t -> 'a t
     val add : 'a t -> key:key -> data:'a -> unit
     val remove : 'a t -> key -> unit
     val find : 'a t -> key -> 'a
     val find_opt : 'a t -> key -> 'a option
-    (** @since 4.05.0 *)
+    (** @since 4.05 *)
 
     val find_all : 'a t -> key -> 'a list
     val replace : 'a t -> key:key -> data:'a -> unit
@@ -374,11 +374,11 @@ module type S =
     val iter : f:(key:key -> data:'a -> unit) -> 'a t -> unit
     val filter_map_inplace: f:(key:key -> data:'a -> 'a option) -> 'a t ->
       unit
-    (** @since 4.03.0 *)
+    (** @since 4.03 *)
 
     val fold : f:(key:key -> data:'a -> 'b -> 'b) -> 'a t -> init:'b -> 'b
     val length : 'a t -> int
-    val stats: 'a t -> statistics (** @since 4.00.0 *)
+    val stats: 'a t -> statistics (** @since 4.00 *)
 
     val to_seq : 'a t -> (key * 'a) Seq.t
     (** @since 4.07 *)
@@ -428,7 +428,7 @@ module type SeededHashedType =
           {!Hashtbl.seeded_hash} below. *)
   end
 (** The input signature of the functor {!MakeSeeded}.
-    @since 4.00.0 *)
+    @since 4.00 *)
 
 module type SeededS =
   sig
@@ -442,7 +442,7 @@ module type SeededS =
     val add : 'a t -> key:key -> data:'a -> unit
     val remove : 'a t -> key -> unit
     val find : 'a t -> key -> 'a
-    val find_opt : 'a t -> key -> 'a option (** @since 4.05.0 *)
+    val find_opt : 'a t -> key -> 'a option (** @since 4.05 *)
 
     val find_all : 'a t -> key -> 'a list
     val replace : 'a t -> key:key -> data:'a -> unit
@@ -450,7 +450,7 @@ module type SeededS =
     val iter : f:(key:key -> data:'a -> unit) -> 'a t -> unit
     val filter_map_inplace: f:(key:key -> data:'a -> 'a option) -> 'a t ->
       unit
-    (** @since 4.03.0 *)
+    (** @since 4.03 *)
 
     val fold : f:(key:key -> data:'a -> 'b -> 'b) -> 'a t -> init:'b -> 'b
     val length : 'a t -> int
@@ -475,7 +475,7 @@ module type SeededS =
     (** @since 4.07 *)
   end
 (** The output signature of the functor {!MakeSeeded}.
-    @since 4.00.0 *)
+    @since 4.00 *)
 
 module MakeSeeded (H : SeededHashedType) : SeededS with type key = H.t
 (** Functor building an implementation of the hashtable structure.
@@ -489,7 +489,7 @@ module MakeSeeded (H : SeededHashedType) : SeededS with type key = H.t
     result structure supports the [~random] optional parameter
     and returns randomized hash tables if [~random:true] is passed
     or if randomization is globally on (see {!Hashtbl.randomize}).
-    @since 4.00.0 *)
+    @since 4.00 *)
 
 
 (** {1 The polymorphic hash functions} *)
@@ -504,7 +504,7 @@ val hash : 'a -> int
 val seeded_hash : int -> 'a -> int
 (** A variant of {!hash} that is further parameterized by
    an integer seed.
-   @since 4.00.0 *)
+   @since 4.00 *)
 
 val hash_param : int -> int -> 'a -> int
 (** [Hashtbl.hash_param meaningful total x] computes a hash value for [x],
@@ -529,7 +529,7 @@ val seeded_hash_param : int -> int -> int -> 'a -> int
 (** A variant of {!hash_param} that is further parameterized by
    an integer seed.  Usage:
    [Hashtbl.seeded_hash_param meaningful total seed x].
-   @since 4.00.0 *)
+   @since 4.00 *)
 
 (** {1:examples Examples}
 

--- a/stdlib/templates/map.template.mli
+++ b/stdlib/templates/map.template.mli
@@ -89,7 +89,7 @@ module type S =
     (** [add_to_list ~key ~data m] is [m] with [key] mapped to [l] such
         that [l] is [data :: Map.find key m] if [key] was bound in
         [m] and [[v]] otherwise.
-        @since 5.1.0 *)
+        @since 5.1 *)
 
     val update: key:key -> f:('a option -> 'a option) -> 'a t -> 'a t
     (** [update ~key ~f m] returns a map containing the same bindings as
@@ -101,12 +101,12 @@ module type S =
         bound in [m] to a value that is physically equal to [z], [m]
         is returned unchanged (the result of the function is then
         physically equal to [m]).
-        @since 4.06.0 *)
+        @since 4.06 *)
 
     val singleton: key -> 'a -> 'a t
     (** [singleton x y] returns the one-element map that contains a binding
         [y] for [x].
-        @since 3.12.0 *)
+        @since 3.12 *)
 
     val remove: key -> 'a t -> 'a t
     (** [remove x m] returns a map containing the same bindings as
@@ -124,7 +124,7 @@ module type S =
         In terms of the [find_opt] operation, we have
         [find_opt x (merge f m1 m2) = f x (find_opt x m1) (find_opt x m2)]
         for any key [x], provided that [f x None None = None].
-        @since 3.12.0 *)
+        @since 3.12 *)
 
     val union: f:(key -> 'a -> 'a -> 'a option) -> 'a t -> 'a t -> 'a t
     (** [union ~f m1 m2] computes a map whose keys are a subset of the keys
@@ -137,11 +137,11 @@ module type S =
         - [f' _key None (Some v) = Some v]
         - [f' key (Some v1) (Some v2) = f key v1 v2]
 
-        @since 4.03.0 *)
+        @since 4.03 *)
 
     val cardinal: 'a t -> int
     (** Return the number of bindings of a map.
-        @since 3.12.0 *)
+        @since 3.12 *)
 
     (** {1:bindings Bindings} *)
 
@@ -150,13 +150,13 @@ module type S =
         The returned list is sorted in increasing order of keys with respect
         to the ordering [Ord.compare], where [Ord] is the argument
         given to {!Map.Make}.
-        @since 3.12.0 *)
+        @since 3.12 *)
 
     val min_binding: 'a t -> (key * 'a)
     (** Return the binding with the smallest key in a given map
         (with respect to the [Ord.compare] ordering), or raise
         [Not_found] if the map is empty.
-        @since 3.12.0 *)
+        @since 3.12 *)
 
     val min_binding_opt: 'a t -> (key * 'a) option
     (** Return the binding with the smallest key in the given map
@@ -167,7 +167,7 @@ module type S =
     val max_binding: 'a t -> (key * 'a)
     (** Same as {!min_binding}, but returns the binding with
         the largest key in the given map.
-        @since 3.12.0 *)
+        @since 3.12 *)
 
     val max_binding_opt: 'a t -> (key * 'a) option
     (** Same as {!min_binding_opt}, but returns the binding with
@@ -178,7 +178,7 @@ module type S =
     (** Return one binding of the given map, or raise [Not_found] if
         the map is empty. Which binding is chosen is unspecified,
         but equal bindings will be chosen for equal maps.
-        @since 3.12.0 *)
+        @since 3.12 *)
 
     val choose_opt: 'a t -> (key * 'a) option
     (** Return one binding of the given map, or [None] if
@@ -259,7 +259,7 @@ module type S =
         that satisfy predicate [p]. If every binding in [m] satisfies [f],
         [m] is returned unchanged (the result of the function is then
         physically equal to [m])
-        @since 3.12.0
+        @since 3.12
         @before 4.03 Physical equality was not ensured. *)
 
     val filter_map: f:(key -> 'a -> 'b option) -> 'a t -> 'b t
@@ -279,14 +279,14 @@ module type S =
         drops all bindings of [m] whose value is an empty list, and pops
         the first element of each value that is non-empty.
 
-        @since 4.11.0 *)
+        @since 4.11 *)
 
     val partition: f:(key -> 'a -> bool) -> 'a t -> 'a t * 'a t
     (** [partition ~f m] returns a pair of maps [(m1, m2)], where
         [m1] contains all the bindings of [m] that satisfy the
         predicate [f], and [m2] is the map with all the bindings of
         [m] that do not satisfy [f].
-        @since 3.12.0 *)
+        @since 3.12 *)
 
     val split: key -> 'a t -> 'a t * 'a option * 'a t
     (** [split x m] returns a triple [(l, data, r)], where
@@ -296,7 +296,7 @@ module type S =
         is strictly greater than [x];
           [data] is [None] if [m] contains no binding for [x],
           or [Some v] if [m] binds [v] to [x].
-        @since 3.12.0 *)
+        @since 3.12 *)
 
     (** {1:predicates Predicates and comparisons} *)
 
@@ -320,24 +320,24 @@ module type S =
     val for_all: f:(key -> 'a -> bool) -> 'a t -> bool
     (** [for_all ~f m] checks if all the bindings of the map
         satisfy the predicate [f].
-        @since 3.12.0 *)
+        @since 3.12 *)
 
     val exists: f:(key -> 'a -> bool) -> 'a t -> bool
     (** [exists ~f m] checks if at least one binding of the map
         satisfies the predicate [f].
-        @since 3.12.0 *)
+        @since 3.12 *)
 
     (** {1:converting Converting} *)
 
     val to_list : 'a t -> (key * 'a) list
     (** [to_list m] is {!bindings}[ m].
-        @since 5.1.0 *)
+        @since 5.1 *)
 
     val of_list : (key * 'a) list -> 'a t
     (** [of_list bs] adds the bindings of [bs] to the empty map,
         in list order (if a key is bound twice in [bs] the last one
         takes over).
-        @since 5.1.0 *)
+        @since 5.1 *)
 
     val to_seq : 'a t -> (key * 'a) Seq.t
     (** Iterate on the whole map, in ascending order of keys

--- a/stdlib/templates/set.template.mli
+++ b/stdlib/templates/set.template.mli
@@ -100,7 +100,7 @@ module type S =
 
     val disjoint: t -> t -> bool
     (** Test if two sets are disjoint.
-        @since 4.08.0 *)
+        @since 4.08 *)
 
     val diff: t -> t -> t
     (** Set difference: [diff s1 s2] contains the elements of [s1]
@@ -154,7 +154,7 @@ module type S =
     (** [find x s] returns the element of [s] equal to [x] (according
         to [Ord.compare]), or raise [Not_found] if no such element
         exists.
-        @since 4.01.0 *)
+        @since 4.01 *)
 
     val find_opt: elt -> t -> elt option
     (** [find_opt x s] returns the element of [s] equal to [x] (according
@@ -216,7 +216,7 @@ module type S =
         If no element of [s] is changed by [f], [s] is returned
         unchanged. (If each output of [f] is physically equal to its
         input, the returned set is physically equal to [s].)
-        @since 4.04.0 *)
+        @since 4.04 *)
 
     val filter: f:(elt -> bool) -> t -> t
     (** [filter ~f s] returns the set of all elements in [s]
@@ -238,7 +238,7 @@ module type S =
         [s] is returned unchanged: the result of the function
         is then physically equal to [s].
 
-        @since 4.11.0 *)
+        @since 4.11 *)
 
     val partition: f:(elt -> bool) -> t -> t * t
     (** [partition ~f s] returns a pair of sets [(s1, s2)], where
@@ -287,13 +287,13 @@ module type S =
 
     val to_list : t -> elt list
     (** [to_list s] is {!elements}[ s].
-        @since 5.1.0 *)
+        @since 5.1 *)
 
     val of_list: elt list -> t
     (** [of_list l] creates a set from a list of elements.
         This is usually more efficient than folding [add] over the list,
         except perhaps for lists with many duplicated elements.
-        @since 4.02.0 *)
+        @since 4.02 *)
 
     val to_seq_from : elt -> t -> elt Seq.t
     (** [to_seq_from x s] iterates on a subset of the elements of [s]

--- a/stdlib/uchar.mli
+++ b/stdlib/uchar.mli
@@ -37,14 +37,14 @@ val bom : t
     {{:http://unicode.org/glossary/#byte_order_mark}byte order mark} (BOM)
     character.
 
-    @since 4.06.0 *)
+    @since 4.06 *)
 
 val rep : t
 (** [rep] is U+FFFD, the
     {{:http://unicode.org/glossary/#replacement_character}replacement}
     character.
 
-    @since 4.06.0 *)
+    @since 4.06 *)
 
 val succ : t -> t
 (** [succ u] is the scalar value after [u] in the set of Unicode scalar

--- a/tools/check-typo
+++ b/tools/check-typo
@@ -29,6 +29,7 @@
 # - maximum line length of 132 characters (very-long-line)
 # - presence of a copyright header (missing-header)
 # - absence of a leftover "$Id" string (svn-keyword)
+# - formatting of version numbers in @since, @after and @before (doc-version)
 
 # Exceptions are handled with git attributes: "typo.*".
 # Its value for a given file is a comma-separated list of rule names,
@@ -372,6 +373,20 @@ EXIT_CODE=0
             }
           } else {
             ++ counts["utf8"];
+          }
+        }
+
+        match($0, /@(since|after|before) +[0-9.]+/) {
+          if (match($0, / [34]\.[0-9]([^0-9]|$)/)) {
+            err("doc-version", "version should be formatted M.mm (e.g. 4.08)");
+          } else {
+            if (match($0, / [5-9][0-9]*\.0[0-9]/)) {
+              err("doc-version", "version should be formatted M.m (e.g. 5.0)");
+            } else {
+              if (match($0, / [0-9]+\.[0-9]+\.0/)) {
+                err("doc-version", "version should not include .0 revision");
+              }
+            }
           }
         }
 

--- a/utils/config.mli
+++ b/utils/config.mli
@@ -184,7 +184,7 @@ val ext_dll: string
 val ext_exe: string
 (** Extension for executable programs, e.g. [.exe] under Windows.
 
-    @since 4.12.0 *)
+    @since 4.12 *)
 
 val default_executable_name: string
 (** Name of executable produced by linking if none is given with -o,
@@ -232,12 +232,12 @@ val windows_unicode: bool
 val naked_pointers : bool
 (** Whether the runtime supports naked pointers
 
-    @since 4.14.0 *)
+    @since 4.14 *)
 
 val supports_shared_libraries: bool
 (** Whether shared libraries are supported
 
-    @since 4.08.0 *)
+    @since 4.08 *)
 
 val force_instrumented_runtime: bool
 (** Force runtime-variant to be "i" at configure time

--- a/utils/misc.mli
+++ b/utils/misc.mli
@@ -524,7 +524,7 @@ module Magic_number : sig
       will generate a textual explanation of each error,
       for use in error messages.
 
-      @since 4.11.0
+      @since 4.11
   *)
 
   type native_obj_config = {


### PR DESCRIPTION
Very minor PR, but while pushing another `@since 5.1` in between a whole load of `@since 4.13.0`, etc. I figured we might finally make these consistent. There's already a mix of `@since 5.0.0` and `@since 5.0`.

The first commit removes the trailing `.0` from all `@since`, `@before` and `@after` annotations. If one displays the commit using a patience diff tool, it's easy to verify that the commit consists entirely of either white space adjustment or the deletion of precisely `.0` sequences. The second commit amends `tools/check-typo` to enforce it.

I don't mind whether we include the `.0` or not, but the inconsistency causes me a disproportionate amount of distress 🙂