### PR TITLE
Improve backtrace abstractions inside runtime

### DIFF
--- a/Changes
+++ b/Changes
@@ -186,6 +186,10 @@ Working version
 - #11911, #12383: Restore statmemprof functionality in part
    (backtrace buffers). (Nick Barnes, review by Gabriel Scherer)
 
+- #11911, #12383: Restore statmemprof functionality in part (backtrace
+   buffers). (Nick Barnes, review by Gabriel Scherer and Fabrice
+   Buoro).
+
 ### Code generation and optimizations:
 
 - #11239: on x86-64 and RISC-V, reduce alignment of OCaml stacks from 16 to 8.

--- a/Changes
+++ b/Changes
@@ -183,6 +183,9 @@ Working version
   (David Allsopp, Antonin Décimo, and Samuel Hym, review by Nicolas
    Ojeda Bar)
 
+- #11911, #12383: Restore statmemprof functionality in part
+   (backtrace buffers). (Nick Barnes, review by Gabriel Scherer)
+
 ### Code generation and optimizations:
 
 - #11239: on x86-64 and RISC-V, reduce alignment of OCaml stacks from 16 to 8.

--- a/runtime/backtrace_byt.c
+++ b/runtime/backtrace_byt.c
@@ -380,6 +380,29 @@ static value alloc_callstack(backtrace_slot *trace, size_t slots)
   CAMLreturn(callstack);
 }
 
