### PR TITLE
Stop ignoring the change of verbosity when using Gc.set

### DIFF
--- a/runtime/caml/misc.h
+++ b/runtime/caml/misc.h
@@ -481,6 +481,8 @@ CAMLextern int caml_read_directory(char_os * dirname,
 
 /* GC flags and messages */
 
+extern atomic_uintnat caml_verb_gc;
+
 void caml_gc_log (char *, ...)
 #ifdef __GNUC__
   __attribute__ ((format (printf, 1, 2)))

--- a/runtime/caml/startup_aux.h
+++ b/runtime/caml/startup_aux.h
@@ -33,7 +33,6 @@ struct caml_params {
 
   const char_os* cds_file;
 
-  uintnat verb_gc;
   uintnat parser_trace;
   uintnat trace_level;
   uintnat runtime_events_log_wsize;

--- a/runtime/gc_ctrl.c
+++ b/runtime/gc_ctrl.c
@@ -127,13 +127,13 @@ CAMLprim value caml_gc_get(value v)
   CAMLlocal1 (res);
 
   res = caml_alloc_tuple (11);
-  Store_field (res, 0, Val_long (Caml_state->minor_heap_wsz));  /* s */
-  Store_field (res, 2, Val_long (caml_percent_free));           /* o */
-  Store_field (res, 3, Val_long (atomic_load_relaxed(&caml_verb_gc)));        /* v */
-  Store_field (res, 5, Val_long (caml_max_stack_wsize));        /* l */
-  Store_field (res, 8, Val_long (caml_custom_major_ratio));     /* M */
-  Store_field (res, 9, Val_long (caml_custom_minor_ratio));     /* m */
-  Store_field (res, 10, Val_long (caml_custom_minor_max_bsz));  /* n */
+  Store_field (res, 0, Val_long (Caml_state->minor_heap_wsz));          /* s */
+  Store_field (res, 2, Val_long (caml_percent_free));                   /* o */
+  Store_field (res, 3, Val_long (atomic_load_relaxed(&caml_verb_gc)));  /* v */
+  Store_field (res, 5, Val_long (caml_max_stack_wsize));                /* l */
+  Store_field (res, 8, Val_long (caml_custom_major_ratio));             /* M */
+  Store_field (res, 9, Val_long (caml_custom_minor_ratio));             /* m */
+  Store_field (res, 10, Val_long (caml_custom_minor_max_bsz));          /* n */
   CAMLreturn (res);
 }
 

--- a/runtime/gc_ctrl.c
+++ b/runtime/gc_ctrl.c
@@ -129,7 +129,7 @@ CAMLprim value caml_gc_get(value v)
   res = caml_alloc_tuple (11);
   Store_field (res, 0, Val_long (Caml_state->minor_heap_wsz));  /* s */
   Store_field (res, 2, Val_long (caml_percent_free));           /* o */
-  Store_field (res, 3, Val_long (caml_params->verb_gc));        /* v */
+  Store_field (res, 3, Val_long (atomic_load_relaxed(&caml_verb_gc)));        /* v */
   Store_field (res, 5, Val_long (caml_max_stack_wsize));        /* l */
   Store_field (res, 8, Val_long (caml_custom_major_ratio));     /* M */
   Store_field (res, 9, Val_long (caml_custom_minor_ratio));     /* m */
@@ -170,6 +170,8 @@ CAMLprim value caml_gc_set(value v)
     caml_gc_message (0x20, "New space overhead: %"
                      ARCH_INTNAT_PRINTF_FORMAT "u%%\n", caml_percent_free);
   }
