### PR TITLE
Test cases for 7241

### DIFF
--- a/testsuite/tests/match-side-effects/contexts_1.ml
+++ b/testsuite/tests/match-side-effects/contexts_1.ml
@@ -1,0 +1,43 @@
+(* Example where a side-effect invalidates static knowledge about
+   a sub-value at the "toplevel" of the current matching context
+   -- on the current arguments of the pattern matrix.
+
+   This example is adapted from the main example of #7241, showing
+   that mutable state combined with context optimization could be
+   unsound.
+
+   The example of #7241 was adapted to return type-unsound result
+   (on non-fixed systems) instead of segfaulting. Segfaults are
+   painful to record and test reliably in a testsuite. *)
+
+type u = {a: bool; mutable b: (bool, int) Either.t}
+
+let example_1 () =
+  let input = { a = true; b = Either.Left true } in
+  match input with
+  | {a = false; b = _} -> Result.Error 1
+  | {a = _;     b = Either.Right _} -> Result.Error 2
+
+  (* evil trick: mutate the scrutinee from a guard *)
+  | {a = _;     b = _} when (input.b <- Either.Right 3; false) -> Result.Error 3
+
+  (* At this point, field [b] has been mutated to hold a [Right]
+     constructor, but the pattern-matching compiler has already
+     checked read the field in the past and checked that the
+     constructor was not [Right] -- otherwise the action [Error 2]
+     would have been taken.
+
+     The following behaviors would be reasonable on the input [f_input]:
+
+     - read the field again, observe [Right], and fail with a match
+       failure -- there is no clause left to match it.
+
+     - reuse the previously read subvalue [Left true], and return [Ok true].
+
+     For many years the OCaml compiler behaved incorrectly here: it
+     would read the mutated value [Right 3], but assume from static
+     context information that the head constructor is [Left]. and
+     dereference its field without checking the constructor
+     again. This returns the unsound result [Ok (3 : bool)]. *)
+  | {a = true;  b = Either.Left y} -> Result.Ok y
+;;

--- a/testsuite/tests/match-side-effects/contexts_2.ml
+++ b/testsuite/tests/match-side-effects/contexts_2.ml
@@ -1,0 +1,15 @@
+(* Example where a side-effect invalidates static knowledge about
+   a sub-value below the "toplevel" of the current matching context
+   -- a sub-value of the current arguments of the pattern matrix.
+ *)
+
+type 'a myref = { mutable mut : 'a }
+type u = {a: bool; b: (bool, int) Either.t myref }
+
+let example_2 () =
+  let input = { a = true; b = { mut = Either.Left true } } in
+  match input with
+  | {a = false; b = _} -> Result.Error 1
+  | {a = _;     b = { mut = Either.Right _ }} -> Result.Error 2
+  | {a = _;     b = _} when (input.b.mut <- Either.Right 3; false) -> Result.Error 3
+  | {a = true;  b = { mut = Either.Left y }} -> Result.Ok y

--- a/testsuite/tests/match-side-effects/contexts_3.ml
+++ b/testsuite/tests/match-side-effects/contexts_3.ml
@@ -1,0 +1,13 @@
+(* Example where a side-effect invalidates static knowledge about
+   a sub-value above the current matching context. *)
+
+type 'a myref = { mutable mut : 'a }
+type u = (bool * (bool, int) Either.t) myref
+
+let example_3 () =
+  let input = { mut = (true, Either.Left true) } in
+  match input with
+  | { mut = (false, _) } -> Result.Error 1
+  | { mut = (_, Either.Right _) } -> Result.Error 2
+  | { mut = (_, _) } when (input.mut <- (true, Either.Right 3); false) -> Result.Error 3
+  | { mut = (true, Either.Left y) } -> Result.Ok y

