### PR TITLE
a more precise "Multicore" changes entry

### DIFF
--- a/Changes
+++ b/Changes
@@ -264,9 +264,13 @@ OCaml 5.0
   Patrick Ferris, Tom Kelly)
 
 - #10831: Multicore OCaml
-  (Tom Kelly, KC Sivaramakrishnan, Stephen Dolan, Enguerrand Decorne,
-   Sadiq Jaffer, Sudha Parimala, David Allsopp, Leo White, the rest of
-   the multicore team, caml-devel and more)
+  (Enguerrand Decorne, Stephen Dolan, Tom Kelly, Sadiq Jaffer,
+  Anil Madhavapeddy, Sudha Parimala, KC Sivaramakrishnan,
+  Leo White, the Tarides multicore team,
+  review by Florian Angeletti, Damien Doligez, Xavier Leroy,
+  Guillaume Munch-Maccagnoni, Olivier Nicole, Nicolás Ojeda Bär,
+  Gabriel Scherer, the OCaml core development team, and many
+  other valued reviewers.)
 
 * #10723: do not use `-flat-namespace` linking for macOS.
   (Carlo Cabrera, review by Damien Doligez)

--- a/Changes
+++ b/Changes
@@ -264,7 +264,9 @@ OCaml 5.0
   Patrick Ferris, Tom Kelly)
 
 - #10831: Multicore OCaml
-  (The multicore team, caml-devel and more)
+  (Tom Kelly, KC Sivaramakrishnan, Stephen Dolan, Enguerrand Decorne,
+   Sadiq Jaffer, Sudha Parimala, David Allsopp, Leo White, the rest of
+   the multicore team, caml-devel and more)
 
 * #10723: do not use `-flat-namespace` linking for macOS.
   (Carlo Cabrera, review by Damien Doligez)

--- a/Changes
+++ b/Changes
@@ -236,6 +236,15 @@ Working version
 OCaml 5.0
 ---------
 
+- #10831: Multicore OCaml
+  (Enguerrand Decorne, Stephen Dolan, Tom Kelly, Sadiq Jaffer,
+  Anil Madhavapeddy, Sudha Parimala, KC Sivaramakrishnan,
+  Leo White, the Tarides multicore team,
+  review by Florian Angeletti, Damien Doligez, Xavier Leroy,
+  Guillaume Munch-Maccagnoni, Olivier Nicole, Nicolás Ojeda Bär,
+  Gabriel Scherer, the OCaml core development team, and many
+  other valued reviewers.)
+
 ### Language features:
 
 ### Runtime system:
@@ -262,15 +271,6 @@ OCaml 5.0
   (Sadiq Jaffer, review by Anil Madhavapeddy, Enguerrand Decorne,
   Richard Warburton, Gabriel Scherer, Sabine Schmaltz, Florian Angeletti,
   Patrick Ferris, Tom Kelly)
-
-- #10831: Multicore OCaml
-  (Enguerrand Decorne, Stephen Dolan, Tom Kelly, Sadiq Jaffer,
-  Anil Madhavapeddy, Sudha Parimala, KC Sivaramakrishnan,
-  Leo White, the Tarides multicore team,
-  review by Florian Angeletti, Damien Doligez, Xavier Leroy,
-  Guillaume Munch-Maccagnoni, Olivier Nicole, Nicolás Ojeda Bär,
-  Gabriel Scherer, the OCaml core development team, and many
-  other valued reviewers.)
 
 * #10723: do not use `-flat-namespace` linking for macOS.
   (Carlo Cabrera, review by Damien Doligez)


### PR DESCRIPTION
This PR changes the Changes entry for Multicore, that is currently very low on the details. Many people worked on Multicore, on writing the code and on reviewing and integrating it in the runtime, the aim of the proposed Change is to reflect the involvement, at least, of the most active contributors on both sides. (My goal is that the Multicore developers are recognized for this work years from now, even those that are less visible and well-known than, say, Stephen and KC.)

(The Changes entry has been discussed with @Octachron and @dra27 first, and then with caml-devel.)