### PR TITLE
Deprecate Gc.stat

### DIFF
--- a/Changes
+++ b/Changes
@@ -2495,6 +2495,9 @@ OCaml 5.2.0 (13 May 2024)
   (Nick Barnes, review by Jacques-Henri Jourdan
    and Guillaume Munch-Maccagnoni).
 
+- #12023: Deprecate Gc.stat
+  (Damien Doligez, review by Gabriel Scherer and Jeremy Yallop)
+
 - #12430: Simplify dynamic bytecode loading in Meta.reify_bytecode
   (Stephen Dolan, review by Sébastien Hinderer, Vincent Laviron and Xavier
    Leroy)

--- a/stdlib/gc.mli
+++ b/stdlib/gc.mli
@@ -247,6 +247,9 @@ type control =
     [ocamlrun]. *)
 
 external stat : unit -> stat = "caml_gc_stat"
+[@@alert deprecated
+    "Use full_major() followed by quick_stat()."
+]
 (** Return the current values of the memory management counters in a
     [stat] record that represents the program's total memory stats.
     The [heap_chunks], [free_blocks], [largest_free], and [stack_size] metrics
@@ -255,12 +258,14 @@ external stat : unit -> stat = "caml_gc_stat"
     This function causes a full major collection. *)
 
 external quick_stat : unit -> stat = "caml_gc_quick_stat"
-(** Returns a record with the current values of the memory management counters
-    like [stat]. Unlike [stat], [quick_stat] does not perform a full major
-    collection, and hence, is much faster. However, [quick_stat] reports the
-    counters sampled at the last minor collection or at the end of the last
-    major collection cycle (whichever is the latest). Hence, the memory stats
-    returned by [quick_stat] are not instantaneously accurate. *)
+(** Return the current values of the memory management counters in a
+    {!type:stat} record that represents the program's total memory
+    stats. Due to per-domain buffers it may only represent the state
+    of the program's total memory usage at the time of the last minor
+    collection or at the end of the last major collection cycle
+    (whichever is the latest). To get exact values, you need to call
+    {!full_major} (which takes a lot of time) immediately before
+    {!quick_stat}. *)
 
 external counters : unit -> float * float * float = "caml_gc_counters"
 (** Return [(minor_words, promoted_words, major_words)] for the current

--- a/testsuite/tests/regression/pr5233/pr5233.ml
+++ b/testsuite/tests/regression/pr5233/pr5233.ml
@@ -46,7 +46,7 @@ let f () =
 
   (* Fill the heap with other stuff. *)
   let rec fill n accu = if n = 0 then accu else fill (n-1) (123 :: accu) in
-  let _r : int list = fill ((Gc.stat ()).Gc.heap_words / 3) [] in
+  let _r : int list = fill ((Gc.quick_stat ()).Gc.heap_words / 3) [] in
   Gc.minor ();
 
   (* Now follow the dangling pointer and exhibit the problem. *)


### PR DESCRIPTION
This is related to #11913.

In OCaml 4, `Gc.stat` does a full traversal of the heap to collect statistics on memory usage and `Gc.quick_stat` returns the counters that are readily available but no information for the ones that would need a heap traversal (those are: `live_words`, `live_blocks`, `free_words`, `free_blocks`, `largest_free`, and `fragments`). `Gc.quick_stat` is very fast, while `Gc.stat` takes a large amount of time.

In OCaml 5, all the counters of the `stat` record are updated incrementally by the GC and `Gc.quick_stat` returns their current value, which was accurate at the time of the latest minor GC. `Gc.stat` does a full major collection (finish the current cycle and do two more cycles) before calling `quick_stat`, which returns accurate results at the time of the call. It also take a very large amount of time (much more than `Gc.stat` in OCaml 4).

This PR changes `Gc.stat` to remove the `Gc.full_major`, making it equivalent to `Gc.quick_stat` and tells the users to call `Gc.full_major` before `Gc.stat` if they want up-to-date counters. In many uses, the slightly out-of-date counters are good enough and the overhead of a full major collection can be avoided. This PR also change `Gc.compact` to do a full major collection (instead of simply finishing the current cycle) for a reason that will be explained below.

I used [Sherlocode](https://sherlocode.com) to find most uses of Gc.stat in opam packages, and found the following.

There are 62 files that match a search for `Gc.stat`. They can be broken down into these categories:
1. correct usage: 13 (10 in production code, 3 in tests) would be broken by this PR
2. wrong usage: 22 (should use quick_stat in both OCaml 4 and OCaml 5) would get way faster with this PR
3. compatible usage: 4 (correct in OCaml 4 and 5, with or without this PR) would get faster with this PR
4. compatible using `Gc.compact`: 9 (mostly the same as compatible usage) would get faster with this PR
5. unclear: 3 (these are mostly lifting the GC module into another interface, we can't tell what the actual usage is)

If we merge this PR, category 2 will be fixed magically, thus becoming much faster. Categories 3 and 4 will get faster, while programs that use `Gc.compact` on its own will get slower.

Unfortunately, the programs in category 1 will need to be modified to get up-to-date results.

I think the new API is better because the cost of the full major GC is explicit instead of being hidden in the `stat` function.
