### PR TITLE
Fix "ocamlrun -b" crash

### DIFF
--- a/Changes
+++ b/Changes
@@ -289,6 +289,9 @@ Working version
 - #11809: Protect Parmatch.pats_of_type from missing cmis
   (Jacques Garrigue, review by Stephen Dolan and Gabriel Scherer)
 
+- #11824: Fix a crash when calling `ocamlrun -b`
+  (Florian Angeletti, review by Sébastien Hinderer)
+
 OCaml 5.0
 ---------
 

--- a/runtime/startup_byt.c
+++ b/runtime/startup_byt.c
@@ -324,7 +324,7 @@ static int parse_command_line(char_os **argv)
         exit(0);
         break;
       case 'b':
-        caml_record_backtraces(1);
+        params->backtrace_enabled = 1;
         break;
       case 'I':
         if (argv[i + 1] != NULL) {


### PR DESCRIPTION
The code paths for `ocamlrun -b` and `OCAMLRUNPARAM=b ocamlrun ...` have currently diverged in such way that the former is currently segfaulting.

The issue is that `ocamlrun -b` calls `caml_record_backtraces` before domains are fully initialized, which results in a crash once `caml_record_backtraces` try to access `Caml_state`.

This PR fixes the divergence and the crash by setting `caml_params<-backtrace_enabled` to true in both code paths.