### PR TITLE
Minor improvements to the IBM Z / s390x port of OCaml 5

### DIFF
--- a/Changes
+++ b/Changes
@@ -243,11 +243,12 @@ OCaml 5.1.0
   (Nicolás Ojeda Bär, Gabriel Scherer, Alain Frisch, review by Gabriel Scherer,
   Alain Frisch and Nathanaëlle Courant)
 
-- #11712: s390x / IBM Z multicore support: OCaml & C stack separation;
-  dynamic stack size checks; fiber and effects support.
-  (Aleksei Nikiforov, with help from Vincent Laviron,
-   additional suggestions by Xavier Leroy and Luc Maranget,
-   review by Xavier Leroy and KC Sivaramakrishnan)
+- #11712, #12258, #12261: s390x / IBM Z multicore support:
+  OCaml & C stack separation; dynamic stack size checks; fiber and
+  effects support.
+  (Aleksei Nikiforov, with help from Vincent Laviron and Xavier Leroy,
+   additional suggestions by Luc Maranget,
+   review by the same and KC Sivaramakrishnan)
 
 - #11904: Remove arm, i386 native-code backends.
   (Nicolás Ojeda Bär, review by Stephen Dolan, Anil Madhavapeddy, and Xavier

--- a/asmcomp/s390x/emit.mlp
+++ b/asmcomp/s390x/emit.mlp
@@ -378,20 +378,18 @@ let emit_instr env i =
           emit_call "caml_c_call";
           `{record_frame env i.live (Dbg_other i.dbg)}\n`
         end else begin
-          ` lgr %r1, %r15\n`;
+          (* Save OCaml SP in C callee-save register *)
+          ` lgr %r12, %r15\n`;
           cfi_remember_state ();
-          cfi_def_cfa_register "%r1";
+          cfi_def_cfa_register "%r12";
           (* NB: gdb has asserts on contiguous stacks that mean it
              will not unwind through this unless we were to tag this
-             calling frame with cfi_signal_frame in it's definition.
-             Also, for some reason ocaml compiler uses %r12, can't use it here.
-             Just save stack pointer to temporary pointer and then to new stack *)
+             calling frame with cfi_signal_frame in it's definition. *)
           let offset = Domainstate.(idx_of_field Domain_c_stack) * 8 in
           ` lg %r15, {emit_int offset}(%r10)\n`;
-          ` lay %r15, -168(%r15)\n`;
-          ` stg %r1, 160(%r15)\n`;
+          ` lay %r15, -160(%r15)\n`;
           emit_call func;
-          ` lg %r15, 160(%r15)\n`;
+          ` lgr %r15, %r12\n`;
           cfi_restore_state ()
         end
 

--- a/asmcomp/s390x/emit.mlp
+++ b/asmcomp/s390x/emit.mlp
@@ -730,9 +730,8 @@ let fundecl fundecl =
     let threshold_offset = Domainstate.stack_ctx_words * 8 + stack_threshold_size in
     let f = max_frame_size + threshold_offset in
     let offset = Domainstate.(idx_of_field Domain_current_stack) * 8 in
-    `  lg %r1, {emit_int offset}(%r10)\n`;
-    `  lay %r1, {emit_int f}(%r1)\n`;
-    `  clgr %r15, %r1\n`;
+    `  lay %r1, {emit_int (-f)}(%r15)\n`;
+    `  clg %r1, {emit_int offset}(%r10)\n`;
     `  brcl 4, {emit_label overflow}\n`;
     `{emit_label ret}:\n`;
     handle_overflow := Some (overflow, ret);

--- a/asmcomp/s390x/emit.mlp
+++ b/asmcomp/s390x/emit.mlp
@@ -387,7 +387,6 @@ let emit_instr env i =
              calling frame with cfi_signal_frame in it's definition. *)
           let offset = Domainstate.(idx_of_field Domain_c_stack) * 8 in
           ` lg %r15, {emit_int offset}(%r10)\n`;
-          ` lay %r15, -160(%r15)\n`;
           emit_call func;
           ` lgr %r15, %r12\n`;
           cfi_restore_state ()

--- a/asmcomp/s390x/emit.mlp
+++ b/asmcomp/s390x/emit.mlp
@@ -747,16 +747,13 @@ let fundecl fundecl =
   | None -> ()
   | Some (overflow,ret) -> begin
       `{emit_label overflow}:\n`;
-      (* Pass the desired frame size on the stack, since all of the
-        argument-passing registers may be in use. *)
       let s = (Config.stack_threshold + max_frame_size / 8) in
-      `  lay  %r15, -16(%r15)\n`;
-      `  stg  %r14, 8(%r15)\n`;
-      `  lgfi %r1, {emit_int s}\n`;
-      `  stg %r1, 0(%r15)\n`;
+      `  lay  %r15, -8(%r15)\n`;
+      `  stg  %r14, 0(%r15)\n`;
+      `  lgfi %r12, {emit_int s}\n`;
       `  brasl %r14, {emit_symbol "caml_call_realloc_stack"}\n`;
-      `  lg   %r14, 8(%r15)\n`;
-      `  la  %r15, 16(%r15)\n`;
+      `  lg   %r14, 0(%r15)\n`;
+      `  la  %r15, 8(%r15)\n`;
       `  brcl 15, {emit_label ret}\n`
     end
   end;

--- a/asmcomp/s390x/proc.ml
+++ b/asmcomp/s390x/proc.ml
@@ -149,9 +149,7 @@ let loc_results res =
 
 (*   C calling conventions under SVR4:
      use GPR 2-6 and FPR 0,2,4,6 just like ML calling conventions.
-     Using a float register does not affect the int registers.
-     Always reserve 160 bytes at bottom of stack, plus whatever is needed
-     to hold the overflow arguments. *)
+     Using a float register does not affect the int registers. *)
 
 let loc_external_arguments ty_args =
   let arg = Cmm.machtype_of_exttype_list ty_args in

