### PR TITLE
Update magic number bumping instructions

### DIFF
--- a/Makefile.config.in
+++ b/Makefile.config.in
@@ -205,7 +205,7 @@ CMXS=@cmxs@
 
 # On Windows, MKDLL, MKEXE and MKMAINDLL must ultimately be equivalent to
 #   flexlink $(FLEXLINK_FLAGS) [-exe|-maindll]
-# or OCAML_FLEXLINK overriding will not work (see utils/config.mlp)
+# or OCAML_FLEXLINK overriding will not work (see utils/config.generated.ml.in)
 
 FLEXDLL_CHAIN=@flexdll_chain@
 FLEXLINK_FLAGS=@flexlink_flags@

--- a/utils/HACKING.adoc
+++ b/utils/HACKING.adoc
@@ -1,6 +1,6 @@
 == Magic numbers
 
-The magic numbers in `config.mlp` are included in the header of
+The magic numbers in `config.common.ml` are included in the header of
 compiled files produced by the OCaml compiler. Different kind of files
 (cmi, cmo, cmx, cma, executables, etc.) get different magic numbers,
 and we also change the magic number whenever we change the format of
@@ -15,7 +15,7 @@ that are not at all valid compiled files, or because they come from
 a different compiler version with an incompatible file format.
 
 We say that we "bump" a magic number when we update its version part
-in config.mlp. To bump all magic numbers is to increment the version
+in config.common.ml. To bump all magic numbers is to increment the version
 of every kind of magic number.
 
 === Updating magic numbers

--- a/utils/HACKING.adoc
+++ b/utils/HACKING.adoc
@@ -18,6 +18,11 @@ We say that we "bump" a magic number when we update its version part
 in config.common.ml. To bump all magic numbers is to increment the version
 of every kind of magic number.
 
+The process for bootstrapping the compiler is covered in
+link:../BOOTSTRAP.adoc[BOOTSTRAP.adoc]. There is also a test script in CI which
+demonstrates the process in
+link:../tools/ci/inria/bootstrap/script[tools/ci/inria/bootstrap].
+
 === Updating magic numbers
 
 Previously people tried to update magic numbers as infrequently as


### PR DESCRIPTION
Removes some references to the old `utils/config.mlp` and also cross-references both documentation and demonstration for the exact process for bumping the magic numbers.

I (briefly) debated either updating `coldstart` to finish with:
```Makefile
	$(MAKE) tools/opnames.ml bytecomp/opcodes.ml
```
or updating `BOOTSTRAP.adoc` here:
https://github.com/ocaml/ocaml/blob/bad6fa399a4edff02231a95fead50932a7950ecc/BOOTSTRAP.adoc?plain=1#L30-L32
to clarify that when bumping the exec magic numbers, one _must_ run `make coreall` (or `make world`, therefore) first, but I decided to do neither, and instead persist this knowledge here! There's various prior PRs on the problems with `tools/make_opcodes` already.