### PR TITLE
codefrag.c: remove DIGEST_LATER to avoid data races

### DIFF
--- a/runtime/caml/codefrag.h
+++ b/runtime/caml/codefrag.h
@@ -21,7 +21,6 @@
 #ifdef CAML_INTERNALS
 
 enum digest_status {
-  DIGEST_LATER,    /* computed on demand */
   DIGEST_NOW,      /* computed by caml_register_code_fragment */
   DIGEST_PROVIDED, /* passed by caller of caml_register_code_fragment */
   DIGEST_IGNORE    /* this code fragment is private and cannot be
@@ -33,6 +32,8 @@ struct code_fragment {
   char *code_end;
   int fragnum;
   unsigned char digest[16];
+  /* the digest is obtained by hashing
+     the bytes between [code_start] and [code_end]. */
   enum digest_status digest_status;
 };
 
@@ -73,9 +74,6 @@ extern struct code_fragment *
    caml_find_code_fragment_by_digest(unsigned char digest[16]);
 
 /* Return the digest of the given code fragment.
-   If the code fragment was registered in [DIGEST_LATER] mode
-   and if the digest was not computed yet, it is obtained by hashing
-   the bytes between [code_start] and [code_end].
    Returns NULL if the code fragment was registered with [DIGEST_IGNORE]. */
 extern unsigned char * caml_digest_of_code_fragment(struct code_fragment *);
 

--- a/runtime/codefrag.c
+++ b/runtime/codefrag.c
@@ -52,8 +52,6 @@ int caml_register_code_fragment(char *start, char *end,
   cf->code_start = start;
   cf->code_end = end;
   switch (digest_kind) {
-  case DIGEST_LATER:
-    break;
   case DIGEST_NOW:
     caml_md5_block(cf->digest, cf->code_start, cf->code_end - cf->code_start);
     digest_kind = DIGEST_PROVIDED;
@@ -120,10 +118,6 @@ struct code_fragment *caml_find_code_fragment_by_num(int fragnum) {
 unsigned char *caml_digest_of_code_fragment(struct code_fragment *cf) {
   if (cf->digest_status == DIGEST_IGNORE)
     return NULL;
-  if (cf->digest_status == DIGEST_LATER) {
-    caml_md5_block(cf->digest, cf->code_start, cf->code_end - cf->code_start);
-    cf->digest_status = DIGEST_PROVIDED;
-  }
   return cf->digest;
 }
 

--- a/runtime/dynlink_nat.c
+++ b/runtime/dynlink_nat.c
@@ -122,7 +122,7 @@ CAMLprim value caml_natdynlink_run(value handle_v, value symbol) {
   /* Do not register empty code fragments */
   if (NULL != sym && NULL != sym2 && sym != sym2) {
     caml_register_code_fragment((char *) sym, (char *) sym2,
-                                DIGEST_LATER, NULL);
+                                DIGEST_NOW, NULL);
   }
 
   if( caml_natdynlink_hook != NULL ) caml_natdynlink_hook(handle,unit);

--- a/runtime/meta.c
+++ b/runtime/meta.c
@@ -104,7 +104,7 @@ CAMLprim value caml_reify_bytecode(value ls_prog,
     digest_kind = DIGEST_PROVIDED;
     digest = (unsigned char *) String_val(Some_val(digest_opt));
   } else {
-    digest_kind = DIGEST_LATER;
+    digest_kind = DIGEST_NOW;
     digest = NULL;
   }
   fragnum = caml_register_code_fragment((char *) prog, (char *) prog + len,

--- a/runtime/startup_nat.c
+++ b/runtime/startup_nat.c
@@ -66,7 +66,7 @@ static void init_segments(void)
   /* Register the code in the table of code fragments */
   caml_register_code_fragment(caml_code_area_start,
                               caml_code_area_end,
-                              DIGEST_LATER, NULL);
+                              DIGEST_NOW, NULL);
   /* Also register the glue code written in assembly */
   caml_register_code_fragment(&caml_system__code_begin,
                               &caml_system__code_end,


### PR DESCRIPTION
See #11791.

This is approach (1) proposed in
  https://github.com/ocaml/ocaml/issues/11791#issuecomment-1339190326

(conflicts with #11796)