### PR TITLE
Print end line and valid end character for multi-line locations in dumps

### DIFF
--- a/.depend
+++ b/.depend
@@ -539,7 +539,6 @@ parsing/printast.cmo : \
     parsing/parsetree.cmi \
     parsing/longident.cmi \
     parsing/location.cmi \
-    utils/clflags.cmi \
     parsing/asttypes.cmi \
     parsing/printast.cmi
 parsing/printast.cmx : \
@@ -547,7 +546,6 @@ parsing/printast.cmx : \
     parsing/parsetree.cmi \
     parsing/longident.cmx \
     parsing/location.cmx \
-    utils/clflags.cmx \
     parsing/asttypes.cmx \
     parsing/printast.cmi
 parsing/printast.cmi : \
@@ -1441,7 +1439,6 @@ typing/printtyped.cmo : \
     parsing/longident.cmi \
     parsing/location.cmi \
     typing/ident.cmi \
-    utils/clflags.cmi \
     parsing/asttypes.cmi \
     typing/printtyped.cmi
 typing/printtyped.cmx : \
@@ -1454,7 +1451,6 @@ typing/printtyped.cmx : \
     parsing/longident.cmx \
     parsing/location.cmx \
     typing/ident.cmx \
-    utils/clflags.cmx \
     parsing/asttypes.cmx \
     typing/printtyped.cmi
 typing/printtyped.cmi : \

--- a/.gitattributes
+++ b/.gitattributes
@@ -221,20 +221,5 @@ runtime/caml/sizeclasses.h typo.missing-header
 # Tests which include references spanning multiple lines fail with \r\n
 # endings, so use \n endings only, even on Windows.
 testsuite/tests/basic-modules/anonymous.ml text eol=lf
-testsuite/tests/formatting/test_locations.ml text eol=lf
 testsuite/tests/functors/functors.ml text eol=lf
-testsuite/tests/parsing/attributes.ml text eol=lf
-testsuite/tests/parsing/extensions.ml text eol=lf
-testsuite/tests/parsing/hash_ambiguity.ml text eol=lf
-testsuite/tests/parsing/int_and_float_with_modifier.ml text eol=lf
-testsuite/tests/parsing/pr6865.ml text eol=lf
-testsuite/tests/parsing/quotedextensions.ml text eol=lf
-testsuite/tests/parsing/shortcut_ext_attr.ml text eol=lf
-testsuite/tests/tool-ocamlc-stop-after/stop_after_parsing_impl.ml text eol=lf
-testsuite/tests/tool-ocamlc-stop-after/stop_after_parsing_intf.mli text eol=lf
-testsuite/tests/tool-ocamlc-stop-after/stop_after_typing_impl.ml text eol=lf
 testsuite/tests/translprim/module_coercion.ml text eol=lf
-
-# This is forced to \n to allow the Cygwin testsuite to pass on a
-# Windows-checkout
-testsuite/tests/parsetree/locations_test.ml text eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -217,9 +217,3 @@ runtime/caml/sizeclasses.h typo.missing-header
 
 /tools/opam/gen_ocaml-system_config.ml.in typo.missing-header
 /tools/opam/gen_ocaml_config.ml.in typo.very-long-line typo.missing-header
-
-# Tests which include references spanning multiple lines fail with \r\n
-# endings, so use \n endings only, even on Windows.
-testsuite/tests/basic-modules/anonymous.ml text eol=lf
-testsuite/tests/functors/functors.ml text eol=lf
-testsuite/tests/translprim/module_coercion.ml text eol=lf

--- a/Changes
+++ b/Changes
@@ -340,6 +340,10 @@ Working version
 
 ### Compiler user-interface and warnings:
 
+- #12297: Don't include bol (beginning-of-line) offsets for -dparsetree and
+  -dtypedtree (allows tests to run with CRLF-formatted source files).
+  (David Allsopp, review by ???)
+
 - #12628: Improved error message for unsafe values: print out the full path for
   the value that is unsafe when they are detected during the compilation of
   recursive modules.

--- a/Changes
+++ b/Changes
@@ -341,7 +341,8 @@ Working version
 ### Compiler user-interface and warnings:
 
 - #12297: Don't include bol (beginning-of-line) offsets for -dparsetree and
-  -dtypedtree (allows tests to run with CRLF-formatted source files).
+  -dtypedtree and use line-relative locations in -dlambda (allows tests to
+  run with CRLF-formatted source files).
   (David Allsopp, review by ???)
 
 - #12628: Improved error message for unsafe values: print out the full path for

--- a/lambda/printlambda.ml
+++ b/lambda/printlambda.ml
@@ -662,13 +662,23 @@ let rec lam ppf = function
       | Loc_unknown ->
         fprintf ppf "@[<2>(%s <unknown location>@ %a)@]" kind lam expr
       | Loc_known {scopes; loc} ->
-        fprintf ppf "@[<2>(%s %s %s(%i)%s:%i-%i@ %a)@]" kind
+        let (pos_start, pos_end) =
+          let open Location in
+          let open Lexing in
+          let pos_start = loc.loc_start.pos_cnum - loc.loc_start.pos_bol in
+          let pos_end = loc.loc_end.pos_cnum - loc.loc_end.pos_bol in
+          if loc.loc_end.pos_lnum = loc.loc_start.pos_lnum then
+            (pos_start, string_of_int pos_end)
+          else
+            (pos_start, Printf.sprintf "(%d):%d" loc.loc_end.pos_lnum pos_end)
+        in
+        fprintf ppf "@[<2>(%s %s %s(%i)%s:%i-%s@ %a)@]" kind
                 (Debuginfo.Scoped_location.string_of_scopes scopes)
                 loc.Location.loc_start.Lexing.pos_fname
                 loc.Location.loc_start.Lexing.pos_lnum
                 (if loc.Location.loc_ghost then "<ghost>" else "")
-                loc.Location.loc_start.Lexing.pos_cnum
-                loc.Location.loc_end.Lexing.pos_cnum
+                pos_start
+                pos_end
                 lam expr
       end
   | Lifused(id, expr) ->

--- a/parsing/location.ml
+++ b/parsing/location.ml
@@ -286,6 +286,23 @@ let print_loc = Fmt.compat Doc.loc
 let print_locs = Fmt.compat Doc.locs
 let separate_new_message ppf = Fmt.compat Doc.separate_new_message ppf ()
 
