### PR TITLE
fix random failure in Marshal.from_{string,bytes} (PR#12056)

### DIFF
--- a/Changes
+++ b/Changes
@@ -258,9 +258,10 @@ Working version
   (Boris Yakobowski, review by Daniel Bünzli, Gabriel Scherer and Nicolás Ojeda
   Bär)
 
-- #12006: Add `Marshal.Compression` flag to `Marshal.to_*` functions,
+- #12006, #12064: Add `Marshal.Compression` flag to `Marshal.to_*` functions,
   causing marshaled data to be compressed using ZSTD.
-  (Xavier Leroy, review by Edwin Török and Gabriel Scherer)
+  (Xavier Leroy, review by Edwin Török and Gabriel Scherer, fix by Damien
+   Doligez)
 
 ### Other libraries:
 

--- a/runtime/intern.c
+++ b/runtime/intern.c
@@ -789,8 +789,8 @@ static void caml_parse_header(struct caml_intern_state* s,
 /* Decompress the input if needed.
    Must be called after [intern_init].
    Should preferably be called before [intern_alloc_storage]
-   (so that the memory block for the compressed input can be freed
-    before more memory is allocated). */
+   when the memory block for the compressed input can be freed
+   before more memory is allocated. */
 
 static void intern_decompress_input(struct caml_intern_state * s,
                                     const char * fun_name,
@@ -907,11 +907,11 @@ CAMLexport value caml_input_val_from_bytes(value str, intnat ofs)
   caml_parse_header(s, "input_val_from_string", &h);
   if (ofs + h.header_len + h.data_len > caml_string_length(str))
     caml_failwith("input_val_from_string: bad length");
-  /* Decompress if needed */
-  s->intern_src = &Byte_u(str, ofs + h.header_len); /* If a GC occurred */
-  intern_decompress_input(s, "input_val_from_string", &h);
   /* Allocate result */
   intern_alloc_storage(s, h.whsize, h.num_objects);
+  s->intern_src = &Byte_u(str, ofs + h.header_len); /* If a GC occurred */
+  /* Decompress if needed */
+  intern_decompress_input(s, "input_val_from_string", &h);
   /* Fill it in */
   intern_rec(s, &obj);
   CAMLreturn (intern_end(s, obj));


### PR DESCRIPTION
The problem is pretty basic after all: a minor GC occurs while `caml_input_val_from_bytes` is holding an infix pointer into a string located in the minor heap.

The fix involves moving the call to `intern_decompress_input` after `intern_alloc_storage` and removing the comment that says not to do that. The comment was misleading because `intern_alloc_storage` only allocates in the minor heap while `intern_decompress_input` frees memory in `malloc` land, so they can't interact anyway.

Fixes (one part of) #12056
