### PR TITLE
Compile recursive bindings in Lambda

### DIFF
--- a/.depend
+++ b/.depend
@@ -3721,7 +3721,6 @@ lambda/simplif.cmo : \
     utils/warnings.cmi \
     lambda/tmc.cmi \
     typing/primitive.cmi \
-    utils/misc.cmi \
     parsing/location.cmi \
     lambda/lambda.cmi \
     typing/ident.cmi \
@@ -3733,7 +3732,6 @@ lambda/simplif.cmx : \
     utils/warnings.cmx \
     lambda/tmc.cmx \
     typing/primitive.cmx \
-    utils/misc.cmx \
     parsing/location.cmx \
     lambda/lambda.cmx \
     typing/ident.cmx \
@@ -3797,6 +3795,7 @@ lambda/translattribute.cmi : \
     parsing/location.cmi \
     lambda/lambda.cmi
 lambda/translclass.cmo : \
+    typing/value_rec_types.cmi \
     typing/types.cmi \
     typing/typeopt.cmi \
     typing/typedtree.cmi \
@@ -3815,6 +3814,7 @@ lambda/translclass.cmo : \
     parsing/asttypes.cmi \
     lambda/translclass.cmi
 lambda/translclass.cmx : \
+    typing/value_rec_types.cmi \
     typing/types.cmx \
     typing/typeopt.cmx \
     typing/typedtree.cmx \
@@ -3833,6 +3833,7 @@ lambda/translclass.cmx : \
     parsing/asttypes.cmi \
     lambda/translclass.cmi
 lambda/translclass.cmi : \
+    typing/value_rec_types.cmi \
     typing/typedtree.cmi \
     parsing/location.cmi \
     lambda/lambda.cmi \
@@ -3840,6 +3841,7 @@ lambda/translclass.cmi : \
     lambda/debuginfo.cmi \
     parsing/asttypes.cmi
 lambda/translcore.cmo : \
+    lambda/value_rec_compiler.cmi \
     typing/types.cmi \
     typing/typeopt.cmi \
     typing/typedtree.cmi \
@@ -3864,6 +3866,7 @@ lambda/translcore.cmo : \
     parsing/asttypes.cmi \
     lambda/translcore.cmi
 lambda/translcore.cmx : \
+    lambda/value_rec_compiler.cmx \
     typing/types.cmx \
     typing/typeopt.cmx \
     typing/typedtree.cmx \
@@ -3897,6 +3900,7 @@ lambda/translcore.cmi : \
     lambda/debuginfo.cmi \
     parsing/asttypes.cmi
 lambda/translmod.cmo : \
+    lambda/value_rec_compiler.cmi \
     typing/types.cmi \
     typing/typedtree.cmi \
     lambda/translprim.cmi \
@@ -3919,6 +3923,7 @@ lambda/translmod.cmo : \
     parsing/asttypes.cmi \
     lambda/translmod.cmi
 lambda/translmod.cmx : \
+    lambda/value_rec_compiler.cmx \
     typing/types.cmx \
     typing/typedtree.cmx \
     lambda/translprim.cmx \
@@ -4018,25 +4023,27 @@ lambda/translprim.cmi : \
     typing/ident.cmi \
     typing/env.cmi
 lambda/value_rec_compiler.cmo : \
-    typing/typedtree.cmi \
+    typing/value_rec_types.cmi \
     typing/primitive.cmi \
     utils/misc.cmi \
+    utils/lazy_backtrack.cmi \
     lambda/lambda.cmi \
     typing/ident.cmi \
     lambda/debuginfo.cmi \
     parsing/asttypes.cmi \
     lambda/value_rec_compiler.cmi
 lambda/value_rec_compiler.cmx : \
-    typing/typedtree.cmx \
+    typing/value_rec_types.cmi \
     typing/primitive.cmx \
     utils/misc.cmx \
+    utils/lazy_backtrack.cmx \
     lambda/lambda.cmx \
     typing/ident.cmx \
     lambda/debuginfo.cmx \
     parsing/asttypes.cmi \
     lambda/value_rec_compiler.cmi
 lambda/value_rec_compiler.cmi : \
-    typing/typedtree.cmi \
+    typing/value_rec_types.cmi \
     lambda/lambda.cmi \
     typing/ident.cmi
 file_formats/cmi_format.cmo : \

--- a/.depend
+++ b/.depend
@@ -1980,8 +1980,6 @@ typing/value_rec_check.cmi : \
     typing/ident.cmi
 typing/value_rec_types.cmi :
 bytecomp/bytegen.cmo : \
-    typing/value_rec_types.cmi \
-    typing/types.cmi \
     lambda/switch.cmi \
     typing/subst.cmi \
     typing/primitive.cmi \
@@ -1997,8 +1995,6 @@ bytecomp/bytegen.cmo : \
     parsing/asttypes.cmi \
     bytecomp/bytegen.cmi
 bytecomp/bytegen.cmx : \
-    typing/value_rec_types.cmi \
-    typing/types.cmx \
     lambda/switch.cmx \
     typing/subst.cmx \
     typing/primitive.cmx \
@@ -2655,8 +2651,6 @@ asmcomp/cmm_invariants.cmx : \
 asmcomp/cmm_invariants.cmi : \
     asmcomp/cmm.cmi
 asmcomp/cmmgen.cmo : \
-    typing/value_rec_types.cmi \
-    typing/types.cmi \
     asmcomp/thread_sanitizer.cmi \
     middle_end/printclambda_primitives.cmi \
     typing/primitive.cmi \
@@ -2676,8 +2670,6 @@ asmcomp/cmmgen.cmo : \
     asmcomp/afl_instrument.cmi \
     asmcomp/cmmgen.cmi
 asmcomp/cmmgen.cmx : \
-    typing/value_rec_types.cmi \
-    typing/types.cmx \
     asmcomp/thread_sanitizer.cmx \
     middle_end/printclambda_primitives.cmx \
     typing/primitive.cmx \
@@ -3361,7 +3353,6 @@ middle_end/backend_var.cmi : \
     typing/ident.cmi \
     lambda/debuginfo.cmi
 middle_end/clambda.cmo : \
-    typing/value_rec_types.cmi \
     typing/path.cmi \
     lambda/lambda.cmi \
     typing/ident.cmi \
@@ -3371,7 +3362,6 @@ middle_end/clambda.cmo : \
     parsing/asttypes.cmi \
     middle_end/clambda.cmi
 middle_end/clambda.cmx : \
-    typing/value_rec_types.cmi \
     typing/path.cmx \
     lambda/lambda.cmx \
     typing/ident.cmx \
@@ -3381,7 +3371,6 @@ middle_end/clambda.cmx : \
     parsing/asttypes.cmi \
     middle_end/clambda.cmi
 middle_end/clambda.cmi : \
-    typing/value_rec_types.cmi \
     typing/path.cmi \
     lambda/lambda.cmi \
     typing/ident.cmi \
@@ -3515,7 +3504,6 @@ middle_end/linkage_name.cmx : \
 middle_end/linkage_name.cmi : \
     utils/identifiable.cmi
 middle_end/printclambda.cmo : \
-    typing/value_rec_types.cmi \
     lambda/printlambda.cmi \
     middle_end/printclambda_primitives.cmi \
     lambda/lambda.cmi \
@@ -3525,7 +3513,6 @@ middle_end/printclambda.cmo : \
     parsing/asttypes.cmi \
     middle_end/printclambda.cmi
 middle_end/printclambda.cmx : \
-    typing/value_rec_types.cmi \
     lambda/printlambda.cmx \
     middle_end/printclambda_primitives.cmx \
     lambda/lambda.cmx \
@@ -3619,7 +3606,6 @@ lambda/debuginfo.cmi : \
     typing/ident.cmi \
     parsing/asttypes.cmi
 lambda/lambda.cmo : \
-    typing/value_rec_types.cmi \
     typing/types.cmi \
     typing/primitive.cmi \
     typing/path.cmi \
@@ -3632,7 +3618,6 @@ lambda/lambda.cmo : \
     parsing/asttypes.cmi \
     lambda/lambda.cmi
 lambda/lambda.cmx : \
-    typing/value_rec_types.cmi \
     typing/types.cmx \
     typing/primitive.cmx \
     typing/path.cmx \
@@ -3645,7 +3630,6 @@ lambda/lambda.cmx : \
     parsing/asttypes.cmi \
     lambda/lambda.cmi
 lambda/lambda.cmi : \
-    typing/value_rec_types.cmi \
     typing/types.cmi \
     typing/primitive.cmi \
     typing/path.cmi \
@@ -3737,6 +3721,7 @@ lambda/simplif.cmo : \
     utils/warnings.cmi \
     lambda/tmc.cmi \
     typing/primitive.cmi \
+    utils/misc.cmi \
     parsing/location.cmi \
     lambda/lambda.cmi \
     typing/ident.cmi \
@@ -3748,6 +3733,7 @@ lambda/simplif.cmx : \
     utils/warnings.cmx \
     lambda/tmc.cmx \
     typing/primitive.cmx \
+    utils/misc.cmx \
     parsing/location.cmx \
     lambda/lambda.cmx \
     typing/ident.cmx \
@@ -4031,6 +4017,28 @@ lambda/translprim.cmi : \
     lambda/lambda.cmi \
     typing/ident.cmi \
     typing/env.cmi
+lambda/value_rec_compiler.cmo : \
+    typing/typedtree.cmi \
+    typing/primitive.cmi \
+    utils/misc.cmi \
+    lambda/lambda.cmi \
+    typing/ident.cmi \
+    lambda/debuginfo.cmi \
+    parsing/asttypes.cmi \
+    lambda/value_rec_compiler.cmi
+lambda/value_rec_compiler.cmx : \
+    typing/typedtree.cmx \
+    typing/primitive.cmx \
+    utils/misc.cmx \
+    lambda/lambda.cmx \
+    typing/ident.cmx \
+    lambda/debuginfo.cmx \
+    parsing/asttypes.cmi \
+    lambda/value_rec_compiler.cmi
+lambda/value_rec_compiler.cmi : \
+    typing/typedtree.cmi \
+    lambda/lambda.cmi \
+    typing/ident.cmi
 file_formats/cmi_format.cmo : \
     typing/types.cmi \
     utils/misc.cmi \
@@ -4555,7 +4563,6 @@ middle_end/flambda/find_recursive_functions.cmi : \
     middle_end/backend_intf.cmi
 middle_end/flambda/flambda.cmo : \
     middle_end/variable.cmi \
-    typing/value_rec_types.cmi \
     middle_end/flambda/base_types/tag.cmi \
     middle_end/symbol.cmi \
     middle_end/flambda/base_types/static_exception.cmi \
@@ -4582,7 +4589,6 @@ middle_end/flambda/flambda.cmo : \
     middle_end/flambda/flambda.cmi
 middle_end/flambda/flambda.cmx : \
     middle_end/variable.cmx \
-    typing/value_rec_types.cmi \
     middle_end/flambda/base_types/tag.cmx \
     middle_end/symbol.cmx \
     middle_end/flambda/base_types/static_exception.cmx \
@@ -4609,7 +4615,6 @@ middle_end/flambda/flambda.cmx : \
     middle_end/flambda/flambda.cmi
 middle_end/flambda/flambda.cmi : \
     middle_end/variable.cmi \
-    typing/value_rec_types.cmi \
     middle_end/flambda/base_types/tag.cmi \
     middle_end/symbol.cmi \
     middle_end/flambda/base_types/static_exception.cmi \
@@ -4679,13 +4684,11 @@ middle_end/flambda/flambda_invariants.cmi : \
     middle_end/flambda/flambda.cmi
 middle_end/flambda/flambda_iterators.cmo : \
     middle_end/variable.cmi \
-    typing/value_rec_types.cmi \
     utils/int_replace_polymorphic_compare.cmi \
     middle_end/flambda/flambda.cmi \
     middle_end/flambda/flambda_iterators.cmi
 middle_end/flambda/flambda_iterators.cmx : \
     middle_end/variable.cmx \
-    typing/value_rec_types.cmi \
     utils/int_replace_polymorphic_compare.cmx \
     middle_end/flambda/flambda.cmx \
     middle_end/flambda/flambda_iterators.cmi
@@ -4835,7 +4838,6 @@ middle_end/flambda/flambda_to_clambda.cmi : \
 middle_end/flambda/flambda_utils.cmo : \
     middle_end/variable.cmi \
     middle_end/flambda/base_types/var_within_closure.cmi \
-    typing/value_rec_types.cmi \
     middle_end/symbol.cmi \
     lambda/switch.cmi \
     middle_end/flambda/base_types/static_exception.cmi \
@@ -4861,7 +4863,6 @@ middle_end/flambda/flambda_utils.cmo : \
 middle_end/flambda/flambda_utils.cmx : \
     middle_end/variable.cmx \
     middle_end/flambda/base_types/var_within_closure.cmx \
-    typing/value_rec_types.cmi \
     middle_end/symbol.cmx \
     lambda/switch.cmx \
     middle_end/flambda/base_types/static_exception.cmx \
@@ -5359,7 +5360,6 @@ middle_end/flambda/invariant_params.cmi : \
     middle_end/backend_intf.cmi
 middle_end/flambda/lift_code.cmo : \
     middle_end/variable.cmi \
-    utils/strongly_connected_components.cmi \
     middle_end/flambda/base_types/mutable_variable.cmi \
     lambda/lambda.cmi \
     utils/int_replace_polymorphic_compare.cmi \
@@ -5369,7 +5369,6 @@ middle_end/flambda/lift_code.cmo : \
     middle_end/flambda/lift_code.cmi
 middle_end/flambda/lift_code.cmx : \
     middle_end/variable.cmx \
-    utils/strongly_connected_components.cmx \
     middle_end/flambda/base_types/mutable_variable.cmx \
     lambda/lambda.cmx \
     utils/int_replace_polymorphic_compare.cmx \
@@ -5430,22 +5429,18 @@ middle_end/flambda/lift_let_to_initialize_symbol.cmo : \
     middle_end/variable.cmi \
     middle_end/flambda/base_types/tag.cmi \
     middle_end/symbol.cmi \
-    middle_end/internal_variable_names.cmi \
     utils/int_replace_polymorphic_compare.cmi \
     middle_end/flambda/flambda_utils.cmi \
     middle_end/flambda/flambda.cmi \
