### PR TITLE
Multicore cleanup: remove traces of Obj.truncate

### DIFF
--- a/Changes
+++ b/Changes
@@ -72,7 +72,8 @@ Working version
 ### Code generation and optimizations:
 
 - #11967: Remove traces of Obj.truncate, which allows some mutable
-   loads to become immutable. (Nick Barnes, review by ??)
+  loads to become immutable.
+  (Nick Barnes, review by Vincent Laviron and KC Sivaramakrishnan)
 
 - #9945, #10883: Turn boolean-result float comparisons into primitive operations
   Uses the architecture's elementary operations for float comparisons,

--- a/Changes
+++ b/Changes
@@ -71,6 +71,9 @@ Working version
 
 ### Code generation and optimizations:
 
+- #11967: Remove traces of Obj.truncate, which allows some mutable
+   loads to become immutable. (Nick Barnes, review by ??)
+
 - #9945, #10883: Turn boolean-result float comparisons into primitive operations
   Uses the architecture's elementary operations for float comparisons,
   when available, rather than branching and then setting the return value.

--- a/asmcomp/cmm_helpers.ml
+++ b/asmcomp/cmm_helpers.ml
@@ -40,6 +40,17 @@ let bind_nonvar name arg fn =
 let caml_black = Nativeint.shift_left (Nativeint.of_int 3) 8
     (* cf. runtime/caml/gc.h *)
 
+(* Loads *)
+
+let mk_load_immut memory_chunk =
+  Cload {memory_chunk; mutability=Immutable; is_atomic=false}
+
+let mk_load_mut memory_chunk =
+  Cload {memory_chunk; mutability=Mutable; is_atomic=false}
+
+let mk_load_atomic memory_chunk =
+  Cload {memory_chunk; mutability=Mutable; is_atomic=true}
+
 (* Block headers. Meaning of the tag field: see stdlib/obj.ml *)
 
 let floatarray_tag dbg = Cconst_int (Obj.double_array_tag, dbg)
@@ -569,13 +580,9 @@ let unbox_float dbg =
           | Some (Uconst_float x) ->
               Cconst_float (x, dbg) (* or keep _dbg? *)
           | _ ->
-              Cop(Cload {memory_chunk=Double; mutability=Immutable;
-                         is_atomic=false},
-                  [cmm], dbg)
+              Cop(mk_load_immut Double, [cmm], dbg)
           end
-      | cmm -> Cop(Cload {memory_chunk=Double; mutability=Immutable;
-                         is_atomic=false},
-                   [cmm], dbg)
+      | cmm -> Cop(mk_load_immut Double, [cmm], dbg)
     )
 
 (* Complex *)
@@ -584,10 +591,9 @@ let box_complex dbg c_re c_im =
   Cop(Calloc, [alloc_floatarray_header 2 dbg; c_re; c_im], dbg)
 
 let complex_re c dbg =
-  Cop(Cload {memory_chunk=Double; mutability=Immutable; is_atomic=false},
-      [c], dbg)
+  Cop(mk_load_immut Double, [c], dbg)
 let complex_im c dbg =
