### PR TITLE
Don't use configured CFLAGS & CPPFLAGS to compile third-party C sources

### DIFF
--- a/Changes
+++ b/Changes
@@ -331,6 +331,13 @@ _______________
   (Sébastien Hinderer, review by Miod Vallat, Gabriel Scherer and
   Olivier Nicole)
 
+* #12578, #12589: Use configured CFLAGS and CPPFLAGS *only* during the
+  build of the compiler itself. Do not use them when compiling third-party
+  C sources through the compiler. Flags for compiling third-party C
+  sources can still be specified at configure time in the
+  COMPILER_{BYTECODE,NATIVE}_{CFLAGS,CPPFLAGS} configuration variables.
+  (Sébastien Hinderer, report by William Hu, review by David Allsopp)
+
 ### Bug fixes:
 
 - #12854: Add a test in the regression suite that flags the bug #12825.

--- a/Makefile
+++ b/Makefile
@@ -1268,8 +1268,9 @@ libcomprmarsh_OBJECTS = runtime/zstd.npic.$(O)
 ## General (non target-specific) assembler and compiler flags
 
 runtime_CPPFLAGS = -DCAMLDLLIMPORT= -DIN_CAML_RUNTIME
-ocamlrund_CPPFLAGS = -DDEBUG
-ocamlruni_CPPFLAGS = -DCAML_INSTR
+ocamlrun_CPPFLAGS = $(runtime_CPPFLAGS)
+ocamlrund_CPPFLAGS = $(runtime_CPPFLAGS) -DDEBUG
+ocamlruni_CPPFLAGS = $(runtime_CPPFLAGS) -DCAML_INSTR
 
 ## Runtime targets
 
@@ -1387,34 +1388,43 @@ runtime/libcomprmarsh.$(A): $(libcomprmarsh_OBJECTS)
 
 ## Runtime target-specific preprocessor and compiler flags
 
-runtime/%.$(O): OC_CPPFLAGS += $(runtime_CPPFLAGS)
-$(DEPDIR)/runtime/%.$(D): OC_CPPFLAGS += $(runtime_CPPFLAGS)
+runtime/%.b.$(O): OC_CFLAGS = $(OC_BYTECODE_CFLAGS)
+runtime/%.b.$(O): OC_CPPFLAGS = $(OC_BYTECODE_CPPFLAGS) $(ocamlrun_CPPFLAGS)
+$(DEPDIR)/runtime/%.b.$(D): \
+  OC_CPPFLAGS = $(OC_BYTECODE_CPPFLAGS) $(ocamlrun_CPPFLAGS)
 
-runtime/%.bd.$(O): OC_CPPFLAGS += $(ocamlrund_CPPFLAGS)
-$(DEPDIR)/runtime/%.bd.$(D): OC_CPPFLAGS += $(ocamlrund_CPPFLAGS)
+runtime/%.bd.$(O): OC_CFLAGS = $(OC_BYTECODE_CFLAGS)
+runtime/%.bd.$(O): OC_CPPFLAGS = $(OC_BYTECODE_CPPFLAGS) $(ocamlrund_CPPFLAGS)
+$(DEPDIR)/runtime/%.bd.$(D): \
+  OC_CPPFLAGS = $(OC_BYTECODE_CPPFLAGS) $(ocamlrund_CPPFLAGS)
 
-runtime/%.bi.$(O): OC_CPPFLAGS += $(ocamlruni_CPPFLAGS)
-$(DEPDIR)/runtime/%.bi.$(D): OC_CPPFLAGS += $(ocamlruni_CPPFLAGS)
+runtime/%.bi.$(O): OC_CFLAGS = $(OC_BYTECODE_CFLAGS)
+runtime/%.bi.$(O): OC_CPPFLAGS = $(OC_BYTECODE_CPPFLAGS) $(ocamlruni_CPPFLAGS)
+$(DEPDIR)/runtime/%.bi.$(D): \
+  OC_CPPFLAGS = $(OC_BYTECODE_CPPFLAGS) $(ocamlruni_CPPFLAGS)
 
