### PR TITLE
toplevel: allow multiple phrases in one line

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -118,6 +118,7 @@ testsuite/tests/generated-parse-errors/errors.*         typo.very-long-line
 testsuite/tools/*.S                                     typo.missing-header
 testsuite/tools/*.asm                                   typo.missing-header
 testsuite/tests/messages/highlight_tabs.ml              typo.tab
+testsuite/tests/tool-toplevel/multi_phrase_line.ml      typo.very-long-line
 
 # prune testsuite reference files
 testsuite/tests/**/*.reference               typo.prune

--- a/Changes
+++ b/Changes
@@ -1240,14 +1240,14 @@ Some of those changes will benefit all OCaml packages.
 
 ### Bug fixes:
 
+- #8813, #12029: In the toplevel, let the user type several phrases in one line
+  (Damien Doligez, report by Daniel Bünzli, review by Gabriel Scherer)
+
 - #12062: fix runtime events consumer: when events are dropped they shouldn't be
   parsed. (Lucas Pluvinage)
 
 - #12132: Fix overcounting of minor collections in GC stats.
   (Damien Doligez, review by Gabriel Scherer)
-
-- #8813, #??: In the toplevel, let the user type several phrases in one line
-  (Damien Doligez, report by Daniel Bünzli, review by ??)
 
 - #12017: Re-register finaliser only after calling user alarm in Gc.create_alarm
   (Fabrice Buoro, report by Sam Goldman, review by Guillaume Munch-Maccagnoni)

--- a/Changes
+++ b/Changes
@@ -1241,7 +1241,8 @@ Some of those changes will benefit all OCaml packages.
 ### Bug fixes:
 
 - #8813, #12029: In the toplevel, let the user type several phrases in one line
-  (Damien Doligez, report by Daniel Bünzli, review by Gabriel Scherer)
+  (Damien Doligez, report by Daniel Bünzli, review by Gabriel Scherer and
+   Wiktor Kuchta)
 
 - #12062: fix runtime events consumer: when events are dropped they shouldn't be
   parsed. (Lucas Pluvinage)

--- a/Changes
+++ b/Changes
@@ -1246,6 +1246,9 @@ Some of those changes will benefit all OCaml packages.
 - #12132: Fix overcounting of minor collections in GC stats.
   (Damien Doligez, review by Gabriel Scherer)
 
+- #8813, #??: In the toplevel, let the user type several phrases in one line
+  (Damien Doligez, report by Daniel Bünzli, review by ??)
+
 - #12017: Re-register finaliser only after calling user alarm in Gc.create_alarm
   (Fabrice Buoro, report by Sam Goldman, review by Guillaume Munch-Maccagnoni)
 

--- a/driver/main_args.ml
+++ b/driver/main_args.ml
@@ -341,6 +341,9 @@ let mk_noinit f =
 let mk_nolabels f =
   "-nolabels", Arg.Unit f, " Ignore non-optional labels in types"
 
+let mk_prompt f =
+  "-prompt", Arg.Unit f, " Output prompts (default)"
+
 let mk_noprompt f =
   "-noprompt", Arg.Unit f, " Suppress all prompts"
 
@@ -873,6 +876,7 @@ module type Toplevel_options = sig
   val _init : string -> unit
   val _noinit : unit -> unit
   val _no_version : unit -> unit
+  val _prompt : unit -> unit
   val _noprompt : unit -> unit
   val _nopromptcont : unit -> unit
   val _stdin : unit -> unit
@@ -1140,6 +1144,7 @@ struct
     mk_noassert F._noassert;
     mk_noinit F._noinit;
     mk_nolabels F._nolabels;
+    mk_prompt F._prompt;
     mk_noprompt F._noprompt;
     mk_nopromptcont F._nopromptcont;
     mk_nostdlib F._nostdlib;
@@ -1389,6 +1394,7 @@ module Make_opttop_options (F : Opttop_options) = struct
     mk_noassert F._noassert;
     mk_noinit F._noinit;
     mk_nolabels F._nolabels;
