### PR TITLE
Improve the type clash error message

### DIFF
--- a/.depend
+++ b/.depend
@@ -1558,6 +1558,7 @@ typing/typecore.cmo : \
     typing/printpat.cmi \
     typing/primitive.cmi \
     typing/predef.cmi \
+    parsing/pprintast.cmi \
     typing/persistent_env.cmi \
     typing/path.cmi \
     parsing/parsetree.cmi \
@@ -1592,6 +1593,7 @@ typing/typecore.cmx : \
     typing/printpat.cmx \
     typing/primitive.cmx \
     typing/predef.cmx \
+    parsing/pprintast.cmx \
     typing/persistent_env.cmx \
     typing/path.cmx \
     parsing/parsetree.cmi \
@@ -1838,7 +1840,6 @@ typing/typedtree.cmo : \
     parsing/longident.cmi \
     parsing/location.cmi \
     typing/ident.cmi \
-    utils/format_doc.cmi \
     typing/env.cmi \
     parsing/asttypes.cmi \
     typing/typedtree.cmi
@@ -1852,7 +1853,6 @@ typing/typedtree.cmx : \
     parsing/longident.cmx \
     parsing/location.cmx \
     typing/ident.cmx \
-    utils/format_doc.cmx \
     typing/env.cmx \
     parsing/asttypes.cmx \
     typing/typedtree.cmi
@@ -1866,7 +1866,6 @@ typing/typedtree.cmi : \
     parsing/longident.cmi \
     parsing/location.cmi \
     typing/ident.cmi \
-    utils/format_doc.cmi \
     typing/env.cmi \
     parsing/asttypes.cmi
 typing/typemod.cmo : \

--- a/Changes
+++ b/Changes
@@ -265,6 +265,13 @@ _______________
 - #13255: Re-enable warning 34 for unused locally abstract types
   (Nick Roberts, review by Chris Casinghino and Florian Angeletti)
 
+- #12182: Improve the type clash error message.
+  For example, this message:
+    This expression has type ...
+  is changed into:
+    The constant "42" has type ...
+  (Jules Aguillon, review by Gabriel Scherer and Florian Angeletti)
+
 ### Internal/compiler-libs changes:
 
 - #11129, #11148: enforce that ppxs do not produce `parsetree`s with

--- a/parsing/pprintast.ml
+++ b/parsing/pprintast.ml
@@ -136,6 +136,37 @@ module Doc = struct
 
   let tyvar ppf s =
     Format_doc.fprintf ppf "%s" (tyvar_of_name s)
+
+  (* Expressions are considered nominal if they can be used as the subject of a
+     sentence or action. In practice, we consider that an expression is nominal
+     if they satisfy one of:
+     - Similar to an identifier: words separated by '.' or '#'.
+     - Do not contain spaces when printed.
+  *)
+  let nominal_exp t =
+    let open Format_doc.Doc in
+    let longident l = Format_doc.doc_printer longident l.Location.txt in
+    let rec nominal_exp doc exp =
+      match exp.pexp_desc with
+      | _ when exp.pexp_attributes <> [] -> None
+      | Pexp_ident l ->
+          Some (longident l doc)
+      | Pexp_constant _ -> assert false
+      | Pexp_variant (lbl, None) ->
+          Some (printf "`%s" lbl doc)
+      | Pexp_construct (l, None) ->
+          Some (longident l doc)
+      | Pexp_field (parent, lbl) ->
+          Option.map
+            (printf ".%t" (longident lbl))
+            (nominal_exp doc parent)
+      | Pexp_send (parent, meth) ->
+          Option.map
+            (printf "#%s" meth.txt)
+            (nominal_exp doc parent)
+      | _ -> None
+    in
+    nominal_exp empty t
 end
 
 let longident ppf l = Format_doc.compat Doc.longident ppf l

--- a/parsing/pprintast.mli
+++ b/parsing/pprintast.mli
@@ -64,4 +64,8 @@ val tyvar: Format.formatter -> string -> unit
 module Doc:sig
   val longident: Longident.t Format_doc.printer
   val tyvar: string Format_doc.printer
+
+  (** Returns a format document if the expression reads nicely as the subject
+      of a sentence in a error message. *)
+  val nominal_exp : Parsetree.expression -> Format_doc.t option
 end

--- a/testsuite/tests/effect-syntax/error_messages.ml
+++ b/testsuite/tests/effect-syntax/error_messages.ml
@@ -24,13 +24,13 @@ let () = match () with
 Line 3, characters 21-22:
 3 |   | effect A _, k -> k
                          ^
-Error: This expression has type "(%eff, unit) continuation"
+Error: The value "k" has type "(%eff, unit) continuation"
        but an expression was expected of type "unit"
 |}, Principal{|
 Line 3, characters 21-22:
 3 |   | effect A _, k -> k
                          ^
-Error: This expression has type "(int, unit) continuation"
+Error: The value "k" has type "(int, unit) continuation"
        but an expression was expected of type "unit"
        This instance of "int" is ambiguous:
        it would escape the scope of its equation

--- a/testsuite/tests/formatting/margins.ocaml.reference
+++ b/testsuite/tests/formatting/margins.ocaml.reference
@@ -1,13 +1,12 @@
 Line 2, characters 4-9:
 2 | 1 + "foo";;
         ^^^^^
-Error: This expression has type
+Error: This constant has type
          "string"
        but an expression was expected of type
          "int"
 Line 2, characters 4-9:
 2 | 1 + "foo";;
         ^^^^^
-Error: This expression has type "string" but an expression was expected of type
-         "int"
+Error: This constant has type "string" but an expression was expected of type "int"
 

--- a/testsuite/tests/generalized-open/gpr1506.ml
+++ b/testsuite/tests/generalized-open/gpr1506.ml
@@ -360,7 +360,7 @@ let x = let open struct type t = T end in T
 Line 1, characters 42-43:
 1 | let x = let open struct type t = T end in T
                                               ^
-Error: This expression has type "t" but an expression was expected of type "'a"
+Error: The constructor "T" has type "t" but an expression was expected of type "'a"
        The type constructor "t" would escape its scope
 |}]
 

--- a/testsuite/tests/hidden_includes/not_included.ocamlc.reference
+++ b/testsuite/tests/hidden_includes/not_included.ocamlc.reference
@@ -1,7 +1,6 @@
 File "libc/c1.ml", line 1, characters 8-11:
 1 | let x = B.x + 1
             ^^^
-Error: The expression "B.x" has type "A.t" but an expression was expected of type
-         "int"
+Error: The value "B.x" has type "A.t" but an expression was expected of type "int"
        Type "A.t" is abstract because no corresponding cmi file was found
        in path.

--- a/testsuite/tests/hidden_includes/not_included.ocamlc.reference
+++ b/testsuite/tests/hidden_includes/not_included.ocamlc.reference
@@ -1,7 +1,7 @@
 File "libc/c1.ml", line 1, characters 8-11:
 1 | let x = B.x + 1
             ^^^
-Error: This expression has type "A.t" but an expression was expected of type
+Error: The expression "B.x" has type "A.t" but an expression was expected of type
          "int"
        Type "A.t" is abstract because no corresponding cmi file was found
        in path.

--- a/testsuite/tests/let-syntax/let_syntax.ml
+++ b/testsuite/tests/let-syntax/let_syntax.ml
@@ -187,7 +187,7 @@ let ill_typed_1 =
 Line 3, characters 13-14:
 3 |     let+ x = 1 in
                  ^
-Error: The expression "1" has type "int" but an expression was expected of type
+Error: The constant "1" has type "int" but an expression was expected of type
          "bool"
 |}];;
 
@@ -215,7 +215,7 @@ let ill_typed_2 =
 Line 3, characters 13-14:
 3 |     let+ x = 1
                  ^
-Error: The expression "1" has type "int" but an expression was expected of type
+Error: The constant "1" has type "int" but an expression was expected of type
          "float"
   Hint: Did you mean "1."?
 |}];;

--- a/testsuite/tests/let-syntax/let_syntax.ml
+++ b/testsuite/tests/let-syntax/let_syntax.ml
@@ -187,7 +187,7 @@ let ill_typed_1 =
 Line 3, characters 13-14:
 3 |     let+ x = 1 in
                  ^
-Error: This expression has type "int" but an expression was expected of type
+Error: The expression "1" has type "int" but an expression was expected of type
          "bool"
 |}];;
 
@@ -215,7 +215,7 @@ let ill_typed_2 =
 Line 3, characters 13-14:
 3 |     let+ x = 1
                  ^
-Error: This expression has type "int" but an expression was expected of type
+Error: The expression "1" has type "int" but an expression was expected of type
          "float"
   Hint: Did you mean "1."?
 |}];;

--- a/testsuite/tests/printing-types/existentials.ml
+++ b/testsuite/tests/printing-types/existentials.ml
@@ -15,7 +15,7 @@ type foo1 = Foo : ('a * 'b * 'c * 'd * 'e * 'f) -> foo1
 Line 6, characters 13-14:
 6 |   | Foo a -> a + 1
                  ^
-Error: This expression has type "$a * $b * $c * $d * $e * $f"
+Error: The value "a" has type "$a * $b * $c * $d * $e * $f"
        but an expression was expected of type "int"
        Hint: "$a", "$b", "$c", "$d", "$e" and "$f" are existential types
          bound by the constructor "Foo".
@@ -48,7 +48,7 @@ type foo2 =
 Line 13, characters 46-47:
 13 |       let x = (a1, a2, a3, a4, a5, a6, a7) in x + 1
                                                    ^
-Error: This expression has type "$a * $a1 * $a2 * $a3 * $a4 * $a5 * $a6"
+Error: The value "x" has type "$a * $a1 * $a2 * $a3 * $a4 * $a5 * $a6"
        but an expression was expected of type "int"
        Hint: "$a" is an existential type bound by the constructor "Foo1".
        Hint: "$a1" is an existential type bound by the constructor "Foo2".
@@ -86,7 +86,7 @@ type foo3 =
 Line 13, characters 46-47:
 13 |       let x = (a1, a2, a3, a4, a5, a6, a7) in x + 1
                                                    ^
-Error: This expression has type
+Error: The value "x" has type
          "($a * $b * $c * $d * $e * $f) *
          ($a1 * $b1 * $c1 * $d1 * $e1 * $f1) *
          ($a2 * $b2 * $c2 * $d2 * $e2 * $f2) *

--- a/testsuite/tests/tool-caml-tex/redirections.reference
+++ b/testsuite/tests/tool-caml-tex/redirections.reference
@@ -9,8 +9,8 @@ $\?$ [@@@warning "+A"];;
 $\?$ 1 + <<2.>> ;;
 \end{camlinput}
 \begin{camlerror}
-Error: The expression 2. has type float
-       but an expression was expected of type int
+Error: The constant 2. has type float but an expression was expected of type
+         int
 \end{camlerror}
 \end{caml}
 \begin{caml}

--- a/testsuite/tests/tool-caml-tex/redirections.reference
+++ b/testsuite/tests/tool-caml-tex/redirections.reference
@@ -9,8 +9,8 @@ $\?$ [@@@warning "+A"];;
 $\?$ 1 + <<2.>> ;;
 \end{camlinput}
 \begin{camlerror}
-Error: This expression has type float but an expression was expected of type
-         int
+Error: The expression 2. has type float
+       but an expression was expected of type int
 \end{camlerror}
 \end{caml}
 \begin{caml}

--- a/testsuite/tests/tool-expect-test/clean_typer.ml
+++ b/testsuite/tests/tool-expect-test/clean_typer.ml
@@ -64,7 +64,7 @@ let f2 = ffoo bar;;
 Line 1, characters 14-17:
 1 | let f2 = ffoo bar;;
                   ^^^
-Error: This expression has type "Variants.bar M.t"
+Error: The expression "bar" has type "Variants.bar M.t"
        but an expression was expected of type "Variants.foo M.t"
        Type "Variants.bar" = "[ `Bar ]" is not compatible with type "Variants.foo"
        The first variant type does not allow tag(s) "`Foo"
@@ -75,7 +75,7 @@ let f3 = fbar foo;;
 Line 1, characters 14-17:
 1 | let f3 = fbar foo;;
                   ^^^
-Error: This expression has type "Variants.foo M.t"
+Error: The expression "foo" has type "Variants.foo M.t"
        but an expression was expected of type "Variants.bar M.t"
        Type "Variants.foo" is not compatible with type "Variants.bar" = "[ `Bar ]"
        The second variant type does not allow tag(s) "`Foo"

--- a/testsuite/tests/tool-expect-test/clean_typer.ml
+++ b/testsuite/tests/tool-expect-test/clean_typer.ml
@@ -64,7 +64,7 @@ let f2 = ffoo bar;;
 Line 1, characters 14-17:
 1 | let f2 = ffoo bar;;
                   ^^^
-Error: The expression "bar" has type "Variants.bar M.t"
+Error: The value "bar" has type "Variants.bar M.t"
        but an expression was expected of type "Variants.foo M.t"
        Type "Variants.bar" = "[ `Bar ]" is not compatible with type "Variants.foo"
        The first variant type does not allow tag(s) "`Foo"
@@ -75,7 +75,7 @@ let f3 = fbar foo;;
 Line 1, characters 14-17:
 1 | let f3 = fbar foo;;
                   ^^^
-Error: The expression "foo" has type "Variants.foo M.t"
+Error: The value "foo" has type "Variants.foo M.t"
        but an expression was expected of type "Variants.bar M.t"
        Type "Variants.foo" is not compatible with type "Variants.bar" = "[ `Bar ]"
        The second variant type does not allow tag(s) "`Foo"

--- a/testsuite/tests/tool-ocamlc-locations/marshalled.compilers.reference
+++ b/testsuite/tests/tool-ocamlc-locations/marshalled.compilers.reference
@@ -1,5 +1,5 @@
 File "foo.ml", line 1, characters 14-18:
 1 | let x : int = true
                   ^^^^
-Error: This expression has type "bool" but an expression was expected of type
-         "int"
+Error: The constructor "\#true" has type "bool"
+       but an expression was expected of type "int"

--- a/testsuite/tests/tool-toplevel/error_highlighting.compilers.reference
+++ b/testsuite/tests/tool-toplevel/error_highlighting.compilers.reference
@@ -22,7 +22,7 @@ Line 2, characters 8-9:
 Line 3, characters 8-9:
 3 | let y = 1 +. 2. in
             ^
-Error: This expression has type "int" but an expression was expected of type
+Error: The expression "1" has type "int" but an expression was expected of type
          "float"
   Hint: Did you mean "1."?
 Line 4, characters 2-4:

--- a/testsuite/tests/tool-toplevel/error_highlighting.compilers.reference
+++ b/testsuite/tests/tool-toplevel/error_highlighting.compilers.reference
@@ -22,7 +22,7 @@ Line 2, characters 8-9:
 Line 3, characters 8-9:
 3 | let y = 1 +. 2. in
             ^
-Error: The expression "1" has type "int" but an expression was expected of type
+Error: The constant "1" has type "int" but an expression was expected of type
          "float"
   Hint: Did you mean "1."?
 Line 4, characters 2-4:
@@ -42,7 +42,7 @@ Error: This expression has type "int" but an expression was expected of type
 Line 2, characters 12-17:
 2 | let x = 1 + "abc" in
                 ^^^^^
-Error: This expression has type "string" but an expression was expected of type
+Error: This constant has type "string" but an expression was expected of type
          "int"
 File "error_highlighting_use1.ml", line 1, characters 8-15:
 1 | let x = (1 + 2) +. 3. in ();;

--- a/testsuite/tests/tool-toplevel/multi_phrase_line.compilers.reference
+++ b/testsuite/tests/tool-toplevel/multi_phrase_line.compilers.reference
@@ -21,8 +21,8 @@ Error: Syntax error
 Line 2, characters 16-20:
 2 | 11;; let x = 12+true;; 13;; (* Type error in second phrase. *)
                     ^^^^
-Error: This expression has type "bool" but an expression was expected of type
-         "int"
+Error: The expression "\#true" has type "bool"
+       but an expression was expected of type "int"
 #   Line 2, characters 0-22:
 2 | match 14 with 15 -> ();; 16;; 17;; (* Warning + run-time error in 1st phrase. *)
     ^^^^^^^^^^^^^^^^^^^^^^

--- a/testsuite/tests/tool-toplevel/multi_phrase_line.compilers.reference
+++ b/testsuite/tests/tool-toplevel/multi_phrase_line.compilers.reference
@@ -21,7 +21,7 @@ Error: Syntax error
 Line 2, characters 16-20:
 2 | 11;; let x = 12+true;; 13;; (* Type error in second phrase. *)
                     ^^^^
-Error: The expression "\#true" has type "bool"
+Error: The constructor "\#true" has type "bool"
        but an expression was expected of type "int"
 #   Line 2, characters 0-22:
 2 | match 14 with 15 -> ();; 16;; 17;; (* Warning + run-time error in 1st phrase. *)

--- a/testsuite/tests/tool-toplevel/redefinition_hints.compilers.reference
+++ b/testsuite/tests/tool-toplevel/redefinition_hints.compilers.reference
@@ -14,7 +14,7 @@ val y : (u * v * (module S)) M.t = M.X (A, B, <module>)
 Line 2, characters 4-5:
 2 | x = y;;
         ^
-Error: The expression "y" has type "(u * v * (module S)) M.t"
+Error: The value "y" has type "(u * v * (module S)) M.t"
        but an expression was expected of type
          "(u/2 * v/2 * (module S/2)) M/2.t"
        Hint: The types "v" and "u" have been defined multiple times in this
@@ -35,22 +35,21 @@ val c : a = A
 Line 2, characters 4-5:
 2 | a = b;;
         ^
-Error: The expression "b" has type "a/2" but an expression was expected of type
-         "a/3"
+Error: The value "b" has type "a/2" but an expression was expected of type "a/3"
        Hint: The type "a" has been defined multiple times in this toplevel
          session. Some toplevel values still refer to old versions of this
          type. Did you try to redefine them?
 Line 1, characters 4-5:
 1 | a = c;;
         ^
-Error: The expression "c" has type "a" but an expression was expected of type "a/3"
+Error: The value "c" has type "a" but an expression was expected of type "a/3"
        Hint: The type "a" has been defined multiple times in this toplevel
          session. Some toplevel values still refer to old versions of this
          type. Did you try to redefine them?
 Line 1, characters 4-5:
 1 | b = c;;
         ^
-Error: The expression "c" has type "a" but an expression was expected of type "a/2"
+Error: The value "c" has type "a" but an expression was expected of type "a/2"
        Hint: The type "a" has been defined multiple times in this toplevel
          session. Some toplevel values still refer to old versions of this
          type. Did you try to redefine them?

--- a/testsuite/tests/tool-toplevel/redefinition_hints.compilers.reference
+++ b/testsuite/tests/tool-toplevel/redefinition_hints.compilers.reference
@@ -14,7 +14,7 @@ val y : (u * v * (module S)) M.t = M.X (A, B, <module>)
 Line 2, characters 4-5:
 2 | x = y;;
         ^
-Error: This expression has type "(u * v * (module S)) M.t"
+Error: The expression "y" has type "(u * v * (module S)) M.t"
        but an expression was expected of type
          "(u/2 * v/2 * (module S/2)) M/2.t"
        Hint: The types "v" and "u" have been defined multiple times in this
@@ -35,7 +35,7 @@ val c : a = A
 Line 2, characters 4-5:
 2 | a = b;;
         ^
-Error: This expression has type "a/2" but an expression was expected of type
+Error: The expression "b" has type "a/2" but an expression was expected of type
          "a/3"
        Hint: The type "a" has been defined multiple times in this toplevel
          session. Some toplevel values still refer to old versions of this
@@ -43,14 +43,14 @@ Error: This expression has type "a/2" but an expression was expected of type
 Line 1, characters 4-5:
 1 | a = c;;
         ^
-Error: This expression has type "a" but an expression was expected of type "a/3"
+Error: The expression "c" has type "a" but an expression was expected of type "a/3"
        Hint: The type "a" has been defined multiple times in this toplevel
          session. Some toplevel values still refer to old versions of this
          type. Did you try to redefine them?
 Line 1, characters 4-5:
 1 | b = c;;
         ^
-Error: This expression has type "a" but an expression was expected of type "a/2"
+Error: The expression "c" has type "a" but an expression was expected of type "a/2"
        Hint: The type "a" has been defined multiple times in this toplevel
          session. Some toplevel values still refer to old versions of this
          type. Did you try to redefine them?

--- a/testsuite/tests/tool-toplevel/use_command.ml
+++ b/testsuite/tests/tool-toplevel/use_command.ml
@@ -20,6 +20,6 @@ Command exited with code 1.
 File "(command-output)", line 1, characters 5-6:
 1 | 1 :: x
          ^
-Error: This expression has type "int" but an expression was expected of type
+Error: The expression "x" has type "int" but an expression was expected of type
          "int list"
 |}];;

--- a/testsuite/tests/tool-toplevel/use_command.ml
+++ b/testsuite/tests/tool-toplevel/use_command.ml
@@ -20,6 +20,6 @@ Command exited with code 1.
 File "(command-output)", line 1, characters 5-6:
 1 | 1 :: x
          ^
-Error: The expression "x" has type "int" but an expression was expected of type
+Error: The value "x" has type "int" but an expression was expected of type
          "int list"
 |}];;

--- a/testsuite/tests/typing-core-bugs/const_int_hint.ml
+++ b/testsuite/tests/typing-core-bugs/const_int_hint.ml
@@ -7,7 +7,7 @@ let _ = Int32.(add 1 2l);;
 Line 1, characters 19-20:
 1 | let _ = Int32.(add 1 2l);;
                        ^
-Error: This expression has type "int" but an expression was expected of type
+Error: The expression "1" has type "int" but an expression was expected of type
          "int32"
   Hint: Did you mean "1l"?
 |}]
@@ -17,7 +17,7 @@ let _ : int32 * int32 = 42l, 43;;
 Line 1, characters 29-31:
 1 | let _ : int32 * int32 = 42l, 43;;
                                  ^^
-Error: This expression has type "int" but an expression was expected of type
+Error: The expression "43" has type "int" but an expression was expected of type
          "int32"
   Hint: Did you mean "43l"?
 |}]
@@ -27,7 +27,7 @@ let _ : int32 * nativeint = 42l, 43;;
 Line 1, characters 33-35:
 1 | let _ : int32 * nativeint = 42l, 43;;
                                      ^^
