### PR TITLE
feat: `caml_fatal_error` on misuse of deserialize functions

### DIFF
--- a/Changes
+++ b/Changes
@@ -382,7 +382,7 @@ Working version
 - #11931: Fix tricky typing bug with type substitutions
   (Stephen Dolan, review by Leo White and Jacques Garrigue)
 
-- #12037: get_extern_state potential NULL dereference.
+- #12037, #12171: Fix get_extern_state potential NULL dereference.
   (Alexander Skvortsov, report by Török Edwin,
    design by Gabriel Scherer, Xavier Leroy)
 

--- a/Changes
+++ b/Changes
@@ -386,6 +386,9 @@ Working version
   (Alexander Skvortsov, report by Török Edwin,
    design by Gabriel Scherer, Xavier Leroy)
 
+- #12635: Fix get_intern_state potential NULL dereference.
+  (Antonin Décimo, review by KC Sivaramakrishnan)
+
 - #12032, #12059: Bug fixes related to compilation of recursive definitions
   (Vincent Laviron, report by Victoire Noizet, review by Gabriel Scherer)
 


### PR DESCRIPTION
Mimicking #12171, this PR gets `intern.c` closer to `extern.c`. It fixes a problem with possible misuse of deserialize functions, as these should only be called from within a `caml_input_*` entrypoint context. Otherwise, the field `intern_src` of `struct caml_intern_state` won't have been populated, and a null pointer dereference occurs.

cc @askvortsov1 and @gasche who authored and reviewed the original PR.