### PR TITLE
Fix undefined Makefile variables [5.0 version]

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -952,6 +952,15 @@ ASPP_ERROR = \
 runtime/%.o: runtime/%.S
 	$(ASPP) $(OC_ASPPFLAGS) -o $@ $< || $(ASPP_ERROR)
 
+# $(OC_DEBUG_CPPFLAGS) and $(OC_INSTR_CPPFLAGS) are still used in the two
+# recipes just below instead of the correct $(ocamlrund_CPPFLAGS) and
+# $(ocamlruni_CPPFLAGS). This has been fixed on trunk, but in the
+# 5.0 maintenance branch here we just define default values for those OC_*
+# variables to avoid an undefined-variable warning, preserving exactly the
+# (somewhat strange) behaviour of the 5.0.0 release.
+OC_DEBUG_CPPFLAGS ?=
+OC_INSTR_CPPFLAGS ?=
+
 runtime/%.d.o: runtime/%.S
 	$(ASPP) $(OC_ASPPFLAGS) $(OC_DEBUG_CPPFLAGS) -o $@ $< || $(ASPP_ERROR)
 

--- a/Makefile.common
+++ b/Makefile.common
@@ -169,6 +169,7 @@ endef # PROGRAM_SYNONYM
 # should take place *before* Makefile.common is included.
 
 OCAMLDEP ?= $(BEST_OCAMLDEP)
+OCAMLDEPFLAGS ?=
 OC_OCAMLDEPFLAGS = -slash
 OC_OCAMLDEPDIRS =
 OCAMLDEP_CMD = $(OCAMLDEP) $(OC_OCAMLDEPFLAGS) \

--- a/tools/ci/actions/runner.sh
+++ b/tools/ci/actions/runner.sh
@@ -67,13 +67,19 @@ Build () {
   else
     script --return --command "$MAKE_WARN" build.log
   fi
-  echo Ensuring that all names are prefixed in the runtime
-  ./tools/check-symbol-names runtime/*.a otherlibs/*/lib*.a
+  failed=0
   if grep -Fq ' warning: undefined variable ' build.log; then
     echo Undefined Makefile variables detected
-    exit 1
+    failed=1
   fi
   rm build.log
+  echo Ensuring that all names are prefixed in the runtime
+  if ! ./tools/check-symbol-names runtime/*.a otherlibs/*/lib*.a ; then
+    failed=1
+  fi
+  if ((failed)); then
+    exit 1
+  fi
 }
 
 Test () {

--- a/tools/ci/actions/runner.sh
+++ b/tools/ci/actions/runner.sh
@@ -21,6 +21,8 @@ PREFIX=~/local
 MAKE="make $MAKE_ARG"
 SHELL=dash
 
+MAKE_WARN="$MAKE --warn-undefined-variables"
+
 export PATH=$PREFIX/bin:$PATH
 
 Configure () {
@@ -60,9 +62,18 @@ EOF
 }
 
 Build () {
-  $MAKE world.opt
+  if [ "$(uname)" = 'Darwin' ]; then
+    script -q build.log $MAKE_WARN
+  else
+    script --return --command "$MAKE_WARN" build.log
+  fi
   echo Ensuring that all names are prefixed in the runtime
   ./tools/check-symbol-names runtime/*.a otherlibs/*/lib*.a
+  if grep -Fq ' warning: undefined variable ' build.log; then
+    echo Undefined Makefile variables detected
+    exit 1
+  fi
+  rm build.log
 }
 
 Test () {

--- a/utils/Makefile
+++ b/utils/Makefile
@@ -90,7 +90,6 @@ config_main.ml: config.mlp $(ROOTDIR)/Makefile.config Makefile config.common.ml
 	    $(call SUBST,FUNCTION_SECTIONS) \
 	    $(call SUBST,CC_HAS_DEBUG_PREFIX_MAP) \
 	    $(call SUBST,AS_HAS_DEBUG_PREFIX_MAP) \
-	    $(call SUBST,FORCE_INSTRUMENTED_RUNTIME) \
 	    $< > $@
 	cat config.common.ml >> $@
 


### PR DESCRIPTION
Back-port of #12022, just as it improves CI for testing should we decide to do a 5.0.1. The CI test is identical; it differs in two places:
- `utils/Makefile` is updated to remove references to `$(FORCE_INSTRUMENTED_RUNTIME)` which was removed in #11660, but not fully back-ported (by me) in 5e975f9976326ea6d0c25fc808ac0979fe052a09 for 5.0.0
- The `runtime/Makefile`-related change with `OC_DEBUG_CPPFLAGS` and `OC_INSTR_CPPFLAGS` is changed to strictly silence the warning only (i.e. the debugging statements in `runtime/amd64.S` are still not compiled in `libasmrund.a`, just as they are not in the 5.0.0)

I've tested the workflow on my fork without the `FORCE_INSTRUMENTED_RUNTIME` commit to verify that CI does indeed fail if undefined variables are introduced.