### PR TITLE
Fix GC corruption when using caml_callback{2,3}_exn with effect handlers

### DIFF
--- a/Changes
+++ b/Changes
@@ -653,6 +653,9 @@ Working version
 - #12103, 12104: fix a concurrency memory-safety bug in Buffer
   (Gabriel Scherer, review by Florian Angeletti, report by Samuel Hym)
 
+- #12112: Fix caml_callback{2,3}_exn when used with effect handlers.
+  (Lucas Pluvinage)
+
 OCaml 5.0.0 (15 December 2022)
 ------------------------------
 

--- a/Changes
+++ b/Changes
@@ -654,7 +654,7 @@ Working version
   (Gabriel Scherer, review by Florian Angeletti, report by Samuel Hym)
 
 - #12112: Fix caml_callback{2,3}_exn when used with effect handlers.
-  (Lucas Pluvinage)
+  (Lucas Pluvinage, review by Gabriel Scherer, David Allsopp and Xavier Leroy)
 
 OCaml 5.0.0 (15 December 2022)
 ------------------------------

--- a/runtime/callback.c
+++ b/runtime/callback.c
@@ -174,7 +174,6 @@ CAMLexport value caml_callback_exn(value closure, value arg)
 CAMLexport value caml_callback2_exn(value closure, value arg1, value arg2)
 {
   Caml_check_caml_state();
-  value args[] = {arg1, arg2};
   caml_domain_state* domain_state = Caml_state;
   caml_maybe_expand_stack();
 
@@ -184,17 +183,13 @@ CAMLexport value caml_callback2_exn(value closure, value arg1, value arg2)
     value res;
 
     cont = save_and_clear_stack_parent(domain_state);
-
-    /* save_and_clear_stack_parent may trigger the GC and move values around.
-       so they are reloaded. */
-    args[0] = arg1;
-    args[1] = arg2;
-
+    value args[] = {arg1, arg2};
     res = caml_callback2_asm(domain_state, closure, args);
     restore_stack_parent(domain_state, cont);
 
     CAMLreturn (res);
   } else {
+    value args[] = {arg1, arg2};
     return caml_callback2_asm(domain_state, closure, args);
   }
 }
@@ -203,7 +198,6 @@ CAMLexport value caml_callback3_exn(value closure,
                                     value arg1, value arg2, value arg3)
 {
   Caml_check_caml_state();
-  value args[] = {arg1, arg2, arg3};
   caml_domain_state* domain_state = Caml_state;
   caml_maybe_expand_stack();
 
@@ -213,18 +207,13 @@ CAMLexport value caml_callback3_exn(value closure,
     value res;
 
     cont = save_and_clear_stack_parent(domain_state);
-
-    /* save_and_clear_stack_parent may trigger the GC and move values around.
-       so they are reloaded. */
-    args[0] = arg1;
-    args[1] = arg2;
-    args[2] = arg3;
-
+    value args[] = {arg1, arg2, arg3};
     res = caml_callback3_asm(domain_state, closure, args);
     restore_stack_parent(domain_state, cont);
 
     CAMLreturn (res);
   } else {
+    value args[] = {arg1, arg2, arg3};
     return caml_callback3_asm(domain_state, closure, args);
   }
 }

--- a/runtime/callback.c
+++ b/runtime/callback.c
@@ -184,6 +184,12 @@ CAMLexport value caml_callback2_exn(value closure, value arg1, value arg2)
     value res;
 
     cont = save_and_clear_stack_parent(domain_state);
+
+    /* save_and_clear_stack_parent may trigger the GC and move values around.
+       so they are reloaded. */
+    args[0] = arg1;
+    args[1] = arg2;
+
     res = caml_callback2_asm(domain_state, closure, args);
     restore_stack_parent(domain_state, cont);
 
@@ -207,6 +213,13 @@ CAMLexport value caml_callback3_exn(value closure,
     value res;
 
     cont = save_and_clear_stack_parent(domain_state);
+
+    /* save_and_clear_stack_parent may trigger the GC and move values around.
+       so they are reloaded. */
+    args[0] = arg1;
+    args[1] = arg2;
+    args[2] = arg3;
+
     res = caml_callback3_asm(domain_state, closure, args);
     restore_stack_parent(domain_state, cont);
 

--- a/testsuite/tests/callback/callback_effects_gc.ml
+++ b/testsuite/tests/callback/callback_effects_gc.ml
@@ -1,0 +1,29 @@
+(* TEST
+   ocamlrunparam = "s=512"
+   * native
+*)
+
+let count = ref 0
+
+let queue = Queue.create ()
+
+let callback (i:int) (ts: int64) =
+  (* add items to queue *)
+  incr count;
+  Queue.push ( (i, ts, ())) queue
+
+external caml_callback : ('a -> 'b -> 'c) -> 'a -> 'b -> 'c = "caml_callback2_exn"
+
+(* main loop *)
+let main () =
+  for i = 0 to 10000 do
+    caml_callback callback (-1) (Int64.of_int i)
+  done
+
+(* a dummy effect handler *)
+let () =
+  Effect.Deep.match_with main () {
+    retc = ignore;
+    exnc = raise;
+    effc = fun _ -> None
+  }

--- a/testsuite/tests/callback/callback_effects_gc.ml
+++ b/testsuite/tests/callback/callback_effects_gc.ml
@@ -1,5 +1,5 @@
 (* TEST
-   ocamlrunparam = "s=512"
+   ocamlrunparam += ",s=512"
    * native
 *)
 


### PR DESCRIPTION
These functions introduced corruption as OCaml values were saved in a local variable that is not tracked by the GC. 

```
CAMLexport value caml_callback2_exn(value closure, value arg1, value arg2)
{
  Caml_check_caml_state();
  value args[] = {arg1, arg2};
```

If the allocation happening in `save_and_clear_stack_parent` triggered a minor GC, these values would be promoted but the `args` array would still point to the old location in the minor heap.
```
  if (Stack_parent(domain_state->current_stack)) {
    CAMLparam3 (closure, arg1, arg2);
    CAMLlocal1 (cont);
    value res;

    cont = save_and_clear_stack_parent(domain_state); // <--- this function allocates
    res = caml_callback2_asm(domain_state, closure, args); // <--- args contains (now invalid) pointers
                                                           //      to the minor heap that were promoted by 
                                                           //      the GC
```

The fix consists in reloading the `arg1`, `arg2` and `arg3` values into `args` before calling the callback. 
I built a small reproduction case that triggers the segfault. 