### PR TITLE
Get rid of the LongString module

### DIFF
--- a/.depend
+++ b/.depend
@@ -2241,7 +2241,6 @@ bytecomp/symtable.cmx : \
     parsing/asttypes.cmi \
     bytecomp/symtable.cmi
 bytecomp/symtable.cmi : \
-    utils/misc.cmi \
     lambda/lambda.cmi \
     typing/ident.cmi \
     file_formats/cmo_format.cmi

--- a/bytecomp/emitcode.ml
+++ b/bytecomp/emitcode.ml
@@ -50,24 +50,30 @@ let () =
     )
 
 (* Buffering of bytecode *)
-let out_buffer = ref(LongString.create 0)
+let create_bigarray = Bigarray.Array1.create Bigarray.Char Bigarray.c_layout
+
+let copy_bigarray src dst size =
+  Bigarray.Array1.(blit src (sub dst 0 size))
+
+let out_buffer = ref(create_bigarray 0)
 and out_position = ref 0
 
 let extend_buffer needed =
-  let size = LongString.length !out_buffer in
+  let size = Bigarray.Array1.dim !out_buffer in
   let new_size = ref(max size 16) (* we need new_size > 0 *) in
   while needed >= !new_size do new_size := 2 * !new_size done;
-  let new_buffer = LongString.create !new_size in
-  LongString.blit !out_buffer 0 new_buffer 0 (LongString.length !out_buffer);
+  let new_buffer = create_bigarray !new_size in
+  copy_bigarray !out_buffer new_buffer size;
   out_buffer := new_buffer
 
 let out_word b1 b2 b3 b4 =
   let p = !out_position in
-  if p+3 >= LongString.length !out_buffer then extend_buffer (p+3);
-  LongString.set !out_buffer p (Char.unsafe_chr b1);
-  LongString.set !out_buffer (p+1) (Char.unsafe_chr b2);
-  LongString.set !out_buffer (p+2) (Char.unsafe_chr b3);
-  LongString.set !out_buffer (p+3) (Char.unsafe_chr b4);
+  let open Bigarray.Array1 in
+  if p+3 >= dim !out_buffer then extend_buffer (p+3);
+  set !out_buffer p (Char.unsafe_chr b1);
+  set !out_buffer (p+1) (Char.unsafe_chr b2);
+  set !out_buffer (p+2) (Char.unsafe_chr b3);
+  set !out_buffer (p+3) (Char.unsafe_chr b4);
   out_position := p + 4
 
 let out opcode =
@@ -117,10 +123,11 @@ let extend_label_table needed =
 
 let backpatch (pos, orig) =
   let displ = (!out_position - orig) asr 2 in
-  LongString.set !out_buffer pos (Char.unsafe_chr displ);
-  LongString.set !out_buffer (pos+1) (Char.unsafe_chr (displ asr 8));
-  LongString.set !out_buffer (pos+2) (Char.unsafe_chr (displ asr 16));
-  LongString.set !out_buffer (pos+3) (Char.unsafe_chr (displ asr 24))
+  let open Bigarray.Array1 in
+  set !out_buffer pos (Char.unsafe_chr displ);
+  set !out_buffer (pos+1) (Char.unsafe_chr (displ asr 8));
+  set !out_buffer (pos+2) (Char.unsafe_chr (displ asr 16));
+  set !out_buffer (pos+3) (Char.unsafe_chr (displ asr 24))
 
 let define_label lbl =
   if lbl >= Array.length !label_table then extend_label_table lbl;
@@ -198,12 +205,12 @@ let clear() =
   reloc_info := [];
   debug_dirs := String.Set.empty;
   events := [];
-  out_buffer := LongString.create 0
+  out_buffer := create_bigarray 0
 
 let init () =
   clear ();
   label_table := Array.make 16 (Label_undefined []);
-  out_buffer := LongString.create 1024
+  out_buffer := create_bigarray 1024
 
 (* Emission of one instruction *)
 
