### PR TITLE
callback.c: unrooted implementations of caml_callback*_exn

### DIFF
--- a/Changes
+++ b/Changes
@@ -105,6 +105,9 @@ Working version
 - #12062: fix runtime events consumer: when events are dropped they shouldn't be
   parsed. (Lucas Pluvinage)
 
+- #12121: unrooted implementations of caml_callback*_exn
+  (Gabriel Scherer, review by KC Sivaramakrishnan and Xavier Leroy)
+
 ### Type system:
 
 - #6941, #11187: prohibit using classes through recursive modules

--- a/runtime/callback.c
+++ b/runtime/callback.c
@@ -176,25 +176,25 @@ CAMLexport value caml_callback_exn(value closure, value arg)
   caml_maybe_expand_stack();
 
   if (Stack_parent(domain_state->current_stack)) {
-    CAMLparam0 ();
-    CAMLlocal1 (cont);
-    value res;
+    value cont, res;
 
-    {
-      /* We ensure that [closure], [arg] are preserved over the stack
-         parent allocation, but avoid rooting them over the
-         [caml_callback_asm] call itself.
+    /* We ensure that [closure], [arg] are preserved over the stack
+       parent allocation, but avoid rooting them over the
+       [caml_callback_asm] call itself.
 
-         See the remark on "unrooted callbacks" above.
-      */
-      CAMLparam2 (closure, arg);
-      cont = alloc_and_clear_stack_parent(domain_state);
-      CAMLdrop;
-    }
+       See the remark on "unrooted callbacks" above.
+    */
+    Begin_roots2(closure, arg);
+    cont = alloc_and_clear_stack_parent(domain_state);
+    End_roots();
+
+    Begin_roots1(cont);
     res = caml_callback_asm(domain_state, closure, &arg);
+    End_roots();
+
     restore_stack_parent(domain_state, cont);
 
-    CAMLreturn (res);
+    return res;
   } else {
     return caml_callback_asm(domain_state, closure, &arg);
   }