-    lambda/debuginfo.cmi \
     parsing/asttypes.cmi \
     middle_end/flambda/lift_let_to_initialize_symbol.cmi
 middle_end/flambda/lift_let_to_initialize_symbol.cmx : \
     middle_end/variable.cmx \
     middle_end/flambda/base_types/tag.cmx \
     middle_end/symbol.cmx \
-    middle_end/internal_variable_names.cmx \
     utils/int_replace_polymorphic_compare.cmx \
     middle_end/flambda/flambda_utils.cmx \
     middle_end/flambda/flambda.cmx \
-    lambda/debuginfo.cmx \
     parsing/asttypes.cmi \
     middle_end/flambda/lift_let_to_initialize_symbol.cmi
 middle_end/flambda/lift_let_to_initialize_symbol.cmi : \
@@ -5802,7 +5797,6 @@ middle_end/flambda/traverse_for_exported_symbols.cmi : \
     middle_end/flambda/base_types/export_id.cmi \
     middle_end/flambda/base_types/closure_id.cmi
 middle_end/flambda/un_anf.cmo : \
-    typing/value_rec_types.cmi \
     middle_end/symbol.cmi \
     middle_end/semantics_of_primitives.cmi \
     middle_end/printclambda.cmi \
@@ -5816,7 +5810,6 @@ middle_end/flambda/un_anf.cmo : \
     parsing/asttypes.cmi \
     middle_end/flambda/un_anf.cmi
 middle_end/flambda/un_anf.cmx : \
-    typing/value_rec_types.cmi \
     middle_end/symbol.cmx \
     middle_end/semantics_of_primitives.cmx \
     middle_end/printclambda.cmx \

--- a/Changes
+++ b/Changes
@@ -211,9 +211,9 @@ Working version
   were not correctly rounded sometimes.
   (Xavier Leroy, review by Anil Madhavapeddy and Tim McGilchrist)
 
-- #12551, #12608, #12782: Overhaul of recursive value compilation.
-  Extend the Rec_check classification to handle constants, propagate the
-  classification through the compiler, compute sizes during classification.
+- #12551, #12608, #12782, #12596: Overhaul of recursive value compilation.
+  Non-function recursive bindings are now forbidden from Lambda onwards,
+  and compiled using a new Value_rec_compiler module.
   (Vincent Laviron and Lunia Ayanides, review by Gabriel Scherer)
 
 - #1809, #12181: rewrite `compare x y op 0` to `x op y` when values are integers

--- a/Changes
+++ b/Changes
@@ -214,7 +214,8 @@ Working version
 - #12551, #12608, #12782, #12596: Overhaul of recursive value compilation.
   Non-function recursive bindings are now forbidden from Lambda onwards,
   and compiled using a new Value_rec_compiler module.
-  (Vincent Laviron and Lunia Ayanides, review by Gabriel Scherer)
+  (Vincent Laviron and Lunia Ayanides, review by Gabriel Scherer,
+   Stefan Muenzel and Nathanaëlle Courant)
 
 - #1809, #12181: rewrite `compare x y op 0` to `x op y` when values are integers
   (Xavier Clerc, Stefan Muenzel, review by Gabriel Scherer and Vincent Laviron)

--- a/Makefile
+++ b/Makefile
@@ -163,6 +163,7 @@ lambda_SOURCES = $(addprefix lambda/, \
   printlambda.mli printlambda.ml \
   switch.mli switch.ml \
   matching.mli matching.ml \
+  value_rec_compiler.mli value_rec_compiler.ml \
   translobj.mli translobj.ml \
   translattribute.mli translattribute.ml \
   translprim.mli translprim.ml \

--- a/asmcomp/cmmgen.ml
+++ b/asmcomp/cmmgen.ml
@@ -20,7 +20,6 @@
 open Misc
 open Asttypes
 open Primitive
-open Types
 open Lambda
 open Clambda
 open Clambda_primitives
@@ -125,121 +124,6 @@ let min_mut x y =
 let get_field env mut ptr n dbg =
   let mut = min_mut mut (mut_from_env env ptr) in
   get_field_gen mut ptr n dbg
-
-type rhs_kind =
-  | RHS_block of int
-  | RHS_infix of { blocksize : int; offset : int }
-  | RHS_floatblock of int
-  | RHS_nonrec
-  | RHS_unreachable
-
- (* We expect Rec_check to associate Dynamic mode to branches with multiple
-    returning paths, which translates to RHS_nonrec. *)
-let join_rhs_kind k1 k2 =
-  match k1, k2 with
-  | RHS_unreachable, k | k, RHS_unreachable -> k
-  | _, _ -> RHS_nonrec
-
-let rec expr_size env = function
-  | Uvar id ->
-      begin try V.find_same id env with Not_found -> RHS_nonrec end
-  | Uclosure(fundecls, clos_vars) ->
-      RHS_block (fundecls_size fundecls + List.length clos_vars)
-  | Ulet(_str, _kind, id, exp, body) ->
-      expr_size (V.add (VP.var id) (expr_size env exp) env) body
-  | Uphantom_let (_id, _def, body) ->
-      expr_size env body
-  | Uletrec(bindings, body) ->
-      let env =
-        List.fold_right
-          (fun (id, _, exp) env -> V.add (VP.var id) (expr_size env exp) env)
-          bindings env
-      in
-      expr_size env body
-  | Uprim(Pmakeblock _, args, _) ->
-      RHS_block (List.length args)
-  | Uprim(Pmakearray((Paddrarray | Pintarray), _), args, _) ->
-      RHS_block (List.length args)
-  | Uprim(Pmakearray(Pfloatarray, _), args, _) ->
-      RHS_floatblock (List.length args)
-  | Uprim(Pmakearray(Pgenarray, _), _, _) ->
-     (* Pgenarray is excluded from recursive bindings by the
-        check in Translcore.check_recursive_lambda *)
-     RHS_nonrec
-  | Uprim (Pduprecord ((Record_regular | Record_inlined _), sz), _, _) ->
-      RHS_block sz
-  | Uprim (Pduprecord (Record_unboxed _, _), _, _) ->
-      assert false
-  | Uprim (Pduprecord (Record_extension _, sz), _, _) ->
-      RHS_block (sz + 1)
-  | Uprim (Pduprecord (Record_float, sz), _, _) ->
-      RHS_floatblock sz
-  | Uprim (Pccall { prim_name; _ }, closure::_, _)
-        when prim_name = "caml_check_value_is_closure" ->
-      (* Used for "-clambda-checks". *)
-      expr_size env closure
-  | Uprim (Praise _, _args, _dbg) -> RHS_unreachable
-  | Uprim (_prim, _args, _dbg) -> RHS_nonrec
-  | Usequence(_exp, exp') ->
-      expr_size env exp'
-  | Uoffset (exp, offset) ->
-      (match expr_size env exp with
-      | RHS_block blocksize -> RHS_infix { blocksize; offset }
-      | RHS_nonrec -> RHS_nonrec
-      | _ -> assert false)
-  | Uswitch (_arg, switch, _dbg) ->
-      let size_consts =
-        Array.fold_left (fun acc expr ->
-            join_rhs_kind acc (expr_size env expr))
-          RHS_unreachable
-          switch.us_actions_consts
-      in
-      let size_blocks =
-        Array.fold_left (fun acc expr ->
-            join_rhs_kind acc (expr_size env expr))
-          RHS_unreachable
-          switch.us_actions_blocks
-      in
-      join_rhs_kind size_consts size_blocks
-  | Ustringswitch (_arg, cases, default) ->
-      List.fold_left (fun acc (_string, act) ->
-          join_rhs_kind acc (expr_size env act))
-        (match default with
-         | None -> RHS_unreachable
-         | Some act -> expr_size env act)
-        cases
-  | Ucatch (_, _, body, handler)
-  | Utrywith (body, _, handler) ->
-      let size_body = expr_size env body in
-      let size_handler = expr_size env handler in
-      join_rhs_kind size_body size_handler
-  | Uifthenelse (_cond, ifso, ifnot) ->
-      let size_ifso = expr_size env ifso in
-      let size_ifnot = expr_size env ifnot in
-      join_rhs_kind size_ifso size_ifnot
-  | Ustaticfail (_nfail, _args) -> RHS_unreachable
-  | Uconst _ | Udirect_apply _ | Ugeneric_apply _ | Uwhile _ | Ufor _
-  | Uassign _ | Usend _ -> RHS_nonrec
-  | Uunreachable -> RHS_unreachable
-
-let expr_size_of_binding (clas : Value_rec_types.recursive_binding_kind) expr =
-  match clas with
-  | Not_recursive | Constant -> RHS_nonrec
-  | Class ->
-       (* Actual size is always 4, but [transl_class] only generates
-          explicit allocations when the classes are actually recursive.
-          Computing the size means that we don't go through pre-allocation
-          when the classes are not recursive. *)
-      expr_size V.empty expr
-  | Static ->
-      let result = expr_size V.empty expr in
-      (* Patching Closure to properly propagate Constant kinds is too complex;
-         for now, just live with the fact that Static expressions may not always
-         be statically allocated with Closure.
-         Forthcoming patches will remove all this logic anyway. *)
-      if Config.flambda then
-        assert (result <> RHS_nonrec);
-      result
 
 (* Translate structured constants to Cmm data items *)
 
@@ -516,8 +400,6 @@ let rec transl env e =
           Some defining_expr
       in
       Cphantom_let (var, defining_expr, transl env body)
-  | Uletrec(bindings, body) ->
-      transl_letrec env bindings (transl env body)
 
   (* Primitives *)
   | Uprim(prim, args, dbg) ->
@@ -1481,45 +1363,6 @@ and transl_switch dbg env arg index cases = match Array.length cases with
     let cases = Array.map (transl env) cases in
     transl_switch_clambda dbg arg index cases
 
-and transl_letrec env bindings cont =
-  let dbg = Debuginfo.none in
-  let bsz =
-    List.map (fun (id, clas, exp) -> (id, exp, expr_size_of_binding clas exp))
-      bindings
-  in
-  let op_alloc prim args =
-    Cop(Cextcall(prim, typ_val, [], true), args, dbg) in
-  let rec init_blocks = function
-    | [] -> fill_nonrec bsz
-    | (id, _exp, RHS_block sz) :: rem ->
-        Clet(id, op_alloc "caml_alloc_dummy" [int_const dbg sz],
-          init_blocks rem)
-    | (id, _exp, RHS_infix { blocksize; offset}) :: rem ->
-        Clet(id, op_alloc "caml_alloc_dummy_infix"
-             [int_const dbg blocksize; int_const dbg offset],
-             init_blocks rem)
-    | (id, _exp, RHS_floatblock sz) :: rem ->
-        Clet(id, op_alloc "caml_alloc_dummy_float" [int_const dbg sz],
-          init_blocks rem)
-    | (id, _exp, (RHS_nonrec | RHS_unreachable)) :: rem ->
-        Clet (id, Cconst_int (1, dbg), init_blocks rem)
-  and fill_nonrec = function
-    | [] -> fill_blocks bsz
-    | (_id, _exp,
-       (RHS_block _ | RHS_infix _ | RHS_floatblock _)) :: rem ->
-        fill_nonrec rem
-    | (id, exp, (RHS_nonrec | RHS_unreachable)) :: rem ->
-        Clet(id, transl env exp, fill_nonrec rem)
-  and fill_blocks = function
-    | [] -> cont
-    | (id, exp, (RHS_block _ | RHS_infix _ | RHS_floatblock _)) :: rem ->
-        let op =
-          Cop(Cextcall("caml_update_dummy", typ_void, [], false),
-              [Cvar (VP.var id); transl env exp], dbg) in
-        Csequence(op, fill_blocks rem)
-    | (_id, _exp, (RHS_nonrec | RHS_unreachable)) :: rem ->
-        fill_blocks rem
-  in init_blocks bsz
 
 (* Translate a function definition *)
 

--- a/lambda/lambda.ml
+++ b/lambda/lambda.ml
@@ -365,6 +365,8 @@ let const_int n = Const_base (Const_int n)
 
 let const_unit = const_int 0
 
+let dummy_constant = Lconst (const_int (0xBBBB / 2))
+
 let max_arity () =
   if !Clflags.native_code then 126 else max_int
   (* 126 = 127 (the maximal number of parameters supported in C--)

--- a/lambda/lambda.ml
+++ b/lambda/lambda.ml
@@ -885,6 +885,10 @@ let duplicate lam =
     Ident.Map.empty
     lam
 
+let map_lfunction f { kind; params; return; body; attr; loc } =
+  let body = f body in
+  { kind; params; return; body; attr; loc }
+
 let shallow_map f = function
   | Lvar _
   | Lmutvar _
@@ -899,8 +903,8 @@ let shallow_map f = function
         ap_inlined;
         ap_specialised;
       }
-  | Lfunction { kind; params; return; body; attr; loc; } ->
-      Lfunction { kind; params; return; body = f body; attr; loc; }
+  | Lfunction lfun ->
+      Lfunction (map_lfunction f lfun)
   | Llet (str, k, v, e1, e2) ->
       Llet (str, k, v, f e1, f e2)
   | Lmutlet (k, v, e1, e2) ->
@@ -908,7 +912,7 @@ let shallow_map f = function
   | Lletrec (idel, e2) ->
       Lletrec
         (List.map (fun rb ->
-             { rb with def = { rb.def with body = f rb.def.body } })
+             { rb with def = map_lfunction f rb.def })
             idel,
          f e2)
   | Lprim (p, el, loc) ->

--- a/lambda/lambda.mli
+++ b/lambda/lambda.mli
@@ -313,6 +313,9 @@ type lambda =
 and rec_binding = {
   id : Ident.t;
   def : lfunction;
+  (* Generic recursive bindings have been removed from Lambda.
+     [Value_rec_compiler.compile_letrec] deals with transforming generic
+     definitions into basic Lambda code. *)
 }
 
 and lfunction = private

--- a/lambda/lambda.mli
+++ b/lambda/lambda.mli
@@ -312,8 +312,7 @@ type lambda =
 
 and rec_binding = {
   id : Ident.t;
-  rkind : Value_rec_types.recursive_binding_kind;
-  def : lambda;
+  def : lfunction;
 }
 
 and lfunction = private
@@ -386,6 +385,15 @@ val lfunction :
   attr:function_attribute -> (* specified with [@inline] attribute *)
   loc:scoped_location ->
   lambda
+
+val lfunction' :
+  kind:function_kind ->
+  params:(Ident.t * value_kind) list ->
+  return:value_kind ->
+  body:lambda ->
+  attr:function_attribute -> (* specified with [@inline] attribute *)
+  loc:scoped_location ->
+  lfunction
 
 
 val iter_head_constructor: (lambda -> unit) -> lambda -> unit
@@ -493,3 +501,4 @@ val merge_inline_attributes
   -> inline_attribute option
 
 val reset: unit -> unit
+

--- a/lambda/lambda.mli
+++ b/lambda/lambda.mli
@@ -313,7 +313,7 @@ type lambda =
 and rec_binding = {
   id : Ident.t;
   def : lfunction;
-  (* Generic recursive bindings have been removed from Lambda.
+  (* Generic recursive bindings have been removed from Lambda in 5.2.
      [Value_rec_compiler.compile_letrec] deals with transforming generic
      definitions into basic Lambda code. *)
 }

--- a/lambda/lambda.mli
+++ b/lambda/lambda.mli
@@ -377,6 +377,10 @@ val make_key: lambda -> lambda option
 val const_unit: structured_constant
 val const_int : int -> structured_constant
 val lambda_unit: lambda
+
+(** [dummy_constant] produces a plecholder value with a recognizable
+    bit pattern (currently 0xBBBB in its tagged form) *)
+val dummy_constant: lambda
 val name_lambda: let_kind -> lambda -> (Ident.t -> lambda) -> lambda
 val name_lambda_list: lambda list -> (lambda list -> lambda) -> lambda
 

--- a/lambda/lambda.mli
+++ b/lambda/lambda.mli
@@ -461,6 +461,9 @@ val map : (lambda -> lambda) -> lambda -> lambda
   (** Bottom-up rewriting, applying the function on
       each node from the leaves to the root. *)
 
+val map_lfunction : (lambda -> lambda) -> lfunction -> lfunction
+  (** Apply the given transformation on the function's body *)
+
 val shallow_map  : (lambda -> lambda) -> lambda -> lambda
   (** Rewrite each immediate sub-term with the function. *)
 

--- a/lambda/lambda.mli
+++ b/lambda/lambda.mli
@@ -454,7 +454,7 @@ val rename : Ident.t Ident.Map.t -> lambda -> lambda
 (** A version of [subst] specialized for the case where we're just renaming
     idents. *)
 
-val duplicate : lambda -> lambda
+val duplicate_function : lfunction -> lfunction
 (** Duplicate a term, freshening all locally-bound identifiers. *)
 
 val map : (lambda -> lambda) -> lambda -> lambda

--- a/lambda/lambda.mli
+++ b/lambda/lambda.mli
@@ -511,4 +511,3 @@ val merge_inline_attributes
   -> inline_attribute option
 
 val reset: unit -> unit
-

--- a/lambda/tmc.ml
+++ b/lambda/tmc.ml
@@ -125,7 +125,7 @@ end = struct
   let tmc_placeholder =
     (* we choose a placeholder whose tagged representation will be
        reconizable. *)
-    Lconst (Const_base (Const_int (0xBBBB / 2)))
+    Lambda.dummy_constant
 
   let with_placeholder constr (body : offset destination -> lambda) =
     let k_with_placeholder =

--- a/lambda/tmc.ml
+++ b/lambda/tmc.ml
@@ -551,10 +551,6 @@ and specialized = {
   direct_kind: function_kind;
 }
 
-type _ binding_kind =
-  | Recursive : rec_binding binding_kind
-  | Non_recursive : (Ident.t * lambda) binding_kind
-
 let llets lk vk bindings body =
   List.fold_right (fun (var, def) body ->
     Llet (lk, vk, var, def, body)
@@ -930,45 +926,43 @@ and traverse ctx = function
   | lam ->
       shallow_map (traverse ctx) lam
 
+and traverse_lfunction ctx lfun =
+  map_lfunction (traverse ctx) lfun
+
 and traverse_let outer_ctx var def =
   let inner_ctx = declare_binding outer_ctx (var, def) in
   let bindings =
-    traverse_binding Non_recursive outer_ctx inner_ctx (var, def)
+    traverse_let_binding outer_ctx inner_ctx var def
   in
   inner_ctx, bindings
 
 and traverse_letrec ctx bindings =
   let ctx =
-    List.fold_left declare_binding ctx
-      (List.map (fun { id; def } -> id, Lfunction def) bindings)
+    List.fold_left (fun ctx { id; def } ->
+        declare_binding ctx (id, Lfunction def)
+      ) ctx bindings
   in
   let bindings =
-    List.concat_map (traverse_binding Recursive ctx ctx) bindings
+    List.concat_map (traverse_letrec_binding ctx) bindings
   in
   ctx, bindings
 
-and traverse_binding :
-  type a. a binding_kind -> context -> context -> a -> a list =
-  fun binding_kind outer_ctx inner_ctx binding ->
-  let (var, def) : Ident.t * lambda =
-    match binding_kind, binding with
-    | Recursive, { id; def } -> id, Lfunction def
-    | Non_recursive, (var, def) -> var, def
-  in
-  let mk_binding (var : Ident.t) (def : lambda) : a =
-    match binding_kind with
-    | Recursive ->
-        let def =
-          match def with
-          | Lfunction lfun -> lfun
-          | _ -> assert false
-        in
-        { id = var; def }
-    | Non_recursive -> var, def
-  in
+and traverse_let_binding outer_ctx inner_ctx var def =
   match find_candidate def with
-  | None -> [mk_binding var (traverse outer_ctx def)]
+  | None -> [ var, traverse outer_ctx def ]
   | Some lfun ->
+      let functions = make_dps_variant var inner_ctx outer_ctx lfun in
+      List.map (fun (var, lfun) -> var, Lfunction lfun) functions
+
+and traverse_letrec_binding ctx { id; def } =
+  if def.attr.tmc_candidate
+  then
+    let functions = make_dps_variant id ctx ctx def in
+    List.map (fun (id, def) -> { id; def }) functions
+  else
+    [ { id; def = traverse_lfunction ctx def } ]
+
+and make_dps_variant var inner_ctx outer_ctx (lfun : lfunction) =
   let special = Ident.Map.find var inner_ctx.specialized in
   let fun_choice = choice outer_ctx ~tail:true lfun.body in
   if fun_choice.Choice.tmc_calls = [] then
@@ -978,7 +972,7 @@ and traverse_binding :
   let direct =
     let { kind; params; return; body = _; attr; loc } = lfun in
     let body = Choice.direct fun_choice in
-    lfunction ~kind ~params ~return ~body ~attr ~loc in
+    lfunction' ~kind ~params ~return ~body ~attr ~loc in
   let dps =
     let dst_param = {
       var = Ident.create_local "dst";
@@ -986,7 +980,7 @@ and traverse_binding :
       loc = lfun.loc;
     } in
     let dst = { dst_param with offset = Offset (Lvar dst_param.offset) } in
-    Lambda.duplicate @@ lfunction
+    Lambda.duplicate_function @@ lfunction'
       ~kind:
         (* Support of Tupled function: see [choice_apply]. *)
         Curried
@@ -997,7 +991,7 @@ and traverse_binding :
       ~loc:lfun.loc
   in
   let dps_var = special.dps_id in
-  [mk_binding var direct; mk_binding dps_var dps]
+  [var, direct; dps_var, dps]
 
 and traverse_list ctx terms =
   List.map (traverse ctx) terms

--- a/lambda/translclass.ml
+++ b/lambda/translclass.ml
@@ -410,10 +410,11 @@ let rec build_class_lets ~scopes cl =
   match cl.cl_desc with
     Tcl_let (rec_flag, defs, _vals, cl') ->
       let env, wrap = build_class_lets ~scopes cl' in
-      (env, fun x ->
-          Translcore.transl_let ~scopes rec_flag defs (wrap x))
+      (env, fun lam_and_kind ->
+          let lam, rkind = wrap lam_and_kind in
+          Translcore.transl_let ~scopes rec_flag defs lam, rkind)
   | _ ->
-      (cl.cl_env, fun x -> x)
+      (cl.cl_env, fun lam_and_kind -> lam_and_kind)
 
 let rec get_class_meths cl =
   match cl.cl_desc with
@@ -682,9 +683,10 @@ let free_methods l =
   in free l; !fv
 
 let transl_class ~scopes ids cl_id pub_meths cl vflag =
+  let open Value_rec_types in
   (* First check if it is not only a rebind *)
   let rebind = transl_class_rebind ~scopes cl vflag in
-  if rebind <> lambda_unit then rebind else
+  if rebind <> lambda_unit then rebind, Dynamic else
 
   (* Prepare for heavy environment handling *)
   let scopes = enter_class_definition ~scopes cl_id in
@@ -791,21 +793,27 @@ let transl_class ~scopes ids cl_id pub_meths cl vflag =
                    mkappl (Lvar obj_init, [lambda_unit])))
   in
   (* Simplest case: an object defined at toplevel (ids=[]) *)
-  if top && ids = [] then llets (ltable cla (ldirect obj_init)) else
+  if top && ids = [] then llets (ltable cla (ldirect obj_init), Dynamic) else
 
   let concrete = (vflag = Concrete)
-  and lclass lam =
-    let cl_init = llets (Lambda.lfunction
-                           ~kind:Curried
-                           ~attr:default_function_attribute
-                           ~loc:Loc_unknown
-                           ~return:Pgenval
-                           ~params:[cla, Pgenval] ~body:cl_init) in
-    Llet(Strict, Pgenval, class_init, cl_init, lam (free_variables cl_init))
+  and lclass mk_lam_and_kind =
+    let cl_init, _ =
+      llets (Lambda.lfunction
+               ~kind:Curried
+               ~attr:default_function_attribute
+               ~loc:Loc_unknown
+               ~return:Pgenval
+               ~params:[cla, Pgenval]
+               ~body:cl_init,
+            Dynamic (* Placeholder, real kind is computed in [lbody] below *))
+    in
+    let lam, rkind = mk_lam_and_kind (free_variables cl_init) in
+    Llet(Strict, Pgenval, class_init, cl_init, lam), rkind
   and lbody fv =
     if List.for_all (fun id -> not (Ident.Set.mem id fv)) ids then
       mkappl (oo_prim "make_class",[transl_meth_list pub_meths;
-                                    Lvar class_init])
+                                    Lvar class_init]),
+      Dynamic
     else
       ltable table (
       Llet(
@@ -815,7 +823,8 @@ let transl_class ~scopes ids cl_id pub_meths cl vflag =
       Lprim(Pmakeblock(0, Immutable, None),
             [mkappl (Lvar env_init, [lambda_unit]);
              Lvar class_init; Lvar env_init; lambda_unit],
-            Loc_unknown))))
+            Loc_unknown)))),
+      Static
   and lbody_virt lenvs =
     Lprim(Pmakeblock(0, Immutable, None),
           [lambda_unit; Lambda.lfunction
@@ -825,7 +834,8 @@ let transl_class ~scopes ids cl_id pub_meths cl vflag =
                           ~return:Pgenval
                           ~params:[cla, Pgenval] ~body:cl_init;
            lambda_unit; lenvs],
-         Loc_unknown)
+         Loc_unknown),
+    Static
   in
   (* Still easy: a class defined at toplevel *)
   if top && concrete then lclass lbody else
