### PR TITLE
Use `mmap`/`munmap` for `sigaltstack` as well as fibers

### DIFF
--- a/Changes
+++ b/Changes
@@ -272,9 +272,10 @@ OCaml 5.0
   (Guillaume Munch-Maccagnoni, review by Xavier Leroy and Gabriel
   Scherer)
 
-- #10875: Add option to allocate stacks with mmap(MAP_STACK) instead of malloc.
-  This is exposed via a configure --enable-mmap-map-stack option, and is
-  enabled by default on OpenBSD where it is mandatory.
+- #10875, #11731: Add option to allocate fiber stacks and sigaltstacks with
+  mmap(MAP_STACK) instead of malloc. This is exposed via a configure
+  --enable-mmap-map-stack option, and is enabled by default on OpenBSD where
+  it is mandatory.
   (Anil Madhavapeddy, review by Gabriel Scherer, Tom Kelly,
    Michael Hendricks and KC Sivaramakrishnan).
 


### PR DESCRIPTION
Alternate implementation of #11091 which passes CI. Run through [precheck#803](https://ci.inria.fr/ocaml/job/precheck/803/) and tested locally on OpenBSD.

The API change proposed in #11091 is thorny as it would introduce `stack_t` into the public API which isn't possible on Windows. So either the functions themselves have to become optional or we have to introduce a `caml_stack_t` type just to keep the Windows build happy.

In this PR I take a slightly different approach - we know that the sigaltstack we allocated was of size `SIGSTKSZ` (that fact is already relied on for the macOS implementation of `sigaltstack`), so that's just unconditionally used with `munmap` here. An alternative would be to use `st.ss_size` as returned from the call to `sigaltstack` when disabling the stack, but that seems unnecessarily "risky" (even if the sigaltstack is not permitted to be grown).