### PR TITLE
Add `find_mapi` and `find_index` to `List`, `Seq`, `Array` and `Float.Array`.

### DIFF
--- a/Changes
+++ b/Changes
@@ -82,7 +82,9 @@ Working version
 ### Standard library:
 
 - #11848: Add `List.find_mapi`, `List.find_index`, `Seq.find_mapi`,
-  `Seq.find_index`, `Array.find_mapi`, `Array.find_index`.
+  `Seq.find_index`, `Array.find_mapi`, `Array.find_index`,
+  `Float.Array.find_opt`, `Float.Array.find_index`, `Float.Array.find_map`,
+  `Float.Array.find_mapi`.
   (Sima Kinsart, review by Daniel Bünzli and Nicolás Ojeda Bär)
 
 - #11859: Make Stdlib.(@) and List.append tail-recursive and faster.

--- a/Changes
+++ b/Changes
@@ -81,6 +81,9 @@ Working version
 
 ### Standard library:
 
+- #11848: Add `List.find_mapi`, `List.find_index`.
+  (Sima Kinsart, review by Daniel Bünzli and Nicolás Ojeda Bär)
+
 - #11859: Make Stdlib.(@) and List.append tail-recursive and faster.
   (Jeremy Yallop, review by Daniel Bünzli, Anil Madhavapeddy, and Bannerets)
 

--- a/Changes
+++ b/Changes
@@ -81,7 +81,8 @@ Working version
 
 ### Standard library:
 
-- #11848: Add `List.find_mapi`, `List.find_index`.
+- #11848: Add `List.find_mapi`, `List.find_index`, `Seq.find_mapi`,
+  `Seq.find_index`.
   (Sima Kinsart, review by Daniel Bünzli and Nicolás Ojeda Bär)
 
 - #11859: Make Stdlib.(@) and List.append tail-recursive and faster.

--- a/Changes
+++ b/Changes
@@ -82,7 +82,7 @@ Working version
 ### Standard library:
 
 - #11848: Add `List.find_mapi`, `List.find_index`, `Seq.find_mapi`,
-  `Seq.find_index`.
+  `Seq.find_index`, `Array.find_mapi`, `Array.find_index`.
   (Sima Kinsart, review by Daniel Bünzli and Nicolás Ojeda Bär)
 
 - #11859: Make Stdlib.(@) and List.append tail-recursive and faster.

--- a/stdlib/array.ml
+++ b/stdlib/array.ml
@@ -255,12 +255,31 @@ let find_opt p a =
   in
   loop 0
 
+let find_index p a =
+  let n = length a in
+  let rec loop i =
+    if i = n then None
+    else if p (unsafe_get a i) then Some i
+    else loop (succ i) in
+  loop 0
+
 let find_map f a =
   let n = length a in
   let rec loop i =
     if i = n then None
     else
       match f (unsafe_get a i) with
+      | None -> loop (succ i)
+      | Some _ as r -> r
+  in
+  loop 0
+
+let find_mapi f a =
+  let n = length a in
+  let rec loop i =
+    if i = n then None
+    else
+      match f i (unsafe_get a i) with
       | None -> loop (succ i)
       | Some _ as r -> r
   in

--- a/stdlib/array.mli
+++ b/stdlib/array.mli
@@ -252,11 +252,27 @@ val find_opt : ('a -> bool) -> 'a array -> 'a option
 
     @since 4.13 *)
 
