### PR TITLE
Matching: improve the readability of the debug output

### DIFF
--- a/Changes
+++ b/Changes
@@ -281,6 +281,9 @@ Working version
   artifacts in preparation for better unicode support for OCaml source files.
   (Florian Angeletti, review by Gabriel Scherer)
 
+- #12532: improve readability of the pattern-matching debug output
+  (Gabriel Scherer, review by Thomas Refis)
+
 ### Build system:
 
 - #12198, #12321: continue the merge of the sub-makefiles into the root Makefile

--- a/lambda/matching.ml
+++ b/lambda/matching.ml
@@ -1818,10 +1818,9 @@ let drop_expr_arg _head _arg rem = rem
 let get_key_constant caller = function
   | { pat_desc = Tpat_constant cst } -> cst
   | p ->
-      Format.eprintf "BAD (%s): %a"
+      fatal_errorf "BAD(%s): %a"
         caller
-        pretty_pat p;
-      assert false
+        pretty_pat p
 
 let get_pat_args_constant = drop_pat_arg
 let get_expr_args_constant = drop_expr_arg
@@ -1957,11 +1956,11 @@ let get_mod_field modname field =
      in
      match Env.open_pers_signature modname env with
      | Error `Not_found ->
-         fatal_error ("Module " ^ modname ^ " unavailable.")
+         fatal_errorf "Module %s unavailable." modname
      | Ok env -> (
          match Env.find_value_by_name (Longident.Lident field) env with
          | exception Not_found ->
-             fatal_error ("Primitive " ^ modname ^ "." ^ field ^ " not found.")
+             fatal_errorf "Primitive %s.%s not found." modname field
          | path, _ -> transl_value_path Loc_unknown env path
        ))
 
@@ -3162,8 +3161,7 @@ let rec event_branch repr lam =
       Llet (str, k, id, lam, event_branch repr body)
   | Lstaticraise _, _ -> lam
   | _, Some _ ->
-      Printlambda.lambda Format.str_formatter lam;
-      fatal_error ("Matching.event_branch: " ^ Format.flush_str_formatter ())
+      fatal_errorf "Matching.event_branch: %a" Printlambda.lambda lam
 
 (*
    This exception is raised when the compiler cannot produce code
@@ -3908,12 +3906,8 @@ let flatten_simple_pattern size (p : Simple.pattern) =
          where we know that the scrutinee is a tuple literal.
 
          Since the PM is well typed, none of these cases are possible. *)
-      let msg =
-        Format.fprintf Format.str_formatter
-          "Matching.flatten_pattern: got '%a'" pretty_pat (General.erase p);
-        Format.flush_str_formatter ()
-      in
-      fatal_error msg
+      fatal_errorf
+        "Matching.flatten_pattern: got '%a'" pretty_pat (General.erase p)
 
 let flatten_cases size cases =
   List.map

--- a/lambda/matching.ml
+++ b/lambda/matching.ml
@@ -93,7 +93,6 @@ open Types
 open Typedtree
 open Lambda
 open Parmatch
-open Printf
 open Printpat
 
 module Scoped_location = Debuginfo.Scoped_location
@@ -868,7 +867,7 @@ end = struct
   let eprintf (env : t) =
     List.iter
       (fun (i, ctx) ->
-        Printf.eprintf "jump for %d\n" i;
+        Format.eprintf "jump for %d\n" i;
         Context.eprintf ctx)
       env
 
@@ -1017,7 +1016,7 @@ let rec pretty_precompiled = function
       pretty_matrix Format.err_formatter x.or_matrix;
       List.iter
         (fun { exit = i; pm; _ } ->
-          eprintf "++ Handler %d ++\n" i;
+          Format.eprintf "++ Handler %d ++\n" i;
           pretty_pm pm)
         x.handlers
 
@@ -1025,7 +1024,7 @@ let pretty_precompiled_res first nexts =
   pretty_precompiled first;
   List.iter
     (fun (e, pmh) ->
-      eprintf "** DEFAULT %d **\n" e;
+      Format.eprintf "** DEFAULT %d **\n" e;
       pretty_precompiled pmh)
     nexts
 
@@ -1072,7 +1071,7 @@ let make_catch_delayed handler =
   | None -> (
       let i = next_raise_count () in
       (*
-    Printf.eprintf "SHARE LAMBDA: %i\n%s\n" i (string_of_lam handler);
+    Format.eprintf "SHARE LAMBDA: %i\n%s\n" i (string_of_lam handler);
 *)
       ( i,
         fun body ->
@@ -2522,7 +2521,7 @@ let as_interval_canfail fail low high l =
   let do_store _tag act =
     let i = store.act_store () act in
     (*
-    eprintf "STORE [%s] %i %s\n" tag i (string_of_lam act) ;
+    Format.eprintf "STORE [%s] %i %s\n" tag i (string_of_lam act) ;
 *)
     i
   in
@@ -2707,16 +2706,16 @@ let mk_failaction_pos partial seen ctx defs =
         defs
     in
     if dbg then (
-      eprintf "POSITIVE JUMPS [%i]:\n" (List.length fail_pats);
+      Format.eprintf "POSITIVE JUMPS [%i]:\n" (List.length fail_pats);
       Jumps.eprintf jmps
     );
     (None, fail, jmps)
   ) else (
     (* Too many non-matched constructors -> reduced information *)
-    if dbg then eprintf "POS->NEG!!!\n%!";
+    if dbg then Format.eprintf "POS->NEG!!!\n%!";
     let fail, jumps = mk_failaction_neg partial ctx defs in
     if dbg then
-      eprintf "FAIL: %s\n"
+      Format.eprintf "FAIL: %s\n"
         ( match fail with
         | None -> "<none>"
         | Some lam -> string_of_lam lam

--- a/typing/parmatch.ml
+++ b/typing/parmatch.ml
@@ -1900,7 +1900,7 @@ let do_check_partial ~pred loc casel pss = match pss with
           try
             let buf = Buffer.create 16 in
             let fmt = Format.formatter_of_buffer buf in
-            Printpat.top_pretty fmt v;
+            Format.fprintf fmt "%a@?" Printpat.pretty_pat v;
             if do_match (initial_only_guarded casel) [v] then
               Buffer.add_string buf
                 "\n(However, some guarded clause may match this value.)";

--- a/typing/printpat.ml
+++ b/typing/printpat.ml
@@ -144,26 +144,20 @@ and pretty_lvals ppf = function
       fprintf ppf "%s=%a;@ %a"
         lbl.lbl_name pretty_val v pretty_lvals rest
 
-let top_pretty ppf v =
-  fprintf ppf "@[%a@]@?" pretty_val v
-
-let pretty_pat p =
-  top_pretty Format.str_formatter p ;
-  prerr_string (Format.flush_str_formatter ())
+let pretty_pat ppf p =
+  fprintf ppf "@[%a@]" pretty_val p
 
 type 'k matrix = 'k general_pattern list list
 
-let pretty_line fmt =
+let pretty_line ppf line =
+  Format.fprintf ppf "@[";
   List.iter (fun p ->
-    Format.fprintf fmt " <";
-    top_pretty fmt p;
-    Format.fprintf fmt ">";
-  )
+    Format.fprintf ppf "<%a>@ "
+      pretty_val p
+  ) line;
+  Format.fprintf ppf "@]"
 
-let pretty_matrix fmt (pss : 'k matrix) =
-  Format.fprintf fmt "begin matrix\n" ;
-  List.iter (fun ps ->
-    pretty_line fmt ps ;
-    Format.fprintf fmt "\n"
-  ) pss;
-  Format.fprintf fmt "end matrix\n%!"
+let pretty_matrix ppf (pss : 'k matrix) =
+  Format.fprintf ppf "@[<v 2>  %a@]"
+    (Format.pp_print_list ~pp_sep:Format.pp_print_cut pretty_line)
+    pss

--- a/typing/printpat.mli
+++ b/typing/printpat.mli
@@ -18,10 +18,9 @@
 val pretty_const
   : Asttypes.constant -> string
 val pretty_val : Format.formatter -> 'k Typedtree.general_pattern -> unit
-val top_pretty
-    : Format.formatter -> 'k Typedtree.general_pattern -> unit
+
 val pretty_pat
-    : 'k Typedtree.general_pattern -> unit
+    : Format.formatter -> 'k Typedtree.general_pattern -> unit
 val pretty_line
     : Format.formatter -> 'k Typedtree.general_pattern list -> unit
 val pretty_matrix


### PR DESCRIPTION
The pattern-matching compiler has a "debug mode" that prints some information on the internals of the pattern-matching computation. (This is necessary because it is written as a single-pass compiler, so there is no intermediate representation to dump to understand what is going on.)

@trefis and myself tried to read the debug mode output when working on #7241, but we found it very difficult and could not use it. One difficulty is that, while pattern-matching compilation is naturally a nested process (pattern matrices are split into submatrices, etc.), the debug output contains no visual clue as to which branch of the compilation tree we are looking at.

The current PR tweaks the debugging output to look like a tree instead of a linear log. This gives us a fighting chance of understanding what is going on.

The PR should not change the behavior of the compiler in any way unless the `dbg` constant of `matching.ml` is set to `true`; in that case it should change only the debug printing, not anything else.

### Before/after example

Consider the following OCaml program:

```ocaml
let test = function
  | Some (x, y) -> x + y
  | None -> 0
