### PR TITLE
Cherry-pick -fno-common-related patches to 4.02-4.05

### DIFF
--- a/asmrun/startup.c
+++ b/asmrun/startup.c
@@ -44,7 +44,6 @@
 #endif
 
 extern int caml_parser_trace;
-CAMLexport header_t caml_atom_table[256];
 char * caml_code_area_start, * caml_code_area_end;
 
 /* Initialize the atom table and the static data and code area limits. */

--- a/asmrun/startup.c
+++ b/asmrun/startup.c
@@ -45,6 +45,7 @@
 
 extern int caml_parser_trace;
 char * caml_code_area_start, * caml_code_area_end;
+struct ext_table caml_code_fragments_table;
 
 /* Initialize the atom table and the static data and code area limits. */
 

--- a/byterun/backtrace.c
+++ b/byterun/backtrace.c
@@ -27,9 +27,6 @@
 #include "caml/backtrace_prim.h"
 #include "caml/fail.h"
 
-/* The table of debug information fragments */
-struct ext_table caml_debug_info;
-
 CAMLexport int32_t caml_backtrace_active = 0;
 CAMLexport int32_t caml_backtrace_pos = 0;
 CAMLexport backtrace_slot * caml_backtrace_buffer = NULL;

--- a/byterun/caml/intext.h
+++ b/byterun/caml/intext.h
@@ -196,7 +196,7 @@ struct code_fragment {
 
 CAMLextern struct code_fragment * caml_extern_find_code(char *addr);
 
-struct ext_table caml_code_fragments_table;
+extern struct ext_table caml_code_fragments_table;
 
 #endif /* CAML_INTERNALS */
 

--- a/byterun/caml/major_gc.h
+++ b/byterun/caml/major_gc.h
@@ -64,9 +64,9 @@ extern uintnat total_heap_size;
 extern char *caml_gc_sweep_hp;
 
 extern int caml_major_window;
-double caml_major_ring[Max_major_window];
-int caml_major_ring_index;
-double caml_major_work_credit;
+extern double caml_major_ring[Max_major_window];
+extern int caml_major_ring_index;
+extern double caml_major_work_credit;
 extern double caml_gc_clock;
 
 /* [caml_major_gc_hook] is called just between the end of the mark

--- a/byterun/fix_code.c
+++ b/byterun/fix_code.c
@@ -38,6 +38,7 @@
 code_t caml_start_code;
 asize_t caml_code_size;
 unsigned char * caml_saved_code;
+struct ext_table caml_code_fragments_table;
 
 /* Read the main bytecode block from a file */
 


### PR DESCRIPTION
Last year we pushed fixes for glibc 2.34 to old maintenance branches partly so that the branches can still be built with modern C compilers, and partly because it provides a very convenient home for the patch files. opam 2.1's CI needs to build old compilers without using opam.

There's a related issue with duplicate definitions of global variables which was jointly fixed by #1770 (in 4.07) and #9180 (in 4.09). These patches are pushed to the 4.06-4.08 maintenance branches (and are not released), but weren't pushed any earlier. For opam 2.1's benefit, it would be handy to include these commits for 4.02-4.05. The other's can be seen on my fork (which will direct pushed after this PR): [4.02](https://github.com/dra27/ocaml/commits/4.02), [4.03](https://github.com/dra27/ocaml/commits/4.03) and [4.04](https://github.com/dra27/ocaml/commits/4.04).

These 4 sets of commits have been tested [in opam 2.1.4's CI run](https://github.com/ocaml/opam/actions/runs/3674949654).