### PR TITLE
Enabling frame pointers should not add -g to CFLAGS

### DIFF
--- a/configure
+++ b/configure
@@ -19010,7 +19010,7 @@ if test x"$enable_frame_pointers" = "xyes"
 then :
   case "$host,$cc_basename" in #(
   x86_64-*-linux*,gcc*|x86_64-*-linux*,clang*) :
-    common_cflags="$common_cflags -g  -fno-omit-frame-pointer"
+    common_cflags="$common_cflags -fno-omit-frame-pointer"
       frame_pointers=true
       printf "%s\n" "#define WITH_FRAME_POINTERS 1" >>confdefs.h
 

--- a/configure.ac
+++ b/configure.ac
@@ -2010,7 +2010,7 @@ AS_IF([$native_compiler],
 AS_IF([test x"$enable_frame_pointers" = "xyes"],
   [AS_CASE(["$host,$cc_basename"],
     [x86_64-*-linux*,gcc*|x86_64-*-linux*,clang*],
-      [common_cflags="$common_cflags -g  -fno-omit-frame-pointer"
+      [common_cflags="$common_cflags -fno-omit-frame-pointer"
       frame_pointers=true
       AC_DEFINE([WITH_FRAME_POINTERS])
       AC_MSG_NOTICE([using frame pointers])],

--- a/otherlibs/Makefile.otherlibs.common
+++ b/otherlibs/Makefile.otherlibs.common
@@ -22,10 +22,6 @@ include $(ROOTDIR)/Makefile.best_binaries
 CAMLC := $(BEST_OCAMLC) $(STDLIBFLAGS)
 CAMLOPT := $(BEST_OCAMLOPT) $(STDLIBFLAGS)
 
-ifneq "$(CCOMPTYPE)" "msvc"
-OC_CFLAGS += -g
-endif
-
 OC_CFLAGS += $(SHAREDLIB_CFLAGS)
 
 # Compilation options

--- a/otherlibs/systhreads/Makefile
+++ b/otherlibs/systhreads/Makefile
@@ -18,10 +18,6 @@ ROOTDIR=../..
 include $(ROOTDIR)/Makefile.common
 include $(ROOTDIR)/Makefile.best_binaries
 
-ifneq "$(CCOMPTYPE)" "msvc"
-OC_CFLAGS += -g
-endif
-
 OC_CFLAGS += $(SHAREDLIB_CFLAGS)
 
 LIBS = $(STDLIBFLAGS) -I $(ROOTDIR)/otherlibs/unix


### PR DESCRIPTION
The -g flags was added to the CFLAGS used for frame pointers in f4d6eafbd31
but does not actually seem useful nowadays.