### PR TITLE
Add a reference to the paper describing the recursive bindings check

### DIFF
--- a/typing/rec_check.ml
+++ b/typing/rec_check.ml
@@ -16,7 +16,11 @@
 (*                                                                        *)
 (**************************************************************************)
 
-(** Static checking of recursive declarations
+(** Static checking of recursive declarations, as described in
+
+      A practical mode system for recursive definitions
+      Alban Reynaud, Gabriel Scherer and Jeremy Yallop
+      POPL 2021
 
 Some recursive definitions are meaningful
 {[


### PR DESCRIPTION
In #12549, @lthis observes that the implementation of the recursive bindings check doesn't link to the paper that documents the check:

> The mode computation is rather well documented, both in the implementation and in an associated paper: A Practical Mode System for Recursive Definitions, by Alban Reynaud, Gabriel Scherer and Jeremy Yallop (that is unfortunately not linked to in the source file, but can be found from the authors' websites).

This PR adds a link to the paper.