### PR TITLE
seek_in, seek_out: consistently fail if pos < 0

### DIFF
--- a/Changes
+++ b/Changes
@@ -233,6 +233,11 @@ Working version
   (Vincent Laviron, report by François Pottier, review by Nathanaëlle Courant
   and Gabriel Scherer)
 
+- #12401: `seek_in` and `seek_out` sometimes returned normally when given
+  negative offsets, instead of failing. Now both functions should consistently
+  raise `Sys_error` in this case.
+  (Nicolás Ojeda Bär, review by Gabriel Scherer)
+
 OCaml 5.1.0
 ---------------
 

--- a/runtime/io.c
+++ b/runtime/io.c
@@ -328,9 +328,11 @@ CAMLexport void caml_really_putblock(struct channel *channel,
 
 CAMLexport void caml_seek_out(struct channel *channel, file_offset dest)
 {
+  file_offset res;
   caml_flush(channel);
   caml_enter_blocking_section_no_pending();
-  if (lseek(channel->fd, dest, SEEK_SET) != dest) {
+  res = lseek(channel->fd, dest, SEEK_SET);
+  if (res < 0 || res != dest) {
     caml_leave_blocking_section();
     caml_sys_error(NO_ARG);
   }
@@ -442,13 +444,15 @@ CAMLexport intnat caml_really_getblock(struct channel *chan, char *p, intnat n)
 
 CAMLexport void caml_seek_in(struct channel *channel, file_offset dest)
 {
+  file_offset res;
   if (dest >= channel->offset - (channel->max - channel->buff)
       && dest <= channel->offset
       && (channel->flags & CHANNEL_TEXT_MODE) == 0) {
     channel->curr = channel->max - (channel->offset - dest);
   } else {
     caml_enter_blocking_section_no_pending();
-    if (lseek(channel->fd, dest, SEEK_SET) != dest) {
+    res = lseek(channel->fd, dest, SEEK_SET);
+    if (res < 0 || res != dest) {
       caml_leave_blocking_section();
       caml_sys_error(NO_ARG);
     }


### PR DESCRIPTION
In #12400 is it observed that the behaviour of `seek_in` and `seek_out` is not fully specified when passed negative offsets. This PR proposes to make this a hard error (raising `Invalid_argument`).

Fixes #12400