### PR TITLE
Unix.write on Windows: return normally after data has been written on non-blocking socket

### DIFF
--- a/Changes
+++ b/Changes
@@ -115,6 +115,12 @@ Working version
 - #11475: Make Unix terminal interface bindings domain-safe
   (Olivier Nicole and Xavier Leroy, review by Xavier Leroy)
 
+- #11775: Unix.write on a non-blocking socket under Windows will return normally
+  if the write blocks after some data has already been written (as otherwise
+  there is no way of knowing how much data has been written before
+  blocking). The same behaviour was already present under Unix.
+  (Nicolás Ojeda Bär)
+
 ### Tools:
 
 - #9290: Add a directive to switch off debugging in toplevel.

--- a/Changes
+++ b/Changes
@@ -119,7 +119,7 @@ Working version
   if the write blocks after some data has already been written (as otherwise
   there is no way of knowing how much data has been written before
   blocking). The same behaviour was already present under Unix.
-  (Nicolás Ojeda Bär)
+  (Nicolás Ojeda Bär, review by David Allsopp)
 
 ### Tools:
 

--- a/otherlibs/unix/write_win32.c
+++ b/otherlibs/unix/write_win32.c
@@ -39,11 +39,9 @@ CAMLprim value caml_unix_write(value fd, value buf, value vofs, value vlen)
       SOCKET s = Socket_val(fd);
       caml_enter_blocking_section();
       ret = send(s, iobuf, numbytes, 0);
+      if (ret == SOCKET_ERROR) err = WSAGetLastError();
       caml_leave_blocking_section();
-      if (ret == SOCKET_ERROR) {
-        err = WSAGetLastError();
-        if (err == WSAEWOULDBLOCK && written > 0) break;
-      }
+      if (ret == SOCKET_ERROR && err == WSAEWOULDBLOCK && written > 0) break;
       numwritten = ret;
     } else {
       HANDLE h = Handle_val(fd);

--- a/otherlibs/unix/write_win32.c
+++ b/otherlibs/unix/write_win32.c
@@ -39,8 +39,11 @@ CAMLprim value caml_unix_write(value fd, value buf, value vofs, value vlen)
       SOCKET s = Socket_val(fd);
       caml_enter_blocking_section();
       ret = send(s, iobuf, numbytes, 0);
-      if (ret == SOCKET_ERROR) err = WSAGetLastError();
       caml_leave_blocking_section();
+      if (ret == SOCKET_ERROR) {
+        err = WSAGetLastError();
+        if (err == WSAEWOULDBLOCK && written > 0) break;
+      }
       numwritten = ret;
     } else {
       HANDLE h = Handle_val(fd);


### PR DESCRIPTION
When using `Unix.write` on a socket, it is impossible to know how much data has actually been written in case an exception is raised (and this is documented). However, in the case of writing to a non-blocking socket, exceptions are also used to signal that the socket has blocked, in which case it is impossible to know how much data has been written before blocking. The solution is to use `Unix.single_write`.

However, the `unix` version of `Unix.write` contains special logic to return normally if the file descriptor becomes blocked after some data has been written:

https://github.com/ocaml/ocaml/blob/6978b365cd2bedd989fb5a735c9326d3448d20f8/otherlibs/unix/write_unix.c#L47

 I propose to add simiar logic to the `win32` version.