### PR TITLE
[refactoring] runtime: define and enforce naming conventions for STW functions

### DIFF
--- a/Changes
+++ b/Changes
@@ -357,6 +357,10 @@ Working version
 - #12532, #12553: improve readability of the pattern-matching debug output
   (Gabriel Scherer, review by Thomas Refis)
 
+- #12169: runtime: document and enforce naming conventions around STW sections.
+  (Gabriel Scherer, review by Enguerrand Decorne, Miod Vallat, B. Szilvasy
+   and Nick Barnes, report by KC Sivaramakrishnan)
+
 ### Build system:
 
 - #12198, #12321: continue the merge of the sub-makefiles into the root Makefile

--- a/runtime/caml/codefrag.h
+++ b/runtime/caml/codefrag.h
@@ -87,9 +87,8 @@ extern struct code_fragment *
    Returns NULL if the code fragment was registered with [DIGEST_IGNORE]. */
 extern unsigned char * caml_digest_of_code_fragment(struct code_fragment *);
 
-/* Cleans up (and frees) removed code fragments. Must be called from a stop the
-   world pause by only a single thread. */
-extern void caml_code_fragment_cleanup(void);
+/* Cleans up (and frees) removed code fragments. */
+extern void caml_code_fragment_cleanup_from_stw_single(void);
 
 #endif
 

--- a/runtime/caml/minor_gc.h
+++ b/runtime/caml/minor_gc.h
@@ -74,7 +74,7 @@ extern void caml_set_minor_heap_size (asize_t); /* size in bytes */
 extern void caml_empty_minor_heap_no_major_slice_from_stw
   (caml_domain_state* domain, void* unused, int participating_count,
     caml_domain_state** participating); /* in STW */
