### PR TITLE
one-line fix for #9265, #11949

### DIFF
--- a/debugger/command_line.ml
+++ b/debugger/command_line.ml
@@ -205,7 +205,7 @@ let line_loop ppf line_buffer =
               !previous_line
           in
             previous_line := "";
-            if interprete_line ppf line then
+            if interprete_line ppf line && !interactif then
               previous_line := line
       done
     with


### PR DESCRIPTION
Fortunately, we already have a reference that tells us whether we are interpreting a file from the `source` command or standard input. It's used to suppress prompts. Let's use it also to suppress command repetition.

Fixes #9265 
