### PR TITLE
Remove arity-interrupting elaboration of module unpacks

### DIFF
--- a/.depend
+++ b/.depend
@@ -908,7 +908,6 @@ typing/parmatch.cmo : \
     typing/predef.cmi \
     typing/patterns.cmi \
     typing/path.cmi \
-    parsing/parsetree.cmi \
     utils/misc.cmi \
     parsing/longident.cmi \
     parsing/location.cmi \
@@ -928,7 +927,6 @@ typing/parmatch.cmx : \
     typing/predef.cmx \
     typing/patterns.cmx \
     typing/path.cmx \
-    parsing/parsetree.cmi \
     utils/misc.cmx \
     parsing/longident.cmx \
     parsing/location.cmx \

--- a/Changes
+++ b/Changes
@@ -567,6 +567,9 @@ Working version
 - #12092: remove Lev_module_definition from lambda
   (Nick Roberts, review by Gabriel Scherer)
 
+- #12117: Remove arity-interrupting elaboration of module unpacks
+  (Nick Roberts, review by Richard Eisenberg and Jacques Garrigue)
+
 - #12118: stop storing names of predefined exceptions in the
   cu_required_globals field of compilation unit descriptors.
   (Sébastien Hinderer, review by Vincent Laviron)

--- a/testsuite/tests/typing-fstclassmod/scope_escape.ml
+++ b/testsuite/tests/typing-fstclassmod/scope_escape.ml
@@ -40,11 +40,14 @@ and (module A : S) =
 in
 ();;
 [%%expect{|
-Line 1, characters 8-9:
-1 | let rec k =
-            ^
-Error: This pattern matches values of type (module S with type t = A.t)
-       but a pattern was expected which matches values of type 'a
+Lines 2-6, characters 2-22:
+2 | ..let (module K : S with type t = A.t) = k in
+3 |   (module struct
+4 |     type t = K.t
+5 |   end : S
+6 |     with type t = K.t)
+Error: This expression has type (module S with type t = A.t)
+       but an expression was expected of type 'a
        The type constructor A.t would escape its scope
 |}, Principal{|
 Lines 8-12, characters 2-6:
@@ -55,11 +58,14 @@ Lines 8-12, characters 2-6:
 12 |   end)
 Warning 18 [not-principal]: this module packing is not principal.
 
-Line 1, characters 8-9:
-1 | let rec k =
-            ^
-Error: This pattern matches values of type (module S with type t = A.t)
-       but a pattern was expected which matches values of type 'a
+Lines 2-6, characters 2-22:
+2 | ..let (module K : S with type t = A.t) = k in
+3 |   (module struct
+4 |     type t = K.t
+5 |   end : S
+6 |     with type t = K.t)
+Error: This expression has type (module S with type t = A.t)
+       but an expression was expected of type 'a
        The type constructor A.t would escape its scope
 |}];;
 

--- a/testsuite/tests/typing-fstclassmod/scope_escape.ml
+++ b/testsuite/tests/typing-fstclassmod/scope_escape.ml
@@ -1,0 +1,117 @@
+(* TEST
+   * expect
+*)
+
+(* Typing for recursive modules checks scope escape *)
+module type S = sig
+  type t
+end;;
+
+let rec (module M : S) =
+  (module struct
+    type t = M.t
+  end : S
+    with type t = M.t)
+in
+();;
+[%%expect{|
+module type S = sig type t end
+Lines 6-9, characters 2-22:
+6 | ..(module struct
+7 |     type t = M.t
+8 |   end : S
+9 |     with type t = M.t)
+Error: This expression has type (module S with type t = M.t)
+       but an expression was expected of type (module S)
+       The type constructor M.t would escape its scope
+|}];;
+
+let rec k =
+  let (module K : S with type t = A.t) = k in
+  (module struct
+    type t = K.t
+  end : S
+    with type t = K.t)
+and (module A : S) =
+  (module struct
+    type t = unit
+
+    let x = ()
+  end)
+in
+();;
+[%%expect{|
+Line 2, characters 41-42:
+2 |   let (module K : S with type t = A.t) = k in
+                                             ^
+Error: This expression has type 'a but an expression was expected of type
+         (module S with type t = A.t)
+       The type constructor A.t would escape its scope
+|}];;
+
+(* The locally abstract type lets us check the module's type
+   without scope escape. *)
+let f (type a) () =
+  let rec (module M : S with type t = a) =
+    (module struct
+      type t = M.t
+    end : S with type t = M.t)
+  in
+  ()
+;;
+[%%expect{|
+val f : unit -> unit = <fun>
+|}];;
+
+let f (type a) () =
+  let rec (module M : S with type t = a) =
+    (module struct
+      type t = M.t
+    end : S with type t = a)
+  in
+  ();;
+[%%expect{|
+val f : unit -> unit = <fun>
+|}];;
+
+(* Reject scope escape via unification *)
+
+module type S = sig
+  type t
+  val x : t
+end;;
+
+let f () =
+  let (module M : S) =
+    (module struct
+      type t = unit
+
+      let x = ()
+    end)
+  in
+  let unify x = if true then M.x else x in
+  unify ()
+;;
+[%%expect{|
+module type S = sig type t val x : t end
+Line 15, characters 8-10:
+15 |   unify ()
+             ^^
+Error: This expression has type unit but an expression was expected of type
+         M.t
+|}, Principal{|
+module type S = sig type t val x : t end
+Lines 8-12, characters 4-8:
+ 8 | ....(module struct
+ 9 |       type t = unit
+10 |
+11 |       let x = ()
+12 |     end)
+Warning 18 [not-principal]: this module packing is not principal.
+
+Line 15, characters 8-10:
+15 |   unify ()
+             ^^
+Error: This expression has type unit but an expression was expected of type
+         M.t
+|}];;

