### PR TITLE
typing/typetexp: simplify create_package_type_mty

### DIFF
--- a/.depend
+++ b/.depend
@@ -1880,8 +1880,7 @@ typing/typetexp.cmi : \
     parsing/longident.cmi \
     parsing/location.cmi \
     typing/errortrace.cmi \
-    typing/env.cmi \
-    parsing/asttypes.cmi
+    typing/env.cmi
 typing/untypeast.cmo : \
     typing/typedtree.cmi \
     typing/path.cmi \

--- a/Changes
+++ b/Changes
@@ -289,7 +289,7 @@ Working version
 
 ### Internal/compiler-libs changes:
 
-- #11847, #11849, #11851: small refactorings in the type checker
+- #11847, #11849, #11851, #11898: small refactorings in the type checker
   (Gabriel Scherer, review by Nicolás Ojeda Bär)
 
 - #11027: Separate typing counter-examples from type_pat into retype_pat;

--- a/typing/typetexp.ml
+++ b/typing/typetexp.ml
@@ -66,15 +66,15 @@ let sort_constraints_no_duplicates loc env l =
        compare s1.txt s2.txt)
     l
 
-let create_package_mty ~fake loc p l =
+let create_package_mty loc p l =
   List.fold_left
-    (fun mty (s, t) ->
+    (fun mty (s, _) ->
       let d = {ptype_name = mkloc (Longident.last s.txt) s.loc;
                ptype_params = [];
                ptype_cstrs = [];
                ptype_kind = Ptype_abstract;
                ptype_private = Asttypes.Public;
-               ptype_manifest = if fake then None else Some t;
+               ptype_manifest = None;
                ptype_attributes = [];
                ptype_loc = loc} in
       Ast_helper.Mty.mk ~loc
@@ -462,7 +462,7 @@ and transl_type_aux env policy styp =
   | Ptyp_package (p, l) ->
       let loc = styp.ptyp_loc in
       let l = sort_constraints_no_duplicates loc env l in
-      let mty = create_package_mty ~fake:true loc p l in
+      let mty = create_package_mty loc p l in
       let mty =
         with_local_type_variable_scope (fun () -> !transl_modtype env mty) in
       let ptys = List.map (fun (s, pty) ->

--- a/typing/typetexp.ml
+++ b/typing/typetexp.ml
@@ -58,7 +58,7 @@ module TyVarMap = Misc.Stdlib.String.Map
 let transl_modtype_longident = ref (fun _ -> assert false)
 let transl_modtype = ref (fun _ -> assert false)
 
-let create_package_mty fake loc env (p, l) =
+let create_package_mty ~fake loc env (p, l) =
   let l =
     List.sort
       (fun (s1, _t1) (s2, _t2) ->
@@ -461,7 +461,7 @@ and transl_type_aux env policy styp =
       unify_var env (newvar()) ty';
       ctyp (Ttyp_poly (vars, cty)) ty'
   | Ptyp_package (p, l) ->
-      let l, mty = create_package_mty true styp.ptyp_loc env (p, l) in
+      let l, mty = create_package_mty ~fake:true styp.ptyp_loc env (p, l) in
       let mty =
         with_local_type_variable_scope (fun () -> !transl_modtype env mty) in
       let ptys = List.map (fun (s, pty) ->
@@ -574,7 +574,7 @@ let make_fixed_univars ty =
   make_fixed_univars ty;
   Btype.unmark_type ty
 
-let create_package_mty = create_package_mty false
+let create_package_mty = create_package_mty ~fake:false
 
 let globalize_used_variables env fixed =
   let r = ref [] in

--- a/typing/typetexp.ml
+++ b/typing/typetexp.ml
@@ -574,8 +574,6 @@ let make_fixed_univars ty =
   make_fixed_univars ty;
   Btype.unmark_type ty
 
-let create_package_mty = create_package_mty ~fake:false
-
 let globalize_used_variables env fixed =
   let r = ref [] in
   TyVarMap.iter

--- a/typing/typetexp.mli
+++ b/typing/typetexp.mli
@@ -85,7 +85,3 @@ val transl_modtype_longident:  (* from Typemod *)
     (Location.t -> Env.t -> Longident.t -> Path.t) ref
 val transl_modtype: (* from Typemod *)
     (Env.t -> Parsetree.module_type -> Typedtree.module_type) ref
-val create_package_mty:
-    Location.t -> Env.t -> Parsetree.package_type ->
-    (Longident.t Asttypes.loc * Parsetree.core_type) list *
-      Parsetree.module_type


### PR DESCRIPTION
(This is the next iteration of #11897.)

This PR refactors the implementation of `Typetexp.create_package_mty`.)
It should not change the compiler behavior in any way.

Reviewing this change does not require any type-checking expertise.

## The story

In #11841, @ccasin and myself were wondering about code in typedecl, and @lpw25 helpfully [pointed out](https://github.com/ocaml/ocaml/pull/11841#discussion_r1069145377) that the code path was only taken by "weird fake with-constraints only created during the typing of package types". The current PR refactors that part of the codebase, in preparation for a follow-up documentation PR.