### PR TITLE
Weak.check missing exception in documentation

### DIFF
--- a/stdlib/weak.mli
+++ b/stdlib/weak.mli
@@ -53,13 +53,13 @@ val set : 'a t -> int -> 'a option -> unit
    (full) pointer to [el]; [Weak.set ar n None] sets the [n]th
    cell of [ar] to empty.
    @raise Invalid_argument if [n] is not in the range
-   0 to {!Weak.length}[ a - 1].*)
+   0 to {!Weak.length}[ ar - 1].*)
 
 val get : 'a t -> int -> 'a option
 (** [Weak.get ar n] returns None if the [n]th cell of [ar] is
    empty, [Some x] (where [x] is the value) if it is full.
    @raise Invalid_argument if [n] is not in the range
-   0 to {!Weak.length}[ a - 1].*)
+   0 to {!Weak.length}[ ar - 1].*)
 
 val get_copy : 'a t -> int -> 'a option
 (** [Weak.get_copy ar n] returns None if the [n]th cell of [ar] is
@@ -70,7 +70,7 @@ val get_copy : 'a t -> int -> 'a option
    the incremental GC from erasing the value in its current cycle
    ([get] may delay the erasure to the next GC cycle).
    @raise Invalid_argument if [n] is not in the range
-   0 to {!Weak.length}[ a - 1].
+   0 to {!Weak.length}[ ar - 1].
 
    If the element is a custom block it is not copied.
 
@@ -88,7 +88,7 @@ val fill : 'a t -> int -> int -> 'a option -> unit
 (** [Weak.fill ar ofs len el] sets to [el] all pointers of [ar] from
    [ofs] to [ofs + len - 1].
    @raise Invalid_argument
-   if [ofs] and [len] do not designate a valid subarray of [a].*)
+   if [ofs] and [len] do not designate a valid subarray of [ar].*)
 
 val blit : 'a t -> int -> 'a t -> int -> int -> unit
 (** [Weak.blit ar1 off1 ar2 off2 len] copies [len] weak pointers

--- a/stdlib/weak.mli
+++ b/stdlib/weak.mli
@@ -80,7 +80,9 @@ val get_copy : 'a t -> int -> 'a option
 val check : 'a t -> int -> bool
 (** [Weak.check ar n] returns [true] if the [n]th cell of [ar] is
    full, [false] if it is empty.  Note that even if [Weak.check ar n]
-   returns [true], a subsequent {!Weak.get}[ ar n] can return [None].*)
+   returns [true], a subsequent {!Weak.get}[ ar n] can return [None].
+   @raise Invalid_argument if [n] is not in the range
+   0 to {!Weak.length}[ ar - 1].*)
 
 val fill : 'a t -> int -> int -> 'a option -> unit
 (** [Weak.fill ar ofs len el] sets to [el] all pointers of [ar] from


### PR DESCRIPTION
I just discovered that `Weak.check` may also raise `Invalid_argument`. This little PR therefore adds this possibility to the documentation.

As a bonus I discovered a few occurrences of `a` which should have been `ar` in the documentation for some of the other `Weak` operations.