### PR TITLE
Remove the Closure module from Obj

### DIFF
--- a/Changes
+++ b/Changes
@@ -187,6 +187,9 @@ Working version
   (Guillaume Munch-Maccagnoni, review by KC Sivaramakrishnan
    and Gabriel Scherer)
 
+- #12625: Remove the Closure module from Obj
+  (Vincent Laviron, not reviewed)
+
 ### Other libraries:
 
 - #12213: Dynlink library, improve legibility of error messages

--- a/Changes
+++ b/Changes
@@ -188,7 +188,7 @@ Working version
    and Gabriel Scherer)
 
 - #12625: Remove the Closure module from Obj
-  (Vincent Laviron, not reviewed)
+  (Vincent Laviron, review by Xavier Leroy)
 
 ### Other libraries:
 

--- a/stdlib/.depend
+++ b/stdlib/.depend
@@ -532,12 +532,10 @@ stdlib__Nativeint.cmx : nativeint.ml \
 stdlib__Nativeint.cmi : nativeint.mli
 stdlib__Obj.cmo : obj.ml \
     stdlib__Sys.cmi \
-    stdlib__Nativeint.cmi \
     stdlib__Int32.cmi \
     stdlib__Obj.cmi
 stdlib__Obj.cmx : obj.ml \
     stdlib__Sys.cmx \
-    stdlib__Nativeint.cmx \
     stdlib__Int32.cmx \
     stdlib__Obj.cmi
 stdlib__Obj.cmi : obj.mli \

--- a/stdlib/obj.ml
+++ b/stdlib/obj.ml
@@ -68,33 +68,6 @@ let int_tag = 1000
 let out_of_heap_tag = 1001
 let unaligned_tag = 1002
 
-module Closure = struct
-  type info = {
-    arity: int;
-    start_env: int;
-  }
-
-  let info_of_raw (info : nativeint) =
-    let open Nativeint in
-    let arity =
-      (* signed: negative for tupled functions *)
-      if Sys.word_size = 64 then
-        to_int (shift_right info 56)
-      else
-        to_int (shift_right info 24)
-    in
-    let start_env =
-      (* start_env is unsigned, but we know it can always fit an OCaml
-         integer so we use [to_int] instead of [unsigned_to_int]. *)
-      to_int (shift_right_logical (shift_left info 8) 9) in
-    { arity; start_env }
-
-  (* note: we expect a closure, not an infix pointer *)
-  let info (obj : t) =
-    assert (tag obj = closure_tag);
-    info_of_raw (raw_field obj 1)
-end
-
 module Extension_constructor =
 struct
   type t = extension_constructor

--- a/stdlib/obj.mli
+++ b/stdlib/obj.mli
@@ -92,14 +92,6 @@ val int_tag : int
 val out_of_heap_tag : int
 val unaligned_tag : int   (* should never happen @since 3.11 *)
 
-module Closure : sig
-  type info = {
-    arity: int;
-    start_env: int;
-  }
-  val info : t -> info
-end
-
 module Extension_constructor :
 sig
   type t = extension_constructor


### PR DESCRIPTION
It was introduced in #9691, for use in `CamlinternalMod`, but rendered obsolete by #10205.
It could have been used outside the compiler, but given that it doesn't support all closures (it fails on infix ones), I don't think it's useful on its own.