### PR TITLE
Add `In_channel.input_lines` and `In_channel.fold_lines`

### DIFF
--- a/Changes
+++ b/Changes
@@ -183,6 +183,9 @@ Working version
   (Daniel Bünzli, review by Jeremy Yallop, Gabriel Scherer, Wiktor Kuchta,
    Nicolás Ojeda Bär)
 
+- #11843: Add `In_channel.input_lines` and `In_channel.fold_lines`.
+  (Xavier Leroy, review by Nicolás Ojeda Bär and Wiktor Kuchta).
+
 ### Other libraries:
 
 - #11374: Remove pointer cast to a type with stricter alignment requirements

--- a/stdlib/in_channel.ml
+++ b/stdlib/in_channel.ml
@@ -170,6 +170,16 @@ let input_all ic =
         loop buf (nread + 1)
   end
 
+let [@tail_mod_cons] rec input_lines ic =
+  match Stdlib.input_line ic with
+  | line -> line :: input_lines ic
+  | exception End_of_file -> []
+
+let rec fold_lines f accu ic =
+  match Stdlib.input_line ic with
+  | line -> fold_lines f (f accu line) ic
+  | exception End_of_file -> accu
+
 let set_binary_mode = Stdlib.set_binary_mode_in
 
 external isatty : t -> bool = "caml_sys_isatty"

--- a/stdlib/in_channel.mli
+++ b/stdlib/in_channel.mli
@@ -112,6 +112,15 @@ val input_all : t -> string
     If the same channel is read concurrently by multiple threads, the returned
     string is not guaranteed to contain contiguous characters from the input. *)
 
+val input_lines : t -> string list
+(** [input_lines ic] reads lines using {!input_line}
+    until the end of file is reached.  It returns the list of all
+    lines read, in the order they were read.  The newline characters
+    that terminate lines are not included in the returned strings.
+    Empty lines produce empty strings.
+
+    @since 5.1 *)
+
 (** {1:advanced_input Advanced input}*)
 
 val input : t -> bytes -> int -> int -> int
@@ -138,6 +147,19 @@ val really_input : t -> bytes -> int -> int -> unit option
     @raise Invalid_argument if [pos] and [len] do not designate a valid range of
     [buf]. *)
 
+val fold_lines : ('acc -> string -> 'acc) -> 'acc -> t -> 'acc
+(** [fold_lines f init ic] reads lines from [ic] using {!input_line}
+    until the end of file is reached, and successively passes each line
+    to function [f] in the style of a fold.
+    More precisely, if lines [l1, ..., lN] are read,
+    [fold_lines f init ic] computes [f (... (f (f init l1) l2) ...) lN].
+    If [f] has no side effects, this is equivalent to
+    [List.fold_left f init (In_channel.input_lines ic)],
+    but is more efficient since it does not construct the list of all
+    lines read.
+
+    @since 5.1 *)
+
 (** {1:seeking Seeking} *)
 
 val seek : t -> int64 -> unit
@@ -161,28 +183,6 @@ val length : t -> int64
     regular file, the result is meaningless.  The returned size does not take
     into account the end-of-line translations that can be performed when reading
     from a channel opened in text mode. *)
-
-val input_lines : t -> string list
-(** [input_lines ic] reads lines using {!input_line}
-    until the end of file is reached.  It returns the list of all
-    lines read, in the order they were read.  The newline characters
-    that terminate lines are not included in the returned strings.
-    Empty lines produce empty strings.
-
-    @since 5.1 *)
-
-val fold_lines : ('acc -> string -> 'acc) -> 'acc -> t -> 'acc
-(** [fold_lines f init ic] reads lines from [ic] using {!input_line}
-    until the end of file is reached, and successively passes each line
-    to function [f] in the style of a fold.
-    More precisely, if lines [l1, ..., lN] are read,
-    [fold_lines f init ic] computes [f (... (f (f init l1) l2) ...) lN].
-    If [f] has no side effects, this is equivalent to
-    [List.fold_left f init (In_channel.input_lines ic)],
-    but is more efficient since it does not construct the list of all
-    lines read.
-
-    @since 5.1 *)
 
 val set_binary_mode : t -> bool -> unit
 (** [set_binary_mode ic true] sets the channel [ic] to binary mode: no

--- a/stdlib/in_channel.mli
+++ b/stdlib/in_channel.mli
@@ -162,6 +162,25 @@ val length : t -> int64
     into account the end-of-line translations that can be performed when reading
     from a channel opened in text mode. *)
 
