### PR TITLE
Add support for mingw postfixed hosts.

### DIFF
--- a/Changes
+++ b/Changes
@@ -274,6 +274,9 @@ Working version
 - #10647: Show hints for the "undefined global" error in the toplevel
   (Wiktor Kuchta, review by Gabriel Scherer)
 
+- #11973: Add support for postfixed mingw host triplets
+  (Romain Beauxis)
+
 ### Manual and documentation:
 
 - #9430, #11291: Document the general desugaring rules for binding operators.

--- a/aclocal.m4
+++ b/aclocal.m4
@@ -440,7 +440,7 @@ int main (void) {
     AS_CASE([$enable_imprecise_c99_float_ops,$target],
       [no,*], [hard_error=true],
       [yes,*], [hard_error=false],
-      [*,x86_64-w64-mingw32], [hard_error=false],
+      [*,x86_64-w64-mingw32*], [hard_error=false],
       [hard_error=true])
     AS_IF([test x"$hard_error" = "xtrue"],
       [AC_MSG_ERROR(m4_normalize([
@@ -449,7 +449,7 @@ int main (void) {
       [AC_MSG_WARN(m4_normalize([
         round does not work; emulation enabled]))])],
     [AS_CASE([$target],
-      [x86_64-w64-mingw32],[AC_MSG_RESULT([cross-compiling; assume not])],
+      [x86_64-w64-mingw32*],[AC_MSG_RESULT([cross-compiling; assume not])],
       [AC_MSG_RESULT([cross-compiling; assume yes])
       AC_DEFINE([HAS_WORKING_ROUND])])])
 ])
@@ -492,7 +492,7 @@ int main (void) {
     AS_CASE([$enable_imprecise_c99_float_ops,$target],
       [no,*], [hard_error=true],
       [yes,*], [hard_error=false],
-      [*,x86_64-w64-mingw32|*,x86_64-*-cygwin*], [hard_error=false],
+      [*,x86_64-w64-mingw32*|*,x86_64-*-cygwin*], [hard_error=false],
       [AS_CASE([$ocaml_cv_cc_vendor],
         [msvc-*], [AS_IF([test "${ocaml_cv_cc_vendor#msvc-}" -lt 1920 ],
           [hard_error=false],
@@ -505,7 +505,7 @@ int main (void) {
       [AC_MSG_WARN(m4_normalize([
         fma does not work; emulation enabled]))])],
     [AS_CASE([$target],
-      [x86_64-w64-mingw32|x86_64-*-cygwin*],
+      [x86_64-w64-mingw32*|x86_64-*-cygwin*],
         [AC_MSG_RESULT([cross-compiling; assume not])],
       [AC_MSG_RESULT([cross-compiling; assume yes])
       AC_DEFINE([HAS_WORKING_FMA])])])

--- a/configure
+++ b/configure
@@ -3594,7 +3594,7 @@ case $host in #(
 esac
 
 case $host in #(
-  *-*-mingw32|*-pc-windows) :
+  *-*-mingw32*|*-pc-windows) :
     CSC=csc
     CSCFLAGS="/nologo /nowarn:1668"
     case $host_cpu in #(
@@ -13513,7 +13513,7 @@ ocamlsrcdir=${ocamlsrcdir%X}
 # Libraries to build depending on the host
 
 case $host in #(
-  *-*-mingw32|*-pc-windows) :
+  *-*-mingw32*|*-pc-windows) :
     unix_or_win32="win32"
     ln='cp -pf'
     ocamltest_libunix="Some false"
@@ -13527,7 +13527,7 @@ case $host in #(
 esac
 
 case $host in #(
-  *-*-cygwin*|*-*-mingw32|*-pc-windows) :
+  *-*-cygwin*|*-*-mingw32*|*-pc-windows) :
     exeext=".exe" ;; #(
   *) :
     exeext='' ;;
@@ -13590,7 +13590,7 @@ long_shebang=false
 if test "x$interpval" = "xyes"
 then :
   case $host in #(
-  *-cygwin|*-*-mingw32|*-pc-windows) :
+  *-cygwin|*-*-mingw32*|*-pc-windows) :
     shebangscripts=false ;; #(
   *) :
     shebangscripts=true
@@ -13674,7 +13674,7 @@ esac
 # the vendor only as a fall-back. We could put tis part of the logic
 # in the macro itself, too
 case $host in #(