--- a/testsuite/tests/match-side-effects/partiality.ml
+++ b/testsuite/tests/match-side-effects/partiality.ml
@@ -1,0 +1,181 @@
+(* TEST
+ flags = "-dlambda";
+ expect;
+*)
+
+(* The original example of unsoundness in #7421. *)
+type t = {a: bool; mutable b: int option}
+
+let f x =
+  match x with
+  | {a = false; b = _} -> 0
+  | {a = _;     b = None} -> 1
+  | {a = _;     b = _} when (x.b <- None; false) -> 2
+  | {a = true;  b = Some y} -> y
+;;
+(* Correctness condition: there should either be a single
+   (field_mut 1) access, or the second access should include
+   a Match_failure case.
+
+   FAIL: the second occurrence of (field_mut 1) is used with a direct
+   (field_imm 0) access without a constructor check. The compiler is
+   unsound here. *)
+[%%expect {|
+0
+type t = { a : bool; mutable b : int option; }
+(let
+  (f/279 =
+     (function x/281 : int
+       (if (field_int 0 x/281)
+         (let (*match*/285 =o (field_mut 1 x/281))
+           (if *match*/285
+             (if (seq (setfield_ptr 1 x/281 0) 0) 2
+               (let (*match*/286 =o (field_mut 1 x/281))
+                 (field_imm 0 *match*/286)))
+             1))
+         0)))
+  (apply (field_mut 1 (global Toploop!)) "f" f/279))
+val f : t -> int = <fun>
+|}]
+
+
+
+(* A simple example of a complete switch
+   inside a mutable position. *)
+type t = {a: bool; mutable b: int option}
+
+let f x =
+  match x with
+  | {a = false; b = _} -> 0
+  | {a = _;     b = None} -> 1
+  | {a = true;  b = Some y} -> y
+;;
+(* Performance expectation: there should not be a Match_failure case. *)
+[%%expect {|
+0
+type t = { a : bool; mutable b : int option; }
+(let
+  (f/290 =
+     (function x/291 : int
+       (if (field_int 0 x/291)
+         (let (*match*/295 =o (field_mut 1 x/291))
+           (if *match*/295 (field_imm 0 *match*/295) 1))
+         0)))
+  (apply (field_mut 1 (global Toploop!)) "f" f/290))
+val f : t -> int = <fun>
+|}]
+
+
+
+(* A variant of the #7421 example. *)
+let f r =
+  match Some r with
+  | Some { contents = None } -> 0
+  | _ when (r := None; false) -> 1
+  | Some { contents = Some n } -> n
+  | None -> 3
+;;
+(* Correctness condition: there should either be a single
+   (field_mut 1) access, or the second access should include
+   a Match_failure case.
+
+   FAIL: the second occurrence of (field_mut 0) is used with a direct
+   (field_imm 0) access without a constructor check. The compiler is
+   unsound here. *)
+[%%expect {|
+(let
+  (f/297 =
+     (function r/298 : int
+       (let (*match*/300 = (makeblock 0 r/298))
+         (catch
+           (if *match*/300
+             (let (*match*/302 =o (field_mut 0 (field_imm 0 *match*/300)))
+               (if *match*/302 (exit 7) 0))
+             (exit 7))
+          with (7)
+           (if (seq (setfield_ptr 0 r/298 0) 0) 1
+             (if *match*/300
+               (let (*match*/304 =o (field_mut 0 (field_imm 0 *match*/300)))
+                 (field_imm 0 *match*/304))
+               3))))))
+  (apply (field_mut 1 (global Toploop!)) "f" f/297))
+val f : int option ref -> int = <fun>
+|}]
+
+
+
+(* This example has an ill-typed counter-example: the type-checker
+   finds it Total, but the pattern-matching compiler cannot see that
+   (Some (Some (Bool b))) cannot occur. *)
+type _ t = Int : int -> int t | Bool : bool -> bool t
+
+let test = function
+  | None -> 0
+  | Some (Int n) -> n
+;;
+(* Performance expectation: there should not be a Match_failure case. *)
+[%%expect {|
+0
+type _ t = Int : int -> int t | Bool : bool -> bool t
+(let
+  (test/308 =
+     (function param/311 : int
+       (if param/311 (field_imm 0 (field_imm 0 param/311)) 0)))
+  (apply (field_mut 1 (global Toploop!)) "test" test/308))
+val test : int t option -> int = <fun>
+|}]
+
+
+(* This example has an ill-typed counter-example, inside
+   a mutable position.  *)
+type _ t = Int : int -> int t | Bool : bool -> bool t
+
+let test = function
+  | { contents = None } -> 0
+  | { contents = Some (Int n) } -> n
+;;
+(* Performance expectation: there should not be a Match_failure case. *)
+[%%expect {|
+0
+type _ t = Int : int -> int t | Bool : bool -> bool t
+(let
+  (test/316 =
+     (function param/318 : int
+       (let (*match*/319 =o (field_mut 0 param/318))
+         (if *match*/319 (field_imm 0 (field_imm 0 *match*/319)) 0))))
+  (apply (field_mut 1 (global Toploop!)) "test" test/316))
+val test : int t option ref -> int = <fun>
+|}]
+
+
+
+(* This example has a ill-typed counter-example,
+   and also mutable sub-patterns, but in different places. *)
+type _ t = Int : int -> int t | Bool : bool -> bool t
+
+let test n =
+  match Some (ref true, Int 42) with
+  | Some ({ contents = true }, Int n) -> n
+  | Some ({ contents = false }, Int n) -> -n
+  | None -> 3
+;;
+(* Performance expectation: there should not be a Match_failure case. *)
+[%%expect {|
+0
+type _ t = Int : int -> int t | Bool : bool -> bool t
+(let
+  (test/324 =
+     (function n/325 : int
+       (let
+         (*match*/328 =
+            (makeblock 0 (makeblock 0 (makemutable 0 (int) 1) [0: 42])))
+         (if *match*/328
+           (let
+             (*match*/329 =a (field_imm 0 *match*/328)
+              *match*/331 =o (field_mut 0 (field_imm 0 *match*/329)))
+             (if *match*/331 (field_imm 0 (field_imm 1 *match*/329))
+               (~ (field_imm 0 (field_imm 1 *match*/329)))))
+           3))))
+  (apply (field_mut 1 (global Toploop!)) "test" test/324))
+val test : 'a -> int = <fun>
+|}]

--- a/testsuite/tests/match-side-effects/test_contexts_code.ml
+++ b/testsuite/tests/match-side-effects/test_contexts_code.ml
@@ -1,0 +1,126 @@
+(* TEST
+ readonly_files = "contexts_1.ml contexts_2.ml contexts_3.ml";
+ flags = "-dsource -dlambda";
+ expect;
+*)
+
+#use "contexts_1.ml";;
+(* Notice that (field_mut 1 input) occurs twice, it
+   is evaluated once in the 'false' branch and once in the 'true'
+   branch. The compiler assumes that its static knowledge about the
+   first read (it cannot be a [Right] as we already matched against it
+   and failed) also applies to the second read, which is unsound.
+*)
+[%%expect {|
+
+#use  "contexts_1.ml";;
+
+type u = {
+  a: bool ;
+  mutable b: (bool, int) Either.t };;
+0
+type u = { a : bool; mutable b : (bool, int) Either.t; }
+
+let example_1 () =
+  let input = { a = true; b = (Either.Left true) } in
+  match input with
+  | { a = false; b = _ } -> Result.Error 1
+  | { a = _; b = Either.Right _ } -> Result.Error 2
+  | { a = _; b = _ } when input.b <- (Either.Right 3); false ->
+      Result.Error 3
+  | { a = true; b = Either.Left y } -> Result.Ok y;;
+(let
+  (example_1/309 =
+     (function param/333[int]
+       (let (input/311 = (makemutable 0 (int,*) 1 [0: 1]))
+         (if (field_int 0 input/311)
+           (let (*match*/336 =o (field_mut 1 input/311))
+             (switch* *match*/336
+              case tag 0:
+               (if (seq (setfield_ptr 1 input/311 [1: 3]) 0) [1: 3]
+                 (let (*match*/338 =o (field_mut 1 input/311))
+                   (makeblock 0 (int) (field_imm 0 *match*/338))))
+              case tag 1: [1: 2]))
+           [1: 1]))))
+  (apply (field_mut 1 (global Toploop!)) "example_1" example_1/309))
+val example_1 : unit -> (bool, int) Result.t = <fun>
+|}]
+
+#use "contexts_2.ml";;
+[%%expect {|
+
+#use  "contexts_2.ml";;
+
+type 'a myref = {
+  mutable mut: 'a };;
+0
+type 'a myref = { mutable mut : 'a; }
+
+type u = {
+  a: bool ;
+  b: (bool, int) Either.t myref };;
+0
+type u = { a : bool; b : (bool, int) Either.t myref; }
+
+let example_2 () =
+  let input = { a = true; b = { mut = (Either.Left true) } } in
+  match input with
+  | { a = false; b = _ } -> Result.Error 1
+  | { a = _; b = { mut = Either.Right _ } } -> Result.Error 2
+  | { a = _; b = _ } when (input.b).mut <- (Either.Right 3); false ->
+      Result.Error 3
+  | { a = true; b = { mut = Either.Left y } } -> Result.Ok y;;
+(let
+  (example_2/345 =
+     (function param/349[int]
+       (let (input/347 = (makeblock 0 (int,*) 1 (makemutable 0 [0: 1])))
+         (if (field_int 0 input/347)
+           (let (*match*/353 =o (field_mut 0 (field_imm 1 input/347)))
+             (switch* *match*/353
+              case tag 0:
+               (if (seq (setfield_ptr 0 (field_imm 1 input/347) [1: 3]) 0)
+                 [1: 3]
+                 (let (*match*/356 =o (field_mut 0 (field_imm 1 input/347)))
+                   (makeblock 0 (int) (field_imm 0 *match*/356))))
+              case tag 1: [1: 2]))
+           [1: 1]))))
+  (apply (field_mut 1 (global Toploop!)) "example_2" example_2/345))
+val example_2 : unit -> (bool, int) Result.t = <fun>
+|}]
+
+#use "contexts_3.ml";;
+[%%expect {|
+
+#use  "contexts_3.ml";;
+
+type 'a myref = {
+  mutable mut: 'a };;
+0
+type 'a myref = { mutable mut : 'a; }
+
+type u = (bool * (bool, int) Either.t) myref;;
+0
+type u = (bool * (bool, int) Either.t) myref
+
+let example_3 () =
+  let input = { mut = (true, (Either.Left true)) } in
+  match input with
+  | { mut = (false, _) } -> Result.Error 1
+  | { mut = (_, Either.Right _) } -> Result.Error 2
+  | { mut = (_, _) } when input.mut <- (true, (Either.Right 3)); false ->
+      Result.Error 3
+  | { mut = (true, Either.Left y) } -> Result.Ok y;;
+(let
+  (example_3/362 =
+     (function param/366[int]
+       (let (input/364 =mut [0: 1 [0: 1]] *match*/367 =o *input/364)
+         (if (field_imm 0 *match*/367)
+           (switch* (field_imm 1 *match*/367)
+            case tag 0:
+             (if (seq (assign input/364 [0: 1 [1: 3]]) 0) [1: 3]
+               (makeblock 0 (int) (field_imm 0 (field_imm 1 *match*/367))))
+            case tag 1: [1: 2])
+           [1: 1]))))
+  (apply (field_mut 1 (global Toploop!)) "example_3" example_3/362))
+val example_3 : unit -> (bool, int) Result.t = <fun>
+|}]

