### PR TITLE
ocamldoc: modernize doctype to avoid quirk mode

### DIFF
--- a/Changes
+++ b/Changes
@@ -364,6 +364,9 @@ Working version
   reduction in size.
   (Xavier Leroy, review by Edwin Török and Gabriel Scherer)
 
+- #12165: ocamldoc, use standard doctype to avoid quirk mode.
+  (Florian Angeletti, review by Gabriel Scherer)
+
 ### Manual and documentation:
 
 - #12095, #12097: Put the sample code of the user's manual and reference

--- a/ocamldoc/odoc_html.ml
+++ b/ocamldoc/odoc_html.ml
@@ -848,7 +848,7 @@ class html =
     inherit info
 
     val mutable doctype =
-      "<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.01 Transitional//EN\">\n"
+      "<!DOCTYPE html>\n"
     method character_encoding b =
       bp b
         "<meta content=\"text/html; charset=%s\" http-equiv=\"Content-Type\">\n"

--- a/testsuite/tests/tool-ocamldoc/Alert_toplevel.html.reference
+++ b/testsuite/tests/tool-ocamldoc/Alert_toplevel.html.reference
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<!DOCTYPE html>
 <html>
 <head>
 <link rel="stylesheet" href="style.css" type="text/css">

--- a/testsuite/tests/tool-ocamldoc/Alert_toplevel2.html.reference
+++ b/testsuite/tests/tool-ocamldoc/Alert_toplevel2.html.reference
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<!DOCTYPE html>
 <html>
 <head>
 <link rel="stylesheet" href="style.css" type="text/css">

--- a/testsuite/tests/tool-ocamldoc/Alerts.html.reference
+++ b/testsuite/tests/tool-ocamldoc/Alerts.html.reference
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<!DOCTYPE html>
 <html>
 <head>
 <link rel="stylesheet" href="style.css" type="text/css">

--- a/testsuite/tests/tool-ocamldoc/Alerts_impl.html.reference
+++ b/testsuite/tests/tool-ocamldoc/Alerts_impl.html.reference
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<!DOCTYPE html>
 <html>
 <head>
 <link rel="stylesheet" href="style.css" type="text/css">

--- a/testsuite/tests/tool-ocamldoc/Documentation_tags.html.reference
+++ b/testsuite/tests/tool-ocamldoc/Documentation_tags.html.reference
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<!DOCTYPE html>
 <html>
 <head>
 <link rel="stylesheet" href="style.css" type="text/css">

--- a/testsuite/tests/tool-ocamldoc/Entities.html.reference
+++ b/testsuite/tests/tool-ocamldoc/Entities.html.reference
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<!DOCTYPE html>
 <html>
 <head>
 <link rel="stylesheet" href="style.css" type="text/css">

--- a/testsuite/tests/tool-ocamldoc/Include_module_type_of.html.reference
+++ b/testsuite/tests/tool-ocamldoc/Include_module_type_of.html.reference
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<!DOCTYPE html>
 <html>
 <head>
 <link rel="stylesheet" href="style.css" type="text/css">

--- a/testsuite/tests/tool-ocamldoc/Inline_records.html.reference
+++ b/testsuite/tests/tool-ocamldoc/Inline_records.html.reference
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<!DOCTYPE html>
 <html>
 <head>
 <link rel="stylesheet" href="style.css" type="text/css">

--- a/testsuite/tests/tool-ocamldoc/Item_ids.html.reference
+++ b/testsuite/tests/tool-ocamldoc/Item_ids.html.reference
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<!DOCTYPE html>
 <html>
 <head>
 <link rel="stylesheet" href="style.css" type="text/css">

--- a/testsuite/tests/tool-ocamldoc/Linebreaks.html.reference
+++ b/testsuite/tests/tool-ocamldoc/Linebreaks.html.reference
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<!DOCTYPE html>
 <html>
 <head>
 <link rel="stylesheet" href="style.css" type="text/css">

--- a/testsuite/tests/tool-ocamldoc/Loop.html.reference
+++ b/testsuite/tests/tool-ocamldoc/Loop.html.reference
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<!DOCTYPE html>
 <html>
 <head>
 <link rel="stylesheet" href="style.css" type="text/css">

--- a/testsuite/tests/tool-ocamldoc/Module_whitespace.html.reference
+++ b/testsuite/tests/tool-ocamldoc/Module_whitespace.html.reference
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<!DOCTYPE html>
 <html>
 <head>
 <link rel="stylesheet" href="style.css" type="text/css">

--- a/testsuite/tests/tool-ocamldoc/No_preamble.html.reference
+++ b/testsuite/tests/tool-ocamldoc/No_preamble.html.reference
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<!DOCTYPE html>
 <html>
 <head>
 <link rel="stylesheet" href="style.css" type="text/css">

--- a/testsuite/tests/tool-ocamldoc/Paragraph.html.reference
+++ b/testsuite/tests/tool-ocamldoc/Paragraph.html.reference
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<!DOCTYPE html>
 <html>
 <head>
 <link rel="stylesheet" href="style.css" type="text/css">

--- a/testsuite/tests/tool-ocamldoc/Variants.html.reference
+++ b/testsuite/tests/tool-ocamldoc/Variants.html.reference
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<!DOCTYPE html>
 <html>
 <head>
 <link rel="stylesheet" href="style.css" type="text/css">


### PR DESCRIPTION
This PR modernizes the doctype of ocamldoc-generated html page to avoid browsers falling back on quirk mode when rendering those pages.