-Error: This expression has type "int" but an expression was expected of type
+Error: The expression "43" has type "int" but an expression was expected of type
          "nativeint"
   Hint: Did you mean "43n"?
 |}]
@@ -37,7 +37,7 @@ let _ = min 6L 7;;
 Line 1, characters 15-16:
 1 | let _ = min 6L 7;;
                    ^
-Error: This expression has type "int" but an expression was expected of type
+Error: The expression "7" has type "int" but an expression was expected of type
          "int64"
   Hint: Did you mean "7L"?
 |}]
@@ -47,7 +47,7 @@ let _ : float = 123;;
 Line 1, characters 16-19:
 1 | let _ : float = 123;;
                     ^^^
-Error: This expression has type "int" but an expression was expected of type
+Error: The expression "123" has type "int" but an expression was expected of type
          "float"
   Hint: Did you mean "123."?
 |}]
@@ -60,7 +60,7 @@ val x : int = 0
 Line 2, characters 19-20:
 2 | let _ = Int32.(add x 2l);;
                        ^
-Error: This expression has type "int" but an expression was expected of type
+Error: The expression "x" has type "int" but an expression was expected of type
          "int32"
 |}]
 
@@ -95,8 +95,8 @@ let _ : int32 = 1L;;
 Line 1, characters 16-18:
 1 | let _ : int32 = 1L;;
                     ^^
-Error: This expression has type "int64" but an expression was expected of type
-         "int32"
+Error: The expression "1L" has type "int64"
+       but an expression was expected of type "int32"
   Hint: Did you mean "1l"?
 |}]
 let _ : float = 1L;;
@@ -104,8 +104,8 @@ let _ : float = 1L;;
 Line 1, characters 16-18:
 1 | let _ : float = 1L;;
                     ^^
-Error: This expression has type "int64" but an expression was expected of type
-         "float"
+Error: The expression "1L" has type "int64"
+       but an expression was expected of type "float"
   Hint: Did you mean "1."?
 |}]
 let _ : int64 = 1n;;
@@ -113,7 +113,7 @@ let _ : int64 = 1n;;
 Line 1, characters 16-18:
 1 | let _ : int64 = 1n;;
                     ^^
-Error: This expression has type "nativeint"
+Error: The expression "1n" has type "nativeint"
        but an expression was expected of type "int64"
   Hint: Did you mean "1L"?
 |}]
@@ -122,8 +122,8 @@ let _ : nativeint = 1l;;
 Line 1, characters 20-22:
 1 | let _ : nativeint = 1l;;
                         ^^
-Error: This expression has type "int32" but an expression was expected of type
-         "nativeint"
+Error: The expression "1l" has type "int32"
+       but an expression was expected of type "nativeint"
   Hint: Did you mean "1n"?
 |}]
 
@@ -133,16 +133,16 @@ let _ : int64 = 0.;;
 Line 1, characters 16-18:
 1 | let _ : int64 = 0.;;
                     ^^
-Error: This expression has type "float" but an expression was expected of type
-         "int64"
+Error: The expression "0." has type "float"
+       but an expression was expected of type "int64"
 |}]
 let _ : int = 1L;;
 [%%expect{|
 Line 1, characters 14-16:
 1 | let _ : int = 1L;;
                   ^^
-Error: This expression has type "int64" but an expression was expected of type
-         "int"
+Error: The expression "1L" has type "int64"
+       but an expression was expected of type "int"
 |}]
 
 (* Check that the hint preserves formatting of int, int32, int64 and nativeint
@@ -152,8 +152,8 @@ let _ : int64 = min 0L 1_000;;
 Line 1, characters 23-28:
 1 | let _ : int64 = min 0L 1_000;;
                            ^^^^^
-Error: This expression has type "int" but an expression was expected of type
-         "int64"
+Error: The expression "1_000" has type "int"
+       but an expression was expected of type "int64"
   Hint: Did you mean "1_000L"?
 |}]
 let _ : nativeint * nativeint = 0n, 0xAA_BBL;;
@@ -161,8 +161,8 @@ let _ : nativeint * nativeint = 0n, 0xAA_BBL;;
 Line 1, characters 36-44:
 1 | let _ : nativeint * nativeint = 0n, 0xAA_BBL;;
                                         ^^^^^^^^
-Error: This expression has type "int64" but an expression was expected of type
-         "nativeint"
+Error: The expression "0xAA_BBL" has type "int64"
+       but an expression was expected of type "nativeint"
   Hint: Did you mean "0xAA_BBn"?
 |}]
 let _ : int32 -> int32 = function
@@ -193,7 +193,7 @@ type t1 = { f1 : int32; }
 Line 1, characters 49-55:
 1 | type t1 = {f1: int32};; let _ = fun x -> x.f1 <- 1_000n;;
                                                      ^^^^^^
-Error: This expression has type "nativeint"
+Error: The expression "1_000n" has type "nativeint"
        but an expression was expected of type "int32"
   Hint: Did you mean "1_000l"?
 |}]

--- a/testsuite/tests/typing-core-bugs/const_int_hint.ml
+++ b/testsuite/tests/typing-core-bugs/const_int_hint.ml
@@ -7,7 +7,7 @@ let _ = Int32.(add 1 2l);;
 Line 1, characters 19-20:
 1 | let _ = Int32.(add 1 2l);;
                        ^
-Error: The expression "1" has type "int" but an expression was expected of type
+Error: The constant "1" has type "int" but an expression was expected of type
          "int32"
   Hint: Did you mean "1l"?
 |}]
@@ -17,7 +17,7 @@ let _ : int32 * int32 = 42l, 43;;
 Line 1, characters 29-31:
 1 | let _ : int32 * int32 = 42l, 43;;
                                  ^^
-Error: The expression "43" has type "int" but an expression was expected of type
+Error: The constant "43" has type "int" but an expression was expected of type
          "int32"
   Hint: Did you mean "43l"?
 |}]
@@ -27,7 +27,7 @@ let _ : int32 * nativeint = 42l, 43;;
 Line 1, characters 33-35:
 1 | let _ : int32 * nativeint = 42l, 43;;
                                      ^^
-Error: The expression "43" has type "int" but an expression was expected of type
+Error: The constant "43" has type "int" but an expression was expected of type
          "nativeint"
   Hint: Did you mean "43n"?
 |}]
@@ -37,7 +37,7 @@ let _ = min 6L 7;;
 Line 1, characters 15-16:
 1 | let _ = min 6L 7;;
                    ^
-Error: The expression "7" has type "int" but an expression was expected of type
+Error: The constant "7" has type "int" but an expression was expected of type
          "int64"
   Hint: Did you mean "7L"?
 |}]
@@ -47,7 +47,7 @@ let _ : float = 123;;
 Line 1, characters 16-19:
 1 | let _ : float = 123;;
                     ^^^
-Error: The expression "123" has type "int" but an expression was expected of type
+Error: The constant "123" has type "int" but an expression was expected of type
          "float"
   Hint: Did you mean "123."?
 |}]
@@ -60,8 +60,7 @@ val x : int = 0
 Line 2, characters 19-20:
 2 | let _ = Int32.(add x 2l);;
                        ^
-Error: The expression "x" has type "int" but an expression was expected of type
-         "int32"
+Error: The value "x" has type "int" but an expression was expected of type "int32"
 |}]
 
 (* pattern *)
@@ -95,8 +94,8 @@ let _ : int32 = 1L;;
 Line 1, characters 16-18:
 1 | let _ : int32 = 1L;;
                     ^^
-Error: The expression "1L" has type "int64"
-       but an expression was expected of type "int32"
+Error: The constant "1L" has type "int64" but an expression was expected of type
+         "int32"
   Hint: Did you mean "1l"?
 |}]
 let _ : float = 1L;;
@@ -104,8 +103,8 @@ let _ : float = 1L;;
 Line 1, characters 16-18:
 1 | let _ : float = 1L;;
                     ^^
-Error: The expression "1L" has type "int64"
-       but an expression was expected of type "float"
+Error: The constant "1L" has type "int64" but an expression was expected of type
+         "float"
   Hint: Did you mean "1."?
 |}]
 let _ : int64 = 1n;;
@@ -113,7 +112,7 @@ let _ : int64 = 1n;;
 Line 1, characters 16-18:
 1 | let _ : int64 = 1n;;
                     ^^
-Error: The expression "1n" has type "nativeint"
+Error: The constant "1n" has type "nativeint"
        but an expression was expected of type "int64"
   Hint: Did you mean "1L"?
 |}]
@@ -122,8 +121,8 @@ let _ : nativeint = 1l;;
 Line 1, characters 20-22:
 1 | let _ : nativeint = 1l;;
                         ^^
-Error: The expression "1l" has type "int32"
-       but an expression was expected of type "nativeint"
+Error: The constant "1l" has type "int32" but an expression was expected of type
+         "nativeint"
   Hint: Did you mean "1n"?
 |}]
 
@@ -133,16 +132,16 @@ let _ : int64 = 0.;;
 Line 1, characters 16-18:
 1 | let _ : int64 = 0.;;
                     ^^
-Error: The expression "0." has type "float"
-       but an expression was expected of type "int64"
+Error: The constant "0." has type "float" but an expression was expected of type
+         "int64"
 |}]
 let _ : int = 1L;;
 [%%expect{|
 Line 1, characters 14-16:
 1 | let _ : int = 1L;;
                   ^^
-Error: The expression "1L" has type "int64"
-       but an expression was expected of type "int"
+Error: The constant "1L" has type "int64" but an expression was expected of type
+         "int"
 |}]
 
 (* Check that the hint preserves formatting of int, int32, int64 and nativeint
@@ -152,8 +151,8 @@ let _ : int64 = min 0L 1_000;;
 Line 1, characters 23-28:
 1 | let _ : int64 = min 0L 1_000;;
                            ^^^^^
-Error: The expression "1_000" has type "int"
-       but an expression was expected of type "int64"
+Error: The constant "1_000" has type "int" but an expression was expected of type
+         "int64"
   Hint: Did you mean "1_000L"?
 |}]
 let _ : nativeint * nativeint = 0n, 0xAA_BBL;;
@@ -161,7 +160,7 @@ let _ : nativeint * nativeint = 0n, 0xAA_BBL;;
 Line 1, characters 36-44:
 1 | let _ : nativeint * nativeint = 0n, 0xAA_BBL;;
                                         ^^^^^^^^
-Error: The expression "0xAA_BBL" has type "int64"
+Error: The constant "0xAA_BBL" has type "int64"
        but an expression was expected of type "nativeint"
   Hint: Did you mean "0xAA_BBn"?
 |}]
@@ -193,7 +192,7 @@ type t1 = { f1 : int32; }
 Line 1, characters 49-55:
 1 | type t1 = {f1: int32};; let _ = fun x -> x.f1 <- 1_000n;;
                                                      ^^^^^^
-Error: The expression "1_000n" has type "nativeint"
+Error: The constant "1_000n" has type "nativeint"
        but an expression was expected of type "int32"
   Hint: Did you mean "1_000l"?
 |}]

--- a/testsuite/tests/typing-core-bugs/type_expected_explanation.ml
+++ b/testsuite/tests/typing-core-bugs/type_expected_explanation.ml
@@ -9,7 +9,7 @@ if 3 then ();;
 Line 1, characters 3-4:
 1 | if 3 then ();;
        ^
-Error: This expression has type "int" but an expression was expected of type
+Error: The expression "3" has type "int" but an expression was expected of type
          "bool"
        because it is in the condition of an if-statement
 |}];;
@@ -20,7 +20,7 @@ fun b -> if true then (print_int b) else (if b then ());;
 Line 1, characters 45-46:
 1 | fun b -> if true then (print_int b) else (if b then ());;
                                                  ^
-Error: This expression has type "int" but an expression was expected of type
+Error: The expression "b" has type "int" but an expression was expected of type
          "bool"
        because it is in the condition of an if-statement
 |}];;
@@ -33,7 +33,7 @@ fun b -> if true then (if b then ()) else (print_int b);;
 Line 1, characters 53-54:
 1 | fun b -> if true then (if b then ()) else (print_int b);;
                                                          ^
-Error: This expression has type "bool" but an expression was expected of type
+Error: The expression "b" has type "bool" but an expression was expected of type
          "int"
 |}];;
 
@@ -43,7 +43,7 @@ if (let x = 3 in x) then ();;
 Line 1, characters 17-18:
 1 | if (let x = 3 in x) then ();;
                      ^
-Error: This expression has type "int" but an expression was expected of type
+Error: The expression "x" has type "int" but an expression was expected of type
          "bool"
        because it is in the condition of an if-statement
 |}];;
@@ -54,7 +54,7 @@ if (if true then 3 else 4) then ();;
 Line 1, characters 17-18:
 1 | if (if true then 3 else 4) then ();;
                      ^
-Error: This expression has type "int" but an expression was expected of type
+Error: The expression "3" has type "int" but an expression was expected of type
          "bool"
        because it is in the condition of an if-statement
 |}];;
@@ -65,7 +65,7 @@ if true then 3;;
 Line 1, characters 13-14:
 1 | if true then 3;;
                  ^
-Error: This expression has type "int" but an expression was expected of type
+Error: The expression "3" has type "int" but an expression was expected of type
          "unit"
        because it is in the result of a conditional with no else branch
 |}];;
@@ -86,7 +86,7 @@ while 42 do () done;;
 Line 1, characters 6-8:
 1 | while 42 do () done;;
           ^^
-Error: This expression has type "int" but an expression was expected of type
+Error: The expression "42" has type "int" but an expression was expected of type
          "bool"
        because it is in the condition of a while-loop
 |}];;
@@ -110,8 +110,8 @@ for i = 3. to 4 do () done;;
 Line 1, characters 8-10:
 1 | for i = 3. to 4 do () done;;
             ^^
-Error: This expression has type "float" but an expression was expected of type
-         "int"
+Error: The expression "3." has type "float"
+       but an expression was expected of type "int"
        because it is in a for-loop start index
 |}];;
 
@@ -121,8 +121,8 @@ for i = 3 to 4. do () done;;
 Line 1, characters 13-15:
 1 | for i = 3 to 4. do () done;;
                  ^^
-Error: This expression has type "float" but an expression was expected of type
-         "int"
+Error: The expression "4." has type "float"
+       but an expression was expected of type "int"
        because it is in a for-loop stop index
 |}];;
 
@@ -145,7 +145,7 @@ assert 12;;
 Line 1, characters 7-9:
 1 | assert 12;;
            ^^
-Error: This expression has type "int" but an expression was expected of type
+Error: The expression "12" has type "int" but an expression was expected of type
          "bool"
        because it is in the condition of an assertion
 |}];;

--- a/testsuite/tests/typing-core-bugs/type_expected_explanation.ml
+++ b/testsuite/tests/typing-core-bugs/type_expected_explanation.ml
@@ -96,8 +96,8 @@ while true do (if true then 3 else 4) done;;
 Line 1, characters 14-37:
 1 | while true do (if true then 3 else 4) done;;
                   ^^^^^^^^^^^^^^^^^^^^^^^
-Error: This expression has type "int" but an expression was expected of type
-         "unit"
+Error: This "if-then-else" expression has type "int"
+       but an expression was expected of type "unit"
        because it is in the body of a while-loop
 |}];;
 
@@ -131,8 +131,8 @@ for i = 0 to 0 do (if true then 3 else 4) done;;
 Line 1, characters 18-41:
 1 | for i = 0 to 0 do (if true then 3 else 4) done;;
                       ^^^^^^^^^^^^^^^^^^^^^^^
-Error: This expression has type "int" but an expression was expected of type
-         "unit"
+Error: This "if-then-else" expression has type "int"
+       but an expression was expected of type "unit"
        because it is in the body of a for-loop
 |}];;
 

--- a/testsuite/tests/typing-core-bugs/type_expected_explanation.ml
+++ b/testsuite/tests/typing-core-bugs/type_expected_explanation.ml
@@ -9,7 +9,7 @@ if 3 then ();;
 Line 1, characters 3-4:
 1 | if 3 then ();;
        ^
-Error: The expression "3" has type "int" but an expression was expected of type
+Error: The constant "3" has type "int" but an expression was expected of type
          "bool"
        because it is in the condition of an if-statement
 |}];;
@@ -20,9 +20,8 @@ fun b -> if true then (print_int b) else (if b then ());;
 Line 1, characters 45-46:
 1 | fun b -> if true then (print_int b) else (if b then ());;
                                                  ^
-Error: The expression "b" has type "int" but an expression was expected of type
-         "bool"
-       because it is in the condition of an if-statement
+Error: The value "b" has type "int" but an expression was expected of type "
+       bool" because it is in the condition of an if-statement
 |}];;
 
 (* Left-to-right bias is still there: if we swap the branches, the new error
@@ -33,8 +32,7 @@ fun b -> if true then (if b then ()) else (print_int b);;
 Line 1, characters 53-54:
 1 | fun b -> if true then (if b then ()) else (print_int b);;
                                                          ^
-Error: The expression "b" has type "bool" but an expression was expected of type
-         "int"
+Error: The value "b" has type "bool" but an expression was expected of type "int"
 |}];;
 
 if (let x = 3 in x) then ();;
@@ -43,9 +41,8 @@ if (let x = 3 in x) then ();;
 Line 1, characters 17-18:
 1 | if (let x = 3 in x) then ();;
                      ^
-Error: The expression "x" has type "int" but an expression was expected of type
-         "bool"
-       because it is in the condition of an if-statement
+Error: The value "x" has type "int" but an expression was expected of type "
+       bool" because it is in the condition of an if-statement
 |}];;
 
 if (if true then 3 else 4) then ();;
@@ -54,7 +51,7 @@ if (if true then 3 else 4) then ();;
 Line 1, characters 17-18:
 1 | if (if true then 3 else 4) then ();;
                      ^
-Error: The expression "3" has type "int" but an expression was expected of type
+Error: The constant "3" has type "int" but an expression was expected of type
          "bool"
        because it is in the condition of an if-statement
 |}];;
@@ -65,7 +62,7 @@ if true then 3;;
 Line 1, characters 13-14:
 1 | if true then 3;;
                  ^
-Error: The expression "3" has type "int" but an expression was expected of type
+Error: The constant "3" has type "int" but an expression was expected of type
          "unit"
        because it is in the result of a conditional with no else branch
 |}];;
@@ -86,7 +83,7 @@ while 42 do () done;;
 Line 1, characters 6-8:
 1 | while 42 do () done;;
           ^^
-Error: The expression "42" has type "int" but an expression was expected of type
+Error: The constant "42" has type "int" but an expression was expected of type
          "bool"
        because it is in the condition of a while-loop
 |}];;
@@ -110,8 +107,8 @@ for i = 3. to 4 do () done;;
 Line 1, characters 8-10:
 1 | for i = 3. to 4 do () done;;
             ^^
-Error: The expression "3." has type "float"
-       but an expression was expected of type "int"
+Error: The constant "3." has type "float" but an expression was expected of type
+         "int"
        because it is in a for-loop start index
 |}];;
 
@@ -121,8 +118,8 @@ for i = 3 to 4. do () done;;
 Line 1, characters 13-15:
 1 | for i = 3 to 4. do () done;;
                  ^^
-Error: The expression "4." has type "float"
-       but an expression was expected of type "int"
+Error: The constant "4." has type "float" but an expression was expected of type
+         "int"
        because it is in a for-loop stop index
 |}];;
 
@@ -145,7 +142,7 @@ assert 12;;
 Line 1, characters 7-9:
 1 | assert 12;;
            ^^
-Error: The expression "12" has type "int" but an expression was expected of type
+Error: The constant "12" has type "int" but an expression was expected of type
          "bool"
        because it is in the condition of an assertion
 |}];;

--- a/testsuite/tests/typing-core-bugs/unit_fun_hints.ml
+++ b/testsuite/tests/typing-core-bugs/unit_fun_hints.ml
@@ -11,7 +11,7 @@ val g : (unit -> 'a) -> 'a = <fun>
 Line 2, characters 10-11:
 2 | let _ = g 3;;       (* missing `fun () ->' *)
               ^
-Error: The expression "3" has type "int" but an expression was expected of type
+Error: The constant "3" has type "int" but an expression was expected of type
          "unit -> 'a"
        Hint: Did you forget to wrap the expression using "fun () ->"?
 |}];;
@@ -28,7 +28,7 @@ let _ =
 Line 3, characters 3-16:
 3 |    print_newline;    (* missing unit argument *)
        ^^^^^^^^^^^^^
-Error: The expression "print_newline" has type "unit -> unit"
+Error: The value "print_newline" has type "unit -> unit"
        but an expression was expected of type "unit"
        because it is in the left-hand side of a sequence
        Hint: Did you forget to provide "()" as argument?
@@ -41,7 +41,7 @@ print_int x;;
 Line 2, characters 10-11:
 2 | print_int x;;
               ^
-Error: The expression "x" has type "unit -> int"
+Error: The value "x" has type "unit -> int"
        but an expression was expected of type "int"
        Hint: Did you forget to provide "()" as argument?
 |}];;
@@ -54,7 +54,7 @@ let g f =
 Line 3, characters 6-7:
 3 |   f = 3;;
           ^
-Error: The expression "3" has type "int" but an expression was expected of type
+Error: The constant "3" has type "int" but an expression was expected of type
          "unit -> 'a"
        Hint: Did you forget to wrap the expression using "fun () ->"?
 |}];;
@@ -67,7 +67,7 @@ let g f =
 Line 3, characters 6-7:
 3 |   3 = f;;
           ^
-Error: The expression "f" has type "unit -> 'a"
-       but an expression was expected of type "int"
+Error: The value "f" has type "unit -> 'a" but an expression was expected of type
+         "int"
        Hint: Did you forget to provide "()" as argument?
 |}]

--- a/testsuite/tests/typing-core-bugs/unit_fun_hints.ml
+++ b/testsuite/tests/typing-core-bugs/unit_fun_hints.ml
@@ -11,7 +11,7 @@ val g : (unit -> 'a) -> 'a = <fun>
 Line 2, characters 10-11:
 2 | let _ = g 3;;       (* missing `fun () ->' *)
               ^
-Error: This expression has type "int" but an expression was expected of type
+Error: The expression "3" has type "int" but an expression was expected of type
          "unit -> 'a"
        Hint: Did you forget to wrap the expression using "fun () ->"?
 |}];;
