### PR TITLE
Runtime: disable THREADED_INTERPRETER for e2k and pin registers

### DIFF
--- a/runtime/caml/config.h
+++ b/runtime/caml/config.h
@@ -179,7 +179,7 @@ typedef uint64_t uintnat;
    as first-class values (GCC 2.x). */
 
 #if defined(__GNUC__) && __GNUC__ >= 2 && !defined(DEBUG) \
-    && !defined (SHRINKED_GNUC)
+    && !defined (SHRINKED_GNUC) && !defined (__LCC__)
 #define THREADED_CODE
 #endif
 

--- a/runtime/interp.c
+++ b/runtime/interp.c
@@ -168,6 +168,11 @@ Caml_inline void check_trap_barrier_for_effect
 
 #if defined(__GNUC__) && !defined(DEBUG) && !defined(__INTEL_COMPILER) \
     && !defined(__llvm__)
+#ifdef __e2k__
+#define PC_REG asm("%g0")
+#define SP_REG asm("%g1")
+#define ACCU_REG asm("%g2")
+#endif
 #ifdef __mips__
 #define PC_REG asm("$16")
 #define SP_REG asm("$17")


### PR DESCRIPTION
This patch disables THREADED_CODE for e2k architecture https://en.wikipedia.org/wiki/Elbrus_2000 (LCC compiler), since it lacks branch predictor. Also it assigns three global registers to PC, SP and accumulator in bytecode interpreter.