-  *-*-mingw32) :
+  *-*-mingw32*) :
     case $ocaml_cv_cc_vendor in #(
   gcc-[01234]-*) :
     as_fn_error $? "This version of MinGW-w64 GCC is too old. Please use GCC version 5 or above." "$LINENO" 5 ;; #(
@@ -13747,7 +13747,7 @@ esac
 
 # Enable SSE2 on x86 mingw to avoid using 80-bit registers.
 case $host in #(
-  i686-*-mingw32) :
+  i686-*-mingw32*) :
     internal_cflags="$internal_cflags -mfpmath=sse -msse2" ;; #(
   *) :
      ;;
@@ -13757,7 +13757,7 @@ esac
 # See also AC_SYS_LARGEFILE
 # Problem: flags are added to CC rather than CPPFLAGS
 case $host in #(
-  *-*-mingw32|*-pc-windows) :
+  *-*-mingw32*|*-pc-windows) :
      ;; #(
   *) :
     common_cppflags="$common_cppflags -D_FILE_OFFSET_BITS=64" ;;
@@ -13775,7 +13775,7 @@ if test x"$enable_shared" = "xno"
 then :
   supports_shared_libraries=false
   case $host in #(
-  *-pc-windows|*-w64-mingw32) :
+  *-pc-windows|*-w64-mingw32*) :
     as_fn_error $? "Cannot build native Win32 with --disable-shared" "$LINENO" 5 ;; #(
   *) :
      ;;
@@ -13795,10 +13795,10 @@ case $host in #(
     flexlink_flags='-merge-manifest -stack 16777216' ;; #(
   *-*-cygwin*) :
     as_fn_error $? "unknown cygwin variant" "$LINENO" 5 ;; #(
-  i686-w64-mingw32) :
+  i686-w64-mingw32*) :
     flexdll_chain='mingw'
     flexlink_flags='-stack 16777216' ;; #(
-  x86_64-w64-mingw32) :
+  x86_64-w64-mingw32*) :
     flexdll_chain='mingw64'
     flexlink_flags='-stack 33554432' ;; #(
   i686-pc-windows) :
@@ -13824,7 +13824,7 @@ printf "%s\n" "disabled" >&6; }
 else $as_nop
   flexmsg=''
     case $target in #(
-  *-*-cygwin*|*-w64-mingw32|*-pc-windows) :
+  *-*-cygwin*|*-w64-mingw32*|*-pc-windows) :
     if test x"$with_flexdll" = 'x' || test x"$with_flexdll" = 'xflexdll'
 then :
   if test -f 'flexdll/flexdll.h'
@@ -13996,7 +13996,7 @@ rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
 
 
     case $host in #(
-  *-w64-mingw32|*-pc-windows) :
+  *-w64-mingw32*|*-pc-windows) :
     flexlink_where="$(cmd /c "$flexlink" -where 2>/dev/null)"
       if test -z "$flexlink_where"
 then :
@@ -14119,7 +14119,7 @@ case $have_flexdll_h,$supports_shared_libraries,$host in #(
     supports_shared_libraries=false
    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: flexdll.h not found: shared library support disabled." >&5
 printf "%s\n" "$as_me: WARNING: flexdll.h not found: shared library support disabled." >&2;} ;; #(
-  no,*,*-w64-mingw32|no,*,*-pc-windows) :
+  no,*,*-w64-mingw32*|no,*,*-pc-windows) :
     as_fn_error $? "flexdll.h is required for native Win32" "$LINENO" 5 ;; #(
   *) :
      ;;
@@ -14130,7 +14130,7 @@ case $flexdir,$supports_shared_libraries,$flexlink,$host in #(
     supports_shared_libraries=false
     { printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: flexlink not found: shared library support disabled." >&5
 printf "%s\n" "$as_me: WARNING: flexlink not found: shared library support disabled." >&2;} ;; #(
-  ,*,,*-w64-mingw32|,*,,*-pc-windows) :
+  ,*,,*-w64-mingw32*|,*,,*-pc-windows) :
     as_fn_error $? "flexlink is required for native Win32" "$LINENO" 5 ;; #(
   *) :
      ;;
@@ -14170,7 +14170,7 @@ else $as_nop
 
 fi
     ostype="Cygwin" ;; #(
-  *,*-*-mingw32) :
+  *,*-*-mingw32*) :
     case $host in #(
   i686-*-*) :
     oc_dll_ldflags="-static-libgcc" ;; #(
@@ -15072,7 +15072,7 @@ fi
 # macOS and MinGW-64 have problems with __thread variables accessed from DLLs
 
 case $host in #(
