### PR TITLE
ocamlc should display badly ordered dependencies only once

### DIFF
--- a/bytecomp/bytelink.ml
+++ b/bytecomp/bytelink.ml
@@ -92,6 +92,10 @@ let missing_globals = ref Ident.Map.empty
 let provided_globals = ref Ident.Set.empty
 let badly_ordered_dependencies : (string * string) list ref = ref []
 
+let record_badly_ordered_dependency (id, compunit) =
+  badly_ordered_dependencies :=
+    ((Ident.name id), compunit.cu_name) :: !badly_ordered_dependencies
+
 let is_required (rel, _pos) =
   match rel with
     Reloc_setglobal id ->
@@ -101,8 +105,7 @@ let is_required (rel, _pos) =
 let add_required compunit =
   let add id =
     if Ident.Set.mem id !provided_globals then
-      badly_ordered_dependencies :=
-        ((Ident.name id), compunit.cu_name) :: !badly_ordered_dependencies;
+      record_badly_ordered_dependency (id, compunit);
     missing_globals := Ident.Map.add id compunit.cu_name !missing_globals
   in
   List.iter add (Symtable.required_globals compunit.cu_reloc);

--- a/bytecomp/bytelink.ml
+++ b/bytecomp/bytelink.ml
@@ -19,6 +19,13 @@ open Misc
 open Config
 open Cmo_format
 
+module Dep = struct
+  type t = string * string
+  let compare = compare
+end
+
+module DepSet = Set.Make (Dep)
+
 type error =
   | File_not_found of filepath
   | Not_an_object_file of filepath
@@ -30,7 +37,7 @@ type error =
   | Cannot_open_dll of filepath
   | Required_module_unavailable of modname * modname
   | Camlheader of string * filepath
-  | Wrong_link_order of (modname * modname) list
+  | Wrong_link_order of DepSet.t
   | Multiple_definition of modname * filepath * filepath
 
 exception Error of error
@@ -90,11 +97,11 @@ let add_ccobjs origin l =
 
 let missing_globals = ref Ident.Map.empty
 let provided_globals = ref Ident.Set.empty
-let badly_ordered_dependencies : (string * string) list ref = ref []
+let badly_ordered_dependencies : DepSet.t ref = ref DepSet.empty
 
 let record_badly_ordered_dependency (id, compunit) =
-  badly_ordered_dependencies :=
-    ((Ident.name id), compunit.cu_name) :: !badly_ordered_dependencies
+  let dep = ((Ident.name id), compunit.cu_name) in
+  badly_ordered_dependencies := DepSet.add dep !badly_ordered_dependencies
 
 let is_required (rel, _pos) =
   match rel with
@@ -632,11 +639,11 @@ let link objfiles output_name =
     match Ident.Map.bindings missing_modules with
     | [] -> ()
     | (id, cu_name) :: _ ->
-        match !badly_ordered_dependencies with
-        | [] ->
+        if DepSet.is_empty !badly_ordered_dependencies
+        then
             raise (Error (Required_module_unavailable (Ident.name id, cu_name)))
-        | l ->
-            raise (Error (Wrong_link_order l))
+        else
+            raise (Error (Wrong_link_order !badly_ordered_dependencies))
   end;
   Clflags.ccobjs := !Clflags.ccobjs @ !lib_ccobjs; (* put user's libs last *)
   Clflags.all_ccopts := !lib_ccopts @ !Clflags.all_ccopts;
@@ -772,7 +779,8 @@ let report_error ppf = function
       fprintf ppf "Module `%s' is unavailable (required by `%s')" s m
   | Camlheader (msg, header) ->
       fprintf ppf "System error while copying file %s: %s" header msg
-  | Wrong_link_order l ->
+  | Wrong_link_order depset ->
+      let l = DepSet.elements depset in
       let depends_on ppf (dep, depending) =
         fprintf ppf "%s depends on %s" depending dep
       in

--- a/bytecomp/bytelink.mli
+++ b/bytecomp/bytelink.mli
@@ -17,6 +17,9 @@ open Misc
 
 (* Link .cmo files and produce a bytecode executable. *)
 
+module Dep : Set.OrderedType with type t = modname * modname
+module DepSet : Set.S with type elt = Dep.t
+
 val link : filepath list -> filepath -> unit
 val reset : unit -> unit
 
@@ -35,7 +38,7 @@ type error =
   | Cannot_open_dll of filepath
   | Required_module_unavailable of modname * modname
   | Camlheader of string * filepath
-  | Wrong_link_order of (modname * modname) list
+  | Wrong_link_order of DepSet.t
   | Multiple_definition of modname * filepath * filepath
 
 exception Error of error

--- a/testsuite/tests/badly-ordered-deps/lib.ml
+++ b/testsuite/tests/badly-ordered-deps/lib.ml
@@ -1,0 +1,1 @@
+let value = Main.value

--- a/testsuite/tests/badly-ordered-deps/main.bytecode.reference
+++ b/testsuite/tests/badly-ordered-deps/main.bytecode.reference
@@ -1,0 +1,2 @@
+File "_none_", line 1:
+Error: Wrong link order: Lib depends on Main

--- a/testsuite/tests/badly-ordered-deps/main.ml
+++ b/testsuite/tests/badly-ordered-deps/main.ml
@@ -1,0 +1,26 @@
+(* TEST
+
+(* Make sure ocamlc prints badly ordeered dependencies only once.
+   See issue #12074. We test with ocamlc.byte only. *)
+
+modules = "lib.ml"
+
+* setup-ocamlc.byte-build-env
+
+** ocamlc.byte
+all_modules = "main.ml"
+compile_only = "true"
+
+*** ocamlc.byte
+all_modules = "lib.ml"
+
+**** ocamlc.byte
+all_modules = "lib.cmo main.cmo"
+compile_only = "false"
+ocamlc_byte_exit_status = "2"
+
+***** check-ocamlc.byte-output
+
+*)
+
+let value = ()


### PR DESCRIPTION
This PR is a fix proposal for issue #12074. The included testcase has been
provided by @hhugo in https://github.com/ocaml/ocaml/issues/12074#issuecomment-1454157135

The PR makes the test pass whereas it fails on trunk and the diff between
the expected and the real output is clear:

```
-Error: Wrong link order: Aux depends on Main
+Error: Wrong link order: Aux depends on Main, Aux depends on Main
```

In other words, it is expected that the bad dependency order is printed
only once but trunk fails to do that and prints it twice.

The PR is done in two commits: the first one splits the recording of the bad
dependency and puts it in its own function without actually changing the
way a bad dependency is recorded. The second commit then modifies
this function so that a bad dependency order gets recorded only if
it has not been already recorded before.