### PR TITLE
manual: update runtime tracing chapter for custom events

### DIFF
--- a/manual/src/cmds/runtime-tracing.etex
+++ b/manual/src/cmds/runtime-tracing.etex
@@ -6,7 +6,9 @@ This chapter describes the runtime events tracing system which enables
 continuous extraction of performance information from the OCaml runtime with
 very low overhead. The system and interfaces are low-level and tightly coupled
 to the runtime implementation, it is intended for end-users to rely on tooling
-to consume and visualise data of interest.
+to consume and visualise data of interest. Additional events can be declared and
+consumed, providing higher-level dynamic introspection capabilities to OCaml
+libraries, they are referred to as {\em custom events}.
 
 Data emitted includes:
 \begin{itemize}
@@ -56,7 +58,9 @@ which emit events and 2) the events transport that ingests and transports
 these events.
 
 \subsection{s:runtime-tracing-probes}{Probes}
-Probes collect events from the runtime system. These are further
+
+\begin{description}
+\item[Runtime probes] collect events from the OCaml runtime system. These are further
 split in to two sets: 1) probes that are always available and 2) probes
 that are only available in the instrumented runtime.
 Probes in the instrumented runtime are primarily of
@@ -70,6 +74,31 @@ The full set of events emitted by probes and their documentation can be found in
  section~\ref{Runtime_events}.
 \fi
 
+\item[Custom probes] are defined using the
+\texttt{Runtime_events.User} module.
+Identified by a globally unique name, they record events and provide payloads of
+built-in (\texttt{unit}, \texttt{int}, \texttt{span}) and user-defined types.
+Consumers and producers are not compiled together, so they don't usually have
+the same set of registered events. The event name is used by the consumer to
+identify producer's events, with a fallback mechanism for unknown events of
+built-in types. Unknown events for user-defined types are currently ignored,
+even if the type is defined both in the producer and consumer side.
+
+An extensible variant \texttt{tag} provides a way to attach additional data to
+events, which can be used to provide additional information about the event's
+origin. The tag is not serialized, so it is only available for \textit{known}
+events.
+
+In summary, the are three cases for the consumer when an event is received:
+\begin{itemize}
+\item event is registered: payload and tag are available.
+\item event is not registered and has a built-in event type (unit, int, span):
+    only the payload is available.
+\item event is not registered and has a custom event type: event is dropped.
+\end{itemize}
+The \texttt{Runtime_events.Type} module provides a way to use built-in event
+types and define new ones using an encoder-decoder pair.
+\end{description}
 \subsection{s:runtime-tracing-ingestion}{Events transport}
 
 The events transport part of the system ingests events emitted by the probes
@@ -203,6 +232,83 @@ instead, call the program as below to produce the same result:
 
 \begin{verbatim}
 OCAML_RUNTIME_EVENTS_START=1 ./example
+\end{verbatim}
+
+\subsubsection{s-runtime-tracing-custom-events}{Tracing custom events}
+
+The following program make use of the \texttt{Runtime_events.User} and
+\texttt{Runtime_events.Type} modules to declare a custom event providing
+\texttt{span} and \texttt{int} values. The \texttt{tag} extensible variant is
+extended with \texttt{CustomSpan} and \texttt{CustomInt}.
+
+\begin{verbatim}
+type Runtime_events.User.tag += CustomSpan | CustomInt
+
+let count_span =
+    Runtime_events.User.register "count.span" CustomSpan
+        Runtime_events.Type.span
+
+let count_value =
+    Runtime_events.User.register "count.value" CustomInt
+        Runtime_events.Type.int
+
+let count () =
+    Runtime_events.User.write count_span Begin;
+    for i = 1 to 5 do
+        Runtime_events.User.write count_value i
+    done;
+    Runtime_events.User.write count_span End
+
+let () =
+    Runtime_events.start ();
+    for _ = 1 to 3 do
+        count ()
+    done
+\end{verbatim}
+
+On the consumer side, one can use the provided event tag and type to match on
+the relevant events.
+
+\begin{verbatim}
+let span_event_handler domain_id ts event value =
+    (* we're only interested in our CustomSpan event *)
+    match Runtime_events.User.tag event, value with
+    | CustomSpan, Runtime_events.Type.Begin -> Printf.printf "> count begin\n"
+    | CustomSpan, End -> Printf.printf "< count end\n"
+    | _ -> ()
+
+let int_event_handler domain_id ts event value =
+    (* we're only interested in our CustomInt event *)
+    match Runtime_events.User.tag event with
+    | CustomInt -> Printf.printf "| count %d\n" value
+    | _ -> ()
+
+let () =
+    let open Runtime_events in
+    let cursor = create_cursor None in
+    let callbacks =
+        Callbacks.create ()
+        |> Callbacks.add_user_event Type.span span_event_handler
+        |> Callbacks.add_user_event Type.int int_event_handler
+    in
+    for _ = 0 to 100 do
+        ignore(read_poll cursor callbacks None)
+    done
+\end{verbatim}
+
+Giving the following output:
+\begin{verbatim}
+> count begin
+| count 1
+| count 2
+| count 3
+| count 4
+| count 5
+< count end
+> count begin
+| count 1
+| count 2
+[...]
 \end{verbatim}
 
 \subsubsection{s-runtime-tracing-environment-variables}{Environment variables}

--- a/manual/src/cmds/runtime-tracing.etex
+++ b/manual/src/cmds/runtime-tracing.etex
@@ -58,9 +58,7 @@ which emit events and 2) the events transport that ingests and transports
 these events.
 
 \subsection{s:runtime-tracing-probes}{Probes}
-
-\begin{description}
-\item[Runtime probes] collect events from the OCaml runtime system. These are further
+Probes collect events from the OCaml runtime system. These are further
 split in to two sets: 1) probes that are always available and 2) probes
 that are only available in the instrumented runtime.
 Probes in the instrumented runtime are primarily of