@@ -207,21 +207,21 @@ CAMLexport value caml_callback2_exn(value closure, value arg1, value arg2)
   caml_maybe_expand_stack();
 
   if (Stack_parent(domain_state->current_stack)) {
-    CAMLparam0 ();
-    CAMLlocal1 (cont);
-    value res;
+    value cont, res;
 
-    {
-      /* Unrooted callbacks; see caml_callback_exn. */
-      CAMLparam3 (closure, arg1, arg2);
-      cont = alloc_and_clear_stack_parent(domain_state);
-      CAMLdrop;
-    }
+    /* Unrooted callbacks; see caml_callback_exn. */
+    Begin_roots3(closure, arg1, arg2);
+    cont = alloc_and_clear_stack_parent(domain_state);
+    End_roots();
+
+    Begin_roots1(cont);
     value args[] = {arg1, arg2};
     res = caml_callback2_asm(domain_state, closure, args);
+    End_roots();
+
     restore_stack_parent(domain_state, cont);
 
-    CAMLreturn (res);
+    return res;
   } else {
     value args[] = {arg1, arg2};
     return caml_callback2_asm(domain_state, closure, args);
@@ -236,21 +236,21 @@ CAMLexport value caml_callback3_exn(value closure,
   caml_maybe_expand_stack();
 
   if (Stack_parent(domain_state->current_stack))  {
-    CAMLparam0 ();
-    CAMLlocal1 (cont);
-    value res;
+    value cont, res;
 
-    {
-      /* Unrooted callbacks; see caml_callback_exn. */
-      CAMLparam4 (closure, arg1, arg2, arg3);
-      cont = alloc_and_clear_stack_parent(domain_state);
-      CAMLdrop;
-    }
+    /* Unrooted callbacks; see caml_callback_exn. */
+    Begin_roots4(closure, arg1, arg2, arg3);
+    cont = alloc_and_clear_stack_parent(domain_state);
+    End_roots();
+
+    Begin_root(cont);
     value args[] = {arg1, arg2, arg3};
     res = caml_callback3_asm(domain_state, closure, args);
+    End_roots();
+
     restore_stack_parent(domain_state, cont);
 
-    CAMLreturn (res);
+    return res;
   } else {
     value args[] = {arg1, arg2, arg3};
     return caml_callback3_asm(domain_state, closure, args);

--- a/runtime/callback.c
+++ b/runtime/callback.c
@@ -36,7 +36,8 @@
  * is executing to ensure that the garbage collector follows the
  * stack parent
  */
-Caml_inline value save_and_clear_stack_parent(caml_domain_state* domain_state) {
+Caml_inline value alloc_and_clear_stack_parent(caml_domain_state* domain_state)
+{
   struct stack_info* parent_stack = Stack_parent(domain_state->current_stack);
   value cont = caml_alloc_1(Cont_tag, Val_ptr(parent_stack));
   Stack_parent(domain_state->current_stack) = NULL;
@@ -44,7 +45,8 @@ Caml_inline value save_and_clear_stack_parent(caml_domain_state* domain_state) {
 }
 
 Caml_inline void restore_stack_parent(caml_domain_state* domain_state,
-                                      value cont) {
+                                      value cont)
+{
   struct stack_info* parent_stack = Ptr_val(Op_val(cont)[0]);
   CAMLassert(Stack_parent(domain_state->current_stack) == NULL);
   Stack_parent(domain_state->current_stack) = parent_stack;
@@ -100,7 +102,7 @@ CAMLexport value caml_callbackN_exn(value closure, int narg, value args[])
   domain_state->current_stack->sp[narg + 2] = Val_long(0); /* extra args */
   domain_state->current_stack->sp[narg + 3] = closure;
 
-  cont = save_and_clear_stack_parent(domain_state);
+  cont = alloc_and_clear_stack_parent(domain_state);
 
   res = caml_interprete(callback_code, sizeof(callback_code));
   if (Is_exception_result(res))
@@ -161,7 +163,7 @@ CAMLexport value caml_callback_exn(value closure, value arg)
     CAMLlocal1 (cont);
     value res;
 
-    cont = save_and_clear_stack_parent(domain_state);
+    cont = alloc_and_clear_stack_parent(domain_state);
     res = caml_callback_asm(domain_state, closure, &arg);
     restore_stack_parent(domain_state, cont);
 
@@ -182,7 +184,7 @@ CAMLexport value caml_callback2_exn(value closure, value arg1, value arg2)
     CAMLlocal1 (cont);
     value res;
 
-    cont = save_and_clear_stack_parent(domain_state);
+    cont = alloc_and_clear_stack_parent(domain_state);
     value args[] = {arg1, arg2};
     res = caml_callback2_asm(domain_state, closure, args);
     restore_stack_parent(domain_state, cont);
@@ -206,7 +208,7 @@ CAMLexport value caml_callback3_exn(value closure,
     CAMLlocal1 (cont);
     value res;
 
-    cont = save_and_clear_stack_parent(domain_state);
+    cont = alloc_and_clear_stack_parent(domain_state);
     value args[] = {arg1, arg2, arg3};
     res = caml_callback3_asm(domain_state, closure, args);
     restore_stack_parent(domain_state, cont);

--- a/runtime/callback.c
+++ b/runtime/callback.c
@@ -176,11 +176,21 @@ CAMLexport value caml_callback_exn(value closure, value arg)
   caml_maybe_expand_stack();
 
   if (Stack_parent(domain_state->current_stack)) {
-    CAMLparam2 (closure, arg);
+    CAMLparam0 ();
     CAMLlocal1 (cont);
     value res;
 
-    cont = alloc_and_clear_stack_parent(domain_state);
+    {
+      /* We ensure that [closure], [arg] are preserved over the stack
+         parent allocation, but avoid rooting them over the
+         [caml_callback_asm] call itself.
+
+         See the remark on "unrooted callbacks" above.
+      */
+      CAMLparam2 (closure, arg);
+      cont = alloc_and_clear_stack_parent(domain_state);
+      CAMLdrop;
+    }
     res = caml_callback_asm(domain_state, closure, &arg);
     restore_stack_parent(domain_state, cont);
 
@@ -197,11 +207,16 @@ CAMLexport value caml_callback2_exn(value closure, value arg1, value arg2)
   caml_maybe_expand_stack();
 
   if (Stack_parent(domain_state->current_stack)) {
-    CAMLparam3 (closure, arg1, arg2);
+    CAMLparam0 ();
     CAMLlocal1 (cont);
     value res;
 
-    cont = alloc_and_clear_stack_parent(domain_state);
+    {
+      /* Unrooted callbacks; see caml_callback_exn. */
+      CAMLparam3 (closure, arg1, arg2);
+      cont = alloc_and_clear_stack_parent(domain_state);
+      CAMLdrop;
+    }
     value args[] = {arg1, arg2};
     res = caml_callback2_asm(domain_state, closure, args);
     restore_stack_parent(domain_state, cont);
@@ -221,11 +236,16 @@ CAMLexport value caml_callback3_exn(value closure,
   caml_maybe_expand_stack();
 
   if (Stack_parent(domain_state->current_stack))  {
-    CAMLparam4 (closure, arg1, arg2, arg3);
+    CAMLparam0 ();
     CAMLlocal1 (cont);
     value res;
 
-    cont = alloc_and_clear_stack_parent(domain_state);
+    {
+      /* Unrooted callbacks; see caml_callback_exn. */
+      CAMLparam4 (closure, arg1, arg2, arg3);
+      cont = alloc_and_clear_stack_parent(domain_state);
+      CAMLdrop;
+    }
     value args[] = {arg1, arg2, arg3};
     res = caml_callback3_asm(domain_state, closure, args);
     restore_stack_parent(domain_state, cont);

--- a/runtime/callback.c
+++ b/runtime/callback.c
@@ -91,8 +91,9 @@ static void init_callback_code(void)
 
 CAMLexport value caml_callbackN_exn(value closure, int narg, value args[])
 {
-  CAMLparam1(closure);
-  CAMLxparamN(args, narg);
+  CAMLparam0();
+  /* We explicitly avoid rooting [closure] and [args].
+     See the remark on "unrooted callbacks" above. */
   CAMLlocal1(cont);
   value res;
   int i;
@@ -115,6 +116,10 @@ CAMLexport value caml_callbackN_exn(value closure, int narg, value args[])
   domain_state->current_stack->sp[narg + 3] = closure;
 
   cont = alloc_and_clear_stack_parent(domain_state);
+  /* This calls the GC and may invalidate the unrooted values
+     [closure] and [args]. They are never used afterwards,
+     as they were copied into the root [domain_state->current_stack].
+  */
 
   res = caml_interprete(callback_code, sizeof(callback_code));
   if (Is_exception_result(res))

--- a/runtime/callback.c
+++ b/runtime/callback.c
@@ -27,6 +27,18 @@
 #include "caml/mlvalues.h"
 #include "caml/platform.h"
 
+/* Unrooted callbacks: an important performance property of callbacks,
+   for example
+     [caml_callback_exn(value closure, value arg)]
+   is that they should not extend the lifetime of the values [closure]
+   and [arg] any farther than necessary, that is, they should be
+   unrooted when the function call actually happens.
+
+   This mirrors the reachability/lifetime guarantees provided by
+   function calls in OCaml code, where the arguments can be collected
+   as soon as they are not used anymore within the function body.
+*/
+
 /*
  * These functions are to ensure effects are handled correctly inside
  * callbacks. There are two aspects:


### PR DESCRIPTION
This is a follow-up to a discussion initiated by @kayceesrk in https://github.com/ocaml/ocaml/pull/12112#issuecomment-1472459975 : when calling an OCaml callback from C (`caml_callback_exn(closure, arg)`), we don't want the callback closure and argument to be rooted during the OCaml-side computation, they should be unrooted so that they can be collected by the GC as soon as they are not needed in the computation anymore -- just like function calls written in OCaml itself, thanks to liveness analysis.

The runtime code previously ensured this property (except for `caml_callbackN_exn` in native code, see below), which I call "unrooted callbacks", but it regressed in 20d107c5e55de22862a8d6f677f69d7c2881e112 : the Multicore logic adds an allocation before the callback itself gets called (for correctness reasons in presence of effects performed in the OCaml callback), and everything got rooted at  this point for correctness.

The present PR restores the property that callbacks are unrooted in both bytecode and native code, following the suggestion in the discussion https://github.com/ocaml/ocaml/pull/12112#issuecomment-1472709699 .

The trickiest change of the PR is the implementation of `caml_callbackN_exn` in native code. Architecture-specific runtimes only implement calls of arity up to 3, and the N-ary version for `N > 3` is implemented by repeated partial application. The liveness property that we should preserve is that each argument is rooted up to just before the corresponding partial application.
This function would in fact not implement unrooted callbacks in its 4.x implementation, see https://github.com/ocaml/ocaml/blob/4.14.0/runtime/callback.c#L128-L157 . In this respect the present PR also improves on 4.x.