### PR TITLE
Release of large allocs for "memory cleanup at exit"

### DIFF
--- a/runtime/caml/shared_heap.h
+++ b/runtime/caml/shared_heap.h
@@ -96,7 +96,7 @@ void caml_cycle_heap(struct caml_heap_state*);
 /* caml_verify_heap must only be called while all domains are paused */
 void caml_verify_heap(caml_domain_state *domain);
 
-void caml_finalise_freelist(void);
+void caml_destroy_freelist(void);
 
 #ifdef DEBUG
 /* [is_garbage(v)] returns true if [v] is a garbage value */

--- a/runtime/caml/shared_heap.h
+++ b/runtime/caml/shared_heap.h
@@ -96,6 +96,8 @@ void caml_cycle_heap(struct caml_heap_state*);
 /* caml_verify_heap must only be called while all domains are paused */
 void caml_verify_heap(caml_domain_state *domain);
 
+void caml_finalise_freelist(void);
+
 #ifdef DEBUG
 /* [is_garbage(v)] returns true if [v] is a garbage value */
 int is_garbage (value);

--- a/runtime/caml/shared_heap.h
+++ b/runtime/caml/shared_heap.h
@@ -96,7 +96,7 @@ void caml_cycle_heap(struct caml_heap_state*);
 /* caml_verify_heap must only be called while all domains are paused */
 void caml_verify_heap(caml_domain_state *domain);
 
-void caml_destroy_freelist(void);
+void caml_release_freelist(void);
 
 #ifdef DEBUG
 /* [is_garbage(v)] returns true if [v] is a garbage value */

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -1569,5 +1569,5 @@ void caml_finalise_heap (void)
   caml_domain_state* d = Caml_state;
   caml_finish_sweeping();
   caml_teardown_shared_heap(d->shared_heap);
-  caml_finalise_freelist();
+  caml_destroy_freelist();
 }

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -1566,5 +1566,8 @@ void caml_teardown_major_gc(void) {
 
 void caml_finalise_heap (void)
 {
-  return;
+  caml_domain_state* d = Caml_state;
+  caml_finish_sweeping();
+  caml_teardown_shared_heap(d->shared_heap);
+  caml_finalise_freelist();
 }

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -1569,5 +1569,5 @@ void caml_finalise_heap (void)
   caml_domain_state* d = Caml_state;
   caml_finish_sweeping();
   caml_teardown_shared_heap(d->shared_heap);
-  caml_destroy_freelist();
+  caml_release_freelist();
 }

--- a/runtime/shared_heap.c
+++ b/runtime/shared_heap.c
@@ -927,8 +927,8 @@ void caml_cycle_heap(struct caml_heap_state* local) {
   local->next_to_sweep = 0;
 }
 
-void caml_finalise_freelist (void) {
-  int freed = 0, freed_large = 0;
+void caml_destroy_freelist (void) {
+  int freed_large = 0;
   caml_plat_lock(&pool_freelist.lock);
   while (pool_freelist.global_large) {
     large_alloc* a = pool_freelist.global_large;
@@ -937,6 +937,5 @@ void caml_finalise_freelist (void) {
     freed_large++;
   }
   caml_plat_unlock(&pool_freelist.lock);
-  caml_gc_log("Finalise freelist. Freed %d active pools, %d large",
-	       freed, freed_large);
+  caml_gc_log("Finalise freelist. Freed %d large", freed_large);
 }

--- a/runtime/shared_heap.c
+++ b/runtime/shared_heap.c
@@ -926,3 +926,17 @@ void caml_cycle_heap(struct caml_heap_state* local) {
 
   local->next_to_sweep = 0;
 }
+
+void caml_finalise_freelist (void) {
+  int freed = 0, freed_large = 0;
+  caml_plat_lock(&pool_freelist.lock);
+  while (pool_freelist.global_large) {
+    large_alloc* a = pool_freelist.global_large;
+    pool_freelist.global_large = a->next;
+    free(a);
+    freed_large++;
+  }
+  caml_plat_unlock(&pool_freelist.lock);
+  caml_gc_log("Finalise freelist. Freed %d active pools, %d large",
+	       freed, freed_large);
+}

--- a/runtime/shared_heap.c
+++ b/runtime/shared_heap.c
@@ -927,7 +927,7 @@ void caml_cycle_heap(struct caml_heap_state* local) {
   local->next_to_sweep = 0;
 }
 
-void caml_destroy_freelist (void) {
+void caml_release_freelist (void) {
   int freed_large = 0;
   caml_plat_lock(&pool_freelist.lock);
   while (pool_freelist.global_large) {


### PR DESCRIPTION
This is the first naïve attempt at resolving #10865. I do not expect it to be acceptable as is. Instead, I would like to gather some feedback from experts and hopefully arrive at a proper solution. This PR aims to handle `The malloc-ed memory for free list pools and for large objects needs to be freed.` in https://github.com/ocaml/ocaml/issues/10865#issuecomment-1014310831

I put the release of `large_alloc` in `caml_finalise_heap`, which is part of `caml_shutdown` and seems to be a correct place for this. Following https://github.com/ocaml/ocaml/issues/10865#issuecomment-1016617223, I assume that only the main domain exists at this point. 
I start by calling `caml_finish_sweeping` to ensure that what I do next does not interfere with any ongoing GC activity. Then, I call `caml_teardown_shared_heap` in order to move the large allocs and the pools from the heap to `pool_freelist`. Finally, I go through the freelist and free the large allocs (and I think, the same should be done with `pools`).

FWIW, this code passes the current OCaml testsuite.
