### PR TITLE
reintroduce native compiler for s390x

### DIFF
--- a/Changes
+++ b/Changes
@@ -243,13 +243,15 @@ OCaml 5.1.0
   (Nicolás Ojeda Bär, Gabriel Scherer, Alain Frisch, review by Gabriel Scherer,
   Alain Frisch and Nathanaëlle Courant)
 
+- #11712: s390x / IBM Z multicore support: OCaml & C stack separation;
+  dynamic stack size checks; fiber and effects support.
+  (Aleksei Nikiforov, with help from Vincent Laviron,
+   additional suggestions by Xavier Leroy and Luc Maranget,
+   review by Xavier Leroy and KC Sivaramakrishnan)
+
 - #11904: Remove arm, i386 native-code backends.
   (Nicolás Ojeda Bär, review by Stephen Dolan, Anil Madhavapeddy, and Xavier
   Leroy)
-
-- #11712: s390x multicore support: OCaml & C stack separation;
-  dynamic stack size checks; fiber and effects support.
-  (Aleksei Nikiforov, Vincent Laviron, suggestions by Xavier Leroy, Luc Maranget)
 
 ### Standard library:
 

--- a/Changes
+++ b/Changes
@@ -247,6 +247,10 @@ OCaml 5.1.0
   (Nicolás Ojeda Bär, review by Stephen Dolan, Anil Madhavapeddy, and Xavier
   Leroy)
 
+- #11712: s390x multicore support: OCaml & C stack separation;
+  dynamic stack size checks; fiber and effects support.
+  (Aleksei Nikiforov, Vincent Laviron, suggestions by Xavier Leroy, Luc Maranget)
+
 ### Standard library:
 
 * #11565: Enable -strict-formats by default. Some incorrect format

--- a/asmcomp/s390x/emit.mlp
+++ b/asmcomp/s390x/emit.mlp
@@ -431,21 +431,33 @@ let emit_instr env i =
         emit_load_store storeinstr addr i.arg 1 i.arg.(0)
 
     | Lop(Ialloc { bytes = n; dbginfo }) ->
-        let lbl_after_alloc = new_label() in
-        let lbl_call_gc = new_label() in
-        let lbl_frame =
-          record_frame_label env i.live (Dbg_alloc dbginfo)
-        in
-        env.call_gc_sites <-
-          { gc_lbl = lbl_call_gc;
-            gc_return_lbl = lbl_after_alloc;
-            gc_frame_lbl = lbl_frame; } :: env.call_gc_sites;
-        `	lay     %r11, {emit_int(-n)}(%r11)\n`;
-        let offset = Domainstate.(idx_of_field Domain_young_limit) * 8 in
-        `	clg	%r11, {emit_int offset}(%r10)\n`;
-        `	brcl    4, {emit_label lbl_call_gc}\n`;  (* less than *)
-        `{emit_label lbl_after_alloc}:`;
-        `	la      {emit_reg i.res.(0)}, 8(%r11)\n`
+        let lbl_frame_lbl = record_frame_label env i.live (Dbg_alloc dbginfo) in
+        if env.f.fun_fast then begin
+          let lbl_after_alloc = new_label () in
+          let lbl_call_gc = new_label () in
+          let offset = Domainstate.(idx_of_field Domain_young_limit) * 8 in
+          `	lay     %r11, {emit_int(-n)}(%r11)\n`;
+          `	clg	%r11, {emit_int offset}(%r10)\n`;
+          `	brcl    4, {emit_label lbl_call_gc}\n`;  (* less than *)
+          `{emit_label lbl_after_alloc}:`;
+          `	la      {emit_reg i.res.(0)}, 8(%r11)\n`;
+          env.call_gc_sites <-
+            { gc_lbl = lbl_call_gc;
+              gc_return_lbl = lbl_after_alloc;
+              gc_frame_lbl = lbl_frame_lbl } :: env.call_gc_sites
+        end else begin
+          begin match n with
+          | 16 -> `	{emit_call "caml_alloc1"}\n`
+          | 24 -> `	{emit_call "caml_alloc2"}\n`
+          | 32 -> `	{emit_call "caml_alloc3"}\n`
+          | _  ->
+              `	lay     %r11, {emit_int(-n)}(%r11)\n`;
+              `	{emit_call "caml_allocN"}\n`
+          end;
+          `{emit_label lbl_frame_lbl}:\n`;
+          `	la      {emit_reg i.res.(0)}, 8(%r11)\n`
+        end
+
     | Lop(Ipoll { return_label }) ->
         let offset = Domainstate.(idx_of_field Domain_young_limit) * 8 in
           `	clg	%r11, {emit_int offset}(%r10)\n`;

--- a/asmcomp/s390x/emit.mlp
+++ b/asmcomp/s390x/emit.mlp
@@ -712,11 +712,51 @@ let fundecl fundecl =
   `	.align	8\n`;
   `{emit_symbol fundecl.fun_name}:\n`;
   cfi_startproc ();
+
+  (* Dynamic stack checking *)
+  let stack_threshold_size = Config.stack_threshold * 8 in (* bytes *)
+  let { max_frame_size; contains_nontail_calls} =
+    preproc_stack_check
+      ~fun_body:fundecl.fun_body ~frame_size:(frame_size env) ~trap_size:16
+  in
+  let handle_overflow = ref None in
+  if contains_nontail_calls || max_frame_size >= stack_threshold_size then begin
+    let overflow = new_label () and ret = new_label () in
+    let threshold_offset = Domainstate.stack_ctx_words * 8 + stack_threshold_size in
+    let f = max_frame_size + threshold_offset in
+    let offset = Domainstate.(idx_of_field Domain_current_stack) * 8 in
+    `  lg %r1, {emit_int offset}(%r10)\n`;
+    `  lay %r1, {emit_int f}(%r1)\n`;
+    `  clgr %r15, %r1\n`;
+    `  jl {emit_label overflow}\n`;
+    `{emit_label ret}:\n`;
+    handle_overflow := Some (overflow, ret);
+  end;
+
   emit_all env fundecl.fun_body;
   (* Emit the glue code to call the GC *)
   List.iter emit_call_gc env.call_gc_sites;
   (* Emit the glue code to handle bound errors *)
   emit_call_bound_errors env;
+
+  begin match !handle_overflow with
+  | None -> ()
+  | Some (overflow,ret) -> begin
+      `{emit_label overflow}:\n`;
+      (* Pass the desired frame size on the stack, since all of the
+        argument-passing registers may be in use. *)
+      let s = (Config.stack_threshold + max_frame_size / 8) in
+      `  lay  %r15, -16(%r15)\n`;
+      `  stg  %r14, 8(%r15)\n`;
+      `  lgfi %r1, {emit_int s}\n`;
+      `  stg %r1, 0(%r15)\n`;
+      `  brasl %r14, {emit_symbol "caml_call_realloc_stack"}\n`;
+      `  lg   %r14, 8(%r15)\n`;
+      `  la  %r15, 16(%r15)\n`;
+      `  jg {emit_label ret}\n`
+    end
+  end;
+
   cfi_endproc ();
   (* Emit the numeric literals *)
   if env.float_literals <> [] || env.int_literals <> [] then begin

--- a/asmcomp/s390x/emit.mlp
+++ b/asmcomp/s390x/emit.mlp
@@ -687,13 +687,10 @@ let emit_instr env i =
     | Lraise k ->
         begin match k with
         | Lambda.Raise_regular->
-          let offset = Domainstate.(idx_of_field Domain_backtrace_pos) * 8 in
-          `	lghi	%r1, 0\n`;
-          `	stg	%r1, {emit_int offset}(%r10)\n`;
           emit_call "caml_raise_exn";
           `{record_frame env Reg.Set.empty (Dbg_raise i.dbg)}\n`
         | Lambda.Raise_reraise ->
-          emit_call "caml_raise_exn";
+          emit_call "caml_reraise_exn";
           `{record_frame env Reg.Set.empty (Dbg_raise i.dbg)}\n`
         | Lambda.Raise_notrace ->
           `	lg	%r1, {emit_int size_addr}(%r13)\n`;

--- a/asmcomp/s390x/emit.mlp
+++ b/asmcomp/s390x/emit.mlp
@@ -665,11 +665,11 @@ let emit_instr env i =
         env.stack_offset <- env.stack_offset + 16;
         emit_stack_adjust 16;
         `	larl	%r14, {emit_label lbl_handler}\n`;
-        `	stg	%r14, 0(%r15)\n`;
-        `	stg	%r13, {emit_int size_addr}(%r15)\n`;
+        `	stg	%r14, {emit_int size_addr}(%r15)\n`;
+        `	stg	%r13, 0(%r15)\n`;
         `	lgr	%r13, %r15\n`
     | Lpoptrap ->
-        `	lg	%r13, {emit_int size_addr}(%r15)\n`;
+        `	lg	%r13, 0(%r15)\n`;
         emit_stack_adjust (-16);
         env.stack_offset <- env.stack_offset - 16
     | Lraise k ->
@@ -684,9 +684,9 @@ let emit_instr env i =
           emit_call "caml_raise_exn";
           `{record_frame env Reg.Set.empty (Dbg_raise i.dbg)}\n`
         | Lambda.Raise_notrace ->
-          `	lg	%r1, 0(%r13)\n`;
+          `	lg	%r1, {emit_int size_addr}(%r13)\n`;
           `	lgr	%r15, %r13\n`;
-          `	lg	%r13, {emit_int size_addr}(%r15)\n`;
+          `	lg	%r13, 0(%r15)\n`;
           emit_stack_adjust (-16);
           `	br	%r1\n`
         end

--- a/asmcomp/s390x/emit.mlp
+++ b/asmcomp/s390x/emit.mlp
@@ -84,6 +84,25 @@ let check_phys_reg reg_idx name =
 
 let reg_f15 = check_phys_reg 115 "%f15"
 let reg_r7 = check_phys_reg 5 "%r7"
+let reg_stack_arg_begin = check_phys_reg 7 "%r9"
+let reg_stack_arg_end = check_phys_reg 6 "%r8"
+
+let cfi_startproc () =
+  if Config.asm_cfi_supported then begin
+    emit_string "\t.cfi_startproc\n";
+  end
+
+let cfi_endproc () =
+  if Config.asm_cfi_supported then begin
+    emit_string "\t.cfi_endproc\n";
+  end
+
+let cfi_def_cfa_register reg =
+  if Config.asm_cfi_supported then begin
+    emit_string "\t.cfi_def_cfa_register ";
+    emit_string reg;
+    emit_string "\n"
+  end
 
 (* Output a stack reference *)
 
@@ -347,12 +366,34 @@ let emit_instr env i =
             `	brcl	15, {emit_symbol func}\n`
         end
 
-     | Lop(Iextcall { func; alloc; }) ->
-        if not alloc then emit_call func
-        else begin
+    | Lop(Iextcall {func; alloc; stack_ofs}) ->
+        if stack_ofs > 160 then begin
+          ` lgr {emit_reg reg_stack_arg_begin}, %r15\n`;
+          ` lgr {emit_reg reg_stack_arg_end}, %r15\n`;
+          ` agfi {emit_reg reg_stack_arg_end}, {emit_int (stack_ofs - 160)}\n`;
+          emit_load_symbol_addr reg_r7 func;
+          emit_call "caml_c_call_stack_args";
+          `{record_frame env i.live (Dbg_other i.dbg)}\n`
+        end else if alloc then begin
           emit_load_symbol_addr reg_r7 func;
           emit_call "caml_c_call";
           `{record_frame env i.live (Dbg_other i.dbg)}\n`
+        end else begin
+          ` lgr %r1, %r15\n`;
+          cfi_remember_state ();
+          cfi_def_cfa_register "%r1";
+          (* NB: gdb has asserts on contiguous stacks that mean it
+             will not unwind through this unless we were to tag this
+             calling frame with cfi_signal_frame in it's definition.
+             Also, for some reason ocaml compiler uses %r12, can't use it here.
+             Just save stack pointer to temporary pointer and then to new stack *)
+          let offset = Domainstate.(idx_of_field Domain_c_stack) * 8 in
+          ` lg %r15, {emit_int offset}(%r10)\n`;
+          ` lay %r15, -168(%r15)\n`;
+          ` stg %r1, 160(%r15)\n`;
+          emit_call func;
+          ` lg %r15, 160(%r15)\n`;
+          cfi_restore_state ()
         end
 
      | Lop(Istackoffset n) ->
@@ -670,11 +711,13 @@ let fundecl fundecl =
   emit_string code_space;
   `	.align	8\n`;
   `{emit_symbol fundecl.fun_name}:\n`;
+  cfi_startproc ();
   emit_all env fundecl.fun_body;
   (* Emit the glue code to call the GC *)
   List.iter emit_call_gc env.call_gc_sites;
   (* Emit the glue code to handle bound errors *)
   emit_call_bound_errors env;
+  cfi_endproc ();
   (* Emit the numeric literals *)
   if env.float_literals <> [] || env.int_literals <> [] then begin
     emit_string rodata_space;

--- a/asmcomp/s390x/emit.mlp
+++ b/asmcomp/s390x/emit.mlp
@@ -737,7 +737,7 @@ let fundecl fundecl =
     `  lg %r1, {emit_int offset}(%r10)\n`;
     `  lay %r1, {emit_int f}(%r1)\n`;
     `  clgr %r15, %r1\n`;
-    `  jl {emit_label overflow}\n`;
+    `  brcl 4, {emit_label overflow}\n`;
     `{emit_label ret}:\n`;
     handle_overflow := Some (overflow, ret);
   end;
@@ -762,7 +762,7 @@ let fundecl fundecl =
       `  brasl %r14, {emit_symbol "caml_call_realloc_stack"}\n`;
       `  lg   %r14, 8(%r15)\n`;
       `  la  %r15, 16(%r15)\n`;
-      `  jg {emit_label ret}\n`
+      `  brcl 15, {emit_label ret}\n`
     end
   end;
 

