### PR TITLE
Discard out_channel buffered data on permanent I/O error

### DIFF
--- a/Changes
+++ b/Changes
@@ -68,6 +68,10 @@ Working version
   due to memory resource exhaustion.  It was previous always a `Failure`.
   (Anil Madhavapeddy, review by David Allsopp)
 
+- #12300, #12314: Discard out_channel buffered data on permanent I/O error
+  (Xavier Leroy, report by Török Edwin, review by Anil Madhavapeddy
+  and Nicolás Ojeda Bär)
+
 ### Code generation and optimizations:
 
 - #11239: on x86-64 and RISC-V, reduce alignment of OCaml stacks from 16 to 8.

--- a/otherlibs/unix/unixsupport_win32.c
+++ b/otherlibs/unix/unixsupport_win32.c
@@ -23,6 +23,7 @@
 #include <caml/fail.h>
 #include <caml/custom.h>
 #include <caml/platform.h>
+#include <caml/osdeps.h>
 #include "unixsupport.h"
 #include "cst2constr.h"
 #include <errno.h>
@@ -89,89 +90,16 @@ value win_alloc_handle_or_socket(HANDLE h)
 
 /* Mapping of Windows error codes to POSIX error codes */
 
-struct error_entry { DWORD win_code; int range; int posix_code; };
-
-static struct error_entry win_error_table[] = {
-  { ERROR_INVALID_FUNCTION, 0, EINVAL},
-  { ERROR_FILE_NOT_FOUND, 0, ENOENT},
-  { ERROR_PATH_NOT_FOUND, 0, ENOENT},
-  { ERROR_TOO_MANY_OPEN_FILES, 0, EMFILE},
-  { ERROR_TOO_MANY_LINKS, 0, EMLINK},
-  { ERROR_ACCESS_DENIED, 0, EACCES},
-  { ERROR_INVALID_HANDLE, 0, EBADF},
-  { ERROR_ARENA_TRASHED, 0, ENOMEM},
-  { ERROR_NOT_ENOUGH_MEMORY, 0, ENOMEM},
-  { ERROR_INVALID_BLOCK, 0, ENOMEM},
-  { ERROR_BAD_ENVIRONMENT, 0, E2BIG},
-  { ERROR_BAD_FORMAT, 0, ENOEXEC},
-  { ERROR_INVALID_ACCESS, 0, EINVAL},
-  { ERROR_INVALID_DATA, 0, EINVAL},
-  { ERROR_INVALID_DRIVE, 0, ENOENT},
-  { ERROR_CURRENT_DIRECTORY, 0, EACCES},
-  { ERROR_NOT_SAME_DEVICE, 0, EXDEV},
-  { ERROR_NO_MORE_FILES, 0, ENOENT},
-  { ERROR_LOCK_VIOLATION, 0, EACCES},
-  { ERROR_BAD_NETPATH, 0, ENOENT},
-  { ERROR_NETWORK_ACCESS_DENIED, 0, EACCES},
-  { ERROR_BAD_NET_NAME, 0, ENOENT},
-  { ERROR_FILE_EXISTS, 0, EEXIST},
-  { ERROR_CANNOT_MAKE, 0, EACCES},
-  { ERROR_FAIL_I24, 0, EACCES},
-  { ERROR_INVALID_PARAMETER, 0, EINVAL},
-  { ERROR_NO_PROC_SLOTS, 0, EAGAIN},
-  { ERROR_DRIVE_LOCKED, 0, EACCES},
-  { ERROR_BROKEN_PIPE, 0, EPIPE},
-  { ERROR_NO_DATA, 0, EPIPE},
-  { ERROR_DISK_FULL, 0, ENOSPC},
-  { ERROR_INVALID_TARGET_HANDLE, 0, EBADF},
-  { ERROR_INVALID_HANDLE, 0, EINVAL},
-  { ERROR_WAIT_NO_CHILDREN, 0, ECHILD},
-  { ERROR_CHILD_NOT_COMPLETE, 0, ECHILD},
-  { ERROR_DIRECT_ACCESS_HANDLE, 0, EBADF},
-  { ERROR_NEGATIVE_SEEK, 0, EINVAL},
-  { ERROR_SEEK_ON_DEVICE, 0, EACCES},
-  { ERROR_DIR_NOT_EMPTY, 0, ENOTEMPTY},
-  { ERROR_NOT_LOCKED, 0, EACCES},
-  { ERROR_BAD_PATHNAME, 0, ENOENT},
-  { ERROR_MAX_THRDS_REACHED, 0, EAGAIN},
-  { ERROR_LOCK_FAILED, 0, EACCES},
-  { ERROR_ALREADY_EXISTS, 0, EEXIST},
-  { ERROR_FILENAME_EXCED_RANGE, 0, ENOENT},
-  { ERROR_NESTING_NOT_ALLOWED, 0, EAGAIN},
-  { ERROR_NOT_ENOUGH_QUOTA, 0, ENOMEM},
-  { ERROR_INVALID_STARTING_CODESEG,
-    ERROR_INFLOOP_IN_RELOC_CHAIN - ERROR_INVALID_STARTING_CODESEG,
-    ENOEXEC },
-  { ERROR_WRITE_PROTECT,
-    ERROR_SHARING_BUFFER_EXCEEDED - ERROR_WRITE_PROTECT,
-    EACCES },
-  { ERROR_PRIVILEGE_NOT_HELD, 0, EPERM},
-  { WSAEINVAL, 0, EINVAL },
-  { WSAEACCES, 0, EACCES },
-  { WSAEBADF, 0, EBADF },
-  { WSAEFAULT, 0, EFAULT },
-  { WSAEINTR, 0, EINTR },
-  { WSAEINVAL, 0, EINVAL },
-  { WSAEMFILE, 0, EMFILE },
-  { WSAENAMETOOLONG, 0, ENAMETOOLONG },
-  { WSAENOTEMPTY, 0, ENOTEMPTY },
-  { 0, -1, 0 }
-};
-
-void caml_win32_maperr(DWORD errcode)
+void caml_win32_maperr(DWORD win32err)
 {
-  int i;
-
-  for (i = 0; win_error_table[i].range >= 0; i++) {
-    if (errcode >= win_error_table[i].win_code &&
-        errcode <= win_error_table[i].win_code + win_error_table[i].range) {
-      errno = win_error_table[i].posix_code;
-      return;
-    }
+  int posixerr = caml_posixerr_of_win32err(win32err);
+  if (posixerr != 0) {
+    errno = posixerr;
+  } else {
+    /* Not found: save original error code, negated so that we can
+       recognize it in caml_unix_error_message */
+    errno = -win32err;
   }
-  /* Not found: save original error code, negated so that we can
-     recognize it in caml_unix_error_message */
-  errno = -errcode;
 }
 
 /* Windows socket errors */

--- a/runtime/caml/osdeps.h
+++ b/runtime/caml/osdeps.h
@@ -112,6 +112,10 @@ void caml_plat_mem_unmap(void *, uintnat);
 
 #ifdef _WIN32
 
+/* Map a Win32 error code (as returned by GetLastError) to a POSIX error code
+   (from <errno.h>).  Return 0 if no POSIX error code matches. */
+CAMLextern int caml_posixerr_of_win32err(unsigned int win32err);
+
 extern int caml_win32_rename(const wchar_t *, const wchar_t *);
 CAMLextern int caml_win32_unlink(const wchar_t *);
 

--- a/runtime/caml/osdeps.h
+++ b/runtime/caml/osdeps.h
@@ -32,16 +32,12 @@ extern unsigned short caml_win32_revision;
 #include "misc.h"
 #include "memory.h"
 
-#define Io_interrupted (-1)
-
 /* Read at most [n] bytes from file descriptor [fd] into buffer [buf].
    [flags] indicates whether [fd] is a socket
    (bit [CHANNEL_FLAG_FROM_SOCKET] is set in this case, see [io.h]).
    (This distinction matters for Win32, but not for Unix.)
    Return number of bytes read.
-   In case of error, raises [Sys_error] or [Sys_blocked_io].
-   If interrupted by a signal and no bytes where read, returns
-   Io_interrupted without raising. */
+   In case of error, set [errno] and return -1. */
 extern int caml_read_fd(int fd, int flags, void * buf, int n);
 
 /* Write at most [n] bytes from buffer [buf] onto file descriptor [fd].
@@ -49,9 +45,7 @@ extern int caml_read_fd(int fd, int flags, void * buf, int n);
    (bit [CHANNEL_FLAG_FROM_SOCKET] is set in this case, see [io.h]).
    (This distinction matters for Win32, but not for Unix.)
    Return number of bytes written.
-   In case of error, raises [Sys_error] or [Sys_blocked_io].
-   If interrupted by a signal and no bytes were written, returns
-   Io_interrupted without raising. */
+   In case of error, set [errno] and return -1. */
 extern int caml_write_fd(int fd, int flags, void * buf, int n);
 
 /* Decompose the given path into a list of directories, and add them

--- a/runtime/unix.c
+++ b/runtime/unix.c
@@ -89,10 +89,6 @@ int caml_read_fd(int fd, int flags, void * buf, int n)
   caml_enter_blocking_section_no_pending();
   retcode = read(fd, buf, n);
   caml_leave_blocking_section();
-  if (retcode == -1) {
-    if (errno == EINTR) return Io_interrupted;
-    else caml_sys_io_error(NO_ARG);
-  }
   return retcode;
 }
 
@@ -104,7 +100,6 @@ int caml_write_fd(int fd, int flags, void * buf, int n)
   retcode = write(fd, buf, n);
   caml_leave_blocking_section();
   if (retcode == -1) {
-    if (errno == EINTR) return Io_interrupted;
     if ((errno == EAGAIN || errno == EWOULDBLOCK) && n > 1) {
       /* We couldn't do a partial write here, probably because
          n <= PIPE_BUF and POSIX says that writes of less than
@@ -114,8 +109,7 @@ int caml_write_fd(int fd, int flags, void * buf, int n)
       n = 1; goto again;
     }
   }
-  if (retcode == -1) caml_sys_io_error(NO_ARG);
-  CAMLassert (retcode > 0);
+  CAMLassert (retcode > 0 || retcode == -1);
   return retcode;
 }
 

--- a/runtime/win32.c
+++ b/runtime/win32.c
@@ -803,7 +803,6 @@ int caml_win32_rename(const wchar_t * oldpath, const wchar_t * newpath)
                  MOVEFILE_COPY_ALLOWED)) {
     return 0;
   }
-
   /* Another cornercase not handled by MoveFileEx:
      - dir to empty dir - positive - should succeed */
   if ((old_attribs != INVALID_FILE_ATTRIBUTES) &&
@@ -820,23 +819,8 @@ int caml_win32_rename(const wchar_t * oldpath, const wchar_t * newpath)
     }
   }
 
