### PR TITLE
Fix off-by-one in debug runtime

### DIFF
--- a/runtime/shared_heap.c
+++ b/runtime/shared_heap.c
@@ -480,7 +480,7 @@ static intnat pool_sweep(struct caml_heap_state* local, pool** plist,
         {
           int i;
           mlsize_t wo = Wosize_whsize(wh);
-          for (i = 2; i < wo; i++) {
+          for (i = 1; i < wo; i++) {
             Field(Val_hp(p), i) = Debug_free_major;
           }
         }


### PR DESCRIPTION
Correctly clear all non-header and free-list fields of swept block in the debug runtime.

This caused me a lot of confusion while debugging.