+let fmt_position with_name f l =
+  let fname = if with_name then l.pos_fname else "" in
+  if l.pos_lnum = -1
+  then Format.fprintf f "%s[%d]" fname l.pos_cnum
+  else Format.fprintf f "%s[%d,%d+%d]" fname l.pos_lnum l.pos_bol
+                      (l.pos_cnum - l.pos_bol)
+
+
+let dump f loc =
+  if not !Clflags.locations then ()
+  else begin
+    let p_2nd_name = loc.loc_start.pos_fname <> loc.loc_end.pos_fname in
+    Format.fprintf f "(%a..%a)" (fmt_position true) loc.loc_start
+                                (fmt_position p_2nd_name) loc.loc_end;
+    if loc.loc_ghost then Format.fprintf f " ghost";
+  end
+
 (******************************************************************************)
 (* An interval set structure; additionally, it stores user-provided information
    at interval boundaries.

--- a/parsing/location.ml
+++ b/parsing/location.ml
@@ -290,8 +290,7 @@ let fmt_position with_name f l =
   let fname = if with_name then l.pos_fname else "" in
   if l.pos_lnum = -1
   then Format.fprintf f "%s[%d]" fname l.pos_cnum
-  else Format.fprintf f "%s[%d,%d+%d]" fname l.pos_lnum l.pos_bol
-                      (l.pos_cnum - l.pos_bol)
+  else Format.fprintf f "%s[%d+%d]" fname l.pos_lnum (l.pos_cnum - l.pos_bol)
 
 
 let dump f loc =

--- a/parsing/location.mli
+++ b/parsing/location.mli
@@ -197,6 +197,9 @@ val print_loc: formatter -> t -> unit
 val print_locs: formatter -> t list -> unit
 val separate_new_message: formatter -> unit
 
+val dump: formatter -> t -> unit
+    (** Used by -dparsetree and -dtypedtree to print locations. *)
+
 module Doc: sig
   val separate_new_message: unit Format_doc.printer
   val filename: string Format_doc.printer

--- a/parsing/printast.ml
+++ b/parsing/printast.ml
@@ -15,25 +15,10 @@
 
 open Asttypes
 open Format
-open Lexing
 open Location
 open Parsetree
 
-let fmt_position with_name f l =
-  let fname = if with_name then l.pos_fname else "" in
-  if l.pos_lnum = -1
-  then fprintf f "%s[%d]" fname l.pos_cnum
-  else fprintf f "%s[%d,%d+%d]" fname l.pos_lnum l.pos_bol
-               (l.pos_cnum - l.pos_bol)
-
-let fmt_location f loc =
-  if not !Clflags.locations then ()
-  else begin
-    let p_2nd_name = loc.loc_start.pos_fname <> loc.loc_end.pos_fname in
-    fprintf f "(%a..%a)" (fmt_position true) loc.loc_start
-                         (fmt_position p_2nd_name) loc.loc_end;
-    if loc.loc_ghost then fprintf f " ghost";
-  end
+let fmt_location = Location.dump
 
 let rec fmt_longident_aux f x =
   match x with

--- a/testsuite/tests/formatting/test_locations.dlocations.ocamlc.reference
+++ b/testsuite/tests/formatting/test_locations.dlocations.ocamlc.reference
@@ -93,79 +93,79 @@
 
 let rec fib = function | 0 | 1 -> 1 | n -> (fib (n - 1)) + (fib (n - 2))
 [
-  structure_item (test_locations.ml[17,534+0]..test_locations.ml[19,572+34])
+  structure_item (test_locations.ml[17,534+0]..[19,572+34])
     Tstr_value Rec
     [
       <def_rec>
-        pattern (test_locations.ml[17,534+8]..test_locations.ml[17,534+11])
+        pattern (test_locations.ml[17,534+8]..[17,534+11])
           Tpat_var "fib"
-        expression (test_locations.ml[17,534+14]..test_locations.ml[19,572+34])
+        expression (test_locations.ml[17,534+14]..[19,572+34])
           Texp_function
           []
-          Tfunction_cases (test_locations.ml[17,534+14]..test_locations.ml[19,572+34])
+          Tfunction_cases (test_locations.ml[17,534+14]..[19,572+34])
             [
               <case>
-                pattern (test_locations.ml[18,557+4]..test_locations.ml[18,557+9])
+                pattern (test_locations.ml[18,557+4]..[18,557+9])
                   Tpat_or
-                  pattern (test_locations.ml[18,557+4]..test_locations.ml[18,557+5])
+                  pattern (test_locations.ml[18,557+4]..[18,557+5])
                     Tpat_constant Const_int 0
-                  pattern (test_locations.ml[18,557+8]..test_locations.ml[18,557+9])
+                  pattern (test_locations.ml[18,557+8]..[18,557+9])
                     Tpat_constant Const_int 1
-                expression (test_locations.ml[18,557+13]..test_locations.ml[18,557+14])
+                expression (test_locations.ml[18,557+13]..[18,557+14])
                   Texp_constant Const_int 1
               <case>
-                pattern (test_locations.ml[19,572+4]..test_locations.ml[19,572+5])
+                pattern (test_locations.ml[19,572+4]..[19,572+5])
                   Tpat_var "n"
-                expression (test_locations.ml[19,572+9]..test_locations.ml[19,572+34])
+                expression (test_locations.ml[19,572+9]..[19,572+34])
                   Texp_apply
-                  expression (test_locations.ml[19,572+21]..test_locations.ml[19,572+22])
+                  expression (test_locations.ml[19,572+21]..[19,572+22])
                     Texp_ident "Stdlib!.+"
                   [
                     <arg>
                       Nolabel
-                      expression (test_locations.ml[19,572+9]..test_locations.ml[19,572+20])
+                      expression (test_locations.ml[19,572+9]..[19,572+20])
                         Texp_apply
-                        expression (test_locations.ml[19,572+9]..test_locations.ml[19,572+12])
+                        expression (test_locations.ml[19,572+9]..[19,572+12])
                           Texp_ident "fib"
                         [
                           <arg>
                             Nolabel
-                            expression (test_locations.ml[19,572+13]..test_locations.ml[19,572+20])
+                            expression (test_locations.ml[19,572+13]..[19,572+20])
                               Texp_apply
-                              expression (test_locations.ml[19,572+16]..test_locations.ml[19,572+17])
+                              expression (test_locations.ml[19,572+16]..[19,572+17])
                                 Texp_ident "Stdlib!.-"
                               [
                                 <arg>
                                   Nolabel
-                                  expression (test_locations.ml[19,572+14]..test_locations.ml[19,572+15])
+                                  expression (test_locations.ml[19,572+14]..[19,572+15])
                                     Texp_ident "n"
                                 <arg>
                                   Nolabel
-                                  expression (test_locations.ml[19,572+18]..test_locations.ml[19,572+19])
+                                  expression (test_locations.ml[19,572+18]..[19,572+19])
                                     Texp_constant Const_int 1
                               ]
                         ]
                     <arg>
                       Nolabel
-                      expression (test_locations.ml[19,572+23]..test_locations.ml[19,572+34])
+                      expression (test_locations.ml[19,572+23]..[19,572+34])
                         Texp_apply
-                        expression (test_locations.ml[19,572+23]..test_locations.ml[19,572+26])
+                        expression (test_locations.ml[19,572+23]..[19,572+26])
                           Texp_ident "fib"
                         [
                           <arg>
                             Nolabel
-                            expression (test_locations.ml[19,572+27]..test_locations.ml[19,572+34])
+                            expression (test_locations.ml[19,572+27]..[19,572+34])
                               Texp_apply
-                              expression (test_locations.ml[19,572+30]..test_locations.ml[19,572+31])
+                              expression (test_locations.ml[19,572+30]..[19,572+31])
                                 Texp_ident "Stdlib!.-"
                               [
                                 <arg>
                                   Nolabel
-                                  expression (test_locations.ml[19,572+28]..test_locations.ml[19,572+29])
+                                  expression (test_locations.ml[19,572+28]..[19,572+29])
                                     Texp_ident "n"
                                 <arg>
                                   Nolabel
-                                  expression (test_locations.ml[19,572+32]..test_locations.ml[19,572+33])
+                                  expression (test_locations.ml[19,572+32]..[19,572+33])
                                     Texp_constant Const_int 2
                               ]
                         ]

--- a/testsuite/tests/formatting/test_locations.dlocations.ocamlc.reference
+++ b/testsuite/tests/formatting/test_locations.dlocations.ocamlc.reference
@@ -1,88 +1,88 @@
 [
-  structure_item (test_locations.ml[17,534+0]..[19,572+34])
+  structure_item (test_locations.ml[17+0]..[19+34])
     Pstr_value Rec
     [
       <def>
-        pattern (test_locations.ml[17,534+8]..[17,534+11])
-          Ppat_var "fib" (test_locations.ml[17,534+8]..[17,534+11])
-        expression (test_locations.ml[17,534+14]..[19,572+34])
+        pattern (test_locations.ml[17+8]..[17+11])
+          Ppat_var "fib" (test_locations.ml[17+8]..[17+11])
+        expression (test_locations.ml[17+14]..[19+34])
           Pexp_function
           []
           None
-          Pfunction_cases (test_locations.ml[17,534+14]..[19,572+34])
+          Pfunction_cases (test_locations.ml[17+14]..[19+34])
             [
               <case>
-                pattern (test_locations.ml[18,557+4]..[18,557+9])
+                pattern (test_locations.ml[18+4]..[18+9])
                   Ppat_or
-                  pattern (test_locations.ml[18,557+4]..[18,557+5])
+                  pattern (test_locations.ml[18+4]..[18+5])
                     Ppat_constant
-                    constant (test_locations.ml[18,557+4]..[18,557+5])
+                    constant (test_locations.ml[18+4]..[18+5])
                       PConst_int (0,None)
-                  pattern (test_locations.ml[18,557+8]..[18,557+9])
+                  pattern (test_locations.ml[18+8]..[18+9])
                     Ppat_constant
-                    constant (test_locations.ml[18,557+8]..[18,557+9])
+                    constant (test_locations.ml[18+8]..[18+9])
                       PConst_int (1,None)
-                expression (test_locations.ml[18,557+13]..[18,557+14])
+                expression (test_locations.ml[18+13]..[18+14])
                   Pexp_constant
-                  constant (test_locations.ml[18,557+13]..[18,557+14])
+                  constant (test_locations.ml[18+13]..[18+14])
                     PConst_int (1,None)
               <case>
-                pattern (test_locations.ml[19,572+4]..[19,572+5])
-                  Ppat_var "n" (test_locations.ml[19,572+4]..[19,572+5])
-                expression (test_locations.ml[19,572+9]..[19,572+34])
+                pattern (test_locations.ml[19+4]..[19+5])
+                  Ppat_var "n" (test_locations.ml[19+4]..[19+5])
+                expression (test_locations.ml[19+9]..[19+34])
                   Pexp_apply
-                  expression (test_locations.ml[19,572+21]..[19,572+22])
-                    Pexp_ident "+" (test_locations.ml[19,572+21]..[19,572+22])
+                  expression (test_locations.ml[19+21]..[19+22])
+                    Pexp_ident "+" (test_locations.ml[19+21]..[19+22])
                   [
                     <arg>
                     Nolabel
-                      expression (test_locations.ml[19,572+9]..[19,572+20])
+                      expression (test_locations.ml[19+9]..[19+20])
                         Pexp_apply
-                        expression (test_locations.ml[19,572+9]..[19,572+12])
-                          Pexp_ident "fib" (test_locations.ml[19,572+9]..[19,572+12])
+                        expression (test_locations.ml[19+9]..[19+12])
+                          Pexp_ident "fib" (test_locations.ml[19+9]..[19+12])
                         [
                           <arg>
                           Nolabel
-                            expression (test_locations.ml[19,572+13]..[19,572+20])
+                            expression (test_locations.ml[19+13]..[19+20])
                               Pexp_apply
-                              expression (test_locations.ml[19,572+16]..[19,572+17])
-                                Pexp_ident "-" (test_locations.ml[19,572+16]..[19,572+17])
+                              expression (test_locations.ml[19+16]..[19+17])
+                                Pexp_ident "-" (test_locations.ml[19+16]..[19+17])
                               [
                                 <arg>
                                 Nolabel
-                                  expression (test_locations.ml[19,572+14]..[19,572+15])
-                                    Pexp_ident "n" (test_locations.ml[19,572+14]..[19,572+15])
+                                  expression (test_locations.ml[19+14]..[19+15])
+                                    Pexp_ident "n" (test_locations.ml[19+14]..[19+15])
                                 <arg>
                                 Nolabel
-                                  expression (test_locations.ml[19,572+18]..[19,572+19])
+                                  expression (test_locations.ml[19+18]..[19+19])
                                     Pexp_constant
-                                    constant (test_locations.ml[19,572+18]..[19,572+19])
+                                    constant (test_locations.ml[19+18]..[19+19])
                                       PConst_int (1,None)
                               ]
                         ]
                     <arg>
                     Nolabel
-                      expression (test_locations.ml[19,572+23]..[19,572+34])
+                      expression (test_locations.ml[19+23]..[19+34])
                         Pexp_apply
-                        expression (test_locations.ml[19,572+23]..[19,572+26])
-                          Pexp_ident "fib" (test_locations.ml[19,572+23]..[19,572+26])
+                        expression (test_locations.ml[19+23]..[19+26])
+                          Pexp_ident "fib" (test_locations.ml[19+23]..[19+26])
                         [
                           <arg>
                           Nolabel
-                            expression (test_locations.ml[19,572+27]..[19,572+34])
+                            expression (test_locations.ml[19+27]..[19+34])
                               Pexp_apply
-                              expression (test_locations.ml[19,572+30]..[19,572+31])
-                                Pexp_ident "-" (test_locations.ml[19,572+30]..[19,572+31])
+                              expression (test_locations.ml[19+30]..[19+31])
+                                Pexp_ident "-" (test_locations.ml[19+30]..[19+31])
                               [
                                 <arg>
                                 Nolabel
-                                  expression (test_locations.ml[19,572+28]..[19,572+29])
-                                    Pexp_ident "n" (test_locations.ml[19,572+28]..[19,572+29])
+                                  expression (test_locations.ml[19+28]..[19+29])
+                                    Pexp_ident "n" (test_locations.ml[19+28]..[19+29])
                                 <arg>
                                 Nolabel
-                                  expression (test_locations.ml[19,572+32]..[19,572+33])
+                                  expression (test_locations.ml[19+32]..[19+33])
                                     Pexp_constant
-                                    constant (test_locations.ml[19,572+32]..[19,572+33])
+                                    constant (test_locations.ml[19+32]..[19+33])
                                       PConst_int (2,None)
                               ]
                         ]
@@ -93,79 +93,79 @@
 
 let rec fib = function | 0 | 1 -> 1 | n -> (fib (n - 1)) + (fib (n - 2))
 [
-  structure_item (test_locations.ml[17,534+0]..[19,572+34])
+  structure_item (test_locations.ml[17+0]..[19+34])
     Tstr_value Rec
     [
       <def_rec>
-        pattern (test_locations.ml[17,534+8]..[17,534+11])
+        pattern (test_locations.ml[17+8]..[17+11])
           Tpat_var "fib"
-        expression (test_locations.ml[17,534+14]..[19,572+34])
+        expression (test_locations.ml[17+14]..[19+34])
           Texp_function
           []
-          Tfunction_cases (test_locations.ml[17,534+14]..[19,572+34])
+          Tfunction_cases (test_locations.ml[17+14]..[19+34])
             [
               <case>
-                pattern (test_locations.ml[18,557+4]..[18,557+9])
+                pattern (test_locations.ml[18+4]..[18+9])
                   Tpat_or
-                  pattern (test_locations.ml[18,557+4]..[18,557+5])
+                  pattern (test_locations.ml[18+4]..[18+5])
                     Tpat_constant Const_int 0
-                  pattern (test_locations.ml[18,557+8]..[18,557+9])
+                  pattern (test_locations.ml[18+8]..[18+9])
                     Tpat_constant Const_int 1
-                expression (test_locations.ml[18,557+13]..[18,557+14])
+                expression (test_locations.ml[18+13]..[18+14])
                   Texp_constant Const_int 1
               <case>
-                pattern (test_locations.ml[19,572+4]..[19,572+5])
+                pattern (test_locations.ml[19+4]..[19+5])
                   Tpat_var "n"
-                expression (test_locations.ml[19,572+9]..[19,572+34])
+                expression (test_locations.ml[19+9]..[19+34])
                   Texp_apply
-                  expression (test_locations.ml[19,572+21]..[19,572+22])
+                  expression (test_locations.ml[19+21]..[19+22])
                     Texp_ident "Stdlib!.+"
                   [
                     <arg>
                       Nolabel
-                      expression (test_locations.ml[19,572+9]..[19,572+20])
+                      expression (test_locations.ml[19+9]..[19+20])
                         Texp_apply
-                        expression (test_locations.ml[19,572+9]..[19,572+12])
+                        expression (test_locations.ml[19+9]..[19+12])
                           Texp_ident "fib"
                         [
                           <arg>
                             Nolabel
-                            expression (test_locations.ml[19,572+13]..[19,572+20])
+                            expression (test_locations.ml[19+13]..[19+20])
                               Texp_apply
-                              expression (test_locations.ml[19,572+16]..[19,572+17])
+                              expression (test_locations.ml[19+16]..[19+17])
                                 Texp_ident "Stdlib!.-"
                               [
                                 <arg>
                                   Nolabel
-                                  expression (test_locations.ml[19,572+14]..[19,572+15])
+                                  expression (test_locations.ml[19+14]..[19+15])
                                     Texp_ident "n"
                                 <arg>
                                   Nolabel
-                                  expression (test_locations.ml[19,572+18]..[19,572+19])
+                                  expression (test_locations.ml[19+18]..[19+19])
                                     Texp_constant Const_int 1
                               ]
                         ]
                     <arg>
                       Nolabel
-                      expression (test_locations.ml[19,572+23]..[19,572+34])
+                      expression (test_locations.ml[19+23]..[19+34])
                         Texp_apply
-                        expression (test_locations.ml[19,572+23]..[19,572+26])
+                        expression (test_locations.ml[19+23]..[19+26])
                           Texp_ident "fib"
                         [
                           <arg>
                             Nolabel
-                            expression (test_locations.ml[19,572+27]..[19,572+34])
+                            expression (test_locations.ml[19+27]..[19+34])
                               Texp_apply
-                              expression (test_locations.ml[19,572+30]..[19,572+31])
+                              expression (test_locations.ml[19+30]..[19+31])
                                 Texp_ident "Stdlib!.-"
                               [
                                 <arg>
                                   Nolabel
-                                  expression (test_locations.ml[19,572+28]..[19,572+29])
+                                  expression (test_locations.ml[19+28]..[19+29])
                                     Texp_ident "n"
                                 <arg>
                                   Nolabel
-                                  expression (test_locations.ml[19,572+32]..[19,572+33])
+                                  expression (test_locations.ml[19+32]..[19+33])
                                     Texp_constant Const_int 2
                               ]
                         ]

--- a/testsuite/tests/formatting/test_locations.dlocations.ocamlc.reference
+++ b/testsuite/tests/formatting/test_locations.dlocations.ocamlc.reference
@@ -178,13 +178,13 @@ let rec fib = function | 0 | 1 -> 1 | n -> (fib (n - 1)) + (fib (n - 2))
   (letrec
     (fib
        (function n[int] : int
-         (funct-body Test_locations.fib test_locations.ml(17):548-606
+         (funct-body Test_locations.fib test_locations.ml(17):14-(19):34
            (if (isout 1 n)
-             (before Test_locations.fib test_locations.ml(19):581-606
+             (before Test_locations.fib test_locations.ml(19):9-34
                (+
-                 (after Test_locations.fib test_locations.ml(19):581-592
+                 (after Test_locations.fib test_locations.ml(19):9-20
                    (apply fib (- n 1)))
-                 (after Test_locations.fib test_locations.ml(19):595-606
+                 (after Test_locations.fib test_locations.ml(19):23-34
                    (apply fib (- n 2)))))
-             (before Test_locations.fib test_locations.ml(18):570-571 1)))))
+             (before Test_locations.fib test_locations.ml(18):13-14 1)))))
     (pseudo <unknown location> (makeblock 0 fib))))

--- a/testsuite/tests/parsetree/locations_test.compilers.reference
+++ b/testsuite/tests/parsetree/locations_test.compilers.reference
@@ -1,14 +1,14 @@
 Ptop_def
   [
-    structure_item (//toplevel//[10,215+0]..[10,215+39])
-      Pstr_modtype "S" (//toplevel//[10,215+12]..[10,215+13])
-        module_type (//toplevel//[10,215+16]..[10,215+23])
+    structure_item (//toplevel//[10+0]..[10+39])
+      Pstr_modtype "S" (//toplevel//[10+12]..[10+13])
+        module_type (//toplevel//[10+16]..[10+23])
           attribute "attr"
             [
-              structure_item (//toplevel//[10,215+31]..[10,215+38])
+              structure_item (//toplevel//[10+31]..[10+38])
                 Pstr_eval
-                expression (//toplevel//[10,215+31]..[10,215+38])
-                  Pexp_ident "payload" (//toplevel//[10,215+31]..[10,215+38])
+                expression (//toplevel//[10+31]..[10+38])
+                  Pexp_ident "payload" (//toplevel//[10+31]..[10+38])
             ]
           Pmty_signature
           []
@@ -17,16 +17,16 @@ Ptop_def
 module type S = sig end
 Ptop_def
   [
-    structure_item (//toplevel//[3,2+0]..[3,2+37])
+    structure_item (//toplevel//[3+0]..[3+37])
       Pstr_module
-      "M" (//toplevel//[3,2+7]..[3,2+8])
-        module_expr (//toplevel//[3,2+11]..[3,2+21])
+      "M" (//toplevel//[3+7]..[3+8])
+        module_expr (//toplevel//[3+11]..[3+21])
           attribute "attr"
             [
-              structure_item (//toplevel//[3,2+29]..[3,2+36])
+              structure_item (//toplevel//[3+29]..[3+36])
                 Pstr_eval
-                expression (//toplevel//[3,2+29]..[3,2+36])
-                  Pexp_ident "payload" (//toplevel//[3,2+29]..[3,2+36])
+                expression (//toplevel//[3+29]..[3+36])
+                  Pexp_ident "payload" (//toplevel//[3+29]..[3+36])
             ]
           Pmod_structure
           []
@@ -35,10 +35,10 @@ Ptop_def
 module M : sig end
 Ptop_def
   [
-    structure_item (//toplevel//[2,1+0]..[2,1+28])
+    structure_item (//toplevel//[2+0]..[2+28])
       Pstr_type Rec
       [
-        type_declaration "t" (//toplevel//[2,1+5]..[2,1+6]) (//toplevel//[2,1+0]..[2,1+28])
+        type_declaration "t" (//toplevel//[2+5]..[2+6]) (//toplevel//[2+0]..[2+28])
           ptype_params =
             []
           ptype_constraints =
@@ -48,15 +48,15 @@ Ptop_def
           ptype_private = Public
           ptype_manifest =
             Some
-              core_type (//toplevel//[2,1+9]..[2,1+12])
+              core_type (//toplevel//[2+9]..[2+12])
                 attribute "attr"
                   [
-                    structure_item (//toplevel//[2,1+20]..[2,1+27])
+                    structure_item (//toplevel//[2+20]..[2+27])
                       Pstr_eval
-                      expression (//toplevel//[2,1+20]..[2,1+27])
-                        Pexp_ident "payload" (//toplevel//[2,1+20]..[2,1+27])
+                      expression (//toplevel//[2+20]..[2+27])
+                        Pexp_ident "payload" (//toplevel//[2+20]..[2+27])
                   ]
-                Ptyp_constr "int" (//toplevel//[2,1+9]..[2,1+12])
+                Ptyp_constr "int" (//toplevel//[2+9]..[2+12])
                 []
       ]
   ]
@@ -64,36 +64,36 @@ Ptop_def
 type t = int
 Ptop_def
   [
-    structure_item (//toplevel//[2,1+0]..[2,1+1])
+    structure_item (//toplevel//[2+0]..[2+1])
       Pstr_eval
-      expression (//toplevel//[2,1+0]..[2,1+1])
+      expression (//toplevel//[2+0]..[2+1])
         attribute "attr"
           [
-            structure_item (//toplevel//[2,1+9]..[2,1+16])
+            structure_item (//toplevel//[2+9]..[2+16])
               Pstr_eval
-              expression (//toplevel//[2,1+9]..[2,1+16])
-                Pexp_ident "payload" (//toplevel//[2,1+9]..[2,1+16])
+              expression (//toplevel//[2+9]..[2+16])
+                Pexp_ident "payload" (//toplevel//[2+9]..[2+16])
           ]
         Pexp_constant
-        constant (//toplevel//[2,1+0]..[2,1+1])
+        constant (//toplevel//[2+0]..[2+1])
           PConst_int (3,None)
   ]
 
 - : int = 3
 Ptop_def
   [
-    structure_item (//toplevel//[2,1+0]..[2,1+30])
+    structure_item (//toplevel//[2+0]..[2+30])
       Pstr_exception
       type_exception
         attribute "attr"
           [
-            structure_item (//toplevel//[2,1+22]..[2,1+29])
+            structure_item (//toplevel//[2+22]..[2+29])
               Pstr_eval
-              expression (//toplevel//[2,1+22]..[2,1+29])
-                Pexp_ident "payload" (//toplevel//[2,1+22]..[2,1+29])
+              expression (//toplevel//[2+22]..[2+29])
+                Pexp_ident "payload" (//toplevel//[2+22]..[2+29])
           ]
         ptyext_constructor =
-          extension_constructor (//toplevel//[2,1+0]..[2,1+13])
+          extension_constructor (//toplevel//[2+0]..[2+13])
             pext_name = "Exn"
             pext_kind =
               Pext_decl
@@ -104,17 +104,17 @@ Ptop_def
 exception Exn
 Ptop_def
   [
-    structure_item (//toplevel//[4,17+0]..[4,17+50])
-      Pstr_modtype "F" (//toplevel//[4,17+12]..[4,17+13])
-        module_type (//toplevel//[4,17+24]..[4,17+50])
-          Pmty_functor "A" (//toplevel//[4,17+25]..[4,17+26])
-          module_type (//toplevel//[4,17+29]..[4,17+30])
-            Pmty_ident "S" (//toplevel//[4,17+29]..[4,17+30])
-          module_type (//toplevel//[4,17+32]..[4,17+50])
-            Pmty_functor "B" (//toplevel//[4,17+33]..[4,17+34])
-            module_type (//toplevel//[4,17+37]..[4,17+38])
-              Pmty_ident "S" (//toplevel//[4,17+37]..[4,17+38])
-            module_type (//toplevel//[4,17+43]..[4,17+50])
+    structure_item (//toplevel//[4+0]..[4+50])
+      Pstr_modtype "F" (//toplevel//[4+12]..[4+13])
+        module_type (//toplevel//[4+24]..[4+50])
+          Pmty_functor "A" (//toplevel//[4+25]..[4+26])
+          module_type (//toplevel//[4+29]..[4+30])
+            Pmty_ident "S" (//toplevel//[4+29]..[4+30])
+          module_type (//toplevel//[4+32]..[4+50])
+            Pmty_functor "B" (//toplevel//[4+33]..[4+34])
+            module_type (//toplevel//[4+37]..[4+38])
+              Pmty_ident "S" (//toplevel//[4+37]..[4+38])
+            module_type (//toplevel//[4+43]..[4+50])
               Pmty_signature
               []
   ]
@@ -122,18 +122,18 @@ Ptop_def
 module type F = (A : S) (B : S) -> sig end
 Ptop_def
   [
-    structure_item (//toplevel//[2,1+0]..[2,1+48])
+    structure_item (//toplevel//[2+0]..[2+48])
       Pstr_module
-      "F" (//toplevel//[2,1+7]..[2,1+8])
-        module_expr (//toplevel//[2,1+19]..[2,1+48])
-          Pmod_functor "A" (//toplevel//[2,1+20]..[2,1+21])
-          module_type (//toplevel//[2,1+24]..[2,1+25])
-            Pmty_ident "S" (//toplevel//[2,1+24]..[2,1+25])
-          module_expr (//toplevel//[2,1+27]..[2,1+48])
-            Pmod_functor "B" (//toplevel//[2,1+28]..[2,1+29])
-            module_type (//toplevel//[2,1+32]..[2,1+33])
-              Pmty_ident "S" (//toplevel//[2,1+32]..[2,1+33])
-            module_expr (//toplevel//[2,1+38]..[2,1+48])
+      "F" (//toplevel//[2+7]..[2+8])
+        module_expr (//toplevel//[2+19]..[2+48])
+          Pmod_functor "A" (//toplevel//[2+20]..[2+21])
+          module_type (//toplevel//[2+24]..[2+25])
+            Pmty_ident "S" (//toplevel//[2+24]..[2+25])
+          module_expr (//toplevel//[2+27]..[2+48])
+            Pmod_functor "B" (//toplevel//[2+28]..[2+29])
+            module_type (//toplevel//[2+32]..[2+33])
+              Pmty_ident "S" (//toplevel//[2+32]..[2+33])
+            module_expr (//toplevel//[2+38]..[2+48])
               Pmod_structure
               []
   ]
@@ -141,15 +141,15 @@ Ptop_def
 module F : (A : S) (B : S) -> sig end
 Ptop_def
   [
-    structure_item (//toplevel//[4,18+0]..[4,18+31])
-      Pstr_modtype "S1" (//toplevel//[4,18+12]..[4,18+14])
-        module_type (//toplevel//[4,18+17]..[4,18+31])
+    structure_item (//toplevel//[4+0]..[4+31])
+      Pstr_modtype "S1" (//toplevel//[4+12]..[4+14])
+        module_type (//toplevel//[4+17]..[4+31])
           Pmty_signature
           [
-            signature_item (//toplevel//[4,18+21]..[4,18+27])
+            signature_item (//toplevel//[4+21]..[4+27])
               Psig_type Rec
               [
-                type_declaration "t" (//toplevel//[4,18+26]..[4,18+27]) (//toplevel//[4,18+21]..[4,18+27])
+                type_declaration "t" (//toplevel//[4+26]..[4+27]) (//toplevel//[4+21]..[4+27])
                   ptype_params =
                     []
                   ptype_constraints =
@@ -166,15 +166,15 @@ Ptop_def
 module type S1 = sig type t end
 Ptop_def
   [
-    structure_item (//toplevel//[2,1+0]..[2,1+37])
-      Pstr_modtype "T1" (//toplevel//[2,1+12]..[2,1+14])
-        module_type (//toplevel//[2,1+17]..[2,1+37])
+    structure_item (//toplevel//[2+0]..[2+37])
+      Pstr_modtype "T1" (//toplevel//[2+12]..[2+14])
+        module_type (//toplevel//[2+17]..[2+37])
           Pmty_with
-          module_type (//toplevel//[2,1+17]..[2,1+19])
-            Pmty_ident "S1" (//toplevel//[2,1+17]..[2,1+19])
+          module_type (//toplevel//[2+17]..[2+19])
+            Pmty_ident "S1" (//toplevel//[2+17]..[2+19])
           [
-            Pwith_type "t" (//toplevel//[2,1+30]..[2,1+31])
-              type_declaration "t" (//toplevel//[2,1+30]..[2,1+31]) (//toplevel//[2,1+25]..[2,1+37])
+            Pwith_type "t" (//toplevel//[2+30]..[2+31])
+              type_declaration "t" (//toplevel//[2+30]..[2+31]) (//toplevel//[2+25]..[2+37])
                 ptype_params =
                   []
                 ptype_constraints =
@@ -184,8 +184,8 @@ Ptop_def
                 ptype_private = Public
                 ptype_manifest =
                   Some
-                    core_type (//toplevel//[2,1+34]..[2,1+37])
-                      Ptyp_constr "int" (//toplevel//[2,1+34]..[2,1+37])
+                    core_type (//toplevel//[2+34]..[2+37])
+                      Ptyp_constr "int" (//toplevel//[2+34]..[2+37])
                       []
           ]
   ]
@@ -193,15 +193,15 @@ Ptop_def
 module type T1 = sig type t = int end
 Ptop_def
   [
-    structure_item (//toplevel//[2,1+0]..[2,1+38])
-      Pstr_modtype "T1" (//toplevel//[2,1+12]..[2,1+14])
-        module_type (//toplevel//[2,1+17]..[2,1+38])
+    structure_item (//toplevel//[2+0]..[2+38])
+      Pstr_modtype "T1" (//toplevel//[2+12]..[2+14])
+        module_type (//toplevel//[2+17]..[2+38])
           Pmty_with
-          module_type (//toplevel//[2,1+17]..[2,1+19])
-            Pmty_ident "S1" (//toplevel//[2,1+17]..[2,1+19])
+          module_type (//toplevel//[2+17]..[2+19])
+            Pmty_ident "S1" (//toplevel//[2+17]..[2+19])
           [
-            Pwith_typesubst "t" (//toplevel//[2,1+30]..[2,1+31])
-              type_declaration "t" (//toplevel//[2,1+30]..[2,1+31]) (//toplevel//[2,1+25]..[2,1+38])
+            Pwith_typesubst "t" (//toplevel//[2+30]..[2+31])
+              type_declaration "t" (//toplevel//[2+30]..[2+31]) (//toplevel//[2+25]..[2+38])
                 ptype_params =
                   []
                 ptype_constraints =
@@ -211,8 +211,8 @@ Ptop_def
                 ptype_private = Public
                 ptype_manifest =
                   Some
-                    core_type (//toplevel//[2,1+35]..[2,1+38])
-                      Ptyp_constr "int" (//toplevel//[2,1+35]..[2,1+38])
+                    core_type (//toplevel//[2+35]..[2+38])
+                      Ptyp_constr "int" (//toplevel//[2+35]..[2+38])
                       []
           ]
   ]
@@ -220,18 +220,18 @@ Ptop_def
 module type T1 = sig end
 Ptop_def
   [
-    structure_item (//toplevel//[4,29+0]..[4,29+15])
+    structure_item (//toplevel//[4+0]..[4+15])
       Pstr_value Nonrec
       [
         <def>
-          pattern (//toplevel//[4,29+4]..[4,29+5])
-            Ppat_var "x" (//toplevel//[4,29+4]..[4,29+5])
-          core_type (//toplevel//[4,29+8]..[4,29+11])
-            Ptyp_constr "int" (//toplevel//[4,29+8]..[4,29+11])
+          pattern (//toplevel//[4+4]..[4+5])
+            Ppat_var "x" (//toplevel//[4+4]..[4+5])
+          core_type (//toplevel//[4+8]..[4+11])
+            Ptyp_constr "int" (//toplevel//[4+8]..[4+11])
             []
-          expression (//toplevel//[4,29+14]..[4,29+15])
+          expression (//toplevel//[4+14]..[4+15])
             Pexp_constant
-            constant (//toplevel//[4,29+14]..[4,29+15])
+            constant (//toplevel//[4+14]..[4+15])
               PConst_int (3,None)
       ]
   ]
@@ -239,94 +239,94 @@ Ptop_def
 val x : int = 3
 Ptop_def
   [
-    structure_item (//toplevel//[2,1+0]..[2,1+35])
+    structure_item (//toplevel//[2+0]..[2+35])
       Pstr_value Nonrec
       [
         <def>
-          pattern (//toplevel//[2,1+4]..[2,1+5])
-            Ppat_var "x" (//toplevel//[2,1+4]..[2,1+5])
-          <type> "a" (//toplevel//[2,1+13]..[2,1+14]).
-          core_type (//toplevel//[2,1+16]..[2,1+22])
+          pattern (//toplevel//[2+4]..[2+5])
+            Ppat_var "x" (//toplevel//[2+4]..[2+5])
+          <type> "a" (//toplevel//[2+13]..[2+14]).
+          core_type (//toplevel//[2+16]..[2+22])
             Ptyp_arrow
             Nolabel
-            core_type (//toplevel//[2,1+16]..[2,1+17])
-              Ptyp_constr "a" (//toplevel//[2,1+16]..[2,1+17])
+            core_type (//toplevel//[2+16]..[2+17])
+              Ptyp_constr "a" (//toplevel//[2+16]..[2+17])
               []
-            core_type (//toplevel//[2,1+21]..[2,1+22])
-              Ptyp_constr "a" (//toplevel//[2,1+21]..[2,1+22])
+            core_type (//toplevel//[2+21]..[2+22])
+              Ptyp_constr "a" (//toplevel//[2+21]..[2+22])
               []
-          expression (//toplevel//[2,1+25]..[2,1+35])
+          expression (//toplevel//[2+25]..[2+35])
             Pexp_function
             [
-              Pparam_val (//toplevel//[2,1+29]..[2,1+30])
+              Pparam_val (//toplevel//[2+29]..[2+30])
                 Nolabel
                 None
-                pattern (//toplevel//[2,1+29]..[2,1+30])
-                  Ppat_var "x" (//toplevel//[2,1+29]..[2,1+30])
+                pattern (//toplevel//[2+29]..[2+30])
+                  Ppat_var "x" (//toplevel//[2+29]..[2+30])
             ]
             None
             Pfunction_body
-              expression (//toplevel//[2,1+34]..[2,1+35])
-                Pexp_ident "x" (//toplevel//[2,1+34]..[2,1+35])
+              expression (//toplevel//[2+34]..[2+35])
+                Pexp_ident "x" (//toplevel//[2+34]..[2+35])
       ]
   ]
 
 val x : 'a -> 'a = <fun>
 Ptop_def
   [
-    structure_item (//toplevel//[2,1+0]..[5,61+3])
+    structure_item (//toplevel//[2+0]..[5+3])
       Pstr_value Nonrec
       [
         <def>
-          pattern (//toplevel//[2,1+4]..[2,1+5])
+          pattern (//toplevel//[2+4]..[2+5])
             Ppat_any
-          expression (//toplevel//[2,1+8]..[5,61+3])
+          expression (//toplevel//[2+8]..[5+3])
             Pexp_object
             class_structure
-              pattern (//toplevel//[2,1+14]..[2,1+14]) ghost
+              pattern (//toplevel//[2+14]..[2+14]) ghost
                 Ppat_any
               [
-                class_field (//toplevel//[3,16+2]..[4,46+14])
+                class_field (//toplevel//[3+2]..[4+14])
                   Pcf_method Public
-                    "x" (//toplevel//[3,16+9]..[3,16+10])
+                    "x" (//toplevel//[3+9]..[3+10])
                     Concrete Fresh
-                    expression (//toplevel//[3,16+18]..[4,46+14]) ghost
+                    expression (//toplevel//[3+18]..[4+14]) ghost
                       Pexp_poly
-                      expression (//toplevel//[3,16+9]..[4,46+14])
+                      expression (//toplevel//[3+9]..[4+14])
                         Pexp_newtype "a"
-                        expression (//toplevel//[3,16+9]..[4,46+14])
+                        expression (//toplevel//[3+9]..[4+14])
                           Pexp_constraint
-                          expression (//toplevel//[4,46+4]..[4,46+14])
+                          expression (//toplevel//[4+4]..[4+14])
                             Pexp_function
                             [
-                              Pparam_val (//toplevel//[4,46+8]..[4,46+9])
+                              Pparam_val (//toplevel//[4+8]..[4+9])
                                 Nolabel
                                 None
-                                pattern (//toplevel//[4,46+8]..[4,46+9])
-                                  Ppat_var "x" (//toplevel//[4,46+8]..[4,46+9])
+                                pattern (//toplevel//[4+8]..[4+9])
+                                  Ppat_var "x" (//toplevel//[4+8]..[4+9])
                             ]
                             None
                             Pfunction_body
-                              expression (//toplevel//[4,46+13]..[4,46+14])
-                                Pexp_ident "x" (//toplevel//[4,46+13]..[4,46+14])
-                          core_type (//toplevel//[3,16+21]..[3,16+27])
+                              expression (//toplevel//[4+13]..[4+14])
+                                Pexp_ident "x" (//toplevel//[4+13]..[4+14])
+                          core_type (//toplevel//[3+21]..[3+27])
                             Ptyp_arrow
                             Nolabel
-                            core_type (//toplevel//[3,16+21]..[3,16+22])
-                              Ptyp_constr "a" (//toplevel//[3,16+21]..[3,16+22])
+                            core_type (//toplevel//[3+21]..[3+22])
+                              Ptyp_constr "a" (//toplevel//[3+21]..[3+22])
                               []
-                            core_type (//toplevel//[3,16+26]..[3,16+27])
-                              Ptyp_constr "a" (//toplevel//[3,16+26]..[3,16+27])
+                            core_type (//toplevel//[3+26]..[3+27])
+                              Ptyp_constr "a" (//toplevel//[3+26]..[3+27])
                               []
                       Some
-                        core_type (//toplevel//[3,16+9]..[4,46+14]) ghost
+                        core_type (//toplevel//[3+9]..[4+14]) ghost
                           Ptyp_poly 'a
-                          core_type (//toplevel//[3,16+21]..[3,16+27])
+                          core_type (//toplevel//[3+21]..[3+27])
                             Ptyp_arrow
                             Nolabel
-                            core_type (//toplevel//[3,16+21]..[3,16+22])
+                            core_type (//toplevel//[3+21]..[3+22])
                               Ptyp_var a
-                            core_type (//toplevel//[3,16+26]..[3,16+27])
+                            core_type (//toplevel//[3+26]..[3+27])
                               Ptyp_var a
               ]
       ]
@@ -335,29 +335,29 @@ Ptop_def
 - : < x : 'a. 'a -> 'a > = <obj>
 Ptop_def
   [
-    structure_item (//toplevel//[4,17+0]..[4,17+29])
+    structure_item (//toplevel//[4+0]..[4+29])
       Pstr_value Nonrec
       [
         <def>
-          pattern (//toplevel//[4,17+4]..[4,17+5])
-            Ppat_var "x" (//toplevel//[4,17+4]..[4,17+5])
-          expression (//toplevel//[4,17+6]..[4,17+29]) ghost
+          pattern (//toplevel//[4+4]..[4+5])
+            Ppat_var "x" (//toplevel//[4+4]..[4+5])
+          expression (//toplevel//[4+6]..[4+29]) ghost
             Pexp_function
             [
-              Pparam_val (//toplevel//[4,17+6]..[4,17+14])
+              Pparam_val (//toplevel//[4+6]..[4+14])
                 Nolabel
                 None
-                pattern (//toplevel//[4,17+6]..[4,17+14])
-                  Ppat_var "contents" (//toplevel//[4,17+6]..[4,17+14])
+                pattern (//toplevel//[4+6]..[4+14])
+                  Ppat_var "contents" (//toplevel//[4+6]..[4+14])
             ]
             None
             Pfunction_body
-              expression (//toplevel//[4,17+17]..[4,17+29])
+              expression (//toplevel//[4+17]..[4+29])
                 Pexp_record
                 [
-                  "contents" (//toplevel//[4,17+19]..[4,17+27]) ghost
-                    expression (//toplevel//[4,17+19]..[4,17+27])
-                      Pexp_ident "contents" (//toplevel//[4,17+19]..[4,17+27])
+                  "contents" (//toplevel//[4+19]..[4+27]) ghost
+                    expression (//toplevel//[4+19]..[4+27])
+                      Pexp_ident "contents" (//toplevel//[4+19]..[4+27])
                 ]
                 None
       ]
@@ -366,24 +366,24 @@ Ptop_def
 val x : 'a -> 'a ref = <fun>
 Ptop_def
   [
-    structure_item (//toplevel//[2,1+0]..[2,1+30])
+    structure_item (//toplevel//[2+0]..[2+30])
       Pstr_value Nonrec
       [
         <def>
-          pattern (//toplevel//[2,1+4]..[2,1+5])
-            Ppat_var "x" (//toplevel//[2,1+4]..[2,1+5])
-          expression (//toplevel//[2,1+8]..[2,1+30])
+          pattern (//toplevel//[2+4]..[2+5])
+            Ppat_var "x" (//toplevel//[2+4]..[2+5])
+          expression (//toplevel//[2+8]..[2+30])
             Pexp_record
             [
-              "contents" (//toplevel//[2,1+10]..[2,1+18])
-                expression (//toplevel//[2,1+19]..[2,1+28])
+              "contents" (//toplevel//[2+10]..[2+18])
+                expression (//toplevel//[2+19]..[2+28])
                   Pexp_constraint
-                  expression (//toplevel//[2,1+27]..[2,1+28])
+                  expression (//toplevel//[2+27]..[2+28])
                     Pexp_constant
-                    constant (//toplevel//[2,1+27]..[2,1+28])
+                    constant (//toplevel//[2+27]..[2+28])
                       PConst_int (3,None)
-                  core_type (//toplevel//[2,1+21]..[2,1+24])
-                    Ptyp_constr "int" (//toplevel//[2,1+21]..[2,1+24])
+                  core_type (//toplevel//[2+21]..[2+24])
+                    Ptyp_constr "int" (//toplevel//[2+21]..[2+24])
                     []
             ]
             None
@@ -393,33 +393,33 @@ Ptop_def
 val x : int ref = {contents = 3}
 Ptop_def
   [
-    structure_item (//toplevel//[2,1+0]..[2,1+35])
+    structure_item (//toplevel//[2+0]..[2+35])
       Pstr_value Nonrec
       [
         <def>
-          pattern (//toplevel//[2,1+4]..[2,1+5])
-            Ppat_var "x" (//toplevel//[2,1+4]..[2,1+5])
-          expression (//toplevel//[2,1+6]..[2,1+35]) ghost
+          pattern (//toplevel//[2+4]..[2+5])
+            Ppat_var "x" (//toplevel//[2+4]..[2+5])
+          expression (//toplevel//[2+6]..[2+35]) ghost
             Pexp_function
             [
-              Pparam_val (//toplevel//[2,1+6]..[2,1+14])
+              Pparam_val (//toplevel//[2+6]..[2+14])
                 Nolabel
                 None
-                pattern (//toplevel//[2,1+6]..[2,1+14])
-                  Ppat_var "contents" (//toplevel//[2,1+6]..[2,1+14])
+                pattern (//toplevel//[2+6]..[2+14])
+                  Ppat_var "contents" (//toplevel//[2+6]..[2+14])
             ]
             None
             Pfunction_body
-              expression (//toplevel//[2,1+17]..[2,1+35])
+              expression (//toplevel//[2+17]..[2+35])
                 Pexp_record
                 [
-                  "contents" (//toplevel//[2,1+19]..[2,1+27]) ghost
-                    expression (//toplevel//[2,1+19]..[2,1+33])
+                  "contents" (//toplevel//[2+19]..[2+27]) ghost
+                    expression (//toplevel//[2+19]..[2+33])
                       Pexp_constraint
-                      expression (//toplevel//[2,1+19]..[2,1+27])
-                        Pexp_ident "contents" (//toplevel//[2,1+19]..[2,1+27])
-                      core_type (//toplevel//[2,1+30]..[2,1+33])
-                        Ptyp_constr "int" (//toplevel//[2,1+30]..[2,1+33])
+                      expression (//toplevel//[2+19]..[2+27])
+                        Pexp_ident "contents" (//toplevel//[2+19]..[2+27])
+                      core_type (//toplevel//[2+30]..[2+33])
+                        Ptyp_constr "int" (//toplevel//[2+30]..[2+33])
                         []
                 ]
                 None
@@ -429,28 +429,28 @@ Ptop_def
 val x : int -> int ref = <fun>
 Ptop_def
   [
-    structure_item (//toplevel//[2,1+0]..[2,1+41])
+    structure_item (//toplevel//[2+0]..[2+41])
       Pstr_value Nonrec
       [
         <def>
-          pattern (//toplevel//[2,1+4]..[2,1+5])
-            Ppat_var "x" (//toplevel//[2,1+4]..[2,1+5])
-          expression (//toplevel//[2,1+8]..[2,1+41])
+          pattern (//toplevel//[2+4]..[2+5])
+            Ppat_var "x" (//toplevel//[2+4]..[2+5])
+          expression (//toplevel//[2+8]..[2+41])
             Pexp_function
             []
             None
-            Pfunction_cases (//toplevel//[2,1+8]..[2,1+41])
+            Pfunction_cases (//toplevel//[2+8]..[2+41])
               [
                 <case>
-                  pattern (//toplevel//[2,1+17]..[2,1+29])
+                  pattern (//toplevel//[2+17]..[2+29])
                     Ppat_record Closed
                     [
-                      "contents" (//toplevel//[2,1+19]..[2,1+27]) ghost
-                        pattern (//toplevel//[2,1+19]..[2,1+27])
-                          Ppat_var "contents" (//toplevel//[2,1+19]..[2,1+27])
+                      "contents" (//toplevel//[2+19]..[2+27]) ghost
+                        pattern (//toplevel//[2+19]..[2+27])
+                          Ppat_var "contents" (//toplevel//[2+19]..[2+27])
                     ]
-                  expression (//toplevel//[2,1+33]..[2,1+41])
-                    Pexp_ident "contents" (//toplevel//[2,1+33]..[2,1+41])
+                  expression (//toplevel//[2+33]..[2+41])
+                    Pexp_ident "contents" (//toplevel//[2+33]..[2+41])
               ]
       ]
   ]
@@ -458,33 +458,33 @@ Ptop_def
 val x : 'a ref -> 'a = <fun>
 Ptop_def
   [
-    structure_item (//toplevel//[2,1+0]..[2,1+47])
+    structure_item (//toplevel//[2+0]..[2+47])
       Pstr_value Nonrec
       [
         <def>
-          pattern (//toplevel//[2,1+4]..[2,1+5])
-            Ppat_var "x" (//toplevel//[2,1+4]..[2,1+5])
-          expression (//toplevel//[2,1+8]..[2,1+47])
+          pattern (//toplevel//[2+4]..[2+5])
+            Ppat_var "x" (//toplevel//[2+4]..[2+5])
+          expression (//toplevel//[2+8]..[2+47])
             Pexp_function
             []
             None
-            Pfunction_cases (//toplevel//[2,1+8]..[2,1+47])
+            Pfunction_cases (//toplevel//[2+8]..[2+47])
               [
                 <case>
-                  pattern (//toplevel//[2,1+17]..[2,1+35])
+                  pattern (//toplevel//[2+17]..[2+35])
                     Ppat_record Closed
                     [
-                      "contents" (//toplevel//[2,1+19]..[2,1+27]) ghost
-                        pattern (//toplevel//[2,1+19]..[2,1+33])
+                      "contents" (//toplevel//[2+19]..[2+27]) ghost
+                        pattern (//toplevel//[2+19]..[2+33])
                           Ppat_constraint
-                          pattern (//toplevel//[2,1+19]..[2,1+27])
-                            Ppat_var "contents" (//toplevel//[2,1+19]..[2,1+27])
-                          core_type (//toplevel//[2,1+30]..[2,1+33])
-                            Ptyp_constr "int" (//toplevel//[2,1+30]..[2,1+33])
+                          pattern (//toplevel//[2+19]..[2+27])
+                            Ppat_var "contents" (//toplevel//[2+19]..[2+27])
+                          core_type (//toplevel//[2+30]..[2+33])
+                            Ptyp_constr "int" (//toplevel//[2+30]..[2+33])
                             []
                     ]
-                  expression (//toplevel//[2,1+39]..[2,1+47])
-                    Pexp_ident "contents" (//toplevel//[2,1+39]..[2,1+47])
+                  expression (//toplevel//[2+39]..[2+47])
+                    Pexp_ident "contents" (//toplevel//[2+39]..[2+47])
               ]
       ]
   ]
@@ -492,33 +492,33 @@ Ptop_def
 val x : int ref -> int = <fun>
 Ptop_def
   [
-    structure_item (//toplevel//[2,1+0]..[2,1+44])
+    structure_item (//toplevel//[2+0]..[2+44])
       Pstr_value Nonrec
       [
         <def>
-          pattern (//toplevel//[2,1+4]..[2,1+5])
-            Ppat_var "x" (//toplevel//[2,1+4]..[2,1+5])
-          expression (//toplevel//[2,1+8]..[2,1+44])
+          pattern (//toplevel//[2+4]..[2+5])
+            Ppat_var "x" (//toplevel//[2+4]..[2+5])
+          expression (//toplevel//[2+8]..[2+44])
             Pexp_function
             []
             None
-            Pfunction_cases (//toplevel//[2,1+8]..[2,1+44])
+            Pfunction_cases (//toplevel//[2+8]..[2+44])
               [
                 <case>
-                  pattern (//toplevel//[2,1+17]..[2,1+39])
+                  pattern (//toplevel//[2+17]..[2+39])
                     Ppat_record Closed
                     [
-                      "contents" (//toplevel//[2,1+19]..[2,1+27])
-                        pattern (//toplevel//[2,1+28]..[2,1+37])
+                      "contents" (//toplevel//[2+19]..[2+27])
+                        pattern (//toplevel//[2+28]..[2+37])
                           Ppat_constraint
-                          pattern (//toplevel//[2,1+36]..[2,1+37])
-                            Ppat_var "i" (//toplevel//[2,1+36]..[2,1+37])
-                          core_type (//toplevel//[2,1+30]..[2,1+33])
-                            Ptyp_constr "int" (//toplevel//[2,1+30]..[2,1+33])
+                          pattern (//toplevel//[2+36]..[2+37])
+                            Ppat_var "i" (//toplevel//[2+36]..[2+37])
+                          core_type (//toplevel//[2+30]..[2+33])
+                            Ptyp_constr "int" (//toplevel//[2+30]..[2+33])
                             []
                     ]
-                  expression (//toplevel//[2,1+43]..[2,1+44])
-                    Pexp_ident "i" (//toplevel//[2,1+43]..[2,1+44])
+                  expression (//toplevel//[2+43]..[2+44])
+                    Pexp_ident "i" (//toplevel//[2+43]..[2+44])
               ]
       ]
   ]
@@ -526,49 +526,49 @@ Ptop_def
 val x : int ref -> int = <fun>
 Ptop_def
   [
-    structure_item (//toplevel//[2,1+0]..[3,9+50])
+    structure_item (//toplevel//[2+0]..[3+50])
       Pstr_value Nonrec
       [
         <def>
-          pattern (//toplevel//[2,1+4]..[2,1+5])
+          pattern (//toplevel//[2+4]..[2+5])
             Ppat_any
-          expression (//toplevel//[3,9+2]..[3,9+50])
+          expression (//toplevel//[3+2]..[3+50])
             Pexp_object
             class_structure
-              pattern (//toplevel//[3,9+8]..[3,9+8]) ghost
+              pattern (//toplevel//[3+8]..[3+8]) ghost
                 Ppat_any
               [
-                class_field (//toplevel//[3,9+9]..[3,9+21])
+                class_field (//toplevel//[3+9]..[3+21])
                   Pcf_val Immutable
-                    "foo" (//toplevel//[3,9+13]..[3,9+16])
+                    "foo" (//toplevel//[3+13]..[3+16])
                     Concrete Fresh
-                    expression (//toplevel//[3,9+19]..[3,9+21])
+                    expression (//toplevel//[3+19]..[3+21])
                       Pexp_constant
-                      constant (//toplevel//[3,9+19]..[3,9+21])
+                      constant (//toplevel//[3+19]..[3+21])
                         PConst_int (12,None)
-                class_field (//toplevel//[3,9+22]..[3,9+46])
+                class_field (//toplevel//[3+22]..[3+46])
                   Pcf_method Public
-                    "x" (//toplevel//[3,9+29]..[3,9+30])
+                    "x" (//toplevel//[3+29]..[3+30])
                     Concrete Fresh
-                    expression (//toplevel//[3,9+31]..[3,9+46]) ghost
+                    expression (//toplevel//[3+31]..[3+46]) ghost
                       Pexp_poly
-                      expression (//toplevel//[3,9+31]..[3,9+46]) ghost
+                      expression (//toplevel//[3+31]..[3+46]) ghost
                         Pexp_function
                         [
-                          Pparam_val (//toplevel//[3,9+31]..[3,9+34])
+                          Pparam_val (//toplevel//[3+31]..[3+34])
                             Nolabel
                             None
-                            pattern (//toplevel//[3,9+31]..[3,9+34])
-                              Ppat_var "foo" (//toplevel//[3,9+31]..[3,9+34])
+                            pattern (//toplevel//[3+31]..[3+34])
+                              Ppat_var "foo" (//toplevel//[3+31]..[3+34])
                         ]
                         None
                         Pfunction_body
-                          expression (//toplevel//[3,9+37]..[3,9+46])
+                          expression (//toplevel//[3+37]..[3+46])
                             Pexp_override
                             [
-                              <override> "foo" (//toplevel//[3,9+40]..[3,9+43]) ghost
-                                expression (//toplevel//[3,9+40]..[3,9+43])
-                                  Pexp_ident "foo" (//toplevel//[3,9+40]..[3,9+43])
+                              <override> "foo" (//toplevel//[3+40]..[3+43]) ghost
+                                expression (//toplevel//[3+40]..[3+43])
+                                  Pexp_ident "foo" (//toplevel//[3+40]..[3+43])
                             ]
                       None
               ]
@@ -578,25 +578,25 @@ Ptop_def
 - : < x : int -> 'a > as 'a = <obj>
 Ptop_def
   [
-    structure_item (//toplevel//[4,19+0]..[4,19+26])
+    structure_item (//toplevel//[4+0]..[4+26])
       Pstr_value Nonrec
       [
         <def>
-          pattern (//toplevel//[4,19+4]..[4,19+5])
-            Ppat_var "x" (//toplevel//[4,19+4]..[4,19+5])
-          expression (//toplevel//[4,19+8]..[4,19+26])
+          pattern (//toplevel//[4+4]..[4+5])
+            Ppat_var "x" (//toplevel//[4+4]..[4+5])
+          expression (//toplevel//[4+8]..[4+26])
             Pexp_struct_item
-            structure_item (_none_[0,0+-1]..[0,0+-1]) ghost
+            structure_item (_none_[0+-1]..[0+-1]) ghost
               Pstr_open Fresh
-              module_expr (//toplevel//[4,19+8]..[4,19+9])
-                Pmod_ident "M" (//toplevel//[4,19+8]..[4,19+9])
-            expression (//toplevel//[4,19+10]..[4,19+26])
+              module_expr (//toplevel//[4+8]..[4+9])
+                Pmod_ident "M" (//toplevel//[4+8]..[4+9])
+            expression (//toplevel//[4+10]..[4+26])
               Pexp_record
               [
-                "contents" (//toplevel//[4,19+12]..[4,19+20])
-                  expression (//toplevel//[4,19+23]..[4,19+24])
+                "contents" (//toplevel//[4+12]..[4+20])
+                  expression (//toplevel//[4+23]..[4+24])
                     Pexp_constant
-                    constant (//toplevel//[4,19+23]..[4,19+24])
+                    constant (//toplevel//[4+23]..[4+24])
                       PConst_int (3,None)
               ]
               None
@@ -606,44 +606,44 @@ Ptop_def
 val x : int ref = {contents = 3}
 Ptop_def
   [
-    structure_item (//toplevel//[2,1+0]..[2,1+18])
+    structure_item (//toplevel//[2+0]..[2+18])
       Pstr_value Nonrec
       [
         <def>
-          pattern (//toplevel//[2,1+4]..[2,1+5])
-            Ppat_var "x" (//toplevel//[2,1+4]..[2,1+5])
-          expression (//toplevel//[2,1+8]..[2,1+18])
+          pattern (//toplevel//[2+4]..[2+5])
+            Ppat_var "x" (//toplevel//[2+4]..[2+5])
+          expression (//toplevel//[2+8]..[2+18])
             Pexp_struct_item
-            structure_item (_none_[0,0+-1]..[0,0+-1]) ghost
+            structure_item (_none_[0+-1]..[0+-1]) ghost
               Pstr_open Fresh
-              module_expr (//toplevel//[2,1+8]..[2,1+9])
-                Pmod_ident "M" (//toplevel//[2,1+8]..[2,1+9])
-            expression (//toplevel//[2,1+10]..[2,1+18])
-              Pexp_construct "::" (//toplevel//[2,1+12]..[2,1+18]) ghost
+              module_expr (//toplevel//[2+8]..[2+9])
+                Pmod_ident "M" (//toplevel//[2+8]..[2+9])
+            expression (//toplevel//[2+10]..[2+18])
+              Pexp_construct "::" (//toplevel//[2+12]..[2+18]) ghost
               Some
-                expression (//toplevel//[2,1+12]..[2,1+18]) ghost
+                expression (//toplevel//[2+12]..[2+18]) ghost
                   Pexp_tuple
                   [
                     None
-                    expression (//toplevel//[2,1+12]..[2,1+13])
+                    expression (//toplevel//[2+12]..[2+13])
                       Pexp_constant
-                      constant (//toplevel//[2,1+12]..[2,1+13])
+                      constant (//toplevel//[2+12]..[2+13])
                         PConst_int (3,None)
                     None
-                    expression (//toplevel//[2,1+15]..[2,1+18]) ghost
-                      Pexp_construct "::" (//toplevel//[2,1+15]..[2,1+18]) ghost
+                    expression (//toplevel//[2+15]..[2+18]) ghost
+                      Pexp_construct "::" (//toplevel//[2+15]..[2+18]) ghost
                       Some
-                        expression (//toplevel//[2,1+15]..[2,1+18]) ghost
+                        expression (//toplevel//[2+15]..[2+18]) ghost
                           Pexp_tuple
                           [
                             None
-                            expression (//toplevel//[2,1+15]..[2,1+16])
+                            expression (//toplevel//[2+15]..[2+16])
                               Pexp_constant
-                              constant (//toplevel//[2,1+15]..[2,1+16])
+                              constant (//toplevel//[2+15]..[2+16])
                                 PConst_int (4,None)
                             None
-                            expression (//toplevel//[2,1+17]..[2,1+18]) ghost
-                              Pexp_construct "[]" (//toplevel//[2,1+17]..[2,1+18]) ghost
+                            expression (//toplevel//[2+17]..[2+18]) ghost
+                              Pexp_construct "[]" (//toplevel//[2+17]..[2+18]) ghost
                               None
                           ]
                   ]
@@ -653,27 +653,27 @@ Ptop_def
 val x : int list = [3; 4]
 Ptop_def
   [
-    structure_item (//toplevel//[2,1+0]..[2,1+18])
+    structure_item (//toplevel//[2+0]..[2+18])
       Pstr_value Nonrec
       [
         <def>
-          pattern (//toplevel//[2,1+4]..[2,1+5])
-            Ppat_var "x" (//toplevel//[2,1+4]..[2,1+5])
-          expression (//toplevel//[2,1+8]..[2,1+18])
+          pattern (//toplevel//[2+4]..[2+5])
+            Ppat_var "x" (//toplevel//[2+4]..[2+5])
+          expression (//toplevel//[2+8]..[2+18])
             Pexp_struct_item
-            structure_item (_none_[0,0+-1]..[0,0+-1]) ghost
+            structure_item (_none_[0+-1]..[0+-1]) ghost
               Pstr_open Fresh
-              module_expr (//toplevel//[2,1+8]..[2,1+9])
-                Pmod_ident "M" (//toplevel//[2,1+8]..[2,1+9])
-            expression (//toplevel//[2,1+12]..[2,1+16])
+              module_expr (//toplevel//[2+8]..[2+9])
+                Pmod_ident "M" (//toplevel//[2+8]..[2+9])
+            expression (//toplevel//[2+12]..[2+16])
               Pexp_sequence
-              expression (//toplevel//[2,1+12]..[2,1+13])
+              expression (//toplevel//[2+12]..[2+13])
                 Pexp_constant
-                constant (//toplevel//[2,1+12]..[2,1+13])
+                constant (//toplevel//[2+12]..[2+13])
                   PConst_int (3,None)
-              expression (//toplevel//[2,1+15]..[2,1+16])
+              expression (//toplevel//[2+15]..[2+16])
                 Pexp_constant
-                constant (//toplevel//[2,1+15]..[2,1+16])
+                constant (//toplevel//[2+15]..[2+16])
                   PConst_int (4,None)
       ]
   ]
@@ -686,277 +686,277 @@ Warning 10 [non-unit-statement]: this expression should have type unit.
 val x : int = 4
 Ptop_def
   [
-    structure_item (//toplevel//[6,56+0]..[6,56+24])
+    structure_item (//toplevel//[6+0]..[6+24])
       Pstr_value Nonrec
       [
         <def>
-          pattern (//toplevel//[6,56+4]..[6,56+12])
-            Ppat_var ".@()" (//toplevel//[6,56+4]..[6,56+12])
-          expression (//toplevel//[6,56+13]..[6,56+24]) ghost
+          pattern (//toplevel//[6+4]..[6+12])
+            Ppat_var ".@()" (//toplevel//[6+4]..[6+12])
+          expression (//toplevel//[6+13]..[6+24]) ghost
             Pexp_function
             [
-              Pparam_val (//toplevel//[6,56+13]..[6,56+14])
+              Pparam_val (//toplevel//[6+13]..[6+14])
                 Nolabel
                 None
-                pattern (//toplevel//[6,56+13]..[6,56+14])
-                  Ppat_var "x" (//toplevel//[6,56+13]..[6,56+14])
-              Pparam_val (//toplevel//[6,56+15]..[6,56+16])
+                pattern (//toplevel//[6+13]..[6+14])
+                  Ppat_var "x" (//toplevel//[6+13]..[6+14])
+              Pparam_val (//toplevel//[6+15]..[6+16])
                 Nolabel
                 None
-                pattern (//toplevel//[6,56+15]..[6,56+16])
-                  Ppat_var "y" (//toplevel//[6,56+15]..[6,56+16])
+                pattern (//toplevel//[6+15]..[6+16])
+                  Ppat_var "y" (//toplevel//[6+15]..[6+16])
             ]
             None
             Pfunction_body
-              expression (//toplevel//[6,56+19]..[6,56+24])
+              expression (//toplevel//[6+19]..[6+24])
                 Pexp_apply
-                expression (//toplevel//[6,56+21]..[6,56+22])
-                  Pexp_ident "+" (//toplevel//[6,56+21]..[6,56+22])
+                expression (//toplevel//[6+21]..[6+22])
+                  Pexp_ident "+" (//toplevel//[6+21]..[6+22])
                 [
                   <arg>
                   Nolabel
-                    expression (//toplevel//[6,56+19]..[6,56+20])
-                      Pexp_ident "x" (//toplevel//[6,56+19]..[6,56+20])
+                    expression (//toplevel//[6+19]..[6+20])
+                      Pexp_ident "x" (//toplevel//[6+19]..[6+20])
                   <arg>
                   Nolabel
-                    expression (//toplevel//[6,56+23]..[6,56+24])
-                      Pexp_ident "y" (//toplevel//[6,56+23]..[6,56+24])
+                    expression (//toplevel//[6+23]..[6+24])
+                      Pexp_ident "y" (//toplevel//[6+23]..[6+24])
                 ]
       ]
-    structure_item (//toplevel//[7,81+0]..[7,81+32])
+    structure_item (//toplevel//[7+0]..[7+32])
       Pstr_value Nonrec
       [
         <def>
-          pattern (//toplevel//[7,81+4]..[7,81+14])
-            Ppat_var ".@()<-" (//toplevel//[7,81+4]..[7,81+14])
-          expression (//toplevel//[7,81+15]..[7,81+32]) ghost
+          pattern (//toplevel//[7+4]..[7+14])
+            Ppat_var ".@()<-" (//toplevel//[7+4]..[7+14])
+          expression (//toplevel//[7+15]..[7+32]) ghost
             Pexp_function
             [
-              Pparam_val (//toplevel//[7,81+15]..[7,81+16])
+              Pparam_val (//toplevel//[7+15]..[7+16])
                 Nolabel
                 None
-                pattern (//toplevel//[7,81+15]..[7,81+16])
-                  Ppat_var "x" (//toplevel//[7,81+15]..[7,81+16])
-              Pparam_val (//toplevel//[7,81+17]..[7,81+18])
+                pattern (//toplevel//[7+15]..[7+16])
+                  Ppat_var "x" (//toplevel//[7+15]..[7+16])
+              Pparam_val (//toplevel//[7+17]..[7+18])
                 Nolabel
                 None
-                pattern (//toplevel//[7,81+17]..[7,81+18])
-                  Ppat_var "y" (//toplevel//[7,81+17]..[7,81+18])
-              Pparam_val (//toplevel//[7,81+19]..[7,81+20])
+                pattern (//toplevel//[7+17]..[7+18])
+                  Ppat_var "y" (//toplevel//[7+17]..[7+18])
+              Pparam_val (//toplevel//[7+19]..[7+20])
                 Nolabel
                 None
-                pattern (//toplevel//[7,81+19]..[7,81+20])
-                  Ppat_var "z" (//toplevel//[7,81+19]..[7,81+20])
+                pattern (//toplevel//[7+19]..[7+20])
+                  Ppat_var "z" (//toplevel//[7+19]..[7+20])
             ]
             None
             Pfunction_body
-              expression (//toplevel//[7,81+23]..[7,81+32])
+              expression (//toplevel//[7+23]..[7+32])
                 Pexp_apply
-                expression (//toplevel//[7,81+29]..[7,81+30])
-                  Pexp_ident "+" (//toplevel//[7,81+29]..[7,81+30])
+                expression (//toplevel//[7+29]..[7+30])
+                  Pexp_ident "+" (//toplevel//[7+29]..[7+30])
                 [
                   <arg>
                   Nolabel
-                    expression (//toplevel//[7,81+23]..[7,81+28])
+                    expression (//toplevel//[7+23]..[7+28])
                       Pexp_apply
-                      expression (//toplevel//[7,81+25]..[7,81+26])
-                        Pexp_ident "+" (//toplevel//[7,81+25]..[7,81+26])
+                      expression (//toplevel//[7+25]..[7+26])
+                        Pexp_ident "+" (//toplevel//[7+25]..[7+26])
                       [
                         <arg>
                         Nolabel
-                          expression (//toplevel//[7,81+23]..[7,81+24])
-                            Pexp_ident "x" (//toplevel//[7,81+23]..[7,81+24])
+                          expression (//toplevel//[7+23]..[7+24])
+                            Pexp_ident "x" (//toplevel//[7+23]..[7+24])
                         <arg>
                         Nolabel
-                          expression (//toplevel//[7,81+27]..[7,81+28])
-                            Pexp_ident "y" (//toplevel//[7,81+27]..[7,81+28])
+                          expression (//toplevel//[7+27]..[7+28])
+                            Pexp_ident "y" (//toplevel//[7+27]..[7+28])
                       ]
                   <arg>
                   Nolabel
-                    expression (//toplevel//[7,81+31]..[7,81+32])
-                      Pexp_ident "z" (//toplevel//[7,81+31]..[7,81+32])
+                    expression (//toplevel//[7+31]..[7+32])
+                      Pexp_ident "z" (//toplevel//[7+31]..[7+32])
                 ]
       ]
-    structure_item (//toplevel//[8,114+0]..[8,114+25])
+    structure_item (//toplevel//[8+0]..[8+25])
       Pstr_value Nonrec
       [
         <def>
-          pattern (//toplevel//[8,114+4]..[8,114+13])
-            Ppat_var ".%.{}" (//toplevel//[8,114+4]..[8,114+13])
-          expression (//toplevel//[8,114+14]..[8,114+25]) ghost
+          pattern (//toplevel//[8+4]..[8+13])
+            Ppat_var ".%.{}" (//toplevel//[8+4]..[8+13])
+          expression (//toplevel//[8+14]..[8+25]) ghost
             Pexp_function
             [
-              Pparam_val (//toplevel//[8,114+14]..[8,114+15])
+              Pparam_val (//toplevel//[8+14]..[8+15])
                 Nolabel
                 None
-                pattern (//toplevel//[8,114+14]..[8,114+15])
-                  Ppat_var "x" (//toplevel//[8,114+14]..[8,114+15])
-              Pparam_val (//toplevel//[8,114+16]..[8,114+17])
+                pattern (//toplevel//[8+14]..[8+15])
+                  Ppat_var "x" (//toplevel//[8+14]..[8+15])
+              Pparam_val (//toplevel//[8+16]..[8+17])
                 Nolabel
                 None
-                pattern (//toplevel//[8,114+16]..[8,114+17])
-                  Ppat_var "y" (//toplevel//[8,114+16]..[8,114+17])
+                pattern (//toplevel//[8+16]..[8+17])
+                  Ppat_var "y" (//toplevel//[8+16]..[8+17])
             ]
             None
             Pfunction_body
-              expression (//toplevel//[8,114+20]..[8,114+25])
+              expression (//toplevel//[8+20]..[8+25])
                 Pexp_apply
-                expression (//toplevel//[8,114+22]..[8,114+23])
-                  Pexp_ident "+" (//toplevel//[8,114+22]..[8,114+23])
+                expression (//toplevel//[8+22]..[8+23])
+                  Pexp_ident "+" (//toplevel//[8+22]..[8+23])
                 [
                   <arg>
                   Nolabel
-                    expression (//toplevel//[8,114+20]..[8,114+21])
-                      Pexp_ident "x" (//toplevel//[8,114+20]..[8,114+21])
+                    expression (//toplevel//[8+20]..[8+21])
+                      Pexp_ident "x" (//toplevel//[8+20]..[8+21])
                   <arg>
                   Nolabel
-                    expression (//toplevel//[8,114+24]..[8,114+25])
-                      Pexp_ident "y" (//toplevel//[8,114+24]..[8,114+25])
+                    expression (//toplevel//[8+24]..[8+25])
+                      Pexp_ident "y" (//toplevel//[8+24]..[8+25])
                 ]
       ]
-    structure_item (//toplevel//[9,140+0]..[9,140+33])
+    structure_item (//toplevel//[9+0]..[9+33])
       Pstr_value Nonrec
       [
         <def>
-          pattern (//toplevel//[9,140+4]..[9,140+15])
-            Ppat_var ".%.{}<-" (//toplevel//[9,140+4]..[9,140+15])
-          expression (//toplevel//[9,140+16]..[9,140+33]) ghost
+          pattern (//toplevel//[9+4]..[9+15])
+            Ppat_var ".%.{}<-" (//toplevel//[9+4]..[9+15])
+          expression (//toplevel//[9+16]..[9+33]) ghost
             Pexp_function
             [
-              Pparam_val (//toplevel//[9,140+16]..[9,140+17])
+              Pparam_val (//toplevel//[9+16]..[9+17])
                 Nolabel
                 None
-                pattern (//toplevel//[9,140+16]..[9,140+17])
-                  Ppat_var "x" (//toplevel//[9,140+16]..[9,140+17])
-              Pparam_val (//toplevel//[9,140+18]..[9,140+19])
+                pattern (//toplevel//[9+16]..[9+17])
+                  Ppat_var "x" (//toplevel//[9+16]..[9+17])
+              Pparam_val (//toplevel//[9+18]..[9+19])
                 Nolabel
                 None
-                pattern (//toplevel//[9,140+18]..[9,140+19])
-                  Ppat_var "y" (//toplevel//[9,140+18]..[9,140+19])
-              Pparam_val (//toplevel//[9,140+20]..[9,140+21])
+                pattern (//toplevel//[9+18]..[9+19])
+                  Ppat_var "y" (//toplevel//[9+18]..[9+19])
+              Pparam_val (//toplevel//[9+20]..[9+21])
                 Nolabel
                 None
-                pattern (//toplevel//[9,140+20]..[9,140+21])
-                  Ppat_var "z" (//toplevel//[9,140+20]..[9,140+21])
+                pattern (//toplevel//[9+20]..[9+21])
+                  Ppat_var "z" (//toplevel//[9+20]..[9+21])
             ]
             None
             Pfunction_body
-              expression (//toplevel//[9,140+24]..[9,140+33])
+              expression (//toplevel//[9+24]..[9+33])
                 Pexp_apply
-                expression (//toplevel//[9,140+30]..[9,140+31])
-                  Pexp_ident "+" (//toplevel//[9,140+30]..[9,140+31])
+                expression (//toplevel//[9+30]..[9+31])
+                  Pexp_ident "+" (//toplevel//[9+30]..[9+31])
                 [
                   <arg>
                   Nolabel
-                    expression (//toplevel//[9,140+24]..[9,140+29])
+                    expression (//toplevel//[9+24]..[9+29])
                       Pexp_apply
-                      expression (//toplevel//[9,140+26]..[9,140+27])
-                        Pexp_ident "+" (//toplevel//[9,140+26]..[9,140+27])
+                      expression (//toplevel//[9+26]..[9+27])
+                        Pexp_ident "+" (//toplevel//[9+26]..[9+27])
                       [
                         <arg>
                         Nolabel
-                          expression (//toplevel//[9,140+24]..[9,140+25])
-                            Pexp_ident "x" (//toplevel//[9,140+24]..[9,140+25])
+                          expression (//toplevel//[9+24]..[9+25])
+                            Pexp_ident "x" (//toplevel//[9+24]..[9+25])
                         <arg>
                         Nolabel
-                          expression (//toplevel//[9,140+28]..[9,140+29])
-                            Pexp_ident "y" (//toplevel//[9,140+28]..[9,140+29])
+                          expression (//toplevel//[9+28]..[9+29])
+                            Pexp_ident "y" (//toplevel//[9+28]..[9+29])
                       ]
                   <arg>
                   Nolabel
-                    expression (//toplevel//[9,140+32]..[9,140+33])
-                      Pexp_ident "z" (//toplevel//[9,140+32]..[9,140+33])
+                    expression (//toplevel//[9+32]..[9+33])
+                      Pexp_ident "z" (//toplevel//[9+32]..[9+33])
                 ]
       ]
-    structure_item (//toplevel//[10,174+0]..[10,174+25])
+    structure_item (//toplevel//[10+0]..[10+25])
       Pstr_value Nonrec
       [
         <def>
-          pattern (//toplevel//[10,174+4]..[10,174+13])
-            Ppat_var ".%.[]" (//toplevel//[10,174+4]..[10,174+13])
-          expression (//toplevel//[10,174+14]..[10,174+25]) ghost
+          pattern (//toplevel//[10+4]..[10+13])
+            Ppat_var ".%.[]" (//toplevel//[10+4]..[10+13])
+          expression (//toplevel//[10+14]..[10+25]) ghost
             Pexp_function
             [
-              Pparam_val (//toplevel//[10,174+14]..[10,174+15])
+              Pparam_val (//toplevel//[10+14]..[10+15])
                 Nolabel
                 None
-                pattern (//toplevel//[10,174+14]..[10,174+15])
-                  Ppat_var "x" (//toplevel//[10,174+14]..[10,174+15])
-              Pparam_val (//toplevel//[10,174+16]..[10,174+17])
+                pattern (//toplevel//[10+14]..[10+15])
+                  Ppat_var "x" (//toplevel//[10+14]..[10+15])
+              Pparam_val (//toplevel//[10+16]..[10+17])
                 Nolabel
                 None
-                pattern (//toplevel//[10,174+16]..[10,174+17])
-                  Ppat_var "y" (//toplevel//[10,174+16]..[10,174+17])
+                pattern (//toplevel//[10+16]..[10+17])
+                  Ppat_var "y" (//toplevel//[10+16]..[10+17])
             ]
             None
             Pfunction_body
-              expression (//toplevel//[10,174+20]..[10,174+25])
+              expression (//toplevel//[10+20]..[10+25])
                 Pexp_apply
-                expression (//toplevel//[10,174+22]..[10,174+23])
-                  Pexp_ident "+" (//toplevel//[10,174+22]..[10,174+23])
+                expression (//toplevel//[10+22]..[10+23])
+                  Pexp_ident "+" (//toplevel//[10+22]..[10+23])
                 [
                   <arg>
                   Nolabel
-                    expression (//toplevel//[10,174+20]..[10,174+21])
-                      Pexp_ident "x" (//toplevel//[10,174+20]..[10,174+21])
+                    expression (//toplevel//[10+20]..[10+21])
+                      Pexp_ident "x" (//toplevel//[10+20]..[10+21])
                   <arg>
                   Nolabel
-                    expression (//toplevel//[10,174+24]..[10,174+25])
-                      Pexp_ident "y" (//toplevel//[10,174+24]..[10,174+25])
+                    expression (//toplevel//[10+24]..[10+25])
+                      Pexp_ident "y" (//toplevel//[10+24]..[10+25])
                 ]
       ]
-    structure_item (//toplevel//[11,200+0]..[11,200+33])
+    structure_item (//toplevel//[11+0]..[11+33])
       Pstr_value Nonrec
       [
         <def>
-          pattern (//toplevel//[11,200+4]..[11,200+15])
-            Ppat_var ".%.[]<-" (//toplevel//[11,200+4]..[11,200+15])
-          expression (//toplevel//[11,200+16]..[11,200+33]) ghost
+          pattern (//toplevel//[11+4]..[11+15])
+            Ppat_var ".%.[]<-" (//toplevel//[11+4]..[11+15])
+          expression (//toplevel//[11+16]..[11+33]) ghost
             Pexp_function
             [
-              Pparam_val (//toplevel//[11,200+16]..[11,200+17])
+              Pparam_val (//toplevel//[11+16]..[11+17])
                 Nolabel
                 None
-                pattern (//toplevel//[11,200+16]..[11,200+17])
-                  Ppat_var "x" (//toplevel//[11,200+16]..[11,200+17])
-              Pparam_val (//toplevel//[11,200+18]..[11,200+19])
+                pattern (//toplevel//[11+16]..[11+17])
+                  Ppat_var "x" (//toplevel//[11+16]..[11+17])
+              Pparam_val (//toplevel//[11+18]..[11+19])
                 Nolabel
                 None
-                pattern (//toplevel//[11,200+18]..[11,200+19])
-                  Ppat_var "y" (//toplevel//[11,200+18]..[11,200+19])
-              Pparam_val (//toplevel//[11,200+20]..[11,200+21])
+                pattern (//toplevel//[11+18]..[11+19])
+                  Ppat_var "y" (//toplevel//[11+18]..[11+19])
+              Pparam_val (//toplevel//[11+20]..[11+21])
                 Nolabel
                 None
-                pattern (//toplevel//[11,200+20]..[11,200+21])
-                  Ppat_var "z" (//toplevel//[11,200+20]..[11,200+21])
+                pattern (//toplevel//[11+20]..[11+21])
+                  Ppat_var "z" (//toplevel//[11+20]..[11+21])
             ]
             None
             Pfunction_body
-              expression (//toplevel//[11,200+24]..[11,200+33])
+              expression (//toplevel//[11+24]..[11+33])
                 Pexp_apply
-                expression (//toplevel//[11,200+30]..[11,200+31])
-                  Pexp_ident "+" (//toplevel//[11,200+30]..[11,200+31])
+                expression (//toplevel//[11+30]..[11+31])
+                  Pexp_ident "+" (//toplevel//[11+30]..[11+31])
                 [
                   <arg>
                   Nolabel
-                    expression (//toplevel//[11,200+24]..[11,200+29])
+                    expression (//toplevel//[11+24]..[11+29])
                       Pexp_apply
-                      expression (//toplevel//[11,200+26]..[11,200+27])
-                        Pexp_ident "+" (//toplevel//[11,200+26]..[11,200+27])
+                      expression (//toplevel//[11+26]..[11+27])
+                        Pexp_ident "+" (//toplevel//[11+26]..[11+27])
                       [
                         <arg>
                         Nolabel
-                          expression (//toplevel//[11,200+24]..[11,200+25])
-                            Pexp_ident "x" (//toplevel//[11,200+24]..[11,200+25])
+                          expression (//toplevel//[11+24]..[11+25])
+                            Pexp_ident "x" (//toplevel//[11+24]..[11+25])
                         <arg>
                         Nolabel
-                          expression (//toplevel//[11,200+28]..[11,200+29])
-                            Pexp_ident "y" (//toplevel//[11,200+28]..[11,200+29])
+                          expression (//toplevel//[11+28]..[11+29])
+                            Pexp_ident "y" (//toplevel//[11+28]..[11+29])
                       ]
                   <arg>
                   Nolabel
-                    expression (//toplevel//[11,200+32]..[11,200+33])
-                      Pexp_ident "z" (//toplevel//[11,200+32]..[11,200+33])
+                    expression (//toplevel//[11+32]..[11+33])
+                      Pexp_ident "z" (//toplevel//[11+32]..[11+33])
                 ]
       ]
   ]
@@ -969,22 +969,22 @@ val ( .%.[] ) : int -> int -> int = <fun>
 val ( .%.[]<- ) : int -> int -> int -> int = <fun>
 Ptop_def
   [
-    structure_item (//toplevel//[4,27+0]..[4,27+6])
+    structure_item (//toplevel//[4+0]..[4+6])
       Pstr_eval
-      expression (//toplevel//[4,27+0]..[4,27+6])
+      expression (//toplevel//[4+0]..[4+6])
         Pexp_apply
-        expression (//toplevel//[4,27+0]..[4,27+6]) ghost
-          Pexp_ident ".@()" (//toplevel//[4,27+0]..[4,27+6]) ghost
+        expression (//toplevel//[4+0]..[4+6]) ghost
+          Pexp_ident ".@()" (//toplevel//[4+0]..[4+6]) ghost
         [
           <arg>
           Nolabel
-            expression (//toplevel//[4,27+0]..[4,27+1])
-              Pexp_ident "x" (//toplevel//[4,27+0]..[4,27+1])
+            expression (//toplevel//[4+0]..[4+1])
+              Pexp_ident "x" (//toplevel//[4+0]..[4+1])
           <arg>
           Nolabel
-            expression (//toplevel//[4,27+4]..[4,27+5])
+            expression (//toplevel//[4+4]..[4+5])
               Pexp_constant
-              constant (//toplevel//[4,27+4]..[4,27+5])
+              constant (//toplevel//[4+4]..[4+5])
                 PConst_int (4,None)
         ]
   ]
@@ -992,28 +992,28 @@ Ptop_def
 - : int = 8
 Ptop_def
   [
-    structure_item (//toplevel//[1,0+0]..[1,0+11])
+    structure_item (//toplevel//[1+0]..[1+11])
       Pstr_eval
-      expression (//toplevel//[1,0+0]..[1,0+11])
+      expression (//toplevel//[1+0]..[1+11])
         Pexp_apply
-        expression (//toplevel//[1,0+0]..[1,0+11]) ghost
-          Pexp_ident ".@()<-" (//toplevel//[1,0+0]..[1,0+11]) ghost
+        expression (//toplevel//[1+0]..[1+11]) ghost
+          Pexp_ident ".@()<-" (//toplevel//[1+0]..[1+11]) ghost
         [
           <arg>
           Nolabel
-            expression (//toplevel//[1,0+0]..[1,0+1])
-              Pexp_ident "x" (//toplevel//[1,0+0]..[1,0+1])
+            expression (//toplevel//[1+0]..[1+1])
+              Pexp_ident "x" (//toplevel//[1+0]..[1+1])
           <arg>
           Nolabel
-            expression (//toplevel//[1,0+4]..[1,0+5])
+            expression (//toplevel//[1+4]..[1+5])
               Pexp_constant
-              constant (//toplevel//[1,0+4]..[1,0+5])
+              constant (//toplevel//[1+4]..[1+5])
                 PConst_int (4,None)
           <arg>
           Nolabel
-            expression (//toplevel//[1,0+10]..[1,0+11])
+            expression (//toplevel//[1+10]..[1+11])
               Pexp_constant
-              constant (//toplevel//[1,0+10]..[1,0+11])
+              constant (//toplevel//[1+10]..[1+11])
                 PConst_int (4,None)
         ]
   ]
@@ -1021,22 +1021,22 @@ Ptop_def
 - : int = 12
 Ptop_def
   [
-    structure_item (//toplevel//[2,1+0]..[2,1+7])
+    structure_item (//toplevel//[2+0]..[2+7])
       Pstr_eval
-      expression (//toplevel//[2,1+0]..[2,1+7])
+      expression (//toplevel//[2+0]..[2+7])
         Pexp_apply
-        expression (//toplevel//[2,1+0]..[2,1+7]) ghost
-          Pexp_ident ".%.{}" (//toplevel//[2,1+0]..[2,1+7]) ghost
+        expression (//toplevel//[2+0]..[2+7]) ghost
+          Pexp_ident ".%.{}" (//toplevel//[2+0]..[2+7]) ghost
         [
           <arg>
           Nolabel
-            expression (//toplevel//[2,1+0]..[2,1+1])
-              Pexp_ident "x" (//toplevel//[2,1+0]..[2,1+1])
+            expression (//toplevel//[2+0]..[2+1])
+              Pexp_ident "x" (//toplevel//[2+0]..[2+1])
           <arg>
           Nolabel
-            expression (//toplevel//[2,1+5]..[2,1+6])
+            expression (//toplevel//[2+5]..[2+6])
               Pexp_constant
-              constant (//toplevel//[2,1+5]..[2,1+6])
+              constant (//toplevel//[2+5]..[2+6])
                 PConst_int (4,None)
         ]
   ]
@@ -1044,28 +1044,28 @@ Ptop_def
 - : int = 8
 Ptop_def
   [
-    structure_item (//toplevel//[1,0+0]..[1,0+12])
+    structure_item (//toplevel//[1+0]..[1+12])
       Pstr_eval
-      expression (//toplevel//[1,0+0]..[1,0+12])
+      expression (//toplevel//[1+0]..[1+12])
         Pexp_apply
-        expression (//toplevel//[1,0+0]..[1,0+12]) ghost
-          Pexp_ident ".%.{}<-" (//toplevel//[1,0+0]..[1,0+12]) ghost
+        expression (//toplevel//[1+0]..[1+12]) ghost
+          Pexp_ident ".%.{}<-" (//toplevel//[1+0]..[1+12]) ghost
         [
           <arg>
           Nolabel
-            expression (//toplevel//[1,0+0]..[1,0+1])
-              Pexp_ident "x" (//toplevel//[1,0+0]..[1,0+1])
+            expression (//toplevel//[1+0]..[1+1])
+              Pexp_ident "x" (//toplevel//[1+0]..[1+1])
           <arg>
           Nolabel
-            expression (//toplevel//[1,0+5]..[1,0+6])
+            expression (//toplevel//[1+5]..[1+6])
               Pexp_constant
-              constant (//toplevel//[1,0+5]..[1,0+6])
+              constant (//toplevel//[1+5]..[1+6])
                 PConst_int (4,None)
           <arg>
           Nolabel
-            expression (//toplevel//[1,0+11]..[1,0+12])
+            expression (//toplevel//[1+11]..[1+12])
               Pexp_constant
-              constant (//toplevel//[1,0+11]..[1,0+12])
+              constant (//toplevel//[1+11]..[1+12])
                 PConst_int (4,None)
         ]
   ]
@@ -1073,22 +1073,22 @@ Ptop_def
 - : int = 12
 Ptop_def
   [
-    structure_item (//toplevel//[2,1+0]..[2,1+7])
+    structure_item (//toplevel//[2+0]..[2+7])
       Pstr_eval
-      expression (//toplevel//[2,1+0]..[2,1+7])
+      expression (//toplevel//[2+0]..[2+7])
         Pexp_apply
-        expression (//toplevel//[2,1+0]..[2,1+7]) ghost
-          Pexp_ident ".%.[]" (//toplevel//[2,1+0]..[2,1+7]) ghost
+        expression (//toplevel//[2+0]..[2+7]) ghost
+          Pexp_ident ".%.[]" (//toplevel//[2+0]..[2+7]) ghost
         [
           <arg>
           Nolabel
-            expression (//toplevel//[2,1+0]..[2,1+1])
-              Pexp_ident "x" (//toplevel//[2,1+0]..[2,1+1])
+            expression (//toplevel//[2+0]..[2+1])
+              Pexp_ident "x" (//toplevel//[2+0]..[2+1])
           <arg>
           Nolabel
-            expression (//toplevel//[2,1+5]..[2,1+6])
+            expression (//toplevel//[2+5]..[2+6])
               Pexp_constant
-              constant (//toplevel//[2,1+5]..[2,1+6])
+              constant (//toplevel//[2+5]..[2+6])
                 PConst_int (4,None)
         ]
   ]
@@ -1096,28 +1096,28 @@ Ptop_def
 - : int = 8
 Ptop_def
   [
-    structure_item (//toplevel//[1,0+0]..[1,0+12])
+    structure_item (//toplevel//[1+0]..[1+12])
       Pstr_eval
-      expression (//toplevel//[1,0+0]..[1,0+12])
+      expression (//toplevel//[1+0]..[1+12])
         Pexp_apply
-        expression (//toplevel//[1,0+0]..[1,0+12]) ghost
-          Pexp_ident ".%.[]<-" (//toplevel//[1,0+0]..[1,0+12]) ghost
+        expression (//toplevel//[1+0]..[1+12]) ghost
+          Pexp_ident ".%.[]<-" (//toplevel//[1+0]..[1+12]) ghost
         [
           <arg>
           Nolabel
-            expression (//toplevel//[1,0+0]..[1,0+1])
-              Pexp_ident "x" (//toplevel//[1,0+0]..[1,0+1])
+            expression (//toplevel//[1+0]..[1+1])
+              Pexp_ident "x" (//toplevel//[1+0]..[1+1])
           <arg>
           Nolabel
-            expression (//toplevel//[1,0+5]..[1,0+6])
+            expression (//toplevel//[1+5]..[1+6])
               Pexp_constant
-              constant (//toplevel//[1,0+5]..[1,0+6])
+              constant (//toplevel//[1+5]..[1+6])
                 PConst_int (4,None)
           <arg>
           Nolabel
-            expression (//toplevel//[1,0+11]..[1,0+12])
+            expression (//toplevel//[1+11]..[1+12])
               Pexp_constant
-              constant (//toplevel//[1,0+11]..[1,0+12])
+              constant (//toplevel//[1+11]..[1+12])
                 PConst_int (4,None)
         ]
   ]
@@ -1125,26 +1125,26 @@ Ptop_def
 - : int = 12
 Ptop_def
   [
-    structure_item (//toplevel//[4,28+0]..[4,28+37])
+    structure_item (//toplevel//[4+0]..[4+37])
       Pstr_value Nonrec
       [
         <def>
-          pattern (//toplevel//[4,28+4]..[4,28+5])
-            Ppat_var "f" (//toplevel//[4,28+4]..[4,28+5])
-          expression (//toplevel//[4,28+8]..[4,28+37])
+          pattern (//toplevel//[4+4]..[4+5])
+            Ppat_var "f" (//toplevel//[4+4]..[4+5])
+          expression (//toplevel//[4+8]..[4+37])
             Pexp_function
             []
             None
-            Pfunction_cases (//toplevel//[4,28+8]..[4,28+37])
+            Pfunction_cases (//toplevel//[4+8]..[4+37])
               [
                 <case>
-                  pattern (//toplevel//[4,28+17]..[4,28+31])
-                    Ppat_unpack "M" (//toplevel//[4,28+25]..[4,28+26])
+                  pattern (//toplevel//[4+17]..[4+31])
+                    Ppat_unpack "M" (//toplevel//[4+25]..[4+26])
                     Some
-                        package_type "S" (//toplevel//[4,28+29]..[4,28+30])
+                        package_type "S" (//toplevel//[4+29]..[4+30])
                         []
-                  expression (//toplevel//[4,28+35]..[4,28+37])
-                    Pexp_construct "()" (//toplevel//[4,28+35]..[4,28+37])
+                  expression (//toplevel//[4+35]..[4+37])
+                    Pexp_construct "()" (//toplevel//[4+35]..[4+37])
                     None
               ]
       ]
@@ -1153,21 +1153,21 @@ Ptop_def
 val f : (module S) -> unit = <fun>
 Ptop_def
   [
-    structure_item (//toplevel//[4,45+0]..[6,71+12])
+    structure_item (//toplevel//[4+0]..[6+12])
       Pstr_class
       [
-        class_declaration (//toplevel//[4,45+0]..[6,71+12])
+        class_declaration (//toplevel//[4+0]..[6+12])
           pci_virt = Concrete
           pci_params =
             []
-          pci_name = "c" (//toplevel//[4,45+6]..[4,45+7])
+          pci_name = "c" (//toplevel//[4+6]..[4+7])
           pci_expr =
-            class_expr (//toplevel//[5,55+2]..[6,71+12])
-              Pcl_open Fresh "M" (//toplevel//[5,55+11]..[5,55+12])
-              class_expr (//toplevel//[6,71+2]..[6,71+12])
+            class_expr (//toplevel//[5+2]..[6+12])
+              Pcl_open Fresh "M" (//toplevel//[5+11]..[5+12])
+              class_expr (//toplevel//[6+2]..[6+12])
                 Pcl_structure
                 class_structure
-                  pattern (//toplevel//[6,71+8]..[6,71+8]) ghost
+                  pattern (//toplevel//[6+8]..[6+8]) ghost
                     Ppat_any
                   []
       ]
@@ -1176,21 +1176,21 @@ Ptop_def
 class c : object  end
 Ptop_def
   [
-    structure_item (//toplevel//[2,1+0]..[4,33+12])
+    structure_item (//toplevel//[2+0]..[4+12])
       Pstr_class_type
       [
-        class_type_declaration (//toplevel//[2,1+0]..[4,33+12])
+        class_type_declaration (//toplevel//[2+0]..[4+12])
           pci_virt = Concrete
           pci_params =
             []
-          pci_name = "ct" (//toplevel//[2,1+11]..[2,1+13])
+          pci_name = "ct" (//toplevel//[2+11]..[2+13])
           pci_expr =
-            class_type (//toplevel//[3,17+2]..[4,33+12])
-              Pcty_open Fresh "M" (//toplevel//[3,17+11]..[3,17+12])
-              class_type (//toplevel//[4,33+2]..[4,33+12])
+            class_type (//toplevel//[3+2]..[4+12])
+              Pcty_open Fresh "M" (//toplevel//[3+11]..[3+12])
+              class_type (//toplevel//[4+2]..[4+12])
                 Pcty_signature
                 class_signature
-                  core_type (//toplevel//[4,33+8]..[4,33+8]) ghost
+                  core_type (//toplevel//[4+8]..[4+8]) ghost
                     Ptyp_any
                   []
       ]
@@ -1199,33 +1199,33 @@ Ptop_def
 class type ct = object  end
 Ptop_def
   [
-    structure_item (//toplevel//[5,56+0]..[6,64+4])
+    structure_item (//toplevel//[5+0]..[6+4])
       Pstr_value Nonrec
       [
         <def>
             attribute "ocaml.doc"
               [
-                structure_item (//toplevel//[4,19+0]..[4,19+36])
+                structure_item (//toplevel//[4+0]..[4+36])
                   Pstr_eval
-                  expression (//toplevel//[4,19+0]..[4,19+36])
+                  expression (//toplevel//[4+0]..[4+36])
                     Pexp_constant
-                    constant (//toplevel//[4,19+0]..[4,19+36])
-                      PConst_string(" Some docstring attached to x. ",(//toplevel//[4,19+0]..[4,19+36]),None)
+                    constant (//toplevel//[4+0]..[4+36])
+                      PConst_string(" Some docstring attached to x. ",(//toplevel//[4+0]..[4+36]),None)
               ]
             attribute "ocaml.doc"
               [
-                structure_item (//toplevel//[7,69+0]..[7,69+39])
+                structure_item (//toplevel//[7+0]..[7+39])
                   Pstr_eval
-                  expression (//toplevel//[7,69+0]..[7,69+39])
+                  expression (//toplevel//[7+0]..[7+39])
                     Pexp_constant
-                    constant (//toplevel//[7,69+0]..[7,69+39])
-                      PConst_string(" Another docstring attached to x. ",(//toplevel//[7,69+0]..[7,69+39]),None)
+                    constant (//toplevel//[7+0]..[7+39])
+                      PConst_string(" Another docstring attached to x. ",(//toplevel//[7+0]..[7+39]),None)
               ]
-          pattern (//toplevel//[5,56+4]..[5,56+5])
-            Ppat_var "x" (//toplevel//[5,56+4]..[5,56+5])
-          expression (//toplevel//[6,64+2]..[6,64+4])
+          pattern (//toplevel//[5+4]..[5+5])
+            Ppat_var "x" (//toplevel//[5+4]..[5+5])
+          expression (//toplevel//[6+2]..[6+4])
             Pexp_constant
-            constant (//toplevel//[6,64+2]..[6,64+4])
+            constant (//toplevel//[6+2]..[6+4])
               PConst_int (42,None)
       ]
   ]
@@ -1233,27 +1233,27 @@ Ptop_def
 val x : int = 42
 Ptop_def
   [
-    structure_item (//toplevel//[3,56+0]..[3,56+31])
+    structure_item (//toplevel//[3+0]..[3+31])
       Pstr_value Nonrec
       [
         <def>
-          pattern (//toplevel//[3,56+4]..[3,56+5])
-            Ppat_var "x" (//toplevel//[3,56+4]..[3,56+5])
-          expression (//toplevel//[3,56+8]..[3,56+31])
+          pattern (//toplevel//[3+4]..[3+5])
+            Ppat_var "x" (//toplevel//[3+4]..[3+5])
+          expression (//toplevel//[3+8]..[3+31])
             Pexp_object
             class_structure
-              pattern (//toplevel//[3,56+14]..[3,56+14]) ghost
+              pattern (//toplevel//[3+14]..[3+14]) ghost
                 Ppat_any
               [
-                class_field (//toplevel//[3,56+15]..[3,56+27])
+                class_field (//toplevel//[3+15]..[3+27])
                   Pcf_method Public
-                    "f" (//toplevel//[3,56+22]..[3,56+23])
+                    "f" (//toplevel//[3+22]..[3+23])
                     Concrete Fresh
-                    expression (//toplevel//[3,56+26]..[3,56+27]) ghost
+                    expression (//toplevel//[3+26]..[3+27]) ghost
                       Pexp_poly
-                      expression (//toplevel//[3,56+26]..[3,56+27])
+                      expression (//toplevel//[3+26]..[3+27])
                         Pexp_constant
-                        constant (//toplevel//[3,56+26]..[3,56+27])
+                        constant (//toplevel//[3+26]..[3+27])
                           PConst_int (1,None)
                       None
               ]
@@ -1263,29 +1263,29 @@ Ptop_def
 val x : < f : int > = <obj>
 Ptop_def
   [
-    structure_item (//toplevel//[1,0+0]..[1,0+35])
+    structure_item (//toplevel//[1+0]..[1+35])
       Pstr_value Nonrec
       [
         <def>
-          pattern (//toplevel//[1,0+4]..[1,0+5])
-            Ppat_var "x" (//toplevel//[1,0+4]..[1,0+5])
-          expression (//toplevel//[1,0+8]..[1,0+35])
+          pattern (//toplevel//[1+4]..[1+5])
+            Ppat_var "x" (//toplevel//[1+4]..[1+5])
+          expression (//toplevel//[1+8]..[1+35])
             Pexp_send "f"
-            expression (//toplevel//[1,0+8]..[1,0+31])
+            expression (//toplevel//[1+8]..[1+31])
               Pexp_object
               class_structure
-                pattern (//toplevel//[1,0+14]..[1,0+14]) ghost
+                pattern (//toplevel//[1+14]..[1+14]) ghost
                   Ppat_any
                 [
-                  class_field (//toplevel//[1,0+15]..[1,0+27])
+                  class_field (//toplevel//[1+15]..[1+27])
                     Pcf_method Public
-                      "f" (//toplevel//[1,0+22]..[1,0+23])
+                      "f" (//toplevel//[1+22]..[1+23])
                       Concrete Fresh
-                      expression (//toplevel//[1,0+26]..[1,0+27]) ghost
+                      expression (//toplevel//[1+26]..[1+27]) ghost
                         Pexp_poly
-                        expression (//toplevel//[1,0+26]..[1,0+27])
+                        expression (//toplevel//[1+26]..[1+27])
                           Pexp_constant
-                          constant (//toplevel//[1,0+26]..[1,0+27])
+                          constant (//toplevel//[1+26]..[1+27])
                             PConst_int (1,None)
                         None
                 ]
@@ -1295,30 +1295,30 @@ Ptop_def
 val x : int = 1
 Ptop_def
   [
-    structure_item (//toplevel//[1,0+0]..[1,0+36])
+    structure_item (//toplevel//[1+0]..[1+36])
       Pstr_value Nonrec
       [
         <def>
-          pattern (//toplevel//[1,0+4]..[1,0+5])
-            Ppat_var "x" (//toplevel//[1,0+4]..[1,0+5])
-          expression (//toplevel//[1,0+8]..[1,0+36])
-            Pexp_construct "Some" (//toplevel//[1,0+8]..[1,0+12])
+          pattern (//toplevel//[1+4]..[1+5])
+            Ppat_var "x" (//toplevel//[1+4]..[1+5])
+          expression (//toplevel//[1+8]..[1+36])
+            Pexp_construct "Some" (//toplevel//[1+8]..[1+12])
             Some
-              expression (//toplevel//[1,0+13]..[1,0+36])
+              expression (//toplevel//[1+13]..[1+36])
                 Pexp_object
                 class_structure
-                  pattern (//toplevel//[1,0+19]..[1,0+19]) ghost
+                  pattern (//toplevel//[1+19]..[1+19]) ghost
                     Ppat_any
                   [
-                    class_field (//toplevel//[1,0+20]..[1,0+32])
+                    class_field (//toplevel//[1+20]..[1+32])
                       Pcf_method Public
-                        "f" (//toplevel//[1,0+27]..[1,0+28])
+                        "f" (//toplevel//[1+27]..[1+28])
                         Concrete Fresh
-                        expression (//toplevel//[1,0+31]..[1,0+32]) ghost
+                        expression (//toplevel//[1+31]..[1+32]) ghost
                           Pexp_poly
-                          expression (//toplevel//[1,0+31]..[1,0+32])
+                          expression (//toplevel//[1+31]..[1+32])
                             Pexp_constant
-                            constant (//toplevel//[1,0+31]..[1,0+32])
+                            constant (//toplevel//[1+31]..[1+32])
                               PConst_int (1,None)
                           None
                   ]
@@ -1328,32 +1328,32 @@ Ptop_def
 val x : < f : int > option = Some <obj>
 Ptop_def
   [
-    structure_item (//toplevel//[1,0+0]..[1,0+40])
+    structure_item (//toplevel//[1+0]..[1+40])
       Pstr_value Nonrec
       [
         <def>
-          pattern (//toplevel//[1,0+4]..[1,0+5])
-            Ppat_var "x" (//toplevel//[1,0+4]..[1,0+5])
-          expression (//toplevel//[1,0+8]..[1,0+40])
-            Pexp_construct "Some" (//toplevel//[1,0+8]..[1,0+12])
+          pattern (//toplevel//[1+4]..[1+5])
+            Ppat_var "x" (//toplevel//[1+4]..[1+5])
+          expression (//toplevel//[1+8]..[1+40])
+            Pexp_construct "Some" (//toplevel//[1+8]..[1+12])
             Some
-              expression (//toplevel//[1,0+13]..[1,0+40])
+              expression (//toplevel//[1+13]..[1+40])
                 Pexp_send "f"
-                expression (//toplevel//[1,0+13]..[1,0+36])
+                expression (//toplevel//[1+13]..[1+36])
                   Pexp_object
                   class_structure
-                    pattern (//toplevel//[1,0+19]..[1,0+19]) ghost
+                    pattern (//toplevel//[1+19]..[1+19]) ghost
                       Ppat_any
                     [
-                      class_field (//toplevel//[1,0+20]..[1,0+32])
+                      class_field (//toplevel//[1+20]..[1+32])
                         Pcf_method Public
-                          "f" (//toplevel//[1,0+27]..[1,0+28])
+                          "f" (//toplevel//[1+27]..[1+28])
                           Concrete Fresh
-                          expression (//toplevel//[1,0+31]..[1,0+32]) ghost
+                          expression (//toplevel//[1+31]..[1+32]) ghost
                             Pexp_poly
-                            expression (//toplevel//[1,0+31]..[1,0+32])
+                            expression (//toplevel//[1+31]..[1+32])
                               Pexp_constant
-                              constant (//toplevel//[1,0+31]..[1,0+32])
+                              constant (//toplevel//[1+31]..[1+32])
                                 PConst_int (1,None)
                             None
                     ]
@@ -1363,91 +1363,91 @@ Ptop_def
 val x : int option = Some 1
 Ptop_def
   [
-    structure_item (//toplevel//[2,1+0]..[5,76+12])
+    structure_item (//toplevel//[2+0]..[5+12])
       Pstr_eval
-      expression (//toplevel//[2,1+0]..[5,76+12])
+      expression (//toplevel//[2+0]..[5+12])
         Pexp_let Nonrec
         [
           <def>
-            pattern (//toplevel//[2,1+4]..[2,1+5])
-              Ppat_var "f" (//toplevel//[2,1+4]..[2,1+5])
-            expression (//toplevel//[2,1+6]..[2,1+15]) ghost
+            pattern (//toplevel//[2+4]..[2+5])
+              Ppat_var "f" (//toplevel//[2+4]..[2+5])
+            expression (//toplevel//[2+6]..[2+15]) ghost
               Pexp_function
               [
-                Pparam_val (//toplevel//[2,1+6]..[2,1+7])
+                Pparam_val (//toplevel//[2+6]..[2+7])
                   Nolabel
                   None
-                  pattern (//toplevel//[2,1+6]..[2,1+7])
-                    Ppat_var "x" (//toplevel//[2,1+6]..[2,1+7])
-                Pparam_val (//toplevel//[2,1+8]..[2,1+9])
+                  pattern (//toplevel//[2+6]..[2+7])
+                    Ppat_var "x" (//toplevel//[2+6]..[2+7])
+                Pparam_val (//toplevel//[2+8]..[2+9])
                   Nolabel
                   None
-                  pattern (//toplevel//[2,1+8]..[2,1+9])
-                    Ppat_var "y" (//toplevel//[2,1+8]..[2,1+9])
-                Pparam_val (//toplevel//[2,1+10]..[2,1+11])
+                  pattern (//toplevel//[2+8]..[2+9])
+                    Ppat_var "y" (//toplevel//[2+8]..[2+9])
+                Pparam_val (//toplevel//[2+10]..[2+11])
                   Nolabel
                   None
-                  pattern (//toplevel//[2,1+10]..[2,1+11])
-                    Ppat_var "z" (//toplevel//[2,1+10]..[2,1+11])
+                  pattern (//toplevel//[2+10]..[2+11])
+                    Ppat_var "z" (//toplevel//[2+10]..[2+11])
               ]
               None
               Pfunction_body
-                expression (//toplevel//[2,1+14]..[2,1+15])
-                  Pexp_ident "x" (//toplevel//[2,1+14]..[2,1+15])
+                expression (//toplevel//[2+14]..[2+15])
+                  Pexp_ident "x" (//toplevel//[2+14]..[2+15])
         ]
-        expression (//toplevel//[3,20+0]..[5,76+12])
+        expression (//toplevel//[3+0]..[5+12])
           Pexp_apply
-          expression (//toplevel//[3,20+0]..[3,20+1])
-            Pexp_ident "f" (//toplevel//[3,20+0]..[3,20+1])
+          expression (//toplevel//[3+0]..[3+1])
+            Pexp_ident "f" (//toplevel//[3+0]..[3+1])
           [
             <arg>
             Nolabel
-              expression (//toplevel//[3,20+2]..[3,20+25])
+              expression (//toplevel//[3+2]..[3+25])
                 Pexp_object
                 class_structure
-                  pattern (//toplevel//[3,20+8]..[3,20+8]) ghost
+                  pattern (//toplevel//[3+8]..[3+8]) ghost
                     Ppat_any
                   [
-                    class_field (//toplevel//[3,20+9]..[3,20+21])
+                    class_field (//toplevel//[3+9]..[3+21])
                       Pcf_method Public
-                        "f" (//toplevel//[3,20+16]..[3,20+17])
+                        "f" (//toplevel//[3+16]..[3+17])
                         Concrete Fresh
-                        expression (//toplevel//[3,20+20]..[3,20+21]) ghost
+                        expression (//toplevel//[3+20]..[3+21]) ghost
                           Pexp_poly
-                          expression (//toplevel//[3,20+20]..[3,20+21])
+                          expression (//toplevel//[3+20]..[3+21])
                             Pexp_constant
-                            constant (//toplevel//[3,20+20]..[3,20+21])
+                            constant (//toplevel//[3+20]..[3+21])
                               PConst_int (1,None)
                           None
                   ]
             <arg>
             Nolabel
-              expression (//toplevel//[4,46+2]..[4,46+29])
+              expression (//toplevel//[4+2]..[4+29])
                 Pexp_send "f"
-                expression (//toplevel//[4,46+2]..[4,46+25])
+                expression (//toplevel//[4+2]..[4+25])
                   Pexp_object
                   class_structure
-                    pattern (//toplevel//[4,46+8]..[4,46+8]) ghost
+                    pattern (//toplevel//[4+8]..[4+8]) ghost
                       Ppat_any
                     [
-                      class_field (//toplevel//[4,46+9]..[4,46+21])
+                      class_field (//toplevel//[4+9]..[4+21])
                         Pcf_method Public
-                          "f" (//toplevel//[4,46+16]..[4,46+17])
+                          "f" (//toplevel//[4+16]..[4+17])
                           Concrete Fresh
-                          expression (//toplevel//[4,46+20]..[4,46+21]) ghost
+                          expression (//toplevel//[4+20]..[4+21]) ghost
                             Pexp_poly
-                            expression (//toplevel//[4,46+20]..[4,46+21])
+                            expression (//toplevel//[4+20]..[4+21])
                               Pexp_constant
-                              constant (//toplevel//[4,46+20]..[4,46+21])
+                              constant (//toplevel//[4+20]..[4+21])
                                 PConst_int (1,None)
                             None
                     ]
             <arg>
             Nolabel
-              expression (//toplevel//[5,76+2]..[5,76+12])
+              expression (//toplevel//[5+2]..[5+12])
                 Pexp_object
                 class_structure
-                  pattern (//toplevel//[5,76+8]..[5,76+8]) ghost
+                  pattern (//toplevel//[5+8]..[5+8]) ghost
                     Ppat_any
                   []
           ]
@@ -1456,70 +1456,70 @@ Ptop_def
 - : < f : int > = <obj>
 Ptop_def
   [
-    structure_item (//toplevel//[3,66+0]..[5,98+12])
+    structure_item (//toplevel//[3+0]..[5+12])
       Pstr_value Nonrec
       [
         <def>
-          pattern (//toplevel//[3,66+4]..[3,66+5])
-            Ppat_var "g" (//toplevel//[3,66+4]..[3,66+5])
-          expression (//toplevel//[3,66+6]..[5,98+12]) ghost
+          pattern (//toplevel//[3+4]..[3+5])
+            Ppat_var "g" (//toplevel//[3+4]..[3+5])
+          expression (//toplevel//[3+6]..[5+12]) ghost
             Pexp_function
             [
-              Pparam_val (//toplevel//[3,66+6]..[3,66+7])
+              Pparam_val (//toplevel//[3+6]..[3+7])
                 Nolabel
                 None
-                pattern (//toplevel//[3,66+6]..[3,66+7])
-                  Ppat_var "y" (//toplevel//[3,66+6]..[3,66+7])
+                pattern (//toplevel//[3+6]..[3+7])
+                  Ppat_var "y" (//toplevel//[3+6]..[3+7])
             ]
             None
             Pfunction_body
-              expression (//toplevel//[4,76+2]..[5,98+12])
+              expression (//toplevel//[4+2]..[5+12])
                 Pexp_let Nonrec
                 [
                   <def>
-                    pattern (//toplevel//[4,76+6]..[4,76+7])
-                      Ppat_var "f" (//toplevel//[4,76+6]..[4,76+7])
-                    expression (//toplevel//[4,76+8]..[4,76+18]) ghost
+                    pattern (//toplevel//[4+6]..[4+7])
+                      Ppat_var "f" (//toplevel//[4+6]..[4+7])
+                    expression (//toplevel//[4+8]..[4+18]) ghost
                       Pexp_function
                       [
-                        Pparam_val (//toplevel//[4,76+8]..[4,76+10])
+                        Pparam_val (//toplevel//[4+8]..[4+10])
                           Labelled "y"
                           None
-                          pattern (//toplevel//[4,76+9]..[4,76+10])
-                            Ppat_var "y" (//toplevel//[4,76+9]..[4,76+10])
+                          pattern (//toplevel//[4+9]..[4+10])
+                            Ppat_var "y" (//toplevel//[4+9]..[4+10])
                       ]
                       None
                       Pfunction_body
-                        expression (//toplevel//[4,76+13]..[4,76+18])
+                        expression (//toplevel//[4+13]..[4+18])
                           Pexp_apply
-                          expression (//toplevel//[4,76+15]..[4,76+16])
-                            Pexp_ident "+" (//toplevel//[4,76+15]..[4,76+16])
+                          expression (//toplevel//[4+15]..[4+16])
+                            Pexp_ident "+" (//toplevel//[4+15]..[4+16])
                           [
                             <arg>
                             Nolabel
-                              expression (//toplevel//[4,76+13]..[4,76+14])
-                                Pexp_ident "y" (//toplevel//[4,76+13]..[4,76+14])
+                              expression (//toplevel//[4+13]..[4+14])
+                                Pexp_ident "y" (//toplevel//[4+13]..[4+14])
                             <arg>
                             Nolabel
-                              expression (//toplevel//[4,76+17]..[4,76+18])
+                              expression (//toplevel//[4+17]..[4+18])
                                 Pexp_constant
-                                constant (//toplevel//[4,76+17]..[4,76+18])
+                                constant (//toplevel//[4+17]..[4+18])
                                   PConst_int (1,None)
                           ]
                 ]
-                expression (//toplevel//[5,98+2]..[5,98+12])
+                expression (//toplevel//[5+2]..[5+12])
                   Pexp_apply
-                  expression (//toplevel//[5,98+2]..[5,98+3])
-                    Pexp_ident "f" (//toplevel//[5,98+2]..[5,98+3])
+                  expression (//toplevel//[5+2]..[5+3])
+                    Pexp_ident "f" (//toplevel//[5+2]..[5+3])
                   [
                     <arg>
                     Labelled "y"
-                      expression (//toplevel//[5,98+5]..[5,98+12])
+                      expression (//toplevel//[5+5]..[5+12])
                         Pexp_constraint
-                        expression (//toplevel//[5,98+6]..[5,98+7])
-                          Pexp_ident "y" (//toplevel//[5,98+6]..[5,98+7])
-                        core_type (//toplevel//[5,98+8]..[5,98+11])
-                          Ptyp_constr "int" (//toplevel//[5,98+8]..[5,98+11])
+                        expression (//toplevel//[5+6]..[5+7])
+                          Pexp_ident "y" (//toplevel//[5+6]..[5+7])
+                        core_type (//toplevel//[5+8]..[5+11])
+                          Ptyp_constr "int" (//toplevel//[5+8]..[5+11])
                           []
                   ]
       ]

--- a/testsuite/tests/parsing/attributes.compilers.reference
+++ b/testsuite/tests/parsing/attributes.compilers.reference
@@ -1,11 +1,11 @@
 [
-  structure_item (attributes.ml[8,120+0]..[8,120+28])
+  structure_item (attributes.ml[8+0]..[8+28])
     Pstr_exception
     type_exception
       attribute "foo"
         []
       ptyext_constructor =
-        extension_constructor (attributes.ml[8,120+0]..[8,120+20])
+        extension_constructor (attributes.ml[8+0]..[8+20])
           attribute "foo"
             []
           pext_name = "Foo"
@@ -13,54 +13,54 @@
             Pext_decl
               []
               None
-  structure_item (attributes.ml[10,150+0]..[10,150+44])
+  structure_item (attributes.ml[10+0]..[10+44])
     Pstr_exception
     type_exception
       attribute "foo"
         []
       ptyext_constructor =
-        extension_constructor (attributes.ml[10,150+0]..[10,150+36])
+        extension_constructor (attributes.ml[10+0]..[10+36])
           attribute "foo"
             []
           pext_name = "Bar"
           pext_kind =
             Pext_decl
               [
-                core_type (attributes.ml[10,150+18]..[10,150+21])
+                core_type (attributes.ml[10+18]..[10+21])
                   attribute "foo"
                     []
-                  Ptyp_constr "int" (attributes.ml[10,150+18]..[10,150+21])
+                  Ptyp_constr "int" (attributes.ml[10+18]..[10+21])
                   []
               ]
               None
-  structure_item (attributes.ml[12,196+0]..[12,196+8])
+  structure_item (attributes.ml[12+0]..[12+8])
     Pstr_attribute "foo"
     []
-  structure_item (attributes.ml[14,206+0]..[15,245+9])
+  structure_item (attributes.ml[14+0]..[15+9])
     Pstr_value Nonrec
     [
       <def>
           attribute "foo"
             []
-        pattern (attributes.ml[14,206+4]..[14,206+13])
+        pattern (attributes.ml[14+4]..[14+13])
           attribute "foo"
             []
-          Ppat_var "x" (attributes.ml[14,206+5]..[14,206+6])
-        core_type (attributes.ml[14,206+16]..[14,206+20])
+          Ppat_var "x" (attributes.ml[14+5]..[14+6])
+        core_type (attributes.ml[14+16]..[14+20])
           attribute "foo"
             []
-          Ptyp_constr "unit" (attributes.ml[14,206+16]..[14,206+20])
+          Ptyp_constr "unit" (attributes.ml[14+16]..[14+20])
           []
-        expression (attributes.ml[14,206+30]..[14,206+32])
+        expression (attributes.ml[14+30]..[14+32])
           attribute "foo"
             []
-          Pexp_construct "()" (attributes.ml[14,206+30]..[14,206+32])
+          Pexp_construct "()" (attributes.ml[14+30]..[14+32])
           None
     ]
-  structure_item (attributes.ml[17,256+0]..[19,293+7])
+  structure_item (attributes.ml[17+0]..[19+7])
     Pstr_type Rec
     [
-      type_declaration "t" (attributes.ml[17,256+5]..[17,256+6]) (attributes.ml[17,256+0]..[19,293+7])
+      type_declaration "t" (attributes.ml[17+5]..[17+6]) (attributes.ml[17+0]..[19+7])
         attribute "foo"
           []
         ptype_params =
@@ -70,15 +70,15 @@
         ptype_kind =
           Ptype_variant
             [
-              (attributes.ml[18,265+2]..[18,265+27])
-                "Foo" (attributes.ml[18,265+4]..[18,265+7])
+              (attributes.ml[18+2]..[18+27])
+                "Foo" (attributes.ml[18+4]..[18+7])
                 attribute "foo"
                   []
                 [
-                  core_type (attributes.ml[18,265+12]..[18,265+13])
+                  core_type (attributes.ml[18+12]..[18+13])
                     attribute "foo"
                       []
-                    Ptyp_constr "t" (attributes.ml[18,265+12]..[18,265+13])
+                    Ptyp_constr "t" (attributes.ml[18+12]..[18+13])
                     []
                 ]
                 None
@@ -87,23 +87,23 @@
         ptype_manifest =
           None
     ]
-  structure_item (attributes.ml[21,302+0]..[21,302+8])
+  structure_item (attributes.ml[21+0]..[21+8])
     Pstr_attribute "foo"
     []
-  structure_item (attributes.ml[24,313+0]..[33,420+7])
+  structure_item (attributes.ml[24+0]..[33+7])
     Pstr_module
-    "M" (attributes.ml[24,313+7]..[24,313+8])
+    "M" (attributes.ml[24+7]..[24+8])
       attribute "foo"
         []
-      module_expr (attributes.ml[24,313+11]..[32,410+3])
+      module_expr (attributes.ml[24+11]..[32+3])
         attribute "foo"
           []
         Pmod_structure
         [
-          structure_item (attributes.ml[25,331+2]..[29,386+11])
+          structure_item (attributes.ml[25+2]..[29+11])
             Pstr_type Rec
             [
-              type_declaration "t" (attributes.ml[25,331+7]..[25,331+8]) (attributes.ml[25,331+2]..[29,386+11])
+              type_declaration "t" (attributes.ml[25+7]..[25+8]) (attributes.ml[25+2]..[29+11])
                 attribute "foo"
                   []
                 attribute "foo"
@@ -115,70 +115,70 @@
                 ptype_kind =
                   Ptype_record
                     [
-                      (attributes.ml[26,344+4]..[26,344+25])
+                      (attributes.ml[26+4]..[26+25])
                         attribute "foo"
                           []
                         Immutable
-                        "l" (attributes.ml[26,344+4]..[26,344+5])                        core_type (attributes.ml[26,344+9]..[26,344+10])
+                        "l" (attributes.ml[26+4]..[26+5])                        core_type (attributes.ml[26+9]..[26+10])
                           attribute "foo"
                             []
-                          Ptyp_constr "t" (attributes.ml[26,344+9]..[26,344+10])
+                          Ptyp_constr "t" (attributes.ml[26+9]..[26+10])
                           []
                     ]
                 ptype_private = Public
                 ptype_manifest =
                   None
             ]
-          structure_item (attributes.ml[31,399+2]..[31,399+10])
+          structure_item (attributes.ml[31+2]..[31+10])
             Pstr_attribute "foo"
             []
         ]
-  structure_item (attributes.ml[35,429+0]..[45,601+7])
-    Pstr_modtype "S" (attributes.ml[35,429+12]..[35,429+13])
+  structure_item (attributes.ml[35+0]..[45+7])
+    Pstr_modtype "S" (attributes.ml[35+12]..[35+13])
       attribute "foo"
         []
-      module_type (attributes.ml[35,429+16]..[44,591+3])
+      module_type (attributes.ml[35+16]..[44+3])
         attribute "foo"
           []
         Pmty_signature
         [
-          signature_item (attributes.ml[37,450+2]..[37,450+46])
+          signature_item (attributes.ml[37+2]..[37+46])
             Psig_exception
             type_exception
               attribute "foo"
                 []
               ptyext_constructor =
-                extension_constructor (attributes.ml[37,450+2]..[37,450+38])
+                extension_constructor (attributes.ml[37+2]..[37+38])
                   attribute "foo"
                     []
                   pext_name = "Bar"
                   pext_kind =
                     Pext_decl
                       [
-                        core_type (attributes.ml[37,450+20]..[37,450+23])
+                        core_type (attributes.ml[37+20]..[37+23])
                           attribute "foo"
                             []
-                          Ptyp_constr "int" (attributes.ml[37,450+20]..[37,450+23])
+                          Ptyp_constr "int" (attributes.ml[37+20]..[37+23])
                           []
                       ]
                       None
-          signature_item (attributes.ml[39,498+2]..[40,566+11])
+          signature_item (attributes.ml[39+2]..[40+11])
             Psig_include
-            module_type (attributes.ml[39,498+10]..[39,498+61])
+            module_type (attributes.ml[39+10]..[39+61])
               attribute "foo"
                 []
               Pmty_with
-              module_type (attributes.ml[39,498+11]..[39,498+35])
+              module_type (attributes.ml[39+11]..[39+35])
                 attribute "foo"
                   []
                 Pmty_typeof
-                module_expr (attributes.ml[39,498+27]..[39,498+28])
+                module_expr (attributes.ml[39+27]..[39+28])
                   attribute "foo"
                     []
-                  Pmod_ident "M" (attributes.ml[39,498+27]..[39,498+28])
+                  Pmod_ident "M" (attributes.ml[39+27]..[39+28])
               [
-                Pwith_typesubst "t" (attributes.ml[39,498+53]..[39,498+54])
-                  type_declaration "t" (attributes.ml[39,498+53]..[39,498+54]) (attributes.ml[39,498+48]..[39,498+61])
+                Pwith_typesubst "t" (attributes.ml[39+53]..[39+54])
+                  type_declaration "t" (attributes.ml[39+53]..[39+54]) (attributes.ml[39+48]..[39+61])
                     ptype_params =
                       []
                     ptype_constraints =
@@ -188,28 +188,28 @@
                     ptype_private = Public
                     ptype_manifest =
                       Some
-                        core_type (attributes.ml[39,498+58]..[39,498+61])
-                          Ptyp_constr "M.t" (attributes.ml[39,498+58]..[39,498+61])
+                        core_type (attributes.ml[39+58]..[39+61])
+                          Ptyp_constr "M.t" (attributes.ml[39+58]..[39+61])
                           []
               ]
               attribute "foo"
                 []
-          signature_item (attributes.ml[42,579+2]..[42,579+10])
+          signature_item (attributes.ml[42+2]..[42+10])
             Psig_attribute "foo"
             []
         ]
-  structure_item (attributes.ml[47,610+0]..[47,610+8])
+  structure_item (attributes.ml[47+0]..[47+8])
     Pstr_attribute "foo"
     []
-  structure_item (attributes.ml[49,620+0]..[49,620+30])
-    Pstr_modtype "T" (attributes.ml[49,620+12]..[49,620+13])
-      module_type (attributes.ml[49,620+16]..[49,620+30])
+  structure_item (attributes.ml[49+0]..[49+30])
+    Pstr_modtype "T" (attributes.ml[49+12]..[49+13])
+      module_type (attributes.ml[49+16]..[49+30])
         Pmty_signature
         [
-          signature_item (attributes.ml[49,620+20]..[49,620+26])
+          signature_item (attributes.ml[49+20]..[49+26])
             Psig_type Rec
             [
-              type_declaration "t" (attributes.ml[49,620+25]..[49,620+26]) (attributes.ml[49,620+20]..[49,620+26])
+              type_declaration "t" (attributes.ml[49+25]..[49+26]) (attributes.ml[49+20]..[49+26])
                 ptype_params =
                   []
                 ptype_constraints =
@@ -221,33 +221,33 @@
                   None
             ]
         ]
-  structure_item (attributes.ml[51,652+0]..[51,652+27])
+  structure_item (attributes.ml[51+0]..[51+27])
     Pstr_module
-    "_" (attributes.ml[51,652+7]..[51,652+8])
-      module_expr (attributes.ml[51,652+11]..[51,652+27])
+    "_" (attributes.ml[51+7]..[51+8])
+      module_expr (attributes.ml[51+11]..[51+27])
         Pmod_constraint
-        module_expr (attributes.ml[51,652+12]..[51,652+15])
-          Pmod_ident "Int" (attributes.ml[51,652+12]..[51,652+15])
-        module_type (attributes.ml[51,652+18]..[51,652+19])
+        module_expr (attributes.ml[51+12]..[51+15])
+          Pmod_ident "Int" (attributes.ml[51+12]..[51+15])
+        module_type (attributes.ml[51+18]..[51+19])
           attribute "foo"
             []
-          Pmty_ident "T" (attributes.ml[51,652+18]..[51,652+19])
-  structure_item (attributes.ml[53,681+0]..[53,681+45])
+          Pmty_ident "T" (attributes.ml[51+18]..[51+19])
+  structure_item (attributes.ml[53+0]..[53+45])
     Pstr_module
-    "_" (attributes.ml[53,681+7]..[53,681+8])
-      module_expr (attributes.ml[53,681+11]..[53,681+45])
+    "_" (attributes.ml[53+7]..[53+8])
+      module_expr (attributes.ml[53+11]..[53+45])
         Pmod_constraint
-        module_expr (attributes.ml[53,681+12]..[53,681+15])
-          Pmod_ident "Int" (attributes.ml[53,681+12]..[53,681+15])
-        module_type (attributes.ml[53,681+18]..[53,681+37])
+        module_expr (attributes.ml[53+12]..[53+15])
+          Pmod_ident "Int" (attributes.ml[53+12]..[53+15])
+        module_type (attributes.ml[53+18]..[53+37])
           attribute "foo"
             []
           Pmty_with
-          module_type (attributes.ml[53,681+18]..[53,681+19])
-            Pmty_ident "T" (attributes.ml[53,681+18]..[53,681+19])
+          module_type (attributes.ml[53+18]..[53+19])
+            Pmty_ident "T" (attributes.ml[53+18]..[53+19])
           [
-            Pwith_type "t" (attributes.ml[53,681+30]..[53,681+31])
-              type_declaration "t" (attributes.ml[53,681+30]..[53,681+31]) (attributes.ml[53,681+25]..[53,681+37])
+            Pwith_type "t" (attributes.ml[53+30]..[53+31])
+              type_declaration "t" (attributes.ml[53+30]..[53+31]) (attributes.ml[53+25]..[53+37])
                 ptype_params =
                   []
                 ptype_constraints =
@@ -257,91 +257,91 @@
                 ptype_private = Public
                 ptype_manifest =
                   Some
-                    core_type (attributes.ml[53,681+34]..[53,681+37])
-                      Ptyp_constr "int" (attributes.ml[53,681+34]..[53,681+37])
+                    core_type (attributes.ml[53+34]..[53+37])
+                      Ptyp_constr "int" (attributes.ml[53+34]..[53+37])
                       []
           ]
-  structure_item (attributes.ml[55,728+0]..[55,728+31])
+  structure_item (attributes.ml[55+0]..[55+31])
     Pstr_value Nonrec
     [
       <def>
-        pattern (attributes.ml[55,728+4]..[55,728+5])
+        pattern (attributes.ml[55+4]..[55+5])
           Ppat_any
-        expression (attributes.ml[55,728+8]..[55,728+31])
+        expression (attributes.ml[55+8]..[55+31])
           Pexp_pack
-          module_expr (attributes.ml[55,728+16]..[55,728+19])
-            Pmod_ident "Int" (attributes.ml[55,728+16]..[55,728+19])
+          module_expr (attributes.ml[55+16]..[55+19])
+            Pmod_ident "Int" (attributes.ml[55+16]..[55+19])
           Some
-              package_type "T" (attributes.ml[55,728+22]..[55,728+23])
+              package_type "T" (attributes.ml[55+22]..[55+23])
               []
                 attribute "foo"
                   []
     ]
-  structure_item (attributes.ml[57,761+0]..[57,761+49])
+  structure_item (attributes.ml[57+0]..[57+49])
     Pstr_value Nonrec
     [
       <def>
-        pattern (attributes.ml[57,761+4]..[57,761+5])
+        pattern (attributes.ml[57+4]..[57+5])
           Ppat_any
-        expression (attributes.ml[57,761+8]..[57,761+49])
+        expression (attributes.ml[57+8]..[57+49])
           Pexp_pack
-          module_expr (attributes.ml[57,761+16]..[57,761+19])
-            Pmod_ident "Int" (attributes.ml[57,761+16]..[57,761+19])
+          module_expr (attributes.ml[57+16]..[57+19])
+            Pmod_ident "Int" (attributes.ml[57+16]..[57+19])
           Some
-              package_type "T" (attributes.ml[57,761+22]..[57,761+23])
+              package_type "T" (attributes.ml[57+22]..[57+23])
               [
-                with type "t" (attributes.ml[57,761+34]..[57,761+35])
-                core_type (attributes.ml[57,761+38]..[57,761+41])
-                  Ptyp_constr "int" (attributes.ml[57,761+38]..[57,761+41])
+                with type "t" (attributes.ml[57+34]..[57+35])
+                core_type (attributes.ml[57+38]..[57+41])
+                  Ptyp_constr "int" (attributes.ml[57+38]..[57+41])
                   []
               ]
                 attribute "foo"
                   []
     ]
-  structure_item (attributes.ml[59,812+0]..[60,869+26])
+  structure_item (attributes.ml[59+0]..[60+26])
     Pstr_value Nonrec
     [
       <def>
-        pattern (attributes.ml[59,812+4]..[59,812+5])
-          Ppat_var "f" (attributes.ml[59,812+4]..[59,812+5])
-        expression (attributes.ml[59,812+6]..[60,869+26]) ghost
+        pattern (attributes.ml[59+4]..[59+5])
+          Ppat_var "f" (attributes.ml[59+4]..[59+5])
+        expression (attributes.ml[59+6]..[60+26]) ghost
           Pexp_function
           [
-            Pparam_val (attributes.ml[59,812+6]..[59,812+16])
+            Pparam_val (attributes.ml[59+6]..[59+16])
               Nolabel
               None
-              pattern (attributes.ml[59,812+6]..[59,812+16])
+              pattern (attributes.ml[59+6]..[59+16])
                 attribute "foo"
                   []
-                Ppat_var "x" (attributes.ml[59,812+7]..[59,812+8])
+                Ppat_var "x" (attributes.ml[59+7]..[59+8])
           ]
           Some
             Pconstraint
-              core_type (attributes.ml[59,812+19]..[59,812+31])
+              core_type (attributes.ml[59+19]..[59+31])
                 attribute "foo"
                   []
                 Ptyp_arrow
                 Nolabel
-                core_type (attributes.ml[59,812+19]..[59,812+23])
-                  Ptyp_constr "unit" (attributes.ml[59,812+19]..[59,812+23])
+                core_type (attributes.ml[59+19]..[59+23])
+                  Ptyp_constr "unit" (attributes.ml[59+19]..[59+23])
                   []
-                core_type (attributes.ml[59,812+27]..[59,812+31])
-                  Ptyp_constr "unit" (attributes.ml[59,812+27]..[59,812+31])
+                core_type (attributes.ml[59+27]..[59+31])
+                  Ptyp_constr "unit" (attributes.ml[59+27]..[59+31])
                   []
-          Pfunction_cases (attributes.ml[59,812+41]..[60,869+26])
+          Pfunction_cases (attributes.ml[59+41]..[60+26])
               attribute "foo"
                 []
             [
               <case>
-                pattern (attributes.ml[60,869+4]..[60,869+14])
+                pattern (attributes.ml[60+4]..[60+14])
                   attribute "foo"
                     []
-                  Ppat_construct "()" (attributes.ml[60,869+5]..[60,869+7])
+                  Ppat_construct "()" (attributes.ml[60+5]..[60+7])
                   None
-                expression (attributes.ml[60,869+18]..[60,869+20])
+                expression (attributes.ml[60+18]..[60+20])
                   attribute "foo"
                     []
-                  Pexp_construct "()" (attributes.ml[60,869+18]..[60,869+20])
+                  Pexp_construct "()" (attributes.ml[60+18]..[60+20])
                   None
             ]
     ]

--- a/testsuite/tests/parsing/extensions.compilers.reference
+++ b/testsuite/tests/parsing/extensions.compilers.reference
@@ -1,109 +1,109 @@
 [
-  structure_item (extensions.ml[9,153+0]..[9,153+22])
+  structure_item (extensions.ml[9+0]..[9+22])
     Pstr_extension "foo"
     [
-      structure_item (extensions.ml[9,153+7]..[9,153+21])
+      structure_item (extensions.ml[9+7]..[9+21])
         Pstr_eval
-        expression (extensions.ml[9,153+7]..[9,153+21])
+        expression (extensions.ml[9+7]..[9+21])
           Pexp_let Nonrec
           [
             <def>
-              pattern (extensions.ml[9,153+11]..[9,153+12])
-                Ppat_var "x" (extensions.ml[9,153+11]..[9,153+12])
-              expression (extensions.ml[9,153+15]..[9,153+16])
+              pattern (extensions.ml[9+11]..[9+12])
+                Ppat_var "x" (extensions.ml[9+11]..[9+12])
+              expression (extensions.ml[9+15]..[9+16])
                 Pexp_constant
-                constant (extensions.ml[9,153+15]..[9,153+16])
+                constant (extensions.ml[9+15]..[9+16])
                   PConst_int (1,None)
           ]
-          expression (extensions.ml[9,153+20]..[9,153+21])
-            Pexp_ident "x" (extensions.ml[9,153+20]..[9,153+21])
+          expression (extensions.ml[9+20]..[9+21])
+            Pexp_ident "x" (extensions.ml[9+20]..[9+21])
     ]
-  structure_item (extensions.ml[10,176+0]..[10,176+46])
+  structure_item (extensions.ml[10+0]..[10+46])
     Pstr_value Nonrec
     [
       <def>
-        pattern (extensions.ml[10,176+4]..[10,176+14])
+        pattern (extensions.ml[10+4]..[10+14])
           Ppat_extension "foo"
           [
-            structure_item (extensions.ml[10,176+10]..[10,176+13])
+            structure_item (extensions.ml[10+10]..[10+13])
               Pstr_eval
-              expression (extensions.ml[10,176+10]..[10,176+13])
+              expression (extensions.ml[10+10]..[10+13])
                 Pexp_apply
-                expression (extensions.ml[10,176+11]..[10,176+12])
-                  Pexp_ident "+" (extensions.ml[10,176+11]..[10,176+12])
+                expression (extensions.ml[10+11]..[10+12])
+                  Pexp_ident "+" (extensions.ml[10+11]..[10+12])
                 [
                   <arg>
                   Nolabel
-                    expression (extensions.ml[10,176+10]..[10,176+11])
+                    expression (extensions.ml[10+10]..[10+11])
                       Pexp_constant
-                      constant (extensions.ml[10,176+10]..[10,176+11])
+                      constant (extensions.ml[10+10]..[10+11])
                         PConst_int (2,None)
                   <arg>
                   Nolabel
-                    expression (extensions.ml[10,176+12]..[10,176+13])
+                    expression (extensions.ml[10+12]..[10+13])
                       Pexp_constant
-                      constant (extensions.ml[10,176+12]..[10,176+13])
+                      constant (extensions.ml[10+12]..[10+13])
                         PConst_int (1,None)
                 ]
           ]
-        core_type (extensions.ml[10,176+17]..[10,176+31])
+        core_type (extensions.ml[10+17]..[10+31])
           Ptyp_extension "foo"
           [
-            structure_item (extensions.ml[10,176+23]..[10,176+30])
+            structure_item (extensions.ml[10+23]..[10+30])
               Pstr_eval
-              expression (extensions.ml[10,176+23]..[10,176+30])
+              expression (extensions.ml[10+23]..[10+30])
                 Pexp_field
-                expression (extensions.ml[10,176+23]..[10,176+26])
-                  Pexp_ident "bar" (extensions.ml[10,176+23]..[10,176+26])
-                "baz" (extensions.ml[10,176+27]..[10,176+30])
+                expression (extensions.ml[10+23]..[10+26])
+                  Pexp_ident "bar" (extensions.ml[10+23]..[10+26])
+                "baz" (extensions.ml[10+27]..[10+30])
           ]
-        expression (extensions.ml[10,176+34]..[10,176+46])
+        expression (extensions.ml[10+34]..[10+46])
           Pexp_extension "foo"
           [
-            structure_item (extensions.ml[10,176+40]..[10,176+45])
+            structure_item (extensions.ml[10+40]..[10+45])
               Pstr_eval
-              expression (extensions.ml[10,176+40]..[10,176+45])
+              expression (extensions.ml[10+40]..[10+45])
                 Pexp_constant
-                constant (extensions.ml[10,176+40]..[10,176+45])
-                  PConst_string("foo",(extensions.ml[10,176+41]..[10,176+44]),None)
+                constant (extensions.ml[10+40]..[10+45])
+                  PConst_string("foo",(extensions.ml[10+41]..[10+44]),None)
           ]
     ]
-  structure_item (extensions.ml[12,224+0]..[12,224+26])
+  structure_item (extensions.ml[12+0]..[12+26])
     Pstr_extension "foo"
     [
-      structure_item (extensions.ml[12,224+7]..[12,224+24])
+      structure_item (extensions.ml[12+7]..[12+24])
         Pstr_module
-        "M" (extensions.ml[12,224+14]..[12,224+15])
-          module_expr (extensions.ml[12,224+18]..[12,224+24])
+        "M" (extensions.ml[12+14]..[12+15])
+          module_expr (extensions.ml[12+18]..[12+24])
             Pmod_extension "bar"
             []
     ]
-  structure_item (extensions.ml[13,251+0]..[13,251+74])
+  structure_item (extensions.ml[13+0]..[13+74])
     Pstr_value Nonrec
     [
       <def>
-        pattern (extensions.ml[13,251+4]..[13,251+23])
+        pattern (extensions.ml[13+4]..[13+23])
           Ppat_extension "foo"
           [
-            structure_item (extensions.ml[13,251+10]..[13,251+21])
+            structure_item (extensions.ml[13+10]..[13+21])
               Pstr_value Nonrec
               [
                 <def>
-                  pattern (extensions.ml[13,251+14]..[13,251+16])
-                    Ppat_construct "()" (extensions.ml[13,251+14]..[13,251+16])
+                  pattern (extensions.ml[13+14]..[13+16])
+                    Ppat_construct "()" (extensions.ml[13+14]..[13+16])
                     None
-                  expression (extensions.ml[13,251+19]..[13,251+21])
-                    Pexp_construct "()" (extensions.ml[13,251+19]..[13,251+21])
+                  expression (extensions.ml[13+19]..[13+21])
+                    Pexp_construct "()" (extensions.ml[13+19]..[13+21])
                     None
               ]
           ]
-        core_type (extensions.ml[13,251+26]..[13,251+44])
+        core_type (extensions.ml[13+26]..[13+44])
           Ptyp_extension "foo"
           [
-            structure_item (extensions.ml[13,251+32]..[13,251+42])
+            structure_item (extensions.ml[13+32]..[13+42])
               Pstr_type Rec
               [
-                type_declaration "t" (extensions.ml[13,251+37]..[13,251+38]) (extensions.ml[13,251+32]..[13,251+42])
+                type_declaration "t" (extensions.ml[13+37]..[13+38]) (extensions.ml[13+32]..[13+42])
                   ptype_params =
                     []
                   ptype_constraints =
@@ -113,162 +113,162 @@
                   ptype_private = Public
                   ptype_manifest =
                     Some
-                      core_type (extensions.ml[13,251+41]..[13,251+42])
-                        Ptyp_constr "t" (extensions.ml[13,251+41]..[13,251+42])
+                      core_type (extensions.ml[13+41]..[13+42])
+                        Ptyp_constr "t" (extensions.ml[13+41]..[13+42])
                         []
               ]
           ]
-        expression (extensions.ml[13,251+47]..[13,251+74])
+        expression (extensions.ml[13+47]..[13+74])
           Pexp_extension "foo"
           [
-            structure_item (extensions.ml[13,251+53]..[13,251+73])
+            structure_item (extensions.ml[13+53]..[13+73])
               Pstr_class
               [
-                class_declaration (extensions.ml[13,251+53]..[13,251+73])
+                class_declaration (extensions.ml[13+53]..[13+73])
                   pci_virt = Concrete
                   pci_params =
                     []
-                  pci_name = "c" (extensions.ml[13,251+59]..[13,251+60])
+                  pci_name = "c" (extensions.ml[13+59]..[13+60])
                   pci_expr =
-                    class_expr (extensions.ml[13,251+63]..[13,251+73])
+                    class_expr (extensions.ml[13+63]..[13+73])
                       Pcl_structure
                       class_structure
-                        pattern (extensions.ml[13,251+69]..[13,251+69]) ghost
+                        pattern (extensions.ml[13+69]..[13+69]) ghost
                           Ppat_any
                         []
               ]
           ]
     ]
-  structure_item (extensions.ml[15,327+0]..[15,327+16])
+  structure_item (extensions.ml[15+0]..[15+16])
     Pstr_extension "foo"
-    core_type (extensions.ml[15,327+8]..[15,327+15])
-      Ptyp_constr "list" (extensions.ml[15,327+11]..[15,327+15])
+    core_type (extensions.ml[15+8]..[15+15])
+      Ptyp_constr "list" (extensions.ml[15+11]..[15+15])
       [
-        core_type (extensions.ml[15,327+8]..[15,327+10])
+        core_type (extensions.ml[15+8]..[15+10])
           Ptyp_var a
       ]
-  structure_item (extensions.ml[16,344+0]..[16,344+60])
+  structure_item (extensions.ml[16+0]..[16+60])
     Pstr_value Nonrec
     [
       <def>
-        pattern (extensions.ml[16,344+4]..[16,344+19])
+        pattern (extensions.ml[16+4]..[16+19])
           Ppat_extension "foo"
-          core_type (extensions.ml[16,344+11]..[16,344+17])
+          core_type (extensions.ml[16+11]..[16+17])
             Ptyp_variant closed=Closed
             [
               Rtag "Foo" true
                 []
             ]
             None
-        core_type (extensions.ml[16,344+22]..[16,344+37])
+        core_type (extensions.ml[16+22]..[16+37])
           Ptyp_extension "foo"
-          core_type (extensions.ml[16,344+29]..[16,344+35])
+          core_type (extensions.ml[16+29]..[16+35])
             Ptyp_arrow
             Nolabel
-            core_type (extensions.ml[16,344+29]..[16,344+30])
-              Ptyp_constr "t" (extensions.ml[16,344+29]..[16,344+30])
+            core_type (extensions.ml[16+29]..[16+30])
+              Ptyp_constr "t" (extensions.ml[16+29]..[16+30])
               []
-            core_type (extensions.ml[16,344+34]..[16,344+35])
-              Ptyp_constr "t" (extensions.ml[16,344+34]..[16,344+35])
+            core_type (extensions.ml[16+34]..[16+35])
+              Ptyp_constr "t" (extensions.ml[16+34]..[16+35])
               []
-        expression (extensions.ml[16,344+40]..[16,344+60])
+        expression (extensions.ml[16+40]..[16+60])
           Pexp_extension "foo"
-          core_type (extensions.ml[16,344+47]..[16,344+58])
+          core_type (extensions.ml[16+47]..[16+58])
             Ptyp_object Closed
               method foo
-                core_type (extensions.ml[16,344+55]..[16,344+56])
-                  Ptyp_constr "t" (extensions.ml[16,344+55]..[16,344+56])
+                core_type (extensions.ml[16+55]..[16+56])
+                  Ptyp_constr "t" (extensions.ml[16+55]..[16+56])
                   []
     ]
-  structure_item (extensions.ml[18,406+0]..[18,406+11])
+  structure_item (extensions.ml[18+0]..[18+11])
     Pstr_extension "foo"
-    pattern (extensions.ml[18,406+8]..[18,406+9])
+    pattern (extensions.ml[18+8]..[18+9])
       Ppat_any
-  structure_item (extensions.ml[19,418+0]..[19,418+26])
+  structure_item (extensions.ml[19+0]..[19+26])
     Pstr_extension "foo"
-    pattern (extensions.ml[19,418+8]..[19,418+14])
-      Ppat_construct "Some" (extensions.ml[19,418+8]..[19,418+12])
+    pattern (extensions.ml[19+8]..[19+14])
+      Ppat_construct "Some" (extensions.ml[19+8]..[19+12])
       Some
         []
-        pattern (extensions.ml[19,418+13]..[19,418+14])
-          Ppat_var "y" (extensions.ml[19,418+13]..[19,418+14])
+        pattern (extensions.ml[19+13]..[19+14])
+          Ppat_var "y" (extensions.ml[19+13]..[19+14])
     <when>
-      expression (extensions.ml[19,418+20]..[19,418+25])
+      expression (extensions.ml[19+20]..[19+25])
         Pexp_apply
-        expression (extensions.ml[19,418+22]..[19,418+23])
-          Pexp_ident ">" (extensions.ml[19,418+22]..[19,418+23])
+        expression (extensions.ml[19+22]..[19+23])
+          Pexp_ident ">" (extensions.ml[19+22]..[19+23])
         [
           <arg>
           Nolabel
-            expression (extensions.ml[19,418+20]..[19,418+21])
-              Pexp_ident "y" (extensions.ml[19,418+20]..[19,418+21])
+            expression (extensions.ml[19+20]..[19+21])
+              Pexp_ident "y" (extensions.ml[19+20]..[19+21])
           <arg>
           Nolabel
-            expression (extensions.ml[19,418+24]..[19,418+25])
+            expression (extensions.ml[19+24]..[19+25])
               Pexp_constant
-              constant (extensions.ml[19,418+24]..[19,418+25])
+              constant (extensions.ml[19+24]..[19+25])
                 PConst_int (0,None)
         ]
-  structure_item (extensions.ml[20,445+0]..[20,445+60])
+  structure_item (extensions.ml[20+0]..[20+60])
     Pstr_value Nonrec
     [
       <def>
-        pattern (extensions.ml[20,445+4]..[20,445+28])
+        pattern (extensions.ml[20+4]..[20+28])
           Ppat_extension "foo"
-          pattern (extensions.ml[20,445+11]..[20,445+26])
+          pattern (extensions.ml[20+11]..[20+26])
             Ppat_or
-            pattern (extensions.ml[20,445+12]..[20,445+17])
-              Ppat_construct "Bar" (extensions.ml[20,445+12]..[20,445+15])
+            pattern (extensions.ml[20+12]..[20+17])
+              Ppat_construct "Bar" (extensions.ml[20+12]..[20+15])
               Some
                 []
-                pattern (extensions.ml[20,445+16]..[20,445+17])
-                  Ppat_var "x" (extensions.ml[20,445+16]..[20,445+17])
-            pattern (extensions.ml[20,445+20]..[20,445+25])
-              Ppat_construct "Baz" (extensions.ml[20,445+20]..[20,445+23])
+                pattern (extensions.ml[20+16]..[20+17])
+                  Ppat_var "x" (extensions.ml[20+16]..[20+17])
+            pattern (extensions.ml[20+20]..[20+25])
+              Ppat_construct "Baz" (extensions.ml[20+20]..[20+23])
               Some
                 []
-                pattern (extensions.ml[20,445+24]..[20,445+25])
-                  Ppat_var "x" (extensions.ml[20,445+24]..[20,445+25])
-        core_type (extensions.ml[20,445+31]..[20,445+44])
+                pattern (extensions.ml[20+24]..[20+25])
+                  Ppat_var "x" (extensions.ml[20+24]..[20+25])
+        core_type (extensions.ml[20+31]..[20+44])
           Ptyp_extension "foo"
-          pattern (extensions.ml[20,445+38]..[20,445+42])
+          pattern (extensions.ml[20+38]..[20+42])
             Ppat_type
-            "bar" (extensions.ml[20,445+39]..[20,445+42])
-        expression (extensions.ml[20,445+47]..[20,445+60])
+            "bar" (extensions.ml[20+39]..[20+42])
+        expression (extensions.ml[20+47]..[20+60])
           Pexp_extension "foo"
-          pattern (extensions.ml[20,445+54]..[20,445+59])
+          pattern (extensions.ml[20+54]..[20+59])
             Ppat_record Closed
             [
-              "x" (extensions.ml[20,445+56]..[20,445+57]) ghost
-                pattern (extensions.ml[20,445+56]..[20,445+57])
-                  Ppat_var "x" (extensions.ml[20,445+56]..[20,445+57])
+              "x" (extensions.ml[20+56]..[20+57]) ghost
+                pattern (extensions.ml[20+56]..[20+57])
+                  Ppat_var "x" (extensions.ml[20+56]..[20+57])
             ]
     ]
-  structure_item (extensions.ml[22,507+0]..[22,507+26])
+  structure_item (extensions.ml[22+0]..[22+26])
     Pstr_extension "foo"
     [
-      signature_item (extensions.ml[22,507+8]..[22,507+25])
-        Psig_module "M" (extensions.ml[22,507+15]..[22,507+16])
-        module_type (extensions.ml[22,507+19]..[22,507+25])
+      signature_item (extensions.ml[22+8]..[22+25])
+        Psig_module "M" (extensions.ml[22+15]..[22+16])
+        module_type (extensions.ml[22+19]..[22+25])
           Pmod_extension "baz"
           []
     ]
-  structure_item (extensions.ml[23,534+0]..[25,606+23])
+  structure_item (extensions.ml[23+0]..[25+23])
     Pstr_value Nonrec
     [
       <def>
-        pattern (extensions.ml[23,534+4]..[23,534+38])
+        pattern (extensions.ml[23+4]..[23+38])
           Ppat_extension "foo"
           [
-            signature_item (extensions.ml[23,534+11]..[23,534+36])
+            signature_item (extensions.ml[23+11]..[23+36])
               Psig_include
-              module_type (extensions.ml[23,534+19]..[23,534+36])
+              module_type (extensions.ml[23+19]..[23+36])
                 Pmty_with
-                module_type (extensions.ml[23,534+19]..[23,534+20])
-                  Pmty_ident "S" (extensions.ml[23,534+19]..[23,534+20])
+                module_type (extensions.ml[23+19]..[23+20])
+                  Pmty_ident "S" (extensions.ml[23+19]..[23+20])
                 [
-                  Pwith_type "t" (extensions.ml[23,534+31]..[23,534+32])
-                    type_declaration "t" (extensions.ml[23,534+31]..[23,534+32]) (extensions.ml[23,534+26]..[23,534+36])
+                  Pwith_type "t" (extensions.ml[23+31]..[23+32])
+                    type_declaration "t" (extensions.ml[23+31]..[23+32]) (extensions.ml[23+26]..[23+36])
                       ptype_params =
                         []
                       ptype_constraints =
@@ -278,36 +278,36 @@
                       ptype_private = Public
                       ptype_manifest =
                         Some
-                          core_type (extensions.ml[23,534+35]..[23,534+36])
-                            Ptyp_constr "t" (extensions.ml[23,534+35]..[23,534+36])
+                          core_type (extensions.ml[23+35]..[23+36])
+                            Ptyp_constr "t" (extensions.ml[23+35]..[23+36])
                             []
                 ]
           ]
-        core_type (extensions.ml[24,573+4]..[24,573+32])
+        core_type (extensions.ml[24+4]..[24+32])
           Ptyp_extension "foo"
           [
-            signature_item (extensions.ml[24,573+11]..[24,573+20])
+            signature_item (extensions.ml[24+11]..[24+20])
               Psig_value
-              value_description "x" (extensions.ml[24,573+15]..[24,573+16]) (extensions.ml[24,573+11]..[24,573+20])
-                core_type (extensions.ml[24,573+19]..[24,573+20])
-                  Ptyp_constr "t" (extensions.ml[24,573+19]..[24,573+20])
+              value_description "x" (extensions.ml[24+15]..[24+16]) (extensions.ml[24+11]..[24+20])
+                core_type (extensions.ml[24+19]..[24+20])
+                  Ptyp_constr "t" (extensions.ml[24+19]..[24+20])
                   []
                 []
-            signature_item (extensions.ml[24,573+22]..[24,573+31])
+            signature_item (extensions.ml[24+22]..[24+31])
               Psig_value
-              value_description "y" (extensions.ml[24,573+26]..[24,573+27]) (extensions.ml[24,573+22]..[24,573+31])
-                core_type (extensions.ml[24,573+30]..[24,573+31])
-                  Ptyp_constr "t" (extensions.ml[24,573+30]..[24,573+31])
+              value_description "y" (extensions.ml[24+26]..[24+27]) (extensions.ml[24+22]..[24+31])
+                core_type (extensions.ml[24+30]..[24+31])
+                  Ptyp_constr "t" (extensions.ml[24+30]..[24+31])
                   []
                 []
           ]
-        expression (extensions.ml[25,606+4]..[25,606+23])
+        expression (extensions.ml[25+4]..[25+23])
           Pexp_extension "foo"
           [
-            signature_item (extensions.ml[25,606+11]..[25,606+21])
+            signature_item (extensions.ml[25+11]..[25+21])
               Psig_type Rec
               [
-                type_declaration "t" (extensions.ml[25,606+16]..[25,606+17]) (extensions.ml[25,606+11]..[25,606+21])
+                type_declaration "t" (extensions.ml[25+16]..[25+17]) (extensions.ml[25+11]..[25+21])
                   ptype_params =
                     []
                   ptype_constraints =
@@ -317,8 +317,8 @@
                   ptype_private = Public
                   ptype_manifest =
                     Some
-                      core_type (extensions.ml[25,606+20]..[25,606+21])
-                        Ptyp_constr "t" (extensions.ml[25,606+20]..[25,606+21])
+                      core_type (extensions.ml[25+20]..[25+21])
+                        Ptyp_constr "t" (extensions.ml[25+20]..[25+21])
                         []
               ]
           ]

--- a/testsuite/tests/parsing/hash_ambiguity.compilers.reference
+++ b/testsuite/tests/parsing/hash_ambiguity.compilers.reference
@@ -1,30 +1,30 @@
 [
-  structure_item (hash_ambiguity.ml[8,140+0]..[8,140+28])
+  structure_item (hash_ambiguity.ml[8+0]..[8+28])
     Pstr_class
     [
-      class_declaration (hash_ambiguity.ml[8,140+0]..[8,140+28])
+      class_declaration (hash_ambiguity.ml[8+0]..[8+28])
         pci_virt = Concrete
         pci_params =
           [
-            core_type (hash_ambiguity.ml[8,140+7]..[8,140+9])
+            core_type (hash_ambiguity.ml[8+7]..[8+9])
               Ptyp_var a
           ]
-        pci_name = "list" (hash_ambiguity.ml[8,140+11]..[8,140+15])
+        pci_name = "list" (hash_ambiguity.ml[8+11]..[8+15])
         pci_expr =
-          class_expr (hash_ambiguity.ml[8,140+18]..[8,140+28])
+          class_expr (hash_ambiguity.ml[8+18]..[8+28])
             Pcl_structure
             class_structure
-              pattern (hash_ambiguity.ml[8,140+24]..[8,140+24]) ghost
+              pattern (hash_ambiguity.ml[8+24]..[8+24]) ghost
                 Ppat_any
               []
     ]
-  structure_item (hash_ambiguity.ml[9,169+0]..[9,169+27])
+  structure_item (hash_ambiguity.ml[9+0]..[9+27])
     Pstr_type Rec
     [
-      type_declaration "t" (hash_ambiguity.ml[9,169+8]..[9,169+9]) (hash_ambiguity.ml[9,169+0]..[9,169+27])
+      type_declaration "t" (hash_ambiguity.ml[9+8]..[9+9]) (hash_ambiguity.ml[9+0]..[9+27])
         ptype_params =
           [
-            core_type (hash_ambiguity.ml[9,169+5]..[9,169+7])
+            core_type (hash_ambiguity.ml[9+5]..[9+7])
               Ptyp_var a
           ]
         ptype_constraints =
@@ -34,23 +34,23 @@
         ptype_private = Public
         ptype_manifest =
           Some
-            core_type (hash_ambiguity.ml[9,169+12]..[9,169+27])
+            core_type (hash_ambiguity.ml[9+12]..[9+27])
               Ptyp_alias "a"
-              core_type (hash_ambiguity.ml[9,169+12]..[9,169+21])
-                Ptyp_class "list" (hash_ambiguity.ml[9,169+17]..[9,169+21])
+              core_type (hash_ambiguity.ml[9+12]..[9+21])
+                Ptyp_class "list" (hash_ambiguity.ml[9+17]..[9+21])
                 [
-                  core_type (hash_ambiguity.ml[9,169+12]..[9,169+15])
-                    Ptyp_constr "int" (hash_ambiguity.ml[9,169+12]..[9,169+15])
+                  core_type (hash_ambiguity.ml[9+12]..[9+15])
+                    Ptyp_constr "int" (hash_ambiguity.ml[9+12]..[9+15])
                     []
                 ]
     ]
-  structure_item (hash_ambiguity.ml[15,425+0]..[15,425+26])
+  structure_item (hash_ambiguity.ml[15+0]..[15+26])
     Pstr_type Rec
     [
-      type_declaration "u" (hash_ambiguity.ml[15,425+8]..[15,425+9]) (hash_ambiguity.ml[15,425+0]..[15,425+26])
+      type_declaration "u" (hash_ambiguity.ml[15+8]..[15+9]) (hash_ambiguity.ml[15+0]..[15+26])
         ptype_params =
           [
-            core_type (hash_ambiguity.ml[15,425+5]..[15,425+7])
+            core_type (hash_ambiguity.ml[15+5]..[15+7])
               Ptyp_var a
           ]
         ptype_constraints =
@@ -58,14 +58,14 @@
         ptype_kind =
           Ptype_variant
             [
-              (hash_ambiguity.ml[15,425+12]..[15,425+26])
-                "A" (hash_ambiguity.ml[15,425+12]..[15,425+13])
+              (hash_ambiguity.ml[15+12]..[15+26])
+                "A" (hash_ambiguity.ml[15+12]..[15+13])
                 [
-                  core_type (hash_ambiguity.ml[15,425+17]..[15,425+26])
-                    Ptyp_class "list" (hash_ambiguity.ml[15,425+22]..[15,425+26])
+                  core_type (hash_ambiguity.ml[15+17]..[15+26])
+                    Ptyp_class "list" (hash_ambiguity.ml[15+22]..[15+26])
                     [
-                      core_type (hash_ambiguity.ml[15,425+17]..[15,425+20])
-                        Ptyp_constr "int" (hash_ambiguity.ml[15,425+17]..[15,425+20])
+                      core_type (hash_ambiguity.ml[15+17]..[15+20])
+                        Ptyp_constr "int" (hash_ambiguity.ml[15+17]..[15+20])
                         []
                     ]
                 ]
@@ -75,13 +75,13 @@
         ptype_manifest =
           None
     ]
-  structure_item (hash_ambiguity.ml[17,453+0]..[17,453+32])
+  structure_item (hash_ambiguity.ml[17+0]..[17+32])
     Pstr_type Rec
     [
-      type_declaration "v" (hash_ambiguity.ml[17,453+8]..[17,453+9]) (hash_ambiguity.ml[17,453+0]..[17,453+32])
+      type_declaration "v" (hash_ambiguity.ml[17+8]..[17+9]) (hash_ambiguity.ml[17+0]..[17+32])
         ptype_params =
           [
-            core_type (hash_ambiguity.ml[17,453+5]..[17,453+7])
+            core_type (hash_ambiguity.ml[17+5]..[17+7])
               Ptyp_var a
           ]
         ptype_constraints =
@@ -89,17 +89,17 @@
         ptype_kind =
           Ptype_variant
             [
-              (hash_ambiguity.ml[17,453+12]..[17,453+32])
-                "A" (hash_ambiguity.ml[17,453+12]..[17,453+13])
+              (hash_ambiguity.ml[17+12]..[17+32])
+                "A" (hash_ambiguity.ml[17+12]..[17+13])
                 [
-                  core_type (hash_ambiguity.ml[17,453+17]..[17,453+20])
-                    Ptyp_constr "int" (hash_ambiguity.ml[17,453+17]..[17,453+20])
+                  core_type (hash_ambiguity.ml[17+17]..[17+20])
+                    Ptyp_constr "int" (hash_ambiguity.ml[17+17]..[17+20])
                     []
-                  core_type (hash_ambiguity.ml[17,453+23]..[17,453+32])
-                    Ptyp_class "list" (hash_ambiguity.ml[17,453+28]..[17,453+32])
+                  core_type (hash_ambiguity.ml[17+23]..[17+32])
+                    Ptyp_class "list" (hash_ambiguity.ml[17+28]..[17+32])
                     [
-                      core_type (hash_ambiguity.ml[17,453+23]..[17,453+26])
-                        Ptyp_constr "int" (hash_ambiguity.ml[17,453+23]..[17,453+26])
+                      core_type (hash_ambiguity.ml[17+23]..[17+26])
+                        Ptyp_constr "int" (hash_ambiguity.ml[17+23]..[17+26])
                         []
                     ]
                 ]

--- a/testsuite/tests/parsing/int_and_float_with_modifier.compilers.reference
+++ b/testsuite/tests/parsing/int_and_float_with_modifier.compilers.reference
@@ -1,101 +1,101 @@
 [
-  structure_item (int_and_float_with_modifier.ml[9,153+0]..[10,184+57])
+  structure_item (int_and_float_with_modifier.ml[9+0]..[10+57])
     Pstr_value Nonrec
     [
       <def>
-        pattern (int_and_float_with_modifier.ml[9,153+4]..[9,153+28])
-          Ppat_var "int_with_custom_modifier" (int_and_float_with_modifier.ml[9,153+4]..[9,153+28])
-        expression (int_and_float_with_modifier.ml[10,184+2]..[10,184+57])
+        pattern (int_and_float_with_modifier.ml[9+4]..[9+28])
+          Ppat_var "int_with_custom_modifier" (int_and_float_with_modifier.ml[9+4]..[9+28])
+        expression (int_and_float_with_modifier.ml[10+2]..[10+57])
           Pexp_constant
-          constant (int_and_float_with_modifier.ml[10,184+2]..[10,184+57])
+          constant (int_and_float_with_modifier.ml[10+2]..[10+57])
             PConst_int (1234567890_1234567890_1234567890_1234567890_1234567890,Some z)
     ]
-  structure_item (int_and_float_with_modifier.ml[11,242+0]..[12,275+58])
+  structure_item (int_and_float_with_modifier.ml[11+0]..[12+58])
     Pstr_value Nonrec
     [
       <def>
-        pattern (int_and_float_with_modifier.ml[11,242+4]..[11,242+30])
-          Ppat_var "float_with_custom_modifier" (int_and_float_with_modifier.ml[11,242+4]..[11,242+30])
-        expression (int_and_float_with_modifier.ml[12,275+2]..[12,275+58])
+        pattern (int_and_float_with_modifier.ml[11+4]..[11+30])
+          Ppat_var "float_with_custom_modifier" (int_and_float_with_modifier.ml[11+4]..[11+30])
+        expression (int_and_float_with_modifier.ml[12+2]..[12+58])
           Pexp_constant
-          constant (int_and_float_with_modifier.ml[12,275+2]..[12,275+58])
+          constant (int_and_float_with_modifier.ml[12+2]..[12+58])
             PConst_float (1234567890_1234567890_1234567890_1234567890_1234567890.,Some z)
     ]
-  structure_item (int_and_float_with_modifier.ml[14,335+0]..[14,335+21])
+  structure_item (int_and_float_with_modifier.ml[14+0]..[14+21])
     Pstr_value Nonrec
     [
       <def>
-        pattern (int_and_float_with_modifier.ml[14,335+4]..[14,335+9])
-          Ppat_var "int32" (int_and_float_with_modifier.ml[14,335+4]..[14,335+9])
-        expression (int_and_float_with_modifier.ml[14,335+16]..[14,335+21])
+        pattern (int_and_float_with_modifier.ml[14+4]..[14+9])
+          Ppat_var "int32" (int_and_float_with_modifier.ml[14+4]..[14+9])
+        expression (int_and_float_with_modifier.ml[14+16]..[14+21])
           Pexp_constant
-          constant (int_and_float_with_modifier.ml[14,335+16]..[14,335+21])
+          constant (int_and_float_with_modifier.ml[14+16]..[14+21])
             PConst_int (1234,Some l)
     ]
-  structure_item (int_and_float_with_modifier.ml[15,357+0]..[15,357+21])
+  structure_item (int_and_float_with_modifier.ml[15+0]..[15+21])
     Pstr_value Nonrec
     [
       <def>
-        pattern (int_and_float_with_modifier.ml[15,357+4]..[15,357+9])
-          Ppat_var "int64" (int_and_float_with_modifier.ml[15,357+4]..[15,357+9])
-        expression (int_and_float_with_modifier.ml[15,357+16]..[15,357+21])
+        pattern (int_and_float_with_modifier.ml[15+4]..[15+9])
+          Ppat_var "int64" (int_and_float_with_modifier.ml[15+4]..[15+9])
+        expression (int_and_float_with_modifier.ml[15+16]..[15+21])
           Pexp_constant
-          constant (int_and_float_with_modifier.ml[15,357+16]..[15,357+21])
+          constant (int_and_float_with_modifier.ml[15+16]..[15+21])
             PConst_int (1234,Some L)
     ]
-  structure_item (int_and_float_with_modifier.ml[16,379+0]..[16,379+21])
+  structure_item (int_and_float_with_modifier.ml[16+0]..[16+21])
     Pstr_value Nonrec
     [
       <def>
-        pattern (int_and_float_with_modifier.ml[16,379+4]..[16,379+13])
-          Ppat_var "nativeint" (int_and_float_with_modifier.ml[16,379+4]..[16,379+13])
-        expression (int_and_float_with_modifier.ml[16,379+16]..[16,379+21])
+        pattern (int_and_float_with_modifier.ml[16+4]..[16+13])
+          Ppat_var "nativeint" (int_and_float_with_modifier.ml[16+4]..[16+13])
+        expression (int_and_float_with_modifier.ml[16+16]..[16+21])
           Pexp_constant
-          constant (int_and_float_with_modifier.ml[16,379+16]..[16,379+21])
+          constant (int_and_float_with_modifier.ml[16+16]..[16+21])
             PConst_int (1234,Some n)
     ]
-  structure_item (int_and_float_with_modifier.ml[18,402+0]..[18,402+32])
+  structure_item (int_and_float_with_modifier.ml[18+0]..[18+32])
     Pstr_value Nonrec
     [
       <def>
-        pattern (int_and_float_with_modifier.ml[18,402+4]..[18,402+24])
-          Ppat_var "hex_without_modifier" (int_and_float_with_modifier.ml[18,402+4]..[18,402+24])
-        expression (int_and_float_with_modifier.ml[18,402+27]..[18,402+32])
+        pattern (int_and_float_with_modifier.ml[18+4]..[18+24])
+          Ppat_var "hex_without_modifier" (int_and_float_with_modifier.ml[18+4]..[18+24])
+        expression (int_and_float_with_modifier.ml[18+27]..[18+32])
           Pexp_constant
-          constant (int_and_float_with_modifier.ml[18,402+27]..[18,402+32])
+          constant (int_and_float_with_modifier.ml[18+27]..[18+32])
             PConst_int (0x32f,None)
     ]
-  structure_item (int_and_float_with_modifier.ml[19,435+0]..[19,435+32])
+  structure_item (int_and_float_with_modifier.ml[19+0]..[19+32])
     Pstr_value Nonrec
     [
       <def>
-        pattern (int_and_float_with_modifier.ml[19,435+4]..[19,435+21])
-          Ppat_var "hex_with_modifier" (int_and_float_with_modifier.ml[19,435+4]..[19,435+21])
-        expression (int_and_float_with_modifier.ml[19,435+27]..[19,435+32])
+        pattern (int_and_float_with_modifier.ml[19+4]..[19+21])
+          Ppat_var "hex_with_modifier" (int_and_float_with_modifier.ml[19+4]..[19+21])
+        expression (int_and_float_with_modifier.ml[19+27]..[19+32])
           Pexp_constant
-          constant (int_and_float_with_modifier.ml[19,435+27]..[19,435+32])
+          constant (int_and_float_with_modifier.ml[19+27]..[19+32])
             PConst_int (0x32,Some g)
     ]
-  structure_item (int_and_float_with_modifier.ml[21,469+0]..[21,469+33])
+  structure_item (int_and_float_with_modifier.ml[21+0]..[21+33])
     Pstr_value Nonrec
     [
       <def>
-        pattern (int_and_float_with_modifier.ml[21,469+4]..[21,469+25])
-          Ppat_var "float_without_modifer" (int_and_float_with_modifier.ml[21,469+4]..[21,469+25])
-        expression (int_and_float_with_modifier.ml[21,469+28]..[21,469+33])
+        pattern (int_and_float_with_modifier.ml[21+4]..[21+25])
+          Ppat_var "float_without_modifer" (int_and_float_with_modifier.ml[21+4]..[21+25])
+        expression (int_and_float_with_modifier.ml[21+28]..[21+33])
           Pexp_constant
-          constant (int_and_float_with_modifier.ml[21,469+28]..[21,469+33])
+          constant (int_and_float_with_modifier.ml[21+28]..[21+33])
             PConst_float (1.2e3,None)
     ]
-  structure_item (int_and_float_with_modifier.ml[22,503+0]..[22,503+32])
+  structure_item (int_and_float_with_modifier.ml[22+0]..[22+32])
     Pstr_value Nonrec
     [
       <def>
-        pattern (int_and_float_with_modifier.ml[22,503+4]..[22,503+22])
-          Ppat_var "float_with_modifer" (int_and_float_with_modifier.ml[22,503+4]..[22,503+22])
-        expression (int_and_float_with_modifier.ml[22,503+28]..[22,503+32])
+        pattern (int_and_float_with_modifier.ml[22+4]..[22+22])
+          Ppat_var "float_with_modifer" (int_and_float_with_modifier.ml[22+4]..[22+22])
+        expression (int_and_float_with_modifier.ml[22+28]..[22+32])
           Pexp_constant
-          constant (int_and_float_with_modifier.ml[22,503+28]..[22,503+32])
+          constant (int_and_float_with_modifier.ml[22+28]..[22+32])
             PConst_float (1.2,Some g)
     ]
 ]

--- a/testsuite/tests/parsing/pr6865.compilers.reference
+++ b/testsuite/tests/parsing/pr6865.compilers.reference
@@ -1,50 +1,50 @@
 [
-  structure_item (pr6865.ml[9,153+0]..[9,153+14]) ghost
+  structure_item (pr6865.ml[9+0]..[9+14]) ghost
     Pstr_extension "foo"
     [
-      structure_item (pr6865.ml[9,153+0]..[9,153+14])
+      structure_item (pr6865.ml[9+0]..[9+14])
         Pstr_value Nonrec
         [
           <def>
-            pattern (pr6865.ml[9,153+8]..[9,153+9])
-              Ppat_var "x" (pr6865.ml[9,153+8]..[9,153+9])
-            expression (pr6865.ml[9,153+12]..[9,153+14])
+            pattern (pr6865.ml[9+8]..[9+9])
+              Ppat_var "x" (pr6865.ml[9+8]..[9+9])
+            expression (pr6865.ml[9+12]..[9+14])
               Pexp_constant
-              constant (pr6865.ml[9,153+12]..[9,153+14])
+              constant (pr6865.ml[9+12]..[9+14])
                 PConst_int (42,None)
         ]
     ]
-  structure_item (pr6865.ml[10,168+0]..[10,168+25]) ghost
+  structure_item (pr6865.ml[10+0]..[10+25]) ghost
     Pstr_extension "foo"
     [
-      structure_item (pr6865.ml[10,168+0]..[10,168+25])
+      structure_item (pr6865.ml[10+0]..[10+25])
         Pstr_value Nonrec
         [
           <def>
-            pattern (pr6865.ml[10,168+8]..[10,168+9])
+            pattern (pr6865.ml[10+8]..[10+9])
               Ppat_any
-            expression (pr6865.ml[10,168+12]..[10,168+14])
-              Pexp_construct "()" (pr6865.ml[10,168+12]..[10,168+14])
+            expression (pr6865.ml[10+12]..[10+14])
+              Pexp_construct "()" (pr6865.ml[10+12]..[10+14])
               None
           <def>
-            pattern (pr6865.ml[10,168+19]..[10,168+20])
+            pattern (pr6865.ml[10+19]..[10+20])
               Ppat_any
-            expression (pr6865.ml[10,168+23]..[10,168+25])
-              Pexp_construct "()" (pr6865.ml[10,168+23]..[10,168+25])
+            expression (pr6865.ml[10+23]..[10+25])
+              Pexp_construct "()" (pr6865.ml[10+23]..[10+25])
               None
         ]
     ]
-  structure_item (pr6865.ml[11,194+0]..[11,194+14]) ghost
+  structure_item (pr6865.ml[11+0]..[11+14]) ghost
     Pstr_extension "foo"
     [
-      structure_item (pr6865.ml[11,194+0]..[11,194+14])
+      structure_item (pr6865.ml[11+0]..[11+14])
         Pstr_value Nonrec
         [
           <def>
-            pattern (pr6865.ml[11,194+8]..[11,194+9])
+            pattern (pr6865.ml[11+8]..[11+9])
               Ppat_any
-            expression (pr6865.ml[11,194+12]..[11,194+14])
-              Pexp_construct "()" (pr6865.ml[11,194+12]..[11,194+14])
+            expression (pr6865.ml[11+12]..[11+14])
+              Pexp_construct "()" (pr6865.ml[11+12]..[11+14])
               None
         ]
     ]

--- a/testsuite/tests/parsing/quotedextensions.compilers.reference
+++ b/testsuite/tests/parsing/quotedextensions.compilers.reference
@@ -1,174 +1,174 @@
 [
-  structure_item (quotedextensions.ml[10,170+0]..[10,170+23])
+  structure_item (quotedextensions.ml[10+0]..[10+23])
     Pstr_extension "M.foo"
     [
-      structure_item (quotedextensions.ml[10,170+0]..[10,170+23]) ghost
+      structure_item (quotedextensions.ml[10+0]..[10+23]) ghost
         Pstr_eval
-        expression (quotedextensions.ml[10,170+0]..[10,170+23]) ghost
+        expression (quotedextensions.ml[10+0]..[10+23]) ghost
           Pexp_constant
-          constant (quotedextensions.ml[10,170+9]..[10,170+21])
-            PConst_string (" <hello>{x} ",(quotedextensions.ml[10,170+9]..[10,170+21]),Some "")
+          constant (quotedextensions.ml[10+9]..[10+21])
+            PConst_string (" <hello>{x} ",(quotedextensions.ml[10+9]..[10+21]),Some "")
     ]
-  structure_item (quotedextensions.ml[11,194+0]..[11,194+25])
+  structure_item (quotedextensions.ml[11+0]..[11+25])
     Pstr_extension "M.foo"
     [
-      structure_item (quotedextensions.ml[11,194+0]..[11,194+25]) ghost
+      structure_item (quotedextensions.ml[11+0]..[11+25]) ghost
         Pstr_eval
-        expression (quotedextensions.ml[11,194+0]..[11,194+25]) ghost
+        expression (quotedextensions.ml[11+0]..[11+25]) ghost
           Pexp_constant
-          constant (quotedextensions.ml[11,194+11]..[11,194+23])
-            PConst_string (" <hello>{x} ",(quotedextensions.ml[11,194+11]..[11,194+23]),Some "")
+          constant (quotedextensions.ml[11+11]..[11+23])
+            PConst_string (" <hello>{x} ",(quotedextensions.ml[11+11]..[11+23]),Some "")
     ]
-  structure_item (quotedextensions.ml[12,220+0]..[12,220+32])
+  structure_item (quotedextensions.ml[12+0]..[12+32])
     Pstr_extension "M.foo"
     [
-      structure_item (quotedextensions.ml[12,220+0]..[12,220+32]) ghost
+      structure_item (quotedextensions.ml[12+0]..[12+32]) ghost
         Pstr_eval
-        expression (quotedextensions.ml[12,220+0]..[12,220+32]) ghost
+        expression (quotedextensions.ml[12+0]..[12+32]) ghost
           Pexp_constant
-          constant (quotedextensions.ml[12,220+13]..[12,220+27])
-            PConst_string (" <hello>{|x|} ",(quotedextensions.ml[12,220+13]..[12,220+27]),Some "bar")
+          constant (quotedextensions.ml[12+13]..[12+27])
+            PConst_string (" <hello>{|x|} ",(quotedextensions.ml[12+13]..[12+27]),Some "bar")
     ]
-  structure_item (quotedextensions.ml[15,271+0]..[18,352+3])
-    Pstr_modtype "S" (quotedextensions.ml[15,271+12]..[15,271+13])
-      module_type (quotedextensions.ml[15,271+16]..[18,352+3])
+  structure_item (quotedextensions.ml[15+0]..[18+3])
+    Pstr_modtype "S" (quotedextensions.ml[15+12]..[15+13])
+      module_type (quotedextensions.ml[15+16]..[18+3])
         Pmty_signature
         [
-          signature_item (quotedextensions.ml[16,291+2]..[16,291+25])
+          signature_item (quotedextensions.ml[16+2]..[16+25])
             Psig_extension "M.foo"
             [
-              structure_item (quotedextensions.ml[16,291+2]..[16,291+25]) ghost
+              structure_item (quotedextensions.ml[16+2]..[16+25]) ghost
                 Pstr_eval
-                expression (quotedextensions.ml[16,291+2]..[16,291+25]) ghost
+                expression (quotedextensions.ml[16+2]..[16+25]) ghost
                   Pexp_constant
-                  constant (quotedextensions.ml[16,291+11]..[16,291+23])
-                    PConst_string (" <hello>{x} ",(quotedextensions.ml[16,291+11]..[16,291+23]),Some "")
+                  constant (quotedextensions.ml[16+11]..[16+23])
+                    PConst_string (" <hello>{x} ",(quotedextensions.ml[16+11]..[16+23]),Some "")
             ]
-          signature_item (quotedextensions.ml[17,317+2]..[17,317+34])
+          signature_item (quotedextensions.ml[17+2]..[17+34])
             Psig_extension "M.foo"
             [
-              structure_item (quotedextensions.ml[17,317+2]..[17,317+34]) ghost
+              structure_item (quotedextensions.ml[17+2]..[17+34]) ghost
                 Pstr_eval
-                expression (quotedextensions.ml[17,317+2]..[17,317+34]) ghost
+                expression (quotedextensions.ml[17+2]..[17+34]) ghost
                   Pexp_constant
-                  constant (quotedextensions.ml[17,317+15]..[17,317+29])
-                    PConst_string (" <hello>{|x|} ",(quotedextensions.ml[17,317+15]..[17,317+29]),Some "bar")
+                  constant (quotedextensions.ml[17+15]..[17+29])
+                    PConst_string (" <hello>{|x|} ",(quotedextensions.ml[17+15]..[17+29]),Some "bar")
             ]
         ]
-  structure_item (quotedextensions.ml[21,389+0]..[23,443+26])
+  structure_item (quotedextensions.ml[21+0]..[23+26])
     Pstr_value Nonrec
     [
       <def>
-        pattern (quotedextensions.ml[21,389+4]..[21,389+26])
+        pattern (quotedextensions.ml[21+4]..[21+26])
           Ppat_extension "M.foo"
           [
-            structure_item (quotedextensions.ml[21,389+4]..[21,389+26]) ghost
+            structure_item (quotedextensions.ml[21+4]..[21+26]) ghost
               Pstr_eval
-              expression (quotedextensions.ml[21,389+4]..[21,389+26]) ghost
+              expression (quotedextensions.ml[21+4]..[21+26]) ghost
                 Pexp_constant
-                constant (quotedextensions.ml[21,389+12]..[21,389+24])
-                  PConst_string (" <hello>{x} ",(quotedextensions.ml[21,389+12]..[21,389+24]),Some "")
+                constant (quotedextensions.ml[21+12]..[21+24])
+                  PConst_string (" <hello>{x} ",(quotedextensions.ml[21+12]..[21+24]),Some "")
           ]
-        core_type (quotedextensions.ml[22,416+4]..[22,416+26])
+        core_type (quotedextensions.ml[22+4]..[22+26])
           Ptyp_extension "M.foo"
           [
-            structure_item (quotedextensions.ml[22,416+4]..[22,416+26]) ghost
+            structure_item (quotedextensions.ml[22+4]..[22+26]) ghost
               Pstr_eval
-              expression (quotedextensions.ml[22,416+4]..[22,416+26]) ghost
+              expression (quotedextensions.ml[22+4]..[22+26]) ghost
                 Pexp_constant
-                constant (quotedextensions.ml[22,416+12]..[22,416+24])
-                  PConst_string (" <hello>{x} ",(quotedextensions.ml[22,416+12]..[22,416+24]),Some "")
+                constant (quotedextensions.ml[22+12]..[22+24])
+                  PConst_string (" <hello>{x} ",(quotedextensions.ml[22+12]..[22+24]),Some "")
           ]
-        expression (quotedextensions.ml[23,443+4]..[23,443+26])
+        expression (quotedextensions.ml[23+4]..[23+26])
           Pexp_extension "M.foo"
           [
-            structure_item (quotedextensions.ml[23,443+4]..[23,443+26]) ghost
+            structure_item (quotedextensions.ml[23+4]..[23+26]) ghost
               Pstr_eval
-              expression (quotedextensions.ml[23,443+4]..[23,443+26]) ghost
+              expression (quotedextensions.ml[23+4]..[23+26]) ghost
                 Pexp_constant
-                constant (quotedextensions.ml[23,443+12]..[23,443+24])
-                  PConst_string (" <hello>{x} ",(quotedextensions.ml[23,443+12]..[23,443+24]),Some "")
+                constant (quotedextensions.ml[23+12]..[23+24])
+                  PConst_string (" <hello>{x} ",(quotedextensions.ml[23+12]..[23+24]),Some "")
           ]
     ]
-  structure_item (quotedextensions.ml[24,470+0]..[26,542+35])
+  structure_item (quotedextensions.ml[24+0]..[26+35])
     Pstr_value Nonrec
     [
       <def>
-        pattern (quotedextensions.ml[24,470+4]..[24,470+35])
+        pattern (quotedextensions.ml[24+4]..[24+35])
           Ppat_extension "M.foo"
           [
-            structure_item (quotedextensions.ml[24,470+4]..[24,470+35]) ghost
+            structure_item (quotedextensions.ml[24+4]..[24+35]) ghost
               Pstr_eval
-              expression (quotedextensions.ml[24,470+4]..[24,470+35]) ghost
+              expression (quotedextensions.ml[24+4]..[24+35]) ghost
                 Pexp_constant
-                constant (quotedextensions.ml[24,470+16]..[24,470+30])
-                  PConst_string (" <hello>{|x|} ",(quotedextensions.ml[24,470+16]..[24,470+30]),Some "bar")
+                constant (quotedextensions.ml[24+16]..[24+30])
+                  PConst_string (" <hello>{|x|} ",(quotedextensions.ml[24+16]..[24+30]),Some "bar")
           ]
-        core_type (quotedextensions.ml[25,506+4]..[25,506+35])
+        core_type (quotedextensions.ml[25+4]..[25+35])
           Ptyp_extension "M.foo"
           [
-            structure_item (quotedextensions.ml[25,506+4]..[25,506+35]) ghost
+            structure_item (quotedextensions.ml[25+4]..[25+35]) ghost
               Pstr_eval
-              expression (quotedextensions.ml[25,506+4]..[25,506+35]) ghost
+              expression (quotedextensions.ml[25+4]..[25+35]) ghost
                 Pexp_constant
-                constant (quotedextensions.ml[25,506+16]..[25,506+30])
-                  PConst_string (" <hello>{|x|} ",(quotedextensions.ml[25,506+16]..[25,506+30]),Some "bar")
+                constant (quotedextensions.ml[25+16]..[25+30])
+                  PConst_string (" <hello>{|x|} ",(quotedextensions.ml[25+16]..[25+30]),Some "bar")
           ]
-        expression (quotedextensions.ml[26,542+4]..[26,542+35])
+        expression (quotedextensions.ml[26+4]..[26+35])
           Pexp_extension "M.foo"
           [
-            structure_item (quotedextensions.ml[26,542+4]..[26,542+35]) ghost
+            structure_item (quotedextensions.ml[26+4]..[26+35]) ghost
               Pstr_eval
-              expression (quotedextensions.ml[26,542+4]..[26,542+35]) ghost
+              expression (quotedextensions.ml[26+4]..[26+35]) ghost
                 Pexp_constant
-                constant (quotedextensions.ml[26,542+16]..[26,542+30])
-                  PConst_string (" <hello>{|x|} ",(quotedextensions.ml[26,542+16]..[26,542+30]),Some "bar")
+                constant (quotedextensions.ml[26+16]..[26+30])
+                  PConst_string (" <hello>{|x|} ",(quotedextensions.ml[26+16]..[26+30]),Some "bar")
           ]
     ]
-  structure_item (quotedextensions.ml[28,579+0]..[30,643+31])
+  structure_item (quotedextensions.ml[28+0]..[30+31])
     Pstr_value Nonrec
     [
       <def>
-        pattern (quotedextensions.ml[28,579+4]..[28,579+31])
+        pattern (quotedextensions.ml[28+4]..[28+31])
           Ppat_extension "M.foo"
           [
-            structure_item (quotedextensions.ml[28,579+4]..[28,579+31]) ghost
+            structure_item (quotedextensions.ml[28+4]..[28+31]) ghost
               Pstr_eval
-              expression (quotedextensions.ml[28,579+4]..[28,579+31]) ghost
+              expression (quotedextensions.ml[28+4]..[28+31]) ghost
                 Pexp_constant
-                constant (quotedextensions.ml[28,579+13]..[28,579+29])
-                  PConst_string (" <hello>{u|x|u} ",(quotedextensions.ml[28,579+13]..[28,579+29]),Some "")
+                constant (quotedextensions.ml[28+13]..[28+29])
+                  PConst_string (" <hello>{u|x|u} ",(quotedextensions.ml[28+13]..[28+29]),Some "")
           ]
-        core_type (quotedextensions.ml[29,611+4]..[29,611+31])
+        core_type (quotedextensions.ml[29+4]..[29+31])
           Ptyp_extension "M.foo"
           [
-            structure_item (quotedextensions.ml[29,611+4]..[29,611+31]) ghost
+            structure_item (quotedextensions.ml[29+4]..[29+31]) ghost
               Pstr_eval
-              expression (quotedextensions.ml[29,611+4]..[29,611+31]) ghost
+              expression (quotedextensions.ml[29+4]..[29+31]) ghost
                 Pexp_constant
-                constant (quotedextensions.ml[29,611+13]..[29,611+29])
-                  PConst_string (" <hello>{u|x|u} ",(quotedextensions.ml[29,611+13]..[29,611+29]),Some "")
+                constant (quotedextensions.ml[29+13]..[29+29])
+                  PConst_string (" <hello>{u|x|u} ",(quotedextensions.ml[29+13]..[29+29]),Some "")
           ]
-        expression (quotedextensions.ml[30,643+4]..[30,643+31])
+        expression (quotedextensions.ml[30+4]..[30+31])
           Pexp_extension "M.foo"
           [
-            structure_item (quotedextensions.ml[30,643+4]..[30,643+31]) ghost
+            structure_item (quotedextensions.ml[30+4]..[30+31]) ghost
               Pstr_eval
-              expression (quotedextensions.ml[30,643+4]..[30,643+31]) ghost
+              expression (quotedextensions.ml[30+4]..[30+31]) ghost
                 Pexp_constant
-                constant (quotedextensions.ml[30,643+13]..[30,643+29])
-                  PConst_string (" <hello>{u|x|u} ",(quotedextensions.ml[30,643+13]..[30,643+29]),Some "")
+                constant (quotedextensions.ml[30+13]..[30+29])
+                  PConst_string (" <hello>{u|x|u} ",(quotedextensions.ml[30+13]..[30+29]),Some "")
           ]
     ]
-  structure_item (quotedextensions.ml[34,693+0]..[38,729+2])
+  structure_item (quotedextensions.ml[34+0]..[38+2])
     Pstr_extension "M.foo"
     [
-      structure_item (quotedextensions.ml[34,693+0]..[38,729+2]) ghost
+      structure_item (quotedextensions.ml[34+0]..[38+2]) ghost
         Pstr_eval
-        expression (quotedextensions.ml[34,693+0]..[38,729+2]) ghost
+        expression (quotedextensions.ml[34+0]..[38+2]) ghost
           Pexp_constant
-          constant (quotedextensions.ml[34,693+9]..[38,729+0])
-            PConst_string ("\n <hello>\n   {x}\n </hello>\n",(quotedextensions.ml[34,693+9]..[38,729+0]),Some "")
+          constant (quotedextensions.ml[34+9]..[38+0])
+            PConst_string ("\n <hello>\n   {x}\n </hello>\n",(quotedextensions.ml[34+9]..[38+0]),Some "")
     ]
 ]
 

--- a/testsuite/tests/parsing/shortcut_ext_attr.compilers.reference
+++ b/testsuite/tests/parsing/shortcut_ext_attr.compilers.reference
@@ -1,520 +1,520 @@
 [
-  structure_item (shortcut_ext_attr.ml[9,170+0]..[30,721+31])
+  structure_item (shortcut_ext_attr.ml[9+0]..[30+31])
     Pstr_value Nonrec
     [
       <def>
-        pattern (shortcut_ext_attr.ml[9,170+4]..[9,170+6])
-          Ppat_construct "()" (shortcut_ext_attr.ml[9,170+4]..[9,170+6])
+        pattern (shortcut_ext_attr.ml[9+4]..[9+6])
+          Ppat_construct "()" (shortcut_ext_attr.ml[9+4]..[9+6])
           None
-        expression (shortcut_ext_attr.ml[10,179+2]..[30,721+31])
+        expression (shortcut_ext_attr.ml[10+2]..[30+31])
           Pexp_extension "foo"
           [
-            structure_item (shortcut_ext_attr.ml[10,179+2]..[30,721+31]) ghost
+            structure_item (shortcut_ext_attr.ml[10+2]..[30+31]) ghost
               Pstr_eval
-              expression (shortcut_ext_attr.ml[10,179+2]..[30,721+31]) ghost
+              expression (shortcut_ext_attr.ml[10+2]..[30+31]) ghost
                 Pexp_let Nonrec
                 [
                   <def>
                       attribute "foo"
                         []
-                    pattern (shortcut_ext_attr.ml[10,179+16]..[10,179+17])
-                      Ppat_var "x" (shortcut_ext_attr.ml[10,179+16]..[10,179+17])
-                    expression (shortcut_ext_attr.ml[10,179+20]..[10,179+21])
+                    pattern (shortcut_ext_attr.ml[10+16]..[10+17])
+                      Ppat_var "x" (shortcut_ext_attr.ml[10+16]..[10+17])
+                    expression (shortcut_ext_attr.ml[10+20]..[10+21])
                       Pexp_constant
-                      constant (shortcut_ext_attr.ml[10,179+20]..[10,179+21])
+                      constant (shortcut_ext_attr.ml[10+20]..[10+21])
                         PConst_int (3,None)
                   <def>
                       attribute "foo"
                         []
-                    pattern (shortcut_ext_attr.ml[11,201+12]..[11,201+13])
-                      Ppat_var "y" (shortcut_ext_attr.ml[11,201+12]..[11,201+13])
-                    expression (shortcut_ext_attr.ml[11,201+16]..[11,201+17])
+                    pattern (shortcut_ext_attr.ml[11+12]..[11+13])
+                      Ppat_var "y" (shortcut_ext_attr.ml[11+12]..[11+13])
+                    expression (shortcut_ext_attr.ml[11+16]..[11+17])
                       Pexp_constant
-                      constant (shortcut_ext_attr.ml[11,201+16]..[11,201+17])
+                      constant (shortcut_ext_attr.ml[11+16]..[11+17])
                         PConst_int (4,None)
                 ]
-                expression (shortcut_ext_attr.ml[12,222+2]..[30,721+31])
+                expression (shortcut_ext_attr.ml[12+2]..[30+31])
                   Pexp_sequence
-                  expression (shortcut_ext_attr.ml[12,222+2]..[12,222+36])
+                  expression (shortcut_ext_attr.ml[12+2]..[12+36])
                     Pexp_struct_item
-                    structure_item (shortcut_ext_attr.ml[12,222+7]..[12,222+29])
+                    structure_item (shortcut_ext_attr.ml[12+7]..[12+29])
                       Pstr_extension "foo"
                       [
-                        structure_item (shortcut_ext_attr.ml[12,222+7]..[12,222+29]) ghost
+                        structure_item (shortcut_ext_attr.ml[12+7]..[12+29]) ghost
                           Pstr_module
-                          "M" (shortcut_ext_attr.ml[12,222+24]..[12,222+25])
+                          "M" (shortcut_ext_attr.ml[12+24]..[12+25])
                             attribute "foo"
                               []
-                            module_expr (shortcut_ext_attr.ml[12,222+28]..[12,222+29])
-                              Pmod_ident "M" (shortcut_ext_attr.ml[12,222+28]..[12,222+29])
+                            module_expr (shortcut_ext_attr.ml[12+28]..[12+29])
+                              Pmod_ident "M" (shortcut_ext_attr.ml[12+28]..[12+29])
                       ]
-                    expression (shortcut_ext_attr.ml[12,222+33]..[12,222+35])
-                      Pexp_construct "()" (shortcut_ext_attr.ml[12,222+33]..[12,222+35])
+                    expression (shortcut_ext_attr.ml[12+33]..[12+35])
+                      Pexp_construct "()" (shortcut_ext_attr.ml[12+33]..[12+35])
                       None
-                  expression (shortcut_ext_attr.ml[13,261+2]..[30,721+31])
+                  expression (shortcut_ext_attr.ml[13+2]..[30+31])
                     Pexp_sequence
-                    expression (shortcut_ext_attr.ml[13,261+2]..[13,261+30])
+                    expression (shortcut_ext_attr.ml[13+2]..[13+30])
                       Pexp_struct_item
-                      structure_item (shortcut_ext_attr.ml[13,261+7]..[13,261+23])
+                      structure_item (shortcut_ext_attr.ml[13+7]..[13+23])
                         Pstr_extension "foo"
                         [
-                          structure_item (shortcut_ext_attr.ml[13,261+7]..[13,261+23]) ghost
+                          structure_item (shortcut_ext_attr.ml[13+7]..[13+23]) ghost
                             Pstr_open Fresh
-                            module_expr (shortcut_ext_attr.ml[13,261+22]..[13,261+23])
-                              Pmod_ident "M" (shortcut_ext_attr.ml[13,261+22]..[13,261+23])
+                            module_expr (shortcut_ext_attr.ml[13+22]..[13+23])
+                              Pmod_ident "M" (shortcut_ext_attr.ml[13+22]..[13+23])
                               attribute "foo"
                                 []
                         ]
-                      expression (shortcut_ext_attr.ml[13,261+27]..[13,261+29])
-                        Pexp_construct "()" (shortcut_ext_attr.ml[13,261+27]..[13,261+29])
+                      expression (shortcut_ext_attr.ml[13+27]..[13+29])
+                        Pexp_construct "()" (shortcut_ext_attr.ml[13+27]..[13+29])
                         None
-                    expression (shortcut_ext_attr.ml[14,294+2]..[30,721+31])
+                    expression (shortcut_ext_attr.ml[14+2]..[30+31])
                       Pexp_sequence
-                      expression (shortcut_ext_attr.ml[14,294+2]..[14,294+25])
+                      expression (shortcut_ext_attr.ml[14+2]..[14+25])
                         Pexp_extension "foo"
                         [
-                          structure_item (shortcut_ext_attr.ml[14,294+3]..[14,294+24]) ghost
+                          structure_item (shortcut_ext_attr.ml[14+3]..[14+24]) ghost
                             Pstr_eval
-                            expression (shortcut_ext_attr.ml[14,294+3]..[14,294+24]) ghost
+                            expression (shortcut_ext_attr.ml[14+3]..[14+24]) ghost
                               attribute "foo"
                                 []
                               Pexp_function
                               [
-                                Pparam_val (shortcut_ext_attr.ml[14,294+17]..[14,294+18])
+                                Pparam_val (shortcut_ext_attr.ml[14+17]..[14+18])
                                   Nolabel
                                   None
-                                  pattern (shortcut_ext_attr.ml[14,294+17]..[14,294+18])
-                                    Ppat_var "x" (shortcut_ext_attr.ml[14,294+17]..[14,294+18])
+                                  pattern (shortcut_ext_attr.ml[14+17]..[14+18])
+                                    Ppat_var "x" (shortcut_ext_attr.ml[14+17]..[14+18])
                               ]
                               None
                               Pfunction_body
-                                expression (shortcut_ext_attr.ml[14,294+22]..[14,294+24])
-                                  Pexp_construct "()" (shortcut_ext_attr.ml[14,294+22]..[14,294+24])
+                                expression (shortcut_ext_attr.ml[14+22]..[14+24])
+                                  Pexp_construct "()" (shortcut_ext_attr.ml[14+22]..[14+24])
                                   None
                         ]
-                      expression (shortcut_ext_attr.ml[15,322+2]..[30,721+31])
+                      expression (shortcut_ext_attr.ml[15+2]..[30+31])
                         Pexp_sequence
-                        expression (shortcut_ext_attr.ml[15,322+2]..[15,322+30])
+                        expression (shortcut_ext_attr.ml[15+2]..[15+30])
                           Pexp_extension "foo"
                           [
-                            structure_item (shortcut_ext_attr.ml[15,322+3]..[15,322+29]) ghost
+                            structure_item (shortcut_ext_attr.ml[15+3]..[15+29]) ghost
                               Pstr_eval
-                              expression (shortcut_ext_attr.ml[15,322+3]..[15,322+29]) ghost
+                              expression (shortcut_ext_attr.ml[15+3]..[15+29]) ghost
                                 attribute "foo"
                                   []
                                 Pexp_function
                                 []
                                 None
-                                Pfunction_cases (shortcut_ext_attr.ml[15,322+3]..[15,322+29])
+                                Pfunction_cases (shortcut_ext_attr.ml[15+3]..[15+29])
                                   [
                                     <case>
-                                      pattern (shortcut_ext_attr.ml[15,322+22]..[15,322+23])
-                                        Ppat_var "x" (shortcut_ext_attr.ml[15,322+22]..[15,322+23])
-                                      expression (shortcut_ext_attr.ml[15,322+27]..[15,322+29])
-                                        Pexp_construct "()" (shortcut_ext_attr.ml[15,322+27]..[15,322+29])
+                                      pattern (shortcut_ext_attr.ml[15+22]..[15+23])
+                                        Ppat_var "x" (shortcut_ext_attr.ml[15+22]..[15+23])
+                                      expression (shortcut_ext_attr.ml[15+27]..[15+29])
+                                        Pexp_construct "()" (shortcut_ext_attr.ml[15+27]..[15+29])
                                         None
                                   ]
                           ]
-                        expression (shortcut_ext_attr.ml[16,355+2]..[30,721+31])
+                        expression (shortcut_ext_attr.ml[16+2]..[30+31])
                           Pexp_sequence
-                          expression (shortcut_ext_attr.ml[16,355+2]..[16,355+33])
+                          expression (shortcut_ext_attr.ml[16+2]..[16+33])
                             Pexp_extension "foo"
                             [
-                              structure_item (shortcut_ext_attr.ml[16,355+3]..[16,355+32]) ghost
+                              structure_item (shortcut_ext_attr.ml[16+3]..[16+32]) ghost
                                 Pstr_eval
-                                expression (shortcut_ext_attr.ml[16,355+3]..[16,355+32]) ghost
+                                expression (shortcut_ext_attr.ml[16+3]..[16+32]) ghost
                                   attribute "foo"
                                     []
                                   Pexp_try
-                                  expression (shortcut_ext_attr.ml[16,355+17]..[16,355+19])
-                                    Pexp_construct "()" (shortcut_ext_attr.ml[16,355+17]..[16,355+19])
+                                  expression (shortcut_ext_attr.ml[16+17]..[16+19])
+                                    Pexp_construct "()" (shortcut_ext_attr.ml[16+17]..[16+19])
                                     None
                                   [
                                     <case>
-                                      pattern (shortcut_ext_attr.ml[16,355+25]..[16,355+26])
+                                      pattern (shortcut_ext_attr.ml[16+25]..[16+26])
                                         Ppat_any
-                                      expression (shortcut_ext_attr.ml[16,355+30]..[16,355+32])
-                                        Pexp_construct "()" (shortcut_ext_attr.ml[16,355+30]..[16,355+32])
+                                      expression (shortcut_ext_attr.ml[16+30]..[16+32])
+                                        Pexp_construct "()" (shortcut_ext_attr.ml[16+30]..[16+32])
                                         None
                                   ]
                             ]
-                          expression (shortcut_ext_attr.ml[17,391+2]..[30,721+31])
+                          expression (shortcut_ext_attr.ml[17+2]..[30+31])
                             Pexp_sequence
-                            expression (shortcut_ext_attr.ml[17,391+2]..[17,391+35])
+                            expression (shortcut_ext_attr.ml[17+2]..[17+35])
                               Pexp_extension "foo"
                               [
-                                structure_item (shortcut_ext_attr.ml[17,391+3]..[17,391+34]) ghost
+                                structure_item (shortcut_ext_attr.ml[17+3]..[17+34]) ghost
                                   Pstr_eval
-                                  expression (shortcut_ext_attr.ml[17,391+3]..[17,391+34]) ghost
+                                  expression (shortcut_ext_attr.ml[17+3]..[17+34]) ghost
                                     attribute "foo"
                                       []
                                     Pexp_ifthenelse
-                                    expression (shortcut_ext_attr.ml[17,391+16]..[17,391+18])
-                                      Pexp_construct "()" (shortcut_ext_attr.ml[17,391+16]..[17,391+18])
+                                    expression (shortcut_ext_attr.ml[17+16]..[17+18])
+                                      Pexp_construct "()" (shortcut_ext_attr.ml[17+16]..[17+18])
                                       None
-                                    expression (shortcut_ext_attr.ml[17,391+24]..[17,391+26])
-                                      Pexp_construct "()" (shortcut_ext_attr.ml[17,391+24]..[17,391+26])
+                                    expression (shortcut_ext_attr.ml[17+24]..[17+26])
+                                      Pexp_construct "()" (shortcut_ext_attr.ml[17+24]..[17+26])
                                       None
                                     Some
-                                      expression (shortcut_ext_attr.ml[17,391+32]..[17,391+34])
-                                        Pexp_construct "()" (shortcut_ext_attr.ml[17,391+32]..[17,391+34])
+                                      expression (shortcut_ext_attr.ml[17+32]..[17+34])
+                                        Pexp_construct "()" (shortcut_ext_attr.ml[17+32]..[17+34])
                                         None
                               ]
-                            expression (shortcut_ext_attr.ml[18,429+2]..[30,721+31])
+                            expression (shortcut_ext_attr.ml[18+2]..[30+31])
                               Pexp_sequence
-                              expression (shortcut_ext_attr.ml[18,429+2]..[18,429+31])
+                              expression (shortcut_ext_attr.ml[18+2]..[18+31])
                                 Pexp_extension "foo"
                                 [
-                                  structure_item (shortcut_ext_attr.ml[18,429+2]..[18,429+31]) ghost
+                                  structure_item (shortcut_ext_attr.ml[18+2]..[18+31]) ghost
                                     Pstr_eval
-                                    expression (shortcut_ext_attr.ml[18,429+2]..[18,429+31]) ghost
+                                    expression (shortcut_ext_attr.ml[18+2]..[18+31]) ghost
                                       attribute "foo"
                                         []
                                       Pexp_while
-                                      expression (shortcut_ext_attr.ml[18,429+18]..[18,429+20])
-                                        Pexp_construct "()" (shortcut_ext_attr.ml[18,429+18]..[18,429+20])
+                                      expression (shortcut_ext_attr.ml[18+18]..[18+20])
+                                        Pexp_construct "()" (shortcut_ext_attr.ml[18+18]..[18+20])
                                         None
-                                      expression (shortcut_ext_attr.ml[18,429+24]..[18,429+26])
-                                        Pexp_construct "()" (shortcut_ext_attr.ml[18,429+24]..[18,429+26])
+                                      expression (shortcut_ext_attr.ml[18+24]..[18+26])
+                                        Pexp_construct "()" (shortcut_ext_attr.ml[18+24]..[18+26])
                                         None
                                 ]
-                              expression (shortcut_ext_attr.ml[19,463+2]..[30,721+31])
+                              expression (shortcut_ext_attr.ml[19+2]..[30+31])
                                 Pexp_sequence
-                                expression (shortcut_ext_attr.ml[19,463+2]..[19,463+39])
+                                expression (shortcut_ext_attr.ml[19+2]..[19+39])
                                   Pexp_extension "foo"
                                   [
-                                    structure_item (shortcut_ext_attr.ml[19,463+2]..[19,463+39]) ghost
+                                    structure_item (shortcut_ext_attr.ml[19+2]..[19+39]) ghost
                                       Pstr_eval
-                                      expression (shortcut_ext_attr.ml[19,463+2]..[19,463+39]) ghost
+                                      expression (shortcut_ext_attr.ml[19+2]..[19+39]) ghost
                                         attribute "foo"
                                           []
                                         Pexp_for Up
-                                        pattern (shortcut_ext_attr.ml[19,463+16]..[19,463+17])
-                                          Ppat_var "x" (shortcut_ext_attr.ml[19,463+16]..[19,463+17])
-                                        expression (shortcut_ext_attr.ml[19,463+20]..[19,463+22])
-                                          Pexp_construct "()" (shortcut_ext_attr.ml[19,463+20]..[19,463+22])
+                                        pattern (shortcut_ext_attr.ml[19+16]..[19+17])
+                                          Ppat_var "x" (shortcut_ext_attr.ml[19+16]..[19+17])
+                                        expression (shortcut_ext_attr.ml[19+20]..[19+22])
+                                          Pexp_construct "()" (shortcut_ext_attr.ml[19+20]..[19+22])
                                           None
-                                        expression (shortcut_ext_attr.ml[19,463+26]..[19,463+28])
-                                          Pexp_construct "()" (shortcut_ext_attr.ml[19,463+26]..[19,463+28])
+                                        expression (shortcut_ext_attr.ml[19+26]..[19+28])
+                                          Pexp_construct "()" (shortcut_ext_attr.ml[19+26]..[19+28])
                                           None
-                                        expression (shortcut_ext_attr.ml[19,463+32]..[19,463+34])
-                                          Pexp_construct "()" (shortcut_ext_attr.ml[19,463+32]..[19,463+34])
+                                        expression (shortcut_ext_attr.ml[19+32]..[19+34])
+                                          Pexp_construct "()" (shortcut_ext_attr.ml[19+32]..[19+34])
                                           None
                                   ]
-                                expression (shortcut_ext_attr.ml[20,505+2]..[30,721+31])
+                                expression (shortcut_ext_attr.ml[20+2]..[30+31])
                                   Pexp_extension "foo"
                                   [
-                                    structure_item (shortcut_ext_attr.ml[20,505+2]..[30,721+31]) ghost
+                                    structure_item (shortcut_ext_attr.ml[20+2]..[30+31]) ghost
                                       Pstr_eval
-                                      expression (shortcut_ext_attr.ml[20,505+2]..[30,721+31]) ghost
+                                      expression (shortcut_ext_attr.ml[20+2]..[30+31]) ghost
                                         Pexp_sequence
-                                        expression (shortcut_ext_attr.ml[20,505+2]..[20,505+4])
-                                          Pexp_construct "()" (shortcut_ext_attr.ml[20,505+2]..[20,505+4])
+                                        expression (shortcut_ext_attr.ml[20+2]..[20+4])
+                                          Pexp_construct "()" (shortcut_ext_attr.ml[20+2]..[20+4])
                                           None
-                                        expression (shortcut_ext_attr.ml[20,505+11]..[30,721+31])
+                                        expression (shortcut_ext_attr.ml[20+11]..[30+31])
                                           Pexp_sequence
-                                          expression (shortcut_ext_attr.ml[20,505+11]..[20,505+13])
-                                            Pexp_construct "()" (shortcut_ext_attr.ml[20,505+11]..[20,505+13])
+                                          expression (shortcut_ext_attr.ml[20+11]..[20+13])
+                                            Pexp_construct "()" (shortcut_ext_attr.ml[20+11]..[20+13])
                                             None
-                                          expression (shortcut_ext_attr.ml[21,521+2]..[30,721+31])
+                                          expression (shortcut_ext_attr.ml[21+2]..[30+31])
                                             Pexp_sequence
-                                            expression (shortcut_ext_attr.ml[21,521+2]..[21,521+23])
+                                            expression (shortcut_ext_attr.ml[21+2]..[21+23])
                                               Pexp_extension "foo"
                                               [
-                                                structure_item (shortcut_ext_attr.ml[21,521+2]..[21,521+23]) ghost
+                                                structure_item (shortcut_ext_attr.ml[21+2]..[21+23]) ghost
                                                   Pstr_eval
-                                                  expression (shortcut_ext_attr.ml[21,521+2]..[21,521+23]) ghost
+                                                  expression (shortcut_ext_attr.ml[21+2]..[21+23]) ghost
                                                     attribute "foo"
                                                       []
                                                     Pexp_assert
-                                                    expression (shortcut_ext_attr.ml[21,521+19]..[21,521+23])
-                                                      Pexp_construct "true" (shortcut_ext_attr.ml[21,521+19]..[21,521+23])
+                                                    expression (shortcut_ext_attr.ml[21+19]..[21+23])
+                                                      Pexp_construct "true" (shortcut_ext_attr.ml[21+19]..[21+23])
                                                       None
                                               ]
-                                            expression (shortcut_ext_attr.ml[22,547+2]..[30,721+31])
+                                            expression (shortcut_ext_attr.ml[22+2]..[30+31])
                                               Pexp_sequence
-                                              expression (shortcut_ext_attr.ml[22,547+2]..[22,547+18])
+                                              expression (shortcut_ext_attr.ml[22+2]..[22+18])
                                                 Pexp_extension "foo"
                                                 [
-                                                  structure_item (shortcut_ext_attr.ml[22,547+2]..[22,547+18]) ghost
+                                                  structure_item (shortcut_ext_attr.ml[22+2]..[22+18]) ghost
                                                     Pstr_eval
-                                                    expression (shortcut_ext_attr.ml[22,547+2]..[22,547+18]) ghost
+                                                    expression (shortcut_ext_attr.ml[22+2]..[22+18]) ghost
                                                       attribute "foo"
                                                         []
                                                       Pexp_lazy
-                                                      expression (shortcut_ext_attr.ml[22,547+17]..[22,547+18])
-                                                        Pexp_ident "x" (shortcut_ext_attr.ml[22,547+17]..[22,547+18])
+                                                      expression (shortcut_ext_attr.ml[22+17]..[22+18])
+                                                        Pexp_ident "x" (shortcut_ext_attr.ml[22+17]..[22+18])
                                                 ]
-                                              expression (shortcut_ext_attr.ml[23,568+2]..[30,721+31])
+                                              expression (shortcut_ext_attr.ml[23+2]..[30+31])
                                                 Pexp_sequence
-                                                expression (shortcut_ext_attr.ml[23,568+2]..[23,568+22])
+                                                expression (shortcut_ext_attr.ml[23+2]..[23+22])
                                                   Pexp_extension "foo"
                                                   [
-                                                    structure_item (shortcut_ext_attr.ml[23,568+2]..[23,568+22]) ghost
+                                                    structure_item (shortcut_ext_attr.ml[23+2]..[23+22]) ghost
                                                       Pstr_eval
-                                                      expression (shortcut_ext_attr.ml[23,568+2]..[23,568+22]) ghost
+                                                      expression (shortcut_ext_attr.ml[23+2]..[23+22]) ghost
                                                         attribute "foo"
                                                           []
                                                         Pexp_object
                                                         class_structure
-                                                          pattern (shortcut_ext_attr.ml[23,568+18]..[23,568+18]) ghost
+                                                          pattern (shortcut_ext_attr.ml[23+18]..[23+18]) ghost
                                                             Ppat_any
                                                           []
                                                   ]
-                                                expression (shortcut_ext_attr.ml[24,593+2]..[30,721+31])
+                                                expression (shortcut_ext_attr.ml[24+2]..[30+31])
                                                   Pexp_sequence
-                                                  expression (shortcut_ext_attr.ml[24,593+2]..[24,593+23])
+                                                  expression (shortcut_ext_attr.ml[24+2]..[24+23])
                                                     Pexp_extension "foo"
                                                     [
-                                                      structure_item (shortcut_ext_attr.ml[24,593+2]..[24,593+23]) ghost
+                                                      structure_item (shortcut_ext_attr.ml[24+2]..[24+23]) ghost
                                                         Pstr_eval
-                                                        expression (shortcut_ext_attr.ml[24,593+2]..[24,593+23]) ghost
+                                                        expression (shortcut_ext_attr.ml[24+2]..[24+23]) ghost
                                                           attribute "foo"
                                                             []
                                                           Pexp_constant
-                                                          constant (shortcut_ext_attr.ml[24,593+18]..[24,593+19])
+                                                          constant (shortcut_ext_attr.ml[24+18]..[24+19])
                                                             PConst_int (3,None)
                                                     ]
-                                                  expression (shortcut_ext_attr.ml[25,619+2]..[30,721+31])
+                                                  expression (shortcut_ext_attr.ml[25+2]..[30+31])
                                                     Pexp_sequence
-                                                    expression (shortcut_ext_attr.ml[25,619+2]..[25,619+17])
+                                                    expression (shortcut_ext_attr.ml[25+2]..[25+17])
                                                       Pexp_extension "foo"
                                                       [
-                                                        structure_item (shortcut_ext_attr.ml[25,619+2]..[25,619+17]) ghost
+                                                        structure_item (shortcut_ext_attr.ml[25+2]..[25+17]) ghost
                                                           Pstr_eval
-                                                          expression (shortcut_ext_attr.ml[25,619+2]..[25,619+17]) ghost
+                                                          expression (shortcut_ext_attr.ml[25+2]..[25+17]) ghost
                                                             attribute "foo"
                                                               []
-                                                            Pexp_new "x" (shortcut_ext_attr.ml[25,619+16]..[25,619+17])
+                                                            Pexp_new "x" (shortcut_ext_attr.ml[25+16]..[25+17])
                                                       ]
-                                                    expression (shortcut_ext_attr.ml[27,640+2]..[30,721+31])
+                                                    expression (shortcut_ext_attr.ml[27+2]..[30+31])
                                                       Pexp_extension "foo"
                                                       [
-                                                        structure_item (shortcut_ext_attr.ml[27,640+2]..[30,721+31]) ghost
+                                                        structure_item (shortcut_ext_attr.ml[27+2]..[30+31]) ghost
                                                           Pstr_eval
-                                                          expression (shortcut_ext_attr.ml[27,640+2]..[30,721+31]) ghost
+                                                          expression (shortcut_ext_attr.ml[27+2]..[30+31]) ghost
                                                             attribute "foo"
                                                               []
                                                             Pexp_match
-                                                            expression (shortcut_ext_attr.ml[27,640+18]..[27,640+20])
-                                                              Pexp_construct "()" (shortcut_ext_attr.ml[27,640+18]..[27,640+20])
+                                                            expression (shortcut_ext_attr.ml[27+18]..[27+20])
+                                                              Pexp_construct "()" (shortcut_ext_attr.ml[27+18]..[27+20])
                                                               None
                                                             [
                                                               <case>
-                                                                pattern (shortcut_ext_attr.ml[29,694+4]..[29,694+20])
+                                                                pattern (shortcut_ext_attr.ml[29+4]..[29+20])
                                                                   Ppat_extension "foo"
-                                                                  pattern (shortcut_ext_attr.ml[29,694+4]..[29,694+20]) ghost
+                                                                  pattern (shortcut_ext_attr.ml[29+4]..[29+20]) ghost
                                                                     attribute "foo"
                                                                       []
                                                                     Ppat_lazy
-                                                                    pattern (shortcut_ext_attr.ml[29,694+19]..[29,694+20])
-                                                                      Ppat_var "x" (shortcut_ext_attr.ml[29,694+19]..[29,694+20])
-                                                                expression (shortcut_ext_attr.ml[29,694+24]..[29,694+26])
-                                                                  Pexp_construct "()" (shortcut_ext_attr.ml[29,694+24]..[29,694+26])
+                                                                    pattern (shortcut_ext_attr.ml[29+19]..[29+20])
+                                                                      Ppat_var "x" (shortcut_ext_attr.ml[29+19]..[29+20])
+                                                                expression (shortcut_ext_attr.ml[29+24]..[29+26])
+                                                                  Pexp_construct "()" (shortcut_ext_attr.ml[29+24]..[29+26])
                                                                   None
                                                               <case>
-                                                                pattern (shortcut_ext_attr.ml[30,721+4]..[30,721+25])
+                                                                pattern (shortcut_ext_attr.ml[30+4]..[30+25])
                                                                   Ppat_extension "foo"
-                                                                  pattern (shortcut_ext_attr.ml[30,721+4]..[30,721+25]) ghost
+                                                                  pattern (shortcut_ext_attr.ml[30+4]..[30+25]) ghost
                                                                     attribute "foo"
                                                                       []
                                                                     Ppat_exception
-                                                                    pattern (shortcut_ext_attr.ml[30,721+24]..[30,721+25])
-                                                                      Ppat_var "x" (shortcut_ext_attr.ml[30,721+24]..[30,721+25])
-                                                                expression (shortcut_ext_attr.ml[30,721+29]..[30,721+31])
-                                                                  Pexp_construct "()" (shortcut_ext_attr.ml[30,721+29]..[30,721+31])
+                                                                    pattern (shortcut_ext_attr.ml[30+24]..[30+25])
+                                                                      Ppat_var "x" (shortcut_ext_attr.ml[30+24]..[30+25])
+                                                                expression (shortcut_ext_attr.ml[30+29]..[30+31])
+                                                                  Pexp_construct "()" (shortcut_ext_attr.ml[30+29]..[30+31])
                                                                   None
                                                             ]
                                                       ]
                                   ]
           ]
     ]
-  structure_item (shortcut_ext_attr.ml[34,779+0]..[46,1049+5])
+  structure_item (shortcut_ext_attr.ml[34+0]..[46+5])
     Pstr_class
     [
-      class_declaration (shortcut_ext_attr.ml[34,779+0]..[46,1049+5])
+      class_declaration (shortcut_ext_attr.ml[34+0]..[46+5])
         pci_virt = Concrete
         pci_params =
           []
-        pci_name = "x" (shortcut_ext_attr.ml[34,779+6]..[34,779+7])
+        pci_name = "x" (shortcut_ext_attr.ml[34+6]..[34+7])
         pci_expr =
-          class_expr (shortcut_ext_attr.ml[35,789+12]..[46,1049+5])
+          class_expr (shortcut_ext_attr.ml[35+12]..[46+5])
             attribute "foo"
               []
             Pcl_fun
             Nolabel
             None
-            pattern (shortcut_ext_attr.ml[35,789+12]..[35,789+13])
-              Ppat_var "x" (shortcut_ext_attr.ml[35,789+12]..[35,789+13])
-            class_expr (shortcut_ext_attr.ml[36,806+2]..[46,1049+5])
+            pattern (shortcut_ext_attr.ml[35+12]..[35+13])
+              Ppat_var "x" (shortcut_ext_attr.ml[35+12]..[35+13])
+            class_expr (shortcut_ext_attr.ml[36+2]..[46+5])
               Pcl_let Nonrec
               [
                 <def>
                     attribute "foo"
                       []
-                  pattern (shortcut_ext_attr.ml[36,806+12]..[36,806+13])
-                    Ppat_var "x" (shortcut_ext_attr.ml[36,806+12]..[36,806+13])
-                  expression (shortcut_ext_attr.ml[36,806+16]..[36,806+17])
+                  pattern (shortcut_ext_attr.ml[36+12]..[36+13])
+                    Ppat_var "x" (shortcut_ext_attr.ml[36+12]..[36+13])
+                  expression (shortcut_ext_attr.ml[36+16]..[36+17])
                     Pexp_constant
-                    constant (shortcut_ext_attr.ml[36,806+16]..[36,806+17])
+                    constant (shortcut_ext_attr.ml[36+16]..[36+17])
                       PConst_int (3,None)
               ]
-              class_expr (shortcut_ext_attr.ml[37,827+2]..[46,1049+5])
+              class_expr (shortcut_ext_attr.ml[37+2]..[46+5])
                 attribute "foo"
                   []
                 Pcl_structure
                 class_structure
-                  pattern (shortcut_ext_attr.ml[37,827+14]..[37,827+14]) ghost
+                  pattern (shortcut_ext_attr.ml[37+14]..[37+14]) ghost
                     Ppat_any
                   [
-                    class_field (shortcut_ext_attr.ml[38,842+4]..[38,842+19])
+                    class_field (shortcut_ext_attr.ml[38+4]..[38+19])
                         attribute "foo"
                           []
                       Pcf_inherit Fresh
-                        class_expr (shortcut_ext_attr.ml[38,842+18]..[38,842+19])
-                          Pcl_constr "x" (shortcut_ext_attr.ml[38,842+18]..[38,842+19])
+                        class_expr (shortcut_ext_attr.ml[38+18]..[38+19])
+                          Pcl_constr "x" (shortcut_ext_attr.ml[38+18]..[38+19])
                           []
                         None
-                    class_field (shortcut_ext_attr.ml[39,862+4]..[39,862+19])
+                    class_field (shortcut_ext_attr.ml[39+4]..[39+19])
                         attribute "foo"
                           []
                       Pcf_val Immutable
-                        "x" (shortcut_ext_attr.ml[39,862+14]..[39,862+15])
+                        "x" (shortcut_ext_attr.ml[39+14]..[39+15])
                         Concrete Fresh
-                        expression (shortcut_ext_attr.ml[39,862+18]..[39,862+19])
+                        expression (shortcut_ext_attr.ml[39+18]..[39+19])
                           Pexp_constant
-                          constant (shortcut_ext_attr.ml[39,862+18]..[39,862+19])
+                          constant (shortcut_ext_attr.ml[39+18]..[39+19])
                             PConst_int (3,None)
-                    class_field (shortcut_ext_attr.ml[40,882+4]..[40,882+27])
+                    class_field (shortcut_ext_attr.ml[40+4]..[40+27])
                         attribute "foo"
                           []
                       Pcf_val Immutable
-                        "x" (shortcut_ext_attr.ml[40,882+22]..[40,882+23])
+                        "x" (shortcut_ext_attr.ml[40+22]..[40+23])
                         Virtual
-                        core_type (shortcut_ext_attr.ml[40,882+26]..[40,882+27])
-                          Ptyp_constr "t" (shortcut_ext_attr.ml[40,882+26]..[40,882+27])
+                        core_type (shortcut_ext_attr.ml[40+26]..[40+27])
+                          Ptyp_constr "t" (shortcut_ext_attr.ml[40+26]..[40+27])
                           []
-                    class_field (shortcut_ext_attr.ml[41,910+4]..[41,910+28])
+                    class_field (shortcut_ext_attr.ml[41+4]..[41+28])
                         attribute "foo"
                           []
                       Pcf_val Mutable
-                        "x" (shortcut_ext_attr.ml[41,910+23]..[41,910+24])
+                        "x" (shortcut_ext_attr.ml[41+23]..[41+24])
                         Concrete Override
-                        expression (shortcut_ext_attr.ml[41,910+27]..[41,910+28])
+                        expression (shortcut_ext_attr.ml[41+27]..[41+28])
                           Pexp_constant
-                          constant (shortcut_ext_attr.ml[41,910+27]..[41,910+28])
+                          constant (shortcut_ext_attr.ml[41+27]..[41+28])
                             PConst_int (3,None)
-                    class_field (shortcut_ext_attr.ml[42,939+4]..[42,939+22])
+                    class_field (shortcut_ext_attr.ml[42+4]..[42+22])
                         attribute "foo"
                           []
                       Pcf_method Public
-                        "x" (shortcut_ext_attr.ml[42,939+17]..[42,939+18])
+                        "x" (shortcut_ext_attr.ml[42+17]..[42+18])
                         Concrete Fresh
-                        expression (shortcut_ext_attr.ml[42,939+21]..[42,939+22]) ghost
+                        expression (shortcut_ext_attr.ml[42+21]..[42+22]) ghost
                           Pexp_poly
-                          expression (shortcut_ext_attr.ml[42,939+21]..[42,939+22])
+                          expression (shortcut_ext_attr.ml[42+21]..[42+22])
                             Pexp_constant
-                            constant (shortcut_ext_attr.ml[42,939+21]..[42,939+22])
+                            constant (shortcut_ext_attr.ml[42+21]..[42+22])
                               PConst_int (3,None)
                           None
-                    class_field (shortcut_ext_attr.ml[43,962+4]..[43,962+30])
+                    class_field (shortcut_ext_attr.ml[43+4]..[43+30])
                         attribute "foo"
                           []
                       Pcf_method Public
-                        "x" (shortcut_ext_attr.ml[43,962+25]..[43,962+26])
+                        "x" (shortcut_ext_attr.ml[43+25]..[43+26])
                         Virtual
-                        core_type (shortcut_ext_attr.ml[43,962+29]..[43,962+30])
-                          Ptyp_constr "t" (shortcut_ext_attr.ml[43,962+29]..[43,962+30])
+                        core_type (shortcut_ext_attr.ml[43+29]..[43+30])
+                          Ptyp_constr "t" (shortcut_ext_attr.ml[43+29]..[43+30])
                           []
-                    class_field (shortcut_ext_attr.ml[44,993+4]..[44,993+31])
+                    class_field (shortcut_ext_attr.ml[44+4]..[44+31])
                         attribute "foo"
                           []
                       Pcf_method Private
-                        "x" (shortcut_ext_attr.ml[44,993+26]..[44,993+27])
+                        "x" (shortcut_ext_attr.ml[44+26]..[44+27])
                         Concrete Override
-                        expression (shortcut_ext_attr.ml[44,993+30]..[44,993+31]) ghost
+                        expression (shortcut_ext_attr.ml[44+30]..[44+31]) ghost
                           Pexp_poly
-                          expression (shortcut_ext_attr.ml[44,993+30]..[44,993+31])
+                          expression (shortcut_ext_attr.ml[44+30]..[44+31])
                             Pexp_constant
-                            constant (shortcut_ext_attr.ml[44,993+30]..[44,993+31])
+                            constant (shortcut_ext_attr.ml[44+30]..[44+31])
                               PConst_int (3,None)
                           None
-                    class_field (shortcut_ext_attr.ml[45,1025+4]..[45,1025+23])
+                    class_field (shortcut_ext_attr.ml[45+4]..[45+23])
                         attribute "foo"
                           []
                       Pcf_initializer
-                        expression (shortcut_ext_attr.ml[45,1025+22]..[45,1025+23])
-                          Pexp_ident "x" (shortcut_ext_attr.ml[45,1025+22]..[45,1025+23])
+                        expression (shortcut_ext_attr.ml[45+22]..[45+23])
+                          Pexp_ident "x" (shortcut_ext_attr.ml[45+22]..[45+23])
                   ]
     ]
-  structure_item (shortcut_ext_attr.ml[49,1085+0]..[57,1265+5])
+  structure_item (shortcut_ext_attr.ml[49+0]..[57+5])
     Pstr_class_type
     [
-      class_type_declaration (shortcut_ext_attr.ml[49,1085+0]..[57,1265+5])
+      class_type_declaration (shortcut_ext_attr.ml[49+0]..[57+5])
         pci_virt = Concrete
         pci_params =
           []
-        pci_name = "t" (shortcut_ext_attr.ml[49,1085+11]..[49,1085+12])
+        pci_name = "t" (shortcut_ext_attr.ml[49+11]..[49+12])
         pci_expr =
-          class_type (shortcut_ext_attr.ml[50,1100+2]..[57,1265+5])
+          class_type (shortcut_ext_attr.ml[50+2]..[57+5])
             attribute "foo"
               []
             Pcty_signature
             class_signature
-              core_type (shortcut_ext_attr.ml[50,1100+14]..[50,1100+14]) ghost
+              core_type (shortcut_ext_attr.ml[50+14]..[50+14]) ghost
                 Ptyp_any
               [
-                class_type_field (shortcut_ext_attr.ml[51,1115+4]..[51,1115+19])
+                class_type_field (shortcut_ext_attr.ml[51+4]..[51+19])
                     attribute "foo"
                       []
                   Pctf_inherit
-                  class_type (shortcut_ext_attr.ml[51,1115+18]..[51,1115+19])
-                    Pcty_constr "t" (shortcut_ext_attr.ml[51,1115+18]..[51,1115+19])
+                  class_type (shortcut_ext_attr.ml[51+18]..[51+19])
+                    Pcty_constr "t" (shortcut_ext_attr.ml[51+18]..[51+19])
                     []
-                class_type_field (shortcut_ext_attr.ml[52,1135+4]..[52,1135+19])
+                class_type_field (shortcut_ext_attr.ml[52+4]..[52+19])
                     attribute "foo"
                       []
                   Pctf_val "x" Immutable Concrete
-                    core_type (shortcut_ext_attr.ml[52,1135+18]..[52,1135+19])
-                      Ptyp_constr "t" (shortcut_ext_attr.ml[52,1135+18]..[52,1135+19])
+                    core_type (shortcut_ext_attr.ml[52+18]..[52+19])
+                      Ptyp_constr "t" (shortcut_ext_attr.ml[52+18]..[52+19])
                       []
-                class_type_field (shortcut_ext_attr.ml[53,1155+4]..[53,1155+27])
+                class_type_field (shortcut_ext_attr.ml[53+4]..[53+27])
                     attribute "foo"
                       []
                   Pctf_val "x" Mutable Concrete
-                    core_type (shortcut_ext_attr.ml[53,1155+26]..[53,1155+27])
-                      Ptyp_constr "t" (shortcut_ext_attr.ml[53,1155+26]..[53,1155+27])
+                    core_type (shortcut_ext_attr.ml[53+26]..[53+27])
+                      Ptyp_constr "t" (shortcut_ext_attr.ml[53+26]..[53+27])
                       []
-                class_type_field (shortcut_ext_attr.ml[54,1183+4]..[54,1183+22])
+                class_type_field (shortcut_ext_attr.ml[54+4]..[54+22])
                     attribute "foo"
                       []
                   Pctf_method "x" Public Concrete
-                    core_type (shortcut_ext_attr.ml[54,1183+21]..[54,1183+22])
-                      Ptyp_constr "t" (shortcut_ext_attr.ml[54,1183+21]..[54,1183+22])
+                    core_type (shortcut_ext_attr.ml[54+21]..[54+22])
+                      Ptyp_constr "t" (shortcut_ext_attr.ml[54+21]..[54+22])
                       []
-                class_type_field (shortcut_ext_attr.ml[55,1206+4]..[55,1206+30])
+                class_type_field (shortcut_ext_attr.ml[55+4]..[55+30])
                     attribute "foo"
                       []
                   Pctf_method "x" Private Concrete
-                    core_type (shortcut_ext_attr.ml[55,1206+29]..[55,1206+30])
-                      Ptyp_constr "t" (shortcut_ext_attr.ml[55,1206+29]..[55,1206+30])
+                    core_type (shortcut_ext_attr.ml[55+29]..[55+30])
+                      Ptyp_constr "t" (shortcut_ext_attr.ml[55+29]..[55+30])
                       []
-                class_type_field (shortcut_ext_attr.ml[56,1237+4]..[56,1237+27])
+                class_type_field (shortcut_ext_attr.ml[56+4]..[56+27])
                     attribute "foo"
                       []
                   Pctf_constraint
-                    core_type (shortcut_ext_attr.ml[56,1237+21]..[56,1237+22])
-                      Ptyp_constr "t" (shortcut_ext_attr.ml[56,1237+21]..[56,1237+22])
+                    core_type (shortcut_ext_attr.ml[56+21]..[56+22])
+                      Ptyp_constr "t" (shortcut_ext_attr.ml[56+21]..[56+22])
                       []
-                    core_type (shortcut_ext_attr.ml[56,1237+25]..[56,1237+27])
-                      Ptyp_constr "t'" (shortcut_ext_attr.ml[56,1237+25]..[56,1237+27])
+                    core_type (shortcut_ext_attr.ml[56+25]..[56+27])
+                      Ptyp_constr "t'" (shortcut_ext_attr.ml[56+25]..[56+27])
                       []
               ]
     ]
-  structure_item (shortcut_ext_attr.ml[60,1295+0]..[61,1304+22])
+  structure_item (shortcut_ext_attr.ml[60+0]..[61+22])
     Pstr_type Rec
     [
-      type_declaration "t" (shortcut_ext_attr.ml[60,1295+5]..[60,1295+6]) (shortcut_ext_attr.ml[60,1295+0]..[61,1304+22])
+      type_declaration "t" (shortcut_ext_attr.ml[60+5]..[60+6]) (shortcut_ext_attr.ml[60+0]..[61+22])
         ptype_params =
           []
         ptype_constraints =
@@ -524,89 +524,89 @@
         ptype_private = Public
         ptype_manifest =
           Some
-            core_type (shortcut_ext_attr.ml[61,1304+2]..[61,1304+22])
+            core_type (shortcut_ext_attr.ml[61+2]..[61+22])
               Ptyp_extension "foo"
-              core_type (shortcut_ext_attr.ml[61,1304+2]..[61,1304+22]) ghost
+              core_type (shortcut_ext_attr.ml[61+2]..[61+22]) ghost
                 attribute "foo"
                   []
                 Ptyp_package
-                  package_type "M" (shortcut_ext_attr.ml[61,1304+20]..[61,1304+21])
+                  package_type "M" (shortcut_ext_attr.ml[61+20]..[61+21])
                   []
     ]
-  structure_item (shortcut_ext_attr.ml[64,1353+0]..[67,1409+22])
+  structure_item (shortcut_ext_attr.ml[64+0]..[67+22])
     Pstr_module
-    "M" (shortcut_ext_attr.ml[64,1353+7]..[64,1353+8])
-      module_expr (shortcut_ext_attr.ml[65,1364+16]..[67,1409+22])
+    "M" (shortcut_ext_attr.ml[64+7]..[64+8])
+      module_expr (shortcut_ext_attr.ml[65+16]..[67+22])
         attribute "foo"
           []
-        Pmod_functor "M" (shortcut_ext_attr.ml[65,1364+17]..[65,1364+18])
-        module_type (shortcut_ext_attr.ml[65,1364+21]..[65,1364+22])
-          Pmty_ident "S" (shortcut_ext_attr.ml[65,1364+21]..[65,1364+22])
-        module_expr (shortcut_ext_attr.ml[66,1391+4]..[67,1409+22])
+        Pmod_functor "M" (shortcut_ext_attr.ml[65+17]..[65+18])
+        module_type (shortcut_ext_attr.ml[65+21]..[65+22])
+          Pmty_ident "S" (shortcut_ext_attr.ml[65+21]..[65+22])
+        module_expr (shortcut_ext_attr.ml[66+4]..[67+22])
           Pmod_apply
-          module_expr (shortcut_ext_attr.ml[66,1391+4]..[66,1391+17])
+          module_expr (shortcut_ext_attr.ml[66+4]..[66+17])
             attribute "foo"
               []
             Pmod_unpack
-            expression (shortcut_ext_attr.ml[66,1391+15]..[66,1391+16])
-              Pexp_ident "x" (shortcut_ext_attr.ml[66,1391+15]..[66,1391+16])
-          module_expr (shortcut_ext_attr.ml[67,1409+5]..[67,1409+21])
+            expression (shortcut_ext_attr.ml[66+15]..[66+16])
+              Pexp_ident "x" (shortcut_ext_attr.ml[66+15]..[66+16])
+          module_expr (shortcut_ext_attr.ml[67+5]..[67+21])
             attribute "foo"
               []
             Pmod_structure
             []
-  structure_item (shortcut_ext_attr.ml[70,1462+0]..[73,1535+19])
-    Pstr_modtype "S" (shortcut_ext_attr.ml[70,1462+12]..[70,1462+13])
-      module_type (shortcut_ext_attr.ml[71,1478+16]..[73,1535+19])
+  structure_item (shortcut_ext_attr.ml[70+0]..[73+19])
+    Pstr_modtype "S" (shortcut_ext_attr.ml[70+12]..[70+13])
+      module_type (shortcut_ext_attr.ml[71+16]..[73+19])
         attribute "foo"
           []
-        Pmty_functor "M" (shortcut_ext_attr.ml[71,1478+17]..[71,1478+18])
-        module_type (shortcut_ext_attr.ml[71,1478+19]..[71,1478+20])
-          Pmty_ident "S" (shortcut_ext_attr.ml[71,1478+19]..[71,1478+20])
-        module_type (shortcut_ext_attr.ml[72,1503+4]..[73,1535+19])
-          Pmty_functor "_" (_none_[0,0+-1]..[0,0+-1]) ghost
-          module_type (shortcut_ext_attr.ml[72,1503+5]..[72,1503+27])
+        Pmty_functor "M" (shortcut_ext_attr.ml[71+17]..[71+18])
+        module_type (shortcut_ext_attr.ml[71+19]..[71+20])
+          Pmty_ident "S" (shortcut_ext_attr.ml[71+19]..[71+20])
+        module_type (shortcut_ext_attr.ml[72+4]..[73+19])
+          Pmty_functor "_" (_none_[0+-1]..[0+-1]) ghost
+          module_type (shortcut_ext_attr.ml[72+5]..[72+27])
             attribute "foo"
               []
             Pmty_typeof
-            module_expr (shortcut_ext_attr.ml[72,1503+26]..[72,1503+27])
-              Pmod_ident "M" (shortcut_ext_attr.ml[72,1503+26]..[72,1503+27])
-          module_type (shortcut_ext_attr.ml[73,1535+5]..[73,1535+18])
+            module_expr (shortcut_ext_attr.ml[72+26]..[72+27])
+              Pmod_ident "M" (shortcut_ext_attr.ml[72+26]..[72+27])
+          module_type (shortcut_ext_attr.ml[73+5]..[73+18])
             attribute "foo"
               []
             Pmty_signature
             []
-  structure_item (shortcut_ext_attr.ml[76,1578+0]..[77,1598+15]) ghost
+  structure_item (shortcut_ext_attr.ml[76+0]..[77+15]) ghost
     Pstr_extension "foo"
     [
-      structure_item (shortcut_ext_attr.ml[76,1578+0]..[77,1598+15])
+      structure_item (shortcut_ext_attr.ml[76+0]..[77+15])
         Pstr_value Nonrec
         [
           <def>
               attribute "foo"
                 []
-            pattern (shortcut_ext_attr.ml[76,1578+14]..[76,1578+15])
-              Ppat_var "x" (shortcut_ext_attr.ml[76,1578+14]..[76,1578+15])
-            expression (shortcut_ext_attr.ml[76,1578+18]..[76,1578+19])
+            pattern (shortcut_ext_attr.ml[76+14]..[76+15])
+              Ppat_var "x" (shortcut_ext_attr.ml[76+14]..[76+15])
+            expression (shortcut_ext_attr.ml[76+18]..[76+19])
               Pexp_constant
-              constant (shortcut_ext_attr.ml[76,1578+18]..[76,1578+19])
+              constant (shortcut_ext_attr.ml[76+18]..[76+19])
                 PConst_int (4,None)
           <def>
               attribute "foo"
                 []
-            pattern (shortcut_ext_attr.ml[77,1598+10]..[77,1598+11])
-              Ppat_var "y" (shortcut_ext_attr.ml[77,1598+10]..[77,1598+11])
-            expression (shortcut_ext_attr.ml[77,1598+14]..[77,1598+15])
-              Pexp_ident "x" (shortcut_ext_attr.ml[77,1598+14]..[77,1598+15])
+            pattern (shortcut_ext_attr.ml[77+10]..[77+11])
+              Ppat_var "y" (shortcut_ext_attr.ml[77+10]..[77+11])
+            expression (shortcut_ext_attr.ml[77+14]..[77+15])
+              Pexp_ident "x" (shortcut_ext_attr.ml[77+14]..[77+15])
         ]
     ]
-  structure_item (shortcut_ext_attr.ml[79,1615+0]..[80,1638+17])
+  structure_item (shortcut_ext_attr.ml[79+0]..[80+17])
     Pstr_extension "foo"
     [
-      structure_item (shortcut_ext_attr.ml[79,1615+0]..[80,1638+17]) ghost
+      structure_item (shortcut_ext_attr.ml[79+0]..[80+17]) ghost
         Pstr_type Rec
         [
-          type_declaration "t" (shortcut_ext_attr.ml[79,1615+15]..[79,1615+16]) (shortcut_ext_attr.ml[79,1615+0]..[79,1615+22])
+          type_declaration "t" (shortcut_ext_attr.ml[79+15]..[79+16]) (shortcut_ext_attr.ml[79+0]..[79+22])
             attribute "foo"
               []
             ptype_params =
@@ -618,10 +618,10 @@
             ptype_private = Public
             ptype_manifest =
               Some
-                core_type (shortcut_ext_attr.ml[79,1615+19]..[79,1615+22])
-                  Ptyp_constr "int" (shortcut_ext_attr.ml[79,1615+19]..[79,1615+22])
+                core_type (shortcut_ext_attr.ml[79+19]..[79+22])
+                  Ptyp_constr "int" (shortcut_ext_attr.ml[79+19]..[79+22])
                   []
-          type_declaration "t" (shortcut_ext_attr.ml[80,1638+10]..[80,1638+11]) (shortcut_ext_attr.ml[80,1638+0]..[80,1638+17])
+          type_declaration "t" (shortcut_ext_attr.ml[80+10]..[80+11]) (shortcut_ext_attr.ml[80+0]..[80+17])
             attribute "foo"
               []
             ptype_params =
@@ -633,25 +633,25 @@
             ptype_private = Public
             ptype_manifest =
               Some
-                core_type (shortcut_ext_attr.ml[80,1638+14]..[80,1638+17])
-                  Ptyp_constr "int" (shortcut_ext_attr.ml[80,1638+14]..[80,1638+17])
+                core_type (shortcut_ext_attr.ml[80+14]..[80+17])
+                  Ptyp_constr "int" (shortcut_ext_attr.ml[80+14]..[80+17])
                   []
         ]
     ]
-  structure_item (shortcut_ext_attr.ml[81,1656+0]..[81,1656+21])
+  structure_item (shortcut_ext_attr.ml[81+0]..[81+21])
     Pstr_extension "foo"
     [
-      structure_item (shortcut_ext_attr.ml[81,1656+0]..[81,1656+21]) ghost
+      structure_item (shortcut_ext_attr.ml[81+0]..[81+21]) ghost
         Pstr_typext
         type_extension
           attribute "foo"
             []
-          ptyext_path = "t" (shortcut_ext_attr.ml[81,1656+15]..[81,1656+16])
+          ptyext_path = "t" (shortcut_ext_attr.ml[81+15]..[81+16])
           ptyext_params =
             []
           ptyext_constructors =
             [
-              extension_constructor (shortcut_ext_attr.ml[81,1656+20]..[81,1656+21])
+              extension_constructor (shortcut_ext_attr.ml[81+20]..[81+21])
                 pext_name = "T"
                 pext_kind =
                   Pext_decl
@@ -660,66 +660,66 @@
             ]
           ptyext_private = Public
     ]
-  structure_item (shortcut_ext_attr.ml[83,1679+0]..[83,1679+21])
+  structure_item (shortcut_ext_attr.ml[83+0]..[83+21])
     Pstr_extension "foo"
     [
-      structure_item (shortcut_ext_attr.ml[83,1679+0]..[83,1679+21]) ghost
+      structure_item (shortcut_ext_attr.ml[83+0]..[83+21]) ghost
         Pstr_class
         [
-          class_declaration (shortcut_ext_attr.ml[83,1679+0]..[83,1679+21])
+          class_declaration (shortcut_ext_attr.ml[83+0]..[83+21])
             attribute "foo"
               []
             pci_virt = Concrete
             pci_params =
               []
-            pci_name = "x" (shortcut_ext_attr.ml[83,1679+16]..[83,1679+17])
+            pci_name = "x" (shortcut_ext_attr.ml[83+16]..[83+17])
             pci_expr =
-              class_expr (shortcut_ext_attr.ml[83,1679+20]..[83,1679+21])
-                Pcl_constr "x" (shortcut_ext_attr.ml[83,1679+20]..[83,1679+21])
+              class_expr (shortcut_ext_attr.ml[83+20]..[83+21])
+                Pcl_constr "x" (shortcut_ext_attr.ml[83+20]..[83+21])
                 []
         ]
     ]
-  structure_item (shortcut_ext_attr.ml[84,1701+0]..[84,1701+26])
+  structure_item (shortcut_ext_attr.ml[84+0]..[84+26])
     Pstr_extension "foo"
     [
-      structure_item (shortcut_ext_attr.ml[84,1701+0]..[84,1701+26]) ghost
+      structure_item (shortcut_ext_attr.ml[84+0]..[84+26]) ghost
         Pstr_class_type
         [
-          class_type_declaration (shortcut_ext_attr.ml[84,1701+0]..[84,1701+26])
+          class_type_declaration (shortcut_ext_attr.ml[84+0]..[84+26])
             attribute "foo"
               []
             pci_virt = Concrete
             pci_params =
               []
-            pci_name = "x" (shortcut_ext_attr.ml[84,1701+21]..[84,1701+22])
+            pci_name = "x" (shortcut_ext_attr.ml[84+21]..[84+22])
             pci_expr =
-              class_type (shortcut_ext_attr.ml[84,1701+25]..[84,1701+26])
-                Pcty_constr "x" (shortcut_ext_attr.ml[84,1701+25]..[84,1701+26])
+              class_type (shortcut_ext_attr.ml[84+25]..[84+26])
+                Pcty_constr "x" (shortcut_ext_attr.ml[84+25]..[84+26])
                 []
         ]
     ]
-  structure_item (shortcut_ext_attr.ml[85,1728+0]..[85,1728+30])
+  structure_item (shortcut_ext_attr.ml[85+0]..[85+30])
     Pstr_extension "foo"
     [
-      structure_item (shortcut_ext_attr.ml[85,1728+0]..[85,1728+30]) ghost
+      structure_item (shortcut_ext_attr.ml[85+0]..[85+30]) ghost
         Pstr_primitive
-        value_description "x" (shortcut_ext_attr.ml[85,1728+19]..[85,1728+20]) (shortcut_ext_attr.ml[85,1728+0]..[85,1728+30])
+        value_description "x" (shortcut_ext_attr.ml[85+19]..[85+20]) (shortcut_ext_attr.ml[85+0]..[85+30])
           attribute "foo"
             []
-          core_type (shortcut_ext_attr.ml[85,1728+23]..[85,1728+24])
+          core_type (shortcut_ext_attr.ml[85+23]..[85+24])
             Ptyp_any
           [
             ""
           ]
     ]
-  structure_item (shortcut_ext_attr.ml[86,1759+0]..[86,1759+21])
+  structure_item (shortcut_ext_attr.ml[86+0]..[86+21])
     Pstr_extension "foo"
     [
-      structure_item (shortcut_ext_attr.ml[86,1759+0]..[86,1759+21]) ghost
+      structure_item (shortcut_ext_attr.ml[86+0]..[86+21]) ghost
         Pstr_exception
         type_exception
           ptyext_constructor =
-            extension_constructor (shortcut_ext_attr.ml[86,1759+0]..[86,1759+21])
+            extension_constructor (shortcut_ext_attr.ml[86+0]..[86+21])
               attribute "foo"
                 []
               pext_name = "X"
@@ -728,112 +728,112 @@
                   []
                   None
     ]
-  structure_item (shortcut_ext_attr.ml[88,1782+0]..[88,1782+22])
+  structure_item (shortcut_ext_attr.ml[88+0]..[88+22])
     Pstr_extension "foo"
     [
-      structure_item (shortcut_ext_attr.ml[88,1782+0]..[88,1782+22]) ghost
+      structure_item (shortcut_ext_attr.ml[88+0]..[88+22]) ghost
         Pstr_module
-        "M" (shortcut_ext_attr.ml[88,1782+17]..[88,1782+18])
+        "M" (shortcut_ext_attr.ml[88+17]..[88+18])
           attribute "foo"
             []
-          module_expr (shortcut_ext_attr.ml[88,1782+21]..[88,1782+22])
-            Pmod_ident "M" (shortcut_ext_attr.ml[88,1782+21]..[88,1782+22])
+          module_expr (shortcut_ext_attr.ml[88+21]..[88+22])
+            Pmod_ident "M" (shortcut_ext_attr.ml[88+21]..[88+22])
     ]
-  structure_item (shortcut_ext_attr.ml[89,1805+0]..[90,1836+19])
+  structure_item (shortcut_ext_attr.ml[89+0]..[90+19])
     Pstr_extension "foo"
     [
-      structure_item (shortcut_ext_attr.ml[89,1805+0]..[90,1836+19]) ghost
+      structure_item (shortcut_ext_attr.ml[89+0]..[90+19]) ghost
         Pstr_recmodule
         [
-          "M" (shortcut_ext_attr.ml[89,1805+21]..[89,1805+22])
+          "M" (shortcut_ext_attr.ml[89+21]..[89+22])
             attribute "foo"
               []
-            module_expr (shortcut_ext_attr.ml[89,1805+23]..[89,1805+30])
+            module_expr (shortcut_ext_attr.ml[89+23]..[89+30])
               Pmod_constraint
-              module_expr (shortcut_ext_attr.ml[89,1805+29]..[89,1805+30])
-                Pmod_ident "M" (shortcut_ext_attr.ml[89,1805+29]..[89,1805+30])
-              module_type (shortcut_ext_attr.ml[89,1805+25]..[89,1805+26])
-                Pmty_ident "S" (shortcut_ext_attr.ml[89,1805+25]..[89,1805+26])
-          "M" (shortcut_ext_attr.ml[90,1836+10]..[90,1836+11])
+              module_expr (shortcut_ext_attr.ml[89+29]..[89+30])
+                Pmod_ident "M" (shortcut_ext_attr.ml[89+29]..[89+30])
+              module_type (shortcut_ext_attr.ml[89+25]..[89+26])
+                Pmty_ident "S" (shortcut_ext_attr.ml[89+25]..[89+26])
+          "M" (shortcut_ext_attr.ml[90+10]..[90+11])
             attribute "foo"
               []
-            module_expr (shortcut_ext_attr.ml[90,1836+12]..[90,1836+19])
+            module_expr (shortcut_ext_attr.ml[90+12]..[90+19])
               Pmod_constraint
-              module_expr (shortcut_ext_attr.ml[90,1836+18]..[90,1836+19])
-                Pmod_ident "M" (shortcut_ext_attr.ml[90,1836+18]..[90,1836+19])
-              module_type (shortcut_ext_attr.ml[90,1836+14]..[90,1836+15])
-                Pmty_ident "S" (shortcut_ext_attr.ml[90,1836+14]..[90,1836+15])
+              module_expr (shortcut_ext_attr.ml[90+18]..[90+19])
+                Pmod_ident "M" (shortcut_ext_attr.ml[90+18]..[90+19])
+              module_type (shortcut_ext_attr.ml[90+14]..[90+15])
+                Pmty_ident "S" (shortcut_ext_attr.ml[90+14]..[90+15])
         ]
     ]
-  structure_item (shortcut_ext_attr.ml[91,1856+0]..[91,1856+27])
+  structure_item (shortcut_ext_attr.ml[91+0]..[91+27])
     Pstr_extension "foo"
     [
-      structure_item (shortcut_ext_attr.ml[91,1856+0]..[91,1856+27]) ghost
-        Pstr_modtype "S" (shortcut_ext_attr.ml[91,1856+22]..[91,1856+23])
+      structure_item (shortcut_ext_attr.ml[91+0]..[91+27]) ghost
+        Pstr_modtype "S" (shortcut_ext_attr.ml[91+22]..[91+23])
           attribute "foo"
             []
-          module_type (shortcut_ext_attr.ml[91,1856+26]..[91,1856+27])
-            Pmty_ident "S" (shortcut_ext_attr.ml[91,1856+26]..[91,1856+27])
+          module_type (shortcut_ext_attr.ml[91+26]..[91+27])
+            Pmty_ident "S" (shortcut_ext_attr.ml[91+26]..[91+27])
     ]
-  structure_item (shortcut_ext_attr.ml[93,1885+0]..[93,1885+19])
+  structure_item (shortcut_ext_attr.ml[93+0]..[93+19])
     Pstr_extension "foo"
     [
-      structure_item (shortcut_ext_attr.ml[93,1885+0]..[93,1885+19]) ghost
+      structure_item (shortcut_ext_attr.ml[93+0]..[93+19]) ghost
         Pstr_include          attribute "foo"
             []
-        module_expr (shortcut_ext_attr.ml[93,1885+18]..[93,1885+19])
-          Pmod_ident "M" (shortcut_ext_attr.ml[93,1885+18]..[93,1885+19])
+        module_expr (shortcut_ext_attr.ml[93+18]..[93+19])
+          Pmod_ident "M" (shortcut_ext_attr.ml[93+18]..[93+19])
     ]
-  structure_item (shortcut_ext_attr.ml[94,1905+0]..[94,1905+16])
+  structure_item (shortcut_ext_attr.ml[94+0]..[94+16])
     Pstr_extension "foo"
     [
-      structure_item (shortcut_ext_attr.ml[94,1905+0]..[94,1905+16]) ghost
+      structure_item (shortcut_ext_attr.ml[94+0]..[94+16]) ghost
         Pstr_open Fresh
-        module_expr (shortcut_ext_attr.ml[94,1905+15]..[94,1905+16])
-          Pmod_ident "M" (shortcut_ext_attr.ml[94,1905+15]..[94,1905+16])
+        module_expr (shortcut_ext_attr.ml[94+15]..[94+16])
+          Pmod_ident "M" (shortcut_ext_attr.ml[94+15]..[94+16])
           attribute "foo"
             []
     ]
-  structure_item (shortcut_ext_attr.ml[97,1945+0]..[120,2341+3])
-    Pstr_modtype "S" (shortcut_ext_attr.ml[97,1945+12]..[97,1945+13])
-      module_type (shortcut_ext_attr.ml[97,1945+16]..[120,2341+3])
+  structure_item (shortcut_ext_attr.ml[97+0]..[120+3])
+    Pstr_modtype "S" (shortcut_ext_attr.ml[97+12]..[97+13])
+      module_type (shortcut_ext_attr.ml[97+16]..[120+3])
         Pmty_signature
         [
-          signature_item (shortcut_ext_attr.ml[98,1965+2]..[98,1965+21])
+          signature_item (shortcut_ext_attr.ml[98+2]..[98+21])
             Psig_extension "foo"
             [
-              signature_item (shortcut_ext_attr.ml[98,1965+2]..[98,1965+21]) ghost
+              signature_item (shortcut_ext_attr.ml[98+2]..[98+21]) ghost
                 Psig_value
-                value_description "x" (shortcut_ext_attr.ml[98,1965+16]..[98,1965+17]) (shortcut_ext_attr.ml[98,1965+2]..[98,1965+21])
+                value_description "x" (shortcut_ext_attr.ml[98+16]..[98+17]) (shortcut_ext_attr.ml[98+2]..[98+21])
                   attribute "foo"
                     []
-                  core_type (shortcut_ext_attr.ml[98,1965+20]..[98,1965+21])
-                    Ptyp_constr "t" (shortcut_ext_attr.ml[98,1965+20]..[98,1965+21])
+                  core_type (shortcut_ext_attr.ml[98+20]..[98+21])
+                    Ptyp_constr "t" (shortcut_ext_attr.ml[98+20]..[98+21])
                     []
                   []
             ]
-          signature_item (shortcut_ext_attr.ml[99,1987+2]..[99,1987+31])
+          signature_item (shortcut_ext_attr.ml[99+2]..[99+31])
             Psig_extension "foo"
             [
-              signature_item (shortcut_ext_attr.ml[99,1987+2]..[99,1987+31]) ghost
+              signature_item (shortcut_ext_attr.ml[99+2]..[99+31]) ghost
                 Psig_value
-                value_description "x" (shortcut_ext_attr.ml[99,1987+21]..[99,1987+22]) (shortcut_ext_attr.ml[99,1987+2]..[99,1987+31])
+                value_description "x" (shortcut_ext_attr.ml[99+21]..[99+22]) (shortcut_ext_attr.ml[99+2]..[99+31])
                   attribute "foo"
                     []
-                  core_type (shortcut_ext_attr.ml[99,1987+25]..[99,1987+26])
-                    Ptyp_constr "t" (shortcut_ext_attr.ml[99,1987+25]..[99,1987+26])
+                  core_type (shortcut_ext_attr.ml[99+25]..[99+26])
+                    Ptyp_constr "t" (shortcut_ext_attr.ml[99+25]..[99+26])
                     []
                   [
                     ""
                   ]
             ]
-          signature_item (shortcut_ext_attr.ml[101,2020+2]..[102,2045+20])
+          signature_item (shortcut_ext_attr.ml[101+2]..[102+20])
             Psig_extension "foo"
             [
-              signature_item (shortcut_ext_attr.ml[101,2020+2]..[102,2045+20]) ghost
+              signature_item (shortcut_ext_attr.ml[101+2]..[102+20]) ghost
                 Psig_type Rec
                 [
-                  type_declaration "t" (shortcut_ext_attr.ml[101,2020+17]..[101,2020+18]) (shortcut_ext_attr.ml[101,2020+2]..[101,2020+24])
+                  type_declaration "t" (shortcut_ext_attr.ml[101+17]..[101+18]) (shortcut_ext_attr.ml[101+2]..[101+24])
                     attribute "foo"
                       []
                     ptype_params =
@@ -845,10 +845,10 @@
                     ptype_private = Public
                     ptype_manifest =
                       Some
-                        core_type (shortcut_ext_attr.ml[101,2020+21]..[101,2020+24])
-                          Ptyp_constr "int" (shortcut_ext_attr.ml[101,2020+21]..[101,2020+24])
+                        core_type (shortcut_ext_attr.ml[101+21]..[101+24])
+                          Ptyp_constr "int" (shortcut_ext_attr.ml[101+21]..[101+24])
                           []
-                  type_declaration "t'" (shortcut_ext_attr.ml[102,2045+12]..[102,2045+14]) (shortcut_ext_attr.ml[102,2045+2]..[102,2045+20])
+                  type_declaration "t'" (shortcut_ext_attr.ml[102+12]..[102+14]) (shortcut_ext_attr.ml[102+2]..[102+20])
                     attribute "foo"
                       []
                     ptype_params =
@@ -860,25 +860,25 @@
                     ptype_private = Public
                     ptype_manifest =
                       Some
-                        core_type (shortcut_ext_attr.ml[102,2045+17]..[102,2045+20])
-                          Ptyp_constr "int" (shortcut_ext_attr.ml[102,2045+17]..[102,2045+20])
+                        core_type (shortcut_ext_attr.ml[102+17]..[102+20])
+                          Ptyp_constr "int" (shortcut_ext_attr.ml[102+17]..[102+20])
                           []
                 ]
             ]
-          signature_item (shortcut_ext_attr.ml[103,2066+2]..[103,2066+23])
+          signature_item (shortcut_ext_attr.ml[103+2]..[103+23])
             Psig_extension "foo"
             [
-              signature_item (shortcut_ext_attr.ml[103,2066+2]..[103,2066+23]) ghost
+              signature_item (shortcut_ext_attr.ml[103+2]..[103+23]) ghost
                 Psig_typext
                 type_extension
                   attribute "foo"
                     []
-                  ptyext_path = "t" (shortcut_ext_attr.ml[103,2066+17]..[103,2066+18])
+                  ptyext_path = "t" (shortcut_ext_attr.ml[103+17]..[103+18])
                   ptyext_params =
                     []
                   ptyext_constructors =
                     [
-                      extension_constructor (shortcut_ext_attr.ml[103,2066+22]..[103,2066+23])
+                      extension_constructor (shortcut_ext_attr.ml[103+22]..[103+23])
                         pext_name = "T"
                         pext_kind =
                           Pext_decl
@@ -887,14 +887,14 @@
                     ]
                   ptyext_private = Public
             ]
-          signature_item (shortcut_ext_attr.ml[105,2091+2]..[105,2091+23])
+          signature_item (shortcut_ext_attr.ml[105+2]..[105+23])
             Psig_extension "foo"
             [
-              signature_item (shortcut_ext_attr.ml[105,2091+2]..[105,2091+23]) ghost
+              signature_item (shortcut_ext_attr.ml[105+2]..[105+23]) ghost
                 Psig_exception
                 type_exception
                   ptyext_constructor =
-                    extension_constructor (shortcut_ext_attr.ml[105,2091+2]..[105,2091+23])
+                    extension_constructor (shortcut_ext_attr.ml[105+2]..[105+23])
                       attribute "foo"
                         []
                       pext_name = "X"
@@ -903,107 +903,107 @@
                           []
                           None
             ]
-          signature_item (shortcut_ext_attr.ml[107,2116+2]..[107,2116+24])
+          signature_item (shortcut_ext_attr.ml[107+2]..[107+24])
             Psig_extension "foo"
             [
-              signature_item (shortcut_ext_attr.ml[107,2116+2]..[107,2116+24]) ghost
-                Psig_module "M" (shortcut_ext_attr.ml[107,2116+19]..[107,2116+20])
+              signature_item (shortcut_ext_attr.ml[107+2]..[107+24]) ghost
+                Psig_module "M" (shortcut_ext_attr.ml[107+19]..[107+20])
                   attribute "foo"
                     []
-                module_type (shortcut_ext_attr.ml[107,2116+23]..[107,2116+24])
-                  Pmty_ident "S" (shortcut_ext_attr.ml[107,2116+23]..[107,2116+24])
+                module_type (shortcut_ext_attr.ml[107+23]..[107+24])
+                  Pmty_ident "S" (shortcut_ext_attr.ml[107+23]..[107+24])
             ]
-          signature_item (shortcut_ext_attr.ml[108,2141+2]..[109,2170+17])
+          signature_item (shortcut_ext_attr.ml[108+2]..[109+17])
             Psig_extension "foo"
             [
-              signature_item (shortcut_ext_attr.ml[108,2141+2]..[109,2170+17]) ghost
+              signature_item (shortcut_ext_attr.ml[108+2]..[109+17]) ghost
                 Psig_recmodule
                 [
-                  "M" (shortcut_ext_attr.ml[108,2141+23]..[108,2141+24])
+                  "M" (shortcut_ext_attr.ml[108+23]..[108+24])
                     attribute "foo"
                       []
-                    module_type (shortcut_ext_attr.ml[108,2141+27]..[108,2141+28])
-                      Pmty_ident "S" (shortcut_ext_attr.ml[108,2141+27]..[108,2141+28])
-                  "M" (shortcut_ext_attr.ml[109,2170+12]..[109,2170+13])
+                    module_type (shortcut_ext_attr.ml[108+27]..[108+28])
+                      Pmty_ident "S" (shortcut_ext_attr.ml[108+27]..[108+28])
+                  "M" (shortcut_ext_attr.ml[109+12]..[109+13])
                     attribute "foo"
                       []
-                    module_type (shortcut_ext_attr.ml[109,2170+16]..[109,2170+17])
-                      Pmty_ident "S" (shortcut_ext_attr.ml[109,2170+16]..[109,2170+17])
+                    module_type (shortcut_ext_attr.ml[109+16]..[109+17])
+                      Pmty_ident "S" (shortcut_ext_attr.ml[109+16]..[109+17])
                 ]
             ]
-          signature_item (shortcut_ext_attr.ml[110,2188+2]..[110,2188+24])
+          signature_item (shortcut_ext_attr.ml[110+2]..[110+24])
             Psig_extension "foo"
             [
-              signature_item (shortcut_ext_attr.ml[110,2188+2]..[110,2188+24]) ghost
-                Psig_module "M" (shortcut_ext_attr.ml[110,2188+19]..[110,2188+20])
+              signature_item (shortcut_ext_attr.ml[110+2]..[110+24]) ghost
+                Psig_module "M" (shortcut_ext_attr.ml[110+19]..[110+20])
                   attribute "foo"
                     []
-                module_type (shortcut_ext_attr.ml[110,2188+23]..[110,2188+24])
-                  Pmty_alias "M" (shortcut_ext_attr.ml[110,2188+23]..[110,2188+24])
+                module_type (shortcut_ext_attr.ml[110+23]..[110+24])
+                  Pmty_alias "M" (shortcut_ext_attr.ml[110+23]..[110+24])
             ]
-          signature_item (shortcut_ext_attr.ml[112,2214+2]..[112,2214+29])
+          signature_item (shortcut_ext_attr.ml[112+2]..[112+29])
             Psig_extension "foo"
             [
-              signature_item (shortcut_ext_attr.ml[112,2214+2]..[112,2214+29]) ghost
-                Psig_modtype "S" (shortcut_ext_attr.ml[112,2214+24]..[112,2214+25])
+              signature_item (shortcut_ext_attr.ml[112+2]..[112+29]) ghost
+                Psig_modtype "S" (shortcut_ext_attr.ml[112+24]..[112+25])
                   attribute "foo"
                     []
-                  module_type (shortcut_ext_attr.ml[112,2214+28]..[112,2214+29])
-                    Pmty_ident "S" (shortcut_ext_attr.ml[112,2214+28]..[112,2214+29])
+                  module_type (shortcut_ext_attr.ml[112+28]..[112+29])
+                    Pmty_ident "S" (shortcut_ext_attr.ml[112+28]..[112+29])
             ]
-          signature_item (shortcut_ext_attr.ml[114,2245+2]..[114,2245+21])
+          signature_item (shortcut_ext_attr.ml[114+2]..[114+21])
             Psig_extension "foo"
             [
-              signature_item (shortcut_ext_attr.ml[114,2245+2]..[114,2245+21]) ghost
+              signature_item (shortcut_ext_attr.ml[114+2]..[114+21]) ghost
                 Psig_include
-                module_type (shortcut_ext_attr.ml[114,2245+20]..[114,2245+21])
-                  Pmty_ident "M" (shortcut_ext_attr.ml[114,2245+20]..[114,2245+21])
+                module_type (shortcut_ext_attr.ml[114+20]..[114+21])
+                  Pmty_ident "M" (shortcut_ext_attr.ml[114+20]..[114+21])
                   attribute "foo"
                     []
             ]
-          signature_item (shortcut_ext_attr.ml[115,2267+2]..[115,2267+18])
+          signature_item (shortcut_ext_attr.ml[115+2]..[115+18])
             Psig_extension "foo"
             [
-              signature_item (shortcut_ext_attr.ml[115,2267+2]..[115,2267+18]) ghost
-                Psig_open Fresh "M" (shortcut_ext_attr.ml[115,2267+17]..[115,2267+18])
+              signature_item (shortcut_ext_attr.ml[115+2]..[115+18]) ghost
+                Psig_open Fresh "M" (shortcut_ext_attr.ml[115+17]..[115+18])
                   attribute "foo"
                     []
             ]
-          signature_item (shortcut_ext_attr.ml[117,2287+2]..[117,2287+23])
+          signature_item (shortcut_ext_attr.ml[117+2]..[117+23])
             Psig_extension "foo"
             [
-              signature_item (shortcut_ext_attr.ml[117,2287+2]..[117,2287+23]) ghost
+              signature_item (shortcut_ext_attr.ml[117+2]..[117+23]) ghost
                 Psig_class
                 [
-                  class_description (shortcut_ext_attr.ml[117,2287+2]..[117,2287+23])
+                  class_description (shortcut_ext_attr.ml[117+2]..[117+23])
                     attribute "foo"
                       []
                     pci_virt = Concrete
                     pci_params =
                       []
-                    pci_name = "x" (shortcut_ext_attr.ml[117,2287+18]..[117,2287+19])
+                    pci_name = "x" (shortcut_ext_attr.ml[117+18]..[117+19])
                     pci_expr =
-                      class_type (shortcut_ext_attr.ml[117,2287+22]..[117,2287+23])
-                        Pcty_constr "t" (shortcut_ext_attr.ml[117,2287+22]..[117,2287+23])
+                      class_type (shortcut_ext_attr.ml[117+22]..[117+23])
+                        Pcty_constr "t" (shortcut_ext_attr.ml[117+22]..[117+23])
                         []
                 ]
             ]
-          signature_item (shortcut_ext_attr.ml[118,2311+2]..[118,2311+28])
+          signature_item (shortcut_ext_attr.ml[118+2]..[118+28])
             Psig_extension "foo"
             [
-              signature_item (shortcut_ext_attr.ml[118,2311+2]..[118,2311+28]) ghost
+              signature_item (shortcut_ext_attr.ml[118+2]..[118+28]) ghost
                 Psig_class_type
                 [
-                  class_type_declaration (shortcut_ext_attr.ml[118,2311+2]..[118,2311+28])
+                  class_type_declaration (shortcut_ext_attr.ml[118+2]..[118+28])
                     attribute "foo"
                       []
                     pci_virt = Concrete
                     pci_params =
                       []
-                    pci_name = "x" (shortcut_ext_attr.ml[118,2311+23]..[118,2311+24])
+                    pci_name = "x" (shortcut_ext_attr.ml[118+23]..[118+24])
                     pci_expr =
-                      class_type (shortcut_ext_attr.ml[118,2311+27]..[118,2311+28])
-                        Pcty_constr "x" (shortcut_ext_attr.ml[118,2311+27]..[118,2311+28])
+                      class_type (shortcut_ext_attr.ml[118+27]..[118+28])
+                        Pcty_constr "x" (shortcut_ext_attr.ml[118+27]..[118+28])
                         []
                 ]
             ]

--- a/testsuite/tests/tool-ocamlc-stop-after/stop_after_parsing_impl.compilers.reference
+++ b/testsuite/tests/tool-ocamlc-stop-after/stop_after_parsing_impl.compilers.reference
@@ -1,39 +1,39 @@
 [
-  structure_item (stop_after_parsing_impl.ml[12,306+0]..[12,306+24])
+  structure_item (stop_after_parsing_impl.ml[12+0]..[12+24])
     Pstr_value Nonrec
     [
       <def>
-        pattern (stop_after_parsing_impl.ml[12,306+4]..[12,306+5])
+        pattern (stop_after_parsing_impl.ml[12+4]..[12+5])
           Ppat_any
-        expression (stop_after_parsing_impl.ml[12,306+8]..[12,306+24])
+        expression (stop_after_parsing_impl.ml[12+8]..[12+24])
           Pexp_apply
-          expression (stop_after_parsing_impl.ml[12,306+21]..[12,306+22])
-            Pexp_ident "+" (stop_after_parsing_impl.ml[12,306+21]..[12,306+22])
+          expression (stop_after_parsing_impl.ml[12+21]..[12+22])
+            Pexp_ident "+" (stop_after_parsing_impl.ml[12+21]..[12+22])
           [
             <arg>
             Nolabel
-              expression (stop_after_parsing_impl.ml[12,306+8]..[12,306+20])
+              expression (stop_after_parsing_impl.ml[12+8]..[12+20])
                 Pexp_apply
-                expression (stop_after_parsing_impl.ml[12,306+11]..[12,306+12])
-                  Pexp_ident "+" (stop_after_parsing_impl.ml[12,306+11]..[12,306+12])
+                expression (stop_after_parsing_impl.ml[12+11]..[12+12])
+                  Pexp_ident "+" (stop_after_parsing_impl.ml[12+11]..[12+12])
                 [
                   <arg>
                   Nolabel
-                    expression (stop_after_parsing_impl.ml[12,306+9]..[12,306+10])
+                    expression (stop_after_parsing_impl.ml[12+9]..[12+10])
                       Pexp_constant
-                      constant (stop_after_parsing_impl.ml[12,306+9]..[12,306+10])
+                      constant (stop_after_parsing_impl.ml[12+9]..[12+10])
                         PConst_int (1,None)
                   <arg>
                   Nolabel
-                    expression (stop_after_parsing_impl.ml[12,306+13]..[12,306+19])
+                    expression (stop_after_parsing_impl.ml[12+13]..[12+19])
                       Pexp_constant
-                      constant (stop_after_parsing_impl.ml[12,306+13]..[12,306+19])
-                        PConst_string("true",(stop_after_parsing_impl.ml[12,306+14]..[12,306+18]),None)
+                      constant (stop_after_parsing_impl.ml[12+13]..[12+19])
+                        PConst_string("true",(stop_after_parsing_impl.ml[12+14]..[12+18]),None)
                 ]
             <arg>
             Nolabel
-              expression (stop_after_parsing_impl.ml[12,306+23]..[12,306+24])
-                Pexp_ident "x" (stop_after_parsing_impl.ml[12,306+23]..[12,306+24])
+              expression (stop_after_parsing_impl.ml[12+23]..[12+24])
+                Pexp_ident "x" (stop_after_parsing_impl.ml[12+23]..[12+24])
           ]
     ]
 ]

--- a/testsuite/tests/tool-ocamlc-stop-after/stop_after_parsing_intf.compilers.reference
+++ b/testsuite/tests/tool-ocamlc-stop-after/stop_after_parsing_intf.compilers.reference
@@ -1,9 +1,9 @@
 [
-  signature_item (stop_after_parsing_intf.mli[12,306+0]..[12,306+61])
+  signature_item (stop_after_parsing_intf.mli[12+0]..[12+61])
     Psig_value
-    value_description "x" (stop_after_parsing_intf.mli[12,306+4]..[12,306+5]) (stop_after_parsing_intf.mli[12,306+0]..[12,306+61])
-      core_type (stop_after_parsing_intf.mli[12,306+8]..[12,306+61])
-        Ptyp_constr "Module_that_does_not_exists.type_that_does_not_exists" (stop_after_parsing_intf.mli[12,306+8]..[12,306+61])
+    value_description "x" (stop_after_parsing_intf.mli[12+4]..[12+5]) (stop_after_parsing_intf.mli[12+0]..[12+61])
+      core_type (stop_after_parsing_intf.mli[12+8]..[12+61])
+        Ptyp_constr "Module_that_does_not_exists.type_that_does_not_exists" (stop_after_parsing_intf.mli[12+8]..[12+61])
         []
       []
 ]

--- a/testsuite/tests/tool-ocamlc-stop-after/stop_after_typing_impl.compilers.reference
+++ b/testsuite/tests/tool-ocamlc-stop-after/stop_after_typing_impl.compilers.reference
@@ -1,14 +1,14 @@
 [
-  structure_item (stop_after_typing_impl.ml[13,365+0]..stop_after_typing_impl.ml[13,365+37])
+  structure_item (stop_after_typing_impl.ml[13,365+0]..[13,365+37])
     Tstr_primitive
-    value_description apply (stop_after_typing_impl.ml[13,365+0]..stop_after_typing_impl.ml[13,365+37])
-      core_type (stop_after_typing_impl.ml[13,365+16]..stop_after_typing_impl.ml[13,365+26])
+    value_description apply (stop_after_typing_impl.ml[13,365+0]..[13,365+37])
+      core_type (stop_after_typing_impl.ml[13,365+16]..[13,365+26])
         Ttyp_arrow
         Nolabel
-        core_type (stop_after_typing_impl.ml[13,365+16]..stop_after_typing_impl.ml[13,365+19])
+        core_type (stop_after_typing_impl.ml[13,365+16]..[13,365+19])
           Ttyp_constr "int!"
           []
-        core_type (stop_after_typing_impl.ml[13,365+23]..stop_after_typing_impl.ml[13,365+26])
+        core_type (stop_after_typing_impl.ml[13,365+23]..[13,365+26])
           Ttyp_constr "int!"
           []
       [

--- a/testsuite/tests/tool-ocamlc-stop-after/stop_after_typing_impl.compilers.reference
+++ b/testsuite/tests/tool-ocamlc-stop-after/stop_after_typing_impl.compilers.reference
@@ -1,14 +1,14 @@
 [
-  structure_item (stop_after_typing_impl.ml[13,365+0]..[13,365+37])
+  structure_item (stop_after_typing_impl.ml[13+0]..[13+37])
     Tstr_primitive
-    value_description apply (stop_after_typing_impl.ml[13,365+0]..[13,365+37])
-      core_type (stop_after_typing_impl.ml[13,365+16]..[13,365+26])
+    value_description apply (stop_after_typing_impl.ml[13+0]..[13+37])
+      core_type (stop_after_typing_impl.ml[13+16]..[13+26])
         Ttyp_arrow
         Nolabel
-        core_type (stop_after_typing_impl.ml[13,365+16]..[13,365+19])
+        core_type (stop_after_typing_impl.ml[13+16]..[13+19])
           Ttyp_constr "int!"
           []
-        core_type (stop_after_typing_impl.ml[13,365+23]..[13,365+26])
+        core_type (stop_after_typing_impl.ml[13+23]..[13+26])
           Ttyp_constr "int!"
           []
       [

--- a/typing/printtyped.ml
+++ b/typing/printtyped.ml
@@ -15,22 +15,10 @@
 
 open Asttypes
 open Format
-open Lexing
 open Location
 open Typedtree
 
-let fmt_position f l =
-  if l.pos_lnum = -1
-  then fprintf f "%s[%d]" l.pos_fname l.pos_cnum
-  else fprintf f "%s[%d,%d+%d]" l.pos_fname l.pos_lnum l.pos_bol
-               (l.pos_cnum - l.pos_bol)
-
-let fmt_location f loc =
-  if not !Clflags.locations then ()
-  else begin
-    fprintf f "(%a..%a)" fmt_position loc.loc_start fmt_position loc.loc_end;
-    if loc.loc_ghost then fprintf f " ghost";
-  end
+let fmt_location = Location.dump
 
 let rec fmt_longident_aux f x =
   match x with


### PR DESCRIPTION
This non-urgent PR (as one may see from the commit dates, it's been in the freezer for a while) continues the excellent work of #8541 at converting multi-line locations from:

```
Line STARTLINE, characters STARTCHAR-OFFSET
```
to
```
Lines STARTLINE-ENDLINE, characters STARTCHAR-ENDCHAR
```

#8541 updated `Location.print_loc` (the biggest case); this PR, thanks to the new debugging information present with #10111, extends this format to:
- Backtrace locations (`Printexc.format_backtrace_slot` and `caml_print_exception_backtrace`)
- `Printast.fmt_location` and `Printtyped.fmt_location` (used for `-dparsetree` and `-dtypedtree` respectively)
- `Lambda.lam` (used for `-dlambda`)

When added to two further tweaks:
- The removal of the "bol" (beginning of line) byte offset from the output of the AST dumps
- The correction of the regular expression in `tools/ocamltex.ml` from #12024 when `tools/ocamltex.ml` has been checked out on Windows

this restores the ability to run the testsuite on a default Windows checkout of the repository and allows a large number of entries in `.gitattributes` to be removed.

As ever, it's easiest viewed commit-by-commit - in particular, with each change the appropriate testsuite reference files demonstrate the effects.