### PR TITLE
Runtime events consumer: don't parse dropped events

### DIFF
--- a/Changes
+++ b/Changes
@@ -96,6 +96,9 @@ Working version
   (Gabriel Scherer, review by Sadiq Jaffer, report by André Maroneze
   for Frama-C and Guillaume Melquiond for Coq)
 
+- #12062: fix runtime events consumer: when events are dropped they shouldn't be
+  parsed. (Lucas Pluvinage)
+
 ### Type system:
 
 - #6941, #11187: prohibit using classes through recursive modules

--- a/otherlibs/runtime_events/runtime_events_consumer.c
+++ b/otherlibs/runtime_events/runtime_events_consumer.c
@@ -439,10 +439,10 @@ caml_runtime_events_read_poll(struct caml_runtime_events_cursor *cursor,
         if (cursor->lost_events) {
           if( !(cursor->lost_events(domain_num, callback_data, lost_words)) ) {
             early_exit = 1;
-            continue;
           }
-
         }
+
+        continue;
       }
 
       if (RUNTIME_EVENTS_ITEM_IS_RUNTIME(header)) {

--- a/testsuite/tests/lib-runtime-events/test_dropped_events.ml
+++ b/testsuite/tests/lib-runtime-events/test_dropped_events.ml
@@ -1,0 +1,50 @@
+(* TEST
+   include runtime_events
+   include unix
+   set OCAMLRUNPARAM = "e=6"
+   * libunix
+   ** native
+   ** bytecode
+*)
+
+type Runtime_events.User.tag += Ev
+let ev = Runtime_events.User.register "ev" Ev Runtime_events.Type.int
+
+let producer () =
+  let open Runtime_events in
+  for _ = 0 to 100000 do
+    User.write ev 0
+  done
+
+let ready = Atomic.make 0
+
+let wait_ready () =
+  let v = Atomic.fetch_and_add ready 1 in
+  if v < 2 then
+    while Atomic.get ready < 2 do
+      Domain.cpu_relax ()
+    done
+
+let _ =
+  Domain.spawn (fun () ->
+    Runtime_events.start ();
+    wait_ready ();
+    producer ())
+
+let callbacks =
+  let open Runtime_events in
+  let evs = Runtime_events.Callbacks.create ()
+  in
+  let id_callback d ts c i =
+    assert (i = 0)
+  in
+  Callbacks.add_user_event Runtime_events.Type.int id_callback evs
+
+let ()
+ =
+  let cursor = Runtime_events.create_cursor None in
+  wait_ready ();
+  for _ = 0 to 10 do
+    Runtime_events.read_poll cursor callbacks None
+    |> ignore
+  done

--- a/testsuite/tests/lib-runtime-events/test_dropped_events.ml
+++ b/testsuite/tests/lib-runtime-events/test_dropped_events.ml
@@ -42,6 +42,7 @@ let callbacks =
 
 let ()
  =
+  Unix.sleepf 0.1;
   let cursor = Runtime_events.create_cursor None in
   wait_ready ();
   for _ = 0 to 10 do


### PR DESCRIPTION
In the runtime events consumer library, there's a code path that handles the case when an event content is read, but in the meantime was overwrote by the producer. In that case, it calls the the `lost_events` callback if it exists, but then continues parsing the event with whatever data overwritten in the ring buffer, yielding incorrect values. 

This problem appeared when I used custom runtime events at a very high rate (700k/s). Indeed, at a low rate this code path is rarely taken. 

The PR includes a reproduction test that spawns two domains, one emitting custom events at a high rate and one consuming them and checking that the associated value is expected (`0`). If it's different, it means that the event payload was overwrote with a new event block (the expected zero value would then contain a header or timestamp value parsed as an integer). 

The proposed fix is the following: `continue` (jump over event parsing) for all code paths as long as the _event dropped_ condition is met:
```diff
 /* Check the message we've read hasn't been overwritten by the writer */
 if (ring_head > cursor->current_positions[domain_num]) {
     ...
+    continue;
 }
```

@Engil @sadiqj 
