### PR TITLE
Runtime code refactoring: `domain_is_foo`

### DIFF
--- a/otherlibs/unix/fork.c
+++ b/otherlibs/unix/fork.c
@@ -36,7 +36,7 @@ void caml_atfork_child(void) {
 CAMLprim value caml_unix_fork(value unit)
 {
   int ret;
-  if (caml_domain_is_multicore()) {
+  if (caml_runtime_is_multicore()) {
     caml_failwith
       ("Unix.fork may not be called after any domain has been spawned");
   }

--- a/runtime/afl.c
+++ b/runtime/afl.c
@@ -126,8 +126,8 @@ CAMLexport value caml_setup_afl(value unit)
   afl_read();
 
   /* ensure that another module has not already spawned a domain */
-  if (caml_domain_is_multicore())
-    caml_fatal_error("afl-fuzz: cannot fork with multiple domains running");
+  if (caml_runtime_is_multicore())
+    caml_fatal_error("afl-fuzz: cannot fork after domains have spawned");
 
   while (1) {
     int child_pid = fork();

--- a/runtime/caml/domain.h
+++ b/runtime/caml/domain.h
@@ -70,10 +70,21 @@ void caml_interrupt_all_signal_safe(void);
 void caml_reset_young_limit(caml_domain_state *);
 void caml_update_young_limit_after_c_call(caml_domain_state *);
 
+/* returns [1] if a second domain has ever been spawned,
+   and in particular some backup threads may be running.
+
+   This is a stricter condition than [caml_domain_alone] below,
+   which returns [1] when other domains have been spawned
+   and then terminated.
+
+   [caml_runtime_is_multicore] can be used as an approximation for 'is
+   forking safe without hassle?'.
+*/
+CAMLextern intnat caml_runtime_is_multicore(void);
+
 CAMLextern void caml_reset_domain_lock(void);
 CAMLextern int caml_bt_is_in_blocking_section(void);
 CAMLextern int caml_bt_is_self(void);
-CAMLextern intnat caml_domain_is_multicore (void);
 CAMLextern void caml_bt_enter_ocaml(void);
 CAMLextern void caml_bt_exit_ocaml(void);
 CAMLextern void caml_acquire_domain_lock(void);

--- a/runtime/caml/domain.h
+++ b/runtime/caml/domain.h
@@ -132,7 +132,7 @@ int caml_global_barrier_is_final(barrier_status);
 void caml_global_barrier_end(barrier_status);
 int caml_global_barrier_num_domains(void);
 
-int caml_domain_is_terminating(void);
+int caml_domain_is_terminating(caml_domain_state *);
 
 #endif /* CAML_INTERNALS */
 

--- a/runtime/caml/domain.h
+++ b/runtime/caml/domain.h
@@ -98,7 +98,7 @@ Caml_inline intnat caml_domain_alone(void)
 }
 
 #ifdef DEBUG
-int caml_domain_is_in_stw(void);
+int caml_domain_is_in_stw(caml_domain_state *);
 #endif
 
 int caml_try_run_on_all_domains_with_spin_work(

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -1368,8 +1368,8 @@ static void stw_handler(caml_domain_state* domain)
 
 
 #ifdef DEBUG
-int caml_domain_is_in_stw(void) {
-  return Caml_state->inside_stw_handler;
+int caml_domain_is_in_stw(caml_domain_state *domain) {
+  return domain->inside_stw_handler;
 }
 #endif
 

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -1835,10 +1835,14 @@ static void handover_finalisers(caml_domain_state* domain_state)
   caml_final_domain_terminate(domain_state);
 }
 
-int caml_domain_is_terminating (void)
+Caml_inline int dom_internal_is_terminating (dom_internal *dom)
 {
-  struct interruptor* s = &domain_self->interruptor;
-  return s->terminating;
+  return dom->interruptor.terminating;
+}
+
+int caml_domain_is_terminating (caml_domain_state *domain_state)
+{
+  return dom_internal_is_terminating(&all_domains[domain_state->id]);
 }
 
 static void domain_terminate (void)

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -402,7 +402,7 @@ void caml_adopt_orphaned_work (void)
   value orph_ephe_list_live, last;
   struct caml_final_info *f, *myf, *temp;
 
-  if (no_orphaned_work() || caml_domain_is_terminating())
+  if (no_orphaned_work() || caml_domain_is_terminating(domain_state))
     return;
 
   caml_plat_lock(&orphaned_lock);

--- a/runtime/minor_gc.c
+++ b/runtime/minor_gc.c
@@ -732,7 +732,7 @@ caml_stw_empty_minor_heap_no_major_slice(caml_domain_state* domain,
 {
 #ifdef DEBUG
   uintnat* initial_young_ptr = (uintnat*)domain->young_ptr;
-  CAMLassert(caml_domain_is_in_stw());
+  CAMLassert(caml_domain_is_in_stw(domain));
 #endif
 
   if( participating[0] == Caml_state ) {
@@ -791,7 +791,7 @@ void caml_empty_minor_heap_no_major_slice_from_stw(caml_domain_state* domain,
 int caml_try_stw_empty_minor_heap_on_all_domains (void)
 {
   #ifdef DEBUG
-  CAMLassert(!caml_domain_is_in_stw());
+  CAMLassert(!caml_domain_is_in_stw(Caml_state));
   #endif
 
   caml_gc_log("requesting stw empty_minor_heap");
@@ -810,7 +810,7 @@ void caml_empty_minor_heaps_once (void)
   uintnat saved_minor_cycle = atomic_load(&caml_minor_cycles_started);
 
   #ifdef DEBUG
-  CAMLassert(!caml_domain_is_in_stw());
+  CAMLassert(!caml_domain_is_in_stw(Caml_state));
   #endif
 
   /* To handle the case where multiple domains try to execute a minor gc


### PR DESCRIPTION
TL;DR: This is a refactoring PR that was prompted by a comment of @kayceesrk when reviewing #12597.

In #12597 I needed a version of `caml_domain_is_terminating(void)` that takes a `caml_domain_state *` as parameter, because I need to ask "are we in the process of terminating?" within a function that is itself parametrized on the domain state. (In fact that function is only ever called with the current domain, but that is another story.)
I considered simply changing `caml_domain_is_terminating(void)` to take a `caml_domain_state *` parameter, but there are other `caml_domain_is_foo` functions and they all take no arguments, so this would have been inconsistent. I chose instead to introduce another function `caml_domain_terminating(caml_domain_state *)` in addition to the existing one.

@kayceesrk suggested in review to push back and move to the `caml_domain_is_terminating(caml_domain_state *)` version. In the present PR, I do this, but I also change the other `caml_domain_is_foo` functions for consistency. The result is a non-trivial refactoring PR:

1. `caml_domain_is_in_stw` now takes a `caml_domain_state *` parameter, this was a trivial change
2. `caml_domain_is_terminating` now takes a `caml_domain_state *` parameter, this is a simple change which is needed for #12597 anyway
3. The hard one is `caml_domain_is_multicore(void)`. It does not really make sense to make it a domain-parametrized function, as this is a global property of the runtime, not of a single given domain. (But then currently the code does not work if it is not called from an OCaml domain thread). So I renamed it to `caml_runtime_is_multicore` *and* changed the implementation to be simpler, and safe to call from any domain. (We just have a global atomic boolean in the runtime to remember if `spawn` was ever called.)
4. I left `caml_domain_alone()`... alone for now because it is used in several places in the standard library, making any change there more invasive (I think it could be called `caml_runtime_is_single_domain` instead).

I am left wondering whether the change is worth it. The result is certainly more consistent / a slightly nicer API, but this is some amount of small code churn, and the change of implementation of `caml_domain_is_multicore` has the potential for hidden surprises.

I would propose to let @kayceesrk judge this, if he has the time to look at the PR.

Note: `caml_domain_is_multicore` returns an `intnat`, while `caml_domain_is_in_stw` and `caml_domain_is_terminating` returns an `int`. I don't know if the inconsistency is intentional or not, and left it alone with no change. (I wish we had a boolean type defined in the runtime.)