### PR TITLE
Print the value of `Uchar.t` in toplevel

### DIFF
--- a/toplevel/genprintval.ml
+++ b/toplevel/genprintval.ml
@@ -331,7 +331,7 @@ module Make(O : OBJ)(EVP : EVALPATH with type valu = O.t) = struct
               when Path.same path (mk_persistent "Stdlib__Uchar" ["t"]) ->
             Oval_constr
               (Oide_ident (Out_name.create "Uchar.of_int"),
-              [Oval_printer (fun ppf -> fprintf ppf "%#x" (O.obj obj : int))])
+              [Oval_printer (fun ppf -> fprintf ppf "0x%04X" (O.obj obj : int))])
 
           | Tconstr (path, [ty_arg], _)
             when Path.same path Predef.path_lazy_t ->

--- a/toplevel/genprintval.ml
+++ b/toplevel/genprintval.ml
@@ -257,6 +257,10 @@ module Make(O : OBJ)(EVP : EVALPATH with type valu = O.t) = struct
 
       let nest f = nest_gen (Oval_stuff "<cycle>") f in
 
+      let mk_persistent m v =
+        List.fold_left (fun p c -> Pdot(p, c)) (Pident (Ident.create_persistent m)) v
+      in
+
       let rec tree_of_val depth obj ty =
         decr printer_steps;
         if !printer_steps < 0 || depth < 0 then Oval_ellipsis
@@ -322,6 +326,12 @@ module Make(O : OBJ)(EVP : EVALPATH with type valu = O.t) = struct
               when Path.same path Predef.path_bytes ->
             let s = Bytes.to_string (O.obj obj : bytes) in
             Oval_string (s, !printer_steps, Ostr_bytes)
+
+          | Tconstr (path, [], _)
+              when Path.same path (mk_persistent "Stdlib__Uchar" ["t"]) ->
+            Oval_constr
+              (Oide_ident (Out_name.create "Uchar.of_int"),
+              [Oval_printer (fun ppf -> fprintf ppf "%#x" (O.obj obj : int))])
 
           | Tconstr (path, [ty_arg], _)
             when Path.same path Predef.path_lazy_t ->


### PR DESCRIPTION
This is a small QoL/interactivity improvement to the toplevel..
Before:
```ocaml
# Uchar.bom;;
- : Uchar.t = <abstr>
```
After:
```ocaml
# Uchar.bom;;
- : Uchar.t = Uchar.of_int 0xfeff

# module U = Uchar;;
module U = Uchar
# U.bom;;
- : U.t = Uchar.of_int 0xfeff

# module U = struct include U end;;
module U :
  sig
    ...
  end
# U.bom;;
- : U.t = Uchar.of_int 0xfeff
```
----
Choices I made:
- Used hex representation of ints because it's the convention for unicode scalars, e.g. this makes it easier to work with the syntax `"\u{...}"`.
- Used `Uchar.of_int` because ints are capable of representing any scalar, unlike `Uchar.of_char`
- Opted to preserve the `Uchar` module name in evaluation output to conform with the behavior of `Bytes`

Finally, if this is a welcome change, it will be one of a couple more similar ones that try to make `Stdlib` types more transparent interactively.