### PR TITLE
Fixing typos

### DIFF
--- a/Changes
+++ b/Changes
@@ -231,7 +231,7 @@ Working version
   Fixed by completely removing the call to `update_type` in
   `Typedecl.transl_type_decl`, as the expansion is already checked by
   `check_regularity`. As a result, recursion is more polymorphic,
-  which may cause some (essentialy wrong) type declarations to have
+  which may cause some (essentially wrong) type declarations to have
   unbound type variables, and some constraints unrelated to the concrete
   type to be ignored (see tests/typing-misc/constraints.ml).
   (Jacques Garrigue, report by Richard Eisenberg, review by Leo White)
@@ -536,7 +536,7 @@ Some of those changes will benefit all OCaml packages.
   (Stefan Muenzel, review by Gabriel Scherer and Jacques Garrigue)
 
 * #11984: Add dedicated syntax for generative functor application.
-  Previously, OCaml did not disinguish between `F ()` and
+  Previously, OCaml did not distinguish between `F ()` and
   `F (struct end)`, even though the latter looks applicative. Instead,
   the decision between generative and applicative functor application
   was made based on the type of `F`. With this patch, we now distinguish
@@ -1388,7 +1388,7 @@ OCaml 5.0.0 (15 December 2022)
 
 - #11279, #11585, #11742: ensure that the unsafe Buffer code
   remains memory-safe in concurrent settings.
-  Unsychronized access to Buffer is a programming error and may
+  Unsynchronized access to Buffer is a programming error and may
   result in wrong behavior, but it should preserve memory-safety.
   (Florian Angeletti and Gabriel Scherer, review by Gabriel Scherer
    and Vincent Laviron, report by David Allsopp)
@@ -2865,7 +2865,7 @@ OCaml 4.13.0 (24 September 2021)
   (Xavier Leroy, report by Richard Bornat, review by Stephen Dolan
    and Mark Shinwell)
 
-- #10371: no longer generatd useless `.cds` file when using
+- #10371: no longer generated useless `.cds` file when using
   `-output-complete-exe`.
   (Nicolás Ojeda Bär, review by David Allsopp)
 
@@ -4492,7 +4492,7 @@ OCaml 4.10.0 (21 February 2020)
   (Florian Angeletti, report by Anton Kochkov, review by Gabriel Scherer)
 
 - #9101: add links to section anchor before the section title,
-  make the name of those anchor explicits.
+  make the name of those anchor explicit.
   (Florian Angeletti, review by Daniel Bünzli, Sébastien Hinderer,
    and Gabriel Scherer)
 

--- a/Changes
+++ b/Changes
@@ -2865,7 +2865,7 @@ OCaml 4.13.0 (24 September 2021)
   (Xavier Leroy, report by Richard Bornat, review by Stephen Dolan
    and Mark Shinwell)
 
-- #10371: no longer generated useless `.cds` file when using
+- #10371: Stop generating useless `.cds` file when using
   `-output-complete-exe`.
   (Nicolás Ojeda Bär, review by David Allsopp)
 

--- a/api_docgen/odoc/Makefile
+++ b/api_docgen/odoc/Makefile
@@ -76,7 +76,7 @@ $(libref:%=build/libref/%.odoc):\
 build/libref/%.odoc: %.cmti | build/libref
 	$(V_ODOC)$(odoc) compile -I build/libref  --package libref $< -o $@
 
-# pervasives is handled separatedly due to the lack of cmti file
+# pervasives is handled separately due to the lack of cmti file
 $(libref_EXTRA:%=build/libref/%.odoc):build/libref/%.odoc:%.cmt
 	$(V_ODOC)$(odoc) compile -I build/libref --package libref $< -o $@
 

--- a/manual/src/html_processing/scss/_common.scss
+++ b/manual/src/html_processing/scss/_common.scss
@@ -1,6 +1,6 @@
 // SCSS Module for manual.scss and style.scss
 
