### PR TITLE
Fix ocamldep after value binding parsetree change

### DIFF
--- a/parsing/depend.ml
+++ b/parsing/depend.ml
@@ -282,7 +282,11 @@ and add_case bv {pc_lhs; pc_guard; pc_rhs} =
 and add_bindings recf bv pel =
   let bv' = List.fold_left (fun bv x -> add_pattern bv x.pvb_pat) bv pel in
   let bv = if recf = Recursive then bv' else bv in
-  List.iter (fun x -> add_expr bv x.pvb_expr) pel;
+  let add_one_binding { pvb_pat= _ ; pvb_loc= _ ; pvb_constraint; pvb_expr } =
+    add_expr bv pvb_expr;
+    Option.iter (fun ct -> add_type bv ct.typ) pvb_constraint
+  in
+  List.iter add_one_binding pel;
   bv'
 
 and add_binding_op bv bv' pbop =


### PR DESCRIPTION
This PR fixes a mistake in #12119 : I forgot that the `Depend` module and  thus `ocamldep` have their own traversal of the parsetree that should have been updated after the change in the Parsetree.

This PR fixes this mistake (and tweaks the updated code in the `Depend` module to be less brittle).