### PR TITLE
Ensure push_defaults can push past module patterns

### DIFF
--- a/Changes
+++ b/Changes
@@ -213,6 +213,10 @@ Working version
   paths.
   (Nicolás Ojeda Bär, report by Jason Gross, review by Gabriel Scherer)
 
+- #11727: Ensure push_defaults can push past module patterns, fixing an
+  currying optimisation accidentally disabled by #10340.
+  (Stephen Dolan, review by Gabriel Scherer)
+
 OCaml 5.0
 ---------
 

--- a/lambda/translcore.ml
+++ b/lambda/translcore.ml
@@ -102,6 +102,8 @@ let rec trivial_pat pat =
   match pat.pat_desc with
     Tpat_var _
   | Tpat_any -> true
+  | Tpat_alias (p, _, _) ->
+      trivial_pat p
   | Tpat_construct (_, cd, [], _) ->
       not cd.cstr_generalized && cd.cstr_consts = 1 && cd.cstr_nonconsts = 0
   | Tpat_tuple patl ->

--- a/testsuite/tests/basic-more/pr10338.ml
+++ b/testsuite/tests/basic-more/pr10338.ml
@@ -19,3 +19,8 @@ let f ?(y=1) : empty -> int = function _ -> .;;
 module type E = sig exception Ex end;;
 let f ((module M) : (module E)) (M.Ex | _) = "42";;
 print_endline (f (module struct exception Ex end) Exit);;
+
+(* push_defaults should push past the module pattern *)
+let f ?(x = assert false) ((module M) : (module E)) () = 1;;
+(* so partial application of the module doesn't raise *)
+let partial = f (module struct exception Ex end);;


### PR DESCRIPTION
This patch fixes a small bug introduced in #10340 in the handling of first class module parameters. This is a performance issue rather than a correctness one: in the current code, module parameters defeat currying optimisations, so a function like the following will process arguments and allocate closures one at a time:
```
let f (module M : A) () = 1
```

The issue is that, while `Translcore.push_defaults` does contain code to specifically handle this case, it cannot be reached because the module binding expands to a pattern involving `Tpat_alias`, which fails the new `is_trivial` check. The fix is to extend `is_trivial` to cover `Tpat_alias` as well.