### PR TITLE
Don't include stdbool.h systematically

### DIFF
--- a/runtime/caml/config.h
+++ b/runtime/caml/config.h
@@ -49,7 +49,6 @@
 #ifndef CAML_CONFIG_H_NO_TYPEDEFS
 
 #include <stddef.h>
-#include <stdbool.h>
 
 #if defined(HAS_LOCALE_H) || defined(HAS_XLOCALE_H)
 #define HAS_LOCALE

--- a/runtime/caml/frame_descriptors.h
+++ b/runtime/caml/frame_descriptors.h
@@ -21,6 +21,7 @@
 
 #ifdef CAML_INTERNALS
 
+#include <stdbool.h>
 #include "config.h"
 
 /* The compiler generates a "frame descriptor" for every potential

--- a/runtime/weak.c
+++ b/runtime/weak.c
@@ -319,7 +319,7 @@ static value ephe_get_field_copy (value e, mlsize_t offset)
   /* Loop in case allocating the copy triggers a GC which modifies the
    * ephemeron or the value. In the common case, we go around this
    * loop 1.5 times. */
-  while(true) {
+  while (1) {
     clean_field(e, offset);
     val = Field(e, offset);
 


### PR DESCRIPTION
It can cause problem with user code that defines its own `bool` type, as reported in #11990. 

Instead, use stdbool.h internally only, and only when really needed.
