### PR TITLE
Minor clean-ups for signals

### DIFF
--- a/runtime/caml/signals.h
+++ b/runtime/caml/signals.h
@@ -65,7 +65,7 @@ void caml_request_major_slice (int global);
 void caml_request_minor_gc (void);
 CAMLextern int caml_convert_signal_number (int);
 CAMLextern int caml_rev_convert_signal_number (int);
-value caml_execute_signal_exn(int signal_number, int in_signal_handler);
+value caml_execute_signal_exn(int signal_number);
 CAMLextern void caml_record_signal(int signal_number);
 CAMLextern value caml_process_pending_signals_exn(void);
 CAMLextern void caml_set_action_pending(caml_domain_state *);

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -1864,18 +1864,9 @@ static void domain_terminate (void)
   caml_domain_state* domain_state = domain_self->state;
   struct interruptor* s = &domain_self->interruptor;
   int finished = 0;
-#ifndef _WIN32
-  sigset_t mask;
-#endif
 
   caml_gc_log("Domain terminating");
   s->terminating = 1;
-
-#ifndef _WIN32
-  /* Block all signals so that signal handlers do not run on this thread */
-  sigfillset(&mask);
-  pthread_sigmask(SIG_BLOCK, &mask, NULL);
-#endif
 
   /* Join ongoing systhreads, if necessary, and then run user-defined
      termination hooks. No OCaml code can run on this domain after


### PR DESCRIPTION
Here are three minor clean-ups related to signals (@kayceesrk)
- The new test used a plain ref to communicate between domains—bad!
- An argument has been dead in a function for some time now, remove it.
- Some now-needless signal masking was forgotten at 5742171, because it was introduced in the meanwhile and not caught during any of the rebasings.

(No change entry needed)