### PR TITLE
Fix #12145: Loopy constraints cause ocamlc to loop

### DIFF
--- a/Changes
+++ b/Changes
@@ -63,11 +63,12 @@ Working version
 ### Bug fixes:
 
 * #12145: Loopy constraints cause ocamlc to loop.
-  Fixed by delaying the check on recursive type definitions after
-  well-foundedness. As a result, recursion is more polymorphic,
+  Fixed by completely removing the call to `update_type` in
+  `Typedecl.transl_type_decl`, as the expansion is already checked by
+  `check_regularity`. As a result, recursion is more polymorphic,
   which may cause some (essentialy wrong) type declarations to have
   unbound type variables.
-  (Jacques Garrigue, report by Richard Esenberg, rewview by ???)
+  (Jacques Garrigue, report by Richard Esenberg, rewview by Gabriel Scherer)
 
 - #12255, #12256: Handle large signal numbers correctly (Nick Barnes,
    review by David Allsopp).

--- a/Changes
+++ b/Changes
@@ -67,8 +67,9 @@ Working version
   `Typedecl.transl_type_decl`, as the expansion is already checked by
   `check_regularity`. As a result, recursion is more polymorphic,
   which may cause some (essentialy wrong) type declarations to have
-  unbound type variables.
-  (Jacques Garrigue, report by Richard Esenberg, review by Gabriel Scherer)
+  unbound type variables, and some constraints unrelated to the concrete
+  type to be ignored (see tests/typing-misc/constraints.ml).
+  (Jacques Garrigue, report by Richard Eisenberg, review by Leo White)
 
 - #12255, #12256: Handle large signal numbers correctly (Nick Barnes,
    review by David Allsopp).

--- a/Changes
+++ b/Changes
@@ -62,6 +62,13 @@ Working version
 
 ### Bug fixes:
 
+* #12145: Loopy constraints cause ocamlc to loop.
+  Fixed by delaying the check on recursive type definitions after
+  well-foundedness. As a result, recursion is more polymorphic,
+  which may cause some (essentialy wrong) type declarations to have
+  unbound type variables.
+  (Jacques Garrigue, report by Richard Esenberg, rewview by ???)
+
 - #12255, #12256: Handle large signal numbers correctly (Nick Barnes,
    review by David Allsopp).
 

--- a/Changes
+++ b/Changes
@@ -68,7 +68,7 @@ Working version
   `check_regularity`. As a result, recursion is more polymorphic,
   which may cause some (essentialy wrong) type declarations to have
   unbound type variables.
-  (Jacques Garrigue, report by Richard Esenberg, rewview by Gabriel Scherer)
+  (Jacques Garrigue, report by Richard Esenberg, review by Gabriel Scherer)
 
 - #12255, #12256: Handle large signal numbers correctly (Nick Barnes,
    review by David Allsopp).

--- a/testsuite/tests/typing-misc/constraints.ml
+++ b/testsuite/tests/typing-misc/constraints.ml
@@ -193,11 +193,17 @@ Error: This recursive type is not regular.
 |}]
 
 type 'a t = 'a * 'b constraint _ * 'a = 'b t;;
