### PR TITLE
type-checker cleanup (3/N): remove `Ctype.copy_rec` global state

### DIFF
--- a/Changes
+++ b/Changes
@@ -219,7 +219,7 @@ Working version
 
 ### Internal/compiler-libs changes:
 
-- #11847, #11849: small refactorings in the type checker
+- #11847, #11849, #11850: small refactorings in the type checker
   (Gabriel Scherer, review by Nicolás Ojeda Bär)
 
 - #11027: Separate typing counter-examples from type_pat into retype_pat;

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -1307,8 +1307,8 @@ let add_delayed_copy t copy_scope ty =
    copy to keep the sharing of the original type without breaking its
    binding structure.
  *)
-let copy_sep ~copy_scope ~fixed ~free ~may_share
-    ~(visited : type_expr TypeHash.t) (ty : type_expr) =
+let copy_sep ~copy_scope ~fixed ~(visited : type_expr TypeHash.t) sch =
+  let free = compute_univars sch in
   let rec copy_rec ~may_share (ty : type_expr) =
     let univars = free ty in
     if is_Tvar ty || may_share && TypeSet.is_empty univars then
@@ -1345,7 +1345,7 @@ let copy_sep ~copy_scope ~fixed ~free ~may_share
       Transient_expr.set_stub_desc t desc';
       t
     end
-  in copy_rec ~may_share ty
+  in copy_rec ~may_share:true sch
 
 let instance_poly' copy_scope ~keep_names fixed univars sch =
   (* In order to compute univars below, [sch] should not contain [Tsubst] *)
@@ -1359,8 +1359,7 @@ let instance_poly' copy_scope ~keep_names fixed univars sch =
   List.iter2 (TypeHash.add visited) univars vars;
   delayed_copy := [];
   let ty =
-    copy_sep ~copy_scope ~fixed ~free:(compute_univars sch)
-      ~may_share:true ~visited sch in
+    copy_sep ~copy_scope ~fixed ~visited sch in
   List.iter Lazy.force !delayed_copy;
   delayed_copy := [];
   vars, ty


### PR DESCRIPTION
This is a follow-up to #11847 that removes global state in Ctype.copy_rec. The change remains behavior-preserving (so it requries no type-checking expertise for review) but it is slightly more complex, so I split it in three small commits that are easier to review separately.
