### PR TITLE
Fix infinite loop in signal handling.

### DIFF
--- a/Changes
+++ b/Changes
@@ -68,6 +68,10 @@ Working version
   due to memory resource exhaustion.  It was previous always a `Failure`.
   (Anil Madhavapeddy, review by David Allsopp)
 
+- #12253, #12342: Fix infinite loop in signal handling.
+  (Guillaume Munch-Maccagnoni, report by Thomas Leonard, review by
+   KC Sivaramakrishnan and Sadiq Jaffer)
+
 ### Code generation and optimizations:
 
 - #11239: on x86-64 and RISC-V, reduce alignment of OCaml stacks from 16 to 8.


### PR DESCRIPTION
Originally authored by @gadmm. The code is from the patch at https://github.com/ocaml/ocaml/pull/11307#issuecomment-1597523166. 
 
Fixes #12253.

## Issue

This commit fixes a race in the signal handling code that creates an infinite loop in `caml_enter_blocking_section`.

In order to process signals, the function `caml_process_pending_signals_exn` first checks whether signals are pending in the flag (`caml_pending_signals` array) and whether the signal belongs to the current signal set of the thread. Then, it clears the pending status in the flag for that signal and calls `caml_execute_signals_exn`. `caml_execute_signals_exn` masks the signal in the current thread's signal set while it runs the OCaml signal handler.

It is possible that a signal may arrive after the signal pending flag is reset by `caml_process_pending_signals_exn` but before the signal is masked by `caml_execute_signals_exn`. The C signal handler for the racy signal sets the pending status flag after which the signal is masked. This puts the system in an inconsistent state.

The OCaml signal handler invoked in `caml_execute_signals_exn` may call `caml_enter_blocking_section`. The function `caml_enter_blocking_section` ensures that all the pending signals are processed before entering the blocking section by calling `caml_process_pending_signals_exn` **until the pending flag is cleared**.

Recall that the signal is masked in the thread's signal set. In order to process the pending signal, `caml_process_pending_signals_exn` checks whether signals are pending by checking the flag (yes) and also whether the signal is part of the current signal set (no, since it has been masked by `caml_execute_signal_exn`). So the pending flag is not cleared and the signal is not processed. Hence, `caml_enter_blocking_section` goes into an infinite loop.

## Fix

The fix is to not check the pending flag for retrying the loop in `caml_enter_blocking_section` but rather check whether the young limit is set to `UINTNAT_MAX`. Setting the young limit to `UINTNAT_MAX` is done whenever a domain needs to be interrupted such as signals but also requesting major slice, minor gc, etc. We replace `caml_process_pending_signals_exn` at the beginning of the `caml_enter_blocking_section` loop with `caml_process_pending_actions`, which handles all the interrupt actions and not just signals. Importantly, `caml_process_pending_actions` resets the young limit. By deciding to retry the loop only when the young limit is `UINTNAT_MAX`, we avoid the infinite loop. Note that the signal is not forgotten as the pending flag still remembers that the signal arrived. We will process it after the signal is unmasked. 

A more comprehensive fix for asynchronous actions including signals should arrive in #11307. This PR fixes the bug for 5.1 release. 