### PR TITLE
Unified metadata for compilation files (or no more capitalize_ascii) 

### DIFF
--- a/.depend
+++ b/.depend
@@ -480,6 +480,21 @@ parsing/syntaxerr.cmx : \
     parsing/syntaxerr.cmi
 parsing/syntaxerr.cmi : \
     parsing/location.cmi
+parsing/unit_info.cmo : \
+    utils/warnings.cmi \
+    utils/misc.cmi \
+    parsing/location.cmi \
+    utils/load_path.cmi \
+    utils/config.cmi \
+    parsing/unit_info.cmi
+parsing/unit_info.cmx : \
+    utils/warnings.cmx \
+    utils/misc.cmx \
+    parsing/location.cmx \
+    utils/load_path.cmx \
+    utils/config.cmx \
+    parsing/unit_info.cmi
+parsing/unit_info.cmi :
 typing/annot.cmi : \
     parsing/location.cmi
 typing/btype.cmo : \

--- a/.depend
+++ b/.depend
@@ -614,6 +614,7 @@ typing/datarepr.cmi : \
     typing/ident.cmi
 typing/env.cmo : \
     utils/warnings.cmi \
+    parsing/unit_info.cmi \
     typing/types.cmi \
     typing/subst.cmi \
     typing/shape.cmi \
@@ -636,6 +637,7 @@ typing/env.cmo : \
     typing/env.cmi
 typing/env.cmx : \
     utils/warnings.cmx \
+    parsing/unit_info.cmx \
     typing/types.cmx \
     typing/subst.cmx \
     typing/shape.cmx \
@@ -658,6 +660,7 @@ typing/env.cmx : \
     typing/env.cmi
 typing/env.cmi : \
     utils/warnings.cmi \
+    parsing/unit_info.cmi \
     typing/types.cmi \
     typing/subst.cmi \
     typing/shape.cmi \
@@ -1008,6 +1011,7 @@ typing/patterns.cmi : \
     parsing/asttypes.cmi
 typing/persistent_env.cmo : \
     utils/warnings.cmi \
+    parsing/unit_info.cmi \
     utils/misc.cmi \
     parsing/location.cmi \
     utils/load_path.cmi \
@@ -1018,6 +1022,7 @@ typing/persistent_env.cmo : \
     typing/persistent_env.cmi
 typing/persistent_env.cmx : \
     utils/warnings.cmx \
+    parsing/unit_info.cmx \
     utils/misc.cmx \
     parsing/location.cmx \
     utils/load_path.cmx \
@@ -1027,6 +1032,7 @@ typing/persistent_env.cmx : \
     utils/clflags.cmx \
     typing/persistent_env.cmi
 typing/persistent_env.cmi : \
+    parsing/unit_info.cmi \
     typing/types.cmi \
     utils/misc.cmi \
     parsing/location.cmi \
@@ -1094,6 +1100,7 @@ typing/printpat.cmi : \
     parsing/asttypes.cmi
 typing/printtyp.cmo : \
     utils/warnings.cmi \
+    parsing/unit_info.cmi \
     typing/types.cmi \
     typing/type_immediacy.cmi \
     typing/signature_group.cmi \
@@ -1118,6 +1125,7 @@ typing/printtyp.cmo : \
     typing/printtyp.cmi
 typing/printtyp.cmx : \
     utils/warnings.cmx \
+    parsing/unit_info.cmx \
     typing/types.cmx \
     typing/type_immediacy.cmx \
     typing/signature_group.cmx \
@@ -1716,6 +1724,7 @@ typing/typedtree.cmi : \
     parsing/asttypes.cmi
 typing/typemod.cmo : \
     utils/warnings.cmi \
+    parsing/unit_info.cmi \
     typing/typetexp.cmi \
     typing/types.cmi \
     typing/typedtree.cmi \
@@ -1739,7 +1748,6 @@ typing/typemod.cmo : \
     typing/ident.cmi \
     typing/env.cmi \
     typing/ctype.cmi \
-    utils/config.cmi \
     file_formats/cmt_format.cmi \
     typing/cmt2annot.cmi \
     file_formats/cmi_format.cmi \
@@ -1751,6 +1759,7 @@ typing/typemod.cmo : \
     typing/typemod.cmi
 typing/typemod.cmx : \
     utils/warnings.cmx \
+    parsing/unit_info.cmx \
     typing/typetexp.cmx \
     typing/types.cmx \
     typing/typedtree.cmx \
@@ -1774,7 +1783,6 @@ typing/typemod.cmx : \
     typing/ident.cmx \
     typing/env.cmx \
     typing/ctype.cmx \
-    utils/config.cmx \
     file_formats/cmt_format.cmx \
     typing/cmt2annot.cmx \
     file_formats/cmi_format.cmx \
@@ -1785,6 +1793,7 @@ typing/typemod.cmx : \
     parsing/asttypes.cmi \
     typing/typemod.cmi
 typing/typemod.cmi : \
+    parsing/unit_info.cmi \
     typing/types.cmi \
     typing/typedtree.cmi \
     typing/typedecl.cmi \
@@ -2041,6 +2050,7 @@ bytecomp/bytelink.cmi : \
     utils/misc.cmi \
     file_formats/cmo_format.cmi
 bytecomp/bytepackager.cmo : \
+    parsing/unit_info.cmi \
     typing/typemod.cmi \
     lambda/translmod.cmi \
     bytecomp/symtable.cmi \
@@ -2062,6 +2072,7 @@ bytecomp/bytepackager.cmo : \
     bytecomp/bytegen.cmi \
     bytecomp/bytepackager.cmi
 bytecomp/bytepackager.cmx : \
+    parsing/unit_info.cmx \
     typing/typemod.cmx \
     lambda/translmod.cmx \
     bytecomp/symtable.cmx \
@@ -2104,6 +2115,7 @@ bytecomp/dll.cmx : \
     bytecomp/dll.cmi
 bytecomp/dll.cmi :
 bytecomp/emitcode.cmo : \
+    parsing/unit_info.cmi \
     lambda/translmod.cmi \
     bytecomp/symtable.cmi \
     typing/primitive.cmi \
@@ -2122,6 +2134,7 @@ bytecomp/emitcode.cmo : \
     parsing/asttypes.cmi \
     bytecomp/emitcode.cmi
 bytecomp/emitcode.cmx : \
+    parsing/unit_info.cmx \
     lambda/translmod.cmx \
     bytecomp/symtable.cmx \
     typing/primitive.cmx \
@@ -2140,6 +2153,7 @@ bytecomp/emitcode.cmx : \
     parsing/asttypes.cmi \
     bytecomp/emitcode.cmi
 bytecomp/emitcode.cmi : \
+    parsing/unit_info.cmi \
     utils/misc.cmi \
     bytecomp/instruct.cmi \
     typing/ident.cmi \
@@ -2293,6 +2307,7 @@ asmcomp/arch.cmi : \
     asmcomp/x86_ast.cmi \
     lambda/lambda.cmi
 asmcomp/asmgen.cmo : \
+    parsing/unit_info.cmi \
     lambda/translmod.cmi \
     asmcomp/split.cmi \
     asmcomp/spill.cmi \
@@ -2336,6 +2351,7 @@ asmcomp/asmgen.cmo : \
     middle_end/backend_intf.cmi \
     asmcomp/asmgen.cmi
 asmcomp/asmgen.cmx : \
+    parsing/unit_info.cmx \
     lambda/translmod.cmx \
     asmcomp/split.cmx \
     asmcomp/spill.cmx \
@@ -2379,6 +2395,7 @@ asmcomp/asmgen.cmx : \
     middle_end/backend_intf.cmi \
     asmcomp/asmgen.cmi
 asmcomp/asmgen.cmi : \
+    parsing/unit_info.cmi \
     lambda/lambda.cmi \
     asmcomp/emitaux.cmi \
     asmcomp/cmm.cmi \
@@ -2453,6 +2470,7 @@ asmcomp/asmlink.cmi : \
     utils/misc.cmi \
     file_formats/cmx_format.cmi
 asmcomp/asmpackager.cmo : \
+    parsing/unit_info.cmi \
     typing/typemod.cmi \
     lambda/translmod.cmi \
     lambda/simplif.cmi \
@@ -2477,6 +2495,7 @@ asmcomp/asmpackager.cmo : \
     asmcomp/asmgen.cmi \
     asmcomp/asmpackager.cmi
 asmcomp/asmpackager.cmx : \
+    parsing/unit_info.cmx \
     typing/typemod.cmx \
     lambda/translmod.cmx \
     lambda/simplif.cmx \
@@ -3993,6 +4012,7 @@ file_formats/cmi_format.cmi : \
 file_formats/cmo_format.cmi : \
     utils/misc.cmi
 file_formats/cmt_format.cmo : \
