### PR TITLE
Fix #12038, assert false on overriding multiple absent methods

### DIFF
--- a/Changes
+++ b/Changes
@@ -594,6 +594,10 @@ Working version
   types.
   (Chris Casinghino, review by Gabriel Scherer)
 
+- #12038, #12049: When inheriting from multiple bases with the same absent
+  method,  don't `assert false` when the method is overridden.
+  (Stefan Muenzel, review by ????)
+
 OCaml 5.0.0 (15 December 2022)
 ------------------------------
 

--- a/testsuite/tests/typing-objects-bugs/pr12038.ml
+++ b/testsuite/tests/typing-objects-bugs/pr12038.ml
@@ -23,6 +23,18 @@ Line 5, characters 16-22:
 5 |   method q () = self#z ()
                     ^^^^^^
 Warning 17 [undeclared-virtual-method]: the virtual method z is not declared.
-Uncaught exception: File "typing/ctype.ml", line 3433, characters 29-35: Assertion failed
 
+class virtual ['a] x :
+  object ('a)
+    constraint 'a = < q : unit -> unit; .. >
+    method q : unit -> unit
+    method private virtual z : unit -> unit
+  end
+and virtual ['a] x' :
+  object ('a)
+    constraint 'a = < q : unit -> unit; .. >
+    method q : unit -> unit
+    method private virtual z : unit -> unit
+  end
+and y : object method q : unit -> unit method z : unit -> unit end
 |}]

--- a/testsuite/tests/typing-objects-bugs/pr12038.ml
+++ b/testsuite/tests/typing-objects-bugs/pr12038.ml
@@ -1,0 +1,28 @@
+(* TEST
+   * expect
+*)
+class virtual ['self] x = object(self : 'self)
+  method q () = self#z ()
+end
+and virtual ['self] x' = object(self : 'self)
+  method q () = self#z ()
+end
+and y = object(self : 'self)
+  inherit ['self] x
+  inherit ['self] x'
+  method z () = ()
+end
+
+[%%expect{|
+Line 2, characters 16-22:
+2 |   method q () = self#z ()
+                    ^^^^^^
+Warning 17 [undeclared-virtual-method]: the virtual method z is not declared.
+
+Line 5, characters 16-22:
+5 |   method q () = self#z ()
+                    ^^^^^^
+Warning 17 [undeclared-virtual-method]: the virtual method z is not declared.
+Uncaught exception: File "typing/ctype.ml", line 3433, characters 29-35: Assertion failed
+
+|}]

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -3428,9 +3428,8 @@ let add_method env label priv virt ty sign =
             match priv with
             | Public ->
                 begin match field_kind_repr k with
-                | Fpublic -> ()
+                | Fabsent | Fpublic -> ()
                 | Fprivate -> link_kind ~inside:k field_public
-                | Fabsent -> assert false
                 end;
                 Mpublic
             | Private -> priv'


### PR DESCRIPTION
When an absent method that is inherited from two bases is overridden, we previously asserted 'false' when the method was supposed to become public. This PR removes this assertion.

@lpw25: I'm assuming that the method becoming public is okay, but you had indicated in your comment on the original pr (see link in #12038), that you wouldn't expect this case to happen. So maybe I'm missing something from my reasoning?