### PR TITLE
Pack the unification data for pattern checking in Typecore

### DIFF
--- a/Changes
+++ b/Changes
@@ -155,6 +155,9 @@ Working version
 - #12109: Pack parameters to unification in unification_environment
   (Takafumi Saikawa and Jacques Garrigue, review by Richard Eisenberg)
 
+- #12331: Pack the unification data for pattern checking in Typecore
+  (Takafumi Saikawa and Jacques Garrigue, review by ??)
+
 ### Build system:
 
 - #12198: continue the merge of the sub-makefiles into the root Makefile

--- a/Changes
+++ b/Changes
@@ -156,7 +156,8 @@ Working version
   (Takafumi Saikawa and Jacques Garrigue, review by Richard Eisenberg)
 
 - #12331: Pack the unification data for pattern checking in Typecore
-  (Takafumi Saikawa and Jacques Garrigue, review by Gabriel Scherer)
+  (Takafumi Saikawa and Jacques Garrigue,
+   review by Gabriel Scherer and Thomas Refis)
 
 ### Build system:
 

--- a/Changes
+++ b/Changes
@@ -157,7 +157,7 @@ Working version
 
 - #12331: Pack the unification data for pattern checking in Typecore
   (Takafumi Saikawa and Jacques Garrigue,
-   review by Gabriel Scherer and Thomas Refis)
+   review by Gabriel Scherer, Thomas Refis and Florian Angeletti)
 
 ### Build system:
 

--- a/Changes
+++ b/Changes
@@ -156,7 +156,7 @@ Working version
   (Takafumi Saikawa and Jacques Garrigue, review by Richard Eisenberg)
 
 - #12331: Pack the unification data for pattern checking in Typecore
-  (Takafumi Saikawa and Jacques Garrigue, review by ??)
+  (Takafumi Saikawa and Jacques Garrigue, review by Gabriel Scherer)
 
 ### Build system:
 

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -266,31 +266,31 @@ let none = newty (Ttuple [])                (* Clearly ill-formed type *)
 (**** information for [Typecore.unify_pat_*] ****)
 
 module Pattern_env : sig
-  type env_ref
+  type hidden_env
   type t = private
