### PR TITLE
TSan should handle `Effect.Unhandled` correctly

### DIFF
--- a/Changes
+++ b/Changes
@@ -430,6 +430,10 @@ Working version
   (Miod Vallat and Xavier Leroy, report by Jan Midtgaard, review by
    KC Sivaramakrishnan)
 
+- #12593: TSan should handle Effect.Unhandled correctly
+  (Fabrice Buoro and Olivier Nicole, report by Jan Midtgaard and Miod Vallat,
+  review by ...)
+
 OCaml 5.1.0 (14 September 2023)
 -------------------------------
 

--- a/runtime/amd64.S
+++ b/runtime/amd64.S
@@ -1102,11 +1102,8 @@ CFI_STARTPROC
         leaq    1(%rsi), %rdi /* %rdi (last_fiber) := Val_ptr(old stack) */
         movq    %rdi, 0(%rbx) /* Initialise continuation */
 LBL(do_perform):
-    /*  %rsi: old stack */
-        movq    Stack_handler(%rsi), %r11  /* %r11 := old stack -> handler */
-        movq    Handler_parent(%r11), %r10 /* %r10 := parent stack */
-        cmpq    $0, %r10                   /* parent is NULL? */
-        je      LBL(112)
+    /*  %rdi: last_fiber
+        %rsi: old stack */
 #if defined(WITH_THREAD_SANITIZER)
     /* Signal to TSan all stack frames exited by the perform. */
         ENTER_FUNCTION
@@ -1118,6 +1115,26 @@ LBL(do_perform):
         SWITCH_C_TO_OCAML
         TSAN_RESTORE_CALLER_REGS
         LEAVE_FUNCTION
+#endif
+        movq    Stack_handler(%rsi), %r11  /* %r11 := old stack -> handler */
+        movq    Handler_parent(%r11), %r10 /* %r10 := parent stack */
+        cmpq    $0, %r10                   /* parent is NULL? */
+        je      LBL(112)
+#if defined(WITH_THREAD_SANITIZER)
+     /* Save non-callee-saved registers %rax, %rdi, %rsi, %r10, %r11 before C
+        call */
+        pushq   %rax; CFI_ADJUST(8);
+        pushq   %rdi; CFI_ADJUST(8);
+        pushq   %rsi; CFI_ADJUST(8);
+        pushq   %r10; CFI_ADJUST(8);
+        pushq   %r11; CFI_ADJUST(8);
+     /* Match the TSan-enter made from caml_runstack */
+        TSAN_EXIT_FUNCTION
+        popq   %r11; CFI_ADJUST(-8);
+        popq   %r10; CFI_ADJUST(-8);
+        popq   %rsi; CFI_ADJUST(-8);
+        popq   %rdi; CFI_ADJUST(-8);
+        popq   %rax; CFI_ADJUST(-8);
 #endif
         SWITCH_OCAML_STACKS /* preserves r11 and rsi */
      /* We have to null the Handler_parent after the switch because the
@@ -1137,7 +1154,10 @@ LBL(112):
 #if defined(WITH_THREAD_SANITIZER)
         /* We must let the TSan runtime know that we switched back to the
            original performer stack. For that, we perform the necessary calls
-           to __tsan_func_entry via caml_tsan_entry_on_resume. */
+           to __tsan_func_entry via caml_tsan_entry_on_resume.
+           Note that from TSan's point of view, we just exited all stack
+           frames, including those of the main fiber. This is ok, because we
+           re-enter them immediately via caml_tsan_entry_on_resume below. */
         TSAN_SAVE_CALLER_REGS
         movq    STACK_RETADDR(%rsp), C_ARG_1       /* arg 1: pc of perform */
         leaq    STACK_ARG_1(%rsp), C_ARG_2         /* arg 2: sp at perform */

--- a/runtime/tsan.c
+++ b/runtime/tsan.c
@@ -215,13 +215,13 @@ void caml_tsan_exit_on_perform(uintnat pc, char* sp)
   /* iterate on each frame  */
   while (1) {
     frame_descr* descr = caml_next_frame_descriptor(fds, &next_pc, &sp, stack);
+    if (descr == NULL) {
+      break;
+    }
 
     caml_tsan_debug_log_pc("forced__tsan_func_exit for", pc);
     __tsan_func_exit(NULL);
 
-    if (descr == NULL) {
-      break;
-    }
     pc = next_pc;
   }
 }

