### PR TITLE
toplevel: -hide-uninformative-sigs

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -136,6 +136,7 @@ John Skaller <skaller@mantis>
 Eduardo Rafael <EduardoRFS@github>
 Runhang Li <objmagic@github>
 Dmitrii Kosarev <Kakadu@github>
+Jean-Pierre Rodi <Fourchaux@github>
 
 # These contributors prefer to be referred to pseudonymously
 whitequark <whitequark@whitequark.org>

--- a/Changes
+++ b/Changes
@@ -137,6 +137,11 @@ Working version
 - #11774: ocamlyacc: fail if there is an I/O error
   (Demi Marie Obenour)
 
+- #10060: toplevel: -{hide,show}-uninformative-sigs to hide (or show)
+  signatures that merely repeat the user definition in the toplevel
+  (shown by default, same as previous behavior)
+  (Gabriel Scherer, suggestion by Jean-Pierre Rodi and Florian Angeletti)
+
 ### Manual and documentation:
 
 - #9430, #11291: Document the general desugaring rules for binding operators.
@@ -1387,8 +1392,8 @@ OCaml 4.13.0 (24 September 2021)
   Adds some eighty examples to the reference manual, principally to the
   expressions and patterns sections.
   https://ocaml.org/releases/4.13/manual/patterns.html
-  (John Whitington, review by Xavier Leroy, Gabriel Scherer, @Fourchaux, and
-  Florian Angeletti)
+  (John Whitington, review by Xavier Leroy, Gabriel Scherer,
+  Jean-Pierre Rodi and Florian Angeletti)
 
 - #9987, #9988, #9996, #9997: add an odoc mode for the documentation
   of the standard library and compiler library

--- a/driver/main_args.ml
+++ b/driver/main_args.ml
@@ -746,6 +746,16 @@ let mk_afl_inst_ratio f =
   "Configure percentage of branches instrumented\n\
   \     (advanced, see afl-fuzz docs for AFL_INST_RATIO)"
 
+let mk_show_uninformative_sigs f =
+  "-show-uninformative-sigs", Arg.Unit f,
+  " Reprint uninformative signatures (repeating the user definition)\n\
+  \     in the interactive toplevel (default)"
+
+let mk_hide_uninformative_sigs f =
+  "-hide-uninformative-sigs", Arg.Unit f,
+  " Omit uninformative signatures (repeating the user definition)\n\
+  \     in the interactive toplevel"
+
 let mk__ f =
   "-", Arg.String f,
   "<file>  Treat <file> as a file name (even if it starts with `-')"
@@ -869,6 +879,8 @@ module type Toplevel_options = sig
   val _no_version : unit -> unit
   val _noprompt : unit -> unit
   val _nopromptcont : unit -> unit
+  val _show_uninformative_sigs: unit -> unit
+  val _hide_uninformative_sigs: unit -> unit
   val _stdin : unit -> unit
   val _args : string -> string array
   val _args0 : string -> string array
@@ -1134,6 +1146,8 @@ struct
     mk_nolabels F._nolabels;
     mk_noprompt F._noprompt;
     mk_nopromptcont F._nopromptcont;
+    mk_show_uninformative_sigs F._show_uninformative_sigs;
+    mk_hide_uninformative_sigs F._hide_uninformative_sigs;
     mk_nostdlib F._nostdlib;
     mk_nocwd F._nocwd;
     mk_nopervasives F._nopervasives;
@@ -1381,6 +1395,8 @@ module Make_opttop_options (F : Opttop_options) = struct
     mk_nolabels F._nolabels;
     mk_noprompt F._noprompt;
     mk_nopromptcont F._nopromptcont;
+    mk_show_uninformative_sigs F._show_uninformative_sigs;
+    mk_hide_uninformative_sigs F._hide_uninformative_sigs;
     mk_nostdlib F._nostdlib;
     mk_nocwd F._nocwd;
     mk_nopervasives F._nopervasives;
@@ -1797,6 +1813,8 @@ module Default = struct
     let _version () = print_version ()
     let _vnum () = print_version_num ()
     let _eval (_:string) = ()
+    let _show_uninformative_sigs = set show_uninformative_sigs
+    let _hide_uninformative_sigs = clear show_uninformative_sigs
   end
 
   module Topmain = struct

