### PR TITLE
Better .ocamlinit lookup on Win32

### DIFF
--- a/man/ocaml.1
+++ b/man/ocaml.1
@@ -326,11 +326,17 @@ giving control to the user. The default file is
 .B .ocamlinit
 in the current directory if it exists, otherwise
 .B XDG_CONFIG_HOME/ocaml/init.ml
-according to the XDG base directory specification lookup if it exists (on
-Windows this is skipped), otherwise
-.B .ocamlinit
-in the user's home directory
-.RB ( HOME " variable)."
+according to the XDG base directory specification lookup if it exists
+(on Windows, if
+.B XDG_CONFIG_HOME
+is not set then
+.B LOCALAPPDATA
+is used in its place),
+otherwise
+.B HOME/.ocamlinit
+(on Windows,
+.B USERPROFILE/.ocamlinit
+is used instead).
 You can specify a different initialization file
 by using the
 .BI \-init " file"
@@ -359,6 +365,16 @@ and look up its capabilities in the terminal database.
 .B XDG_CONFIG_HOME HOME
 .B .ocamlinit
 lookup procedure (see above).
+.TP
+.B LOCALAPPDATA
+used if
+.B XDG_CONFIG_HOME
+is not set (Windows only).
+.TP
+.B USERPROFILE
+used instead of
+.B HOME
+(Windows only).
 .SH SEE ALSO
 .BR ocamlc "(1), " ocamlopt "(1), " ocamlrun (1).
 .br

--- a/manual/src/cmds/top.etex
+++ b/manual/src/cmds/top.etex
@@ -68,10 +68,10 @@ described in section~\ref{s:toplevel-directives}.
 The evaluation outcode for each phrase are not displayed.
 If the current directory does not contain an ".ocamlinit" file,
 the file "XDG_CONFIG_HOME/ocaml/init.ml" is looked up according
-to the XDG base directory specification and used instead (on Windows
-this is skipped). If that file doesn't exist then an [.ocamlinit] file
-in the users' home directory (determined via environment variable "HOME") is
-used if existing.
+to the XDG base directory specification and used instead (on Windows,
+if "XDG_CONFIG_HOME" is not set then "LOCALAPPDATA" is used in its place).
+If that file does not exist then "HOME/.ocamlinit" is used
+if it exists (on Windows, "USERPROFILE/.ocamlinit" is used instead).
 
 The toplevel system does not perform line editing, but it can
 easily be used in conjunction with an external line editor such as

--- a/manual/src/cmds/unified-options.etex
+++ b/manual/src/cmds/unified-options.etex
@@ -304,8 +304,10 @@ the toplevel is running with the "#directory" directive
 \item["-init" \var{file}]
 Load the given file instead of the default initialization file.
 The default file is ".ocamlinit" in the current directory if it
-exists, otherwise "XDG_CONFIG_HOME/ocaml/init.ml" or
-".ocamlinit" in the user's home directory.
+exists, otherwise "XDG_CONFIG_HOME/ocaml/init.ml"
+(on Windows, if "XDG_CONFIG_HOME" is not set then "LOCALAPPDATA" is
+used in its place) or "HOME/.ocamlinit" (on Windows, "USERPROFILE/.ocamlinit"
+is used instead).
 }%top
 
 \notop{%

--- a/toplevel/toploop.ml
+++ b/toplevel/toploop.ml
@@ -154,20 +154,21 @@ let find_ocamlinit () =
         let file = Filename.concat dir file in
         if Sys.file_exists file then Some file else None
   in
-  let home_dir () = getenv "HOME" in
   let config_dir () =
-    if Sys.win32 then None else
     match getenv "XDG_CONFIG_HOME" with
     | Some _ as v -> v
     | None ->
-        match home_dir () with
-        | None -> None
-        | Some dir -> Some (Filename.concat dir ".config")
+        if Sys.win32 then
+          getenv "LOCALAPPDATA"
+        else
+          match getenv "HOME" with
+          | None -> None
+          | Some dir -> Some (Filename.concat dir ".config")
   in
   let init_ml = Filename.concat "ocaml" "init.ml" in
   match exists_in_dir (config_dir ()) init_ml with
   | Some _ as v -> v
-  | None -> exists_in_dir (home_dir ()) ocamlinit
+  | None -> exists_in_dir (getenv (if Sys.win32 then "USERPROFILE" else "HOME")) ocamlinit
 
 let load_ocamlinit ppf =
   if !Clflags.noinit then ()


### PR DESCRIPTION
Currently, `.ocamlinit` is looked up in the following locations on Unix-like systems (in the given order):

- `./.ocamlinit`
- `XDG_CONFIG_HOME/ocaml/init.ml`, or `HOME/.config/ocaml/init.ml` if `XDG_CONFIG_HOME` is not set ("Xdg base specification")
- `HOME/.ocamlinit`

On Win32, we do 1) and 3), and skip 2). 3) is not correct on Windows because `HOME` is not defined in general on Windows and, if it is (in Cygwin-like environments), it may not have the right value.

This PR:

- Enables 2) on Windows with a fallback to `LOCALAPPDATA/ocaml/init.ml` instead of `HOME/ocaml/init.ml`. This is a usual choice on Windows: see eg [GLib](https://docs.gtk.org/glib/func.get_user_config_dir.html).
- Changes 3) so that `USERPROFILE` is used instead of `HOME` on Windows. (This is a breaking change.)

Thanks very much to @jonahbeckford for bringing up the issue in the first place and suggesting the above choices!