@@ -28,7 +28,7 @@ let _ =
 Line 3, characters 3-16:
 3 |    print_newline;    (* missing unit argument *)
        ^^^^^^^^^^^^^
-Error: This expression has type "unit -> unit"
+Error: The expression "print_newline" has type "unit -> unit"
        but an expression was expected of type "unit"
        because it is in the left-hand side of a sequence
        Hint: Did you forget to provide "()" as argument?
@@ -41,7 +41,7 @@ print_int x;;
 Line 2, characters 10-11:
 2 | print_int x;;
               ^
-Error: This expression has type "unit -> int"
+Error: The expression "x" has type "unit -> int"
        but an expression was expected of type "int"
        Hint: Did you forget to provide "()" as argument?
 |}];;
@@ -54,7 +54,7 @@ let g f =
 Line 3, characters 6-7:
 3 |   f = 3;;
           ^
-Error: This expression has type "int" but an expression was expected of type
+Error: The expression "3" has type "int" but an expression was expected of type
          "unit -> 'a"
        Hint: Did you forget to wrap the expression using "fun () ->"?
 |}];;
@@ -67,7 +67,7 @@ let g f =
 Line 3, characters 6-7:
 3 |   3 = f;;
           ^
-Error: This expression has type "unit -> 'a"
+Error: The expression "f" has type "unit -> 'a"
        but an expression was expected of type "int"
        Hint: Did you forget to provide "()" as argument?
 |}]

--- a/testsuite/tests/typing-extensions/extensions.ml
+++ b/testsuite/tests/typing-extensions/extensions.ml
@@ -231,7 +231,7 @@ let a = A 9
 Line 1, characters 10-11:
 1 | let a = A 9
               ^
-Error: This expression has type "int" but an expression was expected of type
+Error: The expression "9" has type "int" but an expression was expected of type
          "[> `Var ]"
 |}]
 

--- a/testsuite/tests/typing-extensions/extensions.ml
+++ b/testsuite/tests/typing-extensions/extensions.ml
@@ -231,7 +231,7 @@ let a = A 9
 Line 1, characters 10-11:
 1 | let a = A 9
               ^
-Error: The expression "9" has type "int" but an expression was expected of type
+Error: The constant "9" has type "int" but an expression was expected of type
          "[> `Var ]"
 |}]
 

--- a/testsuite/tests/typing-fstclassmod/nondep_instance.ml
+++ b/testsuite/tests/typing-fstclassmod/nondep_instance.ml
@@ -46,7 +46,7 @@ end;;
 Line 3, characters 21-22:
 3 |     Linear_map.scale s x
                          ^
-Error: The expression "s" has type "(module Scalar with type t = s)"
+Error: The value "s" has type "(module Scalar with type t = s)"
        but an expression was expected of type
          "(module Vector_space with type scalar = 'a and type t = 'b)"
 |}];;

--- a/testsuite/tests/typing-fstclassmod/nondep_instance.ml
+++ b/testsuite/tests/typing-fstclassmod/nondep_instance.ml
@@ -46,7 +46,7 @@ end;;
 Line 3, characters 21-22:
 3 |     Linear_map.scale s x
                          ^
-Error: This expression has type "(module Scalar with type t = s)"
+Error: The expression "s" has type "(module Scalar with type t = s)"
        but an expression was expected of type
          "(module Vector_space with type scalar = 'a and type t = 'b)"
 |}];;

--- a/testsuite/tests/typing-fstclassmod/scope_escape.ml
+++ b/testsuite/tests/typing-fstclassmod/scope_escape.ml
@@ -117,8 +117,8 @@ module type S = sig type t val x : t end
 Line 15, characters 8-10:
 15 |   unify ()
              ^^
-Error: The expression "()" has type "unit" but an expression was expected of type
-         "M.t"
+Error: The constructor "()" has type "unit"
+       but an expression was expected of type "M.t"
 |}, Principal{|
 module type S = sig type t val x : t end
 Lines 8-12, characters 4-8:
@@ -132,6 +132,6 @@ Warning 18 [not-principal]: this module packing is not principal.
 Line 15, characters 8-10:
 15 |   unify ()
              ^^
-Error: The expression "()" has type "unit" but an expression was expected of type
-         "M.t"
+Error: The constructor "()" has type "unit"
+       but an expression was expected of type "M.t"
 |}];;

--- a/testsuite/tests/typing-fstclassmod/scope_escape.ml
+++ b/testsuite/tests/typing-fstclassmod/scope_escape.ml
@@ -117,7 +117,7 @@ module type S = sig type t val x : t end
 Line 15, characters 8-10:
 15 |   unify ()
              ^^
-Error: This expression has type "unit" but an expression was expected of type
+Error: The expression "()" has type "unit" but an expression was expected of type
          "M.t"
 |}, Principal{|
 module type S = sig type t val x : t end
@@ -132,6 +132,6 @@ Warning 18 [not-principal]: this module packing is not principal.
 Line 15, characters 8-10:
 15 |   unify ()
              ^^
-Error: This expression has type "unit" but an expression was expected of type
+Error: The expression "()" has type "unit" but an expression was expected of type
          "M.t"
 |}];;

--- a/testsuite/tests/typing-gadts/ambiguity.ml
+++ b/testsuite/tests/typing-gadts/ambiguity.ml
@@ -18,7 +18,7 @@ let ret_e1 (type a b) (b : bool) (wit : (a, b) eq) (x : a) (y : b) =
 Line 3, characters 29-30:
 3 |   | Refl -> if b then x else y
                                  ^
-Error: This expression has type "b" = "a" but an expression was expected of type
+Error: The expression "y" has type "b" = "a" but an expression was expected of type
          "a"
        This instance of "a" is ambiguous:
        it would escape the scope of its equation
@@ -33,7 +33,7 @@ let ret_e2 (type a b) (b : bool) (wit : (a, b) eq) (x : a) (y : b) =
 Line 3, characters 29-30:
 3 |   | Refl -> if b then x else y
                                  ^
-Error: This expression has type "b" = "a" but an expression was expected of type
+Error: The expression "y" has type "b" = "a" but an expression was expected of type
          "a"
        This instance of "a" is ambiguous:
        it would escape the scope of its equation
@@ -48,7 +48,7 @@ let ret_ei1 (type a) (b : bool) (wit : (a, int) eq) (x : a) =
 Line 3, characters 29-30:
 3 |   | Refl -> if b then x else 0
                                  ^
-Error: This expression has type "int" but an expression was expected of type
+Error: The expression "0" has type "int" but an expression was expected of type
          "a" = "int"
        This instance of "int" is ambiguous:
        it would escape the scope of its equation
@@ -63,7 +63,7 @@ let ret_ei2 (type a) (b : bool) (wit : (a, int) eq) (x : a) =
 Line 3, characters 29-30:
 3 |   | Refl -> if b then x else 0
                                  ^
-Error: This expression has type "int" but an expression was expected of type
+Error: The expression "0" has type "int" but an expression was expected of type
          "a" = "int"
        This instance of "int" is ambiguous:
        it would escape the scope of its equation
@@ -79,7 +79,7 @@ let ret_f (type a b) (wit : (a, b) eq) (x : a) (y : b) =
 Line 3, characters 16-17:
 3 |   | Refl -> [x; y]
                     ^
-Error: This expression has type "b" = "a" but an expression was expected of type
+Error: The expression "y" has type "b" = "a" but an expression was expected of type
          "a"
        This instance of "a" is ambiguous:
        it would escape the scope of its equation
@@ -94,7 +94,7 @@ let ret_g1 (type a b) (wit : (a, b) eq) (x : a) (y : b) =
 Line 3, characters 16-17:
 3 |   | Refl -> [x; y]
                     ^
-Error: This expression has type "b" = "a" but an expression was expected of type
+Error: The expression "y" has type "b" = "a" but an expression was expected of type
          "a"
        This instance of "a" is ambiguous:
        it would escape the scope of its equation

--- a/testsuite/tests/typing-gadts/ambiguity.ml
+++ b/testsuite/tests/typing-gadts/ambiguity.ml
@@ -18,8 +18,7 @@ let ret_e1 (type a b) (b : bool) (wit : (a, b) eq) (x : a) (y : b) =
 Line 3, characters 29-30:
 3 |   | Refl -> if b then x else y
                                  ^
-Error: The expression "y" has type "b" = "a" but an expression was expected of type
-         "a"
+Error: The value "y" has type "b" = "a" but an expression was expected of type "a"
        This instance of "a" is ambiguous:
        it would escape the scope of its equation
 |}]
@@ -33,8 +32,7 @@ let ret_e2 (type a b) (b : bool) (wit : (a, b) eq) (x : a) (y : b) =
 Line 3, characters 29-30:
 3 |   | Refl -> if b then x else y
                                  ^
-Error: The expression "y" has type "b" = "a" but an expression was expected of type
-         "a"
+Error: The value "y" has type "b" = "a" but an expression was expected of type "a"
        This instance of "a" is ambiguous:
        it would escape the scope of its equation
 |}]
@@ -48,7 +46,7 @@ let ret_ei1 (type a) (b : bool) (wit : (a, int) eq) (x : a) =
 Line 3, characters 29-30:
 3 |   | Refl -> if b then x else 0
                                  ^
-Error: The expression "0" has type "int" but an expression was expected of type
+Error: The constant "0" has type "int" but an expression was expected of type
          "a" = "int"
        This instance of "int" is ambiguous:
        it would escape the scope of its equation
@@ -63,7 +61,7 @@ let ret_ei2 (type a) (b : bool) (wit : (a, int) eq) (x : a) =
 Line 3, characters 29-30:
 3 |   | Refl -> if b then x else 0
                                  ^
-Error: The expression "0" has type "int" but an expression was expected of type
+Error: The constant "0" has type "int" but an expression was expected of type
          "a" = "int"
        This instance of "int" is ambiguous:
        it would escape the scope of its equation
@@ -79,8 +77,7 @@ let ret_f (type a b) (wit : (a, b) eq) (x : a) (y : b) =
 Line 3, characters 16-17:
 3 |   | Refl -> [x; y]
                     ^
-Error: The expression "y" has type "b" = "a" but an expression was expected of type
-         "a"
+Error: The value "y" has type "b" = "a" but an expression was expected of type "a"
        This instance of "a" is ambiguous:
        it would escape the scope of its equation
 |}]
@@ -94,8 +91,7 @@ let ret_g1 (type a b) (wit : (a, b) eq) (x : a) (y : b) =
 Line 3, characters 16-17:
 3 |   | Refl -> [x; y]
                     ^
-Error: The expression "y" has type "b" = "a" but an expression was expected of type
-         "a"
+Error: The value "y" has type "b" = "a" but an expression was expected of type "a"
        This instance of "a" is ambiguous:
        it would escape the scope of its equation
 |}]

--- a/testsuite/tests/typing-gadts/didier.ml
+++ b/testsuite/tests/typing-gadts/didier.ml
@@ -54,7 +54,7 @@ val f : 't -> 't ty -> bool = <fun>
 Line 4, characters 12-13:
 4 |   | Bool -> x
                 ^
-Error: This expression has type "t" = "bool"
+Error: The expression "x" has type "t" = "bool"
        but an expression was expected of type "bool"
        This instance of "bool" is ambiguous:
        it would escape the scope of its equation

--- a/testsuite/tests/typing-gadts/didier.ml
+++ b/testsuite/tests/typing-gadts/didier.ml
@@ -54,8 +54,8 @@ val f : 't -> 't ty -> bool = <fun>
 Line 4, characters 12-13:
 4 |   | Bool -> x
                 ^
-Error: The expression "x" has type "t" = "bool"
-       but an expression was expected of type "bool"
+Error: The value "x" has type "t" = "bool" but an expression was expected of type
+         "bool"
        This instance of "bool" is ambiguous:
        it would escape the scope of its equation
 |}];;

--- a/testsuite/tests/typing-gadts/or_patterns.ml
+++ b/testsuite/tests/typing-gadts/or_patterns.ml
@@ -632,7 +632,7 @@ let return_a (type a) (x : a t3) : a =
 Line 3, characters 13-14:
 3 |   | A | B -> 3 (* fails because the equation [a = int] doesn't escape any of
                  ^
-Error: The expression "3" has type "int" but an expression was expected of type "a"
+Error: The constant "3" has type "int" but an expression was expected of type "a"
 |}]
 
 (* Making sure we don't break a frequent pattern of GADTs indexed by polymorphic

--- a/testsuite/tests/typing-gadts/or_patterns.ml
+++ b/testsuite/tests/typing-gadts/or_patterns.ml
@@ -632,7 +632,7 @@ let return_a (type a) (x : a t3) : a =
 Line 3, characters 13-14:
 3 |   | A | B -> 3 (* fails because the equation [a = int] doesn't escape any of
                  ^
-Error: This expression has type "int" but an expression was expected of type "a"
+Error: The expression "3" has type "int" but an expression was expected of type "a"
 |}]
 
 (* Making sure we don't break a frequent pattern of GADTs indexed by polymorphic

--- a/testsuite/tests/typing-gadts/packed-module-recasting.ml
+++ b/testsuite/tests/typing-gadts/packed-module-recasting.ml
@@ -482,7 +482,7 @@ val f : ('a, 'b -> 'b) eq -> ('a, int -> int) eq -> 'a -> 'b = <fun>
 Line 4, characters 2-7:
 4 |   M.res;;
       ^^^^^
-Error: The expression "M.res" has type "b" = "int"
+Error: The value "M.res" has type "b" = "int"
        but an expression was expected of type "'a"
        This instance of "int" is ambiguous:
        it would escape the scope of its equation
@@ -497,8 +497,7 @@ val f : ('a, 'b -> 'b) eq -> ('a, int -> int) eq -> 'a -> int = <fun>
 Line 4, characters 3-8:
 4 |    M.res;;
        ^^^^^
-Error: The expression "M.res" has type "int"
-       but an expression was expected of type "'a"
+Error: The value "M.res" has type "int" but an expression was expected of type "'a"
        This instance of "int" is ambiguous:
        it would escape the scope of its equation
 |}]

--- a/testsuite/tests/typing-gadts/packed-module-recasting.ml
+++ b/testsuite/tests/typing-gadts/packed-module-recasting.ml
@@ -482,7 +482,7 @@ val f : ('a, 'b -> 'b) eq -> ('a, int -> int) eq -> 'a -> 'b = <fun>
 Line 4, characters 2-7:
 4 |   M.res;;
       ^^^^^
-Error: This expression has type "b" = "int"
+Error: The expression "M.res" has type "b" = "int"
        but an expression was expected of type "'a"
        This instance of "int" is ambiguous:
        it would escape the scope of its equation
@@ -497,7 +497,8 @@ val f : ('a, 'b -> 'b) eq -> ('a, int -> int) eq -> 'a -> int = <fun>
 Line 4, characters 3-8:
 4 |    M.res;;
        ^^^^^
-Error: This expression has type "int" but an expression was expected of type "'a"
+Error: The expression "M.res" has type "int"
+       but an expression was expected of type "'a"
        This instance of "int" is ambiguous:
        it would escape the scope of its equation
 |}]

--- a/testsuite/tests/typing-gadts/pr5689.ml
+++ b/testsuite/tests/typing-gadts/pr5689.ml
@@ -103,7 +103,7 @@ type _ linkp2 = Kind : 'a linkp -> ([< inkind ] as 'a) linkp2
 Line 7, characters 35-43:
 7 |     | (Kind _, Ast_Text txt)    -> Text txt
                                        ^^^^^^^^
-Error: This expression has type "[< inkind > `Nonlink ] inline_t"
+Error: This constructor has type "[< inkind > `Nonlink ] inline_t"
        but an expression was expected of type "a inline_t"
        Type "[< inkind > `Nonlink ]" = "[< `Link | `Nonlink > `Nonlink ]"
        is not compatible with type "a" = "[< `Link | `Nonlink ]"

--- a/testsuite/tests/typing-gadts/pr5948.ml
+++ b/testsuite/tests/typing-gadts/pr5948.ml
@@ -42,7 +42,7 @@ type _ wrapPoly =
 Line 25, characters 23-27:
 25 |     | WrapPoly ATag -> intA
                             ^^^^
-Error: This expression has type "[< `TagA of 'a ] -> 'a"
+Error: The expression "intA" has type "[< `TagA of 'a ] -> 'a"
        but an expression was expected of type "a -> int"
        Type "[< `TagA of 'a ]" is not compatible with type
          "a" = "[< `TagA of int | `TagB ]"

--- a/testsuite/tests/typing-gadts/pr5948.ml
+++ b/testsuite/tests/typing-gadts/pr5948.ml
@@ -42,7 +42,7 @@ type _ wrapPoly =
 Line 25, characters 23-27:
 25 |     | WrapPoly ATag -> intA
                             ^^^^
-Error: The expression "intA" has type "[< `TagA of 'a ] -> 'a"
+Error: The value "intA" has type "[< `TagA of 'a ] -> 'a"
        but an expression was expected of type "a -> int"
        Type "[< `TagA of 'a ]" is not compatible with type
          "a" = "[< `TagA of int | `TagB ]"

--- a/testsuite/tests/typing-gadts/pr6174.ml
+++ b/testsuite/tests/typing-gadts/pr6174.ml
@@ -10,6 +10,5 @@ type _ t = C : ((('a -> 'o) -> 'o) -> ('b -> 'o) -> 'o) t
 Line 3, characters 24-25:
 3 |  fun C k -> k (fun x -> x);;
                             ^
-Error: The expression "x" has type "$0" but an expression was expected of type
-         "$1" = "o"
+Error: The value "x" has type "$0" but an expression was expected of type "$1" = "o"
 |}];;

--- a/testsuite/tests/typing-gadts/pr6174.ml
+++ b/testsuite/tests/typing-gadts/pr6174.ml
@@ -10,6 +10,6 @@ type _ t = C : ((('a -> 'o) -> 'o) -> ('b -> 'o) -> 'o) t
 Line 3, characters 24-25:
 3 |  fun C k -> k (fun x -> x);;
                             ^
-Error: This expression has type "$0" but an expression was expected of type
+Error: The expression "x" has type "$0" but an expression was expected of type
          "$1" = "o"
 |}];;

--- a/testsuite/tests/typing-gadts/pr6980.ml
+++ b/testsuite/tests/typing-gadts/pr6980.ml
@@ -24,7 +24,7 @@ val it : [< `Bar | `Foo > `Bar ] = `Bar
 Line 11, characters 27-29:
 11 | let g (Aux(Second, f)) = f it;;
                                 ^^
-Error: This expression has type "[< `Bar | `Foo > `Bar ]"
+Error: The expression "it" has type "[< `Bar | `Foo > `Bar ]"
        but an expression was expected of type "[< `Bar | `Foo ]"
        The second variant type is bound to "$a",
        it may not allow the tag(s) "`Bar"

--- a/testsuite/tests/typing-gadts/pr6980.ml
+++ b/testsuite/tests/typing-gadts/pr6980.ml
@@ -24,7 +24,7 @@ val it : [< `Bar | `Foo > `Bar ] = `Bar
 Line 11, characters 27-29:
 11 | let g (Aux(Second, f)) = f it;;
                                 ^^
-Error: The expression "it" has type "[< `Bar | `Foo > `Bar ]"
+Error: The value "it" has type "[< `Bar | `Foo > `Bar ]"
        but an expression was expected of type "[< `Bar | `Foo ]"
        The second variant type is bound to "$a",
        it may not allow the tag(s) "`Bar"

--- a/testsuite/tests/typing-gadts/pr7374.ml
+++ b/testsuite/tests/typing-gadts/pr7374.ml
@@ -24,7 +24,7 @@ end;; (* should fail *)
 Line 7, characters 16-20:
 7 |     fun Refl -> Refl
                     ^^^^
-Error: The expression "Refl" has type "(a, a) eq"
+Error: The constructor "Refl" has type "(a, a) eq"
        but an expression was expected of type "(a, t) eq"
        Type "a" is not compatible with type "t" = "[ `Rec of 'a ] X.t as 'a"
 |}]
@@ -56,7 +56,7 @@ end;; (* should fail *)
 Line 4, characters 21-25:
 4 |     fun Refl Refl -> Refl;;
                          ^^^^
-Error: The expression "Refl" has type "(a, a) eq"
+Error: The constructor "Refl" has type "(a, a) eq"
        but an expression was expected of type "(a, a X.t X.t) eq"
        Type "a" = "b X.t" is not compatible with type "a X.t X.t"
        Type "b" is not compatible with type "a X.t"

--- a/testsuite/tests/typing-gadts/pr7374.ml
+++ b/testsuite/tests/typing-gadts/pr7374.ml
@@ -24,7 +24,7 @@ end;; (* should fail *)
 Line 7, characters 16-20:
 7 |     fun Refl -> Refl
                     ^^^^
-Error: This expression has type "(a, a) eq"
+Error: The expression "Refl" has type "(a, a) eq"
        but an expression was expected of type "(a, t) eq"
        Type "a" is not compatible with type "t" = "[ `Rec of 'a ] X.t as 'a"
 |}]
@@ -56,7 +56,7 @@ end;; (* should fail *)
 Line 4, characters 21-25:
 4 |     fun Refl Refl -> Refl;;
                          ^^^^
-Error: This expression has type "(a, a) eq"
+Error: The expression "Refl" has type "(a, a) eq"
        but an expression was expected of type "(a, a X.t X.t) eq"
        Type "a" = "b X.t" is not compatible with type "a X.t X.t"
        Type "b" is not compatible with type "a X.t"

--- a/testsuite/tests/typing-gadts/principality-and-gadts.ml
+++ b/testsuite/tests/typing-gadts/principality-and-gadts.ml
@@ -106,7 +106,7 @@ let f (type a) t (x : a) =
 Line 3, characters 17-18:
 3 |   | IntLit, n -> n+1
                      ^
-Error: The expression "n" has type "a" but an expression was expected of type "int"
+Error: The value "n" has type "a" but an expression was expected of type "int"
 |}]
 
 (**********************)

--- a/testsuite/tests/typing-gadts/principality-and-gadts.ml
+++ b/testsuite/tests/typing-gadts/principality-and-gadts.ml
@@ -106,7 +106,7 @@ let f (type a) t (x : a) =
 Line 3, characters 17-18:
 3 |   | IntLit, n -> n+1
                      ^
