### PR TITLE
Refactor the computation of stack frame parameters

### DIFF
--- a/.depend
+++ b/.depend
@@ -2757,7 +2757,6 @@ asmcomp/emit.cmi : \
     asmcomp/linear.cmi \
     asmcomp/cmm.cmi
 asmcomp/emitaux.cmo : \
-    asmcomp/linear.cmi \
     asmcomp/emitenv.cmi \
     lambda/debuginfo.cmi \
     utils/config.cmi \
@@ -2766,7 +2765,6 @@ asmcomp/emitaux.cmo : \
     asmcomp/arch.cmi \
     asmcomp/emitaux.cmi
 asmcomp/emitaux.cmx : \
-    asmcomp/linear.cmx \
     asmcomp/emitenv.cmi \
     lambda/debuginfo.cmx \
     utils/config.cmx \
@@ -3092,7 +3090,6 @@ asmcomp/selectgen.cmo : \
     lambda/lambda.cmi \
     lambda/debuginfo.cmi \
     asmcomp/cmm.cmi \
-    utils/clflags.cmi \
     middle_end/backend_var.cmi \
     parsing/asttypes.cmi \
     asmcomp/arch.cmi \
@@ -3107,7 +3104,6 @@ asmcomp/selectgen.cmx : \
     lambda/lambda.cmx \
     lambda/debuginfo.cmx \
     asmcomp/cmm.cmx \
-    utils/clflags.cmx \
     middle_end/backend_var.cmx \
     parsing/asttypes.cmi \
     asmcomp/arch.cmx \
@@ -3176,10 +3172,12 @@ asmcomp/split.cmi : \
 asmcomp/stackframe.cmo : \
     asmcomp/stackframegen.cmi \
     asmcomp/mach.cmi \
+    utils/config.cmi \
     asmcomp/stackframe.cmi
 asmcomp/stackframe.cmx : \
     asmcomp/stackframegen.cmx \
     asmcomp/mach.cmx \
+    utils/config.cmx \
     asmcomp/stackframe.cmi
 asmcomp/stackframe.cmi : \
     asmcomp/mach.cmi

--- a/.depend
+++ b/.depend
@@ -3180,6 +3180,7 @@ asmcomp/stackframe.cmx : \
     utils/config.cmx \
     asmcomp/stackframe.cmi
 asmcomp/stackframe.cmi : \
+    asmcomp/stackframegen.cmi \
     asmcomp/mach.cmi
 asmcomp/stackframegen.cmo : \
     asmcomp/mach.cmi \

--- a/.depend
+++ b/.depend
@@ -2828,8 +2828,8 @@ asmcomp/linear.cmi : \
     lambda/debuginfo.cmi \
     asmcomp/cmm.cmi
 asmcomp/linearize.cmo : \
+    asmcomp/stackframe.cmi \
     asmcomp/reg.cmi \
-    asmcomp/proc.cmi \
     utils/misc.cmi \
     asmcomp/mach.cmi \
     asmcomp/linear.cmi \
@@ -2837,8 +2837,8 @@ asmcomp/linearize.cmo : \
     asmcomp/cmm.cmi \
     asmcomp/linearize.cmi
 asmcomp/linearize.cmx : \
+    asmcomp/stackframe.cmx \
     asmcomp/reg.cmx \
-    asmcomp/proc.cmx \
     utils/misc.cmx \
     asmcomp/mach.cmx \
     asmcomp/linear.cmx \
@@ -3172,6 +3172,28 @@ asmcomp/split.cmx : \
     asmcomp/mach.cmx \
     asmcomp/split.cmi
 asmcomp/split.cmi : \
+    asmcomp/mach.cmi
+asmcomp/stackframe.cmo : \
+    asmcomp/stackframegen.cmi \
+    asmcomp/mach.cmi \
+    asmcomp/stackframe.cmi
+asmcomp/stackframe.cmx : \
+    asmcomp/stackframegen.cmx \
+    asmcomp/mach.cmx \
+    asmcomp/stackframe.cmi
+asmcomp/stackframe.cmi : \
+    asmcomp/mach.cmi
+asmcomp/stackframegen.cmo : \
+    asmcomp/mach.cmi \
+    lambda/lambda.cmi \
+    utils/clflags.cmi \
+    asmcomp/stackframegen.cmi
+asmcomp/stackframegen.cmx : \
+    asmcomp/mach.cmx \
+    lambda/lambda.cmx \
+    utils/clflags.cmx \
+    asmcomp/stackframegen.cmi
+asmcomp/stackframegen.cmi : \
     asmcomp/mach.cmi
 asmcomp/strmatch.cmo : \
     lambda/lambda.cmi \

--- a/.gitignore
+++ b/.gitignore
@@ -71,6 +71,7 @@ META
 /asmcomp/reload.ml
 /asmcomp/scheduling.ml
 /asmcomp/CSE.ml
+/asmcomp/stackframe.ml
 
 /boot/ocamlrun
 /boot/camlheader

--- a/Changes
+++ b/Changes
@@ -256,6 +256,11 @@ Working version
   (Nick Roberts; review by Richard Eisenberg, Leo White, and Gabriel Scherer;
   RFC by Stephen Dolan)
 
+- #12242: Move the computation of stack frame parameters to a separate
+  `Stackframe` module, and save the parameters in the results of the
+  `Linearize` pass
+  (Xavier Leroy, review by KC Sivaramakrishnan and Mark Shinwell)
+
 - #12442: document jump summaries in the pattern-matching compiler
   (Gabriel Scherer and Thomas Refis, review by Florian Angeletti
    and Vincent Laviron)

--- a/Makefile
+++ b/Makefile
@@ -599,6 +599,9 @@ asmcomp/reload.ml: asmcomp/$(ARCH)/reload.ml
 asmcomp/scheduling.ml: asmcomp/$(ARCH)/scheduling.ml
 	cd asmcomp; $(LN) $(ARCH)/scheduling.ml .
 
+asmcomp/stackframe.ml: asmcomp/$(ARCH)/stackframe.ml
+	cd asmcomp; $(LN) $(ARCH)/stackframe.ml .
+
 # Preprocess the code emitters
 cvt_emit = tools/cvt_emit$(EXE)
 
@@ -1734,7 +1737,8 @@ tools/ocamltex.cmo: OC_COMMON_COMPFLAGS += -no-alias-deps
 
 ARCH_SPECIFIC =\
   asmcomp/arch.mli asmcomp/arch.ml asmcomp/proc.ml asmcomp/CSE.ml \
-  asmcomp/selection.ml asmcomp/scheduling.ml asmcomp/reload.ml
+  asmcomp/selection.ml asmcomp/scheduling.ml asmcomp/reload.ml \
+  asmcomp/stackframe.ml
 
 partialclean::
 	rm -f $(ARCH_SPECIFIC)

