### PR TITLE
Minor ergonomic improvements to the manual Makefile

### DIFF
--- a/manual/Makefile
+++ b/manual/Makefile
@@ -17,9 +17,11 @@ manual: tools
 
 pdf: tools
 	$(MAKE) -C src pdf
+	@echo "The generated manual is at ./src/texstuff/manual.pdf"
 
 html: tools
 	$(MAKE) -C src html
+	@echo "The generated manual is at ./src/htmlman/index.html"
 
 web: tools
 	$(MAKE) -C src web

--- a/manual/Makefile
+++ b/manual/Makefile
@@ -15,6 +15,9 @@ tools:
 manual: tools
 	$(MAKE) -C src all
 
+pdf: tools
+	$(MAKE) -C src pdf
+
 html: tools
 	$(MAKE) -C src html
 

--- a/manual/src/Makefile
+++ b/manual/src/Makefile
@@ -54,7 +54,7 @@ endif
 $(DIRS):
 	$(MKDIR) $@
 
-manual: files latex_files | texstuff
+pdf: files latex_files | texstuff
 	cd texstuff \
 	  && TEXINPUTS=$(TEXINPUTS) pdflatex manual.tex
 
@@ -101,9 +101,9 @@ all:
 	$(MAKE) html
 	$(MAKE) text
 	$(MAKE) info
-	$(MAKE) manual
+	$(MAKE) pdf
 	$(MAKE) index
-	$(MAKE) manual
+	$(MAKE) pdf
 
 release: all
 	cp htmlman/manual.html $(RELEASE)refman.html


### PR DESCRIPTION
The big picture: I want to check whether a manual change is correct by looking at the generated PDF, without going through the heavier HTML generation process.

This PR solves three pain points with the manual Makefiles that previously made it too hard. 

1. The toplevel `manual/` Makefile and the specialized `manual/src/` Makefile both have a target named `manual`, but they do different thing (in contrast, their `html` targets do the same thing). The toplevel `manual` builds all the manuals, the specialized `manual` builds only the PDF version. I renamed the specialized target to the more precise name `pdf`.

2. There was no toplevel rule to build only the PDF. I added a toplevel `pdf` target.

3. Once you have built the manual, you have no clue where to find the generated artifacts. I added `echo` printing to the toplevel rules to give their location.