### PR TITLE
Insert a blank line between consecutive compiler messages

### DIFF
--- a/Changes
+++ b/Changes
@@ -399,6 +399,9 @@ Working version
   error messages (eg: `Illegal shadowing of included type t/2 by t`)
   (Florian Angeletti, review by Jules Aguillon)
 
+- #12024: insert a blank line between separate compiler messages
+  (Gabriel Scherer, review by Florian Angeletti, report by David Wong)
+
 ### Internal/compiler-libs changes:
 
 - #11990: Improve comments and macros around frame descriptors.

--- a/parsing/location.ml
+++ b/parsing/location.ml
@@ -118,6 +118,13 @@ let echo_eof () =
   print_newline ();
   incr num_loc_lines
 
+(* This is used by the toplevel and the report printers below. *)
+let separate_new_message ppf =
+  if not (is_first_message ()) then begin
+    Format.pp_print_newline ppf ();
+    incr num_loc_lines
+  end
+
 (* Code printing errors and warnings must be wrapped using this function, in
    order to update [num_loc_lines].
 
@@ -741,9 +748,7 @@ let batch_mode_printer : report_printer =
   let pp_txt ppf txt = Format.fprintf ppf "@[%t@]" txt in
   let pp self ppf report =
     setup_colors ();
-    (* Print a blank line between consecutive reports. *)
-    if not (is_first_message ()) then
-      Format.pp_print_newline ppf ();
+    separate_new_message ppf;
     (* Make sure we keep [num_loc_lines] updated.
        The tabulation box is here to give submessage the option
        to be aligned with the main message box

--- a/parsing/location.ml
+++ b/parsing/location.ml
@@ -95,8 +95,19 @@ let setup_terminal () =
    input in the terminal. This would not be possible without this information,
    since printing several warnings/errors adds text between the user input and
    the bottom of the terminal.
+
+   We also use for {!is_first_report}, see below.
 *)
 let num_loc_lines = ref 0
+
+(* We use [num_loc_lines] to determine if the report about to be
+   printed is the first or a follow-up report of the current
+   "batch" -- contiguous reports without user input in between, for
+   example for the current toplevel phrase. We use this to print
+   a blank line between messages of the same batch.
+*)
+let is_first_message () =
+  !num_loc_lines = 0
 
 (* This is used by the toplevel to reset [num_loc_lines] before each phrase *)
 let reset () =
@@ -730,6 +741,9 @@ let batch_mode_printer : report_printer =
   let pp_txt ppf txt = Format.fprintf ppf "@[%t@]" txt in
   let pp self ppf report =
     setup_colors ();
+    (* Print a blank line between consecutive reports. *)
+    if not (is_first_message ()) then
+      Format.pp_print_newline ppf ();
     (* Make sure we keep [num_loc_lines] updated.
        The tabulation box is here to give submessage the option
        to be aligned with the main message box

--- a/parsing/location.mli
+++ b/parsing/location.mli
@@ -88,6 +88,7 @@ val input_phrase_buffer: Buffer.t option ref
 (** {1 Toplevel-specific functions} *)
 
 val echo_eof: unit -> unit
+val separate_new_message: formatter -> unit
 val reset: unit -> unit
 
 

--- a/testsuite/tests/basic-more/morematch.compilers.reference
+++ b/testsuite/tests/basic-more/morematch.compilers.reference
@@ -2,46 +2,57 @@ File "morematch.ml", line 67, characters 2-5:
 67 | | 4|5|7 -> 100
        ^^^
 Warning 12 [redundant-subpat]: this sub-pattern is unused.
+
 File "morematch.ml", line 68, characters 2-3:
 68 | | 7 | 8 -> 6
        ^
 Warning 12 [redundant-subpat]: this sub-pattern is unused.
+
 File "morematch.ml", line 219, characters 33-47:
 219 | let f = function (([]|[_]) as x)|(_::([] as x))|(_::_::x)  -> x
                                        ^^^^^^^^^^^^^^
 Warning 12 [redundant-subpat]: this sub-pattern is unused.
+
 File "morematch.ml", line 388, characters 2-15:
 388 | | A,_,(100|103) -> 5
         ^^^^^^^^^^^^^
 Warning 11 [redundant-case]: this match case is unused.
+
 File "morematch.ml", line 401, characters 2-20:
 401 | | [],_,(100|103|104) -> 5
         ^^^^^^^^^^^^^^^^^^
 Warning 11 [redundant-case]: this match case is unused.
+
 File "morematch.ml", line 402, characters 2-16:
 402 | | [],_,(100|103) -> 6
         ^^^^^^^^^^^^^^
 Warning 11 [redundant-case]: this match case is unused.
+
 File "morematch.ml", line 403, characters 2-29:
 403 | | [],_,(1000|1001|1002|20000) -> 7
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 11 [redundant-case]: this match case is unused.
+
 File "morematch.ml", line 413, characters 5-12:
 413 |   | (100|103|101) -> 2
            ^^^^^^^
 Warning 12 [redundant-subpat]: this sub-pattern is unused.
+
 File "morematch.ml", line 432, characters 43-44:
 432 | | (J,J,((C|D) as x |E x|F (_,x))) | (J,_,((C|J) as x)) -> autre (x,x,x)
                                                  ^
 Warning 12 [redundant-subpat]: this sub-pattern is unused.
+
 File "morematch.ml", line 455, characters 7-8:
 455 | | _,_,(X|U _) -> 8
              ^
 Warning 12 [redundant-subpat]: this sub-pattern is unused.
+
 File "morematch.ml", line 456, characters 2-7:
 456 | | _,_,Y -> 5
         ^^^^^
 Warning 11 [redundant-case]: this match case is unused.
+
 File "morematch.ml", lines 1050-1053, characters 8-10:
 1050 | ........function
 1051 |   | A (`A|`C) -> 0
@@ -50,10 +61,12 @@ File "morematch.ml", lines 1050-1053, characters 8-10:
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 A `D
+
 File "morematch.ml", line 1084, characters 5-51:
 1084 |   |  _, _, _, _, _, A, _, _, _, _, B, _, _, _, _, _ -> "11"
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 11 [redundant-case]: this match case is unused.
+
 File "morematch.ml", line 1086, characters 5-51:
 1086 |   |  _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _ -> "13"
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/testsuite/tests/basic-more/robustmatch.compilers.reference
+++ b/testsuite/tests/basic-more/robustmatch.compilers.reference
@@ -7,6 +7,7 @@ File "robustmatch.ml", lines 33-37, characters 6-23:
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 (AB, MAB, A)
+
 File "robustmatch.ml", lines 43-47, characters 4-21:
 43 | ....match t1, t2, x with
 44 |     | AB,  AB, A -> ()
@@ -16,6 +17,7 @@ File "robustmatch.ml", lines 43-47, characters 4-21:
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 (AB, MAB, A)
+
 File "robustmatch.ml", lines 54-56, characters 4-27:
 54 | ....match r1, r2, a with
 55 |     | R1, _, 0 -> ()
@@ -23,6 +25,7 @@ File "robustmatch.ml", lines 54-56, characters 4-27:
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 (R1, R1, 1)
+
 File "robustmatch.ml", lines 64-66, characters 4-27:
 64 | ....match r1, r2, a with
 65 |     | R1, _, A -> ()
@@ -30,6 +33,7 @@ File "robustmatch.ml", lines 64-66, characters 4-27:
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 (R1, R1, (B|C))
+
 File "robustmatch.ml", lines 69-71, characters 4-20:
 69 | ....match r1, r2, a with
 70 |     | _, R2, "coucou" -> ()
@@ -37,6 +41,7 @@ File "robustmatch.ml", lines 69-71, characters 4-20:
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 (R1, R1, (B|C))
+
 File "robustmatch.ml", lines 74-76, characters 4-20:
 74 | ....match r1, r2, a with
 75 |     | _, R2, "coucou" -> ()
@@ -44,6 +49,7 @@ File "robustmatch.ml", lines 74-76, characters 4-20:
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 (R2, R2, "")
+
 File "robustmatch.ml", lines 85-87, characters 4-20:
 85 | ....match r1, r2, a with
 86 |     | R1, _, A -> ()
@@ -51,6 +57,7 @@ File "robustmatch.ml", lines 85-87, characters 4-20:
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 (R1, R1, (B|C))
+
 File "robustmatch.ml", lines 90-93, characters 4-20:
 90 | ....match r1, r2, a with
 91 |     | R1, _, A -> ()
@@ -59,6 +66,7 @@ File "robustmatch.ml", lines 90-93, characters 4-20:
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 (R2, R2, (Y|Z))
+
 File "robustmatch.ml", lines 96-98, characters 4-20:
 96 | ....match r1, r2, a with
 97 |     | R1, _, _ -> ()
@@ -66,6 +74,7 @@ File "robustmatch.ml", lines 96-98, characters 4-20:
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 (R2, R2, (Y|Z))
+
 File "robustmatch.ml", lines 107-109, characters 4-20:
 107 | ....match r1, r2, a with
 108 |     | R1, _, A -> ()
@@ -73,6 +82,7 @@ File "robustmatch.ml", lines 107-109, characters 4-20:
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 (R1, R1, (B|C))
+
 File "robustmatch.ml", lines 129-131, characters 4-20:
 129 | ....match r1, r2, a with
 130 |     | R1, _, A -> ()
@@ -80,6 +90,7 @@ File "robustmatch.ml", lines 129-131, characters 4-20:
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 (R1, R1, B)
+
 File "robustmatch.ml", lines 151-153, characters 4-20:
 151 | ....match r1, r2, a with
 152 |     | R1, _, A -> ()
@@ -87,6 +98,7 @@ File "robustmatch.ml", lines 151-153, characters 4-20:
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 (R1, R1, B)
+
 File "robustmatch.ml", lines 156-159, characters 4-20:
 156 | ....match r1, r2, a with
 157 |     | R1, _, A -> ()
@@ -95,6 +107,7 @@ File "robustmatch.ml", lines 156-159, characters 4-20:
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 (R2, R2, Y)
+
 File "robustmatch.ml", lines 162-164, characters 4-20:
 162 | ....match r1, r2, a with
 163 |     | R1, _, _ -> ()
@@ -102,6 +115,7 @@ File "robustmatch.ml", lines 162-164, characters 4-20:
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 (R2, R2, Y)
+
 File "robustmatch.ml", lines 167-169, characters 4-20:
 167 | ....match r1, r2, a with
 168 |     | R1, _, C -> ()
@@ -109,6 +123,7 @@ File "robustmatch.ml", lines 167-169, characters 4-20:
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 (R1, R1, A)
+
 File "robustmatch.ml", lines 176-179, characters 4-20:
 176 | ....match r1, r2, a with
 177 |     | _, R1, 0 -> ()
@@ -117,6 +132,7 @@ File "robustmatch.ml", lines 176-179, characters 4-20:
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 (R2, R2, [| _ |])
+
 File "robustmatch.ml", lines 182-184, characters 4-23:
 182 | ....match r1, r2, a with
 183 |     | R1, _, _ -> ()
@@ -124,6 +140,7 @@ File "robustmatch.ml", lines 182-184, characters 4-23:
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 (R2, R2, [| _ |])
+
 File "robustmatch.ml", lines 187-190, characters 4-20:
 187 | ....match r1, r2, a with
 188 |     | _, R2, [||] -> ()
@@ -132,6 +149,7 @@ File "robustmatch.ml", lines 187-190, characters 4-20:
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 (R2, R2, [| _ |])
+
 File "robustmatch.ml", lines 200-203, characters 4-19:
 200 | ....match r1, r2, a with
 201 |     | _, R2, [||] -> ()
@@ -139,6 +157,7 @@ File "robustmatch.ml", lines 200-203, characters 4-19:
 203 |     | _, _, _ -> ()
 Warning 4 [fragile-match]: this pattern-matching is fragile.
 It will remain exhaustive when constructors are added to type repr.
+
 File "robustmatch.ml", lines 210-212, characters 4-27:
 210 | ....match r1, r2, a with
 211 |     | R1, _, 'c' -> ()
@@ -146,6 +165,7 @@ File "robustmatch.ml", lines 210-212, characters 4-27:
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 (R1, R1, 'a')
+
 File "robustmatch.ml", lines 219-221, characters 4-27:
 219 | ....match r1, r2, a with
 220 |     | R1, _, `A -> ()
@@ -153,6 +173,7 @@ File "robustmatch.ml", lines 219-221, characters 4-27:
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 (R1, R1, `B)
+
 File "robustmatch.ml", lines 228-230, characters 4-37:
 228 | ....match r1, r2, a with
 229 |     | R1, _, (3, "") -> ()
@@ -160,6 +181,7 @@ File "robustmatch.ml", lines 228-230, characters 4-37:
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 (R1, R1, (3, "*"))
+
 File "robustmatch.ml", lines 239-241, characters 4-51:
 239 | ....match r1, r2, a with
 240 |     | R1, _, { x = 3; y = "" } -> ()
@@ -167,6 +189,7 @@ File "robustmatch.ml", lines 239-241, characters 4-51:
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 (R1, R1, {x=3; y="*"})
+
 File "robustmatch.ml", lines 244-246, characters 4-36:
 244 | ....match r1, r2, a with
 245 |     | R2, _, { a = 1; b = "coucou"; c = 'a' } -> ()
@@ -174,6 +197,7 @@ File "robustmatch.ml", lines 244-246, characters 4-36:
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 (R2, R2, {a=1; b="coucou"; c='b'})
+
 File "robustmatch.ml", lines 253-255, characters 4-20:
 253 | ....match r1, r2, a with
 254 |     | R1, _, (3, "") -> ()
@@ -181,6 +205,7 @@ File "robustmatch.ml", lines 253-255, characters 4-20:
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 (R1, R1, (3, "*"))
+
 File "robustmatch.ml", lines 263-265, characters 4-20:
 263 | ....match r1, r2, a with
 264 |     | R1, _, { x = 3; y = "" } -> ()
@@ -188,6 +213,7 @@ File "robustmatch.ml", lines 263-265, characters 4-20:
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 (R1, R1, {x=3; y="*"})
+
 File "robustmatch.ml", lines 272-274, characters 4-20:
 272 | ....match r1, r2, a with
 273 |     | R1, _, lazy 1 -> ()
@@ -195,6 +221,7 @@ File "robustmatch.ml", lines 272-274, characters 4-20:
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 (R1, R1, lazy 0)
+
 File "robustmatch.ml", lines 281-284, characters 4-24:
 281 | ....match r1, r2, a with
 282 |     | R1, _, () -> ()

--- a/testsuite/tests/basic/patmatch_incoherence.ml
+++ b/testsuite/tests/basic/patmatch_incoherence.ml
@@ -42,6 +42,7 @@ Lines 1-3, characters 0-20:
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 {x=Some _}
+
 Exception: Assert_failure ("", 1, 12).
 |}];;
 
@@ -57,6 +58,7 @@ Lines 1-3, characters 0-18:
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 {x="*"}
+
 Exception: Assert_failure ("", 1, 12).
 |}];;
 
@@ -72,6 +74,7 @@ Lines 1-3, characters 0-18:
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 {x=`AnyOtherTag}
+
 Exception: Assert_failure ("", 1, 12).
 |}];;
 
@@ -87,6 +90,7 @@ Lines 1-3, characters 0-17:
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 {x=0}
+
 Exception: Assert_failure ("", 1, 12).
 |}];;
 
@@ -102,6 +106,7 @@ Lines 1-3, characters 0-17:
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 {x=0}
+
 Exception: Assert_failure ("", 1, 12).
 |}];;
 
@@ -117,6 +122,7 @@ Lines 1-3, characters 0-17:
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 {x=0}
+
 Exception: Assert_failure ("", 1, 12).
 |}];;
 
@@ -134,5 +140,6 @@ Lines 1-4, characters 0-17:
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 {x=0}
+
 Exception: Assert_failure ("", 1, 12).
 |}];;

--- a/testsuite/tests/let-syntax/let_syntax.ml
+++ b/testsuite/tests/let-syntax/let_syntax.ml
@@ -720,6 +720,7 @@ Line 4, characters 11-19:
                ^^^^^^^^
 Warning 18 [not-principal]: typing this pattern requires considering GADT_ordering.point and a as equal.
 But the knowledge of these types is not principal.
+
 Line 5, characters 11-19:
 5 |       and+ { x; y } = a in
                ^^^^^^^^

--- a/testsuite/tests/let-syntax/let_syntax.ml
+++ b/testsuite/tests/let-syntax/let_syntax.ml
@@ -588,6 +588,7 @@ Line 3, characters 9-10:
 3 |     let+ A = A.A in
              ^
 Warning 18 [not-principal]: this type-based constructor disambiguation is not principal.
+
 val let_not_principal : unit = ()
 |}];;
 
@@ -617,6 +618,7 @@ Line 5, characters 11-12:
 5 |       and+ A = y in
                ^
 Warning 18 [not-principal]: this type-based constructor disambiguation is not principal.
+
 val and_not_principal : A.t -> A.t -> unit = <fun>
 |}];;
 

--- a/testsuite/tests/letrec-check/pr7231.ocaml.reference
+++ b/testsuite/tests/letrec-check/pr7231.ocaml.reference
@@ -2,6 +2,7 @@ Line 5, characters 58-64:
 5 | let rec r = let rec x () = r and y () = x () in y () in r "oops";;
                                                               ^^^^^^
 Warning 20 [ignored-extra-argument]: this argument will not be used by the function.
+
 Line 5, characters 12-52:
 5 | let rec r = let rec x () = r and y () = x () in y () in r "oops";;
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/testsuite/tests/lexing/escape.ocaml.reference
+++ b/testsuite/tests/lexing/escape.ocaml.reference
@@ -5,6 +5,7 @@ Warning 14 [illegal-backslash]: illegal backslash escape in string.
 Hint: Single backslashes \ are reserved for escape sequences
 (\n, \r, ...). Did you check the list of OCaml escape sequences?
 To get a backslash character, escape it with a second backslash: \\.
+
 val invalid : string = "\\99"
 Line 1, characters 15-19:
 1 | let invalid = "\999" ;;
@@ -21,6 +22,7 @@ Warning 14 [illegal-backslash]: illegal backslash escape in string.
 Hint: Single backslashes \ are reserved for escape sequences
 (\n, \r, ...). Did you check the list of OCaml escape sequences?
 To get a backslash character, escape it with a second backslash: \\.
+
 val invalid : string = "\\o77"
 Line 1, characters 15-17:
 1 | let invalid = "\o99" ;;
@@ -29,5 +31,6 @@ Warning 14 [illegal-backslash]: illegal backslash escape in string.
 Hint: Single backslashes \ are reserved for escape sequences
 (\n, \r, ...). Did you check the list of OCaml escape sequences?
 To get a backslash character, escape it with a second backslash: \\.
+
 val invalid : string = "\\o99"
 

--- a/testsuite/tests/lexing/uchar_esc.ocaml.reference
+++ b/testsuite/tests/lexing/uchar_esc.ocaml.reference
@@ -29,6 +29,7 @@ Warning 14 [illegal-backslash]: illegal backslash escape in string.
 Hint: Single backslashes \ are reserved for escape sequences
 (\n, \r, ...). Did you check the list of OCaml escape sequences?
 To get a backslash character, escape it with a second backslash: \\.
+
 val no_hex_digits : string = "\\u{}"
 Line 1, characters 25-27:
 1 | let illegal_hex_digit = "\u{u}" ;;
@@ -37,5 +38,6 @@ Warning 14 [illegal-backslash]: illegal backslash escape in string.
 Hint: Single backslashes \ are reserved for escape sequences
 (\n, \r, ...). Did you check the list of OCaml escape sequences?
 To get a backslash character, escape it with a second backslash: \\.
+
 val illegal_hex_digit : string = "\\u{u}"
 

--- a/testsuite/tests/match-exception-warnings/exhaustiveness_warnings.ml
+++ b/testsuite/tests/match-exception-warnings/exhaustiveness_warnings.ml
@@ -80,10 +80,12 @@ Lines 2-5, characters 4-30:
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 Some true
+
 Line 4, characters 29-30:
 4 |     | Some false | exception _ -> ()
                                  ^
 Warning 11 [redundant-case]: this match case is unused.
+
 Line 5, characters 23-24:
 5 |     | None | exception _ -> ()
                            ^

--- a/testsuite/tests/match-exception-warnings/exhaustiveness_warnings.ml
+++ b/testsuite/tests/match-exception-warnings/exhaustiveness_warnings.ml
@@ -24,6 +24,7 @@ Lines 8-11, characters 4-16:
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 Some true
+
 val test_match_exhaustiveness : unit -> unit = <fun>
 |}]
 ;;
@@ -42,6 +43,7 @@ Lines 2-4, characters 4-30:
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 Some true
+
 val test_match_exhaustiveness_nest1 : unit -> unit = <fun>
 |}]
 ;;
@@ -60,6 +62,7 @@ Lines 2-4, characters 4-16:
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 Some true
+
 val test_match_exhaustiveness_nest2 : unit -> unit = <fun>
 |}]
 ;;
@@ -90,6 +93,7 @@ Line 5, characters 23-24:
 5 |     | None | exception _ -> ()
                            ^
 Warning 11 [redundant-case]: this match case is unused.
+
 val test_match_exhaustiveness_full : unit -> unit = <fun>
 |}]
 ;;

--- a/testsuite/tests/no-alias-deps/aliases.compilers.reference
+++ b/testsuite/tests/no-alias-deps/aliases.compilers.reference
@@ -2,6 +2,7 @@ File "aliases.ml", line 17, characters 12-13:
 17 | module A' = A (* missing a.cmi *)
                  ^
 Warning 49 [no-cmi-file]: no cmi file was found in path for module A
+
 File "aliases.ml", line 18, characters 12-13:
 18 | module B' = B (* broken b.cmi *)
                  ^

--- a/testsuite/tests/parsetree/locations_test.compilers.reference
+++ b/testsuite/tests/parsetree/locations_test.compilers.reference
@@ -643,6 +643,7 @@ Line 2, characters 12-13:
 2 | let x = M.( 3; 4 );;
                 ^
 Warning 10 [non-unit-statement]: this expression should have type unit.
