### PR TITLE
removed set but unused variables in yacc/reader.c

### DIFF
--- a/yacc/reader.c
+++ b/yacc/reader.c
@@ -1049,12 +1049,10 @@ void read_declarations(void)
 void output_token_type(void)
 {
   bucket * bp;
-  int n;
 
   fprintf(interface_file, "type token =\n");
   if (!rflag) ++outline;
   fprintf(output_file, "type token =\n");
-  n = 0;
   for (bp = first_symbol; bp; bp = bp->next) {
     if (bp->class == TERM && bp->true_token) {
       fprintf(interface_file, "  | %s", bp->name);
@@ -1068,7 +1066,6 @@ void output_token_type(void)
       fprintf(interface_file, "\n");
       if (!rflag) ++outline;
       fprintf(output_file, "\n");
-      n++;
     }
   }
   fprintf(interface_file, "\n");


### PR DESCRIPTION
removed set but unused variables `int n` in yacc/reader.c