### PR TITLE
5.0 docs: Make new multicore chapters easier to discover, and emphasize impact on C bindings

### DIFF
--- a/Changes
+++ b/Changes
@@ -314,6 +314,10 @@ OCaml 5.0
   (Amandine Nangah, review by David Allsopp, Florian Angeletti,
   Sébastien Hinderer, and Vincent Laviron)
 
+- #11813: Make new multicore chapters easier to discover, and emphasize impact
+  on C bindings.
+  (Edwin Török, review by KC Sivaramakrishnan, and Florian Angeletti)
+
 ### Compiler user-interface and warnings:
 
 - #9140, #11131: New command-line flag -nocwd to not include implicit

--- a/manual/src/cmds/intf-c.etex
+++ b/manual/src/cmds/intf-c.etex
@@ -2433,6 +2433,7 @@ When OCaml calls the C code implementing a primitive, the domain lock
 is held, therefore the C code has full access to the facilities of the
 run-time system.  However, no other thread in the same domain can execute
 OCaml code concurrently with the C code of the primitive.
+See also chapter~\ref{s:par_c_bindings} for the behaviour with multiple domains.
 
 If a C primitive runs for a long time or performs potentially blocking
 input-output operations, it can explicitly release the domain lock,

--- a/manual/src/tutorials/parallelism.etex
+++ b/manual/src/tutorials/parallelism.etex
@@ -594,6 +594,16 @@ systhread identifiers uniquely identify systhreads in the program. The initial
 domain gets the domain id and the thread id as 0. The newly spawned domain gets
 domain id as 1.
 
+\section{s:par_c_bindings}{Interaction with C bindings}
+
+During parallel execution with multiple domains, C code running on a domain may
+run in parallel with any C code running in other domains even if neither of
+them has released the ``domain lock''. Prior to OCaml 5.0, C bindings may have
+assumed that if the OCaml runtime lock is not released, then it would be safe
+to manipulate global C state (e.g. initialise a function-local static value).
+This is no longer true in the presence of parallel execution with multiple
+domains.
+
 \section{s:par_atomics}{Atomics}
 
 Mutex, condition variables and semaphores are used to implement blocking

--- a/otherlibs/systhreads/thread.mli
+++ b/otherlibs/systhreads/thread.mli
@@ -23,7 +23,7 @@ type t
 val create : ('a -> 'b) -> 'a -> t
 (** [Thread.create funct arg] creates a new thread of control,
    in which the function application [funct arg]
-   is executed concurrently with the other threads of the program.
+   is executed concurrently with the other threads of the domain.
    The application of [Thread.create]
    returns the handle of the newly created thread.
    The new thread terminates when the application [funct arg]
@@ -32,7 +32,10 @@ val create : ('a -> 'b) -> 'a -> t
    In the last case, the uncaught exception is printed on standard error,
    but not propagated back to the parent thread. Similarly, the
    result of the application [funct arg] is discarded and not
-   directly accessible to the parent thread. *)
+   directly accessible to the parent thread.
+
+   See also {!Domain.spawn} if you want parallel execution instead.
+   *)
 
 val self : unit -> t
 (** Return the handle for the thread currently executing. *)

--- a/stdlib/atomic.mli
+++ b/stdlib/atomic.mli
@@ -17,6 +17,8 @@
 
 (** Atomic references.
 
+    See 'Memory model: The hard bits' chapter in the manual.
+
     @since 4.12
 *)
 

--- a/stdlib/domain.mli
+++ b/stdlib/domain.mli
@@ -20,6 +20,12 @@
     "The Domain interface may change in incompatible ways in the future."
 ]
 
+(** Domains.
+
+    See 'Parallel programming' chapter in the manual.
+
+    @since 5.0 *)
+
 type !'a t
 (** A domain of type ['a t] runs independently, eventually producing a
     result of type 'a, or an exception *)

--- a/stdlib/effect.mli
+++ b/stdlib/effect.mli
@@ -18,6 +18,8 @@
 
 (** Effects.
 
+    See 'Language extensions/Effect handlers' section in the manual.
+
     @since 5.0 *)
 
 type _ t = ..


### PR DESCRIPTION
I've almost missed the new fine chapters in the manual about the memory model and parallelism, since it wasn't mentioned in the usual places I look for newly added content (language extensions, and .mli docs of new modules).
Looking a bit more closely I did find them, but considering that this is quite a prominent feature for 5.0, add a few more links to make it easier for people to discover this documentation.

Also explicitly call out the difference between the previous global runtime lock in C bindings and the domain lock. Currently this is only implied by the wording "domain lock", and IIUC this makes some C bindings that are currently working correctly have some subtle bugs in 5.0 if they are used from multiple domains, so might be worthwhile explicitly pointing this out to make bugs like this easier to catch. I hope I got this right, please correct me if I'm wrong.
(this is not just a theoretical worry, I've been recently auditing some C bindings for no-naked-pointer-safety, and came across a comment that initialized a 'static' local variable in a function with a comment saying this is safe because of the OCaml runtime lock, well not anymore...)

Draft PR:
* should I send these changes to master first?
* what do you think of the  'language extension' section addition? Should it be just a link to the other 3 pieces of docs?
(it is not strictly speaking an extension of the language *syntax*, but it is an extension of the language's semantics, so having an entry in the "language changelog" chapter of the manual seems appropriate) However I don't want to duplicate any information present in the tutorials already, so I tried to add just some very minimal context to each link.