### PR TITLE
ocamltest: fix recursive expansion of variables

### DIFF
--- a/Changes
+++ b/Changes
@@ -126,6 +126,10 @@ Working version
   (Damien Doligez with Florian Angeletti, Sébastien Hinderer, Gabriel Scherer,
    review by Sébastien Hinderer and Gabriel Scherer)
 
+- #12371: ocamltest: fix recursive expansion of variables.
+  (Antonin Décimo, Damien Doligez, review by Sébastien Hinderer,
+   Damien Doligez, Gabriel Scherer, and Xavier Leroy)
+
 ### Manual and documentation:
 
 - #12338: clarification of the documentation of process related function in

--- a/ocamltest/actions_helpers.ml
+++ b/ocamltest/actions_helpers.ml
@@ -275,6 +275,12 @@ let run_script log env =
           Printf.sprintf "error in script response: unknown variable %s" name
         in
         (Result.fail_with_reason reason, newenv)
+      | exception Variables.Recursive_variable_definition name ->
+        let reason =
+          Printf.sprintf "error in script response: \
+            recursive variable definition %s" name
+        in
+        (Result.fail_with_reason reason, newenv)
     end else begin
       let reason = String.trim (Sys.string_of_file response_file) in
       let newresult = { result with Result.reason = Some reason } in
@@ -319,6 +325,12 @@ let run_hook hook_name log input_env =
       | exception Variables.No_such_variable name ->
         let reason =
           Printf.sprintf "error in script response: unknown variable %s" name
+        in
+        (Result.fail_with_reason reason, hookenv)
+      | exception Variables.Recursive_variable_definition name ->
+        let reason =
+          Printf.sprintf "error in script response: \
+            recursive variable definition %s" name
         in
         (Result.fail_with_reason reason, hookenv)
       end

--- a/ocamltest/environments.ml
+++ b/ocamltest/environments.ml
@@ -29,21 +29,22 @@ let to_bindings env =
   in
   VariableMap.fold f env []
 
-let expand_aux env value =
-  let bindings = to_bindings env in
-  let f (variable, value) = ((Variables.name_of_variable variable), value) in
-  let simple_bindings = List.map f bindings in
-  let subst s = try (List.assoc s simple_bindings) with Not_found -> "" in
-  let b = Buffer.create 100 in
-  try Buffer.add_substitute b subst value; Buffer.contents b with _ -> value
+let rec expand vars simple_bindings value =
+  let b = Buffer.create (String.length value) in
+  Buffer.add_substitute b (subst vars simple_bindings) value; Buffer.contents b
 
-let rec expand env value =
-  let expanded = expand_aux env value in
-  if expanded=value then value else expand env expanded
+and subst vars simple_bindings s =
+  if List.mem s vars then raise (Variables.Recursive_variable_definition s);
+  try expand (s :: vars) simple_bindings (List.assoc s simple_bindings)
+  with Not_found -> ""
 
 let expand env = function
   | None -> raise Not_found
-  | Some value -> expand env value
+  | Some value ->
+     let bindings = to_bindings env in
+     let f (variable, value) = ((Variables.name_of_variable variable), value) in
+     let simple_bindings = List.map f bindings in
+     expand [] simple_bindings value
 
 let append_to_system_env environment env =
   (* Augment env with any bindings which are only in environment. This must be

--- a/ocamltest/variables.ml
+++ b/ocamltest/variables.ml
@@ -33,6 +33,8 @@ exception Variable_already_registered of string
 
 exception No_such_variable of string
 
+exception Recursive_variable_definition of string
+
 let default_exporter varname value = (varname, value)
 
 let make (name, description) =

--- a/ocamltest/variables.mli
+++ b/ocamltest/variables.mli
@@ -29,6 +29,8 @@ exception Variable_already_registered of string
 
 exception No_such_variable of string
 
+exception Recursive_variable_definition of string
+
 val make : string * string -> t
 
 val make_with_exporter : exporter -> string * string -> t

--- a/testsuite/tests/tool-ocamltest-var-expansion/subst1.ml
+++ b/testsuite/tests/tool-ocamltest-var-expansion/subst1.ml
@@ -1,0 +1,10 @@
+(* TEST
+ set foo = "bar";
+ set expand = "\$foo";
+ arguments = "str \$notvar $unsetvar $expand $foo";
+*)
+
+let () =
+  let len = Array.length Sys.argv - 1 in
+  let argv = Array.sub Sys.argv 1 len in
+  Array.iter print_endline argv

--- a/testsuite/tests/tool-ocamltest-var-expansion/subst1.reference
+++ b/testsuite/tests/tool-ocamltest-var-expansion/subst1.reference
@@ -1,0 +1,4 @@
+str
+$notvar
+$foo
+bar

--- a/testsuite/tests/tool-ocamltest-var-expansion/subst2.ml
+++ b/testsuite/tests/tool-ocamltest-var-expansion/subst2.ml
@@ -1,0 +1,13 @@
+(* TEST
+ set foo = "bar";
+ set expand = "\$foo";
+ set var0 = "var";
+ set var1 = "$var0";
+ set var2 = "$var1";
+ arguments = "str \$notvar $unsetvar $expand $foo $var2";
+*)
+
+let () =
+  let len = Array.length Sys.argv - 1 in
+  let argv = Array.sub Sys.argv 1 len in
+  Array.iter print_endline argv

--- a/testsuite/tests/tool-ocamltest-var-expansion/subst2.reference
+++ b/testsuite/tests/tool-ocamltest-var-expansion/subst2.reference
@@ -1,0 +1,5 @@
+str
+$notvar
+$foo
+bar
+var


### PR DESCRIPTION
ocamltest uses `Buffer.add_substitute` to perform variable substitution.
The function also replaces escaped `$` characters (i.e., the string
`\$`) with the character `$`.
ocamltest would apply substitution in a loop until the input and
substituted strings were equal; however, removing the escape character
during the first iteration would create variables during the second
iteration.
Consider now that a fixpoint is reached when no substitutions have
been performed.

Other problems occur when substituting on the whole string: the number
of substitutions on the whole string is determined by the maximum
number of recursive expansions of a single variable, should it expand
in turn to another variable. With this algorithm, a variable that
should be expanded only once would be expanded at most as many times
as the variable with the maximum number of expansions of the original
string, thus exhibiting inconsistent behavior.

The solution is to apply substitution recursively only on the expanded
values, not always on the whole string, and to keep track as above if
substitutions have been performed.

I extracted this commit from #12239 as I'm taking time to polish this PR.