### PR TITLE
documentation: Format.pp_print_newline wording

### DIFF
--- a/Changes
+++ b/Changes
@@ -318,6 +318,10 @@ Working version
 - #11676: Fix missing since annotation in the `Sys` and `Format` modules
   (Github user Bukolab99, review by Florian Angeletti)
 
+- #?????: Update format documentation to make it clearer that
+  `pp_print_newline` flushes its newline
+  (Floian Angeletti, review by ????)
+
 ### Compiler user-interface and warnings:
 
 - #11679: Improve the error message about too many arguments to a function

--- a/Changes
+++ b/Changes
@@ -318,9 +318,9 @@ Working version
 - #11676: Fix missing since annotation in the `Sys` and `Format` modules
   (Github user Bukolab99, review by Florian Angeletti)
 
-- #?????: Update format documentation to make it clearer that
+- #12028: Update format documentation to make it clearer that
   `pp_print_newline` flushes its newline
-  (Floian Angeletti, review by ????)
+  (Floian Angeletti, review by Gabriel Scherer)
 
 ### Compiler user-interface and warnings:
 

--- a/Changes
+++ b/Changes
@@ -320,7 +320,7 @@ Working version
 
 - #12028: Update format documentation to make it clearer that
   `pp_print_newline` flushes its newline
-  (Floian Angeletti, review by Gabriel Scherer)
+  (Florian Angeletti, review by Gabriel Scherer)
 
 ### Compiler user-interface and warnings:
 

--- a/stdlib/format.ml
+++ b/stdlib/format.ml
@@ -604,14 +604,14 @@ let clear_tag_stack state =
 
 
 (* Flushing pretty-printer queue. *)
-let pp_flush_queue state b =
+let pp_flush_queue state ~end_with_newline =
   clear_tag_stack state;
   while state.pp_curr_depth > 1 do
     pp_close_box state ()
   done;
   state.pp_right_total <- pp_infinity;
   advance_left state;
-  if b then pp_output_newline state;
+  if end_with_newline then pp_output_newline state;
   pp_rinit state
 
 (*
@@ -668,9 +668,9 @@ and pp_open_box state indent = pp_open_box_gen state indent Pp_box
    [pp_print_newline] behaves as [pp_print_flush] after printing an additional
    new line. *)
 let pp_print_newline state () =
-  pp_flush_queue state true; state.pp_out_flush ()
+  pp_flush_queue state ~end_with_newline:true; state.pp_out_flush ()
 and pp_print_flush state () =
-  pp_flush_queue state false; state.pp_out_flush ()
+  pp_flush_queue state ~end_with_newline:false; state.pp_out_flush ()
 
 
 (* To get a newline when one does not want to close the current box. *)
@@ -1077,7 +1077,7 @@ let get_stdbuf () = DLS.get stdbuf_key
    Formatter [ppf] is supposed to print to buffer [buf], otherwise this
    function is not really useful. *)
 let flush_buffer_formatter buf ppf =
-  pp_flush_queue ppf false;
+  pp_flush_queue ppf ~end_with_newline:false;
   let s = Buffer.contents buf in
   Buffer.reset buf;
   s

--- a/stdlib/format.mli
+++ b/stdlib/format.mli
@@ -407,7 +407,8 @@ val print_newline : unit -> unit
 
   All open pretty-printing boxes are closed, all pending text is printed.
 
-  Equivalent to {!print_flush} followed by a new line.
+  Equivalent to {!print_flush} with a new line emitted on the pretty-printer
+  low-level output device immediately before the device is flushed.
   See corresponding words of caution for {!print_flush}.
 
   Note: this is not the normal way to output a new line;


### PR DESCRIPTION
While reading the documentation of `Format.pp_print_newline`:


> Equivalent to {!print_flush}  followed by a new line.

@gasche and myself noted that the current wording does not guarantee that the new line emitted by the function is flushed at all.

This PR proposes to update this text to better reflect the implementation to:

>   Equivalent to {!print_flush} with a new line emitted on the pretty-printer
  low-level output device immediately before the device is flushed.