### PR TITLE
Move last finalisers book keeping to the end of minor gc

### DIFF
--- a/Changes
+++ b/Changes
@@ -20,6 +20,10 @@ Working version
 
 ### Runtime system:
 
+- #12001: Fix book keeping for last finalisers during the minor cycle
+  (KC Sivaramakrishnan and Enguerrand Decorne, report by Guillaume Bury
+   and Vincent Laviron, review by Sadiq Jaffer and KC Sivaramakrishnan)
+
 - #11919: New runtime events counters for major heap stats and minor heap
   resizing.
   (Sadiq Jaffer, review by Gabriel Scherer and David Allsopp)

--- a/runtime/minor_gc.c
+++ b/runtime/minor_gc.c
@@ -597,11 +597,6 @@ void caml_empty_minor_heap_promote(caml_domain_state* domain,
   caml_gc_log("promoted %d roots, %" ARCH_INTNAT_PRINTF_FORMAT "u bytes",
               remembered_roots, st.live_bytes);
 
-  CAML_EV_BEGIN(EV_MINOR_FINALIZERS_ADMIN);
-  caml_gc_log("running finalizer data structure book-keeping");
-  caml_final_update_last_minor(domain);
-  CAML_EV_END(EV_MINOR_FINALIZERS_ADMIN);
-
 #ifdef DEBUG
   caml_global_barrier();
   caml_gc_log("ref_base: %p, ref_ptr: %p",
@@ -723,6 +718,11 @@ caml_stw_empty_minor_heap_no_major_slice(caml_domain_state* domain,
     }
     CAML_EV_END(EV_MINOR_LEAVE_BARRIER);
   }
+
+  CAML_EV_BEGIN(EV_MINOR_FINALIZERS_ADMIN);
+  caml_gc_log("running finalizer data structure book-keeping");
+  caml_final_update_last_minor(domain);
+  CAML_EV_END(EV_MINOR_FINALIZERS_ADMIN);
 
   CAML_EV_BEGIN(EV_MINOR_CLEAR);
   caml_gc_log("running stw empty_minor_heap_domain_clear");

--- a/testsuite/tests/weak-ephe-final/pr12001.ml
+++ b/testsuite/tests/weak-ephe-final/pr12001.ml
@@ -1,0 +1,16 @@
+(* TEST
+*)
+
+let [@inline never] foo () =
+  let s = "Hello" ^ " world!" in
+  Gc.finalise_last (fun () -> print_endline "finalised") s;
+  Gc.minor ();
+  s
+
+let [@inline never] bar () =
+  let s = foo () in
+  print_endline s
+
+let _ =
+  bar ();
+  Gc.full_major ()

--- a/testsuite/tests/weak-ephe-final/pr12001.reference
+++ b/testsuite/tests/weak-ephe-final/pr12001.reference
@@ -1,0 +1,2 @@
+Hello world!
+finalised


### PR DESCRIPTION
This PR is an implementation of @kayceesrk 's suggestion in #11995

This commit implements a fix on how last finalisers are updated during the minor cycle.

Currently, the book keeping is done during the minor cycle, before the values are promoted.
As a result, last finalisers are wrongly run after the end of the minor cycle even is the value is promoted (and as such, live), precisely because the book keeping did not account for the promoted values.

The fix suggested by @kayceesrk is to move said book keeping to the end of the minor gc cycle, and can be done outside of the last barrier for the minor cycle, as a domain will only process finalisers within its own minor heap.

