### PR TITLE
Replace the set-output command with the GITHUB_OUTPUT environment file

### DIFF
--- a/tools/ci/actions/check-manual-modified.sh
+++ b/tools/ci/actions/check-manual-modified.sh
@@ -32,4 +32,4 @@ else
 fi
 
 echo "Manual altered: $result"
-echo "::set-output name=manual_changed::$result"
+echo "manual_changed=$result" >>"$GITHUB_OUTPUT"

--- a/tools/ci/actions/runner.sh
+++ b/tools/ci/actions/runner.sh
@@ -155,7 +155,7 @@ ReportBuildStatus () {
   else
     STATUS='success'
   fi
-  echo "::set-output name=build-status::$STATUS"
+  echo "build-status=$STATUS" >>"$GITHUB_OUTPUT"
   exit $CODE
 }
 


### PR DESCRIPTION
@dra27 I forgot that the `set-output` command had to be replaced as well, sorry! I believe this fixes all the rest of the warnings!