### PR TITLE
Simplify and fix the shadow store reservation on Win64

### DIFF
--- a/Changes
+++ b/Changes
@@ -619,6 +619,9 @@ Working version
   (Jérôme Vouillon, review by Nicolás Ojeda Bär, Stephen Dolan and
    Hugo Heuzard)
 
+- #11846: Mark rbx as destroyed at C call for Win64 (mingw-w64 and Cygwin64).
+  (David Allsopp, review by KC Sivaramakrishnan)
+
 - #11850: When stopping before the `emit` phase (using `-stop-after`), an empty
   temporary assembly file is no longer left in the file system.
   (Nicolás Ojeda Bär, review by Gabriel Scherer and Xavier Leroy)

--- a/Changes
+++ b/Changes
@@ -620,7 +620,12 @@ Working version
    Hugo Heuzard)
 
 - #11846: Mark rbx as destroyed at C call for Win64 (mingw-w64 and Cygwin64).
-  (David Allsopp, review by KC Sivaramakrishnan)
+  Reserve the shadow store for the ABI in the c_stack_link struct instead of
+  explictly when calling C functions. This simultaneously reduces the number of
+  stack pointer manipulations and also fixes a bug when calling noalloc
+  functions where the shadow store was not being reserved.
+  (David Allsopp, report by Vesa Karvonen, review by Xavier Leroy and
+   KC Sivaramakrishnan)
 
 - #11850: When stopping before the `emit` phase (using `-stop-after`), an empty
   temporary assembly file is no longer left in the file system.

--- a/asmcomp/amd64/emit.mlp
+++ b/asmcomp/amd64/emit.mlp
@@ -538,7 +538,7 @@ let emit_instr env fallthrough i =
   | Lop(Iextcall { func; alloc; stack_ofs }) ->
       add_used_symbol func;
       if stack_ofs > 0 then begin
-        I.lea (mem64 QWORD 0 RSP) r13;
+        I.mov rsp r13;
         I.lea (mem64 QWORD stack_ofs RSP) r12;
         load_symbol_addr func rax;
         emit_call "caml_c_call_stack_args";

--- a/asmcomp/amd64/emit.mlp
+++ b/asmcomp/amd64/emit.mlp
@@ -537,13 +537,8 @@ let emit_instr env fallthrough i =
       end
   | Lop(Iextcall { func; alloc; stack_ofs }) ->
       add_used_symbol func;
-      let base_stack_size =
-        if Arch.win64 then
-          32 (* Windows x64 rcx+rdx+r8+r9 shadow stack *)
-        else
-          0 in
-      if stack_ofs > base_stack_size then begin
-        I.lea (mem64 QWORD base_stack_size RSP) r13;
+      if stack_ofs > 0 then begin
+        I.lea (mem64 QWORD 0 RSP) r13;
         I.lea (mem64 QWORD stack_ofs RSP) r12;
         load_symbol_addr func rax;
         emit_call "caml_c_call_stack_args";

--- a/asmcomp/amd64/proc.ml
+++ b/asmcomp/amd64/proc.ml
@@ -291,12 +291,12 @@ let destroyed_at_c_call =
      by the code sequence used for C calls in emit.mlp, so it
      is marked as destroyed. *)
   if win64 then
