### PR TITLE
#11889: ocamldoc, type parameter fixes

### DIFF
--- a/Changes
+++ b/Changes
@@ -283,6 +283,10 @@ Working version
 - #11973: Add support for postfixed mingw host triplets
   (Romain Beauxis)
 
+- #11889, #11978: ocamldoc: handle injectivity annotations and wildcards in type
+  parameters.
+  (Florian Angeletti, report by Wiktor Kuchta, review by Jules Aguillon)
+
 ### Manual and documentation:
 
 - #9430, #11291: Document the general desugaring rules for binding operators.

--- a/ocamldoc/odoc_ast.ml
+++ b/ocamldoc/odoc_ast.ml
@@ -1228,10 +1228,7 @@ module Analyser =
                       ty_name = complete_name ;
                       ty_info = com_opt ;
                       ty_parameters =
-                      List.map2
-                       (fun p v ->
-                         let (co, cn) = Types.Variance.get_upper v in
-                         (Odoc_env.subst_type env p, co, cn))
+                      List.map2 (fun p v -> Odoc_env.subst_type env p, v)
                        tt_type_decl.Types.type_params
                        tt_type_decl.Types.type_variance ;
                       ty_kind = kind ;

--- a/ocamldoc/odoc_info.ml
+++ b/ocamldoc/odoc_info.ml
@@ -129,7 +129,7 @@ let load_modules = Odoc_analyse.load_modules
 
 let reset_type_names = Printtyp.reset
 
-let string_of_variance t (co,cn) = Odoc_str.string_of_variance t (co, cn)
+let string_of_variance t v = Odoc_str.string_of_variance t v
 
 let string_of_type_expr t = Odoc_print.string_of_type_expr t
 

