### PR TITLE
non-exhaustive fix for the Pattern Matching Bug, take two

### DIFF
--- a/lambda/matching.ml
+++ b/lambda/matching.ml
@@ -4061,7 +4061,7 @@ let do_for_multiple_match ~scopes loc v_args pat_act_list partial =
     let partial = check_partial pat_act_list partial in
     let rows = map_on_rows (fun p -> (p, [])) pat_act_list in
     toplevel_handler ~scopes loc ~failer:Raise_match_failure
-      partial [ (arg, Strict) ] rows in
+      partial [ (arg, Alias) ] rows in
   handler (fun partial pm1 ->
     let pm1_half =
       { pm1 with cases = List.map (half_simplify_nonempty ~arg) pm1.cases }

--- a/lambda/matching.ml
+++ b/lambda/matching.ml
@@ -3972,7 +3972,7 @@ let for_let ~scopes loc param pat body =
 (* Easy case since variables are available *)
 let for_tupled_function ~scopes loc paraml pats_act_list partial =
   let partial = check_partial_list pats_act_list partial in
-  let args = List.map (fun id -> (Lvar id, Strict)) paraml in
+  let args = List.map (fun id -> (Lvar id, Alias)) paraml in
   let handler =
     toplevel_handler ~scopes loc ~failer:Raise_match_failure
       partial args pats_act_list in

--- a/testsuite/tests/match-side-effects/partiality.ml
+++ b/testsuite/tests/match-side-effects/partiality.ml
@@ -56,9 +56,10 @@ type t = { a : bool; mutable b : int option; }
 (let
   (f/288 =
      (function x/289 : int
-       (let (*strict*/291 =o (field_mut 1 x/289))
-         (if (field_int 0 x/289)
-           (if *strict*/291 (field_imm 0 *strict*/291) 1) 0))))
+       (if (field_int 0 x/289)
+         (let (*strict*/291 =o (field_mut 1 x/289))
+           (if *strict*/291 (field_imm 0 *strict*/291) 1))
+         0)))
   (apply (field_mut 1 (global Toploop!)) "f" f/288))
 val f : t -> int = <fun>
 |}]

--- a/testsuite/tests/match-side-effects/partiality.ml
+++ b/testsuite/tests/match-side-effects/partiality.ml
@@ -26,14 +26,13 @@ type t = { a : bool; mutable b : int option; }
 (let
   (f/279 =
      (function x/281 : int
-       (if (field_int 0 x/281)
-         (let (*match*/285 =o (field_mut 1 x/281))
-           (if *match*/285
+       (let (*strict*/283 =o (field_mut 1 x/281))
+         (if (field_int 0 x/281)
+           (if *strict*/283
              (if (seq (setfield_ptr 1 x/281 0) 0) 2
-               (let (*match*/286 =o (field_mut 1 x/281))
-                 (field_imm 0 *match*/286)))
-             1))
-         0)))
+               (field_imm 0 *strict*/283))
+             1)
+           0))))
   (apply (field_mut 1 (global Toploop!)) "f" f/279))
 val f : t -> int = <fun>
 |}]
@@ -55,13 +54,12 @@ let f x =
 0
 type t = { a : bool; mutable b : int option; }
 (let
-  (f/290 =
-     (function x/291 : int
-       (if (field_int 0 x/291)
-         (let (*match*/295 =o (field_mut 1 x/291))
-           (if *match*/295 (field_imm 0 *match*/295) 1))
-         0)))
-  (apply (field_mut 1 (global Toploop!)) "f" f/290))
+  (f/288 =
+     (function x/289 : int
+       (let (*strict*/291 =o (field_mut 1 x/289))
+         (if (field_int 0 x/289)
+           (if *strict*/291 (field_imm 0 *strict*/291) 1) 0))))
+  (apply (field_mut 1 (global Toploop!)) "f" f/288))
 val f : t -> int = <fun>
 |}]
 
