### PR TITLE
Suggest using xor to clear lsb of encoded naked pointers in manual

### DIFF
--- a/manual/src/cmds/intf-c.etex
+++ b/manual/src/cmds/intf-c.etex
@@ -517,7 +517,7 @@ static value val_of_typtr(ty * p)
 /* Extract the pointer encapsulated in the given OCaml value */
 static ty * typtr_of_val(value v)
 {
-  return (ty *) (v & ~1);
+  return (ty *) (v ^ 1);
 }
 \end{verbatim}
 


### PR DESCRIPTION
`v & ~1` and `v ^ 1` are equivalent (under the assumption that `v` is at least 2-byte aligned) but the constant resulting from `~1` is large and has a long encoding in generated code. Therefore it seems better to prefer the implementation using xor as the suggested decoding operation.