### PR TITLE
A logarithmic algorithm to find the next free variable

### DIFF
--- a/.depend
+++ b/.depend
@@ -1890,6 +1890,7 @@ typing/untypeast.cmo : \
     typing/typedtree.cmi \
     typing/path.cmi \
     parsing/parsetree.cmi \
+    utils/misc.cmi \
     parsing/longident.cmi \
     parsing/location.cmi \
     typing/ident.cmi \
@@ -1901,6 +1902,7 @@ typing/untypeast.cmx : \
     typing/typedtree.cmx \
     typing/path.cmx \
     parsing/parsetree.cmi \
+    utils/misc.cmx \
     parsing/longident.cmx \
     parsing/location.cmx \
     typing/ident.cmx \

--- a/Changes
+++ b/Changes
@@ -500,6 +500,9 @@ Working version
 - #12012: move calls to Typetexp.TyVarEnv.reset inside with_local_level etc.
   (Jacques Garrigue and Takafumi Saikawa, review by Gabriel Scherer)
 
+- #12034: a logarithmic algorithm to find the next free variable
+  (Gabriel Scherer, review by Stefan Muenzel)
+
 ### Build system:
 
 - #11590: Allow installing to a destination path containing spaces.

--- a/testsuite/tests/utils/find_first_mono.ml
+++ b/testsuite/tests/utils/find_first_mono.ml
@@ -1,0 +1,73 @@
+(* TEST
+include config
+include testing
+binary_modules = "config build_path_prefix_map misc"
+* bytecode
+*)
+
+let check_and_count_calls n =
+  let calls = ref 0 in
+  let res = Misc.find_first_mono (fun i -> incr calls; i >= n) in
+  assert (res = n);
+  !calls
+
+let report i =
+  let calls = check_and_count_calls i in
+  Printf.printf "%d: %d calls\n%!" i calls
+
+let () =
+  print_endline "Testing small values";
+  let small_tests = List.init 20 (fun i -> i) in
+  List.iter report small_tests;
+  print_newline ()
+
+let () =
+  print_endline "Testing around max_int/2";
+  (* we do not use [report] to show the test output, as the output
+     depends on the value of [max_int], so it is not portable across
+     integer sizes. *)
+  let median_tests =
+    List.map (fun i -> max_int / 2 + i) [-2; -1; 0; 1; 2] in
+  List.map check_and_count_calls median_tests |> ignore;
+  print_newline ()
+
+let () =
+  print_endline "Testing around max_int";
+  (* see above for why we do not use [report] *)
+  let max_int_tests =
+    List.map (fun i -> max_int + i) [-4; -3; -2; -1; 0] in
+  List.map check_and_count_calls max_int_tests |> ignore;
+  print_newline ()
+
+let () =
+  let n = 100 in
+  Printf.printf
+    "Showing predicate calls for find_first_mono to find n=%d\n%!" n;
+  let res =
+    Misc.find_first_mono (fun i -> Printf.printf "call on %d\n%!" i; i >= n) in
+  Printf.printf "result: %d\n%!" res;
+  print_newline ()
+
+let () =
+  print_endline "Test constantly-false predicates";
+  print_endline "Constantly-false predicates are outside the spec,\n\
+    but we ask them to return [max_int] rather than loop or crash.";
+  let res = Misc.find_first_mono (fun _ -> false) in
+  assert (res = max_int);
+  print_newline ()
+
+let () =
+  print_endline "Test non-monotonous predicates";
+  print_endline "Non-monotonous predicates are outside the spec,\n\
+    but we ask them to find a satisfying value rather than loop or crash\n\
+    as long as they are asymptotically true.";
+  (* We generate predicates that are true above 1000 but
+     are sometimes-true before that. *)
+  for n = 1 to 499 do
+    let pred i =
+      i >= 1000 || (i > n && i mod n = 0)
+    in
+    let res = Misc.find_first_mono pred in
+    assert (pred res)
+  done;
+  print_newline ()

