### PR TITLE
Reduce size of installed bytecode executables

### DIFF
--- a/Changes
+++ b/Changes
@@ -438,6 +438,12 @@ Working version
   full command-lines).
   (Xavier Leroy, Nicolás Ojeda Bär, review by Sébastien Hinderer)
 
+- #11981: Reduce size of OCaml installations by removing debugging information
+  from installed bytecode executables.  It is no longer possible to
+  run ocamldebug over these installed bytecode executables, nor to get
+  exception backtraces for them.
+  (Xavier Leroy, review by David Allsopp)
+
 ### Bug fixes:
 
 - #11887, #11893: Code duplication in pattern-matching compilation

--- a/Makefile
+++ b/Makefile
@@ -237,9 +237,9 @@ compare:
 # The core system has to be rebuilt after bootstrap anyway, so strip ocamlc
 # and ocamllex, which means the artefacts should be identical.
 	mv ocamlc$(EXE) ocamlc.tmp
-	$(OCAMLRUN) tools/stripdebug ocamlc.tmp ocamlc$(EXE)
+	$(OCAMLRUN) tools/stripdebug -all ocamlc.tmp ocamlc$(EXE)
 	mv lex/ocamllex$(EXE) ocamllex.tmp
-	$(OCAMLRUN) tools/stripdebug ocamllex.tmp lex/ocamllex$(EXE)
+	$(OCAMLRUN) tools/stripdebug -all ocamllex.tmp lex/ocamllex$(EXE)
 	rm -f ocamllex.tmp ocamlc.tmp
 	@if $(CMPCMD) boot/ocamlc ocamlc$(EXE) \
          && $(CMPCMD) boot/ocamllex lex/ocamllex$(EXE); \
@@ -267,7 +267,7 @@ promote-cross: promote-common
 # Promote the newly compiled system to the rank of bootstrap compiler
 # (Runs on the new runtime, produces code for the new runtime)
 .PHONY: promote
-promote: PROMOTE = $(OCAMLRUN) tools/stripdebug
+promote: PROMOTE = $(OCAMLRUN) tools/stripdebug -all
 promote: promote-common
 	rm -f boot/ocamlrun$(EXE)
 	cp runtime/ocamlrun$(EXE) boot/ocamlrun$(EXE)

--- a/Makefile
+++ b/Makefile
@@ -467,7 +467,7 @@ ocamlc_LIBRARIES = $(addprefix compilerlibs/,ocamlcommon ocamlbytecomp)
 
 ocamlc_MODULES = driver/main
 
-ocamlc$(EXE): OC_BYTECODE_LDFLAGS += -compat-32
+ocamlc$(EXE): OC_BYTECODE_LDFLAGS += -compat-32 -g
 
 ocamlc.opt$(EXE): OC_NATIVE_LDFLAGS += $(addprefix -cclib ,$(BYTECCLIBS))
 
@@ -480,6 +480,8 @@ ocamlopt_LIBRARIES = $(addprefix compilerlibs/,ocamlcommon ocamloptcomp)
 
 ocamlopt_MODULES = driver/optmain
 
+ocamlopt$(EXE): OC_BYTECODE_LDFLAGS += -g
+
 partialclean::
 	rm -f ocamlopt ocamlopt.exe ocamlopt.opt ocamlopt.opt.exe
 
@@ -491,7 +493,7 @@ ocaml_LIBRARIES = \
 ocaml_MODULES = toplevel/topstart
 
 .INTERMEDIATE: ocaml.tmp
-ocaml.tmp: OC_BYTECODE_LDFLAGS += -I toplevel/byte -linkall
+ocaml.tmp: OC_BYTECODE_LDFLAGS += -I toplevel/byte -linkall -g
 ocaml.tmp: $(ocaml_LIBRARIES:=.cma) $(ocaml_MODULES:=.cmo)
 	$(V_LINKC)$(LINK_BYTECODE_PROGRAM) -o $@ $^
 

--- a/Makefile
+++ b/Makefile
@@ -1610,7 +1610,8 @@ endif
 	  "$(INSTALL_INCDIR)"
 	$(INSTALL_PROG) ocaml$(EXE) "$(INSTALL_BINDIR)"
 ifeq "$(INSTALL_BYTECODE_PROGRAMS)" "true"
