### PR TITLE
add missing CAMLparam in caml_ml_close_channel

### DIFF
--- a/runtime/io.c
+++ b/runtime/io.c
@@ -690,6 +690,7 @@ CAMLprim value caml_channel_descriptor(value vchannel)
 
 CAMLprim value caml_ml_close_channel(value vchannel)
 {
+  CAMLparam1 (vchannel);
   int result;
   int fd;
 
@@ -716,7 +717,7 @@ CAMLprim value caml_ml_close_channel(value vchannel)
     if (result == -1) caml_sys_error (NO_ARG);
   }
   Unlock(channel);
-  return Val_unit;
+  CAMLreturn (Val_unit);
 }
 
 /* EOVERFLOW is the Unix98 error indicating that a file position or file


### PR DESCRIPTION
This fixes a random crash, which is made much more probable by a future PR of mine.

The crash is as follows:
- Domain A wants to close a channel, which happens to go out of scope after the close. It locks the channel, then enters the blocking section.
- While domain A is blocked, domain B requests a GC
- A's backup thread takes over and completes the GC. The channel gets collected and its finalizer is called.
- The finalizer calls `pthread_mutex_destroy` on a mutex that's still locked and triggers a fatal error.

The fix is to keep the channel alive until it's unlocked.