### PR TITLE
Give hints about existential types appearing in error messages

### DIFF
--- a/Changes
+++ b/Changes
@@ -266,6 +266,9 @@ Working version
   module (e.g `module M = Int(Int)`)
   (Florian Angeletti, review by Gabriel Scherer)
 
+- #12622: Give hints about existential types appearing in error messages
+  (Leo White, review by Gabriel Scherer and Florian Angeletti)
+
 ### Internal/compiler-libs changes:
 
 - #12447: Remove 32-bit targets from X86_proc.system

--- a/manual/src/tutorials/gadtexamples.etex
+++ b/manual/src/tutorials/gadtexamples.etex
@@ -237,16 +237,10 @@ existential types using compiler-generated names. Currently, the
 compiler generates these names according to the following nomenclature:
 \begin{itemize}
 \item First, types whose name starts with a "$" are existentials.
-\item "$Constr_'a" denotes an existential type introduced for the type
-variable "'a" of the GADT constructor "Constr":
+\item "$a" denotes an existential type introduced for the type
+variable "'a" of a GADT constructor:
 \begin{caml_example}{verbatim}[error]
 type any = Any : 'name -> any
-let escape (Any x) = x
-\end{caml_example}
-\item "$Constr" denotes an existential type introduced for an anonymous %$
-type variable in the GADT constructor "Constr":
-\begin{caml_example}{verbatim}[error]
-type any = Any : _ -> any
 let escape (Any x) = x
 \end{caml_example}
 \item "$'a" if the existential variable was unified with the type %$

--- a/testsuite/tests/printing-types/existentials.ml
+++ b/testsuite/tests/printing-types/existentials.ml
@@ -1,0 +1,112 @@
+(* TEST
+ expect;
+*)
+
+type foo1 =
+  | Foo : ('a * 'b * 'c * 'd * 'e * 'f) -> foo1
+
+let bar1 x =
+  match x with
+  | Foo a -> a + 1
+  | _ -> 0
+;;
+[%%expect {|
+type foo1 = Foo : ('a * 'b * 'c * 'd * 'e * 'f) -> foo1
+Line 6, characters 13-14:
+6 |   | Foo a -> a + 1
+                 ^
+Error: This expression has type "$a * $b * $c * $d * $e * $f"
+       but an expression was expected of type "int"
+       Hint: "$a", "$b", "$c", "$d", "$e" and "$f" are existential types
+         bound by the constructor "Foo".
+|}]
+
+type foo2 =
+  | Foo1 : 'a -> foo2
+  | Foo2 : 'a -> foo2
+  | Foo3 : 'a -> foo2
+  | Foo4 : 'a -> foo2
+  | Foo5 : 'a -> foo2
+  | Foo6 : 'a -> foo2
+  | Foo7 : 'a -> foo2
+
+let bar2 x =
+  match x with
+  | Foo1 a1, Foo2 a2, Foo3 a3, Foo4 a4, Foo5 a5, Foo6 a6, Foo7 a7 ->
+      let x = (a1, a2, a3, a4, a5, a6, a7) in x + 1
+  | _ -> 0
+;;
+[%%expect {|
+type foo2 =
+    Foo1 : 'a -> foo2
+  | Foo2 : 'a -> foo2
+  | Foo3 : 'a -> foo2
+  | Foo4 : 'a -> foo2
+  | Foo5 : 'a -> foo2
+  | Foo6 : 'a -> foo2
+  | Foo7 : 'a -> foo2
+Line 13, characters 46-47:
+13 |       let x = (a1, a2, a3, a4, a5, a6, a7) in x + 1
+                                                   ^
+Error: This expression has type "$a * $a1 * $a2 * $a3 * $a4 * $a5 * $a6"
+       but an expression was expected of type "int"
+       Hint: "$a" is an existential type bound by the constructor "Foo1".
+       Hint: "$a1" is an existential type bound by the constructor "Foo2".
+       Hint: "$a2" is an existential type bound by the constructor "Foo3".
+       Hint: "$a3" is an existential type bound by the constructor "Foo4".
+       Hint: "$a4" is an existential type bound by the constructor "Foo5".
+       Hint: "$a5" is an existential type bound by the constructor "Foo6".
+       Hint: "$a6" is an existential type bound by the constructor "Foo7".
+|}]
+
+type foo3 =
+  | Foo1 : ('a * 'b * 'c * 'd * 'e * 'f) -> foo3
+  | Foo2 : ('a * 'b * 'c * 'd * 'e * 'f) -> foo3
+  | Foo3 : ('a * 'b * 'c * 'd * 'e * 'f) -> foo3
+  | Foo4 : ('a * 'b * 'c * 'd * 'e * 'f) -> foo3
+  | Foo5 : ('a * 'b * 'c * 'd * 'e * 'f) -> foo3
+  | Foo6 : ('a * 'b * 'c * 'd * 'e * 'f) -> foo3
+  | Foo7 : ('a * 'b * 'c * 'd * 'e * 'f) -> foo3
+
+let bar2 x =
+  match x with
+  | Foo1 a1, Foo2 a2, Foo3 a3, Foo4 a4, Foo5 a5, Foo6 a6, Foo7 a7 ->
+      let x = (a1, a2, a3, a4, a5, a6, a7) in x + 1
+  | _ -> 0
+;;
+[%%expect {|
+type foo3 =
+    Foo1 : ('a * 'b * 'c * 'd * 'e * 'f) -> foo3
+  | Foo2 : ('a * 'b * 'c * 'd * 'e * 'f) -> foo3
+  | Foo3 : ('a * 'b * 'c * 'd * 'e * 'f) -> foo3
+  | Foo4 : ('a * 'b * 'c * 'd * 'e * 'f) -> foo3
+  | Foo5 : ('a * 'b * 'c * 'd * 'e * 'f) -> foo3
+  | Foo6 : ('a * 'b * 'c * 'd * 'e * 'f) -> foo3
+  | Foo7 : ('a * 'b * 'c * 'd * 'e * 'f) -> foo3
+Line 13, characters 46-47:
+13 |       let x = (a1, a2, a3, a4, a5, a6, a7) in x + 1
+                                                   ^
+Error: This expression has type
+         "($a * $b * $c * $d * $e * $f) *
+         ($a1 * $b1 * $c1 * $d1 * $e1 * $f1) *
+         ($a2 * $b2 * $c2 * $d2 * $e2 * $f2) *
+         ($a3 * $b3 * $c3 * $d3 * $e3 * $f3) *
+         ($a4 * $b4 * $c4 * $d4 * $e4 * $f4) *
+         ($a5 * $b5 * $c5 * $d5 * $e5 * $f5) *
+         ($a6 * $b6 * $c6 * $d6 * $e6 * $f6)"
+       but an expression was expected of type "int"
+       Hint: "$a", "$b", "$c", "$d", "$e" and "$f" are existential types
+         bound by the constructor "Foo1".
+       Hint: "$a1", "$b1", "$c1", "$d1", "$e1" and "$f1" are existential types
+         bound by the constructor "Foo2".
+       Hint: "$a2", "$b2", "$c2", "$d2", "$e2" and "$f2" are existential types
+         bound by the constructor "Foo3".
+       Hint: "$a3", "$b3", "$c3", "$d3", "$e3" and "$f3" are existential types
+         bound by the constructor "Foo4".
+       Hint: "$a4", "$b4", "$c4", "$d4", "$e4" and "$f4" are existential types
+         bound by the constructor "Foo5".
+       Hint: "$a5", "$b5", "$c5", "$d5", "$e5" and "$f5" are existential types
+         bound by the constructor "Foo6".
+       Hint: "$a6", "$b6", "$c6", "$d6", "$e6" and "$f6" are existential types
+         bound by the constructor "Foo7".
+|}]

