### PR TITLE
Decouple major slice from minor GCs

### DIFF
--- a/Changes
+++ b/Changes
@@ -18,6 +18,10 @@ Working version
 
 ### Runtime system:
 
+- #11750: Decouple major slice from minor GC.
+  (KC Sivaramakrishnan, review by Sadiq Jaffer, Guillaume Munch-Maccagnoni and
+  Damien Doligez)
+
 - #11641: Restore Cygwin port. Add GC messages for address space reservations
   when OCAMLRUNPARAM option v includes 0x1000.
   (David Allsopp, review by Xavier Leroy, Guillaume Munch-Maccagnoni

--- a/runtime/caml/domain_state.tbl
+++ b/runtime/caml/domain_state.tbl
@@ -28,6 +28,9 @@ DOMAIN_STATE(value*, young_start)
 DOMAIN_STATE(value*, young_end)
 /* End of the minor heap. always(young_start <= young_ptr <= young_end) */
 
+DOMAIN_STATE(value*, young_trigger)
+/* Input for setting the young_limit */
+
 DOMAIN_STATE(struct stack_info*, current_stack)
 /* Current stack */
 
@@ -78,6 +81,8 @@ DOMAIN_STATE(intnat, major_work_todo)
  */
 
 DOMAIN_STATE(double, major_gc_clock)
+
+DOMAIN_STATE(uintnat, major_slice_epoch)
 
 DOMAIN_STATE(struct caml__roots_block*, local_roots)
 
@@ -134,7 +139,6 @@ DOMAIN_STATE(struct caml_intern_state*, intern_state)
 DOMAIN_STATE(uintnat, stat_minor_words)
 DOMAIN_STATE(uintnat, stat_promoted_words)
 DOMAIN_STATE(uintnat, stat_major_words)
-DOMAIN_STATE(intnat, stat_minor_collections)
 DOMAIN_STATE(intnat, stat_forced_major_collections)
 DOMAIN_STATE(uintnat, stat_blocks_marked)
 

--- a/runtime/caml/gc_ctrl.h
+++ b/runtime/caml/gc_ctrl.h
@@ -20,9 +20,9 @@
 
 #include "misc.h"
 
-extern uintnat caml_max_stack_wsize;
-extern uintnat caml_fiber_wsz;
-extern uintnat caml_major_cycles_completed;
+CAMLextern uintnat caml_max_stack_wsize;
+CAMLextern uintnat caml_fiber_wsz;
+CAMLextern uintnat caml_major_cycles_completed;
 
 void caml_init_gc (void);
 value caml_gc_stat(value);
@@ -34,7 +34,6 @@ value caml_gc_major(value);
 #define caml_stat_heap_wsz Wsize_bsize(caml_heap_size(Caml_state->shared_heap))
 #define caml_stat_heap_chunks caml_heap_blocks(Caml_state->shared_heap)
 #define caml_stat_major_collections caml_major_cycles_completed
-#define caml_stat_minor_collections Caml_state->stat_minor_collections
 #define caml_stat_promoted_words Caml_state->stat_promoted_words
 #define caml_allocated_words Caml_state->allocated_words
 #define caml_stat_major_words Caml_state->stat_major_words

--- a/runtime/caml/minor_gc.h
+++ b/runtime/caml/minor_gc.h
@@ -39,6 +39,13 @@
   asize_t reserve;             \
 }
 
