### PR TITLE
Additions to ocamltest

### DIFF
--- a/Changes
+++ b/Changes
@@ -692,6 +692,9 @@ OCaml 5.1.0
 
 ### Build system:
 
+- #12127: ocamltest additions: expanded scripts, built-in functions
+   (Richard L Ford, review by Sébastien Hinderer)
+
 - #11590: Allow installing to a destination path containing spaces.
    (Élie Brami, review by Sébastien Hinderer and David Allsopp)
 

--- a/ocamltest/actions_helpers.ml
+++ b/ocamltest/actions_helpers.ml
@@ -386,3 +386,23 @@ let check_output kind_of_output output_variable reference_variable log
       let reason = Printf.sprintf "The command %s failed with status %d"
         commandline exitcode in
       (Result.fail_with_reason reason, env)
+
+let is_in_path program =
+  let path_sep = if Sys.win32 then ';' else ':' in
+  let path = Sys.getenv "PATH" in
+  let paths = String.split_on_char path_sep path in
+  let rec loop = function
+    | [] -> false
+    | hd :: tl ->
+      let full_path = hd ^ "/" ^ program in
+      if Sys.file_exists full_path then true else loop tl
+  in
+  loop paths
+
+let available_in_path action_name exec_name = Actions.make
+  ~name:action_name
+  ~description:("Pass if " ^ exec_name
+                ^ " is available in PATH, otherwise skip")
+  (pass_or_skip (is_in_path exec_name)
+      (exec_name ^ " is available")
+      (exec_name ^ " is not available"))

--- a/ocamltest/actions_helpers.mli
+++ b/ocamltest/actions_helpers.mli
@@ -60,3 +60,10 @@ val run_script : Actions.code
 val run_hook : string -> Actions.code
 
 val check_output : string -> Variables.t -> Variables.t -> Actions.code
+
+val available_in_path : string -> string -> Actions.t
+  (**
+    [available_in_path action_name exec_name] returns an
+    action with name [action_name] that checks whether
+    [exec_name] is available on the path.
+   *)

--- a/ocamltest/builtin_actions.mli
+++ b/ocamltest/builtin_actions.mli
@@ -20,6 +20,7 @@ val skip : Actions.t
 val fail : Actions.t
 
 val dumpenv : Actions.t
+val dumpenv_expanded : Actions.t
 
 val hasunix : Actions.t
 val libunix : Actions.t

--- a/ocamltest/builtin_variables.ml
+++ b/ocamltest/builtin_variables.ml
@@ -146,3 +146,29 @@ let _ = List.iter Variables.register_variable
     test_fail;
     timeout;
   ]
+
+  (* Definition of builtin functions available for use *)
+
+(* The functions are listed in alphabetical order *)
+
+let bppm_decode_fun (arg: string) =
+  match Build_path_prefix_map.decode_prefix arg with
+  | Ok path -> path
+  | Error err -> err
+
+let bppm_decode = Variables.make ~variable_function: bppm_decode_fun
+  ("bppm_decode",
+  "function to do BUILD_PATH_PREFIX_MAP decoding")
+
+let bppm_encode_fun (arg: string) =
+  Build_path_prefix_map.encode_prefix arg
+
+let bppm_encode = Variables.make ~variable_function: bppm_encode_fun
+  ("bppm_encode",
+  "function to do BUILD_PATH_PREFIX_MAP encoding")
+
+  let _ = List.iter Variables.register_variable
+  [
+    bppm_decode;
+    bppm_encode
+  ]

--- a/ocamltest/builtin_variables.mli
+++ b/ocamltest/builtin_variables.mli
@@ -75,3 +75,13 @@ val test_skip : Variables.t
 val test_fail : Variables.t
 
 val timeout : Variables.t
