### PR TITLE
Ignore ocamltest's -show-timings flag when built without Unix library

### DIFF
--- a/testsuite/Makefile
+++ b/testsuite/Makefile
@@ -99,9 +99,9 @@ endif
 # users should call the 'promote' target explicitly.
 PROMOTE =
 ifeq "$(PROMOTE)" ""
-  OCAMLTEST_PROMOTE_FLAG :=
+  OCAMLTEST_PROMOTE_FLAG =
 else
-  OCAMLTEST_PROMOTE_FLAG := -promote
+  OCAMLTEST_PROMOTE_FLAG = -promote
 endif
 
 # KEEP_TEST_DIR_ON_SUCCESS should be set by the user (to a non-empty value)
@@ -109,9 +109,9 @@ endif
 # to preserve test data of successful tests.
 KEEP_TEST_DIR_ON_SUCCESS ?=
 ifeq "$(KEEP_TEST_DIR_ON_SUCCESS)" ""
-  OCAMLTEST_KEEP_TEST_DIR_ON_SUCCESS_FLAG :=
+  OCAMLTEST_KEEP_TEST_DIR_ON_SUCCESS_FLAG =
 else
-  OCAMLTEST_KEEP_TEST_DIR_ON_SUCCESS_FLAG := -keep-test-dir-on-success
+  OCAMLTEST_KEEP_TEST_DIR_ON_SUCCESS_FLAG = -keep-test-dir-on-success
 endif
 
 TIMEOUT ?= 600 # 10 minutes
@@ -119,13 +119,14 @@ TIMEOUT ?= 600 # 10 minutes
 # SHOW_TIMINGS should be set by the user (to a non-empty value) if they want
 # the timings for each test file to be included in the log
 SHOW_TIMINGS ?=
-ifeq "$(SHOW_TIMINGS)" ""
-  OCAMLTEST_SHOW_TIMINGS_FLAG :=
-else
-  OCAMLTEST_SHOW_TIMINGS_FLAG := -show-timings
+OCAMLTEST_SHOW_TIMINGS_FLAG =
+ifneq "$(SHOW_TIMINGS)" ""
+ifeq "$(lib_unix)" "true"
+  OCAMLTEST_SHOW_TIMINGS_FLAG = -show-timings
+endif
 endif
 
-OCAMLTESTFLAGS := \
+OCAMLTESTFLAGS = \
   -timeout $(TIMEOUT) \
   $(OCAMLTEST_PROMOTE_FLAG) \
   $(OCAMLTEST_KEEP_TEST_DIR_ON_SUCCESS_FLAG) \

--- a/tools/ci/inria/main
+++ b/tools/ci/inria/main
@@ -283,8 +283,9 @@ rm -rf "$instdir"
 
 cd testsuite
 if test -n "$jobs" && test -x /usr/bin/parallel
-then PARALLEL="$jobs $PARALLEL" $make --warn-undefined-variables parallel
-else $make --warn-undefined-variables all
+then PARALLEL="$jobs $PARALLEL" $make --warn-undefined-variables \
+                                      SHOW_TIMINGS=1 parallel
+else $make --warn-undefined-variables SHOW_TIMINGS=1 all
 fi
 
 if $bootstrap; then


### PR DESCRIPTION
e60307e4a427fcab7f179a7e9a4f03c183038b2d has broken the other-configs Jenkins job. That's been reverted in 17ba54200a099494bef1eee44e86c3fa8c308e65 to unblock that CI job.

Two commits here: the first makes `ocamltest` (silently) ignore the `-show-timings` option when it's built without the Unix library (given the nicheness of the option, I think this is the simplest way).

The second commit, which is optional, turns it back on in Jenkins - I personally think it's useful to collect those timings, but I don't mind removing that commit.