### PR TITLE
runtime/riscv.S: fix shared library build error

### DIFF
--- a/Changes
+++ b/Changes
@@ -48,9 +48,6 @@ Working version
 
 ### Bug fixes:
 
-- #12252: Fix shared library build error on RISC-V.
-  (Edwin Török)
-
 OCaml 5.1.0
 ---------------
 
@@ -840,6 +837,10 @@ OCaml 5.1.0
 
 - #12178: Fix runtime events consumer poll function returning an invalid value
   instead of an OCaml integer value. (Lucas Pluvinage)
+
+- #12252: Fix shared library build error on RISC-V.
+  (Edwin Török, review by Nicolás Ojeda Bär and Xavier Leroy)
+
 
 OCaml 5.0.0 (15 December 2022)
 ------------------------------

--- a/Changes
+++ b/Changes
@@ -48,6 +48,8 @@ Working version
 
 ### Bug fixes:
 
+- #12252: Fix shared library build error on RISC-V.
+  (Edwin Török)
 
 OCaml 5.1.0
 ---------------

--- a/runtime/riscv.S
+++ b/runtime/riscv.S
@@ -282,7 +282,7 @@ FUNCTION(caml_call_realloc_stack)
         addi    sp, sp, 16
         addi    sp, sp, 16 /* pop argument */
         la      a0, caml_exn_Stack_overflow
-        j       caml_raise_exn
+        j       L(caml_raise_exn)
 END_FUNCTION(caml_call_realloc_stack)
 
 FUNCTION(caml_call_gc)
@@ -337,6 +337,7 @@ END_FUNCTION(caml_allocN)
 /* Function to call is in ADDITIONAL_ARG */
 
 FUNCTION(caml_c_call)
+L(caml_c_call):
         CFI_OFFSET(ra, -8)
         addi    sp, sp, -16
         sd      ra, 8(sp)
@@ -561,6 +562,7 @@ L(trap_handler):
 
 /* Raise an exception from OCaml */
 FUNCTION(caml_raise_exn)
+L(caml_raise_exn):
     /* Test if backtrace is active */
         ld      TMP, Caml_state(backtrace_active)
         bnez    TMP, 2f
@@ -608,7 +610,7 @@ FUNCTION(caml_raise_exception)
     /* Restore frame and link on return to OCaml */
         ld      ra, 8(sp)
         addi    sp, sp, 16
-        j       caml_raise_exn
+        j       L(caml_raise_exn)
 END_FUNCTION(caml_raise_exception)
 
 /* Callback from C to OCaml */
@@ -710,7 +712,7 @@ L(do_perform):
         SWITCH_OCAML_STACKS t3, t4
     /*  No parent stack. Raise Effect.Unhandled. */
         la      ADDITIONAL_ARG, caml_raise_unhandled_effect
-        j       caml_c_call
+        j       L(caml_c_call)
 END_FUNCTION(caml_perform)
 
 FUNCTION(caml_reperform)
@@ -744,7 +746,7 @@ FUNCTION(caml_resume)
         mv      a0, a2
         jr      a3
 2:      la      ADDITIONAL_ARG, caml_raise_continuation_already_resumed
-        j       caml_c_call
+        j       L(caml_c_call)
 END_FUNCTION(caml_resume)
 
 /* Run a function on a new stack, then either
@@ -823,7 +825,7 @@ FUNCTION(caml_ml_array_bound_error)
     /* Load address of [caml_array_bound_error_asm] in ADDITIONAL_ARG */
         la      ADDITIONAL_ARG, caml_array_bound_error_asm
     /* Call that function */
-        j       caml_c_call
+        j       L(caml_c_call)
 END_FUNCTION(caml_ml_array_bound_error)
 
         .globl  caml_system__code_end


### PR DESCRIPTION
`libasmrun_shared.so` linking failed with (on both 5.1 alpha and trunk):
```
/usr/bin/ld: relocation R_RISCV_RVC_JUMP against `caml_raise_exn' which may bind externally can not be used when making a shared object; recompile with -fPIC
```

This used to work on OCaml 4.14 (and I think 5.0 lacked 'ocamlopt' support on RISC-V completely due to multicore changes). 
Introduce some local labels for jump targets like 4.14 had.

System information: 
```
SBC: VisionFive2
CPU: JH7110
OS: Debian GNU/Linux bookworm/sid 
$ head -n6 /proc/cpuinfo
processor       : 0
hart            : 1
isa             : rv64imafdc
mmu             : sv39
isa-ext         : 
uarch           : sifive,u74-mc
$ gcc --version
gcc (Debian 12.2.0-10) 12.2.0
[...]
$ ld --version
GNU ld (GNU Binutils for Debian) 2.39.50.20221224
[...]
```

With this change I get a working 'ocamlopt' on RISC-V with shared libraries enabled (otherwise the only way to get a working `ocamlopt` is to turn off shared library support, which cannot be done from `opam` there is no 'ocaml-option-...' package for it).

I've done some minimal testing, and at least the 'spectralnorm_par' test works with this change on trunk and I see some nearly linear speedup when executing on 1,2 vs 4 cores, and running 'make parallel' in 'testsuite/' works too:
```
Summary:
  2768 tests passed
  126 tests skipped
    0 tests failed
  645 tests not started (parent test skipped or failed)
    0 unexpected errors
  3539 tests considered
```

P.S.: perhaps this should be included in 5.1 too?

/cc @nojb 