@@ -854,12 +864,13 @@ let transl_class ~scopes ids cl_id pub_meths cl vflag =
         Lprim(Pfield (3, Pointer, Mutable), [path_lam], Loc_unknown))
       (List.rev inh_init)
   in
-  let make_envs lam =
+  let make_envs (lam, rkind) =
     Llet(StrictOpt, Pgenval, envs,
          (if linh_envs = [] then lenv else
          Lprim(Pmakeblock(0, Immutable, None),
                lenv :: linh_envs, Loc_unknown)),
-         lam)
+         lam),
+    rkind
   and def_ids cla lam =
     Llet(StrictOpt, Pgenval, env2,
          mkappl (oo_prim "new_variable", [Lvar cla; transl_label ""]),
@@ -883,13 +894,6 @@ let transl_class ~scopes ids cl_id pub_meths cl vflag =
                    ~attr:default_function_attribute
                    ~loc:Loc_unknown
                    ~body:(def_ids cla cl_init), lam)
-  and lcache lam =
-    if inh_keys = [] then Llet(Alias, Pgenval, cached, Lvar tables, lam) else
-    Llet(Strict, Pgenval, cached,
-         mkappl (oo_prim "lookup_tables",
-                [Lvar tables; Lprim(Pmakeblock(0, Immutable, None),
-                                    inh_keys, Loc_unknown)]),
-         lam)
   and lset cached i lam =
     Lprim(Psetfield(i, Pointer, Assignment),
           [Lvar cached; lam], Loc_unknown)
@@ -923,12 +927,27 @@ let transl_class ~scopes ids cl_id pub_meths cl vflag =
       lupdate_cache
     else
       Lifthenelse(lfield cached 0, lambda_unit, lupdate_cache) in
+  let lcache (lam, rkind) =
+    let lam = Lsequence (lcheck_cache, lam) in
+    let lam =
+      if inh_keys = []
+      then Llet(Alias, Pgenval, cached, Lvar tables, lam)
+      else
+        Llet(Strict, Pgenval, cached,
+             mkappl (oo_prim "lookup_tables",
+                     [Lvar tables; Lprim(Pmakeblock(0, Immutable, None),
+                                         inh_keys, Loc_unknown)]),
+             lam)
+    in
+    lam, rkind
+  in
   llets (
   lcache (
-  Lsequence(lcheck_cache,
   make_envs (
-  if ids = [] then mkappl (lfield cached 0, [lenvs]) else
-  Lprim(Pmakeblock(0, Immutable, None),
+  if ids = []
+  then mkappl (lfield cached 0, [lenvs]), Dynamic
+  else
+    Lprim(Pmakeblock(0, Immutable, None),
         (if concrete then
           [mkappl (lfield cached 0, [lenvs]);
            lfield cached 1;
@@ -936,7 +955,8 @@ let transl_class ~scopes ids cl_id pub_meths cl vflag =
            lenvs]
         else [lambda_unit; lfield cached 0; lambda_unit; lenvs]),
         Loc_unknown
-       )))))
+       ),
+    Static)))
 
 (* Wrapper for class compilation *)
 (*
@@ -949,11 +969,12 @@ let transl_class ~scopes ids cl_id pub_meths cl vflag =
 *)
 
 let transl_class ~scopes ids id pub_meths cl vf =
