### PR TITLE
fix the configure check for pthread_getaffinity_np

### DIFF
--- a/Changes
+++ b/Changes
@@ -770,6 +770,9 @@ OCaml 5.1.0
 - #12162: Fix miscompilation on amd64 backends involving integer overflows
   (Vincent Laviron and Greta Yorsh, review by Stefan Muenzel)
 
+- #12170: fix pthread_geaffinity_np configure check for android
+  (David Allsopp, review by Sébastien Hinderer)
+
 - #12178: Fix runtime events consumer poll function returning an invalid value
   instead of an OCaml integer value. (Lucas Pluvinage)
 

--- a/configure
+++ b/configure
@@ -17955,6 +17955,8 @@ fi
 
 
 ## pthread_getaffinity_np, args differ from GNU and BSD
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking arguments for pthread_getaffinity_np" >&5
+printf %s "checking arguments for pthread_getaffinity_np... " >&6; }
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 #define _GNU_SOURCE
@@ -17971,8 +17973,10 @@ cpu_set_t cs;
   return 0;
 }
 _ACEOF
-if ac_fn_c_try_compile "$LINENO"
+if ac_fn_c_try_link "$LINENO"
 then :
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: gnu" >&5
+printf "%s\n" "gnu" >&6; }
   printf "%s\n" "#define HAS_GNU_GETAFFINITY_NP 1" >>confdefs.h
 
 else $as_nop
@@ -17993,14 +17997,21 @@ cpuset_t cs;
   return 0;
 }
 _ACEOF
-if ac_fn_c_try_compile "$LINENO"
+if ac_fn_c_try_link "$LINENO"
 then :
-  printf "%s\n" "#define HAS_BSD_GETAFFINITY_NP 1" >>confdefs.h
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: BSD" >&5
+printf "%s\n" "BSD" >&6; }
+    printf "%s\n" "#define HAS_BSD_GETAFFINITY_NP 1" >>confdefs.h
 
+else $as_nop
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: pthread_getaffinity_np not found" >&5
+printf "%s\n" "pthread_getaffinity_np not found" >&6; }
 fi
-rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
+rm -f core conftest.err conftest.$ac_objext conftest.beam \
+    conftest$ac_exeext conftest.$ac_ext
 fi
-rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
+rm -f core conftest.err conftest.$ac_objext conftest.beam \
+    conftest$ac_exeext conftest.$ac_ext
 
 ## ZSTD compression library
 

--- a/configure.ac
+++ b/configure.ac
@@ -1924,7 +1924,8 @@ AC_CHECK_FUNC([ffs], [AC_DEFINE([HAS_FFS])])
 AC_CHECK_FUNC([_BitScanForward], [AC_DEFINE([HAS_BITSCANFORWARD])])
 
 ## pthread_getaffinity_np, args differ from GNU and BSD
-AC_COMPILE_IFELSE(
+AC_MSG_CHECKING([arguments for pthread_getaffinity_np])
+AC_LINK_IFELSE(
   [AC_LANG_PROGRAM(
     [[#define _GNU_SOURCE
       #include <sched.h>
@@ -1933,8 +1934,9 @@ AC_COMPILE_IFELSE(
       CPU_ZERO(&cs);
       CPU_COUNT(&cs);
       pthread_getaffinity_np(pthread_self(), sizeof(cs), &cs);]])],
-  [AC_DEFINE([HAS_GNU_GETAFFINITY_NP])],
-  [AC_COMPILE_IFELSE(
+  [AC_MSG_RESULT([gnu])
+  AC_DEFINE([HAS_GNU_GETAFFINITY_NP])],
+  [AC_LINK_IFELSE(
     [AC_LANG_PROGRAM(
       [[#include <pthread.h>
         #include <pthread_np.h>
@@ -1944,7 +1946,9 @@ AC_COMPILE_IFELSE(
         CPU_ZERO(&cs);
         CPU_COUNT(&cs);
         pthread_getaffinity_np(pthread_self(), sizeof(cs), &cs);]])],
-    [AC_DEFINE([HAS_BSD_GETAFFINITY_NP])])])
+    [AC_MSG_RESULT([BSD])
+    AC_DEFINE([HAS_BSD_GETAFFINITY_NP])],
+    [AC_MSG_RESULT([pthread_getaffinity_np not found])])])
 
 ## ZSTD compression library
 


### PR DESCRIPTION
AC_COMPILE_IFELSE only compiles, but the lack of the function results in a linking error, not a compilation error.

fixes #12101