### PR TITLE
Format.sprintf -- direct users to asprintf if they have %a in the format string

### DIFF
--- a/stdlib/format.mli
+++ b/stdlib/format.mli
@@ -1356,7 +1356,8 @@ val sprintf : ('a, unit, string) format -> 'a
 (** Same as [printf] above, but instead of printing on a formatter,
   returns a string containing the result of formatting the arguments.
   Note that the pretty-printer queue is flushed at the end of {e each
-  call} to [sprintf].
+  call} to [sprintf]. Note that if your format string contains a [%a],
+  you should use [asprintf].
 
   In case of multiple and related calls to [sprintf] to output
   material on a single string, you should consider using [fprintf]


### PR DESCRIPTION
`Format.asprintf` allows `%a` in the format string while `Format.sprintf` does not.

If you use `%a` in `Format.sprintf` you will get a confusing compile error. Even though `asprintf` helpfully has an `a` prefixed to it, this distinction can be forgotten.

```ocaml
# Format.sprintf "%a" Unsigned.UInt64.pp some_unsigned_num;;
Error: This expression has type Format.formatter -> Unsigned.UInt64.t -> unit
       but an expression was expected of type unit -> 'a -> string
       Type Format.formatter is not compatible with type unit
```

Moreover, programmers from C will find it surprising that you need to use _another_ function in order to just be able to use an additional format identifier (here `%a`).

AFAIK, `fprintf`, `printf` in C all support the same format identifiers (`%d`, `%f` etc.).

For these reasons, direct users to `asprintf` if they have `%a` in the format string.

