### PR TITLE
Improve man pages rendering

### DIFF
--- a/man/ocaml.1
+++ b/man/ocaml.1
@@ -73,7 +73,7 @@ Show absolute filenames in error messages.
 .B \-no-absname
 Do not try to show absolute filenames in error messages.
 .TP
-.BI \-I \ directory
+.BI \-I " directory"
 Add the given directory to the list of directories searched for
 source and compiled files. By default, the current directory is
 searched first, then the standard library directory. Directories added
@@ -97,7 +97,7 @@ is running with the
 .B #directory
 directive.
 .TP
-.BI \-init \ file
+.BI \-init " file"
 Load the given file instead of the default initialization file.
 See the "Initialization file" section below.
 .TP
@@ -139,13 +139,13 @@ window.
 Do not include the standard library directory in the list of
 directories searched for source and compiled files.
 .TP
-.BI \-open \ module
+.BI \-open " module"
 Opens the given module before starting the toplevel. If several
 .B \-open
 options are given, they are processed in order, just as if
 the statements open! module1;; ... open! moduleN;; were input.
 .TP
-.BI \-ppx \ command
+.BI \-ppx " command"
 After parsing, pipe the abstract syntax tree through the preprocessor
 .IR command .
 The module
@@ -180,7 +180,7 @@ This is the default.
 .TP
 .B \-safe\-string
 Enforce the separation between types
-.BR string \ and\  bytes ,
+.BR string " and " bytes ,
 thereby making strings read-only. This is the default.
 .TP
 .B \-safer\-matching
@@ -218,7 +218,7 @@ This is the default.
 .TP
 .B \-unsafe
 Turn bound checking off on array and string accesses (the
-.BR v.(i) and s.[i]
+.BR v.(i) " and " s.[i]
 constructs). Programs compiled with
 .B \-unsafe
 are therefore slightly faster, but unsafe: anything can happen if the program
@@ -226,7 +226,7 @@ accesses an array or string outside of its bounds.
 .TP
 .B \-unsafe\-string
 Identify the types
-.BR string \ and\  bytes ,
+.BR string " and " bytes ,
 thereby making strings writable.
 This is intended for compatibility with old source code and should not
 be used with new software.
@@ -240,7 +240,7 @@ Print short version number and exit.
 .B \-no\-version
 Do not print the version banner at startup.
 .TP
-.BI \-w \ warning\-list
+.BI \-w " warning\-list"
 Enable or disable warnings according to the argument
 .IR warning-list .
 See
@@ -249,7 +249,7 @@ for the syntax of the
 .I warning\-list
 argument.
 .TP
-.BI \-warn\-error \ warning\-list
+.BI \-warn\-error " warning\-list"
 Mark as fatal the warnings described by the argument
 .IR warning\-list .
 Note that a warning is not triggered (and does not trigger an error) if
@@ -261,7 +261,7 @@ for the syntax of the
 .I warning\-list
 argument.
 .TP
-.BI \-color \ mode
+.BI \-color " mode"
 Enable or disable colors in compiler messages (especially warnings and errors).
 The following modes are supported:
 
@@ -287,7 +287,7 @@ checks that the "TERM" environment variable exists and is
 not empty or "dumb", and that isatty(stderr) holds.
 
 .TP
-.BI \-error\-style \ mode
+.BI \-error\-style " mode"
 Control the way error messages and warnings are printed.
 The following modes are supported:
 
@@ -309,12 +309,12 @@ above.
 .B \-warn\-help
 Show the description of all available warning numbers.
 .TP
-.BI \- \ file
+.BI \- " file"
 Use
 .I file
 as a script file name, even when it starts with a hyphen (-).
 .TP
-.BR \-help \ or \ \-\-help
+.BR \-help " or " \-\-help
 Display a short usage summary and exit.
 
 .SH INITIALIZATION FILE
@@ -329,12 +329,11 @@ in the current directory if it exists, otherwise
 according to the XDG base directory specification lookup if it exists (on
 Windows this is skipped), otherwise
 .B .ocamlinit
-in the user's home directory (
-.B HOME
-variable).
+in the user's home directory
+.RB ( HOME " variable)."
 You can specify a different initialization file
 by using the
-.BI \-init \ file
+.BI \-init " file"
 option, and disable initialization files by using the
 .B \-noinit
 option.
@@ -361,7 +360,7 @@ and look up its capabilities in the terminal database.
 .B .ocamlinit
 lookup procedure (see above).
 .SH SEE ALSO
-.BR ocamlc (1), \ ocamlopt (1), \ ocamlrun (1).
+.BR ocamlc "(1), " ocamlopt "(1), " ocamlrun (1).
 .br
 .IR The\ OCaml\ user's\ manual ,
 chapter "The toplevel system".

--- a/man/ocamlc.1
+++ b/man/ocamlc.1
@@ -144,7 +144,7 @@ If
 .B caml.out
 is the name of the file produced by the linking phase, the command
 .B ocamlrun caml.out
-.IR arg1 \  \ arg2 \ ... \ argn
+.IR arg1 " " arg2 " ... " argn
 executes the compiled code contained in
 .BR caml.out ,
 passing it as arguments the character strings
@@ -158,7 +158,7 @@ for more details.)
 On most systems, the file produced by the linking
 phase can be run directly, as in:
 .B ./caml.out
-.IR arg1 \  \ arg2 \ ... \ argn .
+.IR arg1 " " arg2 " ... " argn .
 The produced file has the executable bit set, and it manages to launch
 the bytecode interpreter by itself.
 
@@ -186,20 +186,21 @@ file. The name of the library must be set with the
 option.
 .IP
 If
-.BR \-custom , \ \-cclib \ or \ \-ccopt
+.BR \-custom ", " \-cclib " or " \-ccopt
 options are passed on the command
 line, these options are stored in the resulting .cma library.  Then,
 linking with this library automatically adds back the
-.BR \-custom , \ \-cclib \ and \ \-ccopt
+.BR \-custom ", " \-cclib " and " \-ccopt
 options as if they had been provided on the
 command line, unless the
 .B \-noautolink
 option is given. Additionally, a substring
 .B $CAMLORIGIN
 inside a
-.BR \ \-ccopt
+.B \-ccopt
 options will be replaced by the full path to the .cma library,
 excluding the filename.
+.TP
 .B \-absname
 Show absolute filenames in error messages.
 .TP
@@ -231,7 +232,7 @@ compilation. Source code files are turned into compiled files, but no
 executable file is produced. This option is useful to
 compile modules separately.
 .TP
