### PR TITLE
Disable the nonreturning-statement warning for `while true` in more cases.

### DIFF
--- a/Changes
+++ b/Changes
@@ -8,7 +8,8 @@ Working version
 
 ### Language features:
 
-- #12295: Give `while true' a polymorphic type, similarly to `assert false'
+- #12295, #12568: Give `while true' a polymorphic type, similarly to
+  `assert false'
   (Jeremy Yallop, review by Nicolás Ojeda Bär and Gabriel Scherer,
   suggestion by Rodolphe Lepigre and John Whitington)
 

--- a/testsuite/tests/typing-warnings/never_returns.ml
+++ b/testsuite/tests/typing-warnings/never_returns.ml
@@ -10,6 +10,13 @@ fun () -> while true do () done; 3;;
 - : unit -> int = <fun>
 |}];;
 
+(** For now, we don't warn for non-terminating while loops, for backwards compatibility. *)
+fun () -> (if true then while true do () done else while true do () done); 3;;
+
+[%%expect{|
+- : unit -> int = <fun>
+|}];;
+
 let () = (let module L = List in raise Exit); () ;;
 [%%expect {|
 Line 1, characters 33-43:

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -5477,18 +5477,19 @@ and type_statement ?explanation env sexp =
     To avoid this issue, we disable the warning in this particular case.
     We might consider re-enabling it at a point when most users have
     migrated to OCaml 5.2.0 or later. *)
-  let allow_polymorphic e = match e.pexp_desc with
-    | Pexp_while _ -> true
+  let allow_polymorphic e = match e.exp_desc with
+    | Texp_while _ -> true
     | _ -> false
   in
   (* Raise the current level to detect non-returning functions *)
   let exp = with_local_level (fun () -> type_exp env sexp) in
+  let subexp = final_subexpression exp in
   let ty = expand_head env exp.exp_type in
   if is_Tvar ty
      && get_level ty > get_current_level ()
-     && not (allow_polymorphic sexp) then
+     && not (allow_polymorphic subexp) then
     Location.prerr_warning
-      (final_subexpression exp).exp_loc
+      subexp.exp_loc
       Warnings.Nonreturning_statement;
   if !Clflags.strict_sequence then
     let expected_ty = instance Predef.type_unit in


### PR DESCRIPTION
An improved implementation of the disabling of `nonreturning-statement` warnings for `while true`, following feedback from @polytypic in #12295.

Previously the warning was disabled for 
```ocaml
while true do ... done; e
```

This PR also disables the warning in other cases, such as

```ocaml
(if c then while true do done 
      else ...)
; e
```

and 


```ocaml
(let p = e in while true do () done); e'
```
