### PR TITLE
Provide an --{enable,disable}-ocamldebug option synonym of --{enable,disable}-debugger

### DIFF
--- a/Changes
+++ b/Changes
@@ -36,6 +36,10 @@ Working version
 
 ### Compiler user-interface and warnings:
 
+- #12247: configure: --disable-ocamldebug can now be used instead
+  of --disable-debugger (which remains available for compatibility)
+  (Gabriel Scherer, review by Damien Doligez and Sébastien Hinderer)
+
 ### Internal/compiler-libs changes:
 
 - #12216, #12248: Prevent reordering of atomic loads during instruction

--- a/Makefile
+++ b/Makefile
@@ -1299,8 +1299,13 @@ debugger/%: OC_BYTECODE_LINKFLAGS = -linkall
 
 debugger/%: CAMLC = $(BEST_OCAMLC) $(STDLIBFLAGS)
 
-.PHONY: ocamldebugger
+.PHONY: ocamldebug ocamldebugger
+ocamldebug: debugger/ocamldebug$(EXE)
 ocamldebugger: debugger/ocamldebug$(EXE)
+# the 'ocamldebugger' target is an alias of 'ocamldebug' for
+# backward-compatibility with old ./configure scripts; it can be
+# removed after most contributors have re-run ./configure once, for
+# example after 5.2 is branched
 
 debugger/ocamldebug$(EXE): ocamlc ocamlyacc ocamllex
 

--- a/configure
+++ b/configure
@@ -948,6 +948,7 @@ ac_subst_files=''
 ac_user_opts='
 enable_option_checking
 enable_debug_runtime
+enable_ocamldebug
 enable_debugger
 enable_dependency_generation
 enable_instrumented_runtime
@@ -1633,7 +1634,8 @@ Optional Features:
   --disable-FEATURE       do not include FEATURE (same as --enable-FEATURE=no)
   --enable-FEATURE[=ARG]  include FEATURE [ARG=yes]
   --disable-debug-runtime do not build runtime with debugging support
-  --enable-debugger       build the debugger [default=auto]
+  --enable-ocamldebug     build ocamldebug [default=auto]
+  --enable-debugger       alias for --enable-ocamldebug
   --disable-dependency-generation
                           do not compute dependency information for C sources
   --enable-instrumented-runtime
@@ -3643,12 +3645,19 @@ then :
 fi
 
 
+# Check whether --enable-ocamldebug was given.
+if test ${enable_ocamldebug+y}
+then :
+  enableval=$enable_ocamldebug;
+else $as_nop
+  enable_ocamldebug=auto
+fi
+
+
 # Check whether --enable-debugger was given.
 if test ${enable_debugger+y}
 then :
-  enableval=$enable_debugger;
-else $as_nop
-  enable_debugger=auto
+  enableval=$enable_debugger; enable_ocamldebug=$enableval
 fi
 
 
@@ -3951,11 +3960,11 @@ fi
 
 if test x"$enable_unix_lib" = "xno"
 then :
-  if test x"$enable_debugger" = "xyes"
+  if test x"$enable_ocamldebug" = "xyes"
 then :
-  as_fn_error $? "replay debugger requires the unix library" "$LINENO" 5
+  as_fn_error $? "ocamldebug requires the unix library" "$LINENO" 5
 else $as_nop
-  enable_debugger="no"
+  enable_ocamldebug="no"
 fi
 fi
 
@@ -18232,24 +18241,24 @@ fi
 
 ## Determine whether the debugger should/can be built
 
-case $enable_debugger in #(
+case $enable_ocamldebug in #(
   no) :
     with_debugger=""
     build_ocamldebug=false
-    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: replay debugger disabled" >&5
-printf "%s\n" "$as_me: replay debugger disabled" >&6;} ;; #(
+    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: ocamldebug disabled" >&5
+printf "%s\n" "$as_me: ocamldebug disabled" >&6;} ;; #(
   *) :
     if $sockets
 then :
-  with_debugger="ocamldebugger"
+  with_debugger="ocamldebug"
     build_ocamldebug=true