-Error: This expression has type "a" but an expression was expected of type "int"
+Error: The expression "n" has type "a" but an expression was expected of type "int"
 |}]
 
 (**********************)

--- a/testsuite/tests/typing-gadts/test.ml
+++ b/testsuite/tests/typing-gadts/test.ml
@@ -293,8 +293,7 @@ module Existential_escape =
 Line 5, characters 21-22:
 5 |     let eval (D x) = x
                          ^
-Error: The expression "x" has type "$a t" but an expression was expected of type
-         "'a"
+Error: The value "x" has type "$a t" but an expression was expected of type "'a"
        The type constructor "$a" would escape its scope
        Hint: "$a" is an existential type bound by the constructor "D".
 |}];;
@@ -377,7 +376,7 @@ module Propagation :
 Line 13, characters 19-20:
 13 |     | BoolLit b -> b
                         ^
-Error: The expression "b" has type "bool" but an expression was expected of type
+Error: The value "b" has type "bool" but an expression was expected of type
          "s" = "bool"
        This instance of "bool" is ambiguous:
        it would escape the scope of its equation
@@ -586,8 +585,7 @@ val either : 'a -> 'a -> 'a = <fun>
 Line 3, characters 44-45:
 3 |   match v with Int -> let y = either 1 x in y
                                                 ^
-Error: The expression "y" has type "int" but an expression was expected of type
-         "'a"
+Error: The value "y" has type "int" but an expression was expected of type "'a"
        This instance of "int" is ambiguous:
        it would escape the scope of its equation
 |}];;
@@ -705,7 +703,7 @@ let f : type a b. (a,b) eq -> <m : a; ..> -> <m : b; ..> =
 Line 2, characters 14-15:
 2 |   fun Eq o -> o
                   ^
-Error: The expression "o" has type "< m : a; .. >"
+Error: The value "o" has type "< m : a; .. >"
        but an expression was expected of type "< m : b; .. >"
        Type "a" is not compatible with type "b" = "a"
        This instance of "a" is ambiguous:
@@ -718,7 +716,7 @@ let f (type a) (type b) (eq : (a,b) eq) (o : <m : a; ..>) : <m : b; ..> =
 Line 2, characters 22-23:
 2 |   match eq with Eq -> o ;; (* should fail *)
                           ^
-Error: The expression "o" has type "< m : a; .. >"
+Error: The value "o" has type "< m : a; .. >"
        but an expression was expected of type "< m : b; .. >"
        Type "a" is not compatible with type "b" = "a"
        This instance of "a" is ambiguous:
@@ -758,8 +756,8 @@ val f : ('a, 'b) eq -> < m : 'a > -> < m : 'b > = <fun>
 Line 4, characters 44-45:
 4 |     let r : < m : b > = match eq with Eq -> o in (* fail with principal *)
                                                 ^
-Error: The expression "o" has type "< m : a >"
-       but an expression was expected of type "< m : b >"
+Error: The value "o" has type "< m : a >" but an expression was expected of type
+         "< m : b >"
        Type "a" is not compatible with type "b" = "a"
        This instance of "a" is ambiguous:
        it would escape the scope of its equation
@@ -774,7 +772,7 @@ let f : type a b. (a,b) eq -> < m : a; .. > -> < m : b > =
 Line 3, characters 44-45:
 3 |     let r : < m : b > = match eq with Eq -> o in (* fail *)
                                                 ^
-Error: The expression "o" has type "< m : a; .. >"
+Error: The value "o" has type "< m : a; .. >"
        but an expression was expected of type "< m : b >"
        Type "a" is not compatible with type "b" = "a"
        This instance of "a" is ambiguous:
@@ -787,7 +785,7 @@ let f : type a b. (a,b) eq -> [> `A of a] -> [> `A of b] =
 Line 2, characters 14-15:
 2 |   fun Eq o -> o ;; (* fail *)
                   ^
-Error: The expression "o" has type "[> `A of a ]"
+Error: The value "o" has type "[> `A of a ]"
        but an expression was expected of type "[> `A of b ]"
        Type "a" is not compatible with type "b" = "a"
        This instance of "a" is ambiguous:
@@ -800,7 +798,7 @@ let f (type a b) (eq : (a,b) eq) (v : [> `A of a]) : [> `A of b] =
 Line 2, characters 22-23:
 2 |   match eq with Eq -> v ;; (* should fail *)
                           ^
-Error: The expression "v" has type "[> `A of a ]"
+Error: The value "v" has type "[> `A of a ]"
        but an expression was expected of type "[> `A of b ]"
        Type "a" is not compatible with type "b" = "a"
        This instance of "a" is ambiguous:
@@ -856,7 +854,7 @@ Error: This expression has type
 Line 4, characters 49-50:
 4 |     let r : [`A of b | `B] = match eq with Eq -> o in (* fail with principal *)
                                                      ^
-Error: The expression "o" has type "[ `A of a | `B ]"
+Error: The value "o" has type "[ `A of a | `B ]"
        but an expression was expected of type "[ `A of b | `B ]"
        Type "a" is not compatible with type "b" = "a"
        This instance of "a" is ambiguous:
@@ -872,7 +870,7 @@ let f : type a b. (a,b) eq -> [> `A of a | `B] -> [`A of b | `B] =
 Line 3, characters 49-50:
 3 |     let r : [`A of b | `B] = match eq with Eq -> o in (* fail *)
                                                      ^
-Error: The expression "o" has type "[> `A of a | `B ]"
+Error: The value "o" has type "[> `A of a | `B ]"
        but an expression was expected of type "[ `A of b | `B ]"
        Type "a" is not compatible with type "b" = "a"
        This instance of "a" is ambiguous:
@@ -1020,7 +1018,7 @@ module M : sig type 'a t val eq : ('a t, 'b t) eq end
 Line 6, characters 17-19:
 6 |   function Eq -> Eq (* fail *)
                      ^^
-Error: The expression "Eq" has type "(a, a) eq"
+Error: The constructor "Eq" has type "(a, a) eq"
        but an expression was expected of type "(a, b) eq"
        Type "a" is not compatible with type "b"
 |}];;
@@ -1076,7 +1074,7 @@ type _ int_bar = IB_constr : < bar : int; .. > int_bar
 Line 10, characters 3-4:
 10 |   (x:<foo:int>)
         ^
-Error: The expression "x" has type "t" = "< foo : int; .. >"
+Error: The value "x" has type "t" = "< foo : int; .. >"
        but an expression was expected of type "< foo : int >"
        Type "$0" = "< bar : int; .. >" is not compatible with type "<  >"
        The second object type has no method "bar"
@@ -1090,7 +1088,7 @@ let g (type t) (x:t) (e : t int_foo) (e' : t int_bar) =
 Line 3, characters 3-4:
 3 |   (x:<foo:int;bar:int>)
        ^
-Error: The expression "x" has type "t" = "< foo : int; .. >"
+Error: The value "x" has type "t" = "< foo : int; .. >"
        but an expression was expected of type "< bar : int; foo : int >"
        Type "$0" = "< bar : int; .. >" is not compatible with type "< bar : int >"
        The first object type has an abstract row, it cannot be closed
@@ -1135,7 +1133,7 @@ val g : 't -> 't int_foo -> 't int_bar -> 't * int * int = <fun>
 Line 3, characters 5-10:
 3 |   x, x#foo, x#bar
          ^^^^^
-Error: The expression "x#foo" has type "int"
+Error: The method call "x#foo" has type "int"
        but an expression was expected of type "'a"
        This instance of "int" is ambiguous:
        it would escape the scope of its equation
@@ -1204,8 +1202,8 @@ let f : type a b. (a,b) eq -> (a,int) eq -> a -> b -> _ = fun ab aint a b ->
 Line 5, characters 24-25:
 5 |     if true then a else b
                             ^
-Error: The expression "b" has type "b" = "int"
-       but an expression was expected of type "a" = "int"
+Error: The value "b" has type "b" = "int" but an expression was expected of type
+         "a" = "int"
        This instance of "int" is ambiguous:
        it would escape the scope of its equation
 |}];;
@@ -1221,8 +1219,8 @@ let f : type a b. (a,b) eq -> (b,int) eq -> a -> b -> _ = fun ab bint a b ->
 Line 5, characters 24-25:
 5 |     if true then a else b
                             ^
-Error: The expression "b" has type "b" = "int"
-       but an expression was expected of type "a" = "int"
+Error: The value "b" has type "b" = "int" but an expression was expected of type
+         "a" = "int"
        This instance of "int" is ambiguous:
        it would escape the scope of its equation
 |}];;
@@ -1236,8 +1234,8 @@ let f (type a b c) (b : bool) (w1 : (a,b) eq) (w2 : (a,int) eq) (x : a) (y : b) 
 Line 4, characters 19-20:
 4 |   if b then x else y
                        ^
-Error: The expression "y" has type "b" = "int"
-       but an expression was expected of type "a" = "int"
+Error: The value "y" has type "b" = "int" but an expression was expected of type
+         "a" = "int"
        This instance of "int" is ambiguous:
        it would escape the scope of its equation
 |}];;
@@ -1250,8 +1248,8 @@ let f (type a b c) (b : bool) (w1 : (a,b) eq) (w2 : (a,int) eq) (x : a) (y : b) 
 Line 4, characters 19-20:
 4 |   if b then y else x
                        ^
-Error: The expression "x" has type "a" = "int"
-       but an expression was expected of type "b" = "int"
+Error: The value "x" has type "a" = "int" but an expression was expected of type
+         "b" = "int"
        This instance of "int" is ambiguous:
        it would escape the scope of its equation
 |}];;
@@ -1289,7 +1287,7 @@ type (_, _) eq = Refl : ('a, 'a) eq
 Line 7, characters 35-36:
 7 |   if true then fun x -> x + 1 else x
                                        ^
-Error: The expression "x" has type "M.t" = "int -> int"
+Error: The value "x" has type "M.t" = "int -> int"
        but an expression was expected of type "int -> int"
        This instance of "int -> int" is ambiguous:
        it would escape the scope of its equation

--- a/testsuite/tests/typing-gadts/test.ml
+++ b/testsuite/tests/typing-gadts/test.ml
@@ -293,7 +293,7 @@ module Existential_escape =
 Line 5, characters 21-22:
 5 |     let eval (D x) = x
                          ^
-Error: This expression has type "$a t" but an expression was expected of type
+Error: The expression "x" has type "$a t" but an expression was expected of type
          "'a"
        The type constructor "$a" would escape its scope
        Hint: "$a" is an existential type bound by the constructor "D".
@@ -377,7 +377,7 @@ module Propagation :
 Line 13, characters 19-20:
 13 |     | BoolLit b -> b
                         ^
-Error: This expression has type "bool" but an expression was expected of type
+Error: The expression "b" has type "bool" but an expression was expected of type
          "s" = "bool"
        This instance of "bool" is ambiguous:
        it would escape the scope of its equation
@@ -586,7 +586,8 @@ val either : 'a -> 'a -> 'a = <fun>
 Line 3, characters 44-45:
 3 |   match v with Int -> let y = either 1 x in y
                                                 ^
-Error: This expression has type "int" but an expression was expected of type "'a"
+Error: The expression "y" has type "int" but an expression was expected of type
+         "'a"
        This instance of "int" is ambiguous:
        it would escape the scope of its equation
 |}];;
@@ -704,7 +705,7 @@ let f : type a b. (a,b) eq -> <m : a; ..> -> <m : b; ..> =
 Line 2, characters 14-15:
 2 |   fun Eq o -> o
                   ^
-Error: This expression has type "< m : a; .. >"
+Error: The expression "o" has type "< m : a; .. >"
        but an expression was expected of type "< m : b; .. >"
        Type "a" is not compatible with type "b" = "a"
        This instance of "a" is ambiguous:
@@ -717,7 +718,7 @@ let f (type a) (type b) (eq : (a,b) eq) (o : <m : a; ..>) : <m : b; ..> =
 Line 2, characters 22-23:
 2 |   match eq with Eq -> o ;; (* should fail *)
                           ^
-Error: This expression has type "< m : a; .. >"
+Error: The expression "o" has type "< m : a; .. >"
        but an expression was expected of type "< m : b; .. >"
        Type "a" is not compatible with type "b" = "a"
        This instance of "a" is ambiguous:
@@ -757,7 +758,7 @@ val f : ('a, 'b) eq -> < m : 'a > -> < m : 'b > = <fun>
 Line 4, characters 44-45:
 4 |     let r : < m : b > = match eq with Eq -> o in (* fail with principal *)
                                                 ^
-Error: This expression has type "< m : a >"
+Error: The expression "o" has type "< m : a >"
        but an expression was expected of type "< m : b >"
        Type "a" is not compatible with type "b" = "a"
        This instance of "a" is ambiguous:
@@ -773,7 +774,7 @@ let f : type a b. (a,b) eq -> < m : a; .. > -> < m : b > =
 Line 3, characters 44-45:
 3 |     let r : < m : b > = match eq with Eq -> o in (* fail *)
                                                 ^
-Error: This expression has type "< m : a; .. >"
+Error: The expression "o" has type "< m : a; .. >"
        but an expression was expected of type "< m : b >"
        Type "a" is not compatible with type "b" = "a"
        This instance of "a" is ambiguous:
@@ -786,7 +787,7 @@ let f : type a b. (a,b) eq -> [> `A of a] -> [> `A of b] =
 Line 2, characters 14-15:
 2 |   fun Eq o -> o ;; (* fail *)
                   ^
-Error: This expression has type "[> `A of a ]"
+Error: The expression "o" has type "[> `A of a ]"
        but an expression was expected of type "[> `A of b ]"
        Type "a" is not compatible with type "b" = "a"
        This instance of "a" is ambiguous:
@@ -799,7 +800,7 @@ let f (type a b) (eq : (a,b) eq) (v : [> `A of a]) : [> `A of b] =
 Line 2, characters 22-23:
 2 |   match eq with Eq -> v ;; (* should fail *)
                           ^
-Error: This expression has type "[> `A of a ]"
+Error: The expression "v" has type "[> `A of a ]"
        but an expression was expected of type "[> `A of b ]"
        Type "a" is not compatible with type "b" = "a"
        This instance of "a" is ambiguous:
@@ -855,7 +856,7 @@ Error: This expression has type
 Line 4, characters 49-50:
 4 |     let r : [`A of b | `B] = match eq with Eq -> o in (* fail with principal *)
                                                      ^
-Error: This expression has type "[ `A of a | `B ]"
+Error: The expression "o" has type "[ `A of a | `B ]"
        but an expression was expected of type "[ `A of b | `B ]"
        Type "a" is not compatible with type "b" = "a"
        This instance of "a" is ambiguous:
@@ -871,7 +872,7 @@ let f : type a b. (a,b) eq -> [> `A of a | `B] -> [`A of b | `B] =
 Line 3, characters 49-50:
 3 |     let r : [`A of b | `B] = match eq with Eq -> o in (* fail *)
                                                      ^
-Error: This expression has type "[> `A of a | `B ]"
+Error: The expression "o" has type "[> `A of a | `B ]"
        but an expression was expected of type "[ `A of b | `B ]"
        Type "a" is not compatible with type "b" = "a"
        This instance of "a" is ambiguous:
@@ -1019,7 +1020,7 @@ module M : sig type 'a t val eq : ('a t, 'b t) eq end
 Line 6, characters 17-19:
 6 |   function Eq -> Eq (* fail *)
                      ^^
-Error: This expression has type "(a, a) eq"
+Error: The expression "Eq" has type "(a, a) eq"
        but an expression was expected of type "(a, b) eq"
        Type "a" is not compatible with type "b"
 |}];;
@@ -1075,7 +1076,7 @@ type _ int_bar = IB_constr : < bar : int; .. > int_bar
 Line 10, characters 3-4:
 10 |   (x:<foo:int>)
         ^
-Error: This expression has type "t" = "< foo : int; .. >"
+Error: The expression "x" has type "t" = "< foo : int; .. >"
        but an expression was expected of type "< foo : int >"
        Type "$0" = "< bar : int; .. >" is not compatible with type "<  >"
        The second object type has no method "bar"
@@ -1089,7 +1090,7 @@ let g (type t) (x:t) (e : t int_foo) (e' : t int_bar) =
 Line 3, characters 3-4:
 3 |   (x:<foo:int;bar:int>)
        ^
-Error: This expression has type "t" = "< foo : int; .. >"
+Error: The expression "x" has type "t" = "< foo : int; .. >"
        but an expression was expected of type "< bar : int; foo : int >"
        Type "$0" = "< bar : int; .. >" is not compatible with type "< bar : int >"
        The first object type has an abstract row, it cannot be closed
@@ -1134,7 +1135,8 @@ val g : 't -> 't int_foo -> 't int_bar -> 't * int * int = <fun>
 Line 3, characters 5-10:
 3 |   x, x#foo, x#bar
          ^^^^^
-Error: This expression has type "int" but an expression was expected of type "'a"
+Error: The expression "x#foo" has type "int"
+       but an expression was expected of type "'a"
        This instance of "int" is ambiguous:
        it would escape the scope of its equation
 |}];;
@@ -1202,7 +1204,7 @@ let f : type a b. (a,b) eq -> (a,int) eq -> a -> b -> _ = fun ab aint a b ->
 Line 5, characters 24-25:
 5 |     if true then a else b
                             ^
-Error: This expression has type "b" = "int"
+Error: The expression "b" has type "b" = "int"
        but an expression was expected of type "a" = "int"
        This instance of "int" is ambiguous:
        it would escape the scope of its equation
@@ -1219,7 +1221,7 @@ let f : type a b. (a,b) eq -> (b,int) eq -> a -> b -> _ = fun ab bint a b ->
 Line 5, characters 24-25:
 5 |     if true then a else b
                             ^
-Error: This expression has type "b" = "int"
+Error: The expression "b" has type "b" = "int"
        but an expression was expected of type "a" = "int"
        This instance of "int" is ambiguous:
        it would escape the scope of its equation
@@ -1234,7 +1236,7 @@ let f (type a b c) (b : bool) (w1 : (a,b) eq) (w2 : (a,int) eq) (x : a) (y : b) 
 Line 4, characters 19-20:
 4 |   if b then x else y
                        ^
-Error: This expression has type "b" = "int"
+Error: The expression "y" has type "b" = "int"
        but an expression was expected of type "a" = "int"
        This instance of "int" is ambiguous:
        it would escape the scope of its equation
@@ -1248,7 +1250,7 @@ let f (type a b c) (b : bool) (w1 : (a,b) eq) (w2 : (a,int) eq) (x : a) (y : b) 
 Line 4, characters 19-20:
 4 |   if b then y else x
                        ^
-Error: This expression has type "a" = "int"
+Error: The expression "x" has type "a" = "int"
        but an expression was expected of type "b" = "int"
        This instance of "int" is ambiguous:
        it would escape the scope of its equation
@@ -1287,7 +1289,7 @@ type (_, _) eq = Refl : ('a, 'a) eq
 Line 7, characters 35-36:
 7 |   if true then fun x -> x + 1 else x
                                        ^
-Error: This expression has type "M.t" = "int -> int"
+Error: The expression "x" has type "M.t" = "int -> int"
        but an expression was expected of type "int -> int"
        This instance of "int -> int" is ambiguous:
        it would escape the scope of its equation

--- a/testsuite/tests/typing-misc-bugs/pr6303_bad.compilers.reference
+++ b/testsuite/tests/typing-misc-bugs/pr6303_bad.compilers.reference
@@ -1,6 +1,6 @@
 File "pr6303_bad.ml", line 11, characters 22-23:
 11 | let r' : string foo = r
                            ^
-Error: The expression "r" has type "int foo"
-       but an expression was expected of type "string foo"
+Error: The value "r" has type "int foo" but an expression was expected of type
+         "string foo"
        Type "int" is not compatible with type "string"

--- a/testsuite/tests/typing-misc-bugs/pr6303_bad.compilers.reference
+++ b/testsuite/tests/typing-misc-bugs/pr6303_bad.compilers.reference
@@ -1,6 +1,6 @@
 File "pr6303_bad.ml", line 11, characters 22-23:
 11 | let r' : string foo = r
                            ^
-Error: This expression has type "int foo"
+Error: The expression "r" has type "int foo"
        but an expression was expected of type "string foo"
        Type "int" is not compatible with type "string"

--- a/testsuite/tests/typing-misc/exp_denom.ml
+++ b/testsuite/tests/typing-misc/exp_denom.ml
@@ -80,3 +80,23 @@ Line 1, characters 18-23:
 Error: This constant has type "string" but an expression was expected of type
          "int"
 |}]
+
+let _ : int = while false do () done
+
+[%%expect {|
+Line 1, characters 14-36:
+1 | let _ : int = while false do () done
+                  ^^^^^^^^^^^^^^^^^^^^^^
+Error: This "while" expression has type "unit"
+       but an expression was expected of type "int"
+|}]
+
+let _ : int = for _ = 1 to 2 do () done
+
+[%%expect {|
+Line 1, characters 14-39:
+1 | let _ : int = for _ = 1 to 2 do () done
+                  ^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This "for" expression has type "unit"
+       but an expression was expected of type "int"
+|}]

--- a/testsuite/tests/typing-misc/exp_denom.ml
+++ b/testsuite/tests/typing-misc/exp_denom.ml
@@ -1,0 +1,82 @@
+(* TEST
+   expect;
+*)
+
+(* This test showcases the various denominations used in type clash errors *)
+
+let f (x : < m : float >) = print_int x#m
+
+[%%expect {|
+Line 1, characters 38-41:
+1 | let f (x : < m : float >) = print_int x#m
+                                          ^^^
+Error: The method call "x#m" has type "float"
+       but an expression was expected of type "int"
+|}]
+
+type r = { f : float }
+
+let f (x : r) = print_int x.f
+
+[%%expect {|
+type r = { f : float; }
+Line 3, characters 26-29:
+3 | let f (x : r) = print_int x.f
+                              ^^^
+Error: The field access "x.f" has type "float"
+       but an expression was expected of type "int"
+|}]
+
+type v = Cons
+
+let _ = print_int Cons
+
+[%%expect {|
+type v = Cons
+Line 3, characters 18-22:
+3 | let _ = print_int Cons
+                      ^^^^
+Error: The constructor "Cons" has type "v" but an expression was expected of type
+         "int"
+|}]
+
+let _ = print_int `Cons
+
+[%%expect {|
+Line 1, characters 18-23:
+1 | let _ = print_int `Cons
+                      ^^^^^
+Error: The constructor "`Cons" has type "[> `Cons ]"
+       but an expression was expected of type "int"
+|}]
+
+let v = 0.
+let _ = print_int v
+
+[%%expect {|
+val v : float = 0.
+Line 2, characters 18-19:
+2 | let _ = print_int v
+                      ^
+Error: The value "v" has type "float" but an expression was expected of type "int"
+|}]
+
+let _ = print_int 0.
+
+[%%expect {|
+Line 1, characters 18-20:
+1 | let _ = print_int 0.
+                      ^^
+Error: The constant "0." has type "float" but an expression was expected of type
+         "int"
+|}]
+
+let _ = print_int "foo"
+
+[%%expect {|
+Line 1, characters 18-23:
+1 | let _ = print_int "foo"
+                      ^^^^^
+Error: This constant has type "string" but an expression was expected of type
+         "int"
+|}]