+    mk_prompt F._prompt;
     mk_noprompt F._noprompt;
     mk_nopromptcont F._nopromptcont;
     mk_nostdlib F._nostdlib;
@@ -1803,6 +1809,7 @@ module Default = struct
     let _init s = init_file := (Some s)
     let _no_version = set noversion
     let _noinit = set noinit
+    let _prompt = clear noprompt
     let _noprompt = set noprompt
     let _nopromptcont = set nopromptcont
     let _stdin () = (* placeholder: file_argument ""*) ()

--- a/driver/main_args.mli
+++ b/driver/main_args.mli
@@ -134,6 +134,7 @@ module type Toplevel_options = sig
   val _init : string -> unit
   val _noinit : unit -> unit
   val _no_version : unit -> unit
+  val _prompt : unit -> unit
   val _noprompt : unit -> unit
   val _nopromptcont : unit -> unit
   val _stdin : unit -> unit

--- a/man/ocaml.1
+++ b/man/ocaml.1
@@ -37,23 +37,19 @@ command is the toplevel system for OCaml,
 that permits interactive use of the OCaml system through a
 read-eval-print loop. In this mode, the system repeatedly reads OCaml
 phrases from the input, then typechecks, compiles and evaluates
-them, then prints the inferred type and result value, if any. The
+them, then prints the inferred type and result value, if any.
 system prints a # (hash) prompt before reading each phrase.
 
-A toplevel phrase can span several lines. It is terminated by ;; (a
-double-semicolon). The syntax of toplevel phrases is as follows.
+Input to the toplevel can span several lines. It begins after the #
+(sharp) prompt printed by the system and is terminated by ;; (a
+double-semicolon) followed by optional white space and an end of line.
+The toplevel input consists in one or several toplevel phrases.
 
-The toplevel system is started by the command
-.BR ocaml (1).
-Phrases are read on standard input, results are printed on standard
-output, errors on standard error. End-of-file on standard input
-terminates
-.BR ocaml (1).
 
 If one or more
 .I object-files
-(ending in .cmo or .cma) are given, they are loaded silently before
-starting the toplevel.
+(ending in .cmo or .cma) are given on the command line, they are
+loaded silently before starting the toplevel.
 
 If a
 .I script-file

--- a/man/ocaml.1
+++ b/man/ocaml.1
@@ -38,7 +38,6 @@ that permits interactive use of the OCaml system through a
 read-eval-print loop. In this mode, the system repeatedly reads OCaml
 phrases from the input, then typechecks, compiles and evaluates
 them, then prints the inferred type and result value, if any.
-system prints a # (hash) prompt before reading each phrase.
 
 Input to the toplevel can span several lines. It begins after the #
 (sharp) prompt printed by the system and is terminated by ;; (a

--- a/man/ocaml.1
+++ b/man/ocaml.1
@@ -36,14 +36,15 @@ The
 command is the toplevel system for OCaml,
 that permits interactive use of the OCaml system through a
 read-eval-print loop. In this mode, the system repeatedly reads OCaml
-phrases from the input, then typechecks, compiles and evaluates
+phrases from standard input, then typechecks, compiles and evaluates
 them, then prints the inferred type and result value, if any.
+End-of-file on standard input terminates
+.BR ocaml (1).
 
 Input to the toplevel can span several lines. It begins after the #
 (sharp) prompt printed by the system and is terminated by ;; (a
 double-semicolon) followed by optional white space and an end of line.
 The toplevel input consists in one or several toplevel phrases.
-
 
 If one or more
 .I object-files

--- a/manual/src/cmds/top.etex
+++ b/manual/src/cmds/top.etex
@@ -1,17 +1,17 @@
 \chapter{The toplevel system or REPL (ocaml)} \label{c:camllight}
 %HEVEA\cutname{toplevel.html}
 
-This chapter describes the toplevel system for OCaml, that permits
+This chapter describes "ocaml", the toplevel system for OCaml, that permits
 interactive use of the OCaml system
 through a read-eval-print loop (REPL). In this mode, the system repeatedly
 reads OCaml phrases from the input, then typechecks, compile and
 evaluate them, then prints the inferred type and result value, if
-any.
+any. End-of-file on standard input terminates "ocaml".
 
 Input to the toplevel can span several lines. It begins after the "#"
 (sharp) prompt printed by the system and is terminated by @";;"@ (a
-double-semicolon) followed by optional white space and an end of
-line. The toplevel input consists in one or several
+double-semicolon) followed by optional white space and comments and an
+end of line. The toplevel input consists in one or several
 toplevel phrases, with the following syntax:
 
 \begin{syntax}