-	$(INSTALL_PROG) ocamlc$(EXE) "$(INSTALL_BINDIR)/ocamlc.byte$(EXE)"
+	$(call INSTALL_STRIPPED_BYTE_PROG,\
+               ocamlc$(EXE),"$(INSTALL_BINDIR)/ocamlc.byte$(EXE)")
 endif
 	$(MAKE) -C stdlib install
 ifeq "$(INSTALL_BYTECODE_PROGRAMS)" "true"
@@ -1737,7 +1738,8 @@ ifneq "$(runtime_NATIVE_SHARED_LIBRARIES)" ""
 	$(INSTALL_PROG) $(runtime_NATIVE_SHARED_LIBRARIES) "$(INSTALL_LIBDIR)"
 endif
 ifeq "$(INSTALL_BYTECODE_PROGRAMS)" "true"
-	$(INSTALL_PROG) ocamlopt$(EXE) "$(INSTALL_BINDIR)/ocamlopt.byte$(EXE)"
+	$(call INSTALL_STRIPPED_BYTE_PROG,\
+               ocamlopt$(EXE),"$(INSTALL_BINDIR)/ocamlopt.byte$(EXE)")
 endif
 	$(MAKE) -C stdlib installopt
 	$(INSTALL_DATA) \

--- a/Makefile.build_config.in
+++ b/Makefile.build_config.in
@@ -108,13 +108,13 @@ DEFAULT_BUILD_TARGET = @default_build_target@
 OC_COMMON_CFLAGS = -g -strict-sequence -principal -absname \
   -w +a-4-9-40-41-42-44-45-48 -warn-error +a -bin-annot \
   -strict-formats
-OC_COMMON_LDFLAGS = -g $(INCLUDES)
+OC_COMMON_LDFLAGS = $(INCLUDES)
 
 OC_BYTECODE_LDFLAGS =
 
 OC_NATIVE_CFLAGS = @oc_native_cflags@
 
-OC_NATIVE_LDFLAGS =
+OC_NATIVE_LDFLAGS = -g
 
 # Platform-dependent command to create symbolic links
 LN = @ln@

--- a/Makefile.common
+++ b/Makefile.common
@@ -276,3 +276,10 @@ define OCAML_PROGRAM
 $(eval $(call OCAML_BYTECODE_PROGRAM,$(1)))
 $(eval $(call OCAML_NATIVE_PROGRAM,$(1).opt))
 endef # OCAML_PROGRAM
+
+# Installing a bytecode executable, with debug information removed
+define INSTALL_STRIPPED_BYTE_PROG
+$(OCAMLRUN) $(ROOTDIR)/tools/stripdebug $(1) $(1).tmp \
+&& $(INSTALL_PROG) $(1).tmp $(2) \
+&& rm $(1).tmp
+endef # INSTALL_STRIPPED_BYTE_PROG

--- a/debugger/Makefile
+++ b/debugger/Makefile
@@ -21,7 +21,7 @@ include $(ROOTDIR)/Makefile.best_binaries
 DYNLINKDIR=$(ROOTDIR)/otherlibs/dynlink
 UNIXDIR=$(ROOTDIR)/otherlibs/unix
 
-CAMLC=$(BEST_OCAMLC) $(STDLIBFLAGS) -g
+CAMLC=$(BEST_OCAMLC) $(STDLIBFLAGS)
 COMPFLAGS=$(INCLUDES) -absname -w +a-4-9-41-42-44-45-48-70 -warn-error +A \
           -strict-sequence -strict-formats
 LINKFLAGS=-linkall -I $(UNIXDIR) -I $(DYNLINKDIR)

--- a/ocamldoc/Makefile
+++ b/ocamldoc/Makefile
@@ -67,7 +67,7 @@ COMPFLAGS = \
   -g $(INCLUDES) -absname -w +a-4-9-41-42-44-45-48 -warn-error +A \
   -strict-sequence -strict-formats -bin-annot -principal
 
-LINKFLAGS = -g $(INCLUDES)
+LINKFLAGS = $(INCLUDES)
 
 CMOFILES=\
   odoc_config.cmo \

--- a/tools/stripdebug.ml
+++ b/tools/stripdebug.ml
@@ -13,13 +13,20 @@
 (*                                                                        *)
 (**************************************************************************)
 
