### PR TITLE
Correctly handle errors during `Domain.spawn`

### DIFF
--- a/Changes
+++ b/Changes
@@ -63,6 +63,12 @@ Working version
   under certain conditions.
   (Antonin Décimo, review by Nicolás Ojeda Bär)
 
+- #12269, #12410, #13063: Fix unsafety, deadlocks, and/or leaks should
+  rare errors happen during domain creation and thread
+  creation/registration.
+  (Guillaume Munch-Maccagnoni, review by Gabriel Scherer, B. Szilvasy,
+   Miod Vallat)
+
 ### Code generation and optimizations:
 
 ### Standard library:
@@ -499,7 +505,6 @@ OCaml 5.4.0
   prefetching data.
   (Tim McGilchrist, review by Nick Barnes, Antonin Décimo,
    Stephen Dolan and Miod Vallat)
-
 
 - #13675: Make Unix.map_file memory show up in Gc.Memprof.
   (Stephen Dolan, review by Guillaume Munch-Maccagnoni and Gabriel Scherer)

--- a/otherlibs/systhreads/st_pthreads.h
+++ b/otherlibs/systhreads/st_pthreads.h
@@ -109,6 +109,16 @@ static int st_masterlock_init(st_masterlock * m)
   return rc;
 }
 
+static void st_masterlock_destroy(st_masterlock * m)
+{
+  int rc;
+  rc = pthread_cond_destroy(&m->is_free);
+  CAMLassert(!rc);
+  rc = pthread_mutex_destroy(&m->lock);
+  CAMLassert(!rc);
+  (void)rc;
+}
+
 static uintnat st_masterlock_waiters(st_masterlock * m)
 {
   return atomic_load_acquire(&m->waiters);

--- a/otherlibs/systhreads/st_stubs.c
+++ b/otherlibs/systhreads/st_stubs.c
@@ -689,7 +689,7 @@ static void thread_init_current(caml_thread_t th)
 {
   st_tls_set(caml_thread_key, th);
   restore_runtime_state(th);
-  /* FIXME: deal with errors */
+  /* FIXME: deal with NULL error case */
   th->signal_stack = caml_init_signal_stack();
 }
 

--- a/otherlibs/systhreads/st_stubs.c
+++ b/otherlibs/systhreads/st_stubs.c
@@ -215,7 +215,7 @@ static void thread_lock_release(int dom_id)
 static atomic_uintnat thread_next_id = 0;
 
 /* Forward declarations */
-static value caml_threadstatus_new (void);
+static value caml_threadstatus_new_exn (void);
 static void caml_threadstatus_terminate (value);
 static st_retcode caml_threadstatus_wait (value);
 
@@ -414,13 +414,14 @@ void caml_thread_free_info(caml_thread_t th)
 
 /* Allocate a thread descriptor block. */
 
-static value caml_thread_new_descriptor(value clos)
+static value caml_thread_new_descriptor_exn(value clos)
 {
   CAMLparam1(clos);
   CAMLlocal1(mu);
   value descr;
   /* Create and initialize the termination semaphore */
-  mu = caml_threadstatus_new();
+  mu = caml_threadstatus_new_exn();
+  if (Is_exception_result(mu)) CAMLreturn(mu);
   /* Create a descriptor for the new thread */
   descr = caml_alloc_3(0, Val_long(atomic_fetch_add(&thread_next_id, +1)),
                        clos, mu);
@@ -446,7 +447,7 @@ static caml_thread_t thread_alloc_and_add(void)
 
 /* Remove a thread info block from the list of threads
    and free its resources. */
-static void caml_thread_remove_and_free(caml_thread_t th)
+static void thread_remove_and_free(caml_thread_t th)
 {
   if (th->next == th)
     reset_active(); /* last OCaml thread exiting */
@@ -542,23 +543,30 @@ static void caml_thread_domain_stop_hook(void) {
   };
 }
 
-/* FIXME: this should return an encoded exception for use in
-   domain_thread_func, but the latter is not ready to handle it
-   yet. */
-static void caml_thread_domain_initialize_hook(void)
+static value caml_thread_domain_initialize_hook_exn(void)
 {
+  value res = Val_unit;
   caml_thread_t new_thread;
 
   atomic_store_release(&Tick_thread_stop, 0);
 
   int ret = st_masterlock_init(Thread_lock(Caml_state->id));
-  caml_check_error(ret, "caml_thread_domain_initialize_hook");
+  if (ret != 0)
+    return caml_check_error_exn(ret, "caml_thread_domain_initialize_hook");
 
   new_thread =
-    (caml_thread_t) caml_stat_alloc(sizeof(struct caml_thread_struct));
+    (caml_thread_t) caml_stat_alloc_noexc(sizeof(struct caml_thread_struct));
+  if (new_thread == NULL) {
+    res = Make_exception_result(caml_exception_out_of_memory());
+    goto err1;
+  }
 
   new_thread->domain_id = Caml_state->id;
-  new_thread->descr = caml_thread_new_descriptor(Val_unit);
+
+  res = caml_thread_new_descriptor_exn(Val_unit);
+  if (Is_exception_result(res)) goto err2;
+  new_thread->descr = res;
+
   new_thread->next = new_thread;
   new_thread->prev = new_thread;
   new_thread->backtrace_last_exn = Val_unit;
@@ -569,6 +577,13 @@ static void caml_thread_domain_initialize_hook(void)
 
   Active_thread = new_thread;
   caml_memprof_enter_thread(new_thread->memprof);
+  return Val_unit;
+
+ err2:
+  caml_stat_free(new_thread);
+ err1:
+  st_masterlock_destroy(Thread_lock(Caml_state->id));
+  return res;
 }
 
 static void thread_yield(void);
@@ -614,14 +629,15 @@ CAMLprim value caml_thread_initialize(value unit)
   st_tls_newkey(&caml_thread_key);
 
   /* First initialise the systhread chain on this domain */
-  caml_thread_domain_initialize_hook();
+  value res = caml_thread_domain_initialize_hook_exn();
+  if (Is_exception_result(res)) caml_raise(Extract_exception(res));
 
   prev_scan_roots_hook = atomic_exchange(&caml_scan_roots_hook,
                                          caml_thread_scan_roots);
   caml_enter_blocking_section_hook = caml_thread_enter_blocking_section;
   caml_leave_blocking_section_hook = caml_thread_leave_blocking_section;
   caml_domain_external_interrupt_hook = caml_thread_interrupt_hook;
-  caml_domain_initialize_hook = caml_thread_domain_initialize_hook;
+  caml_domain_initialize_hook_exn = caml_thread_domain_initialize_hook_exn;
   caml_domain_stop_hook = caml_thread_domain_stop_hook;
   caml_atfork_hook = caml_thread_reinitialize;
 
@@ -646,30 +662,24 @@ CAMLprim value caml_thread_cleanup(value unit)
   return Val_unit;
 }
 
+static void thread_destroy_current(caml_thread_t th);
+
 static void thread_detach_from_runtime(void)
 {
   caml_thread_t th = This_thread;
   CAMLassert(th == Active_thread);
-  /* PR#5188, PR#7220: some of the global runtime state may have
-     changed as the thread was running, so we save it in the
-     This_thread data to make sure that the cleanup logic
-     below uses accurate information. */
-  save_runtime_state();
   /* The main domain thread does not go through
      [thread_detach_from_runtime]. There is always one more thread in
      the chain at this point in time. */
   CAMLassert(th->next != th);
   /* Signal that the thread has terminated */
   caml_threadstatus_terminate(Terminated(th->descr));
-  /* Remove signal stack */
-  CAMLassert(th->signal_stack != NULL);
-  caml_free_signal_stack(th->signal_stack);
+  /* Undo thread_init_current */
+  thread_destroy_current(th);
   /* The following also sets Active_thread to a sane value in case the
      backup thread does a GC before the domain lock is acquired
      again. */
-  caml_thread_remove_and_free(th);
-  /* Forget the now-freed thread info */
-  st_tls_set(caml_thread_key, NULL);
+  thread_remove_and_free(th);
   /* Release domain lock */
   thread_lock_release(Caml_state->id);
 }
@@ -679,7 +689,21 @@ static void thread_init_current(caml_thread_t th)
 {
   st_tls_set(caml_thread_key, th);
   restore_runtime_state(th);
+  /* FIXME: deal with errors */
   th->signal_stack = caml_init_signal_stack();
+}
+
+/* Undo thread_init_current */
+static void thread_destroy_current(caml_thread_t th)
+{
+  CAMLassert(th->signal_stack != NULL);
+  caml_free_signal_stack(th->signal_stack);
+  /* PR#5188, PR#7220: some of the global runtime state may have
+     changed as the thread was running, so we save it in the
+     This_thread data to make sure that the cleanup logic
+     uses accurate information. */
+  save_runtime_state();
+  st_tls_set(caml_thread_key, NULL);
 }
 
 /* Create a thread */
@@ -771,6 +795,7 @@ static st_retcode create_tick_thread(void)
 CAMLprim value caml_thread_new(value clos)
 {
   CAMLparam1(clos);
+  CAMLlocal1(exn);
 
 #ifndef NATIVE_CODE
   if (caml_debugger_in_use)
@@ -786,17 +811,21 @@ CAMLprim value caml_thread_new(value clos)
   /* Create a thread info block */
   caml_thread_t th = thread_alloc_and_add();
   if (th == NULL) caml_raise_out_of_memory();
-  th->descr = caml_thread_new_descriptor(clos);
+
+  value res = caml_thread_new_descriptor_exn(clos);
+  if (Is_exception_result(res)) goto err;
+  th->descr = res;
 
   err = st_thread_create(NULL, caml_thread_start, (void *) th);
-
-  if (err != 0) {
-    /* Creation failed, remove thread info block from list of threads */
-    caml_thread_remove_and_free(th);
-    caml_check_error(err, "Thread.create");
-  }
+  res = caml_check_error_exn(err, "Thread.create");
+  if (Is_exception_result(res)) goto err;
 
   CAMLreturn(th->descr);
+
+ err:
+  exn = Extract_exception(res);
+  thread_remove_and_free(th);
+  caml_raise(exn);
 }
 
 /* Register a thread already created from C */
@@ -824,20 +853,26 @@ CAMLexport int caml_c_thread_register(void)
 
   /* Set a thread info block */
   caml_thread_t th = thread_alloc_and_add();
-  /* If it fails, we release the lock and return an error. */
   if (th == NULL) goto out_err;
+
   thread_init_current(th);
+
   /* We can now allocate the thread descriptor on the major heap */
-  th->descr = caml_thread_new_descriptor(Val_unit);  /* no closure */
+  value res = caml_thread_new_descriptor_exn(Val_unit);  /* no closure */
+  if (Is_exception_result(res)) goto out_err2;
+  th->descr = res;
 
   /* Release the domain lock the regular way. Note: we cannot receive
      an exception here. */
   caml_enter_blocking_section_no_pending();
   return 1;
 
-out_err:
-  /* Note: we cannot raise an exception here. */
+ out_err2:
+  thread_destroy_current(th);
+  thread_remove_and_free(th);
+ out_err:
   thread_lock_release(Dom_c_threads);
+  /* Note: we cannot raise an exception here. */
   return 0;
 }
 
