### PR TITLE
Stop comparing compiler outputs in the testsuite

### DIFF
--- a/ocamltest/ocaml_tests.ml
+++ b/ocamltest/ocaml_tests.ml
@@ -46,7 +46,7 @@ let bytecode =
     check_program_output;
   ] @
   (if not Sys.win32 && Ocamltest_config.native_compiler then
-    opt_build @ [compare_bytecode_programs]
+    opt_build
   else
     []
   )


### PR DESCRIPTION
While working on #12232 I got bitten by the comparison check failing.
I suspect that it's a harmless difference in memory layouts (usually sharing) between `ocamlc.byte` and `ocamlc.opt`, and with no way to actually get useful info out of the test failure, and no simple way to disable this check, I decided to propose this PR, which turns off the binary comparison of executables from the default bytecode rule.

I did check that running `dumpobj` on the two programs produced the exact same output in my case, so the difference is likely in the rest of the data stored in the executable.

Cc @shindere as it's an ocamltest patch.