--- a/testsuite/tests/typing-misc/labels.ml
+++ b/testsuite/tests/typing-misc/labels.ml
@@ -170,7 +170,7 @@ let () = expect_unlabeled labeled
 Line 1, characters 26-33:
 1 | let () = expect_unlabeled labeled
                               ^^^^^^^
-Error: The expression "labeled" has type "x:'a -> unit"
+Error: The value "labeled" has type "x:'a -> unit"
        but an expression was expected of type "unit -> unit"
        The first argument is labeled "x",
        but an unlabeled argument was expected
@@ -181,7 +181,7 @@ let () = expect_labeled unlabeled
 Line 1, characters 24-33:
 1 | let () = expect_labeled unlabeled
                             ^^^^^^^^^
-Error: The expression "unlabeled" has type "'a -> unit"
+Error: The value "unlabeled" has type "'a -> unit"
        but an expression was expected of type "x:'b -> unit"
        A label "x" was expected
 |}]
@@ -191,7 +191,7 @@ let () = expect_labeled wrong_label
 Line 1, characters 24-35:
 1 | let () = expect_labeled wrong_label
                             ^^^^^^^^^^^
-Error: The expression "wrong_label" has type "y:'a -> unit"
+Error: The value "wrong_label" has type "y:'a -> unit"
        but an expression was expected of type "x:'b -> unit"
        Labels "y" and "x" do not match
 |}]

--- a/testsuite/tests/typing-misc/labels.ml
+++ b/testsuite/tests/typing-misc/labels.ml
@@ -170,7 +170,7 @@ let () = expect_unlabeled labeled
 Line 1, characters 26-33:
 1 | let () = expect_unlabeled labeled
                               ^^^^^^^
-Error: This expression has type "x:'a -> unit"
+Error: The expression "labeled" has type "x:'a -> unit"
        but an expression was expected of type "unit -> unit"
        The first argument is labeled "x",
        but an unlabeled argument was expected
@@ -181,7 +181,7 @@ let () = expect_labeled unlabeled
 Line 1, characters 24-33:
 1 | let () = expect_labeled unlabeled
                             ^^^^^^^^^
-Error: This expression has type "'a -> unit"
+Error: The expression "unlabeled" has type "'a -> unit"
        but an expression was expected of type "x:'b -> unit"
        A label "x" was expected
 |}]
@@ -191,7 +191,7 @@ let () = expect_labeled wrong_label
 Line 1, characters 24-35:
 1 | let () = expect_labeled wrong_label
                             ^^^^^^^^^^^
-Error: This expression has type "y:'a -> unit"
+Error: The expression "wrong_label" has type "y:'a -> unit"
        but an expression was expected of type "x:'b -> unit"
        Labels "y" and "x" do not match
 |}]

--- a/testsuite/tests/typing-misc/let_rec_approx.ml
+++ b/testsuite/tests/typing-misc/let_rec_approx.ml
@@ -17,7 +17,7 @@ and g (x : string) = f ()
 Line 1, characters 17-19:
 1 | let rec f () = g 42
                      ^^
-Error: This expression has type "int" but an expression was expected of type
+Error: The expression "42" has type "int" but an expression was expected of type
          "string"
 |}]
 

--- a/testsuite/tests/typing-misc/let_rec_approx.ml
+++ b/testsuite/tests/typing-misc/let_rec_approx.ml
@@ -17,7 +17,7 @@ and g (x : string) = f ()
 Line 1, characters 17-19:
 1 | let rec f () = g 42
                      ^^
-Error: The expression "42" has type "int" but an expression was expected of type
+Error: The constant "42" has type "int" but an expression was expected of type
          "string"
 |}]
 

--- a/testsuite/tests/typing-misc/occur_check.ml
+++ b/testsuite/tests/typing-misc/occur_check.ml
@@ -11,8 +11,8 @@ type 'a t = 'a
 Line 2, characters 42-43:
 2 | let f (g : 'a list -> 'a t -> 'a) s = g s s;;
                                               ^
-Error: The expression "s" has type "'a list"
-       but an expression was expected of type "'a t" = "'a"
+Error: The value "s" has type "'a list" but an expression was expected of type
+         "'a t" = "'a"
        The type variable "'a" occurs inside "'a list"
 |}];;
 
@@ -21,8 +21,8 @@ let f (g : 'a * 'b -> 'a t -> 'a) s = g s s;;
 Line 1, characters 42-43:
 1 | let f (g : 'a * 'b -> 'a t -> 'a) s = g s s;;
                                               ^
-Error: The expression "s" has type "'a * 'b"
-       but an expression was expected of type "'a t" = "'a"
+Error: The value "s" has type "'a * 'b" but an expression was expected of type
+         "'a t" = "'a"
        The type variable "'a" occurs inside "'a * 'b"
 |}];;
 

--- a/testsuite/tests/typing-misc/occur_check.ml
+++ b/testsuite/tests/typing-misc/occur_check.ml
@@ -11,7 +11,7 @@ type 'a t = 'a
 Line 2, characters 42-43:
 2 | let f (g : 'a list -> 'a t -> 'a) s = g s s;;
                                               ^
-Error: This expression has type "'a list"
+Error: The expression "s" has type "'a list"
        but an expression was expected of type "'a t" = "'a"
        The type variable "'a" occurs inside "'a list"
 |}];;
@@ -21,7 +21,7 @@ let f (g : 'a * 'b -> 'a t -> 'a) s = g s s;;
 Line 1, characters 42-43:
 1 | let f (g : 'a * 'b -> 'a t -> 'a) s = g s s;;
                                               ^
-Error: This expression has type "'a * 'b"
+Error: The expression "s" has type "'a * 'b"
        but an expression was expected of type "'a t" = "'a"
        The type variable "'a" occurs inside "'a * 'b"
 |}];;

--- a/testsuite/tests/typing-misc/polyvars.ml
+++ b/testsuite/tests/typing-misc/polyvars.ml
@@ -180,7 +180,7 @@ type t = private [< `A ]
 Line 2, characters 30-31:
 2 | let f: t -> [ `A ] = fun x -> x
                                   ^
-Error: This expression has type "t" but an expression was expected of type
+Error: The expression "x" has type "t" but an expression was expected of type
          "[ `A ]"
        The first variant type is private, it may not allow the tag(s) "`A"
 |}]
@@ -242,7 +242,7 @@ let f (x:[`X of int]) = (x:[`X])
 Line 5, characters 25-26:
 5 | let f (x:[`X of int]) = (x:[`X])
                              ^
-Error: This expression has type "[ `X of int ]"
+Error: The expression "x" has type "[ `X of int ]"
        but an expression was expected of type "[ `X ]"
        Types for tag "`X" are incompatible
 |}]
@@ -253,7 +253,7 @@ let f (x:[`X of int]) = (x:[<`X of & int])
 Line 1, characters 25-26:
 1 | let f (x:[`X of int]) = (x:[<`X of & int])
                              ^
-Error: This expression has type "[ `X of int ]"
+Error: The expression "x" has type "[ `X of int ]"
        but an expression was expected of type "[< `X of & int ]"
        Types for tag "`X" are incompatible
 |}]
@@ -265,7 +265,7 @@ let f (x:[<`X of & int & float]) = (x:[`X])
 Line 3, characters 36-37:
 3 | let f (x:[<`X of & int & float]) = (x:[`X])
                                         ^
-Error: This expression has type "[< `X of & int & float ]"
+Error: The expression "x" has type "[< `X of & int & float ]"
        but an expression was expected of type "[ `X ]"
        Types for tag "`X" are incompatible
 |}]
@@ -282,7 +282,7 @@ val f : ([< `A | `B of string | `R of 'a ] as 'a) -> int = <fun>
 Line 4, characters 30-31:
 4 | let g (x:[`A | `R of rt]) = f x
                                   ^
-Error: This expression has type "[ `A | `R of rt ]"
+Error: The expression "x" has type "[ `A | `R of rt ]"
        but an expression was expected of type "[< `A | `R of 'a ] as 'a"
        Type "rt" = "[ `A | `B of string | `R of rt ]" is not compatible with type
          "[< `A | `R of 'a ] as 'a"

--- a/testsuite/tests/typing-misc/polyvars.ml
+++ b/testsuite/tests/typing-misc/polyvars.ml
@@ -180,8 +180,7 @@ type t = private [< `A ]
 Line 2, characters 30-31:
 2 | let f: t -> [ `A ] = fun x -> x
                                   ^
-Error: The expression "x" has type "t" but an expression was expected of type
-         "[ `A ]"
+Error: The value "x" has type "t" but an expression was expected of type "[ `A ]"
        The first variant type is private, it may not allow the tag(s) "`A"
 |}]
 
@@ -242,7 +241,7 @@ let f (x:[`X of int]) = (x:[`X])
 Line 5, characters 25-26:
 5 | let f (x:[`X of int]) = (x:[`X])
                              ^
-Error: The expression "x" has type "[ `X of int ]"
+Error: The value "x" has type "[ `X of int ]"
        but an expression was expected of type "[ `X ]"
        Types for tag "`X" are incompatible
 |}]
@@ -253,7 +252,7 @@ let f (x:[`X of int]) = (x:[<`X of & int])
 Line 1, characters 25-26:
 1 | let f (x:[`X of int]) = (x:[<`X of & int])
                              ^
-Error: The expression "x" has type "[ `X of int ]"
+Error: The value "x" has type "[ `X of int ]"
        but an expression was expected of type "[< `X of & int ]"
        Types for tag "`X" are incompatible
 |}]
@@ -265,7 +264,7 @@ let f (x:[<`X of & int & float]) = (x:[`X])
 Line 3, characters 36-37:
 3 | let f (x:[<`X of & int & float]) = (x:[`X])
                                         ^
-Error: The expression "x" has type "[< `X of & int & float ]"
+Error: The value "x" has type "[< `X of & int & float ]"
        but an expression was expected of type "[ `X ]"
        Types for tag "`X" are incompatible
 |}]
@@ -282,7 +281,7 @@ val f : ([< `A | `B of string | `R of 'a ] as 'a) -> int = <fun>
 Line 4, characters 30-31:
 4 | let g (x:[`A | `R of rt]) = f x
                                   ^
-Error: The expression "x" has type "[ `A | `R of rt ]"
+Error: The value "x" has type "[ `A | `R of rt ]"
        but an expression was expected of type "[< `A | `R of 'a ] as 'a"
        Type "rt" = "[ `A | `B of string | `R of rt ]" is not compatible with type
          "[< `A | `R of 'a ] as 'a"

--- a/testsuite/tests/typing-misc/pr7103.ml
+++ b/testsuite/tests/typing-misc/pr7103.ml
@@ -23,7 +23,7 @@ let _ = fun (x : a t) -> f x;;
 Line 1, characters 27-28:
 1 | let _ = fun (x : a t) -> f x;;
                                ^
-Error: The expression "x" has type "a t" but an expression was expected of type
+Error: The value "x" has type "a t" but an expression was expected of type
          "< .. > t"
        Type "a" is not compatible with type "< .. >"
 |}];;
@@ -33,7 +33,7 @@ let _ = fun (x : a t) -> g x;;
 Line 1, characters 27-28:
 1 | let _ = fun (x : a t) -> g x;;
                                ^
-Error: The expression "x" has type "a t" but an expression was expected of type
+Error: The value "x" has type "a t" but an expression was expected of type
          "[< `b ] t"
        Type "a" is not compatible with type "[< `b ]"
 |}];;
@@ -43,7 +43,7 @@ let _ = fun (x : a t) -> h x;;
 Line 1, characters 27-28:
 1 | let _ = fun (x : a t) -> h x;;
                                ^
-Error: The expression "x" has type "a t" but an expression was expected of type
+Error: The value "x" has type "a t" but an expression was expected of type
          "[> `b ] t"
        Type "a" is not compatible with type "[> `b ]"
 |}];;

--- a/testsuite/tests/typing-misc/pr7103.ml
+++ b/testsuite/tests/typing-misc/pr7103.ml
@@ -23,7 +23,7 @@ let _ = fun (x : a t) -> f x;;
 Line 1, characters 27-28:
 1 | let _ = fun (x : a t) -> f x;;
                                ^
-Error: This expression has type "a t" but an expression was expected of type
+Error: The expression "x" has type "a t" but an expression was expected of type
          "< .. > t"
        Type "a" is not compatible with type "< .. >"
 |}];;
@@ -33,7 +33,7 @@ let _ = fun (x : a t) -> g x;;
 Line 1, characters 27-28:
 1 | let _ = fun (x : a t) -> g x;;
                                ^
-Error: This expression has type "a t" but an expression was expected of type
+Error: The expression "x" has type "a t" but an expression was expected of type
          "[< `b ] t"
        Type "a" is not compatible with type "[< `b ]"
 |}];;
@@ -43,7 +43,7 @@ let _ = fun (x : a t) -> h x;;
 Line 1, characters 27-28:
 1 | let _ = fun (x : a t) -> h x;;
                                ^
-Error: This expression has type "a t" but an expression was expected of type
+Error: The expression "x" has type "a t" but an expression was expected of type
          "[> `b ] t"
        Type "a" is not compatible with type "[> `b ]"
 |}];;

--- a/testsuite/tests/typing-misc/pr7937.ml
+++ b/testsuite/tests/typing-misc/pr7937.ml
@@ -10,7 +10,7 @@ type 'a r = 'a constraint 'a = [< `X of int & 'a ]
 Line 3, characters 35-39:
 3 | let f: 'a. 'a r -> 'a r = fun x -> true;;
                                        ^^^^
-Error: The expression "\#true" has type "bool"
+Error: The constructor "\#true" has type "bool"
        but an expression was expected of type "([< `X of int & 'a ] as 'a) r"
 |}]
 

--- a/testsuite/tests/typing-misc/pr7937.ml
+++ b/testsuite/tests/typing-misc/pr7937.ml
@@ -10,8 +10,8 @@ type 'a r = 'a constraint 'a = [< `X of int & 'a ]
 Line 3, characters 35-39:
 3 | let f: 'a. 'a r -> 'a r = fun x -> true;;
                                        ^^^^
-Error: This expression has type "bool" but an expression was expected of type
-         "([< `X of int & 'a ] as 'a) r"
+Error: The expression "\#true" has type "bool"
+       but an expression was expected of type "([< `X of int & 'a ] as 'a) r"
 |}]
 
 let g: 'a. 'a r -> 'a r = fun x -> { contents = 0 };;

--- a/testsuite/tests/typing-misc/printing.ml
+++ b/testsuite/tests/typing-misc/printing.ml
@@ -79,7 +79,7 @@ type t = < m : int * 'a > as 'a
 Line 4, characters 32-33:
 4 |   | Refl -> if true then x else y
                                     ^
-Error: This expression has type "a" but an expression was expected of type "t"
+Error: The expression "y" has type "a" but an expression was expected of type "t"
        This instance of "< m : int * 'a > as 'a" is ambiguous:
        it would escape the scope of its equation
 |}]
@@ -94,7 +94,7 @@ type t2 = < m : 'a. 'a * ('a * 'b) > as 'b
 Line 3, characters 22-23:
 3 | let f (x : t1) : t2 = x;;
                           ^
-Error: This expression has type "t1" but an expression was expected of type "t2"
+Error: The expression "x" has type "t1" but an expression was expected of type "t2"
        The method "m" has type "'c. 'c * ('a * < m : 'c. 'b >) as 'b",
        but the expected method type was "'a. 'a * ('a * < m : 'a. 'd >) as 'd"
        The universal variable "'a" would escape its scope

--- a/testsuite/tests/typing-misc/printing.ml
+++ b/testsuite/tests/typing-misc/printing.ml
@@ -79,7 +79,7 @@ type t = < m : int * 'a > as 'a
 Line 4, characters 32-33:
 4 |   | Refl -> if true then x else y
                                     ^
-Error: The expression "y" has type "a" but an expression was expected of type "t"
+Error: The value "y" has type "a" but an expression was expected of type "t"
        This instance of "< m : int * 'a > as 'a" is ambiguous:
        it would escape the scope of its equation
 |}]
@@ -94,7 +94,7 @@ type t2 = < m : 'a. 'a * ('a * 'b) > as 'b
 Line 3, characters 22-23:
 3 | let f (x : t1) : t2 = x;;
                           ^
-Error: The expression "x" has type "t1" but an expression was expected of type "t2"
+Error: The value "x" has type "t1" but an expression was expected of type "t2"
        The method "m" has type "'c. 'c * ('a * < m : 'c. 'b >) as 'b",
        but the expected method type was "'a. 'a * ('a * < m : 'a. 'd >) as 'd"
        The universal variable "'a" would escape its scope

--- a/testsuite/tests/typing-misc/scope_escape.ml
+++ b/testsuite/tests/typing-misc/scope_escape.ml
@@ -9,7 +9,7 @@ val x : '_weak1 list ref = {contents = []}
 Line 2, characters 34-35:
 2 | module M = struct type t let _ = (x : t list ref) end;;
                                       ^
-Error: The expression "x" has type "'weak1 list ref"
+Error: The value "x" has type "'weak1 list ref"
        but an expression was expected of type "t list ref"
        The type constructor "t" would escape its scope
 |}]

--- a/testsuite/tests/typing-misc/scope_escape.ml
+++ b/testsuite/tests/typing-misc/scope_escape.ml
@@ -9,7 +9,7 @@ val x : '_weak1 list ref = {contents = []}
 Line 2, characters 34-35:
 2 | module M = struct type t let _ = (x : t list ref) end;;
                                       ^
-Error: This expression has type "'weak1 list ref"
+Error: The expression "x" has type "'weak1 list ref"
        but an expression was expected of type "t list ref"
        The type constructor "t" would escape its scope
 |}]

--- a/testsuite/tests/typing-misc/unique_names_in_unification.ml
+++ b/testsuite/tests/typing-misc/unique_names_in_unification.ml
@@ -14,7 +14,7 @@ val x : t = A
 Line 5, characters 27-28:
 5 |   let f: t -> t = fun B -> x
                                ^
-Error: The expression "x" has type "t/2" but an expression was expected of type "t"
+Error: The value "x" has type "t/2" but an expression was expected of type "t"
        Line 4, characters 2-12:
          Definition of type "t"
        Line 1, characters 0-10:
@@ -36,8 +36,7 @@ val y : M.t = M.B
 Line 7, characters 34-35:
 7 |   let f : M.t -> M.t = fun M.C -> y
                                       ^
-Error: The expression "y" has type "M/2.t" but an expression was expected of type
-         "M.t"
+Error: The value "y" has type "M/2.t" but an expression was expected of type "M.t"
        Lines 4-6, characters 2-5:
          Definition of module "M"
        Line 1, characters 0-32:
@@ -53,7 +52,7 @@ type t = D
 Line 2, characters 25-26:
 2 | let f: t -> t = fun D -> x;;
                              ^
-Error: The expression "x" has type "t/2" but an expression was expected of type "t"
+Error: The value "x" has type "t/2" but an expression was expected of type "t"
        Line 1, characters 0-10:
          Definition of type "t"
        Line 1, characters 0-10:
@@ -76,8 +75,7 @@ type nonrec ttt = X of ttt
 Line 2, characters 32-33:
 2 | let x: ttt = let rec y = A y in y;;
                                     ^
-Error: The expression "y" has type "ttt/2" but an expression was expected of type
-         "ttt"
+Error: The value "y" has type "ttt/2" but an expression was expected of type "ttt"
        Line 1, characters 0-26:
          Definition of type "ttt"
        Line 2, characters 0-30:

--- a/testsuite/tests/typing-misc/unique_names_in_unification.ml
+++ b/testsuite/tests/typing-misc/unique_names_in_unification.ml
@@ -14,7 +14,7 @@ val x : t = A
 Line 5, characters 27-28:
 5 |   let f: t -> t = fun B -> x
                                ^
-Error: This expression has type "t/2" but an expression was expected of type "t"
+Error: The expression "x" has type "t/2" but an expression was expected of type "t"
        Line 4, characters 2-12:
          Definition of type "t"
        Line 1, characters 0-10:
@@ -36,7 +36,7 @@ val y : M.t = M.B
 Line 7, characters 34-35:
 7 |   let f : M.t -> M.t = fun M.C -> y
                                       ^
-Error: This expression has type "M/2.t" but an expression was expected of type
+Error: The expression "y" has type "M/2.t" but an expression was expected of type
          "M.t"
        Lines 4-6, characters 2-5:
          Definition of module "M"
@@ -53,7 +53,7 @@ type t = D
 Line 2, characters 25-26:
 2 | let f: t -> t = fun D -> x;;
                              ^
-Error: This expression has type "t/2" but an expression was expected of type "t"
+Error: The expression "x" has type "t/2" but an expression was expected of type "t"
        Line 1, characters 0-10:
          Definition of type "t"
        Line 1, characters 0-10:
@@ -76,7 +76,7 @@ type nonrec ttt = X of ttt
 Line 2, characters 32-33:
 2 | let x: ttt = let rec y = A y in y;;
                                     ^
-Error: This expression has type "ttt/2" but an expression was expected of type
+Error: The expression "y" has type "ttt/2" but an expression was expected of type
          "ttt"
        Line 1, characters 0-26:
          Definition of type "ttt"

