### PR TITLE
Fix #11934 with more conservative Weak.get_copy

### DIFF
--- a/Changes
+++ b/Changes
@@ -29,6 +29,9 @@ Working version
 
 ### Runtime system:
 
+- #12130: Fix multicore crashes with weak hash sets. Fixes #11934.
+  (Nick Barnes, review by ??)
+
 - #12099: Add ocamlrund option, -events, to produce a trace of
   debug events during bytecode interpretation. Fixes #12098.
   (Richard L Ford, review by Gabriel Scherer)

--- a/Changes
+++ b/Changes
@@ -30,7 +30,7 @@ Working version
 ### Runtime system:
 
 - #12130: Fix multicore crashes with weak hash sets. Fixes #11934.
-  (Nick Barnes, review by ??)
+  (Nick Barnes, review by François Bobot)
 
 - #12099: Add ocamlrund option, -events, to produce a trace of
   debug events during bytecode interpretation. Fixes #12098.

--- a/runtime/weak.c
+++ b/runtime/weak.c
@@ -319,7 +319,7 @@ static value ephe_get_field_copy (value e, mlsize_t offset)
     copy_tag = Tag_val(copy);
     copy_offs = infix_offs;
     val = Val_unit;
-  } 
+  }
 
   /* Copy non-scannable prefix */
   if (Tag_val(val) > No_scan_tag) {


### PR DESCRIPTION
The function `ephe_get_field_copy` in `runtime/weak.c` (which is the implementation of `Weak.get_copy`, `Ephemeron.get_key_copy`, and `Ephemeron.get_data_copy`), is not multicore-safe, causing crashes such as #11934 (see the comment thread on that issue). The crashes are particularly likely in weak hash sets, which make extensive use of `get_copy`. This PR replaces the implementation with something much safer. It is possible that this new implementation will very occasionally impede the erasure of weak pointers, if a garbage collection is triggered by the single allocation which makes the copy, because it copies the weak pointer into a root which will preserve the object. That seems like a small price to pay.