### PR TITLE
Reduce installation size by another ~20MiB

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -301,12 +301,12 @@ opt: checknative
 opt.opt: checknative
 	$(MAKE) checkstack
 	$(MAKE) coreall
-	$(MAKE) ocaml
+	$(MAKE) compilerlibs/ocamlcommon.cma ocaml
 	$(MAKE) opt-core
 ifeq "$(BOOTSTRAPPING_FLEXDLL)" "true"
 	$(MAKE) flexlink.opt$(EXE)
 endif
-	$(MAKE) ocamlc.opt
+	$(MAKE) compilerlibs/ocamlcommon.cmxa ocamlc.opt
 	$(MAKE) otherlibraries $(WITH_DEBUGGER) $(WITH_OCAMLDOC) \
 	  $(WITH_OCAMLTEST)
 	$(MAKE) ocamlopt.opt
@@ -349,7 +349,7 @@ endif
 
 .PHONY: all
 all: coreall
-	$(MAKE) ocaml
+	$(MAKE) compilerlibs/ocamlcommon.cma ocaml
 	$(MAKE) otherlibraries $(WITH_DEBUGGER) $(WITH_OCAMLDOC) \
          $(WITH_OCAMLTEST)
 	$(MAKE) othertools
@@ -480,7 +480,7 @@ clean:: partialclean
 
 # The bytecode compiler
 
-ocamlc_LIBRARIES = $(addprefix compilerlibs/,ocamlcommon ocamlbytecomp)
+ocamlc_LIBRARIES = $(addprefix compilerlibs/,ocamlcommon-private ocamlbytecomp)
 
 ocamlc_MODULES = driver/main
 
@@ -493,7 +493,7 @@ partialclean::
 
 # The native-code compiler
 
-ocamlopt_LIBRARIES = $(addprefix compilerlibs/,ocamlcommon ocamloptcomp)
+ocamlopt_LIBRARIES = $(addprefix compilerlibs/,ocamlcommon-private ocamloptcomp)
 
 ocamlopt_MODULES = driver/optmain
 
@@ -505,7 +505,7 @@ partialclean::
 # The toplevel
 
 ocaml_LIBRARIES = \
-  $(addprefix compilerlibs/,ocamlcommon ocamlbytecomp ocamltoplevel)
+  $(addprefix compilerlibs/,ocamlcommon-private ocamlbytecomp ocamltoplevel)
 
 ocaml_MODULES = toplevel/topstart
 
@@ -610,7 +610,7 @@ cvt_emit_MODULES = tools/cvt_emit
 
 # The "expunge" utility
 
-expunge_LIBRARIES = $(addprefix compilerlibs/,ocamlcommon ocamlbytecomp)
+expunge_LIBRARIES = $(addprefix compilerlibs/,ocamlcommon-private ocamlbytecomp)
 
 expunge_MODULES = toplevel/expunge
 
@@ -1215,11 +1215,11 @@ partialclean:: partialclean-menhir
 # OCamldoc
 
 .PHONY: ocamldoc
-ocamldoc: ocamlc ocamlyacc ocamllex otherlibraries
+ocamldoc: ocamlc ocamlyacc ocamllex otherlibraries compilerlibs/ocamlcommon.cma
 	$(MAKE) -C ocamldoc all
 
 .PHONY: ocamldoc.opt
-ocamldoc.opt: ocamlc.opt ocamlyacc ocamllex
+ocamldoc.opt: ocamlc.opt ocamlyacc ocamllex compilerlibs/ocamlcommon.cmxa
 	$(MAKE) -C ocamldoc opt.opt
 
 # OCamltest
@@ -1266,7 +1266,7 @@ clean::
 
 # The replay debugger
 
-ocamldebug_LIBRARIES = compilerlibs/ocamlcommon \
+ocamldebug_LIBRARIES = compilerlibs/ocamlcommon-private \
   $(addprefix otherlibs/,unix/unix dynlink/dynlink)
 
 # The following dependencies are necessary at the moment, because the
@@ -1354,7 +1354,7 @@ endif
 # Lint @since and @deprecated annotations
 
 lintapidiff_LIBRARIES = \
-  $(addprefix compilerlibs/,ocamlcommon ocamlbytecomp) \
+  $(addprefix compilerlibs/,ocamlcommon-private ocamlbytecomp) \
   otherlibs/str/str
 lintapidiff_MODULES = tools/lintapidiff
 
