### PR TITLE
Print the type variable that cannot be generalized

### DIFF
--- a/.depend
+++ b/.depend
@@ -1318,6 +1318,7 @@ typing/typeclass.cmo : \
     typing/path.cmi \
     parsing/parsetree.cmi \
     typing/oprint.cmi \
+    utils/misc.cmi \
     parsing/longident.cmi \
     parsing/location.cmi \
     typing/includeclass.cmi \
@@ -1346,6 +1347,7 @@ typing/typeclass.cmx : \
     typing/path.cmx \
     parsing/parsetree.cmi \
     typing/oprint.cmx \
+    utils/misc.cmx \
     parsing/longident.cmx \
     parsing/location.cmx \
     typing/includeclass.cmx \

--- a/Changes
+++ b/Changes
@@ -462,6 +462,9 @@ Working version
   and `#ct as '_weak1`.
   (Florian Angeletti, suggestion by Stefan Muenzel, review by Gabriel Scherer)
 
+- #12051: Improve the error messages when type variables cannot be generalized
+  (Stefan Muenzel, review by Florian Angeletti)
+
 ### Internal/compiler-libs changes:
 
 - #10512: explain the compilation strategy for switches on constructors

--- a/manual/tests/Makefile
+++ b/manual/tests/Makefile
@@ -25,7 +25,9 @@ check-cross-references: cross-reference-checker
 	  -auxfile $(MANUAL)/texstuff/manual.aux \
 	  $(ROOTDIR)/utils/warnings.ml \
 	  $(ROOTDIR)/driver/main_args.ml \
-	  $(ROOTDIR)/lambda/translmod.ml
+	  $(ROOTDIR)/lambda/translmod.ml \
+	  $(ROOTDIR)/typing/typemod.ml \
+	  $(ROOTDIR)/typing/typeclass.ml
 
 # check that all standard library modules are referenced by the
 # standard library chapter of the manual

--- a/testsuite/tests/typing-modules-bugs/pr6899_first_bad.compilers.reference
+++ b/testsuite/tests/typing-modules-bugs/pr6899_first_bad.compilers.reference
@@ -2,5 +2,5 @@ File "pr6899_first_bad.ml", line 9, characters 4-17:
 9 | let should_reject =
         ^^^^^^^^^^^^^
 Error: The type of this expression, '_weak1 -> '_weak2 -> unit,
-       contains the non-generalizable type variable(s) '_weak2, '_weak1
+       contains the non-generalizable type variable(s): '_weak2, '_weak1.
        (see manual section 6.1.2)

--- a/testsuite/tests/typing-modules-bugs/pr6899_first_bad.compilers.reference
+++ b/testsuite/tests/typing-modules-bugs/pr6899_first_bad.compilers.reference
@@ -2,4 +2,5 @@ File "pr6899_first_bad.ml", line 9, characters 4-17:
 9 | let should_reject =
         ^^^^^^^^^^^^^
 Error: The type of this expression, '_weak1 -> '_weak2 -> unit,
-       contains type variables that cannot be generalized
+       contains the non-generalizable type variable(s) '_weak2, '_weak1
+       (see manual section 6.1.2)

--- a/testsuite/tests/typing-modules-bugs/pr6899_second_bad.compilers.reference
+++ b/testsuite/tests/typing-modules-bugs/pr6899_second_bad.compilers.reference
@@ -2,4 +2,5 @@ File "pr6899_second_bad.ml", line 12, characters 6-9:
 12 |   let bar = wrap ()
            ^^^
 Error: The type of this expression, ([< `Test ] as '_weak1) -> unit,
-       contains type variables that cannot be generalized
+       contains the non-generalizable type variable(s) '_weak1
+       (see manual section 6.1.2)

--- a/testsuite/tests/typing-modules-bugs/pr6899_second_bad.compilers.reference
+++ b/testsuite/tests/typing-modules-bugs/pr6899_second_bad.compilers.reference
@@ -2,5 +2,5 @@ File "pr6899_second_bad.ml", line 12, characters 6-9:
 12 |   let bar = wrap ()
            ^^^
 Error: The type of this expression, ([< `Test ] as '_weak1) -> unit,
-       contains the non-generalizable type variable(s) '_weak1
+       contains the non-generalizable type variable(s): '_weak1.
        (see manual section 6.1.2)

--- a/testsuite/tests/typing-modules/nongen.ml
+++ b/testsuite/tests/typing-modules/nongen.ml
@@ -1,0 +1,22 @@
+(* TEST
+   * expect
+*)
+
+module X = struct
+  let t = ref None
+end
+
+module type X' = module type of X
+[%%expect{|
+module X : sig val t : '_weak1 option ref end
+Line 5, characters 32-33:
+5 | module type X' = module type of X
+                                    ^
+Error: The type of this module, sig val t : '_weak1 option ref end,
+       contains the non-generalizable type variable(s) '_weak1
+       (see manual section 6.1.2)
+Line 2, characters 6-7:
+2 |   let t = ref None
+          ^
+  This item has the non-generalizable type '_weak1 option ref.
+|}]

--- a/testsuite/tests/typing-modules/nongen.ml
+++ b/testsuite/tests/typing-modules/nongen.ml
@@ -13,10 +13,11 @@ Line 5, characters 32-33:
 5 | module type X' = module type of X
                                     ^
 Error: The type of this module, sig val t : '_weak1 option ref end,
-       contains the non-generalizable type variable(s): '_weak1.
+       contains non-generalizable type variable(s).
        (see manual section 6.1.2)
 Line 2, characters 6-7:
 2 |   let t = ref None
           ^
-  This value has the non-generalizable type '_weak1 option ref.
+  The type of this value, '_weak1 option ref,
+  contains the non-generalizable type variable(s) '_weak1.
 |}]

