### PR TITLE
Fix the configuration of ZSTD on mingw-w64

### DIFF
--- a/Changes
+++ b/Changes
@@ -747,6 +747,10 @@ OCaml 5.1.0
   exception backtraces for them.
   (Xavier Leroy, review by David Allsopp, report by Fabrice Le Fessant)
 
+- #12265: Stop adding -lexecinfo to cclibs (leftover debugging code from the
+  multicore project).
+  (David Allsopp, review by Sébastien Hinderer)
+
 ### Bug fixes:
 
 - #12017: Re-register finaliser only after calling user alarm in Gc.create_alarm

--- a/Changes
+++ b/Changes
@@ -748,7 +748,8 @@ OCaml 5.1.0
   (Xavier Leroy, review by David Allsopp, report by Fabrice Le Fessant)
 
 - #12265: Stop adding -lexecinfo to cclibs (leftover debugging code from the
-  multicore project).
+  multicore project). Harden the feature probe for -lm in configure so -lm is
+  only added if strictly necessary.
   (David Allsopp, review by Sébastien Hinderer)
 
 ### Bug fixes:

--- a/Changes
+++ b/Changes
@@ -749,7 +749,9 @@ OCaml 5.1.0
 
 - #12265: Stop adding -lexecinfo to cclibs (leftover debugging code from the
   multicore project). Harden the feature probe for -lm in configure so -lm is
-  only added if strictly necessary.
+  only added if strictly necessary. configure.ac now correctly propagates
+  library flags for the Windows ports, allowing Windows OCaml to be configured
+  with ZSTD support.
   (David Allsopp, review by Sébastien Hinderer)
 
 ### Bug fixes:

--- a/Makefile.config.in
+++ b/Makefile.config.in
@@ -173,7 +173,7 @@ CPPFLAGS=@CPPFLAGS@
 OCAMLC_CFLAGS=@ocamlc_cflags@
 
 OCAMLC_CPPFLAGS=@ocamlc_cppflags@
-BYTECCLIBS=@bytecclibs@
+BYTECCLIBS=@cclibs@
 EXE=@exeext@
 OUTPUTEXE=@outputexe@$(EMPTY)
 SUPPORTS_SHARED_LIBRARIES=@supports_shared_libraries@
@@ -187,7 +187,7 @@ MKLIB=@mklib@
 #        two drivers should be identical.
 OCAMLOPT_CFLAGS=@ocamlc_cflags@
 OCAMLOPT_CPPFLAGS=@ocamlc_cppflags@
-NATIVECCLIBS=@nativecclibs@
+NATIVECCLIBS=@cclibs@
 SYSTHREAD_SUPPORT=@systhread_support@
 PACKLD=@PACKLD@$(EMPTY)
 CCOMPTYPE=@ccomptype@

--- a/configure
+++ b/configure
@@ -16420,8 +16420,76 @@ fi
 sockets=true
 
 case $host in #(
-  *-*-mingw32*|*-pc-windows) :
+  *-*-mingw32*) :
     cclibs="$cclibs -lws2_32"