@@ -1417,7 +1417,8 @@ partialclean::
 
 # The dependency generator
 
-ocamldep_LIBRARIES = $(addprefix compilerlibs/,ocamlcommon ocamlbytecomp)
+ocamldep_LIBRARIES = \
+  $(addprefix compilerlibs/,ocamlcommon-private ocamlbytecomp)
 ocamldep_MODULES = tools/ocamldep
 
 tools/ocamldep$(EXE): OC_BYTECODE_LINKFLAGS += -compat-32
@@ -1455,12 +1456,13 @@ ocamlmktop_MODULES = \
 
 # Reading cmt files
 
-ocamlcmt_LIBRARIES = $(addprefix compilerlibs/,ocamlcommon ocamlbytecomp)
+ocamlcmt_LIBRARIES = \
+  $(addprefix compilerlibs/,ocamlcommon-private ocamlbytecomp)
 ocamlcmt_MODULES = tools/ocamlcmt
 
 # The bytecode disassembler
 
-dumpobj_LIBRARIES = $(addprefix compilerlibs/,ocamlcommon ocamlbytecomp)
+dumpobj_LIBRARIES = $(addprefix compilerlibs/,ocamlcommon-private ocamlbytecomp)
 dumpobj_MODULES = $(addprefix tools/,opnames dumpobj)
 
 make_opcodes = tools/make_opcodes$(EXE)
@@ -1479,29 +1481,29 @@ beforedepend:: $(addprefix tools/,opnames.ml make_opcodes.ml)
 # Display info on compiled files
 
 ocamlobjinfo_LIBRARIES = \
-  $(addprefix compilerlibs/,ocamlcommon ocamlbytecomp ocamlmiddleend)
+  $(addprefix compilerlibs/,ocamlcommon-private ocamlbytecomp ocamlmiddleend)
 ocamlobjinfo_MODULES = tools/objinfo
 
 # Scan object files for required primitives
 
-primreq_LIBRARIES = $(addprefix compilerlibs/,ocamlcommon ocamlbytecomp)
+primreq_LIBRARIES = $(addprefix compilerlibs/,ocamlcommon-private ocamlbytecomp)
 primreq_MODULES = tools/primreq
 
 # Copy a bytecode executable, stripping debug info
 
 stripdebug_LIBRARIES = \
-  $(addprefix compilerlibs/,ocamlcommon ocamlbytecomp)
+  $(addprefix compilerlibs/,ocamlcommon-private ocamlbytecomp)
 stripdebug_MODULES = tools/stripdebug
 
 # Compare two bytecode executables
 
-cmpbyt_LIBRARIES = $(addprefix compilerlibs/,ocamlcommon ocamlbytecomp)
+cmpbyt_LIBRARIES = $(addprefix compilerlibs/,ocamlcommon-private ocamlbytecomp)
 cmpbyt_MODULES = tools/cmpbyt
 
 # Scan latex files, and run ocaml code examples
 
 ocamltex_LIBRARIES = \
-  $(addprefix compilerlibs/,ocamlcommon ocamlbytecomp ocamltoplevel) \
+  $(addprefix compilerlibs/,ocamlcommon-private ocamlbytecomp ocamltoplevel) \
   $(addprefix otherlibs/,str/str unix/unix)
 ocamltex_MODULES = tools/ocamltex
 
@@ -1556,7 +1558,7 @@ endif
 # The native toplevel
 
 ocamlnat_LIBRARIES = \
-  compilerlibs/ocamlcommon compilerlibs/ocamloptcomp \
+  compilerlibs/ocamlcommon-private compilerlibs/ocamloptcomp \
   compilerlibs/ocamlbytecomp otherlibs/dynlink/dynlink \
   compilerlibs/ocamltoplevel
 
@@ -1650,6 +1652,11 @@ distclean: clean
 	rm -rf autom4te.cache flexdll-sources $(BYTE_BUILD_TREE) $(OPT_BUILD_TREE)
 	rm -f config.log config.status libtool
 
+COMPILER_LIBS = ocamlcommon ocamlbytecomp ocamlmiddleend ocamltoplevel
+ifeq "$(NATIVE_COMPILER)" "true"
+COMPILER_LIBS += ocamloptcomp
+endif
+
 # Installation
 .PHONY: install
 install:
