### PR TITLE
test_instrumented.ml: should run only if instrumented runtime is available

### DIFF
--- a/testsuite/tests/lib-runtime-events/test_instrumented.ml
+++ b/testsuite/tests/lib-runtime-events/test_instrumented.ml
@@ -1,7 +1,9 @@
 (* TEST
-  * native
-    include runtime_events
-    flags = "-runtime-variant=i"
+   include runtime_events
+   flags = "-runtime-variant=i"
+
+   * instrumented-runtime
+   ** native
 *)
 
 open Runtime_events


### PR DESCRIPTION
What it says on the tin. See https://github.com/ocaml/ocaml/pull/11708#issuecomment-1309072543 for the context.