+
+(* Builtin functions *)
+
+val bppm_decode : Variables.t
+  (* ${bppm_decode arg} will decode arg according to the
+     BUILD_PATH_PREFIX_MAP specification. *)
+
+val bppm_encode : Variables.t
+  (* ${bppm_encode arg} will encode arg according to the
+     BUILD_PATH_PREFIX_MAP specification. *)

--- a/ocamltest/environments.mli
+++ b/ocamltest/environments.mli
@@ -24,6 +24,7 @@ val to_bindings : t -> (Variables.t * string) list
 val to_system_env : t -> string array
 val append_to_system_env : string array -> t -> string array
 
+val expand_string : t -> string -> string
 val lookup : Variables.t -> t -> string option
 val lookup_nonempty : Variables.t -> t -> string option
 val safe_lookup : Variables.t -> t -> string
@@ -50,6 +51,8 @@ val unsetenv : Variables.t -> t -> t
 val append : Variables.t -> string -> t -> t
 
 val dump : out_channel -> t -> unit
+
+val dump_expanded : out_channel -> t -> unit
 
 (* Initializers *)
 

--- a/ocamltest/variables.ml
+++ b/ocamltest/variables.ml
@@ -19,10 +19,13 @@ type value = string
 
 type exporter = value -> string * string
 
+type var_fun = (string -> string)
+
 type t = {
   variable_name : string;
   variable_description : string;
-  variable_exporter : exporter
+  variable_exporter : exporter;
+  variable_function : var_fun option
 }
 
 let compare v1 v2 = String.compare v1.variable_name v2.variable_name
@@ -35,23 +38,27 @@ exception No_such_variable of string
 
 let default_exporter varname value = (varname, value)
 
-let make (name, description) =
+let make ?variable_function (name, description) =
   if name="" then raise Empty_variable_name else {
     variable_name = name;
     variable_description = description;
-    variable_exporter = default_exporter name
+    variable_exporter = default_exporter name;
+    variable_function;
   }
 
-let make_with_exporter exporter (name, description) =
+let make_with_exporter ?variable_function exporter (name, description) =
   if name="" then raise Empty_variable_name else {
     variable_name = name;
     variable_description = description;
-    variable_exporter = exporter
+    variable_exporter = exporter;
+    variable_function;
   }
 
 let name_of_variable v = v.variable_name
 
 let description_of_variable v = v.variable_description
+
+let function_of_variable v = v.variable_function
 
 let (variables : (string, t) Hashtbl.t) = Hashtbl.create 10
 

--- a/ocamltest/variables.mli
+++ b/ocamltest/variables.mli
@@ -19,6 +19,9 @@ type value = string
 
 type exporter = value -> string * string
 
+(* The signature of functions that variables support. *)
+type var_fun = (string -> string)
+
 type t
 
 val compare : t -> t -> int
@@ -29,13 +32,16 @@ exception Variable_already_registered of string
 
 exception No_such_variable of string
 
-val make : string * string -> t
+val make : ?variable_function:var_fun -> string * string -> t
 
-val make_with_exporter : exporter -> string * string -> t
+val make_with_exporter :
+  ?variable_function:var_fun -> exporter -> string * string -> t
 
 val name_of_variable : t -> string
 
 val description_of_variable : t -> string
+
+val function_of_variable : t -> var_fun option
 
 val register_variable : t -> unit
 

--- a/testsuite/tests/builtin-functions/bppm/decode/decode.ml
+++ b/testsuite/tests/builtin-functions/bppm/decode/decode.ml
@@ -1,0 +1,11 @@
+(* TEST
+ set input1 = "ab%#c%.d%+ef";
+ set input2 = "$input1";
+ set result = "${bppm_decode $input2}";
+ dumpenv_expanded;
+
+ script = "sh ${test_source_directory}/decode_checker.sh";
+ script;
+*)
+
+(* This file only contains the specification of how to run the test *)