@@ -84,21 +82,21 @@ let f r =
    unsound here. *)
 [%%expect {|
 (let
-  (f/297 =
-     (function r/298 : int
-       (let (*match*/300 = (makeblock 0 r/298))
+  (f/293 =
+     (function r/294 : int
+       (let (*match*/296 = (makeblock 0 r/294))
          (catch
-           (if *match*/300
-             (let (*match*/302 =o (field_mut 0 (field_imm 0 *match*/300)))
-               (if *match*/302 (exit 7) 0))
+           (if *match*/296
+             (let (*strict*/298 =o (field_mut 0 (field_imm 0 *match*/296)))
+               (if *strict*/298 (exit 7) 0))
              (exit 7))
           with (7)
-           (if (seq (setfield_ptr 0 r/298 0) 0) 1
-             (if *match*/300
-               (let (*match*/304 =o (field_mut 0 (field_imm 0 *match*/300)))
-                 (field_imm 0 *match*/304))
+           (if (seq (setfield_ptr 0 r/294 0) 0) 1
+             (if *match*/296
+               (let (*strict*/300 =o (field_mut 0 (field_imm 0 *match*/296)))
+                 (field_imm 0 *strict*/300))
                3))))))
-  (apply (field_mut 1 (global Toploop!)) "f" f/297))
+  (apply (field_mut 1 (global Toploop!)) "f" f/293))
 val f : int option ref -> int = <fun>
 |}]
 
@@ -118,10 +116,10 @@ let test = function
 0
 type _ t = Int : int -> int t | Bool : bool -> bool t
 (let
-  (test/308 =
-     (function param/311 : int
-       (if param/311 (field_imm 0 (field_imm 0 param/311)) 0)))
-  (apply (field_mut 1 (global Toploop!)) "test" test/308))
+  (test/304 =
+     (function param/307 : int
+       (if param/307 (field_imm 0 (field_imm 0 param/307)) 0)))
+  (apply (field_mut 1 (global Toploop!)) "test" test/304))
 val test : int t option -> int = <fun>
 |}]
 
@@ -139,11 +137,11 @@ let test = function
 0
 type _ t = Int : int -> int t | Bool : bool -> bool t
 (let
-  (test/316 =
-     (function param/318 : int
-       (let (*match*/319 =o (field_mut 0 param/318))
-         (if *match*/319 (field_imm 0 (field_imm 0 *match*/319)) 0))))
-  (apply (field_mut 1 (global Toploop!)) "test" test/316))
+  (test/312 =
+     (function param/314 : int
+       (let (*strict*/315 =o (field_mut 0 param/314))
+         (if *strict*/315 (field_imm 0 (field_imm 0 *strict*/315)) 0))))
+  (apply (field_mut 1 (global Toploop!)) "test" test/312))
 val test : int t option ref -> int = <fun>
 |}]
 
@@ -164,18 +162,18 @@ let test n =
 0
 type _ t = Int : int -> int t | Bool : bool -> bool t
 (let
-  (test/324 =
-     (function n/325 : int
+  (test/320 =
+     (function n/321 : int
        (let
-         (*match*/328 =
+         (*match*/324 =
             (makeblock 0 (makeblock 0 (makemutable 0 (int) 1) [0: 42])))
-         (if *match*/328
+         (if *match*/324
            (let
-             (*match*/329 =a (field_imm 0 *match*/328)
-              *match*/331 =o (field_mut 0 (field_imm 0 *match*/329)))
-             (if *match*/331 (field_imm 0 (field_imm 1 *match*/329))
-               (~ (field_imm 0 (field_imm 1 *match*/329)))))
+             (*match*/325 =a (field_imm 0 *match*/324)
+              *strict*/327 =o (field_mut 0 (field_imm 0 *match*/325)))
+             (if *strict*/327 (field_imm 0 (field_imm 1 *match*/325))
+               (~ (field_imm 0 (field_imm 1 *match*/325)))))
            3))))
-  (apply (field_mut 1 (global Toploop!)) "test" test/324))
+  (apply (field_mut 1 (global Toploop!)) "test" test/320))
 val test : 'a -> int = <fun>
 |}]