-.BI \-cc \ ccomp
+.BI \-cc " ccomp"
 Use
 .I ccomp
 as the C linker when linking in "custom runtime" mode (see the
@@ -245,7 +246,7 @@ option to the C linker when linking in "custom runtime" mode (see the
 .B \-custom
 option). This causes the given C library to be linked with the program.
 .TP
-.BI \-ccopt \ option
+.BI \-ccopt " option"
 Pass the given
 .I option
 to the C compiler and linker, when linking in
@@ -257,7 +258,7 @@ causes the C linker to search for C libraries in
 directory
 .IR dir .
 .TP
-.BI \-color \ mode
+.BI \-color " mode"
 Enable or disable colors in compiler messages (especially warnings and errors).
 The following modes are supported:
 
@@ -283,7 +284,7 @@ checks that the "TERM" environment variable exists and is
 not empty or "dumb", and that isatty(stderr) holds.
 
 .TP
-.BI \-error\-style \ mode
+.BI \-error\-style " mode"
 Control the way error messages and warnings are printed.
 The following modes are supported:
 
@@ -336,15 +337,15 @@ code with user-defined C functions.
 Never use the
 .BR strip (1)
 command on executables produced by
-.BR ocamlc\ \-custom ,
+.BR ocamlc " \-custom" ,
 this would remove the bytecode part of the executable.
 
 Security warning: never set the "setuid" or "setgid" bits on
 executables produced by
-.BR ocamlc\ \-custom ,
+.BR ocamlc " \-custom" ,
 this would make them vulnerable to attacks.
 .TP
-.BI \-depend\ ocamldep-args
+.BI \-depend " ocamldep-args"
 Compute dependencies, as ocamldep would do.
 .TP
 .BI \-dllib\ \-l libname
@@ -354,7 +355,7 @@ to be loaded dynamically by the run-time system
 .BR ocamlrun (1)
 at program start-up time.
 .TP
-.BI \-dllpath \ dir
+.BI \-dllpath " dir"
 Adds the directory
 .I dir
 to the run-time search path for shared
@@ -371,7 +372,7 @@ executable file, where
 .BR ocamlrun (1)
 can find it and use it.
 .TP
-.BI \-for\-pack \ module\-path
+.BI \-for\-pack " module\-path"
 Generate an object file (.cmo file) that can later be included
 as a sub-module (with the given access path) of a compilation unit
 constructed with
@@ -404,16 +405,16 @@ can help in writing an explicit interface (.mli file) for a file: just
 redirect the standard output of the compiler to a .mli file, and edit
 that file to remove all declarations of unexported names.
 .TP
-.B \-cmi-file \ filename
+.BI \-cmi-file " filename"
 Type-check the source implementation to be compiled against the
 specified interface file (by-passes the normal lookup for .mli and .cmi files).
 .TP
-.BI \-I \ directory
+.BI \-I " directory"
 Add the given directory to the list of directories searched for
 compiled interface files (.cmi), compiled object code files
 (.cmo), libraries (.cma), and C libraries specified with
-.BI \-cclib\ \-l xxx
-.RB .
+.BI \-cclib\ \-l xxx\c
+\[char46]
 By default, the current directory is searched first, then the
 standard library directory. Directories added with
 .B \-I
@@ -432,17 +433,17 @@ adds the subdirectory
 .B compiler-libs
 of the standard library to the search path.
 .TP
-.BI \-impl \ filename
+.BI \-impl " filename"
 Compile the file
 .I filename
 as an implementation file, even if its extension is not .ml.
 .TP
-.BI \-intf \ filename
+.BI \-intf " filename"
 Compile the file
 .I filename
 as an interface file, even if its extension is not .mli.
 .TP
-.BI \-intf\-suffix \ string
+.BI \-intf\-suffix " string"
 Recognize file names ending with
 .I string
 as interface files (instead of the default .mli).
@@ -479,7 +480,7 @@ Build a custom runtime system (in the file specified by option
 incorporating the C object files and libraries given on the command
 line.  This custom runtime system can be used later to execute
 bytecode executables produced with the option
-.B ocamlc\ \-use\-runtime
+.B ocamlc " \-use\-runtime"
 .IR runtime-name .
 .TP
 .B \-match\-context\-rows
@@ -504,7 +505,7 @@ This flag has no effect when linking already-compiled files.
 .TP
 .B \-noautolink
 When linking .cma libraries, ignore
-.BR \-custom , \ \-cclib \ and \ \-ccopt
+.BR \-custom ", " \-cclib " and " \-ccopt
 options potentially contained in the libraries (if these options were
 given when building the libraries).  This can be useful if a library
 contains incorrect specifications of C libraries or C options; in this
@@ -521,12 +522,12 @@ Do not automatically add the standard library directory to the list of
 directories searched for compiled interface files (.cmi), compiled
 object code files (.cmo), libraries (.cma), and C libraries specified
 with
-.BI \-cclib\ \-l xxx
-.RB .
+.BI \-cclib\ \-l xxx\c
+\[char46]
 See also option
 .BR \-I .
 .TP
-.BI \-o \ exec\-file
+.BI \-o " exec\-file"
 Specify the name of the output file produced by the linker. The
 default output name is
 .BR a.out ,
@@ -555,7 +556,7 @@ access the .cmx file of this unit -- nor warn if it is absent. This can
 improve speed of compilation, for both initial and incremental builds,
 at the expense of performance of the generated code.
 .TP
-.BI \-open \ module
+.BI \-open " module"
 Opens the given module before processing the interface or
 implementation files. If several
 .B \-open
@@ -594,7 +595,7 @@ contents of the object files a.cmo, b.cmo and c.cmo.  These
 contents can be referenced as P.A, P.B and P.C in the remainder
 of the program.
 .TP
-.BI \-pp \ command
+.BI \-pp " command"
 Cause the compiler to call the given
 .I command
 as a preprocessor for each source file. The output of
@@ -606,7 +607,7 @@ file is built from the basename of the source file with the
 extension .ppi for an interface (.mli) file and .ppo for an
 implementation (.ml) file.
 .TP
-.BI \-ppx \ command
+.BI \-ppx " command"
 After parsing, pipe the abstract syntax tree through the preprocessor
 .IR command .
 The module
@@ -640,7 +641,7 @@ flag, you must use it again for all dependencies.
 Do no allow arbitrary recursive types during type-checking.
 This is the default.
 .TP
-.BI \-runtime\-variant \ suffix
+.BI \-runtime\-variant " suffix"
 Add
 .I suffix
 to the name of the runtime library that will be used by the program.
@@ -652,7 +653,7 @@ suffix is supported and gives a debug version of the runtime.
 .TP
 .B \-safe\-string
 Enforce the separation between types
-.BR string \ and\  bytes ,
+.BR string " and " bytes " ,"
 thereby making strings read-only. This is the default.
 .TP
 .B \-safer\-matching
@@ -666,7 +667,7 @@ When a type is visible under several module-paths, use the shortest
 one when printing the type's name in inferred interfaces and error and
 warning messages.
 .TP
-.BI \-stop\-after \ pass
+.BI \-stop\-after " pass"
 Stop compilation after the given compilation pass. The currently
 supported passes are:
 .BR parsing ,
@@ -692,7 +693,7 @@ This is the default.
 .TP
 .B \-unsafe
 Turn bound checking off for array and string accesses (the
-.BR v.(i) and s.[i]
+.BR v.(i) " and " s.[i]
 constructs). Programs compiled with
 .B \-unsafe
 are therefore
@@ -701,12 +702,12 @@ accesses an array or string outside of its bounds.
 .TP
 .B \-unsafe\-string
 Identify the types
-.BR string \ and\  bytes ,
+.BR string " and " bytes " ,"
 thereby making strings writable.
 This is intended for compatibility with old source code and should not
 be used with new software.
 .TP
-.BI \-use\-runtime \ runtime\-name
+.BI \-use\-runtime " runtime\-name"
 Generate a bytecode executable file that can be executed on the custom
 runtime system
 .IR runtime\-name ,
@@ -724,19 +725,18 @@ invocations of the C compiler and linker in
 .B \-custom
 mode.  Useful to debug C library problems.
 .TP
-.BR \-vnum \ or\  \-version
+.BR \-vnum " or " \-version
 Print the version number of the compiler in short form (e.g. "3.11.0"),
 then exit.
 .TP
-.BI \-w \ warning\-list
+.BI \-w " warning\-list"
 Enable, disable, or mark as fatal the warnings specified by the argument
 .IR warning\-list .
 
 Each warning can be
-.IR enabled \ or\  disabled ,
+.IR enabled " or " disabled " ,"
 and each warning can be
-.IR fatal \ or
-.IR non-fatal .
+.IR fatal " or " non-fatal .
 If a warning is disabled, it isn't displayed and doesn't affect
 compilation in any way (even if it is fatal).  If a warning is enabled,
 it is displayed normally by the compiler whenever the source code
@@ -932,13 +932,13 @@ Deprecated: now part of warning 8.
 .B 26 [unused-var]
 .br
 Suspicious unused variable: unused variable that is bound with
-.BR let \ or \ as ,
+.BR let " or " as " ,"
 and doesn't start with an underscore (_) character.
 
 .B 27 [unused-var-strict]
 .br
 Innocuous unused variable: unused variable that is not bound with
-.BR let \ nor \ as ,
+.BR let " nor " as " ,"
 and doesn't start with an underscore (_) character.
 
 .B 28 [wildcard-arg-to-constant-constr]
@@ -1188,10 +1188,10 @@ mentioned here corresponds to the empty set.
 The default setting is
 .BR \-w\ +a\-4\-7\-9\-27\-29\-30\-32..42\-44\-45\-48\-50\-60\-66..70 .
 Note that warnings
-.BR 5 \ and \ 10
+.BR 5 " and " 10
 are not always triggered, depending on the internals of the type checker.
 .TP
-.BI \-warn\-error \ warning\-list
+.BI \-warn\-error " warning\-list"
 Mark as errors the warnings specified in the argument
 .IR warning\-list .
 The compiler will stop with an error when one of these
@@ -1231,16 +1231,16 @@ Include the runtime system in the generated program. This is the default.
 The compiler does not include the runtime system (nor a reference to it) in the
 generated program; it must be supplied separately.
 .TP
-.BI \- \ file
+.BI \- " file"
 Process
 .I file
 as a file name, even if it starts with a dash (-) character.
 .TP
-.BR \-help \ or \ \-\-help
+.BR \-help " or " \-\-help
 Display a short usage summary and exit.
 
 .SH SEE ALSO
-.BR ocamlopt (1), \ ocamlrun (1), \ ocaml (1).
+.BR ocamlopt "(1), " ocamlrun "(1), " ocaml (1).
 .br
-.IR "The OCaml user's manual" ,
+.IR The\ OCaml\ user's\ manual ,
 chapter "Batch compilation".

--- a/man/ocamlcp.1
+++ b/man/ocamlcp.1
@@ -24,7 +24,7 @@ ocamlcp, ocamloptp \- The OCaml profiling compilers
 .I ocamlc options
 ]
 [
-.BI \-P \ flags
+.BI \-P " flags"
 ]
 .I filename ...
 
@@ -33,7 +33,7 @@ ocamlcp, ocamloptp \- The OCaml profiling compilers
 .I ocamlopt options
 ]
 [
-.BI \-P \ flags
+.BI \-P " flags"
 ]
 .I filename ...
 
