### PR TITLE
Remove 32-bit targets from X86_proc.system

### DIFF
--- a/Changes
+++ b/Changes
@@ -167,6 +167,9 @@ Working version
 
 ### Internal/compiler-libs changes:
 
+- #12447: Remove 32-bit targets from X86_proc.system
+  (Masanori Ogino, review by David Allsopp)
+
 - #12216, #12248: Prevent reordering of atomic loads during instruction
   scheduling.  This is for reference, as instruction scheduling is currently
   unused in OCaml 5.

--- a/asmcomp/x86_proc.ml
+++ b/asmcomp/x86_proc.ml
@@ -16,20 +16,11 @@
 open X86_ast
 
 type system =
-  (* 32 bits and 64 bits *)
   | S_macosx
   | S_gnu
   | S_cygwin
-
-  (* 32 bits only *)
   | S_solaris
-  | S_win32
-  | S_linux_elf
-  | S_bsd_elf
   | S_beos
-  | S_mingw
-
-  (* 64 bits only *)
   | S_win64
   | S_linux
   | S_mingw64
@@ -42,17 +33,13 @@ type system =
 
 let system = match Config.system with
   | "macosx" -> S_macosx
-  | "solaris" -> S_solaris
-  | "win32" -> S_win32
-  | "linux_elf" -> S_linux_elf
-  | "bsd_elf" -> S_bsd_elf
-  | "beos" -> S_beos
   | "gnu" -> S_gnu
   | "cygwin" -> S_cygwin
-  | "mingw" -> S_mingw
-  | "mingw64" -> S_mingw64
+  | "solaris" -> S_solaris
+  | "beos" -> S_beos
   | "win64" -> S_win64
   | "linux" -> S_linux
+  | "mingw64" -> S_mingw64
   | "freebsd" -> S_freebsd
   | "netbsd" -> S_netbsd
   | "openbsd" -> S_openbsd
@@ -245,7 +232,7 @@ let with_internal_assembler assemble k =
 (* Which asm conventions to use *)
 let masm =
   match system with
-  | S_win32 | S_win64 -> true
+  | S_win64 -> true
   | _ -> false
 
 let use_plt =

--- a/asmcomp/x86_proc.mli
+++ b/asmcomp/x86_proc.mli
@@ -58,20 +58,11 @@ val assemble_file: (*infile*) string -> (*outfile*) string -> (*retcode*) int
 (** System detection *)
 
 type system =
-  (* 32 bits and 64 bits *)
   | S_macosx
   | S_gnu
   | S_cygwin
-
-  (* 32 bits only *)
   | S_solaris
-  | S_win32
-  | S_linux_elf
-  | S_bsd_elf
   | S_beos
-  | S_mingw
-
-  (* 64 bits only *)
   | S_win64
   | S_linux
   | S_mingw64


### PR DESCRIPTION
This cleans up `X86_proc` a bit as 32-bit targets are no longer supported by `asmcomp`.