### PR TITLE
CONTRIBUTING.md: expectations on collective maintenance

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,17 +15,13 @@ how to build the compiler distribution from sources. See
 
 ## Contribution
 
-Modifying its sources is far from the only way to contribute to the
+Modifying the sources is far from the only way to contribute to the
 OCaml distribution. Bug reports (in particular when they come with
 a reproducible example), simple typos or clarifications in the
 documentation also help, and help evaluating and integrating existing
 change proposals also help. Providing good answers on the discussion
 forums, or asking the good questions that highlight deficiencies in
-existing documentations, also help. We currently have more
-contributors willing to propose changes than contributors willing to
-review other people's changes, so more eyes on the existing change
-requests is a good way to increase the integration bandwidth of
-external contributions.
+existing documentations, also help.
 
 There are also many valuable ways to contribute to the wider OCaml
 ecosystem that do not involve changes to the OCaml distribution.
@@ -414,6 +410,52 @@ A major criterion in assessing whether to include an optimisation in
 the compiler is the balance between the increased complexity of the
 compiler code and the expected benefits of the benchmark. Contributors
 are asked to bear this in mind when making submissions.
+
+## Collective maintenance
+
+Proposing changes to the OCaml compiler contribution generates
+"maintenance work" for other people. Maintenance work includes, for
+example:
+
+- reviewing Pull Requests or language change proposals,
+
+- considering change suggestions and giving feedback to turn them into
+  actionable issues,
+
+- implementing bug fixes or feature requests of general interest,
+
+- improving the documentation of the tools or other usability aspects,
+
+- or documenting or clarifying the codebase to preserve and improve
+  our ability to change it in the future.
+
+Doing this collective maintenance work is a selfless task, and we
+typically have much fewer people willing to to do it than people
+willing to submit new language features or generally evolve the
+codebase for their own specific needs. Without a collective effort to
+participate, we end up with a handful of people doing the vast
+majority of this collective maintenance work. This is exhausting, does
+not scale, and slows down the pace of improvement of the compiler
+distribution.
+
+To keep a healthy open source project, we need the total maintenance
+work performed by all contributors to scale proportionally with the
+total demand for maintenance work they generate. This can only work if
+as many contributors as possible perform some (possibly small) amount of
+maintenance work: collective maintenance. One could use the metaphor
+of a shared house: things work well when most people, not just a few
+people, participate to the house chores.
+
+If your contributions generate maintenance work for others -- in
+particular, if you spend a substantial effort working on a change to
+the language or compiler codebase meant to be eventually proposed
+upstream -- we expect that you will spend a fraction of your
+contribution time on maintenance tasks, typically on the parts of the
+compiler codebase that you are already working on. This approach is
+good for the project, and also for you: helping maintain the codebase
+will improve the quality of your own contributions, and the social
+ties created by infrequent collaboration with other contributors will
+be useful when submitting your own work.
 
 ## Contributor License Agreement
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -457,6 +457,13 @@ will improve the quality of your own contributions, and the social
 ties created by infrequent collaboration with other contributors will
 be useful when submitting your own work.
 
+Note: we have been asked whether groups of contributors could balance
+maintenance work at the level of the whole group, rather than
+individual contributors -- for example a company where some frequent
+OCaml contributors would do less maintenance and others would do more
+to compensate. Yes, that sounds reasonable, but also harder to balance
+than encouraging everyone to play nice individually.
+
 ## Contributor License Agreement
 
 We distinguish two kind of contributions:


### PR DESCRIPTION
After the multicore merge, some maintainers and heavy contributors have been having discussions on "collective maintenance" (in particular, to say that we were in trouble because we needed more of it). See in particular the Discuss thread [Maintenance bottlenecks in the compiler distribution](https://discuss.ocaml.org/t/maintenance-bottlenecks-in-the-compiler-distribution/11045) which explains things in details.

The present PR updates our CONTRIBUTING.md document to explicitly spell out some expectations that contributors will participate to collective maintenance -- in proportion to the maintenance work they themselves generate for others.

I have already discussed those expectations with other maintainers. While people broadly agree, there is a definite possibility that some parts of the current PR are in fact not completely consensual -- it's okay, we can discuss it and evolve the PR or people's opinions. Collective maintenance is not reserved to maintainers, other contributors may have a say as well and they are welcome.

### FAQ

Q: This expectation to participate to maintenance work, is it only for maintainers-with-the-commit-bit or for all contributors?

A: For all contributors, *proportionally* to the volume of maintenance work they generate for others. (A system where only "maintainers" ever performance maintenance task does not really scale.) Someone who only contributes a small change once every decade is not expected to do anything in practice, as their "proportion" rounds to 0.

Q: I work on improving ocamlyacc, do I have to review pull requests on the type system now?

A: Oh no, it is understood that most people will focus their maintenance effort on the area they have decided to contribute to. Of course people are encouraged to get out of their comfort zone from time to time and grow expertise in other parts of the codebase.
