### PR TITLE
Add builds.sr.ht configuration

### DIFF
--- a/.builds/alpine.yml
+++ b/.builds/alpine.yml
@@ -1,0 +1,23 @@
+image: alpine/latest
+packages:
+  - make
+  - pkgconf
+  - zstd-dev
+sources:
+  - https://github.com/ocaml/ocaml
+environment:
+  OCAMLRUNPARAM: "b,v=0"
+tasks:
+  - configure: |
+      cd ocaml
+      ./configure --enable-debug-runtime \
+        --enable-flambda --enable-cmm-invariants \
+        --enable-dependency-generation \
+        --enable-native-toplevel
+  - build: |
+      cd ocaml
+      make
+  - test: |
+      cd ocaml
+      make tests
+

--- a/.builds/freebsd.yml
+++ b/.builds/freebsd.yml
@@ -1,0 +1,22 @@
+image: freebsd/latest
+packages:
+  - gmake
+  - pkgconf
+  - zstd
+sources:
+  - https://github.com/ocaml/ocaml
+environment:
+  OCAMLRUNPARAM: "b,v=0"
+tasks:
+  - configure: |
+      cd ocaml
+      ./configure --enable-debug-runtime \
+        --enable-flambda --enable-cmm-invariants \
+        --enable-dependency-generation \
+        --enable-native-toplevel
+  - build: |
+      cd ocaml
+      gmake
+  - test: |
+      cd ocaml
+      gmake tests

--- a/.builds/netbsd.yml
+++ b/.builds/netbsd.yml
@@ -1,0 +1,22 @@
+image: netbsd/latest
+packages:
+  - gmake
+  - pkgconf
+  - zstd
+sources:
+  - https://github.com/ocaml/ocaml
+environment:
+  OCAMLRUNPARAM: "b,v=0"
+tasks:
+  - configure: |
+      cd ocaml
+      ./configure --enable-debug-runtime \
+        --enable-flambda --enable-cmm-invariants \
+        --enable-dependency-generation \
+        --enable-native-toplevel
+  - build: |
+      cd ocaml
+      gmake
+  - test: |
+      cd ocaml
+      gmake tests

--- a/.builds/openbsd.yml
+++ b/.builds/openbsd.yml
@@ -1,0 +1,22 @@
+image: openbsd/latest
+packages:
+  - gmake
+  - pkgconf
+  - zstd
+sources:
+  - https://github.com/ocaml/ocaml
+environment:
+  OCAMLRUNPARAM: "b,v=0"
+tasks:
+  - configure: |
+      cd ocaml
+      ./configure --enable-debug-runtime \
+        --enable-flambda --enable-cmm-invariants \
+        --enable-dependency-generation \
+        --enable-native-toplevel
+  - build: |
+      cd ocaml
+      gmake
+  - test: |
+      cd ocaml
+      gmake tests


### PR DESCRIPTION
Context: https://github.com/ocaml/ocaml/issues/8952

This adds configuration files for builds.sr.ht to build and test OCaml on Alpine Linux (GCC with musl libc), FreeBSD, NetBSD and OpenBSD. Example badges (CI runners for my account) are below:

<table>
  <tr>
    <th>Alpine Linux</th>
    <th>FreeBSD</th>
    <th>NetBSD</th>
    <th>OpenBSD</th>
  </tr>
  <tr>
    <td><a href="https://builds.sr.ht/~omasanori/ocaml/commits/sourcehut-ci/alpine.yml?"><img alt="Build status on Alpine Linux" src="https://builds.sr.ht/~omasanori/ocaml/commits/sourcehut-ci/alpine.yml.svg" /></td>
    <td><a href="https://builds.sr.ht/~omasanori/ocaml/commits/sourcehut-ci/freebsd.yml?"><img alt="Build status on FreeBSD" src="https://builds.sr.ht/~omasanori/ocaml/commits/sourcehut-ci/freebsd.yml.svg" /></td>
    <td><a href="https://builds.sr.ht/~omasanori/ocaml/commits/sourcehut-ci/netbsd.yml?"><img alt="Build status on NetBSD" src="https://builds.sr.ht/~omasanori/ocaml/commits/sourcehut-ci/netbsd.yml.svg" /></td>
    <td><a href="https://builds.sr.ht/~omasanori/ocaml/commits/sourcehut-ci/openbsd.yml?"><img alt="Build status on OpenBSD" src="https://builds.sr.ht/~omasanori/ocaml/commits/sourcehut-ci/openbsd.yml.svg" /></td>
  </tr>
</table>

Build status notification works on GitHub.

![SourceHut CI status notification on GitHub with hottub](https://github.com/ocaml/ocaml/assets/167209/72fdebdc-e589-4fb6-9ff4-de5c1a2f6970)

To activate on [ocaml/ocaml](https://github.com/ocaml/ocaml), we need to signup a SourceHut account ([it costs 20 USD per year at least](https://sourcehut.org/pricing/)), and setup the [hottub](https://sr.ht/~emersion/hottub/) bridge using the public instance (no server installation, few minutes to setup) or a self-hosted server. I believe CI on four platforms is worth paying the costs, but it may be controversial.