+    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for library containing socket" >&5
+printf %s "checking for library containing socket... " >&6; }
+if test ${ac_cv_search_socket+y}
+then :
+  printf %s "(cached) " >&6
+else $as_nop
+  ac_func_search_save_LIBS=$LIBS
+cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+/* Override any GCC internal prototype to avoid an error.
+   Use char because int might match the return type of a GCC
+   builtin and then its argument prototype would still apply.  */
+char socket ();
+int
+main (void)
+{
+return socket ();
+  ;
+  return 0;
+}
+_ACEOF
+for ac_lib in '' ws2_32
+do
+  if test -z "$ac_lib"; then
+    ac_res="none required"
+  else
+    ac_res=-l$ac_lib
+    LIBS="-l$ac_lib  $ac_func_search_save_LIBS"
+  fi
+  if ac_fn_c_try_link "$LINENO"
+then :
+  ac_cv_search_socket=$ac_res
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.beam \
+    conftest$ac_exeext
+  if test ${ac_cv_search_socket+y}
+then :
+  break
+fi
+done
+if test ${ac_cv_search_socket+y}
+then :
+
+else $as_nop
+  ac_cv_search_socket=no
+fi
+rm conftest.$ac_ext
+LIBS=$ac_func_search_save_LIBS
+fi
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_cv_search_socket" >&5
+printf "%s\n" "$ac_cv_search_socket" >&6; }
+ac_res=$ac_cv_search_socket
+if test "$ac_res" != no
+then :
+  test "$ac_res" = "none required" || LIBS="$ac_res $LIBS"
+
+fi
+
+    ac_fn_c_check_func "$LINENO" "socketpair" "ac_cv_func_socketpair"
+if test "x$ac_cv_func_socketpair" = xyes
+then :
+  printf "%s\n" "#define HAS_SOCKETPAIR 1" >>confdefs.h
+
+fi
+ ;; #(
+  *-pc-windows) :
+    cclibs="$cclibs ws2_32.lib"
     { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for library containing socket" >&5
 printf %s "checking for library containing socket... " >&6; }
 if test ${ac_cv_search_socket+y}
@@ -18286,8 +18354,10 @@ esac
 ## Determine how to link with the POSIX threads library
 
 case $host in #(
-  *-*-mingw32*|*-pc-windows) :
-    PTHREAD_LIBS="-l:libpthread.a" ;; #(
+  *-*-mingw32*) :
+    PTHREAD_LIBS="-l:libpthread.a -lgcc_eh" ;; #(
+  *-pc-windows) :
+    PTHREAD_LIBS="-l:libpthread.lib" ;; #(
   *) :
 
 
@@ -19669,16 +19739,19 @@ oc_cflags="$common_cflags $internal_cflags"
 oc_cppflags="$common_cppflags $internal_cppflags"
 ocamlc_cflags="$common_cflags $sharedlib_cflags $CFLAGS"
 ocamlc_cppflags="$common_cppflags $CPPFLAGS"
-cclibs="$cclibs $mathlib"
 
 case $host in #(
   *-*-mingw32*) :
-    cclibs="-lws2_32 -lversion -l:libpthread.a -lgcc_eh" ;; #(
+    cclibs="$cclibs -lversion" ;; #(
   *-pc-windows) :
-    cclibs="advapi32.lib ws2_32.lib version.lib" ;; #(
+    # For whatever reason, flexlink includes -ladvapi32 for mingw-w64, but
+    # doesn't include advapi32.lib for MSVC
+    cclibs="$cclibs advapi32.lib version.lib" ;; #(
   *) :
-    cclibs="$cclibs $DLLIBS $PTHREAD_LIBS" ;;
+     ;;
 esac
+
+
 
 if test x"$libdir" = x'${exec_prefix}/lib'
 then :
@@ -19917,6 +19990,7 @@ LTLIBOBJS=$ac_ltlibobjs
     fi
   done
 
+cclibs="$cclibs $mathlib $DLLIBS $PTHREAD_LIBS"
 
   saved_exec_prefix="$exec_prefix"
   saved_prefix="$prefix"

