### PR TITLE
removed set but unused variables in yacc/reader.c (#11758)

### DIFF
--- a/yacc/reader.c
+++ b/yacc/reader.c
@@ -1049,12 +1049,10 @@ void read_declarations(void)
 void output_token_type(void)
 {
   bucket * bp;
-  int n;
 
   fprintf(interface_file, "type token =\n");
   if (!rflag) ++outline;
   fprintf(output_file, "type token =\n");
-  n = 0;
   for (bp = first_symbol; bp; bp = bp->next) {
     if (bp->class == TERM && bp->true_token) {
       fprintf(interface_file, "  | %s", bp->name);
@@ -1068,7 +1066,6 @@ void output_token_type(void)
       fprintf(interface_file, "\n");
       if (!rflag) ++outline;
       fprintf(output_file, "\n");
-      n++;
     }
   }
   fprintf(interface_file, "\n");


### PR DESCRIPTION
Backport of https://github.com/ocaml/ocaml/pull/11758, since this warning might produce a build failure with some compilers (e.g. clang 15).
The original PR had `no-change-entry-required`, so none added here either.

I've tested this with clang 15.0.6 on Fedora 37 and the following workaround in configure (not part of the PR):
```
diff --git a/configure b/configure
index f54df4138..d0ce62355 100755
--- a/configure
+++ b/configure
@@ -13541,7 +13541,7 @@ case $ocaml_cv_cc_vendor in #(
   *) :
     outputobj='-o $(EMPTY)'
   warn_error_flag='-Werror'
-  cc_warnings='-Wall' ;;
+  cc_warnings='-Wall -Wno-deprecated-non-prototype' ;;
```

A better solution for that warning is discussed in https://github.com/ocaml/ocaml/issues/11759, but having this backport in 5.0 might be useful on its own already to make the code more futureproof.