### PR TITLE
Refactor Dynlink startup to avoid parsing bytecode sections twice

### DIFF
--- a/.depend
+++ b/.depend
@@ -2246,7 +2246,6 @@ bytecomp/symtable.cmo : \
     utils/config.cmi \
     file_formats/cmo_format.cmi \
     utils/clflags.cmi \
-    bytecomp/bytesections.cmi \
     bytecomp/symtable.cmi
 bytecomp/symtable.cmx : \
     lambda/runtimedef.cmx \
@@ -2260,7 +2259,6 @@ bytecomp/symtable.cmx : \
     utils/config.cmx \
     file_formats/cmo_format.cmi \
     utils/clflags.cmx \
-    bytecomp/bytesections.cmx \
     bytecomp/symtable.cmi
 bytecomp/symtable.cmi : \
     lambda/lambda.cmi \

--- a/Changes
+++ b/Changes
@@ -238,6 +238,10 @@ OCaml 5.2.0
   (KC Sivaramakrishnan, report by Gabriel Scherer, review by Gabriel Scherer,
   Sadiq Jaffer and Fabrice Buoro)
 
+- #12599: Refactor Dynlink startup to avoid parsing bytecode sections twice
+  (Stephen Dolan, review by David Allsopp, Hugo Heuzard, Damien Doligez and
+   Xavier Leroy)
+
 - #12681: Fix TSan false positives due to volatile write handling
   (Olivier Nicole, Fabrice Buoro and Anmol Sahoo, review by Luc Maranget,
    Gabriel Scherer, Hernan Ponce de Leon and Xavier Leroy)

--- a/bytecomp/bytelink.ml
+++ b/bytecomp/bytelink.ml
@@ -524,8 +524,6 @@ static char caml_data[] = {
        let sections : (string * Obj.t) array =
          [| Bytesections.Name.to_string SYMB,
             Symtable.data_global_map();
-            Bytesections.Name.to_string PRIM,
-            Obj.repr(Symtable.data_primitive_names());
             Bytesections.Name.to_string CRCS,
             Obj.repr(extract_crc_interfaces()) |]
        in

--- a/bytecomp/bytelink.ml
+++ b/bytecomp/bytelink.ml
@@ -521,13 +521,13 @@ static char caml_data[] = {
 };
 |};
        (* The sections *)
