### PR TITLE
Use type annotations from arguments in let rec

### DIFF
--- a/Changes
+++ b/Changes
@@ -12,6 +12,9 @@ Working version
   (Jeremy Yallop, review by Nicolás Ojeda Bär and Gabriel Scherer,
   suggestion by Rodolphe Lepigre and John Whitington)
 
+- #12315: Use type annotations from arguments in let rec
+  (Stephen Dolan, review by Gabriel Scherer)
+
 ### Runtime system:
 
 - #10111: Increase the detail of location information for debugging events to

--- a/testsuite/tests/typing-misc/let_rec_approx.ml
+++ b/testsuite/tests/typing-misc/let_rec_approx.ml
@@ -1,0 +1,38 @@
+(* TEST
+ expect;
+*)
+
+module M = struct type t = A | B end
+let rec f () = g A
+and g (x : M.t) = f ()
+[%%expect{|
+module M : sig type t = A | B end
+val f : unit -> 'a = <fun>
+val g : M.t -> 'a = <fun>
+|}]
+
+let rec f () = g 42
+and g (x : string) = f ()
+[%%expect{|
+Line 1, characters 17-19:
+1 | let rec f () = g 42
+                     ^^
+Error: This expression has type "int" but an expression was expected of type
+         "string"
+|}]
+
+let rec opt_error ?(opt : string) () = f ?opt ()
+[%%expect{|
+Line 1, characters 20-32:
+1 | let rec opt_error ?(opt : string) () = f ?opt ()
+                        ^^^^^^^^^^^^
+Error: This pattern matches values of type "string"
+       but a pattern was expected which matches values of type "'a option"
+|}]
+
+let rec opt_ok_f () = opt_ok_g ~foo:A ()
+and opt_ok_g ?(foo : M.t option) () = opt_ok_f ()
+[%%expect{|
+val opt_ok_f : unit -> 'a = <fun>
+val opt_ok_g : ?foo:M.t -> unit -> 'a = <fun>
+|}]


### PR DESCRIPTION
When typing `let rec` expressions, the compiler 'approximates' the type of each binding, allowing it to use information about each binding during typechecking. For instance, in a `let rec` of functions, it knows the arity of each definition early, allowing it to produce partial application warnings for mutually recursive functions.

Currently, type annotations on function parameters are ignored during this approximation. This delays typechecking errors, often in a confusing way. This patch makes approximation use these type annotations. As well as improving errors, this also makes type-based disambiguation work in more cases, for instance:
```ocaml
module M = struct type t = A | B end

let rec f () = g A
and g (x : M.t) = f ()
```
With this patch, the above typechecks, because the compiler knows that `g` accepts `M.t` before typing the body of `f`.