--- a/manual/src/cmds/top.etex
+++ b/manual/src/cmds/top.etex
@@ -6,16 +6,17 @@ interactive use of the OCaml system
 through a read-eval-print loop (REPL). In this mode, the system repeatedly
 reads OCaml phrases from the input, then typechecks, compile and
 evaluate them, then prints the inferred type and result value, if
-any. The system prints a "#" (sharp) prompt before reading each
-phrase.
+any.
 
-Input to the toplevel can span several lines. It is terminated by @";;"@ (a
-double-semicolon). The toplevel input consists in one or several
+Input to the toplevel can span several lines. It begins after the "#"
+(sharp) prompt printed by the system and is terminated by @";;"@ (a
+double-semicolon) followed by optional white space and an end of
+line. The toplevel input consists in one or several
 toplevel phrases, with the following syntax:
 
 \begin{syntax}
 toplevel-input:
-          {{ definition }} ';;'
+          { definition } ';;'
         | expr ';;'
         | '#' ident [ directive-argument ] ';;'
 ;
@@ -26,10 +27,10 @@ directive-argument:
         | 'true' || 'false'
 \end{syntax}
 
-A phrase can consist of a definition, like those found in
+A phrase can consist of a sequence of definitions, like those found in
 implementations of compilation units or in @'struct' \ldots 'end'@
-module expressions. The definition can bind value names, type names,
-an exception, a module name, or a module type name. The toplevel
+module expressions. The definitions can bind value names, type names,
+a exceptions, module names, or module type names. The toplevel
 system performs the bindings, then prints the types and values (if
 any) for the names thus defined.
 

--- a/manual/src/cmds/top.etex
+++ b/manual/src/cmds/top.etex
@@ -30,7 +30,7 @@ directive-argument:
 A phrase can consist of a sequence of definitions, like those found in
 implementations of compilation units or in @'struct' \ldots 'end'@
 module expressions. The definitions can bind value names, type names,
-a exceptions, module names, or module type names. The toplevel
+exceptions, module names, or module type names. The toplevel
 system performs the bindings, then prints the types and values (if
 any) for the names thus defined.
 

--- a/testsuite/tests/tool-toplevel/multi_phrase_line.compilers.reference
+++ b/testsuite/tests/tool-toplevel/multi_phrase_line.compilers.reference
@@ -1,56 +1,63 @@
-#     - : int = 1
-- : int = 2
-#     - : int = 1
-- : unit = ()
-#       - : int = 1
-- : unit = ()
-#   Line 2, characters 7-9:
-2 | 1;; let;; 3;; (* Syntax error in second phrase. *)
-           ^^
-Error: Syntax error
+#     - : unit = ()
 #   - : int = 1
-Line 2, characters 14-18:
-2 | 1;; let x = 2+true;; 3;; (* Type error in second phrase. *)
-                  ^^^^
+- : int = 2
+#     - : int = 3
+- : unit = ()
+#       - : int = 5
+- : unit = ()
+#     - : int = 7
+#   Line 2, characters 9-11:
+2 | 8;; let 9;; 10;; (* Syntax error in second phrase. *)
+             ^^
+Error: Syntax error
+#   - : int = 11
+Line 2, characters 16-20:
+2 | 11;; let x = 12+true;; 13;; (* Type error in second phrase. *)
+                    ^^^^
 Error: This expression has type bool but an expression was expected of type
          int
