### PR TITLE
Add the -no-g option to ocamlc and ocamlopt

### DIFF
--- a/Changes
+++ b/Changes
@@ -122,7 +122,8 @@ Working version
   modules with mismatching -for-pack
   (Pierre Chambart and Vincent Laviron, review by Mark Shinwell)
 
-- #11653: Add the -no-absname option to ocamlc, ocamlopt and ocamldep.
+- #11653, #11696: Add the -no-absname and -no-g option to ocamlc,
+  ocamlopt and ocamldep.
   (Abiola Abdulsalam, review by Sébastien Hinderer and Florian Angeletti)
 
 ### Internal/compiler-libs changes:

--- a/Changes
+++ b/Changes
@@ -126,7 +126,8 @@ Working version
   (Abiola Abdulsalam, review by Sébastien Hinderer and Florian Angeletti)
 
 - #11696: Add the -no-g option to ocamlc and ocamlopt.
-  (Abiola Abdulsalam, review by Sébastien Hinderer and Florian Angeletti)
+  (Abiola Abdulsalam, review by Sébastien Hinderer, Nicolás Ojeda Bär and
+  Florian Angeletti)
 
 ### Internal/compiler-libs changes:
 - #11027: Separate typing counter-examples from type_pat into retype_pat;

--- a/Changes
+++ b/Changes
@@ -122,8 +122,10 @@ Working version
   modules with mismatching -for-pack
   (Pierre Chambart and Vincent Laviron, review by Mark Shinwell)
 
-- #11653, #11696: Add the -no-absname and -no-g option to ocamlc,
-  ocamlopt and ocamldep.
+- #11653: Add the -no-absname option to ocamlc, ocamlopt and ocamldep.
+  (Abiola Abdulsalam, review by Sébastien Hinderer and Florian Angeletti)
+
+- #11696: Add the -no-g option to ocamlc and ocamlopt.
   (Abiola Abdulsalam, review by Sébastien Hinderer and Florian Angeletti)
 
 ### Internal/compiler-libs changes:

--- a/driver/main_args.ml
+++ b/driver/main_args.ml
@@ -135,15 +135,12 @@ let mk_for_pack_opt f =
 let mk_g_byt f =
   "-g", Arg.Unit f, " Save debugging information"
 
-let mk_no_g_byt f =
-  "-no-g", Arg.Unit f, " Do not save debugging information"
-
 let mk_g_opt f =
   "-g", Arg.Unit f, " Record debugging information for exception backtrace"
 
-let mk_no_g_opt f =
+let mk_no_g f =
   "-no-g", Arg.Unit f,
-  " Do not record debugging information for exception backtrace"
+  " Do not record debugging information (default)"
 
 let mk_i f =
   "-i", Arg.Unit f, " Print inferred interface"
@@ -859,7 +856,6 @@ module type Compiler_options = sig
   val _where : unit -> unit
   val _color : string -> unit
   val _error_style : string -> unit
-
   val _match_context_rows : int -> unit
   val _dtimings : unit -> unit
   val _dprofile : unit -> unit
@@ -1029,7 +1025,7 @@ struct
     mk_dtypes F._annot;
     mk_for_pack_byt F._for_pack;
     mk_g_byt F._g;
-    mk_no_g_byt F._no_g;
+    mk_no_g F._no_g;
     mk_stop_after ~native:false F._stop_after;
     mk_i F._i;
     mk_I F._I;
@@ -1220,7 +1216,7 @@ struct
     mk_dtypes F._annot;
     mk_for_pack_opt F._for_pack;
     mk_g_opt F._g;
-    mk_no_g_opt F._no_g;
+    mk_no_g F._no_g;
     mk_function_sections F._function_sections;
     mk_stop_after ~native:true F._stop_after;
     mk_save_ir_after ~native:true F._save_ir_after;

--- a/driver/main_args.ml
+++ b/driver/main_args.ml
@@ -135,8 +135,15 @@ let mk_for_pack_opt f =
 let mk_g_byt f =
   "-g", Arg.Unit f, " Save debugging information"
 
+let mk_no_g_byt f =
+  "-no-g", Arg.Unit f, " Do not save debugging information"
+
 let mk_g_opt f =
   "-g", Arg.Unit f, " Record debugging information for exception backtrace"
+
+let mk_no_g_opt f =
+  "-no-g", Arg.Unit f,
+  " Do not record debugging information for exception backtrace"
 
 let mk_i f =
   "-i", Arg.Unit f, " Print inferred interface"