-  Cop(Cload {memory_chunk=Double; mutability=Immutable; is_atomic=false},
+  Cop(mk_load_immut Double,
       [Cop(Cadda, [c; Cconst_int (size_float, dbg)], dbg)], dbg)
 
 (* Unit *)
@@ -623,14 +629,6 @@ let rec remove_unit = function
   | Ctuple [] as c -> c
   | c -> Csequence(c, Ctuple [])
 
-(* Access to block fields *)
-
-let mk_load_mut memory_chunk =
-  Cload {memory_chunk; mutability=Mutable; is_atomic=false}
-
-let mk_load_atomic memory_chunk =
-  Cload {memory_chunk; mutability=Mutable; is_atomic=true}
-
 let field_address ptr n dbg =
   if n = 0
   then ptr
@@ -644,9 +642,7 @@ let set_field ptr n newval init dbg =
   Cop(Cstore (Word_val, init), [field_address ptr n dbg; newval], dbg)
 
 let get_header ptr dbg =
-  (* We cannot deem this as [Immutable] due to the presence of [Obj.truncate]
-     and [Obj.set_tag]. *)
-  Cop(mk_load_mut Word_int,
+  Cop(mk_load_immut Word_int,
     [Cop(Cadda, [ptr; Cconst_int(-size_int, dbg)], dbg)], dbg)
 
 let get_header_masked ptr dbg =
@@ -663,8 +659,7 @@ let get_tag ptr dbg =
   if Proc.word_addressed then           (* If byte loads are slow *)
     Cop(Cand, [get_header ptr dbg; Cconst_int (255, dbg)], dbg)
   else                                  (* If byte loads are efficient *)
-    (* Same comment as [get_header] above *)
-    Cop(mk_load_mut Byte_unsigned,
+    Cop(mk_load_immut Byte_unsigned,
         [Cop(Cadda, [ptr; Cconst_int(tag_offset, dbg)], dbg)], dbg)
 
 let get_size ptr dbg =
@@ -1044,7 +1039,7 @@ let unbox_int dbg bi =
       then Thirtytwo_signed else Word_int
     in
     Cop(
-      Cload {memory_chunk; mutability=Immutable; is_atomic=false},
+      mk_load_immut memory_chunk,
       [Cop(Cadda, [arg; Cconst_int (size_addr, dbg)], dbg)], dbg)
   in
   map_tail

--- a/asmcomp/cmm_helpers.ml
+++ b/asmcomp/cmm_helpers.ml
@@ -642,7 +642,8 @@ let set_field ptr n newval init dbg =
   Cop(Cstore (Word_val, init), [field_address ptr n dbg; newval], dbg)
 
 let get_header ptr dbg =
-  Cop(mk_load_immut Word_int,
+  (* header loads are mutable because laziness changes tags. *)
+  Cop(mk_load_mut Word_int,
     [Cop(Cadda, [ptr; Cconst_int(-size_int, dbg)], dbg)], dbg)
 
 let get_header_masked ptr dbg =
@@ -659,7 +660,8 @@ let get_tag ptr dbg =
   if Proc.word_addressed then           (* If byte loads are slow *)
     Cop(Cand, [get_header ptr dbg; Cconst_int (255, dbg)], dbg)
   else                                  (* If byte loads are efficient *)
-    Cop(mk_load_immut Byte_unsigned,
+    (* header loads are mutable because laziness changes tags. *)
+    Cop(mk_load_mut Byte_unsigned,
         [Cop(Cadda, [ptr; Cconst_int(tag_offset, dbg)], dbg)], dbg)
 
 let get_size ptr dbg =

--- a/middle_end/semantics_of_primitives.ml
+++ b/middle_end/semantics_of_primitives.ml
@@ -73,8 +73,7 @@ let for_primitive (prim : Clambda_primitives.primitive) =
   | Pdivfloat
   | Pfloatcomp _ -> No_effects, No_coeffects
   | Pstringlength | Pbyteslength
-  | Parraylength _ ->
-      No_effects, Has_coeffects  (* That old chestnut: [Obj.truncate]. *)
+  | Parraylength _ -> No_effects, No_coeffects
   | Pisint
   | Pisout
   | Pbintofint _

--- a/runtime/caml/misc.h
+++ b/runtime/caml/misc.h
@@ -515,7 +515,7 @@ int caml_runtime_warnings_active(void);
   00 -> free words in minor heap
   01 -> fields of free list blocks in major heap
   03 -> heap chunks deallocated by heap shrinking
-  04 -> fields deallocated by [caml_obj_truncate]
+  04 -> fields deallocated by caml_obj_truncate: obsolete
   05 -> unused child pointers in large free blocks
   10 -> uninitialised fields of minor objects
   11 -> uninitialised fields of major objects
@@ -529,7 +529,7 @@ int caml_runtime_warnings_active(void);
 #define Debug_free_minor     Debug_tag (0x00)
 #define Debug_free_major     Debug_tag (0x01)
 #define Debug_free_shrink    Debug_tag (0x03)
-#define Debug_free_truncate  Debug_tag (0x04)
+#define Debug_free_truncate  Debug_tag (0x04) /* obsolete */
 #define Debug_free_unused    Debug_tag (0x05)
 #define Debug_uninit_minor   Debug_tag (0x10)
 #define Debug_uninit_major   Debug_tag (0x11)

--- a/runtime/caml/mlvalues.h
+++ b/runtime/caml/mlvalues.h
@@ -313,9 +313,11 @@ CAMLextern value caml_hash_variant(char const * tag);
 #define Byte(x, i) (((char *) (x)) [i])            /* Also an l-value. */
 #define Byte_u(x, i) (((unsigned char *) (x)) [i]) /* Also an l-value. */
 
-/* Abstract things.  Their contents is not traced by the GC; therefore they
-   must not contain any [value]. Must have odd number so that headers with
-   this tag cannot be mistaken for pointers (see caml_obj_truncate).
+/* Abstract things.  Their contents is not traced by the GC; therefore
+   they must not contain any [value]. Must have odd number so that
+   headers with this tag cannot be mistaken for pointers. Previously
+   used in caml_obj_truncate for a header of the truncated tail of the
+   object.
 */
 #define Abstract_tag 251
 #define Data_abstract_val(v) ((void*) Op_val(v))

--- a/stdlib/list.ml
+++ b/stdlib/list.ml
@@ -408,38 +408,11 @@ let stable_sort cmp l =
 let sort = stable_sort
 let fast_sort = stable_sort
 
-(* Note: on a list of length between about 100000 (depending on the minor
-   heap size and the type of the list) and Sys.max_array_size, it is
-   actually faster to use the following, but it might also use more memory
-   because the argument list cannot be deallocated incrementally.
-
-   Also, there seems to be a bug in this code or in the
-   implementation of obj_truncate.
-
-external obj_truncate : 'a array -> int -> unit = "caml_obj_truncate"
-
-let array_to_list_in_place a =
-  let l = Array.length a in
-  let rec loop accu n p =
-    if p <= 0 then accu else begin
-      if p = n then begin
-        obj_truncate a p;
-        loop (a.(p-1) :: accu) (n-1000) (p-1)
-      end else begin
-        loop (a.(p-1) :: accu) n (p-1)
-      end
-    end
-  in
-  loop [] (l-1000) l
-
-
-let stable_sort cmp l =
-  let a = Array.of_list l in
-  Array.stable_sort cmp a;
-  array_to_list_in_place a
-
-*)
-
+(* Note: on a very long list (length over about 100000), it used to be
+   faster to convert the list to an array, sort the array, and convert
+   back, truncating the array object after prepending each thousand
+   entries to the resulting list. Impossible now that Obj.truncate has
+   been removed. *)
 
 (** sorting + removing duplicates *)
 


### PR DESCRIPTION
`Obj.truncate` (`caml_obj_truncate`) was removed in the multicore merge. This is clean-up related to that:

- Comments in various places which referred to it;
- `Cmm_helpers.get_header` and `Cmm_helpers.get_tag` were doing mutable loads, which can now be immutable loads because header words can't change any more;
- The `Parraylength` primitive no longer has any co-effects, because the array cannot be truncated.