--- a/testsuite/tests/utils/find_first_mono.reference
+++ b/testsuite/tests/utils/find_first_mono.reference
@@ -1,0 +1,54 @@
+Testing small values
+0: 1 calls
+1: 2 calls
+2: 4 calls
+3: 4 calls
+4: 6 calls
+5: 6 calls
+6: 6 calls
+7: 6 calls
+8: 8 calls
+9: 8 calls
+10: 8 calls
+11: 8 calls
+12: 8 calls
+13: 8 calls
+14: 8 calls
+15: 8 calls
+16: 10 calls
+17: 10 calls
+18: 10 calls
+19: 10 calls
+
+Testing around max_int/2
+
+Testing around max_int
+
+Showing predicate calls for find_first_mono to find n=100
+call on 0
+call on 1
+call on 3
+call on 7
+call on 15
+call on 31
+call on 63
+call on 127
+call on 95
+call on 111
+call on 103
+call on 99
+call on 101
+call on 100
+result: 100
+
+Test constantly-false predicates
+Constantly-false predicates are outside the spec,
+but we ask them to return [max_int] rather than loop or crash.
+
+Test non-monotonous predicates
+Non-monotonous predicates are outside the spec,
+but we ask them to find a satisfying value rather than loop or crash
+as long as they are asymptotically true.
+
+
+All tests succeeded.

--- a/typing/printtyp.ml
+++ b/typing/printtyp.ml
@@ -936,16 +936,16 @@ end = struct
             (* Some part of the type we've already printed has assigned another
              * unification variable to that name. We want to keep the name, so
              * try adding a number until we find a name that's not taken. *)
-            let current_name = ref name in
-            let i = ref 0 in
-            while List.exists
-                    (fun (_, name') -> !current_name = name')
-                    !names
-            do
-              current_name := name ^ (Int.to_string !i);
-              i := !i + 1;
-            done;
-            !current_name
+            let available name =
+              List.for_all
+                (fun (_, name') -> name <> name')
+                !names
+            in
+            if available name then name
+            else
+              let suffixed i = name ^ Int.to_string i in
+              let i = Misc.find_first_mono (fun i -> available (suffixed i)) in
+              suffixed i
         | _ ->
             (* No name available, create a new one *)
             name_generator ()

--- a/typing/untypeast.ml
+++ b/typing/untypeast.ml
@@ -107,12 +107,10 @@ let map_loc sub {loc; txt} = {loc = sub.location sub loc; txt}
 
 (** Try a name [$name$0], check if it's free, if not, increment and repeat. *)
 let fresh_name s env =
-  let rec aux i =
-    let name = s ^ Int.to_string i in
-    if Env.bound_value name env then aux (i+1)
-    else name
-  in
-  aux 0
+  let name i = s ^ Int.to_string i in
+  let available i = not (Env.bound_value (name i) env) in
+  let first_i = Misc.find_first_mono available in
+  name first_i
 
 (** Extract the [n] patterns from the case of a letop *)
 let rec extract_letop_patterns n pat =

--- a/utils/misc.mli
+++ b/utils/misc.mli
@@ -307,6 +307,25 @@ module Int_literal_converter : sig
 
 end
 
+val find_first_mono : (int -> bool) -> int
+  (**[find_first_mono p] takes an integer predicate [p : int -> bool]
+     that we assume:
+     1. is monotonic on natural numbers:
+        if [a <= b] then [p a] implies [p b],
+     2. is satisfied for some natural numbers in range [0; max_int]
+        (this is equivalent to: [p max_int = true]).
+
+     [find_first_mono p] is the smallest natural number N that satisfies [p],
+     computed in O(log(N)) calls to [p].
+
+     Our implementation supports two cases where the preconditions on [p]
+     are not respected:
+     - If [p] is always [false], we silently return [max_int]
+       instead of looping or crashing.
+     - If [p] is non-monotonic but eventually true,
+       we return some satisfying value.
+  *)
+
 (** {1 String operations} *)
 
 val search_substring: string -> string -> int -> int


### PR DESCRIPTION
Several places in the compiler have logic to "pick a fresh name" by starting from a prefix, say foo, and trying foo/0, foo/1, foo/2... until they find one that is "available" in some sense.

This can easily be implemented through a linear search, but this gives a quadratic behavior when we repeatedly generate fresh names from the same prefix -- which can happen in practice in realistic example of source code repeating the same variable or constructor name many times.

We introduce a function `Misc.find_first_mono` that finds the "first available number" in logarithmic time, assuming that the "unavailable numbers" form a strict prefix of all natural numbers. (That is: some numbers remain available, and all numbers after the first available numbers are available.)

When called repeatedly on the same prefix, this gives a behavior in O(n log n) rather than O(n^2).