@@ -1734,7 +1741,7 @@ ifeq "$(INSTALL_SOURCE_ARTIFACTS)" "true"
 	  "$(INSTALL_LIBDIR_PROFILING)"
 endif
 	$(INSTALL_DATA) \
-	  compilerlibs/*.cma compilerlibs/META \
+	  $(addprefix compilerlibs/, $(COMPILER_LIBS:=.cma)) compilerlibs/META \
 	  "$(INSTALL_COMPLIBDIR)"
 	$(INSTALL_DATA) \
 	   $(ocamlc_MODULES:=.cmo) $(ocaml_MODULES:=.cmo) \
@@ -1890,7 +1897,8 @@ endif
            middle_end/flambda/base_types/*.cmx \
           "$(INSTALL_COMPLIBDIR)"
 	$(INSTALL_DATA) \
-	   compilerlibs/*.cmxa compilerlibs/*.$(A) \
+	   $(addprefix compilerlibs/, $(COMPILER_LIBS:=.cmxa)) \
+	   $(addprefix compilerlibs/, $(COMPILER_LIBS:=.$(A))) \
 	   "$(INSTALL_COMPLIBDIR)"
 	$(INSTALL_DATA) \
 	   $(ocamlc_MODULES:=.cmx) $(ocamlc_MODULES:=.$(O)) \

--- a/Makefile
+++ b/Makefile
@@ -1425,34 +1425,23 @@ tools/ocamldep$(EXE): OC_BYTECODE_LINKFLAGS += -compat-32
 
 # The profiler
 
-ocamlprof_LIBRARIES =
-ocamlprof_MODULES = \
-  config build_path_prefix_map misc identifiable numbers arg_helper \
-  local_store load_path clflags terminfo warnings location longident \
-  docstrings syntaxerr ast_helper camlinternalMenhirLib parser \
-  lexer pprintast parse ocamlprof
+ocamlprof_LIBRARIES = compilerlibs/ocamlcommon-private
+ocamlprof_MODULES = ocamlprof
 
-ocamlcp_ocamloptp_MODULES = \
-  config build_path_prefix_map misc profile warnings identifiable numbers \
-  arg_helper local_store load_path clflags terminfo location ccomp compenv \
-  main_args ocamlcp_common
+ocamlcp_LIBRARIES = compilerlibs/ocamlcommon-private
+ocamlcp_MODULES = ocamlcp_common ocamlcp
 
-ocamlcp_LIBRARIES =
-ocamlcp_MODULES = $(ocamlcp_ocamloptp_MODULES) ocamlcp
-
-ocamloptp_LIBRARIES =
-ocamloptp_MODULES = $(ocamlcp_ocamloptp_MODULES) ocamloptp
+ocamloptp_LIBRARIES = compilerlibs/ocamlcommon-private
+ocamloptp_MODULES = ocamlcp_common ocamloptp
 
 # To help building mixed-mode libraries (OCaml + C)
-ocamlmklib_LIBRARIES =
-ocamlmklib_MODULES = config build_path_prefix_map misc ocamlmklib
+ocamlmklib_LIBRARIES = compilerlibs/ocamlcommon-private
+ocamlmklib_MODULES = ocamlmklib
 
 # To make custom toplevels
 
-ocamlmktop_LIBRARIES =
-ocamlmktop_MODULES = \
-  config build_path_prefix_map misc identifiable numbers arg_helper \
-  local_store load_path clflags profile ccomp ocamlmktop
+ocamlmktop_LIBRARIES = compilerlibs/ocamlcommon-private
+ocamlmktop_MODULES = ocamlmktop
 
 # Reading cmt files
 

--- a/compilerlibs/Makefile.compilerlibs
+++ b/compilerlibs/Makefile.compilerlibs
@@ -428,14 +428,19 @@ $(addprefix compilerlibs/,\
 
 compilerlibs/ocamlcommon.cma: $(COMMON_CMI) $(ALL_CONFIG_CMO) $(COMMON)
 	$(V_LINKC)$(CAMLC) -a -linkall -o $@ $(COMMON)
+compilerlibs/ocamlcommon-private.cma: $(COMMON_CMI) $(ALL_CONFIG_CMO) $(COMMON)
+	$(V_LINKC)$(CAMLC) -a -o $@ $(COMMON)
 partialclean::
-	rm -f compilerlibs/ocamlcommon.cma
+	rm -f compilerlibs/ocamlcommon.cma compilerlibs/ocamlcommon-private.cma
 
 compilerlibs/ocamlcommon.cmxa: $(COMMON_CMI) $(COMMON:.cmo=.cmx)
 	$(V_LINKOPT)$(CAMLOPT) -a -linkall -o $@ $(COMMON:.cmo=.cmx)
+compilerlibs/ocamlcommon-private.cmxa: $(COMMON_CMI) $(COMMON:.cmo=.cmx)
+	$(V_LINKOPT)$(CAMLOPT) -a -o $@ $(COMMON:.cmo=.cmx)
 partialclean::
-	rm -f compilerlibs/ocamlcommon.cmxa \
-	      compilerlibs/ocamlcommon.a compilerlibs/ocamlcommon.lib
+	rm -f compilerlibs/ocamlcommon.cmxa compilerlibs/ocamlcommon-private.cmxa \
+	      compilerlibs/ocamlcommon.a compilerlibs/ocamlcommon.lib \
+	      compilerlibs/ocamlcommon-private.a compilerlibs/ocamlcommon-private.lib
 
 
 compilerlibs/ocamlbytecomp.cma: $(BYTECOMP_CMI) $(BYTECOMP)

--- a/ocamltest/Makefile
+++ b/ocamltest/Makefile
@@ -124,7 +124,7 @@ all: ocamltest$(EXE)
 allopt: ocamltest.opt$(EXE)
 opt.opt: allopt
 
-compdeps_names=ocamlcommon ocamlbytecomp
+compdeps_names=ocamlcommon-private ocamlbytecomp
 compdeps_paths=$(addprefix $(ROOTDIR)/compilerlibs/,$(compdeps_names))
 deps_paths = \
   $(compdeps_paths) $(addprefix $(ocamltest_unix_path)/,$(ocamltest_unix_name))

--- a/testsuite/tools/Makefile
+++ b/testsuite/tools/Makefile
@@ -30,14 +30,14 @@ expect_PROG=$(expect_MAIN)$(EXE)
 expect_DIRS = parsing utils driver typing toplevel
 expect_OCAMLFLAGS = $(addprefix -I $(ROOTDIR)/,$(expect_DIRS))
 expect_LIBS := $(addsuffix .cma,$(addprefix $(COMPILERLIBSDIR)/,\
-  ocamlcommon ocamlbytecomp ocamltoplevel))
+  ocamlcommon-private ocamlbytecomp ocamltoplevel))
 
 codegen_PROG = codegen$(EXE)
 codegen_DIRS = parsing utils typing middle_end bytecomp lambda asmcomp
 codegen_OCAMLFLAGS = $(addprefix -I $(ROOTDIR)/, $(codegen_DIRS)) -w +40 -g
 
 codegen_LIBS = $(addsuffix .cma, $(addprefix $(COMPILERLIBSDIR)/,\
-  ocamlcommon ocamloptcomp))
+  ocamlcommon-private ocamloptcomp))
 
 codegen_CMI_FILES = $(addsuffix .cmi,\
   parsecmmaux parsecmm lexcmm)


### PR DESCRIPTION
`ocamlcommon.cma` sets the `-linkall` flag (see #53) to ensure that _users_ of `ocamlcommon.cma` don't accidentally use modules in an unsound way. Unpicking that, so that `-linkall` is not needed, remains non-trivial.

While working on something else, I had cause to want a version of `ocamlcommon.cma` to use in the build system and another to install. This was a "cheap trick" to ensure that a module would cease to be used in the codebase, but still installed for compatibility, but that's a story for another day. It occurred me that the "trick" of having two versions of `ocamlcommon.cma` would allow us to have a version in the build which doesn't use `-linkall` (trusting ourselves to link the modules correctly) but still install a safe one.

There are two benefits: it allows more of the executables in `tools/` to just link against `ocamlcommon` rather than tediously listing the modules they needed (and requiring these lists to be updated any time the module graph of ocamlcommon is changed) and, more importantly, it reduces the size of `ocamlcmt`, `ocamldep.byte`/`ocamldep.opt` and `ocamlobjinfo.byte`/`ocamlobjinfo.opt` by ~20MiB on my Ubuntu system. This trick seems cleaner than trying to add yet more flags to control `-linkall` (although it'd be nice to do that for the debugger, so that it could just use ocamlbytecomp.cma...).