### PR TITLE
Weak array improvements

### DIFF
--- a/Changes
+++ b/Changes
@@ -18,6 +18,9 @@ Working version
 
 ### Runtime system:
 
+- #11743: Speed up weak array operations
+  (KC Sivaramakrishnan, review by François Bobot and Sadiq Jaffer)
+
 - #11691, #11706: use __asm__ instead of asm for strict ISO C conformance
   (Xavier Leroy, report by Gregg Reynolds , review by Sadiq Jaffer)
 

--- a/runtime/caml/major_gc.h
+++ b/runtime/caml/major_gc.h
@@ -56,7 +56,6 @@ void caml_empty_mark_stack(void);
 void caml_finish_major_cycle(void);
 
 /* Ephemerons and finalisers */
-void caml_ephe_todo_list_emptied(void);
 void caml_orphan_allocated_words(void);
 void caml_add_to_orphaned_ephe_list(struct caml_ephe_info* ephe_info);
 void caml_add_orphaned_finalisers (struct caml_final_info*);

--- a/runtime/caml/weak.h
+++ b/runtime/caml/weak.h
@@ -29,13 +29,25 @@ extern value caml_ephe_none;
 #ifdef CAML_INTERNALS
 
 struct caml_ephe_info {
-  value todo; /* These are ephemerons which need to be marked and swept in the
-                 current cycle. If the ephemeron is alive, after marking, they
-                 go into the live list after cleaning them off the unreachable
-                 keys and releasing values if any of the keys are unreachable.
-                 */
-  value live; /* These are ephemerons which are alive in the current cycle,
-                 whose keys and data are live (or not set). */
+  value todo;
+  /* These are ephemerons which need to be marked and swept in the current
+     cycle. If the ephemeron is alive, after marking, they go into the live
+     list after cleaning them off the unreachable keys and releasing the data
+     if any of the keys are unreachable. */
+
+  value live;
+  /* These are ephemerons are alive (marked). The keys of these ephemerons may
+     be unmarked if these ephemerons were the target of a blit operation. The
+     data field is never unmarked. */
+
+  int must_sweep_ephe;
+  /* At the beginning of [Phase_sweep_ephe] the [live] list is moved to the
+     [todo] list since the ephemerons in the [live] list may contain unmarked
+     keys if the blit operation was performed in earlier phases
+     ([Phase_mark_final] or [Phase_sweep_and_mark_main]). This move is done
+     exactly once per major cycle per domain. This field keeps track of whether
+     this move has been done for the current cycle. */
+
   uintnat cycle;
   struct {
     value* todop;

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -1611,7 +1611,8 @@ CAMLexport void (*caml_atfork_hook)(void) = caml_atfork_default;
 static void handover_ephemerons(caml_domain_state* domain_state)
 {
   if (domain_state->ephe_info->todo == 0 &&
-      domain_state->ephe_info->live == 0)
+      domain_state->ephe_info->live == 0 &&
+      domain_state->ephe_info->must_sweep_ephe == 0)
     return;
 
   caml_add_to_orphaned_ephe_list(domain_state->ephe_info);

--- a/runtime/weak.c
+++ b/runtime/weak.c
@@ -254,8 +254,8 @@ static value ephe_get_field (value e, mlsize_t offset)
   } else {
     elt = Field(e, offset);
     caml_darken (Caml_state, elt, 0);
-    res = caml_alloc_shr (1, Tag_some);
-    caml_initialize(&Field(res, 0), elt);
+    res = caml_alloc_small (1, Tag_some);
+    Field(res, 0) = elt;
   }
   /* run GC and memprof callbacks */
   caml_process_pending_actions();
@@ -328,8 +328,8 @@ static value ephe_get_field_copy (value e, mlsize_t offset)
   } else {
     Field(e, offset) = elt = v;
   }
-  res = caml_alloc_shr (1, Tag_some);
-  caml_initialize(&Field(res, 0), elt + infix_offs);
+  res = caml_alloc_small (1, Tag_some);
+  Field(res, 0) = elt + infix_offs;
  out:
   /* run GC and memprof callbacks */
   caml_process_pending_actions();