-  oo_wrap cl.cl_env false (transl_class ~scopes ids id pub_meths cl) vf
+  oo_wrap_gen cl.cl_env false (transl_class ~scopes ids id pub_meths cl) vf
 
 let () =
   transl_object := (fun ~scopes id meths cl ->
-    transl_class ~scopes [] id meths cl Concrete)
+    let lam, _rkind = transl_class ~scopes [] id meths cl Concrete in
+    lam)
 
 (* Error report *)
 

--- a/lambda/translclass.mli
+++ b/lambda/translclass.mli
@@ -19,7 +19,8 @@ open Debuginfo.Scoped_location
 
 val transl_class :
   scopes:scopes -> Ident.t list -> Ident.t ->
-  string list -> class_expr -> Asttypes.virtual_flag -> lambda
+  string list -> class_expr -> Asttypes.virtual_flag ->
+  lambda * Value_rec_types.recursive_binding_kind
 
 type error = Tags of string * string
 

--- a/lambda/translcore.ml
+++ b/lambda/translcore.ml
@@ -937,9 +937,9 @@ and transl_let ~scopes ?(in_structure=false) rec_flag pat_expr_list =
         let def =
           Translattribute.add_function_attributes def vb_loc vb_attributes
         in
-        { id; rkind; def } in
+        ( id, rkind, def ) in
       let lam_bds = List.map2 transl_case pat_expr_list idlist in
-      fun body -> Lletrec(lam_bds, body)
+      fun body -> Value_rec_compiler.compile_letrec lam_bds body
 
 and transl_setinstvar ~scopes loc self var expr =
   Lprim(Psetfield_computed (maybe_pointer expr, Assignment),

--- a/lambda/translmod.ml
+++ b/lambda/translmod.ml
@@ -426,8 +426,8 @@ let transl_class_bindings ~scopes cl_list =
   (ids,
    List.map
      (fun ({ci_id_class=id; ci_expr=cl; ci_virt=vf}, meths) ->
-       let def = transl_class ~scopes ids id meths cl vf in
-       (id, Value_rec_types.Static, def))
+       let def, rkind = transl_class ~scopes ids id meths cl vf in
+       (id, rkind, def))
      cl_list)
 
 (* Compile one or more functors, merging curried functors to produce

--- a/lambda/translmod.ml
+++ b/lambda/translmod.ml
@@ -427,7 +427,7 @@ let transl_class_bindings ~scopes cl_list =
    List.map
      (fun ({ci_id_class=id; ci_expr=cl; ci_virt=vf}, meths) ->
        let def = transl_class ~scopes ids id meths cl vf in
-       { id; rkind = Class; def})
+       (id, Value_rec_types.Static, def))
      cl_list)
 
 (* Compile one or more functors, merging curried functors to produce
@@ -697,7 +697,7 @@ and transl_structure ~scopes loc fields cc rootpath final_env = function
             transl_structure ~scopes loc (List.rev_append ids fields)
               cc rootpath final_env rem
           in
-          Lletrec(class_bindings, body), size
+          Value_rec_compiler.compile_letrec class_bindings body, size
       | Tstr_include incl ->
           let ids = bound_value_identifiers incl.incl_type in
           let modl = incl.incl_mod in
@@ -1135,7 +1135,8 @@ let transl_store_structure ~scopes glob map prims aliases str =
         | Tstr_class cl_list ->
             let (ids, class_bindings) = transl_class_bindings ~scopes cl_list in
             let lam =
-              Lletrec(class_bindings, store_idents Loc_unknown ids)
+              Value_rec_compiler.compile_letrec class_bindings
+                (store_idents Loc_unknown ids)
             in
             Lsequence(Lambda.subst no_env_update subst lam,
                       transl_store ~scopes rootpath (add_idents false ids subst)
@@ -1502,7 +1503,8 @@ let transl_toplevel_item ~scopes item =
          be a value named identically *)
       let (ids, class_bindings) = transl_class_bindings ~scopes cl_list in
       List.iter set_toplevel_unique_name ids;
-      Lletrec(class_bindings, make_sequence toploop_setvalue_id ids)
+      Value_rec_compiler.compile_letrec class_bindings
+        (make_sequence toploop_setvalue_id ids)
   | Tstr_include incl ->
       let ids = bound_value_identifiers incl.incl_type in
       let modl = incl.incl_mod in

--- a/lambda/translobj.ml
+++ b/lambda/translobj.ml
@@ -162,7 +162,7 @@ let oo_add_class id =
   classes := id :: !classes;
   (!top_env, !cache_required)
 
-let oo_wrap env req f x =
+let oo_wrap_gen env req f x =
   if !wrapping then
     if !cache_required then f x else
       Misc.protect_refs [Misc.R (cache_required, true)] (fun () ->
@@ -174,7 +174,7 @@ let oo_wrap env req f x =
          cache_required := req;
          classes := [];
          method_ids := Ident.Set.empty;
-         let lambda = f x in
+         let lambda, other = f x in
          let lambda =
            List.fold_left
              (fun lambda id ->
@@ -185,8 +185,12 @@ let oo_wrap env req f x =
                      lambda))
              lambda !classes
          in
-         lambda
+         lambda, other
       )
+
+let oo_wrap env req f x =
+  let lam, () = oo_wrap_gen env req (fun x -> f x, ()) x in
+  lam
 
 let reset () =
   Hashtbl.clear consts;

--- a/lambda/translobj.mli
+++ b/lambda/translobj.mli
@@ -28,6 +28,7 @@ val transl_store_label_init:
 val method_ids: Ident.Set.t ref (* reset when starting a new wrapper *)
 
 val oo_wrap: Env.t -> bool -> ('a -> lambda) -> 'a -> lambda
+val oo_wrap_gen: Env.t -> bool -> ('a -> lambda * 'b) -> 'a -> lambda * 'b
 val oo_add_class: Ident.t -> Env.t * bool
 
 val reset: unit -> unit

--- a/lambda/value_rec_compiler.ml
+++ b/lambda/value_rec_compiler.ml
@@ -658,16 +658,12 @@ let update_prim =
   (* Note: [alloc] could be false, but it probably doesn't matter *)
   Primitive.simple ~name:"caml_update_dummy" ~arity:2 ~alloc:true
 
-(** Dummy value for [Constant] case *)
-
-let dummy_lambda = Lambda.Lconst (Lambda.const_int (0xbadbad / 2))
-
 (** Compilation function *)
 
 let compile_letrec input_bindings body =
   let subst_for_constants =
     List.fold_left (fun subst (id, _, _) ->
-        Ident.Map.add id dummy_lambda subst)
+        Ident.Map.add id Lambda.dummy_constant subst)
       Ident.Map.empty input_bindings
   in
   let all_bindings_rev =

--- a/lambda/value_rec_compiler.ml
+++ b/lambda/value_rec_compiler.ml
@@ -646,6 +646,17 @@ and rebuild_arms :
           (let tbl = Hashtbl.make 17 in
            { tbl })
     ]}
+
+    Note on performance for non-syntactic functions: the previous approach
+    used to pre-allocate and backpatches the closure blocks directly.
+    Here we cannot use that directly, as it would require knowing the size of
+    the closure blocks. But our current approach is not even always worse.
+    In general, we end up with an extra block for part of the closure, which
+    turns into a small allocation overhead (one additional header) and an extra
+    indirection when accessing the variable inside the function.
+    But we generate regular function definitions, so the rest of the compiler
+    can either inline them or generate direct calls, and use the compact
+    representation for mutually recursive closures.
  *)
 
 type rec_bindings =

--- a/lambda/value_rec_compiler.ml
+++ b/lambda/value_rec_compiler.ml
@@ -514,9 +514,7 @@ let compile_letrec input_bindings body =
               end
             end
           | Dynamic ->
-            (* Ideally this case should be ruled out, but for now classes can end
-               up here. *)
-            { rev_bindings with dynamic = (id, def) :: rev_bindings.dynamic }
+            Misc.fatal_error "letrec: No size found for Static binding"
           end)
       empty_bindings input_bindings
   in

--- a/lambda/value_rec_compiler.ml
+++ b/lambda/value_rec_compiler.ml
@@ -231,7 +231,7 @@ let compute_static_size lam =
 
     | Pctconst _ ->
         (* These primitives are not special-cased by [Value_rec_check],
-           so we should never end up here; but these are constants anyway *)
+           so we should never end up here; but these are constants anyway. *)
         Constant
 
     | Pbytes_to_string
@@ -380,7 +380,7 @@ let ( let+ ) res f =
 (* The closure blocks are immutable.
    (Note: It is usually safe to declare immutable blocks as mutable,
    but in this case the blocks might be empty and declaring them as Mutable
-   would cause errors later) *)
+   would cause errors later.) *)
 let lifted_block_mut : Asttypes.mutable_flag = Immutable
 
 let no_loc = Debuginfo.Scoped_location.Loc_unknown

--- a/lambda/value_rec_compiler.ml
+++ b/lambda/value_rec_compiler.ml
@@ -307,12 +307,6 @@ let compute_static_size lam =
 let lfunction_with_body { kind; params; return; body = _; attr; loc } body =
   lfunction' ~kind ~params ~return ~body ~attr ~loc
 
-(* The backend doesn't handle mutable empty block correctly *)
-let lifted_block_mut : Asttypes.mutable_flag = Immutable
-
-let no_loc = Debuginfo.Scoped_location.Loc_unknown
-
-
 (** {1. Function Lifting} *)
 
 (* The compiler allows recursive definitions of functions that are not
@@ -382,6 +376,14 @@ let ( let+ ) res f =
   match res with
   | Unreachable -> Unreachable
   | Reachable (func, lam) -> Reachable (func, f lam)
+
+(* The closure blocks are immutable.
+   (Note: It is usually safe to declare immutable blocks as mutable,
+   but in this case the blocks might be empty and declaring them as Mutable
+   would cause errors later) *)
+let lifted_block_mut : Asttypes.mutable_flag = Immutable
+
+let no_loc = Debuginfo.Scoped_location.Loc_unknown
 
 let rec split_static_function block_var local_idents lam :
   Lambda.lambda split_result =

--- a/lambda/value_rec_compiler.ml
+++ b/lambda/value_rec_compiler.ml
@@ -647,14 +647,16 @@ and rebuild_arms :
            { tbl })
     ]}
 
-    Note on performance for non-syntactic functions: the previous approach
-    used to pre-allocate and backpatches the closure blocks directly.
-    Here we cannot use that directly, as it would require knowing the size of
-    the closure blocks. But our current approach is not even always worse.
-    In general, we end up with an extra block for part of the closure, which
-    turns into a small allocation overhead (one additional header) and an extra
-    indirection when accessing the variable inside the function.
-    But we generate regular function definitions, so the rest of the compiler
+    Note on performance for non-syntactic functions:
+    The compiler would previously pre-allocate and backpatch function
+    closures. The new approach is designed to avoid back-patching
+    closures -- besides, we could not pre-allocate at this point in the
+    compiler pipeline, as the closure size will only be determined later.
+
+    For non-syntactic functions with local free variables, we now store the
+    local free variables in a block, which incurs an additional indirection
+    whenever a local variable is accessed by the function. On the other hand,
+    we generate regular function definitions, so the rest of the compiler
     can either inline them or generate direct calls, and use the compact
     representation for mutually recursive closures.
  *)

--- a/lambda/value_rec_compiler.ml
+++ b/lambda/value_rec_compiler.ml
@@ -646,18 +646,25 @@ let empty_bindings =
     dynamic = [];
   }
 
+(** Allocation and backpatching primitives *)
+
+let alloc_prim =
+  Primitive.simple ~name:"caml_alloc_dummy" ~arity:1 ~alloc:true
+
+let alloc_float_record_prim =
+  Primitive.simple ~name:"caml_alloc_dummy_float" ~arity:1 ~alloc:true
+
+let update_prim =
+  (* Note: [alloc] could be false, but it probably doesn't matter *)
+  Primitive.simple ~name:"caml_update_dummy" ~arity:2 ~alloc:true
+
+(** Dummy value for [Constant] case *)
+
+let dummy_lambda = Lambda.Lconst (Lambda.const_int (0xbadbad / 2))
+
+(** Compilation function *)
+
 let compile_letrec input_bindings body =
-  let alloc_prim =
-    Primitive.simple ~name:"caml_alloc_dummy" ~arity:1 ~alloc:true
-  in
-  let alloc_float_record_prim =
-    Primitive.simple ~name:"caml_alloc_dummy_float" ~arity:1 ~alloc:true
-  in
-  let update_prim =
-    (* Note: [alloc] could be false, but who cares *)
-    Primitive.simple ~name:"caml_update_dummy" ~arity:2 ~alloc:true
-  in
-  let dummy_lambda = Lambda.Lconst (Lambda.const_int (0xbadbad / 2)) in
   let subst_for_constants =
     List.fold_left (fun subst (id, _, _) ->
         Ident.Map.add id dummy_lambda subst)

--- a/lambda/value_rec_compiler.ml
+++ b/lambda/value_rec_compiler.ml
@@ -439,6 +439,11 @@ let rec split_static_function block_var local_idents lam :
           (succ i, Ident.Map.add var access subst, Lvar var :: fields))
         local_free_vars (0, Ident.Map.empty, [])
     in
+    (* Note: When there are no local free variables, we don't need the
+       substitution and we don't need to generate code for pre-allocating
+       and backpatching a block of size 0.
+       However, the general scheme also works and it's unlikely to be
+       noticeably worse, so we use it for simplicity. *)
     let new_fun =
       lfunction_with_body lfun
         (Lambda.subst (fun _ _ env -> env) subst lfun.body)

