### PR TITLE
Emphasize that Bigarray.int refers to the OCaml int type, and not the C int type

### DIFF
--- a/Changes
+++ b/Changes
@@ -214,10 +214,9 @@ _______________
 
 ### Manual and documentation:
 
-- #13295: Use syntax for deep effect handlers in the effect handlers manual
-  page.
-  (KC Sivaramakrishnan, review by Anil Madhavapeddy, Florian Angeletti and Miod
-   Vallat)
+- #12298: Manual: emphasize that Bigarray.int refers to an OCaml integer,
+  which does not match the C int type.
+  (Edwin Török, review by Florian Angeletti)
 
 - #12868: Manual: simplify style colours of the post-processed manual and API
   HTML pages, and fix the search button icon
@@ -238,6 +237,11 @@ _______________
 - #13287: stdlib/sys.mli: Update documentation on Sys.opaque_identity
   following #9412.
   (Matt Walker, review by Guillaume Munch-Maccagnoni and Vincent Laviron)
+
+- #13295: Use syntax for deep effect handlers in the effect handlers manual
+  page.
+  (KC Sivaramakrishnan, review by Anil Madhavapeddy, Florian Angeletti and Miod
+   Vallat)
 
 ### Compiler user-interface and warnings:
 

--- a/stdlib/bigarray.mli
+++ b/stdlib/bigarray.mli
@@ -61,7 +61,7 @@
      and {!Stdlib.input_value}).
 *)
 
-(** {1 Element kinds} *)
+(** {1:elementkinds Element kinds} *)
 
 (** Bigarrays can contain elements of the following kinds:
 - IEEE half precision (16 bits) floating-point numbers
@@ -186,7 +186,7 @@ val int16_unsigned : (int, int16_unsigned_elt) kind
 (** See {!Bigarray.char}. *)
 
 val int : (int, int_elt) kind
-(** See {!Bigarray.char}. *)
+(** See {!Bigarray.char} and {!section:elementkinds}. *)
 
 val int32 : (int32, int32_elt) kind
 (** See {!Bigarray.char}. *)

--- a/stdlib/bigarray.mli
+++ b/stdlib/bigarray.mli
@@ -186,7 +186,12 @@ val int16_unsigned : (int, int16_unsigned_elt) kind
 (** See {!Bigarray.char}. *)
 
 val int : (int, int_elt) kind
-(** See {!Bigarray.char} and {!section:elementkinds}. *)
+(** See {!Bigarray.char} and {!section:elementkinds}.
+
+   Beware that this is a bigarray containing OCaml integers
+   (signed, 31 bits on 32-bit architectures, 63 bits on 64-bit architectures),
+   which does not match the [C] int type.
+ *)
 
 val int32 : (int32, int32_elt) kind
 (** See {!Bigarray.char}. *)


### PR DESCRIPTION
This is already documented in 'element kinds', but I think it is worth emphasizing, because it can lead to bugs like  https://github.com/yallop/ocaml-ctypes/issues/744 if the C and OCaml types for 'int' are mixed up.

On Linux x86-64 they are of different sizes (8 bytes vs 4), and this can lead to memory corruption if one is not careful,
in fact the closest C type here would be `size_t`, and there is no bigarray that would map a C `int*` in a platform-independent way.