### PR TITLE
More on external

### DIFF
--- a/.depend
+++ b/.depend
@@ -1470,6 +1470,7 @@ typing/typedecl.cmo : \
     utils/warnings.cmi \
     typing/typetexp.cmi \
     typing/types.cmi \
+    typing/typeopt.cmi \
     typing/typedtree.cmi \
     typing/typedecl_variance.cmi \
     typing/typedecl_unboxed.cmi \
@@ -1487,6 +1488,7 @@ typing/typedecl.cmo : \
     utils/misc.cmi \
     parsing/longident.cmi \
     parsing/location.cmi \
+    lambda/lambda.cmi \
     typing/includecore.cmi \
     typing/ident.cmi \
     typing/errortrace.cmi \
@@ -1505,6 +1507,7 @@ typing/typedecl.cmx : \
     utils/warnings.cmx \
     typing/typetexp.cmx \
     typing/types.cmx \
+    typing/typeopt.cmx \
     typing/typedtree.cmx \
     typing/typedecl_variance.cmx \
     typing/typedecl_unboxed.cmx \
@@ -1522,6 +1525,7 @@ typing/typedecl.cmx : \
     utils/misc.cmx \
     parsing/longident.cmx \
     parsing/location.cmx \
+    lambda/lambda.cmx \
     typing/includecore.cmx \
     typing/ident.cmx \
     typing/errortrace.cmx \

--- a/.depend
+++ b/.depend
@@ -1045,6 +1045,7 @@ typing/predef.cmi : \
     typing/path.cmi \
     typing/ident.cmi
 typing/primitive.cmo : \
+    typing/path.cmi \
     parsing/parsetree.cmi \
     typing/outcometree.cmi \
     utils/misc.cmi \
@@ -1052,6 +1053,7 @@ typing/primitive.cmo : \
     parsing/attr_helper.cmi \
     typing/primitive.cmi
 typing/primitive.cmx : \
+    typing/path.cmx \
     parsing/parsetree.cmi \
     typing/outcometree.cmi \
     utils/misc.cmx \
@@ -1059,6 +1061,7 @@ typing/primitive.cmx : \
     parsing/attr_helper.cmx \
     typing/primitive.cmi
 typing/primitive.cmi : \
+    typing/path.cmi \
     parsing/parsetree.cmi \
     typing/outcometree.cmi \
     parsing/location.cmi

--- a/.depend
+++ b/.depend
@@ -1045,7 +1045,6 @@ typing/predef.cmi : \
     typing/path.cmi \
     typing/ident.cmi
 typing/primitive.cmo : \
-    typing/path.cmi \
     parsing/parsetree.cmi \
     typing/outcometree.cmi \
     utils/misc.cmi \
@@ -1053,7 +1052,6 @@ typing/primitive.cmo : \
     parsing/attr_helper.cmi \
     typing/primitive.cmi
 typing/primitive.cmx : \
-    typing/path.cmx \
     parsing/parsetree.cmi \
     typing/outcometree.cmi \
     utils/misc.cmx \
@@ -1061,7 +1059,6 @@ typing/primitive.cmx : \
     parsing/attr_helper.cmx \
     typing/primitive.cmi
 typing/primitive.cmi : \
-    typing/path.cmi \
     parsing/parsetree.cmi \
     typing/outcometree.cmi \
     parsing/location.cmi

--- a/Changes
+++ b/Changes
@@ -36,10 +36,9 @@ Working version
   handlers, finalisers, memprof callbacks...) on the other hand.
   (Guillaume Munch-Maccagnoni, review by KC Sivaramakrishnan)
 
-- #12375: allow more use of [@untagged] for types char, bool, string, bytes,
-  bigarray with C layout and variant with only constant constructors. string,
-  bytes and bigarray are not allowed as result type.
-  (Christophe Raffalli, report by ..., review by ...)
+- #12375: allow use of [@untagged] for all immediate types like char, bool,
+  and variant with only constant constructors.
+  (Christophe Raffalli, review by Gabriel Scherer)
 
 ### Type system:
 

