### PR TITLE
Faster implementation of {Int,Int32,Int64,Nativeint}.to_string

### DIFF
--- a/runtime/ints.c
+++ b/runtime/ints.c
@@ -989,8 +989,6 @@ CAMLprim value unboxed_caml_int32_to_string(int32_t val) {
   value res = caml_alloc_string(count + (val < 0));
   char* buf = (char*) String_val(res);
 
-  // caml_alloc_string(n) allocates n + 1 bytes
-  buf[count + (val < 0)] = 0;
   write_digits((uint64_t)x, buf, count + (val < 0));
   if (val < 0) { buf[0] = '-'; }
   return res;
@@ -1007,8 +1005,6 @@ CAMLprim value unboxed_caml_int64_to_string(int64_t val) {
   value res = caml_alloc_string(count + (val < 0));
   char* buf = (char*) String_val(res);
 
-  // caml_alloc_string(n) allocates n + 1 bytes
-  buf[count + (val < 0)] = 0;
   write_digits(x, buf, count + (val < 0));
   if (val < 0) { buf[0] = '-'; }
   return res;

--- a/stdlib/int.ml
+++ b/stdlib/int.ml
@@ -47,9 +47,10 @@ external of_float : float -> int = "%intoffloat"
 external int_of_string : string -> int = "caml_int_of_string"
 let of_string s = try Some (int_of_string s) with Failure _ -> None
 *)
-
+(*
 external format_int : string -> int -> string = "caml_format_int"
-let to_string x = format_int "%d" x
+*)
+external to_string : int -> string = "caml_int_to_string"
 
 external seeded_hash_param :
   int -> int -> int -> 'a -> int = "caml_hash" [@@noalloc]

--- a/stdlib/int.mli
+++ b/stdlib/int.mli
@@ -150,7 +150,7 @@ val of_string : string -> int option
     digits of the number. *)
 *)
 
-val to_string : int -> string
+external to_string : int -> string = "caml_int_to_string"
 (** [to_string x] is the written representation of [x] in decimal. *)
 
 val seeded_hash : int -> int -> int

--- a/stdlib/int32.ml
+++ b/stdlib/int32.ml
@@ -68,8 +68,9 @@ let unsigned_to_int =
   | _ ->
       assert false
 
-external format : string -> int32 -> string = "caml_int32_format"
-let to_string n = format "%d" n
+(*external format : string -> int32 -> string = "caml_int32_format"*)
+external to_string: (int32 [@unboxed]) -> string =
+    "caml_int32_to_string" "unboxed_caml_int32_to_string"
 
 external of_string : string -> int32 = "caml_int32_of_string"
 

--- a/stdlib/int32.mli
+++ b/stdlib/int32.mli
@@ -179,7 +179,8 @@ val of_string_opt: string -> int32 option
     @since 4.05 *)
 
 
-val to_string : int32 -> string
+external to_string: (int32 [@unboxed]) -> string =
+    "caml_int32_to_string" "unboxed_caml_int32_to_string"
 (** Return the string representation of its argument, in signed decimal. *)
 
 external bits_of_float : float -> int32

--- a/stdlib/int64.ml
+++ b/stdlib/int64.ml
@@ -58,8 +58,9 @@ let unsigned_to_int =
     else
       None
 
-external format : string -> int64 -> string = "caml_int64_format"
-let to_string n = format "%d" n
+(*external format : string -> int64 -> string = "caml_int64_format"*)
+external to_string: (int64 [@unboxed]) -> string =
+    "caml_int64_to_string" "unboxed_caml_int64_to_string"
 
 external of_string : string -> int64 = "caml_int64_of_string"
 

--- a/stdlib/int64.mli
+++ b/stdlib/int64.mli
@@ -198,7 +198,8 @@ val of_string_opt: string -> int64 option
 (** Same as [of_string], but return [None] instead of raising.
     @since 4.05 *)
 
-val to_string : int64 -> string
+external to_string: (int64 [@unboxed]) -> string =
+    "caml_int64_to_string" "unboxed_caml_int64_to_string"
 (** Return the string representation of its argument, in decimal. *)
 
 external bits_of_float : float -> int64

--- a/stdlib/nativeint.ml
+++ b/stdlib/nativeint.ml
@@ -57,8 +57,9 @@ let unsigned_to_int =
     else
       None
 
-external format : string -> nativeint -> string = "caml_nativeint_format"
-let to_string n = format "%d" n
+(*external format : string -> nativeint -> string = "caml_nativeint_format"*)
+external to_string: (nativeint [@unboxed]) -> string =
+    "caml_nativeint_to_string" "unboxed_caml_nativeint_to_string"
 
 external of_string: string -> nativeint = "caml_nativeint_of_string"
 