+
 val x : int = 4
 Ptop_def
   [

--- a/testsuite/tests/parsing/change_start_loc.reference
+++ b/testsuite/tests/parsing/change_start_loc.reference
@@ -2,5 +2,6 @@ Incomplete version:
 File "file.ml", line 100, characters 10--999:
 Error: Syntax error
 Good version:
+
 File "file.ml", line 100, characters 10-11:
 Error: Syntax error

--- a/testsuite/tests/tmc/other_features.ml
+++ b/testsuite/tests/tmc/other_features.ml
@@ -23,10 +23,12 @@ Lines 6-11, characters 30-40:
 11 |         C (map' a, (map' [@tailcall]) b)
 Warning 71 [unused-tmc-attribute]: This function is marked @tail_mod_cons
 but is never applied in TMC position.
+
 Line 11, characters 19-39:
 11 |         C (map' a, (map' [@tailcall]) b)
                         ^^^^^^^^^^^^^^^^^^^^
 Warning 51 [wrong-tailcall-expectation]: expected tailcall
+
 Line 11, characters 19-39:
 11 |         C (map' a, (map' [@tailcall]) b)
                         ^^^^^^^^^^^^^^^^^^^^

--- a/testsuite/tests/tmc/other_features.ml
+++ b/testsuite/tests/tmc/other_features.ml
@@ -33,6 +33,7 @@ Line 11, characters 19-39:
 11 |         C (map' a, (map' [@tailcall]) b)
                         ^^^^^^^^^^^^^^^^^^^^
 Warning 51 [wrong-tailcall-expectation]: expected tailcall
+
 module Non_recursive_let_bad :
   sig
     type 'a t = N of 'a | C of 'a t * 'a t

--- a/testsuite/tests/tmc/tupled_function_calls.native.reference
+++ b/testsuite/tests/tmc/tupled_function_calls.native.reference
@@ -7,10 +7,12 @@ File "tupled_function_calls.ml", lines 16-21, characters 46-57:
 21 |       f x :: (tupled_map_not_direct[@tailcall true]) pair
 Warning 71 [unused-tmc-attribute]: This function is marked @tail_mod_cons
 but is never applied in TMC position.
+
 File "tupled_function_calls.ml", line 21, characters 13-57:
 21 |       f x :: (tupled_map_not_direct[@tailcall true]) pair
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 51 [wrong-tailcall-expectation]: expected tailcall
+
 File "tupled_function_calls.ml", line 21, characters 13-57:
 21 |       f x :: (tupled_map_not_direct[@tailcall true]) pair
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/testsuite/tests/tmc/usage_warnings.ml
+++ b/testsuite/tests/tmc/usage_warnings.ml
@@ -25,6 +25,7 @@ so the call will not be transformed into a tail call.
 Please either mark the called function with the [@tail_mod_cons]
 attribute, or mark this call with the [@tailcall false] attribute
 to make its non-tailness explicit.
+
 Lines 1-3, characters 34-40:
 1 | ..................................function
 2 |   | [] -> []
@@ -69,6 +70,7 @@ so the call will not be transformed into a tail call.
 Please either mark the called function with the [@tail_mod_cons]
 attribute, or mark this call with the [@tailcall false] attribute
 to make its non-tailness explicit.
+
 Lines 1-10, characters 34-30:
  1 | ..................................function
  2 |   | [] -> []
@@ -250,14 +252,17 @@ so the call will not be transformed into a tail call.
 Please either mark the called function with the [@tail_mod_cons]
 attribute, or mark this call with the [@tailcall false] attribute
 to make its non-tailness explicit.
+
 Line 17, characters 17-67:
 17 |         else Tau ((graft[@tailcall]) (* this should also warn *) n)
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 51 [wrong-tailcall-expectation]: expected tailcall
+
 Line 16, characters 13-56:
 16 |         then (graft[@tailcall]) (* this should warn *) n
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 51 [wrong-tailcall-expectation]: expected tailcall
+
 Line 17, characters 17-67:
 17 |         else Tau ((graft[@tailcall]) (* this should also warn *) n)
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/testsuite/tests/tmc/usage_warnings.ml
+++ b/testsuite/tests/tmc/usage_warnings.ml
@@ -32,6 +32,7 @@ Lines 1-3, characters 34-40:
 3 |   | xs :: xss -> append xs (flatten xss)
 Warning 71 [unused-tmc-attribute]: This function is marked @tail_mod_cons
 but is never applied in TMC position.
+
 val flatten : 'a list list -> 'a list = <fun>
 |}]
 
@@ -84,6 +85,7 @@ Lines 1-10, characters 34-30:
 10 |       in append_flatten xs xss
 Warning 71 [unused-tmc-attribute]: This function is marked @tail_mod_cons
 but is never applied in TMC position.
+
 val flatten : 'a list list -> 'a list = <fun>
 |}]
 
@@ -115,6 +117,7 @@ so the call will not be transformed into a tail call.
 Please either mark the called function with the [@tail_mod_cons]
 attribute, or mark this call with the [@tailcall false] attribute
 to make its non-tailness explicit.
+
 val flatten : 'a list list -> 'a list = <fun>
 |}]
 
@@ -169,6 +172,7 @@ so the call will not be transformed into a tail call.
 Please either mark the called function with the [@tail_mod_cons]
 attribute, or mark this call with the [@tailcall false] attribute
 to make its non-tailness explicit.
+
 module Tail_calls_to_non_specialized_functions :
   sig
     val list_id : 'a list -> 'a list
@@ -267,6 +271,7 @@ Line 17, characters 17-67:
 17 |         else Tau ((graft[@tailcall]) (* this should also warn *) n)
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 51 [wrong-tailcall-expectation]: expected tailcall
+
 module All_annotations_flipped :
   sig
     type 'a t = N of 'a | Graft of int | Tau of 'a t | C of 'a t * 'a t

--- a/testsuite/tests/tool-caml-tex/redirections.reference
+++ b/testsuite/tests/tool-caml-tex/redirections.reference
@@ -19,6 +19,7 @@ $\?$ let f <<x>> = () ;;
 \end{camlinput}
 \begin{camlwarn}
 Warning 27 [unused-var-strict]: unused variable x.
+
 val f : 'a -> unit = <fun>
 \end{camlwarn}
 \end{caml}

--- a/testsuite/tests/tool-ocamlc-open/tool-ocamlc-open-error.compilers.reference
+++ b/testsuite/tests/tool-ocamlc-open/tool-ocamlc-open-error.compilers.reference
@@ -1,4 +1,5 @@
 File "tool-ocamlc-open-error.ml", line 1:
 Warning 24 [bad-module-name]: bad source file name: "Tool-ocamlc-open-error" is not a valid module name.
+
 File "command line argument: -open "F("", line 1, characters 1-2:
 Error: Syntax error

--- a/testsuite/tests/tool-toplevel/pr6468.compilers.reference
+++ b/testsuite/tests/tool-toplevel/pr6468.compilers.reference
@@ -4,6 +4,7 @@ Line 1, characters 11-15:
 1 | let g () = f (); 1;;
                ^^^^
 Warning 21 [nonreturning-statement]: this statement never returns (or has an unsound type.)
+
 val g : unit -> int = <fun>
 Exception: Not_found.
 Raised at f in file "//toplevel//", line 2, characters 11-26

--- a/testsuite/tests/tool-toplevel/pr7060.compilers.reference
+++ b/testsuite/tests/tool-toplevel/pr7060.compilers.reference
@@ -6,6 +6,7 @@ Line 1, characters 18-54:
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 B
+
 val print_t : Format.formatter -> t -> unit = <fun>
 - : t =
 <printer print_t raised an exception: File "//toplevel//", line 1, characters 18-23: Pattern matching failed>

--- a/testsuite/tests/typing-deprecated/alerts.ml
+++ b/testsuite/tests/typing-deprecated/alerts.ml
@@ -49,6 +49,7 @@ Line 1, characters 8-11:
             ^^^
 Error (alert baz): X.t
 BAZ
+
 Line 1, characters 8-11:
 1 | let _ = X.t;;
             ^^^
@@ -87,6 +88,7 @@ Line 2, characters 2-12:
 2 |   val x: int
       ^^^^^^^^^^
   Expected signature
+
 Line 6, characters 6-7:
 6 | end = X;;
           ^
@@ -100,6 +102,7 @@ Line 4, characters 2-12:
 4 |   val z: int
       ^^^^^^^^^^
   Expected signature
+
 Line 6, characters 6-7:
 6 | end = X;;
           ^
@@ -113,6 +116,7 @@ Line 5, characters 2-12:
 5 |   val t: int
       ^^^^^^^^^^
   Expected signature
+
 Line 6, characters 6-7:
 6 | end = X;;
           ^
@@ -151,6 +155,7 @@ Line 4, characters 2-12:
 4 |   val x: int
       ^^^^^^^^^^
   Expected signature
+
 Line 8, characters 6-7:
 8 | end = X;;
           ^
@@ -164,6 +169,7 @@ Line 6, characters 2-12:
 6 |   val z: int
       ^^^^^^^^^^
   Expected signature
+
 Line 8, characters 6-7:
 8 | end = X;;
           ^
@@ -177,6 +183,7 @@ Line 7, characters 2-12:
 7 |   val t: int
       ^^^^^^^^^^
   Expected signature
+
 Line 8, characters 6-7:
 8 | end = X;;
           ^
@@ -259,11 +266,13 @@ Line 2, characters 13-25:
                  ^^^^^^^^^^^^
 Warning 47 [attribute-payload]: illegal payload for attribute 'alert'.
 Invalid payload
+
 Line 3, characters 13-29:
 3 |   val y: int [@@alert bla 42]
                  ^^^^^^^^^^^^^^^^
 Warning 47 [attribute-payload]: illegal payload for attribute 'alert'.
 Invalid payload
+
 Line 4, characters 13-28:
 4 |   val z: int [@@alert "bla"]
                  ^^^^^^^^^^^^^^^

--- a/testsuite/tests/typing-deprecated/alerts.ml
+++ b/testsuite/tests/typing-deprecated/alerts.ml
@@ -25,6 +25,7 @@ Line 1, characters 8-11:
             ^^^
 Alert foo: X.x
 Foo!
+
 - : int = 0
 |}]
 
@@ -197,6 +198,7 @@ Line 7, characters 2-12:
 7 |   val t: int
       ^^^^^^^^^^
   Expected signature
+
 module Z3 : sig val x : int val y : int val z : int val t : int end
 |}]
 
@@ -236,6 +238,7 @@ Alert bla: X.x
 X1
 X2
 X3
+
 - : int = 0
 Line 10, characters 8-11:
 10 | let _ = X.y
@@ -243,11 +246,13 @@ Line 10, characters 8-11:
 Alert bla: X.y
 X1
 X3
+
 - : int = 0
 Line 11, characters 8-11:
 11 | let _ = X.z
              ^^^
 Alert bla: X.z
+
 - : int = 0
 |}]
 
@@ -278,5 +283,6 @@ Line 4, characters 13-28:
                  ^^^^^^^^^^^^^^^
 Warning 47 [attribute-payload]: illegal payload for attribute 'alert'.
 Ill-formed list of alert settings
+
 module X : sig val x : int val y : int val z : int end
 |}]

--- a/testsuite/tests/typing-deprecated/deprecated.ml
+++ b/testsuite/tests/typing-deprecated/deprecated.ml
@@ -99,6 +99,7 @@ Line 1, characters 9-12:
 1 | type t = X.t * X.s
              ^^^
 Alert deprecated: X.t
+
 Line 1, characters 15-18:
 1 | type t = X.t * X.s
                    ^^^
@@ -218,6 +219,7 @@ Line 1, characters 26-29:
 1 | module rec M : sig val x: X.t end = struct let x = X.x end
                               ^^^
 Alert deprecated: X.t
+
 Line 1, characters 51-54:
 1 | module rec M : sig val x: X.t end = struct let x = X.x end
                                                        ^^^
@@ -542,6 +544,7 @@ Line 2, characters 24-39:
 2 |     [@@ocaml.ppwarning  "Pp warning 2!"]
                             ^^^^^^^^^^^^^^^
 Warning 22 [preprocessor]: Pp warning 2!
+
 Line 1, characters 29-44:
 1 | let x = () [@ocaml.ppwarning "Pp warning 1!"]
                                  ^^^^^^^^^^^^^^^
@@ -600,6 +603,7 @@ Line 4, characters 21-36:
 4 |   [@@ocaml.ppwarning "Pp warning 3!"]
                          ^^^^^^^^^^^^^^^
 Warning 22 [preprocessor]: Pp warning 3!
+
 Line 3, characters 21-36:
 3 |   [@ocaml.ppwarning  "Pp warning 2!"]
                          ^^^^^^^^^^^^^^^
@@ -614,6 +618,7 @@ Line 1, characters 25-29:
 1 | let ([][@ocaml.ppwarning "XX"]) = []
                              ^^^^
 Warning 22 [preprocessor]: XX
+
 Line 1, characters 4-31:
 1 | let ([][@ocaml.ppwarning "XX"]) = []
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/testsuite/tests/typing-deprecated/deprecated.ml
+++ b/testsuite/tests/typing-deprecated/deprecated.ml
@@ -20,6 +20,7 @@ Line 7, characters 9-10:
 7 |   val x: t [@@ocaml.deprecated]
              ^
 Alert deprecated: t
+
 module X : sig type t type s type u val x : t end
 |}]
 
@@ -30,6 +31,7 @@ Line 1, characters 9-12:
 1 | type t = X.t
              ^^^
 Alert deprecated: X.t
+
 type t = X.t
 |}]
 
@@ -40,6 +42,7 @@ Line 1, characters 8-11:
 1 | let x = X.x
             ^^^
 Alert deprecated: X.x
+
 val x : X.t = <abstr>
 |}]
 
@@ -54,6 +57,7 @@ Line 3, characters 0-3:
 3 | foo;;
     ^^^
 Alert deprecated: foo
+
 - : unit = ()
 |}]
 
@@ -74,6 +78,7 @@ Line 2, characters 33-36:
 2 |   | bar, cho [@deprecated], _ -> cho + 1
                                      ^^^
 Alert deprecated: cho
+
 val f : 'a * int * 'b -> int = <fun>
 |}]
 
@@ -87,6 +92,7 @@ Line 3, characters 12-15:
 3 |     val h = foo
                 ^^^
 Alert deprecated: foo
+
 class c : 'a * int -> object val h : int end
 |}]
 
@@ -104,6 +110,7 @@ Line 1, characters 15-18:
 1 | type t = X.t * X.s
                    ^^^
 Alert deprecated: X.s
+
 type t = X.t * X.s
 |}]
 
@@ -121,6 +128,7 @@ Line 2, characters 9-12:
 2 | and t2 = X.s
              ^^^
 Alert deprecated: X.s
+
 type t1 = X.t
 and t2 = X.s
 |}]
@@ -132,6 +140,7 @@ Line 1, characters 14-15:
 1 | type t = A of t [@@ocaml.deprecated]
                   ^
 Alert deprecated: t
+
 type t = A of t
 |}]
 
@@ -158,6 +167,7 @@ Line 1, characters 39-42:
 1 | type t = (X.t [@ocaml.warning "-3"]) * X.s
                                            ^^^
 Alert deprecated: X.s
+
 type t = X.t * X.s
 |}]
 
@@ -178,6 +188,7 @@ Line 1, characters 22-25:
 1 | let _ = function (_ : X.t) -> ()
                           ^^^
 Alert deprecated: X.t
+
 - : X.t -> unit = <fun>
 |}]
 
@@ -197,6 +208,7 @@ Line 1, characters 26-29:
 1 | module M = struct let x = X.x end
                               ^^^
 Alert deprecated: X.x
+
 module M : sig val x : X.t end
 |}]
 
@@ -224,6 +236,7 @@ Line 1, characters 51-54:
 1 | module rec M : sig val x: X.t end = struct let x = X.x end
                                                        ^^^
 Alert deprecated: X.x
+
 module rec M : sig val x : X.t end
 |}]
 
@@ -250,6 +263,7 @@ Line 3, characters 17-20:
 3 |   struct let x = X.x end
                      ^^^
 Alert deprecated: X.x
+
 module rec M : sig val x : X.t end
 |}]
 
@@ -262,6 +276,7 @@ Line 1, characters 29-32:
 1 | module type S = sig type t = X.t end
                                  ^^^
 Alert deprecated: X.t
+
 module type S = sig type t = X.t end
 |}]
 
@@ -287,6 +302,7 @@ Line 1, characters 28-31:
 1 | class c = object method x = X.x end
                                 ^^^
 Alert deprecated: X.x
+
 class c : object method x : X.t end
 |}]
 
@@ -318,6 +334,7 @@ Line 1, characters 33-36:
 1 | class type c = object method x : X.t end
                                      ^^^
 Alert deprecated: X.t
+
 class type c = object method x : X.t end
 |}]
 
@@ -350,6 +367,7 @@ Line 1, characters 22-25:
 1 | external foo: unit -> X.t = "foo"
                           ^^^
 Alert deprecated: X.t
+
 external foo : unit -> X.t = "foo"
 |}]
 
@@ -369,6 +387,7 @@ Line 1, characters 0-3:
 1 | X.x
     ^^^
 Alert deprecated: X.x
+
 - : X.t = <abstr>
 |}]
 
@@ -431,6 +450,7 @@ Line 2, characters 9-12:
 2 |   | A of X.t
              ^^^
 Alert deprecated: X.t
+
 type ext += A of X.t | B of X.s | C of X.u
 |}]
 
@@ -450,6 +470,7 @@ Line 1, characters 17-20:
 1 | exception Foo of X.t
                      ^^^
 Alert deprecated: X.t
+
 exception Foo of X.t
 |}]
 
@@ -472,6 +493,7 @@ Line 2, characters 9-12:
 2 |   | A of X.t
              ^^^
 Alert deprecated: X.t
+
 type t = A of X.t | B of X.s | C of X.u
 |}]
 
@@ -487,6 +509,7 @@ Line 3, characters 7-10:
 3 |     a: X.t;
            ^^^
 Alert deprecated: X.t
+
 type t = { a : X.t; b : X.s; c : X.u; }
 |}]
 
@@ -503,6 +526,7 @@ Line 3, characters 7-10:
 3 |     a: X.t;
            ^^^
 Alert deprecated: X.t
+
 type t = < a : X.t; b : X.s; c : X.u >
 |}]
 
@@ -519,6 +543,7 @@ Line 3, characters 10-13:
 3 |   | `A of X.t
               ^^^
 Alert deprecated: X.t
+
 type t = [ `A of X.t | `B of X.s | `C of X.u ]
 |}]
 
@@ -549,6 +574,7 @@ Line 1, characters 29-44:
 1 | let x = () [@ocaml.ppwarning "Pp warning 1!"]
                                  ^^^^^^^^^^^^^^^
 Warning 22 [preprocessor]: Pp warning 1!
+
 val x : unit = ()
 |}]
 
@@ -560,6 +586,7 @@ Line 2, characters 22-35:
 2 |     [@ocaml.ppwarning "Pp warning!"]
                           ^^^^^^^^^^^^^
 Warning 22 [preprocessor]: Pp warning!
+
 type t = unit
 |}]
 
@@ -578,6 +605,7 @@ Line 8, characters 22-36:
 8 |   [@@@ocaml.ppwarning "Pp warning2!"]
                           ^^^^^^^^^^^^^^
 Warning 22 [preprocessor]: Pp warning2!
+
 module X : sig end
 |}]
 
@@ -590,6 +618,7 @@ Line 3, characters 23-38:
 3 |     [@ocaml.ppwarning  "Pp warning 2!"]
                            ^^^^^^^^^^^^^^^
 Warning 22 [preprocessor]: Pp warning 2!
+
 val x : unit = ()
 |}]
 
@@ -608,6 +637,7 @@ Line 3, characters 21-36:
 3 |   [@ocaml.ppwarning  "Pp warning 2!"]
                          ^^^^^^^^^^^^^^^
 Warning 22 [preprocessor]: Pp warning 2!
+
 type t = unit
 |}]
 

--- a/testsuite/tests/typing-extensions/disambiguation.ml
+++ b/testsuite/tests/typing-extensions/disambiguation.ml
@@ -244,5 +244,6 @@ Line 7, characters 8-14:
             ^^^^^^
 Warning 41 [ambiguous-name]: Unique belongs to several types: b M.s t a
 The first one was selected. Please disambiguate if this is wrong.
+
 val x : b = Unique
 |}]

--- a/testsuite/tests/typing-extensions/open_types.ml
+++ b/testsuite/tests/typing-extensions/open_types.ml
@@ -312,6 +312,7 @@ Here is an example of a case that is not matched:
 *extension*
 Matching over values of extensible variant types (the *extension* above)
 must include a wild card pattern in order to be exhaustive.
+
 val f : foo -> unit = <fun>
 |}]
 
@@ -333,6 +334,7 @@ Here is an example of a case that is not matched:
 *extension*::[]
 Matching over values of extensible variant types (the *extension* above)
 must include a wild card pattern in order to be exhaustive.
+
 val f : foo list -> int = <fun>
 |}]
 
@@ -356,5 +358,6 @@ Here is an example of a case that is not matched:
 *extension*
 Matching over values of extensible variant types (the *extension* above)
 must include a wild card pattern in order to be exhaustive.
+
 val f : t -> string = <fun>
 |}]

--- a/testsuite/tests/typing-gadts/didier.ml
+++ b/testsuite/tests/typing-gadts/didier.ml
@@ -18,6 +18,7 @@ Lines 6-7, characters 2-13:
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 Int
+
 val fbool : 't -> 't ty -> 't = <fun>
 |}];;
 (* val fbool : 'a -> 'a ty -> 'a = <fun> *)
@@ -34,6 +35,7 @@ Lines 2-3, characters 2-16:
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 Bool
+
 val fint : 't -> 't ty -> bool = <fun>
 |}];;
 (* val fint : 'a -> 'a ty -> bool = <fun> *)

--- a/testsuite/tests/typing-gadts/pr10189.ml
+++ b/testsuite/tests/typing-gadts/pr10189.ml
@@ -57,6 +57,7 @@ Line 6, characters 2-20:
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 Some A
+
 val g : M.j t option -> unit = <fun>
 |}]
 
@@ -84,6 +85,7 @@ Line 9, characters 2-20:
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 Some A
+
 val g : M.j t option -> unit = <fun>
 |}]
 