-  /* Modest attempt at mapping Win32 error codes to POSIX error codes.
-     The __dosmaperr() function from the CRT does a better job but is
-     generally not accessible. */
-  switch (GetLastError()) {
-  case ERROR_FILE_NOT_FOUND: case ERROR_PATH_NOT_FOUND:
-    errno = ENOENT; break;
-  case ERROR_ACCESS_DENIED: case ERROR_WRITE_PROTECT: case ERROR_CANNOT_MAKE:
-    errno = EACCES; break;
-  case ERROR_CURRENT_DIRECTORY: case ERROR_BUSY:
-    errno = EBUSY; break;
-  case ERROR_NOT_SAME_DEVICE:
-    errno = EXDEV; break;
-  case ERROR_ALREADY_EXISTS:
-    errno = EEXIST; break;
-  default:
-    errno = EINVAL;
-  }
+  errno = caml_posixerr_of_win32err(GetLastError());
+  if (errno == 0) errno = EINVAL;
   return -1;
 }
 
@@ -1176,4 +1160,86 @@ void caml_plat_mem_unmap(void* mem, uintnat size)
 {
   if (!VirtualFree(mem, 0, MEM_RELEASE))
     CAMLassert(0);
+}
+
+/* Mapping Win32 error codes to POSIX error codes */
+
+struct error_entry { DWORD win_code; int range; int posix_code; };
+
+static struct error_entry win_error_table[] = {
+  { ERROR_INVALID_FUNCTION, 0, EINVAL},
+  { ERROR_FILE_NOT_FOUND, 0, ENOENT},
+  { ERROR_PATH_NOT_FOUND, 0, ENOENT},
+  { ERROR_TOO_MANY_OPEN_FILES, 0, EMFILE},
+  { ERROR_TOO_MANY_LINKS, 0, EMLINK},
+  { ERROR_ACCESS_DENIED, 0, EACCES},
+  { ERROR_INVALID_HANDLE, 0, EBADF},
+  { ERROR_ARENA_TRASHED, 0, ENOMEM},
+  { ERROR_NOT_ENOUGH_MEMORY, 0, ENOMEM},
+  { ERROR_INVALID_BLOCK, 0, ENOMEM},
+  { ERROR_BAD_ENVIRONMENT, 0, E2BIG},
+  { ERROR_BAD_FORMAT, 0, ENOEXEC},
+  { ERROR_INVALID_ACCESS, 0, EINVAL},
+  { ERROR_INVALID_DATA, 0, EINVAL},
+  { ERROR_INVALID_DRIVE, 0, ENOENT},
+  { ERROR_CURRENT_DIRECTORY, 0, EACCES},
+  { ERROR_NOT_SAME_DEVICE, 0, EXDEV},
+  { ERROR_NO_MORE_FILES, 0, ENOENT},
+  { ERROR_LOCK_VIOLATION, 0, EACCES},
+  { ERROR_BAD_NETPATH, 0, ENOENT},
+  { ERROR_NETWORK_ACCESS_DENIED, 0, EACCES},
+  { ERROR_BAD_NET_NAME, 0, ENOENT},
+  { ERROR_FILE_EXISTS, 0, EEXIST},
+  { ERROR_CANNOT_MAKE, 0, EACCES},
+  { ERROR_FAIL_I24, 0, EACCES},
+  { ERROR_INVALID_PARAMETER, 0, EINVAL},
+  { ERROR_NO_PROC_SLOTS, 0, EAGAIN},
+  { ERROR_DRIVE_LOCKED, 0, EACCES},
+  { ERROR_BROKEN_PIPE, 0, EPIPE},
+  { ERROR_NO_DATA, 0, EPIPE},
+  { ERROR_DISK_FULL, 0, ENOSPC},
+  { ERROR_INVALID_TARGET_HANDLE, 0, EBADF},
+  { ERROR_INVALID_HANDLE, 0, EINVAL},
+  { ERROR_WAIT_NO_CHILDREN, 0, ECHILD},
+  { ERROR_CHILD_NOT_COMPLETE, 0, ECHILD},
+  { ERROR_DIRECT_ACCESS_HANDLE, 0, EBADF},
+  { ERROR_NEGATIVE_SEEK, 0, EINVAL},
+  { ERROR_SEEK_ON_DEVICE, 0, EACCES},
+  { ERROR_DIR_NOT_EMPTY, 0, ENOTEMPTY},
+  { ERROR_NOT_LOCKED, 0, EACCES},
+  { ERROR_BAD_PATHNAME, 0, ENOENT},
+  { ERROR_MAX_THRDS_REACHED, 0, EAGAIN},
+  { ERROR_LOCK_FAILED, 0, EACCES},
+  { ERROR_ALREADY_EXISTS, 0, EEXIST},
+  { ERROR_FILENAME_EXCED_RANGE, 0, ENOENT},
+  { ERROR_NESTING_NOT_ALLOWED, 0, EAGAIN},
+  { ERROR_NOT_ENOUGH_QUOTA, 0, ENOMEM},
+  { ERROR_INVALID_STARTING_CODESEG,
+    ERROR_INFLOOP_IN_RELOC_CHAIN - ERROR_INVALID_STARTING_CODESEG,
+    ENOEXEC },
+  { ERROR_WRITE_PROTECT,
+    ERROR_SHARING_BUFFER_EXCEEDED - ERROR_WRITE_PROTECT,
+    EACCES },
+  { ERROR_PRIVILEGE_NOT_HELD, 0, EPERM},
+  { WSAEINVAL, 0, EINVAL },
+  { WSAEACCES, 0, EACCES },
+  { WSAEBADF, 0, EBADF },
+  { WSAEFAULT, 0, EFAULT },
+  { WSAEINTR, 0, EINTR },
+  { WSAEINVAL, 0, EINVAL },
+  { WSAEMFILE, 0, EMFILE },
+  { WSAENAMETOOLONG, 0, ENAMETOOLONG },
+  { WSAENOTEMPTY, 0, ENOTEMPTY },
+  { 0, -1, 0 }
+};
+
+int caml_posixerr_of_win32err(unsigned int errcode)
+{
+  for (int i = 0; win_error_table[i].range >= 0; i++) {
+    if (errcode >= win_error_table[i].win_code &&
+        errcode <= win_error_table[i].win_code + win_error_table[i].range) {
+      return win_error_table[i].posix_code;
+    }
+  }
+  return 0;
 }


