### PR TITLE
Document environment variables for running the testsuite

### DIFF
--- a/testsuite/HACKING.adoc
+++ b/testsuite/HACKING.adoc
@@ -50,6 +50,17 @@ then this will run all the tests in those three directories.
   output changed. `make promote` takes the same variables as `make one` to
   determine which tests to run (there is no analog to `make all`).
 
+== Useful environment variables
+
+`KEEP_TEST_DIR_ON_SUCCESS=1`::
+  Keeps temporary output files from a test run. This is handy to validate the
+  content of temporary output files, run a produced executable by hand, etc.
+
+`OCAMLTESTDIR=/tmp/foo`::
+  Changes the output directory to the specified one. This should be combined
+  with `KEEP_TEST_DIR_ON_SUCCESS=1` to inspect the test output. By default
+  `OCAMLTESTDIR` is `_ocamltest`.
+
 == Creating a new test
 
 == Dimensioning the tests


### PR DESCRIPTION
Yesterday when trying to give #11877 a spin I found myself searching for how save the temporary output of tests in the testsuite. Thanks to @shindere and @dra27 I got it working.

This little PR documents `KEEP_TEST_DIR_ON_SUCCESS` and `OCAMLTESTDIR` in `testsuite/HACKING.adoc` to help others in a similar situation.

Non-goal: document all environment variables of `testsuite/Makefile`