+    parsing/unit_info.cmi \
     typing/types.cmi \
     typing/typedtree.cmi \
     typing/tast_mapper.cmi \
@@ -4007,6 +4027,7 @@ file_formats/cmt_format.cmo : \
     utils/clflags.cmi \
     file_formats/cmt_format.cmi
 file_formats/cmt_format.cmx : \
+    parsing/unit_info.cmx \
     typing/types.cmx \
     typing/typedtree.cmx \
     typing/tast_mapper.cmx \
@@ -4021,6 +4042,7 @@ file_formats/cmt_format.cmx : \
     utils/clflags.cmx \
     file_formats/cmt_format.cmi
 file_formats/cmt_format.cmi : \
+    parsing/unit_info.cmi \
     typing/types.cmi \
     typing/typedtree.cmi \
     typing/shape.cmi \
@@ -6012,6 +6034,7 @@ driver/compenv.cmx : \
 driver/compenv.cmi : \
     utils/clflags.cmi
 driver/compile.cmo : \
+    parsing/unit_info.cmi \
     typing/typedtree.cmi \
     lambda/translmod.cmi \
     lambda/simplif.cmi \
@@ -6022,11 +6045,11 @@ driver/compile.cmo : \
     lambda/lambda.cmi \
     bytecomp/emitcode.cmi \
     driver/compile_common.cmi \
-    file_formats/cmo_format.cmi \
     utils/clflags.cmi \
     bytecomp/bytegen.cmi \
     driver/compile.cmi
 driver/compile.cmx : \
+    parsing/unit_info.cmx \
     typing/typedtree.cmx \
     lambda/translmod.cmx \
     lambda/simplif.cmx \
@@ -6037,7 +6060,6 @@ driver/compile.cmx : \
     lambda/lambda.cmx \
     bytecomp/emitcode.cmx \
     driver/compile_common.cmx \
-    file_formats/cmo_format.cmi \
     utils/clflags.cmx \
     bytecomp/bytegen.cmx \
     driver/compile.cmi
@@ -6049,6 +6071,7 @@ driver/compile.cmi : \
     utils/clflags.cmi
 driver/compile_common.cmo : \
     utils/warnings.cmi \
+    parsing/unit_info.cmi \
     typing/typemod.cmi \
     typing/typedtree.cmi \
     typing/typecore.cmi \
@@ -6062,14 +6085,13 @@ driver/compile_common.cmo : \
     utils/misc.cmi \
     typing/includemod.cmi \
     typing/env.cmi \
-    utils/config.cmi \
     driver/compmisc.cmi \
-    driver/compenv.cmi \
     utils/clflags.cmi \
     parsing/builtin_attributes.cmi \
     driver/compile_common.cmi
 driver/compile_common.cmx : \
     utils/warnings.cmx \
+    parsing/unit_info.cmx \
     typing/typemod.cmx \
     typing/typedtree.cmx \
     typing/typecore.cmx \
@@ -6083,13 +6105,12 @@ driver/compile_common.cmx : \
     utils/misc.cmx \
     typing/includemod.cmx \
     typing/env.cmx \
-    utils/config.cmx \
     driver/compmisc.cmx \
-    driver/compenv.cmx \
     utils/clflags.cmx \
     parsing/builtin_attributes.cmx \
     driver/compile_common.cmi
 driver/compile_common.cmi : \
+    parsing/unit_info.cmi \
     typing/typedtree.cmi \
     parsing/parsetree.cmi \
     typing/env.cmi
@@ -6188,6 +6209,7 @@ driver/maindriver.cmx : \
     driver/maindriver.cmi
 driver/maindriver.cmi :
 driver/makedepend.cmo : \
+    parsing/unit_info.cmi \
     driver/pparse.cmi \
     parsing/parsetree.cmi \
     parsing/parser.cmi \
@@ -6201,6 +6223,7 @@ driver/makedepend.cmo : \
     utils/clflags.cmi \
     driver/makedepend.cmi
 driver/makedepend.cmx : \
+    parsing/unit_info.cmx \
     driver/pparse.cmx \
     parsing/parsetree.cmi \
     parsing/parser.cmx \
@@ -6215,6 +6238,7 @@ driver/makedepend.cmx : \
     driver/makedepend.cmi
 driver/makedepend.cmi :
 driver/optcompile.cmo : \
+    parsing/unit_info.cmi \
     typing/typedtree.cmi \
     lambda/translmod.cmi \
     lambda/simplif.cmi \
@@ -6231,6 +6255,7 @@ driver/optcompile.cmo : \
     asmcomp/asmgen.cmi \
     driver/optcompile.cmi
 driver/optcompile.cmx : \
+    parsing/unit_info.cmx \
     typing/typedtree.cmx \
     lambda/translmod.cmx \
     lambda/simplif.cmx \
@@ -6335,12 +6360,14 @@ driver/pparse.cmx : \
 driver/pparse.cmi : \
     parsing/parsetree.cmi
 toplevel/expunge.cmo : \
+    parsing/unit_info.cmi \
     bytecomp/symtable.cmi \
     utils/misc.cmi \
     file_formats/cmo_format.cmi \
     bytecomp/bytesections.cmi \
     toplevel/expunge.cmi
 toplevel/expunge.cmx : \
+    parsing/unit_info.cmx \
     bytecomp/symtable.cmx \
     utils/misc.cmx \
     file_formats/cmo_format.cmi \
@@ -6389,6 +6416,7 @@ toplevel/genprintval.cmi : \
     typing/outcometree.cmi \
     typing/env.cmi
 toplevel/topcommon.cmo : \
+    parsing/unit_info.cmi \
     typing/typedtree.cmi \
     bytecomp/symtable.cmi \
     parsing/printast.cmi \
@@ -6418,6 +6446,7 @@ toplevel/topcommon.cmo : \
     parsing/ast_helper.cmi \
     toplevel/topcommon.cmi
 toplevel/topcommon.cmx : \
+    parsing/unit_info.cmx \
     typing/typedtree.cmx \
     bytecomp/symtable.cmx \
     parsing/printast.cmx \
@@ -7027,6 +7056,7 @@ tools/eqparsetree.cmx : \
 tools/gen_sizeclasses.cmo :
 tools/gen_sizeclasses.cmx :
 tools/lintapidiff.cmo : \
+    parsing/unit_info.cmi \
     otherlibs/str/str.cmi \
     typing/printtyp.cmi \
     driver/pparse.cmi \
@@ -7038,6 +7068,7 @@ tools/lintapidiff.cmo : \
     typing/ident.cmi \
     tools/lintapidiff.cmi
 tools/lintapidiff.cmx : \
+    parsing/unit_info.cmx \
     otherlibs/str/str.cmx \
     typing/printtyp.cmx \
     driver/pparse.cmx \
@@ -7292,6 +7323,7 @@ debugger/checkpoints.cmi : \
 debugger/command_line.cmo : \
     debugger/unix_tools.cmi \
     otherlibs/unix/unix.cmi \
+    parsing/unit_info.cmi \
     typing/types.cmi \
     debugger/time_travel.cmi \
     debugger/symbols.cmi \
@@ -7330,6 +7362,7 @@ debugger/command_line.cmo : \
 debugger/command_line.cmx : \
     debugger/unix_tools.cmx \
     otherlibs/unix/unix.cmx \
+    parsing/unit_info.cmx \
     typing/types.cmx \
     debugger/time_travel.cmx \
     debugger/symbols.cmx \
@@ -7526,6 +7559,7 @@ debugger/int64ops.cmx : \
     debugger/int64ops.cmi
 debugger/int64ops.cmi :
 debugger/loadprinter.cmo : \
+    parsing/unit_info.cmi \
     typing/types.cmi \
     toplevel/topprinters.cmi \
     bytecomp/symtable.cmi \
@@ -7542,6 +7576,7 @@ debugger/loadprinter.cmo : \
     file_formats/cmo_format.cmi \
     debugger/loadprinter.cmi
 debugger/loadprinter.cmx : \
+    parsing/unit_info.cmx \
     typing/types.cmx \
     toplevel/topprinters.cmx \
     bytecomp/symtable.cmx \

--- a/Changes
+++ b/Changes
@@ -277,6 +277,10 @@ Working version
   bytecode executable (`ocamlc -custom`).
   (Antonin Décimo, review by Xavier Leroy)
 
+- #12389, centralize the handling of metadata for compilation units and
+  artifacts in preparation for better unicode support for OCaml source files.
+  (Florian Angeletti, review by Gabriel Scherer)
+
 ### Build system:
 
 - #12198, #12321: continue the merge of the sub-makefiles into the root Makefile

