### PR TITLE
An error message for n-body signature avoidance issues.

### DIFF
--- a/Changes
+++ b/Changes
@@ -388,6 +388,11 @@ Working version
   error messages (eg: `Illegal shadowing of included type t/2 by t`)
   (Florian Angeletti, review by Jules Aguillon)
 
+- #?????: report all involved `include`s in complex signature avoidance issues
+  when it is a set of `include`s which is responsible for making the type of an
+  exported value non-anchorable to an exported type.
+  (Florian Angeletti, review by ????)
+
 ### Internal/compiler-libs changes:
 
 - #11990: Improve comments and macros around frame descriptors.

--- a/parsing/location.ml
+++ b/parsing/location.ml
@@ -70,6 +70,22 @@ type 'a loc = {
   loc : t;
 }
 
+let merge l1 l2 = {
+  loc_start = min l1.loc_start l2.loc_start;
+  loc_end = max l1.loc_end l2.loc_end;
+  loc_ghost = l1.loc_ghost && l2.loc_ghost
+}
+
+let union seq =
+  let rec union loc seq = match seq () with
+    | Seq.Nil -> loc
+    | Seq.Cons (x, seq) ->
+        union (merge x loc) seq
+  in
+  match seq () with
+  | Seq.Nil -> none
+  | Seq.Cons(x,seq) -> union x seq
+
 let mkloc txt loc = { txt ; loc }
 let mknoloc txt = mkloc txt none
 

--- a/parsing/location.mli
+++ b/parsing/location.mli
@@ -44,6 +44,9 @@ val is_none : t -> bool
 val in_file : string -> t
 (** Return an empty ghost range located in a given file. *)
 
+val union: t Seq.t -> t
+(** [union seq] is a location covering all locations present in [seq] *)
+
 val init : Lexing.lexbuf -> string -> unit
 (** Set the file name and line number of the [lexbuf] to be the start
     of the named file. *)

--- a/testsuite/tests/shadow_include/n_body_signature_avoidance.ml
+++ b/testsuite/tests/shadow_include/n_body_signature_avoidance.ml
@@ -1,0 +1,72 @@
+(* TEST
+ * expect
+*)
+
+
+
+module type many_t = sig
+  include sig
+    type t (* t/3 *)
+    type a = t option (* a/2 *)
+    val a : a
+  end
+
+  include sig
+    type t (* t/2 *)
+    val eph: t
+  end
+
+  include sig
+    type t (* t *)
+    type b = t option
+    val b : b
+  end
+
+  val eph : unit
+
+  (* this last definition breaks the anchorability of type of a *)
+  type a (* a *)
+end
+[%%expect {|
+Lines 1-23, characters 21-3:
+ 1 | .....................sig
+ 2 |   include sig
+ 3 |     type t (* t/3 *)
+ 4 |     type a = t option (* a/2 *)
+ 5 |     val a : a
+...
+20 |
+21 |   (* this last definition breaks the anchorability of type of a *)
+22 |   type a (* a *)
+23 | end
+Error: Illegal signature: the value a has no valid type
+       once the following type(s) are shadowed: a/2, t/3.
+Lines 2-6, characters 2-5:
+2 | ..include sig
+3 |     type t (* t/3 *)
+4 |     type a = t option (* a/2 *)
+5 |     val a : a
+6 |   end
+  The type a/2 is introduced by this include.
+Lines 2-6, characters 2-5:
+2 | ..include sig
+3 |     type t (* t/3 *)
+4 |     type a = t option (* a/2 *)
+5 |     val a : a
+6 |   end
+  The type t/3 is introduced by this include.
+Line 5, characters 4-13:
+5 |     val a : a
+        ^^^^^^^^^
+  The value a is defined here.
+Lines 8-11, characters 2-5:
+ 8 | ..include sig
+ 9 |     type t (* t/2 *)
+10 |     val eph: t
+11 |   end
+  The type t/3 is shadowed by t/2 here.
+Line 22, characters 2-8:
+22 |   type a (* a *)
+       ^^^^^^
+  The type a/2 is shadowed by a here.
+|}]

--- a/toplevel/byte/topeval.ml
+++ b/toplevel/byte/topeval.ml
@@ -124,7 +124,10 @@ let execute_phrase print_outcome ppf phr =
         Typemod.type_toplevel_phrase oldenv sstr
       in
       if !Clflags.dump_typedtree then Printtyped.implementation ppf str;