--- a/testsuite/tests/typing-modules/nongen.ml
+++ b/testsuite/tests/typing-modules/nongen.ml
@@ -13,10 +13,10 @@ Line 5, characters 32-33:
 5 | module type X' = module type of X
                                     ^
 Error: The type of this module, sig val t : '_weak1 option ref end,
-       contains the non-generalizable type variable(s) '_weak1
+       contains the non-generalizable type variable(s): '_weak1.
        (see manual section 6.1.2)
 Line 2, characters 6-7:
 2 |   let t = ref None
           ^
-  This item has the non-generalizable type '_weak1 option ref.
+  This value has the non-generalizable type '_weak1 option ref.
 |}]

--- a/testsuite/tests/typing-objects/Tests.ml
+++ b/testsuite/tests/typing-objects/Tests.ml
@@ -185,7 +185,7 @@ Lines 1-3, characters 0-3:
 Error: The type of this class,
        class ['a] c :
          unit -> object constraint 'a = '_weak1 list ref method f : 'a end,
-       contains the non-generalizable type variable(s) '_weak1
+       contains the non-generalizable type variable(s): '_weak1.
        (see manual section 6.1.2)
 |}];;
 

--- a/testsuite/tests/typing-objects/Tests.ml
+++ b/testsuite/tests/typing-objects/Tests.ml
@@ -185,7 +185,8 @@ Lines 1-3, characters 0-3:
 Error: The type of this class,
        class ['a] c :
          unit -> object constraint 'a = '_weak1 list ref method f : 'a end,
-       contains type variables that cannot be generalized
+       contains the non-generalizable type variable(s) '_weak1
+       (see manual section 6.1.2)
 |}];;
 
 (* Abbreviations *)

--- a/testsuite/tests/typing-objects/nongen.ml
+++ b/testsuite/tests/typing-objects/nongen.ml
@@ -18,6 +18,6 @@ Lines 3-6, characters 0-3:
 6 | end
 Error: The type of this class,
        class test : object method b : '_weak1 -> unit end,
-       contains the non-generalizable type variable(s) '_weak1
+       contains the non-generalizable type variable(s): '_weak1.
        (see manual section 6.1.2)
 |}]

--- a/testsuite/tests/typing-objects/nongen.ml
+++ b/testsuite/tests/typing-objects/nongen.ml
@@ -1,0 +1,23 @@
+(* TEST
+   * expect
+*)
+
+let x = ref None
+
+class test =
+object
+  method b v = x := Some v
+end
+
+[%%expect{|
+val x : '_weak1 option ref = {contents = None}
+Lines 3-6, characters 0-3:
+3 | class test =
+4 | object
+5 |   method b v = x := Some v
+6 | end
+Error: The type of this class,
+       class test : object method b : '_weak1 -> unit end,
+       contains the non-generalizable type variable(s) '_weak1
+       (see manual section 6.1.2)
+|}]

