### PR TITLE
Avoid the "constant-logical-operand" warning of recent clang versions

### DIFF
--- a/runtime/printexc.c
+++ b/runtime/printexc.c
@@ -130,7 +130,7 @@ static void default_fatal_uncaught_exception(value exn)
   fprintf(stderr, "Fatal error: exception %s\n", msg);
   caml_stat_free(msg);
   /* Display the backtrace if available */
-  if (Caml_state->backtrace_active && !DEBUGGER_IN_USE)
+  if (!DEBUGGER_IN_USE && Caml_state->backtrace_active)
     caml_print_exception_backtrace();
 }
 


### PR DESCRIPTION
`x && !0` triggers the warning, but `!0 && x` does not, so here is an easy fix.

Observed with clang 15 with `-std=c2x -Wall`, but well documented online (e.g.  https://stackoverflow.com/questions/25706283/use-of-logical-with-constant-operand).  
