### PR TITLE
Add a new debug runtime parameter to efficiently trace the current instruction count

### DIFF
--- a/runtime/caml/startup_aux.h
+++ b/runtime/caml/startup_aux.h
@@ -35,6 +35,7 @@ struct caml_params {
 
   uintnat parser_trace;
   uintnat trace_level;
+  uintnat instruction_counter;
   uintnat runtime_events_log_wsize;
   uintnat verify_heap;
   uintnat print_magic;

--- a/runtime/startup_aux.c
+++ b/runtime/startup_aux.c
@@ -64,6 +64,7 @@ static void init_startup_params(void)
   }
 #endif
   params.trace_level = 0;
+  params.instruction_counter = 0;
   params.cleanup_on_exit = 0;
   params.print_magic = 0;
   params.print_config = 0;
@@ -106,6 +107,7 @@ void caml_parse_ocamlrunparam(void)
       case 'R': break; /*  see stdlib/hashtbl.mli */
       case 's': scanmult (opt, &params.init_minor_heap_wsz); break;
       case 't': scanmult (opt, &params.trace_level); break;
+      case 'C': scanmult (opt, &params.instruction_counter); break;
       case 'v': scanmult (opt, (uintnat *)&caml_verb_gc); break;
       case 'V': scanmult (opt, &params.verify_heap); break;
       case 'W': scanmult (opt, &caml_runtime_warnings); break;

--- a/runtime/startup_byt.c
+++ b/runtime/startup_byt.c
@@ -315,6 +315,9 @@ static int parse_command_line(char_os **argv)
       case 't':
         params->trace_level += 1; /* ignored unless DEBUG mode */
         break;
+      case 'C':
+        params->instruction_counter += 1; /* ignored unless DEBUG mode */
+        break;
       case 'v':
         atomic_store_relaxed(&caml_verb_gc, 0x001+0x004+0x008+0x010+0x020);
         break;


### PR DESCRIPTION
This adds `CAMLRUNPARAM=C=<num>` where `num` is the number of instructions the debug runtime will wait before printing the current instruction counter.

If the trace-level (`CAMLRUNPARAM=t=2` or above) is present, this new parameter will be ignored and the instruction counter will be printed for each instructions as before.

I am using this as a **portable** and **reasonably deterministic** timeout/mini-benchmarking system to detect when opam takes too much time in the opam testsuite.

Compared to using `perf` or the `mperf` OCaml library, this is:
* deterministic: meaning as long as you're not changing the compiler, the result should be the same across platforms and more importantly, with different system load (very important to be able to run this in CI)
* portable: should work on all platform, where perf/mperf's `cycle` or `instructions` stats do not work on some platforms (and aren't reliable anyway)