--- a/testsuite/tests/typing-poly/poly.ml
+++ b/testsuite/tests/typing-poly/poly.ml
@@ -1821,7 +1821,8 @@ Line 1, characters 0-63:
 Error: The type of this class,
        class ['a] r :
          object constraint 'a = '_weak2 list ref method get : 'a end,
-       contains type variables that cannot be generalized
+       contains the non-generalizable type variable(s) '_weak2
+       (see manual section 6.1.2)
 |}]
 
 (* #8701 *)

--- a/testsuite/tests/typing-poly/poly.ml
+++ b/testsuite/tests/typing-poly/poly.ml
@@ -1821,7 +1821,7 @@ Line 1, characters 0-63:
 Error: The type of this class,
        class ['a] r :
          object constraint 'a = '_weak2 list ref method get : 'a end,
-       contains the non-generalizable type variable(s) '_weak2
+       contains the non-generalizable type variable(s): '_weak2.
        (see manual section 6.1.2)
 |}]
 

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -5038,69 +5038,108 @@ let rec arity ty =
   | _ -> 0
 
 (* Check for non-generalizable type variables *)
-exception Nongen
-let visited = ref TypeSet.empty
+let add_nongen_vars_in_schema =
+  let rec loop env ((visited, weak_set) as acc) ty =
+    if TypeSet.mem ty visited
+    then acc
+    else begin
+      let visited = TypeSet.add ty visited in
+      match get_desc ty with
+      | Tvar _ when get_level ty <> generic_level ->
+          visited, TypeSet.add ty weak_set
+      | Tconstr _ ->
+          let (_, unexpanded_candidate) as unexpanded_candidate' =
+            fold_type_expr
+              (loop env)
+              (visited, weak_set)
+              ty
+          in
+          (* Using `==` is okay because `loop` will return the original set
+             when it does not change it. Similarly, `TypeSet.add` will return
+             the original set if the element is already present. *)
+          if unexpanded_candidate == weak_set
+          then (visited, weak_set)
+          else begin
+            match
+              loop env (visited, weak_set)
+                (try_expand_head try_expand_safe env ty)
+            with
+            | exception Cannot_expand -> unexpanded_candidate'
+            | expanded_result -> expanded_result
+          end
+      | Tfield(_, kind, t1, t2) ->
+          let visited, weak_set =
+            match field_kind_repr kind with
+            | Fpublic -> loop env (visited, weak_set) t1
+            | _ -> visited, weak_set
+          in
+          loop env (visited, weak_set) t2
+      | Tvariant row ->
+          let visited, weak_set =
+            fold_row (loop env) (visited, weak_set) row
+          in
+          if not (static_row row)
+          then loop env (visited, weak_set) (row_more row)
+          else (visited, weak_set)
+      | _ ->
+          fold_type_expr (loop env) (visited, weak_set) ty
+    end
+  in
+  fun env acc ty ->
+    let _, result = loop env (TypeSet.empty, acc) ty in
+    result
 
-let rec nongen_schema_rec env ty =
-  if TypeSet.mem ty !visited then () else begin
-    visited := TypeSet.add ty !visited;
-    match get_desc ty with
-      Tvar _ when get_level ty <> generic_level ->
-        raise Nongen
-    | Tconstr _ ->
-        let old = !visited in
-        begin try iter_type_expr (nongen_schema_rec env) ty
-        with Nongen -> try
-          visited := old;
-          nongen_schema_rec env (try_expand_head try_expand_safe env ty)
-        with Cannot_expand ->
-          raise Nongen
-        end
-    | Tfield(_, kind, t1, t2) ->
-        if field_kind_repr kind = Fpublic then
-          nongen_schema_rec env t1;
-        nongen_schema_rec env t2
-    | Tvariant row ->
-        iter_row (nongen_schema_rec env) row;
-        if not (static_row row) then nongen_schema_rec env (row_more row)
-    | _ ->
-        iter_type_expr (nongen_schema_rec env) ty
-  end
-
-(* Return whether all variables of type [ty] are generic. *)
-let nongen_schema env ty =
-  visited := TypeSet.empty;
-  try
-    nongen_schema_rec env ty;
-    visited := TypeSet.empty;
-    false
-  with Nongen ->
-    visited := TypeSet.empty;
-    true
+(* Return all non-generic variables of [ty]. *)
+let nongen_vars_in_schema env ty =
+  let result = add_nongen_vars_in_schema env TypeSet.empty ty in
+  if TypeSet.is_empty result
+  then None
+  else Some result
 
 (* Check that all type variables are generalizable *)
 (* Use Env.empty to prevent expansion of recursively defined object types;
    cf. typing-poly/poly.ml *)
