### PR TITLE
Add I/O primitives for Bigarrays

### DIFF
--- a/Changes
+++ b/Changes
@@ -112,7 +112,8 @@ Working version
 - #12365: Add In_channel.input_bigarray, In_channel.really_input_bigarray,
   Out_channel.output_bigarray, Unix.read_bigarray, Unix.write_bigarray,
   Unix.single_write_bigarray.
-  (Nicolás Ojeda Bär, review by Jeremy Yallop, Xavier Leroy, Gabriel Scherer)
+  (Nicolás Ojeda Bär, review by Jeremy Yallop, Xavier Leroy, Gabriel Scherer,
+   David Allsopp)
 
 ### Other libraries:
 

--- a/Changes
+++ b/Changes
@@ -109,6 +109,11 @@ Working version
    Guillaume Munch-Maccagnoni, KC Sivaramakrishnan, Stefan Muenzel,
    Xavier Leroy)
 
+- #12365: Add In_channel.input_bigarray, In_channel.really_input_bigarray,
+  Out_channel.output_bigarray, Unix.read_bigarray, Unix.write_bigarray,
+  Unix.single_write_bigarray.
+  (Nicolás Ojeda Bär, review by Jeremy Yallop, Xavier Leroy, Gabriel Scherer)
+
 ### Other libraries:
 
 - #12213: Dynlink library, improve legibility of error messages

--- a/otherlibs/unix/read_unix.c
+++ b/otherlibs/unix/read_unix.c
@@ -17,6 +17,7 @@
 #include <caml/mlvalues.h>
 #include <caml/memory.h>
 #include <caml/signals.h>
+#include <caml/bigarray.h>
 #include "unixsupport.h"
 
 CAMLprim value caml_unix_read(value fd, value buf, value ofs, value len)
@@ -33,5 +34,23 @@ CAMLprim value caml_unix_read(value fd, value buf, value ofs, value len)
   caml_leave_blocking_section();
   if (ret == -1) caml_uerror("read", Nothing);
   memmove (&Byte(buf, Long_val(ofs)), iobuf, ret);
+  CAMLreturn(Val_int(ret));
+}
+
+CAMLprim value caml_unix_read_bigarray(value fd, value vbuf,
+                                       value vofs, value vlen)
+{
+  CAMLparam4(fd, vbuf, vofs, vlen);
+  intnat ofs, len;
+  void *buf;
+  int ret;
+
+  buf = Caml_ba_data_val(vbuf);
+  ofs = Long_val(vofs);
+  len = Long_val(vlen);
+  caml_enter_blocking_section();
+  ret = read(Int_val(fd), buf + ofs, len);
+  caml_leave_blocking_section();
+  if (ret == -1) caml_uerror("read_bigarray", Nothing);
   CAMLreturn(Val_int(ret));
 }

