### PR TITLE
fix rendering of a manual example

### DIFF
--- a/manual/src/refman/expr.etex
+++ b/manual/src/refman/expr.etex
@@ -664,10 +664,10 @@ exception "Match_failure" is raised.
 %
 \index{Matchfailure\@\verb`Match_failure`}
 
-\begin{caml_example}{toplevel}[warning=8, error]
+\begin{caml_example}{toplevel}
 let unoption o =
   match o with
-  | Some x -> x 
+  | Some x -> x [@@expect warning 8];;
 
 let l = List.map unoption [Some 1; Some 10; None; Some 2];;
 \end{caml_example}


### PR DESCRIPTION
Before:

    # let unoption o =
        match o with
        | Some x -> x

    let l = List.map unoption [Some 1; Some 10; None; Some 2];;

    Warning 8 [partial-match]: this pattern-matching is not exhaustive.
    Here is an example of a case that is not matched:
    None

    Exception : Match_failure ("expr.etex ", 2, 2).

After:

    # let unoption o =
        match o with
        | Some x -> x ;;

    Warning 8 [partial-match]: this pattern-matching is not exhaustive.
    Here is an example of a case that is not matched:
    None

    val unoption : 'a option -> 'a = <fun >

    # let l = List.map unoption [Some 1; Some 10; None; Some 2];;
    Exception: Match_failure ("expr.etex", 2, 2).
