### PR TITLE
Compile non-speed-critical tools to bytecode only

### DIFF
--- a/Changes
+++ b/Changes
@@ -300,6 +300,13 @@ Working version
   parameters.
   (Florian Angeletti, report by Wiktor Kuchta, review by Jules Aguillon)
 
+* #11993: install only bytecode executables for the `ocamlmklib`, `ocamlcmt`,
+  `ocamlprof`, `ocamlcp`, `ocamloptp`, and `ocamlmktop` tools, but no
+  native-code executables.  A tool like `ocamlmklib` for example is now
+  installed directly to `$BINDIR/ocamlmklib`; `ocamlmklib.byte` and
+  `ocamlmklib.opt` are no longer installed to `$BINDIR`.
+  (Xavier Leroy, review by Gabriel Scherer)
+
 ### Manual and documentation:
 
 - #9430, #11291: Document the general desugaring rules for binding operators.

--- a/Makefile
+++ b/Makefile
@@ -110,11 +110,11 @@ ocamllex_PROGRAMS = $(addprefix lex/,ocamllex ocamllex.opt)
 ocamlyacc_PROGRAM = yacc/ocamlyacc
 
 # Tools to be compiled to native and bytecode, then installed
-TOOLS_TO_INSTALL_NAT = ocamldep
+TOOLS_TO_INSTALL_NAT = ocamldep ocamlobjinfo
 
 # Tools to be compiled to bytecode only, then installed
 TOOLS_TO_INSTALL_BYT = \
-  ocamlcmt ocamlprof ocamlcp ocamlmklib ocamlmktop ocamlobjinfo
+  ocamlcmt ocamlprof ocamlcp ocamlmklib ocamlmktop
 
 ifeq "$(NATIVE_COMPILER)" "true"
 TOOLS_TO_INSTALL_BYT += ocamloptp


### PR DESCRIPTION
Currently, when native-code compilation is supported, the following auxiliary tools are compiled both to bytecode and to native-code, and both binaries are installed in $(PREFIX)/bin:
```
ocamldep ocamlcmt ocamlprof ocamlcp ocamlmklib ocamlmktop ocamlobjinfo
```
This PR proposes to not compile to native-code the following tools, and to install only a bytecode executable:
```
ocamlcmt ocamlprof ocamlcp ocamlmklib ocamlmktop ocamlobjinfo
```
`ocamldep` is still compiled to native-code whenever possible, as this tool is heavily used and execution speed matters.  The other tools are rarely used and not speed-critical (to the best of my knowledge), so compilation to native-code is not warranted.

(I'm not 100% sure about `ocamlcmt`; please contradict me if there are speed-critical uses.)

The intent of this change is to reduce the size of OCaml installations further, now that #11981 is merged.  On x86-64 linux:
- whole installation: 385M currently, 336M with this PR (-13%)
- bin subdirectory: 165M currently, 120M with this  PR  (-27%)

CC: @shindere 