--- a/asmcomp/amd64/emit.mlp
+++ b/asmcomp/amd64/emit.mlp
@@ -461,7 +461,6 @@ let emit_instr env fallthrough i =
   match i.desc with
   | Lend -> ()
   | Lprologue ->
-    assert (env.f.fun_prologue_required);
     if fp then begin
       I.push rbp;
       cfi_adjust_cfa_offset 8;
@@ -908,12 +907,11 @@ let fundecl fundecl =
   cfi_startproc ();
   if !Clflags.runtime_variant = "d" then
     emit_call "caml_assert_stack_invariants";
-  let { max_frame_size; contains_nontail_calls} =
-    preproc_stack_check
-      ~fun_body:fundecl.fun_body ~frame_size:(frame_size env) ~trap_size:16
-  in
+  let max_frame_size =
+    frame_size env + fundecl.fun_extra_stack_used in
   let handle_overflow =
-    if contains_nontail_calls || max_frame_size >= stack_threshold_size then begin
+    if fundecl.fun_contains_nontail_calls
+    || max_frame_size >= stack_threshold_size then begin
       let overflow = new_label () and ret = new_label () in
       let threshold_offset = Domainstate.stack_ctx_words * 8 + stack_threshold_size in
       I.lea (mem64 NONE (-(max_frame_size + threshold_offset)) RSP) r10;

--- a/asmcomp/amd64/proc.ml
+++ b/asmcomp/amd64/proc.ml
@@ -365,15 +365,6 @@ let max_register_pressure =
       consumes ~int:0 ~float:1
   | _ -> consumes ~int:0 ~float:0
 
-(* Layout of the stack frame *)
-
-let frame_required fd =
-  fp || fd.fun_contains_calls ||
-  fd.fun_num_stack_slots.(0) > 0 || fd.fun_num_stack_slots.(1) > 0
-
-let prologue_required fd =
-  frame_required fd
-
 (* Calling the assembler *)
 
 let assemble_file infile outfile =

--- a/asmcomp/amd64/stackframe.ml
+++ b/asmcomp/amd64/stackframe.ml
@@ -1,0 +1,39 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*             Xavier Leroy, projet Cambium, INRIA Paris                  *)
+(*                                                                        *)
+(*   Copyright 2023 Institut National de Recherche en Informatique et     *)
+(*     en Automatique.                                                    *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+(* Compute the parameters needed for allocating and managing stack frames
+   in the Emit phase. *)
+
+open Mach
+
+let trap_handler_size = 16
+
+class stackframe = object
+
+inherit Stackframegen.stackframe_generic as super
+
+method trap_handler_size = trap_handler_size
+
+method! is_call = function
+  | Iop (Iintop (Icheckbound) | Iintop_imm(Icheckbound, _)) -> true
+  | insn -> super#is_call insn
+
+method! frame_required f contains_calls =
+  Config.with_frame_pointers || super#frame_required f contains_calls
+
+end
+
+let analyze f = 
+  (new stackframe)#analyze f

--- a/asmcomp/amd64/stackframe.ml
+++ b/asmcomp/amd64/stackframe.ml
@@ -35,5 +35,5 @@ method! frame_required f contains_calls =
 
 end
 
-let analyze f = 
+let analyze f =
   (new stackframe)#analyze f

--- a/asmcomp/arm64/emit.mlp
+++ b/asmcomp/arm64/emit.mlp
@@ -85,7 +85,7 @@ let emit_wreg = function
 let initial_stack_offset f =
   8 * f.fun_num_stack_slots.(0) +
   8 * f.fun_num_stack_slots.(1) +
-  (if f.fun_contains_calls then 8 else 0)
+  (if f.fun_frame_required then 8 else 0)
 
 let frame_size env =
   let sz =
@@ -274,7 +274,7 @@ let emit_stack_adjustment n =
 
 let output_epilogue env f =
   let n = frame_size env in
-  if env.f.fun_contains_calls then
+  if env.f.fun_frame_required then
     `	ldr	x30, [sp, #{emit_int (n-8)}]\n`;
   if n > 0 then
     emit_stack_adjustment n;
@@ -443,10 +443,10 @@ module BR = Branch_relaxation.Make (struct
 
   let prologue_size f =
     (if initial_stack_offset f > 0 then 2 else 0)
-      + (if f.fun_contains_calls then 1 else 0)
+      + (if f.fun_frame_required then 1 else 0)
 
   let epilogue_size f =
-    if f.fun_contains_calls then 3 else 2
+    if f.fun_frame_required then 3 else 2
 
   let instr_size f = function
     | Lend -> 0
@@ -681,11 +681,10 @@ let emit_instr env i =
     match i.desc with
     | Lend -> ()
     | Lprologue ->
-      assert (env.f.fun_prologue_required);
       let n = frame_size env in
       if n > 0 then
         emit_stack_adjustment (-n);
-      if env.f.fun_contains_calls then begin
+      if env.f.fun_frame_required then begin
         cfi_offset ~reg:30 (* return address *) ~offset:(-8);
         `	str	x30, [sp, #{emit_int (n-8)}]\n`
       end
@@ -1079,12 +1078,10 @@ let fundecl fundecl =
   emit_symbol_type emit_symbol fundecl.fun_name "function";
   (* Dynamic stack checking *)
   let stack_threshold_size = Config.stack_threshold * 8 in (* bytes *)
-  let { max_frame_size; contains_nontail_calls} =
-    preproc_stack_check
-      ~fun_body:fundecl.fun_body ~frame_size:(frame_size env) ~trap_size:16
-  in
+  let max_frame_size = frame_size env + fundecl.fun_extra_stack_used in
   let handle_overflow, stack_check_size =
-    if contains_nontail_calls || max_frame_size >= stack_threshold_size then begin
+    if fundecl.fun_contains_nontail_calls
+    || max_frame_size >= stack_threshold_size then begin
       let overflow = new_label () in
       `{emit_label overflow}:\n`;
       (* Pass the desired frame size on the stack, since all of the

--- a/asmcomp/arm64/proc.ml
+++ b/asmcomp/arm64/proc.ml
@@ -291,15 +291,6 @@ let max_register_pressure = function
   | Iload{memory_chunk=Single; _} | Istore(Single, _, _) -> [| 23; 31 |]
   | _ -> [| 23; 32 |]
 
-(* Layout of the stack *)
-let frame_required fd =
-  fd.fun_contains_calls
-    || fd.fun_num_stack_slots.(0) > 0
-    || fd.fun_num_stack_slots.(1) > 0
-
-let prologue_required fd =
-  frame_required fd
-
 (* Calling the assembler *)
 
 let assemble_file infile outfile =

--- a/asmcomp/arm64/stackframe.ml
+++ b/asmcomp/arm64/stackframe.ml
@@ -28,5 +28,5 @@ method trap_handler_size = trap_handler_size
 
 end
 
-let analyze f = 
+let analyze f =
   (new stackframe)#analyze f

--- a/asmcomp/arm64/stackframe.ml
+++ b/asmcomp/arm64/stackframe.ml
@@ -1,0 +1,32 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*             Xavier Leroy, projet Cambium, INRIA Paris                  *)
+(*                                                                        *)
+(*   Copyright 2023 Institut National de Recherche en Informatique et     *)
+(*     en Automatique.                                                    *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+(* Compute the parameters needed for allocating and managing stack frames
+   in the Emit phase. *)
+
+open! Mach [@@warning "-66"]
+
+let trap_handler_size = 16
+
+class stackframe = object
+
+inherit Stackframegen.stackframe_generic
+
+method trap_handler_size = trap_handler_size
+
+end
+
+let analyze f = 
+  (new stackframe)#analyze f

--- a/asmcomp/emitaux.ml
+++ b/asmcomp/emitaux.ml
@@ -471,32 +471,3 @@ let mk_env f : Emitenv.per_function_env =
     float_literals = [];
     int_literals = [];
   }
-
-type preproc_stack_check_result =
-  { max_frame_size : int;
-    contains_nontail_calls : bool }
-
-let preproc_stack_check ~fun_body ~frame_size ~trap_size =
-  let rec loop (i:Linear.instruction) fs max_fs nontail_flag =
-    match i.desc with
-      | Lend -> { max_frame_size = max_fs;
-                  contains_nontail_calls = nontail_flag}
-      | Ladjust_trap_depth { delta_traps } ->
-        let s = fs + (trap_size * delta_traps) in
-        loop i.next s (max s max_fs) nontail_flag
-      | Lpushtrap _ ->
-        let s = fs + trap_size in
-        loop i.next s (max s max_fs) nontail_flag
-      | Lpoptrap ->
-        loop i.next (fs - trap_size) max_fs nontail_flag
-      | Lop (Istackoffset n) ->
-        let s = fs + n in
-        loop i.next s (max s max_fs) nontail_flag
-      | Lop (Icall_ind | Icall_imm _ ) ->
-        loop i.next fs max_fs true
-      | Lprologue | Lop _ | Lreloadretaddr | Lreturn | Llabel _
-      | Lbranch _ | Lcondbranch _ | Lcondbranch3 _ | Lswitch _
-      | Lentertrap | Lraise _ ->
-        loop i.next fs max_fs nontail_flag
-  in
-  loop fun_body frame_size frame_size false

--- a/asmcomp/emitaux.mli
+++ b/asmcomp/emitaux.mli
@@ -90,13 +90,3 @@ exception Error of error
 val report_error: Format.formatter -> error -> unit
 
 val mk_env : Linear.fundecl -> Emitenv.per_function_env
-
-type preproc_stack_check_result =
-  { max_frame_size : int;
-    contains_nontail_calls : bool }
-
-val preproc_stack_check:
-  fun_body:Linear.instruction ->
-  frame_size:int ->
-  trap_size:int ->
-  preproc_stack_check_result

--- a/asmcomp/linear.ml
+++ b/asmcomp/linear.ml
@@ -54,10 +54,10 @@ type fundecl =
     fun_fast: bool;
     fun_dbg : Debuginfo.t;
     fun_tailrec_entry_point_label : label;
-    fun_contains_calls: bool;
+    fun_contains_nontail_calls: bool;
     fun_num_stack_slots: int array;
     fun_frame_required: bool;
-    fun_prologue_required: bool;
+    fun_extra_stack_used: int
   }
 
 (* Invert a test *)

--- a/asmcomp/linear.mli
+++ b/asmcomp/linear.mli
@@ -55,8 +55,8 @@ type fundecl =
     fun_fast: bool;
     fun_dbg : Debuginfo.t;
     fun_tailrec_entry_point_label : label;
-    fun_contains_calls: bool;
+    fun_contains_nontail_calls: bool;
     fun_num_stack_slots: int array;
     fun_frame_required: bool;
-    fun_prologue_required: bool;
+    fun_extra_stack_used: int
   }

