### PR TITLE
Minor readability improvements to frame descriptors

### DIFF
--- a/Changes
+++ b/Changes
@@ -20,9 +20,6 @@ Working version
 
 ### Runtime system:
 
-- #11990: Improve comments and macros around frame descriptors.
-  (Nick Barnes, review by ??)
-
 - #11919: New runtime events counters for major heap stats and minor heap
   resizing.
   (Sadiq Jaffer, review by Gabriel Scherer and David Allsopp)
@@ -357,6 +354,9 @@ Working version
   (Douglas Smith and Dmitrii Kosarev, review by Gabriel Scherer)
 
 ### Internal/compiler-libs changes:
+
+- #11990: Improve comments and macros around frame descriptors.
+  (Nick Barnes, review by Gabriel Scherer)
 
 - #11847, #11849, #11851, #11898: small refactorings in the type checker
   (Gabriel Scherer, review by Nicolás Ojeda Bär)

--- a/Changes
+++ b/Changes
@@ -20,6 +20,9 @@ Working version
 
 ### Runtime system:
 
+- #11990: Improve comments and macros around frame descriptors.
+  (Nick Barnes, review by ??)
+
 - #11919: New runtime events counters for major heap stats and minor heap
   resizing.
   (Sadiq Jaffer, review by Gabriel Scherer and David Allsopp)

--- a/runtime/backtrace_nat.c
+++ b/runtime/backtrace_nat.c
@@ -47,9 +47,9 @@ frame_descr * caml_next_frame_descriptor
     }
 
     /* Skip to next frame */
