### PR TITLE
extern.c: raise OOM instead of passing null in `caml_output_*` entrypoints

### DIFF
--- a/Changes
+++ b/Changes
@@ -145,6 +145,10 @@ OCaml 5.1.0
   (B. Szilvasy, Gabriel Scherer and Xavier Leroy, review by
    Stefan Muenzel, Guillaume Munch-Maccagnoni and Damien Doligez)
 
+- #12037: get_extern_state potential NULL dereference.
+  (Alexander Skvortsov, report by Török Edwin,
+   design by Gabriel Scherer, Xavier Leroy)
+
 ### Type system:
 
 - #6941, #11187: prohibit using classes through recursive modules

--- a/runtime/extern.c
+++ b/runtime/extern.c
@@ -123,24 +123,23 @@ struct caml_extern_state {
 static struct caml_extern_state* prepare_extern_state (void)
 {
   Caml_check_caml_state();
-  struct caml_extern_state* extern_state;
+  struct caml_extern_state* s;
 
   if (Caml_state->extern_state != NULL)
     return Caml_state->extern_state;
 
-  extern_state =
-    caml_stat_alloc(sizeof(struct caml_extern_state));
+  s = caml_stat_alloc(sizeof(struct caml_extern_state));
 
-  extern_state->extern_flags = 0;
-  extern_state->obj_counter = 0;
-  extern_state->size_32 = 0;
-  extern_state->size_64 = 0;
-  extern_state->extern_stack = extern_state->extern_stack_init;
-  extern_state->extern_stack_limit =
-    extern_state->extern_stack + EXTERN_STACK_INIT_SIZE;
+  s->extern_flags = 0;
+  s->obj_counter = 0;
+  s->size_32 = 0;
+  s->size_64 = 0;
+  s->extern_stack = s->extern_stack_init;
+  s->extern_stack_limit =
+    s->extern_stack + EXTERN_STACK_INIT_SIZE;
 
-  Caml_state->extern_state = extern_state;
-  return extern_state;
+  Caml_state->extern_state = s;
+  return s;
 }
 
 static struct caml_extern_state* get_extern_state (void)

--- a/runtime/extern.c
+++ b/runtime/extern.c
@@ -145,6 +145,13 @@ static struct caml_extern_state* prepare_extern_state (void)
 static struct caml_extern_state* get_extern_state (void)
 {
   Caml_check_caml_state();
+
+  if (Caml_state->extern_state == NULL)
+    caml_fatal_error (
+      "extern_state not initialized:"
+      "this function can only be called from a `caml_output_*` entrypoint."
+    );
+
   return Caml_state->extern_state;
 }
 

--- a/runtime/extern.c
+++ b/runtime/extern.c
@@ -120,7 +120,7 @@ struct caml_extern_state {
   struct output_block * extern_output_block;
 };
 
-static struct caml_extern_state* get_extern_state (void)
+static struct caml_extern_state* prepare_extern_state (void)
 {
   Caml_check_caml_state();
   struct caml_extern_state* extern_state;
@@ -129,10 +129,7 @@ static struct caml_extern_state* get_extern_state (void)
     return Caml_state->extern_state;
 
   extern_state =
-    caml_stat_alloc_noexc(sizeof(struct caml_extern_state));
-  if (extern_state == NULL) {
-    return NULL;
-  }
+    caml_stat_alloc(sizeof(struct caml_extern_state));
 
   extern_state->extern_flags = 0;
   extern_state->obj_counter = 0;
@@ -144,6 +141,12 @@ static struct caml_extern_state* get_extern_state (void)
 
   Caml_state->extern_state = extern_state;
   return extern_state;
+}
+
+static struct caml_extern_state* get_extern_state (void)
+{
+  Caml_check_caml_state();
+  return Caml_state->extern_state;
 }
 
 void caml_free_extern_state (void)
@@ -1072,7 +1075,7 @@ void caml_output_val(struct channel *chan, value v, value flags)
   char header[MAX_INTEXT_HEADER_SIZE];
   int header_len;
   struct output_block * blk, * nextblk;
-  struct caml_extern_state* s = get_extern_state ();
+  struct caml_extern_state* s = prepare_extern_state ();
 
   if (! caml_channel_binary_mode(chan))
     caml_failwith("output_value: not a binary channel");
@@ -1110,7 +1113,7 @@ CAMLprim value caml_output_value_to_bytes(value v, value flags)
   intnat data_len, ofs;
   value res;
   struct output_block * blk, * nextblk;
-  struct caml_extern_state* s = get_extern_state ();
+  struct caml_extern_state* s = prepare_extern_state ();
 
   init_extern_output(s);
   data_len = extern_value(s, v, flags, header, &header_len);
@@ -1143,7 +1146,7 @@ CAMLexport intnat caml_output_value_to_block(value v, value flags,
   char header[MAX_INTEXT_HEADER_SIZE];
   int header_len;
   intnat data_len;
-  struct caml_extern_state* s = get_extern_state ();
+  struct caml_extern_state* s = prepare_extern_state ();
 
   /* At this point we don't know the size of the header.
      Guess that it is small, and fix up later if not. */
@@ -1180,7 +1183,7 @@ CAMLexport void caml_output_value_to_malloc(value v, value flags,
   intnat data_len;
   char * res;
   struct output_block * blk, * nextblk;
-  struct caml_extern_state* s = get_extern_state ();
+  struct caml_extern_state* s = prepare_extern_state ();
 
   init_extern_output(s);
   data_len = extern_value(s, v, flags, header, &header_len);
@@ -1340,7 +1343,7 @@ CAMLprim value caml_obj_reachable_words(value v)
   struct extern_item * sp;
   uintnat h = 0;
   uintnat pos = 0;
-  struct caml_extern_state *s = get_extern_state ();
+  struct caml_extern_state *s = prepare_extern_state ();
 
   s->obj_counter = 0;
   s->extern_flags = 0;


### PR DESCRIPTION
Fix for #12037

### Summary

-fanalyzer detected a potential null dereference in `extern.c`, because the current implementation of `get_extern_state` returns `NULL` on OOM instead of erroring properly. There are two cases where this helper function might be called:

- `caml_output_*` or `caml_obj_reachable_words` entrypoints, where we should initialize `extern_state` if it doesn't yet exist. In this case, an out_of_memory should be thrown if necessary, instead of passing along `NULL`, which would segfault.
- `caml_serialize_*` helpers, which should only be callable from inside a `caml_output_*` context. These should throw a fatal error if `extern_state` is null, since that means they are being called outside the `caml_output_*` context.

`get_extern_state` has been split into `prepare_extern_state` and `get_extern_state`, which handle the two above cases respectively.

### Question for Reviewers

In discussion on [the issue](https://github.com/ocaml/ocaml/issues/12037#issuecomment-1502931684), @gasche proposed that `prepare_extern_state` should throw if the state is initialized, and `get_extern_state` should throw if it isn't; that way, using entrypoints without cleanup, or serialization helpers out of an entrypoint, would both error.

Unfortunately, this wouldn't work, since the memory block allocated for `extern_state` is reused between entrypoint output calls. Instead, we could add an `in_progress` flag that would be toggled on `prepare_extern_state` init calls and `extern_free_state` cleanup calls. Then, we could error if `output`-ing while another `output` is in progress, or `serialize`-ing if no `output` is in progress. I took a first step towards this by factoring out common code used in init-ing/reset-ing the stack. Is this something we'd like to add?