--- a/testsuite/tests/typing-missing-cmi-3/user.ml
+++ b/testsuite/tests/typing-missing-cmi-3/user.ml
@@ -32,7 +32,7 @@ let () = Middle.(f x)
 Line 1, characters 19-20:
 1 | let () = Middle.(f x)
                        ^
-Error: The expression "x" has type "(module Original.T)"
+Error: The value "x" has type "(module Original.T)"
        but an expression was expected of type
          "(module Original.T with type t = int)"
 |}]

--- a/testsuite/tests/typing-missing-cmi-3/user.ml
+++ b/testsuite/tests/typing-missing-cmi-3/user.ml
@@ -32,7 +32,7 @@ let () = Middle.(f x)
 Line 1, characters 19-20:
 1 | let () = Middle.(f x)
                        ^
-Error: This expression has type "(module Original.T)"
+Error: The expression "x" has type "(module Original.T)"
        but an expression was expected of type
          "(module Original.T with type t = int)"
 |}]

--- a/testsuite/tests/typing-missing-cmi/test.compilers.reference
+++ b/testsuite/tests/typing-missing-cmi/test.compilers.reference
@@ -1,8 +1,7 @@
 File "main.ml", line 1, characters 14-17:
 1 | let _ = A.a = B.b
                   ^^^
-Error: The expression "B.b" has type "M.b" but an expression was expected of type
-         "M.a"
+Error: The value "B.b" has type "M.b" but an expression was expected of type "M.a"
        Type "M.b" is abstract because no corresponding cmi file was found
        in path.
        Type "M.a" is abstract because no corresponding cmi file was found

--- a/testsuite/tests/typing-missing-cmi/test.compilers.reference
+++ b/testsuite/tests/typing-missing-cmi/test.compilers.reference
@@ -1,7 +1,7 @@
 File "main.ml", line 1, characters 14-17:
 1 | let _ = A.a = B.b
                   ^^^
-Error: This expression has type "M.b" but an expression was expected of type
+Error: The expression "B.b" has type "M.b" but an expression was expected of type
          "M.a"
        Type "M.b" is abstract because no corresponding cmi file was found
        in path.

--- a/testsuite/tests/typing-modules-bugs/pr6752_bad.compilers.reference
+++ b/testsuite/tests/typing-modules-bugs/pr6752_bad.compilers.reference
@@ -1,6 +1,6 @@
 File "pr6752_bad.ml", line 26, characters 31-40:
 26 | let q' : Common0.msg Queue.t = Common0.q
                                     ^^^^^^^^^
-Error: This expression has type "'a Queue.t"
+Error: The expression "Common0.q" has type "'a Queue.t"
        but an expression was expected of type "Common0.msg Queue.t"
        The type constructor "Common0.msg" would escape its scope

--- a/testsuite/tests/typing-modules-bugs/pr6752_bad.compilers.reference
+++ b/testsuite/tests/typing-modules-bugs/pr6752_bad.compilers.reference
@@ -1,6 +1,6 @@
 File "pr6752_bad.ml", line 26, characters 31-40:
 26 | let q' : Common0.msg Queue.t = Common0.q
                                     ^^^^^^^^^
-Error: The expression "Common0.q" has type "'a Queue.t"
+Error: The value "Common0.q" has type "'a Queue.t"
        but an expression was expected of type "Common0.msg Queue.t"
        The type constructor "Common0.msg" would escape its scope

--- a/testsuite/tests/typing-modules-bugs/pr6992_bad.compilers.reference
+++ b/testsuite/tests/typing-modules-bugs/pr6992_bad.compilers.reference
@@ -1,6 +1,6 @@
 File "pr6992_bad.ml", line 16, characters 69-71:
 16 |   let uniq (type a) (type b) (Eq : a fix) (Eq : b fix) : (a, b) eq = Eq
                                                                           ^^
-Error: The expression "Eq" has type "(a, a) eq"
+Error: The constructor "Eq" has type "(a, a) eq"
        but an expression was expected of type "(a, b) eq"
        Type "a" is not compatible with type "b"

--- a/testsuite/tests/typing-modules-bugs/pr6992_bad.compilers.reference
+++ b/testsuite/tests/typing-modules-bugs/pr6992_bad.compilers.reference
@@ -1,6 +1,6 @@
 File "pr6992_bad.ml", line 16, characters 69-71:
 16 |   let uniq (type a) (type b) (Eq : a fix) (Eq : b fix) : (a, b) eq = Eq
                                                                           ^^
-Error: This expression has type "(a, a) eq"
+Error: The expression "Eq" has type "(a, a) eq"
        but an expression was expected of type "(a, b) eq"
        Type "a" is not compatible with type "b"

--- a/testsuite/tests/typing-modules/firstclass.ml
+++ b/testsuite/tests/typing-modules/firstclass.ml
@@ -32,8 +32,7 @@ val h : (module S2 with type t = 'a) -> (module S with type t = 'a) = <fun>
 Line 5, characters 3-4:
 5 |   (x : (module S'));; (* fail *)
        ^
-Error: The expression "x" has type
-         "(module S2 with type t = int and type u = bool)"
+Error: The value "x" has type "(module S2 with type t = int and type u = bool)"
        but an expression was expected of type "(module S')"
        Modules do not match:
          S'

--- a/testsuite/tests/typing-modules/firstclass.ml
+++ b/testsuite/tests/typing-modules/firstclass.ml
@@ -32,7 +32,7 @@ val h : (module S2 with type t = 'a) -> (module S with type t = 'a) = <fun>
 Line 5, characters 3-4:
 5 |   (x : (module S'));; (* fail *)
        ^
-Error: This expression has type
+Error: The expression "x" has type
          "(module S2 with type t = int and type u = bool)"
        but an expression was expected of type "(module S')"
        Modules do not match:

--- a/testsuite/tests/typing-objects/Exemples.ml
+++ b/testsuite/tests/typing-objects/Exemples.ml
@@ -207,7 +207,7 @@ let c'' = new color_circle p;;
 Line 1, characters 27-28:
 1 | let c'' = new color_circle p;;
                                ^
-Error: This expression has type "point" but an expression was expected of type
+Error: The expression "p" has type "point" but an expression was expected of type
          "#color_point"
        The first object type has no method "color"
 |}];;
@@ -588,7 +588,7 @@ l#add (c3 :> int_comparable);;
 Line 1, characters 25-27:
 1 | (new sorted_list ())#add c3;;
                              ^^
-Error: This expression has type
+Error: The expression "c3" has type
          "int_comparable3" =
            "< cmp : int_comparable -> int; setx : int -> unit; x : int >"
        but an expression was expected of type

--- a/testsuite/tests/typing-objects/Exemples.ml
+++ b/testsuite/tests/typing-objects/Exemples.ml
@@ -207,7 +207,7 @@ let c'' = new color_circle p;;
 Line 1, characters 27-28:
 1 | let c'' = new color_circle p;;
                                ^
-Error: The expression "p" has type "point" but an expression was expected of type
+Error: The value "p" has type "point" but an expression was expected of type
          "#color_point"
        The first object type has no method "color"
 |}];;
@@ -588,7 +588,7 @@ l#add (c3 :> int_comparable);;
 Line 1, characters 25-27:
 1 | (new sorted_list ())#add c3;;
                              ^^
-Error: The expression "c3" has type
+Error: The value "c3" has type
          "int_comparable3" =
            "< cmp : int_comparable -> int; setx : int -> unit; x : int >"
        but an expression was expected of type

--- a/testsuite/tests/typing-objects/Tests.ml
+++ b/testsuite/tests/typing-objects/Tests.ml
@@ -416,8 +416,8 @@ class c () = object val x = - true val y = -. () end;;
 Line 1, characters 30-34:
 1 | class c () = object val x = - true val y = -. () end;;
                                   ^^^^
-Error: This expression has type "bool" but an expression was expected of type
-         "int"
+Error: The expression "\#true" has type "bool"
+       but an expression was expected of type "int"
 |}];;
 
 class c () = object method f = 1 method g = 1 method h = 1 end;;
@@ -789,7 +789,7 @@ fun (x : 'a t) -> (x : 'a); ();;
 Line 1, characters 19-20:
 1 | fun (x : 'a t) -> (x : 'a); ();;
                        ^
-Error: This expression has type "'a t" but an expression was expected of type
+Error: The expression "x" has type "'a t" but an expression was expected of type
          "'a"
        The type variable "'a" occurs inside "'a t"
 |}];;
@@ -1143,8 +1143,8 @@ val is_empty : <  > -> unit = <fun>
 Line 2, characters 54-58:
 2 | class c = object (self) method private foo = is_empty self end;;
                                                           ^^^^
-Error: This expression has type "< .. >" but an expression was expected of type
-         "<  >"
+Error: The expression "self" has type "< .. >"
+       but an expression was expected of type "<  >"
        Self type cannot be unified with a closed object type
 |}];;
 
@@ -1237,8 +1237,8 @@ let o = object(self) initializer has_foo self end;;
 Line 1, characters 41-45:
 1 | let o = object(self) initializer has_foo self end;;
                                              ^^^^
-Error: This expression has type "<  >" but an expression was expected of type
-         "< foo : int; .. >"
+Error: The expression "self" has type "<  >"
+       but an expression was expected of type "< foo : int; .. >"
        The first object type has no method "foo"
 |}];;
 

--- a/testsuite/tests/typing-objects/Tests.ml
+++ b/testsuite/tests/typing-objects/Tests.ml
@@ -416,7 +416,7 @@ class c () = object val x = - true val y = -. () end;;
 Line 1, characters 30-34:
 1 | class c () = object val x = - true val y = -. () end;;
                                   ^^^^
-Error: The expression "\#true" has type "bool"
+Error: The constructor "\#true" has type "bool"
        but an expression was expected of type "int"
 |}];;
 
@@ -789,8 +789,7 @@ fun (x : 'a t) -> (x : 'a); ();;
 Line 1, characters 19-20:
 1 | fun (x : 'a t) -> (x : 'a); ();;
                        ^
-Error: The expression "x" has type "'a t" but an expression was expected of type
-         "'a"
+Error: The value "x" has type "'a t" but an expression was expected of type "'a"
        The type variable "'a" occurs inside "'a t"
 |}];;
 fun ((x : 'a) | (x : 'a t)) -> ();;
@@ -1143,8 +1142,8 @@ val is_empty : <  > -> unit = <fun>
 Line 2, characters 54-58:
 2 | class c = object (self) method private foo = is_empty self end;;
                                                           ^^^^
-Error: The expression "self" has type "< .. >"
-       but an expression was expected of type "<  >"
+Error: The value "self" has type "< .. >" but an expression was expected of type
+         "<  >"
        Self type cannot be unified with a closed object type
 |}];;
 
@@ -1237,8 +1236,8 @@ let o = object(self) initializer has_foo self end;;
 Line 1, characters 41-45:
 1 | let o = object(self) initializer has_foo self end;;
                                              ^^^^
-Error: The expression "self" has type "<  >"
-       but an expression was expected of type "< foo : int; .. >"
+Error: The value "self" has type "<  >" but an expression was expected of type
+         "< foo : int; .. >"
        The first object type has no method "foo"
 |}];;
 

--- a/testsuite/tests/typing-objects/abstract_rows.ml
+++ b/testsuite/tests/typing-objects/abstract_rows.ml
@@ -11,7 +11,7 @@ type t = private < x : int; .. >
 Line 4, characters 24-25:
 4 | let f (x:t) (y:u) = x = y;;
                             ^
-Error: This expression has type "u" but an expression was expected of type "t"
+Error: The expression "y" has type "u" but an expression was expected of type "t"
        The second object type has an abstract row, it cannot be closed
 |}]
 
@@ -21,6 +21,6 @@ let g (x:u) (y:t) = x = y;;
 Line 1, characters 24-25:
 1 | let g (x:u) (y:t) = x = y;;
                             ^
-Error: This expression has type "t" but an expression was expected of type "u"
+Error: The expression "y" has type "t" but an expression was expected of type "u"
        The first object type has an abstract row, it cannot be closed
 |}]

--- a/testsuite/tests/typing-objects/abstract_rows.ml
+++ b/testsuite/tests/typing-objects/abstract_rows.ml
@@ -11,7 +11,7 @@ type t = private < x : int; .. >
 Line 4, characters 24-25:
 4 | let f (x:t) (y:u) = x = y;;
                             ^
-Error: The expression "y" has type "u" but an expression was expected of type "t"
+Error: The value "y" has type "u" but an expression was expected of type "t"
        The second object type has an abstract row, it cannot be closed
 |}]
 
@@ -21,6 +21,6 @@ let g (x:u) (y:t) = x = y;;
 Line 1, characters 24-25:
 1 | let g (x:u) (y:t) = x = y;;
                             ^
-Error: The expression "y" has type "t" but an expression was expected of type "u"
+Error: The value "y" has type "t" but an expression was expected of type "u"
        The first object type has an abstract row, it cannot be closed
 |}]

--- a/testsuite/tests/typing-objects/dummy.ml
+++ b/testsuite/tests/typing-objects/dummy.ml
@@ -45,7 +45,7 @@ end;;
 Line 16, characters 22-26:
 16 |       inherit child1' self
                            ^^^^
-Error: This expression has type "< child : 'a; previous : 'b option; .. >"
+Error: The expression "self" has type "< child : 'a; previous : 'b option; .. >"
        but an expression was expected of type "'c"
        Self type cannot escape its class
 |}]
@@ -193,7 +193,7 @@ class closes_via_inheritance param =
 Line 3, characters 36-41:
 3 |     inherit parameter_contains_self param
                                         ^^^^^
-Error: This expression has type
+Error: The expression "param" has type
          "< redrawWidget : parameter_contains_self -> unit; .. >"
        but an expression was expected of type
          "< redrawWidget : < invalidate : unit; .. > -> unit; .. >"
@@ -209,7 +209,7 @@ class closes_via_application param =
 Line 3, characters 26-31:
 3 |   parameter_contains_self param;;
                               ^^^^^
-Error: This expression has type
+Error: The expression "param" has type
          "< redrawWidget : parameter_contains_self -> unit; .. >"
        but an expression was expected of type
          "< redrawWidget : < invalidate : unit; .. > -> unit; .. >"
@@ -229,7 +229,8 @@ let escapes_via_inheritance param =
 Line 4, characters 38-43:
 4 |       inherit parameter_contains_self param
                                           ^^^^^
-Error: This expression has type "'a" but an expression was expected of type
+Error: The expression "param" has type "'a"
+       but an expression was expected of type
          "< redrawWidget : < invalidate : unit; .. > -> unit; .. >"
        Self type cannot escape its class
 |}]
@@ -243,7 +244,8 @@ let escapes_via_application param =
 Line 3, characters 38-43:
 3 |     class c = parameter_contains_self param
                                           ^^^^^
-Error: This expression has type "'a" but an expression was expected of type
+Error: The expression "param" has type "'a"
+       but an expression was expected of type
          "< redrawWidget : < invalidate : unit; .. > -> unit; .. >"
        Self type cannot escape its class
 |}]
@@ -256,7 +258,7 @@ let can_close_object_via_inheritance param =
 Line 3, characters 36-41:
 3 |     inherit parameter_contains_self param
                                         ^^^^^
-Error: This expression has type
+Error: The expression "param" has type
          "< redrawWidget : parameter_contains_self -> unit; .. >"
        but an expression was expected of type
          "< redrawWidget : < invalidate : unit; .. > -> unit; .. >"

--- a/testsuite/tests/typing-objects/dummy.ml
+++ b/testsuite/tests/typing-objects/dummy.ml
@@ -45,7 +45,7 @@ end;;
 Line 16, characters 22-26:
 16 |       inherit child1' self
                            ^^^^
-Error: The expression "self" has type "< child : 'a; previous : 'b option; .. >"
+Error: The value "self" has type "< child : 'a; previous : 'b option; .. >"
        but an expression was expected of type "'c"
        Self type cannot escape its class
 |}]
@@ -193,7 +193,7 @@ class closes_via_inheritance param =
 Line 3, characters 36-41:
 3 |     inherit parameter_contains_self param
                                         ^^^^^
-Error: The expression "param" has type
+Error: The value "param" has type
          "< redrawWidget : parameter_contains_self -> unit; .. >"
        but an expression was expected of type
          "< redrawWidget : < invalidate : unit; .. > -> unit; .. >"
@@ -209,7 +209,7 @@ class closes_via_application param =
 Line 3, characters 26-31:
 3 |   parameter_contains_self param;;
                               ^^^^^
-Error: The expression "param" has type
+Error: The value "param" has type
          "< redrawWidget : parameter_contains_self -> unit; .. >"
        but an expression was expected of type
          "< redrawWidget : < invalidate : unit; .. > -> unit; .. >"
@@ -229,8 +229,7 @@ let escapes_via_inheritance param =
 Line 4, characters 38-43:
 4 |       inherit parameter_contains_self param
                                           ^^^^^
-Error: The expression "param" has type "'a"
-       but an expression was expected of type
+Error: The value "param" has type "'a" but an expression was expected of type
          "< redrawWidget : < invalidate : unit; .. > -> unit; .. >"
        Self type cannot escape its class
 |}]
@@ -244,8 +243,7 @@ let escapes_via_application param =
 Line 3, characters 38-43:
 3 |     class c = parameter_contains_self param
                                           ^^^^^
-Error: The expression "param" has type "'a"
-       but an expression was expected of type
+Error: The value "param" has type "'a" but an expression was expected of type
          "< redrawWidget : < invalidate : unit; .. > -> unit; .. >"
        Self type cannot escape its class
 |}]
@@ -258,7 +256,7 @@ let can_close_object_via_inheritance param =
 Line 3, characters 36-41:
 3 |     inherit parameter_contains_self param
                                         ^^^^^
-Error: The expression "param" has type
+Error: The value "param" has type
          "< redrawWidget : parameter_contains_self -> unit; .. >"
        but an expression was expected of type
          "< redrawWidget : < invalidate : unit; .. > -> unit; .. >"

--- a/testsuite/tests/typing-objects/pr6123_bad.ml
+++ b/testsuite/tests/typing-objects/pr6123_bad.ml
@@ -29,7 +29,7 @@ end
 Line 15, characters 50-54:
 15 |       let args = List.map (fun ty -> new argument(self, ty)) args_ty in
                                                        ^^^^
-Error: The expression "self" has type "< arguments : 'a; .. >"
+Error: The value "self" has type "< arguments : 'a; .. >"
        but an expression was expected of type "'b"
        Self type cannot escape its class
 |}]

--- a/testsuite/tests/typing-objects/pr6123_bad.ml
+++ b/testsuite/tests/typing-objects/pr6123_bad.ml
@@ -29,7 +29,7 @@ end
 Line 15, characters 50-54:
 15 |       let args = List.map (fun ty -> new argument(self, ty)) args_ty in
                                                        ^^^^
-Error: This expression has type "< arguments : 'a; .. >"
+Error: The expression "self" has type "< arguments : 'a; .. >"
        but an expression was expected of type "'b"
        Self type cannot escape its class
 |}]

--- a/testsuite/tests/typing-objects/self_cannot_be_closed.ml
+++ b/testsuite/tests/typing-objects/self_cannot_be_closed.ml
@@ -11,7 +11,7 @@ class c = object (self) method private foo = is_empty self end;;
 Line 1, characters 54-58:
 1 | class c = object (self) method private foo = is_empty self end;;
                                                           ^^^^
-Error: The expression "self" has type "< .. >"
-       but an expression was expected of type "<  >"
+Error: The value "self" has type "< .. >" but an expression was expected of type
+         "<  >"
        Self type cannot be unified with a closed object type
 |}]

--- a/testsuite/tests/typing-objects/self_cannot_be_closed.ml
+++ b/testsuite/tests/typing-objects/self_cannot_be_closed.ml
@@ -11,7 +11,7 @@ class c = object (self) method private foo = is_empty self end;;
 Line 1, characters 54-58:
 1 | class c = object (self) method private foo = is_empty self end;;
                                                           ^^^^
-Error: This expression has type "< .. >" but an expression was expected of type
-         "<  >"
+Error: The expression "self" has type "< .. >"
+       but an expression was expected of type "<  >"
        Self type cannot be unified with a closed object type
 |}]

--- a/testsuite/tests/typing-poly/error_messages.ml
+++ b/testsuite/tests/typing-poly/error_messages.ml
@@ -36,7 +36,7 @@ let f (x:<a:'a; b:'a. 'a>) (y:<a:'a;b:'a>) = x = y
 Line 4, characters 49-50:
 4 | let f (x:<a:'a; b:'a. 'a>) (y:<a:'a;b:'a>) = x = y
                                                      ^
-Error: This expression has type "< a : 'a; b : 'a >"
+Error: The expression "y" has type "< a : 'a; b : 'a >"
        but an expression was expected of type "< a : 'a; b : 'a0. 'a0 >"
        The method "b" has type "'a", but the expected method type was "'a0. 'a0"
        The universal variable "'a0" would escape its scope
@@ -91,7 +91,7 @@ let f: 'a. ([> `A ] as 'a) -> [ `A ] = fun x -> x
 Line 1, characters 48-49:
 1 | let f: 'a. ([> `A ] as 'a) -> [ `A ] = fun x -> x
                                                     ^
-Error: This expression has type "[> `A ]"
+Error: The expression "x" has type "[> `A ]"
        but an expression was expected of type "[ `A ]"
        The first variant type is bound to the universal type variable "'a",
        it cannot be closed
@@ -102,8 +102,8 @@ let f: 'a. [ `A ] -> ([> `A ] as 'a) = fun x -> x
 Line 1, characters 48-49:
 1 | let f: 'a. [ `A ] -> ([> `A ] as 'a) = fun x -> x
                                                     ^
-Error: This expression has type "[ `A ]" but an expression was expected of type
-         "[> `A ]"
+Error: The expression "x" has type "[ `A ]"
+       but an expression was expected of type "[> `A ]"
        The second variant type is bound to the universal type variable "'a",
        it cannot be closed
 |}]
@@ -114,7 +114,7 @@ let f: 'a. [ `A | `B ] -> ([> `A ] as 'a) = fun x -> x
 Line 1, characters 53-54:
 1 | let f: 'a. [ `A | `B ] -> ([> `A ] as 'a) = fun x -> x
                                                          ^
-Error: This expression has type "[ `A | `B ]"
+Error: The expression "x" has type "[ `A | `B ]"
        but an expression was expected of type "[> `A ]"
        The second variant type is bound to the universal type variable "'a",
        it cannot be closed
