### PR TITLE
Support 'raw identifier' syntax (new version)

### DIFF
--- a/.depend
+++ b/.depend
@@ -441,12 +441,14 @@ parsing/pprintast.cmo : \
     parsing/parsetree.cmi \
     parsing/longident.cmi \
     parsing/location.cmi \
+    parsing/lexer.cmi \
     parsing/asttypes.cmi \
     parsing/pprintast.cmi
 parsing/pprintast.cmx : \
     parsing/parsetree.cmi \
     parsing/longident.cmx \
     parsing/location.cmx \
+    parsing/lexer.cmx \
     parsing/asttypes.cmi \
     parsing/pprintast.cmi
 parsing/pprintast.cmi : \
@@ -892,11 +894,13 @@ typing/mtype.cmi : \
 typing/oprint.cmo : \
     parsing/pprintast.cmi \
     typing/outcometree.cmi \
+    parsing/lexer.cmi \
     parsing/asttypes.cmi \
     typing/oprint.cmi
 typing/oprint.cmx : \
     parsing/pprintast.cmx \
     typing/outcometree.cmi \
+    parsing/lexer.cmx \
     parsing/asttypes.cmi \
     typing/oprint.cmi
 typing/oprint.cmi : \
@@ -949,9 +953,11 @@ typing/parmatch.cmi : \
     typing/env.cmi \
     parsing/asttypes.cmi
 typing/path.cmo : \
+    parsing/lexer.cmi \
     typing/ident.cmi \
     typing/path.cmi
 typing/path.cmx : \
+    parsing/lexer.cmx \
     typing/ident.cmx \
     typing/path.cmi
 typing/path.cmi : \
@@ -1076,6 +1082,7 @@ typing/printtyp.cmo : \
     typing/shape.cmi \
     typing/primitive.cmi \
     typing/predef.cmi \
+    parsing/pprintast.cmi \
     typing/path.cmi \
     parsing/parsetree.cmi \
     typing/outcometree.cmi \
@@ -1099,6 +1106,7 @@ typing/printtyp.cmx : \
     typing/shape.cmx \
     typing/primitive.cmx \
     typing/predef.cmx \
+    parsing/pprintast.cmx \
     typing/path.cmx \
     parsing/parsetree.cmi \
     typing/outcometree.cmi \

--- a/Changes
+++ b/Changes
@@ -16,7 +16,7 @@ Working version
   (Stephen Dolan, review by Gabriel Scherer)
 
 - #11252, RFC 27: Support raw identifier syntax \#foo
-  (Stephen Dolan, review by David Allsopp)
+  (Stephen Dolan, review by David Allsopp, Gabriel Scherer and Olivier Nicole)
 
 ### Type system:
 

--- a/Changes
+++ b/Changes
@@ -15,6 +15,9 @@ Working version
 - #12315: Use type annotations from arguments in let rec
   (Stephen Dolan, review by Gabriel Scherer)
 
+- #11252, RFC 27: Support raw identifier syntax \#foo
+  (Stephen Dolan, review by David Allsopp)
+
 ### Type system:
 
 - #12313, #11799: Do not re-build as-pattern type when a ground type annotation

--- a/Makefile
+++ b/Makefile
@@ -1425,8 +1425,8 @@ ocamlprof_LIBRARIES =
 ocamlprof_MODULES = \
   config build_path_prefix_map misc identifiable numbers arg_helper \
   local_store load_path clflags terminfo warnings location longident \
-  docstrings syntaxerr ast_helper camlinternalMenhirLib parser pprintast \
-  lexer parse ocamlprof
+  docstrings syntaxerr ast_helper camlinternalMenhirLib parser \
+  lexer pprintast parse ocamlprof
 
 ocamlcp_ocamloptp_MODULES = \
   config build_path_prefix_map misc profile warnings identifiable numbers \

--- a/compilerlibs/Makefile.compilerlibs
+++ b/compilerlibs/Makefile.compilerlibs
@@ -55,10 +55,10 @@ PARSING = \
   parsing/docstrings.cmo \
   parsing/syntaxerr.cmo \
   parsing/ast_helper.cmo \
-  parsing/pprintast.cmo \
   parsing/camlinternalMenhirLib.cmo \
   parsing/parser.cmo \
   parsing/lexer.cmo \
+  parsing/pprintast.cmo \
   parsing/parse.cmo \
   parsing/printast.cmo \
   parsing/ast_mapper.cmo \

--- a/otherlibs/dynlink/Makefile
+++ b/otherlibs/dynlink/Makefile
@@ -93,6 +93,9 @@ COMPILERLIBS_SOURCES=\
   parsing/syntaxerr.ml \
   parsing/ast_helper.ml \
   parsing/ast_mapper.ml \
