### PR TITLE
Improve error handling in caml_alloc_sprintf

### DIFF
--- a/Changes
+++ b/Changes
@@ -105,6 +105,9 @@ Working version
   (Stephen Dolan, review by Sébastien Hinderer, Vincent Laviron and Xavier
    Leroy)
 
+- #12489: Fix an error-handling bug in caml_alloc_sprintf
+  (Stephen Dolan, report by Chris Casinghino)
+
 ### Code generation and optimizations:
 
 - #11239: on x86-64 and RISC-V, reduce alignment of OCaml stacks from 16 to 8.

--- a/Changes
+++ b/Changes
@@ -106,7 +106,8 @@ Working version
    Leroy)
 
 - #12489: Fix an error-handling bug in caml_alloc_sprintf
-  (Stephen Dolan, report by Chris Casinghino)
+  (Stephen Dolan, report by Chris Casinghino, review by Jeremy Yallop
+   and Xavier Leroy)
 
 ### Code generation and optimizations:
 

--- a/runtime/str.c
+++ b/runtime/str.c
@@ -404,7 +404,9 @@ CAMLexport value caml_alloc_sprintf(const char * format, ...)
      excluding the terminating '\0'. */
   n = vsnprintf(buf, sizeof(buf), format, args);
   va_end(args);
-  if (n < sizeof(buf)) {
+  if (n < 0) {
+    caml_raise_out_of_memory();
+  } else if (n < sizeof(buf)) {
     /* All output characters were written to buf, including the
        terminating '\0'.  Allocate a Caml string with length "n"
        as computed by vsnprintf, and copy the output of vsnprintf into it. */


### PR DESCRIPTION
vsnprintf can fail if passed an absurd length, and we should report this failure rather than segfaulting.

This expression currently segfaults on Linux glibc due to vsnprintf failure, but doesn't after this patch:

```
Printf.sprintf "%.10000000000000f" 0.0;;
```

(I haven't added a test since I don't think there's a portable way of making vsnprintf fail)