@@ -126,7 +126,7 @@ let f: 'a. [> `A | `B | `C ] -> ([> `A ] as 'a) = fun x -> x
 Line 1, characters 59-60:
 1 | let f: 'a. [> `A | `B | `C ] -> ([> `A ] as 'a) = fun x -> x
                                                                ^
-Error: This expression has type "[> `A | `B | `C ]"
+Error: The expression "x" has type "[> `A | `B | `C ]"
        but an expression was expected of type "[> `A ]"
        The second variant type is bound to the universal type variable "'a",
        it may not allow the tag(s) "`B", "`C"

--- a/testsuite/tests/typing-poly/error_messages.ml
+++ b/testsuite/tests/typing-poly/error_messages.ml
@@ -36,7 +36,7 @@ let f (x:<a:'a; b:'a. 'a>) (y:<a:'a;b:'a>) = x = y
 Line 4, characters 49-50:
 4 | let f (x:<a:'a; b:'a. 'a>) (y:<a:'a;b:'a>) = x = y
                                                      ^
-Error: The expression "y" has type "< a : 'a; b : 'a >"
+Error: The value "y" has type "< a : 'a; b : 'a >"
        but an expression was expected of type "< a : 'a; b : 'a0. 'a0 >"
        The method "b" has type "'a", but the expected method type was "'a0. 'a0"
        The universal variable "'a0" would escape its scope
@@ -91,8 +91,8 @@ let f: 'a. ([> `A ] as 'a) -> [ `A ] = fun x -> x
 Line 1, characters 48-49:
 1 | let f: 'a. ([> `A ] as 'a) -> [ `A ] = fun x -> x
                                                     ^
-Error: The expression "x" has type "[> `A ]"
-       but an expression was expected of type "[ `A ]"
+Error: The value "x" has type "[> `A ]" but an expression was expected of type
+         "[ `A ]"
        The first variant type is bound to the universal type variable "'a",
        it cannot be closed
 |}]
@@ -102,8 +102,8 @@ let f: 'a. [ `A ] -> ([> `A ] as 'a) = fun x -> x
 Line 1, characters 48-49:
 1 | let f: 'a. [ `A ] -> ([> `A ] as 'a) = fun x -> x
                                                     ^
-Error: The expression "x" has type "[ `A ]"
-       but an expression was expected of type "[> `A ]"
+Error: The value "x" has type "[ `A ]" but an expression was expected of type
+         "[> `A ]"
        The second variant type is bound to the universal type variable "'a",
        it cannot be closed
 |}]
@@ -114,7 +114,7 @@ let f: 'a. [ `A | `B ] -> ([> `A ] as 'a) = fun x -> x
 Line 1, characters 53-54:
 1 | let f: 'a. [ `A | `B ] -> ([> `A ] as 'a) = fun x -> x
                                                          ^
-Error: The expression "x" has type "[ `A | `B ]"
+Error: The value "x" has type "[ `A | `B ]"
        but an expression was expected of type "[> `A ]"
        The second variant type is bound to the universal type variable "'a",
        it cannot be closed
@@ -126,7 +126,7 @@ let f: 'a. [> `A | `B | `C ] -> ([> `A ] as 'a) = fun x -> x
 Line 1, characters 59-60:
 1 | let f: 'a. [> `A | `B | `C ] -> ([> `A ] as 'a) = fun x -> x
                                                                ^
-Error: The expression "x" has type "[> `A | `B | `C ]"
+Error: The value "x" has type "[> `A | `B | `C ]"
        but an expression was expected of type "[> `A ]"
        The second variant type is bound to the universal type variable "'a",
        it may not allow the tag(s) "`B", "`C"

--- a/testsuite/tests/typing-poly/poly.ml
+++ b/testsuite/tests/typing-poly/poly.ml
@@ -466,7 +466,7 @@ val f : < m : 'a. 'a -> 'a > -> < m : 'b. 'b -> 'b > = <fun>
 Line 9, characters 41-42:
 9 | let f (x : < m : 'a. 'a -> 'a list >) = (x : < m : 'b. 'b -> 'c >)
                                              ^
-Error: The expression "x" has type "< m : 'b. 'b -> 'b list >"
+Error: The value "x" has type "< m : 'b. 'b -> 'b list >"
        but an expression was expected of type "< m : 'b. 'b -> 'c >"
        The method "m" has type "'b. 'b -> 'b list",
        but the expected method type was "'b. 'b -> 'c"
@@ -590,7 +590,7 @@ val f2 : id -> int * bool = <fun>
 Line 5, characters 24-28:
 5 | let f3 f = f#id 1, f#id true
                             ^^^^
-Error: The expression "\#true" has type "bool"
+Error: The constructor "\#true" has type "bool"
        but an expression was expected of type "int"
 |}];;
 
@@ -1134,7 +1134,7 @@ let f (x : foo') = (x : bar');;
 Line 2, characters 3-4:
 2 |   (x : <m : 'a. 'a * (<m:'b. 'a * <m:'c. 'c * 'bar> > as 'bar) >);;
        ^
-Error: The expression "x" has type "< m : 'a. 'a * < m : 'a * 'b > > as 'b"
+Error: The value "x" has type "< m : 'a. 'a * < m : 'a * 'b > > as 'b"
        but an expression was expected of type
          "< m : 'a. 'a * (< m : 'a * < m : 'c. 'c * 'd > > as 'd) >"
        The method "m" has type
@@ -1157,8 +1157,7 @@ let f x =
 Line 2, characters 3-4:
 2 |   (x : <m : 'b. 'b * ('b * <m : 'c. 'c * ('c * 'bar)>)> as 'bar);;
        ^
-Error: The expression "x" has type
-         "< m : 'b. 'b * ('b * < m : 'c. 'c * 'a > as 'a) >"
+Error: The value "x" has type "< m : 'b. 'b * ('b * < m : 'c. 'c * 'a > as 'a) >"
        but an expression was expected of type
          "< m : 'b. 'b * ('b * < m : 'c. 'c * ('c * 'd) >) > as 'd"
        The method "m" has type "'c. 'c * ('b * < m : 'c. 'e >) as 'e",
@@ -1399,7 +1398,7 @@ type t = { f : 'a. [< `Int of int ] as 'a; }
 Line 4, characters 16-22:
 4 | let zero = {f = `Int 0} ;; (* fails *)
                     ^^^^^^
-Error: This expression has type "[> `Int of int ]"
+Error: This constructor has type "[> `Int of int ]"
        but an expression was expected of type "[< `Int of int ]"
        The second variant type is bound to the universal type variable "'a",
        it may not allow the tag(s) "`Int"
@@ -1572,8 +1571,7 @@ let f (n : < m : 'a 'r. [< `Foo of 'a & int | `Bar] as 'r >) =
 Line 2, characters 3-4:
 2 |   (n : < m : 'b 'r. [< `Foo of int & 'b | `Bar] as 'r >)
        ^
-Error: The expression "n" has type
-         "< m : 'a 'c. [< `Bar | `Foo of 'a & int ] as 'c >"
+Error: The value "n" has type "< m : 'a 'c. [< `Bar | `Foo of 'a & int ] as 'c >"
        but an expression was expected of type
          "< m : 'b 'd. [< `Bar | `Foo of int & 'b ] as 'd >"
        Types for tag "`Foo" are incompatible
@@ -1595,8 +1593,8 @@ let f b (x: 'x) =
 Line 3, characters 19-22:
 3 |   if b then x else M.A;;
                        ^^^
-Error: The expression "M.A" has type "M.t" but an expression was expected of type
-         "'x"
+Error: The constructor "M.A" has type "M.t"
+       but an expression was expected of type "'x"
        The type constructor "M.t" would escape its scope
 |}];;
 
@@ -1892,7 +1890,7 @@ let f (x : u) = (x : v)
 Line 1, characters 17-18:
 1 | let f (x : u) = (x : v)
                      ^
-Error: The expression "x" has type "u" but an expression was expected of type "v"
+Error: The value "x" has type "u" but an expression was expected of type "v"
        The method "m" has type "'a s list * < m : 'b > as 'b",
        but the expected method type was "'a. 'a s list * < m : 'a. 'c > as 'c"
        The universal variable "'a" would escape its scope

--- a/testsuite/tests/typing-poly/poly.ml
+++ b/testsuite/tests/typing-poly/poly.ml
@@ -466,7 +466,7 @@ val f : < m : 'a. 'a -> 'a > -> < m : 'b. 'b -> 'b > = <fun>
 Line 9, characters 41-42:
 9 | let f (x : < m : 'a. 'a -> 'a list >) = (x : < m : 'b. 'b -> 'c >)
                                              ^
-Error: This expression has type "< m : 'b. 'b -> 'b list >"
+Error: The expression "x" has type "< m : 'b. 'b -> 'b list >"
        but an expression was expected of type "< m : 'b. 'b -> 'c >"
        The method "m" has type "'b. 'b -> 'b list",
        but the expected method type was "'b. 'b -> 'c"
@@ -590,8 +590,8 @@ val f2 : id -> int * bool = <fun>
 Line 5, characters 24-28:
 5 | let f3 f = f#id 1, f#id true
                             ^^^^
-Error: This expression has type "bool" but an expression was expected of type
-         "int"
+Error: The expression "\#true" has type "bool"
+       but an expression was expected of type "int"
 |}];;
 
 class c = object
@@ -1134,7 +1134,7 @@ let f (x : foo') = (x : bar');;
 Line 2, characters 3-4:
 2 |   (x : <m : 'a. 'a * (<m:'b. 'a * <m:'c. 'c * 'bar> > as 'bar) >);;
        ^
-Error: This expression has type "< m : 'a. 'a * < m : 'a * 'b > > as 'b"
+Error: The expression "x" has type "< m : 'a. 'a * < m : 'a * 'b > > as 'b"
        but an expression was expected of type
          "< m : 'a. 'a * (< m : 'a * < m : 'c. 'c * 'd > > as 'd) >"
        The method "m" has type
@@ -1157,7 +1157,7 @@ let f x =
 Line 2, characters 3-4:
 2 |   (x : <m : 'b. 'b * ('b * <m : 'c. 'c * ('c * 'bar)>)> as 'bar);;
        ^
-Error: This expression has type
+Error: The expression "x" has type
          "< m : 'b. 'b * ('b * < m : 'c. 'c * 'a > as 'a) >"
        but an expression was expected of type
          "< m : 'b. 'b * ('b * < m : 'c. 'c * ('c * 'd) >) > as 'd"
@@ -1572,7 +1572,7 @@ let f (n : < m : 'a 'r. [< `Foo of 'a & int | `Bar] as 'r >) =
 Line 2, characters 3-4:
 2 |   (n : < m : 'b 'r. [< `Foo of int & 'b | `Bar] as 'r >)
        ^
-Error: This expression has type
+Error: The expression "n" has type
          "< m : 'a 'c. [< `Bar | `Foo of 'a & int ] as 'c >"
        but an expression was expected of type
          "< m : 'b 'd. [< `Bar | `Foo of int & 'b ] as 'd >"
@@ -1595,7 +1595,8 @@ let f b (x: 'x) =
 Line 3, characters 19-22:
 3 |   if b then x else M.A;;
                        ^^^
-Error: This expression has type "M.t" but an expression was expected of type "'x"
+Error: The expression "M.A" has type "M.t" but an expression was expected of type
+         "'x"
        The type constructor "M.t" would escape its scope
 |}];;
 
@@ -1891,7 +1892,7 @@ let f (x : u) = (x : v)
 Line 1, characters 17-18:
 1 | let f (x : u) = (x : v)
                      ^
-Error: This expression has type "u" but an expression was expected of type "v"
+Error: The expression "x" has type "u" but an expression was expected of type "v"
        The method "m" has type "'a s list * < m : 'b > as 'b",
        but the expected method type was "'a. 'a s list * < m : 'a. 'c > as 'c"
        The universal variable "'a" would escape its scope

--- a/testsuite/tests/typing-poly/pr9603.ml
+++ b/testsuite/tests/typing-poly/pr9603.ml
@@ -25,7 +25,7 @@ let foo :
 Line 4, characters 11-12:
 4 | = fun x -> x
                ^
-Error: This expression has type
+Error: The expression "x" has type
          "< m : 'left 'right. < left : 'left; right : 'right > pair >"
        but an expression was expected of type
          "< m : 'left 'right. < left : 'left; right : 'right > pair >"

--- a/testsuite/tests/typing-poly/pr9603.ml
+++ b/testsuite/tests/typing-poly/pr9603.ml
@@ -25,7 +25,7 @@ let foo :
 Line 4, characters 11-12:
 4 | = fun x -> x
                ^
-Error: The expression "x" has type
+Error: The value "x" has type
          "< m : 'left 'right. < left : 'left; right : 'right > pair >"
        but an expression was expected of type
          "< m : 'left 'right. < left : 'left; right : 'right > pair >"

--- a/testsuite/tests/typing-polyvariants-bugs-2/pr3918c.compilers.reference
+++ b/testsuite/tests/typing-polyvariants-bugs-2/pr3918c.compilers.reference
@@ -1,5 +1,5 @@
 File "pr3918c.ml", line 24, characters 11-12:
 24 | let f x = (x : 'a vlist :> 'b vlist)
                 ^
-Error: This expression has type "'b Pr3918b.vlist"
+Error: The value "x" has type "'b Pr3918b.vlist"
        but an expression was expected of type "'b Pr3918b.vlist"

--- a/testsuite/tests/typing-polyvariants-bugs/pr5057a_bad.compilers.reference
+++ b/testsuite/tests/typing-polyvariants-bugs/pr5057a_bad.compilers.reference
@@ -1,6 +1,6 @@
 File "pr5057a_bad.ml", line 14, characters 48-49:
 14 |   let _ = match flag with `A -> T.mem | `B r -> r in
                                                      ^
-Error: This expression has type "'a" but an expression was expected of type
+Error: The expression "r" has type "'a" but an expression was expected of type
          "int -> T.t -> bool"
        The type constructor "T.t" would escape its scope

--- a/testsuite/tests/typing-polyvariants-bugs/pr5057a_bad.compilers.reference
+++ b/testsuite/tests/typing-polyvariants-bugs/pr5057a_bad.compilers.reference
@@ -1,6 +1,6 @@
 File "pr5057a_bad.ml", line 14, characters 48-49:
 14 |   let _ = match flag with `A -> T.mem | `B r -> r in
                                                      ^
-Error: The expression "r" has type "'a" but an expression was expected of type
+Error: The value "r" has type "'a" but an expression was expected of type
          "int -> T.t -> bool"
        The type constructor "T.t" would escape its scope

--- a/testsuite/tests/typing-private/private.compilers.principal.reference
+++ b/testsuite/tests/typing-private/private.compilers.principal.reference
@@ -3,7 +3,7 @@ module F0 : sig type t = private int end
 Line 2, characters 20-21:
 2 | let f (x : F0.t) = (x : Foobar.t);; (* fails *)
                         ^
-Error: The expression "x" has type "F0.t" but an expression was expected of type
+Error: The value "x" has type "F0.t" but an expression was expected of type
          "Foobar.t"
 module F = Foobar
 val f : F.t -> Foobar.t = <fun>
@@ -13,8 +13,7 @@ module M2 : sig type t = private < m : int; .. > end
 Line 1, characters 19-20:
 1 | fun (x : M1.t) -> (x : M2.t);; (* fails *)
                        ^
-Error: The expression "x" has type "M1.t" but an expression was expected of type
-         "M2.t"
+Error: The value "x" has type "M1.t" but an expression was expected of type "M2.t"
 module M3 : sig type t = private M1.t end
 - : M3.t -> M1.t = <fun>
 - : M3.t -> M.t = <fun>

--- a/testsuite/tests/typing-private/private.compilers.principal.reference
+++ b/testsuite/tests/typing-private/private.compilers.principal.reference
@@ -3,7 +3,7 @@ module F0 : sig type t = private int end
 Line 2, characters 20-21:
 2 | let f (x : F0.t) = (x : Foobar.t);; (* fails *)
                         ^
-Error: This expression has type "F0.t" but an expression was expected of type
+Error: The expression "x" has type "F0.t" but an expression was expected of type
          "Foobar.t"
 module F = Foobar
 val f : F.t -> Foobar.t = <fun>
@@ -13,7 +13,7 @@ module M2 : sig type t = private < m : int; .. > end
 Line 1, characters 19-20:
 1 | fun (x : M1.t) -> (x : M2.t);; (* fails *)
                        ^
-Error: This expression has type "M1.t" but an expression was expected of type
+Error: The expression "x" has type "M1.t" but an expression was expected of type
          "M2.t"
 module M3 : sig type t = private M1.t end
 - : M3.t -> M1.t = <fun>

--- a/testsuite/tests/typing-private/private.compilers.reference
+++ b/testsuite/tests/typing-private/private.compilers.reference
@@ -3,7 +3,7 @@ module F0 : sig type t = private int end
 Line 2, characters 20-21:
 2 | let f (x : F0.t) = (x : Foobar.t);; (* fails *)
                         ^
-Error: The expression "x" has type "F0.t" but an expression was expected of type
+Error: The value "x" has type "F0.t" but an expression was expected of type
          "Foobar.t"
 module F = Foobar
 val f : F.t -> Foobar.t = <fun>
@@ -13,8 +13,7 @@ module M2 : sig type t = private < m : int; .. > end
 Line 1, characters 19-20:
 1 | fun (x : M1.t) -> (x : M2.t);; (* fails *)
                        ^
-Error: The expression "x" has type "M1.t" but an expression was expected of type
-         "M2.t"
+Error: The value "x" has type "M1.t" but an expression was expected of type "M2.t"
 module M3 : sig type t = private M1.t end
 - : M3.t -> M1.t = <fun>
 - : M3.t -> M.t = <fun>

--- a/testsuite/tests/typing-private/private.compilers.reference
+++ b/testsuite/tests/typing-private/private.compilers.reference
@@ -3,7 +3,7 @@ module F0 : sig type t = private int end
 Line 2, characters 20-21:
 2 | let f (x : F0.t) = (x : Foobar.t);; (* fails *)
                         ^
-Error: This expression has type "F0.t" but an expression was expected of type
+Error: The expression "x" has type "F0.t" but an expression was expected of type
          "Foobar.t"
 module F = Foobar
 val f : F.t -> Foobar.t = <fun>
@@ -13,7 +13,7 @@ module M2 : sig type t = private < m : int; .. > end
 Line 1, characters 19-20:
 1 | fun (x : M1.t) -> (x : M2.t);; (* fails *)
                        ^
-Error: This expression has type "M1.t" but an expression was expected of type
+Error: The expression "x" has type "M1.t" but an expression was expected of type
          "M2.t"
 module M3 : sig type t = private M1.t end
 - : M3.t -> M1.t = <fun>

--- a/testsuite/tests/typing-rectypes-bugs/pr6174_bad.compilers.reference
+++ b/testsuite/tests/typing-rectypes-bugs/pr6174_bad.compilers.reference
@@ -1,5 +1,5 @@
 File "pr6174_bad.ml", line 11, characters 24-25:
 11 |  fun C k -> k (fun x -> x);;
                              ^
-Error: This expression has type "$0" but an expression was expected of type
+Error: The expression "x" has type "$0" but an expression was expected of type
          "$1" = "($2 -> $1) -> $1"

--- a/testsuite/tests/typing-rectypes-bugs/pr6174_bad.compilers.reference
+++ b/testsuite/tests/typing-rectypes-bugs/pr6174_bad.compilers.reference
@@ -1,5 +1,5 @@
 File "pr6174_bad.ml", line 11, characters 24-25:
 11 |  fun C k -> k (fun x -> x);;
                              ^
-Error: The expression "x" has type "$0" but an expression was expected of type
+Error: The value "x" has type "$0" but an expression was expected of type
          "$1" = "($2 -> $1) -> $1"

--- a/testsuite/tests/typing-short-paths/errors.ml
+++ b/testsuite/tests/typing-short-paths/errors.ml
@@ -51,8 +51,7 @@ type pair = Pair : 'a ty * 'a -> pair
 Line 9, characters 22-23:
 9 |   | Pair (Char, x) -> x + 1
                           ^
-Error: The expression "x" has type "$a" but an expression was expected of type
-         "int"
+Error: The value "x" has type "$a" but an expression was expected of type "int"
        Hint: "$a" is an existential type bound by the constructor "Pair".
 |}]
 
@@ -69,7 +68,7 @@ type pair = Pair : 'a ty * 'a -> pair
 Line 7, characters 35-36:
 7 |   | Pair (Char, x) -> if true then x else 'd'
                                        ^
-Error: The expression "x" has type "$a" but an expression was expected of type "'a"
+Error: The value "x" has type "$a" but an expression was expected of type "'a"
        This instance of "$a" is ambiguous:
        it would escape the scope of its equation
        Hint: "$a" is an existential type bound by the constructor "Pair".

--- a/testsuite/tests/typing-short-paths/errors.ml
+++ b/testsuite/tests/typing-short-paths/errors.ml
@@ -51,7 +51,8 @@ type pair = Pair : 'a ty * 'a -> pair
 Line 9, characters 22-23:
 9 |   | Pair (Char, x) -> x + 1
                           ^
-Error: This expression has type "$a" but an expression was expected of type "int"
+Error: The expression "x" has type "$a" but an expression was expected of type
+         "int"
        Hint: "$a" is an existential type bound by the constructor "Pair".
 |}]
 
@@ -68,7 +69,7 @@ type pair = Pair : 'a ty * 'a -> pair
 Line 7, characters 35-36:
 7 |   | Pair (Char, x) -> if true then x else 'd'
                                        ^
-Error: This expression has type "$a" but an expression was expected of type "'a"
+Error: The expression "x" has type "$a" but an expression was expected of type "'a"
        This instance of "$a" is ambiguous:
        it would escape the scope of its equation
        Hint: "$a" is an existential type bound by the constructor "Pair".

--- a/testsuite/tests/typing-short-paths/short-paths.compilers.reference
+++ b/testsuite/tests/typing-short-paths/short-paths.compilers.reference
@@ -69,7 +69,7 @@ val x : 'a Int.Map.t = <abstr>
 Line 1, characters 8-9:
 1 | let y = x + x ;;
             ^
