### PR TITLE
error messages: simpler names for shadowed identifiers

### DIFF
--- a/.depend
+++ b/.depend
@@ -1071,6 +1071,7 @@ typing/printtyp.cmo : \
     typing/types.cmi \
     typing/type_immediacy.cmi \
     typing/signature_group.cmi \
+    typing/shape.cmi \
     typing/primitive.cmi \
     typing/predef.cmi \
     typing/path.cmi \
@@ -1093,6 +1094,7 @@ typing/printtyp.cmx : \
     typing/types.cmx \
     typing/type_immediacy.cmx \
     typing/signature_group.cmx \
+    typing/shape.cmx \
     typing/primitive.cmx \
     typing/predef.cmx \
     typing/path.cmx \
@@ -1112,6 +1114,7 @@ typing/printtyp.cmx : \
     typing/printtyp.cmi
 typing/printtyp.cmi : \
     typing/types.cmi \
+    typing/shape.cmi \
     typing/path.cmi \
     typing/outcometree.cmi \
     parsing/longident.cmi \

--- a/Changes
+++ b/Changes
@@ -384,6 +384,10 @@ Working version
   the type parameters.
   (Stefan Muenzel, review by Florian Angeletti and Gabriel Scherer)
 
+- #11910: Simplify naming convention for shadowed or ephemeral identifiers in
+  error messages (eg: `Illegal shadowing of included type t/2 by t`)
+  (Florian Angeletti, review by Jules Aguillon)
+
 ### Internal/compiler-libs changes:
 
 - #11990: Improve comments and macros around frame descriptors.

--- a/testsuite/tests/generalized-open/gpr1506.ml
+++ b/testsuite/tests/generalized-open/gpr1506.ml
@@ -103,9 +103,11 @@ include struct open struct type t = T end let x = T end
 Line 1, characters 15-41:
 1 | include struct open struct type t = T end let x = T end
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The type t introduced by this open appears in the signature
-       Line 1, characters 46-47:
-         The value x has no valid type if t is hidden
+Error: The type t introduced by this open appears in the signature.
+Line 1, characters 46-47:
+1 | include struct open struct type t = T end let x = T end
+                                                  ^
+  The value x has no valid type if t is hidden.
 |}];;
 
 module A = struct
@@ -123,9 +125,11 @@ Lines 3-6, characters 4-7:
 4 |       type t = T
 5 |       let x = T
 6 |     end
-Error: The type t introduced by this open appears in the signature
-       Line 7, characters 8-9:
-         The value y has no valid type if t is hidden
+Error: The type t introduced by this open appears in the signature.
+Line 7, characters 8-9:
+7 |     let y = x
+            ^
+  The value y has no valid type if t is hidden.
 |}];;
 
 module A = struct
@@ -142,9 +146,11 @@ Lines 3-5, characters 4-7:
 3 | ....open struct
 4 |       type t = T
 5 |     end
-Error: The type t introduced by this open appears in the signature
-       Line 6, characters 8-9:
-         The value y has no valid type if t is hidden
+Error: The type t introduced by this open appears in the signature.
+Line 6, characters 8-9:
+6 |     let y = T
+            ^
+  The value y has no valid type if t is hidden.
 |}]
 
 (* It was decided to not allow this anymore. *)

--- a/testsuite/tests/generalized-open/gpr1506.ml
+++ b/testsuite/tests/generalized-open/gpr1506.ml
@@ -103,9 +103,9 @@ include struct open struct type t = T end let x = T end
 Line 1, characters 15-41:
 1 | include struct open struct type t = T end let x = T end
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The type t/339 introduced by this open appears in the signature
+Error: The type t introduced by this open appears in the signature
        Line 1, characters 46-47:
-         The value x has no valid type if t/339 is hidden
+         The value x has no valid type if t is hidden
 |}];;
 
 module A = struct
@@ -123,9 +123,9 @@ Lines 3-6, characters 4-7:
 4 |       type t = T
 5 |       let x = T
 6 |     end
-Error: The type t/344 introduced by this open appears in the signature
+Error: The type t introduced by this open appears in the signature
        Line 7, characters 8-9:
-         The value y has no valid type if t/344 is hidden
+         The value y has no valid type if t is hidden
 |}];;
 
 module A = struct