--- a/testsuite/tests/builtin-functions/bppm/decode/decode_checker.sh
+++ b/testsuite/tests/builtin-functions/bppm/decode/decode_checker.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+if [ "${result}" = "ab%c:d=ef" ]; then
+    exit ${TEST_PASS}
+else
+    echo result=${result}, expected "ab%c:d=ef" > ${ocamltest_response}
+    exit ${TEST_FAIL}
+fi

--- a/testsuite/tests/builtin-functions/bppm/encode/encode.ml
+++ b/testsuite/tests/builtin-functions/bppm/encode/encode.ml
@@ -1,0 +1,11 @@
+(* TEST
+ set input1 = "ab%c:d=ef";
+ set input2 = "$input1";
+ set result = "${bppm_encode $input2}";
+ dumpenv_expanded;
+
+ script = "sh ${test_source_directory}/encode_checker.sh";
+ script;
+*)
+
+(* This file only contains the specification of how to run the test *)

--- a/testsuite/tests/builtin-functions/bppm/encode/encode_checker.sh
+++ b/testsuite/tests/builtin-functions/bppm/encode/encode_checker.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+if [ "${result}" = "ab%#c%.d%+ef" ]; then
+    exit ${TEST_PASS}
+else
+    echo result=${result}, expected "ab%#c%.d%+ef" > ${ocamltest_response}
+    exit ${TEST_FAIL}
+fi

--- a/testsuite/tests/builtin-functions/bppm/encode_decode/encode.ml
+++ b/testsuite/tests/builtin-functions/bppm/encode_decode/encode.ml
@@ -1,0 +1,12 @@
+(* TEST
+ set input1 = "ab%c:d=ef";
+ set input2 = "$input1";
+ set result1 = "${bppm_encode $input2}";
+ set result2 = "${bppm_decode $result1}";
+ dumpenv_expanded;
+
+ script = "sh ${test_source_directory}/encode_checker.sh";
+ script;
+*)
+
+(* This file only contains the specification of how to run the test *)

--- a/testsuite/tests/builtin-functions/bppm/encode_decode/encode_checker.sh
+++ b/testsuite/tests/builtin-functions/bppm/encode_decode/encode_checker.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+if [ "${result1}" != "ab%#c%.d%+ef" ]; then
+    echo result1=${result1}, expected "ab%#c%.d%+ef" > ${ocamltest_response}
+    exit ${TEST_FAIL}
+else
+    if [ "${result2}" != "ab%c:d=ef" ]; then
+        echo result1=${result1}, expected "ab%c:d=ef" > ${ocamltest_response}
+        exit ${TEST_FAIL}
+    fi
+    exit ${TEST_PASS}
+fi


### PR DESCRIPTION
This is part 2 of a larger PR, #12085, which includes part 1 (compiler and debugger changes), this part, and a third part which is tests of part 1 that make use of (and hence motivate and test) these changes. Please see that PR for example uses of these changes.

1. Add the ability to have scripts or files with ocamltest variables references expanded. Added a new "expand" action to  camltest. It is mostly like the "copy" action, but the source file is read a line at a time and the lines are expanded. It does not support source directories, but the destination can be a directory.

2. Enhanced ocamltest to have a facility for making built-in functions. These are like ocamltest variables but have a function attached to them, and when the variable is expanded, the arguments are first expanded and then the function is called and its result is returned. Currently they only take one parameter, but it should not be too hard to add the ability to have multiple arguments.

3. Added a new "dumpenv_expanded" action which not only shows the value of each variable but also what they expand to. When variables are originally assigned, their RHS is not expanded, but only later when the variable itself is looked up.

4. Two builtin functions were defined:

- bppm_decode does BUILD_PATH_PREFIX_MAP decoding

- bppm_encode does BUILD_PATH_PREFIX_MAP encoding

See https://reproducible-builds.org/specs/build-path-prefix-map/ and https://github.com/richardlford/build-path-prefix-map-spec/pull/1.

5. Prepare to be able to do Dune tests:

5a. Added an action helper for testing if a program is available in PATH.

5b. Use the helper to make an action, has_dune,
that detects whether dune is available.