### PR TITLE
ocamlmktop: remove +ocamlmktop directory from include path

### DIFF
--- a/tools/ocamlmktop.ml
+++ b/tools/ocamlmktop.ml
@@ -27,7 +27,7 @@ let main () =
   let ocamlc = Filename.(quote (concat (dirname ocamlmktop) ocamlc)) in
   let cmdline =
     extra_quote ^ ocamlc ^
-    " -I +compiler-libs -I +ocamlmktop " ^
+    " -I +compiler-libs " ^
     "-linkall ocamlcommon.cma ocamlbytecomp.cma ocamltoplevel.cma " ^
     args ^ " topstart.cmo" ^
     extra_quote


### PR DESCRIPTION
There is no longer a reason to add `-I +ocamlmktop` to the `ocamlc` command line in ocamlmktop: we are no longer using this directory to host `ocamlmktop` initialization module.

Close #12356 .