### PR TITLE
Fix crash when combining TSan and frame-pointers

### DIFF
--- a/Changes
+++ b/Changes
@@ -386,6 +386,10 @@ Working version
   --enable-frame-pointers
   (Miod Vallat, report by Jan Midtgaard, review by Gabriel Scherer)
 
+- #12561: Fix crash when combining TSan and frame-pointers
+  (Fabrice Buoro and Olivier Nicole, report by Jan Midtgaard, review by Miod
+  Vallat and Gabriel Scherer)
+
 OCaml 5.1.0 (14 September 2023)
 -------------------------------
 

--- a/runtime/amd64.S
+++ b/runtime/amd64.S
@@ -932,16 +932,10 @@ LBL(117):
         testq   $1, Caml_state(backtrace_active)
         je    LBL(118)
 #endif
-        movq    %rax, C_ARG_1     /* arg 1: exception bucket */
-#ifdef WITH_FRAME_POINTERS
-        movq    8(%r13), C_ARG_2   /* arg 2: pc of raise */
-        leaq    16(%r13), C_ARG_3  /* arg 3: sp at raise */
-#else
-        movq    (%r13), C_ARG_2   /* arg 2: pc of raise */
-        leaq    8(%r13), C_ARG_3  /* arg 3: sp at raise */
-#endif
-        movq    Caml_state(exn_handler), C_ARG_4
-                                  /* arg 4: sp of handler */
+        movq    %rax, C_ARG_1                    /* arg 1: exception bucket */
+        movq    STACK_RETADDR(%r13), C_ARG_2     /* arg 2: pc of raise */
+        leaq    STACK_ARG_1(%r13), C_ARG_3       /* arg 3: sp at raise */
+        movq    Caml_state(exn_handler), C_ARG_4 /* arg 4: sp of handler */
         C_call  (GCALL(caml_stash_backtrace))
 #if defined(WITH_THREAD_SANITIZER)
 LBL(118):

--- a/runtime/amd64.S
+++ b/runtime/amd64.S
@@ -947,8 +947,8 @@ LBL(117):
 LBL(118):
     /* Signal to TSan all stack frames exited by the exception. No need to save
        any registers here. */
-        movq    STACK_RETADDR(%r13), C_ARG_1   /* arg 1: pc of raise */
-        leaq    STACK_ARG_1(%r13), C_ARG_2  /* arg 2: sp at raise */
+        movq    STACK_RETADDR(%r13), C_ARG_1     /* arg 1: pc of raise */
+        leaq    STACK_ARG_1(%r13), C_ARG_2       /* arg 2: sp at raise */
         movq    Caml_state(exn_handler), C_ARG_3 /* arg 3: sp of handler */
         C_call  (GCALL(caml_tsan_exit_on_raise))
 #endif
@@ -1117,8 +1117,8 @@ LBL(do_perform):
     /* Signal to TSan all stack frames exited by the perform. */
         ENTER_FUNCTION
         TSAN_SAVE_CALLER_REGS
-        movq    (%rsp), C_ARG_1   /* arg 1: pc of perform */
-        leaq    8(%rsp), C_ARG_2  /* arg 2: sp at perform */
+        movq    STACK_RETADDR(%rsp), C_ARG_1  /* arg 1: pc of perform */
+        leaq    STACK_ARG_1(%rsp), C_ARG_2    /* arg 2: sp at perform */
         SWITCH_OCAML_TO_C
         C_call  (GCALL(caml_tsan_exit_on_perform))
         SWITCH_C_TO_OCAML
@@ -1145,10 +1145,9 @@ LBL(112):
            original performer stack. For that, we perform the necessary calls
            to __tsan_func_entry via caml_tsan_entry_on_resume. */
         TSAN_SAVE_CALLER_REGS
-        movq    Stack_sp(%r10), %r11
-        movq    (%r11), C_ARG_1   /* arg 1: pc of perform */
-        leaq    8(%r11), C_ARG_2  /* arg 2: sp at perform */
-        movq    %r10, C_ARG_3     /* arg 3: fiber */
+        movq    STACK_RETADDR(%rsp), C_ARG_1       /* arg 1: pc of perform */
+        leaq    STACK_ARG_1(%rsp), C_ARG_2         /* arg 2: sp at perform */
+        movq    Caml_state(current_stack), C_ARG_3 /* arg 3: fiber */
         SWITCH_OCAML_TO_C
         C_call  (GCALL(caml_tsan_entry_on_resume))
         SWITCH_C_TO_OCAML
