### PR TITLE
Refactor treatment of type variables

### DIFF
--- a/Changes
+++ b/Changes
@@ -82,7 +82,7 @@ Working version
   (Leo White, review by Gabriel Scherer and Florian Angeletti)
 
 - #11912: Refactoring handling of scoped type variables
-  (Richard Eisenberg, review by Gabriel Scherer)
+  (Richard Eisenberg, review by Gabriel Scherer and Florian Angeletti)
 
 ### Code generation and optimizations:
 

--- a/Changes
+++ b/Changes
@@ -81,6 +81,9 @@ Working version
   would previous behave incorrectly, and now results in a clean error.
   (Leo White, review by Gabriel Scherer and Florian Angeletti)
 
+- #11912: Refactoring handling of scoped type variables
+  (Richard Eisenberg, review by Gabriel Scherer)
+
 ### Code generation and optimizations:
 
 - #11967: Remove traces of Obj.truncate, which allows some mutable

--- a/typing/typeclass.ml
+++ b/typing/typeclass.ml
@@ -644,7 +644,8 @@ let rec class_field_first_pass self_loc cl_num sign self_scope acc cf =
         (fun () ->
            let cty =
              Ctype.with_local_level_if_principal
-               (fun () -> Typetexp.transl_simple_type val_env ~closed:false styp)
+               (fun () -> Typetexp.transl_simple_type val_env
+                            ~closed:false styp)
                ~post:(fun cty -> Ctype.generalize_structure cty.ctyp_type)
            in
            add_instance_variable ~strict:true loc val_env

--- a/typing/typeclass.ml
+++ b/typing/typeclass.ml
@@ -251,9 +251,9 @@ let unify_delayed_method_type loc env label ty expected_ty=
       raise(Error(loc, env, Field_type_mismatch ("method", label, trace)))
 
 let type_constraint val_env sty sty' loc =
-  let cty  = transl_simple_type val_env false sty in
+  let cty  = transl_simple_type val_env ~fixed:false sty in
   let ty = cty.ctyp_type in
-  let cty' = transl_simple_type val_env false sty' in
+  let cty' = transl_simple_type val_env ~fixed:false sty' in
   let ty' = cty'.ctyp_type in
   begin
     try Ctype.unify val_env ty ty' with Ctype.Unify err ->
@@ -293,7 +293,7 @@ let rec class_type_field env sign self_scope ctf =
   | Pctf_val ({txt=lab}, mut, virt, sty) ->
       mkctf_with_attrs
         (fun () ->
-          let cty = transl_simple_type env false sty in
+          let cty = transl_simple_type env ~fixed:false sty in
           let ty = cty.ctyp_type in
           add_instance_variable ~strict:false loc env lab mut virt ty sign;
           Tctf_val (lab, mut, virt, cty))
@@ -317,7 +317,7 @@ let rec class_type_field env sign self_scope ctf =
                  ) :: !delayed_meth_specs;
                Tctf_method (lab, priv, virt, returned_cty)
            | _ ->
-               let cty = transl_simple_type env false sty in
+               let cty = transl_simple_type env ~fixed:false sty in
                let ty = cty.ctyp_type in
                add_method loc env lab priv virt ty sign;
                Tctf_method (lab, priv, virt, cty))
@@ -341,7 +341,7 @@ and class_signature virt env pcsig self_scope loc =
   (* Introduce a dummy method preventing self type from being closed. *)
   Ctype.add_dummy_method env ~scope:self_scope sign;
 
-  let self_cty = transl_simple_type env false sty in
+  let self_cty = transl_simple_type env ~fixed:false sty in
   let self_type = self_cty.ctyp_type in
   begin try
     Ctype.unify env self_type sign.csig_self
@@ -391,7 +391,7 @@ and class_type_aux env virt self_scope scty =
                                                    List.length styl)));
       let ctys = List.map2
         (fun sty ty ->
-          let cty' = transl_simple_type env false sty in
+          let cty' = transl_simple_type env ~fixed:false sty in
           let ty' = cty'.ctyp_type in
           begin
            try Ctype.unify env ty' ty with Ctype.Unify err ->
@@ -411,7 +411,7 @@ and class_type_aux env virt self_scope scty =
       cltyp (Tcty_signature clsig) typ
 
   | Pcty_arrow (l, sty, scty) ->
-      let cty = transl_simple_type env false sty in
+      let cty = transl_simple_type env ~fixed:false sty in
       let ty = cty.ctyp_type in
       let ty =
         if Btype.is_optional l
@@ -644,7 +644,7 @@ let rec class_field_first_pass self_loc cl_num sign self_scope acc cf =
         (fun () ->
            let cty =
              Ctype.with_local_level_if_principal
-               (fun () -> Typetexp.transl_simple_type val_env false styp)
+               (fun () -> Typetexp.transl_simple_type val_env ~fixed:false styp)
                ~post:(fun cty -> Ctype.generalize_structure cty.ctyp_type)
            in
            add_instance_variable ~strict:true loc val_env
@@ -714,7 +714,7 @@ let rec class_field_first_pass self_loc cl_num sign self_scope acc cf =
       with_attrs
         (fun () ->
            let sty = Ast_helper.Typ.force_poly sty in
-           let cty = transl_simple_type val_env false sty in
+           let cty = transl_simple_type val_env ~fixed:false sty in
            let ty = cty.ctyp_type in
            add_method loc val_env label.txt priv Virtual ty sign;
            let field =
@@ -754,7 +754,7 @@ let rec class_field_first_pass self_loc cl_num sign self_scope acc cf =
              | Some sty ->
                  let sty = Ast_helper.Typ.force_poly sty in
                  let cty' =
-                   Typetexp.transl_simple_type val_env false sty
+                   Typetexp.transl_simple_type val_env ~fixed:false sty
                  in
                  cty'.ctyp_type
            in
@@ -1058,7 +1058,7 @@ and class_expr_aux cl_num val_env met_env virt self_scope scl =
       if Path.same decl.cty_path unbound_class then
         raise(Error(scl.pcl_loc, val_env, Unbound_class_2 lid.txt));
       let tyl = List.map
-          (fun sty -> transl_simple_type val_env false sty)
+          (fun sty -> transl_simple_type val_env ~fixed:false sty)
           styl
       in
       let (params, clty) =
@@ -1343,13 +1343,13 @@ and class_expr_aux cl_num val_env met_env virt self_scope scl =
       let cl, clty =
         Ctype.with_local_level_for_class begin fun () ->
           let cl =
-            Typetexp.with_local_type_variable_scope begin fun () ->
+            Typetexp.TyVarEnv.with_local_scope begin fun () ->
               let cl = class_expr cl_num val_env met_env virt self_scope scl' in
               complete_class_type cl.cl_loc val_env virt Class_type cl.cl_type;
               cl
             end
           and clty =
-            Typetexp.with_local_type_variable_scope begin fun () ->
+            Typetexp.TyVarEnv.with_local_scope begin fun () ->
               let clty = class_type val_env virt self_scope scty in
               complete_class_type
                 clty.cltyp_loc val_env virt Class clty.cltyp_type;
@@ -1513,7 +1513,7 @@ let class_infos define_class kind
      dummy_class)
     (res, env) =
 
-  reset_type_variables ();
+  TyVarEnv.reset ();
   let ci_params, params, coercion_locs, expr, typ, sign =
     Ctype.with_local_level_for_class begin fun () ->
       (* Introduce class parameters *)

--- a/typing/typeclass.ml
+++ b/typing/typeclass.ml
@@ -251,9 +251,9 @@ let unify_delayed_method_type loc env label ty expected_ty=
       raise(Error(loc, env, Field_type_mismatch ("method", label, trace)))
 
 let type_constraint val_env sty sty' loc =
-  let cty  = transl_simple_type val_env ~fixed:false sty in
+  let cty  = transl_simple_type val_env ~closed:false sty in
   let ty = cty.ctyp_type in
-  let cty' = transl_simple_type val_env ~fixed:false sty' in
+  let cty' = transl_simple_type val_env ~closed:false sty' in
   let ty' = cty'.ctyp_type in
   begin
     try Ctype.unify val_env ty ty' with Ctype.Unify err ->
@@ -293,7 +293,7 @@ let rec class_type_field env sign self_scope ctf =
   | Pctf_val ({txt=lab}, mut, virt, sty) ->
       mkctf_with_attrs
         (fun () ->
-          let cty = transl_simple_type env ~fixed:false sty in
+          let cty = transl_simple_type env ~closed:false sty in
           let ty = cty.ctyp_type in
           add_instance_variable ~strict:false loc env lab mut virt ty sign;
           Tctf_val (lab, mut, virt, cty))
@@ -317,7 +317,7 @@ let rec class_type_field env sign self_scope ctf =
                  ) :: !delayed_meth_specs;
                Tctf_method (lab, priv, virt, returned_cty)
            | _ ->
-               let cty = transl_simple_type env ~fixed:false sty in
+               let cty = transl_simple_type env ~closed:false sty in
                let ty = cty.ctyp_type in
                add_method loc env lab priv virt ty sign;
                Tctf_method (lab, priv, virt, cty))
