### PR TITLE
Simplify dynamic bytecode loading by having the runtime append RETURN 1

### DIFF
--- a/.depend
+++ b/.depend
@@ -6570,7 +6570,6 @@ toplevel/byte/topeval.cmo : \
     typing/persistent_env.cmi \
     parsing/parsetree.cmi \
     typing/outcometree.cmi \
-    bytecomp/opcodes.cmi \
     utils/misc.cmi \
     bytecomp/meta.cmi \
     parsing/location.cmi \
@@ -6605,7 +6604,6 @@ toplevel/byte/topeval.cmx : \
     typing/persistent_env.cmx \
     parsing/parsetree.cmi \
     typing/outcometree.cmi \
-    bytecomp/opcodes.cmx \
     utils/misc.cmx \
     bytecomp/meta.cmx \
     parsing/location.cmx \

--- a/Changes
+++ b/Changes
@@ -101,6 +101,10 @@ Working version
 - #11911, #12381: Restore statmemprof functionality in part
    (API changes in Gc.Memprof). (Nick Barnes)
 
+- #12430: Simplify dynamic bytecode loading in Meta.reify_bytecode
+  (Stephen Dolan, review by Sébastien Hinderer, Vincent Laviron and Xavier
+   Leroy)
+
 ### Code generation and optimizations:
 
 - #11239: on x86-64 and RISC-V, reduce alignment of OCaml stacks from 16 to 8.

--- a/bytecomp/bytegen.ml
+++ b/bytecomp/bytegen.ml
@@ -1239,14 +1239,14 @@ let reset () =
   compunit_name := "";
   Stack.clear functions_to_compile
 
-let compile_gen ?modulename expr =
+let compile_gen ?modulename ~init_stack expr =
   reset ();
   begin match modulename with
   | Some name -> compunit_name := name
   | None -> ()
   end;
   Fun.protect ~finally:reset (fun () ->
-  let init_code = comp_block empty_env expr 0 [] in
+  let init_code = comp_block empty_env expr init_stack [] in
   if Stack.length functions_to_compile > 0 then begin
     let lbl_init = new_label() in
     (Kbranch lbl_init :: comp_remainder (Klabel lbl_init :: init_code)),
@@ -1255,7 +1255,7 @@ let compile_gen ?modulename expr =
     init_code, true)
 
 let compile_implementation modulename expr =
-  fst (compile_gen ~modulename expr)
+  fst (compile_gen ~modulename ~init_stack:0 expr)
 
 let compile_phrase expr =
-  compile_gen expr
+  compile_gen ~init_stack:1 expr

--- a/bytecomp/bytegen.ml
+++ b/bytecomp/bytegen.ml
@@ -1239,20 +1239,23 @@ let reset () =
   compunit_name := "";
   Stack.clear functions_to_compile
 
-let compile_implementation modulename expr =
+let compile_gen ?modulename expr =
   reset ();
-  compunit_name := modulename;
+  begin match modulename with
+  | Some name -> compunit_name := name
+  | None -> ()
+  end;
   Fun.protect ~finally:reset (fun () ->
   let init_code = comp_block empty_env expr 0 [] in
   if Stack.length functions_to_compile > 0 then begin
     let lbl_init = new_label() in
-    Kbranch lbl_init :: comp_remainder (Klabel lbl_init :: init_code)
+    (Kbranch lbl_init :: comp_remainder (Klabel lbl_init :: init_code)),
+    false
   end else
-    init_code)
+    init_code, true)
+
+let compile_implementation modulename expr =
+  fst (compile_gen ~modulename expr)
 
 let compile_phrase expr =
-  reset ();
-  Fun.protect ~finally:reset (fun () ->
-  let init_code = comp_block empty_env expr 1 [Kreturn 1] in
-  let fun_code = comp_remainder [] in
-  (init_code, fun_code))
+  compile_gen expr

--- a/bytecomp/bytegen.mli
+++ b/bytecomp/bytegen.mli
@@ -19,7 +19,7 @@ open Lambda
 open Instruct
 
 val compile_implementation: string -> lambda -> instruction list
-val compile_phrase: lambda -> instruction list * instruction list
+val compile_phrase: lambda -> instruction list * bool
 
 val merge_events:
   Instruct.debug_event -> Instruct.debug_event -> Instruct.debug_event

