### PR TITLE
Format: add `pp_print_substring` and `pp_print_substring_as`

### DIFF
--- a/Changes
+++ b/Changes
@@ -372,6 +372,10 @@ OCaml 5.2.0
   (Janith Petangoda, reported by Simmo Saan, reviewed by Florian Angeletti,
   Simmo Saan, Josh Berdine and Gabriel Scherer)
 
+- #12133: Expose support for printing substrings in Format
+  (Florian Angeletti, review by Daniel Bünzli, Gabriel Scherer
+   and Nicolás Ojeda Bär)
+
 - #12217: Add `Array.shuffle`.
   (Daniel Bünzli, review by Nicolás Ojeda Bär, David Allsopp and Alain Frisch)
 
@@ -1310,9 +1314,6 @@ Some of those changes will benefit all OCaml packages.
 
 - #11134: Optimise 'include struct' in more cases
   (Stephen Dolan, review by Leo White and Vincent Laviron)
-
-- #?????: Expose support for printing substrings in Format
-  (Florian Angeletti, review by ????)
 
 ### Other libraries:
 

--- a/Changes
+++ b/Changes
@@ -11,6 +11,10 @@ _______________
 
 ### Standard library:
 
+- #12133: Expose support for printing substrings in Format
+  (Florian Angeletti, review by Daniel Bünzli, Gabriel Scherer
+   and Nicolás Ojeda Bär)
+
 - #12869: Add List.take, List.drop, List.take_while and List.drop_while
   (Kate Deplaix and Oscar Butler-Aldridge review by Nicolás Ojeda Bär,
    Craig Ferguson and Gabriel Scherer)
@@ -371,10 +375,6 @@ OCaml 5.2.0
   check that margin is less than pp_infinity when setting or checking geometry.
   (Janith Petangoda, reported by Simmo Saan, reviewed by Florian Angeletti,
   Simmo Saan, Josh Berdine and Gabriel Scherer)
-
-- #12133: Expose support for printing substrings in Format
-  (Florian Angeletti, review by Daniel Bünzli, Gabriel Scherer
-   and Nicolás Ojeda Bär)
 
 - #12217: Add `Array.shuffle`.
   (Daniel Bünzli, review by Nicolás Ojeda Bär, David Allsopp and Alain Frisch)

--- a/Changes
+++ b/Changes
@@ -1311,6 +1311,9 @@ Some of those changes will benefit all OCaml packages.
 - #11134: Optimise 'include struct' in more cases
   (Stephen Dolan, review by Leo White and Vincent Laviron)
 
+- #?????: Expose support for printing substrings in Format
+  (Florian Angeletti, review by ????)
+
 ### Other libraries:
 
 - #11374: Remove pointer cast to a type with stricter alignment requirements

--- a/stdlib/format.ml
+++ b/stdlib/format.ml
@@ -67,7 +67,7 @@ type box_type = CamlinternalFormatBasics.block_type =
    elements that drive indentation and line splitting. *)
 type pp_token =
   | Pp_text of string          (* normal text *)
