### PR TITLE
Add `intersperse` & `intercalate` to `List` & `Seq`

### DIFF
--- a/Changes
+++ b/Changes
@@ -77,7 +77,8 @@ Working version
 
 ### Standard library:
 
-- #11839: Add `List.intersperse`, `List.intercalate`.
+- #11839: Add `List.intersperse`, `List.intercalate`, `Seq.intersperse`,
+  `Seq.intercalate`.
   (Sima Kinsart, review by ???)
 
 - #11836: Add `Array.map_inplace`.

--- a/Changes
+++ b/Changes
@@ -77,6 +77,9 @@ Working version
 
 ### Standard library:
 
+- #11839: Add `List.intersperse`, `List.intercalate`.
+  (Sima Kinsart, review by ???)
+
 - #11836: Add `Array.map_inplace`.
   (Léo Andrès, review by Gabriel Scherer and KC Sivaramakrishnan)
 

--- a/stdlib/list.ml
+++ b/stdlib/list.ml
@@ -77,6 +77,21 @@ let rec flatten = function
 
 let concat = flatten
 
+let[@tail_mod_cons] rec intersperse sep = function
+  | ([] | [ _ ]) as l -> l
+  | a :: (_ :: _ as l) -> a :: sep :: intersperse sep l
+
+let[@tail_mod_cons] rec intercalate sep = function
+  | [] -> []
+  | xs :: [] -> xs
+  | xs :: (_ :: _ as ls) -> ic_one sep ls xs
+and[@tail_mod_cons] ic_one sep ls = function
+  | [] -> ic_sep sep ls sep
+  | x :: xs -> x :: ic_one sep ls xs
+and[@tail_mod_cons] ic_sep sep ls = function
+  | [] -> intercalate sep ls
+  | x :: xs -> x :: ic_sep sep ls xs
+
 let[@tail_mod_cons] rec map f = function
     [] -> []
   | [a1] ->

--- a/stdlib/list.mli
+++ b/stdlib/list.mli
@@ -126,6 +126,21 @@ val flatten : 'a list list -> 'a list
    (length of the argument + length of the longest sub-list).
  *)
 
+val intersperse : 'a -> 'a list -> 'a list
+(** [intersperse sep l] is the list formed by inserting [sep] between
+    adjacent elements of [l].
+    For example, [intersperse 0 \[1; 2; 3\]] is [\[1; 0; 2; 0; 3\]].
+
+    @since 5.1
+ *)
+
+val intercalate : 'a list -> 'a list list -> 'a list
+(** [intercalate sep l] is the list formed by inserting the list [sep]
+    between adjacent lists in [l] and then concatenating the result.
+    It is equivalent to [concat (intersperse sep l)].
+
+    @since 5.1
+ *)
 
 (** {1 Comparison} *)
 

--- a/stdlib/listLabels.mli
+++ b/stdlib/listLabels.mli
@@ -126,6 +126,21 @@ val flatten : 'a list list -> 'a list
    (length of the argument + length of the longest sub-list).
  *)
 
+val intersperse : sep:'a -> 'a list -> 'a list
+(** [intersperse ~sep l] is the list formed by inserting [sep] between
+    adjacent elements of [l].
+    For example, [intersperse 0 \[1; 2; 3\]] is [\[1; 0; 2; 0; 3\]].
+
+    @since 5.1
+ *)
+
+val intercalate : sep:'a list -> 'a list list -> 'a list
+(** [intercalate ~sep l] is the list formed by inserting the list [sep]
+    between adjacent lists in [l] and then concatenating the result.
+    It is equivalent to [intersperse ~sep l |> concat].
+
+    @since 5.1
+ *)
 
 (** {1 Comparison} *)
 

--- a/stdlib/seq.ml
+++ b/stdlib/seq.ml
@@ -62,6 +62,16 @@ let rec flat_map f seq () = match seq () with
 
 let concat_map = flat_map
 
+let rec intersperse sep seq () = match seq () with
+  | Nil -> Nil
+  | Cons (x, next) ->
+      match next () with
+      | Nil -> return x ()
+      | Cons (y, next) -> Cons (x, cons sep (intersperse sep (cons y next)))
+
+let intercalate sep seq () =
+  concat (intersperse sep seq) ()
+
 let rec fold_left f acc seq =
   match seq () with
     | Nil -> acc

--- a/stdlib/seq.mli
+++ b/stdlib/seq.mli
@@ -592,6 +592,19 @@ val concat_map : ('a -> 'b t) -> 'a t -> 'b t
 
     @since 4.13 *)
 