@@ -952,11 +987,14 @@ static struct custom_operations caml_threadstatus_ops = {
   custom_fixed_length_default
 };
 
-static value caml_threadstatus_new (void)
+static value caml_threadstatus_new_exn(void)
 {
   st_event ts = NULL;           /* suppress warning */
   value wrapper;
-  caml_check_error(st_event_create(&ts), "Thread.create");
+  value res = caml_check_error_exn(st_event_create(&ts), "Thread.create");
+  if (Is_exception_result(res)) return res;
+
+  /* this is a small allocation: no noexc version possible */
   wrapper = caml_alloc_custom(&caml_threadstatus_ops,
                               sizeof(st_event *),
                               0, 1);

--- a/runtime/caml/domain.h
+++ b/runtime/caml/domain.h
@@ -81,7 +81,7 @@ CAMLextern void caml_release_domain_lock(void);
 
 /* These hooks are not modified after other domains are spawned. */
 CAMLextern void (*caml_atfork_hook)(void);
-CAMLextern void (*caml_domain_initialize_hook)(void);
+CAMLextern value (*caml_domain_initialize_hook_exn)(void);
 CAMLextern void (*caml_domain_stop_hook)(void);
 CAMLextern void (*caml_domain_external_interrupt_hook)(void);
 

--- a/runtime/caml/fail.h
+++ b/runtime/caml/fail.h
@@ -75,6 +75,7 @@ int caml_is_special_exception(value exn);
 
 /* from runtime/sync.c */
 CAMLextern void caml_check_error(int err, char const * msg);
+CAMLextern value caml_check_error_exn(int err, char const * msg);
 
 #endif /* CAML_INTERNALS */
 

--- a/runtime/caml/sync.h
+++ b/runtime/caml/sync.h
@@ -34,9 +34,6 @@ typedef caml_plat_cond * sync_condvar;
 #define Mutex_val(v) (* ((sync_mutex *) Data_custom_val(v)))
 #define Condition_val(v) (* (sync_condvar *) Data_custom_val(v))
 
-CAMLextern int caml_mutex_lock(sync_mutex mut);
-CAMLextern int caml_mutex_unlock(sync_mutex mut);
-
 value caml_ml_mutex_lock(value wrapper);
 value caml_ml_mutex_unlock(value wrapper);
 value caml_ml_condition_broadcast(value wrapper);

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -1135,7 +1135,6 @@ struct domain_startup_params {
   enum domain_status status; /* in+out:
                                 parent and child synchronize on this value. */
   struct domain_ml_values* ml_values; /* in */
-  dom_internal* newdom; /* out */
   uintnat unique_id; /* out */
 };
 
@@ -1327,7 +1326,6 @@ static void* domain_thread_func(void* v)
     domain_self->tid = pthread_self();
 
   /* this domain is now part of the STW participant set */
-  p->newdom = domain_self;
 
   /* handshake with the parent domain */
   caml_plat_lock_blocking(&p->parent->interruptor.lock);

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -1245,9 +1245,9 @@ static void terminate_backup_thread(dom_internal *di)
   }
 }
 