@@ -142,9 +142,9 @@ Lines 3-5, characters 4-7:
 3 | ....open struct
 4 |       type t = T
 5 |     end
-Error: The type t/349 introduced by this open appears in the signature
+Error: The type t introduced by this open appears in the signature
        Line 6, characters 8-9:
-         The value y has no valid type if t/349 is hidden
+         The value y has no valid type if t is hidden
 |}]
 
 (* It was decided to not allow this anymore. *)

--- a/testsuite/tests/shadow_include/cannot_shadow_error.compilers.reference
+++ b/testsuite/tests/shadow_include/cannot_shadow_error.compilers.reference
@@ -1,8 +1,8 @@
 File "cannot_shadow_error.ml", line 24, characters 2-36:
 24 |   include Comparable with type t = t
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: Illegal shadowing of included type t/10 by t/15
+Error: Illegal shadowing of included type t/2 by t
        File "cannot_shadow_error.ml", line 23, characters 2-19:
-         Type t/10 came from this include
+         Type t/2 came from this include
        File "cannot_shadow_error.ml", line 14, characters 2-23:
-         The value print has no valid type if t/10 is shadowed
+         The value print has no valid type if t/2 is shadowed

--- a/testsuite/tests/shadow_include/cannot_shadow_error.compilers.reference
+++ b/testsuite/tests/shadow_include/cannot_shadow_error.compilers.reference
@@ -1,8 +1,12 @@
 File "cannot_shadow_error.ml", line 24, characters 2-36:
 24 |   include Comparable with type t = t
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: Illegal shadowing of included type t/2 by t
-       File "cannot_shadow_error.ml", line 23, characters 2-19:
-         Type t/2 came from this include
-       File "cannot_shadow_error.ml", line 14, characters 2-23:
-         The value print has no valid type if t/2 is shadowed
+Error: Illegal shadowing of included type t/2 by t.
+File "cannot_shadow_error.ml", line 23, characters 2-19:
+23 |   include Printable
+       ^^^^^^^^^^^^^^^^^
+  Type t/2 came from this include.
+File "cannot_shadow_error.ml", line 14, characters 2-23:
+14 |   val print : t -> unit
+       ^^^^^^^^^^^^^^^^^^^^^
+  The value print has no valid type if t/2 is shadowed.

--- a/testsuite/tests/shadow_include/shadow_all.ml
+++ b/testsuite/tests/shadow_include/shadow_all.ml
@@ -100,11 +100,11 @@ end
 Line 4, characters 2-11:
 4 |   include S
       ^^^^^^^^^
-Error: Illegal shadowing of included type t/131 by t/146
+Error: Illegal shadowing of included type t/2 by t
        Line 2, characters 2-11:
-         Type t/131 came from this include
+         Type t/2 came from this include
        Line 3, characters 2-24:
-         The value ignore has no valid type if t/131 is shadowed
+         The value ignore has no valid type if t/2 is shadowed
 |}]
 
 module type Module = sig
@@ -140,11 +140,11 @@ end
 Line 4, characters 2-11:
 4 |   include S
       ^^^^^^^^^
-Error: Illegal shadowing of included module M/211 by M/226
+Error: Illegal shadowing of included module M/2 by M
        Line 2, characters 2-11:
-         Module M/211 came from this include
+         Module M/2 came from this include
        Line 3, characters 2-26:
-         The value ignore has no valid type if M/211 is shadowed
+         The value ignore has no valid type if M/2 is shadowed
 |}]
 
 
@@ -181,11 +181,11 @@ end
 Line 4, characters 2-11:
 4 |   include S
       ^^^^^^^^^
-Error: Illegal shadowing of included module type T/287 by T/302
+Error: Illegal shadowing of included module type T/2 by T
        Line 2, characters 2-11:
-         Module type T/287 came from this include
+         Module type T/2 came from this include
        Line 3, characters 2-39:
-         The module F has no valid type if T/287 is shadowed
+         The module F has no valid type if T/2 is shadowed
 |}]
 
 module type Extension = sig
@@ -198,11 +198,11 @@ end
 Line 4, characters 2-11:
 4 |   include S
       ^^^^^^^^^
-Error: Illegal shadowing of included type ext/318 by ext/333
+Error: Illegal shadowing of included type ext/2 by ext
        Line 2, characters 2-11:
