### PR TITLE
runtime/major_gc: Fix an access race on `caml_gc_phase`

### DIFF
--- a/runtime/caml/major_gc.h
+++ b/runtime/caml/major_gc.h
@@ -23,20 +23,8 @@ typedef enum {
   Phase_mark_final,
   Phase_sweep_ephe
 } gc_phase_t;
-extern gc_phase_t caml_gc_phase;
 
-Caml_inline char caml_gc_phase_char(gc_phase_t phase) {
-  switch (phase) {
-    case Phase_sweep_and_mark_main:
-      return 'M';
-    case Phase_mark_final:
-      return 'F';
-    case Phase_sweep_ephe:
-      return 'E';
-    default:
-      return 'U';
-  }
-}
+extern gc_phase_t caml_gc_phase;
 
 intnat caml_opportunistic_major_work_available (void);
 void caml_opportunistic_major_collection_slice (intnat);


### PR DESCRIPTION
This is my proposed fix for #12291, a data race on the `caml_gc_phase` global that was observed by @OlivierNicole thanks to ThreadSanitizer.

This PR is a new iteration on my previous attempt to fix the issue, https://github.com/ocaml/ocaml/commit/0d15388dbb1174a6b63273f10afdf79d0f79e0e5 . This previous attempt was integrated in the ThreadSanitizer PR #12114 and it does silence the TSan report -- so it presumably works -- but I didn't like the implementation.

I think that it makes sense for the present patch to be reviewed on its own, outside the TSan PR, because I would prefer to not make the TSan PR any more complex than it needs to be.

## Implementation

Most of the phase-accessing code in the major GC is performed under tests `if (mode != Slice_opportunistic)`. "opportunistic" slices are fragments of major collections that are performed by mutator threads during a *minor* collection, when they are idle waiting for synchronization by other STW participants. I reasoned that it is possible for this to happen while the other threads are in fact in the middle of a major collection, so this access to major-collection state (in particular the non-atomic global `caml_gc_phase`) could be racy.

My first fix was thus to access the `mode` variable of the major GC at the point where `caml_gc_phase` is accessed for debug printing purposes (the TSan report was pointing at this as the race location), and not do the access within opportunistic slices.

This may be a correct change, but in fact this is not the cause of the TSan report: the report points to `domain_terminate` as the place where the race occurs. The reason there is different: the `terminate` logic runs after the current domain has left the set of STW participants, so it may race with any further STW logic (including gc phase updates).

My first patch ( https://github.com/ocaml/ocaml/commit/0d15388dbb1174a6b63273f10afdf79d0f79e0e5 ) was a hack: `domain_terminate` would call a specific function with a `Slice_opportunistic` argument, and this would disable the racy access to `caml_gc_phase`.

The new patch proposed in the present PR is refactored to do the same thing, but without a hack. Instead of a `mode` parameter, the phase-accessing function simply takes a boolean value `may_access_gc_phase`.

## Question

Should `caml_gc_phase` simply be made an atomic variable instead?

Answer: maybe? I don't know what the performance implications would be, if any. Given that most of the runtime code appears to be non-racy (but for a non-completely-obvious reason that I am trying to document in the present PR), I assumed that having `caml_gc_phase` be non-atomic, protected by an existing synchronization mechanism, was an explicit design choice to be preserved.