### PR TITLE
ARM64: emit stack reallocation code before the body of the function

### DIFF
--- a/Changes
+++ b/Changes
@@ -890,6 +890,9 @@ OCaml 5.1.0
 - #12252: Fix shared library build error on RISC-V.
   (Edwin Török, review by Nicolás Ojeda Bär and Xavier Leroy)
 
+- #12277: ARM64, fix a potential assembler error for very large functions by
+  emitting stack reallocation code before the body of the function.
+  (Xavier Leroy, review by KC Sivaramakrishnan)
 
 OCaml 5.0.0 (15 December 2022)
 ------------------------------

--- a/asmcomp/arm64/emit.mlp
+++ b/asmcomp/arm64/emit.mlp
@@ -1069,13 +1069,6 @@ let fundecl fundecl =
   `	.align	3\n`;
   `	.globl	{emit_symbol fundecl.fun_name}\n`;
   emit_symbol_type emit_symbol fundecl.fun_name "function";
-  `{emit_symbol fundecl.fun_name}:\n`;
-  emit_debug_info fundecl.fun_dbg;
-  cfi_startproc();
-  let num_call_gc, num_check_bound =
-    num_call_gc_and_check_bound_points env
-  in
-
   (* Dynamic stack checking *)
   let stack_threshold_size = Config.stack_threshold * 8 in (* bytes *)
   let { max_frame_size; contains_nontail_calls} =
@@ -1084,23 +1077,39 @@ let fundecl fundecl =
   in
   let handle_overflow, stack_check_size =
     if contains_nontail_calls || max_frame_size >= stack_threshold_size then begin
-      let overflow = new_label () and ret = new_label () in
+      let overflow = new_label () in
+      `{emit_label overflow}:\n`;
+      (* Pass the desired frame size on the stack, since all of the
+        argument-passing registers may be in use. *)
+      let s = (Config.stack_threshold + max_frame_size / 8) in
+      `	mov	{emit_reg reg_tmp1}, #{emit_int s}\n`;
+      `	stp	{emit_reg reg_tmp1}, x30, [sp, #-16]!\n`;
+      `	bl	{emit_symbol "caml_call_realloc_stack"}\n`;
+      `	ldp	{emit_reg reg_tmp1}, x30, [sp], #16\n`;
+      (* fall through function entry point *)
+      Some overflow, 5
+    end else
+      None, 0 in
+  `{emit_symbol fundecl.fun_name}:\n`;
+  emit_debug_info fundecl.fun_dbg;
+  cfi_startproc();
+  begin match handle_overflow with
+  | None -> ()
+  | Some overflow ->
       let threshold_offset = Domainstate.stack_ctx_words * 8 + stack_threshold_size in
       let f = max_frame_size + threshold_offset in
       let offset = Domainstate.(idx_of_field Domain_current_stack) * 8 in
       `	ldr	{emit_reg reg_tmp1}, [{emit_reg reg_domain_state_ptr}, #{emit_int offset}]\n`;
       emit_addimm reg_tmp1 reg_tmp1 f;
       `	cmp	sp, {emit_reg reg_tmp1}\n`;
-      `	bcc	{emit_label overflow}\n`;
-      `{emit_label ret}:\n`;
-      Some (overflow, ret), 5
-    end else None, 0
+      `	bcc	{emit_label overflow}\n`
+  end;
+  let num_call_gc, num_check_bound =
+    num_call_gc_and_check_bound_points env
   in
-
   let max_out_of_line_code_offset =
     stack_check_size +
-    max_out_of_line_code_offset ~num_call_gc
-      ~num_check_bound
+    max_out_of_line_code_offset ~num_call_gc ~num_check_bound
   in
 
   BR.relax fundecl ~max_out_of_line_code_offset;
@@ -1110,21 +1119,6 @@ let fundecl fundecl =
   List.iter emit_call_bound_error env.bound_error_sites;
   assert (List.length env.call_gc_sites = num_call_gc);
   assert (List.length env.bound_error_sites = num_check_bound);
-
-  begin match handle_overflow with
-  | None -> ()
-  | Some (overflow,ret) -> begin
-      `{emit_label overflow}:\n`;
-      (* Pass the desired frame size on the stack, since all of the
-        argument-passing registers may be in use. *)
-      let s = (Config.stack_threshold + max_frame_size / 8) in
-      `	mov	{emit_reg reg_tmp1}, #{emit_int s}\n`;
-      `	stp	{emit_reg reg_tmp1}, x30, [sp, #-16]!\n`;
-      `	bl	{emit_symbol "caml_call_realloc_stack"}\n`;
-      `	ldp	{emit_reg reg_tmp1}, x30, [sp], #16\n`;
-      `	b	{emit_label ret}\n`
-    end
-  end;
 
   cfi_endproc();
   emit_symbol_type emit_symbol fundecl.fun_name "function";


### PR DESCRIPTION
A function that contains non-tail calls or uses a lot of stack has some code at the beginning that checks for stack overflow and branches conditionally to some code at the end of the function that reallocates the stack.  If the function is very large, the offset of the conditional branch is too large for an ARM64 conditional branch.  (Repro case available on demand.)

One approach would be to reuse the existing branch relaxation facility to relax this particular conditional branch.  This PR proposes a simpler solution: emit the stack reallocation code *before* the function entry point, so that the conditional branch is always short.

As an additional benefit, we save one branch instruction by falling through the function entry point after stack reallocation.  This causes an extra stack check to be performed, but it occurs rarely enough to be negligible.  Removing one instruction reduces code size, which is always profitable.