@@ -78,7 +78,7 @@ options,
 and
 .B ocamloptp
 accept one option to control the kind of profiling information, the
-.BI \-P \ letters
+.BI \-P " letters"
 option. The
 .I letters
 indicate which parts of the program should be profiled:
@@ -87,16 +87,16 @@ indicate which parts of the program should be profiled:
 all options
 .TP
 .B f
-function calls : a count point is set at the beginning of each function body
+function calls: a count point is set at the beginning of each function body
 .TP
 .B i
-.BR if \ ... \ then \ ... \ else :
-count points are set in both
-.BR then \ and \ else
+.BR if " ... " then " ... " else\c
+: count points are set in both
+.BR then " and " else
 branches
 .TP
 .B l
-.BR while , \ for
+.BR while ", " for
 loops: a count point is set at the beginning of the loop body
 .TP
 .B m
@@ -105,7 +105,7 @@ branches: a count point is set at the beginning of the
 body of each branch of a pattern-matching
 .TP
 .B t
-.BR try \ ... \ with
+.BR try " ... " with
 branches: a count point is set at the beginning of the body of each
 branch of an exception catcher
 
@@ -113,7 +113,7 @@ branch of an exception catcher
 For instance, compiling with
 .B ocamlcp \-P film
 profiles function calls,
-.BR if \ ... \ then \ ... \ else \ ...,
+.BR if " ... " then " ... " else " ...,"
 loops, and pattern matching.
 
 Calling
@@ -123,7 +123,7 @@ or
 without the
 .B \-P
 option defaults to
-.BR \-P\ fm ,
+.BR \-P " fm" ,
 meaning that only function calls and pattern matching are profiled.
 
 Note: for compatibility with previous versions,
@@ -134,9 +134,7 @@ with the same argument and meaning as
 .BR \-P .
 
 .SH SEE ALSO
-.BR ocamlc (1),
-.BR ocamlopt (1),
-.BR ocamlprof (1).
+.BR ocamlc "(1), " ocamlopt "(1), " ocamlprof (1).
 .br
-.IR "The OCaml user's manual" ,
+.IR The\ OCaml\ user's\ manual ,
 chapter "Profiling".

--- a/man/ocamldebug.1
+++ b/man/ocamldebug.1
@@ -19,7 +19,7 @@
 ocamldebug \- the OCaml source-level replay debugger.
 .SH SYNOPSIS
 .B ocamldebug
-.RI [\  options \ ]\  program \ [\  arguments \ ]
+.RI [ " options " ] " program " [ " arguments " ]
 .SH DESCRIPTION
 .B ocamldebug
 is the OCaml source-level replay debugger.
