### PR TITLE
Fixing typos

### DIFF
--- a/Changes
+++ b/Changes
@@ -571,14 +571,14 @@ OCaml 5.0
   (Christopher Zimmermann, review by Anil Madhavapeddy)
 
 - #11126: Build system: make it possible to choose which ocamldep
-  (and flags) to use when computing depencies for the compiler.
+  (and flags) to use when computing dependencies for the compiler.
   Add a -no-slash option to ocamldep to let users override -slash.
   (Sébastien Hinderer, review by David Allsopp)
 
 - #11147: Factorize the stdlib-related compilation flags. Make it
   possible to control them consistently through the STDLIBFLAGS
   build variable. Make sure ocamldoc and ocamllex get compiled and
-  linked with debugging informations (-g).
+  linked with debugging information (-g).
   (Sébastien Hinderer, review by Gabriel Scherer)
 
 - #11149: Make the bootstrap process reproducible on systems with non-big-endian

--- a/Makefile.common
+++ b/Makefile.common
@@ -98,7 +98,7 @@ ALL_OTHERLIBS = dynlink str systhreads unix runtime_events
 # The following variable defines flags to be passed to the C preprocessor
 # when compiling C files for the native runtime.
 # These flags should be passed *in addition* to those in OC_CPPFLAGS, they
-# should not repace them.
+# should not replace them.
 OC_NATIVE_CPPFLAGS=\
   -DNATIVE_CODE -DTARGET_$(ARCH) -DMODEL_$(MODEL) -DSYS_$(SYSTEM)
 

--- a/configure
+++ b/configure
@@ -19573,13 +19573,13 @@ unset ac_cv_header_flexdll_h
 
 # Just before config.status is generated, determine the final values for MKEXE,
 # MKDLL, MKMAINDLL and MKEXE_VIA_CC. The final variables controlling these are:
-# $mkexe - the linking commmand and munged CFLAGS + any extra flexlink flags
+# $mkexe - the linking command and munged CFLAGS + any extra flexlink flags
 # $mkexe_exp: same as above but expanded
 # $mkdll - the full linking command for DLLs
 # $mkdll_exp: same as above but expanded
 # $mkmaindll - the full linking command for main program in DLL
 # $oc_ldflags $oc_dll_ldflags are handled as $(OC_LDFLAGS) and
-# $(OC_DLL_LDFLAGS) and can be overidden in the build.
+# $(OC_DLL_LDFLAGS) and can be overridden in the build.
 
 
 cat >confcache <<\_ACEOF

