### PR TITLE
stdlib: add `Stack.of_list` and `Stack.to_list`

### DIFF
--- a/Changes
+++ b/Changes
@@ -109,6 +109,9 @@ Working version
    Guillaume Munch-Maccagnoni, KC Sivaramakrishnan, Stefan Muenzel,
    Xavier Leroy)
 
+- #12XXX: Add `Stack.of_list` and `Stack.to_list`.
+  (Glen Mével, review by XXX)
+
 ### Other libraries:
 
 - #12213: Dynlink library, improve legibility of error messages

--- a/stdlib/stack.ml
+++ b/stdlib/stack.ml
@@ -62,9 +62,13 @@ let fold f acc s = List.fold_left f acc s.c
 
 let to_seq s = List.to_seq s.c
 
+let to_list s = s.c
+
 let add_seq q i = Seq.iter (fun x -> push x q) i
 
 let of_seq g =
   let s = create() in
   add_seq s g;
   s
+
+let of_list xs = { c = xs ; len = List.length xs }

--- a/stdlib/stack.mli
+++ b/stdlib/stack.mli
@@ -92,9 +92,13 @@ val fold : ('acc -> 'a -> 'acc) -> 'acc -> 'a t -> 'acc
 (** {1 Stacks and Sequences} *)
 
 val to_seq : 'a t -> 'a Seq.t
-(** Iterate on the stack, top to bottom.
+(** Iterate on the stack, from top to bottom.
     It is safe to modify the stack during iteration.
     @since 4.07 *)
+
+val to_list : 'a t -> 'a list
+(** Return the list of the stack's elements, from top to bottom.
+    @since NEXT_OCAML_RELEASE *)
 
 val add_seq : 'a t -> 'a Seq.t -> unit
 (** Add the elements of the sequence to the stack.
@@ -109,3 +113,9 @@ val of_seq : 'a Seq.t -> 'a t
     the top element of the stack is the {i last} element of the input sequence.
     The input sequence must be finite.
     @since 4.07 *)
+
+val of_list : 'a list -> 'a t
+(** Create a stack from the list's elements.
+    The order is preserved:
+    the top element of the stack is the head of the list.
+    @since NEXT_OCAML_RELEASE *)

--- a/stdlib/stack.mli
+++ b/stdlib/stack.mli
@@ -97,9 +97,15 @@ val to_seq : 'a t -> 'a Seq.t
     @since 4.07 *)
 
 val add_seq : 'a t -> 'a Seq.t -> unit
-(** Add the elements from the sequence on the top of the stack.
+(** Add the elements of the sequence to the stack.
+    The order is reversed:
+    the top element of the stack is the {i last} element of the input sequence.
+    The input sequence must be finite.
     @since 4.07 *)
 
 val of_seq : 'a Seq.t -> 'a t
-(** Create a stack from the sequence.
+(** Create a stack from the sequence's elements.
+    The order is reversed:
+    the top element of the stack is the {i last} element of the input sequence.
+    The input sequence must be finite.
     @since 4.07 *)

--- a/testsuite/tests/lib-stack/test.ml
+++ b/testsuite/tests/lib-stack/test.ml
@@ -1,13 +1,6 @@
 (* TEST *)
 
-module S = struct
-  include Stack
-
-  let to_list s =    (* from bottom to top *)
-    let l = ref [] in
-    iter (fun x -> l := x :: !l) s;
-    !l
-end
+module S = Stack
 
 let does_raise f s =
   try
@@ -17,15 +10,21 @@ let does_raise f s =
     true
 
 let () =
+  let s = S.of_list [1; 2; 3; 4] in
+  assert (S.to_list s = [1; 2; 3; 4]) ;
+  assert (S.pop s = 1);
+  assert (S.to_list s = [2; 3; 4])
+
+let () =
   let s = S.create () in
   ();                   assert (S.to_list s = [          ] && S.length s = 0);
-  S.push 1 s;           assert (S.to_list s = [1         ] && S.length s = 1);
-  S.push 2 s;           assert (S.to_list s = [1; 2      ] && S.length s = 2);
-  S.push 3 s;           assert (S.to_list s = [1; 2; 3   ] && S.length s = 3);
-  S.push 4 s;           assert (S.to_list s = [1; 2; 3; 4] && S.length s = 4);
-  assert (S.pop s = 4); assert (S.to_list s = [1; 2; 3;  ] && S.length s = 3);
-  assert (S.pop s = 3); assert (S.to_list s = [1; 2;     ] && S.length s = 2);
-  assert (S.pop s = 2); assert (S.to_list s = [1;        ] && S.length s = 1);
+  S.push 1 s;           assert (S.to_list s = [         1] && S.length s = 1);
+  S.push 2 s;           assert (S.to_list s = [      2; 1] && S.length s = 2);
+  S.push 3 s;           assert (S.to_list s = [   3; 2; 1] && S.length s = 3);
+  S.push 4 s;           assert (S.to_list s = [4; 3; 2; 1] && S.length s = 4);
+  assert (S.pop s = 4); assert (S.to_list s = [   3; 2; 1] && S.length s = 3);
+  assert (S.pop s = 3); assert (S.to_list s = [      2; 1] && S.length s = 2);
+  assert (S.pop s = 2); assert (S.to_list s = [         1] && S.length s = 1);
   assert (S.pop s = 1); assert (S.to_list s = [          ] && S.length s = 0);
   assert (does_raise S.pop s);
 ;;
@@ -64,8 +63,8 @@ let () =
   let s1 = S.create () in
   for i = 1 to 10 do S.push i s1 done;
   let s2 = S.copy s1 in
-  assert (S.to_list s1 = [1; 2; 3; 4; 5; 6; 7; 8; 9; 10]);
-  assert (S.to_list s2 = [1; 2; 3; 4; 5; 6; 7; 8; 9; 10]);
+  assert (S.to_list s1 = [10; 9; 8; 7; 6; 5; 4; 3; 2; 1]);
+  assert (S.to_list s2 = [10; 9; 8; 7; 6; 5; 4; 3; 2; 1]);
   assert (S.length s1 = 10);
   assert (S.length s2 = 10);
   for i = 10 downto 1 do
@@ -111,10 +110,10 @@ let () =
 let () =
   let s1 = S.create () in
   for i = 1 to 4 do S.push i s1 done;
-  assert (S.length s1 = 4); assert (S.to_list s1 = [1; 2; 3; 4]);
+  assert (S.length s1 = 4); assert (S.to_list s1 = [4; 3; 2; 1]);
   let s2 = S.copy s1 in
-  assert (S.length s1 = 4); assert (S.to_list s1 = [1; 2; 3; 4]);
-  assert (S.length s2 = 4); assert (S.to_list s2 = [1; 2; 3; 4]);
+  assert (S.length s1 = 4); assert (S.to_list s1 = [4; 3; 2; 1]);
+  assert (S.length s2 = 4); assert (S.to_list s2 = [4; 3; 2; 1]);
 ;;
 
 let () =
@@ -122,9 +121,9 @@ let () =
   S.push 0 s;
   S.push 1 s;
   S.push 2 s;
-  assert (S.to_list s = [0; 1; 2]);
+  assert (S.to_list s = [2; 1; 0]);
   S.drop s;
-  assert (S.to_list s = [0; 1]);
+  assert (S.to_list s = [1; 0]);
   S.drop s;
   assert (S.to_list s = [0]);
   S.drop s;


### PR DESCRIPTION
I believe it is worthwhile to provide these functions in the standard library, because:

 1. they can be implemented more efficiently (no list allocation; constant time if it wasn’t for computing the length) from the internals of `Stack`.
 2. the correspondence between stacks and OCaml-style lists is natural (since OCaml lists support O(1) push/pop at their front), and it is in fact very common to emulate a stack by using a `'a list ref`.

This PR also improves the documentation of `Stack.add_seq` and `Stack.of_seq`, to clarify that the elements are added in *reverse* order.

Concern about the ordering: the proposed `of_list` preserves the order of the input list. This is consistent with its reciprocal conversion, `to_list` (new), which in turn is consistent with `to_seq` (existing). However it is inconsistent with `of_seq` (existing) and `add_seq` (existing), which both reverse their input sequence. My thoughts on this:

 1. This is an inconsistency we cannot resolve because it is already there in the standard library (`to_seq` versus `of_seq`).
 2. In my opinion, `of_seq` and `add_seq` should have been named e.g. `of_rev_seq` and `rev_add_seq`. Which order is more natural might be a question of perspective, but see my point above about the correspondence between stacks and lists.
 3. I made the order as clear as possible in the documentation.