### PR TITLE
Resource-safe C interface: `caml/fail.h`

### DIFF
--- a/Changes
+++ b/Changes
@@ -49,6 +49,12 @@ _______________
    Guillaume Munch-Maccagnoni and Xavier Leroy,
    suggested by Guillaume Munch-Maccagnoni)
 
+- #12407: Resource-handling improvements: add exception-returning
+  variants for all exception-raising functions in `caml/fail.h`, for
+  the purpose of cleaning-up state and resources before raising.
+  (Guillaume Munch-Maccagnoni, review by Damien Doligez, Xavier Leroy and
+   Gabriel Scherer)
+
 - #13086: Avoid spurious major GC slices.
   (Damien Doligez, report by Stephen Dolan, review by Gabriel Scherer
    and Stephen Dolan)

--- a/Makefile
+++ b/Makefile
@@ -1128,6 +1128,7 @@ runtime_COMMON_C_SOURCES = \
   domain \
   dynlink \
   extern \
+  fail \
   fiber \
   finalise \
   floats \

--- a/manual/src/cmds/intf-c.etex
+++ b/manual/src/cmds/intf-c.etex
@@ -911,6 +911,12 @@ null-terminated C string, raises the exception \var{id} with a copy of
 the C string \var{s} as argument.
 \end{itemize}
 
+Sometimes, it is necessary to clean-up state and release resources
+before actually raising the exception back into OCaml. To this end,
+alternative functions that return the exception instead of raising it
+directly ("caml_exception_failure", "caml_exception_invalid_argument",
+etc.) are provided.
+
 \section{s:c-gc-harmony}{Living in harmony with the garbage collector}
 
 Unused blocks in the heap are automatically reclaimed by the garbage

