### PR TITLE
documentation: comment on heap allocation on Linux

### DIFF
--- a/runtime/platform.c
+++ b/runtime/platform.c
@@ -250,12 +250,9 @@ void* caml_mem_commit(void* mem, uintnat size)
 #else
   void* p = map_fixed(mem, size, PROT_READ | PROT_WRITE);
   /*
-    FIXME: On Linux, with overcommit, you stand a better
-    chance of getting good error messages in OOM conditions
-    by forcing the kernel to allocate actual memory by touching
-    all the pages. Not sure whether this is a good idea, though.
-
-      if (p) memset(p, 0, size);
+    FIXME: On Linux, it might be useful to populate page tables with
+    MAP_POPULATE to reduce the time spent blocking on page faults at
+    a later point.
   */
   return p;
 #endif


### PR DESCRIPTION
One of the discussion still open in #10861 was on the subject of the best way to allocate the minor heap in Linux.
The conclusion of the discussion as far as I understood it was that it was not worth fighting the overcommiting behavior of Linux, but it might make sense to allocate the heap with `MAP_POPULATE` to avoid blocking on page faults at a later point.

This minimalist PR proposes to at least update the current comment to reflect the state of the discussion. 
