### PR TITLE
AFL dynamic allocation

### DIFF
--- a/asmcomp/afl_instrument.ml
+++ b/asmcomp/afl_instrument.ml
@@ -107,10 +107,8 @@ let instrument_initialiser c dbg =
   (* Each instrumented module calls caml_setup_afl at
      initialisation, which is a no-op on the second and subsequent
      calls *)
-  with_afl_logging
-    (Csequence
-       (Cop (Cextcall ("caml_setup_afl", typ_int, [], false),
-             [Cconst_int (0, dbg ())],
-             dbg ()),
-        c))
-    (dbg ())
+  Csequence
+   (Cop (Cextcall ("caml_setup_afl", typ_int, [], false),
+         [Cconst_int (0, dbg ())],
+         dbg ()),
+    with_afl_logging c (dbg ()))

--- a/runtime/afl.c
+++ b/runtime/afl.c
@@ -13,7 +13,11 @@
 /**************************************************************************/
 
 /* Runtime support for afl-fuzz */
+
+#define CAML_INTERNALS
+
 #include "caml/config.h"
+#include "caml/mlvalues.h"
 
 /* Values used by the instrumentation logic (see cmmgen.ml) */
 static unsigned char afl_area_initial[1 << 16];
@@ -21,9 +25,6 @@ unsigned char* caml_afl_area_ptr = afl_area_initial;
 uintnat caml_afl_prev_loc;
 
 #if !defined(HAS_SYS_SHM_H) || !defined(HAS_SHMAT)
-
-#include "caml/mlvalues.h"
-#include "caml/domain.h"
 
 CAMLprim value caml_reset_afl_instrumentation(value full)
 {
@@ -46,9 +47,9 @@ CAMLexport value caml_setup_afl(value unit)
 #include <stdio.h>
 #include <string.h>
 
-#define CAML_INTERNALS
+#include "caml/domain.h"
+#include "caml/memory.h"
 #include "caml/misc.h"
-#include "caml/mlvalues.h"
 #include "caml/osdeps.h"
 
 static int afl_initialised = 0;


### PR DESCRIPTION
The friendly bot reminded me to submit this code as a PR. 
    
Instrumented code produced by `ocamlopt -afl-instrument` but not run  under AFL needs a 64 k dummy buffer at run-time.  Currently, this buffer is allocated statically, and therefore present in all ocamlopt-generated executables, whether compiled with `-afl-instrument` or without, whether AFL was selected at configuration-time or not.  That's a bit of a waste.
    
This PR implements dynamic allocation of the AFL buffer when an AFL-instrumented executable starts.  It is based on the proposal at #10167 and its discussion.  It also un-breaks  the build when configured with `-with-afl`.
  
The tests in `testsuite/tests/afl-instrumentation` fail on my machine, both with and without this PR, both on trunk and on 5.0 and on 4.14.  So, that's probably a problem with my installation of AFL tools.  Yet, if @jmid (the author of the 5.0 tests) could have a look at this PR, I would feel reassured.
 
Fixes: #10117
Closes: #10167
