### PR TITLE
Make CAMLno_asan and CAMLno_tsan compatible with older clangs again

### DIFF
--- a/runtime/caml/misc.h
+++ b/runtime/caml/misc.h
@@ -565,7 +565,7 @@ CAMLextern int caml_snwprintf(wchar_t * buf,
 #if defined(__has_feature)
 #  if __has_feature(address_sanitizer)
 #    undef CAMLno_asan
-#    define CAMLno_asan __attribute__((disable_sanitizer_instrumentation))
+#    define CAMLno_asan __attribute__((no_sanitize("address")))
 #  endif
 #else
 #  if __SANITIZE_ADDRESS__

--- a/runtime/caml/tsan.h
+++ b/runtime/caml/tsan.h
@@ -22,8 +22,16 @@
 #if defined(__has_feature)
 #  if __has_feature(thread_sanitizer)
 #    undef CAMLreally_no_tsan
-#    define CAMLreally_no_tsan \
-       __attribute__((disable_sanitizer_instrumentation))
+#    if defined(__has_attribute)
+#      if __has_attribute(disable_sanitizer_instrumentation)
+#        define CAMLreally_no_tsan \
+           __attribute__((disable_sanitizer_instrumentation))
+#      else
+#        define CAMLreally_no_tsan __attribute__((no_sanitize("thread")))
+#      endif
+#    else
+#      define CAMLreally_no_tsan __attribute__((no_sanitize("thread")))
+#    endif
 #  endif
 #else
 #  if __SANITIZE_THREAD__


### PR DESCRIPTION
#12114 changed the definition of `CAMLno_asan` which broke on clang <14.0 (see https://github.com/ocaml/ocaml/pull/12114#issuecomment-1639981836). This reverts it. It also makes the related macro `CAMLno_tsan` compatible with clang <14.0.