### PR TITLE
Basic thread and domain structures for statmemprof

### DIFF
--- a/Changes
+++ b/Changes
@@ -183,12 +183,10 @@ Working version
   (David Allsopp, Antonin Décimo, and Samuel Hym, review by Nicolas
    Ojeda Bar)
 
-- #11911, #12383: Restore statmemprof functionality in part
-   (backtrace buffers). (Nick Barnes, review by Gabriel Scherer)
-
-- #11911, #12383: Restore statmemprof functionality in part (backtrace
-   buffers). (Nick Barnes, review by Gabriel Scherer and Fabrice
-   Buoro).
+- #11911, #12382, #12383: Restore statmemprof functionality in part
+  (backtrace buffers, per-thread and per-domain data
+  structures). (Nick Barnes, review by Gabriel Scherer, Fabrice Buoro,
+  Sadiq Jaffer, and Guillaume Munch-Maccagnoni).
 
 ### Code generation and optimizations:
 

--- a/runtime/caml/domain_state.tbl
+++ b/runtime/caml/domain_state.tbl
@@ -15,14 +15,15 @@
 /**************************************************************************/
 
 DOMAIN_STATE(atomic_uintnat, young_limit)
+
 /* Minor heap limit. Typically [young_start] <= [young_limit] <=
  * [young_end], but this field can be set atomically to UINTNAT_MAX by
- * another thread (typically from another domain) in order to
- * interrupt this domain (by causing an allocation failure). Setting
- * [young_limit] to UINTNAT_MAX can be done safely at any time
- * whatsoever by any thread. To avoid races, setting [young_limit] to
- * anything else than UINTNAT_MAX should only be done via
- * [caml_reset_young_limit] by the domain itself. */
+ * another thread (typically from another domain), or by the memory
+ * profiler, in order to interrupt this domain (by causing an
+ * allocation failure). Setting [young_limit] to UINTNAT_MAX can be
+ * done safely at any time whatsoever by any thread. To avoid races,
+ * setting [young_limit] to anything else than UINTNAT_MAX should only
+ * be done via [caml_reset_young_limit] by the domain itself. */
 
 DOMAIN_STATE(value*, young_ptr)
 /* Minor heap pointer */
@@ -156,6 +157,9 @@ DOMAIN_STATE(intnat, trap_barrier_off)
 DOMAIN_STATE(int64_t, trap_barrier_block)
 DOMAIN_STATE(struct caml_exception_context*, external_raise)
 /* Bytecode TLS vars, not used for native code */
+
+DOMAIN_STATE(struct memprof_domain_s *, memprof)
+DOMAIN_STATE(value *, memprof_young_trigger)
 
 DOMAIN_STATE(extra_params_area, extra_params)
 /* This member must occur last, because it is an array, not a scalar */

--- a/runtime/caml/memprof.h
+++ b/runtime/caml/memprof.h
@@ -22,36 +22,26 @@
 #include "mlvalues.h"
 #include "roots.h"
 
-extern void caml_memprof_set_suspended(int);
+/* Suspend or unsuspend profiling */
+extern void caml_memprof_update_suspended(_Bool);
 
-extern value caml_memprof_handle_postponed_exn(void);
+/* Freshly set sampling point on minor heap */
+extern void caml_memprof_renew_minor_sample(caml_domain_state *state);
 
-extern void caml_memprof_track_alloc_shr(value block);
-extern void caml_memprof_track_custom(value block, mlsize_t bytes);
-extern void caml_memprof_track_young(uintnat wosize, int from_caml,
-                                     int nallocs, unsigned char* alloc_lens);
-extern void caml_memprof_track_interned(header_t* block, header_t* blockend);
+/* Multi-domain support. */
 
-extern void caml_memprof_renew_minor_sample(void);
-extern value* caml_memprof_young_trigger;
+extern void caml_memprof_new_domain(caml_domain_state *parent,
+                                    caml_domain_state *domain);
+extern void caml_memprof_delete_domain(caml_domain_state *domain);
 
-extern void caml_memprof_oldify_young_roots(void);
-extern void caml_memprof_minor_update(void);
-extern void caml_memprof_do_roots(scanning_action f);
-extern void caml_memprof_update_clean_phase(void);
-extern void caml_memprof_invert_tracked(void);
+/* Multi-thread support */
 
-CAMLextern struct caml_memprof_th_ctx caml_memprof_main_ctx;
+typedef struct memprof_thread_s *memprof_thread_t;
 
