### PR TITLE
Functor error messages: signatures are not functors

### DIFF
--- a/Changes
+++ b/Changes
@@ -145,6 +145,10 @@ Working version
 - #12347: error messages: always report missing polyvariant tags
   (Florian Angeletti, report by Tianbo Hao, review by Gabriel Scherer)
 
+- #12224, specialized error message when trying to apply non-functor
+  module (e.g `module M = Int(Int)`)
+  (Florian Angeletti, review by ???)
+
 ### Internal/compiler-libs changes:
 
 - #12216, #12248: Prevent reordering of atomic loads during instruction

--- a/Changes
+++ b/Changes
@@ -147,7 +147,7 @@ Working version
 
 - #12224, specialized error message when trying to apply non-functor
   module (e.g `module M = Int(Int)`)
-  (Florian Angeletti, review by ???)
+  (Florian Angeletti, review by Gabriel Scherer)
 
 ### Internal/compiler-libs changes:
 

--- a/testsuite/tests/typing-modules/functors.ml
+++ b/testsuite/tests/typing-modules/functors.ml
@@ -41,7 +41,7 @@ module M = F(X)(Z)
 Line 1, characters 11-18:
 1 | module M = F(X)(Z)
                ^^^^^^^
-Error: The functor application is ill-typed.
+Error: This functor application of F is ill-typed.
        These arguments:
          X Z
        do not match these parameters:
@@ -152,7 +152,7 @@ module F : functor () (X : sig type t end) -> sig end
 Line 2, characters 11-16:
 2 | module M = F()()
                ^^^^^
-Error: The functor application is ill-typed.
+Error: This functor application of F is ill-typed.
        These arguments:
          () ()
        do not match these parameters:
@@ -204,7 +204,7 @@ end
 Line 9, characters 13-20:
 9 |   module M = F(Y)(X)
                  ^^^^^^^
-Error: The functor application is ill-typed.
+Error: This functor application of F is ill-typed.
        These arguments:
          Ctx.Y Ctx.X
        do not match these parameters:
@@ -221,7 +221,7 @@ module Ord : sig type t = unit val compare : 'a -> 'b -> int end
 Line 2, characters 11-29:
 2 | module M = Map.Make(Ord)(Ord)
                ^^^^^^^^^^^^^^^^^^
-Error: The functor application is ill-typed.
+Error: This functor application of Map.Make is ill-typed.
        These arguments:
          Ord Ord
        do not match these parameters:
@@ -250,7 +250,7 @@ module K : sig type x = X.x type y = Y.y end
 Line 10, characters 11-73:
 10 | module M = F(K)(struct type x = K.x end)( (* struct type z = K.y end *) )
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The functor application is ill-typed.
+Error: This functor application of F is ill-typed.
        These arguments:
          K $S2 ()
        do not match these parameters:
@@ -265,7 +265,7 @@ module M = F(K)(struct type y = K.y end)
 Line 1, characters 11-40:
 1 | module M = F(K)(struct type y = K.y end)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The functor application is ill-typed.
+Error: This functor application of F is ill-typed.
        These arguments:
          K $S3
        do not match these parameters:
@@ -288,7 +288,7 @@ Lines 2-5, characters 2-30:
 3 |     (struct include X include Y end)
 4 |     (struct type x = K.x end)
 5 |     (struct type yy = K.y end)
-Error: The functor application is ill-typed.
+Error: This functor application of F is ill-typed.
        These arguments:
          $S1 $S2 $S3
        do not match these parameters:
@@ -323,7 +323,7 @@ module Defs :
 Line 13, characters 19-33:
 13 | module Missing_X = F(M.N)(Defs.Y)
                         ^^^^^^^^^^^^^^
-Error: The functor application is ill-typed.
+Error: This functor application of F is ill-typed.
        These arguments:
          M.N Defs.Y
        do not match these parameters:
@@ -339,7 +339,7 @@ module Too_many_Xs = F(M.N)(Defs.X)(Defs.X)(Defs.Y)
 Line 1, characters 21-51:
 1 | module Too_many_Xs = F(M.N)(Defs.X)(Defs.X)(Defs.Y)
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The functor application is ill-typed.
+Error: This functor application of F is ill-typed.
        These arguments:
          M.N Defs.X Defs.X Defs.Y
        do not match these parameters:
@@ -361,7 +361,7 @@ module Y : sig type y = float end
 Line 3, characters 23-67:
 3 | module Missing_X_bis = F(struct type x = int type y = float end)(Y)
                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The functor application is ill-typed.
+Error: This functor application of F is ill-typed.
        These arguments:
          $S1 Y
        do not match these parameters:
@@ -377,7 +377,7 @@ module Too_many_Xs_bis = F(struct type x = int type y = float end)(X)(X)(Y)
 Line 1, characters 25-75:
 1 | module Too_many_Xs_bis = F(struct type x = int type y = float end)(X)(X)(Y)
                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The functor application is ill-typed.
+Error: This functor application of F is ill-typed.
        These arguments:
          $S1 X X Y
        do not match these parameters:
