### PR TITLE
minor code cleanup from multicore merge comments

### DIFF
--- a/runtime/meta.c
+++ b/runtime/meta.c
@@ -156,9 +156,8 @@ CAMLprim value caml_static_release_bytecode(value bc)
 
 CAMLprim value caml_realloc_global(value size)
 {
-  CAMLparam1(size);
-  CAMLlocal2(old_global_data, new_global_data);
   mlsize_t requested_size, actual_size, i;
+  value new_global_data, old_global_data;
   old_global_data = caml_global_data;
 
   requested_size = Long_val(size);
@@ -176,7 +175,7 @@ CAMLprim value caml_realloc_global(value size)
     }
     caml_modify_generational_global_root(&caml_global_data, new_global_data);
   }
-  CAMLreturn (Val_unit);
+  return Val_unit;
 }
 
 CAMLprim value caml_get_current_environment(value unit)

--- a/stdlib/obj.ml
+++ b/stdlib/obj.ml
@@ -29,9 +29,6 @@ external size : t -> int = "%obj_size"
 external reachable_words : t -> int = "caml_obj_reachable_words"
 external field : t -> int -> t = "%obj_field"
 external set_field : t -> int -> t -> unit = "%obj_set_field"
-external compare_and_swap_field : t -> int -> t -> t -> bool
-  = "caml_obj_compare_and_swap"
-external is_shared : t -> bool = "caml_obj_is_shared"
 external floatarray_get : floatarray -> int -> float = "caml_floatarray_get"
 external floatarray_set :
     floatarray -> int -> float -> unit = "caml_floatarray_set"

--- a/stdlib/obj.mli
+++ b/stdlib/obj.mli
@@ -53,9 +53,6 @@ external field : t -> int -> t = "%obj_field"
     be propagated.
 *)
 external set_field : t -> int -> t -> unit = "%obj_set_field"
-external compare_and_swap_field : t -> int -> t -> t -> bool
-  = "caml_obj_compare_and_swap"
-external is_shared : t -> bool = "caml_obj_is_shared"
 
 val [@inline always] double_field : t -> int -> float  (* @since 3.11.2 *)
 val [@inline always] set_double_field : t -> int -> float -> unit

--- a/testsuite/tests/lazy/minor_major_force.ml
+++ b/testsuite/tests/lazy/minor_major_force.ml
@@ -15,7 +15,8 @@ type test_record = {
   mutable lzy_int: int Lazy.t;
 }
 
-let is_shared x = Obj.is_shared (Obj.repr x)
+
+external is_shared : 'a -> bool = "caml_obj_is_shared"
 
 let glbl_int = ref 0
 let glbl_string = ref "init"


### PR DESCRIPTION
This PR implements two minor cleanup proposed in #10861 that seemed too small to require either new issues or separate PRs:

- `caml_realloc_global` is simplified since there are no read barriers
- `Obj.is_shared` and `Obj.compare_and_swap_field` are removed from the `Obj` module

(Note that I am not proposing to backport the changes to 5.0)
