### PR TITLE
Embed printer types in toplevels and debugger

### DIFF
--- a/.depend
+++ b/.depend
@@ -6465,21 +6465,22 @@ toplevel/toploop.cmi : \
 toplevel/topmain.cmi :
 toplevel/topprinters.cmo : \
     typing/types.cmi \
-    typing/typemod.cmi \
+    typing/predef.cmi \
     typing/path.cmi \
-    parsing/parse.cmi \
-    typing/env.cmi \
+    typing/ident.cmi \
+    typing/ctype.cmi \
+    parsing/asttypes.cmi \
     toplevel/topprinters.cmi
 toplevel/topprinters.cmx : \
     typing/types.cmx \
-    typing/typemod.cmx \
+    typing/predef.cmx \
     typing/path.cmx \
-    parsing/parse.cmx \
-    typing/env.cmx \
+    typing/ident.cmx \
+    typing/ctype.cmx \
+    parsing/asttypes.cmi \
     toplevel/topprinters.cmi
 toplevel/topprinters.cmi : \
-    typing/path.cmi \
-    typing/env.cmi
+    typing/types.cmi
 toplevel/topstart.cmo : \
     toplevel/topmain.cmi \
     toplevel/topstart.cmi

--- a/.depend
+++ b/.depend
@@ -6368,6 +6368,7 @@ toplevel/topcommon.cmi : \
 toplevel/topdirs.cmo : \
     utils/warnings.cmi \
     typing/types.cmi \
+    toplevel/topprinters.cmi \
     toplevel/toploop.cmi \
     toplevel/topeval.cmi \
     typing/printtyp.cmi \
@@ -6392,6 +6393,7 @@ toplevel/topdirs.cmo : \
 toplevel/topdirs.cmx : \
     utils/warnings.cmx \
     typing/types.cmx \
+    toplevel/topprinters.cmx \
     toplevel/toploop.cmx \
     toplevel/topeval.cmi \
     typing/printtyp.cmx \
@@ -6461,6 +6463,23 @@ toplevel/toploop.cmi : \
     utils/load_path.cmi \
     typing/env.cmi
 toplevel/topmain.cmi :
+toplevel/topprinters.cmo : \
+    typing/types.cmi \
+    typing/typemod.cmi \
+    typing/path.cmi \
+    parsing/parse.cmi \
+    typing/env.cmi \
+    toplevel/topprinters.cmi
+toplevel/topprinters.cmx : \
+    typing/types.cmx \
+    typing/typemod.cmx \
+    typing/path.cmx \
+    parsing/parse.cmx \
+    typing/env.cmx \
+    toplevel/topprinters.cmi
+toplevel/topprinters.cmi : \
+    typing/path.cmi \
+    typing/env.cmi
 toplevel/topstart.cmo : \
     toplevel/topmain.cmi \
     toplevel/topstart.cmi

--- a/Changes
+++ b/Changes
@@ -190,6 +190,11 @@ Working version
 - #11568: Encode inline record types in Path.t
   (Leo White and Hyunggyu Jang, review by Gabriel Scherer)
 
+- #11745: Debugger and toplevels: embed printer types rather than
+  reading their representations from topdirs.cmi at runtime.
+  (Sébastien Hinderer, review by Florian Angeletti, Nicolás Ojeda Bär and
+  Gabriel Scherer)
+
 ### Build system:
 - #11590: Allow installing to a destination path containing spaces.
    (Élie Brami, review by Sébastien Hinderer and David Allsopp)

--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ TOPLEVELINIT=toplevel/toploop.cmo
 
 # This list is passed to expunge, which accepts both uncapitalized and
 # capitalized module names.
-PERVASIVES=$(STDLIB_MODULES) outcometree topdirs toploop
+PERVASIVES=$(STDLIB_MODULES) outcometree topprinters topdirs toploop
 
 LIBFILES=stdlib.cma std_exit.cmo *.cmi camlheader
 

--- a/compilerlibs/Makefile.compilerlibs
+++ b/compilerlibs/Makefile.compilerlibs
@@ -354,6 +354,7 @@ TOPLEVEL = \
   toplevel/byte/topeval.cmo \
   toplevel/byte/trace.cmo \
   toplevel/toploop.cmo \
