### PR TITLE
ocamlyacc: stop defining the NDEBUG macro

### DIFF
--- a/yacc/defs.h
+++ b/yacc/defs.h
@@ -15,10 +15,6 @@
 
 /* Based on public-domain code from Berkeley Yacc */
 
-#ifndef DEBUG
-#define NDEBUG
-#endif
-
 #include <assert.h>
 #include <ctype.h>
 #include <errno.h>


### PR DESCRIPTION
See issue #11714 for context