### PR TITLE
Error messages: use a simple heuristic to retrieve sourcefile name from compiled interface

### DIFF
--- a/Changes
+++ b/Changes
@@ -417,6 +417,10 @@ Working version
 - #12024: insert a blank line between separate compiler messages
   (Gabriel Scherer, review by Florian Angeletti, report by David Wong)
 
+- #?????: In error messages, retrieve interface source file from the compiled
+  interface whenever possible
+  (Florian Angeletti, report by David Wong, review by ????)
+
 ### Internal/compiler-libs changes:
 
 - #11990: Improve comments and macros around frame descriptors.

--- a/typing/includemod.ml
+++ b/typing/includemod.ml
@@ -969,7 +969,7 @@ let compunit env ~mark impl_name impl_sig intf_name intf_sig unit_shape =
       Subst.identity impl_sig intf_sig unit_shape
   with Result.Error reasons ->
     let cdiff =
-      Error.In_Compilation_unit(Error.diff impl_name intf_name reasons) in
+      Error.In_Compilation_unit(Error.diff impl_name (intf_name ()) reasons) in
     raise(Error(env, cdiff))
   | Ok x -> x
 

--- a/typing/includemod.mli
+++ b/typing/includemod.mli
@@ -178,7 +178,7 @@ val signatures: Env.t -> mark:mark ->
 
 val compunit:
       Env.t -> mark:mark -> string -> signature ->
-      string -> signature -> Shape.t -> module_coercion * Shape.t
+      (unit -> string) -> signature -> Shape.t -> module_coercion * Shape.t
 
 val type_declarations:
   loc:Location.t -> Env.t -> mark:mark ->


### PR DESCRIPTION
Whenever we compare the module type of a cmi file against the module type of its implementation, the name of the cmi file briefly appears in the error message, for instance

> File "common/a.ml", line 1:        
Error: The implementation common/a.ml
       does not match the interface common/.l.objs/byte/l__A.cmi: 
       The type `t' is required but not provided
       File "common/a.mli", line 1, characters 0-6: Expected declaration

An important observation at this point is that this cmi file name is soon replaced by the interface source file name `common/a.mli` as soon as we are not at the toplevel of the error message.

That seems to be a clear sign that we should avoid speaking temporarily of the cmi file at all at the toplevel ... if we can avoid it.

Part of the issue is that the interface source file name is not that straightforward to determine:

- `cmi` files only records the name of the compiled module
- `dune` compiles `ml` file with `-intf-suffix .ml`, thus we cannot deduce the interface file name from the name of the ml file at all.
- line directives can change the source file name to avoid exposing generated files (e.g. `#<n> "parser.mly") in the error message.

As a compromise this PR proposes to look at the locations of all toplevel signature items from the cmi file. If all those locations share a common filename part, we can sensibly use that filename as the name of the source file for the interface. Otherwise, for chimeric cmi assembled from multiple source files, it seems fine to keep using the cmi filename.

Another less hackish alternative would be to add a flag for `ocamlc` and `ocamlopt` to give a source file for interface files and record that name in the cmi file. That might be a better long term path, but that would require more cooperation with build tools. At the same time, having a more explicit flag might be a better option than using `-intf-suffix .ml` for them. 
(cc @rgrinberg ?)