--- a/configure
+++ b/configure
@@ -19659,47 +19659,6 @@ ocamlc_cflags="$common_cflags $sharedlib_cflags $CFLAGS"
 ocamlc_cppflags="$common_cppflags $CPPFLAGS"
 cclibs="$cclibs $mathlib"
 
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for backtrace in -lexecinfo" >&5
-printf %s "checking for backtrace in -lexecinfo... " >&6; }
-if test ${ac_cv_lib_execinfo_backtrace+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
-  ac_check_lib_save_LIBS=$LIBS
-LIBS="-lexecinfo  $LIBS"
-cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-
-/* Override any GCC internal prototype to avoid an error.
-   Use char because int might match the return type of a GCC
-   builtin and then its argument prototype would still apply.  */
-char backtrace ();
-int
-main (void)
-{
-return backtrace ();
-  ;
-  return 0;
-}
-_ACEOF
-if ac_fn_c_try_link "$LINENO"
-then :
-  ac_cv_lib_execinfo_backtrace=yes
-else $as_nop
-  ac_cv_lib_execinfo_backtrace=no
-fi
-rm -f core conftest.err conftest.$ac_objext conftest.beam \
-    conftest$ac_exeext conftest.$ac_ext
-LIBS=$ac_check_lib_save_LIBS
-fi
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib_execinfo_backtrace" >&5
-printf "%s\n" "$ac_cv_lib_execinfo_backtrace" >&6; }
-if test "x$ac_cv_lib_execinfo_backtrace" = xyes
-then :
-  cclibs="$cclibs -lexecinfo"
-fi
-
-
 case $host in #(
   *-*-mingw32*) :
     bytecclibs="-lws2_32 -lversion -l:libpthread.a -lgcc_eh"

--- a/configure
+++ b/configure
@@ -14204,8 +14204,6 @@ case $cc_basename,$host in #(
   *,aarch64-*-darwin*|arm64-*-darwin*) :
     printf "%s\n" "#define HAS_ARCH_CODE32 1" >>confdefs.h
  ;; #(
-  *,*-*-haiku*) :
-    mathlib="" ;; #(
   *,*-*-cygwin*) :
     common_cppflags="$common_cppflags -U_WIN32"
     if $supports_shared_libraries

--- a/configure
+++ b/configure
@@ -14362,14 +14362,13 @@ test -z "$INSTALL_DATA" && INSTALL_DATA='${INSTALL} -m 644'
 # Checks for libraries
 
 ## Mathematical library
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for cos in -lm" >&5
-printf %s "checking for cos in -lm... " >&6; }
-if test ${ac_cv_lib_m_cos+y}
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for library containing cos" >&5
+printf %s "checking for library containing cos... " >&6; }
+if test ${ac_cv_search_cos+y}
 then :
   printf %s "(cached) " >&6
 else $as_nop
-  ac_check_lib_save_LIBS=$LIBS
-LIBS="-lm  $LIBS"
+  ac_func_search_save_LIBS=$LIBS
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
@@ -14385,33 +14384,50 @@ return cos ();
   return 0;
 }
 _ACEOF
-if ac_fn_c_try_link "$LINENO"
+for ac_lib in '' m
+do
+  if test -z "$ac_lib"; then
+    ac_res="none required"
+  else
+    ac_res=-l$ac_lib
+    LIBS="-l$ac_lib  $ac_func_search_save_LIBS"
+  fi
+  if ac_fn_c_try_link "$LINENO"
 then :
-  ac_cv_lib_m_cos=yes
-else $as_nop
-  ac_cv_lib_m_cos=no
+  ac_cv_search_cos=$ac_res
 fi
 rm -f core conftest.err conftest.$ac_objext conftest.beam \
-    conftest$ac_exeext conftest.$ac_ext
-LIBS=$ac_check_lib_save_LIBS
-fi
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib_m_cos" >&5
-printf "%s\n" "$ac_cv_lib_m_cos" >&6; }
-if test "x$ac_cv_lib_m_cos" = xyes
+    conftest$ac_exeext
+  if test ${ac_cv_search_cos+y}
 then :
-  printf "%s\n" "#define HAVE_LIBM 1" >>confdefs.h
-
-  LIBS="-lm $LIBS"
-
+  break
 fi
-
-
-if test "x$ac_cv_lib_m_cos" = xyes
+done
+if test ${ac_cv_search_cos+y}
 then :
-  mathlib="-lm"
+
 else $as_nop
-  mathlib=""
+  ac_cv_search_cos=no
 fi
