### PR TITLE
x86: Force result of Icomp to be in a register

### DIFF
--- a/Changes
+++ b/Changes
@@ -3,6 +3,12 @@ OCaml 4.14 maintenance branch
 
 ### Bug fixes:
 
+- #11803, #11808: on x86, the destination of an integer comparison must be
+  a register, it cannot be a stack slot.
+  (Vincent Laviron, review by Xavier Leroy, report by
+   Emilio Jesús Gallego Arias)
+
+
 OCaml 4.14.1
 -----------------------------
 

--- a/asmcomp/amd64/reload.ml
+++ b/asmcomp/amd64/reload.ml
@@ -73,12 +73,8 @@ method! reload_operation op arg res =
       then ([|arg.(0); self#makereg arg.(1)|], res)
       else (arg, res)
   | Iintop(Icomp _) ->
-      (* The result must be a register *)
-      let res =
-        if stackp res.(0)
-        then [|self#makereg res.(0)|]
-        else res
-      in
+      (* The result must be a register (PR#11803) *)
+      let res = self#makeregs res in
       (* One of the two arguments can reside in the stack, but not both *)
       if stackp arg.(0) && stackp arg.(1)
       then ([|arg.(0); self#makereg arg.(1)|], res)
@@ -93,10 +89,8 @@ method! reload_operation op arg res =
       then (let r = self#makereg arg.(0) in ([|r|], [|r|]))
       else (arg, res)
   | Iintop_imm(Icomp _, _) ->
-      (* The result must be in a register *)
-      if stackp res.(0)
-      then (arg, [|self#makereg res.(0)|])
-      else (arg, res)
+      (* The result must be in a register (PR#11803) *)
+      (arg, self#makeregs res)
   | Iintop(Imulh | Idiv | Imod | Ilsl | Ilsr | Iasr)
   | Iintop_imm(_, _) ->
       (* The argument(s) and results can be either in register or on stack *)

--- a/asmcomp/amd64/reload.ml
+++ b/asmcomp/amd64/reload.ml
@@ -33,7 +33,7 @@ open Mach
      Iload                      R       R       R
      Istore                             R       R
      Iintop(Icomp)              R       R       S
-                            or  S       S       R
+                            or  R       S       R
      Iintop(Imul|Idiv|Imod)     R       R       S
      Iintop(Imulh)              R       R       S
      Iintop(shift)              S       S       R
@@ -41,6 +41,7 @@ open Mach
                             or  S       S       R
      Iintop_imm(Iadd, n)/lea    R       R
      Iintop_imm(Imul, n)        R       R
+     Iintop_imm(Icomp, n)       R       S
      Iintop_imm(others)         S       S
      Inegf...Idivf              R       R       S
      Ifloatofint                R       S
@@ -66,7 +67,18 @@ inherit Reloadgen.reload_generic as super
 
 method! reload_operation op arg res =
   match op with
-  | Iintop(Iadd|Isub|Iand|Ior|Ixor|Icomp _|Icheckbound) ->
+  | Iintop(Iadd|Isub|Iand|Ior|Ixor|Icheckbound) ->
+      (* One of the two arguments can reside in the stack, but not both *)
+      if stackp arg.(0) && stackp arg.(1)
+      then ([|arg.(0); self#makereg arg.(1)|], res)
+      else (arg, res)
+  | Iintop(Icomp _) ->
+      (* The result must be a register *)
+      let res =
+        if stackp res.(0)
+        then [|self#makereg res.(0)|]
+        else res
+      in
       (* One of the two arguments can reside in the stack, but not both *)
       if stackp arg.(0) && stackp arg.(1)
       then ([|arg.(0); self#makereg arg.(1)|], res)
@@ -79,6 +91,11 @@ method! reload_operation op arg res =
       (* The result (= the argument) must be a register (#10626) *)
       if stackp arg.(0)
       then (let r = self#makereg arg.(0) in ([|r|], [|r|]))
+      else (arg, res)
+  | Iintop_imm(Icomp _, _) ->
+      (* The result must be in a register *)
+      if stackp res.(0)
+      then (arg, [|self#makereg res.(0)|])
       else (arg, res)
   | Iintop(Imulh | Idiv | Imod | Ilsl | Ilsr | Iasr)
   | Iintop_imm(_, _) ->

--- a/asmcomp/i386/reload.ml
+++ b/asmcomp/i386/reload.ml
@@ -46,12 +46,8 @@ method! reload_operation op arg res =
       then ([|arg.(0); self#makereg arg.(1)|], res)
       else (arg, res)
   | Iintop(Icomp _) ->
-      (* The result must be a register *)
-      let res =
-        if stackp res.(0)
-        then [|self#makereg res.(0)|]
-        else res
-      in
+      (* The result must be a register (PR#11803) *)
+      let res = self#makeregs res in
       (* One of the two arguments can reside in the stack *)
       if stackp arg.(0) && stackp arg.(1)
       then ([|arg.(0); self#makereg arg.(1)|], res)
@@ -72,10 +68,8 @@ method! reload_operation op arg res =
       then let r = self#makereg arg.(0) in ([|r|], [|r|])
       else (arg, res)
   | Iintop_imm(Icomp _, _) ->
-      (* The result must be in a register *)
-      if stackp res.(0)
-      then (arg, [|self#makereg res.(0)|])
-      else (arg, res)
+      (* The result must be in a register (PR#11803) *)
+      (arg, self#makeregs res)
   | Iintop(Imulh | Ilsl | Ilsr | Iasr) | Iintop_imm(_, _)
   | Ifloatofint | Iintoffloat | Ispecific(Ipush) ->
       (* The argument(s) can be either in register or on stack *)

--- a/asmcomp/reloadgen.ml
+++ b/asmcomp/reloadgen.ml
@@ -46,7 +46,7 @@ method makereg r =
       newr.spill_cost <- 100000;
       newr
 
-method private makeregs rv =
+method makeregs rv =
   let n = Array.length rv in
   let newv = Array.make n Reg.dummy in
   for i = 0 to n-1 do newv.(i) <- self#makereg rv.(i) done;

--- a/asmcomp/reloadgen.mli
+++ b/asmcomp/reloadgen.mli
@@ -20,6 +20,7 @@ class reload_generic : object
     (* Can be overridden to reflect instructions that can operate
        directly on stack locations *)
   method makereg : Reg.t -> Reg.t
+  method makeregs : Reg.t array -> Reg.t array
     (* Can be overridden to avoid creating new registers of some class
        (i.e. if all "registers" of that class are actually on stack) *)
   method fundecl : Mach.fundecl -> int array -> Mach.fundecl * bool


### PR DESCRIPTION
Fixes #11803.
I've made the PR against 4.14, as the bug report only mentioned 32-bit native code which is not supported on trunk, but I think this should be considered for trunk too.
I've checked that the issue reported in #11803 disappears with this patch.