-#   Line 2, characters 0-21:
-2 | match 1 with 11 -> ();; 2;; 3;; (* Warning + run-time error in first phrase. *)
-    ^^^^^^^^^^^^^^^^^^^^^
+#   Line 2, characters 0-22:
+2 | match 14 with 15 -> ();; 16;; 17;; (* Warning + run-time error in 1st phrase. *)
+    ^^^^^^^^^^^^^^^^^^^^^^
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 0
+
 Exception: Match_failure ("//toplevel//", 2, 0).
-- : int = 2
-- : int = 3
-#   - : int = 1
-Line 2, characters 4-25:
-2 | 1;; match 2 with 22 -> ();; 3;; (* Warning + run-time error in second phrase. *)
-        ^^^^^^^^^^^^^^^^^^^^^
+- : int = 16
+- : int = 17
+#   - : int = 18
+Line 2, characters 5-27:
+2 | 18;; match 19 with 20 -> ();; 21;; (* Warning + run-time error in 2nd phrase. *)
+         ^^^^^^^^^^^^^^^^^^^^^^
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 0
-Exception: Match_failure ("//toplevel//", 2, 4).
-- : int = 3
-#   Line 2, characters 6-12:
-2 | let f 1 = ();; let f 2 = ();; let f 3 = ();; (* Several warnings. *)
-          ^^^^^^
+
+Exception: Match_failure ("//toplevel//", 2, 5).
+- : int = 21
+#   Line 2, characters 6-13:
+2 | let f 22 = ();; let f 23 = ();; let f 24 = ();; (* Several warnings. *)
+          ^^^^^^^
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 0
+
 val f : int -> unit = <fun>
-Line 2, characters 21-27:
-2 | let f 1 = ();; let f 2 = ();; let f 3 = ();; (* Several warnings. *)
-                         ^^^^^^
+Line 2, characters 22-29:
+2 | let f 22 = ();; let f 23 = ();; let f 24 = ();; (* Several warnings. *)
+                          ^^^^^^^
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 0
+
 val f : int -> unit = <fun>
-Line 2, characters 36-42:
-2 | let f 1 = ();; let f 2 = ();; let f 3 = ();; (* Several warnings. *)
-                                        ^^^^^^
+Line 2, characters 38-45:
+2 | let f 22 = ();; let f 23 = ();; let f 24 = ();; (* Several warnings. *)
+                                          ^^^^^^^
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 0
+
 val f : int -> unit = <fun>
 #   * * *   

--- a/testsuite/tests/tool-toplevel/multi_phrase_line.compilers.reference
+++ b/testsuite/tests/tool-toplevel/multi_phrase_line.compilers.reference
@@ -5,7 +5,7 @@
 - : unit = ()
 #       - : int = 5
 - : unit = ()
-#     - : int = 7
+#   * - : int = 7
 #   Line 2, characters 9-11:
 2 | 8;; let 9;; 10;; (* Syntax error in second phrase. *)
              ^^

--- a/testsuite/tests/tool-toplevel/multi_phrase_line.compilers.reference
+++ b/testsuite/tests/tool-toplevel/multi_phrase_line.compilers.reference
@@ -21,8 +21,8 @@ Error: Syntax error
 Line 2, characters 16-20:
 2 | 11;; let x = 12+true;; 13;; (* Type error in second phrase. *)
                     ^^^^
-Error: This expression has type bool but an expression was expected of type
-         int
+Error: This expression has type "bool" but an expression was expected of type
+         "int"
 #   Line 2, characters 0-22:
 2 | match 14 with 15 -> ();; 16;; 17;; (* Warning + run-time error in 1st phrase. *)
     ^^^^^^^^^^^^^^^^^^^^^^
@@ -43,25 +43,25 @@ Here is an example of a case that is not matched:
 
 Exception: Match_failure ("//toplevel//", 2, 5).
 - : int = 21
