### PR TITLE
Fix old style declaration warning

### DIFF
--- a/Changes
+++ b/Changes
@@ -593,6 +593,10 @@ Working version
 
 ### Build system:
 
+- #11862: Allow testing whether the C compiler supports a flag. Use it
+  to test and fix an old style declaration warning.
+  (Antonin Décimo, review by Sébastien Hinderer and David Allsopp)
+
 - #11590: Allow installing to a destination path containing spaces.
    (Élie Brami, review by Sébastien Hinderer and David Allsopp)
 

--- a/aclocal.m4
+++ b/aclocal.m4
@@ -142,6 +142,31 @@ AC_DEFUN([OCAML_CL_HAS_VOLATILE_METADATA], [
   CFLAGS="$saved_CFLAGS"
 ])
 
+dnl OCAML_CC_SUPPORTS_CFLAG([-flag], [additional_options],
+dnl                         [if-true], [if-false], [prog])
+dnl Checks whether the C compiler supports [-flag], running the commands in
+dnl [if-true] if it does or the commands in [if-false] otherwise.
+dnl Additional flags may be passed to the C compiler with [additional_options].
+dnl Pass [$warn_error_flag] to turn a warning on an unrecognized flag to a hard
+dnl error with a non-zero exit code value, otherwise detection of the flag
+dnl fails.
+dnl If [prog] is not specified then a default C program is passed to the C
+dnl compiler. The result is cached.
+AC_DEFUN([OCAML_CC_SUPPORTS_CFLAG], [
+  AS_VAR_PUSHDEF([CACHEVAR], [ax_cv_ocaml_cflags_$1])
+  AC_CACHE_CHECK([whether the C compiler supports $1], CACHEVAR, [
+    saved_CFLAGS="$CFLAGS"
+    CFLAGS="$CFLAGS $1 $2"
+    AC_COMPILE_IFELSE([m4_default([$5], [AC_LANG_PROGRAM()])],
+      [AS_VAR_SET(CACHEVAR, [yes])],
+      [AS_VAR_SET(CACHEVAR, [no])])
+    CFLAGS="$saved_CFLAGS"])
+  AS_VAR_IF(CACHEVAR,yes,
+    [m4_default([$3], :)],
+    [m4_default([$4], :)])
+  AS_VAR_POPDEF([CACHEVAR])
+])
+
 # Save C compiler related variables
 AC_DEFUN([OCAML_CC_SAVE_VARIABLES], [
   saved_CC="$CC"

--- a/configure
+++ b/configure
@@ -13678,6 +13678,51 @@ case $ocaml_cv_cc_vendor in #(
 -Wold-style-definition" ;;
 esac
 
+# Use [$warn_error_flag] to turn a warning on an unrecognized flag to
+# a hard error with a non-zero exit code value, otherwise detection of
+# the flag fails.
+
+
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether the C compiler supports -Wold-style-declaration" >&5
+printf %s "checking whether the C compiler supports -Wold-style-declaration... " >&6; }
+if test ${ax_cv_ocaml_cflags__Wold_style_declaration+y}
+then :
+  printf %s "(cached) " >&6
+else $as_nop
+
+    saved_CFLAGS="$CFLAGS"
+    CFLAGS="$CFLAGS -Wold-style-declaration $warn_error_flag"
+    cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+int
+main (void)
+{
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_compile "$LINENO"
+then :
+  ax_cv_ocaml_cflags__Wold_style_declaration=yes
+else $as_nop
+  ax_cv_ocaml_cflags__Wold_style_declaration=no
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
+    CFLAGS="$saved_CFLAGS"
+fi
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ax_cv_ocaml_cflags__Wold_style_declaration" >&5
+printf "%s\n" "$ax_cv_ocaml_cflags__Wold_style_declaration" >&6; }
+  if test "x$ax_cv_ocaml_cflags__Wold_style_declaration" = xyes
+then :
+  cc_warnings="$cc_warnings -Wold-style-declaration"
+else $as_nop
+  :
+fi
+
+
+
 case $enable_warn_error,true in #(
   yes,*|,true) :
     cc_warnings="$cc_warnings $warn_error_flag" ;; #(

--- a/configure.ac
+++ b/configure.ac
@@ -698,6 +698,12 @@ AS_CASE([$ocaml_cv_cc_vendor],
   cc_warnings="-Wall -Wint-conversion -Wstrict-prototypes \
 -Wold-style-definition"])
 
+# Use [$warn_error_flag] to turn a warning on an unrecognized flag to
+# a hard error with a non-zero exit code value, otherwise detection of
+# the flag fails.
+OCAML_CC_SUPPORTS_CFLAG([-Wold-style-declaration], [$warn_error_flag],
+  [cc_warnings="$cc_warnings -Wold-style-declaration"])
+
 AS_CASE([$enable_warn_error,OCAML__DEVELOPMENT_VERSION],
   [yes,*|,true],
     [cc_warnings="$cc_warnings $warn_error_flag"])

--- a/runtime/sys.c
+++ b/runtime/sys.c
@@ -219,7 +219,7 @@ CAMLprim value caml_sys_exit(value retcode)
 #endif
 #endif
 
-const static int sys_open_flags[] = {
+static const int sys_open_flags[] = {
   O_RDONLY, O_WRONLY, O_APPEND | O_WRONLY, O_CREAT, O_TRUNC, O_EXCL,
   O_BINARY, O_TEXT, O_NONBLOCK
 };


### PR DESCRIPTION
This is a teeny tiny fix for a "stricter C" (almost cosmetic really) warning that only GCC supports, that checks the style of declarations in C code.
I've cherry-picked a commit by @dra27 from another branch to detect support for a C compiler flag. As clang only emits a warning (return code 0) and not an error if it doesn't recognize a warning, it is necessary to turn the warning into an error (return code 1).