### PR TITLE
Fix budget accounting for Cont_tag in do_some_marking

### DIFF
--- a/Changes
+++ b/Changes
@@ -158,7 +158,7 @@ OCaml 5.1.0
   (David Allsopp, review by Xavier Leroy, Guillaume Munch-Maccagnoni,
    Stefan Muenzel and Gabriel Scherer)
 
-- #11827: Restore prefetching for GC marking
+- #11827, #12249: Restore prefetching for GC marking
   (Fabrice Buoro and Stephen Dolan, review by Gabriel Scherer and Sadiq Jaffer)
 
 - #11935: Load frametables of dynlink'd modules in batch

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -851,7 +851,7 @@ Caml_noinline static intnat do_some_marking(struct mark_stack* stk,
 
       if (Tag_hd(hd) == Cont_tag) {
         caml_darken_cont(block);
-        budget -= Wosize_hd(block);
+        budget -= Wosize_hd(hd);
         continue;
       }
 


### PR DESCRIPTION
Last December, @fabbing and I ported the prefetching implementation of major GC marking to OCaml 5, which landed as #11827 . A new feature in OCaml 5 is the marking of continuations (stacks paused by effect handlers), for which I added the following code:

```c
      if (Tag_hd(block) == Cont_tag) {
        caml_darken_cont(block);
        budget -= Wosize_hd(block);
        continue;
      }
```

It then took three solid hours of debugging segfaults in hairy effect handler test cases for us to realise that `Tag_hd(block)` is nonsense: `Tag_hd` expects a header, and `block` is a value. It should have been `Tag_hd(hd)` (or, equivalently but less efficiently, `Tag_val(block)`).

Today, @damiendoligez and I spent another three hours of debugging to notice that the third line of this block is also wrong, in exactly the same way: it should be `Wosize_hd(hd)` or `Wosize_val(block)`, as `Wosize_hd(block)` is meaningless. (This bug affects GC pacing, and seems to be the cause of the weird performance issues in #11903)