### PR TITLE
Fix missing flexdll bootstrap dependency on Cygwin

### DIFF
--- a/Changes
+++ b/Changes
@@ -86,10 +86,10 @@ Working version
 - #12210: uniform style for inline code in compiler messages
   (Florian Angeletti, review by Gabriel Scherer)
 
-* #12278: Remove the OCAML_FLEXLINK environment variable from the compiler
-  drivers. This environment variable was previously used as part of the FlexDLL
-  bootstrap procedure and existed solely for that purpose. Its removal greatly
-  simplifies both the build system and testsuite machinery.
+* #12278, #:12325: Remove the OCAML_FLEXLINK environment variable from the
+  compiler drivers. This environment variable was previously used as part of the
+  FlexDLL bootstrap procedure and existed solely for that purpose. Its removal
+  greatly simplifies both the build system and testsuite machinery.
   (David Allsopp, review by Sébastien Hinderer)
 
 ### Internal/compiler-libs changes:

--- a/Makefile
+++ b/Makefile
@@ -206,6 +206,8 @@ boot/ocamlrun$(EXE): runtime/ocamlruns$(EXE)
 
 $(foreach runtime, ocamlrun ocamlrund ocamlruni, \
   $(eval runtime/$(runtime)$(EXE): | $(BYTE_BINDIR)/flexlink$(EXE)))
+
+tools/checkstack$(EXE): | $(BYTE_BINDIR)/flexlink$(EXE)
 else
 boot/ocamlrun$(EXE): runtime/ocamlrun$(EXE) runtime/primitives
 endif


### PR DESCRIPTION
Small regression from #12278, not picked up by Jenkins because it builds Cygwin using an externally installed flexdll (which is also how the Cygwin distribution builds OCaml), so this is mostly a development regression.

The Cygwin port - being a flavour of Unix - builds the `checkstack` utility (the native Windows ports do not), which requires flexlink.byte.exe to have been compiled first, just as the runtimes do on the line above the change.