@@ -1197,9 +1196,9 @@ CFI_STARTPROC
         TSAN_SAVE_CALLER_REGS
     /* Signal to TSan all stack frames exited by the perform. */
         movq    Stack_sp(%r10), %r11
-        movq    (%r11), C_ARG_1   /* arg 1: pc of perform */
-        leaq    8(%r11), C_ARG_2  /* arg 2: sp at perform */
-        movq    %r10, C_ARG_3     /* arg 3: fiber */
+        movq    STACK_RETADDR(%r11), C_ARG_1  /* arg 1: pc of perform */
+        leaq    STACK_ARG_1(%r11), C_ARG_2    /* arg 2: sp at perform */
+        movq    %r10, C_ARG_3                 /* arg 3: fiber */
         SWITCH_OCAML_TO_C
         C_call  (GCALL(caml_tsan_entry_on_resume))
         SWITCH_C_TO_OCAML

--- a/runtime/amd64.S
+++ b/runtime/amd64.S
@@ -1115,6 +1115,7 @@ LBL(do_perform):
         je      LBL(112)
 #if defined(WITH_THREAD_SANITIZER)
     /* Signal to TSan all stack frames exited by the perform. */
+        ENTER_FUNCTION
         TSAN_SAVE_CALLER_REGS
         movq    (%rsp), C_ARG_1   /* arg 1: pc of perform */
         leaq    8(%rsp), C_ARG_2  /* arg 2: sp at perform */
@@ -1122,6 +1123,7 @@ LBL(do_perform):
         C_call  (GCALL(caml_tsan_exit_on_perform))
         SWITCH_C_TO_OCAML
         TSAN_RESTORE_CALLER_REGS
+        LEAVE_FUNCTION
 #endif
         SWITCH_OCAML_STACKS /* preserves r11 and rsi */
      /* We have to null the Handler_parent after the switch because the
@@ -1185,6 +1187,7 @@ CFI_STARTPROC
         jz      2f
 #if defined(WITH_THREAD_SANITIZER)
     /* Save non-callee-saved registers %rax and %r10 before C call */
+        ENTER_FUNCTION
         pushq   %rax; CFI_ADJUST(8);
         pushq   %r10; CFI_ADJUST(8);
     /* Necessary to include the caller of caml_resume in the TSan backtrace */
@@ -1201,6 +1204,7 @@ CFI_STARTPROC
         C_call  (GCALL(caml_tsan_entry_on_resume))
         SWITCH_C_TO_OCAML
         TSAN_RESTORE_CALLER_REGS
+        LEAVE_FUNCTION
 #endif
     /* Find end of list of stacks and add current */
         movq    %r10, %rsi

--- a/runtime/amd64.S
+++ b/runtime/amd64.S
@@ -1141,7 +1141,7 @@ LBL(112):
         TSAN_SAVE_CALLER_REGS
         movq    STACK_RETADDR(%rsp), C_ARG_1       /* arg 1: pc of perform */
         leaq    STACK_ARG_1(%rsp), C_ARG_2         /* arg 2: sp at perform */
-        movq    Caml_state(current_stack), C_ARG_3 /* arg 3: fiber */
+        movq    %r10, C_ARG_3                      /* arg 3: performer stack */
         SWITCH_OCAML_TO_C
         C_call  (GCALL(caml_tsan_entry_on_resume))
         SWITCH_C_TO_OCAML


### PR DESCRIPTION
This PR is a continuation of the work of @dustanddreams who noticed issues with the combination `TSan` and `frame-pointers` in https://github.com/ocaml/ocaml/pull/12535.

This PR assumes that https://github.com/ocaml/ocaml/pull/12535 will be merged since it fixes missing occurrences of `(ENTER|LEAVE)_FUNCTION` in `caml_perform` and `caml_resume`.

This PR:
- Add some more `(ENTER|LEAVE)_FUNCTION` in `caml_perform` and `caml_resume`. Indeed `caml_tsan_*` functions are written in C, and so expect to be called properly called with frame-pointers, otherwise stack scanning will fail.
- Replaces the use of hardcoded offsets for function arguments with `STACK_RETADDR`/`STACK_ARG_X` which account for possible frame-pointers.
- Simplifies `caml_raise_exn` by using these macros and removing of the `ifdef` pragma.

There is still an unrelated issue with `Effect.Unhandled` exceptions occurring with TSan regardless of frame-pointers being enabled, as noted in #12535, which we are working on.