-    { renv : env_ref;
+    { mutable env : hidden_env;
       equations_scope : int;
       allow_recursive_equations : bool; }
   val make: Env.t -> equations_scope:int -> allow_recursive_equations:bool -> t
-  val copy: t -> t
+  val copy: ?equations_scope:int -> t -> t
   val get_env: t -> Env.t
   val set_env: t -> Env.t -> unit
-  val set_equations_scope: int -> t -> t
 end = struct
-  type env_ref = Env.t ref
+  type hidden_env = Env.t
   type t =
-    { renv : env_ref;
+    { mutable env : hidden_env;
       equations_scope : int;
       allow_recursive_equations : bool; }
   let make env ~equations_scope ~allow_recursive_equations =
-    { renv = ref env;
+    { env;
       equations_scope;
       allow_recursive_equations; }
-  let copy penv = { penv with renv = ref !(penv.renv) }
-  let get_env penv = !(penv.renv)
-  let set_env penv env = penv.renv := env
-  let set_equations_scope equations_scope penv =
+  let copy ?equations_scope penv =
+    let equations_scope =
+      match equations_scope with None -> penv.equations_scope | Some s -> s in
     { penv with equations_scope }
+  let get_env penv = penv.env
+  let set_env penv env = penv.env <- env
 end
 
 (**** unification mode ****)

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -263,7 +263,7 @@ let newconstr path tyl = newty (Tconstr (path, tyl, ref Mnil))
 
 let none = newty (Ttuple [])                (* Clearly ill-formed type *)
 
-(**** unification mode ****)
+(**** information for [Typecore.unify_pat_*] ****)
 
 type pattern_environment =
     { env : Env.t ref;
@@ -280,6 +280,8 @@ let copy_pattern_environment penv =
 
 let set_equations_scope equations_scope penv =
   { penv with equations_scope }
+
+(**** unification mode ****)
 
 type equations_generation =
   | Forbidden

--- a/typing/ctype.mli
+++ b/typing/ctype.mli
@@ -177,21 +177,18 @@ val new_local_type:
 val existential_name: constructor_description -> type_expr -> string
 
 module Pattern_env : sig
-  type env_ref
+  type hidden_env
   type t = private
-    { renv : env_ref;
+    { mutable env : hidden_env;
       equations_scope : int;
       (* scope for local type declarations *)
       allow_recursive_equations : bool;
       (* true iff checking counter examples *)
     }
   val make: Env.t -> equations_scope:int -> allow_recursive_equations:bool -> t
-  val copy: t -> t
-        (* replace the [env] reference with a cloned one *)
+  val copy: ?equations_scope:int -> t -> t
   val get_env: t -> Env.t
   val set_env: t -> Env.t -> unit
-  val set_equations_scope: int -> t -> t
-        (* keep the same [env] reference *)
 end
 
 type existential_treatment =

--- a/typing/ctype.mli
+++ b/typing/ctype.mli
@@ -176,9 +176,15 @@ val new_local_type:
         ?manifest_and_scope:(type_expr * int) -> unit -> type_declaration
 val existential_name: constructor_description -> type_expr -> string
 
+type pattern_environment =
+    { env : Env.t ref;
+      allow_recursive_equations : bool;
+      (* level at which to create the local type declarations *)
+      gadt_equations_level : int; }
+
 type existential_treatment =
   | Keep_existentials_flexible
-  | Make_existentials_abstract of { env: Env.t ref; scope: int }
+  | Make_existentials_abstract of pattern_environment
 
 val instance_constructor: existential_treatment ->
         constructor_description -> type_expr list * type_expr * type_expr list
@@ -250,8 +256,7 @@ val extract_concrete_typedecl:
 val unify: Env.t -> type_expr -> type_expr -> unit
         (* Unify the two types given. Raise [Unify] if not possible. *)
 val unify_gadt:
-        equations_level:int -> allow_recursive_equations:bool ->
-        Env.t ref -> type_expr -> type_expr -> Btype.TypePairs.t
+        pattern_environment -> type_expr -> type_expr -> Btype.TypePairs.t
         (* Unify the two types given and update the environment with the
            local constraints. Raise [Unify] if not possible.
            Returns the pairs of types that have been equated.  *)

--- a/typing/ctype.mli
+++ b/typing/ctype.mli
@@ -176,11 +176,18 @@ val new_local_type:
         ?manifest_and_scope:(type_expr * int) -> unit -> type_declaration
 val existential_name: constructor_description -> type_expr -> string
 
-type pattern_environment =
+type pattern_environment = private
     { env : Env.t ref;
-      allow_recursive_equations : bool;
-      (* level at which to create the local type declarations *)
-      gadt_equations_level : int; }
+      equations_scope : int; (* scope for local type declarations *)
+      allow_recursive_equations : bool; (* true iff checking counter examples *)
+    }
+
+val make_pattern_environment: Env.t -> equations_scope:int ->
+        allow_recursive_equations:bool -> pattern_environment
+val copy_pattern_environment: pattern_environment -> pattern_environment
+        (* replace the [env] reference with a cloned one *)
+val set_equations_scope: int -> pattern_environment -> pattern_environment
+        (* keep the same [env] reference *)
 
 type existential_treatment =
   | Keep_existentials_flexible

--- a/typing/ctype.mli
+++ b/typing/ctype.mli
@@ -177,9 +177,8 @@ val new_local_type:
 val existential_name: constructor_description -> type_expr -> string
 
 module Pattern_env : sig
-  type hidden_env
-  type t = private
-    { mutable env : hidden_env;
+  type t =
+    { mutable env : Env.t;
       equations_scope : int;
       (* scope for local type declarations *)
       allow_recursive_equations : bool;
@@ -187,8 +186,6 @@ module Pattern_env : sig
     }
   val make: Env.t -> equations_scope:int -> allow_recursive_equations:bool -> t
   val copy: ?equations_scope:int -> t -> t
-  val get_env: t -> Env.t
-  val set_env: t -> Env.t -> unit
 end
 
 type existential_treatment =

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -26,6 +26,13 @@ open Typedtree
 open Btype
 open Ctype
 
+let (!!) (penv : pattern_environment) = !(penv.env)
+let set_env (penv : pattern_environment) env = penv.env := env
+let get_gadt_equations_level (penv : pattern_environment) =
+  let l = penv.gadt_equations_level in
+  if l = lowest_level then invalid_arg "Typecore.get_gadt_equations_level"
+  else l
+
 module Style = Misc.Style
 
 type type_forcing_context =
@@ -368,12 +375,14 @@ let unify_exp_types loc env ty expected_ty =
   | Tags(l1,l2) ->
       raise(Typetexp.Error(loc, env, Typetexp.Variant_tags (l1, l2)))
 
+(* TODO: REMOVE THIS PART
 (* level at which to create the local type declarations *)
 let gadt_equations_level = ref None
 let get_gadt_equations_level () =
   match !gadt_equations_level with
     Some y -> y
   | None -> assert false
+*)
 
 (* Unification inside type_pat *)
 let unify_pat_types loc env ty ty' =
@@ -385,23 +394,18 @@ let unify_pat_types loc env ty ty' =
 
 (* GADT unification inside solve_Ppat_construct and check_counter_example_pat *)
 let nothing_equated = TypePairs.create 0
-let unify_pat_types_return_equated_pairs ~refine loc env ty ty' =
+let unify_pat_types_return_equated_pairs ~refine loc penv ty ty' =
   try
-    match refine with
-    | Some allow_recursive_equations ->
-        unify_gadt ~equations_level:(get_gadt_equations_level ())
-          ~allow_recursive_equations env ty ty'
-    | None ->
-        unify !env ty ty';
-        nothing_equated
+    if refine then unify_gadt penv ty ty'
+    else (unify !!penv ty ty'; nothing_equated)
   with
   | Unify err ->
-      raise(Error(loc, !env, Pattern_type_clash(err, None)))
+      raise(Error(loc, !!penv, Pattern_type_clash(err, None)))
   | Tags(l1,l2) ->
-      raise(Typetexp.Error(loc, !env, Typetexp.Variant_tags (l1, l2)))
+      raise(Typetexp.Error(loc, !!penv, Typetexp.Variant_tags (l1, l2)))
 
-let unify_pat_types_refine ~refine loc env ty ty' =
-  ignore (unify_pat_types_return_equated_pairs ~refine loc env ty ty')
+let unify_pat_types_refine ~refine loc penv ty ty' =
+  ignore (unify_pat_types_return_equated_pairs ~refine loc penv ty ty')
 
 (** [sdesc_for_hint] is used by error messages to report literals in their
     original formatting *)
@@ -411,11 +415,11 @@ let unify_pat ?sdesc_for_hint env pat expected_ty =
     raise(Error(loc, env, Pattern_type_clash(err, sdesc_for_hint)))
 
 (* unification of a type with a Tconstr with freshly created arguments *)
-let unify_head_only ~refine loc env ty constr =
+let unify_head_only ~refine loc penv ty constr =
   let path = cstr_type_path constr in
-  let decl = Env.find_type path !env in
+  let decl = Env.find_type path !!penv in
   let ty' = Ctype.newconstr path (Ctype.instance_list decl.type_params) in
-  unify_pat_types_refine ~refine loc env ty' ty
+  unify_pat_types_refine ~refine loc penv ty' ty
 
 (* Creating new conjunctive types is not allowed when typing patterns *)
 (* make all Reither present in open variants *)
@@ -679,22 +683,22 @@ let solve_Ppat_tuple (type a) ~refine loc env (args : a list) expected_ty =
   unify_pat_types_refine ~refine loc env ty expected_ty;
   vars
 
-let solve_constructor_annotation env name_list sty ty_args ty_ex =
-  let expansion_scope = get_gadt_equations_level () in
+let solve_constructor_annotation penv name_list sty ty_args ty_ex =
+  let expansion_scope = get_gadt_equations_level penv in
   (* XXX: should use fold and return the updated environment *)
   let ids =
     List.map
       (fun name ->
         let decl = new_local_type ~loc:name.loc () in
         let (id, new_env) =
-          Env.enter_type ~scope:expansion_scope name.txt decl !env in
-        env := new_env;
+          Env.enter_type ~scope:expansion_scope name.txt decl !!penv in
+        set_env penv new_env;
         {name with txt = id})
       name_list
   in
   let cty, ty, force =
     with_local_level ~post:(fun (_,ty,_) -> generalize_structure ty)
-      (fun () -> Typetexp.transl_simple_type_delayed !env sty)
+      (fun () -> Typetexp.transl_simple_type_delayed !!penv sty)
   in
   pattern_force := force :: !pattern_force;
   let ty_args =
@@ -702,11 +706,11 @@ let solve_constructor_annotation env name_list sty ty_args ty_ex =
     match ty_args with
       [] -> assert false
     | [ty_arg] ->
-        unify_pat_types cty.ctyp_loc !env ty1 ty_arg;
+        unify_pat_types cty.ctyp_loc !!penv ty1 ty_arg;
         [ty2]
     | _ ->
-        unify_pat_types cty.ctyp_loc !env ty1 (newty (Ttuple ty_args));
-        match get_desc (expand_head !env ty2) with
+        unify_pat_types cty.ctyp_loc !!penv ty1 (newty (Ttuple ty_args));
+        match get_desc (expand_head !!penv ty2) with
           Ttuple tyl -> tyl
         | _ -> assert false
   in
@@ -719,50 +723,44 @@ let solve_constructor_annotation env name_list sty ty_args ty_ex =
             Tconstr(Path.Pident id, [], _) when List.mem id rem ->
               list_remove id rem
           | _ ->
-              raise (Error (cty.ctyp_loc, !env,
+              raise (Error (cty.ctyp_loc, !!penv,
                             Unbound_existential (ids, ty))))
         ids ty_ex
     in
     if rem <> [] then
-      raise (Error (cty.ctyp_loc, !env,
+      raise (Error (cty.ctyp_loc, !!penv,
                     Unbound_existential (ids, ty)))
   end;
   ty_args, Some (ids, cty)
 
-let solve_Ppat_construct ~refine env loc constr no_existentials
+let solve_Ppat_construct ~refine penv loc constr no_existentials
         existential_styp expected_ty =
   (* if constructor is gadt, we must verify that the expected type has the
      correct head *)
   if constr.cstr_generalized then
-    unify_head_only ~refine loc env (instance expected_ty) constr;
+    unify_head_only ~refine loc penv (instance expected_ty) constr;
 
   (* PR#7214: do not use gadt unification for toplevel lets *)
   let unify_res ty_res expected_ty =
     let refine =
-      match refine, no_existentials with
-      | None, None when constr.cstr_generalized -> Some false
-      | _ -> refine
-    in
-    unify_pat_types_return_equated_pairs ~refine loc env ty_res expected_ty
+      refine || constr.cstr_generalized && no_existentials = None in
+    unify_pat_types_return_equated_pairs ~refine loc penv ty_res expected_ty
   in
 
   let ty_args, equated_types, existential_ctyp =
     with_local_level_iter ~post: generalize_structure begin fun () ->
       let expected_ty = instance expected_ty in
-      let expansion_scope = get_gadt_equations_level () in
       let ty_args, ty_res, equated_types, existential_ctyp =
         match existential_styp with
           None ->
             let ty_args, ty_res, _ =
-              instance_constructor
-                (Make_existentials_abstract { env; scope = expansion_scope })
-                constr
+              instance_constructor (Make_existentials_abstract penv) constr
             in
             ty_args, ty_res, unify_res ty_res expected_ty, None
         | Some (name_list, sty) ->
             let existential_treatment =
               if name_list = [] then
-                Make_existentials_abstract { env; scope = expansion_scope }
+                Make_existentials_abstract penv
               else
                 (* we will unify them (in solve_constructor_annotation) with the
                    local types provided by the user *)
@@ -773,16 +771,16 @@ let solve_Ppat_construct ~refine env loc constr no_existentials
             in
             let equated_types = unify_res ty_res expected_ty in
             let ty_args, existential_ctyp =
-              solve_constructor_annotation env name_list sty ty_args ty_ex in
+              solve_constructor_annotation penv name_list sty ty_args ty_ex in
             ty_args, ty_res, equated_types, existential_ctyp
       in
       if constr.cstr_existentials <> [] then
-        lower_variables_only !env expansion_scope ty_res;
+        lower_variables_only !!penv (get_gadt_equations_level penv) ty_res;
       ((ty_args, equated_types, existential_ctyp),
        expected_ty :: ty_res :: ty_args)
     end
   in
-  if !Clflags.principal && refine = None then begin
+  if !Clflags.principal && not refine then begin
     (* Do not warn for counter-examples *)
     let exception Warn_only_once in
     try
@@ -806,13 +804,13 @@ let solve_Ppat_construct ~refine env loc constr no_existentials
   end;
   (ty_args, existential_ctyp)
 
-let solve_Ppat_record_field ~refine loc env label label_lid record_ty =
+let solve_Ppat_record_field ~refine loc penv label label_lid record_ty =
   with_local_level_iter ~post:generalize_structure begin fun () ->
     let (_, ty_arg, ty_res) = instance_label false label in
     begin try
-      unify_pat_types_refine ~refine loc env ty_res (instance record_ty)
+      unify_pat_types_refine ~refine loc penv ty_res (instance record_ty)
     with Error(_loc, _env, Pattern_type_clash(err, _)) ->
-      raise(Error(label_lid.loc, !env,
+      raise(Error(label_lid.loc, !!penv,
                   Label_mismatch(label_lid.txt, err)))
     end;
     (ty_arg, [ty_res; ty_arg])
@@ -1480,7 +1478,8 @@ let as_comp_pattern
 let rec type_pat
   : type k . k pattern_category ->
       no_existentials: existential_restriction option ->
-      env: Env.t ref -> Parsetree.pattern -> type_expr -> k general_pattern
+      env: pattern_environment -> Parsetree.pattern -> type_expr ->
+      k general_pattern
   = fun category ~no_existentials ~env sp expected_ty ->
   Builtin_attributes.warning_scope sp.ppat_attributes
     (fun () ->
@@ -1496,7 +1495,7 @@ and type_pat_aux
   in
   let loc = sp.ppat_loc in
   let solve_expected (x : pattern) : pattern =
-    unify_pat ~sdesc_for_hint:sp.ppat_desc !env x (instance expected_ty);
+    unify_pat ~sdesc_for_hint:sp.ppat_desc !!env x (instance expected_ty);
     x
   in
   let crp (x : k general_pattern) : k general_pattern =
@@ -1515,7 +1514,7 @@ and type_pat_aux
         pat_loc = loc; pat_extra=[];
         pat_type = instance expected_ty;
         pat_attributes = sp.ppat_attributes;
-        pat_env = !env }
+        pat_env = !!env }
   | Ppat_var name ->
       let ty = instance expected_ty in
       let id = enter_variable loc name ty sp.ppat_attributes in
@@ -1524,7 +1523,7 @@ and type_pat_aux
         pat_loc = loc; pat_extra=[];
         pat_type = ty;
         pat_attributes = sp.ppat_attributes;
-        pat_env = !env }
+        pat_env = !!env }
   | Ppat_unpack name ->
       let t = instance expected_ty in
       begin match name.txt with
@@ -1535,7 +1534,7 @@ and type_pat_aux
             pat_extra=[Tpat_unpack, name.loc, sp.ppat_attributes];
             pat_type = t;
             pat_attributes = [];
-            pat_env = !env }
+            pat_env = !!env }
       | Some s ->
           let v = { name with txt = s } in
           (* We're able to pass ~is_module:true here without an error because
@@ -1548,24 +1547,24 @@ and type_pat_aux
             pat_extra=[Tpat_unpack, loc, sp.ppat_attributes];
             pat_type = t;
             pat_attributes = [];
-            pat_env = !env }
+            pat_env = !!env }
       end
   | Ppat_constraint(
       {ppat_desc=Ppat_var name; ppat_loc=lloc; ppat_attributes = attrs},
       ({ptyp_desc=Ptyp_poly _} as sty)) ->
       (* explicitly polymorphic type *)
       let cty, ty, ty' =
-        solve_Ppat_poly_constraint !env lloc sty expected_ty in
+        solve_Ppat_poly_constraint !!env lloc sty expected_ty in
       let id = enter_variable lloc name ty' attrs in
       rvp { pat_desc = Tpat_var (id, name);
             pat_loc = lloc;
             pat_extra = [Tpat_constraint cty, loc, sp.ppat_attributes];
             pat_type = ty;
             pat_attributes = [];
-            pat_env = !env }
+            pat_env = !!env }
   | Ppat_alias(sq, name) ->
       let q = type_pat Value sq expected_ty in
-      let ty_var = solve_Ppat_alias !env q in
+      let ty_var = solve_Ppat_alias !!env q in
       let id =
         enter_variable ~is_as_variable:true loc name ty_var sp.ppat_attributes
       in
@@ -1573,15 +1572,15 @@ and type_pat_aux
             pat_loc = loc; pat_extra=[];
             pat_type = q.pat_type;
             pat_attributes = sp.ppat_attributes;
-            pat_env = !env }
+            pat_env = !!env }
   | Ppat_constant cst ->
-      let cst = constant_or_raise !env loc cst in
+      let cst = constant_or_raise !!env loc cst in
       rvp @@ solve_expected {
         pat_desc = Tpat_constant cst;
         pat_loc = loc; pat_extra=[];
         pat_type = type_constant cst;
         pat_attributes = sp.ppat_attributes;
-        pat_env = !env }
+        pat_env = !!env }
   | Ppat_interval (Pconst_char c1, Pconst_char c2) ->
       let open Ast_helper.Pat in
       let gloc = {loc with Location.loc_ghost=true} in
@@ -1597,35 +1596,35 @@ and type_pat_aux
       type_pat category p expected_ty
         (* TODO: record 'extra' to remember about interval *)
   | Ppat_interval _ ->
-      raise (Error (loc, !env, Invalid_interval))
+      raise (Error (loc, !!env, Invalid_interval))
   | Ppat_tuple spl ->
       assert (List.length spl >= 2);
       let expected_tys =
-        solve_Ppat_tuple ~refine:None loc env spl expected_ty in
+        solve_Ppat_tuple ~refine:false loc env spl expected_ty in
       let pl = List.map2 (type_pat Value) spl expected_tys in
       rvp {
         pat_desc = Tpat_tuple pl;
         pat_loc = loc; pat_extra=[];
         pat_type = newty (Ttuple(List.map (fun p -> p.pat_type) pl));
         pat_attributes = sp.ppat_attributes;
-        pat_env = !env }
+        pat_env = !!env }
   | Ppat_construct(lid, sarg) ->
       let expected_type =
-        match extract_concrete_variant !env expected_ty with
+        match extract_concrete_variant !!env expected_ty with
         | Variant_type(p0, p, _) ->
             Some (p0, p, is_principal expected_ty)
         | Maybe_a_variant_type -> None
         | Not_a_variant_type ->
             let srt = wrong_kind_sort_of_constructor lid.txt in
             let error = Wrong_expected_kind(srt, Pattern, expected_ty) in
-            raise (Error (loc, !env, error))
+            raise (Error (loc, !!env, error))
       in
       let constr =
         let candidates =
-          Env.lookup_all_constructors Env.Pattern ~loc:lid.loc lid.txt !env in
+          Env.lookup_all_constructors Env.Pattern ~loc:lid.loc lid.txt !!env in
         wrap_disambiguate "This variant pattern is expected to have"
           (mk_expected expected_ty)
-          (Constructor.disambiguate Env.Pattern lid !env expected_type)
+          (Constructor.disambiguate Env.Pattern lid !!env expected_type)
           candidates
       in
       begin match no_existentials, constr.cstr_existentials with
@@ -1633,7 +1632,7 @@ and type_pat_aux
       | Some r, (_ :: _ as exs)  ->
           let exs = List.map (Ctype.existential_name constr) exs in
           let name = constr.cstr_name in
-          raise (Error (loc, !env, Unexpected_existential (r, name, exs)))
+          raise (Error (loc, !!env, Unexpected_existential (r, name, exs)))
       end;
       let sarg', existential_styp =
         match sarg with
@@ -1644,7 +1643,7 @@ and type_pat_aux
         | Some ([], sp) ->
             Some sp, None
         | Some (_, sp) ->
-            raise (Error (sp.ppat_loc, !env, Missing_type_constraint))
+            raise (Error (sp.ppat_loc, !!env, Missing_type_constraint))
       in
       let sargs =
         match sarg' with
@@ -1669,11 +1668,11 @@ and type_pat_aux
         | _ -> ()
         end;
       if List.length sargs <> constr.cstr_arity then
-        raise(Error(loc, !env, Constructor_arity_mismatch(lid.txt,
+        raise(Error(loc, !!env, Constructor_arity_mismatch(lid.txt,
                                      constr.cstr_arity, List.length sargs)));
 
       let (ty_args, existential_ctyp) =
-        solve_Ppat_construct ~refine:None env loc constr no_existentials
+        solve_Ppat_construct ~refine:false env loc constr no_existentials
           existential_styp expected_ty
       in
 
@@ -1685,7 +1684,7 @@ and type_pat_aux
         | Ppat_alias (p, _) ->
             check_non_escaping p
         | Ppat_constraint _ ->
-            raise (Error (p.ppat_loc, !env, Inlined_record_escape))
+            raise (Error (p.ppat_loc, !!env, Inlined_record_escape))
         | _ ->
             ()
       in
@@ -1699,12 +1698,12 @@ and type_pat_aux
             pat_loc = loc; pat_extra=[];
             pat_type = instance expected_ty;
             pat_attributes = sp.ppat_attributes;
-            pat_env = !env }
+            pat_env = !!env }
   | Ppat_variant(tag, sarg) ->
       assert (tag <> Parmatch.some_private_tag);
       let constant = (sarg = None) in
       let arg_type, row, pat_type =
-        solve_Ppat_variant ~refine:None loc env tag constant expected_ty in
+        solve_Ppat_variant ~refine:false loc env tag constant expected_ty in
       let arg =
         (* PR#6235: propagate type information *)
         match sarg, arg_type with
@@ -1716,22 +1715,22 @@ and type_pat_aux
         pat_loc = loc; pat_extra = [];
         pat_type = pat_type;
         pat_attributes = sp.ppat_attributes;
-        pat_env = !env }
+        pat_env = !!env }
   | Ppat_record(lid_sp_list, closed) ->
       assert (lid_sp_list <> []);
       let expected_type, record_ty =
-        match extract_concrete_record !env expected_ty with
+        match extract_concrete_record !!env expected_ty with
         | Record_type(p0, p, _) ->
             let ty = generic_instance expected_ty in
             Some (p0, p, is_principal expected_ty), ty
         | Maybe_a_record_type -> None, newvar ()
         | Not_a_record_type ->
           let error = Wrong_expected_kind(Record, Pattern, expected_ty) in
-          raise (Error (loc, !env, error))
+          raise (Error (loc, !!env, error))
       in
       let type_label_pat (label_lid, label, sarg) =
         let ty_arg =
-          solve_Ppat_record_field ~refine:None loc env label label_lid
+          solve_Ppat_record_field ~refine:false loc env label label_lid
             record_ty in
         (label_lid, label, type_pat Value sarg ty_arg)
       in
@@ -1742,60 +1741,59 @@ and type_pat_aux
           pat_loc = loc; pat_extra=[];
           pat_type = instance record_ty;
           pat_attributes = sp.ppat_attributes;
-          pat_env = !env;
+          pat_env = !!env;
         }
       in
       let lbl_a_list =
         wrap_disambiguate "This record pattern is expected to have"
           (mk_expected expected_ty)
-          (type_label_a_list loc false !env Env.Projection
+          (type_label_a_list loc false !!env Env.Projection
              type_label_pat expected_type)
           lid_sp_list
       in
       rvp @@ solve_expected (make_record_pat lbl_a_list)
   | Ppat_array spl ->
-      let ty_elt = solve_Ppat_array ~refine:None loc env expected_ty in
+      let ty_elt = solve_Ppat_array ~refine:false loc env expected_ty in
       let pl = List.map (fun p -> type_pat Value p ty_elt) spl in
       rvp {
         pat_desc = Tpat_array pl;
         pat_loc = loc; pat_extra=[];
         pat_type = instance expected_ty;
         pat_attributes = sp.ppat_attributes;
-        pat_env = !env }
+        pat_env = !!env }
   | Ppat_or(sp1, sp2) ->
       let initial_pattern_variables = !pattern_variables in
       let initial_module_variables = !module_variables in
-      let equation_level = !gadt_equations_level in
-      let outter_lev = get_current_level () in
+      let equation_level = get_gadt_equations_level env in
       (* Introduce a new scope using with_local_level without generalizations *)
       let env1, p1, p1_variables, p1_module_variables, env2, p2 =
         with_local_level begin fun () ->
           let lev = get_current_level () in
-          gadt_equations_level := Some lev;
+          let env = {env with gadt_equations_level = lev} in
           let type_pat_rec env sp = type_pat category sp expected_ty ~env in
-          let env1 = ref !env in
+          let env1 = {env with env = ref !!env} in
           let p1 = type_pat_rec env1 sp1 in
           let p1_variables = !pattern_variables in
           let p1_module_variables = !module_variables in
           pattern_variables := initial_pattern_variables;
           module_variables := initial_module_variables;
-          let env2 = ref !env in
+          let env2 = {env with env = ref !!env} in
           let p2 = type_pat_rec env2 sp2 in
           (env1, p1, p1_variables, p1_module_variables, env2, p2)
         end
       in
-      gadt_equations_level := equation_level;
       let p2_variables = !pattern_variables in
       (* Make sure no variable with an ambiguous type gets added to the
          environment. *)
+      let outer_lev = get_current_level () in
       List.iter (fun { pv_type; pv_loc; _ } ->
-        check_scope_escape pv_loc !env1 outter_lev pv_type
+        check_scope_escape pv_loc !!env1 outer_lev pv_type
       ) p1_variables;
       List.iter (fun { pv_type; pv_loc; _ } ->
-        check_scope_escape pv_loc !env2 outter_lev pv_type
+        check_scope_escape pv_loc !!env2 outer_lev pv_type
       ) p2_variables;
       let alpha_env =
-        enter_orpat_variables loc !env p1_variables p2_variables in
+        enter_orpat_variables loc !!env p1_variables p2_variables in
       let p2 = alpha_pat alpha_env p2 in
       pattern_variables := p1_variables;
       module_variables := p1_module_variables;
@@ -1803,20 +1801,20 @@ and type_pat_aux
            pat_loc = loc; pat_extra = [];
            pat_type = instance expected_ty;
            pat_attributes = sp.ppat_attributes;
-           pat_env = !env }
+           pat_env = !!env }
   | Ppat_lazy sp1 ->