--- a/testsuite/tests/typing-gadts/dynamic_frisch.ml
+++ b/testsuite/tests/typing-gadts/dynamic_frisch.ml
@@ -605,9 +605,9 @@ Line 7, characters 41-58:
 7 |     | "Cons", Some (Tdyn (Pair (_, Var), (p : a * a vlist))) -> `Cons p)))
                                              ^^^^^^^^^^^^^^^^^
 Error: This pattern matches values of type "a * a vlist"
-       but a pattern was expected which matches values of type
-         "$Tdyn_'a" = "$0 * $1"
+       but a pattern was expected which matches values of type "$a" = "$0 * $1"
        Type "a" is not compatible with type "$0"
+       Hint: "$a" is an existential type bound by the constructor "Tdyn".
 |}];;
 
 (* Define Sum using object instead of record for first-class polymorphism *)

--- a/testsuite/tests/typing-gadts/or_patterns.ml
+++ b/testsuite/tests/typing-gadts/or_patterns.ml
@@ -761,6 +761,7 @@ let f = function
 Line 2, characters 6-7:
 2 |   | A x
           ^
-Error: This pattern matches values of type "$A_'a"
-       The type constructor "$A_'a" would escape its scope
+Error: This pattern matches values of type "$a"
+       The type constructor "$a" would escape its scope
+       Hint: "$a" is an existential type bound by the constructor "A".
 |}]

--- a/testsuite/tests/typing-gadts/pr6980.ml
+++ b/testsuite/tests/typing-gadts/pr6980.ml
@@ -26,6 +26,7 @@ Line 11, characters 27-29:
                                 ^^
 Error: This expression has type "[< `Bar | `Foo > `Bar ]"
        but an expression was expected of type "[< `Bar | `Foo ]"
-       The second variant type is bound to "$Aux_'a",
+       The second variant type is bound to "$a",
        it may not allow the tag(s) "`Bar"
+       Hint: "$a" is an existential type bound by the constructor "Aux".
 |}];;

--- a/testsuite/tests/typing-gadts/pr7222.ml
+++ b/testsuite/tests/typing-gadts/pr7222.ml
@@ -23,8 +23,9 @@ type _ t = Nil : nil t | Cons : ('x, 'fx) elt * 'x t -> 'fx t
 Line 9, characters 11-18:
 9 |   let Cons(Elt dim, _) = sh in ()
                ^^^^^^^
-Error: This pattern matches values of type "($Cons_'x, 'a -> $Cons_'x) elt"
+Error: This pattern matches values of type "($x, 'a -> $x) elt"
        but a pattern was expected which matches values of type
-         "($Cons_'x, 'a -> $'b -> nil) elt"
+         "($x, 'a -> $'b -> nil) elt"
        The type constructor "$'b" would escape its scope
+       Hint: "$x" is an existential type bound by the constructor "Cons".
 |}];;

--- a/testsuite/tests/typing-gadts/test.ml
+++ b/testsuite/tests/typing-gadts/test.ml
@@ -293,9 +293,10 @@ module Existential_escape =
 Line 5, characters 21-22:
 5 |     let eval (D x) = x
                          ^
-Error: This expression has type "$D_'a t"
-       but an expression was expected of type "'a"
-       The type constructor "$D_'a" would escape its scope
+Error: This expression has type "$a t" but an expression was expected of type
+         "'a"
+       The type constructor "$a" would escape its scope
+       Hint: "$a" is an existential type bound by the constructor "D".
 |}];;
 
 module Rectype =
@@ -1353,10 +1354,11 @@ module M :
 Line 9, characters 4-5:
 9 |     z#b
         ^
-Error: This expression has type "$C_'a" = "< b : bool >"
+Error: This expression has type "$a" = "< b : bool >"
        but an expression was expected of type "< b : 'a; .. >"
        This instance of "< b : bool >" is ambiguous:
        it would escape the scope of its equation
+       Hint: "$a" is an existential type bound by the constructor "C".
 |}]
 
 (* Check got/expected when the order changes *)
@@ -1380,8 +1382,9 @@ module M :
 Line 9, characters 4-5:
 9 |     z#b
         ^
-Error: This expression has type "$C_'a" = "< b : bool >"
+Error: This expression has type "$a" = "< b : bool >"
        but an expression was expected of type "< b : 'a; .. >"
        This instance of "< b : bool >" is ambiguous:
        it would escape the scope of its equation
+       Hint: "$a" is an existential type bound by the constructor "C".
 |}]

--- a/testsuite/tests/typing-gadts/unexpected_existentials.ml
+++ b/testsuite/tests/typing-gadts/unexpected_existentials.ml
@@ -14,7 +14,7 @@ Line 1, characters 4-9:
 1 | let Any x = Any ()
         ^^^^^
 Error: Existential types are not allowed in toplevel bindings,
