### PR TITLE
Fix construction of Effect.Unhandled in bytecode

### DIFF
--- a/Changes
+++ b/Changes
@@ -358,6 +358,11 @@ OCaml 5.0
 - #11652: Fix benign off-by-one error in Windows implementation of caml_mem_map.
   (David Allsopp, review by Gabriel Scherer)
 
+- #11669, #11704: Fix construction of Effect.Unhandled exceptions in the
+  bytecode interpreter.
+  (David Allsopp and Xavier Leroy, report by Samuel Hym, review by Xavier Leroy
+  and Gabriel Scherer)
+
 ### Code generation and optimizations:
 
 - #10972: ARM64 multicore support: OCaml & C stack separation;

--- a/runtime/interp.c
+++ b/runtime/interp.c
@@ -1326,7 +1326,9 @@ do_resume: {
 
       check_trap_barrier_for_effect (domain_state);
       if (parent_stack == NULL) {
+        Setup_for_c_call;
         accu = caml_make_unhandled_effect_exn(accu);
+        Restore_after_c_call;
         goto raise_exception;
       }
 
@@ -1370,9 +1372,12 @@ do_resume: {
       sp[1] = Val_long(extra_args);
 
       if (parent == NULL) {
-        accu = caml_continuation_use(cont);
-        resume_fn = raise_unhandled_effect;
+        Setup_for_c_call;
         resume_arg = caml_make_unhandled_effect_exn(eff);
+        accu = caml_continuation_use(cont);
+        Restore_after_c_call;
+        resume_fn = raise_unhandled_effect;
+
         goto do_resume;
       }
 


### PR DESCRIPTION
`caml_make_unhandled_effect` can allocate, so the call needs to ensure that the virtual machine is set-up for the GC.

The original segfault reported in #11669 arises from the `PERFORM` path - I've assumed that the `REPERFORMTERM` path could suffer in the same way. I couldn't re-trigger @shym's original failure with this patch.