-      let nv = solve_Ppat_lazy ~refine:None loc env expected_ty in
+      let nv = solve_Ppat_lazy ~refine:false loc env expected_ty in
       let p1 = type_pat Value sp1 nv in
       rvp {
         pat_desc = Tpat_lazy p1;
         pat_loc = loc; pat_extra=[];
         pat_type = instance expected_ty;
         pat_attributes = sp.ppat_attributes;
-        pat_env = !env }
+        pat_env = !!env }
   | Ppat_constraint(sp, sty) ->
       (* Pretend separate = true *)
       let cty, ty, expected_ty' =
-        solve_Ppat_constraint loc !env sty expected_ty in
+        solve_Ppat_constraint loc !!env sty expected_ty in
       let p = type_pat category sp expected_ty' in
       let extra = (Tpat_constraint cty, loc, sp.ppat_attributes) in
       begin match category, (p : k general_pattern) with
@@ -1832,19 +1830,19 @@ and type_pat_aux
           { p with pat_type = ty; pat_extra = extra::p.pat_extra }
       end
   | Ppat_type lid ->
-      let (path, p) = build_or_pat !env loc lid in
+      let (path, p) = build_or_pat !!env loc lid in
       pure category @@ solve_expected
         { p with pat_extra = (Tpat_type (path, lid), loc, sp.ppat_attributes)
         :: p.pat_extra }
   | Ppat_open (lid,p) ->
       let path, new_env =
