### PR TITLE
Code of Conduct

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -52,7 +52,9 @@ api_docgen/alldoc.tex           typo.missing-header
 tools/mantis2gh_stripped.csv typo.missing-header
 META.in                  typo.missing-header
 
+# Hyperlinks and other markup features cause long lines
 *.adoc                   typo.long-line=may typo.very-long-line=may
+*.md                     typo.long-line=may typo.very-long-line=may
 
 # Github templates and scripts lack headers, have long lines
 /.github/**              typo.missing-header typo.long-line=may typo.very-long-line=may

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,8 +1,8 @@
 # Code of Conduct
 
-This project has adopted the [OCaml Code of Conduct](https://github.com/ocaml/code-of-conduct/CODE_OF_CONDUCT.md).
+This project has adopted the [OCaml Code of Conduct](https://github.com/ocaml/code-of-conduct/blob/main/CODE_OF_CONDUCT.md).
 
 # Enforcement
 
 This project follows the OCaml Code of Conduct
-[enforcement policy](https://github.com/ocaml/code-of-conduct/CODE_OF_CONDUCT.md#enforcement).
+[enforcement policy](https://github.com/ocaml/code-of-conduct/blob/main/CODE_OF_CONDUCT.md#enforcement).

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -4,5 +4,4 @@ This project has adopted the [OCaml Code of Conduct](https://github.com/ocaml/co
 
 # Enforcement
 
-This project follows the OCaml Code of Conduct
-[enforcement policy](https://github.com/ocaml/code-of-conduct/blob/main/CODE_OF_CONDUCT.md#enforcement).
+This project follows the OCaml Code of Conduct [enforcement policy](https://github.com/ocaml/code-of-conduct/blob/main/CODE_OF_CONDUCT.md#enforcement).

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,8 @@
+# Code of Conduct
+
+This project has adopted the [OCaml Code of Conduct](https://github.com/ocaml/code-of-conduct/CODE_OF_CONDUCT.md).
+
+# Enforcement
+
+This project follows the OCaml Code of Conduct
+[enforcement policy](https://github.com/ocaml/code-of-conduct/CODE_OF_CONDUCT.md#enforcement).


### PR DESCRIPTION

This PR proposes to add the OCaml Code of Conduct. Full text is available at https://github.com/ocaml/code-of-conduct, and a discussion around it is at https://discuss.ocaml.org/t/ocaml-community-code-of-conduct/10494.  

We requested feedback from the community on the Code of Conduct, on the discuss forum a couple moths ago. This was not long after this year's OCaml workshop at ICFP where we got to discuss this with some participants who were present. The response has been mostly positive, with some constructive feedback on wordings and such. The text was based off contributor covenant at first. We respect people's inhibitions with using terms such as "pledge" etc. and decided to go with the Coq Code of Conduct. We hope that this is a positive addition to foster an inclusive community.

The text is not immutable, and subject to further changes as the committee sees fit for the OCaml community. For further feedback, please make use of the discuss thread referenced above, or the [issue tracker](https://github.com/ocaml/code-of-conduct/issues) of the `code-of-conduct` repository.

---
Many thanks to the committee members @c-cube, @Khady, @mseri, @pitag-ha and @rjbou for their time and efforts. Thanks to @xavierleroy, @gasche, @avsm and the OCaml Software foundation for their guidance and support. We really appreciate all the thoughtful feedback we've received on the discuss thread and in private. I'm happy to note that everyone put across their points in good faith and with the goal of what's best for the community, even though we may not be in agreement all the time.