### PR TITLE
Update the POWER port for OCaml 5

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,11 @@
 Working version
 ---------------
 
+### Restored backends:
+
+- #12276: native-code compilation for POWER (64 bits, little-endian)
+  (Xavier Leroy, review by KC Sivaramakrishnan and Anil Madhavapeddy)
+
 ### Language features:
 
 ### Runtime system:

--- a/asmcomp/power/NOTES.md
+++ b/asmcomp/power/NOTES.md
@@ -1,26 +1,190 @@
 # Supported platforms
 
-IBM POWER and Freescale (nee Motorola) PowerPC processors, in three flavors:
-* 32 bits, ELF ABI: Debian's `powerpc`
-* 64 bits big-endian, ELF ABI v1: Debian's `powerpc`
-* 64 bits little-endian, ELF ABI v2: Debian's `ppc64el`
+IBM POWER processors, 64-bit, little-endian, ELF ABI v2.
+(Called `ppc64el` in Debian.)
 
-No longer supported: AIX and MacOS X.
+No longer supported:
+* 32 bits, ELF ABI (Debian's `powerpc`)
+* 64 bits big-endian, ELF ABI v1 (Debian's `powerpc`)
+* AIX
+* MacOS X.
 
 # Reference documents
 
 * Instruction set architecture:
-  _PowerPC User Instruction Set Architecture_,
-  book 1 of _PowerPC Architecture Book_
-  (http://www.ibm.com/developerworks/systems/library/es-archguide-v2.html).
-* ELF ABI 32 bits:
-  _System V Application Binary Interface, PowerPC Processor Supplement_
-* ELF ABI 64 bits version 1:
-  _64-bit PowerPC ELF Application Binary Interface Supplement_
-  (http://refspecs.linuxfoundation.org/ELF/ppc64/PPC-elf64abi.html)
+  _Power ISA User Instruction Set Architecture_,
+  book 1 of _Power Instruction Set_
+  (https://openpowerfoundation.org/specifications/isa/)
+
 * ELF ABI 64 bits version 2:
-   _Power Architecture 64-bit ELF V2 ABI Specification,
-    OpenPOWER ABI for Linux Supplement_
-  (http://openpowerfoundation.org/technical/technical-resources/technical-specifications/)
+  _OpenPOWER ABI for Linux Supplement for the Power Architecture
+   64-bit ELF V2 ABI_
+  (https://openpowerfoundation.org/specifications/64bitelfabi/)
+
 * _The PowerPC Compiler Writer's Guide_, Warthman Associates, 1996.
   (PDF available from various sources on the Web.)
+
+# Notes on calling conventions
+
+## The minimal stack frame
+
+The stack pointer SP (register 1) is always 16-byte aligned.
+
+Every stack frame contains a 32-byte reserved area at SP to SP + 31.
+
+* The 64-bit word at SP + 0 is reserved for a back pointer to the
+  previous frame.  ocamlopt-generated code does not maintain this back link.
+* The 32-bit word at SP + 8 is reserved for saving the CR register.
+  ocamlopt-generated code does not use this word.
+* The 32-bit word at SP + 12 is reserved for future uses.
+* The 64-bit word at SP + 16 is used by the *callee* to save its return address
+  (the value of the LR register on entry to the callee).  So, a function
+  saves its return address in the callee's frame, at offset 16 from the SP
+  on entry to the function.
+* The 64-bit word at SP + 24 is used by the *caller* or by
+  linker-generated call *veeners* to save the TOC register r2 across calls.
+
+A typical function prologue that allocates N bytes of stack and saves LR:
+```
+        addi 1, 1, -N
+        mflr 0
+        std  0, (N + 16)(1)    ; in caller's frame!
+```
+If the back pointer is to be maintained as well:
+```
+        stdu 1, -N(1)
+        mflr 0
+        std  0, (N + 16)(1)    ; in caller's frame!
+```
+
+If the function needs to stack-allocate M extra bytes, e.g. for an
+exception handler, it should leave the bottom 32 bytes reserved.  So,
+it decrements SP by M and uses bytes SP + 32 ... SP + 32 + M - 1 as
+the stack-allocated space:
+```
+        addi 1, 1, -32          ; allocate exception handler
+        std  29, 40(1)          ; save previous trap ptr at handler + 8
+```
+
+Because the bottom 32 bytes are used by linker-generated call veeners,
+we need to reserve them both in C stack frames and in OCaml stack
+frames.
+
+To speed up stack switching between OCaml and C, the stack pointers
+saved in struct stack_info and struct c_stack_link point to the bottom
+of the stack frame and include the reserved 32 bytes area.
+
+## TOC references and register r2
+
+Register r2 points to a table of contents (TOC) that contains absolute
+addresses for symbols.  Different compilation units can have different TOCs.
+Hence, register r2 must be properly initialized at the beginning of
+functions that access the TOC, and properly saved and restored around
+function calls.
+
+The general protocol is as follows:
+
+* When a function is called, its address (the address of the first
+  instruction of the function) must be in register r12.
+
+* Every function that makes TOC references starts with two
+  instructions that initialize r2 to a fixed offset from r12, offset
+  determined by the linker:
+```
+0:  addis 2, 12, (.TOC. - 0b)@ha
+    addi  2, 2,  (.TOC. - 0b)@l
+```
+
+* Register r2 is caller-save.  Hence, if the caller makes TOC
+  references, it must save r2 before the call and restore it after.
+  The reserved area of the current frame is typically used to save r2.
+
+For example, here is a call to a function pointer found at offset 0
+from register r3:
+```
+     std   2, 24(1)                 ; save r2
+     ld    12, 0(3)                 ; address of function in r12
+     mtctr 12
+     bctrl                          ; call the function
+     ld    2, 24(1)                 ; restore r2
+```
+
+If the caller does not make TOC references, the `std 2` and `ld 2` can
+be omitted.  Likewise for a tail call:
+```
+     ld    12, 0(3)                 ; address of function in r12
+     mtctr 12
+     bctr                           ; tail call the function
+```
+
+For calls to known functions `bl function_name`, a special protocol is
+implemented by the linker.  The object file contains the `bl`
+instruction followed by a `nop` instruction:
+```
+     bl function_name
+     nop
+```
+If the linker determines that `function_name` and the caller function
+share the same TOC, it rewrites the code as
+```
+     bl function_name+8             ; skip the prologue that initializes r2
+     nop
+```
+So, the callee does not recompute r2 from r12, it just uses the same
+r2 value as the caller.  For this reason, r12 need not be initialized
+by the caller.
+
+If `function_name` uses a different TOC than the caller function, the
+linker generates a branch-and-link to a veener function.  The veener
+function saves r2, recomputes r12, and branches to `function_name`.
+The `nop` after the branch-and-link becomes a reload of the caller's
+TOC pointer in r2.
+```
+     bl veener_function
+     ld 2, 24(1)             ; restore r2
+
+
+veener_function:
+     std 2, 24(1)            ; save caller's r2
+     <load r12 with absolute address of function_name>
+     mtctr r12
+     bctr
+```
+
+However, this doesn't quite work for tail calls.  Consider:
+
+- current function f1 calls f2 that has the same TOC;
+- f2 tailcalls f3 that has a different TOC.
+
+Because f1 and f2 have the same TOC, the linker inserted no code in f1
+to save and restore r2 around the call to f2.
+
+Because f2 tailcalls f3, r2 will not be restored to f2's TOC when f3 returns.
+
+So, we're back into f1, with the wrong TOC in r2.
+
+To avoid this problem, ocamlopt always reloads r2 after a direct call.
+One possibility would be to save r2 and reload r2 around the direct
+call, using the canonical slot in the current frame:
+```
+     std 2, 24(1)
+     bl function_name
+     nop
+     ld 2, 24(1)
+```
+However, this adds 2 instructions to every direct call.  We can avoid
+generating the store if the current function saves its r2 value
+somewhere on the stack at the beginning.  Then, after each direct or
+indirect call, we can reload r2 from there.
+
+What is "there"?  Which location is used for saving r2 at the
+beginning of the function?  A natural choice would be the word at SP + 24,
+i.e. the TOC-saving word for the current function.  However, SP can
+vary inside the function, e.g. to install and remove exception
+handlers, so additional r2 saves would need to be generated.
+
+The code currently generated by ocamlopt saves its r2 at SP + (N + 8)
+where N is the size of the stack frame, that is, at the word reserved
+by the callee for the caller to save the CR register, which
+ocamlopt-generated code does not use otherwise.  This avoids
+allocating one more word in the current frame just to save r2.

--- a/asmcomp/power/arch.ml
+++ b/asmcomp/power/arch.ml
@@ -23,14 +23,7 @@ type cmm_label = int
 
 (* Machine-specific command-line options *)
 
-let big_toc = ref true
-
-let command_line_options = [
-  "-flarge-toc", Arg.Set big_toc,
-     " Support TOC (table of contents) greater than 64 kbytes (default)";
-  "-fsmall-toc", Arg.Clear big_toc,
-     " TOC (table of contents) is limited to 64 kbytes"
-]
+let command_line_options = []
 
 (* Specific operations *)
 

--- a/asmcomp/power/arch.ml
+++ b/asmcomp/power/arch.ml
@@ -18,21 +18,6 @@
 
 open Format
 
-let ppc64 =
-  match Config.model with
-  | "ppc" -> false
-  | "ppc64" | "ppc64le" -> true
-  | _ -> assert false
-
-type abi = ELF32 | ELF64v1 | ELF64v2
-
-let abi =
-  match Config.model with
-  | "ppc" -> ELF32
-  | "ppc64" -> ELF64v1
-  | "ppc64le" -> ELF64v2
-  | _ -> assert false
-
 type cmm_label = int
 (* Do not introduce a dependency to Cmm *)
 
@@ -65,14 +50,8 @@ type addressing_mode =
 
 (* Sizes, endianness *)
 
-let big_endian =
-  match Config.model with
-  | "ppc" -> true
-  | "ppc64" -> true
-  | "ppc64le" -> false
-  | _ -> assert false
-
-let size_addr = if ppc64 then 8 else 4
+let big_endian = false (* ppc64le only *)
+let size_addr = 8
 let size_int = size_addr
 let size_float = 8
 

--- a/asmcomp/power/arch.mli
+++ b/asmcomp/power/arch.mli
@@ -16,12 +16,6 @@
 
 (* Specific operations for the PowerPC processor *)
 
-val ppc64 : bool
-
-type abi = ELF32 | ELF64v1 | ELF64v2
-
-val abi : abi
-
 type cmm_label = int
 (* Do not introduce a dependency to Cmm *)
 

--- a/asmcomp/power/arch.mli
+++ b/asmcomp/power/arch.mli
@@ -21,8 +21,6 @@ type cmm_label = int
 
 (* Machine-specific command-line options *)
 
-val big_toc : bool ref
-
 val command_line_options : (string * Arg.spec * string) list
 
 (* Specific operations *)

--- a/asmcomp/power/emit.mlp
+++ b/asmcomp/power/emit.mlp
@@ -49,7 +49,7 @@ let slot_offset env loc cls =
                   else n * size_float)
   | Incoming n ->
     (* Callee's [reserved_stack_space] is included in [frame_size].
-       To access incoming arguments, add caller's [reserverd_stack_space]. *)
+       To access incoming arguments, add caller's [reserved_stack_space]. *)
       frame_size env + reserved_stack_space + n
   | Outgoing n -> reserved_stack_space + n
   | Domainstate _ -> assert false  (* not a stack slot *)
@@ -58,7 +58,7 @@ let retaddr_offset env = frame_size env + 16
 
 let toc_save_offset env = frame_size env + 8
 
-let (trap_size, trap_handler_offset, trap_previous_offset) = (32, 40, 48)
+let trap_size = 16
 
 (* Output a label *)
 
@@ -208,18 +208,24 @@ let emit_load_store instr addressing_mode addr n arg =
 
 (* After a comparison, extract the result as 0 or 1 *)
 
-let emit_set_comp cmp res =
+let emit_extract_crbit bitnum negated res =
   `	mfcr	0\n`;
+  `	rlwinm	{emit_reg res}, 0, {emit_int(bitnum+1)}, 31, 31\n`;
+  if negated then
+    `	xori	{emit_reg res}, {emit_reg res}, 1\n`
+
+let emit_set_comp cmp res =
   let bitnum =
     match cmp with
       Ceq | Cne -> 2
     | Cgt | Cle -> 1
-    | Clt | Cge -> 0 in
-`	rlwinm	{emit_reg res}, 0, {emit_int(bitnum+1)}, 31, 31\n`;
-  begin match cmp with
-    Cne | Cle | Cge -> `	xori	{emit_reg res}, {emit_reg res}, 1\n`
-  | _ -> ()
-  end
+    | Clt | Cge -> 0
+  and negated =
+    match cmp with
+    | Cne | Cle | Cge -> true
+    | Ceq | Clt | Cgt -> false
+  in
+    emit_extract_crbit bitnum negated res
 
 let emit_float_comp cmp arg =
   `	fcmpu	0, {emit_reg arg.(0)}, {emit_reg arg.(1)}\n`;
@@ -227,20 +233,16 @@ let emit_float_comp cmp arg =
   let bitnum =
     match cmp with
     | CFeq | CFneq -> 2
-    | CFle | CFnle ->
-    `	cror	3, 0, 2\n`; (* lt or eq *)
-    3
+    | CFle | CFnle -> `	cror	3, 0, 2\n`; 3 (* lt or eq *)
     | CFgt | CFngt -> 1
-    | CFge | CFnge ->
-    `	cror	3, 1, 2\n`; (* gt or eq *)
-    3
+    | CFge | CFnge -> `	cror	3, 1, 2\n`; 3 (* gt or eq *)
     | CFlt | CFnlt -> 0
+  and negated =
+    match cmp with
+    | CFneq | CFngt | CFnge | CFnlt | CFnle -> true
+    | CFeq | CFgt | CFge | CFlt | CFle -> false
   in
-  match cmp with
-  | CFneq | CFngt | CFnge | CFnlt | CFnle ->
-    bitnum, true
-  | CFeq | CFgt | CFge | CFlt | CFle ->
-    bitnum, false
+    (bitnum, negated)
 
 (* Free the stack frame *)
 
@@ -406,9 +408,10 @@ module BR = Branch_relaxation.Make (struct
         if func = f.fun_name
         then 1
         else 6 + tocload_size()
-    | Lop(Iextcall { alloc = true; _ }) ->
-        2 + tocload_size()
-    | Lop(Iextcall { alloc = false; _}) -> 2
+    | Lop(Iextcall { alloc; stack_ofs; _}) ->
+        if stack_ofs > 0 then tocload_size() + 4
+        else if alloc then tocload_size() + 2
+        else 5
     | Lop(Istackoffset _) -> 1
     | Lop(Iload {memory_chunk; addressing_mode; _ }) ->
       if memory_chunk = Byte_signed
@@ -423,9 +426,7 @@ module BR = Branch_relaxation.Make (struct
     | Lop(Ispecific(Ipoll_far { return_label = None } )) -> 4
     | Lop(Iintop Imod) -> 3
     | Lop(Iintop(Icomp _)) -> 4
-    | Lop(Icompf _) ->
-        Misc.fatal_error "Icompf is not implemented for this platform";
-        (* 5 *)
+    | Lop(Icompf _) -> 5
     | Lop(Iintop _) -> 1
     | Lop(Iintop_imm(Icomp _, _)) -> 4
     | Lop(Iintop_imm _) -> 1
@@ -434,9 +435,7 @@ module BR = Branch_relaxation.Make (struct
     | Lop(Iintoffloat) -> 4
     | Lop(Iopaque) -> 0
     | Lop(Ispecific _) -> 1
-    | Lop (Idls_get) ->
-        (* Here to maintain build *)
-        assert false
+    | Lop (Idls_get) -> 1
     | Lreloadretaddr -> 2
     | Lreturn -> 2
     | Llabel _ -> 0
@@ -451,7 +450,8 @@ module BR = Branch_relaxation.Make (struct
     | Ladjust_trap_depth _ -> 0
     | Lpushtrap _ -> 4 + tocload_size()
     | Lpoptrap -> 2
-    | Lraise _ -> 6
+    | Lraise (Lambda.Raise_regular | Lambda.Raise_reraise) -> 2
+    | Lraise Lambda.Raise_notrace -> 5
 
   let relax_allocation ~num_bytes:bytes ~dbginfo =
     Lop (Ispecific (Ialloc_far { bytes; dbginfo }))
@@ -637,20 +637,34 @@ let emit_instr env i =
           emit_free_frame env;
           `	bctr\n`
         end
-    | Lop(Iextcall { func; alloc; }) ->
-        if not alloc then begin
-          emit_call func;
-          emit_call_nop()
-        end else begin
+    | Lop(Iextcall { func; alloc; stack_ofs }) ->
+        if stack_ofs > 0 then begin
+          emit_tocload emit_gpr 25 (TocSym func);
+         `	li	24, {emit_int stack_ofs}\n`;
+             (* size in bytes of stack area containing the arguments *)
+          emit_call "caml_c_call_stack_args";
+          record_frame env i.live (Dbg_other i.dbg);
+          `	nop\n`
+        end else if alloc then begin
           emit_tocload emit_gpr 25 (TocSym func);
           emit_call "caml_c_call";
           record_frame env i.live (Dbg_other i.dbg);
           `	nop\n`
+        end else begin
+          (* Save OCaml stack pointer in a callee-save register *)
+          `	mr	28, 1\n`;
+          (* Switch to C stack *)
+          let offset = Domainstate.(idx_of_field Domain_c_stack) * 8 in
+          `	ld	1, {emit_int offset}(30)\n`;
+          emit_call func;
+          emit_call_nop();
+          (* Switch back to OCaml stack *)
+          `	mr	1, 28\n`
         end
     | Lop(Istackoffset n) ->
         `	addi	1, 1, {emit_int (-n)}\n`;
         adjust_stack_offset env n
-    | Lop(Iload { memory_chunk; addressing_mode; _ }) ->
+    | Lop(Iload { memory_chunk; addressing_mode; is_atomic }) ->
         let loadinstr =
           match memory_chunk with
           | Byte_unsigned -> "lbz"
@@ -662,10 +676,17 @@ let emit_instr env i =
           | Word_int | Word_val -> "ld"
           | Single -> "lfs"
           | Double -> "lfd" in
+        if is_atomic then
+          `	sync\n`;
         emit_load_store loadinstr addressing_mode i.arg 0 i.res.(0);
+        if is_atomic then begin
+          `	cmpw	{emit_reg i.res.(0)}, {emit_reg i.res.(0)}\n`;
+          `	bne-	$+4\n`;
+          `	isync\n`
+        end;
         if memory_chunk = Byte_signed then
           `	extsb	{emit_reg i.res.(0)}, {emit_reg i.res.(0)}\n`
-    | Lop(Istore(chunk, addr, _)) ->
+    | Lop(Istore(chunk, addr, assignment)) ->
         let storeinstr =
           match chunk with
           | Byte_unsigned | Byte_signed -> "stb"
@@ -674,6 +695,12 @@ let emit_instr env i =
           | Word_int | Word_val -> "std"
           | Single -> "stfs"
           | Double -> "stfd" in
+        (* Non-initializing stores need a memory barrier to follow the
+           Multicore OCaml memory model.  Stores of size other than
+           Word_int and Word_val do not follow the memory model and therefore
+           do not need a barrier *)
+        if assignment && (chunk = Word_int || chunk = Word_val) then
+          `	lwsync\n`;
         emit_load_store storeinstr addr i.arg 1 i.arg.(0)
     | Lop(Ialloc { bytes; dbginfo }) ->
         emit_alloc env i bytes dbginfo false
@@ -699,20 +726,8 @@ let emit_instr env i =
             emit_set_comp c i.res.(0)
         end
     | Lop(Icompf cmp) ->
-        ignore cmp;
-        Misc.fatal_error "Icompf is not implemented for this platform";
-        (* smuenzel: the following code may be used to implement
-           Icompf when this platform is supported again post 5.0.
-           It will need to be tested.
-           {[
-             let res = i.res.(0) in
-             let bitnum, negated = emit_float_comp cmp i.arg in
-             `	mfcr	0\n`;
-             `	rlwinm	{emit_reg res}, 0, {emit_int(bitnum+1)}, 31, 31\n`;
-             if negated
-             then `  xori  {emit_reg res}, {emit_reg res}, 1\n`
-           ]}
-        *)
+        let (bitnum, negated) = emit_float_comp cmp i.arg in
+        emit_extract_crbit bitnum negated i.res.(0)
     | Lop(Iintop (Icheckbound)) ->
         if !Clflags.debug then
           record_frame env Reg.Set.empty (Dbg_other i.dbg);
@@ -760,8 +775,8 @@ let emit_instr env i =
         let instr = name_for_specific sop in
         `	{emit_string instr}	{emit_reg i.res.(0)}, {emit_reg i.arg.(0)}, {emit_reg i.arg.(1)}, {emit_reg i.arg.(2)}\n`
     | Lop (Idls_get) ->
-        (* Here to maintain build *)
-        assert false
+        let offset = Domainstate.(idx_of_field Domain_dls_root) * 8 in
+        `	ld {emit_reg i.res.(0)}, {emit_int offset}(30)\n`
     | Lreloadretaddr ->
         `	ld	11, {emit_int(retaddr_offset env)}(1)\n`;
         `	mtlr	11\n`
@@ -842,35 +857,29 @@ let emit_instr env i =
     | Lpushtrap { lbl_handler; } ->
         `	addi	1, 1, {emit_int (-trap_size)}\n`;
         adjust_stack_offset env trap_size;
-        `	std	29, {emit_int trap_previous_offset}(1)\n`;
+        `	std	29, {emit_int reserved_stack_space}(1)\n`;
         emit_tocload emit_gpr 29 (TocLabel lbl_handler);
-        `	std     29, {emit_int trap_handler_offset}(1)\n`;
-        `	mr	29, 1\n`
+        `	std     29, {emit_int (reserved_stack_space + 8)}(1)\n`;
+        `	addi	29, 1, {emit_int reserved_stack_space}\n`
     | Lpoptrap ->
-        `	ld	29, {emit_int trap_previous_offset}(1)\n`;
+        `	ld	29, {emit_int reserved_stack_space}(1)\n`;
         `	addi	1, 1, {emit_int trap_size}\n`;
         adjust_stack_offset env (-trap_size)
     | Lraise k ->
         begin match k with
         | Lambda.Raise_regular ->
-            `	li	0, 0\n`;
-            let backtrace_pos =
-              Domainstate.(idx_of_field Domain_backtrace_pos)
-            in
-            `	std	0, {emit_int (backtrace_pos * 8)}(30)\n`;
             emit_call "caml_raise_exn";
             record_frame env Reg.Set.empty (Dbg_raise i.dbg);
             emit_call_nop()
         | Lambda.Raise_reraise ->
-            emit_call "caml_raise_exn";
+            emit_call "caml_reraise_exn";
             record_frame env Reg.Set.empty (Dbg_raise i.dbg);
             emit_call_nop()
         | Lambda.Raise_notrace ->
-            `	ld	0, {emit_int trap_handler_offset}(29)\n`;
-            `	mr	1, 29\n`;
+            `	ld	0, 8(29)\n`;
+            `	addi	1, 29, {emit_int (trap_size - reserved_stack_space)}\n`;
             `	mtctr   0\n`;
-            `	ld	29, {emit_int trap_previous_offset}(1)\n`;
-            `	addi	1, 1, {emit_int trap_size}\n`;
+            `	ld	29, {emit_int (reserved_stack_space - trap_size)}(1)\n`;
             `	bctr\n`
         end
 
@@ -886,15 +895,48 @@ let rec emit_all env i =
 let fundecl fundecl =
   let env = mk_env fundecl in
   emit_string code_space;
+  `	.align	2\n`;
+  (* Dynamic stack checking *)
+  let stack_threshold_size = Config.stack_threshold * 8 in (* bytes *)
+  let { max_frame_size; contains_nontail_calls} =
+    preproc_stack_check
+      ~fun_body:fundecl.fun_body ~frame_size:(frame_size env) ~trap_size:32
+  in
+  let handle_overflow = ref None in
+  if contains_nontail_calls || max_frame_size >= stack_threshold_size then begin
+    let overflow = new_label () and ret = new_label () in
+    (* The return address is saved in a register not used for param passing *)
+    `{emit_label overflow}:	mflr	28\n`;
+    `	li	12, {emit_int (Config.stack_threshold + max_frame_size / 8)}\n`;
+    emit_call "caml_call_realloc_stack";
+    emit_call_nop ();
+    `	mtlr	28\n`;
+    `	b	{emit_label ret}\n`;
+    handle_overflow := Some(overflow, ret)
+  end;
+  (* Function entry point *)
   `	.globl	{emit_symbol fundecl.fun_name}\n`;
   `	.type	{emit_symbol fundecl.fun_name}, @function\n`;
-  `	.align	2\n`;
   `{emit_symbol fundecl.fun_name}:\n`;
   `0:	addis	2, 12, (.TOC. - 0b)@ha\n`;
   `	addi	2, 2, (.TOC. - 0b)@l\n`;
   `	.localentry {emit_symbol fundecl.fun_name}, . - 0b\n`;
   emit_debug_info fundecl.fun_dbg;
   cfi_startproc();
+  (* Dynamic stack checking *)
+  begin match !handle_overflow with
+  | None -> ()
+  | Some(overflow, ret) ->
+      let threshold_offset =
+        Domainstate.stack_ctx_words * 8 + stack_threshold_size in
+      let f = max_frame_size + threshold_offset in
+      let offset = Domainstate.(idx_of_field Domain_current_stack) * 8 in
+      `	ld	11, {emit_int offset}(30)\n`;
+      `	addi	11, 11, {emit_int f}\n`;
+      `	cmpld	1, 11\n`;
+      `	ble-	{emit_label overflow}\n`;
+      `{emit_label ret}:\n`
+  end;
   (* On this target, there is at most one "out of line" code block per
      function: a single "call GC" point.  It comes immediately after the
      function's body. *)

--- a/asmcomp/power/emit.mlp
+++ b/asmcomp/power/emit.mlp
@@ -475,12 +475,12 @@ let emit_alloc env i bytes dbginfo far =
   `	addi    31, 31, {emit_int(-bytes)}\n`;
   `	cmpld	31, 0\n`;
   if not far then begin
-    `	bltl	{emit_label env.call_gc_label}\n`;
+    `	bltl-	{emit_label env.call_gc_label}\n`;
     record_frame env i.live (Dbg_alloc dbginfo);
     `	addi	{emit_reg i.res.(0)}, 31, {emit_int size_addr}\n`
   end else begin
     let lbl = new_label() in
-    `	bge	{emit_label lbl}\n`;
+    `	bge+	{emit_label lbl}\n`;
     `	bl	{emit_label env.call_gc_label}\n`;
     record_frame env i.live (Dbg_alloc dbginfo);
     `{emit_label lbl}:	addi	{emit_reg i.res.(0)}, 31, {emit_int size_addr}\n`
@@ -495,19 +495,19 @@ let emit_poll env i return_label far =
     begin match return_label with
     | None ->
     begin
-      `	bltl	{emit_label env.call_gc_label}\n`;
+      `	bltl-	{emit_label env.call_gc_label}\n`;
       record_frame env i.live (Dbg_alloc [])
     end
     | Some return_label ->
       begin
-        ` bltl  {emit_label env.call_gc_label}\n`;
+        ` bltl-  {emit_label env.call_gc_label}\n`;
         record_frame env i.live (Dbg_alloc []);
         ` b   {emit_label return_label}\n`
       end
     end;
   end else begin
     let lbl = new_label () in
-    `	bge	{emit_label lbl}\n`;
+    `	bge+	{emit_label lbl}\n`;
     `	bl	{emit_label env.call_gc_label}\n`;
     record_frame env i.live (Dbg_alloc []);
     ` {emit_label lbl}:	\n`;

--- a/asmcomp/power/emit.mlp
+++ b/asmcomp/power/emit.mlp
@@ -26,20 +26,15 @@ open Emitenv
 
 (* Reserved space at bottom of stack *)
 
-let reserved_stack_space =
-  match abi with
-  | ELF32 -> 0
-  | ELF64v1 -> 48
-  | ELF64v2 -> 32
+let reserved_stack_space = 32
 
 (* Layout of the stack.  The stack is kept 16-aligned. *)
 
 let initial_stack_offset f =
-  reserved_stack_space +
+  reserved_stack_space +                    (* Including the return address *)
   size_int * f.fun_num_stack_slots.(0) +    (* Local int variables *)
-  size_float * f.fun_num_stack_slots.(1) +  (* Local float variables *)
-  (if f.fun_contains_calls && abi = ELF32 then size_int else 0)
-                                        (* The return address *)
+  size_float * f.fun_num_stack_slots.(1)    (* Local float variables *)
+
 let frame_size env =
   let size =
     env.stack_offset +                     (* Trap frame, outgoing parameters *)
@@ -59,21 +54,11 @@ let slot_offset env loc cls =
   | Outgoing n -> reserved_stack_space + n
   | Domainstate _ -> assert false  (* not a stack slot *)
 
-let retaddr_offset env =
-  match abi with
-  | ELF32 -> frame_size env - size_addr
-  | ELF64v1 | ELF64v2 -> frame_size env + 16
+let retaddr_offset env = frame_size env + 16
 
-let toc_save_offset env =
-  match abi with
-  | ELF32 -> assert false
-  | ELF64v1 | ELF64v2 -> frame_size env + 8
+let toc_save_offset env = frame_size env + 8
 
-let (trap_size, trap_handler_offset, trap_previous_offset) =
-  match abi with
-  | ELF32 -> (16, 0, 4)
-  | ELF64v1 -> (32, 56, 64)
-  | ELF64v2 -> (32, 40, 48)
+let (trap_size, trap_handler_offset, trap_previous_offset) = (32, 40, 48)
 
 (* Output a label *)
 
@@ -87,12 +72,6 @@ let emit_label lbl =
 let code_space =
   "	.section \".text\"\n"
 
-let function_descr_space =
-  match abi with
-  | ELF32 -> code_space
-  | ELF64v1 -> "	.section \".opd\",\"aw\"\n"
-  | ELF64v2 -> code_space
-
 let data_space =
   "	.section \".data\"\n"
 
@@ -101,18 +80,6 @@ let rodata_space =
 
 let toc_space =
   " .section \".toc\",\"aw\"\n"
-
-(* Names of instructions that differ in 32 and 64-bit modes *)
-
-let lg = if ppc64 then "ld" else "lwz"
-let stg = if ppc64 then "std" else "stw"
-let lwa = if ppc64 then "lwa" else "lwz"
-let cmpg = if ppc64 then "cmpd" else "cmpw"
-let cmplg = if ppc64 then "cmpld" else "cmplw"
-let datag = if ppc64 then ".quad" else ".long"
-let mullg = if ppc64 then "mulld" else "mullw"
-let divg = if ppc64 then "divd" else "divw"
-let tglle = if ppc64 then "tdlle" else "twlle"
 
 (* Output a processor register *)
 
@@ -136,13 +103,6 @@ let emit_stack env r =
       let ofs = slot_offset env s (register_class r) in
       `{emit_int ofs}(1)`
   | _ -> Misc.fatal_error "Emit.emit_stack"
-
-(* Output the name of a symbol plus an optional offset *)
-
-let emit_symbol_offset (s, d) =
-  emit_symbol s;
-  if d > 0 then `+`;
-  if d <> 0 then emit_int d
 
 (* Split a 32-bit integer constants in two 16-bit halves *)
 
@@ -215,14 +175,6 @@ let emit_tocload emit_dest dest entry =
     `	ld	{emit_dest dest}, {emit_label lbl}@toc(2) # {emit_tocentry entry}\n`
   end
 
-(* Output a "upper 16 bits" or "lower 16 bits" operator. *)
-
-let emit_upper emit_fun arg =
-  emit_fun arg; emit_string "@ha"
-
-let emit_lower emit_fun arg =
-  emit_fun arg; emit_string "@l"
-
 (* Output a load or store operation *)
 
 let valid_offset instr ofs =
@@ -231,21 +183,15 @@ let valid_offset instr ofs =
 let emit_load_store instr addressing_mode addr n arg =
   match addressing_mode with
   | Ibased(s, d) ->
-      begin match abi with
-      | ELF32 ->
-        `	addis	11, 0, {emit_upper emit_symbol_offset (s,d)}\n`;
-        `	{emit_string instr}	{emit_reg arg}, {emit_lower emit_symbol_offset (s,d)}(11)\n`
-      | ELF64v1 | ELF64v2 ->
-        emit_tocload emit_gpr 11 (TocSym s);
-        let (lo, hi) = low_high_s d in
-        if hi <> 0 then
-          `	addis	11, 11, {emit_int hi}\n`;
-        if valid_offset instr lo then
-          `	{emit_string instr}	{emit_reg arg}, {emit_int lo}(11)\n`
-        else begin
-          `	li	0, {emit_int lo}\n`;
-          `	{emit_string instr}x	{emit_reg arg}, 11, 0\n`
-        end
+      emit_tocload emit_gpr 11 (TocSym s);
+      let (lo, hi) = low_high_s d in
+      if hi <> 0 then
+        `	addis	11, 11, {emit_int hi}\n`;
+      if valid_offset instr lo then
+        `	{emit_string instr}	{emit_reg arg}, {emit_int lo}(11)\n`
+      else begin
+        `	li	0, {emit_int lo}\n`;
+        `	{emit_string instr}x	{emit_reg arg}, 11, 0\n`
       end
   | Iindexed ofs ->
       if is_immediate ofs && valid_offset instr ofs then
@@ -306,18 +252,12 @@ let emit_free_frame env =
 (* Emit a "bl" instruction to a given symbol *)
 
 let emit_call s =
-  match abi with
-  | ELF32 when !Clflags.dlcode || !Clflags.pic_code ->
-    `	bl	{emit_symbol s}@plt\n`
-  | _ ->
-    `	bl	{emit_symbol s}\n`
+  `	bl	{emit_symbol s}\n`
 
 (* Add a nop after a "bl" call for ELF64 *)
 
 let emit_call_nop () =
-  match abi with
-  | ELF32 -> ()
-  | ELF64v1 | ELF64v2 -> `	nop	\n`
+  `	nop	\n`
 
 (* Reload the TOC register r2 from the value saved on the stack *)
 
@@ -357,22 +297,22 @@ let branch_for_comparison = function
   | Cge -> "bge" | Clt -> "blt"
 
 let name_for_int_comparison = function
-    Isigned cmp -> (cmpg, branch_for_comparison cmp)
-  | Iunsigned cmp -> (cmplg, branch_for_comparison cmp)
+    Isigned cmp -> ("cmpd", branch_for_comparison cmp)
+  | Iunsigned cmp -> ("cmpld", branch_for_comparison cmp)
 
 (* Names for various instructions *)
 
 let name_for_intop = function
     Iadd  -> "add"
-  | Imul  -> if ppc64 then "mulld" else "mullw"
-  | Imulh -> if ppc64 then "mulhd" else "mulhw"
-  | Idiv  -> if ppc64 then "divd" else "divw"
+  | Imul  -> "mulld"
+  | Imulh -> "mulhd"
+  | Idiv  -> "divd"
   | Iand  -> "and"
   | Ior   -> "or"
   | Ixor  -> "xor"
-  | Ilsl  -> if ppc64 then "sld" else "slw"
-  | Ilsr  -> if ppc64 then "srd" else "srw"
-  | Iasr  -> if ppc64 then "srad" else "sraw"
+  | Ilsl  -> "sld"
+  | Ilsr  -> "srd"
+  | Iasr  -> "srad"
   | _ -> Misc.fatal_error "Emit.Intop"
 
 let name_for_intop_imm = function
@@ -381,9 +321,9 @@ let name_for_intop_imm = function
   | Iand -> "andi."
   | Ior  -> "ori"
   | Ixor -> "xori"
-  | Ilsl -> if ppc64 then "sldi" else "slwi"
-  | Ilsr -> if ppc64 then "srdi" else "srwi"
-  | Iasr -> if ppc64 then "sradi" else "srawi"
+  | Ilsl -> "sldi"
+  | Ilsr -> "srdi"
+  | Iasr -> "sradi"
   | _ -> Misc.fatal_error "Emit.Intop_imm"
 
 let name_for_floatop1 = function
@@ -429,36 +369,20 @@ module BR = Branch_relaxation.Make (struct
 
   let offset_pc_at_branch = 1
 
-  let size =
-    match abi with
-    | ELF32 -> (fun a _ _ -> a)
-    | ELF64v1 -> (fun _ b _ -> b)
-    | ELF64v2 -> (fun _ _ c -> c)
-
-  let profiling_prologue_size () =
-    match abi with
-    | ELF32 -> 5
-    | ELF64v1 | ELF64v2 -> 6
+  let profiling_prologue_size = 6
 
   let prologue_size f =
-    profiling_prologue_size ()
+    profiling_prologue_size
       + (if initial_stack_offset f > 0 then 1 else 0)
-      + (if f.fun_contains_calls then
-           2 +
-             match abi with
-             | ELF32 -> 0
-             | ELF64v1 | ELF64v2 -> 1
-         else 0)
+      + (if f.fun_contains_calls then 3 else 0)
 
   let tocload_size() =
     if !big_toc || !Clflags.for_package <> None then 2 else 1
 
   let load_store_size = function
     | Ibased(_s, d) ->
-        if abi = ELF32 then 2 else begin
-          let (_lo, hi) = low_high_s d in
-          tocload_size() + (if hi = 0 then 1 else 2)
-        end
+        let (_lo, hi) = low_high_s d in
+        tocload_size() + (if hi = 0 then 1 else 2)
     | Iindexed ofs -> if is_immediate ofs then 1 else 3
     | Iindexed2 -> 1
 
@@ -473,18 +397,18 @@ module BR = Branch_relaxation.Make (struct
       else if (let (_lo, hi) = native_low_high_u n in
                hi >= -0x8000 && hi <= 0x7FFF) then 2
       else tocload_size()
-    | Lop(Iconst_float _) -> if abi = ELF32 then 2 else tocload_size()
-    | Lop(Iconst_symbol _) -> if abi = ELF32 then 2 else tocload_size()
-    | Lop(Icall_ind) -> size 2 5 4
-    | Lop(Icall_imm _) -> size 1 3 3
-    | Lop(Itailcall_ind) -> size 5 7 6
+    | Lop(Iconst_float _) -> tocload_size()
+    | Lop(Iconst_symbol _) -> tocload_size()
+    | Lop(Icall_ind) -> 4
+    | Lop(Icall_imm _) -> 3
+    | Lop(Itailcall_ind) -> 6
     | Lop(Itailcall_imm { func; _ }) ->
         if func = f.fun_name
         then 1
-        else size 4 (7 + tocload_size()) (6 + tocload_size())
+        else 6 + tocload_size()
     | Lop(Iextcall { alloc = true; _ }) ->
-      size 3 (2 + tocload_size()) (2 + tocload_size())
-    | Lop(Iextcall { alloc = false; _}) -> size 1 2 2
+        2 + tocload_size()
+    | Lop(Iextcall { alloc = false; _}) -> 2
     | Lop(Istackoffset _) -> 1
     | Lop(Iload {memory_chunk; addressing_mode; _ }) ->
       if memory_chunk = Byte_signed
@@ -522,10 +446,10 @@ module BR = Branch_relaxation.Make (struct
       1 + (if lbl0 = None then 0 else 1)
         + (if lbl1 = None then 0 else 1)
         + (if lbl2 = None then 0 else 1)
-    | Lswitch _ -> size 7 (5 + tocload_size()) (5 + tocload_size())
-    | Lentertrap -> size 0 (tocload_size()) (tocload_size())
+    | Lswitch _ -> 5 + tocload_size()
+    | Lentertrap -> tocload_size()
     | Ladjust_trap_depth _ -> 0
-    | Lpushtrap _ -> size 5 (4 + tocload_size()) (4 + tocload_size())
+    | Lpushtrap _ -> 4 + tocload_size()
     | Lpoptrap -> 2
     | Lraise _ -> 6
 
@@ -547,9 +471,9 @@ end)
 let emit_alloc env i bytes dbginfo far =
   if env.call_gc_label = 0 then env.call_gc_label <- new_label ();
   let offset = Domainstate.(idx_of_field Domain_young_limit) * 8 in
-  `	{emit_string lg}	0, {emit_int offset}(30)\n`;
+  `	ld	0, {emit_int offset}(30)\n`;
   `	addi    31, 31, {emit_int(-bytes)}\n`;
-  `	{emit_string cmplg}	31, 0\n`;
+  `	cmpld	31, 0\n`;
   if not far then begin
     `	bltl	{emit_label env.call_gc_label}\n`;
     record_frame env i.live (Dbg_alloc dbginfo);
@@ -565,8 +489,8 @@ let emit_alloc env i bytes dbginfo far =
 let emit_poll env i return_label far =
   if env.call_gc_label = 0 then env.call_gc_label <- new_label ();
   let offset = Domainstate.(idx_of_field Domain_young_limit) * 8 in
-  `	{emit_string lg}	0, {emit_int offset}(30)\n`;
-  `	{emit_string cmplg}	31, 0\n`;
+  `	ld	0, {emit_int offset}(30)\n`;
+  `	cmpld	31, 0\n`;
   if not far then begin
     begin match return_label with
     | None ->
@@ -608,12 +532,9 @@ let emit_instr env i =
       if env.f.fun_contains_calls then begin
         let ra = retaddr_offset env in
         `	mflr	0\n`;
-        `	{emit_string stg}	0, {emit_int ra}(1)\n`;
+        `	std	0, {emit_int ra}(1)\n`;
         cfi_offset ~reg: 65 (* LR *) ~offset: (ra - n);
-        match abi with
-        | ELF32 -> ()
-        | ELF64v1 | ELF64v2 ->
-          `	std	2, {emit_int(toc_save_offset env)}(1)\n`
+        `	std	2, {emit_int(toc_save_offset env)}(1)\n`
       end
     | Lop(Imove | Ispill | Ireload) ->
         let src = i.arg.(0) and dst = i.res.(0) in
@@ -624,11 +545,11 @@ let emit_instr env i =
             | {loc = Reg _; typ = Float}, {loc = Reg _; typ = Float} ->
                 `	fmr	{emit_reg dst}, {emit_reg src}\n`
             | {loc = Reg _; typ = (Val | Int | Addr)}, {loc = Stack _} ->
-                `	{emit_string stg}	{emit_reg src}, {emit_stack env dst}\n`
+                `	std	{emit_reg src}, {emit_stack env dst}\n`
             | {loc = Reg _; typ = Float}, {loc = Stack _} ->
                 `	stfd	{emit_reg src}, {emit_stack env dst}\n`
             | {loc = Stack _; typ = (Val | Int | Addr)}, {loc = Reg _} ->
-                `	{emit_string lg}	{emit_reg dst}, {emit_stack env src}\n`
+                `	ld	{emit_reg dst}, {emit_stack env src}\n`
             | {loc = Stack _; typ = Float}, {loc = Reg _} ->
                 `	lfd	{emit_reg dst}, {emit_stack env src}\n`
             | (_, _) ->
@@ -653,62 +574,26 @@ let emit_instr env i =
           if lo <> 0 then
           `	ori	{emit_reg i.res.(0)}, {emit_reg i.res.(0)}, {emit_int lo}\n`
         end else begin
-          match abi with
-          | ELF32 -> assert false
-          | ELF64v1 | ELF64v2 ->
-              emit_tocload emit_reg i.res.(0) (TocInt n)
+          emit_tocload emit_reg i.res.(0) (TocInt n)
         end end end
     | Lop(Iconst_float f) ->
-        begin match abi with
-        | ELF32 ->
-          let lbl = new_label() in
-          env.float_literals <- { fl=f; lbl } :: env.float_literals;
-          `	addis	11, 0, {emit_upper emit_label lbl}\n`;
-          `	lfd	{emit_reg i.res.(0)}, {emit_lower emit_label lbl}(11)\n`
-        | ELF64v1 | ELF64v2 ->
-          let entry = TocFloat f in
-          let lbl = label_for_tocref entry in
-          if !big_toc || !Clflags.for_package <> None then begin
-            `	addis	11, 2, {emit_label lbl}@toc@ha\n`;
-            `	lfd	{emit_reg i.res.(0)}, {emit_label lbl}@toc@l(11) # {emit_tocentry entry}\n`
-          end else begin
-            `	lfd	{emit_reg i.res.(0)}, {emit_label lbl}@toc(2) # {emit_tocentry entry}\n`
-          end
+        let entry = TocFloat f in
+        let lbl = label_for_tocref entry in
+        if !big_toc || !Clflags.for_package <> None then begin
+          `	addis	11, 2, {emit_label lbl}@toc@ha\n`;
+          `	lfd	{emit_reg i.res.(0)}, {emit_label lbl}@toc@l(11) # {emit_tocentry entry}\n`
+        end else begin
+          `	lfd	{emit_reg i.res.(0)}, {emit_label lbl}@toc(2) # {emit_tocentry entry}\n`
         end
     | Lop(Iconst_symbol s) ->
-        begin match abi with
-        | ELF32 ->
-          `	addis	{emit_reg i.res.(0)}, 0, {emit_upper emit_symbol s}\n`;
-          `	addi	{emit_reg i.res.(0)}, {emit_reg i.res.(0)}, {emit_lower emit_symbol s}\n`
-        | ELF64v1 | ELF64v2 ->
-          emit_tocload emit_reg i.res.(0) (TocSym s)
-        end
+        emit_tocload emit_reg i.res.(0) (TocSym s)
     | Lop(Icall_ind) ->
-        begin match abi with
-        | ELF32 ->
-          `	mtctr	{emit_reg i.arg.(0)}\n`;
-          `	bctrl\n`;
-          record_frame env i.live (Dbg_other i.dbg)
-        | ELF64v1 ->
-          `	ld	0, 0({emit_reg i.arg.(0)})\n`;  (* code pointer *)
-          `	mtctr	0\n`;
-          `	ld	2, 8({emit_reg i.arg.(0)})\n`;  (* TOC for callee *)
-          `	bctrl\n`;
-          record_frame env i.live (Dbg_other i.dbg);
-          emit_reload_toc env
-        | ELF64v2 ->
-          `	mtctr	{emit_reg i.arg.(0)}\n`;
-          `	mr	12, {emit_reg i.arg.(0)}\n`;  (* addr of fn in r12 *)
-          `	bctrl\n`;
-          record_frame env i.live (Dbg_other i.dbg);
-          emit_reload_toc env
-        end
+        `	mtctr	{emit_reg i.arg.(0)}\n`;
+        `	mr	12, {emit_reg i.arg.(0)}\n`;  (* addr of fn in r12 *)
+        `	bctrl\n`;
+        record_frame env i.live (Dbg_other i.dbg);
+        emit_reload_toc env
     | Lop(Icall_imm { func; }) ->
-        begin match abi with
-        | ELF32 ->
-            emit_call func;
-            record_frame env i.live (Dbg_other i.dbg)
-        | ELF64v1 | ELF64v2 ->
         (* For PPC64, we cannot just emit a "bl s; nop" sequence, because
            of the following scenario:
               - current function f1 calls f2 that has the same TOC
@@ -726,25 +611,15 @@ let emit_instr env i =
                 by the linker, but this is harmless.
                 Cost: 3 instructions if same TOC, 7 if different TOC.
            Let's try option 2. *)
-            emit_call func;
-            record_frame env i.live (Dbg_other i.dbg);
-            `	nop\n`;
-            emit_reload_toc env
-        end
+        emit_call func;
+        record_frame env i.live (Dbg_other i.dbg);
+        `	nop\n`;
+        emit_reload_toc env
     | Lop(Itailcall_ind) ->
-        begin match abi with
-        | ELF32 ->
-          `	mtctr	{emit_reg i.arg.(0)}\n`
-        | ELF64v1 ->
-          `	ld	0, 0({emit_reg i.arg.(0)})\n`;  (* code pointer *)
-          `	mtctr	0\n`;
-          `	ld	2, 8({emit_reg i.arg.(0)})\n`   (* TOC for callee *)
-        | ELF64v2 ->
-          `	mtctr	{emit_reg i.arg.(0)}\n`;
-          `	mr	12, {emit_reg i.arg.(0)}\n`   (* addr of fn in r12 *)
-        end;
+        `	mtctr	{emit_reg i.arg.(0)}\n`;
+        `	mr	12, {emit_reg i.arg.(0)}\n`;   (* addr of fn in r12 *)
         if env.f.fun_contains_calls then begin
-          `	{emit_string lg}	11, {emit_int(retaddr_offset env)}(1)\n`;
+          `	ld	11, {emit_int(retaddr_offset env)}(1)\n`;
           `	mtlr	11\n`
         end;
         emit_free_frame env;
@@ -753,46 +628,24 @@ let emit_instr env i =
         if func = env.f.fun_name then
           `	b	{emit_label env.f.fun_tailrec_entry_point_label}\n`
         else begin
-          begin match abi with
-          | ELF32 ->
-            ()
-          | ELF64v1 ->
-            emit_tocload emit_gpr 11 (TocSym func);
-            `	ld	0, 0(11)\n`;  (* code pointer *)
-            `	mtctr	0\n`;
-            `	ld	2, 8(11)\n`   (* TOC for callee *)
-          | ELF64v2 ->
-            emit_tocload emit_gpr 12 (TocSym func); (* addr of fn must be in r12 *)
-            `	mtctr	12\n`
-          end;
+          emit_tocload emit_gpr 12 (TocSym func); (* addr of fn must be in r12 *)
+          `	mtctr	12\n`;
           if env.f.fun_contains_calls then begin
-            `	{emit_string lg}	11, {emit_int(retaddr_offset env)}(1)\n`;
+            `	ld	11, {emit_int(retaddr_offset env)}(1)\n`;
             `	mtlr	11\n`
           end;
           emit_free_frame env;
-          begin match abi with
-          | ELF32 ->
-            `	b	{emit_symbol func}\n`
-          | ELF64v1 | ELF64v2 ->
-            `	bctr\n`
-          end
+          `	bctr\n`
         end
     | Lop(Iextcall { func; alloc; }) ->
         if not alloc then begin
           emit_call func;
           emit_call_nop()
         end else begin
-          match abi with
-          | ELF32 ->
-            `	addis	25, 0, {emit_upper emit_symbol func}\n`;
-            `	addi	25, 25, {emit_lower emit_symbol func}\n`;
-            emit_call "caml_c_call";
-            record_frame env i.live (Dbg_other i.dbg)
-          | ELF64v1 | ELF64v2 ->
-            emit_tocload emit_gpr 25 (TocSym func);
-            emit_call "caml_c_call";
-            record_frame env i.live (Dbg_other i.dbg);
-            `	nop\n`
+          emit_tocload emit_gpr 25 (TocSym func);
+          emit_call "caml_c_call";
+          record_frame env i.live (Dbg_other i.dbg);
+          `	nop\n`
         end
     | Lop(Istackoffset n) ->
         `	addi	1, 1, {emit_int (-n)}\n`;
@@ -805,8 +658,8 @@ let emit_instr env i =
           | Sixteen_unsigned -> "lhz"
           | Sixteen_signed -> "lha"
           | Thirtytwo_unsigned -> "lwz"
-          | Thirtytwo_signed -> if ppc64 then "lwa" else "lwz"
-          | Word_int | Word_val -> lg
+          | Thirtytwo_signed -> "lwa"
+          | Word_int | Word_val -> "ld"
           | Single -> "lfs"
           | Double -> "lfd" in
         emit_load_store loadinstr addressing_mode i.arg 0 i.res.(0);
@@ -818,7 +671,7 @@ let emit_instr env i =
           | Byte_unsigned | Byte_signed -> "stb"
           | Sixteen_unsigned | Sixteen_signed -> "sth"
           | Thirtytwo_unsigned | Thirtytwo_signed -> "stw"
-          | Word_int | Word_val -> stg
+          | Word_int | Word_val -> "std"
           | Single -> "stfs"
           | Double -> "stfd" in
         emit_load_store storeinstr addr i.arg 1 i.arg.(0)
@@ -833,16 +686,16 @@ let emit_instr env i =
     | Lop(Iintop Isub) ->               (* subfc has swapped arguments *)
         `	subfc	{emit_reg i.res.(0)}, {emit_reg i.arg.(1)}, {emit_reg i.arg.(0)}\n`
     | Lop(Iintop Imod) ->
-        `	{emit_string divg}	0, {emit_reg i.arg.(0)}, {emit_reg i.arg.(1)}\n`;
-        `	{emit_string mullg}	0, 0, {emit_reg i.arg.(1)}\n`;
+        `	divd	0, {emit_reg i.arg.(0)}, {emit_reg i.arg.(1)}\n`;
+        `	mulld	0, 0, {emit_reg i.arg.(1)}\n`;
         `	subfc	{emit_reg i.res.(0)}, 0, {emit_reg i.arg.(0)}\n`
     | Lop(Iintop(Icomp cmp)) ->
         begin match cmp with
           Isigned c ->
-            `	{emit_string cmpg}	{emit_reg i.arg.(0)}, {emit_reg i.arg.(1)}\n`;
+            `	cmpd	{emit_reg i.arg.(0)}, {emit_reg i.arg.(1)}\n`;
             emit_set_comp c i.res.(0)
         | Iunsigned c ->
-            `	{emit_string cmplg}	{emit_reg i.arg.(0)}, {emit_reg i.arg.(1)}\n`;
+            `	cmpld	{emit_reg i.arg.(0)}, {emit_reg i.arg.(1)}\n`;
             emit_set_comp c i.res.(0)
         end
     | Lop(Icompf cmp) ->
@@ -863,7 +716,7 @@ let emit_instr env i =
     | Lop(Iintop (Icheckbound)) ->
         if !Clflags.debug then
           record_frame env Reg.Set.empty (Dbg_other i.dbg);
-        `	{emit_string tglle}   {emit_reg i.arg.(0)}, {emit_reg i.arg.(1)}\n`
+        `	tdlle   {emit_reg i.arg.(0)}, {emit_reg i.arg.(1)}\n`
     | Lop(Iintop op) ->
         let instr = name_for_intop op in
         `	{emit_string instr}	{emit_reg i.res.(0)}, {emit_reg i.arg.(0)}, {emit_reg i.arg.(1)}\n`
@@ -872,16 +725,16 @@ let emit_instr env i =
     | Lop(Iintop_imm(Icomp cmp, n)) ->
         begin match cmp with
           Isigned c ->
-            `	{emit_string cmpg}i	{emit_reg i.arg.(0)}, {emit_int n}\n`;
+            `	cmpdi	{emit_reg i.arg.(0)}, {emit_int n}\n`;
             emit_set_comp c i.res.(0)
         | Iunsigned c ->
-            `	{emit_string cmplg}i	{emit_reg i.arg.(0)}, {emit_int n}\n`;
+            `	cmpldi	{emit_reg i.arg.(0)}, {emit_int n}\n`;
             emit_set_comp c i.res.(0)
         end
     | Lop(Iintop_imm(Icheckbound, n)) ->
         if !Clflags.debug then
           record_frame env Reg.Set.empty (Dbg_other i.dbg);
-        `	{emit_string tglle}i   {emit_reg i.arg.(0)}, {emit_int n}\n`
+        `	tdllei	{emit_reg i.arg.(0)}, {emit_int n}\n`
     | Lop(Iintop_imm(op, n)) ->
         let instr = name_for_intop_imm op in
         `	{emit_string instr}	{emit_reg i.res.(0)}, {emit_reg i.arg.(0)}, {emit_int n}\n`
@@ -892,36 +745,15 @@ let emit_instr env i =
         let instr = name_for_floatop2 op in
         `	{emit_string instr}	{emit_reg i.res.(0)}, {emit_reg i.arg.(0)}, {emit_reg i.arg.(1)}\n`
     | Lop(Ifloatofint) ->
-        if ppc64 then begin
-          (* Can use protected zone (288 bytes below r1 *)
-          `	std	{emit_reg i.arg.(0)}, -16(1)\n`;
-          `	lfd	{emit_reg i.res.(0)}, -16(1)\n`;
-          `	fcfid	{emit_reg i.res.(0)}, {emit_reg i.res.(0)}\n`
-        end else begin
-          let lbl = new_label() in
-          env.float_literals <- {fl=0x4330000080000000L; lbl} :: env.float_literals;
-          `	addis	11, 0, {emit_upper emit_label lbl}\n`;
-          `	lfd	0, {emit_lower emit_label lbl}(11)\n`;
-          `	lis	0, 0x4330\n`;
-          `	stwu	0, -16(1)\n`;
-          `	xoris	0, {emit_reg i.arg.(0)}, 0x8000\n`;
-          `	stw	0, 4(1)\n`;
-          `	lfd	{emit_reg i.res.(0)}, 0(1)\n`;
-          `	addi	1, 1, 16\n`;
-          `	fsub	{emit_reg i.res.(0)}, {emit_reg i.res.(0)}, 0\n`
-        end
+        (* Can use protected zone (288 bytes below r1 *)
+        `	std	{emit_reg i.arg.(0)}, -16(1)\n`;
+        `	lfd	{emit_reg i.res.(0)}, -16(1)\n`;
+        `	fcfid	{emit_reg i.res.(0)}, {emit_reg i.res.(0)}\n`
     | Lop(Iintoffloat) ->
-        if ppc64 then begin
-          (* Can use protected zone (288 bytes below r1 *)
-          `	fctidz	0, {emit_reg i.arg.(0)}\n`;
-          `	stfd	0, -16(1)\n`;
-          `	ld	{emit_reg i.res.(0)}, -16(1)\n`
-        end else begin
-          `	fctiwz	0, {emit_reg i.arg.(0)}\n`;
-          `	stfdu	0, -16(1)\n`;
-          `	lwz	{emit_reg i.res.(0)}, 4(1)\n`;
-          `	addi	1, 1, 16\n`
-        end
+        (* Can use protected zone (288 bytes below r1 *)
+        `	fctidz	0, {emit_reg i.arg.(0)}\n`;
+        `	stfd	0, -16(1)\n`;
+        `	ld	{emit_reg i.res.(0)}, -16(1)\n`
     | Lop(Iopaque) ->
         assert (i.arg.(0).loc = i.res.(0).loc)
     | Lop(Ispecific sop) ->
@@ -931,7 +763,7 @@ let emit_instr env i =
         (* Here to maintain build *)
         assert false
     | Lreloadretaddr ->
-        `	{emit_string lg}	11, {emit_int(retaddr_offset env)}(1)\n`;
+        `	ld	11, {emit_int(retaddr_offset env)}(1)\n`;
         `	mtlr	11\n`
     | Lreturn ->
         emit_free_frame env;
@@ -943,10 +775,10 @@ let emit_instr env i =
     | Lcondbranch(tst, lbl) ->
         begin match tst with
           Itruetest ->
-            `	{emit_string cmpg}i	{emit_reg i.arg.(0)}, 0\n`;
+            `	cmpdi	{emit_reg i.arg.(0)}, 0\n`;
             `	bne	{emit_label lbl}\n`
         | Ifalsetest ->
-            `	{emit_string cmpg}i	{emit_reg i.arg.(0)}, 0\n`;
+            `	cmpdi	{emit_reg i.arg.(0)}, 0\n`;
             `	beq	{emit_label lbl}\n`
         | Iinttest cmp ->
             let (comp, branch) = name_for_int_comparison cmp in
@@ -970,7 +802,7 @@ let emit_instr env i =
             `	beq	{emit_label lbl}\n`
         end
     | Lcondbranch3(lbl0, lbl1, lbl2) ->
-        `	{emit_string cmpg}i	{emit_reg i.arg.(0)}, 1\n`;
+        `	cmpdi	{emit_reg i.arg.(0)}, 1\n`;
         begin match lbl0 with
           None -> ()
         | Some lbl -> `	blt	{emit_label lbl}\n`
@@ -985,66 +817,37 @@ let emit_instr env i =
         end
     | Lswitch jumptbl ->
         let lbl = new_label() in
-        if ppc64 then begin
-          let jumptables_lbl = match env.jumptables_lbl with
+        let jumptables_lbl = match env.jumptables_lbl with
             | None ->
               env.jumptables_lbl <- Some lbl;
               assert (List.length env.jumptables = 0);
               lbl
-            | Some l-> l
-          in
-          let start = List.length env.jumptables in
-          let (start_lo, start_hi) = low_high_s start in
-          emit_tocload emit_gpr 11 (TocLabel jumptables_lbl);
-          `	addi	12, {emit_reg i.arg.(0)}, {emit_int start_lo}\n`;
-          if start_hi <> 0 then
-            `	addis	12, 12, {emit_int start_hi}\n`;
-          `	sldi	12, 12, 2\n`
-        end else begin
-          `	addis	11, 0, {emit_upper emit_label lbl}\n`;
-          `	addi	11, 11, {emit_lower emit_label lbl}\n`;
-          `	slwi	12, {emit_reg i.arg.(0)}, 2\n`
-        end;
-        `	{emit_string lwa}x	0, 11, 12\n`;
+            | Some l -> l in
+        let start = List.length env.jumptables in
+        let (start_lo, start_hi) = low_high_s start in
+        emit_tocload emit_gpr 11 (TocLabel jumptables_lbl);
+        `	addi	12, {emit_reg i.arg.(0)}, {emit_int start_lo}\n`;
+        if start_hi <> 0 then
+          `	addis	12, 12, {emit_int start_hi}\n`;
+        `	sldi	12, 12, 2\n`;
+        `	lwax	0, 11, 12\n`;
         `	add	0, 11, 0\n`;
         `	mtctr	0\n`;
         `	bctr\n`;
-        if ppc64 then begin
-          env.jumptables <- List.rev_append (Array.to_list jumptbl) env.jumptables
-        end else begin
-          emit_string rodata_space;
-          `{emit_label lbl}:`;
-          for i = 0 to Array.length jumptbl - 1 do
-            `	.long	{emit_label jumptbl.(i)} - {emit_label lbl}\n`
-          done;
-          emit_string code_space
-        end
+        env.jumptables <- List.rev_append (Array.to_list jumptbl) env.jumptables
     | Lentertrap ->
-        begin match abi with
-        | ELF32 -> ()
-        | ELF64v1 | ELF64v2 -> emit_reload_toc env
-        end
+        emit_reload_toc env
     | Ladjust_trap_depth { delta_traps } ->
         adjust_stack_offset env (trap_size * delta_traps)
     | Lpushtrap { lbl_handler; } ->
-        begin match abi with
-        | ELF32 ->
-          `	addis	11, 0, {emit_upper emit_label lbl_handler}\n`;
-          `	addi	11, 11, {emit_lower emit_label lbl_handler}\n`;
-          `	stwu    11, -16(1)\n`;
-          adjust_stack_offset env 16;
-          `	stw	29, 4(1)\n`;
-          `	mr	29, 1\n`
-        | ELF64v1 | ELF64v2 ->
-          `	addi	1, 1, {emit_int (-trap_size)}\n`;
-          adjust_stack_offset env trap_size;
-          `	std	29, {emit_int trap_previous_offset}(1)\n`;
-          emit_tocload emit_gpr 29 (TocLabel lbl_handler);
-          `	std     29, {emit_int trap_handler_offset}(1)\n`;
-          `	mr	29, 1\n`
-          end
+        `	addi	1, 1, {emit_int (-trap_size)}\n`;
+        adjust_stack_offset env trap_size;
+        `	std	29, {emit_int trap_previous_offset}(1)\n`;
+        emit_tocload emit_gpr 29 (TocLabel lbl_handler);
+        `	std     29, {emit_int trap_handler_offset}(1)\n`;
+        `	mr	29, 1\n`
     | Lpoptrap ->
-        `	{emit_string lg}	29, {emit_int trap_previous_offset}(1)\n`;
+        `	ld	29, {emit_int trap_previous_offset}(1)\n`;
         `	addi	1, 1, {emit_int trap_size}\n`;
         adjust_stack_offset env (-trap_size)
     | Lraise k ->
@@ -1054,10 +857,7 @@ let emit_instr env i =
             let backtrace_pos =
               Domainstate.(idx_of_field Domain_backtrace_pos)
             in
-            begin match abi with
-            | ELF32 -> `	stw	0, {emit_int (backtrace_pos * 8)}(30)\n`
-            | _ -> `	std	0, {emit_int (backtrace_pos * 8)}(30)\n`
-            end;
+            `	std	0, {emit_int (backtrace_pos * 8)}(30)\n`;
             emit_call "caml_raise_exn";
             record_frame env Reg.Set.empty (Dbg_raise i.dbg);
             emit_call_nop()
@@ -1066,10 +866,10 @@ let emit_instr env i =
             record_frame env Reg.Set.empty (Dbg_raise i.dbg);
             emit_call_nop()
         | Lambda.Raise_notrace ->
-            `	{emit_string lg}	0, {emit_int trap_handler_offset}(29)\n`;
+            `	ld	0, {emit_int trap_handler_offset}(29)\n`;
             `	mr	1, 29\n`;
             `	mtctr   0\n`;
-            `	{emit_string lg}	29, {emit_int trap_previous_offset}(1)\n`;
+            `	ld	29, {emit_int trap_previous_offset}(1)\n`;
             `	addi	1, 1, {emit_int trap_size}\n`;
             `	bctr\n`
         end
@@ -1085,33 +885,14 @@ let rec emit_all env i =
 
 let fundecl fundecl =
   let env = mk_env fundecl in
-  begin match abi with
-  | ELF32 ->
-    emit_string code_space;
-    `	.globl	{emit_symbol fundecl.fun_name}\n`;
-    `	.type	{emit_symbol fundecl.fun_name}, @function\n`;
-    `	.align	2\n`;
-    `{emit_symbol fundecl.fun_name}:\n`
-  | ELF64v1 ->
-    emit_string function_descr_space;
-    `	.align 3\n`;
-    `	.globl	{emit_symbol fundecl.fun_name}\n`;
-    `	.type   {emit_symbol fundecl.fun_name}, @function\n`;
-    `{emit_symbol fundecl.fun_name}:\n`;
-    `	.quad .L.{emit_symbol fundecl.fun_name}, .TOC.@tocbase\n`;
-    emit_string code_space;
-    `	.align  2\n`;
-    `.L.{emit_symbol fundecl.fun_name}:\n`
-  | ELF64v2 ->
-    emit_string code_space;
-    `	.globl	{emit_symbol fundecl.fun_name}\n`;
-    `	.type	{emit_symbol fundecl.fun_name}, @function\n`;
-    `	.align	2\n`;
-    `{emit_symbol fundecl.fun_name}:\n`;
-    `0:	addis	2, 12, (.TOC. - 0b)@ha\n`;
-    `	addi	2, 2, (.TOC. - 0b)@l\n`;
-    `	.localentry {emit_symbol fundecl.fun_name}, . - 0b\n`
-  end;
+  emit_string code_space;
+  `	.globl	{emit_symbol fundecl.fun_name}\n`;
+  `	.type	{emit_symbol fundecl.fun_name}, @function\n`;
+  `	.align	2\n`;
+  `{emit_symbol fundecl.fun_name}:\n`;
+  `0:	addis	2, 12, (.TOC. - 0b)@ha\n`;
+  `	addi	2, 2, (.TOC. - 0b)@l\n`;
+  `	.localentry {emit_symbol fundecl.fun_name}, . - 0b\n`;
   emit_debug_info fundecl.fun_dbg;
   cfi_startproc();
   (* On this target, there is at most one "out of line" code block per
@@ -1122,31 +903,14 @@ let fundecl fundecl =
   (* Emit the glue code to call the GC *)
   if env.call_gc_label > 0 then begin
     `{emit_label env.call_gc_label}:\n`;
-    match abi with
-    | ELF32 ->
-      `	b	{emit_symbol "caml_call_gc"}\n`
-    | ELF64v1 ->
-      `	std	2, 40(1)\n`;
+    `	std	2, 24(1)\n`;
              (* save our TOC, will be restored by caml_call_gc *)
-      emit_tocload emit_gpr 11 (TocSym "caml_call_gc");
-      `	ld	0, 0(11)\n`;
-      `	mtctr	0\n`;
-      `	ld	2, 8(11)\n`;
-      `	bctr\n`
-    | ELF64v2 ->
-      `	std	2, 24(1)\n`;
-             (* save our TOC, will be restored by caml_call_gc *)
-      emit_tocload emit_gpr 12 (TocSym "caml_call_gc");
-      `	mtctr	12\n`;
-      `	bctr\n`
+    emit_tocload emit_gpr 12 (TocSym "caml_call_gc");
+    `	mtctr	12\n`;
+    `	bctr\n`
   end;
   cfi_endproc();
-  begin match abi with
-  | ELF32 | ELF64v2 ->
-    `	.size	{emit_symbol fundecl.fun_name}, . - {emit_symbol fundecl.fun_name}\n`
-  | ELF64v1 ->
-    `	.size	{emit_symbol fundecl.fun_name}, . - .L.{emit_symbol fundecl.fun_name}\n`
-  end;
+  `	.size	{emit_symbol fundecl.fun_name}, . - {emit_symbol fundecl.fun_name}\n`;
   (* Emit the numeric literals *)
   if env.float_literals <> [] then begin
     emit_string rodata_space;
@@ -1188,15 +952,13 @@ let emit_item = function
   | Cint32 n ->
       `	.long	{emit_nativeint n}\n`
   | Cint n ->
-      `	{emit_string datag}	{emit_nativeint n}\n`
+      `	.quad	{emit_nativeint n}\n`
   | Csingle f ->
       emit_float32_directive ".long" (Int32.bits_of_float f)
   | Cdouble f ->
-      if ppc64
-      then emit_float64_directive ".quad" (Int64.bits_of_float f)
-      else emit_float64_split_directive ".long" (Int64.bits_of_float f)
+      emit_float64_directive ".quad" (Int64.bits_of_float f)
   | Csymbol_address s ->
-      `	{emit_string datag}	{emit_symbol s}\n`
+      `	.quad	{emit_symbol s}\n`
   | Cstring s ->
       emit_bytes_directive "	.byte	" s
   | Cskip n ->
@@ -1206,7 +968,7 @@ let emit_item = function
 
 let data l =
   emit_string data_space;
-  `	.align  {emit_int (if ppc64 then 3 else 2)}\n`;
+  `	.align  3\n`;
   List.iter emit_item l
 
 (* Beginning / end of an assembly file *)
@@ -1214,10 +976,7 @@ let data l =
 let begin_assembly() =
   reset_debug_info();
   `	.file	\"\"\n`;  (* PR#7037 *)
-  begin match abi with
-  | ELF64v2 -> `	.abiversion 2\n`
-  | _ -> ()
-  end;
+  `	.abiversion 2\n`;
   Hashtbl.clear tocref_entries;
   (* Emit the beginning of the segments *)
   let lbl_begin = Compilenv.make_symbol (Some "data_begin") in
@@ -1225,46 +984,38 @@ let begin_assembly() =
   declare_global_data lbl_begin;
   `{emit_symbol lbl_begin}:\n`;
   let lbl_begin = Compilenv.make_symbol (Some "code_begin") in
-  emit_string function_descr_space;
-  (* For the ELF64v1 ABI, we must make sure that the .opd and .data
-     sections are in different pages.  .opd comes after .data,
-     so aligning .opd is enough.  To save space, we do it only
-     for the startup file, not for every OCaml compilation unit. *)
-  let c = Compilenv.current_unit_name() in
-  if abi = ELF64v1 && (c = "_startup" || c = "_shared_startup") then begin
-    `	.p2align	12\n`
-  end;
+  emit_string code_space;
   declare_global_data lbl_begin;
   `{emit_symbol lbl_begin}:\n`
 
 let end_assembly() =
   (* Emit the end of the segments *)
-  emit_string function_descr_space;
+  emit_string code_space;
   let lbl_end = Compilenv.make_symbol (Some "code_end") in
   declare_global_data lbl_end;
   `{emit_symbol lbl_end}:\n`;
-  if abi <> ELF64v1 then `	.long	0\n`;
+  `	.long	0\n`;
   emit_string data_space;
   let lbl_end = Compilenv.make_symbol (Some "data_end") in
   declare_global_data lbl_end;
-  `	{emit_string datag}	0\n`;  (* PR#6329 *)
+  `	.quad	0\n`;  (* PR#6329 *)
   `{emit_symbol lbl_end}:\n`;
-  `	{emit_string datag}	0\n`;
+  `	.quad	0\n`;
   (* Emit the frame descriptors *)
   emit_string data_space;  (* not rodata_space because it contains relocations *)
-  if ppc64 then `	.align  3\n`;   (* #7887 *)
+  `	.align  3\n`;   (* #7887 *)
   let lbl = Compilenv.make_symbol (Some "frametable") in
   declare_global_data lbl;
   `{emit_symbol lbl}:\n`;
   emit_frames
     { efa_code_label =
-         (fun l -> `	{emit_string datag}	{emit_label l}\n`);
+         (fun l -> `	.quad	{emit_label l}\n`);
       efa_data_label =
-         (fun l -> `	{emit_string datag}	{emit_label l}\n`);
+         (fun l -> `	.quad	{emit_label l}\n`);
       efa_8 = (fun n -> `	.byte	{emit_int n}\n`);
       efa_16 = (fun n -> `	.short	{emit_int n}\n`);
       efa_32 = (fun n -> `	.long	{emit_int32 n}\n`);
-      efa_word = (fun n -> `	{emit_string datag}	{emit_int n}\n`);
+      efa_word = (fun n -> `	.quad	{emit_int n}\n`);
       efa_align = (fun n -> `	.balign	{emit_int n}\n`);
       efa_label_rel = (fun lbl ofs ->
                            `	.long	({emit_label lbl} - .) + {emit_int32 ofs}\n`);
@@ -1272,11 +1023,7 @@ let end_assembly() =
       efa_string = (fun s -> emit_bytes_directive "	.byte	" (s ^ "\000"))
      };
   (* Emit the TOC entries *)
-  begin match abi with
-  | ELF32 -> ()
-  | ELF64v1 | ELF64v2 ->
-      emit_string toc_space;
-      emit_toctable();
-      Hashtbl.clear tocref_entries
-  end;
+  emit_string toc_space;
+  emit_toctable();
+  Hashtbl.clear tocref_entries;
   `	.section .note.GNU-stack,\"\",%progbits\n`

--- a/asmcomp/power/emit.mlp
+++ b/asmcomp/power/emit.mlp
@@ -166,14 +166,11 @@ let emit_toctable () =
    The [dest] should not be r0, since [dest] is used as the index register for a
    ld instruction, but r0 reads as zero when used as an index register.
 *)
+
 let emit_tocload emit_dest dest entry =
   let lbl = label_for_tocref entry in
-  if !big_toc || !Clflags.for_package <> None then begin
-    `	addis	{emit_dest dest}, 2, {emit_label lbl}@toc@ha\n`;
-    `	ld	{emit_dest dest}, {emit_label lbl}@toc@l({emit_dest dest}) # {emit_tocentry entry}\n`
-  end else begin
-    `	ld	{emit_dest dest}, {emit_label lbl}@toc(2) # {emit_tocentry entry}\n`
-  end
+  `	addis	{emit_dest dest}, 2, {emit_label lbl}@toc@ha\n`;
+  `	ld	{emit_dest dest}, {emit_label lbl}@toc@l({emit_dest dest}) # {emit_tocentry entry}\n`
 
 (* Output a load or store operation *)
 
@@ -378,13 +375,12 @@ module BR = Branch_relaxation.Make (struct
       + (if initial_stack_offset f > 0 then 1 else 0)
       + (if f.fun_contains_calls then 3 else 0)
 
-  let tocload_size() =
-    if !big_toc || !Clflags.for_package <> None then 2 else 1
+  let tocload_size = 2
 
   let load_store_size = function
     | Ibased(_s, d) ->
         let (_lo, hi) = low_high_s d in
-        tocload_size() + (if hi = 0 then 1 else 2)
+        tocload_size + (if hi = 0 then 1 else 2)
     | Iindexed ofs -> if is_immediate ofs then 1 else 3
     | Iindexed2 -> 1
 
@@ -398,19 +394,19 @@ module BR = Branch_relaxation.Make (struct
                hi >= -0x8000 && hi <= 0x7FFF) then 2
       else if (let (_lo, hi) = native_low_high_u n in
                hi >= -0x8000 && hi <= 0x7FFF) then 2
-      else tocload_size()
-    | Lop(Iconst_float _) -> tocload_size()
-    | Lop(Iconst_symbol _) -> tocload_size()
+      else tocload_size
+    | Lop(Iconst_float _) -> tocload_size
+    | Lop(Iconst_symbol _) -> tocload_size
     | Lop(Icall_ind) -> 4
     | Lop(Icall_imm _) -> 3
     | Lop(Itailcall_ind) -> 6
     | Lop(Itailcall_imm { func; _ }) ->
         if func = f.fun_name
         then 1
-        else 6 + tocload_size()
+        else 6 + tocload_size
     | Lop(Iextcall { alloc; stack_ofs; _}) ->
-        if stack_ofs > 0 then tocload_size() + 4
-        else if alloc then tocload_size() + 2
+        if stack_ofs > 0 then tocload_size + 4
+        else if alloc then tocload_size + 2
         else 5
     | Lop(Istackoffset _) -> 1
     | Lop(Iload {memory_chunk; addressing_mode; _ }) ->
@@ -445,10 +441,10 @@ module BR = Branch_relaxation.Make (struct
       1 + (if lbl0 = None then 0 else 1)
         + (if lbl1 = None then 0 else 1)
         + (if lbl2 = None then 0 else 1)
-    | Lswitch _ -> 5 + tocload_size()
-    | Lentertrap -> tocload_size()
+    | Lswitch _ -> 5 + tocload_size
+    | Lentertrap -> 1
     | Ladjust_trap_depth _ -> 0
-    | Lpushtrap _ -> 4 + tocload_size()
+    | Lpushtrap _ -> 4 + tocload_size
     | Lpoptrap -> 2
     | Lraise (Lambda.Raise_regular | Lambda.Raise_reraise) -> 2
     | Lraise Lambda.Raise_notrace -> 5
@@ -579,12 +575,8 @@ let emit_instr env i =
     | Lop(Iconst_float f) ->
         let entry = TocFloat f in
         let lbl = label_for_tocref entry in
-        if !big_toc || !Clflags.for_package <> None then begin
-          `	addis	11, 2, {emit_label lbl}@toc@ha\n`;
-          `	lfd	{emit_reg i.res.(0)}, {emit_label lbl}@toc@l(11) # {emit_tocentry entry}\n`
-        end else begin
-          `	lfd	{emit_reg i.res.(0)}, {emit_label lbl}@toc(2) # {emit_tocentry entry}\n`
-        end
+        `	addis	11, 2, {emit_label lbl}@toc@ha\n`;
+        `	lfd	{emit_reg i.res.(0)}, {emit_label lbl}@toc@l(11) # {emit_tocentry entry}\n`
     | Lop(Iconst_symbol s) ->
         emit_tocload emit_reg i.res.(0) (TocSym s)
     | Lop(Icall_ind) ->

--- a/asmcomp/power/emit.mlp
+++ b/asmcomp/power/emit.mlp
@@ -900,7 +900,7 @@ let fundecl fundecl =
   let stack_threshold_size = Config.stack_threshold * 8 in (* bytes *)
   let { max_frame_size; contains_nontail_calls} =
     preproc_stack_check
-      ~fun_body:fundecl.fun_body ~frame_size:(frame_size env) ~trap_size:32
+      ~fun_body:fundecl.fun_body ~frame_size:(frame_size env) ~trap_size:16
   in
   let handle_overflow = ref None in
   if contains_nontail_calls || max_frame_size >= stack_threshold_size then begin

--- a/asmcomp/power/proc.ml
+++ b/asmcomp/power/proc.ml
@@ -110,33 +110,14 @@ let loc_float last_float make_stack reg_use_stack int float ofs =
   if !float <= last_float then begin
     let l = phys_reg !float in
     incr float;
-    (* On 64-bit platforms, passing a float in a float register
-       reserves a normal register as well *)
-    if size_int = 8 then incr int;
+    (* Passing a float in a float register reserves a normal register as well *)
+    incr int;
     if reg_use_stack then ofs := !ofs + size_float;
     l
   end else begin
     ofs := Misc.align !ofs size_float;
     let l = stack_slot (make_stack !ofs) Float in
     ofs := !ofs + size_float; l
-  end
-
-let loc_int_pair last_int make_stack int ofs =
-  (* 64-bit quantities split across two registers must either be in a
-     consecutive pair of registers where the lowest numbered is an
-     even-numbered register; or in a stack slot that is 8-byte aligned. *)
-  int := Misc.align !int 2;
-  if !int <= last_int - 1 then begin
-    let reg_lower = phys_reg !int in
-    let reg_upper = phys_reg (1 + !int) in
-    int := !int + 2;
-    [| reg_lower; reg_upper |]
-  end else begin
-    ofs := Misc.align !ofs 8;
-    let stack_lower = stack_slot (make_stack !ofs) Int in
-    let stack_upper = stack_slot (make_stack (size_int + !ofs)) Int in
-    ofs := !ofs + 8;
-    [| stack_lower; stack_upper |]
   end
 
 let calling_conventions first_int last_int first_float last_float
@@ -214,16 +195,9 @@ let external_calling_conventions
   List.iteri
     (fun i ty_arg ->
       match ty_arg with
-      | XInt | XInt32 ->
+      | XInt | XInt32 | XInt64 ->
         loc.(i) <-
           [| loc_int last_int make_stack reg_use_stack int ofs |]
-      | XInt64 ->
-          if size_int = 4 then begin
-            assert (not reg_use_stack);
-            loc.(i) <- loc_int_pair last_int make_stack int ofs
-          end else
-            loc.(i) <-
-              [| loc_int last_int make_stack reg_use_stack int ofs |]
       | XFloat ->
         loc.(i) <-
           [| loc_float last_float make_stack reg_use_stack int float ofs |])
@@ -231,25 +205,15 @@ let external_calling_conventions
   (loc, Misc.align !ofs 16) (* Keep stack 16-aligned *)
 
 let loc_external_arguments ty_args =
-  match abi with
-  | ELF32 ->
-      external_calling_conventions 0 7 100 107 outgoing 8 false ty_args
-  | ELF64v1 ->
-      let (loc, ofs) =
-        external_calling_conventions 0 7 100 112 outgoing 0 true ty_args in
-      (loc, max ofs 64)
-  | ELF64v2 ->
-      let (loc, ofs) =
-        external_calling_conventions 0 7 100 112 outgoing 0 true ty_args in
-      if Array.fold_left
-           (fun stk r ->
-              assert (Array.length r = 1);
-              match r.(0).loc with
-              | Stack _ -> true
-              | _ -> stk)
-           false loc
-      then (loc, ofs)
-      else (loc, 0)
+  let (loc, ofs) =
+    external_calling_conventions 0 7 100 112 outgoing 0 true ty_args in
+  if Array.exists
+       (fun r ->
+          assert (Array.length r = 1);
+          match r.(0).loc with Stack _ -> true | _ -> false)
+       loc
+  then (loc, ofs)
+  else (loc, 0)
 
 (* Results are in GPR 3 and FPR 1 *)
 
@@ -261,20 +225,10 @@ let loc_external_results res =
 
 let loc_exn_bucket = phys_reg 0
 
-(* For ELF32 see:
-   "System V Application Binary Interface PowerPC Processor Supplement"
-   http://refspecs.linux-foundation.org/elf/elfspec_ppc.pdf
-
-   For ELF64v1 see:
-   "64-bit PowerPC ELF Application Binary Interface Supplement 1.9"
-   http://refspecs.linuxfoundation.org/ELF/ppc64/PPC-elf64abi.html
-
-   For ELF64v2 see:
+(* For ELF64v2 see:
    "64-Bit ELF V2 ABI Specification -- Power Architecture"
    http://openpowerfoundation.org/wp-content/uploads/resources/leabi/
      content/dbdoclet.50655239___RefHeading___Toc377640569.html
-
-   All of these specifications seem to agree on the numberings we need.
 *)
 
 let int_dwarf_reg_numbers =
@@ -327,25 +281,9 @@ let max_register_pressure = function
 
 (* Layout of the stack *)
 
-(* See [reserved_stack_space] in emit.mlp. *)
-let reserved_stack_space_required () =
-  match abi with
-  | ELF32 -> false
-  | ELF64v1 | ELF64v2 -> true
+let frame_required _ = true
 
-let frame_required fd =
-  let is_elf32 =
-    match abi with
-    | ELF32 -> true
-    | ELF64v1 | ELF64v2 -> false
-  in
-  reserved_stack_space_required ()
-    || fd.fun_num_stack_slots.(0) > 0
-    || fd.fun_num_stack_slots.(1) > 0
-    || (fd.fun_contains_calls && is_elf32)
-
-let prologue_required fd =
-  frame_required fd
+let prologue_required _ = true
 
 (* Calling the assembler *)
 

--- a/configure
+++ b/configure
@@ -15403,7 +15403,7 @@ case $host in #(
   x86_64-pc-windows) :
     arch=amd64; system=win64 ;; #(
   powerpc64le*-*-linux*) :
-    arch=power; model=ppc64le; system=elf ;; #(
+    has_native_backend=yes; arch=power; model=ppc64le; system=elf ;; #(
   s390x*-*-linux*) :
     has_native_backend=yes; arch=s390x; model=z10; system=elf ;; #(
   # expected to match "gnueabihf" as well as "musleabihf"

--- a/configure
+++ b/configure
@@ -15404,13 +15404,6 @@ case $host in #(
     arch=amd64; system=win64 ;; #(
   powerpc64le*-*-linux*) :
     arch=power; model=ppc64le; system=elf ;; #(
-  powerpc*-*-linux*) :
-    arch=power; if $arch64
-then :
-  model=ppc64
-else $as_nop
-  model=ppc
-fi; system=elf ;; #(
   s390x*-*-linux*) :
     has_native_backend=yes; arch=s390x; model=z10; system=elf ;; #(
   # expected to match "gnueabihf" as well as "musleabihf"

--- a/configure.ac
+++ b/configure.ac
@@ -1218,7 +1218,7 @@ AS_CASE([$host],
   [x86_64-pc-windows],
     [arch=amd64; system=win64],
   [[powerpc64le*-*-linux*]],
-    [arch=power; model=ppc64le; system=elf],
+    [has_native_backend=yes; arch=power; model=ppc64le; system=elf],
   [[s390x*-*-linux*]],
     [has_native_backend=yes; arch=s390x; model=z10; system=elf],
   # expected to match "gnueabihf" as well as "musleabihf"

--- a/configure.ac
+++ b/configure.ac
@@ -1219,8 +1219,6 @@ AS_CASE([$host],
     [arch=amd64; system=win64],
   [[powerpc64le*-*-linux*]],
     [arch=power; model=ppc64le; system=elf],
-  [[powerpc*-*-linux*]],
-    [arch=power; AS_IF([$arch64],[model=ppc64],[model=ppc]); system=elf],
   [[s390x*-*-linux*]],
     [has_native_backend=yes; arch=s390x; model=z10; system=elf],
   # expected to match "gnueabihf" as well as "musleabihf"

--- a/manual/src/cmds/native.etex
+++ b/manual/src/cmds/native.etex
@@ -153,17 +153,6 @@ the default.
 \item["-fno-PIC"] Generate position-dependent machine code.
 \end{options}
 
-\paragraph{Options for the PowerPC architecture}
-The PowerPC code generator supports the following additional options:
-
-\begin{options}
-\item["-flarge-toc"] Enables the PowerPC large model allowing the TOC (table of
-contents) to be arbitrarily large.  This is the default since 4.11.
-\item["-fsmall-toc"] Enables the PowerPC small model allowing the TOC to be up
-to 64 kbytes per compilation unit.  Prior to 4.11 this was the default
-behaviour.
-\end{options}
-
 \paragraph{Contextual control of command-line options}
 
 The compiler command line can be modified ``from the outside''

--- a/runtime/caml/fiber.h
+++ b/runtime/caml/fiber.h
@@ -100,6 +100,9 @@ CAML_STATIC_ASSERT(sizeof(struct stack_info) ==
   #define Reserved_space_c_stack_link 4 * 8
 #elif defined(TARGET_s390x)
   #define Reserved_space_c_stack_link 160
+#elif defined(TARGET_power)
+/* ELF ABI: 4 reserved words at bottom of C stack */
+  #define Reserved_space_c_stack_link 4 * 8
 #endif
 
 /* This structure is used for storing the OCaml return pointer when

--- a/runtime/caml/platform.h
+++ b/runtime/caml/platform.h
@@ -43,8 +43,8 @@ Caml_inline void cpu_relax(void) {
   /* Encoding of the pause instruction */
   __asm__ volatile (".4byte 0x100000F");
 #elif defined(__ppc64__)
-  __asm__ volatile ("or 1, 1, 1	# low priority");
-  __asm__ volatile ("or 2, 2, 2	# medium priority");
+  __asm__ volatile ("or 1, 1, 1 # low priority");
+  __asm__ volatile ("or 2, 2, 2 # medium priority");
   __asm__ volatile ("" ::: "memory");
 #else
   /* Just a compiler barrier */

--- a/runtime/caml/platform.h
+++ b/runtime/caml/platform.h
@@ -42,6 +42,10 @@ Caml_inline void cpu_relax(void) {
 #elif defined(__riscv)
   /* Encoding of the pause instruction */
   __asm__ volatile (".4byte 0x100000F");
+#elif defined(__ppc64__)
+  __asm__ volatile ("or 1, 1, 1	# low priority");
+  __asm__ volatile ("or 2, 2, 2	# medium priority");
+  __asm__ volatile ("" ::: "memory");
 #else
   /* Just a compiler barrier */
   __asm__ volatile ("" ::: "memory");

--- a/runtime/caml/signals.h
+++ b/runtime/caml/signals.h
@@ -79,6 +79,10 @@ void caml_terminate_signals(void);
 CAMLextern void * caml_init_signal_stack(void);
 CAMLextern void caml_free_signal_stack(void *);
 
+#if defined(NATIVE_CODE) && defined(TARGET_power)
+void caml_sigtrap_handler(int, siginfo_t *, void *);
+#endif
+
 /* These hooks are not modified after other threads are spawned. */
 CAMLextern void (*caml_enter_blocking_section_hook)(void);
 CAMLextern void (*caml_leave_blocking_section_hook)(void);

--- a/runtime/caml/stack.h
+++ b/runtime/caml/stack.h
@@ -42,6 +42,16 @@
    to find the first frame of the next chunk, or to reach the top of the stack.
 */
 
+#ifdef TARGET_power
+/* Size of the gc_regs structure, in words.
+   See power.S and power/proc.ml for the indices */
+#define Wosize_gc_regs (23 /* int regs */ + 14 /* caller-save float regs */)
+#define Saved_return_address(sp) *((intnat *)((sp) + 16))
+#define First_frame(sp) (sp)
+#define Saved_gc_regs(sp) (*(value **)((sp) + 32 + 16 + 8))
+#define Stack_header_size (32 + 16 + 16)
+#endif
+
 #ifdef TARGET_s390x
 #define Wosize_gc_regs (2 + 9 /* int regs */ + 16 /* float regs */)
 #define Saved_return_address(sp) *((intnat *)((sp) - 8))

--- a/runtime/power.S
+++ b/runtime/power.S
@@ -27,44 +27,7 @@
 #define DOMAIN_STATE_PTR 30
 #define ALLOC_PTR 31
 
-#if defined(MODEL_ppc64) || defined(MODEL_ppc64le)
-#define EITHER(a,b) b
-#else
-#define EITHER(a,b) a
-#endif
-
-#define WORD EITHER(4,8)
-#define lg EITHER(lwz,ld)
-#define lgu EITHER(lwzu,ldu)
-#define stg EITHER(stw,std)
-#define stgu EITHER(stwu,stdu)
-#define datag EITHER(.long,.quad)
-#define wordalign EITHER(2,3)
-
 /* Stack layout */
-#if defined(MODEL_ppc)
-#define RESERVED_STACK 16
-#define PARAM_SAVE_AREA 0
-#define LR_SAVE 4
-#define TRAP_SIZE 16
-#define TRAP_HANDLER_OFFSET 0
-#define TRAP_PREVIOUS_OFFSET 4
-#define CALLBACK_LINK_SIZE 16
-#define CALLBACK_LINK_OFFSET 0
-#endif
-#if defined(MODEL_ppc64)
-#define RESERVED_STACK 48
-#define PARAM_SAVE_AREA (8*8)
-#define LR_SAVE 16
-#define TOC_SAVE 40
-#define TOC_SAVE_PARENT 8
-#define TRAP_SIZE 32
-#define TRAP_HANDLER_OFFSET 56
-#define TRAP_PREVIOUS_OFFSET 64
-#define CALLBACK_LINK_SIZE 32
-#define CALLBACK_LINK_OFFSET 48
-#endif
-#if defined(MODEL_ppc64le)
 #define RESERVED_STACK 32
 #define PARAM_SAVE_AREA 0
 #define LR_SAVE 16
@@ -75,40 +38,9 @@
 #define TRAP_PREVIOUS_OFFSET 48
 #define CALLBACK_LINK_SIZE 32
 #define CALLBACK_LINK_OFFSET 32
-#endif
 
 /* Function definitions */
 
-#if defined(MODEL_ppc)
-#define FUNCTION(name) \
-  .section ".text"; \
-  .globl name; \
-  .type name, @function; \
-  .align 2; \
-  name:
-
-#define ENDFUNCTION(name) \
-  .size name, . - name
-
-#endif
-
-#if defined(MODEL_ppc64)
-#define FUNCTION(name) \
-  .section ".opd","aw"; \
-  .align 3; \
-  .globl name; \
-  .type name, @function; \
-  name: .quad .L.name,.TOC.@tocbase; \
-  .text; \
-  .align 2; \
-  .L.name:
-
-#define ENDFUNCTION(name) \
-  .size name, . - .L.name
-
-#endif
-
-#if defined(MODEL_ppc64le)
 #define FUNCTION(name) \
   .section ".text"; \
   .globl name; \
@@ -122,24 +54,12 @@
 #define ENDFUNCTION(name) \
   .size name, . - name
 
-#endif
-
 /* Accessing global variables.  */
-
-#if defined(MODEL_ppc)
-
-#define Addrglobal(reg,glob) \
-        addis   reg, 0, glob@ha; \
-        addi    reg, reg, glob@l
-#endif
-
-#if defined(MODEL_ppc64) || defined(MODEL_ppc64le)
 
 #define LSYMB(glob) .L##glob
 
 #define Addrglobal(reg,glob) \
         ld      reg, LSYMB(glob)@toc(2)
-#endif
 
         .set    domain_curr_field, 0
 #define DOMAIN_STATE(c_type, name) \
@@ -150,59 +70,55 @@
 
 #define Caml_state(var) 8*domain_field_caml_##var(DOMAIN_STATE_PTR)
 
-#if defined(MODEL_ppc64)
-        .section ".opd","aw"
-#else
         .section ".text"
-#endif
         .globl  caml_system__code_begin
 caml_system__code_begin:
 
 /* Invoke the garbage collector. */
 
 FUNCTION(caml_call_gc)
-#define STACKSIZE (WORD*32 + 8*32 + PARAM_SAVE_AREA + RESERVED_STACK)
+#define STACKSIZE (8*32 + 8*32 + PARAM_SAVE_AREA + RESERVED_STACK)
     /* 32 integer registers + 32 float registers + space for C call */
     /* Set up stack frame */
         stwu    1, -STACKSIZE(1)
     /* Record return address into OCaml code */
         mflr    0
-        stg     0, Caml_state(last_return_address)
+        std     0, Caml_state(last_return_address)
     /* Record lowest stack address */
         addi    0, 1, STACKSIZE
-        stg     0, Caml_state(bottom_of_stack)
+        std     0, Caml_state(bottom_of_stack)
     /* Record pointer to register array */
         addi    0, 1, 8*32 + PARAM_SAVE_AREA + RESERVED_STACK
-        stg     0, Caml_state(gc_regs)
+        std     0, Caml_state(gc_regs)
     /* Save current allocation pointer for debugging purposes */
-        stg     ALLOC_PTR, Caml_state(young_ptr)
+        std     ALLOC_PTR, Caml_state(young_ptr)
     /* Save exception pointer (if e.g. a sighandler raises) */
-        stg     TRAP_PTR, Caml_state(exception_pointer)
+        std     TRAP_PTR, Caml_state(exception_pointer)
     /* Save all registers used by the code generator */
-        addi    11, 1, 8*32 + PARAM_SAVE_AREA + RESERVED_STACK - WORD
-        stgu    3, WORD(11)
-        stgu    4, WORD(11)
-        stgu    5, WORD(11)
-        stgu    6, WORD(11)
-        stgu    7, WORD(11)
-        stgu    8, WORD(11)
-        stgu    9, WORD(11)
-        stgu    10, WORD(11)
-        stgu    14, WORD(11)
-        stgu    15, WORD(11)
-        stgu    16, WORD(11)
-        stgu    17, WORD(11)
-        stgu    18, WORD(11)
-        stgu    19, WORD(11)
-        stgu    20, WORD(11)
-        stgu    21, WORD(11)
-        stgu    22, WORD(11)
-        stgu    23, WORD(11)
-        stgu    24, WORD(11)
-        stgu    25, WORD(11)
-        stgu    26, WORD(11)
-        stgu    27, WORD(11)
-        stgu    28, WORD(11)
+        addi    11, 1, 8*32 + PARAM_SAVE_AREA + RESERVED_STACK - 8
+        stdu    3, 8(11)
+        stdu    4, 8(11)
+        stdu    5, 8(11)
+        stdu    6, 8(11)
+        stdu    7, 8(11)
+        stdu    8, 8(11)
+        stdu    9, 8(11)
+        stdu    10, 8(11)
+        stdu    14, 8(11)
+        stdu    15, 8(11)
+        stdu    16, 8(11)
+        stdu    17, 8(11)
+        stdu    18, 8(11)
+        stdu    19, 8(11)
+        stdu    20, 8(11)
+        stdu    21, 8(11)
+        stdu    22, 8(11)
+        stdu    23, 8(11)
+        stdu    24, 8(11)
+        stdu    25, 8(11)
+        stdu    26, 8(11)
+        stdu    27, 8(11)
+        stdu    28, 8(11)
         addi    11, 1, PARAM_SAVE_AREA + RESERVED_STACK - 8
         stfdu   1, 8(11)
         stfdu   2, 8(11)
@@ -237,36 +153,34 @@ FUNCTION(caml_call_gc)
         stfdu   31, 8(11)
     /* Call the GC */
         bl      caml_garbage_collection
-#if defined(MODEL_ppc64) || defined(MODEL_ppc64le)
         nop
-#endif
     /* Reload new allocation pointer */
-        lg      ALLOC_PTR, Caml_state(young_ptr)
+        ld      ALLOC_PTR, Caml_state(young_ptr)
     /* Restore all regs used by the code generator */
-        addi    11, 1, 8*32 + PARAM_SAVE_AREA + RESERVED_STACK - WORD
-        lgu     3, WORD(11)
-        lgu     4, WORD(11)
-        lgu     5, WORD(11)
-        lgu     6, WORD(11)
-        lgu     7, WORD(11)
-        lgu     8, WORD(11)
-        lgu     9, WORD(11)
-        lgu     10, WORD(11)
-        lgu     14, WORD(11)
-        lgu     15, WORD(11)
-        lgu     16, WORD(11)
-        lgu     17, WORD(11)
-        lgu     18, WORD(11)
-        lgu     19, WORD(11)
-        lgu     20, WORD(11)
-        lgu     21, WORD(11)
-        lgu     22, WORD(11)
-        lgu     23, WORD(11)
-        lgu     24, WORD(11)
-        lgu     25, WORD(11)
-        lgu     26, WORD(11)
-        lgu     27, WORD(11)
-        lgu     28, WORD(11)
+        addi    11, 1, 8*32 + PARAM_SAVE_AREA + RESERVED_STACK - 8
+        ldu     3, 8(11)
+        ldu     4, 8(11)
+        ldu     5, 8(11)
+        ldu     6, 8(11)
+        ldu     7, 8(11)
+        ldu     8, 8(11)
+        ldu     9, 8(11)
+        ldu     10, 8(11)
+        ldu     14, 8(11)
+        ldu     15, 8(11)
+        ldu     16, 8(11)
+        ldu     17, 8(11)
+        ldu     18, 8(11)
+        ldu     19, 8(11)
+        ldu     20, 8(11)
+        ldu     21, 8(11)
+        ldu     22, 8(11)
+        ldu     23, 8(11)
+        ldu     24, 8(11)
+        ldu     25, 8(11)
+        ldu     26, 8(11)
+        ldu     27, 8(11)
+        ldu     28, 8(11)
         addi    11, 1, PARAM_SAVE_AREA + RESERVED_STACK - 8
         lfdu    1, 8(11)
         lfdu    2, 8(11)
@@ -300,12 +214,10 @@ FUNCTION(caml_call_gc)
         lfdu    30, 8(11)
         lfdu    31, 8(11)
     /* Return to caller, resuming the allocation */
-        lg      11, Caml_state(last_return_address)
+        ld      11, Caml_state(last_return_address)
         mtlr    11
-    /* For PPC64: restore the TOC that the caller saved at the usual place */
-#ifdef TOC_SAVE
+    /* Restore the TOC that the caller saved at the usual place */
         ld      2, (STACKSIZE + TOC_SAVE)(1)
-#endif
     /* Deallocate stack frame */
         addi    1, 1, STACKSIZE
         blr
@@ -320,35 +232,21 @@ FUNCTION(caml_c_call)
         mflr    C_CALL_RET_ADDR
         .cfi_register 65, C_CALL_RET_ADDR
     /* Record lowest stack address and return address */
-        stg     1, Caml_state(bottom_of_stack)
-        stg     C_CALL_RET_ADDR, Caml_state(last_return_address)
+        std     1, Caml_state(bottom_of_stack)
+        std     C_CALL_RET_ADDR, Caml_state(last_return_address)
     /* Make the exception handler and alloc ptr available to the C code */
-        stg     ALLOC_PTR, Caml_state(young_ptr)
-        stg     TRAP_PTR, Caml_state(exception_pointer)
+        std     ALLOC_PTR, Caml_state(young_ptr)
+        std     TRAP_PTR, Caml_state(exception_pointer)
     /* Call C function (address in C_CALL_FUN) */
-#if defined(MODEL_ppc)
-        mtctr   C_CALL_FUN
-        bctrl
-#elif defined(MODEL_ppc64)
-        ld      0, 0(C_CALL_FUN)
-        mr      C_CALL_TOC, 2   /* save current TOC in a callee-save register */
-        mtctr   0
-        ld      2, 8(C_CALL_FUN)
-        bctrl
-        mr      2, C_CALL_TOC   /* restore current TOC */
-#elif defined(MODEL_ppc64le)
         mtctr   C_CALL_FUN
         mr      12, C_CALL_FUN
         mr      C_CALL_TOC, 2   /* save current TOC in a callee-save register */
         bctrl
         mr      2, C_CALL_TOC   /* restore current TOC */
-#else
-#error "wrong MODEL"
-#endif
     /* Restore return address (in 27, preserved by the C function) */
         mtlr    C_CALL_RET_ADDR
     /* Reload allocation pointer*/
-        lg      ALLOC_PTR, Caml_state(young_ptr)
+        ld      ALLOC_PTR, Caml_state(young_ptr)
     /* Return to caller */
         blr
         .cfi_endproc
@@ -357,15 +255,15 @@ ENDFUNCTION(caml_c_call)
 /* Raise an exception from OCaml */
 
 FUNCTION(caml_raise_exn)
-        lg      0, Caml_state(backtrace_active)
+        ld      0, Caml_state(backtrace_active)
         cmpwi   0, 0
         bne     .L111
 .L110:
     /* Pop trap frame */
-        lg      0, TRAP_HANDLER_OFFSET(TRAP_PTR)
+        ld      0, TRAP_HANDLER_OFFSET(TRAP_PTR)
         mr      1, TRAP_PTR
         mtctr   0
-        lg      TRAP_PTR, TRAP_PREVIOUS_OFFSET(1)
+        ld      TRAP_PTR, TRAP_PREVIOUS_OFFSET(1)
         addi    1, 1, TRAP_SIZE
     /* Branch to handler */
         bctr
@@ -378,9 +276,7 @@ FUNCTION(caml_raise_exn)
         addi    1, 1, -(PARAM_SAVE_AREA + RESERVED_STACK)
                                 /* reserve stack space for C call */
         bl      caml_stash_backtrace
-#if defined(MODEL_ppc64) || defined(MODEL_ppc64le)
         nop
-#endif
         mr      3, 27           /* restore exn bucket */
         b       .L110           /* raise the exn */
 ENDFUNCTION(caml_raise_exn)
@@ -391,32 +287,30 @@ FUNCTION(caml_raise_exception)
     /* Load domain state pointer */
         mr      DOMAIN_STATE_PTR, 3
         mr      3, 4
-        lg      0, Caml_state(backtrace_active)
+        ld      0, Caml_state(backtrace_active)
         cmpwi   0, 0
         bne     .L121
 .L120:
     /* Reload OCaml global registers */
-        lg      1, Caml_state(exception_pointer)
-        lg      ALLOC_PTR, Caml_state(young_ptr)
+        ld      1, Caml_state(exception_pointer)
+        ld      ALLOC_PTR, Caml_state(young_ptr)
     /* Pop trap frame */
-        lg      0, TRAP_HANDLER_OFFSET(1)
+        ld      0, TRAP_HANDLER_OFFSET(1)
         mtctr   0
-        lg      TRAP_PTR, TRAP_PREVIOUS_OFFSET(1)
+        ld      TRAP_PTR, TRAP_PREVIOUS_OFFSET(1)
         addi    1, 1, TRAP_SIZE
     /* Branch to handler */
         bctr
 .L121:
         mr      27, 3           /* preserve exn bucket in callee-save reg */
                                 /* arg1: exception bucket, already in r3 */
-        lg      4, Caml_state(last_return_address) /* arg2: PC of raise */
-        lg      5, Caml_state(bottom_of_stack)     /* arg3: SP of raise */
-        lg      6, Caml_state(exception_pointer)   /* arg4: SP of handler */
+        ld      4, Caml_state(last_return_address) /* arg2: PC of raise */
+        ld      5, Caml_state(bottom_of_stack)     /* arg3: SP of raise */
+        ld      6, Caml_state(exception_pointer)   /* arg4: SP of handler */
         addi    1, 1, -(PARAM_SAVE_AREA + RESERVED_STACK)
                                          /* reserve stack space for C call */
         bl      caml_stash_backtrace
-#if defined(MODEL_ppc64) || defined(MODEL_ppc64le)
         nop
-#endif
         mr      3, 27           /* restore exn bucket */
         b       .L120           /* raise the exn */
 ENDFUNCTION(caml_raise_exception)
@@ -425,7 +319,7 @@ ENDFUNCTION(caml_raise_exception)
 
 FUNCTION(caml_start_program)
         .cfi_startproc
-#define STACKSIZE (WORD*18 + 8*18 + CALLBACK_LINK_SIZE + RESERVED_STACK)
+#define STACKSIZE (8*18 + 8*18 + CALLBACK_LINK_SIZE + RESERVED_STACK)
   /* 18 callee-save GPR14...GPR31 + 18 callee-save FPR14...FPR31 */
   /* Domain state pointer is the first arg to caml_start_program. Move it */
         mr      START_PRG_DOMAIN_STATE_PTR, 3
@@ -433,36 +327,34 @@ FUNCTION(caml_start_program)
 /* Code shared between caml_start_program and caml_callback */
 .L102:
     /* Allocate and link stack frame */
-        stgu    1, -STACKSIZE(1)
+        stdu    1, -STACKSIZE(1)
         .cfi_adjust_cfa_offset STACKSIZE
     /* Save return address */
         mflr    0
-        stg     0, (STACKSIZE + LR_SAVE)(1)
+        std     0, (STACKSIZE + LR_SAVE)(1)
         .cfi_offset 65, LR_SAVE
-    /* Save TOC pointer if applicable */
-#ifdef TOC_SAVE_PARENT
+    /* Save TOC pointer */
         std     2, (STACKSIZE + TOC_SAVE_PARENT)(1)
-#endif
     /* Save all callee-save registers */
-        addi    11, 1, CALLBACK_LINK_SIZE + RESERVED_STACK - WORD
-        stgu    14, WORD(11)
-        stgu    15, WORD(11)
-        stgu    16, WORD(11)
-        stgu    17, WORD(11)
-        stgu    18, WORD(11)
-        stgu    19, WORD(11)
-        stgu    20, WORD(11)
-        stgu    21, WORD(11)
-        stgu    22, WORD(11)
-        stgu    23, WORD(11)
-        stgu    24, WORD(11)
-        stgu    25, WORD(11)
-        stgu    26, WORD(11)
-        stgu    27, WORD(11)
-        stgu    28, WORD(11)
-        stgu    29, WORD(11)
-        stgu    30, WORD(11)
-        stgu    31, WORD(11)
+        addi    11, 1, CALLBACK_LINK_SIZE + RESERVED_STACK - 8
+        stdu    14, 8(11)
+        stdu    15, 8(11)
+        stdu    16, 8(11)
+        stdu    17, 8(11)
+        stdu    18, 8(11)
+        stdu    19, 8(11)
+        stdu    20, 8(11)
+        stdu    21, 8(11)
+        stdu    22, 8(11)
+        stdu    23, 8(11)
+        stdu    24, 8(11)
+        stdu    25, 8(11)
+        stdu    26, 8(11)
+        stdu    27, 8(11)
+        stdu    28, 8(11)
+        stdu    29, 8(11)
+        stdu    30, 8(11)
+        stdu    31, 8(11)
         stfdu   14, 8(11)
         stfdu   15, 8(11)
         stfdu   16, 8(11)
@@ -484,12 +376,12 @@ FUNCTION(caml_start_program)
     /* Load domain state pointer from argument */
         mr      DOMAIN_STATE_PTR, START_PRG_DOMAIN_STATE_PTR
     /* Set up a callback link */
-        lg      11, Caml_state(bottom_of_stack)
-        stg     11, CALLBACK_LINK_OFFSET(1)
-        lg      11, Caml_state(last_return_address)
-        stg     11, (CALLBACK_LINK_OFFSET + WORD)(1)
-        lg      11, Caml_state(gc_regs)
-        stg     11, (CALLBACK_LINK_OFFSET + 2 * WORD)(1)
+        ld      11, Caml_state(bottom_of_stack)
+        std     11, CALLBACK_LINK_OFFSET(1)
+        ld      11, Caml_state(last_return_address)
+        std     11, (CALLBACK_LINK_OFFSET + 8)(1)
+        ld      11, Caml_state(gc_regs)
+        std     11, (CALLBACK_LINK_OFFSET + 2 * 8)(1)
     /* Build an exception handler to catch exceptions escaping out of OCaml */
         bl      .L103
         b       .L104
@@ -497,66 +389,52 @@ FUNCTION(caml_start_program)
         addi    1, 1, -TRAP_SIZE
         .cfi_adjust_cfa_offset TRAP_SIZE
         mflr    0
-        stg     0, TRAP_HANDLER_OFFSET(1)
-        lg      11, Caml_state(exception_pointer)
-        stg     11, TRAP_PREVIOUS_OFFSET(1)
+        std     0, TRAP_HANDLER_OFFSET(1)
+        ld      11, Caml_state(exception_pointer)
+        std     11, TRAP_PREVIOUS_OFFSET(1)
         mr      TRAP_PTR, 1
     /* Reload allocation pointer */
-        lg      ALLOC_PTR, Caml_state(young_ptr)
+        ld      ALLOC_PTR, Caml_state(young_ptr)
     /* Call the OCaml code (address in r12) */
-#if defined(MODEL_ppc)
-        mtctr   12
-.L105:  bctrl
-#elif defined(MODEL_ppc64)
-        ld      0, 0(12)
-        mtctr   0
-        std     2, TOC_SAVE(1)
-        ld      2, 8(12)
-.L105:  bctrl
-        ld      2, TOC_SAVE(1)
-#elif defined(MODEL_ppc64le)
         mtctr   12
         std     2, TOC_SAVE(1)
 .L105:  bctrl
         ld      2, TOC_SAVE(1)
-#else
-#error "wrong MODEL"
-#endif
     /* Pop the trap frame, restoring caml_exception_pointer */
-        lg      0, TRAP_PREVIOUS_OFFSET(1)
-        stg     0, Caml_state(exception_pointer)
+        ld      0, TRAP_PREVIOUS_OFFSET(1)
+        std     0, Caml_state(exception_pointer)
         addi    1, 1, TRAP_SIZE
         .cfi_adjust_cfa_offset -TRAP_SIZE
     /* Pop the callback link, restoring the global variables */
 .L106:
-        lg      0, CALLBACK_LINK_OFFSET(1)
-        stg     0, Caml_state(bottom_of_stack)
-        lg      0, (CALLBACK_LINK_OFFSET + WORD)(1)
-        stg     0, Caml_state(last_return_address)
-        lg      0, (CALLBACK_LINK_OFFSET + 2 * WORD)(1)
-        stg     0, Caml_state(gc_regs)
+        ld      0, CALLBACK_LINK_OFFSET(1)
+        std     0, Caml_state(bottom_of_stack)
+        ld      0, (CALLBACK_LINK_OFFSET + 8)(1)
+        std     0, Caml_state(last_return_address)
+        ld      0, (CALLBACK_LINK_OFFSET + 2 * 8)(1)
+        std     0, Caml_state(gc_regs)
     /* Update allocation pointer */
-        stg     ALLOC_PTR, Caml_state(young_ptr)
+        std     ALLOC_PTR, Caml_state(young_ptr)
     /* Restore callee-save registers */
-        addi    11, 1, CALLBACK_LINK_SIZE + RESERVED_STACK - WORD
-        lgu     14, WORD(11)
-        lgu     15, WORD(11)
-        lgu     16, WORD(11)
-        lgu     17, WORD(11)
-        lgu     18, WORD(11)
-        lgu     19, WORD(11)
-        lgu     20, WORD(11)
-        lgu     21, WORD(11)
-        lgu     22, WORD(11)
-        lgu     23, WORD(11)
-        lgu     24, WORD(11)
-        lgu     25, WORD(11)
-        lgu     26, WORD(11)
-        lgu     27, WORD(11)
-        lgu     28, WORD(11)
-        lgu     29, WORD(11)
-        lgu     30, WORD(11)
-        lgu     31, WORD(11)
+        addi    11, 1, CALLBACK_LINK_SIZE + RESERVED_STACK - 8
+        ldu     14, 8(11)
+        ldu     15, 8(11)
+        ldu     16, 8(11)
+        ldu     17, 8(11)
+        ldu     18, 8(11)
+        ldu     19, 8(11)
+        ldu     20, 8(11)
+        ldu     21, 8(11)
+        ldu     22, 8(11)
+        ldu     23, 8(11)
+        ldu     24, 8(11)
+        ldu     25, 8(11)
+        ldu     26, 8(11)
+        ldu     27, 8(11)
+        ldu     28, 8(11)
+        ldu     29, 8(11)
+        ldu     30, 8(11)
+        ldu     31, 8(11)
         lfdu    14, 8(11)
         lfdu    15, 8(11)
         lfdu    16, 8(11)
@@ -576,7 +454,7 @@ FUNCTION(caml_start_program)
         lfdu    30, 8(11)
         lfdu    31, 8(11)
     /* Reload return address */
-        lg      0, (STACKSIZE + LR_SAVE)(1)
+        ld      0, (STACKSIZE + LR_SAVE)(1)
         mtlr    0
     /* Return */
         addi    1, 1, STACKSIZE
@@ -585,11 +463,9 @@ FUNCTION(caml_start_program)
     /* The trap handler: */
 .L104:
     /* Restore TOC pointer */
-#ifdef TOC_SAVE_PARENT
         ld      2, (STACKSIZE + TOC_SAVE_PARENT)(1)
-#endif
     /* Update caml_exception_pointer */
-        stg     TRAP_PTR, Caml_state(exception_pointer)
+        std     TRAP_PTR, Caml_state(exception_pointer)
     /* Encode exception bucket as an exception result and return it */
         ori     3, 3, 2
         b       .L106
@@ -603,42 +479,37 @@ FUNCTION(caml_callback_asm)
     /* Initial shuffling of arguments */
     /* r3 = Caml_state, r4 = closure, 0(r5) = first arg */
         mr      START_PRG_DOMAIN_STATE_PTR, 3
-        lg      3, 0(5)             /* r3 = Argument */
+        ld      3, 0(5)             /* r3 = Argument */
                                     /* r4 = Closure */
-        lg      START_PRG_ARG, 0(4) /* Code pointer */
+        ld      START_PRG_ARG, 0(4) /* Code pointer */
         b       .L102
 ENDFUNCTION(caml_callback_asm)
 
 FUNCTION(caml_callback2_asm)
     /* r3 = Caml_state, r4 = closure, 0(r5) = first arg,
-       WORD(r5) = second arg */
+       8(r5) = second arg */
         mr      START_PRG_DOMAIN_STATE_PTR, 3
         mr      0, 4
-        lg      3, 0(5)             /* r3 = First argument */
-        lg      4, WORD(5)          /* r4 = Second argument */
+        ld      3, 0(5)             /* r3 = First argument */
+        ld      4, 8(5)          /* r4 = Second argument */
         mr      5, 0                /* r5 = Closure */
         Addrglobal(START_PRG_ARG, caml_apply2)
         b       .L102
 ENDFUNCTION(caml_callback2_asm)
 
 FUNCTION(caml_callback3_asm)
-    /* r3 = Caml_state, r4 = closure, 0(r5) = first arg, WORD(r5) = second arg,
-       2*WORD(r5) = third arg */
+    /* r3 = Caml_state, r4 = closure, 0(r5) = first arg, 8(r5) = second arg,
+       2*8(r5) = third arg */
         mr      START_PRG_DOMAIN_STATE_PTR, 3
         mr      6, 4                /* r6 = Closure */
-        lg      3, 0(5)             /* r3 = First argument */
-        lg      4, WORD(5)          /* r4 = Second argument */
-        lg      5, 2*WORD(5)        /* r5 = Third argument */
+        ld      3, 0(5)             /* r3 = First argument */
+        ld      4, 8(5)          /* r4 = Second argument */
+        ld      5, 2*8(5)        /* r5 = Third argument */
         Addrglobal(START_PRG_ARG, caml_apply3)
         b       .L102
 ENDFUNCTION(caml_callback3_asm)
 
-#if defined(MODEL_ppc64)
-        .section ".opd","aw"
-#else
         .section ".text"
-#endif
-
         .globl  caml_system__code_end
 caml_system__code_end:
 
@@ -647,15 +518,13 @@ caml_system__code_end:
         .section ".data"
         .globl  caml_system.frametable
         .type   caml_system.frametable, @object
-caml_system.frametable:
-        datag   1               /* one descriptor */
-        datag   .L105 + 4       /* return address into callback */
+caml_system__frametable:
+        .quad   1               /* one descriptor */
+        .quad   .L105 + 4       /* return address into callback */
         .short  -1              /* negative size count => use callback link */
         .short  0               /* no roots here */
 
 /* TOC entries */
-
-#if defined(MODEL_ppc64) || defined(MODEL_ppc64le)
 
         .section ".toc", "aw"
 
@@ -664,8 +533,6 @@ caml_system.frametable:
 TOCENTRY(caml_apply2)
 TOCENTRY(caml_apply3)
 TOCENTRY(caml_program)
-
-#endif
 
 /* Mark stack as non-executable */
         .section .note.GNU-stack,"",%progbits

--- a/runtime/power.S
+++ b/runtime/power.S
@@ -13,46 +13,67 @@
 /*                                                                        */
 /**************************************************************************/
 
-#if defined(MODEL_ppc64le)
         .abiversion 2
-#endif
 
 /* Special registers */
+#define SP 1
+#define TMP 11
+#define TMP2 12
 #define START_PRG_ARG 12
 #define START_PRG_DOMAIN_STATE_PTR 7
+#define STACK_ARG_BYTES 24
 #define C_CALL_FUN 25
 #define C_CALL_TOC 26
 #define C_CALL_RET_ADDR 27
+#define C_CALL_TMP 28
 #define TRAP_PTR 29
 #define DOMAIN_STATE_PTR 30
 #define ALLOC_PTR 31
 
 /* Stack layout */
 #define RESERVED_STACK 32
-#define PARAM_SAVE_AREA 0
 #define LR_SAVE 16
 #define TOC_SAVE_PARENT 8
 #define TOC_SAVE 24
-#define TRAP_SIZE 32
-#define TRAP_HANDLER_OFFSET 40
-#define TRAP_PREVIOUS_OFFSET 48
+#define TRAP_SIZE 16
+#define TRAP_HANDLER_OFFSET 8
+#define TRAP_PREVIOUS_OFFSET 0
 #define CALLBACK_LINK_SIZE 32
-#define CALLBACK_LINK_OFFSET 32
+
+/* struct stack_info */
+#define Stack_sp(reg)           0(reg)
+#define Stack_sp_offset         0
+#define Stack_exception(reg)    8(reg)
+#define Stack_handler(reg)      16(reg)
+
+/* struct c_stack_link */
+#define Cstack_stack(reg)       32(reg)
+#define Cstack_sp(reg)          40(reg)
+#define Cstack_sp_offset        40
+#define Cstack_prev(reg)        48(reg)
+
+/* struct stack_handler */
+#define Handler_value(reg)      0(reg)
+#define Handler_exception(reg)  8(reg)
+#define Handler_effect(reg)     16(reg)
+#define Handler_parent(reg)     24(reg)
+#define Handler_parent_offset   24
 
 /* Function definitions */
 
-#define FUNCTION(name) \
-  .section ".text"; \
-  .globl name; \
-  .type name, @function; \
-  .align 2; \
-  name: ; \
-  0: addis 2, 12, (.TOC. - 0b)@ha; \
-  addi 2, 2, (.TOC. - 0b)@l; \
-  .localentry name, . - 0b
+.macro FUNCTION name
+        .section ".text"
+        .globl \name
+        .type \name, @function
+\name:
+0:      addis   2, 12, .TOC.- 0b@ha
+        addi    2, 2,  .TOC.- 0b@l
+        .localentry \name, . - \name
+.endm
 
-#define ENDFUNCTION(name) \
-  .size name, . - name
+.macro ENDFUNCTION name
+       .size \name, . - \name
+.endm
 
 /* Accessing global variables.  */
 
@@ -60,6 +81,13 @@
 
 #define Addrglobal(reg,glob) \
         ld      reg, LSYMB(glob)@toc(2)
+
+/* Accessing local code labels.  */
+
+#define LLABEL(lbl) .LL##lbl
+
+#define Addrlabel(reg,lbl) \
+        ld      reg, LLABEL(lbl)@toc(2)
 
         .set    domain_curr_field, 0
 #define DOMAIN_STATE(c_type, name) \
@@ -70,412 +98,500 @@
 
 #define Caml_state(var) 8*domain_field_caml_##var(DOMAIN_STATE_PTR)
 
+/* Call or tail-call function F defined in another compilation unit */
+
+#define Far_call(fn) bl fn; nop
+
+#define Far_tailcall(fn) Addrglobal(12, fn); mtctr 12; bctr
+
+/* Switch from OCaml stack to C stack */
+
+.macro SWITCH_OCAML_TO_C
+   /* Fill in Caml_state->current_stack->sp */
+       ld      TMP, Caml_state(current_stack)
+       std     SP, Stack_sp(TMP)
+   /* Fill in Caml_state->c_stack */
+       ld      TMP2, Caml_state(c_stack)
+       std     TMP, Cstack_stack(TMP2)
+       std     SP, Cstack_sp(TMP2)
+   /* Switch to C stack */
+       mr      SP, TMP2
+.endm
+
+/* Switch from C stack to OCaml stack */
+
+.macro SWITCH_C_TO_OCAML
+       ld      SP, Cstack_sp(SP)
+.endm
+
+/* Save ALLOC_PTR and TRAP_PTR to domain state, and save
+   the registers used by the code generator to a free gc_regs bucket.
+   Address of bucket is then written to Caml_state(gc_regs) */
+
+.macro SAVE_ALL_REGS
+    /* Save allocation pointer and exception pointer */
+       std      ALLOC_PTR, Caml_state(young_ptr)
+       std      TRAP_PTR, Caml_state(exn_handler)
+    /* Point TMP to the gc_regs bucket and skip to next bucket */
+       ld       TMP, Caml_state(gc_regs_buckets)
+       ld       0, 0(TMP)
+       std      0, Caml_state(gc_regs_buckets)
+    /* Save all allocatable integer registers */
+       std      3,  0x000(TMP)
+       std      4,  0x008(TMP)
+       std      5,  0x010(TMP)
+       std      6,  0x018(TMP)
+       std      7,  0x020(TMP)
+       std      8,  0x028(TMP)
+       std      9,  0x030(TMP)
+       std      10, 0x038(TMP)
+       std      14, 0x040(TMP)
+       std      15, 0x048(TMP)
+       std      16, 0x050(TMP)
+       std      17, 0x058(TMP)
+       std      18, 0x060(TMP)
+       std      19, 0x068(TMP)
+       std      20, 0x070(TMP)
+       std      21, 0x078(TMP)
+       std      22, 0x080(TMP)
+       std      23, 0x088(TMP)
+       std      24, 0x090(TMP)
+       std      25, 0x098(TMP)
+       std      26, 0x0A0(TMP)
+       std      27, 0x0A8(TMP)
+       std      28, 0x0B0(TMP)
+    /* Save caller-save floating-point registers */
+    /* (callee-saves are preserved by C functions) */
+       stfd     1,  0x0B8(TMP)
+       stfd     2,  0x0C0(TMP)
+       stfd     3,  0x0C8(TMP)
+       stfd     4,  0x0D0(TMP)
+       stfd     5,  0x0D8(TMP)
+       stfd     6,  0x0E0(TMP)
+       stfd     7,  0x0E8(TMP)
+       stfd     8,  0x0F0(TMP)
+       stfd     9,  0x0F8(TMP)
+       stfd     10, 0x100(TMP)
+       stfd     11, 0x108(TMP)
+       stfd     12, 0x110(TMP)
+       stfd     13, 0x118(TMP)
+       stfd     14, 0x120(TMP)
+    /* Save bucket to gc_regs */
+       std      TMP, Caml_state(gc_regs)
+.endm
+
+/* Undo SAVE_ALL_REGS: load all the registers saved to Caml_state(gc_regs)
+   and refresh ALLOC_PTR and TRAP_PTR from Caml_state */
+.macro RESTORE_ALL_REGS
+       ld       TMP, Caml_state(gc_regs)
+    /* Restore all allocatable integer registers */
+       ld       3,  0x000(TMP)
+       ld       4,  0x008(TMP)
+       ld       5,  0x010(TMP)
+       ld       6,  0x018(TMP)
+       ld       7,  0x020(TMP)
+       ld       8,  0x028(TMP)
+       ld       9,  0x030(TMP)
+       ld       10, 0x038(TMP)
+       ld       14, 0x040(TMP)
+       ld       15, 0x048(TMP)
+       ld       16, 0x050(TMP)
+       ld       17, 0x058(TMP)
+       ld       18, 0x060(TMP)
+       ld       19, 0x068(TMP)
+       ld       20, 0x070(TMP)
+       ld       21, 0x078(TMP)
+       ld       22, 0x080(TMP)
+       ld       23, 0x088(TMP)
+       ld       24, 0x090(TMP)
+       ld       25, 0x098(TMP)
+       ld       26, 0x0A0(TMP)
+       ld       27, 0x0A8(TMP)
+       ld       28, 0x0B0(TMP)
+    /* Save caller-save floating-point registers
+       (callee-saves are preserved by C functions) */
+       lfd      1,  0x0B8(TMP)
+       lfd      2,  0x0C0(TMP)
+       lfd      3,  0x0C8(TMP)
+       lfd      4,  0x0D0(TMP)
+       lfd      5,  0x0D8(TMP)
+       lfd      6,  0x0E0(TMP)
+       lfd      7,  0x0E8(TMP)
+       lfd      8,  0x0F0(TMP)
+       lfd      9,  0x0F8(TMP)
+       lfd      10, 0x100(TMP)
+       lfd      11, 0x108(TMP)
+       lfd      12, 0x110(TMP)
+       lfd      13, 0x118(TMP)
+       lfd      14, 0x120(TMP)
+    /* Put gc_regs struct back in bucket linked list */
+       ld       TMP2, Caml_state(gc_regs_buckets)
+       std      TMP2, 0(TMP)  /* next ptr */
+       std      TMP, Caml_state(gc_regs_buckets)
+    /* Reload new allocation pointer and exception pointer */
+       ld       ALLOC_PTR, Caml_state(young_ptr)
+       ld       TRAP_PTR, Caml_state(exn_handler)
+.endm
+
         .section ".text"
         .globl  caml_system__code_begin
 caml_system__code_begin:
 
+/* Reallocate the stack when it is too small. */
+/* Desired size is passed in register TMP2. */
+
+FUNCTION caml_call_realloc_stack
+   /* Save return address in caller's frame. */
+        mflr    0
+        std     0, LR_SAVE(SP)
+   /* Save all registers, as well as ALLOC_PTR and TRAP_PTR */
+        SAVE_ALL_REGS  /* TMP2 is preserved */
+   /* Recover desired size, to be passed in r3 */
+        mr      3, TMP2
+   /* Switch stacks and call caml_try_realloc_stack */
+        SWITCH_OCAML_TO_C
+        Far_call(caml_try_realloc_stack)
+        SWITCH_C_TO_OCAML
+        cmpdi   3, 0
+   /* Restore all registers, and also return address */
+        RESTORE_ALL_REGS
+        ld      0, LR_SAVE(SP)
+        mtlr    0
+   /* Check status */
+        beq     1f
+   /* Reallocation successful: return to caller */
+        blr
+   /* Reallocation failed: raise the Stack_overflow exception */
+1:      Addrglobal(3, caml_exn_Stack_overflow)
+        b       .Lcaml_raise_exn
+ENDFUNCTION caml_call_realloc_stack
+
 /* Invoke the garbage collector. */
 
-FUNCTION(caml_call_gc)
-#define STACKSIZE (8*32 + 8*32 + PARAM_SAVE_AREA + RESERVED_STACK)
-    /* 32 integer registers + 32 float registers + space for C call */
-    /* Set up stack frame */
-        stwu    1, -STACKSIZE(1)
-    /* Record return address into OCaml code */
+FUNCTION caml_call_gc
+   /* Save return address in caller's frame */
         mflr    0
-        std     0, Caml_state(last_return_address)
-    /* Record lowest stack address */
-        addi    0, 1, STACKSIZE
-        std     0, Caml_state(bottom_of_stack)
-    /* Record pointer to register array */
-        addi    0, 1, 8*32 + PARAM_SAVE_AREA + RESERVED_STACK
-        std     0, Caml_state(gc_regs)
-    /* Save current allocation pointer for debugging purposes */
-        std     ALLOC_PTR, Caml_state(young_ptr)
-    /* Save exception pointer (if e.g. a sighandler raises) */
-        std     TRAP_PTR, Caml_state(exception_pointer)
-    /* Save all registers used by the code generator */
-        addi    11, 1, 8*32 + PARAM_SAVE_AREA + RESERVED_STACK - 8
-        stdu    3, 8(11)
-        stdu    4, 8(11)
-        stdu    5, 8(11)
-        stdu    6, 8(11)
-        stdu    7, 8(11)
-        stdu    8, 8(11)
-        stdu    9, 8(11)
-        stdu    10, 8(11)
-        stdu    14, 8(11)
-        stdu    15, 8(11)
-        stdu    16, 8(11)
-        stdu    17, 8(11)
-        stdu    18, 8(11)
-        stdu    19, 8(11)
-        stdu    20, 8(11)
-        stdu    21, 8(11)
-        stdu    22, 8(11)
-        stdu    23, 8(11)
-        stdu    24, 8(11)
-        stdu    25, 8(11)
-        stdu    26, 8(11)
-        stdu    27, 8(11)
-        stdu    28, 8(11)
-        addi    11, 1, PARAM_SAVE_AREA + RESERVED_STACK - 8
-        stfdu   1, 8(11)
-        stfdu   2, 8(11)
-        stfdu   3, 8(11)
-        stfdu   4, 8(11)
-        stfdu   5, 8(11)
-        stfdu   6, 8(11)
-        stfdu   7, 8(11)
-        stfdu   8, 8(11)
-        stfdu   9, 8(11)
-        stfdu   10, 8(11)
-        stfdu   11, 8(11)
-        stfdu   12, 8(11)
-        stfdu   13, 8(11)
-        stfdu   14, 8(11)
-        stfdu   15, 8(11)
-        stfdu   16, 8(11)
-        stfdu   17, 8(11)
-        stfdu   18, 8(11)
-        stfdu   19, 8(11)
-        stfdu   20, 8(11)
-        stfdu   21, 8(11)
-        stfdu   22, 8(11)
-        stfdu   23, 8(11)
-        stfdu   24, 8(11)
-        stfdu   25, 8(11)
-        stfdu   26, 8(11)
-        stfdu   27, 8(11)
-        stfdu   28, 8(11)
-        stfdu   29, 8(11)
-        stfdu   30, 8(11)
-        stfdu   31, 8(11)
-    /* Call the GC */
-        bl      caml_garbage_collection
-        nop
-    /* Reload new allocation pointer */
-        ld      ALLOC_PTR, Caml_state(young_ptr)
-    /* Restore all regs used by the code generator */
-        addi    11, 1, 8*32 + PARAM_SAVE_AREA + RESERVED_STACK - 8
-        ldu     3, 8(11)
-        ldu     4, 8(11)
-        ldu     5, 8(11)
-        ldu     6, 8(11)
-        ldu     7, 8(11)
-        ldu     8, 8(11)
-        ldu     9, 8(11)
-        ldu     10, 8(11)
-        ldu     14, 8(11)
-        ldu     15, 8(11)
-        ldu     16, 8(11)
-        ldu     17, 8(11)
-        ldu     18, 8(11)
-        ldu     19, 8(11)
-        ldu     20, 8(11)
-        ldu     21, 8(11)
-        ldu     22, 8(11)
-        ldu     23, 8(11)
-        ldu     24, 8(11)
-        ldu     25, 8(11)
-        ldu     26, 8(11)
-        ldu     27, 8(11)
-        ldu     28, 8(11)
-        addi    11, 1, PARAM_SAVE_AREA + RESERVED_STACK - 8
-        lfdu    1, 8(11)
-        lfdu    2, 8(11)
-        lfdu    3, 8(11)
-        lfdu    4, 8(11)
-        lfdu    5, 8(11)
-        lfdu    6, 8(11)
-        lfdu    7, 8(11)
-        lfdu    8, 8(11)
-        lfdu    9, 8(11)
-        lfdu    10, 8(11)
-        lfdu    11, 8(11)
-        lfdu    12, 8(11)
-        lfdu    13, 8(11)
-        lfdu    14, 8(11)
-        lfdu    15, 8(11)
-        lfdu    16, 8(11)
-        lfdu    17, 8(11)
-        lfdu    18, 8(11)
-        lfdu    19, 8(11)
-        lfdu    20, 8(11)
-        lfdu    21, 8(11)
-        lfdu    22, 8(11)
-        lfdu    23, 8(11)
-        lfdu    24, 8(11)
-        lfdu    25, 8(11)
-        lfdu    26, 8(11)
-        lfdu    27, 8(11)
-        lfdu    28, 8(11)
-        lfdu    29, 8(11)
-        lfdu    30, 8(11)
-        lfdu    31, 8(11)
-    /* Return to caller, resuming the allocation */
-        ld      11, Caml_state(last_return_address)
-        mtlr    11
-    /* Restore the TOC that the caller saved at the usual place */
-        ld      2, (STACKSIZE + TOC_SAVE)(1)
-    /* Deallocate stack frame */
-        addi    1, 1, STACKSIZE
+        std     0, LR_SAVE(SP)
+   /* Save all registers, as well as ALLOC_PTR and TRAP_PTR */
+        SAVE_ALL_REGS
+   /* Switch stacks and call caml_garbage_collection */
+        SWITCH_OCAML_TO_C
+        Far_call(caml_garbage_collection)
+        SWITCH_C_TO_OCAML
+   /* Restore registers and return to caller */
+        RESTORE_ALL_REGS
+        ld      0, LR_SAVE(SP)
+        mtlr    0
+        ld      2, TOC_SAVE(SP)
         blr
-#undef STACKSIZE
-ENDFUNCTION(caml_call_gc)
+ENDFUNCTION caml_call_gc
 
-/* Call a C function from OCaml */
+/* Call a C function from OCaml.  Function to call is in C_CALL_FUN */
 
-FUNCTION(caml_c_call)
-        .cfi_startproc
-    /* Save return address in a callee-save register */
+FUNCTION caml_c_call
+.Lcaml_c_call:
+   /* Save return address in caller's frame AND in a callee-save register */
         mflr    C_CALL_RET_ADDR
-        .cfi_register 65, C_CALL_RET_ADDR
-    /* Record lowest stack address and return address */
-        std     1, Caml_state(bottom_of_stack)
-        std     C_CALL_RET_ADDR, Caml_state(last_return_address)
-    /* Make the exception handler and alloc ptr available to the C code */
+        std     C_CALL_RET_ADDR, LR_SAVE(SP)
+   /* Switch from OCaml to C */
+        SWITCH_OCAML_TO_C
+   /* Make the exception handler and alloc ptr available to the C code */
         std     ALLOC_PTR, Caml_state(young_ptr)
-        std     TRAP_PTR, Caml_state(exception_pointer)
+        std     TRAP_PTR, Caml_state(exn_handler)
     /* Call C function (address in C_CALL_FUN) */
         mtctr   C_CALL_FUN
         mr      12, C_CALL_FUN
         mr      C_CALL_TOC, 2   /* save current TOC in a callee-save register */
         bctrl
         mr      2, C_CALL_TOC   /* restore current TOC */
-    /* Restore return address (in 27, preserved by the C function) */
+    /* Restore return address (in register C_CALL_RET_ADDR, preserved by C) */
         mtlr    C_CALL_RET_ADDR
     /* Reload allocation pointer*/
         ld      ALLOC_PTR, Caml_state(young_ptr)
+    /* Switch from C to OCaml */
+        SWITCH_C_TO_OCAML
     /* Return to caller */
         blr
-        .cfi_endproc
-ENDFUNCTION(caml_c_call)
+ENDFUNCTION caml_c_call
+
+FUNCTION caml_c_call_stack_args
+   /* Extra arguments to be passed on stack:
+      STACK_ARG_BYTES at offsets 32 to 32 + STACK_ARG_BYTES from SP */
+        mr      C_CALL_TMP, SP
+   /* Save return address in caller's frame AND in a callee-save register */
+        mflr    C_CALL_RET_ADDR
+        std     C_CALL_RET_ADDR, LR_SAVE(SP)
+   /* Switch from OCaml to C */
+        SWITCH_OCAML_TO_C
+   /* Make the exception handler and alloc ptr available to the C code */
+        std     ALLOC_PTR, Caml_state(young_ptr)
+        std     TRAP_PTR, Caml_state(exn_handler)
+   /* Reserve STACK_ARG_BYTES bytes on the C stack */
+        subfc   SP, STACK_ARG_BYTES, SP
+   /* Copy from OCaml SP + [32...32+STACK_ARG_BYTES)
+           to C SP + [32...32+STACK_ARG_BYTES) */
+        addi    TMP, STACK_ARG_BYTES, 32 - 8
+1:      ldx     0, C_CALL_TMP, TMP
+        stdx    0, SP, TMP
+        addi    TMP, TMP, -8
+        cmpdi   TMP, 32
+        bge     1b
+    /* Call C function (address in C_CALL_FUN) */
+        mtctr   C_CALL_FUN
+        mr      12, C_CALL_FUN
+        mr      C_CALL_TOC, 2   /* save current TOC in a callee-save register */
+        bctrl
+        mr      2, C_CALL_TOC   /* restore current TOC */
+    /* Pop the extra stack space used */
+        add     SP, SP, STACK_ARG_BYTES
+    /* Restore return address (in register C_CALL_RET_ADDR, preserved by C) */
+        mtlr    C_CALL_RET_ADDR
+    /* Reload allocation pointer*/
+        ld      ALLOC_PTR, Caml_state(young_ptr)
+    /* Switch from C to OCaml */
+        SWITCH_C_TO_OCAML
+    /* Return to caller */
+        blr
+ENDFUNCTION caml_c_call_stack_args
 
 /* Raise an exception from OCaml */
 
-FUNCTION(caml_raise_exn)
+FUNCTION caml_raise_exn
+.Lcaml_raise_exn:
         ld      0, Caml_state(backtrace_active)
-        cmpwi   0, 0
+        cmpdi   0, 0
         bne     .L111
 .L110:
     /* Pop trap frame */
         ld      0, TRAP_HANDLER_OFFSET(TRAP_PTR)
-        mr      1, TRAP_PTR
+        addi    SP, TRAP_PTR, TRAP_SIZE-RESERVED_STACK
         mtctr   0
-        ld      TRAP_PTR, TRAP_PREVIOUS_OFFSET(1)
-        addi    1, 1, TRAP_SIZE
+        ld      TRAP_PTR, (RESERVED_STACK-TRAP_SIZE+TRAP_PREVIOUS_OFFSET)(SP)
     /* Branch to handler */
         bctr
 .L111:
+    /* Zero backtrace_pos */
+        li      0, 0
+        std     0, Caml_state(backtrace_pos)
+.L112:
         mr      27, 3           /* preserve exn bucket in callee-save reg */
                                 /* arg1: exception bucket, already in r3 */
         mflr    4               /* arg2: PC of raise */
-        mr      5, 1            /* arg3: SP of raise */
+        mr      5, SP           /* arg3: SP of raise */
         mr      6, TRAP_PTR     /* arg4: SP of handler */
-        addi    1, 1, -(PARAM_SAVE_AREA + RESERVED_STACK)
-                                /* reserve stack space for C call */
-        bl      caml_stash_backtrace
-        nop
-        mr      3, 27           /* restore exn bucket */
-        b       .L110           /* raise the exn */
-ENDFUNCTION(caml_raise_exn)
+    /* Switch to C stack and call caml_stash_backtrace */
+        ld      SP, Caml_state(c_stack)
+        Far_call(caml_stash_backtrace)
+    /* Restore exception bucket and raise */
+        mr      3, 27
+        b       .L110
+ENDFUNCTION caml_raise_exn
+
+FUNCTION caml_reraise_exn
+        ld      0, Caml_state(backtrace_active)
+        cmpdi   0, 0
+        bne     .L112
+    /* Pop trap frame */
+        ld      0, TRAP_HANDLER_OFFSET(TRAP_PTR)
+        addi    SP, TRAP_PTR, TRAP_SIZE-RESERVED_STACK
+        mtctr   0
+        ld      TRAP_PTR, (RESERVED_STACK-TRAP_SIZE+TRAP_PREVIOUS_OFFSET)(SP)
+    /* Branch to handler */
+        bctr
+ENDFUNCTION caml_reraise_exn
 
 /* Raise an exception from C */
 
-FUNCTION(caml_raise_exception)
-    /* Load domain state pointer */
+FUNCTION caml_raise_exception
+    /* Reinitialize domain state pointer */
         mr      DOMAIN_STATE_PTR, 3
+    /* Move exn bucket where caml_raise_exn expects it */
         mr      3, 4
-        ld      0, Caml_state(backtrace_active)
-        cmpwi   0, 0
-        bne     .L121
-.L120:
-    /* Reload OCaml global registers */
-        ld      1, Caml_state(exception_pointer)
+    /* Reload allocation pointer and exception pointer */
         ld      ALLOC_PTR, Caml_state(young_ptr)
-    /* Pop trap frame */
-        ld      0, TRAP_HANDLER_OFFSET(1)
-        mtctr   0
-        ld      TRAP_PTR, TRAP_PREVIOUS_OFFSET(1)
-        addi    1, 1, TRAP_SIZE
-    /* Branch to handler */
-        bctr
-.L121:
-        mr      27, 3           /* preserve exn bucket in callee-save reg */
-                                /* arg1: exception bucket, already in r3 */
-        ld      4, Caml_state(last_return_address) /* arg2: PC of raise */
-        ld      5, Caml_state(bottom_of_stack)     /* arg3: SP of raise */
-        ld      6, Caml_state(exception_pointer)   /* arg4: SP of handler */
-        addi    1, 1, -(PARAM_SAVE_AREA + RESERVED_STACK)
-                                         /* reserve stack space for C call */
-        bl      caml_stash_backtrace
-        nop
-        mr      3, 27           /* restore exn bucket */
-        b       .L120           /* raise the exn */
-ENDFUNCTION(caml_raise_exception)
+        ld      TRAP_PTR, Caml_state(exn_handler)
+    /* Discard the C stack pointer and switch to OCaml stack */
+        ld      TMP, Caml_state(current_stack)
+        ld      SP, Stack_sp(TMP)
+    /* Reload return address from caller's frame (for the backtrace) */
+        ld      0, LR_SAVE(SP)
+        mtlr    0
+    /* Raise the exception */
+        b       .Lcaml_raise_exn
+ENDFUNCTION caml_raise_exception
 
 /* Start the OCaml program */
 
-FUNCTION(caml_start_program)
-        .cfi_startproc
-#define STACKSIZE (8*18 + 8*18 + CALLBACK_LINK_SIZE + RESERVED_STACK)
-  /* 18 callee-save GPR14...GPR31 + 18 callee-save FPR14...FPR31 */
+FUNCTION caml_start_program
   /* Domain state pointer is the first arg to caml_start_program. Move it */
         mr      START_PRG_DOMAIN_STATE_PTR, 3
+  /* Code to call is caml_program */
         Addrglobal(START_PRG_ARG, caml_program)
+
 /* Code shared between caml_start_program and caml_callback */
+/* Domain state pointer is in START_PRG_DOMAIN_STATE_PTR */
+/* Code to call is in START_PRG_ARG */
 .L102:
+    /* Stack frame contains:
+       - 18 callee-save FPRs
+       - 18 callee-save GPRs
+       - a struct c_stack_link
+       - the standard reserved space */
+#define STACKSIZE (18 * 8 + 18 * 8 + CALLBACK_LINK_SIZE + RESERVED_STACK)
     /* Allocate and link stack frame */
         stdu    1, -STACKSIZE(1)
-        .cfi_adjust_cfa_offset STACKSIZE
-    /* Save return address */
+    /* Save return address and TOC pointer */
         mflr    0
         std     0, (STACKSIZE + LR_SAVE)(1)
-        .cfi_offset 65, LR_SAVE
-    /* Save TOC pointer */
         std     2, (STACKSIZE + TOC_SAVE_PARENT)(1)
     /* Save all callee-save registers */
-        addi    11, 1, CALLBACK_LINK_SIZE + RESERVED_STACK - 8
-        stdu    14, 8(11)
-        stdu    15, 8(11)
-        stdu    16, 8(11)
-        stdu    17, 8(11)
-        stdu    18, 8(11)
-        stdu    19, 8(11)
-        stdu    20, 8(11)
-        stdu    21, 8(11)
-        stdu    22, 8(11)
-        stdu    23, 8(11)
-        stdu    24, 8(11)
-        stdu    25, 8(11)
-        stdu    26, 8(11)
-        stdu    27, 8(11)
-        stdu    28, 8(11)
-        stdu    29, 8(11)
-        stdu    30, 8(11)
-        stdu    31, 8(11)
-        stfdu   14, 8(11)
-        stfdu   15, 8(11)
-        stfdu   16, 8(11)
-        stfdu   17, 8(11)
-        stfdu   18, 8(11)
-        stfdu   19, 8(11)
-        stfdu   20, 8(11)
-        stfdu   21, 8(11)
-        stfdu   22, 8(11)
-        stfdu   23, 8(11)
-        stfdu   24, 8(11)
-        stfdu   25, 8(11)
-        stfdu   26, 8(11)
-        stfdu   27, 8(11)
-        stfdu   28, 8(11)
-        stfdu   29, 8(11)
-        stfdu   30, 8(11)
-        stfdu   31, 8(11)
+        addi    TMP, 1, CALLBACK_LINK_SIZE + RESERVED_STACK - 8
+        stdu    14, 8(TMP)
+        stdu    15, 8(TMP)
+        stdu    16, 8(TMP)
+        stdu    17, 8(TMP)
+        stdu    18, 8(TMP)
+        stdu    19, 8(TMP)
+        stdu    20, 8(TMP)
+        stdu    21, 8(TMP)
+        stdu    22, 8(TMP)
+        stdu    23, 8(TMP)
+        stdu    24, 8(TMP)
+        stdu    25, 8(TMP)
+        stdu    26, 8(TMP)
+        stdu    27, 8(TMP)
+        stdu    28, 8(TMP)
+        stdu    29, 8(TMP)
+        stdu    30, 8(TMP)
+        stdu    31, 8(TMP)
+        stfdu   14, 8(TMP)
+        stfdu   15, 8(TMP)
+        stfdu   16, 8(TMP)
+        stfdu   17, 8(TMP)
+        stfdu   18, 8(TMP)
+        stfdu   19, 8(TMP)
+        stfdu   20, 8(TMP)
+        stfdu   21, 8(TMP)
+        stfdu   22, 8(TMP)
+        stfdu   23, 8(TMP)
+        stfdu   24, 8(TMP)
+        stfdu   25, 8(TMP)
+        stfdu   26, 8(TMP)
+        stfdu   27, 8(TMP)
+        stfdu   28, 8(TMP)
+        stfdu   29, 8(TMP)
+        stfdu   30, 8(TMP)
+        stfdu   31, 8(TMP)
     /* Load domain state pointer from argument */
         mr      DOMAIN_STATE_PTR, START_PRG_DOMAIN_STATE_PTR
-    /* Set up a callback link */
-        ld      11, Caml_state(bottom_of_stack)
-        std     11, CALLBACK_LINK_OFFSET(1)
-        ld      11, Caml_state(last_return_address)
-        std     11, (CALLBACK_LINK_OFFSET + 8)(1)
-        ld      11, Caml_state(gc_regs)
-        std     11, (CALLBACK_LINK_OFFSET + 2 * 8)(1)
-    /* Build an exception handler to catch exceptions escaping out of OCaml */
-        bl      .L103
-        b       .L104
-.L103:
-        addi    1, 1, -TRAP_SIZE
-        .cfi_adjust_cfa_offset TRAP_SIZE
-        mflr    0
-        std     0, TRAP_HANDLER_OFFSET(1)
-        ld      11, Caml_state(exception_pointer)
-        std     11, TRAP_PREVIOUS_OFFSET(1)
-        mr      TRAP_PTR, 1
     /* Reload allocation pointer */
         ld      ALLOC_PTR, Caml_state(young_ptr)
-    /* Call the OCaml code (address in r12) */
-        mtctr   12
-        std     2, TOC_SAVE(1)
-.L105:  bctrl
-        ld      2, TOC_SAVE(1)
-    /* Pop the trap frame, restoring caml_exception_pointer */
-        ld      0, TRAP_PREVIOUS_OFFSET(1)
-        std     0, Caml_state(exception_pointer)
-        addi    1, 1, TRAP_SIZE
-        .cfi_adjust_cfa_offset -TRAP_SIZE
-    /* Pop the callback link, restoring the global variables */
-.L106:
-        ld      0, CALLBACK_LINK_OFFSET(1)
-        std     0, Caml_state(bottom_of_stack)
-        ld      0, (CALLBACK_LINK_OFFSET + 8)(1)
-        std     0, Caml_state(last_return_address)
-        ld      0, (CALLBACK_LINK_OFFSET + 2 * 8)(1)
-        std     0, Caml_state(gc_regs)
+    /* Set up a struct c_stack_link on the C stack */
+        ld      0, Caml_state(c_stack)
+        std     0, Cstack_prev(SP)
+        std     SP, Caml_state(c_stack)
+    /* Load the OCaml stack */
+        ld      TMP, Caml_state(current_stack)
+        ld      TMP, Stack_sp(TMP)
+    /* Store the gc_regs for callbacks during a GC */
+        ld      0, Caml_state(gc_regs)
+        stdu    0, -8(TMP)
+    /* Store the stack pointer to allow DWARF unwind (one day) */
+        stdu    SP, -8(TMP)
+    /* Setup a trap frame to catch exceptions escaping the OCaml code */
+        addi    TMP, TMP, -TRAP_SIZE
+        ld      0, Caml_state(exn_handler)
+        std     0, TRAP_PREVIOUS_OFFSET(TMP)
+        Addrlabel(0,trap_handler)
+        std     0, TRAP_HANDLER_OFFSET(TMP)
+        mr      TRAP_PTR, TMP
+    /* Switch stacks, reserving 32 bytes at the bottom of the OCaml stack */
+        addi    SP, TMP, -RESERVED_STACK
+    /* Call the OCaml code (address in START_PRG_ARG) */
+        mtctr   START_PRG_ARG
+.Lcaml_retaddr:
+        bctrl
+    /* Pop the reserved 32 bytes */
+        addi    SP, SP, RESERVED_STACK
+    /* Pop the trap frame, restoring caml_exn_handler */
+        ld      0, TRAP_PREVIOUS_OFFSET(SP)
+        std     0, Caml_state(exn_handler)
+        addi    SP, SP, TRAP_SIZE
     /* Update allocation pointer */
+.L106:
         std     ALLOC_PTR, Caml_state(young_ptr)
+    /* Restore GC regs */
+        ld      0, 8(SP)
+        std     0, Caml_state(gc_regs)
+        addi    SP, SP, 16
+    /* Return to C stack */
+        ld      TMP, Caml_state(current_stack)
+        std     SP, Stack_sp(TMP)
+        ld      SP, Caml_state(c_stack)
+    /* Pop the struct c_stack_link */
+        ld      0, Cstack_prev(SP)
+        std     0, Caml_state(c_stack)
     /* Restore callee-save registers */
-        addi    11, 1, CALLBACK_LINK_SIZE + RESERVED_STACK - 8
-        ldu     14, 8(11)
-        ldu     15, 8(11)
-        ldu     16, 8(11)
-        ldu     17, 8(11)
-        ldu     18, 8(11)
-        ldu     19, 8(11)
-        ldu     20, 8(11)
-        ldu     21, 8(11)
-        ldu     22, 8(11)
-        ldu     23, 8(11)
-        ldu     24, 8(11)
-        ldu     25, 8(11)
-        ldu     26, 8(11)
-        ldu     27, 8(11)
-        ldu     28, 8(11)
-        ldu     29, 8(11)
-        ldu     30, 8(11)
-        ldu     31, 8(11)
-        lfdu    14, 8(11)
-        lfdu    15, 8(11)
-        lfdu    16, 8(11)
-        lfdu    17, 8(11)
-        lfdu    18, 8(11)
-        lfdu    19, 8(11)
-        lfdu    20, 8(11)
-        lfdu    21, 8(11)
-        lfdu    22, 8(11)
-        lfdu    23, 8(11)
-        lfdu    24, 8(11)
-        lfdu    25, 8(11)
-        lfdu    26, 8(11)
-        lfdu    27, 8(11)
-        lfdu    28, 8(11)
-        lfdu    29, 8(11)
-        lfdu    30, 8(11)
-        lfdu    31, 8(11)
-    /* Reload return address */
+        addi    TMP, SP, CALLBACK_LINK_SIZE + RESERVED_STACK - 8
+        ldu     14, 8(TMP)
+        ldu     15, 8(TMP)
+        ldu     16, 8(TMP)
+        ldu     17, 8(TMP)
+        ldu     18, 8(TMP)
+        ldu     19, 8(TMP)
+        ldu     20, 8(TMP)
+        ldu     21, 8(TMP)
+        ldu     22, 8(TMP)
+        ldu     23, 8(TMP)
+        ldu     24, 8(TMP)
+        ldu     25, 8(TMP)
+        ldu     26, 8(TMP)
+        ldu     27, 8(TMP)
+        ldu     28, 8(TMP)
+        ldu     29, 8(TMP)
+        ldu     30, 8(TMP)
+        ldu     31, 8(TMP)
+        lfdu    14, 8(TMP)
+        lfdu    15, 8(TMP)
+        lfdu    16, 8(TMP)
+        lfdu    17, 8(TMP)
+        lfdu    18, 8(TMP)
+        lfdu    19, 8(TMP)
+        lfdu    20, 8(TMP)
+        lfdu    21, 8(TMP)
+        lfdu    22, 8(TMP)
+        lfdu    23, 8(TMP)
+        lfdu    24, 8(TMP)
+        lfdu    25, 8(TMP)
+        lfdu    26, 8(TMP)
+        lfdu    27, 8(TMP)
+        lfdu    28, 8(TMP)
+        lfdu    29, 8(TMP)
+        lfdu    30, 8(TMP)
+        lfdu    31, 8(TMP)
+    /* Reload return address and TOC pointer */
         ld      0, (STACKSIZE + LR_SAVE)(1)
+        ld      2, (STACKSIZE + TOC_SAVE_PARENT)(1)
         mtlr    0
     /* Return */
         addi    1, 1, STACKSIZE
         blr
 
     /* The trap handler: */
-.L104:
-    /* Restore TOC pointer */
-        ld      2, (STACKSIZE + TOC_SAVE_PARENT)(1)
-    /* Update caml_exception_pointer */
-        std     TRAP_PTR, Caml_state(exception_pointer)
+.Ltrap_handler:
+    /* Update caml_exn_handler */
+        std     TRAP_PTR, Caml_state(exn_handler)
+    /* Pop the reserved 32 bytes */
+        addi    SP, SP, RESERVED_STACK
     /* Encode exception bucket as an exception result and return it */
         ori     3, 3, 2
         b       .L106
 #undef STACKSIZE
-        .cfi_endproc
-ENDFUNCTION(caml_start_program)
+ENDFUNCTION caml_start_program
 
 /* Callback from C to OCaml */
 
-FUNCTION(caml_callback_asm)
+FUNCTION caml_callback_asm
     /* Initial shuffling of arguments */
     /* r3 = Caml_state, r4 = closure, 0(r5) = first arg */
         mr      START_PRG_DOMAIN_STATE_PTR, 3
@@ -483,9 +599,9 @@ FUNCTION(caml_callback_asm)
                                     /* r4 = Closure */
         ld      START_PRG_ARG, 0(4) /* Code pointer */
         b       .L102
-ENDFUNCTION(caml_callback_asm)
+ENDFUNCTION caml_callback_asm
 
-FUNCTION(caml_callback2_asm)
+FUNCTION caml_callback2_asm
     /* r3 = Caml_state, r4 = closure, 0(r5) = first arg,
        8(r5) = second arg */
         mr      START_PRG_DOMAIN_STATE_PTR, 3
@@ -495,9 +611,9 @@ FUNCTION(caml_callback2_asm)
         mr      5, 0                /* r5 = Closure */
         Addrglobal(START_PRG_ARG, caml_apply2)
         b       .L102
-ENDFUNCTION(caml_callback2_asm)
+ENDFUNCTION caml_callback2_asm
 
-FUNCTION(caml_callback3_asm)
+FUNCTION caml_callback3_asm
     /* r3 = Caml_state, r4 = closure, 0(r5) = first arg, 8(r5) = second arg,
        2*8(r5) = third arg */
         mr      START_PRG_DOMAIN_STATE_PTR, 3
@@ -507,7 +623,188 @@ FUNCTION(caml_callback3_asm)
         ld      5, 2*8(5)        /* r5 = Third argument */
         Addrglobal(START_PRG_ARG, caml_apply3)
         b       .L102
-ENDFUNCTION(caml_callback3_asm)
+ENDFUNCTION caml_callback3_asm
+
+/* Fibers */
+
+/* Switch between OCaml stacks. Clobbers register 0 and switches TRAP_PTR.
+   Preserves old_stack and new_stack registers */
+.macro SWITCH_OCAML_STACKS old_stack, new_stack
+    /* Save return address for old_stack */
+        mflr    0
+        std     0, LR_SAVE(SP)
+    /* Save OCaml SP and exn_handler in the stack info */
+        std     SP, Stack_sp(\old_stack)
+        std     TRAP_PTR, Stack_exception(\old_stack)
+    /* switch stacks */
+        std     \new_stack, Caml_state(current_stack)
+        ld      SP, Stack_sp(\new_stack)
+    /* restore exn_handler for new stack */
+        ld      TRAP_PTR, Stack_exception(\new_stack)
+    /* Restore return address for new_stack */
+        ld      0, LR_SAVE(SP)
+        mtlr    0
+.endm
+
+/*
+ * A continuation is a one word object that points to a fiber. A fiber [f] will
+ * point to its parent at Handler_parent(Stack_handler(f)). In the following,
+ * the [last_fiber] refers to the last fiber in the linked-list formed by the
+ * parent pointer.
+ */
+
+FUNCTION caml_perform
+  /* r3: effect to perform
+     r4: freshly allocated continuation */
+
+        ld      5, Caml_state(current_stack) /* r5 := old stack */
+        addi    6, 5, 1  /* r6 := Val_ptr(old stack) */
+        std     6, 0(4)  /* Initialize continuation */
+.Ldo_perform:
+  /* r3: effect to perform
+     r4: continuation
+     r5: old_stack
+     r6: last_fiber */
+
+        ld      7, Stack_handler(5)  /* r7 := old stack -> handler */
+        ld      8, Handler_parent(7) /* r8 := parent stack */
+        cmpdi   8, 0
+        beq     1f
+        SWITCH_OCAML_STACKS 5, 8
+  /* We have to null the Handler_parent after the switch because
+     the Handler_parent is needed to unwind the stack for backtraces */
+        li      0, 0
+        std     0, Handler_parent(7) /* Set parent of performer to NULL */
+        ld      0, Handler_effect(7)
+                                     /* 1st argument: effect to perform */
+                                     /* 2nd argument: continuation */
+        mr      5, 6                 /* 3rd argument: last_fiber */
+        mr      6, 0                 /* 4th argument: effect handler */
+        Far_tailcall(caml_apply3)
+1:
+  /* Switch back to original performer before raising Effect.Unhandled
+     (no-op unless this is a reperform) */
+        ld      10, 0(4) /* r10 := performer stack (loaded from continuation) */
+        addi    10, 10, -1 /* r10 := Ptr_val(r10) */
+        ld      9, Caml_state(current_stack)
+        SWITCH_OCAML_STACKS 9, 10
+  /* No parent stack. Raise Effect.Unhandled. */
+        Addrglobal(C_CALL_FUN, caml_raise_unhandled_effect)
+        b       .Lcaml_c_call
+ENDFUNCTION caml_perform
+
+FUNCTION caml_reperform
+  /* r3: effect to perform
+     r4: continuation
+     r5: last_fiber */
+        addi    5, 5, -1
+        ld      TMP, Stack_handler(5)
+        ld      5, Caml_state(current_stack) /* r5 := old stack */
+        std     5, Handler_parent(TMP) /* Append to last_fiber */
+        addi    6, 5, 1 /* r6 (last_fiber) := Val_ptr(old stack) */
+        b       .Ldo_perform
+ENDFUNCTION caml_reperform
+
+FUNCTION caml_resume
+  /* r3: new fiber
+     r4: fun
+     r5: arg */
+        addi    3, 3, -1 /* r3 = Ptr_val(r3) */
+        ld      12, 0(4) /* r12 = code pointer */
+        mtctr   12       /* CTR = code pointer */
+    /* Check if stack is null, then already used */
+        cmpdi   3, 0
+        beq     2f
+    /* Find end of list of stacks (put in r7) */
+        mr      TMP, 3
+1:      ld      7, Stack_handler(TMP)
+        ld      TMP, Handler_parent(7)
+        cmpdi   TMP, 0
+        bne     1b
+    /* Add current stack to the end */
+        ld      8, Caml_state(current_stack)
+        std     8, Handler_parent(7)
+    /* Switch stacks and run code */
+        SWITCH_OCAML_STACKS 8, 3
+        mr      3, 5
+        bctr
+2:      Addrglobal(C_CALL_FUN, caml_raise_continuation_already_resumed)
+        b       .Lcaml_c_call
+ENDFUNCTION caml_resume
+
+/* Run a function on a new stack, then either
+   return the value or invoke exception handler */
+FUNCTION caml_runstack
+  /* r3: fiber
+     r4: fun
+     r5: arg */
+    /* save return address and TOC on old stack */
+        mflr    0
+        std     0, LR_SAVE(SP)
+        std     2, TOC_SAVE_PARENT(SP)
+        addi    3, 3, -1   /* r3 := Ptr_val(r3) */
+        ld      12, 0(4)   /* r12 := code pointer */
+        mtctr   12         /* CTR := code pointer */
+    /*  save old stack pointer and exception handler */
+        ld      8, Caml_state(current_stack) /* r8 := old stack */
+        std     SP, Stack_sp(8)
+        std     TRAP_PTR, Stack_exception(8)
+    /* Load new stack pointer and set parent */
+        ld      TMP, Stack_handler(3)
+        std     8, Handler_parent(TMP)
+        std     3, Caml_state(current_stack)
+        ld      9, Stack_sp(3) /* r9 := sp of new stack */
+    /* Reserve 16-byte DWARF and gc_regs block, which is unused here. */
+        addi    9, 9, -16
+    /* Create an exception handler on the target stack
+       after 16byte DWARF & gc_regs block (which is unused here) */
+        addi    9, 9, -TRAP_SIZE
+        Addrlabel(TMP, fiber_exn_handler)
+        std     TMP, TRAP_HANDLER_OFFSET(9)
+    /* link the previous exn_handler so that copying stacks works */
+        ld      TMP, Stack_exception(3)
+        std     TMP, TRAP_PREVIOUS_OFFSET(9)
+        mr      TRAP_PTR, 9
+    /* Switch to the new stack, after reserving 32 bytes at bottom */
+        addi    SP, 9, -RESERVED_STACK
+    /* Call the function on the new stack */
+        mr      3, 5   /* argument */
+.Lframe_runstack:
+        bctrl
+    /* Clean up on return */
+        addi    8, SP, (RESERVED_STACK + TRAP_SIZE + 16)
+                                       /* r8 := stack_handler */
+        ld      25, Handler_value(8) /* saved across C call */
+1:
+        mr      26, 3                /* save return value across C call */
+        ld      3, Caml_state(current_stack) /* arg to caml_free_stack */
+    /* restore parent stack and exn_handler into Caml_state */
+        ld      TMP, Handler_parent(8)
+        std     TMP, Caml_state(current_stack)
+        ld      TRAP_PTR, Stack_exception(TMP)
+        std     TRAP_PTR, Caml_state(exn_handler)
+    /* restore saved TOC */
+        ld      27, Stack_sp(TMP)    /* saved across C calls */
+        ld      2, TOC_SAVE_PARENT(27)
+    /* free old stack by switching directly to c_stack;
+       this is a no-alloc call */
+        ld      SP, Caml_state(c_stack)
+        Far_call(caml_free_stack)
+    /* switch directly to parent stack with correct return */
+        mr      3, 26  /* return value */
+        mr      4, 25  /* handler value */
+        mr      SP, 27 /* OCaml stack */
+        ld      12, 0(4) /* code pointer */
+        mtctr   12       /* code pointer */
+    /* Invoke handle_value (or handle_exn) */
+        ld      0, LR_SAVE(SP)
+        mtlr    0
+        bctr
+.Lfiber_exn_handler:
+        addi    8, SP, (RESERVED_STACK + 16) /* r8 := stack_handler */
+        ld      25, Handler_exception(8)
+        b       1b
+ENDFUNCTION caml_runstack
 
         .section ".text"
         .globl  caml_system__code_end
@@ -518,21 +815,32 @@ caml_system__code_end:
         .section ".data"
         .globl  caml_system.frametable
         .type   caml_system.frametable, @object
-caml_system__frametable:
-        .quad   1               /* one descriptor */
-        .quad   .L105 + 4       /* return address into callback */
-        .short  -1              /* negative size count => use callback link */
+caml_system.frametable:
+        .quad   2               /* two descriptors */
+        .quad   .Lcaml_retaddr + 4  /* return address into callback */
+        .short  -1              /* negative frame size => use callback link */
+        .short  0               /* no roots */
+        .align  3
+        .quad   .Lframe_runstack + 4 /* return address into fiber handler */
+        .short  -1              /* negative frame size => use callback link */
         .short  0               /* no roots here */
+        .align 3
 
 /* TOC entries */
 
         .section ".toc", "aw"
 
 #define TOCENTRY(glob) LSYMB(glob): .quad glob
+#define TOCENTRYLABEL(lbl) LLABEL(lbl): .quad .L##lbl
 
 TOCENTRY(caml_apply2)
 TOCENTRY(caml_apply3)
 TOCENTRY(caml_program)
+TOCENTRY(caml_exn_Stack_overflow)
+TOCENTRY(caml_raise_unhandled_effect)
+TOCENTRY(caml_raise_continuation_already_resumed)
+TOCENTRYLABEL(fiber_exn_handler)
+TOCENTRYLABEL(trap_handler)
 
 /* Mark stack as non-executable */
         .section .note.GNU-stack,"",%progbits

--- a/runtime/signals.c
+++ b/runtime/signals.c
@@ -540,8 +540,6 @@ static void * caml_signal_stack_0 = NULL;
 
 void caml_init_signals(void)
 {
-  /* Bound-check trap handling for Power and S390x will go here eventually. */
-
   /* Set up alternate signal stack for domain 0 */
 #ifdef POSIX_SIGNALS
   caml_signal_stack_0 = caml_init_signal_stack();
@@ -562,6 +560,16 @@ void caml_init_signals(void)
         sigaction(SIGPROF, &act, NULL);
       }
     }
+  }
+#endif
+  /* Bound-check trap handling for Power */
+#if defined(NATIVE_CODE) && defined(TARGET_power)
+  {
+    struct sigaction act;
+    act.sa_sigaction = caml_sigtrap_handler;
+    sigemptyset(&act.sa_mask);
+    act.sa_flags = SA_SIGINFO | SA_NODEFER;
+    sigaction(SIGTRAP, &act, NULL);
   }
 #endif
 }

--- a/testsuite/tests/arch-power/exn_raise.ml
+++ b/testsuite/tests/arch-power/exn_raise.ml
@@ -1,7 +1,6 @@
 (* TEST
  arch_power;
  native;
- ocamlopt_flags = "-flarge-toc";
  ocamlopt.byte;
  run;
 *)

--- a/testsuite/tests/callback/stack_overflow.ml
+++ b/testsuite/tests/callback/stack_overflow.ml
@@ -23,8 +23,8 @@ open Effect.Deep
 type _ t += E : unit t
 
 let () =
-  Printf.printf "%d\n%d\n%!"
-    (!(deep 1000))
+  Printf.printf "%d\n%!" (!(deep 1000));
+  Printf.printf "%d\n%!"
     (match_with deep 1000
      { retc = (fun x -> !x);
        exnc = (fun e -> raise e);


### PR DESCRIPTION
This big PR restores native-code support for the POWER/PowerPC 64 bits little endian architecture and adds support for all the OCaml 5 niceties.

The other two POWER/PowerPC variants (32 bits and 64 bits big endian) remain bytecode-only, as they have pretty much disappeared from the server world and are now only found in embedded systems that are unlikely to run OCaml code.

The PR is best reviewed commit-by-commit.  Most of the work is in commit 05d82f9d90d501b77a71fbbea2790e73adb1944c :

On the compiler side:
- Generate POWER barriers for atomic loads and noninitializing stores
      Noninitializing stores: as described in the PLDI 2018 memory model paper.
      Atomic loads: as generated by GCC for SC atomic_load.
- Update code generated for external calls
- Add support for Icompf instruction
- Add support for stack overflow checking
- Revised exception handling:
        - Trap frames are 2 words (16 bytes) instead of 4, this is large enough
        - Linkage is in first word of trap frame (needed for stack reallocation)
        - Trap pointer points to trap frame, not to bottom of stack frame (needed for stack reallocation)
        - Implemented caml_reraise_exn and moved zero-ing of backtrace_pos to caml_raise_exn.
    
On the runtime side:
- Extensive rewrite of runtime/power.S, based mostly on runtime/arm64.S
- Added POWER definitions to <caml/stack.h>
- Added POWER definition of `c_stack_link` to `<caml/fiber.h>`
- Handle SIGTRAP signals and turn them into out-of-bounds exceptions

The first 4 commits are ground work.  ~~aa4a81174c is from #12275.~~(now merged).

~~The last commit is an unfinished experiment into supporting frame pointers, which seem necessary to get decent backtraces under GDB.  (CFI information seems ignored by default?)   It needs more work.~~
