### PR TITLE
Add a closing event for when `EV_MAJOR_EPHE_MARK` is complete

### DIFF
--- a/Changes
+++ b/Changes
@@ -315,6 +315,9 @@ Working version
 
 ### Bug fixes:
 
+- #12583: Add a closing event for when `EV_MAJOR_EPHE_MARK` is complete
+  (Sudha Parimala, review by Gabriel Scherer)
+
 - #12566: caml_output_value_to_malloc wrongly uses `caml_stat_alloc`
   instead of `malloc` since 4.06, breaking (in pooled mode) user code
   that uses `free` on the result. Symmetrically,

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -1635,6 +1635,8 @@ mark_again:
           }
         }
 
+        CAML_EV_END(EV_MAJOR_EPHE_MARK);
+
         if (domain_state->ephe_info->todo == (value)NULL) {
           ephe_todo_list_emptied ();
         }


### PR DESCRIPTION
This is a minor fix to add a missing closing runtime event for `EV_MAJOR_EPHE_MARK`. I discovered this while debugging https://github.com/tarides/runtime_events_tools/issues/20. I gave this a spin with [`olly trace`](https://github.com/tarides/runtime_events_tools#trace) on one of the ephemeron tests ([`ephe_test.ml`](https://github.com/ocaml/ocaml/blob/trunk/testsuite/tests/weak-ephe-final/ephetest.ml)) in the testsuite - it appears this patch has fixed this non-terminating event.

The trace produced by 5.1.0 rendered on [ui.perfetto.dev](http://ui.perfetto.dev/):

![before](https://user-images.githubusercontent.com/13328130/268932459-67b012d3-c71d-407b-b007-b6ee111c3c7c.png)

The trace produced by 5.1.0 + this PR:

![after](https://user-images.githubusercontent.com/13328130/268932502-aa441290-0e7c-465d-8db4-a398105e5602.png)

Please note that I ran the tests on 5.1.0 along with the commit in this PR. This was necessary because 'olly' depends on ppx, and support for ppx on the trunk is not available yet (afaict).