### PR TITLE
#12061 fix: avoid adding inconsistent equations in functor error messages

### DIFF
--- a/Changes
+++ b/Changes
@@ -646,6 +646,10 @@ Working version
 - #12046: Flush stderr when tracing the parser
   (Hugo Heuzard, review by David Allsopp and Nicolás Ojeda Bär)
 
+- #12061, #12063: don't add inconsistent equalities when computing
+  high-level error messages for functor applications and inclusions.
+  (Florian Angeletti, review by Gabriel Scherer)
+
 - #12075: auto-detect whether `ar` support @FILE arguments at
   configure-time to avoid using this feature with toolchains
   that do not support it (eg FreeBSD/Darwin).

--- a/testsuite/tests/typing-modules/functors.ml
+++ b/testsuite/tests/typing-modules/functors.ml
@@ -1325,16 +1325,18 @@ Error: The functor application is ill-typed.
        These arguments:
          Add_three' A A A
        do not match these parameters:
-         functor (X : $T1) arg arg arg -> ...
-       1. Modules do not match:
-            Add_three' :
-            sig module M = Add_three'.M module type t = Add_three'.t end
+         functor (X : $T4) -> ...
+       1. The following extra argument is provided
+              Add_three' :
+              sig module M = Add_three'.M module type t = Add_three'.t end
+       2. The following extra argument is provided
+              A : sig type arg = A.arg end
+       3. The following extra argument is provided
+              A : sig type arg = A.arg end
+       4. Modules do not match:
+            A : sig type arg = A.arg end
           is not included in
