### PR TITLE
Allow to name closed types in constructor type annotations

### DIFF
--- a/Changes
+++ b/Changes
@@ -121,6 +121,9 @@ OCaml 5.2.0
   is given. This allows to work around problems with GADTs in as-patterns.
   (Jacques Garrigue, report by Leo White, review by Gabriel Scherer)
 
+- #11891, #12507: Allow to name closed types in constructor type annotations.
+  (Jacques Garrigue, report and review by Gabriel Scherer)
+
 ### Runtime system:
 
 - #12193: Re-introduce GC compaction for shared pools

--- a/Changes
+++ b/Changes
@@ -121,7 +121,8 @@ OCaml 5.2.0
   is given. This allows to work around problems with GADTs in as-patterns.
   (Jacques Garrigue, report by Leo White, review by Gabriel Scherer)
 
-- #11891, #12507: Allow to name closed types in constructor type annotations.
+- #11891, #12507: Allow to name new locally abstract types in constructor type
+  annotations.
   (Jacques Garrigue, report and review by Gabriel Scherer and Florian Angeletti)
 
 ### Runtime system:

--- a/Changes
+++ b/Changes
@@ -122,7 +122,7 @@ OCaml 5.2.0
   (Jacques Garrigue, report by Leo White, review by Gabriel Scherer)
 
 - #11891, #12507: Allow to name closed types in constructor type annotations.
-  (Jacques Garrigue, report and review by Gabriel Scherer)
+  (Jacques Garrigue, report and review by Gabriel Scherer and Florian Angeletti)
 
 ### Runtime system:
 

--- a/manual/src/tutorials/gadtexamples.etex
+++ b/manual/src/tutorials/gadtexamples.etex
@@ -276,9 +276,9 @@ All existential type variables of the constructor must be introduced by
 the ("type" ...) construct and bound by a type annotation on the
 outside of the constructor argument.
 
-One can additionally bind closed types that appear in the type of the
-arguments. This is particularly useful if they were freshly introduced
-by the refinement of another existential type.
+One can additionally bind existentials that were freshly introduced
+by the refinement of another existential type, if they appear in the
+type of the arguments.
 \begin{caml_example*}{verbatim}
 type _ ty =
   | Int : int ty

--- a/manual/src/tutorials/gadtexamples.etex
+++ b/manual/src/tutorials/gadtexamples.etex
@@ -272,7 +272,7 @@ explicitly. For instance, the following code names the type of the argument of
 type _ closure = Closure : ('a -> 'b) * 'a -> 'b closure
 let eval = fun (Closure (type a) (f, x : (a -> _) * _)) -> f (x : a)
 \end{caml_example*}
-All existential type variables of the constructor must by introduced by
+All existential type variables of the constructor must be introduced by
 the ("type" ...) construct and bound by a type annotation on the
 outside of the constructor argument.
 

--- a/manual/src/tutorials/gadtexamples.etex
+++ b/manual/src/tutorials/gadtexamples.etex
@@ -249,7 +249,7 @@ variable "'a" during typing:
 type ('arg,'result,'aux) fn =
   | Fun: ('a ->'b) -> ('a,'b,unit) fn
   | Mem1: ('a ->'b) * 'a * 'b -> ('a, 'b, 'a * 'b) fn
- let apply: ('arg,'result, _ ) fn -> 'arg -> 'result = fun f x ->
+let apply: ('arg,'result, _ ) fn -> 'arg -> 'result = fun f x ->
   match f with
   | Fun f -> f x
   | Mem1 (f,y,fy) -> if x = y then fy else f x
@@ -275,6 +275,19 @@ let eval = fun (Closure (type a) (f, x : (a -> _) * _)) -> f (x : a)
 All existential type variables of the constructor must by introduced by
 the ("type" ...) construct and bound by a type annotation on the
 outside of the constructor argument.
+
+One can additionally bind closed types that appear in the types of the
+arguments. This is particularly useful if they were freshly introduced
+by the refinement of another existential type.
+\begin{caml_example*}{verbatim}
+type _ ty =
+  | Int : int ty
+  | Pair : 'b ty * 'c ty -> ('b * 'c) ty
+let rec default : type a. a ty -> a = function
+  | Int -> 0
+  | Pair (type b c) (b, c : b ty * c ty) ->
+      (default b : b), (default c : c)
+\end{caml_example*}
 
 \section{s:gadt-equation-nonlocal-abstract}{Equations on non-local abstract types}
 

--- a/manual/src/tutorials/gadtexamples.etex
+++ b/manual/src/tutorials/gadtexamples.etex
@@ -276,7 +276,7 @@ All existential type variables of the constructor must by introduced by
 the ("type" ...) construct and bound by a type annotation on the
 outside of the constructor argument.
 
-One can additionally bind closed types that appear in the types of the
+One can additionally bind closed types that appear in the type of the
 arguments. This is particularly useful if they were freshly introduced
 by the refinement of another existential type.
 \begin{caml_example*}{verbatim}

--- a/testsuite/tests/typing-gadts/name_existentials.ml
+++ b/testsuite/tests/typing-gadts/name_existentials.ml
@@ -141,6 +141,17 @@ val example : 'a ty -> 'a = <fun>
 val example : 'a ty -> 'a = <fun>
 |}]
 