```

Here is the debug output when `dbg = true` and the `-dlambda` flag is passed:

```
COMPILE: Total
MATCH
++++ PM ++++
 Some (x, y)
 None
CTX
LEFT: RIGHT: <_>
COMPILE: Total
MATCH
++++ PM ++++
 (x, y)
CTX
LEFT: <Some _> RIGHT: <_>
COMPILE: Total
MATCH
++++ PM ++++
 _ y
CTX
LEFT: <(_, _)> <Some _> RIGHT: <_> <_>
COMPILE: Total
MATCH
++++ PM ++++
 _
CTX
LEFT: <_> <(_, _)> <Some _> RIGHT: <_>
JUMPS
JUMPS
JUMPS
JUMPS
(setglobal Dbg1!
                            (let
                              (test/269 =
                                 (function param/273 : int
                                   (if param/273
                                     (let
                                       (*match*/275 =a
                                          (field_imm 0 param/273))
                                       (+ (field_imm 0 *match*/275)
                                         (field_imm 1 *match*/275)))
                                     0)))
                              (makeblock 0 test/269)))
```

The `-dlambda` output is weirdly indented. This is because there is a bug in trunk where some format boxes are flushed instead of being closed properly.

Here is the output with the PR:

```
MATCHING
MATCH Total
PM:
  Some (x, y) 
  None 
CTX:
  LEFT RIGHT <_> 
COMPILE:
  MATCH Total
  PM:
    (x, y) 
  CTX:
    LEFT <Some _> RIGHT <_> 
  COMPILE:
    MATCH Total
    PM:
      _ y 
    CTX:
      LEFT <(_, _)> <Some _> RIGHT <_> <_> 
    COMPILE:
      MATCH Total
      PM:
        _ 
      CTX:
        LEFT <_> <(_, _)> <Some _> RIGHT <_> 
      COMPILE:
        empty matrix
      NO JUMPS
    NO JUMPS
  NO JUMPS
  empty matrix
NO JUMPS
(setglobal Dbg1!
  (let
    (test/269 =
       (function param/273 : int
         (if param/273
           (let (*match*/275 =a (field_imm 0 param/273))
             (+ (field_imm 0 *match*/275) (field_imm 1 *match*/275)))
           0)))
    (makeblock 0 test/269)))
```

The tree structure is apparent in the output, and the unclosed-boxes issue is gone.