+val input_lines : t -> string list
+(** [input_lines ic] reads lines using {!input_line}
+    until the end of file is reached.  It returns the list of all
+    lines read, in the order they were read.  The newline characters
+    that terminate lines are not included in the returned strings.
+    Empty lines produce empty strings.
+
+    @since 5.1 *)
+
+val fold_lines : ('a -> string -> 'a) -> 'a -> t -> 'a
+(** [fold_lines f init c] reads lines from [ic] using {!input_line}
+    until the end of file is reached.  Each line is passed to function [f]
+    in the style of a fold.  More precisely, [fold_lines f init c] is
+    [List.fold_left f init (In_channel.input_lines ic)],
+    but is more efficient since it does not construct the list of all
+    lines read.
+
+    @since 5.1 *)
+
 val set_binary_mode : t -> bool -> unit
 (** [set_binary_mode ic true] sets the channel [ic] to binary mode: no
     translations take place during input.

--- a/stdlib/in_channel.mli
+++ b/stdlib/in_channel.mli
@@ -176,7 +176,7 @@ val fold_lines : ('acc -> string -> 'acc) -> 'acc -> t -> 'acc
     until the end of file is reached, and successively passes each line
     to function [f] in the style of a fold.
     More precisely, if lines [l1, ..., lN] are read,
-    [fold_lines f init c] computes [f (... (f (f init l1) l2) ...) lN].
+    [fold_lines f init ic] computes [f (... (f (f init l1) l2) ...) lN].
     If [f] has no side effects, this is equivalent to
     [List.fold_left f init (In_channel.input_lines ic)],
     but is more efficient since it does not construct the list of all

--- a/stdlib/in_channel.mli
+++ b/stdlib/in_channel.mli
@@ -171,10 +171,13 @@ val input_lines : t -> string list
 
     @since 5.1 *)
 
-val fold_lines : ('a -> string -> 'a) -> 'a -> t -> 'a
-(** [fold_lines f init c] reads lines from [ic] using {!input_line}
-    until the end of file is reached.  Each line is passed to function [f]
-    in the style of a fold.  More precisely, [fold_lines f init c] is
+val fold_lines : ('acc -> string -> 'acc) -> 'acc -> t -> 'acc
+(** [fold_lines f init ic] reads lines from [ic] using {!input_line}
+    until the end of file is reached, and successively passes each line
+    to function [f] in the style of a fold.
+    More precisely, if lines [l1, ..., lN] are read,
+    [fold_lines f init c] computes [f (... (f (f init l1) l2) ...) lN].
+    If [f] has no side effects, this is equivalent to
     [List.fold_left f init (In_channel.input_lines ic)],
     but is more efficient since it does not construct the list of all
     lines read.

--- a/testsuite/tests/lib-channels/input_lines.ml
+++ b/testsuite/tests/lib-channels/input_lines.ml
@@ -1,0 +1,34 @@
+(* TEST
+
+*)
+
+open Printf
+
+let data_file =
+  "data.txt"
+
+let length = 500
+
+let rec check lo hi l =
+  if lo = hi + 1 then begin
+    if l <> [] then failwith "list too long"
+  end else begin
+    match l with
+    | [] -> failwith "list too short"
+    | h :: t ->
+        if int_of_string h <> lo then failwith "wrong value";
+        check (lo + 1) hi t
+  end
+
+let _ =
+  Out_channel.with_open_text data_file
+    (fun oc ->
+      fprintf oc "0";
+      for i = 1 to length do fprintf oc "\n%d" i done);
+  In_channel.with_open_text data_file In_channel.input_lines
+  |> check 0 length;
+  In_channel.with_open_text data_file
+    (In_channel.fold_lines (fun accu line -> line :: accu) [])
+  |> List.rev
+  |> check 0 length;
+  Sys.remove data_file


### PR DESCRIPTION
This PR adds a function `input_lines` to module `In_channel` that reads lines from an input channel until end of file, and returns the lines as a list of strings.  In my experience, it's very useful for writing scripts or solving programming puzzles.  Compare for example
```
    In_channel.input_lines ic |> List.map int_of_string |> List.fold_left (+) 0
```
with the standard recursive solution
```
   let rec sum_lines ic accu =
      match input_line ic with
      | exception End_of_file -> accu
      | line -> sum_lines ic (accu + int_of_string line)
```
or the standard iterative solution
```
  let sum = ref 0 in
  begin try
    while true do
      let line = input_line ic in sum := !sum + int_of_string line
    done
  with End_of_file -> () end;
  !sum
```

To facilitate reviewing, the rest of this PR is written in Q&A style

Q: What if my input file is really big?  Isn't there a risk of running out of memory?

A: Text files in line-oriented formats are rarely "really big" in the sense of "several gigabytes long".  But that's the reason why, as suggested by @Octachron , this PR also adds the  `In_channel.fold_lines` function, to support streaming computations on line-oriented files.  For example:
```
   In_channel.fold_lines (fun accu line -> accu + int_of_string line) 0 ic
```

Q: Isn't this equivalent to `String.split_on_char '\n' (In_channel.input_all ic)` and therefore not needed in the stdlib?

A: It's not equivalent because the solution based on `String.split_on_char` adds an extra string at the end of the list, which is empty if the input is well formed (all lines terminated by a newline), and this is not something I want to work with.  ~~removes empty lines, while `In_channel.input_lines` carefully preserves them.  (They are very often significant.)~~  Also, this alternate solution uses at least twice as much memory (at the point where `String.split_on_char` returns and the big string built by `input_all` can finally be freed).  Finally, if the input channel is not a file but e.g. a pipe, `input_all` incurs some overheads in space and  time, and reading line per line is probably more efficient.

Q: Why is the result a `string list` and not an `array list` ?

A: It's naturally built as a list, since the number of lines is not known in advance.  For applications that need an array of lines, just pipe into `Array.of_list`.

Q: Why not a `string Seq.t` ?  This would save much space by reading lines on demand!

A: As far as I know, we don't want to do lazy I/O because it's too error-prone, e.g. it's all too easy to close the input channel before everything has been read.
