### PR TITLE
expose procedure for copying environment

### DIFF
--- a/otherlibs/unix/createprocess.c
+++ b/otherlibs/unix/createprocess.c
@@ -99,6 +99,22 @@ static DWORD do_create_process_native(wchar_t * exefile, wchar_t * cmdline,
   return err;
 }
 
+void caml_win32_copy_env(value env, wchar_t * wenv)
+{
+  if (Is_some(env)) {
+    env = Some_val(env);
+    size =
+      caml_win32_multi_byte_to_wide_char(String_val(env),
+                                         caml_string_length(env), NULL, 0);
+    wenv = caml_stat_alloc((size + 1)*sizeof(wchar_t));
+    caml_win32_multi_byte_to_wide_char(String_val(env),
+                                       caml_string_length(env), wenv, size);
+    wenv[size] = 0;
+  } else {
+    wenv = NULL;
+  }
+}
+
 value caml_unix_create_process_native(value cmd, value cmdline, value env,
                                  value fd1, value fd2, value fd3)
 {
@@ -117,18 +133,7 @@ value caml_unix_create_process_native(value cmd, value cmdline, value env,
   caml_stat_free(wcmd);
   wcmdline = caml_stat_strdup_to_utf16(String_val(cmdline));
 
-  if (Is_some(env)) {
-    env = Some_val(env);
-    size =
-      caml_win32_multi_byte_to_wide_char(String_val(env),
-                                         caml_string_length(env), NULL, 0);
-    wenv = caml_stat_alloc((size + 1)*sizeof(wchar_t));
-    caml_win32_multi_byte_to_wide_char(String_val(env),
-                                       caml_string_length(env), wenv, size);
-    wenv[size] = 0;
-  } else {
-    wenv = NULL;
-  }
+  caml_win32_copy_env(env, wenv);
 
   err =
     do_create_process_native(exefile, wcmdline, wenv, Handle_val(fd1),

--- a/otherlibs/unix/unixsupport.h
+++ b/otherlibs/unix/unixsupport.h
@@ -93,6 +93,8 @@ extern void caml_win32_maperr(DWORD errcode);
  */
 #define CAML_NT_EPOCH_100ns_TICKS 116444736000000000ULL
 
+void caml_win32_copy_env(value env, wchar_t * wenv)
+
 #endif /* _WIN32 */
 
 #define Nothing ((value) 0)


### PR DESCRIPTION
Context: This PR is for exposing a part of a function which is potentially useful for other libraries. Specifically, a bit of code that helps set the correct environment which would be useful for Lwt.

See https://github.com/ocsigen/lwt/pull/967

Is this the right way to go around? I.e., is the PR acceptable on principle?  
Are there details that need amending? Names and the like?

Another question is what to do for older versions of OCaml? Libraries that would use this newly extracted function can do so starting at whatever release of OCaml this PR is merged for, but that is quite restrictive. Any idea about that?

Ping @MisterDA