--- a/asmcomp/s390x/emit.mlp
+++ b/asmcomp/s390x/emit.mlp
@@ -369,8 +369,7 @@ let emit_instr env i =
     | Lop(Iextcall {func; alloc; stack_ofs}) ->
         if stack_ofs > 0 then begin
           ` lgr {emit_reg reg_stack_arg_begin}, %r15\n`;
-          ` lgr {emit_reg reg_stack_arg_end}, %r15\n`;
-          ` agfi {emit_reg reg_stack_arg_end}, {emit_int stack_ofs}\n`;
+          ` lay {emit_reg reg_stack_arg_end}, {emit_int stack_ofs}(%r15)\n`;
           emit_load_symbol_addr reg_r7 func;
           emit_call "caml_c_call_stack_args";
           `{record_frame env i.live (Dbg_other i.dbg)}\n`

--- a/asmcomp/s390x/emit.mlp
+++ b/asmcomp/s390x/emit.mlp
@@ -544,8 +544,8 @@ let emit_instr env i =
         let instr = name_for_specific sop in
         `	{emit_string instr}	{emit_reg i.res.(0)}, {emit_reg i.arg.(0)}, {emit_reg i.arg.(1)}\n`
     | Lop (Idls_get) ->
-        (* Here to maintain build *)
-        assert false
+        let ofs = Domainstate.(idx_of_field Domain_dls_root) * 8 in
+        `	lg	{emit_reg i.res.(0)}, {emit_int ofs}(%r10)\n`
     | Lreloadretaddr ->
         let n = frame_size env in
         `	lg	%r14, {emit_int(n - size_addr)}(%r15)\n`

--- a/asmcomp/s390x/emit.mlp
+++ b/asmcomp/s390x/emit.mlp
@@ -367,10 +367,10 @@ let emit_instr env i =
         end
 
     | Lop(Iextcall {func; alloc; stack_ofs}) ->
-        if stack_ofs > 160 then begin
+        if stack_ofs > 0 then begin
           ` lgr {emit_reg reg_stack_arg_begin}, %r15\n`;
           ` lgr {emit_reg reg_stack_arg_end}, %r15\n`;
-          ` agfi {emit_reg reg_stack_arg_end}, {emit_int (stack_ofs - 160)}\n`;
+          ` agfi {emit_reg reg_stack_arg_end}, {emit_int stack_ofs}\n`;
           emit_load_symbol_addr reg_r7 func;
           emit_call "caml_c_call_stack_args";
           `{record_frame env i.live (Dbg_other i.dbg)}\n`

--- a/asmcomp/s390x/proc.ml
+++ b/asmcomp/s390x/proc.ml
@@ -155,7 +155,7 @@ let loc_results res =
 
 let loc_external_arguments ty_args =
   let arg = Cmm.machtype_of_exttype_list ty_args in
-  let (loc, ofs) = calling_conventions 0 4 100 103 outgoing 160 arg in
+  let (loc, ofs) = calling_conventions 0 4 100 103 outgoing 0 arg in
   (Array.map (fun reg -> [|reg|]) loc, ofs)
 
 (* Results are in GPR 2 and FPR 0 *)

--- a/configure
+++ b/configure
@@ -15377,7 +15377,7 @@ else $as_nop
   model=ppc
 fi; system=elf ;; #(
   s390x*-*-linux*) :
-    arch=s390x; model=z10; system=elf ;; #(
+    has_native_backend=yes; arch=s390x; model=z10; system=elf ;; #(
   # expected to match "gnueabihf" as well as "musleabihf"
   armv6*-*-linux-*eabihf) :
     arch=arm; model=armv6; system=linux_eabihf ;; #(

--- a/configure.ac
+++ b/configure.ac
@@ -1203,7 +1203,7 @@ AS_CASE([$host],
   [[powerpc*-*-linux*]],
     [arch=power; AS_IF([$arch64],[model=ppc64],[model=ppc]); system=elf],
   [[s390x*-*-linux*]],
-    [arch=s390x; model=z10; system=elf],
+    [has_native_backend=yes; arch=s390x; model=z10; system=elf],
   # expected to match "gnueabihf" as well as "musleabihf"
   [armv6*-*-linux-*eabihf],
     [arch=arm; model=armv6; system=linux_eabihf],

--- a/runtime/caml/stack.h
+++ b/runtime/caml/stack.h
@@ -38,8 +38,9 @@
 #endif
 
 #ifdef TARGET_s390x
+#define Wosize_gc_regs (2 + 9 /* int regs */ + 16 /* float regs */)
 #define Saved_return_address(sp) *((intnat *)((sp) - SIZEOF_PTR))
-#define Trap_frame_size 16
+#define Pop_frame_pointer(sp)
 #endif
 
 #ifdef TARGET_amd64

--- a/runtime/fiber.c
+++ b/runtime/fiber.c
@@ -269,9 +269,6 @@ next_chunk:
       sp += 3 * sizeof(value); /* trap frame & DWARF pointer */
       regs = *(value**)sp;     /* update gc_regs */
       sp += 1 * sizeof(value); /* gc_regs */
-#ifdef TARGET_s390x
-      sp += 160; /* skip area reserved for regs on stack */
-#endif
       goto next_chunk;
     }
   }

--- a/runtime/fiber.c
+++ b/runtime/fiber.c
@@ -269,6 +269,9 @@ next_chunk:
       sp += 3 * sizeof(value); /* trap frame & DWARF pointer */
       regs = *(value**)sp;     /* update gc_regs */
       sp += 1 * sizeof(value); /* gc_regs */
+#ifdef TARGET_s390x
+      sp += 160; /* skip area reserved for regs on stack */
+#endif
       goto next_chunk;
     }
   }

--- a/runtime/s390x.S
+++ b/runtime/s390x.S
@@ -489,7 +489,7 @@ CFI_STARTPROC
 LBL(105):
         lay     %r8, -8(%r8)
         cgr     %r8, %r9
-        jh      LBL(106)
+        jl      LBL(106)
         lg      %r0, 0(%r8)
         lay     %r15, -8(%r15)
         stg     %r0, 0(%r15)

--- a/runtime/s390x.S
+++ b/runtime/s390x.S
@@ -452,6 +452,7 @@ LBL(caml_c_call):
         CLEANUP_AFTER_C_CALL
     /* Reload alloc ptr  */
         lg      ALLOC_PTR, Caml_state(young_ptr)
+        lg      TRAP_PTR, Caml_state(exn_handler)
     /* Load ocaml stack and restore global variables */
         SWITCH_C_TO_OCAML
     /* Return to OCaml caller */
@@ -568,9 +569,10 @@ LBL(caml_start_program):
     /* link in the previous exn_handler so that copying stacks works */
         lg      %r9, Caml_state(exn_handler)
         stg     %r9, 0(%r8)
-        lay     %r9, LBL(trap_handler)
+        larl    %r9, LBL(trap_handler)
         stg     %r9, 8(%r8)
         stg     %r8, Caml_state(exn_handler)
+        lgr     TRAP_PTR, %r8
     /* Switch stacks and call the OCaml code */
         lgr     %r15, %r8
 #ifdef ASM_CFI_SUPPORTED

--- a/runtime/s390x.S
+++ b/runtime/s390x.S
@@ -57,6 +57,7 @@
 #define CFI_SIGNAL_FRAME .cfi_signal_frame
 #define CFI_REMEMBER_STATE .cfi_remember_state
 #define CFI_RESTORE_STATE .cfi_restore_state
+#define CFI_RESTORE(r) .cfi_restore r
 #else
 #define CFI_STARTPROC
 #define CFI_ENDPROC
@@ -68,7 +69,24 @@
 #define CFI_SIGNAL_FRAME
 #define CFI_REMEMBER_STATE
 #define CFI_RESTORE_STATE
+#define CFI_RESTORE(r)
 #endif
+
+/* special sleb128 constants, precalculated */
+/* Cstack_sp + 160 = 8 + 160 = 168, encoded as sleb128 */
+#define Cstack_sp_plus_160_sleb128_2byte 168, 1
+
+/* struct c_stack_link + callee save regs = 24 + 8*8 = 88 */
+#define start_program_sleb128_2byte 216, 0
+
+/* struct exception handler + callee area = 16 + 160 = 176 */
+#define start_program_call_sleb128_2byte 176, 1
+
+/* exception handler + gc_regs slot + C_STACK_SP + Handler_parent = 16 + 8 + 8 + 24 = 56 */
+#define caml_runstack_sleb128_1byte 56
+
+/* exception handler + gc_regs slot + C_STACK_SP + Handler_parent + callee area = 16 + 8 + 8 + 24 + 160 = 216 */
+#define caml_runstack_callee_sleb128_2byte 216, 1
 
 #define RETADDR_ENTRY_SIZE   8 /* retaddr */
 
@@ -76,11 +94,8 @@
 #define LEAVE_FUNCTION
 
 #define CHECK_STACK_ALIGNMENT
-#define PREPARE_FOR_C_CALL      lay     %r15, -160(%r15); CFI_ADJUST(160)
-#define CLEANUP_AFTER_C_CALL    la      %r15,  160(%r15); CFI_ADJUST(-160)
-
-#define C_call(target) \
-  PREPARE_FOR_C_CALL; CHECK_STACK_ALIGNMENT; brasl %r14, target; CLEANUP_AFTER_C_CALL
+#define PREPARE_FOR_C_CALL      lay     %r15, -160(%r15); CFI_REMEMBER_STATE
+#define CLEANUP_AFTER_C_CALL    la      %r15,  160(%r15); CFI_RESTORE_STATE
 
 /* struct stack_info */
 #define Stack_sp                 0
@@ -163,10 +178,10 @@ caml_system__code_begin:
 #ifdef ASM_CFI_SUPPORTED
 #define SWITCH_OCAML_TO_C_CFI                                   \
         CFI_REMEMBER_STATE;                                     \
+        CFI_OFFSET(14, 0); \
           /* %r15 points to the c_stack_link. */                \
-        .cfi_escape DW_CFA_def_cfa_expression, 5,               \
-           DW_OP_breg + DW_REG_r15, Cstack_sp, DW_OP_deref,     \
-           DW_OP_plus_uconst, RETADDR_ENTRY_SIZE
+        .cfi_escape DW_CFA_def_cfa_expression, 3,               \
+           DW_OP_breg + DW_REG_r15, Cstack_sp, DW_OP_deref
 #else
 #define SWITCH_OCAML_TO_C_CFI
 #endif
@@ -280,22 +295,31 @@ FUNCTION(G(caml_call_realloc_stack))
 CFI_STARTPROC
         CFI_SIGNAL_FRAME
         lay     %r15, -8(%r15)
+        CFI_ADJUST(8)
         stg     %r14, 0(%r15)
-        CFI_OFFSET(14, 0)
+        CFI_OFFSET(14, -168)
         SAVE_ALL_REGS
         lg    C_ARG_1, RETADDR_ENTRY_SIZE(%r15) /* argument */
         SWITCH_OCAML_TO_C
-        C_call  (GCALL(caml_try_realloc_stack))
+        PREPARE_FOR_C_CALL
+#ifdef ASM_CFI_SUPPORTED
+        .cfi_escape DW_CFA_def_cfa_expression, 4, DW_OP_breg + DW_REG_r15, Cstack_sp_plus_160_sleb128_2byte, DW_OP_deref
+#endif
+        CHECK_STACK_ALIGNMENT
+        brasl %r14, GCALL(caml_try_realloc_stack)
+        CLEANUP_AFTER_C_CALL
         SWITCH_C_TO_OCAML
         cgfi    %r2, 0
         je      LBL(120)
         RESTORE_ALL_REGS
         lg      %r14, 0(%r15)
+        CFI_RESTORE(14)
         la      %r15, 8(%r15)
         br      %r14
 LBL(120):
         RESTORE_ALL_REGS
         lg      %r14, 0(%r15)
+        CFI_RESTORE(14)
         la      %r15, 16(%r15) /* %r14 register and pop argument, retaddr */
         LEA_VAR(caml_exn_Stack_overflow, %r2)
         brcl    15, GCALL(caml_raise_exn)
@@ -306,15 +330,23 @@ FUNCTION(G(caml_call_gc))
 CFI_STARTPROC
         CFI_SIGNAL_FRAME
         lay     %r15, -8(%r15)
+        CFI_ADJUST(8)
         stg     %r14, 0(%r15)
-        CFI_OFFSET(14, 0)
+        CFI_OFFSET(14, -168)
 LBL(caml_call_gc):
         SAVE_ALL_REGS
         SWITCH_OCAML_TO_C
-        C_call (GCALL(caml_garbage_collection))
+        PREPARE_FOR_C_CALL
+#ifdef ASM_CFI_SUPPORTED
+        .cfi_escape DW_CFA_def_cfa_expression, 4, DW_OP_breg + DW_REG_r15, Cstack_sp_plus_160_sleb128_2byte, DW_OP_deref
+#endif
+        CHECK_STACK_ALIGNMENT
+        brasl %r14, GCALL(caml_garbage_collection)
+        CLEANUP_AFTER_C_CALL
         SWITCH_C_TO_OCAML
         RESTORE_ALL_REGS
         lg      %r14, 0(%r15)
+        CFI_RESTORE(14)
         la      %r15, 8(%r15)
         br      %r14
 CFI_ENDPROC
@@ -323,14 +355,16 @@ ENDFUNCTION(G(caml_call_gc))
 FUNCTION(G(caml_alloc1))
 CFI_STARTPROC
         lay     %r15, -8(%r15)
+        CFI_ADJUST(8)
         stg     %r14, 0(%r15)
-        CFI_OFFSET(14, 0)
+        CFI_OFFSET(14, -168)
         ENTER_FUNCTION
         lay     ALLOC_PTR, -16(ALLOC_PTR)
         cg      ALLOC_PTR, Caml_state(young_limit)
         jl      LBL(caml_call_gc)
         LEAVE_FUNCTION
         lg      %r14, 0(%r15)
