### PR TITLE
Statically initialize `caml_global_data` with a valid value

### DIFF
--- a/Changes
+++ b/Changes
@@ -82,6 +82,11 @@ OCaml 4.14 maintenance branch
   (this had stopped working in 4.14.0)
   (Gabriel Scherer, review by Jacques Garrigue, report by Yaron Minsky)
 
+- #11768, #11788: Fix crash at start-up of bytecode programs in
+  no-naked-pointers mode caused by wrong initialization of caml_global_data
+  (Xavier Leroy, report by Etienne Millon, review by Gabriel Scherer)
+
+
 OCaml 4.14.0 (28 March 2022)
 ----------------------------
 

--- a/runtime/stacks.c
+++ b/runtime/stacks.c
@@ -24,7 +24,7 @@
 #include "caml/mlvalues.h"
 #include "caml/stacks.h"
 
-value caml_global_data = 0;
+value caml_global_data = Val_unit; /* must be a valid value (#11768) */
 
 uintnat caml_max_stack_size;            /* also used in gc_ctrl.c */
 


### PR DESCRIPTION
In 4.14, the default initial value (0) is not a valid value in no-naked-pointers mode, causing a segfault if a GC is triggered while reading the global data from a bytecode executable.  See #11768 for a repro case.

In 5.0, `caml_global_data` is correctly initialized to `Val_unit` already.

Fixes: #11768