+  toplevel/topprinters.cmo \
   toplevel/topdirs.cmo \
   toplevel/byte/topmain.cmo
 TOPLEVEL_CMI = \
@@ -361,6 +362,7 @@ TOPLEVEL_CMI = \
   toplevel/byte/topeval.cmi \
   toplevel/byte/trace.cmi \
   toplevel/toploop.cmi \
+  toplevel/topprinters.cmi \
   toplevel/topdirs.cmi \
   toplevel/byte/topmain.cmi
 
@@ -371,6 +373,7 @@ OPTTOPLEVEL = \
   toplevel/native/topeval.cmo \
   toplevel/native/trace.cmo \
   toplevel/toploop.cmo \
+  toplevel/topprinters.cmo \
   toplevel/topdirs.cmo \
   toplevel/native/topmain.cmo
 OPTTOPLEVEL_CMI = \
@@ -379,6 +382,7 @@ OPTTOPLEVEL_CMI = \
   toplevel/native/topeval.cmi \
   toplevel/native/trace.cmi \
   toplevel/toploop.cmi \
+  toplevel/topprinters.cmi \
   toplevel/topdirs.cmi \
   toplevel/native/topmain.cmi
 

--- a/debugger/.depend
+++ b/debugger/.depend
@@ -276,13 +276,15 @@ int64ops.cmx : \
 int64ops.cmi :
 loadprinter.cmo : \
     ../typing/types.cmi \
+    ../typing/typemod.cmi \
+    ../toplevel/topprinters.cmi \
     ../bytecomp/symtable.cmi \
     printval.cmi \
     ../typing/printtyp.cmi \
     ../typing/path.cmi \
-    parameters.cmi \
     ../utils/misc.cmi \
     ../parsing/longident.cmi \
+    ../parsing/location.cmi \
     ../utils/load_path.cmi \
     ../typing/ident.cmi \
     ../typing/env.cmi \
@@ -291,13 +293,15 @@ loadprinter.cmo : \
     loadprinter.cmi
 loadprinter.cmx : \
     ../typing/types.cmx \
+    ../typing/typemod.cmx \
+    ../toplevel/topprinters.cmx \
     ../bytecomp/symtable.cmx \
     printval.cmx \
     ../typing/printtyp.cmx \
     ../typing/path.cmx \
-    parameters.cmx \
     ../utils/misc.cmx \
     ../parsing/longident.cmx \
+    ../parsing/location.cmx \
     ../utils/load_path.cmx \
     ../typing/ident.cmx \
     ../typing/env.cmx \
@@ -318,7 +322,6 @@ main.cmo : \
     ../typing/persistent_env.cmi \
     parameters.cmi \
     ../utils/misc.cmi \
-    loadprinter.cmi \
     ../utils/load_path.cmi \
     input_handling.cmi \
     frames.cmi \
@@ -341,7 +344,6 @@ main.cmx : \
     ../typing/persistent_env.cmx \
     parameters.cmx \
     ../utils/misc.cmx \
-    loadprinter.cmx \
     ../utils/load_path.cmx \
     input_handling.cmx \
     frames.cmx \

--- a/debugger/.depend
+++ b/debugger/.depend
@@ -276,7 +276,6 @@ int64ops.cmx : \
 int64ops.cmi :
 loadprinter.cmo : \
     ../typing/types.cmi \
-    ../typing/typemod.cmi \
     ../toplevel/topprinters.cmi \
     ../bytecomp/symtable.cmi \
     printval.cmi \
@@ -284,7 +283,6 @@ loadprinter.cmo : \
     ../typing/path.cmi \
     ../utils/misc.cmi \
     ../parsing/longident.cmi \
-    ../parsing/location.cmi \
     ../utils/load_path.cmi \
     ../typing/ident.cmi \
     ../typing/env.cmi \
@@ -293,7 +291,6 @@ loadprinter.cmo : \
     loadprinter.cmi
 loadprinter.cmx : \
     ../typing/types.cmx \