-static void caml_domain_initialize_default(void)
+static value caml_domain_initialize_default_exn(void)
 {
-  return;
+  return Val_unit;
 }
 
 static void caml_domain_stop_default(void)
@@ -1260,8 +1260,8 @@ static void caml_domain_external_interrupt_hook_default(void)
   return;
 }
 
-CAMLexport void (*caml_domain_initialize_hook)(void) =
-   caml_domain_initialize_default;
+CAMLexport value (*caml_domain_initialize_hook_exn)(void) =
+   caml_domain_initialize_default_exn;
 
 CAMLexport void (*caml_domain_stop_hook)(void) =
    caml_domain_stop_default;
@@ -1347,7 +1347,7 @@ static void* domain_thread_func(void* v)
     CAML_EV_LIFECYCLE(EV_DOMAIN_SPAWN, getpid());
     /* FIXME: ignoring errors during domain initialization is unsafe
        and/or can deadlock. */
-    caml_domain_initialize_hook();
+    caml_domain_initialize_hook_exn();
 
     /* release callback early;
        see the [note about callbacks and GC] in callback.c */

--- a/runtime/sync.c
+++ b/runtime/sync.c
@@ -41,6 +41,7 @@ CAMLexport value caml_check_error_exn(int retcode, char const * msg)
   char * err = caml_strerror(retcode, buf, sizeof(buf));
   size_t msglen = strlen(msg);
   size_t errlen = strlen(err);
