### PR TITLE
ocamlyacc: source locations for %type declarations

### DIFF
--- a/Changes
+++ b/Changes
@@ -328,6 +328,8 @@ Working version
   reduction in size.
   (Xavier Leroy, review by Edwin Török and Gabriel Scherer)
 
+- #11728: ocamlyacc: generate line directives for %type declarations
+  (Demi Marie Obenour, review by Damien Doligez)
 
 ### Manual and documentation:
 

--- a/yacc/defs.h
+++ b/yacc/defs.h
@@ -22,6 +22,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <stdint.h>
 #define CAML_INTERNALS
 #include "caml/osdeps.h"
 #include "caml/misc.h"
@@ -142,6 +143,8 @@ struct bucket
     char assoc;
     unsigned char entry;  /* 1..MAX_ENTRY_POINT (0 for unassigned) */
     char true_token;
+    int lineno;
+    int column;
 };
 
 /* MAX_ENTRY_POINT is the maximal number of entry points into the grammar. */
@@ -239,6 +242,7 @@ extern char_os *interface_file_name;
 
 /* UTF-8 versions of code_file_name and input_file_name */
 extern char *code_file_name_disp;
+extern char *interface_file_name_disp;
 extern char *input_file_name_disp;
 
 extern FILE *action_file;

--- a/yacc/main.c
+++ b/yacc/main.c
@@ -52,7 +52,7 @@ int outline;
 char_os *action_file_name;
 char_os *entry_file_name;
 char_os *code_file_name;
-char *code_file_name_disp;
+char *code_file_name_disp, *interface_file_name_disp;
 char_os *interface_file_name;
 char_os *input_file_name = T("");
 char *input_file_name_disp;
@@ -367,7 +367,8 @@ void create_file_names(void)
         no_space();
     strcpy_os(interface_file_name, file_prefix);
     strcpy_os(interface_file_name + len, INTERFACE_SUFFIX);
-
+    interface_file_name_disp = caml_stat_strdup_of_os(interface_file_name);
+    if (!interface_file_name_disp) no_space();
 }
 
 

--- a/yacc/reader.c
+++ b/yacc/reader.c
@@ -747,7 +747,7 @@ get_tag(void)
 static void
 declare_tokens(int assoc)
 {
-    int c;
+    int c, column;
     bucket *bp;
     char *tag = 0;
 
@@ -757,6 +757,7 @@ declare_tokens(int assoc)
     if (c == EOF) unexpected_EOF();
     if (c == '<')
     {
+        column = cptr - line + 1;
         tag = get_tag();
         c = nextc();
         if (c == EOF) unexpected_EOF();
@@ -784,6 +785,10 @@ declare_tokens(int assoc)
         if (assoc == TOKEN)
         {
             bp->true_token = 1;
+            if (tag) {
+                bp->lineno = lineno;
+                bp->column = column;
+            }
         }
         else
         {
@@ -901,10 +906,12 @@ read_declarations(void)
         }
     }
 }
+static int infline = 1;
 
 static void output_token_type(void)
 {
   bucket * bp;
+  int i;
 
   fprintf(interface_file, "type token =\n");
   if (!rflag) ++outline;
@@ -916,15 +923,25 @@ static void output_token_type(void)
       if (bp->tag) {
         /* Print the type expression in parentheses to make sure
            that the constructor is unary */
-        fprintf(interface_file, " of (%s)", bp->tag);
-        fprintf(output_file, " of (%s)", bp->tag);
+        fprintf(output_file, " of (\n" line_format, bp->lineno, input_file_name_disp);
+        fprintf(interface_file, " of (\n" line_format, bp->lineno, input_file_name_disp);
+        for (i = 0; i < bp->column; i++) {
+            fputc(' ', interface_file);
+            fputc(' ', output_file);
+        }
+        fprintf(interface_file, "%s\n" line_format ")", bp->tag, infline + 5, interface_file_name_disp);
+        fprintf(output_file, "%s\n" line_format ")", bp->tag, outline + 5, code_file_name_disp);
+        infline += 4;
+        if (!rflag) outline += 4;
       }
       fprintf(interface_file, "\n");
+      infline++;
       if (!rflag) ++outline;
       fprintf(output_file, "\n");
     }
   }
   fprintf(interface_file, "\n");
+  infline++;
   if (!rflag) ++outline;
   fprintf(output_file, "\n");
 }

--- a/yacc/skeleton.c
+++ b/yacc/skeleton.c
@@ -19,7 +19,7 @@
 
 char *header[] =
 {
-  "open Parsing;;",
+  "open Parsing",
   "let _ = parse_error;;", /* avoid warning 33 (PR#5719) */
   0
 };


### PR DESCRIPTION
This can be incredibly useful if there is a type error.

Also avoid locale-dependent isalpha().

Fixes #10001.