### PR TITLE
Fix incorrect alert name; re-enable ocamldoc alerts during doc build.

### DIFF
--- a/api_docgen/ocamldoc/Makefile
+++ b/api_docgen/ocamldoc/Makefile
@@ -44,7 +44,7 @@ $(libref:%=build/libref/%.odoc): build/libref/%.odoc: %.mli | build/libref
 	$(V_OCAMLDOC)$(OCAMLDOC_RUN) -nostdlib -hide Stdlib -lib Stdlib \
 	-pp \
 "$(AWK) -v ocamldoc=true -f ../../stdlib/expand_module_aliases.awk" \
-	$(DOC_STDLIB_INCLUDES) -hide-warnings -alert -all $< -dump  $@
+	$(DOC_STDLIB_INCLUDES) -hide-warnings $< -dump  $@
 
 $(compilerlibref:%=build/compilerlibref/%.odoc):\
 build/compilerlibref/%.odoc: %.mli | build/compilerlibref

--- a/stdlib/stack.mli
+++ b/stdlib/stack.mli
@@ -20,7 +20,7 @@
 
 (** {b Unsynchronized accesses} *)
 
-[@@@alert unsynchronized_accesses
+[@@@alert unsynchronized_access
     "Unsynchronized accesses to stacks are a programming error."
 ]
 


### PR DESCRIPTION
In PR #12187, all alerts were turned off during the `api_docgen` build, to kill this annoying alert:
```
File "../../stdlib/stdlib.mli", line 1500, characters 15-28:
1500 | module Stack = Stdlib__Stack
                      ^^^^^^^^^^^^^
Alert unsynchronized_accesses: module Stdlib__Stack
Unsynchronized accesses to stacks are a programming error.
```
This alert was actually caused by a typo in the name of the alert in `stdlib/stack.mli`: `unsynchronized_accesses` instead of `unsynchronized_access`. The latter alert name is disabled by default (which is why we only see it in this case). So this tiny PR re-enables alerts in general but fixes the typo so that this particular one does not appear.