--- a/asmcomp/s390x/proc.ml
+++ b/asmcomp/s390x/proc.ml
@@ -187,10 +187,11 @@ let dwarf_register_numbers ~reg_class =
 let stack_ptr_dwarf_register_number = 15
 
 (* Registers destroyed by operations *)
+(* Mark r12 destroyed by C calls so that it can be used for preserving SP *)
 
 let destroyed_at_c_call =
   Array.of_list(List.map phys_reg
-    [0; 1; 2; 3; 4;
+    [0; 1; 2; 3; 4; 8;
      100; 101; 102; 103; 104; 105; 106; 107])
 
 let destroyed_at_oper = function

--- a/runtime/caml/fiber.h
+++ b/runtime/caml/fiber.h
@@ -98,6 +98,8 @@ CAML_STATIC_ASSERT(sizeof(struct stack_info) ==
 #if defined(TARGET_amd64) && (defined(_WIN32) || defined(__CYGWIN__))
 /* Win64 ABI shadow store for argument registers */
   #define Reserved_space_c_stack_link 4 * 8
+#elif defined(TARGET_s390x)
+  #define Reserved_space_c_stack_link 160
 #endif
 
 /* This structure is used for storing the OCaml return pointer when

--- a/runtime/caml/fiber.h
+++ b/runtime/caml/fiber.h
@@ -93,14 +93,20 @@ CAML_STATIC_ASSERT(sizeof(struct stack_info) ==
  * +------------------------+ <--- Caml_state->current_stack
  */
 
+/* Some ABI reserve space at the bottom of every C stack frame. */
+
+#if defined(TARGET_amd64) && (defined(_WIN32) || defined(__CYGWIN__))
+/* Win64 ABI shadow store for argument registers */
+  #define Reserved_space_c_stack_link 4 * 8
+#endif
+
 /* This structure is used for storing the OCaml return pointer when
  * transitioning from an OCaml stack to a C stack at a C call. When an OCaml
  * stack is reallocated, this linked list is walked to update the OCaml stack
  * pointers. It is also used for DWARF backtraces. */
 struct c_stack_link {
-#if defined(_WIN32) || defined(__CYGWIN__)
-  /* Win64 ABI shadow store for argument registers */
-  void* shadow_store[4];
+#if Reserved_space_c_stack_link > 0
+  char reserved[Reserved_space_c_stack_link];
 #endif
   /* The reference to the OCaml stack */
   struct stack_info* stack;

--- a/runtime/s390x.S
+++ b/runtime/s390x.S
@@ -89,8 +89,8 @@
 #define LEAVE_FUNCTION
 
 #define CHECK_STACK_ALIGNMENT
-#define PREPARE_FOR_C_CALL      lay     %r15, -160(%r15); CFI_REMEMBER_STATE
-#define CLEANUP_AFTER_C_CALL    la      %r15,  160(%r15); CFI_RESTORE_STATE
+#define PREPARE_FOR_C_CALL      CFI_REMEMBER_STATE
+#define CLEANUP_AFTER_C_CALL    CFI_RESTORE_STATE
 
 /* struct stack_info */
 #define Stack_sp                 0
@@ -104,9 +104,10 @@
 #define Handler_parent          24
 
 /* struct c_stack_link */
-#define Cstack_stack             0
-#define Cstack_sp                8
-#define Cstack_prev             16
+#define Cstack_stack           160
+#define Cstack_sp              168
+#define Cstack_prev            176
+#define SIZEOF_C_STACK_LINK    184
 
 /******************************************************************************/
 /* DWARF */
@@ -448,14 +449,15 @@ CFI_STARTPROC
           /* %r12 points to the c_stack_link structure */   \
           DW_OP_breg + DW_REG_r12, Cstack_sp, DW_OP_deref
 #endif
-    /* Copy arguments from OCaml to C stack */
+    /* Copy arguments from OCaml to C stack, always reserving
+       the 160 bytes at the bottom of the C stack. */
 LBL(105):
         lay     %r8, -8(%r8)
         clgr    %r8, %r9
         jl      LBL(106)
         lg      %r0, 0(%r8)
         lay     %r15, -8(%r15)
-        stg     %r0, 0(%r15)
+        stg     %r0, 160(%r15)
         CFI_ADJUST(8)
         brcl    15, LBL(105)
 LBL(106):
@@ -510,7 +512,8 @@ LBL(caml_start_program):
     /* Reload allocation pointer */
         lg      ALLOC_PTR, Caml_state(young_ptr)
     /* Build struct c_stack_link on the C stack */
-        lay     %r15, -24(%r15); /* sizeof struct c_stack_link */ CFI_ADJUST(24)
+        lay     %r15, -SIZEOF_C_STACK_LINK(%r15)
+        CFI_ADJUST(SIZEOF_C_STACK_LINK)
         lg      TMP3,  Caml_state(c_stack)
         lgfi    TMP2,  0
         stg     TMP2,  Cstack_stack(%r15)
@@ -566,7 +569,8 @@ LBL(return_result):  /* restore GC regs */
     /* Pop the struct c_stack_link */
         lg      %r8, Cstack_prev(%r15)
         stg     %r8, Caml_state(c_stack)
-        la      %r15, 24(%r15); CFI_ADJUST(-24)
+        la      %r15, SIZEOF_C_STACK_LINK(%r15)
+        CFI_ADJUST(SIZEOF_C_STACK_LINK)
     /* Restore callee-save registers. */
         lmg     %r6,%r14, 0(%r15)
         CFI_RESTORE(14)

--- a/runtime/s390x.S
+++ b/runtime/s390x.S
@@ -324,12 +324,12 @@ ENDFUNCTION(G(caml_call_realloc_stack))
 
 FUNCTION(G(caml_call_gc))
 CFI_STARTPROC
+LBL(caml_call_gc):
         CFI_SIGNAL_FRAME
         lay     %r15, -8(%r15)
         CFI_ADJUST(8)
         stg     %r14, 0(%r15)
         CFI_OFFSET(14, -168)
-LBL(caml_call_gc):
         SAVE_ALL_REGS
         SWITCH_OCAML_TO_C
         PREPARE_FOR_C_CALL
@@ -351,71 +351,35 @@ ENDFUNCTION(G(caml_call_gc))
 
 FUNCTION(G(caml_alloc1))
 CFI_STARTPROC
-        lay     %r15, -8(%r15)
-        CFI_ADJUST(8)
-        stg     %r14, 0(%r15)
-        CFI_OFFSET(14, -168)
-        ENTER_FUNCTION
         lay     ALLOC_PTR, -16(ALLOC_PTR)
         clg     ALLOC_PTR, Caml_state(young_limit)
         jl      LBL(caml_call_gc)
-        LEAVE_FUNCTION
-        lg      %r14, 0(%r15)
-        CFI_RESTORE(14)
-        la      %r15, 8(%r15)
         br      %r14
 CFI_ENDPROC
 ENDFUNCTION(G(caml_alloc1))
 
 FUNCTION(G(caml_alloc2))
 CFI_STARTPROC
-        lay     %r15, -8(%r15)
-        CFI_ADJUST(8)
-        stg     %r14, 0(%r15)
-        CFI_OFFSET(14, -168)
-        ENTER_FUNCTION
         lay     ALLOC_PTR, -24(ALLOC_PTR)
         clg     ALLOC_PTR, Caml_state(young_limit)
         jl      LBL(caml_call_gc)
-        LEAVE_FUNCTION
-        lg      %r14, 0(%r15)
-        CFI_RESTORE(14)
-        la      %r15, 8(%r15)
         br      %r14
 CFI_ENDPROC
 ENDFUNCTION(G(caml_alloc2))
 
 FUNCTION(G(caml_alloc3))
 CFI_STARTPROC
-        lay     %r15, -8(%r15)
-        CFI_ADJUST(8)
-        stg     %r14, 0(%r15)
-        CFI_OFFSET(14, -168)
-        ENTER_FUNCTION
         lay     ALLOC_PTR, -32(ALLOC_PTR)
         clg     ALLOC_PTR, Caml_state(young_limit)
         jl      LBL(caml_call_gc)
-        LEAVE_FUNCTION
-        lg      %r14, 0(%r15)
-        CFI_RESTORE(14)
-        la      %r15, 8(%r15)
         br      %r14
 CFI_ENDPROC
 ENDFUNCTION(G(caml_alloc3))
 
 FUNCTION(G(caml_allocN))
 CFI_STARTPROC
-        lay     %r15, -8(%r15)
-        CFI_ADJUST(8)
-        stg     %r14, 0(%r15)
-        CFI_OFFSET(14, -168)
-        ENTER_FUNCTION
         clg     ALLOC_PTR, Caml_state(young_limit)
         jl      LBL(caml_call_gc)
-        LEAVE_FUNCTION
-        lg      %r14, 0(%r15)
-        CFI_RESTORE(14)
-        la      %r15, 8(%r15)
         br      %r14
 CFI_ENDPROC
 ENDFUNCTION(G(caml_allocN))

--- a/runtime/s390x.S
+++ b/runtime/s390x.S
@@ -295,7 +295,7 @@ CFI_STARTPROC
         stg     %r14, 0(%r15)
         CFI_OFFSET(14, -168)
         SAVE_ALL_REGS
-        lg    C_ARG_1, RETADDR_ENTRY_SIZE(%r15) /* argument */
+        lgr    C_ARG_1, %r12 /* requested size */
         SWITCH_OCAML_TO_C
         PREPARE_FOR_C_CALL
 #ifdef ASM_CFI_SUPPORTED
@@ -317,7 +317,6 @@ LBL(120):
         RESTORE_ALL_REGS
         lg      %r14, 0(%r15)
         CFI_RESTORE(14)
-        la      %r15, 16(%r15) /* %r14 register and pop argument, retaddr */
         LEA_VAR(caml_exn_Stack_overflow, %r2)
         brcl    15, GCALL(caml_raise_exn)
 CFI_ENDPROC


### PR DESCRIPTION
These are small changes to the code emitter (asmcomp/s390x/emit.mlp) and the runtime glue code (runtime/s390x.S) that reduce the size of ocamlopt-generated code (always a good thing) and probably improve execution speed a bit (but I didn't try to measure).

The PR is best reviewed commit-per-commit.

Cc: @lthls .
