### PR TITLE
 #11450: struct end might be really a structure

### DIFF
--- a/Changes
+++ b/Changes
@@ -508,6 +508,10 @@ Working version
   by leaf functions.
   (Tom Kelly and Xavier Leroy, review by Mark Shinwell)
 
+- #11450, #12018: Fix erroneous functor error messages that were too eager to
+  cast `struct end` functor arguments as unit modules in `F(struct end)`.
+  (Florian Angetti, review by Gabriel Scherer)
+
 - #11643: Add missing test declaration to float_compare test, so that it will
   run.
   (Stefan Muenzel, review by David Allsopp)

--- a/testsuite/tests/typing-modules/functors.ml
+++ b/testsuite/tests/typing-modules/functors.ml
@@ -1745,3 +1745,54 @@ module Shape_arg :
     module M4 : functor (Arg5 : sig end) -> M3(Arg5).S3
   end
 |}]
+
+
+(* Applicative or generative *)
+
+module F(X:A) = struct end
+module R = F(struct end[@warning "-73"]);;
+[%%expect {|
+module F : functor (X : A) -> sig end
+Line 2, characters 11-40:
+2 | module R = F(struct end[@warning "-73"]);;
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: Modules do not match: sig end is not included in A
+     The type `a' is required but not provided
+|}]
+
+module F()(X:empty)()(Y:A) = struct end
+module R =
+  F(struct end[@warning "-73"])(struct end)(struct end[@warning "-73"])();;
+[%%expect {|
+module F : functor () (X : empty) () (Y : A) -> sig end
+Line 3, characters 2-73:
+3 |   F(struct end[@warning "-73"])(struct end)(struct end[@warning "-73"])();;
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The functor application is ill-typed.
+       These arguments:
+         (struct end) (struct end) (struct end) ()
+       do not match these parameters:
+         functor () (X : empty) () (Y : A) -> ...
+       1. Module (struct end) matches the expected module type
+       2. Module (struct end) matches the expected module type empty
+       3. Module (struct end) matches the expected module type
+       4. The functor was expected to be applicative at this position
+|}]
+
+
+module F(X:empty) = struct end
+module R =
+  F(struct end)();;
+[%%expect {|
+module F : functor (X : empty) -> sig end
+Line 3, characters 2-17:
+3 |   F(struct end)();;
+      ^^^^^^^^^^^^^^^
+Error: The functor application is ill-typed.
+       These arguments:
+         (struct end) ()
+       do not match these parameters:
+         functor (X : empty) -> ...
+       1. Module (struct end) matches the expected module type empty
+       2. The following extra argument is provided ()
+|}]

--- a/typing/includemod.mli
+++ b/typing/includemod.mli
@@ -43,6 +43,9 @@ module Error: sig
     | Anonymous
     | Named of Path.t
     | Unit
+    | Empty_struct
+     (** For backward compatibility's sake, an empty struct can be implicitly
+         converted to an unit module. *)
 
   type core_sigitem_symptom =
     | Value_descriptions of

--- a/typing/includemod_errorprinter.ml
+++ b/typing/includemod_errorprinter.ml
@@ -338,6 +338,7 @@ module With_shorthand = struct
     let arg, mty = ua.item in
     match (arg: Err.functor_arg_descr) with
     | Unit -> Format.dprintf "()"
+    | Empty_struct -> Format.dprintf "(struct end)"
     | Named p ->
         let mty = modtype { ua with item = mty } in
         Format.dprintf
@@ -356,6 +357,7 @@ module With_shorthand = struct
     let arg, mty = ua.item in
     match (arg: Err.functor_arg_descr) with
     | Unit -> Format.dprintf "()"
+    | Empty_struct -> Format.dprintf "(struct end)"
     | Named p -> fun ppf -> Printtyp.path ppf p
     | Anonymous ->
         let short_mty = modtype { ua with item=mty } in
@@ -518,7 +520,10 @@ module Functor_suberror = struct
       | Named _ | Anonymous ->
           Format.dprintf
             "The functor was expected to be generative at this position"
-
+      | Empty_struct ->
+          (* an empty structure can be used in both applicative and generative
+             context *)
+          assert false
   end
 
   let subcase sub ~expansion_token env (pos, diff) =

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -2118,7 +2118,7 @@ let simplify_app_summary app_view = match app_view.arg with
   | Some arg ->
     let mty = arg.arg.mod_type in
     match arg.is_syntactic_unit , arg.path with
-    | true , _      -> Includemod.Error.Unit, mty
+    | true , _      -> Includemod.Error.Empty_struct, mty
     | false, Some p -> Includemod.Error.Named p, mty
     | false, None   -> Includemod.Error.Anonymous, mty
 


### PR DESCRIPTION
This PR propagates the parsetree changes from #11984 to the error machinery in order to fix the confusing functor application error message reported in #11450.

In brief, in a functor argument constructor
```ocaml
F(struct end)
```
we need to consider that `struct end` might be both a structure or an unit module in order to have the error message consistent with the typechecker.

Before #11984, it was impossible to make any difference between `F()` and `F(struct end)`, and the error machinery picked the unit interpretation to catch more "user-visible" errors. This approximation lead to the confusing error message reported in #11450 : 
```ocaml
module F(X:sig type t end) = struct end
module R = F(struct end)
```
> Error: The functor was expected to be applicative at this position

because `F(struct end)` was interpreted as `F()`.


With #11984 and this PR, we can distinguish the two constructs and handle properly the special `struct end` case to get back the right error message without any compromise:

```ocaml
module F(X:sig type t end) = struct end
module R = F(struct end)
```
> Error: Modules do not match: sig end is not included in sig type t end
     The type `t' is required but not provided

 

close #11450