### PR TITLE
Ocamltest new log format and better error report

### DIFF
--- a/.depend
+++ b/.depend
@@ -9055,15 +9055,18 @@ ocamltest/filecompare.cmx : \
     ocamltest/filecompare.cmi
 ocamltest/filecompare.cmi :
 ocamltest/main.cmo : \
+    ocamltest/variables.cmi \
     otherlibs/unix/unix.cmi \
     ocamltest/tsl_semantics.cmi \
     ocamltest/tsl_parser.cmi \
     ocamltest/tsl_lexer.cmi \
+    ocamltest/tsl_ast.cmi \
     ocamltest/translate.cmi \
     ocamltest/tests.cmi \
     ocamltest/result.cmi \
     ocamltest/options.cmi \
     ocamltest/ocamltest_stdlib.cmi \
+    ocamltest/ocaml_actions.cmi \
     parsing/location.cmi \
     ocamltest/environments.cmi \
     ocamltest/builtin_variables.cmi \
@@ -9071,15 +9074,18 @@ ocamltest/main.cmo : \
     ocamltest/actions.cmi \
     ocamltest/main.cmi
 ocamltest/main.cmx : \
+    ocamltest/variables.cmx \
     otherlibs/unix/unix.cmx \
     ocamltest/tsl_semantics.cmx \
     ocamltest/tsl_parser.cmx \
     ocamltest/tsl_lexer.cmx \
+    ocamltest/tsl_ast.cmx \
     ocamltest/translate.cmx \
     ocamltest/tests.cmx \
     ocamltest/result.cmx \
     ocamltest/options.cmx \
     ocamltest/ocamltest_stdlib.cmx \
+    ocamltest/ocaml_actions.cmx \
     parsing/location.cmx \
     ocamltest/environments.cmx \
     ocamltest/builtin_variables.cmx \

--- a/ocamltest/main.ml
+++ b/ocamltest/main.ml
@@ -16,11 +16,12 @@
 (* Main program of the ocamltest test driver *)
 
 open Ocamltest_stdlib
+open Tsl_ast
 open Tsl_semantics
 
 type behavior =
