### PR TITLE
Refactor hashtbl.ml

### DIFF
--- a/stdlib/hashtbl.ml
+++ b/stdlib/hashtbl.ml
@@ -209,20 +209,12 @@ let filter_map_inplace f h =
   )
 
 let fold f h init =
-  let rec do_bucket b accu =
-    match b with
-      Empty ->
-        accu
-    | Cons{key; data; next} ->
-        do_bucket next (f key data accu) in
+  let rec do_bucket acc = function
+    | Empty -> acc
+    | Cons {key; data; next} -> do_bucket (f key data acc) next
+  in
   protect_traversal h (fun () ->
-    let d = h.data in
-    let accu = ref init in
-    for i = 0 to Array.length d - 1 do
-      accu := do_bucket d.(i) !accu
-    done;
-    if not old_trav then flip_ongoing_traversal h;
-    !accu
+    Array.fold_left do_bucket init h.data
   )
 
 type statistics = {

--- a/stdlib/hashtbl.ml
+++ b/stdlib/hashtbl.ml
@@ -172,10 +172,7 @@ let iter f h =
     | Cons {key; data; next} -> f key data; do_bucket next
   in
   protect_traversal h (fun () ->
-    let d = h.data in
-    for i = 0 to Array.length d - 1 do
-      do_bucket d.(i)
-    done
+    Array.iter do_bucket h.data
   )
 
 let rec filter_map_inplace_bucket f h i prev = function

--- a/stdlib/hashtbl.ml
+++ b/stdlib/hashtbl.ml
@@ -178,9 +178,9 @@ let iter f h =
     done
   )
 
-let rec filter_map_inplace_bucket f h i prec = function
+let rec filter_map_inplace_bucket f h i prev = function
   | Empty ->
-    begin match prec with
+    begin match prev with
     | Empty -> h.data.(i) <- Empty
     | Cons c -> c.next <- Empty
     end
@@ -188,9 +188,9 @@ let rec filter_map_inplace_bucket f h i prec = function
     begin match f key data with
     | None ->
       h.size <- h.size - 1;
-      filter_map_inplace_bucket f h i prec next
+      filter_map_inplace_bucket f h i prev next
     | Some data ->
-      begin match prec with
+      begin match prev with
       | Empty -> h.data.(i) <- slot
       | Cons c -> c.next <- slot
       end;
@@ -234,10 +234,10 @@ let stats h =
     Array.fold_left (fun m b -> Int.max m (bucket_length b)) 0 h.data
   in
   let histo = Array.make (mbl + 1) 0 in
-  h.data |> Array.iter (fun b ->
+  Array.iter (fun b ->
     let l = bucket_length b in
     histo.(l) <- histo.(l) + 1
-  );
+  ) h.data;
   { num_bindings = h.size;
     num_buckets = Array.length h.data;
     max_bucket_length = mbl;

--- a/testsuite/tests/backtrace/backtrace2.ml
+++ b/testsuite/tests/backtrace/backtrace2.ml
@@ -11,7 +11,7 @@ let test_Error msg =
   let rec f msg n =
     if n = 0 then raise(Error msg) else 1 + f msg (n-1) in
   let exception_raised_internally () =
-    try Hashtbl.find (Hashtbl.create 3) 0
+    try raise (Sys.opaque_identity Not_found)
     with Not_found -> false in
   try
     f msg 5
@@ -40,14 +40,14 @@ let test_Not_found () =
       Currently the wrong backtrace is used. *)
   with exn ->
     print_string "test_Not_found"; print_newline();
-    (try Hashtbl.find (Hashtbl.create 3) 0 with Not_found -> raise exn)
+    (try raise (Sys.opaque_identity Not_found) with Not_found -> raise exn)
 
 let test_lazy =
   let rec aux n =
     if n = 0 then raise Not_found else 1 + aux (n-1)
   in
   let exception_raised_internally () =