--- a/asmcomp/linearize.ml
+++ b/asmcomp/linearize.ml
@@ -333,19 +333,18 @@ let add_prologue first_insn prologue_required =
     tailrec_entry_point_label, tailrec_entry_point
 
 let fundecl f =
-  let (fun_contains_nontail_calls, fun_frame_required, fun_extra_stack_used) =
-    Stackframe.analyze f in
+  let fa = Stackframe.analyze f in
   let (fun_tailrec_entry_point_label, fun_body) =
-    add_prologue (linear f.Mach.fun_body end_instr fun_frame_required)
-                 fun_frame_required in
+    add_prologue (linear f.Mach.fun_body end_instr fa.frame_required)
+                 fa.frame_required in
   { fun_name = f.Mach.fun_name;
     fun_args = Reg.set_of_array f.Mach.fun_args;
     fun_body;
     fun_fast = not (List.mem Cmm.Reduce_code_size f.Mach.fun_codegen_options);
     fun_dbg  = f.Mach.fun_dbg;
     fun_tailrec_entry_point_label;
-    fun_contains_nontail_calls;
+    fun_contains_nontail_calls = fa.contains_nontail_calls;
     fun_num_stack_slots = f.Mach.fun_num_stack_slots;
-    fun_frame_required;
-    fun_extra_stack_used
+    fun_frame_required = fa.frame_required;
+    fun_extra_stack_used = fa.extra_stack_used
   }

--- a/asmcomp/linearize.ml
+++ b/asmcomp/linearize.ml
@@ -333,20 +333,19 @@ let add_prologue first_insn prologue_required =
     tailrec_entry_point_label, tailrec_entry_point
 
 let fundecl f =
-  let fun_prologue_required = Proc.prologue_required f in
-  let contains_calls = f.Mach.fun_contains_calls in
-  let fun_tailrec_entry_point_label, fun_body =
-    add_prologue (linear f.Mach.fun_body end_instr contains_calls)
-      fun_prologue_required
-  in
+  let (fun_contains_nontail_calls, fun_frame_required, fun_extra_stack_used) =
+    Stackframe.analyze f in
+  let (fun_tailrec_entry_point_label, fun_body) =
+    add_prologue (linear f.Mach.fun_body end_instr fun_frame_required)
+                 fun_frame_required in
   { fun_name = f.Mach.fun_name;
     fun_args = Reg.set_of_array f.Mach.fun_args;
     fun_body;
     fun_fast = not (List.mem Cmm.Reduce_code_size f.Mach.fun_codegen_options);
     fun_dbg  = f.Mach.fun_dbg;
     fun_tailrec_entry_point_label;
-    fun_contains_calls = contains_calls;
+    fun_contains_nontail_calls;
     fun_num_stack_slots = f.Mach.fun_num_stack_slots;
-    fun_frame_required = Proc.frame_required f;
-    fun_prologue_required;
+    fun_frame_required;
+    fun_extra_stack_used
   }