+  parsing/camlinternalMenhirLib.ml \
+  parsing/parser.ml \
+  parsing/lexer.ml \
   parsing/attr_helper.ml \
   parsing/builtin_attributes.ml \
   typing/ident.ml \

--- a/parsing/lexer.mli
+++ b/parsing/lexer.mli
@@ -41,6 +41,7 @@ exception Error of error * Location.t
 val in_comment : unit -> bool
 val in_string : unit -> bool
 
+val is_keyword : string -> bool
 
 val print_warnings : bool ref
 val handle_docstrings: bool ref

--- a/parsing/pprintast.ml
+++ b/parsing/pprintast.ml
@@ -94,15 +94,16 @@ let needs_parens txt =
 let needs_spaces txt =
   first_is '*' txt || last_is '*' txt
 
-let string_loc ppf x = fprintf ppf "%s" x.txt
-
 (* add parentheses to binders when they are in fact infix or prefix operators *)
 let protect_ident ppf txt =
   let format : (_, _, _) format =
-    if not (needs_parens txt) then "%s"
+    if Lexer.is_keyword txt then "\\#%s"
+    else if not (needs_parens txt) then "%s"
     else if needs_spaces txt then "(@;%s@;)"
     else "(%s)"
   in fprintf ppf format txt
+
+let protect_ident_loc ppf s = protect_ident ppf s.txt
 
 let protect_longident ppf print_longident longprefix txt =
   let format : (_, _, _) format =
@@ -133,11 +134,15 @@ type construct =
   | `nil
   | `normal
   | `simple of Longident.t
-  | `tuple ]
+  | `tuple
+  | `btrue
+  | `bfalse ]
 
 let view_expr x =
   match x.pexp_desc with
   | Pexp_construct ( {txt= Lident "()"; _},_) -> `tuple
+  | Pexp_construct ( {txt= Lident "true"; _},_) -> `btrue
+  | Pexp_construct ( {txt= Lident "false"; _},_) -> `bfalse
   | Pexp_construct ( {txt= Lident "[]";_},_) -> `nil
   | Pexp_construct ( {txt= Lident"::";_},Some _) ->
       let rec loop exp acc = match exp with
@@ -160,7 +165,7 @@ let view_expr x =
   | _ -> `normal
 
 let is_simple_construct :construct -> bool = function
-  | `nil | `tuple | `list _ | `simple _  -> true
+  | `nil | `tuple | `list _ | `simple _ | `btrue | `bfalse -> true
   | `cons _ | `normal -> false
 
 let pp = fprintf
@@ -267,16 +272,21 @@ let iter_loc f ctxt {txt; loc = _} = f ctxt txt
 
 let constant_string f s = pp f "%S" s
 
-let tyvar ppf s =
+let tyvar_name s =
   if String.length s >= 2 && s.[1] = '\'' then
     (* without the space, this would be parsed as
        a character literal *)
-    Format.fprintf ppf "' %s" s
+    "' " ^ s
+  else if Lexer.is_keyword s then
+    "'\\#" ^ s
   else
-    Format.fprintf ppf "'%s" s
+    "'" ^ s
+
+let tyvar ppf s =
+  Format.fprintf ppf "%s" (tyvar_name s)
 
 let tyvar_loc f str = tyvar f str.txt
-let string_quot f x = pp f "`%s" x
+let string_quot f x = pp f "`%a" protect_ident x
 
 (* c ['a,'b] *)
 let rec class_params_def ctxt f =  function
@@ -288,8 +298,8 @@ let rec class_params_def ctxt f =  function
 and type_with_label ctxt f (label, c) =
   match label with
   | Nolabel    -> core_type1 ctxt f c (* otherwise parenthesize *)
-  | Labelled s -> pp f "%s:%a" s (core_type1 ctxt) c
-  | Optional s -> pp f "?%s:%a" s (core_type1 ctxt) c
+  | Labelled s -> pp f "%a:%a" protect_ident s (core_type1 ctxt) c
+  | Optional s -> pp f "?%a:%a" protect_ident s (core_type1 ctxt) c
 
 and core_type ctxt f x =
   if x.ptyp_attributes <> [] then begin
