### PR TITLE
Add Misc.print_see_manual for easier printing of "see manual section X.Y.Z"

### DIFF
--- a/Changes
+++ b/Changes
@@ -552,9 +552,9 @@ Working version
   cu_required_globals field of compilation unit descriptors.
   (Sébastien Hinderer, review by Vincent Laviron)
 
-- #????: Add Misc.print_see_manual and modify [@manual_ref] to accept
+- #12125: Add Misc.print_see_manual and modify [@manual_ref] to accept
   lists for simpler printing of manual references
-  (Stefan Muenzel, review by ????)
+  (Stefan Muenzel, review by Florian Angeletti)
 
 ### Build system:
 

--- a/Changes
+++ b/Changes
@@ -552,6 +552,10 @@ Working version
   cu_required_globals field of compilation unit descriptors.
   (Sébastien Hinderer, review by Vincent Laviron)
 
+- #????: Add Misc.print_see_manual and modify [@manual_ref] to accept
+  lists for simpler printing of manual references
+  (Stefan Muenzel, review by ????)
+
 ### Build system:
 
 - #11590: Allow installing to a destination path containing spaces.

--- a/lambda/translmod.ml
+++ b/lambda/translmod.ml
@@ -1705,12 +1705,12 @@ let explanation_submsg (id, unsafe_info) =
 
 let report_error loc = function
   | Circular_dependency cycle ->
-      let[@manual.ref "s:recursive-modules"] chapter, section = 12, 2 in
+      let[@manual.ref "s:recursive-modules"] manual_ref = [ 12; 2 ] in
       Location.errorf ~loc ~sub:(List.map explanation_submsg cycle)
         "Cannot safely evaluate the definition of the following cycle@ \
          of recursively-defined modules:@ %a.@ \
-         There are no safe modules in this cycle@ (see manual section %d.%d)."
-        print_cycle cycle chapter section
+         There are no safe modules in this cycle@ %a."
+        print_cycle cycle Misc.print_see_manual manual_ref
   | Conflicting_inline_attributes ->
       Location.errorf "@[Conflicting 'inline' attributes@]"
 

--- a/testsuite/tests/typing-warnings/ambiguous_guarded_disjunction.ml
+++ b/testsuite/tests/typing-warnings/ambiguous_guarded_disjunction.ml
@@ -30,7 +30,7 @@ Line 2, characters 4-29:
 Warning 57 [ambiguous-var-in-pattern-guard]: Ambiguous or-pattern variables under guard;
 variable x appears in different places in different or-pattern alternatives.
 Only the first match will be used to evaluate the guard expression.
-(See manual section 13.5)
+(see manual section 13.5.4)
 
 val ambiguous_typical_example : expr * expr -> unit = <fun>
 |}]
@@ -100,7 +100,7 @@ Line 2, characters 4-43:
 Warning 57 [ambiguous-var-in-pattern-guard]: Ambiguous or-pattern variables under guard;
 variable y appears in different places in different or-pattern alternatives.
 Only the first match will be used to evaluate the guard expression.
-(See manual section 13.5)
+(see manual section 13.5.4)
 
 val ambiguous__y : [> `B of 'a * bool option * bool option ] -> unit = <fun>
 |}]
@@ -134,7 +134,7 @@ Line 2, characters 4-43:
 Warning 57 [ambiguous-var-in-pattern-guard]: Ambiguous or-pattern variables under guard;
 variable y appears in different places in different or-pattern alternatives.
 Only the first match will be used to evaluate the guard expression.
-(See manual section 13.5)
+(see manual section 13.5.4)
 
 val ambiguous__x_y : [> `B of 'a * 'a option * 'a option ] -> unit = <fun>
 |}]
@@ -150,7 +150,7 @@ Line 2, characters 4-43:
 Warning 57 [ambiguous-var-in-pattern-guard]: Ambiguous or-pattern variables under guard;
 variables y, z appear in different places in different or-pattern alternatives.
 Only the first match will be used to evaluate the guard expression.
