### PR TITLE
Compute `$(STDLIB_MODULES)` with GNU make functions instead of `runtime/sak`

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -227,18 +227,6 @@ OCAMLYACCFLAGS ?= --strict -v
 
 SAK = $(ROOTDIR)/runtime/sak$(EXE)
 
-# stdlib/StdlibModules cannot be include'd unless $(SAK) has been built. These
-# two rules add that dependency. They have to be pattern rules since
-# Makefile.common is included before default targets.
-$(ROOTDIR)/%/sak$(EXE):
-	$(MAKE) -C $(ROOTDIR)/$* sak$(EXE)
-
-ifneq "$(REQUIRES_CONFIGURATION)" ""
-ifneq "$(wildcard $(ROOTDIR)/Makefile.config)" ""
-$(ROOTDIR)/%/StdlibModules: $(SAK) ;
-endif
-endif
-
 # Used with the Microsoft toolchain to merge generated manifest files into
 # executables
 if_file_exists = ( test ! -f $(1) || $(2) && rm -f $(1) )

--- a/runtime/sak.c
+++ b/runtime/sak.c
@@ -49,12 +49,6 @@
 
      On Windows, `sak encode-C-literal "C:\OCaml🐫\lib"` returns
      `L"C:\\OCaml\xd83d\xdc2b\\lib"`
-   - add-stdlib-prefix. Used in stdlib/StdlibModules to convert the list of
-     basenames given in STDLIB_MODULE_BASENAMES to the actual file basenames
-     in STDLIB_MODULES.
-
-     For example, `sak add-stdlib-prefix stdlib camlinternalAtomic Sys` returns
-     ` stdlib camlinternalAtomic stdlib__Sys`
  */
 
 void usage(void)
@@ -64,7 +58,6 @@ void usage(void)
     "Usage: sak command\n"
     "Commands:\n"
     " * encode-C-literal path - encodes path as a C string literal\n"
-    " * add-stdlib-prefix name1 ... - prefix standard library module names\n"
   );
 }
 
@@ -106,37 +99,10 @@ void encode_C_literal(char_os *path)
   putchar('"');
 }
 
-/* Print the given array of module names to stdout. "stdlib" and names beginning
-   "camlinternal" are printed unaltered. All other names are prefixed "stdlib__"
-   with the original name capitalised (i.e. "foo" prints "stdlib__Foo"). */
-void add_stdlib_prefix(int count, char_os **names)
-{
-  int i;
-  char_os *name;
-
-  for (i = 0; i < count; i++) {
-    name = *names++;
-
-    /* "stdlib" and camlinternal* do not get changed. All other names get
-       capitalised and prefixed "stdlib__". */
-    if (strcmp_os(T("stdlib"), name) == 0
-     || strncmp_os(T("camlinternal"), name, 12) == 0) {
-      printf_os(T(" %s"), name);
-    } else {
-      /* name is a null-terminated string, so an empty string simply has the
-         null-terminator "capitalised". */
-      *name = toupper_os(*name);
-      printf_os(T(" stdlib__%s"), name);
-    }
-  }
-}
-
 int main_os(int argc, char_os **argv)
 {
   if (argc == 3 && !strcmp_os(argv[1], T("encode-C-literal"))) {
     encode_C_literal(argv[2]);
-  } else if (argc > 1 && !strcmp_os(argv[1], T("add-stdlib-prefix"))) {
-    add_stdlib_prefix(argc - 2, &argv[2]);
   } else {
     usage();
     return 1;

--- a/stdlib/StdlibModules
+++ b/stdlib/StdlibModules
@@ -104,9 +104,23 @@ STDLIB_MODULE_BASENAMES = \
 STDLIB_PREFIXED_MODULES = \
   $(filter-out stdlib camlinternal%, $(STDLIB_MODULE_BASENAMES))
 
-# The pattern FOO = $(eval FOO := $$(shell <cmd>)$(FOO) ensures that <cmd> is
-# executed either once or not at all, giving us GNU make's equivalent of a
-# string lazy_t.
-STDLIB_MODULES = \
-  $(eval STDLIB_MODULES := $$(shell \
-          $(SAK) add-stdlib-prefix $(STDLIB_MODULE_BASENAMES)))$(STDLIB_MODULES)
+# $(STDLIB_MODULES) applies the PREFIX_MODULE macro to each item in
+# $(STDLIB_MODULE_BASENAMES). For the names which require prefixing, this is
+# done using CAPITALIZE. CAPITALIZE is a recursive macro taking the name to
+# transform and a list of transformations to apply to the beginning of the name,
+# thus $(call CAPITALIZE, string, ... r R s S t T ...) expands to String.
+CAPITALIZE = \
+  $(strip $(if $(firstword $(2)), \
+    $(call CAPITALIZE, $(patsubst $(word 1, $(2))%, $(word 2, $(2))%, $(1)), \
+      $(wordlist 3, $(words $(2)), $(2))), \
+    $(1)))
+
+PREFIX_MODULE = \
+  $(if $(filter stdlib camlinternal%, $(1)), \
+    $(1), \
+    stdlib__$(call CAPITALIZE, $(1), \
+                         a A b B c C d D e E f F g G h H i I j J k K l L m M \
+                         n N o O p P q Q r R s S t T u U v V w W x X y Y z Z))
+
+STDLIB_MODULES = $(strip \
+  $(foreach name, $(STDLIB_MODULE_BASENAMES), $(call PREFIX_MODULE, $(name))))


### PR DESCRIPTION
This PR follows on from https://github.com/ocaml/ocaml/issues/12287#issuecomment-1576402019.

`stdlib/StdlibModules` contains the macro `$(STDLIB_MODULES)` which expands to the actual module list for the Standard Library (i.e. with `Stdlib__` prefixes). In #10169, this was computed using a series of shell calls which was hideously slow on Windows and which got changed in #10451 with the introduction of the `sak` tool.

Even ignoring questions of taste or otherwise about the use of C, this constitutes a slightly confusing state of affairs in the build system. `$(STDLIB_MODULES)` is evaluated, but it is the responsibility of the expansion site to ensure that the `sak` tool is compiled _before_ this happens. In other words, the `STDLIB_MODULES` _variable_ has _prerequisites_!

This isn't ideal, and means that `Makefile.common` contains some dark magic to ensure that `sak` is compiled before `StdlibModules` is included (which can also cause `sak` to be (re-)built when not really necessary).

This can be done fairly simply, if inelegantly, in GNU make itself. GNU make doesn't directly have a function to convert case, but it can efficiently evaluate 26 calls to `$(patsubst ...` - i.e. we can just do `$(patsubst a%, A%, $(patsubst b%, B%, ...`. I'm not that keen on 27 right brackets in a row at the end of it, so instead the macro `CAPITALIZE` here receives two space-separated alphabets, and is defined recursively. I like this not involving _any_ auxiliary script.

`runtime/sak` remains only for the purpose of formatting the location of the Standard Library, but this is used in a much more normal way to generate `runtime/build_config.h` (where `runtime/sak` is just a normal dependency). I think I have something in the freezer for that, too, but for another day.