+        CFI_RESTORE(14)
         la      %r15, 8(%r15)
         br      %r14
 CFI_ENDPROC
@@ -339,14 +373,16 @@ ENDFUNCTION(G(caml_alloc1))
 FUNCTION(G(caml_alloc2))
 CFI_STARTPROC
         lay     %r15, -8(%r15)
+        CFI_ADJUST(8)
         stg     %r14, 0(%r15)
-        CFI_OFFSET(14, 0)
+        CFI_OFFSET(14, -168)
         ENTER_FUNCTION
         lay     ALLOC_PTR, -24(ALLOC_PTR)
         cg      ALLOC_PTR, Caml_state(young_limit)
         jl      LBL(caml_call_gc)
         LEAVE_FUNCTION
         lg      %r14, 0(%r15)
+        CFI_RESTORE(14)
         la      %r15, 8(%r15)
         br      %r14
 CFI_ENDPROC
@@ -355,14 +391,16 @@ ENDFUNCTION(G(caml_alloc2))
 FUNCTION(G(caml_alloc3))
 CFI_STARTPROC
         lay     %r15, -8(%r15)
+        CFI_ADJUST(8)
         stg     %r14, 0(%r15)
-        CFI_OFFSET(14, 0)
+        CFI_OFFSET(14, -168)
         ENTER_FUNCTION
         lay     ALLOC_PTR, -32(ALLOC_PTR)
         cg      ALLOC_PTR, Caml_state(young_limit)
         jl      LBL(caml_call_gc)
         LEAVE_FUNCTION
         lg      %r14, 0(%r15)
+        CFI_RESTORE(14)
         la      %r15, 8(%r15)
         br      %r14
 CFI_ENDPROC
@@ -371,13 +409,15 @@ ENDFUNCTION(G(caml_alloc3))
 FUNCTION(G(caml_allocN))
 CFI_STARTPROC
         lay     %r15, -8(%r15)
+        CFI_ADJUST(8)
         stg     %r14, 0(%r15)
-        CFI_OFFSET(14, 0)
+        CFI_OFFSET(14, -168)
         ENTER_FUNCTION
         cg      ALLOC_PTR, Caml_state(young_limit)
         jl      LBL(caml_call_gc)
         LEAVE_FUNCTION
         lg      %r14, 0(%r15)
+        CFI_RESTORE(14)
         la      %r15, 8(%r15)
         br      %r14
 CFI_ENDPROC
@@ -405,6 +445,9 @@ LBL(caml_c_call):
         stg     TRAP_PTR, Caml_state(exn_handler)
     /* Call the function (address in ADDITIONAL_ARG) */
         PREPARE_FOR_C_CALL
+#ifdef ASM_CFI_SUPPORTED
+        .cfi_escape DW_CFA_def_cfa_expression, 4, DW_OP_breg + DW_REG_r15, Cstack_sp_plus_160_sleb128_2byte, DW_OP_deref
+#endif
         basr    %r14, ADDITIONAL_ARG
         CLEANUP_AFTER_C_CALL
     /* Reload alloc ptr  */
@@ -413,6 +456,7 @@ LBL(caml_c_call):
         SWITCH_C_TO_OCAML
     /* Return to OCaml caller */
         lg      %r14, 0(%r15)
+        CFI_RESTORE(14)
         la      %r15, 8(%r15)
         br      %r14
 CFI_ENDPROC
@@ -422,8 +466,9 @@ FUNCTION(G(caml_c_call_stack_args))
 CFI_STARTPROC
         CFI_SIGNAL_FRAME
         lay     %r15, -8(%r15)
+        CFI_ADJUST(8)
         stg     %r14, 0(%r15)
-        CFI_OFFSET(14, 0)
+        CFI_OFFSET(14, -168)
     /* Arguments:
         C arguments         : %r2, %r3, %r4, %r5, %r6
         C function          : ADDITIONAL_ARG
@@ -436,10 +481,9 @@ CFI_STARTPROC
     /* Store sp to restore after call */
         lgr     %r12, %r15
 #ifdef ASM_CFI_SUPPORTED
-        .cfi_escape DW_CFA_def_cfa_expression, 5,           \
-          /* %rbp points to the c_stack_link structure */   \
-          DW_OP_breg + DW_REG_r12, Cstack_sp, DW_OP_deref,  \
-          DW_OP_plus_uconst, RETADDR_ENTRY_SIZE
+        .cfi_escape DW_CFA_def_cfa_expression, 3,           \
+          /* %r12 points to the c_stack_link structure */   \
+          DW_OP_breg + DW_REG_r12, Cstack_sp, DW_OP_deref
 #endif
     /* Copy arguments from OCaml to C stack */
 LBL(105):
@@ -464,6 +508,7 @@ LBL(106):
         SWITCH_C_TO_OCAML
     /* Return */
         lg      %r14, 0(%r15)
+        CFI_RESTORE(14)
         la      %r15, 8(%r15)
         br      %r14
 CFI_ENDPROC
@@ -488,7 +533,7 @@ LBL(caml_start_program):
     /* GPR 6..14 at sp + 0 ... sp + 64
        FPR 10..15 at sp + 72 ... sp + 128 */
         stmg    %r6,%r14, 0(%r15)
-        CFI_OFFSET(14, 64)
+        CFI_OFFSET(14, 64 - 160)
         std     %f8, 72(%r15)
         std     %f9, 80(%r15)
         std     %f10, 88(%r15)
@@ -530,16 +575,21 @@ LBL(caml_start_program):
         lgr     %r15, %r8
 #ifdef ASM_CFI_SUPPORTED
         CFI_REMEMBER_STATE
-        .cfi_escape DW_CFA_def_cfa_expression, 3 + 2,                 \
-            /* %rsp points to the exn handler on the OCaml stack */   \
-            /* %rsp + 16 contains the C_STACK_SP */                   \
+        CFI_OFFSET(14, 0)
+        .cfi_escape DW_CFA_def_cfa_expression, 3 + 3,                 \
+            /* %r15 points to the exn handler on the OCaml stack */   \
+            /* %r15 + 16 contains the C_STACK_SP */                   \
           DW_OP_breg + DW_REG_r15, 16 /* exn handler */, DW_OP_deref, \
-          DW_OP_plus_uconst,                                          \
-             24  /* struct c_stack_link */ +                          \
-             6*8 /* callee save regs */ +                             \
-             8   /* ret addr */
+          DW_OP_plus_uconst, start_program_sleb128_2byte
 #endif
         PREPARE_FOR_C_CALL
+#ifdef ASM_CFI_SUPPORTED
+        .cfi_escape DW_CFA_def_cfa_expression, 4 + 3,                 \
+            /* %r15 points to the exn handler on the OCaml stack */   \
+            /* %r15 + 16 contains the C_STACK_SP */                   \
+          DW_OP_breg + DW_REG_r15, start_program_call_sleb128_2byte, DW_OP_deref, \
+          DW_OP_plus_uconst, start_program_sleb128_2byte
+#endif
         basr    %r14, TMP
 LBL(caml_retaddr):
         CLEANUP_AFTER_C_CALL
@@ -563,6 +613,7 @@ LBL(return_result):  /* restore GC regs */
         la      %r15, 24(%r15); CFI_ADJUST(-24)
     /* Restore callee-save registers. */
         lmg     %r6,%r14, 0(%r15)
+        CFI_RESTORE(14)
         ld      %f8, 72(%r15)
         ld      %f9, 80(%r15)
         ld      %f10, 88(%r15)
@@ -617,7 +668,11 @@ LBL(caml_reraise_exn_stash):
         lg      C_ARG_4, TRAP_PTR /* arg4: SP of handler */
     /* Switch to C stack */
         lg      %r15, Caml_state(c_stack)
-        C_call  (GCALL(caml_stash_backtrace))
+        PREPARE_FOR_C_CALL
+        CFI_ADJUST(160)
+        CHECK_STACK_ALIGNMENT
+        brasl %r14, GCALL(caml_stash_backtrace)
+        CLEANUP_AFTER_C_CALL
     /* Restore exception bucket and raise */
         lgr     %r2, %r9
         brcl    15, LBL(116)
@@ -648,6 +703,7 @@ CFI_STARTPROC
         lg      %r15, Stack_sp(TMP)
     /* Restore frame and link on return to OCaml */
         lg      %r14, 0(%r15)
+        CFI_RESTORE(14)
         la      %r15, 8(%r15)
         brcl    15, LBL(caml_raise_exn)
 CFI_ENDPROC
@@ -794,8 +850,9 @@ FUNCTION(G(caml_runstack))
 CFI_STARTPROC
         CFI_SIGNAL_FRAME
         lay     %r15, -8(%r15)
+        CFI_ADJUST(8)
         stg     %r14, 0(%r15)
-        CFI_OFFSET(14, 0)
+        CFI_OFFSET(14, -168)
         ENTER_FUNCTION
     /* %r2 -> fiber, %r3 -> fun, %r4 -> arg */
         lay     %r2, -1(%r2)  /* %r2 (new stack) = Ptr_val(%r2) */
@@ -824,16 +881,22 @@ CFI_STARTPROC
         CFI_REMEMBER_STATE
         .cfi_escape DW_CFA_def_cfa_expression, 3+3+2, \
           DW_OP_breg + DW_REG_r15,                    \
-            16 /* exn */ +                            \
-            8 /* gc_regs slot (unused) */ +           \
-            8 /* C_STACK_SP for DWARF (unused) */     \
-            + Handler_parent, DW_OP_deref,            \
+          caml_runstack_sleb128_1byte,                \
+          DW_OP_deref,                                \
           DW_OP_plus_uconst, Stack_sp, DW_OP_deref,   \
           DW_OP_plus_uconst, RETADDR_ENTRY_SIZE
 #endif
     /* Call the function on the new stack */
         lgr     %r2, %r4 /* first argument */
         PREPARE_FOR_C_CALL
+#ifdef ASM_CFI_SUPPORTED
+        .cfi_escape DW_CFA_def_cfa_expression, 4+3+2, \
+          DW_OP_breg + DW_REG_r15,                    \
+          caml_runstack_callee_sleb128_2byte,         \
+          DW_OP_deref,                                \
+          DW_OP_plus_uconst, Stack_sp, DW_OP_deref,   \
+          DW_OP_plus_uconst, RETADDR_ENTRY_SIZE
+#endif
         basr    %r14, %r5 /* closure in %r3 (second argument) */
         CLEANUP_AFTER_C_CALL
 LBL(frame_runstack):
@@ -853,7 +916,11 @@ LBL(caml_runstack_1):
         CFI_REMEMBER_STATE
         CFI_DEF_CFA_REGISTER(DW_REG_r9)
         lg      %r15, Caml_state(c_stack)
-        C_call  (GCALL(caml_free_stack))
+        PREPARE_FOR_C_CALL
+        CFI_ADJUST(160)
+        CHECK_STACK_ALIGNMENT
+        brasl %r14, GCALL(caml_free_stack)
+        CLEANUP_AFTER_C_CALL
     /* switch directly to parent stack with correct return */
         lgr     %r2,  %r12
         lgr     %r3,  %r7
@@ -862,6 +929,7 @@ LBL(caml_runstack_1):
         lg      TMP, 0(%r3) /* code pointer */
     /* Invoke handle_value (or handle_exn) */
         lg      %r14, 0(%r15)
+        CFI_RESTORE(14)
         la      %r15, 8(%r15)
         br      TMP
 LBL(fiber_exn_handler):
@@ -874,7 +942,9 @@ ENDFUNCTION(G(caml_runstack))
 FUNCTION(G(caml_ml_array_bound_error))
 CFI_STARTPROC
         lay     %r15, -8(%r15)
+        CFI_ADJUST(8)
         stg     %r14, 0(%r15)
+        CFI_OFFSET(14, -168)
         ENTER_FUNCTION
         LEA_VAR(caml_array_bound_error_asm, %r2)
         brcl    15, LBL(caml_c_call)

--- a/runtime/s390x.S
+++ b/runtime/s390x.S
@@ -594,12 +594,13 @@ LBL(caml_start_program):
 LBL(caml_retaddr):
         CLEANUP_AFTER_C_CALL
     /* pop exn handler */
-        lay     %r8, 16(%r15)
+        lg      %r8, 0(%r15)
+        la      %r15, 16(%r15)
         stg     %r8, Caml_state(exn_handler)
 LBL(return_result):  /* restore GC regs */
-        lg      %r9, 8(%r8)
+        lg      %r9, 8(%r15)
+        la      %r15, 16(%r15)
         stg     %r9, Caml_state(gc_regs)
-        la      %r8, 16(%r8)
     /* Update alloc ptr */
         stg     ALLOC_PTR, Caml_state(young_ptr)
     /* Return to C stack. */
@@ -946,7 +947,7 @@ CFI_STARTPROC
         stg     %r14, 0(%r15)
         CFI_OFFSET(14, -168)
         ENTER_FUNCTION
-        LEA_VAR(caml_array_bound_error_asm, %r2)
+        LEA_VAR(caml_array_bound_error_asm, ADDITIONAL_ARG)
         brcl    15, LBL(caml_c_call)
 CFI_ENDPROC
 ENDFUNCTION(G(caml_ml_array_bound_error))

--- a/runtime/s390x.S
+++ b/runtime/s390x.S
@@ -591,8 +591,8 @@ ENDFUNCTION(G(caml_start_program))
 
 #define JUMP_TO_TRAP_PTR \
         lgr     %r15,     TRAP_PTR;                    \
-        lg      TMP,       0(%r15);                    \
-        lg      TRAP_PTR,  8(%r15);                    \
+        lg      TMP,       8(%r15);                    \
+        lg      TRAP_PTR,  0(%r15);                    \
         la      %r15,     16(%r15);                    \
         br      TMP;
 

