### PR TITLE
Fix broken links in RISC-V platform

### DIFF
--- a/asmcomp/riscv/NOTES.md
+++ b/asmcomp/riscv/NOTES.md
@@ -7,12 +7,10 @@ Debian architecture name: `riscv64`
 # Reference documents
 
 * Instruction set specification:
-  - https://riscv.org/specifications/isa-spec-pdf/
-  - https://rv8.io/isa
+  - https://riscv.org/technical/specifications/
 
 * ELF ABI specification:
-  - https://github.com/riscv/riscv-elf-psabi-doc/blob/master/riscv-elf.md
+  - https://github.com/riscv-non-isa/riscv-elf-psabi-doc/blob/master/riscv-elf.adoc
 
 * Assembly language manual
   - https://github.com/riscv/riscv-asm-manual/blob/master/riscv-asm.md
-  - https://rv8.io/asm


### PR DESCRIPTION
Updates specification links for RISC-V platform and drops no longer existing site links.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>