### PR TITLE
fix over-eager label erasure in the documentation

### DIFF
--- a/stdlib/hashtbl.mli
+++ b/stdlib/hashtbl.mli
@@ -600,7 +600,7 @@ val seeded_hash_param : int -> int -> int -> 'a -> int
       end)
 
     (*  count distinct occurrences of chars in [seq] *)
-    # let count_chars (char Seq.t) : _ list =
+    # let count_chars (seq : char Seq.t) : _ list =
         let counts = Char_tbl.create 16 in
         Seq.iter
           (fun c ->

--- a/stdlib/moreLabels.mli
+++ b/stdlib/moreLabels.mli
@@ -621,7 +621,7 @@ module Hashtbl : sig
         end)
 
       (*  count distinct occurrences of chars in [seq] *)
-      # let count_chars (seq:char Seq.t) : _ list =
+      # let count_chars (seq : char Seq.t) : _ list =
           let counts = Char_tbl.create 16 in
           Seq.iter
             (fun c ->

--- a/stdlib/templates/hashtbl.template.mli
+++ b/stdlib/templates/hashtbl.template.mli
@@ -600,7 +600,7 @@ val seeded_hash_param : int -> int -> int -> 'a -> int
       end)
 
     (*  count distinct occurrences of chars in [seq] *)
-    # let count_chars (seq:char Seq.t) : _ list =
+    # let count_chars (seq : char Seq.t) : _ list =
         let counts = Char_tbl.create 16 in
         Seq.iter
           (fun c ->


### PR DESCRIPTION
The label erasure mechanism of `tool/sync_stdlib_docs` erased the variable `seq` in `(seq:char Seq.t)` in one of the `Hashtbl` examples.
This PR adds space to fix this issue.