### PR TITLE
Documentation-only: Add Windows specifics for `process_status` type

### DIFF
--- a/Changes
+++ b/Changes
@@ -284,6 +284,10 @@ Working version
 * #11991: Unix on Windows: map ERROR_TOO_MANY_LINKS to EMLINK.
   (Nicolás Ojeda Bär)
 
+- #12067: Document Windows specific meanings of `Unix.process_status`
+  type
+  (Samuel Hym, review by David Allsopp)
+
 ### Tools:
 
 - #1172: fix ocamlyacc's handling of raw string literals

--- a/otherlibs/unix/unix.mli
+++ b/otherlibs/unix/unix.mli
@@ -198,7 +198,15 @@ type process_status =
            signal number. *)
 (** The termination status of a process.  See module {!Sys} for the
     definitions of the standard signal numbers.  Note that they are
-    not the numbers used by the OS. *)
+    not the numbers used by the OS.
+
+    On Windows: only [WEXITED] is used (as there are no inter-process signals)
+    but with specific return codes to indicate special termination causes.
+    Look for [NTSTATUS] values in the Windows documentation to decode such error
+    return codes. In particular, [STATUS_ACCESS_VIOLATION] error code
+    is the 32-bit [0xC0000005]: as [Int32.of_int 0xC0000005] is
+    [-1073741819], [WEXITED -1073741819] is the Windows equivalent of
+    [WSIGNALED Sys.sigsegv]. *)
 
 
 type wait_flag =

--- a/otherlibs/unix/unixLabels.mli
+++ b/otherlibs/unix/unixLabels.mli
@@ -198,7 +198,15 @@ type process_status = Unix.process_status =
            signal number. *)
 (** The termination status of a process.  See module {!Sys} for the
     definitions of the standard signal numbers.  Note that they are
-    not the numbers used by the OS. *)
+    not the numbers used by the OS.
+
+    On Windows: only [WEXITED] is used (as there are no inter-process signals)
+    but with specific return codes to indicate special termination causes.
+    Look for [NTSTATUS] values in the Windows documentation to decode such error
+    return codes. In particular, [STATUS_ACCESS_VIOLATION] error code
+    is the 32-bit [0xC0000005]: as [Int32.of_int 0xC0000005] is
+    [-1073741819], [WEXITED -1073741819] is the Windows equivalent of
+    [WSIGNALED Sys.sigsegv]. *)
 
 
 type wait_flag = Unix.wait_flag =


### PR DESCRIPTION
Add a paragraph to `unix.mli` and `unixLabels.mli` about the `process_status` type to:
- clarify that only `WEXITED` is ever used on Windows (no signal there),
- and refer to `NTSTATUS` documentation for the possible return codes to indicate errors.
I think `NTSTATUS` gives the proper keyword to find the full [list of codes] I was missing to decode errors on Windows.

[list of codes]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-erref/596a1078-e883-4972-9bbc-49e60bebca55