### PR TITLE
yacc/closure.c: fix 'closure' prototype

### DIFF
--- a/yacc/closure.c
+++ b/yacc/closure.c
@@ -28,7 +28,7 @@ static unsigned *EFF;
 
 void print_EFF (void);
 void print_first_derives (void);
-void print_closure (void);
+void print_closure (int n);
 
 void set_EFF(void)
 {


### PR DESCRIPTION
Fixes #11700 