--- a/testsuite/tests/match-side-effects/test_contexts_results.ml
+++ b/testsuite/tests/match-side-effects/test_contexts_results.ml
@@ -1,0 +1,43 @@
+(* TEST
+ readonly_files = "contexts_1.ml contexts_2.ml contexts_3.ml";
+ expect;
+*)
+
+#use "contexts_1.ml";;
+[%%expect {|
+type u = { a : bool; mutable b : (bool, int) Either.t; }
+val example_1 : unit -> (bool, int) Result.t = <fun>
+|}]
+
+let _ = example_1 ();;
+(* <unknown constructor> means that we got an 'unsound boolean',
+   which is neither 'true' nor 'false'. There was a bug here! *)
+[%%expect {|
+- : (bool, int) Result.t = Result.Ok <unknown constructor>
+|}]
+
+#use "contexts_2.ml";;
+[%%expect {|
+type 'a myref = { mutable mut : 'a; }
+type u = { a : bool; b : (bool, int) Either.t myref; }
+val example_2 : unit -> (bool, int) Result.t = <fun>
+|}];;
+
+let _ = example_2 ();;
+(* Also a bug! *)
+[%%expect {|
+- : (bool, int) Result.t = Result.Ok <unknown constructor>
+|}]
+
+#use "contexts_3.ml";;
+[%%expect {|
+type 'a myref = { mutable mut : 'a; }
+type u = (bool * (bool, int) Either.t) myref
+val example_3 : unit -> (bool, int) Result.t = <fun>
+|}];;
+
+let _ = example_3 ();;
+(* This one works correctly. *)
+[%%expect {|
+- : (bool, int) Result.t = Result.Ok true
+|}]


