### PR TITLE
Fix code duplication in pattern matching of polymorphic variants

### DIFF
--- a/Changes
+++ b/Changes
@@ -356,7 +356,8 @@ Working version
 ### Bug fixes:
 
 - #11887, #11893: Code duplication in pattern-matching compilation
-  (Vincent Laviron, report par Greta Yorsh, review by ...)
+  (Vincent Laviron, report par Greta Yorsh, review by Luc Maranget and
+   Gabriel Scherer)
 
 - #10664, #11600: Unsoundness in the typing of polymorphic methods
   involving polymorphic variants

--- a/Changes
+++ b/Changes
@@ -355,6 +355,9 @@ Working version
 
 ### Bug fixes:
 
+- #11887, #11893: Code duplication in pattern-matching compilation
+  (Vincent Laviron, report par Greta Yorsh, review by ...)
+
 - #10664, #11600: Unsoundness in the typing of polymorphic methods
   involving polymorphic variants
   (Jacques Garrigue, report by Mike Shulman, review by Gabriel Scherer)

--- a/lambda/matching.ml
+++ b/lambda/matching.ml
@@ -2376,6 +2376,11 @@ module SArg = struct
   let make_if cond ifso ifnot = Lifthenelse (cond, ifso, ifnot)
 
   let make_switch loc arg cases acts =
+    (* The [acts] array can contain arbitrary terms.
+       If several entries in the [cases] array point to the same action,
+       we must share it to avoid duplicating terms.
+       See PR#11893 on Github for an example where the other de-duplication
+       mechanisms do not apply. *)
     let act_uses = Array.make (Array.length acts) 0 in
     for i = 0 to Array.length cases - 1 do
       act_uses.(cases.(i)) <- act_uses.(cases.(i)) + 1

--- a/lambda/matching.ml
+++ b/lambda/matching.ml
@@ -2895,17 +2895,15 @@ let make_test_sequence_variant_constant fail arg int_lambda_list =
   let _, (cases, actions) = as_interval fail min_int max_int int_lambda_list in
   Switcher.test_sequence arg cases actions
 
-let call_switcher_variant_constant loc fail arg int_lambda_list =
-  call_switcher loc fail arg min_int max_int int_lambda_list
-
-let call_switcher_variant_constr loc fail arg int_lambda_list =
+let make_test_sequence_variant_constr loc fail arg int_lambda_list =
   let v = Ident.create_local "variant" in
+  let _, (cases, actions) = as_interval fail min_int max_int int_lambda_list in
   Llet
     ( Alias,
       Pgenval,
       v,
       Lprim (Pfield (0, Pointer, Immutable), [ arg ], loc),
-      call_switcher loc fail (Lvar v) min_int max_int int_lambda_list )
+      Switcher.test_sequence (Lvar v) cases actions )
 
 let combine_variant loc row arg partial ctx def (tag_lambda_list, total1, _pats)
     =
@@ -2955,16 +2953,16 @@ let combine_variant loc row arg partial ctx def (tag_lambda_list, total1, _pats)
             | Some fail -> test_int_or_block arg lam fail
           )
         | [], _ -> (
-            let lam = call_switcher_variant_constr loc fail arg nonconsts in
+            let lam = make_test_sequence_variant_constr loc fail arg nonconsts in
             (* One must not dereference integers *)
             match fail with
             | None -> lam
             | Some fail -> test_int_or_block arg fail lam
           )
         | _, _ ->
-            let lam_const = call_switcher_variant_constant loc fail arg consts
+            let lam_const = make_test_sequence_variant_constant fail arg consts
             and lam_nonconst =
-              call_switcher_variant_constr loc fail arg nonconsts
+              make_test_sequence_variant_constr loc fail arg nonconsts
             in
             test_int_or_block arg lam_const lam_nonconst
       )

--- a/testsuite/tests/regression/pr11887/pr11887.ml
+++ b/testsuite/tests/regression/pr11887/pr11887.ml
@@ -130,3 +130,58 @@ module Constr = struct
     in
     current
 end