@@ -110,6 +112,7 @@ Line 9, characters 2-20:
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 Some A
+
 val g : 'a M.j t option -> unit = <fun>
 |}]
 

--- a/testsuite/tests/typing-gadts/pr5785.ml
+++ b/testsuite/tests/typing-gadts/pr5785.ml
@@ -20,6 +20,7 @@ Lines 7-9, characters 43-24:
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 (One, Two)
+
 module Add :
   functor (T : sig type two end) ->
     sig

--- a/testsuite/tests/typing-gadts/pr5906.ml
+++ b/testsuite/tests/typing-gadts/pr5906.ml
@@ -36,6 +36,7 @@ Lines 12-16, characters 2-36:
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 (Eq, Int _, _)
+
 val eval : ('a, 'b, 'c) binop -> 'a constant -> 'b constant -> 'c constant =
   <fun>
 Exception: Match_failure ("", 12, 2).

--- a/testsuite/tests/typing-gadts/pr5981.ml
+++ b/testsuite/tests/typing-gadts/pr5981.ml
@@ -18,6 +18,7 @@ Lines 7-8, characters 47-21:
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 (A, A)
+
 module F :
   functor (S : sig type 'a t end) ->
     sig
@@ -45,6 +46,7 @@ Lines 10-11, characters 15-21:
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 (A, A)
+
 module F :
   functor (S : sig type 'a t end) ->
     sig

--- a/testsuite/tests/typing-gadts/pr5989.ml
+++ b/testsuite/tests/typing-gadts/pr5989.ml
@@ -31,6 +31,7 @@ Lines 16-17, characters 39-16:
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 Eq
+
 val f : (M.s, [ `A | `B ]) t -> string = <fun>
 Exception: Match_failure ("", 16, 39).
 |}];;
@@ -61,5 +62,6 @@ Lines 12-13, characters 49-16:
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 Eq
+
 val f : (N.s, < a : int; b : bool >) t -> string = <fun>
 |}];;

--- a/testsuite/tests/typing-gadts/pr5997.ml
+++ b/testsuite/tests/typing-gadts/pr5997.ml
@@ -28,6 +28,7 @@ Line 16, characters 0-33:
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 Eq
+
 Exception: Match_failure ("", 16, 0).
 |}];;
 
@@ -51,5 +52,6 @@ Line 11, characters 0-33:
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 Eq
+
 Exception: Match_failure ("", 11, 0).
 |}];;

--- a/testsuite/tests/typing-gadts/pr6241.ml
+++ b/testsuite/tests/typing-gadts/pr6241.ml
@@ -27,6 +27,7 @@ Lines 8-9, characters 52-13:
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 A
+
 module M :
   functor (A : sig module type T end) (B : sig module type T end) ->
     sig val f : ((module A.T), (module B.T)) t -> string end

--- a/testsuite/tests/typing-gadts/pr6993_bad.ml
+++ b/testsuite/tests/typing-gadts/pr6993_bad.ml
@@ -23,6 +23,7 @@ Line 2, characters 36-66:
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 Y
+
 val f : ('a list, 'a) eqp -> unit = <fun>
 module rec A : sig type t = B.t list end
 and B : sig type t val eq : (B.t list, t) eqp end

--- a/testsuite/tests/typing-gadts/pr7016.ml
+++ b/testsuite/tests/typing-gadts/pr7016.ml
@@ -17,6 +17,7 @@ Line 5, characters 9-43:
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 Nil
+
 val get1 : ('b * 'a, 'a) t -> 'b = <fun>
 |}];;
 

--- a/testsuite/tests/typing-gadts/pr7234.ml
+++ b/testsuite/tests/typing-gadts/pr7234.ml
@@ -14,6 +14,7 @@ Line 3, characters 15-40:
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 Eq
+
 val f : ('a, 'a t) eq -> int = <fun>
 |}];;
 
@@ -27,6 +28,7 @@ Line 2, characters 16-43:
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 Eq
+
 module F :
   functor (T : sig type _ t end) -> sig val f : ('a, 'a T.t) eq -> int end
 |}];;

--- a/testsuite/tests/typing-gadts/pr7269.ml
+++ b/testsuite/tests/typing-gadts/pr7269.ml
@@ -17,6 +17,7 @@ Line 4, characters 6-47:
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 T (`Conj _)
+
 val f : s t -> unit = <fun>
 Exception: Match_failure ("", 4, 6).
 |}];;
@@ -45,6 +46,7 @@ Line 11, characters 12-59:
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 T (`Conj _)
+
 Exception: Match_failure ("", 11, 12).
 |}];;
 
@@ -77,5 +79,6 @@ Line 13, characters 21-57:
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 `Conj _
+
 Exception: Match_failure ("", 13, 21).
 |}];;

--- a/testsuite/tests/typing-gadts/pr7390.ml
+++ b/testsuite/tests/typing-gadts/pr7390.ml
@@ -27,5 +27,6 @@ Line 2, characters 2-28:
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 Either (N, Y _)
+
 val f : filled either -> string = <fun>
 |}]

--- a/testsuite/tests/typing-gadts/pr7432.ml
+++ b/testsuite/tests/typing-gadts/pr7432.ml
@@ -27,6 +27,7 @@ Line 2, characters 2-30:
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 `L Refl
+
 val f : [ `L of (s, t) eql | `R of silly ] -> 'a = <fun>
 |}]
 

--- a/testsuite/tests/typing-gadts/pr9019.ml
+++ b/testsuite/tests/typing-gadts/pr9019.ml
@@ -39,6 +39,7 @@ Lines 4-8, characters 2-18:
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 (AB, MAB, A)
+
 val f : 'x M.t -> 'x M.t -> 'x -> int = <fun>
 |}]
 
@@ -138,6 +139,7 @@ Line 7, characters 4-22:
 7 |   | _,  AB,  { a = _ } -> 3
         ^^^^^^^^^^^^^^^^^^
 Warning 11 [redundant-case]: this match case is unused.
+
 val f : 'x M.t -> 'x M.t -> 'x -> int = <fun>
 |}]
 
@@ -170,6 +172,7 @@ Lines 9-11, characters 2-37:
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 (A, A_or_B, `B _)
+
 val f : 'x a -> 'x a_or_b -> 'x -> unit = <fun>
 |}]
 
@@ -201,6 +204,7 @@ Lines 9-11, characters 2-18:
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 (B, `B String_option, None)
+
 val f : ('x, 'y ty) b -> 'x -> 'y -> unit = <fun>
 |}]
 
@@ -221,6 +225,7 @@ Line 2, characters 18-44:
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 `A (Some _)
+
 val f : 'a option a -> unit = <fun>
 |}]
 
@@ -232,5 +237,6 @@ Line 1, characters 23-47:
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 `A `A
+
 val f : [< `A | `B > `A ] a -> unit = <fun>
 |}]

--- a/testsuite/tests/typing-gadts/pr9759.ml
+++ b/testsuite/tests/typing-gadts/pr9759.ml
@@ -27,5 +27,6 @@ Line 9, characters 4-9:
 9 |   | indir ->
         ^^^^^
 Warning 11 [redundant-case]: this match case is unused.
+
 val foo : 'k general -> 'k general = <fun>
 |}]

--- a/testsuite/tests/typing-gadts/principality-and-gadts.ml
+++ b/testsuite/tests/typing-gadts/principality-and-gadts.ml
@@ -24,6 +24,7 @@ Line 1, characters 8-35:
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 Sigma (M, B)
+
 val f : dyn -> unit = <fun>
 |}];;
 
@@ -54,6 +55,7 @@ Line 5, characters 4-11:
         ^^^^^^^
 Warning 18 [not-principal]: typing this pattern requires considering bool and a as equal.
 But the knowledge of these types is not principal.
+
 val f : 'a t -> 'a -> int = <fun>
 |}]
 
@@ -71,6 +73,7 @@ Line 4, characters 4-10:
         ^^^^^^
 Warning 18 [not-principal]: typing this pattern requires considering int and a as equal.
 But the knowledge of these types is not principal.
+
 val f : 'a t -> 'a -> int = <fun>
 |}]
 
@@ -139,6 +142,7 @@ Line 4, characters 4-7:
         ^^^
 Warning 18 [not-principal]: typing this pattern requires considering unit M.mab and unit ab as equal.
 But the knowledge of these types is not principal.
+
 val f1 : unit ab M.t -> bool = <fun>
 |}]
 
@@ -161,6 +165,7 @@ Line 5, characters 4-7:
         ^^^
 Warning 18 [not-principal]: typing this pattern requires considering unit M.mab and x as equal.
 But the knowledge of these types is not principal.
+
 val f2 : 'x M.t -> bool = <fun>
 |}]
 
@@ -178,6 +183,7 @@ Line 5, characters 4-7:
         ^^^
 Warning 18 [not-principal]: typing this pattern requires considering unit M.mab and unit ab as equal.
 But the knowledge of these types is not principal.
+
 val f3 : unit ab M.t -> bool = <fun>
 |}]
 
@@ -205,6 +211,7 @@ Line 3, characters 7-11:
            ^^^^
 Warning 18 [not-principal]: typing this pattern requires considering x and int option as equal.
 But the knowledge of these types is not principal.
+
 val g2 : ('x, int option) eq -> 'x -> int option = <fun>
 |}]
 
@@ -351,6 +358,7 @@ Line 3, characters 18-23:
                       ^^^^^
 Warning 18 [not-principal]: typing this pattern requires considering M.t and N.t as equal.
 But the knowledge of these types is not principal.
+
 val foo : M.t foo -> M.t = <fun>
 |}]
 
@@ -366,6 +374,7 @@ Line 3, characters 26-31:
                               ^^^^^
 Warning 18 [not-principal]: typing this pattern requires considering M.t and N.t as equal.
 But the knowledge of these types is not principal.
+
 val foo : int foo -> int = <fun>
 |}]
 
@@ -409,6 +418,7 @@ Line 3, characters 29-34:
                                  ^^^^^
 Warning 18 [not-principal]: typing this pattern requires considering M.t and N.t as equal.
 But the knowledge of these types is not principal.
+
 val foo : string foo -> string = <fun>
 |}]
 

--- a/testsuite/tests/typing-gadts/principality-and-gadts.ml
+++ b/testsuite/tests/typing-gadts/principality-and-gadts.ml
@@ -48,6 +48,7 @@ Line 4, characters 4-10:
         ^^^^^^
 Warning 18 [not-principal]: typing this pattern requires considering int and a as equal.
 But the knowledge of these types is not principal.
+
 Line 5, characters 4-11:
 5 |   | BoolLit, b -> 1
         ^^^^^^^
@@ -154,6 +155,7 @@ Line 4, characters 4-6:
         ^^
 Warning 18 [not-principal]: typing this pattern requires considering unit ab and x as equal.
 But the knowledge of these types is not principal.
+
 Line 5, characters 4-7:
 5 |   | MAB -> false;;
         ^^^
@@ -385,6 +387,7 @@ Line 3, characters 26-31:
                               ^^^^^
 Warning 18 [not-principal]: typing this pattern requires considering M.t and N.t as equal.
 But the knowledge of these types is not principal.
+
 Line 3, characters 4-33:
 3 |   | { x = (x : N.t); eq = Refl3 } -> x
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/testsuite/tests/typing-gadts/test.ml
+++ b/testsuite/tests/typing-gadts/test.ml
@@ -109,6 +109,7 @@ Lines 11-12, characters 6-19:
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 C1 _
+
 Lines 24-26, characters 6-30:
 24 | ......function
 25 |         | Foo _ , Foo _ -> true
@@ -163,6 +164,7 @@ Line 2, characters 10-18:
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 None
+
 Line 4, characters 10-18:
 4 |   class d (Just x) = object method x : int = x end
               ^^^^^^^^

--- a/testsuite/tests/typing-gadts/test.ml
+++ b/testsuite/tests/typing-gadts/test.ml
@@ -117,6 +117,7 @@ Lines 24-26, characters 6-30:
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 (Foo _, Bar _)
+
 module Nonexhaustive :
   sig
     type 'a u = C1 : int -> int u | C2 : bool -> bool u
@@ -171,6 +172,7 @@ Line 4, characters 10-18:
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 Nothing
+
 module PR6862 :
   sig
     class c : int option -> object method x : int end
@@ -199,6 +201,7 @@ Line 4, characters 43-44:
                                                ^
 Warning 56 [unreachable-case]: this match case is unreachable.
 Consider replacing it with a refutation case '<pat> -> .'
+
 module PR6220 :
   sig
     type 'a t = I : int t | F : float t
@@ -268,6 +271,7 @@ Lines 8-9, characters 4-33:
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 Any
+
 module PR6801 :
   sig
     type _ value =
@@ -922,6 +926,7 @@ Lines 2-8, characters 2-16:
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 (TE TC, D [| 0. |])
+
 val f : 'a ty -> 'a t -> int = <fun>
 |}];;
 
@@ -986,6 +991,7 @@ Lines 4-10, characters 2-29:
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 {left=TE TC; right=D [| 0. |]}
+
 val f : 'a ty -> 'a t -> int = <fun>
 |}];;
 

--- a/testsuite/tests/typing-gadts/yallop_bugs.ml
+++ b/testsuite/tests/typing-gadts/yallop_bugs.ml
@@ -63,6 +63,7 @@ Lines 5-7, characters 39-23:
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 (BoolLit, true)
+
 val check : 's t * 's -> bool = <fun>
 |}];;
 
@@ -81,5 +82,6 @@ Lines 3-5, characters 45-38:
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 {fst=BoolLit; snd=true}
+
 val check : ('s t, 's) pair -> bool = <fun>
 |}];;

--- a/testsuite/tests/typing-misc/build_as_type.ml
+++ b/testsuite/tests/typing-misc/build_as_type.ml
@@ -75,6 +75,7 @@ Lines 5-7, characters 4-7:
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 `B
+
 val f : t -> unit = <fun>
 |}]
 
@@ -131,6 +132,7 @@ Lines 5-7, characters 4-7:
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 `B
+
 val f : t -> unit = <fun>
 |}]
 
@@ -151,5 +153,6 @@ Lines 5-7, characters 4-7:
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 `B
+
 val f : t -> unit = <fun>
 |}]

--- a/testsuite/tests/typing-misc/constraints.ml
+++ b/testsuite/tests/typing-misc/constraints.ml
@@ -160,6 +160,7 @@ Line 6, characters 23-57:
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 `Foo _
+
 Exception: Match_failure ("", 6, 23).
 |}]
 

--- a/testsuite/tests/typing-misc/disambiguate_principality.ml
+++ b/testsuite/tests/typing-misc/disambiguate_principality.ml
@@ -39,6 +39,7 @@ Line 3, characters 2-20:
       ^^^^^^^^^^^^^^^^^^
 Warning 23 [useless-record-with]: all the fields are explicitly listed in this record:
 the 'with' clause is useless.
+
 val after_a : M.r = {M.lbl = 4}
 |}]
 
@@ -53,6 +54,7 @@ Line 3, characters 7-18:
 3 |   x := { lbl = 4 }
            ^^^^^^^^^^^
 Warning 18 [not-principal]: this type-based record disambiguation is not principal.
+
 val b : unit = ()
 |}]
 
@@ -111,6 +113,7 @@ Line 4, characters 4-15:
 4 |   | { lbl = _ } -> ()
         ^^^^^^^^^^^
 Warning 11 [redundant-case]: this match case is unused.
+
 val h : M.r -> unit = <fun>
 |}, Principal{|
 Line 4, characters 4-15:
@@ -122,6 +125,7 @@ Line 4, characters 4-15:
 4 |   | { lbl = _ } -> ()
         ^^^^^^^^^^^
 Warning 11 [redundant-case]: this match case is unused.
+
 val h : M.r -> unit = <fun>
 |}]
 
@@ -147,6 +151,7 @@ Line 4, characters 4-15:
 4 |   | { lbl = _ } -> ()
         ^^^^^^^^^^^
 Warning 12 [redundant-subpat]: this sub-pattern is unused.
+
 val j : M.r -> unit = <fun>
 |}, Principal{|
 Line 4, characters 4-15:
@@ -158,6 +163,7 @@ Line 4, characters 4-15:
 4 |   | { lbl = _ } -> ()
         ^^^^^^^^^^^
 Warning 12 [redundant-subpat]: this sub-pattern is unused.
+
 val j : M.r -> unit = <fun>
 |}]
 
@@ -202,6 +208,7 @@ Line 4, characters 4-30:
 4 |   | { contents = { lbl = _ } } -> ()
         ^^^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 11 [redundant-case]: this match case is unused.
+
 val n : M.r ref -> unit = <fun>
 |}, Principal{|
 Line 4, characters 17-28:
@@ -213,6 +220,7 @@ Line 4, characters 4-30:
 4 |   | { contents = { lbl = _ } } -> ()
         ^^^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 11 [redundant-case]: this match case is unused.
+
 val n : M.r ref -> unit = <fun>
 |}]
 
@@ -238,6 +246,7 @@ Line 4, characters 4-30:
 4 |   | { contents = { lbl = _ } } -> ()
         ^^^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 12 [redundant-subpat]: this sub-pattern is unused.
+
 val p : M.r ref -> unit = <fun>
 |}, Principal{|
 Line 4, characters 17-28:
@@ -249,6 +258,7 @@ Line 4, characters 4-30:
 4 |   | { contents = { lbl = _ } } -> ()
         ^^^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 12 [redundant-subpat]: this sub-pattern is unused.
+
 val p : M.r ref -> unit = <fun>
 |}]
 
@@ -285,6 +295,7 @@ Line 4, characters 9-20:
 4 |     x := { lbl = 4 }
              ^^^^^^^^^^^
 Warning 18 [not-principal]: this type-based record disambiguation is not principal.
+
 val s : M.r ref -> unit = <fun>
 |}]
 
@@ -299,6 +310,7 @@ Line 3, characters 9-20:
 3 |     x := { lbl = 4 }
              ^^^^^^^^^^^
 Warning 18 [not-principal]: this type-based record disambiguation is not principal.
+
 val t : M.r ref -> unit = <fun>
 |}]
 
@@ -349,6 +361,7 @@ Line 3, characters 7-8:
 3 |   x := B
            ^
 Warning 18 [not-principal]: this type-based constructor disambiguation is not principal.
+
 val b : unit = ()
 |}]
 
@@ -393,6 +406,7 @@ Line 4, characters 4-5:
 4 |   | B -> ()
         ^
 Warning 18 [not-principal]: this type-based constructor disambiguation is not principal.
+
 val h : M.t -> unit = <fun>
 |}]
 
@@ -420,6 +434,7 @@ Line 4, characters 4-5:
 4 |   | B -> ()
         ^
 Warning 18 [not-principal]: this type-based constructor disambiguation is not principal.
+
 val j : M.t -> unit = <fun>
 |}]
 
@@ -464,6 +479,7 @@ Line 4, characters 4-20:
 4 |   | { contents = A } -> ()
         ^^^^^^^^^^^^^^^^
 Warning 11 [redundant-case]: this match case is unused.
+
 val n : M.t ref -> unit = <fun>
 |}, Principal{|
 Line 4, characters 17-18:
@@ -475,6 +491,7 @@ Line 4, characters 4-20:
 4 |   | { contents = A } -> ()
         ^^^^^^^^^^^^^^^^
 Warning 11 [redundant-case]: this match case is unused.
+
 val n : M.t ref -> unit = <fun>
 |}]
 
@@ -500,6 +517,7 @@ Line 4, characters 4-20:
 4 |   | { contents = A } -> ()
         ^^^^^^^^^^^^^^^^
 Warning 12 [redundant-subpat]: this sub-pattern is unused.
+
 val p : M.t ref -> unit = <fun>
 |}, Principal{|
 Line 4, characters 17-18:
@@ -511,6 +529,7 @@ Line 4, characters 4-20:
 4 |   | { contents = A } -> ()
         ^^^^^^^^^^^^^^^^
 Warning 12 [redundant-subpat]: this sub-pattern is unused.
+
 val p : M.t ref -> unit = <fun>
 |}]
 
@@ -538,6 +557,7 @@ Line 4, characters 9-10:
 4 |     x := A
              ^
 Warning 18 [not-principal]: this type-based constructor disambiguation is not principal.
+
 val s : M.t ref -> unit = <fun>
 |}]
 
@@ -553,6 +573,7 @@ Lines 1-3, characters 8-10:
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 {contents=B}
+
 val t : M.t ref -> unit = <fun>
 |}, Principal{|
 Line 3, characters 9-10:
@@ -567,5 +588,6 @@ Lines 1-3, characters 8-10:
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 {contents=B}
+
 val t : M.t ref -> unit = <fun>
 |}]

--- a/testsuite/tests/typing-misc/disambiguate_principality.ml
+++ b/testsuite/tests/typing-misc/disambiguate_principality.ml
@@ -117,6 +117,7 @@ Line 4, characters 4-15:
 4 |   | { lbl = _ } -> ()
         ^^^^^^^^^^^
 Warning 18 [not-principal]: this type-based record disambiguation is not principal.
+
 Line 4, characters 4-15:
 4 |   | { lbl = _ } -> ()
         ^^^^^^^^^^^
@@ -152,6 +153,7 @@ Line 4, characters 4-15:
 4 |   | { lbl = _ } -> ()
         ^^^^^^^^^^^
 Warning 18 [not-principal]: this type-based record disambiguation is not principal.
+
 Line 4, characters 4-15:
 4 |   | { lbl = _ } -> ()
         ^^^^^^^^^^^
@@ -206,6 +208,7 @@ Line 4, characters 17-28:
 4 |   | { contents = { lbl = _ } } -> ()
                      ^^^^^^^^^^^
 Warning 18 [not-principal]: this type-based record disambiguation is not principal.
+
 Line 4, characters 4-30:
 4 |   | { contents = { lbl = _ } } -> ()
         ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -241,6 +244,7 @@ Line 4, characters 17-28:
 4 |   | { contents = { lbl = _ } } -> ()
                      ^^^^^^^^^^^
 Warning 18 [not-principal]: this type-based record disambiguation is not principal.
+
 Line 4, characters 4-30:
 4 |   | { contents = { lbl = _ } } -> ()
         ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -466,6 +470,7 @@ Line 4, characters 17-18:
 4 |   | { contents = A } -> ()
                      ^
 Warning 18 [not-principal]: this type-based constructor disambiguation is not principal.
