### PR TITLE
Re-register finaliser only after calling user alarm in Gc.create_alarm

### DIFF
--- a/Changes
+++ b/Changes
@@ -487,6 +487,9 @@ Working version
 
 ### Bug fixes:
 
+- #12017: Re-register finaliser only after calling user alarm in Gc.create_alarm
+  (Fabrice Buoro, report by Sam Goldman, review by ...)
+
 - #11887, #11893: Code duplication in pattern-matching compilation
   (Vincent Laviron, report par Greta Yorsh, review by Luc Maranget and
    Gabriel Scherer)

--- a/Changes
+++ b/Changes
@@ -488,7 +488,7 @@ Working version
 ### Bug fixes:
 
 - #12017: Re-register finaliser only after calling user alarm in Gc.create_alarm
-  (Fabrice Buoro, report by Sam Goldman, review by ...)
+  (Fabrice Buoro, report by Sam Goldman, review by Guillaume Munch-Maccagnoni)
 
 - #11887, #11893: Code duplication in pattern-matching compilation
   (Vincent Laviron, report par Greta Yorsh, review by Luc Maranget and

--- a/stdlib/.depend
+++ b/stdlib/.depend
@@ -358,6 +358,7 @@ stdlib__Gc.cmo : gc.ml \
     stdlib__String.cmi \
     stdlib__Printf.cmi \
     stdlib__Printexc.cmi \
+    stdlib__Fun.cmi \
     stdlib__Atomic.cmi \
     stdlib__Gc.cmi
 stdlib__Gc.cmx : gc.ml \
@@ -365,6 +366,7 @@ stdlib__Gc.cmx : gc.ml \
     stdlib__String.cmx \
     stdlib__Printf.cmx \
     stdlib__Printexc.cmx \
+    stdlib__Fun.cmx \
     stdlib__Atomic.cmx \
     stdlib__Gc.cmi
 stdlib__Gc.cmi : gc.mli \

--- a/stdlib/gc.ml
+++ b/stdlib/gc.ml
@@ -108,8 +108,8 @@ type alarm_rec = {active : alarm; f : unit -> unit}
 
 let rec call_alarm arec =
   if Atomic.get arec.active then begin
-    arec.f ();
-    finalise call_alarm arec;
+    let finally () = finalise call_alarm arec in
+    Fun.protect arec.f ~finally
   end
 
 

--- a/stdlib/gc.ml
+++ b/stdlib/gc.ml
@@ -108,8 +108,8 @@ type alarm_rec = {active : alarm; f : unit -> unit}
 
 let rec call_alarm arec =
   if Atomic.get arec.active then begin
-    finalise call_alarm arec;
     arec.f ();
+    finalise call_alarm arec;
   end
 
 

--- a/stdlib/gc.mli
+++ b/stdlib/gc.mli
@@ -411,7 +411,8 @@ type alarm
 
 val create_alarm : (unit -> unit) -> alarm
 (** [create_alarm f] will arrange for [f] to be called at the end of each
-   major GC cycle, starting with the current cycle or the next one.
+   major GC cycle, not caused by [f] itself, starting with the current
+   cycle or the next one.
    A value of type [alarm] is returned that you can
    use to call [delete_alarm]. *)
 


### PR DESCRIPTION
If the user alarm in `Gc.create_alarm` always causes a major GC, the program will not terminate because the new major GC causes the alarm to be called again and again.
As in the example given in #12002 :
```
let () =
  ignore (Gc.create_alarm Gc.full_major);
  Gc.full_major ()
```

This small PR causes the finaliser to not re-register until the user thunk of create_alarm is called.
This has the drawback of changing the semantics of `Gc.create_alarm`, which is no longer called after every major GC cycle, but only after those not caused by the alarm itself.