### PR TITLE
Rebuild testsuite tools on compiler-libs changes

### DIFF
--- a/testsuite/tools/Makefile
+++ b/testsuite/tools/Makefile
@@ -43,10 +43,13 @@ codegen_LIBS = $(addprefix $(COMPILERLIBSDIR)/,\
 codegen_OBJECTS = $(addsuffix .cmo,\
   parsecmmaux parsecmm lexcmm codegen_main)
 
+ALL_LIBS = $(expect_LIBS)
+
 tools := $(expect_PROG)
 
 ifeq "$(NATIVE_COMPILER)" "true"
 tools += $(codegen_PROG)
+ALL_LIBS += $(codegen_LIBS)
 ifneq "$(CCOMPTYPE)-$(ARCH)" "msvc-amd64"
 # The asmgen tests are not ported to MSVC64 yet
 # so do not compile any arch-specific module
@@ -74,13 +77,13 @@ lexcmm.cmo: lexcmm.cmi
 
 parsecmm.cmo: parsecmm.cmi
 
-%.cmi: %.mli
+%.cmi: %.mli $(ALL_LIBS:=.cma)
 	$(OCAMLC) $(COMPFLAGS) -c $<
 
-%.cmo: %.ml
+%.cmo: %.ml $(ALL_LIBS:=.cma)
 	$(OCAMLC) $(COMPFLAGS) -c $<
 
-%.cmx: %.ml
+%.cmx: %.ml $(ALL_LIBS:=.cmxa)
 	$(OCAMLOPT) $(COMPFLAGS) -c $<
 
 %.$(O): %.S


### PR DESCRIPTION
First part of #11970. This causes both `expect_test` and `codegen` to be completely recompiled if any of the compiler-libs change, which prevents any chance of an inconsistent assumptions. A similar trick _might_ want doing with the stdlib, but I think it's probably better to encounter that as a problem before speculatively adding more dependencies.