### PR TITLE
Tail-mod-constr manual: set an explicit stack limit

### DIFF
--- a/manual/src/cmds/tail-mod-cons.etex
+++ b/manual/src/cmds/tail-mod-cons.etex
@@ -158,6 +158,31 @@ tail-mod-cons are as follows:
   using a convenient monadic notation.
 \end{itemize}
 
+\paragraph{Note: OCaml call stack size} Under OCaml 4, bytecode
+programs respect the "stack_limit" runtime parameter configuration
+(as set using "Gc.set" in the example above), or the "l" setting of
+the "OCAMLRUNPARAM" variable. Native programs ignore these settings
+and only respect the operating system native stack limit, as set by
+"ulimit" on Unix systems. Most operating systems run with a relatively
+low stack size limit by default, so Stack Overflow on
+non-tail-recursive functions are a common programming bug.
+
+Under OCaml 5, native code does not use the native system stack for
+OCaml function calls anymore, so it is not affected by the operating
+system native stack size; both native and bytecode programs respect
+the OCaml runtime's own limit. The runtime limit is set to a much
+higher default than most operating system native stacks, so we expect
+Stack Overflow occurrences to be much less common in
+practice. (We still have a stack limit by default, as they remain
+useful to quickly catch bugs with looping non-tail-recursive
+functions. Without a stack limit you would have instead to wait for
+them to eat your whole memory, which can take a while.)
+
+This means that the "tail modulo constructor" transformation is less
+important on OCaml 5: it does improve performance noticeably in some
+cases, but it is not necessary for basic correctness for most
+use-cases.
+
 \section{sec:disambiguation}{Disambiguation}
 
 It may happen that several arguments of a constructor are recursive

--- a/manual/src/cmds/tail-mod-cons.etex
+++ b/manual/src/cmds/tail-mod-cons.etex
@@ -164,17 +164,17 @@ configuration (as set using "Gc.set" in the example above), or the "l"
 setting of the "OCAMLRUNPARAM" variable. Native programs ignore these
 settings and only respect the operating system native stack limit, as
 set by "ulimit" on Unix systems. Most operating systems run with
-a relatively low stack size limit by default, so Stack Overflow on
+a relatively low stack size limit by default, so stack overflow on
 non-tail-recursive functions are a common programming bug.
 
 Starting from OCaml 5.0, native code does not use the native system
 stack for OCaml function calls anymore, so it is not affected by the
 operating system native stack size; both native and bytecode programs
 respect the OCaml runtime's own limit. The runtime limit is set to
-a much higher default than most operating system native stacks, so we
-expect Stack Overflow occurrences to be much less common in
-practice. There is still a stack limit by default, as it remains
-useful to quickly catch bugs with looping non-tail-recursive
+a much higher default than most operating system native stacks, with
+a limit of at least 512MiB, so stack overflow should be much less
+common in practice. There is still a stack limit by default, as it
+remains useful to quickly catch bugs with looping non-tail-recursive
 functions. Without a stack limit, one has to wait for the whole memory
 to be consumed by the stack for the program to crash, which can take
 a long time and make the system unresponsive.

--- a/manual/src/cmds/tail-mod-cons.etex
+++ b/manual/src/cmds/tail-mod-cons.etex
@@ -158,25 +158,26 @@ tail-mod-cons are as follows:
   using a convenient monadic notation.
 \end{itemize}
 
-\paragraph{Note: OCaml call stack size} Under OCaml 4, bytecode
-programs respect the "stack_limit" runtime parameter configuration
-(as set using "Gc.set" in the example above), or the "l" setting of
-the "OCAMLRUNPARAM" variable. Native programs ignore these settings
-and only respect the operating system native stack limit, as set by
-"ulimit" on Unix systems. Most operating systems run with a relatively
-low stack size limit by default, so Stack Overflow on
+\paragraph{Note: OCaml call stack size} In OCaml 4.x and earlier,
+bytecode programs respect the "stack_limit" runtime parameter
+configuration (as set using "Gc.set" in the example above), or the "l"
+setting of the "OCAMLRUNPARAM" variable. Native programs ignore these
+settings and only respect the operating system native stack limit, as
+set by "ulimit" on Unix systems. Most operating systems run with
+a relatively low stack size limit by default, so Stack Overflow on
 non-tail-recursive functions are a common programming bug.
 
-Under OCaml 5, native code does not use the native system stack for
-OCaml function calls anymore, so it is not affected by the operating
-system native stack size; both native and bytecode programs respect
-the OCaml runtime's own limit. The runtime limit is set to a much
-higher default than most operating system native stacks, so we expect
-Stack Overflow occurrences to be much less common in
-practice. (We still have a stack limit by default, as they remain
+Starting from OCaml 5.0, native code does not use the native system
+stack for OCaml function calls anymore, so it is not affected by the
+operating system native stack size; both native and bytecode programs
+respect the OCaml runtime's own limit. The runtime limit is set to
+a much higher default than most operating system native stacks, so we
+expect Stack Overflow occurrences to be much less common in
+practice. There is still a stack limit by default, as it remains
 useful to quickly catch bugs with looping non-tail-recursive
-functions. Without a stack limit you would have instead to wait for
-them to eat your whole memory, which can take a while.)
+functions. Without a stack limit, one has to wait for the whole memory
+to be consumed by the stack for the program to crash, which can take
+a long time and make the system unresponsive.
 
 This means that the "tail modulo constructor" transformation is less
 important on OCaml 5: it does improve performance noticeably in some

--- a/manual/src/cmds/tail-mod-cons.etex
+++ b/manual/src/cmds/tail-mod-cons.etex
@@ -22,11 +22,19 @@ remember to continue with "y :: r" after the call returns a value "r",
 therefore this function consumes some amount of call-stack space on
 each recursive call. The stack usage of "map f li" is proportional to
 the length of "li". This is a correctness issue for large lists on
-operating systems with limited stack space -- the dreaded
+systems configured with limited stack space -- the dreaded
 "Stack_overflow" exception.
 
 \begin{caml_example}{toplevel}
-List.length (map Fun.id (List.init 1_000_000 Fun.id));;
+let with_stack_limit stack_limit f =
+   let old_gc_settings = Gc.get () in
+   Gc.set { old_gc_settings with stack_limit };
+   Fun.protect ~finally:(fun () -> Gc.set old_gc_settings) f
+ ;;
+
+with_stack_limit 20_000 (fun () ->
+  List.length (map Fun.id (List.init 1_000_000 Fun.id))
+);;
 \end{caml_example}
 
 In this implementation of "map", the recursive call happens in


### PR DESCRIPTION
Fixes #12000: our example of Stack Overflow with a naive `List.map` on a large list would not overflow as expected anymore. Oops, our code silently started working!

The solution, as proposed in #12000, is to explicitly call `Gc.set` to set a lower stack limit.

The PR also adds a paragraph to the TMC manual chapter that explains the different in stack size enforcement between OCaml 4 and OCaml 5.