### PR TITLE
typecore: clarify the backtracking logic of type_label_exp

### DIFF
--- a/Changes
+++ b/Changes
@@ -292,6 +292,9 @@ Working version
 - #11847, #11849, #11851: small refactorings in the type checker
   (Gabriel Scherer, review by Nicolás Ojeda Bär)
 
+- #????: refactor `type_label_exp` in the type checker
+  (Gabriel Scherer, review by ???)
+
 - #11027: Separate typing counter-examples from type_pat into retype_pat;
   type_pat is no longer in CPS.
   (Jacques Garrigue and Takafumi Saikawa, review by Gabriel Scherer)


### PR DESCRIPTION
This PR is a follow-up to https://github.com/ocaml/ocaml/pull/11536, proposing a code simplification that was first sketched during the review of that PR: https://github.com/ocaml/ocaml/pull/11536#discussion_r1060203991

The difficulty in the code that is being fixed is an unpleasant interaction between backtracking logic and the new `with_local_level` wrappers:
- The idiomatic way to use the wrappers is to perform generalization logic in the `~post` action of the wrapper, so that the results returned to the outer level have been correctly generalized.
- The backtracking logic in this function must backtrack on an error condition that is only detected during the generalization step, but backracking from within the `~post` action is not easy as it is not supposed to return any results, just unit.
- In consequence the code was written in an unidiomatic way, with generalization logic left after the `~post` action

The solution proposed in this PR is to use a local exception to signal the need to backtrack from within the `~post` action to the outer code.

I also tried to simplify the code and clarify what is going on, with more comments and some code factorization.

### Review

I believe that it is better to be familiar (not necessarily expert) with the type-checking code, or interested in learning it on the fly, to review this PR. There is code moving in and out of the `with_local_level` callback or `~post` action, so it is not easy to convince oneself that the behavior is preserved without knowing these abstractions.

cc @garrigue @t6s, or possibly @goldfirere 