@@ -362,7 +372,7 @@ and core_type1 ctxt f x =
         let core_field_type f x = match x.pof_desc with
           | Otag (l, ct) ->
             (* Cf #7200 *)
-            pp f "@[<hov2>%s: %a@ %a@ @]" l.txt
+            pp f "@[<hov2>%a: %a@ %a@ @]" protect_ident l.txt
               (core_type ctxt) ct (attributes ctxt) x.pof_attributes
           | Oinherit ct ->
             pp f "@[<hov2>%a@ @]" (core_type ctxt) ct
@@ -431,8 +441,8 @@ and pattern1 ctxt (f:Format.formatter) (x:pattern) : unit =
   if x.ppat_attributes <> [] then pattern ctxt f x
   else match x.ppat_desc with
     | Ppat_variant (l, Some p) ->
-        pp f "@[<2>`%s@;%a@]" l (simple_pattern ctxt) p
-    | Ppat_construct (({txt=Lident("()"|"[]");_}), _) ->
+        pp f "@[<2>`%a@;%a@]" protect_ident l (simple_pattern ctxt) p
+    | Ppat_construct (({txt=Lident("()"|"[]"|"true"|"false");_}), _) ->
         simple_pattern ctxt f x
     | Ppat_construct (({txt;_} as li), po) ->
         (* FIXME The third field always false *)
@@ -444,7 +454,7 @@ and pattern1 ctxt (f:Format.formatter) (x:pattern) : unit =
                pp f "%a@;%a"  longident_loc li (simple_pattern ctxt) x
            | Some (vl, x) ->
                pp f "%a@ (type %a)@;%a" longident_loc li
-                 (list ~sep:"@ " string_loc) vl
+                 (list ~sep:"@ " protect_ident_loc) vl
                  (simple_pattern ctxt) x
            | None -> pp f "%a" longident_loc li)
     | _ -> simple_pattern ctxt f x
@@ -452,7 +462,7 @@ and pattern1 ctxt (f:Format.formatter) (x:pattern) : unit =
 and simple_pattern ctxt (f:Format.formatter) (x:pattern) : unit =
   if x.ppat_attributes <> [] then pattern ctxt f x
   else match x.ppat_desc with
-    | Ppat_construct (({txt=Lident ("()"|"[]" as x);_}), None) ->
+    | Ppat_construct (({txt=Lident ("()"|"[]"|"true"|"false" as x);_}), None) ->
         pp f  "%s" x
     | Ppat_any -> pp f "_";
     | Ppat_var ({txt = txt;_}) -> protect_ident f txt
@@ -485,7 +495,7 @@ and simple_pattern ctxt (f:Format.formatter) (x:pattern) : unit =
         pp f "@[<1>(%a)@]" (list  ~sep:",@;" (pattern1 ctxt))  l (* level1*)
     | Ppat_constant (c) -> pp f "%a" constant c
     | Ppat_interval (c1, c2) -> pp f "%a..%a" constant c1 constant c2
-    | Ppat_variant (l,None) ->  pp f "`%s" l
+    | Ppat_variant (l,None) ->  pp f "`%a" protect_ident l
     | Ppat_constraint (p, ct) ->
         pp f "@[<2>(%a@;:@;%a)@]" (pattern1 ctxt) p (core_type ctxt) ct
     | Ppat_lazy p ->
@@ -497,7 +507,8 @@ and simple_pattern ctxt (f:Format.formatter) (x:pattern) : unit =
         let with_paren =
         match p.ppat_desc with
         | Ppat_array _ | Ppat_record _
-        | Ppat_construct (({txt=Lident ("()"|"[]");_}), None) -> false
+        | Ppat_construct (({txt=Lident ("()"|"[]"|"true"|"false");_}), None) ->
+            false
         | _ -> true in
         pp f "@[<2>%a.%a @]" longident_loc lid
           (paren with_paren @@ pattern1 ctxt) p
@@ -513,20 +524,21 @@ and label_exp ctxt f (l,opt,p) =
       | {ppat_desc = Ppat_var {txt;_}; ppat_attributes = []}
         when txt = rest ->
           (match opt with
-           | Some o -> pp f "?(%s=@;%a)@;" rest  (expression ctxt) o
-           | None -> pp f "?%s@ " rest)
+           | Some o ->
+              pp f "?(%a=@;%a)@;" protect_ident rest  (expression ctxt) o
+           | None -> pp f "?%a@ " protect_ident rest)
       | _ ->
           (match opt with
            | Some o ->
-               pp f "?%s:(%a=@;%a)@;"
-                 rest (pattern1 ctxt) p (expression ctxt) o
-           | None -> pp f "?%s:%a@;" rest (simple_pattern ctxt) p)
+               pp f "?%a:(%a=@;%a)@;"
+                 protect_ident rest (pattern1 ctxt) p (expression ctxt) o
+           | None -> pp f "?%a:%a@;" protect_ident rest (simple_pattern ctxt) p)
       end
   | Labelled l -> match p with
     | {ppat_desc  = Ppat_var {txt;_}; ppat_attributes = []}
       when txt = l ->
-        pp f "~%s@;" l
-    | _ ->  pp f "~%s:%a@;" l (simple_pattern ctxt) p
+        pp f "~%a@;" protect_ident l
+    | _ ->  pp f "~%a:%a@;" protect_ident l (simple_pattern ctxt) p
 
 and sugar_expr ctxt f e =
   if e.pexp_attributes <> [] then false
@@ -624,7 +636,7 @@ and expression ctxt f x =
           (label_exp ctxt) (l, e0, p)
           (expression ctxt) e
     | Pexp_newtype (lid, e) ->