--- a/testsuite/tests/tsan/unhandled.ml
+++ b/testsuite/tests/tsan/unhandled.ml
@@ -1,0 +1,83 @@
+(* TEST
+
+ ocamlopt_flags = "-g";
+ include unix;
+ set TSAN_OPTIONS="detect_deadlocks=0";
+
+ tsan;
+ native;
+
+*)
+
+open Printf
+open Effect
+open Effect.Deep
+
+let print_endline s = Stdlib.print_endline s; flush stdout
+
+type _ t += E : int -> int t
+
+let g_ref1 = ref 0
+let g_ref2 = ref 0
+
+let [@inline never] race = function
+  | 0 -> g_ref1 := 42
+  | 1 -> g_ref2 := 42
+  | _ -> assert false
+
+let [@inline never] h () =
+  print_endline "entering h";
+  let v =
+    try perform (E 0)
+    with Unhandled _ -> race 1; 1
+  in
+  print_endline "leaving h";
+  v
+
+let [@inline never] g () =
+  print_endline "entering g";
+  let v = h () in
+  print_endline "leaving g";
+  v
+
+let f () =
+  print_endline "entering f";
+  let v = g () in
+  print_endline "leaving f";
+  v + 1
+
+let [@inline never] fiber2 () =
+  ignore @@ match_with f ()
+  { retc = Fun.id;
+    exnc = raise;
+    effc = (fun (type a) (e : a t) -> None) };
+  42
+
+let effh : type a. a t -> ((a, 'b) continuation -> 'b) option = fun _ -> None
+
+let [@inline never] fiber1 () =
+  ignore @@ match_with fiber2 ()
+  { retc = (fun v ->
+      print_endline "value handler"; v + 1);
+    exnc = (fun e -> raise e);
+    effc = effh };
+  1338
+
+let[@inline never] main () =
+  print_endline "performing an unhandled effect from the main fiber";
+  try perform (E 42) with
+  | Effect.Unhandled _ -> race 0;
+  print_endline "performing an unhandled effect from another fiber";
+  let v = fiber1 () in
+  v + 1
+
+let[@inline never] other_domain () =
+  ignore @@ (Sys.opaque_identity !g_ref1, !g_ref2);
+  Unix.sleepf 0.66
+
+let () =
+  let d = Domain.spawn other_domain in
+  Unix.sleepf 0.33;
+  let v = main () in
+  printf "result=%d\n%!" v;
+  Domain.join d

--- a/testsuite/tests/tsan/unhandled.reference
+++ b/testsuite/tests/tsan/unhandled.reference
@@ -1,0 +1,100 @@
+performing an unhandled effect from the main fiber
+==================
+WARNING: ThreadSanitizer: data race (pid=<implemspecific>)
+  Write of size 8 at <implemspecific> by main thread (mutexes: write M<implemspecific>):
+    #0 camlUnhandled.race_<implemspecific> <implemspecific> (<implemspecific>)
+    #1 camlUnhandled.main_<implemspecific> <implemspecific> (<implemspecific>)
+    #2 camlUnhandled.entry <implemspecific> (<implemspecific>)
+    #3 caml_program <implemspecific> (<implemspecific>)
+
+  Previous read of size 8 at <implemspecific> by thread T1 (mutexes: write M<implemspecific>):
+    #0 camlUnhandled.other_domain_<implemspecific> <implemspecific> (<implemspecific>)
+    #1 camlStdlib__Domain.body_<implemspecific> <implemspecific> (<implemspecific>)
+
+  As if synchronized via sleep:
+    #0 nanosleep <implemspecific> (<implemspecific>)
+    #1 caml_unix_sleep <implemspecific> (<implemspecific>)
+    #2 caml_c_call <implemspecific> (<implemspecific>)
+    #3 camlUnhandled.entry <implemspecific> (<implemspecific>)
+    #4 caml_program <implemspecific> (<implemspecific>)
+
+  Mutex M<implemspecific> (<implemspecific>) created at:
+    #0 pthread_mutex_init <implemspecific> (<implemspecific>)
+    #1 caml_plat_mutex_init <implemspecific> (<implemspecific>)
+    #2 caml_init_domains <implemspecific> (<implemspecific>)
+    #3 caml_init_gc <implemspecific> (<implemspecific>)
+
+  Mutex M<implemspecific> (<implemspecific>) created at:
+    #0 pthread_mutex_init <implemspecific> (<implemspecific>)
+    #1 caml_plat_mutex_init <implemspecific> (<implemspecific>)
+    #2 caml_init_domains <implemspecific> (<implemspecific>)
+    #3 caml_init_gc <implemspecific> (<implemspecific>)
+
+  Thread T1 (tid=<implemspecific>, running) created by main thread at:
+    #0 pthread_create <implemspecific> (<implemspecific>)
+    #1 caml_domain_spawn <implemspecific> (<implemspecific>)
+    #2 caml_c_call <implemspecific> (<implemspecific>)
+    #3 camlStdlib__Domain.spawn_<implemspecific> <implemspecific> (<implemspecific>)
+    #4 camlUnhandled.entry <implemspecific> (<implemspecific>)
+    #5 caml_program <implemspecific> (<implemspecific>)
+
+SUMMARY: ThreadSanitizer: data race (<systemspecific>:<implemspecific>) in camlUnhandled.race_<implemspecific>
+==================
+performing an unhandled effect from another fiber
+entering f
+entering g
+entering h
+==================
+WARNING: ThreadSanitizer: data race (pid=<implemspecific>)
+  Write of size 8 at <implemspecific> by main thread (mutexes: write M<implemspecific>):
+    #0 camlUnhandled.race_<implemspecific> <implemspecific> (<implemspecific>)
+    #1 camlUnhandled.h_<implemspecific> <implemspecific> (<implemspecific>)
+    #2 camlUnhandled.g_<implemspecific> <implemspecific> (<implemspecific>)
+    #3 camlUnhandled.f_<implemspecific> <implemspecific> (<implemspecific>)
+    #4 caml_runstack <implemspecific> (<implemspecific>)
+    #5 camlUnhandled.fiber2_<implemspecific> <implemspecific> (<implemspecific>)
+    #6 caml_runstack <implemspecific> (<implemspecific>)
+    #7 camlUnhandled.fiber1_<implemspecific> <implemspecific> (<implemspecific>)
+    #8 camlUnhandled.main_<implemspecific> <implemspecific> (<implemspecific>)
+    #9 camlUnhandled.entry <implemspecific> (<implemspecific>)
+    #10 caml_program <implemspecific> (<implemspecific>)
+
+  Previous read of size 8 at <implemspecific> by thread T1 (mutexes: write M<implemspecific>):
+    #0 camlUnhandled.other_domain_<implemspecific> <implemspecific> (<implemspecific>)
+    #1 camlStdlib__Domain.body_<implemspecific> <implemspecific> (<implemspecific>)
+
+  As if synchronized via sleep:
+    #0 nanosleep <implemspecific> (<implemspecific>)
+    #1 caml_unix_sleep <implemspecific> (<implemspecific>)
+    #2 caml_c_call <implemspecific> (<implemspecific>)
+    #3 camlUnhandled.entry <implemspecific> (<implemspecific>)
+    #4 caml_program <implemspecific> (<implemspecific>)
+
+  Mutex M<implemspecific> (<implemspecific>) created at:
+    #0 pthread_mutex_init <implemspecific> (<implemspecific>)
+    #1 caml_plat_mutex_init <implemspecific> (<implemspecific>)
+    #2 caml_init_domains <implemspecific> (<implemspecific>)
+    #3 caml_init_gc <implemspecific> (<implemspecific>)
+
+  Mutex M<implemspecific> (<implemspecific>) created at:
+    #0 pthread_mutex_init <implemspecific> (<implemspecific>)
+    #1 caml_plat_mutex_init <implemspecific> (<implemspecific>)
+    #2 caml_init_domains <implemspecific> (<implemspecific>)
+    #3 caml_init_gc <implemspecific> (<implemspecific>)
+
+  Thread T1 (tid=<implemspecific>, running) created by main thread at:
+    #0 pthread_create <implemspecific> (<implemspecific>)
+    #1 caml_domain_spawn <implemspecific> (<implemspecific>)
+    #2 caml_c_call <implemspecific> (<implemspecific>)
+    #3 camlStdlib__Domain.spawn_<implemspecific> <implemspecific> (<implemspecific>)
+    #4 camlUnhandled.entry <implemspecific> (<implemspecific>)
+    #5 caml_program <implemspecific> (<implemspecific>)
+
+SUMMARY: ThreadSanitizer: data race (<systemspecific>:<implemspecific>) in camlUnhandled.race_<implemspecific>
+==================
+leaving h
+leaving g
+leaving f
+value handler
+result=1339
+ThreadSanitizer: reported 2 warnings

--- a/testsuite/tests/tsan/unhandled.run
+++ b/testsuite/tests/tsan/unhandled.run
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+${program} 2>&1 \
+  | ${test_source_directory}/filter-locations.sh ${program} >${output}


### PR DESCRIPTION
TSan wasn't handling correctly the case where an effect was `perform`ed without a matching effect handler, as noted in https://github.com/ocaml/ocaml/pull/12535#issuecomment-1708573188.

There were two possible behaviours:
- If an effect was `perform`ed from a computation, the last `caml_reperform` would reconnect the `current_stack` to its parent stack (the main fiber) too early, causing `caml_tsan_entry_on_resume` to call `__tsan_func_entry` on too many functions.
The proposed fix introduces a `struct stack_info const* limit` argument to `caml_tsan_entry_on_resume`, which is set to the previous fiber by `caml_perform`, preventing the unnecessary calls to `__tsan_func_entry`.
- If an effect was performed from the main fiber, `caml_tsan_entry_on_resume` was called unconditionally, although `caml_tsan_exit_on_perform` was bypassed because the fiber has no parent stack.
In the proposed fix, the limit set to `Caml_state(current_stack)` by `caml_perform` prevents again the unnecessary calls to `__tsan_func_entry`.

When a continuation is `resume`d, the `limit` for `caml_tsan_entry_on_resume` is set to `NULL` meaning that we expect to unwind the stack of all the fibers from the continuation.

We have also added a test to the TSan testsuite, to validate that the backtrace given by TSan is correct in the 2 cases described above.