### PR TITLE
Infinite recursion detected (sic)

### DIFF
--- a/runtime/misc.c
+++ b/runtime/misc.c
@@ -51,7 +51,7 @@ void caml_failed_assert (char * expr, char_os * file_os, int line)
 {
   char* file = caml_stat_strdup_of_os(file_os);
   fprintf(stderr, "[%02d] file %s; line %d ### Assertion failed: %s\n",
-          (Caml_state_opt != NULL) ? Caml_state->id : -1, file, line, expr);
+          (Caml_state_opt != NULL) ? Caml_state_opt->id : -1, file, line, expr);
   fflush(stderr);
   caml_stat_free(file);
   abort();
@@ -86,7 +86,7 @@ void caml_gc_log (char *msg, ...)
     va_list args;
     va_start (args, msg);
     snprintf(fmtbuf, GC_LOG_LENGTH, "[%02d] %s\n",
-             (Caml_state_opt != NULL) ? Caml_state->id : -1, msg);
+             (Caml_state_opt != NULL) ? Caml_state_opt->id : -1, msg);
     vfprintf(stderr, fmtbuf, args);
     va_end (args);
     fflush(stderr);


### PR DESCRIPTION
GCC version 12 introduced the following warning, part of `-Wall`:

`-Winfinite-recursion`    Warn about infinitely recursive calls. The warning is effective at all optimization levels but requires optimization in order to detect infinite recursion in calls between two or more functions. `-Winfinite-recursion` is included in `-Wall`. 

This warning is rather unreliable.  For example, it triggers on the following function:
```
#include <stdio.h>
#include <stdlib.h>

int * p;

void f(char * msg)
{
  printf("[%d] %s\n",
         p != NULL ? ( (p != NULL ? (void) 0 : f("p is null")), *p ) : -1,
         msg);
  exit(2);
}

```
Note that the recursive call is unreachable code, so recursion cannot occur.  The warning is probably triggered before any optimization takes place, because it occurs at all optimization levels, while the recursive call is optimized away at `-O1`.

More amusingly, the warning goes away if the function is declared
```
void f(char * msg) __attribute__((noreturn));
```
but it still triggers if the function is declared
```
_Noreturn void f(char * msg);
```

Why do I tell you all that in an OCaml pull request?  Because runtime/misc.c contains code similar to the example above, which triggers the "infinite recursion" warning when compiled in debug mode!  Behold:
https://github.com/ocaml/ocaml/blob/1b312360e9d758ebb7e33951c028bb318e0d6b72/runtime/misc.c#L50-L58

Yup, `Caml_state` hides a `CAMLassert` which contains a call to `caml_failed_assert`...  In other words, our assertion-reporting code contains assertion checks -- but the check is guaranteed to succeed.

Currently, `caml_failed_assert` is declared `attribute((noreturn))`, so the infinite-recursion warning does not trigger on GCC 12, miraculously.

But #12235 proposes to declare `caml_failed_assert` as `_Noreturn`, in which case the warning triggers with GCC 12, aborting the build of OCaml in non-release mode.

The present PR offers to add 4 characters to make sure that `caml_failed_assert` does not contain hidden assertions and is obviously not recursive. This should avoid this GCC madness and would make the code clearer.
