### PR TITLE
Minor dynlink cleanups

### DIFF
--- a/otherlibs/dynlink/byte/dynlink.ml
+++ b/otherlibs/dynlink/byte/dynlink.ml
@@ -15,8 +15,6 @@
 (*                                                                        *)
 (**************************************************************************)
 
-[@@@ocaml.warning "+a-4-30-40-41-42"]
-
 open! Dynlink_compilerlibs
 
 module DC = Dynlink_common

--- a/otherlibs/dynlink/byte/dynlink.ml
+++ b/otherlibs/dynlink/byte/dynlink.ml
@@ -68,7 +68,7 @@ module Bytecode = struct
   let adapt_filename f = f
 
   let num_globals_inited () =
-    Misc.fatal_error "Should never be called for bytecode dynlink"
+    failwith "Should never be called for bytecode dynlink"
 
   let fold_initial_units ~init ~f =
     List.fold_left (fun acc (compunit, interface) ->

--- a/otherlibs/dynlink/dynlink.mli
+++ b/otherlibs/dynlink/dynlink.mli
@@ -17,8 +17,6 @@
 
 (** Dynamic loading of .cmo, .cma and .cmxs files. *)
 
-[@@@ocaml.warning "+a-4-30-40-41-42"]
-
 val is_native : bool
 (** [true] if the program is native,
     [false] if the program is bytecode. *)

--- a/otherlibs/dynlink/dynlink_common.ml
+++ b/otherlibs/dynlink/dynlink_common.ml
@@ -15,8 +15,6 @@
 (*                                                                        *)
 (**************************************************************************)
 
-[@@@ocaml.warning "+a-4-30-40-41-42"]
-
 open! Dynlink_compilerlibs
 
 module String = struct

--- a/otherlibs/dynlink/dynlink_common.mli
+++ b/otherlibs/dynlink/dynlink_common.mli
@@ -15,8 +15,6 @@
 (*                                                                        *)
 (**************************************************************************)
 
-[@@@ocaml.warning "+a-4-30-40-41-42"]
-
 (** Construction of dynlink functionality given the platform-specific code. *)
 
 module Make (_ : Dynlink_platform_intf.S) : sig

--- a/otherlibs/dynlink/dynlink_platform_intf.ml
+++ b/otherlibs/dynlink/dynlink_platform_intf.ml
@@ -18,8 +18,6 @@
 (** Interface for platform-specific dynlink providers.
     Note that this file needs to be a valid .mli file. *)
 
-[@@@ocaml.warning "+a-4-30-40-41-42"]
-
 module type S = sig
   type handle
 

--- a/otherlibs/dynlink/dynlink_types.ml
+++ b/otherlibs/dynlink/dynlink_types.ml
@@ -17,8 +17,6 @@
 
 (** Types shared amongst the various parts of the dynlink code. *)
 
-[@@@ocaml.warning "+a-4-30-40-41-42"]
-
 type implem_state =
   | Loaded
   | Not_initialized

--- a/otherlibs/dynlink/dynlink_types.mli
+++ b/otherlibs/dynlink/dynlink_types.mli
@@ -17,8 +17,6 @@
 
 (** Types shared amongst the various parts of the dynlink code. *)
 
-[@@@ocaml.warning "+a-4-30-40-41-42"]
-
 type implem_state =
   | Loaded
   | Not_initialized

--- a/otherlibs/dynlink/native/dynlink.ml
+++ b/otherlibs/dynlink/native/dynlink.ml
@@ -17,8 +17,6 @@
 
 (* Dynamic loading of .cmx files *)
 
-[@@@ocaml.warning "+a-4-30-40-41-42"]
-
 open! Dynlink_compilerlibs
 
 module DC = Dynlink_common

--- a/testsuite/tests/backtrace/backtrace_dynlink.flambda.reference
+++ b/testsuite/tests/backtrace/backtrace_dynlink.flambda.reference
@@ -1,25 +1,25 @@
 Raised by primitive operation at Backtrace_dynlink_plugin in file "backtrace_dynlink_plugin.ml", line 6, characters 13-38
-Called from Dynlink.Native.run.(fun) in file "native/dynlink.ml", line 85, characters 12-29
+Called from Dynlink.Native.run.(fun) in file "native/dynlink.ml", line 83, characters 12-29
 Called from Stdlib__List.iter in file "list.ml" (inlined), line 112, characters 12-15
-Called from Dynlink.Native.run in file "native/dynlink.ml", line 84, characters 4-273
-Called from Dynlink_common.Make.load.(fun) in file "dynlink_common.ml", line 360, characters 11-54
+Called from Dynlink.Native.run in file "native/dynlink.ml", line 82, characters 4-273
+Called from Dynlink_common.Make.load.(fun) in file "dynlink_common.ml", line 358, characters 11-54
 Called from Stdlib__List.iter in file "list.ml" (inlined), line 112, characters 12-15
-Called from Dynlink_common.Make.load.(fun) in file "dynlink_common.ml" (inlined), line 356, characters 6-372
+Called from Dynlink_common.Make.load.(fun) in file "dynlink_common.ml" (inlined), line 354, characters 6-372
 Called from Stdlib__Fun.protect in file "fun.ml" (inlined), line 33, characters 8-15
-Called from Dynlink_common.Make.load in file "dynlink_common.ml", line 349, characters 4-662
-Called from Dynlink_common.Make.loadfile in file "dynlink_common.ml" (inlined), line 368, characters 26-45
+Called from Dynlink_common.Make.load in file "dynlink_common.ml", line 347, characters 4-662
+Called from Dynlink_common.Make.loadfile in file "dynlink_common.ml" (inlined), line 366, characters 26-45
 Called from Backtrace_dynlink in file "backtrace_dynlink.ml", line 39, characters 4-52
 execution of module initializers in the shared library failed: Failure("SUCCESS")
-Raised by primitive operation at Dynlink.Native.run.(fun) in file "native/dynlink.ml", line 85, characters 12-29
-Re-raised at Dynlink.Native.run.(fun) in file "native/dynlink.ml", line 87, characters 10-149
+Raised by primitive operation at Dynlink.Native.run.(fun) in file "native/dynlink.ml", line 83, characters 12-29
+Re-raised at Dynlink.Native.run.(fun) in file "native/dynlink.ml", line 85, characters 10-149
 Called from Stdlib__List.iter in file "list.ml" (inlined), line 112, characters 12-15
-Called from Dynlink.Native.run in file "native/dynlink.ml", line 84, characters 4-273
-Called from Dynlink_common.Make.load.(fun) in file "dynlink_common.ml", line 360, characters 11-54
+Called from Dynlink.Native.run in file "native/dynlink.ml", line 82, characters 4-273
+Called from Dynlink_common.Make.load.(fun) in file "dynlink_common.ml", line 358, characters 11-54
 Called from Stdlib__List.iter in file "list.ml" (inlined), line 112, characters 12-15
-Called from Dynlink_common.Make.load.(fun) in file "dynlink_common.ml" (inlined), line 356, characters 6-372
+Called from Dynlink_common.Make.load.(fun) in file "dynlink_common.ml" (inlined), line 354, characters 6-372
 Called from Stdlib__Fun.protect in file "fun.ml" (inlined), line 33, characters 8-15
-Called from Dynlink_common.Make.load in file "dynlink_common.ml", line 349, characters 4-662
+Called from Dynlink_common.Make.load in file "dynlink_common.ml", line 347, characters 4-662
 Re-raised at Stdlib__Fun.protect in file "fun.ml" (inlined), line 38, characters 6-52
-Called from Dynlink_common.Make.load in file "dynlink_common.ml", line 349, characters 4-662
-Called from Dynlink_common.Make.loadfile in file "dynlink_common.ml" (inlined), line 368, characters 26-45
+Called from Dynlink_common.Make.load in file "dynlink_common.ml", line 347, characters 4-662
+Called from Dynlink_common.Make.loadfile in file "dynlink_common.ml" (inlined), line 366, characters 26-45
 Called from Backtrace_dynlink in file "backtrace_dynlink.ml", line 39, characters 4-52

--- a/testsuite/tests/backtrace/backtrace_dynlink.reference
+++ b/testsuite/tests/backtrace/backtrace_dynlink.reference
@@ -1,18 +1,18 @@
 Raised by primitive operation at Backtrace_dynlink_plugin in file "backtrace_dynlink_plugin.ml", line 6, characters 13-38
-Called from Dynlink.Native.run.(fun) in file "native/dynlink.ml", line 85, characters 12-29
+Called from Dynlink.Native.run.(fun) in file "native/dynlink.ml", line 83, characters 12-29
 Called from Stdlib__List.iter in file "list.ml", line 112, characters 12-15
-Called from Dynlink_common.Make.load.(fun) in file "dynlink_common.ml", line 360, characters 11-54
+Called from Dynlink_common.Make.load.(fun) in file "dynlink_common.ml", line 358, characters 11-54
 Called from Stdlib__List.iter in file "list.ml", line 112, characters 12-15
 Called from Stdlib__Fun.protect in file "fun.ml", line 33, characters 8-15
-Called from Dynlink_common.Make.loadfile in file "dynlink_common.ml" (inlined), line 368, characters 26-45
+Called from Dynlink_common.Make.loadfile in file "dynlink_common.ml" (inlined), line 366, characters 26-45
 Called from Backtrace_dynlink in file "backtrace_dynlink.ml", line 39, characters 4-52
 execution of module initializers in the shared library failed: Failure("SUCCESS")
-Raised by primitive operation at Dynlink.Native.run.(fun) in file "native/dynlink.ml", line 85, characters 12-29
-Re-raised at Dynlink.Native.run.(fun) in file "native/dynlink.ml", line 87, characters 10-149
+Raised by primitive operation at Dynlink.Native.run.(fun) in file "native/dynlink.ml", line 83, characters 12-29
+Re-raised at Dynlink.Native.run.(fun) in file "native/dynlink.ml", line 85, characters 10-149
 Called from Stdlib__List.iter in file "list.ml", line 112, characters 12-15
-Called from Dynlink_common.Make.load.(fun) in file "dynlink_common.ml", line 360, characters 11-54
+Called from Dynlink_common.Make.load.(fun) in file "dynlink_common.ml", line 358, characters 11-54
 Called from Stdlib__List.iter in file "list.ml", line 112, characters 12-15
 Called from Stdlib__Fun.protect in file "fun.ml", line 33, characters 8-15
 Re-raised at Stdlib__Fun.protect in file "fun.ml", line 38, characters 6-52
-Called from Dynlink_common.Make.loadfile in file "dynlink_common.ml" (inlined), line 368, characters 26-45
+Called from Dynlink_common.Make.loadfile in file "dynlink_common.ml" (inlined), line 366, characters 26-45
 Called from Backtrace_dynlink in file "backtrace_dynlink.ml", line 39, characters 4-52

--- a/testsuite/tests/lib-dynlink-initializers/test10_main.byte.reference
+++ b/testsuite/tests/lib-dynlink-initializers/test10_main.byte.reference
@@ -3,9 +3,9 @@ Raised at Stdlib.failwith in file "stdlib.ml", line 29, characters 17-33
 Called from Test10_plugin.g in file "test10_plugin.ml", line 3, characters 2-21
 Called from Test10_plugin.f in file "test10_plugin.ml", line 6, characters 2-6
 Called from Test10_plugin in file "test10_plugin.ml", line 10, characters 2-6
-Called from Dynlink.Bytecode.run in file "byte/dynlink.ml", line 154, characters 16-25
-Re-raised at Dynlink.Bytecode.run in file "byte/dynlink.ml", line 156, characters 6-137
-Called from Dynlink_common.Make.load.(fun) in file "dynlink_common.ml", line 360, characters 11-54
+Called from Dynlink.Bytecode.run in file "byte/dynlink.ml", line 152, characters 16-25
+Re-raised at Dynlink.Bytecode.run in file "byte/dynlink.ml", line 154, characters 6-137
+Called from Dynlink_common.Make.load.(fun) in file "dynlink_common.ml", line 358, characters 11-54
 Called from Stdlib__List.iter in file "list.ml", line 112, characters 12-15
 Called from Stdlib__Fun.protect in file "fun.ml", line 33, characters 8-15
 Re-raised at Stdlib__Fun.protect in file "fun.ml", line 38, characters 6-52

--- a/testsuite/tests/lib-dynlink-initializers/test10_main.native.reference
+++ b/testsuite/tests/lib-dynlink-initializers/test10_main.native.reference
@@ -1,10 +1,10 @@
 Error: Failure("Plugin error")
-Raised by primitive operation at Dynlink.Native.run.(fun) in file "native/dynlink.ml", line 85, characters 12-29
-Re-raised at Dynlink.Native.run.(fun) in file "native/dynlink.ml", line 87, characters 10-149
+Raised by primitive operation at Dynlink.Native.run.(fun) in file "native/dynlink.ml", line 83, characters 12-29
+Re-raised at Dynlink.Native.run.(fun) in file "native/dynlink.ml", line 85, characters 10-149
 Called from Stdlib__List.iter in file "list.ml", line 112, characters 12-15
-Called from Dynlink_common.Make.load.(fun) in file "dynlink_common.ml", line 360, characters 11-54
+Called from Dynlink_common.Make.load.(fun) in file "dynlink_common.ml", line 358, characters 11-54
 Called from Stdlib__List.iter in file "list.ml", line 112, characters 12-15
 Called from Stdlib__Fun.protect in file "fun.ml", line 33, characters 8-15
 Re-raised at Stdlib__Fun.protect in file "fun.ml", line 38, characters 6-52
-Called from Dynlink_common.Make.loadfile in file "dynlink_common.ml" (inlined), line 368, characters 26-45
+Called from Dynlink_common.Make.loadfile in file "dynlink_common.ml" (inlined), line 366, characters 26-45
 Called from Test10_main in file "test10_main.ml", line 49, characters 30-87


### PR DESCRIPTION
This PR contains two independent commits. The first one stops configuring
which warnings are enabled / disabled in several dynlink source files, as
this is either redundent with what is done in the build system or not
required (warning 30).

The second commit stops relying on Misc.fatal_error and rather calls
`failwith`, as a small step towards getting rid of the dependencies of
Dynlink on the compiler internals, in coneection with the emancipatin work
done in #11996.