### PR TITLE
Don't use old-style unprototyped C functions

### DIFF
--- a/Changes
+++ b/Changes
@@ -21,6 +21,9 @@ Working version
 - #11691, #11706: use __asm__ instead of asm for strict ISO C conformance
   (Xavier Leroy, report by Gregg Reynolds , review by Sadiq Jaffer)
 
+- #11764: add prototypes to old-style C function definitions and declarations
+  (Antonin Décimo, review by Xavier Leroy)
+
 ### Code generation and optimizations:
 
 - #8998, #11321, #11430: change mangling of OCaml long identifiers

--- a/otherlibs/systhreads/st_stubs.c
+++ b/otherlibs/systhreads/st_stubs.c
@@ -223,7 +223,7 @@ static void restore_runtime_state(caml_thread_t th)
 
 CAMLprim value caml_thread_cleanup(value unit);
 
-static void reset_active()
+static void reset_active(void)
 {
   Active_thread = NULL;
   /* If no other OCaml thread remains, ask the tick thread to stop
@@ -550,7 +550,7 @@ static void * caml_thread_start(void * v)
   return 0;
 }
 
-static int create_tick_thread()
+static int create_tick_thread(void)
 {
   int err;
 #ifdef POSIX_SIGNALS

--- a/otherlibs/unix/bind_win32.c
+++ b/otherlibs/unix/bind_win32.c
@@ -17,8 +17,7 @@
 #include "unixsupport.h"
 #include "socketaddr.h"
 
-CAMLprim value caml_unix_bind(socket, address)
-     value socket, address;
+CAMLprim value caml_unix_bind(value socket, value address)
 {
   int ret;
   union sock_addr_union addr;

--- a/otherlibs/unix/connect_win32.c
+++ b/otherlibs/unix/connect_win32.c
@@ -18,8 +18,7 @@
 #include "unixsupport.h"
 #include "socketaddr.h"
 
-CAMLprim value caml_unix_connect(socket, address)
-     value socket, address;
+CAMLprim value caml_unix_connect(value socket, value address)
 {
   SOCKET s = Socket_val(socket);
   union sock_addr_union addr;

--- a/otherlibs/unix/fork.c
+++ b/otherlibs/unix/fork.c
@@ -28,7 +28,7 @@ void caml_atfork_parent(pid_t child_pid) {
 }
 
 /* Post-fork tasks to be carried out in the child */
-void caml_atfork_child() {
+void caml_atfork_child(void) {
   caml_runtime_events_post_fork();
   CAML_EV_LIFECYCLE(EV_FORK_CHILD, 0);
 }

--- a/otherlibs/unix/listen_win32.c
+++ b/otherlibs/unix/listen_win32.c
@@ -16,8 +16,7 @@
 #include <caml/mlvalues.h>
 #include "unixsupport.h"
 
-CAMLprim value caml_unix_listen(sock, backlog)
-     value sock, backlog;
+CAMLprim value caml_unix_listen(value sock, value backlog)
 {
   if (listen(Socket_val(sock), Int_val(backlog)) == -1) {
     caml_win32_maperr(WSAGetLastError());

--- a/otherlibs/unix/nonblock.c
+++ b/otherlibs/unix/nonblock.c
@@ -17,8 +17,7 @@
 #include <caml/signals.h>
 #include "unixsupport.h"
 
-CAMLprim value caml_unix_set_nonblock(socket)
-     value socket;
+CAMLprim value caml_unix_set_nonblock(value socket)
 {
   u_long non_block = 1;
 
@@ -30,8 +29,7 @@ CAMLprim value caml_unix_set_nonblock(socket)
   return Val_unit;
 }
 
-CAMLprim value caml_unix_clear_nonblock(socket)
-     value socket;
+CAMLprim value caml_unix_clear_nonblock(value socket)
 {
   u_long non_block = 0;
 

--- a/otherlibs/unix/shutdown_win32.c
+++ b/otherlibs/unix/shutdown_win32.c
@@ -20,8 +20,7 @@ static int shutdown_command_table[] = {
   0, 1, 2
 };
 
-CAMLprim value caml_unix_shutdown(sock, cmd)
-     value sock, cmd;
+CAMLprim value caml_unix_shutdown(value sock, value cmd)
 {
   if (shutdown(Socket_val(sock),
                shutdown_command_table[Int_val(cmd)]) == -1) {

--- a/otherlibs/unix/sleep_win32.c
+++ b/otherlibs/unix/sleep_win32.c
@@ -17,8 +17,7 @@
 #include <caml/signals.h>
 #include "unixsupport.h"
 
-CAMLprim value caml_unix_sleep(t)
-     value t;
+CAMLprim value caml_unix_sleep(value t)
 {
   double d = Double_val(t);
   caml_enter_blocking_section();

--- a/otherlibs/unix/startup.c
+++ b/otherlibs/unix/startup.c
@@ -22,8 +22,7 @@
 
 value caml_win32_process_id;
 
-CAMLprim value caml_unix_startup(unit)
-     value unit;
+CAMLprim value caml_unix_startup(value unit)
 {
   WSADATA wsaData;
   int i;
@@ -40,8 +39,7 @@ CAMLprim value caml_unix_startup(unit)
   return Val_unit;
 }
 
-CAMLprim value caml_unix_cleanup(unit)
-     value unit;
+CAMLprim value caml_unix_cleanup(value unit)
 {
   caml_win32_worker_cleanup();
 

--- a/otherlibs/unix/symlink_win32.c
+++ b/otherlibs/unix/symlink_win32.c
@@ -36,7 +36,7 @@ static _Atomic DWORD additional_symlink_flags = -1;
 
 // Developer Mode allows the creation of symlinks without elevation - see
 // https://docs.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-createsymboliclinkw
-static BOOL IsDeveloperModeEnabled()
+static BOOL IsDeveloperModeEnabled(void)
 {
   HKEY hKey;
   LSTATUS status;

--- a/otherlibs/unix/system.c
+++ b/otherlibs/unix/system.c
@@ -24,8 +24,7 @@
 #include <process.h>
 #include <stdio.h>
 
-CAMLprim value caml_unix_system(cmd)
-     value cmd;
+CAMLprim value caml_unix_system(value cmd)
 {
   int ret;
   value st;

--- a/runtime/afl.c
+++ b/runtime/afl.c
@@ -67,7 +67,7 @@ static void afl_write(uint32_t msg)
     caml_fatal_error("writing to afl-fuzz");
 }
 
-static uint32_t afl_read()
+static uint32_t afl_read(void)
 {
   uint32_t msg;
   if (read(FORKSRV_FD_READ, &msg, 4) != 4)

--- a/runtime/caml/platform.h
+++ b/runtime/caml/platform.h
@@ -33,7 +33,7 @@
 
 /* Hint for busy-waiting loops */
 
-Caml_inline void cpu_relax() {
+Caml_inline void cpu_relax(void) {
 #ifdef __GNUC__
 #if defined(__x86_64__) || defined(__i386__)
   __asm__ volatile("pause" ::: "memory");

--- a/runtime/caml/runtime_events.h
+++ b/runtime/caml/runtime_events.h
@@ -145,20 +145,20 @@ typedef enum {
 /* Starts runtime_events. Needs to be called before
    [caml_runtime_events_create_cursor]. Needs the runtime lock held to call and
    will trigger a stop-the-world pause. Returns Val_unit. */
-CAMLextern value caml_runtime_events_start();
+CAMLextern value caml_runtime_events_start(void);
 
 /* Pauses runtime_events if not currently paused otherwise does nothing.
    No new events (other than the pause itself) will be written to the ring
    buffer by this domain immediately and all other domains soon. Needs the
    runtime lock held to call as a pause event is written during this call.
    Returns Val_unit. */
-CAMLextern value caml_runtime_events_pause();
+CAMLextern value caml_runtime_events_pause(void);
 
 /* Resumes runtime_events if currently paused otherwise does nothing. New events
    (as well as a resume event) will be written to this domain immediately and
    all other domains soon. Needs the runtime lock held to call as a resume event
    is written during this call. Returns Val_unit. */
-CAMLextern value caml_runtime_events_resume();
+CAMLextern value caml_runtime_events_resume(void);
 
 #ifdef CAML_INTERNALS
 
@@ -208,19 +208,19 @@ struct runtime_events_metadata_header {
 
 /* Set up runtime_events (and check if we need to start it immediately).
    Called from startup* */
-void caml_runtime_events_init();
+void caml_runtime_events_init(void);
 
 /* Destroy all allocated runtime_events structures and clear up the ring.
    Called from [caml_sys_exit] */
-void caml_runtime_events_destroy();
+void caml_runtime_events_destroy(void);
 
 /* Handle safely re-initialising the runtime_events structures
    in a forked child */
-void caml_runtime_events_post_fork();
+void caml_runtime_events_post_fork(void);
 
 /* Returns the location of the runtime_events for the current process if started
    or NULL otherwise */
-CAMLextern char_os* caml_runtime_events_current_location();
+CAMLextern char_os* caml_runtime_events_current_location(void);
 
 /* Functions for putting runtime data on to the runtime_events */
 void caml_ev_begin(ev_runtime_phase phase);
@@ -234,7 +234,7 @@ void caml_ev_lifecycle(ev_lifecycle lifecycle, int64_t data);
    function. Until then the buckets are just updated until flushed.
 */
 void caml_ev_alloc(uint64_t sz);
-void caml_ev_alloc_flush();
+void caml_ev_alloc_flush(void);
 
 #endif /* CAML_INTERNALS */
 

--- a/runtime/caml/signals.h
+++ b/runtime/caml/signals.h
@@ -74,8 +74,8 @@ value caml_process_pending_actions_with_root (value extra_root); // raises
 value caml_process_pending_actions_with_root_exn (value extra_root);
 
 void caml_init_signal_handling(void);
-void caml_init_signals();
-void caml_terminate_signals();
+void caml_init_signals(void);
+void caml_terminate_signals(void);
 CAMLextern void * caml_init_signal_stack(void);
 CAMLextern void caml_free_signal_stack(void *);
 

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -274,7 +274,7 @@ static void remove_from_stw_domains(dom_internal* dom) {
   stw_domains.domains[stw_domains.participating_domains] = dom;
 }
 
-static dom_internal* next_free_domain() {
+static dom_internal* next_free_domain(void) {
   if (stw_domains.participating_domains == Max_domains)
     return NULL;
 
@@ -411,7 +411,7 @@ asize_t caml_norm_minor_heap_size (intnat wsize)
   domain, so they need no synchronization.
 */
 
-Caml_inline void check_minor_heap() {
+Caml_inline void check_minor_heap(void) {
   caml_domain_state* domain_state = Caml_state;
   CAMLassert(domain_state->young_ptr == domain_state->young_end);
 
@@ -433,7 +433,7 @@ Caml_inline void check_minor_heap() {
       && domain_state->young_end <= (value*)domain_self->minor_heap_area_end));
 }
 
-static void free_minor_heap() {
+static void free_minor_heap(void) {
   caml_domain_state* domain_state = Caml_state;
 
   caml_gc_log ("trying to free old minor heap: %"
@@ -712,7 +712,7 @@ CAMLexport void caml_reset_domain_lock(void)
 
 /* minor heap initialization and resizing */
 
-static void reserve_minor_heaps() {
+static void reserve_minor_heaps(void) {
   void* heaps_base;
   uintnat minor_heap_reservation_bsize;
   uintnat minor_heap_max_bsz;
@@ -749,7 +749,7 @@ static void reserve_minor_heaps() {
   }
 }
 
-static void unreserve_minor_heaps() {
+static void unreserve_minor_heaps(void) {
   uintnat size;
 
   caml_gc_log("unreserve_minor_heaps");
@@ -1046,7 +1046,7 @@ CAMLexport void (*caml_domain_external_interrupt_hook)(void) =
 CAMLexport _Atomic caml_timing_hook caml_domain_terminated_hook =
   (caml_timing_hook)NULL;
 
-static void domain_terminate();
+static void domain_terminate(void);
 
 static void* domain_thread_func(void* v)
 {

--- a/runtime/fail_nat.c
+++ b/runtime/fail_nat.c
@@ -194,7 +194,7 @@ CAMLexport value caml_raise_if_exception(value res)
 /* We use a pre-allocated exception because we can't
    do a GC before the exception is raised (lack of stack descriptors
    for the ccall to [caml_array_bound_error]).  */
-static value array_bound_exn()
+static value array_bound_exn(void)
 {
   static atomic_uintnat exn_cache = ATOMIC_UINTNAT_INIT(0);
   const value* exn = (const value*)atomic_load_acq(&exn_cache);

--- a/runtime/fix_code.c
+++ b/runtime/fix_code.c
@@ -159,7 +159,7 @@ void caml_thread_code (code_t code, asize_t len)
 
 #else
 
-int* caml_init_opcode_nargs()
+int* caml_init_opcode_nargs(void)
 {
   return NULL;
 }

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -112,7 +112,7 @@ static struct ephe_cycle_info_t {
  * the lock. */
 static caml_plat_mutex ephe_lock = CAML_PLAT_MUTEX_INITIALIZER;
 
-static void ephe_next_cycle ()
+static void ephe_next_cycle (void)
 {
   caml_plat_lock(&ephe_lock);
   atomic_fetch_add(&ephe_cycle_info.ephe_cycle, +1);
@@ -360,7 +360,7 @@ double caml_mean_space_overhead (void)
   return mean;
 }
 
-static void update_major_slice_work() {
+static void update_major_slice_work(void) {
   double p, dp, heap_words;
   intnat computed_work;
   caml_domain_state *dom_st = Caml_state;
@@ -1128,7 +1128,7 @@ static void cycle_all_domains_callback(caml_domain_state* domain, void* unused,
   CAML_EV_END(EV_MAJOR_GC_CYCLE_DOMAINS);
 }
 
-static int is_complete_phase_sweep_and_mark_main ()
+static int is_complete_phase_sweep_and_mark_main (void)
 {
   return
     caml_gc_phase == Phase_sweep_and_mark_main &&
@@ -1142,7 +1142,7 @@ static int is_complete_phase_sweep_and_mark_main ()
     /* All orphaned ephemerons have been adopted */
 }
 
-static int is_complete_phase_mark_final ()
+static int is_complete_phase_mark_final (void)
 {
   return
     caml_gc_phase == Phase_mark_final &&
@@ -1157,7 +1157,7 @@ static int is_complete_phase_mark_final ()
     /* All orphaned ephemerons have been adopted */
 }
 
-static int is_complete_phase_sweep_ephe ()
+static int is_complete_phase_sweep_ephe (void)
 {
   return
     caml_gc_phase == Phase_sweep_ephe &&

--- a/runtime/parsing.c
+++ b/runtime/parsing.c
@@ -137,7 +137,7 @@ static void print_token(struct parser_tables *tables, int state, value tok)
   }
 }
 
-static int trace()
+static int trace(void)
 {
   return caml_params->parser_trace || Caml_state->parser_trace;
 }

--- a/testsuite/tests/asmgen/main.c
+++ b/testsuite/tests/asmgen/main.c
@@ -20,11 +20,11 @@
 
 /* This stub isn't needed for msvc32, since it's already in asmgen_i386nt.asm */
 #if !defined(_MSC_VER) || !defined(_M_IX86)
-void caml_call_gc()
+void caml_call_gc(void)
 {
 
 }
-void caml_call_realloc_stack()
+void caml_call_realloc_stack(void)
 {
 
 };

--- a/testsuite/tests/asmgen/mainarith.c
+++ b/testsuite/tests/asmgen/mainarith.c
@@ -22,7 +22,7 @@
 #include <caml/config.h>
 #define FMT ARCH_INTNAT_PRINTF_FORMAT
 
-void caml_call_poll()
+void caml_call_poll(void)
 {
 }
 


### PR DESCRIPTION
Fixes strict-prototypes and old-style-definition warnings. As a reminder, `f()` declares `f` as an old-style function that can be applied to any number of arguments.

Subsumes and closes #11762.

Note: I've just noticed that I haven't enabled the warnings on mingw, so I haven't checked the prototypes on Windows only code yet.