--- a/Changes
+++ b/Changes
@@ -36,6 +36,11 @@ Working version
   handlers, finalisers, memprof callbacks...) on the other hand.
   (Guillaume Munch-Maccagnoni, review by KC Sivaramakrishnan)
 
+- #12375: allow more use of [@untagged] for types char, bool, string, bytes,
+  bigarray with C layout and variant with only constant constructors. string,
+  bytes and bigarray are not allowed as result type.
+  (Christophe Raffalli, report by ..., review by ...)
+
 ### Type system:
 
 - #12313, #11799: Do not re-build as-pattern type when a ground type annotation

--- a/asmcomp/cmmgen.ml
+++ b/asmcomp/cmmgen.ml
@@ -814,13 +814,8 @@ and transl_ccall env prim args dbg =
           | Pint32 -> XInt32
           | Pint64 -> XInt64 in
         (xty, transl_unbox_int dbg env bi arg)
-    | Untagged_int (Int | Char | Bool | Constants) ->
+    | Untagged_int _ ->
         (XInt, untag_int (transl env arg) dbg)
-    | Untagged_int (String | Bytes) ->
-        (XInt, transl env arg)
-    | Untagged_int (Bigarray) ->
-       (XInt, (Cop(mk_load_mut Word_int,
-                    [field_address (transl env arg) 1 dbg], dbg)))
   in
   let rec transl_args native_repr_args args =
     match native_repr_args, args with
@@ -840,10 +835,7 @@ and transl_ccall env prim args dbg =
     | Same_as_ocaml_repr -> (typ_val, fun x -> x)
     | Unboxed_float -> (typ_float, box_float dbg)
     | Unboxed_integer bi -> (typ_int, box_int dbg bi)
-    | Untagged_int (Int | Char | Bool | Constants) ->
-       (typ_int, (fun i -> tag_int i dbg))
-    | Untagged_int (String | Bytes | Bigarray) ->
-       Misc.fatal_error "String of Bytes are not allowed as untagged result"
+    | Untagged_int _ -> (typ_int, (fun i -> tag_int i dbg))
   in
   let typ_args, args = transl_args prim.prim_native_repr_args args in
   wrap_result

--- a/asmcomp/cmmgen.ml
+++ b/asmcomp/cmmgen.ml
@@ -814,7 +814,7 @@ and transl_ccall env prim args dbg =
           | Pint32 -> XInt32
           | Pint64 -> XInt64 in
         (xty, transl_unbox_int dbg env bi arg)
-    | Untagged_int _ ->
+    | Untagged_immediate ->
         (XInt, untag_int (transl env arg) dbg)
   in
   let rec transl_args native_repr_args args =
@@ -835,7 +835,7 @@ and transl_ccall env prim args dbg =
     | Same_as_ocaml_repr -> (typ_val, fun x -> x)
     | Unboxed_float -> (typ_float, box_float dbg)
     | Unboxed_integer bi -> (typ_int, box_int dbg bi)
-    | Untagged_int _ -> (typ_int, (fun i -> tag_int i dbg))
+    | Untagged_immediate -> (typ_int, (fun i -> tag_int i dbg))
   in
   let typ_args, args = transl_args prim.prim_native_repr_args args in
   wrap_result

--- a/asmcomp/cmmgen.ml
+++ b/asmcomp/cmmgen.ml
@@ -814,8 +814,13 @@ and transl_ccall env prim args dbg =
           | Pint32 -> XInt32
           | Pint64 -> XInt64 in
         (xty, transl_unbox_int dbg env bi arg)
-    | Untagged_int ->
+    | Untagged_int (Int | Char | Bool | Constants) ->
         (XInt, untag_int (transl env arg) dbg)
+    | Untagged_int (String | Bytes) ->
+        (XInt, transl env arg)
+    | Untagged_int (Bigarray) ->
+       (XInt, (Cop(mk_load_mut Word_int,
+                    [field_address (transl env arg) 1 dbg], dbg)))
   in
   let rec transl_args native_repr_args args =
     match native_repr_args, args with
@@ -835,7 +840,10 @@ and transl_ccall env prim args dbg =
     | Same_as_ocaml_repr -> (typ_val, fun x -> x)
     | Unboxed_float -> (typ_float, box_float dbg)
     | Unboxed_integer bi -> (typ_int, box_int dbg bi)
