### PR TITLE
Prevent arbitrary code between large allocations and their initialization

### DIFF
--- a/Changes
+++ b/Changes
@@ -299,6 +299,10 @@ Working version
   `Unix.create_process` (the one used when `posix_spawnp` is unavailable)
   (Xavier Leroy, report by Chris Vine, review by Nicolás Ojeda Bär)
 
+- #12481, #12485: Fix issue with large allocations leaking naked pointers
+  (Vincent Laviron, report by Andrey Popp, review by Xavier Leroy and
+   Gabriel Scherer, with help from KC Sivaramakrishnan)
+
 
 OCaml 5.1.0 release branch
 --------------------------

--- a/asmcomp/cmm_helpers.mli
+++ b/asmcomp/cmm_helpers.mli
@@ -306,8 +306,13 @@ val call_cached_method :
 
 (** Allocations *)
 
-(** Allocate a block of regular values with the given tag *)
-val make_alloc : Debuginfo.t -> int -> expression list -> expression
+(** Allocate a block of regular values with the given tag
+    When [strict_init] is true, the result of the allocation is not allowed
+    to be exposed to the GC before initialization is complete.
+    This is currently used for closures, where the start-of-env field has to be
+    set to its correct value before the block is published. *)
+val make_alloc :
+  strict_init:bool -> Debuginfo.t -> int -> expression list -> expression
 
 (** Allocate a block of unboxed floats with the given tag *)
 val make_float_alloc : Debuginfo.t -> int -> expression list -> expression


### PR DESCRIPTION
This is a potential fix for #12481.
Since #11542, large allocations are allocated using a non-initializing function. The goal of that PR was to prevent the GC from looking at a closure before its start-of-environment field has been read, but the issue is that it didn't prevent the GC from running before the block was initialized completely, ans when it occurs the GC will see naked pointers and fail.
This PR changes the logic around large allocations so that the initializing expressions are guaranteed to be simple, by binding complex expressions and evaluating them before the actual allocation (this is also what happens for small allocations, although the code for that is in `Selectgen`).
The downside of this PR is that it can make a lot of values live around a C call. I've used `bind_load` instead of `bind` to try to mitigate this, as it should cover the cases of duplication of big records (using `{ x with ...}` syntax) and module coercions.

If this approach is accepted I'll update the code with a few comments so that we remember about this issue.