### PR TITLE
error messages: aliases for weak row variables

### DIFF
--- a/Changes
+++ b/Changes
@@ -441,9 +441,10 @@ Working version
 - #12024: insert a blank line between separate compiler messages
   (Gabriel Scherer, review by Florian Angeletti, report by David Wong)
 
-- #????: use aliases to mark weak row variables: `_[< ... ]`, `< _..>`, `_#ct`
-  are now rendered as `[< ...] as '_weak1`, `< .. > as 'weak1`, `#ct as 'weak1`
-  (Florian Angeletti, suggestion by Stefan Muenzel, review by ????)
+- #12107: use aliases to mark weak row variables: `_[< ... ]`, `< _..>`, `_#ct`
+  are now rendered as `[< ...] as '_weak1`, `< .. > as '_weak1`,
+  and `#ct as '_weak1`.
+  (Florian Angeletti, suggestion by Stefan Muenzel, review by Gabriel Scherer)
 
 ### Internal/compiler-libs changes:
 

--- a/Changes
+++ b/Changes
@@ -441,6 +441,10 @@ Working version
 - #12024: insert a blank line between separate compiler messages
   (Gabriel Scherer, review by Florian Angeletti, report by David Wong)
 
+- #????: use aliases to mark weak row variables: `_[< ... ]`, `< _..>`, `_#ct`
+  are now rendered as `[< ...] as '_weak1`, `< .. > as 'weak1`, `#ct as 'weak1`
+  (Florian Angeletti, suggestion by Stefan Muenzel, review by ????)
+
 ### Internal/compiler-libs changes:
 
 - #10512: explain the compilation strategy for switches on constructors

--- a/testsuite/tests/typing-misc/polyvars.ml
+++ b/testsuite/tests/typing-misc/polyvars.ml
@@ -220,3 +220,15 @@ type a = int
 type t = [ `A of a ]
 val inspect : [< `A of a & int ] -> unit = <fun>
 |}]
+
+(** Error messages with weakly polymorphic row variables *)
+let x = Fun.id (function `X -> () | _ -> ())
+[%%expect {|
+val x : ([> `X ] as '_weak1) -> unit = <fun>
+|}]
+
+let x = let rec x = `X (`Y (fun y -> x = y)) in Fun.id x
+[%%expect {|
+val x : [> `X of [> `Y of '_weak2 -> bool ] as '_weak3 ] as '_weak2 =
+  `X (`Y <fun>)
+|}]

--- a/testsuite/tests/typing-modules-bugs/pr6899_second_bad.compilers.reference
+++ b/testsuite/tests/typing-modules-bugs/pr6899_second_bad.compilers.reference
@@ -1,5 +1,5 @@
 File "pr6899_second_bad.ml", line 12, characters 6-9:
 12 |   let bar = wrap ()
            ^^^
-Error: The type of this expression, _[< `Test ] -> unit,
+Error: The type of this expression, ([< `Test ] as '_weak1) -> unit,
        contains type variables that cannot be generalized

--- a/testsuite/tests/typing-objects/Exemples.ml
+++ b/testsuite/tests/typing-objects/Exemples.ml
@@ -517,7 +517,7 @@ class ['a] sorted_list :
 
 let l = new sorted_list ();;
 [%%expect{|
-val l : _#comparable sorted_list = <obj>
+val l : (#comparable as '_weak1) sorted_list = <obj>
 |}];;
 let c = new int_comparable 10;;
 [%%expect{|

--- a/testsuite/tests/typing-objects/Tests.ml
+++ b/testsuite/tests/typing-objects/Tests.ml
@@ -950,7 +950,7 @@ end;;
 Line 2, characters 13-58:
 2 |   method o = object(_ : 'self) method o = assert false end
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: Cannot close type of object literal: < o : '_weak3; _.. >
+Error: Cannot close type of object literal: < o : '_weak4; .. > as '_weak3
        it has been unified with the self type of a class that is not yet
        completely defined.
 |}];;

--- a/testsuite/tests/typing-objects/dummy.ml
+++ b/testsuite/tests/typing-objects/dummy.ml
@@ -169,7 +169,7 @@ Lines 4-10, characters 4-7:
  9 |       method child = assert false
 10 |     end
 Error: Cannot close type of object literal:
-       < child : '_weak1; previous : 'a option; _.. > as 'a
+       < child : '_weak2; previous : '_weak1 option; .. > as '_weak1
        it has been unified with the self type of a class that is not yet
        completely defined.
 |}]

--- a/testsuite/tests/typing-objects/errors.ml
+++ b/testsuite/tests/typing-objects/errors.ml
@@ -9,7 +9,7 @@ Line 1, characters 0-75:
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The type of this class,
        class virtual ['a] c :
-         object constraint 'a = _[< `A of int & float ] end,
+         object constraint '_a = [< `A of int & float ] as '_weak1 end,
        contains non-collapsible conjunctive types in constraints.
        Type int is not compatible with type float
 |}]

