### PR TITLE
compare.c: avoid inner pointers on the compare stack

### DIFF
--- a/runtime/compare.c
+++ b/runtime/compare.c
@@ -25,7 +25,7 @@
 
 /* Structural comparison on trees. */
 
-struct compare_item { volatile value * v1, * v2; mlsize_t count; };
+struct compare_item { value v1, v2; uintnat offset; };
 
 #define COMPARE_STACK_INIT_SIZE 8
 #define COMPARE_STACK_MIN_ALLOC_SIZE 32
@@ -280,9 +280,9 @@ static intnat do_compare_val(struct compare_stack* stk,
       if (sz1 > 1) {
         sp++;
         if (sp >= stk->limit) sp = compare_resize_stack(stk, sp);
-        sp->v1 = &Field(v1, 1);
-        sp->v2 = &Field(v2, 1);
-        sp->count = sz1 - 1;
+        sp->v1 = v1;
+        sp->v2 = v2;
+        sp->offset = 1;
       }
       /* Continue comparison with first field */
       v1 = Field(v1, 0);
@@ -293,9 +293,9 @@ static intnat do_compare_val(struct compare_stack* stk,
   next_item:
     /* Pop one more item to compare, if any */
     if (sp == stk->stack) return EQUAL; /* we're done */
-    v1 = *((sp->v1)++);
-    v2 = *((sp->v2)++);
-    if (--(sp->count) == 0) sp--;
+    v1 = Field(sp->v1, sp->offset);
+    v2 = Field(sp->v2, sp->offset);
+    if (++(sp->offset) == Wosize_val(sp->v1)) sp--;
   }
 }
 


### PR DESCRIPTION
To compare same-size blocks containing values, do_compare_val recursively compares the first argument of each block, and pushes "the rest of the arguments' on both sides to the compare stack. The compare stack thus contains pairs of sequences of arguments to be compared.

Before this PR, pairs of sequences of arguments are represented by:

- two inner pointers (into the parent blocks) to the first arguments to be compared on each side
- a "count" field remembering the number of arguments still to compare

The use of inner pointers that are not valid OCaml values makes some things delicate, for example we could not ask the GC to scan the compare stack (as is being considered in the context of #12039).

After this PR, pairs of sequences of arguments are represented by:

- pointers to the parent containing blocks on each side (that is, valid OCaml values)
- an "offset" field remembering the offset of the next argument to compare

To determine whether there are arguments left to compare we simply ask for the size of the block. (We could add the size information as a new field in the compare stack items, but preferred to keep it slim.)

Early performance results seem to indicate that this new approach is in fact *faster* than the previous one by about 10%, despite the additional work of fetching the next arguments at an offset and checking the block size whenever advancing in the sequence. Our hypothesis is that the extra reads are compensated by performing one less write: each time we advance through an argument sequence we increment just the offset field, instead of incrementing both inner pointers.

(cc @eutro @xavierleroy @gadmm, who were active on #12039)