--- a/configure.ac
+++ b/configure.ac
@@ -2242,13 +2242,13 @@ AC_CONFIG_COMMANDS_PRE([
 
 # Just before config.status is generated, determine the final values for MKEXE,
 # MKDLL, MKMAINDLL and MKEXE_VIA_CC. The final variables controlling these are:
-# $mkexe - the linking commmand and munged CFLAGS + any extra flexlink flags
+# $mkexe - the linking command and munged CFLAGS + any extra flexlink flags
 # $mkexe_exp: same as above but expanded
 # $mkdll - the full linking command for DLLs
 # $mkdll_exp: same as above but expanded
 # $mkmaindll - the full linking command for main program in DLL
 # $oc_ldflags $oc_dll_ldflags are handled as $(OC_LDFLAGS) and
-# $(OC_DLL_LDFLAGS) and can be overidden in the build.
+# $(OC_DLL_LDFLAGS) and can be overridden in the build.
 AC_CONFIG_COMMANDS_PRE([
   # Construct $mkexe
   mkexe="$mkexe_cmd"

--- a/lambda/switch.ml
+++ b/lambda/switch.ml
@@ -188,7 +188,7 @@ end
  1. The code to compute an optimal sequence of tests also makes use of
     an interval check (is the input in the range [m; n]), which
     (as remarked by Bernstein) can be implemented efficiently as
-    a substraction and an unsigned comparison. We don't know of an
+    a subtraction and an unsigned comparison. We don't know of an
     efficient algorithm to compute optimal test sequences using both
     comparison and interval checks, so instead:
     a. on large input intervals, we use the dichotomy
@@ -634,9 +634,9 @@ let rec pkey chan  = function
          else act810
        else act_default
 
-     Our interval check works by substracting the interval lower
+     Our interval check works by subtracting the interval lower
      bound, then checking a range [0; n] using an unsigned
-     comparison. Naively we would generate code with one substraction
+     comparison. Naively we would generate code with one subtraction
      to [a] before each comparison:
 
        let tmp1 = a - 2 in
@@ -650,7 +650,7 @@ let rec pkey chan  = function
        else act_default
 
      but we can avoid some substractions by working with the result
-     of the first substraction, instead of the original index [a],
+     of the first subtraction, instead of the original index [a],
      inside the interval.
 
        let a2 = a - 2 in
@@ -662,7 +662,7 @@ let rec pkey chan  = function
            else act810
        else act_default
 
-     The type [t_ctx] represents an input argumnt "shifted" by a certain
+     The type [t_ctx] represents an input argument "shifted" by a certain
      (negative) offset by repeated substractions.
 
      In the example above, [a5] would be represented with [off = -5].

--- a/manual/src/refman/extensions/bindingops.etex
+++ b/manual/src/refman/extensions/bindingops.etex
@@ -32,7 +32,7 @@ working with monads and applicative functors; for those, we propose
 conventions using operators "*" and "+" respectively. They may be used
 for other purposes, but one should keep in mind that each new
 unfamiliar notation introduced makes programs harder to understand for
-non-experts. We expect that new conventions will be developped over
+non-experts. We expect that new conventions will be developed over
 time on other families of operator.
 
 \subsection{ss:letop-examples}{Examples}

--- a/manual/styles/html.sty
+++ b/manual/styles/html.sty
@@ -105,7 +105,7 @@
 % Basic approach:
 % to comment something out, scoop up  every line in verbatim mode
 % as macro argument, then throw it away.
-% For inclusions, both the opening and closing comands
+% For inclusions, both the opening and closing commands
 % are defined as noop
 %
 % Changed \next to \html@next to prevent clashes with other sty files

--- a/ocamldoc/odoc_type.mli
+++ b/ocamldoc/odoc_type.mli
@@ -16,7 +16,7 @@
 (** Representation and manipulation of a type, but not class nor module type.*)
 
 (** This module has an implementation although it declares only types.
-    This is because other modules yse the let module construct ot access it
+    This is because other modules use the let module construct or access it
     so it is needed as a real module. *)
 
 module Name = Odoc_name

--- a/otherlibs/runtime_events/runtime_events.mli
+++ b/otherlibs/runtime_events/runtime_events.mli
@@ -15,7 +15,7 @@
 (** Runtime events - ring buffer-based runtime tracing
 
     This module enables users to enable and subscribe to tracing events
-    from the Garbage Collector and othe parts of the OCaml runtime. This can
+    from the Garbage Collector and other parts of the OCaml runtime. This can
     be useful for diagnostic or performance monitoring purposes. This module
     can be used to subscribe to events for the current process or external
     processes asynchronously.
@@ -24,7 +24,7 @@
     variable or calling Runtime_events.start) a file with the pid of the process
     and extension .events will be created. By default this is in the
     current directory but can be over-ridden by the OCAML_RUNTIME_EVENTS_DIR
-    environent variable. Each domain maintains its own ring buffer in a section
+    environment variable. Each domain maintains its own ring buffer in a section
     of the larger file into which it emits events.
 
     There is additionally a set of C APIs in runtime_events.h that can enable
@@ -150,7 +150,7 @@ module Callbacks : sig
   (** Create a [Callback] that optionally subscribes to one or more runtime
       events. The first int supplied to callbacks is the ring buffer index.
       Each domain owns a single ring buffer for the duration of the domain's
-      existance. After a domain terminates, a newly spawned domain may take
+      existence. After a domain terminates, a newly spawned domain may take
       ownership of the ring buffer. A [runtime_begin] callback is called when
       the runtime enters a new phase (e.g a runtime_begin with EV_MINOR is
       called at the start of a minor GC). A [runtime_end] callback is called

--- a/otherlibs/unix/socket_win32.c
+++ b/otherlibs/unix/socket_win32.c
@@ -42,7 +42,7 @@ SOCKET caml_win32_socket(int domain, int type, int protocol,
   s = WSASocket(domain, type, protocol, info, 0, flags);
   if (s == INVALID_SOCKET) {
     if (! inherit && WSAGetLastError() == WSAEINVAL) {
-      /* WSASocket probably doesn't suport WSA_FLAG_NO_HANDLE_INHERIT,
+      /* WSASocket probably doesn't support WSA_FLAG_NO_HANDLE_INHERIT,
        * retry without. */
       flags &= ~(DWORD)WSA_FLAG_NO_HANDLE_INHERIT;
       s = WSASocket(domain, type, protocol, info, 0, flags);

--- a/release-info/News
+++ b/release-info/News
@@ -61,7 +61,7 @@ OCaml 4.11.0  (19 August 2020)
 - A new instrumented runtime that logs runtime statistics in a standard format
 - A native backend for the RISC-V architecture
 - Improved backtraces that refer to function names
-- Suppport for recursive and yet unboxed types
+- Support for recursive and yet unboxed types
 - A quoted extension syntax for ppxs.
 - Many quality of life improvements
 - Many bug fixes.

--- a/runtime/HACKING.adoc
+++ b/runtime/HACKING.adoc
@@ -153,4 +153,4 @@ TODO: I would be curious to know!
 (For the brave there are some scripts in
 link:../tools/ci/inria/sanitizers/script[], but you probably don't
 want to run them directly, in particular they will `git clean -xfd`,
-destroying changed/uncommited files in your development repository!)
+destroying changed/uncommitted files in your development repository!)

--- a/runtime/caml/misc.h
+++ b/runtime/caml/misc.h
@@ -286,7 +286,7 @@ void caml_alloc_point_here(void);
 
 /* This hook is called when a fatal error occurs in the OCaml
    runtime. It is given arguments to be passed to the [vprintf]-like
-   functions in order to synthetize the error message.
+   functions in order to synthesize the error message.
    If it returns, the runtime calls [abort()].
 
    If it is [NULL], the error message is printed on stderr and then

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -812,7 +812,7 @@ static void stw_resize_minor_heap_reservation(caml_domain_state* domain,
        and it also updates the reservation boundaries of each domain
        by mutating its [minor_heap_area_start{,_end}] variables.
 
-       Thse variables are synchronized by the fact that we are inside
+       These variables are synchronized by the fact that we are inside
        a STW section: no other domains are running in parallel, and
        the participating domains will synchronize with this write by
        exiting the barrier, before they read those variables in

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -1545,7 +1545,7 @@ static void mark_stack_prune(struct mark_stack* stk)
     mark_entry me = stk->stack[i];
     total_words += me.end - me.start;
     if (me.end - me.start > BITS_PER_WORD) {
-      /* keep entry in the stack as more efficent and move to front */
+      /* keep entry in the stack as more efficient and move to front */
       stk->stack[new_stk_count++] = me;
     } else {
       while(me.start < me.end) {

--- a/runtime/shared_heap.c
+++ b/runtime/shared_heap.c
@@ -256,7 +256,7 @@ static intnat pool_sweep(struct caml_heap_state* local,
                          int release_to_global_pool);
 
 /* Adopt pool from the pool_freelist avail and full pools
-   to satisfy an alloction */
+   to satisfy an allocation */
 static pool* pool_global_adopt(struct caml_heap_state* local, sizeclass sz)
 {
   pool* r = NULL;

--- a/stdlib/camlinternalLazy.ml
+++ b/stdlib/camlinternalLazy.ml
@@ -83,7 +83,7 @@ let force_lazy_block blk = force_gen_lazy_block ~only_val:false blk
 let force_gen ~only_val (lzv : 'arg lazy_t) =
   (* Using [Sys.opaque_identity] prevents two potential problems:
      - If the value is known to have Forward_tag, then it could have been
-       shorcut during GC, so that information must be forgotten (see GPR#713
+       shortcut during GC, so that information must be forgotten (see GPR#713
        and issue #7301). This is not an issue here at the moment since
        [Obj.tag] is not simplified by the compiler, and GPR#713 also
        ensures that no value will be known to have Forward_tag.

--- a/stdlib/queue.mli
+++ b/stdlib/queue.mli
@@ -149,7 +149,7 @@ val of_seq : 'a Seq.t -> 'a t
 
     (* Search in graph [g] using BFS, starting from node [start].
        It returns the first node that satisfies [p], or [None] if
-       no node reachable from [start] satifies [p].
+       no node reachable from [start] satisfies [p].
     *)
     let search_for ~(g:graph) ~(start:int) (p:int -> bool) : int option =
       let to_explore = Queue.create() in

--- a/stdlib/stdlib.mli
+++ b/stdlib/stdlib.mli
@@ -1352,7 +1352,7 @@ val exit : int -> 'a
     system: usually 0 to indicate no errors, and a small positive integer to
     indicate failure. All open output channels are flushed with [flush_all].
     The callbacks registered with {!Domain.at_exit} are called followed by
-    those registed with {!Stdlib.at_exit}.
+    those registered with {!Stdlib.at_exit}.
 
     An implicit [exit 0] is performed each time a program terminates normally.
     An implicit [exit 2] is performed if the program terminates early because

--- a/testsuite/tests/frame-pointers/c_call.ml
+++ b/testsuite/tests/frame-pointers/c_call.ml
@@ -17,9 +17,9 @@ let[@inline never] f () =
   (* Check backtrace through caml_c_call_stack_args *)
   fp_backtrace_many_args 1 2 3 4 5 6 7 8 9 10 11;
   (* Check backtrace through caml_c_call.
-   * Also check that caml_c_call_stack_args correclty restores rbp register *)
+   * Also check that caml_c_call_stack_args correctly restores rbp register *)
   fp_backtrace ();
-  (* Check caml_c_call correclty restores rbp register *)
+  (* Check caml_c_call correctly restores rbp register *)
   fp_backtrace_no_alloc ();
   42
 

--- a/testsuite/tests/frame-pointers/fp_backtrace.c
+++ b/testsuite/tests/frame-pointers/fp_backtrace.c
@@ -18,7 +18,7 @@ jmp_buf resume_buf;
 static void signal_handler(int signum)
 {
   /* Should be safe to be called from a signal handler.
-   * See 21.2.1 "Performing a nonlocal goto from a signal hanlder" from
+   * See 21.2.1 "Performing a nonlocal goto from a signal handler" from
    * The Linux Programming Interface, Michael Kerrisk */
   siglongjmp(resume_buf, 1);
 }

--- a/typing/parmatch.ml
+++ b/typing/parmatch.ml
@@ -1585,7 +1585,7 @@ let extract_columns pss qs = match pss with
 
 let rec every_satisfiables pss qs = match qs.active with
 | []     ->
-    (* qs is now partitionned,  check usefulness *)
+    (* qs is now partitioned,  check usefulness *)
     begin match qs.ors with
     | [] -> (* no or-patterns *)
         if satisfiable (make_matrix pss) (make_vector qs) then

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -1222,7 +1222,7 @@ let disambiguate_lid_a_list loc closed env usage expected_type lid_a_list =
        Prefixing unqualified labels does not change the final
        disambiguation result, it restricts the set of candidates
        without removing any valid choice.
-       It matters if users activated warnings for ambigious or
+       It matters if users activated warnings for ambiguous or
        out-of-scope resolutions -- they get less warnings by
        qualifying at least one of the fields. *)
     List.map2 (fun lid_a lbl ->


### PR DESCRIPTION
Typos found with https://github.com/codespell-project/codespell

Question:
in the file _runtime/caml/misc.h_ L289
we have 'synthetize' . Is this spelling correct (instead of 'synthesize')?