### PR TITLE
remove complex dead code from typing/typetexp

### DIFF
--- a/typing/typedtree.ml
+++ b/typing/typedtree.ml
@@ -452,7 +452,6 @@ and core_type_desc =
 and package_type = {
   pack_path : Path.t;
   pack_fields : (Longident.t loc * core_type) list;
-  pack_type : Types.module_type;
   pack_txt : Longident.t loc;
 }
 

--- a/typing/typedtree.mli
+++ b/typing/typedtree.mli
@@ -593,7 +593,6 @@ and core_type_desc =
 and package_type = {
   pack_path : Path.t;
   pack_fields : (Longident.t loc * core_type) list;
-  pack_type : Types.module_type;
   pack_txt : Longident.t loc;
 }
 

--- a/typing/typetexp.ml
+++ b/typing/typetexp.ml
@@ -58,7 +58,7 @@ module TyVarMap = Misc.Stdlib.String.Map
 let transl_modtype_longident = ref (fun _ -> assert false)
 let transl_modtype = ref (fun _ -> assert false)
 
-let create_package_mty fake loc env (p, l) =
+let create_package_mty ~fake loc env (p, l) =
   let l =
     List.sort
       (fun (s1, _t1) (s2, _t2) ->
@@ -461,7 +461,7 @@ and transl_type_aux env policy styp =
       unify_var env (newvar()) ty';
       ctyp (Ttyp_poly (vars, cty)) ty'
   | Ptyp_package (p, l) ->
-      let l, mty = create_package_mty true styp.ptyp_loc env (p, l) in
+      let l, mty = create_package_mty ~fake:true styp.ptyp_loc env (p, l) in
       let mty =
         with_local_type_variable_scope (fun () -> !transl_modtype env mty) in
       let ptys = List.map (fun (s, pty) ->
@@ -574,7 +574,7 @@ let make_fixed_univars ty =
   make_fixed_univars ty;
   Btype.unmark_type ty
 
-let create_package_mty = create_package_mty false
+let create_package_mty = create_package_mty ~fake:false
 
 let globalize_used_variables env fixed =
   let r = ref [] in

--- a/typing/typetexp.ml
+++ b/typing/typetexp.ml
@@ -574,8 +574,6 @@ let make_fixed_univars ty =
   make_fixed_univars ty;
   Btype.unmark_type ty
 
-let create_package_mty = create_package_mty ~fake:false
-
 let globalize_used_variables env fixed =
   let r = ref [] in
   TyVarMap.iter

--- a/typing/typetexp.ml
+++ b/typing/typetexp.ml
@@ -461,9 +461,7 @@ and transl_type_aux env policy styp =
       unify_var env (newvar()) ty';
       ctyp (Ttyp_poly (vars, cty)) ty'
   | Ptyp_package (p, l) ->
-      let l, mty = create_package_mty ~fake:true styp.ptyp_loc env (p, l) in
-      let mty =
-        with_local_type_variable_scope (fun () -> !transl_modtype env mty) in
+      let l, _mty = create_package_mty ~fake:true styp.ptyp_loc env (p, l) in
       let ptys = List.map (fun (s, pty) ->
                              s, transl_type env policy pty
                           ) l in
@@ -473,7 +471,6 @@ and transl_type_aux env policy styp =
       in
       ctyp (Ttyp_package {
             pack_path = path;
-            pack_type = mty.mty_type;
             pack_fields = ptys;
             pack_txt = p;
            }) ty

--- a/typing/typetexp.mli
+++ b/typing/typetexp.mli
@@ -85,7 +85,3 @@ val transl_modtype_longident:  (* from Typemod *)
     (Location.t -> Env.t -> Longident.t -> Path.t) ref
 val transl_modtype: (* from Typemod *)
     (Env.t -> Parsetree.module_type -> Typedtree.module_type) ref
-val create_package_mty:
-    Location.t -> Env.t -> Parsetree.package_type ->
-    (Longident.t Asttypes.loc * Parsetree.core_type) list *
-      Parsetree.module_type


### PR DESCRIPTION
This PR removes complex code from typing/typetexp that I believe is dead.
It should not change the compiler behavior in any way.

Removed:
- the function `Typetexp.create_package_type_mty`, whose call sites were apparently all removed by c2777a43d0f27194836315797f39f2e6054477c0 in 2010.
- the field `pack_type` of the `package_type` type of the typedtree, that was introduced in the trunk in 35185d610b16e81ea11834963be61cecab7147c9 in 2012 and never used

~~Reviewing this change does not require any type-checking expertise.~~

Edit: wrong prediction, the change as first proposed breaks the type-checker in a subtle way, so it does need type-checking expertise.

## The story

In #11841, @ccasin and myself were wondering about code in typedecl, and @lpw25 helpfully [pointed out](https://github.com/ocaml/ocaml/pull/11841#discussion_r1069145377) that the code path was only taken by "weird fake with-constraints only created during the typing of package types". I went on to read this code that type-checks package types. My refactoring-mania was triggered by an unlabelled boolean argument, the rest is history.