### PR TITLE
Add a warning when redefining the 'true' or 'false' constructors

### DIFF
--- a/man/ocamlc.1
+++ b/man/ocamlc.1
@@ -1132,6 +1132,9 @@ transformation.
 A generative functor is applied to an empty structure (struct end) rather than
 to ().
 
+.B 74 [redefining-boolean]
+.br
+Type declaration defining a new 'true' or 'false' constructor.
 
 The letters stand for the following sets of warnings.  Any letter not
 mentioned here corresponds to the empty set.

--- a/testsuite/tests/typing-misc/pattern_open.ml
+++ b/testsuite/tests/typing-misc/pattern_open.ml
@@ -96,6 +96,7 @@ Right value K.x
 module Exterior = struct
   module Gadt = struct
     module Boolean = struct
+      [@@@ocaml.warning "-74"]
       type t = { b : bool }
       type wrong = false | true
       let print () = pp "Wrong function: Exterior.Gadt.Boolean.print"

--- a/testsuite/tests/typing-misc/wrong_kind.ml
+++ b/testsuite/tests/typing-misc/wrong_kind.ml
@@ -19,6 +19,7 @@ module Record = struct
 end
 
 module Bool = struct
+  [@@@warning "-74"]
   type t = true | false
 
   let get _ _ = true

--- a/testsuite/tests/warnings/w74.compilers.reference
+++ b/testsuite/tests/warnings/w74.compilers.reference
@@ -1,0 +1,33 @@
+File "w74.ml", line 12, characters 0-13:
+12 | type a = true
+     ^^^^^^^^^^^^^
+Warning 74 [redefining-boolean]: This type declaration is defining a new 'true' constructor,
+which shadows the existing constructor.
+
+File "w74.ml", line 13, characters 0-14:
+13 | type b = false
+     ^^^^^^^^^^^^^^
+Warning 74 [redefining-boolean]: This type declaration is defining a new 'false' constructor,
+which shadows the existing constructor.
+
+File "w74.ml", lines 15-17, characters 0-9:
+15 | type c =
+16 |   | true
+17 |   | false
+Warning 74 [redefining-boolean]: This type declaration is defining a new 'true' constructor,
+which shadows the existing constructor.
+
+File "w74.ml", lines 15-17, characters 0-9:
+15 | type c =
+16 |   | true
+17 |   | false
+Warning 74 [redefining-boolean]: This type declaration is defining a new 'false' constructor,
+which shadows the existing constructor.
+
+File "w74.ml", lines 19-22, characters 0-5:
+19 | type d =
+20 |   | A
+21 |   | true
+22 |   | C
+Warning 74 [redefining-boolean]: This type declaration is defining a new 'true' constructor,
+which shadows the existing constructor.

--- a/testsuite/tests/warnings/w74.ml
+++ b/testsuite/tests/warnings/w74.ml
@@ -1,0 +1,34 @@
+(* TEST_BELOW
+(* Blank lines added here to preserve locations. *)
+
+
+
+
+
+
+
+*)
+
+type a = true
+type b = false
+
+type c =
+  | true
+  | false
+
+type d =
+  | A
+  | true
+  | C
+
+type should_not_warn = bool =
+  | false
+  | true
+
+(* TEST
+ flags = "-w +A-70";
+ setup-ocamlc.byte-build-env;
+ compile_only = "true";
+ ocamlc.byte;
+ check-ocamlc.byte-output;
+*)

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -1025,6 +1025,28 @@ let check_redefined_unit (td: Parsetree.type_declaration) =
   | _ ->
       ()
 