-  | Pp_substring of { source:string; start:int; len:int} (* slice of text *)
+  | Pp_substring of { source:string; first:int; len:int} (* slice of text *)
   | Pp_break of {              (* complete break *)
       fits: string * int * string;   (* line is not split *)
       breaks: string * int * string; (* line is split *)
@@ -250,8 +250,8 @@ let pp_infinity = 1000000010
 
 (* Output functions for the formatter. *)
 let pp_output_string state s = state.pp_out_string s 0 (String.length s)
-and pp_output_substring state ~start ~len s =
-  state.pp_out_string s start len
+and pp_output_substring state ~first ~len s =
+  state.pp_out_string s first len
 and pp_output_newline state = state.pp_out_newline ()
 and pp_output_spaces state n = state.pp_out_spaces n
 and pp_output_indent state n = state.pp_out_indent n
@@ -263,9 +263,9 @@ let format_pp_text state size text =
   state.pp_is_new_line <- false
 
 (* Format a slice *)
-let format_pp_substring state size ~start ~len source =
+let format_pp_substring state size ~first ~len source =
   state.pp_space_left <- state.pp_space_left - size;
-  pp_output_substring state ~start ~len source;
+  pp_output_substring state ~first ~len source;
   state.pp_is_new_line <- false
 
 (* Format a string by its length, if not empty *)
@@ -329,8 +329,8 @@ let pp_skip_token state =
 let format_pp_token state size = function
   | Pp_text s ->
     format_pp_text state size s
-  | Pp_substring {source;start;len} ->
-    format_pp_substring state size ~start ~len source
+  | Pp_substring {source;first;len} ->
+    format_pp_substring state size ~first ~len source
   | Pp_begin (off, ty) ->
     let insertion_point = state.pp_margin - state.pp_space_left in
     if insertion_point > state.pp_max_indent then
@@ -459,8 +459,8 @@ let enqueue_string_as state size s =
   enqueue_advance state { size; token = Pp_text s; length = Size.to_int size }
 
 (* To enqueue substrings. *)
-let enqueue_substring_as ~start ~len state size source =
-  let token = Pp_substring {source;len;start} in
+let enqueue_substring_as ~first ~len state size source =
+  let token = Pp_substring {source;first;len} in
   enqueue_advance state { size; token; length = Size.to_int size }
 
 let enqueue_string state s =
@@ -646,12 +646,12 @@ let pp_print_as state isize s =
 let pp_print_string state s =
   pp_print_as state (String.length s) s
 
-let pp_print_substring_as ~start ~len state size s =
+let pp_print_substring_as ~first ~len state size s =
   if state.pp_curr_depth < state.pp_max_boxes
-  then enqueue_substring_as ~start ~len state (Size.of_int size) s
+  then enqueue_substring_as ~first ~len state (Size.of_int size) s
 
-let pp_print_substring ~start ~len state s =
-  pp_print_substring_as ~start ~len state len s
+let pp_print_substring ~first ~len state s =
+  pp_print_substring_as ~first ~len state len s
 
 let pp_print_bytes state s =
   pp_print_as state (Bytes.length s) (Bytes.to_string s)
@@ -1203,10 +1203,10 @@ and open_stag v = pp_open_stag (DLS.get std_formatter_key) v
 and close_stag v = pp_close_stag (DLS.get std_formatter_key) v
 and print_as v w = pp_print_as (DLS.get std_formatter_key) v w
 and print_string v = pp_print_string (DLS.get std_formatter_key) v
-and print_substring ~start ~len v =
-  pp_print_substring  ~start ~len (DLS.get std_formatter_key) v
-and print_substring_as ~start ~len as_len v =
-  pp_print_substring_as ~start ~len (DLS.get std_formatter_key) as_len v
+and print_substring ~first ~len v =
+  pp_print_substring  ~first ~len (DLS.get std_formatter_key) v
+and print_substring_as ~first ~len as_len v =
+  pp_print_substring_as ~first ~len (DLS.get std_formatter_key) as_len v
 and print_bytes v = pp_print_bytes (DLS.get std_formatter_key) v
 and print_int v = pp_print_int (DLS.get std_formatter_key) v
 and print_float v = pp_print_float (DLS.get std_formatter_key) v
@@ -1304,7 +1304,7 @@ let pp_print_text ppf s =
   let left = ref 0 in
   let right = ref 0 in
   let flush () =
-    pp_print_substring ppf s ~start:!left ~len:(!right - !left);
+    pp_print_substring ppf s ~first:!left ~len:(!right - !left);
     incr right; left := !right;
   in
   while (!right <> len) do

--- a/stdlib/format.mli
+++ b/stdlib/format.mli
@@ -235,9 +235,9 @@ val pp_print_string : formatter -> string -> unit
 val print_string : string -> unit
 (** [pp_print_string ppf s] prints [s] in the current pretty-printing box. *)
 
-val pp_print_substring : start:int -> len:int -> formatter -> string -> unit
-val print_substring : start:int -> len:int -> string -> unit
-(** [pp_print_substring ~start ~len ppf s] prints the substring of [s]
+val pp_print_substring : first:int -> len:int -> formatter -> string -> unit
+val print_substring : first:int -> len:int -> string -> unit
+(** [pp_print_substring ~first ~len ppf s] prints the substring of [s]
   that starts at index [start] and stop at index [start+len] in the current
   pretty-printing box.
   @since 5.1
@@ -256,9 +256,9 @@ val print_as : int -> string -> unit
 *)
 
 val pp_print_substring_as :
-  start:int -> len:int -> formatter -> int -> string -> unit
-val print_substring_as : start:int -> len:int -> int -> string -> unit
-(** [pp_print_substring_as ~start ~len ppf len_as s] prints the substring of [s]
+  first:int -> len:int -> formatter -> int -> string -> unit
+val print_substring_as : first:int -> len:int -> int -> string -> unit
+(** [pp_print_substring_as ~first ~len ppf len_as s] prints the substring of [s]
   that starts at index [start] and stop at index [start+len] in the current
   pretty-printing box as if it were of length [len_as].
   @since 5.1

--- a/stdlib/format.mli
+++ b/stdlib/format.mli
@@ -235,6 +235,14 @@ val pp_print_string : formatter -> string -> unit
 val print_string : string -> unit
 (** [pp_print_string ppf s] prints [s] in the current pretty-printing box. *)
 
+val pp_print_substring : start:int -> len:int -> formatter -> string -> unit
+val print_substring : start:int -> len:int -> string -> unit
+(** [pp_print_substring ~start ~len ppf s] prints the substring of [s]
+  that starts at index [start] and stop at index [start+len] in the current
+  pretty-printing box.
+  @since 5.1
+*)
+
 val pp_print_bytes : formatter -> bytes -> unit
 val print_bytes : bytes -> unit
 (** [pp_print_bytes ppf b] prints [b] in the current pretty-printing box.
@@ -245,6 +253,15 @@ val pp_print_as : formatter -> int -> string -> unit
 val print_as : int -> string -> unit
 (** [pp_print_as ppf len s] prints [s] in the current pretty-printing box.
   The pretty-printer formats [s] as if it were of length [len].
+*)
+
+val pp_print_substring_as :
+  start:int -> len:int -> formatter -> int -> string -> unit
+val print_substring_as : start:int -> len:int -> int -> string -> unit
+(** [pp_print_substring_as ~start ~len ppf len_as s] prints the substring of [s]
+  that starts at index [start] and stop at index [start+len] in the current
+  pretty-printing box as if it were of length [len_as].
+  @since 5.1
 *)
 
 val pp_print_int : formatter -> int -> unit

--- a/stdlib/format.mli
+++ b/stdlib/format.mli
@@ -235,11 +235,11 @@ val pp_print_string : formatter -> string -> unit
 val print_string : string -> unit
 (** [pp_print_string ppf s] prints [s] in the current pretty-printing box. *)
 
-val pp_print_substring : first:int -> len:int -> formatter -> string -> unit
-val print_substring : first:int -> len:int -> string -> unit
-(** [pp_print_substring ~first ~len ppf s] prints the substring of [s]
-  that starts at index [start] and stop at index [start+len] in the current
-  pretty-printing box.
+val pp_print_substring : pos:int -> len:int -> formatter -> string -> unit
+val print_substring : pos:int -> len:int -> string -> unit
+(** [pp_print_substring ~pos ~len ppf s] prints the substring of [s] that starts
+    at position [pos] and stops at position [pos+len] in the current
+    pretty-printing box.
   @since 5.1
 *)
 
@@ -256,10 +256,10 @@ val print_as : int -> string -> unit
 *)
 
 val pp_print_substring_as :
-  first:int -> len:int -> formatter -> int -> string -> unit
-val print_substring_as : first:int -> len:int -> int -> string -> unit
+  pos:int -> len:int -> formatter -> int -> string -> unit
+val print_substring_as : pos:int -> len:int -> int -> string -> unit
 (** [pp_print_substring_as ~first ~len ppf len_as s] prints the substring of [s]
-  that starts at index [start] and stop at index [start+len] in the current
+  that starts at position [pos] and stop at position [pos+len] in the current
   pretty-printing box as if it were of length [len_as].
   @since 5.1
 *)

--- a/stdlib/format.mli
+++ b/stdlib/format.mli
@@ -240,7 +240,7 @@ val print_substring : pos:int -> len:int -> string -> unit
 (** [pp_print_substring ~pos ~len ppf s] prints the substring of [s] that starts
     at position [pos] and stops at position [pos+len] in the current
     pretty-printing box.
-  @since 5.1
+  @since 5.3
 *)
 
 val pp_print_bytes : formatter -> bytes -> unit


### PR DESCRIPTION
While looking at `Format` implementation, I was intrigued by the discrepancy that `Format` requires that its low-level printing devices are able to output slice of strings, but `Format` never exposes this feature to end users.

This PR proposes to fix this asymmetry by adding two functions: `pp_print_substring` and `pp_print_substring_as` to the `Format` module.  Along the way, it updates `pp_print_text` to use the new function `pp_print_substring` function.

Note that this PR is mostly a request for comments, I am not sure if the functions are that useful but the implementation was very straightforward.