+let rec example : type a . a ty -> a = function
+| Int -> 0
+| Pair (type b c) (x, y : b ty * c ty) -> (example x, example (*error*)x)
+[%%expect{|
+Line 3, characters 54-72:
+3 | | Pair (type b c) (x, y : b ty * c ty) -> (example x, example (*error*)x)
+                                                          ^^^^^^^^^^^^^^^^^^
+Error: This expression has type "b" = "$0" but an expression was expected of type
+         "$1"
+|}]
+
 type _ th =
   | Thunk : 'a * ('a -> 'b) -> 'b th
 let f1 (type a) : a th -> a = function

--- a/testsuite/tests/typing-gadts/name_existentials.ml
+++ b/testsuite/tests/typing-gadts/name_existentials.ml
@@ -122,6 +122,21 @@ val f : (int, int) pair -> int = <fun>
 (* #11891: allow naming more types *)
 (* We stillonly allow to name freshly introduced existentials *)
 
+type _ ty =
+  | Int : int ty
+  | Pair : 'b ty * 'c ty -> ('b * 'c) ty
+let rec example : type a . a ty -> a = function
+| Int -> 0
+| Pair (x, y) -> (example x, example y)
+let rec example : type a . a ty -> a = function
+| Int -> 0
+| Pair (type b c) (x, y : b ty * c ty) -> (example x, example y)
+[%%expect{|
+type _ ty = Int : int ty | Pair : 'b ty * 'c ty -> ('b * 'c) ty
+val example : 'a ty -> 'a = <fun>
+val example : 'a ty -> 'a = <fun>
+|}]
+
 type _ th =
   | Thunk : 'a * ('a -> 'b) -> 'b th
 let f1 (type a) : a th -> a = function
@@ -177,21 +192,6 @@ let f3 (type a) : a tho -> a = function
 [%%expect{|
 type _ tho = Thunk_opt : 'b * ('b -> 'c option) -> 'c option tho
 val f3 : 'a tho -> 'a = <fun>
-|}]
-
-type _ ty =
-  | Int : int ty
-  | Pair : 'b ty * 'c ty -> ('b * 'c) ty
-let rec example : type a . a ty -> a = function
-| Int -> 0
-| Pair (x, y) -> (example x, example y)
-let rec example : type a . a ty -> a = function
-| Int -> 0
-| Pair (type b c) (x, y : b ty * c ty) -> (example x, example y)
-[%%expect{|
-type _ ty = Int : int ty | Pair : 'b ty * 'c ty -> ('b * 'c) ty
-val example : 'a ty -> 'a = <fun>
-val example : 'a ty -> 'a = <fun>
 |}]
 
 

--- a/testsuite/tests/typing-gadts/name_existentials.ml
+++ b/testsuite/tests/typing-gadts/name_existentials.ml
@@ -32,10 +32,10 @@ Line 1, characters 40-41:
 Error: This type does not bind all existentials in the constructor:
          "type a. 'a ty * 'a"
 |}]
-let ok3 = function Dyn (type a b) (a, x : a ty * b) -> ignore (x : b)
+let ko2 = function Dyn (type a b) (a, x : a ty * b) -> ignore (x : b)
 [%%expect{|
 Line 1, characters 42-50:
-1 | let ok3 = function Dyn (type a b) (a, x : a ty * b) -> ignore (x : b)
+1 | let ko2 = function Dyn (type a b) (a, x : a ty * b) -> ignore (x : b)
                                               ^^^^^^^^
 Error: This type annotation attempts to bind "b"
        to the already bound existential "a".

--- a/testsuite/tests/typing-gadts/name_existentials.ml
+++ b/testsuite/tests/typing-gadts/name_existentials.ml
@@ -79,7 +79,7 @@ let rec test : type a. a expr -> a = function
 Line 2, characters 22-23:
 2 |   | Int (type b) (n : a) -> n
                           ^
-Error: This type does not bind all existentials in the constructor: "type b. a"
+Error: This type annotation attempts to bind b to the non-closed type 'a.
 |}]
 
 (* Strange wildcard *)