+val find_index : ('a -> bool) -> 'a array -> int option
+(** [find_index f a] returns [Some i], where [i] is the index of the first
+    element of the array [a] that satisfies [f x], if there is such an
+    element.
+
+    It returns [None] if there is no such element.
+
+    @since 5.1 *)
+
 val find_map : ('a -> 'b option) -> 'a array -> 'b option
 (** [find_map f a] applies [f] to the elements of [a] in order, and returns the
     first result of the form [Some v], or [None] if none exist.
 
     @since 4.13 *)
+
+val find_mapi : (int -> 'a -> 'b option) -> 'a array -> 'b option
+(** Same as [find_map], but the predicate is applied to the index of
+   the element as first argument (counting from 0), and the element
+   itself as second argument.
+
+   @since 5.1 *)
 
 (** {1 Arrays of pairs} *)
 

--- a/stdlib/arrayLabels.mli
+++ b/stdlib/arrayLabels.mli
@@ -252,11 +252,27 @@ val find_opt : f:('a -> bool) -> 'a array -> 'a option
 
     @since 4.13 *)
 
+val find_index : f:('a -> bool) -> 'a array -> int option
+(** [find_index ~f a] returns [Some i], where [i] is the index of the first
+    element of the array [a] that satisfies [f x], if there is such an
+    element.
+
+    It returns [None] if there is no such element.
+
+    @since 5.1 *)
+
 val find_map : f:('a -> 'b option) -> 'a array -> 'b option
 (** [find_map ~f a] applies [f] to the elements of [a] in order, and returns the
     first result of the form [Some v], or [None] if none exist.
 
     @since 4.13 *)
+
+val find_mapi : f:(int -> 'a -> 'b option) -> 'a array -> 'b option
+(** Same as [find_map], but the predicate is applied to the index of
+   the element as first argument (counting from 0), and the element
+   itself as second argument.
+
+   @since 5.1 *)
 
 (** {1 Arrays of pairs} *)
 

--- a/stdlib/float.ml
+++ b/stdlib/float.ml
@@ -378,6 +378,51 @@ module Array = struct
     loop 0
 
   (* duplicated from array.ml *)
+  let find_opt p a =
+    let n = length a in
+    let rec loop i =
+      if i = n then None
+      else
+        let x = unsafe_get a i in
+        if p x then Some x
+        else loop (i + 1)
+    in
+    loop 0
+
+  (* duplicated from array.ml *)
+  let find_index p a =
+    let n = length a in
+    let rec loop i =
+      if i = n then None
+      else if p (unsafe_get a i) then Some i
+      else loop (i + 1) in
+    loop 0
+
+  (* duplicated from array.ml *)
+  let find_map f a =
+    let n = length a in
+    let rec loop i =
+      if i = n then None
+      else
+        match f (unsafe_get a i) with
+        | None -> loop (i + 1)
+        | Some _ as r -> r
+    in
+    loop 0
+
+  (* duplicated from array.ml *)
+  let find_mapi f a =
+    let n = length a in
+    let rec loop i =
+      if i = n then None
+      else
+        match f i (unsafe_get a i) with
+        | None -> loop (i + 1)
+        | Some _ as r -> r
+    in
+    loop 0
+
+  (* duplicated from array.ml *)
   exception Bottom of int
   let sort cmp a =
     let maxson l i =

--- a/stdlib/float.mli
+++ b/stdlib/float.mli
@@ -654,6 +654,34 @@ module Array : sig
   val mem_ieee : float -> t -> bool
   (** Same as {!mem}, but uses IEEE equality instead of structural equality. *)
 
+  (** {2 Array searching} *)
+
+  val find_opt : (float -> bool) -> t -> float option
+  (* [find_opt f a] returns the first element of the array [a] that satisfies
+     the predicate [f]. Returns [None] if there is no value that satisfies [f]
+     in the array [a].
+     @since 5.1 *)
+
+  val find_index : (float-> bool) -> t -> int option
+  (** [find_index f a] returns [Some i], where [i] is the index of the first
+      element of the array [a] that satisfies [f x], if there is such an
+      element.
+
+      It returns [None] if there is no such element.
+      @since 5.1 *)
+
+  val find_map : (float -> 'a option) -> t -> 'a option
+  (* [find_map f a] applies [f] to the elements of [a] in order, and returns
+     the first result of the form [Some v], or [None] if none exist.
+     @since 5.1 *)
+
+  val find_mapi : (int -> float -> 'a option) -> t -> 'a option
+  (** Same as [find_map], but the predicate is applied to the index of
+     the element as first argument (counting from 0), and the element
+     itself as second argument.
+
+     @since 5.1 *)
+
   (** {2 Sorting} *)
 
   val sort : (float -> float -> int) -> t -> unit
@@ -959,6 +987,34 @@ module ArrayLabels : sig
 
   val mem_ieee : float -> set:t -> bool
   (** Same as {!mem}, but uses IEEE equality instead of structural equality. *)
+
+  (** {2 Array searching} *)
+
+  val find_opt : f:(float -> bool) -> t -> float option
+  (* [find_opt ~f a] returns the first element of the array [a] that satisfies
+     the predicate [f]. Returns [None] if there is no value that satisfies [f]
+     in the array [a].
+     @since 5.1 *)
+
+  val find_index : f:(float-> bool) -> t -> int option
+  (** [find_index ~f a] returns [Some i], where [i] is the index of the first
+      element of the array [a] that satisfies [f x], if there is such an
+      element.
+
+      It returns [None] if there is no such element.
+      @since 5.1 *)
+
+  val find_map : f:(float -> 'a option) -> t -> 'a option
+  (* [find_map ~f a] applies [f] to the elements of [a] in order, and returns
+     the first result of the form [Some v], or [None] if none exist.
+     @since 5.1 *)
+
+  val find_mapi : f:(int -> float -> 'a option) -> t -> 'a option
+  (** Same as [find_map], but the predicate is applied to the index of
+     the element as first argument (counting from 0), and the element
+     itself as second argument.
+
+     @since 5.1 *)
 
   (** {2 Sorting} *)
 

--- a/stdlib/list.ml
+++ b/stdlib/list.ml
@@ -236,6 +236,12 @@ let rec find_opt p = function
   | [] -> None
   | x :: l -> if p x then Some x else find_opt p l
 
+let find_index p =
+  let rec aux i = function
+    [] -> None
+    | a::l -> if p a then Some i else aux (i+1) l in
+  aux 0
+
 let rec find_map f = function
   | [] -> None
   | x :: l ->
@@ -243,6 +249,16 @@ let rec find_map f = function
        | Some _ as result -> result
        | None -> find_map f l
      end
+
+let find_mapi f =
+  let rec aux i = function
+  | [] -> None
+  | x :: l ->
+     begin match f i x with
+       | Some _ as result -> result
+       | None -> aux (i+1) l
+     end in
+  aux 0
 
 let[@tail_mod_cons] rec find_all p = function
   | [] -> []

--- a/stdlib/list.mli
+++ b/stdlib/list.mli
@@ -320,12 +320,27 @@ val find_opt : ('a -> bool) -> 'a list -> 'a option
    @since 4.05
  *)
 
+val find_index : ('a -> bool) -> 'a list -> int option
+(** [find_index f xs] returns [Some i], where [i] is the index of the first
+   element of the list [xs] that satisfies [f x], if there is such an element.
+
+   It returns [None] if there is no such element.
+
+   @since 5.1 *)
+
 val find_map : ('a -> 'b option) -> 'a list -> 'b option
 (** [find_map f l] applies [f] to the elements of [l] in order,
     and returns the first result of the form [Some v], or [None]
     if none exist.
     @since 4.10
 *)
+
+val find_mapi : (int -> 'a -> 'b option) -> 'a list -> 'b option
+(** Same as [find_map], but the predicate is applied to the index of
+   the element as first argument (counting from 0), and the element
+   itself as second argument.
+
+   @since 5.1 *)
 
 val filter : ('a -> bool) -> 'a list -> 'a list
 (** [filter f l] returns all the elements of the list [l]

--- a/stdlib/listLabels.mli
+++ b/stdlib/listLabels.mli
@@ -320,12 +320,27 @@ val find_opt : f:('a -> bool) -> 'a list -> 'a option
    @since 4.05
  *)
 
+val find_index : f:('a -> bool) -> 'a list -> int option
+(** [find_index ~f xs] returns [Some i], where [i] is the index of the first
+   element of the list [xs] that satisfies [f x], if there is such an element.
+
+   It returns [None] if there is no such element.
+
+   @since 5.1 *)
+
 val find_map : f:('a -> 'b option) -> 'a list -> 'b option
 (** [find_map ~f l] applies [f] to the elements of [l] in order,
     and returns the first result of the form [Some v], or [None]
     if none exist.
     @since 4.10
 *)
+
+val find_mapi : f:(int -> 'a -> 'b option) -> 'a list -> 'b option
+(** Same as [find_map], but the predicate is applied to the index of
+   the element as first argument (counting from 0), and the element
+   itself as second argument.
+
+   @since 5.1 *)
 
 val filter : f:('a -> bool) -> 'a list -> 'a list
 (** [filter ~f l] returns all the elements of the list [l]

--- a/stdlib/seq.ml
+++ b/stdlib/seq.ml
@@ -150,6 +150,14 @@ let rec find p xs =
   | Cons (x, xs) ->
       if p x then Some x else find p xs
 
+let find_index p xs =
+  let rec aux i xs = match xs() with
+    | Nil ->
+        None
+    | Cons (x, xs) ->
+        if p x then Some i else aux (i+1) xs in
+  aux 0 xs
+
 let rec find_map f xs =
   match xs() with
   | Nil ->
@@ -160,6 +168,18 @@ let rec find_map f xs =
           find_map f xs
       | Some _ as result ->
           result
+
+let find_mapi f xs =
+  let rec aux i xs = match xs() with
+    | Nil ->
+        None
+    | Cons (x, xs) ->
+        match f i x with
+        | None ->
+            aux (i+1) xs
+        | Some _ as result ->
+            result in
+  aux 0 xs
 
 (* [iter2], [fold_left2], [for_all2], [exists2], [map2], [zip] work also in
    the case where the two sequences have different lengths. They stop as soon

--- a/stdlib/seq.mli
+++ b/stdlib/seq.mli
@@ -220,6 +220,17 @@ val find : ('a -> bool) -> 'a t -> 'a option
 
     @since 4.14 *)
 
+val find_index : ('a -> bool) -> 'a t -> int option
+(** [find_index p xs] returns [Some i], where [i] is the index of the first
+    element of the sequence [xs] that satisfies [p x], if there is such an
+    element.
+
+    It returns [None] if there is no such element.
+
+    The sequence [xs] must be finite.
+
+    @since 5.1 *)
+
 val find_map : ('a -> 'b option) -> 'a t -> 'b option
 (** [find_map f xs] returns [Some y], where [x] is the first element of the
     sequence [xs] such that [f x = Some _], if there is such an element,
@@ -230,6 +241,15 @@ val find_map : ('a -> 'b option) -> 'a t -> 'b option
     The sequence [xs] must be finite.
 
     @since 4.14 *)
+
+val find_mapi : (int -> 'a -> 'b option) -> 'a t -> 'b option
+(** Same as [find_map], but the predicate is applied to the index of
+   the element as first argument (counting from 0), and the element
+   itself as second argument.
+
+   The sequence [xs] must be finite.
+
+   @since 5.1 *)
 
 val iter2 : ('a -> 'b -> unit) -> 'a t -> 'b t -> unit
 (** [iter2 f xs ys] invokes [f x y] successively for every pair [(x, y)] of

--- a/stdlib/templates/floatarraylabeled.template.mli
+++ b/stdlib/templates/floatarraylabeled.template.mli
@@ -170,6 +170,34 @@ val mem : float -> set:t -> bool
 val mem_ieee : float -> set:t -> bool
 (** Same as {!mem}, but uses IEEE equality instead of structural equality. *)
 
+(** {2 Array searching} *)
+
+val find_opt : f:(float -> bool) -> t -> float option
+(* [find_opt ~f a] returns the first element of the array [a] that satisfies
+   the predicate [f]. Returns [None] if there is no value that satisfies [f]
+   in the array [a].
+   @since 5.1 *)
+
+val find_index : f:(float-> bool) -> t -> int option
+(** [find_index ~f a] returns [Some i], where [i] is the index of the first
+    element of the array [a] that satisfies [f x], if there is such an
+    element.
+
+    It returns [None] if there is no such element.
+    @since 5.1 *)
+
+val find_map : f:(float -> 'a option) -> t -> 'a option
+(* [find_map ~f a] applies [f] to the elements of [a] in order, and returns
+   the first result of the form [Some v], or [None] if none exist.
+   @since 5.1 *)
+
+val find_mapi : f:(int -> float -> 'a option) -> t -> 'a option
+(** Same as [find_map], but the predicate is applied to the index of
+   the element as first argument (counting from 0), and the element
+   itself as second argument.
+
+   @since 5.1 *)
+
 (** {2 Sorting} *)
 
 val sort : cmp:(float -> float -> int) -> t -> unit

--- a/testsuite/tests/lib-array/test_array.ml
+++ b/testsuite/tests/lib-array/test_array.ml
@@ -94,11 +94,34 @@ val a : int array = [|1; 2; 3|]
 - : int option = Some 2
 |}]
 
+let a = [|1; 2; 3|];;
+let _ = Array.find_index (function 2 -> true | _ -> false) a;;
+[%%expect{|
+val a : int array = [|1; 2; 3|]
+- : int option = Some 1
+|}]
+
+let a = [|1; 2; 3|];;
+let _ = Array.find_index (function 42 -> true | _ -> false) a;;
+[%%expect{|
+val a : int array = [|1; 2; 3|]
+- : int option = None
+|}]
+
 let a = [|'a'; 'b'; 'c'|];;
 let _ = Array.find_map (function 'b' -> Some 121 | _ -> None) a;;
 [%%expect{|
 val a : char array = [|'a'; 'b'; 'c'|]
 - : int option = Some 121
+|}]
+
+let a = [|1; 2; 3|];;
+let _ = Array.find_mapi (fun i x -> match (i, x) with
+  | (1, 2) -> Some(1, 2)
+  | _ -> None) a;;
+[%%expect{|
+val a : int array = [|1; 2; 3|]
+- : (int * int) option = Some (1, 2)
 |}]
 
 let a = [|1; 2|];;
@@ -113,6 +136,15 @@ let _ = Array.find_map (fun _ -> None) a;;
 [%%expect{|
 val a : int array = [|1; 2|]
 - : 'a option = None
+|}]
+
+let a = [|1; 2|];;
+let _ = Array.find_mapi (fun i x -> match (i, x) with
+  | (i, 101) -> Some(i, 101)
+  | _ -> None) a;;
+[%%expect{|
+val a : int array = [|1; 2|]
+- : (int * int) option = None
 |}]
 
 let a = Array.init 8 succ;;

--- a/testsuite/tests/lib-list/test.ml
+++ b/testsuite/tests/lib-list/test.ml
@@ -96,6 +96,28 @@ let () =
   assert (
     let f a b = a + b, string_of_int b in
     List.fold_left_map f 0 l = (45, sl));
+
+  (* [find_index] *)
+  assert (List.find_index (fun x -> x=1) [] = None);
+  let xs = [1;2;3;4;5] in
+  assert (List.find_index (fun x -> x=1) xs = Some 0);
+  assert (List.find_index (fun x -> x=3) xs = Some 2);
+  assert (List.find_index (fun x -> x=5) xs = Some 4);
+  assert (List.find_index (fun x -> x=6) xs = None);
+
+  (* [find_mapi] *)
+  assert (List.find_mapi
+    (fun i x -> if x+i=3 then Some(i, x) else None) [] = None);
+  let xs = [3;3;3;42;42] in
+  assert (List.find_mapi
+    (fun i x -> if x+i=3 then Some(i, x) else None) xs = Some (0, 3));
+  assert (List.find_mapi
+    (fun i x -> if x+i=4 then Some(i, x) else None) xs = Some (1, 3));
+  assert (List.find_mapi
+    (fun i x -> if x+i=5 then Some(i, x) else None) xs = Some (2, 3));
+  assert (List.find_mapi
+    (fun i x -> if x+i=7 then Some(i, x) else None) xs = None);
+
   ()
 ;;
 

--- a/testsuite/tests/lib-seq/test.ml
+++ b/testsuite/tests/lib-seq/test.ml
@@ -246,6 +246,31 @@ let () =
           = (List.of_seq s |> List.sort compare));
   ()
 
+(* [find_index] *)
+let () =
+  assert (Seq.find_index (fun x -> x=1) !?[] = None);
+  let xs = !?[1;2;3;4;5] in
+  assert (Seq.find_index (fun x -> x=1) xs = Some 0);
+  assert (Seq.find_index (fun x -> x=3) xs = Some 2);
+  assert (Seq.find_index (fun x -> x=5) xs = Some 4);
+  assert (Seq.find_index (fun x -> x=6) xs = None);
+  ()
+
+(* [find_mapi] *)
+let () =
+  assert (Seq.find_mapi
+    (fun i x -> if x+i=3 then Some(i, x) else None) !?[] = None);
+  let xs = !?[3;3;3;42;42] in
+  assert (Seq.find_mapi
+    (fun i x -> if x+i=3 then Some(i, x) else None) xs = Some (0, 3));
+  assert (Seq.find_mapi
+    (fun i x -> if x+i=4 then Some(i, x) else None) xs = Some (1, 3));
+  assert (Seq.find_mapi
+    (fun i x -> if x+i=5 then Some(i, x) else None) xs = Some (2, 3));
+  assert (Seq.find_mapi
+    (fun i x -> if x+i=7 then Some(i, x) else None) xs = None);
+  ()
+
 (* Auxiliary definitions of 2d matrices. *)
 let square n f =
   Seq.(init n (fun i -> init n (fun j -> f i j)))


### PR DESCRIPTION
_UPD: `findi` was replaced with a more general `find_mapi`, and `position` was renamed to `find_index`._

This PR adds the following functions to the standard library:
 - `findi`: it's an indexed generalization of `find`, just like `filter`/`filteri` or `map`/`mapi`.
 - `position`: it returns the index of the element that satisfies the given predicate.

## Use cases

`position` can be useful when you assign specific _meaning_ to your indices. Say you want to convert a named representation of a lambda term into a term that uses the De Bruijn indexing scheme. Your binder environment looks like this: `[ "c"; "b"; "a" ]`, where the first binder (`"c"`) is added most recently; then you encounter a variable `b`, and you need to produce a corresponding De Bruijn index. This is exactly where `position` is applicable: just write `position (fun x -> x = "b") env` and you're good.

Some examples of such usage: [1](https://gist.github.com/mb64/814836449f60b05113885fe93068bf1d#file-tychk_nbe-ml-L15), [2](https://github.com/brendanzab/language-garden/blob/main/elab-dependent/lib/Surface.ml#L9).

Personally, I haven't used `findi`, but since there are other functions in std that follow the same convention `f`/`fi`, e.g., `map` and `mapi`, I think it's logical to have `findi` as well.

## Design decisions

I've tried to be consistent despite the inconsistency across different modules:
 - The `List` and `Array` modules got `findi_opt` and `position_opt`. This is because total functions in these modules are named `f_opt`, while `f` may throw exceptions, e.g., `find` and `find_opt`.
 - The `Seq` module seems to prefer total functions only (without the postfix `_opt`), so it got `findi` and `position`.

We _may_ add `findi` and `position` to `List` and `Array` that throw an exception, but it seems that the current fashion is to add only total functions; e.g., the `Array` module has `find_opt` but no `find`.

## Implementation

`position` is clearly a special case of `findi`, but I've implemented it as a standalone function, just in case. The same holds for `find`, which is a special case of `findi`.

## Other standard libraries

 - [Jane Street Base](https://ocaml.janestreet.com/ocaml-core/v0.12/doc/base/Base/List/index.html#val-findi) (`findi`)
 - [OCaml Containers](http://c-cube.github.io/ocaml-containers/last/containers/CCList/index.html#val-find_idx) (`find_idx`)
 - [Rust](https://doc.rust-lang.org/std/iter/trait.Iterator.html#method.position) (`position`)