--- a/otherlibs/unix/read_unix.c
+++ b/otherlibs/unix/read_unix.c
@@ -41,9 +41,8 @@ CAMLprim value caml_unix_read_bigarray(value fd, value vbuf,
                                        value vofs, value vlen)
 {
   CAMLparam4(fd, vbuf, vofs, vlen);
-  intnat ofs, len;
+  intnat ofs, len, ret;
   void *buf;
-  int ret;
 
   buf = Caml_ba_data_val(vbuf);
   ofs = Long_val(vofs);
@@ -52,5 +51,5 @@ CAMLprim value caml_unix_read_bigarray(value fd, value vbuf,
   ret = read(Int_val(fd), buf + ofs, len);
   caml_leave_blocking_section();
   if (ret == -1) caml_uerror("read_bigarray", Nothing);
-  CAMLreturn(Val_int(ret));
+  CAMLreturn(Val_long(ret));
 }

--- a/otherlibs/unix/read_win32.c
+++ b/otherlibs/unix/read_win32.c
@@ -13,6 +13,7 @@
 /*                                                                        */
 /**************************************************************************/
 
+#include <limits.h>
 #include <string.h>
 #include <caml/mlvalues.h>
 #include <caml/memory.h>
@@ -75,6 +76,7 @@ CAMLprim value caml_unix_read_bigarray(value fd, value vbuf,
   if (Descr_kind_val(fd) == KIND_SOCKET) {
     int ret;
     SOCKET s = Socket_val(fd);
+    if (len > INT_MAX) len = INT_MAX;
     caml_enter_blocking_section();
     ret = recv(s, buf + ofs, len, 0);
     if (ret == SOCKET_ERROR) err = WSAGetLastError();
@@ -82,6 +84,7 @@ CAMLprim value caml_unix_read_bigarray(value fd, value vbuf,
     numread = ret;
   } else {
     HANDLE h = Handle_val(fd);
+    if (len > 0xFFFFFFFF) len = 0xFFFFFFFF;
     caml_enter_blocking_section();
     if (! ReadFile(h, buf + ofs, len, &numread, NULL))
       err = GetLastError();

--- a/otherlibs/unix/read_win32.c
+++ b/otherlibs/unix/read_win32.c
@@ -17,6 +17,7 @@
 #include <caml/mlvalues.h>
 #include <caml/memory.h>
 #include <caml/signals.h>
+#include <caml/bigarray.h>
 #include "unixsupport.h"
 
 CAMLprim value caml_unix_read(value fd, value buf, value ofs, value vlen)
@@ -56,5 +57,46 @@ CAMLprim value caml_unix_read(value fd, value buf, value ofs, value vlen)
     }
   }
   memmove (&Byte(buf, Long_val(ofs)), iobuf, numread);
+  CAMLreturn(Val_int(numread));
+}
+
+CAMLprim value caml_unix_read_bigarray(value fd, value vbuf,
+                                       value vofs, value vlen)
+{
+  CAMLparam4(fd, vbuf, vofs, vlen);
+  intnat ofs, len;
+  void *buf;
+  DWORD numread;
+  DWORD err = 0;
+
+  buf = Caml_ba_data_val(vbuf);
+  ofs = Long_val(vofs);
+  len = Long_val(vlen);
+  if (Descr_kind_val(fd) == KIND_SOCKET) {
+    int ret;
+    SOCKET s = Socket_val(fd);
+    caml_enter_blocking_section();
+    ret = recv(s, buf + ofs, len, 0);
+    if (ret == SOCKET_ERROR) err = WSAGetLastError();
+    caml_leave_blocking_section();
+    numread = ret;
+  } else {
+    HANDLE h = Handle_val(fd);
+    caml_enter_blocking_section();
+    if (! ReadFile(h, buf + ofs, len, &numread, NULL))
+      err = GetLastError();
+    caml_leave_blocking_section();
+  }
+  if (err) {
+    if (err == ERROR_BROKEN_PIPE) {
+      // The write handle for an anonymous pipe has been closed. We match the
+      // Unix behavior, and treat this as a zero-read instead of a Unix_error.
+      err = 0;
+      numread = 0;
+    } else {
+      caml_win32_maperr(err);
+      caml_uerror("read_bigarray", Nothing);
+    }
+  }
   CAMLreturn(Val_int(numread));
 }

--- a/otherlibs/unix/unix.mli
+++ b/otherlibs/unix/unix.mli
@@ -387,7 +387,7 @@ val read_bigarray :
   file_descr ->
   (_, Bigarray.int8_unsigned_elt, Bigarray.c_layout) Bigarray.Array1.t ->
   int -> int -> int
-(** Same as {!read}, but read data into a bigarray.
+(** Same as {!read}, but read the data into a bigarray.
     @since 5.2 *)
 
 val write : file_descr -> bytes -> int -> int -> int
@@ -401,7 +401,7 @@ val write_bigarray :
   file_descr ->
   (_, Bigarray.int8_unsigned_elt, Bigarray.c_layout) Bigarray.Array1.t ->
   int -> int -> int
-(** Same as {!write}, but take data from a bigarray.
+(** Same as {!write}, but take the data from a bigarray.
     @since 5.2 *)
 
 val single_write : file_descr -> bytes -> int -> int -> int

--- a/otherlibs/unix/unix.mli
+++ b/otherlibs/unix/unix.mli
@@ -383,12 +383,26 @@ val read : file_descr -> bytes -> int -> int -> int
     storing them in byte sequence [buf], starting at position [pos] in
     [buf]. Return the number of bytes actually read. *)
 
+val read_bigarray :
+  file_descr ->
+  (_, Bigarray.int8_unsigned_elt, Bigarray.c_layout) Bigarray.Array1.t ->
+  int -> int -> int
+(** Same as {!read}, but read data into a bigarray.
+    @since 5.2 *)
+
 val write : file_descr -> bytes -> int -> int -> int
 (** [write fd buf pos len] writes [len] bytes to descriptor [fd],
     taking them from byte sequence [buf], starting at position [pos]
     in [buff]. Return the number of bytes actually written.  [write]
     repeats the writing operation until all bytes have been written or
     an error occurs.  *)
+
+val write_bigarray :
+  file_descr ->
+  (_, Bigarray.int8_unsigned_elt, Bigarray.c_layout) Bigarray.Array1.t ->
+  int -> int -> int
+(** Same as {!write}, but take data from a bigarray.
+    @since 5.2 *)
 
 val single_write : file_descr -> bytes -> int -> int -> int
 (** Same as {!write}, but attempts to write only once.
@@ -405,6 +419,13 @@ val single_write_substring :
 (** Same as {!single_write}, but take the data from a string instead of
     a byte sequence.
     @since 4.02 *)
+
+val single_write_bigarray :
+  file_descr ->
+  (_, Bigarray.int8_unsigned_elt, Bigarray.c_layout) Bigarray.Array1.t ->
+  int -> int -> int
+(** Same as {!single_write}, but take the data from a bigarray.
+    @since 5.2 *)
 
 (** {1 Interfacing with the standard input/output library} *)
 

--- a/otherlibs/unix/unixLabels.mli
+++ b/otherlibs/unix/unixLabels.mli
@@ -387,7 +387,7 @@ val read_bigarray :
   file_descr ->
   buf:(_, Bigarray.int8_unsigned_elt, Bigarray.c_layout) Bigarray.Array1.t ->
   pos:int -> len:int -> int
-(** Same as {!read}, but read data into a bigarray.
+(** Same as {!read}, but read the data into a bigarray.
     @since 5.2 *)
 
 val write : file_descr -> buf:bytes -> pos:int -> len:int -> int
@@ -401,7 +401,7 @@ val write_bigarray :
   file_descr ->
   buf:(_, Bigarray.int8_unsigned_elt, Bigarray.c_layout) Bigarray.Array1.t ->
   pos:int -> len:int -> int
-(** Same as {!write}, but take data from a bigarray.
+(** Same as {!write}, but take the data from a bigarray.
     @since 5.2 *)
 
 val single_write : file_descr -> buf:bytes -> pos:int -> len:int -> int

--- a/otherlibs/unix/unixLabels.mli
+++ b/otherlibs/unix/unixLabels.mli
@@ -383,12 +383,26 @@ val read : file_descr -> buf:bytes -> pos:int -> len:int -> int
     storing them in byte sequence [buf], starting at position [pos] in
     [buf]. Return the number of bytes actually read. *)
 
+val read_bigarray :
+  file_descr ->
+  buf:(_, Bigarray.int8_unsigned_elt, Bigarray.c_layout) Bigarray.Array1.t ->
+  pos:int -> len:int -> int
+(** Same as {!read}, but read data into a bigarray.
+    @since 5.2 *)
+
 val write : file_descr -> buf:bytes -> pos:int -> len:int -> int
 (** [write fd ~buf ~pos ~len] writes [len] bytes to descriptor [fd],
     taking them from byte sequence [buf], starting at position [pos]
     in [buff]. Return the number of bytes actually written.  [write]
     repeats the writing operation until all bytes have been written or
     an error occurs.  *)
+
+val write_bigarray :
+  file_descr ->
+  buf:(_, Bigarray.int8_unsigned_elt, Bigarray.c_layout) Bigarray.Array1.t ->
+  pos:int -> len:int -> int
+(** Same as {!write}, but take data from a bigarray.
+    @since 5.2 *)
 
 val single_write : file_descr -> buf:bytes -> pos:int -> len:int -> int
 (** Same as {!write}, but attempts to write only once.
@@ -405,6 +419,13 @@ val single_write_substring :
 (** Same as {!single_write}, but take the data from a string instead of
     a byte sequence.
     @since 4.02 *)
+
+val single_write_bigarray :
+  file_descr ->
+  buf:(_, Bigarray.int8_unsigned_elt, Bigarray.c_layout) Bigarray.Array1.t ->
+  pos:int -> len:int -> int
+(** Same as {!single_write}, but take the data from a bigarray.
+    @since 5.2 *)
 
 (** {1 Interfacing with the standard input/output library} *)
 

--- a/otherlibs/unix/unix_unix.ml
+++ b/otherlibs/unix/unix_unix.ml
@@ -264,13 +264,10 @@ external unsafe_read_bigarray :
 external unsafe_write : file_descr -> bytes -> int -> int -> int
                       = "caml_unix_write"
 external unsafe_write_bigarray :
-  file_descr -> _ Bigarray.Array1.t -> int -> int -> int
+  file_descr -> _ Bigarray.Array1.t -> int -> int -> single: bool -> int
   = "caml_unix_write_bigarray"
 external unsafe_single_write : file_descr -> bytes -> int -> int -> int
    = "caml_unix_single_write"
-external unsafe_single_write_bigarray :
-  file_descr -> _ Bigarray.Array1.t -> int -> int -> int
-  = "caml_unix_single_write_bigarray"
 
 let read fd buf ofs len =
   if ofs < 0 || len < 0 || ofs > Bytes.length buf - len
@@ -287,7 +284,7 @@ let write fd buf ofs len =
 let write_bigarray fd buf ofs len =
   if ofs < 0 || len < 0 || ofs > Bigarray.Array1.dim buf - len
   then invalid_arg "Unix.write_bigarray"
-  else unsafe_write_bigarray fd buf ofs len
+  else unsafe_write_bigarray fd buf ofs len ~single:false
 (* write misbehaves because it attempts to write all data by making repeated
    calls to the Unix write function (see comment in write.c and unix.mli).
    single_write fixes this by never calling write twice. *)
@@ -298,7 +295,7 @@ let single_write fd buf ofs len =
 let single_write_bigarray fd buf ofs len =
   if ofs < 0 || len < 0 || ofs > Bigarray.Array1.dim buf - len
   then invalid_arg "Unix.single_write_bigarray"
-  else unsafe_single_write_bigarray fd buf ofs len
+  else unsafe_write_bigarray fd buf ofs len ~single:true
 
 let write_substring fd buf ofs len =
   write fd (Bytes.unsafe_of_string buf) ofs len

--- a/otherlibs/unix/unix_unix.ml
+++ b/otherlibs/unix/unix_unix.ml
@@ -258,19 +258,36 @@ external close : file_descr -> unit = "caml_unix_close"
 external fsync : file_descr -> unit = "caml_unix_fsync"
 external unsafe_read : file_descr -> bytes -> int -> int -> int
    = "caml_unix_read"
+external unsafe_read_bigarray :
+  file_descr -> _ Bigarray.Array1.t -> int -> int -> int
+  = "caml_unix_read_bigarray"
 external unsafe_write : file_descr -> bytes -> int -> int -> int
                       = "caml_unix_write"
+external unsafe_write_bigarray :
+  file_descr -> _ Bigarray.Array1.t -> int -> int -> int
+  = "caml_unix_write_bigarray"
 external unsafe_single_write : file_descr -> bytes -> int -> int -> int
    = "caml_unix_single_write"
+external unsafe_single_write_bigarray :
+  file_descr -> _ Bigarray.Array1.t -> int -> int -> int
+  = "caml_unix_single_write_bigarray"
 
 let read fd buf ofs len =
   if ofs < 0 || len < 0 || ofs > Bytes.length buf - len
   then invalid_arg "Unix.read"
   else unsafe_read fd buf ofs len
+let read_bigarray fd buf ofs len =
+  if ofs < 0 || len < 0 || ofs > Bigarray.Array1.dim buf - len
+  then invalid_arg "Unix.read_bigarray"
+  else unsafe_read_bigarray fd buf ofs len
 let write fd buf ofs len =
   if ofs < 0 || len < 0 || ofs > Bytes.length buf - len
   then invalid_arg "Unix.write"
   else unsafe_write fd buf ofs len
+let write_bigarray fd buf ofs len =
+  if ofs < 0 || len < 0 || ofs > Bigarray.Array1.dim buf - len
+  then invalid_arg "Unix.write_bigarray"
+  else unsafe_write_bigarray fd buf ofs len
 (* write misbehaves because it attempts to write all data by making repeated
    calls to the Unix write function (see comment in write.c and unix.mli).
    single_write fixes this by never calling write twice. *)
@@ -278,6 +295,10 @@ let single_write fd buf ofs len =
   if ofs < 0 || len < 0 || ofs > Bytes.length buf - len
   then invalid_arg "Unix.single_write"
   else unsafe_single_write fd buf ofs len
+let single_write_bigarray fd buf ofs len =
+  if ofs < 0 || len < 0 || ofs > Bigarray.Array1.dim buf - len
+  then invalid_arg "Unix.single_write_bigarray"
+  else unsafe_single_write_bigarray fd buf ofs len
 
 let write_substring fd buf ofs len =
   write fd (Bytes.unsafe_of_string buf) ofs len

--- a/otherlibs/unix/unix_win32.ml
+++ b/otherlibs/unix/unix_win32.ml
@@ -287,13 +287,10 @@ external unsafe_read_bigarray :
 external unsafe_write : file_descr -> bytes -> int -> int -> int
                       = "caml_unix_write"
 external unsafe_write_bigarray :
-  file_descr -> _ Bigarray.Array1.t -> int -> int -> int
+  file_descr -> _ Bigarray.Array1.t -> int -> int -> single: bool -> int
   = "caml_unix_write_bigarray"
 external unsafe_single_write : file_descr -> bytes -> int -> int -> int
                       = "caml_unix_single_write"
-external unsafe_single_write_bigarray :
-  file_descr -> _ Bigarray.Array1.t -> int -> int -> int
-  = "caml_unix_single_write_bigarray"
 
 let read fd buf ofs len =
   if ofs < 0 || len < 0 || ofs > Bytes.length buf - len
@@ -310,7 +307,7 @@ let write fd buf ofs len =
 let write_bigarray fd buf ofs len =
   if ofs < 0 || len < 0 || ofs > Bigarray.Array1.dim buf - len
   then invalid_arg "Unix.write_bigarray"
-  else unsafe_write_bigarray fd buf ofs len
+  else unsafe_write_bigarray fd buf ofs len ~single:false
 let single_write fd buf ofs len =
   if ofs < 0 || len < 0 || ofs > Bytes.length buf - len
   then invalid_arg "Unix.single_write"
@@ -318,7 +315,7 @@ let single_write fd buf ofs len =
 let single_write_bigarray fd buf ofs len =
   if ofs < 0 || len < 0 || ofs > Bigarray.Array1.dim buf - len
   then invalid_arg "Unix.single_write_bigarray"
-  else unsafe_single_write_bigarray fd buf ofs len
+  else unsafe_write_bigarray fd buf ofs len ~single:true
 
 let write_substring fd buf ofs len =
   write fd (Bytes.unsafe_of_string buf) ofs len

--- a/otherlibs/unix/unix_win32.ml
+++ b/otherlibs/unix/unix_win32.ml
@@ -281,23 +281,44 @@ external close : file_descr -> unit = "caml_unix_close"
 external fsync : file_descr -> unit = "caml_unix_fsync"
 external unsafe_read : file_descr -> bytes -> int -> int -> int
                      = "caml_unix_read"
+external unsafe_read_bigarray :
+  file_descr -> _ Bigarray.Array1.t -> int -> int -> int
+  = "caml_unix_read_bigarray"
 external unsafe_write : file_descr -> bytes -> int -> int -> int
                       = "caml_unix_write"
+external unsafe_write_bigarray :
+  file_descr -> _ Bigarray.Array1.t -> int -> int -> int
+  = "caml_unix_write_bigarray"
 external unsafe_single_write : file_descr -> bytes -> int -> int -> int
                       = "caml_unix_single_write"
+external unsafe_single_write_bigarray :
+  file_descr -> _ Bigarray.Array1.t -> int -> int -> int
+  = "caml_unix_single_write_bigarray"
 
 let read fd buf ofs len =
   if ofs < 0 || len < 0 || ofs > Bytes.length buf - len
   then invalid_arg "Unix.read"
   else unsafe_read fd buf ofs len
+let read_bigarray fd buf ofs len =
+  if ofs < 0 || len < 0 || ofs > Bigarray.Array1.dim buf - len
+  then invalid_arg "Unix.read_bigarray"
+  else unsafe_read_bigarray fd buf ofs len
 let write fd buf ofs len =
   if ofs < 0 || len < 0 || ofs > Bytes.length buf - len
   then invalid_arg "Unix.write"
   else unsafe_write fd buf ofs len
+let write_bigarray fd buf ofs len =
+  if ofs < 0 || len < 0 || ofs > Bigarray.Array1.dim buf - len
+  then invalid_arg "Unix.write_bigarray"
+  else unsafe_write_bigarray fd buf ofs len
 let single_write fd buf ofs len =
   if ofs < 0 || len < 0 || ofs > Bytes.length buf - len
   then invalid_arg "Unix.single_write"
   else unsafe_single_write fd buf ofs len
+let single_write_bigarray fd buf ofs len =
+  if ofs < 0 || len < 0 || ofs > Bigarray.Array1.dim buf - len
+  then invalid_arg "Unix.single_write_bigarray"
+  else unsafe_single_write_bigarray fd buf ofs len
 
 let write_substring fd buf ofs len =
   write fd (Bytes.unsafe_of_string buf) ofs len

--- a/otherlibs/unix/write_unix.c
+++ b/otherlibs/unix/write_unix.c
@@ -56,9 +56,9 @@ CAMLprim value caml_unix_write(value fd, value buf, value vofs, value vlen)
 }
 
 CAMLprim value caml_unix_write_bigarray(value fd, value vbuf,
-                                        value vofs, value vlen)
+                                        value vofs, value vlen, value vsingle)
 {
-  CAMLparam4(fd, vbuf, vofs, vlen);
+  CAMLparam5(fd, vbuf, vofs, vlen, vsingle);
   intnat ofs, len, written, ret;
   void *buf;
 
@@ -77,6 +77,7 @@ CAMLprim value caml_unix_write_bigarray(value fd, value vbuf,
     written += ret;
     ofs += ret;
     len -= ret;
+    if (Bool_val(vsingle)) break;
   }
   caml_leave_blocking_section();
   CAMLreturn(Val_long(written));
@@ -110,24 +111,4 @@ CAMLprim value caml_unix_single_write(value fd, value buf, value vofs,
     if (ret == -1) caml_uerror("single_write", Nothing);
   }
   CAMLreturn(Val_int(ret));
-}
-
-CAMLprim value caml_unix_single_write_bigarray(value fd, value vbuf, value vofs,
-                                               value vlen)
-{
-  CAMLparam4(fd, vbuf, vofs, vlen);
-  intnat ofs, len, ret;
-  void *buf;
-
-  buf = Caml_ba_data_val(vbuf);
-  ofs = Long_val(vofs);
-  len = Long_val(vlen);
-  ret = 0;
-  if (len > 0) {
-    caml_enter_blocking_section();
-    ret = write(Int_val(fd), buf + ofs, len);
-    caml_leave_blocking_section();
-    if (ret == -1) caml_uerror("single_write_bigarray", Nothing);
-  }
-  CAMLreturn(Val_long(ret));
 }

--- a/otherlibs/unix/write_unix.c
+++ b/otherlibs/unix/write_unix.c
@@ -59,9 +59,8 @@ CAMLprim value caml_unix_write_bigarray(value fd, value vbuf,
                                         value vofs, value vlen)
 {
   CAMLparam4(fd, vbuf, vofs, vlen);
-  long ofs, len, written;
+  intnat ofs, len, written, ret;
   void *buf;
-  int ret;
 
   buf = Caml_ba_data_val(vbuf);
   ofs = Long_val(vofs);
@@ -117,9 +116,8 @@ CAMLprim value caml_unix_single_write_bigarray(value fd, value vbuf, value vofs,
                                                value vlen)
 {
   CAMLparam4(fd, vbuf, vofs, vlen);
-  intnat ofs, len;
+  intnat ofs, len, ret;
   void *buf;
-  int ret;
 
   buf = Caml_ba_data_val(vbuf);
   ofs = Long_val(vofs);
@@ -131,5 +129,5 @@ CAMLprim value caml_unix_single_write_bigarray(value fd, value vbuf, value vofs,
     caml_leave_blocking_section();
     if (ret == -1) caml_uerror("single_write_bigarray", Nothing);
   }
-  CAMLreturn(Val_int(ret));
+  CAMLreturn(Val_long(ret));
 }

--- a/otherlibs/unix/write_win32.c
+++ b/otherlibs/unix/write_win32.c
@@ -18,6 +18,7 @@
 #include <caml/mlvalues.h>
 #include <caml/memory.h>
 #include <caml/signals.h>
+#include <caml/bigarray.h>
 #include "unixsupport.h"
 
 CAMLprim value caml_unix_write(value fd, value buf, value vofs, value vlen)
@@ -61,6 +62,47 @@ CAMLprim value caml_unix_write(value fd, value buf, value vofs, value vlen)
   CAMLreturn(Val_long(written));
 }
 
+CAMLprim value caml_unix_write_bigarray(value fd, value vbuf,
+                                        value vofs, value vlen)
+{
+  CAMLparam4(fd, vbuf, vofs, vlen);
+  intnat ofs, len, written;
+  void *buf;
+  DWORD numwritten;
+  DWORD err = 0;
+
+  buf = Caml_ba_data_val(vbuf);
+  ofs = Long_val(vofs);
+  len = Long_val(vlen);
+  written = 0;
+  while (len > 0) {
+    if (Descr_kind_val(fd) == KIND_SOCKET) {
+      int ret;
+      SOCKET s = Socket_val(fd);
+      caml_enter_blocking_section();
+      ret = send(s, buf + ofs, len, 0);
+      if (ret == SOCKET_ERROR) err = WSAGetLastError();
+      caml_leave_blocking_section();
+      if (ret == SOCKET_ERROR && err == WSAEWOULDBLOCK && written > 0) break;
+      numwritten = ret;
+    } else {
+      HANDLE h = Handle_val(fd);
+      caml_enter_blocking_section();
+      if (! WriteFile(h, buf + ofs, len, &numwritten, NULL))
+        err = GetLastError();
+      caml_leave_blocking_section();
+    }
+    if (err) {
+      caml_win32_maperr(err);
+      caml_uerror("write_bigarray", Nothing);
+    }
+    written += numwritten;
+    ofs += numwritten;
+    len -= numwritten;
+  }
+  CAMLreturn(Val_long(written));
+}
+
 CAMLprim value caml_unix_single_write(value fd, value buf, value vofs,
                                       value vlen)
 {
@@ -94,6 +136,44 @@ CAMLprim value caml_unix_single_write(value fd, value buf, value vofs,
     if (err) {
       caml_win32_maperr(err);
       caml_uerror("single_write", Nothing);
+    }
+    written = numwritten;
+  }
+  CAMLreturn(Val_long(written));
+}
+
+CAMLprim value caml_unix_single_write_bigarray(value fd, value vbuf,
+                                               value vofs, value vlen)
+{
+  CAMLparam4(fd, vbuf, vofs, vlen);
+  intnat ofs, len, written;
+  void *buf;
+  DWORD numwritten;
+  DWORD err = 0;
+
+  buf = Caml_ba_data_val(vbuf);
+  ofs = Long_val(vofs);
+  len = Long_val(vlen);
+  written = 0;
+  if (len > 0) {
+    if (Descr_kind_val(fd) == KIND_SOCKET) {
+      int ret;
+      SOCKET s = Socket_val(fd);
+      caml_enter_blocking_section();
+      ret = send(s, buf + ofs, len, 0);
+      if (ret == SOCKET_ERROR) err = WSAGetLastError();
+      caml_leave_blocking_section();
+      numwritten = ret;
+    } else {
+      HANDLE h = Handle_val(fd);
+      caml_enter_blocking_section();
+      if (! WriteFile(h, buf + ofs, len, &numwritten, NULL))
+        err = GetLastError();
+      caml_leave_blocking_section();
+    }
+    if (err) {
+      caml_win32_maperr(err);
+      caml_uerror("single_write_bigarray", Nothing);
     }
     written = numwritten;
   }

--- a/stdlib/.depend
+++ b/stdlib/.depend
@@ -400,15 +400,18 @@ stdlib__In_channel.cmo : in_channel.ml \
     stdlib.cmi \
     stdlib__Fun.cmi \
     stdlib__Bytes.cmi \
+    stdlib__Bigarray.cmi \
     stdlib__In_channel.cmi
 stdlib__In_channel.cmx : in_channel.ml \
     stdlib__Sys.cmx \
     stdlib.cmx \
     stdlib__Fun.cmx \
     stdlib__Bytes.cmx \
+    stdlib__Bigarray.cmx \
     stdlib__In_channel.cmi
 stdlib__In_channel.cmi : in_channel.mli \
-    stdlib.cmi
+    stdlib.cmi \
+    stdlib__Bigarray.cmi
 stdlib__Int.cmo : int.ml \
     stdlib.cmi \
     stdlib__Int.cmi
@@ -556,13 +559,16 @@ stdlib__Option.cmi : option.mli \
 stdlib__Out_channel.cmo : out_channel.ml \
     stdlib.cmi \
     stdlib__Fun.cmi \
+    stdlib__Bigarray.cmi \
     stdlib__Out_channel.cmi
 stdlib__Out_channel.cmx : out_channel.ml \
     stdlib.cmx \
     stdlib__Fun.cmx \
+    stdlib__Bigarray.cmx \
     stdlib__Out_channel.cmi
 stdlib__Out_channel.cmi : out_channel.mli \
-    stdlib.cmi
+    stdlib.cmi \
+    stdlib__Bigarray.cmi
 stdlib__Parsing.cmo : parsing.ml \
     stdlib__Obj.cmi \
     stdlib__Lexing.cmi \

--- a/stdlib/in_channel.ml
+++ b/stdlib/in_channel.ml
@@ -68,10 +68,32 @@ let input_line ic =
 
 let input = Stdlib.input
 
+external unsafe_input_bigarray :
+  t -> _ Bigarray.Array1.t -> int -> int -> int
+  = "caml_ml_input_bigarray"
+
+let input_bigarray ic buf ofs len =
+  if ofs < 0 || len < 0 || ofs > Bigarray.Array1.dim buf - len
+  then invalid_arg "input_bigarray"
+  else unsafe_input_bigarray ic buf ofs len
+
 let really_input ic buf pos len =
   match Stdlib.really_input ic buf pos len with
   | () -> Some ()
   | exception End_of_file -> None
+
+let rec unsafe_really_input_bigarray ic buf ofs len =
+  if len <= 0 then Some () else begin
+    let r = unsafe_input_bigarray ic buf ofs len in
+    if r = 0
+    then None
+    else unsafe_really_input_bigarray ic buf (ofs + r) (len - r)
+  end
+
+let really_input_bigarray ic buf ofs len =
+  if ofs < 0 || len < 0 || ofs > Bigarray.Array1.dim buf - len
+  then invalid_arg "really_input_bigarray"
+  else unsafe_really_input_bigarray ic buf ofs len
 
 let really_input_string ic len =
   match Stdlib.really_input_string ic len with

--- a/stdlib/in_channel.mli
+++ b/stdlib/in_channel.mli
@@ -156,7 +156,7 @@ val really_input : t -> bytes -> int -> int -> unit option
 val really_input_bigarray :
   t -> (_, Bigarray.int8_unsigned_elt, Bigarray.c_layout) Bigarray.Array1.t ->
   int -> int -> unit option
-(** Same as {!really_input}, but write data to a bigarray.
+(** Same as {!really_input}, but read the data into a bigarray.
     @since 5.2 *)
 
 val fold_lines : ('acc -> string -> 'acc) -> 'acc -> t -> 'acc

--- a/stdlib/in_channel.mli
+++ b/stdlib/in_channel.mli
@@ -134,6 +134,12 @@ val input : t -> bytes -> int -> int -> int
     @raise Invalid_argument if [pos] and [len] do not designate a valid range of
     [buf]. *)
 
+val input_bigarray :
+  t -> (_, Bigarray.int8_unsigned_elt, Bigarray.c_layout) Bigarray.Array1.t ->
+  int -> int -> int
+(** Same as {!input}, but write data to a bigarray.
+    @since 5.2 *)
+
 val really_input : t -> bytes -> int -> int -> unit option
 (** [really_input ic buf pos len] reads [len] characters from channel [ic],
     storing them in byte sequence [buf], starting at character number [pos].
@@ -146,6 +152,12 @@ val really_input : t -> bytes -> int -> int -> unit option
 
     @raise Invalid_argument if [pos] and [len] do not designate a valid range of
     [buf]. *)
+
+val really_input_bigarray :
+  t -> (_, Bigarray.int8_unsigned_elt, Bigarray.c_layout) Bigarray.Array1.t ->
+  int -> int -> unit option
+(** Same as {!really_input}, but write data to a bigarray.
+    @since 5.2 *)
 
 val fold_lines : ('acc -> string -> 'acc) -> 'acc -> t -> 'acc
 (** [fold_lines f init ic] reads lines from [ic] using {!input_line}

--- a/stdlib/in_channel.mli
+++ b/stdlib/in_channel.mli
@@ -137,7 +137,7 @@ val input : t -> bytes -> int -> int -> int
 val input_bigarray :
   t -> (_, Bigarray.int8_unsigned_elt, Bigarray.c_layout) Bigarray.Array1.t ->
   int -> int -> int
-(** Same as {!input}, but write data to a bigarray.
+(** Same as {!input}, but read the data into a bigarray.
     @since 5.2 *)
 
 val really_input : t -> bytes -> int -> int -> unit option

--- a/stdlib/out_channel.ml
+++ b/stdlib/out_channel.ml
@@ -46,6 +46,10 @@ let with_open_text s f =
 let with_open_gen flags perm s f =
   with_open (Stdlib.open_out_gen flags perm) s f
 
+external unsafe_output_bigarray :
+  t -> _ Bigarray.Array1.t -> int -> int -> unit
+  = "caml_ml_output_bigarray"
+
 let seek = Stdlib.LargeFile.seek_out
 let pos = Stdlib.LargeFile.pos_out
 let length = Stdlib.LargeFile.out_channel_length
@@ -59,6 +63,10 @@ let output_string = Stdlib.output_string
 let output_bytes = Stdlib.output_bytes
 let output = Stdlib.output
 let output_substring = Stdlib.output_substring
+let output_bigarray oc buf ofs len =
+  if ofs < 0 || len < 0 || ofs > Bigarray.Array1.dim buf - len
+  then invalid_arg "output_bigarray"
+  else unsafe_output_bigarray oc buf ofs len
 let set_binary_mode = Stdlib.set_binary_mode_out
 
 external set_buffered : t -> bool -> unit = "caml_ml_set_buffered"

--- a/stdlib/out_channel.mli
+++ b/stdlib/out_channel.mli
@@ -116,7 +116,7 @@ val output_substring : t -> string -> int -> int -> unit
 val output_bigarray :
   t -> (_, Bigarray.int8_unsigned_elt, Bigarray.c_layout) Bigarray.Array1.t ->
   int -> int -> unit
-(** Same as {!output} bu take data from a bigarray.
+(** Same as {!output} but take the data from a bigarray.
     @since 5.2 *)
 
 (** {1:flushing Flushing} *)

--- a/stdlib/out_channel.mli
+++ b/stdlib/out_channel.mli
@@ -113,6 +113,12 @@ val output_substring : t -> string -> int -> int -> unit
 (** Same as {!output} but take a string as argument instead of a byte
     sequence. *)
 
+val output_bigarray :
+  t -> (_, Bigarray.int8_unsigned_elt, Bigarray.c_layout) Bigarray.Array1.t ->
+  int -> int -> unit
+(** Same as {!output} bu take data from a bigarray.
+    @since 5.2 *)
+
 (** {1:flushing Flushing} *)
 
 val flush : t -> unit

--- a/testsuite/tests/lib-channels/bigarrays.ml
+++ b/testsuite/tests/lib-channels/bigarrays.ml
@@ -1,0 +1,21 @@
+(* TEST *)
+
+let filename = "test.out"
+
+let bigarray_of_string s =
+  Bigarray.Array1.init Bigarray.char Bigarray.c_layout (String.length s)
+    (String.get s)
+
+let string_of_bigarray buf =
+  String.init (Bigarray.Array1.dim buf) (Bigarray.Array1.get buf)
+
+let () =
+  let oc = Out_channel.open_bin filename in
+  let str = ">hello, world<" in
+  let buf = bigarray_of_string str in
+  Out_channel.output_bigarray oc buf 1 (String.length str - 2);
+  Out_channel.close oc;
+  let ic = In_channel.open_bin filename in
+  let buf = bigarray_of_string (String.map (fun _ -> 'X') str) in
+  assert (Option.is_some (In_channel.really_input_bigarray ic buf 1 (String.length str - 2)));
+  print_endline (string_of_bigarray buf)

--- a/testsuite/tests/lib-channels/bigarrays.reference
+++ b/testsuite/tests/lib-channels/bigarrays.reference
@@ -1,0 +1,1 @@
+Xhello, worldX

--- a/testsuite/tests/lib-unix/bigarrays.ml
+++ b/testsuite/tests/lib-unix/bigarrays.ml
@@ -1,0 +1,29 @@
+(* TEST
+include unix;
+*)
+
+let filename = "test.out"
+
+let bigarray_of_string s =
+  Bigarray.Array1.init Bigarray.char Bigarray.c_layout (String.length s)
+    (String.get s)
+
+let string_of_bigarray buf =
+  String.init (Bigarray.Array1.dim buf) (Bigarray.Array1.get buf)
+
+let rec really_read f pos len =
+  if len <= 0 then ()
+  else
+    let n = f pos len in
+    really_read f (pos + n) (len - n)
+
+let () =
+  let fd = Unix.openfile filename [O_RDWR; O_CREAT; O_TRUNC] 0o644 in
+  let str = ">hello, world<" in
+  let buf = bigarray_of_string str in
+  assert (Unix.write_bigarray fd buf 1 (String.length str - 2) = String.length str - 2);
+  let _ = Unix.lseek fd 0 Unix.SEEK_SET in
+  let buf = bigarray_of_string (String.map (fun _ -> 'X') str) in
+  really_read (Unix.read_bigarray fd buf) 1 (String.length str - 2);
+  Unix.close fd;
+  print_endline (string_of_bigarray buf)

--- a/testsuite/tests/lib-unix/bigarrays.reference
+++ b/testsuite/tests/lib-unix/bigarrays.reference
@@ -1,0 +1,1 @@
+Xhello, worldX


### PR DESCRIPTION
Following discussion in #12360 this PR proposes adding I/O primitives for bigarrays to the standard library and Unix. I took the liberty of copying the `In_channel` and `Out_channel` functions from #12360. On top of that, `Unix` variants are also added here:

- `In_channel.input_bigarray`, `In_channel.really_input_bigarray`
- `Out_channel.output_bigarray`
- `Unix.read_bigarray`, `Unix.write_bigarray`, `Unix.single_write_bigarray`

In each case the signature of the functions are identical to the existing ones on `bytes`, except that they use `_ Bigarray.Genarray.t` in its place. Offset and length parameters are interpreted in terms of _bytes._

An alternative would be to use `_ Bigarray.Array1.t` instead of `Bigarray.Genarray.t` and interpret offset and length in terms of _elements_. I was going to do this originally, but I sensed a small difficulty with the `Unix.single_write` operation, which could fail to write a "full" element of a bigarray (but perhaps this is not a problem). Opinions welcome.

There is some code duplication in the `Unix` bindings but it is a bit difficult to share code as we take advantage of the fact that the data part of a bigarray does not move in memory to avoid copying data to an intermediate buffer and to release the runtime lock more liberally.