### PR TITLE
caml_output_value_to_malloc: really use malloc

### DIFF
--- a/Changes
+++ b/Changes
@@ -306,6 +306,11 @@ Working version
 
 ### Bug fixes:
 
+- #12566: caml_output_value_to_malloc wrongly uses `caml_stat_alloc`
+  instead of `malloc` since 4.06, breaking (in pooled mode) user code
+  that uses `free` on the result.
+  (Gabriel Scherer, review by Enguerrand Decorne, report by Ido Yariv)
+
 - #12490: Unix: protect the popen_processes hashtable with a mutex
   (Gabriel Scherer, report by Olivier Nicole, review by Xavier Leroy)
 

--- a/Changes
+++ b/Changes
@@ -308,8 +308,10 @@ Working version
 
 - #12566: caml_output_value_to_malloc wrongly uses `caml_stat_alloc`
   instead of `malloc` since 4.06, breaking (in pooled mode) user code
-  that uses `free` on the result.
-  (Gabriel Scherer, review by Enguerrand Decorne, report by Ido Yariv)
+  that uses `free` on the result. Symmetrically,
+  caml_input_value_from_malloc should use `free`.
+  (Gabriel Scherer, review by Xavier Leroy and Enguerrand Decorne,
+   report by Ido Yariv)
 
 - #12490: Unix: protect the popen_processes hashtable with a mutex
   (Gabriel Scherer, report by Olivier Nicole, review by Xavier Leroy)

--- a/runtime/extern.c
+++ b/runtime/extern.c
@@ -1189,7 +1189,7 @@ CAMLexport void caml_output_value_to_malloc(value v, value flags,
 
   init_extern_output(s);
   data_len = extern_value(s, v, flags, header, &header_len);
-  res = caml_stat_alloc_noexc(header_len + data_len);
+  res = malloc(header_len + data_len);
   if (res == NULL) extern_out_of_memory(s);
   *buf = res;
   *len = header_len + data_len;


### PR DESCRIPTION
External users (unison, hhvm, pyre-check) assume that the memory they get from `caml_output_value_to_malloc` can be freed with `free`. (See https://github.com/ocaml/ocaml/issues/12491#issuecomment-1693923773 for some user codebase examples .)

The function was changed to use caml_stat_alloc in 4.06 ( 02a8b999f08dcbf6cfcdc1145f3286392d26ad52 ); this breaks user code, as one should then use `caml_stat_free`.

There is no use of caml_output_value_to_malloc in the runtime itself, so we do not need to provide a `caml_output_value_to_stat_alloc` variant.