### PR TITLE
#12189: anonymous polyvariant rows and explicitly polymorphic type annotations

### DIFF
--- a/Changes
+++ b/Changes
@@ -176,6 +176,11 @@ OCaml 5.1.0
 - #11912: Refactoring handling of scoped type variables
   (Richard Eisenberg, review by Gabriel Scherer and Florian Angeletti)
 
+* #12189, #12211: anonymous row variables in explicitly polymorphic type
+  annotation, e.g. `'a. [< X of 'a ] -> 'a`, are now implicitly
+  universally quantified (in other words, the example above is now read
+  as `'a 'r. ([< X of 'a `] as 'r) -> 'a`).
+
 ### Code generation and optimizations:
 
 - #11967: Remove traces of Obj.truncate, which allows some mutable

--- a/Changes
+++ b/Changes
@@ -180,6 +180,7 @@ OCaml 5.1.0
   annotation, e.g. `'a. [< X of 'a ] -> 'a`, are now implicitly
   universally quantified (in other words, the example above is now read
   as `'a 'r. ([< X of 'a `] as 'r) -> 'a`).
+  (Florian Angeletti and Gabriel Scherer, review by Jacques Garrigue)
 
 ### Code generation and optimizations:
 

--- a/testsuite/tests/typing-gadts/test.ml
+++ b/testsuite/tests/typing-gadts/test.ml
@@ -804,11 +804,12 @@ let f : type a b. (a,b) eq -> [< `A of a | `B] -> [< `A of b | `B] =
 Lines 1-2, characters 4-15:
 1 | ....f : type a b. (a,b) eq -> [< `A of a | `B] -> [< `A of b | `B] =
 2 |   fun Eq o -> o..............
-Error: This expression has type
-         ('a, 'b) eq -> ([< `A of 'b & 'a | `B ] as 'c) -> 'c
-       but an expression was expected of type
-         ('a, 'b) eq -> [< `A of 'a0 | `B ] -> [< `A of 'b0 | `B ]
-       The universal variable 'a0 would escape its scope
+Error: This definition has type
+         'c 'd. ('d, 'd) eq -> ([< `A of 'd | `B ] as 'c) -> 'c
+       which is less general than
+         'e 'f 'a 'b.
+           ('a, 'b) eq ->
+           ([< `A of 'a | `B ] as 'e) -> ([< `A of 'b | `B ] as 'f)
 |}];;
 
 let f : type a b. (a,b) eq -> [`A of a | `B] -> [`A of b | `B] =
@@ -839,8 +840,9 @@ Lines 1-5, characters 4-5:
 Error: This expression has type
          ('a, 'b) eq -> [ `A of 'a | `B ] -> [ `A of 'b | `B ]
        but an expression was expected of type
-         ('a, 'b) eq -> [> `A of 'a0 | `B ] -> [ `A of 'b | `B ]
-       The universal variable 'a0 would escape its scope
+         ('a, 'b) eq -> [> `A of 'a | `B ] -> [ `A of 'b | `B ]
+       The second variant type is bound to the universal type variable 'c,
+       it cannot be closed
 |}, Principal{|
 Line 4, characters 49-50:
 4 |     let r : [`A of b | `B] = match eq with Eq -> o in (* fail with principal *)

--- a/testsuite/tests/typing-gadts/test.ml
+++ b/testsuite/tests/typing-gadts/test.ml
@@ -809,7 +809,7 @@ Error: This definition has type
        which is less general than
          'e 'f 'a 'b.
            ('a, 'b) eq ->
-           ([< `A of 'a | `B ] as 'e) -> ([< `A of 'b | `B ] as 'f)
+           ([< `A of 'a | `B ] as 'f) -> ([< `A of 'b | `B ] as 'e)
 |}];;
 
 let f : type a b. (a,b) eq -> [`A of a | `B] -> [`A of b | `B] =

--- a/testsuite/tests/typing-poly/poly.ml
+++ b/testsuite/tests/typing-poly/poly.ml
@@ -1525,38 +1525,35 @@ end;;
 [%%expect {|
 val n : < m : 'x 'a. ([< `Foo of 'x ] as 'a) -> 'x > = <obj>
 |}];;
