### PR TITLE
Avoid field reload in ephe_get_field

### DIFF
--- a/runtime/weak.c
+++ b/runtime/weak.c
@@ -252,7 +252,6 @@ static value ephe_get_field (value e, mlsize_t offset)
   if (elt == caml_ephe_none) {
     res = Val_none;
   } else {
-    elt = Field(e, offset);
     caml_darken (Caml_state, elt, 0);
     res = caml_alloc_shr (1, Tag_some);
     caml_initialize(&Field(res, 0), elt);

--- a/testsuite/tests/weak-ephe-final/weaktest_par_load.ml
+++ b/testsuite/tests/weak-ephe-final/weaktest_par_load.ml
@@ -1,0 +1,33 @@
+(* TEST *)
+
+(* Testing unsynchronized, parallel Weak usage *)
+
+(* Issue 11749 *)
+let test () =
+  let weak_size = 8 in
+  let t = Weak.create weak_size in
+  let () = Weak.set t 3 (Some 2L) in
+  let wait = Atomic.make true in
+  let d1 =
+    Domain.spawn
+      (fun () ->
+         while Atomic.get wait do Domain.cpu_relax() done; Weak.set t 3 None
+      ) in
+  let d2 =
+    Domain.spawn
+      (fun () ->
+         Atomic.set wait false;
+         let res = Weak.get t 3 in
+         match res with
+         | None
+         | Some 2L -> ()
+         | Some i -> failwith ("received: " ^ (Int64.to_string i))
+      ) in
+  let () = Domain.join d1 in
+  let () = Domain.join d2 in
+  ()
+
+let () =
+  for i = 0 to 100 do
+    test ()
+  done


### PR DESCRIPTION
Consider the following program, performing unsynchronized `Weak.get` and `Weak.set`:
```ocaml
let test () =
  let weak_size = 8 in
  let t = Weak.create weak_size in
  let () = Weak.set t 3 (Some 2L) in
  let wait = Atomic.make true in
  let d1 = Domain.spawn (fun () -> while Atomic.get wait do Domain.cpu_relax() done; Weak.set t 3 None) in
  let d2 = Domain.spawn (fun () -> Atomic.set wait false; let res = Weak.get t 3 in
                          match res with
                          | None
                          | Some 2L -> ()
                          | Some i -> failwith ("received: " ^ (Int64.to_string i))
                        ) in
  let () = Domain.join d1 in
  let () = Domain.join d2 in
  ()

let () =
  for i = 0 to 1000 do
    test ()
  done
```

This can result in weird values being observed:
```
$ ocamlopt weaktest.ml 
$ ./a.out 
Fatal error: exception Failure("received: 94032997501288")
```

The problem is in `ephe_get_field` where we should avoid reloading the field, as it may have been altered in parallel:
https://github.com/ocaml/ocaml/blob/408bba1901a8a2cd29829ab77e7d6f59a5a03533/runtime/weak.c#L244-L256

I'm unsure
- if this requires a Changes entry
- if I should include the test case in the PR

The PR was a tag-team effort with @kayceesrk who cooked up a quick fix after I had found the above test case.