-CAMLextern struct caml_memprof_th_ctx* caml_memprof_new_th_ctx(void);
-CAMLextern void caml_memprof_leave_thread(void);
-CAMLextern void caml_memprof_enter_thread(struct caml_memprof_th_ctx*);
-CAMLextern void caml_memprof_delete_th_ctx(struct caml_memprof_th_ctx*);
-
-typedef void (*th_ctx_action)(struct caml_memprof_th_ctx*, void*);
-
-/* This hook is not modified after other domains are spawned. */
-extern void (*caml_memprof_th_ctx_iter_hook)(th_ctx_action, void*);
+CAMLextern memprof_thread_t caml_memprof_main_thread(caml_domain_state *domain);
+CAMLextern memprof_thread_t caml_memprof_new_thread(caml_domain_state *domain);
+CAMLextern void caml_memprof_enter_thread(memprof_thread_t);
+CAMLextern void caml_memprof_delete_thread(memprof_thread_t);
 
 #endif
 

--- a/runtime/memprof.c
+++ b/runtime/memprof.c
@@ -15,6 +15,263 @@
 
 #define CAML_INTERNALS
 
+#include <stdbool.h>
+#include "caml/memory.h"
+#include "caml/memprof.h"
+
+/* type aliases for the hierarchy of structures for managing memprof status. */
+
+typedef struct memprof_domain_s memprof_domain_s, *memprof_domain_t;
+typedef struct memprof_thread_s memprof_thread_s, *memprof_thread_t;
+
+/* Per-thread memprof state. */
+
+struct memprof_thread_s {
+  /* [suspended] is used for inhibiting memprof callbacks when
+     a callback is running or when an uncaught exception handler is
+     called. */
+  bool suspended;
+
+  /* TODO: More fields to add here */
+
+  /* Per-domain memprof information */
+  memprof_domain_t domain;
+
+  /* Linked list of thread structures for this domain. Could use a
+   * doubly-linked list for performance, but I haven't measured it. */
+  memprof_thread_t next;
+};
+
+/* A memprof configuration is held in an object on the Caml
+ * heap. These are getter macros for each field. */
+
+#define Stopped(config)          Bool_val(Field(config, 0))
+#define Running(config)          ((config != Val_unit) && !Stopped(config))
+#define Lambda(config)           Double_val(Field(config, 1))
+#define One_log1m_lambda(config) Double_val(Field(config, 2))
+#define Callstack_size(config)   Int_val(Field(config, 3)
+#define Alloc_minor(config)      Field(config, 4)
+#define Alloc_major(config)      Field(config, 5)
+#define Promote(config)          Field(config, 6)
+#define Dealloc_minor(config)    Field(config, 7)
+#define Dealloc_major(config)    Field(config, 8)
+
+/* The 'stopped' field is the only one we ever update. */
+
+#define Set_stopped(config, flag) (Field(config, 0) = Val_bool(flag))
+
+/* Per-domain memprof state */
+
+struct memprof_domain_s {
+  /* The owning domain */
+  caml_domain_state *caml_state;
+
+  /* Linked list of threads in this domain */
+  memprof_thread_t threads;
+
+  /* The current thread's memprof state. Note that there may not be a
+     "current thread". TODO: maybe this shouldn't be nullable.
+     Nullability costs us some effort and may be meaningless. See call
+     site of caml_memprof_leave_thread() in st_stubs.c. */
+  memprof_thread_t current;
+
+  /* TODO: More fields to add here */
+
+  /* The current profiling configuration for this domain. */
+  value config;
+};
+
+/**** Create and destroy thread state structures ****/
+
+static memprof_thread_t thread_create(memprof_domain_t domain)
+{
+  memprof_thread_t thread = caml_stat_alloc(sizeof(memprof_thread_s));
+  if (!thread) {
+    return NULL;
+  }
+  thread->suspended = false;
+
+  /* attach to domain record */
+  thread->domain = domain;
+  thread->next = domain->threads;
+  domain->threads = thread;
+
+  return thread;
+}
+
+static void thread_destroy(memprof_thread_t thread)
+{
+  memprof_domain_t domain = thread->domain;
+
+  if (domain->current == thread) {
+    domain->current = NULL;
+  }
+  /* remove thread from the per-domain list. Could go faster if we
+   * used a doubly-linked list, but that's premature optimisation
+   * at this point. */
+  memprof_thread_t *p = &domain->threads;
+  while (*p != thread) {
+    p = &(*p)->next;
+  }
+
+  *p = thread->next;
+
+  caml_stat_free(thread);
+}
+
+/**** Create and destroy domain state structures ****/
+
+static void domain_destroy(memprof_domain_t domain)
+{
+  memprof_thread_t thread = domain->threads;
+  while (thread) {
+    memprof_thread_t next = thread->next;
+    thread_destroy(thread);
+    thread = next;
+  }
+
+  caml_stat_free(domain);
+}
+
+static memprof_domain_t domain_create(caml_domain_state *caml_state)
+{
+  memprof_domain_t domain = caml_stat_alloc(sizeof(memprof_domain_s));
+  if (!domain) {
+    return NULL;
+  }
+
+  domain->caml_state = caml_state;
+  domain->threads = NULL;
+  domain->current = NULL;
+  domain->config = Val_unit;
+
+  /* create initial thread for domain */
+  memprof_thread_t thread = thread_create(domain);
+  if (thread) {
+    domain->current = thread;
+  } else {
+    domain_destroy(domain);
+    domain = NULL;
+  }
+  return domain;
+}
+
+/**** Interface to domain module ***/
+
+void caml_memprof_new_domain(caml_domain_state *parent,
+                             caml_domain_state *child)
+{
+  memprof_domain_t domain = domain_create(child);
+
+  child->memprof = domain;
+  /* domain inherits configuration from parent */
+  if (domain && parent) {
+    domain->config = parent->memprof->config;
+  }
+}
+
+void caml_memprof_delete_domain(caml_domain_state *state)
+{
+  if (!state->memprof) {
+    return;
+  }
+  domain_destroy(state->memprof);
+  state->memprof = NULL;
+}
+
+/**** Interface with domain action-pending flag ****/
+
+/* If profiling is active in the current domain, and we may have some
+ * callbacks pending, set the action pending flag. */
+
+static void set_action_pending_as_needed(memprof_domain_t domain)
+{
+  /* if (condition) caml_set_action_pending(domain->caml_state); */
+}
+
+/* Set the suspended flag on `domain` to `s`. */
+
+static void update_suspended(memprof_domain_t domain, bool s)
+{
+  if (domain->current) {
+    domain->current->suspended = s;
+  }
+  caml_memprof_renew_minor_sample(domain->caml_state);
+  if (!s) set_action_pending_as_needed(domain);
+}
+
+/* Set the suspended flag on the current domain to `s`. */
+
+void caml_memprof_update_suspended(bool s) {
+  update_suspended(Caml_state->memprof, s);
+}
+
+/**** Sampling procedures ****/
+
+Caml_inline bool running(memprof_domain_t domain)
+{
+  memprof_thread_t thread = domain->current;
+
+  if (thread && !thread->suspended) {
+    value config = domain->config;
+    return Running(config);
+  }
+  return false;
+}
+
+/* Renew the next sample in a domain's minor heap. Could race with
+ * sampling and profile-stopping code, so do not call from another
+ * domain unless the world is stopped. Must be called after each minor
+ * sample and after each minor collection. In practice, this is called
+ * at each minor sample, at each minor collection, and when sampling
+ * is suspended and unsuspended. Extra calls do not change the
+ * statistical properties of the sampling because of the
+ * memorylessness of the geometric distribution. */
+
+void caml_memprof_renew_minor_sample(caml_domain_state *state)
+{
+  memprof_domain_t domain = state->memprof;
+  value *trigger = state->young_start;
+  if (running(domain)) {
+    /* set trigger based on geometric distribution */
+  }
+  CAMLassert((trigger >= state->young_start) &&
+             (trigger < state->young_ptr));
+  state->memprof_young_trigger = trigger;
+  caml_reset_young_limit(state);
+}
+
+/**** Interface with systhread. ****/
+
+CAMLexport memprof_thread_t caml_memprof_new_thread(caml_domain_state *state)
+{
+  return thread_create(state->memprof);
+}
+
+CAMLexport memprof_thread_t caml_memprof_main_thread(caml_domain_state *state)
+{
+  memprof_domain_t domain = state->memprof;
+  memprof_thread_t thread = domain->threads;
+
+  /* There should currently be just one thread in this domain */
+  CAMLassert(thread);
+  CAMLassert(thread->next == NULL);
+  return thread;
+}
+
+CAMLexport void caml_memprof_delete_thread(memprof_thread_t thread)
+{
+  thread_destroy(thread);
+}
+
+CAMLexport void caml_memprof_enter_thread(memprof_thread_t thread)
+{
+  thread->domain->current = thread;
+  update_suspended(thread->domain, thread->suspended);
+}
+
+/**** Interface to OCaml ****/
+
 #include "caml/fail.h"
 
 CAMLprim value caml_memprof_start(value lv, value szv, value tracker_param)
