### PR TITLE
Add test case demonstrating that an error in Typetexp can be reached.

### DIFF
--- a/testsuite/tests/typing-misc/typetexp_errors.ml
+++ b/testsuite/tests/typing-misc/typetexp_errors.ml
@@ -31,3 +31,26 @@ Line 1, characters 6-9:
           ^^^
 Error: The type variable name '_a is not allowed in programs
 |}]
+
+(* The next two hit the unification error case at the end of
+   Typetexp.globalize_used_variables. *)
+let f (x: int as 'a) (y: float as 'a) = (x,y)
+[%%expect{|
+Line 1, characters 25-36:
+1 | let f (x: int as 'a) (y: float as 'a) = (x,y)
+                             ^^^^^^^^^^^
+Error: This type float should be an instance of type int
+|}]
+
+type 'a t1 = 'a constraint 'a = 'b list
+type 'a t2 = 'a constraint 'a = 'b option
+
+let f (x : 'a t1) = (assert false : 'a t2)
+[%%expect{|
+type 'a t1 = 'a constraint 'a = 'b list
+type 'a t2 = 'a constraint 'a = 'b option
+Line 4, characters 36-38:
+4 | let f (x : 'a t1) = (assert false : 'a t2)
+                                        ^^
+Error: This type 'a option should be an instance of type 'b list
+|}]


### PR DESCRIPTION
This just adds a test case demonstrating that [the unification error case](https://github.com/ocaml/ocaml/blob/6ca6a7aa6317da83bc72a289f3637c0efd855667/typing/typetexp.ml#L303) at the end of `globalize_used_variables` is reachable.

I was thinking about this function and wondered how to reach this error case, but found that no current test does.  So I made an example that reaches it, and thought it would be useful to have in the test suite - just so that it's easier to understand what's happening here if the code changes in the future.  But let me know if this kind of addition isn't useful.

I'd love to see a simpler example, too.

