### PR TITLE
documentation: currently unavailable GC metrics

### DIFF
--- a/stdlib/gc.mli
+++ b/stdlib/gc.mli
@@ -41,7 +41,8 @@ type stat =
     (** Total size of the major heap, in words. *)
 
     heap_chunks : int;
-    (** Number of contiguous pieces of memory that make up the major heap. *)
+    (** Number of contiguous pieces of memory that make up the major heap.
+        This metrics is currently not available in OCaml 5. *)
 
     live_words : int;
     (** Number of words of live data in the major heap, including the header
@@ -68,10 +69,12 @@ type stat =
     (** Number of words in the free list. *)
 
     free_blocks : int;
-    (** Number of blocks in the free list. *)
+    (** Number of blocks in the free list.
+        This metrics is currently not available in OCaml 5. *)
 
     largest_free : int;
-    (** Size (in words) of the largest block in the free list. *)
+    (** Size (in words) of the largest block in the free list.
+        This metrics is currently not available in OCaml 5. *)
 
     fragments : int;
     (** Number of wasted words due to fragmentation.  These are
@@ -86,6 +89,7 @@ type stat =
 
     stack_size: int;
     (** Current size of the stack, in words.
+        This metrics is currently not available in OCaml 5.
         @since 3.12 *)
 
     forced_major_collections: int;

--- a/stdlib/gc.mli
+++ b/stdlib/gc.mli
@@ -42,7 +42,8 @@ type stat =
 
     heap_chunks : int;
     (** Number of contiguous pieces of memory that make up the major heap.
-        This metrics is currently not available in OCaml 5. *)
+        This metrics is currently not available in OCaml 5: the field value is
+        always [0]. *)
 
     live_words : int;
     (** Number of words of live data in the major heap, including the header
@@ -70,11 +71,13 @@ type stat =
 
     free_blocks : int;
     (** Number of blocks in the free list.
-        This metrics is currently not available in OCaml 5. *)
+        This metrics is currently not available in OCaml 5: the field value is
+        always [0]. *)
 
     largest_free : int;
     (** Size (in words) of the largest block in the free list.
-        This metrics is currently not available in OCaml 5. *)
+        This metrics is currently not available in OCaml 5: the field value
+        is always [0]. *)
 
     fragments : int;
     (** Number of wasted words due to fragmentation.  These are
@@ -89,7 +92,8 @@ type stat =
 
     stack_size: int;
     (** Current size of the stack, in words.
-        This metrics is currently not available in OCaml 5.
+        This metrics is currently not available in OCaml 5: the field value is
+        always [0].
         @since 3.12 *)
 
     forced_major_collections: int;


### PR DESCRIPTION
This small PR documents the handful of GC metrics that are currently not meaningful in the `Gc.stat` record to avoid users scratching their head on why the `stack_size` is always `0` .