### PR TITLE
ocamldep: use `Load_path`

### DIFF
--- a/.depend
+++ b/.depend
@@ -7140,6 +7140,7 @@ driver/makedepend.cmo : \
     parsing/parse.cmi \
     utils/misc.cmi \
     parsing/location.cmi \
+    utils/load_path.cmi \
     parsing/lexer.cmi \
     parsing/depend.cmi \
     utils/config.cmi \
@@ -7154,6 +7155,7 @@ driver/makedepend.cmx : \
     parsing/parse.cmx \
     utils/misc.cmx \
     parsing/location.cmx \
+    utils/load_path.cmx \
     parsing/lexer.cmx \
     parsing/depend.cmx \
     utils/config.cmx \

--- a/Changes
+++ b/Changes
@@ -34,6 +34,9 @@ Working version
   in the debugger
   (Pierre Boutillier and Gabriel Scherer, review by Florian Angeletti)
 
+- #12604: ocamldep: use caching from Load_path.
+  (Antonin Décimo, review by Nicolás Ojeda Bär)
+
 ### Manual and documentation:
 
 * #13975: documented the `[@remove_aliases]` built-in attribute for signatures

--- a/driver/makedepend.ml
+++ b/driver/makedepend.ml
@@ -35,8 +35,7 @@ let one_line = ref false
 let allow_approximation = ref false
 let debug = ref false
 
-(* [(dir, contents)] where [contents] is returned by [Sys.readdir dir]. *)
-let load_path = ref ([] : (string * string array) list)
+let () = Load_path.(init ~auto_include:no_auto_include) []
 let files =
   ref ([] : (string * file_kind * String.Set.t * string list) list)
 let module_map = ref String.Map.empty
@@ -61,32 +60,14 @@ let fix_slash s =
     String.map (function '\\' -> '/' | c -> c) s
   end
 
-(* Since we reinitialize load_path after reading OCAMLCOMP,
-  we must use a cache instead of calling Sys.readdir too often. *)
-let dirs = ref String.Map.empty
-let readdir dir =
-  try
-    String.Map.find dir !dirs
-  with Not_found ->
-    let contents =
-      try
-        Sys.readdir dir
-      with Sys_error msg ->
-        Format.eprintf "@[Bad -I option: %s@]@." msg;
-        Error_occurred.set ();
-        [||]
-    in
-    dirs := String.Map.add dir contents !dirs;
-    contents
-
 let add_to_load_path dir =
-  try
-    let dir = Misc.expand_directory Config.standard_library dir in
-    let contents = readdir dir in
-    prepend_to_list load_path (dir, contents)
-  with Sys_error msg ->
-    Format.eprintf "@[Bad -I option: %s@]@." msg;
-    Error_occurred.set ()
+  let path = Misc.expand_directory Config.standard_library dir in
+  match Load_path.Dir.create path with
+  | dir, None ->
+     Load_path.prepend_dir dir
+  | _, Some msg ->
+     Format.eprintf "@[Bad -I option: %s@]@." msg;
+     Error_occurred.set ()
 
 let add_to_synonym_list synonyms suffix =
   if (String.length suffix) > 1 && suffix.[0] = '.' then
@@ -96,23 +77,34 @@ let add_to_synonym_list synonyms suffix =
     Error_occurred.set ()
   end
 
+let rec is_before e e' = function
+  | [] -> raise Not_found
+  | h :: _ when h = e -> true
+  | h :: _ when h = e' -> false
+  | _ :: l -> is_before e e' l
+
 (* Find file 'name' (capitalized) in search path *)
 let find_module_in_load_path name =
-  let names = List.map (fun ext -> name ^ ext) (!mli_synonyms @ !ml_synonyms) in
-  let unames =
-    let uname = Unit_info.normalize name in
-    List.map (fun ext -> uname ^ ext) (!mli_synonyms @ !ml_synonyms)
+  let find find =
+    List.filter_map (fun ext ->
+        try Some (find (name ^ ext)) with Not_found -> None)
+      (!mli_synonyms @ !ml_synonyms)
   in