@@ -513,7 +513,7 @@ module F : functor (X : x) (B : b) (Y : y) -> sig type t end
 Line 8, characters 15-57:
 8 |     module U = F(struct type x end)(B)(struct type w end)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The functor application is ill-typed.
+Error: This functor application of F is ill-typed.
        These arguments:
          $S1 P.B $S3
        do not match these parameters:
@@ -1253,7 +1253,7 @@ module W = F(PF)(PF)(PF)(PF)(PF)(F)
 Line 1, characters 11-35:
 1 | module W = F(PF)(PF)(PF)(PF)(PF)(F)
                ^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The functor application is ill-typed.
+Error: This functor application of F is ill-typed.
        These arguments:
          PF PF PF PF PF F
        do not match these parameters:
@@ -1319,7 +1319,7 @@ module Choose_one = F(Add_one')(Add_three)(A)(A)(A)
 Line 1, characters 20-51:
 1 | module Choose_one = F(Add_one')(Add_three)(A)(A)(A)
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The functor application is ill-typed.
+Error: This functor application of F is ill-typed.
        These arguments:
          Add_one' Add_three A A A
        do not match these parameters:
@@ -1341,7 +1341,7 @@ module Mislead_chosen_one = F(Add_one)(Add_three)(A)(A)(A)
 Line 1, characters 28-58:
 1 | module Mislead_chosen_one = F(Add_one)(Add_three)(A)(A)(A)
                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The functor application is ill-typed.
+Error: This functor application of F is ill-typed.
        These arguments:
          Add_one Add_three A A A
        do not match these parameters:
@@ -1563,7 +1563,7 @@ module Z : sig type t = Z of int end
 Line 9, characters 13-48:
 9 | module Error=F(X)(struct type t = int end)(Y)(Z)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The functor application is ill-typed.
+Error: This functor application of F is ill-typed.
        These arguments:
          X ... Y Z
        do not match these parameters:
@@ -1745,7 +1745,7 @@ module F : functor () (X : empty) () (Y : A) -> sig end
 Line 3, characters 2-73:
 3 |   F(struct end[@warning "-73"])(struct end)(struct end[@warning "-73"])();;
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The functor application is ill-typed.
+Error: This functor application of F is ill-typed.
        These arguments:
          (struct end) (struct end) (struct end) ()
        do not match these parameters:
@@ -1765,7 +1765,7 @@ module F : functor (X : empty) -> sig end
 Line 3, characters 2-17:
 3 |   F(struct end)();;
       ^^^^^^^^^^^^^^^
-Error: The functor application is ill-typed.
+Error: This functor application of F is ill-typed.
        These arguments:
          (struct end) ()
        do not match these parameters:
@@ -1808,7 +1808,7 @@ Lines 15-21, characters 2-8:
 19 |     (struct
 20 |       let f x = x   (* this is bogus! *)
 21 |     end)
-Error: The functor application is ill-typed.
+Error: This functor application of F is ill-typed.
        These arguments:
          $S1 $S2
        do not match these parameters:
@@ -1844,7 +1844,7 @@ module G :
 Line 8, characters 11-52:
 8 | module R = G(struct end)(struct let f (x,_) = x end)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The functor application is ill-typed.
+Error: This functor application of G is ill-typed.
        These arguments:
          (struct end) $S2
        do not match these parameters:
@@ -1880,7 +1880,7 @@ Lines 5-11, characters 11-6:
  9 |     ()
 10 |     ()
 11 |     ()
-Error: The functor application is ill-typed.
+Error: This functor application of With_expansion is ill-typed.
        These arguments:
          $S1 () () ()
        do not match these parameters:
@@ -1906,7 +1906,7 @@ Lines 1-6, characters 12-6:
 4 |   end)
 5 |     ()
 6 |     ()
-Error: The functor application is ill-typed.
+Error: This functor application of With_expansion is ill-typed.
        These arguments:
          $S1 () ()
        do not match these parameters:
@@ -1957,7 +1957,7 @@ Lines 18-25, characters 2-8:
 23 |     (struct
 24 |       let f x = x   (* this is fine *)
 25 |     end)
-Error: The functor application is ill-typed.
+Error: This functor application of H is ill-typed.
        These arguments:
          $S1 $S2
        do not match these parameters:
@@ -2023,4 +2023,40 @@ Error: Signature mismatch:
             type 'a t = 'a list
           The type "'a * 'a" is not equal to the type "'a list"
        2. Module types $S2 and $T2 match
+|}]
+
+
+(** Application of non-functor *)
+
+module K = List(A)(B)
+[%%expect {|
+Line 3, characters 11-21:
+3 | module K = List(A)(B)
+               ^^^^^^^^^^
+Error: The module List is not a functor, it cannot be applied.
+|}]
+
+module Error = (struct end)(B)
+[%%expect {|
+Line 1, characters 15-30:
+1 | module Error = (struct end)(B)
+                   ^^^^^^^^^^^^^^^
+Error: This module is not a functor, it cannot be applied.
+|}]
+
+let f (x:Set.Make(Set)(A).t) = x
+[%%expect {|
+Line 1, characters 9-27:
+1 | let f (x:Set.Make(Set)(A).t) = x
+             ^^^^^^^^^^^^^^^^^^
+Error: The functor application Set.Make(Set)(A) is ill-typed.
+       These arguments:
+         Set A
+       do not match these parameters:
+         functor (Ord : Set.OrderedType) -> ...
+       1. The following extra argument is provided Set : (module Set)
+       2. Modules do not match:
+            A : sig type a = A.a end
+          is not included in
+            Set.OrderedType
 |}]