-    (* Win64: rbx, rsi, rdi, r12-r15, xmm6-xmm15 preserved *)
+    (* Win64: rsi, rdi, r12-r15, xmm6-xmm15 preserved *)
     Array.of_list(List.map phys_reg
-      [0;4;5;6;7;10;11;12;
+      [0;1;4;5;6;7;10;11;12;
        100;101;102;103;104;105])
   else
-    (* Unix: rbx, r12-r15 preserved *)
+    (* Unix: r12-r15 preserved *)
     Array.of_list(List.map phys_reg
       [0;1;2;3;4;5;6;7;10;11;
        100;101;102;103;104;105;106;107;

--- a/asmcomp/amd64/proc.ml
+++ b/asmcomp/amd64/proc.ml
@@ -235,7 +235,7 @@ let win64_float_external_arguments =
 let win64_loc_external_arguments arg =
   let loc = Array.make (Array.length arg) Reg.dummy in
   let reg = ref 0
-  and ofs = ref 32 in
+  and ofs = ref 0 in
   for i = 0 to Array.length arg - 1 do
     match arg.(i) with
     | Val | Int | Addr as ty ->

--- a/runtime/amd64.S
+++ b/runtime/amd64.S
@@ -144,9 +144,17 @@
 #define Handler_parent          24
 
 /* struct c_stack_link */
+#if defined(SYS_mingw64) || defined (SYS_cygwin)
+#define Cstack_stack            32
+#define Cstack_sp               40
+#define Cstack_prev             48
+#define SIZEOF_C_STACK_LINK     56
+#else
 #define Cstack_stack             0
 #define Cstack_sp                8
 #define Cstack_prev             16
+#define SIZEOF_C_STACK_LINK     24
+#endif
 
 /******************************************************************************/
 /* DWARF */
@@ -369,20 +377,7 @@
 
 #endif
 
-#if defined(SYS_mingw64) || defined (SYS_cygwin)
-   /* Calls from OCaml to C must reserve 32 bytes of extra stack space */
-#  define PREPARE_FOR_C_CALL subq $32, %rsp; CFI_ADJUST(32)
-#  define CLEANUP_AFTER_C_CALL addq $32, %rsp; CFI_ADJUST(-32)
-   /* Stack probing mustn't be larger than the page size */
-#  define STACK_PROBE_SIZE 4096
-#else
-#  define PREPARE_FOR_C_CALL
-#  define CLEANUP_AFTER_C_CALL
-#  define STACK_PROBE_SIZE 4096
-#endif
-
-#define C_call(target) \
-  PREPARE_FOR_C_CALL; CHECK_STACK_ALIGNMENT; call target; CLEANUP_AFTER_C_CALL
+#define C_call(target) CHECK_STACK_ALIGNMENT; call target
 
 /******************************************************************************/
 /* Registers holding arguments of C functions. */
@@ -635,6 +630,9 @@ CFI_STARTPROC
     /* Make the alloc ptr available to the C code */
         movq    %r15, Caml_state(young_ptr)
     /* Copy arguments from OCaml to C stack */
+#if defined(SYS_mingw64) || defined (SYS_cygwin)
+        addq    $32, %rsp
+#endif
 LBL(105):
         subq    $8, %r12
         cmpq    %r13,%r12
@@ -642,6 +640,9 @@ LBL(105):
         push    (%r12); CFI_ADJUST(8)
         jmp     LBL(105)
 LBL(106):
+#if defined(SYS_mingw64) || defined (SYS_cygwin)
+        subq    $32, %rsp
+#endif
     /* Call the function (address in %rax) */
         C_call  (*%rax)
     /* Pop arguments back off the stack */
@@ -680,7 +681,7 @@ LBL(caml_start_program):
     /* Load young_ptr into %r15 */
         movq    Caml_state(young_ptr), %r15
     /* Build struct c_stack_link on the C stack */
-        subq    $24 /* sizeof struct c_stack_link */, %rsp; CFI_ADJUST(24)
+        subq    $SIZEOF_C_STACK_LINK, %rsp; CFI_ADJUST(SIZEOF_C_STACK_LINK)
         movq    $0, Cstack_stack(%rsp)
         movq    $0, Cstack_sp(%rsp)
         movq    Caml_state(c_stack), %r10
@@ -737,7 +738,7 @@ LBL(108):
     /* Pop the struct c_stack_link */
         movq    Cstack_prev(%rsp), %r10
         movq    %r10, Caml_state(c_stack)
-        addq    $24, %rsp; CFI_ADJUST(-24)
+        addq    $SIZEOF_C_STACK_LINK, %rsp; CFI_ADJUST(-SIZEOF_C_STACK_LINK)
     /* Restore callee-save registers. */
         POP_CALLEE_SAVE_REGS
     /* Return to caller. */

--- a/runtime/caml/fiber.h
+++ b/runtime/caml/fiber.h
@@ -98,6 +98,10 @@ CAML_STATIC_ASSERT(sizeof(struct stack_info) ==
  * stack is reallocated, this linked list is walked to update the OCaml stack
  * pointers. It is also used for DWARF backtraces. */
 struct c_stack_link {
+#if defined(_WIN32) || defined(__CYGWIN__)
+  /* Win64 ABI shadow store for argument registers */
+  void* shadow_store[4];
+#endif
   /* The reference to the OCaml stack */
   struct stack_info* stack;
   /* OCaml return address */


### PR DESCRIPTION
This PR addresses two Win64 ABI violations in the native backend/compiler (Win64 in this case means Cygwin64 - MSVC64 - mingw-w64). The first was indirectly spotted while fixing the second, which is that OCaml 5's calling convention clobbers `rbx` which is recorded in the Unix register descriptions but accidentally wasn't in the Windows ones. This predominantly affects large-argument and noalloc function calls, so I think we've just been "lucky" in not seeing that so far.

The second part is more complicated, and relates to the [x64 calling convention on Windows](https://learn.microsoft.com/en-us/cpp/build/x64-calling-convention?view=msvc-170). This requires that the _caller_ reserve space for the four argument registers to be spilled by the function. The callee is not _required_ to use this space for spilling the registers, but the space is supposed to be available, regardless of whether the callee even has 4 parameters.

ocamlopt generates calls to C functions in three different ways:
1. Via `caml_c_call`. This is used when the function being called has 4 or fewer arguments. It's implemented in `amd64.S` and is called with the arguments registers already initialised and the function address in `rax`.
2. Via `caml_c_call_stack_args`. This is used when the function being called has more than 4 arguments. As for `caml_c_call`, the argument registers are already initialised, but the additional arguments are on the wrong stack, as they are on the OCaml stack. `caml_c_call_stack_args` therefore copies these to the C stack and then transfers control to the function address in `rax`.
3. Directly. This is used only for noalloc calls with 4 arguments or fewer. `rbx` is clobbered to maintain the OCaml stack pointer across the call.

OCaml 5.0 reserved 32 bytes on the C stack just prior to the C call for cases 1 and 2 but the shadow store was not reserved at all for the direct call (case 3). Mostly, this had slipped through undetected - although I'm 99% certain this is the root cause of a bug seen by @polytypic with the eio library on mingw-w64. This mistake was trivially spotted in #11835, as compiling with `-Od` (cl's equivalent of gcc's `-O0`) generates function prologues which always spill argument registers to their home locations, causing very easy-to-detect stack corruption for msvc64 programs.

The simple fix initially put in #11835 was to reserve the required 32 bytes of stack prior to the `call` for the noalloc case, but this isn't entirely satisfactory. OCaml 4.x is (of course) aware of the shadow store requirement, and this stack _was_ being reserved **in all three cases**. The problem is that the reservation was being made _on the OCaml stack, not the C stack_.

The fix I propose here requires an understanding of the interaction between the C and OCaml stacks. The startup process for a native program begins - in C - with `caml_main` which brings up the runtime system. It then hands off to `caml_start_program` (in `amd64.S`). Its job is to switch to the newly allocated OCaml stack and execute the program's OCaml entry point on it. The pointer to the C stack is stored in `Caml_state` and then the program can neatly flip between the two stacks as necessary (storing the pointer to resume to on the other stack in a book-keeping `struct` either in `Caml_state` or on the C stack itself). The complexity arises when a C function called from OCaml itself wants to execute OCaml code (i.e. the `caml_callback` family of functions). This book-keeping is managed by `struct c_stack_link`, which is declared in `fiber.h` but only ever created on the C stack by the functions in `amd64.S`. These structs form a linked list and, importantly, when running OCaml code, the C stack _always_ ends with one (this allows `caml_c_call` et al to be able to backup the OCaml stack pointer).

The second commit here capitalises on this separation of OCaml and C stacks. In OCaml 5, the C stack is only ever used to call C functions. The fix therefore is to include the shadow store reservation in `struct c_stack_link` itself (the ABI does not require it to be initialised or cleaned, so it's simply memory addressing arithmetic). This removes all the need for the native backend to have to care at all about the shadow store (logic for it in both `asmcomp/amd64/emit.mlp` and `asmcomp/amd64/proc.ml` is removed). This eliminates the wasted allocation on the OCaml stack. The actual calling of C functions is also simplified - after the sequence `SWITCH_OCAML_TO_C` in `amd64.S`, the C stack is now exactly ready to call a C function. A small amount of care is needed in `caml_c_call_stack_arguments` to put the arguments _above_ the shadow store, but otherwise the only time the shadow store has to be reserved is when C calls OCaml (i.e. the less frequent case - an OCaml program more frequently calls into C).