-       let sections : (string * Obj.t) list =
-         [ Bytesections.Name.to_string SYMB,
-           Symtable.data_global_map();
-           Bytesections.Name.to_string PRIM,
-           Obj.repr(Symtable.data_primitive_names());
-           Bytesections.Name.to_string CRCS,
-           Obj.repr(extract_crc_interfaces()) ]
+       let sections : (string * Obj.t) array =
+         [| Bytesections.Name.to_string SYMB,
+            Symtable.data_global_map();
+            Bytesections.Name.to_string PRIM,
+            Obj.repr(Symtable.data_primitive_names());
+            Bytesections.Name.to_string CRCS,
+            Obj.repr(extract_crc_interfaces()) |]
        in
        output_string outchan {|
 static char caml_sections[] = {

--- a/bytecomp/dll.ml
+++ b/bytecomp/dll.ml
@@ -174,10 +174,7 @@ let init_compile nostdlib =
 (* Initialization for linking in core (dynlink or toplevel) *)
 
 let init_toplevel dllpaths =
-  search_path :=
-    ld_library_path_contents() @
-    dllpaths @
-    ld_conf_contents();
+  search_path := dllpaths;
   opened_dlls :=
     List.map (fun dll -> "", Execution dll)
       (Array.to_list (get_current_dlls()));

--- a/bytecomp/meta.ml
+++ b/bytecomp/meta.ml
@@ -26,5 +26,3 @@ external release_bytecode : bytecode -> unit
                                  = "caml_static_release_bytecode"
 external invoke_traced_function : Obj.raw_data -> Obj.t -> Obj.t -> Obj.t
                                 = "caml_invoke_traced_function"
-external get_section_table : unit -> (string * Obj.t) list
-                           = "caml_get_section_table"

--- a/bytecomp/meta.mli
+++ b/bytecomp/meta.mli
@@ -28,5 +28,3 @@ external release_bytecode : bytecode -> unit
                                  = "caml_static_release_bytecode"
 external invoke_traced_function : Obj.raw_data -> Obj.t -> Obj.t -> Obj.t
                                 = "caml_invoke_traced_function"
-external get_section_table : unit -> (string * Obj.t) list
-                           = "caml_get_section_table"

--- a/bytecomp/symtable.ml
+++ b/bytecomp/symtable.ml
@@ -164,10 +164,9 @@ let all_primitives () =
 let data_primitive_names () =
   all_primitives()
   |> Array.to_list
-  |> concat_null_terminated
 
 let output_primitive_names outchan =
-  output_string outchan (data_primitive_names())
+  output_string outchan (data_primitive_names() |> concat_null_terminated)
 
 open Printf
 
@@ -336,65 +335,24 @@ let update_global_table () =
     !literal_table;
   literal_table := []
 
-(* Recover data for toplevel initialization.  Data can come either from
-   executable file (normal case) or from linked-in data (-output-obj). *)
+type bytecode_sections =
+  { symb: GlobalMap.t;
+    crcs: (string * Digest.t option) list;
+    prim: string list;
+    dlpt: string list }
 
-type section_reader = {
-  read_string: Bytesections.Name.t -> string;
-  read_struct: Bytesections.Name.t -> Obj.t;
-  close_reader: unit -> unit
-}
-
-let read_sections () =
-  try
-    let sections =
-      List.map
-        (fun (n,o) -> Bytesections.Name.of_string n, o)
-        (Meta.get_section_table ())
-    in
-    { read_string =
-        (fun name ->
-           (Obj.magic(List.assoc name sections) : string));
-      read_struct =
-        (fun name -> List.assoc name sections);
-      close_reader =
-        (fun () -> ()) }
-  with Not_found ->
-    let ic = open_in_bin Sys.executable_name in
-    let section_table = Bytesections.read_toc ic in
-    { read_string = Bytesections.read_section_string section_table ic;
-      read_struct = Bytesections.read_section_struct section_table ic;
-      close_reader = fun () -> close_in ic }
+external get_bytecode_sections : unit -> bytecode_sections =
+  "caml_dynlink_get_bytecode_sections"
 
 (* Initialize the linker for toplevel use *)
 
 let init_toplevel () =
-  try
-    let sect = read_sections () in
-    (* Locations of globals *)
-    global_table :=
-      (Obj.magic (sect.read_struct Bytesections.Name.SYMB) : GlobalMap.t);
-    (* Primitives *)
-    let prims =
-      Misc.split_null_terminated (sect.read_string Bytesections.Name.PRIM) in
-    c_prim_table := PrimMap.empty;
-    List.iter set_prim_table prims;
-    (* DLL initialization *)
-    let dllpaths =
-      try Misc.split_null_terminated (sect.read_string Bytesections.Name.DLPT)
-      with Not_found -> [] in
-    Dll.init_toplevel dllpaths;
-    (* Recover CRC infos for interfaces *)
-    let crcintfs =
-      try
-        (Obj.magic (sect.read_struct Bytesections.Name.CRCS)
-         : (string * Digest.t option) list)
-      with Not_found -> [] in
-    (* Done *)
-    sect.close_reader();
-    crcintfs
-  with Bytesections.Bad_magic_number | Not_found | Failure _ ->
-    fatal_error "Toplevel bytecode executable is corrupted"
+  let sect = get_bytecode_sections () in
+  global_table := sect.symb;
+  c_prim_table := PrimMap.empty;
+  List.iter set_prim_table sect.prim;
+  Dll.init_toplevel sect.dlpt;
+  sect.crcs
 
 (* Find the value of a global identifier *)
 

--- a/bytecomp/symtable.mli
+++ b/bytecomp/symtable.mli
@@ -55,7 +55,7 @@ val output_global_map: out_channel -> unit
 val output_primitive_names: out_channel -> unit
 val output_primitive_table: out_channel -> unit
 val data_global_map: unit -> Obj.t
-val data_primitive_names: unit -> string
+val data_primitive_names: unit -> string list
 val transl_const: Lambda.structured_constant -> Obj.t
 
 (* Functions for the toplevel *)

--- a/runtime/caml/dynlink.h
+++ b/runtime/caml/dynlink.h
@@ -27,11 +27,9 @@
    (all three 0-separated in char arrays).
    Abort the runtime system on error.
    Calling this frees caml_shared_libs_path (not touching its contents). */
-extern void caml_init_dynlink(char_os * lib_path,
-                              char_os * libs,
-                              char * req_prims,
-                              char * symb_section, intnat symb_section_len,
-                              char * crcs_section, intnat crcs_section_len);
+extern void caml_build_primitive_table(char_os * lib_path,
+                                       char_os * libs,
+                                       char * req_prims);
 
 /* The search path for shared libraries */
 extern struct ext_table caml_shared_libs_path;

--- a/runtime/caml/dynlink.h
+++ b/runtime/caml/dynlink.h
@@ -27,9 +27,11 @@
    (all three 0-separated in char arrays).
    Abort the runtime system on error.
    Calling this frees caml_shared_libs_path (not touching its contents). */
-extern void caml_build_primitive_table(char_os * lib_path,
-                                       char_os * libs,
-                                       char * req_prims);
+extern void caml_init_dynlink(char_os * lib_path,
+                              char_os * libs,
+                              char * req_prims,
+                              char * symb_section, intnat symb_section_len,
+                              char * crcs_section, intnat crcs_section_len);
 
 /* The search path for shared libraries */
 extern struct ext_table caml_shared_libs_path;

--- a/runtime/caml/startup.h
+++ b/runtime/caml/startup.h
@@ -41,6 +41,7 @@ enum { FILE_NOT_FOUND = -1, BAD_BYTECODE = -2, WRONG_MAGIC = -3, NO_FDS = -4 };
 
 extern int caml_attempt_open(char_os **name, struct exec_trailer *trail,
                              int do_open_script);
+extern int caml_read_trailer(int fd, struct exec_trailer *trail);
 extern void caml_read_section_descriptors(int fd, struct exec_trailer *trail);
 extern int32_t caml_seek_optional_section(int fd, struct exec_trailer *trail,
                                         char *name);

--- a/runtime/startup_byt.c
+++ b/runtime/startup_byt.c
@@ -206,17 +206,22 @@ int32_t caml_seek_section(int fd, struct exec_trailer *trail, char *name)
 /* Read and return the contents of the section having the given name.
    Add a terminating 0.  Return NULL if no such section. */
 
-static char * read_section(int fd, struct exec_trailer *trail, char *name)
+static char * read_section(int fd, struct exec_trailer *trail, char *name,
+                           int32_t *out_len)
 {
   int32_t len;
   char * data;
 
   len = caml_seek_optional_section(fd, trail, name);
-  if (len == -1) return NULL;
+  if (len == -1) {
+    if (out_len != NULL) *out_len = 0;
+    return NULL;
+  }
   data = caml_stat_alloc(len + 1);
   if (read(fd, data, len) != len)
     caml_fatal_error("error reading section %s", name);
   data[len] = 0;
+  if (out_len != NULL) *out_len = len;
   return data;
 }
 
@@ -245,7 +250,8 @@ static char_os * read_section_to_os(int fd, struct exec_trailer *trail,
 
 #else
 
-#define read_section_to_os read_section
+#define read_section_to_os(fd,trail,name) \
+  read_section(fd,trail,name,NULL)
 
 #endif
 
@@ -463,6 +469,8 @@ CAMLexport void caml_main(char_os **argv)
   char * req_prims;
   char_os * shared_lib_path, * shared_libs;
   char_os * exe_name, * proc_self_exe;
+  char * symb_section, * crcs_section;
+  int32_t symb_section_len, crcs_section_len;
 
   /* Determine options */
   caml_parse_ocamlrunparam();
@@ -554,9 +562,13 @@ CAMLexport void caml_main(char_os **argv)
   /* Build the table of primitives */
   shared_lib_path = read_section_to_os(fd, &trail, "DLPT");
   shared_libs = read_section_to_os(fd, &trail, "DLLS");
-  req_prims = read_section(fd, &trail, "PRIM");
+  req_prims = read_section(fd, &trail, "PRIM", NULL);
+  symb_section = read_section(fd, &trail, "SYMB", &symb_section_len);
+  crcs_section = read_section(fd, &trail, "CRCS", &crcs_section_len);
   if (req_prims == NULL) caml_fatal_error("no PRIM section");
-  caml_build_primitive_table(shared_lib_path, shared_libs, req_prims);
+  caml_init_dynlink(shared_lib_path, shared_libs, req_prims,
+                    symb_section, symb_section_len,
+                    crcs_section, crcs_section_len);
   caml_stat_free(shared_lib_path);
   caml_stat_free(shared_libs);
   caml_stat_free(req_prims);

--- a/runtime/startup_byt.c
+++ b/runtime/startup_byt.c
@@ -624,6 +624,7 @@ CAMLexport value caml_startup_code_exn(
 #endif
   caml_init_custom_operations();
   caml_init_os_params();
+  caml_ext_table_init(&caml_shared_libs_path, 8);
 
   /* Initialize the abstract machine */
   caml_init_gc ();


### PR DESCRIPTION
Dynlink startup currently re-parses the bytecode executable (via Symtable) to extract various bits of information, most of which the runtime has already gathered. This PR makes the runtime hang on to this information, and provide it directly to Dynlink startup. (The dependency between Symtable and bytecode parsing (Bytesections) caused some annoyance for @shindere in #11996, and is removed here)

For reviewers: Start by reading `bytecomp/symtable.ml` - the simplification of `init_toplevel` is the point of this patch.

(thanks @dra27 for help figuring out interactions with `-output-complete-obj` and other unusual cases of bytecode loading)