### PR TITLE
Specialized error message for syntactic function arity type clash

### DIFF
--- a/Changes
+++ b/Changes
@@ -178,7 +178,7 @@ Working version
   in Typecore in favor of local mutable state.
   (Nick Roberts, review by Takafumi Saikawa)
 
-- #12236: Use syntax as the sole determiner of function arity
+- #12236, #12386: Use syntax as the sole determiner of function arity
   This changes function arity to be based solely on the source program's
   parsetree. Previously, the heuristic for arity had more subtle heuristics
   that involved type information about patterns.  Function arity is important

--- a/testsuite/tests/typing-gadts/syntactic-arity.ml
+++ b/testsuite/tests/typing-gadts/syntactic-arity.ml
@@ -51,7 +51,7 @@ Error: The syntactic arity of the function doesn't match the type constraint:
        This function has 3 syntactic arguments, but its type is constrained
          to "?opt:(a, int -> int) eq -> unit -> a".
        Hint: consider splitting up the function's syntactic arity by
-       inserting " -> fun " after the argument that introduces the local
+       inserting "-> fun" after the argument that introduces the local
        type equation.
 |}];;
 
@@ -118,7 +118,7 @@ Error: The syntactic arity of the function doesn't match the type constraint:
        This function has 2 syntactic arguments, but its type is constrained
          to "(a, int -> int) eq_or_not -> a".
        Hint: consider splitting up the function's syntactic arity by
-       inserting " -> fun " after the argument that introduces the local
+       inserting "-> fun" after the argument that introduces the local
        type equation.
 |}];;
 
@@ -144,7 +144,7 @@ Error: The syntactic arity of the function doesn't match the type constraint:
        This function has 2 syntactic arguments, but its type is constrained
          to "(a, int -> int) eq lazy_t -> a".
        Hint: consider splitting up the function's syntactic arity by
-       inserting " -> fun " after the argument that introduces the local
+       inserting "-> fun" after the argument that introduces the local
        type equation.
 |}];;
 
@@ -164,6 +164,6 @@ Error: The syntactic arity of the function doesn't match the type constraint:
        This function has 2 syntactic arguments, but its type is constrained
          to "(a, int -> int) eq -> a".
        Hint: consider splitting up the function's syntactic arity by
-       inserting " -> fun " after the argument that introduces the local
+       inserting "-> fun" after the argument that introduces the local
        type equation.
 |}];;

--- a/testsuite/tests/typing-gadts/syntactic-arity.ml
+++ b/testsuite/tests/typing-gadts/syntactic-arity.ml
@@ -46,13 +46,12 @@ Line 2, characters 2-67:
 2 |   fun ?opt:((Eq : (a, int -> int) eq) = assert false) () x -> x + 1;;
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The syntactic arity of the function doesn't match the type constraint:
-       Syntactic function arity must agree with (i.e., must be less than or
-       equal to) function type arity without using local type equations.
-       This function has 3 syntactic arguments, but its type is constrained
-         to "?opt:(a, int -> int) eq -> unit -> a".
-       Hint: consider splitting up the function's syntactic arity by
-       inserting "-> fun" after the argument that introduces the local
-       type equation.
+       This function has 3 syntactic arguments, but its type is constrained to
+         "?opt:(a, int -> int) eq -> unit -> a".
+        Hint: consider splitting the function definition into
+          "fun ... gadt_pat -> fun ..."
+          where "gadt_pat" is the pattern with the GADT constructor that
+          introduces the local type equation on "a".
 |}];;
 
 (* Workaround 1: no GADT in default argument pattern *)
@@ -113,13 +112,12 @@ Line 2, characters 2-49:
 2 |   fun (Eq : (a, int -> int) eq_or_not) x -> x + 1;;
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The syntactic arity of the function doesn't match the type constraint:
-       Syntactic function arity must agree with (i.e., must be less than or
-       equal to) function type arity without using local type equations.
-       This function has 2 syntactic arguments, but its type is constrained
-         to "(a, int -> int) eq_or_not -> a".
-       Hint: consider splitting up the function's syntactic arity by
-       inserting "-> fun" after the argument that introduces the local
-       type equation.
+       This function has 2 syntactic arguments, but its type is constrained to
+         "(a, int -> int) eq_or_not -> a".
+        Hint: consider splitting the function definition into
+          "fun ... gadt_pat -> fun ..."
+          where "gadt_pat" is the pattern with the GADT constructor that
+          introduces the local type equation on "a".
 |}];;
 
 
@@ -139,13 +137,12 @@ Line 2, characters 2-26:
 2 |   fun (lazy Eq) x -> x + 1
       ^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The syntactic arity of the function doesn't match the type constraint:
-       Syntactic function arity must agree with (i.e., must be less than or
-       equal to) function type arity without using local type equations.
-       This function has 2 syntactic arguments, but its type is constrained
-         to "(a, int -> int) eq lazy_t -> a".
-       Hint: consider splitting up the function's syntactic arity by
-       inserting "-> fun" after the argument that introduces the local
-       type equation.
+       This function has 2 syntactic arguments, but its type is constrained to
+         "(a, int -> int) eq lazy_t -> a".
+        Hint: consider splitting the function definition into
+          "fun ... gadt_pat -> fun ..."
+          where "gadt_pat" is the pattern with the GADT constructor that
+          introduces the local type equation on "a".
 |}];;
 
 
@@ -159,11 +156,10 @@ Line 2, characters 2-15:
 2 |   fun Eq x -> x
       ^^^^^^^^^^^^^
 Error: The syntactic arity of the function doesn't match the type constraint:
-       Syntactic function arity must agree with (i.e., must be less than or
-       equal to) function type arity without using local type equations.
-       This function has 2 syntactic arguments, but its type is constrained
-         to "(a, int -> int) eq -> a".
-       Hint: consider splitting up the function's syntactic arity by
-       inserting "-> fun" after the argument that introduces the local
-       type equation.
+       This function has 2 syntactic arguments, but its type is constrained to
+         "(a, int -> int) eq -> a".
+        Hint: consider splitting the function definition into
+          "fun ... gadt_pat -> fun ..."
+          where "gadt_pat" is the pattern with the GADT constructor that
+          introduces the local type equation on "a".
 |}];;

--- a/testsuite/tests/typing-gadts/syntactic-arity.ml
+++ b/testsuite/tests/typing-gadts/syntactic-arity.ml
@@ -45,10 +45,14 @@ let bad : type a. ?opt:(a, int -> int) eq -> unit -> a =
 Line 2, characters 2-67:
 2 |   fun ?opt:((Eq : (a, int -> int) eq) = assert false) () x -> x + 1;;
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This expression has type "?opt:(a, int -> int) eq -> unit -> 'a -> 'b"
-       but an expression was expected of type
-         "?opt:(a, int -> int) eq -> unit -> a"
-       Type "'a -> 'b" is not compatible with type "a"
+Error: The syntactic arity of the function doesn't match the type constraint:
+       Syntactic function arity must agree with (i.e., must be less than or
+       equal to) function type arity without using local type equations.
+       This function has 3 syntactic arguments, but its type is constrained
+         to "?opt:(a, int -> int) eq -> unit -> a".
+       Hint: consider splitting up the function's syntactic arity by
+       inserting " -> fun " after the argument that introduces the local
+       type equation.
 |}];;
 
 (* Workaround 1: no GADT in default argument pattern *)
@@ -108,9 +112,14 @@ Neq
 Line 2, characters 2-49:
 2 |   fun (Eq : (a, int -> int) eq_or_not) x -> x + 1;;
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This expression has type "(a, int -> int) eq_or_not -> 'a -> 'b"
-       but an expression was expected of type "(a, int -> int) eq_or_not -> a"
-       Type "'a -> 'b" is not compatible with type "a"
+Error: The syntactic arity of the function doesn't match the type constraint:
+       Syntactic function arity must agree with (i.e., must be less than or
+       equal to) function type arity without using local type equations.
+       This function has 2 syntactic arguments, but its type is constrained
+         to "(a, int -> int) eq_or_not -> a".
+       Hint: consider splitting up the function's syntactic arity by
+       inserting " -> fun " after the argument that introduces the local
+       type equation.
 |}];;
 
 
@@ -129,9 +138,14 @@ let bad : type a. (a, int -> int) eq lazy_t -> a =
 Line 2, characters 2-26:
 2 |   fun (lazy Eq) x -> x + 1
       ^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This expression has type "(a, int -> int) eq lazy_t -> 'a -> 'b"
-       but an expression was expected of type "(a, int -> int) eq lazy_t -> a"
-       Type "'a -> 'b" is not compatible with type "a"
+Error: The syntactic arity of the function doesn't match the type constraint:
+       Syntactic function arity must agree with (i.e., must be less than or
+       equal to) function type arity without using local type equations.
+       This function has 2 syntactic arguments, but its type is constrained
+         to "(a, int -> int) eq lazy_t -> a".
+       Hint: consider splitting up the function's syntactic arity by
+       inserting " -> fun " after the argument that introduces the local
+       type equation.
 |}];;
 
 
@@ -144,7 +158,12 @@ let spurious : type a. (a, int -> int) eq -> a =
 Line 2, characters 2-15:
 2 |   fun Eq x -> x
       ^^^^^^^^^^^^^
