### PR TITLE
topdirs.ml: refactoring the install_printer logic

### DIFF
--- a/testsuite/tests/tool-toplevel/install_printer.compilers.reference
+++ b/testsuite/tests/tool-toplevel/install_printer.compilers.reference
@@ -1,0 +1,13 @@
+type t = A | B
+val print_t : Format.formatter -> t -> unit = <fun>
+type u = C of t
+- : t = ~B
+- : u = C ~B
+type old = OA | OB
+val print_old : old -> unit = <fun>
+- : old list = [Old(A); Old(B)]
+type ('a, 'b) v = D of 'a * 'b
+type 'a printer = Format.formatter -> 'a -> unit
+val print_generic : 'a printer -> 'b printer -> ('a, 'b) v printer = <fun>
+- : (int, t) v list = [D<0, ~A>; D<42, ~B>]
+

--- a/testsuite/tests/tool-toplevel/install_printer.compilers.reference
+++ b/testsuite/tests/tool-toplevel/install_printer.compilers.reference
@@ -6,8 +6,15 @@ type u = C of t
 type old = OA | OB
 val print_old : old -> unit = <fun>
 - : old list = [Old(A); Old(B)]
+- : old list = [OA; OB]
 type ('a, 'b) v = D of 'a * 'b
 type 'a printer = Format.formatter -> 'a -> unit
 val print_generic : 'a printer -> 'b printer -> ('a, 'b) v printer = <fun>
 - : (int, t) v list = [D<0, ~A>; D<42, ~B>]
+Unbound value name_that_does_not_exist.
+List.map has the wrong type for a printing function.
+Unbound value name_that_does_not_exist.
+List.map has the wrong type for a printing function.
+val non_installed_printer : 'a -> unit -> unit = <fun>
+The printer named non_installed_printer is not installed.
 

--- a/testsuite/tests/tool-toplevel/install_printer.ml
+++ b/testsuite/tests/tool-toplevel/install_printer.ml
@@ -28,6 +28,9 @@ let print_old = function
 #install_printer print_old;;
 [OA; OB];;
 
+#remove_printer print_old;;
+[OA; OB];;
+
 
 (* genreic printers *)
 type ('a, 'b) v = D of 'a * 'b;;
@@ -42,3 +45,14 @@ let print_generic (type a b) (pa : a printer) (pb : b printer) : (a, b) v printe
 
 #install_printer print_generic;;
 [D (0, A); D (42, B)];;
+
+
+(* error cases *)
+#install_printer name_that_does_not_exist;;
+#install_printer List.map;;
+
+#remove_printer name_that_does_not_exist;;
+#remove_printer List.map;;
+
+let non_installed_printer ppf () = ();;
+#remove_printer non_installed_printer;;

--- a/testsuite/tests/tool-toplevel/install_printer.ml
+++ b/testsuite/tests/tool-toplevel/install_printer.ml
@@ -1,0 +1,44 @@
+(* TEST
+   * toplevel
+*)
+
+(* simple printer *)
+type t = A | B;;
+
+let print_t out t =
+  Format.fprintf out "%s"
+    (match t with
+     | A -> "~A"
+     | B -> "~B"
+    );;
+
+#install_printer print_t;;
+type u = C of t;;
+B;;
+C B;;
+
+
+(* old-style printer *)
+type old = OA | OB;;
+let print_old = function
+  | OA -> Format.printf "Old(A)"
+  | OB -> Format.printf "Old(B)"
+;;
+
+#install_printer print_old;;
+[OA; OB];;
+
+
+(* genreic printers *)
+type ('a, 'b) v = D of 'a * 'b;;
+
+type 'a printer = Format.formatter -> 'a -> unit;;
+let print_generic (type a b) (pa : a printer) (pb : b printer) : (a, b) v printer =
+  fun ppf (D (a, b)) ->
+  Format.fprintf ppf "D<%a, %a>"
+    pa a
+    pb b
+;;
+
+#install_printer print_generic;;
+[D (0, A); D (42, B)];;

--- a/toplevel/topdirs.ml
+++ b/toplevel/topdirs.ml
@@ -291,8 +291,9 @@ let find_printer ppf lid =
       raise Exit
 
 let dir_install_printer ppf lid =
-  try
-    let (path, kind) = find_printer ppf lid in
+  match find_printer ppf lid with
+  | exception Exit -> ()
+  | (path, kind) ->
     let v = eval_value_path !toplevel_env path in
     match kind with
     | Printer.Old ty_arg ->
@@ -310,17 +311,16 @@ let dir_install_printer ppf lid =
             Succ
               (fun fn -> build ((Obj.obj v : _ -> Obj.t) fn) args) in
        install_generic_printer' path ty_path (build v printer_args_ty)
-  with Exit -> ()
 
 let dir_remove_printer ppf lid =
-  try
-    let (path, _kind) = find_printer ppf lid in
+  match find_printer ppf lid with
+  | exception Exit -> ()
+  | (path, _kind) ->
     begin try
       remove_printer path
     with Not_found ->
       fprintf ppf "No printer named %a.@." Printtyp.longident lid
     end
-  with Exit -> ()
 
 let _ = add_directive "install_printer"
     (Directive_ident (with_error_fmt dir_install_printer))

--- a/toplevel/topdirs.ml
+++ b/toplevel/topdirs.ml
@@ -324,7 +324,7 @@ let remove_installed_printer path =
   | () -> Ok ()
   | exception Not_found ->
     let report ppf =
-      fprintf ppf "No printer named %a.@."
+      fprintf ppf "The printer named %a is not installed.@."
         Printtyp.path path
     in Error report
 


### PR DESCRIPTION
#11745 left the install_printer code in the debugger and the toplevel in a yet-to-improve state, with in particular large amounts of code duplication that we would like to get rid of (and a dubious abstraction boundary for the new topprinters.ml module).

I tried to work on this, but one issue is that the code that is duplicated is unclear in various places. (For example, the code handles the case of "generic old-style printer", but in fact it can never happen and is dead code.)

The present PR is a first step towards working on install_printer factorization, by doing a series of incremental cleanups to the install_printer implementation in topdirs. The new code is hopefully clearer and more self-documenting.

cc @Octachron @shindere @lthls 