### PR TITLE
[4.14] C17 fixes (strict prototypes and others)

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,10 @@
 OCaml 4.14 maintenance version
 ------------------------------
 
+- #11763, #11759, #11861, #12509: Use strict prototypes on primitives.
+  (Antonin Décimo, review by Xavier Leroy, David Allsopp and Sébastien
+   Hinderer)
+
 ### Build system:
 
 - #11590: Allow installing to a destination path containing spaces.

--- a/Changes
+++ b/Changes
@@ -1,12 +1,14 @@
 OCaml 4.14 maintenance version
 ------------------------------
 
-- #11764: Add prototypes to old-style C function definitions and declarations.
-  (Antonin Décimo, review by Xavier Leroy)
+### Runtime system:
 
-- #11763, #11759, #11861, #12509: Use strict prototypes on primitives.
-  (Antonin Décimo, review by Xavier Leroy, David Allsopp and Sébastien
-   Hinderer)
+- #11764, #12577: Add prototypes to old-style C function definitions and declarations.
+  (Antonin Décimo, review by Xavier Leroy and Nick Barnes)
+
+- #11763, #11759, #11861, #12509, #12577: Use strict prototypes on primitives.
+  (Antonin Décimo, review by Xavier Leroy, David Allsopp, Sébastien
+   Hinderer and Nick Barnes)
 
 ### Build system:
 

--- a/Changes
+++ b/Changes
@@ -1,6 +1,9 @@
 OCaml 4.14 maintenance version
 ------------------------------
 
+- #11764: Add prototypes to old-style C function definitions and declarations.
+  (Antonin Décimo, review by Xavier Leroy)
+
 - #11763, #11759, #11861, #12509: Use strict prototypes on primitives.
   (Antonin Décimo, review by Xavier Leroy, David Allsopp and Sébastien
    Hinderer)

--- a/bytecomp/bytelink.ml
+++ b/bytecomp/bytelink.ml
@@ -465,6 +465,13 @@ let output_cds_file outfile =
 
 (* Output a bytecode executable as a C file *)
 
+(* Primitives declared in the included headers but re-declared in the
+   primitives table need to be guarded and not declared twice. *)
+let guarded_primitives = [
+    "caml_get_public_method", "caml__get_public_method";
+    "caml_set_oo_id", "caml__set_oo_id";
+  ]
+
 let link_bytecode_as_c tolink outfile with_main =
   let outchan = open_out outfile in
   Misc.try_finally