+rm conftest.$ac_ext
+LIBS=$ac_func_search_save_LIBS
+fi
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_cv_search_cos" >&5
+printf "%s\n" "$ac_cv_search_cos" >&6; }
+ac_res=$ac_cv_search_cos
+if test "$ac_res" != no
+then :
+  test "$ac_res" = "none required" || LIBS="$ac_res $LIBS"
+  case $ac_cv_search_cos in #(
+  no) :
+    as_fn_error $? "Could not locate C math functions" "$LINENO" 5 ;; #(
+  'none required') :
+    mathlib="" ;; #(
+  *) :
+    mathlib="$ac_cv_search_cos" ;;
+esac
+fi
+
 
 # Checks for header files
 

--- a/configure
+++ b/configure
@@ -854,8 +854,7 @@ bootstrapping_flexdll
 flexdir
 ocamlc_cppflags
 ocamlc_cflags
-nativecclibs
-bytecclibs
+cclibs
 oc_exe_ldflags
 oc_dll_ldflags
 oc_ldflags
@@ -3291,7 +3290,6 @@ OCAML_VERSION_SHORT=5.2
 # Note: This is present for the flexdll bootstrap where it exposed as the old
 # TOOLPREF variable. It would be better if flexdll where updated to require
 # WINDRES instead.
-
 
 
 
@@ -19675,14 +19673,11 @@ cclibs="$cclibs $mathlib"
 
 case $host in #(
   *-*-mingw32*) :
-    bytecclibs="-lws2_32 -lversion -l:libpthread.a -lgcc_eh"
-    nativecclibs="-lws2_32 -lversion -l:libpthread.a -lgcc_eh" ;; #(
+    cclibs="-lws2_32 -lversion -l:libpthread.a -lgcc_eh" ;; #(
   *-pc-windows) :
-    bytecclibs="advapi32.lib ws2_32.lib version.lib"
-    nativecclibs="advapi32.lib ws2_32.lib version.lib" ;; #(
+    cclibs="advapi32.lib ws2_32.lib version.lib" ;; #(
   *) :
-    bytecclibs="$cclibs $DLLIBS $PTHREAD_LIBS"
-  nativecclibs="$cclibs $DLLIBS $PTHREAD_LIBS" ;;
+    cclibs="$cclibs $DLLIBS $PTHREAD_LIBS" ;;
 esac
 
 if test x"$libdir" = x'${exec_prefix}/lib'

--- a/configure.ac
+++ b/configure.ac
@@ -138,8 +138,7 @@ AC_SUBST([oc_cppflags])
 AC_SUBST([oc_ldflags])
 AC_SUBST([oc_dll_ldflags])
 AC_SUBST([oc_exe_ldflags])
-AC_SUBST([bytecclibs])
-AC_SUBST([nativecclibs])
+AC_SUBST([cclibs])
 AC_SUBST([ocamlc_cflags])
 AC_SUBST([ocamlc_cppflags])
 AC_SUBST([flexdir])
@@ -2228,13 +2227,10 @@ cclibs="$cclibs $mathlib"
 
 AS_CASE([$host],
   [*-*-mingw32*],
-    [bytecclibs="-lws2_32 -lversion -l:libpthread.a -lgcc_eh"
-    nativecclibs="-lws2_32 -lversion -l:libpthread.a -lgcc_eh"],
+    [cclibs="-lws2_32 -lversion -l:libpthread.a -lgcc_eh"],
   [*-pc-windows],
-    [bytecclibs="advapi32.lib ws2_32.lib version.lib"
-    nativecclibs="advapi32.lib ws2_32.lib version.lib"],
-  [bytecclibs="$cclibs $DLLIBS $PTHREAD_LIBS"
-  nativecclibs="$cclibs $DLLIBS $PTHREAD_LIBS"])
+    [cclibs="advapi32.lib ws2_32.lib version.lib"],
+  [cclibs="$cclibs $DLLIBS $PTHREAD_LIBS"])
 
 AS_IF([test x"$libdir" = x'${exec_prefix}/lib'],
   [libdir="$libdir"/ocaml])

