### PR TITLE
interruptible compare.c

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -137,6 +137,7 @@ Eduardo Rafael <EduardoRFS@github>
 Runhang Li <objmagic@github>
 Dmitrii Kosarev <Kakadu@github>
 Samuel Hym <shym@github>
+B. Szilvasy <eutro@github>
 
 # These contributors prefer to be referred to pseudonymously
 whitequark <whitequark@whitequark.org>

--- a/Changes
+++ b/Changes
@@ -111,6 +111,11 @@ Working version
 - #12132: Fix overcounting of minor collections in GC stats.
   (Damien Doligez, review by Gabriel Scherer)
 
+- #3921, #12039, #12128: poll for signals in long-running polymorphic
+  comparisons.
+  (B. Szilvasy, Gabriel Scherer and Xavier Leroy, review by
+   Stefan Muenzel, Guillaume Munch-Maccagnoni and Damien Doligez)
+
 ### Type system:
 
 - #6941, #11187: prohibit using classes through recursive modules

--- a/runtime/compare.c
+++ b/runtime/compare.c
@@ -37,6 +37,8 @@ struct compare_stack {
   struct compare_item* limit;
 };
 
+#define COMPARE_POLL_PERIOD 1024
+
 /* Free the compare stack if needed */
 static void compare_free_stack(struct compare_stack* stk)
 {
@@ -84,7 +86,6 @@ static struct compare_item * compare_resize_stack(struct compare_stack* stk,
   return newstack + sp_offset;
 }
 
-
 static intnat do_compare_val(struct compare_stack* stk,
                              value v1, value v2, int total);
 
@@ -97,6 +98,24 @@ static intnat compare_val(value v1, value v2, int total)
   res = do_compare_val(&stk, v1, v2, total);
   compare_free_stack(&stk);
   return res;
+}
+
+static void run_pending_actions(struct compare_stack* stk,
+                                struct compare_item* sp)
+{
+  value exn;
+  value* roots_start = (value*)(stk->stack);
+  size_t roots_length =
+    (sp - stk->stack)
+    * sizeof(struct compare_item) / sizeof(value);
+  Begin_roots_block(roots_start, roots_length);
+  exn = caml_do_pending_actions_exn();
+  End_roots();
+  if (Is_exception_result(exn)) {
+    exn = Extract_exception(exn);
+    compare_free_stack(stk);
+    caml_raise(exn);
+  }
 }
 
 /* Structural comparison */
