### PR TITLE
TRMC implementation of @

### DIFF
--- a/Changes
+++ b/Changes
@@ -81,6 +81,9 @@ Working version
 
 ### Standard library:
 
+- #11859: Make Stdlib.(@) and List.append tail-recursive and faster.
+  (Jeremy Yallop, review by )
+
 - #11856: Rewrite List.concat_map using TRMC, making it faster
   as well as tail-recursive.
   (Jeremy Yallop, review by Nicolás Ojeda Bär and Gabriel Scherer)

--- a/Changes
+++ b/Changes
@@ -82,7 +82,7 @@ Working version
 ### Standard library:
 
 - #11859: Make Stdlib.(@) and List.append tail-recursive and faster.
-  (Jeremy Yallop, review by )
+  (Jeremy Yallop, review by Daniel Bünzli)
 
 - #11856: Rewrite List.concat_map using TRMC, making it faster
   as well as tail-recursive.

--- a/Changes
+++ b/Changes
@@ -82,7 +82,7 @@ Working version
 ### Standard library:
 
 - #11859: Make Stdlib.(@) and List.append tail-recursive and faster.
-  (Jeremy Yallop, review by Daniel Bünzli)
+  (Jeremy Yallop, review by Daniel Bünzli and Anil Madhavapeddy)
 
 - #11856: Rewrite List.concat_map using TRMC, making it faster
   as well as tail-recursive.

--- a/Changes
+++ b/Changes
@@ -82,7 +82,7 @@ Working version
 ### Standard library:
 
 - #11859: Make Stdlib.(@) and List.append tail-recursive and faster.
-  (Jeremy Yallop, review by Daniel Bünzli and Anil Madhavapeddy)
+  (Jeremy Yallop, review by Daniel Bünzli, Anil Madhavapeddy, and Bannerets)
 
 - #11856: Rewrite List.concat_map using TRMC, making it faster
   as well as tail-recursive.

--- a/stdlib/list.mli
+++ b/stdlib/list.mli
@@ -110,8 +110,7 @@ val append : 'a list -> 'a list -> 'a list
 
 val rev_append : 'a list -> 'a list -> 'a list
 (** [rev_append l1 l2] reverses [l1] and concatenates it with [l2].
-   This is equivalent to [(]{!rev}[ l1) @ l2], but [rev_append] is
-   tail-recursive and more efficient.
+   This is equivalent to [(]{!rev}[ l1) @ l2].
  *)
 
 val concat : 'a list list -> 'a list