--- a/runtime/s390x.S
+++ b/runtime/s390x.S
@@ -798,8 +798,8 @@ LBL(112):
         lg      %r9, Caml_state(current_stack)
         SWITCH_OCAML_STACKS(%r9, %r8)
     /* No parent stack. Raise Unhandled. */
-        LEA_VAR(caml_raise_unhandled_effect, %r2)
-        brcl    15, LBL(caml_raise_exn)
+        LEA_VAR(caml_raise_unhandled_effect, ADDITIONAL_ARG)
+        brcl    15, LBL(caml_c_call)
 CFI_ENDPROC
 ENDFUNCTION(G(caml_perform))
 
@@ -840,8 +840,8 @@ LBL(caml_resume_1):
         lgr     %r2, %r4
         br      %r5
 LBL(caml_resume_2):
-        LEA_VAR(caml_raise_continuation_already_resumed, %r2)
-        brcl    15, LBL(caml_raise_exn)
+        LEA_VAR(caml_raise_continuation_already_resumed, ADDITIONAL_ARG)
+        brcl    15, LBL(caml_c_call)
 CFI_ENDPROC
 ENDFUNCTION(G(caml_resume))
 

--- a/runtime/s390x.S
+++ b/runtime/s390x.S
@@ -374,7 +374,6 @@ CFI_STARTPROC
         stg     %r14, 0(%r15)
         CFI_OFFSET(14, 0)
         ENTER_FUNCTION
-        sgr     ALLOC_PTR, ADDITIONAL_ARG
         cg      ALLOC_PTR, Caml_state(young_limit)
         jl      LBL(caml_call_gc)
         LEAVE_FUNCTION

--- a/runtime/s390x.S
+++ b/runtime/s390x.S
@@ -15,15 +15,121 @@
 /*                                                                        */
 /**************************************************************************/
 
-#if defined(__PIC__)
+#include "caml/m.h"
 
-#define Addrglobal(reg,glob) \
-        lgrl    reg, glob@GOTENT
+/* Special registers */
+
+#define DOMAIN_STATE_PTR %r10
+#define ALLOC_PTR %r11
+#define TRAP_PTR %r13
+#define TMP %r1
+#define TMP2 %r12
+#define TMP3 %r0
+/* Don't use TMP3 for indexed access in form of offset(TMP3) */
+
+#define C_ARG_1 %r2
+#define C_ARG_2 %r3
+#define C_ARG_3 %r4
+#define C_ARG_4 %r5
+#define ADDITIONAL_ARG %r7
+
+#define LBL(x) .L##x
+#define G(r) r
+#define GREL(r) r@GOTENT
+#define GCALL(r) r@PLT
+#define TEXT_SECTION(name)
+#define FUNCTION(name) \
+        TEXT_SECTION(name); \
+        .globl name; \
+        .type name,@function; \
+        name:
+
+#define ENDFUNCTION(name)
+
+#ifdef ASM_CFI_SUPPORTED
+#define CFI_STARTPROC .cfi_startproc
+#define CFI_ENDPROC .cfi_endproc
+#define CFI_ADJUST(n) .cfi_adjust_cfa_offset n
+#define CFI_OFFSET(r, n) .cfi_offset r, n
+#define CFI_DEF_CFA_OFFSET(n) .cfi_def_cfa_offset n
+#define CFI_DEF_CFA_REGISTER(r) .cfi_def_cfa_register r
+#define CFI_SAME_VALUE(r) .cfi_same_value r
+#define CFI_SIGNAL_FRAME .cfi_signal_frame
+#define CFI_REMEMBER_STATE .cfi_remember_state
+#define CFI_RESTORE_STATE .cfi_restore_state
 #else
-
-#define Addrglobal(reg,glob) \
-        larl    reg, glob
+#define CFI_STARTPROC
+#define CFI_ENDPROC
+#define CFI_ADJUST(n)
+#define CFI_OFFSET(r, n)
+#define CFI_DEF_CFA_OFFSET(n)
+#define CFI_DEF_CFA_REGISTER(r)
+#define CFI_SAME_VALUE(r)
+#define CFI_SIGNAL_FRAME
+#define CFI_REMEMBER_STATE
+#define CFI_RESTORE_STATE
 #endif
+
+#define RETADDR_ENTRY_SIZE   8 /* retaddr */
+
+#define ENTER_FUNCTION
+#define LEAVE_FUNCTION
+
+#define CHECK_STACK_ALIGNMENT
+#define PREPARE_FOR_C_CALL      lay     %r15, -160(%r15); CFI_ADJUST(160)
+#define CLEANUP_AFTER_C_CALL    la      %r15,  160(%r15); CFI_ADJUST(-160)
+
+#define C_call(target) \
+  PREPARE_FOR_C_CALL; CHECK_STACK_ALIGNMENT; brasl %r14, target; CLEANUP_AFTER_C_CALL
+
+/* struct stack_info */
+#define Stack_sp                 0
+#define Stack_exception          8
+#define Stack_handler            16
+
+/* struct stack_handler */
+#define Handler_value(REG)       0(REG)
+#define Handler_exception(REG)   8(REG)
+#define Handler_effect(REG)     16(REG)
+#define Handler_parent          24
+
+/* struct c_stack_link */
+#define Cstack_stack             0
+#define Cstack_sp                8
+#define Cstack_prev             16
+
+/******************************************************************************/
+/* DWARF */
+/******************************************************************************/
+
+/* These constants are taken from:
+
+     DWARF Debugging Information Format, Version 3
+     http://dwarfstd.org/doc/Dwarf3.pdf
+
+   with the s390-specific register numbers coming from
+   Table 1.17 ("DWARF Register Number Mapping") of:
+
+     ELF Application Binary Interface
+     s390x Supplement
+     Version 1.6
+     https://github.com/IBM/s390x-abi/releases/download/v1.6/lzsabi_s390x.pdf
+*/
+
+#define DW_CFA_def_cfa_expression 0x0f
+#define DW_REG_r9                 9
+#define DW_REG_r12                12
+#define DW_REG_r15                15
+#define DW_OP_breg                0x70
+#define DW_OP_deref               0x06
+#define DW_OP_plus_uconst         0x23
+
+/******************************************************************************/
+/* Access to the current domain state block. */
+/******************************************************************************/
+
+#define CAML_CONFIG_H_NO_TYPEDEFS
+#include "../runtime/caml/config.h"
 
         .set    domain_curr_field, 0
 #define DOMAIN_STATE(c_type, name) \
@@ -41,177 +147,349 @@
         .globl  caml_system__code_begin
 caml_system__code_begin:
 
-        .globl  caml_call_gc
-        .type   caml_call_gc, @function
-caml_call_gc:
-    /* Set up stack frame */
-#define FRAMESIZE (16*8 + 16*8)
-        lay     %r15, -FRAMESIZE(%r15)
-    /* Record return address into OCaml code */
-        stg     %r14, Caml_state(last_return_address)
-    /* Record lowest stack address */
-        lay     %r0, FRAMESIZE(%r15)
-        stg     %r0, Caml_state(bottom_of_stack)
-    /* Record pointer to register array */
-        lay     %r0, (8*16)(%r15)
-        stg     %r0, Caml_state(gc_regs)
-    /* Save current allocation pointer for debugging purposes */
-        stg     %r11, Caml_state(young_ptr)
-    /* Save exception pointer (if e.g. a sighandler raises) */
-        stg     %r13, Caml_state(exception_pointer)
-    /* Save all registers used by the code generator */
-        stmg    %r2,%r9, (8*16)(%r15)
-        stg     %r12, (8*16 + 8*8)(%r15)
-        std     %f0, 0(%r15)
-        std     %f1, 8(%r15)
-        std     %f2, 16(%r15)
-        std     %f3, 24(%r15)
-        std     %f4, 32(%r15)
-        std     %f5, 40(%r15)
-        std     %f6, 48(%r15)
-        std     %f7, 56(%r15)
-        std     %f8, 64(%r15)
-        std     %f9, 72(%r15)
-        std     %f10, 80(%r15)
-        std     %f11, 88(%r15)
-        std     %f12, 96(%r15)
-        std     %f13, 108(%r15)
-        std     %f14, 112(%r15)
-        std     %f15, 120(%r15)
-    /* Call the GC */
-        lay     %r15, -160(%r15)
-        stg     %r15, 0(%r15)
-        brasl   %r14, caml_garbage_collection@PLT
-        lay     %r15, 160(%r15)
-    /* Reload new allocation pointer */
-        lg      %r11, Caml_state(young_ptr)
-    /* Restore all regs used by the code generator */
-        lmg     %r2,%r9, (8*16)(%r15)
-        lg      %r12, (8*16 + 8*8)(%r15)
-        ld      %f0, 0(%r15)
-        ld      %f1, 8(%r15)
-        ld      %f2, 16(%r15)
-        ld      %f3, 24(%r15)
-        ld      %f4, 32(%r15)
-        ld      %f5, 40(%r15)
-        ld      %f6, 48(%r15)
-        ld      %f7, 56(%r15)
-        ld      %f8, 64(%r15)
-        ld      %f9, 72(%r15)
-        ld      %f10, 80(%r15)
-        ld      %f11, 88(%r15)
-        ld      %f12, 96(%r15)
-        ld      %f13, 108(%r15)
-        ld      %f14, 112(%r15)
-        ld      %f15, 120(%r15)
-    /* Return to caller */
-        lg      %r1, Caml_state(last_return_address)
-    /* Deallocate stack frame */
-        lay     %r15, FRAMESIZE(%r15)
-    /* Return */
-        br      %r1
+#if defined(__PIC__)
+#define LEA_VAR(label,dst) \
+        lgrl  dst, GREL(label)
+#else
+#define LEA_VAR(label,dst) \
+        larl    dst, G(label)
+#endif
 