-         Type ext/318 came from this include
+         Type ext/2 came from this include
        Line 3, characters 14-16:
-         The extension constructor C2 has no valid type if ext/318 is shadowed
+         The extension constructor C2 has no valid type if ext/2 is shadowed
 |}]
 
 module type Class = sig
@@ -474,4 +474,25 @@ module Class_type :
     class c : object  end
     class type ct = object  end
   end
+|}]
+
+(** Test rare interaction between shadowing and generalized open in error messages *)
+module M = struct
+  include struct
+    type t = A
+    let x = A
+  end
+  open struct type t end
+  open struct type t end
+  type t
+end
+[%%expect {|
+Line 8, characters 2-8:
+8 |   type t
+      ^^^^^^
+Error: Illegal shadowing of included type t/4 by t
+       Lines 2-5, characters 2-5:
+         Type t/4 came from this include
+       Line 4, characters 8-9:
+         The value x has no valid type if t/4 is shadowed
 |}]

--- a/testsuite/tests/shadow_include/shadow_all.ml
+++ b/testsuite/tests/shadow_include/shadow_all.ml
@@ -100,11 +100,15 @@ end
 Line 4, characters 2-11:
 4 |   include S
       ^^^^^^^^^
-Error: Illegal shadowing of included type t/2 by t
-       Line 2, characters 2-11:
-         Type t/2 came from this include
-       Line 3, characters 2-24:
-         The value ignore has no valid type if t/2 is shadowed
+Error: Illegal shadowing of included type t/2 by t.
+Line 2, characters 2-11:
+2 |   include S
+      ^^^^^^^^^
+  Type t/2 came from this include.
+Line 3, characters 2-24:
+3 |   val ignore : t -> unit
+      ^^^^^^^^^^^^^^^^^^^^^^
+  The value ignore has no valid type if t/2 is shadowed.
 |}]
 
 module type Module = sig
@@ -140,11 +144,15 @@ end
 Line 4, characters 2-11:
 4 |   include S
       ^^^^^^^^^
-Error: Illegal shadowing of included module M/2 by M
-       Line 2, characters 2-11:
-         Module M/2 came from this include
-       Line 3, characters 2-26:
-         The value ignore has no valid type if M/2 is shadowed
+Error: Illegal shadowing of included module M/2 by M.
+Line 2, characters 2-11:
+2 |   include S
+      ^^^^^^^^^
+  Module M/2 came from this include.
+Line 3, characters 2-26:
+3 |   val ignore : M.t -> unit
+      ^^^^^^^^^^^^^^^^^^^^^^^^
+  The value ignore has no valid type if M/2 is shadowed.
 |}]
 
 
@@ -181,11 +189,15 @@ end
 Line 4, characters 2-11:
 4 |   include S
       ^^^^^^^^^
-Error: Illegal shadowing of included module type T/2 by T
-       Line 2, characters 2-11:
-         Module type T/2 came from this include
-       Line 3, characters 2-39:
-         The module F has no valid type if T/2 is shadowed
+Error: Illegal shadowing of included module type T/2 by T.
+Line 2, characters 2-11:
+2 |   include S
+      ^^^^^^^^^
+  Module type T/2 came from this include.
+Line 3, characters 2-39:
+3 |   module F : functor (_ : T) -> sig end
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  The module F has no valid type if T/2 is shadowed.
 |}]
 
 module type Extension = sig
@@ -198,11 +210,15 @@ end
 Line 4, characters 2-11:
 4 |   include S
       ^^^^^^^^^
-Error: Illegal shadowing of included type ext/2 by ext
-       Line 2, characters 2-11:
-         Type ext/2 came from this include
-       Line 3, characters 14-16:
-         The extension constructor C2 has no valid type if ext/2 is shadowed
+Error: Illegal shadowing of included type ext/2 by ext.
+Line 2, characters 2-11:
+2 |   include S
+      ^^^^^^^^^
+  Type ext/2 came from this include.
+Line 3, characters 14-16:
+3 |   type ext += C2
+                  ^^
+  The extension constructor C2 has no valid type if ext/2 is shadowed.
 |}]
 
 module type Class = sig
@@ -490,9 +506,15 @@ end
 Line 8, characters 2-8:
 8 |   type t
       ^^^^^^