+val intersperse : 'a -> 'a t -> 'a t
+(** [intersperse sep seq] is the sequence formed by inserting [sep] between
+    adjacent elements of [seq].
+
+    @since 5.1 *)
+
+val intercalate : 'a t -> 'a t t -> 'a t
+(** [intercalate sep seq] is the sequence formed by inserting the
+    sequence [sep] between adjacent sequences in [seq] and then concatenating
+    the result. It is equivalent to [concat (intersperse sep seq)].
+
+    @since 5.1 *)
+
 val zip : 'a t -> 'b t -> ('a * 'b) t
 (** [zip xs ys] is the sequence of pairs [(x, y)]
     drawn synchronously from the sequences [xs] and [ys].

--- a/testsuite/tests/backtrace/backtrace_dynlink.reference
+++ b/testsuite/tests/backtrace/backtrace_dynlink.reference
@@ -1,17 +1,17 @@
 Raised by primitive operation at Backtrace_dynlink_plugin in file "backtrace_dynlink_plugin.ml", line 6, characters 13-38
 Called from Dynlink.Native.run.(fun) in file "otherlibs/dynlink/native/dynlink.ml", line 85, characters 12-29
-Called from Stdlib__List.iter in file "list.ml", line 112, characters 12-15
+Called from Stdlib__List.iter in file "list.ml", line 127, characters 12-15
 Called from Dynlink_common.Make.load.(fun) in file "otherlibs/dynlink/dynlink_common.ml", line 363, characters 13-56
-Called from Stdlib__List.iter in file "list.ml", line 112, characters 12-15
+Called from Stdlib__List.iter in file "list.ml", line 127, characters 12-15
 Called from Dynlink_common.Make.load in file "otherlibs/dynlink/dynlink_common.ml", line 359, characters 8-392
 Called from Dynlink_common.Make.loadfile in file "otherlibs/dynlink/dynlink_common.ml" (inlined), line 374, characters 26-45
 Called from Backtrace_dynlink in file "backtrace_dynlink.ml", line 39, characters 4-52
 execution of module initializers in the shared library failed: Failure("SUCCESS")
 Raised by primitive operation at Dynlink.Native.run.(fun) in file "otherlibs/dynlink/native/dynlink.ml", line 85, characters 12-29
 Re-raised at Dynlink.Native.run.(fun) in file "otherlibs/dynlink/native/dynlink.ml", line 87, characters 10-149
-Called from Stdlib__List.iter in file "list.ml", line 112, characters 12-15
+Called from Stdlib__List.iter in file "list.ml", line 127, characters 12-15
 Called from Dynlink_common.Make.load.(fun) in file "otherlibs/dynlink/dynlink_common.ml", line 363, characters 13-56
-Called from Stdlib__List.iter in file "list.ml", line 112, characters 12-15
+Called from Stdlib__List.iter in file "list.ml", line 127, characters 12-15
 Called from Dynlink_common.Make.load in file "otherlibs/dynlink/dynlink_common.ml", line 359, characters 8-392
 Re-raised at Dynlink_common.Make.load in file "otherlibs/dynlink/dynlink_common.ml", line 372, characters 8-17
 Called from Dynlink_common.Make.loadfile in file "otherlibs/dynlink/dynlink_common.ml" (inlined), line 374, characters 26-45

--- a/testsuite/tests/lib-dynlink-initializers/test10_main.byte.reference
+++ b/testsuite/tests/lib-dynlink-initializers/test10_main.byte.reference
@@ -6,7 +6,7 @@ Called from Test10_plugin in file "test10_plugin.ml", line 10, characters 2-6
 Called from Dynlink.Bytecode.run in file "otherlibs/dynlink/dynlink.ml", line 149, characters 16-25
 Re-raised at Dynlink.Bytecode.run in file "otherlibs/dynlink/dynlink.ml", line 151, characters 6-137
 Called from Dynlink_common.Make.load.(fun) in file "otherlibs/dynlink/dynlink_common.ml", line 363, characters 13-56
-Called from Stdlib__List.iter in file "list.ml", line 112, characters 12-15
+Called from Stdlib__List.iter in file "list.ml", line 127, characters 12-15
 Called from Dynlink_common.Make.load in file "otherlibs/dynlink/dynlink_common.ml", line 359, characters 8-392
 Re-raised at Dynlink_common.Make.load in file "otherlibs/dynlink/dynlink_common.ml", line 372, characters 8-17
 Called from Test10_main in file "test10_main.ml", line 51, characters 13-69

--- a/testsuite/tests/lib-dynlink-initializers/test10_main.native.reference
+++ b/testsuite/tests/lib-dynlink-initializers/test10_main.native.reference
@@ -1,9 +1,9 @@
 Error: Failure("Plugin error")
 Raised by primitive operation at Dynlink.Native.run.(fun) in file "otherlibs/dynlink/native/dynlink.ml", line 85, characters 12-29
 Re-raised at Dynlink.Native.run.(fun) in file "otherlibs/dynlink/native/dynlink.ml", line 87, characters 10-149
-Called from Stdlib__List.iter in file "list.ml", line 112, characters 12-15
+Called from Stdlib__List.iter in file "list.ml", line 127, characters 12-15
 Called from Dynlink_common.Make.load.(fun) in file "otherlibs/dynlink/dynlink_common.ml", line 363, characters 13-56
-Called from Stdlib__List.iter in file "list.ml", line 112, characters 12-15
+Called from Stdlib__List.iter in file "list.ml", line 127, characters 12-15
 Called from Dynlink_common.Make.load in file "otherlibs/dynlink/dynlink_common.ml", line 359, characters 8-392
 Re-raised at Dynlink_common.Make.load in file "otherlibs/dynlink/dynlink_common.ml", line 372, characters 8-17
 Called from Dynlink_common.Make.loadfile in file "otherlibs/dynlink/dynlink_common.ml" (inlined), line 374, characters 26-45

--- a/testsuite/tests/lib-list/test.ml
+++ b/testsuite/tests/lib-list/test.ml
@@ -96,6 +96,19 @@ let () =
   assert (
     let f a b = a + b, string_of_int b in
     List.fold_left_map f 0 l = (45, sl));
+
+  assert (List.intersperse 0 [] = []);
+  assert (List.intersperse 0 [1] = [1]);
+  assert (List.intersperse 0 [1; 2; 3] = [1; 0; 2; 0; 3]);
+  assert (List.intersperse 0 [1; 2; 3; 4] = [1; 0; 2; 0; 3; 0; 4]);
+
+  assert (List.intercalate [10] [] = []);
+  assert (List.intercalate [10] [[1; 2]] = [1; 2]);
+  assert (List.intercalate [10] [[1; 2]; [3; 4]; [5; 6]]
+          = [1; 2; 10; 3; 4; 10; 5; 6]);
+  assert (List.intercalate [10; 20] [[1; 2]; [3; 4]; [5; 6]]
+          = [1; 2; 10; 20; 3; 4; 10; 20; 5; 6]);
+
   ()
 ;;
 

--- a/testsuite/tests/lib-seq/test.ml
+++ b/testsuite/tests/lib-seq/test.ml
@@ -246,6 +246,24 @@ let () =
           = (List.of_seq s |> List.sort compare));
   ()
 
