### PR TITLE
Fix incorrect use of `int` in `mark_stack_push_block`

### DIFF
--- a/Changes
+++ b/Changes
@@ -524,8 +524,7 @@ Some of those changes will benefit all OCaml packages.
 - #11935: Load frametables of dynlink'd modules in batch
   (Stephen Dolan, review by David Allsopp and Guillaume Munch-Maccagnoni)
 
-
-- #11284: Use compression of entries scheme when pruning mark stack.
+- #11284, #12525: Use compression of entries scheme when pruning mark stack.
   Can decrease memory usage for some workloads, otherwise should be
   unobservable.
   (Tom Kelly, review by Sabine Schmaltz, Sadiq Jaffer and Damien Doligez)

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -727,7 +727,7 @@ static void realloc_mark_stack (struct mark_stack* stk)
      will not compress and because we are using a domain local heap bound we
      need to fit large blocks into the local mark stack. See PR#11284 */
   if (mark_stack_bsize >= local_heap_bsize / 32) {
-    int i;
+    uintnat i;
     for (i = 0; i < stk->count; ++i) {
       mark_entry* me = &stk->stack[i];
       if (me->end - me->start > BITS_PER_WORD)
@@ -778,8 +778,8 @@ CAMLno_tsan /* Disable TSan reports from this function (see #11040) */
 /* returns the work done by skipping unmarkable objects */
 static intnat mark_stack_push_block(struct mark_stack* stk, value block)
 {
-  int i, block_wsz = Wosize_val(block), end;
-  uintnat offset = 0;
+  int i, end;
+  uintnat block_wsz = Wosize_val(block), offset = 0;
 
   if (Tag_val(block) == Closure_tag) {
     /* Skip the code pointers and integers at beginning of closure;
@@ -1887,8 +1887,7 @@ static void mark_stack_prune(struct mark_stack* stk)
   stk->compressed_stack = new_compressed_stack;
 
   /* scan mark stack and compress entries */
-  int i;
-  uintnat new_stk_count = 0, compressed_entries = 0, total_words = 0;
+  uintnat i, new_stk_count = 0, compressed_entries = 0, total_words = 0;
   for (i=0; i < stk->count; i++) {
     mark_entry me = stk->stack[i];
     total_words += me.end - me.start;


### PR DESCRIPTION
Fixes #12515. In 5.0, we have in `mark_stack_push` an overflow as the result of `Wosize_val` should be stored in a `uintnat`:

https://github.com/ocaml/ocaml/blob/a6b1747b2b288dcb723cf3e766ad943324351e5a/runtime/major_gc.c#L575-L579

In 5.0, this is benign - `block_wsz` is only used in the detection of the small unmarkable block optimisation, and the overflow still causes the very large block to be pushed to the mark stack. In `do_some_marking`, the value is recomputed in the correct type:

https://github.com/ocaml/ocaml/blob/a6b1747b2b288dcb723cf3e766ad943324351e5a/runtime/major_gc.c#L706-L709

For 5.1, as found by @edwintorok's bisect, the error surfaces since #11284, when this overflowed value is used for pointer calculations, now in `mark_stack_push_block`:

https://github.com/ocaml/ocaml/blob/37f8e79ae3c723e4cea2b6e7f355762925095868/runtime/major_gc.c#L815-L817

In this case, we end up with a mark stack entry where `end < start`, which means that `do_some_marking` will do nothing with the entry. In @edwintorok's example, we end up with a block of size 0x80000000 which isn't marked, leading to the heap corruption seen. With this fix, both his original bug and the single-domain bug disappear.

I quickly checked for other erroneous uses of `int` in major_gc.c and fixed two pedantic cases with `mark_stack->count` which is also a `uintnat`, but this should never overflow in 5.1, as the mark stack would already have been compressed.