### PR TITLE
Add Array.shuffle

### DIFF
--- a/Changes
+++ b/Changes
@@ -15,7 +15,7 @@ Working version
 ### Standard library:
 
 - #12217: Add `Array.shuffle`.
-  (Daniel Bünzli, review by Nicolás Ojeda Bär and David Allsopp)
+  (Daniel Bünzli, review by Nicolás Ojeda Bär, David Allsopp and Alain Frisch)
 
 ### Other libraries:
 

--- a/Changes
+++ b/Changes
@@ -14,8 +14,8 @@ Working version
 
 ### Standard library:
 
-- #XXXXX: Add `Array.shuffle`.
-(Daniel Bünzli, review by XXX)
+- #12217: Add `Array.shuffle`.
+  (Daniel Bünzli, review by Nicolás Ojeda Bär and David Allsopp)
 
 ### Other libraries:
 

--- a/Changes
+++ b/Changes
@@ -14,6 +14,9 @@ Working version
 
 ### Standard library:
 
+- #XXXXX: Add `Array.shuffle`.
+(Daniel Bünzli, review by XXX)
+
 ### Other libraries:
 
 - #12213: Dynlink library, improve legibility of error messages

--- a/stdlib/array.ml
+++ b/stdlib/array.ml
@@ -422,7 +422,7 @@ let shuffle ~rand a = (* Fisher-Yates *)
   for i = length a - 1 downto 1 do
     let j = rand (i + 1) in
     let v = unsafe_get a i in
-    unsafe_set a i (unsafe_get a j);
+    unsafe_set a i (get a j);
     unsafe_set a j v
   done
 

--- a/stdlib/array.ml
+++ b/stdlib/array.ml
@@ -418,6 +418,14 @@ let stable_sort cmp a =
 
 let fast_sort = stable_sort
 
+let shuffle ~rand a = (* Fisher-Yates *)
+  for i = length a - 1 downto 1 do
+    let j = rand (i + 1) in
+    let v = unsafe_get a i in
+    unsafe_set a i (unsafe_get a j);
+    unsafe_set a j v
+  done
+
 (** {1 Iterators} *)
 
 let to_seq a =

--- a/stdlib/array.mli
+++ b/stdlib/array.mli
@@ -287,7 +287,7 @@ val combine : 'a array -> 'b array -> ('a * 'b) array
 
     @since 4.13 *)
 