@@ -341,7 +341,7 @@ and class_signature virt env pcsig self_scope loc =
   (* Introduce a dummy method preventing self type from being closed. *)
   Ctype.add_dummy_method env ~scope:self_scope sign;
 
-  let self_cty = transl_simple_type env ~fixed:false sty in
+  let self_cty = transl_simple_type env ~closed:false sty in
   let self_type = self_cty.ctyp_type in
   begin try
     Ctype.unify env self_type sign.csig_self
@@ -391,7 +391,7 @@ and class_type_aux env virt self_scope scty =
                                                    List.length styl)));
       let ctys = List.map2
         (fun sty ty ->
-          let cty' = transl_simple_type env ~fixed:false sty in
+          let cty' = transl_simple_type env ~closed:false sty in
           let ty' = cty'.ctyp_type in
           begin
            try Ctype.unify env ty' ty with Ctype.Unify err ->
@@ -411,7 +411,7 @@ and class_type_aux env virt self_scope scty =
       cltyp (Tcty_signature clsig) typ
 
   | Pcty_arrow (l, sty, scty) ->
-      let cty = transl_simple_type env ~fixed:false sty in
+      let cty = transl_simple_type env ~closed:false sty in
       let ty = cty.ctyp_type in
       let ty =
         if Btype.is_optional l
@@ -644,7 +644,7 @@ let rec class_field_first_pass self_loc cl_num sign self_scope acc cf =
         (fun () ->
            let cty =
              Ctype.with_local_level_if_principal
-               (fun () -> Typetexp.transl_simple_type val_env ~fixed:false styp)
+               (fun () -> Typetexp.transl_simple_type val_env ~closed:false styp)
                ~post:(fun cty -> Ctype.generalize_structure cty.ctyp_type)
            in
            add_instance_variable ~strict:true loc val_env
@@ -714,7 +714,7 @@ let rec class_field_first_pass self_loc cl_num sign self_scope acc cf =
       with_attrs
         (fun () ->
            let sty = Ast_helper.Typ.force_poly sty in
-           let cty = transl_simple_type val_env ~fixed:false sty in
+           let cty = transl_simple_type val_env ~closed:false sty in
            let ty = cty.ctyp_type in
            add_method loc val_env label.txt priv Virtual ty sign;
            let field =
@@ -754,7 +754,7 @@ let rec class_field_first_pass self_loc cl_num sign self_scope acc cf =
              | Some sty ->
                  let sty = Ast_helper.Typ.force_poly sty in
                  let cty' =
-                   Typetexp.transl_simple_type val_env ~fixed:false sty
+                   Typetexp.transl_simple_type val_env ~closed:false sty
                  in
                  cty'.ctyp_type
            in
@@ -1058,7 +1058,7 @@ and class_expr_aux cl_num val_env met_env virt self_scope scl =
       if Path.same decl.cty_path unbound_class then
         raise(Error(scl.pcl_loc, val_env, Unbound_class_2 lid.txt));
       let tyl = List.map
-          (fun sty -> transl_simple_type val_env ~fixed:false sty)
+          (fun sty -> transl_simple_type val_env ~closed:false sty)
           styl
       in
       let (params, clty) =

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -3419,7 +3419,7 @@ and type_expect_
   | Pexp_constraint (sarg, sty) ->
       (* Pretend separate = true, 1% slowdown for lablgtk *)
       let cty =
-        with_local_level (fun () -> Typetexp.transl_simple_type env false sty)
+        with_local_level (fun () -> Typetexp.transl_simple_type env ~fixed:false sty)
           ~post:(fun cty -> generalize_structure cty.ctyp_type)
       in
       let ty = cty.ctyp_type in
@@ -3627,7 +3627,7 @@ and type_expect_
       let (id, pres, modl, _, body) =
         with_local_level begin fun () ->
           let modl, pres, id, new_env =
-            Typetexp.with_local_type_variable_scope begin fun () ->
+            Typetexp.TyVarEnv.with_local_scope begin fun () ->
               let modl, md_shape = !type_module env smodl in
               Mtype.lower_nongen lv modl.mod_type;
               let pres =
@@ -3737,7 +3737,7 @@ and type_expect_
             match sty with None -> protect_expansion env ty_expected, None
             | Some sty ->
                 let sty = Ast_helper.Typ.force_poly sty in
-                let cty = Typetexp.transl_simple_type env false sty in
+                let cty = Typetexp.transl_simple_type env ~fixed:false sty in
                 cty.ctyp_type, Some cty
           end
       in
@@ -4826,7 +4826,7 @@ and type_unpacks ?(in_function : (Location.t * type_expr) option)
     | unpack :: rem ->
         with_local_level begin fun () ->
           let name, modl, pres, id, extended_env =
-            Typetexp.with_local_type_variable_scope begin fun () ->
+            Typetexp.TyVarEnv.with_local_scope begin fun () ->
               let name = unpack.tu_name in
               let modl, md_shape =
                 !type_module env
@@ -5492,7 +5492,7 @@ and type_send env loc explanation e met =
 (* Typing of toplevel bindings *)
 
 let type_binding env rec_flag spat_sexp_list =
-  Typetexp.reset_type_variables();
+  Typetexp.TyVarEnv.reset ();
   let (pat_exp_list, new_env, _unpacks) =
     type_let
       ~check:(fun s -> Warnings.Unused_value_declaration s)
@@ -5510,7 +5510,7 @@ let type_let existential_ctx env rec_flag spat_sexp_list =
 (* Typing of toplevel expressions *)
 
 let type_expression env sexp =
-  Typetexp.reset_type_variables();
+  Typetexp.TyVarEnv.reset();
   let exp =
     with_local_level (fun () -> type_exp env sexp)
       ~post:(may_lower_contravariant_then_generalize env)

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -3420,7 +3420,7 @@ and type_expect_
       (* Pretend separate = true, 1% slowdown for lablgtk *)
       let cty =
         with_local_level begin fun () ->
-          Typetexp.transl_simple_type env ~fixed:false sty
+          Typetexp.transl_simple_type env ~closed:false sty
         end
         ~post:(fun cty -> generalize_structure cty.ctyp_type)
       in
@@ -3739,7 +3739,7 @@ and type_expect_
             match sty with None -> protect_expansion env ty_expected, None
             | Some sty ->
                 let sty = Ast_helper.Typ.force_poly sty in
-                let cty = Typetexp.transl_simple_type env ~fixed:false sty in
+                let cty = Typetexp.transl_simple_type env ~closed:false sty in
                 cty.ctyp_type, Some cty
           end
       in

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -3419,8 +3419,10 @@ and type_expect_
   | Pexp_constraint (sarg, sty) ->
       (* Pretend separate = true, 1% slowdown for lablgtk *)
       let cty =
-        with_local_level (fun () -> Typetexp.transl_simple_type env ~fixed:false sty)
-          ~post:(fun cty -> generalize_structure cty.ctyp_type)
+        with_local_level begin fun () ->
+          Typetexp.transl_simple_type env ~fixed:false sty
+        end
+        ~post:(fun cty -> generalize_structure cty.ctyp_type)
       in
       let ty = cty.ctyp_type in
       let (arg, ty') = (type_argument env sarg ty (instance ty), instance ty) in

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -308,7 +308,7 @@ let make_constructor env loc type_path type_params svars sargs sret_type =
         ~post: begin fun (_, _, args, ret_type, univars) ->
           Btype.iter_type_expr_cstr_args Ctype.generalize args;
           Ctype.generalize ret_type;
-          let _vars = instance_poly_univars env loc univars in
+          let _vars = TyVarEnv.instance_poly_univars env loc univars in
           let set_level t = Ctype.enforce_current_level env t in
           Btype.iter_type_expr_cstr_args set_level args;
           set_level ret_type;

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -229,7 +229,7 @@ let transl_labels env univars closed lbls =
     Builtin_attributes.warning_scope attrs
       (fun () ->
          let arg = Ast_helper.Typ.force_poly arg in
-         let cty = transl_simple_type env ?univars ~fixed:closed arg in
+         let cty = transl_simple_type env ?univars ~closed arg in
          {ld_id = Ident.create_local name.txt;
           ld_name = name; ld_mutable = mut;
           ld_type = cty; ld_loc = loc; ld_attributes = attrs}
@@ -254,7 +254,7 @@ let transl_labels env univars closed lbls =
 
 let transl_constructor_arguments env univars closed = function
   | Pcstr_tuple l ->
-      let l = List.map (transl_simple_type env ?univars ~fixed:closed) l in
+      let l = List.map (transl_simple_type env ?univars ~closed) l in
       Types.Cstr_tuple (List.map (fun t -> t.ctyp_type) l),
       Cstr_tuple l
   | Pcstr_record l ->
@@ -285,7 +285,7 @@ let make_constructor env loc type_path type_params svars sargs sret_type =
             transl_constructor_arguments env univars closed sargs
           in
           let tret_type =
-            transl_simple_type env ?univars ~fixed:closed sret_type in
+            transl_simple_type env ?univars ~closed sret_type in
           let ret_type = tret_type.ctyp_type in
           (* TODO add back type_path as a parameter ? *)
           begin match get_desc ret_type with
@@ -325,8 +325,8 @@ let transl_declaration env sdecl (id, uid) =
   let params = List.map (fun (cty, _) -> cty.ctyp_type) tparams in
   let cstrs = List.map
     (fun (sty, sty', loc) ->
-      transl_simple_type env ~fixed:false sty,
-      transl_simple_type env ~fixed:false sty', loc)
+      transl_simple_type env ~closed:false sty,
+      transl_simple_type env ~closed:false sty', loc)
     sdecl.ptype_cstrs
   in
   let unboxed_attr = get_unboxed_from_attributes sdecl in
@@ -441,7 +441,7 @@ let transl_declaration env sdecl (id, uid) =
         None -> None, None
       | Some sty ->
         let no_row = not (is_fixed_type sdecl) in
-        let cty = transl_simple_type env ~fixed:no_row sty in
+        let cty = transl_simple_type env ~closed:no_row sty in
         Some cty, Some cty.ctyp_type
     in
     let arity = List.length params in
@@ -1499,8 +1499,8 @@ let transl_with_constraint id ?fixed_row_path ~sig_env ~sig_decl ~outer_env
   let arity = List.length params in
   let constraints =
     List.map (fun (ty, ty', loc) ->
-      let cty = transl_simple_type env ~fixed:false ty in
-      let cty' = transl_simple_type env ~fixed:false ty' in
+      let cty = transl_simple_type env ~closed:false ty in
+      let cty' = transl_simple_type env ~closed:false ty' in
       (* Note: We delay the unification of those constraints
          after the unification of parameters, so that clashing
          constraints report an error on the constraint location
@@ -1512,7 +1512,7 @@ let transl_with_constraint id ?fixed_row_path ~sig_env ~sig_decl ~outer_env
   let (tman, man) =  match sdecl.ptype_manifest with
       None -> None, None
     | Some sty ->
-        let cty = transl_simple_type env ~fixed:no_row sty in
+        let cty = transl_simple_type env ~closed:no_row sty in
         Some cty, Some cty.ctyp_type
   in
   (* In the second part, we check the consistency between the two

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -284,7 +284,8 @@ let make_constructor env loc type_path type_params svars sargs sret_type =
           let args, targs =
             transl_constructor_arguments env univars closed sargs
           in
-          let tret_type = transl_simple_type env ?univars ~fixed:closed sret_type in
+          let tret_type =
+            transl_simple_type env ?univars ~fixed:closed sret_type in
           let ret_type = tret_type.ctyp_type in
           (* TODO add back type_path as a parameter ? *)
           begin match get_desc ret_type with

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -229,7 +229,7 @@ let transl_labels env univars closed lbls =
     Builtin_attributes.warning_scope attrs
       (fun () ->
          let arg = Ast_helper.Typ.force_poly arg in
-         let cty = transl_simple_type env ?univars closed arg in
+         let cty = transl_simple_type env ?univars ~fixed:closed arg in
          {ld_id = Ident.create_local name.txt;
           ld_name = name; ld_mutable = mut;
           ld_type = cty; ld_loc = loc; ld_attributes = attrs}
@@ -254,7 +254,7 @@ let transl_labels env univars closed lbls =
 
 let transl_constructor_arguments env univars closed = function
   | Pcstr_tuple l ->
-      let l = List.map (transl_simple_type env ?univars closed) l in
+      let l = List.map (transl_simple_type env ?univars ~fixed:closed) l in
       Types.Cstr_tuple (List.map (fun t -> t.ctyp_type) l),
       Cstr_tuple l
   | Pcstr_record l ->
@@ -273,18 +273,18 @@ let make_constructor env loc type_path type_params svars sargs sret_type =
       (* if it's a generalized constructor we must first narrow and
          then widen so as to not introduce any new constraints *)
       (* narrow and widen are now invoked through wrap_type_variable_scope *)
-      with_local_type_variable_scope begin fun () ->
-      reset_type_variables ();
+      TyVarEnv.with_local_scope begin fun () ->
+      TyVarEnv.reset ();
       let closed = svars <> [] in
       let targs, tret_type, args, ret_type, _univars =
         Ctype.with_local_level_if closed begin fun () ->
           let univar_list =
-            make_poly_univars (List.map (fun v -> v.txt) svars) in
+            TyVarEnv.make_poly_univars (List.map (fun v -> v.txt) svars) in
           let univars = if closed then Some univar_list else None in
           let args, targs =
             transl_constructor_arguments env univars closed sargs
           in
-          let tret_type = transl_simple_type env ?univars closed sret_type in
+          let tret_type = transl_simple_type env ?univars ~fixed:closed sret_type in
           let ret_type = tret_type.ctyp_type in
           (* TODO add back type_path as a parameter ? *)
           begin match get_desc ret_type with
@@ -318,14 +318,14 @@ let make_constructor env loc type_path type_params svars sargs sret_type =
 
 let transl_declaration env sdecl (id, uid) =
   (* Bind type parameters *)
-  reset_type_variables();
+  TyVarEnv.reset();
   Ctype.with_local_level begin fun () ->
   let tparams = make_params env sdecl.ptype_params in
   let params = List.map (fun (cty, _) -> cty.ctyp_type) tparams in
   let cstrs = List.map
     (fun (sty, sty', loc) ->
-      transl_simple_type env false sty,
-      transl_simple_type env false sty', loc)
+      transl_simple_type env ~fixed:false sty,
+      transl_simple_type env ~fixed:false sty', loc)
     sdecl.ptype_cstrs
   in
   let unboxed_attr = get_unboxed_from_attributes sdecl in
@@ -440,7 +440,7 @@ let transl_declaration env sdecl (id, uid) =
         None -> None, None
       | Some sty ->
         let no_row = not (is_fixed_type sdecl) in
-        let cty = transl_simple_type env no_row sty in
+        let cty = transl_simple_type env ~fixed:no_row sty in
         Some cty, Some cty.ctyp_type
     in
     let arity = List.length params in
@@ -1200,9 +1200,9 @@ let transl_type_extension extend env loc styext =
   end;
   let ttype_params, _type_params, constructors =
     (* Note: it would be incorrect to call [create_scope] *after*
-       [reset_type_variables] or after [with_local_level] (see #10010). *)
+       [TyVarEnv.reset] or after [with_local_level] (see #10010). *)
     let scope = Ctype.create_scope () in
-    reset_type_variables();
+    TyVarEnv.reset();
     Ctype.with_local_level begin fun () ->
       let ttype_params = make_params env styext.ptyext_params in
       let type_params = List.map (fun (cty, _) -> cty.ctyp_type) ttype_params in
@@ -1272,7 +1272,7 @@ let transl_type_extension extend env loc styext =
 let transl_exception env sext =
   let ext =
     let scope = Ctype.create_scope () in
-    reset_type_variables();
+    TyVarEnv.reset();
     Ctype.with_local_level
       (fun () ->
         transl_extension_constructor ~scope env
@@ -1487,7 +1487,7 @@ let transl_value_decl env loc valdecl =
 let transl_with_constraint id ?fixed_row_path ~sig_env ~sig_decl ~outer_env
     sdecl =
   Env.mark_type_used sig_decl.type_uid;
-  reset_type_variables();
+  TyVarEnv.reset();
   Ctype.with_local_level begin fun () ->
   (* In the first part of this function, we typecheck the syntactic
      declaration [sdecl] in the outer environment [outer_env]. *)
@@ -1498,8 +1498,8 @@ let transl_with_constraint id ?fixed_row_path ~sig_env ~sig_decl ~outer_env
   let arity = List.length params in
   let constraints =
     List.map (fun (ty, ty', loc) ->
-      let cty = transl_simple_type env false ty in
-      let cty' = transl_simple_type env false ty' in
+      let cty = transl_simple_type env ~fixed:false ty in
+      let cty' = transl_simple_type env ~fixed:false ty' in
       (* Note: We delay the unification of those constraints
          after the unification of parameters, so that clashing
          constraints report an error on the constraint location
@@ -1511,7 +1511,7 @@ let transl_with_constraint id ?fixed_row_path ~sig_env ~sig_decl ~outer_env
   let (tman, man) =  match sdecl.ptype_manifest with
       None -> None, None
     | Some sty ->
-        let cty = transl_simple_type env no_row sty in
+        let cty = transl_simple_type env ~fixed:no_row sty in
         Some cty, Some cty.ctyp_type
   in
   (* In the second part, we check the consistency between the two

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -2886,7 +2886,7 @@ let lookup_type_in_sig sg =
 let type_package env m p fl =
   (* Same as Pexp_letmodule *)
   let modl, scope =
-    Typetexp.with_local_type_variable_scope begin fun () ->
+    Typetexp.TyVarEnv.with_local_scope begin fun () ->
       (* type the module and create a scope in a raised level *)
       Ctype.with_local_level begin fun () ->
         let modl, _mod_shape = type_module env m in

--- a/typing/typetexp.ml
+++ b/typing/typetexp.ml
@@ -222,7 +222,10 @@ end = struct
     try
       List.assoc name !univars
     with Not_found ->
-      fst (TyVarMap.find name !used_variables)
+      instance (fst (TyVarMap.find name !used_variables))
+      (* This call to instance might be redundant; all variables
+         inserted into [used_variables] are non-generic, but some
+         might get generalized. *)
 
   let remember_used name v loc =
     assert (not_generic v);

--- a/typing/typetexp.ml
+++ b/typing/typetexp.ml
@@ -27,7 +27,8 @@ open Ctype
 exception Already_bound
 
 type error =
-    Unbound_type_variable of string
+  | Unbound_type_variable of string * string list
+  | No_type_wildcards
   | Undefined_type_constructor of Path.t
   | Type_arity_mismatch of Longident.t * int * int
   | Bound_type_variable of string
@@ -50,8 +51,159 @@ type error =
 exception Error of Location.t * Env.t * error
 exception Error_forward of Location.error
 
-(** Map indexed by type variable names. *)
-module TyVarMap = Misc.Stdlib.String.Map
+module TyVarEnv : sig
+  val reset : unit -> unit
+  val is_in_scope : string -> bool
+  val add : string -> type_expr -> unit
+
+  val with_local_scope : (unit -> 'a) -> 'a
+
+  type poly_univars
+  val new_pre_univar : ?name:string -> unit -> type_expr
+  val add_pre_univar : type_expr -> unit
+  val collect_pre_univars : (unit -> 'a) -> 'a * type_expr list
+
+  val with_univars : poly_univars -> (unit -> 'a) -> 'a
+  val make_poly_univars : string list -> poly_univars
+  val check_poly_univars : Env.t -> Location.t -> poly_univars -> type_expr list
+
+  val reset_locals : ?univars:poly_univars -> unit -> unit
+  val lookup_local : string -> type_expr
+  val remember_used : string -> type_expr -> Location.t -> unit
+  val globalize_used_variables : globals_only:bool -> Env.t ->
+    fixed:bool -> unit -> unit
+end = struct
+  (** Map indexed by type variable names. *)
+  module TyVarMap = Misc.Stdlib.String.Map
+
+  let type_variables = ref (TyVarMap.empty : type_expr TyVarMap.t)
+  let univars        = ref ([] : (string * type_expr) list)
+  let pre_univars    = ref ([] : type_expr list)
+  let used_variables = ref (TyVarMap.empty : (type_expr * Location.t) TyVarMap.t)
+
+  let reset () =
+    reset_global_level ();
+    Ctype.reset_reified_var_counter ();
+    type_variables := TyVarMap.empty
+
+  let is_in_scope name =
+    TyVarMap.mem name !type_variables
+
+  let add name v =
+    type_variables := TyVarMap.add name v !type_variables
+
+  let narrow () =
+    (increase_global_level (), !type_variables)
+
+  let widen (gl, tv) =
+    restore_global_level gl;
+    type_variables := tv
+
+  let with_local_scope f =
+   let context = narrow () in
+   Fun.protect
+     f
+     ~finally:(fun () -> widen context)
+
+  (* throws Not_found if the variable is not in scope *)
+  let lookup_global_type_variable name =
+    TyVarMap.find name !type_variables
+
+  let get_in_scope_names () =
+    let add_name name _ l = if name = "_" then l else ("'" ^ name) :: l in
+    TyVarMap.fold add_name !type_variables []
+
+  (*****)
+  type poly_univars = (string * type_expr) list
+
+  let add_pre_univar tv =
+    pre_univars := tv :: !pre_univars
+
+  let new_pre_univar ?name () =
+    let v = newvar ?name () in
+    add_pre_univar v;
+    v
+
+  let collect_pre_univars f =
+    pre_univars := [];
+    let result = f () in
+    let univs =
+      List.fold_left
+        (fun acc v ->
+           match get_desc v with
+           | Tvar name when get_level v = Btype.generic_level ->
+               set_type_desc v (Tunivar name);
+               v :: acc
+           | _ -> acc)
+        [] !pre_univars in
+    result, univs
+
+  let with_univars new_ones f =
+    let old_univars = !univars in
+    univars := new_ones @ !univars;
+    Fun.protect
+      f
+      ~finally:(fun () -> univars := old_univars)
+
+  let make_poly_univars vars =
+    List.map (fun name -> name, newvar ~name ()) vars
+
+  let check_poly_univars env loc vars =
+    vars |> List.iter (fun (_, v) -> generalize v);
+    vars |> List.map (fun (name, ty1) ->
+      let v = Btype.proxy ty1 in
+      begin match get_desc v with
+      | Tvar name when get_level v = Btype.generic_level ->
+         set_type_desc v (Tunivar name)
+      | _ ->
+         raise (Error (loc, env, Cannot_quantify(name, v)))
+      end;
+      v)
+
+  (*****)
+  let reset_locals ?univars:(uvs=[]) () =
+    univars := uvs;
+    used_variables := TyVarMap.empty
+
+  (* throws Not_found if the variable is not in scope *)
+  let lookup_local name =
+    let v =
+      try
+        List.assoc name !univars
+      with Not_found ->
+        fst (TyVarMap.find name !used_variables)
+    in
+    instance v
+
+  let remember_used name v loc =
+    used_variables := TyVarMap.add name (v, loc) !used_variables
+
+  let globalize_used_variables ~globals_only env ~fixed =
+    let r = ref [] in
+    TyVarMap.iter
+      (fun name (ty, loc) ->
+        if not globals_only || is_in_scope name then
+          let v = new_global_var () in
+          let snap = Btype.snapshot () in
+          if try unify env v ty; true with _ -> Btype.backtrack snap; false
+          then try
+            r := (loc, v, lookup_global_type_variable name) :: !r
+          with Not_found ->
+            if fixed && Btype.is_Tvar ty then
+              raise(Error(loc, env,
+                          Unbound_type_variable ("'"^name, get_in_scope_names ())));
+            let v2 = new_global_var () in
+            r := (loc, v, v2) :: !r;
+            add name v2)
+      !used_variables;
+    used_variables := TyVarMap.empty;
+    fun () ->
+      List.iter
+        (function (loc, t1, t2) ->
+          try unify env t1 t2 with Unify err ->
+            raise (Error(loc, env, Type_mismatch err)))
+        !r
+end
 
 (* Support for first-class modules. *)
 
@@ -85,29 +237,6 @@ let create_package_mty loc p l =
 
 (* Translation of type expressions *)
 
-let type_variables = ref (TyVarMap.empty : type_expr TyVarMap.t)
-let univars        = ref ([] : (string * type_expr) list)
-let pre_univars    = ref ([] : type_expr list)
-let used_variables = ref (TyVarMap.empty : (type_expr * Location.t) TyVarMap.t)
-
-let reset_type_variables () =
-  reset_global_level ();
-  Ctype.reset_reified_var_counter ();
-  type_variables := TyVarMap.empty
-
-let narrow () =
-  (increase_global_level (), !type_variables)
-
-let widen (gl, tv) =
-  restore_global_level gl;
-  type_variables := tv
-
-let with_local_type_variable_scope f =
-  let context = narrow () in
-  let r = f () in
-  widen context;
-  r
-
 let generalize_ctyp typ = generalize typ.ctyp_type
 
 let strict_ident c = (c = '_' || c >= 'a' && c <= 'z' || c >= 'A' && c <= 'Z')
@@ -122,12 +251,6 @@ let new_global_var ?name () =
 let newvar ?name () =
   newvar ?name:(validate_name name) ()
 
-let type_variable loc name =
-  try
-    TyVarMap.find name !type_variables
-  with Not_found ->
-    raise(Error(loc, Env.empty, Unbound_type_variable ("'" ^ name)))
-
 let valid_tyvar_name name =
   name <> "" && name.[0] <> '_'
 
@@ -140,15 +263,13 @@ let transl_type_param env styp =
           ctyp_loc = loc; ctyp_attributes = styp.ptyp_attributes; }
   | Ptyp_var name ->
       let ty =
-        try
           if not (valid_tyvar_name name) then
             raise (Error (loc, Env.empty, Invalid_variable_name ("'" ^ name)));
-          ignore (TyVarMap.find name !type_variables);
-          raise Already_bound
-        with Not_found ->
+          if TyVarEnv.is_in_scope name then
+            raise Already_bound;
           let v = new_global_var ~name () in
-            type_variables := TyVarMap.add name v !type_variables;
-            v
+          TyVarEnv.add name v;
+          v
       in
         { ctyp_desc = Ttyp_var name; ctyp_type = ty; ctyp_env = env;
           ctyp_loc = loc; ctyp_attributes = styp.ptyp_attributes; }
@@ -161,27 +282,8 @@ let transl_type_param env styp =
     (fun () -> transl_type_param env styp)
 
 
-let new_pre_univar ?name () =
-  let v = newvar ?name () in pre_univars := v :: !pre_univars; v
-
-type poly_univars = (string * type_expr) list
-let make_poly_univars vars =
-  List.map (fun name -> name, newvar ~name ()) vars
-
-let check_poly_univars env loc vars =
-  vars |> List.iter (fun (_, v) -> generalize v);
-  vars |> List.map (fun (name, ty1) ->
-    let v = Btype.proxy ty1 in
-    begin match get_desc v with
-    | Tvar name when get_level v = Btype.generic_level ->
-       set_type_desc v (Tunivar name)
-    | _ ->
-       raise (Error (loc, env, Cannot_quantify(name, v)))
-    end;
-    v)
-
 let instance_poly_univars env loc vars =
-  let vs = check_poly_univars env loc vars in
+  let vs = TyVarEnv.check_poly_univars env loc vars in
   vs |> List.iter (fun v ->
     match get_desc v with
     | Tunivar name ->
@@ -205,9 +307,9 @@ and transl_type_aux env policy styp =
   match styp.ptyp_desc with
     Ptyp_any ->
       let ty =
-        if policy = Univars then new_pre_univar () else
+        if policy = Univars then TyVarEnv.new_pre_univar () else
           if policy = Fixed then
-            raise (Error (styp.ptyp_loc, env, Unbound_type_variable "_"))
+            raise (Error (styp.ptyp_loc, env, No_type_wildcards))
           else newvar ()
       in
       ctyp Ttyp_any ty
@@ -216,14 +318,12 @@ and transl_type_aux env policy styp =
       if not (valid_tyvar_name name) then
         raise (Error (styp.ptyp_loc, env, Invalid_variable_name ("'" ^ name)));
       begin try
-        instance (List.assoc name !univars)
-      with Not_found -> try
-        instance (fst (TyVarMap.find name !used_variables))
+        TyVarEnv.lookup_local name
       with Not_found ->
         let v =
-          if policy = Univars then new_pre_univar ~name () else newvar ~name ()
+          if policy = Univars then TyVarEnv.new_pre_univar ~name () else newvar ~name ()
         in
-        used_variables := TyVarMap.add name (v, styp.ptyp_loc) !used_variables;
+        TyVarEnv.remember_used name v styp.ptyp_loc;
         v
       end
     in
@@ -300,7 +400,7 @@ and transl_type_aux env policy styp =
       let ty = match get_desc ty with
         | Tobject (fi, _) ->
             let _, tv = flatten_fields fi in
-            if policy = Univars then pre_univars := tv :: !pre_univars;
+            if policy = Univars then TyVarEnv.add_pre_univar tv;
             ty
         | _ ->
             assert false
@@ -309,11 +409,7 @@ and transl_type_aux env policy styp =
   | Ptyp_alias(st, alias) ->
       let cty =
         try
-          let t =
-            try List.assoc alias !univars
-            with Not_found ->
-              instance (fst(TyVarMap.find alias !used_variables))
-          in
+          let t = TyVarEnv.lookup_local alias in
           let ty = transl_type env policy st in
           begin try unify_var env t ty.ctyp_type with Unify err ->
             let err = Errortrace.swap_unification_error err in
@@ -324,8 +420,7 @@ and transl_type_aux env policy styp =
           let t, ty =
             with_local_level_if_principal begin fun () ->
               let t = newvar () in
-              used_variables :=
-                TyVarMap.add alias (t, styp.ptyp_loc) !used_variables;
+              TyVarEnv.remember_used alias t styp.ptyp_loc;
               let ty = transl_type env policy st in
               begin try unify_var env t ty.ctyp_type with Unify err ->
                 let err = Errortrace.swap_unification_error err in
@@ -436,7 +531,7 @@ and transl_type_aux env policy styp =
       in
       let more =
         if Btype.static_row (make_row (newvar ())) then newty Tnil else
-        if policy = Univars then new_pre_univar () else newvar ()
+        if policy = Univars then TyVarEnv.new_pre_univar () else newvar ()
       in
       let ty = newty (Tvariant (make_row more)) in
       ctyp (Ttyp_variant (tfields, closed, present)) ty
@@ -444,17 +539,16 @@ and transl_type_aux env policy styp =
       let vars = List.map (fun v -> v.txt) vars in
       let new_univars, cty =
         with_local_level begin fun () ->
-          let new_univars = make_poly_univars vars in
-          let old_univars = !univars in
-          univars := new_univars @ !univars;
-          let cty = transl_type env policy st in
-          univars := old_univars;
+          let new_univars = TyVarEnv.make_poly_univars vars in
+          let cty = TyVarEnv.with_univars new_univars begin fun () ->
+            transl_type env policy st
+          end in
           (new_univars, cty)
         end
         ~post:(fun (_,cty) -> generalize_ctyp cty)
       in
       let ty = cty.ctyp_type in
-      let ty_list = check_poly_univars env styp.ptyp_loc new_univars in
+      let ty_list = TyVarEnv.check_poly_univars env styp.ptyp_loc new_univars in
       let ty_list = List.filter (fun v -> deep_occur v ty) ty_list in
       let ty' = Btype.newgenty (Tpoly(ty, ty_list)) in
       unify_var env (newvar()) ty';
@@ -464,7 +558,7 @@ and transl_type_aux env policy styp =
       let l = sort_constraints_no_duplicates loc env l in
       let mty = create_package_mty loc p l in
       let mty =
-        with_local_type_variable_scope (fun () -> !transl_modtype env mty) in
+        TyVarEnv.with_local_scope (fun () -> !transl_modtype env mty) in
       let ptys = List.map (fun (s, pty) ->
                              s, transl_type env policy pty
                           ) l in
@@ -540,7 +634,7 @@ and transl_fields env policy o fields =
   let ty_init =
      match o, policy with
      | Closed, _ -> newty Tnil
-     | Open, Univars -> new_pre_univar ()
+     | Open, Univars -> TyVarEnv.new_pre_univar ()
      | Open, _ -> newvar () in
   let ty = List.fold_left (fun ty (s, ty') ->
       newty (Tfield (s, field_public, ty', ty))) ty_init fields in
@@ -575,69 +669,31 @@ let make_fixed_univars ty =
   make_fixed_univars ty;
   Btype.unmark_type ty
 
-let globalize_used_variables env fixed =
-  let r = ref [] in
-  TyVarMap.iter
-    (fun name (ty, loc) ->
-      let v = new_global_var () in
-      let snap = Btype.snapshot () in
-      if try unify env v ty; true with _ -> Btype.backtrack snap; false
-      then try
-        r := (loc, v,  TyVarMap.find name !type_variables) :: !r
-      with Not_found ->
-        if fixed && Btype.is_Tvar ty then
-          raise(Error(loc, env, Unbound_type_variable ("'"^name)));
-        let v2 = new_global_var () in
-        r := (loc, v, v2) :: !r;
-        type_variables := TyVarMap.add name v2 !type_variables)
-    !used_variables;
-  used_variables := TyVarMap.empty;
-  fun () ->
-    List.iter
-      (function (loc, t1, t2) ->
-        try unify env t1 t2 with Unify err ->
-          raise (Error(loc, env, Type_mismatch err)))
-      !r
-
-let transl_simple_type env ?univars:(uvs=[]) fixed styp =
-  univars := uvs; used_variables := TyVarMap.empty;
+let transl_simple_type env ?univars ~fixed styp =
+  TyVarEnv.reset_locals ?univars ();
   let typ = transl_type env (if fixed then Fixed else Extensible) styp in
-  globalize_used_variables env fixed ();
+  TyVarEnv.globalize_used_variables ~globals_only:false env ~fixed ();
   make_fixed_univars typ.ctyp_type;
   typ
 
 let transl_simple_type_univars env styp =
-  univars := []; used_variables := TyVarMap.empty; pre_univars := [];
-  let typ =
-    with_local_level ~post:generalize_ctyp begin fun () ->
-      let typ = transl_type env Univars styp in
-      (* Only keep already global variables in used_variables *)
-      let new_variables = !used_variables in
-      used_variables := TyVarMap.empty;
-      TyVarMap.iter
-        (fun name p ->
-          if TyVarMap.mem name !type_variables then
-            used_variables := TyVarMap.add name p !used_variables)
-        new_variables;
-      globalize_used_variables env false ();
-      typ
-    end
-  in
-  let univs =
-    List.fold_left
-      (fun acc v ->
-        match get_desc v with
-          Tvar name when get_level v = Btype.generic_level ->
-            set_type_desc v (Tunivar name); v :: acc
-        | _ -> acc)
-      [] !pre_univars
-  in
+  TyVarEnv.reset_locals ();
+  let typ, univs =
+    TyVarEnv.collect_pre_univars begin fun () ->
+      with_local_level ~post:generalize_ctyp begin fun () ->
+        let typ = transl_type env Univars styp in
+        (* Globalize only local occurrences of variables that are already in global
+           scope; others will be univars and dealt with in make_fixed_univars. *)
+        TyVarEnv.globalize_used_variables ~globals_only:true env ~fixed:false ();
+        typ
+      end
+  end in
   make_fixed_univars typ.ctyp_type;
     { typ with ctyp_type =
         instance (Btype.newgenty (Tpoly (typ.ctyp_type, univs))) }
 
 let transl_simple_type_delayed env styp =
-  univars := []; used_variables := TyVarMap.empty;
+  TyVarEnv.reset_locals ();
   let typ, force =
     with_local_level begin fun () ->
       let typ = transl_type env Extensible styp in
@@ -645,7 +701,8 @@ let transl_simple_type_delayed env styp =
       (* This brings the used variables to the global level, but doesn't link
          them to their other occurrences just yet. This will be done when
          [force] is  called. *)
-      let force = globalize_used_variables env false in
+      let force = TyVarEnv.globalize_used_variables
+                    ~globals_only:false env ~fixed:false in
       (typ, force)
     end
     (* Generalize everything except the variables that were just globalized. *)
@@ -654,14 +711,14 @@ let transl_simple_type_delayed env styp =
   (typ, instance typ.ctyp_type, force)
 
 let transl_type_scheme env styp =
-  reset_type_variables();
+  TyVarEnv.reset ();
   match styp.ptyp_desc with
   | Ptyp_poly (vars, st) ->
      let vars = List.map (fun v -> v.txt) vars in
      let univars, typ =
        with_local_level begin fun () ->
-         let univars = make_poly_univars vars in
-         let typ = transl_simple_type env ~univars true st in
+         let univars = TyVarEnv.make_poly_univars vars in
+         let typ = transl_simple_type env ~univars ~fixed:true st in
          (univars, typ)
        end
        ~post:(fun (_,typ) -> generalize_ctyp typ)
@@ -673,7 +730,7 @@ let transl_type_scheme env styp =
        ctyp_loc = styp.ptyp_loc;
        ctyp_attributes = styp.ptyp_attributes }
   | _ ->
-      with_local_level (fun () -> transl_simple_type env false styp)
+      with_local_level (fun () -> transl_simple_type env ~fixed:false styp)
         ~post:generalize_ctyp
 
 
@@ -683,12 +740,12 @@ open Format
 open Printtyp
 
 let report_error env ppf = function
-  | Unbound_type_variable name ->
-      let add_name name _ l = if name = "_" then l else ("'" ^ name) :: l in
-      let names = TyVarMap.fold add_name !type_variables [] in
+  | Unbound_type_variable (name, in_scope_names) ->
     fprintf ppf "The type variable %s is unbound in this type declaration.@ %a"
       name
-      did_you_mean (fun () -> Misc.spellcheck names name )
+      did_you_mean (fun () -> Misc.spellcheck in_scope_names name )
+  | No_type_wildcards ->
+    fprintf ppf "A type wildcard \"_\" is not allowed here."
   | Undefined_type_constructor p ->
     fprintf ppf "The type constructor@ %a@ is not yet completely defined"
       path p

--- a/typing/typetexp.ml
+++ b/typing/typetexp.ml
@@ -118,15 +118,11 @@ end = struct
 
   (* These are the "global" type variables: they were in scope before
      we started processing the current type.
-
-     INVARIANT: No types at generic_level.
   *)
   let type_variables = ref (TyVarMap.empty : type_expr TyVarMap.t)
 
   (* These are variables that have been used in the currently-being-checked
      type.
-
-     INVARIANT: No types at generic_level.
   *)
   let used_variables =
     ref (TyVarMap.empty : (type_expr * Location.t) TyVarMap.t)
@@ -136,8 +132,6 @@ end = struct
      just birth them as univars? Because they might successfully unify with a
      row variable in the ['a. < m : ty; .. > as 'a] idiom.  They are like the
      [used_variables], but will not be globalized in [globalize_used_variables].
-
-     INVARIANT: No types at generic_level.
   *)
   let univars = ref ([] : (string * type_expr) list)
   let assert_univars uvs =
@@ -146,8 +140,6 @@ end = struct
   (* These are variables that will become univars when we're done with the
      current type. Used to force free variables in method types to become
      univars.
-
-     INVARIANT: No types at generic_level.
   *)
   let pre_univars = ref ([] : type_expr list)
 

--- a/typing/typetexp.ml
+++ b/typing/typetexp.ml
@@ -107,8 +107,15 @@ module TyVarEnv : sig
     (* remember that a given name is bound to a given type *)
 
   val globalize_used_variables : policy -> Env.t -> unit -> unit
-    (* after finishing with a type signature, add used variables to the
-       global type variable scope *)
+   (* after finishing with a type signature, used variables are unified to the
+      corresponding global type variables if they exist. Otherwise, in function
+      of the policy, fresh used variables are either
+        - added to the global type variable scope if they are not longer
+        variables under the {!fixed_policy}
+        - added to the global type variable scope under the {!extensible_policy}
+        - expected to be collected later by a call to `collect_univar` under the
+        {!universal_policy}
+   *)
 
 end = struct
   (** Map indexed by type variable names. *)

--- a/typing/typetexp.mli
+++ b/typing/typetexp.mli
@@ -48,7 +48,7 @@ end
 val valid_tyvar_name : string -> bool
 
 val transl_simple_type:
-        Env.t -> ?univars:TyVarEnv.poly_univars -> fixed:bool
+        Env.t -> ?univars:TyVarEnv.poly_univars -> closed:bool
         -> Parsetree.core_type -> Typedtree.core_type
 val transl_simple_type_univars:
         Env.t -> Parsetree.core_type -> Typedtree.core_type

--- a/typing/typetexp.mli
+++ b/typing/typetexp.mli
@@ -37,14 +37,15 @@ module TyVarEnv : sig
     (** Verify that the given univars are universally quantified,
        and return the list of variables. The type in which the
        univars are used must be generalised *)
+
+  val instance_poly_univars :
+     Env.t -> Location.t -> poly_univars -> type_expr list
+    (** Same as [check_poly_univars], but instantiates the resulting
+       type scheme (i.e. variables become Tvar rather than Tunivar) *)
+
 end
 
 val valid_tyvar_name : string -> bool
-
-val instance_poly_univars :
-   Env.t -> Location.t -> TyVarEnv.poly_univars -> type_expr list
-  (* Same as [check_poly_univars], but instantiates the resulting
-     type scheme (i.e. variables become Tvar rather than Tunivar) *)
 
 val transl_simple_type:
         Env.t -> ?univars:TyVarEnv.poly_univars -> fixed:bool

--- a/typing/typetexp.mli
+++ b/typing/typetexp.mli
@@ -18,18 +18,23 @@
 open Types
 
 module TyVarEnv : sig
+  (* this is just the subset of [TyVarEnv] that is needed outside
+     of [Typetexp]. See the ml file for more. *)
+
   val reset : unit -> unit
-  (* removes all type variables from scope *)
+  (** removes all type variables from scope *)
 
   val with_local_scope : (unit -> 'a) -> 'a
-  (* Evaluate in a narrowed type-variable scope *)
+  (** Evaluate in a narrowed type-variable scope *)
 
   type poly_univars
   val make_poly_univars : string list -> poly_univars
-    (* Create a set of univars with given names *)
+    (** remember that a list of strings connotes univars; this must
+        always be paired with a [check_poly_univars]. *)
+
   val check_poly_univars :
      Env.t -> Location.t -> poly_univars -> type_expr list
-    (* Verify that the given univars are universally quantified,
+    (** Verify that the given univars are universally quantified,
        and return the list of variables. The type in which the
        univars are used must be generalised *)
 end


### PR DESCRIPTION
In part of my work in adding unboxed types within https://github.com/ocaml-flambda/ocaml-jst, I wanted to refactor a bit about how type variables are dealt with while translating types. The three commits in this PR are just a refactor, with no intended (or observed) change in behavior. Each commit can be understood independently, but I prefer going with all three.

This being my first contribution, I'm particularly keen to hear style-oriented feedback. Is this a good move? Have I conformed to local conventions?

Interestingly, my original work within ocaml-jst included two more earlier commits, now completely subsumed by #11536. It's nice to know several of us are working in the same direction!