+
 Line 4, characters 4-20:
 4 |   | { contents = A } -> ()
         ^^^^^^^^^^^^^^^^
@@ -501,6 +506,7 @@ Line 4, characters 17-18:
 4 |   | { contents = A } -> ()
                      ^
 Warning 18 [not-principal]: this type-based constructor disambiguation is not principal.
+
 Line 4, characters 4-20:
 4 |   | { contents = A } -> ()
         ^^^^^^^^^^^^^^^^
@@ -553,6 +559,7 @@ Line 3, characters 9-10:
 3 |     x := B
              ^
 Warning 18 [not-principal]: this type-based constructor disambiguation is not principal.
+
 Lines 1-3, characters 8-10:
 1 | ........function
 2 |   | ({ contents = M.A } : M.t ref) as x ->

--- a/testsuite/tests/typing-misc/empty_variant.ml
+++ b/testsuite/tests/typing-misc/empty_variant.ml
@@ -60,6 +60,7 @@ Lines 16-17, characters 8-18:
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 C ()
+
 val f : unit -> unit = <fun>
 |}]
 
@@ -75,5 +76,6 @@ Line 3, characters 22-42:
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 C
+
 val g : nothing t -> unit = <fun>
 |}]

--- a/testsuite/tests/typing-misc/injectivity.ml
+++ b/testsuite/tests/typing-misc/injectivity.ml
@@ -316,6 +316,7 @@ Line 47, characters 4-11:
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 None
+
 val v' : int Vec.t Vec.t = <abstr>
 |}]
 
@@ -347,6 +348,7 @@ Line 17, characters 2-30:
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 Vec (Vec Int)
+
 val eq_int_any : unit -> (int, 'a) eq = <fun>
 |}]
 

--- a/testsuite/tests/typing-misc/labels.ml
+++ b/testsuite/tests/typing-misc/labels.ml
@@ -11,6 +11,7 @@ Line 2, characters 5-6:
 2 | f ?x:0;;
          ^
 Warning 43 [nonoptional-label]: the label x is not optional.
+
 - : int = 1
 |}];;
 
@@ -94,6 +95,7 @@ Line 1, characters 51-52:
 1 | let f g = ignore (g : ?x:int -> unit -> int); g ~x:3 () ;;
                                                        ^
 Warning 18 [not-principal]: using an optional argument here is not principal.
+
 val f : (?x:int -> unit -> int) -> int = <fun>
 |}];;
 
@@ -105,6 +107,7 @@ Line 1, characters 46-47:
 1 | let f g = ignore (g : ?x:int -> unit -> int); g ();;
                                                   ^
 Warning 19 [non-principal-labels]: eliminated optional argument without principality.
+
 val f : (?x:int -> unit -> int) -> int = <fun>
 |}];;
 
@@ -116,6 +119,7 @@ Line 1, characters 45-46:
 1 | let f g = ignore (g : x:int -> unit -> int); g ();;
                                                  ^
 Warning 19 [non-principal-labels]: commuted an argument without principality.
+
 val f : (x:int -> unit -> int) -> x:int -> int = <fun>
 |}];;
 

--- a/testsuite/tests/typing-misc/polyvars.ml
+++ b/testsuite/tests/typing-misc/polyvars.ml
@@ -83,6 +83,7 @@ Line 10, characters 0-29:
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 (_, 0)
+
 Line 10, characters 21-24:
 10 | function `B,1 -> 1 | _,1 -> 2;;
                           ^^^
@@ -94,6 +95,7 @@ Line 11, characters 0-29:
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 (0, _)
+
 Line 11, characters 21-24:
 11 | function 1,`B -> 1 | 1,_ -> 2;;
                           ^^^

--- a/testsuite/tests/typing-misc/polyvars.ml
+++ b/testsuite/tests/typing-misc/polyvars.ml
@@ -38,6 +38,7 @@ Line 1, characters 49-51:
 1 | let f (x : [< `A | `B]) = match x with `A | `B | `C -> 0;; (* warn *)
                                                      ^^
 Warning 12 [redundant-subpat]: this sub-pattern is unused.
+
 val f : [< `A | `B ] -> int = <fun>
 |}];;
 let f (x : [`A | `B]) = match x with `A | `B | `C -> 0;; (* fail *)
@@ -76,6 +77,7 @@ Line 9, characters 0-41:
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 (`AnyOtherTag, `AnyOtherTag)
+
 - : [> `A | `B ] * [> `A | `B ] -> int = <fun>
 Line 10, characters 0-29:
 10 | function `B,1 -> 1 | _,1 -> 2;;
@@ -88,6 +90,7 @@ Line 10, characters 21-24:
 10 | function `B,1 -> 1 | _,1 -> 2;;
                           ^^^
 Warning 11 [redundant-case]: this match case is unused.
+
 - : [< `B ] * int -> int = <fun>
 Line 11, characters 0-29:
 11 | function 1,`B -> 1 | 1,_ -> 2;;
@@ -100,6 +103,7 @@ Line 11, characters 21-24:
 11 | function 1,`B -> 1 | 1,_ -> 2;;
                           ^^^
 Warning 11 [redundant-case]: this match case is unused.
+
 - : int * [< `B ] -> int = <fun>
 |}];;
 
@@ -143,6 +147,7 @@ Line 2, characters 0-24:
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 `<some private tag>
+
 - : t -> string = <fun>
 |}]
 
@@ -154,6 +159,7 @@ Line 1, characters 8-76:
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 (`AnyOtherTag', `AnyOtherTag'')
+
 val f : [> `AnyOtherTag ] * [> `AnyOtherTag | `AnyOtherTag' ] -> int = <fun>
 |}]
 

--- a/testsuite/tests/typing-misc/pr6416.ml
+++ b/testsuite/tests/typing-misc/pr6416.ml
@@ -402,6 +402,7 @@ Line 5, characters 38-41:
 Warning 40 [name-out-of-scope]: doc was selected from type Foo.info.
 It is not visible in the current scope, and will not
 be selected if the type becomes unknown.
+
 val add_extra_info : Foo.t -> unit = <fun>
 |}]
 
@@ -424,5 +425,6 @@ Line 8, characters 38-41:
 Warning 40 [name-out-of-scope]: doc was selected from type Bar/2.info.
 It is not visible in the current scope, and will not
 be selected if the type becomes unknown.
+
 val add_extra_info : Foo.t -> unit = <fun>
 |}]

--- a/testsuite/tests/typing-misc/pr6939-flat-float-array.ml
+++ b/testsuite/tests/typing-misc/pr6939-flat-float-array.ml
@@ -9,6 +9,7 @@ Line 1, characters 12-19:
 1 | let rec x = [| x |]; 1.;;
                 ^^^^^^^
 Warning 10 [non-unit-statement]: this expression should have type unit.
+
 Line 1, characters 12-23:
 1 | let rec x = [| x |]; 1.;;
                 ^^^^^^^^^^^

--- a/testsuite/tests/typing-misc/records.ml
+++ b/testsuite/tests/typing-misc/records.ml
@@ -172,6 +172,7 @@ Line 1, characters 8-44:
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 23 [useless-record-with]: all the fields are explicitly listed in this record:
 the 'with' clause is useless.
+
 Exception: Assert_failure ("", 1, 10).
 |}]
 

--- a/testsuite/tests/typing-modules/generative.ml
+++ b/testsuite/tests/typing-modules/generative.ml
@@ -52,6 +52,7 @@ Line 3, characters 14-24:
                   ^^^^^^^^^^
 Warning 73 [generative-application-expects-unit]: A generative functor
 should be applied to '()'; using '(struct end)' is deprecated.
+
 module M2 : S
 |}];;
 module M = F(U);; (* fail *)

--- a/testsuite/tests/typing-objects/Exemples.ml
+++ b/testsuite/tests/typing-objects/Exemples.ml
@@ -291,6 +291,7 @@ Line 3, characters 2-36:
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 13 [instance-variable-override]: the following instance variables are overridden by the class printable_point :
   x
+
 class printable_color_point :
   int ->
   string ->
@@ -605,6 +606,7 @@ Line 2, characters 2-69:
 2 |   List.map (fun c -> Format.print_int c#x; Format.print_string " ") l;
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 10 [non-unit-statement]: this expression should have type unit.
+
 val pr : < x : int; .. > list -> unit = <fun>
 |}];;
 let l = [new int_comparable 5; (new int_comparable3 2 :> int_comparable);

--- a/testsuite/tests/typing-objects/Tests.ml
+++ b/testsuite/tests/typing-objects/Tests.ml
@@ -500,6 +500,7 @@ Line 7, characters 6-7:
 7 |   val u = 3
           ^
 Warning 13 [instance-variable-override]: the instance variable u is overridden.
+
 class e :
   unit ->
   object
@@ -805,6 +806,7 @@ Line 1, characters 18-26:
 1 | fun (x : 'a t) -> (x : 'a); ();;
                       ^^^^^^^^
 Warning 10 [non-unit-statement]: this expression should have type unit.
+
 - : ('a t as 'a) t -> unit = <fun>
 |}];;
 
@@ -964,6 +966,7 @@ Line 4, characters 17-23:
 4 |       method n = self#m
                      ^^^^^^
 Warning 17 [undeclared-virtual-method]: the virtual method m is not declared.
+
 class c : object method m : int method n : int end
 |}];;
 
@@ -1130,6 +1133,7 @@ Line 3, characters 10-75:
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 15 [implicit-public-methods]: the following private methods were made public implicitly:
  foo.
+
 class c : object method foo : int end
 |}];;
 

--- a/testsuite/tests/typing-objects/Tests.ml
+++ b/testsuite/tests/typing-objects/Tests.ml
@@ -484,15 +484,18 @@ Line 3, characters 2-13:
       ^^^^^^^^^^^
 Warning 13 [instance-variable-override]: the following instance variables are overridden by the class c :
   x
+
 Line 4, characters 6-7:
 4 |   val y = 3
           ^
 Warning 13 [instance-variable-override]: the instance variable y is overridden.
+
 Line 6, characters 2-13:
 6 |   inherit d 7
       ^^^^^^^^^^^
 Warning 13 [instance-variable-override]: the following instance variables are overridden by the class d :
   t z
+
 Line 7, characters 6-7:
 7 |   val u = 3
           ^

--- a/testsuite/tests/typing-objects/field_kind.ml
+++ b/testsuite/tests/typing-objects/field_kind.ml
@@ -31,6 +31,7 @@ Lines 2-5, characters 2-5:
 5 |   end..
 Warning 15 [implicit-public-methods]: the following private methods were made public implicitly:
  x.
+
 val o' : < m : 'a. 'a t -> 'b -> 'a; x : int > as 'b = <obj>
 val aargh : unit = ()
 |}]
@@ -48,6 +49,7 @@ Lines 2-5, characters 2-5:
 5 |   end..
 Warning 15 [implicit-public-methods]: the following private methods were made public implicitly:
  x.
+
 val o2 : < m : 'a -> int; x : int > as 'a = <obj>
 |}]
 
@@ -68,6 +70,7 @@ Lines 2-6, characters 2-5:
 6 |   end..
 Warning 15 [implicit-public-methods]: the following private methods were made public implicitly:
  x.
+
 val o3 : < m : 'a -> int; x : int > as 'a = <obj>
 val aargh : unit = ()
 |}]

--- a/testsuite/tests/typing-poly/poly.ml
+++ b/testsuite/tests/typing-poly/poly.ml
@@ -55,6 +55,7 @@ Lines 1-4, characters 0-24:
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 {pv=false::_}
+
 - : string = "OK"
 |}];;
 
@@ -72,6 +73,7 @@ Lines 1-4, characters 0-20:
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 {pv=0::_}
+
 - : string = "OK"
 |}];;
 
@@ -305,6 +307,7 @@ Line 8, characters 4-16:
 8 |     self#tl#fold ~f ~init:(f self#hd init)
         ^^^^^^^^^^^^
 Warning 18 [not-principal]: this use of a polymorphic method is not principal.
+
 class ['a] ostream1 :
   hd:'a ->
   tl:'b ->
@@ -1109,6 +1112,7 @@ Line 4, characters 11-60:
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 15 [implicit-public-methods]: the following private methods were made public implicitly:
  n.
+
 val f : unit -> < m : int; n : int > = <fun>
 Line 5, characters 27-39:
 5 | let f () = object (self:c) method n = 1 method m = 2 end;;
@@ -1282,18 +1286,21 @@ Line 2, characters 9-16:
 2 | fun x -> (f x)#m;; (* Warning 18 *)
              ^^^^^^^
 Warning 18 [not-principal]: this use of a polymorphic method is not principal.
+
 - : < m : 'a. 'a -> 'a > -> 'b -> 'b = <fun>
 val f : < m : 'a. 'a -> 'a > * 'b -> < m : 'a. 'a -> 'a > = <fun>
 Line 4, characters 9-20:
 4 | fun x -> (f (x,x))#m;; (* Warning 18 *)
              ^^^^^^^^^^^
 Warning 18 [not-principal]: this use of a polymorphic method is not principal.
+
 - : < m : 'a. 'a -> 'a > -> 'b -> 'b = <fun>
 val f : < m : 'a. 'a -> 'a > -> < m : 'a. 'a -> 'a > array = <fun>
 Line 6, characters 9-20:
 6 | fun x -> (f x).(0)#m;; (* Warning 18 *)
              ^^^^^^^^^^^
 Warning 18 [not-principal]: this use of a polymorphic method is not principal.
+
 - : < m : 'a. 'a -> 'a > -> 'b -> 'b = <fun>
 |}];;
 
@@ -1323,11 +1330,13 @@ Line 4, characters 42-62:
 4 | let f x = let l = [Some x; (None : u)] in (just(List.hd l))#id;;
                                               ^^^^^^^^^^^^^^^^^^^^
 Warning 18 [not-principal]: this use of a polymorphic method is not principal.
+
 val f : c -> 'a -> 'a = <fun>
 Line 7, characters 36-47:
 7 |   let x = List.hd [Some x; none] in (just x)#id;;
                                         ^^^^^^^^^^^
 Warning 18 [not-principal]: this use of a polymorphic method is not principal.
+
 val g : c -> 'a -> 'a = <fun>
 val h : < id : 'a; .. > -> 'a = <fun>
 |}];;

--- a/testsuite/tests/typing-polyvariants-bugs/pr7824.ml
+++ b/testsuite/tests/typing-polyvariants-bugs/pr7824.ml
@@ -43,6 +43,7 @@ Lines 4-5, characters 2-38:
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 []
+
 val f : [ `A ] Element.t -> [ `A | `C ] Element.t = <fun>
 |}];;
 

--- a/testsuite/tests/typing-polyvariants-bugs/pr8575.ml
+++ b/testsuite/tests/typing-polyvariants-bugs/pr8575.ml
@@ -19,6 +19,7 @@ Line 5, characters 49-50:
 5 |   | B -> if Random.bool () then `Onoes else `A_t B;;
                                                      ^
 Warning 18 [not-principal]: this type-based constructor disambiguation is not principal.
+
 val test : unit -> [> `A_t of A.t | `Onoes ] = <fun>
 |}]
 
@@ -34,5 +35,6 @@ Line 5, characters 49-50:
 5 |   | B -> if Random.bool () then `Onoes else `A_t B;;
                                                      ^
 Warning 18 [not-principal]: this type-based constructor disambiguation is not principal.
+
 val test : unit -> [> `A_t of A.t | `Onoes ] = <fun>
 |}]

--- a/testsuite/tests/typing-private/private.compilers.principal.reference
+++ b/testsuite/tests/typing-private/private.compilers.principal.reference
@@ -112,6 +112,7 @@ Line 3, characters 40-63:
 3 | module Test2 : module type of Test with type t = private Test.t = Test;;
                                             ^^^^^^^^^^^^^^^^^^^^^^^
 Alert deprecated: spurious use of private
+
 module Test2 : sig type t = Test.t = private A end
 type t = private < x : int; .. >
 type t = private < x : int; .. >

--- a/testsuite/tests/typing-private/private.compilers.reference
+++ b/testsuite/tests/typing-private/private.compilers.reference
@@ -112,6 +112,7 @@ Line 3, characters 40-63:
 3 | module Test2 : module type of Test with type t = private Test.t = Test;;
                                             ^^^^^^^^^^^^^^^^^^^^^^^
 Alert deprecated: spurious use of private
+
 module Test2 : sig type t = Test.t = private A end
 type t = private < x : int; .. >
 type t = private < x : int; .. >

--- a/testsuite/tests/typing-safe-linking/b_bad.compilers.reference
+++ b/testsuite/tests/typing-safe-linking/b_bad.compilers.reference
@@ -4,6 +4,7 @@ File "b_bad.ml", lines 13-14, characters 29-28:
 Error (warning 8 [partial-match]): this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 Y
+
 File "b_bad.ml", line 18, characters 11-14:
 18 | let () = f A.y
                 ^^^

--- a/testsuite/tests/typing-unboxed/test.ml
+++ b/testsuite/tests/typing-unboxed/test.ml
@@ -90,6 +90,7 @@ Line 6, characters 2-45:
 6 |   external d : float -> float = "d" "noalloc"
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Alert deprecated: [@@noalloc] should be used instead of "noalloc"
+
 module Old_style_warning :
   sig
     external a : float -> float = "a" "a_nat" [@@unboxed] [@@noalloc]
@@ -767,6 +768,7 @@ versions of the compiler, breaking the primitive implementation.
 You should explicitly annotate the declaration of i
 with [@@boxed] or [@@unboxed], so that its external interface
 remains stable in the future.
+
 external id : i -> i = "%identity"
 |}];;
 
@@ -799,6 +801,7 @@ versions of the compiler, breaking the primitive implementation.
 You should explicitly annotate the declaration of j
 with [@@boxed] or [@@unboxed], so that its external interface
 remains stable in the future.
+
 external id : i -> j = "%identity"
 |}];;
 

--- a/testsuite/tests/typing-unboxed/test.ml
+++ b/testsuite/tests/typing-unboxed/test.ml
@@ -74,15 +74,18 @@ Line 3, characters 2-61:
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Alert deprecated: [@@unboxed] + [@@noalloc] should be used
 instead of "float"
+
 Line 4, characters 2-53:
 4 |   external b : float -> float = "b" "noalloc" "b_nat"
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Alert deprecated: [@@noalloc] should be used instead of "noalloc"
+
 Line 5, characters 2-51:
 5 |   external c : float -> float = "c" "c_nat" "float"
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Alert deprecated: [@@unboxed] + [@@noalloc] should be used
 instead of "float"
+
 Line 6, characters 2-45:
 6 |   external d : float -> float = "d" "noalloc"
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -784,6 +787,7 @@ versions of the compiler, breaking the primitive implementation.
 You should explicitly annotate the declaration of i
 with [@@boxed] or [@@unboxed], so that its external interface
 remains stable in the future.
+
 Line 3, characters 0-34:
 3 | external id : i -> j = "%identity";;
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/testsuite/tests/typing-warnings/ambiguous_guarded_disjunction.ml
+++ b/testsuite/tests/typing-warnings/ambiguous_guarded_disjunction.ml
@@ -387,12 +387,14 @@ Line 2, characters 4-5:
         ^
 Warning 41 [ambiguous-name]: A belongs to several types: t2 t
 The first one was selected. Please disambiguate if this is wrong.
+
 Lines 1-3, characters 41-10:
 1 | .........................................function
 2 |   | A (x as z,(0 as y))|A (0 as y as z,x)|B (x,(y as z)) when g x (y+z) -> 1
 3 |   | _ -> 2
 Warning 4 [fragile-match]: this pattern-matching is fragile.
 It will remain exhaustive when constructors are added to type t2.
+
 Line 2, characters 4-56:
 2 |   | A (x as z,(0 as y))|A (0 as y as z,x)|B (x,(y as z)) when g x (y+z) -> 1
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -408,22 +410,26 @@ Line 2, characters 4-5:
         ^
 Warning 41 [ambiguous-name]: A belongs to several types: t2 t
 The first one was selected. Please disambiguate if this is wrong.
+
 Line 2, characters 24-25:
 2 |   | A (x as z,(0 as y))|A (0 as y as z,x)|B (x,(y as z)) when g x (y+z) -> 1
                             ^
 Warning 41 [ambiguous-name]: A belongs to several types: t2 t
 The first one was selected. Please disambiguate if this is wrong.
+
 Line 2, characters 42-43:
 2 |   | A (x as z,(0 as y))|A (0 as y as z,x)|B (x,(y as z)) when g x (y+z) -> 1
                                               ^
 Warning 41 [ambiguous-name]: B belongs to several types: t2 t
 The first one was selected. Please disambiguate if this is wrong.
+
 Lines 1-3, characters 41-10:
 1 | .........................................function
 2 |   | A (x as z,(0 as y))|A (0 as y as z,x)|B (x,(y as z)) when g x (y+z) -> 1
 3 |   | _ -> 2
 Warning 4 [fragile-match]: this pattern-matching is fragile.
 It will remain exhaustive when constructors are added to type t2.
+
 Line 2, characters 4-56:
 2 |   | A (x as z,(0 as y))|A (0 as y as z,x)|B (x,(y as z)) when g x (y+z) -> 1
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/testsuite/tests/typing-warnings/ambiguous_guarded_disjunction.ml
+++ b/testsuite/tests/typing-warnings/ambiguous_guarded_disjunction.ml
@@ -31,6 +31,7 @@ Warning 57 [ambiguous-var-in-pattern-guard]: Ambiguous or-pattern variables unde
 variable x appears in different places in different or-pattern alternatives.
 Only the first match will be used to evaluate the guard expression.
 (See manual section 13.5)
+
 val ambiguous_typical_example : expr * expr -> unit = <fun>
 |}]
 
@@ -100,6 +101,7 @@ Warning 57 [ambiguous-var-in-pattern-guard]: Ambiguous or-pattern variables unde
 variable y appears in different places in different or-pattern alternatives.
 Only the first match will be used to evaluate the guard expression.
 (See manual section 13.5)
