### PR TITLE
dune: enable building @libs target

### DIFF
--- a/ocamltest/dune
+++ b/ocamltest/dune
@@ -20,18 +20,6 @@
  (modules tsl_parser)
  (mode fallback))
 
-(rule
- (targets ocamltest_config.ml)
- (deps
-   ../Makefile.config
-   ../Makefile.build_config
-   ../Makefile.config_if_required
-   ../Makefile.common
-   ../Makefile.best_binaries
-   Makefile
-   ./ocamltest_config.ml.in)
- (action (run make %{targets} COMPUTE_DEPS=false)))
-
 ;; FIXME: handle UNIX_OR_WIN32 or something similar
 (library
  (name ocamltest_core_and_plugin)

--- a/otherlibs/unix/dune
+++ b/otherlibs/unix/dune
@@ -33,13 +33,6 @@
    wait write))
 
 (rule
-  (action (copy unix_unix.ml unix.ml))
-  (enabled_if (<> %{os_type} "Win32")))
-(rule
-  (action (copy unix_win32.ml unix.ml))
-  (enabled_if (= %{os_type} "Win32")))
-
-(rule
  (action (copy accept_unix.c accept.c))
  (enabled_if (<> %{os_type} "Win32")))
 (rule (action (copy bind_unix.c bind.c)) (enabled_if (<> %{os_type} "Win32")))

--- a/stdlib/gc.ml
+++ b/stdlib/gc.ml
@@ -109,7 +109,7 @@ type alarm_rec = {active : alarm; f : unit -> unit}
 let rec call_alarm arec =
   if Atomic.get arec.active then begin
     let finally () = finalise call_alarm arec in
-    Fun.protect arec.f ~finally
+    Fun.protect ~finally arec.f
   end
 
 

--- a/utils/dune
+++ b/utils/dune
@@ -15,12 +15,10 @@
 (rule
  (targets config.ml)
  (mode    fallback)
- (deps    (:mk Makefile)
-          ../Makefile.config
-          ; for now the utils Makefile does not use build_config
-          config.mlp
-          config.common.ml)
- (action  (system "make -f %{mk} %{targets}")))
+ (deps    config.generated.ml config.common.ml)
+ (action
+   (with-stdout-to %{targets}
+     (system "cat %{deps}"))))
 
 (rule
  (targets domainstate.ml)


### PR DESCRIPTION
This needed removing some targets, avoiding calling make, and a small fix to deal with a mismatch between dune and the make-based build system with the use of -no-labels