+/******************************************************************************/
+/* Stack switching operations */
+/******************************************************************************/
+
+/* Switch from OCaml to C stack. Clobbers %r8, %r9. */
+#ifdef ASM_CFI_SUPPORTED
+#define SWITCH_OCAML_TO_C_CFI                                   \
+        CFI_REMEMBER_STATE;                                     \
+          /* %r15 points to the c_stack_link. */                \
+        .cfi_escape DW_CFA_def_cfa_expression, 5,               \
+           DW_OP_breg + DW_REG_r15, Cstack_sp, DW_OP_deref,     \
+           DW_OP_plus_uconst, RETADDR_ENTRY_SIZE
+#else
+#define SWITCH_OCAML_TO_C_CFI
+#endif
+
+#define SWITCH_OCAML_TO_C                                  \
+    /* Fill in Caml_state->current_stack->sp */            \
+        lg      TMP,  Caml_state(current_stack);           \
+        stg     %r15, Stack_sp(TMP);                       \
+    /* Fill in Caml_state->c_stack */                      \
+        lg      TMP2, Caml_state(c_stack);                 \
+        stg     TMP,  Cstack_stack(TMP2);                  \
+        stg     %r15, Cstack_sp(TMP2);                     \
+    /* Switch to C stack */                                \
+        lgr     %r15, TMP2;                                \
+        SWITCH_OCAML_TO_C_CFI
+
+/* Switch from C to OCaml stack.  Clobbers %r9. */
+#define SWITCH_C_TO_OCAML                                           \
+        lg     %r15, Cstack_sp(%r15);                               \
+        CFI_RESTORE_STATE
+
+#define SWITCH_OCAML_STACKS(old_stack, new_stack) \
+    /* Save return address for old_stack */   \
+        lay     %r15, -8(%r15);                                 \
+        stg     %r14, 0(%r15);                                  \
+        CFI_ADJUST(8);                                          \
+    /* Save OCaml SP and exn_handler in the stack info */       \
+        stg     %r15, Stack_sp(old_stack);                      \
+        stg     TRAP_PTR, Stack_exception(old_stack);           \
+    /* switch stacks */                                         \
+        stg     new_stack, Caml_state(current_stack);           \
+        lg      %r15,      Stack_sp(new_stack);                 \
+    /* restore exn_handler for new stack */                     \
+        lg      TRAP_PTR,  Stack_exception(new_stack);          \
+    /* Restore return address for new_stack */                  \
+        lg      %r14, 0(%r15);                                  \
+        la      %r15, 8(%r15);
+
+/******************************************************************************/
+/* Allocation */
+/******************************************************************************/
+
+/* Save all of the registers that may be in use to a free gc_regs bucket
+   and store ALLOC_PTR and TRAP_PTR back to Caml_state
+   At the end the saved registers are placed in Caml_state(gc_regs)
+ */
+#define SAVE_ALL_REGS                                  \
+    /* First, save the young_ptr. */                   \
+        stg     ALLOC_PTR, Caml_state(young_ptr);      \
+        stg     TRAP_PTR,  Caml_state(exn_handler);    \
+    /* Now, use ALLOC_PTR to point to the gc_regs bucket */  \
+        lg      ALLOC_PTR, Caml_state(gc_regs_buckets);\
+        lg      %r0,            0(ALLOC_PTR); /* next ptr */ \
+        stg     %r0, Caml_state(gc_regs_buckets);      \
+    /* Save allocatable registers */                   \
+        stmg    %r2,%r9,    (2*8)(ALLOC_PTR);          \
+        stg     %r12,        10*8(ALLOC_PTR);          \
+        std     %f0,     (0+11)*8(ALLOC_PTR);          \
+        std     %f1,     (1+11)*8(ALLOC_PTR);          \
+        std     %f2,     (2+11)*8(ALLOC_PTR);          \
+        std     %f3,     (3+11)*8(ALLOC_PTR);          \
+        std     %f4,     (4+11)*8(ALLOC_PTR);          \
+        std     %f5,     (5+11)*8(ALLOC_PTR);          \
+        std     %f6,     (6+11)*8(ALLOC_PTR);          \
+        std     %f7,     (7+11)*8(ALLOC_PTR);          \
+        std     %f8,     (8+11)*8(ALLOC_PTR);          \
+        std     %f9,     (9+11)*8(ALLOC_PTR);          \
+        std     %f10,   (10+11)*8(ALLOC_PTR);          \
+        std     %f11,   (11+11)*8(ALLOC_PTR);          \
+        std     %f12,   (12+11)*8(ALLOC_PTR);          \
+        std     %f13,   (13+11)*8(ALLOC_PTR);          \
+        std     %f14,   (14+11)*8(ALLOC_PTR);          \
+        std     %f15,   (15+11)*8(ALLOC_PTR);          \
+        la      ALLOC_PTR, 16(ALLOC_PTR);              \
+        stg     ALLOC_PTR, Caml_state(gc_regs);        \
+        lg      ALLOC_PTR, Caml_state(young_ptr);
+
+/* Undo SAVE_ALL_REGS. Expects gc_regs bucket in %r11 */
+#define RESTORE_ALL_REGS                               \
+        lg      ALLOC_PTR, Caml_state(gc_regs);        \
+        lay     ALLOC_PTR, -16(ALLOC_PTR);             \
+    /* Restore registers */                            \
+        lmg     %r2,%r9,    (2*8)(ALLOC_PTR);          \
+        lg      %r12,        10*8(ALLOC_PTR);          \
+        ld      %f0,     (0+11)*8(ALLOC_PTR);          \
+        ld      %f1,     (1+11)*8(ALLOC_PTR);          \
+        ld      %f2,     (2+11)*8(ALLOC_PTR);          \
+        ld      %f3,     (3+11)*8(ALLOC_PTR);          \
+        ld      %f4,     (4+11)*8(ALLOC_PTR);          \
+        ld      %f5,     (5+11)*8(ALLOC_PTR);          \
+        ld      %f6,     (6+11)*8(ALLOC_PTR);          \
+        ld      %f7,     (7+11)*8(ALLOC_PTR);          \
+        ld      %f8,     (8+11)*8(ALLOC_PTR);          \
+        ld      %f9,     (9+11)*8(ALLOC_PTR);          \
+        ld      %f10,   (10+11)*8(ALLOC_PTR);          \
+        ld      %f11,   (11+11)*8(ALLOC_PTR);          \
+        ld      %f12,   (12+11)*8(ALLOC_PTR);          \
+        ld      %f13,   (13+11)*8(ALLOC_PTR);          \
+        ld      %f14,   (14+11)*8(ALLOC_PTR);          \
+        ld      %f15,   (15+11)*8(ALLOC_PTR);          \
+    /* Put gc_regs struct back in bucket linked list */\
+        lg      %r0, Caml_state(gc_regs_buckets);      \
+        stg     %r0,            0(ALLOC_PTR); /* next ptr */ \
+        stg     ALLOC_PTR, Caml_state(gc_regs_buckets);\
+    /* Reload new allocation pointer & exn handler */  \
+        lg      ALLOC_PTR, Caml_state(young_ptr);      \
+        lg      TRAP_PTR, Caml_state(exn_handler);
+
+
+FUNCTION(G(caml_call_realloc_stack))
+CFI_STARTPROC
+        CFI_SIGNAL_FRAME
+        lay     %r15, -8(%r15)
+        stg     %r14, 0(%r15)
+        CFI_OFFSET(14, 0)
+        SAVE_ALL_REGS
+        lg    C_ARG_1, RETADDR_ENTRY_SIZE(%r15) /* argument */
+        SWITCH_OCAML_TO_C
+        C_call  (GCALL(caml_try_realloc_stack))
+        SWITCH_C_TO_OCAML
+        cgfi    %r2, 0
+        je      LBL(120)
+        RESTORE_ALL_REGS
+        lg      %r14, 0(%r15)
+        la      %r15, 8(%r15)
+        br      %r14
+LBL(120):
+        RESTORE_ALL_REGS
+        lg      %r14, 0(%r15)
+        la      %r15, 16(%r15) /* %r14 register and pop argument, retaddr */
+        LEA_VAR(caml_exn_Stack_overflow, %r2)
+        brcl    15, GCALL(caml_raise_exn)
+CFI_ENDPROC
+ENDFUNCTION(G(caml_call_realloc_stack))
+
+FUNCTION(G(caml_call_gc))
+CFI_STARTPROC
+        CFI_SIGNAL_FRAME
+        lay     %r15, -8(%r15)
+        stg     %r14, 0(%r15)
+        CFI_OFFSET(14, 0)
+LBL(caml_call_gc):
+        SAVE_ALL_REGS
+        SWITCH_OCAML_TO_C
+        C_call (GCALL(caml_garbage_collection))
+        SWITCH_C_TO_OCAML
+        RESTORE_ALL_REGS
+        lg      %r14, 0(%r15)
+        la      %r15, 8(%r15)
+        br      %r14
+CFI_ENDPROC
+ENDFUNCTION(G(caml_call_gc))
+
+FUNCTION(G(caml_alloc1))
+CFI_STARTPROC
+        lay     %r15, -8(%r15)
+        stg     %r14, 0(%r15)
+        CFI_OFFSET(14, 0)
+        ENTER_FUNCTION
+        lay     ALLOC_PTR, -16(ALLOC_PTR)
+        cg      ALLOC_PTR, Caml_state(young_limit)
+        jl      LBL(caml_call_gc)
+        LEAVE_FUNCTION
+        lg      %r14, 0(%r15)
+        la      %r15, 8(%r15)
+        br      %r14
+CFI_ENDPROC
+ENDFUNCTION(G(caml_alloc1))
+
+FUNCTION(G(caml_alloc2))
+CFI_STARTPROC
+        lay     %r15, -8(%r15)
+        stg     %r14, 0(%r15)
+        CFI_OFFSET(14, 0)
+        ENTER_FUNCTION
+        lay     ALLOC_PTR, -24(ALLOC_PTR)
+        cg      ALLOC_PTR, Caml_state(young_limit)
+        jl      LBL(caml_call_gc)
+        LEAVE_FUNCTION
+        lg      %r14, 0(%r15)
+        la      %r15, 8(%r15)
+        br      %r14
+CFI_ENDPROC
+ENDFUNCTION(G(caml_alloc2))
+
+FUNCTION(G(caml_alloc3))
+CFI_STARTPROC
+        lay     %r15, -8(%r15)
+        stg     %r14, 0(%r15)
+        CFI_OFFSET(14, 0)
+        ENTER_FUNCTION
+        lay     ALLOC_PTR, -32(ALLOC_PTR)
+        cg      ALLOC_PTR, Caml_state(young_limit)
+        jl      LBL(caml_call_gc)
+        LEAVE_FUNCTION
+        lg      %r14, 0(%r15)
+        la      %r15, 8(%r15)
+        br      %r14
+CFI_ENDPROC
+ENDFUNCTION(G(caml_alloc3))
+
+FUNCTION(G(caml_allocN))
+CFI_STARTPROC
+        lay     %r15, -8(%r15)
+        stg     %r14, 0(%r15)
+        CFI_OFFSET(14, 0)
+        ENTER_FUNCTION
+        sgr     ALLOC_PTR, ADDITIONAL_ARG
+        cg      ALLOC_PTR, Caml_state(young_limit)
+        jl      LBL(caml_call_gc)
+        LEAVE_FUNCTION
+        lg      %r14, 0(%r15)
+        la      %r15, 8(%r15)
+        br      %r14
+CFI_ENDPROC
+ENDFUNCTION(G(caml_allocN))
+
+/******************************************************************************/
 /* Call a C function from OCaml */
+/******************************************************************************/
 
-        .globl  caml_c_call
-        .type   caml_c_call, @function
-caml_c_call:
-        stg     %r15, Caml_state(bottom_of_stack)
-.L101:
-    /* Save return address */
-        ldgr    %f15, %r14
-    /* Get ready to call C function (address in r7) */
-    /* Record lowest stack address and return address */
-        stg     %r14, Caml_state(last_return_address)
-    /* Make the exception handler and alloc ptr available to the C code */
-        stg     %r11, Caml_state(young_ptr)
-        stg     %r13, Caml_state(exception_pointer)
-    /* Call the function */
-        basr %r14, %r7
-    /* restore return address */
-        lgdr    %r14,%f15
-    /* Reload allocation pointer */
-        lg      %r11, Caml_state(young_ptr)
-    /* Return to caller */
-        br %r14
+FUNCTION(G(caml_c_call))
+CFI_STARTPROC
+        CFI_SIGNAL_FRAME
+        lay     %r15, -8(%r15)
+        CFI_ADJUST(8)
+        stg     %r14, 0(%r15)
+        CFI_OFFSET(14, -168)
+LBL(caml_c_call):
+    /* Arguments:
+        C arguments         : %r2, %r3, %r4, %r5, %r6
+        C function          : ADDITIONAL_ARG */
+    /* Switch from OCaml to C */
+        SWITCH_OCAML_TO_C
+    /* Make the exception handler alloc ptr available to the C code */
+        stg     ALLOC_PTR, Caml_state(young_ptr)
+        stg     TRAP_PTR, Caml_state(exn_handler)
+    /* Call the function (address in ADDITIONAL_ARG) */
+        PREPARE_FOR_C_CALL
+        basr    %r14, ADDITIONAL_ARG
+        CLEANUP_AFTER_C_CALL
+    /* Reload alloc ptr  */
+        lg      ALLOC_PTR, Caml_state(young_ptr)
+    /* Load ocaml stack and restore global variables */
+        SWITCH_C_TO_OCAML
+    /* Return to OCaml caller */
+        lg      %r14, 0(%r15)
+        la      %r15, 8(%r15)
+        br      %r14
+CFI_ENDPROC
+ENDFUNCTION(G(caml_c_call))
 
-/* Raise an exception from OCaml */
-        .globl  caml_raise_exn
-        .type   caml_raise_exn, @function
-caml_raise_exn:
-        lg      %r0, Caml_state(backtrace_active)
-        cgfi    %r0, 0
-        jne     .L110
-.L111:
-    /* Pop trap frame */
-        lg      %r1, 0(%r13)
-        lgr     %r15, %r13
-        lg      %r13, 8(13)
-        agfi    %r15, 16
-    /* Branch to handler */
-        br      %r1
-.L110:
-        ldgr    %f15, %r2       /* preserve exn bucket in callee-save reg */
-                                /* arg1: exception bucket, already in r2 */
-        lgr     %r3, %r14       /* arg2: PC of raise */
-        lgr     %r4, %r15       /* arg3: SP of raise */
-        lgr     %r5, %r13       /* arg4: SP of handler */
-        agfi    %r15, -160      /* reserve stack space for C call */
-        brasl   %r14, caml_stash_backtrace@PLT
-        agfi    %r15, 160
-        lgdr    %r2,%f15        /* restore exn bucket */
-        j       .L111           /* raise the exn */
+FUNCTION(G(caml_c_call_stack_args))
+CFI_STARTPROC
+        CFI_SIGNAL_FRAME
+        lay     %r15, -8(%r15)
+        stg     %r14, 0(%r15)
+        CFI_OFFSET(14, 0)
+    /* Arguments:
+        C arguments         : %r2, %r3, %r4, %r5, %r6
+        C function          : ADDITIONAL_ARG
+        C stack args        : begin=%r9 end=%r8 */
+    /* Switch from OCaml to C */
+        SWITCH_OCAML_TO_C
+    /* Make the exception handler alloc ptr available to the C code */
+        stg     ALLOC_PTR, Caml_state(young_ptr)
+        stg     TRAP_PTR, Caml_state(exn_handler)
+    /* Store sp to restore after call */
+        lgr     %r12, %r15
+#ifdef ASM_CFI_SUPPORTED
+        .cfi_escape DW_CFA_def_cfa_expression, 5,           \
+          /* %rbp points to the c_stack_link structure */   \
+          DW_OP_breg + DW_REG_r12, Cstack_sp, DW_OP_deref,  \
+          DW_OP_plus_uconst, RETADDR_ENTRY_SIZE
+#endif
+    /* Copy arguments from OCaml to C stack */
+LBL(105):
+        lay     %r8, -8(%r8)
+        cgr     %r8, %r9
+        jh      LBL(106)
+        lg      %r0, 0(%r8)
+        lay     %r15, -8(%r15)
+        stg     %r0, 0(%r15)
+        CFI_ADJUST(8)
+        brcl    15, LBL(105)
+LBL(106):
+    /* Call the function (address in %r7) */
+        PREPARE_FOR_C_CALL
+        basr    %r14, ADDITIONAL_ARG
+        CLEANUP_AFTER_C_CALL
+    /* Restore stack */
+        lgr     %r15, %r12
+    /* Reload alloc ptr */
+        lg      ALLOC_PTR, Caml_state(young_ptr)
+    /* Switch from C to OCaml */
+        SWITCH_C_TO_OCAML
+    /* Return */
+        lg      %r14, 0(%r15)
+        la      %r15, 8(%r15)
+        br      %r14
+CFI_ENDPROC
+ENDFUNCTION(G(caml_c_call_stack_args))
 
-/* Raise an exception from C */
-
-        .globl  caml_raise_exception
-        .type   caml_raise_exception, @function
-caml_raise_exception:
-        lgr     %r10, %r2       /* Load domain state pointer */
-        lgr     %r2, %r3        /* Move exception bucket to arg1 register */
-        lg      %r0, Caml_state(backtrace_active)
-        cgfi    %r0, 0
-        jne    .L112
-.L113:
-    /* Reload OCaml global registers */
-        lg      %r15, Caml_state(exception_pointer)
-        lg      %r11, Caml_state(young_ptr)
-    /* Pop trap frame */
-        lg      %r1, 0(%r15)
-        lg      %r13, 8(%r15)
-        agfi    %r15, 16
-    /* Branch to handler */
-        br      %r1;
-.L112:
-        ldgr    %f15,%r2        /* preserve exn bucket in callee-save reg */
-                                /* arg1: exception bucket, already in r2 */
-        lg      %r3, Caml_state(last_return_address) /* arg2: PC of raise */
-        lg      %r4, Caml_state(bottom_of_stack)     /* arg3: SP of raise */
-        lg      %r5, Caml_state(exception_pointer)   /* arg4: SP of handler */
-    /* reserve stack space for C call */
-        lay     %r15, -160(%r15)
-        brasl   %r14, caml_stash_backtrace@PLT
-        lay     %r15, 160(%r15)
-        lgdr    %r2,%f15        /* restore exn bucket */
-        j       .L113           /* raise the exn */
-
+/******************************************************************************/
 /* Start the OCaml program */
