### PR TITLE
Fix interaction of or-patterns, GADTs and as-patterns

### DIFF
--- a/testsuite/tests/typing-gadts/or_patterns.ml
+++ b/testsuite/tests/typing-gadts/or_patterns.ml
@@ -731,3 +731,22 @@ Line 2, characters 6-7:
 Error: This pattern matches values of type $A_'a
        The type constructor $A_'a would escape its scope
 |}]
+
+
+type _ t =
+      | A : [ `A ] t
+      | B : [ `B ] t
+
+let foo : type a. a t -> a t =
+    fun t ->
+      match t with
+      | (A | B) as t -> t
+[%%expect{|
+type _ t = A : [ `A ] t | B : [ `B ] t
+Line 8, characters 13-14:
+8 |       | (A | B) as t -> t
+                 ^
+Error: This pattern matches values of type [ `B ] t
+       but a pattern was expected which matches values of type [ `A ] t
+       These two variant types have no intersection
+|}]

--- a/testsuite/tests/typing-gadts/or_patterns.ml
+++ b/testsuite/tests/typing-gadts/or_patterns.ml
@@ -743,10 +743,5 @@ let foo : type a. a t -> a t =
       | (A | B) as t -> t
 [%%expect{|
 type _ t = A : [ `A ] t | B : [ `B ] t
-Line 8, characters 13-14:
-8 |       | (A | B) as t -> t
-                 ^
-Error: This pattern matches values of type [ `B ] t
-       but a pattern was expected which matches values of type [ `A ] t
-       These two variant types have no intersection
+val foo : 'a t -> 'a t = <fun>
 |}]

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -601,10 +601,17 @@ and build_as_type_aux ~refine (env : Env.t ref) p =
       ty
   | Tpat_or(p1, p2, row) ->
       begin match row with
-        None ->
-          let ty1 = build_as_type env p1 and ty2 = build_as_type env p2 in
-          unify_pat ~refine env {p2 with pat_type = ty2} ty1;
-          ty1
+        None -> begin
+          let ty1 = build_as_type env p1 in
+          let ty2 = build_as_type env p2 in
+          let snap = Btype.snapshot () in
+          match unify_pat_types ~refine p2.pat_loc env ty2 ty1 with
+          | exception (Error _) ->
+              Btype.backtrack snap;
+              p.pat_type
+          | () ->
+              ty1
+        end
       | Some row ->
           let Row {fields; fixed; name} = row_repr row in
           newty (Tvariant (create_row ~fields ~fixed ~name


### PR DESCRIPTION
Currently, the following code:
```ocaml
type _ t =
      | A : [ `A ] t
      | B : [ `B ] t

let foo : type a. a t -> a t =
    fun t ->
      match t with
      | (A | B) as t' -> t'
```
gives an error:
```
Line 8, characters 13-14:
8 |       | (A | B) as t -> t
                 ^
Error: This pattern matches values of type [ `B ] t
       but a pattern was expected which matches values of type [ `A ] t
       These two variant types have no intersection
```
whilst this equivalent code does not:
```ocaml
let foo : type a. a t -> a t =
    fun t ->
      match t with
      | (A | B) -> t
```

This is because that or-pattern requires an expected type in order to type-check since it relies on adding GADT equations. The code which tries to create a type for the `as` binding deliberately does not pass in the expected type, which causes it to fail. This PR makes `build_as_type` fall back to just using the type of the pattern if unifying both sides of an or-pattern fails. This is sound and allows such examples to pass.