-#   Line 2, characters 6-13:
+#   Line 2, characters 6-8:
 2 | let f 22 = ();; let f 23 = ();; let f 24 = ();; (* Several warnings. *)
-          ^^^^^^^
+          ^^
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 0
 
 val f : int -> unit = <fun>
-Line 2, characters 22-29:
+Line 2, characters 22-24:
 2 | let f 22 = ();; let f 23 = ();; let f 24 = ();; (* Several warnings. *)
-                          ^^^^^^^
+                          ^^
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 0
 
 val f : int -> unit = <fun>
-Line 2, characters 38-45:
+Line 2, characters 38-40:
 2 | let f 22 = ();; let f 23 = ();; let f 24 = ();; (* Several warnings. *)
-                                          ^^^^^^^
+                                          ^^
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 0

--- a/testsuite/tests/tool-toplevel/multi_phrase_line.compilers.reference
+++ b/testsuite/tests/tool-toplevel/multi_phrase_line.compilers.reference
@@ -6,6 +6,13 @@
 #       - : int = 5
 - : unit = ()
 #   * - : int = 7
+#   * Line 2, characters 6-9:
+2 | 750;; (*) comment-start warning after semicolon must be displayed once
+          ^^^
+Warning 1 [comment-start]: this `(*' is the start of a comment.
+Hint: Did you forget spaces when writing the infix operator `( * )'?
+
+- : int = 750
 #   Line 2, characters 9-11:
 2 | 8;; let 9;; 10;; (* Syntax error in second phrase. *)
              ^^

--- a/testsuite/tests/tool-toplevel/multi_phrase_line.compilers.reference
+++ b/testsuite/tests/tool-toplevel/multi_phrase_line.compilers.reference
@@ -1,0 +1,56 @@
+#     - : int = 1
+- : int = 2
+#     - : int = 1
+- : unit = ()
+#       - : int = 1
+- : unit = ()
+#   Line 2, characters 7-9:
+2 | 1;; let;; 3;; (* Syntax error in second phrase. *)
+           ^^
+Error: Syntax error
+#   - : int = 1
+Line 2, characters 14-18:
+2 | 1;; let x = 2+true;; 3;; (* Type error in second phrase. *)
+                  ^^^^
+Error: This expression has type bool but an expression was expected of type
+         int
+#   Line 2, characters 0-21:
+2 | match 1 with 11 -> ();; 2;; 3;; (* Warning + run-time error in first phrase. *)
+    ^^^^^^^^^^^^^^^^^^^^^
+Warning 8 [partial-match]: this pattern-matching is not exhaustive.
+Here is an example of a case that is not matched:
+0
+Exception: Match_failure ("//toplevel//", 2, 0).
+- : int = 2
+- : int = 3
+#   - : int = 1
+Line 2, characters 4-25:
+2 | 1;; match 2 with 22 -> ();; 3;; (* Warning + run-time error in second phrase. *)
+        ^^^^^^^^^^^^^^^^^^^^^
+Warning 8 [partial-match]: this pattern-matching is not exhaustive.
+Here is an example of a case that is not matched:
+0
+Exception: Match_failure ("//toplevel//", 2, 4).
+- : int = 3
+#   Line 2, characters 6-12:
+2 | let f 1 = ();; let f 2 = ();; let f 3 = ();; (* Several warnings. *)
+          ^^^^^^
+Warning 8 [partial-match]: this pattern-matching is not exhaustive.
+Here is an example of a case that is not matched:
+0
+val f : int -> unit = <fun>
+Line 2, characters 21-27:
+2 | let f 1 = ();; let f 2 = ();; let f 3 = ();; (* Several warnings. *)
+                         ^^^^^^
+Warning 8 [partial-match]: this pattern-matching is not exhaustive.
+Here is an example of a case that is not matched:
+0
+val f : int -> unit = <fun>
+Line 2, characters 36-42:
+2 | let f 1 = ();; let f 2 = ();; let f 3 = ();; (* Several warnings. *)
+                                        ^^^^^^
+Warning 8 [partial-match]: this pattern-matching is not exhaustive.
+Here is an example of a case that is not matched:
+0
+val f : int -> unit = <fun>
+#   * * *   

