### PR TITLE
Split `Typecore.unify_pat_types` into two to avoid unnecessary references to the environment in `type_pat`

### DIFF
--- a/Changes
+++ b/Changes
@@ -696,6 +696,10 @@ OCaml 5.1.0
 - #12012: move calls to Typetexp.TyVarEnv.reset inside with_local_level etc.
   (Jacques Garrigue and Takafumi Saikawa, review by Gabriel Scherer)
 
+- #12025: Split Typecore.unify_pat_types into two
+  to avoid unnecessary references to the environment in type_pat
+  (Jacques Garrigue and Takafumi Saikawa, review by Gabriel Scherer)
+
 - #12034: a logarithmic algorithm to find the next free variable
   (Gabriel Scherer, review by Stefan Muenzel)
 


### PR DESCRIPTION
`Typecore.unify_pat_types` has two different use-cases: one in `type_pat` that does not update the environment, and the other in `check_counter_example_pat` that needs a `refine` argument and updates the environment.

This PR splits these into two different functions and eliminates the updates to the environment from most parts of `type_pat`.

This PR subsumes #12020 .