-        !type_open Asttypes.Fresh !env sp.ppat_loc lid in
-      env := new_env;
+        !type_open Asttypes.Fresh !!env sp.ppat_loc lid in
+      set_env env new_env;
       let p = type_pat category ~env p expected_ty in
-      let new_env = !env in
+      let new_env = !!env in
       begin match Env.remove_last_open path new_env with
       | None -> assert false
-      | Some closed_env -> env := closed_env
+      | Some closed_env -> set_env env closed_env
       end;
       { p with pat_extra = (Tpat_open (path,lid,new_env),
                                 loc, sp.ppat_attributes) :: p.pat_extra }
@@ -1855,16 +1853,11 @@ and type_pat_aux
         pat_loc = sp.ppat_loc;
         pat_extra = [];
         pat_type = expected_ty;
-        pat_env = !env;
+        pat_env = !!env;
         pat_attributes = sp.ppat_attributes;
       }
   | Ppat_extension ext ->
       raise (Error_forward (Builtin_attributes.error_of_extension ext))
-
-let type_pat category ?no_existentials
-    ?(lev=get_current_level()) env sp expected_ty =
-  Misc.protect_refs [Misc.R (gadt_equations_level, Some lev)]
-    (fun () -> type_pat category ~no_existentials ~env sp expected_ty)
 
 let iter_pattern_variables_type f : pattern_variable list -> unit =
   List.iter (fun {pv_type; _} -> f pv_type)
