### PR TITLE
README.adoc: clarify status of 32-bit native compilation

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -16,7 +16,9 @@ MinGW-w64 port is supported in OCaml 5.0 and the Cygwin port is restored in 5.1.
 On Linux, native code support for RISC-V and s390x/IBM Z will be available in
 OCaml 5.1 and on Power in 5.2.
 
-On 32-bit systems, only the bytecode compiler will be supported.
+❗ Native compilation in OCaml 5 is only available on 64-bit targets.
+Native compilation on 32-bit systems is **not** available, nor are there plans to
+bring it back. The bytecode compiler will continue to work on all architectures.
 
 |=====
 | Branch `trunk` | Branch `5.1` | Branch `5.0` | Branch `4.14`

--- a/README.adoc
+++ b/README.adoc
@@ -17,7 +17,7 @@ On Linux, native code support for RISC-V and s390x/IBM Z will be available in
 OCaml 5.1 and on Power in 5.2.
 
 ❗ From OCaml 5.0 onwards, native compilation is available only on 64-bit
-systems.  Native compilation on 32-bit systems **is no longer available,** nor
+systems.  Native compilation on 32-bit systems is no longer available, nor
 are there plans to bring it back. The bytecode compiler will continue to work on
 all architectures.
 

--- a/README.adoc
+++ b/README.adoc
@@ -16,9 +16,10 @@ MinGW-w64 port is supported in OCaml 5.0 and the Cygwin port is restored in 5.1.
 On Linux, native code support for RISC-V and s390x/IBM Z will be available in
 OCaml 5.1 and on Power in 5.2.
 
-❗ Native compilation in OCaml 5 is only available on 64-bit targets.
-Native compilation on 32-bit systems is **not** available, nor are there plans to
-bring it back. The bytecode compiler will continue to work on all architectures.
+❗ From OCaml 5.0 onwards, native compilation is available only on 64-bit
+systems.  Native compilation on 32-bit systems **is no longer available,** nor
+are there plans to bring it back. The bytecode compiler will continue to work on
+all architectures.
 
 |=====
 | Branch `trunk` | Branch `5.1` | Branch `5.0` | Branch `4.14`


### PR DESCRIPTION
In a recent [thread](https://discuss.ocaml.org/t/32-bit-native-code-support-for-ocaml-5) in Discuss, @jonahbeckford pointed out that the status of native compilation for 32-bit targets may not be clear to people who do not follow the development of the compiler closely.

Personally, I think he may have a point; accordingly I propose a small addition to the main README file spelling it out in black and white.