### PR TITLE
Fix idle domain gc

### DIFF
--- a/Changes
+++ b/Changes
@@ -80,6 +80,11 @@ OCaml 5.1.0
 
 ### Runtime system:
 
+- #11589, #11903: Modify the GC pacing code to make sure the GC keeps
+   up with allocations in the presence of idle domains.
+   (Damien Doligez and Stephen Dolan, report by Florian Angeletti,
+   review by KC Sivaramakrishnan and Sadiq Jaffer)
+
 * #11865, #11868, #11876: Clarify that the operations of a custom
   block must never access the OCaml runtime. The previous
   documentation only mentioned the main illicit usages. In particular,

--- a/runtime/caml/config.h
+++ b/runtime/caml/config.h
@@ -260,6 +260,9 @@ typedef uint64_t uintnat;
    Documented in gc.mli */
 #define Custom_minor_max_bsz_def 8192
 
+/* Minimum amount of work to do in a major GC slice. */
+#define Major_slice_work_min 512
+
 /* Default allocation policy. */
 #define Allocation_policy_def caml_policy_best_fit
 

--- a/runtime/caml/domain.h
+++ b/runtime/caml/domain.h
@@ -121,8 +121,6 @@ int caml_global_barrier_num_domains(void);
 
 int caml_domain_is_terminating(void);
 
-void caml_enumerate_participating_domains(void (*f) (int));
-
 #endif /* CAML_INTERNALS */
 
 #ifdef __cplusplus

--- a/runtime/caml/domain.h
+++ b/runtime/caml/domain.h
@@ -121,6 +121,8 @@ int caml_global_barrier_num_domains(void);
 
 int caml_domain_is_terminating(void);
 
+void caml_enumerate_participating_domains(void (*f) (int));
+
 #endif /* CAML_INTERNALS */
 
 #ifdef __cplusplus

