### PR TITLE
[occurrences] Store modules' shapes in env sumaries

### DIFF
--- a/typing/env.ml
+++ b/typing/env.ml
@@ -151,7 +151,8 @@ type summary =
   | Env_value of summary * Ident.t * value_description
   | Env_type of summary * Ident.t * type_declaration
   | Env_extension of summary * Ident.t * extension_constructor
-  | Env_module of summary * Ident.t * module_presence * module_declaration
+  | Env_module of
+      summary * Ident.t * module_presence * module_declaration * Shape.t
   | Env_modtype of summary * Ident.t * modtype_declaration
   | Env_class of summary * Ident.t * class_declaration
   | Env_cltype of summary * Ident.t * class_type_declaration
@@ -168,7 +169,7 @@ let map_summary f = function
   | Env_value (s, id, d) -> Env_value (f s, id, d)
   | Env_type (s, id, d) -> Env_type (f s, id, d)
   | Env_extension (s, id, d) -> Env_extension (f s, id, d)
-  | Env_module (s, id, p, d) -> Env_module (f s, id, p, d)
+  | Env_module (s, id, p, d, sh) -> Env_module (f s, id, p, d, sh)
   | Env_modtype (s, id, d) -> Env_modtype (f s, id, d)
   | Env_class (s, id, d) -> Env_class (f s, id, d)
   | Env_cltype (s, id, d) -> Env_cltype (f s, id, d)
@@ -2085,7 +2086,7 @@ and store_module ?(update_summary=true) ~check
   in
   let summary =
     if not update_summary then env.summary
-    else Env_module (env.summary, id, presence, force_module_decl md) in
+    else Env_module (env.summary, id, presence, force_module_decl md, shape) in
   { env with
     modules = IdTbl.add id (Mod_local mda) env.modules;
     summary }

--- a/typing/env.mli
+++ b/typing/env.mli
@@ -36,7 +36,8 @@ type summary =
   | Env_value of summary * Ident.t * value_description
   | Env_type of summary * Ident.t * type_declaration
   | Env_extension of summary * Ident.t * extension_constructor
-  | Env_module of summary * Ident.t * module_presence * module_declaration
+  | Env_module of
+      summary * Ident.t * module_presence * module_declaration * Shape.t
   | Env_modtype of summary * Ident.t * modtype_declaration
   | Env_class of summary * Ident.t * class_declaration
   | Env_cltype of summary * Ident.t * class_type_declaration

--- a/typing/envaux.ml
+++ b/typing/envaux.ml
@@ -47,8 +47,8 @@ let rec env_from_summary sum subst =
           Env.add_extension ~check:false ~rebind:false id
             (Subst.extension_constructor subst desc)
             (env_from_summary s subst)
-      | Env_module(s, id, pres, desc) ->
-          Env.add_module_declaration ~check:false id pres
+      | Env_module(s, id, pres, desc, shape) ->
+          Env.add_module_declaration ~check:false ~shape id pres
             (Subst.module_declaration Keep subst desc)
             (env_from_summary s subst)
       | Env_modtype(s, id, desc) ->
@@ -68,9 +68,9 @@ let rec env_from_summary sum subst =
           | Error `Functor -> assert false
           | Error `Not_found -> raise (Error (Module_not_found path'))
           end
-      | Env_functor_arg(Env_module(s, id, pres, desc), id')
+      | Env_functor_arg(Env_module(s, id, pres, desc, shape), id')
             when Ident.same id id' ->
-          Env.add_module_declaration ~check:false
+          Env.add_module_declaration ~check:false ~shape
             id pres (Subst.module_declaration Keep subst desc)
             ~arg:true (env_from_summary s subst)
       | Env_functor_arg _ -> assert false


### PR DESCRIPTION
When the shapes were introduced into the compiler it was primarily with the goal of supporting `jump-to-definition`. For this purpose, visible shapes of compilation units where added to the cmt files and Merlin use these when reducing a value's shape to find its definition.

However, when indexing the code-base to provide project-wide occurrences having only the shape of the top-level of the compilation unit is not sufficient: one have to iterate over values in the cmt's Typedtree and reduce their shapes and that reduction require access to intermediate modules' shapes.

However, naively adding the shapes to the summaries impact the cmt filesize a lot. On Irmin, with this PR, it goes from 190M to 522M. This is the reason why I opened this PR as a draft, so that we can discuss options.

1. I was expecting more sharing to take place. Maybe there is a way to optimize for it ? (ping @trefis) Or maybe we simply add a lot of otherwise discarded information.
2. Maybe we could cut some branches down an only store the shapes of modules which are eventually exposed by the compilation unit ?
3. We discuss with @lpw25  the possibility of having the compiler store the CU's index itself: a table from partially reduced shapes to locations. Doing that should remove the need from having the shapes of intermediate modules.

For now I have little hopes for 1, and will have a try at 2 since it sounds less invasive than 3. Any comments / ideas are welcome :-) 