### PR TITLE
type-checker cleanup (1/N): less global state, more meaningful types

### DIFF
--- a/Changes
+++ b/Changes
@@ -218,6 +218,10 @@ Working version
   (Sébastien Hinderer, review by Gabriel Scherer and David Allsopp)
 
 ### Internal/compiler-libs changes:
+
+- #11847: small refactorings in the type checker
+  (Gabriel Scherer, review by Nicolás Ojeda Bär)
+
 - #11027: Separate typing counter-examples from type_pat into retype_pat;
   type_pat is no longer in CPS.
   (Jacques Garrigue and Takafumi Saikawa, review by Gabriel Scherer)

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -413,64 +413,52 @@ let rec filter_row_fields erase = function
 
 exception Non_closed of type_expr * bool
 
-let free_variables = ref []
-let really_closed = ref None
-
-(* [free_vars_rec] collects the variables of the input type
-   expression into the [free_variables] reference. It is used for
-   several different things in the type-checker, with the following
-   bells and whistles:
-   - If [really_closed] is Some typing environment, types in the environment
+(* [free_vars] collects the variables of the input type expression. It
+   is used for several different things in the type-checker, with the
+   following bells and whistles:
+   - If [env] is Some typing environment, types in the environment
      are expanded to check whether the apparently-free variable would vanish
      during expansion.
-   - We collect both type variables and row variables, paired with a boolean
-     that is [true] if we have a row variable.
+   - We collect both type variables and row variables, paired with
+     a boolean that is [false] if we have a row variable and [true] if
+     we have a "real" variable (not a row variable).
    - We do not count "virtual" free variables -- free variables stored in
      the abbreviation of an object type that has been expanded (we store
      the abbreviations for use when displaying the type).
 
-   The functions [free_vars] and [free_variables] below receive
-   a typing environment as an optional [?env] parameter and
-   set [really_closed] accordingly.
    [free_vars] returns a [(variable * bool) list], while
-   [free_variables] drops the type/row information
+   [free_variables] below drops the type/row information
    and only returns a [variable list].
  *)
-let rec free_vars_rec real ty =
-  if try_mark_node ty then
-    match get_desc ty, !really_closed with
-      Tvar _, _ ->
-        free_variables := (ty, real) :: !free_variables
-    | Tconstr (path, tl, _), Some env ->
-        begin try
-          let (_, body, _) = Env.find_type_expansion path env in
-          if get_level body <> generic_level then
-            free_variables := (ty, real) :: !free_variables
-        with Not_found -> ()
-        end;
-        List.iter (free_vars_rec true) tl
-(* Do not count "virtual" free variables
-    | Tobject(ty, {contents = Some (_, p)}) ->
-        free_vars_rec false ty; List.iter (free_vars_rec true) p
-*)
-    | Tobject (ty, _), _ ->
-        free_vars_rec false ty
-    | Tfield (_, _, ty1, ty2), _ ->
-        free_vars_rec true ty1; free_vars_rec false ty2
-    | Tvariant row, _ ->
-        iter_row (free_vars_rec true) row;
-        if not (static_row row) then free_vars_rec false (row_more row)
-    | _    ->
-        iter_type_expr (free_vars_rec true) ty
-
 let free_vars ?env ty =
-  free_variables := [];
-  really_closed := env;
-  free_vars_rec true ty;
-  let res = !free_variables in
-  free_variables := [];
-  really_closed := None;
-  res
+  let rec fv ~real acc ty =
+    if not (try_mark_node ty) then acc
+    else match get_desc ty, env with
+      | Tvar _, _ ->
+          (ty, real) :: acc
+      | Tconstr (path, tl, _), Some env ->
+          let acc =
+            match Env.find_type_expansion path env with
+            | exception Not_found -> acc
+            | (_, body, _) ->
+                if get_level body = generic_level then acc
+                else (ty, real) :: acc
+          in
+          List.fold_left (fv ~real:true) acc tl
+      | Tobject (ty, _), _ ->
+          (* ignoring the second parameter of [Tobject] amounts to not
+             counting "virtual free variables". *)
+          fv ~real:false acc ty
+      | Tfield (_, _, ty1, ty2), _ ->
+          let acc = fv ~real:true acc ty1 in
+          fv ~real:false acc ty2
+      | Tvariant row, _ ->
+          let acc = fold_row (fv ~real:true) acc row in
+          if static_row row then acc
+          else fv ~real:false acc (row_more row)
+      | _    ->
+          fold_type_expr (fv ~real) acc ty
+  in fv ~real:true [] ty
 
 let free_variables ?env ty =
   let tl = List.map fst (free_vars ?env ty) in

--- a/typing/ctype.mli
+++ b/typing/ctype.mli
@@ -402,13 +402,20 @@ val nongen_class_declaration: class_declaration -> bool
         (* Check whether the given class type contains no non-generic
            type variables. Uses the empty environment.  *)
 
+type variable_kind = Row_variable | Type_variable
+type closed_class_failure = {
+  free_variable: type_expr * variable_kind;
+  meth: string;
+  meth_ty: type_expr;
+}
+
 val free_variables: ?env:Env.t -> type_expr -> type_expr list
         (* If env present, then check for incomplete definitions too *)
 val closed_type_decl: type_declaration -> type_expr option
 val closed_extension_constructor: extension_constructor -> type_expr option
 val closed_class:
         type_expr list -> class_signature ->
-        (type_expr * bool * string * type_expr) option
+        closed_class_failure option
         (* Check whether all type variables are bound *)
 
 val unalias: type_expr -> type_expr

--- a/typing/typeclass.mli
+++ b/typing/typeclass.mli
@@ -111,8 +111,7 @@ type error =
   | Bad_class_type_parameters of Ident.t * type_expr list * type_expr list
   | Class_match_failure of Ctype.class_match_failure list
   | Unbound_val of string
-  | Unbound_type_var of
-      (formatter -> unit) * (type_expr * bool * string * type_expr)
+  | Unbound_type_var of (formatter -> unit) * Ctype.closed_class_failure
   | Non_generalizable_class of Ident.t * Types.class_declaration
   | Cannot_coerce_self of type_expr
   | Non_collapsable_conjunction of


### PR DESCRIPTION
Inspired by the effectiveness of the work of @garrigue, @t6s and @HyunggyuJang (and also: having the opportunity to read more type-checker code thanks to theem), I decided to start cleaning up some parts of the type checker implementation to make it easier to maintain.

This first PR works on `Ctype.free_variables` to:
- remove global mutable state
- use a more informative type, moving from `bool` to a proper sum type

This corresponds to reducing two "code smells" as recognized by [typing/TODO.md](https://github.com/ocaml/ocaml/blob/trunk/typing/TODO.md?plain=1#L29-L30).

### Reviewing

This PR does not change the observable behavior of the type-checker. A reviewer would need to check two things:
- that the code is indeed clearly better than before (otherwise there is no point)
- that the behavior is unchanged

This does not require any expertise in the type-checker codebase.