### PR TITLE
ocamlyacc: Fix lexing of raw string literals

### DIFF
--- a/Changes
+++ b/Changes
@@ -117,6 +117,9 @@ Working version
 
 ### Tools:
 
+- #1172: fix ocamlyacc's handling of raw string literals
+  (Demi Marie Obenour)
+
 - #9290: Add a directive to switch off debugging in toplevel.
   This allows to see optimized bytecode with -dlambda.
   (Jacques Garrigue, review by Gabriel Scherer)

--- a/testsuite/tests/tool-lexyacc/parsecheck.mly
+++ b/testsuite/tests/tool-lexyacc/parsecheck.mly
@@ -1,0 +1,14 @@
+/* TEST
+   ocamlyacc_flags = " -q --strict "
+*/
+%token <unit> SIMPLE
+%type <unit> silly
+%start silly
+%%
+silly : SIMPLE {
+            (* {A|  *)
+            (* {a| *) } } }  |a} *)
+            (* {%%A.ba| *) } } }  |} *)
+    $1
+    }
+;

--- a/yacc/reader.c
+++ b/yacc/reader.c
@@ -320,7 +320,6 @@ static void process_open_curly_bracket(FILE *f) {
                     size_t i;
                     for (i = 0; i <= size; ++i) {
                         if (cptr[i] != buf[i]) {
-                            newcptr--;
                             match = 0;
                             break;
                         }

--- a/yacc/reader.c
+++ b/yacc/reader.c
@@ -16,6 +16,7 @@
 /* Based on public-domain code from Berkeley Yacc */
 
 #include <string.h>
+#include <stdbool.h>
 #include "defs.h"
 
 /*  The line size must be a positive integer.  One hundred was chosen      */
@@ -259,6 +260,9 @@ void process_apostrophe_body(FILE *f)
     }
 }
 
+static bool is_ocaml_ident_start_char(char p) {
+    return p == '_' || (p >= 'a' && p <= 'z');
+}
 
 static void process_open_curly_bracket(FILE *f) {
     char *idcptr = cptr;
@@ -282,12 +286,12 @@ static void process_open_curly_bracket(FILE *f) {
         }
     }
 
-    if (In_bitmap(caml_ident_start, *idcptr) || *idcptr == '|')
+    if (is_ocaml_ident_start_char(*idcptr) || *idcptr == '|')
     {
         char *newcptr = idcptr;
         size_t size = 0;
         char *buf;
-        while(In_bitmap(caml_ident_body, *newcptr)) { newcptr++; }
+        while (is_ocaml_ident_start_char(*newcptr)) { newcptr++; }
         if (*newcptr == '|')
         { /* Raw string */
             int s_lineno;


### PR DESCRIPTION
OCaml requires the delimiter of a raw string literal to be lowercase ASCII, not merely bytes valid in an identifier.

Also check this in the test suite.