### PR TITLE
Fix for segfault in custom runtime events

### DIFF
--- a/Changes
+++ b/Changes
@@ -65,8 +65,8 @@ Working version
   (Guillaume Munch-Maccagnoni, review by Gabriel Scherer and KC
    Sivaramakrishnan)
 
-- #11474: Add support for user-defined events in the runtime event tracing
-  system. (Lucas Pluvinage, review by Sadiq Jaffer)
+- #11474, #11998: Add support for user-defined events in the runtime event
+  tracing system. (Lucas Pluvinage, review by Sadiq Jaffer)
 
 - #11935: Load frametables of dynlink'd modules in batch
   (Stephen Dolan, review by David Allsopp and Guillaume Munch-Maccagnoni)

--- a/otherlibs/runtime_events/runtime_events_consumer.c
+++ b/otherlibs/runtime_events/runtime_events_consumer.c
@@ -1044,6 +1044,14 @@ static int ml_user_custom(int domain_id, void *callback_data, int64_t timestamp,
   event = caml_runtime_events_user_resolve_cached(wrapper_root, event_id,
                                                                 event_name,
                                     EV_USER_ML_TYPE_CUSTOM);
+
+  // the function may return Val_none if the event is unknown
+  // (see caml_runtime_events_user_resolve)
+  if (event == Val_none) {
+    CAMLdrop;
+    return 1;
+  }
+
   event_type = Field(event, 2);
 
   callback_list = user_events_find_callback_list_for_event_type(callbacks_root,

--- a/runtime/runtime_events.c
+++ b/runtime/runtime_events.c
@@ -793,7 +793,8 @@ CAMLprim value caml_runtime_events_user_write(value event, value event_content)
 /* Find which event has the given name using the list of globally known events.
    If the event is not globally known but the type is one of the known types,
    then it can be partially reconstructed, the only missing information being
-   the associated tag.  */
+   the associated tag. This function returns an event structure, except when the
+   event is unknown and the event type id is EV_USER_ML_TYPE_CUSTOM. */
 CAMLprim value caml_runtime_events_user_resolve(
   char* event_name, ev_user_ml_type event_type_id)
 {
@@ -833,5 +834,5 @@ CAMLprim value caml_runtime_events_user_resolve(
 
 
   CAMLdrop;
-  return (value) NULL;
+  return (value) Val_none;
 }

--- a/testsuite/tests/lib-runtime-events/test_user_event_unknown.ml
+++ b/testsuite/tests/lib-runtime-events/test_user_event_unknown.ml
@@ -13,6 +13,9 @@ type User.tag += Ev of int
 let ev0 =
   User.register "ev0" (Ev 0) Type.int
 
+let custom_unit_type =
+  Type.register ~encode:(fun buf () -> 0) ~decode:(fun buf sz -> ())
+
 let () =
   start ();
   let parent_cwd = Sys.getcwd () in
@@ -23,11 +26,14 @@ let () =
     let ev1 = User.register "ev1" (Ev 1) Type.int in
     let ev2 = User.register "ev2" (Ev 2) Type.int in
     let ev3 = User.register "ev3" (Ev 3) Type.span in
+    let ev4 = User.register "ev4" (Ev 4) custom_unit_type in
+
     User.write ev0 17;
     User.write ev1 12;
     User.write ev2 28;
     User.write ev3 Begin;
-    User.write ev3 End
+    User.write ev3 End;
+    User.write ev4 ()
   end
   else
   (* parent consumes events *)


### PR DESCRIPTION
I missed an error path when implementing https://github.com/ocaml/ocaml/pull/11474.
A consumer would fail with SEGFAULT when it encounters an unknown event of unknown type (one defined using the custom types API). 

The fix consists in checking that the returned value of `caml_runtime_events_user_resolve_cached` is not `None` in `ml_user_custom`. Other calls to `caml_runtime_events_user_resolve_cached` are not checked because they are guaranteed to succeed, as unknown events of known types are still resolved except that they have an `UNK` tag.

I have extended the unknown events test to reproduce the error path and check that it's fixed. 