### PR DESCRIPTION
#7241 is an unsoundness bug in the pattern-matching compiler, first reported in 2016 by @stedolan. @trefis and myself are working to fix the bug. The current PR is a couple addition to the compiler testsuite that serve as regression tests for the bug, and also record the pattern-matching compilation behavior in cases where the type-checker and the pattern-matching compiler disagree on whether a given pattern match is total or partial.

This testsuite serves three purposes:

1. Writing it helped me better understand the bug; I realized that there are in fact two independent issues at play when mixing side-effects and pattern-matching (the context information can be incorrect, and the totality information can be incorrect; either of those issues can independently cause unsoundness), which we had not realized earlier as we only studied a single reproduction case.

2. One difficulty with #7241 is that we want to fix a bug that only occurs in a relatively weird corner-case (we are not aware of any user *unintentionally* hitting this bug) without degrading the performance of the pattern-matching code that people *do* write in practice. The simplest approaches to rule the bug out would fix code that no one writes by pessimizing (in some cases noticeably) code that people write and whose performance are sensitive, in particular pattern-matchings on GADTs with dead cases ruled out by typing information. The proposed testsuite contains a series of examples mixing GADTs and mutable states, that should allow to detect if a proposed fix degrades the quality of the pattern-matching compiler output, for which class of programs (*any* use of GADT or mutable state? only when both are combined? must the GADTs be under mutable fields?), and decide whether the degradation is acceptable or not.