@@ -575,13 +832,6 @@ static void check_action_pending(void)
     caml_set_action_pending(Caml_state);
 }
 
-void caml_memprof_set_suspended(int s)
-{
-  local->suspended = s;
-  caml_memprof_renew_minor_sample();
-  if (!s) check_action_pending();
-}
-
 /* In case of a thread context switch during a callback, this can be
    called in a reetrant way. */
 value caml_memprof_handle_postponed_exn(void)
@@ -809,29 +1059,6 @@ static void shift_sample(uintnat n)
     caml_memprof_young_trigger -= n;
   else
     caml_memprof_young_trigger = Caml_state->young_alloc_start;
-  caml_reset_young_limit(Caml_state);
-}
-
-/* Renew the next sample in the minor heap. This needs to be called
-   after each minor sampling and after each minor collection. In
-   practice, this is called at each sampling in the minor heap and at
-   each minor collection. Extra calls do not change the statistical
-   properties of the sampling because of the memorylessness of the
-   geometric distribution. */
-void caml_memprof_renew_minor_sample(void)
-{
-  if (lambda == 0 || local->suspended)
-    /* No trigger in the current minor heap. */
-    caml_memprof_young_trigger = Caml_state->young_alloc_start;
-  else {
-    uintnat geom = rand_geom();
-    if (Caml_state->young_ptr - Caml_state->young_alloc_start < geom)
-      /* No trigger in the current minor heap. */
-      caml_memprof_young_trigger = Caml_state->young_alloc_start;
-    else
-      caml_memprof_young_trigger = Caml_state->young_ptr - (geom - 1);
-  }
-
   caml_reset_young_limit(Caml_state);
 }
 