--- a/runtime/weak.c
+++ b/runtime/weak.c
@@ -398,7 +398,7 @@ static value ephe_blit_field (value es, mlsize_t offset_s,
   if (length == 0) CAMLreturn(Val_unit);
 
   /* We clean the source and destination ephemerons before performing the blit.
-   * This guarnatees that none of the keys and the data fields being accessed
+   * This guarantees that none of the keys and the data fields being accessed
    * during a blit operation is unmarked during [Phase_sweep]. */
   caml_ephe_clean(es);
   caml_ephe_clean(ed);
@@ -435,7 +435,7 @@ CAMLprim value caml_ephe_blit_data (value es, value ed)
 {
   ephe_blit_field (es, CAML_EPHE_DATA_OFFSET, ed, CAML_EPHE_DATA_OFFSET, 1);
   caml_darken(0, Field(ed, CAML_EPHE_DATA_OFFSET), 0);
-  /* [ed] may be in [Caml_state->ephe_info-live] list. The data value may be
+  /* [ed] may be in [Caml_state->ephe_info->live] list. The data value may be
      unmarked. The ephemerons on the live list are not scanned during ephemeron
      marking. Hence, unconditionally darken the data value. */
   return Val_unit;


### PR DESCRIPTION
In https://github.com/ocaml/ocaml/issues/11733, it was observed that there were time and memory regressions with frama-c. On investigation, this pointed to inefficiencies with weak array `blit` and `get_field*` operations. This PR addresses some of the inefficiencies with weak arrays. 

## Optimize `get_field*` 

The first commit https://github.com/ocaml/ocaml/commit/25e7f084b194a73de2e2e2c875631e69f2e651f4 optimises `get_field` and `get_field_copy` operations. On trunk, the `Some` value is allocated on the major heap. This was necessary with the earlier concurrent minor GC scheme where domains cannot directly access the minor heap arena of other domains. Currently, OCaml uses parallel minor GC where there are no restrictions on inter minor heap arena pointers. Hence, these values may be allocated on the minor heap. 

## Optimize `blit` operation

The ephemeron / weak array implementation on trunk uses two per-domain lists to keep track of ephemerons.

https://github.com/ocaml/ocaml/blob/ee75054a9b9a76ae8e859e90de2140b2247d6905/runtime/caml/weak.h#L31-L38

In particular, the assumption is that all of the ephemerons on the live list are marked and all of the keys and the data field are either marked (or unset or is a primitive value). In order to preserve this invariant, during a `blit` operation, the fields being copied are marked; it may be possible that the destination of a bit operation may be an ephemeron on the live list. It was pointed out in the PR that introduced the marking https://github.com/ocaml-multicore/ocaml-multicore/pull/316 that this may cause noticeable difference to performance, which is what was observed with `frama-c` benchmarks. 

The second commit relaxes the invariant on the live list. For the ephemerons on the live list, the ephemerons are marked and the data field is marked (or unset or is a primitive value), but the keys may be unmarked (due to a `blit` operation that copies unmarked keys into the destination ephemeron). During a blit operation, the keys are no longer darkened. As a result, the live list has to be swept during `Phase_sweep_ephe` to release the dead keys. This is done by moving the ephemerons on the live list to the todo list at the beginning of `Phase_sweep_ephe`. 

### Domain creation and termination

Care must be taken to ensure that the new protocol works with domain creation and termination. On trunk, the number of domains to perform ephemeron sweeping is determined at the start of the new cycle. This count is maintained in `num_domains_to_ephe_sweep` variable. Newly created domains in a cycle will only have ephemerons in its live list, and the ephemerons on the live list have the strong invariant that obviates the need to mark or sweep these ephemerons in that cycle.

Since we have relaxed the invariant, newly created domains may have ephemerons on the live list that may have unmarked keys. Hence, the number of ephemerons to perform ephemeron sweeping can only be determined at the beginning of the `Phase_sweep_ephe`. To that end, `num_domains_to_ephe_sweep` is determined at the beginning of `Phase_sweep_ephe` in `major_gc.c:try_complete_gc_phase`. During domain termination, the terminating domain ensures that the `num_domains_to_ephe_sweep` count is decremented appropriately.

## Performance

I repeated the experiments suggested in #11733. There are 3 variants in the experiment:

* 4.12 (baseline)
* 5.0.0_beta1 + #11673
* 5.0.0_beta1 + #11673 + patches from this PR.

The raw results are available in [this sheet](https://docs.google.com/spreadsheets/d/1prmlGRIQxT6FaNQWlOayxA8_gO4OUcaENmGKL4IjvhI/edit?usp=sharing). Here are the time and memory overheads of the two latter variants compared to the baseline:

### Time 
<img width="911" alt="image" src="https://user-images.githubusercontent.com/410484/203374477-9ed55131-0b88-4090-b28b-a60a6014d3cb.png">

The numbers in the parenthesis next to the benchmark name represent the execution time in seconds for the baseline variant. On average, the time increase from 4.12 to 5.0.0_beta1 + pr11673 was 85%, and this drops to 59% with this PR.

### Memory 
<img width="905" alt="image" src="https://user-images.githubusercontent.com/410484/203374164-90ca0637-ca0b-4643-b664-48a72f31457c.png">

The numbers in the parenthesis next to the benchmark name represent the maximum resident set size in kilo bytes for the baseline variant. On average, the memory increase 4.12 to 5.0.0_beta1 + pr11673 was 108% which drops to 28% with this PR. On `debie1.eva` the memory increase on 5.0.0_beta1 + pr11673 was 913%, which comes down to 76% with this PR. 


