### PR TITLE
Bigarray: do not change GC pace when creating sub-arrays

### DIFF
--- a/Changes
+++ b/Changes
@@ -302,6 +302,9 @@ Working version
   `Unix.create_process` (the one used when `posix_spawnp` is unavailable)
   (Xavier Leroy, report by Chris Vine, review by Nicolás Ojeda Bär)
 
+- #12491, #12500: allocating subarrays or slices of bigarrays increases
+  GC speed wrongly -- as if new memory was allocated
+  (Gabriel Scherer, report by Ido Yariv, review by ???)
 
 OCaml 5.1.0 release branch
 --------------------------


### PR DESCRIPTION
This is another attempt to fix #12491 (the first attempt #12493 did not convince me).

This PR introduces a new bigarray-creation function

```
static value caml_ba_inherit(value vb, int num_dims, intnat * dim)
```

that creates a sub-array: a new OCaml bigarray that shares its data with a previous OCaml bigarray -- and does not increase the pace of the GC / correctly accounts for external memory usage.

The behavior of `caml_ba_alloc` is unchanged.

This `caml_ba_inherit` function could be exported to users, it could be useful if they want to define their own bigarray-reusing function, but this is not done in this PR -- it is only visible inside bigarray.c, for data-reusing functions exposed in the stdlib.

I checked that the reproduction case of #12491 terminates immediately with this PR.

## PR structure / review tips

This PR is best reviewed commit by commit.

The first two commits are refactoring commits that should keep the behavior unchanged:
- the first commit factors out the overflow-resilient size computation,
  to make bigarray-creating functions easier to follow
- the second introduces the `caml_ba_inherit` helper and uses it
  (at this point the GC accounting is still wrong)

The last commit fixes the bug by introducing a `caml_ba_alloc_gen` function that takes an extra parameter `owns_data`, that indicates whether the external memory should be credited to the OCaml heap, and using it in `caml_ba_inherit`.