-    ../typing/typemod.cmx \
     ../toplevel/topprinters.cmx \
     ../bytecomp/symtable.cmx \
     printval.cmx \
@@ -301,7 +298,6 @@ loadprinter.cmx : \
     ../typing/path.cmx \
     ../utils/misc.cmx \
     ../parsing/longident.cmx \
-    ../parsing/location.cmx \
     ../utils/load_path.cmx \
     ../typing/ident.cmx \
     ../typing/env.cmx \

--- a/debugger/Makefile
+++ b/debugger/Makefile
@@ -32,7 +32,8 @@ DIRECTORIES=$(UNIXDIR) $(DYNLINKDIR) $(addprefix $(ROOTDIR)/,\
 
 INCLUDES=$(addprefix -I ,$(DIRECTORIES))
 
-compiler_modules := $(ROOTDIR)/toplevel/genprintval
+compiler_modules := $(addprefix $(ROOTDIR)/toplevel/,\
+  genprintval topprinters)
 
 debugger_modules := \
   int64ops primitives unix_tools debugger_config parameters debugger_lexer \

--- a/debugger/loadprinter.mli
+++ b/debugger/loadprinter.mli
@@ -17,8 +17,6 @@
 
 open Format
 
-val init : unit -> unit
-
 val loadfile : formatter -> string -> unit
 val install_printer : formatter -> Longident.t -> unit
 val remove_printer : Longident.t -> unit

--- a/debugger/main.ml
+++ b/debugger/main.ml
@@ -152,8 +152,6 @@ let add_include d =
     Misc.expand_directory Config.standard_library d :: !default_load_path
 let set_socket s =
   socket_name := s
-let set_topdirs_path s =
-  topdirs_path := s
 let set_checkpoints n =
   checkpoint_max_count := n
 let set_directory dir =
@@ -191,8 +189,6 @@ let speclist = [
       " Do not print times";
    "-no-breakpoint-message", Arg.Clear Parameters.breakpoint,
       " Do not print message at breakpoint setup and removal";
-   "-topdirs-path", Arg.String set_topdirs_path,
-      " Set path to the directory containing topdirs.cmi";
    ]
 
 let function_placeholder () =
@@ -228,7 +224,6 @@ let main () =
     end;
     if !Parameters.version
     then printf "\tOCaml Debugger version %s@.@." Config.version;
-    Loadprinter.init();
     Load_path.init ~auto_include:Compmisc.auto_include !default_load_path;
     Clflags.recursive_types := true;    (* Allow recursive types. *)
     toplevel_loop ();                   (* Toplevel. *)

--- a/debugger/parameters.ml
+++ b/debugger/parameters.ml
@@ -30,8 +30,6 @@ let prompt = ref true
 let time = ref true
 let version = ref true
 
-let topdirs_path = ref (Filename.concat Config.standard_library "compiler-libs")
-
 let add_path dir =
   Load_path.add_dir dir;
   Envaux.reset_cache()

--- a/debugger/parameters.mli
+++ b/debugger/parameters.mli
@@ -24,7 +24,6 @@ val breakpoint : bool ref
 val prompt : bool ref
 val time : bool ref
 val version : bool ref
-val topdirs_path : string ref
 
 val add_path : string -> unit
 val add_path_for : string -> string -> unit

--- a/ocamltest/ocaml_flags.ml
+++ b/ocamltest/ocaml_flags.ml
@@ -55,7 +55,6 @@ let toplevel_default_flags = "-noinit -no-version -noprompt"
 
 let ocamldebug_default_flags =
   "-no-version -no-prompt -no-time -no-breakpoint-message " ^
-  ("-I " ^ Ocaml_directories.stdlib ^ " ") ^
-  ("-topdirs-path " ^ Ocaml_directories.toplevel)
+  ("-I " ^ Ocaml_directories.stdlib ^ " ")
 
 let ocamlobjinfo_default_flags = "-null-crc"

--- a/tools/.depend
+++ b/tools/.depend
@@ -146,10 +146,6 @@ ocamlmktop.cmo : \
 ocamlmktop.cmx : \
     ../utils/config.cmx \
     ../utils/ccomp.cmx
-ocamlmktop_init.cmo : \
-    ../toplevel/topcommon.cmi
-ocamlmktop_init.cmx : \
-    ../toplevel/topcommon.cmx
 ocamloptp.cmo : \
     ocamlcp_common.cmo \
     ../driver/main_args.cmi

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -144,14 +144,6 @@ OCAMLMKTOP=config.cmo build_path_prefix_map.cmo misc.cmo \
 
 ocamlmktop$(EXE): $(OCAMLMKTOP)
 ocamlmktop.opt$(EXE): $(call byte2native, $(OCAMLMKTOP))
-# othertools means "after the toplevel has been built" here
-othertools: ocamlmktop_init.cmo
-INSTALL_LIBDIR_OCAMLMKTOP = $(INSTALL_LIBDIR)/ocamlmktop
-install::
-	$(MKDIR) "$(INSTALL_LIBDIR_OCAMLMKTOP)"
-	$(INSTALL_DATA) \
-    ocamlmktop_init.cmi ocamlmktop_init.cmo \
-    "$(INSTALL_LIBDIR_OCAMLMKTOP)"
 
 # Converter olabl/ocaml 2.99 to ocaml 3
 

--- a/tools/ocamlmktop.ml
+++ b/tools/ocamlmktop.ml
@@ -27,7 +27,7 @@ let _ =
     extra_quote ^ ocamlc ^
     " -I +compiler-libs -I +ocamlmktop " ^
     "-linkall ocamlcommon.cma ocamlbytecomp.cma ocamltoplevel.cma " ^
-    "ocamlmktop_init.cmo " ^ args ^ " topstart.cmo" ^
+    args ^ " topstart.cmo" ^
     extra_quote
   in
   exit(Sys.command cmdline)

--- a/toplevel/byte/topmain.ml
+++ b/toplevel/byte/topmain.ml
@@ -216,7 +216,6 @@ let main () =
   Compmisc.read_clflags_from_env ();
   if not (prepare ppf) then raise (Compenv.Exit_with_status 2);
   Compmisc.init_path ();
-  Topcommon.load_topdirs_signature ();
   Toploop.loop Format.std_formatter
 
 let main () =

--- a/toplevel/native/topmain.ml
+++ b/toplevel/native/topmain.ml
@@ -108,7 +108,6 @@ let main () =
   Compmisc.read_clflags_from_env ();
   if not (prepare Format.err_formatter) then raise (Compenv.Exit_with_status 2);
   Compmisc.init_path ();
-  Topcommon.load_topdirs_signature ();
   Toploop.loop Format.std_formatter
 
 let main () =

--- a/toplevel/topcommon.ml
+++ b/toplevel/topcommon.ml
@@ -284,13 +284,6 @@ let update_search_path_from_env () =
   in
   Clflags.include_dirs := List.rev_append extra_paths !Clflags.include_dirs
 
-let load_topdirs_signature () =
-  let compiler_libs =
-    Filename.concat Config.standard_library "compiler-libs" in
-  let topdirs_cmi = Filename.concat compiler_libs "topdirs.cmi" in
-  if Sys.file_exists topdirs_cmi then
-    ignore (Env.read_signature "Topdirs" topdirs_cmi)
-
 let initialize_toplevel_env () =
   toplevel_env := Compmisc.initial_env()
 

--- a/toplevel/topcommon.mli
+++ b/toplevel/topcommon.mli
@@ -36,10 +36,6 @@ val set_paths : ?auto_include:Load_path.auto_include_callback -> unit -> unit
 
 val update_search_path_from_env : unit -> unit
 
-(* Load topdirs.cmi directly from +compiler-libs if not found in include dirs *)
-
-val load_topdirs_signature : unit -> unit
-
 (* Management and helpers for the execution *)
 
 val toplevel_env : Env.t ref

--- a/toplevel/topdirs.mli
+++ b/toplevel/topdirs.mli
@@ -43,9 +43,5 @@ val section_options : string
 
 val section_undocumented : string
 
-
-type 'a printer_type_new = Format.formatter -> 'a -> unit
-type 'a printer_type_old = 'a -> unit
-
 (* Here for backwards compatibility, use [Toploop.load_file]. *)
 val[@deprecated] load_file : formatter -> string -> bool

--- a/toplevel/toploop.ml
+++ b/toplevel/toploop.ml
@@ -114,7 +114,6 @@ let run_script ppf name args =
   let filename = filename_of_input name in
   Compmisc.init_path ~dir:(Filename.dirname filename) ();
                    (* Note: would use [Filename.abspath] here, if we had it. *)
-  Topcommon.load_topdirs_signature ();
   begin
     try toplevel_env := Compmisc.initial_env()
     with Env.Error _ | Typetexp.Error _ as exn ->

--- a/toplevel/topprinters.ml
+++ b/toplevel/topprinters.ml
@@ -1,0 +1,39 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                   Sebastien Hinderer, Tarides, Paris                   *)
+(*                                                                        *)
+(*   Copyright 2022 Institut National de Recherche en Informatique et     *)
+(*     en Automatique.                                                    *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+(* Infrastructure to support user-defined printers in toplevels and debugger *)
+
+let printertypes_str = {|
+  type 'a printer_type_new = Format.formatter -> 'a -> unit
+  type 'a printer_type_old = 'a -> unit
+|}
+
+let printertypes_sig_ast =
+  Parse.interface (Lexing.from_string printertypes_str)
+
+let printertypes_sig env =
+  (Typemod.transl_signature env printertypes_sig_ast).sig_type
+
+let printer_types sign =
+  match sign with
+  | [Types.Sig_type(new_name,_,_,_); Types.Sig_type(old_name,_,_,_)] ->
+    (Path.Pident new_name, Path.Pident old_name)
+  | _ -> assert false
+
+let env_with_printer_types env =
+  let tmp_sign = printertypes_sig env in
+  let tmp_env = Env.add_signature tmp_sign env in
+  let printer_type_new, printer_type_old = printer_types tmp_sign in
+  (tmp_env, printer_type_new, printer_type_old)  

--- a/toplevel/topprinters.mli
+++ b/toplevel/topprinters.mli
@@ -15,4 +15,9 @@
 
 (* Infrastructure to support user-defined printers in toplevels and debugger *)
 
-val env_with_printer_types : Env.t -> Env.t * Path.t * Path.t
+type printer_type = Types.type_expr -> Types.type_expr
+
+val type_arrow : Types.type_expr -> Types.type_expr -> Types.type_expr
+
+val printer_type_new : printer_type
+val printer_type_old : printer_type

--- a/toplevel/topprinters.mli
+++ b/toplevel/topprinters.mli
@@ -2,7 +2,7 @@
 (*                                                                        *)
 (*                                 OCaml                                  *)
 (*                                                                        *)
-(*             Florian Angeletti, projet Cambium, Inria Paris             *)
+(*                   Sebastien Hinderer, Tarides, Paris                   *)
 (*                                                                        *)
 (*   Copyright 2022 Institut National de Recherche en Informatique et     *)
 (*     en Automatique.                                                    *)
@@ -13,5 +13,6 @@
 (*                                                                        *)
 (**************************************************************************)
 
-let () =
-  Topcommon.load_topdirs_signature ()
+(* Infrastructure to support user-defined printers in toplevels and debugger *)
+
+val env_with_printer_types : Env.t -> Env.t * Path.t * Path.t


### PR DESCRIPTION
The debugger and toplevels let users install printers for their data types.

To make sure the provided printers have the right type, both the debugger and
the toplevel need to know the internal OCaml representation of
the expected types.

So far, both the debugger and the toplevels used to extract the expected
type representatioons from topdirs.cmi which they were reading at runtime.

This creates problems (e.g. when the compiler has not yet been installed, as
reported in #11729) and yields not so easy to read code.

In this PR, the type of the printers are defined in strings as they
would be written in OCaml in a module shared by the debugger and the
toplevels. These type declarations are then parsed at runtime and
the corresponding typing declarations are added to the environment.

This PR thus removes ocamldebug's `-topdirs-path` option because
it becomes useless.