### PR TITLE
Ensure that types from packed modules are always generalised

### DIFF
--- a/Changes
+++ b/Changes
@@ -221,6 +221,9 @@ Working version
   currying optimisation accidentally disabled by #10340.
   (Stephen Dolan, review by Gabriel Scherer)
 
+- #11732: Ensure that types from packed modules are always generalised
+  (Stephen Dolan and Leo White, review by Jacques Garrigue)
+
 OCaml 5.0
 ---------
 

--- a/testsuite/tests/typing-modules/packed_module_levels.ml
+++ b/testsuite/tests/typing-modules/packed_module_levels.ml
@@ -1,0 +1,42 @@
+(* TEST
+   * expect
+*)
+type (_, _) equ = Refl : ('q, 'q) equ
+
+module type Ty = sig type t end
+type 'a modu = (module Ty with type t = 'a)
+
+type 'q1 packed =
+    P : 'q0 modu * ('q0, 'q1) equ -> 'q1 packed
+
+(* Adds a module M to the environment where M.t equals an existential *)
+let repack (type q) (x : q packed) : q modu =
+  match x with
+  | P (p, eq) ->
+    let module M = (val p) in
+    let Refl = eq in
+    (module M)
+
+[%%expect{|
+type (_, _) equ = Refl : ('q, 'q) equ
+module type Ty = sig type t end
+type 'a modu = (module Ty with type t = 'a)
+type 'q1 packed = P : 'q0 modu * ('q0, 'q1) equ -> 'q1 packed
+val repack : 'q packed -> 'q modu = <fun>
+|}]
+
+(* Same, using a polymorphic function rather than an existential *)
+
+let mkmod (type a) () : a modu =
+  (module struct type t = a end)
+
+let f (type foo) (intish : (foo, int) equ) =
+  let module M = (val (mkmod () : foo modu)) in
+  let Refl = intish in
+  let module C : sig type t = int end = M in
+  ()
+
+[%%expect{|
+val mkmod : unit -> 'a modu = <fun>
+val f : ('foo, int) equ -> unit = <fun>
+|}]

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -2038,9 +2038,11 @@ and package_constraints env loc mty constrs =
   end
 
 let modtype_of_package env loc p fl =
+  (* We call Ctype.correct_levels to ensure that the types being added to the
+     module type are at generic_level. *)
   let mty =
     package_constraints env loc (Mty_ident p)
-      (List.map (fun (n, t) -> (Longident.flatten n, t)) fl)
+      (List.map (fun (n, t) -> Longident.flatten n, Ctype.correct_levels t) fl)
   in
   Subst.modtype Keep Subst.identity mty
 


### PR DESCRIPTION
The type system ensures that in the right-hand side of a type definition `type t = foo`, the type `foo` is always generalised.

This invariant is violated in one case, when the right-hand side comes not from the module language but from a `with` constraint on a first class module (e.g. `(module T with type t = foo)`). In this case, types with level below `generic_level` could end up in declarations.

In older versions of OCaml, I think this still occurred but mostly was ignored. When OCaml 4.13 (specifically, #10277) introduced stricter level and scope checking, this issue began to cause some code to spuriously fail to typecheck. Under OCaml 4.14 and later, the second example in the attached test yields the following nonsensical error message:
```
Error: Signature mismatch:
       Modules do not match:
         sig type t = foo end
       is not included in
         sig type t = int end
       Type declarations do not match:
         type t = foo
       is not included in
         type t = int
       The type foo = int is not equal to the type int
```
where `foo` is simultaneously equal to and not equal to `int`.

The fix is to ensure that the type is at `generic_level` before adding it to the environment, by calling `Ctype.correct_levels`.