-extern int caml_try_stw_empty_minor_heap_on_all_domains(void); /* out STW */
+extern int caml_try_empty_minor_heap_on_all_domains(void); /* out STW */
 extern void caml_empty_minor_heaps_once(void); /* out STW */
 void caml_alloc_small_dispatch (caml_domain_state* domain,
                                 intnat wosize, int flags,

--- a/runtime/caml/shared_heap.h
+++ b/runtime/caml/shared_heap.h
@@ -88,18 +88,14 @@ void caml_redarken_pool(struct pool*, scanning_action, void*);
 
 intnat caml_sweep(struct caml_heap_state*, intnat);
 
-
-/* must be called during STW */
-void caml_cycle_heap_stw(void);
+void caml_cycle_heap_from_stw_single(void);
 
 /* must be called on each domain
-   (after caml_cycle_heap_stw) */
+   (after caml_cycle_heap_from_stw_single) */
 void caml_cycle_heap(struct caml_heap_state*);
 
 /* Heap invariant verification (for debugging) */
-
-/* caml_verify_heap must only be called while all domains are paused */
-void caml_verify_heap(caml_domain_state *domain);
+void caml_verify_heap_from_stw(caml_domain_state *domain);
 
 #ifdef DEBUG
 /* [is_garbage(v)] returns true if [v] is a garbage value */

--- a/runtime/codefrag.c
+++ b/runtime/codefrag.c
@@ -160,7 +160,7 @@ caml_find_code_fragment_by_digest(unsigned char digest[16]) {
 }
 
 /* This is only ever called from a stw by one domain */
-void caml_code_fragment_cleanup (void)
+void caml_code_fragment_cleanup_from_stw_single (void)
 {
   struct code_fragment_garbage *curr;
 

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -753,7 +753,7 @@ CAMLexport void caml_reset_domain_lock(void)
 
 /* minor heap initialization and resizing */
 
-static void reserve_minor_heaps(void) {
+static void reserve_minor_heaps_from_stw_single(void) {
   void* heaps_base;
   uintnat minor_heap_reservation_bsize;
   uintnat minor_heap_max_bsz;
@@ -790,7 +790,7 @@ static void reserve_minor_heaps(void) {
   }
 }
 
-static void unreserve_minor_heaps(void) {
+static void unreserve_minor_heaps_from_stw_single(void) {
   uintnat size;
 
   caml_gc_log("unreserve_minor_heaps");
@@ -842,16 +842,16 @@ static void stw_resize_minor_heap_reservation(caml_domain_state* domain,
     caml_gc_log("stw_resize_minor_heap_reservation: "
                 "unreserve_minor_heaps");
 
-    unreserve_minor_heaps();
+    unreserve_minor_heaps_from_stw_single();
     /* new_minor_wsz is page-aligned because caml_norm_minor_heap_size has
        been called to normalize it earlier.
     */
     caml_minor_heap_max_wsz = new_minor_wsz;
     caml_gc_log("stw_resize_minor_heap_reservation: reserve_minor_heaps");
-    reserve_minor_heaps();
-    /* The call to [reserve_minor_heaps] makes a new reservation,
-       and it also updates the reservation boundaries of each domain
-       by mutating its [minor_heap_area_start{,_end}] variables.
+    reserve_minor_heaps_from_stw_single();
+    /* The call to [reserve_minor_heaps_from_stw_single] makes a new
+       reservation, and it also updates the reservation boundaries of each
+       domain by mutating its [minor_heap_area_start{,_end}] variables.
 
        These variables are synchronized by the fact that we are inside
        a STW section: no other domains are running in parallel, and
@@ -887,7 +887,9 @@ void caml_update_minor_heap_max(uintnat requested_wsz) {
 void caml_init_domains(uintnat minor_heap_wsz) {
   int i;
 
-  reserve_minor_heaps();
+  reserve_minor_heaps_from_stw_single();
+  /* stw_single: mutators and domains have not started yet. */
+
   for (i = 0; i < Max_domains; i++) {
     struct dom_internal* dom = &all_domains[i];
 

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -1652,10 +1652,11 @@ Caml_inline void advance_global_major_slice_epoch (caml_domain_state* d)
   }
 }
 
-static void global_major_slice_callback (caml_domain_state *domain,
-                                         void *unused,
-                                         int participating_count,
-                                         caml_domain_state **participating)
+static void stw_global_major_slice(
+  caml_domain_state *domain,
+  void *unused,
+  int participating_count,
+  caml_domain_state **participating)
 {
   domain->requested_major_slice = 1;
   /* Nothing else to do, as [stw_hander] will call [caml_poll_gc_work]
@@ -1710,7 +1711,7 @@ void caml_poll_gc_work(void)
 
   if (d->requested_global_major_slice) {
     if (caml_try_run_on_all_domains_async(
-          &global_major_slice_callback, NULL, NULL)){
+          &stw_global_major_slice, NULL, NULL)){
       d->requested_global_major_slice = 0;
     }
     /* If caml_try_run_on_all_domains_async fails, we'll try again next time

--- a/runtime/frame_descriptors.c
+++ b/runtime/frame_descriptors.c
@@ -180,7 +180,7 @@ typedef struct frametable_array {
   int ntables;
 } frametable_array;
 
-static void register_frametables(frametable_array *array)
+static void register_frametables_from_stw_single(frametable_array *array)
 {
   caml_frametable_list *new_frametables = NULL;
   for (int i = 0; i < array->ntables; i++)
@@ -198,7 +198,7 @@ static void stw_register_frametables(
   barrier_status b = caml_global_barrier_begin ();
 
   if (caml_global_barrier_is_final(b)) {
-    register_frametables((frametable_array*) frametables);
+    register_frametables_from_stw_single((frametable_array*) frametables);
   }
 
   caml_global_barrier_end(b);

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -1345,9 +1345,7 @@ static void stw_cycle_all_domains(
 
       atomic_store(&domain_global_roots_started, WORK_UNSTARTED);
 
-      /* Cleanups for various data structures that must be done in a STW by
-        only a single domain */
-      caml_code_fragment_cleanup();
+      caml_code_fragment_cleanup_from_stw_single();
     }
     // should interrupts be processed here or not?
     // depends on whether marking above may need interrupts

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -1237,9 +1237,10 @@ static intnat ephe_sweep (caml_domain_state* domain_state, intnat budget)
   return budget;
 }
 
-static void cycle_all_domains_callback(caml_domain_state* domain, void* unused,
-                                       int participating_count,
-                                       caml_domain_state** participating)
+static void stw_cycle_all_domains(
+  caml_domain_state* domain, void* unused,
+  int participating_count,
+  caml_domain_state** participating)
 {
   uintnat num_domains_in_stw;
 
@@ -1742,10 +1743,10 @@ mark_again:
 
     while (saved_major_cycle == caml_major_cycles_completed) {
       if (barrier_participants) {
-        cycle_all_domains_callback
+        stw_cycle_all_domains
               (domain_state, (void*)0, participant_count, barrier_participants);
       } else {
-        caml_try_run_on_all_domains(&cycle_all_domains_callback, 0, 0);
+        caml_try_run_on_all_domains(&stw_cycle_all_domains, 0, 0);
       }
     }
   }
@@ -1782,9 +1783,10 @@ void caml_major_collection_slice(intnat howmuch)
   Caml_state->major_slice_epoch = major_slice_epoch;
 }
 
-static void finish_major_cycle_callback (caml_domain_state* domain, void* arg,
-                                         int participating_count,
-                                         caml_domain_state** participating)
+static void stw_finish_major_cycle(
+  caml_domain_state* domain, void* arg,
+  int participating_count,
+  caml_domain_state** participating)
 {
   uintnat saved_major_cycles = (uintnat)arg;
   CAMLassert (domain == Caml_state);
@@ -1811,7 +1813,7 @@ void caml_finish_major_cycle (void)
 
   while( saved_major_cycles == caml_major_cycles_completed ) {
     caml_try_run_on_all_domains
-    (&finish_major_cycle_callback, (void*)caml_major_cycles_completed, 0);
+    (&stw_finish_major_cycle, (void*)caml_major_cycles_completed, 0);
   }
 }
 

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -1789,6 +1789,11 @@ static void finish_major_cycle_callback (caml_domain_state* domain, void* arg,
   uintnat saved_major_cycles = (uintnat)arg;
   CAMLassert (domain == Caml_state);
 
+  /* We are in a STW critical section here. There is no obvious call
+     to a barrier at the end of the callback, but the [while] loop
+     will only terminate when [caml_major_cycles_completed] is
+     incremented, and this happens in [cycle_all_domains] inside
+     a barrier. */
   caml_empty_minor_heap_no_major_slice_from_stw
     (domain, (void*)0, participating_count, participating);
 

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -1483,9 +1483,10 @@ static int is_complete_phase_sweep_ephe (void)
     /* All orphaned structures have been adopted */
 }
 
-static void try_complete_gc_phase (caml_domain_state* domain, void* unused,
-                                   int participant_count,
-                                   caml_domain_state** participating)
+static void stw_try_complete_gc_phase(
+  caml_domain_state* domain, void* unused,
+  int participant_count,
+  caml_domain_state** participating)
 {
   barrier_status b;
   CAML_EV_BEGIN(EV_MAJOR_GC_PHASE_CHANGE);
@@ -1709,12 +1710,13 @@ mark_again:
         is_complete_phase_mark_final ()) {
       CAMLassert (caml_gc_phase != Phase_sweep_ephe);
       if (barrier_participants) {
-        try_complete_gc_phase (domain_state,
-                              (void*)0,
-                              participant_count,
-                              barrier_participants);
+        stw_try_complete_gc_phase(
+          domain_state,
+          (void*)0,
+          participant_count,
+          barrier_participants);
       } else {
-        caml_try_run_on_all_domains (&try_complete_gc_phase, 0, 0);
+        caml_try_run_on_all_domains (&stw_try_complete_gc_phase, 0, 0);
       }
       if (get_major_slice_work(mode) > 0) goto mark_again;
     }

--- a/runtime/minor_gc.c
+++ b/runtime/minor_gc.c
@@ -774,10 +774,11 @@ static void caml_stw_empty_minor_heap (caml_domain_state* domain, void* unused,
 }
 
 /* must be called within a STW section  */
-void caml_empty_minor_heap_no_major_slice_from_stw(caml_domain_state* domain,
-                                            void* unused,
-                                             int participating_count,
-                                             caml_domain_state** participating)
+void caml_empty_minor_heap_no_major_slice_from_stw(
+  caml_domain_state* domain,
+  void* unused,
+  int participating_count,
+  caml_domain_state** participating)
 {
   barrier_status b = caml_global_barrier_begin();
   if( caml_global_barrier_is_final(b) ) {
@@ -792,7 +793,7 @@ void caml_empty_minor_heap_no_major_slice_from_stw(caml_domain_state* domain,
 }
 
 /* must be called outside a STW section */
-int caml_try_stw_empty_minor_heap_on_all_domains (void)
+int caml_try_empty_minor_heap_on_all_domains (void)
 {
   #ifdef DEBUG
   CAMLassert(!caml_domain_is_in_stw());
@@ -820,7 +821,7 @@ void caml_empty_minor_heaps_once (void)
   /* To handle the case where multiple domains try to execute a minor gc
      STW section */
   do {
-    caml_try_stw_empty_minor_heap_on_all_domains();
+    caml_try_empty_minor_heap_on_all_domains();
   } while (saved_minor_cycle == atomic_load(&caml_minor_cycles_started));
 }
 

--- a/runtime/shared_heap.c
+++ b/runtime/shared_heap.c
@@ -777,7 +777,7 @@ static void verify_object(struct heap_verify_state* st, value v) {
   }
 }
 
-void caml_verify_heap(caml_domain_state *domain) {
+void caml_verify_heap_from_stw(caml_domain_state *domain) {
   struct heap_verify_state* st = caml_verify_begin();
   caml_do_roots (&caml_verify_root, verify_scanning_flags, st, domain, 1);
   caml_scan_global_roots(&caml_verify_root, st);
@@ -882,7 +882,7 @@ static void verify_swept (struct caml_heap_state* local) {
   CAMLassert(local->stats.large_blocks == large_stats.live_blocks);
 }
 
-void caml_cycle_heap_stw (void) {
+void caml_cycle_heap_from_stw_single (void) {
   struct global_heap_state oldg = caml_global_heap_state;
   struct global_heap_state newg;
   newg.UNMARKED     = oldg.MARKED;


### PR DESCRIPTION
When reviewing #12597, @kayceesrk asked about our naming conventions around STW sections: is there a conventional suffix for functions that must run within a STW critical section, and where is it documented? ( https://github.com/ocaml/ocaml/pull/12597#discussion_r1340006595 )

The present PR answers this question by defining and documenting a convention around STW sections, and enforcing it in the runtime.

This is purely a documentation and renaming PR, there must be no behavior change. (In the process I found a few places where the code could profitably be changed, they are marked as TODO items.)

To review this PR, one should start by looking at the domain.h diff which specifies the naming conventions, before looking at runtime changes enforcing the conventions or commenting on their use.

The gist of the naming convention proposed:

- use `stw_foo` or `caml_stw_foo` for whole STW callbacks (there was another convention in play in some parts of the runtime to use `foo_callback`, those are renamed accordingly)
- use `foo_from_stw` for functions that can only be called within a STW critical section (when mutators cannot run)
- use `foo_from_stw_single` for functions that must be called from a single domain within a STW critical section (typically, the last one entering a barrier)

Remark: another refactoring PR I submitted based on KC's feedback was #12617. For that PR I was not sure that the benefits of the PR are worth the code churn. In the present case I feel fairly confident that this PR is a desirable change, because it enforces (through names) a discipline on the most delicate synchronization mechanism in the runtime.

Anyone interested in the concurrent runtime code could review this PR. (For example @kayceesrk, @gadmm, @Engil, @fabbing, @OlivierNicole, etc. )