### PR TITLE
Fix thread-unsafety with custom operations

### DIFF
--- a/Changes
+++ b/Changes
@@ -54,6 +54,11 @@ Working version
   (Christiano Haesbaert, review by Guillaume Munch-Maccagnoni and
    Sébastien Hinderer)
 
+- #11881: Fix thread-unsafety of registration of operations for "custom"
+   values.
+  (Guillaume Munch-Maccagnoni, review by Gabriel Scherer and KC
+   Sivaramakrishnan)
+
 ### Type system:
 
 - #6941, #11187: prohibit using classes through recursive modules


### PR DESCRIPTION
This PR fixes thread-unsafety of custom operations table. It used to store custom operations in global non-atomic linked lists. This PR pushes onto the list atomically. A CAS is enough because nothing is ever removed from the lists.

I think the present straightforward approach is fine, but I am open to an alternative based on lock-free skiplists which is a tad more work. (You need to initialize the skip-lists somewhere; and probably do not need to clean-up garbage regularly.)

A better-documented version is available at https://github.com/gadmm/ocaml/compare/custom_thread_safety2..custom_thread_safety but this style needs the listed (minor) change to `platform.h`.