### PR TITLE
Allow to disable usage warnings on invidual fields or constructors

### DIFF
--- a/Changes
+++ b/Changes
@@ -217,6 +217,10 @@ Working version
   variables available through ocamlc -config.
   (Sébastien Hinderer, review by Gabriel Scherer and David Allsopp)
 
+- #11235, #11864: usage warnings for constructors and fields can now be disabled
+  on field-by-field or constructor-by-constructor basis
+  (Florian Angeletti, review by Gabriel Scherer)
+
 ### Internal/compiler-libs changes:
 
 - #11847, #11849, #11851: small refactorings in the type checker

--- a/testsuite/tests/typing-warnings/unused_types.ml
+++ b/testsuite/tests/typing-warnings/unused_types.ml
@@ -196,6 +196,21 @@ Warning 38 [unused-extension]: unused extension constructor Nobody_uses_me
 module Unused_extension_constructor : sig type t = .. end
 |}]
 
+module Unused_extension_disabled_warning : sig
+  type t = ..
+end = struct
+  type t = ..
+  type t += Dont_warn_on_me [@warning "-unused-extension"] | Nobody_uses_me
+end
+;;
+[%%expect {|
+Line 5, characters 59-75:
+5 |   type t += Dont_warn_on_me [@warning "-unused-extension"] | Nobody_uses_me
+                                                               ^^^^^^^^^^^^^^^^
+Warning 38 [unused-extension]: unused extension constructor Nobody_uses_me
+module Unused_extension_disabled_warning : sig type t = .. end
+|}]
+
 module Unused_exception_outside_patterns : sig
   val falsity : exn -> bool
 end = struct
@@ -346,6 +361,21 @@ Warning 34 [unused-type-declaration]: unused type t.
 module Unused_constructor_disable_warning : sig end
 |}]
 
+module Unused_constructor_disable_one_warning : sig
+end = struct
+  type t = A [@warning "-37"] | B
+end;;
+[%%expect {|
+Line 3, characters 2-33:
+3 |   type t = A [@warning "-37"] | B
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Warning 34 [unused-type-declaration]: unused type t.
+Line 3, characters 30-33:
+3 |   type t = A [@warning "-37"] | B
+                                  ^^^
+Warning 37 [unused-constructor]: unused constructor B.
+module Unused_constructor_disable_one_warning : sig end
+|}]
 
 module Unused_record : sig end = struct
   type t = { a : int; b : int }
@@ -442,4 +472,32 @@ Line 4, characters 22-37:
 Warning 69 [unused-field]: mutable record field b is never mutated.
 module Unused_mutable_field_exported_private :
   sig type t = private { a : int; mutable b : int; } end
+|}]
+
+module Unused_field_disable_warning : sig
+end = struct
+  type t = { a: int; b:int } [@@warning "-unused-field"]
+end;;
+[%%expect {|
+Line 3, characters 2-56:
+3 |   type t = { a: int; b:int } [@@warning "-unused-field"]
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Warning 34 [unused-type-declaration]: unused type t.
+module Unused_field_disable_warning : sig end
+|}]
+
+module Unused_field_disable_one_warning : sig
+end = struct
+  type t = { a: int [@warning "-unused-field"]; b:int }
+end;;
+[%%expect {|
+Line 3, characters 2-55:
+3 |   type t = { a: int [@warning "-unused-field"]; b:int }
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Warning 34 [unused-type-declaration]: unused type t.
+Line 3, characters 48-53:
+3 |   type t = { a: int [@warning "-unused-field"]; b:int }
+                                                    ^^^^^
+Warning 69 [unused-field]: unused record field b.
+module Unused_field_disable_one_warning : sig end
 |}]

--- a/typing/env.ml
+++ b/typing/env.ml
@@ -1897,6 +1897,7 @@ and store_value ?check id addr decl shape env =
     summary = Env_value(env.summary, id, decl) }
 
 and store_constructor ~check type_decl type_id cstr_id cstr env =
+  Builtin_attributes.warning_scope cstr.cstr_attributes (fun () ->
   if check && not type_decl.type_loc.Location.loc_ghost
      && Warnings.is_active (Warnings.Unused_constructor ("", Unused))
   then begin
@@ -1920,7 +1921,7 @@ and store_constructor ~check type_decl type_id cstr_id cstr env =
                      (Warnings.Unused_constructor(name, complaint)))
               (constructor_usage_complaint ~rebind:false priv used));
     end;
-  end;
+  end);
   let cda_shape = Shape.leaf cstr.cstr_uid in
   { env with
     constrs =
@@ -1929,6 +1930,7 @@ and store_constructor ~check type_decl type_id cstr_id cstr env =
   }
 
 and store_label ~check type_decl type_id lbl_id lbl env =
+  Builtin_attributes.warning_scope lbl.lbl_attributes (fun () ->
   if check && not type_decl.type_loc.Location.loc_ghost
      && Warnings.is_active (Warnings.Unused_field ("", Unused))
   then begin
@@ -1951,7 +1953,7 @@ and store_label ~check type_decl type_id lbl_id lbl env =
                    Location.prerr_warning
                      loc (Warnings.Unused_field(name, complaint)))
               (label_usage_complaint priv mut used))
-  end;
+  end);
   { env with
     labels = TycompTbl.add lbl_id lbl env.labels;
   }
@@ -2020,6 +2022,7 @@ and store_extension ~check ~rebind id addr ext shape env =
       cda_address = Some addr;
       cda_shape = shape }
   in
+  Builtin_attributes.warning_scope ext.ext_attributes (fun () ->
   if check && not loc.Location.loc_ghost &&
     Warnings.is_active (Warnings.Unused_extension ("", false, Unused))
   then begin
@@ -2041,7 +2044,7 @@ and store_extension ~check ~rebind id addr ext shape env =
                        (name, is_exception, complaint)))
              (constructor_usage_complaint ~rebind priv used))
     end;
-  end;
+  end);
   { env with
     constrs = TycompTbl.add id cda env.constrs;
     summary = Env_extension(env.summary, id, ext) }


### PR DESCRIPTION
This PR ensures that we read the warning attributes attached to fields, constructors or extension constructors before deciding if we should track their uses or not. For instance, the code example below disables usage warnings for the constructor "B" or the field "b":

```ocaml
module M: sig end = struct
  type s = A | B [@warning "-unused-constructor"] | C
  type r = { a: int; b:int [@warning "-unused-field"]; c:int }
  type t += A | B [@warning "-unused-extension"] | C
end
```

Close #11235