### PR TITLE
Make evaluation order for tuples consistent

### DIFF
--- a/testsuite/tests/basic-more/pr12348.ml
+++ b/testsuite/tests/basic-more/pr12348.ml
@@ -1,0 +1,32 @@
+(* TEST *)
+
+let first x =
+  print_endline "First";
+  x
+
+let second x =
+  print_endline "Second";
+  x
+
+let reference () =
+  let c = (first 0, second 1) in
+  match c with
+  | 0, 1 -> ()
+  | _, _ -> assert false
+
+let match_no_exn () =
+  match first 0, second 1 with
+  | 0, 1 -> ()
+  | _, _ -> assert false
+
+let match_exn () =
+  match first 0, second 1 with
+  | 0, 1 -> ()
+  | _, _ -> assert false
+  | exception _ -> assert false
+
+let () =
+  reference ();
+  match_no_exn ();
+  match_exn ();
+  ()

--- a/testsuite/tests/basic-more/pr12348.reference
+++ b/testsuite/tests/basic-more/pr12348.reference
@@ -1,0 +1,6 @@
+Second
+First
+Second
+First
+Second
+First

--- a/testsuite/tests/basic/patmatch_for_multiple.ml
+++ b/testsuite/tests/basic/patmatch_for_multiple.ml
@@ -26,14 +26,14 @@ match (3, 2, 1) with
 | _ -> false
 ;;
 [%%expect{|
-(let (*match*/276 = 3 *match*/277 = 2 *match*/278 = 1)
+(let (*match*/278 = 1 *match*/277 = 2 *match*/276 = 3)
   (catch
     (catch
       (catch (if (!= *match*/277 3) (exit 3) (exit 1)) with (3)
         (if (!= *match*/276 1) (exit 2) (exit 1)))
      with (2) 0)
    with (1) 1))
-(let (*match*/276 = 3 *match*/277 = 2 *match*/278 = 1)
+(let (*match*/278 = 1 *match*/277 = 2 *match*/276 = 3)
   (catch (if (!= *match*/277 3) (if (!= *match*/276 1) 0 (exit 1)) (exit 1))
    with (1) 1))
 - : bool = false
@@ -47,7 +47,7 @@ match (3, 2, 1) with
 | _ -> false
 ;;
 [%%expect{|
-(let (*match*/281 = 3 *match*/282 = 2 *match*/283 = 1)
+(let (*match*/283 = 1 *match*/282 = 2 *match*/281 = 3)
   (catch
     (catch
       (catch
@@ -60,7 +60,7 @@ match (3, 2, 1) with
             (exit 4 x/284))))
      with (5) 0)
    with (4 x/279) (seq (ignore x/279) 1)))
-(let (*match*/281 = 3 *match*/282 = 2 *match*/283 = 1)
+(let (*match*/283 = 1 *match*/282 = 2 *match*/281 = 3)
   (catch
     (if (!= *match*/282 3)
       (if (!= *match*/281 1) 0


### PR DESCRIPTION
Fixes #12438.

This makes expressions like ` match expr1, expr2 with ...` evaluate `expr2` before `expr1`. This is consistent with all other evaluation order decisions, and the inconsistency is what caused the error reported in #12438, but since we explicitly do not specify any evaluation order then one might argue that there's no bug and that the left-to-right evaluation order is more natural and should be kept when possible.

My opinion is that the consistency offered by this PR is worth it, but we may want to mark the change as potentially breaking in case some users were actually relying on the left-to-right order.