@@ -46,11 +46,11 @@ A summary of options are included below.
 For a complete description, see the html documentation in the ocaml-doc
 package.
 .TP
-.BI \-c \ count
+.BI \-c " count"
 Set the maximum number of simultaneously live checkpoints to
 .IR count .
 .TP
-.BI \-cd \ dir
+.BI \-cd " dir"
 Run the debugger program from the working directory
 .IR dir ,
 instead of the current working directory. (See also the
@@ -59,12 +59,12 @@ command.)
 .TP
 .B \-emacs
 Tell the debugger it is executed under Emacs.  (See
-.I "The OCaml user's manual"
+.I "The\ OCaml\ user's\ manual"
 for information on how to run the debugger under Emacs.)
 Implies
 .BR \-machine-readable .
 .TP
-.BI \-I \ directory
+.BI \-I " directory"
 Add
 .I directory
 to the list of directories searched for source files and
@@ -79,14 +79,14 @@ program, such as when printing a backtrace, print the program counter and
 character offset in a file instead of the filename, line number, and character
 offset in that line.
 .TP
-.BI \-s \ socket
+.BI \-s " socket"
 Use
 .I socket
 for communicating with the debugged program. See the description
 of the command
 .B set\ socket
 in
-.I "The OCaml user's manual"
+.I "The\ OCaml\ user's\ manual"
 for the format of
 .IR socket .
 .TP
@@ -96,7 +96,7 @@ Print version string and exit.
 .B \-vnum
 Print short version number and exit.
 .TP
-.BR \-help \ or \ \-\-help
+.BR \-help " or " \-\-help
 Display a short usage summary and exit.
 
 .SH INITIALIZATION FILE
@@ -115,9 +115,9 @@ Note that you can also use the
 command to read commands from a file.
 
 .SH SEE ALSO
-.BR ocamlc (1)
+.BR ocamlc (1).
 .br
-.IR "The OCaml user's manual" ,
+.IR The\ OCaml\ user's\ manual ,
 chapter "The debugger".
 .SH AUTHOR
 This manual page was written by Sven LUTHER <luther@debian.org>,

--- a/man/ocamldep.1
+++ b/man/ocamldep.1
@@ -83,7 +83,7 @@ the aliases it contains.
 .B \-debug\-map
 Dump the delayed dependency map for each map file.
 .TP
-.BI \-I \ directory
+.BI \-I " directory"
 Add the given directory to the list of directories searched for
 source files. If a source file foo.ml mentions an external
 compilation unit Bar, a dependency on that unit's interface
@@ -101,33 +101,33 @@ options that are passed to the compiler.
 .B \-nocwd
 Do not add current working directory to the list of include directories.
 .TP
-.BI \-impl \ file
+.BI \-impl " file"
 Process
 .IR file
 as a .ml file.
 .TP
-.BI \-intf \ file
+.BI \-intf " file"
 Process
 .IR file
 as a .mli file.
 .TP
-.BI \-map \ file
+.BI \-map " file"
 Read an propagate the delayed dependencies for module aliases in
 .IR file ,
 so that the following files will depend on the
 exported aliased modules if they use them.
 .TP
-.BI \-ml\-synonym \ .ext
+.BI \-ml\-synonym " .ext"
 Consider the given extension (with leading dot) to be a synonym for .ml.
 .TP
-.BI \-mli\-synonym \ .ext
+.BI \-mli\-synonym " .ext"
 Consider the given extension (with leading dot) to be a synonym for .mli.
 .TP
 .B \-modules
 Output raw dependencies of the form
-.IR filename : \ Module1\ Module2 \ ... \ ModuleN
+.IR filename : " Module1 Module2" " ... " ModuleN
 where
-.IR Module1 ,\ ..., \ ModuleN
+.IR Module1 ", ...," " ModuleN"
 are the names of the compilation
 units referenced within the file
 .IR filename ,
@@ -155,20 +155,20 @@ have explicit .mli interface files.)
 .B \-one-line
 Output one line per file, regardless of the length.
 .TP
-.BI \-open \ module
+.BI \-open " module"
 Assume that module
 .IR module
 is opened before parsing each of the
 following files.
 .TP
-.BI \-pp \ command
+.BI \-pp " command"
 Cause
 .BR ocamldep (1)
 to call the given
 .I command
 as a preprocessor for each source file.
 .TP
-.BI \-ppx \ command
+.BI \-ppx " command"
 Pipe abstract syntax tree through preprocessor
 .IR command .
 .TP
@@ -188,12 +188,11 @@ Print version string and exit.
 .B \-vnum
 Print short version number and exit.
 .TP
-.BR \-help \ or \ \-\-help
+.BR \-help " or " \-\-help
 Display a short usage summary and exit.
 
 .SH SEE ALSO
-.BR ocamlc (1),
-.BR ocamlopt (1).
+.BR ocamlc "(1), " ocamlopt (1).
 .br
 .IR The\ OCaml\ user's\ manual ,
 chapter "Dependency generator".

--- a/man/ocamldoc.1
+++ b/man/ocamldoc.1
@@ -15,15 +15,6 @@
 .\"
 .TH OCAMLDOC 1
 
-\" .de Sh \" Subsection heading
-\" .br
-\" .if t .Sp
-\" .ne 5
-\" .PP
-\" \fB\\$1\fR
-\" .PP
-\" ..
-
 .SH NAME
 ocamldoc \- The OCaml documentation generator
 
@@ -33,7 +24,7 @@ ocamldoc \- The OCaml documentation generator
 [
 .I options
 ]
-.IR filename \ ...
+.IR filename " ..."
 
 .SH DESCRIPTION
 
@@ -45,7 +36,7 @@ comments used by
 are of the form
 .I (** ... *)
 and follow the format described in the
-.IR "The OCaml user's manual" .
+.IR The\ OCaml\ user's\ manual .
 
 .B ocamldoc
 can produce documentation in various formats: HTML, LaTeX, TeXinfo,
@@ -111,9 +102,9 @@ option.
 .B \-dot
 Generate a dependency graph for the toplevel modules, in a format suitable for
 displaying and processing by
-.IR dot (1).
+.BR dot (1).
 The
-.IR dot (1)
+.BR dot (1)
 tool is available from
 .IR https://graphviz.org/ .
 The textual representation of the graph is written to the file
@@ -121,10 +112,10 @@ The textual representation of the graph is written to the file
 or to the file specified with the
 .B -o
 option. Use
-.BI dot \ ocamldoc.out
+.BI dot " ocamldoc.out"
 to display it.
 .TP
-.BI \-g \ file
+.BI \-g " file"
 Dynamically load the given file (which extension usually is .cmo or .cma),
 which defines a custom documentation generator.
 If the given file is a simple one and does not exist in
@@ -138,16 +129,16 @@ option.
 .BI \-customdir
 Display the custom generators default directory.
 .TP