@@ -420,7 +427,7 @@ let to_file outchan artifact_info ~required_globals code =
   output_binary_int outchan 0;
   let pos_code = pos_out outchan in
   emit code;
-  LongString.output outchan !out_buffer 0 !out_position;
+  Out_channel.output_bigarray outchan !out_buffer 0 !out_position;
   let (pos_debug, size_debug) =
     if !Clflags.debug then begin
       let filename = Unit_info.Artifact.filename artifact_info in
@@ -466,8 +473,8 @@ let to_memory instrs =
   init();
   Fun.protect ~finally:clear (fun () ->
   emit instrs;
-  let code = LongString.create !out_position in
-  LongString.blit !out_buffer 0 code 0 !out_position;
+  let code = create_bigarray !out_position in
+  copy_bigarray !out_buffer code !out_position;
   let reloc = List.rev !reloc_info in
   let events = !events in
   (code, reloc, events))
@@ -478,7 +485,7 @@ let to_packed_file outchan code =
   init ();
   Fun.protect ~finally:clear (fun () ->
   emit code;
-  LongString.output outchan !out_buffer 0 !out_position;
+  Out_channel.output_bigarray outchan !out_buffer 0 !out_position;
   let reloc = List.rev !reloc_info in
   let events = !events in
   let debug_dirs = !debug_dirs in

--- a/bytecomp/emitcode.ml
+++ b/bytecomp/emitcode.ml
@@ -53,7 +53,7 @@ let () =
 let create_bigarray = Bigarray.Array1.create Bigarray.Char Bigarray.c_layout
 
 let copy_bigarray src dst size =
-  Bigarray.Array1.(blit src (sub dst 0 size))
+  Bigarray.Array1.(blit (sub src 0 size) (sub dst 0 size))
 
 let out_buffer = ref(create_bigarray 0)
 and out_position = ref 0

--- a/bytecomp/emitcode.mli
+++ b/bytecomp/emitcode.mli
@@ -29,7 +29,8 @@ val to_file: out_channel -> Unit_info.Artifact.t ->
              list of instructions to emit *)
 val to_memory:
   instruction list ->