--- a/runtime/caml/domain.h
+++ b/runtime/caml/domain.h
@@ -100,6 +100,7 @@ int caml_domain_is_in_stw(void);
 #endif
 
 int caml_try_run_on_all_domains_with_spin_work(
+  int sync,
   void (*handler)(caml_domain_state*, void*, int, caml_domain_state**),
   void* data,
   void (*leader_setup)(caml_domain_state*),

--- a/runtime/caml/domain_state.tbl
+++ b/runtime/caml/domain_state.tbl
@@ -71,17 +71,6 @@ DOMAIN_STATE(uintnat, allocated_words)
 
 DOMAIN_STATE(uintnat, swept_words)
 
-DOMAIN_STATE(intnat, major_work_computed)
-/* total work accumulated in this GC clock cycle (in words) */
-
-DOMAIN_STATE(intnat, major_work_todo)
-/* balance of work to do in this GC clock cycle (in words)
- *  positive: we need to do this amount of work to finish the slice
- *  negative: we have done more than we need and this is credit
- */
-
-DOMAIN_STATE(double, major_gc_clock)
-
 DOMAIN_STATE(uintnat, major_slice_epoch)
 
 DOMAIN_STATE(struct caml__roots_block*, local_roots)
@@ -127,6 +116,11 @@ DOMAIN_STATE(double, extra_heap_resources_minor)
 
 DOMAIN_STATE(uintnat, dependent_size)
 DOMAIN_STATE(uintnat, dependent_allocated)
+
+DOMAIN_STATE(double, alloc_ratio)
+DOMAIN_STATE(double, dependent_ratio)
+DOMAIN_STATE(double, extra_ratio)
+DOMAIN_STATE(intnat, slice_budget)
 
 DOMAIN_STATE(struct caml_extern_state*, extern_state)
 DOMAIN_STATE(struct caml_intern_state*, intern_state)

--- a/runtime/caml/domain_state.tbl
+++ b/runtime/caml/domain_state.tbl
@@ -122,7 +122,6 @@ DOMAIN_STATE(double, alloc_ratio)
 DOMAIN_STATE(double, dependent_ratio)
 DOMAIN_STATE(double, extra_ratio)
 DOMAIN_STATE(intnat, slice_budget)
-DOMAIN_STATE(int, is_actively_collecting)
 
 DOMAIN_STATE(struct caml_extern_state*, extern_state)
 DOMAIN_STATE(struct caml_intern_state*, intern_state)

--- a/runtime/caml/domain_state.tbl
+++ b/runtime/caml/domain_state.tbl
@@ -92,6 +92,7 @@ DOMAIN_STATE(intnat, compare_unordered)
 DOMAIN_STATE(uintnat, oo_next_id_local)
 
 DOMAIN_STATE(uintnat, requested_major_slice)
+DOMAIN_STATE(uintnat, requested_global_major_slice)
 
 DOMAIN_STATE(uintnat, requested_minor_gc)
 

--- a/runtime/caml/domain_state.tbl
+++ b/runtime/caml/domain_state.tbl
@@ -118,7 +118,13 @@ DOMAIN_STATE(double, extra_heap_resources_minor)
 DOMAIN_STATE(uintnat, dependent_size)
 DOMAIN_STATE(uintnat, dependent_allocated)
 
+/* How much work needs to be done (by all domains) before we stop this slice. */
 DOMAIN_STATE(intnat, slice_target)
+
+/* Minimum amount of work to do in this slice by this domain. */
+DOMAIN_STATE(intnat, slice_budget)
+
+/* Accounting for sweeping work done while allocating. */
 DOMAIN_STATE(intnat, major_work_done_between_slices)
 
 DOMAIN_STATE(struct caml_extern_state*, extern_state)

--- a/runtime/caml/domain_state.tbl
+++ b/runtime/caml/domain_state.tbl
@@ -122,6 +122,7 @@ DOMAIN_STATE(double, alloc_ratio)
 DOMAIN_STATE(double, dependent_ratio)
 DOMAIN_STATE(double, extra_ratio)
 DOMAIN_STATE(intnat, slice_budget)
+DOMAIN_STATE(intnat, major_work_done_between_slices)
 
 DOMAIN_STATE(struct caml_extern_state*, extern_state)
 DOMAIN_STATE(struct caml_intern_state*, intern_state)

--- a/runtime/caml/domain_state.tbl
+++ b/runtime/caml/domain_state.tbl
@@ -122,6 +122,7 @@ DOMAIN_STATE(double, alloc_ratio)
 DOMAIN_STATE(double, dependent_ratio)
 DOMAIN_STATE(double, extra_ratio)
 DOMAIN_STATE(intnat, slice_budget)
+DOMAIN_STATE(int, is_actively_collecting)
 
 DOMAIN_STATE(struct caml_extern_state*, extern_state)
 DOMAIN_STATE(struct caml_intern_state*, intern_state)

--- a/runtime/caml/domain_state.tbl
+++ b/runtime/caml/domain_state.tbl
@@ -118,10 +118,7 @@ DOMAIN_STATE(double, extra_heap_resources_minor)
 DOMAIN_STATE(uintnat, dependent_size)
 DOMAIN_STATE(uintnat, dependent_allocated)
 
-DOMAIN_STATE(double, alloc_ratio)
-DOMAIN_STATE(double, dependent_ratio)
-DOMAIN_STATE(double, extra_ratio)
-DOMAIN_STATE(intnat, slice_budget)
+DOMAIN_STATE(intnat, slice_target)
 DOMAIN_STATE(intnat, major_work_done_between_slices)
 
 DOMAIN_STATE(struct caml_extern_state*, extern_state)

--- a/runtime/caml/signals.h
+++ b/runtime/caml/signals.h
@@ -61,8 +61,7 @@ CAMLextern atomic_uintnat caml_pending_signals[NSIG_WORDS];
 #define caml_requested_minor_gc (Caml_state_field(requested_minor_gc))
 
 int caml_check_pending_signals(void);
-void caml_request_major_slice_local (void);
-void caml_request_major_slice_global (void);
+void caml_request_major_slice (int global);
 void caml_request_minor_gc (void);
 CAMLextern int caml_convert_signal_number (int);
 CAMLextern int caml_rev_convert_signal_number (int);

--- a/runtime/caml/signals.h
+++ b/runtime/caml/signals.h
@@ -61,7 +61,8 @@ CAMLextern atomic_uintnat caml_pending_signals[NSIG_WORDS];
 #define caml_requested_minor_gc (Caml_state_field(requested_minor_gc))
 
 int caml_check_pending_signals(void);
-void caml_request_major_slice (void);
+void caml_request_major_slice_local (void);
+void caml_request_major_slice_global (void);
 void caml_request_minor_gc (void);
 CAMLextern int caml_convert_signal_number (int);
 CAMLextern int caml_rev_convert_signal_number (int);

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -1744,7 +1744,6 @@ static void domain_terminate (void)
   call_timing_hook(&caml_domain_terminated_hook);
 
   while (!finished) {
-    caml_orphan_allocated_words();
     caml_finish_sweeping();
 
     caml_empty_minor_heaps_once();

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -1625,17 +1625,17 @@ void caml_poll_gc_work(void)
     caml_empty_minor_heaps_once();
   }
 
-  if (d->requested_global_major_slice) {
-    d->requested_global_major_slice = 0;
-    (void) caml_try_run_on_all_domains_async(
-             &global_major_slice_stw_handler, NULL, NULL);
-  }
-
   if (d->requested_major_slice) {
     CAML_EV_BEGIN(EV_MAJOR);
     d->requested_major_slice = 0;
     caml_major_collection_slice(AUTO_TRIGGERED_MAJOR_SLICE);
     CAML_EV_END(EV_MAJOR);
+  }
+
+  if (d->requested_global_major_slice) {
+    d->requested_global_major_slice = 0;
+    (void) caml_try_run_on_all_domains_async(
+             &global_major_slice_stw_handler, NULL, NULL);
   }
 
   if (atomic_load_acquire(&d->requested_external_interrupt)) {

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -1858,6 +1858,15 @@ static void domain_terminate (void)
   atomic_fetch_add(&caml_num_domains_running, -1);
 }
 
+void caml_enumerate_participating_domains (void (*f) (int))
+{
+  int i;
+
+  for (i = 0; i < stw_domains.participating_domains; i++){
+    f (stw_domains.domains[i]->id);
+  }
+}
+
 CAMLprim value caml_ml_domain_cpu_relax(value t)
 {
   struct interruptor* self = &domain_self->interruptor;

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -1470,7 +1470,6 @@ int caml_try_run_on_all_domains_with_spin_work(
 
   for(i = 0; i < stw_request.num_domains; i++) {
     int id = stw_request.participating[i]->id;
-caml_gc_log ("STW: waiting for domain %d", id);
     caml_wait_interrupt_serviced(&all_domains[id].interruptor);
   }
 
@@ -1875,15 +1874,6 @@ static void domain_terminate (void)
      on caml_domain_alone (which uses caml_num_domains_running) in at least
      the shared_heap lockfree fast paths */
   atomic_fetch_add(&caml_num_domains_running, -1);
-}
-
-void caml_enumerate_participating_domains (void (*f) (int))
-{
-  int i;
-
-  for (i = 0; i < stw_domains.participating_domains; i++){
-    f (stw_domains.domains[i]->id);
-  }
 }
 
 CAMLprim value caml_ml_domain_cpu_relax(value t)

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -1734,7 +1734,7 @@ void caml_major_collection_slice(intnat howmuch)
         );
     if (interrupted_work > 0) {
       caml_gc_log("Major slice interrupted, rescheduling major slice");
-      caml_request_major_slice();
+      caml_request_major_slice_local();
     }
   } else {
     /* TODO: could make forced API slices interruptible, but would need to do

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -611,7 +611,7 @@ static void update_major_slice_work(intnat howmuch) {
               " %"ARCH_INTNAT_PRINTF_FORMAT "d alloc_work, "
               " %"ARCH_INTNAT_PRINTF_FORMAT "d dependent_work, "
               " %"ARCH_INTNAT_PRINTF_FORMAT "d extra_work,  "
-              " %"ARCH_INTNAT_PRINTF_FORMAT "u work counter%s,  "
+              " %"ARCH_INTNAT_PRINTF_FORMAT "u work counter %s,  "
               " %"ARCH_INTNAT_PRINTF_FORMAT "u alloc counter,  "
               " %"ARCH_INTNAT_PRINTF_FORMAT "u slice target,  "
               " %"ARCH_INTNAT_PRINTF_FORMAT "d slice budget"
@@ -620,7 +620,8 @@ static void update_major_slice_work(intnat howmuch) {
               (uintnat)heap_words, dom_st->allocated_words,
               alloc_work, dependent_work, extra_work,
               atomic_load (&work_counter),
-              atomic_load (&work_counter) > atomic_load (&alloc_counter) ? "[ahead]" : "[behind]",
+              atomic_load (&work_counter) > atomic_load (&alloc_counter)
+                ? "[ahead]" : "[behind]",
               atomic_load (&alloc_counter),
               dom_st->slice_target, dom_st->slice_budget
               );

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -1850,7 +1850,7 @@ void caml_major_collection_slice(intnat howmuch)
         );
     if (interrupted_work > 0) {
       caml_gc_log("Major slice interrupted, rescheduling major slice");
-      caml_request_major_slice_local();
+      caml_request_major_slice(0);
     }
   } else {
     /* TODO: could make forced API slices interruptible, but would need to do

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -522,12 +522,14 @@ static void print_stats (int after, intnat budget)
                " ?? dependent size, "
                " %.3g total extra, "
                " %"ARCH_INTNAT_PRINTF_FORMAT"d total work done, "
+               " %.2g work/alloc, "
                " %"ARCH_INTNAT_PRINTF_FORMAT"d slice %s, "
                " %s",
                total_alloc, caml_heap_size(dom_st->shared_heap),
                total_dependent,
                total_extra,
                total_work_done,
+               (double) total_work_done / (double) total_alloc,
                budget,
                after ? "done" : "budget",
                domain_accounts[dom_st->id].is_active ? "active" : "inactive");

--- a/runtime/memory.c
+++ b/runtime/memory.c
@@ -192,9 +192,8 @@ CAMLexport void caml_adjust_gc_speed (mlsize_t res, mlsize_t max)
   if (max == 0) max = 1;
   if (res > max) res = max;
   Caml_state->extra_heap_resources += (double) res / (double) max;
-  if (Caml_state->extra_heap_resources > 1.0){
+  if (Caml_state->extra_heap_resources > 0.5){
     CAML_EV_COUNTER (EV_C_REQUEST_MAJOR_ADJUST_GC_SPEED, 1);
-    Caml_state->extra_heap_resources = 1.0;
     caml_request_major_slice_global ();
   }
 }
@@ -342,7 +341,7 @@ Caml_inline value alloc_shr(mlsize_t wosize, tag_t tag, reserved_t reserved,
   }
 
   dom_st->allocated_words += Whsize_wosize(wosize);
-  if (dom_st->allocated_words > dom_st->minor_heap_wsz) {
+  if (dom_st->allocated_words > dom_st->minor_heap_wsz / 2) {
     CAML_EV_COUNTER (EV_C_REQUEST_MAJOR_ALLOC_SHR, 1);
     caml_request_major_slice_global();
   }

--- a/runtime/memory.c
+++ b/runtime/memory.c
@@ -341,11 +341,11 @@ Caml_inline value alloc_shr(mlsize_t wosize, tag_t tag, reserved_t reserved,
   }
 
   dom_st->allocated_words += Whsize_wosize(wosize);
-  caml_gc_log ("alloc_shr: %"ARCH_INTNAT_PRINTF_FORMAT"u allocated, "
+  caml_gc_log ("GCSP: alloc_shr: %"ARCH_INTNAT_PRINTF_FORMAT"u allocated, "
                "%"ARCH_INTNAT_PRINTF_FORMAT"u minor_heap",
                dom_st->allocated_words,
                dom_st->minor_heap_wsz);
-  if (dom_st->allocated_words > dom_st->minor_heap_wsz / 4) {
+  if (dom_st->allocated_words > dom_st->minor_heap_wsz / 10) {
     CAML_EV_COUNTER (EV_C_REQUEST_MAJOR_ALLOC_SHR, 1);
     caml_request_major_slice(1);
   }

--- a/runtime/memory.c
+++ b/runtime/memory.c
@@ -195,7 +195,7 @@ CAMLexport void caml_adjust_gc_speed (mlsize_t res, mlsize_t max)
   if (Caml_state->extra_heap_resources > 1.0){
     CAML_EV_COUNTER (EV_C_REQUEST_MAJOR_ADJUST_GC_SPEED, 1);
     Caml_state->extra_heap_resources = 1.0;
-    caml_request_major_slice ();
+    caml_request_major_slice_global ();
   }
 }
 
@@ -344,7 +344,7 @@ Caml_inline value alloc_shr(mlsize_t wosize, tag_t tag, reserved_t reserved,
   dom_st->allocated_words += Whsize_wosize(wosize);
   if (dom_st->allocated_words > dom_st->minor_heap_wsz) {
     CAML_EV_COUNTER (EV_C_REQUEST_MAJOR_ALLOC_SHR, 1);
-    caml_request_major_slice();
+    caml_request_major_slice_global();
   }
 
 #ifdef DEBUG

--- a/runtime/memory.c
+++ b/runtime/memory.c
@@ -192,7 +192,7 @@ CAMLexport void caml_adjust_gc_speed (mlsize_t res, mlsize_t max)
   if (max == 0) max = 1;
   if (res > max) res = max;
   Caml_state->extra_heap_resources += (double) res / (double) max;
-  if (Caml_state->extra_heap_resources > 0.5){
+  if (Caml_state->extra_heap_resources > 0.2){
     CAML_EV_COUNTER (EV_C_REQUEST_MAJOR_ADJUST_GC_SPEED, 1);
     caml_request_major_slice (1);
   }
@@ -341,11 +341,7 @@ Caml_inline value alloc_shr(mlsize_t wosize, tag_t tag, reserved_t reserved,
   }
 
   dom_st->allocated_words += Whsize_wosize(wosize);
-  caml_gc_log ("GCSP: alloc_shr: %"ARCH_INTNAT_PRINTF_FORMAT"u allocated, "
-               "%"ARCH_INTNAT_PRINTF_FORMAT"u minor_heap",
-               dom_st->allocated_words,
-               dom_st->minor_heap_wsz);
-  if (dom_st->allocated_words > dom_st->minor_heap_wsz / 10) {
+  if (dom_st->allocated_words > dom_st->minor_heap_wsz / 5) {
     CAML_EV_COUNTER (EV_C_REQUEST_MAJOR_ALLOC_SHR, 1);
     caml_request_major_slice(1);
   }

--- a/runtime/memory.c
+++ b/runtime/memory.c
@@ -341,7 +341,11 @@ Caml_inline value alloc_shr(mlsize_t wosize, tag_t tag, reserved_t reserved,
   }
 
   dom_st->allocated_words += Whsize_wosize(wosize);
-  if (dom_st->allocated_words > dom_st->minor_heap_wsz / 2) {
+  caml_gc_log ("alloc_shr: %"ARCH_INTNAT_PRINTF_FORMAT"u allocated, "
+               "%"ARCH_INTNAT_PRINTF_FORMAT"u minor_heap",
+               dom_st->allocated_words,
+               dom_st->minor_heap_wsz);
+  if (dom_st->allocated_words > dom_st->minor_heap_wsz / 4) {
     CAML_EV_COUNTER (EV_C_REQUEST_MAJOR_ALLOC_SHR, 1);
     caml_request_major_slice_global();
   }

--- a/runtime/memory.c
+++ b/runtime/memory.c
@@ -194,7 +194,7 @@ CAMLexport void caml_adjust_gc_speed (mlsize_t res, mlsize_t max)
   Caml_state->extra_heap_resources += (double) res / (double) max;
   if (Caml_state->extra_heap_resources > 0.5){
     CAML_EV_COUNTER (EV_C_REQUEST_MAJOR_ADJUST_GC_SPEED, 1);
-    caml_request_major_slice_global ();
+    caml_request_major_slice (1);
   }
 }
 
@@ -347,7 +347,7 @@ Caml_inline value alloc_shr(mlsize_t wosize, tag_t tag, reserved_t reserved,
                dom_st->minor_heap_wsz);
   if (dom_st->allocated_words > dom_st->minor_heap_wsz / 4) {
     CAML_EV_COUNTER (EV_C_REQUEST_MAJOR_ALLOC_SHR, 1);
-    caml_request_major_slice_global();
+    caml_request_major_slice(1);
   }
 
 #ifdef DEBUG

--- a/runtime/minor_gc.c
+++ b/runtime/minor_gc.c
@@ -666,7 +666,7 @@ void caml_do_opportunistic_major_slice
   if (caml_opportunistic_major_work_available()) {
     uintnat log_events = atomic_load_relaxed(&caml_verb_gc) & 0x40;
     if (log_events) CAML_EV_BEGIN(EV_MAJOR_MARK_OPPORTUNISTIC);
-    caml_opportunistic_major_collection_slice(0x200);
+    caml_opportunistic_major_collection_slice(Major_slice_work_min);
     if (log_events) CAML_EV_END(EV_MAJOR_MARK_OPPORTUNISTIC);
   }
 }
@@ -742,9 +742,6 @@ static void caml_stw_empty_minor_heap (caml_domain_state* domain, void* unused,
 {
   caml_stw_empty_minor_heap_no_major_slice(domain, unused,
                                            participating_count, participating);
-
-  /* can change how we account clock in future, here just do raw count */
-  domain->major_gc_clock += 1.0;
 }
 
 /* must be called within a STW section  */

