### PR TITLE
Add `find_all` to associative arrays in `List`

### DIFF
--- a/stdlib/list.ml
+++ b/stdlib/list.ml
@@ -205,7 +205,7 @@ let rec assoc_opt x = function
 
 let[@tail_mod_cons] rec assoc_find_all p = function
   | [] -> []
-  | x :: l -> if p (fst x) then x :: find_all p l else find_all p l
+  | x :: l -> if p (fst x) then x :: assoc_find_all p l else assoc_find_all p l
 
 let assoc_filter = assoc_find_all
 

--- a/stdlib/list.ml
+++ b/stdlib/list.ml
@@ -203,6 +203,12 @@ let rec assoc_opt x = function
     [] -> None
   | (a,b)::l -> if compare a x = 0 then Some b else assoc_opt x l
 
+let[@tail_mod_cons] rec assoc_find_all p = function
+  | [] -> []
+  | x :: l -> if p (fst x) then x :: find_all p l else find_all p l
+
+let assoc_filter = assoc_find_all
+
 let rec assq x = function
     [] -> raise Not_found
   | (a,b)::l -> if a == x then b else assq x l

--- a/stdlib/list.mli
+++ b/stdlib/list.mli
@@ -405,6 +405,17 @@ val assoc_opt : 'a -> ('a * 'b) list -> 'b option
     @since 4.05
  *)
 
+val assoc_filter : ('a -> bool) -> ('a * 'b) list -> ('a * 'b) list
+(** [assoc_filter f l] returns all the elements of the list [l]
+   where the key of each associative pair satisfies the predicate [f]. The order of the elements
+   in the input list is preserved.
+ *)
+
+val assoc_find_all : ('a -> bool) -> ('a * 'b) list -> ('a * 'b) list
+(** [assoc_find_all] is another name for {!assoc_filter}.
+ *)
+
+
 val assq : 'a -> ('a * 'b) list -> 'b
 (** Same as {!assoc}, but uses physical equality instead of
    structural equality to compare keys.

--- a/stdlib/listLabels.mli
+++ b/stdlib/listLabels.mli
@@ -405,6 +405,16 @@ val assoc_opt : 'a -> ('a * 'b) list -> 'b option
     @since 4.05
  *)
 
+val assoc_filter : ('a -> bool) -> ('a * 'b) list -> ('a * 'b) list
+(** [assoc_filter f l] returns all the elements of the list [l]
+   where the key of each associative pair satisfies the predicate [f]. The order of the elements
+   in the input list is preserved.
+ *)
+
+val assoc_find_all : ('a -> bool) -> ('a * 'b) list -> ('a * 'b) list
+(** [assoc_find_all] is another name for {!assoc_filter}.
+ *)
+
 val assq : 'a -> ('a * 'b) list -> 'b
 (** Same as {!assoc}, but uses physical equality instead of
    structural equality to compare keys.


### PR DESCRIPTION
As associative arrays are commonly used for medium-sized collections of data, I am of the opinion that a filter function (and find_all alias, in order to remain consistent with the rest of the `list` module) would be a useful addition to the standard library.
I have not added test cases due to the simple nature of the functions - if requested, I can easily add some. 