@@ -74,22 +72,24 @@ The full set of events emitted by probes and their documentation can be found in
  section~\ref{Runtime_events}.
 \fi
 
-\item[Custom probes] are defined using the
-\texttt{Runtime_events.User} module.
-Identified by a globally unique name, they record events and provide payloads of
-built-in (\texttt{unit}, \texttt{int}, \texttt{span}) and user-defined types.
-Consumers and producers are not compiled together, so they don't usually have
-the same set of registered events. The event name is used by the consumer to
-identify producer's events, with a fallback mechanism for unknown events of
-built-in types. Unknown events for user-defined types are currently ignored,
-even if the type is defined both in the producer and consumer side.
+\subsection{s:runtime-tracing-custom-events}{Custom events}
+The runtime events system supports defining custom events. Identified by a
+globally unique name, they are emitted with payloads of built-in (\texttt{unit},
+\texttt{int}, \texttt{span}) and user-defined types. They are registered using
+the \texttt{Runtime_events.User.register} function. Once an event is registered,
+values for that event are emitted using \texttt{Runtime_events.User.write}.
+
+As consumer and producer can be different programs, they might not have the same
+set of registered events. The event name is used by the consumer to identify
+producer events, with a fallback mechanism for unknown events of built-in types.
+Unknown events for user-defined types are currently ignored, even if the type is
+defined both in the producer and consumer side.
 
 An extensible variant \texttt{tag} provides a way to attach additional data to
-events, which can be used to provide additional information about the event's
-origin. The tag is not serialized, so it is only available for \textit{known}
+events. The tag is not serialized, so it is only available for \textit{known}
 events.
 
-In summary, the are three cases for the consumer when an event is received:
+In summary, there are three cases for the consumer when an event is received:
 \begin{itemize}
 \item event is registered: payload and tag are available.
 \item event is not registered and has a built-in event type (unit, int, span):
@@ -98,7 +98,7 @@ In summary, the are three cases for the consumer when an event is received:
 \end{itemize}
 The \texttt{Runtime_events.Type} module provides a way to use built-in event
 types and define new ones using an encoder-decoder pair.
-\end{description}
+
 \subsection{s:runtime-tracing-ingestion}{Events transport}
 
 The events transport part of the system ingests events emitted by the probes
@@ -236,8 +236,8 @@ OCAML_RUNTIME_EVENTS_START=1 ./example
 
 \subsubsection{s-runtime-tracing-custom-events}{Tracing custom events}
 
-The following program make use of the \texttt{Runtime_events.User} and
-\texttt{Runtime_events.Type} modules to declare a custom event providing
+The following program uses the \texttt{Runtime_events.User} and
+\texttt{Runtime_events.Type} modules to declare two custom events providing
 \texttt{span} and \texttt{int} values. The \texttt{tag} extensible variant is
 extended with \texttt{CustomSpan} and \texttt{CustomInt}.
 

--- a/manual/src/cmds/runtime-tracing.etex
+++ b/manual/src/cmds/runtime-tracing.etex
@@ -97,7 +97,7 @@ In summary, there are three cases for the consumer when an event is received:
 \item event is not registered and has a custom event type: event is dropped.
 \end{itemize}
 The \texttt{Runtime_events.Type} module provides a way to use built-in event
-types and define new ones using an encoder-decoder pair.
+types and define custom ones using an encoder-decoder pair.
 
 Event consumers bind callbacks to event types, so they can work as generic
 listeners interpreting payloads coming from events that were not registered.

--- a/manual/src/cmds/runtime-tracing.etex
+++ b/manual/src/cmds/runtime-tracing.etex
@@ -8,7 +8,7 @@ very low overhead. The system and interfaces are low-level and tightly coupled
 to the runtime implementation, it is intended for end-users to rely on tooling
 to consume and visualise data of interest. Additional events can be declared and
 consumed, providing higher-level dynamic introspection capabilities to OCaml
-libraries, they are referred to as {\em custom events}.
+libraries. They are referred to as {\em custom events}.
 
 Data emitted includes:
 \begin{itemize}

--- a/manual/src/cmds/runtime-tracing.etex
+++ b/manual/src/cmds/runtime-tracing.etex
@@ -99,6 +99,12 @@ In summary, there are three cases for the consumer when an event is received:
 The \texttt{Runtime_events.Type} module provides a way to use built-in event
 types and define new ones using an encoder-decoder pair.
 
