### PR TITLE
ocamldep refactors

### DIFF
--- a/Changes
+++ b/Changes
@@ -207,6 +207,9 @@ Working version
   (Antonin Décimo, Damien Doligez, review by Sébastien Hinderer,
    Damien Doligez, Gabriel Scherer, and Xavier Leroy)
 
+- #12576: ocamldep: various refactors.
+  (Antonin Décimo, review by Florian Angeletti, Gabriel Scherer, and Léo Andrès)
+
 ### Manual and documentation:
 
 - #12338: clarification of the documentation of process related function in

--- a/driver/makedepend.ml
+++ b/driver/makedepend.ml
@@ -13,11 +13,12 @@
 (*                                                                        *)
 (**************************************************************************)
 
+(** Print the dependencies *)
+
 open Parsetree
 module String = Misc.Stdlib.String
 
-let ppf = Format.err_formatter
-(* Print the dependencies *)
+let stderr = Format.err_formatter
 
 type file_kind = ML | MLI
 
@@ -69,7 +70,7 @@ let readdir dir =
       try
         Sys.readdir dir
       with Sys_error msg ->
-        Format.fprintf Format.err_formatter "@[Bad -I option: %s@]@." msg;
+        Format.eprintf "@[Bad -I option: %s@]@." msg;
         Error_occurred.set ();
         [||]
     in
@@ -85,14 +86,14 @@ let add_to_load_path dir =
     let contents = readdir dir in
     add_to_list load_path (dir, contents)
   with Sys_error msg ->
-    Format.fprintf Format.err_formatter "@[Bad -I option: %s@]@." msg;
+    Format.eprintf "@[Bad -I option: %s@]@." msg;
     Error_occurred.set ()
 
 let add_to_synonym_list synonyms suffix =
   if (String.length suffix) > 1 && suffix.[0] = '.' then
     add_to_list synonyms suffix
   else begin
-    Format.fprintf Format.err_formatter "@[Bad suffix: '%s'@]@." suffix;
+    Format.eprintf "@[Bad suffix: '%s'@]@." suffix;
     Error_occurred.set ()
   end
 
@@ -237,7 +238,7 @@ let print_raw_dependencies source_file deps =
 (* Process one file *)
 
 let print_exception exn =
-  Location.report_exception Format.err_formatter exn
+  Location.report_exception stderr exn
 
 let report_err exn =
   Error_occurred.set ();
@@ -397,7 +398,7 @@ let mli_file_dependencies source_file =
   files := (source_file, MLI, extracted_deps, !Depend.pp_deps) :: !files
 
 let process_file_as process_fun def source_file =
