### PR TITLE
fix overcounting of minor collections

### DIFF
--- a/Changes
+++ b/Changes
@@ -108,6 +108,9 @@ Working version
 - #12121: unrooted implementations of caml_callback*_exn
   (Gabriel Scherer, review by KC Sivaramakrishnan and Xavier Leroy)
 
+- #12132: Fix overcounting of minor collections in GC stats.
+  (Damien Doligez, review by Gabriel Scherer)
+
 ### Type system:
 
 - #6941, #11187: prohibit using classes through recursive modules

--- a/runtime/caml/gc_stats.h
+++ b/runtime/caml/gc_stats.h
@@ -56,7 +56,6 @@ struct alloc_stats {
   uint64_t minor_words;
   uint64_t promoted_words;
   uint64_t major_words;
-  uint64_t minor_collections;
   uint64_t forced_major_collections;
 };
 void caml_accum_alloc_stats(

--- a/runtime/gc_ctrl.c
+++ b/runtime/gc_ctrl.c
@@ -56,16 +56,17 @@ CAMLprim value caml_gc_quick_stat(value v)
   CAMLlocal1 (res);
 
   /* get a copy of these before allocating anything... */
-  intnat majcoll;
+  intnat majcoll, mincoll;
   struct gc_stats s;
   caml_compute_gc_stats(&s);
   majcoll = caml_major_cycles_completed;
+  mincoll = atomic_load(&caml_minor_collections_count);
 
   res = caml_alloc_tuple (17);
   Store_field (res, 0, caml_copy_double ((double)s.alloc_stats.minor_words));
   Store_field (res, 1, caml_copy_double ((double)s.alloc_stats.promoted_words));
   Store_field (res, 2, caml_copy_double ((double)s.alloc_stats.major_words));
-  Store_field (res, 3, Val_long (s.alloc_stats.minor_collections));
+  Store_field (res, 3, Val_long (mincoll));
   Store_field (res, 4, Val_long (majcoll));
   Store_field (res, 5, Val_long (
     s.heap_stats.pool_words + s.heap_stats.large_words));

--- a/runtime/gc_stats.c
+++ b/runtime/gc_stats.c
@@ -54,7 +54,6 @@ void caml_accum_alloc_stats(
   acc->minor_words += s->minor_words;
   acc->promoted_words += s->promoted_words;
   acc->major_words += s->major_words;
-  acc->minor_collections += s->minor_collections;
   acc->forced_major_collections += s->forced_major_collections;
 }
 
@@ -65,7 +64,6 @@ void caml_collect_alloc_stats_sample(
   sample->minor_words = local->stat_minor_words;
   sample->promoted_words = local->stat_promoted_words;
   sample->major_words = local->stat_major_words;
-  sample->minor_collections = atomic_load(&caml_minor_collections_count);
   sample->forced_major_collections = local->stat_forced_major_collections;
 }
 
@@ -96,7 +94,7 @@ void caml_orphan_alloc_stats(caml_domain_state *domain) {
   caml_collect_alloc_stats_sample(domain, &alloc_stats);
   caml_reset_domain_alloc_stats(domain);
 
-  /* push them into the oprhan stats */
+  /* push them into the orphan stats */
   caml_plat_lock(&orphan_lock);
   caml_accum_alloc_stats(&orphaned_alloc_stats, &alloc_stats);
   caml_plat_unlock(&orphan_lock);

--- a/runtime/sys.c
+++ b/runtime/sys.c
@@ -169,7 +169,7 @@ CAMLexport void caml_do_exit(int retcode)
                       (intnat) majwords);
       caml_gc_message(0x400,
           "minor_collections: %"ARCH_INTNAT_PRINTF_FORMAT"d\n",
-          (intnat) s.alloc_stats.minor_collections);
+          (intnat) atomic_load(&caml_minor_collections_count));
       caml_gc_message(0x400,
           "major_collections: %"ARCH_INTNAT_PRINTF_FORMAT"d\n",
           caml_major_cycles_completed);


### PR DESCRIPTION
In `Gc.quick_stat` and `Gc.stat`, each minor GC gets counted n times, where n is the number of domains currently running. This is because the number of minor collections is treated as a per-domain statistic and accumulated over all the domains.

Fixed by removing the minor GC count from the per-domain stat record and using the global variable directly.

This bug is probably a leftover from the old multicore design when minor GCs were local to each domain.