+[%%expect{|
+Line 1, characters 0-44:
+1 | type 'a t = 'a * 'b constraint _ * 'a = 'b t;;
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: A type variable is unbound in this type declaration.
+       In type 'a * 'b the variable 'b is unbound
+|}]
 type 'a t = 'a * 'b constraint 'a = 'b t;;
 [%%expect{|
-type 'b t = 'b * 'b
-Line 2, characters 0-40:
-2 | type 'a t = 'a * 'b constraint 'a = 'b t;;
+Line 1, characters 0-40:
+1 | type 'a t = 'a * 'b constraint 'a = 'b t;;
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The type abbreviation t is cyclic:
          'a t t = 'a t * 'a,
@@ -394,4 +400,21 @@ let test_obj_with_expansion :
 val test_obj_with_expansion :
   'a tag -> ('b, < bar : bar -> 'b; foo : foo -> 'b; .. >) obj -> 'a -> 'b =
   <fun>
+|}]
+
+
+(* PR#12145 -- Loopy constraints cause ocamlc to loop *)
+
+type 'a t constraint 'a = 'b * 'c
+type cycle = cycle id
+and 'a id = 'a
+and s = cycle t
+[%%expect{|
+type 'a t constraint 'a = 'b * 'c
+Line 2, characters 0-21:
+2 | type cycle = cycle id
+    ^^^^^^^^^^^^^^^^^^^^^
+Error: The type abbreviation cycle is cyclic:
+         cycle = cycle id,
+         cycle id = cycle
 |}]

--- a/testsuite/tests/typing-misc/constraints.ml
+++ b/testsuite/tests/typing-misc/constraints.ml
@@ -418,3 +418,18 @@ Error: The type abbreviation cycle is cyclic:
          cycle = cycle id,
          cycle id = cycle
 |}]
