### PR TITLE
stdlib: add Array.init_matrix

### DIFF
--- a/Changes
+++ b/Changes
@@ -165,7 +165,8 @@ Working version
   (Nicolás Ojeda Bär, review by Jeremy Yallop, Xavier Leroy, Gabriel Scherer,
    David Allsopp)
 
-- #12455: Add `Array.init_matrix`.
+- #12455: Add `Array.init_matrix`, `Float.Array.make_matrix`,
+  `Float.Array.init_matrix`.
   (Glen Mével, review by Xavier Leroy, Gabriel Scherer, Jeremy Yallop,
   Nicolas Ojeda Bar)
 

--- a/Changes
+++ b/Changes
@@ -165,6 +165,9 @@ Working version
   (Nicolás Ojeda Bär, review by Jeremy Yallop, Xavier Leroy, Gabriel Scherer,
    David Allsopp)
 
+- #12455: Add `Array.init_matrix`.
+  (Glen Mével, review by Xavier Leroy, Gabriel Scherer and Jeremy Yallop)
+
 - #12511: Minor performance improvements and cleanups in the implementation
   of modules Int32, Int64, and Nativeint
   (Xavier Leroy, review by Gabriel Scherer and Daniel Bünzli)

--- a/Changes
+++ b/Changes
@@ -166,11 +166,12 @@ Working version
    David Allsopp)
 
 - #12455: Add `Array.init_matrix`.
-  (Glen Mével, review by Xavier Leroy, Gabriel Scherer and Jeremy Yallop)
+  (Glen Mével, review by Xavier Leroy, Gabriel Scherer, Jeremy Yallop,
+  Nicolas Ojeda Bar)
 
 * #12455: `Array.make_matrix dimx dimy f` now raises `Invalid_argument`
   when `dimx = 0 && dimy < 0` This was already specified but not enforced.
-  (Glen Mével, report by Jeremy Yallop)
+  (Glen Mével, report by Jeremy Yallop, review by Nicolas Ojeda Bar)
 
 - #12511: Minor performance improvements and cleanups in the implementation
   of modules Int32, Int64, and Nativeint

--- a/Changes
+++ b/Changes
@@ -168,6 +168,10 @@ Working version
 - #12455: Add `Array.init_matrix`.
   (Glen Mével, review by Xavier Leroy, Gabriel Scherer and Jeremy Yallop)
 
+* #12455: `Array.make_matrix dimx dimy f` now raises `Invalid_argument`
+  when `dimx = 0 && dimy < 0` This was already specified but not enforced.
+  (Glen Mével, report by Jeremy Yallop)
+
 - #12511: Minor performance improvements and cleanups in the implementation
   of modules Int32, Int64, and Nativeint
   (Xavier Leroy, review by Gabriel Scherer and Daniel Bünzli)

--- a/stdlib/array.ml
+++ b/stdlib/array.ml
@@ -64,10 +64,17 @@ let make_matrix sx sy init =
   res
 
 let init_matrix sx sy f =
+  if sy < 0 then invalid_arg "Array.init_matrix";
   let res = create sx [||] in
-  for x = 0 to pred sx do
-    unsafe_set res x (init sy (fun y -> f x y))
-  done;
+  if sy > 0 then begin
+    for x = 0 to pred sx do
+      let row = create sy (f x 0) in
+      for y = 1 to pred sy do
+        unsafe_set row y (f x y)
+      done;
+      unsafe_set res x row
+    done;
+  end;
   res
 
 let copy a =

--- a/stdlib/array.ml
+++ b/stdlib/array.ml
@@ -57,6 +57,8 @@ let init l f =
    res
 
 let make_matrix sx sy init =
+  (* We raise even if [sx = 0 && sy < 0]: *)
+  if sy < 0 then invalid_arg "Array.make_matrix";
   let res = create sx [||] in
   for x = 0 to pred sx do
     unsafe_set res x (create sy init)
@@ -64,6 +66,7 @@ let make_matrix sx sy init =
   res
 
 let init_matrix sx sy f =
+  (* We raise even if [sx = 0 && sy < 0]: *)
   if sy < 0 then invalid_arg "Array.init_matrix";
   let res = create sx [||] in
   if sy > 0 then begin

--- a/stdlib/array.ml
+++ b/stdlib/array.ml
@@ -47,7 +47,8 @@ end
 let init l f =
   if l = 0 then [||] else
   if l < 0 then invalid_arg "Array.init"
