### PR TITLE
Initialize variables in interp.c

### DIFF
--- a/runtime/interp.c
+++ b/runtime/interp.c
@@ -262,8 +262,9 @@ value caml_interprete(code_t prog, asize_t prog_size)
   register char * jumptbl_base;
 #endif
 #endif
-  value env;
-  intnat extra_args;
+  value env = Atom(0);
+  pc = 0;
+  intnat extra_args = 0;
   struct caml_exception_context * initial_external_raise;
   int initial_stack_words;
   intnat initial_trap_sp_off;


### PR DESCRIPTION
I was building OCaml/trunk on Elbrus E2K machine and got warning/errors from `lcc` compiler about _may be uninitialized variables_ (verbatim output):

```console
lcc: "runtime/interp.c", строка 248: в функции "caml_interprete":
lcc: "runtime/interp.c", строка 623: ошибка: переменная "env" может быть
          использована неинициализированной [-Werror=maybe-uninitialized]
lcc: "runtime/interp.c", строка 1028: ошибка: переменная "pc" может быть
          использована неинициализированной [-Werror=maybe-uninitialized]
lcc: "runtime/interp.c", строка 1028: ошибка: переменная "extra_args" может
          быть использована неинициализированной [-Werror=maybe-uninitialized]
```

translation

```console
lcc : "runtime/interp.c", ligne 248 : dans la fonction "caml_interprete" :
lcc : "runtime/interp.c", ligne 623 : erreur : la variable "env" peut être
           utilisé non initialisé [-Werror=maybe-uninitialized]
lcc : "runtime/interp.c", ligne 1028 : erreur : la variable "pc" peut être
           utilisé non initialisé [-Werror=maybe-uninitialized]
lcc : "runtime/interp.c", ligne 1028 : erreur : la variable "extra_args" peut
           être utilisé non initialisé [-Werror=maybe-uninitialized]
```

`lcc` has EDG frontend, which is different from gcc/clang/mvsc frontends. I was unable to reproduce these warnings using gcc (I provided `-Wmaybe-uninitialized` in CFLAGS). So, this might be a red herring.