### PR TITLE
Format_tutorial: Tell readers how they can set the line width in columns

### DIFF
--- a/api_docgen/Format_tutorial.mld
+++ b/api_docgen/Format_tutorial.mld
@@ -291,6 +291,9 @@ vertical box!
 + End your main program by a [print_newline ()] call, that flushes the
 pretty-printer tables (hence the output).  (Note that the top-level loop of the
 interactive system does it as well, just before a new input.)
++ By default, a line is assumed to be 78 columns wide. To set a different width
+you can use ([Format.set_margin]) if you're using ([Format.printf]) or
+([Format.pp_set_margin]) if you wish to set the width for a specific formatter.
 
 {1 Printing to stdout: using printf}
 


### PR DESCRIPTION
The format tutorial says:
 “break hints are used to cut the line when there is no more room on the line”.

Which leads to the question:
  How do you tell Format what width it should assume for a line?

Add a practical advice point to the tutorial

----

More context: https://discuss.ocaml.org/t/format-when-is-there-no-more-room-on-a-line/12083