--- a/configure.ac
+++ b/configure.ac
@@ -1587,8 +1587,12 @@ but no proper monotonic clock source was found.])
 sockets=true
 
 AS_CASE([$host],
-  [*-*-mingw32*|*-pc-windows],
+  [*-*-mingw32*],
     [cclibs="$cclibs -lws2_32"
+    AC_SEARCH_LIBS([socket], [ws2_32])
+    AC_CHECK_FUNC([socketpair], [AC_DEFINE([HAS_SOCKETPAIR])])],
+  [*-pc-windows],
+    [cclibs="$cclibs ws2_32.lib"
     AC_SEARCH_LIBS([socket], [ws2_32])
     AC_CHECK_FUNC([socketpair], [AC_DEFINE([HAS_SOCKETPAIR])])],
   [*-*-haiku],
@@ -2031,8 +2035,10 @@ AS_CASE([$enable_debug_runtime],
 ## Determine how to link with the POSIX threads library
 
 AS_CASE([$host],
-  [*-*-mingw32*|*-pc-windows],
-    [PTHREAD_LIBS="-l:libpthread.a"],
+  [*-*-mingw32*],
+    [PTHREAD_LIBS="-l:libpthread.a -lgcc_eh"],
+  [*-pc-windows],
+    [PTHREAD_LIBS="-l:libpthread.lib"],
   [AX_PTHREAD(
     [common_cflags="$common_cflags $PTHREAD_CFLAGS"
     saved_CFLAGS="$CFLAGS"
@@ -2223,14 +2229,16 @@ oc_cflags="$common_cflags $internal_cflags"
 oc_cppflags="$common_cppflags $internal_cppflags"
 ocamlc_cflags="$common_cflags $sharedlib_cflags $CFLAGS"
 ocamlc_cppflags="$common_cppflags $CPPFLAGS"
-cclibs="$cclibs $mathlib"
 
 AS_CASE([$host],
   [*-*-mingw32*],
-    [cclibs="-lws2_32 -lversion -l:libpthread.a -lgcc_eh"],
+    [cclibs="$cclibs -lversion"],
   [*-pc-windows],
-    [cclibs="advapi32.lib ws2_32.lib version.lib"],
-  [cclibs="$cclibs $DLLIBS $PTHREAD_LIBS"])
+    [# For whatever reason, flexlink includes -ladvapi32 for mingw-w64, but
+    # doesn't include advapi32.lib for MSVC
+    cclibs="$cclibs advapi32.lib version.lib"])
+
+AC_CONFIG_COMMANDS_PRE([cclibs="$cclibs $mathlib $DLLIBS $PTHREAD_LIBS"])
 
 AS_IF([test x"$libdir" = x'${exec_prefix}/lib'],
   [libdir="$libdir"/ocaml])

--- a/configure.ac
+++ b/configure.ac
@@ -2225,8 +2225,6 @@ ocamlc_cflags="$common_cflags $sharedlib_cflags $CFLAGS"
 ocamlc_cppflags="$common_cppflags $CPPFLAGS"
 cclibs="$cclibs $mathlib"
 
-AC_CHECK_LIB(execinfo, backtrace, cclibs="$cclibs -lexecinfo",[])
-
 AS_CASE([$host],
   [*-*-mingw32*],
     [bytecclibs="-lws2_32 -lversion -l:libpthread.a -lgcc_eh"

--- a/configure.ac
+++ b/configure.ac
@@ -918,7 +918,6 @@ AS_CASE([$cc_basename,$host],
     AC_DEFINE([HAS_ARCH_CODE32], [1])],
   [*,aarch64-*-darwin*|arm64-*-darwin*],
     AC_DEFINE([HAS_ARCH_CODE32], [1]),
-  [*,*-*-haiku*], [mathlib=""],
   [*,*-*-cygwin*],
     [common_cppflags="$common_cppflags -U_WIN32"
     AS_IF([$supports_shared_libraries],

--- a/configure.ac
+++ b/configure.ac
@@ -966,9 +966,11 @@ AC_PROG_INSTALL
 # Checks for libraries
 
 ## Mathematical library
-AC_CHECK_LIB([m],[cos])
-
-AS_IF([test "x$ac_cv_lib_m_cos" = xyes ], [mathlib="-lm"], [mathlib=""])
+AC_SEARCH_LIBS([cos], [m],
+  [AS_CASE([$ac_cv_search_cos],
+    [no], [AC_MSG_ERROR([Could not locate C math functions])],
+    ['none required'], [mathlib=""],
+    [mathlib="$ac_cv_search_cos"])])
 
 # Checks for header files
 

--- a/ocamltest/ocamltest_config.ml.in
+++ b/ocamltest/ocamltest_config.ml.in
@@ -80,9 +80,9 @@ let exe = {@QS@|@exeext@|@QS@}
 let mkdll = {@QS@|@mkdll_exp@|@QS@}
 let mkexe = {@QS@|@mkexe_exp@|@QS@}
 
-let bytecc_libs = {@QS@|@bytecclibs@|@QS@}
+let bytecc_libs = {@QS@|@cclibs@|@QS@}
 
-let nativecc_libs = {@QS@|@nativecclibs@|@QS@}
+let nativecc_libs = {@QS@|@cclibs@|@QS@}
 
 let windows_unicode = @windows_unicode@ != 0
 

--- a/utils/config.generated.ml.in
+++ b/utils/config.generated.ml.in
@@ -33,7 +33,7 @@ let ocamlc_cppflags = {@QS@|@ocamlc_cppflags@|@QS@}
           the two drivers should be identical. *)
 let ocamlopt_cflags = {@QS@|@ocamlc_cflags@|@QS@}
 let ocamlopt_cppflags = {@QS@|@ocamlc_cppflags@|@QS@}
-let bytecomp_c_libraries = {@QS@|@bytecclibs@|@QS@}
+let bytecomp_c_libraries = {@QS@|@cclibs@|@QS@}
 (* bytecomp_c_compiler and native_c_compiler have been supported for a
    long time and are retained for backwards compatibility.
    For programs that don't need compatibility with older OCaml releases
@@ -44,7 +44,7 @@ let bytecomp_c_compiler =
   c_compiler ^ " " ^ ocamlc_cflags ^ " " ^ ocamlc_cppflags
 let native_c_compiler =
   c_compiler ^ " " ^ ocamlopt_cflags ^ " " ^ ocamlopt_cppflags
-let native_c_libraries = {@QS@|@nativecclibs@|@QS@}
+let native_c_libraries = {@QS@|@cclibs@|@QS@}
 let native_pack_linker = {@QS@|@PACKLD@|@QS@}
 let default_rpath = {@QS@|@rpath@|@QS@}
 let mksharedlibrpath = {@QS@|@mksharedlibrpath@|@QS@}


### PR DESCRIPTION
#12190 means that the mingw-w64 version of ZSTD is correctly detected by `configure.ac` and `HAS_ZSTD` is correctly defined in `s.h`. However, the way that `bytecclibs` and `nativecclibs` are declared for the Windows ports means that `-lzstd` does _not_ get added and consequently the build fails with a linking error.

This PR ultimately unifies the computation of `cclibs` between Unix and Windows, a side-effect of which is that ZSTD now configures correctly. The PR is best reviewed commit-by-commit. There's no distinction in `configure.ac` between bytecode and nativecode libraries, so the variables have been merged to `cclibs` to remove the code duplication.

The important check here is the diff in `config.status` before and after the PR. There's no relevant change on Unix. On Windows, the only pertinent change is that `-latomic` gets added for 32-bit mingw-w64 (as for the other 32-bit GCC ports).