-  | Skip_all_tests
-  | Run of Environments.t
+  | Skip_all
+  | Run
 
 (* this primitive announce should be used for tests
    that were aborted on system error before ocamltest
@@ -73,31 +74,37 @@ let join_summaries sa sb =
   | All_skipped, All_skipped -> All_skipped
   | _ -> No_failure
 
-let rec run_test log common_prefix path behavior = function
-  Node (testenvspec, test, env_modifiers, subtrees) ->
-  Printf.printf "%s %s (%s) %!" common_prefix path test.Tests.test_name;
-  let (msg, children_behavior, result) = match behavior with
-    | Skip_all_tests -> "=> n/a", Skip_all_tests, Result.skip
-    | Run env ->
-      let testenv0 = interpret_environment_statements env testenvspec in
-      let testenv = List.fold_left apply_modifiers testenv0 env_modifiers in
-      let (result, newenv) = Tests.run log testenv test in
-      let msg = Result.string_of_result result in
-      let children_behavior =
-        if Result.is_pass result then Run newenv else Skip_all_tests in
-      (msg, children_behavior, result) in
-  Printf.printf "%s\n%!" msg;
-  join_result
-    (run_test_trees log common_prefix path children_behavior subtrees) result
-
-and run_test_trees log common_prefix path behavior trees =
-  List.fold_left join_summaries All_skipped
-    (List.mapi (run_test_i log common_prefix path behavior) trees)
-
-and run_test_i log common_prefix path behavior i test_tree =
-  let path_prefix = if path="" then "" else path ^ "." in
-  let new_path = Printf.sprintf "%s%d" path_prefix (i+1) in
-  run_test log common_prefix new_path behavior test_tree
+let rec run_test_tree log common_prefix behavior env summ ast =
+  match ast with
+  | Ast (Environment_statement s :: stmts, subs) ->
+    let env = interpret_environment_statement env s in
+    run_test_tree log common_prefix behavior env summ (Ast (stmts, subs))
+  | Ast (Test (_, name, mods) :: stmts, subs) ->
+    let locstr =
+      if name.loc = Location.none then
+        "default"
+      else
+        Printf.sprintf "line %d" name.loc.Location.loc_start.Lexing.pos_lnum
+    in
+    Printf.printf "%s %s (%s) %!" common_prefix locstr name.node;
+    let (msg, children_behavior, newenv, result) =
+      match behavior with
+      | Skip_all -> ("=> n/a", Skip_all, env, Result.skip)
+      | Run ->
+        let testenv = List.fold_left apply_modifiers env mods in
+        let test = lookup_test name in
+        let (result, newenv) = Tests.run log testenv test in
+        let msg = Result.string_of_result result in
+        let sub_behavior = if Result.is_pass result then Run else Skip_all in
+        (msg, sub_behavior, newenv, result)
+    in
+    Printf.printf "%s\n%!" msg;
+    let newsumm = join_result summ result in
+    let newast = Ast (stmts, subs) in
+    run_test_tree log common_prefix children_behavior newenv newsumm newast
+  | Ast ([], subs) ->
+    List.fold_left join_summaries All_skipped
+      (List.map (run_test_tree log common_prefix behavior env All_skipped) subs)
 
 let get_test_source_directory test_dirname =
   if (Filename.is_relative test_dirname) then
@@ -118,18 +125,26 @@ let tests_to_skip = ref []
 let init_tests_to_skip () =
   tests_to_skip := String.words (Sys.safe_getenv "OCAMLTEST_SKIP_TESTS")
 
+let extract_rootenv (Ast (stmts, subs)) =
+  let (env, stmts) = split_env stmts in
+  (env, Ast (stmts, subs))
+
 let test_file test_filename =
   let start = if Options.show_timings then Unix.gettimeofday () else 0.0 in
   let skip_test = List.mem test_filename !tests_to_skip in
   let tsl_ast = tsl_parse_file_safe test_filename in
-  let (rootenv_statements, test_trees) = test_trees_of_tsl_ast tsl_ast in
-  let test_trees = match test_trees with
-    | [] ->
+  let (rootenv_statements, tsl_ast) = extract_rootenv tsl_ast in
+  let tsl_ast = match tsl_ast with
+    | Ast ([], []) ->
       let default_tests = Tests.default_tests() in
-      let make_tree test = Node ([], test, [], []) in
-      List.map make_tree default_tests
-    | _ -> test_trees in
-  let used_tests = tests_in_trees test_trees in
+      let make_tree test =
+        let id = make_identifier test.Tests.test_name in
+        Ast ([Test (0, id, [])], [])
+      in
+      Ast ([], List.map make_tree default_tests)
+    | _ -> tsl_ast
+  in
+  let used_tests = tests_in_tree tsl_ast in
   let used_actions = actions_in_tests used_tests in
   let action_names =
     let f act names = String.Set.add (Actions.name act) names in
@@ -190,10 +205,12 @@ let test_file test_filename =
        let rootenv = Environments.initialize Environments.Post log rootenv in
        let common_prefix = " ... testing '" ^ test_basename ^ "' with" in
        let initial_status =
-         if skip_test then Skip_all_tests else Run rootenv
+         if skip_test then Skip_all else Run
        in
        let summary =
-         run_test_trees log common_prefix "" initial_status test_trees in
+         run_test_tree log common_prefix initial_status rootenv All_skipped
+           tsl_ast
+       in
        Actions.clear_all_hooks();
        summary
     ) in

--- a/ocamltest/ocaml_actions.ml
+++ b/ocamltest/ocaml_actions.ml
@@ -158,6 +158,8 @@ let generate_lexer = generate_module ocamllex
 
 let generate_parser = generate_module ocamlyacc
 
+exception Cannot_compile_file_type of string
+
 let prepare_module output_variable log env input =
   let input_type = snd input in
   let open Ocaml_filetypes in
@@ -165,12 +167,12 @@ let prepare_module output_variable log env input =
     | Implementation | Interface | C | Obj -> [input]
     | Binary_interface -> [input]
     | Backend_specific _ -> [input]
-    | C_minus_minus -> assert false
     | Lexer ->
       generate_lexer output_variable input log env
     | Grammar ->
       generate_parser output_variable input log env
-    | Text -> assert false
+    | Text | C_minus_minus | Other _ ->
+      raise (Cannot_compile_file_type (string_of_filetype input_type))
 
 let get_program_file backend env =
   let testfile = Actions_helpers.testfile env in

--- a/ocamltest/ocaml_actions.mli
+++ b/ocamltest/ocaml_actions.mli
@@ -15,6 +15,8 @@
 
 (* Actions specific to the OCaml compilers *)
 