-(** {1 Sorting} *)
+(** {1:sorting_and_shuffling Sorting and shuffling} *)
 
 val sort : ('a -> 'a -> int) -> 'a array -> unit
 (** Sort an array in increasing order according to a comparison
@@ -328,6 +328,17 @@ val fast_sort : ('a -> 'a -> int) -> 'a array -> unit
 (** Same as {!sort} or {!stable_sort}, whichever is
     faster on typical input. *)
 
+val shuffle :
+  rand: (* thwart tools/sync_stdlib_docs *) (int -> int) -> 'a array -> unit
+(** [shuffle rand a] randomly permutes [a]'s elements using [rand]
+    for randomness.
+
+    [rand] must be such that a call to [rand n] returns a uniformly
+    distributed random number in the range \[[0];[n-1]\].
+    {!Random.int} can be used for this (do not forget to
+    {{!Random.self_init}initialize} the generator).
+
+    @since 5.2 *)
 
 (** {1 Arrays and Sequences} *)
 

--- a/stdlib/array.mli
+++ b/stdlib/array.mli
@@ -330,8 +330,8 @@ val fast_sort : ('a -> 'a -> int) -> 'a array -> unit
 
 val shuffle :
   rand: (* thwart tools/sync_stdlib_docs *) (int -> int) -> 'a array -> unit
-(** [shuffle rand a] randomly permutes [a]'s elements using [rand]
-    for randomness.
+(** [shuffle rand a] randomly permutes [a]'s element using [rand] for
+    randomness. The distribution of permutations is uniform.
 
     [rand] must be such that a call to [rand n] returns a uniformly
     distributed random number in the range \[[0];[n-1]\].

--- a/stdlib/arrayLabels.mli
+++ b/stdlib/arrayLabels.mli
@@ -287,7 +287,7 @@ val combine : 'a array -> 'b array -> ('a * 'b) array
 
     @since 4.13 *)
 
-(** {1 Sorting} *)
+(** {1:sorting_and_shuffling Sorting and shuffling} *)
 
 val sort : cmp:('a -> 'a -> int) -> 'a array -> unit
 (** Sort an array in increasing order according to a comparison
@@ -328,6 +328,17 @@ val fast_sort : cmp:('a -> 'a -> int) -> 'a array -> unit
 (** Same as {!sort} or {!stable_sort}, whichever is
     faster on typical input. *)
 
+val shuffle :
+  rand: (* thwart tools/sync_stdlib_docs *) (int -> int) -> 'a array -> unit
+(** [shuffle ~rand a] randomly permutes [a]'s elements using [rand]
+    for randomness.
+
+    [rand] must be such that a call to [rand n] returns a uniformly
+    distributed random number in the range \[[0];[n-1]\].
+    {!Random.int} can be used for this (do not forget to
+    {{!Random.self_init}initialize} the generator).
+
+    @since 5.2 *)
 
 (** {1 Arrays and Sequences} *)
 

--- a/stdlib/arrayLabels.mli
+++ b/stdlib/arrayLabels.mli
@@ -330,8 +330,8 @@ val fast_sort : cmp:('a -> 'a -> int) -> 'a array -> unit
 
 val shuffle :
   rand: (* thwart tools/sync_stdlib_docs *) (int -> int) -> 'a array -> unit
-(** [shuffle ~rand a] randomly permutes [a]'s elements using [rand]
-    for randomness.
+(** [shuffle ~rand a] randomly permutes [a]'s element using [rand] for
+    randomness. The distribution of permutations is uniform.
 
     [rand] must be such that a call to [rand n] returns a uniformly
     distributed random number in the range \[[0];[n-1]\].

--- a/stdlib/float.ml
+++ b/stdlib/float.ml
@@ -528,6 +528,15 @@ module Array = struct
   let fast_sort = stable_sort
 
   (* duplicated from array.ml *)
+  let shuffle ~rand a = (* Fisher-Yates *)
+    for i = length a - 1 downto 1 do
+      let j = rand (i + 1) in
+      let v = unsafe_get a i in
+      unsafe_set a i (unsafe_get a j);
+      unsafe_set a j v
+    done
+
+  (* duplicated from array.ml *)
   let to_seq a =
     let rec aux i () =
       if i < length a

--- a/stdlib/float.ml
+++ b/stdlib/float.ml
@@ -532,7 +532,7 @@ module Array = struct
     for i = length a - 1 downto 1 do
       let j = rand (i + 1) in
       let v = unsafe_get a i in
-      unsafe_set a i (unsafe_get a j);
+      unsafe_set a i (get a j);
       unsafe_set a j v
     done
 

--- a/stdlib/float.mli
+++ b/stdlib/float.mli
@@ -725,7 +725,7 @@ module Array : sig
   val shuffle :
     rand: (* thwart tools/sync_stdlib_docs *) (int -> int) -> t -> unit
   (** [shuffle rand a] randomly permutes [a]'s elements using [rand]
-      for randomness.
+      for randomness. The distribution of permutations is uniform.
 
       [rand] must be such that a call to [rand n] returns a uniformly
       distributed random number in the range \[[0];[n-1]\].
@@ -1071,7 +1071,7 @@ module ArrayLabels : sig
   val shuffle :
     rand: (* thwart tools/sync_stdlib_docs *) (int -> int) -> t -> unit
   (** [shuffle ~rand a] randomly permutes [a]'s elements using [rand]
-      for randomness.
+      for randomness. The distribution of permutations is uniform.
 
       [rand] must be such that a call to [rand n] returns a uniformly
       distributed random number in the range \[[0];[n-1]\].

--- a/stdlib/float.mli
+++ b/stdlib/float.mli
@@ -580,7 +580,7 @@ module Array : sig
       @raise Invalid_argument if the length of [l] is greater than
       [Sys.max_floatarray_length].*)
 
-  (** {2 Iterators} *)
+  (** {1 Iterators} *)
 
   val iter : (float -> unit) -> t -> unit
   (** [iter f a] applies function [f] in turn to all
@@ -621,7 +621,7 @@ module Array : sig
       [f a.(0) (f a.(1) ( ... (f a.(n-1) init) ...))],
       where [n] is the length of the floatarray [a]. *)
 
-  (** {2 Iterators on two arrays} *)
+  (** {1 Iterators on two arrays} *)
 
   val iter2 : (float -> float -> unit) -> t -> t -> unit
   (** [Array.iter2 f a b] applies function [f] to all the elements of [a]
@@ -634,7 +634,7 @@ module Array : sig
       [[| f a.(0) b.(0); ...; f a.(length a - 1) b.(length b - 1)|]].
       @raise Invalid_argument if the floatarrays are not the same size. *)
 
-  (** {2 Array scanning} *)
+  (** {1 Array scanning} *)
 
   val for_all : (float -> bool) -> t -> bool
   (** [for_all f [|a1; ...; an|]] checks if all elements of the floatarray
@@ -654,7 +654,7 @@ module Array : sig
   val mem_ieee : float -> t -> bool
   (** Same as {!mem}, but uses IEEE equality instead of structural equality. *)
 
-  (** {2 Array searching} *)
+  (** {1 Array searching} *)
 
   val find_opt : (float -> bool) -> t -> float option
   (* [find_opt f a] returns the first element of the array [a] that satisfies
@@ -682,7 +682,7 @@ module Array : sig
 
      @since 5.1 *)
 
-  (** {2 Sorting} *)
+  (** {1 Sorting} *)
 
   val sort : (float -> float -> int) -> t -> unit
   (** Sort a floatarray in increasing order according to a comparison
@@ -722,7 +722,7 @@ module Array : sig
   (** Same as {!sort} or {!stable_sort}, whichever is faster
       on typical input. *)
 
-  (** {2 Float arrays and Sequences} *)
+  (** {1 Float arrays and Sequences} *)
 
   val to_seq : t -> float Seq.t
   (** Iterate on the floatarray, in increasing order. Modifications of the
@@ -822,7 +822,7 @@ module Array : sig
 
   (**/**)
 
-  (** {2 Undocumented functions} *)
+  (** {1 Undocumented functions} *)
 
   (* These functions are for system use only. Do not call directly. *)
   external unsafe_get : t -> int -> float = "%floatarray_unsafe_get"
@@ -914,7 +914,7 @@ module ArrayLabels : sig
       @raise Invalid_argument if the length of [l] is greater than
       [Sys.max_floatarray_length].*)
 
-  (** {2 Iterators} *)
+  (** {1 Iterators} *)
 
   val iter : f:(float -> unit) -> t -> unit
   (** [iter ~f a] applies function [f] in turn to all
@@ -955,7 +955,7 @@ module ArrayLabels : sig
       [f a.(0) (f a.(1) ( ... (f a.(n-1) init) ...))],
       where [n] is the length of the floatarray [a]. *)
 
-  (** {2 Iterators on two arrays} *)
+  (** {1 Iterators on two arrays} *)
 
   val iter2 : f:(float -> float -> unit) -> t -> t -> unit
   (** [Array.iter2 ~f a b] applies function [f] to all the elements of [a]
@@ -968,7 +968,7 @@ module ArrayLabels : sig
       [[| f a.(0) b.(0); ...; f a.(length a - 1) b.(length b - 1)|]].
       @raise Invalid_argument if the floatarrays are not the same size. *)
 
-  (** {2 Array scanning} *)
+  (** {1 Array scanning} *)
 
   val for_all : f:(float -> bool) -> t -> bool
   (** [for_all ~f [|a1; ...; an|]] checks if all elements of the floatarray
@@ -988,7 +988,7 @@ module ArrayLabels : sig
   val mem_ieee : float -> set:t -> bool
   (** Same as {!mem}, but uses IEEE equality instead of structural equality. *)
 
-  (** {2 Array searching} *)
+  (** {1 Array searching} *)
 
   val find_opt : f:(float -> bool) -> t -> float option
   (* [find_opt ~f a] returns the first element of the array [a] that satisfies
@@ -1016,7 +1016,7 @@ module ArrayLabels : sig
 
      @since 5.1 *)
 
-  (** {2 Sorting} *)
+  (** {1 Sorting} *)
 
   val sort : cmp:(float -> float -> int) -> t -> unit
   (** Sort a floatarray in increasing order according to a comparison
@@ -1056,7 +1056,7 @@ module ArrayLabels : sig
   (** Same as {!sort} or {!stable_sort}, whichever is faster
       on typical input. *)
 
-  (** {2 Float arrays and Sequences} *)
+  (** {1 Float arrays and Sequences} *)
 
   val to_seq : t -> float Seq.t
   (** Iterate on the floatarray, in increasing order. Modifications of the
@@ -1156,7 +1156,7 @@ module ArrayLabels : sig
 
   (**/**)
 
-  (** {2 Undocumented functions} *)
+  (** {1 Undocumented functions} *)
 
   (* These functions are for system use only. Do not call directly. *)
   external unsafe_get : t -> int -> float = "%floatarray_unsafe_get"

--- a/stdlib/float.mli
+++ b/stdlib/float.mli
@@ -682,7 +682,7 @@ module Array : sig
 
      @since 5.1 *)
 
-  (** {1 Sorting} *)
+  (** {1:sorting_and_shuffling Sorting and shuffling} *)
 
   val sort : (float -> float -> int) -> t -> unit
   (** Sort a floatarray in increasing order according to a comparison
@@ -721,6 +721,18 @@ module Array : sig
   val fast_sort : (float -> float -> int) -> t -> unit
   (** Same as {!sort} or {!stable_sort}, whichever is faster
       on typical input. *)
+
+  val shuffle :
+    rand: (* thwart tools/sync_stdlib_docs *) (int -> int) -> t -> unit
+  (** [shuffle rand a] randomly permutes [a]'s elements using [rand]
+      for randomness.
+
+      [rand] must be such that a call to [rand n] returns a uniformly
+      distributed random number in the range \[[0];[n-1]\].
+      {!Random.int} can be used for this (do not forget to
+      {{!Random.self_init}initialize} the generator).
+
+      @since 5.2 *)
 
   (** {1 Float arrays and Sequences} *)
 
@@ -1016,7 +1028,7 @@ module ArrayLabels : sig
 
      @since 5.1 *)
 
-  (** {1 Sorting} *)
+  (** {1:sorting_and_shuffling Sorting and shuffling} *)
 
   val sort : cmp:(float -> float -> int) -> t -> unit
   (** Sort a floatarray in increasing order according to a comparison
@@ -1055,6 +1067,18 @@ module ArrayLabels : sig
   val fast_sort : cmp:(float -> float -> int) -> t -> unit
   (** Same as {!sort} or {!stable_sort}, whichever is faster
       on typical input. *)
+
+  val shuffle :
+    rand: (* thwart tools/sync_stdlib_docs *) (int -> int) -> t -> unit
+  (** [shuffle ~rand a] randomly permutes [a]'s elements using [rand]
+      for randomness.
+
+      [rand] must be such that a call to [rand n] returns a uniformly
+      distributed random number in the range \[[0];[n-1]\].
+      {!Random.int} can be used for this (do not forget to
+      {{!Random.self_init}initialize} the generator).
+
+      @since 5.2 *)
 
   (** {1 Float arrays and Sequences} *)
 

--- a/stdlib/templates/floatarraylabeled.template.mli
+++ b/stdlib/templates/floatarraylabeled.template.mli
@@ -96,7 +96,7 @@ val of_list : float list -> t
     @raise Invalid_argument if the length of [l] is greater than
     [Sys.max_floatarray_length].*)
 
-(** {2 Iterators} *)
+(** {1 Iterators} *)
 
 val iter : f:(float -> unit) -> t -> unit
 (** [iter ~f a] applies function [f] in turn to all
@@ -137,7 +137,7 @@ val fold_right : f:(float -> 'acc -> 'acc) -> t -> init:'acc -> 'acc
     [f a.(0) (f a.(1) ( ... (f a.(n-1) init) ...))],
     where [n] is the length of the floatarray [a]. *)
 
-(** {2 Iterators on two arrays} *)
+(** {1 Iterators on two arrays} *)
 
 val iter2 : f:(float -> float -> unit) -> t -> t -> unit
 (** [Array.iter2 ~f a b] applies function [f] to all the elements of [a]
@@ -150,7 +150,7 @@ val map2 : f:(float -> float -> float) -> t -> t -> t
     [[| f a.(0) b.(0); ...; f a.(length a - 1) b.(length b - 1)|]].
     @raise Invalid_argument if the floatarrays are not the same size. *)
 
-(** {2 Array scanning} *)
+(** {1 Array scanning} *)
 
 val for_all : f:(float -> bool) -> t -> bool
 (** [for_all ~f [|a1; ...; an|]] checks if all elements of the floatarray
@@ -170,7 +170,7 @@ val mem : float -> set:t -> bool
 val mem_ieee : float -> set:t -> bool
 (** Same as {!mem}, but uses IEEE equality instead of structural equality. *)
 
-(** {2 Array searching} *)
+(** {1 Array searching} *)
 
 val find_opt : f:(float -> bool) -> t -> float option
 (* [find_opt ~f a] returns the first element of the array [a] that satisfies
@@ -198,7 +198,7 @@ val find_mapi : f:(int -> float -> 'a option) -> t -> 'a option
 
    @since 5.1 *)
 
-(** {2 Sorting} *)
+(** {1 Sorting} *)
 
 val sort : cmp:(float -> float -> int) -> t -> unit
 (** Sort a floatarray in increasing order according to a comparison
@@ -238,7 +238,7 @@ val fast_sort : cmp:(float -> float -> int) -> t -> unit
 (** Same as {!sort} or {!stable_sort}, whichever is faster
     on typical input. *)
 
-(** {2 Float arrays and Sequences} *)
+(** {1 Float arrays and Sequences} *)
 
 val to_seq : t -> float Seq.t
 (** Iterate on the floatarray, in increasing order. Modifications of the
@@ -338,7 +338,7 @@ let () = Domain.join d1; Domain.join d2
 
 (**/**)
 
-(** {2 Undocumented functions} *)
+(** {1 Undocumented functions} *)
 
 (* These functions are for system use only. Do not call directly. *)
 external unsafe_get : t -> int -> float = "%floatarray_unsafe_get"

--- a/stdlib/templates/floatarraylabeled.template.mli
+++ b/stdlib/templates/floatarraylabeled.template.mli
@@ -241,7 +241,7 @@ val fast_sort : cmp:(float -> float -> int) -> t -> unit
 val shuffle :
   rand: (* thwart tools/sync_stdlib_docs *) (int -> int) -> t -> unit
 (** [shuffle ~rand a] randomly permutes [a]'s elements using [rand]
-    for randomness.
+    for randomness. The distribution of permutations is uniform.
 
     [rand] must be such that a call to [rand n] returns a uniformly
     distributed random number in the range \[[0];[n-1]\].

--- a/stdlib/templates/floatarraylabeled.template.mli
+++ b/stdlib/templates/floatarraylabeled.template.mli
@@ -198,7 +198,7 @@ val find_mapi : f:(int -> float -> 'a option) -> t -> 'a option
 
    @since 5.1 *)
 
-(** {1 Sorting} *)
+(** {1:sorting_and_shuffling Sorting and shuffling} *)
 
 val sort : cmp:(float -> float -> int) -> t -> unit
 (** Sort a floatarray in increasing order according to a comparison
@@ -237,6 +237,18 @@ val stable_sort : cmp:(float -> float -> int) -> t -> unit
 val fast_sort : cmp:(float -> float -> int) -> t -> unit
 (** Same as {!sort} or {!stable_sort}, whichever is faster
     on typical input. *)
+
+val shuffle :
+  rand: (* thwart tools/sync_stdlib_docs *) (int -> int) -> t -> unit
+(** [shuffle ~rand a] randomly permutes [a]'s elements using [rand]
+    for randomness.
+
+    [rand] must be such that a call to [rand n] returns a uniformly
+    distributed random number in the range \[[0];[n-1]\].
+    {!Random.int} can be used for this (do not forget to
+    {{!Random.self_init}initialize} the generator).
+
+    @since 5.2 *)
 
 (** {1 Float arrays and Sequences} *)
 


### PR DESCRIPTION
Today I got tired of c&p this bit. 

```ocaml
val shuffle : rand:(int -> int) -> 'a array -> unit
(** [shuffle rand a] randomly permutes [a]'s elements using [rand]
    for randomness.

    [rand] must be such that a call to [rand n] returns a uniformly
    distributed random number in the range \[[0];[n-1]\].
    {!Random.int} can be used for this (do not forget to
    {{!Random.self_init}initialize} the generator).
```

Implemented via [Fisher-Yates](https://en.wikipedia.org/wiki/Fisher%E2%80%93Yates_shuffle#The_modern_algorithm).