+
 val ambiguous__y : [> `B of 'a * bool option * bool option ] -> unit = <fun>
 |}]
 
@@ -133,6 +135,7 @@ Warning 57 [ambiguous-var-in-pattern-guard]: Ambiguous or-pattern variables unde
 variable y appears in different places in different or-pattern alternatives.
 Only the first match will be used to evaluate the guard expression.
 (See manual section 13.5)
+
 val ambiguous__x_y : [> `B of 'a * 'a option * 'a option ] -> unit = <fun>
 |}]
 
@@ -148,6 +151,7 @@ Warning 57 [ambiguous-var-in-pattern-guard]: Ambiguous or-pattern variables unde
 variables y, z appear in different places in different or-pattern alternatives.
 Only the first match will be used to evaluate the guard expression.
 (See manual section 13.5)
+
 val ambiguous__x_y_z : [> `B of 'a * 'a option * 'a option ] -> unit = <fun>
 |}]
 
@@ -181,6 +185,7 @@ Warning 57 [ambiguous-var-in-pattern-guard]: Ambiguous or-pattern variables unde
 variable x appears in different places in different or-pattern alternatives.
 Only the first match will be used to evaluate the guard expression.
 (See manual section 13.5)
+
 val ambiguous__in_depth :
   [> `A of [> `B of bool option * bool option ] ] -> unit = <fun>
 |}]
@@ -214,6 +219,7 @@ Warning 57 [ambiguous-var-in-pattern-guard]: Ambiguous or-pattern variables unde
 variable x appears in different places in different or-pattern alternatives.
 Only the first match will be used to evaluate the guard expression.
 (See manual section 13.5)
+
 val ambiguous__first_orpat :
   [> `A of
        [> `B of 'a option * 'a option ] *
@@ -234,6 +240,7 @@ Warning 57 [ambiguous-var-in-pattern-guard]: Ambiguous or-pattern variables unde
 variable y appears in different places in different or-pattern alternatives.
 Only the first match will be used to evaluate the guard expression.
 (See manual section 13.5)
+
 val ambiguous__second_orpat :
   [> `A of
        [> `B of 'a option * 'b option * 'c option ] *
@@ -329,6 +336,7 @@ Warning 57 [ambiguous-var-in-pattern-guard]: Ambiguous or-pattern variables unde
 variables x, y appear in different places in different or-pattern alternatives.
 Only the first match will be used to evaluate the guard expression.
 (See manual section 13.5)
+
 val ambiguous__amoi : amoi -> int = <fun>
 |}]
 
@@ -351,6 +359,7 @@ Warning 57 [ambiguous-var-in-pattern-guard]: Ambiguous or-pattern variables unde
 variable M appears in different places in different or-pattern alternatives.
 Only the first match will be used to evaluate the guard expression.
 (See manual section 13.5)
+
 val ambiguous__module_variable :
   (module S) * (module S) * (int * int) -> bool -> int = <fun>
 |}]
@@ -365,6 +374,7 @@ Line 2, characters 12-13:
 2 |   | (module M:S),_,(1,_)
                 ^
 Warning 60 [unused-module]: unused module M.
+
 val not_ambiguous__module_variable :
   (module S) * (module S) * (int * int) -> bool -> int = <fun>
 |}]
@@ -402,6 +412,7 @@ Warning 57 [ambiguous-var-in-pattern-guard]: Ambiguous or-pattern variables unde
 variables x, y appear in different places in different or-pattern alternatives.
 Only the first match will be used to evaluate the guard expression.
 (See manual section 13.5)
+
 val ambiguous_xy_but_not_ambiguous_z : (int -> int -> bool) -> t2 -> int =
   <fun>
 |}, Principal{|
@@ -437,6 +448,7 @@ Warning 57 [ambiguous-var-in-pattern-guard]: Ambiguous or-pattern variables unde
 variables x, y appear in different places in different or-pattern alternatives.
 Only the first match will be used to evaluate the guard expression.
 (See manual section 13.5)
+
 val ambiguous_xy_but_not_ambiguous_z : (int -> int -> bool) -> t2 -> int =
   <fun>
 |}]
@@ -498,6 +510,7 @@ Warning 57 [ambiguous-var-in-pattern-guard]: Ambiguous or-pattern variables unde
 variable y appears in different places in different or-pattern alternatives.
 Only the first match will be used to evaluate the guard expression.
 (See manual section 13.5)
+
 val guarded_ambiguity : expr * expr -> unit = <fun>
 |}]
 
@@ -529,6 +542,7 @@ Warning 57 [ambiguous-var-in-pattern-guard]: Ambiguous or-pattern variables unde
 variable x appears in different places in different or-pattern alternatives.
 Only the first match will be used to evaluate the guard expression.
 (See manual section 13.5)
+
 val cmp : (a -> bool) -> a alg -> a alg -> unit = <fun>
 |}]
 

--- a/testsuite/tests/typing-warnings/application.ml
+++ b/testsuite/tests/typing-warnings/application.ml
@@ -21,6 +21,7 @@ Line 1, characters 8-22:
             ^^^^^^^^^^^^^^
 Warning 5 [ignored-partial-application]: this function application is partial,
 maybe some arguments are missing.
+
 - : int -> 'a = <fun>
 |}]
 
@@ -50,6 +51,7 @@ Line 1, characters 21-35:
                          ^^^^^^^^^^^^^^
 Warning 5 [ignored-partial-application]: this function application is partial,
 maybe some arguments are missing.
+
 - : int -> int = <fun>
 |}]
 
@@ -73,6 +75,7 @@ Line 1, characters 18-23:
                       ^^^^^
 Warning 5 [ignored-partial-application]: this function application is partial,
 maybe some arguments are missing.
+
 val f : t -> unit = <fun>
 |}]
 
@@ -82,6 +85,7 @@ Line 1, characters 19-20:
 1 | let _ = raise Exit 3;;
                        ^
 Warning 20 [ignored-extra-argument]: this argument will not be used by the function.
+
 Exception: Stdlib.Exit.
 |}]
 

--- a/testsuite/tests/typing-warnings/coercions.ml
+++ b/testsuite/tests/typing-warnings/coercions.ml
@@ -13,6 +13,7 @@ Line 1, characters 45-48:
 1 | fun b -> if b then format_of_string "x" else "y"
                                                  ^^^
 Warning 18 [not-principal]: this coercion to format6 is not principal.
+
 - : bool -> ('a, 'b, 'c, 'd, 'd, 'a) format6 = <fun>
 |}]
 ;;
@@ -66,5 +67,6 @@ Line 3, characters 49-59:
 3 |   let f x = let y = if true then x else (x:t) in (y :> int)
                                                      ^^^^^^^^^^
 Warning 18 [not-principal]: this ground coercion is not principal.
+
 module Test1 : sig type t = private int val f : t -> int end
 |}]

--- a/testsuite/tests/typing-warnings/disable_warnings_classes.ml
+++ b/testsuite/tests/typing-warnings/disable_warnings_classes.ml
@@ -18,6 +18,7 @@ Line 8, characters 8-9:
 8 |     let y = 5 in ()
             ^
 Warning 26 [unused-var]: unused variable y.
+
 class c : object val a : unit val x : unit end
 |}];;
 
@@ -36,6 +37,7 @@ Line 8, characters 8-9:
 8 |     let y = 5 in ()
             ^
 Warning 26 [unused-var]: unused variable y.
+
 class c : object method a : unit method x : unit end
 |}];;
 
@@ -54,6 +56,7 @@ Line 8, characters 8-9:
 8 |     let y = 5 in ()
             ^
 Warning 26 [unused-var]: unused variable y.
+
 class c : object  end
 |}];;
 
@@ -83,6 +86,7 @@ Line 4, characters 8-9:
 4 |     let b = 5 in ()
             ^
 Warning 26 [unused-var]: unused variable b.
+
 class c : object val a : unit val x : unit end
 |}];;
 
@@ -104,6 +108,7 @@ Line 9, characters 10-13:
               ^^^
 Alert deprecated: dep
 deprecated
+
 class type c = object val a : dep val x : dep end
 |}];;
 
@@ -121,6 +126,7 @@ Line 6, characters 13-16:
                  ^^^
 Alert deprecated: dep
 deprecated
+
 class type c = object method a : dep method x : dep end
 |}];;
 
@@ -148,5 +154,6 @@ Line 3, characters 10-13:
               ^^^
 Alert deprecated: dep
 deprecated
+
 class type c = object val a : dep val x : dep end
 |}];;

--- a/testsuite/tests/typing-warnings/exhaustiveness.ml
+++ b/testsuite/tests/typing-warnings/exhaustiveness.ml
@@ -14,6 +14,7 @@ Lines 1-3, characters 8-23:
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 (None, Some _)
+
 val f : 'a option * 'b option -> int = <fun>
 |}]
 
@@ -42,6 +43,7 @@ Line 1, characters 42-43:
                                               ^
 Warning 56 [unreachable-case]: this match case is unreachable.
 Consider replacing it with a refutation case '<pat> -> .'
+
 val f : int t -> int = <fun>
 |}]
 
@@ -52,6 +54,7 @@ Line 1, characters 53-54:
                                                          ^
 Warning 56 [unreachable-case]: this match case is unreachable.
 Consider replacing it with a refutation case '<pat> -> .'
+
 val f : unit t option -> int = <fun>
 |}]
 
@@ -62,6 +65,7 @@ Line 1, characters 53-59:
                                                          ^^^^^^
 Warning 56 [unreachable-case]: this match case is unreachable.
 Consider replacing it with a refutation case '<pat> -> .'
+
 val f : unit t option -> int = <fun>
 |}]
 
@@ -78,6 +82,7 @@ Line 1, characters 27-49:
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 Some A
+
 val f : int t option -> int = <fun>
 |}]
 
@@ -98,6 +103,7 @@ Line 1, characters 49-68:
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 Some ({left=Box A; right=Box A}, _)
+
 val f : (int t box pair * bool) option -> unit = <fun>
 |}]
 
@@ -114,6 +120,7 @@ Line 1, characters 8-39:
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 {left=Box 1; _ }
+
 val f : int box pair -> unit = <fun>
 |}]
 
@@ -125,6 +132,7 @@ Line 1, characters 8-47:
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 {left=Box 0; right=Box 0}
+
 val f : int box pair -> unit = <fun>
 |}]
 
@@ -182,6 +190,7 @@ Line 1, characters 33-51:
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 Eq
+
 val f : (A.a, A.b) cmp -> unit = <fun>
 |}]
 
@@ -235,6 +244,7 @@ Line 2, characters 2-24:
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 Some (PlusS _)
+
 val harder : (zero succ, zero succ, zero succ) plus option -> bool = <fun>
 |}]
 
@@ -311,6 +321,7 @@ Line 1, characters 12-42:
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 All clauses in this pattern-matching are guarded.
+
 val f : 'a -> 'a -> int = <fun>
 |}]
 
@@ -323,6 +334,7 @@ Line 1, characters 8-37:
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 (_, 1)
+
 val f : 'a ref * int -> int = <fun>
 |}]
 
@@ -342,6 +354,7 @@ Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 Some _
 (However, some guarded clause may match this value.)
+
 val f : int option -> unit = <fun>
 |}]
 
@@ -377,6 +390,7 @@ Lines 20-22, characters 45-49:
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 ((A|B), (A|B), (A|B), B)
+
 module Single_row_optim :
   sig type t = A | B val non_exhaustive : t * t * t * t -> unit end
 |}]

--- a/testsuite/tests/typing-warnings/exhaustiveness.ml
+++ b/testsuite/tests/typing-warnings/exhaustiveness.ml
@@ -36,6 +36,7 @@ Line 1, characters 20-48:
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 4 [fragile-match]: this pattern-matching is fragile.
 It will remain exhaustive when constructors are added to type t.
+
 Line 1, characters 42-43:
 1 | let f (x : int t) = match x with A -> 1 | _ -> 2;; (* warn *)
                                               ^

--- a/testsuite/tests/typing-warnings/never_returns.ml
+++ b/testsuite/tests/typing-warnings/never_returns.ml
@@ -9,6 +9,7 @@ Line 1, characters 33-43:
 1 | let () = (let module L = List in raise Exit); () ;;
                                      ^^^^^^^^^^
 Warning 21 [nonreturning-statement]: this statement never returns (or has an unsound type.)
+
 Exception: Stdlib.Exit.
 |}]
 let () = (let exception E in raise Exit); ();;
@@ -17,6 +18,7 @@ Line 1, characters 29-39:
 1 | let () = (let exception E in raise Exit); ();;
                                  ^^^^^^^^^^
 Warning 21 [nonreturning-statement]: this statement never returns (or has an unsound type.)
+
 Exception: Stdlib.Exit.
 |}]
 let () = (raise Exit : _); ();;
@@ -25,6 +27,7 @@ Line 1, characters 10-20:
 1 | let () = (raise Exit : _); ();;
               ^^^^^^^^^^
 Warning 21 [nonreturning-statement]: this statement never returns (or has an unsound type.)
+
 Exception: Stdlib.Exit.
 |}]
 let () = (let open Stdlib in raise Exit); ();;
@@ -33,5 +36,6 @@ Line 1, characters 29-39:
 1 | let () = (let open Stdlib in raise Exit); ();;
                                  ^^^^^^^^^^
 Warning 21 [nonreturning-statement]: this statement never returns (or has an unsound type.)
+
 Exception: Stdlib.Exit.
 |}]

--- a/testsuite/tests/typing-warnings/open_warnings.ml
+++ b/testsuite/tests/typing-warnings/open_warnings.ml
@@ -11,6 +11,7 @@ Line 2, characters 20-26:
 2 |   module M = struct type t end  (* unused type t *)
                         ^^^^^^
 Warning 34 [unused-type-declaration]: unused type t.
+
 Line 3, characters 2-8:
 3 |   open M  (* unused open *)
       ^^^^^^
@@ -39,10 +40,12 @@ Line 4, characters 2-8:
 4 |   open M (* used by line below; shadow constructor A *)
       ^^^^^^
 Warning 45 [open-shadow-label-constructor]: this open statement shadows the constructor A (which is later used)
+
 Line 2, characters 2-13:
 2 |   type t0 = A  (* unused type and constructor *)
       ^^^^^^^^^^^
 Warning 34 [unused-type-declaration]: unused type t0.
+
 Line 2, characters 12-13:
 2 |   type t0 = A  (* unused type and constructor *)
                 ^
@@ -61,10 +64,12 @@ Line 3, characters 20-30:
 3 |   module M = struct type t = A end (* unused type and constructor *)
                         ^^^^^^^^^^
 Warning 34 [unused-type-declaration]: unused type t.
+
 Line 3, characters 29-30:
 3 |   module M = struct type t = A end (* unused type and constructor *)
                                  ^
 Warning 37 [unused-constructor]: unused constructor A.
+
 Line 4, characters 2-8:
 4 |   open M (* unused open; no shadowing (A below refers to the one in t0) *)
       ^^^^^^
@@ -83,10 +88,12 @@ Line 4, characters 2-8:
 4 |   open M (* shadow constructor A *)
       ^^^^^^
 Warning 45 [open-shadow-label-constructor]: this open statement shadows the constructor A (which is later used)
+
 Line 2, characters 2-13:
 2 |   type t0 = A (* unused type and constructor *)
       ^^^^^^^^^^^
 Warning 34 [unused-type-declaration]: unused type t0.
+
 Line 2, characters 12-13:
 2 |   type t0 = A (* unused type and constructor *)
                 ^
@@ -104,6 +111,7 @@ Line 2, characters 20-26:
 2 |   module M = struct type t end  (* unused type t *)
                         ^^^^^^
 Warning 34 [unused-type-declaration]: unused type t.
+
 Line 3, characters 2-9:
 3 |   open! M  (* unused open *)
       ^^^^^^^
@@ -131,6 +139,7 @@ Line 2, characters 2-13:
 2 |   type t0 = A  (* unused type and constructor *)
       ^^^^^^^^^^^
 Warning 34 [unused-type-declaration]: unused type t0.
+
 Line 2, characters 12-13:
 2 |   type t0 = A  (* unused type and constructor *)
                 ^
@@ -149,10 +158,12 @@ Line 3, characters 20-30:
 3 |   module M = struct type t = A end (* unused type and constructor *)
                         ^^^^^^^^^^
 Warning 34 [unused-type-declaration]: unused type t.
+
 Line 3, characters 29-30:
 3 |   module M = struct type t = A end (* unused type and constructor *)
                                  ^
 Warning 37 [unused-constructor]: unused constructor A.
+
 Line 4, characters 2-9:
 4 |   open! M (* unused open; no shadowing (A below refers to the one in t0) *)
       ^^^^^^^
@@ -171,6 +182,7 @@ Line 2, characters 2-13:
 2 |   type t0 = A (* unused type and constructor *)
       ^^^^^^^^^^^
 Warning 34 [unused-type-declaration]: unused type t0.
+
 Line 2, characters 12-13:
 2 |   type t0 = A (* unused type and constructor *)
                 ^

--- a/testsuite/tests/typing-warnings/open_warnings.ml
+++ b/testsuite/tests/typing-warnings/open_warnings.ml
@@ -16,6 +16,7 @@ Line 3, characters 2-8:
 3 |   open M  (* unused open *)
       ^^^^^^
 Warning 33 [unused-open]: unused open M.
+
 module T1 : sig end
 |}]
 
@@ -50,6 +51,7 @@ Line 2, characters 12-13:
 2 |   type t0 = A  (* unused type and constructor *)
                 ^
 Warning 37 [unused-constructor]: unused constructor A.
+
 module T3 : sig end
 |}]
 
@@ -74,6 +76,7 @@ Line 4, characters 2-8:
 4 |   open M (* unused open; no shadowing (A below refers to the one in t0) *)
       ^^^^^^
 Warning 33 [unused-open]: unused open M.
+
 module T4 : sig end
 |}]
 
@@ -98,6 +101,7 @@ Line 2, characters 12-13:
 2 |   type t0 = A (* unused type and constructor *)
                 ^
 Warning 37 [unused-constructor]: unused constructor A.
+
 module T5 : sig end
 |}]
 
@@ -116,6 +120,7 @@ Line 3, characters 2-9:
 3 |   open! M  (* unused open *)
       ^^^^^^^
 Warning 66 [unused-open-bang]: unused open! M.
+
 module T1_bis : sig end
 |}]
 
@@ -144,6 +149,7 @@ Line 2, characters 12-13:
 2 |   type t0 = A  (* unused type and constructor *)
                 ^
 Warning 37 [unused-constructor]: unused constructor A.
+
 module T3_bis : sig end
 |}]
 
@@ -168,6 +174,7 @@ Line 4, characters 2-9:
 4 |   open! M (* unused open; no shadowing (A below refers to the one in t0) *)
       ^^^^^^^
 Warning 66 [unused-open-bang]: unused open! M.
+
 module T4_bis : sig end
 |}]
 
@@ -187,6 +194,7 @@ Line 2, characters 12-13:
 2 |   type t0 = A (* unused type and constructor *)
                 ^
 Warning 37 [unused-constructor]: unused constructor A.
+
 module T5_bis : sig end
 |}]
 

--- a/testsuite/tests/typing-warnings/pr5892.ml
+++ b/testsuite/tests/typing-warnings/pr5892.ml
@@ -20,5 +20,6 @@ Line 1, characters 31-52:
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 Right
+
 val f : CamlinternalOO.label choice -> bool = <fun>
 |}]

--- a/testsuite/tests/typing-warnings/pr6872.ml
+++ b/testsuite/tests/typing-warnings/pr6872.ml
@@ -29,6 +29,7 @@ Line 1, characters 0-1:
     ^
 Warning 41 [ambiguous-name]: A belongs to several types: a exn
 The first one was selected. Please disambiguate if this is wrong.
+
 - : a = A
 |}]
 ;;
@@ -40,6 +41,7 @@ Line 1, characters 6-7:
           ^
 Warning 42 [disambiguated-name]: this use of A relies on type-directed disambiguation,
 it will not compile with OCaml 4.00 or earlier.
+
 Exception: A.
 |}]
 ;;
@@ -57,6 +59,7 @@ Line 1, characters 26-27:
                               ^
 Warning 42 [disambiguated-name]: this use of A relies on type-directed disambiguation,
 it will not compile with OCaml 4.00 or earlier.
+
 - : exn -> int = <fun>
 |}, Principal{|
 Line 1, characters 26-27:
@@ -69,6 +72,7 @@ Line 1, characters 26-27:
                               ^
 Warning 42 [disambiguated-name]: this use of A relies on type-directed disambiguation,
 it will not compile with OCaml 4.00 or earlier.
+
 - : exn -> int = <fun>
 |}]
 ;;
@@ -86,6 +90,7 @@ Line 1, characters 17-18:
                      ^
 Warning 42 [disambiguated-name]: this use of A relies on type-directed disambiguation,
 it will not compile with OCaml 4.00 or earlier.
+
 - : int = 2
 |}]
 ;;

--- a/testsuite/tests/typing-warnings/pr6872.ml
+++ b/testsuite/tests/typing-warnings/pr6872.ml
@@ -63,6 +63,7 @@ Line 1, characters 26-27:
 1 | function Not_found -> 1 | A -> 2 | _ -> 3
                               ^
 Warning 18 [not-principal]: this type-based constructor disambiguation is not principal.
+
 Line 1, characters 26-27:
 1 | function Not_found -> 1 | A -> 2 | _ -> 3
                               ^
@@ -79,6 +80,7 @@ Line 1, characters 10-11:
               ^
 Warning 42 [disambiguated-name]: this use of A relies on type-directed disambiguation,
 it will not compile with OCaml 4.00 or earlier.
+
 Line 1, characters 17-18:
 1 | try raise A with A -> 2
                      ^

--- a/testsuite/tests/typing-warnings/pr7085.ml
+++ b/testsuite/tests/typing-warnings/pr7085.ml
@@ -34,6 +34,7 @@ Line 17, characters 5-35:
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 Some (Is Eq)
+
 module Make : functor (M : T) -> sig val f : unit -> int end
 |}]
 

--- a/testsuite/tests/typing-warnings/pr7115.ml
+++ b/testsuite/tests/typing-warnings/pr7115.ml
@@ -45,6 +45,7 @@ Line 2, characters 24-25:
 2 |   module O = struct let x = 42 (* unused *) end
                             ^
 Warning 32 [unused-value-declaration]: unused value x.
+
 Line 3, characters 2-8:
 3 |   open O (* unused open *)
       ^^^^^^

--- a/testsuite/tests/typing-warnings/pr7115.ml
+++ b/testsuite/tests/typing-warnings/pr7115.ml
@@ -17,6 +17,7 @@ Line 2, characters 10-11:
 2 |   let _f ~x (* x unused argument *) = function
               ^
 Warning 27 [unused-var-strict]: unused variable x.
+
 module X1 : sig end
 |}]
 
@@ -30,6 +31,7 @@ Line 2, characters 6-7:
 2 |   let x = 42 (* unused value *)
           ^
 Warning 32 [unused-value-declaration]: unused value x.
+
 module X2 : sig end
 |}]
 
@@ -50,5 +52,6 @@ Line 3, characters 2-8:
 3 |   open O (* unused open *)
       ^^^^^^
 Warning 33 [unused-open]: unused open O.
+
 module X3 : sig end
 |}]

--- a/testsuite/tests/typing-warnings/pr7261.compilers.reference
+++ b/testsuite/tests/typing-warnings/pr7261.compilers.reference
@@ -6,5 +6,6 @@ Line 2, characters 35-49:
 2 |     Foo: 'b * 'b -> foo constraint 'b = [> `Bla ];;
                                        ^^^^^^^^^^^^^^
 Warning 62 [constraint-on-gadt]: Type constraints do not apply to GADT cases of variant types.
+
 type foo = Foo : 'b * 'b -> foo
 

--- a/testsuite/tests/typing-warnings/pr7297.ml
+++ b/testsuite/tests/typing-warnings/pr7297.ml
@@ -15,5 +15,6 @@ Line 1, characters 9-19:
 1 | let () = raise Exit; () ;; (* warn *)
              ^^^^^^^^^^
 Warning 21 [nonreturning-statement]: this statement never returns (or has an unsound type.)
+
 Exception: Stdlib.Exit.
 |}]

--- a/testsuite/tests/typing-warnings/pr7553.ml
+++ b/testsuite/tests/typing-warnings/pr7553.ml
@@ -42,6 +42,7 @@ Line 5, characters 10-14:
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 Some _
+
 Line 4, characters 6-12:
 4 |       open A
           ^^^^^^

--- a/testsuite/tests/typing-warnings/pr7553.ml
+++ b/testsuite/tests/typing-warnings/pr7553.ml
@@ -24,6 +24,7 @@ Line 2, characters 2-8:
 2 |   open A
       ^^^^^^
 Warning 33 [unused-open]: unused open A.
+
 module rec C : sig end
 |}]
 
