### PR TITLE
Mention in Gc documentation that compaction is currently not implemented.

### DIFF
--- a/runtime/gc_ctrl.c
+++ b/runtime/gc_ctrl.c
@@ -159,6 +159,7 @@ CAMLprim value caml_gc_set(value v)
   uintnat newminwsz = caml_norm_minor_heap_size (Long_val (Field (v, 0)));
   uintnat newpf = norm_pfree (Long_val (Field (v, 2)));
   uintnat new_verb_gc = Long_val (Field (v, 3));
+  uintnat new_percent_max = Long_val (Field (v, 4));
   uintnat new_max_stack_size = Long_val (Field (v, 5));
   uintnat new_custom_maj = norm_custom_maj (Long_val (Field (v, 8)));
   uintnat new_custom_min = norm_custom_min (Long_val (Field (v, 9)));
@@ -168,6 +169,9 @@ CAMLprim value caml_gc_set(value v)
 
   caml_change_max_stack_size (new_max_stack_size);
 
+  if (new_percent_max != 0){
+    caml_invalid_argument("max_overhead must be zero");
+  }
   if (newpf != caml_percent_free){
     caml_percent_free = newpf;
     caml_gc_message (0x20, "New space overhead: %"

--- a/runtime/gc_ctrl.c
+++ b/runtime/gc_ctrl.c
@@ -298,7 +298,7 @@ CAMLprim value caml_gc_compaction(value v)
   value exn = Val_unit;
   CAML_EV_BEGIN(EV_EXPLICIT_GC_COMPACT);
   CAMLassert (v == Val_unit);
-  exn = gc_major_exn();
+  exn = gc_full_major_exn();
   ++ Caml_state->stat_forced_major_collections;
   CAML_EV_END(EV_EXPLICIT_GC_COMPACT);
   return exn;

--- a/stdlib/gc.mli
+++ b/stdlib/gc.mli
@@ -79,7 +79,9 @@ type stat =
        are not available for allocation. *)
 
     compactions : int;
-    (** Number of heap compactions since the program was started. *)
+    (** Note: As of OCaml 5.0, compaction is not available and this field's
+        value will always be zero.
+        Number of heap compactions since the program was started. *)
 
     top_heap_words : int;
     (** Maximum size reached by the major heap, in words. *)
@@ -143,7 +145,9 @@ type control =
        Default: 0. *)
 
     max_overhead : int;
-    (** Heap compaction is triggered when the estimated amount
+    (** Note: As of OCaml 5.0, compaction is not implemented, and this field
+       will have no effect.
+       Heap compaction is triggered when the estimated amount
        of "wasted" memory is more than [max_overhead] percent of the
        amount of live data.  If [max_overhead] is set to 0, heap
        compaction is triggered at the end of each major GC cycle
@@ -300,7 +304,9 @@ external full_major : unit -> unit = "caml_gc_full_major"
    unreachable blocks. *)
 
 external compact : unit -> unit = "caml_gc_compaction"
-(** Perform a full major collection and compact the heap.  Note that heap
+(** Note: As of OCaml 5.0, compaction is not implemented, and calling this
+   function will only trigger a major collection.
+   Perform a full major collection and compact the heap.  Note that heap
    compaction is a lengthy operation. *)
 
 val print_stat : out_channel -> unit

--- a/stdlib/gc.mli
+++ b/stdlib/gc.mli
@@ -80,8 +80,7 @@ type stat =
 
     compactions : int;
     (** Note: As of OCaml 5.0, compaction is not available and this field's
-        value will always be zero.
-        Number of heap compactions since the program was started. *)
+        value will always be zero. *)
 
     top_heap_words : int;
     (** Maximum size reached by the major heap, in words. *)
@@ -145,17 +144,10 @@ type control =
        Default: 0. *)
 
     max_overhead : int;
-    (** Note: As of OCaml 5.0, compaction is not implemented, and this field
-       will have no effect.
-       Heap compaction is triggered when the estimated amount
-       of "wasted" memory is more than [max_overhead] percent of the
-       amount of live data.  If [max_overhead] is set to 0, heap
-       compaction is triggered at the end of each major GC cycle
-       (this setting is intended for testing purposes only).
-       If [max_overhead >= 1000000], compaction is never triggered.
-       If compaction is permanently disabled, it is strongly suggested
-       to set [allocation_policy] to 2.
-       Default: 500. *)
+    (** As of OCaml 5.0, compaction is not implemented.
+       As a result, setting this field to anything other than 0
+       will raise [Invalid_argument].
+       Default: 0. *)
 
     stack_limit : int;
     (** The maximum size of the fiber stacks (in words).

--- a/testsuite/tests/lib-runtime-events/test.reference
+++ b/testsuite/tests/lib-runtime-events/test.reference
@@ -1,2 +1,2 @@
-minors: 9, majors: 3
-minors: 9, majors: 3
+minors: 27, majors: 9
+minors: 27, majors: 9


### PR DESCRIPTION
I decided to go with #11812 step-by-step, and this PR is the first one.

This simply addresses the first point: annotate documentation for compaction related functions and stating that compaction is currently not available since release 5.0.

