### PR TITLE
[refactoring] minor improvements to pattern typing

### DIFF
--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -1472,7 +1472,7 @@ let copy_sep ~copy_scope ~fixed ~(visited : type_expr TypeHash.t) sch =
   List.iter Lazy.force !delayed_copies;
   ty
 
-let instance_poly' copy_scope ~keep_names fixed univars sch =
+let instance_poly' copy_scope ~keep_names ~fixed univars sch =
   (* In order to compute univars below, [sch] should not contain [Tsubst] *)
   let copy_var ty =
     match get_desc ty with
@@ -1485,17 +1485,17 @@ let instance_poly' copy_scope ~keep_names fixed univars sch =
   let ty = copy_sep ~copy_scope ~fixed ~visited sch in
   vars, ty
 
-let instance_poly ?(keep_names=false) fixed univars sch =
+let instance_poly ?(keep_names=false) ~fixed univars sch =
   For_copy.with_scope (fun copy_scope ->
-    instance_poly' copy_scope ~keep_names fixed univars sch
+    instance_poly' copy_scope ~keep_names ~fixed univars sch
   )
 
-let instance_label fixed lbl =
+let instance_label ~fixed lbl =
   For_copy.with_scope (fun copy_scope ->
     let vars, ty_arg =
       match get_desc lbl.lbl_arg with
         Tpoly (ty, tl) ->
-          instance_poly' copy_scope ~keep_names:false fixed tl ty
+          instance_poly' copy_scope ~keep_names:false ~fixed tl ty
       | _ ->
           [], copy copy_scope lbl.lbl_arg
     in
@@ -4894,7 +4894,7 @@ let rec subtype_rec env trace t1 t2 cstrs =
     | (Tpoly (u1, []), Tpoly (u2, [])) ->
         subtype_rec env trace u1 u2 cstrs
     | (Tpoly (u1, tl1), Tpoly (u2, [])) ->
-        let _, u1' = instance_poly false tl1 u1 in
+        let _, u1' = instance_poly ~fixed:false tl1 u1 in
         subtype_rec env trace u1' u2 cstrs
     | (Tpoly (u1, tl1), Tpoly (u2,tl2)) ->
         begin try

--- a/typing/ctype.mli
+++ b/typing/ctype.mli
@@ -206,12 +206,13 @@ val instance_class:
         type_expr list -> class_type -> type_expr list * class_type
 
 val instance_poly:
-        ?keep_names:bool ->
-        bool -> type_expr list -> type_expr -> type_expr list * type_expr
+        ?keep_names:bool -> fixed:bool ->
+        type_expr list -> type_expr -> type_expr list * type_expr
         (* Take an instance of a type scheme containing free univars *)
 val polyfy: Env.t -> type_expr -> type_expr list -> type_expr * bool
 val instance_label:
-        bool -> label_description -> type_expr list * type_expr * type_expr
+        fixed:bool ->
+        label_description -> type_expr list * type_expr * type_expr
         (* Same, for a label *)
 val apply:
         ?use_current_level:bool ->

--- a/typing/printtyped.ml
+++ b/typing/printtyped.ml
@@ -106,6 +106,11 @@ let fmt_private_flag f x =
   | Public -> fprintf f "Public"
   | Private -> fprintf f "Private"
 
+let fmt_partiality f x =
+  match x with
+  | Total -> ()
+  | Partial -> fprintf f " (Partial)"
+
 let line i f s (*...*) =
   fprintf f "%s" (String.make (2*i) ' ');
   fprintf f s (*...*)
@@ -292,9 +297,11 @@ and function_body i ppf (body : function_body) =
       line i ppf "Tfunction_body\n";
       expression (i+1) ppf e
   | Tfunction_cases
-      { cases; loc; exp_extra; attributes = attrs; param = _; partial = _ }
+      { cases; loc; exp_extra; attributes = attrs; param = _; partial }
     ->
-      line i ppf "Tfunction_cases %a\n" fmt_location loc;
+      line i ppf "Tfunction_cases%a %a\n"
+        fmt_partiality partial
+        fmt_location loc;
       attributes (i+1) ppf attrs;
       Option.iter (fun e -> expression_extra (i+1) ppf e []) exp_extra;
       list (i+1) case ppf cases
@@ -344,8 +351,9 @@ and expression i ppf x =
       line i ppf "Texp_apply\n";
       expression i ppf e;
       list i label_x_expression ppf l;
-  | Texp_match (e, l, _partial) ->
-      line i ppf "Texp_match\n";
+  | Texp_match (e, l, partial) ->
+      line i ppf "Texp_match%a\n"
+        fmt_partiality partial;
       expression i ppf e;
       list i case ppf l;
   | Texp_try (e, l) ->
@@ -436,8 +444,9 @@ and expression i ppf x =
   | Texp_pack me ->
       line i ppf "Texp_pack";
       module_expr i ppf me
-  | Texp_letop {let_; ands; param = _; body; partial = _} ->
-      line i ppf "Texp_letop";
+  | Texp_letop {let_; ands; param = _; body; partial } ->
+      line i ppf "Texp_letop%a"
+        fmt_partiality partial;
       binding_op (i+1) ppf let_;
       list (i+1) binding_op ppf ands;
       case i ppf body
@@ -469,10 +478,12 @@ and function_param i ppf x =
   arg_label i ppf p;
   match x.fp_kind with
   | Tparam_pat pat ->
-      line i ppf "Param_pat\n";
+      line i ppf "Param_pat%a\n"
+        fmt_partiality x.fp_partial;
       pattern (i+1) ppf pat
   | Tparam_optional_default (pat, expr) ->
-      line i ppf "Param_optional_default\n";
+      line i ppf "Param_optional_default%a\n"
+        fmt_partiality x.fp_partial;
       pattern (i+1) ppf pat;
       expression (i+1) ppf expr
 

--- a/typing/typeclass.ml
+++ b/typing/typeclass.ml
@@ -779,7 +779,7 @@ let rec class_field_first_pass self_loc cl_num sign self_scope acc cf =
                    Ctype.unify val_env (Ctype.newty (Tpoly (ty', []))) ty;
                    Ctype.unify val_env (type_approx val_env sbody) ty'
                | Tpoly (ty1, tl) ->
-                   let _, ty1' = Ctype.instance_poly false tl ty1 in
+                   let _, ty1' = Ctype.instance_poly ~fixed:false tl ty1 in
                    let ty2 = type_approx val_env sbody in
                    Ctype.unify val_env ty2 ty1'
                | _ -> assert false

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -528,7 +528,7 @@ let rec check_constraints_rec env loc visited ty =
       end;
       List.iter (check_constraints_rec env loc visited) args
   | Tpoly (ty, tl) ->
-      let _, ty = Ctype.instance_poly false tl ty in
+      let _, ty = Ctype.instance_poly ~fixed:false tl ty in
       check_constraints_rec env loc visited ty
   | _ ->
       Btype.iter_type_expr (check_constraints_rec env loc visited) ty
@@ -946,7 +946,8 @@ let check_regularity ~abs_env env loc path decl to_check =
           end;
           List.iter (check_subtype cpath args prev_exp trace ty) args'
       | Tpoly (ty, tl) ->
-          let (_, ty) = Ctype.instance_poly ~keep_names:true false tl ty in
+          let (_, ty) =
+            Ctype.instance_poly ~keep_names:true ~fixed:false tl ty in
           check_regular cpath args prev_exp trace ty
       | _ ->
           Btype.iter_type_expr


### PR DESCRIPTION
I was trying to re-read the code computing partiality of pattern-matching in the type-checker and to test it. This PR contains three independent, minor improvements:

1. indicate the Partial|Total status of typedtree nodes in the `-dtypedtree` output; because Total is vastly more frequent, only change the printing when Partial
2. rename and label the `partial_flag` argument to `type_pat` (one of `partial_flag:true` and `partial_flag:false` means that we know that the match is partial without checking; can you guess which one?)
3. label the `fixed` argument of `instance_poly` and `instance_label` (not obviously related: it was the last remaining unlabeled boolean arguments used in Typecore)

The patches should not change the behavior of the compiler (except the `-dtypedtree` output) and they should be trivial to review. They could be rejected if you found them (1) not useful or (2) not improving readability.