### PR TITLE
Dune build: fix domainstate ml/mli generation

### DIFF
--- a/utils/dune
+++ b/utils/dune
@@ -29,7 +29,7 @@
  (action
    (with-stdout-to %{targets}
      (bash
-       "`grep '^CPP=' %{conf} | cut -d'=' -f2` -I ../runtime/caml %{c} %{tbl}"
+       "`grep '^CPP=' %{conf} | cut -d'=' -f2` -I ../runtime/caml %{c}"
        ))))
 
 (rule
@@ -41,5 +41,5 @@
  (action
    (with-stdout-to %{targets}
      (bash
-       "`grep '^CPP=' %{conf} | cut -d'=' -f2` -I ../runtime/caml %{c} %{tbl}"
+       "`grep '^CPP=' %{conf} | cut -d'=' -f2` -I ../runtime/caml %{c}"
        ))))


### PR DESCRIPTION
Do not pass the tbl file to the cpp, only the C file is required. Now the Dune file is in sync with the Makefile. Fixes the following warning:

    clang: warning: runtime/caml/domain_state.tbl: 'linker' input unused [-Wunused-command-line-argument]