### PR TITLE
Remove Ctype.reified_var_counter

### DIFF
--- a/Changes
+++ b/Changes
@@ -518,17 +518,22 @@ Working version
   in preparation for quadratic-time fix
   (Gabriel Scherer, review by Enguerrand Decorne)
 
+<<<<<<< HEAD
 - #11997: translate structured constants into their Obj.t representation
   at compile time rather than link time. Changes the way dumpobj prints
   these constants because their representaiton becomes untyped.
   (Sébastien Hinderer, review by Xavier Leroy, Nicolás Ojeda Bär and
   Hugo Heuzard)
 
+- #12011: remove Ctype.reified_var_counter
+  (Takafumi Saikawa and Jacques Garrigue, review by ??)
+
 - #12012: move calls to Typetexp.TyVarEnv.reset inside with_local_level etc.
   (Jacques Garrigue and Takafumi Saikawa, review by Gabriel Scherer)
 
 - #12034: a logarithmic algorithm to find the next free variable
   (Gabriel Scherer, review by Stefan Muenzel)
+
 
 ### Build system:
 

--- a/Changes
+++ b/Changes
@@ -518,7 +518,6 @@ Working version
   in preparation for quadratic-time fix
   (Gabriel Scherer, review by Enguerrand Decorne)
 
-<<<<<<< HEAD
 - #11997: translate structured constants into their Obj.t representation
   at compile time rather than link time. Changes the way dumpobj prints
   these constants because their representaiton becomes untyped.

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -1220,16 +1220,17 @@ let instance_list schl =
 let get_new_abstract_name env s =
   (* unique names are needed only for error messages *)
   if in_counterexample () then s else
-  let rec loop index =
-    let name =
-      if index = 0 && s <> "" && s.[String.length s - 1] <> '$' then s else
-      Printf.sprintf "%s%d" s index
-    in
-    match Env.find_type_by_name (Longident.Lident name) env with
-    | _ -> loop (index + 1)
-    | exception Not_found -> name
+  let name index =
+    if index = 0 && s <> "" && s.[String.length s - 1] <> '$' then s else
+    Printf.sprintf "%s%d" s index
   in
-  loop 0
+  let check index =
+    match Env.find_type_by_name (Longident.Lident (name index)) env with
+    | _ -> false
+    | exception Not_found -> true
+  in
+  let index = Misc.find_first_mono check in
+  name index
 
 let new_local_type ?(loc = Location.none) ?manifest_and_scope () =
   let manifest, expansion_scope =

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -307,6 +307,11 @@ let can_assume_injective () =
   | Expression | Subst -> false
   | Pattern { assume_injective } -> assume_injective
 
+let in_counterexample () =
+  match !umode with
+  | Expression | Subst -> false
+  | Pattern { allow_recursive_equations } -> allow_recursive_equations
+
 let allow_recursive_equations () =
   !Clflags.recursive_types
   || match !umode with
@@ -1210,20 +1215,21 @@ let instance_list schl =
   For_copy.with_scope (fun copy_scope ->
     List.map (fun t -> copy copy_scope t) schl)
 
-let reified_var_counter = ref Vars.empty
-let reset_reified_var_counter () =
-  reified_var_counter := Vars.empty
-
-(* names given to new type constructors.
-   Used for existential types and
-   local constraints *)
-let get_new_abstract_name s =
-  let index =
-    try Vars.find s !reified_var_counter + 1
-    with Not_found -> 0 in
-  reified_var_counter := Vars.add s index !reified_var_counter;
-  if index = 0 && s <> "" && s.[String.length s - 1] <> '$' then s else
-  Printf.sprintf "%s%d" s index
+(* Create unique names to new type constructors.
+   Used for existential types and local constraints. *)
+let get_new_abstract_name env s =
+  (* unique names are needed only for error messages *)
+  if in_counterexample () then s else
+  let rec loop index =
+    let name =
+      if index = 0 && s <> "" && s.[String.length s - 1] <> '$' then s else
+      Printf.sprintf "%s%d" s index
+    in
+    match Env.find_type_by_name (Longident.Lident name) env with
+    | _ -> loop (index + 1)
+    | exception Not_found -> name
+  in
+  loop 0
 
 let new_local_type ?(loc = Location.none) ?manifest_and_scope () =
   let manifest, expansion_scope =
@@ -1267,7 +1273,7 @@ let instance_constructor existential_treatment cstr =
             let decl = new_local_type () in
             let name = existential_name cstr existential in
             let (id, new_env) =
-              Env.enter_type (get_new_abstract_name name) decl !env
+              Env.enter_type (get_new_abstract_name !env name) decl !env
                 ~scope:fresh_constr_scope in
             env := new_env;
             let to_unify = newty (Tconstr (Path.Pident id,[],ref Mnil)) in
@@ -2163,7 +2169,7 @@ let reify env t =
     let name = match name with Some s -> "$'"^s | _ -> "$" in
     let decl = new_local_type () in
     let (id, new_env) =
-      Env.enter_type (get_new_abstract_name name) decl !env
+      Env.enter_type (get_new_abstract_name !env name) decl !env
         ~scope:fresh_constr_scope in
     let path = Path.Pident id in
     let t = newty2 ~level:lev (Tconstr (path,[],ref Mnil))  in

--- a/typing/ctype.mli
+++ b/typing/ctype.mli
@@ -448,7 +448,6 @@ val collapse_conj_params: Env.t -> type_expr list -> unit
 
 val get_current_level: unit -> int
 val wrap_trace_gadt_instances: Env.t -> ('a -> 'b) -> 'a -> 'b
-val reset_reified_var_counter: unit -> unit
 
 val immediacy : Env.t -> type_expr -> Type_immediacy.t
 

--- a/typing/typetexp.ml
+++ b/typing/typetexp.ml
@@ -152,7 +152,6 @@ end = struct
 
   let reset () =
     reset_global_level ();
-    Ctype.reset_reified_var_counter ();
     type_variables := TyVarMap.empty
 
   let is_in_scope name =


### PR DESCRIPTION
This PR removes a global variable that is used for generating names for types appearing only in error messages.
The need to reset this variable in `Typetexp.TyVarEnv.reset` is now avoided.