-        pp f "@[<2>fun@;(type@;%s)@;->@;%a@]" lid.txt
+        pp f "@[<2>fun@;(type@;%a)@;->@;%a@]" protect_ident lid.txt
           (expression ctxt) e
     | Pexp_function l ->
         pp f "@[<hv>function%a@]" (case_list ctxt) l
@@ -715,10 +727,10 @@ and expression ctxt f x =
     | Pexp_new (li) ->
         pp f "@[<hov2>new@ %a@]" longident_loc li;
     | Pexp_setinstvar (s, e) ->
-        pp f "@[<hov2>%s@ <-@ %a@]" s.txt (expression ctxt) e
+        pp f "@[<hov2>%a@ <-@ %a@]" protect_ident s.txt (expression ctxt) e
     | Pexp_override l -> (* FIXME *)
         let string_x_expression f (s, e) =
-          pp f "@[<hov2>%s@ =@ %a@]" s.txt (expression ctxt) e in
+          pp f "@[<hov2>%a@ =@ %a@]" protect_ident s.txt (expression ctxt) e in
         pp f "@[<hov2>{<%a>}@]"
           (list string_x_expression  ~sep:";"  )  l;
     | Pexp_letmodule (s, me, e) ->
@@ -745,7 +757,7 @@ and expression ctxt f x =
           (override o.popen_override) (module_expr ctxt) o.popen_expr
           (expression ctxt) e
     | Pexp_variant (l,Some eo) ->
-        pp f "@[<2>`%s@;%a@]" l (simple_expr ctxt) eo
+        pp f "@[<2>`%a@;%a@]" protect_ident l (simple_expr ctxt) eo
     | Pexp_letop {let_; ands; body} ->
         pp f "@[<2>@[<v>%a@,%a@] in@;<1 -2>%a@]"
           (binding_op ctxt) let_
@@ -767,7 +779,8 @@ and expression2 ctxt f x =
   else match x.pexp_desc with
     | Pexp_field (e, li) ->
         pp f "@[<hov2>%a.%a@]" (simple_expr ctxt) e longident_loc li
-    | Pexp_send (e, s) -> pp f "@[<hov2>%a#%s@]" (simple_expr ctxt) e s.txt
+    | Pexp_send (e, s) ->
+        pp f "@[<hov2>%a#%a@]" (simple_expr ctxt) e protect_ident s.txt
 
     | _ -> simple_expr ctxt f x
 
@@ -778,6 +791,8 @@ and simple_expr ctxt f x =
         (match view_expr x with
          | `nil -> pp f "[]"
          | `tuple -> pp f "()"
+         | `btrue -> pp f "true"
+         | `bfalse -> pp f "false"
          | `list xs ->
              pp f "@[<hv0>[%a]@]"
                (list (expression (under_semi ctxt)) ~sep:";@;") xs
@@ -799,7 +814,7 @@ and simple_expr ctxt f x =
         pp f "(%a%a :> %a)" (expression ctxt) e
           (option (core_type ctxt) ~first:" : " ~last:" ") cto1 (* no sep hint*)
           (core_type ctxt) ct
-    | Pexp_variant (l, None) -> pp f "`%s" l
+    | Pexp_variant (l, None) -> pp f "`%a" protect_ident l
     | Pexp_record (l, eo) ->
         let longident_x_expression f ( li, e) =
           match e with
@@ -867,12 +882,14 @@ and class_type_field ctxt f x =
       pp f "@[<2>inherit@ %a@]%a" (class_type ctxt) ct
         (item_attributes ctxt) x.pctf_attributes
   | Pctf_val (s, mf, vf, ct) ->
-      pp f "@[<2>val @ %a%a%s@ :@ %a@]%a"
-        mutable_flag mf virtual_flag vf s.txt (core_type ctxt) ct
+      pp f "@[<2>val @ %a%a%a@ :@ %a@]%a"
+        mutable_flag mf virtual_flag vf
+        protect_ident s.txt (core_type ctxt) ct
         (item_attributes ctxt) x.pctf_attributes
   | Pctf_method (s, pf, vf, ct) ->
-      pp f "@[<2>method %a %a%s :@;%a@]%a"
-        private_flag pf virtual_flag vf s.txt (core_type ctxt) ct
+      pp f "@[<2>method %a %a%a :@;%a@]%a"
+        private_flag pf virtual_flag vf
+        protect_ident s.txt (core_type ctxt) ct
         (item_attributes ctxt) x.pctf_attributes
   | Pctf_constraint (ct1, ct2) ->
       pp f "@[<2>constraint@ %a@ =@ %a@]%a"
@@ -919,9 +936,10 @@ and class_type ctxt f x =
 and class_type_declaration_list ctxt f l =
   let class_type_declaration kwd f x =
     let { pci_params=ls; pci_name={ txt; _ }; _ } = x in
-    pp f "@[<2>%s %a%a%s@ =@ %a@]%a" kwd
+    pp f "@[<2>%s %a%a%a@ =@ %a@]%a" kwd
       virtual_flag x.pci_virt
-      (class_params_def ctxt) ls txt
+      (class_params_def ctxt) ls
+      protect_ident txt
       (class_type ctxt) x.pci_expr
       (item_attributes ctxt) x.pci_attributes
   in
@@ -940,21 +958,24 @@ and class_field ctxt f x =
         (class_expr ctxt) ce
         (fun f so -> match so with
            | None -> ();
-           | Some (s) -> pp f "@ as %s" s.txt ) so
+           | Some (s) -> pp f "@ as %a" protect_ident s.txt ) so
         (item_attributes ctxt) x.pcf_attributes
   | Pcf_val (s, mf, Cfk_concrete (ovf, e)) ->
