### PR TITLE
Name the type variable that cannot be deduced from the type parameters

### DIFF
--- a/Changes
+++ b/Changes
@@ -364,6 +364,10 @@ Working version
 - #8602, #11863: Add -stop-after lambda flag option
   (Douglas Smith and Dmitrii Kosarev, review by Gabriel Scherer)
 
+- #11888: Improve the error message when type variables cannot be deduced from
+  the type parameters.
+  (Stefan Muenzel, review by Florian Angeletti and Gabriel Scherer)
+
 ### Internal/compiler-libs changes:
 
 - #11990: Improve comments and macros around frame descriptors.

--- a/testsuite/tests/typing-extensions/extensions.ml
+++ b/testsuite/tests/typing-extensions/extensions.ml
@@ -574,6 +574,20 @@ Error: This extension does not match the definition of type bar
        Their variances do not agree.
 |}]
 
+type -'a poly_and_contravariant = .. constraint <x: 'a. 'a -> 'a; ..> = 'a
+type 'a poly_and_contravariant += A | X of 'a
+[%%expect {|
+type -'b poly_and_contravariant = .. constraint 'b = < x : 'a. 'a -> 'a; .. >
+Line 2, characters 0-45:
+2 | type 'a poly_and_contravariant += A | X of 'a
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: In the extension constructor
+         type 'a poly_and_contravariant += X of 'a
+       the type variable 'a has a variance that
+       is not reflected by its occurrence in type parameters.
+       It was expected to be contravariant, but it is covariant.
+|}]
+
 (* Exceptions are compatible with extensions *)
 
 module M : sig

--- a/testsuite/tests/typing-gadts/pr11888.ml
+++ b/testsuite/tests/typing-gadts/pr11888.ml
@@ -1,0 +1,59 @@
+(* TEST
+   * expect
+*)
+
+type z
+type 'a s
+type _ nat =
+  | Nz : z -> z nat
+  | Nss : 'd nat -> 'd s s nat
+  | Ns : 'a nat -> 'a s nat
+;;
+
+[%%expect{|
+type z
+type 'a s
+Lines 3-6, characters 0-27:
+3 | type _ nat =
+4 |   | Nz : z -> z nat
+5 |   | Nss : 'd nat -> 'd s s nat
+6 |   | Ns : 'a nat -> 'a s nat
+Error: In the GADT constructor
+         Nss : 'd nat -> 'd s s nat
+       the type variable 'd cannot be deduced from the type parameters.
+|}];;
+
+type z
+type 'a s
+type _ nat = ..
+type _ nat += Nz : z -> z nat
+type _ nat += Nss : 'd nat -> 'd s s nat
+;;
+
+[%%expect{|
+type z
+type 'a s
+type _ nat = ..
+type _ nat += Nz : z -> z nat
+Line 5, characters 0-40:
+5 | type _ nat += Nss : 'd nat -> 'd s s nat
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: In the extension constructor
+         type _ nat += Nss : 'd nat -> 'd s s nat
+       the type variable 'd cannot be deduced from the type parameters.
+|}];;
+
+type 'any any = int
+type _ t = ..
+type 'b t += A: 'b -> 'b any t
+
+[%%expect{|
+type 'any any = int
+type _ t = ..
+Line 3, characters 0-30:
+3 | type 'b t += A: 'b -> 'b any t
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: In the extension constructor
+         type 'b t += A : 'b -> 'b any t
+       the type variable 'b cannot be deduced from the type parameters.
+|}]

--- a/testsuite/tests/typing-gadts/pr5985.ml
+++ b/testsuite/tests/typing-gadts/pr5985.ml
@@ -11,8 +11,9 @@ end;; (* fail *)
 Line 3, characters 2-29:
 3 |   type _ t = T : 'a -> 'a s t
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: In this definition, a type variable cannot be deduced
-       from the type parameters.
+Error: In the GADT constructor
+         T : 'a -> 'a s t
+       the type variable 'a cannot be deduced from the type parameters.
 |}];;
 (*
 module M = F (struct type 'a s = int end) ;;
@@ -40,8 +41,9 @@ end;; (* fail *)
 Lines 2-3, characters 2-67:
 2 | ..class ['a] c x =
 3 |     object constraint 'a = 'b T.t val x' : 'b = x method x = x' end
-Error: In this definition, a type variable cannot be deduced
-       from the type parameters.
+Error: In the definition
+         type 'a c = < x : 'b > constraint 'a = 'b T.t
+       the type variable 'b cannot be deduced from the type parameters.
 |}];;
 
 (* Another (more direct) instance using polymorphic variants *)
@@ -54,8 +56,9 @@ let magic (x : int) : bool  =
 Line 1, characters 0-49:
 1 | type 'x t = A of 'a constraint 'x = [< `X of 'a ] ;; (* fail *)
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: In this definition, a type variable cannot be deduced
-       from the type parameters.
+Error: In the definition
+         type 'b t = A of 'a constraint 'b = [< `X of 'a ]
+       the type variable 'a cannot be deduced from the type parameters.
 |}];;
 
 type 'a t = A : 'a -> [< `X of 'a ] t;; (* fail *)
@@ -63,8 +66,9 @@ type 'a t = A : 'a -> [< `X of 'a ] t;; (* fail *)
 Line 1, characters 0-37:
 1 | type 'a t = A : 'a -> [< `X of 'a ] t;; (* fail *)
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: In this definition, a type variable cannot be deduced
-       from the type parameters.
+Error: In the GADT constructor
+         A : 'a -> [< `X of 'a ] t
+       the type variable 'a cannot be deduced from the type parameters.
 |}];;
 
 (* It is not OK to allow modules exported by other compilation units *)