@@ -478,12 +485,17 @@ let link_bytecode_as_c tolink outfile with_main =
 \n\
 \n#ifdef __cplusplus\
 \nextern \"C\" {\
-\n#endif\
+\n#endif";
+       List.iter (fun (f, f') -> Printf.fprintf outchan "\n#define %s %s" f f')
+         guarded_primitives;
+       output_string outchan "\
 \n#include <caml/mlvalues.h>\
 \n#include <caml/startup.h>\
 \n#include <caml/sys.h>\
 \n#include <caml/misc.h>\n";
-       output_string outchan "static int caml_code[] = {\n";
+       List.iter (fun (f, _) -> Printf.fprintf outchan "\n#undef %s" f)
+         guarded_primitives;
+       output_string outchan "\nstatic int caml_code[] = {\n";
        Symtable.init();
        clear_crc_interfaces ();
        let currpos = ref 0 in

--- a/bytecomp/symtable.ml
+++ b/bytecomp/symtable.ml
@@ -132,19 +132,19 @@ open Printf
 let output_primitive_table outchan =
   let prim = all_primitives() in
   for i = 0 to Array.length prim - 1 do
-    fprintf outchan "extern value %s();\n" prim.(i)
+    fprintf outchan "extern value %s(void);\n" prim.(i)
   done;
-  fprintf outchan "typedef value (*primitive)();\n";
-  fprintf outchan "primitive caml_builtin_cprim[] = {\n";
+  fprintf outchan "typedef value (*c_primitive)(void);\n";
+  fprintf outchan "c_primitive caml_builtin_cprim[] = {\n";
   for i = 0 to Array.length prim - 1 do
     fprintf outchan "  %s,\n" prim.(i)
   done;
-  fprintf outchan "  (primitive) 0 };\n";
+  fprintf outchan "  0 };\n";
   fprintf outchan "const char * caml_names_of_builtin_cprim[] = {\n";
   for i = 0 to Array.length prim - 1 do
     fprintf outchan "  \"%s\",\n" prim.(i)
   done;
-  fprintf outchan "  (char *) 0 };\n"
+  fprintf outchan "  0 };\n"
 
 (* Initialization for batch linking *)
 

--- a/otherlibs/win32unix/bind.c
+++ b/otherlibs/win32unix/bind.c
@@ -17,8 +17,7 @@
 #include "unixsupport.h"
 #include "socketaddr.h"
 
-CAMLprim value unix_bind(socket, address)
-     value socket, address;
+CAMLprim value unix_bind(value socket, value address)
 {
   int ret;
   union sock_addr_union addr;

--- a/otherlibs/win32unix/connect.c
+++ b/otherlibs/win32unix/connect.c
@@ -18,8 +18,7 @@
 #include "unixsupport.h"
 #include "socketaddr.h"
 
-CAMLprim value unix_connect(socket, address)
-     value socket, address;
+CAMLprim value unix_connect(value socket, value address)
 {
   SOCKET s = Socket_val(socket);
   union sock_addr_union addr;

--- a/otherlibs/win32unix/listen.c
+++ b/otherlibs/win32unix/listen.c
@@ -16,8 +16,7 @@
 #include <caml/mlvalues.h>
 #include "unixsupport.h"
 
-CAMLprim value unix_listen(sock, backlog)
-     value sock, backlog;
+CAMLprim value unix_listen(value sock, value backlog)
 {
   if (listen(Socket_val(sock), Int_val(backlog)) == -1) {
     win32_maperr(WSAGetLastError());

--- a/otherlibs/win32unix/nonblock.c
+++ b/otherlibs/win32unix/nonblock.c
@@ -17,8 +17,7 @@
 #include <caml/signals.h>
 #include "unixsupport.h"
 
-CAMLprim value unix_set_nonblock(socket)
-     value socket;
+CAMLprim value unix_set_nonblock(value socket)
 {
   u_long non_block = 1;
 
@@ -30,8 +29,7 @@ CAMLprim value unix_set_nonblock(socket)
   return Val_unit;
 }
 
-CAMLprim value unix_clear_nonblock(socket)
-     value socket;
+CAMLprim value unix_clear_nonblock(value socket)
 {
   u_long non_block = 0;
 

--- a/otherlibs/win32unix/shutdown.c
+++ b/otherlibs/win32unix/shutdown.c
@@ -20,8 +20,7 @@ static int shutdown_command_table[] = {
   0, 1, 2
 };
 
-CAMLprim value unix_shutdown(sock, cmd)
-     value sock, cmd;
+CAMLprim value unix_shutdown(value sock, value cmd)
 {
   if (shutdown(Socket_val(sock),
                shutdown_command_table[Int_val(cmd)]) == -1) {

--- a/otherlibs/win32unix/sleep.c
+++ b/otherlibs/win32unix/sleep.c
@@ -17,8 +17,7 @@
 #include <caml/signals.h>
 #include "unixsupport.h"
 
-CAMLprim value unix_sleep(t)
-     value t;
+CAMLprim value unix_sleep(value t)
 {
   double d = Double_val(t);
   caml_enter_blocking_section();

--- a/otherlibs/win32unix/startup.c
+++ b/otherlibs/win32unix/startup.c
@@ -22,8 +22,7 @@
 
 value val_process_id;
 
-CAMLprim value win_startup(unit)
-     value unit;
+CAMLprim value win_startup(value unit)
 {
   WSADATA wsaData;
   int i;
@@ -40,8 +39,7 @@ CAMLprim value win_startup(unit)
   return Val_unit;
 }
 
-CAMLprim value win_cleanup(unit)
-     value unit;
+CAMLprim value win_cleanup(value unit)
 {
   worker_cleanup();
 

--- a/otherlibs/win32unix/symlink.c
+++ b/otherlibs/win32unix/symlink.c
@@ -40,7 +40,7 @@ static DWORD additional_symlink_flags = 0;
 
 // Developer Mode allows the creation of symlinks without elevation - see
 // https://docs.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-createsymboliclinkw
-static BOOL IsDeveloperModeEnabled()
+static BOOL IsDeveloperModeEnabled(void)
 {
   HKEY hKey;
   LSTATUS status;

--- a/otherlibs/win32unix/system.c
+++ b/otherlibs/win32unix/system.c
@@ -24,8 +24,7 @@
 #include <process.h>
 #include <stdio.h>
 
-CAMLprim value win_system(cmd)
-     value cmd;
+CAMLprim value win_system(value cmd)
 {
   int ret;
   value st;

--- a/runtime/Makefile
+++ b/runtime/Makefile
@@ -219,16 +219,20 @@ primitives: $(shell ./gen_primitives.sh > primitives.new; \
 	cp $^ $@
 
 prims.c : primitives
-	(echo '#define CAML_INTERNALS'; \
-         echo '#include "caml/mlvalues.h"'; \
-	 echo '#include "caml/prims.h"'; \
-	 sed -e 's/.*/extern value &();/' primitives; \
+	export LC_ALL=C; \
+	(echo '#include "caml/config.h"'; \
+	 echo 'typedef intnat value;'; \
+	 echo 'typedef value (*c_primitive)(void);'; \
+	 echo; \
+	 sed -e 's/.*/extern value &(void);/' $<; \
+	 echo; \
 	 echo 'c_primitive caml_builtin_cprim[] = {'; \
-	 sed -e 's/.*/  &,/' primitives; \
+	 sed -e 's/.*/  &,/' $<; \
 	 echo '  0 };'; \
+	 echo; \
 	 echo 'char * caml_names_of_builtin_cprim[] = {'; \
-	 sed -e 's/.*/  "&",/' primitives; \
-	 echo '  0 };') > prims.c
+	 sed -e 's/.*/  "&",/' $<; \
+	 echo '  0 };') > $@
 
 caml/opnames.h : caml/instruct.h
 	tr -d '\r' < $< | \

--- a/runtime/afl.c
+++ b/runtime/afl.c
@@ -66,7 +66,7 @@ static void afl_write(uint32_t msg)
     caml_fatal_error("writing to afl-fuzz");
 }
 
-static uint32_t afl_read()
+static uint32_t afl_read(void)
 {
   uint32_t msg;
   if (read(FORKSRV_FD_READ, &msg, 4) != 4)

--- a/runtime/caml/major_gc.h
+++ b/runtime/caml/major_gc.h
@@ -92,7 +92,7 @@ void caml_init_major_heap (asize_t);           /* size in bytes */
 asize_t caml_clip_heap_chunk_wsz (asize_t wsz);
 void caml_darken (value, value *);
 void caml_major_collection_slice (intnat);
-void caml_shrink_mark_stack ();
+void caml_shrink_mark_stack (void);
 void major_collection (void);
 void caml_finish_major_cycle (void);
 void caml_set_major_window (int);

--- a/runtime/caml/prims.h
+++ b/runtime/caml/prims.h
@@ -20,7 +20,7 @@
 
 #ifdef CAML_INTERNALS
 
-typedef value (*c_primitive)();
+typedef value (*c_primitive)(void);
 
 extern c_primitive caml_builtin_cprim[];
 extern char * caml_names_of_builtin_cprim[];
@@ -30,7 +30,18 @@ extern struct ext_table caml_prim_table;
 extern struct ext_table caml_prim_name_table;
 #endif
 
-#define Primitive(n) ((c_primitive)(caml_prim_table.contents[n]))
+#define Primitive1(n) \
+    ((value (*)(value)) caml_prim_table.contents[n])
+#define Primitive2(n) \
+    ((value (*)(value,value)) caml_prim_table.contents[n])
+#define Primitive3(n) \
+    ((value (*)(value,value,value)) caml_prim_table.contents[n])
+#define Primitive4(n) \
+    ((value (*)(value,value,value,value)) caml_prim_table.contents[n])
+#define Primitive5(n) \
+    ((value (*)(value,value,value,value,value)) caml_prim_table.contents[n])
+#define PrimitiveN(n) \
+    ((value (*)(value*,int)) caml_prim_table.contents[n])
 
 extern char * caml_section_table;
 extern asize_t caml_section_table_size;

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -21,7 +21,7 @@
 
 CAMLexport caml_domain_state* Caml_state;
 
-void caml_init_domain ()
+void caml_init_domain (void)
 {
   if (Caml_state != NULL)
     return;

--- a/runtime/eventlog.c
+++ b/runtime/eventlog.c
@@ -120,7 +120,7 @@ static int64_t time_counter(void)
 #endif
 }
 
-static void setup_evbuf()
+static void setup_evbuf(void)
 {
   CAMLassert(!evbuf);
   evbuf = caml_stat_alloc_noexc(sizeof(*evbuf));
@@ -132,7 +132,7 @@ static void setup_evbuf()
 }
 
 #define OUTPUT_FILE_LEN 4096
-static void setup_eventlog_file()
+static void setup_eventlog_file(void)
 {
   char_os output_file[OUTPUT_FILE_LEN];
   char_os *eventlog_filename = NULL;
@@ -239,7 +239,7 @@ static void teardown_eventlog(void)
   }
 }
 
-void caml_eventlog_init()
+void caml_eventlog_init(void)
 {
   char_os *toggle = caml_secure_getenv(T("OCAML_EVENTLOG_ENABLED"));
 
@@ -330,7 +330,7 @@ void caml_ev_alloc(uint64_t sz)
 /*  Note that this function does not trigger an actual disk flush, it just
     pushes events in the event buffer.
 */
-void caml_ev_alloc_flush()
+void caml_ev_alloc_flush(void)
 {
   int i;
 
@@ -345,7 +345,7 @@ void caml_ev_alloc_flush()
   }
 }
 
-void caml_ev_flush()
+void caml_ev_flush(void)
 {
   if (!Caml_state->eventlog_enabled) return;
   if (Caml_state->eventlog_paused) return;
@@ -357,7 +357,7 @@ void caml_ev_flush()
   };
 }
 
-void caml_eventlog_disable()
+void caml_eventlog_disable(void)
 {
   Caml_state->eventlog_enabled = 0;
   teardown_eventlog();

--- a/runtime/finalise.c
+++ b/runtime/finalise.c
@@ -152,11 +152,11 @@ static void generic_final_update (struct finalisable * final, int darken_value)
   }
 }
 
-void caml_final_update_mark_phase (){
+void caml_final_update_mark_phase (void){
   generic_final_update(&finalisable_first, /* darken_value */ 1);
 }
 
-void caml_final_update_clean_phase (){
+void caml_final_update_clean_phase (void){
   generic_final_update(&finalisable_last, /* darken_value */ 0);
 }
 
@@ -227,7 +227,7 @@ void caml_final_do_roots (scanning_action f)
 /* Call caml_invert_root on the values of the finalisable set. This is called
    directly by the compactor.
 */
-void caml_final_invert_finalisable_values ()
+void caml_final_invert_finalisable_values (void)
 {
   uintnat i;
 
@@ -247,7 +247,7 @@ void caml_final_invert_finalisable_values ()
 /* Call [caml_oldify_one] on the closures and values of the recent set.
    This is called by the minor GC through [caml_oldify_local_roots].
 */
-void caml_final_oldify_young_roots ()
+void caml_final_oldify_young_roots (void)
 {
   uintnat i;
 
@@ -337,7 +337,7 @@ static void generic_final_minor_update (struct finalisable * final)
    minor heap when moved to major heap or moved them to the finalising
    set when dead.
 */
-void caml_final_update_minor_roots ()
+void caml_final_update_minor_roots (void)
 {
   generic_final_minor_update(&finalisable_last);
 }

--- a/runtime/fix_code.c
+++ b/runtime/fix_code.c
@@ -158,7 +158,7 @@ void caml_thread_code (code_t code, asize_t len)
 
 #else
 
-int* caml_init_opcode_nargs()
+int* caml_init_opcode_nargs(void)
 {
   return NULL;
 }

--- a/runtime/gc_ctrl.c
+++ b/runtime/gc_ctrl.c
@@ -319,7 +319,7 @@ CAMLprim value caml_gc_quick_stat(value v)
   CAMLreturn (res);
 }
 
-double caml_gc_minor_words_unboxed()
+double caml_gc_minor_words_unboxed(void)
 {
   return (Caml_state->stat_minor_words
           + (double) (Caml_state->young_alloc_end - Caml_state->young_ptr));

--- a/runtime/instrtrace.c
+++ b/runtime/instrtrace.c
@@ -36,10 +36,9 @@ extern code_t caml_start_code;
 
 intnat caml_icount = 0;
 
-void caml_stop_here () {}
+void caml_stop_here (void) {}
 
-void caml_disasm_instr(pc)
-     code_t pc;
+void caml_disasm_instr(code_t pc)
 {
   int instr = *pc;
   printf("%6ld  %s", (long) (pc - caml_start_code),

--- a/runtime/interp.c
+++ b/runtime/interp.c
@@ -927,34 +927,34 @@ value caml_interprete(code_t prog, asize_t prog_size)
 
     Instruct(C_CALL1):
       Setup_for_c_call;
-      accu = Primitive(*pc)(accu);
+      accu = Primitive1(*pc)(accu);
       Restore_after_c_call;
       pc++;
       Next;
     Instruct(C_CALL2):
       Setup_for_c_call;
-      accu = Primitive(*pc)(accu, sp[2]);
+      accu = Primitive2(*pc)(accu, sp[2]);
       Restore_after_c_call;
       sp += 1;
       pc++;
       Next;
     Instruct(C_CALL3):
       Setup_for_c_call;
-      accu = Primitive(*pc)(accu, sp[2], sp[3]);
+      accu = Primitive3(*pc)(accu, sp[2], sp[3]);
       Restore_after_c_call;
       sp += 2;
       pc++;
       Next;
     Instruct(C_CALL4):
       Setup_for_c_call;
-      accu = Primitive(*pc)(accu, sp[2], sp[3], sp[4]);
+      accu = Primitive4(*pc)(accu, sp[2], sp[3], sp[4]);
       Restore_after_c_call;
       sp += 3;
       pc++;
       Next;
     Instruct(C_CALL5):
       Setup_for_c_call;
-      accu = Primitive(*pc)(accu, sp[2], sp[3], sp[4], sp[5]);
+      accu = Primitive5(*pc)(accu, sp[2], sp[3], sp[4], sp[5]);
       Restore_after_c_call;
       sp += 4;
       pc++;
@@ -963,7 +963,7 @@ value caml_interprete(code_t prog, asize_t prog_size)
       int nargs = *pc++;
       *--sp = accu;
       Setup_for_c_call;
-      accu = Primitive(*pc)(sp + 2, nargs);
+      accu = PrimitiveN(*pc)(sp + 2, nargs);
       Restore_after_c_call;
       sp += nargs;
       pc++;

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -315,7 +315,7 @@ void caml_darken (value v, value *p)
 /* This function shrinks the mark stack back to the MARK_STACK_INIT_SIZE size
    and is called at the end of a GC compaction to avoid a mark stack greater
    than 1/32th of the heap. */
-void caml_shrink_mark_stack () {
+void caml_shrink_mark_stack (void) {
   struct mark_stack* stk = Caml_state->mark_stack;
   intnat init_stack_bsize = MARK_STACK_INIT_SIZE * sizeof(mark_entry);
   mark_entry* shrunk_stack;

--- a/runtime/memprof.c
+++ b/runtime/memprof.c
@@ -340,7 +340,7 @@ static uintnat rand_binom(uintnat len)
    which may call the GC, but prefer using [caml_alloc_shr], which
    gives this guarantee. The return value is either a valid callstack
    or 0 in out-of-memory scenarios. */
-static value capture_callstack_postponed()
+static value capture_callstack_postponed(void)
 {
   value res;
   intnat callstack_len =
@@ -1099,7 +1099,7 @@ static void th_ctx_iter_default(th_ctx_action f, void* data) {
 CAMLexport void (*caml_memprof_th_ctx_iter_hook)(th_ctx_action, void*)
   = th_ctx_iter_default;
 
-CAMLexport struct caml_memprof_th_ctx* caml_memprof_new_th_ctx()
+CAMLexport struct caml_memprof_th_ctx* caml_memprof_new_th_ctx(void)
 {
   struct caml_memprof_th_ctx* ctx =
     caml_stat_alloc(sizeof(struct caml_memprof_th_ctx));

--- a/runtime/minor_gc.c
+++ b/runtime/minor_gc.c
@@ -63,7 +63,7 @@
 
 struct generic_table CAML_TABLE_STRUCT(char);
 
-void caml_alloc_minor_tables ()
+void caml_alloc_minor_tables (void)
 {
   Caml_state->ref_table =
     caml_stat_alloc_noexc(sizeof(struct caml_ref_table));

--- a/runtime/signals.c
+++ b/runtime/signals.c
@@ -305,7 +305,7 @@ Caml_inline value process_pending_actions_with_root_exn(value extra_root)
 }
 
 CAMLno_tsan /* The access to [caml_something_to_do] is not synchronized. */
-int caml_check_pending_actions()
+int caml_check_pending_actions(void)
 {
   return caml_something_to_do;
 }

--- a/testsuite/tests/asmgen/mainarith.c
+++ b/testsuite/tests/asmgen/mainarith.c
@@ -22,7 +22,7 @@
 #include <caml/config.h>
 #define FMT ARCH_INTNAT_PRINTF_FORMAT
 
-void caml_call_poll()
+void caml_call_poll(void)
 {
 }
 

--- a/yacc/reader.c
+++ b/yacc/reader.c
@@ -1049,12 +1049,10 @@ void read_declarations(void)
 void output_token_type(void)
 {
   bucket * bp;
-  int n;
 
   fprintf(interface_file, "type token =\n");
   if (!rflag) ++outline;
   fprintf(output_file, "type token =\n");
-  n = 0;
   for (bp = first_symbol; bp; bp = bp->next) {
     if (bp->class == TERM && bp->true_token) {
       fprintf(interface_file, "  | %s", bp->name);
@@ -1068,7 +1066,6 @@ void output_token_type(void)
       fprintf(interface_file, "\n");
       if (!rflag) ++outline;
       fprintf(output_file, "\n");
-      n++;
     }
   }
   fprintf(interface_file, "\n");


### PR DESCRIPTION
Changes backported from trunk to fix strict prototypes, old style definition, unused variables warnings. The warnings are raised by clang (by default in GNU C17 mode), failing the build of the compiler (with the warnings-as-error `-Werror` flag), and headers with non-strict prototypes leak into user code, adding warnings when compiling C stubs or when using the bytecode compiler.
I've regrouped the commits by topic, since the issues took multiple PRs to get fixed in trunk, and that code can be slightly different between 4.14 and 5.x ;)