### PR TITLE
Bigarray: do not change GC pace when creating subarrays or slices

### DIFF
--- a/Changes
+++ b/Changes
@@ -302,6 +302,9 @@ Working version
   `Unix.create_process` (the one used when `posix_spawnp` is unavailable)
   (Xavier Leroy, report by Chris Vine, review by Nicolás Ojeda Bär)
 
+- #12491: allocating subarrays or slices of bigarrays increases
+  GC speed wrongly -- as if new memory was allocated
+  (Gabriel Scherer, report by Ido Yariv, review by ???)
 
 OCaml 5.1.0 release branch
 --------------------------

--- a/runtime/bigarray.c
+++ b/runtime/bigarray.c
@@ -225,7 +225,7 @@ CAMLexport value
 caml_ba_alloc(int flags, int num_dims, void * data, intnat * dim)
 {
   uintnat num_elts, asize, size;
-  int i, is_managed;
+  int i, must_alloc;
   value res;
   struct caml_ba_array * b;
   intnat dimcopy[CAML_BA_MAX_NUM_DIMS];
@@ -242,14 +242,14 @@ caml_ba_alloc(int flags, int num_dims, void * data, intnat * dim)
                          caml_ba_element_size[flags & CAML_BA_KIND_MASK],
                          &size))
     caml_raise_out_of_memory();
-  if (data == NULL) {
+  must_alloc = (data == NULL);
+  if (must_alloc) {
     data = malloc(size);
     if (data == NULL && size != 0) caml_raise_out_of_memory();
     flags |= CAML_BA_MANAGED;
   }
   asize = SIZEOF_BA_ARRAY + num_dims * sizeof(intnat);
-  is_managed = ((flags & CAML_BA_MANAGED_MASK) == CAML_BA_MANAGED);
-  res = caml_alloc_custom_mem(&caml_ba_ops, asize, is_managed ? size : 0);
+  res = caml_alloc_custom_mem(&caml_ba_ops, asize, must_alloc ? size : 0);
   b = Caml_ba_array_val(res);
   b->data = data;
   b->num_dims = num_dims;


### PR DESCRIPTION
This is a proposed fix for #12491.

## The issue

When creating bigarrays, we increase the GC pacing in a way that should be proportional to the amount of "external" memory held by the bigarray. The bug in #12491 is that creating proxies (copies, slices) of an existing bigarray increases the GC speed as if new external memory was allocated, which is unnecessary (and hurts performance) as the proxy reuses memory from an existing bigarray.

## The fix (details)

Before this PR, the logic was as follows:

- `caml_ba_alloc` takes `flags` as input and `data`
- if `data` is NULL, malloc some memory for the bigarray and add the `MANAGED` flag to `flags`
- if `flags` has MANAGED, increase GC pacing on bigarray creation

After this PR, the logic is as follows:

- if `data` is NULL, set a `must_alloc` boolean
- if `must_alloc`, malloc some memory
- if `must_alloc`, increase GC pacing on bigarray creation

The only change in behavior corresponds to calls that initially have the `MANAGED` flag in `flags`, but a non-null `data` field. Those would increase the GC pacing before the PR, and they do not increase it after the PR.

This exactly covers the case of slices of subarrays, but also possibly some other cases of `caml_ba_alloc` calls in user code.
I believe that the change is correct (a bugfix) in all these cases: if the caller of `caml_ba_alloc` passes existing memory and, at the same time, claims that this memory is owned by the OCaml heap, then we should not increase the GC pacing.