### PR TITLE
CI: Check relevance of parsetree-change label

### DIFF
--- a/.github/workflows/hygiene.yml
+++ b/.github/workflows/hygiene.yml
@@ -47,6 +47,20 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         if: github.event_name == 'pull_request'
 
+      - name: Parsetree updated
+        run: >-
+          tools/ci/actions/check-parsetree-modified.sh
+          '${{ github.event.pull_request.issue_url }}'
+          '${{ github.ref }}'
+          'pull_request'
+          '${{ github.event.pull_request.base.ref }}'
+          '${{ github.event.pull_request.base.sha }}'
+          '${{ github.event.pull_request.head.ref }}'
+          '${{ github.event.pull_request.head.sha }}'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        if: github.event_name == 'pull_request'
+
       - name: configure correctly generated
         run: >-
           tools/ci/actions/check-configure.sh

--- a/tools/ci/actions/check-parsetree-modified.sh
+++ b/tools/ci/actions/check-parsetree-modified.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+#**************************************************************************
+#*                                                                        *
+#*                                 OCaml                                  *
+#*                                                                        *
+#*                 Paul-Elliot Anglès d'Auriac, Tarides                   *
+#*                                                                        *
+#*   Copyright 2023 Tarides                                               *
+#*                                                                        *
+#*   All rights reserved.  This file is distributed under the terms of    *
+#*   the GNU Lesser General Public License version 2.1, with the          *
+#*   special exception on linking described in the file LICENSE.          *
+#*                                                                        *
+#**************************************************************************
+
+set -e
+
+# Hygiene Checks: check that whenever the parsetree.mli file has been modified,
+# the parsetree-change label has been applied to the PR
+
+# Exactly of the following must be true:
+#   - No commit in the PR alters the parsetree.mli file
+#   - The parsetree-change label is applied to the PR
+
+API_URL="$1"
+shift 1
+
+AUTH="authorization: Bearer $GITHUB_TOKEN"
+
+# We need all the commits in the PR to be available
+. tools/ci/actions/deepen-fetch.sh
+
+COMMIT_RANGE="$MERGE_BASE..$PR_HEAD"
+
+LABEL='parsetree-change'
+
+if ! git diff "$COMMIT_RANGE" --name-only --exit-code parsing/parsetree.mli \
+   > /dev/null; then
+  echo -e "The parsetree has been modified."
+  if curl --silent --header "$AUTH" "$API_URL/labels" | grep -q "$LABEL"; then
+    echo -e "Label $LABEL is assigned to the PR."
+  else
+    echo -e "Please assign the label $LABEL to the PR"
+    exit 1
+  fi
+else
+  echo -e "The parsetree has not been modified."
+  if curl --silent --header "$AUTH" "$API_URL/labels" | grep -q "$LABEL"; then
+    echo -e "Please remove the label $LABEL to the PR"
+    exit 1
+  else
+    echo -e "Label $LABEL is not assigned to the PR"
+  fi
+fi


### PR DESCRIPTION
Suggested by @gasche in https://github.com/ocaml/ocaml/pull/12391#issuecomment-1663654427

The parsetree-change label is useful for PPX-related maintainance. This new CI check enforces that `parsetree-change` is equivalent to a change in the `parsetree.mli` file.



Some comments:
- I based the file on `check-changes-modified.sh`, but removed the License banner, I was not sure what to do about the license
- Compared to the `no-change-entry-needed`, where the label can be added on a PR where a change entry is added, the CI will fail on an unmodified `parsetree.mli` with the `parsetree-change` label.
- A change in the documentation comments of `parsetree.mli` will also need a `parsetree-change` label, while the type does not change. A fix for this could be to have another label `ignored-parsetree-change`, and the check would be that "change in parsetree.mli" <=> `parsetree-change` OR `ignored-parsetree-change` is present.
But, I don't think that is necessary.