--- a/asmcomp/asmgen.ml
+++ b/asmcomp/asmgen.ml
@@ -300,12 +300,13 @@ let linear_gen_implementation filename =
   Profile.record "Emit" (List.iter emit_item) linear_unit_info.items;
   emit_end_assembly ()
 
-let compile_implementation_linear output_prefix ~progname =
+let compile_implementation_linear target =
+  let output_prefix = Unit_info.prefix target in
   compile_unit ~output_prefix
     ~asm_filename:(asm_filename output_prefix) ~keep_asm:!keep_asm_file
     ~obj_filename:(output_prefix ^ ext_obj)
     (fun () ->
-      linear_gen_implementation progname)
+      linear_gen_implementation (Unit_info.source_file target))
 
 (* Error report *)
 module Style = Misc.Style

--- a/asmcomp/asmgen.mli
+++ b/asmcomp/asmgen.mli
@@ -34,7 +34,7 @@ val compile_implementation
   -> unit
 
 val compile_implementation_linear :
-    string -> progname:string -> unit
+    Unit_info.t -> unit
 
 val compile_phrase :
     ppf_dump:Format.formatter -> Cmm.phrase -> unit

--- a/bytecomp/bytepackager.ml
+++ b/bytecomp/bytepackager.ml
@@ -122,13 +122,12 @@ type pack_member =
     pm_kind: pack_member_kind }
 
 let read_member_info targetname file =