--- a/ocamldoc/odoc_info.mli
+++ b/ocamldoc/odoc_info.mli
@@ -301,8 +301,8 @@ module Type :
         {
           ty_name : Name.t ; (** Complete name of the type. *)
           mutable ty_info : info option ; (** Information found in the optional associated comment. *)
-          ty_parameters : (Types.type_expr * bool * bool) list ;
-                    (** type parameters: (type, covariant, contravariant) *)
+          ty_parameters : (Types.type_expr * Types.Variance.t) list ;
+                    (** type parameters: (type, variance) *)
           ty_kind : type_kind; (** Type kind. *)
           ty_private : private_flag; (** Private or public type. *)
           ty_manifest : type_manifest option ;
@@ -687,12 +687,10 @@ module Module :
    classes (call it) and methods and attributes (don't call it).*)
 val reset_type_names : unit -> unit
 
-(** [string_of_variance t (covariant, invariant)] returns ["+"] if
-   the given information means "covariant", ["-"] if it means
-   "contravariant", orelse [""], and always [""] if the given
-   type is not an abstract type with no manifest (i.e. no need
-   for the variance to be printed).*)
-val string_of_variance : Type.t_type -> (bool * bool) -> string
+(** [string_of_variance t variance] returns the variance and injectivity
+   annotation (e.g ["+"] for covariance, ["-"] for contravariance,
+   ["!-"] for injectivity) if the type [t] is abstract.*)
+val string_of_variance : Type.t_type -> Types.Variance.t -> string
 
 (** This function returns a string representing a Types.type_expr. *)
 val string_of_type_expr : Types.type_expr -> string

--- a/ocamldoc/odoc_latex.ml
+++ b/ocamldoc/odoc_latex.ml
@@ -507,13 +507,13 @@ class latex =
 
     (** Print LaTeX code for the parameters of a type. *)
     method latex_of_type_params fmt m_name t =
-      let print_one (p, co, cn) =
-        ps fmt (Odoc_info.string_of_variance t (co,cn));
+      let print_one (p, v) =
+        ps fmt (Odoc_info.string_of_variance t v);
         ps fmt (self#normal_type m_name p)
       in
       match t.ty_parameters with
         [] -> ()
-      | [(p,co,cn)] -> print_one (p, co, cn)
+      | [t] -> print_one t
       | _ ->
           ps fmt "(";
           print_concat fmt ", " print_one t.ty_parameters;

--- a/ocamldoc/odoc_sig.ml
+++ b/ocamldoc/odoc_sig.ml
@@ -1059,9 +1059,7 @@ module Analyser =
                       ty_name = Name.concat current_module_name name.txt ;
                       ty_info = assoc_com ;
                       ty_parameters =
-                        List.map2 (fun p v ->
-                          let (co, cn) = Types.Variance.get_upper v in
-                          (Odoc_env.subst_type env p,co, cn))
+                        List.map2 (fun p v -> Odoc_env.subst_type env p,v)
                         sig_type_decl.Types.type_params
                         sig_type_decl.Types.type_variance;
                       ty_kind = type_kind;
@@ -1144,9 +1142,7 @@ module Analyser =
                       ty_name = Name.concat current_module_name name.txt ;
                       ty_info = assoc_com ;
                       ty_parameters =
-                        List.map2 (fun p v ->
-                          let (co, cn) = Types.Variance.get_upper v in
-                          (Odoc_env.subst_type env p,co, cn))
+                        List.map2 (fun p v -> Odoc_env.subst_type env p,v)
                         sig_type_decl.Types.type_params
                         sig_type_decl.Types.type_variance;
                       ty_kind = type_kind;

--- a/ocamldoc/odoc_str.ml
+++ b/ocamldoc/odoc_str.ml
@@ -55,10 +55,15 @@ let print_type_scheme ppf t =
   else
     Printtyp.shared_type_scheme ppf t
 
-let print_type_param t ppf (param,co,cn) =
-  Format.fprintf ppf "%s%a"
-    (string_of_variance t (co, cn))
-    print_type_scheme param
+let print_type_param decl ppf (param,co,cn) =
+  (* HACK: we print type parameters as type expressions, and amend ["'_"] to ["_"] *)
+  let ty = Format.asprintf "%a" Printtyp.shared_type_scheme param in
+  let ty = if ty = "'_" then "_" else ty in
+  let var = string_of_variance decl (co, cn) in
+  if need_parent param then
+    Format.fprintf  ppf "(%s%s)" var ty
+  else
+    Format.fprintf ppf "%s%s" var ty
 
 let raw_string_of_type_list sep elt ppf type_list =
   let pp_sep ppf () = Format.fprintf ppf "@,%s" sep in

--- a/ocamldoc/odoc_str.mli
+++ b/ocamldoc/odoc_str.mli
@@ -15,8 +15,9 @@
 
 (** The functions to get a string from different kinds of elements (types, modules, ...). *)
 
-(** @return the variance string for the given type and (covariant, contravariant) information. *)
-val string_of_variance : Odoc_type.t_type -> (bool * bool) -> string
+(** @return the variance and injectivity annotation for the given type and
+    variance and injectivity information. *)
+val string_of_variance : Odoc_type.t_type -> Types.Variance.t -> string
 
 (** This function returns a string to represent the given list of types,
    with a given separator.

--- a/ocamldoc/odoc_texi.ml
+++ b/ocamldoc/odoc_texi.ml
@@ -625,15 +625,14 @@ class texi =
 
 
     method string_of_type_parameters t =
-      let f (tp, co, cn) =
+      let f (tp, v) =
         Printf.sprintf "%s%s"
-          (Odoc_info.string_of_variance t (co, cn))
+          (Odoc_info.string_of_variance t v)
           (Odoc_info.string_of_type_expr tp)
       in
       match t.ty_parameters with
       | [] -> ""
-      | [ (tp, co, cn) ] ->
-          (f (tp, co, cn))^" "
+      | [ tv ] -> (f tv)^" "
       | l ->
           Printf.sprintf "(%s) "
             (String.concat ", " (List.map f l))

--- a/ocamldoc/odoc_type.ml
+++ b/ocamldoc/odoc_type.ml
@@ -59,8 +59,7 @@ type type_manifest =
 type t_type = {
     ty_name : Name.t ;
     mutable ty_info : Odoc_types.info option ; (** optional user information *)
-    ty_parameters : (Types.type_expr * bool * bool) list ;
-                    (** type parameters: (type, covariant, contravariant) *)
+    ty_parameters : (Types.type_expr * Types.Variance.t ) list ;
     ty_kind : type_kind ;
     ty_private : private_flag;
     ty_manifest : type_manifest option;

--- a/ocamldoc/odoc_type.mli
+++ b/ocamldoc/odoc_type.mli
@@ -63,7 +63,7 @@ type type_manifest =
 type t_type = {
   ty_name : Name.t;
   mutable ty_info : Odoc_types.info option;
-  ty_parameters : (Types.type_expr * bool * bool) list;
+  ty_parameters : (Types.type_expr * Types.Variance.t) list;
   ty_kind : type_kind;
   ty_private : private_flag;
   ty_manifest : type_manifest option;


### PR DESCRIPTION
When generating the documentation, `ocamldoc` prints the type parameters of type declarations as if those parameters were just type variables.

This fails in many different ways in presence of either constraints
```ocaml
type ('a,'b) t constraint 'a = 'b
```
which is printed as
```ocaml
type ('a,'a) t
```
or  wildcard type parameters
```ocaml
type _ t
```
which is printed as
```ocaml
type '_ t
```

The right fix would require to rewire the handling of type declarations in ocamldoc in order to use the functions exposed by `Printtyp`.

To avoid such amount of changes, this PR takes the easy path and patches `"'_"` to `"_"` when printing type parameters.

In a semi-related ways, the third commit adds also supports to injectivity annotations.

With those two changes, ocamldoc is once again able to generate the documentation for the standard library.

Close #11889