-  (* See #6575. We could also check for maximum array size, but this depends
+  (* See #6575. We must not evaluate [f 0] when [l <= 0].
+     We could also check for maximum array size, but this depends
      on whether we create a float array or a regular one... *)
   else
    let res = create l (f 0) in
@@ -60,15 +61,18 @@ let make_matrix sx sy init =
   (* We raise even if [sx = 0 && sy < 0]: *)
   if sy < 0 then invalid_arg "Array.make_matrix";
   let res = create sx [||] in
-  for x = 0 to pred sx do
-    unsafe_set res x (create sy init)
-  done;
+  if sy > 0 then begin
+    for x = 0 to pred sx do
+      unsafe_set res x (create sy init)
+    done;
+  end;
   res
 
 let init_matrix sx sy f =
   (* We raise even if [sx = 0 && sy < 0]: *)
   if sy < 0 then invalid_arg "Array.init_matrix";
   let res = create sx [||] in
+  (* We must not evaluate [f x 0] when [sy <= 0]: *)
   if sy > 0 then begin
     for x = 0 to pred sx do
       let row = create sy (f x 0) in

--- a/stdlib/array.ml
+++ b/stdlib/array.ml
@@ -63,6 +63,13 @@ let make_matrix sx sy init =
   done;
   res
 
+let init_matrix sx sy f =
+  let res = create sx [||] in
+  for x = 0 to pred sx do
+    unsafe_set res x (init sy (fun y -> f x y))
+  done;
+  res
+
 let copy a =
   let l = length a in if l = 0 then [||] else unsafe_sub a 0 l
 

--- a/stdlib/array.mli
+++ b/stdlib/array.mli
@@ -91,6 +91,21 @@ val make_matrix : int -> int -> 'a -> 'a array array
    If the value of [e] is a floating-point number, then the maximum
    size is only [Sys.max_array_length / 2]. *)
 