+let check_redefined_boolean (td : Parsetree.type_declaration) =
+  let redefined_boolean_constructor ({ txt; loc = _ } : _ Asttypes.loc) =
+    match txt with
+    | "true" -> Some true
+    | "false" -> Some false
+    | _ -> None
+  in
+  match td with
+  | { ptype_name = _;
+      ptype_manifest = None;
+      ptype_kind = Ptype_variant cds } ->
+      List.iter
+        (fun cd ->
+         match redefined_boolean_constructor cd.pcd_name with
+         | Some boolean -> Location.prerr_warning td.ptype_loc
+           (Warnings.Redefining_boolean boolean)
+         | None -> ())
+       cds
+  | _ ->
+      ()
+
+
 let add_types_to_env decls env =
   List.fold_right
     (fun (id, decl) env -> add_type ~check:true id decl env)
@@ -1033,6 +1055,7 @@ let add_types_to_env decls env =
 (* Translate a set of type declarations, mutually recursive or not *)
 let transl_type_decl env rec_flag sdecl_list =
   List.iter check_redefined_unit sdecl_list;
+  List.iter check_redefined_boolean sdecl_list;
   (* Add dummy types for fixed rows *)
   let fixed_types = List.filter is_fixed_type sdecl_list in
   let sdecl_list =

--- a/utils/warnings.ml
+++ b/utils/warnings.ml
@@ -109,6 +109,7 @@ type t =
   | Unused_tmc_attribute                    (* 71 *)
   | Tmc_breaks_tailcall                     (* 72 *)
   | Generative_application_expects_unit     (* 73 *)
+  | Redefining_boolean of bool              (* 74 *)
 
 (* If you remove a warning, leave a hole in the numbering.  NEVER change
    the numbers of existing warnings.
@@ -190,12 +191,13 @@ let number = function
   | Unused_tmc_attribute -> 71
   | Tmc_breaks_tailcall -> 72
   | Generative_application_expects_unit -> 73
+  | Redefining_boolean _ -> 74
 ;;
 (* DO NOT REMOVE the ;; above: it is used by
    the testsuite/ests/warnings/mnemonics.mll test to determine where
    the  definition of the number function above ends *)
 
-let last_warning_number = 73
+let last_warning_number = 74
 
 type description =
   { number : int;
@@ -534,6 +536,11 @@ let descriptions = [
     description = "A generative functor is applied to an empty structure \
                    (struct end) rather than to ().";
     since = since 5 1 };
+  { number = 74;
+    names = ["redefining-boolean"];
+    description = "Type declaration defining a new 'true' or 'false' \
+                   constructor.";
+    since = since 5 2 };
 ]
 
 let name_to_number =
@@ -1135,6 +1142,11 @@ let message = function
   | Generative_application_expects_unit ->
       "A generative functor\n\
        should be applied to '()'; using '(struct end)' is deprecated."
+  | Redefining_boolean redefined_boolean ->
+      Printf.sprintf
+        "This type declaration is defining a new '%B' constructor,\n\
+         which shadows the existing constructor."
+       redefined_boolean
 ;;
 
 let nerrors = ref 0

--- a/utils/warnings.ml
+++ b/utils/warnings.ml
@@ -15,7 +15,7 @@
 
 (* When you change this, you need to update:
    - the list 'description' at the bottom of this file
-   - man/ocamlc.m
+   - man/ocamlc.1
 *)
 
 type loc = {

--- a/utils/warnings.mli
+++ b/utils/warnings.mli
@@ -112,6 +112,7 @@ type t =
   | Unused_tmc_attribute                    (* 71 *)
   | Tmc_breaks_tailcall                     (* 72 *)
   | Generative_application_expects_unit     (* 73 *)
+  | Redefining_boolean of bool              (* 74 *)
 
 type alert = {kind:string; message:string; def:loc; use:loc}
 


### PR DESCRIPTION
This PR partially addresses #10655. It adds a new warning for when the 'true' or 'false' constructors are redefined (but not equated with an existing type), similar to when '()' constructors are defined. This warning differs from the unit constructor redefinition warning in that the latter does not warn on:
```ocaml
type t =
  | A
  | ()
```
whereas this new warning is emitted on
```ocaml
type t =
  | A
  | true
```

This is my first contribution, please let me know if the PR is missing anything! I am planning on adding the change to the Changes file if it gets reviewed/approved.