### PR TITLE
New Build_path_prefix_map module interface

### DIFF
--- a/Changes
+++ b/Changes
@@ -473,6 +473,9 @@ Working version
 
 ### Internal/compiler-libs changes:
 
+- #12138: Generalize interface for BUILD_PATH_PREFIX_MAP mapping.
+  (Richard L Ford, suggestions and review by Gabriel Scherer)
+
 - #10512: explain the compilation strategy for switches on constructors
   (Gabriel Scherer, review by Vincent Laviron)
 

--- a/utils/build_path_prefix_map.mli
+++ b/utils/build_path_prefix_map.mli
@@ -18,6 +18,9 @@
   {b Warning:} this module is unstable and part of
   {{!Compiler_libs}compiler-libs}.
 
+  See
+  {{: https://reproducible-builds.org/specs/build-path-prefix-map/ }
+  the BUILD_PATH_PREFIX_MAP spec}
 *)
 
 
@@ -38,10 +41,21 @@ type map = pair option list
 val encode_map : map -> string
 val decode_map : string -> (map, error_message) result
 
-val rewrite_opt : map -> path -> path option
-(** [rewrite_opt map path] tries to find a source in [map]
+val rewrite_first : map -> path -> path option
+(** [rewrite_first map path] tries to find a source in [map]
     that is a prefix of the input [path]. If it succeeds,
     it replaces this prefix with the corresponding target.
     If it fails, it just returns [None]. *)
 
+val rewrite_all : map -> path -> path list
+(** [rewrite_all map path] finds all sources in [map]
+    that are a prefix of the input [path]. For each matching
+    source, in priority order, it replaces this prefix with
+    the corresponding target and adds the result to
+    the returned list.
+    If there are no matches, it just returns [[]]. *)
+
 val rewrite : map -> path -> path
+(** [rewrite path] uses [rewrite_first] to try to find a
+    mapping for path. If found, it returns that, otherwise
+    it just returns [path]. *)


### PR DESCRIPTION
The BUILD_PATH_PREFIX_MAP specification tells how to use that environment variable to achieve reproducible build, i.e. builds of products that do not leak absolute paths from the build environment. See
https://reproducible-builds.org/specs/build-path-prefix-map.

However, that specification only describes half of the story.  Let us call the building of reproducible products the "Build Phase". That is the phase covered by the existing specification.

Let us defined the "Deployment phase" as the phase where you accept a built reproducible product and make use of it, i.e. deploy it. An example would be the debugger taking a reproducible binary and letting the user debug it, showing the user the source code, etc.

We use the same mechanism in the deployment phase. Then the BUILD_PATH_PREFIX_MAP must be setup with the logical inverse of the mapping used during the build phase.

This PR generalized the functions in Build_path_prefix_map and Location to facility the inverse map.

Also, this is part of a larger PR,
https://github.com/ocaml/ocaml/pull/12126, which itself was part of
https://github.com/ocaml/ocaml/pull/12085, that is being split up because it was too large. In addition to these changes, that PR includes ocamltest enhancements plus the tests for these changes. See it for prior discussion and the other changes.

I will now describe the essence of the changes.

1. utils/build_path_prefix_map.{ml,mli}

The API is now:

```ocaml
    val rewrite_first : map -> path -> path option
    (** [rewrite_first map path] tries to find a source in [map]
	that is a prefix of the input [path]. If it succeeds,
	it replaces this prefix with the corresponding target.
	If it fails, it just returns [None]. *)

    val rewrite_all : map -> path -> path list
    (** [rewrite_all map path] finds all sources in [map]
	that are a prefix of the input [path]. For each matching
	source, in priority order, it replaces this prefix with
	the corresponding target and adds the result to
	the returned list.
	If there are no matches, it just returns [[]]. *)

    val rewrite : map -> path -> path
```

2. parsing/location.{ml,mli}

Use the new API and renamed the rewriting functions.

```ocaml
    val rewrite_find_first_existing: string -> string option
    (** [rewrite_find_first_existing path] uses a BUILD_PATH_PREFIX_MAP mapping
	(https://reproducible-builds.org/specs/build-path-prefix-map/)
	and tries to find a source in mapping
	that maps to a result that exists in the file system.
	There are the following return values:
	- None, means BUILD_PATH_PREFIX_MAP is not set.
	- Some None, no source prefixes of [path] in the mapping were found,
	- Some (Some target), means target is the first file (in priority order) that [path] mapped to that exists in the file system.
	- Not_found raised, means some source prefixes in the map were found that matched [path], but none of them existed in the file system. *)

    val rewrite_find_all_existing_dirs: string -> string list
    (** [rewrite_find_all_existing_dirs absdir] accumulates a list of existing
	directories, [dirs], that are the result of mapping abstract directory,
	[absdir], over all the mapping pairs in the BUILD_PATH_PREFIX_MAP
	environment variable, if any. The list [dirs] will be in priority order
	(head as highest priority). The possible results are:
	- [], means BUILD_PATH_PREFIX_MAP is not set, or if set, then there were no matching prefixes of path.
	- Some dirs, means dirs are the directories found. A possibility is that there was no mapping, but the input path is an existing directory and the result if [[path]].
	- Not_found raised, means some source prefixes in the map were found that matched [path], but none of mapping results were existing directories (possibly due to misconfiguration)

	See the BUILD_PATH_PREFIX_MAP spec at
	(https://reproducible-builds.org/specs/build-path-prefix-map/)
	*)
```

In addition to those new APIs, Location.absolute_path was modified to do rewriting on absolute paths (in addition to relative paths which it was already doing).

At the present time their is no code depending on these APIs. They are used in the other parts of the PRs mentioned.