+/******************************************************************************/
 
-        .globl  caml_start_program
-        .type   caml_start_program, @function
-caml_start_program:
-    /* Move Caml_state passed as first argument to r1 */
-        lgr     %r1, %r2
-        Addrglobal(%r0, caml_program)
-
-/* Code shared between caml_start_program and caml_callback */
-.L102:
+FUNCTION(G(caml_start_program))
+CFI_STARTPROC
+        CFI_SIGNAL_FRAME
+    /* Load Caml_state into TMP (was passed as an argument from C) */
+        lgr    TMP3, C_ARG_1
+    /* Initial entry point is G(caml_program) */
+        LEA_VAR(caml_program, TMP)
+    /* Common code for caml_start_program and caml_callback* */
+LBL(caml_start_program):
     /* Allocate stack frame */
-        lay     %r15, -144(%r15)
+        lay     %r15, -160(%r15)
     /* Save all callee-save registers + return address */
     /* GPR 6..14 at sp + 0 ... sp + 64
        FPR 10..15 at sp + 72 ... sp + 128 */
         stmg    %r6,%r14, 0(%r15)
+        CFI_OFFSET(14, 64)
         std     %f8, 72(%r15)
         std     %f9, 80(%r15)
         std     %f10, 88(%r15)
@@ -220,50 +498,71 @@ caml_start_program:
         std     %f13, 112(%r15)
         std     %f14, 120(%r15)
         std     %f15, 128(%r15)
-
-    /* Load Caml_state to r10 register */
-        lgr     %r10, %r1
-    /* Set up a callback link */
-        lay     %r15, -32(%r15)
-        lg      %r1, Caml_state(bottom_of_stack)
-        stg     %r1, 0(%r15)
-        lg      %r1, Caml_state(last_return_address)
-        stg     %r1, 8(%r15)
-        lg      %r1, Caml_state(gc_regs)
-        stg     %r1, 16(%r15)
-    /* Build an exception handler to catch exceptions escaping out of OCaml */
-        brasl   %r14, .L103
-        j       .L104
-.L103:
-        lay     %r15, -16(%r15)
-        stg     %r14, 0(%r15)
-        lg      %r1, Caml_state(exception_pointer)
-        stg     %r1, 8(%r15)
-        lgr     %r13, %r15
+    /* Load domain state pointer from argument */
+        lgr     DOMAIN_STATE_PTR, TMP3
     /* Reload allocation pointer */
-        lg      %r11, Caml_state(young_ptr)
-    /* Call the OCaml code */
-        lgr     %r1,%r0
-        basr    %r14, %r1
-.L105:
-    /* Pop the trap frame, restoring caml_exception_pointer */
-        lg      %r0, 8(%r15)
-        stg     %r0, Caml_state(exception_pointer)
-        la      %r15, 16(%r15)
-    /* Pop the callback link, restoring the global variables */
-.L106:
-        lg      %r5, 0(%r15)
-        lg      %r6, 8(%r15)
-        lg      %r0, 16(%r15)
-        stg     %r5, Caml_state(bottom_of_stack)
-        stg     %r6, Caml_state(last_return_address)
-        stg     %r0, Caml_state(gc_regs)
-        la      %r15, 32(%r15)
-
-    /* Update allocation pointer */
-        stg     %r11, Caml_state(young_ptr)
-
-    /* Restore registers */
+        lg      ALLOC_PTR, Caml_state(young_ptr)
+    /* Build struct c_stack_link on the C stack */
+        lay     %r15, -24(%r15); /* sizeof struct c_stack_link */ CFI_ADJUST(24)
+        lg      TMP3,  Caml_state(c_stack)
+        lgfi    TMP2,  0
+        stg     TMP2,  Cstack_stack(%r15)
+        stg     TMP2,  Cstack_sp(%r15)
+        stg     TMP3,  Cstack_prev(%r15)
+        stg     %r15,  Caml_state(c_stack)
+    /* Load the OCaml stack. */
+        lg      %r8, Caml_state(current_stack)
+        lg      %r8, Stack_sp(%r8)
+    /* Store the stack pointer to allow DWARF unwind */
+        lay     %r8, -16(%r8)
+        stg     %r15, 0(%r8) /* C_STACK_SP */
+    /* Store the gc_regs for callbacks during a GC */
+        lg      %r9, Caml_state(gc_regs)
+        stg     %r9, 8(%r8)
+    /* Build a handler for exceptions raised in OCaml on the OCaml stack. */
+        lay     %r8, -16(%r8)
+    /* link in the previous exn_handler so that copying stacks works */
+        lg      %r9, Caml_state(exn_handler)
+        stg     %r9, 0(%r8)
+        lay     %r9, LBL(trap_handler)
+        stg     %r9, 8(%r8)
+        stg     %r8, Caml_state(exn_handler)
+    /* Switch stacks and call the OCaml code */
+        lgr     %r15, %r8
+#ifdef ASM_CFI_SUPPORTED
+        CFI_REMEMBER_STATE
+        .cfi_escape DW_CFA_def_cfa_expression, 3 + 2,                 \
+            /* %rsp points to the exn handler on the OCaml stack */   \
+            /* %rsp + 16 contains the C_STACK_SP */                   \
+          DW_OP_breg + DW_REG_r15, 16 /* exn handler */, DW_OP_deref, \
+          DW_OP_plus_uconst,                                          \
+             24  /* struct c_stack_link */ +                          \
+             6*8 /* callee save regs */ +                             \
+             8   /* ret addr */
+#endif
+        PREPARE_FOR_C_CALL
+        basr    %r14, TMP
+LBL(caml_retaddr):
+        CLEANUP_AFTER_C_CALL
+    /* pop exn handler */
+        lay     %r8, 16(%r15)
+        stg     %r8, Caml_state(exn_handler)
+LBL(return_result):  /* restore GC regs */
+        lg      %r9, 8(%r8)
+        stg     %r9, Caml_state(gc_regs)
+        la      %r8, 16(%r8)
+    /* Update alloc ptr */
+        stg     ALLOC_PTR, Caml_state(young_ptr)
+    /* Return to C stack. */
+        lg      %r8, Caml_state(current_stack)
+        stg     %r15, Stack_sp(%r8)
+        lg      %r15, Caml_state(c_stack)
+        CFI_RESTORE_STATE
+    /* Pop the struct c_stack_link */
+        lg      %r8, Cstack_prev(%r15)
+        stg     %r8, Caml_state(c_stack)
+        la      %r15, 24(%r15); CFI_ADJUST(-24)
+    /* Restore callee-save registers. */
         lmg     %r6,%r14, 0(%r15)
         ld      %f8, 72(%r15)
         ld      %f9, 80(%r15)
@@ -273,68 +572,325 @@ caml_start_program:
         ld      %f13, 112(%r15)
         ld      %f14, 120(%r15)
         ld      %f15, 128(%r15)
-
     /* Return */
-        lay     %r15, 144(%r15)
+        la     %r15, 160(%r15)
+    /* Return to caller. */
         br      %r14
-
-    /* The trap handler: */
-.L104:
-    /* Update caml_exception_pointer */
-        stg     %r13, Caml_state(exception_pointer)
-    /* Encode exception bucket as an exception result and return it */
+LBL(trap_handler):
+    /* Exception handler*/
+        stg     TRAP_PTR, Caml_state(exn_handler)
+    /* Mark the bucket as an exception result and return it */
         oill     %r2,  2
-        j       .L106
+        j       LBL(return_result)
+CFI_ENDPROC
+ENDFUNCTION(G(caml_start_program))
 
+/******************************************************************************/
+/* Exceptions */
+/******************************************************************************/
+
+#define JUMP_TO_TRAP_PTR \
+        lgr     %r15,     TRAP_PTR;                    \
+        lg      TMP,       0(%r15);                    \
+        lg      TRAP_PTR,  8(%r15);                    \
+        la      %r15,     16(%r15);                    \
+        br      TMP;
+
+/* Raise an exception from OCaml */
+
+FUNCTION(G(caml_raise_exn))
+CFI_STARTPROC
+LBL(caml_raise_exn):
+        clghsi  Caml_state(backtrace_active), 0
+        jne     LBL(117)
+LBL(116):
+        JUMP_TO_TRAP_PTR
+LBL(117):
+        /* Zero backtrace_pos */
+        lgfi    TMP, 0
+        stg     TMP, Caml_state(backtrace_pos)
+LBL(caml_reraise_exn_stash):
+        lgr     %r9, %r2          /* Save exception bucket */
+    /* Stash the backtrace */
+                                  /* arg1: exception bucket, already in r2 */
+        lgr     C_ARG_2, %r14     /* arg2: PC of raise */
+        lgr     C_ARG_3, %r15     /* arg3: SP of raise */
+        lg      C_ARG_4, TRAP_PTR /* arg4: SP of handler */
+    /* Switch to C stack */
+        lg      %r15, Caml_state(c_stack)
+        C_call  (GCALL(caml_stash_backtrace))
+    /* Restore exception bucket and raise */
+        lgr     %r2, %r9
+        brcl    15, LBL(116)
+CFI_ENDPROC
+ENDFUNCTION(G(caml_raise_exn))
+
+FUNCTION(G(caml_reraise_exn))
+CFI_STARTPROC
+        clghsi  Caml_state(backtrace_active), 0
+        jne     LBL(caml_reraise_exn_stash)
+        JUMP_TO_TRAP_PTR
+CFI_ENDPROC
+ENDFUNCTION(G(caml_reraise_exn))
+
+/* Raise an exception from C */
+
+FUNCTION(G(caml_raise_exception))
+CFI_STARTPROC
+    /* Load the domain state ptr */
+        lgr     DOMAIN_STATE_PTR, C_ARG_1
+    /* Load the exception bucket */
+        lgr     C_ARG_1,  C_ARG_2
+    /* Reload trap ptr and alloc ptr */
+        lg      TRAP_PTR, Caml_state(exn_handler)
+        lg      ALLOC_PTR, Caml_state(young_ptr)
+    /* Discard the C stack pointer and reset to ocaml stack */
+        lg      TMP, Caml_state(current_stack)
+        lg      %r15, Stack_sp(TMP)
+    /* Restore frame and link on return to OCaml */
+        lg      %r14, 0(%r15)
+        la      %r15, 8(%r15)
+        brcl    15, LBL(caml_raise_exn)
+CFI_ENDPROC
+ENDFUNCTION(G(caml_raise_exception))
+
+/******************************************************************************/
 /* Callback from C to OCaml */
+/******************************************************************************/
 
-        .globl  caml_callback_asm
-        .type   caml_callback_asm, @function
-caml_callback_asm:
+FUNCTION(G(caml_callback_asm))
+CFI_STARTPROC
     /* Initial shuffling of arguments */
-    /* (r2 = Caml_state, r3 = closure, 0(r4) = arg1) */
-        lgr     %r1, %r2            /* r1 = Caml_state */
-        lg      %r2, 0(%r4)         /* r2 = Argument */
-                                    /* r3 = Closure */
-        lg      %r0, 0(%r3)         /* r0 = Code pointer */
-        j       .L102
+    /* (%r2 = Caml_state, %r3 = closure, 0(%r4) = first arg) */
+        lgr     TMP3, C_ARG_1        /* Caml_state */
+        lg      C_ARG_1, 0(C_ARG_3)  /* %r2 - first arg */
+                                     /* %r3 - closure environment */
+        lg      TMP,     0(C_ARG_2)  /* code pointer */
+        brcl    15, LBL(caml_start_program)
+CFI_ENDPROC
+ENDFUNCTION(G(caml_callback_asm))
 
-        .globl  caml_callback2_asm
-        .type   caml_callback2_asm, @function
-caml_callback2_asm:
+FUNCTION(G(caml_callback2_asm))
+CFI_STARTPROC
     /* Initial shuffling of arguments */
-    /* (r2 = Caml_state, r3 = closure, 0(r4) = arg1, 8(r4) = arg2) */
-        lgr      %r1, %r2            /* r1 = Caml_state */
-        lgr      %r0, %r3
-        lg       %r2, 0(%r4)         /* r2 = First argument */
-        lg       %r3, 8(%r4)         /* r3 = Second argument */
-        lgr      %r4, %r0            /* r4 = Closure */
-        Addrglobal(%r0, caml_apply2) /* r0 = Code pointer */
-        j       .L102
+    /* (%r2 = Caml_state, %r3 = closure, 0(%r4) = arg1, 8(%r4) = arg2) */
+        lgr     TMP3, C_ARG_1       /* Caml_state */
+        lgr     TMP2, C_ARG_2
+        lg      C_ARG_1, 0(C_ARG_3) /* first argument */
+        lg      C_ARG_2, 8(C_ARG_3) /* second argument */
+        lgr     C_ARG_3, TMP2       /* closure */
+        LEA_VAR(caml_apply2, TMP)   /* code pointer */
+        brcl    15, LBL(caml_start_program)
+CFI_ENDPROC
+ENDFUNCTION(G(caml_callback2_asm))
 
-        .globl  caml_callback3_asm
-        .type   caml_callback3_asm, @function
-caml_callback3_asm:
+FUNCTION(G(caml_callback3_asm))
+CFI_STARTPROC
     /* Initial shuffling of arguments */