--- a/testsuite/tests/tool-toplevel/multi_phrase_line.ml
+++ b/testsuite/tests/tool-toplevel/multi_phrase_line.ml
@@ -1,0 +1,24 @@
+(* TEST_BELOW *)
+
+1;; 2;; (* Two phrases on the same line *)
+
+1;; ignore
+2;; (* Wait for ;; at end of line before evaluating anything. *)
+
+1;;                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       ignore
+2;; (* Very long line needs buffer refills. *)
+
+1;; let;; 3;; (* Syntax error in second phrase. *)
+
+1;; let x = 2+true;; 3;; (* Type error in second phrase. *)
+
+match 1 with 11 -> ();; 2;; 3;; (* Warning + run-time error in first phrase. *)
+
+1;; match 2 with 22 -> ();; 3;; (* Warning + run-time error in second phrase. *)
+
+let f 1 = ();; let f 2 = ();; let f 3 = ();; (* Several warnings. *)
+
+(* TEST
+   * toplevel
+     flags = "-prompt"
+*)

--- a/testsuite/tests/tool-toplevel/multi_phrase_line.ml
+++ b/testsuite/tests/tool-toplevel/multi_phrase_line.ml
@@ -1,22 +1,27 @@
 (* TEST_BELOW *)
 
+Printexc.record_backtrace false;;
+
 1;; 2;; (* Two phrases on the same line *)
 
-1;; ignore
-2;; (* Wait for ;; at end of line before evaluating anything. *)
+3;; ignore
+4;; (* Wait for ;; at end of line before evaluating anything. *)
 
-1;;                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       ignore
-2;; (* Very long line needs buffer refills. *)
+5;;                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       ignore
+6;; (* Very long line needs buffer refills. *)
 
-1;; let;; 3;; (* Syntax error in second phrase. *)
+7;; (* linefeed in a comment after double-semi
+*)
 
-1;; let x = 2+true;; 3;; (* Type error in second phrase. *)
+8;; let 9;; 10;; (* Syntax error in second phrase. *)
 
-match 1 with 11 -> ();; 2;; 3;; (* Warning + run-time error in first phrase. *)
+11;; let x = 12+true;; 13;; (* Type error in second phrase. *)
 
-1;; match 2 with 22 -> ();; 3;; (* Warning + run-time error in second phrase. *)
+match 14 with 15 -> ();; 16;; 17;; (* Warning + run-time error in 1st phrase. *)
 
-let f 1 = ();; let f 2 = ();; let f 3 = ();; (* Several warnings. *)
+18;; match 19 with 20 -> ();; 21;; (* Warning + run-time error in 2nd phrase. *)
+
+let f 22 = ();; let f 23 = ();; let f 24 = ();; (* Several warnings. *)
 
 (* TEST
    * toplevel

--- a/testsuite/tests/tool-toplevel/multi_phrase_line.ml
+++ b/testsuite/tests/tool-toplevel/multi_phrase_line.ml
@@ -13,6 +13,9 @@ Printexc.record_backtrace false;;
 7;; (* linefeed in a comment after double-semi
 *)
 
+750;; (*) comment-start warning after semicolon must be displayed once
+*)
+
 8;; let 9;; 10;; (* Syntax error in second phrase. *)
 
 11;; let x = 12+true;; 13;; (* Type error in second phrase. *)

--- a/testsuite/tests/tool-toplevel/multi_phrase_line.ml
+++ b/testsuite/tests/tool-toplevel/multi_phrase_line.ml
@@ -27,6 +27,6 @@ match 14 with 15 -> ();; 16;; 17;; (* Warning + run-time error in 1st phrase. *)
 let f 22 = ();; let f 23 = ();; let f 24 = ();; (* Several warnings. *)
 
 (* TEST
-   * toplevel
-     flags = "-prompt"
+   flags = "-prompt";
+   toplevel;
 *)