-  let member_name =
-    String.capitalize_ascii(Filename.basename(chop_extensions file))
-  in
+  let member = Unit_info.Artifact.from_filename file in
+  let member_name = Unit_info.Artifact.modname member in
   let member_compunit = Compunit member_name in
   let kind =
     (* PR#7479: make sure it is either a .cmi or a .cmo *)
-    if Filename.check_suffix file ".cmi" then
+    if Unit_info.is_cmi member then
       PM_intf
     else begin
       let ic = open_in_bin file in
@@ -240,7 +239,9 @@ let build_global_target ~ppf_dump oc target_name state components coercion =
 
 (* Build the .cmo file obtained by packaging the given .cmo files. *)
 
-let package_object_files ~ppf_dump files targetfile targetname coercion =
+let package_object_files ~ppf_dump files target coercion =
+  let targetfile = Unit_info.Artifact.filename target in
+  let targetname = Unit_info.Artifact.modname target in
   let members = map_left_right (read_member_info targetname) files in
   let required_compunits =
     List.fold_right (fun compunit required_compunits -> match compunit with
@@ -333,13 +334,12 @@ let package_files ~ppf_dump initial_env files targetfile =
          try Load_path.find f
          with Not_found -> raise(Error(File_not_found f)))
       files in
-  let prefix = chop_extensions targetfile in
-  let targetcmi = prefix ^ ".cmi" in
-  let targetname = String.capitalize_ascii(Filename.basename prefix) in
+  let target = Unit_info.Artifact.from_filename targetfile in
   Misc.try_finally (fun () ->
       let coercion =
-        Typemod.package_units initial_env files targetcmi targetname in
-      package_object_files ~ppf_dump files targetfile targetname coercion
+        Typemod.package_units initial_env files (Unit_info.companion_cmi target)
+      in
+      package_object_files ~ppf_dump files target coercion
     )
     ~exceptionally:(fun () -> remove_file targetfile)
 

--- a/bytecomp/emitcode.ml
+++ b/bytecomp/emitcode.ml
@@ -412,7 +412,7 @@ let rec emit = function
 
 (* Emission to a file *)
 
-let to_file outchan unit_name objfile ~required_globals code =
+let to_file outchan artifact_info ~required_globals code =
   init();
   Fun.protect ~finally:clear (fun () ->
   output_string outchan cmo_magic_number;
@@ -423,8 +423,9 @@ let to_file outchan unit_name objfile ~required_globals code =
   LongString.output outchan !out_buffer 0 !out_position;
   let (pos_debug, size_debug) =
     if !Clflags.debug then begin
+      let filename = Unit_info.Artifact.filename artifact_info in
       debug_dirs := String.Set.add
-        (Filename.dirname (Location.absolute_path objfile))
+          (Filename.dirname (Location.absolute_path filename))
         !debug_dirs;
       let p = pos_out outchan in
       Marshal.(to_channel outchan !events [Compression]);
@@ -434,7 +435,7 @@ let to_file outchan unit_name objfile ~required_globals code =
     end else
       (0, 0) in
   let compunit =
-    { cu_name = unit_name;
+    { cu_name = Cmo_format.Compunit (Unit_info.Artifact.modname artifact_info);
       cu_pos = pos_code;
       cu_codesize = !out_position;
       cu_reloc = List.rev !reloc_info;
@@ -452,7 +453,8 @@ let to_file outchan unit_name objfile ~required_globals code =
        See doc-comment for [Types.abbrev_memo] *)
     Btype.cleanup_abbrev ();
     marshal_to_channel_with_possibly_32bit_compat
-      ~filename:objfile ~kind:"bytecode unit"
+      ~filename:(Unit_info.Artifact.filename artifact_info)
+      ~kind:"bytecode unit"
       outchan compunit
   in
   seek_out outchan pos_depl;

--- a/bytecomp/emitcode.mli
+++ b/bytecomp/emitcode.mli
@@ -18,7 +18,7 @@
 open Cmo_format
 open Instruct
 
-val to_file: out_channel -> Cmo_format.compunit -> string ->
+val to_file: out_channel -> Unit_info.Artifact.t ->
   required_globals:Ident.Set.t -> instruction list -> unit
         (* Arguments:
              channel on output file

--- a/compilerlibs/Makefile.compilerlibs
+++ b/compilerlibs/Makefile.compilerlibs
@@ -51,6 +51,7 @@ UTILS_CMI =
 
 PARSING = \
   parsing/location.cmo \
+  parsing/unit_info.cmo \
   parsing/longident.cmo \
   parsing/docstrings.cmo \
   parsing/syntaxerr.cmo \

--- a/debugger/command_line.ml
+++ b/debugger/command_line.ml
@@ -154,10 +154,12 @@ let module_of_longident id =
 let convert_module mdle =
   match mdle with
   | Some m ->
-      (* Strip .ml extension if any, and capitalize *)
-      String.capitalize_ascii(if Filename.check_suffix m ".ml"
-                              then Filename.chop_suffix m ".ml"
-                              else m)
+     (* Strip .ml extension if any, beware that mdle might be a module path *)
+     let stripped =
+       if Filename.check_suffix m ".ml" then Filename.chop_suffix m ".ml"
+       else m
+     in
+     Unit_info.modulize stripped
   | None ->
       try (get_current_event ()).ev_ev.ev_module
       with Not_found -> error "Not in a module."

--- a/debugger/loadprinter.ml
+++ b/debugger/loadprinter.ml
@@ -51,7 +51,7 @@ let rec loadfiles ppf name =
     true
   with
   | Dynlink.Error (Dynlink.Unavailable_unit unit) ->
-      loadfiles ppf (String.uncapitalize_ascii unit ^ ".cmo")
+      loadfiles ppf (Unit_info.normalize unit ^ ".cmo")
         &&
       loadfiles ppf name
   | Not_found ->

--- a/debugger/source.ml
+++ b/debugger/source.ml
@@ -52,7 +52,7 @@ let source_of_module pos mdle =
       function
         | [] -> raise Not_found
         | ext :: exts ->
-          try find_in_path_uncap path (innermost_module ^ ext)
+          try find_in_path_normalized path (innermost_module ^ ext)
           with Not_found -> loop exts
     in loop source_extensions
   else if Filename.is_relative fname then

--- a/driver/compenv.ml
+++ b/driver/compenv.ml
@@ -62,41 +62,6 @@ let first_objfiles = ref []
 let last_objfiles = ref []
 let stop_early = ref false
 
-(* Check validity of module name *)
-let is_unit_name name =
-  try
-    if name = "" then raise Exit;
-    begin match name.[0] with
-    | 'A'..'Z' -> ()
-    | _ ->
-       raise Exit;
-    end;
-    for i = 1 to String.length name - 1 do
-      match name.[i] with
-      | 'A'..'Z' | 'a'..'z' | '0'..'9' | '_' | '\'' -> ()
-      | _ ->
-         raise Exit;
-    done;
-    true
-  with Exit -> false
-
-let check_unit_name filename name =
-  if not (is_unit_name name) then
-    Location.prerr_warning (Location.in_file filename)
-      (Warnings.Bad_module_name name)
-
-(* Compute name of module from output file name *)
-let module_of_filename inputfile outputprefix =
-  let basename = Filename.basename outputprefix in
-  let name =
-    try
-      let pos = String.index basename '.' in
-      String.sub basename 0 pos
-    with Not_found -> basename
-  in
-  let name = String.capitalize_ascii name in
-  check_unit_name inputfile name;
-  name
 
 type filename = string
 

--- a/driver/compenv.mli
+++ b/driver/compenv.mli
@@ -15,8 +15,6 @@
 
 exception Exit_with_status of int
 
-val module_of_filename : string -> string -> string
-
 val output_prefix : string -> string
 val extract_output : string option -> string
 val default_output : string option -> string
@@ -45,13 +43,6 @@ type readenv_position =
   Before_args | Before_compile of filename | Before_link
 
 val readenv : Format.formatter -> readenv_position -> unit
-
-(* [is_unit_name name] returns true only if [name] can be used as a
-   correct module name *)
-val is_unit_name : string -> bool
-(* [check_unit_name ppf filename name] prints a warning in [filename]
-   on [ppf] if [name] should not be used as a module name. *)
-val check_unit_name : string -> string -> unit
 
 (* Deferred actions of the compiler, while parsing arguments *)
 

--- a/driver/compile_common.mli
+++ b/driver/compile_common.mli
@@ -17,9 +17,7 @@
 (** {2 Initialization} *)
 
 type info = {
-  source_file : string;
-  module_name : string;
-  output_prefix : string;
+  target : Unit_info.t;
   env : Env.t;
   ppf_dump : Format.formatter;
   tool_name : string;
@@ -77,13 +75,3 @@ val typecheck_impl : info -> Parsetree.structure -> Typedtree.implementation
 val implementation :
   info -> backend:(info -> Typedtree.implementation -> unit) -> unit
 (** The complete compilation pipeline for implementations. *)
-
-(** {2 Build artifacts} *)
-
-val cmo : info -> string
-val cmx : info -> string
-val obj : info -> string
-val annot : info -> string
-(** Return the filename of some compiler build artifacts associated
-    with the file being compiled.
-*)

--- a/driver/makedepend.ml
+++ b/driver/makedepend.ml
@@ -100,7 +100,7 @@ let add_to_synonym_list synonyms suffix =
 let find_module_in_load_path name =
   let names = List.map (fun ext -> name ^ ext) (!mli_synonyms @ !ml_synonyms) in
   let unames =
-    let uname = String.uncapitalize_ascii name in
+    let uname = Unit_info.normalize name in
     List.map (fun ext -> uname ^ ext) (!mli_synonyms @ !ml_synonyms)
   in
   let rec find_in_array a pos =
@@ -440,9 +440,7 @@ let sort_files_by_dependencies files =
 
 (* Init Hashtbl with all defined modules *)
   let files = List.map (fun (file, file_kind, deps, pp_deps) ->
-    let modname =
-      String.capitalize_ascii (Filename.chop_extension (Filename.basename file))
-    in
+    let modname = Unit_info.modname_from_source file in
     let key = (modname, file_kind) in
     let new_deps = ref [] in
     Hashtbl.add h key (file, new_deps);
@@ -545,9 +543,7 @@ let parse_map fname =
       ~mli_file:process_mli_map
   in
   Clflags.transparent_modules := old_transp;
-  let modname =
-    String.capitalize_ascii
-      (Filename.basename (Filename.chop_extension fname)) in
+  let modname = Unit_info.modname_from_source fname in
   if String.Map.is_empty m then
     report_err (Failure (fname ^ " : empty map file or parse error"));
   let mm = Depend.make_node m in

--- a/dune
+++ b/dune
@@ -45,7 +45,7 @@
    config build_path_prefix_map misc identifiable numbers arg_helper clflags
    profile terminfo ccomp warnings consistbl strongly_connected_components
    targetint load_path int_replace_polymorphic_compare binutils local_store
-   lazy_backtrack diffing diffing_with_keys
+   lazy_backtrack diffing diffing_with_keys unit_info
 
    ;; PARSING
    location longident docstrings syntaxerr ast_helper camlinternalMenhirLib

--- a/file_formats/cmt_format.ml
+++ b/file_formats/cmt_format.ml
@@ -164,19 +164,20 @@ let record_value_dependency vd1 vd2 =
   if vd1.Types.val_loc <> vd2.Types.val_loc then
     value_deps := (vd1, vd2) :: !value_deps
 
-let save_cmt filename modname binary_annots sourcefile initial_env cmi shape =
+let save_cmt target binary_annots initial_env cmi shape =
   if !Clflags.binary_annotations && not !Clflags.print_types then begin
     Misc.output_to_file_via_temporary
-       ~mode:[Open_binary] filename
+       ~mode:[Open_binary] (Unit_info.Artifact.filename target)
        (fun temp_file_name oc ->
          let this_crc =
            match cmi with
            | None -> None
            | Some cmi -> Some (output_cmi temp_file_name oc cmi)
          in
+         let sourcefile = Unit_info.Artifact.source_file target in
          let source_digest = Option.map Digest.file sourcefile in
          let cmt = {
-           cmt_modname = modname;
+           cmt_modname = Unit_info.Artifact.modname target;
            cmt_annots = clear_env binary_annots;
            cmt_value_dependencies = !value_deps;
            cmt_comments = Lexer.comments ();

--- a/file_formats/cmt_format.mli
+++ b/file_formats/cmt_format.mli
@@ -90,10 +90,8 @@ val read_cmi : string -> Cmi_format.cmi_infos
 (** [save_cmt filename modname binary_annots sourcefile initial_env cmi]
     writes a cmt(i) file.  *)
 val save_cmt :
-  string ->  (* filename.cmt to generate *)
-  string ->  (* module name *)
+  Unit_info.Artifact.t ->
   binary_annots ->
-  string option ->  (* source file *)
   Env.t -> (* initial env *)
   Cmi_format.cmi_infos option -> (* if a .cmi was generated *)
   Shape.t option ->

--- a/middle_end/compilenv.ml
+++ b/middle_end/compilenv.ml
@@ -191,7 +191,7 @@ let get_global_info global_ident = (
         else begin
           try
             let filename =
-              Load_path.find_uncap (modname ^ ".cmx") in
+              Load_path.find_normalized (modname ^ ".cmx") in
             let (ui, crc) = read_unit_info filename in
             if ui.ui_name <> modname then
               raise(Error(Illegal_renaming(modname, ui.ui_name, filename)));

--- a/ocamldoc/.depend
+++ b/ocamldoc/.depend
@@ -19,6 +19,7 @@ odoc.cmx : \
 odoc.cmi :
 odoc_analyse.cmo : \
     ../utils/warnings.cmi \
+    ../parsing/unit_info.cmi \
     ../typing/types.cmi \
     ../typing/typemod.cmi \
     ../typing/typedtree.cmi \
@@ -46,6 +47,7 @@ odoc_analyse.cmo : \
     odoc_analyse.cmi
 odoc_analyse.cmx : \
     ../utils/warnings.cmx \
+    ../parsing/unit_info.cmx \
     ../typing/types.cmx \
     ../typing/typemod.cmx \
     ../typing/typedtree.cmx \
@@ -107,6 +109,7 @@ odoc_args.cmx : \
 odoc_args.cmi : \
     odoc_gen.cmi
 odoc_ast.cmo : \
+    ../parsing/unit_info.cmi \
     ../typing/types.cmi \
     ../typing/typedtree.cmi \
     ../typing/predef.cmi \
@@ -130,6 +133,7 @@ odoc_ast.cmo : \
     ../parsing/asttypes.cmi \
     odoc_ast.cmi
 odoc_ast.cmx : \
+    ../parsing/unit_info.cmx \
     ../typing/types.cmx \
     ../typing/typedtree.cmx \
     ../typing/predef.cmx \
@@ -623,11 +627,13 @@ odoc_module.cmi : \
     odoc_class.cmi \
     ../utils/misc.cmi
 odoc_name.cmo : \
+    ../parsing/unit_info.cmi \
     ../typing/path.cmi \
     odoc_misc.cmi \
     ../typing/ident.cmi \
     odoc_name.cmi
 odoc_name.cmx : \
+    ../parsing/unit_info.cmx \
     ../typing/path.cmx \
     odoc_misc.cmx \
     ../typing/ident.cmx \
@@ -737,6 +743,7 @@ odoc_see_lexer.cmx : \
 odoc_see_lexer.cmi : \
     odoc_parser.cmi
 odoc_sig.cmo : \
+    ../parsing/unit_info.cmi \
     ../typing/types.cmi \
     ../typing/typedtree.cmi \
     ../parsing/parsetree.cmi \
@@ -761,6 +768,7 @@ odoc_sig.cmo : \
     ../parsing/asttypes.cmi \
     odoc_sig.cmi
 odoc_sig.cmx : \
+    ../parsing/unit_info.cmx \
     ../typing/types.cmx \
     ../typing/typedtree.cmx \
     ../parsing/parsetree.cmi \

--- a/ocamldoc/odoc_analyse.ml
+++ b/ocamldoc/odoc_analyse.ml
@@ -66,11 +66,14 @@ let no_docstring f x =
   Lexer.handle_docstrings := true;
   result
 
+let unit_from_source source_file =
+    Unit_info.make ~check_modname:false ~source_file
+      (Filename.remove_extension source_file)
+
 let process_implementation_file sourcefile =
   init_path ();
-  let prefixname = Filename.chop_extension sourcefile in
-  let modulename = String.capitalize_ascii(Filename.basename prefixname) in
-  Env.set_unit_name modulename;
+  let source = unit_from_source sourcefile in
+  Env.set_unit_name (Unit_info.modname source);
   let inputfile = preprocess sourcefile in
   let env = initial_env () in
   try
@@ -78,10 +81,7 @@ let process_implementation_file sourcefile =
       Pparse.file ~tool_name inputfile
         (no_docstring Parse.implementation) Pparse.Structure
     in
-    let typedtree =
-      Typemod.type_implementation
-        sourcefile prefixname modulename env parsetree
-    in
+    let typedtree = Typemod.type_implementation source env parsetree in
     (Some (parsetree, typedtree), inputfile)
   with
   | Syntaxerr.Error _ as exn ->
@@ -102,8 +102,8 @@ let process_implementation_file sourcefile =
    no error occurred, else None and an error message is printed.*)
 let process_interface_file sourcefile =
   init_path ();
-  let prefixname = Filename.chop_extension sourcefile in
-  let modulename = String.capitalize_ascii(Filename.basename prefixname) in
+  let unit = unit_from_source sourcefile in
+  let modulename = Unit_info.modname unit in
   Env.set_unit_name modulename;
   let inputfile = preprocess sourcefile in
   let ast =
@@ -207,13 +207,7 @@ let process_file sourcefile =
   | Odoc_global.Text_file file ->
       Location.input_name := file;
       try
-        let mod_name =
-          let s =
-            try Filename.chop_extension file
-            with _ -> file
-          in
-          String.capitalize_ascii (Filename.basename s)
-        in
+        let mod_name = Unit_info.modname_from_source file in
         let txt =
           try Odoc_text.Texter.text_of_string (Odoc_misc.input_file_as_string file)
           with Odoc_text.Text_syntax (l, c, s) ->

--- a/ocamldoc/odoc_ast.ml
+++ b/ocamldoc/odoc_ast.ml
@@ -1845,7 +1845,7 @@ module Analyser =
        let (tree_structure, _) = typedtree in
        prepare_file source_file input_file;
        (* We create the t_module for this file. *)
-       let mod_name = String.capitalize_ascii (Filename.basename (Filename.chop_extension source_file)) in
+       let mod_name = Unit_info.modname_from_source source_file in
        let len, info_opt = Sig.preamble !file_name !file
            (fun x -> x.Parsetree.pstr_loc) parsetree in
       let info_opt = analyze_toplevel_alerts info_opt parsetree in

--- a/ocamldoc/odoc_name.ml
+++ b/ocamldoc/odoc_name.ml
@@ -197,11 +197,10 @@ let get_relative_opt n1 n2 =
 
 let alias_unprefix ln s =
   if ln = "" then s else
-  let p = ln ^ "__" in
-  let n, k = String.(length p, length s) in
-  if k > n &&
-     String.sub s 0 n = p then
-    String.( capitalize_ascii @@ sub s n (k-n) )
+  let prefix = ln ^ "__" in
+  if String.starts_with ~prefix s then
+    let pre = String.length prefix in
+    Unit_info.modulize (String.sub s pre (String.length s-pre))
   else
     s
 

--- a/ocamldoc/odoc_sig.ml
+++ b/ocamldoc/odoc_sig.ml
@@ -1885,9 +1885,7 @@ module Analyser =
         (ast : Parsetree.signature) (signat : Types.signature) =
       prepare_file source_file input_file;
       (* We create the t_module for this file. *)
-      let mod_name = String.capitalize_ascii
-          (Filename.basename (try Filename.chop_extension source_file with _ -> source_file))
-      in
+      let mod_name = Unit_info.modname_from_source source_file in
       let len, info_opt = preamble !file_name !file
           (fun x -> x.Parsetree.psig_loc) ast in
       let info_opt = analyze_toplevel_alerts info_opt ast in

--- a/otherlibs/dynlink/Makefile
+++ b/otherlibs/dynlink/Makefile
@@ -88,6 +88,7 @@ COMPILERLIBS_SOURCES=\
   utils/int_replace_polymorphic_compare.ml \
   utils/lazy_backtrack.ml \
   parsing/location.ml \
+  parsing/unit_info.ml \
   parsing/longident.ml \
   parsing/docstrings.ml \
   parsing/syntaxerr.ml \

--- a/parsing/unit_info.ml
+++ b/parsing/unit_info.ml
@@ -50,13 +50,13 @@ let is_identchar_latin1 = function
   | _ -> false
 
 (* Check validity of module name *)
-let is_unit_name ~strict name =
+let is_unit_name name =
   String.length name > 0
-  && (not strict || start_char name.[0])
+  && start_char name.[0]
   && String.for_all is_identchar_latin1 name
 
 let check_unit_name file =
-  if not (is_unit_name ~strict:true (modname file)) then
+  if not (is_unit_name (modname file)) then
     Location.prerr_warning (Location.in_file (source_file file))
       (Warnings.Bad_module_name (modname file))
 

--- a/parsing/unit_info.ml
+++ b/parsing/unit_info.ml
@@ -1,0 +1,119 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*             Florian Angeletti, projet Cambium, Inria Paris             *)
+(*                                                                        *)
+(*   Copyright 2023 Institut National de Recherche en Informatique et     *)
+(*     en Automatique.                                                    *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+type modname = string
+type filename = string
+type file_prefix = string
+
+type t = {
+  source_file: filename;
+  prefix: file_prefix;
+  modname: modname;
+}
+
+let source_file (x: t) = x.source_file
+let modname (x: t) = x.modname
+let prefix (x: t) = x.prefix
+
+let basename_chop_extensions basename  =
+  match String.index basename '.' with
+  | dot_pos -> String.sub basename 0 dot_pos
+  | exception Not_found -> basename
+
+let modulize s = String.capitalize_ascii s
+
+(* We re-export the [Misc] definition *)
+let normalize = Misc.normalized_unit_filename
+
+let modname_from_source source_file =
+  source_file |> Filename.basename |> basename_chop_extensions |> modulize
+
+let start_char = function
+  | 'A' .. 'Z' -> true
+  | _ -> false
+
+let is_identchar_latin1 = function
+  | 'A'..'Z' | 'a'..'z' | '_' | '\192'..'\214' | '\216'..'\246'
+  | '\248'..'\255' | '\'' | '0'..'9' -> true
+  | _ -> false
+
+(* Check validity of module name *)
+let is_unit_name ~strict name =
+  String.length name > 0
+  && (not strict || start_char name.[0])
+  && String.for_all is_identchar_latin1 name
+
+let check_unit_name file =
+  if not (is_unit_name ~strict:true (modname file)) then
+    Location.prerr_warning (Location.in_file (source_file file))
+      (Warnings.Bad_module_name (modname file))
+
+let make ?(check_modname=true) ~source_file prefix =
+  let modname = modname_from_source prefix in
+  let p = { modname; prefix; source_file } in
+  if check_modname then check_unit_name p;
+  p
+
+module Artifact = struct
+  type t =
+   {
+     source_file: filename option;
+     filename: filename;
+     modname: modname;
+   }
+  let source_file x = x.source_file
+  let filename x = x.filename
+  let modname x = x.modname
+  let prefix x = Filename.remove_extension (filename x)
+
+  let from_filename filename =
+    let modname = modname_from_source filename in
+    { modname; filename; source_file = None }
+
+end
+
+let mk_artifact ext u =
+  {
+    Artifact.filename = u.prefix ^ ext;
+    modname = u.modname;
+    source_file = Some u.source_file;
+  }
+
+let companion_artifact ext x =
+  { x with Artifact.filename = Artifact.prefix x ^ ext }
+
+let cmi f = mk_artifact ".cmi" f
+let cmo f = mk_artifact ".cmo" f
+let cmx f = mk_artifact ".cmx" f
+let obj f = mk_artifact Config.ext_obj f
+let cmt f = mk_artifact ".cmt" f
+let cmti f = mk_artifact ".cmti" f
+let annot f = mk_artifact ".annot" f
+
+let companion_obj f = companion_artifact Config.ext_obj f
+let companion_cmi f = companion_artifact ".cmi" f
+let companion_cmt f = companion_artifact ".cmt" f
+
+let mli_from_artifact f = Artifact.prefix f ^ !Config.interface_suffix
+let mli_from_source u =
+   let prefix = Filename.remove_extension (source_file u) in
+   prefix  ^ !Config.interface_suffix
+
+let is_cmi f = Filename.check_suffix (Artifact.filename f) ".cmi"
+
+let find_normalized_cmi f =
+  let filename = prefix f ^ ".cmi" in
+  let filename = Load_path.find_uncap filename in
+  { Artifact.filename; modname = modname f; source_file = Some f.source_file  }

--- a/parsing/unit_info.ml
+++ b/parsing/unit_info.ml
@@ -115,5 +115,5 @@ let is_cmi f = Filename.check_suffix (Artifact.filename f) ".cmi"
 
 let find_normalized_cmi f =
   let filename = prefix f ^ ".cmi" in
-  let filename = Load_path.find_uncap filename in
+  let filename = Load_path.find_normalized filename in
   { Artifact.filename; modname = modname f; source_file = Some f.source_file  }

--- a/parsing/unit_info.mli
+++ b/parsing/unit_info.mli
@@ -1,0 +1,154 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*             Florian Angeletti, projet Cambium, Inria Paris             *)
+(*                                                                        *)
+(*   Copyright 2023 Institut National de Recherche en Informatique et     *)
+(*     en Automatique.                                                    *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+(** This module centralize the handling of compilation files and their metadata.
+
+  Maybe more importantly, this module provides functions for deriving module
+  names from strings or filenames.
+*)
+
+(** {1:modname_from_strings Module name convention and computation} *)
+
+type modname = string
+type filename = string
+type file_prefix = string
+
+(** [modulize s] capitalizes the first letter of [s]. *)
+val modulize: string -> modname
+
+(** [normalize s] uncapitalizes the first letter of [s]. *)
+val normalize: string -> string
+
+(** [modname_from_source filename] is [modulize stem] where [stem] is the
+    basename of the filename [filename] stripped from all its extensions.
+    For instance, [modname_from_source "/pa.th/x.ml.pp"] is ["X"]. *)
+val modname_from_source: filename -> modname
+
+(** {2:module_name_validation Module name validation function}*)
+
+(** [is_unit_name ~strict name] is true only if [name] can be used as a
+    valid module name. The [strict] mode enforces that the first character is
+    an ascii capital letter. *)
+val is_unit_name : strict:bool -> modname -> bool
+
+
+(** {1:unit_info Metadata for compilation unit} *)
+
+type t
+(**  Metadata for a compilation unit:
+    - the module name associated to the unit
+    - the filename prefix (dirname + basename with all extensions stripped)
+      for compilation artifacts
+    - the input source file
+    For instance, when calling [ocamlopt dir/x.mli -o target/y.cmi],
+    - the input source file is [dir/x.mli]
+    - the module name is [Y]
+    - the prefix is [target/y]
+*)
+
+(** [source_file u] is the source file of [u]. *)
+val source_file: t -> filename
+
+(** [prefix u] is the filename prefix of the unit. *)
+val prefix: t -> file_prefix
+
+(** [modname u] or [artifact_modname a] is the module name of the unit
+    or compilation artifact.*)
+val modname: t -> modname
+
+(** [check_unit_name u] prints a warning if the derived module name [modname u]
+    should not be used as a module name as specified
+    by {!is_unit_name}[ ~strict:true]. *)
+val check_unit_name : t -> unit
+
+(** [make ~check ~source_file prefix] associates both the
+    [source_file] and the module name {!modname_from_source}[ target_prefix] to
+    the prefix filesystem path [prefix].
+
+   If [check_modname=true], this function emits a warning if the derived module
+   name is not valid according to {!check_unit_name}.
+*)
+val make: ?check_modname:bool -> source_file:filename -> file_prefix -> t
+
+(** {1:artifact_function Build artifacts }*)
+module Artifact: sig
+  type t
+(**  Metadata for a single compilation artifact:
+    - the module name associated to the artifact
+    - the filesystem path
+    - the input source file if it exists
+*)
+
+   (** [source_file a] is the source file of [a] if it exists. *)
+   val source_file: t -> filename option
+
+  (** [prefix a] is the filename prefix of the compilation artifact. *)
+   val prefix: t ->  file_prefix
+
+   (** [filename u] is the filesystem path for a compilation artifact. *)
+   val filename: t -> filename
+
+   (** [modname a] is the module name of the compilation artifact.*)
+   val modname: t -> modname
+
+   (** [from_filename filename] reconstructs the module name
+       [modname_from_source filename] associated to the artifact [filename]. *)
+   val from_filename: filename -> t
+
+end
+
+(** {1:info_build_artifacts Derived build artifact metadata} *)
+
+(** Those functions derive a specific [artifact] metadata from an [unit]
+    metadata.*)
+val cmi: t -> Artifact.t
+val cmo: t -> Artifact.t
+val cmx: t -> Artifact.t
+val obj: t -> Artifact.t
+val cmt: t -> Artifact.t
+val cmti: t -> Artifact.t
+val annot: t -> Artifact.t
+
+(** The functions below change the type of an artifact by updating the
+    extension of its filename.
+    Those functions purposefully do not cover all artifact kinds because we want
+    to track which artifacts are assumed to be bundled together. *)
+val companion_cmi: Artifact.t -> Artifact.t
+val companion_obj: Artifact.t -> Artifact.t
+val companion_cmt: Artifact.t -> Artifact.t
+
+
+(** {1:ml_mli_cmi_interaction Mli and cmi derived from implementation files } *)
+
+(** The compilation of module implementation changes in presence of mli and cmi
+    files, the function belows help to handle this. *)
+
+(** [mli_from_source u] is the interface source filename associated to the unit
+    [u]. The actual suffix depends on {!Config.interface_suffix}.
+*)
+val mli_from_source: t -> filename
+
+(** [mli_from_artifact t] is the name of the interface source file derived from
+    the artifact [t]. This variant is necessary when handling artifacts derived
+    from an unknown source files (e.g. packed modules). *)
+val mli_from_artifact: Artifact.t -> filename
+
+(** Check if the artifact is a cmi *)
+val is_cmi: Artifact.t -> bool
+
+(** [find_normalized_cmi u] finds in the load_path a file matching the module
+    name [modname u].
+    @raise Not_found if no such cmi exists *)
+val find_normalized_cmi: t -> Artifact.t

--- a/parsing/unit_info.mli
+++ b/parsing/unit_info.mli
@@ -39,9 +39,8 @@ val modname_from_source: filename -> modname
 (** {2:module_name_validation Module name validation function}*)
 
 (** [is_unit_name ~strict name] is true only if [name] can be used as a
-    valid module name. The [strict] mode enforces that the first character is
-    an ascii capital letter. *)
-val is_unit_name : strict:bool -> modname -> bool
+    valid module name. *)
+val is_unit_name : modname -> bool
 
 
 (** {1:unit_info Metadata for compilation unit} *)

--- a/tools/lintapidiff.ml
+++ b/tools/lintapidiff.ml
@@ -185,8 +185,7 @@ module Ast = struct
   let parse_file ~orig ~f ~init input =
     try
       let id =
-        orig |> Filename.chop_extension |> Filename.basename |>
-        String.capitalize_ascii |> Ident.create_persistent in
+        orig |> Unit_info.modname_from_source |> Ident.create_persistent in
       let ast = Pparse.file ~tool_name:"lintapidiff" input
           Parse.interface Pparse.Signature in
       Location.input_name := orig;

--- a/toplevel/byte/topeval.ml
+++ b/toplevel/byte/topeval.ml
@@ -267,7 +267,7 @@ and really_load_file recursive ppf name filename ic =
               when not (Symtable.is_global_defined
                 (Symtable.Global.Glob_compunit cu)) ->
                 let file = (Symtable.Compunit.name cu) ^ ".cmo" in
-                begin match Load_path.find_uncap file with
+                begin match Load_path.find_normalized file with
                 | exception Not_found -> ()
                 | file ->
                     if not (load_file recursive ppf file) then raise Load_failed

--- a/toplevel/expunge.ml
+++ b/toplevel/expunge.ml
@@ -40,7 +40,7 @@ let main () =
   let input_name = Sys.argv.(1) in
   let output_name = Sys.argv.(2) in
   for i = (if negate then 4 else 3) to Array.length Sys.argv - 1 do
-    to_keep := String.Set.add (String.capitalize_ascii Sys.argv.(i)) !to_keep
+    to_keep := String.Set.add (Unit_info.modulize Sys.argv.(i)) !to_keep
   done;
   let ic = open_in_bin input_name in
   let toc = Bytesections.read_toc ic in

--- a/toplevel/topcommon.ml
+++ b/toplevel/topcommon.ml
@@ -34,10 +34,7 @@ let print_warning = Location.print_warning
 let input_name = Location.input_name
 
 let parse_mod_use_file name lb =
-  let modname =
-    String.capitalize_ascii
-      (Filename.remove_extension (Filename.basename name))
-  in
+  let modname = Unit_info.modname_from_source name in
   let items =
     List.concat
       (List.map
@@ -402,7 +399,7 @@ let loading_hint_printer ppf cu =
   let global = Symtable.Global.Glob_compunit (Cmo_format.Compunit cu) in
   Symtable.report_error ppf (Symtable.Undefined_global global);
   let find_with_ext ext =
-    try Some (Load_path.find_uncap (cu ^ ext)) with Not_found -> None
+    try Some (Load_path.find_normalized (cu ^ ext)) with Not_found -> None
   in
   fprintf ppf
     "@.Hint: @[\

--- a/toplevel/topdirs.ml
+++ b/toplevel/topdirs.ml
@@ -95,7 +95,7 @@ let _ = add_directive "directory" (Directive_string dir_directory)
 let dir_remove_directory s =
   let d = expand_directory Config.standard_library s in
   let keep id =
-    match Load_path.find_uncap (Ident.name id ^ ".cmi") with
+    match Load_path.find_normalized (Ident.name id ^ ".cmi") with
     | exception Not_found -> true
     | fn -> Filename.dirname fn <> d
   in

--- a/typing/env.ml
+++ b/typing/env.ml
@@ -937,8 +937,8 @@ let imports () = Persistent_env.imports !persistent_env
 let import_crcs ~source crcs =
   Persistent_env.import_crcs !persistent_env ~source crcs
 
-let read_pers_mod modname filename =
-  Persistent_env.read !persistent_env read_sign_of_cmi modname filename
+let read_pers_mod cmi =
+  Persistent_env.read !persistent_env read_sign_of_cmi cmi
 
 let find_pers_mod name =
   Persistent_env.find !persistent_env read_sign_of_cmi name
@@ -2509,29 +2509,20 @@ let open_signature
   else open_signature None root env
 
 (* Read a signature from a file *)
-let read_signature modname filename =
-  let mda = read_pers_mod modname filename in
+let read_signature u =
+  let mda = read_pers_mod u in
   let md = Subst.Lazy.force_module_decl mda.mda_declaration in
   match md.md_type with
   | Mty_signature sg -> sg
   | Mty_ident _ | Mty_functor _ | Mty_alias _ -> assert false
 
-let is_identchar_latin1 = function
-  | 'A'..'Z' | 'a'..'z' | '_' | '\192'..'\214' | '\216'..'\246'
-  | '\248'..'\255' | '\'' | '0'..'9' -> true
-  | _ -> false
 
 let unit_name_of_filename fn =
   match Filename.extension fn with
-  | ".cmi" -> begin
-      let unit =
-        String.capitalize_ascii (Filename.remove_extension fn)
-      in
-      if String.for_all is_identchar_latin1 unit then
-        Some unit
-      else
-        None
-    end
+  | ".cmi" ->
+      let modname = Unit_info.modname_from_source fn in
+      if Unit_info.is_unit_name ~strict:false modname then Some modname
+      else None
   | _ -> None
 
 let persistent_structures_of_dir dir =
@@ -2541,27 +2532,27 @@ let persistent_structures_of_dir dir =
   |> String.Set.of_seq
 
 (* Save a signature to a file *)
-let save_signature_with_transform cmi_transform ~alerts sg modname filename =
+let save_signature_with_transform cmi_transform ~alerts sg cmi_info =
   Btype.cleanup_abbrev ();
   Subst.reset_for_saving ();
   let sg = Subst.signature Make_local (Subst.for_saving Subst.identity) sg in
   let cmi =
-    Persistent_env.make_cmi !persistent_env modname sg alerts
+    Persistent_env.make_cmi !persistent_env
+      (Unit_info.Artifact.modname cmi_info) sg alerts
     |> cmi_transform in
+  let filename = Unit_info.Artifact.filename cmi_info in
   let pm = save_sign_of_cmi
       { Persistent_env.Persistent_signature.cmi; filename } in
   Persistent_env.save_cmi !persistent_env
     { Persistent_env.Persistent_signature.filename; cmi } pm;
   cmi
 
-let save_signature ~alerts sg modname filename =
-  save_signature_with_transform (fun cmi -> cmi)
-    ~alerts sg modname filename
+let save_signature ~alerts sg cmi =
+  save_signature_with_transform (fun cmi -> cmi) ~alerts sg cmi
 
-let save_signature_with_imports ~alerts sg modname filename imports =
+let save_signature_with_imports ~alerts sg cmi imports =
   let with_imports cmi = { cmi with cmi_crcs = imports } in
-  save_signature_with_transform with_imports
-    ~alerts sg modname filename
+  save_signature_with_transform with_imports ~alerts sg cmi
 
 (* Make the initial environment *)
 let initial =

--- a/typing/env.ml
+++ b/typing/env.ml
@@ -2521,7 +2521,7 @@ let unit_name_of_filename fn =
   match Filename.extension fn with
   | ".cmi" ->
       let modname = Unit_info.modname_from_source fn in
-      if Unit_info.is_unit_name ~strict:false modname then Some modname
+      if Unit_info.is_unit_name modname then Some modname
       else None
   | _ -> None
 

--- a/typing/env.mli
+++ b/typing/env.mli
@@ -325,7 +325,7 @@ val add_local_type: Path.t -> type_declaration -> t -> t
    contents of the module is accessed. *)
 val add_persistent_structure : Ident.t -> t -> t
 
-(* Returns the set of persistent structures found in the given
+ (* Returns the set of persistent structures found in the given
    directory. *)
 val persistent_structures_of_dir : Load_path.Dir.t -> Misc.Stdlib.String.Set.t
 
@@ -398,14 +398,14 @@ val set_unit_name: string -> unit
 val get_unit_name: unit -> string
 
 (* Read, save a signature to/from a file *)
-val read_signature: modname -> filepath -> signature
+val read_signature: Unit_info.Artifact.t -> signature
         (* Arguments: module name, file name. Results: signature. *)
 val save_signature:
-  alerts:alerts -> signature -> modname -> filepath
+  alerts:alerts -> Types.signature -> Unit_info.Artifact.t
   -> Cmi_format.cmi_infos
         (* Arguments: signature, module name, file name. *)
 val save_signature_with_imports:
-  alerts:alerts -> signature -> modname -> filepath -> crcs
+  alerts:alerts -> signature -> Unit_info.Artifact.t -> crcs
   -> Cmi_format.cmi_infos
         (* Arguments: signature, module name, file name,
            imported units with their CRCs. *)

--- a/typing/persistent_env.ml
+++ b/typing/persistent_env.ml
@@ -37,7 +37,7 @@ module Persistent_signature = struct
       cmi : Cmi_format.cmi_infos }
 
   let load = ref (fun ~unit_name ->
-      match Load_path.find_uncap (unit_name ^ ".cmi") with
+      match Load_path.find_normalized (unit_name ^ ".cmi") with
       | filename -> Some { filename; cmi = read_cmi filename }
       | exception Not_found -> None)
 end
@@ -192,7 +192,9 @@ let acknowledge_pers_struct penv check modname pers_sig pm =
   Hashtbl.add persistent_structures modname (Found (ps, pm));
   ps
 
-let read_pers_struct penv val_of_pers_sig check modname filename =
+let read_pers_struct penv val_of_pers_sig check cmi =
+  let modname = Unit_info.Artifact.modname cmi in
+  let filename = Unit_info.Artifact.filename cmi in
   add_import penv modname;
   let cmi = read_cmi filename in
   let pers_sig = { Persistent_signature.filename; cmi } in
@@ -254,8 +256,8 @@ let check_pers_struct penv f ~loc name =
       let warn = Warnings.No_cmi_file(name, Some msg) in
         Location.prerr_warning loc warn
 
-let read penv f modname filename =
-  snd (read_pers_struct penv f true modname filename)
+let read penv f a =
+  snd (read_pers_struct penv f true a)
 
 let find penv f name =
   snd (find_pers_struct penv f true name)

--- a/typing/persistent_env.mli
+++ b/typing/persistent_env.mli
@@ -53,10 +53,8 @@ val clear_missing : 'a t -> unit
 
 val fold : 'a t -> (modname -> 'a -> 'b -> 'b) -> 'b -> 'b
 
-val read : 'a t -> (Persistent_signature.t -> 'a)
-  -> modname -> filepath -> 'a
-val find : 'a t -> (Persistent_signature.t -> 'a)
-  -> modname -> 'a
+val read : 'a t -> (Persistent_signature.t -> 'a) -> Unit_info.Artifact.t -> 'a
+val find : 'a t -> (Persistent_signature.t -> 'a) -> modname -> 'a
 
 val find_in_cache : 'a t -> modname -> 'a option
 

--- a/typing/printtyp.ml
+++ b/typing/printtyp.ml
@@ -383,7 +383,7 @@ let rec rewrite_double_underscore_paths env p =
       let better_lid =
         Ldot
           (Lident (String.sub name 0 i),
-           String.capitalize_ascii
+           Unit_info.modulize
              (String.sub name (i + 2) (String.length name - i - 2)))
       in
       match Env.find_module_by_name better_lid env with

--- a/typing/typemod.mli
+++ b/typing/typemod.mli
@@ -39,8 +39,8 @@ val type_toplevel_phrase:
   Typedtree.structure * Types.signature * Signature_names.t * Shape.t *
   Env.t
 val type_implementation:
-  string -> string -> string -> Env.t ->
-  Parsetree.structure -> Typedtree.implementation
+  Unit_info.t -> Env.t -> Parsetree.structure ->
+  Typedtree.implementation
 val type_interface:
         Env.t -> Parsetree.signature -> Typedtree.signature
 val transl_signature:
@@ -60,11 +60,11 @@ val modtype_of_package:
 val path_of_module : Typedtree.module_expr -> Path.t option
 
 val save_signature:
-  string -> Typedtree.signature -> string -> string ->
-  Env.t -> Cmi_format.cmi_infos -> unit
+  Unit_info.t -> Typedtree.signature -> Env.t ->
+  Cmi_format.cmi_infos -> unit
 
 val package_units:
-  Env.t -> string list -> string -> string -> Typedtree.module_coercion
+  Env.t -> string list -> Unit_info.Artifact.t -> Typedtree.module_coercion
 
 (* Should be in Envaux, but it breaks the build of the debugger *)
 val initial_env:

--- a/utils/load_path.ml
+++ b/utils/load_path.ml
@@ -37,10 +37,10 @@ module Dir = struct
     else
       None
 
-  let find_uncap t fn =
-    let fn = String.uncapitalize_ascii fn in
+  let find_normalized t fn =
+    let fn = Misc.normalized_unit_filename fn in
     let search base =
-      if String.uncapitalize_ascii base = fn then
+      if Misc.normalized_unit_filename base = fn then
         Some (Filename.concat t.path base)
       else
         None
@@ -85,7 +85,7 @@ let prepend_add dir =
   List.iter (fun base ->
       let fn = Filename.concat dir.Dir.path base in
       STbl.replace !files base fn;
-      STbl.replace !files_uncap (String.uncapitalize_ascii base) fn
+      STbl.replace !files_uncap (Misc.normalized_unit_filename base) fn
     ) dir.Dir.files
 
 let init ~auto_include l =
@@ -113,7 +113,7 @@ let add dir =
        let fn = Filename.concat dir.Dir.path base in
        if not (STbl.mem !files base) then
          STbl.replace !files base fn;
-       let ubase = String.uncapitalize_ascii base in
+       let ubase = Misc.normalized_unit_filename base in
        if not (STbl.mem !files_uncap ubase) then
          STbl.replace !files_uncap ubase fn)
     dir.Dir.files;
@@ -164,13 +164,13 @@ let find fn =
   with Not_found ->
     !auto_include_callback Dir.find fn
 
-let find_uncap fn =
+let find_normalized fn =
   assert (not Config.merlin || Local_store.is_bound ());
   try
     if is_basename fn && not !Sys.interactive then
-      STbl.find !files_uncap (String.uncapitalize_ascii fn)
+      STbl.find !files_uncap (Misc.normalized_unit_filename fn)
     else
-      Misc.find_in_path_uncap (get_paths ()) fn
+      Misc.find_in_path_normalized (get_paths ()) fn
   with Not_found ->
-    let fn_uncap = String.uncapitalize_ascii fn in
-    !auto_include_callback Dir.find_uncap fn_uncap
+    let fn_uncap = Misc.normalized_unit_filename fn in
+    !auto_include_callback Dir.find_normalized fn_uncap

--- a/utils/load_path.mli
+++ b/utils/load_path.mli
@@ -46,7 +46,7 @@ module Dir : sig
   val find : t -> string -> string option
   (** [find dir fn] returns the full path to [fn] in [dir]. *)
 
-  val find_uncap : t -> string -> string option
+  val find_normalized : t -> string -> string option
   (** As {!find}, but search also for uncapitalized name, i.e. if name is
       Foo.ml, either /path/Foo.ml or /path/foo.ml may be returned. *)
 end
@@ -77,9 +77,10 @@ val find : string -> string
     filename is a basename, i.e. doesn't contain a directory
     separator. *)
 
