### PR TITLE
Poll for actions in structural equality loop.

### DIFF
--- a/Changes
+++ b/Changes
@@ -29,6 +29,9 @@ Working version
 
 ### Runtime system:
 
+- #12039: Poll for actions in structural equality loop.
+  (B. Szilvasy, reviewed by Gabriel Scherer)
+
 - #12001: Fix book keeping for last finalisers during the minor cycle
   (KC Sivaramakrishnan and Enguerrand Decorne, report by Guillaume Bury
    and Vincent Laviron, review by Sadiq Jaffer and KC Sivaramakrishnan)


### PR DESCRIPTION
Fixes #3921.

This PR updates the implementation of structural equality in [`compare.c`](./runtime/compare.c) to periodically poll for actions (outstanding signals, garbage collection interrupts), since this is an unbounded loop.

This ensures, for example, that the following comparison:
```ocaml
let rec x = 1 :: x
in x = x
```
can appropriately be interrupted with Ctrl-C at the top level.

It is possible that handling actions does _not_ throw an exception, this happens in the case of a gc interrupt, or in the case that the signal handler (such as one registered by a user) does not raise an exception. It is also possible that a major garbage collection occurs:
```ocaml
Sys.set_signal
  Sys.sigusr1
  (Sys.Signal_handle
    (fun _sb -> 
      print_endline "Full major";
      Gc.full_major ();
      ()));;
```

Thus, the structural equality loop pessimistically saves the two compared values across the action handling, and restarts from the beginning if no exception was thrown. This is necessary for correctness when the comparison is not a loop, but just a very large tree.
```ocaml
# let make n x = List.init n (fun _ -> x);;
val make : int -> 'a -> 'a list = <fun>
# let ll = make 100 (make 100 (make 100 (make 100 (make 10 1))));;
val ll : int list list list list list = ...
# ll = ll;;
(* must be true, even with interrupts *)
# (ll, 0) = (ll, 0);;
(* must be true *)
# (ll, 0) = (ll, 1);;
(* must be false *)
```

Automated tests for this would likely be finnicky and unreliable, but please let me know if and how I should write them.