-(* Copy a bytecode executable, removing debugging information
-   and #! header from the copy.
-   Usage: stripdebug <source file> <dest file>
+(* Copy a bytecode executable, removing debugging information and possibly
+   dynlink information and #! header from the copy.
 *)
 
-open Printf
 open Misc
+
+let remove_header = ref false
+let remove_DBUG = ref true
+let remove_CRCS = ref false
+
+let remove_section = function
+  | "DBUG" -> !remove_DBUG
+  | "CRCS" -> !remove_CRCS
+  | _ -> false
 
 let stripdebug infile outfile =
   let ic = open_in_bin infile in
@@ -29,13 +36,19 @@ let stripdebug infile outfile =
   let oc =
     open_out_gen [Open_wronly; Open_creat; Open_trunc; Open_binary] 0o777
                  outfile in
-  (* Skip the #! header, going straight to the first section. *)
-  seek_in ic pos_first_section;
-  (* Copy each section except DBUG and CRCS *)
+  if !remove_header then begin
+    (* Skip the #! header, going straight to the first section. *)
+    seek_in ic pos_first_section
+  end else begin
+    (* Copy header up to first section *)
+    seek_in ic 0;
+    copy_file_chunk ic oc pos_first_section
+  end;
+  (* Copy each section except those to be removed *)
   Bytesections.init_record oc;
   List.iter
     (fun (name, len) ->
-      if name = "DBUG" || name = "CRCS" then begin
+      if remove_section name then begin
         seek_in ic (pos_in ic + len)
       end else begin
         copy_file_chunk ic oc len;
@@ -48,12 +61,33 @@ let stripdebug infile outfile =
   close_in ic;
   close_out oc
 
-let main () =
-  if Array.length Sys.argv = 3
-  then stripdebug Sys.argv.(1) Sys.argv.(2)
-  else begin
-    eprintf "Usage: stripdebug <source file> <destination file>\n";
-    exit 2
-  end
+let options = [
+  "-remove-header", Arg.Set remove_header,
+     "remove the header that calls ocamlrun automatically";
+  "-keep-header", Arg.Clear remove_header,
+     "preserve the header that calls ocamlrun automatically (default)";
+  "-remove-debug", Arg.Set remove_DBUG,
+     "remove all debugging information (default)";
+  "-keep-debug", Arg.Clear remove_DBUG,
+     "preserve all debugging information";
+  "-remove-dynlink", Arg.Set remove_CRCS,
+     "remove the data needed for dynamic code loading";
+  "-keep-dynlink", Arg.Clear remove_CRCS,
+     "preserve the data needed for dynamic code loading (default)";
+  "-all", Arg.Unit (fun () -> remove_header := true; remove_DBUG := true;
+                              remove_CRCS := true),
+     "remove header, debugging info, and dynamic code loading info"
+]
 
-let _ = main ()
+let usage =
+"Usage: stripdebug [options] <input file> <output file>\n\
+Options are:"
+
+let main() =
+  let anon = ref [] in
+  Arg.parse options (fun x -> anon := x :: !anon) usage;
+  match !anon with
+  | [output; input] -> stripdebug input output
+  | _ -> Arg.usage options usage; exit 2
+
+let _ = main()

--- a/tools/stripdebug.ml
+++ b/tools/stripdebug.ml
@@ -36,7 +36,7 @@ let stripdebug infile outfile =
   List.iter
     (fun (name, len) ->
       if name = "DBUG" || name = "CRCS" then begin
-        seek_in ic (in_channel_length ic + len)
+        seek_in ic (pos_in ic + len)
       end else begin
         copy_file_chunk ic oc len;
         Bytesections.record oc name


### PR DESCRIPTION
There have been complaints that OCaml installations (e.g. OPAM switches) take up too much disk space.  An obvious culprit is the bytecode executables for ocamlc, ocamlopt, ocamlobjinfo, ocamldoc, etc, which are > 20 Mb.  18 of those 20 Mb are debugging information, which are sometimes useful for core  developers (who need to run ocamldebug over ocamlc, for instance) but not for end-users.

This PR addresses partially this issue by:
- linking bytecode executables without `-g` by default (but .cmo files are still built with `ocamlc -g`, so that compilerlibs contains full debugging information);
- as an exception, `ocamlc` and `ocamlopt` are linked with `ocamlc -g`, so that developers can still play ocamldebug games with them; additionally, `ocaml` is linked with `-g` too so that end users can benefit from stack backtraces;
- removing debugging information from `ocamlc` and `ocamlopt` when installing them in the bin/ installation directory.

To support this, the `tools/stripdebug.ml` tool was extended, and a silly bug fixed.

Some measurements (on a Mac M1):
- total size of installation: 469M before, 310M with this PR;
- size of bin/ subdirectory: 263M before, 122M with this PR.

Further reductions in size are possible, stay tuned for more PRs.

