### PR TITLE
Move `caml_collect_gc_stats_sample` before barrier arrival

### DIFF
--- a/Changes
+++ b/Changes
@@ -333,6 +333,10 @@ Working version
 
 ### Bug fixes:
 
+- #12590, #12595: Move `caml_collect_gc_stats_sample` in
+  `caml_empty_minor_heap_promote` before barrier arrival.
+  (B. Szilvasy, review by Gabriel Scherer)
+
 - #12580: Fix location of alias pattern variables.
   (Chris Casinghino, review Gabriel Scherer, report by Milo Davis)
 

--- a/runtime/minor_gc.c
+++ b/runtime/minor_gc.c
@@ -459,6 +459,9 @@ void caml_empty_minor_heap_domain_clear(caml_domain_state* domain)
   domain->extra_heap_resources_minor = 0.0;
 }
 
+void caml_do_opportunistic_major_slice
+  (caml_domain_state* domain_unused, void* unused);
+
 void caml_empty_minor_heap_promote(caml_domain_state* domain,
                                    int participating_count,
                                    caml_domain_state** participating)
@@ -641,13 +644,33 @@ void caml_empty_minor_heap_promote(caml_domain_state* domain,
     + (domain->young_end - domain->young_start) / 2;
   caml_reset_young_limit(domain);
 
+  domain->stat_minor_words += Wsize_bsize (minor_allocated_bytes);
+  domain->stat_promoted_words += domain->allocated_words - prev_alloc_words;
+
+  /* gc stats may be accessed unsynchronised by mutator code, so we collect the
+     sample before arriving at the barrier, which ensures that it doesn't race
+  */
+  caml_collect_gc_stats_sample(domain);
+
+  /* The code above is synchronised with other domains by the barrier below,
+     which is split into two steps, "arriving" and "leaving". When the final
+     domain arrives at the barrier, all other domains are free to leave, after
+     which they finish running the STW callback and may, depending on the
+     specific STW section, begin executing mutator code.
+
+     Leaving the barrier synchronises (only) with the arrivals of other domains,
+     so that all writes performed by a domain before arrival "happen-before" any
+     domain leaves the barrier. However, any code after arrival, including the
+     code between the two steps, can potentially race with mutator code.
+  */
+
+  /* arrive at the barrier */
   if( participating_count > 1 ) {
     atomic_fetch_add_explicit
       (&domains_finished_minor_gc, 1, memory_order_release);
   }
-
-  domain->stat_minor_words += Wsize_bsize (minor_allocated_bytes);
-  domain->stat_promoted_words += domain->allocated_words - prev_alloc_words;
+  /* other domains may be executing mutator code from this point, but
+     not before */
 
   call_timing_hook(&caml_minor_gc_end_hook);
   CAML_EV_COUNTER(EV_C_MINOR_PROMOTED,
@@ -660,6 +683,22 @@ void caml_empty_minor_heap_promote(caml_domain_state* domain,
                domain->id,
                100.0 * (double)st.live_bytes / (double)minor_allocated_bytes,
                (unsigned)(minor_allocated_bytes + 512)/1024);
+
+  /* leave the barrier */
+  if( participating_count > 1 ) {
+    CAML_EV_BEGIN(EV_MINOR_LEAVE_BARRIER);
+    {
+      SPIN_WAIT {
+        if (atomic_load_acquire(&domains_finished_minor_gc) ==
+            participating_count) {
+          break;
+        }
+
+        caml_do_opportunistic_major_slice(domain, 0);
+      }
+    }
+    CAML_EV_END(EV_MINOR_LEAVE_BARRIER);
+  }
 }
 
 void caml_do_opportunistic_major_slice
@@ -702,24 +741,6 @@ caml_stw_empty_minor_heap_no_major_slice(caml_domain_state* domain,
 
   caml_gc_log("running stw empty_minor_heap_promote");
   caml_empty_minor_heap_promote(domain, participating_count, participating);
-
-  /* collect gc stats before leaving the barrier */
-  caml_collect_gc_stats_sample(domain);
-
-  if( participating_count > 1 ) {
-    CAML_EV_BEGIN(EV_MINOR_LEAVE_BARRIER);
-    {
-      SPIN_WAIT {
-        if (atomic_load_acquire(&domains_finished_minor_gc) ==
-            participating_count) {
-          break;
-        }
-
-        caml_do_opportunistic_major_slice(domain, 0);
-      }
-    }
-    CAML_EV_END(EV_MINOR_LEAVE_BARRIER);
-  }
 
   CAML_EV_BEGIN(EV_MINOR_FINALIZERS_ADMIN);
   caml_gc_log("running finalizer data structure book-keeping");


### PR DESCRIPTION
This PR moves the call to `caml_collect_gc_stats_sample` during minor collections to being before arrival into the minor GC barrier, with the intention of preventing the data race described in #12590.

It also adds some comments to describe the synchronisation guarantees provided by the barrier.

Note that I am deeply suspicious of the [`caml_clear_gc_stats_sample` call in `domain_terminate`](https://github.com/ocaml/ocaml/blob/94c5327fe028c24772d0eec6dfd981db7b9e0573/runtime/domain.c#L1957C44-L1957C44) racing too, though I haven't looked into it too deeply, so I don't think all `gc_stats` data races are fixed.

Changes entry needed?