### PR TITLE
Use a more relaxed mode for unification in `Ctype.subst`

### DIFF
--- a/Changes
+++ b/Changes
@@ -356,6 +356,9 @@ Working version
 - #11732: Ensure that types from packed modules are always generalised
   (Stephen Dolan and Leo White, review by Jacques Garrigue)
 
+- #11771: Use a more relaxed mode for unification in Ctype.subst
+  (Leo White, review by Jacques Garrigue and Gabriel Scherer)
+
 - #11776: Extend environment with functor parameters in `strengthen_lazy`.
   (Chris Casinghino and Luke Maurer, review by Gabriel Scherer)
 

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -238,31 +238,73 @@ let none = newty (Ttuple [])                (* Clearly ill-formed type *)
 
 (**** unification mode ****)
 
-type unification_mode =
-  | Expression (* unification in expression *)
-  | Pattern (* unification in pattern which may add local constraints *)
-
 type equations_generation =
   | Forbidden
   | Allowed of { equated_types : TypePairs.t }
 
+type unification_mode =
+  | Expression (* unification in expression *)
+  | Pattern of
+      { equations_generation : equations_generation;
+        assume_injective : bool;
+        allow_recursive_equations : bool; }
+    (* unification in pattern which may add local constraints *)
+
 let umode = ref Expression
-let equations_generation = ref Forbidden
-let assume_injective = ref false
-let allow_recursive_equation = ref false
+
+let in_pattern_mode () =
+  match !umode with
+  | Expression -> false
+  | Pattern _ -> true
 
 let can_generate_equations () =
-  match !equations_generation with
-  | Forbidden -> false
-  | _ -> true
+  match !umode with
+  | Expression | Pattern { equations_generation = Forbidden } -> false
+  | Pattern { equations_generation = Allowed _ } -> true
 
-let set_mode_pattern ~generate ~injective ~allow_recursive f =
-  Misc.protect_refs
-    [ Misc.R (umode, Pattern);
-      Misc.R (equations_generation, generate);
-      Misc.R (assume_injective, injective);
-      Misc.R (allow_recursive_equation, allow_recursive);
-    ] f
+(* Can only be called when generate_equations is true *)
+let record_equation t1 t2 =
+  match !umode with
+  | Expression | Pattern { equations_generation = Forbidden } ->
+      assert false
+  | Pattern { equations_generation = Allowed { equated_types } } ->
+      TypePairs.add equated_types (t1, t2)
+
+let can_assume_injective () =
+  match !umode with
+  | Expression -> false
+  | Pattern { assume_injective } -> assume_injective
+
+let allow_recursive_equations () =
+  !Clflags.recursive_types
+  || match !umode with
+     | Expression -> false
+     | Pattern { allow_recursive_equations } -> allow_recursive_equations
+
+let set_mode_pattern ~allow_recursive_equations ~equated_types f =
+  let equations_generation = Allowed { equated_types } in
+  let assume_injective = true in
+  let new_umode =
+    Pattern
+      { equations_generation;
+        assume_injective;
+        allow_recursive_equations }
+  in
+  Misc.protect_refs [ Misc.R (umode, new_umode) ] f
+
+let without_assume_injective f =
+  match !umode with
+  | Expression -> f ()
+  | Pattern r ->
+      let new_umode = Pattern { r with assume_injective = false } in
+      Misc.protect_refs [ Misc.R (umode, new_umode) ] f
+
+let without_generating_equations f =
+  match !umode with
+  | Expression -> f ()
+  | Pattern r ->
+    let new_umode = Pattern { r with equations_generation = Forbidden } in
+    Misc.protect_refs [ Misc.R (umode, new_umode) ] f
 
 (*** Checks for type definitions ***)
 
@@ -1743,8 +1785,7 @@ let type_changed = ref false (* trace possible changes to the studied type *)
 let merge r b = if b then r := true
 
 let occur env ty0 ty =
-  let allow_recursive =
-    !Clflags.recursive_types || !umode = Pattern && !allow_recursive_equation in
+  let allow_recursive = allow_recursive_equations () in
   let old = !type_changed in
   try
     while
@@ -1804,8 +1845,7 @@ let rec local_non_recursive_abbrev ~allow_rec strict visited env p ty =
   end
 
 let local_non_recursive_abbrev env p ty =
