### PR TITLE
Honor `inline always` even for functions with optional arguments and default values

### DIFF
--- a/Changes
+++ b/Changes
@@ -339,6 +339,10 @@ Working version
   (Miod Vallat, report by Jan Midtgaard, review by Vincent Laviron and Xavier
   Leroy)
 
+- #12526: Honor `ocaml.inline always` attribute on functions with
+  optional arguments and default values in the Closure backend
+  (Alain Frisch, review by Vincent Laviron)
+
 OCaml 5.1.0
 ---------------
 

--- a/testsuite/tests/asmcomp/optargs.ml
+++ b/testsuite/tests/asmcomp/optargs.ml
@@ -24,3 +24,21 @@ let () =
   let x2 = Gc.allocated_bytes () in
   assert(x1 -. x0 = x2 -. x1)
      (* check that we have not allocated anything between x1 and x2 *)
+
+
+(* Check that 'ocaml.inline always' is not broken due to the split
+   into a worker+wrapper. *)
+
+
+let[@ocaml.inline always] f ?(x = 1.) a b = a +. b *. x
+let () =
+  let r = ref 0. in
+  let x0 = Gc.allocated_bytes () in
+  let x1 = Gc.allocated_bytes () in
+  for _ = 1 to 1000 do
+    r := !r +. f 1. 1.
+  done;
+  let x2 = Gc.allocated_bytes () in
+  assert(x1 -. x0 = x2 -. x1)
+  (* If the body of `f` itself were not inlined, we would get float
+     boxing allocations. *)


### PR DESCRIPTION
(Note: this is only about the Closure middle-end; I haven't checked Flambda.)

Functions with optional arguments and default values are split into an inner function and wrapper, which is responsible for filling in missing arguments with their default values (and then tail-calling the inner function). The rationale is that the wrapper can then be inlined on call sites, avoiding in particular the need to wrap passed optional arguments with `Some` and deconstruct that `Some` immediately.

However, we don't want this split in two cases:
   - When the function is explicitly marked with `inline always` ==> we want to inline the whole function, not just the wrapper. (The way inlining currently works, after a split, the inner function is never inlined in the wrapper.)
   - When the function is explicitly marked with `inline never` ==> we should honor that, and not even inline the wrapper (which makes the split useless).

This PR disables the split in these cases. One could try to be more clever, and also avoid the split if the inlining heuristics triggers on the whole function, but this is more tricky (the function size that determines if we are below the inlining threshold is computed on Clambda, but the split is done at the Lambda level). Honoring the `inline` attribute is simple and could be seen as a bug fix.

Here is a micro-benchmark to illustrate the benefits of this PR:
```ocaml
let[@ocaml.inline always] f ?(x = 1.) a b = a +. b *. x
let () = let r = ref 0. in for _ = 1 to 1000000000 do r := !r +. f 1. 1. done
```

With trunk, this takes 2.8s on my machine. With this PR, it takes 0.45s (6x faster), thanks to the float unboxing made possible by inlining.

Without the `inline` attributes, trunk and PR behave the same.

With `inline never`, we have trunk->2.7s and PR->2.9s. The slowdown is intentional; it corresponds to that lack of inlining of the wrapper with the PR.

Shall I create a non-regression test (perhaps based on observing Gc.allocated_bytes in the example above)?