### PR TITLE
Provide event trace for ocamlrund, with -events option

### DIFF
--- a/Changes
+++ b/Changes
@@ -29,6 +29,10 @@ Working version
 
 ### Runtime system:
 
+- #12099: Add ocamlrund option, -events, to produce a trace of
+  debug events during bytecode interpretation. Fixes #12098.
+  (Richard L Ford, review by Gabriel Scherer)
+
 - #12001: Fix book keeping for last finalisers during the minor cycle
   (KC Sivaramakrishnan and Enguerrand Decorne, report by Guillaume Bury
    and Vincent Laviron, review by Sadiq Jaffer and KC Sivaramakrishnan)

--- a/runtime/backtrace_byt.c
+++ b/runtime/backtrace_byt.c
@@ -73,17 +73,6 @@ enum {
   POS_CNUM = 3
 };
 
-/* Runtime representation of the debug information, optimized
-   for quick lookup */
-struct ev_info {
-  code_t ev_pc;
-  char *ev_filename;
-  char *ev_defname;
-  int ev_lnum;
-  int ev_startchr;
-  int ev_endchr;
-};
-
 struct debug_info {
   code_t start;
   code_t end;
@@ -550,6 +539,16 @@ static struct ev_info *event_for_location(code_t pc)
     return &di->events[low];
   if (low+1 < di->num_events && di->events[low+1].ev_pc == pc + 1)
     return &di->events[low+1];
+
+  return NULL;
+}
+
+/* Search for event info at the exact given PC. */
+struct ev_info * caml_exact_event_for_location(code_t pc)
+{
+  struct ev_info *ev = event_for_location(pc);
+  if (ev && ev->ev_pc == pc)
+    return ev;
 
   return NULL;
 }

--- a/runtime/caml/backtrace_prim.h
+++ b/runtime/caml/backtrace_prim.h
@@ -104,6 +104,20 @@ value caml_remove_debug_info(code_t start);
  * explicitly.
  */
 
+/* Runtime representation of the debug information, optimized
+   for quick lookup */
+struct ev_info {
+  code_t ev_pc;
+  char *ev_filename;
+  char *ev_defname;
+  int ev_lnum;
+  int ev_startchr;
+  int ev_endchr;
+};
+
+/* Find the event with the given pc. */
+struct ev_info * caml_exact_event_for_location(code_t pc);
+
 #endif /* CAML_INTERNALS */
 
 #endif /* CAML_BACKTRACE_PRIM_H */

--- a/runtime/caml/instrtrace.h
+++ b/runtime/caml/instrtrace.h
@@ -29,6 +29,7 @@ void caml_disasm_instr (code_t pc);
 void caml_trace_value_file (value v, code_t prog, asize_t proglen, FILE * f);
 void caml_trace_accu_sp_file(value accu, value * sp, code_t prog,
                              asize_t proglen, FILE * f);
+void caml_event_trace (code_t pc);
 
 #endif /* CAML_INTERNALS */
 

--- a/runtime/caml/startup_aux.h
+++ b/runtime/caml/startup_aux.h
@@ -51,6 +51,7 @@ struct caml_params {
   uintnat backtrace_enabled;
   uintnat runtime_warnings;
   uintnat cleanup_on_exit;
+  uintnat event_trace;
 };
 
 extern const struct caml_params* const caml_params;

--- a/runtime/instrtrace.c
+++ b/runtime/instrtrace.c
@@ -32,6 +32,7 @@
 #include "caml/opnames.h"
 #include "caml/prims.h"
 #include "caml/startup.h"
+#include "caml/backtrace_prim.h"
 
 extern code_t caml_start_code;
 
@@ -42,6 +43,22 @@ void caml_stop_here (void)
 }
 
 char * caml_instr_string (code_t pc);
+
+
+void
+caml_event_trace(code_t pc)
+{
+  struct ev_info *evi = caml_exact_event_for_location(pc);
+  if (evi == NULL)
+    return;
+
+  printf("[%02d] Event at PC:%ld, Def:%s, File: %s, Line: %d, Chars:%d-%d\n",
+     Caml_state->id,
+     (long) (pc - caml_start_code),
+     evi->ev_defname, evi->ev_filename,
+     evi->ev_lnum, evi->ev_startchr, evi->ev_endchr);
+  fflush (stdout);
+}
 
 void caml_disasm_instr(code_t pc)
 {

--- a/runtime/interp.c
+++ b/runtime/interp.c
@@ -357,6 +357,7 @@ value caml_interprete(code_t prog, asize_t prog_size)
     if (caml_params->trace_level>1)
       printf("\n##%" ARCH_INTNAT_PRINTF_FORMAT "d\n", caml_bcodcount);
     if (caml_params->trace_level>0) caml_disasm_instr(pc);
+    if (caml_params->event_trace>0) caml_event_trace(pc);
     if (caml_params->trace_level>1) {
       printf("env=");
       caml_trace_value_file(env,prog,prog_size,stdout);

--- a/runtime/startup_aux.c
+++ b/runtime/startup_aux.c
@@ -67,6 +67,7 @@ static void init_startup_params(void)
   params.cleanup_on_exit = 0;
   params.print_magic = 0;
   params.print_config = 0;
+  params.event_trace = 0;
 }
 
 static void scanmult (char_os *opt, uintnat *var)

--- a/runtime/startup_byt.c
+++ b/runtime/startup_byt.c
@@ -281,6 +281,8 @@ static void do_print_help(void)
     "Options are:\n"
     "  -b  Set runtime parameter b (detailed exception backtraces)\n"
     "  -config  Print configuration values and exit\n"
+    "  -events  Trace debug events in bytecode interpreter (ignored \n"
+    "      if not ocamlrund)\n"
     "  -I <dir>  Add <dir> to the list of DLL search directories\n"
     "  -m  Print the magic number of <executable> and exit\n"
     "  -M  Print the magic number expected by this runtime and exit\n"
@@ -352,6 +354,8 @@ static int parse_command_line(char_os **argv)
       } else if (!strcmp_os(argv[i], T("-vnum"))) {
         printf("%s\n", OCAML_VERSION_STRING);
         exit(0);
+      } else if (!strcmp_os(argv[i], T("-events"))) {
+        params->event_trace = 1; /* Ignored unless DEBUG mode */
       } else if (!strcmp_os(argv[i], T("-help")) ||
                  !strcmp_os(argv[i], T("--help"))) {
         do_print_help();


### PR DESCRIPTION
When diagnosing problems with bytecode interpretation (or even just trying to understand the bytecode), it is very helpful to see the associated debug events. This change prints debug events matching the PC, if OCAMLRUNPARAM=b,E. The "b" is to cause the debug information to be read (as needed for backtraces), and the "E" enables the actual printing of events.

Fixes #12098.