### PR TITLE
Relax `fma` check in configure for Visual Studio

### DIFF
--- a/Changes
+++ b/Changes
@@ -47,6 +47,13 @@ OCaml 4.14 maintenance version
   that causes very slow compaction.
   (Damien Doligez, report by Arseniy Alekseyev, review by Sadiq Jaffer)
 
+- #12513, #12518: Automatically enable emulated `fma` for Visual Studio 2019+
+  to allow configuration with either pre-Haswell/pre-Piledriver CPUs or running
+  in VirtualBox. Restores parity with the other Windows ports, which don't
+  require explicit `--enable-imprecise-c99-float-ops`.
+  (David Allsopp, report by Jonah Beckford and Kate Deplaix, review by
+   Sébastien Hinderer)
+
 - #11633, #11636: bugfix in caml_unregister_frametable
   (Frédéric Recoules, review by Gabriel Scherer)
 

--- a/aclocal.m4
+++ b/aclocal.m4
@@ -437,7 +437,9 @@ AC_DEFUN([OCAML_C99_CHECK_FMA], [
 #include <math.h>
 int main (void) {
   /* Tests 264-266 from testsuite/tests/fma/fma.ml. These tests trigger the
-     broken implementations of Cygwin64, mingw-w64 (x86_64) and VS2013-2017.
+     broken implementations of Cygwin64, mingw-w64 (x86_64) Visual Studio
+     (VS2019+ use hardware support when available, but the library function
+     remains broken).
      The static volatile variables aim to thwart GCC's constant folding. */
   static volatile double x, y, z;
   volatile double t264, t265, t266;
@@ -468,12 +470,9 @@ int main (void) {
     AS_CASE([$enable_imprecise_c99_float_ops,$target],
       [no,*], [hard_error=true],
       [yes,*], [hard_error=false],
-      [*,x86_64-w64-mingw32|*,x86_64-*-cygwin*], [hard_error=false],
-      [AS_CASE([$ocaml_cv_cc_vendor],
-        [msvc-*], [AS_IF([test "${ocaml_cv_cc_vendor#msvc-}" -lt 1920 ],
-          [hard_error=false],
-          [hard_error=true])],
-        [hard_error=true])])
+      [*,x86_64-w64-mingw32|*,x86_64-*-cygwin*|*,*-pc-windows],
+        [hard_error=false],
+      [hard_error=true])
     AS_IF([test x"$hard_error" = "xtrue"],
       [AC_MSG_ERROR(m4_normalize([
         fma does not work, enable emulation with

--- a/configure
+++ b/configure
@@ -14852,7 +14852,9 @@ else
 #include <math.h>
 int main (void) {
   /* Tests 264-266 from testsuite/tests/fma/fma.ml. These tests trigger the
-     broken implementations of Cygwin64, mingw-w64 (x86_64) and VS2013-2017.
+     broken implementations of Cygwin64, mingw-w64 (x86_64) Visual Studio
+     (VS2019+ use hardware support when available, but the library function
+     remains broken).
      The static volatile variables aim to thwart GCC's constant folding. */
   static volatile double x, y, z;
   volatile double t264, t265, t266;
@@ -14891,19 +14893,10 @@ $as_echo "no" >&6; }
     hard_error=true ;; #(
   yes,*) :
     hard_error=false ;; #(
-  *,x86_64-w64-mingw32|*,x86_64-*-cygwin*) :
+  *,x86_64-w64-mingw32|*,x86_64-*-cygwin*|*,*-pc-windows) :
     hard_error=false ;; #(
   *) :
-    case $ocaml_cv_cc_vendor in #(
-  msvc-*) :
-    if test "${ocaml_cv_cc_vendor#msvc-}" -lt 1920 ; then :
-  hard_error=false
-else
-  hard_error=true
-fi ;; #(
-  *) :
     hard_error=true ;;
-esac ;;
 esac
     if test x"$hard_error" = "xtrue"; then :
   as_fn_error $? "fma does not work, enable emulation with --enable-imprecise-c99-float-ops" "$LINENO" 5


### PR DESCRIPTION
In #944, Visual Studio 2019 onwards is assumed by `configure` to have a working `fma` function, and it's a hard error if it fails the checks for it. This assumption is not quite correct - Visual Studio 2019 in fact fixed the use of hardware fma support, not the software version of the function. If that hardware support is unavailable, the same broken fallback function is used.

Fixes #12513 (NB this is for 4.14, as this only affects MSVC; see also #12519 for trunk)