### PR TITLE
OS-based Synchronisation for Stop-the-World Sections

### DIFF
--- a/Changes
+++ b/Changes
@@ -33,6 +33,10 @@ _______________
   (Nick Barnes, review by Stephen Dolan, Jacques-Henri Jourdan
    and Guillaume Munch-Maccagnoni).
 
+- #12579: OS-based Synchronisation for Stop-the-World Sections
+  (B. Szilvasy, review by Miod Vallat, Nick Barnes, Olivier Nicole,
+   Gabriel Scherer and Damien Doligez)
+
 - #12789: Restore caml_unregister_frametable from OCaml 4
   (Frédéric Recoules, review by Gabriel Scherer)
 

--- a/configure
+++ b/configure
@@ -14917,6 +14917,19 @@ then :
 fi
 
 
+case $host in #(
+  *-*-linux*) :
+    ac_fn_c_check_header_compile "$LINENO" "linux/futex.h" "ac_cv_header_linux_futex_h" "$ac_includes_default"
+if test "x$ac_cv_header_linux_futex_h" = xyes
+then :
+  printf "%s\n" "#define HAS_LINUX_FUTEX_H 1" >>confdefs.h
+
+fi
+ ;; #(
+  *) :
+     ;;
+esac
+
 # Checks for types
 
 ## off_t
@@ -20799,12 +20812,12 @@ bytecode_cppflags="$common_cppflags $CPPFLAGS"
 
 case $host in #(
   *-*-mingw32*) :
-    cclibs="$cclibs -lole32 -luuid -lversion -lshlwapi" ;; #(
+    cclibs="$cclibs -lole32 -luuid -lversion -lshlwapi -lsynchronization" ;; #(
   *-pc-windows) :
     # For whatever reason, flexlink includes -ladvapi32 and -lshell32 for
     # mingw-w64, but doesn't include advapi32.lib and shell32.lib for MSVC
-    cclibs=\
-"$cclibs ole32.lib uuid.lib advapi32.lib shell32.lib version.lib shlwapi.lib" ;; #(
+    cclibs="$cclibs ole32.lib uuid.lib advapi32.lib shell32.lib version.lib \
+shlwapi.lib synchronization.lib" ;; #(
   *) :
      ;;
 esac

--- a/configure.ac
+++ b/configure.ac
@@ -1137,6 +1137,10 @@ AC_CHECK_HEADER([sys/select.h], [AC_DEFINE([HAS_SYS_SELECT_H], [1])], [],
 
 AC_CHECK_HEADER([sys/mman.h], [AC_DEFINE([HAS_SYS_MMAN_H], [1])])
 
+AS_CASE([$host],
+  [*-*-linux*],
+    [AC_CHECK_HEADER([linux/futex.h], [AC_DEFINE([HAS_LINUX_FUTEX_H])])])
+
 # Checks for types
 
 ## off_t
@@ -2575,12 +2579,12 @@ bytecode_cppflags="$common_cppflags $CPPFLAGS"
 
 AS_CASE([$host],
   [*-*-mingw32*],
-    [cclibs="$cclibs -lole32 -luuid -lversion -lshlwapi"],
+    [cclibs="$cclibs -lole32 -luuid -lversion -lshlwapi -lsynchronization"],
   [*-pc-windows],
     [# For whatever reason, flexlink includes -ladvapi32 and -lshell32 for
     # mingw-w64, but doesn't include advapi32.lib and shell32.lib for MSVC
-    cclibs=\
-"$cclibs ole32.lib uuid.lib advapi32.lib shell32.lib version.lib shlwapi.lib"])
+    cclibs="$cclibs ole32.lib uuid.lib advapi32.lib shell32.lib version.lib \
+shlwapi.lib synchronization.lib"])
 
 AC_CONFIG_COMMANDS_PRE([cclibs="$cclibs $mathlib $DLLIBS $PTHREAD_LIBS"])
 