@@ -149,6 +149,16 @@ Error: This pattern matches values of type "b * (b -> 'a)"
        but a pattern was expected which matches values of type "b * (b -> 'b)"
        This instance of "'a" is ambiguous:
        it would escape the scope of its equation
+|}]
+let ko3 () =
+  match [] with
+  | [Thunk (type b c) (x, f : b * (b -> c))] -> f x
+  | _ -> assert false
+[%%expect{|
+Line 3, characters 30-42:
+3 |   | [Thunk (type b c) (x, f : b * (b -> c))] -> f x
+                                  ^^^^^^^^^^^^
+Error: This type annotation attempts to bind c to the non-closed type 'a.
 |}]
 
 type _ tho =

--- a/testsuite/tests/typing-gadts/name_existentials.ml
+++ b/testsuite/tests/typing-gadts/name_existentials.ml
@@ -37,8 +37,10 @@ let ko2 = function Dyn (type a b) (a, x : a ty * b) -> ignore (x : b)
 Line 1, characters 42-50:
 1 | let ko2 = function Dyn (type a b) (a, x : a ty * b) -> ignore (x : b)
                                               ^^^^^^^^
-Error: This type annotation attempts to bind "b"
-       to the already bound existential "a".
+Error: The local name "b" can only be given to an existential variable
+       introduced by this GADT constructor.
+       The type annotation tries to bind it to the name "a"
+       that is already bound.
 |}]
 
 type u = C : 'a * ('a -> 'b list) -> u
@@ -83,8 +85,10 @@ let rec test : type a. a expr -> a = function
 Line 2, characters 22-23:
 2 |   | Int (type b) (n : a) -> n
                           ^
-Error: This type annotation attempts to bind "b"
-       to the non-locally-abstract type "'a".
+Error: The local name "b" can only be given to an existential variable
+       introduced by this GADT constructor.
+       The type annotation tries to bind it to the type "'a"
+       that is not a locally abstract type.
 |}]
 
 (* Strange wildcard *)
@@ -149,8 +153,10 @@ val f1 : 'a th -> 'a = <fun>
 Line 6, characters 29-41:
 6 |   | Thunk (type b c) (x, f : b * (b -> c)) -> f x
                                  ^^^^^^^^^^^^
-Error: This type annotation attempts to bind "c"
-       to the non-locally-abstract type "a".
+Error: The local name "c" can only be given to an existential variable
+       introduced by this GADT constructor.
+       The type annotation tries to bind it to the name "a"
+       that was defined before.
 |}]
 (* Do not allow to deduce extra assumptions *)
 let ko1 (type a) : a th -> a = function
@@ -170,8 +176,10 @@ let ko2 = function
 Line 2, characters 29-41:
 2 |   | Thunk (type b c) (x, f : b * (b -> c)) -> f x
                                  ^^^^^^^^^^^^
-Error: This type annotation attempts to bind "c"
-       to the non-locally-abstract type "'a".
+Error: The local name "c" can only be given to an existential variable
+       introduced by this GADT constructor.
+       The type annotation tries to bind it to the type "'a"
+       that is not a locally abstract type.
 |}]
 let ko3 () =
   match [] with
@@ -181,8 +189,10 @@ let ko3 () =
 Line 3, characters 30-42:
 3 |   | [Thunk (type b c) (x, f : b * (b -> c))] -> f x
                                   ^^^^^^^^^^^^
-Error: This type annotation attempts to bind "c"
-       to the non-locally-abstract type "'a".
+Error: The local name "c" can only be given to an existential variable
+       introduced by this GADT constructor.
+       The type annotation tries to bind it to the type "'a"
+       that is not a locally abstract type.
 |}]
 
 type _ tho =
@@ -217,6 +227,8 @@ let rec default : type a. a ty -> a = function
 Line 3, characters 34-45:
 3 |   | Pair (Wrap (type b c) (b, c : b ty * c ty)) ->
                                       ^^^^^^^^^^^
-Error: This type annotation attempts to bind "b"
-       to the previously defined existential "$0".
+Error: The local name "b" can only be given to an existential variable
+       introduced by this GADT constructor.
+       The type annotation tries to bind it to the name "$0"
+       that was defined before.
 |}]

