### PR TITLE
Makefile: build `runtop` without `otherlibraries`

### DIFF
--- a/Changes
+++ b/Changes
@@ -304,6 +304,10 @@ Working version
   started with #11243, #11248, #11268, #11420 and #11675.
   (Sébastien Hinderer, review by David Allsopp and Florian Angeletti)
 
+- #12569, #12570: remove 'otherlibraries' as a prerequisite for 'runtop';
+  use 'runtop-with-otherlibs' to use a library from otherlibs/
+  (Gabriel Scherer, review by Sébastien Hinderer, suggestion by David Allsopp)
+
 ### Bug fixes:
 
 - #12490: Unix: protect the popen_processes hashtable with a mutex

--- a/HACKING.adoc
+++ b/HACKING.adoc
@@ -399,6 +399,8 @@ installation, the following targets may be of use:
 
 `make runtop` :: builds and runs the ocaml toplevel of the distribution
                           (optionally uses `rlwrap` for readline+history support)
+                          (use `make runtop-with-otherlibs` if you need `Unix` or other
+                           `otherlibs/` libraries)
 `make natruntop`:: builds and runs the native ocaml toplevel (experimental)
 
 `make partialclean`:: Clean the OCaml files but keep the compiled C files.

--- a/Makefile
+++ b/Makefile
@@ -535,23 +535,31 @@ partialclean::
 TOPFLAGS ?=
 OC_TOPFLAGS = $(STDLIBFLAGS) -I toplevel -noinit $(TOPINCLUDES) $(TOPFLAGS)
 
-# Note: Beware that, since this rule begins with a coldstart, both
+RUN_OCAML = $(RLWRAP) $(OCAMLRUN) ./ocaml$(EXE) $(OC_TOPFLAGS)
+RUN_OCAMLNAT = $(RLWRAP) ./ocamlnat$(EXE) $(OC_TOPFLAGS)
+
+# Note: Beware that, since these rules begin with a coldstart, both
 # boot/ocamlrun and runtime/ocamlrun will be the same when the toplevel
 # is run.
 .PHONY: runtop
-runtop:
-	$(MAKE) coldstart
+runtop: coldstart
+	$(MAKE) ocamlc
+	$(MAKE) ocaml
+	@$(RUN_OCAML)
+
+.PHONY: runtop-with-otherlibs
+runtop-with-otherlibs: coldstart
 	$(MAKE) ocamlc
 	$(MAKE) otherlibraries
 	$(MAKE) ocaml
-	@$(RLWRAP) $(OCAMLRUN) ./ocaml$(EXE) $(OC_TOPFLAGS)
+	@$(RUN_OCAML)
 
 .PHONY: natruntop
 natruntop:
 	$(MAKE) core
 	$(MAKE) opt
 	$(MAKE) ocamlnat
-	@$(RLWRAP) ./ocamlnat$(EXE) $(OC_TOPFLAGS)
+	@$(RUN_OCAMLNAT)
 
 # Native dynlink
 


### PR DESCRIPTION
This shortens a cold `runtop` build from 1m20s to 40s on my machine. If you want to test an otheribs/ library (Unix, Str, etc.) from the toplevel, use the new target `runtop-with-otherlibs`.

(This comes from the discussion with @dra27 in #12569.)