### PR TITLE
CI: Cancel redundant workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,6 +17,12 @@ permissions: {}
 env:
   PARALLEL_TESTS: parallel callback gc-roots weak-ephe-final
 
+# https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#concurrency
+# Concurrent workflows are grouped by the PR or branch that triggered them
+# (github.ref) and the name of the workflow (github.workflow). The
+# 'cancel-in-progress' option then make sure that only one workflow is running
+# at a time. This doesn't prevent new jobs from running, rather it cancels
+# already running jobs before scheduling new jobs.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ env:
 # at a time. This doesn't prevent new jobs from running, rather it cancels
 # already running jobs before scheduling new jobs.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name == 'pull_request' || github.sha }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,6 +17,10 @@ permissions: {}
 env:
   PARALLEL_TESTS: parallel callback gc-roots weak-ephe-final
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
 # This job will do the initial build of the compiler (on linux), with flambda on.
 # We then upload the compiler tree as a build artifact to enable re-use in

--- a/.github/workflows/hygiene.yml
+++ b/.github/workflows/hygiene.yml
@@ -11,6 +11,10 @@ on:
 # Restrict the GITHUB_TOKEN
 permissions: {}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   hygiene:
     name: Checks


### PR DESCRIPTION
The new [concurrency](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#concurrency) option allows to group concurrent runs by a key and then to cancel running jobs before running the workflow again.
This avoids starting many CI jobs for which the result is uninteresting.

I'm submitting this because I just force-pushed 4 times on one of my PR (rebase, update changes, mistake in changes, test failure) and I feel like many Wh were wasted.
In my testing, the workflows run after a push are delayed by several seconds (at least 10s, perhaps the time needed to cancel the running jobs) but perhaps this is compensated by the workflows running faster ? (I noticed on an other project that very long jobs get slower if many are run concurrently)