### PR TITLE
Fix warnings emitted when compiling the documentation

### DIFF
--- a/api_docgen/ocamldoc/Makefile
+++ b/api_docgen/ocamldoc/Makefile
@@ -44,7 +44,7 @@ $(libref:%=build/libref/%.odoc): build/libref/%.odoc: %.mli | build/libref
 	$(V_OCAMLDOC)$(OCAMLDOC_RUN) -nostdlib -hide Stdlib -lib Stdlib \
 	-pp \
 "$(AWK) -v ocamldoc=true -f ../../stdlib/expand_module_aliases.awk" \
-	$(DOC_STDLIB_INCLUDES) -hide-warnings  $< -dump  $@
+	$(DOC_STDLIB_INCLUDES) -hide-warnings -alert -all $< -dump  $@
 
 $(compilerlibref:%=build/compilerlibref/%.odoc):\
 build/compilerlibref/%.odoc: %.mli | build/compilerlibref

--- a/otherlibs/unix/unix.mli
+++ b/otherlibs/unix/unix.mli
@@ -921,7 +921,7 @@ val open_process_full :
 val open_process_args : string -> string array -> in_channel * out_channel
 (** [open_process_args prog args] runs the program [prog] with arguments
     [args].  Note that the first argument is by convention the filename of
-    the program being executed, just like {!Sys.argv.(0)}.  The new process
+    the program being executed, just like [Sys.argv.(0)].  The new process
     executes concurrently with the current process.  The standard input and
     output of the new process are redirected to pipes, which can be
     respectively read and written via the returned channels.  The input

--- a/otherlibs/unix/unixLabels.mli
+++ b/otherlibs/unix/unixLabels.mli
@@ -921,7 +921,7 @@ val open_process_full :
 val open_process_args : string -> string array -> in_channel * out_channel
 (** [open_process_args prog args] runs the program [prog] with arguments
     [args].  Note that the first argument is by convention the filename of
-    the program being executed, just like {!Sys.argv.(0)}.  The new process
+    the program being executed, just like [Sys.argv.(0)].  The new process
     executes concurrently with the current process.  The standard input and
     output of the new process are redirected to pipes, which can be
     respectively read and written via the returned channels.  The input

--- a/stdlib/marshal.mli
+++ b/stdlib/marshal.mli
@@ -102,7 +102,7 @@ val to_channel : out_channel -> 'a -> extern_flags list -> unit
    If [flags] contains [Marshal.Compression], the marshaled data
    representing value [v] is compressed before being written to
    channel [chan].  Decompression takes place automatically in
-   the unmarshaling functions {!input_value}, {!Marshal.from_channel},
+   the unmarshaling functions {!Stdlib.input_value}, {!Marshal.from_channel},
    {!Marshal.from_string}, etc.  For large values [v], compression
    typically reduces the size of marshaled data by a factor 2 to 4,
    but slows down marshaling and, to a lesser extent, unmarshaling.
@@ -203,14 +203,14 @@ val compression_supported : unit -> bool
 (** Indicates whether the compressed data format is supported.
 
     If [Marshal.compression_supported()] is [true], compressed data
-    is unmarshaled safely by {!input_value}, {!Marshal.from_channel},
+    is unmarshaled safely by {!Stdlib.input_value}, {!Marshal.from_channel},
     {!Marshal.from_string} and related functions.  Moreover, the
     [Marshal.Compression] flag is honored by the {!Marshal.to_channel},
     {!Marshal.to_string} and related functions, resulting in the
     production of compressed data.
 
     If [Marshal.compression_supported()] is [false], compressed data
-    causes {!input_value}, {!Marshal.from_channel},
+    causes {!Stdlib.input_value}, {!Marshal.from_channel},
     {!Marshal.from_string} and related functions to fail and a
     [Failure] exception to be raised.  Moreover,
     {!Marshal.to_channel}, {!Marshal.to_string} and related functions


### PR DESCRIPTION
This fixes the alert and the ocamldoc warnings that are output by `make world`.