-  Compenv.readenv ppf (Before_compile source_file);
+  Compenv.readenv stderr (Before_compile source_file);
   load_path := [];
   let cwd = if !nocwd then [] else [Filename.current_dir_name] in
   List.iter add_to_load_path (
@@ -486,19 +487,18 @@ let sort_files_by_dependencies files =
 
   if !worklist <> [] then begin
     Location.error "cycle in dependencies. End of list is not sorted."
-    |> Location.print_report Format.err_formatter;
+    |> Location.print_report stderr;
     let sorted_deps =
       let li = ref [] in
       Hashtbl.iter (fun _ file_deps -> li := file_deps :: !li) h;
       List.sort (fun (file1, _) (file2, _) -> String.compare file1 file2) !li
     in
     List.iter (fun (file, deps) ->
-      Format.fprintf Format.err_formatter "\t@[%s: " file;
+      Format.eprintf "\t@[%s: " file;
       List.iter (fun (modname, kind) ->
-        Format.fprintf Format.err_formatter "%s.%s " modname
-          (if kind=ML then "ml" else "mli");
+        Format.eprintf "%s.%s " modname (if kind=ML then "ml" else "mli")
       ) !deps;
-      Format.fprintf Format.err_formatter "@]@.";
+      Format.eprintf "@]@.";
       Printf.printf "%s " file) sorted_deps;
     Error_occurred.set ()
   end;
@@ -577,7 +577,7 @@ let run_main argv =
   let add_dep_arg f s = dep_args_rev := (f s) :: !dep_args_rev in
   Clflags.classic := false;
   try
-    Compenv.readenv ppf Before_args;
+    Compenv.readenv stderr Before_args;
     Clflags.reset_arguments (); (* reset arguments from ocamlc/ocamlopt *)
     Clflags.add_arguments __LOC__ [
       "-absname", Arg.Set Clflags.absname,
@@ -647,7 +647,7 @@ let run_main argv =
     Compenv.parse_arguments (ref argv)
       (add_dep_arg (fun f -> Src (f, None))) program;
     process_dep_args (List.rev !dep_args_rev);
-    Compenv.readenv ppf Before_link;
+    Compenv.readenv stderr Before_link;
     if !sort_files then sort_files_by_dependencies !files
     else List.iter print_file_dependencies (List.sort compare !files);
     (if Error_occurred.get () then 2 else 0)
@@ -655,7 +655,7 @@ let run_main argv =
   | Compenv.Exit_with_status n ->
       n
   | exn ->
-      Location.report_exception ppf exn;
+      Location.report_exception stderr exn;
       2
 
 

--- a/driver/makedepend.ml
+++ b/driver/makedepend.ml
@@ -21,6 +21,7 @@ let ppf = Format.err_formatter
 
 type file_kind = ML | MLI
 
+(* [(dir, contents)] where [contents] is returned by [Sys.readdir dir]. *)
 let load_path = ref ([] : (string * string array) list)
 let ml_synonyms = ref [".ml"]
 let mli_synonyms = ref [".mli"]
@@ -381,7 +382,7 @@ let ml_file_dependencies source_file =
       | Ptop_def s -> s
       | Ptop_dir _ -> []
     in
-    List.flatten (List.map f (Parse.use_file lexbuf))
+    List.concat_map f (Parse.use_file lexbuf)
   in
   let (extracted_deps, ()) =
     read_parse_and_extract parse_use_file_as_impl Depend.add_implementation ()
@@ -546,7 +547,7 @@ let parse_map fname =
       (fun ppf -> String.Set.iter (Format.fprintf ppf " %s") deps)
       (dump_map deps) (String.Map.add modname mm String.Map.empty)
   end;
-  let mm = Depend.(weaken_map (String.Set.singleton modname) mm) in
+  let mm = Depend.weaken_map (String.Set.singleton modname) mm in
   module_map := String.Map.add modname mm !module_map
 
 (* Dependency processing *)

--- a/driver/makedepend.ml
+++ b/driver/makedepend.ml
@@ -36,7 +36,6 @@ let one_line = ref false
 let files =
   ref ([] : (string * file_kind * String.Set.t * string list) list)
 let allow_approximation = ref false
-let map_files = ref []
 let module_map = ref String.Map.empty
 let debug = ref false
 
@@ -53,7 +52,6 @@ end
 
 (* Fix path to use '/' as directory separator instead of '\'.
    Only under Windows. *)
-
 let fix_slash s =
   if Sys.os_type = "Unix" then s else begin
     String.map (function '\\' -> '/' | c -> c) s
@@ -529,7 +527,6 @@ let process_mli_map =
                          String.Map.empty Pparse.Signature
 
 let parse_map fname =
-  map_files := fname :: !map_files ;
   let old_transp = !Clflags.transparent_modules in
   Clflags.transparent_modules := true;
   let (deps, m) =

--- a/driver/makedepend.ml
+++ b/driver/makedepend.ml
@@ -253,25 +253,25 @@ let rec lexical_approximation lexbuf =
        lower-case identifier
      - always skip the token after a backquote
   *)
-  let rec process after_lident lexbuf =
+  let rec process ~after_lident lexbuf =
     match Lexer.token lexbuf with
     | Parser.UIDENT name ->
         Depend.free_structure_names :=
           String.Set.add name !Depend.free_structure_names;
-        process false lexbuf
-    | Parser.LIDENT _ -> process true lexbuf
-    | Parser.DOT when after_lident -> process false lexbuf
+        process ~after_lident:false lexbuf
+    | Parser.LIDENT _ -> process ~after_lident:true lexbuf
+    | Parser.DOT when after_lident -> process ~after_lident:false lexbuf
     | Parser.DOT | Parser.BACKQUOTE -> skip_one lexbuf
     | Parser.EOF -> ()
-    | _ -> process false lexbuf
+    | _ -> process ~after_lident:false lexbuf
   and skip_one lexbuf =
     match Lexer.token lexbuf with
     | Parser.DOT | Parser.BACKQUOTE -> skip_one lexbuf
     | Parser.EOF -> ()
-    | _ -> process false lexbuf
+    | _ -> process ~after_lident:false lexbuf
 
   in
-  try process false lexbuf
+  try process ~after_lident:false lexbuf
   with Lexer.Error _ -> lexical_approximation lexbuf
 
 let read_and_approximate inputfile =

--- a/driver/makedepend.ml
+++ b/driver/makedepend.ml
@@ -278,19 +278,17 @@ let rec lexical_approximation lexbuf =
 
 let read_and_approximate inputfile =
   Depend.free_structure_names := String.Set.empty;
-  let ic = open_in_bin inputfile in
-  try
+  begin try
+    In_channel.with_open_bin inputfile @@ fun ic ->
     seek_in ic 0;
     Location.input_name := inputfile;
     let lexbuf = Lexing.from_channel ic in
     Location.init lexbuf inputfile;
-    lexical_approximation lexbuf;
-    close_in ic;
-    !Depend.free_structure_names
+    lexical_approximation lexbuf
   with exn ->
-    close_in ic;
-    report_err exn;
-    !Depend.free_structure_names
+    report_err exn
+  end;
+  !Depend.free_structure_names
 
 let read_parse_and_extract parse_function extract_function def ast_kind
     source_file =

--- a/driver/makedepend.ml
+++ b/driver/makedepend.ml
@@ -103,21 +103,15 @@ let find_module_in_load_path name =
     let uname = Unit_info.normalize name in
     List.map (fun ext -> uname ^ ext) (!mli_synonyms @ !ml_synonyms)
   in
-  let rec find_in_array a pos =
-    if pos >= Array.length a then None else begin
-      let s = a.(pos) in
-      if List.mem s names || List.mem s unames then
-        Some s
-      else
-        find_in_array a (pos + 1)
-    end in
   let rec find_in_path = function
-    [] -> raise Not_found
-  | (dir, contents) :: rem ->
-      match find_in_array contents 0 with
-        Some truename ->
-          if dir = "." then truename else Filename.concat dir truename
-      | None -> find_in_path rem in
+    | [] -> raise Not_found
+    | (dir, contents) :: rem ->
+        let mem s = List.mem s names || List.mem s unames in
+        match Array.find_opt mem contents with
+        | Some truename ->
+            if dir = Filename.current_dir_name then truename
+            else Filename.concat dir truename
+        | None -> find_in_path rem in
   find_in_path !load_path
 
 let find_dependency target_kind modname (byt_deps, opt_deps) =

--- a/driver/makedepend.ml
+++ b/driver/makedepend.ml
@@ -21,8 +21,6 @@ let ppf = Format.err_formatter
 
 type file_kind = ML | MLI
 
-(* [(dir, contents)] where [contents] is returned by [Sys.readdir dir]. *)
-let load_path = ref ([] : (string * string array) list)
 let ml_synonyms = ref [".ml"]
 let mli_synonyms = ref [".mli"]
 let shared = ref false
@@ -33,11 +31,14 @@ let sort_files = ref false
 let all_dependencies = ref false
 let nocwd = ref false
 let one_line = ref false
+let allow_approximation = ref false
+let debug = ref false
+
+(* [(dir, contents)] where [contents] is returned by [Sys.readdir dir]. *)
+let load_path = ref ([] : (string * string array) list)
 let files =
   ref ([] : (string * file_kind * String.Set.t * string list) list)
-let allow_approximation = ref false
 let module_map = ref String.Map.empty
-let debug = ref false
 
 module Error_occurred : sig
   val set : unit -> unit

--- a/man/ocamldep.1
+++ b/man/ocamldep.1
@@ -177,6 +177,11 @@ Generate dependencies for native plugin files (.cmxs) in addition to
 native compiled files (.cmx).
 .TP
 .B \-slash
+(Windows) Use forward slash / instead of backslash \\ in file paths.
+Under Unix, this option does nothing.
+.TP
+.B \-no\-slash
+(Windows) Preserve any backslash \\ in file paths.
 Under Unix, this option does nothing.
 .TP
 .B \-sort
@@ -187,6 +192,14 @@ Print version string and exit.
 .TP
 .B \-vnum
 Print short version number and exit.
+.TP
+.BI \-args " file"
+Read additional newline separated command line arguments from
+.IR file .
+.TP
+.BI \-args0 " file"
+Read additional NUL separated command line arguments from
+.IR file .
 .TP
 .BR \-help " or " \-\-help
 Display a short usage summary and exit.

--- a/parsing/depend.ml
+++ b/parsing/depend.ml
@@ -52,8 +52,6 @@ let rec lookup_map lid m =
   | Ldot (l, s) -> String.Map.find s (get_map (lookup_map l m))
   | Lapply _    -> raise Not_found
 
-(* Collect free module identifiers in the a.s.t. *)
-
 let free_structure_names = ref String.Set.empty
 
 let add_names s =

--- a/parsing/depend.mli
+++ b/parsing/depend.mli
@@ -28,9 +28,10 @@ val make_leaf : string -> map_tree
 val make_node : bound_map -> map_tree
 val weaken_map : String.Set.t -> map_tree -> map_tree
 
+(** Collect free module identifiers in the a.s.t. *)
 val free_structure_names : String.Set.t ref
 
-(** dependencies found by preprocessing tools *)
+(** Dependencies found by preprocessing tools. *)
 val pp_deps : string list ref
 
 val open_module : bound_map -> Longident.t -> bound_map


### PR DESCRIPTION
I've collected simple refactors while working on new features for ocamldep. None of them should change the semantics or behavior of ocamldep in any ways. The goal is to remove dead code, replace ad-hoc functions if they've been introduced in the standard library or compiler-libs, and improve readability. The commits are split by topic.