--- a/runtime/minor_gc.c
+++ b/runtime/minor_gc.c
@@ -771,6 +771,7 @@ int caml_try_stw_empty_minor_heap_on_all_domains (void)
 
   caml_gc_log("requesting stw empty_minor_heap");
   return caml_try_run_on_all_domains_with_spin_work(
+    1, /* synchronous */
     &caml_stw_empty_minor_heap, 0, /* stw handler */
     &caml_empty_minor_heap_setup, /* leader setup */
     &caml_do_opportunistic_major_slice, 0 /* enter spin work */);

--- a/runtime/shared_heap.c
+++ b/runtime/shared_heap.c
@@ -316,7 +316,7 @@ static pool* pool_global_adopt(struct caml_heap_state* local, sizeclass sz)
   caml_plat_unlock(&pool_freelist.lock);
 
   if( !r && adopted_pool ) {
-    // XXX TODO: accounting   local->owner->major_work_todo -=
+    Caml_state->major_work_done_between_slices +=
       pool_sweep(local, &local->full_pools[sz], sz, 0);
     r = local->avail_pools[sz];
   }
@@ -333,7 +333,7 @@ static pool* pool_find(struct caml_heap_state* local, sizeclass sz) {
 
   /* Otherwise, try to sweep until we find one */
   while (!local->avail_pools[sz] && local->unswept_avail_pools[sz]) {
-    // XXX TODO: accounting   local->owner->major_work_todo -=
+    Caml_state->major_work_done_between_slices +=
       pool_sweep(local, &local->unswept_avail_pools[sz], sz, 0);
   }
 

--- a/runtime/shared_heap.c
+++ b/runtime/shared_heap.c
@@ -316,7 +316,7 @@ static pool* pool_global_adopt(struct caml_heap_state* local, sizeclass sz)
   caml_plat_unlock(&pool_freelist.lock);
 
   if( !r && adopted_pool ) {
-    local->owner->major_work_todo -=
+    // XXX TODO: accounting   local->owner->major_work_todo -=
       pool_sweep(local, &local->full_pools[sz], sz, 0);
     r = local->avail_pools[sz];
   }
@@ -333,7 +333,7 @@ static pool* pool_find(struct caml_heap_state* local, sizeclass sz) {
 
   /* Otherwise, try to sweep until we find one */
   while (!local->avail_pools[sz] && local->unswept_avail_pools[sz]) {
-    local->owner->major_work_todo -=
+    // XXX TODO: accounting   local->owner->major_work_todo -=
       pool_sweep(local, &local->unswept_avail_pools[sz], sz, 0);
   }
 

--- a/runtime/signals.c
+++ b/runtime/signals.c
@@ -236,8 +236,11 @@ value caml_execute_signal_exn(int signal_number, int in_signal_handler)
 
 void caml_request_major_slice (int global)
 {
-  Caml_state->requested_major_slice = 1;
-  Caml_state->requested_global_major_slice |= global;
+  if (global){
+    Caml_state->requested_global_major_slice = 1;
+  }else{
+    Caml_state->requested_major_slice = 1;
+  }
   caml_interrupt_self();
 }
 

--- a/runtime/signals.c
+++ b/runtime/signals.c
@@ -244,7 +244,9 @@ static void major_slice_stw_handler (caml_domain_state *domain, void *unused,
                                      int participating_count,
                                      caml_domain_state **participating)
 {
+  CAMLassert (domain == Caml_state);
   domain->requested_major_slice = 1;
+  //caml_interrupt_self();
 }
 
 void caml_request_major_slice_global (void)

--- a/runtime/signals.c
+++ b/runtime/signals.c
@@ -240,13 +240,13 @@ void caml_request_major_slice_local (void)
   caml_interrupt_self();
 }
 
-static void major_slice_stw_handler (caml_domain_state *domain, void *unused,
+static void major_slice_stw_handler (caml_domain_state *d, void *unused,
                                      int participating_count,
                                      caml_domain_state **participating)
 {
-  CAMLassert (domain == Caml_state);
-  domain->requested_major_slice = 1;
-  //caml_interrupt_self();
+  CAMLassert (d == Caml_state);
+  d->requested_major_slice = 1;
+  caml_interrupt_self();
 }
 
 void caml_request_major_slice_global (void)

--- a/runtime/signals.c
+++ b/runtime/signals.c
@@ -234,27 +234,11 @@ value caml_execute_signal_exn(int signal_number, int in_signal_handler)
 
 /* Arrange for a garbage collection to be performed as soon as possible */
 
-void caml_request_major_slice_local (void)
+void caml_request_major_slice (int global)
 {
   Caml_state->requested_major_slice = 1;
+  Caml_state->requested_global_major_slice |= global;
   caml_interrupt_self();
-}
-
-static void major_slice_stw_handler (caml_domain_state *d, void *unused,
-                                     int participating_count,
-                                     caml_domain_state **participating)
-{
-  CAMLassert (d == Caml_state);
-  d->requested_major_slice = 1;
-  caml_interrupt_self();
-}
-
-void caml_request_major_slice_global (void)
-{
-  (void) caml_try_run_on_all_domains_with_spin_work(
-    0,
-    &major_slice_stw_handler, NULL,
-    NULL, NULL, NULL);
 }
 
 void caml_request_minor_gc (void)

--- a/runtime/signals.c
+++ b/runtime/signals.c
@@ -234,10 +234,25 @@ value caml_execute_signal_exn(int signal_number, int in_signal_handler)
 
 /* Arrange for a garbage collection to be performed as soon as possible */
 
-void caml_request_major_slice (void)
+void caml_request_major_slice_local (void)
 {
   Caml_state->requested_major_slice = 1;
   caml_interrupt_self();
+}
+
+static void major_slice_stw_handler (caml_domain_state *domain, void *unused,
+                                     int participating_count,
+                                     caml_domain_state **participating)
+{
+  domain->requested_major_slice = 1;
+}
+
+void caml_request_major_slice_global (void)
+{
+  (void) caml_try_run_on_all_domains_with_spin_work(
+    0,
+    &major_slice_stw_handler, NULL,
+    NULL, NULL, NULL);
 }
 
 void caml_request_minor_gc (void)

--- a/testsuite/tests/lib-runtime-events/test_instrumented.reference
+++ b/testsuite/tests/lib-runtime-events/test_instrumented.reference
@@ -1,1 +1,1 @@
-lost_event_words: 0, total_sizes: 2000004, total_minors: 30
+lost_event_words: 0, total_sizes: 2000004, total_minors: 31

--- a/testsuite/tests/parallel/major_gc_wait_backup.ml
+++ b/testsuite/tests/parallel/major_gc_wait_backup.ml
@@ -37,6 +37,6 @@ let _ =
   ) in
   Gc.full_major ();
   let n = major_collections () in
-  ignore (make 22);
+  ignore (make 24);
   assert ((major_collections ()) > n);
   print_endline "sleep OK"


### PR DESCRIPTION
Trying to fix #11589 (and maybe #11548). Two changes here:

1. GC work accounting and distribution becomes global.
2. extra major slices are done globally instead of locally.

The benchmark code is here: https://gist.github.com/damiendoligez/86a3afa6c6a594e0274d6194d91457b7

### GC work accounting
Major allocations are counted globally and the counts are evenly distributed among active domains. These counts tell the major GC slices how much work they have to do. The main difficulty is that some domains may run out of major GC work for the current cycle before others. Then they cannot do any more GC work before the global synchronization at the end of the GC cycle (i.e. the STW event that starts the next cycle). In this case we have to redistribute their counts back to the domains that still have something to do.
This accounting tries to guarante that the global speed of major collection keeps up with the speed of allocation.

### extra major slices
When we allocate directly in the major heap, we sometimes have to trigger major GC slices in addition to the ones that are automatically run between minor collections. In trunk, this is done only in the allocating domain, but that's not enough: in the benchmark program, the allocating domain has already run out of GC work and these slices do nothing and allocation gets ahead of collection. In order to do these global slices, we have to send a signal to all other domains, but we don't need synchronization, do I modified the STW code to add an asynchronous mode.

### benchmark results
| test | max heap size (MB) | minor collections | major collections |
|-----|--------------:|------------------:|-----------------:|
|trunk sequential | 30.5 | 125 | 116 |
|trunk with idle domain | 694.0 | 121 | 6 |
|this PR sequential | 52.6 | 112 | 112 |
|this PR with idle domain | 99.9 | 194 | 47 |

We can clearly see some improvement, but I still have to investigate:
- ~~why the number of minor collections changes so much~~
- ~~why the sequential test of this PR uses much more memory than trunk~~
- ~~what is still holding up the major GC~~

Fixes #11589
Fixes #12042