3. Having the testsuite already in `trunk` is going to make reviewing fixes easier. In particular, for one aspect (the bug in context information) we have a choice between several approaches, and I am considering submitting two alternative PRs for discussion; having a relevant testsuite already in-tree is going to make it easier to review and compare both approaches. 


Two downsides of the PR which I believe are acceptable (other I would not submit it right now):

A. We don't have a consensus about including known-bugs testcases in the compiler testsuite, because we want to keep it fast. This PR proposed known-bugs testcases, but they are meant as regression tests submitted a few days or weeks before the fix, not as long-term known-bugs testcases. We will get a fix for The Bug in September 2023, I swear! The tests are also instantaneous and bytecode-only (expect tests).

B. Most of the tests check the `-drawlambda` or `-dlambda` output of compiler phrases, and it is not obvious to the untrained reader whether a given output is correct or not. I was careful to write comments explaining what aspect of the output one should look at to tell whether a given output represents a change in expected behavior or not. One can wonder if the tests would still prove burdensome to maintain in the future -- will people changing the dlambda output know whether promoting the changed output is the right thing to do. My belief is as follows:
- Most changes to dlambda output are trivially behavior-preserving (change in stamp numbers, variable naming strategy, etc.)
- For non-trivial changes to the Lambda output structure, it is reasonable to ask users to review the test definition to understand the impact of their changes on those synthetic examples.
- If those tests prove burdensome to maintain in the future, we can easily decide to remove them. (I just said so, so you wouldn't feel bad about suggesting it.)

(cc @trefis and @Octachron who are most likely to have an opinion about this PR.)