### PR TITLE
Check for syntax errors in test scripts instead of ignoring them.

### DIFF
--- a/ocamltest/main.ml
+++ b/ocamltest/main.ml
@@ -22,22 +22,6 @@ type behavior =
   | Skip_all_tests
   | Run of Environments.t
 
-(*
-let first_token filename =
-  let input_channel = open_in filename in
-  let lexbuf = Lexing.from_channel input_channel in
-  Location.init lexbuf filename;
-  let token =
-    try Tsl_lexer.token lexbuf with e -> close_in input_channel; raise e
-  in close_in input_channel; token
-
-let is_test filename =
-  match first_token filename with
-    | exception _ -> false
-    | Tsl_parser.TSL_BEGIN_C_STYLE | TSL_BEGIN_OCAML_STYLE -> true
-    | _ -> false
-*)
-
 (* this primitive announce should be used for tests
    that were aborted on system error before ocamltest
    could parse them *)
@@ -221,10 +205,12 @@ let test_file test_filename =
     Printf.eprintf "Wall clock: %s took %.02fs\n%!"
                    test_filename wall_clock_duration
 
-let is_test s =
-  match tsl_block_of_file s with
-  | _ -> true
-  | exception _ -> false
+let is_test filename =
+  let input_channel = open_in filename in
+  let lexbuf = Lexing.from_channel input_channel in
+  Fun.protect ~finally:(fun () -> close_in input_channel) begin fun () ->
+    Tsl_lexer.is_test lexbuf
+  end
 
 let ignored s =
   s = "" || s.[0] = '_' || s.[0] = '.'

--- a/ocamltest/tsl_lexer.mli
+++ b/ocamltest/tsl_lexer.mli
@@ -16,5 +16,6 @@
 (* Interface to the Tsl_lexer module *)
 
 val token : Lexing.lexbuf -> Tsl_parser.token
+val is_test : Lexing.lexbuf -> bool
 val modifier :
     Lexing.lexbuf -> string * [`Remove | `Add of string | `Append of string]

--- a/ocamltest/tsl_lexer.mll
+++ b/ocamltest/tsl_lexer.mll
@@ -32,7 +32,7 @@ let num = ['0'-'9']
 
 rule is_test = parse
   | blank * { is_test lexbuf }
-  | newline { is_test lexbuf }
+  | newline { Lexing.new_line lexbuf; is_test lexbuf }
   | "/*" blank* "TEST" { true }
   | "/*" blank* "TEST_BELOW" { true }
   | "(*" blank* "TEST" { true }

--- a/ocamltest/tsl_lexer.mll
+++ b/ocamltest/tsl_lexer.mll
@@ -30,7 +30,17 @@ let blank = [' ' '\009' '\012']
 let identchar = ['A'-'Z' 'a'-'z' '_' '.' '-' '\'' '0'-'9']
 let num = ['0'-'9']
 
-rule token = parse
+rule is_test = parse
+  | blank * { is_test lexbuf }
+  | newline { is_test lexbuf }
+  | "/*" blank* "TEST" { true }
+  | "/*" blank* "TEST_BELOW" { true }
+  | "(*" blank* "TEST" { true }
+  | "(*" blank* "TEST_BELOW" { true }
+  | _ { false }
+  | eof { false }
+
+and token = parse
   | blank * { token lexbuf }
   | newline { Lexing.new_line lexbuf; token lexbuf }
   | "/*" blank* "TEST" { TSL_BEGIN_C_STYLE }


### PR DESCRIPTION
Before this PR, ocamltest would just return "not a test" on any file that has a syntax error in its test script. Because the makefile only runs ocamltest on test files, this means that the test is not run and the error is ignored when running `make tests`.

After this PR, any file that starts with the TEST or TEST_BELOW marker, will be run through `ocamltest`, which will report the syntax errors where appropriate.
