### PR TITLE
non-exhaustive fix for the Pattern Matching Bug

### DIFF
--- a/Changes
+++ b/Changes
@@ -28,6 +28,12 @@ _______________
   unsupported native backends (POWER, riscv64 and s390x)
   (Miod Vallat, review by Nicolás Ojeda Bär)
 
+- #7241, #12555: fix a soundness bug in the pattern-matching compiler
+  when side-effects mutate the scrutinee during matching.
+  Note that #7241 is not fully fixed yet, see the issue for the
+  current status.
+  (Gabriel Scherer, review by Nick Roberts)
+
 ### Standard library:
 
 - #12133: Expose support for printing substrings in Format

--- a/lambda/matching.ml
+++ b/lambda/matching.ml
@@ -541,11 +541,10 @@ end = struct
     (** Recombination of contexts.
         For example:
           { (_,_)::left; p1::p2::right } -> { left; (p1,p2)::right }
-        All mutable fields are replaced by '_', since side-effects in
-        guards can alter these fields. *)
+    *)
     let combine { left; right } =
       match left with
-      | p :: ps -> { left = ps; right = set_args_erase_mutable p right }
+      | p :: ps -> { left = ps; right = set_args p right }
       | _ -> assert false
   end
 

--- a/testsuite/tests/match-side-effects/partiality.ml
+++ b/testsuite/tests/match-side-effects/partiality.ml
@@ -17,9 +17,7 @@ let f x =
    (field_mut 1) access, or the second access should include
    a Match_failure case.
 
-   FAIL: the second occurrence of (field_mut 1) is used with a direct
-   (field_imm 0) access without a constructor check. The compiler is
-   unsound here. *)
+   PASS: the second access includes a Match_failure case. *)
 [%%expect {|
 0
 type t = { a : bool; mutable b : int option; }
@@ -31,7 +29,9 @@ type t = { a : bool; mutable b : int option; }
            (if *match*/286
              (if (seq (setfield_ptr 1 x/282 0) 0) 2
                (let (*match*/287 =o (field_mut 1 x/282))
-                 (field_imm 0 *match*/287)))
+                 (if *match*/287 (field_imm 0 *match*/287)
+                   (raise
+                     (makeblock 0 (global Match_failure/18!) [0: "" 4 2])))))
              1))
          0)))
   (apply (field_mut 1 (global Toploop!)) "f" f/280))

--- a/testsuite/tests/match-side-effects/test_contexts_code.ml
+++ b/testsuite/tests/match-side-effects/test_contexts_code.ml
@@ -7,9 +7,10 @@
 #use "contexts_1.ml";;
 (* Notice that (field_mut 1 input) occurs twice, it
    is evaluated once in the 'false' branch and once in the 'true'
-   branch. The compiler assumes that its static knowledge about the
+   branch. The compiler does not assume that its static knowledge about the
    first read (it cannot be a [Right] as we already matched against it
-   and failed) also applies to the second read, which is unsound.
+   and failed) also applies to the second read, and it inserts a Match_failure
+   case if [Right] is read again.
 *)
 [%%expect {|
 
@@ -39,7 +40,12 @@ let example_1 () =
               case tag 0:
                (if (seq (setfield_ptr 1 input/312 [1: 3]) 0) [1: 3]
                  (let (*match*/339 =o (field_mut 1 input/312))
-                   (makeblock 0 (int) (field_imm 0 *match*/339))))
+                   (switch* *match*/339
+                    case tag 0: (makeblock 0 (int) (field_imm 0 *match*/339))
+                    case tag 1:
+                     (raise
+                       (makeblock 0 (global Match_failure/18!)
+                         [0: "contexts_1.ml" 17 2])))))
               case tag 1: [1: 2]))
            [1: 1]))))
   (apply (field_mut 1 (global Toploop!)) "example_1" example_1/310))

--- a/testsuite/tests/match-side-effects/test_contexts_results.ml
+++ b/testsuite/tests/match-side-effects/test_contexts_results.ml
@@ -10,10 +10,10 @@ val example_1 : unit -> (bool, int) Result.t = <fun>
 |}]
 
 let _ = example_1 ();;
-(* <unknown constructor> means that we got an 'unsound boolean',
-   which is neither 'true' nor 'false'. There was a bug here! *)
+(* Getting a Match_failure is not the only reasonable behavior
+   for this test, but it is sound. *)
 [%%expect {|
-- : (bool, int) Result.t = Result.Ok <unknown constructor>
+Exception: Match_failure ("contexts_1.ml", 17, 2).
 |}]
 
 #use "contexts_2.ml";;
@@ -24,7 +24,8 @@ val example_2 : unit -> (bool, int) Result.t = <fun>
 |}];;
 
 let _ = example_2 ();;
-(* Also a bug! *)
+(* <unknown constructor> means that we got an 'unsound boolean',
+   which is neither 'true' nor 'false'. There was a bug here! *)
 [%%expect {|
 - : (bool, int) Result.t = Result.Ok <unknown constructor>
 |}]