-      pp f "@[<2>val%s %a%s =@;%a@]%a" (override ovf)
-        mutable_flag mf s.txt
+      pp f "@[<2>val%s %a%a =@;%a@]%a" (override ovf)
+        mutable_flag mf
+        protect_ident s.txt
         (expression ctxt) e
         (item_attributes ctxt) x.pcf_attributes
   | Pcf_method (s, pf, Cfk_virtual ct) ->
-      pp f "@[<2>method virtual %a %s :@;%a@]%a"
-        private_flag pf s.txt
+      pp f "@[<2>method virtual %a %a :@;%a@]%a"
+        private_flag pf
+        protect_ident s.txt
         (core_type ctxt) ct
         (item_attributes ctxt) x.pcf_attributes
   | Pcf_val (s, mf, Cfk_virtual ct) ->
-      pp f "@[<2>val virtual %a%s :@ %a@]%a"
-        mutable_flag mf s.txt
+      pp f "@[<2>val virtual %a%a :@ %a@]%a"
+        mutable_flag mf
+        protect_ident s.txt
         (core_type ctxt) ct
         (item_attributes ctxt) x.pcf_attributes
   | Pcf_method (s, pf, Cfk_concrete (ovf, e)) ->
@@ -976,8 +997,8 @@ and class_field ctxt f x =
         private_flag pf
         (fun f -> function
            | {pexp_desc=Pexp_poly (e, Some ct); pexp_attributes=[]; _} ->
-               pp f "%s :@;%a=@;%a"
-                 s.txt (core_type ctxt) ct (expression ctxt) e
+               pp f "%a :@;%a=@;%a"
+                 protect_ident s.txt (core_type ctxt) ct (expression ctxt) e
            | {pexp_desc=Pexp_poly (e, None); pexp_attributes=[]; _} ->
                bind e
            | _ -> bind e) e
@@ -1121,9 +1142,10 @@ and signature_item ctxt f x : unit =
       exception_declaration ctxt f ed
   | Psig_class l ->
       let class_description kwd f ({pci_params=ls;pci_name={txt;_};_} as x) =
-        pp f "@[<2>%s %a%a%s@;:@;%a@]%a" kwd
+        pp f "@[<2>%s %a%a%a@;:@;%a@]%a" kwd
           virtual_flag x.pci_virt
-          (class_params_def ctxt) ls txt
+          (class_params_def ctxt) ls
+          protect_ident txt
           (class_type ctxt) x.pci_expr
           (item_attributes ctxt) x.pci_attributes
       in begin
@@ -1257,7 +1279,7 @@ and binding ctxt f {pvb_pat=p; pvb_expr=x; pvb_constraint = ct; _} =
             pp f "%a@ %a"
               (label_exp ctxt) (label,eo,p) pp_print_pexp_function e
       | Pexp_newtype (str,e) ->
-          pp f "(type@ %s)@ %a" str.txt pp_print_pexp_function e
+          pp f "(type@ %a)@ %a" protect_ident str.txt pp_print_pexp_function e
       | _ -> pp f "=@;%a" (expression ctxt) x
   in
   match ct with
@@ -1386,9 +1408,10 @@ and structure_item ctxt f x =
       let class_declaration kwd f
           ({pci_params=ls; pci_name={txt;_}; _} as x) =
         let args, constr, cl = extract_class_args x.pci_expr in
-        pp f "@[<2>%s %a%a%s %a%a=@;%a@]%a" kwd
+        pp f "@[<2>%s %a%a%a %a%a=@;%a@]%a" kwd
           virtual_flag x.pci_virt
-          (class_params_def ctxt) ls txt
+          (class_params_def ctxt) ls
+          protect_ident txt
           (list (label_exp ctxt)) args
           (option class_constraint) constr
           (class_expr ctxt) cl