+  /* Never raises if msglen <= 1000 */
   value str = caml_alloc_string(msglen + 2 + errlen);
   memcpy (&Byte(str, 0), msg, msglen);
   memcpy (&Byte(str, msglen), ": ", 2);

--- a/runtime/sync.c
+++ b/runtime/sync.c
@@ -31,23 +31,27 @@
 
 /* Reporting errors */
 
+CAMLexport value caml_check_error_exn(int retcode, char const * msg)
+{
+  if (retcode == 0) return Val_unit;
+  if (retcode == ENOMEM)
+    return Make_exception_result(caml_exception_out_of_memory());
+
+  char buf[1024];
+  char * err = caml_strerror(retcode, buf, sizeof(buf));
+  size_t msglen = strlen(msg);
+  size_t errlen = strlen(err);
+  value str = caml_alloc_string(msglen + 2 + errlen);
+  memcpy (&Byte(str, 0), msg, msglen);
+  memcpy (&Byte(str, msglen), ": ", 2);
+  memcpy (&Byte(str, msglen + 2), err, errlen);
+  return Make_exception_result(caml_exception_sys_error(str));
+}
+
 CAMLexport void caml_check_error(int retcode, char const * msg)
 {
-  char const * err;
-  char buf[1024];
-  int errlen, msglen;
-  value str;
-
-  if (retcode == 0) return;
-  if (retcode == ENOMEM) caml_raise_out_of_memory();
-  err = caml_strerror(retcode, buf, sizeof(buf));
-  msglen = strlen(msg);
-  errlen = strlen(err);
-  str = caml_alloc_string(msglen + 2 + errlen);
-  memcpy(&Byte(str, 0), msg, msglen);
-  memcpy(&Byte(str, msglen), ": ", 2);
-  memcpy(&Byte(str, msglen + 2), err, errlen);
-  caml_raise_sys_error(str);
+  value exn = caml_check_error_exn(retcode, msg);
+  if (Is_exception_result(exn)) caml_raise(Extract_exception(exn));
 }
 
 /* Mutex operations */

--- a/stdlib/domain.ml
+++ b/stdlib/domain.ml
@@ -254,7 +254,8 @@ let spawn f =
   do_before_first_spawn ();
   let pk = DLS.get_initial_keys () in
 
-  (* [term_sync] is used to synchronize with the joining domains *)
+  (* [term_sync] is used to synchronize with the joining domains.
+     Accessed from C code: runtime/domain.c. *)
   let term_sync =
     Raw.{ state = Running ;
           mut = Mutex.create () ;


### PR DESCRIPTION
Fix #12269 and similar issues.

We generalize the use of `sync_check_error` and make it into a `caml_check_error_exn` that allows for clean-up before raising.

This is based on top of #12407 and #12409.