### PR TITLE
Fix the computation of dependencies for the standard library

### DIFF
--- a/stdlib/Makefile
+++ b/stdlib/Makefile
@@ -244,18 +244,14 @@ GNUISH_SED = \
   $(if $(filter X,$(shell echo x | $(SED) -E -e 's/./\u&/' 2>/dev/null)),\
        $(SED),$(error GNU sed is needed for make depend))
 
-.INTERMEDIATE: .depend.tmp
-
-.depend.tmp:
-	$(OCAMLDEP_CMD) $(filter-out stdlib.%,$(wildcard *.mli *.ml)) > $@
-	$(OCAMLDEP_CMD) -pp "$(AWK) -f ./remove_module_aliases.awk" \
-	  stdlib.ml stdlib.mli >> $@
-
 .PHONY: depend
-depend: .depend
-
-.depend: .depend.tmp
+depend:
+	{ \
+	  $(OCAMLDEP_CMD) $(filter-out stdlib.%,$(wildcard *.mli *.ml)); \
+	  $(OCAMLDEP_CMD) -pp "$(AWK) -f ./remove_module_aliases.awk" \
+	  stdlib.ml stdlib.mli; \
+	} | \
 	$(GNUISH_SED) -E \
 	-e 's/^(${STDLIB_NAMESPACE_MODULES})(\.[^i]*)(i?) :/\1\2\3 : \1.ml\3/' \
 	-e 's#(^| )(${STDLIB_NAMESPACE_MODULES})[.]#\1stdlib__\u\2.#' \
-	$< > $@
+	> .$@


### PR DESCRIPTION
This fixes issue #11588.

Roughly speaking, the problem was that `make` is a bit too lazy in the way
it regenerates intermediate files, as has been explained by @dra27 in
https://github.com/ocaml/ocaml/pull/11421#discussion_r918008508.

Instead of stickin to `.depend.tmp` being an intermediate file, this PR
includes its generation in the recipe that writes `.depend` and makes
the computation a bit more similar to what happens e.g. in the
root Makefile.