### PR TITLE
Remove the dependency of the cmo and cmxs file formats on compiler internals

### DIFF
--- a/.depend
+++ b/.depend
@@ -4006,8 +4006,7 @@ file_formats/cmi_format.cmx : \
 file_formats/cmi_format.cmi : \
     typing/types.cmi \
     utils/misc.cmi
-file_formats/cmo_format.cmi : \
-    utils/misc.cmi
+file_formats/cmo_format.cmi :
 file_formats/cmt_format.cmo : \
     parsing/unit_info.cmi \
     typing/types.cmi \
@@ -4051,8 +4050,7 @@ file_formats/cmx_format.cmi : \
     utils/misc.cmi \
     middle_end/flambda/export_info.cmi \
     middle_end/clambda.cmi
-file_formats/cmxs_format.cmi : \
-    utils/misc.cmi
+file_formats/cmxs_format.cmi :
 file_formats/linear_format.cmo : \
     utils/misc.cmi \
     parsing/location.cmi \

--- a/file_formats/cmo_format.mli
+++ b/file_formats/cmo_format.mli
@@ -15,7 +15,8 @@
 
 (* Symbol table information for .cmo and .cma files *)
 
-open Misc
+type modname = string
+type crcs = (modname * Digest.t option) list
 
 (* Names of compilation units as represented in CMO files *)
 type compunit = Compunit of string [@@unboxed]

--- a/file_formats/cmx_format.mli
+++ b/file_formats/cmx_format.mli
@@ -17,7 +17,7 @@
 (*                                                                        *)
 (**************************************************************************)
 
-(* Format of .cmx, .cmxa and .cmxs files *)
+(* Format of .cmx and .cmxa files *)
 
 open Misc
 

--- a/file_formats/cmxs_format.mli
+++ b/file_formats/cmxs_format.mli
@@ -15,7 +15,8 @@
 
 (* Format of .cmxs files *)
 
-open Misc
+type modname = string
+type crcs = (modname * Digest.t option) list
 
 (* Each .cmxs dynamically-loaded plugin contains a symbol
    "caml_plugin_header" containing the following info


### PR DESCRIPTION
This small PR has to be understood in the context of the dynlink emancipation
work (#11996).

It removes the dependency of the Cmo_format and Cmxs_format modules on the
internal Misc module by unfolding the definitions for the `modname`
and `crcs` types.

It is worth pointing out that the other file formats do not need to be made
independent of compiler internals in the dynlink emancipation context
because they cannot be loaded by dynlink.