### PR TITLE
Fix bug introduced in Bytesections: cleanup API  #11623 

### DIFF
--- a/.depend
+++ b/.depend
@@ -2138,15 +2138,12 @@ bytecomp/instruct.cmi : \
     typing/env.cmi
 bytecomp/meta.cmo : \
     bytecomp/instruct.cmi \
-    bytecomp/bytesections.cmi \
     bytecomp/meta.cmi
 bytecomp/meta.cmx : \
     bytecomp/instruct.cmx \
-    bytecomp/bytesections.cmx \
     bytecomp/meta.cmi
 bytecomp/meta.cmi : \
-    bytecomp/instruct.cmi \
-    bytecomp/bytesections.cmi
+    bytecomp/instruct.cmi
 bytecomp/opcodes.cmo : \
     bytecomp/opcodes.cmi
 bytecomp/opcodes.cmx : \

--- a/Changes
+++ b/Changes
@@ -492,8 +492,9 @@ Working version
 - #11569: Remove hash type encoding
   (Hyunggyu Jang, review by Gabriel Scherer and Florian Angeletti)
 
-- #11601, #11612, #11628, #11613, #11623: Clean up some global state handling
-  in emitcode, bytepackager, bytegen, bytesections, spill.
+- #11601, #11612, #11628, #11613, #11623, #12120 : Clean up some
+  global state handling in emitcode, bytepackager, bytegen,
+  bytesections, spill.
   (Hugo Heuzard, Stefan Muenzel, review by Vincent Laviron, Gabriel Scherer
    and Nathanaëlle Courant)
 

--- a/bytecomp/bytelink.ml
+++ b/bytecomp/bytelink.ml
@@ -503,9 +503,9 @@ let link_bytecode_as_c tolink outfile with_main =
        output_string outchan "\n};\n\n";
        (* The sections *)
        let sections =
-         [ Bytesections.Name.SYMB, Symtable.data_global_map();
-           Bytesections.Name.PRIM, Obj.repr(Symtable.data_primitive_names());
-           Bytesections.Name.CRCS, Obj.repr(extract_crc_interfaces()) ] in
+         [ Bytesections.Name.to_string SYMB, Symtable.data_global_map();
+           Bytesections.Name.to_string PRIM, Obj.repr(Symtable.data_primitive_names());
+           Bytesections.Name.to_string CRCS, Obj.repr(extract_crc_interfaces()) ] in
        output_string outchan "static char caml_sections[] = {\n";
        output_data_string outchan
          (Marshal.to_string sections []);

--- a/bytecomp/bytelink.ml
+++ b/bytecomp/bytelink.ml
@@ -503,9 +503,13 @@ let link_bytecode_as_c tolink outfile with_main =
        output_string outchan "\n};\n\n";
        (* The sections *)
        let sections =
-         [ Bytesections.Name.to_string SYMB, Symtable.data_global_map();
-           Bytesections.Name.to_string PRIM, Obj.repr(Symtable.data_primitive_names());
-           Bytesections.Name.to_string CRCS, Obj.repr(extract_crc_interfaces()) ] in
+         [ Bytesections.Name.to_string SYMB,
+           Symtable.data_global_map();
+           Bytesections.Name.to_string PRIM,
+           Obj.repr(Symtable.data_primitive_names());
+           Bytesections.Name.to_string CRCS,
+           Obj.repr(extract_crc_interfaces()) ]
+       in
        output_string outchan "static char caml_sections[] = {\n";
        output_data_string outchan
          (Marshal.to_string sections []);

--- a/bytecomp/bytelink.ml
+++ b/bytecomp/bytelink.ml
@@ -502,7 +502,7 @@ let link_bytecode_as_c tolink outfile with_main =
          (Marshal.to_string (Symtable.initial_global_table()) []);
        output_string outchan "\n};\n\n";
        (* The sections *)
-       let sections =
+       let sections : (string * Obj.t) list =
          [ Bytesections.Name.to_string SYMB,
            Symtable.data_global_map();
            Bytesections.Name.to_string PRIM,

--- a/bytecomp/meta.ml
+++ b/bytecomp/meta.ml
@@ -25,5 +25,5 @@ external release_bytecode : bytecode -> unit
                                  = "caml_static_release_bytecode"
 external invoke_traced_function : Obj.raw_data -> Obj.t -> Obj.t -> Obj.t
                                 = "caml_invoke_traced_function"
-external get_section_table : unit -> (Bytesections.Name.t * Obj.t) list
+external get_section_table : unit -> (string * Obj.t) list
                            = "caml_get_section_table"

--- a/bytecomp/meta.mli
+++ b/bytecomp/meta.mli
@@ -27,5 +27,5 @@ external release_bytecode : bytecode -> unit
                                  = "caml_static_release_bytecode"
 external invoke_traced_function : Obj.raw_data -> Obj.t -> Obj.t -> Obj.t
                                 = "caml_invoke_traced_function"
-external get_section_table : unit -> (Bytesections.Name.t * Obj.t) list
+external get_section_table : unit -> (string * Obj.t) list
                            = "caml_get_section_table"

--- a/bytecomp/symtable.ml
+++ b/bytecomp/symtable.ml
@@ -282,7 +282,11 @@ type section_reader = {
 
 let read_sections () =
   try
-    let sections = Meta.get_section_table () in
+    let sections =
+      List.map
+        (fun (n,o) -> Bytesections.Name.of_string n, o)
+        (Meta.get_section_table ())
+    in
     { read_string =
         (fun name ->
            (Obj.magic(List.assoc name sections) : string));


### PR DESCRIPTION
Some change during code review in https://github.com/ocaml/ocaml/pull/11623 introduced a bug in `meta.ml`.

`Bytesections.Name.t` used to be a string but was later changed to a variant.
This resulted in a wrong signature for Meta.get_section_table.
```
external get_section_table : unit -> (Bytesections.Name.t * Obj.t) list  = "caml_get_section_table"
```
This PR fixes it.