### PR TITLE
documentation: fix Format.make_formatter code example

### DIFF
--- a/stdlib/format.mli
+++ b/stdlib/format.mli
@@ -1041,7 +1041,7 @@ val make_formatter :
   For instance,
   {[
     make_formatter
-      (Stdlib.output oc)
+      (Stdlib.output_substring oc)
       (fun () -> Stdlib.flush oc)
   ]}
   returns a formatter to the {!Stdlib.out_channel} [oc].


### PR DESCRIPTION
Hello,

This fix a type error in the code example of `Format.make_formatter`