### PR TITLE
Document that Sys.rename works on directories too

### DIFF
--- a/Changes
+++ b/Changes
@@ -288,6 +288,9 @@ Working version
   type
   (Samuel Hym, review by David Allsopp)
 
+- #12072: Document and test that Sys.rename works over directories too
+  (Jan Midtgaard, review by Anil Madhavapeddy and Xavier Leroy)
+
 ### Tools:
 
 - #1172: fix ocamlyacc's handling of raw string literals

--- a/stdlib/sys.mli
+++ b/stdlib/sys.mli
@@ -53,10 +53,11 @@ external remove : string -> unit = "caml_sys_remove"
 (** Remove the given file name from the file system. *)
 
 external rename : string -> string -> unit = "caml_sys_rename"
-(** Rename a file.  [rename oldpath newpath] renames the file
-    called [oldpath], giving it [newpath] as its new name,
-    moving it between directories if needed.  If [newpath] already
-    exists, its contents will be replaced with those of [oldpath].
+(** Rename a file or directory.  [rename oldpath newpath] renames the
+    file or directory called [oldpath], giving it [newpath] as its new name,
+    moving it between (parent) directories if needed.  If a file named
+    [newpath] already exists, its contents will be replaced with those of
+    [oldpath].
     Depending on the operating system, the metadata (permissions,
     owner, etc) of [newpath] can either be preserved or be replaced by
     those of [oldpath].

--- a/testsuite/tests/lib-sys/rename.ml
+++ b/testsuite/tests/lib-sys/rename.ml
@@ -75,3 +75,11 @@ let _ =
   print_string "Rename a nonexisting directory: ";
   testfailure "foo" "bar";
   print_newline();
+  print_string "Rename directory to a non-empty directory: ";
+  Sys.mkdir "foo" 0o755;
+  Sys.mkdir "bar" 0o755;
+  let f1 = Filename.concat "bar" "file1.dat" in
+  writefile f1 "abc";
+  testfailure "foo" "bar";
+  print_newline();
+  safe_remove f1; safe_remove_dir "foo"; safe_remove_dir "bar";

--- a/testsuite/tests/lib-sys/rename.ml
+++ b/testsuite/tests/lib-sys/rename.ml
@@ -18,6 +18,9 @@ let readfile filename =
 let safe_remove filename =
   try Sys.remove filename with Sys_error _ -> ()
 
+let safe_remove_dir dirname =
+  try Sys.rmdir dirname with Sys_error _ -> ()
+
 let testrename f1 f2 contents =
   try
     Sys.rename f1 f2;
@@ -32,6 +35,17 @@ let testfailure f1 f2 =
     Sys.rename f1 f2; print_string "should fail but doesn't!"
   with Sys_error _ ->
     print_string "fails as expected"
+
+let testrenamedir d1 d2 =
+  try
+    Sys.rename d1 d2;
+    try
+      if Sys.is_directory d1 then print_string "source directory still exists!"
+    with Sys_error msg ->
+      if not (Sys.is_directory d2) then print_string "target directory not created!"
+      else print_string "passed"
+  with Sys_error msg ->
+    print_string "Sys_error exception: "; print_string msg
 
 let _ =
   let f1 = "file1.dat" and f2 = "file2.dat" in
@@ -52,4 +66,12 @@ let _ =
   writefile f1 "abc";
   testfailure f1 (Filename.concat "nosuchdir" f2);
   print_newline();
-  safe_remove f1; safe_remove f2
+  safe_remove f1; safe_remove f2;
+  print_string "Rename directory to a nonexisting directory: ";
+  Sys.mkdir "foo" 0o755;
+  testrenamedir "foo" "bar";
+  print_newline();
+  safe_remove_dir "bar";
+  print_string "Rename a nonexisting directory: ";
+  testfailure "foo" "bar";
+  print_newline();

--- a/testsuite/tests/lib-sys/rename.reference
+++ b/testsuite/tests/lib-sys/rename.reference
@@ -2,3 +2,5 @@ Rename to nonexisting file: passed
 Rename to existing file: passed
 Renaming a nonexisting file: fails as expected
 Renaming to a nonexisting directory: fails as expected
+Rename directory to a nonexisting directory: passed
+Rename a nonexisting directory: fails as expected

--- a/testsuite/tests/lib-sys/rename.reference
+++ b/testsuite/tests/lib-sys/rename.reference
@@ -4,3 +4,4 @@ Renaming a nonexisting file: fails as expected
 Renaming to a nonexisting directory: fails as expected
 Rename directory to a nonexisting directory: passed
 Rename a nonexisting directory: fails as expected
+Rename directory to a non-empty directory: fails as expected


### PR DESCRIPTION
This PR documents existing `Sys.rename` functionality over directories:
```ocaml
# Sys.mkdir "/tmp/foo" 0x755;;
- : unit = ()
# Sys.rename "/tmp/foo" "/tmp/bar";;
- : unit = ()
# Sys.is_directory "/tmp/bar";;
- : bool = true
# Sys.is_directory "/tmp/foo";;
Exception: Sys_error "/tmp/foo: No such file or directory".
```

and over symlinks:
```ocaml
$ ln -s /tmp/bar /tmp/link
$ ocaml
# Sys.rename "/tmp/link" "/tmp/link2";;
- : unit = ()
# Sys.file_exists "/tmp/link";;
- : bool = false
# Sys.file_exists "/tmp/link2";;
- : bool = true
```

Digging a bit, I found, e.g., https://github.com/ocaml/ocaml/pull/1306 to make `Sys.rename` more POSIX compatible.
On that note, https://pubs.opengroup.org/onlinepubs/9699919799/functions/rename.html specifies `rename` to work over directories and symlinks too.

This documentation PR is intended as a first step.
I'll open a separate issue with some corner case differences I found for Windows.