### PR TITLE
Bugfix for #12315

### DIFF
--- a/testsuite/tests/typing-misc/let_rec_approx.ml
+++ b/testsuite/tests/typing-misc/let_rec_approx.ml
@@ -30,9 +30,9 @@ Error: This pattern matches values of type "string"
        but a pattern was expected which matches values of type "'a option"
 |}]
 
-let rec opt_ok_f () = opt_ok_g ~foo:A ()
-and opt_ok_g ?(foo : M.t option) () = opt_ok_f ()
+let rec opt_ok_f () = opt_ok_g ~foo:A ~bar:A ()
+and opt_ok_g ?(foo : M.t option) ?(bar : M.t = M.A) () = opt_ok_f ()
 [%%expect{|
 val opt_ok_f : unit -> 'a = <fun>
-val opt_ok_g : ?foo:M.t -> unit -> 'a = <fun>
+val opt_ok_g : ?foo:M.t -> ?bar:M.t -> unit -> 'a = <fun>
 |}]


### PR DESCRIPTION
#12315 introduced a bug in the typing of `let rec`, causing recursive functions with optional parameters that have defaults to no longer typecheck.

The issue is that the typing of patterns on optional parameters is slightly different depending on whether a default is present:
```
let f ?(x : int option) () = ()
let g ?(x : int = 5) () = ()
```

In both cases, the type is `?x:int -> unit -> unit`, represented internally as something like this:
```
(Optional "x", int option) -> ((Nolabel, unit) -> unit)
```
The type in the function arrow is internally always `int option`, but the type of the *pattern* should be `int option` only when there is no default, and `int` if there is a default.

#12315 always typechecked like `f`, causing type errors on code with defaults. (Since the change was to `type_approx`, this only affects such functions when they are part of a recursive group).