### PR TITLE
Allow `make promote-menhir` from Windows

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -30,6 +30,14 @@ SPACE := $(EMPTY) $(EMPTY)
 # $( ) suppresses warning from the alignments in the V_ macros below
 $(SPACE) :=
 
+ifeq "$(UNIX_OR_WIN32)" "win32"
+DIR_SEP := \$ # There must a space following the $
+CONVERT_PATH = $(subst /,$(DIR_SEP),$(strip $(1)))
+else
+DIR_SEP = /
+CONVERT_PATH = $(strip $(1))
+endif
+
 V ?= 0
 
 ifeq "$(V)" "0"

--- a/Makefile.menhir
+++ b/Makefile.menhir
@@ -76,7 +76,7 @@ MENHIRBASICFLAGS := \
 MENHIRFLAGS := \
   $(MENHIRBASICFLAGS) \
   --infer \
-  --ocamlc "$(CAMLC) $(OC_COMMON_COMPFLAGS) $(INCLUDES)" \
+  --ocamlc "$(call CONVERT_PATH, $(CAMLC)) $(OC_COMMON_COMPFLAGS) $(INCLUDES)" \
   --fixed-exception \
   --table \
   --strategy simplified \
@@ -105,12 +105,12 @@ promote-menhir: parsing/parser.mly
 # an incompatible version of menhirLib, which would fail at
 # compile-time.
 
+boot/menhir:
+	@$(MKDIR) $@
+
 .PHONY: import-menhirLib
-import-menhirLib:
-	@ mkdir -p boot/menhir
-	@ cp \
-           $(addprefix `$(MENHIR) --suggest-menhirLib`/menhirLib.,ml mli) \
-           boot/menhir
+import-menhirLib: | boot/menhir
+	@cp $(addprefix $(shell $(MENHIR) --suggest-menhirLib)/menhirLib.,ml mli) $|
 
 
 ## demote-menhir


### PR DESCRIPTION
On the occasions in the past when I've had to run `make promote-menhir` I've clearly been lazy and done it from Linux 😉

There were two problems which are fixed here:
- `menhir --suggest-menhirLib` returns a CRLF string on Windows, and the `\r` was causing problems. The best fix is to use `$(shell` instead of backticks, both because it stops menhir being called twice and also because `$(shell `) automatically strips the line endings.
- Menhir's `--ocamlc` needs to be passed a Windows path (i.e. with backslashes) because it gets passed to `Sys.command`. The necessary machinery is added to convert the slashes when running from Windows.