--- a/testsuite/tests/typing-modules/functors.ml
+++ b/testsuite/tests/typing-modules/functors.ml
@@ -41,7 +41,7 @@ module M = F(X)(Z)
 Line 1, characters 11-18:
 1 | module M = F(X)(Z)
                ^^^^^^^
-Error: This application of the functor F is ill-typed.
+Error: This application of the functor "F" is ill-typed.
        These arguments:
          X Z
        do not match these parameters:
@@ -134,7 +134,7 @@ module F :
 Line 4, characters 9-18:
 4 | type u = F(X)(Z).t
              ^^^^^^^^^
-Error: The functor application F(X)(Z) is ill-typed.
+Error: The functor application "F(X)(Z)" is ill-typed.
        These arguments:
          X Z
        do not match these parameters:
@@ -152,7 +152,7 @@ module F : functor () (X : sig type t end) -> sig end
 Line 2, characters 11-16:
 2 | module M = F()()
                ^^^^^
-Error: This application of the functor F is ill-typed.
+Error: This application of the functor "F" is ill-typed.
        These arguments:
          () ()
        do not match these parameters:
@@ -204,7 +204,7 @@ end
 Line 9, characters 13-20:
 9 |   module M = F(Y)(X)
                  ^^^^^^^
-Error: This application of the functor F is ill-typed.
+Error: This application of the functor "F" is ill-typed.
        These arguments:
          Ctx.Y Ctx.X
        do not match these parameters:
@@ -221,7 +221,7 @@ module Ord : sig type t = unit val compare : 'a -> 'b -> int end
 Line 2, characters 11-29:
 2 | module M = Map.Make(Ord)(Ord)
                ^^^^^^^^^^^^^^^^^^
-Error: This application of the functor Map.Make is ill-typed.
+Error: This application of the functor "Map.Make" is ill-typed.
        These arguments:
          Ord Ord
        do not match these parameters:
@@ -250,7 +250,7 @@ module K : sig type x = X.x type y = Y.y end
 Line 10, characters 11-73:
 10 | module M = F(K)(struct type x = K.x end)( (* struct type z = K.y end *) )
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This application of the functor F is ill-typed.
+Error: This application of the functor "F" is ill-typed.
        These arguments:
          K $S2 ()
        do not match these parameters:
@@ -265,7 +265,7 @@ module M = F(K)(struct type y = K.y end)
 Line 1, characters 11-40:
 1 | module M = F(K)(struct type y = K.y end)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This application of the functor F is ill-typed.
+Error: This application of the functor "F" is ill-typed.
        These arguments:
          K $S3
        do not match these parameters:
@@ -288,7 +288,7 @@ Lines 2-5, characters 2-30:
 3 |     (struct include X include Y end)
 4 |     (struct type x = K.x end)
 5 |     (struct type yy = K.y end)
-Error: This application of the functor F is ill-typed.
+Error: This application of the functor "F" is ill-typed.
        These arguments:
          $S1 $S2 $S3
        do not match these parameters:
@@ -323,7 +323,7 @@ module Defs :
 Line 13, characters 19-33:
 13 | module Missing_X = F(M.N)(Defs.Y)
                         ^^^^^^^^^^^^^^
-Error: This application of the functor F is ill-typed.
+Error: This application of the functor "F" is ill-typed.
        These arguments:
          M.N Defs.Y
        do not match these parameters:
@@ -339,7 +339,7 @@ module Too_many_Xs = F(M.N)(Defs.X)(Defs.X)(Defs.Y)
 Line 1, characters 21-51:
 1 | module Too_many_Xs = F(M.N)(Defs.X)(Defs.X)(Defs.Y)
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This application of the functor F is ill-typed.
+Error: This application of the functor "F" is ill-typed.
        These arguments:
          M.N Defs.X Defs.X Defs.Y
        do not match these parameters:
@@ -361,7 +361,7 @@ module Y : sig type y = float end
 Line 3, characters 23-67:
 3 | module Missing_X_bis = F(struct type x = int type y = float end)(Y)
                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This application of the functor F is ill-typed.
+Error: This application of the functor "F" is ill-typed.
        These arguments:
          $S1 Y
        do not match these parameters:
@@ -377,7 +377,7 @@ module Too_many_Xs_bis = F(struct type x = int type y = float end)(X)(X)(Y)
 Line 1, characters 25-75:
 1 | module Too_many_Xs_bis = F(struct type x = int type y = float end)(X)(X)(Y)
                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This application of the functor F is ill-typed.
