### PR TITLE
manual: fix odoc variant

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -128,7 +128,10 @@ META
 /manual/src/htmlman/*.hind
 /manual/src/htmlman/compilerlibref
 /manual/src/htmlman/highlight.pack.js
+/manual/src/htmlman/katex.min.css
+/manual/src/htmlman/katex.min.js
 /manual/src/htmlman/libref
+/manual/src/htmlman/fonts/KaTeX*
 /manual/src/htmlman/manual.hmanual
 /manual/src/htmlman/manual.hmanual.kwd
 /manual/src/htmlman/manual.css

--- a/api_docgen/alldoc.tex
+++ b/api_docgen/alldoc.tex
@@ -9,33 +9,14 @@
 \usepackage{textcomp}
 \else
 \usepackage{changepage}
-\usepackage{longtable}
 \usepackage{listings}
-\newcommand{\ocamlcodefragment}[1]{{\ttfamily\setlength{\parindent}{0cm}%
-\raggedright#1}}
-\newcommand{\ocamlinlinecode}[1]{{\ttfamily#1}}
-\newcommand{\bold}[1]{{\bfseries#1}}
-\newenvironment{ocamlexception}{\bfseries}{}
-\newenvironment{ocamlextension}{\bfseries}{}
-\newenvironment{ocamlarrow}{}
-
-\newcommand{\ocamltag}[2]{\begin{ocaml#1}#2\end{ocaml#1}}
-\newenvironment{ocamlkeyword}{\bfseries}{}
-\newenvironment{ocamlconstructor}{\bfseries}{}
-\newenvironment{ocamltype-var}{\itshape\ttfamily}{}
-
+\newcommand{\ocamlkeyword}{\bfseries}
 \newcommand{\ocamlhighlight}{\bfseries\uline}
 \newcommand{\ocamlerror}{\bfseries}
 \newcommand{\ocamlwarning}{\bfseries}
-
-\definecolor{lightgray}{gray}{0.97}
 \definecolor{gray}{gray}{0.5}
 \newcommand{\ocamlcomment}{\color{gray}\normalfont\small}
 \newcommand{\ocamlstring}{\color{gray}\bfseries}
-\newenvironment{ocamlindent}{\begin{adjustwidth}{2em}{0pt}}{\end{adjustwidth}}
-\newenvironment{ocamltabular}[2][l]{\begin{tabular}{#2}}%
-{\end{tabular}}
-
 \lstnewenvironment{ocamlcodeblock}{
   \lstset{
     backgroundcolor = \color{lightgray},
@@ -57,7 +38,22 @@
     literate={'"'}{\textquotesingle "\textquotesingle}3
     {'\\"'}{\textquotesingle \textbackslash"\textquotesingle}4,
   }
-}{}
+  }{}
+\newcommand{\ocamltag}[2]{\begin{ocaml#1}#2\end{ocaml#1}}
+\newcommand{\ocamlcodefragment}[1]{{\ttfamily\setlength{\parindent}{0cm}%
+\raggedright#1}}
+\newcommand{\ocamlinlinecode}[1]{{\ttfamily#1}}
+\newenvironment{ocamlarrow}{}{}
+\newenvironment{ocamlexception}{\bfseries}{}
+\newenvironment{ocamlextension}{\bfseries}{}
+\newenvironment{ocamlconstructor}{\bfseries}{}
+\newenvironment{ocamltype-var}{\itshape\ttfamily}{}
+\definecolor{lightgray}{gray}{0.97}
+\definecolor{gray}{gray}{0.5}
+\newenvironment{ocamlindent}{\begin{adjustwidth}{2em}{0pt}}{\end{adjustwidth}}
+\newenvironment{ocamltabular}[1]{\begin{tabular}{#1}}%
+{\end{tabular}}
+\newcommand{\bold}[1]{{\bfseries#1}}
 \fi
 
 \ifocamldoc

--- a/manual/src/Makefile
+++ b/manual/src/Makefile
@@ -166,7 +166,8 @@ clean:
 	$(MAKE) -C refman clean
 	$(MAKE) -C tutorials clean
 	cd htmlman; rm -rf libref compilerlibref *.htoc *.html *.haux *.hind *.svg \
-	                   manual.hmanual manual.hmanual.kwd manual.css
+                       fonts/KaTeX* katex.min.css katex.min.js highlight.pack.js \
+	                   manual.hmanual manual.hmanual.kwd manual.css odoc.css
 	rm -rf $(DIRS)
 
 .PHONY: distclean

--- a/manual/src/cmds/runtime-tracing.etex
+++ b/manual/src/cmds/runtime-tracing.etex
@@ -65,7 +65,7 @@ present, only consist of major heap allocation size counter events.
 
 The full set of events emitted by probes and their documentation can be found in
 \ifouthtml
- \ahref{libref/Runtime_events.html}{Module \texttt{Runtime_events}}.
+ \moduleref{libref}{Runtime_events}{Module \texttt{Runtime_events}}.
 \else
  section~\ref{Runtime_events}.
 \fi
@@ -91,7 +91,7 @@ running domain and, on domain termination, ring buffers may be re-used for newly
 spawned domains. The ring buffers themselves are stored in a memory-mapped file
 with the processes identifier as the name and the extension ".events", this
 enables them to be read from outside the main OCaml process. See
-\stdmoduleref{Runtime_events} for more information.
+\moduleref{libref}{Runtime_events}{\texttt{Runtime_events}} for more information.
 
 \subsubsection{s:runtime-tracing-apis}{Consumption APIs}
 

--- a/manual/src/library/stdlib-blurb.etex
+++ b/manual/src/library/stdlib-blurb.etex
@@ -110,10 +110,6 @@ be called from C \\
 "Semaphore" & p.~\stdpageref{Semaphore} & semaphores \\
 "Effect" & p.~\stdpageref{Effect} & deep and shallow effect handlers \\
 \end{tabular}
-\subsubsection*{sss:stdlib-tracing}{Tracing:}
-\begin{tabular}{lll}
-"Runtime_events" & p.~\stdpageref{Runtime_events} & runtime event tracing \\
-\end{tabular}
 \subsubsection*{sss:stdlib-misc}{Misc:}
 \begin{tabular}{lll}
 "Fun" & p.~\stdpageref{Fun} & function values \\
@@ -168,7 +164,6 @@ be called from C \\
 \stddocitem{Queue}{first-in first-out queues}
 \stddocitem{Random}{pseudo-random number generator (PRNG)}
 \stddocitem{Result}{result values}
-\stddocitem{Runtime_events}{Runtime event tracing}
 \stddocitem{Scanf}{formatted input functions}
 \stddocitem{Seq}{functional iterators}
 \stddocitem{Set}{sets over ordered types}

--- a/manual/src/macros.tex
+++ b/manual/src/macros.tex
@@ -221,11 +221,16 @@
 
 %%% Linking to modules
 \ifocamldoc
-\newcommand{\stdmoduleref}[1]{\hyperref[#1]{\texttt{#1}}[\ref{#1}]}
+\newcommand{\moduleref}[3]{\hyperref[#2]{#3}[\ref{#2}]}
+\newcommand{\stdmoduleref}[1]{\moduleref{}{#1}{\texttt{#1}}}
 \newcommand{\stdpageref}[1]{\pageref{#1}}
 \else
-\newcommand{\stdmoduleref}[1]{\hyperref[container-page-libref-module-Stdlib-module-#1]{\texttt{#1}}[\ref{container-page-libref-module-Stdlib-module-#1}]}
-\newcommand{\stdpageref}[1]{\pageref{container-page-libref-module-Stdlib-module-#1}}
+\newcommand{\moduleLabel}[2]{page-#1-module-#2}
+\newcommand{\moduleref}[3]{%
+\hyperref[\moduleLabel{#1}{#2}]{#3}[\ref{\moduleLabel{#1}{#2}}]%
+}
+\newcommand{\stdmoduleref}[1]{\moduleref{libref-module-Stdlib}{#1}{\texttt{#1}}}
+\newcommand{\stdpageref}[1]{\pageref{\moduleLabel{libref-module-Stdlib}{#1}}}
 \fi
 \newenvironment{linklist}{\begingroup\ocamldocinputstart}{\endgroup}
 


### PR DESCRIPTION
When the `Runtime_events` module was moved to its own library, I forgot to check that the references to the module in the manual were updated to reflect its new status. 

This wasn't the case and the module was still referred as a module of the standard library. This worked for the ocamldoc version of the manual but this broke the build of the odoc variant which is more sensitive to the distinction between `stdlib` modules and the other modules.
 
The first commit of this PR fixes this issue by removing `Runtime_events` from the list of standard library module and by using `\moduleref` rather than `\stdmoduleref` when linking to the module.

The second commit synchronize the latex preamble from the manual and the `light` manual that lives in `api_docgen`.

The third commit updates the `clean` target and `.gitignore` file to take care of the new auxiliary files installed by odoc. 

Note: The full fix requires a companion fix to odoc escaping rule for labels too, otherwise references to module with an underscore `_` in their name fail in the manual.