--- a/driver/main_args.mli
+++ b/driver/main_args.mli
@@ -135,6 +135,8 @@ module type Toplevel_options = sig
   val _no_version : unit -> unit
   val _noprompt : unit -> unit
   val _nopromptcont : unit -> unit
+  val _show_uninformative_sigs: unit -> unit
+  val _hide_uninformative_sigs: unit -> unit
   val _stdin : unit -> unit
   val _args : string -> string array
   val _args0 : string -> string array

--- a/testsuite/tests/tool-toplevel/foo.ml
+++ b/testsuite/tests/tool-toplevel/foo.ml
@@ -1,0 +1,1 @@
+type t = Foo

--- a/testsuite/tests/tool-toplevel/hide_uninformative_sigs.ml
+++ b/testsuite/tests/tool-toplevel/hide_uninformative_sigs.ml
@@ -1,0 +1,16 @@
+(* TEST
+   readonly_files = "foo.ml"
+   flags = "-hide-uninformative-sigs"
+   * expect
+*)
+
+(* uninformative signatures are not reprinted in interactive use *)
+type t = Foo;;
+[%%expect {|
+|}];;
+
+(* but they are when using code from a file *)
+#use "foo.ml";;
+[%%expect {|
+type t = Foo
+|}];;

--- a/testsuite/tools/expect_test.ml
+++ b/testsuite/tools/expect_test.ml
@@ -165,7 +165,7 @@ let capture_everything buf ppf ~f =
 let exec_phrase ppf phrase =
   if !Clflags.dump_parsetree then Printast. top_phrase ppf phrase;
   if !Clflags.dump_source    then Pprintast.top_phrase ppf phrase;
-  Toploop.execute_phrase true ppf phrase
+  Toploop.execute_phrase ~in_use:false ~print_outcome:true ppf phrase
 
 let parse_contents ~fname contents =
   let lexbuf = Lexing.from_string contents in

--- a/tools/ocamltex.ml
+++ b/tools/ocamltex.ml
@@ -191,7 +191,8 @@ module Toplevel = struct
 
   let exec (_,ppf) p =
     try
-      ignore @@ Toploop.execute_phrase true ppf p
+      Toploop.execute_phrase ~in_use:false ~print_outcome:true ppf p
+      |> ignore
     with exn ->
       let bt = Printexc.get_raw_backtrace () in
       begin try Location.report_exception (snd error_fmt) exn

--- a/toplevel/byte/topeval.ml
+++ b/toplevel/byte/topeval.ml
@@ -116,7 +116,6 @@ let pr_item =
 (* Execute a toplevel phrase *)
 
 let execute_phrase ~in_use ~print_outcome ppf phr =
-  ignore in_use;
   match phr with
   | Ptop_def sstr ->
       let oldenv = !toplevel_env in
@@ -138,7 +137,11 @@ let execute_phrase ~in_use ~print_outcome ppf phr =
         let out_phr =
           match res with
           | Result v ->