--- a/testsuite/tests/typing-polyvariants-bugs/pr10664a.ml
+++ b/testsuite/tests/typing-polyvariants-bugs/pr10664a.ml
@@ -110,7 +110,7 @@ let y = g o;;
 [%%expect{|
 val o : < m : 'a 'c. < n : ([< `A of 'a ] as 'c) -> 'b > > as 'b = <obj>
 val y :
-  < n : _[< `A of '_weak2 ] ->
+  < n : ([< `A of '_weak3 ] as '_weak2) ->
         (< m : 'a 'c. < n : ([< `A of 'a ] as 'c) -> 'b > > as 'b) > =
   <obj>
 |}]

--- a/testsuite/tests/typing-polyvariants-bugs/pr7817_bad.ml
+++ b/testsuite/tests/typing-polyvariants-bugs/pr7817_bad.ml
@@ -19,15 +19,18 @@ Lines 5-8, characters 6-3:
 8 | end
 Error: Signature mismatch:
        Modules do not match:
-         sig val write : _[< `A of '_weak2 | `B of '_weak3 ] -> unit end
+         sig
+           val write :
+             ([< `A of '_weak3 | `B of '_weak4 ] as '_weak2) -> unit
+         end
        is not included in
          sig val write : [< `A of string | `B of int ] -> unit end
        Values do not match:
-         val write : _[< `A of '_weak2 | `B of '_weak3 ] -> unit
+         val write : ([< `A of '_weak3 | `B of '_weak4 ] as '_weak2) -> unit
        is not included in
          val write : [< `A of string | `B of int ] -> unit
-       The type _[< `A of '_weak2 | `B of '_weak3 ] -> unit
+       The type ([< `A of '_weak3 | `B of '_weak4 ] as '_weak2) -> unit
        is not compatible with the type [< `A of string | `B of int ] -> unit
-       Type _[< `A of '_weak2 | `B of '_weak3 ] is not compatible with type
-         [< `A of string | `B of int ]
+       Type [< `A of '_weak3 | `B of '_weak4 ] as '_weak2
+       is not compatible with type [< `A of string | `B of int ]
 |}]

--- a/typing/outcometree.mli
+++ b/typing/outcometree.mli
@@ -63,17 +63,16 @@ type out_type =
   | Otyp_open
   | Otyp_alias of {non_gen:bool; aliased:out_type; alias:string}
   | Otyp_arrow of string * out_type * out_type
-  | Otyp_class of bool * out_ident * out_type list
+  | Otyp_class of out_ident * out_type list
   | Otyp_constr of out_ident * out_type list
   | Otyp_manifest of out_type * out_type
-  | Otyp_object of (string * out_type) list * bool option
+  | Otyp_object of { fields: (string * out_type) list; open_row:bool}
   | Otyp_record of (string * bool * out_type) list
   | Otyp_stuff of string
   | Otyp_sum of out_constructor list
   | Otyp_tuple of out_type list
   | Otyp_var of bool * string
-  | Otyp_variant of
-      bool * out_variant * bool * (string list) option
+  | Otyp_variant of out_variant * bool * (string list) option
   | Otyp_poly of string list * out_type
   | Otyp_module of out_ident * (string * out_type) list
   | Otyp_attribute of out_type * out_attribute

--- a/typing/outcometree.mli
+++ b/typing/outcometree.mli
@@ -61,7 +61,7 @@ type out_type_param = string * (Asttypes.variance * Asttypes.injectivity)
 type out_type =
   | Otyp_abstract
   | Otyp_open
-  | Otyp_alias of out_type * string
+  | Otyp_alias of {non_gen:bool; aliased:out_type; alias:string}
   | Otyp_arrow of string * out_type * out_type
   | Otyp_class of bool * out_ident * out_type list
   | Otyp_constr of out_ident * out_type list


### PR DESCRIPTION
On an idea of @smuenzel , this PR proposes to use aliases (` _ as _`) to make weak row type variables more apparent in error messages.

As an illustration, with the current display scheme the type of
```ocaml
let x = Fun.id (function `X -> () | _ -> ())
```
is displayed as ``_[> `X ] -> unit``.  My experience is that the leading `_` can be hard to spot, and people don't necessarily make the link with weakly polymorphic type variables.

To solve both issues, this PR proposes to render this type as `` ([> `X] as '_weak1) -> unit)`` reusing the same naming scheme for weakly polymorphic type variable.

In term of implementation, this PR works by re-using the aliasing mechanism and thus plays nicely with cycle aliases. For instance, the type of
```ocaml
let rec y = `X(`Y (fun z -> y = z)) in Fun.id y
```
is displayed as 
```ocaml
[> `X of [> `Y of '_weak1 -> bool ] as '_weak2 ] as '_weak1
```
( compared to  
```ocaml
_[> `X of _[> `Y of 'a -> bool ] ] as 'a
```
in trunk
).