-    Misc.LongString.t * (reloc_info * int) list * debug_event list
+    (char, Bigarray.int8_unsigned_elt, Bigarray.c_layout) Bigarray.Array1.t *
+    (reloc_info * int) list * debug_event list
         (* Arguments:
              initialization code (terminated by STOP)
              function code

--- a/bytecomp/meta.ml
+++ b/bytecomp/meta.ml
@@ -18,7 +18,8 @@ external realloc_global_data : int -> unit = "caml_realloc_global"
 type closure = unit -> Obj.t
 type bytecode
 external reify_bytecode :
-  bytes array -> Instruct.debug_event list array -> string option ->
+  (char, Bigarray.int8_unsigned_elt, Bigarray.c_layout) Bigarray.Array1.t ->
+  Instruct.debug_event list array -> string option ->
     bytecode * closure
                            = "caml_reify_bytecode"
 external release_bytecode : bytecode -> unit

--- a/bytecomp/meta.mli
+++ b/bytecomp/meta.mli
@@ -20,7 +20,8 @@ external realloc_global_data : int -> unit = "caml_realloc_global"
 type closure = unit -> Obj.t
 type bytecode
 external reify_bytecode :
-  bytes array -> Instruct.debug_event list array -> string option ->
+  (char, Bigarray.int8_unsigned_elt, Bigarray.c_layout) Bigarray.Array1.t ->
+  Instruct.debug_event list array -> string option ->
     bytecode * closure
                            = "caml_reify_bytecode"
 external release_bytecode : bytecode -> unit

--- a/bytecomp/symtable.ml
+++ b/bytecomp/symtable.ml
@@ -270,10 +270,11 @@ let init () =
 (* Relocate a block of object bytecode *)
 
 let patch_int buff pos n =
-  LongString.set buff pos (Char.unsafe_chr n);
-  LongString.set buff (pos + 1) (Char.unsafe_chr (n asr 8));
-  LongString.set buff (pos + 2) (Char.unsafe_chr (n asr 16));
-  LongString.set buff (pos + 3) (Char.unsafe_chr (n asr 24))
+  let open Bigarray.Array1 in
+  set buff pos (Char.unsafe_chr n);
+  set buff (pos + 1) (Char.unsafe_chr (n asr 8));
+  set buff (pos + 2) (Char.unsafe_chr (n asr 16));
+  set buff (pos + 3) (Char.unsafe_chr (n asr 24))
 
 let patch_object buff patchlist =
   List.iter

--- a/bytecomp/symtable.mli
+++ b/bytecomp/symtable.mli
@@ -46,7 +46,9 @@ end
 (* Functions for batch linking *)
 
 val init: unit -> unit
-val patch_object: Misc.LongString.t -> (reloc_info * int) list -> unit
+val patch_object:
+  (char, Bigarray.int8_unsigned_elt, Bigarray.c_layout) Bigarray.Array1.t ->
+  (reloc_info * int) list -> unit
 val require_primitive: string -> unit
 val initial_global_table: unit -> Obj.t array
 val output_global_map: out_channel -> unit

--- a/testsuite/tests/lib-dynlink-initializers/test10_main.byte.reference
+++ b/testsuite/tests/lib-dynlink-initializers/test10_main.byte.reference
@@ -3,8 +3,8 @@ Raised at Stdlib.failwith in file "stdlib.ml", line 29, characters 17-33
 Called from Test10_plugin.g in file "test10_plugin.ml", line 3, characters 2-21
 Called from Test10_plugin.f in file "test10_plugin.ml", line 6, characters 2-6
 Called from Test10_plugin in file "test10_plugin.ml", line 10, characters 2-6
-Called from Dynlink.Bytecode.run in file "byte/dynlink.ml", line 146, characters 16-25
-Re-raised at Dynlink.Bytecode.run in file "byte/dynlink.ml", line 148, characters 6-137
+Called from Dynlink.Bytecode.run in file "byte/dynlink.ml", line 154, characters 16-25
+Re-raised at Dynlink.Bytecode.run in file "byte/dynlink.ml", line 156, characters 6-137
 Called from Dynlink_common.Make.load.(fun) in file "dynlink_common.ml", line 360, characters 11-54
 Called from Stdlib__List.iter in file "list.ml", line 112, characters 12-15
 Called from Stdlib__Fun.protect in file "fun.ml", line 33, characters 8-15

--- a/toplevel/byte/topeval.ml
+++ b/toplevel/byte/topeval.ml
@@ -218,7 +218,12 @@ let check_consistency ppf filename cu =
 let load_compunit ic filename ppf compunit =
   check_consistency ppf filename compunit;
   seek_in ic compunit.cu_pos;
-  let code = LongString.input_bytes ic compunit.cu_codesize in
+  let code =
+    Bigarray.Array1.create Bigarray.Char Bigarray.c_layout compunit.cu_codesize
+  in
+  match In_channel.really_input_bigarray ic code 0 compunit.cu_codesize with
+    | None -> raise End_of_file
+    | Some () -> ();
   let initial_symtable = Symtable.current_state() in
   Symtable.patch_object code compunit.cu_reloc;
   Symtable.update_global_table();

--- a/utils/misc.ml
+++ b/utils/misc.ml
@@ -513,53 +513,6 @@ let thd4 (_,_,x,_) = x
 let for4 (_,_,_,x) = x
 
 
-module LongString = struct
-  type t = bytes array
-
-  let create str_size =
-    let tbl_size = str_size / Sys.max_string_length + 1 in
-    let tbl = Array.make tbl_size Bytes.empty in
-    for i = 0 to tbl_size - 2 do
-      tbl.(i) <- Bytes.create Sys.max_string_length;
-    done;
-    tbl.(tbl_size - 1) <- Bytes.create (str_size mod Sys.max_string_length);
-    tbl
-
-  let length tbl =
-    let tbl_size = Array.length tbl in
-    Sys.max_string_length * (tbl_size - 1) + Bytes.length tbl.(tbl_size - 1)
-
-  let get tbl ind =
-    Bytes.get tbl.(ind / Sys.max_string_length) (ind mod Sys.max_string_length)
-
-  let set tbl ind c =
-    Bytes.set tbl.(ind / Sys.max_string_length) (ind mod Sys.max_string_length)
-              c
-
-  let blit src srcoff dst dstoff len =
-    for i = 0 to len - 1 do
-      set dst (dstoff + i) (get src (srcoff + i))
-    done
-
-  let output oc tbl pos len =
-    for i = pos to pos + len - 1 do
-      output_char oc (get tbl i)
-    done
-
-  let input_bytes_into tbl ic len =
-    let count = ref len in
-    Array.iter (fun str ->
-      let chunk = Int.min !count (Bytes.length str) in
-      really_input ic str 0 chunk;
-      count := !count - chunk) tbl
-
-  let input_bytes ic len =
-    let tbl = create len in
-    input_bytes_into tbl ic len;
-    tbl
-end
-
-
 let cut_at s c =
   let pos = String.index s c in
   String.sub s 0 pos, String.sub s (pos+1) (String.length s - pos - 1)

--- a/utils/misc.mli
+++ b/utils/misc.mli
@@ -416,23 +416,6 @@ val snd4: 'a * 'b * 'c * 'd -> 'b
 val thd4: 'a * 'b * 'c * 'd -> 'c
 val for4: 'a * 'b * 'c * 'd -> 'd
 
-(** {1 Long strings} *)
-
-(** ``Long strings'' are mutable arrays of characters that are not limited
-    in length to {!Sys.max_string_length}. *)
-
-module LongString :
-  sig
-    type t = bytes array
-    val create : int -> t
-    val length : t -> int
-    val get : t -> int -> char
-    val set : t -> int -> char -> unit
-    val blit : t -> int -> t -> int -> int -> unit
-    val output : out_channel -> t -> int -> int -> unit
-    val input_bytes : in_channel -> int -> t
-  end
-
 (** {1 Spell checking and ``did you mean'' suggestions} *)
 
 val edit_distance : string -> string -> int -> int option


### PR DESCRIPTION
This PR is a follow-up to [this comment](https://github.com/ocaml/ocaml/pull/1723#issuecomment-381522567) by @xavierleroy.

Co-authored with @stedolan, it reimplements the LongString module defined
in `utils/misc.ml` on top of 1-dimension bigarrays of characters, which
are a more efficient representation than the currently implemented
one, based on an array of strings.

The current commit history reflects how things happened: @stedolan
has provided the primitives that were missing to read/write bigarrays
of characters from/to channels. I then reimplemented `LongStirng` on top
of this work.

The current implementation's role is above all to get discussions going.
For the time being, I tried to touch the standard library as lightly as
possible because it's a sensitive territory. However, I do think we
could come up with a nicer implementation if we moved at least a bit of
`Bigstring` in the stdlib, thus also making it available to users
since it feels a nice-to-have (I think the well known alternatives to our
standard library do all provide such an implementatin of bigstrings, which
is both a pro in the sense that it shows it's useful and a con because it
can be argued that, since it's available elsewhere then we dont need to make
it available once more, but since we ourselves need it for the compiler,
perhaps it means it would actually make sense to also make public the
implementation we use).

One possibility would be to add `Bigstring` as a sub-module of `Bigarray`,
as a kind of specialisation of `Array1`, but I'm wondering whether it
wouldn't be even nicer to introduce `Bigstring` as a top-level module of the
standard library, which would depend on `Bigarray`. But of course that
introduces the risk of name clashes.