-val find_uncap : string -> string
-(** Same as [find], but search also for uncapitalized name, i.e.  if
-    name is Foo.ml, allow /path/Foo.ml and /path/foo.ml to match. *)
+val find_normalized : string -> string
+(** Same as [find], but search also for normalized unit name (see
+    {!Misc.normalized_unit_filename}), i.e. if name is [Foo.ml], allow
+    [/path/Foo.ml] and [/path/foo.ml] to match. *)
 
 val[@deprecated] add : Dir.t -> unit
 (** Old name for {!append_dir} *)

--- a/utils/misc.ml
+++ b/utils/misc.ml
@@ -277,7 +277,7 @@ let find_in_path_rel path name =
 
 let normalized_unit_filename = String.uncapitalize_ascii
 
-let find_in_path_uncap path name =
+let find_in_path_normalized path name =
   let uname = normalized_unit_filename name in
   let rec try_dir = function
     [] -> raise Not_found

--- a/utils/misc.ml
+++ b/utils/misc.ml
@@ -275,8 +275,10 @@ let find_in_path_rel path name =
       if Sys.file_exists fullname then fullname else try_dir rem
   in try_dir path
 
+let normalized_unit_filename = String.uncapitalize_ascii
+
 let find_in_path_uncap path name =
-  let uname = String.uncapitalize_ascii name in
+  let uname = normalized_unit_filename name in
   let rec try_dir = function
     [] -> raise Not_found
   | dir::rem ->

