### PR TITLE
flush stderr when tracing the parser

### DIFF
--- a/Changes
+++ b/Changes
@@ -594,6 +594,9 @@ Working version
   types.
   (Chris Casinghino, review by Gabriel Scherer)
 
+- #12046: Flush stderr when tracing the parser
+  (Hugo Heuzard, review by David Allsopp and Nicolás Ojeda Bär)
+
 OCaml 5.0.0 (15 December 2022)
 ------------------------------
 

--- a/runtime/parsing.c
+++ b/runtime/parsing.c
@@ -135,6 +135,7 @@ static void print_token(struct parser_tables *tables, int state, value tok)
       fprintf(stderr, "_");
     fprintf(stderr, ")\n");
   }
+  fflush(stderr);
 }
 
 static int trace(void)
@@ -205,16 +206,20 @@ CAMLprim value caml_parse_engine(struct parser_tables *tables,
         n2 = n1 + ERRCODE;
         if (n1 != 0 && n2 >= 0 && n2 <= Int_val(tables->tablesize) &&
             Short(tables->check, n2) == ERRCODE) {
-          if (trace())
+          if (trace()){
             fprintf(stderr, "Recovering in state %d\n", state1);
+            fflush(stderr);
+          }
           goto shift_recover;
         } else {
           if (trace()){
             fprintf(stderr, "Discarding state %d\n", state1);
+            fflush(stderr);
           }
           if (sp <= Int_val(env->stackbase)) {
             if (trace()){
               fprintf(stderr, "No more states to discard\n");
+              fflush(stderr);
             }
             return RAISE_PARSE_ERROR; /* The ML code raises Parse_error */
           }
@@ -224,7 +229,10 @@ CAMLprim value caml_parse_engine(struct parser_tables *tables,
     } else {
       if (Int_val(env->curr_char) == 0)
         return RAISE_PARSE_ERROR; /* The ML code raises Parse_error */
-      if (trace()) fprintf(stderr, "Discarding last token read\n");
+      if (trace()){
+        fprintf(stderr, "Discarding last token read\n");
+        fflush(stderr);
+      }
       env->curr_char = Val_int(-1);
       goto loop;
     }
@@ -233,9 +241,11 @@ CAMLprim value caml_parse_engine(struct parser_tables *tables,
     env->curr_char = Val_int(-1);
     if (errflag > 0) errflag--;
   shift_recover:
-    if (trace())
+    if (trace()){
       fprintf(stderr, "State %d: shift to state %d\n",
               state, Short(tables->table, n2));
+      fflush(stderr);
+    }
     state = Short(tables->table, n2);
     sp++;
     if (sp < Long_val(env->stacksize)) goto push;
@@ -252,8 +262,10 @@ CAMLprim value caml_parse_engine(struct parser_tables *tables,
     goto loop;
 
   reduce:
-    if (trace())
+    if (trace()){
       fprintf(stderr, "State %d: reduce by rule %d\n", state, n);
+      fflush(stderr);
+    }
     m = Short(tables->len, n);
     env->asp = Val_int(sp);
     env->rule_number = Val_int(n);

--- a/runtime/parsing.c
+++ b/runtime/parsing.c
@@ -143,6 +143,18 @@ static int trace(void)
   return caml_params->parser_trace || Caml_state->parser_trace;
 }
 
+void print_trace (const char *template, ...){
+  va_list ap;
+  if(trace()) {
+     va_start (ap, template);
+     vfprintf (stderr, template, ap);
+     va_end (ap);
+     /* Windows seem to sometimes perform buffering on stderr. Better
+        to flush explicitly. */
+     fflush(stderr);
+  }
+}
+
 /* The pushdown automata */
 
 CAMLprim value caml_parse_engine(struct parser_tables *tables,
@@ -206,21 +218,12 @@ CAMLprim value caml_parse_engine(struct parser_tables *tables,
         n2 = n1 + ERRCODE;
         if (n1 != 0 && n2 >= 0 && n2 <= Int_val(tables->tablesize) &&
             Short(tables->check, n2) == ERRCODE) {
-          if (trace()){
-            fprintf(stderr, "Recovering in state %d\n", state1);
-            fflush(stderr);
-          }
+          print_trace("Recovering in state %d\n", state1);
           goto shift_recover;
         } else {
-          if (trace()){
-            fprintf(stderr, "Discarding state %d\n", state1);
-            fflush(stderr);
-          }
+          print_trace("Discarding state %d\n", state1);
           if (sp <= Int_val(env->stackbase)) {
-            if (trace()){
-              fprintf(stderr, "No more states to discard\n");
-              fflush(stderr);
-            }
+            print_trace("No more states to discard\n");
             return RAISE_PARSE_ERROR; /* The ML code raises Parse_error */
           }
           sp--;
@@ -229,10 +232,7 @@ CAMLprim value caml_parse_engine(struct parser_tables *tables,
     } else {
       if (Int_val(env->curr_char) == 0)
         return RAISE_PARSE_ERROR; /* The ML code raises Parse_error */
-      if (trace()){
-        fprintf(stderr, "Discarding last token read\n");
-        fflush(stderr);
-      }
+      print_trace("Discarding last token read\n");
       env->curr_char = Val_int(-1);
       goto loop;
     }
@@ -241,11 +241,8 @@ CAMLprim value caml_parse_engine(struct parser_tables *tables,
     env->curr_char = Val_int(-1);
     if (errflag > 0) errflag--;
   shift_recover:
-    if (trace()){
-      fprintf(stderr, "State %d: shift to state %d\n",
-              state, Short(tables->table, n2));
-      fflush(stderr);
-    }
+    print_trace("State %d: shift to state %d\n",
+                state, Short(tables->table, n2));
     state = Short(tables->table, n2);
     sp++;
     if (sp < Long_val(env->stacksize)) goto push;
@@ -262,10 +259,7 @@ CAMLprim value caml_parse_engine(struct parser_tables *tables,
     goto loop;
 
   reduce:
-    if (trace()){
-      fprintf(stderr, "State %d: reduce by rule %d\n", state, n);
-      fflush(stderr);
-    }
+    print_trace("State %d: reduce by rule %d\n", state, n);
     m = Short(tables->len, n);
     env->asp = Val_int(sp);
     env->rule_number = Val_int(n);

--- a/runtime/parsing.c
+++ b/runtime/parsing.c
@@ -143,7 +143,7 @@ static int trace(void)
   return caml_params->parser_trace || Caml_state->parser_trace;
 }
 
-void print_trace (const char *template, ...){
+static void print_trace (const char *template, ...){
   va_list ap;
   if(trace()) {
      va_start (ap, template);


### PR DESCRIPTION
Make sure to flush stderr when tracing the parser. 
This issue caused me some pain while trying to capture the trace inside an expect test.

see https://github.com/ocsigen/js_of_ocaml/pull/1308 and https://github.com/janestreet/ppx_expect/issues/43