### PR TITLE
improving the {In,Out}_channel documentation

### DIFF
--- a/Changes
+++ b/Changes
@@ -88,6 +88,9 @@ Working version
   Alain Frisch and Nathanaëlle Courant)
 
 ### Standard library:
+- #11883, #11884: Update documentation for In_channel and Out_channel
+  with examples and sections to group related functions.
+  (Kiran Gopinathan, review by Daniel Bünzli and Xavier Leroy)
 
 - #11859: Make Stdlib.(@) and List.append tail-recursive and faster.
   (Jeremy Yallop, review by Daniel Bünzli, Anil Madhavapeddy, and Bannerets)

--- a/stdlib/in_channel.mli
+++ b/stdlib/in_channel.mli
@@ -15,6 +15,11 @@
 
 (** Input channels.
 
+    This module provides helper functions for working with input
+    channels.
+
+    See {{!examples} the example section} below.
+
     @since 4.14 *)
 
 type t = in_channel
@@ -34,6 +39,8 @@ type open_flag = Stdlib.open_flag =
 
 val stdin : t
 (** The standard input for the process. *)
+
+(** {1 Opening/Closing channels} *)
 
 val open_bin : string -> t
 (** Open the named file for reading, and return a new input channel on that
@@ -64,26 +71,6 @@ val with_open_gen : open_flag list -> int -> string -> (t -> 'a) -> 'a
 (** Like {!with_open_bin}, but can specify the opening mode and file permission,
     in case the file must be created (see {!open_gen}). *)
 
-val seek : t -> int64 -> unit
-(** [seek chan pos] sets the current reading position to [pos] for channel
-    [chan]. This works only for regular files. On files of other kinds, the
-    behavior is unspecified. *)
-
-val pos : t -> int64
-(** Return the current reading position for the given channel.  For files opened
-    in text mode under Windows, the returned position is approximate (owing to
-    end-of-line conversion); in particular, saving the current position with
-    {!pos}, then going back to this position using {!seek} will not work.  For
-    this programming idiom to work reliably and portably, the file must be
-    opened in binary mode. *)
-
-val length : t -> int64
-(** Return the size (number of characters) of the regular file on which the
-    given channel is opened.  If the channel is opened on a file that is not a
-    regular file, the result is meaningless.  The returned size does not take
-    into account the end-of-line translations that can be performed when reading
-    from a channel opened in text mode. *)
-
 val close : t -> unit
 (** Close the given channel.  Input functions raise a [Sys_error] exception when
     they are applied to a closed input channel, except {!close}, which does
@@ -91,6 +78,8 @@ val close : t -> unit
 
 val close_noerr : t -> unit
 (** Same as {!close}, but ignore all errors. *)
+
+(** {1 Consuming input} *)
 
 val input_char : t -> char option
 (** Read one character from the given input channel.  Returns [None] if there
@@ -148,6 +137,29 @@ val input_all : t -> string
     If the same channel is read concurrently by multiple threads, the returned
     string is not guaranteed to contain contiguous characters from the input. *)
 
+
+(** {1 Channel management} *)
+
+val seek : t -> int64 -> unit
+(** [seek chan pos] sets the current reading position to [pos] for channel
+    [chan]. This works only for regular files. On files of other kinds, the
+    behavior is unspecified. *)
+
+val pos : t -> int64
+(** Return the current reading position for the given channel.  For files opened
+    in text mode under Windows, the returned position is approximate (owing to
+    end-of-line conversion); in particular, saving the current position with
+    {!pos}, then going back to this position using {!seek} will not work.  For
+    this programming idiom to work reliably and portably, the file must be
+    opened in binary mode. *)
+
+val length : t -> int64
+(** Return the size (number of characters) of the regular file on which the
+    given channel is opened.  If the channel is opened on a file that is not a
+    regular file, the result is meaningless.  The returned size does not take
+    into account the end-of-line translations that can be performed when reading
+    from a channel opened in text mode. *)
+
 val set_binary_mode : t -> bool -> unit
 (** [set_binary_mode ic true] sets the channel [ic] to binary mode: no
     translations take place during input.
@@ -165,3 +177,19 @@ val isatty : t -> bool
     [false] otherwise.
 
     @since 5.1 *)
+
+(** {1:examples Examples}
+   Reading the contents of a file:
+    {[
+    # let text = In_channel.with_open_text "./example.txt"
+                         (fun ic -> In_channel.input_all ic)
+    val text : string = "..."
+    ]}
+
+   Reading a line from stdin:
+    {[
+    # let user_input = In_channel.input_line In_channel.stdin
+    val user_input : string option = Some "..."
+    ]}
+
+   *)

--- a/stdlib/in_channel.mli
+++ b/stdlib/in_channel.mli
@@ -15,8 +15,7 @@
 
 (** Input channels.
 
-    This module provides helper functions for working with input
-    channels.
+    This module provides functions for working with input channels.
 
     See {{!examples} the example section} below.
 
@@ -182,17 +181,12 @@ val isatty : t -> bool
     @since 5.1 *)
 
 (** {1:examples Examples}
-   Reading the contents of a file:
+    Reading the contents of a file:
     {[
-    # let text = In_channel.with_open_text "./example.txt"
-                         (fun ic -> In_channel.input_all ic)
-    val text : string = "..."
+      let read_file file = In_channel.with_open_bin file In_channel.input_all
     ]}
 
-   Reading a line from stdin:
+    Reading a line from stdin:
     {[
-    # let user_input = In_channel.input_line In_channel.stdin
-    val user_input : string option = Some "..."
-    ]}
-
-   *)
+      let user_input () = In_channel.input_line In_channel.stdin
+    ]} *)

