### PR TITLE
Ignore Emacs and Vim temporary files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,7 +38,14 @@ _ocamltestd
 .merlin
 _build
 META
+
+# VScode, Emacs, VIM temporary files
+
 .vscode
+*~
+#*#
+*.swp
+*.swo
 
 # local to root directory
 

--- a/.gitignore
+++ b/.gitignore
@@ -43,7 +43,7 @@ META
 
 .vscode
 *~
-#*#
+\#*\#
 *.swp
 *.swo
 


### PR DESCRIPTION
PR #12504 added gitignore patterns for VScode temporary files.  This PR makes sure we're equally kind towards users of Emacs and Vim, adding gitignore patterns for the temporary files of these popular editors.

For the record: I'm not happy with #12504, since I believe such editor-specific patterns should go into the user's `$HOME/.gitignore` file, not in every project.  I would prefer #12504 to be reverted and the present PR to be closed.  But if #12504 is here to stay, the present PR must be accepted.

Concerning Vim, the full story of temporary file names is complicated (https://stackoverflow.com/questions/4824188/git-ignore-vim-temporary-files), so this is just a reasonable approximation.