### PR TITLE
More macros to describe the layout of OCaml stacks

### DIFF
--- a/Changes
+++ b/Changes
@@ -17,6 +17,10 @@ Working version
 - #12234: make instrumented time calculation more thread-safe on macOS.
   (Anil Madhavapeddy, review by Daniel Bünzli and Xavier Leroy)
 
+- #12275: caml/stack.h: more abstract macros to describe OCaml stacks and
+  how to traverse them, supporting more stack layouts.
+  (Xavier Leroy, review by KC Sivaramakrishnan and Fabrice Buoro)
+
 ### Code generation and optimizations:
 
 ### Standard library:

--- a/runtime/backtrace_nat.c
+++ b/runtime/backtrace_nat.c
@@ -56,15 +56,14 @@ frame_descr * caml_next_frame_descriptor
       /* This marks the top of an ML stack chunk. Move sp to the previous stack
        chunk. This includes skipping over the DWARF link & trap frame
        (4 words). */
-      *sp += 4 * sizeof(value);
+      *sp += Stack_header_size;
       if (*sp == (char*)Stack_high(stack)) {
         /* We've reached the top of stack. No more frames. */
         *pc = 0;
         return NULL;
       }
-      Pop_frame_pointer(*sp);
-      *pc = **(uintnat**)sp;
-      *sp += sizeof(value); /* return address */
+      *sp = First_frame(*sp);
+      *pc = Saved_return_address(*sp);
     }
   }
 }

--- a/runtime/caml/stack.h
+++ b/runtime/caml/stack.h
@@ -35,7 +35,7 @@
    If [sp] points to the bottom of an OCaml stack,
    [First_frame(sp)] is the first stack frame of the first chunk of this stack.
 
-   If [sp] points to the special frame for [caml_start_program] and
+   If [sp] points to the special frame for [caml_start_program] or
    [caml_callback_*], this marks the end of the current chunk.
    The saved value of [gc_regs] for the previous chunk is in
    [Saved_gc_regs(sp)], and [Stack_header_size] bytes must be skipped

--- a/runtime/caml/stack.h
+++ b/runtime/caml/stack.h
@@ -20,27 +20,34 @@
 
 #ifdef CAML_INTERNALS
 
-/* Macros to access the stack frame */
+/* Macros to access OCaml stacks */
 
-#ifdef TARGET_power
-#if defined(MODEL_ppc)
-#define Saved_return_address(sp) *((intnat *)((sp) - 4))
-#elif defined(MODEL_ppc64)
-#define Saved_return_address(sp) *((intnat *)((sp) + 16))
-#elif defined(MODEL_ppc64le)
-#define Saved_return_address(sp) *((intnat *)((sp) + 16))
-#else
-#error "TARGET_power: wrong MODEL"
-#endif
-#define Already_scanned(sp, retaddr) ((retaddr) & 1)
-#define Mask_already_scanned(retaddr) ((retaddr) & ~1)
-#define Mark_scanned(sp, retaddr) Saved_return_address(sp) = (retaddr) | 1
-#endif
+/* An OCaml stack is composed of one or several "chunks", each chunk
+   being a sequence of frames (activation records) for ocamlopt-generated
+   functions.
+
+   A chunk terminates when the OCaml code calls into C code
+   (explicitly or to perform garbage collection or signal polling).
+
+   A chunk starts when the program starts, or a fiber is created,
+   or a callback is performed from C to OCaml.
+
+   If [sp] points to the bottom of an OCaml stack,
+   [First_frame(sp)] is the first stack frame of the first chunk of this stack.
+
+   If [sp] points to the special frame for [caml_start_program] and
+   [caml_callback_*], this marks the end of the current chunk.
+   The saved value of [gc_regs] for the previous chunk is in
+   [Saved_gc_regs(sp)], and [Stack_header_size] bytes must be skipped
+   to find the first frame of the next chunk, or to reach the top of the stack.
+*/
 
 #ifdef TARGET_s390x
 #define Wosize_gc_regs (2 + 9 /* int regs */ + 16 /* float regs */)
-#define Saved_return_address(sp) *((intnat *)((sp) - SIZEOF_PTR))
-#define Pop_frame_pointer(sp)
+#define Saved_return_address(sp) *((intnat *)((sp) - 8))
+#define First_frame(sp) ((sp) + 8)
+#define Saved_gc_regs(sp) (*(value **)((sp) + 24))
+#define Stack_header_size 32
 #endif
 
 #ifdef TARGET_amd64
@@ -49,10 +56,12 @@
 #define Wosize_gc_regs (13 /* int regs */ + 16 /* float regs */)
 #define Saved_return_address(sp) *((intnat *)((sp) - 8))
 #ifdef WITH_FRAME_POINTERS
-#define Pop_frame_pointer(sp) (sp) += sizeof(value)
+#define First_frame(sp) ((sp) + 16)
 #else
-#define Pop_frame_pointer(sp)
+#define First_frame(sp) ((sp) + 8)
 #endif
+#define Saved_gc_regs(sp) (*(value **)((sp) + 24))
+#define Stack_header_size 32
 #endif
 
 #ifdef TARGET_arm64
@@ -60,7 +69,9 @@
    See arm64.S and arm64/proc.ml for the indices */
 #define Wosize_gc_regs (2 + 24 /* int regs */ + 24 /* float regs */)
 #define Saved_return_address(sp) *((intnat *)((sp) - 8))
-#define Pop_frame_pointer(sp) sp += sizeof(value)
+#define First_frame(sp) ((sp) + 16)
+#define Saved_gc_regs(sp) (*(value **)((sp) + 24))
+#define Stack_header_size 32
 #endif
 
 #ifdef TARGET_riscv
@@ -68,11 +79,9 @@
    See riscv.S and riscv/proc.ml for the indices */
 #define Wosize_gc_regs (2 + 22 /* int regs */ + 20 /* float regs */)
 #define Saved_return_address(sp) *((intnat *)((sp) - 8))
-/* RISC-V does not use a frame pointer, but requires the stack to be
-   16-aligned, so when pushing the return address to the stack there
-   is an extra word of padding after it that needs to be skipped when
-   walking the stack. */
-#define Pop_frame_pointer(sp) sp += sizeof(value)
+#define First_frame(sp) ((sp) + 16)
+#define Saved_gc_regs(sp) (*(value **)((sp) + 24))
+#define Stack_header_size 32
 #endif
 
 /* Declaration of variables used in the asm code */

--- a/runtime/signals_nat.c
+++ b/runtime/signals_nat.c
@@ -47,8 +47,8 @@ void caml_garbage_collection(void)
   struct stack_info* stack = dom_st->current_stack;
 
   char * sp = (char*)stack->sp;
-  Pop_frame_pointer(sp);
-  uintnat retaddr = *(uintnat*)sp;
+  sp = First_frame(sp);
+  uintnat retaddr = Saved_return_address(sp);
 
   /* Synchronise for the case when [young_limit] was used to interrupt
      us. */


### PR DESCRIPTION
This PR adds macros and documentation to `<caml/stack.h>` to better describe the layout of ocamlopt-managed stacks:

- The `First_frame` macro goes from bottom of stack to first frame. It generalizes and replaces the `Pop_frame_pointer` macro.

- The `Saved_return_address` macro fetches the return address into the next frame.

- The `Stack_header_size` and `Saved_gc_regs` macros describe how to skip from a stack chunk to the next chunk. They replace ad-hoc code in backtrace.c and fiber.c.

The additional generality is not used today (all ports have the same definitions for these macros), but will be used in the POWER port, where the return address is stored at an unusual location relative to the stack frame, and the separator between chunks has a peculiar shape.