### PR TITLE
error messages: always report missing polyvariant tag

### DIFF
--- a/Changes
+++ b/Changes
@@ -131,6 +131,9 @@ Working version
   greatly simplifies both the build system and testsuite machinery.
   (David Allsopp, review by Sébastien Hinderer)
 
+- #12347: error messages: always report missing polyvariant tags
+  (Florian Angeletti, review by Gabriel Scherer)
+
 ### Internal/compiler-libs changes:
 
 - #12216, #12248: Prevent reordering of atomic loads during instruction

--- a/testsuite/tests/typing-misc/polyvars.ml
+++ b/testsuite/tests/typing-misc/polyvars.ml
@@ -232,3 +232,21 @@ let x = let rec x = `X (`Y (fun y -> x = y)) in Fun.id x
 val x : [> `X of [> `Y of '_weak2 -> bool ] as '_weak3 ] as '_weak2 =
   `X (`Y <fun>)
 |}]
+
+(** Missing tag correctly attributed *)
+type rt = [ `A | `B of string | `R of rt ]
+let rec f = function `A -> 0 | `B s -> int_of_string s | `R x -> f x
+
+let g (x:[`A | `R of rt]) = f x
+[%%expect{|
+type rt = [ `A | `B of string | `R of rt ]
+val f : ([< `A | `B of string | `R of 'a ] as 'a) -> int = <fun>
+Line 4, characters 30-31:
+4 | let g (x:[`A | `R of rt]) = f x
+                                  ^
+Error: This expression has type "[ `A | `R of rt ]"
+       but an expression was expected of type "[< `A | `R of 'a ] as 'a"
+       Type "rt" = "[ `A | `B of string | `R of rt ]" is not compatible with type
+         "[< `A | `R of 'a ] as 'a"
+       The second variant type does not allow tag(s) "`B"
+|}]

--- a/testsuite/tests/typing-misc/polyvars.ml
+++ b/testsuite/tests/typing-misc/polyvars.ml
@@ -233,6 +233,44 @@ val x : [> `X of [> `Y of '_weak2 -> bool ] as '_weak3 ] as '_weak2 =
   `X (`Y <fun>)
 |}]
 
+(** Code coverage for [unify_row_field] erros *)
+
+(** Arity mismatch *)
+
+let f (x:[`X of int]) = (x:[`X])
+[%%expect{|
+Line 5, characters 25-26:
+5 | let f (x:[`X of int]) = (x:[`X])
+                             ^
+Error: This expression has type "[ `X of int ]"
+       but an expression was expected of type "[ `X ]"
+       Types for tag "`X" are incompatible
+|}]
+
+
+let f (x:[`X of int]) = (x:[<`X of & int])
+[%%expect{|
+Line 1, characters 25-26:
+1 | let f (x:[`X of int]) = (x:[<`X of & int])
+                             ^
+Error: This expression has type "[ `X of int ]"
+       but an expression was expected of type "[< `X of & int ]"
+       Types for tag "`X" are incompatible
+|}]
+
+(** Inconsistent type *)
+
+let f (x:[<`X of & int & float]) = (x:[`X])
+[%%expect{|
+Line 3, characters 36-37:
+3 | let f (x:[<`X of & int & float]) = (x:[`X])
+                                        ^
+Error: This expression has type "[< `X of & int & float ]"
+       but an expression was expected of type "[ `X ]"
+       Types for tag "`X" are incompatible
+|}]
+
+
 (** Missing tag correctly attributed *)
 type rt = [ `A | `B of string | `R of rt ]
 let rec f = function `A -> 0 | `B s -> int_of_string s | `R x -> f x

--- a/testsuite/tests/typing-ocamlc-i/pr7620_bad.compilers.reference
+++ b/testsuite/tests/typing-ocamlc-i/pr7620_bad.compilers.reference
@@ -3,4 +3,4 @@ File "pr7620_bad.ml", line 10, characters 17-19:
                       ^^
 Error: This pattern matches values of type "[? `B ]"
        but a pattern was expected which matches values of type "[ `A ]"
-       Types for tag "`B" are incompatible
+       The second variant type does not allow tag(s) "`B"

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -3175,7 +3175,20 @@ and unify_row_field uenv fixed1 fixed2 rm1 rm2 l f1 f2 =
       if_not_fixed first (fun () -> link_row_field_ext ~inside:f1 f2)
   | Rpresent None, Reither(true, [], _) ->
       if_not_fixed second (fun () -> link_row_field_ext ~inside:f2 f1)
-  | _ -> raise_unexplained_for Unify
+  | Rabsent, (Rpresent _ | Reither(_,_,true)) ->
+      raise_trace_for Unify [Variant(No_tags(First, [l,f1]))]
+  | (Rpresent _ | Reither (_,_,true)), Rabsent ->
+      raise_trace_for Unify [Variant(No_tags(Second, [l,f2]))]
+  | (Rpresent (Some _) | Reither(false,_,_)),
+    (Rpresent None | Reither(true,_,_))
+  | (Rpresent None | Reither(true,_,_)),
+    (Rpresent (Some _) | Reither(false,_,_)) ->
+      (* constructor arity mismatch: 0 <> 1 *)
+      raise_unexplained_for Unify
+  | Reither(true, _ :: _, _ ), Rpresent _
+  | Rpresent _ , Reither(true, _ :: _, _ ) ->
+      (* inconsistent conjunction on a non-absent field *)
+      raise_unexplained_for Unify
 
 let unify uenv ty1 ty2 =
   let snap = Btype.snapshot () in


### PR DESCRIPTION
This PR makes sure that missing polyvariant tags are always correctly reported in error messages even if the tag was discovered as absent during unification.

More concretely, on trunk, the following function 
```ocaml
let f (x: [ `R of ([ `A | `R of 'b ] as 'b)]) =
  (x : [< `A | `R of 'a ] as 'a )
```
fails to typecheck with
```
 Error: This expression has type [ `R of [ `A | `R of 'a ] as 'a ]
       but an expression was expected of type [< `R of 'a0 ] as 'a0
       Types for tag `A are incompatible
```
when the real mismatch between the two types is that there is no tags `` `A `` in the second type.
With this PR, the error message correctly mentions the missing tag:
```
Error: This expression has type [ `R of [ `A | `R of 'a ] as 'a ]
       but an expression was expected of type [< `R of 'a0 ] as 'a0
       The second variant type does not allow tag(s) `A
```
The fix consists in recording in the error trace that we encountered a presence mismatch in the "low-level" function `unify_row_field`. This was not done before because in nearly all cases mismatches in term of tag presence are discovered when comparing the list tags of polymorphic variants in the higher level `unify_row` function.