### PR TITLE
Bugfix for Ctype.nondep_type

### DIFF
--- a/Changes
+++ b/Changes
@@ -53,6 +53,9 @@ Working version
   would previous behave incorrectly, and now results in a clean error.
   (Leo White, review by Gabriel Scherer and Florian Angeletti)
 
+- #11879: Bugfix for Ctype.nondep_type
+  (Stephen Dolan, review by Gabriel Scherer)
+
 ### Code generation and optimizations:
 
 - #8998, #11321, #11430: change mangling of OCaml long identifiers

--- a/testsuite/tests/typing-signatures/nondep_regression.ml
+++ b/testsuite/tests/typing-signatures/nondep_regression.ml
@@ -1,0 +1,17 @@
+(* TEST
+   * expect
+*)
+
+type 'a seq = 'a list
+
+module Make (A : sig type t end) = struct
+  type t = A.t seq
+end
+
+module H = Make (struct type t end)
+
+[%%expect{|
+type 'a seq = 'a list
+module Make : functor (A : sig type t end) -> sig type t = A.t seq end
+module H : sig type t end
+|}]

--- a/typing/btype.ml
+++ b/typing/btype.ml
@@ -47,6 +47,7 @@ module TransientTypeHash = Hashtbl.Make(TransientTypeOps)
 module TypeHash = struct
   include TransientTypeHash
   let add hash = wrap_repr (add hash)
+  let remove hash = wrap_repr (remove hash)
   let find hash = wrap_repr (find hash)
   let iter f = TransientTypeHash.iter (wrap_type_expr f)
 end

--- a/typing/btype.mli
+++ b/typing/btype.mli
@@ -40,6 +40,7 @@ end
 module TypeHash : sig
   include Hashtbl.S with type key = transient_expr
   val add: 'a t -> type_expr -> 'a -> unit
+  val remove : 'a t -> type_expr -> unit
   val find: 'a t -> type_expr -> 'a
   val iter: (type_expr -> 'a -> unit) -> 'a t -> unit
 end


### PR DESCRIPTION
`Ctype.nondep_type_rec` may fail, but if it does it fails to undo the change to the `nondep_hash` hashtable. This can cause future calls to `Ctype.nondep_type_rec` to succeed, producing a nonsensical answer. In the attached test case (based on one reduced from a larger piece of code by @goldfirere), this causes a fatal error in the type checker.

The fix is trivial, to undo the state change if nondep_type_rec fails.