### PR TITLE
fix a concurrency memory-safety bug in Buffer

### DIFF
--- a/Changes
+++ b/Changes
@@ -639,6 +639,9 @@ Working version
   (Nicolás Ojeda Bär, review by Xavier Leroy, David Allsop, Javier
   Chávarri, Anil Madhavapeddy)
 
+- #12103, 12104: fix a concurrency memory-safety bug in Buffer
+  (Gabriel Scherer, review by ?, report by Samuel Hym)
+
 OCaml 5.0.0 (15 December 2022)
 ------------------------------
 

--- a/Changes
+++ b/Changes
@@ -883,6 +883,14 @@ OCaml 5.0.0 (15 December 2022)
 - #8878: Add String.hash and String.seeded_hash.
   (Tom Kelly, review by Alain Frisch and Nicolás Ojeda Bär)
 
+- #11279, #11585, #11742: ensure that the unsafe Buffer code
+  remains memory-safe in concurrent settings.
+  Unsychronized access to Buffer is a programming error and may
+  result in wrong behavior, but it should preserve memory-safety.
+  (Florian Angeletti and Gabriel Scherer, review by Gabriel Scherer
+   and Vincent Laviron, report by David Allsopp)
+
+
 ### Other libraries:
 
 * #9071, #9100, #10935: Reimplement `Thread.exit()` as raising the

--- a/stdlib/buffer.ml
+++ b/stdlib/buffer.ml
@@ -166,7 +166,7 @@ let add_string b s =
   let len = String.length s in
   let position = b.position in
   let {buffer; length} = b.inner in
-  let new_position = b.position + len in
+  let new_position = position + len in
   if new_position > length then (
     resize b len;
     Bytes.blit_string s 0 b.inner.buffer b.position len;


### PR DESCRIPTION
Unlike all other add_* functions, Buffer.add_string was reading b.position twice within a code section performing unsafe operations; the unsafe operations could break memory safety in case of race on b.position between the two reads.

closes #12103