-  let rec find_in_path = function
-    | [] -> raise Not_found
-    | (dir, contents) :: rem ->
-        let mem s = List.mem s names || List.mem s unames in
-        match Array.find_opt mem contents with
-        | Some truename ->
-            if dir = Filename.current_dir_name then truename
-            else Filename.concat dir truename
-        | None -> find_in_path rem in
-  find_in_path !load_path
+  let names = find Load_path.find and unames = find Load_path.find_normalized in
+  let paths = Load_path.get_paths () in
+  let rec aux current = function
+    | [] -> current
+    | f :: tl ->
+       let dir = Filename.dirname f in
+       if dir = Filename.current_dir_name then Some (dir, Filename.basename f)
+       else match current with
+            | None -> aux (Some (dir, f)) tl
+            | Some (dir', _) ->
+               if is_before dir dir' paths then aux (Some (dir, f)) tl
+               else aux current tl
+  in
+  match aux None (names @ unames) with
+  | None -> raise Not_found | Some (_, f) -> f
 
 let find_dependency target_kind modname (byt_deps, opt_deps) =
   match find_module_in_load_path modname with
@@ -390,7 +382,7 @@ let mli_file_dependencies source_file =
 
 let process_file_as process_fun def source_file =
   Compenv.readenv stderr (Before_compile source_file);
-  load_path := [];
+  Load_path.clear ();
   let cwd = if !nocwd then [] else [Filename.current_dir_name] in
   List.iter add_to_load_path (
       (!Clflags.hidden_include_dirs @

--- a/toplevel/topdirs.ml
+++ b/toplevel/topdirs.ml
@@ -76,7 +76,7 @@ let _ = add_directive "quit" (Directive_none dir_quit)
 let dir_directory s =
   let d = expand_directory Config.standard_library s in
   Dll.add_path [d];
-  let dir = Load_path.Dir.create ~hidden:false d in
+  let dir, _error = Load_path.Dir.create ~hidden:false d in
   Load_path.prepend_dir dir;
   toplevel_env :=
     Stdlib.String.Set.fold

--- a/utils/load_path.ml
+++ b/utils/load_path.ml
@@ -74,14 +74,17 @@ let hidden_dirs = s_ref []
 let no_auto_include _ _ = raise Not_found
 let auto_include_callback = ref no_auto_include
 
+let clear () =
+  hidden_dirs := [];
+  visible_dirs := []
+
 let reset () =
   assert (not Config.merlin || Local_store.is_bound ());
   STbl.clear !hidden_files;
   STbl.clear !hidden_files_uncap;
   STbl.clear !visible_files;
   STbl.clear !visible_files_uncap;
-  hidden_dirs := [];
-  visible_dirs := [];
+  clear ();
   auto_include_callback := no_auto_include
 
 let get_visible () = List.rev !visible_dirs

--- a/utils/load_path.ml
+++ b/utils/load_path.ml
@@ -57,12 +57,13 @@ module Dir = struct
      + treat [""] as the current directory. *)
   let readdir_compat dir =
     try
-      Sys.readdir (if dir = "" then Filename.current_dir_name else dir)
-    with Sys_error _ ->
-      [||]
+      Sys.readdir (if dir = "" then Filename.current_dir_name else dir), None
+    with Sys_error msg ->
+      [||], Some msg
 
   let create ~hidden path =
-    { path; files = Array.to_list (readdir_compat path); hidden }
+    let files, error = readdir_compat path in
+    { path; files = Array.to_list files; hidden }, error
 end
 
 type auto_include_callback =
@@ -119,8 +120,10 @@ let prepend_add dir =
 
 let init ~auto_include ~visible ~hidden =
   reset ();
-  visible_dirs := List.rev_map (Dir.create ~hidden:false) visible;
-  hidden_dirs := List.rev_map (Dir.create ~hidden:true) hidden;
+  visible_dirs :=
+    List.rev_map (fun path -> Dir.create ~hidden:false path |> fst) visible;
+  hidden_dirs :=
+    List.rev_map (fun path -> Dir.create ~hidden:true path |> fst) hidden;
   List.iter prepend_add !hidden_dirs;
   List.iter prepend_add !visible_dirs;
   auto_include_callback := auto_include
@@ -166,7 +169,7 @@ let add (dir : Dir.t) =
 
 let append_dir = add
 
-let add_dir ~hidden dir = add (Dir.create ~hidden dir)
+let add_dir ~hidden dir = add (Dir.create ~hidden dir |> fst)
 
 (* Add the directory at the start of load path - so basenames are
    unconditionally added. *)
@@ -198,7 +201,8 @@ let auto_include_otherlibs =
   (* Ensure directories are only ever scanned once *)
   let expand = Misc.expand_directory Config.standard_library in
   let otherlibs =
-    let read_lib lib = lazy (Dir.create ~hidden:false (expand ("+" ^ lib))) in
+    let read_lib lib =
+      lazy (Dir.create ~hidden:false (expand ("+" ^ lib)) |> fst) in
     List.map (fun lib -> (lib, read_lib lib)) ["dynlink"; "str"; "unix"] in
   auto_include_libs otherlibs
 

--- a/utils/load_path.mli
+++ b/utils/load_path.mli
@@ -35,7 +35,10 @@ module Dir : sig
   type t
   (** Represent one directory in the load path. *)
 
-  val create : hidden:bool -> string -> t
+  val create : hidden:bool -> string -> t * string option
+  (** [create path] creates an entry in the load path. If an error
+      occurred, the directory is considered empty and an error message
+      is returned. *)
 
   val path : t -> string
 

--- a/utils/load_path.mli
+++ b/utils/load_path.mli
@@ -28,8 +28,11 @@ val add_dir : hidden:bool -> string -> unit
 val remove_dir : string -> unit
 (** Remove a directory from the load path *)
 
+val clear : unit -> unit
+(** Remove all directories, but not the internal caches. *)
+
 val reset : unit -> unit
-(** Remove all directories *)
+(** Remove all directories and internal caches. *)
 
 module Dir : sig
   type t


### PR DESCRIPTION
The referenced `OCAMLCOMP` environment variable was probably a typo, referring to `OCAMLCOMPPARAM`, later renamed to `OCAMLPARAM`. The load path is still reinitialised after the call to `Compenv.readenv`, and the caching is taken care of by `Load_path`.

Entries returned by `Load_path` need to be sorted against the include path(s) to ensure modules are not shadowed.