### PR TITLE
Correct size for recursive values with branching

### DIFF
--- a/Changes
+++ b/Changes
@@ -164,6 +164,9 @@ Working version
   (Alexander Skvortsov, report by Török Edwin,
    design by Gabriel Scherer, Xavier Leroy)
 
+- #12032, #12059: Bug fixes related to compilation of recursive definitions
+  (Vincent Laviron, report by Github user @lupjo, review by Gabriel Scherer)
+
 * #12145: Loopy constraints cause ocamlc to loop.
   Fixed by completely removing the call to `update_type` in
   `Typedecl.transl_type_decl`, as the expansion is already checked by

--- a/Changes
+++ b/Changes
@@ -165,7 +165,7 @@ Working version
    design by Gabriel Scherer, Xavier Leroy)
 
 - #12032, #12059: Bug fixes related to compilation of recursive definitions
-  (Vincent Laviron, report by Github user @lupjo, review by Gabriel Scherer)
+  (Vincent Laviron, report by Louis Noizet, review by Gabriel Scherer)
 
 * #12145: Loopy constraints cause ocamlc to loop.
   Fixed by completely removing the call to `update_type` in

--- a/bytecomp/bytegen.ml
+++ b/bytecomp/bytegen.ml
@@ -198,6 +198,14 @@ type rhs_kind =
   | RHS_floatblock of int
   | RHS_nonrec
   | RHS_function of int * int
+  | RHS_unreachable
+
+ (* We expect Rec_check to associate Dynamic mode to branches with multiple
+    returning paths, which translates to RHS_nonrec. *)
+let join_rhs_kind k1 k2 =
+  match k1, k2 with
+  | RHS_unreachable, k | k, RHS_unreachable -> k
+  | _, _ -> RHS_nonrec
 
 let rec check_recordwith_updates id e =
   match e with
@@ -209,6 +217,12 @@ let rec check_recordwith_updates id e =
 let rec size_of_lambda env = function
   | Lvar id ->
       begin try Ident.find_same id env with Not_found -> RHS_nonrec end
+  | Lconst _ ->
+      (* This is a constant, so obviously not recursive. But Rec_check might
+         have treated it as Static. We rely on the fact that the compilation
+         of non-recursive values (RHS_nonrec) already handles that case
+         correctly, and return RHS_nonrec. *)
+      RHS_nonrec
   | Lfunction{params} as funct ->
       RHS_function (2 + Ident.Set.cardinal(free_variables funct),
                     List.length params)
@@ -222,6 +236,8 @@ let rec size_of_lambda env = function
       end
   | Llet(_str, _k, id, arg, body) ->
       size_of_lambda (Ident.add id (size_of_lambda env arg) env) body
+  | Lmutlet (_kind, _id, _def, body) ->
+      size_of_lambda env body
   (* See the Lletrec case of comp_expr *)
   | Lletrec(bindings, body) when
       List.for_all (function (_, Lfunction _) -> true | _ -> false) bindings ->
@@ -256,9 +272,41 @@ let rec size_of_lambda env = function
   | Lprim (Pduprecord (Record_extension _, size), _, _) ->
       RHS_block (size + 1)
   | Lprim (Pduprecord (Record_float, size), _, _) -> RHS_floatblock size
