### PR TITLE
Fix semantically-important typo in 'Ch 10. Memory model'

### DIFF
--- a/manual/src/tutorials/memorymodel.etex
+++ b/manual/src/tutorials/memorymodel.etex
@@ -116,7 +116,7 @@ consistency.
 
 One way to explain the observed behaviour is as if the operations performed on
 a domain were reordered. For example, if the second and the third reads from
-"d2" were reordered,
+"d1" were reordered,
 
 \begin{caml_example*}{verbatim}
 let d1 a b =


### PR DESCRIPTION
Unless I'm severely mis-reading, it's the ordering of operations in **`d1`** that's been changed in this example, yes? (In fact, `d2` only _has_ one operation?)

Someone please triple-check this before merging, afraid to be modifying a difficult chapter that's a bit over my head. Heh.