### PR TITLE
asmcomp/*/emit.mlp: use tabs in generated asm where appropriate

### DIFF
--- a/asmcomp/arm64/emit.mlp
+++ b/asmcomp/arm64/emit.mlp
@@ -898,10 +898,10 @@ let emit_instr env i =
         `	smulh	{emit_reg i.res.(0)}, {emit_reg i.arg.(0)}, {emit_reg i.arg.(1)}\n`
     | Lop(Iintop op) ->
         let instr = name_for_int_operation op in
-        `	{emit_string instr}     {emit_reg i.res.(0)}, {emit_reg i.arg.(0)}, {emit_reg i.arg.(1)}\n`
+        `	{emit_string instr}	{emit_reg i.res.(0)}, {emit_reg i.arg.(0)}, {emit_reg i.arg.(1)}\n`
     | Lop(Iintop_imm(op, n)) ->
         let instr = name_for_int_operation op in
-        `	{emit_string instr}     {emit_reg i.res.(0)}, {emit_reg i.arg.(0)}, #{emit_int n}\n`
+        `	{emit_string instr}	{emit_reg i.res.(0)}, {emit_reg i.arg.(0)}, #{emit_int n}\n`
     | Lop(Ifloatofint | Iintoffloat | Iabsf | Inegf | Ispecific Isqrtf as op) ->
         let instr = (match op with
                      | Ifloatofint      -> "scvtf"

--- a/asmcomp/power/emit.mlp
+++ b/asmcomp/power/emit.mlp
@@ -492,7 +492,7 @@ let emit_alloc env i bytes dbginfo far =
   if env.call_gc_label = 0 then env.call_gc_label <- new_label ();
   let offset = Domainstate.(idx_of_field Domain_young_limit) * 8 in
   `	ld	0, {emit_int offset}(30)\n`;
-  `	addi    31, 31, {emit_int(-bytes)}\n`;
+  `	addi	31, 31, {emit_int(-bytes)}\n`;
   `	cmpld	31, 0\n`;
   if not far then begin
     `	bltl-	{emit_label env.call_gc_label}\n`;
@@ -520,9 +520,9 @@ let emit_poll env i return_label far =
     end
     | Some return_label ->
       begin
-        ` bltl-  {emit_label env.call_gc_label}\n`;
+        `	bltl-	{emit_label env.call_gc_label}\n`;
         record_frame env i.live (Dbg_alloc []);
-        ` b   {emit_label return_label}\n`
+        `	b	{emit_label return_label}\n`
       end
     end;
   end else begin
@@ -530,10 +530,10 @@ let emit_poll env i return_label far =
     `	bge+	{emit_label lbl}\n`;
     `	bl	{emit_label env.call_gc_label}\n`;
     record_frame env i.live (Dbg_alloc []);
-    ` {emit_label lbl}:	\n`;
+    `{emit_label lbl}:	\n`;
     match return_label with
     | None ->   ()
-    | Some return_label -> ` b   {emit_label return_label}\n`
+    | Some return_label -> `	b	{emit_label return_label}\n`
   end
 
 let bound_error_label env dbg =
@@ -838,7 +838,7 @@ let emit_instr env i =
         `	{emit_string instr}	{emit_reg i.res.(0)}, {emit_reg i.arg.(0)}, {emit_reg i.arg.(1)}, {emit_reg i.arg.(2)}\n`
     | Lop (Idls_get) ->
         let offset = Domainstate.(idx_of_field Domain_dls_root) * 8 in
-        `	ld {emit_reg i.res.(0)}, {emit_int offset}(30)\n`
+        `	ld	{emit_reg i.res.(0)}, {emit_int offset}(30)\n`
     | Lop (Ireturn_addr) ->
         invalid_arg (
           "Support for Ireturn_addr is not implemented on architecture "
@@ -925,7 +925,7 @@ let emit_instr env i =
         adjust_stack_offset env trap_size;
         `	std	29, {emit_int reserved_stack_space}(1)\n`;
         emit_tocload emit_gpr 29 (TocLabel lbl_handler);
-        `	std     29, {emit_int (reserved_stack_space + 8)}(1)\n`;
+        `	std	29, {emit_int (reserved_stack_space + 8)}(1)\n`;
         `	addi	29, 1, {emit_int reserved_stack_space}\n`
     | Lpoptrap ->
         `	ld	29, {emit_int reserved_stack_space}(1)\n`;
@@ -944,7 +944,7 @@ let emit_instr env i =
         | Lambda.Raise_notrace ->
             `	ld	0, 8(29)\n`;
             `	addi	1, 29, {emit_int (trap_size - reserved_stack_space)}\n`;
-            `	mtctr   0\n`;
+            `	mtctr	0\n`;
             `	ld	29, {emit_int (reserved_stack_space - trap_size)}(1)\n`;
             `	bctr\n`
         end

--- a/asmcomp/riscv/emit.mlp
+++ b/asmcomp/riscv/emit.mlp
@@ -99,10 +99,10 @@ let emit_reg r =
 let emit_stack_adjustment n =
   if n <> 0 then begin
     if is_immediate n then
-      `        addi    sp, sp, {emit_int n}\n`
+      `	addi	sp, sp, {emit_int n}\n`
     else begin
-      `        li      {emit_reg reg_tmp}, {emit_int n}\n`;
-      `        add     sp, sp, {emit_reg reg_tmp}\n`
+      `	li	{emit_reg reg_tmp}, {emit_int n}\n`;
+      `	add	sp, sp, {emit_reg reg_tmp}\n`
     end;
     cfi_adjust_cfa_offset (-n)
   end
@@ -274,7 +274,7 @@ let emit_instr env i =
       if src.loc <> dst.loc then begin
         match (src, dst) with
         | {loc = Reg _; typ = (Val | Int | Addr)}, {loc = Reg _} ->
-            `	mv      {emit_reg dst}, {emit_reg src}\n`
+            `	mv	{emit_reg dst}, {emit_reg src}\n`
         | {loc = Reg _; typ = Float}, {loc = Reg _; typ = Float} ->
             `	fmv.d   {emit_reg dst}, {emit_reg src}\n`
         | {loc = Reg _; typ = Float}, {loc = Reg _; typ = (Val | Int | Addr)} ->
@@ -431,8 +431,8 @@ let emit_instr env i =
       begin match return_label with
       | None -> `	bltu	{emit_reg reg_alloc_ptr}, {emit_reg reg_tmp}, {emit_label lbl_call_gc}\n`;
                 `{emit_label lbl_after_poll}:\n`;
-      | Some lbl -> ` bgeu  {emit_reg reg_alloc_ptr}, {emit_reg reg_tmp}, {emit_label lbl}\n`;
-                    ` j {emit_label lbl_call_gc}\n`
+      | Some lbl -> `	bgeu	{emit_reg reg_alloc_ptr}, {emit_reg reg_tmp}, {emit_label lbl}\n`;
+                    `	j	{emit_label lbl_call_gc}\n`
       end;
       env.call_gc_sites <-
         { gc_lbl = lbl_call_gc;

--- a/asmcomp/s390x/emit.mlp
+++ b/asmcomp/s390x/emit.mlp
@@ -367,8 +367,8 @@ let emit_instr env i =
 
     | Lop(Iextcall {func; alloc; stack_ofs}) ->
         if stack_ofs > 0 then begin
-          ` lgr {emit_reg reg_stack_arg_begin}, %r15\n`;
-          ` lay {emit_reg reg_stack_arg_end}, {emit_int stack_ofs}(%r15)\n`;
+          `	lgr	{emit_reg reg_stack_arg_begin}, %r15\n`;
+          `	lay	{emit_reg reg_stack_arg_end}, {emit_int stack_ofs}(%r15)\n`;
           emit_load_symbol_addr reg_r7 func;
           emit_call "caml_c_call_stack_args";
           `{record_frame env i.live (Dbg_other i.dbg)}\n`
@@ -378,16 +378,16 @@ let emit_instr env i =
           `{record_frame env i.live (Dbg_other i.dbg)}\n`
         end else begin
           (* Save OCaml SP in C callee-save register *)
-          ` lgr %r12, %r15\n`;
+          `	lgr	%r12, %r15\n`;
           cfi_remember_state ();
           cfi_def_cfa_register "%r12";
           (* NB: gdb has asserts on contiguous stacks that mean it
              will not unwind through this unless we were to tag this
              calling frame with cfi_signal_frame in it's definition. *)
           let offset = Domainstate.(idx_of_field Domain_c_stack) * 8 in
-          ` lg %r15, {emit_int offset}(%r10)\n`;
+          `	lg	%r15, {emit_int offset}(%r10)\n`;
           emit_call func;
-          ` lgr %r15, %r12\n`;
+          `	lgr	%r15, %r12\n`;
           cfi_restore_state ()
         end
 
@@ -431,11 +431,11 @@ let emit_instr env i =
           let lbl_after_alloc = new_label () in
           let lbl_call_gc = new_label () in
           let offset = Domainstate.(idx_of_field Domain_young_limit) * 8 in
-          `	lay     %r11, {emit_int(-n)}(%r11)\n`;
+          `	lay	%r11, {emit_int(-n)}(%r11)\n`;
           `	clg	%r11, {emit_int offset}(%r10)\n`;
-          `	brcl    4, {emit_label lbl_call_gc}\n`;  (* less than *)
+          `	brcl	4, {emit_label lbl_call_gc}\n`;  (* less than *)
           `{emit_label lbl_after_alloc}:`;
-          `	la      {emit_reg i.res.(0)}, 8(%r11)\n`;
+          `	la	{emit_reg i.res.(0)}, 8(%r11)\n`;
           env.call_gc_sites <-
             { gc_lbl = lbl_call_gc;
               gc_return_lbl = lbl_after_alloc;
@@ -446,11 +446,11 @@ let emit_instr env i =
           | 24 -> `	{emit_call "caml_alloc2"}\n`
           | 32 -> `	{emit_call "caml_alloc3"}\n`
           | _  ->
-              `	lay     %r11, {emit_int(-n)}(%r11)\n`;
+              `	lay	%r11, {emit_int(-n)}(%r11)\n`;
               `	{emit_call "caml_allocN"}\n`
           end;
           `{emit_label lbl_frame_lbl}:\n`;
-          `	la      {emit_reg i.res.(0)}, 8(%r11)\n`
+          `	la	{emit_reg i.res.(0)}, 8(%r11)\n`
         end
 
     | Lop(Ipoll { return_label }) ->
@@ -464,8 +464,8 @@ let emit_instr env i =
           record_frame_label env i.live (Dbg_alloc [])
         in
         begin match return_label with
-        | None -> `	brcl    4, {emit_label lbl_call_gc}\n`;  (* less than *)
-        | Some return_label -> `	brcl    10, {emit_label return_label}\n`;  (* greater or equal *)
+        | None -> `	brcl	4, {emit_label lbl_call_gc}\n`;  (* less than *)
+        | Some return_label -> `	brcl	10, {emit_label return_label}\n`;  (* greater or equal *)
         end;
         env.call_gc_sites <-
           { gc_lbl = lbl_call_gc;
@@ -473,7 +473,7 @@ let emit_instr env i =
             gc_frame_lbl = lbl_frame; } :: env.call_gc_sites;
         begin match return_label with
         | None -> `{emit_label label_after_gc}:`;
-        | Some _ -> `	brcl    15, {emit_label lbl_call_gc}\n`;  (* unconditional *)
+        | Some _ -> `	brcl	15, {emit_label lbl_call_gc}\n`;  (* unconditional *)
         end
     | Lop(Iintop Imulh) ->
        (* Hacker's Delight section 8.3:
@@ -731,9 +731,9 @@ let fundecl fundecl =
     let threshold_offset = Domainstate.stack_ctx_words * 8 + stack_threshold_size in
     let f = max_frame_size + threshold_offset in
     let offset = Domainstate.(idx_of_field Domain_current_stack) * 8 in
-    `  lay %r1, {emit_int (-f)}(%r15)\n`;
-    `  clg %r1, {emit_int offset}(%r10)\n`;
-    `  brcl 4, {emit_label overflow}\n`;
+    `	lay	%r1, {emit_int (-f)}(%r15)\n`;
+    `	clg	%r1, {emit_int offset}(%r10)\n`;
+    `	brcl	4, {emit_label overflow}\n`;
     `{emit_label ret}:\n`;
     handle_overflow := Some (overflow, ret);
   end;
@@ -749,13 +749,13 @@ let fundecl fundecl =
   | Some (overflow,ret) -> begin
       `{emit_label overflow}:\n`;
       let s = (Config.stack_threshold + max_frame_size / 8) in
-      `  lay  %r15, -8(%r15)\n`;
-      `  stg  %r14, 0(%r15)\n`;
-      `  lgfi %r12, {emit_int s}\n`;
-      `  brasl %r14, {emit_symbol "caml_call_realloc_stack"}\n`;
-      `  lg   %r14, 0(%r15)\n`;
-      `  la  %r15, 8(%r15)\n`;
-      `  brcl 15, {emit_label ret}\n`
+      `	lay	%r15, -8(%r15)\n`;
+      `	stg	%r14, 0(%r15)\n`;
+      `	lgfi	%r12, {emit_int s}\n`;
+      `	brasl	%r14, {emit_symbol "caml_call_realloc_stack"}\n`;
+      `	lg	%r14, 0(%r15)\n`;
+      `	la	%r15, 8(%r15)\n`;
+      `	brcl	15, {emit_label ret}\n`
     end
   end;
 


### PR DESCRIPTION
We try to stick to the format  `<TAB>opcode<TAB>arguments`, as it produces asm files that are both legible and small (one tabs = up to 8 spaces). 

While reading the Power emitter once more, I noticed a few wrong uses of spaces instead of tabs.  Then I wrote a script to fix them, and ran it on all the emitters, resulting in this PR.  This is literally a whitespace-only change.