### PR TITLE
Make pattern-matching and ocamldoc more robust to 5.1 changes to typedtree

### DIFF
--- a/lambda/matching.ml
+++ b/lambda/matching.ml
@@ -3736,8 +3736,14 @@ let for_let ~scopes loc param pat body =
       (* This eliminates a useless variable (and stack slot in bytecode)
          for "let _ = ...". See #6865. *)
       Lsequence (param, body)
-  | Tpat_var (id, _) ->
-      (* fast path, and keep track of simple bindings to unboxable numbers *)
+  | Tpat_var (id, _) | Tpat_alias ({ pat_desc = Tpat_any }, id, _) ->
+      (* Fast path, and keep track of simple bindings to unboxable numbers.
+
+         Note: the (Tpat_alias (Tpat_any, id)) case needs to be
+         supported as well because the type-checker emits a typedtree
+         of this shape in presence of type constraints -- see the
+         non-polymorphic Ppat_constraint case in type_pat_aux.
+      *)
       let k = Typeopt.value_kind pat.pat_env pat.pat_type in
       Llet (Strict, k, id, param, body)
   | _ ->

--- a/ocamldoc/odoc_ast.ml
+++ b/ocamldoc/odoc_ast.ml
@@ -50,7 +50,8 @@ module Typedtree_search =
 
     let iter_val_pattern = function
       | Typedtree.Tpat_any -> None
-      | Typedtree.Tpat_var (name, _) -> Some (Name.from_ident name)
+      | Typedtree.Tpat_var (name, _)
+      | Typedtree.Tpat_alias (_, name, _)  -> Some (Name.from_ident name)
       | Typedtree.Tpat_tuple _ -> None (* FIXME when we will handle tuples *)
       | _ -> None
 
@@ -332,8 +333,10 @@ module Analyser =
      let tt_analyse_value env current_module_name comment_opt loc pat_exp rec_flag attrs =
        let (pat, exp) = pat_exp in
        let comment_opt = Odoc_sig.analyze_alerts comment_opt attrs in
-       match (pat.pat_desc, exp.exp_desc) with
-         (Tpat_var (ident, _), Texp_function (params, body)) ->
+       match pat.pat_desc with
+       | Tpat_var (ident, _) | Tpat_alias (_, ident, _) ->
+          begin match exp.exp_desc with
+          | Texp_function (params, body) ->
 
            (* a new function is defined *)
            let name_pre = Name.from_ident ident in
@@ -360,7 +363,7 @@ module Analyser =
            in
            [ new_value ]
 
-       | (Typedtree.Tpat_var (ident, _), _) ->
+          | _ ->
            (* a new value is defined *)
            let name_pre = Name.from_ident ident in
            let name = Name.parens_if_infix name_pre in
@@ -383,8 +386,9 @@ module Analyser =
            }
            in
            [ new_value ]
+         end
 
-       | (Typedtree.Tpat_tuple _, _) ->
+       | Typedtree.Tpat_tuple _ ->
            (* new identifiers are defined *)
            (* FIXME : by now we don't accept to have global variables defined in tuples *)
            []


### PR DESCRIPTION
As I explained in https://github.com/ocaml/ocaml/discussions/12522 , the typed-tree generated for bindings of the form `let x : foo = ...` has changed between 5.0 and 5.1/trunk, it generates a typed pattern of the form `((_ as x) : foo)` instead of `(x : foo)`. The change was caused by the interaction between #12119 and a pre-existing obscure piece of code in the typechecker, and it is not clear to me that we can easily disable it. In theory this should be innocuous. (As innocuous as #12119, right?)
This affects the behavior of some typedtree consumers in the compiler that would previously special-case on `Tpat_var(ident)`, and would not deal properly with the `Tpat_alias` case. @trefis and myself noticed this while working on the pattern-matching compiler.

The present PR fixes the two places that I could find that are affected by this typedtree change: pattern-matching compilation, and some places `ocamldoc`. The change guarantee that the 5.0-and-earlier behavior is preserved for these two consumers.

I am not aware of any *bug* caused by the small changes that are worked around in the present PR, and this PR is submitted only against trunk. However:

1. In matching.ml, the logic that had been disabled by the change was a fast-path when compiling `let` bindings; disabling this fast path for annotated let-bindings might have a negative impact on compile-time (quite probably minor) *and* an obscure (to me) comment in the relevant code suggests that this may have an impact on the quality of the generated code:

   `(* fast path, and keep track of simple bindings to unboxable numbers *)`

   We might want to double-check that 5.1 does not silently degrade the unboxing behavior of annotated (local?) let bindings.

2. I have not tested ocamldoc at all, it is *possible* that its output its broken by the change and that this PR fixes the issue. We might want to double-check that the affected ocamldoc features still work with 5.1. The changes are in Odoc_ast, which is relevant to the analysis of *implementation* files, maybe we don't care. It reads like "search for structure items by name in a Typedtree.structure" may be broken for annotated let-bindings.

(Dear release manager: sorry.)