-      let sg' = Typemod.Signature_names.simplify newenv sn sg in
+      let loc () =
+        Location.union @@ Seq.map (fun i -> i.pstr_loc) @@ List.to_seq sstr
+      in
+      let sg' = Typemod.Signature_names.simplify newenv sn loc sg in
       ignore (Includemod.signatures ~mark:Mark_positive oldenv sg sg');
       Typecore.force_delayed_checks ();
       let shape = Shape.local_reduce shape in

--- a/toplevel/native/topeval.ml
+++ b/toplevel/native/topeval.ml
@@ -165,7 +165,10 @@ let execute_phrase print_outcome ppf phr =
         Typemod.type_toplevel_phrase oldenv sstr
       in
       if !Clflags.dump_typedtree then Printtyped.implementation ppf str;
-      let sg' = Typemod.Signature_names.simplify newenv names sg in
+      let loc () =
+        Location.union @@ Seq.map (fun i -> i.pstr_loc) @@ List.to_seq sstr
+      in
+      let sg' = Typemod.Signature_names.simplify newenv names loc sg in
       ignore (Includemod.signatures oldenv ~mark:Mark_positive sg sg');
       Typecore.force_delayed_checks ();
       let shape = Shape.local_reduce shape in

--- a/typing/ctype.mli
+++ b/typing/ctype.mli
@@ -390,7 +390,7 @@ val hide_private_methods : Env.t -> class_signature -> unit
 
 val close_class_signature : Env.t -> class_signature -> bool
 
-exception Nondep_cannot_erase of Ident.t
+exception Nondep_cannot_erase of Ident.Set.t
 
 val nondep_type: Env.t -> Ident.t list -> type_expr -> type_expr
         (* Return a type equivalent to the given type but without

--- a/typing/mtype.ml
+++ b/typing/mtype.ml
@@ -187,7 +187,7 @@ let rec nondep_mty_with_presence env va ids pres mty =
           let expansion =
             try Env.find_modtype_expansion p env
             with Not_found ->
-              raise (Ctype.Nondep_cannot_erase id)
+              raise (Ctype.Nondep_cannot_erase (Ident.Set.singleton id))
           in
           nondep_mty_with_presence env va ids pres expansion
       | None -> pres, mty
@@ -198,7 +198,7 @@ let rec nondep_mty_with_presence env va ids pres mty =
           let expansion =
             try Env.find_module p env
             with Not_found ->
-              raise (Ctype.Nondep_cannot_erase id)
+              raise (Ctype.Nondep_cannot_erase (Ident.Set.singleton id))
           in
           nondep_mty_with_presence env va ids Mp_present expansion.md_type
       | None -> pres, mty


### PR DESCRIPTION
This is a follow-up PR for #11910 which is probably mostly useful to offer more context to the simplification in #11910 .

The main objective of this PR is to extend the existing error report for signature avoidance in a fairly uncommon case to avoid a kind of "spooky-error-at-distance" where adding a new type definition can make the compiler raises an error on a seemingly unrelated pair of an `include`  and a type definition that *precedes* the new definition.

To make this clearer, let's first consider the following example of a valid but contrived module type:

```ocaml
module type t = sig
  include sig type t end (* t/3 *)
  include sig type topt = t option end
  val x: topt
  include sig
    type t
    val eph:t
  end (* t/2 *)
  val eph:unit
  type t
end
```
This module type is valid because we can anchor the type of the value `x` to the type `topt`, even after we lose the equality `topt = t option`. However, if we go one step further and hide the type `topt`, we reach a signature avoidance issue:
```ocaml
module type t = sig
  include sig type t (* t/3 *) end 
  include sig type topt = t option end
  val x: topt
  include sig
    type t (* t/2 *)
    val eph:t
  end 
  val eph:unit
  type t
  type topt
end
```
```
Error: Illegal shadowing of included type t/2 by t
       Line 2, characters 2-24:
         Type t/2 came from this include
       Line 4, characters 2-13:
         The value x has no valid type if t/2 is shadowed
```
However, this error message does not point at all to the line we have just added, and instead points to an include which was fine earlier. The reason behind this asymmetry is that when the typechecker tries to anchor the type of the value `x` to an exported type, it goes through various candidate types
```
val x: topt (* invalid: topt  is not exported, let's expand it *) 
val x : t option (* invalid: t  is not exported *)
(* t cannot be expanded, there are no other candidates *)
```
However, the error message only report the last candidate as the lone source of the error. This simplification creates the `spooky-error-at-distance` phenomenon that we observed earlier by hiding the context that the type `topt` was also not available in the exported signature.

To avoid this `spooky-error-at-distance` scenario, this PR proposes that whenever we have eliminated more than one candidates anchor types due to erased types (or module components) we report to the user that we have a signature avoidance issue on the whole module, and points all `include`s involved to the user:
```
File "test.ml", lines 1-12, characters 16-3:
 1 | ................sig
 2 |   include sig type t (* t/3 *) end 
 3 |   include sig type topt = t option end
 4 |   val x: topt
 5 |   include sig
...
 9 |   val eph:unit
10 |   type t
11 |   type topt
12 | end
Error: Illegal signature: the value x has no valid type
       once the following type(s) are shadowed: topt/2, t/3.
File "test.ml", line 2, characters 2-34:
2 |   include sig type t (* t/3 *) end 
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  The type t/3 is introduced by this include.
File "test.ml", line 3, characters 2-38:
3 |   include sig type topt = t option end
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  The type topt/2 is introduced by this include.
File "test.ml", line 4, characters 2-13:
4 |   val x: topt
      ^^^^^^^^^^^
  The value x is defined here.
File "test.ml", lines 5-8, characters 2-5:
5 | ..include sig
6 |     type t (* t/2 *)
7 |     val eph:t
8 |   end.
  The type t/3 is shadowed by t/2 here.
File "test.ml", line 11, characters 2-11:
11 |   type topt
       ^^^^^^^^^
  The type topt/2 is shadowed by topt here.
```
This is a fairly complex error message but for a complex (and hopefully unfrequent) corner cases.

----------
Beyond the specific error, this is quite an interesting use case for error message with many highlighted location. As discussed with @Armael and @gasche, it could be quite interesting for the error message infrastructure to be able to highlight subpart of a code quote to make it possible to inline the problematic `include` locations inside the whole module code quote.

-----
Another interesting point is that as soon as we print the full module type, we may find situation where there are many types (or module components) sharing the same name. This contrasts with the situation in #11910 where the signature avoidance issue was always reduced to a single illegal include, which is a case where we have precisely two components sharing the same name in the scope of the error message.