--- a/testsuite/tests/typing-gadts/name_existentials.ml
+++ b/testsuite/tests/typing-gadts/name_existentials.ml
@@ -128,7 +128,7 @@ val f1 : 'a th -> 'a = <fun>
 val f2 : 'a th -> 'a = <fun>
 |}]
 (* Do not allow to deduce extra assumptions *)
-let ko (type a) : a th -> a = function
+let ko1 (type a) : a th -> a = function
   | Thunk (type b c) (x, f : b * (b -> c option)) -> f x
 [%%expect{|
 Line 2, characters 29-48:
@@ -137,6 +137,18 @@ Line 2, characters 29-48:
 Error: This pattern matches values of type "b * (b -> c option)"
        but a pattern was expected which matches values of type "b * (b -> a)"
        Type "c option" is not compatible with type "a"
+|}]
+(* Can only name closed types *)
+let ko2 = function
+  | Thunk (type b c) (x, f : b * (b -> c)) -> f x
+[%%expect{|
+Line 2, characters 29-41:
+2 |   | Thunk (type b c) (x, f : b * (b -> c)) -> f x
+                                 ^^^^^^^^^^^^
+Error: This pattern matches values of type "b * (b -> 'a)"
+       but a pattern was expected which matches values of type "b * (b -> 'b)"
+       This instance of "'a" is ambiguous:
+       it would escape the scope of its equation
 |}]
 
 type _ tho =

--- a/testsuite/tests/typing-gadts/name_existentials.ml
+++ b/testsuite/tests/typing-gadts/name_existentials.ml
@@ -155,10 +155,8 @@ let ko2 = function
 Line 2, characters 29-41:
 2 |   | Thunk (type b c) (x, f : b * (b -> c)) -> f x
                                  ^^^^^^^^^^^^
-Error: This pattern matches values of type "b * (b -> 'a)"
-       but a pattern was expected which matches values of type "b * (b -> 'b)"
-       This instance of "'a" is ambiguous:
-       it would escape the scope of its equation
+Error: This type annotation attempts to bind "c"
+       to the non-locally-abstract type "'a".
 |}]
 let ko3 () =
   match [] with

--- a/typing/ident.ml
+++ b/typing/ident.ml
@@ -111,6 +111,9 @@ let stamp = function
   | Scoped { stamp; _ } -> stamp
   | _ -> 0
 
+let compare_stamp id1 id2 =
+  compare (stamp id1) (stamp id2)
+
 let scope = function
   | Scoped { scope; _ } -> scope
   | Local _ -> highest_scope

--- a/typing/ident.mli
+++ b/typing/ident.mli
@@ -50,7 +50,11 @@ val same: t -> t -> bool
             [create_*], or if they are both persistent and have the same
             name. *)
 
+val compare_stamp: t -> t -> int
+        (** Compare only the internal stamps, 0 if absent *)
+
 val compare: t -> t -> int
