### PR TITLE
Fix #11869: weak variance for package types

### DIFF
--- a/Changes
+++ b/Changes
@@ -255,9 +255,9 @@ Working version
   type_pat is no longer in CPS.
   (Jacques Garrigue and Takafumi Saikawa, review by Gabriel Scherer)
 
-- #11018: Clean up Types.Variance, adding a description of the lattice used,
-  and defining explicitly composition.
-  (Jacques Garrigue, review by Gabriel Scherer)
+- #11018, #11869: Clean up Types.Variance, adding a description of
+  the lattice used, and defining explicitly composition.
+  (Jacques Garrigue, review by Gabriel Scherer and Jeremy Yallop)
 
 - #11286, #11515: disambiguate identifiers by using how recently they have
   been bound in the current environment

--- a/testsuite/tests/typing-misc/variance.ml
+++ b/testsuite/tests/typing-misc/variance.ml
@@ -27,3 +27,12 @@ let ul = !(ref ([] : 'a u list));;
 type 'a u = U of (('a -> unit) -> unit)
 val ul : 'a u list = []
 |}]
+
+(* #11869 *)
+
+module type s = sig type t end;;
+type !'a t = (module s with type t = 'a);;
+[%%expect{|
+module type s = sig type t end
+type 'a t = (module s with type t = 'a)
+|}]

--- a/typing/typedecl_variance.ml
+++ b/typing/typedecl_variance.ml
@@ -88,9 +88,7 @@ let compute_variance env visited vari ty =
         compute_same ty
     | Tvar _ | Tnil | Tlink _ | Tunivar _ -> ()
     | Tpackage (_, fl) ->
-        let v =
-          Variance.(if mem Inv vari then full else unknown)
-        in
+        let v = Variance.(compose vari full) in
         List.iter (fun (_, ty) -> compute_variance_rec v ty) fl
   in
   compute_variance_rec vari ty


### PR DESCRIPTION
#11018 wrongly weakened the variance of package types aka first class modules.
This fixes that: their parameters should indeed be invariant.