-.BI \-i \ directory
+.BI \-i " directory"
 Add the given directory to the path where to look for custom generators.
 .SS "General options"
 .TP
-.BI \-d \ dir
+.BI \-d " dir"
 Generate files in directory
 .IR dir ,
 rather than the current directory.
 .TP
-.BI \-dump \ file
+.BI \-dump " file"
 Dump collected information into
 .IR file .
 This information can be read with the
@@ -155,7 +146,7 @@ This information can be read with the
 option in a subsequent invocation of
 .BR ocamldoc (1).
 .TP
-.BI \-hide \ modules
+.BI \-hide " modules"
 Hide the given complete module names in the generated documentation.
 .I modules
 is a list of complete module names are separated by commas (,),
@@ -175,16 +166,16 @@ available. The source code is always kept when a .ml
 file is given, but is by default discarded when a .mli
 is given. This option allows the source code to be always kept.
 .TP
-.BI \-load \ file
+.BI \-load " file"
 Load information from
 .IR file ,
 which has been produced by
-.BR ocamldoc\ \-dump .
+.BR ocamldoc " \-dump" .
 Several
 .B -load
 options can be given.
 .TP
-.BI \-m \ flags
+.BI \-m " flags"
 Specify merge options between interfaces and implementations.
 .I flags
 can be one or several of the following characters:
@@ -227,25 +218,25 @@ Keep elements placed after the
 .B (**/**)
 special comment.
 .TP
-.BI \-o \ file
+.BI \-o " file"
 Output the generated documentation to
 .I file
 instead of
 .IR ocamldoc.out .
 This option is meaningful only in conjunction with the
-.BR \-latex , \ \-texi ,\ or \ \-dot
+.BR \-latex ", " \-texi ", or " \-dot
 options.
 .TP
-.BI \-open \ module
+.BI \-open " module"
 Opens
 .I module
 before typing.
 .TP
-.BI \-pp \ command
+.BI \-pp " command"
 Pipe sources through preprocessor
 .IR command .
 .TP
-.BI \-ppx \ command
+.BI \-ppx " command"
 Pipe abstract syntax tree through preprocessor
 .IR command .
 .TP
@@ -258,15 +249,15 @@ Sort the list of top-level modules before generating the documentation.
 .B \-stars
 Remove blank characters until the first asterisk ('*') in each line of comments.
 .TP
-.BI \-t \ title
+.BI \-t " title"
 Use
 .I title
 as the title for the generated documentation.
 .TP
-.BI \-text \ file
+.BI \-text " file"
 Consider \fIfile\fR as a .txt file.
 .TP
-.BI \-intro \ file
+.BI \-intro " file"
 Use content of
 .I file
 as
@@ -293,17 +284,17 @@ Do not print
 .B ocamldoc
 warnings.
 .TP
-.BR \-help \ or \ \-\-help
+.BR \-help " or " \-\-help
 Display a short usage summary and exit.
 .SS "Type-checking options"
 .BR ocamldoc (1)
 calls the OCaml type-checker to obtain type information. The
 following options impact the type-checking phase. They have the same meaning
 as for the
-.BR ocamlc (1)\ and \ ocamlopt (1)
+.BR ocamlc (1) " and " ocamlopt "(1)"
 commands.
 .TP
-.BI \-I \ directory
+.BI \-I " directory"
 Add
 .I directory
 to the list of directories search for compiled interface files (.cmi files).
@@ -324,11 +315,11 @@ option:
 .B \-all\-params
 Display the complete list of parameters for functions and methods.
 .TP
-.BI \-charset \ s
+.BI \-charset " s"
 Add information about character encoding being \fIs\fR
 (default is \fBiso-8859-1\fR).
 .TP
-.BI \-css\-style \ filename
+.BI \-css\-style " filename"
 Use
 .I filename
 as the Cascading Style Sheet file.
@@ -360,14 +351,14 @@ document. The default prefix is the empty string. You can also use the options
 .BR -latex-module-type-prefix ,
 .BR -latex-class-prefix ,
 .BR -latex-class-type-prefix ,
-.BR -latex-attribute-prefix ,\ and
+.BR -latex-attribute-prefix ", and"
 .BR -latex-method-prefix .
 
 These options are useful when you have, for example, a type and a value
 with the same name. If you do not specify prefixes, LaTeX will complain about
 multiply defined labels.
 .TP
-.BI \-latextitle \ n,style
+.BI \-latextitle " n,style"
 Associate style number
 .I n
 to the given LaTeX sectioning command
@@ -420,7 +411,7 @@ The following options apply in conjunction with the
 .B \-dot
 option:
 .TP
-.BI \-dot\-colors \ colors
+.BI \-dot\-colors " colors"
 Specify the colors to use in the generated dot code. When generating module
 dependencies,
 .BR ocamldoc (1)
@@ -460,18 +451,16 @@ option:
 Generate man pages only for modules, module types, classes and class types,
 instead of pages for all elements.
 .TP
-.BI \-man\-suffix \ suffix
+.BI \-man\-suffix " suffix"
 Set the suffix used for generated man filenames. Default is o, as in
 .IR List.o .
 .TP
-.BI \-man\-section \ section
+.BI \-man\-section " section"
 Set the section number used for generated man filenames. Default is 3.
 
 
 .SH SEE ALSO
-.BR ocaml (1),
-.BR ocamlc (1),
-.BR ocamlopt (1).
+.BR ocaml "(1), " ocamlc "(1), " ocamlopt (1).
 .br
-.IR "The OCaml user's manual",
+.IR The\ OCaml\ user's\ manual ,
 chapter "The documentation generator".

--- a/man/ocamllex.1
+++ b/man/ocamllex.1
@@ -21,7 +21,7 @@ ocamllex \- The OCaml lexer generator
 .SH SYNOPSIS
 .B ocamllex
 [
-.BI \-o \ output-file
+.BI \-o " output-file"
 ]
 [
 .B \-ml
@@ -72,7 +72,7 @@ This option is mainly useful for debugging
 .BR ocamllex (1),
 using it for production lexers is not recommended.
 .TP
-.BI \-o \ output\-file
+.BI \-o " output\-file"
 Specify the name of the output file produced by
 .BR ocamllex (1).
 The default is the input file name, with its extension replaced by .ml.
@@ -85,17 +85,17 @@ to standard output.  They are suppressed if option
 .B \-q
 is used.
 .TP
-.BR \-v \ or \ \-version
+.BR \-v " or " \-version
 Print version string and exit.
 .TP
 .B \-vnum
 Print short version number and exit.
 .TP
-.BR \-help \ or \ \-\-help
+.BR \-help " or " \-\-help
 Display a short usage summary and exit.
 
 .SH SEE ALSO
 .BR ocamlyacc (1).
 .br
-.IR "The OCaml user's manual" ,
+.IR The\ OCaml\ user's\ manual ,
 chapter "Lexer and parser generators".

--- a/man/ocamlmktop.1
+++ b/man/ocamlmktop.1
@@ -24,18 +24,19 @@ ocamlmktop \- Building custom toplevel systems
 .BR \-v | \-version | \-vnum
 ]
 [
-.BI \-cclib \ libname
+.BI \-cclib " libname"
 ]
 [
-.BI \-ccopt \ option
+.BI \-ccopt " option"
 ]
 [
 .B \-custom
-[
-.BI \-o \ exec-file
 ]
 [
-.BI \-I \ lib-dir
+.BI \-o " exec-file"
+]
+[
+.BI \-I " lib-dir"
 ]
 .I filename ...
 
@@ -65,7 +66,7 @@ The following command-line options are recognized by
 .B \-v
 Print the version string of the compiler and exit.
 .TP
-.BR \-vnum \ or\  \-version
+.BR \-vnum " or " \-version
 Print the version number of the compiler in short form and exit.
 .TP
 .BI \-cclib\ \-l libname
@@ -84,11 +85,11 @@ Pass the given option to the C compiler and linker, when linking in
 Link in ``custom runtime'' mode. See the corresponding option for
 .BR ocamlc (1).
 .TP
-.BI \-I \ directory
+.BI \-I " directory"
 Add the given directory to the list of directories searched for
 compiled interface files (.cmo and .cma).
 .TP
-.BI \-o \ exec\-file
+.BI \-o " exec\-file"
 Specify the name of the toplevel file produced by the linker.
 The default is is
 .BR a.out .

--- a/man/ocamlopt.1
+++ b/man/ocamlopt.1
@@ -25,7 +25,7 @@ ocamlopt \- The OCaml native-code compiler
 [
 .I options
 ]
-.IR filename \ ...
+.IR filename " ..."
 
 .B ocamlopt.opt
 (same options)
@@ -148,18 +148,18 @@ executable file. The name of the library must be set with the
 option.
 
 If
-.BR \-cclib \ or \ \-ccopt
+.BR \-cclib " or " \-ccopt
 options are passed on the command
 line, these options are stored in the resulting .cmxa library.  Then,
 linking with this library automatically adds back the
-.BR \-cclib \ and \ \-ccopt
+.BR \-cclib " and " \-ccopt
 options as if they had been provided on the
 command line, unless the
 .B \-noautolink
 option is given. Additionally, a substring
 .B $CAMLORIGIN
 inside a
-.BR \ \-ccopt
+.B " \-ccopt"
 options will be replaced by the full path to the .cma library,
 excluding the filename.
 .TP
@@ -194,7 +194,7 @@ compilation. Source code files are turned into compiled files, but no
 executable file is produced. This option is useful to
 compile modules separately.
 .TP
-.BI \-cc \ ccomp
+.BI \-cc " ccomp"
 Use
 .I ccomp
 as the C linker called to build the final executable and as the C
@@ -206,14 +206,14 @@ Pass the
 option to the linker. This causes the given C library to be linked
 with the program.
 .TP
-.BI \-ccopt \ option
+.BI \-ccopt " option"
 Pass the given option to the C compiler and linker. For instance,
 .BI \-ccopt\ \-L dir
 causes the C linker to search for C libraries in
 directory
 .IR dir .
 .TP
-.BI \-color \ mode
+.BI \-color " mode"
 Enable or disable colors in compiler messages (especially warnings and errors).
 The following modes are supported:
 
@@ -239,7 +239,7 @@ checks that the "TERM" environment variable exists and is
 not empty or "dumb", and that isatty(stderr) holds.
 
 .TP
-.BI \-error\-style \ mode
+.BI \-error\-style " mode"
 Control the way error messages and warnings are printed.
 The following modes are supported:
 
@@ -275,10 +275,10 @@ from the
 output, then exit. If the variable does not exist,
 the exit code is non-zero.
 .TP
-.BI \-depend\ ocamldep-args
+.BI \-depend " ocamldep-args"
 Compute dependencies, as ocamldep would do.
 .TP
-.BI \-for\-pack \ module\-path
+.BI \-for\-pack " module\-path"
 Generate an object file (.cmx and .o files) that can later be included
 as a sub-module (with the given access path) of a compilation unit
 constructed with
@@ -307,11 +307,11 @@ can help in writing an explicit interface (.mli file) for a file:
 just redirect the standard output of the compiler to a .mli file,
 and edit that file to remove all declarations of unexported names.
 .TP
-.B \-cmi-file \ filename
+.BI \-cmi\-file " filename"
 Type-check the source implementation to be compiled against the
 specified interface file (by-passes the normal lookup for .mli and .cmi files).
 .TP
-.BI \-I \ directory
+.BI \-I " directory"
 Add the given directory to the list of directories searched for
 compiled interface files (.cmi), compiled object code files (.cmx),
 and libraries (.cmxa). By default, the current directory is searched
@@ -330,12 +330,12 @@ adds the subdirectory
 .B compiler-libs
 of the standard library to the search path.
 .TP
-.BI \-impl \ filename
+.BI \-impl " filename"
 Compile the file
 .I filename
 as an implementation file, even if its extension is not .ml.
 .TP
-.BI \-inline \ n
+.BI \-inline " n"
 Set aggressiveness of inlining to
 .IR n ,
 where
@@ -346,7 +346,7 @@ integer. Specifying
 prevents all functions from being
 inlined, except those whose body is smaller than the call site. Thus,
 inlining causes no expansion in code size. The default aggressiveness,
-.BR \-inline\ 1 ,
+.BR \-inline " 1" ,
 allows slightly larger functions to be inlined, resulting
 in a slight expansion in code size. Higher values for the
 .B \-inline
@@ -356,12 +356,12 @@ inlining, but can result in a serious increase in code size.
 .B \-insn\-sched
 Enables the instruction scheduling pass in the compiler backend.
 .TP
-.BI \-intf \ filename
+.BI \-intf " filename"
 Compile the file
 .I filename
 as an interface file, even if its extension is not .mli.
 .TP
-.BI \-intf\-suffix \ string
+.BI \-intf\-suffix " string"
 Recognize file names ending with
 .I string
 as interface files (instead of the default .mli).
@@ -421,7 +421,7 @@ This flag has no effect when linking already-compiled files.
 .TP
 .B \-noautolink
 When linking .cmxa libraries, ignore
-.BR \-cclib \ and \ \-ccopt
+.BR \-cclib " and " \-ccopt
 options potentially contained in the libraries (if these options were
 given when building the libraries).  This can be useful if a library
 contains incorrect specifications of C libraries or C options; in this
@@ -446,7 +446,7 @@ object code files (.cmx), and libraries (.cmxa). See also option
 Ignore non-optional labels in types. Labels cannot be used in
 applications, and parameter order becomes strict.
 .TP
-.BI \-o \ exec\-file
+.BI \-o " exec\-file"
 Specify the name of the output file produced by the linker. The
 default output name is a.out, in keeping with the Unix tradition. If the
 .B \-a
@@ -470,7 +470,7 @@ option of the bytecode compiler. When compiling a .ml implementation
 file, this produces a .cmx file without cross-module optimization
 information, which reduces recompilation on module change.
 .TP
-.BI \-open \ module
+.BI \-open " module"
 Opens the given module before processing the interface or
 implementation files. If several
 .B \-open
@@ -524,7 +524,7 @@ See
 .IR "The OCaml user's manual" ,
 chapter "Native-code compilation" for more details.
 .TP
-.BI \-pp \ command
+.BI \-pp " command"
 Cause the compiler to call the given
 .I command
 as a preprocessor for each source file. The output of
@@ -533,7 +533,7 @@ is redirected to
 an intermediate file, which is compiled. If there are no compilation
 errors, the intermediate file is deleted afterwards.
 .TP
-.BI \-ppx \ command
+.BI \-ppx " command"
 After parsing, pipe the abstract syntax tree through the preprocessor
 .IR command .
 The module
@@ -561,7 +561,7 @@ flag, you must use it again for all dependencies.
 Do no allow arbitrary recursive types during type-checking.
 This is the default.
 .TP
-.BI \-runtime\-variant \ suffix
+.BI \-runtime\-variant " suffix"
 Add
 .I suffix
 to the name of the runtime library that will be used by the program.
@@ -580,7 +580,7 @@ is saved in the file
 .TP
 .B \-safe\-string
 Enforce the separation between types
-.BR string \ and\  bytes ,
+.BR string " and " bytes ,
 thereby making strings read-only. This is the default.
 .TP
 .B \-safer\-matching
@@ -589,7 +589,7 @@ This allows to detect match failures even if a pattern-matching was
 wrongly assumed to be exhaustive. This only impacts GADT and
 polymorphic variant compilation.
 .TP
-.BI \-save\-ir\-after \ pass
+.BI \-save\-ir\-after " pass"
 Save intermediate representation after the given compilation pass. The currently
 supported passes are:
 .BR scheduling .
@@ -617,7 +617,7 @@ When a type is visible under several module-paths, use the shortest
 one when printing the type's name in inferred interfaces and error and
 warning messages.
 .TP
-.BI \-stop\-after \ pass
+.BI \-stop\-after " pass"
 Stop compilation after the given compilation pass. The currently
 supported passes are:
 .BR parsing ,
@@ -645,7 +645,7 @@ This is the default.
 .TP
 .B \-unsafe
 Turn bound checking off for array and string accesses (the
-.BR v.(i) and s.[i]
+.BR v.(i) " and " s.[i]
 constructs). Programs compiled with
 .B \-unsafe
 are therefore
@@ -661,7 +661,7 @@ exception.
 .TP
 .B \-unsafe\-string
 Identify the types
-.BR string \ and\  bytes ,
+.BR string " and " bytes ,
 thereby making strings writable.
 This is intended for compatibility with old source code and should not
 be used with new software.
@@ -674,11 +674,11 @@ standard library directory, then exit.
 Print all external commands before they are executed, in particular
 invocations of the assembler, C compiler, and linker.
 .TP
-.BR \-version \ or\  \-vnum
+.BR \-version " or " \-vnum
 Print the version number of the compiler in short form (e.g. "3.11.0"),
 then exit.
 .TP
-.BI \-w \ warning\-list
+.BI \-w " warning\-list"
 Enable, disable, or mark as fatal the warnings specified by the argument
 .IR warning\-list .
 See
@@ -686,7 +686,7 @@ See
 for the syntax of
 .IR warning-list .
 .TP
-.BI \-warn\-error \ warning\-list
+.BI \-warn\-error " warning\-list"
 Mark as fatal the warnings specified in the argument
 .IR warning\-list .
 The compiler will stop with an error when one of these
@@ -726,12 +726,12 @@ Include the runtime system in the generated program. This is the default.
 The compiler does not include the runtime system (nor a reference to it) in the
 generated program; it must be supplied separately.
 .TP
-.BI \- \ file
+.BI \- " file"
 Process
 .I file
 as a file name, even if it starts with a dash (-) character.
 .TP
-.BR \-help \ or \ \-\-help
+.BR \-help " or " \-\-help
 Display a short usage summary and exit.
 
 .SH OPTIONS FOR THE FLAMBDA MIDDLE-END
@@ -835,11 +835,11 @@ itself. This configuration can be inspected using
 .BR ocamlopt\ \-config .
 Target architecture depends on the "model" setting, while
 floating-point hardware and thumb support are determined from the ABI
-setting in "system" (
-.BR linux_eabi or linux_eabihf ).
+setting in "system"
+.RB ( linux_eabi " or " linux_eabihf ).
 
 .SH SEE ALSO
 .BR ocamlc (1).
 .br
-.IR "The OCaml user's manual" ,
+.IR The\ OCaml\ user's\ manual ,
 chapter "Native-code compilation".

--- a/man/ocamlprof.1
+++ b/man/ocamlprof.1
@@ -45,28 +45,28 @@ since the profiling execution took place.
 .SH OPTIONS
 
 .TP
-.BI \-f \ dumpfile
+.BI \-f " dumpfile"
 Specifies an alternate dump file of profiling information.
 .TP
-.BI \-F \ string
+.BI \-F " string"
 Specifies an additional string to be output with profiling information.
 By default,
 .BR ocamlprof (1)
 will annotate programs with comments of the form
-.BI (* \ n \ *)
+.BI (* " n " *)
 where
 .I n
 is the counter value for a profiling point. With option
-.BI \-F \ s
+.BI \-F " s"
 the annotation will be
-.BI (* \ sn \ *)
+.BI (* " sn " *)
 .TP
-.BI \-impl \ filename
+.BI \-impl " filename"
 Compile the file
 .I filename
 as an implementation file, even if its extension is not .ml.
 .TP
-.BI \-intf \ filename
+.BI \-intf " filename"
 Compile the file
 .I filename
 as an interface file, even if its extension is not .mli.
@@ -77,11 +77,11 @@ Print version string and exit.
 .B \-vnum
 Print short version number and exit.
 .TP
-.BR \-help \ or \ \-\-help
+.BR \-help " or " \-\-help
 Display a short usage summary and exit.
 
 .SH SEE ALSO
 .BR ocamlcp (1).
 .br
-.IR "The OCaml user's manual" ,
+.IR The\ OCaml\ user's\ manual ,
 chapter "Profiling".

--- a/man/ocamlrun.1
+++ b/man/ocamlrun.1
@@ -69,12 +69,12 @@ set.  This option is equivalent to setting the
 .B b
 flag in the OCAMLRUNPARAM environment variable (see below).
 .TP
-.BI \-I \ dir
+.BI \-I " dir"
 Search the directory
 .I dir
 for dynamically-loaded libraries, in addition to the standard search path.
 .TP
-.BI \-m \ file
+.BI \-m " file"
 Print the magic number of the bytecode executable
 .I file
 and exit.
@@ -133,16 +133,16 @@ and an optional multiplier. If the letter is followed by anything
 else, the corresponding option is set to 1. Unknown letters
 are ignored.
 The options are documented below; the options
-.B a, i, l, m, M, n, o, O, s, v, w
+.BR a , i , l , m , M , n , o , O , s , v , w
 correspond to the fields of the
 .B control
 record documented in
-.IR "The OCaml user's manual",
+.IR The\ OCaml\ user's\ manual ,
 chapter "Standard Library", section "Gc".
 
 .RS 7
 .TP
-.BR a \ (allocation_policy)
+.BR a " (allocation_policy)"
 The policy used for allocating in the OCaml heap.  Possible values
 are 0 for the next-fit policy, 1 for the first-fit
 policy, and 2 for the best-fit policy. The default is 2.
@@ -165,14 +165,14 @@ The initial size of the major heap (in words).
 Allocate heap chunks by mmapping huge pages. Huge pages are locked into
 memory, and are not swapped.
 .TP
-.BR i \ (major_heap_increment)
+.BR i " (major_heap_increment)"
 The default size increment for the major heap (in words if greater than 1000,
 else in percents of the heap size).
 .TP
-.BR l \ (stack_limit)
+.BR l " (stack_limit)"
 The limit (in words) of the stack size.
 .TP
-.BR m \ (custom_minor_ratio)
+.BR m " (custom_minor_ratio)"
 Bound on floating garbage for out-of-heap memory
 held by custom values in the minor heap. A minor GC is triggered
 when this much memory is held by custom values located in the minor
@@ -180,9 +180,9 @@ heap. Expressed as a percentage of minor heap size.
 Note: this only applies to values allocated with
 .B caml_alloc_custom_mem
 (e.g. bigarrays).
- Default: 100.
+Default: 100.
 .TP
-.BR M \ (custom_major_ratio)
+.BR M " (custom_major_ratio)"
 Target ratio of floating garbage to
 major heap size for out-of-heap memory held by custom values
 located in the major heap. The GC speed is adjusted
@@ -195,7 +195,7 @@ Note: this only applies to values allocated with
 (e.g. bigarrays).
 Default: 44.
 .TP
-.BR n \ (custom_minor_max_size)
+.BR n " (custom_minor_max_size)"
 Maximum amount of out-of-heap
 memory for each custom value allocated in the minor heap. When a custom
 value is allocated on the minor heap and holds more than this many
@@ -208,10 +208,10 @@ Note: this only applies to values allocated with
 (e.g. bigarrays).
 Default: 8192 bytes.
 .TP
-.BR o \ (space_overhead)
+.BR o " (space_overhead)"
 The major GC speed setting.
 .TP
-.BR O \ (max_overhead)
+.BR O " (max_overhead)"
 The heap compaction trigger setting.
 .TP
 .B p
@@ -227,14 +227,14 @@ Turn on randomization of all hash tables by default (see the
 module of the standard library). This option takes no
 argument.
 .TP
-.BR s \ (minor_heap_size)
+.BR s " (minor_heap_size)"
 The size of the minor heap (in words).
 .TP
 .B t
 Set the trace level for the debug runtime (ignored by the standard
 runtime).
 .TP
-.BR v \ (verbose)
+.BR v " (verbose)"
 What GC messages to print to stderr.  This is a sum of values selected
 from the following:
 
@@ -279,7 +279,7 @@ GC debugging messages.
 Address space reservation changes.
 
 .TP
-.BR w \ (window_size)
+.BR w " (window_size)"
 Set size of the window used by major GC for smoothing out variations in
 its workload. This is an integer between 1 and 50. (Default: 1)
 .TP
@@ -289,9 +289,7 @@ being closed, unflushed data, etc.)
 
 .RS 0
 The multiplier is
-.BR k ,
-.BR M ,\ or
-.BR G ,
+.BR k , M ", or " G ,
 for multiplication by 2^10, 2^20, and 2^30 respectively.
 
 If the option letter is not recognized, the whole parameter is ignored;
@@ -316,5 +314,5 @@ List of directories searched to find the bytecode executable file.
 .SH SEE ALSO
 .BR ocamlc (1).
 .br
-.IR "The OCaml user's manual" ,
+.IR The\ OCaml\ user's\ manual ,
 chapter "Runtime system".

--- a/man/ocamlyacc.1
+++ b/man/ocamlyacc.1
@@ -21,7 +21,7 @@ ocamlyacc \- The OCaml parser generator
 .SH SYNOPSIS
 .B ocamlyacc
 [
-.BI \-b prefix
+.BI \-b " prefix"
 ] [
 .B \-q
 ] [
@@ -69,7 +69,7 @@ The
 .BR ocamlyacc (1)
 command recognizes the following options:
 .TP
-.BI \-b prefix
+.BI \-b " prefix"
 Name the output files
 .IR prefix \&.ml,
 .IR prefix \&.mli,
@@ -79,7 +79,7 @@ instead of the default naming convention.
 .B \-q
 This option has no effect.
 .TP
-.B \--strict
+.B \-\-strict
 Reject grammars with conflicts.
 .TP
 .B \-v
@@ -96,9 +96,10 @@ Print short version number and exit.
 .TP
 .B \-
 Read the grammar specification from standard input.  The default
-output file names are stdin.ml and stdin.mli.
+output file names are
+.IR stdin.ml " and " stdin.mli .
 .TP
-.BI \-\- \ file
+.BI \-\- " file"
 Process
 .I file
 as the grammar specification, even if its name
@@ -108,5 +109,5 @@ command line.
 .SH SEE ALSO
 .BR ocamllex (1).
 .br
-.IR "The OCaml user's manual" ,
+.IR The\ OCaml\ user's\ manual ,
 chapter "Lexer and parser generators".


### PR DESCRIPTION
Thinking too hard about the manual syntax and processing tools would give headache to anyone.

The processing of spaces differs with the BSDs mdoc and GNU's man.
If set in `.I` mode, `\ ` is rendered as an underlined space on BSD, but with GNU the space is not underlined. This leads to this ugly underlined space:

<img width="508" alt="image" src="https://github.com/ocaml/ocaml/assets/1773581/2bd129d8-e31a-45b4-8a37-be0c91d22f31">

The fix is to quote the word instead, with the leading space. This leads to consistent rendering across platforms (the space isn't underlined).

The PR also includes some formatting fixes: some spaces and typesetting macros had been forgotten.

I've also tried to have "The OCaml user's manual" always underlined, including spaces (looks better IMO). This doesn't work with GNU man, but works on the BSDs/macOS. If someone knows make this portable, I'm mildly interested.