+  | Lprim (Praise _, _, _) -> RHS_unreachable
+  | Lprim (_, _, _) -> RHS_nonrec
   | Levent (lam, _) -> size_of_lambda env lam
   | Lsequence (_lam, lam') -> size_of_lambda env lam'
-  | _ -> RHS_nonrec
+  | Lifthenelse (_cond, ifso, ifnot) ->
+      let size_ifso = size_of_lambda env ifso in
+      let size_ifnot = size_of_lambda env ifnot in
+      join_rhs_kind size_ifso size_ifnot
+  | Lstaticraise (_, _) -> RHS_unreachable
+  | Lstaticcatch (body, _, handler)
+  | Ltrywith (body, _, handler) ->
+      (* For Lstaticcatch, we could refine the sizes of the parameters by
+         propagating the sizes from the Lstaticraise sites. *)
+      let size_body = size_of_lambda env body in
+      let size_handler = size_of_lambda env handler in
+      join_rhs_kind size_body size_handler
+  | Lswitch (_arg, sw, _loc) ->
+      List.fold_left (fun acc (_const, act) ->
+          join_rhs_kind acc (size_of_lambda env act))
+        (List.fold_left (fun acc (_tag, act) ->
+             join_rhs_kind acc (size_of_lambda env act))
+           (match sw.sw_failaction with
+            | None -> RHS_unreachable
+            | Some act -> size_of_lambda env act)
+           sw.sw_blocks)
+        sw.sw_consts
+  | Lstringswitch (_arg, cases, default, _loc) ->
+      List.fold_left (fun acc (_string, act) ->
+          join_rhs_kind acc (size_of_lambda env act))
+        (match default with
+         | None -> RHS_unreachable
+         | Some act -> size_of_lambda env act)
+        cases
+  | Lmutvar _ | Lapply _ | Lwhile _ | Lfor _ | Lassign _ | Lsend _
+  | Lifused _ -> RHS_nonrec
 
 (**** Merging consecutive events ****)
 
@@ -730,10 +778,13 @@ let rec comp_expr stack_info env exp sz cont =
           | (id, _exp, RHS_nonrec) :: rem ->
               Kconst(Const_base(Const_int 0)) :: Kpush ::
               comp_init (add_var id (sz+1) new_env) (sz+1) rem
+          | (id, _exp, RHS_unreachable) :: rem ->
+              Kconst(Const_base(Const_int 0)) :: Kpush ::
+              comp_init (add_var id (sz+1) new_env) (sz+1) rem
         and comp_nonrec new_env sz i = function
           | [] -> comp_rec new_env sz ndecl decl_size
           | (_id, _exp, (RHS_block _ | RHS_infix _ |
-                         RHS_floatblock _ | RHS_function _))
+                         RHS_floatblock _ | RHS_function _ | RHS_unreachable))
             :: rem ->
               comp_nonrec new_env sz (i-1) rem
           | (_id, exp, RHS_nonrec) :: rem ->
@@ -747,6 +798,10 @@ let rec comp_expr stack_info env exp sz cont =
               comp_expr stack_info new_env exp sz
                 (Kpush :: Kacc i :: Kccall("caml_update_dummy", 2) ::
                  comp_rec new_env sz (i-1) rem)
+          | (_id, exp, RHS_unreachable)
+            :: rem ->
+              comp_expr stack_info new_env exp sz
+                (discard_dead_code (comp_rec new_env sz (i-1) rem))
           | (_id, _exp, RHS_nonrec) :: rem ->
               comp_rec new_env sz (i-1) rem
         in


### PR DESCRIPTION
This PR is a proposal for fixing issue #12032.

I've started with the bytecode version only, for design discussions, but will update the native version when we have agreed on the design.

## Overview of the issue

Recursive definitions are quite tricky in OCaml, because while there are obviously definitions that make no sense and are rejected, and definitions that definitively make sense and should be allowed, there are also a lot of weird corner cases that do not make much sense but are allowed anyway (and also some definitions that could be allowed but aren't, but this isn't going to be relevant in this discussion).

### Basic compilation scheme

The basic strategy for compiling recursive values is to compute the amount of memory that each of the recursive values will occupy, then have the compiler generate code that pre-allocates memory for each recursive binding (using `caml_alloc_dummy*` functions), computes the actual values using the pre-allocated values as placeholders, and finally copies the resulting values back into their expected slot.

This strategy is only possible if the computation of the actual values doesn't actually inspect the contents of the values being defined (which are not type-sound yet at this point), so the `Rec_check` module implements an algorithm that rejects definitions that do not meet this criterion.

### Non-recursive/Dynamic bindings

However, OCaml also supports recursive definitions where one or several of the bindings cannot be pre-allocated, on the condition that those bindings are not actually recursive.
For example, `let rec x = if cond then 0 :: x else []` is forbidden but `let rec x = if cond then [0] else []` is allowed.

