### PR TITLE
Fix the configure test for pthread_getaffinity_np

### DIFF
--- a/configure
+++ b/configure
@@ -18260,65 +18260,6 @@ then :
 fi
 
 
-## pthread_getaffinity_np, args differ from GNU and BSD
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking arguments for pthread_getaffinity_np" >&5
-printf %s "checking arguments for pthread_getaffinity_np... " >&6; }
-cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-#define _GNU_SOURCE
-      #include <sched.h>
-      #include <pthread.h>
-int
-main (void)
-{
-cpu_set_t cs;
-      CPU_ZERO(&cs);
-      CPU_COUNT(&cs);
-      pthread_getaffinity_np(pthread_self(), sizeof(cs), &cs);
-  ;
-  return 0;
-}
-_ACEOF
-if ac_fn_c_try_link "$LINENO"
-then :
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: gnu" >&5
-printf "%s\n" "gnu" >&6; }
-  printf "%s\n" "#define HAS_GNU_GETAFFINITY_NP 1" >>confdefs.h
-
-else $as_nop
-  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-#include <pthread.h>
-        #include <pthread_np.h>
-        #include <sys/cpuset.h>
-int
-main (void)
-{
-cpuset_t cs;
-        /* Not every BSD has CPU_ZERO and CPU_COUNT (NetBSD) */
-        CPU_ZERO(&cs);
-        CPU_COUNT(&cs);
-        pthread_getaffinity_np(pthread_self(), sizeof(cs), &cs);
-  ;
-  return 0;
-}
-_ACEOF
-if ac_fn_c_try_link "$LINENO"
-then :
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: BSD" >&5
-printf "%s\n" "BSD" >&6; }
-    printf "%s\n" "#define HAS_BSD_GETAFFINITY_NP 1" >>confdefs.h
-
-else $as_nop
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: pthread_getaffinity_np not found" >&5
-printf "%s\n" "pthread_getaffinity_np not found" >&6; }
-fi
-rm -f core conftest.err conftest.$ac_objext conftest.beam \
-    conftest$ac_exeext conftest.$ac_ext
-fi
-rm -f core conftest.err conftest.$ac_objext conftest.beam \
-    conftest$ac_exeext conftest.$ac_ext
-
 if test -n "$ac_tool_prefix"; then
   # Extract the first word of "${ac_tool_prefix}pkg-config", so it can be a program name with args.
 set dummy ${ac_tool_prefix}pkg-config; ac_word=$2
@@ -19339,6 +19280,65 @@ ac_compiler_gnu=$ac_cv_c_compiler_gnu
 
  ;;
 esac
+
+## pthread_getaffinity_np, args differ from GNU and BSD
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking arguments for pthread_getaffinity_np" >&5
+printf %s "checking arguments for pthread_getaffinity_np... " >&6; }
+cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+#define _GNU_SOURCE
+      #include <sched.h>
+      #include <pthread.h>
+int
+main (void)
+{
+cpu_set_t cs;
+      CPU_ZERO(&cs);
+      CPU_COUNT(&cs);
+      pthread_getaffinity_np(pthread_self(), sizeof(cs), &cs);
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_link "$LINENO"
+then :
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: GNU" >&5
+printf "%s\n" "GNU" >&6; }
+  printf "%s\n" "#define HAS_GNU_GETAFFINITY_NP 1" >>confdefs.h
+
+else $as_nop
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+#include <pthread.h>
+        #include <pthread_np.h>
+        #include <sys/cpuset.h>
+int
+main (void)
+{
+cpuset_t cs;
+        /* Not every BSD has CPU_ZERO and CPU_COUNT (NetBSD) */
+        CPU_ZERO(&cs);
+        CPU_COUNT(&cs);
+        pthread_getaffinity_np(pthread_self(), sizeof(cs), &cs);
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_link "$LINENO"
+then :
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: BSD" >&5
+printf "%s\n" "BSD" >&6; }
+    printf "%s\n" "#define HAS_BSD_GETAFFINITY_NP 1" >>confdefs.h
+
+else $as_nop
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: pthread_getaffinity_np not found" >&5
+printf "%s\n" "pthread_getaffinity_np not found" >&6; }
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.beam \
+    conftest$ac_exeext conftest.$ac_ext
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.beam \
+    conftest$ac_exeext conftest.$ac_ext
 
 ## Activate the systhread library
 

--- a/configure
+++ b/configure
@@ -19287,6 +19287,9 @@ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 #define _GNU_SOURCE
       #include <sched.h>
+      #ifdef HAS_PTHREAD_NP_H
+      #include <pthread_np.h>
+      #endif
       #include <pthread.h>
 int
 main (void)

--- a/configure
+++ b/configure
@@ -19254,8 +19254,9 @@ test -n "$PTHREAD_CXX" || PTHREAD_CXX="$CXX"
 # Finally, execute ACTION-IF-FOUND/ACTION-IF-NOT-FOUND:
 if test "x$ax_pthread_ok" = "xyes"; then
         common_cflags="$common_cflags $PTHREAD_CFLAGS"
-    saved_CFLAGS="$CFLAGS"
-    saved_LIBS="$LIBS"
+    # The two following lines add flags and libraries for pthread to the
+    # global CFLAGS and LIBS variables. This means that all the subsequent
+    # tests can rely on the assumption that pthread is enabled.
     CFLAGS="$CFLAGS $PTHREAD_CFLAGS"
     LIBS="$LIBS $PTHREAD_LIBS"
     ac_fn_c_check_func "$LINENO" "sigwait" "ac_cv_func_sigwait"