-runtime/%.bpic.$(O): OC_CFLAGS += $(SHAREDLIB_CFLAGS)
+runtime/%.bpic.$(O): OC_CFLAGS = $(OC_BYTECODE_CFLAGS) $(SHAREDLIB_CFLAGS)
+runtime/%.bpic.$(O): OC_CPPFLAGS = $(OC_BYTECODE_CPPFLAGS)
+$(DEPDIR)/runtime/%.bpic.$(D): OC_CPPFLAGS = $(OC_BYTECODE_CPPFLAGS)
 
-runtime/%.n.$(O): OC_CFLAGS += $(OC_NATIVE_CFLAGS)
-runtime/%.n.$(O): OC_CPPFLAGS += $(OC_NATIVE_CPPFLAGS)
-$(DEPDIR)/runtime/%.n.$(D): OC_CPPFLAGS += $(OC_NATIVE_CPPFLAGS)
+runtime/%.n.$(O): OC_CFLAGS = $(OC_NATIVE_CFLAGS)
+runtime/%.n.$(O): OC_CPPFLAGS = $(OC_NATIVE_CPPFLAGS) $(ocamlrun_CPPFLAGS)
+$(DEPDIR)/runtime/%.n.$(D): \
+  OC_CPPFLAGS = $(OC_NATIVE_CPPFLAGS) $(ocamlrun_CPPFLAGS)
 
-runtime/%.nd.$(O): OC_CFLAGS += $(OC_NATIVE_CFLAGS)
-runtime/%.nd.$(O): OC_CPPFLAGS += $(OC_NATIVE_CPPFLAGS) $(ocamlrund_CPPFLAGS)
+runtime/%.nd.$(O): OC_CFLAGS = $(OC_NATIVE_CFLAGS)
+runtime/%.nd.$(O): OC_CPPFLAGS = $(OC_NATIVE_CPPFLAGS) $(ocamlrund_CPPFLAGS)
 $(DEPDIR)/runtime/%.nd.$(D): \
-  OC_CPPFLAGS += $(OC_NATIVE_CPPFLAGS) $(ocamlrund_CPPFLAGS)
+  OC_CPPFLAGS = $(OC_NATIVE_CPPFLAGS) $(ocamlrund_CPPFLAGS)
 
-runtime/%.ni.$(O): OC_CFLAGS += $(OC_NATIVE_CFLAGS)
-runtime/%.ni.$(O): OC_CPPFLAGS += $(OC_NATIVE_CPPFLAGS) $(ocamlruni_CPPFLAGS)
+runtime/%.ni.$(O): OC_CFLAGS = $(OC_NATIVE_CFLAGS)
+runtime/%.ni.$(O): OC_CPPFLAGS = $(OC_NATIVE_CPPFLAGS) $(ocamlruni_CPPFLAGS)
 $(DEPDIR)/runtime/%.ni.$(D): \
-  OC_CPPFLAGS += $(OC_NATIVE_CPPFLAGS) $(ocamlruni_CPPFLAGS)
+  OC_CPPFLAGS = $(OC_NATIVE_CPPFLAGS) $(ocamlruni_CPPFLAGS)
 
-runtime/%.npic.$(O): OC_CFLAGS += $(OC_NATIVE_CFLAGS) $(SHAREDLIB_CFLAGS)
-runtime/%.npic.$(O): OC_CPPFLAGS += $(OC_NATIVE_CPPFLAGS)
-$(DEPDIR)/runtime/%.npic.$(D): OC_CPPFLAGS += $(OC_NATIVE_CPPFLAGS)
+runtime/%.npic.$(O): OC_CFLAGS = $(OC_NATIVE_CFLAGS) $(SHAREDLIB_CFLAGS)
+runtime/%.npic.$(O): OC_CPPFLAGS = $(OC_NATIVE_CPPFLAGS)
+$(DEPDIR)/runtime/%.npic.$(D): OC_CPPFLAGS = $(OC_NATIVE_CPPFLAGS)
 
 ## Compilation of runtime C files
 

--- a/Makefile
+++ b/Makefile
@@ -1326,7 +1326,7 @@ $(SAK): runtime/sak.$(O)
 	$(V_MKEXE)$(call SAK_LINK,$@,$^)
 
 runtime/sak.$(O): runtime/sak.c runtime/caml/misc.h runtime/caml/config.h