-(See manual section 13.5)
+(see manual section 13.5.4)
 
 val ambiguous__x_y_z : [> `B of 'a * 'a option * 'a option ] -> unit = <fun>
 |}]
@@ -184,7 +184,7 @@ Line 2, characters 4-40:
 Warning 57 [ambiguous-var-in-pattern-guard]: Ambiguous or-pattern variables under guard;
 variable x appears in different places in different or-pattern alternatives.
 Only the first match will be used to evaluate the guard expression.
-(See manual section 13.5)
+(see manual section 13.5.4)
 
 val ambiguous__in_depth :
   [> `A of [> `B of bool option * bool option ] ] -> unit = <fun>
@@ -218,7 +218,7 @@ Lines 2-3, characters 4-58:
 Warning 57 [ambiguous-var-in-pattern-guard]: Ambiguous or-pattern variables under guard;
 variable x appears in different places in different or-pattern alternatives.
 Only the first match will be used to evaluate the guard expression.
-(See manual section 13.5)
+(see manual section 13.5.4)
 
 val ambiguous__first_orpat :
   [> `A of
@@ -239,7 +239,7 @@ Lines 2-3, characters 4-42:
 Warning 57 [ambiguous-var-in-pattern-guard]: Ambiguous or-pattern variables under guard;
 variable y appears in different places in different or-pattern alternatives.
 Only the first match will be used to evaluate the guard expression.
-(See manual section 13.5)
+(see manual section 13.5.4)
 
 val ambiguous__second_orpat :
   [> `A of
@@ -335,7 +335,7 @@ Lines 2-3, characters 2-17:
 Warning 57 [ambiguous-var-in-pattern-guard]: Ambiguous or-pattern variables under guard;
 variables x, y appear in different places in different or-pattern alternatives.
 Only the first match will be used to evaluate the guard expression.
-(See manual section 13.5)
+(see manual section 13.5.4)
 
 val ambiguous__amoi : amoi -> int = <fun>
 |}]
@@ -358,7 +358,7 @@ Lines 2-3, characters 4-24:
 Warning 57 [ambiguous-var-in-pattern-guard]: Ambiguous or-pattern variables under guard;
 variable M appears in different places in different or-pattern alternatives.
 Only the first match will be used to evaluate the guard expression.
-(See manual section 13.5)
+(see manual section 13.5.4)
 
 val ambiguous__module_variable :
   (module S) * (module S) * (int * int) -> bool -> int = <fun>
@@ -411,7 +411,7 @@ Line 2, characters 4-56:
 Warning 57 [ambiguous-var-in-pattern-guard]: Ambiguous or-pattern variables under guard;
 variables x, y appear in different places in different or-pattern alternatives.
 Only the first match will be used to evaluate the guard expression.
-(See manual section 13.5)
+(see manual section 13.5.4)
 
 val ambiguous_xy_but_not_ambiguous_z : (int -> int -> bool) -> t2 -> int =
   <fun>
@@ -447,7 +447,7 @@ Line 2, characters 4-56:
 Warning 57 [ambiguous-var-in-pattern-guard]: Ambiguous or-pattern variables under guard;
 variables x, y appear in different places in different or-pattern alternatives.
 Only the first match will be used to evaluate the guard expression.
-(See manual section 13.5)
+(see manual section 13.5.4)
 
 val ambiguous_xy_but_not_ambiguous_z : (int -> int -> bool) -> t2 -> int =
   <fun>
@@ -509,7 +509,7 @@ Line 3, characters 4-29:
 Warning 57 [ambiguous-var-in-pattern-guard]: Ambiguous or-pattern variables under guard;
 variable y appears in different places in different or-pattern alternatives.
 Only the first match will be used to evaluate the guard expression.
-(See manual section 13.5)
+(see manual section 13.5.4)
 
 val guarded_ambiguity : expr * expr -> unit = <fun>
 |}]
@@ -541,7 +541,7 @@ Line 4, characters 4-29:
 Warning 57 [ambiguous-var-in-pattern-guard]: Ambiguous or-pattern variables under guard;
 variable x appears in different places in different or-pattern alternatives.
 Only the first match will be used to evaluate the guard expression.
-(See manual section 13.5)
+(see manual section 13.5.4)
 
 val cmp : (a -> bool) -> a alg -> a alg -> unit = <fun>
 |}]

--- a/testsuite/tests/warnings/w52.ml
+++ b/testsuite/tests/warnings/w52.ml
@@ -10,7 +10,7 @@ Line 1, characters 38-43:
                                           ^^^^^
 Warning 52 [fragile-literal-pattern]: Code should not depend on the actual values of
 this constructor's arguments. They are only for information
-and may change in future versions. (See manual section 13.5)
+and may change in future versions. (see manual section 13.5.3)
 |}];;
 
 let () = try () with Match_failure ("Any",_,_) -> ();;
@@ -20,7 +20,7 @@ Line 1, characters 35-46:
                                        ^^^^^^^^^^^
 Warning 52 [fragile-literal-pattern]: Code should not depend on the actual values of
 this constructor's arguments. They are only for information
-and may change in future versions. (See manual section 13.5)
+and may change in future versions. (see manual section 13.5.3)
 |}];;
 
 let () = try () with Match_failure (_,0,_) -> ();;
@@ -30,7 +30,7 @@ Line 1, characters 35-42:
                                        ^^^^^^^
 Warning 52 [fragile-literal-pattern]: Code should not depend on the actual values of
 this constructor's arguments. They are only for information
-and may change in future versions. (See manual section 13.5)
+and may change in future versions. (see manual section 13.5.3)
 |}];;
 
 type t =
@@ -55,7 +55,7 @@ Line 2, characters 7-17:
            ^^^^^^^^^^
 Warning 52 [fragile-literal-pattern]: Code should not depend on the actual values of
 this constructor's arguments. They are only for information
-and may change in future versions. (See manual section 13.5)
+and may change in future versions. (see manual section 13.5.3)
 
 val f : t -> unit = <fun>
 |}];;
@@ -69,7 +69,7 @@ Line 2, characters 8-10:
             ^^
 Warning 52 [fragile-literal-pattern]: Code should not depend on the actual values of
 this constructor's arguments. They are only for information
-and may change in future versions. (See manual section 13.5)
+and may change in future versions. (see manual section 13.5.3)
 
 val g : t -> unit = <fun>
 |}];;
@@ -97,7 +97,7 @@ Line 2, characters 7-34:
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 52 [fragile-literal-pattern]: Code should not depend on the actual values of
 this constructor's arguments. They are only for information
-and may change in future versions. (See manual section 13.5)
+and may change in future versions. (see manual section 13.5.3)
 
 val j : t -> unit = <fun>
 |}];;

--- a/utils/misc.ml
+++ b/utils/misc.ml
@@ -905,6 +905,12 @@ let print_if ppf flag printer arg =
   if !flag then Format.fprintf ppf "%a@." printer arg;
   arg
 
+let print_see_manual ppf manual_section =
+  let open Format in
+  fprintf ppf "(see manual section %a)"
+    (pp_print_list ~pp_sep:(fun f () -> pp_print_char f '.') pp_print_int)
+    manual_section
+
 
 type filepath = string
 type modname = string

--- a/utils/misc.mli
+++ b/utils/misc.mli
@@ -547,6 +547,9 @@ val pp_two_columns :
     v}
 *)
 
+val print_see_manual : Format.formatter -> int list -> unit
+(** See manual section *)
+
 (** {1 Displaying configuration variables} *)
 
 val show_config_and_exit : unit -> unit

--- a/utils/warnings.ml
+++ b/utils/warnings.ml
@@ -872,12 +872,6 @@ let () = ignore @@ parse_options true defaults_warn_error
 let () =
   List.iter (set_alert ~error:false ~enable:false) default_disabled_alerts
 
-let ref_manual_explanation () =
-  (* manual references are checked a posteriori by the manual
-     cross-reference consistency check in manual/tests*)
-  let[@manual.ref "s:comp-warnings"] chapter, section = 13, 5 in
-  Printf.sprintf "(See manual section %d.%d)" chapter section
-
 let message = function
   | Comment_start ->
       "this `(*' is the start of a comment.\n\
@@ -1040,10 +1034,12 @@ let message = function
       Printf.sprintf "expected %s"
         (if b then "tailcall" else "non-tailcall")
   | Fragile_literal_pattern ->
-      Printf.sprintf
+      let[@manual.ref "ss:warn52"] ref_manual = [ 13; 5; 3 ] in
+      Format.asprintf
         "Code should not depend on the actual values of\n\
          this constructor's arguments. They are only for information\n\
-         and may change in future versions. %t" ref_manual_explanation
+         and may change in future versions. %a"
+        Misc.print_see_manual ref_manual
   | Unreachable_case ->
       "this match case is unreachable.\n\
        Consider replacing it with a refutation case '<pat> -> .'"
@@ -1056,6 +1052,7 @@ let message = function
   | Inlining_impossible reason ->
       Printf.sprintf "Cannot inline: %s" reason
   | Ambiguous_var_in_pattern_guard vars ->
+      let[@manual.ref "ss:warn57"] ref_manual = [ 13; 5; 4 ] in
       let vars = List.sort String.compare vars in
       let vars_explanation =
         let in_different_places =
@@ -1068,12 +1065,12 @@ let message = function
             let vars = String.concat ", " vars in
             "variables " ^ vars ^ " appear " ^ in_different_places
       in
-      Printf.sprintf
+      Format.asprintf
         "Ambiguous or-pattern variables under guard;\n\
          %s.\n\
          Only the first match will be used to evaluate the guard expression.\n\
-         %t"
-        vars_explanation ref_manual_explanation
+         %a"
+        vars_explanation Misc.print_see_manual ref_manual
   | No_cmx_file name ->
       Printf.sprintf
         "no cmx file was found in path for module %s, \


### PR DESCRIPTION
Prerequisite to #12051

Make printing references to manual sections easier/more consistent by adding `Misc.print_see_manual`.
Additionally, modify the manual check to accept lists of manual sections, so that we can easily pass these as a parameter to `print_see_manual`.

This PR also makes some manual references more detailed.