@@ -19265,8 +19266,6 @@ then :
 
 fi
 
-    LIBS="$saved_LIBS"
-    CFLAGS="$saved_CFLAGS"
         :
 else
         ax_pthread_ok=no

--- a/configure.ac
+++ b/configure.ac
@@ -2161,6 +2161,9 @@ AC_LINK_IFELSE(
   [AC_LANG_PROGRAM(
     [[#define _GNU_SOURCE
       #include <sched.h>
+      #ifdef HAS_PTHREAD_NP_H
+      #include <pthread_np.h>
+      #endif
       #include <pthread.h>]],
     [[cpu_set_t cs;
       CPU_ZERO(&cs);

--- a/configure.ac
+++ b/configure.ac
@@ -2078,33 +2078,6 @@ AC_CHECK_HEADER([spawn.h],
 AC_CHECK_FUNC([ffs], [AC_DEFINE([HAS_FFS])])
 AC_CHECK_FUNC([_BitScanForward], [AC_DEFINE([HAS_BITSCANFORWARD])])
 
-## pthread_getaffinity_np, args differ from GNU and BSD
-AC_MSG_CHECKING([arguments for pthread_getaffinity_np])
-AC_LINK_IFELSE(
-  [AC_LANG_PROGRAM(
-    [[#define _GNU_SOURCE
-      #include <sched.h>
-      #include <pthread.h>]],
-    [[cpu_set_t cs;
-      CPU_ZERO(&cs);
-      CPU_COUNT(&cs);
-      pthread_getaffinity_np(pthread_self(), sizeof(cs), &cs);]])],
-  [AC_MSG_RESULT([gnu])
-  AC_DEFINE([HAS_GNU_GETAFFINITY_NP])],
-  [AC_LINK_IFELSE(
-    [AC_LANG_PROGRAM(
-      [[#include <pthread.h>
-        #include <pthread_np.h>
-        #include <sys/cpuset.h>]],
-      [[cpuset_t cs;
-        /* Not every BSD has CPU_ZERO and CPU_COUNT (NetBSD) */
-        CPU_ZERO(&cs);
-        CPU_COUNT(&cs);
-        pthread_getaffinity_np(pthread_self(), sizeof(cs), &cs);]])],
-    [AC_MSG_RESULT([BSD])
-    AC_DEFINE([HAS_BSD_GETAFFINITY_NP])],
-    [AC_MSG_RESULT([pthread_getaffinity_np not found])])])
-
 AC_PATH_TOOL([PKG_CONFIG], [pkg-config], [false])
 
 ## ZSTD compression library
@@ -2182,6 +2155,33 @@ AS_CASE([$host],
     CFLAGS="$saved_CFLAGS"],
     [AC_MSG_ERROR(m4_normalize([POSIX threads are required but not supported on
       this platform]))])])
+
+## pthread_getaffinity_np, args differ from GNU and BSD
+AC_MSG_CHECKING([arguments for pthread_getaffinity_np])
+AC_LINK_IFELSE(
+  [AC_LANG_PROGRAM(
+    [[#define _GNU_SOURCE
+      #include <sched.h>
+      #include <pthread.h>]],
+    [[cpu_set_t cs;
+      CPU_ZERO(&cs);
+      CPU_COUNT(&cs);
+      pthread_getaffinity_np(pthread_self(), sizeof(cs), &cs);]])],
+  [AC_MSG_RESULT([GNU])
+  AC_DEFINE([HAS_GNU_GETAFFINITY_NP])],
+  [AC_LINK_IFELSE(
+    [AC_LANG_PROGRAM(
+      [[#include <pthread.h>
+        #include <pthread_np.h>
+        #include <sys/cpuset.h>]],
+      [[cpuset_t cs;
+        /* Not every BSD has CPU_ZERO and CPU_COUNT (NetBSD) */
+        CPU_ZERO(&cs);
+        CPU_COUNT(&cs);
+        pthread_getaffinity_np(pthread_self(), sizeof(cs), &cs);]])],
+    [AC_MSG_RESULT([BSD])
+    AC_DEFINE([HAS_BSD_GETAFFINITY_NP])],
+    [AC_MSG_RESULT([pthread_getaffinity_np not found])])])
 
 ## Activate the systhread library
 

--- a/configure.ac
+++ b/configure.ac
@@ -2146,13 +2146,12 @@ AS_CASE([$host],
     [PTHREAD_LIBS="-l:libpthread.lib"],
   [AX_PTHREAD(
     [common_cflags="$common_cflags $PTHREAD_CFLAGS"
-    saved_CFLAGS="$CFLAGS"
-    saved_LIBS="$LIBS"
+    # The two following lines add flags and libraries for pthread to the
+    # global CFLAGS and LIBS variables. This means that all the subsequent
+    # tests can rely on the assumption that pthread is enabled.
     CFLAGS="$CFLAGS $PTHREAD_CFLAGS"
     LIBS="$LIBS $PTHREAD_LIBS"
-    AC_CHECK_FUNC([sigwait], [AC_DEFINE([HAS_SIGWAIT])])
-    LIBS="$saved_LIBS"
-    CFLAGS="$saved_CFLAGS"],
+    AC_CHECK_FUNC([sigwait], [AC_DEFINE([HAS_SIGWAIT])])],
     [AC_MSG_ERROR(m4_normalize([POSIX threads are required but not supported on
       this platform]))])])
 


### PR DESCRIPTION
The C test program shouldinclude the right header files to avoid warnings.