+Error: This application of the functor "F" is ill-typed.
        These arguments:
          $S1 X X Y
        do not match these parameters:
@@ -513,7 +513,7 @@ module F : functor (X : x) (B : b) (Y : y) -> sig type t end
 Line 8, characters 15-57:
 8 |     module U = F(struct type x end)(B)(struct type w end)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This application of the functor F is ill-typed.
+Error: This application of the functor "F" is ill-typed.
        These arguments:
          $S1 P.B $S3
        do not match these parameters:
@@ -1050,7 +1050,7 @@ module type Arg =
 Line 14, characters 11-29:
 14 |   type u = G(X)(Y)(X)(Y)(X).t
                 ^^^^^^^^^^^^^^^^^^
-Error: The functor application G(X)(Y)(X)(Y)(X) is ill-typed.
+Error: The functor application "G(X)(Y)(X)(Y)(X)" is ill-typed.
        These arguments:
          A.X A.Y A.X A.Y A.X
        do not match these parameters:
@@ -1253,7 +1253,7 @@ module W = F(PF)(PF)(PF)(PF)(PF)(F)
 Line 1, characters 11-35:
 1 | module W = F(PF)(PF)(PF)(PF)(PF)(F)
                ^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This application of the functor F is ill-typed.
+Error: This application of the functor "F" is ill-typed.
        These arguments:
          PF PF PF PF PF F
        do not match these parameters:
@@ -1319,7 +1319,7 @@ module Choose_one = F(Add_one')(Add_three)(A)(A)(A)
 Line 1, characters 20-51:
 1 | module Choose_one = F(Add_one')(Add_three)(A)(A)(A)
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This application of the functor F is ill-typed.
+Error: This application of the functor "F" is ill-typed.
        These arguments:
          Add_one' Add_three A A A
        do not match these parameters:
@@ -1341,7 +1341,7 @@ module Mislead_chosen_one = F(Add_one)(Add_three)(A)(A)(A)
 Line 1, characters 28-58:
 1 | module Mislead_chosen_one = F(Add_one)(Add_three)(A)(A)(A)
                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This application of the functor F is ill-typed.
+Error: This application of the functor "F" is ill-typed.
        These arguments:
          Add_one Add_three A A A
        do not match these parameters:
@@ -1563,7 +1563,7 @@ module Z : sig type t = Z of int end
 Line 9, characters 13-48:
 9 | module Error=F(X)(struct type t = int end)(Y)(Z)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This application of the functor F is ill-typed.
+Error: This application of the functor "F" is ill-typed.
        These arguments:
          X ... Y Z
        do not match these parameters:
@@ -1643,7 +1643,7 @@ type broken1 = Bar(B)(FiveArgsExt)(B)(AExt).a
 Line 1, characters 15-45:
 1 | type broken1 = Bar(B)(FiveArgsExt)(B)(AExt).a
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The functor application Bar(B)(FiveArgsExt)(B)(AExt) is ill-typed.
+Error: The functor application "Bar(B)(FiveArgsExt)(B)(AExt)" is ill-typed.
        These arguments:
          B FiveArgsExt B AExt
        do not match these parameters:
@@ -1663,7 +1663,7 @@ type broken2 = Bar(A)(FiveArgsExt)(TY)(TY)(TY)(TY)(TY).a
 Line 1, characters 15-56:
 1 | type broken2 = Bar(A)(FiveArgsExt)(TY)(TY)(TY)(TY)(TY).a
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The functor application Bar(A)(FiveArgsExt)(TY)(TY)(TY)(TY)(TY) is ill-typed.
+Error: The functor application "Bar(A)(FiveArgsExt)(TY)(TY)(TY)(TY)(TY)" is ill-typed.
        These arguments:
          A FiveArgsExt TY TY TY TY TY
        do not match these parameters:
@@ -1745,7 +1745,7 @@ module F : functor () (X : empty) () (Y : A) -> sig end
 Line 3, characters 2-73:
 3 |   F(struct end[@warning "-73"])(struct end)(struct end[@warning "-73"])();;
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This application of the functor F is ill-typed.
+Error: This application of the functor "F" is ill-typed.
        These arguments:
          (struct end) (struct end) (struct end) ()
        do not match these parameters:
@@ -1765,7 +1765,7 @@ module F : functor (X : empty) -> sig end
 Line 3, characters 2-17:
 3 |   F(struct end)();;
       ^^^^^^^^^^^^^^^
-Error: This application of the functor F is ill-typed.
+Error: This application of the functor "F" is ill-typed.
        These arguments:
          (struct end) ()
        do not match these parameters:
@@ -1808,7 +1808,7 @@ Lines 15-21, characters 2-8:
 19 |     (struct
 20 |       let f x = x   (* this is bogus! *)
 21 |     end)
-Error: This application of the functor F is ill-typed.
+Error: This application of the functor "F" is ill-typed.
        These arguments:
          $S1 $S2
        do not match these parameters:
@@ -1844,7 +1844,7 @@ module G :
 Line 8, characters 11-52:
 8 | module R = G(struct end)(struct let f (x,_) = x end)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This application of the functor G is ill-typed.
+Error: This application of the functor "G" is ill-typed.
        These arguments:
          (struct end) $S2
        do not match these parameters:
@@ -1880,7 +1880,7 @@ Lines 5-11, characters 11-6:
  9 |     ()
 10 |     ()
 11 |     ()
-Error: This application of the functor With_expansion is ill-typed.
+Error: This application of the functor "With_expansion" is ill-typed.
        These arguments:
          $S1 () () ()
        do not match these parameters:
@@ -1906,7 +1906,7 @@ Lines 1-6, characters 12-6:
 4 |   end)
 5 |     ()
 6 |     ()
-Error: This application of the functor With_expansion is ill-typed.
+Error: This application of the functor "With_expansion" is ill-typed.
        These arguments:
          $S1 () ()
        do not match these parameters:
@@ -1957,7 +1957,7 @@ Lines 18-25, characters 2-8:
 23 |     (struct
 24 |       let f x = x   (* this is fine *)
 25 |     end)
-Error: This application of the functor H is ill-typed.
+Error: This application of the functor "H" is ill-typed.
        These arguments:
          $S1 $S2
        do not match these parameters:
@@ -2033,7 +2033,7 @@ module K = List(A)(B)
 Line 3, characters 11-21:
 3 | module K = List(A)(B)
                ^^^^^^^^^^
-Error: The module List is not a functor, it cannot be applied.
+Error: The module "List" is not a functor, it cannot be applied.
 |}]
 
 module Error = (struct end)(B)
