### PR TITLE
Config.mkexe should not include C flags that are used internally only

### DIFF
--- a/configure
+++ b/configure
@@ -19734,7 +19734,7 @@ fi
   if test -n "$mkexe_cflags"
 then :
   mkexe="$mkexe $mkexe_cflags"
-    mkexe_exp="$mkexe_exp $oc_cflags $CFLAGS"
+    mkexe_exp="$mkexe_exp $common_cflags $CFLAGS"
 fi
   if test -n "$mkexe_extra_flags"
 then :

--- a/configure.ac
+++ b/configure.ac
@@ -2255,7 +2255,7 @@ AC_CONFIG_COMMANDS_PRE([
   mkexe_exp="$mkexe_cmd_exp"
   AS_IF([test -n "$mkexe_cflags"],
     [mkexe="$mkexe $mkexe_cflags"
-    mkexe_exp="$mkexe_exp $oc_cflags $CFLAGS"])
+    mkexe_exp="$mkexe_exp $common_cflags $CFLAGS"])
   AS_IF([test -n "$mkexe_extra_flags"],
     [mkexe="$mkexe $mkexe_extra_flags"
     mkexe_exp="$mkexe_exp $mkexe_extra_flags"])


### PR DESCRIPTION
During the configure stage, two sets of C flags are distinguished:
those to be used to build programs during the compiler's build
(internal C flags) and those to be used when the compiler itself
builds user programs.

There was a mistake in the way the flags to use to build user programs
were computed, so that they ended up being built with internal flags.

One such flag was `-g`, which on some operating systems led to
the creation of spurious `.dSYM` files and directories.