--- a/toplevel/topcommon.ml
+++ b/toplevel/topcommon.ml
@@ -239,13 +239,15 @@ let read_input_default prompt buffer len =
 
 let read_interactive_input = ref read_input_default
 
+let comment_prompt_override = ref false
+
 let refill_lexbuf buffer len =
   if !got_eof then (got_eof := false; 0) else begin
     let prompt =
       if !Clflags.noprompt then ""
       else if !first_line then "# "
       else if !Clflags.nopromptcont then ""
-      else if Lexer.in_comment () then "* "
+      else if Lexer.in_comment () || !comment_prompt_override then "* "
       else "  "
     in
     first_line := false;

--- a/toplevel/topcommon.mli
+++ b/toplevel/topcommon.mli
@@ -230,4 +230,6 @@ val backtrace: string option ref
 val parse_mod_use_file:
   string -> Lexing.lexbuf -> Parsetree.toplevel_phrase list
 
+val comment_prompt_override : bool ref
+
 val refill_lexbuf: bytes -> int -> int

--- a/toplevel/toploop.ml
+++ b/toplevel/toploop.ml
@@ -220,7 +220,12 @@ let process_phrase ppf snap phr =
   ignore(execute_phrase true ppf phr)
 
 (* Type, compile and execute a list of phrases, setting the report printer
-   to bach mode for all but the first one. *)
+   to batch mode for all but the first one.
+   We have to use batch mode for reporting for two reasons:
+   1. we can't underline several parts of the input line(s) in place
+   2. the execution of the first phrase may mess up the line count so we
+      can't move the cursor back to the correct line
+ *)
 let process_phrases ppf snap phrs =
   match phrs with
   | [] -> ()

--- a/toplevel/toploop.ml
+++ b/toplevel/toploop.ml
@@ -231,9 +231,10 @@ let process_phrases ppf snap phrs =
   | [] -> ()
   | phr :: rest ->
     process_phrase ppf snap phr;
-    Misc.protect_refs
-      Location.[R (report_printer, fun () -> batch_mode_printer)]
-      (fun () -> List.iter (process_phrase ppf snap) rest)
+    if rest <> [] then
+      Misc.protect_refs
+        Location.[R (report_printer, fun () -> batch_mode_printer)]
+        (fun () -> List.iter (process_phrase ppf snap) rest)
 
 let loop ppf =
   Clflags.debug := true;

--- a/toplevel/toploop.ml
+++ b/toplevel/toploop.ml
@@ -220,7 +220,8 @@ let is_blank_with_linefeed lb =
                                    | Unterminated_string_in_comment _), _)) ->
             (* In this case we don't know whether there will be a token
                before the next linefeed, so get more chars and continue. *)
-            lb.refill_buff lb;
+            Misc.protect_refs [ R (comment_prompt_override, true) ]
+              (fun () -> lb.refill_buff lb);
             loop ()
         | exception _ -> false (* syntax error *)
       end


### PR DESCRIPTION
fixes #8813

As described in https://github.com/ocaml/ocaml/issues/8813#issuecomment-546355599, the toplevel waits for a `;;` **at end of line** (ignoring whitespace) before it starts executing the input.

There are some non-obvious choices to make when handling errors and warnings. You have to choose something that makes sense for the user and is not too hard to implement. This is what I've done:

1. In case of syntax error, the whole line is aborted and nothing gets executed. The error is reported (and the input flushed) as soon as detected, even if there isn't a `;;` at the end of the line.
2. In case of type error or compilation error (or user interrupt while compiling) execution stops at the phrase in error and the rest of the line is ignored.
3. If a phrase raises an exception or the user interrupts its execution, the exception is reported and execution goes on with the rest of the line.

There is a difficulty with displaying warnings and errors. What I've implemented is that errors and warnings display normally for the first phrase, but we switch to batch-mode display for the others.
