### PR TITLE
generalize tests/unwind to work on clang -O0

### DIFF
--- a/testsuite/tests/unwind/stack_walker.c
+++ b/testsuite/tests/unwind/stack_walker.c
@@ -50,7 +50,7 @@ value ml_perform_stack_walk(value unused) {
             } else {
               printf("%s\n", procname);
             }
-            if (!strcmp(procname, "main")) break;
+            if (!strcmp(procname, "caml_program")) break;
         }
 
         {

--- a/testsuite/tests/unwind/unwind_test.reference
+++ b/testsuite/tests/unwind/unwind_test.reference
@@ -3,16 +3,8 @@ caml_c_call
 Mylib.baz
 Driver.entry
 caml_program
-caml_start_program
-caml_startup_common
-caml_main
-main
 ml_perform_stack_walk
 ml_do_no_alloc
 Mylib.bob
 Driver.entry
 caml_program
-caml_start_program
-caml_startup_common
-caml_main
-main


### PR DESCRIPTION
On Macos, when I configure with `CFLAGS=-O0` (for debugging) I get a failure on tests/unwind. This is because the stack trace produced by unwind has two more entries, probably functions that are inlined at the default optimization level (-O2).

The fix is to suppress printing of these two functions when the backtrace is printed.
