### PR TITLE
Add a `?events_dir` parameter to `Runtime_events.start`

### DIFF
--- a/Changes
+++ b/Changes
@@ -5,6 +5,10 @@ Working version
 
 ### Runtime system:
 
+- #12176: Add a ?events_dir parameter to [Runtime_events.start], that has the
+  same effect as OCAML_RUNTIME_EVENTS_DIR. Fixes #12173.
+  (Fabian Hemmer, review by ...)
+
 ### Code generation and optimizations:
 
 ### Standard library:

--- a/otherlibs/runtime_events/runtime_events.ml
+++ b/otherlibs/runtime_events/runtime_events.ml
@@ -297,7 +297,8 @@ module Callbacks = struct
 
 end
 
-external start : unit -> unit = "caml_runtime_events_start"
+external start : ?events_dir:string -> unit -> unit
+                                        = "caml_runtime_events_start_args"
 external pause : unit -> unit = "caml_runtime_events_pause"
 external resume : unit -> unit = "caml_runtime_events_resume"
 

--- a/otherlibs/runtime_events/runtime_events.mli
+++ b/otherlibs/runtime_events/runtime_events.mli
@@ -253,9 +253,10 @@ module Callbacks : sig
       with the corresponding event and payload. *)
 end
 
-val start : unit -> unit
-(** [start ()] will start the collection of events in the runtime if not already
-  started.
+val start : ?events_dir:string -> unit -> unit
+(** [start ?events_dir ()] will start the collection of events in the runtime
+    if not already started. If present, [events_dir] overrides the effect of
+    the [OCAML_RUNTIME_EVENTS_DIR] environment variable.
 
   Events can be consumed by creating a cursor with [create_cursor] and providing
   a set of callbacks to be called for each type of event.

--- a/runtime/caml/runtime_events.h
+++ b/runtime/caml/runtime_events.h
@@ -156,7 +156,7 @@ typedef enum {
 /* Starts runtime_events. Needs to be called before
    [caml_runtime_events_create_cursor]. Needs the runtime lock held to call and
    will trigger a stop-the-world pause. Returns Val_unit. */
-CAMLextern value caml_runtime_events_start(void);
+CAMLextern value caml_runtime_events_start(char_os *events_dir);
 
 /* Pauses runtime_events if not currently paused otherwise does nothing.
    No new events (other than the pause itself) will be written to the ring

--- a/testsuite/tests/lib-runtime-events/stubs.c
+++ b/testsuite/tests/lib-runtime-events/stubs.c
@@ -17,7 +17,7 @@ struct counters {
 };
 
 void start_runtime_events() {
-    caml_runtime_events_start();
+    caml_runtime_events_start(NULL);
 }
 
 int ev_begin(int domain_id, void* callback_data,


### PR DESCRIPTION
(wip, do not merge).

Fix #12173.