--- a/stdlib/nativeint.mli
+++ b/stdlib/nativeint.mli
@@ -204,7 +204,8 @@ val of_string_opt: string -> nativeint option
 (** Same as [of_string], but return [None] instead of raising.
     @since 4.05 *)
 
-val to_string : nativeint -> string
+external to_string: (nativeint [@unboxed]) -> string =
+    "caml_nativeint_to_string" "unboxed_caml_nativeint_to_string"
 (** Return the string representation of its argument, in decimal. *)
 
 type t = nativeint


### PR DESCRIPTION
This PR provides a 5-6x faster implementation of `{Int,Int32,Int64,Nativeint}.to_string` than the current implementation based on `sprintf`.

The implementation works as follows.
- We consider unsigned integers (for signed integers it suffices to add a '-' in front if necessary).
- We first compute how many decimal digits are necessary to represent the integer. This would usually be computed by the base 10 logarithm which is quite expensive to implement. The base 2 logarithm is quite simpler to compute with dedicated instructions on modern architectures such as `bsr` and available as compiler builtins. The base 10 logarithm can then be cheaply approximated using the formula for changing bases.
- We allocate a string of the necessary size.
- We write the integer starting from the end 2 digits at a time. `n % 100` is the number we need to write, all the results are tabulated, i.e., "00", "01", ... are stored in a table to avoid computing. Thus `table[n % 100]` is what's needed to be written to the string morally.
- Finish writing the last digit if necessary.

## Correctness

The implementations are available as a [library](https://git.sr.ht/~atrieu/ocaml-fastnumconv) which is what I tested.
The new `Int32.to_string` has been tested exhaustively on all possible inputs and provides the same string result as the current standard library implementation. Other implementations have been tested and compared with the original implementation on random inputs.

## Benchmarks

Naive benchmarking by converting a few millions random integers of increasing size (i.e., 1 digit, then 2 digits, etc until maximum number of digits possible). For instance, on an Apple M2 Pro CPU:

```shell
Sampling 10_000_000 values in [0..10[
Fast_Int64.to_string      59.1ms
Int64.to_string           415ms
Sampling 10_000_000 values in [0..100[
Fast_Int64.to_string      76.1ms
Int64.to_string           422ms
Sampling 10_000_000 values in [0..1000[
Fast_Int64.to_string      74.4ms
Int64.to_string           463ms
Sampling 10_000_000 values in [0..10000[
Fast_Int64.to_string      74.5ms
Int64.to_string           479ms
Sampling 10_000_000 values in [0..100000[
Fast_Int64.to_string      85.8ms
Int64.to_string           545ms
Sampling 10_000_000 values in [0..1000000[
Fast_Int64.to_string      86.4ms
Int64.to_string           559ms
Sampling 10_000_000 values in [0..10000000[
Fast_Int64.to_string      94.5ms
Int64.to_string           567ms
Sampling 10_000_000 values in [0..100000000[
Fast_Int64.to_string      92.8ms
Int64.to_string           537ms
Sampling 10_000_000 values in [0..1000000000[
Fast_Int64.to_string      90.2ms
Int64.to_string           510ms
Sampling 10_000_000 values in [0..10000000000[
Fast_Int64.to_string      84ms
Int64.to_string           478ms
Sampling 10_000_000 values in [0..100000000000[
Fast_Int64.to_string      87.8ms
Int64.to_string           508ms
Sampling 10_000_000 values in [0..1000000000000[
Fast_Int64.to_string      89.9ms
Int64.to_string           533ms
Sampling 10_000_000 values in [0..10000000000000[
Fast_Int64.to_string      87.1ms
Int64.to_string           572ms
Sampling 10_000_000 values in [0..100000000000000[
Fast_Int64.to_string      89.3ms
Int64.to_string           588ms
Sampling 10_000_000 values in [0..1000000000000000[
Fast_Int64.to_string      94.4ms
Int64.to_string           614ms
Sampling 10_000_000 values in [0..10000000000000000[
Fast_Int64.to_string      99.8ms
Int64.to_string           593ms
Sampling 10_000_000 values in [0..100000000000000000[
Fast_Int64.to_string      96.6ms
Int64.to_string           599ms
Sampling 10_000_000 values in [0..1000000000000000000[
Fast_Int64.to_string      99.2ms
Int64.to_string           627ms
Sampling 10_000_000 values in [0..9223372036854775807[
Fast_Int64.to_string      108ms
Int64.to_string           676ms
```

## Caveats

- Untested on a 32 bits architecture machine.
- Untested with the Microsoft MSVC compiler.
- I have no idea if the `[@unboxed]` annotations are actually useful.

This is my first PR so hopefully it's OK.