### PR TITLE
Adapt Gc alarms for multicore

### DIFF
--- a/Changes
+++ b/Changes
@@ -154,7 +154,7 @@ Working version
   of modules Int32, Int64, and Nativeint
   (Xavier Leroy, review by Gabriel Scherer and Daniel Bünzli)
 
-- #12557: Adapt GC alarms for multicore and fix their documentation.
+- #12558: Adapt GC alarms for multicore and fix their documentation.
   (Guillaume Munch-Maccagnoni, review by)
 
 ### Other libraries:

--- a/Changes
+++ b/Changes
@@ -154,6 +154,9 @@ Working version
   of modules Int32, Int64, and Nativeint
   (Xavier Leroy, review by Gabriel Scherer and Daniel Bünzli)
 
+- #12557: Adapt GC alarms for multicore and fix their documentation.
+  (Guillaume Munch-Maccagnoni, review by)
+
 ### Other libraries:
 
 - #12213: Dynlink library, improve legibility of error messages

--- a/stdlib/.depend
+++ b/stdlib/.depend
@@ -359,6 +359,7 @@ stdlib__Gc.cmo : gc.ml \
     stdlib__Printf.cmi \
     stdlib__Printexc.cmi \
     stdlib__Fun.cmi \
+    stdlib__Domain.cmi \
     stdlib__Atomic.cmi \
     stdlib__Gc.cmi
 stdlib__Gc.cmx : gc.ml \
@@ -367,6 +368,7 @@ stdlib__Gc.cmx : gc.ml \
     stdlib__Printf.cmx \
     stdlib__Printexc.cmx \
     stdlib__Fun.cmx \
+    stdlib__Domain.cmx \
     stdlib__Atomic.cmx \
     stdlib__Gc.cmi
 stdlib__Gc.cmi : gc.mli \

--- a/stdlib/domain.ml
+++ b/stdlib/domain.ml
@@ -177,10 +177,6 @@ let at_exit_key = DLS.new_key (fun () -> (fun () -> ()))
 let at_exit f =
   let old_exit : unit -> unit = DLS.get at_exit_key in
   let new_exit () =
-    (* The domain termination callbacks ([at_exit]) are run in
-       last-in-first-out (LIFO) order in order to be symmetric with the domain
-       creation callbacks ([at_each_spawn]) which run in first-in-fisrt-out
-       (FIFO) order. *)
     f (); old_exit ()
   in
   DLS.set at_exit_key new_exit

--- a/stdlib/gc.ml
+++ b/stdlib/gc.ml
@@ -112,14 +112,14 @@ let rec call_alarm arec =
     Fun.protect ~finally arec.f
   end
 
+let delete_alarm a = Atomic.set a false
 
 let create_alarm f =
   let arec = { active = Atomic.make true; f = f } in
+  Domain.at_exit (fun () -> delete_alarm arec.active);
   finalise call_alarm arec;
   arec.active
 
-
-let delete_alarm a = Atomic.set a false
 
 module Memprof =
   struct


### PR DESCRIPTION
Foreword: nobody cares about GC alarms, so let us not waste too much time on this. If you feel like suggesting corrections for typos or wording, please use the github feature for code suggestions so that I can apply them in one click.

- Gc alarms do not actually run at the end every major cycle, this has not been the case for a while, though this has been made worse by the new GC. This is not worth fixing, we simply document the fact. A use-case is added, just because this snippet of code was laying around (and in fact is the original use-case of Gc alarms).
- We delete GC alarms if their domain exits. There is no sense in having the alarm start running in a completely unrelated domain after orphaning.
- 2nd commit: Remove an outdated and superfluous comment along the way, at_each_spawn no longer exists (be reassured that its useful contents already appear inside the interface documentation).