### PR TITLE
Add deployment phase support for BUILD_PATH_PREFIX_MAP

### DIFF
--- a/Changes
+++ b/Changes
@@ -403,6 +403,13 @@ OCaml 5.1.0
 - #11787: Fix GDB scripts to work with OCaml 5's heap layout. (Nick
   Barnes)
 
+- #12085: Support BUILD_PATH_PREFIX_PATH in ocamldebug. This allows
+  ocamldebug to find the source code even when the build system
+  has mapped build-time absolute paths to abstract paths,
+  such as "/workspace_root" (like Dune does).
+  (Richard L Ford, review and discusson by David Allsop, Gabriel Scherer,
+  and Daniel Bünzli)
+
 - #1172: fix ocamlyacc's handling of raw string literals
   (Demi Marie Obenour)
 

--- a/bytecomp/bytelink.ml
+++ b/bytecomp/bytelink.ml
@@ -297,13 +297,6 @@ let output_debug_info oc =
     !debug_info;
   debug_info := []
 
-(* Transform a file name into an absolute file name *)
-
-let make_absolute file =
-  if not (Filename.is_relative file) then file
-  else Location.rewrite_absolute_path
-         (Filename.concat (Sys.getcwd()) file)
-
 (* Create a bytecode executable file *)
 
 let link_bytecode ?final_name tolink exec_name standalone =
@@ -343,6 +336,10 @@ let link_bytecode ?final_name tolink exec_name standalone =
        (* The path to the bytecode interpreter (in use_runtime mode) *)
        if String.length !Clflags.use_runtime > 0 && !Clflags.with_runtime then
        begin
+         (* Do not use BUILD_PATH_PREFIX_MAP mapping for this. *)
+         let make_absolute file =
+           if Filename.is_relative file then Filename.concat (Sys.getcwd()) file
+           else file in
          let runtime = make_absolute !Clflags.use_runtime in
          let runtime =
            (* shebang mustn't exceed 128 including the #! and \0 *)

--- a/bytecomp/emitcode.ml
+++ b/bytecomp/emitcode.ml
@@ -168,6 +168,41 @@ and slot_for_c_prim name =
 let events = ref ([] : debug_event list)
 let debug_dirs = ref String.Set.empty
 
+(* Map from absolute paths of .ml files to their sanitized paths. *)
+let sanitize_map = Hashtbl.create 17
+
+let sanitize_event ev =
+  let loc = ev.ev_loc in
+  let sloc = loc.loc_start in
+  let path = sloc.pos_fname in
+  match path with
+  | "_none_" | "" | "//toplevel//" ->
+    (* Leave these as it. *)
+    ev
+  | _ ->
+  let unmapped_abspath =
+    if (Filename.is_relative path) then (Filename.concat (Sys.getcwd ()) path)
+    else path
+  in
+  let mapped_abspath = Location.rewrite_absolute_path unmapped_abspath in
+  (* If mapping did nothing, just keep the event as is. *)
+  if mapped_abspath = unmapped_abspath then ev
+  else begin
+    (* We want to share the same sanitized path to save space *)
+    let new_fname = match Hashtbl.find_opt sanitize_map mapped_abspath with
+    | Some saved_path -> saved_path
+    | None ->
+        Hashtbl.add sanitize_map mapped_abspath mapped_abspath;
+        mapped_abspath
+    in
+    let eloc = loc.loc_end in
+    let nsloc = {sloc with pos_fname=new_fname} in
+    let neloc = {eloc with pos_fname=new_fname} in
+    let new_loc: Location.t = {loc with loc_start=nsloc; loc_end=neloc} in
+    let new_ev: Instruct.debug_event = {ev with ev_loc=new_loc} in
+    new_ev
+  end
+
 let record_event ev =
   let path = ev.ev_loc.Location.loc_start.Lexing.pos_fname in
   let abspath = Location.absolute_path path in
@@ -177,6 +212,7 @@ let record_event ev =
     debug_dirs := String.Set.add cwd !debug_dirs;
   end;
   ev.ev_pos <- !out_position;
+  let ev = sanitize_event ev in
   events := ev :: !events
 
 (* Initialization *)
@@ -187,6 +223,7 @@ let clear() =
   reloc_info := [];
   debug_dirs := String.Set.empty;
   events := [];
+  Hashtbl.clear sanitize_map;
   out_buffer := LongString.create 0
 
 let init () =

--- a/debugger/.depend
+++ b/debugger/.depend
@@ -540,12 +540,14 @@ show_source.cmi : \
 source.cmo : \
     primitives.cmi \
     ../utils/misc.cmi \
+    ../parsing/location.cmi \
     ../utils/load_path.cmi \
     debugger_config.cmi \
     source.cmi
 source.cmx : \
     primitives.cmx \
     ../utils/misc.cmx \
+    ../parsing/location.cmx \
     ../utils/load_path.cmx \
     debugger_config.cmx \
     source.cmi
@@ -554,6 +556,7 @@ symbols.cmo : \
     ../bytecomp/symtable.cmi \
     program_loading.cmi \
     ../utils/misc.cmi \
+    ../parsing/location.cmi \
     ../bytecomp/instruct.cmi \
     events.cmi \
     debugger_config.cmi \
@@ -565,6 +568,7 @@ symbols.cmx : \
     ../bytecomp/symtable.cmx \
     program_loading.cmx \
     ../utils/misc.cmx \
+    ../parsing/location.cmx \
     ../bytecomp/instruct.cmx \
     events.cmx \
     debugger_config.cmx \

--- a/debugger/command_line.ml
+++ b/debugger/command_line.ml
@@ -823,6 +823,14 @@ let raw_variable kill name =
        if (not kill) || ask_kill_program () then name := argument),
   function ppf -> fprintf ppf "%s@." !name
 
+let environ_variable kill name =
+  (function lexbuf ->
+     let argument = argument_eol argument lexbuf in
+       if (not kill) || ask_kill_program () then Unix.putenv name argument),
+  function ppf ->
+    try fprintf ppf "%s@." (Unix.getenv name)
+    with Not_found -> fprintf ppf "%s is not set.@." name
+
 let raw_line_variable kill name =
   (function lexbuf ->
      let argument = argument_eol line_argument lexbuf in
@@ -1221,7 +1229,13 @@ It can be either :\n\
      { var_name = "break_on_load";
        var_action = boolean_variable false break_on_load;
        var_help =
-"whether to stop after loading new code (e.g. with Dynlink)." }];
+"whether to stop after loading new code (e.g. with Dynlink)." };
+      { var_name = "mapping";
+        var_action = environ_variable false "DEPLOY_PATH_PREFIX_MAP";
+        var_help =
+"DEPLOY_PATH_PREFIX_MAP used to map abstract\n\
+paths to runtime environment."};
+];
 
   info_list :=
     (* info name, function, help *)

--- a/debugger/program_management.ml
+++ b/debugger/program_management.ml
@@ -128,7 +128,7 @@ let initialize_loading () =
   end;
   Symbols.clear_symbols ();
   Symbols.read_symbols Debugcom.main_frag !program_name;
-  let dirs = Load_path.get_paths () @ !Symbols.program_source_dirs in
+  let dirs = Load_path.get_paths () @ (List.rev !Symbols.program_source_dirs) in
   Load_path.init ~auto_include:Compmisc.auto_include dirs;
   Envaux.reset_cache ();
   if !debug_loading then

--- a/debugger/source.ml
+++ b/debugger/source.ml
@@ -25,6 +25,14 @@ let source_extensions = [".ml"]
 
 let source_of_module pos mdle =
   let pos_fname = pos.Lexing.pos_fname in
+  let pos_fname =
+    match Location.rewrite_find_first_existing pos_fname with
+    | None -> pos_fname
+    | Some target -> target
+    | exception Not_found ->
+      Printf.printf "DEPLOY_PATH_PREFIX_MAP fails to find %s.\n%!" pos_fname;
+      raise Not_found
+  in
   if Sys.file_exists pos_fname then pos_fname else
   let is_submodule m m' =
     let len' = String.length m' in

--- a/man/ocamldebug.1
+++ b/man/ocamldebug.1
@@ -114,6 +114,38 @@ Note that you can also use the
 .B source file
 command to read commands from a file.
 
+.SH ENVIRONMENT VARIABLES
+
+The following environment variable is also consulted:
+.TP
+.B DEPLOY_PATH_PREFIX_MAP
+ocamldebug(1) uses a generalization of the BUILD_PATH_PREFIX_MAP
+specification. See
+.IR https://reproducible-builds.org/specs/build-path-prefix-map/.
+Whereas BUILD_PATH_PREFIX_MAP is used to map from build-time
+absolute paths to abstract paths, the DEPLOY_PATH_PREFIX_MAP
+environment variable is used to map from abstract paths to
+runtime paths. It is the logical inverse of 
+BUILD_PATH_PREFIX_MAP. 
+
+The format of these environment variables is a list of pairs, separated by ':'.
+Each pair is of the form "target=source".
+The source and target paths all are encoded in a way that
+avoids occurrences of ':' and '='. In particular,
+':' -> "%.", '=' -> "%+", '%' -> "%#".
+
+For the deployment mapping, we can have the same source mapping
+to multiple locations. The first one that exists is chosen.
+The mapping are applied from right to left.
+
+For example, with the mapping:
+"/A=/workspace_root:/B=/workspace_root:/C=/workspace_root",
+an abstract path "/workspace_root/afile" will map to the first
+of "/C/afile", "/B/afile", or "/A/afile" that exists.
+This kind of mapping allows for a file to be found first
+in the source directory, but if not there, in the build directory,
+and if not there, in the install directory (usually ~/.opam/switch).
+
 .SH SEE ALSO
 .BR ocamlc (1)
 .br

--- a/man/ocamldebug.1
+++ b/man/ocamldebug.1
@@ -125,8 +125,8 @@ specification. See
 Whereas BUILD_PATH_PREFIX_MAP is used to map from build-time
 absolute paths to abstract paths, the DEPLOY_PATH_PREFIX_MAP
 environment variable is used to map from abstract paths to