--- a/testsuite/tests/typing-fstclassmod/scope_escape.ml
+++ b/testsuite/tests/typing-fstclassmod/scope_escape.ml
@@ -23,7 +23,6 @@ Lines 6-9, characters 2-22:
 9 |     with type t = M.t)
 Error: This expression has type (module S with type t = M.t)
        but an expression was expected of type (module S)
-       The type constructor M.t would escape its scope
 |}];;
 
 let rec k =
@@ -41,11 +40,26 @@ and (module A : S) =
 in
 ();;
 [%%expect{|
-Line 2, characters 41-42:
-2 |   let (module K : S with type t = A.t) = k in
-                                             ^
-Error: This expression has type 'a but an expression was expected of type
-         (module S with type t = A.t)
+Line 1, characters 8-9:
+1 | let rec k =
+            ^
+Error: This pattern matches values of type (module S with type t = A.t)
+       but a pattern was expected which matches values of type 'a
+       The type constructor A.t would escape its scope
+|}, Principal{|
+Lines 8-12, characters 2-6:
+ 8 | ..(module struct
+ 9 |     type t = unit
+10 |
+11 |     let x = ()
+12 |   end)
+Warning 18 [not-principal]: this module packing is not principal.
+
+Line 1, characters 8-9:
+1 | let rec k =
+            ^
+Error: This pattern matches values of type (module S with type t = A.t)
+       but a pattern was expected which matches values of type 'a
        The type constructor A.t would escape its scope
 |}];;
 

--- a/typing/parmatch.ml
+++ b/typing/parmatch.ml
@@ -2312,52 +2312,17 @@ let pattern_stable_vars ns p =
 
 (* All identifier paths that appear in an expression that occurs
    as a clause right hand side or guard.
-
-  The function is rather complex due to the compilation of
-  unpack patterns by introducing code in rhs expressions
-  and **guards**.
-
-  For pattern (module M:S)  -> e the code is
-  let module M_mod = unpack M .. in e
-
-  Hence M is "free" in e iff M_mod is free in e.
-
-  Not doing so will yield excessive  warning in
-  (module (M:S) } ...) when true -> ....
-  as M is always present in
-  let module M_mod = unpack M .. in true
 *)
 
 let all_rhs_idents exp =
   let ids = ref Ident.Set.empty in
-(* Very hackish, detect unpack pattern  compilation
-   and perform "indirect check for them" *)
-  let is_unpack exp =
-      List.exists
-        (fun attr -> attr.Parsetree.attr_name.txt = "#modulepat")
-        exp.exp_attributes in
   let open Tast_iterator in
   let expr_iter iter exp =
-    (match exp.exp_desc with
-      | Texp_ident (path, _lid, _descr) ->
+    match exp.exp_desc with
+    | Texp_ident (path, _lid, _descr) ->
         List.iter (fun id -> ids := Ident.Set.add id !ids) (Path.heads path)
-      (* Use default iterator methods for rest of match.*)
-      | _ -> Tast_iterator.default_iterator.expr iter exp);
-
-    if is_unpack exp then begin match exp.exp_desc with
-    | Texp_letmodule
-        (id_mod,_,_,
-         {mod_desc=
-          Tmod_unpack ({exp_desc=Texp_ident (Path.Pident id_exp,_,_)},_)},
-         _) ->
-           assert (Ident.Set.mem id_exp !ids) ;
-           begin match id_mod with
-           | Some id_mod when not (Ident.Set.mem id_mod !ids) ->
-             ids := Ident.Set.remove id_exp !ids
-           | _ -> ()
-           end
-    | _ -> assert false
-    end
+    (* Use default iterator methods for rest of match.*)
+    | _ -> Tast_iterator.default_iterator.expr iter exp
   in
   let iterator = {Tast_iterator.default_iterator with expr = expr_iter} in
   iterator.expr iterator exp;