-    if (!FRAME_CHUNK_TOP(d)) {
+    if (!frame_return_to_C(d)) {
       /* Regular frame, update sp/pc and return the frame descriptor */
-      *sp += FRAME_SIZE(d);
+      *sp += frame_size(d);
       *pc = Saved_return_address(*sp);
       return d;
     } else {
@@ -222,16 +222,17 @@ debuginfo caml_debuginfo_extract(backtrace_slot slot)
   uint32_t debuginfo_offset;
   frame_descr * d = (frame_descr *)slot;
 
-  /* The special frames marking the top of an ML stack chunk are never
-     returned by caml_next_frame_descriptor, so should never reach here. */
-  CAMLassert(!FRAME_CHUNK_TOP(d));
+  /* The special frames marking returns from Caml to C are never
+     returned by caml_next_frame_descriptor, so should never reach
+     here. */
+  CAMLassert(!frame_return_to_C(d));
 
-  if (!FRAME_HAS_DEBUG(d)) {
+  if (!frame_has_debug(d)) {
     return NULL;
   }
   /* Recover debugging info */
   infoptr = (unsigned char*)&d->live_ofs[d->num_live];
-  if (FRAME_HAS_ALLOC(d)) {
+  if (frame_has_allocs(d)) {
     /* skip alloc_lengths */
     infoptr += *infoptr + 1;
     /* align to 32 bits */

--- a/runtime/backtrace_nat.c
+++ b/runtime/backtrace_nat.c
@@ -47,9 +47,9 @@ frame_descr * caml_next_frame_descriptor
     }
 
     /* Skip to next frame */
-    if (d->frame_size != 0xFFFF) {
+    if (!FRAME_CHUNK_TOP(d)) {
       /* Regular frame, update sp/pc and return the frame descriptor */
-      *sp += (d->frame_size & 0xFFFC);
+      *sp += FRAME_SIZE(d);
       *pc = Saved_return_address(*sp);
       return d;
     } else {
@@ -224,14 +224,14 @@ debuginfo caml_debuginfo_extract(backtrace_slot slot)
 
   /* The special frames marking the top of an ML stack chunk are never
      returned by caml_next_frame_descriptor, so should never reach here. */
-  CAMLassert(d->frame_size != 0xffff);
+  CAMLassert(!FRAME_CHUNK_TOP(d));
 
-  if ((d->frame_size & 1) == 0) {
+  if (!FRAME_HAS_DEBUG(d)) {
     return NULL;
   }
   /* Recover debugging info */
   infoptr = (unsigned char*)&d->live_ofs[d->num_live];
-  if (d->frame_size & 2) {
+  if (FRAME_HAS_ALLOC(d)) {
     /* skip alloc_lengths */
     infoptr += *infoptr + 1;
     /* align to 32 bits */

--- a/runtime/caml/config.h
+++ b/runtime/caml/config.h
@@ -49,6 +49,7 @@
 #ifndef CAML_CONFIG_H_NO_TYPEDEFS
 
 #include <stddef.h>
+#include <stdbool.h>
 
 #if defined(HAS_LOCALE_H) || defined(HAS_XLOCALE_H)
 #define HAS_LOCALE

--- a/runtime/fiber.c
+++ b/runtime/fiber.c
@@ -248,7 +248,7 @@ next_chunk:
   while(1) {
     d = caml_find_frame_descr(fds, retaddr);
     CAMLassert(d);
-    if (!FRAME_CHUNK_TOP(d)) {
+    if (!frame_return_to_C(d)) {
       /* Scan the roots in this frame */
       for (p = d->live_ofs, n = d->num_live; n > 0; n--, p++) {
         ofs = *p;
@@ -260,7 +260,7 @@ next_chunk:
         f (fdata, *root, root);
       }
       /* Move to next frame */
-      sp += FRAME_SIZE(d);
+      sp += frame_size(d);
       retaddr = Saved_return_address(sp);
       /* XXX KC: disabled already scanned optimization. */
     } else {

--- a/runtime/fiber.c
+++ b/runtime/fiber.c
@@ -248,7 +248,7 @@ next_chunk:
   while(1) {
     d = caml_find_frame_descr(fds, retaddr);
     CAMLassert(d);
-    if (d->frame_size != 0xFFFF) {
+    if (!FRAME_CHUNK_TOP(d)) {
       /* Scan the roots in this frame */
       for (p = d->live_ofs, n = d->num_live; n > 0; n--, p++) {
         ofs = *p;
@@ -260,7 +260,7 @@ next_chunk:
         f (fdata, *root, root);
       }
       /* Move to next frame */
-      sp += (d->frame_size & 0xFFFC);
+      sp += FRAME_SIZE(d);
       retaddr = Saved_return_address(sp);
       /* XXX KC: disabled already scanned optimization. */
     } else {

--- a/runtime/frame_descriptors.c
+++ b/runtime/frame_descriptors.c
@@ -36,19 +36,19 @@ extern intnat * caml_frametable[];
 static frame_descr * next_frame_descr(frame_descr * d) {
   unsigned char num_allocs = 0, *p;
   CAMLassert(d->retaddr >= 4096);
-  if (!FRAME_CHUNK_TOP(d)) {
+  if (!frame_return_to_C(d)) {
     /* Skip to end of live_ofs */
     p = (unsigned char*)&d->live_ofs[d->num_live];
     /* Skip alloc_lengths if present */
-    if (FRAME_HAS_ALLOC(d)) {
+    if (frame_has_allocs(d)) {
       num_allocs = *p;
       p += num_allocs + 1;
     }
     /* Skip debug info if present */
-    if (FRAME_HAS_DEBUG(d)) {
+    if (frame_has_debug(d)) {
       /* Align to 32 bits */
       p = Align_to(p, uint32_t);
-      p += sizeof(uint32_t) * (FRAME_HAS_ALLOC(d) ? num_allocs : 1);
+      p += sizeof(uint32_t) * (frame_has_allocs(d) ? num_allocs : 1);
     }
     /* Align to word size */
     p = Align_to(p, void*);

--- a/runtime/frame_descriptors.c
+++ b/runtime/frame_descriptors.c
@@ -36,19 +36,19 @@ extern intnat * caml_frametable[];
 static frame_descr * next_frame_descr(frame_descr * d) {
   unsigned char num_allocs = 0, *p;
   CAMLassert(d->retaddr >= 4096);
-  if (d->frame_size != 0xFFFF) {
+  if (!FRAME_CHUNK_TOP(d)) {
     /* Skip to end of live_ofs */
     p = (unsigned char*)&d->live_ofs[d->num_live];
     /* Skip alloc_lengths if present */
-    if (d->frame_size & 2) {
+    if (FRAME_HAS_ALLOC(d)) {
       num_allocs = *p;
       p += num_allocs + 1;
     }
     /* Skip debug info if present */
-    if (d->frame_size & 1) {
+    if (FRAME_HAS_DEBUG(d)) {
       /* Align to 32 bits */
       p = Align_to(p, uint32_t);
-      p += sizeof(uint32_t) * (d->frame_size & 2 ? num_allocs : 1);
+      p += sizeof(uint32_t) * (FRAME_HAS_ALLOC(d) ? num_allocs : 1);
     }
     /* Align to word size */
     p = Align_to(p, void*);

--- a/runtime/signals_nat.c
+++ b/runtime/signals_nat.c
@@ -57,7 +57,7 @@ void caml_garbage_collection(void)
   { /* Find the frame descriptor for the current allocation */
     d = caml_find_frame_descr(fds, retaddr);
     /* Must be an allocation frame */
-    CAMLassert(!FRAME_CHUNK_TOP(d) && FRAME_HAS_ALLOC(d));
+    CAMLassert(d && !frame_return_to_C(d) && frame_has_allocs(d));
   }
 
   { /* Compute the total allocation size at this point,

--- a/runtime/signals_nat.c
+++ b/runtime/signals_nat.c
@@ -57,7 +57,7 @@ void caml_garbage_collection(void)
   { /* Find the frame descriptor for the current allocation */
     d = caml_find_frame_descr(fds, retaddr);
     /* Must be an allocation frame */
-    CAMLassert(d && d->frame_size != 0xFFFF && (d->frame_size & 2));
+    CAMLassert(!FRAME_CHUNK_TOP(d) && FRAME_HAS_ALLOC(d));
   }
 
   { /* Compute the total allocation size at this point,


### PR DESCRIPTION
It took me a while to grasp how the frame descriptor structure worked, because of an out-of-date comment and numerous un-commented hard-wired constants. Hopefully with this little change it will be easier for the next person.