+exception Cannot_compile_file_type of string
+
 val setup_ocamlc_byte_build_env : Actions.t
 val ocamlc_byte : Actions.t
 val check_ocamlc_byte_output : Actions.t

--- a/ocamltest/ocaml_filetypes.ml
+++ b/ocamltest/ocaml_filetypes.ml
@@ -28,6 +28,7 @@ type t =
   | Obj
   | Backend_specific of Ocaml_backends.t * backend_specific
   | Text (* used by ocamldoc for text only documentation *)
+  | Other of string
 
 let string_of_backend_specific = function
   | Object -> "object"
@@ -38,7 +39,7 @@ let string_of_filetype = function
   | Implementation -> "implementation"
   | Interface -> "interface"
   | C -> "C source file"
-  | C_minus_minus -> "C minus minus source file"
+  | C_minus_minus -> "C minus minus source"
   | Lexer -> "lexer"
   | Grammar -> "grammar"
   | Binary_interface -> "binary interface"
@@ -47,6 +48,7 @@ let string_of_filetype = function
     ((Ocaml_backends.string_of_backend backend) ^ " " ^
       (string_of_backend_specific filetype))
   | Text -> "text"
+  | Other s -> Printf.sprintf "unknown (%s)" s
 
 let extension_of_filetype = function
   | Implementation -> "ml"
@@ -67,6 +69,7 @@ let extension_of_filetype = function
       | (Ocaml_backends.Bytecode, Program) -> "byte"
     end
   | Text -> "txt"
+  | Other s -> s
 
 let filetype_of_extension = function
   | "ml" -> Implementation
@@ -85,7 +88,7 @@ let filetype_of_extension = function
   | "cma" -> Backend_specific (Ocaml_backends.Bytecode, Library)
   | "byte" -> Backend_specific (Ocaml_backends.Bytecode, Program)
   | "txt" -> Text
-  | _ as e -> Printf.eprintf "Unknown file extension %s\n%!" e; exit 2
+  | e -> Other e
 
 let split_filename name =
   let l = String.length name in

--- a/ocamltest/ocaml_filetypes.mli
+++ b/ocamltest/ocaml_filetypes.mli
@@ -28,6 +28,7 @@ type t =
   | Obj
   | Backend_specific of Ocaml_backends.t * backend_specific
   | Text (** text-only documentation file *)
+  | Other of string
 
 val string_of_filetype : t -> string
 

--- a/ocamltest/tsl_ast.ml
+++ b/ocamltest/tsl_ast.ml
@@ -37,6 +37,12 @@ type tsl_block = tsl_item list
 
 type t = Ast of tsl_item list * t list
 
+let rec split_env l =
+  match l with
+  | Environment_statement env :: tl ->
+    let (env2, rest) = split_env tl in (env :: env2, rest)
+  | _ -> ([], l)
+
 let make ?(loc = Location.none) foo = { node = foo; loc = loc }
 
 let make_identifier = make

--- a/ocamltest/tsl_ast.mli
+++ b/ocamltest/tsl_ast.mli
@@ -38,6 +38,8 @@ type tsl_block = tsl_item list
 
 (* New syntax *)
 type t = Ast of tsl_item list * t list
+val split_env :
+  tsl_item list -> environment_statement located list * tsl_item list
 
 val make_identifier : ?loc:Location.t -> string -> string located
 val make_string : ?loc:Location.t -> string -> string located

--- a/ocamltest/tsl_semantics.ml
+++ b/ocamltest/tsl_semantics.ml
@@ -67,9 +67,6 @@ let interpret_environment_statement env statement = match statement.node with
       in
       Environments.unsetenv var env
 
-let interpret_environment_statements env l =
-  List.fold_left interpret_environment_statement env l
-
 type test_tree =
   | Node of
     (Tsl_ast.environment_statement located list) *

--- a/ocamltest/tsl_semantics.mli
+++ b/ocamltest/tsl_semantics.mli
@@ -27,6 +27,8 @@ val interpret_environment_statements :
   Environments.t -> Tsl_ast.environment_statement Tsl_ast.located list ->
   Environments.t
 
+val lookup_test : string located -> Tests.t
+
 type test_tree =
   | Node of
     (Tsl_ast.environment_statement located list) *
@@ -38,21 +40,14 @@ val test_trees_of_tsl_block :
   Tsl_ast.tsl_item list ->
   Tsl_ast.environment_statement located list * test_tree list
 