@@ -820,6 +827,7 @@ module type Compiler_options = sig
   val _config_var : string -> unit
   val _for_pack : string -> unit
   val _g : unit -> unit
+  val _no_g : unit -> unit
   val _stop_after : string -> unit
   val _i : unit -> unit
   val _impl : string -> unit
@@ -1021,6 +1029,7 @@ struct
     mk_dtypes F._annot;
     mk_for_pack_byt F._for_pack;
     mk_g_byt F._g;
+    mk_no_g_byt F._no_g;
     mk_stop_after ~native:false F._stop_after;
     mk_i F._i;
     mk_I F._I;
@@ -1211,6 +1220,7 @@ struct
     mk_dtypes F._annot;
     mk_for_pack_opt F._for_pack;
     mk_g_opt F._g;
+    mk_no_g_opt F._no_g;
     mk_function_sections F._function_sections;
     mk_stop_after ~native:true F._stop_after;
     mk_save_ir_after ~native:true F._save_ir_after;
@@ -1732,6 +1742,7 @@ module Default = struct
     let _dump_dir s = dump_dir := Some s
     let _for_pack s = for_package := (Some s)
     let _g = set debug
+    let _no_g = clear debug
     let _i = set print_types
     let _impl = Compenv.impl
     let _intf = Compenv.intf

--- a/driver/main_args.mli
+++ b/driver/main_args.mli
@@ -86,6 +86,7 @@ module type Compiler_options = sig
   val _config_var : string -> unit
   val _for_pack : string -> unit
   val _g : unit -> unit
+  val _no_g : unit -> unit
   val _stop_after : string -> unit
   val _i : unit -> unit
   val _impl : string -> unit

--- a/man/ocamlc.1
+++ b/man/ocamlc.1
@@ -391,6 +391,9 @@ required in order to be able to debug the program with
 and to produce stack backtraces when
 the program terminates on an uncaught exception.
 .TP
+.B \-no-g
+Do not add debugging information while compiling and linking.
+.TP
 .B \-i
 Cause the compiler to print all defined names (with their inferred
 types or their definitions) when compiling an implementation (.ml

--- a/man/ocamlc.1
+++ b/man/ocamlc.1
@@ -392,7 +392,7 @@ and to produce stack backtraces when
 the program terminates on an uncaught exception.
 .TP
 .B \-no-g
-Do not add debugging information while compiling and linking.
+Do not record debugging information (default).
 .TP
 .B \-i
 Cause the compiler to print all defined names (with their inferred

--- a/man/ocamlopt.1
+++ b/man/ocamlopt.1
@@ -294,6 +294,9 @@ required in order to produce stack backtraces when
 the program terminates on an uncaught exception (see
 .BR ocamlrun (1)).
 .TP
+.B \-no-g
+Do not add debugging information while compiling and linking.
+.TP
 .B \-i
 Cause the compiler to print all defined names (with their inferred
 types or their definitions) when compiling an implementation (.ml

--- a/man/ocamlopt.1
+++ b/man/ocamlopt.1
@@ -295,7 +295,7 @@ the program terminates on an uncaught exception (see
 .BR ocamlrun (1)).
 .TP
 .B \-no-g
-Do not add debugging information while compiling and linking.
+Do not record debugging information (default).
 .TP
 .B \-i
 Cause the compiler to print all defined names (with their inferred

--- a/manual/src/cmds/unified-options.etex
+++ b/manual/src/cmds/unified-options.etex
@@ -260,6 +260,11 @@ section~\ref{s:ocamlrun-options}).
 }%notop
 
 \notop{%
+\item["-no-g"]
+Do not add debugging information while compiling and linking.
+}%notop
+
+\notop{%
 \item["-i"]
 Cause the compiler to print all defined names (with their inferred
 types or their definitions) when compiling an implementation (".ml"

--- a/manual/src/cmds/unified-options.etex
+++ b/manual/src/cmds/unified-options.etex
@@ -261,7 +261,7 @@ section~\ref{s:ocamlrun-options}).
 
 \notop{%
 \item["-no-g"]
-Do not add debugging information while compiling and linking.
+Do not record debugging information (default).
 }%notop
 
 \notop{%


### PR DESCRIPTION
I am adding a -no-g #counterpart to the -g flag that matches the current default of the compiler.