### PR TITLE
Be more XDG-compliant when searching for `init.ml`

### DIFF
--- a/Changes
+++ b/Changes
@@ -336,6 +336,12 @@ Working version
 - #12615: ocamldoc: get rid of the odoc_literate and odoc_todo generators.
   (Sébaistien Hinderer, review by Gabriel Scherer and Florian Angeletti)
 
+- #12624: Use $XDG_CONFIG_DIRS in addition to $XDG_CONFIG_HOME when searching
+  for init.ml and use this to extend init.ml support to the toplevel when
+  running on Windows.
+  (David Allsopp, report by Jonah Beckford, review by Nicolás Ojeda Bär and
+   Antonin Décimo)
+
 - #12688: Setting the env variable `NO_COLOR` with an empty value no longer
   has effects. Previously, setting `NO_COLOR` with any value, including
   the empty value, would disable colors (unless `OCAML_COLOR` is also set).

--- a/configure
+++ b/configure
@@ -20137,11 +20137,11 @@ ocamlc_cppflags="$common_cppflags $CPPFLAGS"
 
 case $host in #(
   *-*-mingw32*) :
-    cclibs="$cclibs -lversion" ;; #(
+    cclibs="$cclibs -lole32 -luuid -lversion" ;; #(
   *-pc-windows) :
     # For whatever reason, flexlink includes -ladvapi32 for mingw-w64, but
     # doesn't include advapi32.lib for MSVC
-    cclibs="$cclibs advapi32.lib version.lib" ;; #(
+    cclibs="$cclibs ole32.lib uuid.lib advapi32.lib version.lib" ;; #(
   *) :
      ;;
 esac

--- a/configure.ac
+++ b/configure.ac
@@ -2444,11 +2444,11 @@ ocamlc_cppflags="$common_cppflags $CPPFLAGS"
 
 AS_CASE([$host],
   [*-*-mingw32*],
-    [cclibs="$cclibs -lversion"],
+    [cclibs="$cclibs -lole32 -luuid -lversion"],
   [*-pc-windows],
     [# For whatever reason, flexlink includes -ladvapi32 for mingw-w64, but
     # doesn't include advapi32.lib for MSVC
-    cclibs="$cclibs advapi32.lib version.lib"])
+    cclibs="$cclibs ole32.lib uuid.lib advapi32.lib version.lib"])
 
 AC_CONFIG_COMMANDS_PRE([cclibs="$cclibs $mathlib $DLLIBS $PTHREAD_LIBS"])
 

--- a/man/ocaml.1
+++ b/man/ocaml.1
@@ -318,15 +318,29 @@ Display a short usage summary and exit.
 When
 .BR ocaml (1)
 is invoked, it will read phrases from an initialization file before
