### PR TITLE
domain_create: deliver an Out_of_memory exception if malloc fails

### DIFF
--- a/Changes
+++ b/Changes
@@ -43,6 +43,10 @@ Working version
   how to traverse them, supporting more stack layouts.
   (Xavier Leroy, review by KC Sivaramakrishnan and Fabrice Buoro)
 
+- #12268: deliver `Out_of_memory` exception if domain creation fails
+  due to memory resource exhaustion.  It was previous always a `Failure`.
+  (Anil Madhavapeddy, review by David Allsopp)
+
 ### Code generation and optimizations:
 
 ### Standard library:

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -1141,11 +1141,8 @@ CAMLprim value caml_domain_spawn(value callback, value mutex)
   p.status = Dom_starting;
 
   p.ml_values =
-      (struct domain_ml_values*) caml_stat_alloc_noexc(
+      (struct domain_ml_values*) caml_stat_alloc(
                                     sizeof(struct domain_ml_values));
-  if (!p.ml_values) {
-    caml_failwith("failed to create ml values for domain thread");
-  }
   init_domain_ml_values(p.ml_values, callback, mutex);
 
 /* We block all signals while we spawn the new domain. This is because


### PR DESCRIPTION
This is what we do elsewhere in the runtime if a malloc fails, and it helps distinguish the sort of resource exhaustion a domain create is seeing (thread limits _vs_ memory limits)

Spotted during review for #12263