### PR TITLE
Fix bug where incorrect levels from type_package led to scope escape

### DIFF
--- a/Changes
+++ b/Changes
@@ -23,6 +23,9 @@ Working version
 
 ### Bug fixes:
 
+- #12195: Lower levels in checked module packages so that remaining weak
+  variables may not be unified with out-of-scope types.
+  (Chris Casinghino and Leo White, review by ???)
 
 OCaml 5.1.0
 ---------------

--- a/testsuite/tests/typing-modules-bugs/pr12195_bad.compilers.reference
+++ b/testsuite/tests/typing-modules-bugs/pr12195_bad.compilers.reference
@@ -1,0 +1,19 @@
+File "pr12195_bad.ml", lines 21-25, characters 11-5:
+21 | ...........struct
+22 |     type s = A
+23 | 
+24 |     let created = Foo.create (fun _ -> ())
+25 |   end..
+Error: Signature mismatch:
+       Modules do not match:
+         sig type s = A val created : '_weak1 Foo.t end
+       is not included in
+         Bar
+       Values do not match:
+         val created : '_weak1 Foo.t
+       is not included in
+         val created : s Foo.t
+       The type '_weak1 Foo.t is not compatible with the type s Foo.t
+       The type constructor s would escape its scope
+       File "pr12195_bad.ml", line 17, characters 2-23: Expected declaration
+       File "pr12195_bad.ml", line 24, characters 8-15: Actual declaration

--- a/testsuite/tests/typing-modules-bugs/pr12195_bad.ml
+++ b/testsuite/tests/typing-modules-bugs/pr12195_bad.ml
@@ -1,0 +1,25 @@
+(* TEST
+ocamlc_byte_exit_status = "2"
+* setup-ocamlc.byte-build-env
+** ocamlc.byte
+*** check-ocamlc.byte-output
+*)
+module Foo = struct
+  type 'a t
+
+  let create : ('a -> unit) -> 'a t =
+    fun  _ -> assert false
+end
+
+module type Bar = sig
+  type s = A
+
+  val created : s Foo.t
+end
+
+let baz : (module Bar) =
+  (module (struct
+    type s = A
+
+    let created = Foo.create (fun _ -> ())
+  end))

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -2938,6 +2938,7 @@ let lookup_type_in_sig sg =
 
 let type_package env m p fl =
   (* Same as Pexp_letmodule *)
+  let outer_scope = Ctype.get_current_level () in
   let modl, scope =
     Typetexp.TyVarEnv.with_local_scope begin fun () ->
       (* type the module and create a scope in a raised level *)
@@ -2948,6 +2949,7 @@ let type_package env m p fl =
       end
     end
   in
+  Mtype.lower_nongen outer_scope modl.mod_type;
   let fl', env =
     match fl with
     | [] -> [], env


### PR DESCRIPTION
This fixes a bug where the compiler will allow a weak type variable to be unified with an out of scope type because the level on the type variable is incorrect.  The fix is for `Typemod.type_package` to call `Mtype.lower_nongen`, just like `Type_mod.type_structure` already does in its similar `Pstr_module` case.

Here is a program that typechecks but should not:

```
module Foo = struct
  type 'a t

  let create : ('a -> unit) -> 'a t =
    fun  _ -> assert false
end

module type Bar = sig
  type s = A

  val created : s Foo.t
end

let baz : (module Bar) =
  (module (struct
    type s = A

    let created = Foo.create (fun _ -> ())
  end))
```

The type of `created` after typing the inner structure in `baz` is `_weak Foo.t`.  To satisfy the `Bar` type annotation on `baz`, this weak variable would need to unify with `s`, but this shouldn't be allowed because `s` isn't in scope any more.  What actually happens is that the weak variable ends up being unified with a fresh `s` created by Subst in `wrap_constraint_package`, resulting in a very odd term.

If we replace `baz` with this very similar definition, it is correctly rejected:

```
let baz' : (module Bar) =
  let module M = struct
    type s = A

    let created = Foo.create (fun _ -> ())
  end in
  (module M)
```

This correctly yields the error:

```
File "/home/ccasinghino/ocaml/ex/bug23.ml", line 27, characters 10-11:
27 |   (module M)
               ^
Error: Signature mismatch:
       Modules do not match:
         sig type s = M.s = A val created : '_weak1 Foo.t end
       is not included in
         Bar
       Values do not match:
         val created : '_weak1 Foo.t
       is not included in
         val created : s Foo.t
       The type '_weak1 Foo.t is not compatible with the type M.s Foo.t
       The type constructor M.s would escape its scope
```

The difference is that in `baz'` we end up checking `M`'s definition through the `Pstr_module` case of `type_structure`, which correctly lowers the levels of the the remaining ungeneralized type variables to the outer scope after the module is typed.  The original `baz` is checked by `type_package` instead, which was missing this lowering step, so I've added it.  I've also added the bad program to the test suite.

This is joint work with @lpw25, who spotted the cause of this bug.
