### PR TITLE
Fix the compilation of camlheader when BINDIR contains escaping characters

### DIFF
--- a/Changes
+++ b/Changes
@@ -30,6 +30,11 @@ Working version
 
 ### Build system:
 
+- #12214: Fix the compilation of camlheader when BINDIR contains escaping
+  characters. This can for example happen when compiling with
+  ./configure '--prefix=C:\some\directory' under Cygwin.
+  (Kate Deplaix, review by Sébastien Hinderer and Nicolás Ojeda Bär)
+
 ### Bug fixes:
 
 

--- a/Makefile
+++ b/Makefile
@@ -846,8 +846,6 @@ $(SAK): runtime/sak.$(O)
 runtime/sak.$(O): runtime/sak.c runtime/caml/misc.h runtime/caml/config.h
 	$(V_CC)$(SAK_CC) -c $(SAK_CFLAGS) $(OUTPUTOBJ)$@ $<
 
-C_LITERAL = $(shell $(SAK) encode-C-literal '$(1)')
-
 runtime/build_config.h: $(ROOTDIR)/Makefile.config $(SAK)
 	$(V_GEN)echo '/* This file is generated from $(ROOTDIR)/Makefile.config */' > $@ && \
 	echo '#define OCAML_STDLIB_DIR $(call C_LITERAL,$(LIBDIR))' >> $@ && \

--- a/Makefile.common
+++ b/Makefile.common
@@ -218,6 +218,7 @@ OCAMLYACCFLAGS ?= --strict -v
 	$(V_OCAMLYACC)$(OCAMLYACC) $(OCAMLYACCFLAGS) $<
 
 SAK = $(ROOTDIR)/runtime/sak$(EXE)
+C_LITERAL = $(shell $(SAK) encode-C-literal '$(1)')
 
 # stdlib/StdlibModules cannot be include'd unless $(SAK) has been built. These
 # two rules add that dependency. They have to be pattern rules since

--- a/stdlib/Makefile
+++ b/stdlib/Makefile
@@ -99,6 +99,9 @@ HEADER_PATH =
 HEADER_TARGET_PATH =
 endif
 
+C_RUNTIME_NAME = $(call C_LITERAL,$(HEADER_PATH)$(1))
+C_TARGET_RUNTIME_NAME = $(call C_LITERAL,$(HEADER_TARGET_PATH)$(1))
+
 TARGETHEADERPROGRAM = target_$(HEADERPROGRAM)
 
 # The shebang test in configure.ac will need updating if any runtime is
@@ -147,7 +150,7 @@ ifneq "$(UNIX_OR_WIN32)" "win32"
 endif
 
 $(HEADERPROGRAM)%$(O): \
-  OC_CPPFLAGS += -DRUNTIME_NAME='"$(HEADER_PATH)ocamlrun$(subst .,,$*)"'
+  OC_CPPFLAGS += -DRUNTIME_NAME='$(call C_RUNTIME_NAME,ocamlrun$(subst .,,$*))'
 
 $(HEADERPROGRAM)%$(O): $(HEADERPROGRAM).c
 	$(V_CC)$(CC) -c $(OC_CFLAGS) $(CFLAGS) $(OC_CPPFLAGS) $(CPPFLAGS) \
@@ -163,7 +166,7 @@ tmptargetcamlheader%exe: $(TARGETHEADERPROGRAM)%$(O)
 
 $(TARGETHEADERPROGRAM)%$(O): $(HEADERPROGRAM).c
 	$(V_CC)$(CC) -c $(OC_CFLAGS) $(CFLAGS) $(OC_CPPFLAGS) $(CPPFLAGS) \
-	      -DRUNTIME_NAME='"$(HEADER_TARGET_PATH)ocamlrun$(subst .,,$*)"' \
+	      -DRUNTIME_NAME='$(call C_TARGET_RUNTIME_NAME,ocamlrun$(subst .,,$*))' \
 	      $(OUTPUTOBJ)$@ $^
 
 target_%: tmptarget%.exe


### PR DESCRIPTION
This can happen when, for example, compiling OCaml on Cygwin with:
```
./configure '--prefix=C:\opam\default'
```