### PR TITLE
Always remove asm temp file, unless explicitly kept

### DIFF
--- a/Changes
+++ b/Changes
@@ -352,6 +352,10 @@ Working version
   (Jérôme Vouillon, review by Nicolás Ojeda Bär, Stephen Dolan and
    Hugo Heuzard)
 
+- #11850: When stopping before the `emit` phase (using `-stop-after`), an empty
+  temporary assembly file is no longer left in the file system.
+  (Nicolás Ojeda Bär, review by Gabriel Scherer and Xavier Leroy)
+
 OCaml 5.0
 ---------
 

--- a/asmcomp/asmgen.ml
+++ b/asmcomp/asmgen.ml
@@ -212,6 +212,9 @@ let compile_unit ~output_prefix ~asm_filename ~keep_asm ~obj_filename gen =
   let create_asm = should_emit () &&
                    (keep_asm || not !Emitaux.binary_backend_available) in
   Emitaux.create_asm_file := create_asm;
+  let remove_asm_file () =
+    if not create_asm || not keep_asm then remove_file asm_filename
+  in
   Misc.try_finally
     ~exceptionally:(fun () -> remove_file obj_filename)
     (fun () ->
@@ -222,8 +225,7 @@ let compile_unit ~output_prefix ~asm_filename ~keep_asm ~obj_filename gen =
             write_linear output_prefix)
          ~always:(fun () ->
              if create_asm then close_out !Emitaux.output_channel)
-         ~exceptionally:(fun () ->
-             if create_asm && not keep_asm then remove_file asm_filename);
+         ~exceptionally:remove_asm_file;
        if should_emit () then begin
          let assemble_result =
            Profile.record "assemble"
@@ -232,7 +234,7 @@ let compile_unit ~output_prefix ~asm_filename ~keep_asm ~obj_filename gen =
          if assemble_result <> 0
          then raise(Error(Assembler_error asm_filename));
        end;
-       if create_asm && not keep_asm then remove_file asm_filename
+       remove_asm_file ()
     )
 
 let end_gen_implementation ?toplevel ~ppf_dump

--- a/asmcomp/asmgen.ml
+++ b/asmcomp/asmgen.ml
@@ -213,6 +213,8 @@ let compile_unit ~output_prefix ~asm_filename ~keep_asm ~obj_filename gen =
                    (keep_asm || not !Emitaux.binary_backend_available) in
   Emitaux.create_asm_file := create_asm;
   let remove_asm_file () =
+    (* if [should_emit ()] is [false] then no assembly is generated,
+       so the (empty) temporary file should be deleted. *)
     if not create_asm || not keep_asm then remove_file asm_filename
   in
   Misc.try_finally


### PR DESCRIPTION
Apart from returning the temporary file name, the function `Asmgen.asm_filename` creates the file in question as a side-effect. When the compilation pipeline is stopped before the "emit" phase (with the `-stop-after` option), the (empty) temporary file is left in the filesystem, which can fill up the `/tmp` directory in some circonstances (eg CI).

The solution is to always delete the temporary file unless it is being kept explicitly. A different approach would be to create the temporary file lazily to avoid creating it at all if not used.

Fixes #11471

