### PR TITLE
Add definition of cpu_relax for RISC-V

### DIFF
--- a/Changes
+++ b/Changes
@@ -36,7 +36,7 @@ Working version
 - #11102: Speed up register allocation by permanently spilling registers
   (Stephen Dolan, review by Xavier Leroy)
 
-- #11418: RISC-V multicore support.
+- #11418, #11708: RISC-V multicore support.
   (Nicolás Ojeda Bär, review by KC Sivaramakrishnan)
 
 - #11686: Better spilling heuristic for the Linear Scan allocator for more

--- a/configure
+++ b/configure
@@ -15436,7 +15436,7 @@ fi; system=elf ;; #(
   x86_64-*-cygwin*) :
     arch=amd64; system=cygwin ;; #(
   riscv64-*-linux*) :
-    arch=riscv; model=riscv64; system=linux
+    has_native_backend=yes; arch=riscv; model=riscv64; system=linux
  ;; #(
   *) :
      ;;

--- a/configure.ac
+++ b/configure.ac
@@ -1268,7 +1268,7 @@ AS_CASE([$host],
   [x86_64-*-cygwin*],
     [arch=amd64; system=cygwin],
   [riscv64-*-linux*],
-    [arch=riscv; model=riscv64; system=linux]
+    [has_native_backend=yes; arch=riscv; model=riscv64; system=linux]
 )
 
 AS_CASE([$ccomptype],

--- a/runtime/caml/platform.h
+++ b/runtime/caml/platform.h
@@ -40,7 +40,7 @@ Caml_inline void cpu_relax() {
 #elif defined(__aarch64__)
   asm volatile ("yield" ::: "memory");
 #elif defined(__riscv)
-  asm volatile ("pause");
+  asm volatile (".4byte 0x100000F");
 #else
   /* Just a compiler barrier */
   asm volatile ("" ::: "memory");

--- a/runtime/caml/platform.h
+++ b/runtime/caml/platform.h
@@ -39,6 +39,8 @@ Caml_inline void cpu_relax() {
   asm volatile("pause" ::: "memory");
 #elif defined(__aarch64__)
   asm volatile ("yield" ::: "memory");
+#elif defined(__riscv)
+  asm volatile ("pause");
 #else
   /* Just a compiler barrier */
   asm volatile ("" ::: "memory");

--- a/runtime/caml/platform.h
+++ b/runtime/caml/platform.h
@@ -40,6 +40,7 @@ Caml_inline void cpu_relax() {
 #elif defined(__aarch64__)
   __asm__ volatile ("yield" ::: "memory");
 #elif defined(__riscv)
+  /* Encoding of the pause instruction */
   __asm__ volatile (".4byte 0x100000F");
 #else
   /* Just a compiler barrier */

--- a/runtime/riscv.S
+++ b/runtime/riscv.S
@@ -702,15 +702,15 @@ L(do_perform):
         mv      a3, TMP                /* a3 := effect handler */
         tail    PLT(caml_apply3)
 1:
-    /*  switch back to original performer before raising Unhandled
+    /*  switch back to original performer before raising Effect.Unhandled
         (no-op unless this is a reperform) */
         ld      t4, 0(a1) /* load performer stack from continuation */
         addi    t4, t4, -1 /* t4 := Ptr_val(t4) */
         ld      t3, Caml_state(current_stack)
         SWITCH_OCAML_STACKS t3, t4
-    /*  No parent stack. Raise Unhandled. */
-        la      a0, caml_exn_Unhandled
-        j       caml_raise_exn
+    /*  No parent stack. Raise Effect.Unhandled. */
+        la      ADDITIONAL_ARG, caml_raise_unhandled_effect
+        j       caml_c_call
 END_FUNCTION(caml_perform)
 
 FUNCTION(caml_reperform)
@@ -743,8 +743,8 @@ FUNCTION(caml_resume)
         SWITCH_OCAML_STACKS t3, a0
         mv      a0, a2
         jr      a3
-2:      la      a0, caml_exn_Continuation_already_taken
-        j       caml_raise_exn
+2:      la      ADDITIONAL_ARG, caml_raise_continuation_already_resumed
+        j       caml_c_call
 END_FUNCTION(caml_resume)
 
 /* Run a function on a new stack, then either


### PR DESCRIPTION
The macro `__riscv` is documented here: https://github.com/riscv-non-isa/riscv-c-api-doc/blob/master/riscv-c-api.md#preprocessor-definitions

Not really sure how to test this, but I guess that running the testsuite should be enough. Will report back here once it is complete.