### PR TITLE
Do not re-build type for or-pattern if a ground type annotation is given

### DIFF
--- a/Changes
+++ b/Changes
@@ -15,6 +15,12 @@ Working version
 - #12315: Use type annotations from arguments in let rec
   (Stephen Dolan, review by Gabriel Scherer)
 
+### Type system:
+
+- #???, #11799: Do not re-build as-pattern type when a ground type annotation
+  is given. This allows to work around problems with GADTs in as-patterns.
+  (Jacques Garrigue, report by Leo White, review by ???)
+
 ### Runtime system:
 
 - #10111: Increase the detail of location information for debugging events to

--- a/Changes
+++ b/Changes
@@ -17,9 +17,9 @@ Working version
 
 ### Type system:
 
-- #???, #11799: Do not re-build as-pattern type when a ground type annotation
+- #12313, #11799: Do not re-build as-pattern type when a ground type annotation
   is given. This allows to work around problems with GADTs in as-patterns.
-  (Jacques Garrigue, report by Leo White, review by ???)
+  (Jacques Garrigue, report by Leo White, review by Gabriel Scherer)
 
 ### Runtime system:
 

--- a/testsuite/tests/typing-gadts/or_patterns.ml
+++ b/testsuite/tests/typing-gadts/or_patterns.ml
@@ -697,17 +697,50 @@ val f_ok : 'a t -> bool iref -> 'a iref -> unit = <fun>
 let f_amb (type a) (t : a t) (a : bool ref) (b : a ref) =
   match t, a, b with
   | IntLit,  ({ contents = true } as x), _
-  | BoolLit,  _,                        ({ contents = true} as x) -> ignore x
+  | BoolLit,  _, ({ contents = true} as x) -> ignore x
   | _, _, _ -> ()
 ;;
 [%%expect{|
-Lines 3-4, characters 4-65:
+Lines 3-4, characters 4-42:
 3 | ....IntLit,  ({ contents = true } as x), _
-4 |   | BoolLit,  _,                        ({ contents = true} as x)............
+4 |   | BoolLit,  _, ({ contents = true} as x)............
 Error: The variable "x" on the left-hand side of this or-pattern has type
          "bool ref"
        but on the right-hand side it has type "a ref"
        Type "bool" is not compatible with type "a"
+|}]
+
+let f_disamb (type a) (t : a t) (a : bool ref) (b : a ref) =
+  match t, a, b with
+  | IntLit,  ({ contents = true } as x), _
+  | BoolLit,  _, (({ contents = true} : bool ref) as x) -> ignore x
+  | _, _, _ -> ()
+;;
+[%%expect{|
+val f_disamb : 'a t -> bool ref -> 'a ref -> unit = <fun>
+|}]
+
+(* #11799 *)
+type _ t =
+      | A : [ `A ] t
+      | B : [ `B ] t
+
+let foo : type a. a t -> a t =
+  function (A | B) as t -> t
+[%%expect{|
+type _ t = A : [ `A ] t | B : [ `B ] t
+Line 6, characters 16-17:
+6 |   function (A | B) as t -> t
+                    ^
+Error: This pattern matches values of type "[ `B ] t"
+       but a pattern was expected which matches values of type "[ `A ] t"
+       These two variant types have no intersection
+|}]
+
+let foo : type a. a t -> a t =
+  function (A | B : a t) as t -> t
+[%%expect{|
+val foo : 'a t -> 'a t = <fun>
 |}]
 
 (********************************************)

--- a/testsuite/tests/typing-gadts/or_patterns.ml
+++ b/testsuite/tests/typing-gadts/or_patterns.ml
@@ -720,7 +720,7 @@ let f_disamb (type a) (t : a t) (a : bool ref) (b : a ref) =
 val f_disamb : 'a t -> bool ref -> 'a ref -> unit = <fun>
 |}]
 
-(* #11799 *)
+(* #11799, #12313 *)
 type _ t =
       | A : [ `A ] t
       | B : [ `B ] t

--- a/testsuite/tests/typing-gadts/pr10735.ml
+++ b/testsuite/tests/typing-gadts/pr10735.ml
@@ -18,10 +18,6 @@ type (_, _) eq = Refl : ('a, 'a) eq
 |}]
 
 let () =
-  let (Refl : (bool X.t, bool t) eq) as t = Obj.magic  () in ()
+  let (Refl : (bool X.t, bool t) eq) as t = Obj.magic  () in ignore t
 [%%expect{|
-Line 2, characters 6-41:
-2 |   let (Refl : (bool X.t, bool t) eq) as t = Obj.magic  () in ()
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Warning 26 [unused-var]: unused variable t.
 |}]

