### PR TITLE
Add two tests for `-short-paths` with existential types

### DIFF
--- a/Changes
+++ b/Changes
@@ -100,6 +100,10 @@ Working version
 
 ### Tools:
 
+- #12340: testsuite: collect known issues with current -short-paths
+  implementation for existential types
+  (Florian Angeletti, Samuel Hym, review by Florian Angeletti and Thomas Refis)
+
 - #12147: ocamllex: Allow carriage returns at the end of line directives.
   (SeungCheol Jung, review by Nicolás Ojeda Bär)
 

--- a/testsuite/tests/typing-short-paths/errors.ml
+++ b/testsuite/tests/typing-short-paths/errors.ml
@@ -34,3 +34,42 @@ Line 7, characters 9-18:
 Error: This expression has type "c"
        It has no method "bar"
 |}]
+
+
+(** Known issue: how to print existential types with equality in scope? *)
+
+type _ ty = Char : char ty
+type pair = Pair : 'a ty * 'a -> pair
+
+(* In the following function, we would like to see that [x] has type [char],
+   rather than an existential type *)
+let f = function
+  | Pair (Char, x) -> x + 1
+[%%expect {|
+type _ ty = Char : char ty
+type pair = Pair : 'a ty * 'a -> pair
+Line 9, characters 22-23:
+9 |   | Pair (Char, x) -> x + 1
+                          ^
+Error: This expression has type "$Pair_'a"
+       but an expression was expected of type "int"
+|}]
+
+type _ ty = Char : char ty
+type pair = Pair : 'a ty * 'a -> pair
+
+(* In the following function, an error report with the existential type is more
+   useful than one stating that type [char] would escape the scope *)
+let f = function
+  | Pair (Char, x) -> if true then x else 'd'
+[%%expect {|
+type _ ty = Char : char ty
+type pair = Pair : 'a ty * 'a -> pair
+Line 7, characters 35-36:
+7 |   | Pair (Char, x) -> if true then x else 'd'
+                                       ^
+Error: This expression has type "$Pair_'a"
+       but an expression was expected of type "'a"
+       This instance of "$Pair_'a" is ambiguous:
+       it would escape the scope of its equation
+|}]


### PR DESCRIPTION
As `$` is used to prefix existential types, favor an alternative if it exists when `-short-paths` is enabled by using exactly the same penalty as for the `_` prefix.

On the following program:

```ocaml
type _ ty = Char : char ty
type pair = Pair : 'a ty * 'a -> pair

let f = function
  | Pair (Char, x) -> x + 1
```

`$ ocamlc -short-paths` reported before:

```
5 |   | Pair (Char, x) -> x + 1
                          ^
Error: This expression has type $Pair_'a
       but an expression was expected of type int
```

while it now reports:

```
5 |   | Pair (Char, x) -> x + 1
                          ^
Error: This expression has type char
       but an expression was expected of type int
```

I'm not sure whether `$` can appear in other cases than existential types.