+
+  atomic_store_relaxed(&caml_verb_gc, Long_val (Field (v, 3)));
 
   /* These fields were added in 4.08.0. */
   if (Wosize_val (v) >= 11){

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -981,7 +981,7 @@ static void cycle_all_domains_callback(caml_domain_state* domain, void* unused,
       caml_major_cycles_completed++;
       caml_gc_message(0x40, "Starting major GC cycle\n");
 
-      if (caml_params->verb_gc & 0x400) {
+      if (atomic_load_relaxed(&caml_verb_gc) & 0x400) {
         struct gc_stats s;
         intnat heap_words, not_garbage_words, swept_words;
 
@@ -1232,7 +1232,7 @@ static intnat major_collection_slice(intnat howmuch,
   intnat computed_work, budget, interrupted_budget = 0;
 
   int log_events = mode != Slice_opportunistic ||
-                   (caml_params->verb_gc & 0x40) ||
+                   (atomic_load_relaxed(&caml_verb_gc) & 0x40) ||
                    major_cycle_spinning;
 
   update_major_slice_work();

--- a/runtime/minor_gc.c
+++ b/runtime/minor_gc.c
@@ -662,7 +662,7 @@ void caml_do_opportunistic_major_slice
   /* NB: need to put guard around the ev logs to prevent
     spam when we poll */
   if (caml_opportunistic_major_work_available()) {
-    int log_events = caml_params->verb_gc & 0x40;
+    uintnat log_events = atomic_load_relaxed(&caml_verb_gc) & 0x40;
     if (log_events) CAML_EV_BEGIN(EV_MAJOR_MARK_OPPORTUNISTIC);
     caml_opportunistic_major_collection_slice(0x200);
     if (log_events) CAML_EV_END(EV_MAJOR_MARK_OPPORTUNISTIC);

--- a/runtime/misc.c
+++ b/runtime/misc.c
@@ -76,9 +76,11 @@ void caml_alloc_point_here(void)
 
 #define GC_LOG_LENGTH 512
 
+atomic_uintnat caml_verb_gc = 0;
+
 void caml_gc_log (char *msg, ...)
 {
-  if ((caml_params->verb_gc & 0x800) != 0) {
+  if ((atomic_load_relaxed(&caml_verb_gc) & 0x800) != 0) {
     char fmtbuf[GC_LOG_LENGTH];
     va_list args;
     va_start (args, msg);
@@ -92,7 +94,7 @@ void caml_gc_log (char *msg, ...)
 
 void caml_gc_message (int level, char *msg, ...)
 {
-  if ((caml_params->verb_gc & level) != 0){
+  if ((atomic_load_relaxed(&caml_verb_gc) & level) != 0){
     va_list ap;
     va_start(ap, msg);
     vfprintf (stderr, msg, ap);

--- a/runtime/startup_aux.c
+++ b/runtime/startup_aux.c
@@ -55,7 +55,7 @@ static void init_startup_params(void)
   params.runtime_events_log_wsize = Default_runtime_events_log_wsize;
 
 #ifdef DEBUG
-  params.verb_gc = 0x3F;
+  atomic_store_relaxed(&caml_verb_gc, 0x3F);
 #endif
 #ifndef NATIVE_CODE
   cds_file = caml_secure_getenv(T("CAML_DEBUG_FILE"));
@@ -79,6 +79,7 @@ static void scanmult (char_os *opt, uintnat *var)
   case 'k':   *var = (uintnat) val * 1024; break;
   case 'M':   *var = (uintnat) val * (1024 * 1024); break;
   case 'G':   *var = (uintnat) val * (1024 * 1024 * 1024); break;
+  case 'v':   atomic_store_relaxed((atomic_uintnat *)var, val);
   default:    *var = (uintnat) val; break;
   }
 }
@@ -105,7 +106,7 @@ void caml_parse_ocamlrunparam(void)
       case 'R': break; /*  see stdlib/hashtbl.mli */
       case 's': scanmult (opt, &params.init_minor_heap_wsz); break;
       case 't': scanmult (opt, &params.trace_level); break;
-      case 'v': scanmult (opt, &params.verb_gc); break;
+      case 'v': scanmult (opt, (uintnat *)&caml_verb_gc); break;
       case 'V': scanmult (opt, &params.verify_heap); break;
       case 'W': scanmult (opt, &caml_runtime_warnings); break;
       case ',': continue;

--- a/runtime/startup_byt.c
+++ b/runtime/startup_byt.c
@@ -316,7 +316,7 @@ static int parse_command_line(char_os **argv)
         params->trace_level += 1; /* ignored unless DEBUG mode */
         break;
       case 'v':
-        params->verb_gc = 0x001+0x004+0x008+0x010+0x020;
+        atomic_store_relaxed(&caml_verb_gc, 0x001+0x004+0x008+0x010+0x020);
         break;
       case 'p':
         for (j = 0; caml_names_of_builtin_cprim[j] != NULL; j++)

--- a/runtime/sys.c
+++ b/runtime/sys.c
@@ -136,7 +136,7 @@ CAMLexport void caml_do_exit(int retcode)
   caml_domain_state* domain_state = Caml_state;
   struct gc_stats s;
 
-  if ((caml_params->verb_gc & 0x400) != 0) {
+  if ((atomic_load_relaxed(&caml_verb_gc) & 0x400) != 0) {
     caml_compute_gc_stats(&s);
     {
       /* cf caml_gc_counters */

--- a/runtime/win32.c
+++ b/runtime/win32.c
@@ -231,7 +231,8 @@ void * caml_dlopen(wchar_t * libname, int global)
   void *handle;
   int flags = (global ? FLEXDLL_RTLD_GLOBAL : 0);
   handle = flexdll_wdlopen(libname, flags);
-  if ((handle != NULL) && ((caml_params->verb_gc & 0x100) != 0)) {
+  if ((handle != NULL)
+     && ((atomic_load_relaxed(&caml_verb_gc) & 0x100) != 0)) {
     flexdll_dump_exports(handle);
     fflush(stdout);
   }


### PR DESCRIPTION
This commit re-introduces the global variable `caml_verb_gc` as an atomic, addressing #11692.

The changes to it are currently ignored because the code to do it is missing, and the `verb_gc` flag is located in `caml_params`, which is immutable after initialisation. 

The implementation requires the re-introduction of a global variable (`caml_verb_gc`), this time as a global atomic.

To note: I decided to split the streamlining of log levels in a separate PR, because this is actually a fair amount of work and reading. (see https://github.com/ocaml/ocaml/issues/11692#issuecomment-1301599862 for details.)