### PR TITLE
Use strict prototypes on primitives in bytecomp

### DIFF
--- a/Changes
+++ b/Changes
@@ -269,7 +269,7 @@ Working version
   (Gabriel Scherer, review by Xavier Leroy)
 
 - #12509: Use strict prototypes on primitives when generating a standalone
-  bytecode executable ( `ocamlc -custom`).
+  bytecode executable (`ocamlc -custom`).
   (Antonin Décimo, review by Xavier Leroy)
 
 ### Build system:

--- a/Changes
+++ b/Changes
@@ -268,6 +268,10 @@ Working version
 - #12446: remove the hooks machinery around channel locking in runtimee/io.c
   (Gabriel Scherer, review by Xavier Leroy)
 
+- #12509: Use strict prototypes on primitives when generating a standalone
+  bytecode executable ( `ocamlc -custom`).
+  (Antonin Décimo, review by Xavier Leroy)
+
 ### Build system:
 
 - #12198, #12321: continue the merge of the sub-makefiles into the root Makefile

--- a/Makefile
+++ b/Makefile
@@ -835,11 +835,11 @@ runtime/prims.c : runtime/primitives
 	 echo; \
 	 sed -e 's/.*/extern value &(void);/' $<; \
 	 echo; \
-	 echo 'c_primitive caml_builtin_cprim[] = {'; \
+	 echo 'const c_primitive caml_builtin_cprim[] = {'; \
 	 sed -e 's/.*/  &,/' $<; \
 	 echo '  0 };'; \
 	 echo; \
-	 echo 'char * caml_names_of_builtin_cprim[] = {'; \
+	 echo 'const char * const caml_names_of_builtin_cprim[] = {'; \
 	 sed -e 's/.*/  "&",/' $<; \
 	 echo '  0 };') > $@
 

--- a/bytecomp/bytelink.ml
+++ b/bytecomp/bytelink.ml
@@ -470,6 +470,13 @@ let output_cds_file outfile =
 
 (* Output a bytecode executable as a C file *)
 
+(* Primitives declared in the included headers but re-declared in the
+   primitives table need to be guarded and not declared twice. *)
+let guarded_primitives = [
+    "caml_get_public_method", "caml__get_public_method";
+    "caml_set_oo_id", "caml__set_oo_id";
+  ]
+
 let link_bytecode_as_c tolink outfile with_main =
   let outchan = open_out outfile in
   Misc.try_finally
@@ -483,12 +490,17 @@ let link_bytecode_as_c tolink outfile with_main =
 \n\
 \n#ifdef __cplusplus\
 \nextern \"C\" {\
-\n#endif\
+\n#endif";
+       List.iter (fun (f, f') -> Printf.fprintf outchan "\n#define %s %s" f f')
+         guarded_primitives;
+       output_string outchan "\
 \n#include <caml/mlvalues.h>\
 \n#include <caml/startup.h>\
 \n#include <caml/sys.h>\
 \n#include <caml/misc.h>\n";
-       output_string outchan "static int caml_code[] = {\n";
+       List.iter (fun (f, _) -> Printf.fprintf outchan "\n#undef %s" f)
+         guarded_primitives;
+       output_string outchan "\nstatic int caml_code[] = {\n";
        Symtable.init();
        clear_crc_interfaces ();
        let currpos = ref 0 in

--- a/bytecomp/symtable.ml
+++ b/bytecomp/symtable.ml
@@ -177,19 +177,19 @@ open Printf
 let output_primitive_table outchan =
   let prim = all_primitives() in
   for i = 0 to Array.length prim - 1 do
-    fprintf outchan "extern value %s();\n" prim.(i)
+    fprintf outchan "extern value %s(void);\n" prim.(i)
   done;
-  fprintf outchan "typedef value (*primitive)();\n";
-  fprintf outchan "primitive caml_builtin_cprim[] = {\n";
+  fprintf outchan "typedef value (*c_primitive)(void);\n";
+  fprintf outchan "c_primitive caml_builtin_cprim[] = {\n";
   for i = 0 to Array.length prim - 1 do
     fprintf outchan "  %s,\n" prim.(i)
   done;
-  fprintf outchan "  (primitive) 0 };\n";
+  fprintf outchan "  0 };\n";
   fprintf outchan "const char * caml_names_of_builtin_cprim[] = {\n";
   for i = 0 to Array.length prim - 1 do
     fprintf outchan "  \"%s\",\n" prim.(i)
   done;
-  fprintf outchan "  (char *) 0 };\n"
+  fprintf outchan "  0 };\n"
 
 (* Translate structured constants *)
 

--- a/bytecomp/symtable.ml
+++ b/bytecomp/symtable.ml
@@ -180,12 +180,12 @@ let output_primitive_table outchan =
     fprintf outchan "extern value %s(void);\n" prim.(i)
   done;
   fprintf outchan "typedef value (*c_primitive)(void);\n";
-  fprintf outchan "c_primitive caml_builtin_cprim[] = {\n";
+  fprintf outchan "const c_primitive caml_builtin_cprim[] = {\n";
   for i = 0 to Array.length prim - 1 do
     fprintf outchan "  %s,\n" prim.(i)
   done;
   fprintf outchan "  0 };\n";
-  fprintf outchan "const char * caml_names_of_builtin_cprim[] = {\n";
+  fprintf outchan "const char * const caml_names_of_builtin_cprim[] = {\n";
   for i = 0 to Array.length prim - 1 do
     fprintf outchan "  \"%s\",\n" prim.(i)
   done;


### PR DESCRIPTION
Earlier this year, we enabled warnings for strict prototypes in C code (mostly replacing `f()` declarations with `f(void)`). This led to fixing the primitives' list generation; see #11763 and #11861 for history.
clang has started raising warnings by default when it encounters such K&R declarations.
We didn't catch that there was another place generating the list of primitives: the bytecode compiler when it builds a complete executable!
The first commit brings the bytecomp to generate the code we've agreed on from the previous PRs, with the additional twist that we must prevent two functions from `mlvalues.h` from being re-declared with conflicting types. This is done with some preprocessor tricks inspired by what we already do with `ATOM` and `ATOM_WS`.
We can't extract the original types of the primitives, the bytecomp uses its `Dll` module to check whether a symbol exists in a dll, and types aren't retained.

Side dishes are switching to quoted strings for C code: note how it's nice now. Backslashes can be a bit confusing when dealing with macros, too. edit: although looking at a recent issue, I wonder if this can introduce end-of-line problems between Windows and other systems.

I think we can also constify the primitive lists, right?

I wonder if we can make `caml_data`, `caml_code`, and `caml_sections` `const` in the generated C code for the complete bytecode executable.
