### PR TITLE
check_well_founded: give expansion traces in error messages

### DIFF
--- a/Changes
+++ b/Changes
@@ -205,6 +205,9 @@ Working version
   (Abiola Abdulsalam, review by Sébastien Hinderer, Nicolás Ojeda Bär and
   Florian Angeletti)
 
+- #11722: clearer error messages on non-well-founded type definitions
+  (Gabriel Scherer, review by Jacques Garrigue)
+
 - #11819: make the `native_compiler` and `native_dynlink` configuration
   variables available through ocamlc -config.
   (Sébastien Hinderer, review by Gabriel Scherer and David Allsopp)

--- a/testsuite/tests/typing-misc/polyvars.ml
+++ b/testsuite/tests/typing-misc/polyvars.ml
@@ -193,8 +193,11 @@ Error: This recursive type is not regular.
        but it is used as
          ('e, 'c, 'b, 'd, 'a) a
        after the following expansion(s):
+         [ `A of ('d, 'a, 'e, 'c, 'b) b ] contains ('d, 'a, 'e, 'c, 'b) b,
          ('d, 'a, 'e, 'c, 'b) b = [ `B of ('e, 'c, 'b, 'd, 'a) c ],
-         ('e, 'c, 'b, 'd, 'a) c = [ `C of ('e, 'c, 'b, 'd, 'a) a ]
+         [ `B of ('e, 'c, 'b, 'd, 'a) c ] contains ('e, 'c, 'b, 'd, 'a) c,
+         ('e, 'c, 'b, 'd, 'a) c = [ `C of ('e, 'c, 'b, 'd, 'a) a ],
+         [ `C of ('e, 'c, 'b, 'd, 'a) a ] contains ('e, 'c, 'b, 'd, 'a) a
        All uses need to match the definition for the recursive type to be regular.
 |}]
 

--- a/testsuite/tests/typing-misc/wellfounded.ml
+++ b/testsuite/tests/typing-misc/wellfounded.ml
@@ -18,5 +18,8 @@ type _ prod = Prod : ('a * 'y) prod
 Line 6, characters 6-20:
 6 |       type d = d * d
           ^^^^^^^^^^^^^^
-Error: The type abbreviation d is cyclic
+Error: The type abbreviation d is cyclic:
+         d = d * d,
+         d * d contains d,
+         d = d * d
 |}];;

--- a/testsuite/tests/typing-modules/pr7726.ml
+++ b/testsuite/tests/typing-modules/pr7726.ml
@@ -19,7 +19,12 @@ Line 1, characters 12-77:
 1 | module T1 = Fix(functor (X:sig type t end) -> struct type t = X.t option end);;
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: In the signature of this functor application:
-       The type abbreviation Fixed.t is cyclic
+       The type abbreviation Fixed.t is cyclic:
+         F(Fixed).t = Fixed.t option,
+         Fixed.t option contains Fixed.t,
+         Fixed.t = F(Fixed).t,
+         F(Fixed).t = Fixed.t option,
+         Fixed.t option contains Fixed.t
 |}]
 module T2 = Fix(functor (X:sig type t end) -> struct type t = X.t end);;
 [%%expect{|
@@ -28,7 +33,9 @@ Line 1, characters 12-70:
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: In the signature of this functor application:
        The definition of Fixed.t contains a cycle:
-       F(Fixed).t
+         F(Fixed).t = Fixed.t,
+         Fixed.t = F(Fixed).t,
+         F(Fixed).t = Fixed.t
 |}]
 
 (* Positive example *)
@@ -69,7 +76,9 @@ Line 1, characters 18-38:
                       ^^^^^^^^^^^^^^^^^^^^
 Error: In this instantiated signature:
        The definition of Fixed.t contains a cycle:
-       F(Fixed).t
+         F(Fixed).t = Fixed.t,
+         Fixed.t = F(Fixed).t,
+         F(Fixed).t = Fixed.t
 |}]
 
 (* More examples by lpw25 *)
@@ -80,7 +89,9 @@ Line 1, characters 11-18:
                ^^^^^^^
 Error: In the signature of this functor application:
        The definition of Fixed.t contains a cycle:
-       Id(Fixed).t
+         Id(Fixed).t = Fixed.t,
+         Fixed.t = Id(Fixed).t,
+         Id(Fixed).t = Fixed.t
 |}]
 type t = Fix(Id).Fixed.t;;
 [%%expect{|
@@ -89,7 +100,9 @@ Line 1, characters 9-24:
              ^^^^^^^^^^^^^^^
 Error: In the signature of Fix(Id):
        The definition of Fixed.t contains a cycle:
-       Id(Fixed).t
+         Id(Fixed).t = Fixed.t,
+         Fixed.t = Id(Fixed).t,
+         Id(Fixed).t = Fixed.t
 |}]
 let f (x : Fix(Id).Fixed.t) = x;;
 [%%expect{|
@@ -98,7 +111,9 @@ Line 1, characters 11-26:
                ^^^^^^^^^^^^^^^
 Error: In the signature of Fix(Id):
        The definition of Fixed.t contains a cycle:
-       Id(Fixed).t
+         Id(Fixed).t = Fixed.t,
+         Fixed.t = Id(Fixed).t,
+         Id(Fixed).t = Fixed.t
 |}]
 
 module Foo (F : T -> T) = struct
@@ -113,7 +128,9 @@ module M : sig val f : Fix(Id).Fixed.t -> Fix(Id).Fixed.t end
 Line 1:
 Error: In the signature of Fix(Id):
        The definition of Fixed.t contains a cycle:
-       Id(Fixed).t
+         Id(Fixed).t = Fixed.t,
+         Fixed.t = Id(Fixed).t,
+         Id(Fixed).t = Fixed.t
 |}]
 
 (* Extra tests for GPR#1676 *)
@@ -146,5 +163,7 @@ Line 5, characters 11-26:
                ^^^^^^^^^^^^^^^
 Error: In the signature of Fix2(Id):
        The definition of Fixed.t contains a cycle:
-       Id(Fixed).t
+         Id(Fixed).t = Fixed.t,
+         Fixed.t = Id(Fixed).t,
+         Id(Fixed).t = Fixed.t
 |}]

--- a/testsuite/tests/typing-modules/recursive.ml
+++ b/testsuite/tests/typing-modules/recursive.ml
@@ -9,5 +9,7 @@ module rec T : sig type t = T.t end = T;;
 Line 1, characters 0-39:
 1 | module rec T : sig type t = T.t end = T;;
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The type abbreviation T.t is cyclic
+Error: The type abbreviation T.t is cyclic:
+         T.t = T.t,
+         T.t = T.t
 |}]

--- a/testsuite/tests/typing-objects/Tests.ml
+++ b/testsuite/tests/typing-objects/Tests.ml
@@ -201,7 +201,9 @@ Error: This recursive type is not regular.
        but it is used as
          int c
        after the following expansion(s):
-         'a d = < f : int c >
+         < f : 'a c; g : 'a d > contains 'a d,
+         'a d = < f : int c >,
+         < f : int c > contains int c
        All uses need to match the definition for the recursive type to be regular.
 |}];;
 type 'a c = <f : 'a c; g : 'a d>
@@ -223,7 +225,10 @@ Line 2, characters 0-17:
 2 | and 'a t = 'a t u;;
     ^^^^^^^^^^^^^^^^^
 Error: The definition of t contains a cycle:
-       'a t u
+         'a t u contains 'a t,
+         'a t = 'a t u,
+         'a t u contains 'a t,
+         'a t = 'a t u
 |}];; (* fails since 4.04 *)
 type 'a u = 'a
 and 'a t = 'a t u;;
@@ -231,7 +236,11 @@ and 'a t = 'a t u;;
 Line 2, characters 0-17:
 2 | and 'a t = 'a t u;;
     ^^^^^^^^^^^^^^^^^
-Error: The type abbreviation t is cyclic
+Error: The type abbreviation t is cyclic:
+         'a t = 'a t u,
+         'a t u contains 'a t,
+         'a t = 'a t u,
+         'a t u = 'a t
 |}];;
 type 'a u = 'a;;
 [%%expect{|
@@ -242,7 +251,12 @@ type t = t u * t u;;
 Line 1, characters 0-18:
 1 | type t = t u * t u;;
     ^^^^^^^^^^^^^^^^^^
-Error: The type abbreviation t is cyclic
+Error: The type abbreviation t is cyclic:
+         t = t u * t u,
+         t u * t u contains t,
+         t = t u * t u,
+         t u * t u contains t u,
+         t u = t
 |}];;
 
 type t = <x : 'a> as 'a;;

--- a/testsuite/tests/typing-poly/poly.ml
+++ b/testsuite/tests/typing-poly/poly.ml
@@ -617,7 +617,11 @@ val app : int * bool = (1, true)
 Line 9, characters 0-25:
 9 | type 'a foo = 'a foo list
     ^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The type abbreviation foo is cyclic
+Error: The type abbreviation foo is cyclic:
+         'a foo = 'a foo list,
+         'a foo list contains 'a foo,
+         'a foo = 'a foo list,
+         'a foo list contains 'a foo
 |}];;
 
 class ['a] bar (x : 'a) = object end
@@ -910,7 +914,9 @@ Line 1, characters 0-10:
 1 | type t = u and u = t;;
     ^^^^^^^^^^
 Error: The definition of t contains a cycle:
-       u
+         u = t,
+         t = u,
+         u = t
 |}];;
 
 (* PR#8188 *)
@@ -991,6 +997,7 @@ Error: This recursive type is not regular.
        but it is used as
          'a list u
        after the following expansion(s):
+         < m : 'a v > contains 'a v,
          'a v = 'a list u
        All uses need to match the definition for the recursive type to be regular.
 |}];;
@@ -1026,7 +1033,7 @@ Line 1, characters 0-83:
 1 | type ('a1, 'b1) ty1 = 'a1 -> unit constraint 'a1 = [> `V1 of ('a1, 'b1) ty2 as 'b1]
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The definition of ty1 contains a cycle:
-       [> `V1 of ('a, 'b) ty2 as 'b ] as 'a
+         [> `V1 of ('a, 'b) ty2 as 'b ] as 'a contains 'b
 |}];;
 
 (* PR#8359: expanding may change original in Ctype.unify2 *)

--- a/testsuite/tests/typing-private-bugs/pr5026_bad.compilers.reference
+++ b/testsuite/tests/typing-private-bugs/pr5026_bad.compilers.reference
@@ -2,4 +2,6 @@ File "pr5026_bad.ml", line 11, characters 0-36:
 11 | type -'typing wrapped = private sexp
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The definition of wrapped contains a cycle:
-       sexp
+         sexp = untyped wrapped,
+         untyped wrapped = sexp,
+         sexp = untyped wrapped

--- a/testsuite/tests/typing-recmod/t01bad.compilers.reference
+++ b/testsuite/tests/typing-recmod/t01bad.compilers.reference
@@ -1,4 +1,6 @@
 File "t01bad.ml", line 10, characters 0-61:
 10 | module rec A : sig type t = A.t end = struct type t = A.t end;;
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The type abbreviation A.t is cyclic
+Error: The type abbreviation A.t is cyclic:
+         A.t = A.t,
+         A.t = A.t

--- a/testsuite/tests/typing-recmod/t02bad.compilers.reference
+++ b/testsuite/tests/typing-recmod/t02bad.compilers.reference
@@ -2,4 +2,6 @@ File "t02bad.ml", line 10, characters 0-61:
 10 | module rec A : sig type t = B.t end = struct type t = B.t end
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The definition of A.t contains a cycle:
-       B.t
+         B.t = A.t,
+         A.t = B.t,
+         B.t = A.t

--- a/testsuite/tests/typing-recmod/t04bad.compilers.reference
+++ b/testsuite/tests/typing-recmod/t04bad.compilers.reference
@@ -2,4 +2,7 @@ File "t04bad.ml", line 10, characters 0-73:
 10 | module rec A : sig type t = int * A.t end = struct type t = int * A.t end;;
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The definition of A.t contains a cycle:
-       int * A.t
+         int * A.t contains A.t,
+         A.t = int * A.t,
+         int * A.t contains A.t,
+         A.t = int * A.t

--- a/testsuite/tests/typing-recmod/t05bad.compilers.reference
+++ b/testsuite/tests/typing-recmod/t05bad.compilers.reference
@@ -2,4 +2,8 @@ File "t05bad.ml", line 10, characters 0-75:
 10 | module rec A : sig type t = B.t -> int end = struct type t = B.t -> int end
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The definition of A.t contains a cycle:
-       B.t -> int
+         B.t -> int contains B.t,
+         B.t = A.t,
+         A.t = B.t -> int,
+         B.t -> int contains B.t,
+         B.t = A.t

--- a/testsuite/tests/typing-recmod/t08bad.compilers.reference
+++ b/testsuite/tests/typing-recmod/t08bad.compilers.reference
@@ -7,5 +7,6 @@ Error: This recursive type is not regular.
        but it is used as
          'a array A.t
        after the following expansion(s):
+         < m : 'a list B.t; n : 'a array B.t > contains 'a array B.t,
          'a array B.t = 'a array A.t
        All uses need to match the definition for the recursive type to be regular.

--- a/testsuite/tests/typing-recmod/t09bad.compilers.reference
+++ b/testsuite/tests/typing-recmod/t09bad.compilers.reference
@@ -7,5 +7,6 @@ Error: This recursive type is not regular.
        but it is used as
          'a array A.t
        after the following expansion(s):
-         'a B.t = < m : 'a list A.t; n : 'a array A.t >
+         'a B.t = < m : 'a list A.t; n : 'a array A.t >,
+         < m : 'a list A.t; n : 'a array A.t > contains 'a array A.t
        All uses need to match the definition for the recursive type to be regular.

--- a/testsuite/tests/typing-recmod/t14bad.compilers.reference
+++ b/testsuite/tests/typing-recmod/t14bad.compilers.reference
@@ -2,4 +2,5 @@ File "t14bad.ml", line 23, characters 2-43:
 23 |   module rec U : T with type D.t = U'.t = U
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The definition of U.D.t contains a cycle:
-       U'.t
+         U'.t = U'.t,
+         U'.t = U'.t

--- a/testsuite/tests/typing-recmod/t15bad.compilers.reference
+++ b/testsuite/tests/typing-recmod/t15bad.compilers.reference
@@ -1,4 +1,6 @@
 File "t15bad.ml", line 11, characters 0-61:
 11 | module rec M : S' with type t = M.t = struct type t = M.t end;;
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The type abbreviation M.t is cyclic
+Error: The type abbreviation M.t is cyclic:
+         M.t = M.t,
+         M.t = M.t

--- a/testsuite/tests/typing-rectypes-bugs/pr5343_bad.compilers.reference
+++ b/testsuite/tests/typing-rectypes-bugs/pr5343_bad.compilers.reference
@@ -1,4 +1,8 @@
 File "pr5343_bad.ml", line 11, characters 2-14:
 11 |   type u = u t and v = v t
        ^^^^^^^^^^^^
-Error: The type abbreviation u is cyclic
+Error: The type abbreviation u is cyclic:
+         u = u t,
+         u t contains u,
+         u = u t,
+         u t contains u

--- a/testsuite/tests/typing-unboxed-types/test_flat.ml
+++ b/testsuite/tests/typing-unboxed-types/test_flat.ml
@@ -311,5 +311,9 @@ type 'a id = Id of 'a [@@unboxed]
 Line 2, characters 0-21:
 2 | type cycle = cycle id
     ^^^^^^^^^^^^^^^^^^^^^
-Error: The type abbreviation cycle is cyclic
+Error: The type abbreviation cycle is cyclic:
+         cycle = cycle id,
+         cycle id contains cycle,
+         cycle = cycle id,
+         cycle id contains cycle
 |}];;

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -26,13 +26,22 @@ module String = Misc.Stdlib.String
 
 type native_repr_kind = Unboxed | Untagged
 
+(* Our static analyses explore the set of type expressions "reachable"
+   from a type declaration, by expansion of definitions or by the
+   subterm relation (a type expression is syntactically contained
+   in another). *)
+type reaching_type_path = reaching_type_step list
+and reaching_type_step =
+  | Expands_to of type_expr * type_expr
+  | Contains of type_expr * type_expr
+
 type error =
     Repeated_parameter
   | Duplicate_constructor of string
   | Too_many_constructors
   | Duplicate_label of string
-  | Recursive_abbrev of string
-  | Cycle_in_def of string * type_expr
+  | Recursive_abbrev of string * Env.t * reaching_type_path
+  | Cycle_in_def of string * Env.t * reaching_type_path
   | Definition_mismatch of type_expr * Env.t * Includecore.type_mismatch option
   | Constraint_failed of Env.t * Errortrace.unification_error
   | Inconsistent_constraint of Env.t * Errortrace.unification_error
@@ -41,7 +50,7 @@ type error =
       definition: Path.t;
       used_as: type_expr;
       defined_as: type_expr;
-      expansions: (type_expr * type_expr) list;
+      reaching_path: reaching_type_path;
     }
   | Null_arity_external
   | Missing_native_external
@@ -645,14 +654,23 @@ let check_abbrev env sdecl (id, decl) =
 
 let check_well_founded env loc path to_check ty =
   let visited = ref TypeMap.empty in
-  let rec check ty0 parents ty =
+  let rec check ty0 parents trace ty =
     if TypeSet.mem ty parents then begin
       (*Format.eprintf "@[%a@]@." Printtyp.raw_type_expr ty;*)
-      if match get_desc ty0 with
-      | Tconstr (p, _, _) -> Path.same p path
-      | _ -> false
-      then raise (Error (loc, Recursive_abbrev (Path.name path)))
-      else raise (Error (loc, Cycle_in_def (Path.name path, ty0)))
+      let err =
+        let reaching_path =
+          (* The reaching trace is accumulated in reverse order, we
+             reverse it to get a reaching path. *)
+          match trace with
+          | [] -> assert false
+          | trace ->
+              List.rev trace in
+        if match get_desc ty0 with
+          | Tconstr (p, _, _) -> Path.same p path
+          | _ -> false
+        then Recursive_abbrev (Path.name path, env, reaching_path)
+        else Cycle_in_def (Path.name path, env, reaching_path)
+      in raise (Error (loc, err))
     end;
     let (fini, parents) =
       try
@@ -676,7 +694,7 @@ let check_well_founded env loc path to_check ty =
         visited := visited';
         let parents =
           if rec_ok then TypeSet.empty else TypeSet.add ty parents in
-        Btype.iter_type_expr (check ty0 parents) ty;
+        Btype.iter_type_expr (check_subtype ty0 parents trace ty) ty;
         None
       with e ->
         visited := visited'; Some e
@@ -684,18 +702,20 @@ let check_well_founded env loc path to_check ty =
     match get_desc ty with
     | Tconstr(p, _, _) when arg_exn <> None || to_check p ->
         if to_check p then Option.iter raise arg_exn
-        else Btype.iter_type_expr (check ty0 TypeSet.empty) ty;
+        else Btype.iter_type_expr (check_subtype ty0 TypeSet.empty trace ty) ty;
         begin try
           let ty' = Ctype.try_expand_once_opt env ty in
           let ty0 = if TypeSet.is_empty parents then ty else ty0 in
-          check ty0 (TypeSet.add ty parents) ty'
+          check ty0 (TypeSet.add ty parents) (Expands_to (ty, ty') :: trace) ty'
         with
           Ctype.Cannot_expand -> Option.iter raise arg_exn
         end
     | _ -> Option.iter raise arg_exn
+  and check_subtype ty0 parents trace outer_ty inner_ty =
+      check ty0 parents (Contains (outer_ty, inner_ty) :: trace) inner_ty
   in
   let snap = Btype.snapshot () in
-  try Ctype.wrap_trace_gadt_instances env (check ty TypeSet.empty) ty
+  try Ctype.wrap_trace_gadt_instances env (check ty TypeSet.empty []) ty
   with Ctype.Escape _ ->
     (* Will be detected by check_regularity *)
     Btype.backtrack snap
@@ -729,7 +749,7 @@ let check_regularity ~orig_env env loc path decl to_check =
 
   let visited = ref TypeSet.empty in
 
-  let rec check_regular cpath args prev_exp prev_expansions ty =
+  let rec check_regular cpath args prev_exp trace ty =
     if not (TypeSet.mem ty !visited) then begin
       visited := TypeSet.add ty !visited;
       match get_desc ty with
@@ -741,7 +761,7 @@ let check_regularity ~orig_env env loc path decl to_check =
                        definition=path;
                        used_as=ty;
                        defined_as=Ctype.newconstr path args;
-                       expansions=List.rev prev_expansions;
+                       reaching_path=List.rev trace;
                      }))
           end
           (* Attempt to expand a type abbreviation if:
@@ -762,18 +782,22 @@ let check_regularity ~orig_env env loc path decl to_check =
                   raise (Error(loc, Constraint_failed (orig_env, err)));
               end;
               check_regular path' args
-                (path' :: prev_exp) ((ty,body) :: prev_expansions)
+                (path' :: prev_exp) (Expands_to (ty,body) :: trace)
                 body
             with Not_found -> ()
           end;
-          List.iter (check_regular cpath args prev_exp prev_expansions) args'
+          List.iter (check_subtype cpath args prev_exp trace ty) args'
       | Tpoly (ty, tl) ->
           let (_, ty) = Ctype.instance_poly ~keep_names:true false tl ty in
-          check_regular cpath args prev_exp prev_expansions ty
+          check_regular cpath args prev_exp trace ty
       | _ ->
           Btype.iter_type_expr
-            (check_regular cpath args prev_exp prev_expansions) ty
-    end in
+            (check_subtype cpath args prev_exp trace ty) ty
+    end
+    and check_subtype cpath args prev_exp trace outer_ty inner_ty =
+      let trace = Contains (outer_ty, inner_ty) :: trace in
+      check_regular cpath args prev_exp trace inner_ty
+  in
 
   Option.iter
     (fun body ->
@@ -1682,6 +1706,51 @@ let tys_of_constr_args = function
   | Types.Cstr_tuple tl -> tl
   | Types.Cstr_record lbls -> List.map (fun l -> l.Types.ld_type) lbls
 
+module Reaching_path = struct
+  type t = reaching_type_path
+
+  (* Simplify a reaching path before showing it in error messages. *)
+  let simplify path =
+    let rec simplify : t -> t = function
+      | Contains (ty1, _ty2) :: Contains (_ty2', ty3) :: rest ->
+          (* If t1 contains t2 and t2 contains t3, then t1 contains t3
+             and we don't need to show t2. *)
+          simplify (Contains (ty1, ty3) :: rest)
+      | hd :: rest -> hd :: simplify rest
+      | [] -> []
+    in simplify path
+
+  (* See Printtyp.add_type_to_preparation.
+
+     Note: it is better to call this after [simplify], otherwise some
+     type variable names may be used for types that are removed
+     by simplification and never actually shown to the user.
+  *)
+  let add_to_preparation path =
+    List.iter (function
+      | Contains (ty1, ty2) | Expands_to (ty1, ty2) ->
+          List.iter Printtyp.add_type_to_preparation [ty1; ty2]
+    ) path
+
+  let pp ppf reaching_path =
+    let pp_step ppf = function
+      | Expands_to (ty, body) ->
+          Format.fprintf ppf "%a = %a"
+            Printtyp.prepared_type_expr ty
+            Printtyp.prepared_type_expr body
+      | Contains (outer, inner) ->
+          Format.fprintf ppf "%a contains %a"
+            Printtyp.prepared_type_expr outer
+            Printtyp.prepared_type_expr inner
+    in
+    let comma ppf () = Format.fprintf ppf ",@ " in
+    Format.(pp_print_list ~pp_sep:comma pp_step) ppf reaching_path
+
+  let pp_colon ppf path =
+  Format.fprintf ppf ":@;<1 2>@[<v>%a@]"
+    pp path
+end
+
 let report_error ppf = function
   | Repeated_parameter ->
       fprintf ppf "A type parameter occurs several times"
@@ -1693,11 +1762,22 @@ let report_error ppf = function
         (Config.max_tag + 1) "non-constant constructors"
   | Duplicate_label s ->
       fprintf ppf "Two labels are named %s" s
-  | Recursive_abbrev s ->
-      fprintf ppf "The type abbreviation %s is cyclic" s
-  | Cycle_in_def (s, ty) ->
-      fprintf ppf "@[<v>The definition of %s contains a cycle:@ %a@]"
-        s Printtyp.type_expr ty
+  | Recursive_abbrev (s, env, reaching_path) ->
+      let reaching_path = Reaching_path.simplify reaching_path in
+      Printtyp.wrap_printing_env ~error:true env @@ fun () ->
+      Printtyp.reset ();
+      Reaching_path.add_to_preparation reaching_path;
+      fprintf ppf "@[<v>The type abbreviation %s is cyclic%a@]"
+        s
+        Reaching_path.pp_colon reaching_path
+  | Cycle_in_def (s, env, reaching_path) ->
+      let reaching_path = Reaching_path.simplify reaching_path in
+      Printtyp.wrap_printing_env ~error:true env @@ fun () ->
+      Printtyp.reset ();
+      Reaching_path.add_to_preparation reaching_path;
+      fprintf ppf "@[<v>The definition of %s contains a cycle%a@]"
+        s
+        Reaching_path.pp_colon reaching_path
   | Definition_mismatch (ty, _env, None) ->
       fprintf ppf "@[<v>@[<hov>%s@ %s@;<1 2>%a@]@]"
         "This variant or record definition" "does not match that of type"
@@ -1715,40 +1795,26 @@ let report_error ppf = function
         (fun ppf -> fprintf ppf "Type")
         (fun ppf -> fprintf ppf "should be an instance of");
       fprintf ppf "@]"
-  | Non_regular { definition; used_as; defined_as; expansions } ->
-      let pp_expansion ppf (ty,body) =
-        Format.fprintf ppf "%a = %a"
-          Printtyp.type_expr ty
-          Printtyp.type_expr body in
-      let comma ppf () = Format.fprintf ppf ",@;<1 2>" in
-      let pp_expansions ppf expansions =
-        Format.(pp_print_list ~pp_sep:comma pp_expansion) ppf expansions in
+  | Non_regular { definition; used_as; defined_as; reaching_path } ->
+      let reaching_path = Reaching_path.simplify reaching_path in
       Printtyp.prepare_for_printing [used_as; defined_as];
+      Reaching_path.add_to_preparation reaching_path;
       Printtyp.Naming_context.reset ();
-      begin match expansions with
-      | [] ->
-          fprintf ppf
-            "@[<hv>This recursive type is not regular.@ \
-             The type constructor %s is defined as@;<1 2>type %a@ \
-             but it is used as@;<1 2>%a.@ \
-             All uses need to match the definition for the recursive type \
-             to be regular.@]"
-            (Path.name definition)
-            !Oprint.out_type (Printtyp.tree_of_typexp Type defined_as)
-            !Oprint.out_type (Printtyp.tree_of_typexp Type used_as)
-      | _ :: _ ->
-          fprintf ppf
-            "@[<hv>This recursive type is not regular.@ \
-             The type constructor %s is defined as@;<1 2>type %a@ \
-             but it is used as@;<1 2>%a@ \
-             after the following expansion(s):@;<1 2>%a@ \
-             All uses need to match the definition for the recursive type \
-             to be regular.@]"
-            (Path.name definition)
-            !Oprint.out_type (Printtyp.tree_of_typexp Type defined_as)
-            !Oprint.out_type (Printtyp.tree_of_typexp Type used_as)
-            pp_expansions expansions
-      end
+      fprintf ppf
+        "@[<hv>This recursive type is not regular.@ \
+         The type constructor %s is defined as@;<1 2>type %a@ \
+         but it is used as@;<1 2>%a%t\
+         All uses need to match the definition for the recursive type \
+         to be regular.@]"
+        (Path.name definition)
+        !Oprint.out_type (Printtyp.tree_of_typexp Type defined_as)
+        !Oprint.out_type (Printtyp.tree_of_typexp Type used_as)
+        (fun pp ->
+           let is_expansion = function Expands_to _ -> true | _ -> false in
+           if List.exists is_expansion reaching_path then
+             fprintf pp "@ after the following expansion(s)%a@ "
+             Reaching_path.pp_colon reaching_path
+           else fprintf pp ".@ ")
   | Inconsistent_constraint (env, err) ->
       fprintf ppf "@[<v>The type constraints are not consistent.@ ";
       Printtyp.report_unification_error ppf env err
@@ -1772,13 +1838,13 @@ let report_error ppf = function
       begin match decl.type_kind, decl.type_manifest with
       | Type_variant (tl, _rep), _ ->
           explain_unbound_gen ppf ty tl (fun c ->
-              let tl = tys_of_constr_args c.Types.cd_args in
-              Btype.newgenty (Ttuple tl)
-            )
+            let tl = tys_of_constr_args c.Types.cd_args in
+            Btype.newgenty (Ttuple tl)
+          )
             "case" (fun ppf c ->
-                fprintf ppf
-                  "%a of %a" Printtyp.ident c.Types.cd_id
-                  Printtyp.constructor_arguments c.Types.cd_args)
+              fprintf ppf
+                "%a of %a" Printtyp.ident c.Types.cd_id
+                Printtyp.constructor_arguments c.Types.cd_args)
       | Type_record (tl, _), _ ->
           explain_unbound ppf ty tl (fun l -> l.Types.ld_type)
             "field" (fun l -> Ident.name l.Types.ld_id ^ ": ")

--- a/typing/typedecl.mli
+++ b/typing/typedecl.mli
@@ -60,13 +60,18 @@ val is_fixed_type : Parsetree.type_declaration -> bool
 
 type native_repr_kind = Unboxed | Untagged
 
+type reaching_type_path = reaching_type_step list
+and reaching_type_step =
+  | Expands_to of type_expr * type_expr
+  | Contains of type_expr * type_expr
+
 type error =
     Repeated_parameter
   | Duplicate_constructor of string
   | Too_many_constructors
   | Duplicate_label of string
-  | Recursive_abbrev of string
-  | Cycle_in_def of string * type_expr
+  | Recursive_abbrev of string * Env.t * reaching_type_path
+  | Cycle_in_def of string * Env.t * reaching_type_path
   | Definition_mismatch of type_expr * Env.t * Includecore.type_mismatch option
   | Constraint_failed of Env.t * Errortrace.unification_error
   | Inconsistent_constraint of Env.t * Errortrace.unification_error
@@ -75,7 +80,7 @@ type error =
       definition: Path.t;
       used_as: type_expr;
       defined_as: type_expr;
-      expansions: (type_expr * type_expr) list;
+      reaching_path: reaching_type_path;
     }
   | Null_arity_external
   | Missing_native_external


### PR DESCRIPTION
I just restarted reviewing #11207 (a PR which fixes a compiler-performance bug). I'm convinced that the new implementation is correct, but one aspect of the change that is fairly tricky to reason about is its effect on error messages. It seems to make some error messages worse, but it's not clear why.

I propose to make the difference (in quality of the error messages between the two algorithms to check well-foundedness of type definitions) obvious by making the error messages informative in the first place. The present PR therefore gives a full trace of expansions that lead to a cycle, instead of just giving (sometimes) the final type we reach during cycle detection. I believe that this will be useful to review this aspect of #11207, but note that this is already a usability improvement with today's algorithm, independently of the other PR.

Note: with the current way that well-foundedness is checked, there is in fact little difference between the two different exceptions, Recursive_abbrev and Cycle_in_def. (Recursive_abbrev sounds a bit more confident in blaming the cycle precisely on a given definition, but otherwise they are explained in the same way.) For now I would suggest keeping the two distinct errors instead of merging them, to see whether they remain similar or grow more different with the different algorithm in #11207.

(cc @garrigue @Octachron)