### PR TITLE
Fix old style declaration warning (was #11862)

### DIFF
--- a/configure
+++ b/configure
@@ -13731,6 +13731,48 @@ case $ocaml_cv_cc_vendor in #(
 -Wold-style-definition" ;;
 esac
 
+# Use -Wold-style-declaration if supported
+as_CACHEVAR=`printf "%s\n" "ax_cv_check_cflags_$warn_error_flag_-Wold-style-declaration" | $as_tr_sh`
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether C compiler accepts -Wold-style-declaration" >&5
+printf %s "checking whether C compiler accepts -Wold-style-declaration... " >&6; }
+if eval test \${$as_CACHEVAR+y}
+then :
+  printf %s "(cached) " >&6
+else $as_nop
+
+  ax_check_save_flags=$CFLAGS
+  CFLAGS="$CFLAGS $warn_error_flag -Wold-style-declaration"
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+int
+main (void)
+{
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_compile "$LINENO"
+then :
+  eval "$as_CACHEVAR=yes"
+else $as_nop
+  eval "$as_CACHEVAR=no"
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
+  CFLAGS=$ax_check_save_flags
+fi
+eval ac_res=\$$as_CACHEVAR
+	       { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+printf "%s\n" "$ac_res" >&6; }
+if eval test \"x\$"$as_CACHEVAR"\" = x"yes"
+then :
+  cc_warnings="$cc_warnings -Wold-style-declaration"
+else $as_nop
+  :
+fi
+
+
 case $enable_warn_error,true in #(
   yes,*|,true) :
     cc_warnings="$cc_warnings $warn_error_flag" ;; #(

--- a/configure.ac
+++ b/configure.ac
@@ -735,6 +735,11 @@ AS_CASE([$ocaml_cv_cc_vendor],
   cc_warnings="-Wall -Wint-conversion -Wstrict-prototypes \
 -Wold-style-definition"])
 
+# Use -Wold-style-declaration if supported
+AX_CHECK_COMPILE_FLAG([-Wold-style-declaration],
+  [cc_warnings="$cc_warnings -Wold-style-declaration"], [],
+  [$warn_error_flag])
+
 AS_CASE([$enable_warn_error,OCAML__DEVELOPMENT_VERSION],
   [yes,*|,true],
     [cc_warnings="$cc_warnings $warn_error_flag"])

--- a/runtime/sys.c
+++ b/runtime/sys.c
@@ -219,7 +219,7 @@ CAMLprim value caml_sys_exit(value retcode)
 #endif
 #endif
 
-const static int sys_open_flags[] = {
+static const int sys_open_flags[] = {
   O_RDONLY, O_WRONLY, O_APPEND | O_WRONLY, O_CREAT, O_TRUNC, O_EXCL,
   O_BINARY, O_TEXT, O_NONBLOCK
 };


### PR DESCRIPTION
This is a teeny tiny fix for a "stricter C" (almost cosmetic really) warning that only GCC supports, that checks the style of declarations in C code.
I've cherry-picked a commit from another branch to detect support for a C compiler flag. As clang only emits a warning (return code 0) and not an error if it doesn't recognize a warning, it is necessary to turn the warning into an error (return code 1).

My apologies, I closed #11862 by mistake, which was the previous submission of this branch.
@shindere was currently reviewing it.