@@ -47,5 +48,6 @@ Line 4, characters 6-12:
 4 |       open A
           ^^^^^^
 Warning 33 [unused-open]: unused open A.
+
 module rec D : sig module M : sig module X : sig end end end
 |}]

--- a/testsuite/tests/typing-warnings/pr9244.ml
+++ b/testsuite/tests/typing-warnings/pr9244.ml
@@ -23,6 +23,7 @@ Line 5, characters 8-9:
 5 |     let x = 13
             ^
 Warning 32 [unused-value-declaration]: unused value x.
+
 module M : sig module F2 : U -> U end
 |}]
 
@@ -41,6 +42,7 @@ Line 5, characters 8-9:
 5 |     let x = 13
             ^
 Warning 32 [unused-value-declaration]: unused value x.
+
 module N : sig module F2 : U -> U end
 |}]
 
@@ -51,5 +53,6 @@ Line 1, characters 25-31:
 1 | module F (X : sig type t type s end) = struct type t = X.t end
                              ^^^^^^
 Warning 34 [unused-type-declaration]: unused type s.
+
 module F : functor (X : sig type t type s end) -> sig type t = X.t end
 |}]

--- a/testsuite/tests/typing-warnings/records.ml
+++ b/testsuite/tests/typing-warnings/records.ml
@@ -27,21 +27,25 @@ Line 3, characters 19-20:
                        ^
 Warning 42 [disambiguated-name]: this use of x relies on type-directed disambiguation,
 it will not compile with OCaml 4.00 or earlier.
+
 Line 4, characters 29-30:
 4 |   let f2 r = ignore (r:t); r.x (* non principal *)
                                  ^
 Warning 42 [disambiguated-name]: this use of x relies on type-directed disambiguation,
 it will not compile with OCaml 4.00 or earlier.
+
 Line 7, characters 18-19:
 7 |     match r with {x; y} -> y + y (* ok *)
                       ^
 Warning 42 [disambiguated-name]: this use of x relies on type-directed disambiguation,
 it will not compile with OCaml 4.00 or earlier.
+
 Line 7, characters 21-22:
 7 |     match r with {x; y} -> y + y (* ok *)
                          ^
 Warning 42 [disambiguated-name]: this use of y relies on type-directed disambiguation,
 it will not compile with OCaml 4.00 or earlier.
+
 Line 7, characters 18-19:
 7 |     match r with {x; y} -> y + y (* ok *)
                       ^
@@ -54,25 +58,30 @@ Line 3, characters 19-20:
                        ^
 Warning 42 [disambiguated-name]: this use of x relies on type-directed disambiguation,
 it will not compile with OCaml 4.00 or earlier.
+
 Line 4, characters 29-30:
 4 |   let f2 r = ignore (r:t); r.x (* non principal *)
                                  ^
 Warning 18 [not-principal]: this type-based field disambiguation is not principal.
+
 Line 4, characters 29-30:
 4 |   let f2 r = ignore (r:t); r.x (* non principal *)
                                  ^
 Warning 42 [disambiguated-name]: this use of x relies on type-directed disambiguation,
 it will not compile with OCaml 4.00 or earlier.
+
 Line 7, characters 18-19:
 7 |     match r with {x; y} -> y + y (* ok *)
                       ^
 Warning 42 [disambiguated-name]: this use of x relies on type-directed disambiguation,
 it will not compile with OCaml 4.00 or earlier.
+
 Line 7, characters 21-22:
 7 |     match r with {x; y} -> y + y (* ok *)
                          ^
 Warning 42 [disambiguated-name]: this use of y relies on type-directed disambiguation,
 it will not compile with OCaml 4.00 or earlier.
+
 Line 7, characters 18-19:
 7 |     match r with {x; y} -> y + y (* ok *)
                       ^
@@ -91,6 +100,7 @@ Line 3, characters 25-31:
                              ^^^^^^
 Warning 41 [ambiguous-name]: these field labels belong to several types: M1.u M1.t
 The first one was selected. Please disambiguate if this is wrong.
+
 Line 3, characters 35-36:
 3 |   let f r = match r with {x; y} -> y + y
                                        ^
@@ -111,11 +121,13 @@ Line 6, characters 8-9:
             ^
 Warning 42 [disambiguated-name]: this use of x relies on type-directed disambiguation,
 it will not compile with OCaml 4.00 or earlier.
+
 Line 6, characters 11-12:
 6 |        {x; y} -> y + y
                ^
 Warning 42 [disambiguated-name]: this use of y relies on type-directed disambiguation,
 it will not compile with OCaml 4.00 or earlier.
+
 Line 6, characters 8-9:
 6 |        {x; y} -> y + y
             ^
@@ -127,15 +139,18 @@ Line 6, characters 8-9:
             ^
 Warning 42 [disambiguated-name]: this use of x relies on type-directed disambiguation,
 it will not compile with OCaml 4.00 or earlier.
+
 Line 6, characters 11-12:
 6 |        {x; y} -> y + y
                ^
 Warning 42 [disambiguated-name]: this use of y relies on type-directed disambiguation,
 it will not compile with OCaml 4.00 or earlier.
+
 Line 6, characters 7-13:
 6 |        {x; y} -> y + y
            ^^^^^^
 Warning 18 [not-principal]: this type-based record disambiguation is not principal.
+
 Line 6, characters 8-9:
 6 |        {x; y} -> y + y
             ^
@@ -168,6 +183,7 @@ Line 1, characters 18-19:
 Warning 40 [name-out-of-scope]: x was selected from type M.t.
 It is not visible in the current scope, and will not
 be selected if the type becomes unknown.
+
 Line 1, characters 18-19:
 1 | let f (r:M.t) = r.x;; (* warning *)
                       ^
@@ -182,6 +198,7 @@ Line 1, characters 8-9:
             ^
 Warning 42 [disambiguated-name]: this use of x relies on type-directed disambiguation,
 it will not compile with OCaml 4.00 or earlier.
+
 Line 1, characters 7-10:
 1 | let f ({x}:M.t) = x;; (* warning *)
            ^^^
@@ -214,6 +231,7 @@ Line 4, characters 20-21:
                         ^
 Warning 42 [disambiguated-name]: this use of x relies on type-directed disambiguation,
 it will not compile with OCaml 4.00 or earlier.
+
 Line 3, characters 2-8:
 3 |   open N
       ^^^^^^
@@ -264,6 +282,7 @@ Line 3, characters 9-10:
              ^
 Warning 42 [disambiguated-name]: this use of x relies on type-directed disambiguation,
 it will not compile with OCaml 4.00 or earlier.
+
 Line 3, characters 8-13:
 3 |   let f {x;z} = x,z
             ^^^^^
@@ -282,6 +301,7 @@ Line 3, characters 11-12:
                ^
 Warning 42 [disambiguated-name]: this use of x relies on type-directed disambiguation,
 it will not compile with OCaml 4.00 or earlier.
+
 Line 3, characters 10-24:
 3 |   let r = {x=true;z='z'}
               ^^^^^^^^^^^^^^
@@ -299,6 +319,7 @@ Line 4, characters 11-12:
                ^
 Warning 42 [disambiguated-name]: this use of x relies on type-directed disambiguation,
 it will not compile with OCaml 4.00 or earlier.
+
 Line 4, characters 16-17:
 4 |   let r = {x=3; y=true}
                     ^
@@ -365,11 +386,13 @@ Line 1, characters 8-28:
             ^^^^^^^^^^^^^^^^^^^^
 Warning 41 [ambiguous-name]: x belongs to several types: MN.bar MN.foo
 The first one was selected. Please disambiguate if this is wrong.
+
 Line 1, characters 8-28:
 1 | let r = {MN.x = 3; NM.y = 4};; (* error: type would change with order *)
             ^^^^^^^^^^^^^^^^^^^^
 Warning 41 [ambiguous-name]: y belongs to several types: NM.foo NM.bar
 The first one was selected. Please disambiguate if this is wrong.
+
 Line 1, characters 19-23:
 1 | let r = {MN.x = 3; NM.y = 4};; (* error: type would change with order *)
                        ^^^^
@@ -400,6 +423,7 @@ Line 3, characters 37-38:
                                          ^
 Warning 42 [disambiguated-name]: this use of x relies on type-directed disambiguation,
 it will not compile with OCaml 4.00 or earlier.
+
 Line 3, characters 44-45:
 3 |   let f r = ignore (r: foo); {r with x = 2; z = 3}
                                                 ^
@@ -428,6 +452,7 @@ Line 3, characters 38-39:
                                           ^
 Warning 42 [disambiguated-name]: this use of x relies on type-directed disambiguation,
 it will not compile with OCaml 4.00 or earlier.
+
 Line 3, characters 45-46:
 3 |   let f r = ignore (r: foo); { r with x = 3; a = 4 }
                                                  ^
@@ -445,11 +470,13 @@ Line 3, characters 11-12:
                ^
 Warning 42 [disambiguated-name]: this use of x relies on type-directed disambiguation,
 it will not compile with OCaml 4.00 or earlier.
+
 Line 3, characters 16-17:
 3 |   let r = {x=1; y=2}
                     ^
 Warning 42 [disambiguated-name]: this use of y relies on type-directed disambiguation,
 it will not compile with OCaml 4.00 or earlier.
+
 Line 4, characters 18-19:
 4 |   let r: other = {x=1; y=2}
                       ^
@@ -517,6 +544,7 @@ Line 1, characters 13-14:
                  ^
 Warning 42 [disambiguated-name]: this use of A relies on type-directed disambiguation,
 it will not compile with OCaml 4.00 or earlier.
+
 Line 1, characters 20-21:
 1 | class g = f (A : t) A;; (* warn with -principal *)
                         ^
@@ -529,10 +557,12 @@ Line 1, characters 13-14:
                  ^
 Warning 42 [disambiguated-name]: this use of A relies on type-directed disambiguation,
 it will not compile with OCaml 4.00 or earlier.
+
 Line 1, characters 20-21:
 1 | class g = f (A : t) A;; (* warn with -principal *)
                         ^
 Warning 18 [not-principal]: this type-based constructor disambiguation is not principal.
+
 Line 1, characters 20-21:
 1 | class g = f (A : t) A;; (* warn with -principal *)
                         ^
@@ -558,6 +588,7 @@ Line 7, characters 15-16:
                    ^
 Warning 42 [disambiguated-name]: this use of x relies on type-directed disambiguation,
 it will not compile with OCaml 4.00 or earlier.
+
 Line 6, characters 2-8:
 6 |   open M  (* this open is unused, it isn't reported as shadowing 'x' *)
       ^^^^^^
@@ -582,6 +613,7 @@ Line 6, characters 2-8:
 6 |   open M  (* this open shadows label 'x' *)
       ^^^^^^
 Warning 45 [open-shadow-label-constructor]: this open statement shadows the label x (which is later used)
+
 Line 7, characters 10-18:
 7 |   let y = {x = ""}
               ^^^^^^^^
@@ -647,6 +679,7 @@ Line 7, characters 11-14:
                ^^^
 Warning 42 [disambiguated-name]: this use of loc relies on type-directed disambiguation,
 it will not compile with OCaml 4.00 or earlier.
+
 Line 7, characters 10-15:
 7 |     |`Key {loc} -> loc
               ^^^^^
@@ -691,6 +724,7 @@ Line 2, characters 27-28:
                                ^
 Warning 42 [disambiguated-name]: this use of y relies on type-directed disambiguation,
 it will not compile with OCaml 4.00 or earlier.
+
 Line 2, characters 18-36:
 2 | let f (x : M.t) = { x with y = 'a' }
                       ^^^^^^^^^^^^^^^^^^
@@ -703,6 +737,7 @@ Line 3, characters 27-28:
                                ^
 Warning 42 [disambiguated-name]: this use of y relies on type-directed disambiguation,
 it will not compile with OCaml 4.00 or earlier.
+
 Line 3, characters 18-36:
 3 | let g (x : M.t) = { x with y = 'a' } :: []
                       ^^^^^^^^^^^^^^^^^^
@@ -715,17 +750,20 @@ Line 4, characters 27-28:
                                ^
 Warning 42 [disambiguated-name]: this use of y relies on type-directed disambiguation,
 it will not compile with OCaml 4.00 or earlier.
+
 Line 4, characters 18-36:
 4 | let h (x : M.t) = { x with y = 'a' } :: { x with y = 'b' } :: [];;
                       ^^^^^^^^^^^^^^^^^^
 Warning 40 [name-out-of-scope]: this record of type M.t contains fields that are
 not visible in the current scope: y.
 They will not be selected if the type becomes unknown.
+
 Line 4, characters 49-50:
 4 | let h (x : M.t) = { x with y = 'a' } :: { x with y = 'b' } :: [];;
                                                      ^
 Warning 42 [disambiguated-name]: this use of y relies on type-directed disambiguation,
 it will not compile with OCaml 4.00 or earlier.
+
 Line 4, characters 40-58:
 4 | let h (x : M.t) = { x with y = 'a' } :: { x with y = 'b' } :: [];;
                                             ^^^^^^^^^^^^^^^^^^

--- a/testsuite/tests/typing-warnings/records.ml
+++ b/testsuite/tests/typing-warnings/records.ml
@@ -50,6 +50,7 @@ Line 7, characters 18-19:
 7 |     match r with {x; y} -> y + y (* ok *)
                       ^
 Warning 27 [unused-var-strict]: unused variable x.
+
 module OK :
   sig val f1 : M1.t -> int val f2 : M1.t -> int val f3 : M1.t -> int end
 |}, Principal{|
@@ -86,6 +87,7 @@ Line 7, characters 18-19:
 7 |     match r with {x; y} -> y + y (* ok *)
                       ^
 Warning 27 [unused-var-strict]: unused variable x.
+
 module OK :
   sig val f1 : M1.t -> int val f2 : M1.t -> int val f3 : M1.t -> int end
 |}]
@@ -132,6 +134,7 @@ Line 6, characters 8-9:
 6 |        {x; y} -> y + y
             ^
 Warning 27 [unused-var-strict]: unused variable x.
+
 module F2 : sig val f : M1.t -> int end
 |}, Principal{|
 Line 6, characters 8-9:
@@ -155,6 +158,7 @@ Line 6, characters 8-9:
 6 |        {x; y} -> y + y
             ^
 Warning 27 [unused-var-strict]: unused variable x.
+
 module F2 : sig val f : M1.t -> int end
 |}]
 
@@ -173,6 +177,7 @@ Line 1, characters 18-21:
                       ^^^
 Warning 42 [disambiguated-name]: this use of x relies on type-directed disambiguation,
 it will not compile with OCaml 4.00 or earlier.
+
 val f : M.t -> int = <fun>
 |}]
 let f (r:M.t) = r.x;; (* warning *)
@@ -189,6 +194,7 @@ Line 1, characters 18-19:
                       ^
 Warning 42 [disambiguated-name]: this use of x relies on type-directed disambiguation,
 it will not compile with OCaml 4.00 or earlier.
+
 val f : M.t -> int = <fun>
 |}]
 let f ({x}:M.t) = x;; (* warning *)
@@ -205,6 +211,7 @@ Line 1, characters 7-10:
 Warning 40 [name-out-of-scope]: this record of type M.t contains fields that are
 not visible in the current scope: x.
 They will not be selected if the type becomes unknown.
+
 val f : M.t -> int = <fun>
 |}]
 
@@ -236,6 +243,7 @@ Line 3, characters 2-8:
 3 |   open N
       ^^^^^^
 Warning 33 [unused-open]: unused open N.
+
 module OK : sig val f : M.t -> int end
 |}]
 
@@ -289,6 +297,7 @@ Line 3, characters 8-13:
 Warning 9 [missing-record-field-pattern]: the following labels are not bound in this record pattern:
 y
 Either bind these labels explicitly or add '; _' to the pattern.
+
 module OK : sig val f : M.u -> bool * char end
 |}]
 module F3 = struct
@@ -325,6 +334,7 @@ Line 4, characters 16-17:
                     ^
 Warning 42 [disambiguated-name]: this use of y relies on type-directed disambiguation,
 it will not compile with OCaml 4.00 or earlier.
+
 module OK :
   sig
     type u = { x : int; y : bool; }
@@ -534,6 +544,7 @@ Line 1, characters 12-13:
                 ^
 Warning 42 [disambiguated-name]: this use of A relies on type-directed disambiguation,
 it will not compile with OCaml 4.00 or earlier.
+
 class g : f
 class f : 'a -> 'a -> object  end
 |}]
@@ -550,6 +561,7 @@ Line 1, characters 20-21:
                         ^
 Warning 42 [disambiguated-name]: this use of A relies on type-directed disambiguation,
 it will not compile with OCaml 4.00 or earlier.
+
 class g : f
 |}, Principal{|
 Line 1, characters 13-14:
@@ -568,6 +580,7 @@ Line 1, characters 20-21:
                         ^
 Warning 42 [disambiguated-name]: this use of A relies on type-directed disambiguation,
 it will not compile with OCaml 4.00 or earlier.
+
 class g : f
 |}]
 
@@ -593,6 +606,7 @@ Line 6, characters 2-8:
 6 |   open M  (* this open is unused, it isn't reported as shadowing 'x' *)
       ^^^^^^
 Warning 33 [unused-open]: unused open M.
+
 module Shadow1 :
   sig
     type t = { x : int; }
@@ -619,6 +633,7 @@ Line 7, characters 10-18:
               ^^^^^^^^
 Warning 41 [ambiguous-name]: these field labels belong to several types: M.s t
 The first one was selected. Please disambiguate if this is wrong.
+
 module Shadow2 :
   sig
     type t = { x : int; }
@@ -641,6 +656,7 @@ Line 5, characters 37-40:
                                          ^^^
 Warning 42 [disambiguated-name]: this use of loc relies on type-directed disambiguation,
 it will not compile with OCaml 4.00 or earlier.
+
 module P6235 :
   sig
     type t = { loc : string; }
@@ -666,6 +682,7 @@ Line 7, characters 11-14:
                ^^^
 Warning 42 [disambiguated-name]: this use of loc relies on type-directed disambiguation,
 it will not compile with OCaml 4.00 or earlier.
+
 module P6235' :
   sig
     type t = { loc : string; }
@@ -684,6 +701,7 @@ Line 7, characters 10-15:
 7 |     |`Key {loc} -> loc
               ^^^^^
 Warning 18 [not-principal]: this type-based record disambiguation is not principal.
+
 module P6235' :
   sig
     type t = { loc : string; }
@@ -731,6 +749,7 @@ Line 2, characters 18-36:
 Warning 40 [name-out-of-scope]: this record of type M.t contains fields that are
 not visible in the current scope: y.
 They will not be selected if the type becomes unknown.
+
 val f : M.t -> M.t = <fun>
 Line 3, characters 27-28:
 3 | let g (x : M.t) = { x with y = 'a' } :: []
@@ -744,6 +763,7 @@ Line 3, characters 18-36:
 Warning 40 [name-out-of-scope]: this record of type M.t contains fields that are
 not visible in the current scope: y.
 They will not be selected if the type becomes unknown.
+
 val g : M.t -> M.t list = <fun>
 Line 4, characters 27-28:
 4 | let h (x : M.t) = { x with y = 'a' } :: { x with y = 'b' } :: [];;
@@ -770,5 +790,6 @@ Line 4, characters 40-58:
 Warning 40 [name-out-of-scope]: this record of type M.t contains fields that are
 not visible in the current scope: y.
 They will not be selected if the type becomes unknown.
+
 val h : M.t -> M.t list = <fun>
 |}]

--- a/testsuite/tests/typing-warnings/unused_functor_parameter.ml
+++ b/testsuite/tests/typing-warnings/unused_functor_parameter.ml
@@ -9,6 +9,7 @@ Line 1, characters 11-17:
 1 | module Foo(Unused : sig end) = struct end;;
                ^^^^^^
 Warning 60 [unused-module]: unused module Unused.