-Error: This expression has type "(a, int -> int) eq -> 'a -> 'b"
-       but an expression was expected of type "(a, int -> int) eq -> a"
-       Type "'a -> 'b" is not compatible with type "a"
+Error: The syntactic arity of the function doesn't match the type constraint:
+       Syntactic function arity must agree with (i.e., must be less than or
+       equal to) function type arity without using local type equations.
+       This function has 2 syntactic arguments, but its type is constrained
+         to "(a, int -> int) eq -> a".
+       Hint: consider splitting up the function's syntactic arity by
+       inserting " -> fun " after the argument that introduces the local
+       type equation.
 |}];;

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -6478,12 +6478,13 @@ let report_error ~loc env = function
        @]@ \
        @[@{<hint>Hint@}: \
        consider splitting up the function's syntactic arity by@ \
-       inserting \" -> fun \" after the argument that introduces the local@ \
+       inserting %a after the argument that introduces the local@ \
        type equation.\
        @]\
        @]"
       syntactic_arity
       (Style.as_inline_code Printtyp.type_expr) type_constraint
+      Style.inline_code "-> fun"
   | Apply_non_function {
       funct; func_ty; res_ty; previous_arg_loc; extra_arg_loc
     } ->

--- a/typing/typecore.mli
+++ b/typing/typecore.mli
@@ -154,6 +154,10 @@ type error =
   | Expr_type_clash of
       Errortrace.unification_error * type_forcing_context option
       * Parsetree.expression_desc option
+  | Function_arity_type_clash of
+      { syntactic_arity :  int;
+        type_constraint : type_expr;
+      }
   | Apply_non_function of {
       funct : Typedtree.expression;
       func_ty : type_expr;

--- a/typing/typecore.mli
+++ b/typing/typecore.mli
@@ -157,6 +157,7 @@ type error =
   | Function_arity_type_clash of
       { syntactic_arity :  int;
         type_constraint : type_expr;
+        trace : Errortrace.unification_error;
       }
   | Apply_non_function of {
       funct : Typedtree.expression;


### PR DESCRIPTION
This continues a discussion with @Octachron from #12236. The topic is what error message to generate in a case of typing backward-incompatibility. Here's an example of such a case:

```ocaml
type (_, _) eq = Eq : ('a, 'a) eq
let f : type a. (a, int -> int) eq -> a =
  fun Eq x -> x 
```
As of #12236, the error message is a generic-looking unification error:

```
Error: This expression has type "(a, int -> int) eq -> 'a -> 'b"
       but an expression was expected of type "(a, int -> int) eq -> a"
       Type "'a -> 'b" is not compatible with type "a"
```

We thought we should do better to explain the problem, especially given that the change to typing is backward-incompatible. I'm making this PR to summarize the ideas so far, suggest a wording, and solicit further refinements/ideas.

---

**(A) First try from original PR that we decided against:**
```
3 |   fun Eq x -> x
      ^^^^^^^^^^^^^
Error: The type of a function with 2 arguments must have at least 2 arrows.
       This expression has type "(a, int -> int) eq -> 'a -> 'b"
       but an expression was expected of type "(a, int -> int) eq -> a"
       Type "'a -> 'b" is not compatible with type "a"
```

Some remarks that @Octachron made:
  * The criteria is not actually syntactic on types, despite the error message's claim to the contrary, since having a type `(int -> int -> int as 'a) ->'a` is fine.
  * The type `(a, int -> int) eq -> 'a -> 'b` is potentially confusing to include in the output. It doesn't match any type written by the user, so they may struggle to connect it to the main point of the error message.

**(B)** @Octachron **'s suggestion that focuses on syntactic arity:**
```
3 |   fun Eq x -> x
      ^^^^^^^^^^^^^
Error: The syntactic arity of the function doesn't match the type constraint:
       syntactic function arity and function type arity must agree without relying
       on local type equations.
       This function has two syntactic arguments, but its type is constrained to 
       "(a,int->int) eq -> a".
```

**(C) Current draft:**
```
3 |   fun Eq x -> x
      ^^^^^^^^^^^^^
Error: The syntactic arity of the function doesn't match the type constraint:
       Syntactic function arity must agree with (i.e., must be less than or
       equal to) function type arity without using local type equations.
       This function has 2 syntactic arguments, but its type is constrained
         to "(a, int -> int) eq -> a".
       Hint: consider splitting up the function's syntactic arity by
       inserting "-> fun" after the argument that introduces the local
       type equation.
```
This latest version:
  * clarifies what it means for syntactic function arity to "agree" with the function type arity. (It's not just that they are equal, as the function type can have more arrows than the function has syntactic arguments without any issue.)
  * attempts to suggest a fix.

This fix is meant to guide the user to this program, which type-checks:
```ocaml
type (_, _) eq = Eq : ('a, 'a) eq
let f : type a. (a, int -> int) eq -> a =
  fun Eq -> fun x -> x 
```

Here are a few areas of discussion that immediately come to mind:
  * In the hint, we could generate a list of candidate parameters with GADT patterns, as these are the only ones that could have introduced local type equations.
  * It doesn’t seem great to say “insert `-> fun`” as the grammatical object is a snippet of text, not a sensible AST. But maybe it is still a good way to guide the user to a type-checking program.