To handle this, `Rec_check` also classifies recursive bindings as either `Static` or `Dynamic`. `Static` bindings are the ones where we know that we can compute the size at compile time, while `Dynamic` ones are the others (we don't know if we will be able to compute the size or not). `Static` bindings are expected to go through the compilation scheme described above, so they are allowed as long as they do not inspect the content of a recursively-bound variable during initialisation. `Dynamic` bindings, on the other hand, are not allowed to refer to any other recursive binding (with some exceptions, that are not relevant here). This means that the compiler is allowed to first generate regular let-bindings for these dynamic bindings, then generate the code for the static bindings (pre-allocation, computation, copy).

### The bug: mismatch between `Rec_check` and the actual compiling code

`Rec_check` only returns a boolean value (more or less). In particular, the static/dynamic status is never stored anywhere. So when doing the actual compilation, the compilers have to redo this computation (the actual size needs to be computed too at this point). This corresponds to `Bytegen.size_of_lambda` for the bytecode compiler, and `Cmmgen.expr_size` for the native compiler.
But these computations are not done on the same expressions as the original ones: some have been expanded (typically by the pattern-matching compiler), others may have been removed or simplified by an optimisation.

In one direction, this is not problematic. If a `Dynamic` binding has been simplified so that it now looks like a `Static` binding, then it's fine; the code generated will be slightly different (and less efficient), but it's sound.
Problems start appearing when `Rec_check` decides that a binding is `Static`, but the compiler can't compute a size and assumes it must be have been `Dynamic`. In that case, the compiler assumes that this dynamic binding can be evaluated prior to the actual recursive bindings, but `Rec_check` has allowed it to refer to recursive variables (including itself) that are not being preallocated. This won't lead to an error at compile time, because for other reasons the compiler inserts a dummy binding anyway even for dynamic bindings, but at runtime this dummy binding can end up leaking to the user, and since it is not type-sound bad things happen.

## The solution(s)

### This PR: handle non-returning branches

The example from #12032 is one of a number of cases where `Rec_check` doesn't see any branching construction, but some non-returning branches are inserted later and the size computations assume that it must be dynamic.
This PR introduces a new constructor `RHS_unreachable` in the size computations, that is used for non-returning branches. Branching instructions then compute the sizes of all their branches, and return `RHS_nonrec` if there are more than one returning branch (assuming that `Rec_check` would have attributed a `Dynamic` mode), or the mode of the size of the only returning branch if there is one.

### Possible extension: branches with the same size

This example currently fails to compile: `let rec x = if cond then 0 :: x else 1 :: x`. Given that all branches return a value of the same size, it would be possible to compile it using the current scheme. In the size computations, it would be relatively straightforward support (on top of this PR, it's just a small modification to the `join_rhs_kind` function).
However, for this to be actually useful we would need `Rec_check` to be able to compare sizes, which adds again more complexity to the algorithm (for some constructions like functions, we cannot even compute the size in `Rec_check`).

### Constants: static or dynamic ?

There is one other known case where `Rec_check` will claim `Static` mode but the compiler will assume a dynamic definition: constants. This can take several forms, from basic integer or numeric constants, to arbitrary combinations of constructors (like `(Some []) :: None :: (Some (1 :: 2 :: 3))`). This also includes unit-returning expressions like loops and assignments.
For allocated constants the compiler could compute the size and pre-allocate, but since by definition constants cannot refer to other variables it is safe to compile them before (note that things like `let rec x = let _ = Some x in 42` are still allowed, so we still need dummy bindings).
These cases are also causing trouble with our work on alternative let-rec compilation (#8956), so @chambart is looking at some better ways to deal with that.

### Storing and propagating the result of `Rec_check`

Finally, I've also considered whether recursive bindings should store their mode (static or dynamic) so that the compilers know whether it is safe to use `RHS_nonrec` or if it must be pre-allocated. As discussed above, this needs some care in the case of constants (we cannot pre-allocate them, but we can pre-define them). Apart from that I think it would be doable, but looks like a lot of tedious work so I won't do it unless we agree in advance that it's the right solution.