### PR TITLE
Instruction scheduling: do not reorder atomic loads

### DIFF
--- a/Changes
+++ b/Changes
@@ -38,6 +38,12 @@ Working version
 
 ### Internal/compiler-libs changes:
 
+- #12216, #12248: Prevent reordering of atomic loads during instruction
+  scheduling.  This is for reference, as instruction scheduling is currently
+  unused in OCaml 5.
+  (Xavier Leroy, report by Luc Maranget and KC Sivaramakrishnan,
+   review by Nicolás Ojeda Bär)
+
 ### Build system:
 
 ### Bug fixes:

--- a/asmcomp/schedgen.ml
+++ b/asmcomp/schedgen.ml
@@ -181,12 +181,17 @@ method private instr_in_basic_block instr try_nesting =
    Can be overridden for some processors to signal specific
    load or store instructions (e.g. on the I386). *)
 
+(* Stores are not reordered with other stores nor with loads.
+   Loads can be reordered with other loads, but not with stores.
+   Atomic loads must not be reordered, so we treat them like stores. *)
+
 method is_store = function
     Istore(_, _, _) -> true
+  | Iload {is_atomic = true} -> true 
   | _ -> false
 
 method is_load = function
-    Iload _ -> true
+    Iload {is_atomic = false} -> true
   | _ -> false
 
 method is_checkbound = function

--- a/asmcomp/schedgen.ml
+++ b/asmcomp/schedgen.ml
@@ -187,7 +187,7 @@ method private instr_in_basic_block instr try_nesting =
 
 method is_store = function
     Istore(_, _, _) -> true
-  | Iload {is_atomic = true} -> true 
+  | Iload {is_atomic = true} -> true
   | _ -> false
 
 method is_load = function

--- a/asmcomp/schedgen.mli
+++ b/asmcomp/schedgen.mli
@@ -37,9 +37,10 @@ class virtual scheduler_generic : object
   method oper_in_basic_block : Mach.operation -> bool
       (* Says whether the given operation terminates a basic block *)
   method is_store : Mach.operation -> bool
-      (* Says whether the given operation is a memory store *)
+      (* Says whether the given operation is a memory store
+         or an atomic load. *)
   method is_load : Mach.operation -> bool
-      (* Says whether the given operation is a memory load *)
+      (* Says whether the given operation is a memory load (non-atomic) *)
   method is_checkbound : Mach.operation -> bool
       (* Says whether the given operation is a checkbound *)
   (* Entry point *)

--- a/asmcomp/schedgen.mli
+++ b/asmcomp/schedgen.mli
@@ -40,7 +40,7 @@ class virtual scheduler_generic : object
       (* Says whether the given operation is a memory store
          or an atomic load. *)
   method is_load : Mach.operation -> bool
-      (* Says whether the given operation is a memory load (non-atomic) *)
+      (* Says whether the given operation is a non-atomic memory load *)
   method is_checkbound : Mach.operation -> bool
       (* Says whether the given operation is a checkbound *)
   (* Entry point *)


### PR DESCRIPTION
As noticed in https://github.com/ocaml/ocaml/pull/11712#issuecomment-1381854655, instruction scheduling can reorder atomic loads just like it reorders normal loads, which is incorrect.

This PR fixes the issue trivially, by treating atomic loads like stores, which are never reordered (w.r.t. other stores / atomic loads, and even w.r.t. normal loads).

This fix is mostly cosmetic, since the scheduling pass is currently unused in OCaml 5 (none of the supported target architectures need it), and may very well never be used again in the future.

Fixes: #12216