-Error: Illegal shadowing of included type t/4 by t
-       Lines 2-5, characters 2-5:
-         Type t/4 came from this include
-       Line 4, characters 8-9:
-         The value x has no valid type if t/4 is shadowed
+Error: Illegal shadowing of included type t/4 by t.
+Lines 2-5, characters 2-5:
+2 | ..include struct
+3 |     type t = A
+4 |     let x = A
+5 |   end
+  Type t/4 came from this include.
+Line 4, characters 8-9:
+4 |     let x = A
+            ^
+  The value x has no valid type if t/4 is shadowed.
 |}]

--- a/testsuite/tests/typing-sigsubst/sigsubst.ml
+++ b/testsuite/tests/typing-sigsubst/sigsubst.ml
@@ -24,11 +24,15 @@ end
 Line 3, characters 2-36:
 3 |   include Comparable with type t = t
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: Illegal shadowing of included type t/2 by t
-       Line 2, characters 2-19:
-         Type t/2 came from this include
-       Line 3, characters 2-23:
-         The value print has no valid type if t/2 is shadowed
+Error: Illegal shadowing of included type t/2 by t.
+Line 2, characters 2-19:
+2 |   include Printable
+      ^^^^^^^^^^^^^^^^^
+  Type t/2 came from this include.
+Line 3, characters 2-23:
+3 |   val print : t -> unit
+      ^^^^^^^^^^^^^^^^^^^^^
+  The value print has no valid type if t/2 is shadowed.
 |}]
 
 module type Sunderscore = sig

--- a/testsuite/tests/typing-sigsubst/sigsubst.ml
+++ b/testsuite/tests/typing-sigsubst/sigsubst.ml
@@ -24,11 +24,11 @@ end
 Line 3, characters 2-36:
 3 |   include Comparable with type t = t
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: Illegal shadowing of included type t/286 by t/291
+Error: Illegal shadowing of included type t/2 by t
        Line 2, characters 2-19:
-         Type t/286 came from this include
+         Type t/2 came from this include
        Line 3, characters 2-23:
-         The value print has no valid type if t/286 is shadowed
+         The value print has no valid type if t/2 is shadowed
 |}]
 
 module type Sunderscore = sig

--- a/typing/printtyp.mli
+++ b/typing/printtyp.mli
@@ -21,6 +21,7 @@ open Outcometree
 
 val longident: formatter -> Longident.t -> unit
 val ident: formatter -> Ident.t -> unit
+val namespaced_ident: Shape.Sig_component_kind.t -> Ident.t -> string
 val tree_of_path: Path.t -> out_ident
 val path: formatter -> Path.t -> unit
 val string_of_path: Path.t -> string
@@ -34,13 +35,7 @@ module Out_name: sig
   val print: out_name -> string
 end
 
-type namespace =
-  | Type
-  | Module
-  | Module_type
-  | Class
-  | Class_type
-  | Other (** Other bypasses the unique name for identifier mechanism *)
+type namespace := Shape.Sig_component_kind.t option
 
 val strings_of_paths: namespace -> Path.t list -> string list
     (** Print a list of paths, using the same naming context to
@@ -69,7 +64,7 @@ module Conflicts: sig
         an identifier to avoid a name collision *)
 
   type explanation =
-    { kind: namespace;
+    { kind: Shape.Sig_component_kind.t;
       name:string;
       root_name:string;
       location:Location.t

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -966,7 +966,7 @@ end) = struct
       [_] -> []
     | _ -> let open Printtyp in
         wrap_printing_env ~error:true env (fun () ->
-            reset(); strings_of_paths Type tpaths)
+            reset(); strings_of_paths (Some Type) tpaths)
 
   let disambiguate_by_type env tpath lbls =
     match lbls with

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -3332,28 +3332,35 @@ let report_error ~loc _env = function
   | Cannot_hide_id Illegal_shadowing
       { shadowed_item_kind; shadowed_item_id; shadowed_item_loc;
         shadower_id; user_id; user_kind; user_loc } ->
+      let shadowed =
+        Printtyp.namespaced_ident shadowed_item_kind shadowed_item_id
+      in
+      let shadower =
+        Printtyp.namespaced_ident shadowed_item_kind shadower_id
+      in
       let shadowed_item_kind= Sig_component_kind.to_string shadowed_item_kind in
       Location.errorf ~loc