--- a/utils/misc.mli
+++ b/utils/misc.mli
@@ -210,10 +210,13 @@ val find_in_path: string list -> string -> string
 val find_in_path_rel: string list -> string -> string
        (** Search a relative file in a list of directories. *)
 
+ (** Normalize file name [Foo.ml] to [foo.ml] *)
+val normalized_unit_filename: string -> string
+
 val find_in_path_uncap: string list -> string -> string
-       (** Same, but search also for uncapitalized name, i.e.
-           if name is [Foo.ml], allow [/path/Foo.ml] and [/path/foo.ml]
-           to match. *)
+(** Same as {!find_in_path_rel} , but search also for normalized unit filename,
+    i.e. if name is [Foo.ml], allow [/path/Foo.ml] and [/path/foo.ml] to
+    match. *)
 
 val remove_file: string -> unit
        (** Delete the given file if it exists and is a regular file.

--- a/utils/misc.mli
+++ b/utils/misc.mli
@@ -213,7 +213,7 @@ val find_in_path_rel: string list -> string -> string
  (** Normalize file name [Foo.ml] to [foo.ml] *)
 val normalized_unit_filename: string -> string
 
-val find_in_path_uncap: string list -> string -> string
+val find_in_path_normalized: string list -> string -> string
 (** Same as {!find_in_path_rel} , but search also for normalized unit filename,
     i.e. if name is [Foo.ml], allow [/path/Foo.ml] and [/path/foo.ml] to
     match. *)


### PR DESCRIPTION
This PR is an alternative implementation of a slice of #11736 that is entirely focused on the handling of metadata (module name and source file currently) for compilation files (either compilation targets or source files) in order to avoid the proliferation of `String.{uncapitalize_ascii,capitalize_ascii}` within the compiler codebase.

In brief, this PR makes sure that we define the transformations from compilation filenames to module names in one place, and the same for the reverse transform. 
(However, dependencies made it easier to define the two functions in two different places).

After this PRs, the only calls to `String.capitalize_ascii` in the compiler happen in error message printers (typically to capitalize either `first` or `second`) and are only an obstacle to the internationalization of the compiler messages.

The PR goes one step further and ensures that the module name associated to a compilation file is computed once by tracking file metadata across change of file extensions.

With this change, it is quite straightforward to check that the compiler only tries to derive filenames from module names when doing lookup for `cmo`, `cmx` or `cmi` file through `Load_path`.

This suggest to me that a good solution for the compilation artifact ambiguity (which files between `Foo.cmi` and `foo.cmi` should provide the module `Foo`?) is to emit an error if the same directory contains distinct filename with the same normalization as suggested by @dbuenzli in #11736.