-giving control to the user. The default file is
-.B .ocamlinit
-in the current directory if it exists, otherwise
-.B XDG_CONFIG_HOME/ocaml/init.ml
-according to the XDG base directory specification lookup if it exists (on
-Windows this is skipped), otherwise
-.B .ocamlinit
-in the user's home directory
-.RB ( HOME " variable)."
+giving control to the user. The file read is the first found of:
+.IP 1.
+\fB.ocamlinit\fP in the current directory;
+.IP 2.
+\fBXDG_CONFIG_HOME/ocaml/init.ml\fP, if \fBXDG_CONFIG_HOME\fP is an absolute
+path;
+.IP 3.
+otherwise, on Unix, \fBHOME/ocaml/init.ml\fP or, on Windows,
+\fBocaml\\init.ml\fP under \fBLocalAppData\fP
+(e.g. \fBC:\\Users\\Bactrian\\AppData\\Local\\ocaml\\init.ml\fP);
+.IP 4.
+\fBocaml/init.ml\fP under any of the absolute paths in \fBXDG_CONFIG_DIRS\fP.
+Paths in \fBXDG_CONFIG_DIRS\fP are colon-delimited on Unix, and
+semicolon-delimited on Windows;
+.IP 5.
+if \fBXDG_CONFIG_DIRS\fP contained no absolute paths,
+\fB/usr/xdg/ocaml/init.ml\fP on Unix or, \fBocaml\\init.ml\fP under any of
+\fBLocalAppData\fP (e.g. \fBC:\\Users\\Bactrian\\AppData\\Local\fP),
+\fBRoamingAppData\fP (e.g. \fBC:\\Users\\Bactrian\\AppData\\Roaming\fP), or
+\fBProgramData\fP (e.g. \fBC:\\ProgramData\fP) on Windows;
+.IP 6.
+\fBHOME/.ocamlinit\fP, if \fBHOME\fP is non-empty;
+
 You can specify a different initialization file
 by using the
 .BI \-init " file"
@@ -352,9 +366,10 @@ attempts to underline visually the location of the error. It
 consults the TERM variable to determines the type of output terminal
 and look up its capabilities in the terminal database.
 .TP
-.B XDG_CONFIG_HOME HOME
-.B .ocamlinit
-lookup procedure (see above).
+.B XDG_CONFIG_HOME HOME XDG_CONFIG_DIRS
+See
+.B INITIALIZATION FILE
+above.
 .SH SEE ALSO
 .BR ocamlc "(1), " ocamlopt "(1), " ocamlrun (1).
 .br

--- a/manual/src/cmds/top.etex
+++ b/manual/src/cmds/top.etex
@@ -61,18 +61,29 @@ are printed on standard output, errors on standard error. End-of-file
 on standard input terminates "ocaml" (see also the "#quit" directive
 in section~\ref{s:toplevel-directives}).
 
-On start-up (before the first phrase is read), if the file
-".ocamlinit" exists in the current directory,
-its contents are read as a sequence of OCaml phrases
-and executed as per the "#use" directive
-described in section~\ref{s:toplevel-directives}.
+On start-up (before the first phrase is read), the contents of initialization
+file are read as a sequence of OCaml phrases and executed as per the "#use"
+directive described in section~\ref{s:toplevel-directives}.
 The evaluation outcode for each phrase are not displayed.
-If the current directory does not contain an ".ocamlinit" file,
-the file "XDG_CONFIG_HOME/ocaml/init.ml" is looked up according
-to the XDG base directory specification and used instead (on Windows
-this is skipped). If that file doesn't exist then an [.ocamlinit] file
-in the users' home directory (determined via environment variable "HOME") is
-used if existing.
+
+The initialization file is the first found of:
+\begin{enumerate}
+  \item ".ocamlinit" in the current directory;
+  \item "XDG_CONFIG_HOME/ocaml/init.ml", if "XDG_CONFIG_HOME" is an absolute
+    path;
+  \item otherwise, on Unix, "HOME/ocaml/init.ml" or, on Windows,
+    "ocaml\\init.ml" under "LocalAppData"
+    (e.g. "C:\\Users\\Bactrian\\AppData\\Local\\ocaml\\init.ml");
+  \item "ocaml/init.ml" under any of the absolute paths in "XDG_CONFIG_DIRS".
+    Paths in "XDG_CONFIG_DIRS" are colon-delimited on Unix, and
+    semicolon-delimited on Windows;
+  \item if "XDG_CONFIG_DIRS" contained no absolute paths,
+    "/usr/xdg/ocaml/init.ml" on Unix or, "ocaml\\init.ml" under any of
+    "LocalAppData" (e.g. "C:\\Users\\Bactrian\\AppData\\Local"),
+    "RoamingAppData" (e.g. "C:\\Users\\Bactrian\\AppData\\Roaming"), or
+    "ProgramData" (e.g. "C:\\ProgramData") on Windows;
+  \item "HOME/.ocamlinit", if "HOME" is non-empty;
+\end{enumerate}
 
 The toplevel system does not perform line editing, but it can
 easily be used in conjunction with an external line editor such as
@@ -136,8 +147,8 @@ attempts to underline visually the location of the error. It
 consults the "TERM" variable to determines the type of output terminal
 and look up its capabilities in the terminal database.
 
-\item["XDG_CONFIG_HOME", "HOME"]
-".ocamlinit" lookup procedure (see above).
+\item["XDG_CONFIG_HOME", "HOME", "XDG_CONFIG_DIRS"]
+Initialization file lookup procedure (see above).
 \end{options}
 \end{unix}
 

--- a/manual/src/cmds/unified-options.etex
+++ b/manual/src/cmds/unified-options.etex
@@ -313,9 +313,24 @@ them to silently become direct dependencies.
 \top{%
 \item["-init" \var{file}]
 Load the given file instead of the default initialization file.
-The default file is ".ocamlinit" in the current directory if it
-exists, otherwise "XDG_CONFIG_HOME/ocaml/init.ml" or
-".ocamlinit" in the user's home directory.
+The default initialization file is the first found of:
+\begin{enumerate}
+  \item ".ocamlinit" in the current directory;
+  \item "XDG_CONFIG_HOME/ocaml/init.ml", if "XDG_CONFIG_HOME" is an absolute
+    path;
+  \item otherwise, on Unix, "HOME/ocaml/init.ml" or, on Windows,
+    "ocaml\\init.ml" under "LocalAppData"
+    (e.g. "C:\\Users\\Bactrian\\AppData\\Local\\ocaml\\init.ml");
+  \item "ocaml/init.ml" under any of the absolute paths in "XDG_CONFIG_DIRS".
+    Paths in "XDG_CONFIG_DIRS" are colon-delimited on Unix, and
+    semicolon-delimited on Windows;
+  \item if "XDG_CONFIG_DIRS" contained no absolute paths,
+    "/usr/xdg/ocaml/init.ml" on Unix or, "ocaml\\init.ml" under any of
+    "LocalAppData" (e.g. "C:\\Users\\Bactrian\\AppData\\Local"),
+    "RoamingAppData" (e.g. "C:\\Users\\Bactrian\\AppData\\Roaming"), or
+    "ProgramData" (e.g. "C:\\ProgramData") on Windows;
+  \item "HOME/.ocamlinit", if "HOME" is non-empty;
+\end{enumerate}
 }%top
 
 \notop{%

--- a/runtime/caml/osdeps.h
+++ b/runtime/caml/osdeps.h
@@ -140,6 +140,8 @@ CAMLextern void caml_expand_command_line (int *, wchar_t ***);
 
 CAMLextern clock_t caml_win32_clock(void);
 
+CAMLextern value caml_win32_xdg_defaults(void);
+
 #endif /* _WIN32 */
 
 /* Returns the current value of a counter that increments once per nanosecond.

--- a/runtime/sys.c
+++ b/runtime/sys.c
@@ -758,3 +758,15 @@ CAMLprim value caml_sys_isatty(value chan)
 
   return ret;
 }
+
+/* On Windows, returns a string list of directories to search for configuration
+   files. On Unix, this list is more easily computed in OCaml, so the list
+   returned by the primitive is empty. */
+CAMLprim value caml_xdg_defaults(value unit)
+{
+#ifdef _WIN32
+  return caml_win32_xdg_defaults();
+#else
+  return Val_emptylist;
+#endif
+}

--- a/runtime/win32.c
+++ b/runtime/win32.c
@@ -27,6 +27,7 @@
 #include <winbase.h>
 #include <winsock2.h>
 #include <winioctl.h>
+#include <shlobj.h>
 #include <direct.h>
 #include <stdlib.h>
 #include <stdio.h>
@@ -1237,4 +1238,31 @@ int caml_posixerr_of_win32err(unsigned int errcode)
     }
   }
   return 0;