+
+(* Vanishing constraints may be discarded during the translation *)
+type 'a t = [`Foo]
+type 'a cstr constraint 'a = float
+[%%expect{|
+type 'a t = [ `Foo ]
+type 'a cstr constraint 'a = float
+|}]
+
+type s = int
+and r = [s cstr t | `Bar]
+[%%expect{|
+type s = int
+and r = [ `Bar | `Foo ]
+|}]

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -119,7 +119,7 @@ let enter_type rec_flag env sdecl (id, uid) =
       type_private = sdecl.ptype_private;
       type_manifest =
         begin match sdecl.ptype_manifest with None -> None
-        | Some _ -> Some(Ctype.newvar ()) end;
+        | Some _ -> Some(Btype.newgenvar ()) end;
       type_variance = Variance.unknown_signature ~injective:false ~arity;
       type_separability = Types.Separability.default_signature ~arity;
       type_is_newtype = false;
@@ -132,22 +132,6 @@ let enter_type rec_flag env sdecl (id, uid) =
     }
   in
   add_type ~check:true id decl env
-
-(* Check that the temporary definition of a type abbreviation is
-   compatible  with the actual definition *)
-let check_temp_type temp_env env id loc =
-  let path = Path.Pident id in
-  let decl = Env.find_type path temp_env in
-  match decl.type_manifest with None -> ()
-  | Some ty ->
-      (* Since this function may be called after generalizing declarations,
-         there may be hidden generalized nodes *)
-      Ctype.generalize ty;
-      let ty = Ctype.instance ty in
-      let params = List.map (fun _ -> Ctype.newvar ()) decl.type_params in
-      try Ctype.unify env (Ctype.newconstr path params) ty
-      with Ctype.Unify err ->
-        raise (Error(loc, Type_clash (env, err)))
 
 (* Determine if a type's values are represented by floats at run-time. *)
 let is_float env ty =
@@ -1075,7 +1059,7 @@ let transl_type_decl env rec_flag sdecl_list =
       Uid.mk ~current_unit:(Env.get_unit_name ())
     ) sdecl_list
   in
-  let tdecls, decls, temp_env, new_env =
+  let tdecls, decls, new_env =
     Ctype.with_local_level_iter ~post:generalize_decl begin fun () ->
       (* Enter types. *)
       let temp_env =
@@ -1119,7 +1103,7 @@ let transl_type_decl env rec_flag sdecl_list =
       check_duplicates sdecl_list;
       (* Build the final env. *)
       let new_env = add_types_to_env decls env in
-      ((tdecls, decls, temp_env, new_env), List.map snd decls)
+      ((tdecls, decls, new_env), List.map snd decls)
     end
   in
   (* Check for ill-formed abbrevs *)
@@ -1139,15 +1123,6 @@ let transl_type_decl env rec_flag sdecl_list =
     decls;
   List.iter
     (check_abbrev_regularity ~orig_env:env new_env id_loc_list to_check) tdecls;
-  (* Check temporary definitions (for well-founded recursive types) *)
-  begin match rec_flag with
-  | Asttypes.Nonrecursive -> ()
-  | Asttypes.Recursive ->
-      List.iter2
-        (fun (id, _) sdecl ->
-          check_temp_type temp_env new_env id sdecl.ptype_loc)
-        ids_list sdecl_list
-  end;
   (* Check that all type variables are closed *)
   List.iter2
     (fun sdecl tdecl ->

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -133,11 +133,17 @@ let enter_type rec_flag env sdecl (id, uid) =
   in
   add_type ~check:true id decl env
 
-let update_type temp_env env id loc =
+(* Check that the temporary definition of a type abbreviation is
+   compatible  with the actual definition *)
+let check_temp_type temp_env env id loc =
   let path = Path.Pident id in
   let decl = Env.find_type path temp_env in
   match decl.type_manifest with None -> ()
   | Some ty ->
+      (* Since this function may be called after generalizing declarations,
+         there may be hidden generalized nodes *)
+      Ctype.generalize ty;
+      let ty = Ctype.instance ty in
       let params = List.map (fun _ -> Ctype.newvar ()) decl.type_params in
       try Ctype.unify env (Ctype.newconstr path params) ty
       with Ctype.Unify err ->
@@ -1069,7 +1075,7 @@ let transl_type_decl env rec_flag sdecl_list =
       Uid.mk ~current_unit:(Env.get_unit_name ())
     ) sdecl_list
   in
-  let tdecls, decls, new_env =
+  let tdecls, decls, temp_env, new_env =
     Ctype.with_local_level_iter ~post:generalize_decl begin fun () ->
       (* Enter types. *)
       let temp_env =
@@ -1113,16 +1119,7 @@ let transl_type_decl env rec_flag sdecl_list =
       check_duplicates sdecl_list;
       (* Build the final env. *)
       let new_env = add_types_to_env decls env in
-      (* Update stubs *)
-      begin match rec_flag with
-      | Asttypes.Nonrecursive -> ()
-      | Asttypes.Recursive ->
-          List.iter2
-            (fun (id, _) sdecl ->
-              update_type temp_env new_env id sdecl.ptype_loc)
-            ids_list sdecl_list
-      end;
-      ((tdecls, decls, new_env), List.map snd decls)
+      ((tdecls, decls, temp_env, new_env), List.map snd decls)
     end
   in
   (* Check for ill-formed abbrevs *)
@@ -1142,6 +1139,15 @@ let transl_type_decl env rec_flag sdecl_list =
     decls;
   List.iter
     (check_abbrev_regularity ~orig_env:env new_env id_loc_list to_check) tdecls;
+  (* Check temporary definitions (for well-founded recursive types) *)
+  begin match rec_flag with
+  | Asttypes.Nonrecursive -> ()
+  | Asttypes.Recursive ->
+      List.iter2
+        (fun (id, _) sdecl ->
+          check_temp_type temp_env new_env id sdecl.ptype_loc)
+        ids_list sdecl_list
+  end;
   (* Check that all type variables are closed *)
   List.iter2
     (fun sdecl tdecl ->


### PR DESCRIPTION
Calling `Ctype.unify` in `Typedecl` before checking the well-foundedness of definitions can cause infinite loops, as in #12145.
This PR removes one such cause, by moving the unification of dummy definitions in the temporary environment until after the well-foundedness check.
Note that this changes the semantics: as the unification now occurs only after definitions are generalized, more polymorphism is allowed. Since all checks are done once more on the final definitions, this should not create correctness issues, but this extra polymorphism actually causes one test to fail in `typing-misc/constraints.ml` (which is fine, as this file is full of meaningless examples checking the limits of the type checker).