--- a/runtime/caml/fail.h
+++ b/runtime/caml/fail.h
@@ -79,13 +79,19 @@ int caml_is_special_exception(value exn);
 extern "C" {
 #endif
 
-/* The following functions raise immediately into OCaml. */
+/* The following functions raise immediately into OCaml.
+
+   The argument [exn_constr] can be obtained using [caml_named_value]
+   from caml/callback.h after registering and naming an exception from
+   OCaml using [Callback.register_exception].
+*/
 CAMLnoret CAMLextern void caml_raise (value exception);
-CAMLnoret CAMLextern void caml_raise_constant (value tag);
-CAMLnoret CAMLextern void caml_raise_with_arg (value tag, value arg);
-CAMLnoret CAMLextern void caml_raise_with_args (value tag,
+CAMLnoret CAMLextern void caml_raise_constant (value exn_constr);
+CAMLnoret CAMLextern void caml_raise_with_arg (value exn_constr, value arg);
+CAMLnoret CAMLextern void caml_raise_with_args (value exn_constr,
                                                 int nargs, value arg[]);
-CAMLnoret CAMLextern void caml_raise_with_string (value tag, char const * msg);
+CAMLnoret CAMLextern void caml_raise_with_string (value exn_constr,
+                                                  char const * msg);
 CAMLnoret CAMLextern void caml_failwith (char const *msg);
 CAMLnoret CAMLextern void caml_failwith_value (value msg);
 CAMLnoret CAMLextern void caml_invalid_argument (char const *msg);
@@ -101,11 +107,15 @@ CAMLnoret CAMLextern void caml_raise_sys_blocked_io (void);
 
 /* Non-raising variants of the above functions. The exception is
    returned as a normal value, which can be raised with [caml_raise],
-   typically after cleaning-up resources. */
-CAMLextern value caml_exception_constant (value tag);
-CAMLextern value caml_exception_with_arg (value tag, value arg);
-CAMLextern value caml_exception_with_args (value tag, int nargs, value arg[]);
-CAMLextern value caml_exception_with_string (value tag, char const * msg);
+   or returned as a value of type [caml_result] using
+   [Result_exception], typically to allow resource clean-up before
+   raising the exception. */
+CAMLextern value caml_exception_constant (value exn_constr);
+CAMLextern value caml_exception_with_arg (value exn_constr, value arg);
+CAMLextern value caml_exception_with_args (value exn_constr,
+                                           int nargs, value arg[]);
+CAMLextern value caml_exception_with_string (value exn_constr,
+                                             char const * msg);
 CAMLextern value caml_exception_failure (char const *msg);
 CAMLextern value caml_exception_failure_value (value msg);
 CAMLextern value caml_exception_invalid_argument (char const *msg);

--- a/runtime/caml/fail.h
+++ b/runtime/caml/fail.h
@@ -79,40 +79,45 @@ int caml_is_special_exception(value exn);
 extern "C" {
 #endif
 
-CAMLnoret CAMLextern void caml_raise (value bucket);
-
+/* The following functions raise immediately into OCaml. */
+CAMLnoret CAMLextern void caml_raise (value exception);
 CAMLnoret CAMLextern void caml_raise_constant (value tag);
-
 CAMLnoret CAMLextern void caml_raise_with_arg (value tag, value arg);
-
-CAMLnoret CAMLextern
-void caml_raise_with_args (value tag, int nargs, value arg[]);
-
+CAMLnoret CAMLextern void caml_raise_with_args (value tag,
+                                                int nargs, value arg[]);
 CAMLnoret CAMLextern void caml_raise_with_string (value tag, char const * msg);
-
 CAMLnoret CAMLextern void caml_failwith (char const *msg);
-
 CAMLnoret CAMLextern void caml_failwith_value (value msg);
-
 CAMLnoret CAMLextern void caml_invalid_argument (char const *msg);
-
 CAMLnoret CAMLextern void caml_invalid_argument_value (value msg);
-
 CAMLnoret CAMLextern void caml_raise_out_of_memory (void);
-
 CAMLnoret CAMLextern void caml_raise_stack_overflow (void);
-
 CAMLnoret CAMLextern void caml_raise_sys_error (value);
-
 CAMLnoret CAMLextern void caml_raise_end_of_file (void);
-
 CAMLnoret CAMLextern void caml_raise_zero_divide (void);
-
 CAMLnoret CAMLextern void caml_raise_not_found (void);
-
 CAMLnoret CAMLextern void caml_array_bound_error (void);
-
 CAMLnoret CAMLextern void caml_raise_sys_blocked_io (void);
+
+/* Non-raising variants of the above functions. The exception is
+   returned as a normal value, which can be raised with [caml_raise],
+   typically after cleaning-up resources. */
+CAMLextern value caml_exception_constant (value tag);
+CAMLextern value caml_exception_with_arg (value tag, value arg);
+CAMLextern value caml_exception_with_args (value tag, int nargs, value arg[]);
+CAMLextern value caml_exception_with_string (value tag, char const * msg);
+CAMLextern value caml_exception_failure (char const *msg);
+CAMLextern value caml_exception_failure_value (value msg);
+CAMLextern value caml_exception_invalid_argument (char const *msg);
+CAMLextern value caml_exception_invalid_argument_value (value msg);
+CAMLextern value caml_exception_out_of_memory (void);
+CAMLextern value caml_exception_stack_overflow (void);
+CAMLextern value caml_exception_sys_error (value msg);
+CAMLextern value caml_exception_end_of_file (void);
+CAMLextern value caml_exception_zero_divide (void);
+CAMLextern value caml_exception_not_found (void);
+CAMLextern value caml_exception_array_bound_error (void);
+CAMLextern value caml_exception_sys_blocked_io (void);
 
 /* Returns the value of a [caml_result] or raises the exception.
    This function replaced [caml_raise_if_exception] in 5.3. */

--- a/runtime/fail.c
+++ b/runtime/fail.c
@@ -1,0 +1,72 @@
+/**************************************************************************/
+/*                                                                        */
+/*                                 OCaml                                  */
+/*                                                                        */
+/*             Xavier Leroy, projet Cristal, INRIA Rocquencourt           */
+/*                                                                        */
+/*   Copyright 1996 Institut National de Recherche en Informatique et     */
+/*     en Automatique.                                                    */
+/*                                                                        */
+/*   All rights reserved.  This file is distributed under the terms of    */
+/*   the GNU Lesser General Public License version 2.1, with the          */
+/*   special exception on linking described in the file LICENSE.          */
+/*                                                                        */
+/**************************************************************************/
+
+#define CAML_INTERNALS
+
+/* Raising exceptions from C. */
+
+#include "caml/alloc.h"
+#include "caml/fail.h"
+#include "caml/memory.h"
+#include "caml/mlvalues.h"
+
+/* Used by the stack overflow handler -> deactivate ASAN (see
+   segv_handler in signals_nat.c). */
+CAMLno_asan
+CAMLexport void caml_raise_constant(value tag)
+{
+  caml_raise(tag);
+}
+
+CAMLexport void caml_raise_with_arg(value tag, value arg)
+{
+  CAMLparam2 (tag, arg);
+  CAMLlocal1 (bucket);
+
+  bucket = caml_alloc_small (2, 0);
+  Field(bucket, 0) = tag;
+  Field(bucket, 1) = arg;
+  caml_raise(bucket);
+  CAMLnoreturn;
+}
+
+CAMLexport void caml_raise_with_args(value tag, int nargs, value args[])
+{
+  CAMLparam1 (tag);
+  CAMLxparamN (args, nargs);
+  value bucket;
+  int i;
+
+  CAMLassert(1 + nargs <= Max_young_wosize);
+  bucket = caml_alloc_small (1 + nargs, 0);
+  Field(bucket, 0) = tag;
+  for (i = 0; i < nargs; i++) Field(bucket, 1 + i) = args[i];
+  caml_raise(bucket);
+  CAMLnoreturn;
+}
+
+CAMLexport void caml_raise_with_string(value tag, char const *msg)
+{
+  CAMLparam1(tag);
+  value v_msg = caml_copy_string(msg);
+  caml_raise_with_arg(tag, v_msg);
+  CAMLnoreturn;
+}
+
+CAMLexport value caml_raise_if_exception(value val)
+{
+  if (Is_exception_result(val)) caml_raise(Extract_exception(val));
+  return val;
+}

--- a/runtime/fail.c
+++ b/runtime/fail.c
@@ -22,72 +22,73 @@
 #include "caml/memory.h"
 #include "caml/mlvalues.h"
 
-#define Assert_is_tag(tag)                                  \
-  (CAMLassert(Is_block(tag) && Tag_val(tag) == Object_tag))
+#define Assert_is_exn_constructor(v)                    \
+  (CAMLassert(Is_block(v) && Tag_val(v) == Object_tag))
 
-CAMLexport value caml_exception_constant(value tag)
+CAMLexport value caml_exception_constant(value exn_constr)
 {
-  Assert_is_tag(tag);
-  return tag;
+  Assert_is_exn_constructor(exn_constr);
+  return exn_constr;
 }
 
-CAMLexport value caml_exception_with_arg(value tag, value arg)
+CAMLexport value caml_exception_with_arg(value exn_constr, value arg)
 {
-  CAMLparam2 (tag, arg);
+  CAMLparam2 (exn_constr, arg);
   CAMLlocal1 (bucket);
-  Assert_is_tag(tag);
+  Assert_is_exn_constructor(exn_constr);
 
   bucket = caml_alloc_small (2, 0);
-  Field(bucket, 0) = tag;
+  Field(bucket, 0) = exn_constr;
   Field(bucket, 1) = arg;
   CAMLreturn(bucket);
 }
 
-CAMLexport value caml_exception_with_args(value tag, int nargs, value args[])
+CAMLexport value caml_exception_with_args(value exn_constr,
+                                          int nargs, value args[])
 {
-  CAMLparam1 (tag);
+  CAMLparam1 (exn_constr);
   CAMLxparamN (args, nargs);
-  Assert_is_tag(tag);
+  Assert_is_exn_constructor(exn_constr);
 
   value bucket;
   int i;
 
   CAMLassert(1 + nargs <= Max_young_wosize);
   bucket = caml_alloc_small (1 + nargs, 0);
-  Field(bucket, 0) = tag;
+  Field(bucket, 0) = exn_constr;
   for (i = 0; i < nargs; i++) Field(bucket, 1 + i) = args[i];
   CAMLreturn(bucket);
 }
 
-CAMLexport value caml_exception_with_string(value tag, char const *msg)
+CAMLexport value caml_exception_with_string(value exn_constr, char const *msg)
 {
-  CAMLparam1(tag);
+  CAMLparam1(exn_constr);
   value v_msg = caml_copy_string(msg);
-  CAMLreturn(caml_exception_with_arg(tag, v_msg));
+  CAMLreturn(caml_exception_with_arg(exn_constr, v_msg));
 }
 
 
 /* Used by the stack overflow handler -> deactivate ASAN (see
    segv_handler in signals_nat.c). */
 CAMLno_asan
-CAMLexport void caml_raise_constant(value tag)
+CAMLexport void caml_raise_constant(value exn_constr)
 {
-  caml_raise(caml_exception_constant(tag));
+  caml_raise(caml_exception_constant(exn_constr));
 }
 
-CAMLexport void caml_raise_with_arg(value tag, value arg)
+CAMLexport void caml_raise_with_arg(value exn_constr, value arg)
 {
-  caml_raise(caml_exception_with_arg(tag, arg));
+  caml_raise(caml_exception_with_arg(exn_constr, arg));
 }
 
-CAMLexport void caml_raise_with_args(value tag, int nargs, value arg[])
+CAMLexport void caml_raise_with_args(value exn_constr, int nargs, value arg[])
 {
-  caml_raise(caml_exception_with_args(tag, nargs, arg));
+  caml_raise(caml_exception_with_args(exn_constr, nargs, arg));
 }
 
-CAMLexport void caml_raise_with_string(value tag, char const * msg)
+CAMLexport void caml_raise_with_string(value exn_constr, char const * msg)
 {
-  caml_raise(caml_exception_with_string(tag, msg));
+  caml_raise(caml_exception_with_string(exn_constr, msg));
 }
 
 CAMLexport void caml_failwith(char const *msg)

--- a/runtime/fail.c
+++ b/runtime/fail.c
@@ -22,30 +22,33 @@
 #include "caml/memory.h"
 #include "caml/mlvalues.h"
 
-/* Used by the stack overflow handler -> deactivate ASAN (see
-   segv_handler in signals_nat.c). */
-CAMLno_asan
-CAMLexport void caml_raise_constant(value tag)
+#define Assert_is_tag(tag)                                  \
+  (CAMLassert(Is_block(tag) && Tag_val(tag) == Object_tag))
+
+CAMLexport value caml_exception_constant(value tag)
 {
-  caml_raise(tag);
+  Assert_is_tag(tag);
+  return tag;
 }
 
-CAMLexport void caml_raise_with_arg(value tag, value arg)
+CAMLexport value caml_exception_with_arg(value tag, value arg)
 {
   CAMLparam2 (tag, arg);
   CAMLlocal1 (bucket);
+  Assert_is_tag(tag);
 
   bucket = caml_alloc_small (2, 0);
   Field(bucket, 0) = tag;
   Field(bucket, 1) = arg;
-  caml_raise(bucket);
-  CAMLnoreturn;
+  CAMLreturn(bucket);
 }
 
-CAMLexport void caml_raise_with_args(value tag, int nargs, value args[])
+CAMLexport value caml_exception_with_args(value tag, int nargs, value args[])
 {
   CAMLparam1 (tag);
   CAMLxparamN (args, nargs);
+  Assert_is_tag(tag);
+
   value bucket;
   int i;
 
@@ -53,16 +56,98 @@ CAMLexport void caml_raise_with_args(value tag, int nargs, value args[])
   bucket = caml_alloc_small (1 + nargs, 0);
   Field(bucket, 0) = tag;
   for (i = 0; i < nargs; i++) Field(bucket, 1 + i) = args[i];
-  caml_raise(bucket);
-  CAMLnoreturn;
+  CAMLreturn(bucket);
 }
 
-CAMLexport void caml_raise_with_string(value tag, char const *msg)
+CAMLexport value caml_exception_with_string(value tag, char const *msg)
 {
   CAMLparam1(tag);
   value v_msg = caml_copy_string(msg);
-  caml_raise_with_arg(tag, v_msg);
-  CAMLnoreturn;
+  CAMLreturn(caml_exception_with_arg(tag, v_msg));
+}
+
+
+/* Used by the stack overflow handler -> deactivate ASAN (see
+   segv_handler in signals_nat.c). */
+CAMLno_asan
+CAMLexport void caml_raise_constant(value tag)
+{
+  caml_raise(caml_exception_constant(tag));
+}
+
+CAMLexport void caml_raise_with_arg(value tag, value arg)
+{
+  caml_raise(caml_exception_with_arg(tag, arg));
+}
+
+CAMLexport void caml_raise_with_args(value tag, int nargs, value arg[])
+{
+  caml_raise(caml_exception_with_args(tag, nargs, arg));
+}
+
+CAMLexport void caml_raise_with_string(value tag, char const * msg)
+{
+  caml_raise(caml_exception_with_string(tag, msg));
+}
+
+CAMLexport void caml_failwith(char const *msg)
+{
+  caml_raise(caml_exception_failure(msg));
+}
+
+CAMLexport void caml_failwith_value(value msg)
+{
+  caml_raise(caml_exception_failure_value(msg));
+}
+
+CAMLexport void caml_invalid_argument(char const *msg)
+{
+  caml_raise(caml_exception_invalid_argument(msg));
+}
+
+CAMLexport void caml_invalid_argument_value(value msg)
+{
+  caml_raise(caml_exception_invalid_argument_value(msg));
+}
+
+CAMLexport void caml_raise_out_of_memory(void)
+{
+  caml_raise(caml_exception_out_of_memory());
+}
+
+CAMLexport void caml_raise_stack_overflow(void)
+{
+  caml_raise(caml_exception_stack_overflow());
+}
+
+CAMLexport void caml_raise_sys_error(value msg)
+{
+  caml_raise(caml_exception_sys_error(msg));
+}
+
+CAMLexport void caml_raise_end_of_file(void)
+{
+  caml_raise(caml_exception_end_of_file());
+}
+
+CAMLexport void caml_raise_zero_divide(void)
+{
+  caml_raise(caml_exception_zero_divide());
+}
+
+CAMLexport void caml_raise_not_found(void)
+{
+  caml_raise(caml_exception_not_found());
+}
+
+CAMLexport void caml_array_bound_error(void)
+{
+  caml_raise(caml_exception_array_bound_error());
+}
+
+CAMLexport void caml_raise_sys_blocked_io(void)
+{
+  caml_raise(caml_exception_sys_blocked_io());
 }
 
 CAMLexport value caml_raise_if_exception(value val)

--- a/runtime/fail_byt.c
+++ b/runtime/fail_byt.c
@@ -55,46 +55,6 @@ CAMLexport void caml_raise(value v)
   siglongjmp(Caml_state->external_raise->jmp->buf, 1);
 }
 
-CAMLexport void caml_raise_constant(value tag)
-{
-  caml_raise(tag);
-}
-
-CAMLexport void caml_raise_with_arg(value tag, value arg)
-{
-  CAMLparam2 (tag, arg);
-  CAMLlocal1 (bucket);
-
-  bucket = caml_alloc_small (2, 0);
-  Field(bucket, 0) = tag;
-  Field(bucket, 1) = arg;
-  caml_raise(bucket);
-  CAMLnoreturn;
-}
-
-CAMLexport void caml_raise_with_args(value tag, int nargs, value args[])
-{
-  CAMLparam1 (tag);
-  CAMLxparamN (args, nargs);
-  value bucket;
-  int i;
-
-  CAMLassert(1 + nargs <= Max_young_wosize);
-  bucket = caml_alloc_small (1 + nargs, 0);
-  Field(bucket, 0) = tag;
-  for (i = 0; i < nargs; i++) Field(bucket, 1 + i) = args[i];
-  caml_raise(bucket);
-  CAMLnoreturn;
-}
-
-CAMLexport void caml_raise_with_string(value tag, char const *msg)
-{
-  CAMLparam1(tag);
-  value v_msg = caml_copy_string(msg);
-  caml_raise_with_arg(tag, v_msg);
-  CAMLnoreturn;
-}
-
 /* PR#5115: Built-in exceptions can be triggered by input_value
    while reading the initial value of [caml_global_data].
 

--- a/runtime/fail_byt.c
+++ b/runtime/fail_byt.c
@@ -82,89 +82,87 @@ static void check_global_data_param(char const *exception_name, char const *msg)
   }
 }
 
-Caml_inline value caml_get_failwith_tag (char const *msg)
+Caml_inline value caml_get_failwith_tag(char const *msg)
 {
   check_global_data_param("Failure", msg);
   return Field(caml_global_data, FAILURE_EXN);
 }
 
-CAMLexport void caml_failwith (char const *msg)
+CAMLexport value caml_exception_failure(char const *msg)
 {
-  caml_raise_with_string(caml_get_failwith_tag(msg), msg);
+  return caml_exception_with_string(caml_get_failwith_tag(msg), msg);
 }
 
-CAMLexport void caml_failwith_value (value msg)
+CAMLexport value caml_exception_failure_value(value msg)
 {
   CAMLparam1(msg);
   value tag = caml_get_failwith_tag(String_val(msg));
-  caml_raise_with_arg(tag, msg);
-  CAMLnoreturn;
+  CAMLreturn(caml_exception_with_arg(tag, msg));
 }
 
-Caml_inline value caml_get_invalid_argument_tag (char const *msg)
+Caml_inline value caml_get_invalid_argument_tag(char const *msg)
 {
   check_global_data_param("Invalid_argument", msg);
   return Field(caml_global_data, INVALID_EXN);
 }
 
-CAMLexport void caml_invalid_argument (char const *msg)
+CAMLexport value caml_exception_invalid_argument(char const *msg)
 {
-  caml_raise_with_string(caml_get_invalid_argument_tag(msg), msg);
+  return caml_exception_with_string(caml_get_invalid_argument_tag(msg), msg);
 }
 
-CAMLexport void caml_invalid_argument_value (value msg)
+CAMLexport value caml_exception_invalid_argument_value(value msg)
 {
   CAMLparam1(msg);
   value tag = caml_get_invalid_argument_tag(String_val(msg));
-  caml_raise_with_arg(tag, msg);
-  CAMLnoreturn;
+  CAMLreturn(caml_exception_with_arg(tag, msg));
 }
 
-CAMLexport void caml_array_bound_error(void)
+CAMLexport value caml_exception_array_bound_error(void)
 {
-  caml_invalid_argument("index out of bounds");
+  return caml_exception_invalid_argument("index out of bounds");
 }
 
-CAMLexport void caml_raise_out_of_memory(void)
+CAMLexport value caml_exception_out_of_memory(void)
 {
   check_global_data("Out_of_memory");
-  caml_raise_constant(Field(caml_global_data, OUT_OF_MEMORY_EXN));
+  return Field(caml_global_data, OUT_OF_MEMORY_EXN);
 }
 
-CAMLexport void caml_raise_stack_overflow(void)
+CAMLexport value caml_exception_stack_overflow(void)
 {
   check_global_data("Stack_overflow");
-  caml_raise_constant(Field(caml_global_data, STACK_OVERFLOW_EXN));
+  return Field(caml_global_data, STACK_OVERFLOW_EXN);
 }
 
-CAMLexport void caml_raise_sys_error(value msg)
+CAMLexport value caml_exception_sys_error(value msg)
 {
   check_global_data_param("Sys_error", String_val(msg));
-  caml_raise_with_arg(Field(caml_global_data, SYS_ERROR_EXN), msg);
+  return caml_exception_with_arg(Field(caml_global_data, SYS_ERROR_EXN), msg);
 }
 
-CAMLexport void caml_raise_end_of_file(void)
+CAMLexport value caml_exception_end_of_file(void)
 {
   check_global_data("End_of_file");
-  caml_raise_constant(Field(caml_global_data, END_OF_FILE_EXN));
+  return Field(caml_global_data, END_OF_FILE_EXN);
 }
 
-CAMLexport void caml_raise_zero_divide(void)
+CAMLexport value caml_exception_zero_divide(void)
 {
   check_global_data("Division_by_zero");
-  caml_raise_constant(Field(caml_global_data, ZERO_DIVIDE_EXN));
+  return Field(caml_global_data, ZERO_DIVIDE_EXN);
 }
 
-CAMLexport void caml_raise_not_found(void)
+CAMLexport value caml_exception_not_found(void)
 {
   check_global_data("Not_found");
-  caml_raise_constant(Field(caml_global_data, NOT_FOUND_EXN));
+  return Field(caml_global_data, NOT_FOUND_EXN);
 }
 
-CAMLexport void caml_raise_sys_blocked_io(void)
+CAMLexport value caml_exception_sys_blocked_io(void)
 {
   check_global_data("Sys_blocked_io");
-  caml_raise_constant(Field(caml_global_data, SYS_BLOCKED_IO));
+  return Field(caml_global_data, SYS_BLOCKED_IO);
 }
 
 int caml_is_special_exception(value exn) {

--- a/runtime/fail_nat.c
+++ b/runtime/fail_nat.c
@@ -89,48 +89,6 @@ void caml_raise(value v)
   caml_raise_exception(Caml_state, v);
 }
 
-/* Used by the stack overflow handler -> deactivate ASAN (see
-   segv_handler in signals_nat.c). */
-CAMLno_asan
-void caml_raise_constant(value tag)
-{
-  caml_raise(tag);
-}
-
-void caml_raise_with_arg(value tag, value arg)
-{
-  CAMLparam2 (tag, arg);
-  CAMLlocal1 (bucket);
-
-  bucket = caml_alloc_small (2, 0);
-  Field(bucket, 0) = tag;
-  Field(bucket, 1) = arg;
-  caml_raise(bucket);
-  CAMLnoreturn;
-}
-
-void caml_raise_with_args(value tag, int nargs, value args[])
-{
-  CAMLparam1 (tag);
-  CAMLxparamN (args, nargs);
-  value bucket;
-  int i;
-
-  bucket = caml_alloc (1 + nargs, 0);
-  Field(bucket, 0) = tag;
-  for (i = 0; i < nargs; i++) Field(bucket, 1 + i) = args[i];
-  caml_raise(bucket);
-  CAMLnoreturn;
-}
-
-void caml_raise_with_string(value tag, char const *msg)
-{
-  CAMLparam1(tag);
-  value v_msg = caml_copy_string(msg);
-  caml_raise_with_arg(tag, v_msg);
-  CAMLnoreturn;
-}
-
 void caml_failwith (char const *msg)
 {
   caml_raise_with_string((value) caml_exn_Failure, msg);


### PR DESCRIPTION
Dusting-off old commits, as a preliminary change to fix the error handling during the spawning of domains (#12269)...

This PR introduces `_exn` variants of the functions that do not immediately raise the exception, allowing for correct resource cleanup.

Another motivating example is given at https://github.com/ocaml/ocaml/issues/7423:

> caml_invalid_argument(str) is no return and does not free it's argument. So calling it with a string constructed dynamically will mean it'll never get freed.

This led at the time to the introduction of `caml_invalid_argument_value` and `caml_failwith_value` that accept an
OCaml string as argument, as a way to work around the lack of control on resource management. But this is a more general problem, for which the present commit gives a general solution that fits the rest of the resource-safe API.

This is best reviewed commit-per-commit.

cc @kayceesrk