### PR TITLE
Matching: more debug

### DIFF
--- a/Changes
+++ b/Changes
@@ -281,7 +281,7 @@ Working version
   artifacts in preparation for better unicode support for OCaml source files.
   (Florian Angeletti, review by Gabriel Scherer)
 
-- #12532: improve readability of the pattern-matching debug output
+- #12532, #12553: improve readability of the pattern-matching debug output
   (Gabriel Scherer, review by Thomas Refis)
 
 ### Build system:

--- a/lambda/matching.ml
+++ b/lambda/matching.ml
@@ -104,6 +104,10 @@ let debugf fmt =
   then Format.eprintf fmt
   else Format.ifprintf Format.err_formatter fmt
 
+let pp_partial ppf = function
+  | Total -> Format.fprintf ppf "Total"
+  | Partial -> Format.fprintf ppf "Partial"
+
 (*
    Compatibility predicate that considers potential rebindings of constructors
    of an extension type.
@@ -3427,12 +3431,9 @@ and combine_handlers ~scopes repr partial ctx (v, str, arg) first_match rem =
 (* verbose version of do_compile_matching, for debug *)
 and do_compile_matching_pr ~scopes repr partial ctx x =
   debugf
-    "@[<v>MATCH %s\
+    "@[<v>MATCH %a\
      @,%a"
-    ( match partial with
-    | Partial -> "Partial"
-    | Total -> "Total"
-    )
+    pp_partial partial
     pretty_precompiled x;
   debugf "@,@[<v 2>CTX:@,%a@]"
     Context.pp ctx;

--- a/lambda/matching.ml
+++ b/lambda/matching.ml
@@ -2735,6 +2735,10 @@ let complete_pats_constrs = function
 *)
 
 let mk_failaction_neg partial ctx def =
+  debugf
+    "@,@[<v 2>COMBINE (mk_failaction_neg %a)@]"
+    pp_partial partial
+  ;
   match partial with
   | Partial -> (
       match Default_environment.pop def with
@@ -2783,13 +2787,14 @@ let mk_failaction_pos partial seen ctx defs =
         defs
     in
     debugf
-      "@,@[<v 2>COMBINE (mk_failaction_pos)@,\
+      "@,@[<v 2>COMBINE (mk_failaction_pos %a)@,\
            %a@,\
            @[<v 2>FAIL PATTERNS:@,\
              %a@]@,\
            @[<v 2>POSITIVE JUMPS:@,\
              %a@]\
            @]"
+      pp_partial partial
       Default_environment.pp defs
       (Format.pp_print_list ~pp_sep:Format.pp_print_cut
          Printpat.pretty_pat) fail_pats

--- a/testsuite/tests/typing-warnings/exhaustiveness.ml
+++ b/testsuite/tests/typing-warnings/exhaustiveness.ml
@@ -333,7 +333,7 @@ Line 1, characters 8-37:
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
-(_, 1)
+({ _ }, 1)
 
 val f : 'a ref * int -> int = <fun>
 |}]

--- a/typing/printpat.ml
+++ b/typing/printpat.ml
@@ -84,7 +84,7 @@ let rec pretty_val : type k . _ -> k general_pattern -> _ = fun ppf v ->
             | (_,_,{pat_desc=Tpat_any}) -> false (* do not show lbl=_ *)
             | _ -> true) lvs in
       begin match filtered_lvs with
-      | [] -> fprintf ppf "_"
+      | [] -> fprintf ppf "{ _ }"
       | (_, lbl, _) :: q ->
           let elision_mark ppf =
             (* we assume that there is no label repetitions here *)


### PR DESCRIPTION
This is an update on the now-merged #12532, adding smaller, more specialized changes to the pattern-matching debug output that were useful to track #7241.

The notable change is in the first commit. Quoting the commit message:

> Before this commit, a record pattern that accepts all values for all
its fields will be pretty-printed (in exhaustivity counter-examples
and in the debug output of the pattern-matching compiler0 as
a wildcard pattern `_`. This is correct for users, but it gives
inaccurate information in the debug output, as the two patterns are
distinct.
>
> Instead I propose to show `{ _ }` in this case, to mean a record whose
field values do not matter. This happens to not be valid OCaml syntax,
but it is perfectly understandable (it is the 0-ary version of the
`{ <fields>; _ }` syntax) and thus unlikely to confuse users.

The same code is used to print patterns in debug output, and to show exhaustiveness counter-examples to users. For debug output it is really necessary to differentiate `_` from say `{ contents = _ }` (which reads a mutable field) to understand what is going on. (I am not sure that such patterns are ever shown to users, as intuitively all-wildcard record patterns should not occur in exhaustiveness counter-examples.)