### PR TITLE
chore: add .vscode/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ _ocamltestd
 .merlin
 _build
 META
+.vscode
 
 # local to root directory
 


### PR DESCRIPTION
This directory should be hidden from git as it is created by vscode when any local configuration is done. This will save vscode users from having to cleanup all the time.