--- a/bytecomp/emitcode.ml
+++ b/bytecomp/emitcode.ml
@@ -460,11 +460,10 @@ let to_file outchan unit_name objfile ~required_globals code =
 
 (* Emission to a memory block *)
 
-let to_memory init_code fun_code =
+let to_memory instrs =
   init();
   Fun.protect ~finally:clear (fun () ->
-  emit init_code;
-  emit fun_code;
+  emit instrs;
   let code = LongString.create !out_position in
   LongString.blit !out_buffer 0 code 0 !out_position;
   let reloc = List.rev !reloc_info in

--- a/bytecomp/emitcode.mli
+++ b/bytecomp/emitcode.mli
@@ -28,7 +28,7 @@ val to_file: out_channel -> Cmo_format.compunit -> string ->
                evaluated before this one
              list of instructions to emit *)
 val to_memory:
-  instruction list -> instruction list ->
+  instruction list ->
     Misc.LongString.t * (reloc_info * int) list * debug_event list
         (* Arguments:
              initialization code (terminated by STOP)

--- a/otherlibs/dynlink/byte/dynlink.ml
+++ b/otherlibs/dynlink/byte/dynlink.ml
@@ -105,12 +105,7 @@ module Bytecode = struct
         let old_state = Symtable.current_state () in
         let compunit : Cmo_format.compilation_unit = unit_header in
         seek_in ic compunit.cu_pos;
-        let code_size = compunit.cu_codesize + 8 in
-        let code = LongString.create code_size in
-        LongString.input_bytes_into code ic compunit.cu_codesize;
-        LongString.set code compunit.cu_codesize (Char.chr Opcodes.opRETURN);
-        LongString.blit_string "\000\000\000\001\000\000\000" 0
-          code (compunit.cu_codesize + 1) 7;
+        let code = LongString.input_bytes ic compunit.cu_codesize in
         begin try
           Symtable.patch_object code compunit.cu_reloc;
           Symtable.check_global_initialized compunit.cu_reloc;

--- a/testsuite/tests/lib-dynlink-initializers/test10_main.byte.reference
+++ b/testsuite/tests/lib-dynlink-initializers/test10_main.byte.reference
@@ -3,8 +3,8 @@ Raised at Stdlib.failwith in file "stdlib.ml", line 29, characters 17-33
 Called from Test10_plugin.g in file "test10_plugin.ml", line 3, characters 2-21
 Called from Test10_plugin.f in file "test10_plugin.ml", line 6, characters 2-6
 Called from Test10_plugin in file "test10_plugin.ml", line 10, characters 2-6
-Called from Dynlink.Bytecode.run in file "byte/dynlink.ml", line 151, characters 16-25
-Re-raised at Dynlink.Bytecode.run in file "byte/dynlink.ml", line 153, characters 6-137
+Called from Dynlink.Bytecode.run in file "byte/dynlink.ml", line 146, characters 16-25
+Re-raised at Dynlink.Bytecode.run in file "byte/dynlink.ml", line 148, characters 6-137
 Called from Dynlink_common.Make.load.(fun) in file "dynlink_common.ml", line 360, characters 11-54
 Called from Stdlib__List.iter in file "list.ml", line 112, characters 12-15
 Called from Stdlib__Fun.protect in file "fun.ml", line 33, characters 8-15

--- a/testsuite/tests/tool-toplevel/pr6468.compilers.reference
+++ b/testsuite/tests/tool-toplevel/pr6468.compilers.reference
@@ -9,5 +9,6 @@ val g : unit -> int = <fun>
 Exception: Not_found.
 Raised at f in file "//toplevel//", line 2, characters 11-26
 Called from g in file "//toplevel//", line 1, characters 11-15
-Called from Topeval.load_lambda in file "toplevel/byte/topeval.ml", line 95, characters 4-14
+Called from <unknown> in file "//toplevel//", line 1, characters 0-4
+Called from Topeval.load_lambda in file "toplevel/byte/topeval.ml", line 93, characters 4-14
 

--- a/testsuite/tests/tool-toplevel/pr9701.compilers.reference
+++ b/testsuite/tests/tool-toplevel/pr9701.compilers.reference
@@ -1,4 +1,4 @@
 Exception: Failure "test".
 Raised at Stdlib.failwith in file "stdlib.ml", line 29, characters 17-33
 Called from <unknown> in file "pr9701.ml", line 5, characters 9-16
-Called from Topeval.load_lambda in file "toplevel/byte/topeval.ml", line 95, characters 4-14
+Called from Topeval.load_lambda in file "toplevel/byte/topeval.ml", line 93, characters 4-14

--- a/toplevel/byte/topeval.ml
+++ b/toplevel/byte/topeval.ml
@@ -220,12 +220,7 @@ let check_consistency ppf filename cu =
 let load_compunit ic filename ppf compunit =
   check_consistency ppf filename compunit;
   seek_in ic compunit.cu_pos;
-  let code_size = compunit.cu_codesize + 8 in
-  let code = LongString.create code_size in
-  LongString.input_bytes_into code ic compunit.cu_codesize;
-  LongString.set code compunit.cu_codesize (Char.chr Opcodes.opRETURN);
-  LongString.blit_string "\000\000\000\001\000\000\000" 0
-                     code (compunit.cu_codesize + 1) 7;
+  let code = LongString.input_bytes ic compunit.cu_codesize in
   let initial_symtable = Symtable.current_state() in
   Symtable.patch_object code compunit.cu_reloc;
   Symtable.update_global_table();

--- a/toplevel/byte/topeval.ml
+++ b/toplevel/byte/topeval.ml
@@ -75,15 +75,13 @@ let load_lambda ppf lam =
   if !Clflags.dump_rawlambda then fprintf ppf "%a@." Printlambda.lambda lam;
   let slam = Simplif.simplify_lambda lam in
   if !Clflags.dump_lambda then fprintf ppf "%a@." Printlambda.lambda slam;
-  let (init_code, fun_code) = Bytegen.compile_phrase slam in
+  let instrs, can_free = Bytegen.compile_phrase slam in
   if !Clflags.dump_instr then
-    fprintf ppf "%a%a@."
-    Printinstr.instrlist init_code
-    Printinstr.instrlist fun_code;
+    fprintf ppf "%a@."
+    Printinstr.instrlist instrs;
   let (code, reloc, events) =
-    Emitcode.to_memory init_code fun_code
+    Emitcode.to_memory instrs
   in
-  let can_free = (fun_code = []) in
   let initial_symtable = Symtable.current_state() in
   Symtable.patch_object code reloc;
   Symtable.check_global_initialized reloc;

--- a/utils/misc.ml
+++ b/utils/misc.ml
@@ -539,11 +539,6 @@ module LongString = struct
       set dst (dstoff + i) (get src (srcoff + i))
     done
 
-  let blit_string src srcoff dst dstoff len =
-    for i = 0 to len - 1 do
-      set dst (dstoff + i) (String.get src (srcoff + i))
-    done
-
   let output oc tbl pos len =
     for i = pos to pos + len - 1 do
       output_char oc (get tbl i)

--- a/utils/misc.mli
+++ b/utils/misc.mli
@@ -426,9 +426,7 @@ module LongString :
     val get : t -> int -> char
     val set : t -> int -> char -> unit
     val blit : t -> int -> t -> int -> int -> unit
-    val blit_string : string -> int -> t -> int -> int -> unit
     val output : out_channel -> t -> int -> int -> unit
-    val input_bytes_into : t -> in_channel -> int -> unit
     val input_bytes : in_channel -> int -> t
   end
 


### PR DESCRIPTION
There is a function `Meta.reify_bytecode` which is used to turn a sequence of bytecode instructions into a callable closure, used by the toplevel and by Dynlink. To do this, the bytecode sequence needs to end in a `RETURN 1` instruction.

Currently, this `RETURN 1` instruction is added by the caller of `reify_bytecode` [*]. This patch makes `reify_bytecode` do this step instead. This seems cleaner, as it removes hardcoded binary strings from the callers of `reify_bytecode`, who need no longer care about endianness / opcode numbering, in particular removing a dependency from `Dynlink` to `Opcodes`. (The runtime now has to do this, but the runtime must already care about such things).

[*] actually this was done by only two of the three callers. The third now gets a redundant `RETURN 1`, but an extra bytecode instruction that's never executed isn't harmful.

cc @shindere 