-    | Untagged_int -> (typ_int, (fun i -> tag_int i dbg))
+    | Untagged_int (Int | Char | Bool | Constants) ->
+       (typ_int, (fun i -> tag_int i dbg))
+    | Untagged_int (String | Bytes | Bigarray) ->
+       Misc.fatal_error "String of Bytes are not allowed as untagged result"
   in
   let typ_args, args = transl_args prim.prim_native_repr_args args in
   wrap_result

--- a/compilerlibs/Makefile.compilerlibs
+++ b/compilerlibs/Makefile.compilerlibs
@@ -113,8 +113,8 @@ TYPING = \
   typing/typedecl_unboxed.cmo \
   typing/typedecl_immediacy.cmo \
   typing/typedecl_separability.cmo \
-  typing/typedecl.cmo \
   typing/typeopt.cmo \
+  typing/typedecl.cmo \
   typing/rec_check.cmo \
   typing/typecore.cmo \
   typing/typeclass.cmo \

--- a/dune
+++ b/dune
@@ -60,7 +60,7 @@
    typedtree printtyped ctype printtyp includeclass mtype envaux includecore
    tast_iterator tast_mapper signature_group cmt_format untypeast
    includemod includemod_errorprinter
-   typetexp patterns printpat parmatch stypes typedecl typeopt rec_check
+   typetexp patterns printpat parmatch stypes typeopt typedecl rec_check
    typecore
    typeclass typemod typedecl_variance typedecl_properties typedecl_immediacy
    typedecl_unboxed typedecl_separability cmt2annot

--- a/manual/src/cmds/intf-c.etex
+++ b/manual/src/cmds/intf-c.etex
@@ -2404,6 +2404,11 @@ The corresponding C type must be "intnat".
 {\bf Note:} Do not use the C "int" type in correspondence with "(int
 [\@untagged])". This is because they often differ in size.
 
+It is possible to annotate with "[\@untagged]" any immediate type, i.e. types
+that are represented like "int". This includes "bool", "char", any variant
+type with only constant constructors. Note: this does not include
+"Unix.file_descr" which is not represented as an interger on all platforms.
+
 \subsection{ss:c-direct-call}{Direct C call}
 
 In order to be able to run the garbage collector in the middle of

--- a/testsuite/tests/c-api/external.ml
+++ b/testsuite/tests/c-api/external.ml
@@ -19,32 +19,6 @@ external test_data : (int [@untagged])
                     -> (char [@untagged]) -> (data [@untagged])
                     -> (data [@untagged]) = "unavailable" "test" [@@noalloc]
 
-external test_string : (string [@untagged]) -> (int [@untagged])
-  = "unavailable" "tests" [@@noalloc]
-
-external test_bytes : (bytes [@untagged]) -> (int [@untagged])
-  = "unavailable" "tests" [@@noalloc]
-
-open Bigarray
-
-external test_bigarray : ((char, int8_unsigned_elt, c_layout) Array1.t [@untagged])
-                     -> (int [@untagged]) = "unavailable" "tests" [@@noalloc]
-
-external test_float_bigarray : ((float, float32_elt, c_layout) Array1.t [@untagged])
-                     -> (int [@untagged]) -> (float [@unboxed])
-  = "unavailable" "testf" [@@noalloc]
-
 let _ = assert(test_int 1 '\001' B = 3)
 let _ = assert(test_char 1 '\001' B = '\003')
 let _ = assert(test_data 1 '\001' B = D)
-
-let _ = assert(test_string "\001\001\002\003" = 7)
-let _ = assert(test_bytes (Bytes.of_string "\001\001\002\003") = 7)
-
-let tbl = Array1.init Bigarray.char c_layout 5 (fun i -> Char.chr (4 - i))
-
-let _ = assert(test_bigarray tbl = 10)
-
-let tblf = Array1.init Bigarray.float32 c_layout 5 (fun i -> float (4 - i))
-
-let _ = assert(test_float_bigarray tblf (Array1.dim tblf) = 10.0)