@@ -2049,7 +2049,7 @@ let f (x:Set.Make(Set)(A).t) = x
 Line 1, characters 9-27:
 1 | let f (x:Set.Make(Set)(A).t) = x
              ^^^^^^^^^^^^^^^^^^
-Error: The functor application Set.Make(Set)(A) is ill-typed.
+Error: The functor application "Set.Make(Set)(A)" is ill-typed.
        These arguments:
          Set A
        do not match these parameters:

--- a/testsuite/tests/typing-modules/functors.ml
+++ b/testsuite/tests/typing-modules/functors.ml
@@ -41,7 +41,7 @@ module M = F(X)(Z)
 Line 1, characters 11-18:
 1 | module M = F(X)(Z)
                ^^^^^^^
-Error: This functor application of F is ill-typed.
+Error: This application of the functor F is ill-typed.
        These arguments:
          X Z
        do not match these parameters:
@@ -152,7 +152,7 @@ module F : functor () (X : sig type t end) -> sig end
 Line 2, characters 11-16:
 2 | module M = F()()
                ^^^^^
-Error: This functor application of F is ill-typed.
+Error: This application of the functor F is ill-typed.
        These arguments:
          () ()
        do not match these parameters:
@@ -204,7 +204,7 @@ end
 Line 9, characters 13-20:
 9 |   module M = F(Y)(X)
                  ^^^^^^^
-Error: This functor application of F is ill-typed.
+Error: This application of the functor F is ill-typed.
        These arguments:
          Ctx.Y Ctx.X
        do not match these parameters:
@@ -221,7 +221,7 @@ module Ord : sig type t = unit val compare : 'a -> 'b -> int end
 Line 2, characters 11-29:
 2 | module M = Map.Make(Ord)(Ord)
                ^^^^^^^^^^^^^^^^^^
-Error: This functor application of Map.Make is ill-typed.
+Error: This application of the functor Map.Make is ill-typed.
        These arguments:
          Ord Ord
        do not match these parameters:
@@ -250,7 +250,7 @@ module K : sig type x = X.x type y = Y.y end
 Line 10, characters 11-73:
 10 | module M = F(K)(struct type x = K.x end)( (* struct type z = K.y end *) )
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This functor application of F is ill-typed.
+Error: This application of the functor F is ill-typed.
        These arguments:
          K $S2 ()
        do not match these parameters:
@@ -265,7 +265,7 @@ module M = F(K)(struct type y = K.y end)
 Line 1, characters 11-40:
 1 | module M = F(K)(struct type y = K.y end)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This functor application of F is ill-typed.
+Error: This application of the functor F is ill-typed.
        These arguments:
          K $S3
        do not match these parameters:
@@ -288,7 +288,7 @@ Lines 2-5, characters 2-30:
 3 |     (struct include X include Y end)
 4 |     (struct type x = K.x end)
 5 |     (struct type yy = K.y end)
-Error: This functor application of F is ill-typed.
+Error: This application of the functor F is ill-typed.
        These arguments:
          $S1 $S2 $S3
        do not match these parameters:
@@ -323,7 +323,7 @@ module Defs :
 Line 13, characters 19-33:
 13 | module Missing_X = F(M.N)(Defs.Y)
                         ^^^^^^^^^^^^^^
