### PR TITLE
better pretty-printing of module shapes

### DIFF
--- a/testsuite/tests/shapes/comp_units.ml
+++ b/testsuite/tests/shapes/comp_units.ml
@@ -97,8 +97,7 @@ module Without_constraint = Set.Make(Int)
 [%%expect{|
 {
  "Without_constraint"[module] ->
-     CU Stdlib . "Set"[module] . "Make"[module](
-     CU Stdlib . "Int"[module])<.9>;
+   CU Stdlib . "Set"[module] . "Make"[module](CU Stdlib . "Int"[module])<.9>;
  }
 module Without_constraint :
   sig
@@ -158,11 +157,11 @@ end
 [%%expect{|
 {
  "With_identity_constraint"[module] ->
-     {<.12>
-      "M"[module] ->
-          CU Stdlib . "Set"[module] . "Make"[module](
-          CU Stdlib . "Int"[module])<.10>;
-      };
+   {<.12>
+    "M"[module] ->
+      CU Stdlib . "Set"[module] . "Make"[module](
+      CU Stdlib . "Int"[module])<.10>;
+    };
  }
 module With_identity_constraint : sig module M : Set.S end
 |}]
@@ -175,14 +174,14 @@ end
 [%%expect{|
 {
  "With_constraining_constraint"[module] ->
-     {<.16>
-      "M"[module] ->
-          {<.13>
-           "t"[type] ->
-               CU Stdlib . "Set"[module] . "Make"[module](
-               CU Stdlib . "Int"[module])<.13> . "t"[type];
-           };
-      };
+   {<.16>
+    "M"[module] ->
+      {<.13>
+       "t"[type] ->
+         CU Stdlib . "Set"[module] . "Make"[module](
+         CU Stdlib . "Int"[module])<.13> . "t"[type];
+       };
+    };
  }
 module With_constraining_constraint : sig module M : sig type t end end
 |}]

--- a/testsuite/tests/shapes/functors.ml
+++ b/testsuite/tests/shapes/functors.ml
@@ -28,12 +28,12 @@ end
 [%%expect{|
 {
  "Finclude"[module] ->
-     Abs<.6>
-        (X/284,
-         {
-          "t"[type] -> X/284<.5> . "t"[type];
-          "x"[value] -> X/284<.5> . "x"[value];
-          });
+   Abs<.6>
+      (X/284,
+       {
+        "t"[type] -> X/284<.5> . "t"[type];
+        "x"[value] -> X/284<.5> . "x"[value];
+        });
  }
 module Finclude : functor (X : S) -> sig type t = X.t val x : t end
 |}]
@@ -45,10 +45,10 @@ end
 [%%expect{|
 {
  "Fredef"[module] ->
-     Abs<.10>(X/291, {
-                      "t"[type] -> <.8>;
-                      "x"[value] -> <.9>;
-                      });
+   Abs<.10>(X/291, {
+                    "t"[type] -> <.8>;
+                    "x"[value] -> <.9>;
+                    });
  }
 module Fredef : functor (X : S) -> sig type t = X.t val x : X.t end
 |}]
@@ -60,10 +60,10 @@ end
 [%%expect{|
 {
  "Fignore"[module] ->
-     Abs<.14>(()/1, {
-                     "t"[type] -> <.11>;
-                     "x"[value] -> <.13>;
-                     });
+   Abs<.14>(()/1, {
+                   "t"[type] -> <.11>;
+                   "x"[value] -> <.13>;
+                   });
  }
 module Fignore : S -> sig type t = Fresh val x : t end
 |}]
@@ -223,9 +223,9 @@ module Big_to_small1 : B2S = functor (X : Big) -> X
 [%%expect{|
 {
  "Big_to_small1"[module] ->
-     Abs<.40>(X/386, {<.39>
-                      "t"[type] -> X/386<.39> . "t"[type];
-                      });
+   Abs<.40>(X/386, {<.39>
+                    "t"[type] -> X/386<.39> . "t"[type];
+                    });
  }
 module Big_to_small1 : B2S
 |}]
@@ -234,9 +234,9 @@ module Big_to_small2 : B2S = functor (X : Big) -> struct include X end
 [%%expect{|
 {
  "Big_to_small2"[module] ->
-     Abs<.42>(X/389, {
-                      "t"[type] -> X/389<.41> . "t"[type];
-                      });
+   Abs<.42>(X/389, {
+                    "t"[type] -> X/389<.41> . "t"[type];
+                    });
  }
 module Big_to_small2 : B2S
 |}]

--- a/testsuite/tests/shapes/recmodules.ml
+++ b/testsuite/tests/shapes/recmodules.ml
@@ -80,16 +80,15 @@ end = Set.Make(A)
                  "t"[type] -> <.35>;
                  };
  "ASet"[module] ->
-     {
-      "compare"[value] ->
-          CU Stdlib . "Set"[module] . "Make"[module](A/325<.19>) .
-          "compare"[value];
-      "elt"[type] ->
-          CU Stdlib . "Set"[module] . "Make"[module](A/325<.19>) .
-          "elt"[type];
-      "t"[type] ->
-          CU Stdlib . "Set"[module] . "Make"[module](A/325<.19>) . "t"[type];
-      };
+   {
+    "compare"[value] ->
+      CU Stdlib . "Set"[module] . "Make"[module](A/325<.19>) .
+      "compare"[value];
+    "elt"[type] ->
+      CU Stdlib . "Set"[module] . "Make"[module](A/325<.19>) . "elt"[type];
+    "t"[type] ->
+      CU Stdlib . "Set"[module] . "Make"[module](A/325<.19>) . "t"[type];
+    };
  }
 module rec A :
   sig