@@ -1073,14 +1300,6 @@ static void empty_entry_array(struct entry_array *ea) {
     ea->t = NULL;
   }
 }
-
-static void th_ctx_memprof_stop(struct caml_memprof_th_ctx* ctx, void* data)
-{
-  (void)data;
-  if (ctx->callback_status != CB_IDLE) ctx->callback_status = CB_STOPPED;
-  empty_entry_array(&ctx->entries);
-}
-
 CAMLprim value caml_memprof_stop(value unit)
 {
   if (!started) caml_failwith("Gc.Memprof.stop: not started.");
@@ -1107,51 +1326,6 @@ CAMLprim value caml_memprof_stop(value unit)
   callstack_buffer_len = 0;
 
   return Val_unit;
-}
-
-/**** Interface with systhread. ****/
-
-static void th_ctx_iter_default(th_ctx_action f, void* data) {
-  f(local, data);
-}
-
-CAMLexport void (*caml_memprof_th_ctx_iter_hook)(th_ctx_action, void*)
-  = th_ctx_iter_default;
-
-CAMLexport struct caml_memprof_th_ctx* caml_memprof_new_th_ctx()
-{
-  struct caml_memprof_th_ctx* ctx =
-    caml_stat_alloc(sizeof(struct caml_memprof_th_ctx));
-  ctx->suspended = 0;
-  ctx->callback_status = CB_IDLE;
-  ctx->entries.t = NULL;
-  ctx->entries.min_alloc_len = MIN_ENTRIES_LOCAL_ALLOC_LEN;
-  ctx->entries.alloc_len = ctx->entries.len = 0;
-  ctx->entries.young_idx = ctx->entries.delete_idx = 0;
-  return ctx;
-}
-
-CAMLexport void caml_memprof_delete_th_ctx(struct caml_memprof_th_ctx* ctx)
-{
-  if (ctx->callback_status >= 0)
-    /* A callback is running in this thread from the global entries
-       array. We delete the corresponding entry. */
-    mark_deleted(&entries_global, ctx->callback_status);
-  if (ctx == local) local = NULL;
-  caml_stat_free(ctx->entries.t);
-  if (ctx != &caml_memprof_main_ctx) caml_stat_free(ctx);
-}
-
-CAMLexport void caml_memprof_leave_thread(void)
-{
-  local = NULL;
-}
-
-CAMLexport void caml_memprof_enter_thread(struct caml_memprof_th_ctx* ctx)
-{
-  CAMLassert(local == NULL);
-  local = ctx;
-  caml_memprof_set_suspended(ctx->suspended);
 }
 
 #endif

--- a/runtime/printexc.c
+++ b/runtime/printexc.c
@@ -17,6 +17,7 @@
 
 /* Print an uncaught exception and abort */
 
+#include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -142,6 +143,12 @@ void caml_fatal_uncaught_exception(value exn)
 
   handle_uncaught_exception =
     caml_named_value("Printexc.handle_uncaught_exception");
+
+  /* If the callback allocates, memprof could be called, in which case
+     a memprof callback could raise an exception while
+     [handle_uncaught_exception] is running, and the printing of
+     the exception could fail. */
+  caml_memprof_update_suspended(true);
 
   if (handle_uncaught_exception != NULL)
     /* [Printexc.handle_uncaught_exception] does not raise exception. */


### PR DESCRIPTION
Statmemprof needs per-thread and per-domain data structures, and calls from the thread and domain modules to create and destroy them. This small PR adds skeleton structures and calls, without enabling statmemprof.

I am breaking the large statmemprof PR (#12379) into a number of small separate ones, some of which are wholly independent. This is one such.