### PR TITLE
Fix incorrect dependency and tweak shell quoting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -423,7 +423,7 @@ endif
 flexlink.opt$(EXE): $(FLEXDLL_SOURCE_FILES)
 	$(MAKE) -C $(FLEXDLL_SOURCES) $(FLEXLINK_BUILD_ENV) \
     OCAML_FLEXLINK='$(value OCAMLRUN) $$(ROOTDIR)/boot/flexlink.byte$(EXE)' \
-	  OCAMLOPT="$(FLEXLINK_OCAMLOPT) -nostdlib -I ../stdlib" -B flexlink.exe
+	  OCAMLOPT='$(FLEXLINK_OCAMLOPT) -nostdlib -I ../stdlib' -B flexlink.exe
 	cp $(FLEXDLL_SOURCES)/flexlink.exe $@
 
 partialclean::

--- a/stdlib/Makefile
+++ b/stdlib/Makefile
@@ -30,7 +30,7 @@ COMPFLAGS=-strict-sequence -absname -w +a-4-9-41-42-44-45-48 \
 ifeq "$(FLAMBDA)" "true"
 OPTCOMPFLAGS += -O3
 endif
-OPTCOMPILER=$(ROOTDIR)/ocamlopt
+OPTCOMPILER=$(ROOTDIR)/ocamlopt$(EXE)
 CAMLOPT=$(OCAMLRUN) $(OPTCOMPILER)
 
 include StdlibModules

--- a/stdlib/Makefile
+++ b/stdlib/Makefile
@@ -147,7 +147,7 @@ ifneq "$(UNIX_OR_WIN32)" "win32"
 endif
 
 $(HEADERPROGRAM)%$(O): \
-  OC_CPPFLAGS += -DRUNTIME_NAME='"$(HEADER_PATH)ocamlrun$(subst .,,$*)"'
+  OC_CPPFLAGS += -DRUNTIME_NAME="$(HEADER_PATH)ocamlrun$(subst .,,$*)"
 
 $(HEADERPROGRAM)%$(O): $(HEADERPROGRAM).c
 	$(V_CC)$(CC) -c $(OC_CFLAGS) $(CFLAGS) $(OC_CPPFLAGS) $(CPPFLAGS) \
@@ -163,7 +163,7 @@ tmptargetcamlheader%exe: $(TARGETHEADERPROGRAM)%$(O)
 
 $(TARGETHEADERPROGRAM)%$(O): $(HEADERPROGRAM).c
 	$(V_CC)$(CC) -c $(OC_CFLAGS) $(CFLAGS) $(OC_CPPFLAGS) $(CPPFLAGS) \
-	      -DRUNTIME_NAME='"$(HEADER_TARGET_PATH)ocamlrun$(subst .,,$*)"' \
+	      -DRUNTIME_NAME="$(HEADER_TARGET_PATH)ocamlrun$(subst .,,$*)" \
 	      $(OUTPUTOBJ)$@ $^
 
 target_%: tmptarget%.exe

--- a/stdlib/header.c
+++ b/stdlib/header.c
@@ -30,7 +30,13 @@
 #include "caml/mlvalues.h"
 #include "caml/exec.h"
 
-char * default_runtime_path = RUNTIME_NAME;
+/* Two macros are required so that QUOTE(foo) stringizes the _expansion_ of foo
+   rather than foo itself. cf. the Stringizing chapter in the cpp manual
+   (https://gcc.gnu.org/onlinedocs/gcc-13.1.0/cpp/Stringizing.html). */
+#define Q(x) #x
+#define QUOTE(x) Q(x)
+
+char * default_runtime_path = QUOTE(RUNTIME_NAME);
 
 #ifndef MAXPATHLEN
 #define MAXPATHLEN 1024

--- a/stdlib/headernt.c
+++ b/stdlib/headernt.c
@@ -31,7 +31,13 @@
 #endif
 #endif
 
-char * default_runtime_name = RUNTIME_NAME;
+/* Two macros are required so that QUOTE(foo) stringizes the _expansion_ of foo
+   rather than foo itself. cf. the Stringizing chapter in the cpp manual
+   (https://gcc.gnu.org/onlinedocs/gcc-13.1.0/cpp/Stringizing.html). */
+#define Q(x) #x
+#define QUOTE(x) Q(x)
+
+char * default_runtime_name = QUOTE(RUNTIME_NAME);
 
 static
 #ifdef _MSC_VER


### PR DESCRIPTION
This PR contains three minor tweaks to the build system which should be fairly straightforward to review. As it happens, combined, they allow `world.opt` to be compiled using a native GNU make, rather than using Cygwin/MSYS2's build of `make`. The first and third commits do technically fix bugs, but highly obscure and nearly impossible to hit ones.

- The first commit is a straightforward missing `$(EXE)` in a filename (i.e. the dependency is wrong). It gets masked with Cygwin's `make` owing to the `.exe` trickery it goes through (and which we have to work around elsewhere in the build system...).
- The second commit switches the quoting for a recursive call to `make` from using double-quotes to single-quotes, with no semantic impact (although it is more consistent as it previously had two parameters passed using different string quoting for no actual reason). As it happens, that stops native GNU make from struggling with the recursive call.
- The third commit works around the same problem (trying to use both double and single quotes) but solves it differently. Previously, we were attempting to pass a literal C string using `-D`, but it is more robust to pass the string and allow the C pre-processor to stringize it instead. The more robust approach means that the resulting is definitely a properly escaped C string literal (on the Cygwin port, it is possible to use `"` in a filename, and the previous code would fail to compile if the configured prefix included a double-quote).