### PR TITLE
Document libzstd in INSTALL.adoc

### DIFF
--- a/INSTALL.adoc
+++ b/INSTALL.adoc
@@ -38,8 +38,8 @@
 * If you do not have write access to `/tmp`, you should set the environment
   variable `TMPDIR` to the name of some other temporary directory.
 
-* The zstd library is used for compression of marshaled data, if it is not available
-  the option `--without-zstd` should be passed to `configure` disabling it.
+* The zstd library is used for compression of marshaled data. The option
+  `--without-zstd` may be passed to `configure` in order to disable it.
 
 == Prerequisites (special cases)
 

--- a/INSTALL.adoc
+++ b/INSTALL.adoc
@@ -38,6 +38,9 @@
 * If you do not have write access to `/tmp`, you should set the environment
   variable `TMPDIR` to the name of some other temporary directory.
 
+* The zstd library is used for compression of marshaled data, if it is not available
+  the option `--without-zstd` should be passed to `configure` disabling it.
+
 == Prerequisites (special cases)
 
 * Under Cygwin, the `gcc-core` package is required. `flexdll` is also necessary


### PR DESCRIPTION
I think it would be beneficial if the libzstd is mentioned in the install instructions as prerequesite together with the necessary configure option to disable it.