-    /* (r2 = Caml_state, r3 = closure, 0(r4) = arg1, 8(r4) = arg2,
-        16(r4) = arg3) */
-        lgr      %r1, %r2            /* r1 = Caml_state */
-        lgr      %r5, %r3            /* r5 = Closure */
-        lg       %r2, 0(%r4)         /* r2 = First argument */
-        lg       %r3, 8(%r4)         /* r3 = Second argument */
-        lg       %r4, 16(%r4)        /* r4 = Third argument */
-        Addrglobal(%r0, caml_apply3) /* r0 = Code pointer */
-        j        .L102
+    /* (%r2 = Caml_state, %r3 = closure, 0(%r4) = arg1, 8(%r4) = arg2,
+        16(%r4) = arg3) */
+        lgr     TMP3,       C_ARG_1     /* Caml_state */
+        lgr     C_ARG_4,    C_ARG_2     /* closure */
+        lg      C_ARG_1,  0(C_ARG_3)    /* first argument */
+        lg      C_ARG_2,  8(C_ARG_3)    /* second argument */
+        lg      C_ARG_3, 16(C_ARG_3)    /* third argument */
+        LEA_VAR(caml_apply3, TMP)       /* code pointer */
+        brcl    15, LBL(caml_start_program)
+CFI_ENDPROC
+ENDFUNCTION(G(caml_callback3_asm))
 
-        .globl  caml_ml_array_bound_error
-        .type   caml_ml_array_bound_error, @function
-caml_ml_array_bound_error:
-        /* Save return address before decrementing SP, otherwise
-           the frame descriptor for the call site is not correct */
-        stg     %r15, Caml_state(bottom_of_stack)
-        lay     %r15, -160(%r15)    /* Reserve stack space for C call */
-        Addrglobal(%r7, caml_array_bound_error_asm)
-        j       .L101
+/******************************************************************************/
+/* Fibers */
+/*
+ * A continuation is a one word object that points to a fiber. A fiber [f] will
+ * point to its parent at Handler_parent(Stack_handler(f)). In the following,
+ * the [last_fiber] refers to the last fiber in the linked-list formed by the
+ * parent pointer.
+ */
+/******************************************************************************/
+
+FUNCTION(G(caml_perform))
+CFI_STARTPROC
+    /*  %r2: effect to perform
+        %r3: freshly allocated continuation */
+        lg      %r4, Caml_state(current_stack) /* %r4 := old stack */
+        lay     %r5, 1(%r4) /* %r5 (last_fiber) := Val_ptr(old stack) */
+        stg     %r5, 0(%r3) /* Initialise continuation */
+LBL(do_perform):
+    /*  %r2: effect to perform
+        %r3: continuation
+        %r4: old_stack
+        %r5: last_fiber */
+
+        lg      %r9, Stack_handler(%r4)  /* %r9 := old stack -> handler */
+        lg      %r8, Handler_parent(%r9)
+        clgfi   %r8, 0   /* %r10 := parent stack; is parent NULL? */
+        je      LBL(112)
+        SWITCH_OCAML_STACKS(%r4, %r8)
+     /* We have to null the Handler_parent after the switch because the
+        Handler_parent is needed to unwind the stack for backtraces */
+        lgfi    %r0, 0
+        stg     %r0, Handler_parent(%r9) /* Set parent of performer to NULL */
+        lgr     %r4, %r5                 /* %r4 = last_fiber */
+        lg      %r5, Handler_effect(%r9) /* %r5 := effect handler */
+        brasl    %r14, GCALL(caml_apply3)
+LBL(112):
+    /* Switch back to original performer before raising Unhandled
+       (no-op unless this is a reperform) */
+        lg      %r8, 0(%r3)              /* load performer stack from continuation */
+        lay     %r8, -1(%r8)             /* r8 := Ptr_val(r8) */
+        lg      %r9, Caml_state(current_stack)
+        SWITCH_OCAML_STACKS(%r9, %r8)
+    /* No parent stack. Raise Unhandled. */
+        LEA_VAR(caml_raise_unhandled_effect, %r2)
+        brcl    15, LBL(caml_raise_exn)
+CFI_ENDPROC
+ENDFUNCTION(G(caml_perform))
+
+FUNCTION(G(caml_reperform))
+CFI_STARTPROC
+    /*  %r2: effect to reperform
+        %r3: continuation
+        %r4: last_fiber */
+        lg      TMP, (Stack_handler-1)(%r4)
+        lg      %r4, Caml_state(current_stack)  /* %r4 := old stack */
+        stg     %r4, Handler_parent(TMP)        /* Append to last_fiber */
+        lay     %r5, 1(%r4)  /* %r5 (last_fiber) := Val_ptr(old stack) */
+        brcl    15, LBL(do_perform)
+CFI_ENDPROC
+ENDFUNCTION(G(caml_reperform))
+
+FUNCTION(G(caml_resume))
+CFI_STARTPROC
+    /* %r2 -> new fiber, %r3 -> fun, %r4 -> arg */
+        lay     %r2, -1(%r2)  /* %r2 (new stack) = Ptr_val(%r2) */
+        lg      %r5,  0(%r3)  /* code pointer */
+    /*  check if stack null, then already used */
+        cgfi    %r2, 0
+        jz      LBL(caml_resume_2)
+    /* Find end of list of stacks and add current */
+        lgr     TMP, %r2
+LBL(caml_resume_1):
+        lg      %r8, Stack_handler(TMP)
+        lg      TMP, Handler_parent(%r8)
+        cgfi    TMP, 0
+        jnz     LBL(caml_resume_1)
+        lg      %r9, Caml_state(current_stack)
+        stg     %r9, Handler_parent(%r8)
+     /* Need to update the oldest saved frame pointer here as the current fiber
+        stack may have been reallocated or we may be resuming a computation
+        that was not originally run here. */
+        SWITCH_OCAML_STACKS(%r9, %r2)
+        lgr     %r2, %r4
+        br      %r5
+LBL(caml_resume_2):
+        LEA_VAR(caml_raise_continuation_already_resumed, %r2)
+        brcl    15, LBL(caml_raise_exn)
+CFI_ENDPROC
+ENDFUNCTION(G(caml_resume))
+
+/* Run a function on a new stack,
+   then invoke either the value or exception handler */
+FUNCTION(G(caml_runstack))
+CFI_STARTPROC
+        CFI_SIGNAL_FRAME
+        lay     %r15, -8(%r15)
+        stg     %r14, 0(%r15)
+        CFI_OFFSET(14, 0)
+        ENTER_FUNCTION
+    /* %r2 -> fiber, %r3 -> fun, %r4 -> arg */
+        lay     %r2, -1(%r2)  /* %r2 (new stack) = Ptr_val(%r2) */
+        lg      %r5,  0(%r3)  /* code pointer */
+    /* save old stack pointer and exception handler */
+        lg      %r8, Caml_state(current_stack) /* %r8 = old stack */
+        stg     %r15, Stack_sp(%r8)
+        stg     TRAP_PTR, Stack_exception(%r8)
+    /* Load new stack pointer and set parent */
+        lg      TMP, Stack_handler(%r2)
+        stg     %r8, Handler_parent(TMP)
+        stg     %r2, Caml_state(current_stack)
+        lg      %r9, Stack_sp(%r2) /* %r9 = sp of new stack */
+    /* Create an exception handler on the target stack
+       after 16byte DWARF & gc_regs block (which is unused here) */
+        lay     %r9, 32(%r9)
+        larl    TMP, LBL(fiber_exn_handler)
+        stg     TMP, 8(%r9)
+    /* link the previous exn_handler so that copying stacks works */
+        lg      TMP, Stack_exception(%r2)
+        stg     TMP, 0(%r9)
+        lgr     TRAP_PTR, %r9
+    /* Switch to the new stack */
+        lgr     %r15, %r9
+#ifdef ASM_CFI_SUPPORTED
+        CFI_REMEMBER_STATE
+        .cfi_escape DW_CFA_def_cfa_expression, 3+3+2, \
+          DW_OP_breg + DW_REG_r15,                    \
+            16 /* exn */ +                            \
+            8 /* gc_regs slot (unused) */ +           \
+            8 /* C_STACK_SP for DWARF (unused) */     \
+            + Handler_parent, DW_OP_deref,            \
+          DW_OP_plus_uconst, Stack_sp, DW_OP_deref,   \
+          DW_OP_plus_uconst, RETADDR_ENTRY_SIZE
+#endif
+    /* Call the function on the new stack */
+        lgr     %r2, %r4 /* first argument */
+        PREPARE_FOR_C_CALL
+        basr    %r14, %r5 /* closure in %r3 (second argument) */
+        CLEANUP_AFTER_C_CALL
+LBL(frame_runstack):
+        lay     %r8, 32(%r15) /*%r8 = stack_handler */
+        lg      %r7, Handler_value(%r8) /* saved across C call */
+LBL(caml_runstack_1):
+        lgr     %r12, %r2 /* save return across C call */
+        lg      %r2, Caml_state(current_stack)
+    /* restore parent stack and exn_handler into Caml_state */
+        lg      TMP, Handler_parent(%r8)
+        stg     TMP, Caml_state(current_stack)
+        lg      TRAP_PTR, Stack_exception(TMP)
+        stg     TRAP_PTR, Caml_state(exn_handler)
+    /* free old stack by switching directly to c_stack; is a no-alloc call */
+        lg      %r9, Stack_sp(TMP) /* saved across C call */
+        CFI_RESTORE_STATE
+        CFI_REMEMBER_STATE
+        CFI_DEF_CFA_REGISTER(DW_REG_r9)
+        lg      %r15, Caml_state(c_stack)
+        C_call  (GCALL(caml_free_stack))
+    /* switch directly to parent stack with correct return */
+        lgr     %r2,  %r12
+        lgr     %r3,  %r7
+        lgr     %r15, %r9
+        CFI_RESTORE_STATE
+        lg      TMP, 0(%r3) /* code pointer */
+    /* Invoke handle_value (or handle_exn) */
+        lg      %r14, 0(%r15)
+        la      %r15, 8(%r15)
+        br      TMP
+LBL(fiber_exn_handler):
+        lay     %r8, 16(%r15)
+        lg      %r3, Handler_exception(%r8)
+        brcl    15, LBL(caml_runstack_1)
+CFI_ENDPROC
+ENDFUNCTION(G(caml_runstack))
+
+FUNCTION(G(caml_ml_array_bound_error))
+CFI_STARTPROC
+        lay     %r15, -8(%r15)
+        stg     %r14, 0(%r15)
+        ENTER_FUNCTION
+        LEA_VAR(caml_array_bound_error_asm, %r2)
+        brcl    15, LBL(caml_c_call)
+CFI_ENDPROC
+ENDFUNCTION(G(caml_ml_array_bound_error))
+
+FUNCTION(G(caml_assert_stack_invariants))
+CFI_STARTPROC
+    /* Load address of [caml_array_bound_error_asm] in ADDITIONAL_ARG */
+        LEA_VAR(caml_array_bound_error_asm, ADDITIONAL_ARG)
+    /* Call that function */
+        brcl    15, GCALL(caml_c_call)
+CFI_ENDPROC
+ENDFUNCTION(G(caml_assert_stack_invariants))
+
         .globl  caml_system__code_end
 caml_system__code_end:
 
@@ -345,8 +901,12 @@ caml_system__code_end:
         .globl  caml_system.frametable
         .type   caml_system.frametable, @object
 caml_system.frametable:
-        .quad   1               /* one descriptor */
-        .quad   .L105           /* return address into callback */
+        .quad   2               /* two descriptors */
+        .quad   LBL(caml_retaddr)  /* return address into callback */
+        .short  -1              /* negative size count => use callback link */
+        .short  0               /* no roots here */
+        .align  8
+        .quad   LBL(frame_runstack) /* return address into fiber_val_handler */
         .short  -1              /* negative size count => use callback link */
         .short  0               /* no roots here */
         .align  8

--- a/runtime/s390x.S
+++ b/runtime/s390x.S
@@ -79,7 +79,8 @@
 /* struct c_stack_link + callee save regs = 24 + 8*8 = 88 */
 #define start_program_sleb128_2byte 216, 0
 
-/* exception handler + gc_regs slot + C_STACK_SP + Handler_parent = 16 + 8 + 8 + 24 = 56 */
+/* exception handler + gc_regs slot + C_STACK_SP + Handler_parent
+   = 16 + 8 + 8 + 24 = 56 */
 #define caml_runstack_sleb128_1byte 56
 
 #define RETADDR_ENTRY_SIZE   8 /* retaddr */
@@ -175,7 +176,7 @@ caml_system__code_begin:
         CFI_OFFSET(14, 0); \
           /* %r15 points to the c_stack_link. */                \
         .cfi_escape DW_CFA_def_cfa_expression, 3,               \
-           DW_OP_breg + DW_REG_r15, Cstack_sp, DW_OP_deref
+          DW_OP_breg + DW_REG_r15, Cstack_sp, DW_OP_deref
 #else
 #define SWITCH_OCAML_TO_C_CFI
 #endif
@@ -297,7 +298,8 @@ CFI_STARTPROC
         SWITCH_OCAML_TO_C
         PREPARE_FOR_C_CALL
 #ifdef ASM_CFI_SUPPORTED
-        .cfi_escape DW_CFA_def_cfa_expression, 4, DW_OP_breg + DW_REG_r15, Cstack_sp_plus_160_sleb128_2byte, DW_OP_deref
+        .cfi_escape DW_CFA_def_cfa_expression, 4, DW_OP_breg + DW_REG_r15, \
+          Cstack_sp_plus_160_sleb128_2byte, DW_OP_deref
 #endif
         CHECK_STACK_ALIGNMENT
         brasl %r14, GCALL(caml_try_realloc_stack)
@@ -332,7 +334,8 @@ LBL(caml_call_gc):
         SWITCH_OCAML_TO_C
         PREPARE_FOR_C_CALL
 #ifdef ASM_CFI_SUPPORTED
