### PR TITLE
runtime: ensure that finalizers are not called in [noexc] mode

### DIFF
--- a/Changes
+++ b/Changes
@@ -46,6 +46,9 @@ Working version
   (Gabriel Scherer, review by Xavier Leroy, Guillaume Munch-Maccagnoni
    and Nicolás Ojeda Bär)
 
+- #????: ensure that finalizers are not called in [noexc] mode
+  (Gabriel Scherer, report by Timothy Bourke)
+
 ### Type system:
 
 - #6941, #11187: prohibit using classes through recursive modules

--- a/runtime/caml/shared_heap.h
+++ b/runtime/caml/shared_heap.h
@@ -82,7 +82,7 @@ Caml_inline int is_marked(value v) {
 
 void caml_redarken_pool(struct pool*, scanning_action, void*);
 
-intnat caml_sweep(struct caml_heap_state*, intnat work, int noexc);
+intnat caml_sweep(struct caml_heap_state*, intnat work);
 
 
 /* must be called during STW */

--- a/runtime/caml/shared_heap.h
+++ b/runtime/caml/shared_heap.h
@@ -30,7 +30,8 @@ struct pool;
 struct caml_heap_state* caml_init_shared_heap(void);
 void caml_teardown_shared_heap(struct caml_heap_state* heap);
 
-value* caml_shared_try_alloc(struct caml_heap_state*, mlsize_t, tag_t, int);
+value* caml_shared_try_alloc(struct caml_heap_state*, mlsize_t, tag_t,
+                             int noexc, int pinned);
 
 /* Copy the domain-local heap stats into a heap stats sample. */
 void caml_collect_heap_stats_sample(
@@ -81,7 +82,7 @@ Caml_inline int is_marked(value v) {
 
 void caml_redarken_pool(struct pool*, scanning_action, void*);
 
-intnat caml_sweep(struct caml_heap_state*, intnat);
+intnat caml_sweep(struct caml_heap_state*, intnat work, int noexc);
 
 
 /* must be called during STW */

--- a/runtime/intern.c
+++ b/runtime/intern.c
@@ -379,7 +379,8 @@ static value intern_alloc_obj(struct caml_intern_state* s, caml_domain_state* d,
     *s->intern_dest = Make_header (wosize, tag, 0);
     s->intern_dest += 1 + wosize;
   } else {
-    p = caml_shared_try_alloc(d->shared_heap, wosize, tag, 0 /* not pinned */);
+    p = caml_shared_try_alloc(d->shared_heap, wosize, tag,
+                              1 /* noexc */, 0 /* not pinned */);
     d->allocated_words += Whsize_wosize(wosize);
     if (p == NULL) {
       intern_cleanup (s);

--- a/runtime/memory.c
+++ b/runtime/memory.c
@@ -332,7 +332,7 @@ Caml_inline value alloc_shr(mlsize_t wosize, tag_t tag, int noexc)
 {
   Caml_check_caml_state();
   caml_domain_state *dom_st = Caml_state;
-  value *v = caml_shared_try_alloc(dom_st->shared_heap, wosize, tag, 0);
+  value *v = caml_shared_try_alloc(dom_st->shared_heap, wosize, tag, noexc, 0);
   if (v == NULL) {
     if (!noexc)
       caml_raise_out_of_memory();

--- a/runtime/minor_gc.c
+++ b/runtime/minor_gc.c
@@ -147,6 +147,7 @@ struct oldify_state {
 static value alloc_shared(caml_domain_state* d, mlsize_t wosize, tag_t tag)
 {
   void* mem = caml_shared_try_alloc(d->shared_heap, wosize, tag,
+                                    1 /* noexc */,
                                     0 /* not pinned */);
   d->allocated_words += Whsize_wosize(wosize);
   if (mem == NULL) {


### PR DESCRIPTION
This is an attempt at fixing #11865. It is a small but invasive change to the runtime code, and we would need feedback from people familiar with `shared_heap.c` to tell if this may work.

### The problem

#11865 is a deadlock caused by the execution of a finalizer during the scanning of minor GC roots. The reason that a finalizer might run during the minor GC root scanning is that moving live roots to the major heap will try to find "free slots" in the major heap, which will in some case try to sweep some dead values to get such free slots. When the values swept are custom blocks with a finalizer, sweeping calls the finalizer.

I suspect that calling finalizers from oldification code of the minor GC is adefect of the current runtime, that is bound to create many more issues than #11865. (In particular issues that are not specific to global roots, which are involved in the #11865 deadlock.) For example, it appears that currently the `intern_alloc_obj` function, which also calls `caml_shared_try_alloc`, could also call finalizers. 

(A look at the 4.x runtime sources suggests that the 4.x runtime would not try to sweep existing dead blocks in these situations, it would extend the major heap right away.)

### The proposed fix

The fix proposed here is to propagate a `noexc` boolean to all runtime functions that may eventually call a `sweep` function. (`noexc` is an existing runtime convention to say that a function is called in a setting where raising exceptions is not safe. In particular, if one may not raise exceptions then one cannot call finalizers.) When sweeping functions find a dead custom block with finalizer in `noexc` mode, the value is left as-is instead of being freed. Those values can only be freed by major-GC invocations that are not in `noexc` mode.

I could observe that this fixes the issue in #11865.

### Remaining issues

This change may affect the dynamics of the major GC in non-trivial way, and we should test the performance impact carefully.

In particular, the test [compaction_corner_case.ml](https://github.com/ocaml/ocaml/blob/5f05c2b0cf2866b071396e100d896bb519477c5e/testsuite/tests/regression/pr9853/compaction_corner_case.ml) seems to slow down massively due to this change (to the point that it appears to never terminate), and I currently have no idea why. (The rest of the tessuite passes.)

I have marked the PR as "draft" while I haven't found the cause of the compaction_corner_case slowdown, but design comments and reviews are still warmly welcome in the meantime.