### PR TITLE
Clean lex directory during partialclean rather than clean

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1127,13 +1127,12 @@ ocamllex.opt: ocamlopt
 lex/ocamllex$(EXE): OC_BYTECODE_LINKFLAGS += -compat-32
 
 partialclean::
-	rm -f lex/*.cm* lex/*.o lex/*.obj
+	rm -f lex/*.cm* lex/*.o lex/*.obj \
+        $(ocamllex_PROGRAMS) $(ocamllex_PROGRAMS:=.exe) \
+        lex/parser.ml lex/parser.mli lex/parser.output \
+        lex/lexer.ml
 
 beforedepend:: lex/parser.ml lex/parser.mli lex/lexer.ml
-
-clean::
-	rm -f lex/parser.ml lex/parser.mli lex/parser.output
-	rm -f lex/lexer.ml
 
 # The ocamlyacc parser generator
 


### PR DESCRIPTION
A tiny difference missed in #11420 - the `clean` target of `lex/Makefile` was invoked as part of `partialclean` in the root `Makefile`, but some of the files were moved to `clean` targets in the root Makefile. Only affects the bootstrap (which uses partialclean between cycles), and it wouldn't have mattered since the object files were being removed in partialclean.