### PR TITLE
Make `Unix.create_process_env` thread-safe in all cases

### DIFF
--- a/Changes
+++ b/Changes
@@ -280,6 +280,11 @@ Working version
 - #12267: Fix stack alignment computation
   (Miod Vallat, report by Jan Midtgaard, review by Gabriel Scherer)
 
+- #12395, #12404: Fix thread-unsafety in the fallback implementation of
+  `Unix.create_process` (the one used when `posix_spawnp` is unavailable)
+  (Xavier Leroy, report by Chris Vine, review by Nicolás Ojeda Bär)
+
+
 OCaml 5.1.0 release branch
 --------------------------
 


### PR DESCRIPTION
If neither `spawnp` nor `execvpe` are provided by the C library, the emulation code in otherlibs/unix, which is based on `fork`, ended up allocating memory in the child process using `malloc`.

This is not thread-safe: if the `fork` occurs while another OCaml domain or C thread is running inside `malloc`, the child process can inherit a memory state where it's unsafe to do `malloc`.  For example, the mutex protecting `malloc` is locked, because it was locked at `fork` time, but the other thread is no longer there to finish the `malloc` and unlock the mutex, so `malloc` deadlocks in the child process.

This PR proposes a simple fix: in the child process, instead of calling our `malloc`-based emulation of `execvpe`, we just set `environ` to the desired environment and call `execvp`.  This is safe because no other thread is running in the child process, so nobody can observe the change to the global variable `environ`.

Fixes: #12395.