@@ -79,8 +83,9 @@ val eq : (('a, 'b) Ephemeron.K1.t, ('c, 'd) Ephemeron.K1.t) eq = Eq
 Line 4, characters 0-46:
 4 | type _ t = T : 'a -> ('a, 'b) Ephemeron.K1.t t;; (* fail *)
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: In this definition, a type variable cannot be deduced
-       from the type parameters.
+Error: In the GADT constructor
+         T : 'a -> ('a, 'b) Ephemeron.K1.t t
+       the type variable 'a cannot be deduced from the type parameters.
 |}];;
 (*
 let castT (type a) (type b) (x : a t) (e: (a, b) eq) : b t =
@@ -97,8 +102,9 @@ end;; (* fail *)
 Line 3, characters 2-29:
 3 |   type _ t = T : 'a -> 'a s t
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: In this definition, a type variable cannot be deduced
-       from the type parameters.
+Error: In the GADT constructor
+         T : 'a -> 'a s t
+       the type variable 'a cannot be deduced from the type parameters.
 |}];;
 (* Otherwise we can write the following *)
 module rec M : (S with type 'a s = unit) = M;;
@@ -131,7 +137,9 @@ type 'a q = Q
 Line 2, characters 0-36:
 2 | type +'a t = 'b constraint 'a = 'b q;;
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: In this definition, a type variable has a variance that
+Error: In the definition
+         type +'a t = 'b constraint 'a = 'b q
+       the type variable 'b has a variance that
        cannot be deduced from the type parameters.
        It was expected to be unrestricted, but it is covariant.
 |}];;
@@ -148,7 +156,9 @@ type -'a s = 'b constraint 'a = 'b t;; (* fail *)
 Line 1, characters 0-36:
 1 | type -'a s = 'b constraint 'a = 'b t;; (* fail *)
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: In this definition, a type variable has a variance that
+Error: In the definition
+         type -'a s = 'b constraint 'a = 'b t
+       the type variable 'b has a variance that
        is not reflected by its occurrence in type parameters.
        It was expected to be contravariant, but it is covariant.
 |}];;
@@ -169,7 +179,9 @@ type +'a s = 'b constraint 'a = 'b t q;; (* fail *)
 Line 1, characters 0-38:
 1 | type +'a s = 'b constraint 'a = 'b t q;; (* fail *)
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: In this definition, a type variable has a variance that
+Error: In the definition
+         type +'a s = 'b constraint 'a = 'b t q
+       the type variable 'b has a variance that
        cannot be deduced from the type parameters.
        It was expected to be unrestricted, but it is covariant.
 |}];;
@@ -197,6 +209,7 @@ type +'a t = unit constraint 'a = 'b list
 Line 2, characters 0-27:
 2 | type _ g = G : 'a -> 'a t g;; (* fail *)
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: In this definition, a type variable cannot be deduced
-       from the type parameters.
+Error: In the GADT constructor
+         G : 'a list -> 'a list t g
+       the type variable 'a cannot be deduced from the type parameters.
 |}];;

--- a/testsuite/tests/typing-misc/injectivity.ml
+++ b/testsuite/tests/typing-misc/injectivity.ml
@@ -54,16 +54,18 @@ type _ t = N : 'a -> 'a N.t t (* KO *)
 Line 1, characters 0-29:
 1 | type _ t = N : 'a -> 'a N.t t (* KO *)
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: In this definition, a type variable cannot be deduced
-       from the type parameters.
+Error: In the GADT constructor
+         N : 'a -> 'a N.t t
+       the type variable 'a cannot be deduced from the type parameters.
 |}]
 type 'a u = 'b constraint 'a = 'b N.t
 [%%expect{|
 Line 1, characters 0-37:
 1 | type 'a u = 'b constraint 'a = 'b N.t
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: In this definition, a type variable cannot be deduced
-       from the type parameters.
+Error: In the definition
+         type 'a u = 'b constraint 'a = 'b N.t
+       the type variable 'b cannot be deduced from the type parameters.
 |}]
 
 (* Of course, the internal type should be injective in this parameter *)
@@ -124,8 +126,9 @@ module M : sig type 'a t = private < m : int; .. > end
 Line 3, characters 0-30:
 3 | type 'a u = M : 'a -> 'a M.t u
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: In this definition, a type variable cannot be deduced
-       from the type parameters.
+Error: In the GADT constructor
+         M : 'a -> 'a M.t u
+       the type variable 'a cannot be deduced from the type parameters.
 |}]
 module M : sig type !'a t = private < m : int ; .. > end =
   struct type 'a t = < m : int > end
