### PR TITLE
Remove use of C variable length arrays (VLAs)

### DIFF
--- a/Changes
+++ b/Changes
@@ -81,6 +81,10 @@ Working version
 - #11474, #11998: Add support for user-defined events in the runtime event
   tracing system. (Lucas Pluvinage, review by Sadiq Jaffer)
 
+- #11693: Remove use of C99 Variable Length Arrays (VLAs) in the runtime.
+  (David Allsopp, review by Xavier Leroy, Guillaume Munch-Maccagnoni,
+   Stefan Muenzel and Gabriel Scherer)
+
 - #11827: Restore prefetching for GC marking
   (Fabrice Buoro and Stephen Dolan, review by Gabriel Scherer and Sadiq Jaffer)
 

--- a/configure
+++ b/configure
@@ -13709,7 +13709,8 @@ esac ;; #(
       as_fn_error 69 "This version of GCC is too old. Please use GCC version 4.9 or above." "$LINENO" 5 ;; #(
   gcc-*) :
     common_cflags="-O2 -fno-strict-aliasing -fwrapv";
-      internal_cflags="$cc_warnings -fno-common -fexcess-precision=standard" ;; #(
+      internal_cflags="$cc_warnings -fno-common -fexcess-precision=standard \
+-Wvla" ;; #(
   msvc-*) :
     common_cflags="-nologo -O2 -Gy- -MD $cc_warnings"
       common_cppflags="-D_CRT_SECURE_NO_DEPRECATE"

--- a/configure.ac
+++ b/configure.ac
@@ -731,7 +731,8 @@ AS_CASE([$host],
         Please use GCC version 4.9 or above.]), 69)],
     [gcc-*],
       [common_cflags="-O2 -fno-strict-aliasing -fwrapv";
-      internal_cflags="$cc_warnings -fno-common -fexcess-precision=standard"],
+      internal_cflags="$cc_warnings -fno-common -fexcess-precision=standard \
+-Wvla"],
     [msvc-*],
       [common_cflags="-nologo -O2 -Gy- -MD $cc_warnings"
       common_cppflags="-D_CRT_SECURE_NO_DEPRECATE"

--- a/runtime/alloc.c
+++ b/runtime/alloc.c
@@ -79,10 +79,11 @@ CAMLexport value caml_alloc_shr_check_gc (mlsize_t wosize, tag_t tag)
 /* This has to be done with a macro, rather than an inline function, since
    otherwise the wosize parameter to CAMLlocalN expands to be a VLA, which
    breaks MSVC. */
-#define Do_alloc_small(wosize, tag)                     \
+#define Do_alloc_small(wosize, tag, ...)                \
 {                                                       \
   Caml_check_caml_state();                              \
   value v;                                              \
+  value vals[wosize] = {__VA_ARGS__};                   \
   mlsize_t i;                                           \
   CAMLassert ((tag) < 256);                             \
                                                         \
@@ -95,61 +96,52 @@ CAMLexport value caml_alloc_shr_check_gc (mlsize_t wosize, tag_t tag)
 
 CAMLexport value caml_alloc_1 (tag_t tag, value a)
 {
-  value vals[1] = {a};
-  Do_alloc_small(1, tag);
+  Do_alloc_small(1, tag, a);
 }
 
 CAMLexport value caml_alloc_2 (tag_t tag, value a, value b)
 {
-  value vals[2] = {a, b};
-  Do_alloc_small(2, tag);
+  Do_alloc_small(2, tag, a, b);
 }
 
 CAMLexport value caml_alloc_3 (tag_t tag, value a, value b, value c)
 {
-  value vals[3] = {a, b, c};
-  Do_alloc_small(3, tag);
+  Do_alloc_small(3, tag, a, b, c);
 }
 
 CAMLexport value caml_alloc_4 (tag_t tag, value a, value b, value c, value d)
 {
-  value vals[4] = {a, b, c, d};
-  Do_alloc_small(4, tag);
+  Do_alloc_small(4, tag, a, b, c, d);
 }
 
 CAMLexport value caml_alloc_5 (tag_t tag, value a, value b, value c, value d,
                                value e)
 {
-  value vals[5] = {a, b, c, d, e};
-  Do_alloc_small(5, tag);
+  Do_alloc_small(5, tag, a, b, c, d, e);
 }
 
 CAMLexport value caml_alloc_6 (tag_t tag, value a, value b, value c, value d,
                                value e, value f)
 {
-  value vals[6] = {a, b, c, d, e, f};
-  Do_alloc_small(6, tag);
+  Do_alloc_small(6, tag, a, b, c, d, e, f);
 }
 
 CAMLexport value caml_alloc_7 (tag_t tag, value a, value b, value c, value d,
                                value e, value f, value g)
 {
-  value vals[7] = {a, b, c, d, e, f, g};
-  Do_alloc_small(7, tag);
+  Do_alloc_small(7, tag, a, b, c, d, e, f, g);
 }
 
 CAMLexport value caml_alloc_8 (tag_t tag, value a, value b, value c, value d,
                                value e, value f, value g, value h)
 {
-  value vals[8] = {a, b, c, d, e, f, g, h};
-  Do_alloc_small(8, tag);
+  Do_alloc_small(8, tag, a, b, c, d, e, f, g, h);
 }
 
 CAMLexport value caml_alloc_9 (tag_t tag, value a, value b, value c, value d,
                                value e, value f, value g, value h, value i)
 {
-  value vals[9] = {a, b, c, d, e, f, g, h, i};
-  Do_alloc_small(9, tag);
+  Do_alloc_small(9, tag, a, b, c, d, e, f, g, h, i);
 }
 
 CAMLexport value caml_alloc_small (mlsize_t wosize, tag_t tag)


### PR DESCRIPTION
OCaml 5 adds `caml_alloc_1`..`caml_alloc_9` and the general `caml_alloc_N` to `caml/alloc.h` (see 
https://github.com/ocaml-multicore/ocaml-multicore/pull/72). These are implemented using C99 variable length arrays (VLAs). VLAs are (if I understand correctly) deprecated in C11 and they're not supported in our favourite MS C compiler (and they have no intention of adding them as part of their C11 and C17 support).

This PR is intended mainly to start discussion - at this stage I've removed `caml_alloc_N`, but it may be possible to reintroduce it as a macro (cf. `CAMLlocalN`) if we wanted?

I've reimplemented the 9 allocation functions with the inlined function as a macro, but this needs checking to ensure that the generated code is still correct (cf. the discussion in the original PR and cc @stedolan and @gadmm).