### PR TITLE
Fix lintapidiff and add some @since annotations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ _ocamltestd
 .merlin
 _build
 META
+*.mli_lint
 
 # local to root directory
 

--- a/Makefile
+++ b/Makefile
@@ -1309,7 +1309,7 @@ VERSIONS=$(shell git tag|grep '^[0-9]*.[0-9]*.[0-9]*$$'|grep -v '^[12].')
 .PHONY: lintapidiff
 lintapidiff: tools/lintapidiff.opt$(EXE)
 	git ls-files -- 'otherlibs/*/*.mli' 'stdlib/*.mli' |\
-	    grep -Ev internal\|obj\|stdLabels\|moreLabels |\
+	    grep -Ev internal\|obj\|stdLabels\|moreLabels\|templates |\
 	    tools/lintapidiff.opt $(VERSIONS)
 
 # Tools

--- a/Makefile
+++ b/Makefile
@@ -1307,10 +1307,15 @@ tools/lintapidiff.opt$(EXE): VPATH += otherlibs/str
 
 VERSIONS=$(shell git tag|grep '^[0-9]*.[0-9]*.[0-9]*$$'|grep -v '^[12].')
 .PHONY: lintapidiff
-lintapidiff: tools/lintapidiff.opt$(EXE)
-	git ls-files -- 'otherlibs/*/*.mli' 'stdlib/*.mli' |\
-	    grep -Ev internal\|obj\|stdLabels\|moreLabels\|templates |\
-	    tools/lintapidiff.opt $(VERSIONS)
+
+%.mli_lint: %.mli tools/lintapidiff.opt$(EXE)
+	echo $< | tools/lintapidiff.opt$(EXE) $(VERSIONS)
+	touch $@
+
+MLI_NOTLINT=stdlib/stdLabels.mli stdlib/moreLabels.mli stdlib/obj.mli $(wildcard stdlib/*internal*.mli)
+MLI_TO_LINT=$(wildcard otherslibs/*/*.mli)
+MLI_TO_LINT+=$(filter-out $(MLI_NOTLINT), $(wildcard stdlib/*.mli))
+lintapidiff: $(MLI_TO_LINT:.mli=.mli_lint)
 
 # Tools
 

--- a/otherlibs/dynlink/dynlink.mli
+++ b/otherlibs/dynlink/dynlink.mli
@@ -85,7 +85,10 @@ val set_allowed_units : string list -> unit
     dynamically-linked code, and prevent access to all other units,
     e.g. private, internal modules of the running program.
 
-    Note that {!loadfile} changes the allowed-units list. *)
+    Note that {!loadfile} changes the allowed-units list.
+
+    @since 4.8
+    *)
 
 val allow_only: string list -> unit
 (** [allow_only units] sets the list of allowed units to be the intersection
@@ -100,17 +103,26 @@ val prohibit : string list -> unit
 
 val main_program_units : unit -> string list
 (** Return the list of compilation units that form the main program (i.e.
-    are not dynamically linked). *)
+    are not dynamically linked).
+
+    @since 4.8
+    *)
 
 val public_dynamically_loaded_units : unit -> string list
 (** Return the list of compilation units that have been dynamically loaded via
     [loadfile] (and not via [loadfile_private]).  Note that compilation units
-    loaded dynamically cannot be unloaded. *)
+    loaded dynamically cannot be unloaded.
+
+    @since 4.8
+    *)
 
 val all_units : unit -> string list
 (** Return the list of compilation units that form the main program together
     with those that have been dynamically loaded via [loadfile] (and not via
-    [loadfile_private]). *)
+    [loadfile_private]).
+
+    @since 4.8
+    *)
 
 val allow_unsafe_modules : bool -> unit
 (** Govern whether unsafe object files are allowed to be
@@ -170,4 +182,6 @@ val unsafe_get_global_value : bytecode_or_asm_symbol:string -> Obj.t option
     ([update_global_table] and [assign_global_value], accessed through a
     client's version of [Symtable]). This is why we can't use [Dynlink] from the
     toplevel interactive loop, in particular.
-*)
+
+    @since 4.9
+    *)

--- a/otherlibs/dynlink/dynlink_types.mli
+++ b/otherlibs/dynlink/dynlink_types.mli
@@ -15,7 +15,10 @@
 (*                                                                        *)
 (**************************************************************************)
 
-(** Types shared amongst the various parts of the dynlink code. *)
+(** Types shared amongst the various parts of the dynlink code.
+
+    @since 4.8
+    *)
 
 [@@@ocaml.warning "+a-4-30-40-41-42"]
 

--- a/otherlibs/runtime_events/runtime_events.mli
+++ b/otherlibs/runtime_events/runtime_events.mli
@@ -44,7 +44,9 @@
   - OCAML_RUNTIME_EVENTS_PRESERVE if set will prevent the OCaml runtime from
     removing its ring buffers when it terminates. This can help if monitoring
     very short running programs.
-*)
+
+    @since 5.0
+    *)
 
 (** The type for counter events emitted by the runtime *)
 type runtime_counter =
@@ -163,18 +165,31 @@ end
 
 module Type : sig
   type 'a t
-  (** The type for a user event content type *)
+  (** The type for a user event content type
+
+      @since 5.1
+  *)
 
   val unit : unit t
-  (** An event that has no data associated with it *)
+  (** An event that has no data associated with it
 
+      @since 5.1
+  *)
+
+  (** @since 5.1 *)
   type span = Begin | End
 
   val span : span t
-  (** An event that has a beginning and an end *)
+  (** An event that has a beginning and an end
+
+      @since 5.1
+  *)
 
   val int : int t
-  (** An event containing an integer value *)
+  (** An event containing an integer value
+
+      @since 5.1
+  *)
 
   val register : encode:(bytes -> 'a -> int) -> decode:(bytes -> int -> 'a)
                                                                         -> 'a t
@@ -183,7 +198,10 @@ module Type : sig
       written. The decoder gets a slice of the buffer of specified length, and
       returns the decoded value.
 
-      The maximum value length is 1024 bytes. *)
+      The maximum value length is 1024 bytes.
+
+      @since 5.1
+  *)
 end
 
 module User : sig
@@ -193,26 +211,44 @@ module User : sig
 
   type tag = ..
   (** The type for a user event tag. Tags are used to discriminate between
-      user events of the same type *)
+      user events of the same type
+
+      @since 5.1
+  *)
 
   type 'value t
   (** The type for a user event. User events describe their tag, carried data
-      type and an unique string-based name *)
+      type and an unique string-based name
+
+      @since 5.1
+  *)
 
   val register : string -> tag -> 'value Type.t -> 'value t
   (** [register name tag ty] registers a new event with an unique [name],
-      carrying a [tag] and values of type [ty] *)
+      carrying a [tag] and values of type [ty]
+
+      @since 5.1
+  *)
 
   val write : 'value t -> 'value -> unit
-  (** [write t v] records a new event [t] with value [v] *)
+  (** [write t v] records a new event [t] with value [v]
+
+      @since 5.1
+  *)
 
   val name : _ t -> string
-  (** [name t] is the uniquely identifying name of event [t] *)
+  (** [name t] is the uniquely identifying name of event [t]
+
+      @since 5.1
+  *)
 
   val tag : 'a t -> tag
   (** [tag t] is the associated tag of event [t], when it is known.
       An event can be unknown if it was not registered in the consumer
-      program. *)
+      program.
+
+      @since 5.1
+  *)
 
 end
 
@@ -250,7 +286,10 @@ module Callbacks : sig
                         t -> t
   (** [add_user_event ty callback t] extends [t] to additionally subscribe to
       user events of type [ty]. When such an event happens, [callback] is called
-      with the corresponding event and payload. *)
+      with the corresponding event and payload.
+
+      @since 5.1
+  *)
 end
 
 val start : unit -> unit

--- a/stdlib/array.mli
+++ b/stdlib/array.mli
@@ -28,7 +28,7 @@
 *)
 
 type 'a t = 'a array
-(** An alias for the type of arrays. *)
+(** An alias for the type of arrays. @since 4.08 *)
 
 external length : 'a array -> int = "%array_length"
 (** Return the length (number of elements) of the given array. *)

--- a/stdlib/arrayLabels.mli
+++ b/stdlib/arrayLabels.mli
@@ -28,7 +28,7 @@
 *)
 
 type 'a t = 'a array
-(** An alias for the type of arrays. *)
+(** An alias for the type of arrays. @since 4.08 *)
 
 external length : 'a array -> int = "%array_length"
 (** Return the length (number of elements) of the given array. *)

--- a/stdlib/ephemeron.mli
+++ b/stdlib/ephemeron.mli
@@ -84,24 +84,56 @@ module type S = sig
       can run between the two.
   *)
 
-  type key
+  type key (** @since 4.14.0 *)
+
   type !'a t
   val create : int -> 'a t
+  (** @since 4.14.0 *)
+
   val clear : 'a t -> unit
+  (** @since 4.14.0 *)
+
   val reset : 'a t -> unit
+  (** @since 4.14.0 *)
+
   val copy : 'a t -> 'a t
+  (** @since 4.14.0 *)
+
   val add : 'a t -> key -> 'a -> unit
+  (** @since 4.14.0 *)
+
   val remove : 'a t -> key -> unit
+  (** @since 4.14.0 *)
+
   val find : 'a t -> key -> 'a
+  (** @since 4.14.0 *)
+
   val find_opt : 'a t -> key -> 'a option
+  (** @since 4.14.0 *)
+
   val find_all : 'a t -> key -> 'a list
+  (** @since 4.14.0 *)
+
   val replace : 'a t -> key -> 'a -> unit
+  (** @since 4.14.0 *)
+
   val mem : 'a t -> key -> bool
+  (** @since 4.14.0 *)
+
   val length : 'a t -> int
+  (** @since 4.14.0 *)
+
   val stats : 'a t -> Hashtbl.statistics
+  (** @since 4.14.0 *)
+
   val add_seq : 'a t -> (key * 'a) Seq.t -> unit
+  (** @since 4.14.0 *)
+
   val replace_seq : 'a t -> (key * 'a) Seq.t -> unit
+  (** @since 4.14.0 *)
+
   val of_seq : (key * 'a) Seq.t -> 'a t
+  (** @since 4.14.0 *)
 
   val clean: 'a t -> unit
   (** remove all dead bindings. Done automatically during automatic resizing. *)
@@ -117,24 +149,56 @@ end
 
 module type SeededS = sig
 
-  type key
+  type key (** @since 4.14.0 *)
+
   type !'a t
   val create : ?random (*thwart tools/sync_stdlib_docs*) : bool -> int -> 'a t
+  (** @since 4.14.0 *)
+
   val clear : 'a t -> unit
+  (** @since 4.14.0 *)
+
   val reset : 'a t -> unit
+  (** @since 4.14.0 *)
+
   val copy : 'a t -> 'a t
+  (** @since 4.14.0 *)
+
   val add : 'a t -> key -> 'a -> unit
+  (** @since 4.14.0 *)
+
   val remove : 'a t -> key -> unit
+  (** @since 4.14.0 *)
+
   val find : 'a t -> key -> 'a
+  (** @since 4.14.0 *)
+
   val find_opt : 'a t -> key -> 'a option
+  (** @since 4.14.0 *)
+
   val find_all : 'a t -> key -> 'a list
+  (** @since 4.14.0 *)
+
   val replace : 'a t -> key -> 'a -> unit
+  (** @since 4.14.0 *)
+
   val mem : 'a t -> key -> bool
+  (** @since 4.14.0 *)
+
   val length : 'a t -> int
+  (** @since 4.14.0 *)
+
   val stats : 'a t -> Hashtbl.statistics
+  (** @since 4.14.0 *)
+
   val add_seq : 'a t -> (key * 'a) Seq.t -> unit
+  (** @since 4.14.0 *)
+
   val replace_seq : 'a t -> (key * 'a) Seq.t -> unit
+  (** @since 4.14.0 *)
+
   val of_seq : (key * 'a) Seq.t -> 'a t
+  (** @since 4.14.0 *)
 
   val clean: 'a t -> unit
   (** remove all dead bindings. Done automatically during automatic resizing. *)
@@ -146,15 +210,18 @@ end
 *)
 
 module K1 : sig
+
   type ('k,'d) t (** an ephemeron with one key *)
 
   val make : 'k -> 'd -> ('k,'d) t
-  (** [Ephemeron.K1.make k d] creates an ephemeron with key [k] and data [d]. *)
+  (** [Ephemeron.K1.make k d] creates an ephemeron with key [k] and data [d].
+      @since 4.14.0 *)
 
   val query : ('k,'d) t -> 'k -> 'd option
   (** [Ephemeron.K1.query eph key] returns [Some x] (where [x] is the
       ephemeron's data) if [key] is physically equal to [eph]'s key, and
-      [None] if [eph] is empty or [key] is not equal to [eph]'s key. *)
+      [None] if [eph] is empty or [key] is not equal to [eph]'s key.
+      @since 4.14.0 *)
 
   module Make (H:Hashtbl.HashedType) : S with type key = H.t
   (** Functor building an implementation of a weak hash table *)
@@ -163,6 +230,7 @@ module K1 : sig
   (** Functor building an implementation of a weak hash table.
       The seed is similar to the one of {!Hashtbl.MakeSeeded}. *)
 
+  (** @since 4.14.0 *)
   module Bucket : sig
 
     type ('k, 'd) t
@@ -198,10 +266,10 @@ module K2 : sig
   type ('k1,'k2,'d) t (** an ephemeron with two keys *)
 
   val make : 'k1 -> 'k2 -> 'd -> ('k1,'k2,'d) t
-  (** Same as {!Ephemeron.K1.make} *)
+  (** Same as {!Ephemeron.K1.make}. @since 4.14.0 *)
 
   val query : ('k1,'k2,'d) t -> 'k1 -> 'k2 -> 'd option
-  (** Same as {!Ephemeron.K1.query} *)
+  (** Same as {!Ephemeron.K1.query}. @since 4.14.0 *)
 
   module Make
       (H1:Hashtbl.HashedType)
@@ -216,6 +284,7 @@ module K2 : sig
   (** Functor building an implementation of a weak hash table.
       The seed is similar to the one of {!Hashtbl.MakeSeeded}. *)
 
+  (** @since 4.14.0 *)
   module Bucket : sig
 
     type ('k1, 'k2, 'd) t
@@ -252,10 +321,10 @@ module Kn : sig
                       of the same type *)
 
   val make : 'k array -> 'd -> ('k,'d) t
-  (** Same as {!Ephemeron.K1.make} *)
+  (** Same as {!Ephemeron.K1.make}. @since 4.14.0 *)
 
   val query : ('k,'d) t -> 'k array -> 'd option
-  (** Same as {!Ephemeron.K1.query} *)
+  (** Same as {!Ephemeron.K1.query}. @since 4.14.0 *)
 
   module Make
       (H:Hashtbl.HashedType) :
@@ -268,6 +337,7 @@ module Kn : sig
   (** Functor building an implementation of a weak hash table.
       The seed is similar to the one of {!Hashtbl.MakeSeeded}. *)
 
+  (** @since 4.14.0 *)
   module Bucket : sig
 
     type ('k, 'd) t

--- a/stdlib/float.mli
+++ b/stdlib/float.mli
@@ -498,9 +498,10 @@ val hash : t -> int
     to the functor {!Hashtbl.Make}. *)
 
 module Array : sig
+  (** @since 4.12 *)
+
   type t = floatarray
   (** The type of float arrays with packed representation.
-      @since 4.08
     *)
 
   val length : t -> int
@@ -657,7 +658,7 @@ module Array : sig
   (** {2 Array searching} *)
 
   val find_opt : (float -> bool) -> t -> float option
-  (* [find_opt f a] returns the first element of the array [a] that satisfies
+  (** [find_opt f a] returns the first element of the array [a] that satisfies
      the predicate [f]. Returns [None] if there is no value that satisfies [f]
      in the array [a].
      @since 5.1 *)
@@ -671,7 +672,7 @@ module Array : sig
       @since 5.1 *)
 
   val find_map : (float -> 'a option) -> t -> 'a option
-  (* [find_map f a] applies [f] to the elements of [a] in order, and returns
+  (** [find_map f a] applies [f] to the elements of [a] in order, and returns
      the first result of the form [Some v], or [None] if none exist.
      @since 5.1 *)
 
@@ -832,9 +833,10 @@ end
 (** Float arrays with packed representation. *)
 
 module ArrayLabels : sig
+  (** @since 4.12 *)
+
   type t = floatarray
   (** The type of float arrays with packed representation.
-      @since 4.08
     *)
 
   val length : t -> int
@@ -991,7 +993,7 @@ module ArrayLabels : sig
   (** {2 Array searching} *)
 
   val find_opt : f:(float -> bool) -> t -> float option
-  (* [find_opt ~f a] returns the first element of the array [a] that satisfies
+  (** [find_opt ~f a] returns the first element of the array [a] that satisfies
      the predicate [f]. Returns [None] if there is no value that satisfies [f]
      in the array [a].
      @since 5.1 *)
@@ -1005,7 +1007,7 @@ module ArrayLabels : sig
       @since 5.1 *)
 
   val find_map : f:(float -> 'a option) -> t -> 'a option
-  (* [find_map ~f a] applies [f] to the elements of [a] in order, and returns
+  (** [find_map ~f a] applies [f] to the elements of [a] in order, and returns
      the first result of the form [Some v], or [None] if none exist.
      @since 5.1 *)
 

--- a/stdlib/hashtbl.mli
+++ b/stdlib/hashtbl.mli
@@ -439,7 +439,10 @@ module type SeededHashedType =
           the seed.  It must be the case that if [equal x y] is true,
           then [seeded_hash seed x = seeded_hash seed y] for any value of
           [seed].  A suitable choice for [seeded_hash] is the function
-          {!Hashtbl.seeded_hash} below. *)
+          {!Hashtbl.seeded_hash} below.
+
+        @since 5.00
+        *)
   end
 (** The input signature of the functor {!MakeSeeded}.
     @since 4.00 *)

--- a/stdlib/lexing.mli
+++ b/stdlib/lexing.mli
@@ -127,6 +127,8 @@ val with_positions : lexbuf -> bool
     When [with_positions] is [false], lexer actions should not
     modify position fields.  Doing it nevertheless could
     re-enable the [with_position] mode and degrade performances.
+
+    @since 4.08.0
 *)
 
 

--- a/stdlib/moreLabels.mli
+++ b/stdlib/moreLabels.mli
@@ -458,7 +458,10 @@ module Hashtbl : sig
             the seed.  It must be the case that if [equal x y] is true,
             then [seeded_hash seed x = seeded_hash seed y] for any value of
             [seed].  A suitable choice for [seeded_hash] is the function
-            {!Hashtbl.seeded_hash} below. *)
+            {!Hashtbl.seeded_hash} below.
+
+          @since 5.00
+          *)
     end
   (** The input signature of the functor {!MakeSeeded}.
       @since 4.00 *)

--- a/stdlib/stdlib.mli
+++ b/stdlib/stdlib.mli
@@ -1316,6 +1316,7 @@ type ('a,'b) result = Ok of 'a | Error of 'b
 
 type ('a, 'b, 'c, 'd, 'e, 'f) format6 =
   ('a, 'b, 'c, 'd, 'e, 'f) CamlinternalFormatBasics.format6
+(** @since 4.02.0 *)
 
 type ('a, 'b, 'c, 'd) format4 = ('a, 'b, 'c, 'c, 'c, 'd) format6
 

--- a/stdlib/sys.mli
+++ b/stdlib/sys.mli
@@ -413,14 +413,14 @@ external opaque_identity : 'a -> 'a = "%opaque"
     @since 4.03
 *)
 
-module Immediate64 : sig
-  (** This module allows to define a type [t] with the [immediate64]
-      attribute. This attribute means that the type is immediate on 64
-      bit architectures. On other architectures, it might or might not
-      be immediate.
+(** This module allows to define a type [t] with the [immediate64]
+  attribute. This attribute means that the type is immediate on 64
+  bit architectures. On other architectures, it might or might not
+  be immediate.
 
-      @since 4.10
-  *)
+  @since 4.10
+*)
+module Immediate64 : sig
 
   module type Non_immediate = sig
     type t

--- a/stdlib/templates/floatarraylabeled.template.mli
+++ b/stdlib/templates/floatarraylabeled.template.mli
@@ -173,7 +173,7 @@ val mem_ieee : float -> set:t -> bool
 (** {2 Array searching} *)
 
 val find_opt : f:(float -> bool) -> t -> float option
-(* [find_opt ~f a] returns the first element of the array [a] that satisfies
+(** [find_opt ~f a] returns the first element of the array [a] that satisfies
    the predicate [f]. Returns [None] if there is no value that satisfies [f]
    in the array [a].
    @since 5.1 *)
@@ -187,7 +187,7 @@ val find_index : f:(float-> bool) -> t -> int option
     @since 5.1 *)
 
 val find_map : f:(float -> 'a option) -> t -> 'a option
-(* [find_map ~f a] applies [f] to the elements of [a] in order, and returns
+(** [find_map ~f a] applies [f] to the elements of [a] in order, and returns
    the first result of the form [Some v], or [None] if none exist.
    @since 5.1 *)
 

--- a/stdlib/templates/hashtbl.template.mli
+++ b/stdlib/templates/hashtbl.template.mli
@@ -439,7 +439,10 @@ module type SeededHashedType =
           the seed.  It must be the case that if [equal x y] is true,
           then [seeded_hash seed x = seeded_hash seed y] for any value of
           [seed].  A suitable choice for [seeded_hash] is the function
-          {!Hashtbl.seeded_hash} below. *)
+          {!Hashtbl.seeded_hash} below.
+
+        @since 5.00
+        *)
   end
 (** The input signature of the functor {!MakeSeeded}.
     @since 4.00 *)

--- a/stdlib/uchar.mli
+++ b/stdlib/uchar.mli
@@ -98,44 +98,58 @@ val compare : t -> t -> int
 val hash : t -> int
 (** [hash u] associates a non-negative integer to [u]. *)
 
-(** {1:utf UTF codecs tools}
-
-    @since 4.14 *)
+(** {1:utf UTF codecs tools} *)
 
 type utf_decode [@@immediate]
 (** The type for UTF decode results. Values of this type represent
-    the result of a Unicode Transformation Format decoding attempt. *)
+    the result of a Unicode Transformation Format decoding attempt.
+
+    @since 4.14 *)
 
 val utf_decode_is_valid : utf_decode -> bool
 (** [utf_decode_is_valid d] is [true] if and only if [d] holds a valid
-    decode. *)
+    decode.
+
+    @since 4.14 *)
 
 val utf_decode_uchar : utf_decode -> t
 (** [utf_decode_uchar d] is the Unicode character decoded by [d] if
-    [utf_decode_is_valid d] is [true] and {!Uchar.rep} otherwise. *)
+    [utf_decode_is_valid d] is [true] and {!Uchar.rep} otherwise.
+
+    @since 4.14 *)
 
 val utf_decode_length : utf_decode -> int
 (** [utf_decode_length d] is the number of elements from the source
     that were consumed by the decode [d]. This is always strictly
     positive and smaller or equal to [4]. The kind of source elements
     depends on the actual decoder; for the decoders of the standard
-    library this function always returns a length in bytes. *)
+    library this function always returns a length in bytes.
+
+    @since 4.14 *)
 
 val utf_decode : int -> t -> utf_decode
 (** [utf_decode n u] is a valid UTF decode for [u] that consumed [n]
     elements from the source for decoding. [n] must be positive and
-    smaller or equal to [4] (this is not checked by the module). *)
+    smaller or equal to [4] (this is not checked by the module).
+
+    @since 4.14 *)
 
 val utf_decode_invalid : int -> utf_decode
 (** [utf_decode_invalid n] is an invalid UTF decode that consumed [n]
     elements from the source to error. [n] must be positive and
     smaller or equal to [4] (this is not checked by the module). The
-    resulting decode has {!rep} as the decoded Unicode character. *)
+    resulting decode has {!rep} as the decoded Unicode character.
+
+    @since 4.14 *)
 
 val utf_8_byte_length : t -> int
 (** [utf_8_byte_length u] is the number of bytes needed to encode
-    [u] in UTF-8. *)
+    [u] in UTF-8.
+
+    @since 4.14 *)
 
 val utf_16_byte_length : t -> int
 (** [utf_16_byte_length u] is the number of bytes needed to encode
-    [u] in UTF-16. *)
+    [u] in UTF-16.
+
+    @since 4.14 *)

--- a/tools/lintapidiff.ml
+++ b/tools/lintapidiff.ml
@@ -265,7 +265,7 @@ module Diff = struct
           if s.Doc.deprecated then
             Format.fprintf ppf "@,%s is marked as deprecated" k
     in
-    Location.errorf ~loc "@[%s %s@,%a@,%a@]" msg k
+    Location.errorf ~loc "@[<v>%s %s@,%a@,%a@]" msg k
       info_seen seen info_latest latest |>
     Location.print_report Format.err_formatter
 

--- a/tools/lintapidiff.ml
+++ b/tools/lintapidiff.ml
@@ -77,7 +77,10 @@ module Doc = struct
   let empty = {since = None; deprecated=false; loc=Location.none;
                has_doc_parent=false;has_doc=false}
 
-  let since = Str.regexp "\\(.\\|\n\\)*@since +\\([^ ]+\\).*"
+  (* only match @since that contains version number and nothing else,
+     @since can also be used for semantic changes with a comment
+   *)
+  let since = Str.regexp "\\(.\\|\n\\)*@since +\\([^ ]+\\) *$"
 
   let find_attr lst attrs =
     try Some (List.find (fun attr -> List.mem attr.attr_name.txt lst) attrs)

--- a/tools/lintapidiff.ml
+++ b/tools/lintapidiff.ml
@@ -306,6 +306,11 @@ module Diff = struct
     let git_show_result = match Git.with_show ~f rev path with
         | Error File_not_found when path = "stdlib/stdlib.mli" ->
             Git.with_show ~f rev "stdlib/pervasives.mli"
+        | Error File_not_found when path = "stdlib/bigarray.mli" ->
+            Git.with_show ~f rev "otherlibs/bigarray/bigarray.mli"
+        | Error File_not_found when Filename.dirname path = "stdlib" ->
+            Filename.concat "otherlibs/systhreads" (Filename.basename path)
+            |> Git.with_show ~f rev
         | r -> r
     in
     let map = match git_show_result with


### PR DESCRIPTION
Started as part of https://github.com/tarides/compiler-hacking/wiki/Restore-lintapidiff
Also had some help from @Rokcas to fix the `otherlibs` docs during the compiler hacking session (see the last 2 commits).

'lintapidiff' has bitrotten, this teaches it about some of the changes (modules renamed, special handling for Pervasives vs Stdlib, etc.).

There were also some small bugs in existing docs:
* `(* *)` insteadof `(** *)`
* Sys.Immediate64 `@since` was present but not rendered, at first I thought my tool was wrong, but since ocamldoc didn't render it either, moved the doc comment.

This is not quite ready (there are more stdlib docs to fix up, and potentially to improve the tool, in particular the handling of `(**/**)` isn't quite correct yet. However opening this PR just so that someone else doesn't end up needlessly duplicating this part of the work.