+/* Obtain up to [max_slots] of the callstack of the current domain,
+ * including parent fibers. The callstack is written into [*buffer_p],
+ * current size [*alloc_size_p], which should be reallocated (on the C
+ * heap) if required. Returns the number of slots obtained.
+ *
+ * [alloc_idx] is ignored, and must be negative (this interface is
+ * also used by the native-code runtime, in which [alloc_idx] is
+ * meaningful.
+ */
+
+size_t caml_get_callstack(size_t max_slots,
+                          backtrace_slot **buffer_p,
+                          size_t *alloc_size_p,
+                          ssize_t alloc_idx)
+{
+  CAMLassert(alloc_idx < 1); /* allocation indexes not used in bytecode */
+  return get_callstack(Caml_state->current_stack->sp,
+                       Caml_state->trap_sp_off,
+                       Caml_state->current_stack,
+                       max_slots,
+                       buffer_p, alloc_size_p);
+}
+
 CAMLprim value caml_get_current_callstack (value max_frames_value)
 {
   backtrace_slot *backtrace = NULL;

--- a/runtime/backtrace_nat.c
+++ b/runtime/backtrace_nat.c
@@ -192,6 +192,26 @@ static size_t get_callstack(struct stack_info* stack, intnat max_slots,
   return slots;
 }
 
+/* Obtain up to [max_slots] of the callstack of the current domain,
+ * including parent fibers. The callstack is written into [*buffer_p],
+ * current size [*alloc_size_p], which should be reallocated (on the C
+ * heap) if required. Returns the number of slots obtained.
+ *
+ * If [alloc_idx] is non-negative, then the backtrace is of an
+ * allocation point and may therefore include an initial entry of the
+ * allocation point itself.
+ */
+
+size_t caml_get_callstack(size_t max_slots,
+                          backtrace_slot **buffer_p,
+                          size_t *alloc_size_p,
+                          ssize_t alloc_idx)
+{
+  return get_callstack(Caml_state->current_stack, max_slots,
+                       alloc_idx,
+                       buffer_p, alloc_size_p);
+}
+
 static value alloc_callstack(backtrace_slot* trace, size_t slots)
 {
   CAMLparam0();

--- a/runtime/backtrace_nat.c
+++ b/runtime/backtrace_nat.c
@@ -95,7 +95,11 @@ static debuginfo debuginfo_extract(frame_descr *d, ssize_t alloc_idx);
    it is called at each [raise] in a program compiled with [-g], so we
    preserved the global, statically bounded buffer of the old
    implementation -- before the more flexible
-   [caml_get_current_callstack] was implemented. */
+   [caml_get_current_callstack] was implemented.
+
+   TODO: Consider rewriting this to use get_callstack, so we only have
+   one body of code capturing callstacks.
+*/
 void caml_stash_backtrace(value exn, uintnat pc, char * sp, char* trapsp)
 {
   caml_domain_state* domain_state = Caml_state;
@@ -127,110 +131,115 @@ void caml_stash_backtrace(value exn, uintnat pc, char * sp, char* trapsp)
   }
 }
 
-/* Stores upto [max_frames_value] frames of the current call stack to
-   return to the user. This is used not in an exception-raising
-   context, but only when the user requests to save the trace
-   (hopefully less often). Instead of using a bounded buffer as
-   [caml_stash_backtrace], we first traverse the stack to compute the
-   right size, then allocate space for the trace. */
-static void get_callstack(struct stack_info* orig_stack, intnat max_frames,
-                          backtrace_slot** trace, intnat* trace_size,
-                          ssize_t alloc_idx)
+/* minimum size to allocate a backtrace (in slots) */
+#define MIN_BACKTRACE_SIZE 16
+
+/* Stores up to [max_slots] backtrace slots of the current call stack to
+   return to the user in [*backtrace_p] (with the allocated size in
+   [*alloc_size_p]). Returns the number of frames stored. Instead of
+   using a bounded buffer as [caml_stash_backtrace], we dynamically
+   grow the allocated space as required. */
+static size_t get_callstack(struct stack_info* stack, intnat max_slots,
+                            ssize_t alloc_idx,
+                            backtrace_slot **backtrace_p,
+                            size_t *alloc_size_p)
 {
-  intnat trace_pos;
+  backtrace_slot *backtrace = *backtrace_p;
+  size_t alloc_size = *alloc_size_p;
+  size_t slots = 0;
   char *sp;
   uintnat pc;
-  caml_frame_descrs fds;
+  caml_frame_descrs fds = caml_get_frame_descrs();
   CAMLnoalloc;
 
-  fds = caml_get_frame_descrs();
+  caml_get_stack_sp_pc(stack, &sp, &pc);
 
-  /* first compute the size of the trace */
-  {
-    struct stack_info* stack = orig_stack;
-    caml_get_stack_sp_pc(stack, &sp, &pc);
-    trace_pos = 0;
+  while (slots < max_slots) {
+    frame_descr *descr = caml_next_frame_descriptor(fds, &pc, &sp, stack);
+    if (!descr) {
+      stack = Stack_parent(stack);
+      if (!stack) break;
+      caml_get_stack_sp_pc(stack, &sp, &pc);
+    } else {
+      if (slots == alloc_size) {
+        size_t new_size = alloc_size ? alloc_size * 2 : MIN_BACKTRACE_SIZE;
+        backtrace = caml_stat_resize_noexc(backtrace,
+                                           sizeof(backtrace_slot) * new_size);
 
-    while(1) {
-      frame_descr *descr = caml_next_frame_descriptor(fds, &pc, &sp, stack);
-      if (trace_pos >= max_frames) break;
-      if (descr == NULL) {
-        stack = Stack_parent(stack);
-        if (stack == NULL) break;
-        caml_get_stack_sp_pc(stack, &sp, &pc);
-      } else {
-        ++trace_pos;
-      }
-    }
-  }
-
-  *trace_size = trace_pos;
-  *trace = caml_stat_alloc(sizeof(backtrace_slot) * trace_pos);
-
-  /* then collect the trace */
-  {
-    struct stack_info* stack = orig_stack;
-    caml_get_stack_sp_pc(stack, &sp, &pc);
-    trace_pos = 0;
-
-    while (trace_pos < max_frames) {
-      frame_descr *descr = caml_next_frame_descriptor(fds, &pc, &sp, stack);
-      if (descr == NULL) {
-        stack = Stack_parent(stack);
-        if (stack == NULL) break;
-        caml_get_stack_sp_pc(stack, &sp, &pc);
-      } else {
-        backtrace_slot slot = Slot_frame_descr(descr);
-        if (alloc_idx >= 0) {
-          debuginfo info = debuginfo_extract(descr, alloc_idx);
-          if (info) {
-            CAMLassert(((uintnat)info & 3) == 0); /* so we can tag it */
-            slot = Slot_debuginfo(info);
-          }
-          alloc_idx = -1;
+        if (!backtrace) { /* allocation failed */
+          *backtrace_p = NULL;
+          *alloc_size_p = 0;
+          return 0;
         }
-        (*trace)[trace_pos] = slot;
-        ++trace_pos;
+        alloc_size = new_size;
       }
+
+      backtrace_slot slot = Slot_frame_descr(descr);
+      if (alloc_idx >= 0) {
+        debuginfo info = debuginfo_extract(descr, alloc_idx);
+        if (info) {
+          CAMLassert(((uintnat)info & 3) == 0); /* so we can tag it */
+          slot = Slot_debuginfo(info);
+        }
+        alloc_idx = -1;
+      }
+      backtrace[slots++] = slot;
     }
   }
+
+  *alloc_size_p = alloc_size;
+  *backtrace_p = backtrace;
+  return slots;
 }
 
-static value alloc_callstack(backtrace_slot* trace, intnat trace_len)
+static value alloc_callstack(backtrace_slot* trace, size_t slots)
 {
   CAMLparam0();
   CAMLlocal1(callstack);
   int i;
-  callstack = caml_alloc(trace_len, 0);
-  for (i = 0; i < trace_len; i++)
+  callstack = caml_alloc(slots, 0);
+  for (i = 0; i < slots; i++)
     Store_field(callstack, i, Val_backtrace_slot(trace[i]));
   caml_stat_free(trace);
   CAMLreturn(callstack);
 }
 
-CAMLprim value caml_get_current_callstack (value max_frames_value) {
-  backtrace_slot *trace;
-  intnat trace_len;
-  get_callstack(Caml_state->current_stack, Long_val(max_frames_value),
-                &trace, &trace_len, -1);
-  return alloc_callstack(trace, trace_len);
+/* Create and return a [Printexc.raw_backtrace] of the current
+ * callstack, of up to [max_frames_value] entries. Includes parent
+ * fibers.
+ */
+
+CAMLprim value caml_get_current_callstack (value max_frames_value)
+{
+  backtrace_slot *trace = NULL;
+  size_t trace_size = 0;
+  size_t slots = get_callstack(Caml_state->current_stack,
+                               Long_val(max_frames_value),
+                               -1, &trace, &trace_size);
+  return alloc_callstack(trace, slots);
 }
+
+/* Create and return a [Printexc.raw_backtrace] of the callstack of
+ * the continuation [cont], of up to [max_frames_value]
+ * entries. Includes parent fibers.
+ */
 
 CAMLprim value caml_get_continuation_callstack (value cont, value max_frames)
 {
-  backtrace_slot *trace;
-  intnat trace_len;
+  backtrace_slot *trace = NULL;
+  size_t trace_size = 0;
+  size_t slots;
   struct stack_info* stack;
 
   stack = Ptr_val(caml_continuation_use(cont));
   {
     CAMLnoalloc;
-    get_callstack(stack, max_frames,
-                  &trace, &trace_len, -1);
+    slots = get_callstack(stack, max_frames, -1,
+                          &trace, &trace_size);
     caml_continuation_replace(cont, stack);
   }
 
-  return alloc_callstack(trace, trace_len);
+  return alloc_callstack(trace, slots);
 }
 
 static debuginfo debuginfo_extract(frame_descr *d, ssize_t alloc_idx)

--- a/runtime/caml/backtrace.h
+++ b/runtime/caml/backtrace.h
@@ -114,6 +114,21 @@ extern void caml_stash_backtrace(value exn, value * sp, int reraise);
 CAMLextern void caml_load_main_debug_info(void);
 #endif
 
+/* Obtain up to [max_slots] of the callstack of the current domain,
+ * including parent fibers. The callstack is written into [*buffer_p],
+ * current size [*alloc_size_p], which should be reallocated (on the C
+ * heap) if required. Returns the number of slots obtained.
+ *
+ * If [alloc_idx] is non-negative, then the backtrace is of an
+ * allocation point and may therefore include an initial entry of the
+ * allocation point itself.
+ */
+
+extern size_t caml_get_callstack(size_t max_slots,
+                                 backtrace_slot **buffer_p,
+                                 size_t *alloc_size_p,
+                                 ssize_t alloc_idx);
+
 
 /* Default (C-level) printer for backtraces.  It is called if an
  * exception causes a termination of the program or of a thread.

--- a/runtime/caml/frame_descriptors.h
+++ b/runtime/caml/frame_descriptors.h
@@ -149,7 +149,9 @@ caml_frame_descrs caml_get_frame_descrs(void);
 frame_descr* caml_find_frame_descr(caml_frame_descrs fds, uintnat pc);
 
 
-frame_descr * caml_next_frame_descriptor
+/* Returns the next frame descriptor (or NULL if none is available),
+   and updates *pc and *sp to point to the following one.  */
+frame_descr *caml_next_frame_descriptor
     (caml_frame_descrs fds, uintnat * pc, char ** sp, struct stack_info* stack);
 
 #endif /* CAML_INTERNALS */


### PR DESCRIPTION
In the trunk runtime, the backtrace API allows backtraces to be obtained either as (a) a single per-domain buffer, reserved for the "backtrace at the last exception raise", or (b) an object on the Caml heap, reflecting the current backtrace. This is insufficient for statmemprof, which needs the current backtrace at arbitrary allocation points, when Caml heap allocation might not be possible (or might change the backtrace, by garbage collection). So this branch changes the `backtrace.h` abstraction by adding `caml_get_callstack()`.

I took the opportunity to also improve the code which actually iterates over the stack gathering backtrace entries—in each runtime (native-code and bytecode) there's now a single piece of code which does this, and it only iterates over the stack once. This key function (`get_callstack()` in both `backtrace_nat.c` and `backtrace_byt.c`) has a rather ugly ("candy machine") interface, because it turns out that the semantics of this are pretty twisty, depending for instance on whether the callstack should trace up into parent stack fibers or just to the current fiber, which depends (in the native-code runtime) on exactly why we want a backtrace. I'm not sure the current semantics are all that great but I believe I've preserved them.

I was tempted to improve the abstraction further, by making a new type (`callstack_t`) of C-heap-allocated backtrace objects which have slots for some metadata such as frame count (number of live entries) and size (for re-sizing), and support a small number of operations. That would allow this code to be further improved, removing some duplicated code in each runtime and also moving some source code from `backtrace_nat.c` and `backtrace_byt.c` into `backtrace.c`. However, I've deferred that for now.

This is one of a number of small PRs working towards restoring statmemprof on trunk. The large (unmergeable) PR #12379 shows where these are heading.