--- a/testsuite/tests/c-api/external.ml
+++ b/testsuite/tests/c-api/external.ml
@@ -1,0 +1,50 @@
+(* TEST
+ modules = "external_stubs.c";
+{
+   native;
+ }
+ *)
+
+type data = A | B | C | D | E | F
+
+external test_int : (int [@untagged])
+                    -> (char [@untagged]) -> (data [@untagged])
+                    -> (int [@untagged]) = "unavailable" "test" [@@noalloc]
+
+external test_char : (int [@untagged])
+                    -> (char [@untagged]) -> (data [@untagged])
+                    -> (char [@untagged]) = "unavailable" "test" [@@noalloc]
+
+external test_data : (int [@untagged])
+                    -> (char [@untagged]) -> (data [@untagged])
+                    -> (data [@untagged]) = "unavailable" "test" [@@noalloc]
+
+external test_string : (string [@untagged]) -> (int [@untagged])
+  = "unavailable" "tests" [@@noalloc]
+
+external test_bytes : (bytes [@untagged]) -> (int [@untagged])
+  = "unavailable" "tests" [@@noalloc]
+
+open Bigarray
+
+external test_bigarray : ((char, int8_unsigned_elt, c_layout) Array1.t [@untagged])
+                     -> (int [@untagged]) = "unavailable" "tests" [@@noalloc]
+
+external test_float_bigarray : ((float, float32_elt, c_layout) Array1.t [@untagged])
+                     -> (int [@untagged]) -> (float [@unboxed])
+  = "unavailable" "testf" [@@noalloc]
+
+let _ = assert(test_int 1 '\001' B = 3)
+let _ = assert(test_char 1 '\001' B = '\003')
+let _ = assert(test_data 1 '\001' B = D)
+
+let _ = assert(test_string "\001\001\002\003" = 7)
+let _ = assert(test_bytes (Bytes.of_string "\001\001\002\003") = 7)
+
+let tbl = Array1.init Bigarray.char c_layout 5 (fun i -> Char.chr (4 - i))
+
+let _ = assert(test_bigarray tbl = 10)
+
+let tblf = Array1.init Bigarray.float32 c_layout 5 (fun i -> float (4 - i))
+
+let _ = assert(test_float_bigarray tblf (Array1.dim tblf) = 10.0)

--- a/testsuite/tests/c-api/external_stubs.c
+++ b/testsuite/tests/c-api/external_stubs.c
@@ -1,0 +1,20 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <caml/mlvalues.h>
+
+intnat test(intnat b,intnat c,intnat d) {
+  return(b+c+d);
+}
+
+intnat tests(const char * str) {
+  intnat r = 0;
+  //printf("===========> %s\n", str);
+  while (*str) r += *str++;
+  return(r);
+}
+
+intnat testf(const float * str, intnat size) {
+  double r = 0;
+  for (int i=0; i < size; i++) r += (double) str[i];
+  return(r);
+}

--- a/testsuite/tests/c-api/external_stubs.c
+++ b/testsuite/tests/c-api/external_stubs.c
@@ -5,16 +5,3 @@
 intnat test(intnat b,intnat c,intnat d) {
   return(b+c+d);
 }
-
-intnat tests(const char * str) {
-  intnat r = 0;
-  //printf("===========> %s\n", str);
-  while (*str) r += *str++;
-  return(r);
-}
-
-intnat testf(const float * str, intnat size) {
-  double r = 0;
-  for (int i=0; i < size; i++) r += (double) str[i];
-  return(r);
-}

--- a/testsuite/tests/typing-unboxed/test.ml
+++ b/testsuite/tests/typing-unboxed/test.ml
@@ -631,8 +631,8 @@ external g : (float [@untagged]) -> float = "g" "g_nat";;
 Line 1, characters 14-19:
 1 | external g : (float [@untagged]) -> float = "g" "g_nat";;
                   ^^^^^