+}
+
+value caml_win32_xdg_defaults(void)
+{
+  CAMLparam0();
+  CAMLlocal2(opath, result);
+
+  PWSTR wpath;
+
+  result = Val_emptylist;
+  if (SHGetKnownFolderPath(&FOLDERID_ProgramData, 0, NULL, &wpath) == S_OK) {
+    opath = caml_copy_string_of_utf16(wpath);
+    result = caml_alloc_2(Tag_cons, opath, result);
+  }
+  CoTaskMemFree(wpath); /* wpath must be freed, even on error */
+  if (SHGetKnownFolderPath(&FOLDERID_RoamingAppData, 0, NULL, &wpath) == S_OK) {
+    opath = caml_copy_string_of_utf16(wpath);
+    result = caml_alloc_2(Tag_cons, opath, result);
+  }
+  CoTaskMemFree(wpath);
+  if (SHGetKnownFolderPath(&FOLDERID_LocalAppData, 0, NULL, &wpath) == S_OK) {
+    opath = caml_copy_string_of_utf16(wpath);
+    result = caml_alloc_2(Tag_cons, opath, result);
+  }
+  CoTaskMemFree(wpath);
+
+  CAMLreturn(result);
 }

--- a/tools/check-symbol-names
+++ b/tools/check-symbol-names
@@ -23,6 +23,8 @@ nm -A -P "$@" | LC_ALL=C awk '
 $2 ~ /^(\.refptr\.)?(__emutls_v\.)?(_?caml[_A-Z])/ { next }
 # ignore re_foo
 $2 ~ /^(\.refptr\.)?(_?re_)/ { next }