--- a/testsuite/tests/typing-gadts/pr10735.ml
+++ b/testsuite/tests/typing-gadts/pr10735.ml
@@ -20,11 +20,8 @@ type (_, _) eq = Refl : ('a, 'a) eq
 let () =
   let (Refl : (bool X.t, bool t) eq) as t = Obj.magic  () in ()
 [%%expect{|
-Line 2, characters 7-11:
+Line 2, characters 6-41:
 2 |   let (Refl : (bool X.t, bool t) eq) as t = Obj.magic  () in ()
-           ^^^^
-Error: This pattern matches values of type "(bool X.t, bool X.t) eq"
-       but a pattern was expected which matches values of type
-         "(bool X.t, bool t) eq"
-       Type "bool X.t" is not compatible with type "bool t"
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Warning 26 [unused-var]: unused variable t.
 |}]

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -571,7 +571,14 @@ let enter_orpat_variables loc env  p1_vs p2_vs =
   unify_vars p1_vs p2_vs
 
 let rec build_as_type (env : Env.t) p =
-  let as_ty = build_as_type_aux env p in
+  let has_ground_constraint =
+    List.exists
+      (function Tpat_constraint cty, _, _ -> free_variables cty.ctyp_type = []
+        | _ -> false)
+      p.pat_extra
+  in
+  let as_ty =
+    if has_ground_constraint then newgenvar () else build_as_type_aux env p in
   (* Cf. #1655 *)
   List.fold_left (fun as_ty (extra, _loc, _attrs) ->
     match extra with

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -571,35 +571,30 @@ let enter_orpat_variables loc env  p1_vs p2_vs =
   unify_vars p1_vs p2_vs
 
 let rec build_as_type (env : Env.t) p =
-  (* Special handling of ground type annotations (#12313) *)
-  let has_ground_constraint =
-    List.exists
-      (function Tpat_constraint cty, _, _ -> free_variables cty.ctyp_type = []
-        | _ -> false)
-      p.pat_extra
-  in
-  let as_ty =
-    (* If there is a ground constraint, the [fold_left] below is going to
-       return it, so we can just use a fesh type variable here. *)
-    if has_ground_constraint then newgenvar () else build_as_type_aux env p in
-  (* Cf. #1655 *)
-  List.fold_left (fun as_ty (extra, _loc, _attrs) ->
-    match extra with
-    | Tpat_type _ | Tpat_open _ | Tpat_unpack -> as_ty
-    | Tpat_constraint cty ->
+  build_as_type_extra env p p.pat_extra
+
+and build_as_type_extra env p = function
+  | [] -> build_as_type_aux env p
+  | ((Tpat_type _ | Tpat_open _ | Tpat_unpack), _, _) :: rest ->
+      build_as_type_extra env p rest
+  | (Tpat_constraint {ctyp_type = ty; _}, _, _) :: rest ->
+      (* If the type constraint is ground, then this is the best type
+         we can return, so just return an instance (cf. #12313) *)
+      if free_variables ty = [] then instance ty else
+      (* Otherwise we combine the inferred type for the pattern with
+         then non-ground constraint in a non-ambivalent way *)
+      let as_ty = build_as_type_extra env p rest in
       (* [generic_instance] can only be used if the variables of the original
          type ([cty.ctyp_type] here) are not at [generic_level], which they are
          here.
          If we used [generic_instance] we would lose the sharing between
          [instance ty] and [ty].  *)
       let ty =
-        with_local_level ~post:generalize_structure
-          (fun () -> instance cty.ctyp_type)
+        with_local_level ~post:generalize_structure (fun () -> instance ty)
       in
       (* This call to unify may only fail due to missing GADT equations *)
       unify_pat_types p.pat_loc env (instance as_ty) (instance ty);
       ty
-  ) as_ty p.pat_extra
 
 and build_as_type_aux (env : Env.t) p =
   match p.pat_desc with


### PR DESCRIPTION
This is an alternative fix to #11799 : rather than introduce a new behavior in case of failure, do not reconstruct the type if a ground type annotation is given. This one is conservative, as `build_as_type` already honors type annotations: if a ground type annotation is given, then the only possible type is that one.

See https://github.com/ocaml/ocaml/pull/11799#issuecomment-1597363236 for a discussion leading to this approach.