### PR TITLE
Let `build_as_type` take an environment directly, not a reference to it

### DIFF
--- a/Changes
+++ b/Changes
@@ -462,6 +462,9 @@ Working version
   in preparation for quadratic-time fix
   (Gabriel Scherer, review by Enguerrand Decorne)
 
+- #12020: Let build_as_type take an environment directly, not a reference to it
+  (Takafumi Saikawa and Jacques Garrigue, review by ??)
+
 ### Build system:
 
 - #11590: Allow installing to a destination path containing spaces.


### PR DESCRIPTION
`Typecore.build_as_type` calls `Ctype.unify_pat` with a `refine` parameter and a reference to an environment.
While the `refine` is needed (see #10738), there is no need to keep the updated environment.

This PR makes `build_as_types` to take a bare environment as its argument, and reduce interleaving of
the level management and updates to the environment.
This change is intended to be a preparation to move levels into the environment.
