### PR TITLE
add Array.map_inplace

### DIFF
--- a/Changes
+++ b/Changes
@@ -72,6 +72,9 @@ Working version
 
 ### Standard library:
 
+- #11836: Add `Array.map_inplace`.
+  (Léo Andrès, review by Gabriel Scherer and KC Sivaramakrishnan)
+
 - #11410: Add Set.to_list, Map.to_list, Map.of_list, Map.add_to_list,
   (Daniel Bünzli, review by Nicolás Ojeda Bär and Gabriel Scherer)
 

--- a/stdlib/array.ml
+++ b/stdlib/array.ml
@@ -107,6 +107,11 @@ let map f a =
     r
   end
 
+let map_inplace f a =
+  for i = 0 to length a - 1 do
+    unsafe_set a i (f (unsafe_get a i))
+  done
+
 let map2 f a b =
   let la = length a in
   let lb = length b in

--- a/stdlib/array.mli
+++ b/stdlib/array.mli
@@ -160,6 +160,11 @@ val map : ('a -> 'b) -> 'a array -> 'b array
    and builds an array with the results returned by [f]:
    [[| f a.(0); f a.(1); ...; f a.(length a - 1) |]]. *)
 
+val map_inplace : ('a -> 'a) -> 'a array -> unit
+(** [map_inplace f a] applies function [f] to all elements of [a],
+    and updates their values in place.
+    @since 5.1 *)
+
 val mapi : (int -> 'a -> 'b) -> 'a array -> 'b array
 (** Same as {!map}, but the
    function is applied to the index of the element as first argument,

--- a/stdlib/arrayLabels.mli
+++ b/stdlib/arrayLabels.mli
@@ -160,6 +160,11 @@ val map : f:('a -> 'b) -> 'a array -> 'b array
    and builds an array with the results returned by [f]:
    [[| f a.(0); f a.(1); ...; f a.(length a - 1) |]]. *)
 
+val map_inplace : f:('a -> 'a) -> 'a array -> unit
+(** [map_inplace ~f a] applies function [f] to all elements of [a],
+    and updates their values in place.
+    @since 5.1 *)
+
 val mapi : f:(int -> 'a -> 'b) -> 'a array -> 'b array
 (** Same as {!map}, but the
    function is applied to the index of the element as first argument,

--- a/testsuite/tests/lib-array/test_array.ml
+++ b/testsuite/tests/lib-array/test_array.ml
@@ -129,3 +129,11 @@ let (_ : (_ * unit array)) =
 [%%expect{|
 - : int * unit array = (0, [||])
 |}]
+
+let a : int array =
+  let a = [| 1 ; 2 ; 3 ; 4 |] in
+  Array.map_inplace (fun x -> 2 * x) a;
+  a
+[%%expect{|
+val a : int array = [|2; 4; 6; 8|]
+|}]


### PR DESCRIPTION
Hi,

This PR adds a `val map_inplace : ('a -> 'a) -> 'a array -> unit` function to the `Array` module.

This allow to replace code like :

```ocaml
let a = Array.init 10 (fun n -> 2 * n)
let () = Array.iteri (fun i x ->
    Array.set a i (succ x)
  ) a
```

by :

```ocaml
let a = Array.init 10 (fun n -> 2 * n)
let () = Array.map_inplace succ a
```

The function is in containers and in base, with the exact same name. In base it's implemented the same way, in containers it's using `iteri` instead of a loop.

I've written a simple test and added the function in the `ArrayLabels` module too.

The CI says:

> ./stdlib/array.mli:166.16: [doc-version] version should be formatted M.m (e.g. 5.0)

That's because I wrote `5.01`. But I'm not sure which one is the best as everywhere else it's e.g. `4.03` or `4.07` (in `array.mli` at least).