### PR TITLE
do not return 0 on ENOENT in win32:caml_read_directory

### DIFF
--- a/Changes
+++ b/Changes
@@ -367,6 +367,10 @@ Working version
   temporary assembly file is no longer left in the file system.
   (Nicolás Ojeda Bär, review by Gabriel Scherer and Xavier Leroy)
 
+- #11866: Fix the result of `caml_read_directory()` on non-existent paths.
+  (Andrei Paskevich and Charlène Gros, review by David Allsopp and
+   Nicolás Ojeda Bär)
+
 OCaml 5.0
 ---------
 

--- a/runtime/win32.c
+++ b/runtime/win32.c
@@ -431,7 +431,7 @@ CAMLexport int caml_read_directory(wchar_t * dirname,
   h = _wfindfirst(template, &fileinfo);
   if (h == -1) {
     caml_stat_free(template);
-    return errno == ENOENT ? 0 : -1;
+    return -1;
   }
   do {
     if (wcscmp(fileinfo.name, L".") != 0 && wcscmp(fileinfo.name, L"..") != 0) {

--- a/runtime/win32.c
+++ b/runtime/win32.c
@@ -415,7 +415,7 @@ CAMLexport void caml_expand_command_line(int * argcp, wchar_t *** argvp)
 CAMLexport int caml_read_directory(wchar_t * dirname,
                                    struct ext_table * contents)
 {
-  size_t dirnamelen, xdirnamelen;
+  size_t dirnamelen;
   wchar_t * template;
   intptr_t h;
   struct _wfinddata_t fileinfo;
@@ -425,12 +425,11 @@ CAMLexport int caml_read_directory(wchar_t * dirname,
   if (dirnamelen > 0 &&
       (dirname[dirnamelen - 1] == L'/'
        || dirname[dirnamelen - 1] == L'\\'
-       || dirname[dirnamelen - 1] == L':')) {
+       || dirname[dirnamelen - 1] == L':'))
     template = caml_stat_wcsconcat(2, dirname, L"*.*");
-    xdirnamelen = dirnamelen;
-  } else {
+  else {
     template = caml_stat_wcsconcat(2, dirname, L"\\*.*");
-    xdirnamelen = dirnamelen + 1;
+    dirnamelen++; /* template[dirnamelen] always points after the backslash */
   }
   h = _wfindfirst(template, &fileinfo);
   if (h == -1) {
@@ -438,7 +437,7 @@ CAMLexport int caml_read_directory(wchar_t * dirname,
        [GetFileAttributes()] on [template] without the trailing [*.*].
        The added backslash at the end gives us the expected result (-1)
        on pathological paths like [...]. */
-    template[xdirnamelen] = L'\0';
+    template[dirnamelen] = L'\0';
     res = errno == ENOENT &&
           GetFileAttributes(template) != INVALID_FILE_ATTRIBUTES ? 0 : -1;
     caml_stat_free(template);


### PR DESCRIPTION
fixes #11829