### PR TITLE
Fix bucket assignments in `caml_ev_alloc`

### DIFF
--- a/runtime/caml/runtime_events.h
+++ b/runtime/caml/runtime_events.h
@@ -225,8 +225,17 @@ struct runtime_events_metadata_header {
 };
 
 #define RUNTIME_EVENTS_MAX_CUSTOM_EVENTS (1 << 13)
-#define RUNTIME_EVENTS_NUM_ALLOC_BUCKETS 20
 #define RUNTIME_EVENTS_MAX_MSG_LENGTH (1 << 10)
+
+/* Number of tens of single-size buckets */
+#define RUNTIME_EVENTS_NUM_ALLOC_BUCKETS_SINGLE 1
+/* Number of buckets of 10 sizes */
+#define RUNTIME_EVENTS_NUM_ALLOC_BUCKETS_DECADE 9
+/* Total number of buckets */
+#define RUNTIME_EVENTS_NUM_ALLOC_BUCKETS \
+  (10 * RUNTIME_EVENTS_NUM_ALLOC_BUCKETS_SINGLE \
+   + RUNTIME_EVENTS_NUM_ALLOC_BUCKETS_DECADE \
+   + 1)
 
 /* event header fields (for runtime events):
 - length (10 bits)

--- a/runtime/runtime_events.c
+++ b/runtime/runtime_events.c
@@ -593,18 +593,17 @@ void caml_ev_lifecycle(ev_lifecycle lifecycle, int64_t data) {
   }
 }
 
-static uint64_t alloc_buckets[RUNTIME_EVENTS_NUM_ALLOC_BUCKETS] = {
-    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+static uint64_t alloc_buckets[RUNTIME_EVENTS_NUM_ALLOC_BUCKETS] = { 0, };
 
 void caml_ev_alloc(uint64_t sz) {
   if ( !ring_is_active() )
     return;
 
-  if (sz < (RUNTIME_EVENTS_NUM_ALLOC_BUCKETS / 2)) {
+  if (sz < 10 * RUNTIME_EVENTS_NUM_ALLOC_BUCKETS_SINGLE) {
     ++alloc_buckets[sz];
-  } else if (sz < (RUNTIME_EVENTS_NUM_ALLOC_BUCKETS * 10 / 2)) {
-    ++alloc_buckets[sz / (RUNTIME_EVENTS_NUM_ALLOC_BUCKETS / 2)
-      + (RUNTIME_EVENTS_NUM_ALLOC_BUCKETS / 2 - 1)];
+  } else if (sz - 10 * RUNTIME_EVENTS_NUM_ALLOC_BUCKETS_SINGLE
+             < 10 * RUNTIME_EVENTS_NUM_ALLOC_BUCKETS_DECADE){
+    ++alloc_buckets[sz / 10 + 9 * RUNTIME_EVENTS_NUM_ALLOC_BUCKETS_SINGLE];
   } else {
     ++alloc_buckets[RUNTIME_EVENTS_NUM_ALLOC_BUCKETS - 1];
   }


### PR DESCRIPTION
`caml_ev_alloc` is used to count allocations for the runtime events system. Its code doesn't make sense, and indeed it only works when the constant `RUNTIME_EVENTS_NUM_ALLOC_BUCKETS` is between 18 and 21 (inclusive). Above 21, it leaves some unused buckets in the array, and below 18 it does out-of-bounds writes. Fortunately, there is a (redundant) initializer with 20 values, so you get an error from the C compiler if you try to reduce `RUNTIME_EVENTS_NUM_ALLOC_BUCKETS` from its default value (20).

The initial idea was to have an array with 20 buckets: one bucket for each size from 0 to 9, one bucket for each decade from 10-19 to 90-99, and one bucket for 100 and above. `RUNTIME_EVENTS_NUM_ALLOC_BUCKETS` is a failed attempt at generalizing that.

With this PR, there are now two parameters: `RUNTIME_EVENTS_NUM_ALLOC_BUCKETS_SINGLE`, which counts how many tens of buckets will store a single size each, and `RUNTIME_EVENTS_NUM_ALLOC_BUCKETS_DECADE`, which counts how many buckets will store 10 sizes each. The size of the array is computed from these two parameters, which can be chosen arbitrarily.