+
 module Foo : functor (Unused : sig end) -> sig end
 |}]
 
@@ -18,6 +19,7 @@ Line 1, characters 25-31:
 1 | module type S = functor (Unused : sig end) -> sig end;;
                              ^^^^^^
 Warning 67 [unused-functor-parameter]: unused functor parameter Unused.
+
 module type S = functor (Unused : sig end) -> sig end
 |}]
 
@@ -29,5 +31,6 @@ Line 2, characters 12-18:
 2 |   module M (Unused : sig end) : sig end
                 ^^^^^^
 Warning 67 [unused-functor-parameter]: unused functor parameter Unused.
+
 module type S = sig module M : functor (Unused : sig end) -> sig end end
 |}]

--- a/testsuite/tests/typing-warnings/unused_rec.ml
+++ b/testsuite/tests/typing-warnings/unused_rec.ml
@@ -10,6 +10,7 @@ Line 3, characters 8-9:
 3 | let rec f () = 3;;
             ^
 Warning 39 [unused-rec-flag]: unused rec flag.
+
 val f : unit -> int = <fun>
 |}];;
 
@@ -24,6 +25,7 @@ Line 1, characters 24-25:
 1 | let[@warning "+39"] rec h () = 3;;
                             ^
 Warning 39 [unused-rec-flag]: unused rec flag.
+
 val h : unit -> int = <fun>
 |}];;
 
@@ -45,5 +47,6 @@ Line 1, characters 24-25:
 1 | let[@warning "+39"] rec h () = 3;;
                             ^
 Warning 39 [unused-rec-flag]: unused rec flag.
+
 val h : unit -> int = <fun>
 |}];;

--- a/testsuite/tests/typing-warnings/unused_recmodule.ml
+++ b/testsuite/tests/typing-warnings/unused_recmodule.ml
@@ -27,5 +27,6 @@ Line 14, characters 4-10:
 14 |     type t
          ^^^^^^
 Warning 34 [unused-type-declaration]: unused type t.
+
 module M : sig end
 |}];;

--- a/testsuite/tests/typing-warnings/unused_types.ml
+++ b/testsuite/tests/typing-warnings/unused_types.ml
@@ -40,6 +40,7 @@ Line 3, characters 2-27:
 3 |   type unused = A of unused
       ^^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 34 [unused-type-declaration]: unused type unused.
+
 Line 3, characters 16-27:
 3 |   type unused = A of unused
                     ^^^^^^^^^^^
@@ -370,6 +371,7 @@ Line 3, characters 2-33:
 3 |   type t = A [@warning "-37"] | B
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 34 [unused-type-declaration]: unused type t.
+
 Line 3, characters 30-33:
 3 |   type t = A [@warning "-37"] | B
                                   ^^^
@@ -387,6 +389,7 @@ Line 2, characters 13-21:
 2 |   type t = { a : int; b : int }
                  ^^^^^^^^
 Warning 69 [unused-field]: unused record field a.
+
 Line 2, characters 22-29:
 2 |   type t = { a : int; b : int }
                           ^^^^^^^
@@ -495,6 +498,7 @@ Line 3, characters 2-55:
 3 |   type t = { a: int [@warning "-unused-field"]; b:int }
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 34 [unused-type-declaration]: unused type t.
+
 Line 3, characters 48-53:
 3 |   type t = { a: int [@warning "-unused-field"]; b:int }
                                                     ^^^^^

--- a/testsuite/tests/typing-warnings/unused_types.ml
+++ b/testsuite/tests/typing-warnings/unused_types.ml
@@ -13,6 +13,7 @@ Line 3, characters 2-19:
 3 |   type unused = int
       ^^^^^^^^^^^^^^^^^
 Warning 34 [unused-type-declaration]: unused type unused.
+
 module Unused : sig end
 |}]
 
@@ -27,6 +28,7 @@ Line 4, characters 2-27:
 4 |   type nonrec unused = used
       ^^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 34 [unused-type-declaration]: unused type unused.
+
 module Unused_nonrec : sig end
 |}]
 
@@ -45,6 +47,7 @@ Line 3, characters 16-27:
 3 |   type unused = A of unused
                     ^^^^^^^^^^^
 Warning 37 [unused-constructor]: unused constructor A.
+
 module Unused_rec : sig end
 |}]
 
@@ -71,6 +74,7 @@ Line 4, characters 11-12:
 4 |   type t = T
                ^
 Warning 37 [unused-constructor]: unused constructor T.
+
 module Unused_constructor : sig type t end
 |}]
 
@@ -89,6 +93,7 @@ Line 5, characters 11-12:
                ^
 Warning 37 [unused-constructor]: constructor T is never used to build values.
 (However, this constructor appears in patterns.)
+
 module Unused_constructor_outside_patterns :
   sig type t val nothing : t -> unit end
 |}]
@@ -105,6 +110,7 @@ Line 4, characters 11-12:
                ^
 Warning 37 [unused-constructor]: constructor T is never used to build values.
 Its type is exported as a private type.
+
 module Unused_constructor_exported_private : sig type t = private T end
 |}]
 
@@ -132,6 +138,7 @@ Line 4, characters 19-20:
 4 |   type t = private T
                        ^
 Warning 37 [unused-constructor]: unused constructor T.
+
 module Unused_private_constructor : sig type t end
 |}]
 
@@ -179,6 +186,7 @@ Line 3, characters 2-26:
 3 |   exception Nobody_uses_me
       ^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 38 [unused-extension]: unused exception Nobody_uses_me
+
 module Unused_exception : sig end
 |}]
 
@@ -194,6 +202,7 @@ Line 5, characters 12-26:
 5 |   type t += Nobody_uses_me
                 ^^^^^^^^^^^^^^
 Warning 38 [unused-extension]: unused extension constructor Nobody_uses_me
+
 module Unused_extension_constructor : sig type t = .. end
 |}]
 
@@ -209,6 +218,7 @@ Line 5, characters 59-75:
 5 |   type t += Dont_warn_on_me [@warning "-unused-extension"] | Nobody_uses_me
                                                                ^^^^^^^^^^^^^^^^
 Warning 38 [unused-extension]: unused extension constructor Nobody_uses_me
+
 module Unused_extension_disabled_warning : sig type t = .. end
 |}]
 
@@ -227,6 +237,7 @@ Line 4, characters 2-32:
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 38 [unused-extension]: exception Nobody_constructs_me is never used to build values.
 (However, this constructor appears in patterns.)
+
 module Unused_exception_outside_patterns : sig val falsity : exn -> bool end
 |}]
 
@@ -247,6 +258,7 @@ Line 6, characters 12-27:
                 ^^^^^^^^^^^^^^^
 Warning 38 [unused-extension]: extension constructor Noone_builds_me is never used to build values.
 (However, this constructor appears in patterns.)
+
 module Unused_extension_outside_patterns :
   sig type t = .. val falsity : t -> bool end
 |}]
@@ -263,6 +275,7 @@ Line 4, characters 2-23:
       ^^^^^^^^^^^^^^^^^^^^^
 Warning 38 [unused-extension]: exception Private_exn is never used to build values.
 It is exported or rebound as a private extension.
+
 module Unused_exception_exported_private :
   sig type exn += private Private_exn end
 |}]
@@ -281,6 +294,7 @@ Line 6, characters 12-23:
                 ^^^^^^^^^^^
 Warning 38 [unused-extension]: extension constructor Private_ext is never used to build values.
 It is exported or rebound as a private extension.
+
 module Unused_extension_exported_private :
   sig type t = .. type t += private Private_ext end
 |}]
@@ -311,6 +325,7 @@ Line 5, characters 20-31:
 5 |   type t += private Private_ext
                         ^^^^^^^^^^^
 Warning 38 [unused-extension]: unused extension constructor Private_ext
+
 module Unused_private_extension : sig type t end
 |}]
 
@@ -347,6 +362,7 @@ Line 3, characters 11-12:
 3 |   type t = A [@@warning "-34"]
                ^
 Warning 37 [unused-constructor]: unused constructor A.
+
 module Unused_type_disable_warning : sig end
 |}]
 
@@ -359,6 +375,7 @@ Line 3, characters 2-30:
 3 |   type t = A [@@warning "-37"]
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 34 [unused-type-declaration]: unused type t.
+
 module Unused_constructor_disable_warning : sig end
 |}]
 
@@ -376,6 +393,7 @@ Line 3, characters 30-33:
 3 |   type t = A [@warning "-37"] | B
                                   ^^^
 Warning 37 [unused-constructor]: unused constructor B.
+
 module Unused_constructor_disable_one_warning : sig end
 |}]
 
@@ -394,6 +412,7 @@ Line 2, characters 22-29:
 2 |   type t = { a : int; b : int }
                           ^^^^^^^
 Warning 69 [unused-field]: unused record field b.
+
 module Unused_record : sig end
 |}]
 
@@ -408,6 +427,7 @@ Line 2, characters 13-20:
                  ^^^^^^^
 Warning 69 [unused-field]: record field a is never read.
 (However, this field is used to build or mutate values.)
+
 module Unused_field : sig end
 |}]
 
@@ -424,6 +444,7 @@ Line 2, characters 22-30:
                           ^^^^^^^^
 Warning 69 [unused-field]: record field b is never read.
 (However, this field is used to build or mutate values.)
+
 module Unused_field : sig end
 |}]
 
@@ -438,6 +459,7 @@ Line 2, characters 22-37:
 2 |   type t = { a : int; mutable b : int }
                           ^^^^^^^^^^^^^^^
 Warning 69 [unused-field]: mutable record field b is never mutated.
+
 module Unused_mutable_field : sig end
 |}]
 
@@ -473,6 +495,7 @@ Line 4, characters 22-37:
 4 |   type t = { a : int; mutable b : int }
                           ^^^^^^^^^^^^^^^
 Warning 69 [unused-field]: mutable record field b is never mutated.
+
 module Unused_mutable_field_exported_private :
   sig type t = private { a : int; mutable b : int; } end
 |}]
@@ -486,6 +509,7 @@ Line 3, characters 2-56:
 3 |   type t = { a: int; b:int } [@@warning "-unused-field"]
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 34 [unused-type-declaration]: unused type t.
+
 module Unused_field_disable_warning : sig end
 |}]
 
@@ -503,5 +527,6 @@ Line 3, characters 48-53:
 3 |   type t = { a: int [@warning "-unused-field"]; b:int }
                                                     ^^^^^
 Warning 69 [unused-field]: unused record field b.
+
 module Unused_field_disable_one_warning : sig end
 |}]

--- a/testsuite/tests/typing-warnings/warning16.ml
+++ b/testsuite/tests/typing-warnings/warning16.ml
@@ -7,6 +7,7 @@ Line 1, characters 9-10:
 1 | let foo ?x = ()
              ^
 Warning 16 [unerasable-optional-argument]: this optional argument cannot be erased.
+
 val foo : ?x:'a -> unit = <fun>
 |}]
 
@@ -16,6 +17,7 @@ Line 1, characters 9-10:
 1 | let foo ?x ~y = ()
              ^
 Warning 16 [unerasable-optional-argument]: this optional argument cannot be erased.
+
 val foo : ?x:'a -> y:'b -> unit = <fun>
 |}]
 
@@ -35,6 +37,7 @@ Line 1, characters 11-12:
 1 | class bar ?x = object end
                ^
 Warning 16 [unerasable-optional-argument]: this optional argument cannot be erased.
+
 class bar : ?x:'a -> object  end
 |}]
 
@@ -44,6 +47,7 @@ Line 1, characters 11-12:
 1 | class bar ?x ~y = object end
                ^
 Warning 16 [unerasable-optional-argument]: this optional argument cannot be erased.
+
 class bar : ?x:'a -> y:'b -> object  end
 |}]
 

--- a/testsuite/tests/warnings/deprecated_module.compilers.reference
+++ b/testsuite/tests/warnings/deprecated_module.compilers.reference
@@ -2,6 +2,7 @@ File "deprecated_module.ml", line 16, characters 8-11:
 16 | let _ = M.x
              ^^^
 Alert deprecated: module M
+
 File "deprecated_module.ml", line 17, characters 8-9:
 17 | include M
              ^

--- a/testsuite/tests/warnings/deprecated_module_assigment.compilers.reference
+++ b/testsuite/tests/warnings/deprecated_module_assigment.compilers.reference
@@ -11,6 +11,7 @@ File "deprecated_module_assigment.ml", line 17, characters 15-26:
 17 | module Y : sig val x : int end = X
                     ^^^^^^^^^^^
   Expected signature
+
 File "deprecated_module_assigment.ml", line 23, characters 13-14:
 23 | module B = F(X)
                   ^
@@ -24,6 +25,7 @@ File "deprecated_module_assigment.ml", line 21, characters 17-28:
 21 | module F(A : sig val x : int end) = struct let _ = A.x end
                       ^^^^^^^^^^^
   Expected signature
+
 File "deprecated_module_assigment.ml", line 33, characters 39-78:
 33 | module CSTR : sig type t = A | B end = struct type t = A [@deprecated] | B end
                                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -36,6 +38,7 @@ File "deprecated_module_assigment.ml", line 33, characters 27-28:
 33 | module CSTR : sig type t = A | B end = struct type t = A [@deprecated] | B end
                                 ^
   Expected signature
+
 File "deprecated_module_assigment.ml", line 37, characters 2-20:
 37 |   type s = t = A | B
        ^^^^^^^^^^^^^^^^^^
@@ -48,6 +51,7 @@ File "deprecated_module_assigment.ml", line 37, characters 15-16:
 37 |   type s = t = A | B
                     ^
   Expected signature
+
 File "deprecated_module_assigment.ml", line 45, characters 0-58:
 45 | struct type t = {mutable x: int [@deprecated_mutable]} end
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -60,6 +64,7 @@ File "deprecated_module_assigment.ml", line 44, characters 14-28:
 44 | sig type t = {mutable x: int} end =
                    ^^^^^^^^^^^^^^
   Expected signature
+
 File "deprecated_module_assigment.ml", line 49, characters 2-31:
 49 |   type s = t = {mutable x: int}
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -72,6 +77,7 @@ File "deprecated_module_assigment.ml", line 49, characters 16-30:
 49 |   type s = t = {mutable x: int}
                      ^^^^^^^^^^^^^^
   Expected signature
+
 File "deprecated_module_assigment.ml", line 54, characters 37-75:
 54 | module TYPE : sig type t = int end = struct type t = int [@@deprecated] end
                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -84,6 +90,7 @@ File "deprecated_module_assigment.ml", line 54, characters 18-30:
 54 | module TYPE : sig type t = int end = struct type t = int [@@deprecated] end
                        ^^^^^^^^^^^^
   Expected signature
+
 File "deprecated_module_assigment.ml", line 60, characters 0-52:
 60 | struct class c = object end [@@deprecated "FOO"] end
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -97,6 +104,7 @@ File "deprecated_module_assigment.ml", line 59, characters 4-24:
 59 | sig class c : object end end =
          ^^^^^^^^^^^^^^^^^^^^
   Expected signature
+
 File "deprecated_module_assigment.ml", line 64, characters 0-57:
 64 | struct class type c = object end [@@deprecated "FOO"] end
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -110,6 +118,7 @@ File "deprecated_module_assigment.ml", line 63, characters 4-29:
 63 | sig class type c = object end end =
          ^^^^^^^^^^^^^^^^^^^^^^^^^
   Expected signature
+
 File "deprecated_module_assigment.ml", line 71, characters 0-55:
 71 | struct module type S = sig end [@@deprecated "FOO"] end
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -123,6 +132,7 @@ File "deprecated_module_assigment.ml", line 70, characters 4-27:
 70 | sig module type S = sig end end =
          ^^^^^^^^^^^^^^^^^^^^^^^
   Expected signature
+
 File "deprecated_module_assigment.ml", line 82, characters 0-53:
 82 | struct module M = struct end [@@deprecated "FOO"] end
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/testsuite/tests/warnings/deprecated_module_use.compilers.reference
+++ b/testsuite/tests/warnings/deprecated_module_use.compilers.reference
@@ -6,18 +6,22 @@ Alert deprecated: module Deprecated_module
   As you could guess, Deprecated_module is deprecated.
   Please use something else!
 
+
 File "deprecated_module_use.ml", line 20, characters 9-12:
 20 | type s = M.t
               ^^^
 Alert deprecated: module Deprecated_module.M
+
 File "deprecated_module_use.ml", line 20, characters 9-12:
 20 | type s = M.t
               ^^^
 Alert deprecated: Deprecated_module.M.t
+
 File "deprecated_module_use.ml", line 22, characters 5-6:
 22 | open M
           ^
 Alert deprecated: module Deprecated_module.M
+
 File "deprecated_module_use.ml", line 23, characters 8-9:
 23 | let _ = x
              ^

--- a/testsuite/tests/warnings/w01.compilers.reference
+++ b/testsuite/tests/warnings/w01.compilers.reference
@@ -2,25 +2,30 @@ File "w01.ml", line 14, characters 12-14:
 14 | let foo = ( *);;
                  ^^
 Warning 2 [comment-not-end]: this is not the end of a comment.
+
 File "w01.ml", line 20, characters 0-3:
 20 | f 1; f 1;;
      ^^^
 Warning 5 [ignored-partial-application]: this function application is partial,
 maybe some arguments are missing.
+
 File "w01.ml", line 30, characters 4-5:
 30 | let 1 = 1;;
          ^
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 0
+
 File "w01.ml", line 35, characters 0-1:
 35 | 1; 1;;
      ^
 Warning 10 [non-unit-statement]: this expression should have type unit.
+
 File "w01.ml", line 42, characters 2-3:
 42 | | 1 -> ()
        ^
 Warning 11 [redundant-case]: this match case is unused.
+
 File "w01.ml", line 19, characters 8-9:
 19 | let f x y = x;;
              ^

--- a/testsuite/tests/warnings/w03.compilers.reference
+++ b/testsuite/tests/warnings/w03.compilers.reference
@@ -2,6 +2,7 @@ File "w03.ml", line 14, characters 8-9:
 14 | let _ = A
              ^
 Alert deprecated: A
+
 File "w03.ml", line 17, characters 12-26:
 17 | exception B [@@deprecated]
                  ^^^^^^^^^^^^^^

--- a/testsuite/tests/warnings/w04_failure.compilers.reference
+++ b/testsuite/tests/warnings/w04_failure.compilers.reference
@@ -5,6 +5,7 @@ File "w04_failure.ml", lines 20-23, characters 2-17:
 23 |   | _, _, _ -> ()
 Warning 4 [fragile-match]: this pattern-matching is fragile.
 It will remain exhaustive when constructors are added to type repr.
+
 File "w04_failure.ml", lines 20-23, characters 2-17:
 20 | ..match r1, r2, t with
 21 |   | AB, _, A -> ()
@@ -12,6 +13,7 @@ File "w04_failure.ml", lines 20-23, characters 2-17:
 23 |   | _, _, _ -> ()
 Warning 4 [fragile-match]: this pattern-matching is fragile.
 It will remain exhaustive when constructors are added to type ab.
+
 File "w04_failure.ml", lines 20-23, characters 2-17:
 20 | ..match r1, r2, t with
 21 |   | AB, _, A -> ()

--- a/testsuite/tests/warnings/w06.compilers.reference
+++ b/testsuite/tests/warnings/w06.compilers.reference
@@ -2,6 +2,7 @@ File "w06.ml", line 16, characters 9-12:
 16 | let () = foo 2
               ^^^
 Warning 6 [labels-omitted]: label bar was omitted in the application of this function.
+
 File "w06.ml", line 17, characters 9-12:
 17 | let () = bar 4 2
               ^^^

--- a/testsuite/tests/warnings/w32.compilers.reference
+++ b/testsuite/tests/warnings/w32.compilers.reference
@@ -2,10 +2,12 @@ File "w32.mli", line 12, characters 10-11:
 12 | module F (X : sig val x : int end) : sig end
                ^
 Warning 67 [unused-functor-parameter]: unused functor parameter X.
+
 File "w32.mli", line 14, characters 10-11:
 14 | module G (X : sig val x : int end) : sig end
                ^
 Warning 67 [unused-functor-parameter]: unused functor parameter X.
+
 File "w32.mli", line 16, characters 10-11:
 16 | module H (X : sig val x : int end) : sig val x : int end
                ^
@@ -14,50 +16,62 @@ File "w32.ml", line 40, characters 24-25:
 40 | let[@warning "-32"] rec q x = x
                              ^
 Warning 39 [unused-rec-flag]: unused rec flag.
+
 File "w32.ml", line 43, characters 24-25:
 43 | let[@warning "-32"] rec s x = x
                              ^
 Warning 39 [unused-rec-flag]: unused rec flag.
+
 File "w32.ml", line 20, characters 4-5:
 20 | let h x = x
          ^
 Warning 32 [unused-value-declaration]: unused value h.
+
 File "w32.ml", line 26, characters 4-5:
 26 | and j x = x
          ^
 Warning 32 [unused-value-declaration]: unused value j.
+
 File "w32.ml", line 28, characters 4-5:
 28 | let k x = x
          ^
 Warning 32 [unused-value-declaration]: unused value k.
+
 File "w32.ml", line 41, characters 4-5:
 41 | and r x = x
          ^
 Warning 32 [unused-value-declaration]: unused value r.
+
 File "w32.ml", line 44, characters 20-21:
 44 | and[@warning "-39"] t x = x
                          ^
 Warning 32 [unused-value-declaration]: unused value t.
+
 File "w32.ml", line 46, characters 24-25:
 46 | let[@warning "-39"] rec u x = x
                              ^
 Warning 32 [unused-value-declaration]: unused value u.
+
 File "w32.ml", line 47, characters 4-5:
 47 | and v x = v x
          ^
 Warning 32 [unused-value-declaration]: unused value v.
+
 File "w32.ml", line 55, characters 22-23:
 55 |   let[@warning "+32"] g x = x
                            ^
 Warning 32 [unused-value-declaration]: unused value g.
+
 File "w32.ml", line 56, characters 22-23:
 56 |   let[@warning "+32"] h x = x
                            ^
 Warning 32 [unused-value-declaration]: unused value h.
+
 File "w32.ml", line 59, characters 22-23:
 59 |   and[@warning "+32"] k x = x
                            ^
 Warning 32 [unused-value-declaration]: unused value k.
