### PR TITLE
[backport, 4.14] emit (amd64): emit frametable size on BSD as well (#10845)

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,8 @@
+* #10845 Emit frametable size on amd64 BSD (OpenBSD, FreeBSD, NetBSD) systems
+  (emitted for Linux in #8805)
+  (Hannes Mehnert, review by Nicolás Ojeda Bär)
+
+
 OCaml 4.14 maintenance version
 
 ### Runtime system:

--- a/asmcomp/amd64/emit.mlp
+++ b/asmcomp/amd64/emit.mlp
@@ -1020,7 +1020,7 @@ let end_assembly() =
       efa_string = (fun s -> D.bytes (s ^ "\000"))
     };
 
-  if system = S_linux then begin
+  if system = S_linux || system = S_freebsd || system = S_netbsd || system = S_openbsd then begin
     let frametable = emit_symbol (Compilenv.make_symbol (Some "frametable")) in
     D.size frametable (ConstSub (ConstThis, ConstLabel frametable))
   end;

--- a/asmcomp/x86_proc.ml
+++ b/asmcomp/x86_proc.ml
@@ -33,6 +33,9 @@ type system =
   | S_win64
   | S_linux
   | S_mingw64
+  | S_freebsd
+  | S_netbsd
+  | S_openbsd
 
   | S_unknown
 
@@ -50,6 +53,9 @@ let system = match Config.system with
   | "mingw64" -> S_mingw64
   | "win64" -> S_win64
   | "linux" -> S_linux
+  | "freebsd" -> S_freebsd
+  | "netbsd" -> S_netbsd
+  | "openbsd" -> S_openbsd
 
   | _ -> S_unknown
 

--- a/asmcomp/x86_proc.mli
+++ b/asmcomp/x86_proc.mli
@@ -74,6 +74,9 @@ type system =
   | S_win64
   | S_linux
   | S_mingw64
+  | S_freebsd
+  | S_netbsd
+  | S_openbsd
 
   | S_unknown
 


### PR DESCRIPTION
* emit (amd64): emit frametable size on BSD as well

As discussed on https://github.com/ocaml/ocaml/pull/10845#issuecomment-1589307566