-       but this pattern introduces the existential type "$a".
+       but the constructor "Any" introduces existential types.
 |}]
 
 let () =
@@ -25,7 +25,7 @@ Line 2, characters 6-11:
 2 |   let Any x = Any () and () = () in
           ^^^^^
 Error: Existential types are not allowed in "let ... and ..." bindings,
-       but this pattern introduces the existential type "$a".
+       but the constructor "Any" introduces existential types.
 |}]
 
 
@@ -37,7 +37,7 @@ Line 2, characters 10-15:
 2 |   let rec Any x = Any () in
               ^^^^^
 Error: Existential types are not allowed in recursive bindings,
-       but this pattern introduces the existential type "$a".
+       but the constructor "Any" introduces existential types.
 |}]
 
 
@@ -49,7 +49,7 @@ Line 2, characters 18-23:
 2 |   let[@attribute] Any x = Any () in
                       ^^^^^
 Error: Existential types are not allowed in presence of attributes,
-       but this pattern introduces the existential type "$a".
+       but the constructor "Any" introduces existential types.
 |}]
 
 
@@ -59,7 +59,7 @@ Line 1, characters 8-15:
 1 | class c (Any x) = object end
             ^^^^^^^
 Error: Existential types are not allowed in class arguments,
-       but this pattern introduces the existential type "$a".
+       but the constructor "Any" introduces existential types.
 |}]
 
 class c = object(Any x)end
@@ -68,7 +68,7 @@ Line 1, characters 16-23:
 1 | class c = object(Any x)end
                     ^^^^^^^
 Error: Existential types are not allowed in self patterns,
-       but this pattern introduces the existential type "$a".
+       but the constructor "Any" introduces existential types.
 |}]
 
 type other = Any: _ -> other
@@ -82,7 +82,7 @@ Line 1, characters 4-9:
 1 | let Any x = Any ()
         ^^^^^
 Error: Existential types are not allowed in toplevel bindings,
-       but this pattern introduces the existential type "$a".
+       but the constructor "Any" introduces existential types.
 |}]
 
 
@@ -92,7 +92,7 @@ Line 1, characters 14-20:
 1 | class c = let Any _x = () in object end
                   ^^^^^^
 Error: Existential types are not allowed in bindings inside class definition,
-       but this pattern introduces the existential type "$a".
+       but the constructor "Any" introduces existential types.
 |}]
 
 let () =
@@ -103,7 +103,7 @@ Line 2, characters 6-11:
 2 |   let Any x = Any () and () = () in
           ^^^^^
 Error: Existential types are not allowed in "let ... and ..." bindings,
-       but this pattern introduces the existential type "$a".
+       but the constructor "Any" introduces existential types.
 |}]
 
 
@@ -115,7 +115,7 @@ Line 2, characters 10-15:
 2 |   let rec Any x = Any () in
               ^^^^^
 Error: Existential types are not allowed in recursive bindings,
-       but this pattern introduces the existential type "$a".
+       but the constructor "Any" introduces existential types.
 |}]
 
 
@@ -127,7 +127,7 @@ Line 2, characters 18-23:
 2 |   let[@attribute] Any x = Any () in
                       ^^^^^
 Error: Existential types are not allowed in presence of attributes,
-       but this pattern introduces the existential type "$a".
+       but the constructor "Any" introduces existential types.
 |}]
 
 class c (Any x) = object end
@@ -136,7 +136,7 @@ Line 1, characters 8-15:
 1 | class c (Any x) = object end
             ^^^^^^^
 Error: Existential types are not allowed in class arguments,
-       but this pattern introduces the existential type "$a".
+       but the constructor "Any" introduces existential types.
 |}]
 
 class c = object(Any x) end
@@ -145,7 +145,7 @@ Line 1, characters 16-23:
 1 | class c = object(Any x) end
                     ^^^^^^^
 Error: Existential types are not allowed in self patterns,
-       but this pattern introduces the existential type "$a".
+       but the constructor "Any" introduces existential types.
 |}]
 
 class c = let Any _x = () in object end
@@ -154,5 +154,5 @@ Line 1, characters 14-20:
 1 | class c = let Any _x = () in object end
                   ^^^^^^
 Error: Existential types are not allowed in bindings inside class definition,
-       but this pattern introduces the existential type "$a".
+       but the constructor "Any" introduces existential types.
 |}]

--- a/testsuite/tests/typing-gadts/unexpected_existentials.ml
+++ b/testsuite/tests/typing-gadts/unexpected_existentials.ml
@@ -14,7 +14,7 @@ Line 1, characters 4-9:
 1 | let Any x = Any ()
         ^^^^^
 Error: Existential types are not allowed in toplevel bindings,
-       but this pattern introduces the existential type "$Any_'a".
+       but this pattern introduces the existential type "$a".
 |}]
 
 let () =
@@ -25,7 +25,7 @@ Line 2, characters 6-11:
 2 |   let Any x = Any () and () = () in
           ^^^^^
 Error: Existential types are not allowed in "let ... and ..." bindings,
-       but this pattern introduces the existential type "$Any_'a".
+       but this pattern introduces the existential type "$a".
 |}]
 
 
@@ -37,7 +37,7 @@ Line 2, characters 10-15:
 2 |   let rec Any x = Any () in
               ^^^^^
 Error: Existential types are not allowed in recursive bindings,
-       but this pattern introduces the existential type "$Any_'a".
+       but this pattern introduces the existential type "$a".
 |}]
 
 
@@ -49,7 +49,7 @@ Line 2, characters 18-23:
 2 |   let[@attribute] Any x = Any () in
                       ^^^^^
 Error: Existential types are not allowed in presence of attributes,
-       but this pattern introduces the existential type "$Any_'a".
+       but this pattern introduces the existential type "$a".
 |}]
 
 
@@ -59,7 +59,7 @@ Line 1, characters 8-15:
 1 | class c (Any x) = object end
             ^^^^^^^
 Error: Existential types are not allowed in class arguments,
-       but this pattern introduces the existential type "$Any_'a".
+       but this pattern introduces the existential type "$a".
 |}]
 
 class c = object(Any x)end
@@ -68,7 +68,7 @@ Line 1, characters 16-23:
 1 | class c = object(Any x)end
                     ^^^^^^^
 Error: Existential types are not allowed in self patterns,