-        .cfi_escape DW_CFA_def_cfa_expression, 4, DW_OP_breg + DW_REG_r15, Cstack_sp_plus_160_sleb128_2byte, DW_OP_deref
+        .cfi_escape DW_CFA_def_cfa_expression, 4, DW_OP_breg + DW_REG_r15, \
+          Cstack_sp_plus_160_sleb128_2byte, DW_OP_deref
 #endif
         CHECK_STACK_ALIGNMENT
         brasl %r14, GCALL(caml_garbage_collection)
@@ -440,7 +443,8 @@ LBL(caml_c_call):
     /* Call the function (address in ADDITIONAL_ARG) */
         PREPARE_FOR_C_CALL
 #ifdef ASM_CFI_SUPPORTED
-        .cfi_escape DW_CFA_def_cfa_expression, 4, DW_OP_breg + DW_REG_r15, Cstack_sp_plus_160_sleb128_2byte, DW_OP_deref
+        .cfi_escape DW_CFA_def_cfa_expression, 4, DW_OP_breg + DW_REG_r15, \
+          Cstack_sp_plus_160_sleb128_2byte, DW_OP_deref
 #endif
         basr    %r14, ADDITIONAL_ARG
         CLEANUP_AFTER_C_CALL
@@ -780,8 +784,8 @@ LBL(do_perform):
 LBL(112):
     /* Switch back to original performer before raising Unhandled
        (no-op unless this is a reperform) */
-        lg      %r8, 0(%r3)              /* load performer stack from continuation */
-        lay     %r8, -1(%r8)             /* r8 := Ptr_val(r8) */
+        lg      %r8, 0(%r3)         /* load performer stack from continuation */
+        lay     %r8, -1(%r8)        /* r8 := Ptr_val(r8) */
         lg      %r9, Caml_state(current_stack)
         SWITCH_OCAML_STACKS(%r9, %r8)
     /* No parent stack. Raise Unhandled. */

--- a/runtime/s390x.S
+++ b/runtime/s390x.S
@@ -668,7 +668,7 @@ LBL(caml_reraise_exn_stash):
                                   /* arg1: exception bucket, already in r2 */
         lgr     C_ARG_2, %r14     /* arg2: PC of raise */
         lgr     C_ARG_3, %r15     /* arg3: SP of raise */
-        lg      C_ARG_4, TRAP_PTR /* arg4: SP of handler */
+        lgr     C_ARG_4, TRAP_PTR /* arg4: SP of handler */
     /* Switch to C stack */
         lg      %r15, Caml_state(c_stack)
         PREPARE_FOR_C_CALL

--- a/runtime/s390x.S
+++ b/runtime/s390x.S
@@ -933,15 +933,6 @@ CFI_STARTPROC
 CFI_ENDPROC
 ENDFUNCTION(G(caml_ml_array_bound_error))
 
-FUNCTION(G(caml_assert_stack_invariants))
-CFI_STARTPROC
-    /* Load address of [caml_array_bound_error_asm] in ADDITIONAL_ARG */
-        LEA_VAR(caml_array_bound_error_asm, ADDITIONAL_ARG)
-    /* Call that function */
-        brcl    15, GCALL(caml_c_call)
-CFI_ENDPROC
-ENDFUNCTION(G(caml_assert_stack_invariants))
-
         .globl  caml_system__code_end
 caml_system__code_end:
 

--- a/runtime/s390x.S
+++ b/runtime/s390x.S
@@ -79,14 +79,8 @@
 /* struct c_stack_link + callee save regs = 24 + 8*8 = 88 */
 #define start_program_sleb128_2byte 216, 0
 
-/* struct exception handler + callee area = 16 + 160 = 176 */
-#define start_program_call_sleb128_2byte 176, 1
-
 /* exception handler + gc_regs slot + C_STACK_SP + Handler_parent = 16 + 8 + 8 + 24 = 56 */
 #define caml_runstack_sleb128_1byte 56
-
-/* exception handler + gc_regs slot + C_STACK_SP + Handler_parent + callee area = 16 + 8 + 8 + 24 + 160 = 216 */
-#define caml_runstack_callee_sleb128_2byte 216, 1
 
 #define RETADDR_ENTRY_SIZE   8 /* retaddr */
 
@@ -584,13 +578,6 @@ LBL(caml_start_program):
           DW_OP_breg + DW_REG_r15, 16 /* exn handler */, DW_OP_deref, \
           DW_OP_plus_uconst, start_program_sleb128_2byte
 #endif
-#ifdef ASM_CFI_SUPPORTED
-        .cfi_escape DW_CFA_def_cfa_expression, 4 + 3,                 \
-            /* %r15 points to the exn handler on the OCaml stack */   \
-            /* %r15 + 16 contains the C_STACK_SP */                   \
-          DW_OP_breg + DW_REG_r15, start_program_call_sleb128_2byte, DW_OP_deref, \
-          DW_OP_plus_uconst, start_program_sleb128_2byte
-#endif
         basr    %r14, TMP
 LBL(caml_retaddr):
     /* pop exn handler */
@@ -889,14 +876,6 @@ CFI_STARTPROC
 #endif
     /* Call the function on the new stack */
         lgr     %r2, %r4 /* first argument */
-#ifdef ASM_CFI_SUPPORTED
-        .cfi_escape DW_CFA_def_cfa_expression, 4+3+2, \
-          DW_OP_breg + DW_REG_r15,                    \
-          caml_runstack_callee_sleb128_2byte,         \
-          DW_OP_deref,                                \
-          DW_OP_plus_uconst, Stack_sp, DW_OP_deref,   \
-          DW_OP_plus_uconst, RETADDR_ENTRY_SIZE
-#endif
         basr    %r14, %r5 /* closure in %r3 (second argument) */
 LBL(frame_runstack):
         lay     %r8, 32(%r15) /*%r8 = stack_handler */

--- a/runtime/s390x.S
+++ b/runtime/s390x.S
@@ -584,7 +584,6 @@ LBL(caml_start_program):
           DW_OP_breg + DW_REG_r15, 16 /* exn handler */, DW_OP_deref, \
           DW_OP_plus_uconst, start_program_sleb128_2byte
 #endif
-        PREPARE_FOR_C_CALL
 #ifdef ASM_CFI_SUPPORTED
         .cfi_escape DW_CFA_def_cfa_expression, 4 + 3,                 \
             /* %r15 points to the exn handler on the OCaml stack */   \
@@ -594,7 +593,6 @@ LBL(caml_start_program):
 #endif
         basr    %r14, TMP
 LBL(caml_retaddr):
-        CLEANUP_AFTER_C_CALL
     /* pop exn handler */
         lg      %r8, 0(%r15)
         la      %r15, 16(%r15)
@@ -791,7 +789,7 @@ LBL(do_perform):
         stg     %r0, Handler_parent(%r9) /* Set parent of performer to NULL */
         lgr     %r4, %r5                 /* %r4 = last_fiber */
         lg      %r5, Handler_effect(%r9) /* %r5 := effect handler */
-        brasl    %r14, GCALL(caml_apply3)
+        brcl    15, GCALL(caml_apply3)
 LBL(112):
     /* Switch back to original performer before raising Unhandled
        (no-op unless this is a reperform) */
@@ -871,7 +869,7 @@ CFI_STARTPROC
         lg      %r9, Stack_sp(%r2) /* %r9 = sp of new stack */
     /* Create an exception handler on the target stack
        after 16byte DWARF & gc_regs block (which is unused here) */
-        lay     %r9, 32(%r9)
+        lay     %r9, -32(%r9)
         larl    TMP, LBL(fiber_exn_handler)
         stg     TMP, 8(%r9)
     /* link the previous exn_handler so that copying stacks works */
@@ -891,7 +889,6 @@ CFI_STARTPROC
 #endif
     /* Call the function on the new stack */
         lgr     %r2, %r4 /* first argument */
-        PREPARE_FOR_C_CALL
 #ifdef ASM_CFI_SUPPORTED
         .cfi_escape DW_CFA_def_cfa_expression, 4+3+2, \
           DW_OP_breg + DW_REG_r15,                    \
@@ -901,7 +898,6 @@ CFI_STARTPROC
           DW_OP_plus_uconst, RETADDR_ENTRY_SIZE
 #endif
         basr    %r14, %r5 /* closure in %r3 (second argument) */
-        CLEANUP_AFTER_C_CALL
 LBL(frame_runstack):
         lay     %r8, 32(%r15) /*%r8 = stack_handler */
         lg      %r7, Handler_value(%r8) /* saved across C call */
@@ -937,7 +933,7 @@ LBL(caml_runstack_1):
         br      TMP
 LBL(fiber_exn_handler):
         lay     %r8, 16(%r15)
-        lg      %r3, Handler_exception(%r8)
+        lg      %r7, Handler_exception(%r8)
         brcl    15, LBL(caml_runstack_1)
 CFI_ENDPROC
 ENDFUNCTION(G(caml_runstack))


### PR DESCRIPTION
It's first version of reintroduction of native compiler for s390x.

There are still some issues remain, some stuff to improve, and some questions. Help is appreciated!

1. ocaml stack size is increased. This is a workaround for stack exhaustion crashes, like when running command "../../ocamlc.opt -nostdlib -I ../../stdlib -g -c -for-pack Dynlink_compilerlibs -strict-sequence -principal -absname -w +a-4-9-40-41-42-44-45-48 -warn-error +A -bin-annot -strict-formats -I byte -I dynlink_compilerlibs -o dynlink_compilerlibs/clflags.cmo dynlink_compilerlibs/clflags.ml" from "otherlibs/dynlink" directory, which is running when building native compiler.

2. CFI is not working correctly yet.

3. It looks like ocaml doesn't follow s390x ABI when generating s390x assembly code. It often doesn't allocate 160 bytes on stack. For example in function "camlStdlib.entry":
```
Dump of assembler code for function camlStdlib.entry:
   0x00000000014cf890 <+0>:     lay     %r15,-8(%r15)
   0x00000000014cf896 <+6>:     stg     %r14,0(%r15)
...
   0x00000000014d1268 <+6616>:  lay     %r11,-56(%r11)
   0x00000000014d126e <+6622>:  clg     %r11,0(%r10)
   0x00000000014d1274 <+6628>:  clg     %r11,0(%r10)
   0x00000000014d127a <+6634>:  jgl     0x14d1558 <camlStdlib.entry+7368>
   0x00000000014d1280 <+6640>:  la      %r3,8(%r11)
   0x00000000014d1284 <+6644>:  lghi    %r4,6144
   0x00000000014d1288 <+6648>:  stg     %r4,-8(%r3)
...
   0x00000000014d1534 <+7332>:  lg      %r14,0(%r15)
   0x00000000014d153a <+7338>:  la      %r15,8(%r15)
   0x00000000014d153e <+7342>:  br      %r14
   0x00000000014d1540 <+7344>:  brasl   %r14,0x159085c <caml_call_gc>
   0x00000000014d1546 <+7350>:  jg      0x14d1440 <camlStdlib.entry+7088>
   0x00000000014d154c <+7356>:  brasl   %r14,0x159085c <caml_call_gc>
   0x00000000014d1552 <+7362>:  jg      0x14d139c <camlStdlib.entry+6924>
   0x00000000014d1558 <+7368>:  brasl   %r14,0x159085c <caml_call_gc>
=> 0x00000000014d155e <+7374>:  jg      0x14d1280 <camlStdlib.entry+6640>
   0x00000000014d1564 <+7380>:  brasl   %r14,0x159085c <caml_call_gc>
   0x00000000014d156a <+7386>:  jg      0x14d056a <camlStdlib.entry+3290>
   0x00000000014d1570 <+7392>:  brasl   %r14,0x159085c <caml_call_gc>
   0x00000000014d1576 <+7398>:  jg      0x14d04d6 <camlStdlib.entry+3142>
   0x00000000014d157c <+7404>:  brasl   %r14,0x159085c <caml_call_gc>
   0x00000000014d1582 <+7410>:  jg      0x14d0442 <camlStdlib.entry+2994>
   0x00000000014d1588 <+7416>:  brasl   %r14,0x159085c <caml_call_gc>
   0x00000000014d158e <+7422>:  jg      0x14d03ae <camlStdlib.entry+2846>
   0x00000000014d1594 <+7428>:  brasl   %r14,0x159085c <caml_call_gc>
   0x00000000014d159a <+7434>:  jg      0x14d031a <camlStdlib.entry+2698>
   0x00000000014d15a0 <+7440>:  brasl   %r14,0x159085c <caml_call_gc>
   0x00000000014d15a6 <+7446>:  jg      0x14d0286 <camlStdlib.entry+2550>
   0x00000000014d15ac <+7452>:  brasl   %r14,0x159085c <caml_call_gc>
   0x00000000014d15b2 <+7458>:  jg      0x14cfdae <camlStdlib.entry+1310>
   0x00000000014d15b8 <+7464>:  brasl   %r14,0x159085c <caml_call_gc>
   0x00000000014d15be <+7470>:  jg      0x14cfcb0 <camlStdlib.entry+1056>
```

Between call to entry to function camlStdlib.entry on 0x00000000014cf890 and caml_call_gc on 0x00000000014d1558 only 16 bytes on stack (register %r15) are allocated while it should be 160 bytes at least according to s390x ABI. Is this deviation from ABI intended? Changes like these affect how CFI has to be updated.

4. When generating code for Iextcall operand, the stack is allocated beforehand. For s390x it actually allocates 160 bytes in that case. The problem is that in one of cases it has to switch stack before calling function, and due to that stack allocation happens on wrong stack, not on the one it switches to, but on the one it switches from. As workaround, I've explicitly allocated 160 bytes on that stack. In addition to that, I've allocated 8 more bytes to save old stack pointer. Can't use any other register since it's value is already being used for something else important. At least I didn't find such non-volatile register on s390x yet.