### PR TITLE
manual, doc: try to reduce confusion between character and byte

### DIFF
--- a/manual/src/library/builtin.etex
+++ b/manual/src/library/builtin.etex
@@ -22,7 +22,12 @@ consequence, they can only be referred by their short names.
 \end{ocamldoccode}
 \index{char@\verb`char`}
 \begin{ocamldocdescription}
-   The type of characters.
+  The type of bytes, historically referred to as characters.
+  A byte is an 8-bit unit of arbitrary data,
+  commonly used to represent a character
+  from a restricted charset such as ASCII or Latin-1.
+  However it cannot represent an arbitrary Unicode character
+  (see modules \stdmoduleref{Uchar} and \stdmoduleref{String}).
 \end{ocamldocdescription}
 
 \begin{ocamldoccode}

--- a/manual/src/tutorials/coreexamples.etex
+++ b/manual/src/tutorials/coreexamples.etex
@@ -57,7 +57,7 @@ usual basic data types:
 (1 < 2) = false;;
 let one = if true then 1 else 2;;
 \end{caml_example}
-\item characters
+\item characters (or more accurately, bytes)
 \begin{caml_example}{toplevel}
  'a';;
  int_of_char '\n';;

--- a/manual/src/tutorials/moduleexamples.etex
+++ b/manual/src/tutorials/moduleexamples.etex
@@ -283,7 +283,7 @@ Abstracting a type component in a functor result is a powerful
 technique that provides a high degree of type safety, as we now
 illustrate. Consider an ordering over character strings that is
 different from the standard ordering implemented in the
-"OrderedString" structure. For instance, we compare strings without
+"OrderedString" structure. For instance, we compare ASCII strings without
 distinguishing upper and lower case.
 \begin{caml_example}{toplevel}
 module NoCaseString =

--- a/stdlib/bytes.mli
+++ b/stdlib/bytes.mli
@@ -79,7 +79,7 @@ val make : int -> char -> bytes
 
 val init : int -> (int -> char) -> bytes
 (** [init n f] returns a fresh byte sequence of length [n],
-    with character [i] initialized to the result of [f i] (in increasing
+    with byte [i] initialized to the result of [f i] (in increasing
     index order).
     @raise Invalid_argument if [n < 0] or [n > ]{!Sys.max_string_length}. *)
 
@@ -120,7 +120,7 @@ val extend : bytes -> int -> int -> bytes
 
 val fill : bytes -> int -> int -> char -> unit
 (** [fill s pos len c] modifies [s] in place, replacing [len]
-    characters with [c], starting at [pos].
+    bytes with [c], starting at [pos].
     @raise Invalid_argument if [pos] and [len] do not designate a
     valid range of [s]. *)
 
@@ -178,7 +178,7 @@ val map : (char -> char) -> bytes -> bytes
     that is returned as the result. *)
 
 val mapi : (int -> char -> char) -> bytes -> bytes
-(** [mapi f s] calls [f] with each character of [s] and its
+(** [mapi f s] calls [f] with each byte of [s] and its
     index (in increasing index order) and stores the resulting bytes
     in a new sequence that is returned as the result. *)
 
@@ -195,11 +195,11 @@ val fold_right : (char -> 'acc -> 'acc) -> bytes -> 'acc -> 'acc
     @since 4.13 *)
 
 val for_all : (char -> bool) -> bytes -> bool
