### PR TITLE
type-checker cleanup (2/N) remove dead function in Ctype

### DIFF
--- a/Changes
+++ b/Changes
@@ -219,7 +219,7 @@ Working version
 
 ### Internal/compiler-libs changes:
 
-- #11847: small refactorings in the type checker
+- #11847, #11849: small refactorings in the type checker
   (Gabriel Scherer, review by Nicolás Ojeda Bär)
 
 - #11027: Separate typing counter-examples from type_pat into retype_pat;

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -1215,14 +1215,6 @@ let instance_parameterized_type ?keep_names sch_args sch =
     (ty_args, ty)
   )
 
-let instance_parameterized_type_2 sch_args sch_lst sch =
-  For_copy.with_scope (fun copy_scope ->
-    let ty_args = List.map (copy copy_scope) sch_args in
-    let ty_lst = List.map (copy copy_scope) sch_lst in
-    let ty = copy copy_scope sch in
-    (ty_args, ty_lst, ty)
-  )
-
 let map_kind f = function
   | Type_abstract -> Type_abstract
   | Type_open -> Type_open

--- a/typing/ctype.mli
+++ b/typing/ctype.mli
@@ -163,9 +163,6 @@ val instance_constructor: existential_treatment ->
 val instance_parameterized_type:
         ?keep_names:bool ->
         type_expr list -> type_expr -> type_expr list * type_expr
-val instance_parameterized_type_2:
-        type_expr list -> type_expr list -> type_expr ->
-        type_expr list * type_expr list * type_expr
 val instance_declaration: type_declaration -> type_declaration
 val generic_instance_declaration: type_declaration -> type_declaration
         (* Same as instance_declaration, but new nodes at generic_level *)


### PR DESCRIPTION
This is a minor follow-up to #11847 that simply removes a dead function from Ctype.

This function uses the copy/abbreviation machinery that I am hoping to eventually simplify -- so its removal would benefit maintenance.

The last use of this function appears to have been removed in 87b17301f4a408109a0f00f7a297b02c79724bc1 in 1998.

(Again, no type-checker expertise is necessary to review this.)