### PR TITLE
Initialize the block allocated by `caml_alloc_shr_check_gc`

### DIFF
--- a/Changes
+++ b/Changes
@@ -888,6 +888,12 @@ Some of those changes will benefit all OCaml packages.
 - #12445: missing GC root registrations in runtime/io.c
   (Gabriel Scherer, review by Xavier Leroy and Jeremy Yallop)
 
+- #12481, #12505: Fix incorrect initialization of array expressions
+  `[|e1;...;eN|]` when `N` is large enough to require major heap allocation.
+  (Xavier Leroy, report by Andrey Popp, analysis by KC Sivaramakrishnan
+   and Vincent Laviron, review by Gabriel Scherer)
+
+
 OCaml 5.0.0 (15 December 2022)
 ------------------------------
 

--- a/asmcomp/cmmgen.ml
+++ b/asmcomp/cmmgen.ml
@@ -402,6 +402,13 @@ let rec transl env e =
         | [] -> Debuginfo.none
         | fundecl::_ -> fundecl.dbg
       in
+      (* #11482, #12481: the 'clos_vars' may be arbitrary expressions
+         and may invoke the GC, which would be able to observe the
+         partially-filled block. This is safe because 'make_alloc'
+         evaluates and fills fields from left to right, and does not
+         call a GC between the allocation and filling fields. So the
+         closure metadata, which comes before the closure variables,
+         will always have been written before a GC can happen. *)
       make_alloc dbg Obj.closure_tag (transl_fundecls 0 fundecls)
   | Uoffset(arg, offset) ->
       (* produces a valid Caml value, pointing just after an infix header *)


### PR DESCRIPTION
This is the quick fix for issue #12481 mentioned in https://github.com/ocaml/ocaml/issues/12481#issuecomment-1682627736 .  I think it's appropriate as an emergency fix for the 5.1 release, even though we may want to consider #12485 or other approaches later.

Fixes: #12481
