### PR TITLE
Disable unstable alert in some stdlib modules

### DIFF
--- a/stdlib/filename.ml
+++ b/stdlib/filename.ml
@@ -13,6 +13,8 @@
 (*                                                                        *)
 (**************************************************************************)
 
+[@@@alert "-unstable"]
+
 let generic_quote quotequote s =
   let l = String.length s in
   let b = Buffer.create (l + 20) in

--- a/stdlib/format.ml
+++ b/stdlib/format.ml
@@ -13,6 +13,8 @@
 (*                                                                        *)
 (**************************************************************************)
 
+[@@@alert "-unstable"]
+
 (* A pretty-printing facility and definition of formatters for 'parallel'
    (i.e. unrelated or independent) pretty-printing on multiple out channels. *)
 

--- a/stdlib/hashtbl.ml
+++ b/stdlib/hashtbl.ml
@@ -13,6 +13,8 @@
 (*                                                                        *)
 (**************************************************************************)
 
+[@@@alert "-unstable"]
+
 (* Hash tables *)
 
 (* We do dynamic hashing, and resize the table and rehash the elements

--- a/stdlib/random.ml
+++ b/stdlib/random.ml
@@ -14,6 +14,8 @@
 (*                                                                        *)
 (**************************************************************************)
 
+[@@@alert "-unstable"]
+
 (* Pseudo-random number generator *)
 
 external random_seed: unit -> int array = "caml_sys_random_seed"


### PR DESCRIPTION
The `unstable` alert (#11526) is triggered during the compilation of the standard library. As this is expected, I propose to disable this alert in the affected modules. An alternative could be to disable it everywhere by passing the flag uncondtionally.