-val test_trees_of_tsl_ast :
-  Tsl_ast.t ->
-  Tsl_ast.environment_statement located list * test_tree list
-
 val tsl_ast_of_test_trees :
   Tsl_ast.environment_statement located list * test_tree list ->
   Tsl_ast.t
 
-val tests_in_tree : test_tree -> Tests.TestSet.t
-
-val tests_in_trees : test_tree list -> Tests.TestSet.t
+val tests_in_tree : Tsl_ast.t -> Tests.TestSet.t
 
 val actions_in_test : Tests.t -> Actions.ActionSet.t
 
 val actions_in_tests : Tests.TestSet.t -> Actions.ActionSet.t
-
 
 val print_tsl_ast : compact:bool -> out_channel -> Tsl_ast.t -> unit

--- a/ocamltest/tsl_semantics.mli
+++ b/ocamltest/tsl_semantics.mli
@@ -27,6 +27,7 @@ val interpret_environment_statements :
   Environments.t -> Tsl_ast.environment_statement Tsl_ast.located list ->
   Environments.t
 
+exception No_such_test_or_action of string
 val lookup_test : string located -> Tests.t
 
 type test_tree =

--- a/ocamltest/tsl_semantics.mli
+++ b/ocamltest/tsl_semantics.mli
@@ -23,10 +23,6 @@ val interpret_environment_statement :
   Environments.t -> Tsl_ast.environment_statement Tsl_ast.located ->
   Environments.t
 
-val interpret_environment_statements :
-  Environments.t -> Tsl_ast.environment_statement Tsl_ast.located list ->
-  Environments.t
-
 exception No_such_test_or_action of string
 val lookup_test : string located -> Tests.t
 


### PR DESCRIPTION
There are three things in this PR:
1. get rid of the `test_tree` data structure and directly interpret the AST instead.
2. change the outputs to give the line number rather than a long sequence of numbers that is hard to interpret.
3. change the error messages to put them all in the format expected by the `summarize.awk` script.

### Some details:

The `test_tree` type is still here to support the translation mode. It will be removed in a few months when we are sure there's no pending PR with tests written in the old syntax that would need the translation tool.

Error messages used to be a mix of `Fatal error: uncaught exception` and some error messages output on stderr and followed by `exit 2`. It's hard to be sure that such messages won't be missed when the test log is parsed.

### Examples of test files and log/error messages:
----
```
(* TEST
  bytecode;
  {
    native;
  }
*)
```
Trunk:
```
 ... testing 'foo.ml' with 1 (bytecode) => passed
 ... testing 'foo.ml' with 1.1 (native) => passed
```
This PR:
```
 ... testing 'foo.ml' with line 2 (bytecode) => passed
 ... testing 'foo.ml' with line 4 (native) => passed
```
----
```
(* TEST
modules = "foo.txt";
*)
```
trunk:
```
   ... testing 'foo.ml' with 1 (native) Fatal error: exception File "ocaml_actions.ml", line 173, characters 14-20: Assertion failed
```
this PR:
```
 ... testing 'foo.ml' with default (native) 
Cannot compile files of type text.
=> error in test script
 ... testing 'foo.ml' with default (bytecode) 
Cannot compile files of type text.
=> error in test script
```
----
```
(* TEST
modules = "foo.bar";
*)
```
trunk:
```
Unknown file extension bar
```
this PR:
```
  ... testing 'foo.ml' with default (native) 
Cannot compile files of type unknown (bar).
=> error in test script
 ... testing 'foo.ml' with default (bytecode) 
Cannot compile files of type unknown (bar).
=> error in test script
```
----
```
(* TEST
set x = "1";
set x = "1";
*)
```
trunk:
```
  Fatal error: exception Variables.Variable_already_registered("x")
```
this PR:
```
 ... testing 'foo.ml' with line 4 
foo.ml:4: Variable "x" is already in the environment.
=> error in test script
 ... testing 'foo.ml' with default (native) => n/a
 ... testing 'foo.ml' with default (bytecode) => n/a
```
----
```
(* TEST
unset x;
x += "1";
*)
```
Trunk:
```
  Fatal error: exception Variables.No_such_variable("x")
```
This PR:
```
 ... testing 'foo.ml' with line 3 
foo.ml:3: Variable "x" is not in the environment.
=> error in test script
 ... testing 'foo.ml' with default (native) => n/a
 ... testing 'foo.ml' with default (bytecode) => n/a
```