@@ -192,8 +195,9 @@ let M.G (x : bool) = M.G 3
 Line 3, characters 2-29:
 3 |   type _ x = G : 'a -> 'a u x
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: In this definition, a type variable cannot be deduced
-       from the type parameters.
+Error: In the GADT constructor
+         G : 'a X.t -> 'a X.t u x
+       the type variable 'a cannot be deduced from the type parameters.
 |}]
 
 (* Try to be clever *)
@@ -370,8 +374,9 @@ type 'a t = 'b constraint 'a = < b : 'b; c : 'c >
 Line 2, characters 0-27:
 2 | type _ u = M : 'a -> 'a t u (* KO *)
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: In this definition, a type variable cannot be deduced
-       from the type parameters.
+Error: In the GADT constructor
+         M : < b : 'a; c : 'b > -> < b : 'a; c : 'b > t u
+       the type variable 'b cannot be deduced from the type parameters.
 |}]
 
 

--- a/typing/printtyp.mli
+++ b/typing/printtyp.mli
@@ -134,12 +134,21 @@ val shared_type_scheme: formatter -> type_expr -> unit
 val tree_of_value_description: Ident.t -> value_description -> out_sig_item
 val value_description: Ident.t -> formatter -> value_description -> unit
 val label : formatter -> label_declaration -> unit
+val add_constructor_to_preparation : constructor_declaration -> unit
+val prepared_constructor : formatter -> constructor_declaration -> unit
 val constructor : formatter -> constructor_declaration -> unit
 val tree_of_type_declaration:
     Ident.t -> type_declaration -> rec_status -> out_sig_item
+val add_type_declaration_to_preparation :
+  Ident.t -> type_declaration -> unit
+val prepared_type_declaration: Ident.t -> formatter -> type_declaration -> unit
 val type_declaration: Ident.t -> formatter -> type_declaration -> unit
 val tree_of_extension_constructor:
     Ident.t -> extension_constructor -> ext_status -> out_sig_item
+val add_extension_constructor_to_preparation :
+    extension_constructor -> unit
+val prepared_extension_constructor:
+    Ident.t -> formatter -> extension_constructor -> unit
 val extension_constructor:
     Ident.t -> formatter -> extension_constructor -> unit
 (* Prints extension constructor with the type signature:

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -2109,7 +2109,7 @@ let report_error ppf = function
                  "cannot be deduced from the type parameters."
            end
        | Variance_not_satisfied n ->
-           fprintf ppf "@[%s@ %s@ The %d%s type parameter"
+           fprintf ppf "@[@[%s@ %s@ The %d%s type parameter"
              "In this definition, expected parameter"
              "variances are not satisfied."
              n (Misc.ordinal_suffix n));

--- a/typing/typedecl_variance.mli
+++ b/typing/typedecl_variance.mli
@@ -29,15 +29,27 @@ type prop = Variance.t list
 type req = surface_variance list
 val property : (Variance.t list, req) property
 
+type variance_variable_context =
+  | Type_declaration of Ident.t * type_declaration
+  | Gadt_constructor of constructor_declaration
+  | Extension_constructor of Ident.t * extension_constructor
+
+type variance_variable_error =
+  | No_variable
+  | Variance_not_reflected
+  | Variance_not_deducible
+
 type variance_error =
-| Variance_not_satisfied of int
-| No_variable
-| Variance_not_reflected
-| Variance_not_deducible
+  | Variance_not_satisfied of int
+  | Variance_variable_error of {
+       error : variance_variable_error;
+       context : variance_variable_context;
+       variable : type_expr
+     }
 
 type error =
-| Bad_variance of variance_error * surface_variance * surface_variance
-| Varying_anonymous
+  | Bad_variance of variance_error * surface_variance * surface_variance
+  | Varying_anonymous
 
 exception Error of Location.t * error
 
@@ -46,7 +58,7 @@ val check_variance_extension :
   Typedtree.extension_constructor -> req * Location.t -> unit
 
 val compute_decl :
-  Env.t -> check:bool -> type_declaration -> req -> prop
+  Env.t -> check:Ident.t option -> type_declaration -> req -> prop
 
 val update_decls :
   Env.t -> Parsetree.type_declaration list ->


### PR DESCRIPTION
The error
```
Error: In this definition, a type variable cannot be deduced
       from the type parameters.
```
is not very helpful for complex types with many type variables (and some type variables/constraints may be hidden behind another type)

This draft PR tries to expose the deeper error by showing the type variable that fails, and the state of the declaration at the time.
Since some sort of expanded form of the definition is used to report the error, the error might be confusing at first. I believe even if it is confusing, it is more helpful than not attempting to report the variable at all. At least the user has a chance to trace it.

If this is an acceptable compromise, we may need to expand the `prepare` functions to type declarations to get this PR in a better state, since I'm relying on `Printtyp.tree_of_type_declaration` to set up the preparation context for `Printtyp.add_type_to_preparation`.