### PR TITLE
Cherry-pick AArch64 GOT fix to 4.03-4.05

### DIFF
--- a/Changes
+++ b/Changes
@@ -19,6 +19,10 @@ Working 4.05.x branch
   (Mark Shinwell, Xavier Clerc, report and initial debugging by
   Valentin Gatien-Baron)
 
+- GPR#1330: when generating dynamically-linkable code on AArch64, always
+  reference symbols (even locally-defined ones) through the GOT.
+  (Mark Shinwell, review by Xavier Leroy)
+
 - GPR#1752: do not alias function arguments to sigprocmask.
   (Anil Madhavapeddy)
 

--- a/asmcomp/arm64/emit.mlp
+++ b/asmcomp/arm64/emit.mlp
@@ -114,6 +114,7 @@ let emit_addressing addr r =
   | Iindexed ofs ->
       `[{emit_reg r}, #{emit_int ofs}]`
   | Ibased(s, ofs) ->
+      assert (not !Clflags.dlcode);  (* see selection.ml *)
       `[{emit_reg r}, #:lo12:{emit_symbol_offset s ofs}]`
 
 (* Record live pointers at call points *)
@@ -323,7 +324,7 @@ let emit_literals() =
 (* Emit code to load the address of a symbol *)
 
 let emit_load_symbol_addr dst s =
-  if (not !Clflags.dlcode) || Compilenv.symbol_in_current_unit s then begin
+  if not !Clflags.dlcode then begin
     `	adrp	{emit_reg dst}, {emit_symbol s}\n`;
     `	add	{emit_reg dst}, {emit_reg dst}, #:lo12:{emit_symbol s}\n`
   end else begin
@@ -609,6 +610,7 @@ let emit_instr i =
           match addr with
           | Iindexed _ -> i.arg.(0)
           | Ibased(s, ofs) ->
+              assert (not !Clflags.dlcode);  (* see selection.ml *)
               `	adrp	{emit_reg reg_tmp1}, {emit_symbol_offset s ofs}\n`;
               reg_tmp1 in
         begin match size with
@@ -636,6 +638,7 @@ let emit_instr i =
           match addr with
           | Iindexed _ -> i.arg.(1)
           | Ibased(s, ofs) ->
+              assert (not !Clflags.dlcode);
               `	adrp	{emit_reg reg_tmp1}, {emit_symbol_offset s ofs}\n`;
               reg_tmp1 in
         begin match size with
@@ -924,7 +927,15 @@ let fundecl fundecl =
 
 let emit_item = function
   | Cglobal_symbol s -> `	.globl	{emit_symbol s}\n`;
-  | Cdefine_symbol s -> `{emit_symbol s}:\n`
+  | Cdefine_symbol s ->
+    if !Clflags.dlcode then begin
+      (* GOT relocations against non-global symbols don't seem to work
+         properly: GOT entries are not created for the symbols and the
+         relocations evaluate to random other GOT entries.  For the moment
+         force all symbols to be global. *)
+      `	.globl	{emit_symbol s}\n`;
+    end;
+    `{emit_symbol s}:\n`
   | Cint8 n -> `	.byte	{emit_int n}\n`
   | Cint16 n -> `	.short	{emit_int n}\n`
   | Cint32 n -> `	.long	{emit_nativeint n}\n`

--- a/asmcomp/arm64/selection.ml
+++ b/asmcomp/arm64/selection.ml
@@ -82,8 +82,8 @@ let inline_ops =
   [ "sqrt"; "caml_bswap16_direct"; "caml_int32_direct_bswap";
     "caml_int64_direct_bswap"; "caml_nativeint_direct_bswap" ]
 
-let use_direct_addressing symb =
-  (not !Clflags.dlcode) || Compilenv.symbol_in_current_unit symb
+let use_direct_addressing _symb =
+  not !Clflags.dlcode
 
 (* Instruction selection *)
 


### PR DESCRIPTION
'tis the season to do back-ports, fa la la la la, la la la la 🎉🥳

We noticed a while ago - but had not made high priority - that the aarch64 _flambda_ Docker images were not building for 4.03-4.05. This is down to the lack of #1330 from 4.06.1. This change was to do with an alteration in binutils, so it also falls under the "building an _older_ compiler with _newer_ external tools" category.

This is the commit for 4.05. Changes separated (as with the glibc patches last year) to allow the commit patch to be referenced from opam-repository. opam-repository PR to follow. The commits for 4.03 is https://github.com/dra27/ocaml/commit/13700615d31c0609dcacc5f2de1cbbfd562dbb2b and for 4.04 is https://github.com/dra27/ocaml/commit/1adab0d9593dfd97fbff5fd4890734ee982ce170. I've tested all three of them on an arm64 box and even the testsuite is a full pass 💪

(as before, this will be merged by direct push, so please don't use the merge button from the PR)