### PR TITLE
Make tests/parallel/catch_break.ml more robust

### DIFF
--- a/testsuite/tests/parallel/catch_break.ml
+++ b/testsuite/tests/parallel/catch_break.ml
@@ -68,6 +68,9 @@ let rec wait n =
     wait n
   )
 
+(* We busy-wait because other synchronisation mechanisms involve
+   blocking calls, which may exercise other parts of the async
+   callback implementation than we want.*)
 let break_trap s =
   begin
     try Atomic.incr ready_count; while true do () done

--- a/testsuite/tests/parallel/catch_break.ml
+++ b/testsuite/tests/parallel/catch_break.ml
@@ -9,6 +9,27 @@ not-windows;
 }
 *)
 
+(* PR #11307. The following program deadlocks when input in the
+   toplevel and interrupted by the user with Ctrl-C, by busy-waiting
+   on signals to be processed.
+
+   {[
+let break_trap s =
+  (try while true do () done
+   with Sys.Break -> print_endline "[Sys.Break caught]" ) ;
+  print_endline s
+
+let () =
+  Sys.catch_break true ;
+  let d = Domain.spawn (fun () -> break_trap "Domain 1") in
+  break_trap "Domain 0 - 1" ;
+  Domain.join d ;
+  break_trap  "Domain 0 - 2";
+  print_endline "Success."
+   ]}
+
+*)
+
 let verbose = false
 
 (* Expected when verbose (depending on scheduling and platform):
@@ -23,43 +44,65 @@ Success.
 
 *)
 
+let delay = 0.001 (* 1 ms *)
+let fuel = Atomic.make 1000 (* 1s *)
+
 let print = if verbose then print_endline else fun _ -> ()
+
+let ready_count = Atomic.make 0
+
+(* Does not poll *)
+
+let sleep () =
+  if Atomic.get fuel <= 0 then (
+    print "[Reached max attempts without succeeding]";
+    Unix._exit 1
+  );
+  Atomic.decr fuel;
+  Unix.sleepf delay
+
+let rec wait n =
+  if Atomic.get ready_count <> n then (
+    sleep ();
+    wait n
+  )
 
 let break_trap s =
   begin
-    try while true do () done
-    with Sys.Break -> print "[Sys.Break caught]";
+    try Atomic.incr ready_count; while true do () done
+    with Sys.Break -> print "[Sys.Break caught]"
   end;
-  print s
+  print s;
+  Atomic.decr ready_count
+
+(* Simulate repeated Ctrl-C *)
+let interruptor_domain () =
+  Domain.spawn @@ fun () ->
+  ignore (Thread.sigmask Unix.SIG_BLOCK [Sys.sigint]);
+  let kill () = sleep () ; Unix.kill (Unix.getpid ()) Sys.sigint in
+  wait 2;
+  kill ();
+  wait 1;
+  kill ();
+  wait 2;
+  kill ()
 
 let run () =
-  (* Goal: joining the domain [d] must be achievable by Ctrl-C *)
-  let d = Domain.spawn (fun () -> break_trap "Domain 1")
-  in
-  let finished = Atomic.make false in
-  (* Simulate repeated Ctrl-C *)
-  let d2 = Domain.spawn (fun () ->
-    ignore (Thread.sigmask Unix.SIG_BLOCK [Sys.sigint]);
-    let pid = Unix.getpid () in
-    let rec kill n =
-      if n = 0 then (
-        print "[Kill thread reached max attempts without succeeding]";
-        Unix._exit 1
-      );
-      Unix.sleepf 0.05;
-      Unix.kill pid Sys.sigint;
-      if not (Atomic.get finished) then kill (n - 1)
-    in
-    kill 10)
-  in
+  (* We simulate the user pressing Ctrl-C repeatedly. Goal: joining
+     the domain [d] must be achievable by Ctrl-C. This tests proper
+     reception of SIGINT. *)
+  let d = Domain.spawn (fun () -> break_trap "Domain 1") in
+  let d2 = interruptor_domain () in
   break_trap "Domain 0 - 1";
   Domain.join d;
+  assert (Atomic.get ready_count = 0);
+  Atomic.incr ready_count;
   break_trap "Domain 0 - 2";
-  Atomic.set finished true;
   Domain.join d2
 
 let () =
   Sys.catch_break true;
-  (try run () with Sys.Break -> ());
-  (try print "Success." with Sys.Break -> ());
+  (try run () with Sys.Break ->
+     print "Test could not complete due to scheduling hazard.");
+  print "Success.";
   exit 0


### PR DESCRIPTION
Attempted fix for #12614: false positives with tests/parallel/catch_break.ml.

Only send exceptions when the domains are ready; do not send more exceptions than necessary.

I believe this eliminates false positives, and leaves false negatives as the only possible scheduling hazard.