### PR TITLE
a failed attempt at using lf_skiplist for generational roots

### DIFF
--- a/genroots/bench.ml
+++ b/genroots/bench.ml
@@ -1,0 +1,132 @@
+module type Root = sig
+  type 'a t
+  val create : 'a -> 'a t
+  val get : 'a t -> 'a
+  val delete : 'a t -> unit
+end
+
+module Ref : Root = struct
+  type 'a t = 'a ref
+  let create v = ref v
+  let get r = !r
+  let delete _ = ()
+end
+
+module Genroot : Root = struct
+  type 'a t
+  external create : 'a -> 'a t         = "generational_ref_create"
+  external get : 'a t -> 'a            = "generational_ref_get"
+  external delete : 'a t -> unit       = "generational_ref_delete"
+end
+
+module Primes (Root : Root) : sig
+  val count_upto : int -> int
+end = struct
+  let consume r =
+    let v = Root.get r in
+    Root.delete r; v
+  
+  type 'a rseq = Seq of (unit -> 'a rnode) [@@unboxed]
+  
+  and 'a rnode =
+  | Nil
+  | Cons of ('a * 'a rseq) Root.t
+  
+  let cons x xs = Cons (Root.create (x, xs))
+  
+  let numbers_from_to k n =
+    let rec loop k n = Seq (fun () ->
+      if k > n then Nil
+      else cons k (loop (k + 1) n)
+    ) in loop k n
+  
+  let rec map_consume f (Seq f) = Seq (fun () ->
+    match f () with
+    | Nil -> Nil
+    | Cons r ->
+      let (x, xs) = consume r in
+      cons (f x) (map_consume f xs)
+  )
+  
+  let rec filter_consume p (Seq f) = Seq (fun () ->
+    match f () with
+    | Nil -> Nil
+    | Cons r ->
+      let (x, xs) = consume r in
+      let ys = filter_consume p xs in
+      if p x then cons x ys else (let (Seq f) = ys in f ())
+  )
+  
+  let seq_uncons_consume (Seq f) = match f () with
+  | Nil -> None
+  | Cons r -> Some (consume r)
+  
+  (* prime numbers up to [n] *)
+  let rec eratosthenes n =
+    let rec loop n (Seq f) = Seq (fun () ->
+      match f () with
+      | Nil -> Nil
+      | Cons r as nums ->
+         let (k, rest) = Root.get r in
+         if k * k > n then nums
+         else begin
+           Root.delete r;
+           cons k
+             (rest
+              |> filter_consume (fun i -> i mod k <> 0)
+              |> loop n)
+         end
+    ) in
+    loop n (numbers_from_to 2 n)
+
+  let rec to_list_consume (Seq f) = match f () with
+    | Nil -> []
+    | Cons r ->
+       let (x, xs) = consume r in
+       x :: to_list_consume xs
+
+  let rec length_consume (Seq f) = match f () with
+    | Nil -> 0
+    | Cons r ->
+       let (_, xs) = consume r in
+       1 + length_consume xs
+
+  let count_upto n =
+    eratosthenes n
+    |> length_consume
+end
+
+module Conf = struct
+  let n =
+    try int_of_string (Sys.getenv "N")
+    with _ ->
+      Printf.ksprintf failwith "We expected an environment variable N with an integer value."
+  
+  let doms =
+    try int_of_string (Sys.getenv "DOMS")
+    with _ ->
+      Printf.ksprintf failwith "We expected an environment variable DOMS with an integer value."
+
+  type impl = Ref | Genroot
+  let impl =
+    let impls = [("ref", Ref); ("genroot", Genroot)] in
+    try List.assoc (Sys.getenv "IMPL") impls
+    with _ ->
+      Printf.ksprintf failwith "We expected an environment variable IMPL, 'ref' or 'genroot'."
+
+  let impl_mod : (module Root) = match impl with
+    | Ref -> (module Ref)
+    | Genroot -> (module Genroot)
+  
+  module Impl = (val impl_mod : Root)
+end
+
+module P = Primes(Conf.Impl)
+
+let () =
+  let do_work () = P.count_upto Conf.n in
+  let worker_domains = List.init (Conf.doms - 1) (fun _ -> Domain.spawn do_work) in
+  let res0 = do_work () in
+  let results = res0 :: List.map Domain.join worker_domains in
+  Printf.printf "%d\n%!" res0;
+  assert (List.for_all ((=) res0) results);