@@ -1913,19 +1906,28 @@ let add_module_variables env module_variables =
     end
   ) env module_variables
 
+let make_pattern_environment ?(lev=get_current_level ())
+    env allow_recursive_equations =
+  {env = ref env;
+   allow_recursive_equations;
+   gadt_equations_level = lev}
+
+let type_pat category ?no_existentials env =
+  type_pat category ~no_existentials ~env
+
 let type_pattern category ~lev env spat expected_ty allow_modules =
   reset_pattern allow_modules;
-  let new_env = ref env in
-  let pat = type_pat category ~lev new_env spat expected_ty in
+  let new_env = make_pattern_environment ~lev env false in
+  let pat = type_pat category new_env spat expected_ty in
   let pvs = get_ref pattern_variables in
   let mvs = get_ref module_variables in
-  (pat, !new_env, get_ref pattern_force, pvs, mvs)
+  (pat, !!new_env, get_ref pattern_force, pvs, mvs)
 
 let type_pattern_list
     category no_existentials env spatl expected_tys allow_modules
   =
   reset_pattern allow_modules;
-  let new_env = ref env in
+  let new_env = make_pattern_environment env false in
   let type_pat (attrs, pat) ty =
     Builtin_attributes.warning_scope ~ppwarning:false attrs
       (fun () ->
@@ -1935,13 +1937,14 @@ let type_pattern_list
   let patl = List.map2 type_pat spatl expected_tys in
   let pvs = get_ref pattern_variables in
   let mvs = get_ref module_variables in
-  (patl, !new_env, get_ref pattern_force, pvs, mvs)
+  (patl, !!new_env, get_ref pattern_force, pvs, mvs)
 
 let type_class_arg_pattern cl_num val_env met_env l spat =
   reset_pattern Modules_rejected;
   let nv = newvar () in
+  let new_env = make_pattern_environment val_env false in
   let pat =
-    type_pat Value ~no_existentials:In_class_args (ref val_env) spat nv in
+    type_pat Value ~no_existentials:In_class_args new_env spat nv in
   if has_variants pat then begin
     Parmatch.pressure_variants val_env [pat];
     finalize_variants pat;
@@ -1987,8 +1990,9 @@ let type_self_pattern env spat =
   let spat = Pat.mk(Ppat_alias (spat, mknoloc "selfpat-*")) in
   reset_pattern Modules_rejected;
   let nv = newvar() in
+  let new_env = make_pattern_environment env false in
   let pat =
-    type_pat Value ~no_existentials:In_self_pattern (ref env) spat nv in
+    type_pat Value ~no_existentials:In_self_pattern new_env spat nv in
   List.iter (fun f -> f()) (get_ref pattern_force);
   let pv = !pattern_variables in
   pattern_variables := [];
@@ -2292,7 +2296,7 @@ let check_counter_example_pat ~counter_example_args
    to type check gadt nonexhaustiveness *)
 let partial_pred ~lev ~allow_modules ~splitting_mode ?(explode=0)
       env expected_ty p =
