### PR TITLE
Missing CAMLparam in win32's Unix.stat

### DIFF
--- a/Changes
+++ b/Changes
@@ -224,6 +224,9 @@ Working version
 - #11732: Ensure that types from packed modules are always generalised
   (Stephen Dolan and Leo White, review by Jacques Garrigue)
 
+- #11737: Missing CAMLparam in win32's Unix.stat
+  (Marc Lasson, Nicolás Ojeda Bär)
+
 OCaml 5.0
 ---------
 

--- a/Changes
+++ b/Changes
@@ -224,8 +224,9 @@ Working version
 - #11732: Ensure that types from packed modules are always generalised
   (Stephen Dolan and Leo White, review by Jacques Garrigue)
 
-- #11737: Missing CAMLparam in win32's Unix.stat
-  (Marc Lasson, Nicolás Ojeda Bär)
+- #11737: Fix segfault condition in Unix.stat under Windows in the presence of
+  multiple threads.
+  (Marc Lasson, Nicolás Ojeda Bär, review by Gabriel Scherer and David Allsopp)
 
 OCaml 5.0
 ---------

--- a/otherlibs/unix/stat_win32.c
+++ b/otherlibs/unix/stat_win32.c
@@ -339,6 +339,7 @@ static int do_stat(int do_lstat, int use_64, const char* opath, HANDLE fstat, __
 
 CAMLprim value caml_unix_stat(value path)
 {
+  CAMLparam1(path);
   struct _stat64 buf;
   __int64 st_ino;
 
@@ -346,11 +347,12 @@ CAMLprim value caml_unix_stat(value path)
   if (!do_stat(0, 0, String_val(path), NULL, &st_ino, &buf)) {
     caml_uerror("stat", path);
   }
-  return stat_aux(0, st_ino, &buf);
+  CAMLreturn (stat_aux(0, st_ino, &buf));
 }
 
 CAMLprim value caml_unix_stat_64(value path)
 {
+  CAMLparam1(path);
   struct _stat64 buf;
   __int64 st_ino;
 
@@ -358,11 +360,12 @@ CAMLprim value caml_unix_stat_64(value path)
   if (!do_stat(0, 1, String_val(path), NULL, &st_ino, &buf)) {
     caml_uerror("stat", path);
   }
-  return stat_aux(1, st_ino, &buf);
+  CAMLreturn (stat_aux(1, st_ino, &buf));
 }
 
 CAMLprim value caml_unix_lstat(value path)
 {
+  CAMLparam1(path);
   struct _stat64 buf;
   __int64 st_ino;
 
@@ -370,11 +373,12 @@ CAMLprim value caml_unix_lstat(value path)
   if (!do_stat(1, 0, String_val(path), NULL, &st_ino, &buf)) {
     caml_uerror("lstat", path);
   }
-  return stat_aux(0, st_ino, &buf);
+  CAMLreturn (stat_aux(0, st_ino, &buf));
 }
 
 CAMLprim value caml_unix_lstat_64(value path)
 {
+  CAMLparam1(path);
   struct _stat64 buf;
   __int64 st_ino;
 
@@ -382,7 +386,7 @@ CAMLprim value caml_unix_lstat_64(value path)
   if (!do_stat(1, 1, String_val(path), NULL, &st_ino, &buf)) {
     caml_uerror("lstat", path);
   }
-  return stat_aux(1, st_ino, &buf);
+  CAMLreturn (stat_aux(1, st_ino, &buf));
 }
 
 static value do_fstat(value handle, int use_64)


### PR DESCRIPTION
## What does the PR fix ?

There could be corruption of OCaml heap when interleaving with threads successful calls of `Unix.stat` with non-successful call (when the file does not exist).

This caused this bug: https://github.com/ocaml/ocaml-lsp/issues/929.

## Description

The `path` argument is used after a `caml_enter_blocking_section` when the path does not exist (the path is used to build the unix error exception).

Unfortunately, during the blocking section we may "yield" to a thread that can trigger a garbage collection and move the content of `path` elsewhere.

The CAMLparam is therefore needed in that case.

## Credits 

Thanks @nojb for your help on finding the problem !