--- a/genroots/generational.c
+++ b/genroots/generational.c
@@ -1,0 +1,30 @@
+/* SPDX-License-Identifier: MIT */
+#define CAML_NAME_SPACE
+#include <caml/mlvalues.h>
+#include <caml/memory.h>
+#include <caml/alloc.h>
+#include <caml/gc.h>
+
+#include "tagged_out_of_heap.h"
+
+typedef value ref;
+
+ref generational_ref_create(value v)
+{
+  value b = alloc_tagged_block();
+  *(Block_data(b)) = v;
+  caml_register_generational_global_root(Block_data(b));
+  return b;
+}
+
+value generational_ref_get(ref r)
+{
+  return *Block_data(r);
+}
+
+value generational_ref_delete(ref r)
+{
+  caml_remove_generational_global_root(Block_data(r));
+  free_tagged_block(r);
+  return Val_unit;
+}

--- a/genroots/tagged_out_of_heap.h
+++ b/genroots/tagged_out_of_heap.h
@@ -1,0 +1,19 @@
+/* SPDX-License-Identifier: MIT */
+#ifndef ABSTRACT_OUT_OF_HEAP_H
+
+#include "caml/mlvalues.h"
+
+#define Block_data(b) ((value *)(b & ~((value)1)))
+
+inline value alloc_tagged_block(void)
+{
+  value *b = malloc(sizeof(value));
+  return (value)b | (value)1;
+}
+
+inline void free_tagged_block(value b)
+{
+  free(Block_data(b));
+}
+
+#endif // ABSTRACT_OUT_OF_HEAP_H

--- a/runtime/caml/globroots.h
+++ b/runtime/caml/globroots.h
@@ -23,6 +23,8 @@
 #include "mlvalues.h"
 #include "roots.h"
 
+void caml_init_global_roots();
+
 void caml_scan_global_roots(scanning_action f, void* fdata);
 void caml_scan_global_young_roots(scanning_action f, void* fdata);
 

