### PR TITLE
Use __asm__ instead of asm for strict ISO C conformance

### DIFF
--- a/runtime/caml/platform.h
+++ b/runtime/caml/platform.h
@@ -36,12 +36,12 @@
 Caml_inline void cpu_relax() {
 #ifdef __GNUC__
 #if defined(__x86_64__) || defined(__i386__)
-  asm volatile("pause" ::: "memory");
+  __asm__ volatile("pause" ::: "memory");
 #elif defined(__aarch64__)
-  asm volatile ("yield" ::: "memory");
+  __asm__ volatile ("yield" ::: "memory");
 #else
   /* Just a compiler barrier */
-  asm volatile ("" ::: "memory");
+  __asm__ volatile ("" ::: "memory");
 #endif
 #endif
 }


### PR DESCRIPTION
Although GCC and Clang accept `asm` even in `-std=cXX` mode, other compilers do not (see #11691 for a report).  So, it's safer to use `__asm__` instead.

Ref: https://gcc.gnu.org/onlinedocs/gcc-12.2.0/gcc/Alternate-Keywords.html

Fixes: #11691