-          Error: Don't know how to untag this type. Only "int"
-                 and other immediate types can be untagged.
+Error: Don't know how to untag this type. Only "int"
+       and other immediate types can be untagged.
 |}]
 external h : (int [@unboxed]) -> float = "h" "h_nat";;
 [%%expect{|

--- a/testsuite/tests/typing-unboxed/test.ml
+++ b/testsuite/tests/typing-unboxed/test.ml
@@ -631,7 +631,7 @@ external g : (float [@untagged]) -> float = "g" "g_nat";;
 Line 1, characters 14-19:
 1 | external g : (float [@untagged]) -> float = "g" "g_nat";;
                   ^^^^^
-Error: Don't know how to untag this type. Only "int" can be untagged.
+Error: Don't know how to untag this type. Only "int", "char", "bool" and other immediate types can be untagged.
 |}]
 external h : (int [@unboxed]) -> float = "h" "h_nat";;
 [%%expect{|

--- a/testsuite/tests/typing-unboxed/test.ml
+++ b/testsuite/tests/typing-unboxed/test.ml
@@ -631,8 +631,8 @@ external g : (float [@untagged]) -> float = "g" "g_nat";;
 Line 1, characters 14-19:
 1 | external g : (float [@untagged]) -> float = "g" "g_nat";;
                   ^^^^^
-Error: Don't know how to untag this type.
-       Only "int", "char", "bool" and other immediate types can be untagged.
+          Error: Don't know how to untag this type. Only "int"
+                 and other immediate types can be untagged.
 |}]
 external h : (int [@unboxed]) -> float = "h" "h_nat";;
 [%%expect{|

--- a/testsuite/tests/typing-unboxed/test.ml
+++ b/testsuite/tests/typing-unboxed/test.ml
@@ -631,7 +631,8 @@ external g : (float [@untagged]) -> float = "g" "g_nat";;
 Line 1, characters 14-19:
 1 | external g : (float [@untagged]) -> float = "g" "g_nat";;
                   ^^^^^
-Error: Don't know how to untag this type. Only "int", "char", "bool" and other immediate types can be untagged.
+Error: Don't know how to untag this type.
+       Only "int", "char", "bool" and other immediate types can be untagged.
 |}]
 external h : (int [@unboxed]) -> float = "h" "h_nat";;
 [%%expect{|

--- a/typing/primitive.ml
+++ b/typing/primitive.ml
@@ -24,7 +24,7 @@ type native_repr =
   | Same_as_ocaml_repr
   | Unboxed_float
   | Unboxed_integer of boxed_integer
-  | Untagged_int of Path.t
+  | Untagged_immediate
 
 type description =
   { prim_name: string;         (* Name of primitive  or C function *)
@@ -45,16 +45,16 @@ let is_ocaml_repr = function
   | Same_as_ocaml_repr -> true
   | Unboxed_float
   | Unboxed_integer _
-  | Untagged_int _ -> false
+  | Untagged_immediate -> false
 
 let is_unboxed = function
   | Same_as_ocaml_repr
-  | Untagged_int _ -> false
+  | Untagged_immediate -> false
   | Unboxed_float
   | Unboxed_integer _ -> true
 
 let is_untagged = function
-  | Untagged_int _ -> true
+  | Untagged_immediate -> true
   | Same_as_ocaml_repr
   | Unboxed_float
   | Unboxed_integer _ -> false
@@ -181,7 +181,7 @@ let print p osig_val_decl =
     | Same_as_ocaml_repr -> None
     | Unboxed_float
     | Unboxed_integer _ -> if all_unboxed then None else Some oattr_unboxed
-    | Untagged_int _ -> if all_untagged then None else Some oattr_untagged
+    | Untagged_immediate -> if all_untagged then None else Some oattr_untagged
   in
   let type_attrs =
     List.map attr_of_native_repr p.prim_native_repr_args @
@@ -209,22 +209,19 @@ let equal_boxed_integer bi1 bi2 =
   | (Pnativeint | Pint32 | Pint64), _ ->
     false
 
-let equal_untagged_integer ui1 ui2 =
-  Path.same ui1 ui2
-
 let equal_native_repr nr1 nr2 =
   match nr1, nr2 with
   | Same_as_ocaml_repr, Same_as_ocaml_repr -> true
   | Same_as_ocaml_repr,
-    (Unboxed_float | Unboxed_integer _ | Untagged_int _) -> false
+    (Unboxed_float | Unboxed_integer _ | Untagged_immediate) -> false
   | Unboxed_float, Unboxed_float -> true
   | Unboxed_float,
-    (Same_as_ocaml_repr | Unboxed_integer _ | Untagged_int _) -> false
+    (Same_as_ocaml_repr | Unboxed_integer _ | Untagged_immediate) -> false
   | Unboxed_integer bi1, Unboxed_integer bi2 -> equal_boxed_integer bi1 bi2
   | Unboxed_integer _,
-    (Same_as_ocaml_repr | Unboxed_float | Untagged_int _) -> false
-  | Untagged_int ui1, Untagged_int ui2 -> equal_untagged_integer ui1 ui2
-  | Untagged_int _,
+    (Same_as_ocaml_repr | Unboxed_float | Untagged_immediate) -> false
+  | Untagged_immediate, Untagged_immediate -> true
+  | Untagged_immediate,
     (Same_as_ocaml_repr | Unboxed_float | Unboxed_integer _) -> false
 
 let native_name_is_external p =

--- a/typing/primitive.ml
+++ b/typing/primitive.ml
@@ -21,7 +21,8 @@ open Parsetree
 type boxed_integer = Pnativeint | Pint32 | Pint64
 
 (* String, Bytes and Bigarray are not allowed as @untagged results *)
-type untagged_integer = Int | Bool | Char | Constants | String | Bytes | Bigarray
+type untagged_integer = Int | Bool | Char | Constants
+                        | String | Bytes | Bigarray
 
 type native_repr =
   | Same_as_ocaml_repr

--- a/typing/primitive.ml
+++ b/typing/primitive.ml
@@ -20,15 +20,11 @@ open Parsetree
 
 type boxed_integer = Pnativeint | Pint32 | Pint64
 
-(* String, Bytes and Bigarray are not allowed as @untagged results *)
-type untagged_integer = Int | Bool | Char | Constants
-                        | String | Bytes | Bigarray
-
 type native_repr =
   | Same_as_ocaml_repr
   | Unboxed_float
   | Unboxed_integer of boxed_integer
-  | Untagged_int of untagged_integer
+  | Untagged_int of Path.t
 
 type description =
   { prim_name: string;         (* Name of primitive  or C function *)
@@ -214,17 +210,7 @@ let equal_boxed_integer bi1 bi2 =
     false
 
 let equal_untagged_integer ui1 ui2 =
-  match ui1, ui2 with
-  | Int, Int
-  | Bool, Bool
-  | Char, Char
-  | Constants, Constants
-  | String, String
-  | Bigarray, Bigarray
-  | Bytes, Bytes ->
-    true
-  | (Int | Bool | Char | Constants | String | Bytes | Bigarray), _ ->
-    false
+  Path.same ui1 ui2
 
 let equal_native_repr nr1 nr2 =
   match nr1, nr2 with

--- a/typing/primitive.mli
+++ b/typing/primitive.mli
@@ -17,17 +17,13 @@
 
 type boxed_integer = Pnativeint | Pint32 | Pint64
 
-(* String, Bytes and Bigarray are not allowed as @untagged results *)
-type untagged_integer = Int | Bool | Char | Constants
-                        | String | Bytes | Bigarray
-
 (* Representation of arguments/result for the native code version
    of a primitive *)
 type native_repr =
   | Same_as_ocaml_repr
   | Unboxed_float
   | Unboxed_integer of boxed_integer
-  | Untagged_int of untagged_integer
+  | Untagged_int of Path.t
 
 type description = private
   { prim_name: string;         (* Name of primitive  or C function *)

--- a/typing/primitive.mli
+++ b/typing/primitive.mli
@@ -23,7 +23,7 @@ type native_repr =
   | Same_as_ocaml_repr
   | Unboxed_float
   | Unboxed_integer of boxed_integer
-  | Untagged_int of Path.t
+  | Untagged_immediate
 
 type description = private
   { prim_name: string;         (* Name of primitive  or C function *)

--- a/typing/primitive.mli
+++ b/typing/primitive.mli
@@ -17,13 +17,16 @@
 
 type boxed_integer = Pnativeint | Pint32 | Pint64
 
+(* String, Bytes and Bigarray are not allowed as @untagged results *)
+type untagged_integer = Int | Bool | Char | Constants | String | Bytes | Bigarray
+
 (* Representation of arguments/result for the native code version
    of a primitive *)
 type native_repr =
   | Same_as_ocaml_repr
   | Unboxed_float
   | Unboxed_integer of boxed_integer
-  | Untagged_int
+  | Untagged_int of untagged_integer
 
 type description = private
   { prim_name: string;         (* Name of primitive  or C function *)

--- a/typing/primitive.mli
+++ b/typing/primitive.mli
@@ -18,7 +18,8 @@
 type boxed_integer = Pnativeint | Pint32 | Pint64
 
 (* String, Bytes and Bigarray are not allowed as @untagged results *)
-type untagged_integer = Int | Bool | Char | Constants | String | Bytes | Bigarray
+type untagged_integer = Int | Bool | Char | Constants
+                        | String | Bytes | Bigarray
 
 (* Representation of arguments/result for the native code version
    of a primitive *)

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -2149,8 +2149,10 @@ let report_error ppf = function
         Style.inline_code "nativeint"
   | Cannot_unbox_or_untag_type Untagged ->
       fprintf ppf "@[Don't know how to untag this type.@ \
-                   Only %a can be untagged.@]"
+                   Only %a, %a, %a and other immadiate types can be untagged.@]"
         Style.inline_code "int"
+        Style.inline_code "char"
+        Style.inline_code "bool"
   | Deep_unbox_or_untag_attribute kind ->
       fprintf ppf
         "@[The attribute %a should be attached to@ \

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -1483,37 +1483,11 @@ let get_native_repr_attribute attrs ~global_repr =
   | _, Some { Location.loc }, _ ->
     raise (Error (loc, Multiple_native_repr_attributes))
 
-let is_constants_only_variant path env =
-  let open Types in
-  let decl = Env.find_type path env in
-  let constants cd = match cd.cd_args with
-    | Cstr_tuple [] -> true
-    | _ -> false
-  in
-  match decl.type_kind with
-  | Type_abstract | Type_record _ | Type_open -> false
-  | Type_variant(crts, _) -> List.for_all constants crts
-
-let is_bigarray_c_layout ty env =
-  let (_, layout) = Typeopt.bigarray_type_kind_and_layout env ty in
-  layout = Lambda.Pbigarray_c_layout
-
-let native_repr_of_type env kind ty ~result =
+let native_repr_of_type env kind ty =
   match kind, get_desc (Ctype.expand_head_opt env ty) with
-  | Untagged, Tconstr (path, _, _) when Path.same path Predef.path_int ->
-    Some (Untagged_int Int)
-  | Untagged, Tconstr (path, _, _) when Path.same path Predef.path_bool ->
-    Some (Untagged_int Bool)
-  | Untagged, Tconstr (path, _, _) when Path.same path Predef.path_char ->
-    Some (Untagged_int Char)
-  | Untagged, Tconstr (path, _, _) when is_constants_only_variant path env ->
-    Some (Untagged_int Constants)
-  | Untagged, Tconstr (path, _, _) when Path.same path Predef.path_string ->
-    if result then None else Some (Untagged_int String)
-  | Untagged, Tconstr (path, _, _) when Path.same path Predef.path_bytes ->
-    if result then None else Some (Untagged_int Bytes)
-  | Untagged, Tconstr _ when is_bigarray_c_layout ty env ->
-    if result then None else Some (Untagged_int Bigarray)
+  | Untagged, Tconstr (path, _, _) when
+         Typeopt.maybe_pointer_type env ty = Lambda.Immediate ->
+    Some (Untagged_int path)
   | Unboxed, Tconstr (path, _, _) when Path.same path Predef.path_float ->
     Some Unboxed_float
   | Unboxed, Tconstr (path, _, _) when Path.same path Predef.path_int32 ->
@@ -1544,13 +1518,13 @@ let error_if_has_deep_native_repr_attributes core_type =
   in
   default_iterator.typ this_iterator core_type
 
-let make_native_repr env core_type ty ~global_repr ~result =
+let make_native_repr env core_type ty ~global_repr =
   error_if_has_deep_native_repr_attributes core_type;
   match get_native_repr_attribute core_type.ptyp_attributes ~global_repr with
   | Native_repr_attr_absent ->
     Same_as_ocaml_repr
   | Native_repr_attr_present kind ->
-    begin match native_repr_of_type env kind ty ~result with
+    begin match native_repr_of_type env kind ty with
     | None ->
       raise (Error (core_type.ptyp_loc, Cannot_unbox_or_untag_type kind))
     | Some repr -> repr
@@ -1563,7 +1537,7 @@ let rec parse_native_repr_attributes env core_type ty ~global_repr =
   | Ptyp_arrow _, Tarrow _, Native_repr_attr_present kind  ->
     raise (Error (core_type.ptyp_loc, Cannot_unbox_or_untag_type kind))
   | Ptyp_arrow (_, ct1, ct2), Tarrow (_, t1, t2, _), _ ->
-    let repr_arg = make_native_repr env ct1 t1 ~global_repr ~result:false in
+    let repr_arg = make_native_repr env ct1 t1 ~global_repr in
     let repr_args, repr_res =
       parse_native_repr_attributes env ct2 t2 ~global_repr
     in
@@ -1571,7 +1545,7 @@ let rec parse_native_repr_attributes env core_type ty ~global_repr =
   | (Ptyp_poly (_, t) | Ptyp_alias (t, _)), _, _ ->
      parse_native_repr_attributes env t ty ~global_repr
   | Ptyp_arrow _, _, _ | _, Tarrow _, _ -> assert false
-  | _ -> ([], make_native_repr env core_type ty ~global_repr ~result:true)
+  | _ -> ([], make_native_repr env core_type ty ~global_repr)
 
 
 let check_unboxable env loc ty =

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -2149,7 +2149,7 @@ let report_error ppf = function
         Style.inline_code "nativeint"
   | Cannot_unbox_or_untag_type Untagged ->
       fprintf ppf "@[Don't know how to untag this type.@ \
-                   Only %a, %a, %a and other immadiate types can be untagged.@]"
+                   Only %a, %a, %a and other immediate types can be untagged.@]"
         Style.inline_code "int"
         Style.inline_code "char"
         Style.inline_code "bool"

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -2148,11 +2148,9 @@ let report_error ppf = function
         Style.inline_code "int64"
         Style.inline_code "nativeint"
   | Cannot_unbox_or_untag_type Untagged ->
-      fprintf ppf "@[Don't know how to untag this type.@ \
-                   Only %a, %a, %a and other immediate types can be untagged.@]"
+      fprintf ppf "@[Don't know how to untag this type. Only %a@ \
+                   and other immediate types can be untagged.@]"
         Style.inline_code "int"
-        Style.inline_code "char"
-        Style.inline_code "bool"
   | Deep_unbox_or_untag_attribute kind ->
       fprintf ppf
         "@[The attribute %a should be attached to@ \

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -1485,9 +1485,9 @@ let get_native_repr_attribute attrs ~global_repr =
 
 let native_repr_of_type env kind ty =
   match kind, get_desc (Ctype.expand_head_opt env ty) with
-  | Untagged, Tconstr (path, _, _) when
+  | Untagged, Tconstr (_, _, _) when
          Typeopt.maybe_pointer_type env ty = Lambda.Immediate ->
-    Some (Untagged_int path)
+    Some Untagged_immediate
   | Unboxed, Tconstr (path, _, _) when Path.same path Predef.path_float ->
     Some Unboxed_float
   | Unboxed, Tconstr (path, _, _) when Path.same path Predef.path_int32 ->


### PR DESCRIPTION
This PR tries to fix issue #12367. 

This is my first PR to the compiler, I hope it is not too messy.

If allows the use of [[@untagged]] for
- char, bool
- variant type with only constant constructors
- string and bytes   FOR ANOTHER PR
- bigarray with C layout FOR ANOTHER PR

The idea is to allow more c binding without stubs. The are some questions:

- Actually, I was thinking that a new annotation [[@direct]] (or a better name) that would cover both [@untagged] and [@unboxed] could be nice.

- Moreover, it would be nice if the new annotation [[@direct]] were supported in bytecode.
 
