### PR TITLE
Fix undefined Makefile variables

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -983,10 +983,10 @@ runtime/%.o: runtime/%.S
 	$(V_ASM)$(ASPP) $(OC_ASPPFLAGS) -o $@ $< || $(ASPP_ERROR)
 
 runtime/%.d.o: runtime/%.S
-	$(V_ASM)$(ASPP) $(OC_ASPPFLAGS) $(OC_DEBUG_CPPFLAGS) -o $@ $< || $(ASPP_ERROR)
+	$(V_ASM)$(ASPP) $(OC_ASPPFLAGS) $(ocamlrund_CPPFLAGS) -o $@ $< || $(ASPP_ERROR)
 
 runtime/%.i.o: runtime/%.S
-	$(V_ASM)$(ASPP) $(OC_ASPPFLAGS) $(OC_INSTR_CPPFLAGS) -o $@ $< || $(ASPP_ERROR)
+	$(V_ASM)$(ASPP) $(OC_ASPPFLAGS) $(ocamlruni_CPPFLAGS) -o $@ $< || $(ASPP_ERROR)
 
 runtime/%_libasmrunpic.o: runtime/%.S
 	$(V_ASM)$(ASPP) $(OC_ASPPFLAGS) $(SHAREDLIB_CFLAGS) -o $@ $<

--- a/Makefile.common
+++ b/Makefile.common
@@ -27,6 +27,8 @@ MKDIR=mkdir -p
 EMPTY :=
 # $(SPACE) contains a single space
 SPACE := $(EMPTY) $(EMPTY)
+# $( ) suppresses warning from the alignments in the V_ macros below
+$(SPACE) :=
 
 V ?= 0
 

--- a/Makefile.common
+++ b/Makefile.common
@@ -194,6 +194,7 @@ endef # PROGRAM_SYNONYM
 # should take place *before* Makefile.common is included.
 
 OCAMLDEP ?= $(BEST_OCAMLDEP)
+OCAMLDEPFLAGS ?=
 OC_OCAMLDEPFLAGS = -slash
 OC_OCAMLDEPDIRS =
 OCAMLDEP_CMD = $(OCAMLDEP) $(OC_OCAMLDEPFLAGS) \

--- a/tools/ci/actions/runner.sh
+++ b/tools/ci/actions/runner.sh
@@ -21,6 +21,8 @@ PREFIX=~/local
 MAKE="make $MAKE_ARG"
 SHELL=dash
 
+MAKE_WARN="$MAKE --warn-undefined-variables"
+
 export PATH=$PREFIX/bin:$PATH
 
 Configure () {
@@ -56,9 +58,18 @@ EOF
 }
 
 Build () {
-  $MAKE
+  if [ "$(uname)" = 'Darwin' ]; then
+    script -q build.log $MAKE_WARN
+  else
+    script --return --command "$MAKE_WARN" build.log
+  fi
   echo Ensuring that all names are prefixed in the runtime
   ./tools/check-symbol-names runtime/*.a otherlibs/*/lib*.a
+  if grep -Fq ' warning: undefined variable ' build.log; then
+    echo Undefined Makefile variables detected
+    exit 1
+  fi
+  rm build.log
 }
 
 Test () {

--- a/tools/ci/actions/runner.sh
+++ b/tools/ci/actions/runner.sh
@@ -63,13 +63,19 @@ Build () {
   else
     script --return --command "$MAKE_WARN" build.log
   fi
-  echo Ensuring that all names are prefixed in the runtime
-  ./tools/check-symbol-names runtime/*.a otherlibs/*/lib*.a
+  failed=0
   if grep -Fq ' warning: undefined variable ' build.log; then
     echo Undefined Makefile variables detected
-    exit 1
+    failed=1
   fi
   rm build.log
+  echo Ensuring that all names are prefixed in the runtime
+  if ! ./tools/check-symbol-names runtime/*.a otherlibs/*/lib*.a ; then
+    failed=1
+  fi
+  if ((failed)); then
+    exit 1
+  fi
 }
 
 Test () {


### PR DESCRIPTION
The majority of the warnings are coming from the `V_` macros from #11844, which uses `$ ` to allow indenting the commands by two spaces. This PR restores the CI check from #10270 for this which was accidentally lost in the multicore merge and also borrows the definition `$(SPACE) :=` which was originally in that PR and silences the warning. The others:
- `OC_DEBUG_CPPFLAGS` and `OC_INSTR_CPPFLAGS` - not switched over to the new variable in #11248; these flags were introduced as part of the multicore merge, and their absence will have only prevented debugging statements in `amd64.S` from ever being enabled.
- `OCAMLDEPFLAGS` - default not added in #11126