### PR TITLE
fix invalid_argument on some external or module aliases in ocamlnat

### DIFF
--- a/Changes
+++ b/Changes
@@ -28,6 +28,9 @@ Working version
 
 ### Tools:
 
+- #12260: Fix invalid_argument on some external or module aliases in ocamlnat
+  (Fabian Hemmer, review by Vincent Laviron)
+
 - #12185: New script language for ocamltest.
   (Damien Doligez with Florian Angeletti, Sébastien Hinderer, Gabriel Scherer,
    review by Sébastien Hinderer and Gabriel Scherer)

--- a/testsuite/tests/tool-toplevel/topeval.compilers.reference
+++ b/testsuite/tests/tool-toplevel/topeval.compilers.reference
@@ -7,4 +7,7 @@ val _bar : ('a, 'b) A.t -> 'a option = <fun>
 - : string = ""
 - : char = 'd'
 - : float = 42.
+external foo : int -> int -> int = "%addint"
+module S = String
+val x : int = 42
 

--- a/testsuite/tests/tool-toplevel/topeval.ml
+++ b/testsuite/tests/tool-toplevel/topeval.ml
@@ -48,3 +48,10 @@ let List.(String.(_)) = 'd'
 
 let List.(_) : float = 42.0
 ;;
+
+(* issue #12257: external or module alias followed by regular value triggers
+   an exception in ocamlnat *)
+external foo : int -> int -> int = "%addint"
+module S = String
+let x = 42
+;;

--- a/toplevel/native/topeval.ml
+++ b/toplevel/native/topeval.ml
@@ -34,15 +34,17 @@ let global_symbol id =
 
 let remembered = ref Ident.empty
 
-let rec remember phrase_name i = function
-  | [] -> ()
-  | Sig_value  (id, _, _) :: rest
-  | Sig_module (id, _, _, _, _) :: rest
-  | Sig_typext (id, _, _, _) :: rest
-  | Sig_class  (id, _, _, _) :: rest ->
-      remembered := Ident.add id (phrase_name, i) !remembered;
-      remember phrase_name (succ i) rest
-  | _ :: rest -> remember phrase_name i rest
+let remember phrase_name signature =
+  let exported = List.filter Includemod.is_runtime_component signature in
+  List.iteri (fun i sg ->
+      match sg with
+      | Sig_value  (id, _, _)
+      | Sig_module (id, _, _, _, _)
+      | Sig_typext (id, _, _, _)
+      | Sig_class  (id, _, _, _) ->
+          remembered := Ident.add id (phrase_name, i) !remembered
+      | _ -> ())
+    exported
 
 let toplevel_value id =
   try Ident.find_same id !remembered
@@ -197,7 +199,7 @@ let execute_phrase print_outcome ppf phr =
             Translmod.transl_implementation_flambda phrase_name
               (str, Tcoerce_none)
           in
-          remember module_ident 0 sg';
+          remember module_ident sg';
           module_ident, close_phrase res, required_globals, size
         else
           let size, res = Translmod.transl_store_phrases phrase_name str in


### PR DESCRIPTION
Fixes #12257.

As suspected in https://github.com/ocaml/ocaml/issues/12257#issuecomment-1561024241, module aliases also trigger the problem. I'm not too familiar with the module representation, so it would be good if an flambda dev could have a closer look to see if any other constructs could trigger the problem.