-    try Hashtbl.find (Hashtbl.create 3) 0
+    try raise (Sys.opaque_identity Not_found)
     with Not_found -> () in
   let l = lazy (aux 5) in
   (** Test the backtrace obtained from a lazy value.

--- a/testsuite/tests/backtrace/backtrace2.reference
+++ b/testsuite/tests/backtrace/backtrace2.reference
@@ -35,7 +35,7 @@ Uncaught exception Invalid_argument("index out of bounds")
 Raised by primitive operation at Backtrace2.run in file "backtrace2.ml", line 62, characters 14-22
 test_Not_found
 Uncaught exception Not_found
-Raised at Stdlib__Hashtbl.find in file "hashtbl.ml", line 542, characters 13-28
+Raised at Stdlib__Hashtbl.Impl.find.(fun) in file "hashtbl.ml", line 329, characters 17-32
 Called from Backtrace2.test_Not_found in file "backtrace2.ml", line 43, characters 9-42
 Re-raised at Backtrace2.test_Not_found in file "backtrace2.ml", line 43, characters 61-70
 Called from Backtrace2.run in file "backtrace2.ml", line 62, characters 11-23
@@ -50,7 +50,7 @@ Called from CamlinternalLazy.do_force_block in file "camlinternalLazy.ml", line 
 Re-raised at CamlinternalLazy.do_force_block in file "camlinternalLazy.ml", line 56, characters 4-11
 Called from Backtrace2.run in file "backtrace2.ml", line 62, characters 11-23
 Uncaught exception Not_found
-Raised at Stdlib__Hashtbl.find in file "hashtbl.ml", line 542, characters 13-28
+Raised at Stdlib__Hashtbl.Impl.find.(fun) in file "hashtbl.ml", line 329, characters 17-32
 Called from Backtrace2.test_lazy.exception_raised_internally in file "backtrace2.ml", line 50, characters 8-41
 Re-raised at CamlinternalLazy.do_force_block.(fun) in file "camlinternalLazy.ml", line 54, characters 43-50
 Called from CamlinternalLazy.do_force_block in file "camlinternalLazy.ml", line 49, characters 17-27

--- a/testsuite/tests/backtrace/backtrace2.reference
+++ b/testsuite/tests/backtrace/backtrace2.reference
@@ -35,9 +35,8 @@ Uncaught exception Invalid_argument("index out of bounds")
 Raised by primitive operation at Backtrace2.run in file "backtrace2.ml", line 62, characters 14-22
 test_Not_found
 Uncaught exception Not_found
-Raised at Stdlib__Hashtbl.Impl.find.(fun) in file "hashtbl.ml", line 329, characters 17-32
-Called from Backtrace2.test_Not_found in file "backtrace2.ml", line 43, characters 9-42
-Re-raised at Backtrace2.test_Not_found in file "backtrace2.ml", line 43, characters 61-70
+Raised at Backtrace2.test_Not_found in file "backtrace2.ml", line 43, characters 9-46
+Re-raised at Backtrace2.test_Not_found in file "backtrace2.ml", line 43, characters 65-74
 Called from Backtrace2.run in file "backtrace2.ml", line 62, characters 11-23
 Uncaught exception Not_found
 Raised at Backtrace2.test_lazy.aux in file "backtrace2.ml", line 47, characters 18-33
@@ -50,8 +49,7 @@ Called from CamlinternalLazy.do_force_block in file "camlinternalLazy.ml", line 
 Re-raised at CamlinternalLazy.do_force_block in file "camlinternalLazy.ml", line 56, characters 4-11
 Called from Backtrace2.run in file "backtrace2.ml", line 62, characters 11-23
 Uncaught exception Not_found
-Raised at Stdlib__Hashtbl.Impl.find.(fun) in file "hashtbl.ml", line 329, characters 17-32
-Called from Backtrace2.test_lazy.exception_raised_internally in file "backtrace2.ml", line 50, characters 8-41
+Raised at Backtrace2.test_lazy.exception_raised_internally in file "backtrace2.ml", line 50, characters 8-45
 Re-raised at CamlinternalLazy.do_force_block.(fun) in file "camlinternalLazy.ml", line 54, characters 43-50
 Called from CamlinternalLazy.do_force_block in file "camlinternalLazy.ml", line 49, characters 17-27
 Re-raised at CamlinternalLazy.do_force_block in file "camlinternalLazy.ml", line 56, characters 4-11


### PR DESCRIPTION
This PR cleans up the implementation of `Hashtbl` (see discussion in #11753), by removing duplicate functions and factoring out common logic. 

I went through a couple iterations that were slightly "cleaner" but had performance regressions. These changes, as far as I could measure (with godbolt and `Core_bench`) do not negatively impact performance, either of the functorial or polymorphic interface.

@gasche @nojb 

PS: I assume this doesn't need a changelog entry, right?