### PR TITLE
Protect Parmatch.pats_of_type from missing cmis

### DIFF
--- a/Changes
+++ b/Changes
@@ -271,6 +271,9 @@ Working version
 - #11776: Extend environment with functor parameters in `strengthen_lazy`.
   (Chris Casinghino and Luke Maurer, review by Gabriel Scherer)
 
+- #11809: Protect Parmatch.pats_of_type from missing cmis
+  (Jacques Garrigue, review by ???)
+
 OCaml 5.0
 ---------
 

--- a/Changes
+++ b/Changes
@@ -272,7 +272,7 @@ Working version
   (Chris Casinghino and Luke Maurer, review by Gabriel Scherer)
 
 - #11809: Protect Parmatch.pats_of_type from missing cmis
-  (Jacques Garrigue, review by ???)
+  (Jacques Garrigue, review by Stephen Dolan and Gabriel Scherer)
 
 OCaml 5.0
 ---------

--- a/testsuite/tests/typing-missing-cmi-3/middle.ml
+++ b/testsuite/tests/typing-missing-cmi-3/middle.ml
@@ -18,3 +18,5 @@ let s = Original.s
 (* Check expansion in gadt *)
 type ('a,'b) gadt =
 | G: ('a, 'a ti) gadt
+
+type 'a is_int = 'a Original.is_int = Is_int : int is_int

--- a/testsuite/tests/typing-missing-cmi-3/original.ml
+++ b/testsuite/tests/typing-missing-cmi-3/original.ml
@@ -6,3 +6,5 @@ let r = { x = () }
 
 type s = S
 let s = S
+
+type _ is_int = Is_int : int is_int

--- a/testsuite/tests/typing-missing-cmi-3/user.ml
+++ b/testsuite/tests/typing-missing-cmi-3/user.ml
@@ -107,3 +107,12 @@ let  f : type a b. (a Middle.ti -> unit) -> (a,b) Middle.gadt -> b -> unit =
 [%%expect {|
 val f : ('a Middle.ti -> unit) -> ('a, 'b) Middle.gadt -> 'b -> unit = <fun>
 |}]
+
+(* Check re-exportation of GADTs *)
+
+let f : type a. a Middle.is_int -> a -> int = fun Middle.Is_int x -> x
+let g : bool Middle.is_int -> 'a = function _ -> .
+[%%expect{|
+val f : 'a Middle.is_int -> 'a -> int = <fun>
+val g : bool Middle.is_int -> 'a = <fun>
+|}]


### PR DESCRIPTION
`Parmatch.pats_of_type` was expanding types naively, causing some failures with refutation cases when a cmi is missing.
Fixed it by calling `Ctype.extract_concrete_typedecl` to get the right path.