### PR TITLE
Replace explicit constant with macro

### DIFF
--- a/Changes
+++ b/Changes
@@ -18,7 +18,7 @@ Working version
 
 ### Runtime system:
 
-- #11287, #11872: Clean up reserved header bits (once used for
+- #11287, #11872, #11955: Clean up reserved header bits (once used for
   Spacetime profiling).
   (Nick Barnes, review by Gabriel Scherer and Damien Doligez)
 

--- a/runtime/caml/mlvalues.h
+++ b/runtime/caml/mlvalues.h
@@ -126,6 +126,7 @@ where 0 <= R <= 31 is HEADER_RESERVED_BITS, set with the
                              << HEADER_WOSIZE_SHIFT)
 
 #define Tag_hd(hd) ((tag_t) ((hd) & HEADER_TAG_MASK))
+#define Hd_with_tag(hd, tag) ((hd) &~ HEADER_TAG_MASK | (tag))
 #define Wosize_hd(hd) ((mlsize_t) (((hd) & HEADER_WOSIZE_MASK) \
                                      >> HEADER_WOSIZE_SHIFT))
 

--- a/runtime/caml/mlvalues.h
+++ b/runtime/caml/mlvalues.h
@@ -126,7 +126,7 @@ where 0 <= R <= 31 is HEADER_RESERVED_BITS, set with the
                              << HEADER_WOSIZE_SHIFT)
 
 #define Tag_hd(hd) ((tag_t) ((hd) & HEADER_TAG_MASK))
-#define Hd_with_tag(hd, tag) ((hd) &~ HEADER_TAG_MASK | (tag))
+#define Hd_with_tag(hd, tag) (((hd) &~ HEADER_TAG_MASK) | (tag))
 #define Wosize_hd(hd) ((mlsize_t) (((hd) & HEADER_WOSIZE_MASK) \
                                      >> HEADER_WOSIZE_SHIFT))
 

--- a/runtime/obj.c
+++ b/runtime/obj.c
@@ -211,7 +211,7 @@ static int obj_update_tag (value blk, int old_tag, int new_tag)
     }
 
     if (atomic_compare_exchange_strong(Hp_atomic_val(blk), &hd,
-                                       (hd & ~HEADER_TAG_MASK) | new_tag))
+                                       Hd_with_tag(hd, new_tag)))
       return 1;
   }
 }

--- a/runtime/obj.c
+++ b/runtime/obj.c
@@ -211,7 +211,7 @@ static int obj_update_tag (value blk, int old_tag, int new_tag)
     }
 
     if (atomic_compare_exchange_strong(Hp_atomic_val(blk), &hd,
-                                       (hd & ~0xFF) | new_tag))
+                                       (hd & ~HEADER_TAG_MASK) | new_tag))
       return 1;
   }
 }


### PR DESCRIPTION
This is a continuation of the cleanups in PR #11872 - I stumbled across this explicit constant in `obj.c`, which I missed in that PR.