### PR TITLE
Fix cmi lookup after #12389 

### DIFF
--- a/Changes
+++ b/Changes
@@ -277,7 +277,7 @@ Working version
   bytecode executable (`ocamlc -custom`).
   (Antonin Décimo, review by Xavier Leroy)
 
-- #12389, centralize the handling of metadata for compilation units and
+- #12389, #12544: centralize the handling of metadata for compilation units and
   artifacts in preparation for better unicode support for OCaml source files.
   (Florian Angeletti, review by Gabriel Scherer)
 

--- a/parsing/unit_info.ml
+++ b/parsing/unit_info.ml
@@ -114,6 +114,6 @@ let mli_from_source u =
 let is_cmi f = Filename.check_suffix (Artifact.filename f) ".cmi"
 
 let find_normalized_cmi f =
-  let filename = prefix f ^ ".cmi" in
+  let filename = modname f ^ ".cmi" in
   let filename = Load_path.find_normalized filename in
   { Artifact.filename; modname = modname f; source_file = Some f.source_file  }


### PR DESCRIPTION
The PR #12389  restricted the lookup for cmi file when compiling `pa/th/name.mid.ml` to  `{P,p}a/th/name.mid.ml` which is a far too strict behavior.

This PR restores the intending behavior by looking for any cmi file in the load paths whose basename normalize to "name.cmi".