### PR TITLE
Remove `caml_alloc_N` function

### DIFF
--- a/runtime/alloc.c
+++ b/runtime/alloc.c
@@ -149,21 +149,6 @@ CAMLexport value caml_alloc_9 (tag_t tag, value a, value b, value c, value d,
   return do_alloc_small(9, tag, v);
 }
 
-CAMLexport value caml_alloc_N (mlsize_t wosize, tag_t tag, ...)
-{
-  va_list args;
-  mlsize_t i;
-  value vals[wosize];
-  value ret;
-  va_start(args, tag);
-  for (i = 0; i < wosize; i++)
-    vals[i] = va_arg(args, value);
-  ret = do_alloc_small(wosize, tag, vals);
-  va_end(args);
-  return ret;
-}
-
-
 CAMLexport value caml_alloc_small (mlsize_t wosize, tag_t tag)
 {
   value result;

--- a/runtime/caml/alloc.h
+++ b/runtime/caml/alloc.h
@@ -28,7 +28,6 @@ extern "C" {
    any OCaml callback such as finalizers or signal handlers. */
 
 CAMLextern value caml_alloc (mlsize_t, tag_t);
-CAMLextern value caml_alloc_N(mlsize_t, tag_t, ...);
 CAMLextern value caml_alloc_1(tag_t, value);
 CAMLextern value caml_alloc_2(tag_t, value, value);
 CAMLextern value caml_alloc_3(tag_t, value, value, value);


### PR DESCRIPTION
Extracted from #11693 as this is intended for 5.0.

`caml_alloc_N` requires use of C99 variable length arrays which are deprecated in C11 and will not therefore ever be supported by MSVC[^1]

@Octachron - it seems odd to put a `Changes` entry describing the removal of a function for which there is no Changes entry for its addition... I can of course add one, or I was wondering if you'd simply note it in the release announcement for the final beta?

[^1]: Microsoft have committed MSVC to C11 and C17 compliance, but that means that they will never _have_ to implement VLAs as C11 only permits their continued existence in compilers which already have them).