### PR TITLE
Add volatile casts to FFI macros to enforce memory model

### DIFF
--- a/Changes
+++ b/Changes
@@ -1039,6 +1039,11 @@ Some of those changes will benefit all OCaml packages.
   to set up to get flexdll working changed
   (David Allsopp and Samuel Hym, light review by Xavier Leroy)
 
+* #12512: Add volatile casts to FFI macros to enforce memory model (technically
+  a breaking change although no opam package seemed broken by it.)
+  (Olivier Nicole, suggested by Guillaume Munch-Maccagnoni, review by Gabriel
+   Scherer and Xavier Leroy)
+
 ### Language features:
 
 * #11694: Add short syntax for generative functor types `() -> ...`

--- a/runtime/caml/mlvalues.h
+++ b/runtime/caml/mlvalues.h
@@ -163,13 +163,13 @@ Caml_inline header_t Hd_val(value val)
 
 #define Color_val(val) (Color_hd (Hd_val (val)))
 
-#define Hd_hp(hp) (* ((header_t *) (hp)))              /* Also an l-value. */
-#define Hp_val(val) (((header_t *) (val)) - 1)
+#define Hd_hp(hp) (* ((volatile header_t *) (hp)))      /* Also an l-value. */
+#define Hp_val(val) (((volatile header_t *) (val)) - 1)
 #define Hp_op(op) (Hp_val (op))
 #define Hp_bp(bp) (Hp_val (bp))
 #define Val_op(op) ((value) (op))
 #define Val_hp(hp) ((value) (((header_t *) (hp)) + 1))
-#define Op_hp(hp) ((value *) Val_hp (hp))
+#define Op_hp(hp) ((volatile value *) Val_hp (hp))
 #define Bp_hp(hp) ((char *) Val_hp (hp))
 
 #define Num_tags (1ull << HEADER_TAG_BITS)
@@ -354,7 +354,7 @@ CAMLextern void caml_Store_double_val (value,double);
 
 /* The [_flat_field] macros are for [floatarray] values and float-only records.
 */
-#define Double_flat_field(v,i) Double_val((value)((double *)(v) + (i)))
+#define Double_flat_field(v,i) Double_val((value)((volatile double *)(v) + (i)))
 #define Store_double_flat_field(v,i,d) do{ \
   mlsize_t caml__temp_i = (i); \
   double caml__temp_d = (d); \

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -285,7 +285,7 @@ Caml_inline void prefetch_block(value v)
      somewhere between 1/8-1/2 of a prefetch operation (in expectation,
      depending on alignment, word size, and cache line size), which is
      cheap enough to make this worthwhile. */
-  caml_prefetch(Hp_val(v));
+  caml_prefetch((void*)Hp_val(v));
   caml_prefetch((void*)&Field(v, 3));
 }
 

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -285,8 +285,8 @@ Caml_inline void prefetch_block(value v)
      somewhere between 1/8-1/2 of a prefetch operation (in expectation,
      depending on alignment, word size, and cache line size), which is
      cheap enough to make this worthwhile. */
-  caml_prefetch((void*)Hp_val(v));
-  caml_prefetch((void*)&Field(v, 3));
+  caml_prefetch((const void *)Hp_val(v));
+  caml_prefetch((const void *)&Field(v, 3));
 }
 
 static void ephe_next_cycle (void)

--- a/stdlib/marshal.mli
+++ b/stdlib/marshal.mli
@@ -219,3 +219,12 @@ val compression_supported : unit -> bool
 
     @since 5.1
 *)
+
+(** {1:marshal_concurrency Marshal and domain safety}
+
+    Care must be taken when marshaling a mutable value that may be modified by
+    a different domain. Mutating a value that is being marshaled (i.e., turned
+    into a sequence of bytes) is a programming error and might result in
+    suprising values (when unmarshaling) due to tearing, since marshaling
+    involves byte-per-byte copy.
+*)


### PR DESCRIPTION
This is a step toward solving https://github.com/ocaml/ocaml/issues/11426, in which I listed which macros require a cast to a `volatile` pointer in order to comply with our mixed C/OCaml memory model policy (see 33a0b7d4e5b125b96926f8d58e01b79e0a654d5b).

Technically, this change is not entirely backward-compatible as it restricts the use of the pointers returned by these macros. However in practice, running opam-health-check with those changes on top of 5.0 shows compile errors in only 4 packages (namely class_group_vdf, re2, taglib and sfml), for which I intend to submit PRs (for sequential code, the fix is a simple cast).

It’s arguably not related, but working on this prompted me to add a small documentation paragraph in the manual of `Marshal` to explain that it is a programming error to marshal values that are being modified.