### PR TITLE
Make Pattern_env.t private

### DIFF
--- a/Changes
+++ b/Changes
@@ -151,7 +151,7 @@ Working version
 - #12109: Pack parameters to unification in unification_environment
   (Takafumi Saikawa and Jacques Garrigue, review by Richard Eisenberg)
 
-- #12331: Pack the unification data for pattern checking in Typecore
+- #12331, #12361: Pack the unification data for pattern checking in Typecore
   (Takafumi Saikawa and Jacques Garrigue,
    review by Gabriel Scherer, Thomas Refis and Florian Angeletti)
 

--- a/typing/ctype.mli
+++ b/typing/ctype.mli
@@ -177,7 +177,7 @@ val new_local_type:
 val existential_name: constructor_description -> type_expr -> string
 
 module Pattern_env : sig
-  type t =
+  type t = private
     { mutable env : Env.t;
       equations_scope : int;
       (* scope for local type declarations *)
@@ -186,6 +186,7 @@ module Pattern_env : sig
     }
   val make: Env.t -> equations_scope:int -> allow_recursive_equations:bool -> t
   val copy: ?equations_scope:int -> t -> t
+  val set_env: t -> Env.t -> unit
 end
 
 type existential_treatment =

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -733,7 +733,7 @@ let solve_constructor_annotation
         let decl = new_local_type ~loc:name.loc () in
         let (id, new_env) =
           Env.enter_type ~scope:expansion_scope name.txt decl !!penv in
-        penv.env <- new_env;
+        Pattern_env.set_env penv new_env;
         {name with txt = id})
       name_list
   in
@@ -1894,12 +1894,12 @@ and type_pat_aux
   | Ppat_open (lid,p) ->
       let path, new_env =
         !type_open Asttypes.Fresh !!penv sp.ppat_loc lid in
-      penv.env <- new_env;
+      Pattern_env.set_env penv new_env;
       let p = type_pat tps category ~penv p expected_ty in
       let new_env = !!penv in
       begin match Env.remove_last_open path new_env with
       | None -> assert false
-      | Some closed_env -> penv.env <- closed_env
+      | Some closed_env -> Pattern_env.set_env penv closed_env
       end;
       { p with pat_extra = (Tpat_open (path,lid,new_env),
                                 loc, sp.ppat_attributes) :: p.pat_extra }
@@ -2195,7 +2195,7 @@ let save_state penv =
     env = !!penv; }
 let set_state s penv =
   Btype.backtrack s.snapshot;
-  penv.Pattern_env.env <- s.env
+  Pattern_env.set_env penv s.env
 
 (** Find the first alternative in the tree of or-patterns for which
     [f] does not raise an error. If all fail, the last error is


### PR DESCRIPTION
Follow-up to #12331, making `Pattern_env.t` private, so that we can track better who modifies it.