### PR TITLE
Linear-time closure computation

### DIFF
--- a/Changes
+++ b/Changes
@@ -163,6 +163,11 @@ Working version
   type to be ignored (see tests/typing-misc/constraints.ml).
   (Jacques Garrigue, report by Richard Eisenberg, review by Leo White)
 
+- #12207, #12222: Make closure computation linear in the number of recursive
+  functions instead of quadratic
+  (Vincent Laviron, report by François Pottier, review by Nathanaëlle Courant
+  and Gabriel Scherer)
+
 
 OCaml 5.1.0
 ---------------

--- a/bytecomp/instruct.ml
+++ b/bytecomp/instruct.ml
@@ -15,10 +15,20 @@
 
 open Lambda
 
+type closure_entry =
+  | Free_variable of int
+  | Function of int
+
+type closure_env =
+  | Not_in_closure
+  | In_closure of {
+      entries: closure_entry Ident.tbl;
+      env_pos: int;
+    }
+
 type compilation_env =
   { ce_stack: int Ident.tbl;
-    ce_heap: int Ident.tbl;
-    ce_rec: int Ident.tbl }
+    ce_closure: closure_env }
 
 type debug_event =
   { mutable ev_pos: int;                (* Position in bytecode *)

--- a/bytecomp/instruct.mli
+++ b/bytecomp/instruct.mli
@@ -19,21 +19,35 @@ open Lambda
 
 (* Structure of compilation environments *)
 
+type closure_entry =
+  | Free_variable of int
+  | Function of int
+
+type closure_env =
+  | Not_in_closure
+  | In_closure of {
+      entries: closure_entry Ident.tbl; (* Offsets of the free variables and
+                                           recursive functions from the start of
+                                           the block *)
+      env_pos: int;                     (* Offset of the current function from
+                                           the start of the block *)
+    }
+
 type compilation_env =
-  { ce_stack: int Ident.tbl; (* Positions of variables in the stack *)
-    ce_heap: int Ident.tbl;  (* Structure of the heap-allocated env *)
-    ce_rec: int Ident.tbl }  (* Functions bound by the same let rec *)
+  { ce_stack: int Ident.tbl;  (* Positions of variables in the stack *)
+    ce_closure: closure_env } (* Structure of the heap-allocated env *)
 
 (* The ce_stack component gives locations of variables residing
    in the stack. The locations are offsets w.r.t. the origin of the
    stack frame.
-   The ce_heap component gives the positions of variables residing in the
-   heap-allocated environment.
-   The ce_rec component associates offsets to identifiers for functions
-   bound by the same let rec as the current function.  The offsets
-   are used by the OFFSETCLOSURE instruction to recover the closure
-   pointer of the desired function from the env register (which
-   points to the closure for the current function). *)
+   The ce_closure component gives the positions of variables residing in the
+   heap-allocated environment. The env_pos component gives the position of
+   the current function from the start of the closure block, and the entries
+   component gives the positions of free variables and functions bound by the
+   same let rec as the current function, from the start of the closure block.
+   These are used by the ENVACC and OFFSETCLOSURE instructions to recover the
+   relevant value from the env register (which points to the current function).
+*)
 
 (* Debugging events *)
 


### PR DESCRIPTION
This PR adapts the algorithms for closure conversion in the bytecode and native compilers so that their complexity stays (pseudo-)linear in the number of mutually-recursive functions that are being compiled.

In essence, the compilation environments used to store information about the other functions (and free variables) in relative form: the environment for `f_i` would store the relative offsets from `f_i` to all other functions `f_j`.
There is no obvious sharing for these environments, so in practice each individual environment takes a linear time to build and there is a linear number of them, so we get quadratic complexity.

With my patch, environments now store a shared part that is the absolute offsets from the start of the block for each function, and a relative part that is just the offset for the current function (and the environment parameter in native mode). This means that we take a linear time computing the shared part, then each function takes a constant time building its relative part, so the overall time stays linear.

Fixes #12207.

Note that Flambda is likely still quadratic on sets of recursive functions (at least at toplevel), but not for the same reasons. Instead, an issue with the code that transforms constant expressions (including closed functions) into statically-allocated data makes these examples quadratic. This problem also occurs on nested functions, and is tracked in issue #7826.