--- a/typing/parmatch.mli
+++ b/typing/parmatch.mli
@@ -75,13 +75,11 @@ val lubs : pattern list -> pattern list -> pattern list
 
 val get_mins : ('a -> 'a -> bool) -> 'a list -> 'a list
 
-(** Those two functions recombine one pattern and its arguments:
+(** This function recombines one pattern and its arguments:
     For instance:
       (_,_)::p1::p2::rem -> (p1, p2)::rem
-    The second one will replace mutable arguments by '_'
 *)
 val set_args : pattern -> pattern list -> pattern list
-val set_args_erase_mutable : pattern -> pattern list -> pattern list
 
 val pat_of_constr : pattern -> constructor_description -> pattern
 val complete_constrs :


### PR DESCRIPTION
The infamous Pattern Matching Bug #7241 is a conjunction of two issues, two things that go wrong in the pattern-matching compiler when the scrutinee is mutated during matching:

1. Context information can become incorrect.
2. Totality information can become incorrect.

The present PR fixes issue 1: context information is fixed, and some instance of the bug are thus fixed. Issue 2 remains, so other instances of the bug remain unfixed.

People who are already familiar with the pattern-matching can review
the PR right away, commit by commit (there are only two).
For the others, the rest of the present PR description explains the
issue. It also contains a comparison with an alternative fix that
@trefis and myself wrote together -- I ended up preferring the
approach in the present PR.

## A repro case

Consider the following program:

```ocaml
type t = { a : bool; mutable b : int option }

let f guard x = match x with
| { a = false; b = _ } -> 0
| { a = true; b = None } -> 1
| { a = _; b = _ } when guard () -> 2
| { a = _; b = Some n } -> n
```

### Primer on compilation with pattern matrices

The pattern-matching compiler will see the `match x with` clauses as the following *pattern matrix*:

```
args: (x.(0)   x.(1))
clauses:
      (false   _)               -> 0
      (true    None)            -> 1
      (_       _) when guard () -> 2
      (_       Some n)          -> n
```

The general compilation strategy is to "switch" on the arguments of the matrix one after another, from left to right. However, in this example the first column cannot be turned into a single switch on `x.(0)` (with cases for `true` and `false`) without duplicating cases, and the third and fourth clauses would need to be repeated for both `true` and `false`.

When this happens the matrix is "split" into several matrices that are tried in sequence (in source order), stitched together using "static exceptions". The matrix above will be split as follows:

```
start:
       false   _                    -> 0
       true    None                 -> 1

exit 1:
       _       _      when guard () -> 2

exit 2:
       _       Some n               -> n
```

Then each of those sub-matrices can either "switch" on its first column or just ignore it, and recursively compile the second column. The final compiled code could be shown as this pseudo-code (try the `-drawlambda` flag to see the real thing):

```ocaml
static-catch
  let xa = x.(0) in
  switch xa with
  | false -> 0
  | true ->
    let xb = x.(1) in
    begin switch xb with
    | None -> 1
    | _ -> static-raise 1
    end
with
| 1 ->
  if guard () then 2 else static-raise 2
| 2 ->
  let xb' = x.(1) in
  switch xb' with
  | Some -> xb'.(0)
```

(`switch` is like a match on the head constructor, does not bind any variable -- fields and constructor arguments are accessed with `x.(i)` -- and `static-catch` and `static-raise` are like "static" exceptions, but the exception names are just number.)

In each sub-matrix, the argument expressions `x.(0)` and `x.(1)` are bound on-demand, when the corresponding column is switched on. This explains why `x.(0)` is bound once in the generated code (it is the leftmost column, switched on first), while `x.(1)` is bound inside the `start` submatrix and also in the `exit 2` submatrix.

This code is compiled in an unsound way because the pattern-match compiler believes that the very last switch on `xb'` cannot fail: that necessarily it must be a `Some` constructor, so `switch xb' with Some -> xb'.(0)` is optimized into `xb'.(0)`. This belief comes from the fact that we already checked `x.(1)` against `None` in the branche `1`. But the value observed could have been
`Some _` initially and then *mutated* into `None` by the `guard ()` function call. The unchecked access to `xb'.(0)`, that is `None.(1)`, would then segfault.

### Context information

The pattern-matching compiler maintains "context information", it
tracks some knowledge about the possible values of the sub-values of
the scrutinee. At the point where `static-raise 1` is called, we have
matched `x.(0)` on `true` and `x.(1)` did not match `None`, so we can
deduce that we are in the following context:

```
args: (x.(0)    x.(1))
ctx:  (true     Some _)
```

This information can be invalidated by calling `guard ()`, so the
mutable field lookup `xb' = x.(1)` can observe a different value for `x.(1)`; but the pattern compiler missed this and assume that the last switch was exhaustive.

### set_args_erase_mutable

The pattern-matching compiler contains code to prevent incorrect
information caused by side-effects: whenever it "combines" information from several arguments of a pattern into information on the whole pattern, it will "erase" its information on arguments in mutable position. This is the role of the `set_args_erase_mutable` function called in `Context.combine`.

For example, at the first point where we call `static-raise 1`, the context information is

```
args: (x.(0)    x.(1))
ctx:  (true     Some _)
```

If we asked for the context "from the point of view of `x`", that is outside the `Bar -> ...` branch, we would *not* get the anser

```
args: (x)
ctx:  ({ a = true; b = Some _ })
```

but instead the answer

```
args: (x)
ctx:  ({ a = true; b = _ })
```

as information on the field `b`, which may be invalidated by side-effects, is erased from the combined context when moving from sub-patterns on the fields `x.(0)` and `x.(1)` to the toplevel record pattern.

Unfortunately, this erasure occurs "too late", at the scope of the match on the whole record. Inside the match on the two-column submatrix, the context information for the field `x.(1)` (the second column of the pattern matrices) is preserved, but the access expression `x.(1)` may be evaluated several times and return different results.

Remark: if we changed the clauses from

```ocaml
| { a = false } -> 0
| { a = true; b = None } -> 1
| { a = _; b = _ } when guard () -> 2
| { a = _; b = Some n } -> n
```

to the apparently-equivalent

```ocaml
| { a = false } -> 0
| { a = true; b = None } -> 1
| _ when guard () -> 2
| { a = _; b = Some n } -> n
```

then the third clause `_ when guard ()` is "at toplevel" and
`set_args_erase_mutable` gets called, providing the correct context to
the fourth clause. (The clause remains compiled incorrectly due to the
orthogonal "incorrect totality information" issue.)


### Two approaches

We want to guarantee that context information on a column does not outlive the binding to its argument expression, when the argument expression is mutable.

There are two approaches to ensure this:

- Bind mutable fields earlier.

   One could change the bindings of mutable fields to happen as soon as
   the record constructor with fields is matched on, instead of binding them on-demand.

   Instead of

   ```ocaml
   static-catch
     ..
     let xb = x.(1) in switch xb with ...
   with
   ...
   | 2 -> let xb' = x.(1) in switch xb' with ...
   ```

   we would have

   ```ocaml
   let xb = x.(1) in
   static-catch
     ..
     switch xb with ...
   with
   ...
   | 2 -> switch xb with ...
   ```

   If we do this, the binding of `x.(1)` scopes for as long as the context information about it. The context information on `x.(1)` is erased by `set_args_erase_mutable` at the toplevel of the whole code fragment, that is exactly when exiting the scope of the `let xb = x.(1)` binding.

   This is the approach that @trefis and myself proposed in https://github.com/ocaml/ocaml/issues/7241#issuecomment-1655821178.

- Erase contexts more often.

  Instead of erasing the context information on the mutable fields when we leave the record-matching clauses, we could erase the context information of each split submatrix, whenever we leave the scope of the corresponding argument binding.

  This is the approach implemented in the current PR.

I have implemented both approaches, and I prefer the second one.

### Binding fields earlier

The problem with binding mutable fields earlier is that we may end up reading mutable fields that are not necessary. Consider the following variant:

```ocaml
match x with
| {a = true; _} -> 0
| {a = false; None} -> -1
| {a = false; Some n} -> n
```

Binding fields earlier would give code looking like the following

```ocaml
let xb = x.(1) in
let xa = x.(0) in
switch xa with
| true -> 0
| false ->
  switch xb with
  | None -> -1
  | Some -> xb.(0)
```

Notice that in the `xa = true` case, we have performed an unnecessary read of `x.(1)` before returning `0`.

Changing the pattern-matching compiler to bind mutable fields earlier than today (reduces code size and) risks adding useless mutable field reads in existing code paths.
I find it difficult to predict the performance at impact of the change, and so I would rather avoid it. (On the positive side: fields are close to each other in memory, so accessing extra fields is cheap, and we don't have a read barrier, even on mutable reads.)

In particular, note that even clauses that are *not* split in several submatrices -- as in the variant just above -- pay through extra bindings in some cases.

### Erasing context information

Erasing context information means that we could be unable to prove that a given incomplete switch cannot fail. In particular the second exit of our running example:

```ocaml
  | 2 ->
    let xb' = x.(1) in
    switch xb' with
    | Some -> xb'.(0)
```

would become compiled as follows:

```ocaml
  | 2 ->
    let xb_3 = x.(1) in
    switch xb_3 with
    | Some -> xb_3.(1)
    | None -> raise (Match_failure ...)
```

which adds an extra test to account for the possibility of mutation between field accesses.

With this approach, the overall code-generation strategy of the pattern-matching compiler is unchanged -- the binding of arguments is delayed as late as possible, as intentionally designed -- but context information is weakened in some places that involve split submatrices. In particular, if there are not split submatrices (which is the common case), there is no performance penalty for mutable fields.

### Getting rid of set_args_erase_mutable

With the "second approach" implemented in this PR, we erase the context information of mutable fields earlier, as soon as their argument bindings gets out of scope. By the time we "combine" all field arguments into a single record pattern, they have already been erased, and there is no need for a second erasure in `set_args_erase_mutable`. The second commit in the PR gets rid of the `set_args_erase_mutable` logic, which simplifies the code. We remove an attempt at avoiding issues with side-effects that proved insufficient, instead of piling more defenses on top of it.