--- a/runtime/caml/major_gc.h
+++ b/runtime/caml/major_gc.h
@@ -26,7 +26,7 @@ typedef enum {
 
 extern gc_phase_t caml_gc_phase;
 
-intnat caml_opportunistic_major_work_available (void);
+intnat caml_opportunistic_major_work_available (caml_domain_state*);
 void caml_opportunistic_major_collection_slice (intnat);
 /* auto-triggered slice from within the GC */
 #define AUTO_TRIGGERED_MAJOR_SLICE -1

--- a/runtime/caml/misc.h
+++ b/runtime/caml/misc.h
@@ -608,6 +608,11 @@ CAMLextern int caml_snwprintf(wchar_t * buf,
 #  endif
 #endif
 
+/* Generate a named symbol that is unique within the current macro expansion */
+#define CAML_GENSYM_3(name, l) caml__##name##_##l
+#define CAML_GENSYM_2(name, l) CAML_GENSYM_3(name, l)
+#define CAML_GENSYM(name) CAML_GENSYM_2(name, __LINE__)
+
 #endif /* CAML_INTERNALS */
 
 /* The [backtrace_slot] type represents values stored in

--- a/runtime/caml/platform.h
+++ b/runtime/caml/platform.h
@@ -120,92 +120,156 @@ void caml_plat_broadcast(caml_plat_cond*);
 void caml_plat_signal(caml_plat_cond*);
 void caml_plat_cond_free(caml_plat_cond*);
 
-/* Futexes */
+/* Futexes
 
-/* An integer that can be waited on and woken, used to build other
-   synchronisation primitives; either uses OS facilities directly, or
-   a condition-variable fallback */
-typedef struct caml_plat_futex caml_plat_futex;
+   A futex is an integer that can be waited on and woken, used to build other
+   synchronisation primitives. Either uses OS facilities directly, or a
+   condition variable fallback.
+*/
+typedef struct caml_plat_futex /* {
+  // this field is available regardless of implementation
+  caml_plat_futex_word value;
+  <possibly other fields>; ...
+} */ caml_plat_futex;
 
 typedef uint32_t caml_plat_futex_value;
 typedef _Atomic caml_plat_futex_value caml_plat_futex_word;
 
-/* Block while `futex` has the value `undesired`, until woken by `wake_all` */
+/* Block while [futex] has the value [undesired], until woken by [wake_all()] */
 void caml_plat_futex_wait(caml_plat_futex* futex,
                           caml_plat_futex_value undesired);
-/* Wake all threads `wait`ing on `futex` */
+/* Wake all threads [wait()]-ing on [futex] */
 void caml_plat_futex_wake_all(caml_plat_futex* futex);
+/* Initialise the futex for the first time, use [CAML_PLAT_FUTEX_INITIALIZER] to
+   do this statically */
+void caml_plat_futex_init(caml_plat_futex* ftx, caml_plat_futex_value value);
+/* Deinitialise the futex; no-op if native futexes are used */
+void caml_plat_futex_free(caml_plat_futex*);
 
-/* Define CAML_PLAT_FUTEX_FALLBACK to use the condition-variable
-   fallback, even if a futex implementation is available */
+/* [CAML_PLAT_FUTEX_FALLBACK] can be defined to use the condition variable
+   fallback, even if a futex implementation is available. */
 #ifndef CAML_PLAT_FUTEX_FALLBACK
 #  if defined(_WIN32)                                   \
   || (defined(__linux__) && defined(HAS_LINUX_FUTEX_H)) \
   || defined(__FreeBSD__) || defined(__OpenBSD__)
 /*  These exist, but are untested
-     defined(__NetBSD__) || defined(__DragonFly__) */
+  || defined(__NetBSD__) || defined(__DragonFly__) */
 #  else
+/* Use the fallback on platforms that we do not have an OS-specific
+   implementation for, such as macOS. */
 #    define CAML_PLAT_FUTEX_FALLBACK
 #  endif
 #endif
 
-#if !defined(CAML_PLAT_FUTEX_FALLBACK)
-struct caml_plat_futex {
-  caml_plat_futex_word value;
-};
-#  define CAML_PLAT_FUTEX_INITIALIZER(value) { (value) }
-
-Caml_inline void caml_plat_futex_init(caml_plat_futex* ftx,
-                                      caml_plat_futex_value value) {
-  ftx->value = value;
-}
-Caml_inline void caml_plat_futex_free(caml_plat_futex* ftx) {
-  (void) ftx; /* noop */
-}
-#else
+#ifdef CAML_PLAT_FUTEX_FALLBACK
 struct caml_plat_futex {
   caml_plat_futex_word value;
   caml_plat_mutex mutex;
   caml_plat_cond cond;
 };
 #  define CAML_PLAT_FUTEX_INITIALIZER(value) \
-  { value, CAML_PLAT_MUTEX_INITIALIZER, CAML_PLAT_COND_INITIALIZER }
+  { (value), CAML_PLAT_MUTEX_INITIALIZER, CAML_PLAT_COND_INITIALIZER }
+#else
+struct caml_plat_futex {
+  caml_plat_futex_word value;
+};
+#  define CAML_PLAT_FUTEX_INITIALIZER(value) { (value) }
+#endif /* CAML_PLAT_FUTEX_FALLBACK */
 
-void caml_plat_futex_init(caml_plat_futex* ftx, caml_plat_futex_value value);
-void caml_plat_futex_free(caml_plat_futex*);
-#endif
+/* Latches
 
-/* Barriers */
+   A binary latch is a boolean value with a [wait()] operation. It has two
+   states, "released" and "unreleased" (or "set"). [latch_set()] can be used to
+   set the latch to unreleased, [latch_release()] can be used to release it, and
+   [latch_wait()] can be used from the unreleased state to block until
+   [latch_release()] is called.
 
-/*
- * A barrier that can be either single-sense (separate release and
- * reset) or sense-reversing (unified release and reset).
- *
- * | Operation | `caml_plat_barrier_*` function      |
- * |           |---------------+---------------------|
- * |           | Single-sense  | Sense-reversing     |
- * |-----------|---------------+---------------------|
- * | Reset     | `reset`       | automatic at `flip` |
- * | Arrive    | `arrive`      | `arrive`            |
- * | Check     | `is_released` | `sense_has_flipped` |
- * | Block     | `wait`        | `wait_sense`        |
- * | Release   | `release`     | `flip`              |
- *
- * The lifecycle is as follows:
- *
- *      Reset (1 thread)          (other threads)
- *              |                       |
- *              +----------+------------+
- *                         |
- *                      Arrive (all threads)
- *                         |
- *                         | check arrival number
- *              +----------+------------+
- *              |                       |
- *       Check or Block              Release
- *     (non-final threads)         (final thread)
- *              |                       |
+                    [latch_set()]
+         +------------------------------------+
+         v                                    |
+     UNRELEASED                            RELEASED
+         |                                    ^
+         +-< unblock [latch_wait()] callers >-+
+                   [latch_release()]
+
+   This type of object is also called a manual-reset event in Windows APIs, or
+   it can be considered a special case of Java's [CountDownLatch] or C++'s
+   [std::latch] with the counter capped at one.
  */
+typedef caml_plat_futex caml_plat_binary_latch;
+
+/* Released state */
+#define Latch_released 0
+/* Unreleased state, no [latch_wait()] callers */
+#define Latch_unreleased 1
+/* Unreleased state, at least one [latch_wait()] caller */
+#define Latch_contested 2
+
+/* Initialise the latch to a released state */
+#define CAML_PLAT_LATCH_INITIALIZER CAML_PLAT_FUTEX_INITIALIZER(Latch_released)
+Caml_inline void caml_plat_latch_init(caml_plat_binary_latch* latch) {
+  caml_plat_futex_init(latch, Latch_released);
+}
+/* Release the latch, waking any waiters */
+void caml_plat_latch_release(caml_plat_binary_latch*);
+/* Block until released. This is no-op (but more expensive than checking with
+   [is_released()]) if the latch has already been released. */
+void caml_plat_latch_wait(caml_plat_binary_latch*);
+/* Check if a latch is released */
+Caml_inline int caml_plat_latch_is_released(caml_plat_binary_latch* latch) {
+  return atomic_load_acquire(&latch->value) == Latch_released;
+}
+/* Check if a latch is unreleased */
+Caml_inline int caml_plat_latch_is_set(caml_plat_binary_latch* latch) {
+  return !caml_plat_latch_is_released(latch);
+}
+/* Set the latch to unreleased */
+Caml_inline void caml_plat_latch_set(caml_plat_binary_latch* latch) {
+  atomic_store_release(&latch->value, Latch_unreleased);
+}
+
+/* Barriers
+
+   A barrier is an object used to synchronise a variable number of
+   threads/parties. Each party arrives at the barrier, and only once all parties
+   have arrived can any threads leave the barrier. There are two variants: the
+   "single-sense" barrier must be manually reset before it can be reused,
+   whereas the "sense-reversing" barrier can be reused immediately after it has
+   been released.
+
+   | Operation | [caml_plat_barrier_*] function      |
+   |           |---------------+---------------------|
+   |           | Single-sense  | Sense-reversing     |
+   |-----------|---------------+---------------------|
+   | Reset     | [reset]       | automatic at [flip] |
+   | Arrive    | [arrive]      | [arrive]            |
+   | Check     | [is_released] | [sense_has_flipped] |
+   | Block     | [wait]        | [wait_sense]        |
+   | Release   | [release]     | [flip]              |
+
+   The lifecycle is as follows:
+
+        Reset (1 thread)          (other threads)
+                |                       |
+                +----------+------------+
+                           |
+                        Arrive (all threads)
+                           |
+                           | check arrival number
+                +----------+------------+
+                |                       |
+         Check or Block              Release
+       (non-final threads)        (final thread)
+                |                       |
+
+   Note that leaving the barrier (after [Check] or [Block]) synchronises only
+   with the [Release] of the barrier, which in turn only synchronises with the
+   other threads at the time they [Arrive]-d. That is, anything performed
+   between [Arrive] and [Check]/[Block] is unsynchronised by the barrier, and
+   could potentially race with code in other threads that occurs after the
+   barrier.
+
+*/
 typedef struct caml_plat_barrier {
   caml_plat_futex futex;
   atomic_uintnat arrived; /* includes sense bit */
@@ -214,71 +278,46 @@ typedef struct caml_plat_barrier {
   { CAML_PLAT_FUTEX_INITIALIZER(0), 0 }
 
 typedef uintnat barrier_status;
-/* Arrive at the barrier, returns the number of parties that have
-   arrived at the barrier (including this one); the caller should
-   check whether it is the last expected party to arrive, and release
-   or flip the barrier if so.
+#define BARRIER_SENSE_BIT 0x100000
+/* Arrive at the barrier, returns the number of parties that have arrived at the
+   barrier (including this one); the caller should check whether it is the last
+   expected party to arrive, and release or flip the barrier if so.
 
-   In a sense-reversing barrier, this also encodes the current sense
-   of the barrier in BARRIER_SENSE_BIT, which should be masked off if
-   checking for the last arrival. */
+   In a sense-reversing barrier, this also encodes the current sense of the
+   barrier in [BARRIER_SENSE_BIT], which should be masked off if checking for
+   the last arrival. */
 Caml_inline barrier_status caml_plat_barrier_arrive(caml_plat_barrier* barrier)
 {
   return 1 + atomic_fetch_add(&barrier->arrived, 1);
 }
-#define BARRIER_SENSE_BIT 0x100000
 
 /* -- Single-sense --
-
-   Futex states:
-   - 0 if released
-   - 1 if nobody is blocking (but they may be spinning)
-   - 2 if anybody is blocking (or about to)
- */
-#define Barrier_released 0
-#define Barrier_unreleased 1
-#define Barrier_contested 2
+   [futex] is used as a binary latch. */
 
 /* Reset the barrier to 0 arrivals, block new waiters */
 Caml_inline void caml_plat_barrier_reset(caml_plat_barrier* barrier) {
-  atomic_store_relaxed(&barrier->futex.value, Barrier_unreleased);
-  /* threads check arrivals before the futex, 'release' ordering
-     ensures they see it reset */
+  caml_plat_latch_set(&barrier->futex);
   atomic_store_release(&barrier->arrived, 0);
 }
 /* Check if the barrier has been released */
 Caml_inline int caml_plat_barrier_is_released(caml_plat_barrier* barrier) {
-  return atomic_load_acquire(&barrier->futex.value) == Barrier_released;
+  return caml_plat_latch_is_released(&barrier->futex);
 }
-
-/* Release and wait, but on a futex only.
-
-   This is like a(n inverted) binary semaphore, but with no decrement
-   on `wait`. That is, `release` sets the futex to 0, which `wait`
-   waits for.
-
-   A futex used this way is 0 (Barrier_released) when released, and
-   nonzero otherwise. It should be set to 1 (Barrier_unreleased) to
-   block.
-*/
-void caml_plat_barrier_raw_release(caml_plat_futex* futex);
-void caml_plat_barrier_raw_wait(caml_plat_futex* futex);
-
 /* Release the barrier unconditionally, letting all parties through */
 Caml_inline void caml_plat_barrier_release(caml_plat_barrier* barrier) {
-  caml_plat_barrier_raw_release(&barrier->futex);
+  caml_plat_latch_release(&barrier->futex);
 }
 /* Block until released */
 Caml_inline void caml_plat_barrier_wait(caml_plat_barrier* barrier) {
-  caml_plat_barrier_raw_wait(&barrier->futex);
+  caml_plat_latch_wait(&barrier->futex);
 }
 
 /* -- Sense-reversing -- */
 /* Flip the sense of the barrier, releasing current waiters and
    blocking new ones.
 
-   `current_sense` should be just `(b & BARRIER_SENSE_BIT)`
-   with b as returned by `caml_plat_barrier_arrive`. */
+   [current_sense] should be [(b & BARRIER_SENSE_BIT)] with [b] as
+   returned by [barrier_arrive()]. */
 void caml_plat_barrier_flip(caml_plat_barrier*, barrier_status current_sense);
 Caml_inline int
 caml_plat_barrier_sense_has_flipped(caml_plat_barrier* barrier,
@@ -291,29 +330,56 @@ caml_plat_barrier_sense_has_flipped(caml_plat_barrier* barrier,
 void caml_plat_barrier_wait_sense(caml_plat_barrier*,
                                   barrier_status current_sense);
 
-/* Spin-wait loops */
+/* Spin-wait loops
 
-#define GENSYM_3(name, l) name##l
-#define GENSYM_2(name, l) GENSYM_3(name, l)
-#define GENSYM(name) GENSYM_2(name, __LINE__)
+   We provide the macros [SPIN_WAIT], [SPIN_WAIT_NTIMES(N)] and
+   [SPIN_WAIT_BOUNDED] that expand to [for]-loop headers for spin-wait
+   loops. The latter two are expected to be used alongside OS-based
+   synchronisation (e.g. latches, barriers).
 
+   Example usage:
+
+   SPIN_WAIT {
+     if (condition_has_come_true()) {
+       break; // or return;
+     }
+
+     perform_useful_spin_work();
+   }
+
+   [SPIN_WAIT] spins for unbounded time, and should only be used when hashing
+   out contention over a short critical section that only one thread needs to
+   run, where more complex synchronisation would be too expensive and
+   unnecessary.
+
+   [SPIN_WAIT_NTIMES(N)] should be used with one of the [Max_spins_*] constants
+   defined below (though the N expression doesn't need to be a constant), it
+   loops the body up to N times and then ends, even if the condition hasn't come
+   true. Exactly how much spinning is optimal can be tricky and may warrant
+   profiling, with the caveat that it is also probably machine-dependent.
+   Typically, [Max_spins_long] iterations are only useful when there are exactly
+   2 domains, otherwise [Max_spins_short] is best to yield to OS synchronisation
+   as fast as possible.
+
+   [SPIN_WAIT_BOUNDED] expands to [SPIN_WAIT_NTIMES(Max_spins_medium)] and
+   should be used when there is useful work to do in the body of the loop.
+ */
+
+/* The exact values here are estimates based on data from a specific machine,
+   and shouldn't be focused on too much. */
 #define Max_spins_long 1000
 #define Max_spins_medium 300
 #define Max_spins_short 30
 
-/* Spin up to some number of times, should be used when we have useful
-   work to do, or expect the condition to come true fast */
-#define SPIN_WAIT_BOUNDED SPIN_WAIT_NTIMES(Max_spins_medium)
-#define SPIN_WAIT_BOUNDED_LONG SPIN_WAIT_NTIMES(Max_spins_long)
 #define SPIN_WAIT_NTIMES(N)                             \
-  unsigned GENSYM(caml__spins) = 0;                     \
-  unsigned GENSYM(caml__max_spins) = (N);               \
-  for (; GENSYM(caml__spins) < GENSYM(caml__max_spins); \
-       cpu_relax(), ++GENSYM(caml__spins))
-
-/* Spin for unbounded time, this should only be used when there is a
-   very short critical section we are waiting on */
+  unsigned CAML_GENSYM(spins) = 0;                      \
+  unsigned CAML_GENSYM(max_spins) = (N);                \
+  for (; CAML_GENSYM(spins) < CAML_GENSYM(max_spins);   \
+       cpu_relax(), ++CAML_GENSYM(spins))
+#define SPIN_WAIT_BOUNDED SPIN_WAIT_NTIMES(Max_spins_medium)
 #define SPIN_WAIT SPIN_WAIT_BACK_OFF(Max_spins_long)
+
+/* [SPIN_WAIT_*] implementation details */
 
 struct caml_plat_srcloc {
   const char* file;
@@ -321,8 +387,9 @@ struct caml_plat_srcloc {
   const char* function;
 };
 
-CAMLextern unsigned caml_plat_spin_wait(unsigned spins,
-                                        const struct caml_plat_srcloc* loc);
+/* Start/continue backing off, returns the next [sleep_ns] */
+CAMLextern unsigned caml_plat_spin_back_off(unsigned sleep_ns,
+                                            const struct caml_plat_srcloc* loc);
 
 Caml_inline unsigned caml_plat_spin_step(unsigned spins,
                                          unsigned max_spins,
@@ -331,19 +398,20 @@ Caml_inline unsigned caml_plat_spin_step(unsigned spins,
   if (CAMLlikely(spins < max_spins)) {
     return spins + 1;
   } else {
-    return caml_plat_spin_wait(spins, loc);
+    /* [spins] becomes [sleep_ns] at this point, which remains greater than
+       [max_spins] */
+    return caml_plat_spin_back_off(spins, loc);
   }
 }
 
-#define SPIN_WAIT_BACK_OFF(max_spins)                        \
-  unsigned GENSYM(caml__spins) = 0;                          \
-  unsigned GENSYM(caml__max_spins) = (max_spins);            \
-  static const struct caml_plat_srcloc GENSYM(caml__loc) = { \
-    __FILE__, __LINE__, __func__                             \
-  };                                                         \
-  for (; 1; GENSYM(caml__spins) = caml_plat_spin_step(       \
-         GENSYM(caml__spins), GENSYM(caml__max_spins),       \
-         &GENSYM(caml__loc)))
+#define SPIN_WAIT_BACK_OFF(max_spins)                                   \
+  unsigned CAML_GENSYM(spins) = 0;                                      \
+  unsigned CAML_GENSYM(max_spins) = (max_spins);                        \
+  static const struct caml_plat_srcloc CAML_GENSYM(loc) = {             \
+    __FILE__, __LINE__, __func__                                        \
+  };                                                                    \
+  for (; 1; CAML_GENSYM(spins) = caml_plat_spin_step(                   \
+         CAML_GENSYM(spins), CAML_GENSYM(max_spins), &CAML_GENSYM(loc)))
 
 /* Memory management primitives (mmap) */
 

--- a/runtime/caml/platform.h
+++ b/runtime/caml/platform.h
@@ -199,7 +199,7 @@ struct caml_plat_futex {
 typedef caml_plat_futex caml_plat_binary_latch;
 
 /* Released state */
-#define Latch_released 0
+#define Latch_released 0 /* must be zero, see barrier initialisation */
 /* Unreleased state, no [latch_wait()] callers */
 #define Latch_unreleased 1
 /* Unreleased state, at least one [latch_wait()] caller */
@@ -274,8 +274,12 @@ typedef struct caml_plat_barrier {
   caml_plat_futex futex;
   atomic_uintnat arrived; /* includes sense bit */
 } caml_plat_barrier;
+
+/* This initialises both a single-sense and sense-reversing barrier, for
+   single-sense this is the released state ([Latch_released], which must be 0)
+   and for sense-reversing it is just a valid initialised state. */
 #define CAML_PLAT_BARRIER_INITIALIZER \
-  { CAML_PLAT_FUTEX_INITIALIZER(0), 0 }
+  { CAML_PLAT_FUTEX_INITIALIZER(Latch_released), 0 }
 
 typedef uintnat barrier_status;
 #define BARRIER_SENSE_BIT 0x100000

--- a/runtime/caml/platform.h
+++ b/runtime/caml/platform.h
@@ -211,7 +211,7 @@ typedef struct caml_plat_barrier {
   atomic_uintnat arrived; /* includes sense bit */
 } caml_plat_barrier;
 #define CAML_PLAT_BARRIER_INITIALIZER \
-  { CAML_PLAT_FUTEX_INITIALIZER(0), ATOMIC_UINTNAT_INIT(0) }
+  { CAML_PLAT_FUTEX_INITIALIZER(0), 0 }
 
 typedef uintnat barrier_status;
 /* Arrive at the barrier, returns the number of parties that have

--- a/runtime/caml/s.h.in
+++ b/runtime/caml/s.h.in
@@ -80,6 +80,8 @@
 
 #undef HAS_SYS_MMAN_H
 
+#undef HAS_LINUX_FUTEX_H
+
 /* 2. For the Unix library. */
 
 #undef HAS_SOCKETS

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -198,8 +198,8 @@ struct dom_internal {
 typedef struct dom_internal dom_internal;
 
 static struct {
-  /* enter barrier, released by the leader once all domains have handled their
-     interrupt */
+  /* enter barrier for STW sections, participating domains arrive into
+     the barrier before executing the STW callback */
   caml_plat_barrier domains_still_running;
   /* the number of domains that have yet to return from the callback */
   atomic_uintnat num_domains_still_processing;

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -1306,7 +1306,6 @@ CAMLprim value caml_ml_domain_index(value unit)
 }
 
 /* sense-reversing barrier */
-#define BARRIER_SENSE_BIT 0x100000
 
 barrier_status caml_global_barrier_begin(void)
 {

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -167,7 +167,7 @@ struct interruptor {
   /* unlike the domain ID, this ID number is not reused */
   uintnat unique_id;
 
-  atomic_uintnat interrupt_pending;
+  caml_plat_futex interrupt_pending;
 };
 
 struct dom_internal {
@@ -189,24 +189,34 @@ struct dom_internal {
 };
 typedef struct dom_internal dom_internal;
 
-
 static struct {
-  atomic_uintnat domains_still_running;
+  /* enter barrier */
+  caml_plat_futex domains_still_running;
   atomic_uintnat num_domains_still_processing;
   void (*callback)(caml_domain_state*,
                    void*,
                    int participating_count,
                    caml_domain_state** others_participating);
   void* data;
-  void (*enter_spin_callback)(caml_domain_state*, void*);
+  int (*enter_spin_callback)(caml_domain_state*, void*);
   void* enter_spin_data;
 
   /* barrier state */
   int num_domains;
-  atomic_uintnat barrier;
+  caml_plat_barrier barrier;
 
   caml_domain_state* participating[Max_domains];
-} stw_request = { 0, 0, NULL, NULL, NULL, NULL, 0, 0, { 0 } };
+} stw_request = {
+  CAML_PLAT_FUTEX_INITIALIZER(0),
+  0,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  0,
+  CAML_PLAT_BARRIER_INITIALIZER,
+  { 0 },
+};
 
 static caml_plat_mutex all_domains_lock = CAML_PLAT_MUTEX_INITIALIZER;
 static caml_plat_cond all_domains_cond = CAML_PLAT_COND_INITIALIZER;
@@ -314,17 +324,18 @@ Caml_inline void interrupt_domain_local(caml_domain_state* dom_st)
 
 int caml_incoming_interrupts_queued(void)
 {
-  return atomic_load_acquire(&domain_self->interruptor.interrupt_pending);
+  return atomic_load_acquire(&domain_self->interruptor.interrupt_pending.value)
+    != Barrier_released;
 }
 
 /* must NOT be called with s->lock held */
 static void stw_handler(caml_domain_state* domain);
 static uintnat handle_incoming(struct interruptor* s)
 {
-  uintnat handled = atomic_load_acquire(&s->interrupt_pending);
+  uintnat handled = atomic_load_acquire(&s->interrupt_pending.value);
   CAMLassert (s->running);
   if (handled) {
-    atomic_store_release(&s->interrupt_pending, 0);
+    caml_plat_barrier_raw_release(&s->interrupt_pending);
 
     stw_handler(domain_self->state);
   }
@@ -345,7 +356,7 @@ void caml_handle_incoming_interrupts(void)
 int caml_send_interrupt(struct interruptor* target)
 {
   /* signal that there is an interrupt pending */
-  atomic_store_release(&target->interrupt_pending, 1);
+  atomic_store_release(&target->interrupt_pending.value, Barrier_unreleased);
 
   /* Signal the condition variable, in case the target is itself
      waiting for an interrupt to be processed elsewhere, or to wake up
@@ -361,22 +372,24 @@ int caml_send_interrupt(struct interruptor* target)
 
 static void caml_wait_interrupt_serviced(struct interruptor* target)
 {
-  int i;
-
-  /* Often, interrupt handlers are fast, so spin for a bit before waiting */
-  for (i=0; i<1000; i++) {
-    if (!atomic_load_acquire(&target->interrupt_pending)) {
+  /* Interrupt handlers tend to be fast, and in a lot of cases the
+     interrupt has already been handled since we issued it. (The
+     leader also calls this on itself, and this is always true in that
+     case) */
+  if (CAMLlikely(!atomic_load_acquire(&target->interrupt_pending.value))) {
+    return;
+  }
+  /* With two domains, we can usually get by with spinning for it,
+     otherwise it isn't worth it. */
+  unsigned spins = stw_request.num_domains == 2
+    ? Max_spins_long : Max_spins_short;
+  SPIN_WAIT_NTIMES(spins) {
+    if (!atomic_load_acquire(&target->interrupt_pending.value)) {
       return;
     }
-    cpu_relax();
   }
-
-  {
-    SPIN_WAIT {
-      if (!atomic_load_acquire(&target->interrupt_pending))
-        return;
-    }
-  }
+  /* Otherwise, block */
+  caml_plat_barrier_raw_wait(&target->interrupt_pending);
 }
 
 asize_t caml_norm_minor_heap_size (intnat wsize)
@@ -578,7 +591,7 @@ static void domain_create(uintnat initial_minor_heap_wsize,
 
   s = &d->interruptor;
   CAMLassert(!s->running);
-  CAMLassert(!s->interrupt_pending);
+  CAMLassert(!s->interrupt_pending.value);
 
   /* If the chosen domain slot has not been previously used, allocate a fresh
      domain state. Otherwise, reuse it.
@@ -631,7 +644,7 @@ static void domain_create(uintnat initial_minor_heap_wsize,
     goto init_memprof_failure;
   }
 
-  CAMLassert(!s->interrupt_pending);
+  CAMLassert(!s->interrupt_pending.value);
 
   domain_state->extra_heap_resources = 0.0;
   domain_state->extra_heap_resources_minor = 0.0;
@@ -930,7 +943,7 @@ void caml_init_domains(uintnat minor_heap_wsz) {
     dom->interruptor.running = 0;
     dom->interruptor.terminating = 0;
     dom->interruptor.unique_id = 0;
-    dom->interruptor.interrupt_pending = 0;
+    caml_plat_futex_init(&dom->interruptor.interrupt_pending, 0);
 
     caml_plat_mutex_init(&dom->domain_lock);
     caml_plat_cond_init(&dom->domain_cond);
@@ -1309,27 +1322,44 @@ CAMLprim value caml_ml_domain_index(value unit)
 
 barrier_status caml_global_barrier_begin(void)
 {
-  uintnat b = 1 + atomic_fetch_add(&stw_request.barrier, 1);
-  return b;
+  return caml_plat_barrier_arrive(&stw_request.barrier);
 }
 
 int caml_global_barrier_is_final(barrier_status b)
 {
-  return ((b & ~BARRIER_SENSE_BIT) == stw_request.num_domains);
+  return caml_global_barrier_is_nth(b, stw_request.num_domains);
+}
+
+/* last domain into the barrier, flip sense */
+static void caml_global_barrier_flip(barrier_status sense)
+{
+  caml_plat_barrier_flip(&stw_request.barrier, sense);
+}
+
+/* wait until another domain flips the sense */
+static
+void caml_global_barrier_wait(barrier_status sense, int num_participating)
+{
+  /* it's not worth spinning for too long if there's more than one other domain
+   */
+  unsigned spins = num_participating == 2 ? Max_spins_long : Max_spins_short;
+  SPIN_WAIT_NTIMES(spins) {
+    if (caml_plat_barrier_sense_has_flipped(&stw_request.barrier, sense)) {
+      return;
+    }
+  }
+  /* just block */
+  caml_plat_barrier_wait_sense(&stw_request.barrier, sense);
 }
 
 void caml_global_barrier_end(barrier_status b)
 {
-  uintnat sense = b & BARRIER_SENSE_BIT;
-  if (caml_global_barrier_is_final(b)) {
-    /* last domain into the barrier, flip sense */
-    atomic_store_release(&stw_request.barrier, sense ^ BARRIER_SENSE_BIT);
+  barrier_status sense = b & BARRIER_SENSE_BIT;
+  int num_domains = stw_request.num_domains;
+  if (caml_global_barrier_is_nth(b, num_domains)) {
+    caml_global_barrier_flip(sense);
   } else {
-    /* wait until another domain flips the sense */
-    SPIN_WAIT {
-      uintnat barrier = atomic_load_acquire(&stw_request.barrier);
-      if ((barrier & BARRIER_SENSE_BIT) != sense) break;
-    }
+    caml_global_barrier_wait(sense, num_domains);
   }
 }
 
@@ -1337,6 +1367,23 @@ void caml_global_barrier(void)
 {
   barrier_status b = caml_global_barrier_begin();
   caml_global_barrier_end(b);
+}
+
+barrier_status caml_global_barrier_wait_unless_final(int num_participating)
+{
+  barrier_status b = caml_global_barrier_begin();
+  if (caml_global_barrier_is_nth(b, num_participating)) {
+    CAMLassert(b); /* always nonzero */
+    return b;
+  } else {
+    caml_global_barrier_wait(b & BARRIER_SENSE_BIT, num_participating);
+    return 0;
+  }
+}
+
+void caml_global_barrier_release_as_final(barrier_status b)
+{
+  caml_global_barrier_flip(b & BARRIER_SENSE_BIT);
 }
 
 int caml_global_barrier_num_domains(void)
@@ -1362,19 +1409,44 @@ static void decrement_stw_domains_still_processing(void)
   }
 }
 
+/* Wait for other running domains to stop */
+static void stw_wait_for_running(caml_domain_state* domain)
+{
+  /* The STW leader issues interrupts to all threads, then checks if
+     all threads have been successfully interrupted, before flipping
+     the barrier we are waiting on; this tends to (and should) be
+     fast, but we likely need to wait a bit in any case */
+
+  if (stw_request.enter_spin_callback) {
+    /* Spin while there is useful work to do */
+    SPIN_WAIT_BOUNDED {
+      if (!atomic_load_acquire(&stw_request.domains_still_running.value)) {
+        return;
+      }
+
+      if (!stw_request.enter_spin_callback
+            (domain, stw_request.enter_spin_data)) {
+        break;
+      }
+    }
+  }
+
+  /* Spin a bit for the other domains */
+  SPIN_WAIT_BOUNDED {
+    if (!atomic_load_acquire(&stw_request.domains_still_running.value)) {
+      return;
+    }
+  }
+
+  /* If we're still waiting, block */
+  caml_plat_barrier_raw_wait(&stw_request.domains_still_running);
+}
+
 static void stw_handler(caml_domain_state* domain)
 {
   CAML_EV_BEGIN(EV_STW_HANDLER);
   CAML_EV_BEGIN(EV_STW_API_BARRIER);
-  {
-    SPIN_WAIT {
-      if (atomic_load_acquire(&stw_request.domains_still_running) == 0)
-        break;
-
-      if (stw_request.enter_spin_callback)
-        stw_request.enter_spin_callback(domain, stw_request.enter_spin_data);
-    }
-  }
+  stw_wait_for_running(domain);
   CAML_EV_END(EV_STW_API_BARRIER);
 
   #ifdef DEBUG
@@ -1472,7 +1544,7 @@ int caml_try_run_on_all_domains_with_spin_work(
   void (*handler)(caml_domain_state*, void*, int, caml_domain_state**),
   void* data,
   void (*leader_setup)(caml_domain_state*),
-  void (*enter_spin_callback)(caml_domain_state*, void*),
+  int (*enter_spin_callback)(caml_domain_state*, void*),
   void* enter_spin_data)
 {
   int i;
@@ -1507,17 +1579,18 @@ int caml_try_run_on_all_domains_with_spin_work(
   CAML_EV_BEGIN(EV_STW_LEADER);
   caml_gc_log("causing STW");
 
-  /* setup all fields for this stw_request, must have those needed
-     for domains waiting at the enter spin barrier */
+  /* set up all fields for this stw_request, must have those needed
+     for domains waiting at the enter barrier */
   stw_request.enter_spin_callback = enter_spin_callback;
   stw_request.enter_spin_data = enter_spin_data;
   stw_request.callback = handler;
   stw_request.data = data;
-  atomic_store_release(&stw_request.barrier, 0);
-  atomic_store_release(&stw_request.domains_still_running, sync);
+  /* stw_request.barrier doesn't need resetting */
+  atomic_store_release(&stw_request.domains_still_running.value,
+                       sync ? Barrier_unreleased : Barrier_released);
   stw_request.num_domains = stw_domains.participating_domains;
   atomic_store_release(&stw_request.num_domains_still_processing,
-                   stw_domains.participating_domains);
+                       stw_domains.participating_domains);
 
   if( leader_setup ) {
     leader_setup(domain_state);
@@ -1539,7 +1612,7 @@ int caml_try_run_on_all_domains_with_spin_work(
   for(i = 0; i < stw_domains.participating_domains; i++) {
     dom_internal * d = stw_domains.domains[i];
     stw_request.participating[i] = d->state;
-    CAMLassert(!d->interruptor.interrupt_pending);
+    CAMLassert(!d->interruptor.interrupt_pending.value);
     if (d->state != domain_state) caml_send_interrupt(&d->interruptor);
   }
 
@@ -1566,7 +1639,9 @@ int caml_try_run_on_all_domains_with_spin_work(
   }
 
   /* release from the enter barrier */
-  atomic_store_release(&stw_request.domains_still_running, 0);
+  if (sync) {
+    caml_plat_barrier_raw_release(&stw_request.domains_still_running);
+  }
 
   #ifdef DEBUG
   domain_state->inside_stw_handler = 1;
@@ -1655,7 +1730,7 @@ void caml_reset_young_limit(caml_domain_state * dom_st)
   /* For non-delayable asynchronous actions, we immediately interrupt
      the domain again. */
   dom_internal * d = &all_domains[dom_st->id];
-  if (atomic_load_relaxed(&d->interruptor.interrupt_pending)
+  if (atomic_load_relaxed(&d->interruptor.interrupt_pending.value)
       || dom_st->requested_minor_gc
       || dom_st->requested_major_slice
       || dom_st->major_slice_epoch < atomic_load (&caml_major_slice_epoch)) {

--- a/runtime/frame_descriptors.c
+++ b/runtime/frame_descriptors.c
@@ -294,13 +294,9 @@ static void stw_register_frametables(
     int participating_count,
     caml_domain_state** participating)
 {
-  barrier_status b = caml_global_barrier_begin ();
-
-  if (caml_global_barrier_is_final(b)) {
+  Caml_global_barrier_if_final(participating_count) {
     register_frametables_from_stw_single((caml_frametable_list*) frametables);
   }
-
-  caml_global_barrier_end(b);
 }
 
 void caml_register_frametables(void **table, int ntables) {

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -1420,7 +1420,6 @@ static void cycle_major_heap_from_stw_single(
 
   domain->swept_words = 0;
 
-  num_domains_in_stw = (uintnat)caml_global_barrier_num_domains();
   atomic_store_release(&num_domains_to_sweep, num_domains_in_stw);
   atomic_store_release(&num_domains_to_mark, num_domains_in_stw);
 

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -1490,7 +1490,7 @@ static void stw_cycle_all_domains(
     /* This global barrier avoids races between the verify_heap code
        and the rest of the STW critical section, for example the parts
        that mark global roots. */
-    Caml_maybe_global_barrier(participating_count);
+    caml_global_barrier(participating_count);
   }
 
   caml_cycle_heap(domain->shared_heap);
@@ -1576,7 +1576,7 @@ static void stw_cycle_all_domains(
   /* To ensure a mutator doesn't resume while global roots are being marked.
      Mutators can alter the set of global roots, to preserve its correctness,
      they should not run while global roots are being marked.*/
-  Caml_maybe_global_barrier(participating_count);
+  caml_global_barrier(participating_count);
 
   /* Someone should flush the allocation stats we gathered during the cycle */
   if( participating[0] == domain ) {

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -1662,9 +1662,8 @@ static void stw_try_complete_gc_phase(
   CAML_EV_END(EV_MAJOR_GC_PHASE_CHANGE);
 }
 
-intnat caml_opportunistic_major_work_available (void)
+intnat caml_opportunistic_major_work_available (caml_domain_state* domain_state)
 {
-  caml_domain_state* domain_state = Caml_state;
   return !domain_state->sweeping_done || !domain_state->marking_done;
 }
 
@@ -1710,7 +1709,7 @@ static void major_collection_slice(intnat howmuch,
   /* shortcut out if there is no opportunistic work to be done
    * NB: needed particularly to avoid caml_ev spam when polling */
   if (mode == Slice_opportunistic &&
-      !caml_opportunistic_major_work_available()) {
+      !caml_opportunistic_major_work_available(domain_state)) {
     commit_major_slice_work (0);
     return;
   }

--- a/runtime/minor_gc.c
+++ b/runtime/minor_gc.c
@@ -490,7 +490,9 @@ void caml_empty_minor_heap_promote(caml_domain_state* domain,
   CAML_EV_BEGIN(EV_MINOR);
   call_timing_hook(&caml_minor_gc_begin_hook);
 
-  if( participating[0] == Caml_state ) {
+  CAMLassert(domain == Caml_state);
+
+  if( participating[0] == domain ) {
     CAML_EV_BEGIN(EV_MINOR_GLOBAL_ROOTS);
     caml_scan_global_young_roots(oldify_one, &st);
     CAML_EV_END(EV_MINOR_GLOBAL_ROOTS);
@@ -500,7 +502,6 @@ void caml_empty_minor_heap_promote(caml_domain_state* domain,
 
   if( participating_count > 1 ) {
     int participating_idx = -1;
-    CAMLassert(domain == Caml_state);
 
     for( int i = 0; i < participating_count ; i++ ) {
       if( participating[i] == domain ) {
@@ -712,6 +713,12 @@ static void custom_finalize_minor (caml_domain_state * domain)
   }
 }
 
+/* Increment the counter non-atomically, when it is already known that this
+   thread is alone in trying to increment it. */
+static void nonatomic_increment_counter(atomic_uintnat* counter) {
+  atomic_store_relaxed(counter, 1 + atomic_load_relaxed(counter));
+}
+
 static void minor_gc_leave_barrier
   (caml_domain_state* domain, int participating_count)
 {
@@ -726,10 +733,9 @@ static void minor_gc_leave_barrier
     }
   }
 
-  /* Spin a bit longer, which is far less fruitful if we're waiting on more than
-     one thread */
-  unsigned spins = participating_count == 2
-    ? Max_spins_medium : Max_spins_short;
+  /* Spin a bit longer, which is far less fruitful if we're waiting on
+     more than one thread */
+  unsigned spins = participating_count == 2 ? Max_spins_medium : Max_spins_short;
   SPIN_WAIT_NTIMES(spins) {
     if (caml_plat_barrier_is_released(&domains_finished_minor_gc)) {
       return;
@@ -739,7 +745,6 @@ static void minor_gc_leave_barrier
   /* If there's nothing to do, block */
   caml_plat_barrier_wait(&domains_finished_minor_gc);
 }
-
 
 int caml_do_opportunistic_major_slice
   (caml_domain_state* domain_state, void* unused)
@@ -759,9 +764,9 @@ int caml_do_opportunistic_major_slice
    if needed.
 */
 void caml_empty_minor_heap_setup(caml_domain_state* domain_unused) {
-  caml_plat_barrier_reset(&domains_finished_minor_gc);
   /* Increment the total number of minor collections done in the program */
-  atomic_fetch_add (&caml_minor_collections_count, 1);
+  nonatomic_increment_counter (&caml_minor_collections_count);
+  caml_plat_barrier_reset(&domains_finished_minor_gc);
 }
 
 /* must be called within a STW section */
@@ -776,8 +781,8 @@ caml_stw_empty_minor_heap_no_major_slice(caml_domain_state* domain,
   CAMLassert(caml_domain_is_in_stw());
 #endif
 
-  if( participating[0] == Caml_state ) {
-    atomic_fetch_add(&caml_minor_cycles_started, 1);
+  if( participating[0] == domain ) {
+    nonatomic_increment_counter(&caml_minor_cycles_started);
   }
 
   caml_gc_log("running stw empty_minor_heap_promote");
@@ -823,11 +828,9 @@ void caml_empty_minor_heap_no_major_slice_from_stw(
   int participating_count,
   caml_domain_state** participating)
 {
-  barrier_status b = caml_global_barrier_begin();
-  if( caml_global_barrier_is_final(b) ) {
+  Caml_global_barrier_if_final(participating_count) {
     caml_empty_minor_heap_setup(domain);
   }
-  caml_global_barrier_end(b);
 
   /* if we are entering from within a major GC STW section then
      we do not schedule another major collection slice */
@@ -855,7 +858,7 @@ int caml_try_empty_minor_heap_on_all_domains (void)
    minor heap */
 void caml_empty_minor_heaps_once (void)
 {
-  uintnat saved_minor_cycle = atomic_load(&caml_minor_cycles_started);
+  uintnat saved_minor_cycle = atomic_load_relaxed(&caml_minor_cycles_started);
 
   #ifdef DEBUG
   CAMLassert(!caml_domain_is_in_stw());
@@ -865,7 +868,8 @@ void caml_empty_minor_heaps_once (void)
      STW section */
   do {
     caml_try_empty_minor_heap_on_all_domains();
-  } while (saved_minor_cycle == atomic_load(&caml_minor_cycles_started));
+  } while (saved_minor_cycle ==
+           atomic_load_relaxed(&caml_minor_cycles_started));
 }
 
 /* Called by minor allocations when [Caml_state->young_ptr] reaches

--- a/runtime/minor_gc.c
+++ b/runtime/minor_gc.c
@@ -461,8 +461,10 @@ void caml_empty_minor_heap_domain_clear(caml_domain_state* domain)
   domain->extra_heap_resources_minor = 0.0;
 }
 
-/* try to do a major slice, returns nonzero if there was any work available,
-   used as useful spin work while waiting for synchronisation */
+/* Try to do a major slice, returns nonzero if there was any work available,
+   used as useful spin work while waiting for synchronisation. The return type
+   is [int] and not [bool] since it is passed as a parameter to
+   [caml_try_run_on_all_domains_with_spin_work]. */
 int caml_do_opportunistic_major_slice
   (caml_domain_state* domain_unused, void* unused);
 static void minor_gc_leave_barrier
@@ -576,7 +578,7 @@ void caml_empty_minor_heap_promote(caml_domain_state* domain,
   }
 
   #ifdef DEBUG
-    caml_global_barrier();
+    caml_global_barrier(participating_count);
     /* At this point all domains should have gone through all remembered set
        entries. We need to verify that all our remembered set entries are now in
        the major heap or promoted */
@@ -606,7 +608,7 @@ void caml_empty_minor_heap_promote(caml_domain_state* domain,
               remembered_roots, st.live_bytes);
 
 #ifdef DEBUG
-  caml_global_barrier();
+  caml_global_barrier(participating_count);
   caml_gc_log("ref_base: %p, ref_ptr: %p",
     self_minor_tables->major_ref.base, self_minor_tables->major_ref.ptr);
   for (r = self_minor_tables->major_ref.base;

--- a/runtime/minor_gc.c
+++ b/runtime/minor_gc.c
@@ -737,7 +737,7 @@ static void minor_gc_leave_barrier
   /* Spin a bit longer, which is far less fruitful if we're waiting on
      more than one thread */
   unsigned spins =
-    participating_count == 2 ? Max_spins_medium : Max_spins_short;
+    participating_count == 2 ? Max_spins_long : Max_spins_medium;
   SPIN_WAIT_NTIMES(spins) {
     if (caml_plat_barrier_is_released(&minor_gc_end_barrier)) {
       return;

--- a/runtime/platform.c
+++ b/runtime/platform.c
@@ -204,10 +204,11 @@ void caml_plat_futex_free(caml_plat_futex* ftx) {
 
 #  if defined(_WIN32)
 #    include <synchapi.h>
-#    define CAML_PLAT_FUTEX_WAIT(ftx, undesired)                \
-  WaitOnAddress(ftx, &undesired, sizeof(undesired), INFINITE)
+#    define CAML_PLAT_FUTEX_WAIT(ftx, undesired)  \
+  WaitOnAddress((volatile void *)ftx, &undesired, \
+                sizeof(undesired), INFINITE)
 #    define CAML_PLAT_FUTEX_WAKE(ftx)           \
-  WakeByAddressAll(ftx)
+  WakeByAddressAll((void *)ftx)
 
 #  elif defined(__linux__)
 #    include <linux/futex.h>

--- a/runtime/platform.c
+++ b/runtime/platform.c
@@ -142,97 +142,13 @@ void caml_plat_cond_free(caml_plat_cond* cond)
   check_err("cond_free", pthread_cond_destroy(cond));
 }
 
-/* Barriers */
+/* Futexes */
 
-#ifndef CAML_PLAT_FUTEX_FALLBACK
-#  if defined(_WIN32)
-#    include <synchapi.h>
-#    define CAML_PLAT_FUTEX_WAIT(ftx, undesired)                \
-  WaitOnAddress(ftx, &undesired, sizeof(undesired), INFINITE)
-#    define CAML_PLAT_FUTEX_WAKE(ftx) \
-  WakeByAddressAll(ftx)
+#ifdef CAML_PLAT_FUTEX_FALLBACK
 
-#  elif defined(__linux__)
-#    include <linux/futex.h>
-#    include <sys/syscall.h>
-#    define CAML_PLAT_FUTEX_WAIT(ftx, undesired)    \
-  syscall(SYS_futex, ftx, FUTEX_WAIT_PRIVATE,       \
-          /* expected */ undesired,                 \
-          /* timeout */ NULL,                       \
-          /* ignored */ NULL, 0)
-#    define CAML_PLAT_FUTEX_WAKE(ftx)           \
-  syscall(SYS_futex, ftx, FUTEX_WAKE_PRIVATE,   \
-          /* count */ INT_MAX,                  \
-          /* timeout */ NULL,                   \
-          /* ignored */ NULL, 0)
-
-/* #  elif defined(__APPLE__)
-   macOS has __ulock_wait which is used in implementations of libc++,
-   (e.g. by LLVM) but the API is private and unstable. */
-
-#  elif defined(__FreeBSD__)
-#    include <sys/umtx.h>
-#    define CAML_PLAT_FUTEX_WAIT(ftx, undesired) \
-  _umtx_op(ftx, UMTX_OP_WAIT_UINT_PRIVATE,       \
-           /* expected */ undesired,             \
-           /* timeout */ NULL, NULL)
-#    define CAML_PLAT_FUTEX_WAKE(ftx) \
-  _umtx_op(ftx, UMTX_OP_WAKE_PRIVATE, \
-           /* count */ INT_MAX,       \
-           /* unused */ NULL, NULL)
-
-#  elif defined(__OpenBSD__)
-#    include <sys/futex.h>
-#    define CAML_PLAT_FUTEX_WAIT(ftx, undesired)      \
-  futex((volatile uint32_t*)ftx, FUTEX_WAIT_PRIVATE,  \
-        /* expected */ undesired,                     \
-        /* timeout */ NULL,                           \
-        /* ignored */ NULL)
-#    define CAML_PLAT_FUTEX_WAKE(ftx)                \
-  futex((volatile uint32_t*)ftx, FUTEX_WAKE_PRIVATE, \
-        /* count */ INT_MAX,                         \
-        /* ignored */ NULL, NULL)
-
-#  elif defined(__NetBSD__)
-#    include <sys/futex.h>
-#    include <sys/syscall.h>
-#    define CAML_PLAT_FUTEX_WAIT(ftx, undesired)    \
-  syscall(SYS___futex, ftx,                         \
-          FUTEX_WAIT | FUTEX_PRIVATE_FLAG,          \
-          /* expected */ undesired,                 \
-          /* timeout */ NULL,                       \
-          /* ignored */ NULL, 0, 0)
-#    define CAML_PLAT_FUTEX_WAKE(ftx)            \
-  sycall(SYS___futex, ftx,                       \
-         FUTEX_WAKE | FUTEX_PRIVATE_FLAG,        \
-         /* count */ INT_MAX,                    \
-         /* ignored */ NULL, NULL, 0, 0)
-
-#  elif defined(__DragonFly__)
-#    define CAML_PLAT_FUTEX_WAIT(ftx, undesired)    \
-  umtx_sleep((volatile const int*)ftx, undesired, 0)
-#    define CAML_PLAT_FUTEX_WAKE(ftx)           \
-  umtx_wakeup((volatile const int*)ftx, INT_MAX)
-
-#  else
-#    error "No futex implementation available"
-#  endif
-#endif
-
-#if !defined(CAML_PLAT_FUTEX_FALLBACK)
-
-void caml_plat_futex_wait(caml_plat_futex* ftx,
-                          caml_plat_futex_value undesired) {
-  while (atomic_load_acquire(&ftx->value) == undesired) {
-    CAML_PLAT_FUTEX_WAIT(&ftx->value, undesired);
-  }
-}
-
-void caml_plat_futex_wake_all(caml_plat_futex* ftx) {
-  CAML_PLAT_FUTEX_WAKE(&ftx->value);
-}
-
-#else
+/* Conditon-variable-based futex implementation, for when a native OS
+   version isn't available. This also illustrates the semantics of the
+   [wait()] and [wake_all()] operations. */
 
 void caml_plat_futex_wait(caml_plat_futex* futex,
                           caml_plat_futex_value undesired) {
@@ -259,31 +175,155 @@ void caml_plat_futex_free(caml_plat_futex* ftx) {
   caml_plat_mutex_free(&ftx->mutex);
   check_err("cond_destroy", pthread_cond_destroy(&ftx->cond));
 }
-#endif
 
-/* single-sense */
+#else /* ! CAML_PLAT_FUTEX_FALLBACK */
 
-void caml_plat_barrier_raw_release(caml_plat_futex* futex) {
-  /* if nobody is blocking, release in user-space */
-  if (atomic_exchange(&futex->value, Barrier_released)
-      != Barrier_unreleased) {
-    /* at least one thread is (going to be) blocked on the futex, notify */
-    caml_plat_futex_wake_all(futex);
+/* Platform-specific futex implementation.
+
+   For each platform we define [WAIT(futex_word* ftx, futex_value
+   undesired)] and [WAKE(futex_word* ftx)] in terms of
+   platform-specific syscalls. The exact semantics vary, but these are
+   the weakest expected guarantees:
+
+   - [WAIT()] compares the value at [ftx] to [undesired], and if they
+     are equal, goes to sleep on [ftx].
+
+   - [WAKE()] wakes up all [WAIT()]-ers on [ftx].
+
+   - [WAIT()] must be atomic with respect to [WAKE()], in that if the
+     [WAIT()]-ing thread observes the undesired value and goes to
+     sleep, it will not miss a wakeup from the [WAKE()]-ing thread
+     between the comparison and sleep.
+
+   - [WAIT()]'s initial read of [ftx] is to be treated as being atomic
+     with [memory_order_relaxed]. That is, no memory ordering is
+     guaranteed around it.
+
+   - Spurious wakeups of [WAIT()] may be possible.
+*/
+
+#  if defined(_WIN32)
+#    include <synchapi.h>
+#    define CAML_PLAT_FUTEX_WAIT(ftx, undesired)                \
+  WaitOnAddress(ftx, &undesired, sizeof(undesired), INFINITE)
+#    define CAML_PLAT_FUTEX_WAKE(ftx)           \
+  WakeByAddressAll(ftx)
+
+#  elif defined(__linux__)
+#    include <linux/futex.h>
+#    include <sys/syscall.h>
+#    define CAML_PLAT_FUTEX_WAIT(ftx, undesired)    \
+  syscall(SYS_futex, ftx, FUTEX_WAIT_PRIVATE,       \
+          /* expected */ undesired,                 \
+          /* timeout */ NULL,                       \
+          /* ignored */ NULL, 0)
+#    define CAML_PLAT_FUTEX_WAKE(ftx)           \
+  syscall(SYS_futex, ftx, FUTEX_WAKE_PRIVATE,   \
+          /* count */ INT_MAX,                  \
+          /* timeout */ NULL,                   \
+          /* ignored */ NULL, 0)
+
+#  elif 0 /* defined(__APPLE__)
+   macOS has [__ulock_(wait|wake)()] which is used in implementations
+   of libc++, (e.g. by LLVM) but the API is private and unstable.
+   Therefore, we currently use the condition variable fallback on
+   macOS. */
+
+#  elif defined(__FreeBSD__)
+#    include <sys/umtx.h>
+#    define CAML_PLAT_FUTEX_WAIT(ftx, undesired) \
+  _umtx_op(ftx, UMTX_OP_WAIT_UINT_PRIVATE,       \
+           /* expected */ undesired,             \
+           /* timeout */ NULL, NULL)
+#    define CAML_PLAT_FUTEX_WAKE(ftx) \
+  _umtx_op(ftx, UMTX_OP_WAKE_PRIVATE, \
+           /* count */ INT_MAX,       \
+           /* unused */ NULL, NULL)
+
+#  elif defined(__OpenBSD__)
+#    include <sys/futex.h>
+#    define CAML_PLAT_FUTEX_WAIT(ftx, undesired)      \
+  futex((volatile uint32_t*)ftx, FUTEX_WAIT_PRIVATE,  \
+        /* expected */ undesired,                     \
+        /* timeout */ NULL,                           \
+        /* ignored */ NULL)
+#    define CAML_PLAT_FUTEX_WAKE(ftx)                \
+  futex((volatile uint32_t*)ftx, FUTEX_WAKE_PRIVATE, \
+        /* count */ INT_MAX,                         \
+        /* ignored */ NULL, NULL)
+
+#  elif 0 /* defined(__NetBSD__)
+   this platform is untested, the fallback is used instead */
+#    include <sys/futex.h>
+#    include <sys/syscall.h>
+#    define CAML_PLAT_FUTEX_WAIT(ftx, undesired)    \
+  syscall(SYS___futex, ftx,                         \
+          FUTEX_WAIT | FUTEX_PRIVATE_FLAG,          \
+          /* expected */ undesired,                 \
+          /* timeout */ NULL,                       \
+          /* ignored */ NULL, 0, 0)
+#    define CAML_PLAT_FUTEX_WAKE(ftx)            \
+  sycall(SYS___futex, ftx,                       \
+         FUTEX_WAKE | FUTEX_PRIVATE_FLAG,        \
+         /* count */ INT_MAX,                    \
+         /* ignored */ NULL, NULL, 0, 0)
+
+#  elif 0 /* defined(__DragonFly__)
+   this platform is untested, the fallback is used instead */
+#    define CAML_PLAT_FUTEX_WAIT(ftx, undesired)        \
+  umtx_sleep((volatile const int*)ftx, undesired, 0)
+#    define CAML_PLAT_FUTEX_WAKE(ftx)               \
+  umtx_wakeup((volatile const int*)ftx, INT_MAX)
+
+#  else
+#    error "No futex implementation available"
+#  endif
+
+void caml_plat_futex_wait(caml_plat_futex* ftx,
+                          caml_plat_futex_value undesired) {
+  while (atomic_load_acquire(&ftx->value) == undesired) {
+    CAML_PLAT_FUTEX_WAIT(&ftx->value, undesired);
   }
 }
 
-void caml_plat_barrier_raw_wait(caml_plat_futex* futex) {
-  /* indicate that we are about to block */
-  caml_plat_futex_value expected = Barrier_unreleased;
-  (void)atomic_compare_exchange_strong
-    (&futex->value, &expected, Barrier_contested);
-  /* it's either already released (== Barrier_released), or we are
-     going to block (== Barrier_contested), futex_wait() here will
-     take care of both */
-  caml_plat_futex_wait(futex, Barrier_contested);
+void caml_plat_futex_wake_all(caml_plat_futex* ftx) {
+  CAML_PLAT_FUTEX_WAKE(&ftx->value);
 }
 
-/* sense-reversing */
+void caml_plat_futex_init(caml_plat_futex* ftx,
+                          caml_plat_futex_value value) {
+  ftx->value = value;
+}
+
+void caml_plat_futex_free(caml_plat_futex* ftx) {
+  (void) ftx; /* noop */
+}
+
+#endif /* CAML_PLAT_FUTEX_FALLBACK */
+
+/* Latches */
+
+void caml_plat_latch_release(caml_plat_binary_latch* latch) {
+  /* if nobody is blocking, release in user-space */
+  if (atomic_exchange(&latch->value, Latch_released)
+      != Latch_unreleased) {
+    /* at least one thread is (going to be) blocked on the futex, notify */
+    caml_plat_futex_wake_all(latch);
+  }
+}
+
+void caml_plat_latch_wait(caml_plat_binary_latch* latch) {
+  /* indicate that we are about to block */
+  caml_plat_futex_value expected = Latch_unreleased;
+  (void)atomic_compare_exchange_strong
+    (&latch->value, &expected, Latch_contested);
+  /* it's either already released (== Latch_released), or we are
+     going to block (== Latch_contested), futex_wait() here will
+     take care of both */
+  caml_plat_futex_wait(latch, Latch_contested);
+}
+
+/* Sense-reversing barrier */
 /* futex states:
    - X...0 if nobody is blocking (but they may be spinning)
    - X...1 if anybody is blocking (or about to)
@@ -405,20 +445,20 @@ void caml_mem_unmap(void* mem, uintnat size)
 #define Slow_sleep_ns    1000000 //  1 ms
 #define Max_sleep_ns  1000000000 //  1 s
 
-unsigned caml_plat_spin_wait(unsigned spins,
-                             const struct caml_plat_srcloc* loc)
+unsigned caml_plat_spin_back_off(unsigned sleep_ns,
+                                 const struct caml_plat_srcloc* loc)
 {
-  if (spins < Min_sleep_ns) spins = Min_sleep_ns;
-  if (spins > Max_sleep_ns) spins = Max_sleep_ns;
-  unsigned next_spins = spins + spins / 4;
-  if (spins < Slow_sleep_ns && Slow_sleep_ns <= next_spins) {
+  if (sleep_ns < Min_sleep_ns) sleep_ns = Min_sleep_ns;
+  if (sleep_ns > Max_sleep_ns) sleep_ns = Max_sleep_ns;
+  unsigned next_sleep_ns = sleep_ns + sleep_ns / 4;
+  if (sleep_ns < Slow_sleep_ns && Slow_sleep_ns <= next_sleep_ns) {
     caml_gc_log("Slow spin-wait loop in %s at %s:%d",
                 loc->function, loc->file, loc->line);
   }
 #ifdef _WIN32
-  Sleep(spins/1000000);
+  Sleep(sleep_ns/1000000);
 #else
-  usleep(spins/1000);
+  usleep(sleep_ns/1000);
 #endif
-  return next_spins;
+  return next_sleep_ns;
 }

--- a/runtime/platform.c
+++ b/runtime/platform.c
@@ -146,7 +146,7 @@ void caml_plat_cond_free(caml_plat_cond* cond)
 
 #ifdef CAML_PLAT_FUTEX_FALLBACK
 
-/* Conditon-variable-based futex implementation, for when a native OS
+/* Condition-variable-based futex implementation, for when a native OS
    version isn't available. This also illustrates the semantics of the
    [wait()] and [wake_all()] operations. */
 
@@ -254,7 +254,8 @@ void caml_plat_futex_free(caml_plat_futex* ftx) {
         /* ignored */ NULL, NULL)
 
 #  elif 0 /* defined(__NetBSD__)
-   this platform is untested, the fallback is used instead */
+   TODO The following code for NetBSD is untested,
+   we currently use the fallback instead. */
 #    include <sys/futex.h>
 #    include <sys/syscall.h>
 #    define CAML_PLAT_FUTEX_WAIT(ftx, undesired)    \
@@ -270,7 +271,8 @@ void caml_plat_futex_free(caml_plat_futex* ftx) {
          /* ignored */ NULL, NULL, 0, 0)
 
 #  elif 0 /* defined(__DragonFly__)
-   this platform is untested, the fallback is used instead */
+   TODO The following code for DragonFly is untested,
+   we currently use the fallback instead. */ */
 #    define CAML_PLAT_FUTEX_WAIT(ftx, undesired)        \
   umtx_sleep((volatile const int*)ftx, undesired, 0)
 #    define CAML_PLAT_FUTEX_WAKE(ftx)               \

--- a/runtime/platform.c
+++ b/runtime/platform.c
@@ -142,6 +142,184 @@ void caml_plat_cond_free(caml_plat_cond* cond)
   check_err("cond_free", pthread_cond_destroy(cond));
 }
 
+/* Barriers */
+
+#ifndef CAML_PLAT_FUTEX_FALLBACK
+#  if defined(_WIN32)
+#    include <synchapi.h>
+#    define CAML_PLAT_FUTEX_WAIT(ftx, undesired)                \
+  WaitOnAddress(ftx, &undesired, sizeof(undesired), INFINITE)
+#    define CAML_PLAT_FUTEX_WAKE(ftx) \
+  WakeByAddressAll(ftx)
+
+#  elif defined(__linux__)
+#    include <linux/futex.h>
+#    include <sys/syscall.h>
+#    define CAML_PLAT_FUTEX_WAIT(ftx, undesired)    \
+  syscall(SYS_futex, ftx, FUTEX_WAIT_PRIVATE,       \
+          /* expected */ undesired,                 \
+          /* timeout */ NULL,                       \
+          /* ignored */ NULL, 0)
+#    define CAML_PLAT_FUTEX_WAKE(ftx)           \
+  syscall(SYS_futex, ftx, FUTEX_WAKE_PRIVATE,   \
+          /* count */ INT_MAX,                  \
+          /* timeout */ NULL,                   \
+          /* ignored */ NULL, 0)
+
+/* #  elif defined(__APPLE__)
+   macOS has __ulock_wait which is used in implementations of libc++,
+   (e.g. by LLVM) but the API is private and unstable. */
+
+#  elif defined(__FreeBSD__)
+#    include <sys/umtx.h>
+#    define CAML_PLAT_FUTEX_WAIT(ftx, undesired) \
+  _umtx_op(ftx, UMTX_OP_WAIT_UINT_PRIVATE,       \
+           /* expected */ undesired,             \
+           /* timeout */ NULL, NULL)
+#    define CAML_PLAT_FUTEX_WAKE(ftx) \
+  _umtx_op(ftx, UMTX_OP_WAKE_PRIVATE, \
+           /* count */ INT_MAX,       \
+           /* unused */ NULL, NULL)
+
+#  elif defined(__OpenBSD__)
+#    include <sys/futex.h>
+#    define CAML_PLAT_FUTEX_WAIT(ftx, undesired)      \
+  futex((volatile uint32_t*)ftx, FUTEX_WAIT_PRIVATE,  \
+        /* expected */ undesired,                     \
+        /* timeout */ NULL,                           \
+        /* ignored */ NULL)
+#    define CAML_PLAT_FUTEX_WAKE(ftx)                \
+  futex((volatile uint32_t*)ftx, FUTEX_WAKE_PRIVATE, \
+        /* count */ INT_MAX,                         \
+        /* ignored */ NULL, NULL)
+
+#  elif defined(__NetBSD__)
+#    include <sys/futex.h>
+#    include <sys/syscall.h>
+#    define CAML_PLAT_FUTEX_WAIT(ftx, undesired)    \
+  syscall(SYS___futex, ftx,                         \
+          FUTEX_WAIT | FUTEX_PRIVATE_FLAG,          \
+          /* expected */ undesired,                 \
+          /* timeout */ NULL,                       \
+          /* ignored */ NULL, 0, 0)
+#    define CAML_PLAT_FUTEX_WAKE(ftx)            \
+  sycall(SYS___futex, ftx,                       \
+         FUTEX_WAKE | FUTEX_PRIVATE_FLAG,        \
+         /* count */ INT_MAX,                    \
+         /* ignored */ NULL, NULL, 0, 0)
+
+#  elif defined(__DragonFly__)
+#    define CAML_PLAT_FUTEX_WAIT(ftx, undesired)    \
+  umtx_sleep((volatile const int*)ftx, undesired, 0)
+#    define CAML_PLAT_FUTEX_WAKE(ftx)           \
+  umtx_wakeup((volatile const int*)ftx, INT_MAX)
+
+#  else
+#    error "No futex implementation available"
+#  endif
+#endif
+
+#if !defined(CAML_PLAT_FUTEX_FALLBACK)
+
+void caml_plat_futex_wait(caml_plat_futex* ftx,
+                          caml_plat_futex_value undesired) {
+  while (atomic_load_acquire(&ftx->value) == undesired) {
+    CAML_PLAT_FUTEX_WAIT(&ftx->value, undesired);
+  }
+}
+
+void caml_plat_futex_wake_all(caml_plat_futex* ftx) {
+  CAML_PLAT_FUTEX_WAKE(&ftx->value);
+}
+
+#else
+
+void caml_plat_futex_wait(caml_plat_futex* futex,
+                          caml_plat_futex_value undesired) {
+  caml_plat_lock_blocking(&futex->mutex);
+  while (atomic_load_acquire(&futex->value) == undesired) {
+    caml_plat_wait(&futex->cond, &futex->mutex);
+  }
+  caml_plat_unlock(&futex->mutex);
+}
+
+void caml_plat_futex_wake_all(caml_plat_futex* futex) {
+  caml_plat_lock_blocking(&futex->mutex);
+  caml_plat_broadcast(&futex->cond);
+  caml_plat_unlock(&futex->mutex);
+}
+
+void caml_plat_futex_init(caml_plat_futex* ftx, caml_plat_futex_value value) {
+  ftx->value = value;
+  caml_plat_mutex_init(&ftx->mutex);
+  caml_plat_cond_init(&ftx->cond);
+}
+
+void caml_plat_futex_free(caml_plat_futex* ftx) {
+  caml_plat_mutex_free(&ftx->mutex);
+  check_err("cond_destroy", pthread_cond_destroy(&ftx->cond));
+}
+#endif
+
+/* single-sense */
+
+void caml_plat_barrier_raw_release(caml_plat_futex* futex) {
+  /* if nobody is blocking, release in user-space */
+  if (atomic_exchange(&futex->value, Barrier_released)
+      != Barrier_unreleased) {
+    /* at least one thread is (going to be) blocked on the futex, notify */
+    caml_plat_futex_wake_all(futex);
+  }
+}
+
+void caml_plat_barrier_raw_wait(caml_plat_futex* futex) {
+  /* indicate that we are about to block */
+  caml_plat_futex_value expected = Barrier_unreleased;
+  (void)atomic_compare_exchange_strong
+    (&futex->value, &expected, Barrier_contested);
+  /* it's either already released (== Barrier_released), or we are
+     going to block (== Barrier_contested), futex_wait() here will
+     take care of both */
+  caml_plat_futex_wait(futex, Barrier_contested);
+}
+
+/* sense-reversing */
+/* futex states:
+   - X...0 if nobody is blocking (but they may be spinning)
+   - X...1 if anybody is blocking (or about to)
+
+   where X is the sense bit
+ */
+
+void caml_plat_barrier_flip(caml_plat_barrier* barrier,
+                            barrier_status current_sense) {
+  uintnat new_sense = current_sense ^ BARRIER_SENSE_BIT;
+  atomic_store_relaxed(&barrier->arrived, new_sense);
+  /* if a thread observes the flip below, it will also observe the
+     reset counter, since any currently waiting threads will check the
+     futex before leaving, they will see the counter correctly */
+
+  caml_plat_futex_value
+    current_sense_word = (caml_plat_futex_value) current_sense,
+    new_sense_word = (caml_plat_futex_value) new_sense;
+
+  /* if nobody is blocking, flip in user-space */
+  if (atomic_exchange(&barrier->futex.value, new_sense_word)
+      != current_sense_word) {
+    /* a thread is (about to be) blocked, notify */
+    caml_plat_futex_wake_all(&barrier->futex);
+  }
+}
+
+void caml_plat_barrier_wait_sense(caml_plat_barrier* barrier,
+                                  barrier_status sense_bit) {
+  /* indicate that we are about to block */
+  caml_plat_futex_value expected = sense_bit;
+  (void)atomic_compare_exchange_strong
+    (&barrier->futex.value, &expected, sense_bit | 1);
+  /* wait until the sense changes */
+  caml_plat_futex_wait(&barrier->futex, sense_bit | 1);
+}
 
 /* Memory management */
 
@@ -228,15 +406,14 @@ void caml_mem_unmap(void* mem, uintnat size)
 #define Max_sleep_ns  1000000000 //  1 s
 
 unsigned caml_plat_spin_wait(unsigned spins,
-                             const char* file, int line,
-                             const char* function)
+                             const struct caml_plat_srcloc* loc)
 {
-  unsigned next_spins;
   if (spins < Min_sleep_ns) spins = Min_sleep_ns;
   if (spins > Max_sleep_ns) spins = Max_sleep_ns;
-  next_spins = spins + spins / 4;
+  unsigned next_spins = spins + spins / 4;
   if (spins < Slow_sleep_ns && Slow_sleep_ns <= next_spins) {
-    caml_gc_log("Slow spin-wait loop in %s at %s:%d", function, file, line);
+    caml_gc_log("Slow spin-wait loop in %s at %s:%d",
+                loc->function, loc->file, loc->line);
   }
 #ifdef _WIN32
   Sleep(spins/1000000);

--- a/runtime/shared_heap.c
+++ b/runtime/shared_heap.c
@@ -982,7 +982,7 @@ void caml_compact_heap(caml_domain_state* domain_state,
   filled pools, determine pools to be evacuated and then evacuate from them.
   For the first phase we need not consider full pools, they
   cannot be evacuated to or from. */
-  caml_global_barrier();
+  Caml_maybe_global_barrier(participating_count);
   CAML_EV_BEGIN(EV_COMPACT_EVACUATE);
 
   struct caml_heap_state* heap = Caml_state->shared_heap;
@@ -1209,7 +1209,7 @@ void caml_compact_heap(caml_domain_state* domain_state,
   }
 
   CAML_EV_END(EV_COMPACT_EVACUATE);
-  caml_global_barrier();
+  Caml_maybe_global_barrier(participating_count);
   CAML_EV_BEGIN(EV_COMPACT_FORWARD);
 
   /* Second phase: at this point all live blocks in evacuated pools
@@ -1253,7 +1253,7 @@ void caml_compact_heap(caml_domain_state* domain_state,
   compact_update_ephe_list(&ephe_info->live);
 
   CAML_EV_END(EV_COMPACT_FORWARD);
-  caml_global_barrier();
+  Caml_maybe_global_barrier(participating_count);
   CAML_EV_BEGIN(EV_COMPACT_RELEASE);
 
   /* Third phase: free all evacuated pools and release the mappings back to
@@ -1278,7 +1278,7 @@ void caml_compact_heap(caml_domain_state* domain_state,
   }
 
   CAML_EV_END(EV_COMPACT_RELEASE);
-  caml_global_barrier();
+  Caml_maybe_global_barrier(participating_count);
 
   /* Fourth phase: one domain also needs to release the free list */
   if( participants[0] == Caml_state ) {

--- a/runtime/shared_heap.c
+++ b/runtime/shared_heap.c
@@ -986,7 +986,7 @@ void caml_compact_heap(caml_domain_state* domain_state,
   filled pools, determine pools to be evacuated and then evacuate from them.
   For the first phase we need not consider full pools, they
   cannot be evacuated to or from. */
-  Caml_maybe_global_barrier(participating_count);
+  caml_global_barrier(participating_count);
   CAML_EV_BEGIN(EV_COMPACT_EVACUATE);
 
   struct caml_heap_state* heap = Caml_state->shared_heap;
@@ -1213,7 +1213,7 @@ void caml_compact_heap(caml_domain_state* domain_state,
   }
 
   CAML_EV_END(EV_COMPACT_EVACUATE);
-  Caml_maybe_global_barrier(participating_count);
+  caml_global_barrier(participating_count);
   CAML_EV_BEGIN(EV_COMPACT_FORWARD);
 
   /* Second phase: at this point all live blocks in evacuated pools
@@ -1257,7 +1257,7 @@ void caml_compact_heap(caml_domain_state* domain_state,
   compact_update_ephe_list(&ephe_info->live);
 
   CAML_EV_END(EV_COMPACT_FORWARD);
-  Caml_maybe_global_barrier(participating_count);
+  caml_global_barrier(participating_count);
   CAML_EV_BEGIN(EV_COMPACT_RELEASE);
 
   /* Third phase: free all evacuated pools and release the mappings back to
@@ -1282,7 +1282,7 @@ void caml_compact_heap(caml_domain_state* domain_state,
   }
 
   CAML_EV_END(EV_COMPACT_RELEASE);
-  Caml_maybe_global_barrier(participating_count);
+  caml_global_barrier(participating_count);
 
   /* Fourth phase: one domain also needs to release the free list */
   if( participants[0] == Caml_state ) {


### PR DESCRIPTION
This PR augments the existing busy-wait based synchronisation of stop-the-world (STW) sections using proper OS-based synchronisation primitives (barriers and futexes).

The branch also currently includes a couple (the first two) unrelated commits touching ocamltest and the testsuite to make extracting executables from the latter easier. Please ignore these.

## Busy Waits in the Runtime

See also #11707 where non-runtime spins are discussed too.

The runtime currently uses busy-waiting/spinning in several places for synchronisation. In almost all places this is done with the `SPIN_WAIT` macro in `platform.h`, which expands to an endless loop with eventual exponential backoff (using `usleep`) in `caml_plat_spin_wait`:

<details>
<summary><code>SPIN_WAIT</code> implementation</summary>

https://github.com/ocaml/ocaml/blob/2ee5c063060e00285fe3ead7c92edf3b6319df00/runtime/caml/platform.h#L79-L86

https://github.com/ocaml/ocaml/blob/2ee5c063060e00285fe3ead7c92edf3b6319df00/runtime/platform.c#L223-L240

</details>

Spinning is used in a handful of places, quite reasonably, for ironing out contention over object headers (in [obj.c](https://github.com/ocaml/ocaml/blob/2ee5c063060e00285fe3ead7c92edf3b6319df00/runtime/obj.c#L203), [major_gc.c](https://github.com/ocaml/ocaml/blob/2ee5c063060e00285fe3ead7c92edf3b6319df00/runtime/major_gc.c#L1074), [minor_gc.c](https://github.com/ocaml/ocaml/blob/2ee5c063060e00285fe3ead7c92edf3b6319df00/runtime/minor_gc.c#L168)), which this PR does not touch (other than minor adjustments to the `SPIN_WAIT` macro itself).

The more interesting uses, which this PR does affect, are those for STW sections. These are:

<details>
<summary>Existing STW Spins</summary>

### Existing STW Spins

For starting an STW section, all domains are issued interrupts, waited on, then released by a barrier:

https://github.com/ocaml/ocaml/blob/2ee5c063060e00285fe3ead7c92edf3b6319df00/runtime/domain.c#L1513-L1544

The two spins here are in `caml_wait_interrupt_serviced` (by the leader, waiting for each domain to service its interrupt) and in `stw_handler` (by each participant, waiting for the leader to release the barrier - in most cases, "async" STW requests don't).

https://github.com/ocaml/ocaml/blob/2ee5c063060e00285fe3ead7c92edf3b6319df00/runtime/domain.c#L346-L364

https://github.com/ocaml/ocaml/blob/2ee5c063060e00285fe3ead7c92edf3b6319df00/runtime/domain.c#L1340-L1353

There are also two barrier implementations with spinning, one used as a barrier for minor collections:

https://github.com/ocaml/ocaml/blob/c287b9d7855302581c7135ec7102b1b545f9e53e/runtime/minor_gc.c#L667-L701

~~(as a side-note, writes between barrier arrival and barrier departure may race with code outside the STW, `caml_collect_gc_stats_sample` has unsynchronised writes that could race with caml_compute_gc_stats, which is precisely what has been reported by [TSan](https://gist.github.com/OlivierNicole/9ba2a2dd4252586505f493677850721b))~~ (this has since been fixed in #12595, and the barrier arrival/departure moved around)

The other is the global barrier used by several STW sections, notably in major collections, but implemented in one place:

https://github.com/ocaml/ocaml/blob/2ee5c063060e00285fe3ead7c92edf3b6319df00/runtime/domain.c#L1282-L1315

</details>

<details>
<summary>Spinning Performance</summary>

### Spinning Performance

These spins tend to works reasonably well in most cases, particularly on Linux. Spinning has some advantages:

- It is easy, to write and to verify
- It is cheap to release, no explicit wake-ups needed
- If we are lucky, we can avoid a context switch

Spinning also has notable disadvantages:

- We may waste CPU and power
- We may waste our time slice, get scheduled out anyway, or we sleep and context-switch
- The OS doesn't know what we're waiting on, though this is less of an issue than with fair locks
- The effectiveness of the exponential backoff depends heavily on how well the OS can `usleep` for short times
  - On Windows with MinGW, sleeps shorter than 1ms [call `Sleep` with `0`](https://github.com/mirror/mingw-w64/blob/eff726c461e09f35eeaed125a3570fa5f807f02b/mingw-w64-crt/misc/mingw_usleep.c#L14) and so [don't sleep at all](https://learn.microsoft.com/en-us/windows/win32/api/synchapi/nf-synchapi-sleep), at best merely yielding instead
- It is fragile, bad spinning behaviour can lead to awful synchronisation latency if we back off for a long time
  - Some spins have no guarantees for ending in a timely manner (though they tend to)
    - A domain can run for a while without handling interrupts, which in certain cases may or may not be considered [a bug](https://github.com/ocaml/ocaml/issues/11580)
    - Barrier-delimited major and minor GC sections can also take varying lengths of time, so arrivals can be staggered
      - This is offset in the minor GC barrier with opportunistic major slices _if there is work available_

I took measurements for how long the STW-synchronising `SPIN_WAIT`s tend to spin. With `Max_spins` at both `1000` and `10000`, I logged the `caml__spins` variable after each `SPIN_WAIT` (with an ad-hoc C program over shared memory). The test load was the testsuite with `make -C testsuite/ parallel` (the serial run shows a similar distribution). I found that:

- With only two domains, the barriers would often release before the thread had to back off, but with more domains this gets rarer
- In most cases, threads only end up sleeping a few times

<details>
<summary>Spin Counter Plots</summary>

### Spin Counter Plots

In the plots below, each line is the distribution of spin counts (number of iterations) for different numbers of threads. The X axis shows the number of iterations (value of `caml__spins` after the loop), and on the Y axis is the [empirical cumulative distribution function](https://en.wikipedia.org/wiki/Empirical_distribution_function), i.e. the Y axis shows the proportion of `SPIN_WAIT`s which finished within the number of iterations on the X axis. The graphs are labelled with the source of the spin: `1ae2` is the `interrupt_serviced` spin, `5ae1` is the `stw_handler` spin, `ba01` is the global barrier, and `ba02` is the minor GC barrier.

#### Non-waiting Spins

These are plots of the distribution of `SPIN_WAIT`s limited to those that didn't call `caml_plat_spin_wait`, the step at the end indicating spins which _do_ end up calling `caml_plat_spin_wait`.

- `Max_spins = 10_000`
![Non-waiting spins max 10k](https://eutro.dev/share/ocaml/spins_10k_unblocked.svg)

- `Max_spins = 1_000`
![Non-waiting spins max 1k](https://eutro.dev/share/ocaml/spins_1k_unblocked.svg)

#### Waiting Spins

These are plots of the distribution of `SPIN_WAIT`s that do actually call `caml_plat_spin_wait`. Here the spin count on the X axis is actually the nanosecond sleep used and returned by `caml_plat_spin_wait` on the last iteration.

- `Max_spins = 10_000`
![Waiting spins max 10k](https://eutro.dev/share/ocaml/spins_10k_blocked.svg)

- `Max_spins = 1_000`
![Waiting spins max 1k](https://eutro.dev/share/ocaml/spins_1k_blocked.svg)

</details>

</details>

## This PR

The aim of this PR is to improve the situation of busy-waits in the runtime, initially motivated by poor performance on certain Windows machines, where tests like `memory-model/forbidden` run for three minutes. It does two things: replaces pure busy-spinning in STW synchronisation with OS-based synchronisation, and cleans up some of the issues that are exacerbated by this. No existing semantic bugs are addressed.

This PR introduces two new synchronisation objects in `platform.h`: `caml_plat_futex`, and `caml_plat_barrier` implemented using it. Hand-rolling synchronisation objects may be alarming and controversial, but should hopefully be easy enough to review.

<details>
<summary>Descriptions</summary>

`caml_plat_futex` is fundamentally a 32-bit word with `wait` and `wake`(`_all`) operations, implemented using syscalls on Linux (if the `linux/futex.h` header is available) and some BSDs, `WaitOnAddress` on Windows, and a mutex + condition variable as a fallback, on macOS and elsewhere.

`caml_plat_barrier` can be used as either a "single-sense" count-down latch (which needs explicit resetting), or a ["sense-reversing"](https://en.wikipedia.org/wiki/Barrier_(computer_science)#Sense-Reversal_Centralized_Barrier) conventional barrier (which doesn't need explicit resetting).

Other pthreads synchronisation primitives were considered: semaphores and pthreads' own barrier. The latter was deemed unsuitable - it must be created for a known number of parties, and doesn't support split `arrive` and `wait` that the runtime currently uses. A semaphore may work for the `wait_interrupt_serviced` spin, but wasn't used with `caml_plat_futex` already available and more suitable.

</details>

The STW-synchronising spin waits mentioned in the previous section were changed in this PR to use these. The barriers in `minor_gc.c` and `caml_global_barrier_*` now use `caml_plat_barrier` in the same mode (sense-reversing or single-sense) as the original code did. The `interrupt_serviced` and `stw_handler` spins were replaced by `caml_plat_futex`es used in a similar way to a binary semaphore. Some bounded spinning was also kept for all of these, particularly in the two-domain case (where yielding to the OS is often unnecessary), and where useful work can be done (this is only in the minor GC STW, which does opportunistic major slices while spinning), as guided by the spin plots above.

Finally, this PR also includes the following optimisations (guided by `perf` on `artemis`) in impacted code. Some of these can apply to trunk directly without the busy-wait changes, but they seem to be much more impactful with them.
- Some atomic operations were relaxed, and `Caml_state` reads removed, where these were hot
- The `global_barrier` API was streamlined for the common running-something-as-the-final-party use-case
  - The primary aim being to elide the now slightly more expensive barrier arrival entirely if there is only one domain in the STW
- `pool_sweep`, now slightly hotter, was optimised to skip the first bounds check and to hoist the in-loop `work` increment
- `alloc_counter` and `work_counter` in `major_gc.c` were unified into one `outstanding_work_counter`
  - This reduces the now-exacerbated contention in `update_major_slice_work` which had been updating two atomics that were probably on the same cache line
  - **This also changes the gc log output**
- `domain_spawn` disallows new STW sections, which it cannot run concurrently with, if it's already been forced to wait for a few (currently 2) STW sections to end
  - Some cases where this triggers were already substantially improved by the busy-wait changes
  - Previously, relentless STW requests could prevent `domain_spawn` (and its parent thread) from making any progress (see all the `spawn_burn` tests), which was exacerbated in some cases (particularly on macOS in CI)

## Benchmarks

A lot of benchmarking was done running (individual tests of) the [testsuite](../tree/trunk/testsuite/), which, while not necessarily made for benchmarking, does have a wide variety of program behaviours. Some benchmarking (for `perf`) was also done on the [Sandmark](https://github.com/ocaml-bench/sandmark) benchmarks, running them manually.

<details>
<summary>Testsuite Benchmarks</summary>

### Testsuite Benchmarks

The plots below include:

- a summary plot of the absolute and relative changes in duration compared to `trunk` or `trunk+backports` (bars which go down are good, bars which go up are bad).
- a summary plot showing a histogram of the relative changes in duration (left is good, right is bad)
- detailed plots of the distribution of each individual test, with:
  - a box plot showing the median and quartiles
  - a violin plot showing the distribution (kernel density estimation)
  - a scatter plot showing individual results

Tests which didn't run for long enough to be useful (the majority) were excluded from benchmarking. [Here is the full list of tests run](https://eutro.dev/share/ocaml/long.txt), though not all platforms ran all tests. The source code of the programs I used to compile, run, time, and plot all the tests is currently not public, but I will work on publishing these after opening this PR.

In each plot, some tests are excluded for not meeting a threshold of statistical significance, which is noted on the first page.

| Device Name | Operating System | Processor                                     | Plots                                                              |
|-------------|------------------|-----------------------------------------------|--------------------------------------------------------------------|
| artemis     | Arch Linux       | [AMD Ryzen™ 5 2600][r5-2600] @ 3.40GHz        | [v. trunk](https://eutro.dev/share/ocaml/artemis_09_18_trunk.pdf)  |
|             |                  |                                               | [v. backports](https://eutro.dev/share/ocaml/artemis_09_18_bp.pdf) |
|             |                  |                                               | [unified](https://eutro.dev/share/ocaml/artemis_09_18.pdf)         |
| herse       | Windows 11       | [Intel® Core™ i7-8665U][i7-8665U] @ 1.90GHz   | [v. trunk](https://eutro.dev/share/ocaml/herse_09_18_trunk.pdf)    |
|             |                  |                                               | [v. backports](https://eutro.dev/share/ocaml/herse_09_18_bp.pdf)   |
|             |                  |                                               | [unified](https://eutro.dev/share/ocaml/herse_09_18.pdf)           |
| apollo      | Windows 10       | [Intel® Core™ i7-6700HQ][i7-6700HQ] @ 2.60GHz | [v. trunk](https://eutro.dev/share/ocaml/apollo_09_18_trunk.pdf)   |
|             |                  |                                               | [v. backports](https://eutro.dev/share/ocaml/apollo_09_18_bp.pdf)  |
|             |                  |                                               | [unified](https://eutro.dev/share/ocaml/apollo_09_18.pdf)          |
| summer      | FreeBSD 13.2     | [Intel® Xeon® Silver 4108][xs-4108] @ 1.80GHz | [v. trunk](https://eutro.dev/share/ocaml/summer_09_18_trunk.pdf)   |
|             |                  |                                               | [v. backports](https://eutro.dev/share/ocaml/summer_09_18_bp.pdf)  |
|             |                  |                                               | [unified](https://eutro.dev/share/ocaml/summer_09_18.pdf)          |

Notes:

- [`OCAML_TEST_SIZE`](../blob/trunk/testsuite/HACKING.adoc#dimensioning-the-tests) was 2 for `summer`, and 3 for all the others
- `trunk` for these benchmarks was at 4a458b91ab585629c08af1f0adbd848f32a276eb, `barriers` was at d057cc64f2a70a12a12109f856a42c08d1684955
- `trunk+backports` is `trunk` with patches for the `pool_sweep`, `outstanding_work_counter` and `domain_spawn` optimisation patches applied
- All these devices are on x64
- [Artemis](https://en.wikipedia.org/wiki/Artemis) is the goddess of the hunt, and the namesake of my Linux PC. Her twin, [Apollo](https://en.wikipedia.org/wiki/Apollo), is the god of a myriad of things, and the namesake of my old laptop. [Herse](https://en.wikipedia.org/wiki/Ersa), or Ersa, is the personification of dew, and the namesake of my work laptop. Summer is [a season](https://en.wikipedia.org/wiki/Summer) and a given name. It is also the hostname of a CI server.

[i7-6700HQ]: https://www.intel.com/content/www/us/en/products/sku/88967/intel-core-i76700hq-processor-6m-cache-up-to-3-50-ghz/specifications.html
[r5-2600]: https://web.archive.org/web/20201121015827mp_/https://www.amd.com/en/products/cpu/amd-ryzen-5-2600#product-specs
[i7-8665U]: https://ark.intel.com/content/www/us/en/ark/products/193563/intel-core-i78665u-processor-8m-cache-up-to-4-80-ghz.html
[xs-4108]: https://ark.intel.com/content/www/us/en/ark/products/123544/intel-xeon-silver-4108-processor-11m-cache-1-80-ghz.html

### Sandmark Nightly

See the latest `5.2.0+trunk+eutro+barriers` on <https://sandmark.tarides.com/>.

</details>