@@ -1462,10 +1485,11 @@ and type_def_list ctxt f (rf, exported, l) =
       else if exported then " ="
       else " :="
     in
-    pp f "@[<2>%s %a%a%s%s%a@]%a" kwd
+    pp f "@[<2>%s %a%a%a%s%a@]%a" kwd
       nonrec_flag rf
       (type_params ctxt) x.ptype_params
-      x.ptype_name.txt eq
+      protect_ident x.ptype_name.txt
+      eq
       (type_declaration ctxt) x
       (item_attributes ctxt) x.ptype_attributes
   in
@@ -1478,9 +1502,9 @@ and type_def_list ctxt f (rf, exported, l) =
 
 and record_declaration ctxt f lbls =
   let type_record_field f pld =
-    pp f "@[<2>%a%s:@;%a@;%a@]"
+    pp f "@[<2>%a%a:@;%a@;%a@]"
       mutable_flag pld.pld_mutable
-      pld.pld_name.txt
+      protect_ident pld.pld_name.txt
       (core_type ctxt) pld.pld_type
       (attributes ctxt) pld.pld_attributes
   in
@@ -1612,14 +1636,14 @@ and label_x_expression_param ctxt f (l,e) =
   | Nolabel  -> expression2 ctxt f e (* level 2*)
   | Optional str ->
       if Some str = simple_name then
-        pp f "?%s" str
+        pp f "?%a" protect_ident str
       else
-        pp f "?%s:%a" str (simple_expr ctxt) e
+        pp f "?%a:%a" protect_ident str (simple_expr ctxt) e
   | Labelled lbl ->
       if Some lbl = simple_name then
-        pp f "~%s" lbl
+        pp f "~%a" protect_ident lbl
       else
-        pp f "~%s:%a" lbl (simple_expr ctxt) e
+        pp f "~%a:%a" protect_ident lbl (simple_expr ctxt) e
 
 and directive_argument f x =
   match x.pdira_desc with

--- a/parsing/pprintast.mli
+++ b/parsing/pprintast.mli
@@ -50,7 +50,12 @@ val signature_item: Format.formatter -> Parsetree.signature_item -> unit
 val binding: Format.formatter -> Parsetree.value_binding -> unit
 val payload: Format.formatter -> Parsetree.payload -> unit
 
-val tyvar_name : string -> string
+val tyvar_of_name : string -> string
+  (** Turn a type variable name into a valid identifier, taking care of the
+      special treatment required for the single quote character in second
+      position, or for keywords by escaping them with \#. No-op on "_". *)
+
 val tyvar: Format.formatter -> string -> unit
-  (** Print a type variable name, taking care of the special treatment
-      required for the single quote character in second position. *)
+  (** Print a type variable name as a valid identifier, taking care of the
+      special treatment required for the single quote character in second
+      position, or for keywords by escaping them with \#. No-op on "_". *)

--- a/parsing/pprintast.mli
+++ b/parsing/pprintast.mli
@@ -50,6 +50,7 @@ val signature_item: Format.formatter -> Parsetree.signature_item -> unit
 val binding: Format.formatter -> Parsetree.value_binding -> unit
 val payload: Format.formatter -> Parsetree.payload -> unit
 
+val tyvar_name : string -> string
 val tyvar: Format.formatter -> string -> unit
   (** Print a type variable name, taking care of the special treatment
       required for the single quote character in second position. *)

--- a/testsuite/tests/let-syntax/let_syntax.ml
+++ b/testsuite/tests/let-syntax/let_syntax.ml
@@ -146,7 +146,7 @@ let let_unbound =
 Line 3, characters 4-8:
 3 |     let+ x = 1 in
         ^^^^
-Error: Unbound value "let+"
+Error: Unbound value "(let+)"
 |}];;
 
 module And_unbound = struct
@@ -166,7 +166,7 @@ let and_unbound =
 Line 4, characters 4-8:
 4 |     and+ y = 2 in
         ^^^^
-Error: Unbound value "and+"
+Error: Unbound value "(and+)"
 |}];;
 
 module Ill_typed_1 = struct