-// set this to true for integration into the ocaml.org wesite
+// set this to true for integration into the ocaml.org website
 $ocamlorg:false;
 /* ocaml logo color */
 $logocolor:#ec6a0d;

--- a/manual/src/html_processing/scss/style.scss
+++ b/manual/src/html_processing/scss/style.scss
@@ -171,7 +171,7 @@
 	margin-top: 0
     }
 
-    /* Text alignements, this should be forbidden. */
+    /* Text alignments, this should be forbidden. */
 
     .left {
 	text-align: left;

--- a/middle_end/flambda/augment_specialised_args.ml
+++ b/middle_end/flambda/augment_specialised_args.ml
@@ -155,7 +155,7 @@ module Processed_what_to_specialise = struct
        needs a "new inner var" and a "new outer var".  However if there
        is already a lifted projection being introduced around the set
        of closures (corresponding to another new specialised argument),
-       we should re-use its "new outer var" to avoid duplication of
+       we should reuse its "new outer var" to avoid duplication of
        projection definitions.  Likewise if the definition is just
        [Existing_inner_free_var], in which case we can use the
        corresponding existing outer free variable. *)

--- a/ocamldoc/odoc_text_lexer.mll
+++ b/ocamldoc/odoc_text_lexer.mll
@@ -784,7 +784,7 @@ rule main = parse
       if !shortcut_list_mode then
         (
          shortcut_list_mode := false;
-                        (* go back one char to re-use the last '\n', so we can
+                        (* go back one char to reuse the last '\n', so we can
                            restart another shortcut-list with a single blank line,
                            and not two.*)
          END_SHORTCUT_LIST

--- a/ocamltest/OCAMLTEST.org
+++ b/ocamltest/OCAMLTEST.org
@@ -582,7 +582,7 @@ namely:
 #+end_src
 
 The braces make explicit the scope of variable assignments: an
-assignement modifies a variable for the rest of its block and for all
+assignment modifies a variable for the rest of its block and for all
 sub-blocks (unless overridden at some point).
 
 For instance, given the following blocks:

--- a/runtime/afl.c
+++ b/runtime/afl.c
@@ -140,7 +140,7 @@ CAMLexport value caml_setup_afl(value unit)
       return Val_unit;
     }
 
-    /* As long as the child keeps raising SIGSTOP, we re-use the same process */
+    /* As long as the child keeps raising SIGSTOP, we reuse the same process */
     while (1) {
       int status;
       uint32_t was_killed;

--- a/runtime/arm64.S
+++ b/runtime/arm64.S
@@ -752,7 +752,7 @@ FUNCTION(caml_perform)
         x1: freshly allocated continuation */
         ldr     x2, Caml_state(current_stack) /* x2 := old stack */
         add     x3, x2, 1 /* x3 := Val_ptr(old stack) */
-        str     x3, [x1] /* Iniitalize continuation */
+        str     x3, [x1] /* Initialize continuation */
 L(do_perform):
     /*  x0: effect to perform
         x1: continuation

--- a/runtime/array.c
+++ b/runtime/array.c
@@ -319,7 +319,7 @@ CAMLprim value caml_make_array(value init)
    Since the [memmove] implementation does not guarantee that the writes are
    always word-sized, we explicitly perform word-sized writes of the release
    kind to avoid mixed-mode accesses. Performing release writes should be
-   sufficient to prevent smart compilers from coalesing the writes into vector
+   sufficient to prevent smart compilers from coalescing the writes into vector
    writes, and hence prevent mixed-mode accesses. [MM].
    */
 static void wo_memmove (volatile value* const dst,

--- a/runtime/caml/startup.h
+++ b/runtime/caml/startup.h
@@ -50,7 +50,7 @@ extern int32_t caml_seek_section(int fd, struct exec_trailer *trail,
 enum caml_byte_program_mode
   {
    STANDARD /* normal bytecode program requiring "ocamlrun" */,
-   COMPLETE_EXE /* embeding the vm, i.e. compiled with --output-complete-exe */
+   COMPLETE_EXE /* embedding the vm, i.e. compiled with --output-complete-exe */
   };
 
 extern enum caml_byte_program_mode caml_byte_program_mode;

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -117,7 +117,7 @@ gc_phase_t caml_gc_phase;
 
    - Opportunistic collections may happen while a domain is waiting on
      a STW barrier, so it might race with the code running inside
-     anoter in-STW barrier. (It is possible that a deeper analysis of
+     another in-STW barrier. (It is possible that a deeper analysis of
      the current runtime code would in fact rule out such a race, but
      it is simpler to avoid phase accesses during opportunistic
      collections.)

--- a/runtime/riscv.S
+++ b/runtime/riscv.S
@@ -685,7 +685,7 @@ FUNCTION(caml_perform)
         a1: freshly allocated continuation */
         ld      a2, Caml_state(current_stack) /* a2 := old stack */
         addi    a3, a2, 1 /* a3 := Val_ptr(old stack) */
-        sd      a3, 0(a1) /* Iniitalize continuation */
+        sd      a3, 0(a1) /* Initialize continuation */
 L(do_perform):
     /*  a0: effect to perform
         a1: continuation

--- a/runtime/tsan.c
+++ b/runtime/tsan.c
@@ -58,7 +58,7 @@
    It is important to keep TSan entries and exits balanced to avoid
    underflow/overflow on the TSan internal buffer used for reconstructing
    events backtrace.
-   The runtime is responsible for emiting `__tsan_func_exit` call for each
+   The runtime is responsible for emitting `__tsan_func_exit` call for each
    function "aborted" while raising an exception or performing an effect. They
    match the corresponding `__tsan_func_entry` call inserted by the Cmm
    instrumentation pass.
@@ -92,7 +92,7 @@
 
    2. Effects
 
-   Similary to exceptions, when `perform` is called `__tsan_func_exit` must be
+   Similarly to exceptions, when `perform` is called `__tsan_func_exit` must be
    called for every function on the current fiber. The process can be repeated
    for every fiber's parents, because of `caml_repeform` until reaching the
    effect handler.

--- a/stdlib/camlinternalFormat.ml
+++ b/stdlib/camlinternalFormat.ml
@@ -2067,7 +2067,7 @@ let fmt_ebb_of_string ?legacy_behavior str =
     | Some flag -> flag
     | None -> true
   (*  When this flag is enabled, the format parser tries to behave as
-      the <4.02 implementations, in particular it ignores most benine
+      the <4.02 implementations, in particular it ignores most benign
       nonsensical format. When the flag is disabled, it will reject any
       format that is not accepted by the specification.
 

--- a/stdlib/camlinternalFormat.ml
+++ b/stdlib/camlinternalFormat.ml
@@ -2068,7 +2068,7 @@ let fmt_ebb_of_string ?legacy_behavior str =
     | None -> true
   (*  When this flag is enabled, the format parser tries to behave as
       the <4.02 implementations, in particular it ignores most benign
-      nonsensical format. When the flag is disabled, it will reject any
+      nonsensical formats. When the flag is disabled, it will reject any
       format that is not accepted by the specification.
 
       A typical example would be "%+ d": specifying both '+' (if the

--- a/stdlib/random.ml
+++ b/stdlib/random.ml
@@ -46,7 +46,7 @@ module State = struct
        a version number. We should update this prefix if we change
        the Random algorithm or the serialization format, so that users
        get a clean error instead of believing that they faithfully
-       reproduce their previous state and in fact get a differrent
+       reproduce their previous state and in fact get a different
        stream.
 
        Note that there is no constraint to keep the same

--- a/testsuite/tests/tool-toplevel/install_printer.ml
+++ b/testsuite/tests/tool-toplevel/install_printer.ml
@@ -32,7 +32,7 @@ let print_old = function
 [OA; OB];;
 
 
-(* genreic printers *)
+(* generic printers *)
 type ('a, 'b) v = D of 'a * 'b;;
 
 type 'a printer = Format.formatter -> 'a -> unit;;

--- a/testsuite/tests/typing-misc/polyvars.ml
+++ b/testsuite/tests/typing-misc/polyvars.ml
@@ -233,7 +233,7 @@ val x : [> `X of [> `Y of '_weak2 -> bool ] as '_weak3 ] as '_weak2 =
   `X (`Y <fun>)
 |}]
 
-(** Code coverage for [unify_row_field] erros *)
+(** Code coverage for [unify_row_field] errors *)
 
 (** Arity mismatch *)
 

--- a/testsuite/tests/typing-modules/functors.ml
+++ b/testsuite/tests/typing-modules/functors.ml
@@ -1333,7 +1333,7 @@ Error: This application of the functor "F" is ill-typed.
        5. Module A matches the expected module type arg
 |}]
 
-(** Known lmitation: we choose the wrong environment without the
+(** Known limitation: we choose the wrong environment without the
     error on Add_one
 **)
 module Mislead_chosen_one = F(Add_one)(Add_three)(A)(A)(A)

--- a/typing/includemod.ml
+++ b/typing/includemod.ml
@@ -1137,7 +1137,7 @@ module Functor_app_diff = struct
     | Insert(Named(Some param, param_ty))
     | Change(_, Named(Some param, param_ty), _ ) ->
         (* Change is Delete + Insert: we add the Inserted parameter to the
-           environnement to track equalities with external components that the
+           environment to track equalities with external components that the
            parameter might add. *)
         let mty = Subst.modtype Keep st.subst param_ty in
         let env = Env.add_module ~arg:true param Mp_present mty st.env in

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -4665,7 +4665,7 @@ and type_function
                     [type_argument] on the cases, and discard the cases'
                     inferred type in favor of the constrained type. (Function
                     cases aren't inferred, so [type_argument] would just call
-                    [type_expect] straight away, so we do the same here.)
+                    [type_expect] straightaway, so we do the same here.)
                   - [type_without_constraint]: If there is just a coercion and
                     no constraint, call [type_exp] on the cases and surface the
                     cases' inferred type to [type_constraint_expect]. *)

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -4665,7 +4665,7 @@ and type_function
                     [type_argument] on the cases, and discard the cases'
                     inferred type in favor of the constrained type. (Function
                     cases aren't inferred, so [type_argument] would just call
-                    [type_expect] straightaway, so we do the same here.)
+                    [type_expect] straight away, so we do the same here.)
                   - [type_without_constraint]: If there is just a coercion and
                     no constraint, call [type_exp] on the cases and surface the
                     cases' inferred type to [type_constraint_expect]. *)

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -652,7 +652,7 @@ let check_abbrev env sdecl (id, decl) =
    We want to guarantee that all cycles within OCaml types are
    "guarded".
 
-   More precisly, we consider a reachability relation
+   More precisely, we consider a reachability relation
      "[t] is reachable [guarded|unguarded] from [u]"
    defined as follows:
 
@@ -896,7 +896,7 @@ let check_well_founded_decl env loc path decl to_check =
 
    Note: in the case of a constrained type definition
    [type 'a t = ... constraint 'a = ...], we require
-   that all instances in [...] be equal to the constrainted type.
+   that all instances in [...] be equal to the constrained type.
 *)
 
 let check_regularity ~abs_env env loc path decl to_check =
@@ -1070,7 +1070,7 @@ let transl_type_decl env rec_flag sdecl_list =
   in
   (* Translate declarations, using a temporary environment where abbreviations
      expand to a generic type variable. After that, we check the coherence of
-     the translated declarations in the resulting new enviroment. *)
+     the translated declarations in the resulting new environment. *)
   let tdecls, decls, new_env =
     Ctype.with_local_level_iter ~post:generalize_decl begin fun () ->
       (* Enter types. *)


### PR DESCRIPTION
Typos found with https://github.com/codespell-project/codespell