### PR TITLE
Minor symbol table cleanups

### DIFF
--- a/.depend
+++ b/.depend
@@ -2223,7 +2223,6 @@ bytecomp/symtable.cmo : \
     file_formats/cmo_format.cmi \
     utils/clflags.cmi \
     bytecomp/bytesections.cmi \
-    parsing/asttypes.cmi \
     bytecomp/symtable.cmi
 bytecomp/symtable.cmx : \
     lambda/runtimedef.cmx \
@@ -2238,7 +2237,6 @@ bytecomp/symtable.cmx : \
     file_formats/cmo_format.cmi \
     utils/clflags.cmx \
     bytecomp/bytesections.cmx \
-    parsing/asttypes.cmi \
     bytecomp/symtable.cmi
 bytecomp/symtable.cmi : \
     lambda/lambda.cmi \

--- a/bytecomp/symtable.ml
+++ b/bytecomp/symtable.ml
@@ -13,8 +13,6 @@
 (*                                                                        *)
 (**************************************************************************)
 
-[@@@ocaml.warning "-40"]
-
 (* To assign numbers to globals and primitives *)
 
 open Misc

--- a/bytecomp/symtable.ml
+++ b/bytecomp/symtable.ml
@@ -16,7 +16,6 @@
 (* To assign numbers to globals and primitives *)
 
 open Misc
-open Asttypes
 open Lambda
 open Cmo_format
 


### PR DESCRIPTION
This PR has two commits. The first one is in the same vein than the
first commit of #12602, removing a warning configuration from a source
file because the same configuration is already defined at the level
of the compiler's build system.

The second commit removes an unused `open Asttypes` directive. I find
it surprising that this unused open has not triggered warning 33
(unused-open) whereas this warning is not disabled.

Does this perhaps have to do with the fact that `Asttypes` is an
MIL-only module? Is it known that such modules do not trigger warning
33 when they are opened but not used? Is that an expected behaviour
or is it worth an issue?