--- a/testsuite/tests/parsetree/source.ml
+++ b/testsuite/tests/parsetree/source.ml
@@ -7455,3 +7455,21 @@ module type s = sig type ('a,'b) t end with type ('a,'b) t := 'b -> 'a list
 
 let x: [`A] :> [> `A | `B ] = `A
 let x :> [> `A | `B ] = `A
+
+(* Raw identifiers *)
+
+module type A = sig
+  type ('\#let, '\#a) \#virtual = ('\#let * '\#a) as '\#mutable
+  val foo : '\#let '\#a . '\#a -> '\#let -> unit
+  type \#foo = { \#let : int }
+end
+
+module M = struct
+  let (\#let,\#foo) as \#val = (\#mutable,\#baz)
+  let _ = fun (type \#let) (type \#foo) -> 1
+  let f g ~\#let ?\#and ?(\#for = \#and) () =
+    g ~\#let ?\#and ()
+  class \#let = object
+    inherit \#val \#let as \#mutable
+  end
+end

--- a/testsuite/tests/parsing/rawidents.ml
+++ b/testsuite/tests/parsing/rawidents.ml
@@ -1,0 +1,100 @@
+(* TEST
+   expect;
+*)
+
+module M : sig
+  class \#and : object
+    val mutable \#and : int
+    method \#and : int
+  end
+end = struct
+  class \#and =
+    let \#and = 1 in
+    object
+      val mutable \#and = \#and
+      method \#and = 2
+    end
+end
+let obj = new M.\#and
+[%%expect{|
+module M :
+  sig class \#and : object val mutable \#and : int method \#and : int end end
+val obj : M.\#and = <obj>
+|}]
+
+module M : sig type \#and = int end = struct type \#and = string end
+[%%expect{|
+Line 1, characters 38-68:
+1 | module M : sig type \#and = int end = struct type \#and = string end
+                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: Signature mismatch:
+       Modules do not match:
+         sig type \#and = string end
+       is not included in
+         sig type \#and = int end
+       Type declarations do not match:
+         type \#and = string
+       is not included in
+         type \#and = int
+       The type "string" is not equal to the type "int"
+|}]
+
+let x = (`\#let `\#and : [ `\#let of [ `\#and ] ])
+let `\#let \#rec = x
+[%%expect{|
+val x : [ `\#let of [ `\#and ] ] = `\#let `\#and
+val \#rec : [ `\#and ] = `\#and
+|}]
+
+
+let f g ~\#let ?\#and ?(\#for = \#and) () =
+  g ~\#let ?\#and ()
+[%%expect{|
+val f :
+  (\#let:'a -> ?\#and:'b -> unit -> 'c) ->
+  \#let:'a -> ?\#and:'b -> ?\#for:'b option -> unit -> 'c = <fun>
+|}]
+
+
+type t = '\#let
+[%%expect{|
+Line 1, characters 9-15:
+1 | type t = '\#let
+             ^^^^^^
+Error: The type variable "'\#let" is unbound in this type declaration.
+|}]
+
+type \#mutable = { mutable \#mutable : \#mutable }
+let rec \#rec = { \#mutable = \#rec }
+[%%expect{|
+type \#mutable = { mutable \#mutable : \#mutable; }
+val \#rec : \#mutable = {\#mutable = <cycle>}
+|}]
+
+type \#and = ..
+type \#and += Foo
+[%%expect{|
+type \#and = ..
+type \#and += Foo
+|}]
+
+let x = (++);;
+[%%expect{|
+Line 1, characters 8-12:
+1 | let x = (++);;
+            ^^^^
+Error: Unbound value "(++)"
+|}]
+
+let x = \#let;;
+[%%expect{|
+Line 1, characters 8-13:
+1 | let x = \#let;;
+            ^^^^^
+Error: Unbound value "\#let"
+|}]
+
+let f ~\#let ?\#and () = 1
+[%%expect{|
+val f : \#let:'a -> ?\#and:'b -> unit -> int = <fun>
+|}]

--- a/toplevel/genprintval.ml
+++ b/toplevel/genprintval.ml
@@ -378,7 +378,7 @@ module Make(O : OBJ)(EVP : EVALPATH with type valu = O.t) = struct
                    then nest tree_of_val depth forced_obj ty_arg
                    else      tree_of_val depth forced_obj ty_arg
                  in
-                 Oval_constr (Oide_ident (Out_name.create "lazy"), [v])
+                 Oval_lazy v
                end
           | Tconstr(path, ty_list, _) -> begin
               try

--- a/typing/outcometree.mli
+++ b/typing/outcometree.mli
@@ -55,6 +55,7 @@ type out_value =
   | Oval_stuff of string
   | Oval_tuple of out_value list
   | Oval_variant of string * out_value option
+  | Oval_lazy of out_value
 
 type out_type_param = string * (Asttypes.variance * Asttypes.injectivity)
 
@@ -62,7 +63,7 @@ type out_type =
   | Otyp_abstract
   | Otyp_open
   | Otyp_alias of {non_gen:bool; aliased:out_type; alias:string}
-  | Otyp_arrow of string * out_type * out_type
+  | Otyp_arrow of Asttypes.arg_label * out_type * out_type
   | Otyp_class of out_ident * out_type list
   | Otyp_constr of out_ident * out_type list
   | Otyp_manifest of out_type * out_type
@@ -89,7 +90,7 @@ and out_variant =
 
 type out_class_type =
   | Octy_constr of out_ident * out_type list
-  | Octy_arrow of string * out_type * out_class_type
+  | Octy_arrow of Asttypes.arg_label * out_type * out_class_type
   | Octy_signature of out_type option * out_class_sig_item list
 and out_class_sig_item =
   | Ocsg_constraint of out_type * out_type

--- a/typing/path.ml
+++ b/typing/path.ml
@@ -90,9 +90,13 @@ let rec scope = function
 
 let kfalse _ = false
 
+let maybe_escape s =
+  if Lexer.is_keyword s then "\\#" ^ s else s
+
 let rec name ?(paren=kfalse) = function
-    Pident id -> Ident.name id
+    Pident id -> maybe_escape (Ident.name id)
   | Pdot(p, s) | Pextra_ty (p, Pcstr_ty s) ->
+      let s = maybe_escape s in
       name ~paren p ^ if paren s then ".( " ^ s ^ " )" else "." ^ s
   | Papply(p1, p2) -> name ~paren p1 ^ "(" ^ name ~paren p2 ^ ")"
   | Pextra_ty (p, Pext_ty) -> name ~paren p

--- a/typing/printtyp.ml
+++ b/typing/printtyp.ml
@@ -30,11 +30,7 @@ module Sig_component_kind = Shape.Sig_component_kind
 module Style = Misc.Style
 
 (* Print a long identifier *)
-
-let rec longident ppf = function
-  | Lident s -> pp_print_string ppf s
-  | Ldot(p, s) -> fprintf ppf "%a.%s" longident p s
-  | Lapply(p1, p2) -> fprintf ppf "%a(%a)" longident p1 longident p2
+let longident = Pprintast.longident
 
 let () = Env.print_longident := longident
 
@@ -1105,7 +1101,7 @@ let rec tree_of_typexp mode ty =
         Otyp_var (non_gen, Names.name_of_type name_gen tty)
     | Tarrow(l, ty1, ty2, _) ->
         let lab =
-          if !print_labels || is_optional l then string_of_label l else ""
+          if !print_labels || is_optional l then l else Nolabel
         in
         let t1 =
           if is_optional l then
@@ -1757,7 +1753,7 @@ let rec tree_of_class_type mode params =
       Octy_signature (self_ty, List.rev csil)
   | Cty_arrow (l, ty, cty) ->
       let lab =
-        if !print_labels || is_optional l then string_of_label l else ""
+        if !print_labels || is_optional l then l else Nolabel
       in
       let tr =
        if is_optional l then

--- a/typing/typetexp.ml
+++ b/typing/typetexp.ml
@@ -186,7 +186,9 @@ end = struct
     TyVarMap.find name !type_variables
 
   let get_in_scope_names () =
-    let add_name name _ l = if name = "_" then l else ("'" ^ name) :: l in
+    let add_name name _ l =
+      if name = "_" then l else Pprintast.tyvar_name name :: l
+    in
     TyVarMap.fold add_name !type_variables []
 
   (*****)
@@ -317,7 +319,7 @@ end = struct
           with Not_found ->
             if extensibility = Fixed && Btype.is_Tvar ty then
               raise(Error(loc, env,
-                          Unbound_type_variable ("'"^name,
+                          Unbound_type_variable (Pprintast.tyvar_name name,
                                                  get_in_scope_names ())));
             let v2 = new_global_var () in
             r := (loc, v, v2) :: !r;

--- a/typing/typetexp.ml
+++ b/typing/typetexp.ml
@@ -187,7 +187,7 @@ end = struct
 
   let get_in_scope_names () =
     let add_name name _ l =
-      if name = "_" then l else Pprintast.tyvar_name name :: l
+      if name = "_" then l else Pprintast.tyvar_of_name name :: l
     in
     TyVarMap.fold add_name !type_variables []
 
@@ -319,7 +319,7 @@ end = struct
           with Not_found ->
             if extensibility = Fixed && Btype.is_Tvar ty then
               raise(Error(loc, env,
-                          Unbound_type_variable (Pprintast.tyvar_name name,
+                          Unbound_type_variable (Pprintast.tyvar_of_name name,
                                                  get_in_scope_names ())));
             let v2 = new_global_var () in
             r := (loc, v, v2) :: !r;


### PR DESCRIPTION
This is a resubmit of @stedolan’s PR #11252. I rebased it on trunk and took into account @gasche’s comments on the original PR. Below is the original PR message.

This PR implements part of https://github.com/ocaml/RFCs/pull/27 by adding support for 'raw identifiers' `\#foo`. The syntax `\#foo` means the same thing as `foo`, but is always an identifier even when `foo` is a keyword. This allows future versions of the language to introduce new keywords in a backwards-compatible way (see the RFC for full details).

The important part of this patch is the small patch to `lexer.mll` which adds the new concrete syntax. The entire rest of the patch is changes to various pretty-printers, to ensure that keywords are printed in appropriately escaped form should they ever occur as variable names, in types, in error messages, and the like.