-            $T1 = sig type witness module type t module M : t end
-          The type `witness' is required but not provided
-       2. Module A matches the expected module type arg
-       3. Module A matches the expected module type arg
-       4. Module A matches the expected module type arg
+            $T4 = sig type witness module type t module M : t end
 |}]
 
 module Choose_one = F(Add_one')(Add_three)(A)(A)(A)
@@ -1795,4 +1797,211 @@ Error: The functor application is ill-typed.
          functor (X : empty) -> ...
        1. Module (struct end) matches the expected module type empty
        2. The following extra argument is provided ()
+|}]
+
+
+(** Incoherent type views *)
+
+module F
+    (A : sig type 'a t end)
+    (B : sig
+       type 'a t
+       val f : 'a A.t -> 'a t
+     end) =
+struct end
+
+(** The definition of `F` and its application belows disagree on
+    the arity of `t`, we should not equate the two types *)
+
+include
+  F
+    (struct
+      type t = unit   (* this is bogus! *)
+    end)
+    (struct
+      let f x = x   (* this is bogus! *)
+    end)
+[%%expect {|
+module F :
+  functor (A : sig type 'a t end)
+    (B : sig type 'a t val f : 'a A.t -> 'a t end) -> sig end
+Lines 15-21, characters 2-8:
+15 | ..F
+16 |     (struct
+17 |       type t = unit   (* this is bogus! *)
+18 |     end)
+19 |     (struct
+20 |       let f x = x   (* this is bogus! *)
+21 |     end)
+Error: The functor application is ill-typed.
+       These arguments:
+         $S1 $S2
+       do not match these parameters:
+         functor (A : $T1) (B : $T2) -> ...
+       1. Modules do not match:
+            $S1 : sig type t = unit end
+          is not included in
+            $T1 = sig type 'a t end
+          Type declarations do not match:
+            type t = unit
+          is not included in
+            type 'a t
+          They have different arities.
+       2. Modules do not match:
+            $S2 : sig val f : 'a -> 'a end
+          is not included in
+            $T2 = sig type 'a t val f : 'a A.t -> 'a t end
+|}]
+
+
+module G
+    (A : sig type 'a t = 'a * 'a end)
+    (B : sig
+       val f : 'a A.t -> 'a
+     end) =
+struct end
+
+module R = G(struct end)(struct let f (x,_) = x end)
+[%%expect {|
+module G :
+  functor (A : sig type 'a t = 'a * 'a end)
+    (B : sig val f : 'a A.t -> 'a end) -> sig end
+Line 8, characters 11-52:
+8 | module R = G(struct end)(struct let f (x,_) = x end)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The functor application is ill-typed.
+       These arguments:
+         (struct end) $S2
+       do not match these parameters:
+         functor (A : $T1) (B : ...) -> ...
+       1. Modules do not match:
+            (struct end)
+          is not included in
+            $T1 = sig type 'a t = 'a * 'a end
+          The type `t' is required but not provided
+       2. Module $S2 matches the expected module type
+|}]
+
+module With_expansion
+    (A: sig module type t module M:t end)
+    (B:sig module type t = A.t end) = (A.M:B.t)
+
+module R = With_expansion(struct
+    module M()() = struct end
+    module type t = module type of M
+  end)
+    ()
+    ()
+    ()
+[%%expect {|
+module With_expansion :
+  functor (A : sig module type t module M : t end)
+    (B : sig module type t = A.t end) -> B.t
+Lines 5-11, characters 11-6:
+ 5 | ...........With_expansion(struct
+ 6 |     module M()() = struct end
+ 7 |     module type t = module type of M
+ 8 |   end)
+ 9 |     ()
+10 |     ()
+11 |     ()
+Error: The functor application is ill-typed.
+       These arguments:
+         $S1 () () ()
+       do not match these parameters:
+         functor (A : ...) (B : $T2) () () -> ...
+       1. Module $S1 matches the expected module type
+       2. The functor was expected to be applicative at this position
+       3. Module () matches the expected module type
+       4. Module () matches the expected module type
+|}]
+
+
+module R' = With_expansion(struct
+    module M()() = struct end
+    module type t = module type of M
+  end)
+    ()
+    ()
+[%%expect {|
+Lines 1-6, characters 12-6:
+1 | ............With_expansion(struct
+2 |     module M()() = struct end
+3 |     module type t = module type of M
+4 |   end)
+5 |     ()
+6 |     ()
+Error: The functor application is ill-typed.
+       These arguments:
+         $S1 () ()
+       do not match these parameters:
+         functor (A : ...) (B : $T2) () () -> ...
+       1. Module $S1 matches the expected module type
+       2. An argument appears to be missing with module type
+              $T2 = sig module type t = A.t end
+       3. Module () matches the expected module type
+       4. Module () matches the expected module type
+|}]
+
+
+(** The definition of `H` and its application belows still disagree on
+    the arity of `t`. However, they agree on the type constructor s.
+    Currently, we don't add an equality X.s = G($1).s, but we may want
+    to do so in the future. *)
+
+module H
+    (X:sig
+       type 'a t
+       type 'a s
+     end)
+    (Y: sig
+       val f: 'a X.s -> 'a
+     end)
+= struct end
+
+
+module _ =
+  H
+    (struct
+      type t (** this is wrong*)
+      type 'a s = 'a (** this matches the expected type *)
+    end)
+    (struct
+      let f x = x   (* this is fine *)
+    end)
+[%%expect {|
+module H :
+  functor (X : sig type 'a t type 'a s end)
+    (Y : sig val f : 'a X.s -> 'a end) -> sig end
+Lines 18-25, characters 2-8:
+18 | ..H
+19 |     (struct
+20 |       type t (** this is wrong*)
+21 |       type 'a s = 'a (** this matches the expected type *)
+22 |     end)
+23 |     (struct
+24 |       let f x = x   (* this is fine *)
+25 |     end)
+Error: The functor application is ill-typed.
+       These arguments:
+         $S1 $S2
+       do not match these parameters:
+         functor (X : $T1) (Y : $T2) -> ...
+       1. Modules do not match:
+            $S1 : sig type t type 'a s = 'a end
+          is not included in
+            $T1 = sig type 'a t type 'a s end
+          Type declarations do not match: type t is not included in type 'a t
+          They have different arities.
+       2. Modules do not match:
+            $S2 : sig val f : 'a -> 'a end
+          is not included in
+            $T2 = sig val f : 'a X.s -> 'a end
+          Values do not match:
+            val f : 'a -> 'a
+          is not included in
+            val f : 'a X.s -> 'a
+          The type 'a X.s -> 'a X.s is not compatible with the type
+            'a X.s -> 'a
+          Type 'a X.s is not compatible with type 'a
 |}]

--- a/testsuite/tests/typing-modules/functors.ml
+++ b/testsuite/tests/typing-modules/functors.ml
@@ -1289,18 +1289,13 @@ end
 
 module Add_one = struct type witness include Add_one' end
 
-module Add_three' = struct
+module Add_three = struct
   module M(_:arg)(_:arg)(_:arg) = A
   module type t = module type of M
-end
-
-module Add_three = struct
-  include Add_three'
   type witness
 end
 
 
