### PR TITLE
Allow line directives without filename

### DIFF
--- a/parsing/lexer.mll
+++ b/parsing/lexer.mll
@@ -585,7 +585,7 @@ rule token = parse
 
 and directive = parse
   | ([' ' '\t']* (['0'-'9']+ as num) [' ' '\t']*
-        ("\"" ([^ '\010' '\013' '\"' ] * as name) "\"") as directive)
+        ("\"" ([^ '\010' '\013' '\"' ] * as name) "\"")? as directive)
         [^ '\010' '\013'] *
       {
         match int_of_string num with
@@ -597,7 +597,7 @@ and directive = parse
            (* Documentation says that the line number should be
               positive, but we have never guarded against this and it
               might have useful hackish uses. *)
-            update_loc lexbuf (Some name) (line_num - 1) true 0;
+            update_loc lexbuf name (line_num - 1) true 0;
             token lexbuf
       }
 and comment = parse

--- a/testsuite/tests/parsing/line_number_directives_without_file.compilers.reference
+++ b/testsuite/tests/parsing/line_number_directives_without_file.compilers.reference
@@ -1,0 +1,12 @@
+File "line_number_directives_without_file.ml", line 8, characters 13-14:
+8 | let () = let z = 1 in ()
+                 ^
+Warning 26 [unused-var]: unused variable z.
+File "line_number_directives_without_file.ml", line 1000, characters 13-14:
+1000 | let () = let z = 1 in ()
+                    ^
+Warning 26 [unused-var]: unused variable z.
+File "test-line-number-directiveXXX.ml", line 20, characters 13-14:
+Warning 26 [unused-var]: unused variable z.
+File "test-line-number-directiveXXX.ml", line 1000, characters 13-14:
+Warning 26 [unused-var]: unused variable z.

--- a/testsuite/tests/parsing/line_number_directives_without_file.ml
+++ b/testsuite/tests/parsing/line_number_directives_without_file.ml
@@ -1,0 +1,17 @@
+(* TEST
+   ocamlc_byte_exit_status = "0"
+   * setup-ocamlc.byte-build-env
+   ** ocamlc.byte
+   *** check-ocamlc.byte-output
+*)
+
+let () = let z = 1 in ()
+
+# 1000
+let () = let z = 1 in ()
+
+# 20 "test-line-number-directiveXXX.ml"
+let () = let z = 1 in ()
+
+# 1000
+let () = let z = 1 in ()


### PR DESCRIPTION
Another _Hello from Zombieland_:

When it issues line number directives, SUN C preprocessor sometimes omits the name of the file (when it does not change). Like in this snippet from `utils/domainstate.mli` (introduced by Multicore):

```ocaml
type t =
# 1 "runtime/caml/domain_state.tbl"

... (* lines omitted, KR *)

 | Domain_eventlog_out


# 92

 | Domain_extra_params

```

Ocaml lexer fails to parse line directive `# 92`. I found out that it is very easy to change the lexer, much easier than to make our build scripts use gcc preprocessor.

--------------------

In this PR I would like you to consider if this change might be useful for OCaml compiler. I met this preprocessor behavior only using `SunPRO` and `xlc`. The example of how to use it is in the test.

If it is not needed, please let me know, I will close the PR.