### PR TITLE
Clarify a C example in the manual

### DIFF
--- a/manual/src/cmds/intf-c.etex
+++ b/manual/src/cmds/intf-c.etex
@@ -953,11 +953,19 @@ variables "caml__dummy_xxx" at each use of "CAMLparam" and
 
 Example:
 \begin{verbatim}
-void foo (value v1, value v2, value v3)
+static void helper (value v1, value v2, value v3)
 {
   CAMLparam3 (v1, v2, v3);
   ...
   CAMLreturn0;
+}
+
+CAMLprim value foo (value v1, value v2, value v3)
+{
+  CAMLparam3 (v1, v2, v3);
+  helper(v1, v2, v3);
+  ...
+  CAMLreturn (Val_unit);
 }
 \end{verbatim}
 


### PR DESCRIPTION
There is an example in the "Interfacing with C" section of the manual of using the `CAMLxxx` macros in a C function returning `void`. I've seen several people misread this section and end up believing that it is OK to write C externals that return `void` instead of doing `CAMLreturn (Val_unit)`.

This is a tricky mistake to catch: neither OCaml nor C will warn about it, and it will mostly work fine, except in obscure scenarios where it can segfault.

This patch changes the example to make it a bit clearer what is being demonstrated: an unexported helper function that happens to return `void`, used from a C external that correctly returns `value`.