--- a/typing/typeclass.ml
+++ b/typing/typeclass.ml
@@ -1175,7 +1175,7 @@ and class_expr_aux cl_num val_env met_env virt self_scope scl =
       in
       let partial =
         let dummy = type_exp val_env (Ast_helper.Exp.unreachable ()) in
-        Typecore.check_partial val_env pat.pat_type pat.pat_loc
+        Typecore.check_partial Modules_rejected val_env pat.pat_type pat.pat_loc
           [{c_lhs = pat; c_guard = None; c_rhs = dummy}]
       in
       let cl =

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -3113,7 +3113,7 @@ and type_expect_
       let may_contain_modules =
         List.exists (fun pvb -> may_contain_modules pvb.pvb_pat) spat_sexp_list
       in
-      let pat_exp_list, body, _new_env =
+      let (pat_exp_list, body, _new_env) =
         with_local_level_if may_contain_modules begin fun () ->
           let allow_modules =
             if may_contain_modules
@@ -3131,17 +3131,19 @@ and type_expect_
             if rec_flag = Recursive then
               check_recursive_bindings env pat_exp_list
           in
-          pat_exp_list, body, new_env
+          (pat_exp_list, body, new_env)
         end
         (* If the patterns contain module unpacks, there is a possibility that
            the type of the let body or variables bound by the let mention types
            introduced by those unpacks. (The latter can only happen with
            recursive definitions.) Here, we check for scope escape via both of
-           these pathways (body, variables). Checking unification within an
-           environment extended with the module bindings allows us to correctly
-           accept more programs. This environment allows unification to identify
-           more cases where a type introduced by the module is equal to a type
-           introduced at an outer scope. *)
+           these pathways (body, variables).
+
+           Checking unification within an environment extended with the module
+           bindings allows us to correctly accept more programs. This
+           environment allows unification to identify more cases where a type
+           introduced by the module is equal to a type introduced at an outer
+           scope. *)
         ~post:(fun (pat_exp_list, body, new_env) ->
           unify_exp new_env body (newvar ());
           if rec_flag = Recursive then

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -2890,18 +2890,6 @@ let unify_exp ?sdesc_for_hint env exp expected_ty =
   with Error(loc, env, Expr_type_clash(err, tfc, None)) ->
     raise (Error(loc, env, Expr_type_clash(err, tfc, sdesc_for_hint)))
 
-(* Ensure that no bound ident's type mentions a type variable from an inner
-   scope.
-*)
-let check_scope_escape_let_bound_idents env value_bindings =
-  List.iter
-    (fun (_, ident_loc, bound_ident_type) ->
-       try unify env bound_ident_type (newvar ())
-       with Unify trace ->
-         let loc = ident_loc.loc in
-         raise (Error(loc, env, Pattern_type_clash(trace, None))))
-    (let_bound_idents_full value_bindings)
-
 (* If [is_inferred e] is true, [e] will be typechecked without using
    the "expected type" provided by the context. *)
 
@@ -3134,10 +3122,10 @@ and type_expect_
           (pat_exp_list, body, new_env)
         end
         (* If the patterns contain module unpacks, there is a possibility that
-           the type of the let body or variables bound by the let mention types
+           the types of the let body or let definitions mention types
            introduced by those unpacks. (The latter can only happen with
            recursive definitions.) Here, we check for scope escape via both of
-           these pathways (body, variables).
+           these pathways (body, definitions).
 
            Checking unification within an environment extended with the module
            bindings allows us to correctly accept more programs. This
@@ -3147,7 +3135,9 @@ and type_expect_
         ~post:(fun (pat_exp_list, body, new_env) ->
           unify_exp new_env body (newvar ());
           if rec_flag = Recursive then
-            check_scope_escape_let_bound_idents new_env pat_exp_list)
+            List.iter
+              (fun vb -> unify_exp new_env vb.vb_expr (newvar ()))
+              pat_exp_list)
       in
       re {
         exp_desc = Texp_let(rec_flag, pat_exp_list, body);

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -5253,12 +5253,12 @@ and type_let ?check ?check_strict
       in
       (* Note [add_module_variables after checking expressions]
          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-         Don't call [add_module_variables] here, because its use of [type_module]
-         will fail until after we have type-checked the expression of the let.
-         Example: [let m : (module S) = ... in let (module M) = m in ...]
-         We learn the signature [S] from the type of [m] in the RHS of the second
-         let, and we need that knowledge for [type_module] to succeed. If we
-         type-checked expressions before patterns, then we could call
+         Don't call [add_module_variables] here, because its use of
+         [type_module] will fail until after we have type-checked the expression
+         of the let. Example: [let m : (module S) = ... in let (module M) = m in
+         ...] We learn the signature [S] from the type of [m] in the RHS of the
+         second let, and we need that knowledge for [type_module] to succeed. If
+         we type-checked expressions before patterns, then we could call
          [add_module_variables] here.
       *)
       let new_env = add_pattern_variables new_env pvs in

--- a/typing/typecore.mli
+++ b/typing/typecore.mli
@@ -98,6 +98,10 @@ type existential_restriction =
   | In_class_def (** or in [class c = let ... in ...] *)
   | In_self_pattern (** or in self pattern *)
 
+type module_patterns_restriction =
+  | Modules_allowed of { scope : int }
+  | Modules_rejected
+
 val type_binding:
         Env.t -> rec_flag ->
           Parsetree.value_binding list ->
@@ -117,7 +121,7 @@ val type_self_pattern:
         Env.t -> Parsetree.pattern ->
         Typedtree.pattern * pattern_variable list
 val check_partial:
-        ?lev:int -> Env.t -> type_expr ->
+        ?lev:int -> module_patterns_restriction -> Env.t -> type_expr ->
         Location.t -> Typedtree.value Typedtree.case list -> Typedtree.partial
 val type_expect:
         ?in_function:(Location.t * type_expr) ->

--- a/typing/typedtree.mli
+++ b/typing/typedtree.mli
@@ -69,6 +69,8 @@ and pat_extra =
   | Tpat_unpack
         (** (module P)     { pat_desc  = Tpat_var "P"
                            ; pat_extra = (Tpat_unpack, _, _) :: ... }
+            (module _)     { pat_desc  = Tpat_any
+            ; pat_extra = (Tpat_unpack, _, _) :: ... }
          *)
 
 and 'k pattern_desc =


### PR DESCRIPTION
Remove the elaboration of module patterns, where typechecking would insert let-module expressions for each unpack. For example, this source program:
```ocaml
fun (module M : S) y -> M.x + y
```
would be elaborated to this typedtree AST:
```ocaml
fun (m : (module S)) ->
  let module M = (val m) in
  fun y -> M.x + y
```
That is, the only way that modules could be unpacked in typedtree was via `Texp_letmodule`. Now, we perform no such elaboration, and instead treat the `Tpat_var` pattern as an unpack when it has `pat_extra = Tpat_unpack`.

It would be best to review this PR commit-by-commit. The main commit that removes the elaboration is https://github.com/ocaml/ocaml/commit/78d59d67d470770f1b292c90ff33effd28970225, but this makes available a cleanup in a later commit.

The ideas are the same as a Jane Street version of this patch (https://github.com/ocaml-flambda/ocaml-jst/pull/146 and https://github.com/ocaml-flambda/ocaml-jst/pull/150), if you would like to refer to the discussion there when reviewing this.

### Rationale

The old elaboration interrupted the arity of functions, as seen in the example above. Removing this elaboration allows us to simplify the code that tried to recover the arity later. (See https://github.com/ocaml/ocaml/commit/64907ddef5ed5a11f2aa433a1eb5f74c92d0dc61.) This is in service of a PR I'm working on to make function arity syntactic; see https://github.com/ocaml/RFCs/pull/32. But, even without the larger PR, I think this patch is a simplification.

Though the old elaboration was mainly problematic for functions and not so much for `match`/`let`, I remove the elaboration everywhere for consistency.

### Approach

To type-check in the new scheme, we:
  * Treat module patterns as introducing a module identifier at an elevated scope
  * Take care to check that the module's types don't escape via the overall expression type (or the bound variable types, in the case of recursive let definitions)
 
The mechanism we use for this is similar to `gadt_equations_level`, in that we wrap the type-checking of patterns and their extent in its own level, and store the elevated scope in a global ref that pattern type-checking refers to. (In particular, we repurpose the `allow_modules` bool to something like `int option`, where the int payload communicates the scope to enter the module identifier at.)

It's important to think about not only how this PR avoids scope escape, but also how future constructs involving patterns will avoid scope escape. Previously, the way this was accomplished was via the `type_unpacks` function, which type-checked a body expression within the scope of a list of unpacked modules, and confirmed the modules' types didn't escape via the body's type. In this world, it was easy to see that scope escape was checked anywhere a module was used. Now, the responsibility is more diffuse. But we can still state the matter simply. The responsibility to check scope escape falls to whoever creates the scope such that pattern type-checking sets `allow_modules = Modules_allowed { scope }`. You can see this responsibility in action in both the `type_cases` and `type_let` functions. This is summarized in a comment by the `module_patterns_restriction` type.