### PR TITLE
fix warnings on Alpine Linux for parser freshness check

### DIFF
--- a/tools/check-parser-uptodate-or-warn.sh
+++ b/tools/check-parser-uptodate-or-warn.sh
@@ -35,7 +35,7 @@ if test $? != 0
 then MTIME=""
 elif stat --version 2>/dev/null | grep -Fq 'coreutils'
 then MTIME="stat --format %Y"
-elif stat 2>&1 | grep -Fq 'busybox'
+elif stat 2>&1 | grep -Fiq 'busybox'
 then MTIME="stat -c %Y"
 else MTIME="stat -f %m" # BSD stat?
 fi


### PR DESCRIPTION
On Alpine, the `stat` command reports itself as:
```
BusyBox v1.36.0 (2023-05-05 06:41:49 UTC) multi-call binary.
```

This small PR changes the `check-parser-uptodate-or-warn.sh` to do a case-insensitive check for Busybox, and fixes the following warnings on building on Alpine 3.18:

```
./tools/check-parser-uptodate-or-warn.sh
stat: can't read file system information for '%m': No such file or directory
stat: can't read file system information for '%m': No such file or directory
./tools/check-parser-uptodate-or-warn.sh: line 58: arithmetic syntax error
```