### PR TITLE
Tweak the dropped runtime events test

### DIFF
--- a/testsuite/tests/lib-runtime-events/test_dropped_events.ml
+++ b/testsuite/tests/lib-runtime-events/test_dropped_events.ml
@@ -14,11 +14,16 @@
 type Runtime_events.User.tag += Ev
 let ev = Runtime_events.User.register "ev" Ev Runtime_events.Type.int
 
-let producer () =
+let target_callbacks_count = 10
+let lost_events_callbacks = Atomic.make 0
+
+let rec producer () =
   let open Runtime_events in
   for _ = 0 to 100000 do
     User.write ev 0
-  done
+  done;
+  if Atomic.get lost_events_callbacks < target_callbacks_count then
+    producer ()
 
 let ready = Atomic.make 0
 
@@ -35,9 +40,12 @@ let _ =
     wait_ready ();
     producer ())
 
+let lost_events _ _ =
+  Atomic.incr lost_events_callbacks
+
 let callbacks =
   let open Runtime_events in
-  let evs = Runtime_events.Callbacks.create ()
+  let evs = Runtime_events.Callbacks.create ~lost_events ()
   in
   let id_callback d ts c i =
     assert (i = 0)
@@ -49,7 +57,9 @@ let ()
   Unix.sleepf 0.1;
   let cursor = Runtime_events.create_cursor None in
   wait_ready ();
-  for _ = 0 to 10 do
-    Runtime_events.read_poll cursor callbacks None
-    |> ignore
+  while Atomic.get lost_events_callbacks < target_callbacks_count do
+    for _ = 0 to 10 do
+      Runtime_events.read_poll cursor callbacks None
+      |> ignore
+    done
   done

--- a/testsuite/tests/lib-runtime-events/test_dropped_events.ml
+++ b/testsuite/tests/lib-runtime-events/test_dropped_events.ml
@@ -2,7 +2,7 @@
  not-msvc; (* FIXME: currently flaky on clang-cl 64 bits *)
  include runtime_events;
  include unix;
- set OCAMLRUNPARAM = "e=6";
+ ocamlrunparam += ",e=6";
  hasunix;
  {
    native;


### PR DESCRIPTION
While debugging something else, @NickBarnes and I spotted that this test was setting `OCAMLRUNPARAM` in a slightly unusual way. We then further looked at this test and wondered how it can ever fail (I'm guessing its original intent was more to ensure that the runtime didn't segfault!) so I've added a check to ensure events were actually dropped (and also checked that with suitably large `e` they are indeed _not_ dropped).

cc @sadiqj