-Error: This functor application of F is ill-typed.
+Error: This application of the functor F is ill-typed.
        These arguments:
          M.N Defs.Y
        do not match these parameters:
@@ -339,7 +339,7 @@ module Too_many_Xs = F(M.N)(Defs.X)(Defs.X)(Defs.Y)
 Line 1, characters 21-51:
 1 | module Too_many_Xs = F(M.N)(Defs.X)(Defs.X)(Defs.Y)
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This functor application of F is ill-typed.
+Error: This application of the functor F is ill-typed.
        These arguments:
          M.N Defs.X Defs.X Defs.Y
        do not match these parameters:
@@ -361,7 +361,7 @@ module Y : sig type y = float end
 Line 3, characters 23-67:
 3 | module Missing_X_bis = F(struct type x = int type y = float end)(Y)
                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This functor application of F is ill-typed.
+Error: This application of the functor F is ill-typed.
        These arguments:
          $S1 Y
        do not match these parameters:
@@ -377,7 +377,7 @@ module Too_many_Xs_bis = F(struct type x = int type y = float end)(X)(X)(Y)
 Line 1, characters 25-75:
 1 | module Too_many_Xs_bis = F(struct type x = int type y = float end)(X)(X)(Y)
                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This functor application of F is ill-typed.
+Error: This application of the functor F is ill-typed.
        These arguments:
          $S1 X X Y
        do not match these parameters:
@@ -513,7 +513,7 @@ module F : functor (X : x) (B : b) (Y : y) -> sig type t end
 Line 8, characters 15-57:
 8 |     module U = F(struct type x end)(B)(struct type w end)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This functor application of F is ill-typed.
+Error: This application of the functor F is ill-typed.
        These arguments:
          $S1 P.B $S3
        do not match these parameters:
@@ -1253,7 +1253,7 @@ module W = F(PF)(PF)(PF)(PF)(PF)(F)
 Line 1, characters 11-35:
 1 | module W = F(PF)(PF)(PF)(PF)(PF)(F)
                ^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This functor application of F is ill-typed.
+Error: This application of the functor F is ill-typed.
        These arguments:
          PF PF PF PF PF F
        do not match these parameters:
