### PR TITLE
Modify bytecomp for BUILD_PATH_PREFIX_MAP

### DIFF
--- a/Changes
+++ b/Changes
@@ -203,6 +203,9 @@ OCaml 5.1.0
 
 ### Code generation and optimizations:
 
+- #12139: BUILD_PATH_PREFIX_MAP support in bytecomp.
+  (Richard L ford, review by Gabriel Scherer)
+
 - #11967: Remove traces of Obj.truncate, which allows some mutable
   loads to become immutable.
   (Nick Barnes, review by Vincent Laviron and KC Sivaramakrishnan)

--- a/bytecomp/bytelink.ml
+++ b/bytecomp/bytelink.ml
@@ -297,13 +297,6 @@ let output_debug_info oc =
     !debug_info;
   debug_info := []
 
-(* Transform a file name into an absolute file name *)
-
-let make_absolute file =
-  if not (Filename.is_relative file) then file
-  else Location.rewrite_absolute_path
-         (Filename.concat (Sys.getcwd()) file)
-
 (* Create a bytecode executable file *)
 
 let link_bytecode ?final_name tolink exec_name standalone =
@@ -343,6 +336,10 @@ let link_bytecode ?final_name tolink exec_name standalone =
        (* The path to the bytecode interpreter (in use_runtime mode) *)
        if String.length !Clflags.use_runtime > 0 && !Clflags.with_runtime then
        begin
+         (* Do not use BUILD_PATH_PREFIX_MAP mapping for this. *)
+         let make_absolute file =
+           if Filename.is_relative file then Filename.concat (Sys.getcwd()) file
+           else file in
          let runtime = make_absolute !Clflags.use_runtime in
          let runtime =
            (* shebang mustn't exceed 128 including the #! and \0 *)

--- a/bytecomp/emitcode.ml
+++ b/bytecomp/emitcode.ml
@@ -168,6 +168,41 @@ and slot_for_c_prim name =
 let events = ref ([] : debug_event list)
 let debug_dirs = ref String.Set.empty
 
+(* Map from absolute paths of .ml files to their sanitized paths. *)
+let sanitize_map = Hashtbl.create 17
+
+let sanitize_event ev =
+  let loc = ev.ev_loc in
+  let sloc = loc.loc_start in
+  let path = sloc.pos_fname in
+  match path with
+  | "_none_" | "" | "//toplevel//" ->
+    (* Leave these as it. *)
+    ev
+  | _ ->
+  let unmapped_abspath =
+    if (Filename.is_relative path) then (Filename.concat (Sys.getcwd ()) path)
+    else path
+  in
+  let mapped_abspath = Location.rewrite_absolute_path unmapped_abspath in
+  (* If mapping did nothing, just keep the event as is. *)
+  if mapped_abspath = unmapped_abspath then ev
+  else begin
+    (* We want to share the same sanitized path to save space *)
+    let new_fname = match Hashtbl.find_opt sanitize_map mapped_abspath with
+    | Some saved_path -> saved_path
+    | None ->
+        Hashtbl.add sanitize_map mapped_abspath mapped_abspath;
+        mapped_abspath
+    in
+    let eloc = loc.loc_end in
+    let nsloc = {sloc with pos_fname=new_fname} in
+    let neloc = {eloc with pos_fname=new_fname} in
+    let new_loc: Location.t = {loc with loc_start=nsloc; loc_end=neloc} in
+    let new_ev: Instruct.debug_event = {ev with ev_loc=new_loc} in
+    new_ev
+  end
+
 let record_event ev =
   let path = ev.ev_loc.Location.loc_start.Lexing.pos_fname in
   let abspath = Location.absolute_path path in
@@ -177,6 +212,7 @@ let record_event ev =
     debug_dirs := String.Set.add cwd !debug_dirs;
   end;
   ev.ev_pos <- !out_position;
+  let ev = sanitize_event ev in
   events := ev :: !events
 
 (* Initialization *)
@@ -187,6 +223,7 @@ let clear() =
   reloc_info := [];
   debug_dirs := String.Set.empty;
   events := [];
+  Hashtbl.clear sanitize_map;
   out_buffer := LongString.create 0
 
 let init () =

--- a/parsing/location.ml
+++ b/parsing/location.ml
@@ -158,7 +158,7 @@ let rewrite_absolute_path path =
   | Some map -> Build_path_prefix_map.rewrite map path
 
 let rewrite_find_first_existing path =
-  match Misc.get_build_path_prefix_map () with
+  match Misc.get_deploy_path_prefix_map () with
   | None ->
       if Sys.file_exists path then Some path
       else None
@@ -172,7 +172,7 @@ let rewrite_find_first_existing path =
 
 let rewrite_find_all_existing_dirs path =
   let ok path = Sys.file_exists path && Sys.is_directory path in
-  match Misc.get_build_path_prefix_map () with
+  match Misc.get_deploy_path_prefix_map () with
   | None ->
       if ok path then [path]
       else []

--- a/utils/misc.ml
+++ b/utils/misc.ml
@@ -882,6 +882,24 @@ let get_build_path_prefix_map =
     end;
     !map_cache
 
+let get_deploy_path_prefix_map =
+  let init = ref false in
+  let map_cache = ref None in
+  fun () ->
+    if not !init then begin
+      init := true;
+      match Sys.getenv "DEPLOY_PATH_PREFIX_MAP" with
+      | exception Not_found -> ()
+      | encoded_map ->
+        match Build_path_prefix_map.decode_map encoded_map with
+          | Error err ->
+              fatal_errorf
+                "Invalid value for the environment variable \
+                 DEPLOY_PATH_PREFIX_MAP: %s" err
+          | Ok map -> map_cache := Some map
+    end;
+    !map_cache
+
 let debug_prefix_map_flags () =
   if not Config.as_has_debug_prefix_map then
     []

--- a/utils/misc.mli
+++ b/utils/misc.mli
@@ -569,6 +569,10 @@ val get_build_path_prefix_map: unit -> Build_path_prefix_map.map option
 (** Returns the map encoded in the [BUILD_PATH_PREFIX_MAP] environment
     variable. *)
 
+val get_deploy_path_prefix_map: unit -> Build_path_prefix_map.map option
+(** Returns the map encoded in the [BUILD_PATH_PREFIX_MAP] environment
+    variable. *)
+
 val debug_prefix_map_flags: unit -> string list
 (** Returns the list of [--debug-prefix-map] flags to be passed to the
     assembler, built from the [BUILD_PATH_PREFIX_MAP] environment variable. *)


### PR DESCRIPTION
1. bytecomp/emitcode.ml

Sanitize the paths in debug events using BUILD_PATH_PREFIX_MAP. However, if the mapping has no effect, then do nothing.

2. bytecomp/bytelink.ml

Do not do BUILD_PATH_PREFIX_MAP mapping of the path supplied by the user with the `-use-runtime` option. This is used to fill in the shebang part of the
executable, and an abstract path is unlikely to work there.
