### PR TITLE
ocamllex: Check for matched parentheses in actions

### DIFF
--- a/Changes
+++ b/Changes
@@ -1346,6 +1346,10 @@ Some of those changes will benefit all OCaml packages.
   parameters.
   (Florian Angeletti, report by Wiktor Kuchta, review by Jules Aguillon)
 
+- #11716: ocamllex: mismatched parentheses and curly brackets are now caught
+  by ocamllex, instead of causing invalid OCaml code to be generated.
+  (Demi Marie Obenour)
+
 - #11787: Fix GDB scripts to work with OCaml 5's heap layout. (Nick
   Barnes)
 

--- a/testsuite/tests/tool-lexyacc/csets.mll
+++ b/testsuite/tests/tool-lexyacc/csets.mll
@@ -7,7 +7,7 @@ let alpha = ['a'-'z']
 let alpha' = (digit | alpha) # digit
 
 rule read = parse
-| alpha'+ as lxm { Some lxm }
+| alpha'+ as lxm { (Some lxm) }
 | digit+ as lxm { Some lxm }
 | eof { None }
 


### PR DESCRIPTION
This checks that parentheses and curly braces are properly balenced in ocamllex actions.

Fixes #7455 for ocamllex (it was already fixed for ocamlyacc).