-  *-apple-darwin*|*-mingw32) :
+  *-apple-darwin*|*-mingw32*) :
      ;; #(
   *) :
     printf "%s\n" "#define HAS_FULL_THREAD_VARIABLES 1" >>confdefs.h
@@ -15100,7 +15100,7 @@ then :
   aarch64-apple-darwin*|arm64-apple-darwin*) :
     mkdll_flags='-shared -undefined dynamic_lookup -Wl,-w'
       supports_shared_libraries=true ;; #(
-  *-*-mingw32|*-pc-windows|*-*-cygwin*) :
+  *-*-mingw32*|*-pc-windows|*-*-cygwin*) :
     mkdll_flags="-chain ${flexdll_chain} ${flexlink_flags}"
       mkdll_exp="flexlink ${mkdll_flags}"
       mkdll="${flexlink_cmd} ${mkdll_flags}"
@@ -15163,7 +15163,7 @@ then :
   case "$host" in #(
   *-*-cygwin*) :
     natdynlink=true ;; #(
-  *-*-mingw32) :
+  *-*-mingw32*) :
     natdynlink=true ;; #(
   *-pc-windows) :
     natdynlink=true ;; #(
@@ -15334,7 +15334,7 @@ case $host in #(
     arch=i386; system=cygwin ;; #(
   i[3456]86-*-gnu*) :
     arch=i386; system=gnu ;; #(
-  i[3456]86-*-mingw32) :
+  i[3456]86-*-mingw32*) :
     arch=i386; system=mingw ;; #(
   i686-pc-windows) :
     arch=i386; system=win32 ;; #(
@@ -15406,7 +15406,7 @@ fi; system=elf ;; #(
     has_native_backend=yes; arch=arm64; system=macosx ;; #(
   x86_64-*-darwin*) :
     has_native_backend=yes; arch=amd64; system=macosx ;; #(
-  x86_64-*-mingw32) :
+  x86_64-*-mingw32*) :
     has_native_backend=yes; arch=amd64; system=mingw64 ;; #(
   aarch64-*-linux*) :
     has_native_backend=yes; arch=arm64; system=linux ;; #(
@@ -15838,7 +15838,7 @@ fi
   if test "$cross_compiling" = yes
 then :
   case $target in #(
-  x86_64-w64-mingw32) :
+  x86_64-w64-mingw32*) :
     { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: cross-compiling; assume not" >&5
 printf "%s\n" "cross-compiling; assume not" >&6; } ;; #(
   *) :
@@ -15872,7 +15872,7 @@ printf "%s\n" "no" >&6; }
     hard_error=true ;; #(
   yes,*) :
     hard_error=false ;; #(
-  *,x86_64-w64-mingw32) :
+  *,x86_64-w64-mingw32*) :
     hard_error=false ;; #(
   *) :
     hard_error=true ;;
@@ -15906,7 +15906,7 @@ fi
   if test "$cross_compiling" = yes
 then :
   case $target in #(
-  x86_64-w64-mingw32|x86_64-*-cygwin*) :
+  x86_64-w64-mingw32*|x86_64-*-cygwin*) :
     { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: cross-compiling; assume not" >&5
 printf "%s\n" "cross-compiling; assume not" >&6; } ;; #(
   *) :
@@ -15962,7 +15962,7 @@ printf "%s\n" "no" >&6; }
     hard_error=true ;; #(
   yes,*) :
     hard_error=false ;; #(
-  *,x86_64-w64-mingw32|*,x86_64-*-cygwin*) :
+  *,x86_64-w64-mingw32*|*,x86_64-*-cygwin*) :
     hard_error=false ;; #(
   *) :
     case $ocaml_cv_cc_vendor in #(
@@ -16358,7 +16358,7 @@ fi
 sockets=true
 
 case $host in #(
-  *-*-mingw32|*-pc-windows) :
+  *-*-mingw32*|*-pc-windows) :
     cclibs="$cclibs -lws2_32"
     { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for library containing socket" >&5
 printf %s "checking for library containing socket... " >&6; }
@@ -16638,7 +16638,7 @@ fi
 ## socklen_t
 
 case $host in #(
-  *-*-mingw32|*-pc-windows) :
+  *-*-mingw32*|*-pc-windows) :
     ac_fn_c_check_type "$LINENO" "socklen_t" "ac_cv_type_socklen_t" "#include <ws2tcpip.h>
 "
 if test "x$ac_cv_type_socklen_t" = xyes
@@ -16669,7 +16669,7 @@ fi
 ## Unix domain sockets support on Windows
 
 case $host in #(