--- a/asmcomp/mach.ml
+++ b/asmcomp/mach.ml
@@ -97,7 +97,6 @@ type fundecl =
     fun_dbg : Debuginfo.t;
     fun_poll: Lambda.poll_attribute;
     fun_num_stack_slots: int array;
-    fun_contains_calls: bool;
   }
 
 let rec dummy_instr =

--- a/asmcomp/mach.mli
+++ b/asmcomp/mach.mli
@@ -98,7 +98,6 @@ type fundecl =
     fun_dbg : Debuginfo.t;
     fun_poll: Lambda.poll_attribute;
     fun_num_stack_slots: int array;
-    fun_contains_calls: bool;
   }
 
 val dummy_instr: instruction

--- a/asmcomp/polling.ml
+++ b/asmcomp/polling.ml
@@ -187,10 +187,7 @@ let potentially_recursive_tailcall ~future_funcnames funbody =
    the resulting function contains any [Ipoll] instructions.
 *)
 
-let contains_polls = ref false
-
 let add_poll i =
-  contains_polls := true;
   Mach.instr_cons_debug (Iop (Ipoll { return_label = None })) [||] [||] i.dbg i
 
 let instr_body handler_safe i =
@@ -238,11 +235,7 @@ let instr_body handler_safe i =
         next = instr ube i.next;
       }
     | Iend | Ireturn | Iraise _ -> i
-    | Iop op ->
-      begin match op with
-      | Ipoll _ -> contains_polls := true
-      | _ -> ()
-      end;
+    | Iop _ ->
       { i with next = instr ube i.next }
   in
   instr Int.Set.empty i
@@ -276,7 +269,6 @@ let instrument_fundecl ~future_funcnames:_ (f : Mach.fundecl) : Mach.fundecl =
   if function_is_assumed_to_never_poll f.fun_name then f
   else begin
     let handler_needs_poll = polled_loops_analysis f.fun_body in
-    contains_polls := false;
     let new_body = instr_body handler_needs_poll f.fun_body in
     begin match f.fun_poll with
     | Error_poll -> begin
@@ -285,8 +277,7 @@ let instrument_fundecl ~future_funcnames:_ (f : Mach.fundecl) : Mach.fundecl =
         | poll_error_instrs -> raise (Error(Poll_error poll_error_instrs))
       end
     | Default_poll -> () end;
-    let new_contains_calls = f.fun_contains_calls || !contains_polls in
-    { f with fun_body = new_body; fun_contains_calls = new_contains_calls }
+    { f with fun_body = new_body }
   end
 
 let requires_prologue_poll ~future_funcnames ~fun_name i =

