### PR TITLE
Add `-source-tree` and `-build-tree` options to ocamldep

### DIFF
--- a/Changes
+++ b/Changes
@@ -84,6 +84,10 @@ Working version
   started with #11243, #11248, #11268, #11420 and #11675.
   (Sébastien Hinderer, review by David Allsopp and Florian Angeletti)
 
+- #12239: Add -source-tree and -build-tree options to ocamldep to
+  specify where to find dependencies and where to output a target.
+  (Antonin Décimo, review by Sébastien Hinderer, Nicolás Ojeda Bär)
+
 ### Bug fixes:
 
 - #12037: get_extern_state potential NULL dereference.

--- a/driver/makedepend.ml
+++ b/driver/makedepend.ml
@@ -38,6 +38,7 @@ let allow_approximation = ref false
 let map_files = ref []
 let module_map = ref String.Map.empty
 let debug = ref false
+let source_tree = ref ""
 let build_tree = ref ""
 
 module Error_occurred : sig
@@ -199,8 +200,8 @@ let print_filename s =
 let print_dependencies target_files deps =
   let pos = ref 0 in
   let artifacts = [".cmi"; ".cmo"; ".cmx"; ".cmxs"; ".o"] in
-  let print_build_tree, build_tree_len =
-    match !build_tree with
+  let print_prefix prefix =
+    match !prefix with
     | "" -> Fun.id, 0
     | prefix ->
        let len = String.length prefix in
@@ -211,14 +212,19 @@ let print_dependencies target_files deps =
                     else prefix ^ String.make 1 dir_sep, len + 1 in
        (fun () -> print_string s; pos := !pos + len), len
   in
+  let print_build_tree, build_tree_len = print_prefix build_tree
+  and print_source_tree, _ = print_prefix source_tree
+  in
   let print_on_same_line ~is_artifact item =
     if !pos <> 0 then print_string " ";
-    if is_artifact then print_build_tree ();
+    if is_artifact then print_build_tree ()
+    else print_source_tree ();
     print_filename item;
     pos := !pos + String.length item + 1;
   and print_on_new_line ~is_artifact item =
     print_string escaped_eol;
-    if is_artifact then print_build_tree ();
+    if is_artifact then print_build_tree ()
+    else print_source_tree ();
     print_filename item;
     pos := String.length item + 4;
   in
@@ -660,6 +666,8 @@ let run_main argv =
         " Sort files according to their dependencies";
       "-build-tree", Arg.String(fun s -> build_tree := s),
         "<path>  Tree where build artifacts are written";
+      "-source-tree", Arg.String(fun s -> source_tree := s),
+        "<path>  Tree where dependencies are found";
       "-version", Arg.Unit print_version,
         " Print version and exit";
       "-vnum", Arg.Unit print_version_num,

--- a/man/ocamldep.1
+++ b/man/ocamldep.1
@@ -187,6 +187,9 @@ Under Unix, this option does nothing.
 .B \-sort
 Sort files according to their dependencies.
 .TP
+.B \-build\-tree \ path
+Tree where build artifacts are written.
+.TP
 .B \-version
 Print version string and exit.
 .TP

--- a/man/ocamldep.1
+++ b/man/ocamldep.1
@@ -190,6 +190,9 @@ Sort files according to their dependencies.
 .B \-build\-tree \ path
 Tree where build artifacts are written.
 .TP
+.B \-source\-tree \ path
+Tree where dependencies are found.
+.TP
 .B \-version
 Print version string and exit.
 .TP

--- a/man/ocamldep.1
+++ b/man/ocamldep.1
@@ -177,6 +177,11 @@ Generate dependencies for native plugin files (.cmxs) in addition to
 native compiled files (.cmx).
 .TP
 .B \-slash
+(Windows) Use forward slash / instead of backslash \\ in file paths.
+Under Unix, this option does nothing.
+.TP
+.B \-no\-slash
+(Windows) Preserve any backslash \\ in file paths.
 Under Unix, this option does nothing.
 .TP
 .B \-sort
@@ -187,6 +192,14 @@ Print version string and exit.
 .TP
 .B \-vnum
 Print short version number and exit.
+.TP
+.BI \-args " file"
+Read additional newline separated command line arguments from
+.IR file .
+.TP
+.BI \-args0 " file"
+Read additional NUL separated command line arguments from
+.IR file .
 .TP
 .BR \-help " or " \-\-help
 Display a short usage summary and exit.

--- a/manual/src/cmds/ocamldep.etex
+++ b/manual/src/cmds/ocamldep.etex
@@ -132,6 +132,9 @@ nothing.
 \item["-sort"]
 Sort files according to their dependencies.
 
+\item["-build-tree" \var{path}]
+Tree where build artifacts are written.
+
 \item["-version"]
 Print version string and exit.
 

--- a/manual/src/cmds/ocamldep.etex
+++ b/manual/src/cmds/ocamldep.etex
@@ -135,6 +135,9 @@ Sort files according to their dependencies.
 \item["-build-tree" \var{path}]
 Tree where build artifacts are written.
 
+\item["-source-tree" \var{path}]
+Tree where dependencies are found.
+
 \item["-version"]
 Print version string and exit.
 

--- a/testsuite/tests/tool-ocamldep-tree/lib.ml
+++ b/testsuite/tests/tool-ocamldep-tree/lib.ml
@@ -1,0 +1,1 @@
+let message = "Hello, world!"

--- a/testsuite/tests/tool-ocamldep-tree/main.compilers.reference
+++ b/testsuite/tests/tool-ocamldep-tree/main.compilers.reference
@@ -1,0 +1,11 @@
+$(OD)/lib.cmo $(OD)/lib.cmi : \
+    $(srcdir)/lib.ml
+$(OD)/lib.cmx $(OD)/lib.o $(OD)/lib.cmi : \
+    $(srcdir)/lib.ml
+$(OD)/main.cmo $(OD)/main.cmi : \
+    $(OD)/lib.cmi \
+    $(srcdir)/main.ml
+$(OD)/main.cmx $(OD)/main.o $(OD)/main.cmi : \
+    $(OD)/lib.cmi \
+    $(OD)/lib.cmx \
+    $(srcdir)/main.ml

--- a/testsuite/tests/tool-ocamldep-tree/main.ml
+++ b/testsuite/tests/tool-ocamldep-tree/main.ml
@@ -1,0 +1,9 @@
+(* TEST
+ modules = "lib.ml main.ml";
+ setup-ocamlc.byte-build-env;
+ commandline = "-depend -all -source-tree $(srcdir) -build-tree $(OD) lib.ml main.ml";
+ ocamlc.byte;
+ check-ocamlc.byte-output;
+ *)
+
+let () = print_endline Lib.message


### PR DESCRIPTION
ocamldep generates the list of dependencies for a given ocaml target file. The new `-source-tree` option allows to find dependencies in an other location than just the current working directory. The new `-build-tree` option allows to write targets (build artifacts) in an other location than just the current working directory.

This is useful for out-of-source builds and cross-compilation.

ocamldep outputs a trailing directory separator if the given string doesn't contain one, and respects `-slash` and `-no-slash` options. No other processing is made on the string. It is for instance possible to give a Makefile variable instead of a path.