### PR TITLE
Reduce loop length in runtime event test to avoid overflowing ring buffers

### DIFF
--- a/testsuite/tests/lib-runtime-events/test_caml.ml
+++ b/testsuite/tests/lib-runtime-events/test_caml.ml
@@ -1,14 +1,11 @@
 (* TEST
  include runtime_events;
+ ocamlrunparam += ",e=17";
 *)
+
 open Runtime_events
 
-let major = ref 0
-let minor = ref 0
-let compact = ref 0
-let majors = ref 0
-let minors = ref 0
-let compacts = ref 0
+(* Record whether we have seen an EV_RING_START lifecycle event. *)
 
 let got_start = ref false
 
@@ -16,24 +13,32 @@ let lifecycle domain_id ts lifecycle_event data =
     match lifecycle_event with
     | EV_RING_START ->
         begin
-            assert(match data with
-            | Some(pid) -> true
-            | None -> false);
+            assert (match data with
+                    | Some(pid) -> true
+                    | None -> false);
             got_start := true
         end
     | _ -> ()
+
+(* Count completed major and minor collections, and check that phase
+ * begin/end callbacks are called in order. *)
+
+let in_major = ref false
+let in_minor = ref false
+let majors = ref 0
+let minors = ref 0
 
 let runtime_begin domain_id ts phase =
     match phase with
     | EV_MAJOR_FINISH_CYCLE ->
         begin
-            assert(!major == 0);
-            major := 1
+            assert (not !in_major);
+            in_major := true
         end
     | EV_MINOR ->
         begin
-            assert(!minor == 0);
-            minor := 1
+            assert (not !in_minor);
+            in_minor := true
         end
     | _ -> ()
 
@@ -41,22 +46,30 @@ let runtime_end domain_id ts phase =
     match phase with
     | EV_MAJOR_FINISH_CYCLE ->
         begin
-            assert(!major == 1);
-            major := 0;
+            assert !in_major;
+            in_major := false;
             incr majors
         end
     | EV_MINOR ->
         begin
-            assert(!minor == 1);
-            minor := 0;
+            assert !in_minor;
+            in_minor := false;
             incr minors
         end
     | _ -> ()
+
+(* Record when unprocessed events are lost. If you see these messages,
+ * it probably means your ring buffers are too small; try changing
+ * the ocamlrunparam e=N setting at the head of this file.
+ * Note that we only process events at the end of each "epoch" of
+ * the test. *)
 
 let lost_events domain_id num =
     Printf.printf "Lost %d events\n" num
 
 let epochs = 20
+
+let majors_per_epoch = 100
 
 let () =
     let list_ref = ref [] in
@@ -66,7 +79,7 @@ let () =
                                     ~lost_events ()
     in
     for epoch = 1 to epochs do
-        for a = 1 to 100 do
+        for a = 1 to majors_per_epoch do
             list_ref := [];
             for a = 1 to 10 do
                 list_ref := (Sys.opaque_identity(ref 42)) :: !list_ref
@@ -75,5 +88,5 @@ let () =
         done;
         ignore(read_poll cursor callbacks None)
     done;
-    assert(!got_start);
+    assert !got_start;
     Printf.printf "minors: %d, major cycles: %d\n" !minors !majors

--- a/testsuite/tests/lib-runtime-events/test_caml.ml
+++ b/testsuite/tests/lib-runtime-events/test_caml.ml
@@ -1,15 +1,12 @@
 (* TEST
  include runtime_events;
- ocamlrunparam += ",e=17";
 *)
 
 (* Tests that:
  * - the runtime events subsystem works, logging events and passing
  *   them to OCaml;
  * - runtime event phases start and stop in matched pairs;
- * - major and minor collections happen at expected frequencies;
- * - it's possible to change the size of runtime event ring buffers
- *   with OCAMLRUNPARAM.
+ * - major and minor collections happen at expected frequencies.
  *)
 
 open Runtime_events
@@ -77,7 +74,7 @@ let lost_events domain_id num =
     Printf.printf "Lost %d events\n" num
 
 let epochs = 20
-let majors_per_epoch = 100
+let majors_per_epoch = 50
 let conses_per_major = 10
 
 let () =

--- a/testsuite/tests/lib-runtime-events/test_caml.reference
+++ b/testsuite/tests/lib-runtime-events/test_caml.reference
@@ -1,1 +1,1 @@
-minors: 18000, major cycles: 6000
+minors: 9000, major cycles: 3000


### PR DESCRIPTION
`tests/lib-runtime-events/test_caml.ml` is failing on a recent PR (#12390), because that test nearly exceeds the ring buffer size, and new events added in the PR cause them to overflow and events to be lost. This tiny PR grows the ring buffers in that test, and also adds comments and improves some variable names to make the test easier to hack on in future.