--- a/lambda/value_rec_compiler.ml
+++ b/lambda/value_rec_compiler.ml
@@ -92,6 +92,15 @@ and lambda_with_env = {
 let dynamic_size () =
   Misc.fatal_error "letrec: No size found for Static binding"
 
+(* [join_sizes] is used to compute the size of an expression with multiple
+   branches. Such expressions are normally classified as [Dynamic] by
+   [Value_rec_check], so the default behaviour is a compile-time failure.
+   However, for partial pattern-matching (typically in let bindings)
+   the compiler will later add a branch for the failing cases, and this
+   is handled here with the [Unreachable] case.
+   Note that the current compilation scheme would work if we allowed the
+   [Constant] and [Block] cases to be joined, but [Function] needs to be
+   a single function. *)
 let join_sizes size1 size2 =
   match size1, size2 with
   | Unreachable, size | size, Unreachable -> size

--- a/lambda/value_rec_compiler.ml
+++ b/lambda/value_rec_compiler.ml
@@ -1,0 +1,562 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                       Vincent Laviron, OCamlPro                        *)
+(*                                                                        *)
+(*   Copyright 2023 OCamlPro SAS                                          *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+open Lambda
+
+type size =
+  | Unreachable
+  | Dynamic
+  | Constant
+  | Function
+  | Regular_block of int
+  | Float_record of int
+
+let join_sizes size1 size2 =
+  match size1, size2 with
+  | Unreachable, size | size, Unreachable -> size
+  | _, _ -> Dynamic
+
+let compute_static_size lam =
+  let rec compute_expression_size env lam =
+    match lam with
+    | Lvar v ->
+      begin match Ident.Map.find_opt v env with
+      | None -> Dynamic
+      | Some size -> size
+      end
+    | Lmutvar _ -> Dynamic
+    | Lconst _ -> Constant
+    | Lapply _ -> Dynamic
+    | Lfunction _ -> Function
+    | Llet (_, _, id, def, body) ->
+      let size = compute_expression_size env def in
+      compute_expression_size (Ident.Map.add id size env) body
+    | Lmutlet(_, _, _, body) ->
+      compute_expression_size env body
+    | Lletrec (bindings, body) ->
+      let env =
+        List.fold_left (fun env_acc { id; def = _ } ->
+            Ident.Map.add id Function env_acc)
+          env bindings
+      in
+      compute_expression_size env body
+    | Lprim (p, args, _) ->
+      size_of_primitive env p args
+    | Lswitch (_, sw, _) ->
+      let fail_case =
+        match sw.sw_failaction with
+        | None -> []
+        | Some fail -> [0 (* ignored *), fail]
+      in
+      compute_and_join_sizes_switch env [sw.sw_consts; sw.sw_blocks; fail_case]
+    | Lstringswitch (_, cases, fail, _) ->
+      let fail_case =
+        match fail with
+        | None -> []
+        | Some fail -> ["" (* ignored *), fail]
+      in
+      compute_and_join_sizes_switch env [cases; fail_case]
+    | Lstaticraise _ -> Unreachable
+    | Lstaticcatch (body, _, handler)
+    | Ltrywith (body, _, handler) ->
+      compute_and_join_sizes env [body; handler]
+    | Lifthenelse (_cond, ifso, ifnot) ->
+      compute_and_join_sizes env [ifso; ifnot]
+    | Lsequence (_, e) ->
+      compute_expression_size env e
+    | Lwhile _
+    | Lfor _
+    | Lassign _ -> Constant
+    | Lsend _ -> Dynamic
+    | Levent (e, _) ->
+      compute_expression_size env e
+    | Lifused _ -> Constant
+  and compute_and_join_sizes env branches =
+    List.fold_left (fun size branch ->
+        join_sizes size (compute_expression_size env branch))
+      Unreachable branches
+  and compute_and_join_sizes_switch :
+    type a. size Ident.Map.t -> (a * lambda) list list -> size =
+    fun env all_cases ->
+      List.fold_left (fun size cases ->
+          List.fold_left (fun size (_key, action) ->
+              join_sizes size (compute_expression_size env action))
+            size cases)
+        Unreachable all_cases
+  and size_of_primitive env p args =
+    match p with
+    | Pignore
+    | Psetfield _
+    | Psetfield_computed _
+    | Psetfloatfield _
+    | Poffsetint _
+    | Poffsetref _
+    | Pbytessetu
+    | Pbytessets
+    | Parraysetu _
+    | Parraysets _
+    | Pbigarrayset _
+    | Pbytes_set_16 _
+    | Pbytes_set_32 _
+    | Pbytes_set_64 _
+    | Pbigstring_set_16 _
+    | Pbigstring_set_32 _
+    | Pbigstring_set_64 _ ->
+        (* Unit-returning primitives. Most of these are only generated from
+           external declarations and not special-cased by [Value_rec_check],
+           but it doesn't hurt to be consistent. *)
+        Constant
+
+    | Pduprecord (repres, size) ->
+        begin match repres with
+        | Record_regular | Record_inlined _ | Record_extension _ ->
+            Regular_block size
+        | Record_float ->
+            Float_record size
+        | Record_unboxed _ ->
+            Misc.fatal_error "size_of_primitive"
+        end
+    | Pmakeblock _ ->
+        (* The block shape is unfortunately an option, so we rely on the
+           number of arguments instead *)
+        Regular_block (List.length args)
+    | Pmakearray (kind, _) ->
+        let size = List.length args in
+        begin match kind with
+        | Pgenarray | Paddrarray | Pintarray ->
+            Regular_block size
+        | Pfloatarray ->
+            Float_record size
+        end
+    | Pduparray _ ->
+        (* The size has to be recovered from the size of the argument *)
+        begin match args with
+        | [arg] ->
+            compute_expression_size env arg
+        | [] | _ :: _ :: _ ->
+            Misc.fatal_error "size_of_primitive"
+        end
+
+    | Praise _ ->
+        Unreachable
+
+    | Pctconst _ ->
+        (* These primitives are not special-cased by [Value_rec_check],
+           so we could return [Dynamic] too *)
+        Constant
+
+    | Pbytes_to_string
+    | Pbytes_of_string
+    | Pgetglobal _
+    | Psetglobal _
+    | Pfield _
+    | Pfield_computed
+    | Pfloatfield _
+    | Prunstack
+    | Pperform
+    | Presume
+    | Preperform
+    | Pccall _
+    | Psequand | Psequor | Pnot
+    | Pnegint | Paddint | Psubint | Pmulint
+    | Pdivint _ | Pmodint _
+    | Pandint | Porint | Pxorint
+    | Plslint | Plsrint | Pasrint
+    | Pintcomp _
+    | Pcompare_ints | Pcompare_floats | Pcompare_bints _
+    | Pintoffloat | Pfloatofint
+    | Pnegfloat | Pabsfloat
+    | Paddfloat | Psubfloat | Pmulfloat | Pdivfloat
+    | Pfloatcomp _
+    | Pstringlength | Pstringrefu  | Pstringrefs
+    | Pbyteslength | Pbytesrefu | Pbytesrefs
+    | Parraylength _
+    | Parrayrefu _
+    | Parrayrefs _
+    | Pisint
+    | Pisout
+    | Pbintofint _
+    | Pintofbint _
+    | Pcvtbint _
+    | Pnegbint _
+    | Paddbint _
+    | Psubbint _
+    | Pmulbint _
+    | Pdivbint _
+    | Pmodbint _
+    | Pandbint _
+    | Porbint _
+    | Pxorbint _
+    | Plslbint _
+    | Plsrbint _
+    | Pasrbint _
+    | Pbintcomp _
+    | Pbigarrayref _
+    | Pbigarraydim _
+    | Pstring_load_16 _
+    | Pstring_load_32 _
+    | Pstring_load_64 _
+    | Pbytes_load_16 _
+    | Pbytes_load_32 _
+    | Pbytes_load_64 _
+    | Pbigstring_load_16 _
+    | Pbigstring_load_32 _
+    | Pbigstring_load_64 _
+    | Pbswap16
+    | Pbbswap _
+    | Pint_as_pointer
+    | Patomic_load _
+    | Patomic_exchange
+    | Patomic_cas
+    | Patomic_fetch_add
+    | Popaque
+    | Pdls_get ->
+        Dynamic
+  in
+  compute_expression_size Ident.Map.empty lam
+
+let lfunction_with_body { kind; params; return; body = _; attr; loc } body =
+  lfunction' ~kind ~params ~return ~body ~attr ~loc
+
+(* The backend doesn't handle mutable empty block correctly *)
+let lifted_block_mut : Asttypes.mutable_flag = Immutable
+
+let no_loc = Debuginfo.Scoped_location.Loc_unknown
+
+type lifted_function =
+  { lfun : Lambda.lfunction;
+    free_vars_block_size : int;
+  }
+
+type 'a split_result =
+  | Unreachable
+  | Reachable of lifted_function * 'a
+
+let ( let** ) res f =
+  match res with
+  | Unreachable -> Unreachable
+  | Reachable (func, lam) -> Reachable (func, f lam)
+
+let rec split_static_function block_var local_idents lam :
+  Lambda.lambda split_result =
+  match lam with
+  | Lvar v ->
+    (* Eta-expand *)
+    (* Note: knowing the arity might let us generate slightly better code *)
+    let param = Ident.create_local "let_rec_param" in
+    let ap_func =
+      Lprim (Pfield (0, Pointer, lifted_block_mut), [Lvar block_var], no_loc)
+    in
+    let body =
+      Lapply {
+        ap_func;
+        ap_args = [Lvar param];
+        ap_loc = no_loc;
+        ap_tailcall = Default_tailcall;
+        ap_inlined = Default_inline;
+        ap_specialised = Default_specialise;
+      }
+    in
+    let wrapper =
+      lfunction'
+        ~kind:Curried
+        ~params:[param, Pgenval]
+        ~return:Pgenval
+        ~body
+        ~attr:default_stub_attribute
+        ~loc:no_loc
+    in
+    let lifted = { lfun = wrapper; free_vars_block_size = 1 } in
+    Reachable (lifted,
+               Lprim (Pmakeblock (0, lifted_block_mut, None), [Lvar v], no_loc))
+  | Lfunction lfun ->
+    let free_vars = Lambda.free_variables lfun.body in
+    let local_free_vars = Ident.Set.inter free_vars local_idents in
+    let free_vars_block_size, subst, block_fields_rev =
+      Ident.Set.fold (fun var (i, subst, fields) ->
+          let access =
+            Lprim (Pfield (i, Pointer, lifted_block_mut),
+                   [Lvar block_var],
+                   no_loc)
+          in
+          (succ i, Ident.Map.add var access subst, Lvar var :: fields))
+        local_free_vars (0, Ident.Map.empty, [])
+    in
+    let new_fun =
+      lfunction_with_body lfun
+        (Lambda.subst (fun _ _ env -> env) subst lfun.body)
+    in
+    let lifted = { lfun = new_fun; free_vars_block_size } in
+    let block =
+      Lprim (Pmakeblock (0, lifted_block_mut, None),
+             List.rev block_fields_rev,
+             no_loc)
+    in
+    Reachable (lifted, block)
+  | Llet (lkind, vkind, var, def, body) ->
+    let** body =
+      split_static_function block_var (Ident.Set.add var local_idents) body
+    in
+    Llet (lkind, vkind, var, def, body)
+  | Lmutlet (vkind, var, def, body) ->
+    let** body =
+      split_static_function block_var (Ident.Set.add var local_idents) body
+    in
+    Lmutlet (vkind, var, def, body)
+  | Lletrec (bindings, body) ->
+    let local_idents =
+      List.fold_left (fun ids { id } -> Ident.Set.add id ids)
+        local_idents bindings
+    in
+    let** body =
+      split_static_function block_var local_idents body
+    in
+    Lletrec (bindings, body)
+  | Lprim (Praise _, _, _) -> Unreachable
+  | Lstaticraise _ -> Unreachable
+  | Lswitch (arg, sw, loc) ->
+    let sw_consts_res = rebuild_arms block_var local_idents sw.sw_consts in
+    let sw_blocks_res = rebuild_arms block_var local_idents sw.sw_blocks in
+    let sw_failaction_res =
+      Option.map (split_static_function block_var local_idents) sw.sw_failaction
+    in
+    begin match sw_consts_res, sw_blocks_res, sw_failaction_res with
+    | Unreachable, Unreachable, (None | Some Unreachable) -> Unreachable
+    | Reachable (lfun, sw_consts), Unreachable, (None | Some Unreachable) ->
+      Reachable (lfun, Lswitch (arg, { sw with sw_consts }, loc))
+    | Unreachable, Reachable (lfun, sw_blocks), (None | Some Unreachable) ->
+      Reachable (lfun, Lswitch (arg, { sw with sw_blocks }, loc))
+    | Unreachable, Unreachable, Some (Reachable (lfun, failaction)) ->
+      let switch =
+        Lswitch (arg, { sw with sw_failaction = Some failaction }, loc)
+      in
+      Reachable (lfun, switch)
+    | Reachable _, Reachable _, _ | Reachable _, _, Some (Reachable _)
+    | _, Reachable _, Some (Reachable _) ->
+      Misc.fatal_error "letrec: multiple functions"
+    end
+  | Lstringswitch (arg, arms, failaction, loc) ->
+    let arms_res = rebuild_arms block_var local_idents arms in
+    let failaction_res =
+      Option.map (split_static_function block_var local_idents) failaction
+    in
+    begin match arms_res, failaction_res with
+    | Unreachable, (None | Some Unreachable) -> Unreachable
+    | Reachable (lfun, arms), (None | Some Unreachable) ->
+      Reachable (lfun, Lstringswitch (arg, arms, failaction, loc))
+    | Unreachable, Some (Reachable (lfun, failaction)) ->
+      Reachable (lfun, Lstringswitch (arg, arms, Some failaction, loc))
+    | Reachable _, Some (Reachable _) ->
+      Misc.fatal_error "letrec: multiple functions"
+    end
+  | Lstaticcatch (body, (nfail, params), handler) ->
+    let body_res = split_static_function block_var local_idents body in
+    let handler_res =
+      let local_idents =
+        List.fold_left (fun vars (var, _) -> Ident.Set.add var vars)
+          local_idents params
+      in
+      split_static_function block_var local_idents handler
+    in
+    begin match body_res, handler_res with
+    | Unreachable, Unreachable -> Unreachable
+    | Reachable (lfun, body), Unreachable ->
+      Reachable (lfun, Lstaticcatch (body, (nfail, params), handler))
+    | Unreachable, Reachable (lfun, handler) ->
+      Reachable (lfun, Lstaticcatch (body, (nfail, params), handler))
+    | Reachable _, Reachable _ ->
+      Misc.fatal_error "letrec: multiple functions"
+    end
+  | Ltrywith (body, exn_var, handler) ->
+    let body_res = split_static_function block_var local_idents body in
+    let handler_res =
+      split_static_function block_var
+        (Ident.Set.add exn_var local_idents) handler
+    in
+    begin match body_res, handler_res with
+    | Unreachable, Unreachable -> Unreachable
+    | Reachable (lfun, body), Unreachable ->
+      Reachable (lfun, Ltrywith (body, exn_var, handler))
+    | Unreachable, Reachable (lfun, handler) ->
+      Reachable (lfun, Ltrywith (body, exn_var, handler))
+    | Reachable _, Reachable _ ->
+      Misc.fatal_error "letrec: multiple functions"
+    end
+  | Lifthenelse (cond, ifso, ifnot) ->
+    let ifso_res = split_static_function block_var local_idents ifso in
+    let ifnot_res = split_static_function block_var local_idents ifnot in
+    begin match ifso_res, ifnot_res with
+    | Unreachable, Unreachable -> Unreachable
+    | Reachable (lfun, ifso), Unreachable ->
+      Reachable (lfun, Lifthenelse (cond, ifso, ifnot))
+    | Unreachable, Reachable (lfun, ifnot) ->
+      Reachable (lfun, Lifthenelse (cond, ifso, ifnot))
+    | Reachable _, Reachable _ ->
+      Misc.fatal_error "letrec: multiple functions"
+    end
+  | Lsequence (e1, e2) ->
+    let** e2 = split_static_function block_var local_idents e2 in
+    Lsequence (e1, e2)
+  | Levent (lam, lev) ->
+    let** lam = split_static_function block_var local_idents lam in
+    Levent (lam, lev)
+  | Lmutvar _
+  | Lconst _
+  | Lapply _
+  | Lprim _
+  | Lwhile _
+  | Lfor _
+  | Lassign _
+  | Lsend _
+  | Lifused _ -> Misc.fatal_error "letrec binding is not a static function"
+and rebuild_arms :
+  type a. _ -> _ -> (a * Lambda.lambda) list ->
+  (a * Lambda.lambda) list split_result =
+  fun block_var local_idents arms ->
+  match arms with
+  | [] -> Unreachable
+  | (i, lam) :: arms ->
+    let res = rebuild_arms block_var local_idents arms in
+    let lam_res = split_static_function block_var local_idents lam in
+    match lam_res, res with
+    | Unreachable, Unreachable -> Unreachable
+    | Reachable (lfun, lam), Unreachable ->
+      Reachable (lfun, (i, lam) :: arms)
+    | Unreachable, Reachable (lfun, arms) ->
+      Reachable (lfun, (i, lam) :: arms)
+    | Reachable _, Reachable _ ->
+      Misc.fatal_error "letrec: multiple functions"
+
+type static_block_size =
+  | Regular_block of int
+  | Float_record of int
+
+type rec_bindings =
+  { static : (Ident.t * static_block_size * Lambda.lambda) list;
+    functions : (Ident.t * Lambda.lfunction) list;
+    dynamic : (Ident.t * Lambda.lambda) list;
+  }
+
+let empty_bindings =
+  { static = [];
+    functions = [];
+    dynamic = [];
+  }
+
+let compile_letrec input_bindings body =
+  let alloc_prim =
+    Primitive.simple ~name:"caml_alloc_dummy" ~arity:1 ~alloc:true
+  in
+  let alloc_float_record_prim =
+    Primitive.simple ~name:"caml_alloc_dummy_float" ~arity:1 ~alloc:true
+  in
+  let update_prim =
+    (* Note: [alloc] could be false, but who cares *)
+    Primitive.simple ~name:"caml_update_dummy" ~arity:2 ~alloc:true
+  in
+  let dummy_lambda = Lambda.Lconst (Lambda.const_int (0xbadbad / 2)) in
+  let subst_for_constants =
+    List.fold_left (fun subst (id, _, _) ->
+        Ident.Map.add id dummy_lambda subst)
+      Ident.Map.empty input_bindings
+  in
+  let all_bindings_rev =
+    List.fold_left (fun rev_bindings (id, rkind, def) ->
+        match (rkind : Value_rec_types.recursive_binding_kind) with
+        | Dynamic ->
+          { rev_bindings with dynamic = (id, def) :: rev_bindings.dynamic }
+        | Static ->
+          let size = compute_static_size def in
+          begin match size with
+          | Constant | Unreachable ->
+            (* The result never escapes any recursive variables, so as we know
+               it doesn't inspect them either we can just bind the recursive
+               variables to dummy values and evaluate the definition normally.
+            *)
+            let def =
+              Lambda.subst (fun _ _ env -> env) subst_for_constants def
+            in
+            { rev_bindings with dynamic = (id, def) :: rev_bindings.dynamic }
+          | Regular_block size ->
+            { rev_bindings with
+              static = (id, Regular_block size, def) :: rev_bindings.static }
+          | Float_record size ->
+            { rev_bindings with
+              static = (id, Float_record size, def) :: rev_bindings.static }
+          | Function ->
+            begin match def with
+            | Lfunction lfun ->
+              { rev_bindings with
+                functions = (id, lfun) :: rev_bindings.functions
+              }
+            | _ ->
+              let block_var = Ident.create_local "letrec_lifted_block" in
+              begin match split_static_function block_var Ident.Set.empty def with
+              | Unreachable -> Misc.fatal_error "letrec: no function for binding"
+              | Reachable ({ lfun; free_vars_block_size }, lam) ->
+                let functions = (id, lfun) :: rev_bindings.functions in
+                let static =
+                  (block_var, Regular_block free_vars_block_size, lam) ::
+                  rev_bindings.static
+                in
+                { rev_bindings with functions; static }
+              end
+            end
+          | Dynamic ->
+            (* Ideally this case should be ruled out, but for now classes can end
+               up here. *)
+            { rev_bindings with dynamic = (id, def) :: rev_bindings.dynamic }
+          end)
+      empty_bindings input_bindings
+  in
+  let body_with_patches =
+    List.fold_left (fun body (id, _size, lam) ->
+        let update =
+          Lprim (Pccall update_prim, [Lvar id; lam], no_loc)
+        in
+        Lsequence (update, body))
+      body (all_bindings_rev.static)
+  in
+  let body_with_functions =
+    match all_bindings_rev.functions with
+    | [] -> body_with_patches
+    | bindings_rev ->
+      let function_bindings =
+        List.rev_map (fun (id, lfun) ->
+            { id; def = lfun })
+          bindings_rev
+      in
+      Lletrec (function_bindings, body_with_patches)
+  in
+  let body_with_dynamic_values =
+    List.fold_left (fun body (id, lam) ->
+        Llet(Strict, Pgenval, id, lam, body))
+      body_with_functions all_bindings_rev.dynamic
+  in
+  let body_with_pre_allocations =
+    List.fold_left (fun body (id, size, _lam) ->
+        let alloc_prim, size =
+          match size with
+          | Regular_block size -> alloc_prim, size
+          | Float_record size -> alloc_float_record_prim, size
+        in
+        let alloc =
+          Lprim (Pccall alloc_prim,
+                 [Lconst (Lambda.const_int size)],
+                 no_loc)
+        in
+        Llet(Strict, Pgenval, id, alloc, body))
+      body_with_dynamic_values all_bindings_rev.static
+  in
+  body_with_pre_allocations

--- a/lambda/value_rec_compiler.ml
+++ b/lambda/value_rec_compiler.ml
@@ -707,13 +707,14 @@ let compile_letrec input_bindings body =
                 functions = (id, lfun) :: rev_bindings.functions
               }
             | _ ->
-              let block_var = Ident.create_local "letrec_lifted_block" in
-              begin match split_static_function block_var Ident.Set.empty def with
-              | Unreachable -> Misc.fatal_error "letrec: no function for binding"
+              let ctx_id = Ident.create_local "letrec_function_context" in
+              begin match split_static_function ctx_id Ident.Set.empty def with
+              | Unreachable ->
+                Misc.fatal_error "letrec: no function for binding"
               | Reachable ({ lfun; free_vars_block_size }, lam) ->
                 let functions = (id, lfun) :: rev_bindings.functions in
                 let static =
-                  (block_var, Regular_block free_vars_block_size, lam) ::
+                  (ctx_id, Regular_block free_vars_block_size, lam) ::
                   rev_bindings.static
                 in
                 { rev_bindings with functions; static }

--- a/lambda/value_rec_compiler.mli
+++ b/lambda/value_rec_compiler.mli
@@ -2,9 +2,9 @@
 (*                                                                        *)
 (*                                 OCaml                                  *)
 (*                                                                        *)
-(*                         Vincent Laviron, OCamlPro                      *)
+(*                       Vincent Laviron, OCamlPro                        *)
 (*                                                                        *)
-(*   Copyright 2023 OCamlPro, SAS                                         *)
+(*   Copyright 2023 OCamlPro SAS                                          *)
 (*                                                                        *)
 (*   All rights reserved.  This file is distributed under the terms of    *)
 (*   the GNU Lesser General Public License version 2.1, with the          *)
@@ -12,16 +12,7 @@
 (*                                                                        *)
 (**************************************************************************)
 
-(** Types related to the compilation of value let-recs (non-functional
-     recursive definitions) *)
-
-(** The kind of recursive bindings, as computed by
-    [Value_rec_check.classify_expression] *)
-type recursive_binding_kind =
-| Static
-  (** Bindings for which some kind of pre-allocation scheme is possible.
-      The expression is allowed to be recursive, as long as its definition does
-      not inspect recursively defined values. *)
-| Dynamic
-  (** Bindings for which pre-allocation is not possible.
-      The expression is not allowed to refer to any recursive variable. *)
+val compile_letrec :
+  (Ident.t * Value_rec_types.recursive_binding_kind * Lambda.lambda) list ->
+  Lambda.lambda ->
+  Lambda.lambda

--- a/middle_end/clambda.ml
+++ b/middle_end/clambda.ml
@@ -54,11 +54,6 @@ and ulambda =
       * ulambda * ulambda
   | Uphantom_let of Backend_var.With_provenance.t
       * uphantom_defining_expr option * ulambda
-  | Uletrec of
-      (Backend_var.With_provenance.t *
-       Value_rec_types.recursive_binding_kind *
-       ulambda) list
-      * ulambda
   | Uprim of Clambda_primitives.primitive * ulambda list * Debuginfo.t
   | Uswitch of ulambda * ulambda_switch * Debuginfo.t
   | Ustringswitch of ulambda * (string * ulambda) list * ulambda option

--- a/middle_end/clambda.mli
+++ b/middle_end/clambda.mli
@@ -65,11 +65,6 @@ and ulambda =
       * ulambda * ulambda
   | Uphantom_let of Backend_var.With_provenance.t
       * uphantom_defining_expr option * ulambda
-  | Uletrec of
-      (Backend_var.With_provenance.t *
-       Value_rec_types.recursive_binding_kind *
-       ulambda) list
-      * ulambda
   | Uprim of Clambda_primitives.primitive * ulambda list * Debuginfo.t
   | Uswitch of ulambda * ulambda_switch * Debuginfo.t
   | Ustringswitch of ulambda * (string * ulambda) list * ulambda option

--- a/middle_end/flambda/build_export_info.ml
+++ b/middle_end/flambda/build_export_info.ml
@@ -238,14 +238,6 @@ let rec approx_of_expr (env : Env.t) (flam : Flambda.t) : Export_info.approx =
     approx_of_expr env body
   | Let_mutable { body } ->
     approx_of_expr env body
-  | Let_rec (defs, body) ->
-    let env =
-      List.fold_left (fun env (var, _rkind, defining_expr) ->
-          let approx = descr_of_named env defining_expr in
-          Env.add_approx env var approx)
-        env defs
-    in
-    approx_of_expr env body
   | Apply { func; kind; _ } ->
     begin match kind with
     | Indirect -> Value_unknown

--- a/middle_end/flambda/effect_analysis.ml
+++ b/middle_end/flambda/effect_analysis.ml
@@ -29,9 +29,6 @@ let rec no_effects (flam : Flambda.t) =
   | Let { defining_expr; body; _ } ->
     no_effects_named defining_expr && no_effects body
   | Let_mutable { body } -> no_effects body
-  | Let_rec (defs, body) ->
-    no_effects body
-      && List.for_all (fun (_, _, def) -> no_effects_named def) defs
   | If_then_else (_, ifso, ifnot) -> no_effects ifso && no_effects ifnot
   | Switch (_, sw) ->
     let aux (_, flam) = no_effects flam in

--- a/middle_end/flambda/extract_projections.ml
+++ b/middle_end/flambda/extract_projections.ml
@@ -106,7 +106,7 @@ let rec analyse_expr ~which_variables expr =
     | For { from_value; to_value; _ } ->
       check_free_variable from_value;
       check_free_variable to_value
-    | Let _ | Let_rec _ | Static_catch _ | While _ | Try_with _
+    | Let _ | Static_catch _ | While _ | Try_with _
     | Proved_unreachable -> ()
   in
   let for_named (named : Flambda.named) =

--- a/middle_end/flambda/flambda.mli
+++ b/middle_end/flambda/flambda.mli
@@ -93,9 +93,6 @@ type t =
   | Var of Variable.t
   | Let of let_expr
   | Let_mutable of let_mutable
-  | Let_rec of
-      (Variable.t * Value_rec_types.recursive_binding_kind * named) list * t
-  (** CR-someday lwhite: give Let_rec the same fields as Let. *)
   | Apply of apply
   | Send of send
   | Assign of assign

--- a/middle_end/flambda/flambda_invariants.ml
+++ b/middle_end/flambda/flambda_invariants.ml
@@ -29,8 +29,6 @@ type flambda_kind =
 *)
 (* CR-someday pchambart: for sum types, we should probably add an exhaustive
    pattern in ignores functions to be reminded if a type change *)
-let already_added_bound_variable_to_env (_ : Variable.t) = ()
-let will_traverse_named_expression_later (_ : Flambda.named) = ()
 let ignore_variable (_ : Variable.t) = ()
 let ignore_call_kind (_ : Flambda.call_kind) = ()
 let ignore_debuginfo (_ : Debuginfo.t) = ()
@@ -160,17 +158,6 @@ let variable_and_symbol_invariants (program : Flambda.program) =
       ignore_value_kind contents_kind;
       check_variable_is_bound env var;
       loop (add_mutable_binding_occurrence env mut_var) body
-    | Let_rec (defs, body) ->
-      let env =
-        List.fold_left (fun env (var, _rkind, def) ->
-            will_traverse_named_expression_later def;
-            add_binding_occurrence env var)
-          env defs
-      in
-      List.iter (fun (var, _rkind, def) ->
-        already_added_bound_variable_to_env var;
-        loop_named env def) defs;
-      loop env body
     | For { bound_var; from_value; to_value; direction; body; } ->
       ignore_direction_flag direction;
       check_variable_is_bound env from_value;

--- a/middle_end/flambda/flambda_iterators.mli
+++ b/middle_end/flambda/flambda_iterators.mli
@@ -95,12 +95,12 @@ val iter_on_set_of_closures_of_program
   -> f:(constant:bool -> Flambda.set_of_closures -> unit)
   -> unit
 
-val iter_all_immutable_let_and_let_rec_bindings
+val iter_all_immutable_let_bindings
    : Flambda.t
   -> f:(Variable.t -> Flambda.named -> unit)
   -> unit
 
-val iter_all_toplevel_immutable_let_and_let_rec_bindings
+val iter_all_toplevel_immutable_let_bindings
    : Flambda.t
   -> f:(Variable.t -> Flambda.named -> unit)
   -> unit

--- a/middle_end/flambda/flambda_to_clambda.ml
+++ b/middle_end/flambda/flambda_to_clambda.ml
@@ -244,19 +244,6 @@ let rec to_clambda t env (flam : Flambda.t) : Clambda.ulambda =
     let id, env_body = Env.add_fresh_mutable_ident env mut_var in
     let def = subst_var env var in
     Ulet (Mutable, contents_kind, VP.create id, def, to_clambda t env_body body)
-  | Let_rec (defs, body) ->
-    let env, defs =
-      List.fold_right (fun (var, rkind, def) (env, defs) ->
-          let id, env = Env.add_fresh_ident env var in
-          env, (id, var, rkind, def) :: defs)
-        defs (env, [])
-    in
-    let defs =
-      List.map (fun (id, var, rkind, def) ->
-          VP.create id, rkind, to_clambda_named t env var def)
-        defs
-    in
-    Uletrec (defs, to_clambda t env body)
   | Apply { func; args; kind = Direct direct_func; dbg = dbg } ->
     (* The closure _parameter_ of the function is added by cmmgen.
        At the call site, for a direct call, the closure argument must be

--- a/middle_end/flambda/inconstant_idents.ml
+++ b/middle_end/flambda/inconstant_idents.ml
@@ -235,13 +235,6 @@ module Inconstants (P:Param) (Backend:Backend_intf.S) = struct
     | Let_mutable { initial_value = var; body } ->
       mark_var var curr;
       mark_loop ~toplevel curr body
-    | Let_rec(defs, body) ->
-      List.iter (fun (var, _rkind, def) ->
-          mark_named ~toplevel [Var var] def;
-          (* adds 'var in NC => curr in NC' same remark as let case *)
-          mark_var var curr)
-        defs;
-      mark_loop ~toplevel curr body
     | Var var -> mark_var var curr
     (* Not constant cases: we mark directly 'curr in NC' and mark
        bound variables as in NC also *)

--- a/middle_end/flambda/inline_and_simplify.ml
+++ b/middle_end/flambda/inline_and_simplify.ml
@@ -1134,24 +1134,6 @@ and simplify env r (tree : Flambda.t) : Flambda.t * R.t =
           body;
           contents_kind },
       r)