-       but this pattern introduces the existential type "$Any_'a".
+       but this pattern introduces the existential type "$a".
 |}]
 
 type other = Any: _ -> other
@@ -82,7 +82,7 @@ Line 1, characters 4-9:
 1 | let Any x = Any ()
         ^^^^^
 Error: Existential types are not allowed in toplevel bindings,
-       but the constructor "Any" introduces existential types.
+       but this pattern introduces the existential type "$a".
 |}]
 
 
@@ -92,7 +92,7 @@ Line 1, characters 14-20:
 1 | class c = let Any _x = () in object end
                   ^^^^^^
 Error: Existential types are not allowed in bindings inside class definition,
-       but the constructor "Any" introduces existential types.
+       but this pattern introduces the existential type "$a".
 |}]
 
 let () =
@@ -103,7 +103,7 @@ Line 2, characters 6-11:
 2 |   let Any x = Any () and () = () in
           ^^^^^
 Error: Existential types are not allowed in "let ... and ..." bindings,
-       but the constructor "Any" introduces existential types.
+       but this pattern introduces the existential type "$a".
 |}]
 
 
@@ -115,7 +115,7 @@ Line 2, characters 10-15:
 2 |   let rec Any x = Any () in
               ^^^^^
 Error: Existential types are not allowed in recursive bindings,
-       but the constructor "Any" introduces existential types.
+       but this pattern introduces the existential type "$a".
 |}]
 
 
@@ -127,7 +127,7 @@ Line 2, characters 18-23:
 2 |   let[@attribute] Any x = Any () in
                       ^^^^^
 Error: Existential types are not allowed in presence of attributes,
-       but the constructor "Any" introduces existential types.
+       but this pattern introduces the existential type "$a".
 |}]
 
 class c (Any x) = object end
@@ -136,7 +136,7 @@ Line 1, characters 8-15:
 1 | class c (Any x) = object end
             ^^^^^^^
 Error: Existential types are not allowed in class arguments,
-       but the constructor "Any" introduces existential types.
+       but this pattern introduces the existential type "$a".
 |}]
 
 class c = object(Any x) end
@@ -145,7 +145,7 @@ Line 1, characters 16-23:
 1 | class c = object(Any x) end
                     ^^^^^^^
 Error: Existential types are not allowed in self patterns,
-       but the constructor "Any" introduces existential types.
+       but this pattern introduces the existential type "$a".
 |}]
 
 class c = let Any _x = () in object end
@@ -154,5 +154,5 @@ Line 1, characters 14-20:
 1 | class c = let Any _x = () in object end
                   ^^^^^^
 Error: Existential types are not allowed in bindings inside class definition,
-       but the constructor "Any" introduces existential types.
+       but this pattern introduces the existential type "$a".
 |}]

--- a/testsuite/tests/typing-short-paths/errors.ml
+++ b/testsuite/tests/typing-short-paths/errors.ml
@@ -51,8 +51,8 @@ type pair = Pair : 'a ty * 'a -> pair
 Line 9, characters 22-23:
 9 |   | Pair (Char, x) -> x + 1
                           ^
-Error: This expression has type "$Pair_'a"
-       but an expression was expected of type "int"
+Error: This expression has type "$a" but an expression was expected of type "int"
+       Hint: "$a" is an existential type bound by the constructor "Pair".
 |}]
 
 type _ ty = Char : char ty
@@ -68,8 +68,8 @@ type pair = Pair : 'a ty * 'a -> pair
 Line 7, characters 35-36:
 7 |   | Pair (Char, x) -> if true then x else 'd'
                                        ^
-Error: This expression has type "$Pair_'a"
-       but an expression was expected of type "'a"
-       This instance of "$Pair_'a" is ambiguous:
+Error: This expression has type "$a" but an expression was expected of type "'a"
+       This instance of "$a" is ambiguous:
        it would escape the scope of its equation
+       Hint: "$a" is an existential type bound by the constructor "Pair".
 |}]

--- a/typing/btype.ml
+++ b/typing/btype.ml
@@ -130,7 +130,7 @@ let type_kind_is_abstract decl =
 let type_origin decl =
   match decl.type_kind with
   | Type_abstract origin -> origin
-  | Type_variant _ | Type_record _ | Type_open -> Origin_def
+  | Type_variant _ | Type_record _ | Type_open -> Definition
 
 let dummy_method = "*dummy method*"
 

--- a/typing/btype.ml
+++ b/typing/btype.ml
@@ -127,6 +127,10 @@ let is_Tunivar ty = match get_desc ty with Tunivar _ -> true | _ -> false
 let is_Tconstr ty = match get_desc ty with Tconstr _ -> true | _ -> false
 let type_kind_is_abstract decl =
   match decl.type_kind with Type_abstract _ -> true | _ -> false
+let type_origin decl =
+  match decl.type_kind with
+  | Type_abstract origin -> origin
+  | Type_variant _ | Type_record _ | Type_open -> Origin_def
 
 let dummy_method = "*dummy method*"
 

--- a/typing/btype.mli
+++ b/typing/btype.mli
@@ -79,6 +79,7 @@ val is_Tunivar: type_expr -> bool
 val is_Tconstr: type_expr -> bool
 val dummy_method: label
 val type_kind_is_abstract: type_declaration -> bool
+val type_origin : type_declaration -> type_origin
 
 (**** polymorphic variants ****)
 

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -1300,20 +1300,11 @@ let existential_name name_counter ty =
     match get_desc ty with
     | Tvar (Some name) -> name
     | _ ->
-        let name =
-          if !name_counter < 26
-          then String.make 1 (Char.chr(97 + !name_counter))
-          else String.make 1 (Char.chr(97 + !name_counter mod 26))
-               ^ Int.to_string(!name_counter / 26)
-        in
+        let name = Misc.letter_of_int !name_counter in
         incr name_counter;
         name
   in
   "$" ^ name
-
-let existential_names tys =
-  let name_counter = ref 0 in
-  List.map (existential_name name_counter) tys
 
 type existential_treatment =
   | Keep_existentials_flexible
@@ -1329,7 +1320,7 @@ let instance_constructor existential_treatment cstr =
           fun existential ->
             let env = penv.env in
             let fresh_constr_scope = penv.equations_scope in