--- a/stdlib/in_channel.mli
+++ b/stdlib/in_channel.mli
@@ -22,6 +22,8 @@
 
     @since 4.14 *)
 
+(** {1:channels Channels} *)
+
 type t = in_channel
 (** The type of input channel. *)
 
@@ -39,8 +41,6 @@ type open_flag = Stdlib.open_flag =
 
 val stdin : t
 (** The standard input for the process. *)
-
-(** {1 Opening/Closing channels} *)
 
 val open_bin : string -> t
 (** Open the named file for reading, and return a new input channel on that
@@ -79,7 +79,7 @@ val close : t -> unit
 val close_noerr : t -> unit
 (** Same as {!close}, but ignore all errors. *)
 
-(** {1 Consuming input} *)
+(** {1:input Input} *)
 
 val input_char : t -> char option
 (** Read one character from the given input channel.  Returns [None] if there
@@ -98,6 +98,22 @@ val input_line : t -> string option
     A newline is the character [\n] unless the file is open in text mode and
     {!Sys.win32} is [true] in which case it is the sequence of characters
     [\r\n]. *)
+
+val really_input_string : t -> int -> string option
+(** [really_input_string ic len] reads [len] characters from channel [ic] and
+    returns them in a new string.  Returns [None] if the end of file is reached
+    before [len] characters have been read.
+
+    If the same channel is read concurrently by multiple threads, the returned
+    string is not guaranteed to contain contiguous characters from the input. *)
+
+val input_all : t -> string
+(** [input_all ic] reads all remaining data from [ic].
+
+    If the same channel is read concurrently by multiple threads, the returned
+    string is not guaranteed to contain contiguous characters from the input. *)
+
+(** {1:advanced_input Advanced input}*)
 
 val input : t -> bytes -> int -> int -> int
 (** [input ic buf pos len] reads up to [len] characters from the given channel
@@ -123,22 +139,7 @@ val really_input : t -> bytes -> int -> int -> unit option
     @raise Invalid_argument if [pos] and [len] do not designate a valid range of
     [buf]. *)
 
-val really_input_string : t -> int -> string option
-(** [really_input_string ic len] reads [len] characters from channel [ic] and
-    returns them in a new string.  Returns [None] if the end of file is reached
-    before [len] characters have been read.
-
-    If the same channel is read concurrently by multiple threads, the returned
-    string is not guaranteed to contain contiguous characters from the input. *)
-
-val input_all : t -> string
-(** [input_all ic] reads all remaining data from [ic].
-
-    If the same channel is read concurrently by multiple threads, the returned
-    string is not guaranteed to contain contiguous characters from the input. *)
-
-
-(** {1 Channel management} *)
+(** {1:seeking Seeking} *)
 
 val seek : t -> int64 -> unit
 (** [seek chan pos] sets the current reading position to [pos] for channel
@@ -152,6 +153,8 @@ val pos : t -> int64
     {!pos}, then going back to this position using {!seek} will not work.  For
     this programming idiom to work reliably and portably, the file must be
     opened in binary mode. *)
+
+(** {1:attributes Attributes} *)
 
 val length : t -> int64
 (** Return the size (number of characters) of the regular file on which the

--- a/stdlib/out_channel.mli
+++ b/stdlib/out_channel.mli
@@ -15,8 +15,7 @@
 
 (** Output channels.
 
-    This module provides helper functions for working with output
-    channels.
+    This module provides functions for working with output channels.
 
     See {{!examples} the example section} below.
 
@@ -184,10 +183,10 @@ val isatty : t -> bool
     @since 5.1 *)
 
 (** {1:examples Examples}
-   Writing a string to a file:
+    Writing the contents of a file:
     {[
-    # Out_channel.with_open_text "./example.txt"
-                    (fun oc -> Out_channel.ouptut_string oc "hello")
-    - : unit = ()
+      let write_file file s =
+        Out_channel.with_open_bin file
+          (fun oc -> Out_channel.output_string oc s))
     ]}
-   *)
+*)