-              if print_outcome then
+              if print_outcome
+              && (in_use
+                  || !Clflags.show_uninformative_sigs
+                  || List.exists has_informative_sig str.str_items)
+              then
                 Printtyp.wrap_printing_env ~error:false oldenv (fun () ->
                   match str.str_items with
                   | [] -> Ophr_signature []

--- a/toplevel/byte/topeval.ml
+++ b/toplevel/byte/topeval.ml
@@ -115,7 +115,8 @@ let pr_item =
 
 (* Execute a toplevel phrase *)
 
-let execute_phrase print_outcome ppf phr =
+let execute_phrase ~in_use ~print_outcome ppf phr =
+  ignore in_use;
   match phr with
   | Ptop_def sstr ->
       let oldenv = !toplevel_env in
@@ -177,8 +178,8 @@ let execute_phrase print_outcome ppf phr =
   | Ptop_dir {pdir_name = {Location.txt = dir_name}; pdir_arg } ->
       try_run_directive ppf dir_name pdir_arg
 
-let execute_phrase print_outcome ppf phr =
-  try execute_phrase print_outcome ppf phr
+let execute_phrase ~in_use ~print_outcome ppf phr =
+  try execute_phrase ~in_use ~print_outcome ppf phr
   with exn ->
     Warnings.reset_fatal ();
     raise exn

--- a/toplevel/native/topeval.ml
+++ b/toplevel/native/topeval.ml
@@ -153,7 +153,8 @@ let name_expression ~loc ~attrs exp =
    in
    str, sg
 
-let execute_phrase print_outcome ppf phr =
+let execute_phrase ~in_use ~print_outcome ppf phr =
+  ignore in_use;
   match phr with
   | Ptop_def sstr ->
       let oldenv = !toplevel_env in

--- a/toplevel/native/topeval.ml
+++ b/toplevel/native/topeval.ml
@@ -154,7 +154,6 @@ let name_expression ~loc ~attrs exp =
    str, sg
 
 let execute_phrase ~in_use ~print_outcome ppf phr =
-  ignore in_use;
   match phr with
   | Ptop_def sstr ->
       let oldenv = !toplevel_env in
@@ -218,7 +217,11 @@ let execute_phrase ~in_use ~print_outcome ppf phr =
                 Env.register_import_as_opaque (Ident.name module_ident)
               else
                 Compilenv.record_global_approx_toplevel ();
-              if print_outcome then
+              if print_outcome
+              && (in_use
+                  || !Clflags.show_uninformative_sigs
+                  || List.exists has_informative_sig str.str_items)
+              then
                 Printtyp.wrap_printing_env ~error:false oldenv (fun () ->
                 match str.str_items with
                 | [] -> Ophr_signature []

--- a/toplevel/topcommon.ml
+++ b/toplevel/topcommon.ml
@@ -77,6 +77,30 @@ let find_eval_phrase str =
       Some (e, attrs, loc)
   | _ -> None
 
+let has_informative_sig str = match str.Typedtree.str_desc with
+  | Tstr_eval _
+  | Tstr_value _
+  | Tstr_include _
+  | Tstr_module _ | Tstr_recmodule _
+      (* could be refined:
+         modules with only uninformative items are uninformative *)
+  | Tstr_class _
+      (* could be refined:
+         virtual classes are uninformative *)
+    -> true
+  | Tstr_primitive _
+  | Tstr_exception _
+  | Tstr_type _
+  | Tstr_typext _
+  | Tstr_open _
+  | Tstr_class_type _
+  | Tstr_attribute _
+  | Tstr_modtype _
+      (* could be refined:
+         'include' makes signatures informative *)
+    -> false
+
+
 (* The current typing environment for the toplevel *)
 
 let toplevel_env = ref Env.empty

--- a/toplevel/topcommon.mli
+++ b/toplevel/topcommon.mli
@@ -55,6 +55,28 @@ val find_eval_phrase :
   Typedtree.structure ->
     (Typedtree.expression * Typedtree.attributes * Location.t) option
 
+(* A structure item has an informative (most general) signature
+   when the signature contains elements that are not directly
+   visible in the source of the structure item itself.
+
+   For example, the signature of [let x = ...] shows the type
+   of [x], which may not be obvious from the source, it is
+   informative. On the other the signature of [type t = Foo]
+   is exactly [type t = Foo], it is not informativee.
+
+   Note: our current implementation is best-effort, and in particular
+   it both under-approximates and over-approximates:
+
+   - we consider that all modules and classes are informative
+     (but arguably an unconstrained module that contains only type
+     declarations has an uninformative signature)
+
+   - we consider that all module types and class types are
+     uninformative (but arguably a module type that contains
+     a signature inclusion has an informative signature)
+*)
+val has_informative_sig : Typedtree.structure_item -> bool
+
 val max_printer_depth: int ref
 val max_printer_steps: int ref
 

--- a/toplevel/topeval.mli
+++ b/toplevel/topeval.mli
@@ -35,11 +35,9 @@ val setvalue : string -> Obj.t -> unit
 (* Label appended after [OCaml version XXX] when starting the toplevel. *)
 val implementation_label: string
 
-val execute_phrase : bool -> formatter -> Parsetree.toplevel_phrase -> bool
-        (* Read and execute commands from a file.
-           [use_file] prints the types and values of the results.
-           [use_silently] does not print them.
-           [mod_use_file] wrap the file contents into a module. *)
+val execute_phrase :
+  in_use:bool -> print_outcome:bool ->
+  formatter -> Parsetree.toplevel_phrase -> bool
 
 val may_trace : bool ref
 

--- a/toplevel/toploop.ml
+++ b/toplevel/toploop.ml
@@ -41,7 +41,9 @@ let use_lexbuf ppf ~wrap_in_module lb name filename =
       List.iter
         (fun ph ->
           let ph = preprocess_phrase ppf ph in
-          if not (execute_phrase !use_print_results ppf ph) then raise Exit)
+          let in_use = true in
+          let print_outcome = !use_print_results in
+          if not (execute_phrase ~in_use ~print_outcome ppf ph) then raise Exit)
         (if wrap_in_module then
            parse_mod_use_file name lb
          else
@@ -217,7 +219,7 @@ let loop ppf =
       let phr = try !parse_toplevel_phrase lb with Exit -> raise PPerror in
       let phr = preprocess_phrase ppf phr  in
       Env.reset_cache_toplevel ();
-      ignore(execute_phrase true ppf phr)
+      ignore(execute_phrase ~in_use:false ~print_outcome:true ppf phr)
     with
     | End_of_file -> raise (Compenv.Exit_with_status 0)
     | Sys.Break -> fprintf ppf "Interrupted.@."; Btype.backtrack snap

--- a/toplevel/toploop.mli
+++ b/toplevel/toploop.mli
@@ -82,11 +82,17 @@ val initialize_toplevel_env : unit -> unit
         (* Initialize the typing environment for the toplevel *)
 val print_exception_outcome : formatter -> exn -> unit
         (* Print an exception resulting from the evaluation of user code. *)
-val execute_phrase : bool -> formatter -> Parsetree.toplevel_phrase -> bool
+val execute_phrase :
+  in_use:bool -> print_outcome:bool ->
+  formatter -> Parsetree.toplevel_phrase -> bool
         (* Execute the given toplevel phrase. Return [true] if the
            phrase executed with no errors and [false] otherwise.
-           First bool says whether the values and types of the results
-           should be printed. Uncaught exceptions are always printed. *)
+           Uncaught exceptions are always printed.
+
+           - [in_use] indicates that we are called from a #use directive
+             or another file-providing command
+           - [print_outcome] indicates that we want to print the outcome of
+             each phrase executed. *)
 val preprocess_phrase :
       formatter -> Parsetree.toplevel_phrase ->  Parsetree.toplevel_phrase
         (* Preprocess the given toplevel phrase using regular and ppx

--- a/utils/clflags.ml
+++ b/utils/clflags.ml
@@ -545,6 +545,9 @@ let set_save_ir_after pass enabled =
   in
   save_ir_after := new_passes
 
+let show_uninformative_sigs = ref true
+(* -{show,hide}-uninformative-sigs *)
+
 module String = Misc.Stdlib.String
 
 let arg_spec = ref []

--- a/utils/clflags.mli
+++ b/utils/clflags.mli
@@ -256,6 +256,8 @@ val should_stop_after : Compiler_pass.t -> bool
 val set_save_ir_after : Compiler_pass.t -> bool -> unit
 val should_save_ir_after : Compiler_pass.t -> bool
 
+val show_uninformative_sigs : bool ref
+
 val arg_spec : (string * Arg.spec * string) list ref
 
 (* [add_arguments __LOC__ args] will add the arguments from [args] at


### PR DESCRIPTION
## Context

Currently, passing a type definition to the toplevel reprints it
unchanged:

    # type t = Foo;;
    type t = Foo
    # (* next prompt *)

When the new option -hide-uninformative-sigs is passed, the type
definition is not reprinted in this case, nothing is shown.

    # type t = Foo;;
    # (* next prompt *)

See #10060: this repetition shows up in particular in the manual
(thanks to our automated way to include examples from toplevel session)
where it is cumbersome.

## Details

This hiding only happens when using the toplevel interactively,
not with #use directives that reprint everything.

The definition of 'uninformative signature' is not obvious, in
particular it does not correspond to a type-level vs. term-level
distinction:

- `external foo : ... = ...` has an uninformative signature
  (despite being term-level)
- `include List` has an informative signature

Our implementation is only an approximation (it both under- and
over-approximates):

- we consider that all modules and classes are informative
  (but arguably an unconstrained module that contains only type
  declarations has an uninformative signature)

- we consider that all module types and class types are uninformative
  (but arguably a module type that contains a signature inclusion
  has an informative signature)