+        (** Compare identifiers structurally, including the name *)
 
 val global: t -> bool
 val is_predef: t -> bool

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -834,9 +834,8 @@ let solve_constructor_annotation
               if List.exists (Ident.same id') !bound_ids then
                 raise (Error (cty.ctyp_loc, !!penv,
                               Bind_existential (Bind_already_bound, id, tv')));
-              (* Both id and id' are Scoped identifiers, so Ident.compare
-                 will only compare their stamps *)
-              if Ident.compare id id' > 0 then
+              (* Both id and id' are Scoped identifiers, so their stamps grow *)
+              if Ident.compare_stamp id id' > 0 then
                 raise (Error (cty.ctyp_loc, !!penv,
                               Bind_existential (Bind_not_in_scope, id, tv')));
               bound_ids := id' :: !bound_ids

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -805,6 +805,9 @@ let solve_constructor_annotation
                   {decl with type_manifest = None} !!penv
               in
               Pattern_env.set_env penv env;
+              (* We have changed the definition, so clean up *)
+              Btype.cleanup_abbrev ();
+              (* Since id is now abstract, this does not create a cycle *)
               unify_pat_types cty.ctyp_loc env tv tv';
               list_remove id rem
           | _ ->
@@ -825,6 +828,7 @@ let solve_constructor_annotation
         in
         Pattern_env.set_env penv env)
       rem;
+    if rem <> [] then Btype.cleanup_abbrev ();
   end;
   ty_args, Some (ids, cty)
 

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -827,12 +827,15 @@ let solve_constructor_annotation
     List.iter
       (fun id ->
         let decl, tv' = get_decl_manifest id !!penv in
+        let tv' = expand_head !!penv tv' in
         begin match get_desc tv' with
         | Tconstr (Path.Pident id', [], _) when
             Ident.scope id' = penv.equations_scope ->
               if List.exists (Ident.same id') !bound_ids then
                 raise (Error (cty.ctyp_loc, !!penv,
                               Bind_existential (Bind_already_bound, id, tv')));
+              (* Both id and id' are Scoped identifiers, so Ident.compare
+                 will only compare their stamps *)
               if Ident.compare id id' > 0 then
                 raise (Error (cty.ctyp_loc, !!penv,
                               Bind_existential (Bind_not_in_scope, id, tv')));

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -762,7 +762,7 @@ let solve_constructor_annotation
       (fun name ->
         let decl =
           new_local_type ~loc:name.loc Definition
-            ~manifest_and_scope:(newvar (),expansion_scope) in
+            ~manifest_and_scope:(newvar (),Ident.lowest_scope) in
         let (id, new_env) =
           Env.enter_type ~scope:expansion_scope name.txt decl !!penv in
         Pattern_env.set_env penv new_env;

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -833,7 +833,7 @@ let solve_constructor_annotation
               if List.exists (Ident.same id') !bound_ids then
                 raise (Error (cty.ctyp_loc, !!penv,
                               Bind_existential (Bind_already_bound, id, tv')));
-              if List.exists (fun id -> Ident.compare id id' > 0) ids then
+              if Ident.compare id id' > 0 then
                 raise (Error (cty.ctyp_loc, !!penv,
                               Bind_existential (Bind_not_in_scope, id, tv')));
               bound_ids := id' :: !bound_ids

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -6924,7 +6924,7 @@ let report_error ~loc env = function
   | Bind_existential (reason, id, ty) ->
       let reason = match reason with
       | Bind_already_bound -> "already bound existential"
-      | Bind_not_in_scope -> "out-of-scope existential"
+      | Bind_not_in_scope -> "previously defined existential"
       | Bind_non_locally_abstract -> "non-locally-abstract type"
       in
       Location.errorf ~loc

--- a/typing/typecore.mli
+++ b/typing/typecore.mli
@@ -223,6 +223,7 @@ type error =
   | Andop_type_clash of string * Errortrace.unification_error
   | Bindings_type_clash of Errortrace.unification_error
   | Unbound_existential of Ident.t list * type_expr
+  | Non_closed_type_alias of Ident.t * type_expr
   | Missing_type_constraint
   | Wrong_expected_kind of wrong_kind_sort * wrong_kind_context * type_expr
   | Expr_not_a_record_type of type_expr

--- a/typing/typecore.mli
+++ b/typing/typecore.mli
@@ -142,6 +142,11 @@ val name_cases : string -> Typedtree.value Typedtree.case list -> Ident.t
 
 val self_coercion : (Path.t * Location.t list ref) list ref
 
+type existential_binding =
+  | Bind_already_bound
+  | Bind_not_in_scope
+  | Bind_non_locally_abstract
+
 type error =
   | Constructor_arity_mismatch of Longident.t * int * int
   | Label_mismatch of Longident.t * Errortrace.unification_error
@@ -223,7 +228,7 @@ type error =
   | Andop_type_clash of string * Errortrace.unification_error
   | Bindings_type_clash of Errortrace.unification_error
   | Unbound_existential of Ident.t list * type_expr
-  | Non_closed_type_alias of Ident.t * type_expr
+  | Bind_existential of existential_binding * Ident.t * type_expr
   | Missing_type_constraint
   | Wrong_expected_kind of wrong_kind_sort * wrong_kind_context * type_expr
   | Expr_not_a_record_type of type_expr


### PR DESCRIPTION
In #11891 it was pointed that, for constructor type annotations, the current approach of only allowing to name existentials that do not appear in the return type was too restrictive, as existentials could also appear through unification of the return type.

This PR relaxes this restriction, allowing to name any closed type appearing in the type of the arguments.
This seems to answer the request in #11891, however this means that we are now using local type definitions for two different things: existentials introduced by constructors, and aliases written in the annotation.
Note that while it could be possible to restrict those aliases to existentials, I'm not sure this would be a stable property: according to the order of unification, an existential could have been already refined. So I would prefer to stick to this relaxed definition. Note that there is still a scope restriction, so that one can only alias already known closed types.