### PR TITLE
fix quadratic behavior in natdynlink by using a STW section for frame-descriptor updates

### DIFF
--- a/Changes
+++ b/Changes
@@ -81,11 +81,16 @@ Working version
 - #11474, #11998: Add support for user-defined events in the runtime event
   tracing system. (Lucas Pluvinage, review by Sadiq Jaffer)
 
+- #11827: Restore prefetching for GC marking
+  (Fabrice Buoro and Stephen Dolan, review by Gabriel Scherer and Sadiq Jaffer)
+
 - #11935: Load frametables of dynlink'd modules in batch
   (Stephen Dolan, review by David Allsopp and Guillaume Munch-Maccagnoni)
 
-- #11827: Restore prefetching for GC marking
-  (Fabrice Buoro and Stephen Dolan, review by Gabriel Scherer and Sadiq Jaffer)
+- #11980: fix quadratic behavior in natdynlink by using a STW section
+  for frame-descriptor updates.
+  (Gabriel Scherer, review by Sadiq Jaffer, report by André Maroneze
+  for Frama-C and Guillaume Melquiond for Coq)
 
 ### Type system:
 


### PR DESCRIPTION
This PR proposes a fix for the quadratic behavior discussed in https://github.com/ocaml/ocaml/pull/11673#issuecomment-1297384255 (which causes performance regressions in both Frama-C and Coq, see also https://github.com/ocaml/ocaml/issues/11926).

We have discussed several implementation strategies to fix the quadratic behavior:

1. use the STW for synchronization: https://github.com/ocaml/ocaml/pull/11673#issuecomment-1399451455
2. use a hashtable with safe concurrent addition: https://github.com/ocaml/ocaml/issues/11926#issuecomment-1399512446
3. use a reader-writer lock: https://github.com/ocaml/ocaml/pull/11673#issuecomment-1399530867

This PR implements option (1): updates to the "current" caml_frame_descrs table are performed in a STW section. This allows unprotected access to caml_frame_descrs from mutators.

Note: I have not tested yet that the quadratic behavior is really gone from Frama-C or Coq. (Compiling them on the current trunk sounds a bit exhausting.) I am thinking of writing a synthetic test instead, but I am not sure how to proceed with that.