### PR DESCRIPTION
This PR explores the third approach mentioned here: https://github.com/ocaml/ocaml/issues/12300#issuecomment-1592725290 .  Implementing it led me to refactor some I/O code in the runtime system, but the new code is an improvement, if I may say so myself.

This PR is best reviewed commit-by-commit.

The third commit changes the `flush` operation over `out_channel` to discard the buffered data if the actual write fails with an EBADF ("bad file descriptor", including "the file descriptor was closed") or EPIPE ("pipe was closed at the other end") error.  In both cases, retrying the write will fail, it's not a transient error condition like ENOSPC ("no space left on device").  So, before raising Sys_error, we just remove the buffered data.

This way, if the channel is finalized later, it will appear as empty (not containing unflushed data) and it will be freed immediately.  This avoids the memory leak reported in #12300.  It also avoids keeping the channel around and trying to flush it again when the program exits, which can lead to writing to the wrong file, as shown in #12300.

To implement this behavior, I had to change the interface of `caml_read_fd` and `caml_write_fd`.  Currently, they return an error code for EINTR and directly raise a Sys_error exception for any other error.  The second commit changes them to return -1 on any error and set errno to the error code, like a POSIX system call.  It's now the caller's responsibility to act on the error, either by retrying, or by raising Sys_error, or by emptying an out_channel then raising Sys_error.

But there's a snag in the Windows implementation of `caml_{read,write}_fd`.  They either call CRT functions, which leave POSIX-style error codes in errno, or Win32 socket functions, which produce Win32 error codes via `WSAGetLastError()`.  So we need to convert from Win32 error codes to POSIX error codes.  There's a `_dosmaperr` function in the CRT that does just this but is not exported.  There's a `caml_win32_maperr` function in otherlibs/unix that does just this but we need it in the runtime.  So, the first commit bites the bullet and moves the core of the `caml_win32_maperr` function from otherlibs/unix/unixsupport_win32.c to runtime/win32.c, where it can be used by `caml_{read,write}_fd` and also by `caml_win32_rename`.  Phew!