-  *-*-mingw32|*-pc-windows) :
+  *-*-mingw32*|*-pc-windows) :
            for ac_header in afunix.h
 do :
   ac_fn_c_check_header_compile "$LINENO" "afunix.h" "ac_cv_header_afunix_h" "#include <winsock2.h>
@@ -16691,7 +16691,7 @@ esac
 ipv6=true
 
 case $host in #(
-  *-*-mingw32|*-pc-windows) :
+  *-*-mingw32*|*-pc-windows) :
     ac_fn_c_check_type "$LINENO" "struct sockaddr_in6" "ac_cv_type_struct_sockaddr_in6" "#include <ws2tcpip.h>
 "
 if test "x$ac_cv_type_struct_sockaddr_in6" = xyes
@@ -16811,7 +16811,7 @@ fi
 # seem to detect it properly on Windows so we hardcode the definition
 # of HAS_UTIME on Windows but this will probably need to be clarified
 case $host in #(
-  *-*-mingw32|*-pc-windows) :
+  *-*-mingw32*|*-pc-windows) :
     printf "%s\n" "#define HAS_UTIME 1" >>confdefs.h
  ;; #(
   *) :
@@ -17029,7 +17029,7 @@ fi
 # Note: detection fails on Windows so hardcoding the result
 # (should be debugged later)
 case $host in #(
-  *-*-mingw32|*-pc-windows) :
+  *-*-mingw32*|*-pc-windows) :
     printf "%s\n" "#define HAS_GETHOSTNAME 1" >>confdefs.h
  ;; #(
   *) :
@@ -17085,7 +17085,7 @@ fi
 ## setsid
 
 case $host in #(
-  *-cygwin|*-*-mingw32|*-pc-windows) :
+  *-cygwin|*-*-mingw32*|*-pc-windows) :
      ;; #(
   *) :
     ac_fn_c_check_func "$LINENO" "setsid" "ac_cv_func_setsid"
@@ -17198,7 +17198,7 @@ esac
 if $supports_shared_libraries
 then :
   case $host in #(
-  *-*-mingw32|*-pc-windows|*-*-cygwin*) :
+  *-*-mingw32*|*-pc-windows|*-*-cygwin*) :
     DLLIBS="" ;; #(
   *) :
     ac_fn_c_check_func "$LINENO" "dlopen" "ac_cv_func_dlopen"
@@ -17298,7 +17298,7 @@ fi
 
 ## -fdebug-prefix-map support by the C compiler
 case $ocaml_cv_cc_vendor,$host in #(
-  *,*-*-mingw32) :
+  *,*-*-mingw32*) :
     cc_has_debug_prefix_map=false ;; #(
   *,*-pc-windows) :
     cc_has_debug_prefix_map=false ;; #(
@@ -18008,7 +18008,7 @@ esac
 ## Determine how to link with the POSIX threads library
 
 case $host in #(
-  *-*-mingw32|*-pc-windows) :
+  *-*-mingw32*|*-pc-windows) :
     PTHREAD_LIBS="-l:libpthread.a" ;; #(
   *) :
 
@@ -18813,7 +18813,7 @@ asm_cfi_supported=false
 if $native_compiler
 then :
   case $host in #(
-  *-*-mingw32|*-pc-windows) :
+  *-*-mingw32*|*-pc-windows) :
      ;; #(
   *) :
 
@@ -19435,7 +19435,7 @@ fi
 
 
 case $host in #(
-  *-*-mingw32) :
+  *-*-mingw32*) :
     bytecclibs="-lws2_32 -lversion -l:libpthread.a -lgcc_eh"
     nativecclibs="-lws2_32 -lversion -l:libpthread.a -lgcc_eh" ;; #(
   *-pc-windows) :
@@ -19457,7 +19457,7 @@ then :
 fi
 
 case $host in #(
-  *-*-mingw32|*-pc-windows) :
+  *-*-mingw32*|*-pc-windows) :
     case $WINDOWS_UNICODE_MODE in #(
   ansi) :
     windows_unicode=0 ;; #(
@@ -19474,9 +19474,9 @@ esac
 if test x"$prefix" = "xNONE"
 then :
   case $host in #(
-  i686-w64-mingw32) :
+  i686-w64-mingw32*) :
     prefix='C:/ocamlmgw' ;; #(
-  x86_64-w64-mingw32) :
+  x86_64-w64-mingw32*) :
     prefix='C:/ocamlmgw64' ;; #(
   i686-pc-windows) :
     prefix='C:/ocamlms' ;; #(
