### PR TITLE
Document that `Domain.spawn` can raise an exception

### DIFF
--- a/stdlib/domain.mli
+++ b/stdlib/domain.mli
@@ -32,7 +32,10 @@ type !'a t
 
 val spawn : (unit -> 'a) -> 'a t
 (** [spawn f] creates a new domain that runs in parallel with the
-    current domain. *)
+    current domain.
+
+    @raise Failure if the program has insufficient resources to create another
+    domain. *)
 
 val join : 'a t -> 'a
 (** [join d] blocks until domain [d] runs to completion. If [d] results in a


### PR DESCRIPTION
This little PR documents that `Domain.spawn` can raise `Failure`.