### PR TITLE
Sys.rename win fixes

### DIFF
--- a/Changes
+++ b/Changes
@@ -262,6 +262,9 @@ Working version
   causing marshaled data to be compressed using ZSTD.
   (Xavier Leroy, review by Edwin Török and Gabriel Scherer)
 
+- #12184: Sys.rename Windows fixes on directory corner cases.
+  (Jan Midtgaard, review by Anil Madhavapeddy)
+
 ### Other libraries:
 
 - #11374: Remove pointer cast to a type with stricter alignment requirements

--- a/runtime/win32.c
+++ b/runtime/win32.c
@@ -784,10 +784,16 @@ int caml_win32_rename(const wchar_t * oldpath, const wchar_t * newpath)
   /* First handle corner-cases not handled by MoveFileEx:
      - dir to empty dir - positive - should succeed
      - dir to existing file - should fail */
-  if (GetFileAttributes(oldpath) & FILE_ATTRIBUTE_DIRECTORY) {
-    int new_ret = GetFileAttributes(newpath);
-    if (new_ret != -1) {
-      if (new_ret & FILE_ATTRIBUTE_DIRECTORY) {
+  DWORD old_attribs = GetFileAttributes(oldpath);
+  if ((old_attribs != INVALID_FILE_ATTRIBUTES) &&
+      (old_attribs & FILE_ATTRIBUTE_DIRECTORY) != 0 &&
+      (old_attribs & FILE_ATTRIBUTE_HIDDEN) == 0 &&
+      (old_attribs & FILE_ATTRIBUTE_SYSTEM) == 0) {
+    DWORD new_attribs = GetFileAttributes(newpath);
+    if ((new_attribs != INVALID_FILE_ATTRIBUTES) &&
+	(new_attribs & FILE_ATTRIBUTE_HIDDEN) == 0 &&
+	(new_attribs & FILE_ATTRIBUTE_SYSTEM) == 0) {
+      if ((new_attribs & FILE_ATTRIBUTE_DIRECTORY) != 0) {
 	/* Try to delete and fall though.
            RemoveDirectoryW fails on non-empty dirs as intended. */
 	RemoveDirectoryW(newpath);

--- a/runtime/win32.c
+++ b/runtime/win32.c
@@ -791,15 +791,15 @@ int caml_win32_rename(const wchar_t * oldpath, const wchar_t * newpath)
       (old_attribs & FILE_ATTRIBUTE_SYSTEM) == 0) {
     DWORD new_attribs = GetFileAttributes(newpath);
     if ((new_attribs != INVALID_FILE_ATTRIBUTES) &&
-	(new_attribs & FILE_ATTRIBUTE_HIDDEN) == 0 &&
-	(new_attribs & FILE_ATTRIBUTE_SYSTEM) == 0) {
+        (new_attribs & FILE_ATTRIBUTE_HIDDEN) == 0 &&
+        (new_attribs & FILE_ATTRIBUTE_SYSTEM) == 0) {
       if ((new_attribs & FILE_ATTRIBUTE_DIRECTORY) != 0) {
-	/* Try to delete and fall though.
+        /* Try to delete and fall though.
            RemoveDirectoryW fails on non-empty dirs as intended. */
-	RemoveDirectoryW(newpath);
+        RemoveDirectoryW(newpath);
       } else {
-	errno = ENOTDIR;
-	return -1;
+        errno = ENOTDIR;
+        return -1;
       }
     }
   }

--- a/testsuite/tests/lib-sys/rename.ml
+++ b/testsuite/tests/lib-sys/rename.ml
@@ -83,3 +83,11 @@ let _ =
   testfailure "foo" "bar";
   print_newline();
   safe_remove f1; safe_remove_dir "foo"; safe_remove_dir "bar";
+  print_string "Rename directory to existing file: ";
+  Sys.mkdir "foo" 0o755;
+  writefile f2 "xyz";
+  testfailure "foo" f2;
+  print_newline();
+  safe_remove_dir "foo";
+  safe_remove f2;
+  safe_remove_dir f2;

--- a/testsuite/tests/lib-sys/rename.ml
+++ b/testsuite/tests/lib-sys/rename.ml
@@ -83,6 +83,13 @@ let _ =
   testfailure "foo" "bar";
   print_newline();
   safe_remove f1; safe_remove_dir "foo"; safe_remove_dir "bar";
+  print_string "Rename directory to existing empty directory: ";
+  Sys.mkdir "foo" 0o755;
+  Sys.mkdir "bar" 0o755;
+  testrenamedir "foo" "bar";
+  print_newline();
+  safe_remove_dir "foo";
+  safe_remove_dir "bar";
   print_string "Rename directory to existing file: ";
   Sys.mkdir "foo" 0o755;
   writefile f2 "xyz";

--- a/testsuite/tests/lib-sys/rename.reference
+++ b/testsuite/tests/lib-sys/rename.reference
@@ -5,4 +5,5 @@ Renaming to a nonexisting directory: fails as expected
 Rename directory to a nonexisting directory: passed
 Rename a nonexisting directory: fails as expected
 Rename directory to a non-empty directory: fails as expected
+Rename directory to existing empty directory: passed
 Rename directory to existing file: fails as expected

--- a/testsuite/tests/lib-sys/rename.reference
+++ b/testsuite/tests/lib-sys/rename.reference
@@ -5,3 +5,4 @@ Renaming to a nonexisting directory: fails as expected
 Rename directory to a nonexisting directory: passed
 Rename a nonexisting directory: fails as expected
 Rename directory to a non-empty directory: fails as expected
+Rename directory to existing file: fails as expected


### PR DESCRIPTION
This PR fixes the two `Sys.rename` corner cases reported in #12073.

It builds on top of #12072 in that we try to offer consistent and documented behavior across platforms when renaming directories with `Sys.rename`.

While digging I found the related #9793 with Windows fixes to `Sys.{file_exists,is_directory}` for symlinks.
Now I better understand the expressed concern for symlink corner cases... :slightly_smiling_face: 