--- a/asmcomp/power/emit.mlp
+++ b/asmcomp/power/emit.mlp
@@ -373,7 +373,7 @@ module BR = Branch_relaxation.Make (struct
   let prologue_size f =
     profiling_prologue_size
       + (if initial_stack_offset f > 0 then 1 else 0)
-      + (if f.fun_contains_calls then 3 else 0)
+      + (if f.fun_frame_required then 3 else 0)
 
   let tocload_size = 2
 
@@ -528,13 +528,12 @@ let emit_instr env i =
     match i.desc with
     | Lend -> ()
     | Lprologue ->
-      assert (env.f.fun_prologue_required);
       let n = frame_size env in
       if n > 0 then begin
         `	addi	1, 1, {emit_int(-n)}\n`;
         cfi_adjust_cfa_offset n
       end;
-      if env.f.fun_contains_calls then begin
+      if env.f.fun_frame_required then begin
         let ra = retaddr_offset env in
         `	mflr	0\n`;
         `	std	0, {emit_int ra}(1)\n`;
@@ -619,7 +618,7 @@ let emit_instr env i =
     | Lop(Itailcall_ind) ->
         `	mtctr	{emit_reg i.arg.(0)}\n`;
         `	mr	12, {emit_reg i.arg.(0)}\n`;   (* addr of fn in r12 *)
-        if env.f.fun_contains_calls then begin
+        if env.f.fun_frame_required then begin
           `	ld	11, {emit_int(retaddr_offset env)}(1)\n`;
           `	mtlr	11\n`
         end;
@@ -631,7 +630,7 @@ let emit_instr env i =
         else begin
           emit_tocload emit_gpr 12 (TocSym func); (* addr of fn must be in r12 *)
           `	mtctr	12\n`;
-          if env.f.fun_contains_calls then begin
+          if env.f.fun_frame_required then begin
             `	ld	11, {emit_int(retaddr_offset env)}(1)\n`;
             `	mtlr	11\n`
           end;
@@ -907,12 +906,10 @@ let fundecl fundecl =
   `	.align	2\n`;
   (* Dynamic stack checking *)
   let stack_threshold_size = Config.stack_threshold * 8 in (* bytes *)
-  let { max_frame_size; contains_nontail_calls} =
-    preproc_stack_check
-      ~fun_body:fundecl.fun_body ~frame_size:(frame_size env) ~trap_size:16
-  in
+  let max_frame_size = frame_size env + fundecl.fun_extra_stack_used in
   let handle_overflow = ref None in
-  if contains_nontail_calls || max_frame_size >= stack_threshold_size then begin
+  if fundecl.fun_contains_nontail_calls
+  || max_frame_size >= stack_threshold_size then begin
     let overflow = new_label () and ret = new_label () in
     (* The return address is saved in a register not used for param passing *)
     `{emit_label overflow}:	mflr	28\n`;

--- a/asmcomp/power/proc.ml
+++ b/asmcomp/power/proc.ml
@@ -270,12 +270,6 @@ let max_register_pressure = function
   | Iintoffloat | Istore(Single, _, _) -> [| 23; 31 |]
   | _ -> [| 23; 32 |]
 
-(* Layout of the stack *)
-
-let frame_required _ = true
-
-let prologue_required _ = true
-
 (* Calling the assembler *)
 
 let assemble_file infile outfile =

--- a/asmcomp/power/stackframe.ml
+++ b/asmcomp/power/stackframe.ml
@@ -1,0 +1,34 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*             Xavier Leroy, projet Cambium, INRIA Paris                  *)
+(*                                                                        *)
+(*   Copyright 2023 Institut National de Recherche en Informatique et     *)
+(*     en Automatique.                                                    *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+(* Compute the parameters needed for allocating and managing stack frames
+   in the Emit phase. *)
+
+open! Mach [@@warning "-66"]
+
+let trap_handler_size = 16
+
+class stackframe = object
+
+inherit Stackframegen.stackframe_generic
+
+method! frame_required _f _contains_calls = true
+
+method trap_handler_size = trap_handler_size
+
+end
+
+let analyze f = 
+  (new stackframe)#analyze f

--- a/asmcomp/power/stackframe.ml
+++ b/asmcomp/power/stackframe.ml
@@ -30,5 +30,5 @@ method trap_handler_size = trap_handler_size
 
 end
 
-let analyze f = 
+let analyze f =
   (new stackframe)#analyze f

--- a/asmcomp/proc.mli
+++ b/asmcomp/proc.mli
@@ -55,12 +55,6 @@ val destroyed_at_oper: Mach.instruction_desc -> Reg.t array
 val destroyed_at_raise: Reg.t array
 val destroyed_at_reloadretaddr : Reg.t array
 
-(* Info for laying out the stack frame *)
-val frame_required : Mach.fundecl -> bool
-
-(* Function prologues *)
-val prologue_required : Mach.fundecl -> bool
-
 (** For a given register class, the DWARF register numbering for that class.
     Given an allocated register with location [Reg n] and class [reg_class], the
     returned array contains the corresponding DWARF register number at index

--- a/asmcomp/reloadgen.ml
+++ b/asmcomp/reloadgen.ml
@@ -130,12 +130,7 @@ method private reload i =
 method fundecl f num_stack_slots =
   redo_regalloc <- false;
   let new_body = self#reload f.fun_body in
-  ({fun_name = f.fun_name; fun_args = f.fun_args;
-    fun_body = new_body; fun_codegen_options = f.fun_codegen_options;
-    fun_dbg  = f.fun_dbg;
-    fun_poll = f.fun_poll;
-    fun_contains_calls = f.fun_contains_calls;
-    fun_num_stack_slots = Array.copy num_stack_slots;
-   },
+  ({f with fun_body = new_body;
+           fun_num_stack_slots = Array.copy num_stack_slots},
    redo_regalloc)
 end

--- a/asmcomp/riscv/emit.mlp
+++ b/asmcomp/riscv/emit.mlp
@@ -31,7 +31,7 @@ let frame_size env =
   env.stack_offset +                     (* Trap frame, outgoing parameters *)
   size_int * env.f.fun_num_stack_slots.(0) +    (* Local int variables *)
   size_float * env.f.fun_num_stack_slots.(1) +  (* Local float variables *)
-  (if env.f.fun_contains_calls then size_addr else 0) (* Return address *)
+  (if env.f.fun_frame_required then size_addr else 0) (* Return address *)
 
 let slot_offset env loc cls =
   match loc with
@@ -263,10 +263,9 @@ let emit_instr env i =
   match i.desc with
     Lend -> ()
   | Lprologue ->
-      assert (env.f.fun_prologue_required);
       let n = frame_size env in
       emit_stack_adjustment (-n);
-      if env.f.fun_contains_calls then begin
+      if env.f.fun_frame_required then begin
         store_ra n;
         cfi_offset ~reg:1 (* ra *) ~offset:(-8)
       end;
@@ -312,7 +311,7 @@ let emit_instr env i =
       record_frame env i.live (Dbg_other i.dbg)
   | Lop(Itailcall_ind) ->
       let n = frame_size env in
-      if env.f.fun_contains_calls then reload_ra n;
+      if env.f.fun_frame_required then reload_ra n;
       emit_stack_adjustment n;
       `	jr	{emit_reg i.arg.(0)}\n`
   | Lop(Itailcall_imm {func}) ->
@@ -320,7 +319,7 @@ let emit_instr env i =
         `	j	{emit_label env.f.fun_tailrec_entry_point_label}\n`
       end else begin
         let n = frame_size env in
-        if env.f.fun_contains_calls then reload_ra n;
+        if env.f.fun_frame_required then reload_ra n;
         emit_stack_adjustment n;
         `	{emit_tail func}\n`
       end
@@ -627,12 +626,10 @@ let fundecl fundecl =
 
   (* Dynamic stack checking *)
   let stack_threshold_size = Config.stack_threshold * 8 in (* bytes *)
-  let { max_frame_size; contains_nontail_calls } =
-    preproc_stack_check
-      ~fun_body:fundecl.fun_body ~frame_size:(frame_size env) ~trap_size:16
-  in
+  let max_frame_size = frame_size env + fundecl.fun_extra_stack_used in
   let handle_overflow =
-    if contains_nontail_calls || max_frame_size >= stack_threshold_size then begin
+    if fundecl.fun_contains_nontail_calls
+    || max_frame_size >= stack_threshold_size then begin
       let overflow = new_label () and ret = new_label () in
       let threshold_offset = Domainstate.stack_ctx_words * 8 + stack_threshold_size in
       let f = max_frame_size + threshold_offset in

--- a/asmcomp/riscv/proc.ml
+++ b/asmcomp/riscv/proc.ml
@@ -273,16 +273,6 @@ let max_register_pressure = function
   | Iextcall _ -> [| 9; 12 |]
   | _ -> [| 23; 30 |]
 
-(* Layout of the stack *)
-
-let frame_required fd =
-  fd.fun_contains_calls
-  || fd.fun_num_stack_slots.(0) > 0
-  || fd.fun_num_stack_slots.(1) > 0
-
-let prologue_required fd =
-  frame_required fd
-
 (* See
    https://github.com/riscv-non-isa/riscv-elf-psabi-doc/blob/master/riscv-elf.adoc
 *)

--- a/asmcomp/riscv/stackframe.ml
+++ b/asmcomp/riscv/stackframe.ml
@@ -28,5 +28,5 @@ method trap_handler_size = trap_handler_size
 
 end
 
-let analyze f = 
+let analyze f =
   (new stackframe)#analyze f

--- a/asmcomp/riscv/stackframe.ml
+++ b/asmcomp/riscv/stackframe.ml
@@ -1,0 +1,32 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*             Xavier Leroy, projet Cambium, INRIA Paris                  *)
+(*                                                                        *)
+(*   Copyright 2023 Institut National de Recherche en Informatique et     *)
+(*     en Automatique.                                                    *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+(* Compute the parameters needed for allocating and managing stack frames
+   in the Emit phase. *)
+
+open! Mach [@@warning "-66"]
+
+let trap_handler_size = 16
+
+class stackframe = object
+
+inherit Stackframegen.stackframe_generic
+
+method trap_handler_size = trap_handler_size
+
+end
+
+let analyze f = 
+  (new stackframe)#analyze f

--- a/asmcomp/s390x/emit.mlp
+++ b/asmcomp/s390x/emit.mlp
@@ -30,7 +30,7 @@ let frame_size env =
     env.stack_offset +      (* Trap frame, outgoing parameters *)
     size_int * env.f.fun_num_stack_slots.(0) +    (* Local int variables *)
     size_float * env.f.fun_num_stack_slots.(1) +  (* Local float variables *)
-    (if env.f.fun_contains_calls then size_addr else 0) in (* The return address *)
+    (if env.f.fun_frame_required then size_addr else 0) in (* The return address *)
   Misc.align size 8
 
 let slot_offset env loc cls =
@@ -298,10 +298,9 @@ let emit_instr env i =
     match i.desc with
       Lend -> ()
     | Lprologue ->
-      assert (env.f.fun_prologue_required);
       let n = frame_size env in
       emit_stack_adjust n;
-      if env.f.fun_contains_calls then
+      if env.f.fun_frame_required then
         `	stg	%r14, {emit_int(n - size_addr)}(%r15)\n`
     | Lop(Imove | Ispill | Ireload) ->
         let src = i.arg.(0) and dst = i.res.(0) in
@@ -348,7 +347,7 @@ let emit_instr env i =
         `{record_frame env i.live (Dbg_other i.dbg)}\n`
     | Lop(Itailcall_ind) ->
         let n = frame_size env in
-        if env.f.fun_contains_calls then
+        if env.f.fun_frame_required then
           `	lg	%r14, {emit_int(n - size_addr)}(%r15)\n`;
         emit_stack_adjust (-n);
         `	br	{emit_reg i.arg.(0)}\n`
@@ -357,7 +356,7 @@ let emit_instr env i =
           `	brcl	15, {emit_label env.f.fun_tailrec_entry_point_label}\n`
         else begin
           let n = frame_size env in
-          if env.f.fun_contains_calls then
+          if env.f.fun_frame_required then
             `	lg	%r14, {emit_int(n - size_addr)}(%r15)\n`;
           emit_stack_adjust (-n);
           if !pic_code then
@@ -724,12 +723,10 @@ let fundecl fundecl =
 
   (* Dynamic stack checking *)
   let stack_threshold_size = Config.stack_threshold * 8 in (* bytes *)
-  let { max_frame_size; contains_nontail_calls} =
-    preproc_stack_check
-      ~fun_body:fundecl.fun_body ~frame_size:(frame_size env) ~trap_size:16
-  in
+  let max_frame_size = frame_size env + fundecl.fun_extra_stack_used in
   let handle_overflow = ref None in
-  if contains_nontail_calls || max_frame_size >= stack_threshold_size then begin
+  if fundecl.fun_contains_nontail_calls
+  || max_frame_size >= stack_threshold_size then begin
     let overflow = new_label () and ret = new_label () in
     let threshold_offset = Domainstate.stack_ctx_words * 8 + stack_threshold_size in
     let f = max_frame_size + threshold_offset in

--- a/asmcomp/s390x/proc.ml
+++ b/asmcomp/s390x/proc.ml
@@ -214,16 +214,6 @@ let max_register_pressure = function
     Iextcall _ -> [| 4; 7 |]
   | _ -> [| 9; 15 |]
 
-(* Layout of the stack *)
-
-let frame_required fd =
-  fd.fun_contains_calls
-    || fd.fun_num_stack_slots.(0) > 0
-    || fd.fun_num_stack_slots.(1) > 0
-
-let prologue_required fd =
-  frame_required fd
-
 (* Calling the assembler *)
 
 let assemble_file infile outfile =

--- a/asmcomp/s390x/stackframe.ml
+++ b/asmcomp/s390x/stackframe.ml
@@ -28,5 +28,5 @@ method trap_handler_size = trap_handler_size
 
 end
 
-let analyze f = 
+let analyze f =
   (new stackframe)#analyze f

--- a/asmcomp/s390x/stackframe.ml
+++ b/asmcomp/s390x/stackframe.ml
@@ -1,0 +1,32 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*             Xavier Leroy, projet Cambium, INRIA Paris                  *)
+(*                                                                        *)
+(*   Copyright 2023 Institut National de Recherche en Informatique et     *)
+(*     en Automatique.                                                    *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+(* Compute the parameters needed for allocating and managing stack frames
+   in the Emit phase. *)
+
+open! Mach [@@warning "-66"]
+
+let trap_handler_size = 16
+
+class stackframe = object
+
+inherit Stackframegen.stackframe_generic
+
+method trap_handler_size = trap_handler_size
+
+end
+
+let analyze f = 
+  (new stackframe)#analyze f

--- a/asmcomp/schedgen.ml
+++ b/asmcomp/schedgen.ml
@@ -397,17 +397,7 @@ method schedule_fundecl f =
   if f.fun_fast && !Clflags.insn_sched then begin
     let new_body = schedule f.fun_body 0 in
     clear_code_dag();
-    { fun_name = f.fun_name;
-      fun_args = f.fun_args;
-      fun_body = new_body;
-      fun_fast = f.fun_fast;
-      fun_dbg  = f.fun_dbg;
-      fun_tailrec_entry_point_label = f.fun_tailrec_entry_point_label;
-      fun_contains_calls = f.fun_contains_calls;
-      fun_num_stack_slots = f.fun_num_stack_slots;
-      fun_frame_required = f.fun_frame_required;
-      fun_prologue_required = f.fun_prologue_required;
-    }
+    { f with fun_body = new_body }
   end else
     f
 

--- a/asmcomp/selectgen.mli
+++ b/asmcomp/selectgen.mli
@@ -115,34 +115,6 @@ class virtual selector_generic : object
     (* Fill a freshly allocated block.  Can be overridden for architectures
        that do not provide Arch.offset_addressing. *)
 
-  method mark_call : unit
-  (* informs the code emitter that the current function is non-leaf:
-     it may perform a (non-tail) call; by default, sets
-     [contains_calls := true] *)
-
-  method mark_tailcall : unit
-  (* informs the code emitter that the current function may end with
-     a tail-call; by default, does nothing *)
-
-  method mark_c_tailcall : unit
-  (* informs the code emitter that the current function may call
-     a C function that never returns; by default, sets
-     [contains_calls := true] in [-g] mode and does nothing otherwise.
-
-     It is unnecessary to save the stack pointer in this situation,
-     unless we need to produce exact stack backtraces, hence the default
-     definition.
-
-     Some architectures still need to ensure that the stack is properly
-     aligned when the C function is called, regardless of [-g].
-     This is achieved by overloading this method to set
-     [contains_calls := true]. *)
-
-  method mark_instr : Mach.instruction_desc -> unit
-  (* dispatches on instructions to call one of the marking function
-     above; overloading this is useful if Ispecific instructions need
-     marking *)
-
   (* The following method is the entry point and should not be overridden *)
   method emit_fundecl : future_funcnames:Misc.Stdlib.String.Set.t
                                               -> Cmm.fundecl -> Mach.fundecl
@@ -166,11 +138,6 @@ class virtual selector_generic : object
   method emit_expr :
     environment -> Cmm.expression -> Reg.t array option
   method emit_tail : environment -> Cmm.expression -> unit
-
-  (* [contains_calls] is declared as a reference instance variable,
-     instead of a mutable boolean instance variable,
-     because the traversal uses functional object copies. *)
-  val contains_calls : bool ref
 end
 
 val reset : unit -> unit

--- a/asmcomp/spill.ml
+++ b/asmcomp/spill.ml
@@ -423,12 +423,4 @@ let fundecl f =
       (Reg.inter_set_array tospill_at_entry f.fun_args)
       body2
   in
-  { fun_name = f.fun_name;
-    fun_args = f.fun_args;
-    fun_body = new_body;
-    fun_codegen_options = f.fun_codegen_options;
-    fun_poll = f.fun_poll;
-    fun_dbg  = f.fun_dbg;
-    fun_num_stack_slots = f.fun_num_stack_slots;
-    fun_contains_calls = f.fun_contains_calls;
-  }
+  { f with fun_body = new_body }

--- a/asmcomp/split.ml
+++ b/asmcomp/split.ml
@@ -214,12 +214,4 @@ let fundecl f =
   repres_regs new_args;
   set_repres new_body;
   equiv_classes := Reg.Map.empty;
-  { fun_name = f.fun_name;
-    fun_args = new_args;
-    fun_body = new_body;
-    fun_codegen_options = f.fun_codegen_options;
-    fun_poll = f.fun_poll;
-    fun_dbg  = f.fun_dbg;
-    fun_num_stack_slots = f.fun_num_stack_slots;
-    fun_contains_calls = f.fun_contains_calls;
-  }
+  { f with fun_args = new_args; fun_body = new_body }

--- a/asmcomp/stackframe.mli
+++ b/asmcomp/stackframe.mli
@@ -17,4 +17,24 @@
    in the Emit phase. *)
 
 val trap_handler_size : int
+
 val analyze : Mach.fundecl -> bool * bool * int
+  (** [analyze f] returns a triple
+      [(contains_nontail_calls, frame_required, extra_space)].
+
+      [contains_nontail_calls] says whether the function contains
+      non-tail calls to OCaml functions.  Calls to C functions don't count.
+
+      [frame_required] says whether the function must allocate a stack
+      frame on entry, for one of the following reasons:
+        - some local variables are stack-allocated
+        - the function needs to save its return address on the stack, e.g.:
+           -- it contains a non-tail call to an OCaml function
+           -- it calls a C function
+           -- it contains an allocation or a poll point
+           -- it performs an array bound check (on some ports)
+
+      [extra_stack_used] is the mount of stack space used, in bytes,
+      in addition to the initial stack frame.
+      This counts trap handlers and "outgoing" stack slots
+      used for parameter passing. *)

--- a/asmcomp/stackframe.mli
+++ b/asmcomp/stackframe.mli
@@ -18,23 +18,4 @@
 
 val trap_handler_size : int
 
-val analyze : Mach.fundecl -> bool * bool * int
-  (** [analyze f] returns a triple
-      [(contains_nontail_calls, frame_required, extra_space)].
-
-      [contains_nontail_calls] says whether the function contains
-      non-tail calls to OCaml functions.  Calls to C functions don't count.
-
-      [frame_required] says whether the function must allocate a stack
-      frame on entry, for one of the following reasons:
-        - some local variables are stack-allocated
-        - the function needs to save its return address on the stack, e.g.:
-           -- it contains a non-tail call to an OCaml function
-           -- it calls a C function
-           -- it contains an allocation or a poll point
-           -- it performs an array bound check (on some ports)
-
-      [extra_stack_used] is the mount of stack space used, in bytes,
-      in addition to the initial stack frame.
-      This counts trap handlers and "outgoing" stack slots
-      used for parameter passing. *)
+val analyze : Mach.fundecl -> Stackframegen.analysis_result

--- a/asmcomp/stackframe.mli
+++ b/asmcomp/stackframe.mli
@@ -1,0 +1,20 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*             Xavier Leroy, projet Cambium, INRIA Paris                  *)
+(*                                                                        *)
+(*   Copyright 2023 Institut National de Recherche en Informatique et     *)
+(*     en Automatique.                                                    *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+(* Compute the parameters needed for allocating and managing stack frames
+   in the Emit phase. *)
+
+val trap_handler_size : int
+val analyze : Mach.fundecl -> bool * bool * int

--- a/asmcomp/stackframegen.ml
+++ b/asmcomp/stackframegen.ml
@@ -1,0 +1,110 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*             Xavier Leroy, projet Cambium, INRIA Paris                  *)
+(*                                                                        *)
+(*   Copyright 2023 Institut National de Recherche en Informatique et     *)
+(*     en Automatique.                                                    *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+(* Compute the parameters needed for allocating and managing stack frames
+   in the Emit phase. *)
+
+open Mach
+
+class virtual stackframe_generic = object (self)
+
+(* Size of an exception handler block on the stack.
+   To be provided for each target. *)
+
+method virtual trap_handler_size : int
+
+(* Determine if an instruction performs a call that requires
+   the return address to be saved in the stack frame, and a stack frame to
+   be allocated.
+
+   At a minimum, these instructions include all non-tail calls,
+   both to OCaml functions or to C functions.
+
+   For exception-raising constructs, we get better stack backtraces
+   by treating them as non-tail calls, even if they are implemented as
+   tail calls.
+
+   This method can be overriden in [Stackframe] to implement target-specific
+   behaviors. *)
+
+method is_call = function
+  | Iop (Icall_ind | Icall_imm _ | Iextcall _) -> true
+  | Iop (Ialloc _) | Iop (Ipoll _) -> true
+      (* caml_alloc*, caml_garbage_collection (incl. polls) *)
+  | Iop (Iintop (Icheckbound) | Iintop_imm(Icheckbound, _)) -> !Clflags.debug
+      (* caml_ml_array_bound_error *)
+  | Iraise Lambda.Raise_notrace -> false
+  | Iraise (Lambda.Raise_regular | Lambda.Raise_reraise) -> true
+      (* caml_stash_backtrace; having a frame gives better stack backtrace *)
+  | Itrywith _ -> true
+  | _ -> false
+
+(* Determine if a function requires a stack frame to be allocated.
+   This is the case if it contains calls, but also if it allocates
+   variables on the stack.
+
+   This method can be overriden in [Stackframe] to implement target-specific
+   behaviors. *)
+
+method frame_required f contains_calls =
+  contains_calls || 
+  f.fun_num_stack_slots.(0) > 0 || f.fun_num_stack_slots.(1) > 0
+
+(* Analyze the body of a Mach function to determine
+   - whether it contains non-tail-calls to OCaml functions
+   - whether it requires allocating a stack frame and saving the return address
+   - how much extra stack space is needed for exception handlers
+     and for passing parameters to C function on stack.
+*)
+
+method analyze f =
+  let contains_nontail_calls = ref false
+  and contains_calls = ref false
+  and extra_space = ref 0 in
+  let rec analyze sp i =
+    if sp > !extra_space then extra_space := sp;
+    contains_calls := !contains_calls || self#is_call i.desc;
+    match i.desc with
+    | Iend -> ()
+    | Iop (Istackoffset delta) ->
+        analyze (sp + delta) i.next
+    | Iop (Itailcall_ind | Itailcall_imm _) -> ()
+    | Iop (Icall_ind | Icall_imm _) ->
+        contains_nontail_calls := true;
+        analyze sp i.next
+    | Iop _ ->
+        analyze sp i.next
+    | Ireturn -> ()
+    | Iifthenelse(_, ifso, ifnot) ->
+        analyze sp ifso; analyze sp ifnot; analyze sp i.next
+    | Iswitch(_, branches) ->
+        Array.iter (analyze sp) branches; analyze sp i.next
+    | Icatch(_, handlers, body) ->
+        List.iter (fun (_, handler) -> analyze sp handler) handlers;
+        analyze sp body;
+        analyze sp i.next
+    | Iexit _ -> ()
+    | Itrywith(body, handler) ->
+        analyze (sp + self#trap_handler_size) body;
+        analyze sp handler;
+        analyze sp i.next
+    | Iraise _ -> ()
+ in
+   analyze 0 f.fun_body;
+   (!contains_nontail_calls,
+    self#frame_required f !contains_calls,
+    !extra_space)
+
+end

--- a/asmcomp/stackframegen.ml
+++ b/asmcomp/stackframegen.ml
@@ -18,6 +18,12 @@
 
 open Mach
 
+type analysis_result = {
+  contains_nontail_calls: bool;
+  frame_required: bool;
+  extra_stack_used: int;
+}
+
 class virtual stackframe_generic = object (self)
 
 (* Size of an exception handler block on the stack.
@@ -103,8 +109,8 @@ method analyze f =
     | Iraise _ -> ()
  in
    analyze 0 f.fun_body;
-   (!contains_nontail_calls,
-    self#frame_required f !contains_calls,
-    !extra_space)
+   { contains_nontail_calls = !contains_nontail_calls;
+     frame_required = self#frame_required f !contains_calls;
+     extra_stack_used = !extra_space }
 
 end

--- a/asmcomp/stackframegen.ml
+++ b/asmcomp/stackframegen.ml
@@ -65,7 +65,7 @@ method is_call = function
    behaviors. *)
 
 method frame_required f contains_calls =
-  contains_calls || 
+  contains_calls ||
   f.fun_num_stack_slots.(0) > 0 || f.fun_num_stack_slots.(1) > 0
 
 (* Analyze the body of a Mach function to determine

--- a/asmcomp/stackframegen.mli
+++ b/asmcomp/stackframegen.mli
@@ -1,0 +1,25 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*             Xavier Leroy, projet Cambium, INRIA Paris                  *)
+(*                                                                        *)
+(*   Copyright 2023 Institut National de Recherche en Informatique et     *)
+(*     en Automatique.                                                    *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+(* Compute the parameters needed for allocating and managing stack frames
+   in the Emit phase. *)
+
+class virtual stackframe_generic : object
+  method virtual trap_handler_size : int
+  method is_call : Mach.instruction_desc -> bool
+  method frame_required : Mach.fundecl -> bool -> bool
+  method analyze : Mach.fundecl -> bool * bool * int
+end
+

--- a/asmcomp/stackframegen.mli
+++ b/asmcomp/stackframegen.mli
@@ -16,10 +16,32 @@
 (* Compute the parameters needed for allocating and managing stack frames
    in the Emit phase. *)
 
+type analysis_result = {
+  contains_nontail_calls: bool;
+    (** Whether the function contains non-tail calls to OCaml functions.
+        Calls to C functions don't count.
+    *)
+  frame_required: bool;
+    (** Whether the function must allocate a stack frame on entry, for
+        one of the following reasons:
+        - some local variables are stack-allocated
+        - the function needs to save its return address on the stack, e.g.:
+           -- it contains a non-tail call to an OCaml function
+           -- it calls a C function
+           -- it contains an allocation or a poll point
+           -- it performs an array bound check (on some ports)
+     *)
+  extra_stack_used: int;
+     (** Amount of stack space used, in bytes,
+         in addition to the initial stack frame.
+         This counts trap handlers and "outgoing" stack slots used
+         for parameter passing. *)
+}
+
 class virtual stackframe_generic : object
   method virtual trap_handler_size : int
   method is_call : Mach.instruction_desc -> bool
   method frame_required : Mach.fundecl -> bool -> bool
-  method analyze : Mach.fundecl -> bool * bool * int
+  method analyze : Mach.fundecl -> analysis_result
 end
 

--- a/asmcomp/stackframegen.mli
+++ b/asmcomp/stackframegen.mli
@@ -44,4 +44,3 @@ class virtual stackframe_generic : object
   method frame_required : Mach.fundecl -> bool -> bool
   method analyze : Mach.fundecl -> analysis_result
 end
-

--- a/compilerlibs/Makefile.compilerlibs
+++ b/compilerlibs/Makefile.compilerlibs
@@ -228,6 +228,8 @@ ASMCOMP = \
   asmcomp/reloadgen.cmo \
   asmcomp/reload.cmo \
   asmcomp/deadcode.cmo \
+  asmcomp/stackframegen.cmo \
+  asmcomp/stackframe.cmo \
   asmcomp/linear.cmo \
   asmcomp/printlinear.cmo \
   asmcomp/linearize.cmo \


### PR DESCRIPTION
The code emitters `$ARCH/emit.mlp` need to know the following characteristics of the Linear code in order to manage stack frames:

1. The maximal size of the stack frame during the function execution [for stack bound checking]
2. Whether the function contains non-tail calls to OCaml functions [for stack bound checking]
3. Whether the function contains anything resembling a non-tail call and requiring the return address to be saved on stack
4. Whether the function needs to allocate a stack frame on entry and free it on return.

Currently, these parameters are computed all over the native back-end: 1 and 2 by function `preproc_stack_check` in `emitaux.ml`, and 4 by functions in `$ARCH/proc.ml`.  The main pain point is 3: `contains_calls` is computed early during the Selection pass, then propagated through later passes, but needs updating in the `Polling` pass.

This PR proposes to group all these computations in the same place: a shared `stackframe_gen.ml` file that is specialized in a per-target `$ARCH/stackframe.ml` file.  The computations are performed late in the native compilation pipeline, so as to minimize the amount of information that needs propagating and updating through the pipeline.

The PR also makes a not-completely-related simplification.  The current code makes provisions to distinguish two conditions: (a) the return address must be saved on stack, and (b) a stack frame must be set up.  (a) implies (b), but a tail function that spills some local variables on the stack needs (b) but not (a).  However, the current code is not taking advantage of this, always saving the return address if a stack frame is set up.  I don't think it matters performance-wise, so I propose to simplify the code accordingly.
