### PR TITLE
Improve location of alias pattern variables

### DIFF
--- a/Changes
+++ b/Changes
@@ -315,6 +315,9 @@ Working version
 
 ### Bug fixes:
 
+- #12580: Fix location of alias pattern variables.
+  (Chris Casinghino, review by ???, report by Milo Davis)
+
 - #12566: caml_output_value_to_malloc wrongly uses `caml_stat_alloc`
   instead of `malloc` since 4.06, breaking (in pooled mode) user code
   that uses `free` on the result. Symmetrically,

--- a/Changes
+++ b/Changes
@@ -316,7 +316,7 @@ Working version
 ### Bug fixes:
 
 - #12580: Fix location of alias pattern variables.
-  (Chris Casinghino, review by ???, report by Milo Davis)
+  (Chris Casinghino, review Gabriel Scherer, report by Milo Davis)
 
 - #12566: caml_output_value_to_malloc wrongly uses `caml_stat_alloc`
   instead of `malloc` since 4.06, breaking (in pooled mode) user code

--- a/testsuite/tests/typing-gadts/or_patterns.ml
+++ b/testsuite/tests/typing-gadts/or_patterns.ml
@@ -217,9 +217,9 @@ let simple_merged_annotated_return (type a) (t : a t) (a : a) =
 ;;
 
 [%%expect{|
-Line 3, characters 12-20:
+Line 3, characters 18-19:
 3 |   | IntLit, (3 as x)
-                ^^^^^^^^
+                      ^
 Error: This pattern matches values of type "int"
        This instance of "int" is ambiguous:
        it would escape the scope of its equation

--- a/testsuite/tests/warnings/w26_alias.ml
+++ b/testsuite/tests/warnings/w26_alias.ml
@@ -1,0 +1,19 @@
+(* TEST
+ expect;
+*)
+type t =
+  { x : int
+  ; y : int
+  }
+
+let sum ({ x; y } as t) = x + y
+
+[%%expect{|
+type t = { x : int; y : int; }
+Line 6, characters 21-22:
+6 | let sum ({ x; y } as t) = x + y
+                         ^
+Warning 26 [unused-var]: unused variable t.
+
+val sum : t -> int = <fun>
+|}]

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -1640,7 +1640,7 @@ and type_pat_aux
       let ty_var = solve_Ppat_alias !!penv q in
       let id =
         enter_variable
-          ~is_as_variable:true tps loc name ty_var sp.ppat_attributes
+          ~is_as_variable:true tps name.loc name ty_var sp.ppat_attributes
       in
       rvp { pat_desc = Tpat_alias(q, id, name);
             pat_loc = loc; pat_extra=[];


### PR DESCRIPTION
This fixes a minor bug where the compiler sometimes records the wrong location for the name in an alias pattern, causing suboptimal locations in warnings/errors.  For example, this program has an unused pattern variable:
```ocaml
type t =
  { x : int
  ; y : int
  }

let sum ({ x; y } as t) = x + y
```
But the compiler currently reports the location of the whole pattern as the location of the unused variable:
```
File "/home/ccasinghino/tmp/pat.ml", line 6, characters 8-23:
6 | let sum ({ x; y } as t) = x + y
            ^^^^^^^^^^^^^^^
Warning 26 [unused-var]: unused variable t.
```
This is unhelpful, and is worse when the pattern is larger.  After this PR, the compiler reports the correct location:
```
File "/home/ccasinghino/tmp/pat.ml", line 6, characters 21-22:
6 | let sum ({ x; y } as t) = x + y
                         ^
Warning 26 [unused-var]: unused variable t.
```
(This location is already printed at one place in the testsuite for a different error, also improved by this PR.)