--- a/stdlib/out_channel.mli
+++ b/stdlib/out_channel.mli
@@ -15,6 +15,11 @@
 
 (** Output channels.
 
+    This module provides helper functions for working with output
+    channels.
+
+    See {{!examples} the example section} below.
+
     @since 4.14 *)
 
 type t = out_channel
@@ -37,6 +42,8 @@ val stdout : t
 
 val stderr : t
 (** The standard error output for the process. *)
+
+(** {1 Opening/Closing channels} *)
 
 val open_bin : string -> t
 (** Open the named file for writing, and return a new output channel on that
@@ -69,26 +76,6 @@ val with_open_gen : open_flag list -> int -> string -> (t -> 'a) -> 'a
 (** Like {!with_open_bin}, but can specify the opening mode and file permission,
     in case the file must be created (see {!open_gen}). *)
 
-val seek : t -> int64 -> unit
-(** [seek chan pos] sets the current writing position to [pos] for channel
-    [chan]. This works only for regular files. On files of other kinds (such as
-    terminals, pipes and sockets), the behavior is unspecified. *)
-
-val pos : t -> int64
-(** Return the current writing position for the given channel.  Does not work on
-    channels opened with the [Open_append] flag (returns unspecified results).
-
-    For files opened in text mode under Windows, the returned position is
-    approximate (owing to end-of-line conversion); in particular, saving the
-    current position with {!pos}, then going back to this position using {!seek}
-    will not work.  For this programming idiom to work reliably and portably,
-    the file must be opened in binary mode. *)
-
-val length : t -> int64
-(** Return the size (number of characters) of the regular file on which the
-    given channel is opened.  If the channel is opened on a file that is not a
-    regular file, the result is meaningless. *)
-
 val close : t -> unit
 (** Close the given channel, flushing all buffered write operations.  Output
     functions raise a [Sys_error] exception when they are applied to a closed
@@ -99,13 +86,7 @@ val close : t -> unit
 val close_noerr : t -> unit
 (** Same as {!close}, but ignore all errors. *)
 
-val flush : t -> unit
-(** Flush the buffer associated with the given output channel, performing all
-    pending writes on that channel.  Interactive programs must be careful about
-    flushing standard output and standard error at the right time. *)
-
-val flush_all : unit -> unit
-(** Flush all open output channels; ignore errors. *)
+(** {1 Writing output} *)
 
 val output_char : t -> char -> unit
 (** Write the character on the given output channel. *)
@@ -130,6 +111,37 @@ val output : t -> bytes -> int -> int -> unit
 val output_substring : t -> string -> int -> int -> unit
 (** Same as {!output} but take a string as argument instead of a byte
     sequence. *)
+
+val flush : t -> unit
+(** Flush the buffer associated with the given output channel, performing all
+    pending writes on that channel.  Interactive programs must be careful about
+    flushing standard output and standard error at the right time. *)
+
+val flush_all : unit -> unit
+(** Flush all open output channels; ignore errors. *)
+
+(** {1 Managing channels} *)
+
+val seek : t -> int64 -> unit
+(** [seek chan pos] sets the current writing position to [pos] for channel
+    [chan]. This works only for regular files. On files of other kinds (such as
+    terminals, pipes and sockets), the behavior is unspecified. *)
+
+val pos : t -> int64
+(** Return the current writing position for the given channel.  Does not work on
+    channels opened with the [Open_append] flag (returns unspecified results).
+
+    For files opened in text mode under Windows, the returned position is
+    approximate (owing to end-of-line conversion); in particular, saving the
+    current position with {!pos}, then going back to this position using {!seek}
+    will not work.  For this programming idiom to work reliably and portably,
+    the file must be opened in binary mode. *)
+
+val length : t -> int64
+(** Return the size (number of characters) of the regular file on which the
+    given channel is opened.  If the channel is opened on a file that is not a
+    regular file, the result is meaningless. *)
+
 
 val set_binary_mode : t -> bool -> unit
 (** [set_binary_mode oc true] sets the channel [oc] to binary mode: no
@@ -164,3 +176,12 @@ val isatty : t -> bool
     [false] otherwise.
 
     @since 5.1 *)
+
+(** {1:examples Examples}
+   Writing a string to a file:
+    {[
+    # Out_channel.with_open_text "./example.txt"
+                    (fun oc -> Out_channel.ouptut_string oc "hello")
+    - : unit = ()
+    ]}
+   *)

--- a/stdlib/out_channel.mli
+++ b/stdlib/out_channel.mli
@@ -22,6 +22,8 @@
 
     @since 4.14 *)
 
+(** {1:channels Channels}  *)
+
 type t = out_channel
 (** The type of output channel. *)
 
@@ -42,8 +44,6 @@ val stdout : t
 
 val stderr : t
 (** The standard error output for the process. *)
-
-(** {1 Opening/Closing channels} *)
 
 val open_bin : string -> t
 (** Open the named file for writing, and return a new output channel on that
@@ -86,7 +86,7 @@ val close : t -> unit
 val close_noerr : t -> unit
 (** Same as {!close}, but ignore all errors. *)
 
-(** {1 Writing output} *)
+(** {1:output Output} *)
 
 val output_char : t -> char -> unit
 (** Write the character on the given output channel. *)
@@ -101,6 +101,8 @@ val output_string : t -> string -> unit
 val output_bytes : t -> bytes -> unit
 (** Write the byte sequence on the given output channel. *)
 
+(** {1:advanced_output Advanced output} *)
+
 val output : t -> bytes -> int -> int -> unit
 (** [output oc buf pos len] writes [len] characters from byte sequence [buf],
     starting at offset [pos], to the given output channel [oc].
@@ -112,6 +114,8 @@ val output_substring : t -> string -> int -> int -> unit
 (** Same as {!output} but take a string as argument instead of a byte
     sequence. *)
 
+(** {1:flushing Flushing} *)
+
 val flush : t -> unit
 (** Flush the buffer associated with the given output channel, performing all
     pending writes on that channel.  Interactive programs must be careful about
@@ -120,7 +124,7 @@ val flush : t -> unit
 val flush_all : unit -> unit
 (** Flush all open output channels; ignore errors. *)
 
-(** {1 Managing channels} *)
+(** {1:seeking Seeking} *)
 
 val seek : t -> int64 -> unit
 (** [seek chan pos] sets the current writing position to [pos] for channel
@@ -136,6 +140,8 @@ val pos : t -> int64
     current position with {!pos}, then going back to this position using {!seek}
     will not work.  For this programming idiom to work reliably and portably,
     the file must be opened in binary mode. *)
+
+(** {1:attributes Attributes}  *)
 
 val length : t -> int64
 (** Return the size (number of characters) of the regular file on which the


### PR DESCRIPTION
This PR tackles #11883 and improves the documentation for the In_channel and Out_channel modules in the stdlib.

Notably, as mentioned in #11883 by @gasche :

 - For both modules, it provides sections that group the function in related clusters - primarily, for opening/closing channels, reading/writing data and managing channels
 - Provides code examples that demonstrates the basic usage of the modules.