-	$(V_CC)$(SAK_CC) -c $(SAK_CFLAGS) $(OUTPUTOBJ)$@ $<
+	$(V_CC)$(SAK_CC) $(SAK_CFLAGS) $(OUTPUTOBJ)$@ -c $<
 
 C_LITERAL = $(shell $(SAK) encode-C-literal '$(1)')
 
@@ -1441,15 +1441,15 @@ $(1).$(O): $(2).c \
   $(runtime_CONFIGURED_HEADERS) $(runtime_BUILT_HEADERS) \
   $(RUNTIME_HEADERS)
 endif # ifeq "$(COMPUTE_DEPS)" "true"
-	$$(V_CC)$$(CC) -c $$(OC_CFLAGS) $$(CFLAGS) $$(OC_CPPFLAGS) $$(CPPFLAGS) \
-	  $$(OUTPUTOBJ)$$@ $$<
+	$$(V_CC)$$(CC) $$(OC_CFLAGS) $$(CFLAGS) $$(OC_CPPFLAGS) $$(CPPFLAGS) \
+	  $$(OUTPUTOBJ)$$@ -c $$<
 endef
 
 runtime/winpthreads/%.$(O): $(WINPTHREADS_SOURCE_DIR)/src/%.c \
                             $(wildcard $(WINPTHREADS_SOURCE_DIR)/include/*.h) \
                               | runtime/winpthreads
-	$(V_CC)$(CC) -c $(OC_CFLAGS) $(CFLAGS) $(OC_CPPFLAGS) $(CPPFLAGS) \
-	  $(OUTPUTOBJ)$@ $<
+	$(V_CC)$(CC) $(OC_CFLAGS) $(CFLAGS) $(OC_CPPFLAGS) $(CPPFLAGS) \
+	  $(OUTPUTOBJ)$@ -c $<
 
 runtime/winpthreads:
 	$(MKDIR) $@

--- a/Makefile.build_config.in
+++ b/Makefile.build_config.in
@@ -63,12 +63,23 @@ INSTALL_OCAMLNAT = @install_ocamlnat@
 DEP_CC=@DEP_CC@ -MM
 COMPUTE_DEPS=@compute_deps@
 
-# Build-system flags to use to compile C files
-OC_CFLAGS=@oc_cflags@
+# Default flags to use to compile C files
+OC_CFLAGS = @oc_cflags@
+
+# Flags to use when compiling C files to be linked with bytecode
+OC_BYTECODE_CFLAGS = @oc_bytecode_cflags@
+
+# Flags to use when compiling C files to be linked with native code
+OC_NATIVE_CFLAGS = @oc_native_cflags@
+
 # The submodules should be searched *before* any other external -I paths
 OC_INCLUDES = $(addprefix -I $(ROOTDIR)/, \
   runtime @flexdll_source_dir@ @winpthreads_source_include_dir@)
 OC_CPPFLAGS = $(OC_INCLUDES) @oc_cppflags@
+
+OC_BYTECODE_CPPFLAGS = $(OC_INCLUDES) @oc_bytecode_cppflags@
+
+OC_NATIVE_CPPFLAGS = $(OC_INCLUDES) @oc_native_cppflags@
 
 # Additional link-time options
 # To support dynamic loading of shared libraries (they need to look at

--- a/Makefile.common
+++ b/Makefile.common
@@ -171,8 +171,8 @@ REQUIRED_HEADERS := $(RUNTIME_HEADERS) $(wildcard *.h)
 endif
 
 %.$(O): %.c $(REQUIRED_HEADERS)
-	$(V_CC)$(CC) -c $(OC_CFLAGS) $(CFLAGS) $(OC_CPPFLAGS) $(CPPFLAGS) \
-	  $(OUTPUTOBJ)$@ $<
+	$(V_CC)$(CC) $(OC_CFLAGS) $(CFLAGS) $(OC_CPPFLAGS) $(CPPFLAGS) \
+	  $(OUTPUTOBJ)$@ -c $<
 
 $(DEPDIR):
 	$(MKDIR) $@

--- a/Makefile.config.in
+++ b/Makefile.config.in
@@ -182,14 +182,6 @@ MKLIB=@mklib@
 # C libraries when it needs to be different from the one used to
 # link with bytecode.
 
-# These flags should be passed *in addition* to those in OC_CPPFLAGS, they
-# should not replace them.
-
-OC_NATIVE_CPPFLAGS=@native_cppflags@
-
-# Same as above, for CFLAGS
-OC_NATIVE_CFLAGS=@native_cflags@
-
 NATIVECCLIBS=@cclibs@
 SYSTHREAD_SUPPORT=@systhread_support@
 PACKLD=@PACKLD@$(EMPTY)

--- a/configure
+++ b/configure
@@ -20180,7 +20180,7 @@ test -n "$PTHREAD_CXX" || PTHREAD_CXX="$CXX"
 
 # Finally, execute ACTION-IF-FOUND/ACTION-IF-NOT-FOUND:
 if test "x$ax_pthread_ok" = "xyes"; then
-        common_cflags="$common_cflags $PTHREAD_CFLAGS"
+
     # The two following lines add flags and libraries for pthread to the
     # global CFLAGS and LIBS variables. This means that all the subsequent
     # tests can rely on the assumption that pthread is enabled.

--- a/configure
+++ b/configure
@@ -14154,7 +14154,8 @@ fi
   sunc-*) :
     # Optimization should be >= O4 to inline functions
             # and prevent unresolved externals
-    common_cflags="-O4 -xc99=all -D_XPG6 $CFLAGS";
+    common_cflags="-O4 -xc99=all"
+    common_cppflags="-D_XPG6"
     internal_cflags="$cc_warnings" ;; #(
   *) :
     common_cflags="-O" ;;

--- a/configure
+++ b/configure
@@ -767,6 +767,10 @@ WINDOWS_UNICODE_MODE
 LIBUNWIND_LDFLAGS
 LIBUNWIND_CPPFLAGS
 DLLIBS
+COMPILER_NATIVE_CPPFLAGS
+COMPILER_NATIVE_CFLAGS
+COMPILER_BYTECODE_CPPFLAGS
+COMPILER_BYTECODE_CFLAGS
 PARTIALLD
 csc
 target_os
@@ -857,8 +861,6 @@ winpthreads_source_dir
 flexdll_dir
 bootstrapping_flexdll
 flexdll_source_dir
-bytecode_cppflags
-bytecode_cflags
 zstd_libs
 native_ldflags
 cclibs
@@ -886,8 +888,14 @@ ln
 unix_or_win32
 ocamlsrcdir
 systhread_support
+oc_native_cppflags
+oc_native_cflags
+oc_bytecode_cppflags
+oc_bytecode_cflags
 native_cppflags
 native_cflags
+bytecode_cppflags
+bytecode_cflags
 system
 model
 arch64
@@ -1025,6 +1033,10 @@ target_alias
 AS
 ASPP
 PARTIALLD
+COMPILER_BYTECODE_CFLAGS
+COMPILER_BYTECODE_CPPFLAGS
+COMPILER_NATIVE_CFLAGS
+COMPILER_NATIVE_CPPFLAGS
 DLLIBS
 LIBUNWIND_CPPFLAGS
 LIBUNWIND_LDFLAGS
@@ -1735,6 +1747,14 @@ Some influential environment variables:
   AS          which assembler to use
   ASPP        which assembler (with preprocessor) to use
   PARTIALLD   how to build partial (relocatable) object files
+  COMPILER_BYTECODE_CFLAGS
+              CFLAGS for compiling C files to be linked with bytecode
+  COMPILER_BYTECODE_CPPFLAGS
+              CPPFLAGS for compiling C files to be linked with bytecode
+  COMPILER_NATIVE_CFLAGS
+              CFLAGS for compiling C files to be linked with native code
+  COMPILER_NATIVE_CPPFLAGS
+              CPPFLAGS for compiling C files to be linked with native code
   DLLIBS      which libraries to use (in addition to -ldl) to load dynamic
               libs
   LIBUNWIND_CPPFLAGS
@@ -3440,6 +3460,12 @@ LINEAR_MAGIC_NUMBER=Caml1999L035
 
 
 
+
+
+
+
+
+
  # TODO: rename this variable
 
 
@@ -3766,6 +3792,11 @@ esac
 fi
 
 # Environment variables that are taken into account
+
+
+
+
+
 
 
 
@@ -16231,7 +16262,8 @@ case $arch in #(
 esac
 
 native_cflags=''
-native_cppflags="-DNATIVE_CODE\
+oc_native_cflags=''
+oc_native_cppflags="-DNATIVE_CODE\
  -DTARGET_${arch} -DMODEL_${model} -DSYS_${system}"
 case $ccomptype in #(
   msvc) :
@@ -17239,7 +17271,8 @@ else $as_nop
 fi
 
   tsan_cflags="$tsan_cflags $tsan_distinguish_volatile_cflags"
-  native_cppflags="$native_cppflags $tsan_cppflags"
+  oc_native_cppflags="$oc_native_cppflags $tsan_cppflags"
+  oc_native_cflags="$oc_native_cflags $tsan_cflags"
   native_cflags="$native_cflags $tsan_cflags"
   native_ldflags="$native_ldflags $tsan_ldflags"
   tsan_native_runtime_c_sources="tsan"
@@ -17300,7 +17333,7 @@ then :
   libunwind_ldflags="$LIBUNWIND_LDFLAGS $libunwind_ldflags"
 fi
 
-  native_cppflags="$native_cppflags $libunwind_cppflags"
+  oc_native_cppflags="$oc_native_cppflags $libunwind_cppflags"
   native_ldflags="$native_ldflags $libunwind_ldflags"
 
 
@@ -20858,8 +20891,20 @@ fi
 
 oc_cflags="$common_cflags $internal_cflags"
 oc_cppflags="$common_cppflags $internal_cppflags"
-bytecode_cflags="$bytecode_cflags $common_cflags $sharedlib_cflags $CFLAGS"
-bytecode_cppflags="$common_cppflags $CPPFLAGS"
+
+oc_bytecode_cflags="$oc_cflags"
+oc_bytecode_cppflags="$oc_cppflags"
+
+oc_native_cflags="$oc_cflags $oc_native_cflags"
+native_cflags="$common_cflags $native_cflags"
+oc_native_cppflags="$oc_cppflags $oc_native_cppflags"
+
+bytecode_cflags="$common_cflags $sharedlib_cflags\
+ $PTHREAD_CFLAGS $COMPILER_BYTECODE_CFLAGS"
+native_cflags="$native_cflags $PTHREAD_CFLAGS $COMPILER_NATIVE_CFLAGS"
+
+bytecode_cppflags="$common_cppflags $COMPILER_BYTECODE_CPPFLAGS"
+native_cppflags="$common_cppflags $COMPILER_NATIVE_CPPFLAGS"
 
 case $host in #(
   *-*-mingw32*) :

--- a/configure.ac
+++ b/configure.ac
@@ -140,8 +140,14 @@ AC_SUBST([arch_specific_SOURCES])
 AC_SUBST([arch64])
 AC_SUBST([model])
 AC_SUBST([system])
+AC_SUBST([bytecode_cflags])
+AC_SUBST([bytecode_cppflags])
 AC_SUBST([native_cflags])
 AC_SUBST([native_cppflags])
+AC_SUBST([oc_bytecode_cflags])
+AC_SUBST([oc_bytecode_cppflags])
+AC_SUBST([oc_native_cflags])
+AC_SUBST([oc_native_cppflags])
 AC_SUBST([systhread_support])
 AC_SUBST([ocamlsrcdir])
 AC_SUBST([unix_or_win32])
@@ -335,6 +341,15 @@ AS_IF([test -n "$csc"],
 AC_ARG_VAR([AS], [which assembler to use])
 AC_ARG_VAR([ASPP], [which assembler (with preprocessor) to use])
 AC_ARG_VAR([PARTIALLD], [how to build partial (relocatable) object files])
+
+AC_ARG_VAR([COMPILER_BYTECODE_CFLAGS],
+  [CFLAGS for compiling C files to be linked with bytecode])
+AC_ARG_VAR([COMPILER_BYTECODE_CPPFLAGS],
+  [CPPFLAGS for compiling C files to be linked with bytecode])
+AC_ARG_VAR([COMPILER_NATIVE_CFLAGS],
+  [CFLAGS for compiling C files to be linked with native code])
+AC_ARG_VAR([COMPILER_NATIVE_CPPFLAGS],
+  [CPPFLAGS for compiling C files to be linked with native code])
 
 # Command-line arguments to configure
 
@@ -1501,7 +1516,8 @@ AS_CASE([$arch],
   [arch_specific_SOURCES=''])
 
 native_cflags=''
-native_cppflags="-DNATIVE_CODE\
+oc_native_cflags=''
+oc_native_cppflags="-DNATIVE_CODE\
  -DTARGET_${arch} -DMODEL_${model} -DSYS_${system}"
 AS_CASE([$ccomptype],
   [msvc],
@@ -1856,7 +1872,8 @@ AS_IF([$tsan],
       `$tsan_distinguish_volatile_cflags' flag. Try upgrading to GCC >= 11, or
       to Clang >= 11.]))], [$warn_error_flag])
   tsan_cflags="$tsan_cflags $tsan_distinguish_volatile_cflags"
-  native_cppflags="$native_cppflags $tsan_cppflags"
+  oc_native_cppflags="$oc_native_cppflags $tsan_cppflags"
+  oc_native_cflags="$oc_native_cflags $tsan_cflags"
   native_cflags="$native_cflags $tsan_cflags"
   native_ldflags="$native_ldflags $tsan_ldflags"
   tsan_native_runtime_c_sources="tsan"],
@@ -1895,7 +1912,7 @@ AS_IF([$tsan],
   AS_IF([test x"$LIBUNWIND_LDFLAGS" != x],
     [libunwind_ldflags="$LIBUNWIND_LDFLAGS $libunwind_ldflags"])
 
-  native_cppflags="$native_cppflags $libunwind_cppflags"
+  oc_native_cppflags="$oc_native_cppflags $libunwind_cppflags"
   native_ldflags="$native_ldflags $libunwind_ldflags"
 
   OCAML_CHECK_LIBUNWIND
@@ -2584,8 +2601,20 @@ AS_IF([test "$ccomptype" != "msvc"],
 
 oc_cflags="$common_cflags $internal_cflags"
 oc_cppflags="$common_cppflags $internal_cppflags"
-bytecode_cflags="$bytecode_cflags $common_cflags $sharedlib_cflags $CFLAGS"
-bytecode_cppflags="$common_cppflags $CPPFLAGS"
+
+oc_bytecode_cflags="$oc_cflags"
+oc_bytecode_cppflags="$oc_cppflags"
+
+oc_native_cflags="$oc_cflags $oc_native_cflags"
+native_cflags="$common_cflags $native_cflags"
+oc_native_cppflags="$oc_cppflags $oc_native_cppflags"
+
+bytecode_cflags="$common_cflags $sharedlib_cflags\
+ $PTHREAD_CFLAGS $COMPILER_BYTECODE_CFLAGS"
+native_cflags="$native_cflags $PTHREAD_CFLAGS $COMPILER_NATIVE_CFLAGS"
+
+bytecode_cppflags="$common_cppflags $COMPILER_BYTECODE_CPPFLAGS"
+native_cppflags="$common_cppflags $COMPILER_NATIVE_CPPFLAGS"
 
 AS_CASE([$host],
   [*-*-mingw32*],

--- a/configure.ac
+++ b/configure.ac
@@ -2371,7 +2371,7 @@ AS_CASE([$host],
   [*-pc-windows],
     [PTHREAD_LIBS=''],
   [AX_PTHREAD(
-    [common_cflags="$common_cflags $PTHREAD_CFLAGS"
+    [
     # The two following lines add flags and libraries for pthread to the
     # global CFLAGS and LIBS variables. This means that all the subsequent
     # tests can rely on the assumption that pthread is enabled.

--- a/configure.ac
+++ b/configure.ac
@@ -908,7 +908,8 @@ AS_CASE([$ocaml_cc_vendor],
     internal_cflags="$cc_warnings"],
   [sunc-*], # Optimization should be >= O4 to inline functions
             # and prevent unresolved externals
-    [common_cflags="-O4 -xc99=all -D_XPG6 $CFLAGS";
+    [common_cflags="-O4 -xc99=all"
+    common_cppflags="-D_XPG6"
     internal_cflags="$cc_warnings"],
   [common_cflags="-O"])
 

--- a/otherlibs/Makefile.otherlibs.common
+++ b/otherlibs/Makefile.otherlibs.common
@@ -161,14 +161,14 @@ distclean:: clean
 	$(V_OCAMLOPT)$(CAMLOPT) -c $(COMPFLAGS) $(OPTCOMPFLAGS) $<
 
 %.b.$(O): %.c $(REQUIRED_HEADERS)
-	$(V_CC)$(CC) -c $(OC_CFLAGS) $(CFLAGS) $(OC_CPPFLAGS) $(CPPFLAGS) \
-	  $(OUTPUTOBJ)$@ $<
+	$(V_CC)$(CC) $(OC_CFLAGS) $(CFLAGS) $(OC_CPPFLAGS) $(CPPFLAGS) \
+	  $(OUTPUTOBJ)$@ -c $<
 
 %.n.$(O): OC_CFLAGS += $(OC_NATIVE_CFLAGS)
 
 %.n.$(O): %.c $(REQUIRED_HEADERS)
-	$(V_CC)$(CC) -c $(OC_CFLAGS) $(CFLAGS) \
-	  $(OC_CPPFLAGS) $(CPPFLAGS) $(OUTPUTOBJ)$@ $<
+	$(V_CC)$(CC) $(OC_CFLAGS) $(CFLAGS) \
+	  $(OC_CPPFLAGS) $(CPPFLAGS) $(OUTPUTOBJ)$@ -c $<
 
 ifeq "$(COMPUTE_DEPS)" "true"
 ifneq "$(COBJS_BYTECODE)" ""

--- a/otherlibs/systhreads/Makefile
+++ b/otherlibs/systhreads/Makefile
@@ -141,7 +141,8 @@ ifeq "$(COMPUTE_DEPS)" "true"
 include $(addprefix $(DEPDIR)/, $(DEP_FILES))
 endif
 
-%.n.$(D): OC_CPPFLAGS += $(OC_NATIVE_CPPFLAGS)
+%.b.$(D): OC_CPPFLAGS = $(OC_BYTECODE_CPPFLAGS)
+%.n.$(D): OC_CPPFLAGS = $(OC_NATIVE_CPPFLAGS)
 
 define GEN_RULE
 $(DEPDIR)/%.$(1).$(D): %.c | $(DEPDIR)

--- a/otherlibs/systhreads/Makefile
+++ b/otherlibs/systhreads/Makefile
@@ -82,8 +82,8 @@ st_stubs.%.$(O): st_stubs.c
 else
 st_stubs.%.$(O): st_stubs.c $(RUNTIME_HEADERS) $(wildcard *.h)
 endif
-	$(V_CC)$(CC) -c $(OC_CFLAGS) $(CFLAGS) $(OC_CPPFLAGS) $(CPPFLAGS) \
-	  $(OUTPUTOBJ)$@ $<
+	$(V_CC)$(CC) $(OC_CFLAGS) $(CFLAGS) $(OC_CPPFLAGS) $(CPPFLAGS) \
+	  $(OUTPUTOBJ)$@ -c $<
 
 .PHONY: partialclean
 partialclean:

--- a/utils/config.generated.ml.in
+++ b/utils/config.generated.ml.in
@@ -29,10 +29,8 @@ let c_has_debug_prefix_map = @cc_has_debug_prefix_map@
 let as_has_debug_prefix_map = @as_has_debug_prefix_map@
 let bytecode_cflags = {@QS@|@bytecode_cflags@|@QS@}
 let bytecode_cppflags = {@QS@|@bytecode_cppflags@|@QS@}
-let native_cflags =
-  {@QS@|@bytecode_cflags@|@QS@} ^ " " ^ {@QS@|@native_cflags@|@QS@}
-let native_cppflags =
-  {@QS@|@bytecode_cppflags@|@QS@} ^ " " ^ {@QS@|@native_cppflags@|@QS@}
+let native_cflags = {@QS@|@native_cflags@|@QS@}
+let native_cppflags = {@QS@|@native_cppflags@|@QS@}
 
 let bytecomp_c_libraries = {@QS@|@zstd_libs@ @cclibs@|@QS@}
 (* bytecomp_c_compiler and native_c_compiler have been supported for a


### PR DESCRIPTION
When C flags or C preprocessor flags are passed to configure, they
should be used to build the compiler itself only, not when the
compiler is invoked to compile third-party C sources, like stubs.

The way flags were computed for the Sun C compiler looked suspiscious,
so it gets updated here, too.