-    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: replay debugger supported" >&5
-printf "%s\n" "$as_me: replay debugger supported" >&6;}
+    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: ocamldebug supported" >&5
+printf "%s\n" "$as_me: ocamldebug supported" >&6;}
 else $as_nop
   with_debugger=""
     build_ocamldebug=false
-    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: replay debugger not supported" >&5
-printf "%s\n" "$as_me: replay debugger not supported" >&6;}
+    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: ocamldebug not supported" >&5
+printf "%s\n" "$as_me: ocamldebug not supported" >&6;}
 fi
    ;;
 esac

--- a/configure.ac
+++ b/configure.ac
@@ -2015,7 +2015,7 @@ AS_CASE([$enable_ocamldebug],
     build_ocamldebug=false
     AC_MSG_NOTICE([ocamldebug disabled])],
   [AS_IF([$sockets],
-    [with_debugger="ocamldebugger"
+    [with_debugger="ocamldebug"
     build_ocamldebug=true
     AC_MSG_NOTICE([ocamldebug supported])],
     [with_debugger=""

--- a/configure.ac
+++ b/configure.ac
@@ -307,11 +307,17 @@ AC_ARG_ENABLE([debug-runtime],
   [AS_HELP_STRING([--disable-debug-runtime],
     [do not build runtime with debugging support])])
 
+AC_ARG_ENABLE([ocamldebug],
+  [AS_HELP_STRING([--enable-ocamldebug],
+    [build ocamldebug @<:@default=auto@:>@])],
+  [],
+  [enable_ocamldebug=auto])
+
 AC_ARG_ENABLE([debugger],
   [AS_HELP_STRING([--enable-debugger],
-    [build the debugger @<:@default=auto@:>@])],
-  [],
-  [enable_debugger=auto])
+    [alias for --enable-ocamldebug])],
+  [enable_ocamldebug=$enableval],
+  [])
 
 AC_ARG_ENABLE([dependency-generation],
   [AS_HELP_STRING([--disable-dependency-generation],
@@ -489,9 +495,9 @@ AC_ARG_WITH([zstd],
     [disable compression of marshaled data])])
 
 AS_IF([test x"$enable_unix_lib" = "xno"],
-  [AS_IF([test x"$enable_debugger" = "xyes"],
-    [AC_MSG_ERROR([replay debugger requires the unix library])],
-    [enable_debugger="no"])])
+  [AS_IF([test x"$enable_ocamldebug" = "xyes"],
+    [AC_MSG_ERROR([ocamldebug requires the unix library])],
+    [enable_ocamldebug="no"])])
 
 AS_IF([test x"$enable_unix_lib" = "xno" || test x"$enable_str_lib" = "xno"],
   [AS_IF([test x"$enable_ocamldoc" = "xyes"],
@@ -2003,18 +2009,18 @@ AS_IF([test x"$zstd_status" = "xok"],
 
 ## Determine whether the debugger should/can be built
 
-AS_CASE([$enable_debugger],
+AS_CASE([$enable_ocamldebug],
   [no],
     [with_debugger=""
     build_ocamldebug=false
-    AC_MSG_NOTICE([replay debugger disabled])],
+    AC_MSG_NOTICE([ocamldebug disabled])],
   [AS_IF([$sockets],
     [with_debugger="ocamldebugger"
     build_ocamldebug=true
-    AC_MSG_NOTICE([replay debugger supported])],
+    AC_MSG_NOTICE([ocamldebug supported])],
     [with_debugger=""
     build_ocamldebug=false
-    AC_MSG_NOTICE([replay debugger not supported])])
+    AC_MSG_NOTICE([ocamldebug not supported])])
   ])
 
 ## Should the runtime with debugging support be built


### PR DESCRIPTION
I never remember the command-line option to disable ocamldebug at configure time. In contrast, I can do --{enable,disable}-{ocamldoc,ocamltest} just fine. I propose to add --enable-ocamldebug as an alias for --enable-debugger.

I tested the resulting configure script to work as intended, when at most one of -*-ocamldebug and -*-debugger options are used. (I don't really care about the behavior if someone was to specify both options explicitly.)

cc @shindere