### PR TITLE
Dune build: `gen_primitives.sh` must be called from the root

### DIFF
--- a/runtime/dune
+++ b/runtime/dune
@@ -17,14 +17,13 @@
  (mode    fallback)
  (deps
    ; matches the line structure of files in gen_primitives.sh
-   alloc.c array.c compare.c extern.c floats.c gc_ctrl.c hash.c intern.c
-     interp.c ints.c io.c
-   lexing.c md5.c meta.c memprof.c obj.c parsing.c signals.c str.c sys.c
-     callback.c weak.c
-   finalise.c dynlink.c backtrace_byt.c backtrace.c
-     afl.c
-   bigarray.c runtime_events.c)
- (action  (with-stdout-to %{targets} (run %{dep:gen_primitives.sh}))))
+   alloc.c array.c compare.c extern.c floats.c gc_ctrl.c hash.c intern.c interp.c ints.c io.c
+   lexing.c md5.c meta.c memprof.c obj.c parsing.c signals.c str.c sys.c callback.c weak.c
+   finalise.c domain.c platform.c fiber.c memory.c startup_aux.c runtime_events.c sync.c
+   dynlink.c backtrace_byt.c backtrace.c afl.c bigarray.c prng.c)
+ (action
+   (chdir ..
+     (with-stdout-to %{targets} (run %{dep:gen_primitives.sh})))))
 
 (rule
  (targets libcamlrun.a)

--- a/runtime/gen_primitives.sh
+++ b/runtime/gen_primitives.sh
@@ -15,8 +15,6 @@
 #*                                                                        *
 #**************************************************************************
 
-# duplicated from $(ROOTDIR)/runtime/Makefile
-
 # #8985: the meaning of character range a-z depends on the locale, so force C
 #        locale throughout.
 export LC_ALL=C


### PR DESCRIPTION
Also sync the list of dependencies with gen_primitives.