-Error: This expression has type "'a Int.Map.t"
+Error: The expression "x" has type "'a Int.Map.t"
        but an expression was expected of type "int"
 module M : sig type t = A type u = C end
 module N : sig type t = B end

--- a/testsuite/tests/typing-short-paths/short-paths.compilers.reference
+++ b/testsuite/tests/typing-short-paths/short-paths.compilers.reference
@@ -69,7 +69,7 @@ val x : 'a Int.Map.t = <abstr>
 Line 1, characters 8-9:
 1 | let y = x + x ;;
             ^
-Error: The expression "x" has type "'a Int.Map.t"
+Error: The value "x" has type "'a Int.Map.t"
        but an expression was expected of type "int"
 module M : sig type t = A type u = C end
 module N : sig type t = B end

--- a/testsuite/tests/typing-typeparam/newtype.ocaml.reference
+++ b/testsuite/tests/typing-typeparam/newtype.ocaml.reference
@@ -8,11 +8,11 @@ abc,xyz
 Line 2, characters 32-33:
 2 | let f x (type a) (y : a) = (x = y);; (* Fails *)
                                     ^
-Error: This expression has type "a" but an expression was expected of type "'a"
+Error: The expression "y" has type "a" but an expression was expected of type "'a"
        The type constructor "a" would escape its scope
 Line 3, characters 53-54:
 3 |   method n : 'a -> 'a = fun (type g) (x:g) -> self#m x
                                                          ^
-Error: This expression has type "g" but an expression was expected of type "'a"
+Error: The expression "x" has type "g" but an expression was expected of type "'a"
        The type constructor "g" would escape its scope
 

--- a/testsuite/tests/typing-typeparam/newtype.ocaml.reference
+++ b/testsuite/tests/typing-typeparam/newtype.ocaml.reference
@@ -8,11 +8,11 @@ abc,xyz
 Line 2, characters 32-33:
 2 | let f x (type a) (y : a) = (x = y);; (* Fails *)
                                     ^
-Error: The expression "y" has type "a" but an expression was expected of type "'a"
+Error: The value "y" has type "a" but an expression was expected of type "'a"
        The type constructor "a" would escape its scope
 Line 3, characters 53-54:
 3 |   method n : 'a -> 'a = fun (type g) (x:g) -> self#m x
                                                          ^
-Error: The expression "x" has type "g" but an expression was expected of type "'a"
+Error: The value "x" has type "g" but an expression was expected of type "'a"
        The type constructor "g" would escape its scope
 

--- a/testsuite/tests/typing-warnings/records.ml
+++ b/testsuite/tests/typing-warnings/records.ml
@@ -106,7 +106,7 @@ The first one was selected. Please disambiguate if this is wrong.
 Line 3, characters 35-36:
 3 |   let f r = match r with {x; y} -> y + y
                                        ^
-Error: This expression has type "bool" but an expression was expected of type
+Error: The expression "y" has type "bool" but an expression was expected of type
          "int"
 |}]
 

--- a/testsuite/tests/typing-warnings/records.ml
+++ b/testsuite/tests/typing-warnings/records.ml
@@ -106,8 +106,7 @@ The first one was selected. Please disambiguate if this is wrong.
 Line 3, characters 35-36:
 3 |   let f r = match r with {x; y} -> y + y
                                        ^
-Error: The expression "y" has type "bool" but an expression was expected of type
-         "int"
+Error: The value "y" has type "bool" but an expression was expected of type "int"
 |}]
 
 module F2 = struct

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -111,7 +111,7 @@ type error =
   | Orpat_vars of Ident.t * Ident.t list
   | Expr_type_clash of
       Errortrace.unification_error * type_forcing_context option
-      * Parsetree.expression_desc option
+      * Parsetree.expression option
   | Function_arity_type_clash of
       { syntactic_arity :  int;
         type_constraint : type_expr;
@@ -3161,14 +3161,14 @@ let name_cases default lst =
 
 (* Typing of expressions *)
 
-(** [sdesc_for_hint] is used by error messages to report literals in their
+(** [sexp_for_hint] is used by error messages to report literals in their
     original formatting *)
-let unify_exp ?sdesc_for_hint env exp expected_ty =
+let unify_exp ~sexp env exp expected_ty =
   let loc = proper_exp_loc exp in
   try
     unify_exp_types loc env exp.exp_type expected_ty
   with Error(loc, env, Expr_type_clash(err, tfc, None)) ->
-    raise (Error(loc, env, Expr_type_clash(err, tfc, sdesc_for_hint)))
+    raise (Error(loc, env, Expr_type_clash(err, tfc, Some sexp)))
 
 (* If [is_inferred e] is true, [e] will be typechecked without using
    the "expected type" provided by the context. *)
@@ -3313,16 +3313,15 @@ and type_expect_
     env sexp ty_expected_explained =
   let { ty = ty_expected; explanation } = ty_expected_explained in
   let loc = sexp.pexp_loc in
-  let desc = sexp.pexp_desc in
   (* Record the expression type before unifying it with the expected type *)
   let with_explanation = with_explanation explanation in
   (* Unify the result with [ty_expected], enforcing the current level *)
   let rue exp =
     with_explanation (fun () ->
-      unify_exp ~sdesc_for_hint:desc env (re exp) (instance ty_expected));
+      unify_exp ~sexp env (re exp) (instance ty_expected));
     exp
   in
-  match desc with
+  match sexp.pexp_desc with
   | Pexp_ident lid ->
       let path, desc = type_ident env ~recarg lid in
       let exp_desc =
@@ -3455,7 +3454,7 @@ and type_expect_
         end
         ~before_generalize:(fun (_pat_exp_list, body, new_env) ->
           (* The "body" component of the scope escape check. *)
-          unify_exp new_env body (newvar ()))
+          unify_exp ~sexp new_env body (newvar ()))
       in
       re {
         exp_desc = Texp_let(rec_flag, pat_exp_list, body);
@@ -3653,7 +3652,7 @@ and type_expect_
         exp_attributes = sexp.pexp_attributes;
         exp_env = env }
   | Pexp_construct(lid, sarg) ->
-      type_construct env loc lid sarg ty_expected_explained sexp.pexp_attributes
+      type_construct env ~sexp lid sarg ty_expected_explained
   | Pexp_variant(l, sarg) ->
       (* Keep sharing *)
       let ty_expected1 = protect_expansion env ty_expected in
@@ -3842,7 +3841,7 @@ and type_expect_
         type_label_access env srecord Env.Projection lid
       in
       let (_, ty_arg, ty_res) = instance_label ~fixed:false label in
-      unify_exp env record ty_res;
+      unify_exp ~sexp env record ty_res;
       rue {
         exp_desc = Texp_field(record, lid, label);
         exp_loc = loc; exp_extra = [];
@@ -3856,7 +3855,7 @@ and type_expect_
         if expected_type = None then newvar () else record.exp_type in
       let (label_loc, label, newval) =
         type_label_exp false env loc ty_record (lid, label, snewval) in
-      unify_exp env record ty_record;
+      unify_exp ~sexp env record ty_record;
       if label.lbl_mut = Immutable then
         raise(Error(loc, env, Label_not_mutable lid.txt));
       rue {
@@ -3895,7 +3894,7 @@ and type_expect_
           let ifso = type_expect env sifso ty_expected_explained in
           let ifnot = type_expect env sifnot ty_expected_explained in
           (* Keep sharing *)
-          unify_exp env ifnot ifso.exp_type;
+          unify_exp ~sexp env ifnot ifso.exp_type;
           re {
             exp_desc = Texp_ifthenelse(cond, ifso, Some ifnot);
             exp_loc = loc; exp_extra = [];
@@ -4228,7 +4227,7 @@ and type_expect_
         | Tvar _ ->
             let exp = type_exp env sbody in
             let exp = {exp with exp_type = newty (Tpoly (exp.exp_type, []))} in
-            unify_exp env exp ty;
+            unify_exp ~sexp env exp ty;
             exp
         | _ -> assert false
       in
@@ -5207,7 +5206,7 @@ and type_argument ?explanation ?recarg env sarg ty_expected' ty_expected =
       let args, ty_fun', simple_res = make_args [] texp.exp_type
       and texp = {texp with exp_type = instance texp.exp_type} in
       if not (simple_res || safe_expect) then begin
-        unify_exp env texp ty_expected;
+        unify_exp ~sexp:sarg env texp ty_expected;
         texp
       end else begin
       let warn = !Clflags.principal &&
@@ -5218,7 +5217,7 @@ and type_argument ?explanation ?recarg env sarg ty_expected' ty_expected =
           Tarrow(Nolabel,ty_arg,ty_res,_) -> ty_arg, ty_res
         | _ -> assert false
       in
-      unify_exp env {texp with exp_type = ty_fun} ty_expected;
+      unify_exp ~sexp:sarg env {texp with exp_type = ty_fun} ty_expected;
       if args = [] then texp else
       (* eta-expand to avoid side effects *)
       let var_pair name ty =
@@ -5278,7 +5277,7 @@ and type_argument ?explanation ?recarg env sarg ty_expected' ty_expected =
   | None ->
       let texp = type_expect ?recarg env sarg
         (mk_expected ?explanation ty_expected') in
-      unify_exp env texp ty_expected;
+      unify_exp ~sexp:sarg env texp ty_expected;
       texp
 
 and type_application env funct sargs =
@@ -5343,7 +5342,7 @@ and type_application env funct sargs =
     let arg () =
       let arg = type_expect env sarg (mk_expected ty_arg) in
       if is_optional lbl then
-        unify_exp env arg (type_option(newvar()));
+        unify_exp ~sexp:sarg env arg (type_option(newvar()));
       arg
     in
     (ty_res, (lbl, Some (arg, Some sarg.pexp_loc)) :: typed_args)
@@ -5486,7 +5485,7 @@ and type_application env funct sargs =
       let ty = funct.exp_type in
       type_args [] ty (instance ty) sargs
 
-and type_construct env loc lid sarg ty_expected_explained attrs =
+and type_construct env ~sexp lid sarg ty_expected_explained =
   let { ty = ty_expected; explanation } = ty_expected_explained in
   let expected_type =
     match extract_concrete_variant env ty_expected with
@@ -5497,7 +5496,7 @@ and type_construct env loc lid sarg ty_expected_explained attrs =
         let srt = wrong_kind_sort_of_constructor lid.txt in
         let ctx = Expression explanation in
         let error = Wrong_expected_kind(srt, ctx, ty_expected) in
-        raise (Error (loc, env, error))
+        raise (Error (sexp.pexp_loc, env, error))
   in
   let constrs =
     Env.lookup_all_constructors ~loc:lid.loc Env.Positive lid.txt env
@@ -5511,12 +5510,14 @@ and type_construct env loc lid sarg ty_expected_explained attrs =
     match sarg with
       None -> []
     | Some {pexp_desc = Pexp_tuple sel} when
-        constr.cstr_arity > 1 || Builtin_attributes.explicit_arity attrs
+        constr.cstr_arity > 1
+        || Builtin_attributes.explicit_arity sexp.pexp_attributes
       -> sel
     | Some se -> [se] in
   if List.length sargs <> constr.cstr_arity then
-    raise(Error(loc, env, Constructor_arity_mismatch
-                            (lid.txt, constr.cstr_arity, List.length sargs)));
+    raise(Error(sexp.pexp_loc, env,
+                Constructor_arity_mismatch
+                  (lid.txt, constr.cstr_arity, List.length sargs)));
   let separate = !Clflags.principal || Env.has_local_constraints env in
   let ty_args, ty_res, texp =
     with_local_level_generalize_structure_if separate begin fun () ->
@@ -5528,15 +5529,15 @@ and type_construct env loc lid sarg ty_expected_explained attrs =
           let texp =
             re {
             exp_desc = Texp_construct(lid, constr, []);
-            exp_loc = loc; exp_extra = [];
+            exp_loc = sexp.pexp_loc; exp_extra = [];
             exp_type = ty_res;
-            exp_attributes = attrs;
+            exp_attributes = sexp.pexp_attributes;
             exp_env = env } in
           (ty_args, ty_res, texp)
         end
       in
       with_explanation explanation (fun () ->
-        unify_exp env {texp with exp_type = instance ty_res}
+        unify_exp ~sexp env {texp with exp_type = instance ty_res}
           (instance ty_expected));
       (ty_args, ty_res, texp)
     end
@@ -5547,7 +5548,7 @@ and type_construct env loc lid sarg ty_expected_explained attrs =
     | _ -> assert false
   in
   let texp = {texp with exp_type = ty_res} in
-  if not separate then unify_exp env texp (instance ty_expected);
+  if not separate then unify_exp ~sexp env texp (instance ty_expected);
   let recarg =
     match constr.cstr_inlined with
     | None -> Rejected
@@ -5558,7 +5559,7 @@ and type_construct env loc lid sarg ty_expected_explained attrs =
             Pexp_record (_, (Some {pexp_desc = Pexp_ident _}| None))}] ->
         Required
       | _ ->
-        raise (Error(loc, env, Inlined_record_expected))
+        raise (Error(sexp.pexp_loc, env, Inlined_record_expected))
       end
   in
   let args =
@@ -5567,9 +5568,9 @@ and type_construct env loc lid sarg ty_expected_explained attrs =
   if constr.cstr_private = Private then
     begin match constr.cstr_tag with
     | Cstr_extension _ ->
-        raise(Error(loc, env, Private_constructor (constr, ty_res)))
+        raise(Error(sexp.pexp_loc, env, Private_constructor (constr, ty_res)))
     | Cstr_constant _ | Cstr_block _ | Cstr_unboxed ->
-        raise (Error(loc, env, Private_type ty_res));
+        raise (Error(sexp.pexp_loc, env, Private_type ty_res));
     end;
   (* NOTE: shouldn't we call "re" on this final expression? -- AF *)
   { texp with
@@ -5606,7 +5607,7 @@ and type_statement ?explanation env sexp =
     if !Clflags.strict_sequence then
       let expected_ty = instance Predef.type_unit in
       with_explanation explanation (fun () ->
-        unify_exp env exp expected_ty)
+        unify_exp ~sexp env exp expected_ty)
     else begin
       check_partial_application ~statement:true exp;
       enforce_current_level env ty
@@ -6421,6 +6422,23 @@ let type_clash_of_trace trace =
     | _ -> None
   ))
 
+(** Implements the "This expression" message, printing the expression if it
+    should be according to {!Parsetree.Doc.nominal_exp}. *)
+let report_this_pexp_has_type denom ppf exp =
+  let denom ppf =
+    match denom with
+    | Some d -> fprintf ppf "%s" d
+    | None -> fprintf ppf "expression"
+  in
+  let nexp = Option.bind exp Pprintast.Doc.nominal_exp in
+  match nexp with
+  | Some nexp ->
+      fprintf ppf "The %t %a has type" denom (Style.as_inline_code pp_doc) nexp
+  | _ -> fprintf ppf "This %t has type" denom
+
+let report_this_texp_has_type denom ppf texp =
+  report_this_pexp_has_type denom ppf (Some (Untypeast.untype_expression texp))
+
 (* Hint on type error on integer literals
    To avoid confusion, it is disabled on float literals
    and when the expected type is `int` *)
@@ -6471,9 +6489,13 @@ let report_partial_application = function
 
 let report_expr_type_clash_hints exp diff =
   match exp with
-  | Some (Pexp_constant const) -> report_literal_type_constraint const diff
-  | Some (Pexp_apply _) -> report_partial_application diff
-  | _ -> []
+  | Some exp -> begin
+      match exp.pexp_desc with
+      | Pexp_constant const -> report_literal_type_constraint const diff
+      | Pexp_apply _ -> report_partial_application diff
+      | _ -> []
+    end
+  | None -> []
 
 let report_pattern_type_clash_hints pat diff =
   match pat with
@@ -6516,14 +6538,6 @@ let report_unification_error ~loc ?sub env err
       ?type_expected_explanation txt1 txt2
   ) ()
 
-let report_this_function ppf funct =
-  let pexp = Untypeast.untype_expression funct in
-  match Pprintast.Doc.nominal_exp pexp with
-  | None -> Fmt.fprintf ppf "This function"
-  | Some name ->
-    Fmt.fprintf ppf "The function %a"
-      (Style.as_inline_code Fmt.pp_doc) name
-
 let report_too_many_arg_error ~funct ~func_ty ~previous_arg_loc
     ~extra_arg_loc ~returns_unit loc =
   let open Location in
@@ -6550,9 +6564,10 @@ let report_too_many_arg_error ~funct ~func_ty ~previous_arg_loc
     msg ~loc:extra_arg_loc "This extra argument is not expected.";
   ] in
   errorf ~loc:app_loc ~sub
-    "@[<v>@[<2>%a has type@ %a@]\
+    "@[<v>@[<2>%a@ %a@]\
      @ It is applied to too many arguments@]"
-    report_this_function funct Printtyp.type_expr func_ty
+    (report_this_texp_has_type (Some "function")) funct
+    Printtyp.type_expr func_ty
 
 let msg = Fmt.doc_printf
 
@@ -6597,7 +6612,7 @@ let report_error ~loc env = function
       report_unification_error ~loc ~sub env err
         ~type_expected_explanation:
           (report_type_expected_explanation_opt explanation)
-        (msg "This expression has type")
+        (msg "%a" (report_this_pexp_has_type (Some "expression")) exp)
         (msg "but an expression was expected of type");
   | Function_arity_type_clash {
       syntactic_arity; type_constraint; trace = { trace };

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -6517,7 +6517,8 @@ let report_unification_error ~loc ?sub env err
   ) ()
 
 let report_this_function ppf funct =
-  match Typedtree.nominal_exp_doc Printtyp.longident funct with
+  let pexp = Untypeast.untype_expression funct in
+  match Pprintast.Doc.nominal_exp pexp with
   | None -> Fmt.fprintf ppf "This function"
   | Some name ->
     Fmt.fprintf ppf "The function %a"

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -6427,14 +6427,20 @@ let type_clash_of_trace trace =
     - [This <denom> ...]
     - [The <denom> "foo" ...] *)
 let pp_exp_denom ppf pexp =
-  let p = fprintf ppf "%s" in
+  let d = pp_print_string ppf in
+  let d_expression = fprintf ppf "%a expression" Style.inline_code in
   match pexp.pexp_desc with
-  | Pexp_constant _ -> p "constant"
-  | Pexp_ident _ -> p "value"
-  | Pexp_construct _ | Pexp_variant _ -> p "constructor"
-  | Pexp_field _ -> p "field access"
-  | Pexp_send _ -> p "method call"
-  | _ -> p "expression"
+  | Pexp_constant _ -> d "constant"
+  | Pexp_ident _ -> d "value"
+  | Pexp_construct _ | Pexp_variant _ -> d "constructor"
+  | Pexp_field _ -> d "field access"
+  | Pexp_send _ -> d "method call"
+  | Pexp_while _ -> d_expression "while"
+  | Pexp_for _ -> d_expression "for"
+  | Pexp_ifthenelse _ -> d_expression "if-then-else"
+  | Pexp_match _ -> d_expression "match"
+  | Pexp_try _ -> d_expression "try-with"
+  | _ -> d "expression"
 
 (** Implements the "This expression" message, printing the expression if it
     should be according to {!Parsetree.Doc.nominal_exp}. *)

--- a/typing/typecore.mli
+++ b/typing/typecore.mli
@@ -163,7 +163,7 @@ type error =
   | Orpat_vars of Ident.t * Ident.t list
   | Expr_type_clash of
       Errortrace.unification_error * type_forcing_context option
-      * Parsetree.expression_desc option
+      * Parsetree.expression option
   | Function_arity_type_clash of
       { syntactic_arity :  int;
         type_constraint : type_expr;

--- a/typing/typedtree.ml
+++ b/typing/typedtree.ml
@@ -893,38 +893,3 @@ let split_pattern pat =
         combine_opts (into cpat) exns1 exns2
   in
   split_pattern pat
-
-(* Expressions are considered nominal if they can be used as the subject of a
-   sentence or action. In practice, we consider that an expression is nominal
-   if they satisfy one of:
-   - Similar to an identifier: words separated by '.' or '#'.
-   - Do not contain spaces when printed.
-*)
-let nominal_exp_doc lid t =
-  let open Format_doc.Doc in
-  let longident l = Format_doc.doc_printer lid l.Location.txt in
-  let rec nominal_exp_doc doc exp =
-    match exp.exp_desc with
-    | _ when exp.exp_attributes <> [] -> None
-    | Texp_ident (_,l,_) ->
-        Some (longident l doc)
-    | Texp_instvar (_,_,s) ->
-        Some (string s.Location.txt doc)
-    | Texp_constant _ -> assert false
-    | Texp_variant (lbl, None) ->
-        Some (printf "`%s" lbl doc)
-    | Texp_construct (l, _, []) -> Some (longident l doc)
-    | Texp_field (parent, lbl, _) ->
-        Option.map
-          (printf ".%t" (longident lbl))
-          (nominal_exp_doc doc parent)
-    | Texp_send (parent, meth) ->
-        let name = match meth with
-          | Tmeth_name name -> name
-          | Tmeth_val id | Tmeth_ancestor (id,_) -> Ident.name id in
-        Option.map
-          (printf "#%s" name)
-          (nominal_exp_doc doc parent)
-    | _ -> None
-  in
-  nominal_exp_doc empty t

--- a/typing/typedtree.mli
+++ b/typing/typedtree.mli
@@ -919,9 +919,3 @@ val pat_bound_idents_full:
 (** Splits an or pattern into its value (left) and exception (right) parts. *)
 val split_pattern:
   computation general_pattern -> pattern option * pattern option
-
-(** Returns a format document if the expression reads nicely as the subject of a
-    sentence in a error message. *)
-val nominal_exp_doc :
-  Longident.t Format_doc.printer -> expression
-  -> Format_doc.t option


### PR DESCRIPTION
Related: https://github.com/ocaml/ocaml/issues/12152

The second commit re-use the mechanism implemented in https://github.com/ocaml/ocaml/pull/11679 for type clash errors:

    Error: The expression '43' has type int
           but an expression was expected of type int32

The third commit change the denomination for some expressions instead of the generic "expression".
For example:

    The constant '42' has type ...

    This field has type ...

This is similar to the previous PR (https://github.com/ocaml/ocaml/pull/11679):

    The function 'foo' has type ...

This could be extended to most expressions (eg. `object`, `unnamed function`, `tuple`, `match expression`, etc..).