### PR TITLE
Allow paths in ocaml_compiler_internal_params

### DIFF
--- a/driver/compenv.ml
+++ b/driver/compenv.ml
@@ -526,7 +526,7 @@ type file_option = {
 }
 
 let scan_line ic =
-  Scanf.bscanf ic "%[0-9a-zA-Z_.*] : %[a-zA-Z_-] = %s "
+  Scanf.bscanf ic "%[0-9a-zA-Z_.*/] : %[a-zA-Z_-] = %s "
     (fun pattern name value ->
        let pattern =
          match pattern with


### PR DESCRIPTION
The `ocaml_compiler_internal_params` file can be used to set flags for a given file, with directives like:
```
foo.ml : strict-sequence = 1
```
This will adjust the flags for a compiler invocation like `ocamlc foo.ml`.

But because the name in the directive is matched exactly with the command line argument, it does not work for a compiler invocation like `ocamlc dir/foo.ml`.  And because the parser for these directives doesn't permit the `/` character in the filenames, there is no way around this - if the compiler is being run in a different directory than the file being compiled, there is no way to use `ocaml_compiler_internal_params` to adjust the parameters.

The fix is just to allow `/`.  Now this works as well:
```
dir/foo.ml : strict-sequence = 1
```
Of course, this mechanism is just meant for debugging and testing, but I can't see any reason to restrict it in this way.  I've tested locally and it seems to work fine.

(An alternative fix would be to match only on the filename part of the path.  I'd be happy to do that too, but it seems a little error-prone if, for example, the compiler is being invoked by a build system and there may be many files in different directories with the same name.)