### PR TITLE
Restore the correct sigmask in systhreads

### DIFF
--- a/Changes
+++ b/Changes
@@ -46,6 +46,10 @@ Working version
   (Gabriel Scherer, review by Xavier Leroy, Guillaume Munch-Maccagnoni
    and Nicolás Ojeda Bär)
 
+- #11880: Restore the correct sigmask in systhreads.
+  (Christiano Haesbaert, review by Guillaume Munch-Maccagnoni and
+   Sébastien Hinderer)
+
 ### Type system:
 
 - #6941, #11187: prohibit using classes through recursive modules

--- a/otherlibs/systhreads/st_stubs.c
+++ b/otherlibs/systhreads/st_stubs.c
@@ -597,7 +597,7 @@ CAMLprim value caml_thread_new(value clos)
   th->descr = caml_thread_new_descriptor(clos);
 
 #ifdef POSIX_SIGNALS
-  th->init_mask = mask;
+  th->init_mask = old_mask;
 #endif
 
   th->next = Active_thread->next;

--- a/testsuite/tests/lib-systhreads/threadsigmask.ml
+++ b/testsuite/tests/lib-systhreads/threadsigmask.ml
@@ -24,7 +24,8 @@ let rec loop () =
   let res = List.length (List.rev_map sin long_list) in
   ignore (Sys.opaque_identity res)
 
-let thread s =
+let thread (s, init_mask) =
+  assert (init_mask = (Thread.sigmask Unix.SIG_UNBLOCK []));
   ignore (Thread.sigmask Unix.SIG_UNBLOCK [s]);
   while not !stopped do loop () done
 
@@ -35,6 +36,8 @@ let handler tid_exp cnt signal =
 
 let _ =
   ignore (Thread.sigmask Unix.SIG_BLOCK [Sys.sigusr1; Sys.sigusr2]);
+  (* expected initial mask of spawned thread *)
+  let init_mask = (Thread.sigmask Unix.SIG_BLOCK []) in
 
   (* Install the signal handlers *)
   let (tid1, tid2) = (ref 0, ref 0) in
@@ -43,7 +46,7 @@ let _ =
   Sys.set_signal Sys.sigusr2 (Sys.Signal_handle (handler tid2 cnt2));
 
   (* Spawn the other thread and unblock sigusr2 in the main thread *)
-  let t1 = Thread.create thread Sys.sigusr1 in
+  let t1 = Thread.create thread (Sys.sigusr1, init_mask) in
   let t2 = Thread.self () in
   ignore (Thread.sigmask Unix.SIG_UNBLOCK [Sys.sigusr2]);
   tid1 := Thread.id t1;


### PR DESCRIPTION
The code correctly blocks and restores the signal mask on the parent while creating a systhread, but the new mask, not the old mask was being passed down the child to be restored.

The bug results on every systhread being run with all signals masked, which does not seem to be the intent, otherwise the `init_mask` has no function.

The following program shows the bug with before and after outputs:
```ocaml
let () =
  let cur_mask = Unix.sigprocmask SIG_BLOCK [] in
  Printf.printf "main mask: ";
  List.iter (fun signal -> Printf.printf "%d " signal) cur_mask;
  print_newline ();
  flush stdout;
  let tid = Thread.create
      (fun () ->
         let cur_mask = Unix.sigprocmask SIG_BLOCK [] in
         Printf.printf "systhread mask: ";
         List.iter (fun signal -> Printf.printf "%d " signal) cur_mask;
         print_newline ();
         flush stdout;
      ) ()
  in
  Thread.join tid
```

Before:
```
main mask:
systhread mask: 64 63 62 61 60 59 58 57 56 55 54 53 52 51 50 49 48 47 46 45 44 43 42 41 40 39 38 37 36 35 34 -24 30 -23 28 -21 -20 -28 -27 -26 -19 -18 -17 -15 -14 16 -11 -2 -8 -13 -10 -12 -3 -22 -1 -25 -5 -9 -6 -4
```

After:
```
main mask:
systhread mask:
```