-(* ok *)
+(* ok, due to implicit `'o. [< `Foo of _ ] as 'o`  *)
 let n =
   object method m : 'x. [< `Foo of 'x] -> 'x = fun x -> assert false end;;
 [%%expect {|
-Line 2, characters 9-68:
-2 |   object method m : 'x. [< `Foo of 'x] -> 'x = fun x -> assert false end;;
-             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The method m has type 'a -> 'b but is expected to have type
-         [< `Foo of 'x ] -> 'c
-       The universal variable 'x would escape its scope
+val n : < m : 'a 'x. ([< `Foo of 'x ] as 'a) -> 'x > = <obj>
 |}];;
 (* fail *)
 let (n : < m : 'a. [< `Foo of int] -> 'a >) =
   object method m : 'x. [< `Foo of 'x] -> 'x = fun x -> assert false end;;
 [%%expect {|
-Line 2, characters 9-68:
+Line 2, characters 2-72:
 2 |   object method m : 'x. [< `Foo of 'x] -> 'x = fun x -> assert false end;;
-             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The method m has type 'a -> 'b but is expected to have type
-         [< `Foo of 'x ] -> 'c
-       The universal variable 'x would escape its scope
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This expression has type < m : 'b 'x. ([< `Foo of 'x ] as 'b) -> 'x >
+       but an expression was expected of type
+         < m : 'c 'a. ([< `Foo of int ] as 'c) -> 'a >
+       Types for tag `Foo are incompatible
 |}];;
 (* fail *)
 let (n : 'b -> < m : 'a . ([< `Foo of int] as 'b) -> 'a >) = fun x ->
   object method m : 'x. [< `Foo of 'x] -> 'x = fun x -> assert false end;;
 [%%expect {|
-Line 2, characters 9-68:
+Line 2, characters 2-72:
 2 |   object method m : 'x. [< `Foo of 'x] -> 'x = fun x -> assert false end;;
-             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The method m has type 'a -> 'b but is expected to have type
-         [< `Foo of 'x ] -> 'c
-       The universal variable 'x would escape its scope
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This expression has type < m : 'b 'x. ([< `Foo of 'x ] as 'b) -> 'x >
+       but an expression was expected of type
+         < m : 'a. [< `Foo of int ] -> 'a >
+       Types for tag `Foo are incompatible
 |}];;
 (* ok *)
 let f (n : < m : 'a 'r. [< `Foo of 'a & int | `Bar] as 'r >) =
@@ -1579,22 +1576,13 @@ Error: This expression has type
          < m : 'b 'd. [< `Bar | `Foo of int & 'b ] as 'd >
        Types for tag `Foo are incompatible
 |}]
-(* fail? *)
+(* ok (with implicit universal quantification) *)
 let f (n : < m : 'a. [< `Foo of 'a & int | `Bar] >) =
   (n : < m : 'b. [< `Foo of 'b & int | `Bar] >)
 [%%expect{|
-Line 1:
-Error: Values do not match:
-         val f :
-           < m : 'a. [< `Bar | `Foo of 'a & int ] as 'c > -> < m : 'b. 'c >
-       is not included in
-         val f :
-           < m : 'a. [< `Bar | `Foo of 'b & int ] as 'c > -> < m : 'b. 'c >
-       The type
-         < m : 'a. [< `Bar | `Foo of 'b & int ] as 'c > -> < m : 'b. 'c >
-       is not compatible with the type
-         < m : 'a. [< `Bar | `Foo of 'b & int ] as 'd > -> < m : 'b. 'd >
-       Types for tag `Foo are incompatible
+val f :
+  < m : 'c 'a. [< `Bar | `Foo of 'a & int ] as 'c > ->
+  < m : 'd 'b. [< `Bar | `Foo of 'b & int ] as 'd > = <fun>
 |}]
 
 (* PR#6171 *)

--- a/testsuite/tests/typing-poly/poly.ml
+++ b/testsuite/tests/typing-poly/poly.ml
@@ -1988,12 +1988,12 @@ Error: This pattern matches values of type [? `Y ]
        it may not allow the tag(s) `Y
 |}]
 
-let fail_example_corrected: 'a . 'a -> [< `X of 'a | `Y > `X ] -> 'a = fun x y ->
+let fail_example_corrected: 'a . 'a -> [< `X of 'a | `Y ] -> 'a = fun x y ->
   match y with
   | `Y -> x
   | `X x -> x
 [%%expect {|
-val fail_example_corrected : 'a -> [< `X of 'a | `Y > `X ] -> 'a = <fun>
+val fail_example_corrected : 'a -> [< `X of 'a | `Y ] -> 'a = <fun>
 |}]
 
 

--- a/testsuite/tests/typing-polyvariants-bugs/pr10664a.ml
+++ b/testsuite/tests/typing-polyvariants-bugs/pr10664a.ml
@@ -115,30 +115,39 @@ val y :
   <obj>
 |}]
 
-(* Since the row variable is not explicitly bound, 'a and 'b leak *)
+(* Since the row variable is is implicitly bound, 'a and 'b don't leak *)
 
 let h (x : < m : 'a. <n : 'b. [< `A of 'a * 'b * 'c] > > as 'c) = x#m;;
 [%%expect{|
-Line 1, characters 66-69:
-1 | let h (x : < m : 'a. <n : 'b. [< `A of 'a * 'b * 'c] > > as 'c) = x#m;;
-                                                                      ^^^
-Error: This expression has type
-         < n : 'b. [< `A of 'a * 'b0 * < m : 'a. < n : 'b0. 'c > > ] as 'c >
-       but an expression was expected of type 'd
-       The universal variable 'a would escape its scope
+val h :
+  (< m : 'a. < n : 'd 'b. [< `A of 'a * 'b * 'c ] as 'd > > as 'c) ->
+  < n : 'e 'b. [< `A of 'f * 'b * 'c ] as 'e > = <fun>
+|}, Principal{|
+val h :
+  (< m : 'a. < n : 'd 'b. [< `A of 'a * 'b * 'c ] as 'd > > as 'c) ->
+  < n : 'e 'b.
+          [< `A of
+               'f * 'b *
+               (< m : 'a. < n : 'h 'b0. [< `A of 'a * 'b0 * 'g ] as 'h > >
+                as 'g) ]
+          as 'e > =
+  <fun>
 |}]
 
-(* Since the row variable is not bound, 'a leaks *)
+(* Since the row variable is implicitly bound, 'a doesn't leak *)
 
 let j (x : < m : 'a. <n : 'b. [< `A of 'a ] -> 'c > > as 'c) = x#m;;
 [%%expect{|
-Line 1, characters 63-66:
-1 | let j (x : < m : 'a. <n : 'b. [< `A of 'a ] -> 'c > > as 'c) = x#m;;
-                                                                   ^^^
-Error: This expression has type
-         < n : ([< `A of 'a ] as 'b) -> (< m : 'a. < n : 'b -> 'c > > as 'c) >
-       but an expression was expected of type 'd
-       The universal variable 'a would escape its scope
+val j :
+  (< m : 'a. < n : 'c. ([< `A of 'a ] as 'c) -> 'b > > as 'b) ->
+  < n : 'd. ([< `A of 'e ] as 'd) -> 'b > = <fun>
+|}, Principal{|
+val j :
+  (< m : 'a. < n : 'c. ([< `A of 'a ] as 'c) -> 'b > > as 'b) ->
+  < n : 'd.
+          ([< `A of 'e ] as 'd) ->
+          (< m : 'a. < n : 'g. ([< `A of 'a ] as 'g) -> 'f > > as 'f) > =
+  <fun>
 |}]
 
 let o =
@@ -147,11 +156,5 @@ let o =
       object method n _ = self end
   end;;
 [%%expect{|
-Lines 3-4, characters 4-34:
-3 | ....method m : 'a. < n : [< `A of 'a] -> 'b > =
-4 |       object method n _ = self end
-Error: The method m has type 'b but is expected to have type
-         < n : ([< `A of 'a ] as 'c) ->
-               (< m : 'a. < n : 'c -> 'd >; .. > as 'd) >
-       The universal variable 'a would escape its scope
+val o : < m : 'c 'a. < n : ([< `A of 'a ] as 'c) -> 'b > > as 'b = <obj>
 |}]

--- a/testsuite/tests/typing-polyvariants-bugs/pr10664a.ml
+++ b/testsuite/tests/typing-polyvariants-bugs/pr10664a.ml
@@ -115,7 +115,7 @@ val y :
   <obj>
 |}]
 
-(* Since the row variable is is implicitly bound, 'a and 'b don't leak *)
+(* Since the row variable is implicitly bound, 'a and 'b don't leak *)
 
 let h (x : < m : 'a. <n : 'b. [< `A of 'a * 'b * 'c] > > as 'c) = x#m;;
 [%%expect{|
@@ -139,14 +139,13 @@ val h :
 let j (x : < m : 'a. <n : 'b. [< `A of 'a ] -> 'c > > as 'c) = x#m;;
 [%%expect{|
 val j :
-  (< m : 'a. < n : 'c. ([< `A of 'a ] as 'c) -> 'b > > as 'b) ->
-  < n : 'd. ([< `A of 'e ] as 'd) -> 'b > = <fun>
+  (< m : 'c 'a. < n : ([< `A of 'a ] as 'c) -> 'b > > as 'b) ->
+  < n : [< `A of 'd ] -> 'b > = <fun>
 |}, Principal{|
 val j :
-  (< m : 'a. < n : 'c. ([< `A of 'a ] as 'c) -> 'b > > as 'b) ->
-  < n : 'd.
-          ([< `A of 'e ] as 'd) ->
-          (< m : 'a. < n : 'g. ([< `A of 'a ] as 'g) -> 'f > > as 'f) > =
+  (< m : 'c 'a. < n : ([< `A of 'a ] as 'c) -> 'b > > as 'b) ->
+  < n : [< `A of 'd ] ->
+        (< m : 'f 'a. < n : ([< `A of 'a ] as 'f) -> 'e > > as 'e) > =
   <fun>
 |}]
 

--- a/typing/typetexp.ml
+++ b/typing/typetexp.ml
@@ -99,7 +99,7 @@ module TyVarEnv : sig
        a new e.g. type signature. Optionally pass some univars that
        are in scope. *)
 
-  val lookup_local : string -> type_expr
+  val lookup_local : row_context:type_expr ref list -> string -> type_expr
     (* look up a local type variable; throws Not_found if it isn't in scope *)
 
   val remember_used : string -> type_expr -> Location.t -> unit
@@ -139,9 +139,16 @@ end = struct
      row variable in the ['a. < m : ty; .. > as 'a] idiom.  They are like the
      [used_variables], but will not be globalized in [globalize_used_variables].
   *)
-  let univars = ref ([] : (string * type_expr) list)
+  type pending_univar = {
+    univar: type_expr  (** the univar itself *);
+    mutable associated: type_expr ref list
+     (** associated references to row variables that we want to generalize
+       if possible *)
+  }
+
+  let univars = ref ([] : (string * pending_univar) list)
   let assert_univars uvs =
-    assert (List.for_all (fun (_name, v) -> not_generic v) uvs)
+    assert (List.for_all (fun (_name, v) -> not_generic v.univar) uvs)
 
   (* These are variables that will become univars when we're done with the
      current type. Used to force free variables in method types to become
@@ -182,7 +189,7 @@ end = struct
     TyVarMap.fold add_name !type_variables []
 
   (*****)
-  type poly_univars = (string * type_expr) list
+  type poly_univars = (string * pending_univar) list
 
   let with_univars new_ones f =
     assert_univars new_ones;
@@ -193,11 +200,24 @@ end = struct
       ~finally:(fun () -> univars := old_univars)
 
   let make_poly_univars vars =
-    List.map (fun name -> name, newvar ~name ()) vars
+    let make name = { univar=newvar ~name (); associated = [] } in
+    List.map (fun name -> name, make name ) vars
+
+  let promote_generics_to_univars promoted vars =
+      List.fold_left
+        (fun acc v ->
+           match get_desc v with
+           | Tvar name when get_level v = Btype.generic_level ->
+               set_type_desc v (Tunivar name);
+               v :: acc
+           | _ -> acc
+        )
+        promoted vars
 
   let check_poly_univars env loc vars =
-    vars |> List.iter (fun (_, v) -> generalize v);
-    vars |> List.map (fun (name, ty1) ->
+    vars |> List.iter (fun (_, p) -> generalize p.univar);
+    let univars =
+      vars |> List.map (fun (name, {univar=ty1; _ }) ->
       let v = Btype.proxy ty1 in
       begin match get_desc v with
       | Tvar name when get_level v = Btype.generic_level ->
@@ -206,6 +226,16 @@ end = struct
          raise (Error (loc, env, Cannot_quantify(name, v)))
       end;
       v)
+    in
+    (* Since we are checking univars in reverse order of bindings,
+       even if a row variable is associated with multiple univars, we will
+       promote it only when checking the nearest univar associated to this
+       row variable.
+    *)
+    let promote_associated acc (_,v) =
+      promote_generics_to_univars acc @@ List.map (!) v.associated
+    in
+    List.fold_left promote_associated univars vars
 
   let instance_poly_univars env loc vars =
     let vs = check_poly_univars env loc vars in
@@ -222,10 +252,16 @@ end = struct
     univars := uvs;
     used_variables := TyVarMap.empty
 
+  let associate row_context p =
+    let add l x = if List.memq x l then l else x :: l in
+    p.associated <- List.fold_left add row_context p.associated
+
   (* throws Not_found if the variable is not in scope *)
-  let lookup_local name =
+  let lookup_local ~row_context name =
     try
-      List.assoc name !univars
+      let p = List.assoc name !univars in
+      associate row_context p;
+      p.univar
     with Not_found ->
       instance (fst (TyVarMap.find name !used_variables))
       (* This call to instance might be redundant; all variables
@@ -252,18 +288,9 @@ end = struct
     | _ -> ()
 
   let collect_univars f =
-    Misc.protect_refs [R(pre_univars, [])] @@ fun () ->
     pre_univars := [];
     let result = f () in
-    let univs =
-      List.fold_left
-        (fun acc v ->
-           match get_desc v with
-           | Tvar name when get_level v = Btype.generic_level ->
-               set_type_desc v (Tunivar name);
-               v :: acc
-           | _ -> acc)
-        [] !pre_univars in
+    let univs = promote_generics_to_univars [] !pre_univars in
     result, univs
 
   let new_var ?name policy =
@@ -379,11 +406,11 @@ let transl_type_param env styp =
   Builtin_attributes.warning_scope styp.ptyp_attributes
     (fun () -> transl_type_param env styp)
 
-let rec transl_type env ~policy ~row_policy styp =
+let rec transl_type env ~policy ?(aliased=false) ~row_context styp =
   Builtin_attributes.warning_scope styp.ptyp_attributes
-    (fun () -> transl_type_aux env ~policy ~row_policy styp)
+    (fun () -> transl_type_aux env ~policy ~aliased ~row_context styp)
 
-and transl_type_aux env ~policy ~row_policy styp =
+and transl_type_aux env ~row_context ~aliased ~policy styp =
   let loc = styp.ptyp_loc in
   let ctyp ctyp_desc ctyp_type =
     { ctyp_desc; ctyp_type; ctyp_env = env;
@@ -398,7 +425,7 @@ and transl_type_aux env ~policy ~row_policy styp =
       if not (valid_tyvar_name name) then
         raise (Error (styp.ptyp_loc, env, Invalid_variable_name ("'" ^ name)));
       begin try
-        TyVarEnv.lookup_local name
+        TyVarEnv.lookup_local ~row_context:row_context name
       with Not_found ->
         let v = TyVarEnv.new_var ~name policy in
         TyVarEnv.remember_used name v styp.ptyp_loc;
@@ -407,8 +434,8 @@ and transl_type_aux env ~policy ~row_policy styp =
     in
     ctyp (Ttyp_var name) ty
   | Ptyp_arrow(l, st1, st2) ->
-    let cty1 = transl_type env ~policy ~row_policy st1 in
-    let cty2 = transl_type env ~policy ~row_policy st2 in
+    let cty1 = transl_type env ~policy ~row_context st1 in
+    let cty2 = transl_type env ~policy ~row_context st2 in
     let ty1 = cty1.ctyp_type in
     let ty1 =
       if Btype.is_optional l
@@ -418,7 +445,7 @@ and transl_type_aux env ~policy ~row_policy styp =
     ctyp (Ttyp_arrow (l, cty1, cty2)) ty
   | Ptyp_tuple stl ->
     assert (List.length stl >= 2);
-    let ctys = List.map (transl_type env ~policy ~row_policy) stl in
+    let ctys = List.map (transl_type env ~policy ~row_context) stl in
     let ty = newty (Ttuple (List.map (fun ctyp -> ctyp.ctyp_type) ctys)) in
     ctyp (Ttyp_tuple ctys) ty
   | Ptyp_constr(lid, stl) ->
@@ -433,7 +460,7 @@ and transl_type_aux env ~policy ~row_policy styp =
         raise(Error(styp.ptyp_loc, env,
                     Type_arity_mismatch(lid.txt, decl.type_arity,
                                         List.length stl)));
-      let args = List.map (transl_type env ~policy ~row_policy) stl in
+      let args = List.map (transl_type env ~policy ~row_context) stl in
       let params = instance_list decl.type_params in
       let unify_param =
         match decl.type_manifest with
@@ -452,7 +479,7 @@ and transl_type_aux env ~policy ~row_policy styp =
         newconstr path (List.map (fun ctyp -> ctyp.ctyp_type) args) in
       ctyp (Ttyp_constr (path, lid, args)) constr
   | Ptyp_object (fields, o) ->
-      let ty, fields = transl_fields env ~policy ~row_policy o fields in
+      let ty, fields = transl_fields env ~policy ~row_context o fields in
       ctyp (Ttyp_object (fields, o)) (newobj ty)
   | Ptyp_class(lid, stl) ->
       let (path, decl) =
@@ -463,7 +490,7 @@ and transl_type_aux env ~policy ~row_policy styp =
         raise(Error(styp.ptyp_loc, env,
                     Type_arity_mismatch(lid.txt, decl.type_arity,
                                         List.length stl)));
-      let args = List.map (transl_type env ~policy ~row_policy) stl in
+      let args = List.map (transl_type env ~policy ~row_context) stl in
       let body = Option.get decl.type_manifest in
       let (params, body) = instance_parameterized_type decl.type_params body in
       List.iter2
@@ -487,8 +514,8 @@ and transl_type_aux env ~policy ~row_policy styp =
   | Ptyp_alias(st, alias) ->
       let cty =
         try
-          let t = TyVarEnv.lookup_local alias in
-          let ty = transl_type env ~policy ~row_policy:policy st in
+          let t = TyVarEnv.lookup_local ~row_context alias in
+          let ty = transl_type env ~policy ~aliased:true ~row_context st in
           begin try unify_var env t ty.ctyp_type with Unify err ->
             let err = Errortrace.swap_unification_error err in
             raise(Error(styp.ptyp_loc, env, Alias_type_mismatch err))
@@ -499,7 +526,7 @@ and transl_type_aux env ~policy ~row_policy styp =
             with_local_level_if_principal begin fun () ->
               let t = newvar () in
               TyVarEnv.remember_used alias t styp.ptyp_loc;
-              let ty = transl_type env ~policy ~row_policy st in
+              let ty = transl_type env ~policy ~row_context st in
               begin try unify_var env t ty.ctyp_type with Unify err ->
                 let err = Errortrace.swap_unification_error err in
                 raise(Error(styp.ptyp_loc, env, Alias_type_mismatch err))
@@ -538,7 +565,7 @@ and transl_type_aux env ~policy ~row_policy styp =
         with Not_found ->
           Hashtbl.add hfields h (l,f)
       in
-      let add_field field =
+      let add_field row_context field =
         let rf_loc = field.prf_loc in
         let rf_attributes = field.prf_attributes in
         let rf_desc = match field.prf_desc with
@@ -546,7 +573,7 @@ and transl_type_aux env ~policy ~row_policy styp =
             name := None;
             let tl =
               Builtin_attributes.warning_scope rf_attributes
-                (fun () -> List.map (transl_type env ~policy ~row_policy) stl)
+                (fun () -> List.map (transl_type env ~policy ~row_context) stl)
             in
             let f = match present with
               Some present when not (List.mem l.txt present) ->
@@ -562,7 +589,7 @@ and transl_type_aux env ~policy ~row_policy styp =
             add_typed_field styp.ptyp_loc l.txt f;
               Ttag (l,c,tl)
         | Rinherit sty ->
-            let cty = transl_type env ~policy ~row_policy sty in
+            let cty = transl_type env ~policy ~row_context sty in
             let ty = cty.ctyp_type in
             let nm =
               match get_desc cty.ctyp_type with
@@ -594,7 +621,11 @@ and transl_type_aux env ~policy ~row_policy styp =
         in
         { rf_desc; rf_loc; rf_attributes; }
       in
-      let tfields = List.map add_field fields in
+      let more_ref = ref (newvar ()) in
+      let row_context =
+        if aliased then row_context else more_ref :: row_context
+      in
+      let tfields = List.map (add_field row_context) fields in
       let fields = List.rev (Hashtbl.fold (fun _ p l -> p :: l) hfields []) in
       begin match present with None -> ()
       | Some present ->
@@ -609,35 +640,25 @@ and transl_type_aux env ~policy ~row_policy styp =
       in
       let more =
         if Btype.static_row (make_row (newvar ())) then newty Tnil else
-           TyVarEnv.new_var row_policy
+           TyVarEnv.new_var policy
       in
+      more_ref := more;
       let ty = newty (Tvariant (make_row more)) in
       ctyp (Ttyp_variant (tfields, closed, present)) ty
   | Ptyp_poly(vars, st) ->
       let vars = List.map (fun v -> v.txt) vars in
-      let (new_univars, cty), implicit_row_univars =
-        let collect = match vars with
-          | [] ->
-              (* empty Ptyp_poly are a typechecker encoding  *)
-              (fun f -> f (), [])
-          | _ :: _ -> TyVarEnv.collect_univars
-        in
-        collect begin fun () ->
-          with_local_level begin fun () ->
-            let new_univars = TyVarEnv.make_poly_univars vars in
-            let cty = TyVarEnv.with_univars new_univars begin fun () ->
-              transl_type env ~policy ~row_policy:TyVarEnv.univars_policy st
-            end in
-            (new_univars, cty)
-          end
-          ~post:(fun (_,cty) -> generalize_ctyp cty)
+      let new_univars, cty =
+        with_local_level begin fun () ->
+          let new_univars = TyVarEnv.make_poly_univars vars in
+          let cty = TyVarEnv.with_univars new_univars begin fun () ->
+            transl_type env ~policy ~row_context st
+          end in
+          (new_univars, cty)
         end
+        ~post:(fun (_,cty) -> generalize_ctyp cty)
       in
-      let explicit_ty_list =
-        TyVarEnv.check_poly_univars env styp.ptyp_loc new_univars
-      in
-      let ty_list = implicit_row_univars @ explicit_ty_list in
       let ty = cty.ctyp_type in
+      let ty_list = TyVarEnv.check_poly_univars env styp.ptyp_loc new_univars in
       let ty_list = List.filter (fun v -> deep_occur v ty) ty_list in
       let ty' = Btype.newgenty (Tpoly(ty, ty_list)) in
       unify_var env (newvar()) ty';
@@ -649,7 +670,7 @@ and transl_type_aux env ~policy ~row_policy styp =
       let mty =
         TyVarEnv.with_local_scope (fun () -> !transl_modtype env mty) in
       let ptys = List.map (fun (s, pty) ->
-                             s, transl_type env ~policy ~row_policy pty
+                             s, transl_type env ~policy ~row_context pty
                           ) l in
       let path = !transl_modtype_longident loc env p.txt in
       let ty = newty (Tpackage (path,
@@ -664,7 +685,7 @@ and transl_type_aux env ~policy ~row_policy styp =
   | Ptyp_extension ext ->
       raise (Error_forward (Builtin_attributes.error_of_extension ext))
 
-and transl_fields env ~policy ~row_policy o fields =
+and transl_fields env ~policy ~row_context o fields =
   let hfields = Hashtbl.create 17 in
   let add_typed_field loc l ty =
     try
@@ -682,7 +703,7 @@ and transl_fields env ~policy ~row_policy o fields =
     | Otag (s, ty1) -> begin
         let ty1 =
           Builtin_attributes.warning_scope of_attributes
-            (fun () -> transl_type env ~policy ~row_policy
+            (fun () -> transl_type env ~policy ~row_context
                 (Ast_helper.Typ.force_poly ty1))
         in
         let field = OTtag (s, ty1) in
@@ -690,7 +711,7 @@ and transl_fields env ~policy ~row_policy o fields =
         field
       end
     | Oinherit sty -> begin
-        let cty = transl_type env ~policy ~row_policy sty in
+        let cty = transl_type env ~policy ~row_context sty in
         let nm =
           match get_desc cty.ctyp_type with
             Tconstr(p, _, _) -> Some p
@@ -756,7 +777,7 @@ let rec make_fixed_univars ty =
     end
 
 let transl_type env policy styp =
-  transl_type env ~policy ~row_policy:policy styp
+  transl_type env ~policy ~row_context:[] styp
 
 let make_fixed_univars ty =
   make_fixed_univars ty;
@@ -783,7 +804,7 @@ let transl_simple_type_univars env styp =
   end in
   make_fixed_univars typ.ctyp_type;
     { typ with ctyp_type =
-        instance (Btype.newgenty (Tpoly(typ.ctyp_type, univs))) }
+        instance (Btype.newgenty (Tpoly (typ.ctyp_type, univs))) }
 
 let transl_simple_type_delayed env styp =
   TyVarEnv.reset_locals ();

--- a/typing/typetexp.ml
+++ b/typing/typetexp.ml
@@ -228,10 +228,10 @@ end = struct
       end;
       v)
     in
-    (* Since we are checking univars in reverse order of bindings,
-       even if a row variable is associated with multiple univars, we will
-       promote it only when checking the nearest univar associated to this
-       row variable.
+    (* Since we are promoting variables to univars in
+       {!promote_generics_to_univars}, even if a row variable is associated with
+       multiple univars we will promote it once, when checking the nearest
+       univar associated to this row variable.
     *)
     let promote_associated acc (_,v) =
       let enclosed_rows = List.filter_map (!) v.associated in


### PR DESCRIPTION
Anonymous rows in polyvariant types like ``[> `Foo]`` can be perilous when mixed with explicitly polymorphic type annotation. Indeed, the hidden row variable might capture some of  the universal type variables. This behavior leads to the following error in OCaml 5.1 and later

```ocaml
let f: 'a. [> `Foo of 'a ] -> unit = fun _ -> ()
```
```
Error: This pattern matches values of type [> `Foo of 'a ]
       but a pattern was expected which matches values of type 'b
       The universal variable 'a would escape its scope
```

Unfortunately, this code was allowed by mistake before OCaml 5.1 . And fixing this bug broke some existing code (see #12189) without a painless workaround due to the short form for GADT:

```ocaml
let f: type a. [> `Foo of a ] -> unit = fun _ -> ()
```
In this case, fixing the error above requires to desugar by hand the short form.

To decrease the pain created by this bug fix, this PR proposes to bind anonymous row variables of syntactic polymorphic variant types to the nearest explicitly polymorphic type annotations. In other words,

```ocaml
let f: 'a. [> `Foo of 'a ] -> unit = fun _ -> ()
```
is read as
```ocaml
let f: 'a 'r. ([> `Foo of 'a ] as 'r) -> unit = fun _ -> ()
```

This new reading has the advantage of preserving the ability to use the short form`type a b c. ... ` when mixing GADTs and polymorphic variants in OCaml 5.1. Consider for instance:

```ocaml
type 'a w = Int: int w
let f: type a. a w -> [> `Foo of a ] -> unit = fun Int ->
function `Foo x -> x | _ -> 0
```
this short form is elaborated into
```ocaml
let f: 'a. 'a w -> [> `Foo of 'a ] -> 'a = (fun (type a) -> ... )
```
which is correct with the rule introduced in this PR that the anonymous row variable in `[> Foo ... ]` is bound at the `'a. ... ` level.

However, beware this PR is still a breaking change: users now need to add an alias to an unification variable if they really intended to use a global variable for the row variable:

```ocaml
let f: 'b. [< `Foo | `Bar ] -> 'b -> 'b = fun `Foo x -> x
```
needs to be rewritten after this PR into

```ocaml
let f: 'b. ([< `Foo | `Bar ] as 'r) -> 'b -> 'b = fun `Foo x -> x
```

Fix #12189