+
+module Gadts = struct
+  type keep = private Keep
+  type drop = private Drop
+
+  type _ t =
+  | C00 : keep t
+  | C01 : drop t
+  | C02 : drop t
+  | C03 : drop t
+  | C04 : drop t
+  | C05 : drop t
+  | C06 : drop t
+  | C07 : drop t
+  | C08 : drop t
+  | C09 : drop t
+  | C10 : drop t
+  | C11 : drop t
+  | C12 : drop t
+  | C13 : drop t
+  | C14 : drop t
+  | C15 : drop t
+  | C16 : drop t
+  | C17 : drop t
+  | C18 : drop t
+  | C19 : drop t
+  | C20 : keep t
+  | C21 : drop t
+  | C22 : drop t
+  | C23 : drop t
+  | C24 : keep t
+  | C25 : keep t
+  | C26 : drop t
+  | C27 : drop t
+  | C28 : keep t
+
+  let not_at_toplevel b =
+    let f (x: keep t) =
+      match x with
+      | C00 -> 0
+      | C20 ->
+        begin
+          (* The implementation of the local function optimisation will not
+             handle well multiple bindings of the same function, so this
+             code will reliably fail to compile with Closure if it ends up
+             duplicated. *)
+          let[@local] handler x = x + 2 in
+          if b then handler 0 else handler 1
+        end
+      | C24 -> 2
+      | C25 -> 3
+      | C28 -> 4
+    in
+    f
+end

--- a/testsuite/tests/regression/pr11887/pr11887.ml
+++ b/testsuite/tests/regression/pr11887/pr11887.ml
@@ -1,0 +1,132 @@
+(* TEST
+   * native
+     ocamlopt_flags = "-dcmm-invariants"
+*)
+
+module Constant = struct
+  type ('a, 'b) result =
+    | Ok of 'a
+    | Error of 'b
+
+
+  module S = struct
+    type t =
+      [
+        `B0
+      (* renaming the following variants makes the problem go away *)
+      | `CA
+      | `CH
+      | `CI
+      | `CL
+      | `Other of string
+      ]
+  end
+
+  type a1 = [ `CA ]
+  type a2 = [ `CH ]
+  type a3 = [ `CL ]
+
+  let ok = Ok ()
+  let error s =
+    Error s
+
+  let foo =
+    let current =
+      let module T = struct
+        type a1 =
+          [ `Common
+          | `Uuuu
+          | `Ssss
+          | `Rrrr
+          ]
+
+        type a2 = [ `Common ]
+
+        type a3 =
+          [ `Common  ]
+      end
+      in
+      fun ~s typ ->
+
+        match s with
+        | `None           -> error s
+        | #a1         ->
+          (match typ with
+           | #T.a1 -> ok
+           | _ -> error s)
+        | #a2    ->
+          (match typ with
+           | #T.a2 -> ok
+           | _ -> error s)
+        | #a3 ->
+          (match typ with
+           | #T.a3 -> ok
+           | _ -> error s)
+        | #S.t -> error s
+    in
+    current
+end
+
+module Constr = struct
+  type ('a, 'b) result =
+    | Ok of 'a
+    | Error of 'b
+
+
+  module S = struct
+    type t =
+      [
+        `B0 of int
+      (* renaming the following variants makes the problem go away *)
+      | `CA of int
+      | `CH of int
+      | `CI of int
+      | `CL of int
+      | `Other
+      ]
+  end
+
+  type a1 = [ `CA of int ]
+  type a2 = [ `CH of int ]
+  type a3 = [ `CL of int ]
+
+  let ok = Ok ()
+  let error s =
+    Error s
+
+  let foo =
+    let current =
+      let module T = struct
+        type a1 =
+          [ `Common
+          | `Uuuu
+          | `Ssss
+          | `Rrrr
+          ]
+
+        type a2 = [ `Common ]
+
+        type a3 =
+          [ `Common  ]
+      end
+      in
+      fun ~s typ ->
+
+        match s with
+        | `None           -> error s
+        | #a1         ->
+          (match typ with
+           | #T.a1 -> ok
+           | _ -> error s)
+        | #a2    ->
+          (match typ with
+           | #T.a2 -> ok
+           | _ -> error s)
+        | #a3 ->
+          (match typ with
+           | #T.a3 -> ok
+           | _ -> error s)
+        | #S.t -> error s
+    in
+    current
+end


### PR DESCRIPTION
Fixes #11887.

I've left in the first commit a different approach, that always uses test sequences instead of switches for polymorphic variants. If all variant constructors are constant, we already force the use of test sequences, although I don't know why this case is special (the difference was introduced in 157c4e54c9fd3e5ce83bd67072b74217937e42b2; before that we used test sequences in all cases). So it looked like a simple and reasonable fix to revert to test sequences only in all those cases.
However, I think that with enough care we could create the same problem with regular variants (with lots of constructors), so I went with what I think is the right fix, which is to detect potential duplication in `Matching.SArg.make_switch` and introduce wrappers.
I think we could now remove the special case in `Matching.as_interval_nofail` that detects holes and shares the first action in this case, but I haven't done it here (and I haven't checked that it works).