-(** [for_all p s] checks if all characters in [s] satisfy the predicate [p].
+(** [for_all p s] checks if all bytes in [s] satisfy the predicate [p].
     @since 4.13 *)
 
 val exists : (char -> bool) -> bytes -> bool
-(** [exists p s] checks if at least one character of [s] satisfies the predicate
+(** [exists p s] checks if at least one byte of [s] satisfies the predicate
     [p].
     @since 4.13 *)
 
@@ -211,7 +211,7 @@ val trim : bytes -> bytes
 val escaped : bytes -> bytes
 (** Return a copy of the argument, with special characters represented
     by escape sequences, following the lexical conventions of OCaml.
-    All characters outside the ASCII printable range (32..126) are
+    All bytes outside the ASCII printable range (32..126) are
     escaped, as well as backslash and double-quote.
     @raise Invalid_argument if the result is longer than
     {!Sys.max_string_length} bytes. *)
@@ -459,7 +459,7 @@ let s = Bytes.of_string "hello"
 
 val split_on_char: char -> bytes -> bytes list
 (** [split_on_char sep s] returns the list of all (possibly empty)
-    subsequences of [s] that are delimited by the [sep] character.
+    subsequences of [s] that are delimited by the [sep] byte.
 
     The function's output is specified by the following invariants:
 
@@ -467,7 +467,7 @@ val split_on_char: char -> bytes -> bytes list
     - Concatenating its elements using [sep] as a separator returns a
       byte sequence equal to the input ([Bytes.concat (Bytes.make 1 sep)
       (Bytes.split_on_char sep s) = s]).
-    - No byte sequence in the result contains the [sep] character.
+    - No byte sequence in the result contains the [sep] byte.
 
     @since 4.13
 *)

--- a/stdlib/bytes.mli
+++ b/stdlib/bytes.mli
@@ -494,11 +494,11 @@ val of_seq : char Seq.t -> t
 (** {2:utf_8 UTF-8} *)
 
 val get_utf_8_uchar : t -> int -> Uchar.utf_decode
-(** [get_utf_8_uchar b i] decodes an UTF-8 character at index [i] in
+(** [get_utf_8_uchar b i] decodes an UTF-8 character at byte index [i] in
     [b]. *)
 
 val set_utf_8_uchar : t -> int -> Uchar.t -> int
-(** [set_utf_8_uchar b i u] UTF-8 encodes [u] at index [i] in [b]
+(** [set_utf_8_uchar b i u] UTF-8 encodes [u] at byte index [i] in [b]
     and returns the number of bytes [n] that were written starting
     at [i]. If [n] is [0] there was not enough space to encode [u]
     at [i] and [b] was left untouched. Otherwise a new character can
@@ -511,11 +511,11 @@ val is_valid_utf_8 : t -> bool
 (** {2:utf_16be UTF-16BE} *)
 
 val get_utf_16be_uchar : t -> int -> Uchar.utf_decode
-(** [get_utf_16be_uchar b i] decodes an UTF-16BE character at index
+(** [get_utf_16be_uchar b i] decodes an UTF-16BE character at byte index
     [i] in [b]. *)
 
 val set_utf_16be_uchar : t -> int -> Uchar.t -> int
-(** [set_utf_16be_uchar b i u] UTF-16BE encodes [u] at index [i] in [b]
+(** [set_utf_16be_uchar b i u] UTF-16BE encodes [u] at byte index [i] in [b]
     and returns the number of bytes [n] that were written starting
     at [i]. If [n] is [0] there was not enough space to encode [u]
     at [i] and [b] was left untouched. Otherwise a new character can
@@ -528,11 +528,11 @@ val is_valid_utf_16be : t -> bool
 (** {2:utf_16le UTF-16LE} *)
 
 val get_utf_16le_uchar : t -> int -> Uchar.utf_decode
-(** [get_utf_16le_uchar b i] decodes an UTF-16LE character at index
+(** [get_utf_16le_uchar b i] decodes an UTF-16LE character at byte index
     [i] in [b]. *)
 
 val set_utf_16le_uchar : t -> int -> Uchar.t -> int
-(** [set_utf_16le_uchar b i u] UTF-16LE encodes [u] at index [i] in [b]
+(** [set_utf_16le_uchar b i u] UTF-16LE encodes [u] at byte index [i] in [b]
     and returns the number of bytes [n] that were written starting
     at [i]. If [n] is [0] there was not enough space to encode [u]
     at [i] and [b] was left untouched. Otherwise a new character can
@@ -548,7 +548,7 @@ val is_valid_utf_16le : t -> bool
     and from byte sequences.
 
     All following functions raise [Invalid_argument] if the space
-    needed at index [i] to decode or encode the integer is not
+    needed at byte index [i] to decode or encode the integer is not
     available.
 
     Little-endian (resp. big-endian) encoding means that least

--- a/stdlib/bytes.mli
+++ b/stdlib/bytes.mli
@@ -40,8 +40,9 @@
    range of [s] if [len >= 0] and [start] and [start+len] are valid
    positions in [s].
 
-   Byte sequences can be modified in place, for instance via the [set]
-   and [blit] functions described below.  See also strings (module
+   Byte sequences can be modified in place, for instance via the
+   {!set}, {!blit} or {!set_utf_8_uchar} functions described below.
+   See also strings (module
    {!String}), which are almost the same data structure, but cannot be
    modified in place.
 

--- a/stdlib/bytes.mli
+++ b/stdlib/bytes.mli
@@ -328,165 +328,6 @@ val ends_with :
 
     @since 4.13 *)
 
-(** {1:unsafe Unsafe conversions (for advanced users)}
-
-    This section describes unsafe, low-level conversion functions
-    between [bytes] and [string]. They do not copy the internal data;
-    used improperly, they can break the immutability invariant on
-    strings provided by the [-safe-string] option. They are available for
-    expert library authors, but for most purposes you should use the
-    always-correct {!to_string} and {!of_string} instead.
-*)
-
-val unsafe_to_string : bytes -> string
-(** Unsafely convert a byte sequence into a string.
-
-    To reason about the use of [unsafe_to_string], it is convenient to
-    consider an "ownership" discipline. A piece of code that
-    manipulates some data "owns" it; there are several disjoint ownership
-    modes, including:
-    - Unique ownership: the data may be accessed and mutated
-    - Shared ownership: the data has several owners, that may only
-      access it, not mutate it.
-
-    Unique ownership is linear: passing the data to another piece of
-    code means giving up ownership (we cannot write the
-    data again). A unique owner may decide to make the data shared
-    (giving up mutation rights on it), but shared data may not become
-    uniquely-owned again.
-
-   [unsafe_to_string s] can only be used when the caller owns the byte
-   sequence [s] -- either uniquely or as shared immutable data. The
-   caller gives up ownership of [s], and gains ownership of the
-   returned string.
-
-   There are two valid use-cases that respect this ownership
-   discipline:
-
-   1. Creating a string by initializing and mutating a byte sequence
-   that is never changed after initialization is performed.
-
-   {[
-let string_init len f : string =
-  let s = Bytes.create len in
-  for i = 0 to len - 1 do Bytes.set s i (f i) done;
-  Bytes.unsafe_to_string s
-   ]}
-
-   This function is safe because the byte sequence [s] will never be
-   accessed or mutated after [unsafe_to_string] is called. The
-   [string_init] code gives up ownership of [s], and returns the
-   ownership of the resulting string to its caller.
-
-   Note that it would be unsafe if [s] was passed as an additional
-   parameter to the function [f] as it could escape this way and be
-   mutated in the future -- [string_init] would give up ownership of
-   [s] to pass it to [f], and could not call [unsafe_to_string]
-   safely.
-
-   We have provided the {!String.init}, {!String.map} and
-   {!String.mapi} functions to cover most cases of building
-   new strings. You should prefer those over [to_string] or
-   [unsafe_to_string] whenever applicable.
-
-   2. Temporarily giving ownership of a byte sequence to a function
-   that expects a uniquely owned string and returns ownership back, so
-   that we can mutate the sequence again after the call ended.
-
-   {[
-let bytes_length (s : bytes) =
-  String.length (Bytes.unsafe_to_string s)
-   ]}
-
-   In this use-case, we do not promise that [s] will never be mutated
-   after the call to [bytes_length s]. The {!String.length} function
-   temporarily borrows unique ownership of the byte sequence
-   (and sees it as a [string]), but returns this ownership back to
-   the caller, which may assume that [s] is still a valid byte
-   sequence after the call. Note that this is only correct because we
-   know that {!String.length} does not capture its argument -- it could
-   escape by a side-channel such as a memoization combinator.
-
-   The caller may not mutate [s] while the string is borrowed (it has
-   temporarily given up ownership). This affects concurrent programs,
-   but also higher-order functions: if {!String.length} returned
-   a closure to be called later, [s] should not be mutated until this
-   closure is fully applied and returns ownership.
-*)
-
-val unsafe_of_string : string -> bytes
-(** Unsafely convert a shared string to a byte sequence that should
-    not be mutated.
-
-    The same ownership discipline that makes [unsafe_to_string]
-    correct applies to [unsafe_of_string]: you may use it if you were
-    the owner of the [string] value, and you will own the return
-    [bytes] in the same mode.
-
-    In practice, unique ownership of string values is extremely
-    difficult to reason about correctly. You should always assume
-    strings are shared, never uniquely owned.
-
-    For example, string literals are implicitly shared by the
-    compiler, so you never uniquely own them.
-
-    {[
-let incorrect = Bytes.unsafe_of_string "hello"
-let s = Bytes.of_string "hello"
-    ]}
-
-    The first declaration is incorrect, because the string literal
-    ["hello"] could be shared by the compiler with other parts of the
-    program, and mutating [incorrect] is a bug. You must always use
-    the second version, which performs a copy and is thus correct.
-
-    Assuming unique ownership of strings that are not string
-    literals, but are (partly) built from string literals, is also
-    incorrect. For example, mutating [unsafe_of_string ("foo" ^ s)]
-    could mutate the shared string ["foo"] -- assuming a rope-like
-    representation of strings. More generally, functions operating on
-    strings will assume shared ownership, they do not preserve unique
-    ownership. It is thus incorrect to assume unique ownership of the
-    result of [unsafe_of_string].
-
-    The only case we have reasonable confidence is safe is if the
-    produced [bytes] is shared -- used as an immutable byte
-    sequence. This is possibly useful for incremental migration of
-    low-level programs that manipulate immutable sequences of bytes
-    (for example {!Marshal.from_bytes}) and previously used the
-    [string] type for this purpose.
-*)
-
-
-val split_on_char: char -> bytes -> bytes list
-(** [split_on_char sep s] returns the list of all (possibly empty)
-    subsequences of [s] that are delimited by the [sep] byte.
-
-    The function's output is specified by the following invariants:
-
-    - The list is not empty.
-    - Concatenating its elements using [sep] as a separator returns a
-      byte sequence equal to the input ([Bytes.concat (Bytes.make 1 sep)
-      (Bytes.split_on_char sep s) = s]).
-    - No byte sequence in the result contains the [sep] byte.
-
-    @since 4.13
-*)
-
-(** {1 Iterators} *)
-
-val to_seq : t -> char Seq.t
-(** Iterate on the string, in increasing index order. Modifications of the
-    string during iteration will be reflected in the sequence.
-    @since 4.07 *)
-
-val to_seqi : t -> (int * char) Seq.t
-(** Iterate on the string, in increasing order, yielding indices along chars
-    @since 4.07 *)
-
-val of_seq : char Seq.t -> t
-(** Create a string from the generator
-    @since 4.07 *)
 
 (** {1:utf UTF codecs and validations}
 
@@ -542,6 +383,7 @@ val set_utf_16le_uchar : t -> int -> Uchar.t -> int
 val is_valid_utf_16le : t -> bool
 (** [is_valid_utf_16le b] is [true] if and only if [b] contains valid
     UTF-16LE data. *)
+
 
 (** {1 Binary encoding/decoding of integers} *)
 
@@ -737,6 +579,168 @@ val set_int64_le : bytes -> int -> int64 -> unit
 (** [set_int64_le b i v] sets [b]'s little-endian 64-bit integer
     starting at byte index [i] to [v].
     @since 4.08
+*)
+
+
+(** {1 Iterators} *)
+
+val to_seq : t -> char Seq.t
+(** Iterate on the string, in increasing index order. Modifications of the
+    string during iteration will be reflected in the sequence.
+    @since 4.07 *)
+
+val to_seqi : t -> (int * char) Seq.t
+(** Iterate on the string, in increasing order, yielding indices along chars
+    @since 4.07 *)
+
+val of_seq : char Seq.t -> t
+(** Create a string from the generator
+    @since 4.07 *)
+
+
+(** {1:unsafe Unsafe conversions (for advanced users)}
+
+    This section describes unsafe, low-level conversion functions
+    between [bytes] and [string]. They do not copy the internal data;
+    used improperly, they can break the immutability invariant on
+    strings provided by the [-safe-string] option. They are available for
+    expert library authors, but for most purposes you should use the
+    always-correct {!to_string} and {!of_string} instead.
+*)
+
+val unsafe_to_string : bytes -> string
+(** Unsafely convert a byte sequence into a string.
+
+    To reason about the use of [unsafe_to_string], it is convenient to
+    consider an "ownership" discipline. A piece of code that
+    manipulates some data "owns" it; there are several disjoint ownership
+    modes, including:
+    - Unique ownership: the data may be accessed and mutated
+    - Shared ownership: the data has several owners, that may only
+      access it, not mutate it.
+
+    Unique ownership is linear: passing the data to another piece of
+    code means giving up ownership (we cannot write the
+    data again). A unique owner may decide to make the data shared
+    (giving up mutation rights on it), but shared data may not become
+    uniquely-owned again.
+
+   [unsafe_to_string s] can only be used when the caller owns the byte
+   sequence [s] -- either uniquely or as shared immutable data. The
+   caller gives up ownership of [s], and gains ownership of the
+   returned string.
+
+   There are two valid use-cases that respect this ownership
+   discipline:
+
+   1. Creating a string by initializing and mutating a byte sequence
+   that is never changed after initialization is performed.
+
+   {[
+let string_init len f : string =
+  let s = Bytes.create len in
+  for i = 0 to len - 1 do Bytes.set s i (f i) done;
+  Bytes.unsafe_to_string s
+   ]}
+
+   This function is safe because the byte sequence [s] will never be
+   accessed or mutated after [unsafe_to_string] is called. The
+   [string_init] code gives up ownership of [s], and returns the
+   ownership of the resulting string to its caller.
+
+   Note that it would be unsafe if [s] was passed as an additional
+   parameter to the function [f] as it could escape this way and be
+   mutated in the future -- [string_init] would give up ownership of
+   [s] to pass it to [f], and could not call [unsafe_to_string]
+   safely.
+
+   We have provided the {!String.init}, {!String.map} and
+   {!String.mapi} functions to cover most cases of building
+   new strings. You should prefer those over [to_string] or
+   [unsafe_to_string] whenever applicable.
+
+   2. Temporarily giving ownership of a byte sequence to a function
+   that expects a uniquely owned string and returns ownership back, so
+   that we can mutate the sequence again after the call ended.
+
+   {[
+let bytes_length (s : bytes) =
+  String.length (Bytes.unsafe_to_string s)
+   ]}
+
+   In this use-case, we do not promise that [s] will never be mutated
+   after the call to [bytes_length s]. The {!String.length} function
+   temporarily borrows unique ownership of the byte sequence
+   (and sees it as a [string]), but returns this ownership back to
+   the caller, which may assume that [s] is still a valid byte
+   sequence after the call. Note that this is only correct because we
+   know that {!String.length} does not capture its argument -- it could
+   escape by a side-channel such as a memoization combinator.
+
+   The caller may not mutate [s] while the string is borrowed (it has
+   temporarily given up ownership). This affects concurrent programs,
+   but also higher-order functions: if {!String.length} returned
+   a closure to be called later, [s] should not be mutated until this
+   closure is fully applied and returns ownership.
+*)
+
+val unsafe_of_string : string -> bytes
+(** Unsafely convert a shared string to a byte sequence that should
+    not be mutated.
+
+    The same ownership discipline that makes [unsafe_to_string]
+    correct applies to [unsafe_of_string]: you may use it if you were
+    the owner of the [string] value, and you will own the return
+    [bytes] in the same mode.
+
+    In practice, unique ownership of string values is extremely
+    difficult to reason about correctly. You should always assume
+    strings are shared, never uniquely owned.
+
+    For example, string literals are implicitly shared by the
+    compiler, so you never uniquely own them.
+
+    {[
+let incorrect = Bytes.unsafe_of_string "hello"
+let s = Bytes.of_string "hello"
+    ]}
+
+    The first declaration is incorrect, because the string literal
+    ["hello"] could be shared by the compiler with other parts of the
+    program, and mutating [incorrect] is a bug. You must always use
+    the second version, which performs a copy and is thus correct.
+
+    Assuming unique ownership of strings that are not string
+    literals, but are (partly) built from string literals, is also
+    incorrect. For example, mutating [unsafe_of_string ("foo" ^ s)]
+    could mutate the shared string ["foo"] -- assuming a rope-like
+    representation of strings. More generally, functions operating on
+    strings will assume shared ownership, they do not preserve unique
+    ownership. It is thus incorrect to assume unique ownership of the
+    result of [unsafe_of_string].
+
+    The only case we have reasonable confidence is safe is if the
+    produced [bytes] is shared -- used as an immutable byte
+    sequence. This is possibly useful for incremental migration of
+    low-level programs that manipulate immutable sequences of bytes
+    (for example {!Marshal.from_bytes}) and previously used the
+    [string] type for this purpose.
+*)
+
+
+val split_on_char: char -> bytes -> bytes list
+(** [split_on_char sep s] returns the list of all (possibly empty)
+    subsequences of [s] that are delimited by the [sep] byte.
+
+    The function's output is specified by the following invariants:
+
+    - The list is not empty.
+    - Concatenating its elements using [sep] as a separator returns a
+      byte sequence equal to the input ([Bytes.concat (Bytes.make 1 sep)
+      (Bytes.split_on_char sep s) = s]).
+    - No byte sequence in the result contains the [sep] byte.
+
+    @since 4.13
 *)
 
 

--- a/stdlib/bytesLabels.mli
+++ b/stdlib/bytesLabels.mli
@@ -494,11 +494,11 @@ val of_seq : char Seq.t -> t
 (** {2:utf_8 UTF-8} *)
 
 val get_utf_8_uchar : t -> int -> Uchar.utf_decode
-(** [get_utf_8_uchar b i] decodes an UTF-8 character at index [i] in
+(** [get_utf_8_uchar b i] decodes an UTF-8 character at byte index [i] in
     [b]. *)
 
 val set_utf_8_uchar : t -> int -> Uchar.t -> int
-(** [set_utf_8_uchar b i u] UTF-8 encodes [u] at index [i] in [b]
+(** [set_utf_8_uchar b i u] UTF-8 encodes [u] at byte index [i] in [b]
     and returns the number of bytes [n] that were written starting
     at [i]. If [n] is [0] there was not enough space to encode [u]
     at [i] and [b] was left untouched. Otherwise a new character can
@@ -511,11 +511,11 @@ val is_valid_utf_8 : t -> bool
 (** {2:utf_16be UTF-16BE} *)
 
 val get_utf_16be_uchar : t -> int -> Uchar.utf_decode
-(** [get_utf_16be_uchar b i] decodes an UTF-16BE character at index
+(** [get_utf_16be_uchar b i] decodes an UTF-16BE character at byte index
     [i] in [b]. *)
 
 val set_utf_16be_uchar : t -> int -> Uchar.t -> int
-(** [set_utf_16be_uchar b i u] UTF-16BE encodes [u] at index [i] in [b]
+(** [set_utf_16be_uchar b i u] UTF-16BE encodes [u] at byte index [i] in [b]
     and returns the number of bytes [n] that were written starting
     at [i]. If [n] is [0] there was not enough space to encode [u]
     at [i] and [b] was left untouched. Otherwise a new character can
@@ -528,11 +528,11 @@ val is_valid_utf_16be : t -> bool
 (** {2:utf_16le UTF-16LE} *)
 
 val get_utf_16le_uchar : t -> int -> Uchar.utf_decode
-(** [get_utf_16le_uchar b i] decodes an UTF-16LE character at index
+(** [get_utf_16le_uchar b i] decodes an UTF-16LE character at byte index
     [i] in [b]. *)
 
 val set_utf_16le_uchar : t -> int -> Uchar.t -> int
-(** [set_utf_16le_uchar b i u] UTF-16LE encodes [u] at index [i] in [b]
+(** [set_utf_16le_uchar b i u] UTF-16LE encodes [u] at byte index [i] in [b]
     and returns the number of bytes [n] that were written starting
     at [i]. If [n] is [0] there was not enough space to encode [u]
     at [i] and [b] was left untouched. Otherwise a new character can
@@ -548,7 +548,7 @@ val is_valid_utf_16le : t -> bool
     and from byte sequences.
 
     All following functions raise [Invalid_argument] if the space
-    needed at index [i] to decode or encode the integer is not
+    needed at byte index [i] to decode or encode the integer is not
     available.
 
     Little-endian (resp. big-endian) encoding means that least

--- a/stdlib/bytesLabels.mli
+++ b/stdlib/bytesLabels.mli
@@ -40,8 +40,9 @@
    range of [s] if [len >= 0] and [start] and [start+len] are valid
    positions in [s].
 
-   Byte sequences can be modified in place, for instance via the [set]
-   and [blit] functions described below.  See also strings (module
+   Byte sequences can be modified in place, for instance via the
+   {!set}, {!blit} or {!set_utf_8_uchar} functions described below.
+   See also strings (module
    {!String}), which are almost the same data structure, but cannot be
    modified in place.
 

--- a/stdlib/bytesLabels.mli
+++ b/stdlib/bytesLabels.mli
@@ -328,165 +328,6 @@ val ends_with :
 
     @since 4.13 *)
 
-(** {1:unsafe Unsafe conversions (for advanced users)}
-
-    This section describes unsafe, low-level conversion functions
-    between [bytes] and [string]. They do not copy the internal data;
-    used improperly, they can break the immutability invariant on
-    strings provided by the [-safe-string] option. They are available for
-    expert library authors, but for most purposes you should use the
-    always-correct {!to_string} and {!of_string} instead.
-*)
-
-val unsafe_to_string : bytes -> string
-(** Unsafely convert a byte sequence into a string.
-
-    To reason about the use of [unsafe_to_string], it is convenient to
-    consider an "ownership" discipline. A piece of code that
-    manipulates some data "owns" it; there are several disjoint ownership
-    modes, including:
-    - Unique ownership: the data may be accessed and mutated
-    - Shared ownership: the data has several owners, that may only
-      access it, not mutate it.
-
-    Unique ownership is linear: passing the data to another piece of
-    code means giving up ownership (we cannot write the
-    data again). A unique owner may decide to make the data shared
-    (giving up mutation rights on it), but shared data may not become
-    uniquely-owned again.
-
-   [unsafe_to_string s] can only be used when the caller owns the byte
-   sequence [s] -- either uniquely or as shared immutable data. The
-   caller gives up ownership of [s], and gains ownership of the
-   returned string.
-
-   There are two valid use-cases that respect this ownership
-   discipline:
-
-   1. Creating a string by initializing and mutating a byte sequence
-   that is never changed after initialization is performed.
-
-   {[
-let string_init len f : string =
-  let s = Bytes.create len in
-  for i = 0 to len - 1 do Bytes.set s i (f i) done;
-  Bytes.unsafe_to_string s
-   ]}
-
-   This function is safe because the byte sequence [s] will never be
-   accessed or mutated after [unsafe_to_string] is called. The
-   [string_init] code gives up ownership of [s], and returns the
-   ownership of the resulting string to its caller.
-
-   Note that it would be unsafe if [s] was passed as an additional
-   parameter to the function [f] as it could escape this way and be
-   mutated in the future -- [string_init] would give up ownership of
-   [s] to pass it to [f], and could not call [unsafe_to_string]
-   safely.
-
-   We have provided the {!String.init}, {!String.map} and
-   {!String.mapi} functions to cover most cases of building
-   new strings. You should prefer those over [to_string] or
-   [unsafe_to_string] whenever applicable.
-
-   2. Temporarily giving ownership of a byte sequence to a function
-   that expects a uniquely owned string and returns ownership back, so
-   that we can mutate the sequence again after the call ended.
-
-   {[
-let bytes_length (s : bytes) =
-  String.length (Bytes.unsafe_to_string s)
-   ]}
-
-   In this use-case, we do not promise that [s] will never be mutated
-   after the call to [bytes_length s]. The {!String.length} function
-   temporarily borrows unique ownership of the byte sequence
-   (and sees it as a [string]), but returns this ownership back to
-   the caller, which may assume that [s] is still a valid byte
-   sequence after the call. Note that this is only correct because we
-   know that {!String.length} does not capture its argument -- it could
-   escape by a side-channel such as a memoization combinator.
-
-   The caller may not mutate [s] while the string is borrowed (it has
-   temporarily given up ownership). This affects concurrent programs,
-   but also higher-order functions: if {!String.length} returned
-   a closure to be called later, [s] should not be mutated until this
-   closure is fully applied and returns ownership.
-*)
-
-val unsafe_of_string : string -> bytes
-(** Unsafely convert a shared string to a byte sequence that should
-    not be mutated.
-
-    The same ownership discipline that makes [unsafe_to_string]
-    correct applies to [unsafe_of_string]: you may use it if you were
-    the owner of the [string] value, and you will own the return
-    [bytes] in the same mode.
-
-    In practice, unique ownership of string values is extremely
-    difficult to reason about correctly. You should always assume
-    strings are shared, never uniquely owned.
-
-    For example, string literals are implicitly shared by the
-    compiler, so you never uniquely own them.
-
-    {[
-let incorrect = Bytes.unsafe_of_string "hello"
-let s = Bytes.of_string "hello"
-    ]}
-
-    The first declaration is incorrect, because the string literal
-    ["hello"] could be shared by the compiler with other parts of the
-    program, and mutating [incorrect] is a bug. You must always use
-    the second version, which performs a copy and is thus correct.
-
-    Assuming unique ownership of strings that are not string
-    literals, but are (partly) built from string literals, is also
-    incorrect. For example, mutating [unsafe_of_string ("foo" ^ s)]
-    could mutate the shared string ["foo"] -- assuming a rope-like
-    representation of strings. More generally, functions operating on
-    strings will assume shared ownership, they do not preserve unique
-    ownership. It is thus incorrect to assume unique ownership of the
-    result of [unsafe_of_string].
-
-    The only case we have reasonable confidence is safe is if the
-    produced [bytes] is shared -- used as an immutable byte
-    sequence. This is possibly useful for incremental migration of
-    low-level programs that manipulate immutable sequences of bytes
-    (for example {!Marshal.from_bytes}) and previously used the
-    [string] type for this purpose.
-*)
-
-
-val split_on_char: sep:char -> bytes -> bytes list
-(** [split_on_char sep s] returns the list of all (possibly empty)
-    subsequences of [s] that are delimited by the [sep] byte.
-
-    The function's output is specified by the following invariants:
-
-    - The list is not empty.
-    - Concatenating its elements using [sep] as a separator returns a
-      byte sequence equal to the input ([Bytes.concat (Bytes.make 1 sep)
-      (Bytes.split_on_char sep s) = s]).
-    - No byte sequence in the result contains the [sep] byte.
-
-    @since 4.13
-*)
-
-(** {1 Iterators} *)
-
-val to_seq : t -> char Seq.t
-(** Iterate on the string, in increasing index order. Modifications of the
-    string during iteration will be reflected in the sequence.
-    @since 4.07 *)
-
-val to_seqi : t -> (int * char) Seq.t
-(** Iterate on the string, in increasing order, yielding indices along chars
-    @since 4.07 *)
-
-val of_seq : char Seq.t -> t
-(** Create a string from the generator
-    @since 4.07 *)
 
 (** {1:utf UTF codecs and validations}
 
@@ -542,6 +383,7 @@ val set_utf_16le_uchar : t -> int -> Uchar.t -> int
 val is_valid_utf_16le : t -> bool
 (** [is_valid_utf_16le b] is [true] if and only if [b] contains valid
     UTF-16LE data. *)
+
 
 (** {1 Binary encoding/decoding of integers} *)
 
@@ -737,6 +579,168 @@ val set_int64_le : bytes -> int -> int64 -> unit
 (** [set_int64_le b i v] sets [b]'s little-endian 64-bit integer
     starting at byte index [i] to [v].
     @since 4.08
+*)
+
+
+(** {1 Iterators} *)
+
+val to_seq : t -> char Seq.t
+(** Iterate on the string, in increasing index order. Modifications of the
+    string during iteration will be reflected in the sequence.
+    @since 4.07 *)
+
+val to_seqi : t -> (int * char) Seq.t
+(** Iterate on the string, in increasing order, yielding indices along chars
+    @since 4.07 *)
+
+val of_seq : char Seq.t -> t
+(** Create a string from the generator
+    @since 4.07 *)
+
+
+(** {1:unsafe Unsafe conversions (for advanced users)}
+
+    This section describes unsafe, low-level conversion functions
+    between [bytes] and [string]. They do not copy the internal data;
+    used improperly, they can break the immutability invariant on
+    strings provided by the [-safe-string] option. They are available for
+    expert library authors, but for most purposes you should use the
+    always-correct {!to_string} and {!of_string} instead.
+*)
+
+val unsafe_to_string : bytes -> string
+(** Unsafely convert a byte sequence into a string.
+
+    To reason about the use of [unsafe_to_string], it is convenient to
+    consider an "ownership" discipline. A piece of code that
+    manipulates some data "owns" it; there are several disjoint ownership
+    modes, including:
+    - Unique ownership: the data may be accessed and mutated
+    - Shared ownership: the data has several owners, that may only
+      access it, not mutate it.
+
+    Unique ownership is linear: passing the data to another piece of
+    code means giving up ownership (we cannot write the
+    data again). A unique owner may decide to make the data shared
+    (giving up mutation rights on it), but shared data may not become
+    uniquely-owned again.
+
+   [unsafe_to_string s] can only be used when the caller owns the byte
+   sequence [s] -- either uniquely or as shared immutable data. The
+   caller gives up ownership of [s], and gains ownership of the
+   returned string.
+
+   There are two valid use-cases that respect this ownership
+   discipline:
+
+   1. Creating a string by initializing and mutating a byte sequence
+   that is never changed after initialization is performed.
+
+   {[
+let string_init len f : string =
+  let s = Bytes.create len in
+  for i = 0 to len - 1 do Bytes.set s i (f i) done;
+  Bytes.unsafe_to_string s
+   ]}
+
+   This function is safe because the byte sequence [s] will never be
+   accessed or mutated after [unsafe_to_string] is called. The
+   [string_init] code gives up ownership of [s], and returns the
+   ownership of the resulting string to its caller.
+
+   Note that it would be unsafe if [s] was passed as an additional
+   parameter to the function [f] as it could escape this way and be
+   mutated in the future -- [string_init] would give up ownership of
+   [s] to pass it to [f], and could not call [unsafe_to_string]
+   safely.
+
+   We have provided the {!String.init}, {!String.map} and
+   {!String.mapi} functions to cover most cases of building
+   new strings. You should prefer those over [to_string] or
+   [unsafe_to_string] whenever applicable.
+
+   2. Temporarily giving ownership of a byte sequence to a function
+   that expects a uniquely owned string and returns ownership back, so
+   that we can mutate the sequence again after the call ended.
+
+   {[
+let bytes_length (s : bytes) =
+  String.length (Bytes.unsafe_to_string s)
+   ]}
+
+   In this use-case, we do not promise that [s] will never be mutated
+   after the call to [bytes_length s]. The {!String.length} function
+   temporarily borrows unique ownership of the byte sequence
+   (and sees it as a [string]), but returns this ownership back to
+   the caller, which may assume that [s] is still a valid byte
+   sequence after the call. Note that this is only correct because we
+   know that {!String.length} does not capture its argument -- it could
+   escape by a side-channel such as a memoization combinator.
+
+   The caller may not mutate [s] while the string is borrowed (it has
+   temporarily given up ownership). This affects concurrent programs,
+   but also higher-order functions: if {!String.length} returned
+   a closure to be called later, [s] should not be mutated until this
+   closure is fully applied and returns ownership.
+*)
+
+val unsafe_of_string : string -> bytes
+(** Unsafely convert a shared string to a byte sequence that should
+    not be mutated.
+
+    The same ownership discipline that makes [unsafe_to_string]
+    correct applies to [unsafe_of_string]: you may use it if you were
+    the owner of the [string] value, and you will own the return
+    [bytes] in the same mode.
+
+    In practice, unique ownership of string values is extremely
+    difficult to reason about correctly. You should always assume
+    strings are shared, never uniquely owned.
+
+    For example, string literals are implicitly shared by the
+    compiler, so you never uniquely own them.
+
+    {[
+let incorrect = Bytes.unsafe_of_string "hello"
+let s = Bytes.of_string "hello"
+    ]}
+
+    The first declaration is incorrect, because the string literal
+    ["hello"] could be shared by the compiler with other parts of the
+    program, and mutating [incorrect] is a bug. You must always use
+    the second version, which performs a copy and is thus correct.
+
+    Assuming unique ownership of strings that are not string
+    literals, but are (partly) built from string literals, is also
+    incorrect. For example, mutating [unsafe_of_string ("foo" ^ s)]
+    could mutate the shared string ["foo"] -- assuming a rope-like
+    representation of strings. More generally, functions operating on
+    strings will assume shared ownership, they do not preserve unique
+    ownership. It is thus incorrect to assume unique ownership of the
+    result of [unsafe_of_string].
+
+    The only case we have reasonable confidence is safe is if the
+    produced [bytes] is shared -- used as an immutable byte
+    sequence. This is possibly useful for incremental migration of
+    low-level programs that manipulate immutable sequences of bytes
+    (for example {!Marshal.from_bytes}) and previously used the
+    [string] type for this purpose.
+*)
+
+
+val split_on_char: sep:char -> bytes -> bytes list
+(** [split_on_char sep s] returns the list of all (possibly empty)
+    subsequences of [s] that are delimited by the [sep] byte.
+
+    The function's output is specified by the following invariants:
+
+    - The list is not empty.
+    - Concatenating its elements using [sep] as a separator returns a
+      byte sequence equal to the input ([Bytes.concat (Bytes.make 1 sep)
+      (Bytes.split_on_char sep s) = s]).
+    - No byte sequence in the result contains the [sep] byte.
+
+    @since 4.13
 *)
 
 

--- a/stdlib/bytesLabels.mli
+++ b/stdlib/bytesLabels.mli
@@ -79,7 +79,7 @@ val make : int -> char -> bytes
 
 val init : int -> f:(int -> char) -> bytes
 (** [init n f] returns a fresh byte sequence of length [n],
-    with character [i] initialized to the result of [f i] (in increasing
+    with byte [i] initialized to the result of [f i] (in increasing
     index order).
     @raise Invalid_argument if [n < 0] or [n > ]{!Sys.max_string_length}. *)
 
@@ -120,7 +120,7 @@ val extend : bytes -> left:int -> right:int -> bytes
 
 val fill : bytes -> pos:int -> len:int -> char -> unit
 (** [fill s ~pos ~len c] modifies [s] in place, replacing [len]
-    characters with [c], starting at [pos].
+    bytes with [c], starting at [pos].
     @raise Invalid_argument if [pos] and [len] do not designate a
     valid range of [s]. *)
 
@@ -178,7 +178,7 @@ val map : f:(char -> char) -> bytes -> bytes
     that is returned as the result. *)
 
 val mapi : f:(int -> char -> char) -> bytes -> bytes
-(** [mapi ~f s] calls [f] with each character of [s] and its
+(** [mapi ~f s] calls [f] with each byte of [s] and its
     index (in increasing index order) and stores the resulting bytes
     in a new sequence that is returned as the result. *)
 
@@ -195,11 +195,11 @@ val fold_right : f:(char -> 'acc -> 'acc) -> bytes -> init:'acc -> 'acc
     @since 4.13 *)
 
 val for_all : f:(char -> bool) -> bytes -> bool
-(** [for_all p s] checks if all characters in [s] satisfy the predicate [p].
+(** [for_all p s] checks if all bytes in [s] satisfy the predicate [p].
     @since 4.13 *)
 
 val exists : f:(char -> bool) -> bytes -> bool
-(** [exists p s] checks if at least one character of [s] satisfies the predicate
+(** [exists p s] checks if at least one byte of [s] satisfies the predicate
     [p].
     @since 4.13 *)
 
@@ -211,7 +211,7 @@ val trim : bytes -> bytes
 val escaped : bytes -> bytes
 (** Return a copy of the argument, with special characters represented
     by escape sequences, following the lexical conventions of OCaml.
-    All characters outside the ASCII printable range (32..126) are
+    All bytes outside the ASCII printable range (32..126) are
     escaped, as well as backslash and double-quote.
     @raise Invalid_argument if the result is longer than
     {!Sys.max_string_length} bytes. *)
@@ -459,7 +459,7 @@ let s = Bytes.of_string "hello"
 
 val split_on_char: sep:char -> bytes -> bytes list
 (** [split_on_char sep s] returns the list of all (possibly empty)
-    subsequences of [s] that are delimited by the [sep] character.
+    subsequences of [s] that are delimited by the [sep] byte.
 
     The function's output is specified by the following invariants:
 
@@ -467,7 +467,7 @@ val split_on_char: sep:char -> bytes -> bytes list
     - Concatenating its elements using [sep] as a separator returns a
       byte sequence equal to the input ([Bytes.concat (Bytes.make 1 sep)
       (Bytes.split_on_char sep s) = s]).
-    - No byte sequence in the result contains the [sep] character.
+    - No byte sequence in the result contains the [sep] byte.
 
     @since 4.13
 *)

--- a/stdlib/in_channel.mli
+++ b/stdlib/in_channel.mli
@@ -99,18 +99,18 @@ val input_line : t -> string option
     [\r\n]. *)
 
 val really_input_string : t -> int -> string option
-(** [really_input_string ic len] reads [len] characters from channel [ic] and
+(** [really_input_string ic len] reads [len] bytes from channel [ic] and
     returns them in a new string.  Returns [None] if the end of file is reached
-    before [len] characters have been read.
+    before [len] bytes have been read.
 
     If the same channel is read concurrently by multiple threads, the returned
-    string is not guaranteed to contain contiguous characters from the input. *)
+    string is not guaranteed to contain contiguous bytes from the input. *)
 
 val input_all : t -> string
 (** [input_all ic] reads all remaining data from [ic].
 
     If the same channel is read concurrently by multiple threads, the returned
-    string is not guaranteed to contain contiguous characters from the input. *)
+    string is not guaranteed to contain contiguous bytes from the input. *)
 
 val input_lines : t -> string list
 (** [input_lines ic] reads lines using {!input_line}
@@ -124,12 +124,12 @@ val input_lines : t -> string list
 (** {1:advanced_input Advanced input}*)
 
 val input : t -> bytes -> int -> int -> int
-(** [input ic buf pos len] reads up to [len] characters from the given channel
-    [ic], storing them in byte sequence [buf], starting at character number
-    [pos]. It returns the actual number of characters read, between 0 and [len]
+(** [input ic buf pos len] reads up to [len] bytes from the given channel
+    [ic], storing them in byte sequence [buf], starting at byte number
+    [pos]. It returns the actual number of bytes read, between 0 and [len]
     (inclusive). A return value of 0 means that the end of file was reached.
 
-    Use {!really_input} to read exactly [len] characters.
+    Use {!really_input} to read exactly [len] bytes.
 
     @raise Invalid_argument if [pos] and [len] do not designate a valid range of
     [buf]. *)
@@ -141,10 +141,10 @@ val input_bigarray :
     @since 5.2 *)
 
 val really_input : t -> bytes -> int -> int -> unit option
-(** [really_input ic buf pos len] reads [len] characters from channel [ic],
-    storing them in byte sequence [buf], starting at character number [pos].
+(** [really_input ic buf pos len] reads [len] bytes from channel [ic],
+    storing them in byte sequence [buf], starting at byte number [pos].
 
-    Returns [None] if the end of file is reached before [len] characters have
+    Returns [None] if the end of file is reached before [len] bytes have
     been read.
 
     If the same channel is read concurrently by multiple threads, the bytes
@@ -190,7 +190,7 @@ val pos : t -> int64
 (** {1:attributes Attributes} *)
 
 val length : t -> int64
-(** Return the size (number of characters) of the regular file on which the
+(** Return the size (number of bytes) of the regular file on which the
     given channel is opened.  If the channel is opened on a file that is not a
     regular file, the result is meaningless.  The returned size does not take
     into account the end-of-line translations that can be performed when reading

--- a/stdlib/out_channel.mli
+++ b/stdlib/out_channel.mli
@@ -103,7 +103,7 @@ val output_bytes : t -> bytes -> unit
 (** {1:advanced_output Advanced output} *)
 
 val output : t -> bytes -> int -> int -> unit
-(** [output oc buf pos len] writes [len] characters from byte sequence [buf],
+(** [output oc buf pos len] writes [len] bytes from byte sequence [buf],
     starting at offset [pos], to the given output channel [oc].
 
     @raise Invalid_argument if [pos] and [len] do not designate a valid range of
@@ -149,7 +149,7 @@ val pos : t -> int64
 (** {1:attributes Attributes}  *)
 
 val length : t -> int64
-(** Return the size (number of characters) of the regular file on which the
+(** Return the size (number of bytes) of the regular file on which the
     given channel is opened.  If the channel is opened on a file that is not a
     regular file, the result is meaningless. *)
 

--- a/stdlib/stdlib.mli
+++ b/stdlib/stdlib.mli
@@ -995,7 +995,7 @@ val output_bytes : out_channel -> bytes -> unit
    @since 4.02 *)
 
 val output : out_channel -> bytes -> int -> int -> unit
-(** [output oc buf pos len] writes [len] characters from byte sequence [buf],
+(** [output oc buf pos len] writes [len] bytes from byte sequence [buf],
    starting at offset [pos], to the given output channel [oc].
    @raise Invalid_argument if [pos] and [len] do not
    designate a valid range of [buf]. *)
@@ -1044,7 +1044,7 @@ val pos_out : out_channel -> int
     opened in binary mode. *)
 
 val out_channel_length : out_channel -> int
-(** Return the size (number of characters) of the regular file
+(** Return the size (number of bytes) of the regular file
    on which the given channel is opened.  If the channel is opened
     on a file that is not a regular file, the result is meaningless. *)
 
@@ -1101,35 +1101,35 @@ val input_line : in_channel -> string
    at the beginning of line. *)
 
 val input : in_channel -> bytes -> int -> int -> int
-(** [input ic buf pos len] reads up to [len] characters from
+(** [input ic buf pos len] reads up to [len] bytes from
    the given channel [ic], storing them in byte sequence [buf], starting at
-   character number [pos].
-   It returns the actual number of characters read, between 0 and
+   byte number [pos].
+   It returns the actual number of bytes read, between 0 and
    [len] (inclusive).
    A return value of 0 means that the end of file was reached.
    A return value between 0 and [len] exclusive means that
-   not all requested [len] characters were read, either because
-   no more characters were available at that time, or because
+   not all requested [len] bytes were read, either because
+   no more bytes were available at that time, or because
    the implementation found it convenient to do a partial read;
-   [input] must be called again to read the remaining characters,
+   [input] must be called again to read the remaining bytes,
    if desired.  (See also {!Stdlib.really_input} for reading
-   exactly [len] characters.)
+   exactly [len] bytes.)
    Exception [Invalid_argument "input"] is raised if [pos] and [len]
    do not designate a valid range of [buf]. *)
 
 val really_input : in_channel -> bytes -> int -> int -> unit
-(** [really_input ic buf pos len] reads [len] characters from channel [ic],
-   storing them in byte sequence [buf], starting at character number [pos].
+(** [really_input ic buf pos len] reads [len] bytes from channel [ic],
+   storing them in byte sequence [buf], starting at byte number [pos].
    @raise End_of_file if the end of file is reached before [len]
-   characters have been read.
+   bytes have been read.
    @raise Invalid_argument if
    [pos] and [len] do not designate a valid range of [buf]. *)
 
 val really_input_string : in_channel -> int -> string
-(** [really_input_string ic len] reads [len] characters from channel [ic]
+(** [really_input_string ic len] reads [len] bytes from channel [ic]
    and returns them in a new string.
    @raise End_of_file if the end of file is reached before [len]
-   characters have been read.
+   bytes have been read.
    @since 4.02 *)
 
 val input_byte : in_channel -> int
@@ -1165,7 +1165,7 @@ val pos_in : in_channel -> int
     binary mode. *)
 
 val in_channel_length : in_channel -> int
-(** Return the size (number of characters) of the regular file
+(** Return the size (number of bytes) of the regular file
     on which the given channel is opened.  If the channel is opened
     on a file that is not a regular file, the result is meaningless.
     The returned size does not take into account the end-of-line

--- a/stdlib/stdlib.mli
+++ b/stdlib/stdlib.mli
@@ -149,7 +149,7 @@ external ( <= ) : 'a -> 'a -> bool = "%lessequal"
 
 external ( >= ) : 'a -> 'a -> bool = "%greaterequal"
 (** Structural ordering functions. These functions coincide with
-   the usual orderings over integers, characters, strings, byte sequences
+   the usual orderings over integers, bytes, strings, byte sequences
    and floating-point numbers, and extend them to a
    total ordering over all types.
    The ordering is compatible with [( = )]. As in the case

--- a/stdlib/string.mli
+++ b/stdlib/string.mli
@@ -368,7 +368,7 @@ val of_seq : char Seq.t -> t
 (** {2:utf_8 UTF-8} *)
 
 val get_utf_8_uchar : t -> int -> Uchar.utf_decode
-(** [get_utf_8_uchar b i] decodes an UTF-8 character at index [i] in
+(** [get_utf_8_uchar b i] decodes an UTF-8 character at byte index [i] in
     [b]. *)
 
 val is_valid_utf_8 : t -> bool
@@ -378,7 +378,7 @@ val is_valid_utf_8 : t -> bool
 (** {2:utf_16be UTF-16BE} *)
 
 val get_utf_16be_uchar : t -> int -> Uchar.utf_decode
-(** [get_utf_16be_uchar b i] decodes an UTF-16BE character at index
+(** [get_utf_16be_uchar b i] decodes an UTF-16BE character at byte index
     [i] in [b]. *)
 
 val is_valid_utf_16be : t -> bool
@@ -388,7 +388,7 @@ val is_valid_utf_16be : t -> bool
 (** {2:utf_16le UTF-16LE} *)
 
 val get_utf_16le_uchar : t -> int -> Uchar.utf_decode
-(** [get_utf_16le_uchar b i] decodes an UTF-16LE character at index
+(** [get_utf_16le_uchar b i] decodes an UTF-16LE character at byte index
     [i] in [b]. *)
 
 val is_valid_utf_16le : t -> bool
@@ -400,7 +400,7 @@ val is_valid_utf_16le : t -> bool
 (** The functions in this section binary decode integers from strings.
 
     All following functions raise [Invalid_argument] if the bytes
-    needed at index [i] to decode the integer are not available.
+    needed at byte index [i] to decode the integer are not available.
 
     Little-endian (resp. big-endian) encoding means that least
     (resp. most) significant bytes are stored first.  Big-endian is

--- a/stdlib/string.mli
+++ b/stdlib/string.mli
@@ -58,6 +58,8 @@ v}
     is the encoding used by Unicode escapes in string literals. For
     example the string ["\u{1F42B}"] is the UTF-8 encoding of the
     Unicode character U+1F42B.
+    This module offers
+    {{!utf} functions for encoding and decoding UTF-8}.
 
     {b Past mutability.} Before OCaml 4.02, strings used to be modifiable in
     place like {!Bytes.t} mutable sequences of bytes.

--- a/stdlib/string.mli
+++ b/stdlib/string.mli
@@ -77,13 +77,13 @@ type t = string
 
 val make : int -> char -> string
 (** [make n c] is a string of length [n] with each index holding the
-    character [c].
+    byte [c].
 
     @raise Invalid_argument if [n < 0] or [n > ]{!Sys.max_string_length}. *)
 
 val init : int -> (int -> char) -> string
 (** [init n f] is a string of length [n] with index
-    [i] holding the character [f i] (called in increasing index order).
+    [i] holding the byte [f i] (called in increasing index order).
 
     @raise Invalid_argument if [n < 0] or [n > ]{!Sys.max_string_length}.
     @since 4.02 *)
@@ -95,10 +95,10 @@ val empty : string
 *)
 
 external length : string -> int = "%string_length"
-(** [length s] is the length (number of bytes/characters) of [s]. *)
+(** [length s] is the length (number of bytes) of [s]. *)
 
 external get : string -> int -> char = "%string_safe_get"
-(** [get s i] is the character at index [i] in [s]. This is the same
+(** [get s i] is the byte at index [i] in [s]. This is the same
     as writing [s.[i]].
 
     @raise Invalid_argument if [i] not an index of [s]. *)
@@ -145,7 +145,7 @@ val cat : string -> string -> string
 (** {1:predicates Predicates and comparisons} *)
 
 val equal : t -> t -> bool
-(** [equal s0 s1] is [true] if and only if [s0] and [s1] are character-wise
+(** [equal s0 s1] is [true] if and only if [s0] and [s1] are byte-wise
     equal.
     @since 4.03 (4.05 in StringLabels) *)
 
@@ -194,7 +194,7 @@ val sub : string -> int -> int -> string
 
 val split_on_char : char -> string -> string list
 (** [split_on_char sep s] is the list of all (possibly empty)
-    substrings of [s] that are delimited by the character [sep].
+    substrings of [s] that are delimited by the byte [sep].
 
     The function's result is specified by the following invariants:
     {ul
@@ -202,7 +202,7 @@ val split_on_char : char -> string -> string list
     {- Concatenating its elements using [sep] as a separator returns a
       string equal to the input ([concat (make 1 sep)
       (split_on_char sep s) = s]).}
-    {- No string in the result contains the [sep] character.}}
+    {- No string in the result contains the [sep] byte.}}
 
     @since 4.04 (4.05 in StringLabels) *)
 
@@ -210,12 +210,12 @@ val split_on_char : char -> string -> string list
 
 val map : (char -> char) -> string -> string
 (** [map f s] is the string resulting from applying [f] to all the
-    characters of [s] in increasing order.
+    bytes of [s] in increasing order.
 
     @since 4.00 *)
 
 val mapi : (int -> char -> char) -> string -> string
-(** [mapi f s] is like {!map} but the index of the character is also
+(** [mapi f s] is like {!map} but the index of the byte is also
     passed to [f].
 
     @since 4.02 *)
@@ -231,11 +231,11 @@ val fold_right : (char -> 'acc -> 'acc) -> string -> 'acc -> 'acc
     @since 4.13 *)
 
 val for_all : (char -> bool) -> string -> bool
-(** [for_all p s] checks if all characters in [s] satisfy the predicate [p].
+(** [for_all p s] checks if all bytes in [s] satisfy the predicate [p].
     @since 4.13 *)
 
 val exists : (char -> bool) -> string -> bool
-(** [exists p s] checks if at least one character of [s] satisfies the predicate
+(** [exists p s] checks if at least one byte of [s] satisfies the predicate
     [p].
     @since 4.13 *)
 
@@ -249,7 +249,7 @@ val escaped : string -> string
 (** [escaped s] is [s] with special characters represented by escape
     sequences, following the lexical conventions of OCaml.
 
-    All characters outside the US-ASCII printable range \[0x20;0x7E\] are
+    All bytes outside the US-ASCII printable range \[0x20;0x7E\] are
     escaped, as well as backslash (0x2F) and double-quote (0x22).
 
     The function {!Scanf.unescaped} is a left inverse of [escaped],
@@ -286,12 +286,12 @@ val uncapitalize_ascii : string -> string
 (** {1:traversing Traversing} *)
 
 val iter : (char -> unit) -> string -> unit
-(** [iter f s] applies function [f] in turn to all the characters of [s].
+(** [iter f s] applies function [f] in turn to all the bytes of [s].
     It is equivalent to [f s.[0]; f s.[1]; ...; f s.[length s - 1]; ()]. *)
 
 val iteri : (int -> char -> unit) -> string -> unit
 (** [iteri] is like {!iter}, but the function is also given the
-    corresponding character index.
+    corresponding byte index.
 
     @since 4.00 *)
 
@@ -345,7 +345,7 @@ val rindex_opt : string -> char -> int option
 (** {1 Strings and Sequences} *)
 
 val to_seq : t -> char Seq.t
-(** [to_seq s] is a sequence made of the string's characters in
+(** [to_seq s] is a sequence made of the string's bytes in
     increasing order. In ["unsafe-string"] mode, modifications of the string
     during iteration will be reflected in the sequence.
 
@@ -357,7 +357,7 @@ val to_seqi : t -> (int * char) Seq.t
     @since 4.07 *)
 
 val of_seq : char Seq.t -> t
-(** [of_seq s] is a string made of the sequence's characters.
+(** [of_seq s] is a string made of the sequence's bytes.
 
     @since 4.07 *)
 
@@ -399,7 +399,7 @@ val is_valid_utf_16le : t -> bool
 
 (** The functions in this section binary decode integers from strings.
 
-    All following functions raise [Invalid_argument] if the characters
+    All following functions raise [Invalid_argument] if the bytes
     needed at index [i] to decode the integer are not available.
 
     Little-endian (resp. big-endian) encoding means that least
@@ -418,14 +418,14 @@ val is_valid_utf_16le : t -> bool
 *)
 
 val get_uint8 : string -> int -> int
-(** [get_uint8 b i] is [b]'s unsigned 8-bit integer starting at character
+(** [get_uint8 b i] is [b]'s unsigned 8-bit integer starting at byte
     index [i].
 
     @since 4.13
 *)
 
 val get_int8 : string -> int -> int
-(** [get_int8 b i] is [b]'s signed 8-bit integer starting at character
+(** [get_int8 b i] is [b]'s signed 8-bit integer starting at byte
     index [i].
 
     @since 4.13
@@ -433,49 +433,49 @@ val get_int8 : string -> int -> int
 
 val get_uint16_ne : string -> int -> int
 (** [get_uint16_ne b i] is [b]'s native-endian unsigned 16-bit integer
-    starting at character index [i].
+    starting at byte index [i].
 
     @since 4.13
 *)
 
 val get_uint16_be : string -> int -> int
 (** [get_uint16_be b i] is [b]'s big-endian unsigned 16-bit integer
-    starting at character index [i].
+    starting at byte index [i].
 
     @since 4.13
 *)
 
 val get_uint16_le : string -> int -> int
 (** [get_uint16_le b i] is [b]'s little-endian unsigned 16-bit integer
-    starting at character index [i].
+    starting at byte index [i].
 
     @since 4.13
 *)
 
 val get_int16_ne : string -> int -> int
 (** [get_int16_ne b i] is [b]'s native-endian signed 16-bit integer
-    starting at character index [i].
+    starting at byte index [i].
 
     @since 4.13
 *)
 
 val get_int16_be : string -> int -> int
 (** [get_int16_be b i] is [b]'s big-endian signed 16-bit integer
-    starting at character index [i].
+    starting at byte index [i].
 
     @since 4.13
 *)
 
 val get_int16_le : string -> int -> int
 (** [get_int16_le b i] is [b]'s little-endian signed 16-bit integer
-    starting at character index [i].
+    starting at byte index [i].
 
     @since 4.13
 *)
 
 val get_int32_ne : string -> int -> int32
 (** [get_int32_ne b i] is [b]'s native-endian 32-bit integer
-    starting at character index [i].
+    starting at byte index [i].
 
     @since 4.13
 *)
@@ -496,35 +496,35 @@ val seeded_hash : int -> t -> int
 
 val get_int32_be : string -> int -> int32
 (** [get_int32_be b i] is [b]'s big-endian 32-bit integer
-    starting at character index [i].
+    starting at byte index [i].
 
     @since 4.13
 *)
 
 val get_int32_le : string -> int -> int32
 (** [get_int32_le b i] is [b]'s little-endian 32-bit integer
-    starting at character index [i].
+    starting at byte index [i].
 
     @since 4.13
 *)
 
 val get_int64_ne : string -> int -> int64
 (** [get_int64_ne b i] is [b]'s native-endian 64-bit integer
-    starting at character index [i].
+    starting at byte index [i].
 
     @since 4.13
 *)
 
 val get_int64_be : string -> int -> int64
 (** [get_int64_be b i] is [b]'s big-endian 64-bit integer
-    starting at character index [i].
+    starting at byte index [i].
 
     @since 4.13
 *)
 
 val get_int64_le : string -> int -> int64
 (** [get_int64_le b i] is [b]'s little-endian 64-bit integer
-    starting at character index [i].
+    starting at byte index [i].
 
     @since 4.13
 *)

--- a/stdlib/stringLabels.mli
+++ b/stdlib/stringLabels.mli
@@ -77,13 +77,13 @@ type t = string
 
 val make : int -> char -> string
 (** [make n c] is a string of length [n] with each index holding the
-    character [c].
+    byte [c].
 
     @raise Invalid_argument if [n < 0] or [n > ]{!Sys.max_string_length}. *)
 
 val init : int -> f:(int -> char) -> string
 (** [init n ~f] is a string of length [n] with index
-    [i] holding the character [f i] (called in increasing index order).
+    [i] holding the byte [f i] (called in increasing index order).
 
     @raise Invalid_argument if [n < 0] or [n > ]{!Sys.max_string_length}.
     @since 4.02 *)
@@ -95,10 +95,10 @@ val empty : string
 *)
 
 external length : string -> int = "%string_length"
-(** [length s] is the length (number of bytes/characters) of [s]. *)
+(** [length s] is the length (number of bytes) of [s]. *)
 
 external get : string -> int -> char = "%string_safe_get"
-(** [get s i] is the character at index [i] in [s]. This is the same
+(** [get s i] is the byte at index [i] in [s]. This is the same
     as writing [s.[i]].
 
     @raise Invalid_argument if [i] not an index of [s]. *)
@@ -145,7 +145,7 @@ val cat : string -> string -> string
 (** {1:predicates Predicates and comparisons} *)
 
 val equal : t -> t -> bool
-(** [equal s0 s1] is [true] if and only if [s0] and [s1] are character-wise
+(** [equal s0 s1] is [true] if and only if [s0] and [s1] are byte-wise
     equal.
     @since 4.03 (4.05 in StringLabels) *)
 
@@ -194,7 +194,7 @@ val sub : string -> pos:int -> len:int -> string
 
 val split_on_char : sep:char -> string -> string list
 (** [split_on_char ~sep s] is the list of all (possibly empty)
-    substrings of [s] that are delimited by the character [sep].
+    substrings of [s] that are delimited by the byte [sep].
 
     The function's result is specified by the following invariants:
     {ul
@@ -202,7 +202,7 @@ val split_on_char : sep:char -> string -> string list
     {- Concatenating its elements using [sep] as a separator returns a
       string equal to the input ([concat (make 1 sep)
       (split_on_char sep s) = s]).}
-    {- No string in the result contains the [sep] character.}}
+    {- No string in the result contains the [sep] byte.}}
 
     @since 4.04 (4.05 in StringLabels) *)
 
@@ -210,12 +210,12 @@ val split_on_char : sep:char -> string -> string list
 
 val map : f:(char -> char) -> string -> string
 (** [map f s] is the string resulting from applying [f] to all the
-    characters of [s] in increasing order.
+    bytes of [s] in increasing order.
 
     @since 4.00 *)
 
 val mapi : f:(int -> char -> char) -> string -> string
-(** [mapi ~f s] is like {!map} but the index of the character is also
+(** [mapi ~f s] is like {!map} but the index of the byte is also
     passed to [f].
 
     @since 4.02 *)
@@ -231,11 +231,11 @@ val fold_right : f:(char -> 'acc -> 'acc) -> string -> init:'acc -> 'acc
     @since 4.13 *)
 
 val for_all : f:(char -> bool) -> string -> bool
-(** [for_all p s] checks if all characters in [s] satisfy the predicate [p].
+(** [for_all p s] checks if all bytes in [s] satisfy the predicate [p].
     @since 4.13 *)
 
 val exists : f:(char -> bool) -> string -> bool
-(** [exists p s] checks if at least one character of [s] satisfies the predicate
+(** [exists p s] checks if at least one byte of [s] satisfies the predicate
     [p].
     @since 4.13 *)
 
@@ -249,7 +249,7 @@ val escaped : string -> string
 (** [escaped s] is [s] with special characters represented by escape
     sequences, following the lexical conventions of OCaml.
 
-    All characters outside the US-ASCII printable range \[0x20;0x7E\] are
+    All bytes outside the US-ASCII printable range \[0x20;0x7E\] are
     escaped, as well as backslash (0x2F) and double-quote (0x22).
 
     The function {!Scanf.unescaped} is a left inverse of [escaped],
@@ -286,12 +286,12 @@ val uncapitalize_ascii : string -> string
 (** {1:traversing Traversing} *)
 
 val iter : f:(char -> unit) -> string -> unit
-(** [iter ~f s] applies function [f] in turn to all the characters of [s].
+(** [iter ~f s] applies function [f] in turn to all the bytes of [s].
     It is equivalent to [f s.[0]; f s.[1]; ...; f s.[length s - 1]; ()]. *)
 
 val iteri : f:(int -> char -> unit) -> string -> unit
 (** [iteri] is like {!iter}, but the function is also given the
-    corresponding character index.
+    corresponding byte index.
 
     @since 4.00 *)
 
@@ -345,7 +345,7 @@ val rindex_opt : string -> char -> int option
 (** {1 Strings and Sequences} *)
 
 val to_seq : t -> char Seq.t
-(** [to_seq s] is a sequence made of the string's characters in
+(** [to_seq s] is a sequence made of the string's bytes in
     increasing order. In ["unsafe-string"] mode, modifications of the string
     during iteration will be reflected in the sequence.
 
@@ -357,7 +357,7 @@ val to_seqi : t -> (int * char) Seq.t
     @since 4.07 *)
 
 val of_seq : char Seq.t -> t
-(** [of_seq s] is a string made of the sequence's characters.
+(** [of_seq s] is a string made of the sequence's bytes.
 
     @since 4.07 *)
 
@@ -399,7 +399,7 @@ val is_valid_utf_16le : t -> bool
 
 (** The functions in this section binary decode integers from strings.
 
-    All following functions raise [Invalid_argument] if the characters
+    All following functions raise [Invalid_argument] if the bytes
     needed at index [i] to decode the integer are not available.
 
     Little-endian (resp. big-endian) encoding means that least
@@ -418,14 +418,14 @@ val is_valid_utf_16le : t -> bool
 *)
 
 val get_uint8 : string -> int -> int
-(** [get_uint8 b i] is [b]'s unsigned 8-bit integer starting at character
+(** [get_uint8 b i] is [b]'s unsigned 8-bit integer starting at byte
     index [i].
 
     @since 4.13
 *)
 
 val get_int8 : string -> int -> int
-(** [get_int8 b i] is [b]'s signed 8-bit integer starting at character
+(** [get_int8 b i] is [b]'s signed 8-bit integer starting at byte
     index [i].
 
     @since 4.13
@@ -433,49 +433,49 @@ val get_int8 : string -> int -> int
 
 val get_uint16_ne : string -> int -> int
 (** [get_uint16_ne b i] is [b]'s native-endian unsigned 16-bit integer
-    starting at character index [i].
+    starting at byte index [i].
 
     @since 4.13
 *)
 
 val get_uint16_be : string -> int -> int
 (** [get_uint16_be b i] is [b]'s big-endian unsigned 16-bit integer
-    starting at character index [i].
+    starting at byte index [i].
 
     @since 4.13
 *)
 
 val get_uint16_le : string -> int -> int
 (** [get_uint16_le b i] is [b]'s little-endian unsigned 16-bit integer
-    starting at character index [i].
+    starting at byte index [i].
 
     @since 4.13
 *)
 
 val get_int16_ne : string -> int -> int
 (** [get_int16_ne b i] is [b]'s native-endian signed 16-bit integer
-    starting at character index [i].
+    starting at byte index [i].
 
     @since 4.13
 *)
 
 val get_int16_be : string -> int -> int
 (** [get_int16_be b i] is [b]'s big-endian signed 16-bit integer
-    starting at character index [i].
+    starting at byte index [i].
 
     @since 4.13
 *)
 
 val get_int16_le : string -> int -> int
 (** [get_int16_le b i] is [b]'s little-endian signed 16-bit integer
-    starting at character index [i].
+    starting at byte index [i].
 
     @since 4.13
 *)
 
 val get_int32_ne : string -> int -> int32
 (** [get_int32_ne b i] is [b]'s native-endian 32-bit integer
-    starting at character index [i].
+    starting at byte index [i].
 
     @since 4.13
 *)
@@ -496,35 +496,35 @@ val seeded_hash : int -> t -> int
 
 val get_int32_be : string -> int -> int32
 (** [get_int32_be b i] is [b]'s big-endian 32-bit integer
-    starting at character index [i].
+    starting at byte index [i].
 
     @since 4.13
 *)
 
 val get_int32_le : string -> int -> int32
 (** [get_int32_le b i] is [b]'s little-endian 32-bit integer
-    starting at character index [i].
+    starting at byte index [i].
 
     @since 4.13
 *)
 
 val get_int64_ne : string -> int -> int64
 (** [get_int64_ne b i] is [b]'s native-endian 64-bit integer
-    starting at character index [i].
+    starting at byte index [i].
 
     @since 4.13
 *)
 
 val get_int64_be : string -> int -> int64
 (** [get_int64_be b i] is [b]'s big-endian 64-bit integer
-    starting at character index [i].
+    starting at byte index [i].
 
     @since 4.13
 *)
 
 val get_int64_le : string -> int -> int64
 (** [get_int64_le b i] is [b]'s little-endian 64-bit integer
-    starting at character index [i].
+    starting at byte index [i].
 
     @since 4.13
 *)

--- a/stdlib/stringLabels.mli
+++ b/stdlib/stringLabels.mli
@@ -368,7 +368,7 @@ val of_seq : char Seq.t -> t
 (** {2:utf_8 UTF-8} *)
 
 val get_utf_8_uchar : t -> int -> Uchar.utf_decode
-(** [get_utf_8_uchar b i] decodes an UTF-8 character at index [i] in
+(** [get_utf_8_uchar b i] decodes an UTF-8 character at byte index [i] in
     [b]. *)
 
 val is_valid_utf_8 : t -> bool
@@ -378,7 +378,7 @@ val is_valid_utf_8 : t -> bool
 (** {2:utf_16be UTF-16BE} *)
 
 val get_utf_16be_uchar : t -> int -> Uchar.utf_decode
-(** [get_utf_16be_uchar b i] decodes an UTF-16BE character at index
+(** [get_utf_16be_uchar b i] decodes an UTF-16BE character at byte index
     [i] in [b]. *)
 
 val is_valid_utf_16be : t -> bool
@@ -388,7 +388,7 @@ val is_valid_utf_16be : t -> bool
 (** {2:utf_16le UTF-16LE} *)
 
 val get_utf_16le_uchar : t -> int -> Uchar.utf_decode
-(** [get_utf_16le_uchar b i] decodes an UTF-16LE character at index
+(** [get_utf_16le_uchar b i] decodes an UTF-16LE character at byte index
     [i] in [b]. *)
 
 val is_valid_utf_16le : t -> bool
@@ -400,7 +400,7 @@ val is_valid_utf_16le : t -> bool
 (** The functions in this section binary decode integers from strings.
 
     All following functions raise [Invalid_argument] if the bytes
-    needed at index [i] to decode the integer are not available.
+    needed at byte index [i] to decode the integer are not available.
 
     Little-endian (resp. big-endian) encoding means that least
     (resp. most) significant bytes are stored first.  Big-endian is

--- a/stdlib/stringLabels.mli
+++ b/stdlib/stringLabels.mli
@@ -58,6 +58,8 @@ v}
     is the encoding used by Unicode escapes in string literals. For
     example the string ["\u{1F42B}"] is the UTF-8 encoding of the
     Unicode character U+1F42B.
+    This module offers
+    {{!utf} functions for encoding and decoding UTF-8}.
 
     {b Past mutability.} Before OCaml 4.02, strings used to be modifiable in
     place like {!Bytes.t} mutable sequences of bytes.


### PR DESCRIPTION
This PR does small-scale improvements to the documentation, trying to clear up a tiny bit the matter of text encoding without a full rewrite of the material.

  - replace some occurrences of “character” with “byte”
  - disambiguate the doc-strings of the UTF codecs (“index” has been disambiguated to “byte index”)
  - give some more visibility to the new UTF codecs
      + by adding a couple of hyperlinks in the header of modules `String` and `Bytes`
      + by reordering the sections of module `Bytes`

## Previous state

The previous state was that the header of the documentation of module `String` contained the following sentence:

> A string `s` of length `n` is an indexable and immutable sequence of `n` bytes. For historical reasons these bytes are referred to as characters.

As well as this paragraph:

> **Unicode text.** Strings being arbitrary sequences of bytes, they can hold any kind of textual encoding. However the recommended encoding for storing Unicode text in OCaml strings is UTF-8. This is the encoding used by Unicode escapes in string literals. For example the string `"\u{1F42B}"` is the UTF-8 encoding of the Unicode character U+1F42B.

And then the doc-strings in `String` and `Bytes` used the words “character” and “byte” inconsistently, while the rest of the material (manual, other doc pages) almost exclusively used the word “character” in its legacy meaning.

I think that state is not satisfying because it uses a known word (“character”) with a non-standard, misleading meaning. The sentence that defines it in the header of `String` is relatively clear, but you have to *know* that it is there to begin with. It is not even at the root of the doc hierarchy, i.e. this remark is also relevant for other parts of the standard library (modules `Stdlib`, `In_channel`, `Out_channel`, `Char`, `Uchar`, `Bytes` at least) and even before that, for the manual. For instance, when reading the doc-string of `Stdlib.really_input_string`, you have no way of knowing that the doc says “character” but really means “byte”.

Another example: in the manual’s tour of the language (so, much earlier than the doc page of `String`), one reads:

> characters
>
> ```
> # 'a';;
> - : char = 'a'
> # int_of_char '\n';;
> - : int = 10
> ```

Let’s say I’m an OCaml beginner (not even a programming beginner) and I take this tour of OCaml; at this point I try it myself in the REPL, with my favorite *character* (but nothing too fancy, it is in latin-1):

```
# 'é';;
Line 1, characters 1-2:
Alert deprecated: ISO-Latin1 characters in identifiers
Error: Syntax error
```

Hence a deceived expectation (here compounding with obscure error signaling) that makes for a bad first experience with OCaml.

## Amending the manual

In the portion of the language’s tour quoted above, I replaced “characters” with “characters (or more accurately, bytes)”; which, while still very allusive, at least hints that something is going on.

Further, I amended the definition of the `char` type in the chapter about the core library. Instead of saying that “`char` is the type of characters”, it essentially says that `char` is the type of *bytes*, which are 8-bit values able to represent arbitrary data, such as ASCII characters; and so, for historical reasons, they are often referred to as characters. But I find it is impossible to give the minimum required level of clarification while sticking to the extreme terseness of the manual. Plus, I think something should also be said about character literals, but I could not find the relevant place for that.

## Replacing “character” with “byte” in doc-strings

This PR replaces many occurrences of “character” with “byte”. I wasn’t daring enough to replace all of them where it would make sense (see below), so it’s still not consistent, but I think replacing a misleading (even if defined somewhere) term with an unambiguous one does not hurt, even if done incompletely.

  - in `String` and `Bytes` most occurrences were replaced. In some cases it is undebatably an improvement, in particular for the functions about binary encoding/decoding of integers. The few occurrences of “character“ that stayed are those where specific characters are mentioned (whitespaces, latin letters…), and a specific (ASCII-compatible) text encoding is thus assumed.
  - In `Stdlib` (and equivalent functions in `In_channel` and `Out_channel` I followed the same principle, so `output`, `out_channel_length`, `input`, `really_input`, `really_input_string` and `in_channel_length` got their doc rewritten (all these functions have in common that they deal with byte counts, so I think it is especially important for them), whereas `input_line` for instance was left as-is (it mentions “newline characters”).

Changes I haven’t done, because it was a bit too “large-scale” for what I had in mind; we can discuss their usefulness:

  - I did not dare rewrite the doc-strings of the `Stdlib` functions that deal with a single `char`, i.e. `output_char`, `output_byte` and so on; as well as the “Character operations” `char_of_int` and `int_of_char`, whose description is currently not general enough (`char` is not limited to ASCII characters). That’s because I feel it would need a proper explanation, readily available, about what is a byte, what’s the connection with characters and the `char` type (an expanded version of the explanation I just added to the manual). It seems to me that a good place for this would be the header of the `Char` module. Then, in `Stdlib`, the documentation of “Character operations” would conveniently point to / remind of this explanation. And the word “byte” could then be used much more consistently across the doc.
  - Since we already state that strings may contain arbitrary data, perhaps there should be a short note somewhere that the functions which expect or produce specific characters assume an ASCII-compatible text encoding. For one spot, there is the “String conversion functions” section in `Stdlib`. This matter is tied to that of character literals, which have the same assumption.

## Reording `Bytes`

Before this PR, the documentation of module `Bytes` was sectioned as follows:

 0. (un-sectioned content, with most of the functions)
 1. Unsafe conversions (for advanced users)
 2. Iterators
 3. UTF codecs and validations
 4. Binary encoding/decoding of integers
 5. Byte sequences and concurrency safety

I moved the section about unsafe string conversions to the bottom of module `Bytes`, just before the concurrency section. A heading in big font with the words “unsafe” and “advanced” is a strong signal that contents for the profane ends there and below are <s>dragons</s> arcane knowledge. It is better to present general-usage functions for use by everyone, before that. Benefits:

  - the new UTF codecs are now a bit more visible (which was the motivation);
  - the two discussions about safety (unsafe conversion to `string`, concurrency) are now next to each other.

I guess it would make sense to further reorganize `Bytes` to align with the model of `String`, but that’s out of scope for this PR.