### PR TITLE
Fix async exception handling inside Domain.spawn

### DIFF
--- a/Changes
+++ b/Changes
@@ -80,6 +80,10 @@ Working version
   the whole duration of the children domain lifetime.
   (Guillaume Munch-Maccagnoni, review by Gabriel Scherer)
 
+- #12409: Fix unsafety and deadlocks should an asynchronous exception
+  arise at specific locations during domain creation and shutdown.
+  (Guillaume Munch-Maccagnoni, review by Gabriel Scherer)
+
 ### Code generation and optimizations:
 
 - #11239: on x86-64 and RISC-V, reduce alignment of OCaml stacks from 16 to 8.

--- a/runtime/caml/sync.h
+++ b/runtime/caml/sync.h
@@ -29,6 +29,10 @@ typedef pthread_mutex_t * sync_mutex;
 CAMLextern int caml_mutex_lock(sync_mutex mut);
 CAMLextern int caml_mutex_unlock(sync_mutex mut);
 
+value caml_ml_mutex_lock(value wrapper);
+value caml_ml_mutex_unlock(value wrapper);
+value caml_ml_condition_broadcast(value wrapper);
+
 #endif /* CAML_INTERNALS */
 
 #endif /* CAML_SYNC_H */


### PR DESCRIPTION
This PR fixes unsafety and deadlocks, should an asynchronous exception arise at specific locations during domain creation and shutdown.

Explanation: some OCaml code is reimplemented in C for better control over asynchronous exceptions.

A simpler implementation could use masks (#8961) to have the needed control, but the present change is also useful as a preliminary work to fix #12269.

Note: this is based over #12408 for convenience.

cc @kayceesrk 