### PR TITLE
Make ocamlc/ocamlopt fail when not given input files

### DIFF
--- a/Changes
+++ b/Changes
@@ -221,6 +221,10 @@ Working version
 - #12615: ocamldoc: get rid of the odoc_literate and odoc_todo generators.
   (Sébaistien Hinderer, review by Gabriel Scherer and Florian Angeletti)
 
+* #12497, #12613: Make ocamlc/ocamlopt fail with an error when no
+  input files are specified to build an executable.
+  (Antonin Décimo, review by Sébastien Hinderer)
+
 ### Manual and documentation:
 
 - #12338: clarification of the documentation of process related function in

--- a/driver/compenv.ml
+++ b/driver/compenv.ml
@@ -687,10 +687,14 @@ let process_deferred_actions env =
             fatal "Options -c -o are incompatible with compiling multiple files"
         end;
   end;
-  if !make_archive && List.exists (function
-      | ProcessOtherFile name -> Filename.check_suffix name ".cmxa"
-      | _ -> false) !deferred_actions then
-    fatal "Option -a cannot be used with .cmxa input files.";
+  if !make_archive then begin
+    if List.exists (function
+        | ProcessOtherFile name -> Filename.check_suffix name ".cmxa"
+        | _ -> false) !deferred_actions then
+      fatal "Option -a cannot be used with .cmxa input files."
+    end
+  else if !deferred_actions = [] then
+    fatal "No input files";
   List.iter (process_action env) (List.rev !deferred_actions);
   output_name := final_output_name;
   stop_early :=

--- a/driver/compenv.ml
+++ b/driver/compenv.ml
@@ -647,7 +647,7 @@ let process_action
         | Some start_from ->
           Location.input_name := name;
           impl ~start_from name
-        | None -> raise(Arg.Bad("don't know what to do with " ^ name))
+        | None -> raise(Arg.Bad("Don't know what to do with " ^ name))
 
 
 let action_of_file name =

--- a/testsuite/tests/tool-command-line/test-no-input-file.compilers.reference
+++ b/testsuite/tests/tool-command-line/test-no-input-file.compilers.reference
@@ -1,0 +1,2 @@
+No input files
+No input files

--- a/testsuite/tests/tool-command-line/test-no-input-file.ml
+++ b/testsuite/tests/tool-command-line/test-no-input-file.ml
@@ -1,0 +1,16 @@
+(* TEST
+ setup-ocamlopt.opt-build-env;
+ all_modules = "";
+ compile_only = "true";
+ ocamlopt_opt_exit_status = "2";
+ flags = "";
+ ocamlopt.opt;
+ flags = "-o test.exe";
+ ocamlopt.opt;
+ check-ocamlopt.opt-output;
+*)
+
+(*
+  This file is just a test driver, the test does not contain any
+  real OCaml code
+ *)

--- a/testsuite/tests/tool-command-line/test-unknown-file.compilers.reference
+++ b/testsuite/tests/tool-command-line/test-unknown-file.compilers.reference
@@ -1,1 +1,1 @@
-don't know what to do with unknown-file
+Don't know what to do with unknown-file


### PR DESCRIPTION
An invocation such as `ocamlc` (without any command-line parameters), or `ocamlc -o a.out` will now fail with an error message and an error code.

cc @shindere who reviewed the PR offline
fixes #12497 