### PR TITLE
update the ill-types ppx_example in Ast_mapper module

### DIFF
--- a/parsing/ast_mapper.mli
+++ b/parsing/ast_mapper.mli
@@ -36,7 +36,7 @@ let test_mapper argv =
     expr = fun mapper expr ->
       match expr with
       | { pexp_desc = Pexp_extension ({ txt = "test" }, PStr [])} ->
-        Ast_helper.Exp.constant (Const_int 42)
+        Ast_helper.Exp.constant (Pconst_integer ("42", None))
       | other -> default_mapper.expr mapper other; }
 
 let () =


### PR DESCRIPTION
The example used in [documentation](https://v2.ocaml.org/releases/5.0/api/compilerlibref/Ast_mapper.html) will not compiler due to `Ast_helper.Exp.constant` is expecting a constant type of `Parsetree.constant` as a argument while the example given is of type "Asttypes.constant"

This PR fix this issue and make the example compile and usable against the current ocaml compiler.