### PR TITLE
Fix "Open shadowing warning mistriggers"

### DIFF
--- a/Changes
+++ b/Changes
@@ -328,6 +328,8 @@ Working version
   `Unix.create_process` (the one used when `posix_spawnp` is unavailable)
   (Xavier Leroy, report by Chris Vine, review by Nicolás Ojeda Bär)
 
+- #12949: open shadowing mistriggers
+  (Gabriel Scherer, review by Florian Angeletti, report by Andreas Rossberg)
 
 OCaml 5.1.0
 ---------------

--- a/testsuite/tests/warnings/w44.ml
+++ b/testsuite/tests/warnings/w44.ml
@@ -29,11 +29,6 @@ val g : (unit -> 'a) -> int = <fun>
 *)
 let f () = M.(f ());;
 [%%expect {|
-Line 1, characters 11-12:
-1 | let f () = M.(f ());;
-               ^
-Warning 44 [open-shadow-identifier]: this open statement shadows the value identifier f (which is later used)
-
 val f : unit -> int = <fun>
 |}]
 
@@ -66,10 +61,5 @@ class c = object
 end;;
 [%%expect {|
 module M : sig val x : int end
-Line 5, characters 10-11:
-5 |   val y = M.( x ) + 1
-              ^
-Warning 44 [open-shadow-identifier]: this open statement shadows the value identifier x (which is later used)
-
 class c : object val x : int val y : int end
 |}]

--- a/testsuite/tests/warnings/w44.ml
+++ b/testsuite/tests/warnings/w44.ml
@@ -1,0 +1,75 @@
+(* TEST
+ flags = "-w +A";
+ expect;
+*)
+
+
+module M = struct let f () = 1 end;;
+[%%expect {|
+module M : sig val f : unit -> int end
+|}]
+
+let g f = f (); M.(f ());;
+[%%expect {|
+Line 1, characters 16-17:
+1 | let g f = f (); M.(f ());;
+                    ^
+Warning 44 [open-shadow-identifier]: this open statement shadows the value identifier f (which is later used)
+
+val g : (unit -> 'a) -> int = <fun>
+|}]
+
+(* regression test for #12494
+
+   When checking 'let f ...' functions, the type-checker sometimes
+   inserts a dummy 'unbound' variable 'f' in the environment to detect
+   failed lookups on 'f' in the definition and hint at a missing 'rec'
+   keyword. Ensure that those dummy bindings do not result in
+   shadowing warnings.
+*)
+let f () = M.(f ());;
+[%%expect {|
+Line 1, characters 11-12:
+1 | let f () = M.(f ());;
+               ^
+Warning 44 [open-shadow-identifier]: this open statement shadows the value identifier f (which is later used)
+
+val f : unit -> int = <fun>
+|}]
+
+(* Advanced behaviors related to #12494: in classes.
+
+   (See the discussion in #12498 for a weird related example by Florian
+    Angeletti using modules that is arguably not completely fixed by
+    #12498.)
+
+ *)
+
+(* this is expected *)
+class c = object
+  val x = 0
+  val y = x + 1
+end;;
+[%%expect {|
+Line 3, characters 10-11:
+3 |   val y = x + 1
+              ^
+Error: The instance variable "x"
+       cannot be accessed from the definition of another instance variable
+|}]
+
+module M = struct let x = 0 end
+class c = object
+  val x=0
+  (* ... so there is no shadowing here *)
+  val y = M.( x ) + 1
+end;;
+[%%expect {|
+module M : sig val x : int end
+Line 5, characters 10-11:
+5 |   val y = M.( x ) + 1
+              ^
+Warning 44 [open-shadow-identifier]: this open statement shadows the value identifier x (which is later used)
+
+class c : object val x : int val y : int end
+|}]

--- a/typing/env.ml
+++ b/typing/env.ml
@@ -694,9 +694,12 @@ let check_shadowing env = function
   | `Label (Some (l1, l2))
     when not (!same_constr env l1.lbl_res l2.lbl_res) ->
       Some "label"
-  | `Value (Some _) -> Some "value"
+  | `Value (Some (Val_unbound _, _)) -> None
+  | `Value (Some (_, _)) -> Some "value"
   | `Type (Some _) -> Some "type"
-  | `Module (Some _) | `Component (Some _) -> Some "module"
+  | `Module (Some (Mod_unbound _, _)) -> None
+  | `Module (Some _) | `Component (Some _) ->
+      Some "module"
   | `Module_type (Some _) -> Some "module type"
   | `Class (Some _) -> Some "class"
   | `Class_type (Some _) -> Some "class type"


### PR DESCRIPTION
This is a fix for #12494. The first commit introduces a testcase (exhibiting the bug), the second commit fixes the bug and updates the testcase -- its commit message has more details on why the fix is correct.