-        "@[<v>Illegal shadowing of included %s %a by %a@ \
-         %a:@;<1 2>%s %a came from this include@ \
-         %a:@;<1 2>The %s %s has no valid type if %a is shadowed@]"
-        shadowed_item_kind Ident.print shadowed_item_id Ident.print shadower_id
+        "@[<v>Illegal shadowing of included %s %s by %s@ \
+         %a:@;<1 2>%s %s came from this include@ \
+         %a:@;<1 2>The %s %s has no valid type if %s is shadowed@]"
+        shadowed_item_kind shadowed shadower
         Location.print_loc shadowed_item_loc
         (String.capitalize_ascii shadowed_item_kind)
-        Ident.print shadowed_item_id
+        shadowed
         Location.print_loc user_loc
         (Sig_component_kind.to_string user_kind) (Ident.name user_id)
-        Ident.print shadowed_item_id
+        shadowed
   | Cannot_hide_id Appears_in_signature
       { opened_item_kind; opened_item_id; user_id; user_kind; user_loc } ->
       let opened_item_kind= Sig_component_kind.to_string opened_item_kind in
+      let opened_id = Ident.name opened_item_id in
       Location.errorf ~loc
-        "@[<v>The %s %a introduced by this open appears in the signature@ \
-         %a:@;<1 2>The %s %s has no valid type if %a is hidden@]"
-        opened_item_kind Ident.print opened_item_id
+        "@[<v>The %s %s introduced by this open appears in the signature@ \
+         %a:@;<1 2>The %s %s has no valid type if %s is hidden@]"
+        opened_item_kind opened_id
         Location.print_loc user_loc
         (Sig_component_kind.to_string user_kind) (Ident.name user_id)
-        Ident.print opened_item_id
+        opened_id
   | Invalid_type_subst_rhs ->
       Location.errorf ~loc "Only type synonyms are allowed on the right of :="
   | Unpackable_local_modtype_subst p ->


### PR DESCRIPTION
This PR proposes to use the new naming convention for ambiguous identifiers in the error messages for `illegal include`s (and `generalized open`s).

Currently, when printing identifiers involved in a signature avoidance issue, for instance
```ocaml
include struct
  type t = A
  let x = A
end
type t
```
the error messages resort to using the internal stamp to disambiguate the two types `t`:
```
Error: Illegal shadowing of included type t/1155 by t/1157
       Lines 1-4, characters 0-3:
         Type t/1155 came from this include
       Line 3, characters 6-7:
         The value x has no valid type if t/1155 is shadowed
```
However, for type-level error message, we have recently adopted the convention  that  `t/<n>` means the `n`-th most recent identifier `t` in scope.
This leaves us with two conflicting interpretations for `t/<n>` in error messages.

Moreover, the new convention can be easily applied to `illegal include`s, contrarily to the previous ad-hoc printing mechanism in `Printtyp`: the shadower item should be named `t`  since it is the newest `t` in scope, whereas the shadowed item should be named `t/2`:

```
Error: Illegal shadowing of included type t/2 by t
       File "test.ml", lines 1-4, characters 0-3:
         Type t/2 came from this include
       File "test.ml", line 3, characters 6-7:
         The value x has no valid type if t/2 is shadowed
```

Consequently, I propose to switch to the new convention in both the `illegal include` and `generalized open` error messages in order to decrease the complexity of our error messages.

------------------------------

Note that for generalized opens, 

```ocaml
open struct type t = A end
let x = A
```

the current error message is also using the internal stamp

```
Error: The type t/1160 introduced by this open appears in the signature
       Line 3, characters 4-5:
         The value x has no valid type if t/1160 is hidden
```
but without a second type `t` in the context of the error. Using just `t` in this case seems fine to me.

------------------

Similarly, one might wonder if it might be possible for `illegal include`s to involve more than two types (or components) sharing the same name.

This cannot happen currently because the current typechecker error path reduces signature avoidance issues into a single `illegal include` error that only concerns two components with the same name. 

Unfortunately, this can result in some  `spooky-error-at-distance` phenomenon which are not ideal from my point-of-view, but this is a story for another PR.

(cc @trefis: I remember that we disagreed when we discussed my previous proposition in this area, so if you have any comments or criticisms (or not) on this new proposition, you are very welcome) 