### PR TITLE
Code sections of ocamlopt-generated executables must remain readable

### DIFF
--- a/Changes
+++ b/Changes
@@ -931,6 +931,11 @@ Some of those changes will benefit all OCaml packages.
   with ZSTD support.
   (David Allsopp, review by Sébastien Hinderer)
 
+- #12372: Pass option -no-execute-only to the linker for OpenBSD >= 7.3
+  so that code sections remain readable, as needed for closure marshaling.
+  (Xavier Leroy and Anil Madhavapeddy, review by Anil Madhavapeddy and
+  Sébastien Hinderer)
+
 ### Bug fixes:
 
 - #12062: fix runtime events consumer: when events are dropped they shouldn't be

--- a/configure
+++ b/configure
@@ -15185,6 +15185,12 @@ esac ;; #(
   *) :
     mkdll_flags='-shared' ;;
 esac
+       case $host in #(
+  *-*-openbsd7.[3-9]|*-*-openbsd[89].*) :
+    mkdll_flags="${mkdll_flags} -Wl,--no-execute-only" ;; #(
+  *) :
+     ;;
+esac
       oc_ldflags="$oc_ldflags -Wl,-E"
       rpath="-Wl,-rpath,"
       mksharedlibrpath="-Wl,-rpath,"

--- a/configure
+++ b/configure
@@ -15206,6 +15206,17 @@ then :
   mkmaindll="$mkdll"
 fi
 
+# Make sure code sections in OCaml-generated executables are readable
+# (required for marshaling of function closures)
+
+case $host in #(
+  *-*-openbsd7.[3-9]|*-*-openbsd[89].*) :
+    oc_ldflags="$oc_ldflags -Wl,--no-execute-only"
+     natdynlinkopts="$natdynlinkopts -Wl,--no-execute-only" ;; #(
+  *) :
+     ;;
+esac
+
 # Configure native dynlink
 
 natdynlink=false

--- a/configure.ac
+++ b/configure.ac
@@ -1135,6 +1135,14 @@ AS_IF([test -z "$mkmaindll"],
   [mkmaindll_exp="$mkdll_exp"
   mkmaindll="$mkdll"])
 
+# Make sure code sections in OCaml-generated executables are readable
+# (required for marshaling of function closures)
+
+AS_CASE([$host],
+  [[*-*-openbsd7.[3-9]|*-*-openbsd[89].*]],
+    [oc_ldflags="$oc_ldflags -Wl,--no-execute-only"
+     natdynlinkopts="$natdynlinkopts -Wl,--no-execute-only"])
+
 # Configure native dynlink
 
 natdynlink=false

--- a/configure.ac
+++ b/configure.ac
@@ -1121,6 +1121,9 @@ AS_IF([test x"$enable_shared" != "xno"],
            # See https://github.com/ocaml/ocaml/issues/9800
            [mkdll_flags='-shared -Wl,-z,notext'],
            [mkdll_flags='-shared'])
+       AS_CASE([$host],
+           [[*-*-openbsd7.[3-9]|*-*-openbsd[89].*]],
+           [mkdll_flags="${mkdll_flags} -Wl,--no-execute-only"])
       oc_ldflags="$oc_ldflags -Wl,-E"
       rpath="-Wl,-rpath,"
       mksharedlibrpath="-Wl,-rpath,"


### PR DESCRIPTION
This is required for marshaling of function closures. OpenBSD 7.3 makes code sections non-readable by default.  This PR adds magic to `configure` so as to detect OpenBSD >= 7.3 and activate the `--no-execute-only` linker flag.
