### PR TITLE
Optimize representation of Env.t

### DIFF
--- a/typing/env.mli
+++ b/typing/env.mli
@@ -45,6 +45,7 @@ type summary =
       to skip, i.e. that won't be imported in the toplevel namespace. *)
   | Env_functor_arg of summary * Ident.t
   | Env_constraints of summary * type_declaration Path.Map.t
+  | Env_in_signature of summary
   | Env_copy_types of summary
   | Env_persistent of summary * Ident.t
   | Env_value_unbound of summary * string * value_unbound_reason

--- a/typing/envaux.ml
+++ b/typing/envaux.ml
@@ -80,6 +80,9 @@ let rec env_from_summary sum subst =
               Env.add_local_type (Subst.type_path subst path)
                 (Subst.type_declaration subst info))
             map (env_from_summary s subst)
+      | Env_in_signature s ->
+          let env = env_from_summary s subst in
+          Env.in_signature true env
       | Env_copy_types s ->
           let env = env_from_summary s subst in
           Env.make_copy_of_types env env


### PR DESCRIPTION
In the context https://github.com/ocaml/RFCs/pull/23, I suggested that small tweaks to the representation of types stored in .cmt/.cmti file could reduce the file of those files quite easily.

This PR tweaks the representation of `Env.t`.  This type is threaded through the type-checking processing, keeping a kind of "log" of changes (in addition to direct changes on its "real" fields), called the summary.  Before storing the `Env.t` values to .cmt/.cmti files, most fields are reset, keeping mostly the summary field intact; tools can fold over the store summary to rebuilt "full" `Env.t` values, if needed.  (Summaries are also passed to ocamldebug through "debug events".)

In the new representation of `Env.t`, we keep only 3 fields at toplevel: `values`, `summary` and a new `sub` record which packages all the other fields.  The main impact is on the size of .cmt files : we avoid storing all the "empty" fields under `sub`.  The potential downsides : more indirection to access fields under `sub`, and possibly more allocations when updating those fields. This is why we keep `values` at the toplevel, since this field is the one updated quite often. When we update that field, we actually allocate fewer words than before.

Here are some concrete results, compiling typing/typecore.ml:

  - Size of .cmt file reduce by 5.47% (2727461 -> 2578348 bytes).
  - Top heap words reduced by 1.53%
  - Allocated words reduced by 0.09%


I've also tried with moving `values` under `sub` as well (which is what the current state of the PR does). Here are the results:

  - Size of .cmt file reduce by 6.20%
  - Top heap words reduced by 0.45%
  - Allocated words reduced by 0.01%

So even in this mode, we don't really allocate more than before (probably because the rewriting of `Env.t` before writing to the .cmt file allocates less and compensate for the extra allocation during type-checking).

The compilation speed seems to be very slightly improved, but this is "in the noise" (at least, not significant degradation).

Moving most fields under `sub` was mechanical.  Two exceptions: `local_constraints` and `flags` (in practice, only the in_signature flag).  They used to be kept in the stored `Env.t` values (not represented in the `summary`).  For local_constraints, there was already a way to encode it in the summary (for the debugger); it has been extended to cover the flags as well, and now it is used when creating `Env.t`  values for .cmt files.

One possibility to go a bit further would be to avoid the "empty" `sub` field altogether in marshalled Typedtrees.  This could be done by defining `Env.t` as:
````
 type t =
    | Stored of summary
    | Live of { summary: summary; values: ...; types: ... }
````
We would still store a "useless" indirection for the `Stored` constructor. To avoid it, one could merge the `summary` and `t` types, and add to `summary` a new constructor:
````
type t =
 | Env_empty
 | Env_value of summary * ....
 | ...
 | Env_full of { summary: summary; values : ...; types: .... }
````
with the invariant that `Env_full` cannot be found nested, and that
environments manipulated during type-checking have `Env_full` at their root.

This is a bit more invasive than the current diff.  Happy to explore it if people would find it useful!