--- a/runtime/caml/lf_skiplist.h
+++ b/runtime/caml/lf_skiplist.h
@@ -84,9 +84,16 @@ extern int caml_lf_skiplist_insert(struct lf_skiplist *sk, uintnat key,
    If [key] was not there, leave the skip list unchanged and return 0. */
 extern int caml_lf_skiplist_remove(struct lf_skiplist *sk, uintnat key);
 
-/* This must only be called by a single domain during a stop-the world
-    protected by global barriers. */
+/* These are not concurrency-safe, they must only be called by
+    a single domain during a stop-the world protected by global
+    barriers.
+
+    [caml_lf_skiplist_free_garbage] frees the removed elemnts.
+    [caml_lf_skiplist_free] frees the whole data structure.
+*/
 extern void caml_lf_skiplist_free_garbage(struct lf_skiplist *sk);
+extern void caml_lf_skiplist_free(struct lf_skiplist *sk); /* free the whole structure */
+
 
 /* Macros used for marking pointers and that are unfortunately necessary
   in the header for FOREACH_LF_SKIPLIST_ELEMENT to work */

--- a/runtime/globroots.c
+++ b/runtime/globroots.c
@@ -21,20 +21,18 @@
 #include "caml/memory.h"
 #include "caml/roots.h"
 #include "caml/globroots.h"
-#include "caml/skiplist.h"
+#include "caml/lf_skiplist.h"
 #include "caml/stack.h"
-
-static caml_plat_mutex roots_mutex = CAML_PLAT_MUTEX_INITIALIZER;
 
 /* The three global root lists.
    Each is represented by a skip list with the key being the address
    of the root.  (The associated data field is unused.) */
 
-struct skiplist caml_global_roots = SKIPLIST_STATIC_INITIALIZER;
+struct lf_skiplist caml_global_roots;
                   /* mutable roots, don't know whether old or young */
-struct skiplist caml_global_roots_young = SKIPLIST_STATIC_INITIALIZER;
+struct lf_skiplist caml_global_roots_young;
                   /* generational roots pointing to minor or major heap */
-struct skiplist caml_global_roots_old = SKIPLIST_STATIC_INITIALIZER;
+struct lf_skiplist caml_global_roots_old;
                   /* generational roots pointing to major heap */
 
 /* The invariant of the generational roots is the following:
@@ -46,20 +44,23 @@ struct skiplist caml_global_roots_old = SKIPLIST_STATIC_INITIALIZER;
      then neither [caml_global_roots_young] nor [caml_global_roots_old] contain
      it. */
 
-/* Insertion and deletion */
-
-Caml_inline void caml_insert_global_root(struct skiplist * list, value * r)
+void caml_init_global_roots()
 {
-  caml_plat_lock(&roots_mutex);
-  caml_skiplist_insert(list, (uintnat) r, 0);
-  caml_plat_unlock(&roots_mutex);
+  caml_lf_skiplist_init(&caml_global_roots);
+  caml_lf_skiplist_init(&caml_global_roots_young);
+  caml_lf_skiplist_init(&caml_global_roots_old);
 }
 
-Caml_inline void caml_delete_global_root(struct skiplist * list, value * r)
+/* Insertion and deletion */
+
+Caml_inline void caml_insert_global_root(struct lf_skiplist * list, value * r)
 {
-  caml_plat_lock(&roots_mutex);
-  caml_skiplist_remove(list, (uintnat) r);
-  caml_plat_unlock(&roots_mutex);
+  caml_lf_skiplist_insert(list, (uintnat) r, 0);
+}
+
+Caml_inline void caml_delete_global_root(struct lf_skiplist * list, value * r)
+{
+  caml_lf_skiplist_remove(list, (uintnat) r);
 }
 
 /* Register a global C root of the mutable kind */
@@ -158,12 +159,14 @@ CAMLexport void caml_modify_generational_global_root(value *r, value newval)
 
 #ifdef NATIVE_CODE
 
-/* Linked-list of natdynlink'd globals */
+/* Linked-list of natdynlink'd globals, protected by a global mutex. */
 
 typedef struct link {
   void *data;
   struct link *next;
 } link;
+
+static caml_plat_mutex dyn_globals_lock = CAML_PLAT_MUTEX_INITIALIZER;
 
 static link *cons(void *data, link *tl) {
   link *lnk = caml_stat_alloc(sizeof(link));
@@ -175,14 +178,12 @@ static link *cons(void *data, link *tl) {
 #define iter_list(list,lnk) \
   for (lnk = list; lnk != NULL; lnk = lnk->next)
 
-
-/* protected by roots_mutex */
 static link * caml_dyn_globals = NULL;
 
 void caml_register_dyn_global(void *v) {
-  caml_plat_lock(&roots_mutex);
+  caml_plat_lock(&dyn_globals_lock);
   caml_dyn_globals = cons((void*) v,caml_dyn_globals);
-  caml_plat_unlock(&roots_mutex);
+  caml_plat_unlock(&dyn_globals_lock);
 }
 
 static void scan_native_globals(scanning_action f, void* fdata)
@@ -192,9 +193,9 @@ static void scan_native_globals(scanning_action f, void* fdata)
   value* glob;
   link* lnk;
 
-  caml_plat_lock(&roots_mutex);
+  caml_plat_lock(&dyn_globals_lock);
   dyn_globals = caml_dyn_globals;
-  caml_plat_unlock(&roots_mutex);
+  caml_plat_unlock(&dyn_globals_lock);
 
   /* The global roots */
   for (i = 0; caml_globals[i] != 0; i++) {
@@ -219,41 +220,54 @@ static void scan_native_globals(scanning_action f, void* fdata)
 
 /* Iterate a GC scanning action over a global root list */
 Caml_inline void caml_iterate_global_roots(scanning_action f,
-                                      struct skiplist * rootlist, void* fdata)
+                                      struct lf_skiplist * rootlist, void* fdata)
 {
-  FOREACH_SKIPLIST_ELEMENT(e, rootlist, {
+  FOREACH_LF_SKIPLIST_ELEMENT(e, rootlist, {
       value * r = (value *) (e->key);
       f(fdata, *r, r);
     })
 }
 
-/* Scan all global roots */
+/* Scan all global roots.
+   Called by a single thread during a STW section
+   (no possible race against insert/delete in mutators). */
 void caml_scan_global_roots(scanning_action f, void* fdata) {
-  caml_plat_lock(&roots_mutex);
   caml_iterate_global_roots(f, &caml_global_roots, fdata);
+  caml_lf_skiplist_free_garbage(&caml_global_roots);
+
   caml_iterate_global_roots(f, &caml_global_roots_young, fdata);
+  caml_lf_skiplist_free_garbage(&caml_global_roots_young);
+
   caml_iterate_global_roots(f, &caml_global_roots_old, fdata);
-  caml_plat_unlock(&roots_mutex);
+  caml_lf_skiplist_free_garbage(&caml_global_roots_old);
+
 
   #ifdef NATIVE_CODE
   scan_native_globals(f, fdata);
   #endif
 }
 
-/* Scan global roots for a minor collection */
+/* Scan global roots for a minor collection.
+   Called by a single domain during a STW section
+   (no possible race against insert/delete in mutators). */
 void caml_scan_global_young_roots(scanning_action f, void* fdata)
 {
-  caml_plat_lock(&roots_mutex);
-
+  /* Note: we do not free the skiplist garbage here,
+     only in [caml_scan_global_roots], to reduce
+     minor GC latencis. */
   caml_iterate_global_roots(f, &caml_global_roots, fdata);
   caml_iterate_global_roots(f, &caml_global_roots_young, fdata);
 
   /* Move young roots to old roots */
-  FOREACH_SKIPLIST_ELEMENT(e, &caml_global_roots_young, {
+  int young_count = 0;
+  FOREACH_LF_SKIPLIST_ELEMENT(e, &caml_global_roots_young, {
+      young_count++;
       value * r = (value *) (e->key);
-      caml_skiplist_insert(&caml_global_roots_old, (uintnat) r, 0);
+      caml_lf_skiplist_insert(&caml_global_roots_old, (uintnat) r, 0);
+      /* caml_lf_skiplist_remove(&caml_global_roots_young, (uintnat) r); */
     });
-  caml_skiplist_empty(&caml_global_roots_young);
-
-  caml_plat_unlock(&roots_mutex);
+  if (young_count > 0) {
+    caml_lf_skiplist_free(&caml_global_roots_young);
+    caml_lf_skiplist_init(&caml_global_roots_young);
+  }
 }

--- a/runtime/startup_byt.c
+++ b/runtime/startup_byt.c
@@ -43,6 +43,7 @@
 #include "caml/fiber.h"
 #include "caml/fix_code.h"
 #include "caml/gc_ctrl.h"
+#include "caml/globroots.h"
 #include "caml/instrtrace.h"
 #include "caml/interp.h"
 #include "caml/intext.h"
@@ -470,6 +471,7 @@ CAMLexport void caml_main(char_os **argv)
     return;
 
   caml_init_codefrag();
+  caml_init_global_roots();
 
   caml_init_locale();
 #ifdef _MSC_VER
@@ -613,6 +615,7 @@ CAMLexport value caml_startup_code_exn(
     return Val_unit;
 
   caml_init_codefrag();
+  caml_init_global_roots();
 
   caml_init_locale();
 #ifdef _MSC_VER

--- a/runtime/startup_nat.c
+++ b/runtime/startup_nat.c
@@ -28,6 +28,7 @@
 #include "caml/fail.h"
 #include "caml/gc.h"
 #include "caml/gc_ctrl.h"
+#include "caml/globroots.h"
 #include "caml/intext.h"
 #include "caml/memory.h"
 #include "caml/misc.h"
@@ -102,6 +103,7 @@ value caml_startup_common(char_os **argv, int pooling)
     return Val_unit;
 
   caml_init_codefrag();
+  caml_init_global_roots();
   caml_init_locale();
 #ifdef _MSC_VER
   caml_install_invalid_parameter_handler();


### PR DESCRIPTION
Meta: This PR records a failed attempt at improving the performance of generational global roots in the Multicore runtime. I submit it as a way to record a trace, to help future discussions and possibly be of use later -- for example it includes a function to `free` a skiplist that is currently missing from lf_skiplist, and could be of use to other people. It will be closed immediately upon submission.

## Context

Generational global roots scale poorly when in heavy use by multiple domains. (Thankfully, workflows that make heavy use of generational global roots are relatively rare.)

I wrote a small benchmark making heavy use of generational roots. The benchmark has a given workload (parametrized by the environment variable N), and it spawns $DOMS domains to run a copy of this workflow in parallel on each domain. If we had perfect scalability, then the runtime would be the same for any value of $DOMS (each domain completes its workload independently of the other, in the same amount of time). In practice, (generational) global roots are handled globally across domains, so they scaling properties are very far from this perfect picture.

| DOMS   | real time | slowdown vs. DOMS=1 | user time | system time |
| ------ | --------- | ------------------- | --------- | --------- |
| DOMS=1 | 0m00.709s | x1                  | 0m00.698s | 0m00.009s |
| DOMS=2 | 0m06.562s | x9                  | 0m08.035s | 0m04.727s |
| DOMS=4 | 0m14.914s | x21                 | 0m20.363s | 0m27.283s |
| DOMS=6 | 0m32.883s | x46                 | 0m47.421s | 1m41.375s |

(one can observe the "system" time growing quite a bit, I believe that this corresponds to the total time spent waiting for locks in contended situations.)

### The PR

Global roots are currently implemented using a sequential skiplist data structure, protected by a global mutex. Trunk code example:

https://github.com/ocaml/ocaml/blob/eb31831a960800f20ca2edd556858c00546cc178/runtime/globroots.c#L51-L56

Multicore OCaml also provides a concurrent skiplist (lf_skiplist for "lock free skiplist") that is used in other parts of the runtime that should scale well under concurrent usage. So the idea of this PR is to move from a sequential mutex + global lock to a concurrent skiplist. PR code example:

https://github.com/ocaml/ocaml/blob/d3844b36b92b167c01c6a9c08b1eecefb4ecdccc/runtime/globroots.c#L56-L59

## Results

Unfortunately, the performance results of the PR are worse than with the current code, so the PR is dead on arrival. 

lf_skiplist clearly scales better, but it also has a noticeable overhead compared to the sequential skiplist (it is a much more complex implementation), making the DOMS=1 version twice slower than trunk. Having more domains make the results look a bit better but on my (arbitrary) benchmark they are not much better than with the global lock.

| DOMS   | real time | slowdown vs. DOMS=1 | user time | system time |
| ------ | --------- | ------------------- | --------- | ----------- |
| DOMS=1 | 0m01.464s | x1                  | 0m01.428s | 0m0.025s    |
| DOMS=2 | 0m05.168s | x3.5                | 0m09.855s | 0m0.020s    |
| DOMS=4 | 0m16.882s | x11.5               | 1m00.489s | 0m0.068s    |
| DOMS=6 | 0m26.335s | x18                 | 2m18.004s | 0m0.181s    |

(The user time is much higher than win the pre-PR benchmark results. To me this suggests that this version may consume more CPU / more energy, but I don't know much about how to measure this.)

## Useful bits

I'm opening the PR because some bits of my local branch may be useful to myself or other in the future:

- a `free` function for lf_skiplist: https://github.com/gasche/ocaml/blob/c173b35aad885fe0c5720bc5ca8bf7745b2dff7e/runtime/lf_skiplist.c#L518-L534
- a somewhat artificial benchmark that makes heavy use of generational global roots (it is inspired by the benchmarks we wrote for [boxroot](https://gitlab.com/ocaml-rust/ocaml-boxroot/) and reuses some code from there): https://github.com/ocaml/ocaml/tree/c173b35aad885fe0c5720bc5ca8bf7745b2dff7e/genroots

Thanks for reading this far and, well, sorry for the disappointing results. Closing.