### PR TITLE
intext_par: avoid a sequentiality assumption on object identifiers

### DIFF
--- a/testsuite/tests/lib-marshal/intext_par.ml
+++ b/testsuite/tests/lib-marshal/intext_par.ml
@@ -482,7 +482,7 @@ let test_objects () =
   test 509 (x#test2 = false);
   test 510 (x#test3 = "footest5test3test442");
   test 511 (x#test4 = 42L);
-  test 512 (Oo.id x = Oo.id x0 + 1)     (* PR#5610 *)
+  test 512 (Oo.id x > Oo.id x0)     (* PR#5610 *)
 
 (* Test for infix pointers *)
 let test_infix () =


### PR DESCRIPTION
In presence of concurrent code execution, we cannot assume that two object creation in sequence will return consecutive integers.

(The testcase was added as a regression test for a case where object identifiers were all constant after demarshalling. The weaker test that we propose would also catch this issue if it came back.)

Note: due to the batching of object identifiers, it is in fact very hard to observe a failure of this test: each domain reserves the next 1024 identifiers, so in most case we observe consecutive identifiers for the same domain.