-  | Let_rec (defs, body) ->
-    let defs, sb = Freshening.add_variables3 (E.freshening env) defs in
-    let env = E.set_freshening env sb in
-    let def_env =
-      List.fold_left (fun env_acc (id, _rkind, _lam) ->
-          E.add env_acc id (A.value_unknown Other))
-        env defs
-    in
-    let defs, body_env, r =
-      List.fold_right (fun (id, rkind, lam) (defs, env_acc, r) ->
-          let lam, r = simplify_named def_env r lam in
-          let defs = (id, rkind, lam) :: defs in
-          let env_acc = E.add env_acc id (R.approx r) in
-          defs, env_acc, r)
-        defs ([], env, r)
-    in
-    let body, r = simplify body_env r body in
-    Let_rec (defs, body), r
   | Static_raise (i, args) ->
     let i = Freshening.apply_static_exception (E.freshening env) i in
     simplify_free_variables env args ~f:(fun _env args _args_approxs ->

--- a/middle_end/flambda/inlining_cost.ml
+++ b/middle_end/flambda/inlining_cost.ml
@@ -85,9 +85,6 @@ let lambda_smaller' lam ~than:threshold =
       lambda_named_size defining_expr;
       lambda_size body
     | Let_mutable { body } -> lambda_size body
-    | Let_rec (bindings, body) ->
-      List.iter (fun (_, _, lam) -> lambda_named_size lam) bindings;
-      lambda_size body
     | Switch (_, sw) ->
       let cost cases =
         let size = List.length cases in
@@ -266,7 +263,7 @@ module Benefit = struct
     | Switch _ | String_switch _ | Static_raise _ | Try_with _
     | If_then_else _ | While _ | For _ -> b := remove_branch !b
     | Apply _ | Send _ -> b := remove_call !b
-    | Let _ | Let_mutable _ | Let_rec _ | Proved_unreachable | Var _
+    | Let _ | Let_mutable _ | Proved_unreachable | Var _
     | Static_catch _ -> ()
 
   let remove_code_helper_named b (named : Flambda.named) =

--- a/middle_end/flambda/invariant_params.ml
+++ b/middle_end/flambda/invariant_params.ml
@@ -138,7 +138,7 @@ let function_variable_alias
   in
   let fun_var_bindings = ref Variable.Map.empty in
   Variable.Map.iter (fun _ ( function_decl : Flambda.function_declaration ) ->
-      Flambda_iterators.iter_all_toplevel_immutable_let_and_let_rec_bindings
+      Flambda_iterators.iter_all_toplevel_immutable_let_bindings
         ~f:(fun var named ->
            (* CR-soon mshinwell: consider having the body passed to this
               function and using fv calculation instead of used_variables.

--- a/middle_end/flambda/lift_constants.ml
+++ b/middle_end/flambda/lift_constants.ml
@@ -20,7 +20,6 @@ open! Int_replace_polymorphic_compare
 (* CR-someday mshinwell: move to Flambda_utils *)
 let rec tail_variable : Flambda.t -> Variable.t option = function
   | Var v -> Some v
-  | Let_rec (_, e)
   | Let_mutable { body = e }
   | Let { body = e; _ } -> tail_variable e
   | _ -> None
@@ -113,7 +112,7 @@ let assign_symbols_and_collect_constant_definitions
     end
   in
   let assign_symbol_program expr =
-    Flambda_iterators.iter_all_immutable_let_and_let_rec_bindings expr
+    Flambda_iterators.iter_all_immutable_let_bindings expr
       ~f:assign_symbol
   in
   Flambda_iterators.iter_exprs_at_toplevel_of_program program

--- a/middle_end/flambda/lift_let_to_initialize_symbol.ml
+++ b/middle_end/flambda/lift_let_to_initialize_symbol.ml
@@ -28,7 +28,6 @@ let should_copy (named:Flambda.named) =
 
 type extracted =
   | Expr of Variable.t * Flambda.t
-  | Exprs of Variable.t list * Flambda.t
   | Block of Variable.t * Tag.t * Variable.t list
 
 type accumulated = {
@@ -40,27 +39,12 @@ type accumulated = {
 let rec accumulate ~substitution ~copied_lets ~extracted_lets
       (expr : Flambda.t) =
   match expr with
-  | Let { var; body = Var var'; _ } | Let_rec ([var, _, _], Var var')
+  | Let { var; body = Var var'; _ }
     when Variable.equal var var' ->
     { copied_lets; extracted_lets;
       terminator = Flambda_utils.toplevel_substitution substitution expr;
     }
-  (* If the pattern is what lifting let_rec generates, prevent it from being
-     lifted again. *)
-  | Let_rec (defs,
-             Let { var; body = Var var';
-                   defining_expr = Prim (Pmakeblock _, fields, _); })
-    when
-      Variable.equal var var'
-      && List.for_all (fun field ->
-          List.exists (fun (def_var, _, _) ->
-              Variable.equal def_var field) defs)
-      fields ->
-    { copied_lets; extracted_lets;
-      terminator = Flambda_utils.toplevel_substitution substitution expr;
-    }
-  | Let { var; defining_expr = Expr (Var alias); body; _ }
-  | Let_rec ([var, _, Expr (Var alias)], body) ->
+  | Let { var; defining_expr = Expr (Var alias); body; _ } ->
     let alias =
       match Variable.Map.find alias substitution with
       | exception Not_found -> alias
@@ -72,7 +56,6 @@ let rec accumulate ~substitution ~copied_lets ~extracted_lets
       ~extracted_lets
       body
   | Let { var; defining_expr = named; body; _ }
-  | Let_rec ([var, _, named], body)
     when should_copy named ->
       accumulate body
         ~substitution
@@ -97,43 +80,6 @@ let rec accumulate ~substitution ~copied_lets ~extracted_lets
             (Flambda.create_let renamed named (Var renamed))
         in
         Expr (var, expr)
-    in
-    accumulate body
-      ~substitution
-      ~copied_lets
-      ~extracted_lets:(extracted::extracted_lets)
-  | Let_rec ([var, rkind, named], body) ->
-    let renamed = Variable.rename var in
-    let def_substitution = Variable.Map.add var renamed substitution in
-    let expr =
-      Flambda_utils.toplevel_substitution def_substitution
-        (Let_rec ([renamed, rkind, named], Var renamed))
-    in
-    let extracted = Expr (var, expr) in
-    accumulate body
-      ~substitution
-      ~copied_lets
-      ~extracted_lets:(extracted::extracted_lets)
-  | Let_rec (defs, body) ->
-    let renamed_defs, def_substitution =
-      List.fold_right (fun (var, rkind, def) (acc, substitution) ->
-          let new_var = Variable.rename var in
-          (new_var, rkind, def) :: acc,
-          Variable.Map.add var new_var substitution)
-        defs ([], substitution)
-    in
-    let extracted =
-      let fst3 (v, _, _) = v in
-      let expr =
-        let name = Internal_variable_names.lifted_let_rec_block in
-        Flambda_utils.toplevel_substitution def_substitution
-          (Let_rec (renamed_defs,
-                    Flambda_utils.name_expr ~name
-                      (Prim (Pmakeblock (0, Immutable, None),
-                             List.map fst3 renamed_defs,
-                             Debuginfo.none))))
-      in
-      Exprs (List.map fst3 defs, expr)
     in
     accumulate body
       ~substitution
@@ -176,11 +122,7 @@ let rebuild (used_variables:Variable.Set.t) (accumulated:accumulated) =
     List.map (fun decl ->
         match decl with
         | Block (var, _, _) | Expr (var, _) ->
-          Symbol.of_variable (Variable.rename var), decl
-        | Exprs _ ->
-          let name = Internal_variable_names.lifted_let_rec_block in
-          let var = Variable.create name in
-          Symbol.of_variable var, decl)
+          Symbol.of_variable (Variable.rename var), decl)
       accumulated.extracted_lets
   in
   let extracted_definitions =
@@ -200,15 +142,7 @@ let rebuild (used_variables:Variable.Set.t) (accumulated:accumulated) =
         | Block (var, _tag, _fields) ->
           Variable.Map.add var (symbol, []) map
         | Expr (var, _expr) ->
-          Variable.Map.add var (symbol, [0]) map
-        | Exprs (vars, _expr) ->
-          let map, _ =
-            List.fold_left (fun (map, field) var ->
-                Variable.Map.add var (symbol, [field; 0]) map,
-                field + 1)
-              (map, 0) vars
-          in
-          map)
+          Variable.Map.add var (symbol, [0]) map)
       Variable.Map.empty accumulated_extracted_lets
   in
   let extracted =
@@ -226,12 +160,6 @@ let rebuild (used_variables:Variable.Set.t) (accumulated:accumulated) =
                [expr])
           else
             Effect expr
-        | Exprs (_vars, decl) ->
-          let expr =
-            rebuild_expr ~extracted_definitions ~copied_definitions
-              ~substitute:true decl
-          in
-          Initialisation (symbol, Tag.create_exn 0, [expr])
         | Block (_var, tag, fields) ->
           let fields =
             List.map (fun var ->

--- a/middle_end/flambda/ref_to_variables.ml
+++ b/middle_end/flambda/ref_to_variables.ml
@@ -44,9 +44,6 @@ let variables_not_used_as_local_reference (tree:Flambda.t) =
     | Let { defining_expr; body; _ } ->
       loop_named defining_expr;
       loop body
-    | Let_rec (defs, body) ->
-      List.iter (fun (_var, _rkind, named) -> loop_named named) defs;
-      loop body
     | Var v ->
       set := Variable.Set.add v !set
     | Let_mutable { initial_value = v; body } ->
@@ -148,7 +145,7 @@ let eliminate_ref_of_expr flam =
         expr
       | Let _ | Let_mutable _
       | Assign _ | Var _ | Apply _
-      | Let_rec _ | Switch _ | String_switch _
+      | Switch _ | String_switch _
       | Static_raise _ | Static_catch _
       | Try_with _ | If_then_else _
       | While _ | For _ | Send _ | Proved_unreachable ->

--- a/middle_end/flambda/un_anf.ml
+++ b/middle_end/flambda/un_anf.ml
@@ -57,7 +57,6 @@ let ignore_params_with_value_kind (_ : (VP.t * Lambda.value_kind) list) = ()
 let ignore_direction_flag (_ : Asttypes.direction_flag) = ()
 let ignore_meth_kind (_ : Lambda.meth_kind) = ()
 let ignore_value_kind (_ : Lambda.value_kind) = ()
-let ignore_rec_kind (_ : Value_rec_types.recursive_binding_kind) = ()
 
 (* CR-soon mshinwell: check we aren't traversing function bodies more than
    once (need to analyse exactly what the calls are from Cmmgen into this
@@ -166,13 +165,6 @@ let make_var_info (clam : Clambda.ulambda) : var_info =
     | Uphantom_let (var, defining_expr_opt, body) ->
       ignore_var_with_provenance var;
       ignore_uphantom_defining_expr_option defining_expr_opt;
-      loop ~depth body
-    | Uletrec (defs, body) ->
-      List.iter (fun (var, rkind, def) ->
-          ignore_var_with_provenance var;
-          ignore_rec_kind rkind;
-          loop ~depth def)
-        defs;
       loop ~depth body
     | Uprim (prim, args, dbg) ->
       ignore_primitive prim;
@@ -350,17 +342,6 @@ let let_bound_vars_that_can_be_moved var_info (clam : Clambda.ulambda) =
     | Uphantom_let (var, _defining_expr, body) ->
       ignore_var_with_provenance var;
       loop body
-    | Uletrec (defs, body) ->
-      (* Evaluation order for [defs] is not defined, and this case
-         probably isn't important for [Cmmgen] anyway. *)
-      let_stack := [];
-      List.iter (fun (var, rkind, def) ->
-          ignore_var_with_provenance var;
-          ignore_rec_kind rkind;
-          loop def;
-          let_stack := [])
-        defs;
-      loop body
     | Uprim (prim, args, dbg) ->
       ignore_primitive prim;
       examine_argument_list args;
@@ -518,14 +499,6 @@ let rec substitute_let_moveable is_let_moveable env (clam : Clambda.ulambda)
   | Uphantom_let (var, defining_expr, body) ->
     let body = substitute_let_moveable is_let_moveable env body in
     Uphantom_let (var, defining_expr, body)
-  | Uletrec (defs, body) ->
-    let defs =
-      List.map (fun (var, rkind, def) ->
-          var, rkind, substitute_let_moveable is_let_moveable env def)
-        defs
-    in
-    let body = substitute_let_moveable is_let_moveable env body in
-    Uletrec (defs, body)
   | Uprim (prim, args, dbg) ->
     let args = substitute_let_moveable_list is_let_moveable env args in
     Uprim (prim, args, dbg)
@@ -744,12 +717,6 @@ let rec un_anf_and_moveable var_info env (clam : Clambda.ulambda)
   | Uphantom_let (var, defining_expr, body) ->
     let body, body_moveable = un_anf_and_moveable var_info env body in
     Uphantom_let (var, defining_expr, body), body_moveable
-  | Uletrec (defs, body) ->
-    let defs =
-      List.map (fun (var, rk, def) -> var, rk, un_anf var_info env def) defs
-    in
-    let body = un_anf var_info env body in
-    Uletrec (defs, body), Fixed
   | Uprim (prim, args, dbg) ->
     let args, args_moveable = un_anf_list_and_moveable var_info env args in
     let moveable =

--- a/middle_end/printclambda.ml
+++ b/middle_end/printclambda.ml
@@ -141,26 +141,6 @@ and lam ppf = function
         phantom_defining_expr_opt defining_expr;
       let expr = letbody body in
       fprintf ppf ")@]@ %a)@]" lam expr
-  | Uletrec(id_arg_list, body) ->
-      let bindings ppf id_arg_list =
-        let spc = ref false in
-        List.iter
-          (fun (id, rkind, l) ->
-            if !spc then fprintf ppf "@ " else spc := true;
-            let rec_annot =
-              match (rkind : Value_rec_types.recursive_binding_kind) with
-              | Static -> ""
-              | Not_recursive -> "[Nonrec]"
-              | Constant -> "[Cst]"
-              | Class -> "[Class]"
-            in
-            fprintf ppf "@[<2>%a%s@ %a@]"
-              VP.print id
-              rec_annot
-              lam l)
-          id_arg_list in
-      fprintf ppf
-        "@[<2>(letrec@ (@[<hv 1>%a@])@ %a)@]" bindings id_arg_list lam body
   | Uprim(prim, largs, _) ->
       let lams ppf largs =
         List.iter (fun l -> fprintf ppf "@ %a" lam l) largs in

--- a/testsuite/tests/formatting/test_locations.dlocations.ocamlc.reference
+++ b/testsuite/tests/formatting/test_locations.dlocations.ocamlc.reference
@@ -86,7 +86,7 @@ let rec fib = function | 0 | 1 -> 1 | n -> (fib (n - 1)) + (fib (n - 2))
   structure_item (test_locations.ml[17,534+0]..test_locations.ml[19,572+34])
     Tstr_value Rec
     [
-      <def>
+      <def_rec>
         pattern (test_locations.ml[17,534+8]..test_locations.ml[17,534+11])
           Tpat_var "fib"
         expression (test_locations.ml[17,534+14]..test_locations.ml[19,572+34])

--- a/testsuite/tests/formatting/test_locations.dno-locations.ocamlc.reference
+++ b/testsuite/tests/formatting/test_locations.dno-locations.ocamlc.reference
@@ -86,7 +86,7 @@ let rec fib = function | 0 | 1 -> 1 | n -> (fib (n - 1)) + (fib (n - 2))
   structure_item 
     Tstr_value Rec
     [
-      <def>
+      <def_rec>
         pattern 
           Tpat_var "fib"
         expression 

--- a/toplevel/native/topeval.ml
+++ b/toplevel/native/topeval.ml
@@ -139,7 +139,7 @@ let name_expression ~loc ~attrs exp =
    let vb =
      { vb_pat = pat;
        vb_expr = exp;
-       vb_rec_kind = Not_recursive;
+       vb_rec_kind = Dynamic;
        vb_attributes = attrs;
        vb_loc = loc; }
    in

--- a/typing/printtyped.ml
+++ b/typing/printtyped.ml
@@ -341,7 +341,7 @@ and expression i ppf x =
   | Texp_constant (c) -> line i ppf "Texp_constant %a\n" fmt_constant c;
   | Texp_let (rf, l, e) ->
       line i ppf "Texp_let %a\n" fmt_rec_flag rf;
-      list i value_binding ppf l;
+      list i (value_binding rf) ppf l;
       expression i ppf e;
   | Texp_function (params, body) ->
       line i ppf "Texp_function\n";
@@ -648,7 +648,7 @@ and class_expr i ppf x =
       list i label_x_expression ppf l;
   | Tcl_let (rf, l1, l2, ce) ->
       line i ppf "Tcl_let %a\n" fmt_rec_flag rf;
-      list i value_binding ppf l1;
+      list i (value_binding rf) ppf l1;
       list i ident_x_expression_def ppf l2;
       class_expr i ppf ce;
   | Tcl_constraint (ce, Some ct, _, _, _) ->
@@ -868,7 +868,7 @@ and structure_item i ppf x =
       expression i ppf e;
   | Tstr_value (rf, l) ->
       line i ppf "Tstr_value %a\n" fmt_rec_flag rf;
-      list i value_binding ppf l;
+      list i (value_binding rf) ppf l;
   | Tstr_primitive vd ->
       line i ppf "Tstr_primitive\n";
       value_description i ppf vd;
@@ -954,8 +954,12 @@ and case
   end;
   expression (i+1) ppf c_rhs;
 
-and value_binding i ppf x =
-  line i ppf "<def>\n";
+and value_binding rec_flag i ppf x =
+  begin match rec_flag, x.vb_rec_kind with
+  | Nonrecursive, _ -> line i ppf "<def>\n"
+  | Recursive, Static -> line i ppf "<def_rec>\n"
+  | Recursive, Dynamic -> line i ppf "<def_rec_dynamic>\n"
+  end;
   attributes (i+1) ppf x.vb_attributes;
   pattern (i+1) ppf x.vb_pat;
   expression (i+1) ppf x.vb_expr

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -5165,7 +5165,7 @@ and type_argument ?explanation ?recarg env sarg ty_expected' ty_expected =
       re { texp with exp_type = ty_fun; exp_desc =
            Texp_let (Nonrecursive,
                      [{vb_pat=let_pat; vb_expr=texp; vb_attributes=[];
-                       vb_loc=Location.none; vb_rec_kind = Not_recursive;
+                       vb_loc=Location.none; vb_rec_kind = Dynamic;
                       }],
                      func let_var) }
       end
@@ -5979,7 +5979,7 @@ and type_let ?check ?check_strict
       (fun (p, (e, _)) pvb ->
         (* vb_rec_kind will be computed later for recursive bindings *)
         {vb_pat=p; vb_expr=e; vb_attributes=pvb.pvb_attributes;
-         vb_loc=pvb.pvb_loc; vb_rec_kind = Not_recursive;
+         vb_loc=pvb.pvb_loc; vb_rec_kind = Dynamic;
         })
       l spat_sexp_list
   in

--- a/typing/value_rec_check.ml
+++ b/typing/value_rec_check.ml
@@ -145,51 +145,56 @@ let classify_expression : Typedtree.expression -> sd =
     size) but the second one is unsound (`y` has no statically-known size).
   *)
   let rec classify_expression env e : sd =
-    let is_constant expr =
-      match classify_expression env expr with
-      | Constant -> true
-      | _ -> false
-    in
     match e.exp_desc with
     (* binding and variable cases *)
     | Texp_let (rec_flag, vb, e) ->
         let env = classify_value_bindings rec_flag env vb in
+        classify_expression env e
+    | Texp_letmodule (Some mid, _, _, mexp, e) ->
+        (* Note on module presence:
+           For absent modules (i.e. module aliases), the module being bound
+           does not have a physical representation, but its size can still be
+           derived from the alias itself, so we can re-use the same code as
+           for modules that are present. *)
+        let size = classify_module_expression env mexp in
+        let env = Ident.add mid size env in
         classify_expression env e
     | Texp_ident (path, _, _) ->
         classify_path env path
 
     (* non-binding cases *)
     | Texp_open (_, e)
-    | Texp_letmodule (_, _, _, _, e)
+    | Texp_letmodule (None, _, _, _, e)
     | Texp_sequence (_, e)
     | Texp_letexception (_, e) ->
         classify_expression env e
 
     | Texp_construct (_, {cstr_tag = Cstr_unboxed}, [e]) ->
         classify_expression env e
-    | Texp_construct (_, _, exprs) ->
-        if List.for_all is_constant exprs then Constant else Static
-
-    | Texp_variant (_, Some expr) ->
-        if is_constant expr then Constant else Static
-    | Texp_variant (_, None) ->
-        Constant
+    | Texp_construct _ ->
+        Static
 
     | Texp_record { representation = Record_unboxed _;
                     fields = [| _, Overridden (_,e) |] } ->
         classify_expression env e
-    | Texp_record { fields; _ } ->
-        (* We ignore the [extended_expression] field.
-           As long as all fields are Overridden rather than Kept, the value
-           can be constant. *)
-        let is_constant_field (_label, def) =
-          match def with
-          | Kept _ -> false
-          | Overridden (_loc, expr) -> is_constant expr
-        in
-        if Array.for_all is_constant_field fields then Constant else Static
-    | Texp_tuple exprs ->
-        if List.for_all is_constant exprs then Constant else Static
+    | Texp_record _ ->
+        Static
+
+    | Texp_variant _
+    | Texp_tuple _
+    | Texp_extension_constructor _
+    | Texp_constant _ ->
+        Static
+
+    | Texp_for _
+    | Texp_setfield _
+    | Texp_while _
+    | Texp_setinstvar _ ->
+        (* Unit-returning expressions *)
+        Static
+
+    | Texp_unreachable ->
+        Static
 
     | Texp_apply ({exp_desc = Texp_ident (_, _, vd)}, _)
       when is_ref vd ->
@@ -198,7 +203,7 @@ let classify_expression : Typedtree.expression -> sd =
       when List.exists is_abstracted_arg args ->
         Static
     | Texp_apply _ ->
-        Not_recursive
+        Dynamic
 
     | Texp_array _ ->
         Static
@@ -223,21 +228,6 @@ let classify_expression : Typedtree.expression -> sd =
           (* other cases compile to a lazy block holding a function *)
           Static
       end
-    | Texp_extension_constructor _ ->
-        Static
-
-    | Texp_constant _ ->
-        Constant
-
-    | Texp_for _
-    | Texp_setfield _
-    | Texp_while _
-    | Texp_setinstvar _ ->
-        (* Unit-returning expressions *)
-        Constant
-
-    | Texp_unreachable ->
-        Constant
 
     | Texp_new _
     | Texp_instvar _
@@ -250,7 +240,7 @@ let classify_expression : Typedtree.expression -> sd =
     | Texp_try _
     | Texp_override _
     | Texp_letop _ ->
-        Not_recursive
+        Dynamic
   and classify_value_bindings rec_flag env bindings =
     (* We use a non-recursive classification, classifying each
         binding with respect to the old environment
@@ -294,31 +284,33 @@ let classify_expression : Typedtree.expression -> sd =
 
                 This could be fixed by a more complete implementation.
             *)
-            Not_recursive
+            Dynamic
         end
     | Path.Pdot _ | Path.Papply _ | Path.Pextra_ty _ ->
         (* local modules could have such paths to local definitions;
             classify_expression could be extend to compute module
             shapes more precisely *)
-        Not_recursive
+        Dynamic
   and classify_module_expression env mexp : sd =
     match mexp.mod_desc with
-    | Tmod_ident _ ->
-        Not_recursive
+    | Tmod_ident (path, _) ->
+        classify_path env path
     | Tmod_structure _ ->
         Static
     | Tmod_functor _ ->
         Static
     | Tmod_apply _ ->
-        Not_recursive
+        Dynamic
     | Tmod_apply_unit _ ->
-        Not_recursive
+        Dynamic
     | Tmod_constraint (mexp, _, _, coe) ->
         begin match coe with
-        | Tcoerce_none -> classify_module_expression env mexp
+        | Tcoerce_none ->
+            classify_module_expression env mexp
         | Tcoerce_structure _ ->
             Static
-        | Tcoerce_functor _ -> Static
+        | Tcoerce_functor _ ->
+            Static
         | Tcoerce_primitive _ ->
             Misc.fatal_error "letrec: primitive coercion on a module"
         | Tcoerce_alias _ ->
@@ -1370,16 +1362,14 @@ let is_valid_recursive_expression idlist expr : sd option =
      let rkind = classify_expression expr in
      let is_valid =
        match rkind with
-       | Static | Constant ->
+       | Static ->
          (* The expression has known size or is constant *)
          let ty = expression expr Return in
          Env.unguarded ty idlist = []
-       | Not_recursive ->
+       | Dynamic ->
          (* The expression has unknown size *)
          let ty = expression expr Return in
          Env.unguarded ty idlist = [] && Env.dependent ty idlist = []
-       | Class ->
-         assert false (* Not generated by [classify_expression] *)
      in
      if is_valid then Some rkind else None
 


### PR DESCRIPTION
This PR represents my full work on recursive bindings. It contains a full compilation scheme in Lambda, that supports all of the definitions currently allowed (except for a few corner cases that are now properly rejected, see #12585 and #12592).

~~I don't advise to review this PR directly now, as it is a bit complex and better reviewed by parts. I'll now get back to #12551, get it properly reviewed and merged, then open new PRs for each part (roughly one PR per commit, except the first three that are all in #12551). I'll also add a commit at some point to remove the existing backend support for non-function recursive definitions.~~
Update: Now that otehr PRs have been merged, this one is reviewable.

But if someone wants to check whether my work will break existing code, the branch associated to this PR can be used.