### PR TITLE
normalize \r*\n newlines to \n during lexing

### DIFF
--- a/Changes
+++ b/Changes
@@ -41,14 +41,14 @@ Working version
   and variant with only constant constructors.
   (Christophe Raffalli, review by Gabriel Scherer)
 
-- #12502: the compiler now normalizes newline sequences (\r*\n) to
+- #12502: the compiler now normalizes the newline sequence \r\n to
   a single \n character during lexing, to guarantee that the semantics
-  of newlines in string literals is not modified by tools applying OS-specific
-  newline conversions.
+  of newlines in string literals is not modified by Windows tools
+  transforming \n into \r\n in source files.
   Warning 29 [eol-in-string] is not emitted anymore, as the normalization
   gives a more robust semantics to newlines in string literals.
-  (Gabriel Scherer, review by Daniel Bünzli and David Allsopp, report
-   by Andreas Rossberg)
+  (Gabriel Scherer and Damien Doligez, review by Daniel Bünzli, David
+   Allsopp, Andreas Rossberg, Xavier Leroy, report by Andreas Rossberg)
 
 ### Type system:
 

--- a/Changes
+++ b/Changes
@@ -41,6 +41,15 @@ Working version
   and variant with only constant constructors.
   (Christophe Raffalli, review by Gabriel Scherer)
 
+- #12502: the compiler now normalizes newline sequences (\r*\n) to
+  a single \n character during lexing, to guarantee that the semantics
+  of newlines in string literals is not modified by tools applying OS-specific
+  newline conversions.
+  Warning 29 [eol-in-string] is not emitted anymore, as the normalization
+  gives a more robust semantics to newlines in string literals.
+  (Gabriel Scherer, review by Daniel Bünzli and David Allsopp, report
+   by Andreas Rossberg)
+
 ### Type system:
 
 - #12313, #11799: Do not re-build as-pattern type when a ground type annotation

--- a/manual/src/refman/lex.etex
+++ b/manual/src/refman/lex.etex
@@ -212,11 +212,9 @@ let greeting = "Hello, World!\n"
 let superscript_plus = "\u{207A}";;
 \end{caml_example}
 