@@ -19502,7 +19502,7 @@ fi
 # but whose value is not guessed properly by configure
 # (all this should be understood and fixed)
 case $host in #(
-  *-*-mingw32) :
+  *-*-mingw32*) :
     printf "%s\n" "#define HAS_BROKEN_PRINTF 1" >>confdefs.h
 
     printf "%s\n" "#define HAS_STRERROR 1" >>confdefs.h

--- a/configure.ac
+++ b/configure.ac
@@ -277,7 +277,7 @@ AS_CASE([$host],
   syslib='-l$(1)'])
 
 AS_CASE([$host],
-  [*-*-mingw32|*-pc-windows],
+  [*-*-mingw32*|*-pc-windows],
     [CSC=csc
     CSCFLAGS="/nologo /nowarn:1668"
     AS_CASE([$host_cpu], [i*86], [CSCFLAGS="$CSCFLAGS /platform:x86"])])
@@ -592,7 +592,7 @@ ocamlsrcdir=${ocamlsrcdir%X}
 # Libraries to build depending on the host
 
 AS_CASE([$host],
-  [*-*-mingw32|*-pc-windows],
+  [*-*-mingw32*|*-pc-windows],
     [unix_or_win32="win32"
     ln='cp -pf'
     ocamltest_libunix="Some false"
@@ -604,7 +604,7 @@ AS_CASE([$host],
   ocamlyacc_wstr_module=""])
 
 AS_CASE([$host],
-  [*-*-cygwin*|*-*-mingw32|*-pc-windows],
+  [*-*-cygwin*|*-*-mingw32*|*-pc-windows],
     [exeext=".exe"],
   [exeext=''])
 
@@ -637,7 +637,7 @@ long_shebang=false
 AS_IF(
   [test "x$interpval" = "xyes"],
     [AS_CASE([$host],
-      [*-cygwin|*-*-mingw32|*-pc-windows],
+      [*-cygwin|*-*-mingw32*|*-pc-windows],
         [shebangscripts=false],
       [shebangscripts=true
        prev_exec_prefix="$exec_prefix"
@@ -703,7 +703,7 @@ AS_CASE([$enable_warn_error,OCAML__DEVELOPMENT_VERSION],
 # the vendor only as a fall-back. We could put tis part of the logic
 # in the macro itself, too
 AS_CASE([$host],
-  [*-*-mingw32],
+  [*-*-mingw32*],
     [AS_CASE([$ocaml_cv_cc_vendor],
       [gcc-[[01234]]-*],
         [AC_MSG_ERROR(m4_normalize([This version of MinGW-w64 GCC is too old.
@@ -748,14 +748,14 @@ AS_CASE([$host],
 
 # Enable SSE2 on x86 mingw to avoid using 80-bit registers.
 AS_CASE([$host],
-  [i686-*-mingw32],
+  [i686-*-mingw32*],
     [internal_cflags="$internal_cflags -mfpmath=sse -msse2"])
 
 # Use 64-bit file offset if possible
 # See also AC_SYS_LARGEFILE
 # Problem: flags are added to CC rather than CPPFLAGS
 AS_CASE([$host],
-  [*-*-mingw32|*-pc-windows], [],
+  [*-*-mingw32*|*-pc-windows], [],
   [common_cppflags="$common_cppflags -D_FILE_OFFSET_BITS=64"])
 
 # Adjust according to target
@@ -769,7 +769,7 @@ AS_CASE([$host],
 AS_IF([test x"$enable_shared" = "xno"],
   [supports_shared_libraries=false
   AS_CASE([$host],
-    [*-pc-windows|*-w64-mingw32],
+    [*-pc-windows|*-w64-mingw32*],
     [AC_MSG_ERROR([Cannot build native Win32 with --disable-shared])])],
   [supports_shared_libraries=true])
 
@@ -784,10 +784,10 @@ AS_CASE([$host],
     flexlink_flags='-merge-manifest -stack 16777216'],
   [*-*-cygwin*],
     [AC_MSG_ERROR([unknown cygwin variant])],
-  [i686-w64-mingw32],
+  [i686-w64-mingw32*],
     [flexdll_chain='mingw'
     flexlink_flags='-stack 16777216'],
-  [x86_64-w64-mingw32],
+  [x86_64-w64-mingw32*],
     [flexdll_chain='mingw64'
     flexlink_flags='-stack 33554432'],
   [i686-pc-windows],
@@ -805,7 +805,7 @@ AS_IF([test x"$supports_shared_libraries" != 'xfalse'], [
     AC_MSG_RESULT([disabled])],
     [flexmsg=''
     AS_CASE([$target],
-      [*-*-cygwin*|*-w64-mingw32|*-pc-windows],
+      [*-*-cygwin*|*-w64-mingw32*|*-pc-windows],
       [AS_IF([m4_normalize([test x"$with_flexdll" = 'x'
                             || test x"$with_flexdll" = 'xflexdll'])],
         [AS_IF([test -f 'flexdll/flexdll.h'],
@@ -842,7 +842,7 @@ AS_IF([test x"$supports_shared_libraries" != 'xfalse'], [
                         [$internal_cppflags], [$host])
 
     AS_CASE([$host],
-      [*-w64-mingw32|*-pc-windows],
+      [*-w64-mingw32*|*-pc-windows],
       [flexlink_where="$(cmd /c "$flexlink" -where 2>/dev/null)"
       AS_IF([test -z "$flexlink_where"],
         [AC_MSG_ERROR([$flexlink is not executable from a native Win32 process])
@@ -862,14 +862,14 @@ AS_CASE([$have_flexdll_h,$supports_shared_libraries,$host],
  [no,true,*-*-cygwin*],
    [supports_shared_libraries=false
    AC_MSG_WARN([flexdll.h not found: shared library support disabled.])],
- [no,*,*-w64-mingw32|no,*,*-pc-windows],
+ [no,*,*-w64-mingw32*|no,*,*-pc-windows],
    [AC_MSG_ERROR([flexdll.h is required for native Win32])])
 
 AS_CASE([$flexdir,$supports_shared_libraries,$flexlink,$host],
   [,true,,*-*-cygwin*],
     [supports_shared_libraries=false
     AC_MSG_WARN([flexlink not found: shared library support disabled.])],
-  [,*,,*-w64-mingw32|,*,,*-pc-windows],
+  [,*,,*-w64-mingw32*|,*,,*-pc-windows],
     [AC_MSG_ERROR([flexlink is required for native Win32])])
 
 mkexe_cmd_exp="$CC"
@@ -897,7 +897,7 @@ AS_CASE([$cc_basename,$host],
       oc_ldflags='-Wl,--stack,16777216']
     )
     ostype="Cygwin"],
-  [*,*-*-mingw32],
+  [*,*-*-mingw32*],
     [AS_CASE([$host],
       [i686-*-*], [oc_dll_ldflags="-static-libgcc"])
     ostype="Win32"
@@ -1037,7 +1037,7 @@ AS_IF([! $cc_supports_atomic],
 # macOS and MinGW-64 have problems with __thread variables accessed from DLLs
 
 AS_CASE([$host],
-  [*-apple-darwin*|*-mingw32], [],
+  [*-apple-darwin*|*-mingw32*], [],
   [AC_DEFINE([HAS_FULL_THREAD_VARIABLES])]
 )
 
@@ -1060,7 +1060,7 @@ AS_IF([test x"$enable_shared" != "xno"],
     [aarch64-apple-darwin*|arm64-apple-darwin*],
       [mkdll_flags='-shared -undefined dynamic_lookup -Wl,-w'
       supports_shared_libraries=true],
-    [*-*-mingw32|*-pc-windows|*-*-cygwin*],
+    [*-*-mingw32*|*-pc-windows|*-*-cygwin*],
       [mkdll_flags="-chain ${flexdll_chain} ${flexlink_flags}"
       mkdll_exp="flexlink ${mkdll_flags}"
       mkdll="${flexlink_cmd} ${mkdll_flags}"
@@ -1109,7 +1109,7 @@ natdynlink=false
 AS_IF([test x"$supports_shared_libraries" = 'xtrue'],
   [AS_CASE(["$host"],
     [*-*-cygwin*], [natdynlink=true],
-    [*-*-mingw32], [natdynlink=true],
+    [*-*-mingw32*], [natdynlink=true],
     [*-pc-windows], [natdynlink=true],
     [[i[3456]86-*-linux*]], [natdynlink=true],
     [[i[3456]86-*-gnu*]], [natdynlink=true],
@@ -1178,7 +1178,7 @@ AS_CASE([$host],
     [arch=i386; system=cygwin],
   [[i[3456]86-*-gnu*]],
     [arch=i386; system=gnu],
-  [[i[3456]86-*-mingw32]],
+  [[i[3456]86-*-mingw32*]],
     [arch=i386; system=mingw],
   [i686-pc-windows],
     [arch=i386; system=win32],
@@ -1245,7 +1245,7 @@ AS_CASE([$host],
     [has_native_backend=yes; arch=arm64; system=macosx],
   [x86_64-*-darwin*],
     [has_native_backend=yes; arch=amd64; system=macosx],
-  [x86_64-*-mingw32],
+  [x86_64-*-mingw32*],
     [has_native_backend=yes; arch=amd64; system=mingw64],
   [aarch64-*-linux*],
     [has_native_backend=yes; arch=arm64; system=linux],
@@ -1551,7 +1551,7 @@ but no proper monotonic clock source was found.])
 sockets=true
 
 AS_CASE([$host],
-  [*-*-mingw32|*-pc-windows],
+  [*-*-mingw32*|*-pc-windows],
     [cclibs="$cclibs -lws2_32"
     AC_SEARCH_LIBS([socket], [ws2_32])
     AC_CHECK_FUNC([socketpair], [AC_DEFINE([HAS_SOCKETPAIR])])],
@@ -1575,7 +1575,7 @@ AS_IF([$sockets], [AC_DEFINE([HAS_SOCKETS])])
 ## socklen_t
 
 AS_CASE([$host],
-  [*-*-mingw32|*-pc-windows],
+  [*-*-mingw32*|*-pc-windows],
     [AC_CHECK_TYPE([socklen_t], [AC_DEFINE([HAS_SOCKLEN_T])], [],
       [#include <ws2tcpip.h>])],
   [AC_CHECK_TYPE([socklen_t], [AC_DEFINE([HAS_SOCKLEN_T])], [],
@@ -1586,7 +1586,7 @@ AC_CHECK_FUNC([inet_aton], [AC_DEFINE([HAS_INET_ATON])])
 ## Unix domain sockets support on Windows
 
 AS_CASE([$host],
-  [*-*-mingw32|*-pc-windows],
+  [*-*-mingw32*|*-pc-windows],
     [AC_CHECK_HEADERS([afunix.h], [AC_DEFINE([HAS_AFUNIX_H])], [],
       [#include <winsock2.h>])])
 
@@ -1595,7 +1595,7 @@ AS_CASE([$host],
 ipv6=true
 
 AS_CASE([$host],
-  [*-*-mingw32|*-pc-windows],
+  [*-*-mingw32*|*-pc-windows],
     [AC_CHECK_TYPE(
       [struct sockaddr_in6], [], [ipv6=false], [#include <ws2tcpip.h>])],
   [AC_CHECK_TYPE(
@@ -1635,7 +1635,7 @@ AC_CHECK_DECL([system], [AC_DEFINE([HAS_SYSTEM])], [], [[#include <stdlib.h>]])
 # seem to detect it properly on Windows so we hardcode the definition
 # of HAS_UTIME on Windows but this will probably need to be clarified
 AS_CASE([$host],
-  [*-*-mingw32|*-pc-windows], [AC_DEFINE([HAS_UTIME])],
+  [*-*-mingw32*|*-pc-windows], [AC_DEFINE([HAS_UTIME])],
   [AC_CHECK_HEADER([sys/types.h],
     [AC_CHECK_HEADER([utime.h],
       [AC_CHECK_FUNC([utime], [AC_DEFINE([HAS_UTIME])])])])])
@@ -1712,7 +1712,7 @@ AC_CHECK_FUNC([setitimer],
 # Note: detection fails on Windows so hardcoding the result
 # (should be debugged later)
 AS_CASE([$host],
-  [*-*-mingw32|*-pc-windows], [AC_DEFINE([HAS_GETHOSTNAME])],
+  [*-*-mingw32*|*-pc-windows], [AC_DEFINE([HAS_GETHOSTNAME])],
   [AC_CHECK_FUNC([gethostname], [AC_DEFINE([HAS_GETHOSTNAME])])])
 
 ## uname
@@ -1736,7 +1736,7 @@ AC_CHECK_FUNC([mktime], [AC_DEFINE([HAS_MKTIME])])
 ## setsid
 
 AS_CASE([$host],
-  [*-cygwin|*-*-mingw32|*-pc-windows], [],
+  [*-cygwin|*-*-mingw32*|*-pc-windows], [],
   [AC_CHECK_FUNC([setsid], [AC_DEFINE([HAS_SETSID])])])
 
 ## putenv
@@ -1773,7 +1773,7 @@ AS_CASE([$host],
 ## shared library support
 AS_IF([$supports_shared_libraries],
   [AS_CASE([$host],
-    [*-*-mingw32|*-pc-windows|*-*-cygwin*],
+    [*-*-mingw32*|*-pc-windows|*-*-cygwin*],
       [DLLIBS=""],
     [AC_CHECK_FUNC([dlopen],
       [supports_shared_libraries=true DLLIBS=""],
@@ -1799,7 +1799,7 @@ AC_CHECK_FUNC([pwrite], [AC_DEFINE([HAS_PWRITE])])
 
 ## -fdebug-prefix-map support by the C compiler
 AS_CASE([$ocaml_cv_cc_vendor,$host],
-  [*,*-*-mingw32], [cc_has_debug_prefix_map=false],
+  [*,*-*-mingw32*], [cc_has_debug_prefix_map=false],
   [*,*-pc-windows], [cc_has_debug_prefix_map=false],
   [xlc*,powerpc-ibm-aix*], [cc_has_debug_prefix_map=false],
   [sunc*,sparc-sun-*], [cc_has_debug_prefix_map=false],
@@ -1953,7 +1953,7 @@ AS_CASE([$enable_debug_runtime],
 ## Determine how to link with the POSIX threads library
 
 AS_CASE([$host],
-  [*-*-mingw32|*-pc-windows],
+  [*-*-mingw32*|*-pc-windows],
     [PTHREAD_LIBS="-l:libpthread.a"],
   [AX_PTHREAD(
     [common_cflags="$common_cflags $PTHREAD_CFLAGS"
@@ -1987,7 +1987,7 @@ as_has_debug_prefix_map=false
 asm_cfi_supported=false
 AS_IF([$native_compiler],
   [AS_CASE([$host],
-    [*-*-mingw32|*-pc-windows], [],
+    [*-*-mingw32*|*-pc-windows], [],
     [OCAML_AS_HAS_DEBUG_PREFIX_MAP
     OCAML_AS_HAS_CFI_DIRECTIVES])])
 
@@ -2150,7 +2150,7 @@ cclibs="$cclibs $mathlib"
 AC_CHECK_LIB(execinfo, backtrace, cclibs="$cclibs -lexecinfo",[])
 
 AS_CASE([$host],
-  [*-*-mingw32],
+  [*-*-mingw32*],
     [bytecclibs="-lws2_32 -lversion -l:libpthread.a -lgcc_eh"
     nativecclibs="-lws2_32 -lversion -l:libpthread.a -lgcc_eh"],
   [*-pc-windows],
@@ -2166,7 +2166,7 @@ AS_IF([test x"$mandir" = x'${datarootdir}/man'],
   [mandir='${prefix}/man'])
 
 AS_CASE([$host],
-  [*-*-mingw32|*-pc-windows],
+  [*-*-mingw32*|*-pc-windows],
     [AS_CASE([$WINDOWS_UNICODE_MODE],
       [ansi],
         [windows_unicode=0],
@@ -2178,8 +2178,8 @@ AS_CASE([$host],
 # Define default prefix correctly for the different Windows ports
 AS_IF([test x"$prefix" = "xNONE"],
   [AS_CASE([$host],
-    [i686-w64-mingw32], [prefix='C:/ocamlmgw'],
-    [x86_64-w64-mingw32], [prefix='C:/ocamlmgw64'],
+    [i686-w64-mingw32*], [prefix='C:/ocamlmgw'],
+    [x86_64-w64-mingw32*], [prefix='C:/ocamlmgw64'],
     [i686-pc-windows], [prefix='C:/ocamlms'],
     [x86_64-pc-windows], [prefix='C:/ocamlms64'])],
   [AS_IF([test x"$unix_or_win32" = "xwin32" \
@@ -2191,7 +2191,7 @@ AS_IF([test x"$prefix" = "xNONE"],
 # but whose value is not guessed properly by configure
 # (all this should be understood and fixed)
 AS_CASE([$host],
-  [*-*-mingw32],
+  [*-*-mingw32*],
     [AC_DEFINE([HAS_BROKEN_PRINTF])
     AC_DEFINE([HAS_STRERROR])
     AC_DEFINE([HAS_IPV6])


### PR DESCRIPTION
Some mingw cross-compilation toolchain use post-fixed hostnames to denote specific features, e.g. `x86_64-w64-mingw32.static` so statically linking mingw. For instance here: https://github.com/dockcross/dockcross

This is causing issues when compiling a cross-compiler targeting mingw hosts. See for instance: https://github.com/ocaml-cross/opam-cross-windows/issues/246.

This PR fixes it by allowing any postfix when detecting mingw hosts in `configure`.