-let rec nongen_class_type = function
-  | Cty_constr (_, params, _) ->
-      List.exists (nongen_schema Env.empty) params
-  | Cty_signature sign ->
-      nongen_schema Env.empty sign.csig_self
-      || nongen_schema Env.empty sign.csig_self_row
-      || Meths.exists
-           (fun _ (_, _, ty) -> nongen_schema Env.empty ty)
-           sign.csig_meths
-      || Vars.exists
-           (fun _ (_, _, ty) -> nongen_schema Env.empty ty)
-           sign.csig_vars
-  | Cty_arrow (_, ty, cty) ->
-      nongen_schema Env.empty ty
-      || nongen_class_type cty
+let nongen_class_type =
+  let add_nongen_vars_in_schema' ty weak_set =
+    add_nongen_vars_in_schema Env.empty weak_set ty
+  in
+  let add_nongen_vars_in_schema_fold fold m weak_set =
+    let f _key (_,_,ty) weak_set =
+      add_nongen_vars_in_schema Env.empty weak_set ty
+    in
+    fold f m weak_set
+  in
+  let rec nongen_class_type cty weak_set =
+    match cty with
+    | Cty_constr (_, params, _) ->
+        List.fold_left
+          (add_nongen_vars_in_schema Env.empty)
+          weak_set
+          params
+    | Cty_signature sign ->
+        weak_set
+        |> add_nongen_vars_in_schema' sign.csig_self
+        |> add_nongen_vars_in_schema' sign.csig_self_row
+        |> add_nongen_vars_in_schema_fold Meths.fold sign.csig_meths
+        |> add_nongen_vars_in_schema_fold Vars.fold sign.csig_vars
+    | Cty_arrow (_, ty, cty) ->
+        add_nongen_vars_in_schema' ty weak_set
+        |> nongen_class_type cty
+  in
+  nongen_class_type
 
 let nongen_class_declaration cty =
-  List.exists (nongen_schema Env.empty) cty.cty_params
-  || nongen_class_type cty.cty_type
+  List.fold_left
+    (add_nongen_vars_in_schema Env.empty)
+    TypeSet.empty
+    cty.cty_params
+  |> nongen_class_type cty.cty_type
 
+let nongen_vars_in_class_declaration cty =
+  let result = nongen_class_declaration cty in
+  if TypeSet.is_empty result
+  then None
+  else Some result
 
 (* Normalize a type before printing, saving... *)
 (* Cannot use mark_type because deep_occur uses it too *)

--- a/typing/ctype.mli
+++ b/typing/ctype.mli
@@ -414,13 +414,12 @@ val nondep_cltype_declaration:
 val is_contractive: Env.t -> Path.t -> bool
 val normalize_type: type_expr -> unit
 
-val nongen_schema: Env.t -> type_expr -> bool
-        (* Check whether the given type scheme contains no non-generic
-           type variables *)
+val nongen_vars_in_schema: Env.t -> type_expr -> Btype.TypeSet.t option
+        (* Return any non-generic variables in the type scheme *)
 