--- a/stdlib/list.mli
+++ b/stdlib/list.mli
@@ -105,6 +105,7 @@ val init : int -> (int -> 'a) -> 'a list
 val append : 'a list -> 'a list -> 'a list
 (** [append l0 l1] appends [l1] to [l0].
      Same function as the infix operator [@].
+     @since 5.1 this function is tail-recursive.
  *)
 
 val rev_append : 'a list -> 'a list -> 'a list

--- a/stdlib/list.mli
+++ b/stdlib/list.mli
@@ -103,7 +103,8 @@ val init : int -> (int -> 'a) -> 'a list
  *)
 
 val append : 'a list -> 'a list -> 'a list
-(** Concatenate two lists. Same function as the infix operator [@].
+(** [append l0 l1] appends [l1] to [l0].
+     Same function as the infix operator [@].
  *)
 
 val rev_append : 'a list -> 'a list -> 'a list

--- a/stdlib/list.mli
+++ b/stdlib/list.mli
@@ -104,8 +104,6 @@ val init : int -> (int -> 'a) -> 'a list
 
 val append : 'a list -> 'a list -> 'a list
 (** Concatenate two lists. Same function as the infix operator [@].
-   Not tail-recursive (length of the first argument). The [@]
-   operator is not tail-recursive either.
  *)
 
 val rev_append : 'a list -> 'a list -> 'a list

--- a/stdlib/listLabels.mli
+++ b/stdlib/listLabels.mli
@@ -110,8 +110,7 @@ val append : 'a list -> 'a list -> 'a list
 
 val rev_append : 'a list -> 'a list -> 'a list
 (** [rev_append l1 l2] reverses [l1] and concatenates it with [l2].
-   This is equivalent to [(]{!rev}[ l1) @ l2], but [rev_append] is
-   tail-recursive and more efficient.
+   This is equivalent to [(]{!rev}[ l1) @ l2].
  *)
 
 val concat : 'a list list -> 'a list

--- a/stdlib/listLabels.mli
+++ b/stdlib/listLabels.mli
@@ -105,6 +105,7 @@ val init : len:int -> f:(int -> 'a) -> 'a list
 val append : 'a list -> 'a list -> 'a list
 (** [append l0 l1] appends [l1] to [l0].
      Same function as the infix operator [@].
+     @since 5.1 this function is tail-recursive.
  *)
 
 val rev_append : 'a list -> 'a list -> 'a list

--- a/stdlib/listLabels.mli
+++ b/stdlib/listLabels.mli
@@ -103,7 +103,8 @@ val init : len:int -> f:(int -> 'a) -> 'a list
  *)
 
 val append : 'a list -> 'a list -> 'a list
-(** Concatenate two lists. Same function as the infix operator [@].
+(** [append l0 l1] appends [l1] to [l0].
+     Same function as the infix operator [@].
  *)
 
 val rev_append : 'a list -> 'a list -> 'a list

--- a/stdlib/listLabels.mli
+++ b/stdlib/listLabels.mli
@@ -104,8 +104,6 @@ val init : len:int -> f:(int -> 'a) -> 'a list
 
 val append : 'a list -> 'a list -> 'a list
 (** Concatenate two lists. Same function as the infix operator [@].
-   Not tail-recursive (length of the first argument). The [@]
-   operator is not tail-recursive either.
  *)
 
 val rev_append : 'a list -> 'a list -> 'a list

--- a/stdlib/stdlib.ml
+++ b/stdlib/stdlib.ml
@@ -295,10 +295,12 @@ let float_of_string_opt s =
 
 (* List operations -- more in module List *)
 
-let rec ( @ ) l1 l2 =
+let[@tail_mod_cons] rec ( @ ) l1 l2 =
   match l1 with
-    [] -> l2
-  | hd :: tl -> hd :: (tl @ l2)
+  | [] -> l2
+  | h1 :: [] -> h1 :: l2
+  | h1 :: h2 :: [] -> h1 :: h2 :: l2
+  | h1 :: h2 :: h3 :: tl -> h1 :: h2 :: h3 :: (tl @ l2)
 
 (* I/O operations *)
 

--- a/stdlib/stdlib.mli
+++ b/stdlib/stdlib.mli
@@ -815,7 +815,7 @@ external snd : 'a * 'b -> 'b = "%field1"
 *)
 
 val ( @ ) : 'a list -> 'a list -> 'a list
-(** List concatenation.  Not tail-recursive (length of the first argument).
+(** List concatenation.
   Right-associative operator, see {!Ocaml_operators} for more information.
 *)
 

--- a/stdlib/stdlib.mli
+++ b/stdlib/stdlib.mli
@@ -815,7 +815,7 @@ external snd : 'a * 'b -> 'b = "%field1"
 *)
 
 val ( @ ) : 'a list -> 'a list -> 'a list
-(** List concatenation.
+(** [l0 @ l1] appends [l1] to [l0]. Same function as {!List.append}.
   Right-associative operator, see {!Ocaml_operators} for more information.
 *)
 

--- a/stdlib/stdlib.mli
+++ b/stdlib/stdlib.mli
@@ -817,6 +817,7 @@ external snd : 'a * 'b -> 'b = "%field1"
 val ( @ ) : 'a list -> 'a list -> 'a list
 (** [l0 @ l1] appends [l1] to [l0]. Same function as {!List.append}.
   Right-associative operator, see {!Ocaml_operators} for more information.
+  @since 5.1 this function is tail-recursive.
 *)
 
 (** {1 Input/output}

--- a/testsuite/tests/backtrace/pr2195-locs.byte.reference
+++ b/testsuite/tests/backtrace/pr2195-locs.byte.reference
@@ -1,4 +1,4 @@
 Fatal error: exception Stdlib.Exit
-Raised by primitive operation at Stdlib.open_in_gen in file "stdlib.ml", line 403, characters 28-54
+Raised by primitive operation at Stdlib.open_in_gen in file "stdlib.ml", line 405, characters 28-54
 Called from Pr2195 in file "pr2195.ml", line 24, characters 6-19
 Re-raised at Pr2195 in file "pr2195.ml", line 29, characters 4-41

--- a/testsuite/tests/backtrace/pr2195.opt.reference
+++ b/testsuite/tests/backtrace/pr2195.opt.reference
@@ -1,5 +1,5 @@
 Fatal error: exception Stdlib.Exit
-Raised by primitive operation at Stdlib.open_in_gen in file "stdlib.ml", line 403, characters 28-54
-Called from Stdlib.open_in in file "stdlib.ml" (inlined), line 408, characters 2-45
+Raised by primitive operation at Stdlib.open_in_gen in file "stdlib.ml", line 405, characters 28-54
+Called from Stdlib.open_in in file "stdlib.ml" (inlined), line 410, characters 2-45
 Called from Pr2195 in file "pr2195.ml", line 24, characters 6-19
 Re-raised at Pr2195 in file "pr2195.ml", line 29, characters 4-41


### PR DESCRIPTION
A tail-recursive-modulo-cons implementation of `Stdlib.(@)` (and `List.append`), replacing the existing stack-consuming implementation.

To avoid a slowdown over the existing version, the function is also unrolled.  (It's worth noting, though, that this isn't the fastest possible implementation: an unrolled stack-consuming version would be even faster.)

### Benchmark results: 

<details><summary>Almost always faster than the current implementation; always faster on lists of length less than 16384; twice as fast on long lists</summary>


| l1 length | original   | trmc       | trmc/unrolled |
|-----------|------------|------------|---------------|
| 1         | 6.46ns     | 9.74ns     | 5.47ns        |
| 2         | 9.25ns     | 14.58ns    | 7.56ns        |
| 4         | 16.58ns    | 24.49ns    | 13.76ns       |
| 8         | 28.55ns    | 43.67ns    | 22.30ns       |
| 16        | 61.44ns    | 84.18ns    | 55.11ns       |
| 32        | 131.71ns   | 151.22ns   | 102.34ns      |
| 64        | 250.58ns   | 286.24ns   | 197.16ns      |
| 128       | 511.47ns   | 596.78ns   | 382.34ns      |
| 256       | 1_046.92ns | 1_222.15ns | 804.63ns      |
| 512       | 2.93us     | 2.75us     | 1.79us        |
| 1024      | 6.36us     | 5.84us     | 3.96us        |
| 2048      | 14.37us    | 12.96us    | 9.38us        |
| 4096      | 33.32us    | 31.76us    | 23.32us       |
| 8192      | 79.70us    | 82.88us    | 67.22us       |
| 16384     | 240.20us   | 246.96us   | 226.37us      |
| 32768     | 776.65us   | 870.93us   | 796.78us      |
| 65536     | 2.84ms     | 3.02ms     | 2.76ms        |
| 131072    | 9.16ms     | 8.45ms     | 7.79ms        |
| 262144    | 23.33ms    | 18.02ms    | 16.17ms       |
| 524288    | 59.84ms    | 36.45ms    | 34.23ms       |
| 1048576   | 155.05ms   | 80.61ms    | 75.15ms       |

</details>
