### PR TITLE
Restore prefetching for GC marking

### DIFF
--- a/Changes
+++ b/Changes
@@ -71,6 +71,9 @@ Working version
 - #11935: Load frametables of dynlink'd modules in batch
   (Stephen Dolan, review by David Allsopp and Guillaume Munch-Maccagnoni)
 
+- #11827: Restore prefetching for GC marking
+  (Fabrice Buoro and Stephen Dolan, review by Gabriel Scherer and Sadiq Jaffer)
+
 ### Type system:
 
 - #6941, #11187: prohibit using classes through recursive modules


### PR DESCRIPTION
This PR restores the prefetching used in 4.14 to speed up the GC marking. See the initial PR [Speed up GC by prefetching during marking #10195](https://github.com/ocaml/ocaml/pull/10195) for more explanation.

# The tracing algorithm with prefetching
- Attempt to pop a block from the `prefetch_buffer` with `pb_pop` if it's filled enough (`pb_above_waterline`) for the prefetching to have completed.
  - The poped block is marked.
  - Construct a `mark_entry` from the block fields.
- Otherwise, pop a `mark_entry` from the `mark_stack`.
- Otherwise, the `mark_stack` being empty, set the `prefetch_buffer` to draining mode with `pb_drain`, and try again. The marking is complete if the `prefetch_buffer` is already in draining mode.
- Attempt to prefetch each field of the `mark_entry`, adding them to the `prefetch_buffer` with `pb_push`. Blocks that can't be prefetched because the `prefetch_buffer` is full (`pb_full`) are added back to the `mark_stack`.
 
# Changes to 4.14 implementation
The `prefetch_buffer_t` type is introduced to hold implementation details for the prefetch ring buffer.
`prefetch_buffer_t` operations have their own set of associated inline functions (`pb_*`) to increase readability.
A `waterline` member is added to the `prefetch_buffer_t` struct acting as the `min_pb` in 4.14.
Calling the function `pb_drain` to set the `prefetch_buffer_t` in draining mode is equivalent to setting the `waterline` (`min_pb` previously) to 0. Likewise, calling `pb_fill` resets it to filling mode, setting the `waterline` to `PREFETCH_BUFFER_MIN` (`Pb_min` previously).
The `prefetch_buffer_t` is reset to filling mode (`pb_fill`) as soon it's filled with more than `PREFETCH_BUFFER_MIN` elements.
Also, the `Chunk_size` was increased from `0x400` to `0x4000` to better use the `prefetch_buffer`.

# Performance
Using @stedolan [micro-benchmark](https://gist.github.com/stedolan/4369a0fa27820e27d6e56bee5e412896) (using `GC.major` rather `GC.full_major`) yields as good performance as 4.14:
* Results on 4.14:
```
$ perf stat -- ./4.14.out
0.292 s/gc

 Performance counter stats for './4.14.out':

          6 882,45 msec task-clock                       #    1,000 CPUs utilized          
                21      context-switches                 #    3,051 /sec                   
                 4      cpu-migrations                   #    0,581 /sec                   
           204 288      page-faults                      #   29,682 K/sec                  
    31 417 903 050      cycles                           #    4,565 GHz                    
    79 234 045 125      instructions                     #    2,52  insn per cycle         
    15 569 722 764      branches                         #    2,262 G/sec                  
         1 747 089      branch-misses                    #    0,01% of all branches        
   156 756 988 485      slots                            #   22,776 G/sec                  
    62 702 795 394      topdown-retiring                 #     39,9% Retiring              
    10 450 465 899      topdown-bad-spec                 #      6,7% Bad Speculation       
     7 024 075 924      topdown-fe-bound                 #      4,5% Frontend Bound        
    76 841 661 022      topdown-be-bound                 #     48,9% Backend Bound         

       6,883408392 seconds time elapsed

       6,778832000 seconds user
       0,100007000 seconds sys
```
* Results with this PR latest commit:
```
0.297 s/gc

 Performance counter stats for './a.out':

          6 975,48 msec task-clock                       #    0,996 CPUs utilized          
               381      context-switches                 #   54,620 /sec                   
                 6      cpu-migrations                   #    0,860 /sec                   
           202 655      page-faults                      #   29,052 K/sec                  
    31 338 550 747      cycles                           #    4,493 GHz                    
    97 787 430 050      instructions                     #    3,12  insn per cycle         
    26 528 909 898      branches                         #    3,803 G/sec                  
         3 306 533      branch-misses                    #    0,01% of all branches        
   156 123 397 625      slots                            #   22,382 G/sec                  
    68 973 229 344      topdown-retiring                 #     39,0% Retiring              
    46 530 894 978      topdown-bad-spec                 #     26,3% Bad Speculation       
     9 527 351 720      topdown-fe-bound                 #      5,4% Frontend Bound        
    51 699 140 857      topdown-be-bound                 #     29,3% Backend Bound         

       7,002423462 seconds time elapsed

       6,727727000 seconds user
       0,239205000 seconds sys
```
* Results on trunk (actually the parent commit to this PR):
```
$ perf stat -- ./97aa649.out 
1.051 s/gc

 Performance counter stats for './97aa649.out':

         22 742,08 msec task-clock                       #    1,000 CPUs utilized          
                54      context-switches                 #    2,374 /sec                   
                 3      cpu-migrations                   #    0,132 /sec                   
           202 708      page-faults                      #    8,913 K/sec                  
   104 298 566 270      cycles                           #    4,586 GHz                    
   101 710 911 014      instructions                     #    0,98  insn per cycle         
    24 616 971 674      branches                         #    1,082 G/sec                  
         3 696 047      branch-misses                    #    0,02% of all branches        
   521 433 112 175      slots                            #   22,928 G/sec                  
    85 977 421 213      topdown-retiring                 #     16,3% Retiring              
    36 807 043 212      topdown-bad-spec                 #      7,0% Bad Speculation       
     6 860 349 204      topdown-fe-bound                 #      1,3% Frontend Bound        
   397 861 864 068      topdown-be-bound                 #     75,4% Backend Bound         

      22,743431435 seconds time elapsed

      22,556285000 seconds user
       0,179963000 seconds sys
```
# Acknowldgement
Thanks to @stedolan for his help, @ctk21 and @sadiqj for their advice, and @Engil for the initial bootstrap.