### PR TITLE
TRMC implementation of List.concat_map

### DIFF
--- a/Changes
+++ b/Changes
@@ -77,6 +77,10 @@ Working version
 
 ### Standard library:
 
+- #11856: Rewrite List.concat_map using TRMC, making it faster
+  as well as tail-recursive.
+  (Jeremy Yallop, review by Nicolás Ojeda Bär and Gabriel Scherer)
+
 - #11836: Add `Array.map_inplace`.
   (Léo Andrès, review by Gabriel Scherer and KC Sivaramakrishnan)
 

--- a/stdlib/list.ml
+++ b/stdlib/list.ml
@@ -265,13 +265,13 @@ let[@tail_mod_cons] rec filter_map f = function
       | None -> filter_map f l
       | Some v -> v :: filter_map f l
 
-let concat_map f l =
-  let rec aux f acc = function
-    | [] -> rev acc
-    | x :: l ->
-       let xs = f x in
-       aux f (rev_append xs acc) l
-  in aux f [] l
+let[@tail_mod_cons] rec concat_map f = function
+  | [] -> []
+  | x::xs -> prepend_concat_map (f x) f xs
+and[@tail_mod_cons] prepend_concat_map ys f xs =
+  match ys with
+  | [] -> concat_map f xs
+  | y :: ys -> y :: prepend_concat_map ys f xs
 
 let fold_left_map f accu l =
   let rec aux accu l_accu = function


### PR DESCRIPTION
A tail-recursive-modulo-cons implementation of `concat_map`, replacing the existing accumulate-and-reverse implementation.

### [Benchmark](https://gist.github.com/yallop/6a4235ae8dfa454228f9d0f7759b1499) results: 

<details><summary>Always faster; always less memory-intensive; about twice as fast on very long lists.</summary>

| Name         | Time/Run | mWd/Run    | mjWd/Run   | Prom/Run   | Percentage |
|--------------|----------|------------|------------|------------|------------|
| orig 1       | 41.70ns  | 45.00w     | 100.00%    |            | 100.00%    |
| tmrc 1       | 40.08ns  | 29.99w     | 96.13%     |            | 96.13%     |
| orig 2       | 81.99ns  | 90.01w     | 100.00%    |            | 100.00%    |
| tmrc 2       | 76.71ns  | 60.00w     | 93.57%     |            | 93.57%     |
| orig 4       | 158.00ns | 179.97w    | 100.00%    |            | 100.00%    |
| tmrc 4       | 156.66ns | 120.03w    | 99.15%     |            | 99.15%     |
| orig 8       | 311.84ns | 359.96w    | 0.10w      | 0.10w      | 100.00%    |
| tmrc 8       | 303.11ns | 239.93w    | 0.11w      | 0.11w      | 97.20%     |
| orig 16      | 625.99ns | 720.10w    | 0.44w      | 0.44w      | 100.00%    |
| tmrc 16      | 611.85ns | 480.09w    | 0.44w      | 0.44w      | 97.74%     |
| orig 32      | 1.31us   | 1_440.25w  | 1.76w      | 1.76w      | 100.00%    |
| tmrc 32      | 1.22us   | 959.94w    | 1.65w      | 1.65w      | 93.04%     |
| orig 64      | 2.86us   | 2.88kw     | 6.97w      | 6.97w      | 100.00%    |
| tmrc 64      | 2.53us   | 1.92kw     | 6.83w      | 6.83w      | 88.65%     |
| orig 128     | 6.46us   | 5.76kw     | 28.03w     | 28.03w     | 100.00%    |
| tmrc 128     | 5.27us   | 3.84kw     | 27.71w     | 27.71w     | 81.49%     |
| orig 256     | 14.39us  | 11.52kw    | 112.40w    | 112.40w    | 100.00%    |
| tmrc 256     | 11.63us  | 7.68kw     | 111.53w    | 111.53w    | 80.80%     |
| orig 512     | 33.45us  | 23.06kw    | 448.69w    | 448.69w    | 100.00%    |
| tmrc 512     | 27.64us  | 15.37kw    | 450.37w    | 450.37w    | 82.62%     |
| orig 1024    | 83.48us  | 46.09kw    | 1.80kw     | 1.80kw     | 100.00%    |
| tmrc 1024    | 71.25us  | 30.75kw    | 1.80kw     | 1.80kw     | 85.35%     |
| orig 2048    | 235.88us | 92.21kw    | 7.17kw     | 7.17kw     | 100.00%    |
| tmrc 2048    | 205.11us | 61.44kw    | 7.21kw     | 7.21kw     | 86.96%     |
| orig 4096    | 728.89us | 184.38kw   | 28.89kw    | 28.89kw    | 100.00%    |
| tmrc 4096    | 659.61us | 122.93kw   | 28.81kw    | 28.81kw    | 90.49%     |
| orig 8192    | 2.36ms   | 368.98kw   | 108.22kw   | 108.22kw   | 100.00%    |
| tmrc 8192    | 2.31ms   | 245.93kw   | 115.31kw   | 115.31kw   | 97.72%     |
| orig 16384   | 6.78ms   | 740.16kw   | 325.08kw   | 325.08kw   | 100.00%    |
| tmrc 16384   | 4.99ms   | 491.94kw   | 245.97kw   | 245.97kw   | 73.65%     |
| orig 32768   | 17.60ms  | 1_480.27kw | 829.81kw   | 829.81kw   | 100.00%    |
| tmrc 32768   | 10.56ms  | 983.02kw   | 491.51kw   | 491.51kw   | 60.03%     |
| orig 65536   | 42.65ms  | 2.97Mw     | 1_832.81kw | 1_832.81kw | 100.00%    |
| tmrc 65536   | 23.18ms  | 1.97Mw     | 982.63kw   | 982.63kw   | 54.36%     |
| orig 131072  | 87.07ms  | 5.89Mw     | 3.83Mw     | 3.83Mw     | 100.00%    |
| tmrc 131072  | 46.38ms  | 3.93Mw     | 1.97Mw     | 1.97Mw     | 53.27%     |
| orig 262144  | 186.11ms | 11.80Mw    | 7.86Mw     | 7.86Mw     | 100.00%    |
| tmrc 262144  | 96.45ms  | 7.86Mw     | 3.93Mw     | 3.93Mw     | 51.82%     |
| orig 524288  | 403.35ms | 23.59Mw    | 15.73Mw    | 15.73Mw    | 100.00%    |
| tmrc 524288  | 198.84ms | 15.73Mw    | 7.86Mw     | 7.86Mw     | 49.30%     |
| orig 1048576 | 839.07ms | 47.19Mw    | 31.46Mw    | 31.46Mw    | 100.00%    |
| tmrc 1048576 | 413.03ms | 31.46Mw    | 15.73Mw    | 15.73Mw    | 49.22%     |

</details>