-runtime paths. It is the logical inverse of 
-BUILD_PATH_PREFIX_MAP. 
+runtime paths. It is the logical inverse of
+BUILD_PATH_PREFIX_MAP.
 
 The format of these environment variables is a list of pairs, separated by ':'.
 Each pair is of the form "target=source".

--- a/manual/src/cmds/debugger.etex
+++ b/manual/src/cmds/debugger.etex
@@ -79,6 +79,62 @@ file before giving control to the user. The default file is
 ".ocamldebug" in the current directory if it exists, otherwise
 ".ocamldebug" in the user's home directory.
 
+\subsection{ss:debugger-environ}{Environment Variables}
+
+The debugger supports a generalization of the "BUILD_PATH_PREFIX_MAP" 
+environment variable, as defined by the ``BUILD_PATH_PREFIX_MAP specification''
+(see
+\url{https://reproducible-builds.org/specs/build-path-prefix-map}).
+
+The generalization uses a different environment variable,
+"DEPLOY_PATH_PREFIX_MAP" that is the logical inverse of the
+"BUILD_PATH_PREFIX_MAP".
+
+The use of ``DEPLOY_PATH_PREFIX_MAP'' is optional, and not needed
+if the program being debugged was not mapped using
+``BUILD_PATH_PREFIX_MAP'' when it was built.
+
+If ``BUILD_PATH_PREFIX_MAP'' is being used, then
+when the product being debugged was built, ``BUILD_PATH_PREFIX_MAP''
+was set by the build tools so that build-time absolute paths
+where mapped to abstract reproducible paths.
+
+In that case, before ocamldebug is invoked, ``DEPLOY_PATH_PREFIX_MAP``
+must be set to the logical inverse of the
+first mapping. Typically that will be one by a build tool,
+but it may be done manually by a knowledgeable user.
+
+For the deployment mapping, we can have the same source mapping
+to multiple locations. The first one that exists is chosen.
+The mapping are applied from right to left.
+
+For example, with the mapping:
+"/A=/workspace_root:/B=/workspace_root:/C=/workspace_root",
+an abstract path "/workspace_root/afile" will map to the first
+of "/C/afile", "/B/afile", or "/A/afile" that exists.
+This kind of mapping allows for a file to be found first
+in the source directory, but if not there, in the build directory,
+and if not there, in the install directory (usually ~/.opam/switch).
+
+The user (or build tool) can either set the "DEPLOY_PATH_PREFIX_MAP"
+environment variable prior to invoking the debugger, or can use
+debugger commands to set or show it.
+
+To set it within the debugger, for example, use
+
+\begin{verbatim}
+    set mapping target1=src1:target2=src2
+\end{verbatim}
+
+To show the current value, use
+
+\begin{verbatim}
+    show mapping
+\end{verbatim}
+
+Of course, these commands can be used from the user's initialization
+file to set the mapping conveniently.
+
 \subsection{ss:debugger-exut}{Exiting the debugger}
 
 The command "quit" exits the debugger. You can also exit the debugger

--- a/ocamltest/actions_helpers.ml
+++ b/ocamltest/actions_helpers.ml
@@ -386,3 +386,23 @@ let check_output kind_of_output output_variable reference_variable log
       let reason = Printf.sprintf "The command %s failed with status %d"
         commandline exitcode in
       (Result.fail_with_reason reason, env)
+
+let is_in_path program =
+  let path_sep = if Sys.win32 then ';' else ':' in
+  let path = Sys.getenv "PATH" in
+  let paths = String.split_on_char path_sep path in
+  let rec loop = function
+    | [] -> false
+    | hd :: tl ->
+      let full_path = hd ^ "/" ^ program in
+      if Sys.file_exists full_path then true else loop tl
+  in
+  loop paths
+
+let available_in_path action_name exec_name = Actions.make
+  ~name:action_name
+  ~description:("Pass if " ^ exec_name
+                ^ " is available in PATH, otherwise skip")
+  (pass_or_skip (is_in_path exec_name)
+      (exec_name ^ " is available")
+      (exec_name ^ " is not available"))

--- a/ocamltest/actions_helpers.mli
+++ b/ocamltest/actions_helpers.mli
@@ -60,3 +60,10 @@ val run_script : Actions.code
 val run_hook : string -> Actions.code
 
 val check_output : string -> Variables.t -> Variables.t -> Actions.code
+
+val available_in_path : string -> string -> Actions.t
+  (**
+    [available_in_path action_name exec_name] returns an
+    action with name [action_name] that checks whether
+    [exec_name] is available on the path.
+   *)

--- a/ocamltest/builtin_actions.mli
+++ b/ocamltest/builtin_actions.mli
@@ -20,6 +20,7 @@ val skip : Actions.t
 val fail : Actions.t
 
 val dumpenv : Actions.t
+val dumpenv_expanded : Actions.t
 
 val hasunix : Actions.t
 val libunix : Actions.t

--- a/ocamltest/builtin_variables.ml
+++ b/ocamltest/builtin_variables.ml
@@ -146,3 +146,29 @@ let _ = List.iter Variables.register_variable
     test_fail;
     timeout;
   ]
+
+  (* Definition of builtin functions available for use *)
+
+(* The functions are listed in alphabetical order *)
+
+let bppm_decode_fun (arg: string) =
+  match Build_path_prefix_map.decode_prefix arg with
+  | Ok path -> path
+  | Error err -> err
+
+let bppm_decode = Variables.make ~variable_function: bppm_decode_fun
+  ("bppm_decode",
+  "function to do BUILD_PATH_PREFIX_MAP decoding")
+
+let bppm_encode_fun (arg: string) =
+  Build_path_prefix_map.encode_prefix arg
+
+let bppm_encode = Variables.make ~variable_function: bppm_encode_fun
+  ("bppm_encode",
+  "function to do BUILD_PATH_PREFIX_MAP encoding")
+
+  let _ = List.iter Variables.register_variable
+  [
+    bppm_decode;
+    bppm_encode
+  ]

--- a/ocamltest/builtin_variables.mli
+++ b/ocamltest/builtin_variables.mli
@@ -75,3 +75,13 @@ val test_skip : Variables.t
 val test_fail : Variables.t
 
 val timeout : Variables.t
+
+(* Builtin functions *)
+
+val bppm_decode : Variables.t
+  (* ${bppm_decode arg} will decode arg according to the
+     BUILD_PATH_PREFIX_MAP specification. *)
+
+val bppm_encode : Variables.t
+  (* ${bppm_encode arg} will encode arg according to the
+     BUILD_PATH_PREFIX_MAP specification. *)

--- a/ocamltest/environments.mli
+++ b/ocamltest/environments.mli
@@ -24,6 +24,7 @@ val to_bindings : t -> (Variables.t * string) list
 val to_system_env : t -> string array
 val append_to_system_env : string array -> t -> string array
 
+val expand_string : t -> string -> string
 val lookup : Variables.t -> t -> string option
 val lookup_nonempty : Variables.t -> t -> string option
 val safe_lookup : Variables.t -> t -> string
@@ -50,6 +51,8 @@ val unsetenv : Variables.t -> t -> t
 val append : Variables.t -> string -> t -> t
 
 val dump : out_channel -> t -> unit
+
+val dump_expanded : out_channel -> t -> unit
 
 (* Initializers *)
 

--- a/ocamltest/variables.ml
+++ b/ocamltest/variables.ml
@@ -19,10 +19,13 @@ type value = string
 
 type exporter = value -> string * string
 
+type var_fun = (string -> string)
+
 type t = {
   variable_name : string;
   variable_description : string;
-  variable_exporter : exporter
+  variable_exporter : exporter;
+  variable_function : var_fun option
 }
 
 let compare v1 v2 = String.compare v1.variable_name v2.variable_name
@@ -35,23 +38,27 @@ exception No_such_variable of string
 
 let default_exporter varname value = (varname, value)
 
-let make (name, description) =
+let make ?variable_function (name, description) =
   if name="" then raise Empty_variable_name else {
     variable_name = name;
     variable_description = description;
-    variable_exporter = default_exporter name
+    variable_exporter = default_exporter name;
+    variable_function;
   }
 
-let make_with_exporter exporter (name, description) =
+let make_with_exporter ?variable_function exporter (name, description) =
   if name="" then raise Empty_variable_name else {
     variable_name = name;
     variable_description = description;
-    variable_exporter = exporter
+    variable_exporter = exporter;
+    variable_function;
   }
 
 let name_of_variable v = v.variable_name
 
 let description_of_variable v = v.variable_description
+
+let function_of_variable v = v.variable_function
 
 let (variables : (string, t) Hashtbl.t) = Hashtbl.create 10
 

--- a/ocamltest/variables.mli
+++ b/ocamltest/variables.mli
@@ -19,6 +19,9 @@ type value = string
 
 type exporter = value -> string * string
 
+(* The signature of functions that variables support. *)
+type var_fun = (string -> string)
+
 type t
 
 val compare : t -> t -> int
@@ -29,13 +32,16 @@ exception Variable_already_registered of string
 
 exception No_such_variable of string
 
-val make : string * string -> t
+val make : ?variable_function:var_fun -> string * string -> t
 
-val make_with_exporter : exporter -> string * string -> t
+val make_with_exporter :
+  ?variable_function:var_fun -> exporter -> string * string -> t
 
 val name_of_variable : t -> string
 
 val description_of_variable : t -> string
+
+val function_of_variable : t -> var_fun option
 
 val register_variable : t -> unit
 

--- a/parsing/location.ml
+++ b/parsing/location.ml
@@ -158,7 +158,7 @@ let rewrite_absolute_path path =
   | Some map -> Build_path_prefix_map.rewrite map path
 
 let rewrite_find_first_existing path =
-  match Misc.get_build_path_prefix_map () with
+  match Misc.get_deploy_path_prefix_map () with
   | None ->
       if Sys.file_exists path then Some path
       else None
@@ -172,7 +172,7 @@ let rewrite_find_first_existing path =
 
 let rewrite_find_all_existing_dirs path =
   let ok path = Sys.file_exists path && Sys.is_directory path in
-  match Misc.get_build_path_prefix_map () with
+  match Misc.get_deploy_path_prefix_map () with
   | None ->
       if ok path then [path]
       else []

--- a/testsuite/tests/builtin-functions/bppm/decode/decode.ml
+++ b/testsuite/tests/builtin-functions/bppm/decode/decode.ml
@@ -1,0 +1,11 @@
+(* TEST
+ set input1 = "ab%#c%.d%+ef";
+ set input2 = "$input1";
+ set result = "${bppm_decode $input2}";
+ dumpenv_expanded;
+
+ script = "sh ${test_source_directory}/decode_checker.sh";
+ script;
+*)
+
+(* This file only contains the specification of how to run the test *)

--- a/testsuite/tests/builtin-functions/bppm/decode/decode_checker.sh
+++ b/testsuite/tests/builtin-functions/bppm/decode/decode_checker.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+if [ "${result}" = "ab%c:d=ef" ]; then
+    exit ${TEST_PASS}
+else
+    echo result=${result}, expected "ab%c:d=ef" > ${ocamltest_response}
+    exit ${TEST_FAIL}
+fi

--- a/testsuite/tests/builtin-functions/bppm/encode/encode.ml
+++ b/testsuite/tests/builtin-functions/bppm/encode/encode.ml
@@ -1,0 +1,11 @@
+(* TEST
+ set input1 = "ab%c:d=ef";
+ set input2 = "$input1";
+ set result = "${bppm_encode $input2}";
+ dumpenv_expanded;
+
+ script = "sh ${test_source_directory}/encode_checker.sh";
+ script;
+*)
+
+(* This file only contains the specification of how to run the test *)

--- a/testsuite/tests/builtin-functions/bppm/encode/encode_checker.sh
+++ b/testsuite/tests/builtin-functions/bppm/encode/encode_checker.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+if [ "${result}" = "ab%#c%.d%+ef" ]; then
+    exit ${TEST_PASS}
+else
+    echo result=${result}, expected "ab%#c%.d%+ef" > ${ocamltest_response}
+    exit ${TEST_FAIL}
+fi

--- a/testsuite/tests/builtin-functions/bppm/encode_decode/encode.ml
+++ b/testsuite/tests/builtin-functions/bppm/encode_decode/encode.ml
@@ -1,0 +1,12 @@
+(* TEST
+ set input1 = "ab%c:d=ef";
+ set input2 = "$input1";
+ set result1 = "${bppm_encode $input2}";
+ set result2 = "${bppm_decode $result1}";
+ dumpenv_expanded;
+
+ script = "sh ${test_source_directory}/encode_checker.sh";
+ script;
+*)
+
+(* This file only contains the specification of how to run the test *)

--- a/testsuite/tests/builtin-functions/bppm/encode_decode/encode_checker.sh
+++ b/testsuite/tests/builtin-functions/bppm/encode_decode/encode_checker.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+if [ "${result1}" != "ab%#c%.d%+ef" ]; then
+    echo result1=${result1}, expected "ab%#c%.d%+ef" > ${ocamltest_response}
+    exit ${TEST_FAIL}
+else
+    if [ "${result2}" != "ab%c:d=ef" ]; then
+        echo result1=${result1}, expected "ab%c:d=ef" > ${ocamltest_response}
+        exit ${TEST_FAIL}
+    fi
+    exit ${TEST_PASS}
+fi

--- a/testsuite/tests/tool-debugger/prefix_mapping/find-artifacts-fail/debuggee.ml
+++ b/testsuite/tests/tool-debugger/prefix_mapping/find-artifacts-fail/debuggee.ml
@@ -1,0 +1,46 @@
+(* TEST
+ readonly_files = "printer.ml";
+ include debugger;
+ ocamldebug_script = "${test_source_directory}/input_script";
+ {
+   dumpenv_expanded;
+ }{
+   debugger;
+
+   shared-libraries;
+
+   setup-ocamlc.byte-build-env;
+
+   script = "mkdir out";
+   script;
+
+   flags = "-g -c";
+   set BUILD_PATH_PREFIX_MAP = "/stdlib_root=${bppm_encode ${ocamlsrcdir}}/stdlib";
+   BUILD_PATH_PREFIX_MAP += ":/source_root=${bppm_encode ${test_source_directory}}";
+   BUILD_PATH_PREFIX_MAP += ":/build_root=${bppm_encode ${test_build_directory}}";
+   dumpenv_expanded;
+
+   all_modules = "${test_source_directory}/in/blah.ml";
+   program = "out/blah.cmo";
+   ocamlc.byte;
+
+   program = "out/foo.cmo";
+   flags = "-I out -g -c";
+   all_modules = "${test_source_directory}/in/foo.ml";
+   ocamlc.byte;
+
+   all_modules = "out/blah.cmo out/foo.cmo";
+   flags = " -g ";
+   program = "debuggee.exe";
+   ocamlc.byte;
+
+   check-ocamlc.byte-output;
+
+   unset BUILD_PATH_PREFIX_MAP;
+   ocamldebug;
+
+   check-program-output;
+ }
+*)
+
+(* This file only contains the specification of how to run the test *)

--- a/testsuite/tests/tool-debugger/prefix_mapping/find-artifacts-fail/debuggee.reference
+++ b/testsuite/tests/tool-debugger/prefix_mapping/find-artifacts-fail/debuggee.reference
@@ -1,0 +1,8 @@
+DEPLOY_PATH_PREFIX_MAP is not set.
+Loading program... done.
+No source file for Foo.
+Foo
+Bar(hi)
+Program exit.
+Unbound identifier x
+Unbound identifier y

--- a/testsuite/tests/tool-debugger/prefix_mapping/find-artifacts-fail/in/blah.ml
+++ b/testsuite/tests/tool-debugger/prefix_mapping/find-artifacts-fail/in/blah.ml
@@ -1,0 +1,3 @@
+type blah =
+  | Foo
+  | Bar of string

--- a/testsuite/tests/tool-debugger/prefix_mapping/find-artifacts-fail/in/foo.ml
+++ b/testsuite/tests/tool-debugger/prefix_mapping/find-artifacts-fail/in/foo.ml
@@ -1,0 +1,13 @@
+open Blah
+
+let print = function
+  | Foo -> print_endline "Foo";
+  | Bar s -> print_endline ("Bar(" ^ s ^ ")")
+
+let main five =
+  let x = Foo in
+  let y = Bar "hi" in
+  print x;
+  print y
+
+let _ = main 5

--- a/testsuite/tests/tool-debugger/prefix_mapping/find-artifacts-fail/input_script
+++ b/testsuite/tests/tool-debugger/prefix_mapping/find-artifacts-fail/input_script
@@ -1,0 +1,6 @@
+show mapping
+break @ Foo 9
+run
+print x
+print y
+quit

--- a/testsuite/tests/tool-debugger/prefix_mapping/find-artifacts-ok1/debuggee.ml
+++ b/testsuite/tests/tool-debugger/prefix_mapping/find-artifacts-ok1/debuggee.ml
@@ -1,0 +1,45 @@
+(* TEST
+ ocamldebug_script = "${test_source_directory}/input_script";
+ {
+   dumpenv;
+ }{
+   debugger;
+
+   shared-libraries;
+
+   setup-ocamlc.byte-build-env;
+
+   script = "mkdir out";
+   script;
+
+   flags = "-g -c";
+   set BUILD_PATH_PREFIX_MAP = "/stdlib_root=${bppm_encode ${ocamlsrcdir}}/stdlib";
+   BUILD_PATH_PREFIX_MAP += ":/source_root=${bppm_encode ${test_source_directory}}";
+   BUILD_PATH_PREFIX_MAP += ":/build_root=${bppm_encode ${test_build_directory}}";
+   all_modules = "${test_source_directory}/in/blah.ml";
+   program = "out/blah.cmo";
+   ocamlc.byte;
+
+   program = "out/foo.cmo";
+   flags = "-I out -g -c";
+   all_modules = "${test_source_directory}/in/foo.ml";
+   ocamlc.byte;
+
+   all_modules = "out/blah.cmo out/foo.cmo";
+   flags = " -g ";
+   program = "debuggee.exe";
+   ocamlc.byte;
+
+   check-ocamlc.byte-output;
+
+   set DEPLOY_PATH_PREFIX_MAP = "${bppm_encode ${ocamlsrcdir}}/stdlib=/stdlib_root";
+   DEPLOY_PATH_PREFIX_MAP += ":${bppm_encode ${test_source_directory}}=/source_root";
+   DEPLOY_PATH_PREFIX_MAP += ":${bppm_encode ${test_build_directory}}=/build_root";
+   dumpenv_expanded;
+   ocamldebug;
+
+   check-program-output;
+ }
+*)
+
+(* This file only contains the specification of how to run the test *)

--- a/testsuite/tests/tool-debugger/prefix_mapping/find-artifacts-ok1/debuggee.reference
+++ b/testsuite/tests/tool-debugger/prefix_mapping/find-artifacts-ok1/debuggee.reference
@@ -1,0 +1,5 @@
+Loading program... done.
+Breakpoint: 1
+10   <|b|>print x;
+x: Blah.blah = Foo
+y: Blah.blah = Bar "hi"

--- a/testsuite/tests/tool-debugger/prefix_mapping/find-artifacts-ok1/in/blah.ml
+++ b/testsuite/tests/tool-debugger/prefix_mapping/find-artifacts-ok1/in/blah.ml
@@ -1,0 +1,3 @@
+type blah =
+  | Foo
+  | Bar of string

--- a/testsuite/tests/tool-debugger/prefix_mapping/find-artifacts-ok1/in/foo.ml
+++ b/testsuite/tests/tool-debugger/prefix_mapping/find-artifacts-ok1/in/foo.ml
@@ -1,0 +1,13 @@
+open Blah
+
+let print = function
+  | Foo -> print_endline "Foo";
+  | Bar s -> print_endline ("Bar(" ^ s ^ ")")
+
+let main () =
+  let x = Foo in
+  let y = Bar "hi" in
+  print x;
+  print y
+
+let _ = main ()

--- a/testsuite/tests/tool-debugger/prefix_mapping/find-artifacts-ok1/input_script
+++ b/testsuite/tests/tool-debugger/prefix_mapping/find-artifacts-ok1/input_script
@@ -1,0 +1,6 @@
+cd ..
+break @ Foo 10
+run
+print x
+print y
+quit

--- a/testsuite/tests/tool-debugger/prefix_mapping/find-artifacts-ok2/debuggee.ml
+++ b/testsuite/tests/tool-debugger/prefix_mapping/find-artifacts-ok2/debuggee.ml
@@ -1,0 +1,50 @@
+(* TEST
+ ocamldebug_script = "${test_source_directory}/input_script";
+ {
+   dumpenv;
+ }{
+   readonly_files = "input_script_in";
+   debugger;
+
+   shared-libraries;
+
+   setup-ocamlc.byte-build-env;
+
+   script = "mkdir out";
+   script;
+
+   flags = "-g -c";
+   set BUILD_PATH_PREFIX_MAP = "/stdlib_root=${bppm_encode ${ocamlsrcdir}}/stdlib";
+   BUILD_PATH_PREFIX_MAP += ":/source_root=${bppm_encode ${test_source_directory}}";
+   BUILD_PATH_PREFIX_MAP += ":/build_root=${bppm_encode ${test_build_directory}}";
+   all_modules = "${test_source_directory}/in/blah.ml";
+   program = "out/blah.cmo";
+   ocamlc.byte;
+
+   program = "out/foo.cmo";
+   flags = "-I out -g -c";
+   all_modules = "${test_source_directory}/in/foo.ml";
+   ocamlc.byte;
+
+   all_modules = "out/blah.cmo out/foo.cmo";
+   flags = " -g ";
+   program = "debuggee.exe";
+   ocamlc.byte;
+
+   check-ocamlc.byte-output;
+
+   set the_map = "${bppm_encode ${ocamlsrcdir}}/stdlib=/stdlib_root";
+   the_map += ":${bppm_encode ${test_source_directory}}=/source_root";
+   the_map += ":${bppm_encode ${test_build_directory}}=/build_root";
+   src = "input_script_in";
+   dst = "input_script";
+   expand;
+
+   ocamldebug_script = "${test_build_directory}/input_script";
+   ocamldebug;
+
+   check-program-output;
+ }
+*)
+
+(* This file only contains the specification of how to run the test *)

--- a/testsuite/tests/tool-debugger/prefix_mapping/find-artifacts-ok2/debuggee.reference
+++ b/testsuite/tests/tool-debugger/prefix_mapping/find-artifacts-ok2/debuggee.reference
@@ -1,0 +1,5 @@
+Loading program... done.
+Breakpoint: 1
+10   <|b|>print x;
+x: Blah.blah = Foo
+y: Blah.blah = Bar "hi"

--- a/testsuite/tests/tool-debugger/prefix_mapping/find-artifacts-ok2/in/blah.ml
+++ b/testsuite/tests/tool-debugger/prefix_mapping/find-artifacts-ok2/in/blah.ml
@@ -1,0 +1,3 @@
+type blah =
+  | Foo
+  | Bar of string

--- a/testsuite/tests/tool-debugger/prefix_mapping/find-artifacts-ok2/in/foo.ml
+++ b/testsuite/tests/tool-debugger/prefix_mapping/find-artifacts-ok2/in/foo.ml
@@ -1,0 +1,13 @@
+open Blah
+
+let print = function
+  | Foo -> print_endline "Foo";
+  | Bar s -> print_endline ("Bar(" ^ s ^ ")")
+
+let main () =
+  let x = Foo in
+  let y = Bar "hi" in
+  print x;
+  print y
+
+let _ = main ()

--- a/testsuite/tests/tool-debugger/prefix_mapping/find-artifacts-ok2/input_script_in
+++ b/testsuite/tests/tool-debugger/prefix_mapping/find-artifacts-ok2/input_script_in
@@ -1,0 +1,6 @@
+set mapping ${the_map}
+break @ Foo 10
+run
+print x
+print y
+quit

--- a/testsuite/tests/tool-debugger/prefix_mapping/find-artifacts-ok3/debuggee.ml
+++ b/testsuite/tests/tool-debugger/prefix_mapping/find-artifacts-ok3/debuggee.ml
@@ -1,0 +1,49 @@
+(* TEST
+ ocamldebug_script = "${test_source_directory}/input_script";
+ {
+   dumpenv;
+ }{
+   readonly_files = "dot_ocamldebug_in";
+   debugger;
+
+   shared-libraries;
+
+   setup-ocamlc.byte-build-env;
+
+   script = "mkdir out";
+   script;
+
+   flags = "-g -c";
+   set BUILD_PATH_PREFIX_MAP = "/stdlib_root=${bppm_encode ${ocamlsrcdir}}/stdlib";
+   BUILD_PATH_PREFIX_MAP += ":/source_root=${bppm_encode ${test_source_directory}}";
+   BUILD_PATH_PREFIX_MAP += ":/build_root=${bppm_encode ${test_build_directory}}";
+   all_modules = "${test_source_directory}/in/blah.ml";
+   program = "out/blah.cmo";
+   ocamlc.byte;
+
+   program = "out/foo.cmo";
+   flags = "-I out -g -c";
+   all_modules = "${test_source_directory}/in/foo.ml";
+   ocamlc.byte;
+
+   all_modules = "out/blah.cmo out/foo.cmo";
+   flags = " -g ";
+   program = "debuggee.exe";
+   ocamlc.byte;
+
+   check-ocamlc.byte-output;
+
+   set the_map = "${bppm_encode ${ocamlsrcdir}}/stdlib=/stdlib_root";
+   the_map += ":${bppm_encode ${test_source_directory}}=/source_root";
+   the_map += ":${bppm_encode ${test_build_directory}}=/build_root";
+   src = "dot_ocamldebug_in";
+   dst = ".ocamldebug";
+   expand;
+
+   ocamldebug;
+
+   check-program-output;
+ }
+*)
+
+(* This file only contains the specification of how to run the test *)

--- a/testsuite/tests/tool-debugger/prefix_mapping/find-artifacts-ok3/debuggee.reference
+++ b/testsuite/tests/tool-debugger/prefix_mapping/find-artifacts-ok3/debuggee.reference
@@ -1,0 +1,6 @@
+Executing file .ocamldebug
+Loading program... done.
+Breakpoint: 1
+10   <|b|>print x;
+x: Blah.blah = Foo
+y: Blah.blah = Bar "hi"

--- a/testsuite/tests/tool-debugger/prefix_mapping/find-artifacts-ok3/dot_ocamldebug_in
+++ b/testsuite/tests/tool-debugger/prefix_mapping/find-artifacts-ok3/dot_ocamldebug_in
@@ -1,0 +1,1 @@
+set mapping ${the_map}

--- a/testsuite/tests/tool-debugger/prefix_mapping/find-artifacts-ok3/in/blah.ml
+++ b/testsuite/tests/tool-debugger/prefix_mapping/find-artifacts-ok3/in/blah.ml
@@ -1,0 +1,3 @@
+type blah =
+  | Foo
+  | Bar of string

--- a/testsuite/tests/tool-debugger/prefix_mapping/find-artifacts-ok3/in/foo.ml
+++ b/testsuite/tests/tool-debugger/prefix_mapping/find-artifacts-ok3/in/foo.ml
@@ -1,0 +1,13 @@
+open Blah
+
+let print = function
+  | Foo -> print_endline "Foo";
+  | Bar s -> print_endline ("Bar(" ^ s ^ ")")
+
+let main () =
+  let x = Foo in
+  let y = Bar "hi" in
+  print x;
+  print y
+
+let _ = main ()

--- a/testsuite/tests/tool-debugger/prefix_mapping/find-artifacts-ok3/input_script
+++ b/testsuite/tests/tool-debugger/prefix_mapping/find-artifacts-ok3/input_script
@@ -1,0 +1,5 @@
+break @ Foo 10
+run
+print x
+print y
+quit

--- a/testsuite/tests/tool-debugger/prefix_mapping/matching-dirs-no-match/debuggee.ml
+++ b/testsuite/tests/tool-debugger/prefix_mapping/matching-dirs-no-match/debuggee.ml
@@ -1,0 +1,37 @@
+(* Test the case where none of the matching directories exist. *)
+
+(* TEST
+ flags += " -g ";
+ ocamldebug_script = "${test_source_directory}/input_script";
+ readonly_files = "printer.ml";
+ include debugger;
+ include ocamlcommon;
+ set DEPLOY_PATH_PREFIX_MAP = "abc=/workspace_root:def=/workspace_root";
+ debugger;
+
+ shared-libraries;
+
+ setup-ocamlc.byte-build-env;
+ {
+   module = "printer.ml";
+   ocamlc.byte;
+ }{
+   ocamlc.byte;
+
+   check-ocamlc.byte-output;
+
+   ocamldebug;
+
+   check-program-output;
+ }
+*)
+
+let f x =
+  for _i = 0 to x do
+    print_endline "..."
+  done
+
+let main () =
+  f 3
+let () =
+  main ()

--- a/testsuite/tests/tool-debugger/prefix_mapping/matching-dirs-no-match/debuggee.reference
+++ b/testsuite/tests/tool-debugger/prefix_mapping/matching-dirs-no-match/debuggee.reference
@@ -1,0 +1,12 @@
+File printer.cmo loaded
+Loading program... done.
+Breakpoint: 1
+30   <|b|>for _i = 0 to x do
+x: int = 3
+DEPLOY_PATH_PREFIX_MAP="abc=/workspace_root:def=/workspace_root"
+DEPLOY_PATH_PREFIX_MAP fails to map "/workspace_root/pack1/lib1/".
+{t1, /workspace_root/pack1/lib1/ -> #items=0
+  }
+
+Load path length = 14.
+

--- a/testsuite/tests/tool-debugger/prefix_mapping/matching-dirs-no-match/input_script
+++ b/testsuite/tests/tool-debugger/prefix_mapping/matching-dirs-no-match/input_script
@@ -1,0 +1,6 @@
+load_printer printer.cmo
+install_printer Printer.p
+break @ Debuggee 22
+run
+print x
+quit

--- a/testsuite/tests/tool-debugger/prefix_mapping/matching-dirs-no-match/printer.ml
+++ b/testsuite/tests/tool-debugger/prefix_mapping/matching-dirs-no-match/printer.ml
@@ -1,0 +1,41 @@
+(*
+  Note, a program being debugged does not have access to the
+  debugger process, but a printer that has been loaded is
+  running in the debugger process and has access to its
+  internals. This can be used as a back-door to enable some
+  unit testing of the debugger.
+*)
+open Format
+
+let print_mapping ppf title src (alist: string list) =
+  fprintf ppf "@[<v2>{%s, %s -> #items=%d@ " title src (List.length alist);
+  List.iteri (fun i item ->
+    fprintf ppf "[%d]=%s@ " i item
+    ) alist;
+  fprintf ppf "}@]\n@."
+
+let print_list ppf title (alist: string list) =
+  fprintf ppf "@[<v2>{%s: #items=%d@ " title (List.length alist);
+  List.iteri (fun i item ->
+    fprintf ppf "[%d]=%s@ " i item
+    ) alist;
+  fprintf ppf "}@]\n@."
+
+let p : Format.formatter -> int -> unit = fun ppf n ->
+  let debug = false in
+  fprintf ppf "%d@." n;
+  let bppm = Sys.getenv "DEPLOY_PATH_PREFIX_MAP" in
+  fprintf ppf "DEPLOY_PATH_PREFIX_MAP=\"%s\"\n%!" bppm;
+  let test1 = "/workspace_root/pack1/lib1/" in
+  let result1 = match Location.rewrite_find_all_existing_dirs test1 with
+  | dirs -> dirs
+  | exception Not_found ->
+    (* We are doing mapping, but either no prefix matches, or else
+       mapped directories did not exists. *)
+    Printf.printf "DEPLOY_PATH_PREFIX_MAP fails to map %S.\n%!" test1;
+    [] in
+  print_mapping ppf "t1" test1 result1;
+  let load_paths = Load_path.get_paths () in
+  fprintf ppf "Load path length = %d.@." (List.length load_paths);
+  if debug then
+    print_list ppf "Load_path" load_paths

--- a/testsuite/tests/tool-debugger/prefix_mapping/matching-dirs-some-matches/abc/pack1/lib1/readme.txt
+++ b/testsuite/tests/tool-debugger/prefix_mapping/matching-dirs-some-matches/abc/pack1/lib1/readme.txt
@@ -1,0 +1,1 @@
+This is here to ensure the enclosing directory exists

--- a/testsuite/tests/tool-debugger/prefix_mapping/matching-dirs-some-matches/debuggee.ml
+++ b/testsuite/tests/tool-debugger/prefix_mapping/matching-dirs-some-matches/debuggee.ml
@@ -1,0 +1,39 @@
+(* Test the case where some matching directories exist. *)
+
+(* TEST
+ flags += " -g ";
+ ocamldebug_script = "${test_source_directory}/input_script";
+ readonly_files = "printer.ml";
+ subdirectories = "abc def";
+ include debugger;
+ include ocamlcommon;
+ set DEPLOY_PATH_PREFIX_MAP = "abc=/workspace_root";
+ DEPLOY_PATH_PREFIX_MAP += ":def=/workspace_root";
+ debugger;
+
+ shared-libraries;
+
+ setup-ocamlc.byte-build-env;
+ {
+   module = "printer.ml";
+   ocamlc.byte;
+ }{
+   ocamlc.byte;
+
+   check-ocamlc.byte-output;
+   dumpenv_expanded;
+   ocamldebug;
+
+   check-program-output;
+ }
+*)
+
+let f x =
+  for _i = 0 to x do
+    print_endline "..."
+  done
+
+let main () =
+  f 3
+let () =
+  main ()

--- a/testsuite/tests/tool-debugger/prefix_mapping/matching-dirs-some-matches/debuggee.reference
+++ b/testsuite/tests/tool-debugger/prefix_mapping/matching-dirs-some-matches/debuggee.reference
@@ -1,0 +1,12 @@
+File printer.cmo loaded
+Loading program... done.
+Breakpoint: 1
+32   <|b|>for _i = 0 to x do
+x: int = 3
+DEPLOY_PATH_PREFIX_MAP="abc=/workspace_root:def=/workspace_root"
+{t1, /workspace_root/pack1/lib1 -> #items=2
+  [0]=./def/pack1/lib1
+  [1]=./abc/pack1/lib1
+  }
+
+

--- a/testsuite/tests/tool-debugger/prefix_mapping/matching-dirs-some-matches/def/pack1/lib1/readme.txt
+++ b/testsuite/tests/tool-debugger/prefix_mapping/matching-dirs-some-matches/def/pack1/lib1/readme.txt
@@ -1,0 +1,1 @@
+This is here to ensure the enclosing directory exists

--- a/testsuite/tests/tool-debugger/prefix_mapping/matching-dirs-some-matches/input_script
+++ b/testsuite/tests/tool-debugger/prefix_mapping/matching-dirs-some-matches/input_script
@@ -1,0 +1,6 @@
+load_printer printer.cmo
+install_printer Printer.p
+break @ Debuggee 32
+run
+print x
+quit

--- a/testsuite/tests/tool-debugger/prefix_mapping/matching-dirs-some-matches/printer.ml
+++ b/testsuite/tests/tool-debugger/prefix_mapping/matching-dirs-some-matches/printer.ml
@@ -1,0 +1,71 @@
+(*
+  Note, a program being debugged does not have access to the
+  debugger process, but a printer that has been loaded is
+  running in the debugger process and has access to its
+  internals. This can be used as a back-door to enable some
+  unit testing of the debugger.
+*)
+open Format
+
+let debug = true
+
+(* Convert to system-dependent filename from part. *)
+
+let to_sys_name parts =
+  match parts with
+  | [] -> ""
+  | hd :: tl ->
+     List.fold_left Filename.concat hd tl
+
+let to_canonical parts =
+  match parts with
+  | [] -> "."
+  | hd :: tl ->
+     if hd = "/" then
+       "/" ^ String.concat "/" tl
+     else
+       String.concat "/" parts
+
+let filename_parts filename =
+  let open Filename in
+  let rec loop filename acc =
+    let d = dirname filename in
+    if d = filename then filename :: acc
+    else
+      let b = basename filename in
+      loop d (b :: acc)
+  in
+  loop filename []
+
+let canonicalize filename =
+  let parts = filename_parts filename in
+  to_canonical parts
+
+let print_mapping ppf title src (alist: string list) =
+  fprintf ppf "@[<v2>{%s, %s -> #items=%d@ " title (canonicalize src) (List.length alist);
+  if debug then
+    List.iteri (fun i item ->
+        fprintf ppf "[%d]=%s@ " i (canonicalize item)
+      ) alist;
+  fprintf ppf "}@]\n@."
+
+let print_list ppf title (alist: string list) =
+  fprintf ppf "@[<v2>{%s: #items=%d@ " title (List.length alist);
+  if debug then
+    List.iteri (fun i item ->
+        fprintf ppf "[%d]=%s@ " i (canonicalize item)
+      ) alist;
+  fprintf ppf "}@]\n@."
+
+let p : Format.formatter -> int -> unit = fun ppf n ->
+  fprintf ppf "%d@." n;
+  let bppm = Sys.getenv "DEPLOY_PATH_PREFIX_MAP" in
+  if debug then
+    fprintf ppf "DEPLOY_PATH_PREFIX_MAP=\"%s\"\n%!" bppm;
+  let test1 = to_sys_name ["/workspace_root"; "pack1"; "lib1"] in
+  let result1 = Location.rewrite_find_all_existing_dirs test1 in
+  print_mapping ppf "t1" test1 result1;
+  if false then begin
+      let load_paths = Load_path.get_paths () in
+      print_list ppf "Load_path" load_paths
+  end

--- a/testsuite/tests/tool-debugger/prefix_mapping/rewrite-exists-found-second/abc/pack1/lib1/mod1.ml
+++ b/testsuite/tests/tool-debugger/prefix_mapping/rewrite-exists-found-second/abc/pack1/lib1/mod1.ml
@@ -1,0 +1,1 @@
+(* We just test existence of this file. *)

--- a/testsuite/tests/tool-debugger/prefix_mapping/rewrite-exists-found-second/abc/pack1/lib1/readme.txt
+++ b/testsuite/tests/tool-debugger/prefix_mapping/rewrite-exists-found-second/abc/pack1/lib1/readme.txt
@@ -1,0 +1,1 @@
+This is here to ensure the enclosing directory exists

--- a/testsuite/tests/tool-debugger/prefix_mapping/rewrite-exists-found-second/debuggee.ml
+++ b/testsuite/tests/tool-debugger/prefix_mapping/rewrite-exists-found-second/debuggee.ml
@@ -1,0 +1,42 @@
+(* Test rewrite_find_first_existing for the case where DEPLOY_PATH_PREFIX_MAP is set,
+   there is a prefix match, and the desired file is not found
+   at the first prefix map. So this demonstrates we can
+   skip mapping entries. *)
+
+(* TEST
+ flags += " -g ";
+ ocamldebug_script = "${test_source_directory}/input_script";
+ readonly_files = "printer.ml";
+ subdirectories = "abc def";
+ include debugger;
+ include ocamlcommon;
+ set DEPLOY_PATH_PREFIX_MAP = "abc=/workspace_root";
+ DEPLOY_PATH_PREFIX_MAP += ":def=/workspace_root";
+ debugger;
+
+ shared-libraries;
+
+ setup-ocamlc.byte-build-env;
+ {
+   module = "printer.ml";
+   ocamlc.byte;
+ }{
+   ocamlc.byte;
+
+   check-ocamlc.byte-output;
+
+   ocamldebug;
+
+   check-program-output;
+ }
+*)
+
+let f x =
+  for _i = 0 to x do
+    print_endline "..."
+  done
+
+let main () =
+  f 3
+let () =
+  main ()

--- a/testsuite/tests/tool-debugger/prefix_mapping/rewrite-exists-found-second/debuggee.reference
+++ b/testsuite/tests/tool-debugger/prefix_mapping/rewrite-exists-found-second/debuggee.reference
@@ -1,0 +1,13 @@
+File printer.cmo loaded
+Loading program... done.
+Breakpoint: 1
+35   <|b|>for _i = 0 to x do
+x: int = 3
+DEPLOY_PATH_PREFIX_MAP="abc=/workspace_root:def=/workspace_root"
+{test1_dir, /workspace_root/pack1/lib1 -> #items=2
+  [0]=./def/pack1/lib1
+  [1]=./abc/pack1/lib1
+  }
+
+/workspace_root/pack1/lib1/mod1.ml -> Some ./abc/pack1/lib1/mod1.ml
+

--- a/testsuite/tests/tool-debugger/prefix_mapping/rewrite-exists-found-second/def/pack1/lib1/other.ml
+++ b/testsuite/tests/tool-debugger/prefix_mapping/rewrite-exists-found-second/def/pack1/lib1/other.ml
@@ -1,0 +1,1 @@
+(* We just test existence of this file. *)

--- a/testsuite/tests/tool-debugger/prefix_mapping/rewrite-exists-found-second/def/pack1/lib1/readme.txt
+++ b/testsuite/tests/tool-debugger/prefix_mapping/rewrite-exists-found-second/def/pack1/lib1/readme.txt
@@ -1,0 +1,1 @@
+This is here to ensure the enclosing directory exists

--- a/testsuite/tests/tool-debugger/prefix_mapping/rewrite-exists-found-second/input_script
+++ b/testsuite/tests/tool-debugger/prefix_mapping/rewrite-exists-found-second/input_script
@@ -1,0 +1,6 @@
+load_printer printer.cmo
+install_printer Printer.p
+break @ Debuggee 35
+run
+print x
+quit

--- a/testsuite/tests/tool-debugger/prefix_mapping/rewrite-exists-found-second/printer.ml
+++ b/testsuite/tests/tool-debugger/prefix_mapping/rewrite-exists-found-second/printer.ml
@@ -1,0 +1,84 @@
+(*
+  Note, a program being debugged does not have access to the
+  debugger process, but a printer that has been loaded is
+  running in the debugger process and has access to its
+  internals. This can be used as a back-door to enable some
+  unit testing of the debugger.
+*)
+open Format
+
+let debug = true
+
+(* Convert to system-dependent filename from part. *)
+let to_sys_name parts =
+  match parts with
+  | [] -> ""
+  | hd :: tl ->
+     List.fold_left Filename.concat hd tl
+
+let to_canonical parts =
+  match parts with
+  | [] -> "."
+  | hd :: tl ->
+     if hd = "/" then
+       "/" ^ String.concat "/" tl
+     else
+       String.concat "/" parts
+
+let filename_parts filename =
+  let open Filename in
+  let rec loop filename acc =
+    let d = dirname filename in
+    if d = filename then filename :: acc
+    else
+      let b = basename filename in
+      loop d (b :: acc)
+  in
+  loop filename []
+
+let canonicalize filename =
+  let parts = filename_parts filename in
+  to_canonical parts
+
+let print_mapping ppf title src (alist: string list) =
+  fprintf ppf "@[<v2>{%s, %s -> #items=%d@ " title (canonicalize src) (List.length alist);
+  if debug then
+    List.iteri (fun i item ->
+        fprintf ppf "[%d]=%s@ " i (canonicalize item)
+      ) alist;
+  fprintf ppf "}@]\n@."
+
+let print_list ppf title (alist: string list) =
+  fprintf ppf "@[<v2>{%s: #items=%d@ " title (List.length alist);
+  if debug then
+    List.iteri (fun i item ->
+        fprintf ppf "[%d]=%s@ " i (canonicalize item)
+      ) alist;
+  fprintf ppf "}@]\n@."
+
+let p : Format.formatter -> int -> unit = fun ppf n ->
+  fprintf ppf "%d@." n;
+  let bppm = Sys.getenv "DEPLOY_PATH_PREFIX_MAP" in
+  if debug then
+    fprintf ppf "DEPLOY_PATH_PREFIX_MAP=\"%s\"\n%!" bppm;
+  let test1_dir =
+    to_sys_name ["/workspace_root"; "pack1"; "lib1"] in
+  let result1 = Location.rewrite_find_all_existing_dirs test1_dir in
+  print_mapping ppf "test1_dir" test1_dir result1;
+  let test1_mod =
+    to_sys_name ["/workspace_root"; "pack1"; "lib1"; "mod1.ml"] in
+  let open Printf in
+  match Location.rewrite_find_first_existing test1_mod with
+  | None ->
+     (* DEPLOY_PATH_PREFIX_MAP not set. *)
+     printf "%s -> None\n%!" (canonicalize test1_mod)
+  | Some target ->
+     printf "%s -> Some %s\n%!"
+       (canonicalize test1_mod) (canonicalize target)
+  | exception Not_found ->
+     printf "DEPLOY_PATH_PREFIX_MAP fails to find %s.\n%!"
+       (canonicalize test1_mod);
+  if false then begin
+      let load_paths = Load_path.get_paths () in
+      print_list ppf "Load_path" load_paths
+  end

--- a/testsuite/tests/tool-debugger/prefix_mapping/rewrite-exists-no-bppm/abc/pack1/lib1/readme.txt
+++ b/testsuite/tests/tool-debugger/prefix_mapping/rewrite-exists-no-bppm/abc/pack1/lib1/readme.txt
@@ -1,0 +1,1 @@
+This is here to ensure the enclosing directory exists

--- a/testsuite/tests/tool-debugger/prefix_mapping/rewrite-exists-no-bppm/debuggee.ml
+++ b/testsuite/tests/tool-debugger/prefix_mapping/rewrite-exists-no-bppm/debuggee.ml
@@ -1,0 +1,37 @@
+(* Test rewrite_find_first_existing for the case where DEPLOY_PATH_PREFIX_MAP is not set *)
+
+(* TEST
+ flags += " -g ";
+ ocamldebug_script = "${test_source_directory}/input_script";
+ readonly_files = "printer.ml";
+ subdirectories = "abc def";
+ include debugger;
+ include ocamlcommon;
+ debugger;
+
+ shared-libraries;
+
+ setup-ocamlc.byte-build-env;
+ {
+   module = "printer.ml";
+   ocamlc.byte;
+ }{
+   ocamlc.byte;
+
+   check-ocamlc.byte-output;
+
+   ocamldebug;
+
+   check-program-output;
+ }
+*)
+
+let f x =
+  for _i = 0 to x do
+    print_endline "..."
+  done
+
+let main () =
+  f 3
+let () =
+  main ()

--- a/testsuite/tests/tool-debugger/prefix_mapping/rewrite-exists-no-bppm/debuggee.reference
+++ b/testsuite/tests/tool-debugger/prefix_mapping/rewrite-exists-no-bppm/debuggee.reference
@@ -1,0 +1,8 @@
+File printer.cmo loaded
+Loading program... done.
+Breakpoint: 1
+30   <|b|>for _i = 0 to x do
+x: int = 3
+DEPLOY_PATH_PREFIX_MAP=""
+/workspace_root/pack1/lib1/mod1.ml -> None
+

--- a/testsuite/tests/tool-debugger/prefix_mapping/rewrite-exists-no-bppm/def/pack1/lib1/readme.txt
+++ b/testsuite/tests/tool-debugger/prefix_mapping/rewrite-exists-no-bppm/def/pack1/lib1/readme.txt
@@ -1,0 +1,1 @@
+This is here to ensure the enclosing directory exists

--- a/testsuite/tests/tool-debugger/prefix_mapping/rewrite-exists-no-bppm/input_script
+++ b/testsuite/tests/tool-debugger/prefix_mapping/rewrite-exists-no-bppm/input_script
@@ -1,0 +1,6 @@
+load_printer printer.cmo
+install_printer Printer.p
+break @ Debuggee 30
+run
+print x
+quit

--- a/testsuite/tests/tool-debugger/prefix_mapping/rewrite-exists-no-bppm/printer.ml
+++ b/testsuite/tests/tool-debugger/prefix_mapping/rewrite-exists-no-bppm/printer.ml
@@ -1,0 +1,82 @@
+(*
+  Note, a program being debugged does not have access to the
+  debugger process, but a printer that has been loaded is
+  running in the debugger process and has access to its
+  internals. This can be used as a back-door to enable some
+  unit testing of the debugger.
+*)
+open Format
+
+let debug = true
+
+(* Convert to system-dependent filename from part. *)
+let to_sys_name parts =
+  match parts with
+  | [] -> ""
+  | hd :: tl ->
+     List.fold_left Filename.concat hd tl
+
+let to_canonical parts =
+  match parts with
+  | [] -> "."
+  | hd :: tl ->
+     if hd = "/" then
+       "/" ^ String.concat "/" tl
+     else
+       String.concat "/" parts
+
+let filename_parts filename =
+  let open Filename in
+  let rec loop filename acc =
+    let d = dirname filename in
+    if d = filename then filename :: acc
+    else
+      let b = basename filename in
+      loop d (b :: acc)
+  in
+  loop filename []
+
+let canonicalize filename =
+  let parts = filename_parts filename in
+  to_canonical parts
+
+let print_mapping ppf title src (alist: string list) =
+  fprintf ppf "@[<v2>{%s, %s -> #items=%d@ " title (canonicalize src) (List.length alist);
+  if debug then
+    List.iteri (fun i item ->
+        fprintf ppf "[%d]=%s@ " i (canonicalize item)
+      ) alist;
+  fprintf ppf "}@]\n@."
+
+let print_list ppf title (alist: string list) =
+  fprintf ppf "@[<v2>{%s: #items=%d@ " title (List.length alist);
+  if debug then
+    List.iteri (fun i item ->
+        fprintf ppf "[%d]=%s@ " i (canonicalize item)
+      ) alist;
+  fprintf ppf "}@]\n@."
+
+let p : Format.formatter -> int -> unit = fun ppf n ->
+  fprintf ppf "%d@." n;
+  let bppm =
+    match Sys.getenv "DEPLOY_PATH_PREFIX_MAP" with
+    | exception Not_found -> ""
+    | map -> map in
+  if debug then
+    fprintf ppf "DEPLOY_PATH_PREFIX_MAP=\"%s\"\n%!" bppm;
+  let test1 =
+    to_sys_name ["/workspace_root"; "pack1"; "lib1"; "mod1.ml"] in
+  match Location.rewrite_find_first_existing test1 with
+  | None ->
+     (* DEPLOY_PATH_PREFIX_MAP not set. *)
+     printf "%s -> None\n%!" (canonicalize test1)
+  |  Some target ->
+     printf "%s -> Some %s\n%!"
+       (canonicalize test1) (canonicalize target)
+  | exception Not_found ->
+     printf "DEPLOY_PATH_PREFIX_MAP fails to find %s.\n%!"
+       (canonicalize test1);
+  if false then begin
+      let load_paths = Load_path.get_paths () in
+      print_list ppf "Load_path" load_paths
+  end

--- a/testsuite/tests/tool-debugger/prefix_mapping/rewrite-exists-no-prefix/abc/pack1/lib1/readme.txt
+++ b/testsuite/tests/tool-debugger/prefix_mapping/rewrite-exists-no-prefix/abc/pack1/lib1/readme.txt
@@ -1,0 +1,1 @@
+This is here to ensure the enclosing directory exists

--- a/testsuite/tests/tool-debugger/prefix_mapping/rewrite-exists-no-prefix/debuggee.ml
+++ b/testsuite/tests/tool-debugger/prefix_mapping/rewrite-exists-no-prefix/debuggee.ml
@@ -1,0 +1,40 @@
+(* Test rewrite_find_first_existing for the case where DEPLOY_PATH_PREFIX_MAP is set,
+   there is a not prefix match, so the desired file is not found. *)
+
+(* TEST
+ flags += " -g ";
+ ocamldebug_script = "${test_source_directory}/input_script";
+ readonly_files = "printer.ml";
+ subdirectories = "abc def";
+ include debugger;
+ include ocamlcommon;
+ set DEPLOY_PATH_PREFIX_MAP = "abc=/workspace_root";
+ DEPLOY_PATH_PREFIX_MAP += ":def=/workspace_root";
+ debugger;
+
+ shared-libraries;
+
+ setup-ocamlc.byte-build-env;
+ {
+   module = "printer.ml";
+   ocamlc.byte;
+ }{
+   ocamlc.byte;
+
+   check-ocamlc.byte-output;
+
+   ocamldebug;
+
+   check-program-output;
+ }
+*)
+
+let f x =
+  for _i = 0 to x do
+    print_endline "..."
+  done
+
+let main () =
+  f 3
+let () =
+  main ()

--- a/testsuite/tests/tool-debugger/prefix_mapping/rewrite-exists-no-prefix/debuggee.reference
+++ b/testsuite/tests/tool-debugger/prefix_mapping/rewrite-exists-no-prefix/debuggee.reference
@@ -1,0 +1,8 @@
+File printer.cmo loaded
+Loading program... done.
+Breakpoint: 1
+33   <|b|>for _i = 0 to x do
+x: int = 3
+DEPLOY_PATH_PREFIX_MAP="abc=/workspace_root:def=/workspace_root"
+/other_root/pack1/lib1/mod1.ml -> None
+

--- a/testsuite/tests/tool-debugger/prefix_mapping/rewrite-exists-no-prefix/def/pack1/lib1/readme.txt
+++ b/testsuite/tests/tool-debugger/prefix_mapping/rewrite-exists-no-prefix/def/pack1/lib1/readme.txt
@@ -1,0 +1,1 @@
+This is here to ensure the enclosing directory exists

--- a/testsuite/tests/tool-debugger/prefix_mapping/rewrite-exists-no-prefix/input_script
+++ b/testsuite/tests/tool-debugger/prefix_mapping/rewrite-exists-no-prefix/input_script
@@ -1,0 +1,6 @@
+load_printer printer.cmo
+install_printer Printer.p
+break @ Debuggee 33
+run
+print x
+quit

--- a/testsuite/tests/tool-debugger/prefix_mapping/rewrite-exists-no-prefix/printer.ml
+++ b/testsuite/tests/tool-debugger/prefix_mapping/rewrite-exists-no-prefix/printer.ml
@@ -1,0 +1,83 @@
+(*
+  Note, a program being debugged does not have access to the
+  debugger process, but a printer that has been loaded is
+  running in the debugger process and has access to its
+  internals. This can be used as a back-door to enable some
+  unit testing of the debugger.
+*)
+open Format
+
+let debug = true
+
+(* Convert to system-dependent filename from part. *)
+let to_sys_name parts =
+  match parts with
+  | [] -> ""
+  | hd :: tl ->
+     List.fold_left Filename.concat hd tl
+
+let to_canonical parts =
+  match parts with
+  | [] -> "."
+  | hd :: tl ->
+     if hd = "/" then
+       "/" ^ String.concat "/" tl
+     else
+       String.concat "/" parts
+
+let filename_parts filename =
+  let open Filename in
+  let rec loop filename acc =
+    let d = dirname filename in
+    if d = filename then filename :: acc
+    else
+      let b = basename filename in
+      loop d (b :: acc)
+  in
+  loop filename []
+
+let canonicalize filename =
+  let parts = filename_parts filename in
+  to_canonical parts
+
+let print_mapping ppf title src (alist: string list) =
+  fprintf ppf "@[<v2>{%s, %s -> #items=%d@ " title (canonicalize src) (List.length alist);
+  if debug then
+    List.iteri (fun i item ->
+        fprintf ppf "[%d]=%s@ " i (canonicalize item)
+      ) alist;
+  fprintf ppf "}@]\n@."
+
+let print_list ppf title (alist: string list) =
+  fprintf ppf "@[<v2>{%s: #items=%d@ " title (List.length alist);
+  if debug then
+    List.iteri (fun i item ->
+        fprintf ppf "[%d]=%s@ " i (canonicalize item)
+      ) alist;
+  fprintf ppf "}@]\n@."
+
+let p : Format.formatter -> int -> unit = fun ppf n ->
+  fprintf ppf "%d@." n;
+  let bppm =
+    match Sys.getenv "DEPLOY_PATH_PREFIX_MAP" with
+    | exception Not_found -> ""
+    | map -> map in
+  if debug then
+    fprintf ppf "DEPLOY_PATH_PREFIX_MAP=\"%s\"\n%!" bppm;
+  let test1 =
+    to_sys_name ["/other_root"; "pack1"; "lib1"; "mod1.ml"] in
+  let open Printf in
+  match Location.rewrite_find_first_existing test1 with
+  | None ->
+     (* DEPLOY_PATH_PREFIX_MAP not set. *)
+     printf "%s -> None\n%!" (canonicalize test1)
+  | Some target ->
+     printf "%s -> Some %s\n%!"
+       (canonicalize test1) (canonicalize target)
+  | exception Not_found ->
+     printf "DEPLOY_PATH_PREFIX_MAP fails to find %s.\n%!"
+       (canonicalize test1);
+  if false then begin
+      let load_paths = Load_path.get_paths () in
+      print_list ppf "Load_path" load_paths
+  end

--- a/testsuite/tests/tool-debugger/prefix_mapping/rewrite-exists-not-found/abc/pack1/lib1/readme.txt
+++ b/testsuite/tests/tool-debugger/prefix_mapping/rewrite-exists-not-found/abc/pack1/lib1/readme.txt
@@ -1,0 +1,1 @@
+This is here to ensure the enclosing directory exists

--- a/testsuite/tests/tool-debugger/prefix_mapping/rewrite-exists-not-found/debuggee.ml
+++ b/testsuite/tests/tool-debugger/prefix_mapping/rewrite-exists-not-found/debuggee.ml
@@ -1,0 +1,40 @@
+(* Test rewrite_find_first_existing for the case where DEPLOY_PATH_PREFIX_MAP is set,
+   there is a prefix match, but the desired file is not found. *)
+
+(* TEST
+ flags += " -g ";
+ ocamldebug_script = "${test_source_directory}/input_script";
+ readonly_files = "printer.ml";
+ subdirectories = "abc def";
+ include debugger;
+ include ocamlcommon;
+ set DEPLOY_PATH_PREFIX_MAP = "abc=/workspace_root";
+ DEPLOY_PATH_PREFIX_MAP += ":def=/workspace_root";
+ debugger;
+
+ shared-libraries;
+
+ setup-ocamlc.byte-build-env;
+ {
+   module = "printer.ml";
+   ocamlc.byte;
+ }{
+   ocamlc.byte;
+
+   check-ocamlc.byte-output;
+
+   ocamldebug;
+
+   check-program-output;
+ }
+*)
+
+let f x =
+  for _i = 0 to x do
+    print_endline "..."
+  done
+
+let main () =
+  f 3
+let () =
+  main ()

--- a/testsuite/tests/tool-debugger/prefix_mapping/rewrite-exists-not-found/debuggee.reference
+++ b/testsuite/tests/tool-debugger/prefix_mapping/rewrite-exists-not-found/debuggee.reference
@@ -1,0 +1,8 @@
+File printer.cmo loaded
+Loading program... done.
+Breakpoint: 1
+33   <|b|>for _i = 0 to x do
+x: int = 3
+DEPLOY_PATH_PREFIX_MAP="abc=/workspace_root:def=/workspace_root"
+DEPLOY_PATH_PREFIX_MAP fails to find /workspace_root/pack1/lib1/mod1.ml.
+

--- a/testsuite/tests/tool-debugger/prefix_mapping/rewrite-exists-not-found/def/pack1/lib1/readme.txt
+++ b/testsuite/tests/tool-debugger/prefix_mapping/rewrite-exists-not-found/def/pack1/lib1/readme.txt
@@ -1,0 +1,1 @@
+This is here to ensure the enclosing directory exists

--- a/testsuite/tests/tool-debugger/prefix_mapping/rewrite-exists-not-found/input_script
+++ b/testsuite/tests/tool-debugger/prefix_mapping/rewrite-exists-not-found/input_script
@@ -1,0 +1,6 @@
+load_printer printer.cmo
+install_printer Printer.p
+break @ Debuggee 33
+run
+print x
+quit

--- a/testsuite/tests/tool-debugger/prefix_mapping/rewrite-exists-not-found/printer.ml
+++ b/testsuite/tests/tool-debugger/prefix_mapping/rewrite-exists-not-found/printer.ml
@@ -1,0 +1,80 @@
+(*
+  Note, a program being debugged does not have access to the
+  debugger process, but a printer that has been loaded is
+  running in the debugger process and has access to its
+  internals. This can be used as a back-door to enable some
+  unit testing of the debugger.
+*)
+open Format
+
+let debug = true
+
+(* Convert to system-dependent filename from part. *)
+let to_sys_name parts =
+  match parts with
+  | [] -> ""
+  | hd :: tl ->
+     List.fold_left Filename.concat hd tl
+
+let to_canonical parts =
+  match parts with
+  | [] -> "."
+  | hd :: tl ->
+     if hd = "/" then
+       "/" ^ String.concat "/" tl
+     else
+       String.concat "/" parts
+
+let filename_parts filename =
+  let open Filename in
+  let rec loop filename acc =
+    let d = dirname filename in
+    if d = filename then filename :: acc
+    else
+      let b = basename filename in
+      loop d (b :: acc)
+  in
+  loop filename []
+
+let canonicalize filename =
+  let parts = filename_parts filename in
+  to_canonical parts
+
+let print_mapping ppf title src (alist: string list) =
+  fprintf ppf "@[<v2>{%s, %s -> #items=%d@ " title (canonicalize src) (List.length alist);
+  if debug then
+    List.iteri (fun i item ->
+        fprintf ppf "[%d]=%s@ " i (canonicalize item)
+      ) alist;
+  fprintf ppf "}@]\n@."
+
+let print_list ppf title (alist: string list) =
+  fprintf ppf "@[<v2>{%s: #items=%d@ " title (List.length alist);
+  if debug then
+    List.iteri (fun i item ->
+        fprintf ppf "[%d]=%s@ " i (canonicalize item)
+      ) alist;
+  fprintf ppf "}@]\n@."
+
+let p : Format.formatter -> int -> unit = fun ppf n ->
+  fprintf ppf "%d@." n;
+  let bppm = Sys.getenv "DEPLOY_PATH_PREFIX_MAP" in
+  if debug then
+    fprintf ppf "DEPLOY_PATH_PREFIX_MAP=\"%s\"\n%!" bppm;
+  let test1 =
+    to_sys_name ["/workspace_root"; "pack1"; "lib1"; "mod1.ml"] in
+  let open Printf in
+  match Location.rewrite_find_first_existing test1 with
+  | None ->
+     (* DEPLOY_PATH_PREFIX_MAP not set. *)
+     printf "%s -> None\n%!" (canonicalize test1)
+  | Some target ->
+     printf "%s -> Some %s\n%!"
+       (canonicalize test1) (canonicalize target)
+  | exception Not_found ->
+     printf "DEPLOY_PATH_PREFIX_MAP fails to find %s.\n%!"
+       (canonicalize test1);
+  if false then begin
+      let load_paths = Load_path.get_paths () in
+      print_list ppf "Load_path" load_paths
+  end

--- a/utils/misc.ml
+++ b/utils/misc.ml
@@ -882,6 +882,24 @@ let get_build_path_prefix_map =
     end;
     !map_cache
 
+let get_deploy_path_prefix_map =
+  let init = ref false in
+  let map_cache = ref None in
+  fun () ->
+    if not !init then begin
+      init := true;
+      match Sys.getenv "DEPLOY_PATH_PREFIX_MAP" with
+      | exception Not_found -> ()
+      | encoded_map ->
+        match Build_path_prefix_map.decode_map encoded_map with
+          | Error err ->
+              fatal_errorf
+                "Invalid value for the environment variable \
+                 DEPLOY_PATH_PREFIX_MAP: %s" err
+          | Ok map -> map_cache := Some map
+    end;
+    !map_cache
+
 let debug_prefix_map_flags () =
   if not Config.as_has_debug_prefix_map then
     []

--- a/utils/misc.mli
+++ b/utils/misc.mli
@@ -569,6 +569,10 @@ val get_build_path_prefix_map: unit -> Build_path_prefix_map.map option
 (** Returns the map encoded in the [BUILD_PATH_PREFIX_MAP] environment
     variable. *)
 
+val get_deploy_path_prefix_map: unit -> Build_path_prefix_map.map option
+(** Returns the map encoded in the [BUILD_PATH_PREFIX_MAP] environment
+    variable. *)
+
 val debug_prefix_map_flags: unit -> string list
 (** Returns the list of [--debug-prefix-map] flags to be passed to the
     assembler, built from the [BUILD_PATH_PREFIX_MAP] environment variable. *)


### PR DESCRIPTION
Add deployment phase support for BUILD_PATH_PREFIX_MAP
The BUILD_PATH_PREFIX_MAP specification tells how to use that
environment variable to achieve reproducible build, i.e. builds of
products that do not leak absolute paths from the build
environment. See
https://reproducible-builds.org/specs/build-path-prefix-map.

However, that specification only describes half of the story.  Let us
call the building of reproducible products the "Build Phase". That is
the phase covered by the existing specification.

Let us defined the "Deployment phase" as the phase where you accept a
built reproducible product and make use of it, i.e. deploy it. An
example would be the debugger taking a reproducible binary and letting
the user debug it, showing the user the source code, etc.

We use the same mechanism in the deployment phase. Then
the BUILD_PATH_PREFIX_MAP must be setup with the logical
inverse of the mapping used during the build phase.

Also, this is part of a larger PR,
https://github.com/ocaml/ocaml/pull/12085, that is being split up
because it was too large. In addition to these changes, that PR
includes ocamltest enhancements plus the tests for
these changes. See it for prior discussion and the other changes.

I will now describe the essence of the changes.

1. utils/build_path_prefix_map.{ml,mli}

Added these functions to aid in use of the mapping
during the deployment phase. They allow to skip
mapping entries that are not applicable (find_rewrite).
find_rewrite is then used to implement rewrite_exists and
matching_dirs.

```ocaml
val find_rewrite : map -> (path -> bool) -> path -> path option
(** [rewrite_opt map pred path] tries to find a source in [map]
    that is a prefix of the input [path] that produces a result
    that satisfies predicate [pred]. If it succeeds,
    it replaces this prefix with the corresponding target.
    If it fails, it just returns [None]. *)

val rewrite_exists : map -> path -> path option
(** [rewrite_exists map path] tries to find a source in [map]
    that maps to a result that exists in the file system.
    If so, returns Some result. Otherwise, is there was
    at least one source that was a prefix of path, it is
    assumed that the map is deficient and Not_found is raised.
    If no source prefixes were found, None is returned.
*)

val matching_dirs : map -> path -> path list
(** [matching_dirs map absdir] accumulates a list of existing directories,
  [dirs], that are the result of mapping abstract directory, [absdir],
  over all the mapping pairs in [map]. The list [dirs] will be in
  priority order (head as highest priority). If there is success,
  returns [dirs]. If no source in the map was a prefix of [absdir],
  returns [[]]. If at least one source in the map was a prefix of
  [absdir], but none of the mappings were existing directories,
  raise Not_found.
*)
```

2. parsing/location.{ml, mli}

This has convenience functions for using the above
mapping API. It reads and caches the environment
variable so the end-user does not need to.

Location.absolute_path was modified so that BUILD_PATH_PREFIX_MAP
rewriting is done for both absolute and relative paths. Relative paths
are made absolute by appending to the cwd.  Previously only relative
paths were rewritten.  One discovery during testing was that if the
compiler is given an absolute path as the input source, the debug
event information had that absolute path (see below).

New functions are:

```ocaml
val rewrite_exists: string -> string option option
(** [rewrite_exists path] uses a BUILD_PATH_PREFIX_MAP mapping
    (https://reproducible-builds.org/specs/build-path-prefix-map/)
    and tries to find a source in mapping
    that maps to a result that exists in the file system.
    There are the following return values:
    - None, means BUILD_PATH_PREFIX_MAP is not set.
    - Some None, no source prefixes of [path] in the mapping were found,
    - Some (Some target), means target is the first file (in priority
      order) that [path] mapped to that exists in the file system.
    - Not_found raised, means some source prefixes in the map
      were found that matched [path], but none of them existed
      in the file system. *)

val matching_dirs: string -> string list option
(** [matching_dirs absdir] accumulates a list of existing directories,
    [dirs], that are the result of mapping abstract directory, [absdir],
    over all the mapping pairs in the BUILD_PATH_PREFIX_MAP environment
    variable. The list [dirs] will be in priority order (head as highest
    priority). The possible results are:
    - None, means BUILD_PATH_PREFIX_MAP is not set.
    - Some [], no source prefixes in the mapping were found,
    - Some dirs, means dirs are the directories found
    - Not_found raised, means some source prefixes in the map
      were found that matched [path], but none of mapping results
      were existing directories.
    See the BUILD_PATH_PREFIX_MAP spec at
    (https://reproducible-builds.org/specs/build-path-prefix-map/)
    *)
```

3. bytecomp/emitcode.ml

Added sanitizing of paths in the debug events.
If the compiler is given absolute source paths
this was leaking absolute build paths.

4. bytecomp/bytelink.ml

Rewrite when producing the path for a shebang.
The value written is from the user "-use-runtime"
option. The one setting BUILD_PATH_PREFIX_MAP
will have control whether this does anything or not.

5. debugger/command_line.ml

A debugger variable, "mapping", was added, which is tied to the
BUILD_PATH_PREFIX_MAP environment variable.  So "set mapping value"
will set BUILD_PATH_PREFIX_MAP, and "show mapping" will show the value
of BUILD_PATH_PREFIX_MAP. This allows the user to set it
programmaticaly, possibly from the ".ocamldebug" file.

6. debugger/source.ml

In source_of_module, use the Location.rewrite_exists.

6. debugger/symbols.{ml, mli}

a. Avoid adding directories redundantly

b. Expose bppm_expand_path and get_load_path so they
can be called from a fake printer which, when
loaded and installed in a test, can do unit testing
of ocamldebug.

c. Use Location.matching_dirs to expand directories.

7. Man page and manual updated.

Fixes https://github.com/ocaml/ocaml/issues/12083