### PR TITLE
Fix a typo in inheritance error message.

### DIFF
--- a/Changes
+++ b/Changes
@@ -227,6 +227,9 @@ Working version
   of --disable-debugger (which remains available for compatibility)
   (Gabriel Scherer, review by Damien Doligez and Sébastien Hinderer)
 
+- #12199: improve the error message for non-overriding `inherit!`
+  (Florian Angeletti, review by Jules Aguillon)
+
 - #12210: uniform style for inline code in compiler messages
   (Florian Angeletti, review by Gabriel Scherer)
 

--- a/testsuite/tests/typing-objects/errors.ml
+++ b/testsuite/tests/typing-objects/errors.ml
@@ -58,5 +58,6 @@ class empty : object  end
 Line 2, characters 26-40:
 2 | class also_empty = object inherit! empty end
                               ^^^^^^^^^^^^^^
-Error: This inheritance does not override any methods or instance variables.
+Error: This inheritance does not override any methods or instance variables
+       but is explicitly marked as overriding with "!".
 |}]

--- a/testsuite/tests/typing-objects/errors.ml
+++ b/testsuite/tests/typing-objects/errors.ml
@@ -50,3 +50,13 @@ Line 1, characters 37-41:
                                          ^^^^
 Error: This expression has no method "bar"
 |}]
+
+class empty = object end
+class also_empty = object inherit! empty end
+[%%expect{|
+class empty : object  end
+Line 2, characters 26-40:
+2 | class also_empty = object inherit! empty end
+                              ^^^^^^^^^^^^^^
+Error: This inheritance does not override any methods or instance variables.
+|}]

--- a/typing/typeclass.ml
+++ b/typing/typeclass.ml
@@ -2173,8 +2173,11 @@ let report_error env ppf =
         "@[The instance variable is %s;@ it cannot be redefined as %s@]"
         mut1 mut2
   | No_overriding (_, "") ->
-      fprintf ppf "@[This inheritance does not override any methods@ \
-                   or instance variables.@]"
+      fprintf ppf
+        "@[This inheritance does not override any methods@ \
+         or instance variables@ but is explicitly marked as@ \
+         overriding with %a.@]"
+        Style.inline_code "!"
   | No_overriding (kind, name) ->
       fprintf ppf "@[The %s %a@ has no previous definition@]" kind
         Style.inline_code name

--- a/typing/typeclass.ml
+++ b/typing/typeclass.ml
@@ -2173,8 +2173,8 @@ let report_error env ppf =
         "@[The instance variable is %s;@ it cannot be redefined as %s@]"
         mut1 mut2
   | No_overriding (_, "") ->
-      fprintf ppf "@[This inheritance does not override any methods@ %s@]"
-        "or instance variables"
+      fprintf ppf "@[This inheritance does not override any methods@ \
+                   or instance variables.@]"
   | No_overriding (kind, name) ->
       fprintf ppf "@[The %s %a@ has no previous definition@]" kind
         Style.inline_code name


### PR DESCRIPTION
Currently,
```ocaml
class empty = object end
class also_empty = object inherit! empty end
```
emits the following error message:
```
Error: This inheritance does not override any method instance variable
```
This PR fixes the missing `or` and plural between `method` and `instance variable`:
```
Error: This inheritance does not override any methods or instance variables.
```