+
 File "w32.ml", lines 52-60, characters 0-3:
 52 | module M = struct
 53 |   [@@@warning "-32"]
@@ -69,14 +83,17 @@ File "w32.ml", lines 52-60, characters 0-3:
 59 |   and[@warning "+32"] k x = x
 60 | end
 Warning 60 [unused-module]: unused module M.
+
 File "w32.ml", line 63, characters 18-29:
 63 | module F (X : sig val x : int end) = struct end
                        ^^^^^^^^^^^
 Warning 32 [unused-value-declaration]: unused value x.
+
 File "w32.ml", line 63, characters 10-11:
 63 | module F (X : sig val x : int end) = struct end
                ^
 Warning 60 [unused-module]: unused module X.
+
 File "w32.ml", line 65, characters 18-29:
 65 | module G (X : sig val x : int end) = X
                        ^^^^^^^^^^^

--- a/testsuite/tests/warnings/w32b.compilers.reference
+++ b/testsuite/tests/warnings/w32b.compilers.reference
@@ -2,6 +2,7 @@ File "w32b.ml", line 13, characters 18-24:
 13 | module Q (M : sig type t end) = struct end
                        ^^^^^^
 Warning 34 [unused-type-declaration]: unused type t.
+
 File "w32b.ml", line 13, characters 10-11:
 13 | module Q (M : sig type t end) = struct end
                ^

--- a/testsuite/tests/warnings/w33.compilers.reference
+++ b/testsuite/tests/warnings/w33.compilers.reference
@@ -2,10 +2,12 @@ File "w33.ml", line 19, characters 6-11:
 19 | let f M.(x) = x (* useless open *)
            ^^^^^
 Warning 33 [unused-open]: unused open M.
+
 File "w33.ml", line 26, characters 0-7:
 26 | open! M (* useless open! *)
      ^^^^^^^
 Warning 66 [unused-open-bang]: unused open! M.
+
 File "w33.ml", line 27, characters 0-6:
 27 | open M (* useless open *)
      ^^^^^^

--- a/testsuite/tests/warnings/w45.compilers.reference
+++ b/testsuite/tests/warnings/w45.compilers.reference
@@ -2,11 +2,13 @@ File "w45.ml", line 24, characters 2-9:
 24 |   open T2 (* shadow X, which is later used; but not A, see #6762 *)
        ^^^^^^^
 Warning 45 [open-shadow-label-constructor]: this open statement shadows the constructor X (which is later used)
+
 File "w45.ml", line 26, characters 14-15:
 26 |   let _ = (A, X) (* X belongs to several types *)
                    ^
 Warning 41 [ambiguous-name]: X belongs to several types: T2.s T1.s
 The first one was selected. Please disambiguate if this is wrong.
+
 File "w45.ml", line 23, characters 2-9:
 23 |   open T1 (* unused open *)
        ^^^^^^^

--- a/testsuite/tests/warnings/w47_inline.compilers.reference
+++ b/testsuite/tests/warnings/w47_inline.compilers.reference
@@ -2,40 +2,48 @@ File "w47_inline.ml", line 30, characters 20-22:
 30 |   let[@local never] f2 x = x (* ok *) in
                          ^^
 Warning 26 [unused-var]: unused variable f2.
+
 File "w47_inline.ml", line 31, characters 24-26:
 31 |   let[@local malformed] f3 x = x (* bad payload *) in
                              ^^
 Warning 26 [unused-var]: unused variable f3.
+
 File "w47_inline.ml", line 15, characters 23-29:
 15 | let d = (fun x -> x) [@inline malformed attribute] (* rejected *)
                             ^^^^^^
 Warning 47 [attribute-payload]: illegal payload for attribute 'inline'.
 It must be either 'never', 'always', 'hint' or empty
+
 File "w47_inline.ml", line 16, characters 23-29:
 16 | let e = (fun x -> x) [@inline malformed_attribute] (* rejected *)
                             ^^^^^^
 Warning 47 [attribute-payload]: illegal payload for attribute 'inline'.
 It must be either 'never', 'always', 'hint' or empty
+
 File "w47_inline.ml", line 17, characters 23-29:
 17 | let f = (fun x -> x) [@inline : malformed_attribute] (* rejected *)
                             ^^^^^^
 Warning 47 [attribute-payload]: illegal payload for attribute 'inline'.
 It must be either 'never', 'always', 'hint' or empty
+
 File "w47_inline.ml", line 18, characters 23-29:
 18 | let g = (fun x -> x) [@inline ? malformed_attribute] (* rejected *)
                             ^^^^^^
 Warning 47 [attribute-payload]: illegal payload for attribute 'inline'.
 It must be either 'never', 'always', 'hint' or empty
+
 File "w47_inline.ml", line 23, characters 15-22:
 23 | let k x = (a [@inlined malformed]) x (* rejected *)
                     ^^^^^^^
 Warning 47 [attribute-payload]: illegal payload for attribute 'inlined'.
 It must be either 'never', 'always', 'hint' or empty
+
 File "w47_inline.ml", line 31, characters 7-12:
 31 |   let[@local malformed] f3 x = x (* bad payload *) in
             ^^^^^
 Warning 47 [attribute-payload]: illegal payload for attribute 'local'.
 It must be either 'never', 'always', 'maybe' or empty
+
 File "w47_inline.ml", line 32, characters 17-26:
 32 |   let[@local] f4 x = 2 * x (* not local *) in
                       ^^^^^^^^^

--- a/testsuite/tests/warnings/w50.compilers.reference
+++ b/testsuite/tests/warnings/w50.compilers.reference
@@ -2,6 +2,7 @@ File "w50.ml", line 13, characters 2-17:
 13 |   module L = List
        ^^^^^^^^^^^^^^^
 Warning 60 [unused-module]: unused module L.
+
 File "w50.ml", line 17, characters 2-16:
 17 |   module Y1 = X1
        ^^^^^^^^^^^^^^

--- a/testsuite/tests/warnings/w51.ml
+++ b/testsuite/tests/warnings/w51.ml
@@ -12,6 +12,7 @@ Line 3, characters 13-37:
 3 |   | n -> n * (fact [@tailcall]) (n-1)
                  ^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 51 [wrong-tailcall-expectation]: expected tailcall
+
 val fact : int -> int = <fun>
 |}]
 
@@ -24,6 +25,7 @@ Line 3, characters 13-42:
 3 |   | n -> n * (fact [@tailcall true]) (n-1)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 51 [wrong-tailcall-expectation]: expected tailcall
+
 val fact : int -> int = <fun>
 |}]
 
@@ -60,6 +62,7 @@ Line 3, characters 9-56:
 3 |   | n -> (fact_tail [@tailcall false]) (n * acc) (n - 1)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 51 [wrong-tailcall-expectation]: expected non-tailcall
+
 val fact_tail : int -> int -> int = <fun>
 |}]
 
@@ -72,5 +75,6 @@ Line 1, characters 24-32:
                             ^^^^^^^^
 Warning 47 [attribute-payload]: illegal payload for attribute 'tailcall'.
 Only an optional boolean literal is supported.
+
 val test : 'a -> 'b = <fun>
 |}]

--- a/testsuite/tests/warnings/w52.ml
+++ b/testsuite/tests/warnings/w52.ml
@@ -56,6 +56,7 @@ Line 2, characters 7-17:
 Warning 52 [fragile-literal-pattern]: Code should not depend on the actual values of
 this constructor's arguments. They are only for information
 and may change in future versions. (See manual section 13.5)
+
 val f : t -> unit = <fun>
 |}];;
 
@@ -69,6 +70,7 @@ Line 2, characters 8-10:
 Warning 52 [fragile-literal-pattern]: Code should not depend on the actual values of
 this constructor's arguments. They are only for information
 and may change in future versions. (See manual section 13.5)
+
 val g : t -> unit = <fun>
 |}];;
 
@@ -96,5 +98,6 @@ Line 2, characters 7-34:
 Warning 52 [fragile-literal-pattern]: Code should not depend on the actual values of
 this constructor's arguments. They are only for information
 and may change in future versions. (See manual section 13.5)
+
 val j : t -> unit = <fun>
 |}];;

--- a/testsuite/tests/warnings/w53.compilers.reference
+++ b/testsuite/tests/warnings/w53.compilers.reference
@@ -2,66 +2,82 @@ File "w53.ml", line 12, characters 4-5:
 12 | let h x = x [@inline] (* rejected *)
          ^
 Warning 32 [unused-value-declaration]: unused value h.
+
 File "w53.ml", line 12, characters 14-20:
 12 | let h x = x [@inline] (* rejected *)
                    ^^^^^^
 Warning 53 [misplaced-attribute]: the "inline" attribute cannot appear in this context
+
 File "w53.ml", line 13, characters 14-26:
 13 | let h x = x [@ocaml.inline] (* rejected *)
                    ^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "ocaml.inline" attribute cannot appear in this context
+
 File "w53.ml", line 15, characters 14-21:
 15 | let i x = x [@inlined] (* rejected *)
                    ^^^^^^^
 Warning 53 [misplaced-attribute]: the "inlined" attribute cannot appear in this context
+
 File "w53.ml", line 16, characters 14-27:
 16 | let j x = x [@ocaml.inlined] (* rejected *)
                    ^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "ocaml.inlined" attribute cannot appear in this context
+
 File "w53.ml", line 19, characters 16-23:
 19 | let l x = h x [@inlined] (* rejected *)
                      ^^^^^^^
 Warning 53 [misplaced-attribute]: the "inlined" attribute cannot appear in this context
+
 File "w53.ml", line 21, characters 14-22:
 21 | let m x = x [@tailcall] (* rejected *)
                    ^^^^^^^^
 Warning 53 [misplaced-attribute]: the "tailcall" attribute cannot appear in this context
+
 File "w53.ml", line 22, characters 14-28:
 22 | let n x = x [@ocaml.tailcall] (* rejected *)
                    ^^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "ocaml.tailcall" attribute cannot appear in this context
+
 File "w53.ml", line 25, characters 16-24:
 25 | let q x = h x [@tailcall] (* rejected *)
                      ^^^^^^^^
 Warning 53 [misplaced-attribute]: the "tailcall" attribute cannot appear in this context
+
 File "w53.ml", line 33, characters 0-32:
 33 | module C = struct end [@@inline] (* rejected *)
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "inline" attribute cannot appear in this context
+
 File "w53.ml", line 34, characters 0-39:
 34 | module C' = struct end [@@ocaml.inline] (* rejected *)
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "inline" attribute cannot appear in this context
+
 File "w53.ml", line 40, characters 16-22:
 40 | module G = (A [@inline])(struct end) (* rejected *)
                      ^^^^^^
 Warning 53 [misplaced-attribute]: the "inline" attribute cannot appear in this context
+
 File "w53.ml", line 41, characters 17-29:
 41 | module G' = (A [@ocaml.inline])(struct end) (* rejected *)
                       ^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "ocaml.inline" attribute cannot appear in this context
+
 File "w53.ml", line 45, characters 22-29:
 45 | module I = Set.Make [@inlined]
                            ^^^^^^^
 Warning 53 [misplaced-attribute]: the "inlined" attribute cannot appear in this context
+
 File "w53.ml", line 46, characters 23-36:
 46 | module I' = Set.Make [@ocaml.inlined]
                             ^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "ocaml.inlined" attribute cannot appear in this context
+
 File "w53.ml", line 48, characters 23-30:
 48 | module J = Set.Make [@@inlined]
                             ^^^^^^^
 Warning 53 [misplaced-attribute]: the "inlined" attribute cannot appear in this context
+
 File "w53.ml", line 49, characters 24-37:
 49 | module J' = Set.Make [@@ocaml.inlined]
                              ^^^^^^^^^^^^^

--- a/testsuite/tests/warnings/w54.compilers.reference
+++ b/testsuite/tests/warnings/w54.compilers.reference
@@ -2,14 +2,17 @@ File "w54.ml", line 12, characters 33-39:
 12 | let f = (fun x -> x) [@inline] [@inline never]
                                       ^^^^^^
 Warning 54 [duplicated-attribute]: the "inline" attribute is used more than once on this expression
+
 File "w54.ml", line 13, characters 51-63:
 13 | let g = (fun x -> x) [@inline] [@something_else] [@ocaml.inline]
                                                         ^^^^^^^^^^^^
 Warning 54 [duplicated-attribute]: the "ocaml.inline" attribute is used more than once on this expression
+
 File "w54.ml", line 15, characters 26-39:
 15 | let h x = (g [@inlined] [@ocaml.inlined never]) x
                                ^^^^^^^^^^^^^
 Warning 54 [duplicated-attribute]: the "ocaml.inlined" attribute is used more than once on this expression
+
 File "w54.ml", line 19, characters 0-43:
 19 | let i = ((fun x -> x) [@inline]) [@@inline]
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/testsuite/tests/warnings/w55.flambda.reference
+++ b/testsuite/tests/warnings/w55.flambda.reference
@@ -2,10 +2,12 @@ File "w55.ml", line 33, characters 10-26:
 33 | let h x = (j [@inlined]) x
                ^^^^^^^^^^^^^^^^
 Warning 55 [inlining-impossible]: Cannot inline: [@inlined] attributes may not be used on partial applications
+
 File "w55.ml", line 29, characters 10-27:
 29 | let i x = (!r [@inlined]) x
                ^^^^^^^^^^^^^^^^^
 Warning 55 [inlining-impossible]: Cannot inline: [@inlined] attribute was not used on this function application (the optimizer did not know what function was being applied)
+
 File "w55.ml", line 39, characters 12-30:
 39 | let b x y = (a [@inlined]) x y
                  ^^^^^^^^^^^^^^^^^^

--- a/testsuite/tests/warnings/w55.native.reference
+++ b/testsuite/tests/warnings/w55.native.reference
@@ -2,22 +2,27 @@ File "w55.ml", line 25, characters 10-26:
 25 | let g x = (f [@inlined]) x
                ^^^^^^^^^^^^^^^^
 Warning 55 [inlining-impossible]: Cannot inline: Function information unavailable
+
 File "w55.ml", line 29, characters 10-27:
 29 | let i x = (!r [@inlined]) x
                ^^^^^^^^^^^^^^^^^
 Warning 55 [inlining-impossible]: Cannot inline: Unknown function
+
 File "w55.ml", line 33, characters 10-26:
 33 | let h x = (j [@inlined]) x
                ^^^^^^^^^^^^^^^^
 Warning 55 [inlining-impossible]: Cannot inline: Partial application
+
 File "w55.ml", line 39, characters 12-30:
 39 | let b x y = (a [@inlined]) x y
                  ^^^^^^^^^^^^^^^^^^
 Warning 55 [inlining-impossible]: Cannot inline: Over-application
+
 File "w55.ml", line 39, characters 12-30:
 39 | let b x y = (a [@inlined]) x y
                  ^^^^^^^^^^^^^^^^^^
 Warning 55 [inlining-impossible]: Cannot inline: Function information unavailable
+
 File "w55.ml", line 42, characters 10-26:
 42 | let d x = (c [@inlined]) x
                ^^^^^^^^^^^^^^^^

--- a/testsuite/tests/warnings/w59.flambda.reference
+++ b/testsuite/tests/warnings/w59.flambda.reference
@@ -4,24 +4,28 @@ File "w59.ml", line 47, characters 2-43:
 Warning 59 [flambda-assignment-to-non-mutable-value]: A potential assignment to a non-mutable value was detected 
 in this source file.  Such assignments may generate incorrect code 
 when using Flambda.
+
 File "w59.ml", line 48, characters 2-43:
 48 |   Obj.set_field (Obj.repr p) 0 (Obj.repr 3);
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 59 [flambda-assignment-to-non-mutable-value]: A potential assignment to a non-mutable value was detected 
 in this source file.  Such assignments may generate incorrect code 
 when using Flambda.
+
 File "w59.ml", line 49, characters 2-43:
 49 |   Obj.set_field (Obj.repr q) 0 (Obj.repr 3);
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 59 [flambda-assignment-to-non-mutable-value]: A potential assignment to a non-mutable value was detected 
 in this source file.  Such assignments may generate incorrect code 
 when using Flambda.
+
 File "w59.ml", line 50, characters 2-43:
 50 |   Obj.set_field (Obj.repr r) 0 (Obj.repr 3)
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 59 [flambda-assignment-to-non-mutable-value]: A potential assignment to a non-mutable value was detected 
 in this source file.  Such assignments may generate incorrect code 
 when using Flambda.
+
 File "w59.ml", line 57, characters 2-7:
 57 |   set o
        ^^^^^

--- a/testsuite/tests/warnings/w68.compilers.reference
+++ b/testsuite/tests/warnings/w68.compilers.reference
@@ -4,6 +4,7 @@ File "w68.ml", line 34, characters 33-43:
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 Some _
+
 File "w68.ml", line 14, characters 10-13:
 14 | let alloc {a} b = a + b
                ^^^

--- a/testsuite/tools/expect_test.ml
+++ b/testsuite/tools/expect_test.ml
@@ -163,6 +163,7 @@ let capture_everything buf ppf ~f =
                      ~f:(fun () -> Compiler_messages.capture ppf ~f)
 
 let exec_phrase ppf phrase =
+  Location.reset ();
   if !Clflags.dump_parsetree then Printast. top_phrase ppf phrase;
   if !Clflags.dump_source    then Pprintast.top_phrase ppf phrase;
   Toploop.execute_phrase true ppf phrase

--- a/tools/ocamltex.ml
+++ b/tools/ocamltex.ml
@@ -352,7 +352,8 @@ module Output = struct
   let catch_warning =
     function
     | [] -> None
-    | s :: _ when string_match ~!{|Warning \([0-9]+\)\( \[[a-z-]+\]\)?:|} s 0 ->
+    | s :: _ when string_match ~!{|
+*Warning \([0-9]+\)\( \[[a-z-]+\]\)?:|} s 0 ->
         Some (Warning (int_of_string @@ matched_group 1 s))
     | _ -> None
 
@@ -679,6 +680,7 @@ let process_file file =
         let implicit_stop, phrase, expected = read_phrase () in
         let ast = Toplevel.parse file mode phrase in
         let ellipses = Ellipsis.find ast in
+        let () = Location.reset () in
         let () = Toplevel.(exec out_fmt) ast in
         let out = Toplevel.read_output () in
         let error_msgs = String.concat "" (out.warnings @ [out.error]) in

--- a/toplevel/byte/topeval.ml
+++ b/toplevel/byte/topeval.ml
@@ -157,12 +157,18 @@ let execute_phrase print_outcome ppf phr =
               in
               Ophr_exception (exn, outv)
         in
-        !print_out_phrase ppf out_phr;
+        begin match out_phr with
+        | Ophr_signature [] -> ()
+        | _ ->
+            Location.separate_new_message ppf;
+            !print_out_phrase ppf out_phr;
+        end;
         if Printexc.backtrace_status ()
         then begin
           match !backtrace with
             | None -> ()
             | Some b ->
+                Location.separate_new_message ppf;
                 pp_print_string ppf b;
                 pp_print_flush ppf ();
                 backtrace := None;

--- a/toplevel/native/topeval.ml
+++ b/toplevel/native/topeval.ml
@@ -243,7 +243,12 @@ let execute_phrase print_outcome ppf phr =
               in
               Ophr_exception (exn, outv)
         in
-        !print_out_phrase ppf out_phr;
+        begin match out_phr with
+        | Ophr_signature [] -> ()
+        | _ ->
+            Location.separate_new_message ppf;
+            !print_out_phrase ppf out_phr;
+        end;
         begin match out_phr with
         | Ophr_eval (_, _) | Ophr_signature _ -> true
         | Ophr_exception _ -> false


### PR DESCRIPTION
This PR is inspired by user feedback from @mimoo on compiler error messages which originated in #11539.

Currently OCaml tools will include several messages concatenated together -- several warnings, possibly followed by one error -- and it may not be obvious especially for new users to visually split the output in several reports. 

This PR introduces a blank line between consecutive reports.

(cc @Octachron)

### Batch compiler example

Before:

```
File "b_bad.ml", lines 13-14, characters 29-28:
13 | .............................function
14 |     A.X s -> print_endline s
Error (warning 8 [partial-match]): this pattern-matching is not exhaustive.
Here is an example of a case that is not matched:
Y
File "b_bad.ml", line 18, characters 11-14:
18 | let () = f A.y
                ^^^
Error: Unbound value A.y
```

After:

```
File "b_bad.ml", lines 13-14, characters 29-28:
13 | .............................function
14 |     A.X s -> print_endline s
Error (warning 8 [partial-match]): this pattern-matching is not exhaustive.
Here is an example of a case that is not matched:
Y

File "b_bad.ml", line 18, characters 11-14:
18 | let () = f A.y
                ^^^
Error: Unbound value A.y
```

### Toplevel example

Before:

```
# type _ t = Int : int -> int t | Bool : bool -> bool t;;
type _ t = Int : int -> int t | Bool : bool -> bool t
# let test : int t -> int = function Int n -> n | _ -> 0;;
Warning 4 [fragile-match]: this pattern-matching is fragile.
It will remain exhaustive when constructors are added to type t.
Warning 56 [unreachable-case]: this match case is unreachable.
Consider replacing it with a refutation case '<pat> -> .'
val test : int t -> int = <fun>
```

After:

```
# type _ t = Int : int -> int t | Bool : bool -> bool t;;
type _ t = Int : int -> int t | Bool : bool -> bool t
# let test : int t -> int = function Int n -> n | _ -> 0;;
Warning 4 [fragile-match]: this pattern-matching is fragile.
It will remain exhaustive when constructors are added to type t.

Warning 56 [unreachable-case]: this match case is unreachable.
Consider replacing it with a refutation case '<pat> -> .'

val test : int t -> int = <fun>
```

### Implementation

Most of the logic is hidden in `Location`, but unfortunately there are other places in the compiler that print user messages than `Location.print_report`, so we need to break the abstraction a bit and expose a function "I'm about to print a new message" to be called by other modules. Not super nice, but not too bad either -- and very short.

### Note

In the original report, the issue was at the build-system level (the build system would concatenate several errors coming from different files); I reported this issue on dune in https://github.com/ocaml/dune/issues/6158 , and this is getting fixed by @esope in https://github.com/ocaml/dune/pull/6823. The present PR is about messages concatenated by the compiler itself.