+/* Count of the total number of minor collections performed by the program */
+CAMLextern atomic_uintnat caml_minor_collections_count;
+
+/* The epoch number for major slice. Used to trigger major slices.
+   Always, [caml_major_slice_epoch <= caml_minor_collections_count] */
+CAMLextern atomic_uintnat caml_major_slice_epoch;
+
 struct caml_ref_table CAML_TABLE_STRUCT(value *);
 
 struct caml_ephe_ref_elt {

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -1500,6 +1500,7 @@ void caml_interrupt_self(void) {
 
 void caml_reset_young_limit(caml_domain_state * dom_st)
 {
+  CAMLassert ((uintnat)dom_st->young_ptr > (uintnat)dom_st->young_trigger);
   /* An interrupt might have been queued in the meanwhile; this
      achieves the proper synchronisation. */
   atomic_exchange(&dom_st->young_limit, (uintnat)dom_st->young_trigger);
@@ -1570,6 +1571,9 @@ void caml_poll_gc_work(void)
       /* We have used half of our minor heap arena. Request a major slice on
          this domain. */
       advance_global_major_slice_epoch (d);
+      /* Advance the [young_trigger] to [young_start] so that the allocation
+         fails when the minor heap is full. */
+      d->young_trigger = d->young_start;
     }
   } else if (d->requested_minor_gc) {
     /* This domain has _not_ used up half of its minor heap arena, but a minor

--- a/runtime/gc_stats.c
+++ b/runtime/gc_stats.c
@@ -15,8 +15,9 @@
 
 #define CAML_INTERNALS
 
-#include "caml/shared_heap.h"
 #include "caml/gc_stats.h"
+#include "caml/minor_gc.h"
+#include "caml/shared_heap.h"
 
 Caml_inline intnat intnat_max(intnat a, intnat b) {
   return (a > b ? a : b);
@@ -64,7 +65,7 @@ void caml_collect_alloc_stats_sample(
   sample->minor_words = local->stat_minor_words;
   sample->promoted_words = local->stat_promoted_words;
   sample->major_words = local->stat_major_words;
-  sample->minor_collections = local->stat_minor_collections;
+  sample->minor_collections = atomic_load(&caml_minor_collections_count);
   sample->forced_major_collections = local->stat_forced_major_collections;
 }
 
@@ -73,7 +74,6 @@ void caml_reset_domain_alloc_stats(caml_domain_state *local)
   local->stat_minor_words = 0;
   local->stat_promoted_words = 0;
   local->stat_major_words = 0;
-  local->stat_minor_collections = 0;
   local->stat_forced_major_collections = 0;
 }
 

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -1453,7 +1453,6 @@ void caml_opportunistic_major_collection_slice(intnat howmuch)
 
 void caml_major_collection_slice(intnat howmuch)
 {
-  caml_domain_state *d = Caml_state;
   uintnat major_slice_epoch = atomic_load (&caml_major_slice_epoch);
 
   /* if this is an auto-triggered GC slice, make it interruptible */
@@ -1468,10 +1467,6 @@ void caml_major_collection_slice(intnat howmuch)
     if (interrupted_work > 0) {
       caml_gc_log("Major slice interrupted, rescheduling major slice");
       caml_request_major_slice();
-    } else {
-      /* Advance the [young_trigger] to [young_start] so that the allocation
-         fails when the minor heap is full. */
-      d->young_trigger = d->young_start;
     }
   } else {
     /* TODO: could make forced API slices interruptible, but would need to do

--- a/testsuite/tests/asmcomp/polling.c
+++ b/testsuite/tests/asmcomp/polling.c
@@ -3,6 +3,8 @@
 #include <caml/mlvalues.h>
 #include <caml/domain_state.h>
 #include <caml/signals.h>
+#include <caml/minor_gc.h>
+#include <caml/camlatomic.h>
 
 CAMLprim value request_minor_gc(value v) {
   Caml_state->requested_minor_gc = 1;
@@ -18,5 +20,5 @@ CAMLprim value request_minor_gc(value v) {
 }
 
 CAMLprim value minor_gcs(value v) {
-  return Val_long(Caml_state->stat_minor_collections);
+  return Val_long(atomic_load(&caml_minor_collections_count));
 }

--- a/testsuite/tests/lib-runtime-events/test.reference
+++ b/testsuite/tests/lib-runtime-events/test.reference
@@ -1,2 +1,2 @@
-minors: 9, majors: 3
-minors: 9, majors: 3
+minors: 9, majors: 0
+minors: 9, majors: 0

--- a/testsuite/tests/lib-runtime-events/test_instrumented.reference
+++ b/testsuite/tests/lib-runtime-events/test_instrumented.reference
@@ -1,1 +1,1 @@
-lost_event_words: 0, total_sizes: 2000003, total_minors: 33
+lost_event_words: 0, total_sizes: 2000003, total_minors: 30


### PR DESCRIPTION
OCaml 4 triggers a major slice when the minor heap is half full. This was shown to improve the responsiveness of programs. Multicore OCaml did not implement this functionality. This PR restores this functionality and extends it to parallel programs. In a parallel program, when one of the domains uses up half of its minor heap arena, it signals other domains to perform a slice of the major GC work.

## Improvement

### Sequential 

A slice of the GC trace (obtained through [`olly`](https://github.com/sadiqj/runtime_events_tools/#olly)) of the [sequential binary trees benchmark](https://github.com/ocaml-bench/sandmark/blob/main/benchmarks/benchmarksgame/binarytrees5.ml) compiled with trunk is shown below:

![image](https://user-images.githubusercontent.com/410484/203781839-7dea9ba0-67eb-44c9-8939-b79214db184b.png)

Observe that the major slice immediately follows the minor collection. 

The trace with this PR is shown below:

![image](https://user-images.githubusercontent.com/410484/203782125-7f93a455-0b4a-4ecc-8ede-26a1fefed9d2.png)

Observe that the major slices are now separated from the minor collection. They're triggered when the minor heap is half-full.

### Parallel

Here is the slice of the trace from the [parallel version of the binary trees benchmark](https://github.com/ocaml-bench/sandmark/blob/main/benchmarks/multicore-numerical/binarytrees5_multicore.ml). The trace with trunk (shown below) again shows that major slice immediately follows the minor collection in the same stop-the-world section. The major slices of the domains except the first one are short and hence hard to see on the trace. I've highlighted them with a red box.

<img align="middle" src="https://user-images.githubusercontent.com/410484/203783731-e8fe578a-c0df-4dfa-827f-dbec870e69fc.png" width="30%"/>

With this PR, the major slices are spaced out between the stop-the-world minor collections:

<img align="middle" src="https://user-images.githubusercontent.com/410484/203785071-8dd59963-14c2-4171-9f00-a1602a18dcb7.png" width="70%"/>

## Performance impact

As a sanity check, I measured the performance impact of this change on sequential programs in Sandmark. Here are the normalised results compared to the `trunk` baseline:

**Time:**
![image](https://user-images.githubusercontent.com/410484/203901005-8bde51b6-31b1-42cb-85c1-5e81393f5e84.png)

**Instructions retired:**
![image](https://user-images.githubusercontent.com/410484/203899506-b6f8f351-a621-42bf-8ed4-531e8cf0cc02.png)

Some swing in the wall clock time is expected. Instructions retired helps place the wall-clock time swings in context. From the normalised instructions retired graph, one can see that most programs execute similar number of instructions. The odd-one-outs are the `lwt` programs towards the right. Two of these can be explained by the increase in the number of major GCs.

**Major GCs:**
![image](https://user-images.githubusercontent.com/410484/203901073-c4b6fb0b-05bb-4d7b-89e4-714952bd8bc5.png)
You can see that the two `lwt` programs end up doing more major GCs than trunk. This may explain additional instructions executed. 

Since we are changing when the major slices are scheduled, some change is expected in the GC speed. I plan to spend a little bit of time understanding why this is more significant in the `lwt` programs than the other ones. That said, I don't expect this to change the PR much. I consider the PR to be ready for review. 

Sandmark nightly is currently down due to a broken dependency. A fix is being actively worked on. I am expecting parallelism results to be available early next week. 