### PR TITLE
The toplevels should respect -nostdlib when loading topdirs.cmi

### DIFF
--- a/Changes
+++ b/Changes
@@ -575,6 +575,9 @@ OCaml 5.0
   from +compiler-libs, as the debugger does.
   (David Allsopp, review by Sébastien Hinderer)
 
+- #11729: The toplevels should respect -nostdlib when loading topdirs.cmi.
+  (Sébastien Hinderer, review by ?)
+
 - #11007, #11399: META files for the stdlib, compiler-libs and other libraries
   (unix, dynlink, str, runtime_events, threads, ocamldoc) are now installed
   along with the compiler.

--- a/toplevel/topcommon.ml
+++ b/toplevel/topcommon.ml
@@ -288,7 +288,7 @@ let load_topdirs_signature () =
   let compiler_libs =
     Filename.concat Config.standard_library "compiler-libs" in
   let topdirs_cmi = Filename.concat compiler_libs "topdirs.cmi" in
-  if Sys.file_exists topdirs_cmi then
+  if not !Clflags.no_std_include && Sys.file_exists topdirs_cmi then
     ignore (Env.read_signature "Topdirs" topdirs_cmi)
 
 let initialize_toplevel_env () =


### PR DESCRIPTION
This is a follow-up to PR #11199.

Currently if one runs `make runtop` on a freshly built trunk whereas an
older, incompatible version of `topdirs.cmi` is installed, that results
in a failure. This is because the `-nostdlib` flags is not honoured
in `toplevel/topcommon.ml`, in the `load_topdirs_signature` function.

Moreover this results in an uncaught exception rather than in a meaningful
error message.

Currently this PR just fixes the code to not try to load `topdirs.cmi`
from the standard place if `-nostdlib` has been given but there might
be more to do here. Shall we try to read `topdirs.cmi` from another
location? Perhaps it would also be good to catch the exceptions raised
while reading the CMI file and maybe to just ignore them?