-module Wrong_intro = F(Add_three')(A)(A)(A)
 [%%expect {|
 module type arg = sig type arg end
 module A : sig type arg end
@@ -1311,32 +1306,12 @@ module Add_one' :
   end
 module Add_one :
   sig type witness module M = Add_one'.M module type t = Add_one'.t end
-module Add_three' :
+module Add_three :
   sig
     module M : arg -> arg -> arg -> sig type arg = A.arg end
     module type t = arg -> arg -> arg -> sig type arg = A.arg end
+    type witness
   end
-module Add_three :
-  sig module M = Add_three'.M module type t = Add_three'.t type witness end
-Line 22, characters 21-43:
-22 | module Wrong_intro = F(Add_three')(A)(A)(A)
-                          ^^^^^^^^^^^^^^^^^^^^^^
-Error: The functor application is ill-typed.
-       These arguments:
-         Add_three' A A A
-       do not match these parameters:
-         functor (X : $T4) -> ...
-       1. The following extra argument is provided
-              Add_three' :
-              sig module M = Add_three'.M module type t = Add_three'.t end
-       2. The following extra argument is provided
-              A : sig type arg = A.arg end
-       3. The following extra argument is provided
-              A : sig type arg = A.arg end
-       4. Modules do not match:
-            A : sig type arg = A.arg end
-          is not included in
-            $T4 = sig type witness module type t module M : t end
 |}]
 
 module Choose_one = F(Add_one')(Add_three)(A)(A)(A)

--- a/typing/includemod.ml
+++ b/typing/includemod.ml
@@ -574,6 +574,9 @@ and functor_param ~in_eq ~loc env ~mark subst param1 param2 =
 and equate_one_functor_param subst env arg2' name1 name2  =
   match name1, name2 with
   | Some id1, Some id2 ->
+  (* two matching abstract parameters: we add one identifier to the
+     environment and record the equality between the two identifiers
+     in the substitution *)
       Env.add_module id1 Mp_present arg2' env,
       Subst.add_module id2 (Path.Pident id1) subst
   | None, Some id2 ->

--- a/typing/includemod.ml
+++ b/typing/includemod.ml
@@ -1039,15 +1039,21 @@ module Functor_inclusion_diff = struct
     | Keep (Unit,_,_)
     | Keep (_,Unit,_)
     | Change ((Unit|Named(None,_)),(Unit | Named (None,_)), _) ->
+        (* No named abstract parameters: we keep the same environment *)
         st, [||]
     | Insert (Named (Some id, arg))
     | Delete (Named (Some id, arg))
     | Change ((Unit|Named(None,_)), Named (Some id, arg), _)
     | Change (Named (Some id, arg), (Unit|Named(None,_)), _) ->
+        (* One named parameter that doesn't match it anonymous counterpart,
+           we add it to the typing environment because it may
+           contain useful abbreviations. *)
         let arg' = Subst.modtype Keep st.subst arg in
         let env = Env.add_module id Mp_present arg' st.env in
         expand_params { st with env }
     | Change (Named (Some id, arg), Named(Some id2, arg2), _) ->
+        (* Change should be delete + insert: we add both abstract parameters
+           to the environment without equating them. *)
         let arg = Subst.modtype Keep st.subst arg in
         let env = Env.add_module id Mp_present arg st.env in
         let arg2 = Subst.modtype Keep st.subst arg2 in
@@ -1057,10 +1063,13 @@ module Functor_inclusion_diff = struct
         let arg' = Subst.modtype Keep st.subst arg2 in
         match name1, name2 with
         | Some id1, Some id2 ->
+            (* two matching abstract parameters: we add one identifier to the
+               environment and record the equality between the two identifiers
+               in the substitution *)
             let env = Env.add_module id1 Mp_present arg' st.env in
             let subst = Subst.add_module id2 (Path.Pident id1) st.subst in
             expand_params { st with env; subst }
-        | None, Some id2 ->
+        | None, Some id2  ->
             let env = Env.add_module id2 Mp_present arg' st.env in
             { st with env }, [||]
         | Some id1, None ->
@@ -1126,46 +1135,37 @@ module Functor_app_diff = struct
     let open Error in
     match d with
     | Insert (Unit|Named(None,_))
-    | Delete _
-    | Keep ((Unit,_),_,_)
-    | Keep (_,Unit,_)
+    | Delete _ (* delete is a concrete argument, not an abstract parameter*)
+    | Keep ((Unit,_),_,_) (* Keep(Unit,_) implies Keep(Unit,Unit) *)
+    | Keep (_,(Unit|Named(None,_)),_)
     | Change (_,(Unit|Named (None,_)), _ ) ->
+        (* no abstract parameters to add, nor any equations *)
         st, [||]
     | Insert(Named(Some param, param_ty))
     | Change(_, Named(Some param, param_ty), _ ) ->
-        (* we add the parameter to the environnement to track equalities with
-           external components that the parameter might add. *)
+        (* Change is Delete + Insert: we add the Inserted parameter to the
+           environnement to track equalities with external components that the
+           parameter might add. *)
         let mty = Subst.modtype Keep st.subst param_ty in
         let env = Env.add_module ~arg:true param Mp_present mty st.env in
         I.expand_params { st with env }
-    | Keep ((Named arg,  _mty) , Named (param_name, _param), _) ->
-        begin match param_name with
-        | Some param ->
-            let res =
-              Option.map (fun res ->
-                  let scope = Ctype.create_scope () in
-                  let subst = Subst.add_module param arg Subst.identity in
-                  Subst.modtype (Rescope scope) subst res
-                )
-                st.res
-            in
-            let subst = Subst.add_module param arg st.subst in
-            I.expand_params { st with subst; res }
-        | None ->
-            st, [||]
-        end
-    | Keep (((Anonymous|Empty_struct), mty) , Named (param_name, _param), _) ->
-        begin match param_name with
-        | Some param ->
-            let mty' = Subst.modtype Keep st.subst mty in
-            let env =
-              Env.add_module ~arg:true param Mp_present mty' st.env in
-            let res =
-              Option.map (Mtype.nondep_supertype env [param]) st.res in
-            I.expand_params { st with env; res}
-        | None ->
-            st, [||]
-        end
+    | Keep ((Named arg,  _mty) , Named (Some param, _param), _) ->
+        let res =
+          Option.map (fun res ->
+              let scope = Ctype.create_scope () in
+              let subst = Subst.add_module param arg Subst.identity in
+              Subst.modtype (Rescope scope) subst res
+            )
+            st.res
+        in
+        let subst = Subst.add_module param arg st.subst in
+        I.expand_params { st with subst; res }
+    | Keep (((Anonymous|Empty_struct), mty),
+            Named (Some param, _param), _) ->
+        let mty' = Subst.modtype Keep st.subst mty in
+        let env = Env.add_module ~arg:true param Mp_present mty' st.env in
+        let res = Option.map (Mtype.nondep_supertype env [param]) st.res in
+        I.expand_params { st with env; res}
 
   let diff env ~f ~args =
     let params, res = retrieve_functor_params env f in

--- a/typing/includemod.ml
+++ b/typing/includemod.ml
@@ -1038,13 +1038,20 @@ module Functor_inclusion_diff = struct
     | Delete (Unit | Named (None,_))
     | Keep (Unit,_,_)
     | Keep (_,Unit,_)
-    | Change (_,(Unit | Named (None,_)), _) ->
+    | Change ((Unit|Named(None,_)),(Unit | Named (None,_)), _) ->
         st, [||]
     | Insert (Named (Some id, arg))
     | Delete (Named (Some id, arg))
-    | Change (_, Named (Some id, arg), _) ->
+    | Change ((Unit|Named(None,_)), Named (Some id, arg), _)
+    | Change (Named (Some id, arg), (Unit|Named(None,_)), _) ->
         let arg' = Subst.modtype Keep st.subst arg in
         let env = Env.add_module id Mp_present arg' st.env in
+        expand_params { st with env }
+    | Change (Named (Some id, arg), Named(Some id2, arg2), _) ->
+        let arg = Subst.modtype Keep st.subst arg in
+        let env = Env.add_module id Mp_present arg st.env in
+        let arg2 = Subst.modtype Keep st.subst arg2 in
+        let env = Env.add_module id2 Mp_present arg2 env in
         expand_params { st with env }
     | Keep (Named (name1, _), Named (name2, arg2), _) -> begin
         let arg' = Subst.modtype Keep st.subst arg2 in


### PR DESCRIPTION
This PR fixes by #12061 by making sure that the diffing algorithm for functor errors doesn't add inconsistent equations to the typing environment when exploring potential patches.

More precisely, this PR ensures that whenever the type of the concrete functor argument and the type of the abstract parameter disagree, we don't add any equations between the two.

It might be possible to be more finer-grained and keep consistent equations but that's probably better done at a later point. Note that the second commit in this PR removes a test which is no longer relevant without such addition of consistent equations.

Along the way, this PR fixes a small fixes when the diffing algorithm was not adding enough equations when inserting a missing argument.

Fix #12061 