-val nongen_class_declaration: class_declaration -> bool
-        (* Check whether the given class type contains no non-generic
-           type variables. Uses the empty environment.  *)
+val nongen_vars_in_class_declaration:class_declaration -> Btype.TypeSet.t option
+        (* Return any non-generic variables in the class type.
+           Uses the empty environment.  *)
 
 type variable_kind = Row_variable | Type_variable
 type closed_class_failure = {

--- a/typing/printtyp.ml
+++ b/typing/printtyp.ml
@@ -1123,7 +1123,7 @@ let rec tree_of_typexp mode ty =
           let tpath = tree_of_best_type_path p p' in
           Otyp_constr (tpath, tree_of_typlist mode tyl')
     | Tvariant row ->
-        let Row {fields; name; closed} = row_repr row in
+        let Row {fields; name; closed; _} = row_repr row in
         let fields =
           if closed then
             List.filter (fun (_, f) -> row_field_repr f <> Rabsent)
@@ -1281,9 +1281,11 @@ let shared_type_scheme ppf ty =
   prepare_type ty;
   typexp Type_scheme ppf ty
 
+let prepared_type_scheme ppf ty = typexp Type_scheme ppf ty
+
 let type_scheme ppf ty =
   prepare_for_printing [ty];
-  typexp Type_scheme ppf ty
+  prepared_type_scheme ppf ty
 
 let type_path ppf p =
   let (p', s) = best_type_path p in

--- a/typing/printtyp.mli
+++ b/typing/printtyp.mli
@@ -119,6 +119,7 @@ val prepared_type_expr: formatter -> type_expr -> unit
 val constructor_arguments: formatter -> constructor_arguments -> unit
 val tree_of_type_scheme: type_expr -> out_type
 val type_scheme: formatter -> type_expr -> unit
+val prepared_type_scheme: formatter -> type_expr -> unit
 val shared_type_scheme: formatter -> type_expr -> unit
 (** [shared_type_scheme] is very similar to [type_scheme], but does not reset
     the printing context first.  This is intended to be used in cases where the

--- a/typing/typeclass.mli
+++ b/typing/typeclass.mli
@@ -113,7 +113,10 @@ type error =
   | Unbound_val of string
   | Unbound_type_var of (formatter -> unit) * Ctype.closed_class_failure
   | Non_generalizable_class of
-      Ident.t * Types.class_declaration * (type_expr list)
+      { id : Ident.t
+      ; clty : Types.class_declaration
+      ; nongen_vars : type_expr list
+      }
   | Cannot_coerce_self of type_expr
   | Non_collapsable_conjunction of
       Ident.t * Types.class_declaration * Errortrace.unification_error

--- a/typing/typeclass.mli
+++ b/typing/typeclass.mli
@@ -112,7 +112,8 @@ type error =
   | Class_match_failure of Ctype.class_match_failure list
   | Unbound_val of string
   | Unbound_type_var of (formatter -> unit) * Ctype.closed_class_failure
-  | Non_generalizable_class of Ident.t * Types.class_declaration
+  | Non_generalizable_class of
+      Ident.t * Types.class_declaration * (type_expr list)
   | Cannot_coerce_self of type_expr
   | Non_collapsable_conjunction of
       Ident.t * Types.class_declaration * Errortrace.unification_error

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -57,8 +57,9 @@ type error =
   | With_changes_module_alias of Longident.t * Ident.t * Path.t
   | With_cannot_remove_constrained_type
   | Repeated_name of Sig_component_kind.t * string
-  | Non_generalizable of type_expr
-  | Non_generalizable_module of module_type
+  | Non_generalizable of { vars : type_expr list; expression : type_expr }
+  | Non_generalizable_module of
+      { vars : type_expr list; item : value_description; mty : module_type }
   | Implementation_is_required of string
   | Interface_not_compiled of string
   | Not_allowed_in_functor_body
@@ -1829,11 +1830,11 @@ let path_of_module mexp =
    do not contain non-generalized type variable *)
 
 let rec nongen_modtype env = function
-    Mty_ident _ -> false
-  | Mty_alias _ -> false
+    Mty_ident _ -> None
+  | Mty_alias _ -> None
   | Mty_signature sg ->
       let env = Env.add_signature sg env in
-      List.exists (nongen_signature_item env) sg
+      List.find_map (nongen_signature_item env) sg
   | Mty_functor(arg_opt, body) ->
       let env =
         match arg_opt with
@@ -1845,18 +1846,35 @@ let rec nongen_modtype env = function
       nongen_modtype env body
 
 and nongen_signature_item env = function
-    Sig_value(_id, desc, _) -> Ctype.nongen_schema env desc.val_type
+  | Sig_value(_id, desc, _) ->
+      Ctype.nongen_vars_in_schema env desc.val_type
+      |> Option.map (fun vars -> (vars, desc))
   | Sig_module(_id, _, md, _, _) -> nongen_modtype env md.md_type
-  | _ -> false
+  | _ -> None
+
+let nongen_modtype env loc mty =
+  nongen_modtype env mty
+  |> Option.iter (fun (vars, item) ->
+      let vars = Btype.TypeSet.elements vars in
+      let error =
+        Non_generalizable_module { vars; item; mty }
+      in
+      raise(Error(loc, env, error))
+    )
 
 let check_nongen_signature_item env sig_item =
   match sig_item with
     Sig_value(_id, vd, _) ->
-      if Ctype.nongen_schema env vd.val_type then
-        raise (Error (vd.val_loc, env, Non_generalizable vd.val_type))
+      Ctype.nongen_vars_in_schema env vd.val_type
+      |> Option.iter (fun vars ->
+          let vars = Btype.TypeSet.elements vars in
+          let error =
+            Non_generalizable { vars; expression = vd.val_type }
+          in
+          raise (Error (vd.val_loc, env, error))
+        )
   | Sig_module (_id, _, md, _, _) ->
-      if nongen_modtype env md.md_type then
-        raise(Error(md.md_loc, env, Non_generalizable_module md.md_type))
+      nongen_modtype env md.md_loc md.md_type
   | _ -> ()
 
 let check_nongen_signature env sg =
@@ -2877,8 +2895,7 @@ let type_module_type_of env smod =
   in
   let mty = Mtype.scrape_for_type_of ~remove_aliases env tmty.mod_type in
   (* PR#5036: must not contain non-generalized type variables *)
-  if nongen_modtype env mty then
-    raise(Error(smod.pmod_loc, env, Non_generalizable_module mty));
+  nongen_modtype env smod.pmod_loc mty;
   tmty, mty
 
 (* For Typecore *)
@@ -3281,14 +3298,35 @@ let report_error ~loc _env = function
         "@[Multiple definition of the %s name %s.@ \
          Names must be unique in a given structure or signature.@]"
         (Sig_component_kind.to_string kind) name
-  | Non_generalizable typ ->
+  | Non_generalizable { vars; expression } ->
+      let[@manual.ref "ss:valuerestriction"] manual_ref = [ 6; 1; 2 ] in
+      prepare_for_printing vars;
+      add_type_to_preparation expression;
       Location.errorf ~loc
         "@[The type of this expression,@ %a,@ \
-           contains type variables that cannot be generalized@]" type_scheme typ
-  | Non_generalizable_module mty ->
-      Location.errorf ~loc
+         contains the non-generalizable type variable(s) %a@ %a@]"
+        prepared_type_scheme expression
+        (pp_print_list ~pp_sep:(fun f () -> fprintf f ",@ ")
+           prepared_type_scheme) vars
+        Misc.print_see_manual manual_ref
+  | Non_generalizable_module { vars; mty; item } ->
+      let[@manual.ref "ss:valuerestriction"] manual_ref = [ 6; 1; 2 ] in
+      prepare_for_printing vars;
+      add_type_to_preparation item.val_type;
+      let sub =
+        [ Location.msg ~loc:item.val_loc
+            "This item has the non-generalizable type@ %a."
+            prepared_type_scheme
+            item.val_type
+        ]
+      in
+      Location.errorf ~loc ~sub
         "@[The type of this module,@ %a,@ \
-           contains type variables that cannot be generalized@]" modtype mty
+         contains the non-generalizable type variable(s) %a@ %a@]"
+        modtype mty
+        (pp_print_list ~pp_sep:(fun f () -> fprintf f ",@ ")
+           prepared_type_scheme) vars
+        Misc.print_see_manual manual_ref
   | Implementation_is_required intf_name ->
       Location.errorf ~loc
         "@[The interface %a@ declares values, not just types.@ \

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -3315,17 +3315,18 @@ let report_error ~loc _env = function
       add_type_to_preparation item.val_type;
       let sub =
         [ Location.msg ~loc:item.val_loc
-            "This value has the non-generalizable type@ %a."
+            "The type of this value,@ %a,@ \
+             contains the non-generalizable type variable(s) %a."
             prepared_type_scheme
             item.val_type
+            (pp_print_list ~pp_sep:(fun f () -> fprintf f ",@ ")
+               prepared_type_scheme) vars
         ]
       in
       Location.errorf ~loc ~sub
         "@[The type of this module,@ %a,@ \
-         contains the non-generalizable type variable(s): %a.@ %a@]"
+         contains non-generalizable type variable(s).@ %a@]"
         modtype mty
-        (pp_print_list ~pp_sep:(fun f () -> fprintf f ",@ ")
-           prepared_type_scheme) vars
         Misc.print_see_manual manual_ref
   | Implementation_is_required intf_name ->
       Location.errorf ~loc

--- a/typing/typemod.mli
+++ b/typing/typemod.mli
@@ -116,8 +116,9 @@ type error =
   | With_changes_module_alias of Longident.t * Ident.t * Path.t
   | With_cannot_remove_constrained_type
   | Repeated_name of Sig_component_kind.t * string
-  | Non_generalizable of type_expr
-  | Non_generalizable_module of module_type
+  | Non_generalizable of { vars : type_expr list; expression : type_expr }
+  | Non_generalizable_module of
+      { vars : type_expr list; item : value_description; mty : module_type }
   | Implementation_is_required of string
   | Interface_not_compiled of string
   | Not_allowed_in_functor_body


### PR DESCRIPTION
Like #11888, this PR prints the type variable in the non-generalized error messages.

There are some things that make this non-trivial:
1. Weak polymorphic variants didn't have their type variables printed, so this PR always prints them (in a type Scheme)
2. There may be more than one variable that cannot be generalized, we just print the first one