### PR TITLE
Fix handling of <assert.h>

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1114,6 +1114,9 @@ ocamlyacc_MODULES = $(ocamlyacc_WSTR_MODULE) $(ocamlyacc_OTHER_MODULES)
 
 ocamlyacc_OBJECTS = $(ocamlyacc_MODULES:=.$(O))
 
+# Do not compile assertions in ocamlyacc
+ocamlyacc_CPPFLAGS = -DNDEBUG
+
 .PHONY: ocamlyacc
 ocamlyacc: $(ocamlyacc_PROGRAM)$(EXE)
 
@@ -1124,6 +1127,8 @@ clean::
 	rm -f $(ocamlyacc_MODULES:=.o) $(ocamlyacc_MODULES:=.obj)
 
 $(ocamlyacc_OTHER_MODULES:=.$(O)): yacc/defs.h
+
+$(ocamlyacc_OTHER_MODULES:=.$(O)): OC_CPPFLAGS += $(ocamlyacc_CPPFLAGS)
 
 # The Menhir-generated parser
 

--- a/otherlibs/systhreads/st_pthreads.h
+++ b/otherlibs/systhreads/st_pthreads.h
@@ -15,7 +15,6 @@
 
 /* POSIX thread implementation of the "st" interface */
 
-#include <assert.h>
 #include <errno.h>
 #include <string.h>
 #include <stdio.h>

--- a/yacc/defs.h
+++ b/yacc/defs.h
@@ -15,10 +15,6 @@
 
 /* Based on public-domain code from Berkeley Yacc */
 
-#if !defined(DEBUG) && !defined(NDEBUG)
-#define NDEBUG
-#endif
-
 #include <assert.h>
 #include <ctype.h>
 #include <errno.h>

--- a/yacc/defs.h
+++ b/yacc/defs.h
@@ -15,7 +15,7 @@
 
 /* Based on public-domain code from Berkeley Yacc */
 
-#ifndef DEBUG
+#if !defined(DEBUG) && !defined(NDEBUG)
 #define NDEBUG
 #endif
 


### PR DESCRIPTION
The main part of the codebase uses `CAMLassert` over C's `<assert.h>`. This PR:

- Removes a no-longer used `<assert.h>` in `st_pthreads.h` (`assert` was used in the yield implementation in 4.x)
- Hardens the definition of `NDEBUG` in `ocamlyacc` not to raise an error if the build system has already defined it

It seems slightly neater to go back to the pre-#1114 mechanism where the flag is defined on the command line (thoughts, @shindere?)