--- a/testsuite/tests/shapes/rotor_example.ml
+++ b/testsuite/tests/shapes/rotor_example.ml
@@ -25,10 +25,10 @@ end
 [%%expect{|
 {
  "Pair"[module] ->
-     Abs<.9>(X/280, Y/281, {
-                            "t"[type] -> <.5>;
-                            "to_string"[value] -> <.6>;
-                            });
+   Abs<.9>(X/280, Y/281, {
+                          "t"[type] -> <.5>;
+                          "to_string"[value] -> <.6>;
+                          });
  }
 module Pair :
   functor (X : Stringable) (Y : Stringable) ->

--- a/testsuite/tests/shapes/rotor_example.ml
+++ b/testsuite/tests/shapes/rotor_example.ml
@@ -25,11 +25,10 @@ end
 [%%expect{|
 {
  "Pair"[module] ->
-     Abs<.9>
-        (X/280, Abs(Y/281, {
+     Abs<.9>(X/280, Y/281, {
                             "t"[type] -> <.5>;
                             "to_string"[value] -> <.6>;
-                            }));
+                            });
  }
 module Pair :
   functor (X : Stringable) (Y : Stringable) ->

--- a/typing/shape.ml
+++ b/typing/shape.ml
@@ -178,7 +178,7 @@ let print fmt =
     | Struct map ->
         let print_map fmt =
           Item.Map.iter (fun item t ->
-              Format.fprintf fmt "@[<hv 4>%a ->@ %a;@]@,"
+              Format.fprintf fmt "@[<hv 2>%a ->@ %a;@]@,"
                 Item.print item
                 aux t
             )


### PR DESCRIPTION
(Remember: "shapes" are an abstraction of the module structure of OCaml programs introduced in #10718.)

I am trying again to understand what it is about the Irmin source code that made earlier implementations of shape-reduction blow up. This involves looking at the `-dshape` output for a manually-minized subset of `irmin.ml`, whose printing starts like this:

```
 "Maker_ext"[module] ->
     Abs<Irmin_short.167>
        (CA/1399,
         Abs
            (AW/1400,
             Abs
                (N/1479,
                 Abs
                    (CT/1523,
                     {
                      "Make"[module] ->
                          Abs<Irmin_short.166>
                             (M/1529,
                              Abs
                                 (C/1555,
                                  Abs
                                     (P/1574,
                                      Abs
                                         (B/1588,
                                          Abs
                                             (H/1589,
                                              {
                                               "AW"[module] ->
                                                   Abs<Irmin_short.111>
                                                      (K/1234,
                                                       Abs
                                                          (V/1235,
                                                           {
                                                            "clear"[value] ->
                                                                <Irmin_short.97>;
                                                            "close"[value] ->
                                                                <Irmin_short.95>;
                                                            "find"[value] ->
                                                                <Irmin_short.62>;
```

(I won't show the whole output because it takes 2GiB.)

This PR introduces a compact notation for n-ary functors (and reduces the structure indentation slightly). `-dshape` then gives the following result:

```
 "Maker_ext"[module] ->
   Abs<Irmin_short.167>
      (CA/1399, AW/1400, N/1479, CT/1523,
       {
        "Make"[module] ->
          Abs<Irmin_short.166>
             (M/1529, C/1555, P/1574, B/1588, H/1589,
              {
               "AW"[module] ->
                 Abs<Irmin_short.111>
                    (K/1234, V/1235,
                     {
                      "clear"[value] -> <Irmin_short.97>;
                      "close"[value] -> <Irmin_short.95>;

```

which is much nicer to read and work with.