### PR TITLE
Fix bytecode-only install failing due to #11828

### DIFF
--- a/Changes
+++ b/Changes
@@ -265,7 +265,7 @@ Working version
   (Sébastien Hinderer, review by David Allsopp and Florian Angeletti)
 
 - #11828: Compile otherlibs/ C stubs in two version for native and bytecode
-  (Olivier Nicole, review by Sébastien Hinderer)
+  (Olivier Nicole, review by Sébastien Hinderer and Xavier Leroy)
 
 ### Bug fixes:
 

--- a/otherlibs/Makefile.otherlibs.common
+++ b/otherlibs/Makefile.otherlibs.common
@@ -106,15 +106,8 @@ install::
 	  $(INSTALL_PROG) \
 	    dll$(CLIBNAME_BYTECODE)$(EXT_DLL) "$(INSTALL_STUBLIBDIR)"; \
 	fi
-	if test -f dll$(CLIBNAME_NATIVE)$(EXT_DLL); then \
-	  $(INSTALL_PROG) \
-	    dll$(CLIBNAME_NATIVE)$(EXT_DLL) "$(INSTALL_STUBLIBDIR)"; \
-	fi
 ifneq "$(STUBSLIB_BYTECODE)" ""
 	$(INSTALL_DATA) $(STUBSLIB_BYTECODE) "$(INSTALL_LIBDIR)/"
-endif
-ifneq "$(STUBSLIB_NATIVE)" ""
-	$(INSTALL_DATA) $(STUBSLIB_NATIVE) "$(INSTALL_LIBDIR)/"
 endif
 # If installing over a previous OCaml version, ensure the library is removed
 # from the previous installation.
@@ -143,6 +136,13 @@ installopt:
 	if test -f $(LIBNAME).cmxs; then \
 	  $(INSTALL_PROG) $(LIBNAME).cmxs "$(INSTALL_LIBDIR_LIBNAME)"; \
 	fi
+	if test -f dll$(CLIBNAME_NATIVE)$(EXT_DLL); then \
+	  $(INSTALL_PROG) \
+	    dll$(CLIBNAME_NATIVE)$(EXT_DLL) "$(INSTALL_STUBLIBDIR)"; \
+	fi
+ifneq "$(STUBSLIB_NATIVE)" ""
+	$(INSTALL_DATA) $(STUBSLIB_NATIVE) "$(INSTALL_LIBDIR)/"
+endif
 
 partialclean:
 	rm -f *.cm*


### PR DESCRIPTION
FIx failure of the install step on bytecode-only systems introduced in #11828. This moves the relevant install steps from the `install` to the `installopt` target which seems to remove the problem.

I assume this does not require a Changes entry, so I’m merely modifying the preceding entry to acknowledge @xavierleroy’s review.