### PR TITLE
Fix a build breakage on NetBSD 9

### DIFF
--- a/runtime/floats.c
+++ b/runtime/floats.c
@@ -23,6 +23,9 @@
 /* Needed for strtod_l */
 #define _GNU_SOURCE
 
+/* Needed for copysign */
+#define _NETBSD_SOURCE
+
 #include <math.h>
 #include <stdio.h>
 #include <stdlib.h>


### PR DESCRIPTION
On NetBSD 9, `copysign` is not declared in `math.h` if a certain macro is not defined.

Fixes https://github.com/ocaml/ocaml/issues/12413