### PR TITLE
Workaround #12238 by using large lexing buffers

### DIFF
--- a/Changes
+++ b/Changes
@@ -191,6 +191,10 @@ Working version
   (Vincent Laviron, report by François Pottier, review by Nathanaëlle Courant
   and Gabriel Scherer)
 
+- #12238: printing source on error is wrong in presence of compiler directives
+  partial workaround by using large lexing buffers
+  (Gabriel Scherer, report by Mike Spivey and Vincent Laviron)
+
 OCaml 5.1.0
 ---------------
 


### PR DESCRIPTION
Some of our error printing styles print the source code at the location of the error. This source is found either in the lexing buffer when available (it has not been discarded to make room for more source code), orelse by trying to re-open the source file. Re-opening the source file is not so reliable, in particular it fails in presence of preprocessor directives (the user-facing locations we have do not necessarily refer to real locations in the input file).

We propose to workaround this issue by simply using large lexing buffers by default, so that the vast majority of program keep the whole source input in the lexing buffer, and the unreliable fallback is rarely used.