### PR TITLE
Restore a call to `instance` that was dropped in #12236

### DIFF
--- a/Changes
+++ b/Changes
@@ -261,6 +261,9 @@ Working version
   (Nick Roberts; review by Richard Eisenberg, Leo White, and Gabriel Scherer;
   RFC by Stephen Dolan)
 
+- #12542: Minor bugfix to #12236: restore dropped call to `instance`
+  (Nick Roberts, review by Jacques Garrigue)
+
 - #12242: Move the computation of stack frame parameters to a separate
   `Stackframe` module, and save the parameters in the results of the
   `Linearize` pass

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -3807,8 +3807,9 @@ and type_expect_
         exp_attributes = sexp.pexp_attributes;
         exp_env = env }
   | Pexp_constraint (sarg, sty) ->
-      let (ty', exp_extra) = type_constraint env sty in
-      let arg = type_argument env sarg ty' (instance ty') in
+      let (ty, exp_extra) = type_constraint env sty in
+      let ty' = instance ty in
+      let arg = type_argument env sarg ty (instance ty) in
       rue {
         exp_desc = arg.exp_desc;
         exp_loc = arg.exp_loc;

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -3808,12 +3808,11 @@ and type_expect_
         exp_env = env }
   | Pexp_constraint (sarg, sty) ->
       let (ty, exp_extra) = type_constraint env sty in
-      let ty' = instance ty in
       let arg = type_argument env sarg ty (instance ty) in
       rue {
         exp_desc = arg.exp_desc;
         exp_loc = arg.exp_loc;
-        exp_type = ty';
+        exp_type = instance ty;
         exp_attributes = arg.exp_attributes;
         exp_env = env;
         exp_extra = (exp_extra, loc, sexp.pexp_attributes) :: arg.exp_extra;


### PR DESCRIPTION
#12236 dropped a possibly-load-bearing call to `instance` from the type-checking of `Pexp_constraint`: [see the second component of the tuple on this removed line](https://github.com/ocaml/ocaml/pull/12236/files#diff-154f81eaa30645133fc97f3cd10102b14c29295eff4e36cb8982a33ae884b3d7L3717). This PR restores it.

I am unable to find a way that this change matters. I happened to notice the discrepancy while reading through #12236 for a related change internal to Jane Street. The main difference between pre-#12236 and post-#12236 code that I can think of is:
  * pre-#12236, the `exp_type` field of the result of type-checking `Pexp_constraint` was an instance of a possibly-generic type. (In particular, it was this result of this now-restored call to `instance`.)
  * post-#12236, the `exp_type` field of the result of type-checking `Pexp_constraint` can possibly be a type with generic level (and not an instance thereof).

I've been unable to find a way that this discrepancy results in a change in principality warnings/errors/etc. It's possible this current PR is just not needed! Either this call to `instance` is needed and this PR fixes an unintentional change in behavior, or it's not needed and I'll have learned something new about the type-checker.