### PR TITLE
Fix #12255 - handle large signal numbers correctly.

### DIFF
--- a/Changes
+++ b/Changes
@@ -48,7 +48,8 @@ Working version
 
 ### Bug fixes:
 
-- #12255: Handle large signal numbers correctly (Nick Barnes, review by ??).
+- #12255, #12256: Handle large signal numbers correctly (Nick Barnes,
+   review by David Allsopp).
 
 OCaml 5.1.0
 ---------------

--- a/Changes
+++ b/Changes
@@ -48,6 +48,8 @@ Working version
 
 ### Bug fixes:
 
+- #12255: Handle large signal numbers correctly (Nick Barnes, review by ??).
+
 OCaml 5.1.0
 ---------------
 

--- a/runtime/signals.c
+++ b/runtime/signals.c
@@ -82,7 +82,7 @@ CAMLexport value caml_process_pending_signals_exn(void)
     for (j = 0; j < BITS_PER_WORD; j++) {
       mask = (uintnat)1 << j;
       if ((curr & mask) == 0) goto next_bit;
-      signo = i * 8 + j + 1;
+      signo = i * BITS_PER_WORD + j + 1;
 #ifdef POSIX_SIGNALS
       if (sigismember(&set, signo)) goto next_bit;
 #endif


### PR DESCRIPTION
One-liner fixing #12255; see issue for description.