### PR TITLE
Fix bug in `Mtype.strengthen_lazy` causing spurious typing errors

### DIFF
--- a/Changes
+++ b/Changes
@@ -239,6 +239,9 @@ Working version
 - #11732: Ensure that types from packed modules are always generalised
   (Stephen Dolan and Leo White, review by Jacques Garrigue)
 
+- #11776: Extend environment with functor parameters in `strengthen_lazy`.
+  (Chris Casinghino and Luke Maurer, review by ???)
+
 OCaml 5.0
 ---------
 

--- a/Changes
+++ b/Changes
@@ -240,7 +240,7 @@ Working version
   (Stephen Dolan and Leo White, review by Jacques Garrigue)
 
 - #11776: Extend environment with functor parameters in `strengthen_lazy`.
-  (Chris Casinghino and Luke Maurer, review by ???)
+  (Chris Casinghino and Luke Maurer, review by Gabriel Scherer)
 
 OCaml 5.0
 ---------

--- a/typing/env.ml
+++ b/typing/env.ml
@@ -2200,6 +2200,14 @@ and add_cltype ?shape id ty env =
 let add_module ?arg ?shape id presence mty env =
   add_module_declaration ~check:false ?arg ?shape id presence (md mty) env
 
+let add_module_lazy ~update_summary id presence mty env =
+  let md = Subst.Lazy.{mdl_type = mty;
+                       mdl_attributes = [];
+                       mdl_loc = Location.none;
+                       mdl_uid = Uid.internal_not_actually_unique}
+  in
+  add_module_declaration_lazy ~update_summary id presence md env
+
 let add_local_type path info env =
   { env with
     local_constraints = Path.Map.add path info env.local_constraints }

--- a/typing/env.mli
+++ b/typing/env.mli
@@ -287,6 +287,8 @@ val add_extension:
   check:bool -> rebind:bool -> Ident.t -> extension_constructor -> t -> t
 val add_module: ?arg:bool -> ?shape:Shape.t ->
   Ident.t -> module_presence -> module_type -> t -> t
+val add_module_lazy: update_summary:bool ->
+  Ident.t -> module_presence -> Subst.Lazy.modtype -> t -> t
 val add_module_declaration: ?arg:bool -> ?shape:Shape.t -> check:bool ->
   Ident.t -> module_presence -> module_declaration -> t -> t
 val add_module_declaration_lazy: update_summary:bool ->

--- a/typing/mtype.ml
+++ b/typing/mtype.ml
@@ -46,6 +46,9 @@ let rec strengthen_lazy ~aliasable env mty p =
       MtyL_signature(strengthen_lazy_sig ~aliasable env sg p)
   | MtyL_functor(Named (Some param, arg), res)
     when !Clflags.applicative_functors ->
+      let env =
+        Env.add_module_lazy ~update_summary:false param Mp_present arg env
+      in
       MtyL_functor(Named (Some param, arg),
         strengthen_lazy ~aliasable:false env res (Papply(p, Pident param)))
   | MtyL_functor(Named (None, arg), res)


### PR DESCRIPTION
This fixes a bug in `strengthen_lazy`.  

The bug is that, when recursing on the result type of a functor with a named parameter, `strengthen_lazy` didn't add this parameter to the environment.  In most cases this doesn't matter, but the added test case shows a program that 4.14 rejects incorrectly as a result:

```ocaml
module M1 (Arg : sig end) = struct
  module type S1 = sig
    type t
  end
end

module type S2 = sig
  module Make (Arg : sig end) : M1(Arg).S1
end

module M2 : S2 = struct
  module Make (Arg : sig end) = struct
    type t = T
  end
end

module M3 (Arg : sig end) = struct
  module type S3 = sig
    type t = M2.Make(Arg).t
  end
end

module M4 (Arg : sig end) : M3(Arg).S3 = struct
  module M5 = M2.Make (Arg)

  type t = M5.t
end
```

Here, `M5` is given a less precise type than it could be, because a `Not_found` exception is raised during strengthening due to the module that's missing from the env.  As a result, `t`'s type is also less precise (losing the connection to `M2` that would have come from strengthening), and the module inclusion comparing `M4`'s body to its result type fails (incorrectly).

In this case, the `Not_found` exception is raised by the shape computation in `components_of_functor_appl`, which expects to be able to compute the shape of a functor argument.  So this program fails on 4.14 but checks on 4.12, before the shape system was added.  But I don't think the bug is actually related to the shape system, and suspect it could be triggered pre-shapes by a more complex example.

Credit to @lukemaurer for noticing the bug and constructing the test case.