### PR TITLE
testsuite: unlock mutexes in tests before exit

### DIFF
--- a/testsuite/tests/backtrace/backtrace_systhreads.ml
+++ b/testsuite/tests/backtrace/backtrace_systhreads.ml
@@ -22,7 +22,7 @@ let thread_backtrace (cond, mut) =
   try throw_exn "backtrace" with
   | exn ->
      Mutex.lock mut;
-     Condition.wait cond mut;
+     Condition.wait cond mut; Mutex.unlock mut;
      raise exn
 
 let () =

--- a/testsuite/tests/lib-sync/trylock.ml
+++ b/testsuite/tests/lib-sync/trylock.ml
@@ -6,6 +6,7 @@ let () =
   let m = Mutex.create () in
   Mutex.lock m;
   let res = Mutex.try_lock m in
+  Mutex.unlock m;
   if res = false then
     print_endline "passed"
   else

--- a/testsuite/tests/lib-threads/mutex_errors.ml
+++ b/testsuite/tests/lib-threads/mutex_errors.ml
@@ -58,7 +58,8 @@ let mutex_unlock_other_thread () =
     mutex_unlock_must_fail m;
     log "Releasing mutex from another thread (again)";
     mutex_unlock_must_fail m in
-  Thread.join (Thread.create f ())
+  Thread.join (Thread.create f ());
+  Mutex.unlock m
 
 let _ =
   log "---- Self deadlock";


### PR DESCRIPTION
This PR fixes the testsuite on openbsd by unlocking mutex before exiting in a handful of tests.

Those tests have been failing since the merge of #11903 because the GC was finally calling the finalisers of those mutexes, and calling `pthread_destroy_mutex` on a locked mutex yields an error message
```
pthread_mutex_destroy on mutex with waiters!
```
in openBSD implementation of pthreads.

This PR fixes this issue by unlocking the problematic mutexes.