### PR TITLE
manual: explain the difference between multi-argument and single-tuple-argument variant constructors

### DIFF
--- a/manual/src/tutorials/coreexamples.etex
+++ b/manual/src/tutorials/coreexamples.etex
@@ -297,6 +297,41 @@ let rec insert x btree =
                 else Node(y, left, insert x right);;
 \end{caml_example}
 
+\subsection{ss:several-arguments-or-tuple-argument}{Several arguments or a tuple of arguments?}
+
+A constructor declared as "A of int * string" takes two arguments of
+type "int" and "string". In contrast, a constructor declared as "B of
+(int * string)" takes a single argument, a tuple of type "int *
+string". The difference is subtle and this can be a source of
+confusion.
+
+\begin{caml_example}{toplevel}
+type t =
+  | A of int * string
+  | B of (int * string)
+;;
+\end{caml_example}
+
+Passing the arguments separately, when constructing a value or
+pattern-matching, works with both definitions.
+
+\begin{caml_example}{toplevel}
+let a = A (3, "haha");;
+let b = B (3, "haha");;
+\end{caml_example}
+
+On the other hand, passing a tuple as single argument is only allowed
+with constructor "B".
+\begin{caml_example}{toplevel}
+let tup = (3, "haha");;
+
+let fails = A tup[@@expect error];;
+let works = B tup;;
+\end{caml_example}
+
+When in doubt, it is better to use the first form with separate
+arguments ("A of int * string"), which has a more compact memory
+representation.
 
 \subsection{ss:record-and-variant-disambiguation}{Record and variant disambiguation}
 ( This subsection can be skipped on the first reading )


### PR DESCRIPTION
fixes #7783, see also
https://discuss.ocaml.org/t/sum-type-constructor-declaration-subtlety-and-documentation-wanted/1898

The new content is included at the end of the (fairly brief) presentation of records and variants in the "tutorial / language tour" part of the manual.

This is arguably more advanced content and it could also somewhere else, but it is unclear that the "reference manual" part of the manual would be more appropriate.

It depends on how we think of this explanation/warning and its intended target audience: is it a pitfall that all OCaml beginners should be told about to avoid confusion later (similar to: `Array.make xlen (Array.make ylen 0)`), or is it advanced content that we want teachers/mentors to be able to point to as a reference explanation?

This commits tries to aim for the "beginner tour" aspect, as suggested by past discussions, so it is intentionally brief and light on details.