@@ -118,188 +137,206 @@ static intnat do_compare_val(struct compare_stack* stk,
 {
   struct compare_item * sp;
   tag_t t1, t2;
+  int poll_timer;
 
   sp = stk->stack;
   while (1) {
-    if (v1 == v2 && total) goto next_item;
-    if (Is_long(v1)) {
-      if (v1 == v2) goto next_item;
-      if (Is_long(v2))
-        return Long_val(v1) - Long_val(v2);
-      /* Subtraction above cannot overflow and cannot result in UNORDERED */
-      switch (Tag_val(v2)) {
-        case Forward_tag:
-          v2 = Forward_val(v2);
-          continue;
-        case Custom_tag: {
-          int res;
-          int (*compare)(value v1, value v2) = Custom_ops_val(v2)->compare_ext;
-          if (compare == NULL) break;  /* for backward compatibility */
-          Caml_state->compare_unordered = 0;
-          res = compare(v1, v2);
-          if (Caml_state->compare_unordered && !total) return UNORDERED;
-          if (res != 0) return res;
-          goto next_item;
-        }
-        default: /*fallthrough*/;
-        }
+    poll_timer = COMPARE_POLL_PERIOD;
+    while (--poll_timer > 0) {
+      if (v1 == v2 && total) goto next_item;
+      if (Is_long(v1)) {
+        if (v1 == v2) goto next_item;
+        if (Is_long(v2))
+          return Long_val(v1) - Long_val(v2);
+        /* Subtraction above cannot overflow and cannot result in UNORDERED */
+        switch (Tag_val(v2)) {
+          case Forward_tag:
+            v2 = Forward_val(v2);
+            continue;
+          case Custom_tag: {
+            int res;
+            int (*compare)(value v1, value v2) =
+              Custom_ops_val(v2)->compare_ext;
+            if (compare == NULL) break;  /* for backward compatibility */
+            Caml_state->compare_unordered = 0;
+            res = compare(v1, v2);
+            if (Caml_state->compare_unordered && !total) return UNORDERED;
+            if (res != 0) return res;
+            goto next_item;
+          }
+          default: /*fallthrough*/;
+          }
 
-      return LESS;                /* v1 long < v2 block */
-    }
-    if (Is_long(v2)) {
-      switch (Tag_val(v1)) {
-        case Forward_tag:
-          v1 = Forward_val(v1);
-          continue;
-        case Custom_tag: {
-          int res;
-          int (*compare)(value v1, value v2) = Custom_ops_val(v1)->compare_ext;
-          if (compare == NULL) break;  /* for backward compatibility */
-          Caml_state->compare_unordered = 0;
-          res = compare(v1, v2);
-          if (Caml_state->compare_unordered && !total) return UNORDERED;
-          if (res != 0) return res;
-          goto next_item;
-        }
-        default: /*fallthrough*/;
-        }
-      return GREATER;            /* v1 block > v2 long */
-    }
-    t1 = Tag_val(v1);
-    t2 = Tag_val(v2);
-    if (t1 != t2) {
-        /* Besides long/block comparisons, the only forms of
-           heterogeneous comparisons we support are:
-           - Forward_tag pointers, which may point to values of any type, and
-           - comparing Infix_tag and Closure_tag functions (#9521).
-
-           Other heterogeneous cases may still happen due to
-           existential types, and we just compare the tags.
-        */
-        if (t1 == Forward_tag) { v1 = Forward_val (v1); continue; }
-        if (t2 == Forward_tag) { v2 = Forward_val (v2); continue; }
-        if (t1 == Infix_tag) t1 = Closure_tag;
-        if (t2 == Infix_tag) t2 = Closure_tag;
-        if (t1 != t2)
-            return (intnat)t1 - (intnat)t2;
-    }
-    switch(t1) {
-    case Forward_tag: {
-        v1 = Forward_val (v1);
-        v2 = Forward_val (v2);
-        continue;
-    }
-    case String_tag: {
-      mlsize_t len1, len2;
-      int res;
-      if (v1 == v2) break;
-      len1 = caml_string_length(v1);
-      len2 = caml_string_length(v2);
-      res = memcmp(String_val(v1), String_val(v2), len1 <= len2 ? len1 : len2);
-      if (res < 0) return LESS;
-      if (res > 0) return GREATER;
-      if (len1 != len2) return len1 - len2;
-      break;
-    }
-    case Double_tag: {
-      double d1 = Double_val(v1);
-      double d2 = Double_val(v2);
-      if (d1 < d2) return LESS;
-      if (d1 > d2) return GREATER;
-      if (d1 != d2) {
-        if (! total) return UNORDERED;
-        /* One or both of d1 and d2 is NaN.  Order according to the
-           convention NaN = NaN and NaN < f for all other floats f. */
-        if (d1 == d1) return GREATER; /* d1 is not NaN, d2 is NaN */
-        if (d2 == d2) return LESS;    /* d2 is not NaN, d1 is NaN */
-        /* d1 and d2 are both NaN, thus equal: continue comparison */
+        return LESS;                /* v1 long < v2 block */
       }
-      break;
-    }
-    case Double_array_tag: {
-      mlsize_t sz1 = Wosize_val(v1) / Double_wosize;
-      mlsize_t sz2 = Wosize_val(v2) / Double_wosize;
-      mlsize_t i;
-      if (sz1 != sz2) return sz1 - sz2;
-      for (i = 0; i < sz1; i++) {
-        double d1 = Double_flat_field(v1, i);
-        double d2 = Double_flat_field(v2, i);
+      if (Is_long(v2)) {
+        switch (Tag_val(v1)) {
+          case Forward_tag:
+            v1 = Forward_val(v1);
+            continue;
+          case Custom_tag: {
+            int res;
+            int (*compare)(value v1, value v2) =
+              Custom_ops_val(v1)->compare_ext;
+            if (compare == NULL) break;  /* for backward compatibility */
+            Caml_state->compare_unordered = 0;
+            res = compare(v1, v2);
+            if (Caml_state->compare_unordered && !total) return UNORDERED;
+            if (res != 0) return res;
+            goto next_item;
+          }
+          default: /*fallthrough*/;
+          }
+        return GREATER;            /* v1 block > v2 long */
+      }
+      t1 = Tag_val(v1);
+      t2 = Tag_val(v2);
+      if (t1 != t2) {
+          /* Besides long/block comparisons, the only forms of
+             heterogeneous comparisons we support are:
+             - Forward_tag pointers, which may point to values of any type, and
+             - comparing Infix_tag and Closure_tag functions (#9521).
+
+             Other heterogeneous cases may still happen due to
+             existential types, and we just compare the tags.
+          */
+          if (t1 == Forward_tag) { v1 = Forward_val (v1); continue; }
+          if (t2 == Forward_tag) { v2 = Forward_val (v2); continue; }
+          if (t1 == Infix_tag) t1 = Closure_tag;
+          if (t2 == Infix_tag) t2 = Closure_tag;
+          if (t1 != t2)
+              return (intnat)t1 - (intnat)t2;
+      }
+      switch(t1) {
+      case Forward_tag: {
+          v1 = Forward_val (v1);
+          v2 = Forward_val (v2);
+          continue;
+      }
+      case String_tag: {
+        mlsize_t len1, len2;
+        int res;
+        if (v1 == v2) break;
+        len1 = caml_string_length(v1);
+        len2 = caml_string_length(v2);
+        res = memcmp(String_val(v1), String_val(v2),
+                     len1 <= len2 ? len1 : len2);
+        if (res < 0) return LESS;
+        if (res > 0) return GREATER;
+        if (len1 != len2) return len1 - len2;
+        break;
+      }
+      case Double_tag: {
+        double d1 = Double_val(v1);
+        double d2 = Double_val(v2);
         if (d1 < d2) return LESS;
         if (d1 > d2) return GREATER;
         if (d1 != d2) {
           if (! total) return UNORDERED;
-          /* See comment for Double_tag case */
-          if (d1 == d1) return GREATER;
-          if (d2 == d2) return LESS;
+          /* One or both of d1 and d2 is NaN.  Order according to the
+             convention NaN = NaN and NaN < f for all other floats f. */
+          if (d1 == d1) return GREATER; /* d1 is not NaN, d2 is NaN */
+          if (d2 == d2) return LESS;    /* d2 is not NaN, d1 is NaN */
+          /* d1 and d2 are both NaN, thus equal: continue comparison */
         }
+        break;
       }
-      break;
-    }
-    case Abstract_tag:
-      compare_free_stack(stk);
-      caml_invalid_argument("compare: abstract value");
-    case Closure_tag:
-    case Infix_tag:
-      compare_free_stack(stk);
-      caml_invalid_argument("compare: functional value");
-    case Cont_tag:
-      compare_free_stack(stk);
-      caml_invalid_argument("compare: continuation value");
-    case Object_tag: {
-      intnat oid1 = Oid_val(v1);
-      intnat oid2 = Oid_val(v2);
-      if (oid1 != oid2) return oid1 - oid2;
-      break;
-    }
-    case Custom_tag: {
-      int res;
-      int (*compare)(value v1, value v2) = Custom_ops_val(v1)->compare;
-      /* Hardening against comparisons between different types */
-      if (compare != Custom_ops_val(v2)->compare) {
-        return strcmp(Custom_ops_val(v1)->identifier,
-                      Custom_ops_val(v2)->identifier) < 0
-               ? LESS : GREATER;
+      case Double_array_tag: {
+        mlsize_t sz1 = Wosize_val(v1) / Double_wosize;
+        mlsize_t sz2 = Wosize_val(v2) / Double_wosize;
+        mlsize_t i;
+        if (sz1 != sz2) return sz1 - sz2;
+        for (i = 0; i < sz1; i++) {
+          double d1 = Double_flat_field(v1, i);
+          double d2 = Double_flat_field(v2, i);
+          if (d1 < d2) return LESS;
+          if (d1 > d2) return GREATER;
+          if (d1 != d2) {
+            if (! total) return UNORDERED;
+            /* See comment for Double_tag case */
+            if (d1 == d1) return GREATER;
+            if (d2 == d2) return LESS;
+          }
+        }
+        break;
       }
-      if (compare == NULL) {
+      case Abstract_tag:
         compare_free_stack(stk);
         caml_invalid_argument("compare: abstract value");
+      case Closure_tag:
+      case Infix_tag:
+        compare_free_stack(stk);
+        caml_invalid_argument("compare: functional value");
+      case Cont_tag:
+        compare_free_stack(stk);
+        caml_invalid_argument("compare: continuation value");
+      case Object_tag: {
+        intnat oid1 = Oid_val(v1);
+        intnat oid2 = Oid_val(v2);
+        if (oid1 != oid2) return oid1 - oid2;
+        break;
       }
-      Caml_state->compare_unordered = 0;
-      res = compare(v1, v2);
-      if (Caml_state->compare_unordered && !total) return UNORDERED;
-      if (res != 0) return res;
-      break;
-    }
-    default: {
-      mlsize_t sz1 = Wosize_val(v1);
-      mlsize_t sz2 = Wosize_val(v2);
-      /* Compare sizes first for speed */
-      if (sz1 != sz2) return sz1 - sz2;
-      if (sz1 == 0) break;
-      /* Remember that we still have to compare fields 1 ... sz - 1. */
-      if (sz1 > 1) {
-        if (sp >= stk->limit) sp = compare_resize_stack(stk, sp);
-        struct compare_item* next = sp++;
-        next->v1 = v1;
-        next->v2 = v2;
-        next->size = Val_long(sz1);
-        next->offset = Val_long(1);
+      case Custom_tag: {
+        int res;
+        int (*compare)(value v1, value v2) = Custom_ops_val(v1)->compare;
+        /* Hardening against comparisons between different types */
+        if (compare != Custom_ops_val(v2)->compare) {
+          return strcmp(Custom_ops_val(v1)->identifier,
+                        Custom_ops_val(v2)->identifier) < 0
+                 ? LESS : GREATER;
+        }
+        if (compare == NULL) {
+          compare_free_stack(stk);
+          caml_invalid_argument("compare: abstract value");
+        }
+        Caml_state->compare_unordered = 0;
+        res = compare(v1, v2);
+        if (Caml_state->compare_unordered && !total) return UNORDERED;
+        if (res != 0) return res;
+        break;
       }
-      /* Continue comparison with first field */
-      v1 = Field(v1, 0);
-      v2 = Field(v2, 0);
-      continue;
-    }
-    }
-  next_item:
-    /* Pop one more item to compare, if any */
-    if (sp == stk->stack) return EQUAL; /* we're done */
+      default: {
+        mlsize_t sz1 = Wosize_val(v1);
+        mlsize_t sz2 = Wosize_val(v2);
+        /* Compare sizes first for speed */
+        if (sz1 != sz2) return sz1 - sz2;
+        if (sz1 == 0) break;
+        /* Remember that we still have to compare fields 1 ... sz - 1. */
+        if (sz1 > 1) {
+          if (sp >= stk->limit) sp = compare_resize_stack(stk, sp);
+          struct compare_item* next = sp++;
+          next->v1 = v1;
+          next->v2 = v2;
+          next->size = Val_long(sz1);
+          next->offset = Val_long(1);
+        }
+        /* Continue comparison with first field */
+        v1 = Field(v1, 0);
+        v2 = Field(v2, 0);
+        continue;
+      }
+      }
+    next_item:
+      /* Pop one more item to compare, if any */
+      if (sp == stk->stack) return EQUAL; /* we're done */
 
-    struct compare_item* last = sp-1;
-    v1 = Field(last->v1, Long_val(last->offset));
-    v2 = Field(last->v2, Long_val(last->offset));
-    last->offset += 2;/* Long_val(last->offset) += 1 */
-    if (last->offset == last->size) sp--;
+      struct compare_item* last = sp-1;
+      v1 = Field(last->v1, Long_val(last->offset));
+      v2 = Field(last->v2, Long_val(last->offset));
+      last->offset += 2;/* Long_val(last->offset) += 1 */
+      if (last->offset == last->size) sp--;
+    }
+    /* Poll for actions */
+    if (caml_check_pending_actions()) {
+      /* Preserve v1, v2 if a GC occurs.  Registering v1 and v2 directly
+         as roots would prevent them from being allocated to registers. */
+      value root_v1 = v1, root_v2 = v2;
+      Begin_roots2(root_v1, root_v2);
+      run_pending_actions(stk, sp);
+      v1 = root_v1; v2 = root_v2;
+      End_roots();
+    }
+    /* Resume comparison after resetting poll_timer */
   }
 }
 

--- a/runtime/compare.c
+++ b/runtime/compare.c
@@ -25,7 +25,7 @@
 
 /* Structural comparison on trees. */
 
-struct compare_item { volatile value * v1, * v2; mlsize_t count; };
+struct compare_item { value v1, v2, offset, size; };
 
 #define COMPARE_STACK_INIT_SIZE 8
 #define COMPARE_STACK_MIN_ALLOC_SIZE 32
@@ -280,9 +280,10 @@ static intnat do_compare_val(struct compare_stack* stk,
       if (sz1 > 1) {
         sp++;
         if (sp >= stk->limit) sp = compare_resize_stack(stk, sp);
-        sp->v1 = &Field(v1, 1);
-        sp->v2 = &Field(v2, 1);
-        sp->count = sz1 - 1;
+        sp->v1 = v1;
+        sp->v2 = v2;
+        sp->offset = Val_long(1);
+        sp->size = Val_long(sz1);
       }
       /* Continue comparison with first field */
       v1 = Field(v1, 0);
@@ -293,9 +294,10 @@ static intnat do_compare_val(struct compare_stack* stk,
   next_item:
     /* Pop one more item to compare, if any */
     if (sp == stk->stack) return EQUAL; /* we're done */
-    v1 = *((sp->v1)++);
-    v2 = *((sp->v2)++);
-    if (--(sp->count) == 0) sp--;
+    v1 = Field(sp->v1, Long_val(sp->offset));
+    v2 = Field(sp->v2, Long_val(sp->offset));
+    sp->offset += 2;/* Long_val(sp->offset) += 1 */
+    if (sp->offset == sp->size) sp--;
   }
 }
 


### PR DESCRIPTION
In #12039, @eutro proposed a fix for issue #3921 (which is a more pressing issue in a multi-domain world) as follows:
- regularly poll for GC interrupts inside the compare loop
- if an interrupt is present, service the GC request and continue

In #12039, what is meant by "continue" is actually "restart the comparison from the start", which makes sense because the intermediate data-structure used by the comparison loop, the "compare stack", has been invalidated by a GC -- it contain interior pointers.

In #12053 we discussed changing the structure of the compare stack to avoid interior pointers. @eutro further suggested in the discussion in #12039 to use only valid OCaml values in the compare stack, that is to use tagged integers for block offsets and sizes.

The present PR combines the following:
- it uses a representation of the compare stack with only valid OCaml values
- it contains @eutro's original logic for regularly polling in the comparison function
- when a GC needs to be serviced, the compare stack is declared as a block of local roots

Note that in #12039 the polling logic is now more sophisticated than it was in the first iteration of the PR. I have only included the simple logic from the first commit, not the more complex code. I think that we should refine that (there are issues with the simple logic, some which we probably want to fix, in particular the looping on cyclic blocks of size 1), but the idea is to get the simplest overall code to demonstrate the combined design.

(My plan if we gather positive feedback on this approach would be to let @eutro adopt this approach if interested, and close the present PR.)

cc people who participated to discussions @eutro @smuenzel @xavierleroy @gadmm

### Performance impact

I re-ran the microbenchmark of #12053 (but remember that @smuenzel demonstrated that the results can be fairly different depending on the CPU), comparing the following versions:

- `trunk`: the current trunk. The compare stack uses interior pointers and the number of arguments left.
- `compare-root-stack-val-val-long`: the code of #12053 rebased on top of the current trunk;
  The compare stack uses base pointers and an offset, compared against the value size as recomputed from the value header.
  Benchmarking by @smuenzel has shown that this version is 10% faster or 10% slower than trunk depending on the CPU/machine.
- `compare-root-stack-val-val-long-long`: the variant of #12053 with base pointers, an offset and a size.
  Uses more memory, but seems consistently faster than trunk on all machines (for this test).
- `compare-root-stack-val-val-val-val`: using OCaml tagged integers for the offset and size.
  You will see below that it has the exact same performance as the `val-val-long-long` version.
- `compare-interruptible`: adding the polling logic

Benchmark results:

```
Benchmark 1: ./ocamlrun.trunk test.byte --width 7 --height 7 --niter 10
  Time (mean ± σ):     454.1 ms ±   9.6 ms    [User: 451.0 ms, System: 1.4 ms]
  Range (min … max):   447.7 ms … 508.9 ms    50 runs
 
Benchmark 2: ./ocamlrun.compare-root-stack-val-val-long test.byte --width 7 --height 7 --niter 10
  Time (mean ± σ):     406.2 ms ±   2.9 ms    [User: 403.1 ms, System: 1.7 ms]
  Range (min … max):   404.0 ms … 417.0 ms    50 runs
 
Benchmark 3: ./ocamlrun.compare-root-stack-val-val-long-long test.byte --width 7 --height 7 --niter 10
  Time (mean ± σ):     390.3 ms ±   5.8 ms    [User: 387.1 ms, System: 1.7 ms]
  Range (min … max):   381.1 ms … 406.1 ms    50 runs
 
Benchmark 4: ./ocamlrun.compare-root-stack-val-val-val-val test.byte --width 7 --height 7 --niter 10
  Time (mean ± σ):     389.9 ms ±   4.6 ms    [User: 386.9 ms, System: 1.6 ms]
  Range (min … max):   386.2 ms … 411.1 ms    50 runs
 
Benchmark 5: ./ocamlrun.compare-interruptible test.byte --width 7 --height 7 --niter 10
  Time (mean ± σ):     411.5 ms ±   4.1 ms    [User: 408.4 ms, System: 1.6 ms]
  Range (min … max):   405.2 ms … 427.6 ms    50 runs
 
Summary
  './ocamlrun.compare-root-stack-val-val-val-val test.byte --width 7 --height 7 --niter 10' ran
    1.00 ± 0.02 times faster than './ocamlrun.compare-root-stack-val-val-long-long test.byte --width 7 --height 7 --niter 10'
    1.04 ± 0.01 times faster than './ocamlrun.compare-root-stack-val-val-long test.byte --width 7 --height 7 --niter 10'
    1.06 ± 0.02 times faster than './ocamlrun.compare-interruptible test.byte --width 7 --height 7 --niter 10'
    1.16 ± 0.03 times faster than './ocamlrun.trunk test.byte --width 7 --height 7 --niter 10'
```

On my machine we see that the polling logic introduces a non-neglectible cost, but that the PR remains faster than trunk. (I believe that this comes from the fact that we only increment one offset instead of two interior pointers.)