--- a/testsuite/tests/match-side-effects/strict_bindings.ml
+++ b/testsuite/tests/match-side-effects/strict_bindings.ml
@@ -29,8 +29,8 @@ type ('a, 'b) mut_first = { mutable mut : 'a; immut : 'b; }
   (_no_mention/279 =
      (function param/282
        (let
-         (*strict*/283 =o (field_mut 0 param/282)
-          immut/281 =a (field_imm 1 param/282))
+         (immut/281 =a (field_imm 1 param/282)
+          *strict*/283 =o (field_mut 0 param/282))
          immut/281)))
   0)
 (let (_no_mention/279 = (function param/282 (field_imm 1 param/282))) 0)
@@ -44,8 +44,8 @@ let _no_use {immut; mut = _} = immut in ();;
   (_no_use/284 =
      (function param/287
        (let
-         (*strict*/288 =o (field_mut 0 param/287)
-          immut/286 =a (field_imm 1 param/287))
+         (immut/286 =a (field_imm 1 param/287)
+          *strict*/288 =o (field_mut 0 param/287))
          immut/286)))
   0)
 (let (_no_use/284 = (function param/287 (field_imm 1 param/287))) 0)
@@ -129,8 +129,8 @@ type ('a, 'b) mut_second = { immut : 'a; mutable mut : 'b; }
   (_matching_second_in_two_switches/306 =
      (function param/310 : int
        (let
-         (*strict*/311 =o (field_mut 1 param/310)
-          *match*/312 =a (field_imm 0 param/310))
+         (*match*/312 =a (field_imm 0 param/310)
+          *strict*/311 =o (field_mut 1 param/310))
          (if *match*/312
            (if *strict*/311 (let (n/309 =a (field_imm 0 *strict*/311)) n/309)
              0)
@@ -153,28 +153,25 @@ let _matching_second_in_one_switch : (_, _) mut_second -> _ = function
 | {immut = true ; mut = None} -> 0
 | {immut = true ; mut = Some n} -> n
 in ();;
-(* exceptation: a single mutable read in the [true] branch.
-   current (suboptimal) behavior: the mutable read is performed as the
-   top, so it is computed even in the [false] branch.
-*)
+(* exceptation: a single mutable read in the [true] branch. *)
 [%%expect {|
 (let
   (_matching_second_in_one_switch/313 =
      (function param/316 : int
-       (let
-         (*strict*/317 =o (field_mut 1 param/316)
-          *match*/318 =a (field_imm 0 param/316))
+       (let (*match*/318 =a (field_imm 0 param/316))
          (if *match*/318
-           (if *strict*/317 (let (n/315 =a (field_imm 0 *strict*/317)) n/315)
-             0)
+           (let (*strict*/317 =o (field_mut 1 param/316))
+             (if *strict*/317
+               (let (n/315 =a (field_imm 0 *strict*/317)) n/315) 0))
            -1))))
   0)
 (let
   (_matching_second_in_one_switch/313 =
      (function param/316 : int
-       (let (*strict*/317 =o (field_mut 1 param/316))
-         (if (field_imm 0 param/316)
-           (if *strict*/317 (field_imm 0 *strict*/317) 0) -1))))
+       (if (field_imm 0 param/316)
+         (let (*strict*/317 =o (field_mut 1 param/316))
+           (if *strict*/317 (field_imm 0 *strict*/317) 0))
+         -1)))
   0)
 - : unit = ()
 |}];;
@@ -201,8 +198,8 @@ in ();;
   (_matching_second_in_one_switch_among_many/324 =
      (function param/327 : int
        (let
-         (*strict*/328 =o (field_mut 1 param/327)
-          *match*/329 =a (field_imm 0 param/327))
+         (*match*/329 =a (field_imm 0 param/327)
+          *strict*/328 =o (field_mut 1 param/327))
          (switch* *match*/329
           case int 0: -1
           case int 1:
@@ -234,12 +231,11 @@ in ();;
 (let
   (_matching_second_in_two_cuts/330 =
      (function param/333 : int
-       (let
-         (*strict*/334 =o (field_mut 1 param/333)
-          *match*/335 =a (field_imm 0 param/333))
+       (let (*strict*/334 =o (field_mut 1 param/333))
          (catch
-           (if *match*/335 (if *strict*/334 (exit 1) 0)
-             (if *strict*/334 (exit 1) -1))
+           (let (*match*/335 =a (field_imm 0 param/333))
+             (if *match*/335 (if *strict*/334 (exit 1) 0)
+               (if *strict*/334 (exit 1) -1)))
           with (1) (let (n/332 =a (field_imm 0 *strict*/334)) n/332)))))
   0)
 (let

--- a/testsuite/tests/match-side-effects/strict_bindings.ml
+++ b/testsuite/tests/match-side-effects/strict_bindings.ml
@@ -1,0 +1,258 @@
+(* TEST
+ flags = "-drawlambda -dlambda";
+ expect;
+*)
+
+(* These test casees are meant to study the performance impact of
+   strict bindings of mutable fields. Each example lists two
+   intermediate representations;
+
+   -drawlambda output: exactly what the pattern compiler produced,
+    easier to see the splits / exit handlers
+
+   -dlambda output: after simplificatino, easier to check that some bindings
+    have been optimized away as expected.
+*)
+
+type ('a, 'b) mut_first = { mutable mut : 'a; immut : 'b ; };;
+
+let _no_mention {immut} = immut in ();;
+(* exceptation: no mutable read *)
+[%%expect {|
+0
+0
+type ('a, 'b) mut_first = { mutable mut : 'a; immut : 'b; }
+(let
+  (_no_mention/279 =
+     (function param/282
+       (let
+         (*match*/283 =o (field_mut 0 param/282)
+          immut/281 =a (field_imm 1 param/282))
+         immut/281)))
+  0)
+(let (_no_mention/279 = (function param/282 (field_imm 1 param/282))) 0)
+- : unit = ()
+|}];;
+
+let _no_use {immut; mut = _} = immut in ();;
+(* exceptation: no mutable read *)
+[%%expect {|
+(let
+  (_no_use/284 =
+     (function param/287
+       (let
+         (*match*/288 =o (field_mut 0 param/287)
+          immut/286 =a (field_imm 1 param/287))
+         immut/286)))
+  0)
+(let (_no_use/284 = (function param/287 (field_imm 1 param/287))) 0)
+- : unit = ()
+|}];;
+
+let _matching : _ mut_first -> _ = function
+| {mut = None} -> 0
+| {mut = Some n} -> n
+in ();;
+(* exceptation: a single mutable read *)
+[%%expect {|
+(let
+  (_matching/289 =
+     (function param/292 : int
+       (let (*match*/293 =o (field_mut 0 param/292))
+         (if *match*/293
+           (let
+             (*match*/295 =a (field_imm 1 param/292)
+              n/291 =a (field_imm 0 *match*/293))
+             n/291)
+           (let (*match*/294 =a (field_imm 1 param/292)) 0)))))
+  0)
+(let
+  (_matching/289 =
+     (function param/292 : int
+       (let (*match*/293 =o (field_mut 0 param/292))
+         (if *match*/293 (field_imm 0 *match*/293) 0))))
+  0)
+- : unit = ()
+|}];;
+
+
+let _matching_first : _ mut_first -> _ = function
+| {mut = None; immut = false} -> -1
+| {mut = None; immut = true} -> 0
+| {mut = Some n} -> n
+in ();;
+(* exceptation: a mutable read, a test, then testing [immut] *)
+[%%expect {|
+(let
+  (_matching_first/296 =
+     (function param/299 : int
+       (let (*match*/300 =o (field_mut 0 param/299))
+         (if *match*/300
+           (let
+             (*match*/302 =a (field_imm 1 param/299)
+              n/298 =a (field_imm 0 *match*/300))
+             n/298)
+           (let (*match*/301 =a (field_imm 1 param/299))
+             (if *match*/301 0 -1))))))
+  0)
+(let
+  (_matching_first/296 =
+     (function param/299 : int
+       (let (*match*/300 =o (field_mut 0 param/299))
+         (if *match*/300 (field_imm 0 *match*/300)
+           (if (field_imm 1 param/299) 0 -1)))))
+  0)
+- : unit = ()
+|}];;
+
+
+type ('a, 'b) mut_second = { immut : 'a; mutable mut : 'b; };;
+(* The pattern-matching order is (currently) determined by the field
+   order in the type declaration! Swapping the two fields in the
+   declaration means that the immutable value will be tested first. *)
+
+let _matching_second_in_two_switches : (_, _) mut_second -> _ = function
+| {immut = false; mut = None} -> -1
+| {immut = false; mut = Some n} -> -n
+| {immut = true ; mut = None} -> 0
+| {immut = true ; mut = Some n} -> n
+in ();;
+(* exceptation: two mutable read, one in each branch of an 'if' on [immut] *)
+[%%expect {|
+0
+0
+type ('a, 'b) mut_second = { immut : 'a; mutable mut : 'b; }
+(let
+  (_matching_second_in_two_switches/306 =
+     (function param/310 : int
+       (let (*match*/311 =a (field_imm 0 param/310))
+         (if *match*/311
+           (let (*match*/313 =o (field_mut 1 param/310))
+             (if *match*/313 (let (n/309 =a (field_imm 0 *match*/313)) n/309)
+               0))
+           (let (*match*/312 =o (field_mut 1 param/310))
+             (if *match*/312
+               (let (n/308 =a (field_imm 0 *match*/312)) (~ n/308)) -1))))))
+  0)
+(let
+  (_matching_second_in_two_switches/306 =
+     (function param/310 : int
+       (if (field_imm 0 param/310)
+         (let (*match*/313 =o (field_mut 1 param/310))
+           (if *match*/313 (field_imm 0 *match*/313) 0))
+         (let (*match*/312 =o (field_mut 1 param/310))
+           (if *match*/312 (~ (field_imm 0 *match*/312)) -1)))))
+  0)
+- : unit = ()
+|}];;
+
+let _matching_second_in_one_switch : (_, _) mut_second -> _ = function
+| {immut = false; _ } -> -1
+| {immut = true ; mut = None} -> 0
+| {immut = true ; mut = Some n} -> n
+in ();;
+(* exceptation: a single mutable read in the [true] branch. *)
+[%%expect {|
+(let
+  (_matching_second_in_one_switch/314 =
+     (function param/317 : int
+       (let (*match*/318 =a (field_imm 0 param/317))
+         (if *match*/318
+           (let (*match*/320 =o (field_mut 1 param/317))
+             (if *match*/320 (let (n/316 =a (field_imm 0 *match*/320)) n/316)
+               0))
+           (let (*match*/319 =o (field_mut 1 param/317)) -1)))))
+  0)
+(let
+  (_matching_second_in_one_switch/314 =
+     (function param/317 : int
+       (if (field_imm 0 param/317)
+         (let (*match*/320 =o (field_mut 1 param/317))
+           (if *match*/320 (field_imm 0 *match*/320) 0))
+         -1)))
+  0)
+- : unit = ()
+|}];;
+
+type t = A | B | C | D;;
+[%%expect {|
+0
+0
+type t = A | B | C | D
+|}];;
+
+let _matching_second_in_one_switch_among_many : (_, _) mut_second -> _ = function
+| {immut = A; _ } -> -1
+| {immut = B ; mut = None} -> 0
+| {immut = B ; mut = Some n} -> n
+| {immut = C; _ } -> -2
+| {immut = D; _ } -> -3
+in ();;
+(* exceptation: a single mutable read in the [true] branch. *)
+[%%expect {|
+(let
+  (_matching_second_in_one_switch_among_many/326 =
+     (function param/329 : int
+       (let (*match*/330 =a (field_imm 0 param/329))
+         (switch* *match*/330
+          case int 0: (let (*match*/331 =o (field_mut 1 param/329)) -1)
+          case int 1:
+           (let (*match*/332 =o (field_mut 1 param/329))
+             (if *match*/332 (let (n/328 =a (field_imm 0 *match*/332)) n/328)
+               0))
+          case int 2: (let (*match*/333 =o (field_mut 1 param/329)) -2)
+          case int 3: (let (*match*/334 =o (field_mut 1 param/329)) -3)))))
+  0)
+(let
+  (_matching_second_in_one_switch_among_many/326 =
+     (function param/329 : int
+       (switch* (field_imm 0 param/329)
+        case int 0: -1
+        case int 1:
+         (let (*match*/332 =o (field_mut 1 param/329))
+           (if *match*/332 (field_imm 0 *match*/332) 0))
+        case int 2: -2
+        case int 3: -3)))
+  0)
+- : unit = ()
+|}];;
+
+let _matching_second_in_two_cuts : (_, _) mut_second -> _ = function
+| {immut = false; mut = None} -> -1
+| {immut = true ; mut = None} -> 0
+| {immut = _ ;    mut = Some n} -> n
+in ();;
+(* exceptation: a mutable read in each switch -- the second is in an
+   exit handler. *)
+[%%expect {|
+(let
+  (_matching_second_in_two_cuts/335 =
+     (function param/338 : int
+       (let (*match*/339 =a (field_imm 0 param/338))
+         (catch
+           (if *match*/339
+             (let (*match*/341 =o (field_mut 1 param/338))
+               (if *match*/341 (exit 1) 0))
+             (let (*match*/340 =o (field_mut 1 param/338))
+               (if *match*/340 (exit 1) -1)))
+          with (1)
+           (let
+             (*match*/342 =o (field_mut 1 param/338)
+              n/337 =a (field_imm 0 *match*/342))
+             n/337)))))
+  0)
+(let
+  (_matching_second_in_two_cuts/335 =
+     (function param/338 : int
+       (catch
+         (if (field_imm 0 param/338)
+           (let (*match*/341 =o (field_mut 1 param/338))
+             (if *match*/341 (exit 1) 0))
+           (let (*match*/340 =o (field_mut 1 param/338))
+             (if *match*/340 (exit 1) -1)))
+        with (1)
+         (let (*match*/342 =o (field_mut 1 param/338))
+           (field_imm 0 *match*/342)))))
+  0)
+- : unit = ()
+|}];;

--- a/testsuite/tests/match-side-effects/test_contexts_results.ml
+++ b/testsuite/tests/match-side-effects/test_contexts_results.ml
@@ -10,10 +10,8 @@ val example_1 : unit -> (bool, int) Result.t = <fun>
 |}]
 
 let _ = example_1 ();;
-(* <unknown constructor> means that we got an 'unsound boolean',
-   which is neither 'true' nor 'false'. There was a bug here! *)
 [%%expect {|
-- : (bool, int) Result.t = Result.Ok <unknown constructor>
+- : (bool, int) Result.t = Result.Ok true
 |}]
 
 #use "contexts_2.ml";;
@@ -24,7 +22,8 @@ val example_2 : unit -> (bool, int) Result.t = <fun>
 |}];;
 
 let _ = example_2 ();;
-(* Also a bug! *)
+(* <unknown constructor> means that we got an 'unsound boolean',
+   which is neither 'true' nor 'false'. There is a bug here! *)
 [%%expect {|
 - : (bool, int) Result.t = Result.Ok <unknown constructor>
 |}]


### PR DESCRIPTION
This PR implements the "alternative approach of binding mutable fields" earlier to fix the "incorrect context information" half of the Pattern Matching Bug #7241. This approach was jointly designed with @trefis. See the detailed description of the situation in #12555, which implements another fix for the same issue which I prefer.

This PR is larger than #12555, it contains the following:

- a new testsuite file specifically designed to study the impact on generated code of this change
- the bugfix itself, which works by special-casing intermediate arguments that have "let strictness" Strict or StrictOpt
- refactorings to the pattern-matching compiler to remove some other sources of Strict and StrictOpt bindings, to clarify and simplify the codebase ; without this simplification, I personally find hard to convince myself that "the bugfix itself" actually fixes all instance of the issue.
- finally, an optimization to push the "strict bindings" inside the branches in some cases where detect that it can avoid useless reads ; this reuses existing `lower_bind` logic from the pattern-matching compiler. (I explicitly decided against being *more* aggressive than the current optimization.)

The testsuite is updated at each commit, and looking at its diff for a given commit can be a good way to see the impact of code-generation changes in the commit.