-  let env = ref env in
+  let env = ref env in (* TODO: create uenv instead of ref env *)
   let state = save_state env in
   let counter_example_args =
       {

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -368,15 +368,8 @@ let unify_exp_types loc env ty expected_ty =
   | Tags(l1,l2) ->
       raise(Typetexp.Error(loc, env, Typetexp.Variant_tags (l1, l2)))
 
-(* helper functions for pattern environments *)
+(* helper notation for pattern environments *)
 let (!!) penv = Pattern_env.get_env penv
-(*
-let set_env (penv : pattern_environment) env = penv.env := env
-let get_equations_scope (penv : pattern_environment) =
-  let l = penv.equations_scope in
-  if l = lowest_level then invalid_arg "Typecore.get_equations_scope"
-  else l
-*)
 
 (* Unification inside type_pat *)
 let unify_pat_types loc env ty ty' =

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -26,13 +26,6 @@ open Typedtree
 open Btype
 open Ctype
 
-let (!!) (penv : pattern_environment) = !(penv.env)
-let set_env (penv : pattern_environment) env = penv.env := env
-let get_gadt_equations_level (penv : pattern_environment) =
-  let l = penv.gadt_equations_level in
-  if l = lowest_level then invalid_arg "Typecore.get_gadt_equations_level"
-  else l
-
 module Style = Misc.Style
 
 type type_forcing_context =
@@ -375,14 +368,13 @@ let unify_exp_types loc env ty expected_ty =
   | Tags(l1,l2) ->
       raise(Typetexp.Error(loc, env, Typetexp.Variant_tags (l1, l2)))
 
-(* TODO: REMOVE THIS PART
-(* level at which to create the local type declarations *)
-let gadt_equations_level = ref None
-let get_gadt_equations_level () =
-  match !gadt_equations_level with
-    Some y -> y
-  | None -> assert false
-*)
+(* helper functions for pattern environments *)
+let (!!) (penv : pattern_environment) = !(penv.env)
+let set_env (penv : pattern_environment) env = penv.env := env
+let get_gadt_equations_level (penv : pattern_environment) =
+  let l = penv.gadt_equations_level in
+  if l = lowest_level then invalid_arg "Typecore.get_gadt_equations_level"
+  else l
 
 (* Unification inside type_pat *)
 let unify_pat_types loc env ty ty' =

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -1754,11 +1754,10 @@ and type_pat_aux
       (* Introduce a new scope using with_local_level without generalizations *)
       let penv1, p1, p1_variables, p1_module_variables, penv2, p2 =
         with_local_level begin fun () ->
-          let penv =
-            Pattern_env.set_equations_scope (get_current_level ()) penv in
           let type_pat_rec penv sp = type_pat category sp expected_ty ~penv in
-          let penv1 = Pattern_env.copy penv
-          and penv2 = Pattern_env.copy penv in
+          let penv1 =
+            Pattern_env.copy ~equations_scope:(get_current_level ()) penv in
+          let penv2 = Pattern_env.copy penv1 in
           let p1 = type_pat_rec penv1 sp1 in
           let p1_variables = !pattern_variables in
           let p1_module_variables = !module_variables in


### PR DESCRIPTION
This PR is a sequel to #12109 and defines a record [pattern_environment] to pack data in Typecore that are to be given to unification functions defined in Ctype.

[gadt_equations_level] is renamed to [equations_scope] to better explain its uses.
