### PR TITLE
Stricter C99 warnings, strict prototypes for primitives list

### DIFF
--- a/Changes
+++ b/Changes
@@ -310,6 +310,11 @@ Working version
 - #11615: remove global variables form asmcomp/linearize.ml
   (Stefan Muenzel, review by Nicolás Ojeda Bär)
 
+- #11763, #11759, #11861: Enable stricter C compilation warnings, use
+  strict prototypes on primitives.
+  (Antonin Décimo, review by Xavier Leroy, David Allsopp and Sébastien
+  Hinderer)
+
 ### Build system:
 
 - #11590: Allow installing to a destination path containing spaces.

--- a/Makefile
+++ b/Makefile
@@ -796,13 +796,17 @@ runtime/primitives: \
 	cp $^ $@
 
 runtime/prims.c : runtime/primitives
-	(echo '#define CAML_INTERNALS'; \
-         echo '#include "caml/mlvalues.h"'; \
-	 echo '#include "caml/prims.h"'; \
-	 sed -e 's/.*/extern value &();/' $<; \
+	export LC_ALL=C; \
+	(echo '#include "caml/config.h"'; \
+	 echo 'typedef intnat value;'; \
+	 echo 'typedef value (*c_primitive)(void);'; \
+	 echo; \
+	 sed -e 's/.*/extern value &(void);/' $<; \
+	 echo; \
 	 echo 'c_primitive caml_builtin_cprim[] = {'; \
 	 sed -e 's/.*/  &,/' $<; \
 	 echo '  0 };'; \
+	 echo; \
 	 echo 'char * caml_names_of_builtin_cprim[] = {'; \
 	 sed -e 's/.*/  "&",/' $<; \
 	 echo '  0 };') > $@

--- a/configure
+++ b/configure
@@ -13656,7 +13656,8 @@ case $ocaml_cv_cc_vendor in #(
   *) :
     outputobj='-o '
   warn_error_flag='-Werror'
-  cc_warnings='-Wall' ;;
+  cc_warnings="-Wall -Wint-conversion -Wstrict-prototypes \
+-Wold-style-definition" ;;
 esac
 
 case $enable_warn_error,true in #(

--- a/configure.ac
+++ b/configure.ac
@@ -688,7 +688,8 @@ AS_CASE([$ocaml_cv_cc_vendor],
     cc_warnings=''],
   [outputobj='-o '
   warn_error_flag='-Werror'
-  cc_warnings='-Wall'])
+  cc_warnings="-Wall -Wint-conversion -Wstrict-prototypes \
+-Wold-style-definition"])
 
 AS_CASE([$enable_warn_error,OCAML__DEVELOPMENT_VERSION],
   [yes,*|,true],

--- a/runtime/caml/prims.h
+++ b/runtime/caml/prims.h
@@ -20,7 +20,7 @@
 
 #ifdef CAML_INTERNALS
 
-typedef value (*c_primitive)();
+typedef value (*c_primitive)(void);
 
 extern c_primitive caml_builtin_cprim[];
 extern char * caml_names_of_builtin_cprim[];
@@ -30,7 +30,18 @@ extern struct ext_table caml_prim_table;
 extern struct ext_table caml_prim_name_table;
 #endif
 
-#define Primitive(n) ((c_primitive)(caml_prim_table.contents[n]))
+#define Primitive1(n) \
+    ((value (*)(value)) caml_prim_table.contents[n])
+#define Primitive2(n) \
+    ((value (*)(value,value)) caml_prim_table.contents[n])
+#define Primitive3(n) \
+    ((value (*)(value,value,value)) caml_prim_table.contents[n])
+#define Primitive4(n) \
+    ((value (*)(value,value,value,value)) caml_prim_table.contents[n])
+#define Primitive5(n) \
+    ((value (*)(value,value,value,value,value)) caml_prim_table.contents[n])
+#define PrimitiveN(n) \
+    ((value (*)(value*,int)) caml_prim_table.contents[n])
 
 extern char * caml_section_table;
 extern asize_t caml_section_table_size;

--- a/runtime/interp.c
+++ b/runtime/interp.c
@@ -1034,34 +1034,34 @@ value caml_interprete(code_t prog, asize_t prog_size)
 
     Instruct(C_CALL1):
       Setup_for_c_call;
-      accu = Primitive(*pc)(accu);
+      accu = Primitive1(*pc)(accu);
       Restore_after_c_call;
       pc++;
       Next;
     Instruct(C_CALL2):
       Setup_for_c_call;
-      accu = Primitive(*pc)(accu, sp[2]);
+      accu = Primitive2(*pc)(accu, sp[2]);
       Restore_after_c_call;
       sp += 1;
       pc++;
       Next;
     Instruct(C_CALL3):
       Setup_for_c_call;
-      accu = Primitive(*pc)(accu, sp[2], sp[3]);
+      accu = Primitive3(*pc)(accu, sp[2], sp[3]);
       Restore_after_c_call;
       sp += 2;
       pc++;
       Next;
     Instruct(C_CALL4):
       Setup_for_c_call;
-      accu = Primitive(*pc)(accu, sp[2], sp[3], sp[4]);
+      accu = Primitive4(*pc)(accu, sp[2], sp[3], sp[4]);
       Restore_after_c_call;
       sp += 3;
       pc++;
       Next;
     Instruct(C_CALL5):
       Setup_for_c_call;
-      accu = Primitive(*pc)(accu, sp[2], sp[3], sp[4], sp[5]);
+      accu = Primitive5(*pc)(accu, sp[2], sp[3], sp[4], sp[5]);
       Restore_after_c_call;
       sp += 4;
       pc++;
@@ -1070,7 +1070,7 @@ value caml_interprete(code_t prog, asize_t prog_size)
       int nargs = *pc++;
       *--sp = accu;
       Setup_for_c_call;
-      accu = Primitive(*pc)(sp + 2, nargs);
+      accu = PrimitiveN(*pc)(sp + 2, nargs);
       Restore_after_c_call;
       sp += nargs;
       pc++;


### PR DESCRIPTION
This PR is a simplified version of #11763, where we don't use the actual types of the primitives when generating the list of primitives, because we end up casting the primitives to a default type anyway (as noted by David Allsopp).
I've retained some of the changes I made to the Makefile, because I think they're easier to understand than the current version.

cc @dra27 @xavierleroy, reviewers of the previous PR.