### PR TITLE
Implement leaf functions on POWER

### DIFF
--- a/Changes
+++ b/Changes
@@ -3,8 +3,9 @@ Working version
 
 ### Restored backends:
 
-- #12276: native-code compilation for POWER (64 bits, little-endian)
-  (Xavier Leroy, review by KC Sivaramakrishnan and Anil Madhavapeddy)
+- #12276, #12601: native-code compilation for POWER (64 bits, little-endian)
+  (Xavier Leroy, review by KC Sivaramakrishnan, Anil Madhavapeddy,
+   and Stephen Dolan)
 
 ### Language features:
 

--- a/asmcomp/power/emit.mlp
+++ b/asmcomp/power/emit.mlp
@@ -31,9 +31,12 @@ let reserved_stack_space = 32
 (* Layout of the stack.  The stack is kept 16-aligned. *)
 
 let initial_stack_offset f =
-  reserved_stack_space +                    (* Including the return address *)
-  size_int * f.fun_num_stack_slots.(0) +    (* Local int variables *)
-  size_float * f.fun_num_stack_slots.(1)    (* Local float variables *)
+  if f.fun_frame_required then
+    reserved_stack_space +                    (* Including the return address *)
+    size_int * f.fun_num_stack_slots.(0) +    (* Local int variables *)
+    size_float * f.fun_num_stack_slots.(1)    (* Local float variables *)
+  else
+    0
 
 let frame_size env =
   let size =
@@ -375,12 +378,8 @@ module BR = Branch_relaxation.Make (struct
 
   let offset_pc_at_branch = 1
 
-  let profiling_prologue_size = 6
-
   let prologue_size f =
-    profiling_prologue_size
-      + (if initial_stack_offset f > 0 then 1 else 0)
-      + (if f.fun_frame_required then 3 else 0)
+    if f.fun_frame_required then 4 else 0
 
   let tocload_size = 2
 

--- a/asmcomp/power/stackframe.ml
+++ b/asmcomp/power/stackframe.ml
@@ -24,8 +24,6 @@ class stackframe = object
 
 inherit Stackframegen.stackframe_generic
 
-method! frame_required _f _contains_calls = true
-
 method trap_handler_size = trap_handler_size
 
 end


### PR DESCRIPTION
Previously, a stack frame was always allocated and the return address always saved in the stack frame.  This is not necessary if the function is a leaf function (no calls to other functions) and has no stack-allocated variables.  This PR should improve speed and reduce code size for these functions.

A bit of history.  In OCaml 4, the POWER/PPC port implements leaf functions correctly in 32-bit mode.  In 64-bit mode, a stack frame is always allocated (either wrongly or because it was required by the ELF64v1 big-endian ABI), but leaf functions do not save and restore the return address.  When I adapted this port to OCaml 5, the systematic allocation of the stack frame remained, but became a systematic save/restore of the return address because of #12242 ...

I think the implementation in leaf functions in this PR is compatible with the ELF64v2 little-endian ABI that we currently use, but some OPAM-wide testing would reassure me.
