### PR TITLE
runtime events consumer: fix invalid value returned from runtime_events_read_poll

### DIFF
--- a/Changes
+++ b/Changes
@@ -734,6 +734,9 @@ Working version
 - #12162: Fix miscompilation on amd64 backends involving integer overflows
   (Vincent Laviron and Greta Yorsh, review by Stefan Muenzel)
 
+- #12178: Fix runtime events consumer poll function returning an invalid value
+  instead of an OCaml integer value. (Lucas Pluvinage)
+
 OCaml 5.0.0 (15 December 2022)
 ------------------------------
 

--- a/otherlibs/runtime_events/runtime_events_consumer.c
+++ b/otherlibs/runtime_events/runtime_events_consumer.c
@@ -1219,5 +1219,5 @@ CAMLprim value caml_ml_runtime_events_read_poll(value wrapper,
     }
   }
 
-  CAMLreturn(Int_val(events_consumed));
+  CAMLreturn(Val_int(events_consumed));
 };


### PR DESCRIPTION
`caml_ml_runtime_events_read_poll` is supposed to return an OCaml integer, but the conversion was done the other way around, using `Int_val` instead of `Val_int`. 

cc @sadiqj @Engil 