### PR TITLE
Don't suggest a semicolon when the type is not unit

### DIFF
--- a/Changes
+++ b/Changes
@@ -376,6 +376,9 @@ Working version
 
 ### Compiler user-interface and warnings:
 
+- #12116: Don't suggest to insert a semicolon when the type is not unit
+  (Jules Aguillon, review by Florian Angeletti)
+
 - #11679: Improve the error message about too many arguments to a function
   (Jules Aguillon, review by Gabriel Scherer and Florian Angeletti)
 

--- a/testsuite/tests/typing-misc/apply_non_function.ml
+++ b/testsuite/tests/typing-misc/apply_non_function.ml
@@ -83,3 +83,20 @@ Line 4, characters 19-20:
                        ^
   This extra argument is not expected.
 |}]
+
+(* The result of [(+) 1 2] is not [unit], we don't expect the hint to insert a
+   ';'. *)
+
+let () =
+  (+) 1 2 3
+[%%expect{|
+Line 2, characters 2-11:
+2 |   (+) 1 2 3
+      ^^^^^^^^^
+Error: The function '(+)' has type int -> int -> int
+       It is applied to too many arguments
+Line 2, characters 10-11:
+2 |   (+) 1 2 3
+              ^
+  This extra argument is not expected.
+|}]

--- a/testsuite/tests/typing-misc/apply_non_function.ml
+++ b/testsuite/tests/typing-misc/apply_non_function.ml
@@ -100,3 +100,43 @@ Line 2, characters 10-11:
               ^
   This extra argument is not expected.
 |}]
+
+(* The arrow type might be hidden behind a constructor. *)
+
+type t = int -> int -> unit
+let f (x:t) = x 0 1 2
+[%%expect{|
+type t = int -> int -> unit
+Line 2, characters 14-21:
+2 | let f (x:t) = x 0 1 2
+                  ^^^^^^^
+Error: The function 'x' has type int -> int -> unit
+       It is applied to too many arguments
+Line 2, characters 18-20:
+2 | let f (x:t) = x 0 1 2
+                      ^^
+  Hint: Did you forget a ';'?
+Line 2, characters 20-21:
+2 | let f (x:t) = x 0 1 2
+                        ^
+  This extra argument is not expected.
+|}]
+
+type t = int -> unit
+let f (x:int -> t) = x 0 1 2
+[%%expect{|
+type t = int -> unit
+Line 2, characters 21-28:
+2 | let f (x:int -> t) = x 0 1 2
+                         ^^^^^^^
+Error: The function 'x' has type int -> t
+       It is applied to too many arguments
+Line 2, characters 25-27:
+2 | let f (x:int -> t) = x 0 1 2
+                             ^^
+  Hint: Did you forget a ';'?
+Line 2, characters 27-28:
+2 | let f (x:int -> t) = x 0 1 2
+                               ^
+  This extra argument is not expected.
+|}]

--- a/typing/typecore.mli
+++ b/typing/typecore.mli
@@ -158,6 +158,7 @@ type error =
   | Apply_non_function of {
       funct : Typedtree.expression;
       func_ty : type_expr;
+      res_ty : type_expr;
       previous_arg_loc : Location.t;
       extra_arg_loc : Location.t;
     }


### PR DESCRIPTION
This was suggested by @Octachron in https://github.com/ocaml/ocaml/pull/11679#pullrequestreview-1251290288

This hint message is printed when a function receives too many arguments. It doesn't make sense when the return type of the function is not unit:

    Line 2, characters 2-11:
    2 |   (+) 1 2 3
          ^^^^^^^^^
    Error: The function '(+)' has type int -> int -> int
           It is applied to too many arguments
    Line 2, characters 8-10:
    2 |   (+) 1 2 3
                ^^
      Hint: Did you forget a ';'?

This removes the message when it is not applicable.

The return type is computed again in the printing function by traversing the arrows to avoid passing more values and modifying the type checker.