### PR TITLE
Handle attributes on lambdas with locally abstract types

### DIFF
--- a/Changes
+++ b/Changes
@@ -531,6 +531,10 @@ Working version
 - #11879: Bugfix for Ctype.nondep_type
   (Stephen Dolan, review by Gabriel Scherer)
 
+- #12004: Don't ignore function attributes on lambdas with locally abstract
+  types.
+  (Chris Casinghino, review by Gabriel Scherer)
+
 OCaml 5.0.0 (15 December 2022)
 ------------------------------
 

--- a/testsuite/tests/ppx-attributes/inline.ml
+++ b/testsuite/tests/ppx-attributes/inline.ml
@@ -1,0 +1,14 @@
+(* TEST
+   flags = "-dlambda -dno-unique-ids"
+   * expect
+*)
+
+(* This checks that function attributes like [@inline] aren't dropped when they
+   end up on a Texp_newtype node in the exp_extra field. *)
+
+let f = fun [@inline] (type a) (x : a) -> x
+[%%expect{|
+(let (f = (function x always_inline x))
+  (apply (field_mut 1 (global Toploop!)) "f" f))
+val f : 'a -> 'a = <fun>
+|}]


### PR DESCRIPTION
Currently OCaml silently ignores some attributes on lambdas with locally abstract types, like:

```
  let f = fun [@inline] (type a) (x : a) -> x
```

The issue is that the attribute ends up on a `Pexp_newtype` node in the parser, which then gets pushed into the `exp_extra` field on the function in the typed tree, and the translation to lambda wasn't collecting attributes from `exp_extra`.

I've fixed it by just collecting attributes from any `Texp_newtype` nodes in the `exp_extra` list before we call `Translattribute.add_function_attributes` in the translation to lambda.  That function is where we check for attributes like `inline` on functions.

I can imagine other possible solutions.  For example, perhaps we should take attributes from all the `exp_extra`s, not just the newtype ones.  My view is that the fix here is the most in keeping with the current standard that attributes like `[@inline]` and `[@local]` must go right on the function definition.  It's just a quirk of the parser that `fun [@foo] a b -> ...` is parsed very differently depending on whether `a` is a locally abstract type or an argument.

I'm not sure how best to test this.  Really, it's a failing of warning 53 that this attribute is silently ignored.  I think warning 53 should be reworked entirely to be handled more like the way ppxlib detects misplaced attributes, which would have caught this. I have a future PR coming that does that, but it's a larger (and more controversial) change.  I looked around in the testsuite for other tests that deal with inlining behavior specifically so that we could at least test one of the attributes that can appear in this position, but I didn't spot any.  I'm open to suggestions.