@@ -1319,7 +1319,7 @@ module Choose_one = F(Add_one')(Add_three)(A)(A)(A)
 Line 1, characters 20-51:
 1 | module Choose_one = F(Add_one')(Add_three)(A)(A)(A)
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This functor application of F is ill-typed.
+Error: This application of the functor F is ill-typed.
        These arguments:
          Add_one' Add_three A A A
        do not match these parameters:
@@ -1341,7 +1341,7 @@ module Mislead_chosen_one = F(Add_one)(Add_three)(A)(A)(A)
 Line 1, characters 28-58:
 1 | module Mislead_chosen_one = F(Add_one)(Add_three)(A)(A)(A)
                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This functor application of F is ill-typed.
+Error: This application of the functor F is ill-typed.
        These arguments:
          Add_one Add_three A A A
        do not match these parameters:
@@ -1563,7 +1563,7 @@ module Z : sig type t = Z of int end
 Line 9, characters 13-48:
 9 | module Error=F(X)(struct type t = int end)(Y)(Z)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This functor application of F is ill-typed.
+Error: This application of the functor F is ill-typed.
        These arguments:
          X ... Y Z
        do not match these parameters:
@@ -1745,7 +1745,7 @@ module F : functor () (X : empty) () (Y : A) -> sig end
 Line 3, characters 2-73:
 3 |   F(struct end[@warning "-73"])(struct end)(struct end[@warning "-73"])();;
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This functor application of F is ill-typed.
+Error: This application of the functor F is ill-typed.
        These arguments:
          (struct end) (struct end) (struct end) ()
        do not match these parameters:
@@ -1765,7 +1765,7 @@ module F : functor (X : empty) -> sig end
 Line 3, characters 2-17:
 3 |   F(struct end)();;
       ^^^^^^^^^^^^^^^
-Error: This functor application of F is ill-typed.
+Error: This application of the functor F is ill-typed.
        These arguments:
          (struct end) ()
        do not match these parameters:
@@ -1808,7 +1808,7 @@ Lines 15-21, characters 2-8:
 19 |     (struct
 20 |       let f x = x   (* this is bogus! *)
 21 |     end)
-Error: This functor application of F is ill-typed.
+Error: This application of the functor F is ill-typed.
        These arguments:
          $S1 $S2
        do not match these parameters:
@@ -1844,7 +1844,7 @@ module G :
 Line 8, characters 11-52:
 8 | module R = G(struct end)(struct let f (x,_) = x end)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This functor application of G is ill-typed.
+Error: This application of the functor G is ill-typed.
        These arguments:
          (struct end) $S2
        do not match these parameters:
@@ -1880,7 +1880,7 @@ Lines 5-11, characters 11-6:
  9 |     ()
 10 |     ()
 11 |     ()
-Error: This functor application of With_expansion is ill-typed.
+Error: This application of the functor With_expansion is ill-typed.
        These arguments:
          $S1 () () ()
        do not match these parameters:
@@ -1906,7 +1906,7 @@ Lines 1-6, characters 12-6:
 4 |   end)
 5 |     ()
 6 |     ()
-Error: This functor application of With_expansion is ill-typed.
+Error: This application of the functor With_expansion is ill-typed.
        These arguments:
          $S1 () ()
        do not match these parameters:
@@ -1957,7 +1957,7 @@ Lines 18-25, characters 2-8:
 23 |     (struct
 24 |       let f x = x   (* this is fine *)
 25 |     end)
-Error: This functor application of H is ill-typed.
+Error: This application of the functor H is ill-typed.
        These arguments:
          $S1 $S2
        do not match these parameters:

--- a/typing/includemod.ml
+++ b/typing/includemod.ml
@@ -922,10 +922,14 @@ let can_alias env path =
 type explanation = Env.t * Error.all
 exception Error of explanation
 
+type application_name =
+  | Anonymous_functor
+  | Full_application_path of Longident.t
+  | Named_leftmost_functor of Longident.t
 exception Apply_error of {
     loc : Location.t ;
     env : Env.t ;
-    lid_app : Longident.t option ;
+    app_name : application_name ;
     mty_f : module_type ;
     args : (Error.functor_arg_descr * module_type) list ;
   }
@@ -955,8 +959,8 @@ let check_functor_application_in_path
         in
         let mty_f = (Env.find_module f0_path env).md_type in
         let args = List.map prepare_arg args in
-        let lid_app = Some lid_whole_app in
-        raise (Apply_error {loc; env; lid_app; mty_f; args})
+        let app_name = Full_application_path lid_whole_app in
+        raise (Apply_error {loc; env; app_name; mty_f; args})
       else
         raise Not_found
 

--- a/typing/includemod.mli
+++ b/typing/includemod.mli
@@ -215,10 +215,16 @@ type pos =
   | Body of functor_parameter
 
 exception Error of explanation
+
+type application_name =
+  | Anonymous_functor (** [(functor (_:sig end) -> struct end)(Int)] *)
+  | Full_application_path of Longident.t (** [F(G(X).P)(Y)] *)
+  | Named_leftmost_functor of Longident.t (** [F(struct end)...(...)] *)
+
 exception Apply_error of {
     loc : Location.t ;
     env : Env.t ;
-    lid_app : Longident.t option ;
+    app_name : application_name ;
     mty_f : module_type ;
     args : (Error.functor_arg_descr * Types.module_type)  list ;
   }

--- a/typing/includemod_errorprinter.ml
+++ b/typing/includemod_errorprinter.ml
@@ -947,7 +947,8 @@ let report_apply_error ~loc env (app_name, mty_f, args) =
               Format.fprintf ppf "The functor application %a is ill-typed."
                 Printtyp.longident lid
           |  Includemod.Named_leftmost_functor lid ->
-              Format.fprintf ppf "This functor application of %a is ill-typed."
+              Format.fprintf ppf
+                "This application of the functor %a is ill-typed."
                 Printtyp.longident lid
         in
         let actual = Functor_suberror.App.got d in

--- a/typing/includemod_errorprinter.ml
+++ b/typing/includemod_errorprinter.ml
@@ -928,7 +928,7 @@ let report_apply_error ~loc env (app_name, mty_f, args) =
         | Includemod.Named_leftmost_functor lid ->
             Location.errorf ~loc
               "@[The module %a is not a functor, it cannot be applied.@]"
-              Printtyp.longident lid
+               (Style.as_inline_code Printtyp.longident)  lid
         | Includemod.Anonymous_functor
         | Includemod.Full_application_path _
           (* The "non-functor application in term" case is directly handled in
@@ -945,11 +945,11 @@ let report_apply_error ~loc env (app_name, mty_f, args) =
               Format.fprintf ppf "This functor application is ill-typed."
           | Includemod.Full_application_path lid ->
               Format.fprintf ppf "The functor application %a is ill-typed."
-                Printtyp.longident lid
+                (Style.as_inline_code Printtyp.longident) lid
           |  Includemod.Named_leftmost_functor lid ->
               Format.fprintf ppf
                 "This application of the functor %a is ill-typed."
-                Printtyp.longident lid
+                 (Style.as_inline_code Printtyp.longident) lid
         in
         let actual = Functor_suberror.App.got d in
         let expected = Functor_suberror.expected d in

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -2322,10 +2322,11 @@ and type_application loc strengthen funct_body env smod =
     let strengthen = strengthen && List.for_all has_path args in
     type_module strengthen funct_body None env sfunct
   in
-  List.fold_left (type_one_application ~ctx:(loc, funct, args) funct_body env)
+  List.fold_left
+    (type_one_application ~ctx:(loc, sfunct, funct, args) funct_body env)
     (funct, funct_shape) args
 
-and type_one_application ~ctx:(apply_loc,md_f,args)
+and type_one_application ~ctx:(apply_loc,sfunct,md_f,args)
     funct_body env (funct, funct_shape) app_view =
   match Env.scrape_alias env funct.mod_type with
   | Mty_functor (Unit, mty_res) ->
@@ -2355,7 +2356,10 @@ and type_one_application ~ctx:(apply_loc,md_f,args)
       let apply_error () =
         let args = List.map simplify_app_summary args in
         let mty_f = md_f.mod_type in
-        let lid_app = None in
+        let lid_app = match sfunct.pmod_desc with
+          | Pmod_ident l -> Some l.txt
+          | _ -> None
+        in
         raise(Includemod.Apply_error {loc=apply_loc;env;lid_app;mty_f;args})
       in
       begin match app_view with
@@ -2418,10 +2422,13 @@ and type_one_application ~ctx:(apply_loc,md_f,args)
     end
   | Mty_alias path ->
       raise(Error(app_view.f_loc, env, Cannot_scrape_alias path))
-  | _ ->
+  | Mty_ident _ | Mty_signature _  ->
       let args = List.map simplify_app_summary args in
       let mty_f = md_f.mod_type in
-      let lid_app = None in
+      let lid_app = match sfunct.pmod_desc with
+        | Pmod_ident l -> Some l.txt
+        | _ -> None
+      in
       raise(Includemod.Apply_error {loc=apply_loc;env;lid_app;mty_f;args})
 
 and type_open_decl ?used_slot ?toplevel funct_body names env sod =

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -2356,11 +2356,11 @@ and type_one_application ~ctx:(apply_loc,sfunct,md_f,args)
       let apply_error () =
         let args = List.map simplify_app_summary args in
         let mty_f = md_f.mod_type in
-        let lid_app = match sfunct.pmod_desc with
-          | Pmod_ident l -> Some l.txt
-          | _ -> None
+        let app_name = match sfunct.pmod_desc with
+          | Pmod_ident l -> Includemod.Named_leftmost_functor l.txt
+          | _ -> Includemod.Anonymous_functor
         in
-        raise(Includemod.Apply_error {loc=apply_loc;env;lid_app;mty_f;args})
+        raise(Includemod.Apply_error {loc=apply_loc;env;app_name;mty_f;args})
       in
       begin match app_view with
       | { arg = None; _ } -> apply_error ()
@@ -2425,11 +2425,11 @@ and type_one_application ~ctx:(apply_loc,sfunct,md_f,args)
   | Mty_ident _ | Mty_signature _  ->
       let args = List.map simplify_app_summary args in
       let mty_f = md_f.mod_type in
-      let lid_app = match sfunct.pmod_desc with
-        | Pmod_ident l -> Some l.txt
-        | _ -> None
+      let app_name = match sfunct.pmod_desc with
+        | Pmod_ident l -> Includemod.Named_leftmost_functor l.txt
+        | _ -> Includemod.Anonymous_functor
       in
-      raise(Includemod.Apply_error {loc=apply_loc;env;lid_app;mty_f;args})
+      raise(Includemod.Apply_error {loc=apply_loc;env;app_name;mty_f;args})
 
 and type_open_decl ?used_slot ?toplevel funct_body names env sod =
   Builtin_attributes.warning_scope sod.popen_attributes


### PR DESCRIPTION
This PR proposes to add a specialized error message whenever some code tries to use a signature as a functor.


For instance, since OCaml 4.14,
```ocaml
module R = Int(List)
```
falls in the functor error code path, resulting in this quite long
>```
> Error: The functor application is ill-typed.
>       These arguments:
>         List
>       do not match these parameters:
>         functor  -> ...
>       The following extra argument is provided
>           List :
>           sig
>             type 'a t = 'a list = [] | (::) of 'a * 'a list
>             val length : 'a t -> int
>             ...
>            end
>```
error message. Prior to OCaml 4.13, the error message was more specialized
>```
> Error: This module is not a functor; it has type
>       sig
>         type 'a t = 'a list = [] | (::) of 'a * 'a list
>         val length : 'a list -> int
>         ...
>        end
>```
This PR proposes to go one step further and reduces the error message to
>```
> Error: The module Int is not a functor, it cannot be applied.
>```
and similarly for inclusion error
```ocaml
module F(X:sig end): () -> sig end = X
```

>```Error: Signature mismatch:
>       Modules do not match: sig end is not included in functor () -> sig end
>       The first one is a signature whereas the second one is a functor.
>```

under the assumption that in this context it is better to emphasize the module kind mismatch rather than the types of the extraneous arguments.

Along the way, this PR updates the error message for functor applications to display the name of the applicand  whenever possible. Previously, this name was only printed for ill-typed functor applications in type expressions: 
```ocaml
let f (x:Set.Make(Set)(Int).t) = x
```
>  Error: The functor application Set.Make(Set)(Int) is ill-typed.

but not at the module expression level

```ocaml
module R = Set.Make(Set)(Int)
```
>  Error: The functor application is ill-typed.

with this PR, this error abstract is amended to

>  Error: This functor application of Set.Make is ill-typed.

since this change is a low hanging fruit, once the non functor case is already checking if the applicand has a human readable name.