### PR TITLE
fix for 4.14: avoid pathological case for compact_allocate

### DIFF
--- a/Changes
+++ b/Changes
@@ -10,7 +10,7 @@ OCaml 4.14 maintenance version
 
 - #12264, #12289: Fix compact_allocate to avoid a pathological case
   that causes very slow compaction.
-  (Damien Doligez, report by Arseniy Alekseyev, review by ???)
+  (Damien Doligez, report by Arseniy Alekseyev, review by Sadiq Jaffer)
 
 OCaml 4.14.1 (20 December 2022)
 ------------------------------

--- a/Changes
+++ b/Changes
@@ -8,6 +8,10 @@ OCaml 4.14 maintenance version
 
 ### Bug fixes:
 
+- #12264, #12289: Fix compact_allocate to avoid a pathological case
+  that causes very slow compaction.
+  (Damien Doligez, report by Arseniy Alekseyev, review by ???)
+
 OCaml 4.14.1 (20 December 2022)
 ------------------------------
 

--- a/runtime/compact.c
+++ b/runtime/compact.c
@@ -123,15 +123,13 @@ static void init_compact_allocate (void)
   compact_fl_small = compact_fl_large = caml_heap_start;
 }
 
-#define Chunk_free(c) (Chunk_size(c) - Chunk_alloc(c))
-
 /* [size] is a number of bytes and includes the header size */
 static char *compact_allocate (mlsize_t size)
 {
   char *chunk, *adr;
 
   chunk = size > COMPACT_FL_CUTOFF_SIZE ? compact_fl_large : compact_fl_small;
-  while (Chunk_free (chunk) < size){
+  while (Chunk_size(chunk) - Chunk_alloc(chunk) < size){
     chunk = Chunk_next (chunk);
     CAMLassert (chunk != NULL);
   }

--- a/runtime/compact.c
+++ b/runtime/compact.c
@@ -106,7 +106,12 @@ void caml_invert_root (value v, value *p)
   invert_pointer_at ((word *) p);
 }
 
-static char *compact_fl;
+static char *compact_fl_small, *compact_fl_large;
+#define COMPACT_FL_CUTOFF_SIZE Bhsize_wosize(10)
+/* COMPACT_FL_CUTOFF_SIZE should be "small" (at most 4096), as it is the
+   maximum size of "wasted" free space at the end of each chunk, and it
+   should be "large" (at least Bhsize_wosize(5)) so that the compactor
+   finds enough live blocks to fill those spaces. */
 
 static void init_compact_allocate (void)
 {
@@ -115,23 +120,23 @@ static void init_compact_allocate (void)
     Chunk_alloc (ch) = 0;
     ch = Chunk_next (ch);
   }
-  compact_fl = caml_heap_start;
+  compact_fl_small = compact_fl_large = caml_heap_start;
 }
+
+#define Chunk_free(c) (Chunk_size(c) - Chunk_alloc(c))
 
 /* [size] is a number of bytes and includes the header size */
 static char *compact_allocate (mlsize_t size)
 {
   char *chunk, *adr;
 
-  while (Chunk_size(compact_fl) - Chunk_alloc(compact_fl) < Bhsize_wosize(1)){
-    compact_fl = Chunk_next (compact_fl);
-    CAMLassert (compact_fl != NULL);
-  }
-  chunk = compact_fl;
-  while (Chunk_size (chunk) - Chunk_alloc (chunk) < size){
+  chunk = size > COMPACT_FL_CUTOFF_SIZE ? compact_fl_large : compact_fl_small;
+  while (Chunk_free (chunk) < size){
     chunk = Chunk_next (chunk);
     CAMLassert (chunk != NULL);
   }
+  *(size > COMPACT_FL_CUTOFF_SIZE ? &compact_fl_large : &compact_fl_small)
+    = chunk;
   adr = chunk + Chunk_alloc (chunk);
   Chunk_alloc (chunk) += size;
   return adr;


### PR DESCRIPTION
A low-impact fix for a rather unlikely corner case of the compactor. I couldn't trigger the repro case on my machine, so I can't test this PR properly...

fixes #12264