+(* [intersperse] *)
+let () =
+  assert (!!(Seq.intersperse 0 !?[]) = []);
+  assert (!!(Seq.intersperse 0 !?[1]) = [1]);
+  assert (!!(Seq.intersperse 0 !?[1; 2; 3]) = [1; 0; 2; 0; 3]);
+  assert (!!(Seq.intersperse 0 !?[1; 2; 3; 4]) = [1; 0; 2; 0; 3; 0; 4]);
+  ()
+
+(* [intercalate] *)
+let () =
+  assert (!!(Seq.intercalate !?[10] !?[]) = []);
+  assert (!!(Seq.intercalate !?[10] !?[!?[1; 2]]) = [1; 2]);
+  assert (!!(Seq.intercalate !?[10] !?[!?[1; 2]; !?[3; 4]; !?[5; 6]])
+          = [1; 2; 10; 3; 4; 10; 5; 6]);
+  assert (!!(Seq.intercalate !?[10; 20] !?[!?[1; 2]; !?[3; 4]; !?[5; 6]])
+          = [1; 2; 10; 20; 3; 4; 10; 20; 5; 6]);
+  ()
+
 (* Auxiliary definitions of 2d matrices. *)
 let square n f =
   Seq.(init n (fun i -> init n (fun j -> f i j)))

--- a/testsuite/tests/translprim/comparison_table.compilers.reference
+++ b/testsuite/tests/translprim/comparison_table.compilers.reference
@@ -159,7 +159,7 @@
                 (apply f (field_imm 0 param) (field_imm 1 param)))
             map =
               (function f l
-                (apply (field_imm 19 (global Stdlib__List!))
+                (apply (field_imm 21 (global Stdlib__List!))
                   (apply uncurry f) l)))
            (makeblock 0
              (makeblock 0 (apply map gen_cmp vec) (apply map cmp vec))
@@ -198,7 +198,7 @@
                     (apply f (field_imm 0 param) (field_imm 1 param)))
                 map =
                   (function f l
-                    (apply (field_imm 19 (global Stdlib__List!))
+                    (apply (field_imm 21 (global Stdlib__List!))
                       (apply uncurry f) l)))
                (makeblock 0
                  (makeblock 0 (apply map eta_gen_cmp vec)


### PR DESCRIPTION
This PR un-stalls https://github.com/ocaml/ocaml/pull/9962.

The `List` code is taken from that PR, except that I've renamed the two helper functions `inner` to `aux`, since this convention seems to be dominating throughout the file. In addition, I've also implemented `intersperse` and `intercalate` for `Seq` -- to maintain consistency. The `List` functions are tail-recursive.

For use cases and related discussion, see the above link.
