### PR TITLE
Put the user's manual and stdlib sample code under the CC0 license.

### DIFF
--- a/Changes
+++ b/Changes
@@ -147,6 +147,10 @@ Working version
 
 ### Standard library:
 
+- 12095: Put the sample code of the user's manual and reference
+  documentation of the standard library under the CC0 1.0 Universal
+  (CC0 1.0) Public Domain Dedication license.
+
 * #11565: Enable -strict-formats by default. Some incorrect format
   specifications (for `printf`) where silently ignored and now fail.
   Those new failures occur at compile-time, except if you use advanced

--- a/Changes
+++ b/Changes
@@ -147,10 +147,6 @@ Working version
 
 ### Standard library:
 
-- 12095: Put the sample code of the user's manual and reference
-  documentation of the standard library under the CC0 1.0 Universal
-  (CC0 1.0) Public Domain Dedication license.
-
 * #11565: Enable -strict-formats by default. Some incorrect format
   specifications (for `printf`) where silently ignored and now fail.
   Those new failures occur at compile-time, except if you use advanced
@@ -350,6 +346,10 @@ Working version
   (Xavier Leroy, review by Edwin Török and Gabriel Scherer)
 
 ### Manual and documentation:
+
+- #12095, #12097: Put the sample code of the user's manual and reference
+  documentation of the standard library under the CC0 1.0 Universal
+  (CC0 1.0) Public Domain Dedication license.
 
 - #9430, #11291: Document the general desugaring rules for binding operators.
   (Gabriel Scherer, review by Nicolás Ojeda Bär)

--- a/manual/src/foreword.etex
+++ b/manual/src/foreword.etex
@@ -54,13 +54,24 @@ Automatique (INRIA).
 The OCaml documentation and user's manual is licensed under a Creative
 Commons Attribution-ShareAlike 4.0 International License (CC BY-SA
 4.0), \url{https://creativecommons.org/licenses/by-sa/4.0/}.
+
+The sample code in the user's manual and in the reference documentation
+of the standard library is licensed under a Creative Commons
+CC0 1.0 Universal (CC0 1.0) Public Domain Dedication License,
+\url{https://creativecommons.org/publicdomain/zero/1.0/}.
 \end{latexonly}
 
 \begin{htmlonly}
 \begin{rawhtml}
-<a id="cc_license_logo" rel="license" href="http://creativecommons.org/licenses/by-sa/4.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-sa/4.0/88x31.png"></a>
+<a id="cc_license_logo" rel="license" href="http://creativecommons.org/licenses/by-sa/4.0/"><img alt="Creative Commons License" style="border-width:0" src="https://licensebuttons.net/l/by-sa/4.0/88x31.png"></a>
 The OCaml documentation and user's manual is licensed under a
 <a rel="license" href="http://creativecommons.org/licenses/by-sa/4.0/">Creative Commons Attribution-ShareAlike 4.0 International License</a>.
+
+<a id="cc0_license_logo" rel="license" href="https://creativecommons.org/publicdomain/zero/1.0/"><img alt="Creative Commons License" style="border-width:0" src="https://licensebuttons.net/l/publicdomain/88x31.png"></a>
+The sample code in the user's manual and in the reference documentation
+of the standard library is licensed under a
+<a rel="license" href="https://creativecommons.org/publicdomain/zero/1.0/">Creative Commons
+CC0 1.0 Universal (CC0 1.0) Public Domain Dedication License</a>.
 \end{rawhtml}
 \end{htmlonly}
 

--- a/manual/src/foreword.etex
+++ b/manual/src/foreword.etex
@@ -66,8 +66,10 @@ CC0 1.0 Universal (CC0 1.0) Public Domain Dedication License,
 <a id="cc_license_logo" rel="license" href="http://creativecommons.org/licenses/by-sa/4.0/"><img alt="Creative Commons License" style="border-width:0" src="https://licensebuttons.net/l/by-sa/4.0/88x31.png"></a>
 The OCaml documentation and user's manual is licensed under a
 <a rel="license" href="http://creativecommons.org/licenses/by-sa/4.0/">Creative Commons Attribution-ShareAlike 4.0 International License</a>.
+\end{rawhtml}
 
-<a id="cc0_license_logo" rel="license" href="https://creativecommons.org/publicdomain/zero/1.0/"><img alt="Creative Commons License" style="border-width:0" src="https://licensebuttons.net/l/publicdomain/88x31.png"></a>
+\begin{rawhtml}
+<a id="cc_license_logo" rel="license" href="https://creativecommons.org/publicdomain/zero/1.0/"><img alt="Creative Commons License" style="border-width:0" src="https://licensebuttons.net/l/publicdomain/88x31.png"></a>
 The sample code in the user's manual and in the reference documentation
 of the standard library is licensed under a
 <a rel="license" href="https://creativecommons.org/publicdomain/zero/1.0/">Creative Commons


### PR DESCRIPTION
Closes #12095.