### PR TITLE
Release callback early in domain_thread_func

### DIFF
--- a/Changes
+++ b/Changes
@@ -76,6 +76,10 @@ Working version
   (Guillaume Munch-Maccagnoni, review by Anil Madhavapeddy and KC
    Sivaramakrishnan)
 
+- #12408: `Domain.spawn` no longer leaks its functional argument for
+  the whole duration of the children domain lifetime.
+  (Guillaume Munch-Maccagnoni, review by Gabriel Scherer)
+
 ### Code generation and optimizations:
 
 - #11239: on x86-64 and RISC-V, reduce alignment of OCaml stacks from 16 to 8.


### PR DESCRIPTION
`caml_callback` is careful not to keep its callback alive for the duration of the call. This allows the closure to be collected as early as possible.

Similarly, this change makes sure not to keep the functional argument to `Domain.spawn` alive longer than needed.

cc @kayceesrk