+Event consumers bind callbacks to event types, so they can work as generic
+listeners interpreting payloads coming from events that were not registered.
+Because this only works for events of built-in types, it is useful to pair
+an event of custom type with an event of built-in type, enabling the design of
+a specialized consumer while staying compatible with generic tracing tools.
+
 \subsection{s:runtime-tracing-ingestion}{Events transport}
 
 The events transport part of the system ingests events emitted by the probes

--- a/otherlibs/runtime_events/runtime_events.mli
+++ b/otherlibs/runtime_events/runtime_events.mli
@@ -46,7 +46,7 @@
     very short running programs.
 *)
 
-(** The type for counter events emitted by the runtime *)
+(** The type for counter events emitted by the runtime. *)
 type runtime_counter =
 | EV_C_FORCE_MINOR_ALLOC_SMALL
 | EV_C_FORCE_MINOR_MAKE_VECT
@@ -88,7 +88,7 @@ Live blocks of a Domain's major heap pools.
 Live blocks of a Domain's major heap large allocations.
 @since 5.1 *)
 
-(** The type for span events emitted by the runtime *)
+(** The type for span events emitted by the runtime. *)
 type runtime_phase =
 | EV_EXPLICIT_GC_SET
 | EV_EXPLICIT_GC_STAT
@@ -131,7 +131,7 @@ type runtime_phase =
 | EV_DOMAIN_CONDITION_WAIT
 | EV_DOMAIN_RESIZE_HEAP_RESERVATION
 
-(** Lifecycle events for the ring itself *)
+(** Lifecycle events for the ring itself. *)
 type lifecycle =
   EV_RING_START
 | EV_RING_STOP
@@ -143,38 +143,38 @@ type lifecycle =
 | EV_DOMAIN_TERMINATE
 
 val lifecycle_name : lifecycle -> string
-(** Return a string representation of a given lifecycle event type *)
+(** Return a string representation of a given lifecycle event type. *)
 
 val runtime_phase_name : runtime_phase -> string
-(** Return a string representation of a given runtime phase event type *)
+(** Return a string representation of a given runtime phase event type. *)
 
 val runtime_counter_name : runtime_counter -> string
-(** Return a string representation of a given runtime counter type *)
+(** Return a string representation of a given runtime counter type. *)
 
 type cursor
-(** Type of the cursor used when consuming *)
+(** Type of the cursor used when consuming. *)
 
 module Timestamp : sig
     type t
-    (** Type for the int64 timestamp to allow for future changes *)
+    (** Type for the int64 timestamp to allow for future changes. *)
 
     val to_int64 : t -> int64
 end
 
 module Type : sig
   type 'a t
-  (** The type for a user event content type *)
+  (** The type for a user event content type. *)
 
   val unit : unit t
-  (** An event that has no data associated with it *)
+  (** An event that has no data associated with it. *)
 
   type span = Begin | End
 
   val span : span t
-  (** An event that has a beginning and an end *)
+  (** An event that has a beginning and an end. *)
 
   val int : int t
-  (** An event containing an integer value *)
+  (** An event containing an integer value. *)
 
   val register : encode:(bytes -> 'a -> int) -> decode:(bytes -> int -> 'a)
                                                                         -> 'a t
@@ -193,21 +193,21 @@ module User : sig
 
   type tag = ..
   (** The type for a user event tag. Tags are used to discriminate between
-      user events of the same type *)
+      user events of the same type. *)
 
   type 'value t
   (** The type for a user event. User events describe their tag, carried data
-      type and an unique string-based name *)
+      type and an unique string-based name. *)
 
   val register : string -> tag -> 'value Type.t -> 'value t
   (** [register name tag ty] registers a new event with an unique [name],
-      carrying a [tag] and values of type [ty] *)
+      carrying a [tag] and values of type [ty]. *)
 
   val write : 'value t -> 'value -> unit
-  (** [write t v] records a new event [t] with value [v] *)
+  (** [write t v] emits value [v] for event [t]. *)
 
   val name : _ t -> string
-  (** [name t] is the uniquely identifying name of event [t] *)
+  (** [name t] is the uniquely identifying name of event [t]. *)
 
   val tag : 'a t -> tag
   (** [tag t] is the associated tag of event [t], when it is known.
@@ -218,7 +218,7 @@ end
 
 module Callbacks : sig
   type t
-  (** Type of callbacks *)
+  (** Type of callbacks. *)
 
   val create : ?runtime_begin:(int -> Timestamp.t -> runtime_phase
                                 -> unit) ->
@@ -285,7 +285,7 @@ val create_cursor : (string * int) option -> cursor
    external process to monitor. *)
 
 val free_cursor : cursor -> unit
-(** Free a previously created runtime_events cursor *)
+(** Free a previously created runtime_events cursor. *)
 
 val read_poll : cursor -> Callbacks.t -> int option -> int
 (** [read_poll cursor callbacks max_option] calls the corresponding functions


### PR DESCRIPTION
This PR extends the runtime tracing section to account for custom events introduced in https://github.com/ocaml/ocaml/pull/11474

It should be included in the 5.1 release