### PR TITLE
Missing GC root registrations in runtime/io.c

### DIFF
--- a/Changes
+++ b/Changes
@@ -1139,6 +1139,9 @@ Some of those changes will benefit all OCaml packages.
   (Guillaume Munch-Maccagnoni, report by Thomas Leonard, review by
    KC Sivaramakrishnan and Sadiq Jaffer)
 
+- #12445: missing GC root registrations in runtime/io.c
+  (Gabriel Scherer, review by Xavier Leroy and Jeremy Yallop)
+
 OCaml 5.0.0 (15 December 2022)
 ------------------------------
 

--- a/runtime/io.c
+++ b/runtime/io.c
@@ -623,6 +623,7 @@ CAMLprim value caml_ml_open_descriptor_out(value fd) {
 
 CAMLprim value caml_ml_set_channel_name(value vchannel, value vname)
 {
+  CAMLparam2(vchannel, vname);
   struct channel * channel = Channel(vchannel);
   Lock(channel);
   caml_stat_free(channel->name);
@@ -631,7 +632,7 @@ CAMLprim value caml_ml_set_channel_name(value vchannel, value vname)
   else
     channel->name = NULL;
   Unlock(channel);
-  return Val_unit;
+  CAMLreturn (Val_unit);
 }
 
 struct channel_list {
@@ -690,6 +691,7 @@ CAMLprim value caml_channel_descriptor(value vchannel)
 
 CAMLprim value caml_ml_close_channel(value vchannel)
 {
+  CAMLparam1(vchannel);
   int result;
   int fd;
 
@@ -716,7 +718,7 @@ CAMLprim value caml_ml_close_channel(value vchannel)
     if (result == -1) caml_sys_error (NO_ARG);
   }
   Unlock(channel);
-  return Val_unit;
+  CAMLreturn (Val_unit);
 }
 
 /* EOVERFLOW is the Unix98 error indicating that a file position or file
@@ -754,6 +756,7 @@ CAMLprim value caml_ml_channel_size_64(value vchannel)
 
 CAMLprim value caml_ml_set_binary_mode(value vchannel, value mode)
 {
+  CAMLparam2(vchannel, mode);
 #if defined(_WIN32) || defined(__CYGWIN__)
   struct channel * channel = Channel(vchannel);
   Lock(channel);
@@ -774,7 +777,7 @@ CAMLprim value caml_ml_set_binary_mode(value vchannel, value mode)
     channel->flags |= CHANNEL_TEXT_MODE;
   Unlock(channel);
 #endif
-  return Val_unit;
+  CAMLreturn (Val_unit);
 }
 
 /*
@@ -798,6 +801,7 @@ CAMLprim value caml_ml_flush(value vchannel)
 
 CAMLprim value caml_ml_set_buffered(value vchannel, value mode)
 {
+  CAMLparam2(vchannel, mode);
   struct channel * channel = Channel(vchannel);
   Lock(channel);
   if (Bool_val(mode)) {
@@ -808,7 +812,7 @@ CAMLprim value caml_ml_set_buffered(value vchannel, value mode)
       caml_flush(channel);
   }
   Unlock(channel);
-  return Val_unit;
+  CAMLreturn(Val_unit);
 }
 
 CAMLprim value caml_ml_is_buffered(value vchannel)
@@ -892,23 +896,25 @@ CAMLprim value caml_ml_seek_out_64(value vchannel, value pos)
 
 CAMLprim value caml_ml_pos_out(value vchannel)
 {
+  CAMLparam1 (vchannel);
   file_offset pos;
   struct channel *channel = Channel(vchannel);
   Lock(channel);
   pos = caml_pos_out(channel);
   Unlock(channel);
   if (pos > Max_long) { errno = EOVERFLOW; caml_sys_error(NO_ARG); }
-  return Val_long(pos);
+  CAMLreturn (Val_long(pos));
 }
 
 CAMLprim value caml_ml_pos_out_64(value vchannel)
 {
+  CAMLparam1 (vchannel);
   file_offset pos;
   struct channel *channel = Channel(vchannel);
   Lock(channel);
   pos = caml_pos_out(channel);
   Unlock(channel);
-  return Val_file_offset(pos);
+  CAMLreturn (Val_file_offset(pos));
 }
 
 CAMLprim value caml_ml_input_char(value vchannel)
@@ -1002,23 +1008,25 @@ CAMLprim value caml_ml_seek_in_64(value vchannel, value pos)
 
 CAMLprim value caml_ml_pos_in(value vchannel)
 {
+  CAMLparam1 (vchannel);
   file_offset pos;
   struct channel *channel = Channel(vchannel);
   Lock(channel);
   pos = caml_pos_in(channel);
   Unlock(channel);
   if (pos > Max_long) { errno = EOVERFLOW; caml_sys_error(NO_ARG); }
-  return Val_long(pos);
+  CAMLreturn (Val_long(pos));
 }
 
 CAMLprim value caml_ml_pos_in_64(value vchannel)
 {
+  CAMLparam1 (vchannel);
   file_offset pos;
   struct channel *channel = Channel(vchannel);
   Lock(channel);
   pos = caml_pos_in(channel);
   Unlock(channel);
-  return Val_file_offset(pos);
+  CAMLreturn (Val_file_offset(pos));
 }
 
 CAMLprim value caml_ml_input_scan_line(value vchannel)


### PR DESCRIPTION
#12436 led me to realize that most of the code of io.c is subtly wrong because it does not root its value arguments when it should. (This was already broken for OCaml 4.x.)

In this PR I decided to systematically review all functions, root arguments if necessary, and add an explicit justification comment for any function with unrooted value arguments or temporaries.

(cc @damiendoligez @yallop)

(This PR supersedes #12436.)