+val init_matrix : int -> int -> (int -> int -> 'a) -> 'a array array
+(** [init_matrix dimx dimy f] returns a two-dimensional array
+   (an array of arrays)
+   with first dimension [dimx] and second dimension [dimy],
+   where the element at index ([x,y]) is initialized with [f x y].
+   The element ([x,y]) of a matrix [m] is accessed
+   with the notation [m.(x).(y)].
+
+   @raise Invalid_argument if [dimx] or [dimy] is negative or
+   greater than {!Sys.max_array_length}.
+   If the return type of [f] is [float],
+   then the maximum size is only [Sys.max_array_length / 2].
+
+   @since 5.2 *)
+
 val append : 'a array -> 'a array -> 'a array
 (** [append v1 v2] returns a fresh array containing the
    concatenation of the arrays [v1] and [v2].

--- a/stdlib/arrayLabels.mli
+++ b/stdlib/arrayLabels.mli
@@ -91,6 +91,21 @@ val make_matrix : dimx:int -> dimy:int -> 'a -> 'a array array
    If the value of [e] is a floating-point number, then the maximum
    size is only [Sys.max_array_length / 2]. *)
 
+val init_matrix : dimx:int -> dimy:int -> f:(int -> int -> 'a) -> 'a array array
+(** [init_matrix ~dimx ~dimy ~f] returns a two-dimensional array
+   (an array of arrays)
+   with first dimension [dimx] and second dimension [dimy],
+   where the element at index ([x,y]) is initialized with [f x y].
+   The element ([x,y]) of a matrix [m] is accessed
+   with the notation [m.(x).(y)].
+
+   @raise Invalid_argument if [dimx] or [dimy] is negative or
+   greater than {!Sys.max_array_length}.
+   If the return type of [f] is [float],
+   then the maximum size is only [Sys.max_array_length / 2].
+
+   @since 5.2 *)
+
 val append : 'a array -> 'a array -> 'a array
 (** [append v1 v2] returns a fresh array containing the
    concatenation of the arrays [v1] and [v2].

--- a/stdlib/float.ml
+++ b/stdlib/float.ml
@@ -204,6 +204,32 @@ module Array = struct
       done;
       res
 
+  let make_matrix sx sy v =
+    (* We raise even if [sx = 0 && sy < 0]: *)
+    if sy < 0 then invalid_arg "Float.Array.make_matrix";
+    let res = Array.make sx (create 0) in
+    if sy > 0 then begin
+      for x = 0 to sx - 1 do
+        Array.unsafe_set res x (make sy v)
+      done;
+    end;
+    res
+
+  let init_matrix sx sy f =
+    (* We raise even if [sx = 0 && sy < 0]: *)
+    if sy < 0 then invalid_arg "Float.Array.init_matrix";
+    let res = Array.make sx (create 0) in
+    if sy > 0 then begin
+      for x = 0 to sx - 1 do
+        let row = create sy in
+        for y = 0 to sy - 1 do
+          unsafe_set row y (f x y)
+        done;
+        Array.unsafe_set res x row
+      done;
+    end;
+    res
+
   let append a1 a2 =
     let l1 = length a1 in
     let l2 = length a2 in

--- a/stdlib/float.mli
+++ b/stdlib/float.mli
@@ -533,6 +533,27 @@ module Array : sig
       applied to the integers [0] to [n-1].
       @raise Invalid_argument if [n < 0] or [n > Sys.max_floatarray_length]. *)
 
+  val make_matrix : int -> int -> float -> t array
+  (** [make_matrix dimx dimy e] returns a two-dimensional array
+      (an array of arrays) with first dimension [dimx] and
+      second dimension [dimy], where all elements are initialized with [e].
+
+      @raise Invalid_argument if [dimx] or [dimy] is negative or
+      greater than {!Sys.max_floatarray_length}.
+
+      @since 5.2 *)
+
+  val init_matrix : int -> int -> (int -> int -> float) -> t array
+  (** [init_matrix dimx dimy f] returns a two-dimensional array
+      (an array of arrays)
+      with first dimension [dimx] and second dimension [dimy],
+      where the element at index ([x,y]) is initialized with [f x y].
+
+      @raise Invalid_argument if [dimx] or [dimy] is negative or
+      greater than {!Sys.max_floatarray_length}.
+
+      @since 5.2 *)
+
   val append : t -> t -> t
   (** [append v1 v2] returns a fresh floatarray containing the
       concatenation of the floatarrays [v1] and [v2].
@@ -878,6 +899,27 @@ module ArrayLabels : sig
       In other terms, [init n ~f] tabulates the results of [f]
       applied to the integers [0] to [n-1].
       @raise Invalid_argument if [n < 0] or [n > Sys.max_floatarray_length]. *)
+
+  val make_matrix : dimx:int -> dimy:int -> float -> t array
+  (** [make_matrix ~dimx ~dimy e] returns a two-dimensional array
+      (an array of arrays) with first dimension [dimx] and
+      second dimension [dimy], where all elements are initialized with [e].
+
+      @raise Invalid_argument if [dimx] or [dimy] is negative or
+      greater than {!Sys.max_floatarray_length}.
+
+      @since 5.2 *)
+
+  val init_matrix : dimx:int -> dimy:int -> f:(int -> int -> float) -> t array
+  (** [init_matrix ~dimx ~dimy ~f] returns a two-dimensional array
+      (an array of arrays)
+      with first dimension [dimx] and second dimension [dimy],
+      where the element at index ([x,y]) is initialized with [f x y].
+
+      @raise Invalid_argument if [dimx] or [dimy] is negative or
+      greater than {!Sys.max_floatarray_length}.
+
+      @since 5.2 *)
 
   val append : t -> t -> t
   (** [append v1 v2] returns a fresh floatarray containing the

--- a/stdlib/templates/floatarraylabeled.template.mli
+++ b/stdlib/templates/floatarraylabeled.template.mli
@@ -49,6 +49,27 @@ val init : int -> f:(int -> float) -> t
     applied to the integers [0] to [n-1].
     @raise Invalid_argument if [n < 0] or [n > Sys.max_floatarray_length]. *)
 
+val make_matrix : dimx:int -> dimy:int -> float -> t array
+(** [make_matrix ~dimx ~dimy e] returns a two-dimensional array
+    (an array of arrays) with first dimension [dimx] and
+    second dimension [dimy], where all elements are initialized with [e].
+
+    @raise Invalid_argument if [dimx] or [dimy] is negative or
+    greater than {!Sys.max_floatarray_length}.
+
+    @since 5.2 *)
+
+val init_matrix : dimx:int -> dimy:int -> f:(int -> int -> float) -> t array
+(** [init_matrix ~dimx ~dimy ~f] returns a two-dimensional array
+    (an array of arrays)
+    with first dimension [dimx] and second dimension [dimy],
+    where the element at index ([x,y]) is initialized with [f x y].
+
+    @raise Invalid_argument if [dimx] or [dimy] is negative or
+    greater than {!Sys.max_floatarray_length}.
+
+    @since 5.2 *)
+
 val append : t -> t -> t
 (** [append v1 v2] returns a fresh floatarray containing the
     concatenation of the floatarrays [v1] and [v2].

--- a/testsuite/tests/lib-array/test_array.ml
+++ b/testsuite/tests/lib-array/test_array.ml
@@ -178,15 +178,20 @@ let a : int array =
 val a : int array = [|2; 4; 6; 8|]
 |}]
 
-let a = Array.init_matrix 2 3 (fun i j -> ref (10*i+j));;
-a.(0).(0) := 99;;
-a (* other cells are unchanged *);;
+let a = Array.make_matrix 2 3 "placeholder";;
+a.(0).(0) <- "hello";;
+a (* other rows are unchanged *);;
 [%%expect{|
-val a : int ref array array =
-  [|[|{contents = 0}; {contents = 1}; {contents = 2}|];
-    [|{contents = 10}; {contents = 11}; {contents = 12}|]|]
+val a : string array array =
+  [|[|"placeholder"; "placeholder"; "placeholder"|];
+    [|"placeholder"; "placeholder"; "placeholder"|]|]
 - : unit = ()
-- : int ref array array =
-[|[|{contents = 99}; {contents = 1}; {contents = 2}|];
-  [|{contents = 10}; {contents = 11}; {contents = 12}|]|]
+- : string array array =
+[|[|"hello"; "placeholder"; "placeholder"|];
+  [|"placeholder"; "placeholder"; "placeholder"|]|]
+|}]
+
+let a = Array.init_matrix 2 3 (fun i j -> 10 * i + j);;
+[%%expect{|
+val a : int array array = [|[|0; 1; 2|]; [|10; 11; 12|]|]
 |}]

--- a/testsuite/tests/lib-array/test_array.ml
+++ b/testsuite/tests/lib-array/test_array.ml
@@ -177,3 +177,16 @@ let a : int array =
 [%%expect{|
 val a : int array = [|2; 4; 6; 8|]
 |}]
+
+let a = Array.init_matrix 2 3 (fun i j -> ref (10*i+j));;
+a.(0).(0) := 99;;
+a (* other cells are unchanged *);;
+[%%expect{|
+val a : int ref array array =
+  [|[|{contents = 0}; {contents = 1}; {contents = 2}|];
+    [|{contents = 10}; {contents = 11}; {contents = 12}|]|]
+- : unit = ()
+- : int ref array array =
+[|[|{contents = 99}; {contents = 1}; {contents = 2}|];
+  [|{contents = 10}; {contents = 11}; {contents = 12}|]|]
+|}]

--- a/testsuite/tests/lib-floatarray/floatarray.ml
+++ b/testsuite/tests/lib-floatarray/floatarray.ml
@@ -11,6 +11,8 @@ module type S = sig
   val make : int -> float -> t
   val create : int -> t
   val init : int -> (int -> float) -> t
+  val make_matrix : int -> int -> float -> t array
+  val init_matrix : int -> int -> (int -> int -> float) -> t array
   val append : t -> t -> t
   val concat : t list -> t
   val sub : t -> int -> int -> t
@@ -124,6 +126,47 @@ module Test (A : S) : sig end = struct
   check_i a;
   check_inval (fun i -> A.init i Float.of_int) (-1);
   check_inval (fun i -> A.init i Float.of_int) (A.max_length + 1);
+
+  (* [make_matrix] *)
+  let check_make_matrix m n =
+    let a = A.make_matrix m n 42. in
+    assert (Array.length a = m);
+    for i = 0 to m-1 do
+      let row = Array.get a i in
+      assert (A.length row = n);
+      for j = 0 to n-1 do
+        assert (A.get row j = 42.);
+        A.set row j (Float.of_int (i*n + j));
+      done;
+    done;
+    (* check absence of sharing: *)
+    if n > 0 then begin
+      for i = 0 to m-1 do
+        assert (A.get (Array.get a i) 0 = Float.of_int (i*n));
+      done
+    end
+  in
+  check_make_matrix 0 0;
+  check_make_matrix 0 3;
+  check_make_matrix 5 0;
+  check_make_matrix 5 3;
+
+  (* [init_matrix] *)
+  let check_init_matrix m n =
+    let a = A.init_matrix m n (fun i j -> Float.of_int (i*n + j)) in
+    assert (Array.length a = m);
+    for i = 0 to m-1 do
+      let row = Array.get a i in
+      assert (A.length row = n);
+      for j = 0 to n-1 do
+        assert (A.get row j = Float.of_int (i*n + j));
+      done;
+    done;
+  in
+  check_init_matrix 0 0;
+  check_init_matrix 0 3;
+  check_init_matrix 5 0;
+  check_init_matrix 5 3;
 
   (* [append] *)
   let check m n =


### PR DESCRIPTION
This PR adds `Array.init_matrix` to the standard library, with the obvious semantics. It fills a gap because:

  1. a user expects to find this function, considering that there exist `Array.make` and `Array.init` and `Array.make_matrix`;
  2. just like `Array.make_matrix`, it reduces the risk of someone falling into the beginner’s trap of initializing an array with pointers to a shared mutable value.

I included a test.

Remaining questions:

  1. I would also add this function to `Float.Array`, but apparently there is no `Float.Array.make_matrix`. Is this intentional?
  2. The current docstring does not specify in which order the various invokations of `f` take place; should it? (I incline to think it should not, but this contrasts with the current docstring of `Array.init`.)
  3. This is my first PR. I am not sure what is the correct syntax for this docstring: `@since NEXT_OCAML_RELEASE`.