-            let decl = new_local_type (Origin_existential cstr.cstr_name) in
+            let decl = new_local_type (Existential cstr.cstr_name) in
             let name = existential_name name_counter existential in
             let (id, new_env) =
               Env.enter_type (get_new_abstract_name env name) decl env
@@ -2216,7 +2207,7 @@ let reify uenv t =
   let fresh_constr_scope = get_equations_scope uenv in
   let create_fresh_constr lev name =
     let name = match name with Some s -> "$'"^s | _ -> "$" in
-    let decl = new_local_type Origin_def in
+    let decl = new_local_type Definition in
     let env = get_env uenv in
     let new_name =
       (* unique names are needed only for error messages *)
@@ -5409,7 +5400,7 @@ let nondep_type_decl env mid is_covariant decl =
     let params = List.map (nondep_type_rec env mid) decl.type_params in
     let tk =
       try map_kind (nondep_type_rec env mid) decl.type_kind
-      with Nondep_cannot_erase _ when is_covariant -> Type_abstract Origin_def
+      with Nondep_cannot_erase _ when is_covariant -> Type_abstract Definition
     and tm, priv =
       match decl.type_manifest with
       | None -> None, decl.type_private

--- a/typing/ctype.mli
+++ b/typing/ctype.mli
@@ -175,7 +175,6 @@ val new_local_type:
         ?loc:Location.t ->
         ?manifest_and_scope:(type_expr * int) ->
         type_origin -> type_declaration
-val existential_names: type_expr list -> string list
 
 module Pattern_env : sig
   type t = private

--- a/typing/ctype.mli
+++ b/typing/ctype.mli
@@ -173,8 +173,9 @@ val instance_list: type_expr list -> type_expr list
         (* Take an instance of a list of type schemes *)
 val new_local_type:
         ?loc:Location.t ->
-        ?manifest_and_scope:(type_expr * int) -> unit -> type_declaration
-val existential_name: constructor_description -> type_expr -> string
+        ?manifest_and_scope:(type_expr * int) ->
+        type_origin -> type_declaration
+val existential_names: type_expr list -> string list
 
 module Pattern_env : sig
   type t = private

--- a/typing/env.ml
+++ b/typing/env.ml
@@ -1136,7 +1136,7 @@ let rec find_type_data path env =
   | decl ->
     {
       tda_declaration = decl;
-      tda_descriptions = Type_abstract Abstract_def;
+      tda_descriptions = Type_abstract Origin_def;
       tda_shape = Shape.leaf decl.type_uid;
     }
   | exception Not_found -> begin
@@ -2024,7 +2024,7 @@ and store_type_infos ~tda_shape id info env =
   let tda =
     {
       tda_declaration = info;
-      tda_descriptions = Type_abstract Abstract_def;
+      tda_descriptions = Type_abstract Origin_def;
       tda_shape
     }
   in

--- a/typing/env.ml
+++ b/typing/env.ml
@@ -1136,7 +1136,7 @@ let rec find_type_data path env =
   | decl ->
     {
       tda_declaration = decl;
-      tda_descriptions = Type_abstract Origin_def;
+      tda_descriptions = Type_abstract (Btype.type_origin decl);
       tda_shape = Shape.leaf decl.type_uid;
     }
   | exception Not_found -> begin
@@ -2024,7 +2024,7 @@ and store_type_infos ~tda_shape id info env =
   let tda =
     {
       tda_declaration = info;
-      tda_descriptions = Type_abstract Origin_def;
+      tda_descriptions = Type_abstract (Btype.type_origin info);
       tda_shape
     }
   in

--- a/typing/predef.ml
+++ b/typing/predef.ml
@@ -135,7 +135,7 @@ and ident_none = ident_create "None"
 and ident_some = ident_create "Some"
 
 let mk_add_type add_type type_ident ?manifest
