### PR TITLE
typedecl: document well-foundedness

### DIFF
--- a/Changes
+++ b/Changes
@@ -1002,7 +1002,7 @@ OCaml 5.0
   socket and deadlock the parent.
   (Antonin Décimo, review by Xavier Leroy)
 
-- #11150, #11207: Avoid recomputation in Typedecl.check_wellfounded
+- #11150, #11207, #11936: Avoid recomputation in Typedecl.check_wellfounded
   (Jacques Garrigue, report by Boris Yakobowski, review by Gabriel Scherer)
 
 - #11186, #11188: Fix composition of coercions with aliases


### PR DESCRIPTION
This is a documentation-only follow-up of #11207, integrating documentation comments that I wrote to understand what was going on during the review, but were not integrated in the PR. This PR explains:

- what we mean when we say that a type is well-founded (or ill-founded)
- some non-obvious implementation details of the `well_founded` checks

I need @garrigue to confirm that what is written is not technically incorrect, but ideally the main review would come from someone less expert in the type-checker (and more comfortable with doing reviews) to confirm that the documentation is accessible to non-experts.