### PR TITLE
Fix tricky typing bug with type substitutions

### DIFF
--- a/Changes
+++ b/Changes
@@ -973,6 +973,9 @@ Some of those changes will benefit all OCaml packages.
 - #11879: Bugfix for Ctype.nondep_type
   (Stephen Dolan, review by Gabriel Scherer)
 
+- #11931: Fix tricky typing bug with type substitutions
+  (Stephen Dolan, review by Leo White and Jacques Garrigue)
+
 - #12004: Don't ignore function attributes on lambdas with locally abstract
   types.
   (Chris Casinghino, review by Gabriel Scherer)

--- a/testsuite/tests/typing-signatures/regression_tsubst_error.ml
+++ b/testsuite/tests/typing-signatures/regression_tsubst_error.ml
@@ -1,5 +1,5 @@
 (* TEST
-   * expect
+   expect;
 *)
 type t = bool
 module type Subst = sig

--- a/testsuite/tests/typing-signatures/regression_tsubst_error.ml
+++ b/testsuite/tests/typing-signatures/regression_tsubst_error.ml
@@ -1,0 +1,12 @@
+(* TEST
+   * expect
+*)
+type t = bool
+module type Subst = sig
+  type t2 := t
+  type _ s = C : 'a -> (t * t2 * 'a) s
+end
+[%%expect{|
+type t = bool
+module type Subst = sig type _ s = C : 'a -> (t * t * 'a) s end
+|}]

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -1521,6 +1521,7 @@ let subst env level priv abbrev oty params args body =
    care about efficiency here.
 *)
 let apply ?(use_current_level = false) env params body args =
+  simple_abbrevs := Mnil;
   let level = if use_current_level then !current_level else generic_level in
   try
     subst env level Public (ref Mnil) None params args body

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -1528,8 +1528,6 @@ let apply ?(use_current_level = false) env params body args =
   with
     Cannot_subst -> raise Cannot_apply
 
-let () = Subst.ctype_apply_env_empty := apply Env.empty
-
                               (****************************)
                               (*  Abbreviation expansion  *)
                               (****************************)

--- a/typing/subst.mli
+++ b/typing/subst.mli
@@ -84,11 +84,6 @@ val module_declaration: scoping -> t -> module_declaration -> module_declaration
      apply (compose s1 s2) x = apply s2 (apply s1 x) *)
 val compose: t -> t -> t
 
-(* A forward reference to be filled in ctype.ml. *)
-val ctype_apply_env_empty:
-  (type_expr list -> type_expr -> type_expr list -> type_expr) ref
-
-
 module Lazy : sig
   type module_decl =
     {


### PR DESCRIPTION
The following code crashes the compiler with `Fatal error: fold Tsubst`:
```ocaml
type t = bool
module type Subst = sig
  type t2 := t
  type _ s = C : 'a -> (t * t2 * 'a) s
end
```
The bug concerns the cached type expansion abbreviations in `Ctype.simple_abbrevs`. The sequence of events, as far as I can follow it, is:

  1. After typechecking the signature, we have two `simple_abbrevs` entries: `t = bool` and `t2 = t`.
      The three occurrences of `t` (one in `s`, two in simple_abbrevs) are physically equal `type_expr` nodes.  
      The two occurrences of `t2` (one in `s`, one in simple_abbrevs) are physically equal `type_expr` nodes.
  2. We begin applying the substitution `t2 := t` to the definition of `s`, and traverse the tuple `t * t2 * 'a` in `Subst.tyexp`
  3. `Subst.tyexp` visits `t`, sees that there is no transformation to apply, so copies `t`  to a fresh `type_expr` node (also `t`) and mutates the original to be a `Tsubst`.
      **NB**: Since this `t` is shared with `simple_abbrevs`, we now have `t2 = Tsubst ...` in `simple_abbrevs`.
  4. `Subst.tyexp` visits `t2`, sees that it must apply the transformation `t2 := t`, so calls `Ctype.apply`.
  5. `Ctype.apply` tries to expand `t2` by calling `instance_parameterized_type`
  6. `instance_parameterized_type` notices that it has a `simple_abbrevs` to hand, and so expands `t2` not to `t` but to `Tsubst ...`
  7. `Ctype.apply` feeds the result to the unifier, which explodes upon seeing a `Tsubst`.

Since `Ctype.apply` is called from the middle of substitution (during which types are temporarily changed to Tsubst), it seems dangerous to use the shared `simple_abbrevs` cache. So, the patch here is to clear that cache in `apply`.

This makes the issue go away, but I'm not convinced it's the right fix as I barely understand how any of the abbrevs / simple_abbrevs machinery works. Opinions? (cc @garrigue @lpw25)