### PR TITLE
Prevent `seek_in` from marking buffer data as valid after closing the channel (Fixes #11878)

### DIFF
--- a/Changes
+++ b/Changes
@@ -117,6 +117,10 @@ Working version
   with examples and sections to group related functions.
   (Kiran Gopinathan, review by Daniel Bünzli and Xavier Leroy)
 
+- #11878, #11965: Prevent seek_in from marking buffer data as valid after
+  closing the channel. This could lead to inputting uninitialized bytes.
+  (Samuel Hym, review by Xavier Leroy and Olivier Nicole)
+
 - #11848: Add `List.find_mapi`, `List.find_index`, `Seq.find_mapi`,
   `Seq.find_index`, `Array.find_mapi`, `Array.find_index`,
   `Float.Array.find_opt`, `Float.Array.find_index`, `Float.Array.find_map`,

--- a/runtime/io.c
+++ b/runtime/io.c
@@ -681,6 +681,9 @@ CAMLprim value caml_ml_close_channel(value vchannel)
      immediate caml_flush_partial or caml_refill, thus raising a Sys_error
      exception */
   channel->curr = channel->max = channel->end;
+  /* Prevent any seek backward that would mark the last bytes of the
+   * channel buffer as valid */
+  channel->offset = 0;
 
   /* If already closed, we are done */
   if (channel->fd != -1) {

--- a/testsuite/tests/lib-channels/close_in.ml
+++ b/testsuite/tests/lib-channels/close_in.ml
@@ -11,10 +11,6 @@ let () =
   seek_in ic nb_bytes;
   close_in ic;
   seek_in ic 0;
-  for _ = 1 to nb_bytes do
-    (* the bytes we get here were never initialised *)
-    ignore (input_byte ic)
-  done;
   assert (
     try
       ignore (input_byte ic);

--- a/testsuite/tests/lib-channels/close_in.ml
+++ b/testsuite/tests/lib-channels/close_in.ml
@@ -1,0 +1,24 @@
+(* TEST *)
+
+(* Test that inputting bytes from a closed in_channel triggers an exception *)
+
+(* The number of bytes we'll rewind after closing; a value
+   between 1 and IO_BUFFER_SIZE *)
+let nb_bytes = 3
+
+let () =
+  let ic = open_in_bin Sys.argv.(0) in
+  seek_in ic nb_bytes;
+  close_in ic;
+  seek_in ic 0;
+  for _ = 1 to nb_bytes do
+    (* the bytes we get here were never initialised *)
+    ignore (input_byte ic)
+  done;
+  assert (
+    try
+      ignore (input_byte ic);
+      false
+    with
+    | Sys_error _ -> true
+    | _           -> false)


### PR DESCRIPTION
This proposes a fix for issue #11878 in which some part of a `in_channel` buffer can be considered as valid _after_ the channel has been closed.
This works by simply resetting the channel offset to 0 when the channel is closed to disable any backward `seek_in` later.
This PR also introduces a test for that issue (before and with the fix).

Closes issue #11878