-  let allow_rec =
-    !Clflags.recursive_types || !umode = Pattern && !allow_recursive_equation in
+  let allow_rec = allow_recursive_equations () in
   try (* PR#7397: need to check trace_gadt_instances *)
     wrap_trace_gadt_instances env
       (local_non_recursive_abbrev ~allow_rec false [] env p) ty;
@@ -2502,11 +2542,9 @@ let unify_package env unify_list lv1 p1 fl1 lv2 p2 fl2 =
 let rigid_variants = ref false
 
 let unify_eq t1 t2 =
-  eq_type t1 t2 ||
-  match !umode with
-  | Expression -> false
-  | Pattern ->
-      TypePairs.mem unify_eq_set (order_type_pair t1 t2)
+  eq_type t1 t2
+  || (in_pattern_mode ()
+      && TypePairs.mem unify_eq_set (order_type_pair t1 t2))
 
 let unify1_var env t1 t2 =
   assert (is_Tvar t1);
@@ -2522,22 +2560,15 @@ let unify1_var env t1 t2 =
       end;
       link_type t1 t2;
       true
-  | exception Unify_trace _ when !umode = Pattern ->
+  | exception Unify_trace _ when in_pattern_mode () ->
       false
-
-(* Can only be called when generate_equations is true *)
-let record_equation t1 t2 =
-  match !equations_generation with
-  | Forbidden -> assert false
-  | Allowed { equated_types } ->
-      TypePairs.add equated_types (t1, t2)
 
 (* Called from unify3 *)
 let unify3_var env t1' t2 t2' =
   occur_for Unify !env t1' t2;
   match occur_univar_for Unify !env t2 with
   | () -> link_type t1' t2
-  | exception Unify_trace _ when !umode = Pattern ->
+  | exception Unify_trace _ when in_pattern_mode () ->
       reify env t1';
       reify env t2';
       if can_generate_equations () then begin
@@ -2680,17 +2711,16 @@ and unify3 env t1 t1' t2 t2' =
   | (Tfield _, Tfield _) -> (* special case for GADTs *)
       unify_fields env t1' t2'
   | _ ->
-    begin match !umode with
-    | Expression ->
-        occur_for Unify !env t1' t2;
-        link_type t1' t2
-    | Pattern ->
-        add_type_equality t1' t2'
+    if in_pattern_mode () then
+      add_type_equality t1' t2'
+    else begin
+      occur_for Unify !env t1' t2;
+      link_type t1' t2
     end;
     try
       begin match (d1, d2) with
         (Tarrow (l1, t1, u1, c1), Tarrow (l2, t2, u2, c2)) when l1 = l2 ||
-        (!Clflags.classic || !umode = Pattern) &&
+        (!Clflags.classic || in_pattern_mode ()) &&
         not (is_optional l1 || is_optional l2) ->
           unify  env t1 t2; unify env  u1 u2;
           begin match is_commu_ok c1, is_commu_ok c2 with
@@ -2702,12 +2732,10 @@ and unify3 env t1 t1' t2 t2' =
       | (Ttuple tl1, Ttuple tl2) ->
           unify_list env tl1 tl2
       | (Tconstr (p1, tl1, _), Tconstr (p2, tl2, _)) when Path.same p1 p2 ->
-          if !umode = Expression || !equations_generation = Forbidden then
+          if not (can_generate_equations ()) then
             unify_list env tl1 tl2
-          else if !assume_injective then
-            set_mode_pattern ~generate:!equations_generation ~injective:false
-              ~allow_recursive:!allow_recursive_equation
-              (fun () -> unify_list env tl1 tl2)
+          else if can_assume_injective () then
+            without_assume_injective (fun () -> unify_list env tl1 tl2)
           else if in_current_module p1 (* || in_pervasives p1 *)
                || List.exists (expands_to_datatype !env) [t1'; t1; t2]
           then
@@ -2721,8 +2749,7 @@ and unify3 env t1 t1' t2 t2' =
             List.iter2
               (fun i (t1, t2) ->
                 if i then unify env t1 t2 else
-                set_mode_pattern ~generate:Forbidden ~injective:false
-                  ~allow_recursive:!allow_recursive_equation
+                without_generating_equations
                   begin fun () ->
                     let snap = snapshot () in
                     try unify env t1 t2 with Unify_trace _ ->
@@ -2752,7 +2779,7 @@ and unify3 env t1 t1' t2 t2' =
           reify env t1';
           record_equation t1' t2';
           add_gadt_equation env path t1'
-      | (Tconstr (_,_,_), _) | (_, Tconstr (_,_,_)) when !umode = Pattern ->
+      | (Tconstr (_,_,_), _) | (_, Tconstr (_,_,_)) when in_pattern_mode () ->
           reify env t1';
           reify env t2';
           if can_generate_equations () then (
@@ -2771,7 +2798,7 @@ and unify3 env t1 t1' t2 t2' =
           | _ -> ()
           end
       | (Tvariant row1, Tvariant row2) ->
-          if !umode = Expression then
+          if not (in_pattern_mode ()) then
             unify_row env row1 row2
           else begin
             let snap = snapshot () in
@@ -2810,7 +2837,7 @@ and unify3 env t1 t1' t2 t2' =
             unify_package !env (unify_list env)
               (get_level t1) p1 fl1 (get_level t2) p2 fl2
           with Not_found ->
-            if !umode = Expression then raise_unexplained_for Unify;
+            if not (in_pattern_mode ()) then raise_unexplained_for Unify;
             List.iter (fun (_n, ty) -> reify env ty) (fl1 @ fl2);
             (* if !generate_equations then List.iter2 (mcomp !env) tl1 tl2 *)
           end
@@ -3104,15 +3131,13 @@ let unify env ty1 ty2 =
       undo_compress snap;
       raise (Unify (expand_to_unification_error !env trace))
 
-let unify_gadt ~equations_level:lev ~allow_recursive (env:Env.t ref) ty1 ty2 =
+let unify_gadt ~equations_level:lev ~allow_recursive_equations
+      (env:Env.t ref) ty1 ty2 =
   try
     univar_pairs := [];
     gadt_equations_level := Some lev;
     let equated_types = TypePairs.create 0 in
-    set_mode_pattern
-      ~generate:(Allowed { equated_types })
-      ~injective:true
-      ~allow_recursive
+    set_mode_pattern ~allow_recursive_equations ~equated_types
       (fun () -> unify env ty1 ty2);
     gadt_equations_level := None;
     TypePairs.clear unify_eq_set;

--- a/typing/ctype.mli
+++ b/typing/ctype.mli
@@ -227,7 +227,7 @@ val extract_concrete_typedecl:
 val unify: Env.t -> type_expr -> type_expr -> unit
         (* Unify the two types given. Raise [Unify] if not possible. *)
 val unify_gadt:
-        equations_level:int -> allow_recursive:bool ->
+        equations_level:int -> allow_recursive_equations:bool ->
         Env.t ref -> type_expr -> type_expr -> Btype.TypePairs.t
         (* Unify the two types given and update the environment with the
            local constraints. Raise [Unify] if not possible.

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -367,9 +367,9 @@ let nothing_equated = TypePairs.create 0
 let unify_pat_types_return_equated_pairs ?(refine = None) loc env ty ty' =
   try
     match refine with
-    | Some allow_recursive ->
+    | Some allow_recursive_equations ->
         unify_gadt ~equations_level:(get_gadt_equations_level ())
-          ~allow_recursive env ty ty'
+          ~allow_recursive_equations env ty ty'
     | None ->
         unify !env ty ty';
         nothing_equated


### PR DESCRIPTION
When expanding a type constructor we need to unify the arguments to the constructor with it's parameters. This unification is needed because of constrained parameters. When doing unification inside a GADT match we treat object types and polymorphic variant types more strictly -- forcing the levels of the methods and constructors to be at most the level of the row. I'm not actually sure why that is needed, but it's clearly deliberate.

The combination of these things means that, given the following definitions:
```ocaml
type foo = Foo
type bar = Bar

type _ tag =
  | Foo_tag : foo tag
  | Bar_tag : bar tag

type ('a, 'self) obj =
  < foo : foo -> 'a ; bar : bar -> 'a; .. > as 'self
```
the following code gives an error:
```ocaml
let test_obj_with_expansion :
  type a b. a tag -> (b, _) obj -> a -> b =
    fun t obj x ->
      match t with
      | Foo_tag -> obj#foo x
      | Bar_tag -> obj#bar x
```
whilst if we expand out the definition of `obj` it doesn't:
```ocaml
let test_obj_no_expansion :
  type a b. a tag -> < foo : foo -> b ; bar : bar -> b; .. > -> a -> b =
    fun t obj x ->
      match t with
      | Foo_tag -> obj#foo x
      | Bar_tag -> obj#bar x
```

The fix implemented in this PR is to add a third unification mode for the unifications done as part of `subst`. In this mode we never use the strict treatment of object or polymorphic variant types. This is fine because the unifications done in subst should be between a fresh instance of the parameters of the type constructor and another type that is also an instance of those parameters: it's only effect should be for some fresh type variables to get unified with some existing types.

I've always thought it suspicious that the `subst` unifications were done in the same mode as the surrounding unification -- we shouldn't be adding equations during type expansion -- so this PR also makes that aspect more clearly correct.

I took the opportunity to also refactor the handling of the unification modes, which is done in the first commit.