-Any sequence of carriage return characters followed by a line feed
-character is considered as a newline sequence. Since OCaml 5.2,
-a newline sequence occurring in a string literal is normalized into
-a single line feed character. This guarantees that the OCaml value is
-independent of the newline convention used by the source file.
+A newline sequence is a line feed optionally preceded by a carriage
+return. Since OCaml 5.2, a newline sequence occurring in a string
+literal is normalized into a single line feed character.
 
 To allow splitting long string literals across lines, the sequence
 "\\"\var{newline}~\var{spaces-or-tabs} (a backslash at the end of a line
@@ -251,12 +249,12 @@ string literals. They are useful to represent strings of arbitrary
 content without escaping. Quoted strings are delimited by a matching
 pair of @'{' quoted-string-id '|'@ and @'|' quoted-string-id '}'@ with
 the same @quoted-string-id@ on both sides. Quoted strings do not
-interpret any character in a special way (except for
-newline normalization) but requires that the sequence @'|'
-quoted-string-id '}'@ does not occur in the string itself.  The
-identifier @quoted-string-id@ is a (possibly empty) sequence of
-lowercase letters and underscores that can be freely chosen to avoid
-such issue.
+interpret any character in a special way\footnote{Except for the
+  normalization of newline sequences into a single line feed mentioned
+  earlier.} but requires that the sequence @'|' quoted-string-id '}'@
+does not occur in the string itself.  The identifier
+@quoted-string-id@ is a (possibly empty) sequence of lowercase letters
+and underscores that can be freely chosen to avoid such issue.
 
 \begin{caml_example}{toplevel}
 let quoted_greeting = {|"Hello, World!"|}

--- a/manual/src/refman/lex.etex
+++ b/manual/src/refman/lex.etex
@@ -183,7 +183,7 @@ let copyright = '\xA9';;
 \begin{syntax}
 string-literal:
           '"' { string-character } '"'
-       |  '{' quoted-string-id '|' { any-char } '|' quoted-string-id '}'
+       |  '{' quoted-string-id '|' { newline | any-char } '|' quoted-string-id '}'
 ;
 quoted-string-id:
      { 'a'...'z' || '_' }
@@ -192,6 +192,7 @@ string-character:
           regular-string-char
         | escape-sequence
         | "\u{" {{ "0"\ldots"9" || "A"\ldots"F" || "a"\ldots"f" }} "}"
+        | newline
         | '\' newline { space || tab }
 \end{syntax}
 
@@ -211,6 +212,12 @@ let greeting = "Hello, World!\n"
 let superscript_plus = "\u{207A}";;
 \end{caml_example}
 
+Any sequence of carriage return characters followed by a line feed
+character is considered as a newline sequence. Since OCaml 5.2,
+a newline sequence occurring in a string literal is normalized into
+a single line feed character. This guarantees that the OCaml value is
+independent of the newline convention used by the source file.
+
 To allow splitting long string literals across lines, the sequence
 "\\"\var{newline}~\var{spaces-or-tabs} (a backslash at the end of a line
 followed by any number of spaces and horizontal tabulations at the
@@ -225,14 +232,29 @@ let longstr =
   he world.";;
 \end{caml_example}
 
+Escaped newlines provide more convenient behavior than non-escaped
+newlines, as the indentation is not considered part of the string
+literal.
+
+\begin{caml_example}{toplevel}
+let contains_unexpected_spaces =
+  "This multiline literal
+   contains three consecutive spaces."
+
+let no_unexpected_spaces =
+  "This multiline literal \n\
+   uses a single space between all words.";;
+\end{caml_example}
+
 Quoted string literals provide an alternative lexical syntax for
-string literals. They are useful to represent strings of arbitrary content
-without escaping. Quoted strings are delimited by a matching pair
-of @'{' quoted-string-id '|'@ and @'|' quoted-string-id '}'@ with
-the same @quoted-string-id@ on both sides. Quoted strings do not interpret
-any character in a special way but requires that the
-sequence @'|' quoted-string-id '}'@ does not occur in the string itself.
-The identifier @quoted-string-id@ is a (possibly empty) sequence of
+string literals. They are useful to represent strings of arbitrary
+content without escaping. Quoted strings are delimited by a matching
+pair of @'{' quoted-string-id '|'@ and @'|' quoted-string-id '}'@ with
+the same @quoted-string-id@ on both sides. Quoted strings do not
+interpret any character in a special way (except for
+newline normalization) but requires that the sequence @'|'
+quoted-string-id '}'@ does not occur in the string itself.  The
+identifier @quoted-string-id@ is a (possibly empty) sequence of
 lowercase letters and underscores that can be freely chosen to avoid
 such issue.
 

--- a/parsing/lexer.mll
+++ b/parsing/lexer.mll
@@ -108,7 +108,7 @@ let store_string_char c = Buffer.add_char string_buffer c
 let store_string_utf_8_uchar u = Buffer.add_utf_8_uchar string_buffer u
 let store_string s = Buffer.add_string string_buffer s
 let store_lexeme lexbuf = store_string (Lexing.lexeme lexbuf)
-let store_normalizated_newline () =
+let store_normalized_newline () =
   (* #12502: we normalize newlines to "\n" at lexing time,
      to avoid behavior difference due to OS-specific
      newline characters in string literals.

--- a/testsuite/tests/lexing/newlines.ml
+++ b/testsuite/tests/lexing/newlines.ml
@@ -1,0 +1,23 @@
+(* TEST *)
+
+let check ~kind ~input ~result =
+  if input <> result then
+    Printf.printf "FAIL: %s %S should normalize to %S
+"
+      kind input result
+;;
+
+check ~kind:"string literal" ~input:"
+" ~result:"\n";
+check ~kind:"quoted string literal" ~input:{|
+|} ~result:"\n";
+
+check ~kind:"string literal" ~input:"
+" ~result:"\n";
+check ~kind:"quoted string literal" ~input:{|
+|} ~result:"\n";
+
+check ~kind:"string literal" ~input:"
+" ~result:"\r\n";
+check ~kind:"quoted string literal" ~input:{|
+|} ~result:"\r\n";

--- a/utils/warnings.ml
+++ b/utils/warnings.ml
@@ -944,7 +944,8 @@ let message = function
   | Wildcard_arg_to_constant_constr ->
      "wildcard pattern given as argument to a constant constructor"
   | Eol_in_string ->
-     "unescaped end-of-line in a string constant (non-portable code)"
+     "unescaped end-of-line in a string constant\n\
+      (non-portable behavior before OCaml 5.2)"
   | Duplicate_definitions (kind, cname, tc1, tc2) ->
       Printf.sprintf "the %s %s is defined in both types %s and %s."
         kind cname tc1 tc2

--- a/utils/warnings.mli
+++ b/utils/warnings.mli
@@ -69,7 +69,7 @@ type t =
   | Unused_var_strict of string             (* 27 *)
   | Wildcard_arg_to_constant_constr         (* 28 *)
   | Eol_in_string                           (* 29
-      Note: since OCaml 5.2, the lexer normalizes \r*\n sequences in
+      Note: since OCaml 5.2, the lexer normalizes \r\n sequences in
       the source file to a single \n character, so the behavior of
       newlines in string literals is portable. This warning is
       never emitted anymore. *)

--- a/utils/warnings.mli
+++ b/utils/warnings.mli
@@ -68,7 +68,11 @@ type t =
   | Unused_var of string                    (* 26 *)
   | Unused_var_strict of string             (* 27 *)
   | Wildcard_arg_to_constant_constr         (* 28 *)
-  | Eol_in_string                           (* 29 *)
+  | Eol_in_string                           (* 29
+      Note: since OCaml 5.2, the lexer normalizes \r*\n sequences in
+      the source file to a single \n character, so the behavior of
+      newlines in string literals is portable. This warning is
+      never emitted anymore. *)
   | Duplicate_definitions of string * string * string * string (* 30 *)
   | Unused_value_declaration of string      (* 32 *)
   | Unused_open of string                   (* 33 *)


### PR DESCRIPTION
If I understand correctly, this PR implements the consensus on "an ideal behavior of the compiler would be ..." that emerged from #12502.

This PR changes the language semantics of multiline string literals for all OCaml files that use \r\n (or in fact \r+\n) line endings. Our expectation is that this only concerns Windows users, and that the behavior change in fact corresponds to a *bug fix* for them, because the files they are seeing were meant to use \n line endings but were converted on the fly by some tools (for example, Git for Windows on checkout).

Because the semantics of newlines in string literals is now "portable" across os-specific newline conventions, this PR removes warning 29 (which was disabled by default I think?) on newlines in `"..."` string literals. (There was no warning on newlines in quoted string literals.) The warning definition, warning number, etc. are all left for compatibility reasons, the warning is just not raised anymore.