+# ignore symbols pulled in by SHGetKnownFolderPath
+$2 ~ /^\.refptr\.FOLDERID_[a-zA-Z]+/ { next }
 # ignore local and undefined symbols
 $3 ~ /^[a-zU]$/ { next }
 # ignore "main", which should be externally linked

--- a/toplevel/toploop.mli
+++ b/toplevel/toploop.mli
@@ -195,3 +195,11 @@ val override_sys_argv : string array -> unit
    This is called by [run_script] so that [Sys.argv] represents
    "script.ml args..." instead of the full command line:
    "ocamlrun unix.cma ... script.ml args...". *)
+
+val split_path : string -> string list
+(** [split_path path] splits [path] according to the PATH-splitting conventions
+    of the platform. On Unix, this is exactly [String.split_on_char ':' path].
+    On Windows, entries are separated by semicolons. Sections of entries may be
+    double-quoted (which allows semicolons in filenames to be quoted). The
+    double-quote characters are stripped (i.e. [f"o"o = foo]; also
+    [split_path "foo\";\";bar" = ["foo;"; "bar"]) *)


### PR DESCRIPTION
This is a possible alternate implementation for extending the toplevel's use of XDG when searching for `init.ml` for better Windows support, originally outlined in https://github.com/ocaml/ocaml/pull/12364#issuecomment-1688836250.

The fundamental problem here arises from a Windows configuration subtlety added a while ago in Windows 2000. For Windows users, there are two kinds of user configuration - _roaming_ (typically stored in `AppData\Roaming` in a user's profile directory and intended to be synchronised between machines) and _local_ (typically stored in `AppData\Local` in a user's profile directory and for that specific machine only). For the OCaml toplevel, it is not possible to define which one a user may want (indeed, it's quite plausible that a user might want to load configuration from both!).

This PR seeks to solve the problem on Windows by adopting more of the [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html) on _all_ platforms, and then doing an appropriate translation of the XDG defaults for Windows. At present, the toplevel only inspects `$XDG_CONFIG_HOME`, but XDG also provides `$XDG_CONFIG_DIRS`.

For Unix, the toplevel now reads the first startup file of:

1. `.ocamlinit` in the current directory
2. `$XDG_CONFIG_HOME/ocaml/init.ml` if `$XDG_CONFIG_HOME` is an absolute path
3. `$HOME/.config/ocaml/init.ml` _only_ if `$XDG_CONFIG_HOME` is unset, empty or a non-absolute path and `$HOME` is non-empty
4. `ocaml/init.ml` under any of the absolute paths in the `:`-separated list `$XDG_CONFIG_DIRS`
5. `/etc/xdg/ocaml/init.ml` _only_ if `$XDG_CONFIG_DIRS` is unset, or contains no absolute paths
6. `$HOME/.ocamlinit`, if `$HOME` is non-empty

For Windows, we use the XDG environment variables, but with the following tweaks:
- Instead of `$HOME/.config` (case 3), we use the location of [FOLDERID_LocalAppData](https://learn.microsoft.com/en-us/windows/win32/shell/knownfolderid#FOLDERID_LocalAppData) returned by [SHGetKnownFolderPath](https://learn.microsoft.com/en-us/windows/win32/api/shlobj_core/nf-shlobj_core-shgetknownfolderpath)
- Instead of treating `$XDG_CONFIG_DIRS` as `:`-separated, we use the same rules as for splitting the `Path` environment variable on Windows (`;`-separated; double-quoted sub-strings treated as literals)
- Instead of `/etc/xdg` (case 5), we use the following three locations from [SHGetKnownFolderPath](https://learn.microsoft.com/en-us/windows/win32/api/shlobj_core/nf-shlobj_core-shgetknownfolderpath):
  - [FOLDERID_LocalAppData](https://learn.microsoft.com/en-us/windows/win32/shell/knownfolderid#FOLDERID_LocalAppData) returned by [SHGetKnownFolderPath](https://learn.microsoft.com/en-us/windows/win32/api/shlobj_core/nf-shlobj_core-shgetknownfolderpath) - typically `C:\Users\userid\AppData\Local`
  - [FOLDERID_RoamingAppData](https://learn.microsoft.com/en-us/windows/win32/shell/knownfolderid#FOLDERID_LocalAppData) returned by [SHGetKnownFolderPath](https://learn.microsoft.com/en-us/windows/win32/api/shlobj_core/nf-shlobj_core-shgetknownfolderpath) - typically `C:\Users\userid\AppData\Roaming`
  - [FOLDERID_ProgramData](https://learn.microsoft.com/en-us/windows/win32/shell/knownfolderid#FOLDERID_LocalAppData) returned by [SHGetKnownFolderPath](https://learn.microsoft.com/en-us/windows/win32/api/shlobj_core/nf-shlobj_core-shgetknownfolderpath) - typically `C:\ProgramData`

There is a subtle tweak to the Windows default for `$XDG_CONFIG_DIRS` (noted in the code as well), which is intended to cater for the not inconceivable scenario where a Windows user has `$XDG_CONFIG_HOME` set _in Cygwin_ (e.g. to `/home/userid/.config`) and then starts a _native Windows_ `ocaml.exe` (which is likely not to find anything in `\home\userid\.config` on the current drive). The tweak is that `FOLDERID_LocalAppData` is _both_ the default for `$XDG_CONFIG_HOME` and _also_ the first entry in the default for `$XDG_CONFIG_DIRS`.

The hope is that what previously would have been Windows-specific workarounds are now merely platform-specific defaults for a cross-platform solution. Incidentally, various other libraries propose alternate defaults for macOS, but there seems to be even less agreement on what those should be than there is for Windows, so I've left grasping that nettle for another day by just leaving macOS treated as Unix.

For the OCaml toplevel, the _first_ located `init.ml` is the only one which matters (cf. last paragraph of XDG BDS); naturally, nothing prevents a user from configuring their `init.ml` files such that `init.ml` from further locations is loaded. In particular, for Windows users, that means that a user could choose to call `Toploop.use_silently` from within `init.ml` in `AppData\Local` to source the `init.ml` in `AppData\Roaming` should they so desire!

Notes on the implementation:
- Path-splitting on Windows is tedious because of the `"`-quote rules. Although it's technically only necessary to double-quote semicolon characters (which are _not_ common in directory names!), it's really quite commonplace to see spaces double-quoted.
- `SHGetKnownFolderPath` is a tricky function to wrap (the `FOLDERID_` values are bulky and numerous, so not really wanted in a static array, etc.). I elected for what I hope is a simpler approach with a C primitive that just returns an empty list on Unix and returns the three values needed on Windows. It's much less code, at the cost of a slightly odd-looking primitive. Pedantically, the Unix version of it could construct `["/etc/xdg"]` in C code 🤷‍♂
- The diff of `Toploop.find_ocamlinit` is very noisy - it's probably easiest just to re-review the entire function in terms of the specification above.

TODO
- [x] Documentation (as in #12364 - man-pages, and manual)