-    ?(immediate=Type_immediacy.Unknown) ?(kind=Type_abstract Abstract_def) env =
+    ?(immediate=Type_immediacy.Unknown) ?(kind=Type_abstract Origin_def) env =
   let decl =
     {type_params = [];
      type_arity = 0;
@@ -158,7 +158,7 @@ let mk_add_type add_type type_ident ?manifest
 let build_initial_env add_type add_extension empty_env =
   let add_type = mk_add_type add_type
   and add_type1 type_ident
-      ~variance ~separability ?(kind=fun _ -> Type_abstract Abstract_def) env =
+      ~variance ~separability ?(kind=fun _ -> Type_abstract Origin_def) env =
     let param = newgenvar () in
     let decl =
       {type_params = [param];

--- a/typing/predef.ml
+++ b/typing/predef.ml
@@ -135,7 +135,7 @@ and ident_none = ident_create "None"
 and ident_some = ident_create "Some"
 
 let mk_add_type add_type type_ident ?manifest
-    ?(immediate=Type_immediacy.Unknown) ?(kind=Type_abstract Origin_def) env =
+    ?(immediate=Type_immediacy.Unknown) ?(kind=Type_abstract Definition) env =
   let decl =
     {type_params = [];
      type_arity = 0;
@@ -158,7 +158,7 @@ let mk_add_type add_type type_ident ?manifest
 let build_initial_env add_type add_extension empty_env =
   let add_type = mk_add_type add_type
   and add_type1 type_ident
-      ~variance ~separability ?(kind=fun _ -> Type_abstract Origin_def) env =
+      ~variance ~separability ?(kind=fun _ -> Type_abstract Definition) env =
     let param = newgenvar () in
     let decl =
       {type_params = [param];

--- a/typing/printtyp.ml
+++ b/typing/printtyp.ml
@@ -829,6 +829,70 @@ let printer_iter_type_expr f ty =
   | _ ->
       Btype.iter_type_expr f ty
 
+module Internal_names : sig
+
+  val reset : unit -> unit
+
+  val add : Path.t -> unit
+
+  val print_explanations : Env.t -> Format.formatter -> unit
+
+end = struct
+
+  let names = ref Ident.Set.empty
+
+  let reset () =
+    names := Ident.Set.empty
+
+  let add p =
+    match p with
+    | Pident id ->
+        let name = Ident.name id in
+        if String.length name > 0 && name.[0] = '$' then begin
+          names := Ident.Set.add id !names
+        end
+    | Pdot _ | Papply _ | Pextra_ty _ -> ()
+
+  let print_explanations env ppf =
+    let constrs =
+      Ident.Set.fold
+        (fun id acc ->
+          let p = Pident id in
+          match Env.find_type p env with
+          | exception Not_found -> acc
+          | decl ->
+              match type_origin decl with
+              | Origin_existential constr ->
+                  let prev = String.Map.find_opt constr acc in
+                  let prev = Option.value ~default:[] prev in
+                  String.Map.add constr (tree_of_path None p :: prev) acc
+              | Origin_def | Origin_rec_check_regularity -> acc)
+        !names String.Map.empty
+    in
+    String.Map.iter
+      (fun constr out_idents ->
+        match out_idents with
+        | [] -> ()
+        | [out_ident] ->
+            fprintf ppf
+              "@ @[<2>@{<hint>Hint@}:@ %a@ is an existential type@ \
+               bound by the constructor@ %a.@]"
+              (Style.as_inline_code !Oprint.out_ident) out_ident
+              Style.inline_code constr
+        | out_ident :: out_idents ->
+            fprintf ppf
+              "@ @[<2>@{<hint>Hint@}:@ %a@ and %a@ are existential types@ \
+               bound by the constructor@ %a.@]"
+              (Format.pp_print_list
+                 ~pp_sep:(fun ppf () -> fprintf ppf ",@ ")
+                 (Style.as_inline_code !Oprint.out_ident))
+              (List.rev out_idents)
+              (Style.as_inline_code !Oprint.out_ident) out_ident
+              Style.inline_code constr)
+      constrs
+
+end
+
 module Names : sig
   val reset_names : unit -> unit
 
@@ -1063,7 +1127,7 @@ let reset_loop_marks () =
   visited_objects := []; aliased := []; delayed := []; printed_aliases := []
 
 let reset_except_context () =
-  Names.reset_names (); reset_loop_marks ()
+  Names.reset_names (); reset_loop_marks (); Internal_names.reset ()
 
 let reset () =
   Conflicts.reset ();
@@ -1119,9 +1183,10 @@ let rec tree_of_typexp mode ty =
         let tyl' = apply_subst s tyl in
         if is_nth s && not (tyl'=[])
         then tree_of_typexp mode (List.hd tyl')
-        else
-          let tpath = tree_of_best_type_path p p' in
-          Otyp_constr (tpath, tree_of_typlist mode tyl')
+        else begin
+          Internal_names.add p';
+          Otyp_constr (tree_of_best_type_path p p', tree_of_typlist mode tyl')
+        end
     | Tvariant row ->
         let Row {fields; name; closed; _} = row_repr row in
         let fields =
@@ -1867,7 +1932,7 @@ let dummy =
   {
     type_params = [];
     type_arity = 0;
-    type_kind = Type_abstract Abstract_def;
+    type_kind = Type_abstract Origin_def;
     type_private = Public;
     type_manifest = None;
     type_variance = [];
@@ -2285,7 +2350,11 @@ let explain_fixed_row pos expl = match expl with
   | Reified p ->
     dprintf "The %a variant type is bound to %a"
       Errortrace.print_pos pos
-      (Style.as_inline_code (fun ppf p -> print_path p ppf)) p
+      (Style.as_inline_code
+         (fun ppf p ->
+           Internal_names.add p;
+           print_path p ppf))
+      p
   | Rigid -> ignore
 
 let explain_variant (type variety) : variety Errortrace.variant -> _ = function
@@ -2436,7 +2505,8 @@ let warn_on_missing_def env ppf t =
   match get_desc t with
   | Tconstr (p,_,_) ->
     begin match Env.find_type p env with
-    | { type_kind = Type_abstract Abstract_rec_check_regularity; _ } ->
+    | { type_kind = Type_abstract Origin_rec_check_regularity;
+        type_manifest = None; _ } ->
         fprintf ppf
           "@,@[<hov>Type %a was considered abstract@ when checking\
            @ constraints@ in this@ recursive type definition.@]"
@@ -2445,9 +2515,7 @@ let warn_on_missing_def env ppf t =
         fprintf ppf
           "@,@[<hov>Type %a is abstract because@ no corresponding\
            @ cmi file@ was found@ in path.@]" (Style.as_inline_code path) p
-    | {type_kind =
-       Type_abstract Abstract_def | Type_record _ | Type_variant _ | Type_open }
-      -> ()
+    | _ -> ()
     end
   | _ -> ()
 
@@ -2503,6 +2571,7 @@ let error trace_format mode subst env tr txt1 ppf txt2 ty_expect_explanation =
         (explain mis);
       if env <> Env.empty
       then warn_on_missing_defs env ppf head;
+      Internal_names.print_explanations env ppf;
       Conflicts.print_explanations ppf;
       print_labels := true
     with exn ->

--- a/typing/typeclass.ml
+++ b/typing/typeclass.ml
@@ -1448,7 +1448,7 @@ let temp_abbrev loc arity uid =
   let ty_td =
       {type_params = !params;
        type_arity = arity;
-       type_kind = Type_abstract Abstract_def;
+       type_kind = Type_abstract Origin_def;
        type_private = Public;
        type_manifest = Some ty;
        type_variance = Variance.unknown_signature ~injective:false ~arity;
@@ -1672,7 +1672,7 @@ let class_infos define_class kind
     {
      type_params = obj_params;
      type_arity = arity;
-     type_kind = Type_abstract Abstract_def;
+     type_kind = Type_abstract Origin_def;
      type_private = Public;
      type_manifest = Some obj_ty;
      type_variance = Variance.unknown_signature ~injective:false ~arity;

--- a/typing/typeclass.ml
+++ b/typing/typeclass.ml
@@ -1448,7 +1448,7 @@ let temp_abbrev loc arity uid =
   let ty_td =
       {type_params = !params;
        type_arity = arity;
-       type_kind = Type_abstract Origin_def;
+       type_kind = Type_abstract Definition;
        type_private = Public;
        type_manifest = Some ty;
        type_variance = Variance.unknown_signature ~injective:false ~arity;
@@ -1672,7 +1672,7 @@ let class_infos define_class kind
     {
      type_params = obj_params;
      type_arity = arity;
-     type_kind = Type_abstract Origin_def;
+     type_kind = Type_abstract Definition;
      type_private = Public;
      type_manifest = Some obj_ty;
      type_variance = Variance.unknown_signature ~injective:false ~arity;

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -752,7 +752,7 @@ let solve_constructor_annotation
   let ids =
     List.map
       (fun name ->
-        let decl = new_local_type ~loc:name.loc () in
+        let decl = new_local_type ~loc:name.loc Origin_def in
         let (id, new_env) =
           Env.enter_type ~scope:expansion_scope name.txt decl !!penv in
         Pattern_env.set_env penv new_env;
@@ -1704,7 +1704,7 @@ and type_pat_aux
       begin match no_existentials, constr.cstr_existentials with
       | None, _ | _, [] -> ()
       | Some r, (_ :: _ as exs)  ->
-          let exs = List.map (Ctype.existential_name constr) exs in
+          let exs = Ctype.existential_names exs in
           let name = constr.cstr_name in
           raise (Error (loc, !!penv, Unexpected_existential (r, name, exs)))
       end;
@@ -4393,7 +4393,7 @@ and type_newtype
   (* Use [with_local_level] just for scoping *)
   with_local_level begin fun () ->
     (* Create a fake abstract type declaration for [name]. *)
-    let decl = new_local_type ~loc () in
+    let decl = new_local_type ~loc Origin_def in
     let scope = create_scope () in
     let (id, new_env) = Env.enter_type ~scope name decl env in
 

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -169,7 +169,7 @@ type error =
   | Modules_not_allowed
   | Cannot_infer_signature
   | Not_a_packed_module of type_expr
-  | Unexpected_existential of existential_restriction * string * string list
+  | Unexpected_existential of existential_restriction * string
   | Invalid_interval
   | Invalid_for_loop_index
   | No_value_clauses
@@ -752,7 +752,7 @@ let solve_constructor_annotation
   let ids =
     List.map
       (fun name ->
-        let decl = new_local_type ~loc:name.loc Origin_def in
+        let decl = new_local_type ~loc:name.loc Definition in
         let (id, new_env) =
           Env.enter_type ~scope:expansion_scope name.txt decl !!penv in
         Pattern_env.set_env penv new_env;
@@ -1703,10 +1703,9 @@ and type_pat_aux
       in
       begin match no_existentials, constr.cstr_existentials with
       | None, _ | _, [] -> ()
-      | Some r, (_ :: _ as exs)  ->
-          let exs = Ctype.existential_names exs in
+      | Some r, (_ :: _) ->
           let name = constr.cstr_name in
-          raise (Error (loc, !!penv, Unexpected_existential (r, name, exs)))
+          raise (Error (loc, !!penv, Unexpected_existential (r, name)))
       end;
       let sarg', existential_styp =
         match sarg with
@@ -4393,7 +4392,7 @@ and type_newtype
   (* Use [with_local_level] just for scoping *)
   with_local_level begin fun () ->
     (* Create a fake abstract type declaration for [name]. *)
-    let decl = new_local_type ~loc Origin_def in
+    let decl = new_local_type ~loc Definition in
     let scope = create_scope () in
     let (id, new_env) = Env.enter_type ~scope name decl env in
 
@@ -6744,7 +6743,7 @@ let report_error ~loc env = function
       Location.errorf ~loc
         "This expression is packed module, but the expected type is@ %a"
         (Style.as_inline_code Printtyp.type_expr) ty
-  | Unexpected_existential (reason, name, types) ->
+  | Unexpected_existential (reason, name) ->
       let reason_str =
          match reason with
         | In_class_args ->
@@ -6765,16 +6764,9 @@ let report_error ~loc env = function
             dprintf
               "Existential types are not allowed in presence of attributes"
       in
-      begin match List.find (fun ty -> ty <> "$" ^ name) types with
-      | example ->
-          Location.errorf ~loc
-            "%t,@ but this pattern introduces the existential type %a."
-            reason_str Style.inline_code example
-      | exception Not_found ->
-          Location.errorf ~loc
-            "%t,@ but the constructor %a introduces existential types."
-            reason_str Style.inline_code name
-      end
+      Location.errorf ~loc
+        "%t,@ but the constructor %a introduces existential types."
+        reason_str Style.inline_code name
   | Invalid_interval ->
       Location.errorf ~loc
         "@[Only character intervals are supported in patterns.@]"

--- a/typing/typecore.mli
+++ b/typing/typecore.mli
@@ -203,7 +203,7 @@ type error =
   | Modules_not_allowed
   | Cannot_infer_signature
   | Not_a_packed_module of type_expr
-  | Unexpected_existential of existential_restriction * string * string list
+  | Unexpected_existential of existential_restriction * string
   | Invalid_interval
   | Invalid_for_loop_index
   | No_value_clauses

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -118,8 +118,8 @@ let enter_type ?abstract_abbrevs rec_flag env sdecl (id, uid) =
   if not needed then env else
   let abstract_source, type_manifest =
     match sdecl.ptype_manifest, abstract_abbrevs with
-    | None, _             -> Origin_def, None
-    | Some _, None        -> Origin_def, Some (Btype.newgenvar ())
+    | None, _             -> Definition, None
+    | Some _, None        -> Definition, Some (Btype.newgenvar ())
     | Some _, Some reason -> reason, None
   in
   let decl =
@@ -374,7 +374,7 @@ let transl_declaration env sdecl (id, uid) =
   in
   let (tkind, kind) =
     match sdecl.ptype_kind with
-      | Ptype_abstract -> Ttype_abstract, Type_abstract Origin_def
+      | Ptype_abstract -> Ttype_abstract, Type_abstract Definition
       | Ptype_variant scstrs ->
         if List.exists (fun cstr -> cstr.pcd_res <> None) scstrs then begin
           match cstrs with
@@ -1140,7 +1140,7 @@ let transl_type_decl env rec_flag sdecl_list =
      cannot be expanded (#12334, #12368) *)
   let abs_env =
     List.fold_left2
-      (enter_type ~abstract_abbrevs:Origin_rec_check_regularity rec_flag)
+      (enter_type ~abstract_abbrevs:Rec_check_regularity rec_flag)
       env sdecl_list ids_list in
   List.iter
     (check_abbrev_regularity ~abs_env new_env id_loc_list to_check)
@@ -1709,7 +1709,7 @@ let transl_with_constraint id ?fixed_row_path ~sig_env ~sig_decl ~outer_env
     if arity_ok && man <> None then
       sig_decl.type_kind, sig_decl.type_unboxed_default
     else
-      Type_abstract Origin_def, false
+      Type_abstract Definition, false
   in
   let new_sig_decl =
     { type_params = params;
@@ -1792,7 +1792,7 @@ let abstract_type_decl ~injective arity =
   Ctype.with_local_level ~post:generalize_decl begin fun () ->
     { type_params = make_params arity;
       type_arity = arity;
-      type_kind = Type_abstract Origin_def;
+      type_kind = Type_abstract Definition;
       type_private = Public;
       type_manifest = None;
       type_variance = Variance.unknown_signature ~injective ~arity;

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -499,7 +499,7 @@ let merge_constraint initial_env loc sg lid constr =
             type_params =
               List.map (fun _ -> Btype.newgenvar()) sdecl.ptype_params;
             type_arity = arity;
-            type_kind = Type_abstract Abstract_def;
+            type_kind = Type_abstract Origin_def;
             type_private = Private;
             type_manifest = None;
             type_variance =

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -499,7 +499,7 @@ let merge_constraint initial_env loc sg lid constr =
             type_params =
               List.map (fun _ -> Btype.newgenvar()) sdecl.ptype_params;
             type_arity = arity;
-            type_kind = Type_abstract Origin_def;
+            type_kind = Type_abstract Definition;
             type_private = Private;
             type_manifest = None;
             type_variance =

--- a/typing/types.ml
+++ b/typing/types.ml
@@ -250,14 +250,15 @@ type type_declaration =
 and type_decl_kind = (label_declaration, constructor_declaration) type_kind
 
 and ('lbl, 'cstr) type_kind =
-    Type_abstract of abstract_reason
+    Type_abstract of type_origin
   | Type_record of 'lbl list * record_representation
   | Type_variant of 'cstr list * variant_representation
   | Type_open
 
-and abstract_reason =
-    Abstract_def
-  | Abstract_rec_check_regularity
+and type_origin =
+    Origin_def
+  | Origin_rec_check_regularity
+  | Origin_existential of string
 
 and record_representation =
     Record_regular                      (* All fields are boxed / tagged *)

--- a/typing/types.ml
+++ b/typing/types.ml
@@ -256,9 +256,9 @@ and ('lbl, 'cstr) type_kind =
   | Type_open
 
 and type_origin =
-    Origin_def
-  | Origin_rec_check_regularity
-  | Origin_existential of string
+    Definition
+  | Rec_check_regularity
+  | Existential of string
 
 and record_representation =
     Record_regular                      (* All fields are boxed / tagged *)

--- a/typing/types.mli
+++ b/typing/types.mli
@@ -492,9 +492,9 @@ and ('lbl, 'cstr) type_kind =
   | Type_open
 
 and type_origin =
-    Origin_def
-  | Origin_rec_check_regularity       (* See Typedecl.transl_type_decl *)
-  | Origin_existential of string
+    Definition
+  | Rec_check_regularity       (* See Typedecl.transl_type_decl *)
+  | Existential of string
 
 and record_representation =
     Record_regular                      (* All fields are boxed / tagged *)

--- a/typing/types.mli
+++ b/typing/types.mli
@@ -486,14 +486,15 @@ type type_declaration =
 and type_decl_kind = (label_declaration, constructor_declaration) type_kind
 
 and ('lbl, 'cstr) type_kind =
-    Type_abstract of abstract_reason
+    Type_abstract of type_origin
   | Type_record of 'lbl list  * record_representation
   | Type_variant of 'cstr list * variant_representation
   | Type_open
 
-and abstract_reason =
-    Abstract_def
-  | Abstract_rec_check_regularity       (* See Typedecl.transl_type_decl *)
+and type_origin =
+    Origin_def
+  | Origin_rec_check_regularity       (* See Typedecl.transl_type_decl *)
+  | Origin_existential of string
 
 and record_representation =
     Record_regular                      (* All fields are boxed / tagged *)

--- a/utils/misc.ml
+++ b/utils/misc.ml
@@ -398,6 +398,12 @@ let no_overflow_mul a b =
 let no_overflow_lsl a k =
   0 <= k && k < Sys.word_size - 1 && min_int asr k <= a && a <= max_int asr k
 
+let letter_of_int n =
+  let letter = String.make 1 (Char.chr (Char.code 'a' + n mod 26)) in
+  let num = n / 26 in
+  if num = 0 then letter
+  else letter ^ Int.to_string num
+
 module Int_literal_converter = struct
   (* To convert integer literals, allowing max_int + 1 (PR#4210) *)
   let cvt_int_aux str neg of_string =

--- a/utils/misc.mli
+++ b/utils/misc.mli
@@ -307,6 +307,8 @@ val no_overflow_lsl: int -> int -> bool
        (** [no_overflow_lsl n k] returns [true] if the computation of
            [n lsl k] does not overflow. *)
 
+val letter_of_int : int -> string
+
 module Int_literal_converter : sig
   val int : string -> int
     (** Convert a string to an integer.  Unlike {!Stdlib.int_of_string},


### PR DESCRIPTION
This PR changes the names of existential types from things like `$Foo_'a` to just `$a` and instead adds an explicit hint describing where `$a` came from. For instance, this message from the testsuite:

```
 Line 2, characters 6-7:
 2 |   | A x
           ^
Error: This pattern matches values of type "$A_'a"
       The type constructor "$A_'a" would escape its scope
```
becomes:
```
 Line 2, characters 6-7:
 2 |   | A x
           ^
Error: This pattern matches values of type "$a"
       The type constructor "$a" would escape its scope
       Hint: "$a" is an existential type bound by the constructor "A".
```

It does this by broadening the `abstract_reason` type to a `type_origin` type that describes where a type has come from, and uses that to annotate existential types in the environment with the constructor they have come from.

The printing is done in the same way as the existing hints about conflicting names. Personally, I think these don't have the best indentation -- it would be better if the hint was unindented -- but I can't see an obvious way to achieve that and it's as much a problem with the conflict hints as with the new ones.