### PR TITLE
Fix cyclic type error messages in presence of `-short-paths`

### DIFF
--- a/Changes
+++ b/Changes
@@ -458,6 +458,10 @@ OCaml 5.1.1
 - #12623, fix the computation of variance composition
   (Florian Angeletti, report by Vesa Karvonen, review by Gabriel Scherer)
 
+- #12645, fix error messages for cyclic type definitions in presence of
+  the `-short-paths` flag.
+  (Florian Angeletti, report by Vesa Karvonen, review by Gabriel Scherer)
+
 OCaml 5.1.0 (14 September 2023)
 -------------------------------
 

--- a/testsuite/tests/typing-short-paths/errors.ml
+++ b/testsuite/tests/typing-short-paths/errors.ml
@@ -73,3 +73,61 @@ Error: This expression has type "$a" but an expression was expected of type "'a"
        it would escape the scope of its equation
        Hint: "$a" is an existential type bound by the constructor "Pair".
 |}]
+
+(** Cycle type definitions *)
+
+type 'a t = 'a t
+[%%expect {|
+Line 3, characters 0-16:
+3 | type 'a t = 'a t
+    ^^^^^^^^^^^^^^^^
+Error: The type abbreviation "t" is cyclic:
+         "'a t" = "'a t"
+|}]
+
+type 'a t = 'a u
+and 'a u = 'a v * 'a
+and 'a v = 'a w list
+and 'a w = 'a option z
+and 'a z = 'a t
+[%%expect {|
+Line 1, characters 0-16:
+1 | type 'a t = 'a u
+    ^^^^^^^^^^^^^^^^
+Error: The type abbreviation "t" is cyclic:
+         "'a t" = "'a u",
+         "'a u" = "'a v * 'a",
+         "'a v * 'a" contains "'a v",
+         "'a v" = "'a w list",
+         "'a w list" contains "'a w",
+         "'a w" = "'a option z",
+         "'a option z" = "'a option t"
+|}]
+
+
+type 'a u = < x : 'a>
+and 'a t = 'a t u;;
+[%%expect{|
+Line 2, characters 0-17:
+2 | and 'a t = 'a t u;;
+    ^^^^^^^^^^^^^^^^^
+Error: The type abbreviation "t" is cyclic:
+         "'a t u" contains "'a t",
+         "'a t" = "'a t u",
+         "'a t u" contains "'a t"
+|}];; (* fails since 4.04 *)
+
+
+module rec A : sig type t = B.t -> int end = struct type t = B.t -> int end
+       and B : sig type t = A.t end = struct type t = A.t end;;
+[%%expect {|
+Line 1, characters 0-75:
+1 | module rec A : sig type t = B.t -> int end = struct type t = B.t -> int end
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The definition of "A.t" contains a cycle:
+         "B.t -> int" contains "B.t",
+         "B.t" = "B.t",
+         "B.t" = "B.t -> int",
+         "B.t -> int" contains "B.t",
+         "B.t" = "B.t"
+|}]

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -781,7 +781,7 @@ let check_abbrev env sdecl (id, decl) =
    - if -rectypes is not used, we only allow cycles in the type graph
      if they go through an object or polymorphic variant type *)
 
-let check_well_founded env loc path to_check visited ty0 =
+let check_well_founded ~abs_env env loc path to_check visited ty0 =
   let rec check parents trace ty =
     if TypeSet.mem ty parents then begin
       (*Format.eprintf "@[%a@]@." Printtyp.raw_type_expr ty;*)
@@ -797,8 +797,8 @@ let check_well_founded env loc path to_check visited ty0 =
           | trace -> List.rev trace, false
         in
         if rec_abbrev
-        then Recursive_abbrev (Path.name path, env, reaching_path)
-        else Cycle_in_def (Path.name path, env, reaching_path)
+        then Recursive_abbrev (Path.name path, abs_env, reaching_path)
+        else Cycle_in_def (Path.name path, abs_env, reaching_path)
       in raise (Error (loc, err))
     end;
     let (fini, parents) =
@@ -843,11 +843,11 @@ let check_well_founded env loc path to_check visited ty0 =
     (* Will be detected by check_regularity *)
     Btype.backtrack snap
 
-let check_well_founded_manifest env loc path decl =
+let check_well_founded_manifest ~abs_env env loc path decl =
   if decl.type_manifest = None then () else
   let args = List.map (fun _ -> Ctype.newvar()) decl.type_params in
   let visited = ref TypeMap.empty in
-  check_well_founded env loc path (Path.same path) visited
+  check_well_founded ~abs_env env loc path (Path.same path) visited
     (Ctype.newconstr path args)
 
 (* Given a new type declaration [type t = ...] (potentially mutually-recursive),
@@ -865,7 +865,7 @@ let check_well_founded_manifest env loc path decl =
    (we don't have an example at hand where it is necessary), but we
    are doing it anyway out of caution.
 *)
-let check_well_founded_decl env loc path decl to_check =
+let check_well_founded_decl  ~abs_env env loc path decl to_check =
   let open Btype in
   (* We iterate on all subexpressions of the declaration to check
      "in depth" that no ill-founded type exists. *)
@@ -884,7 +884,7 @@ let check_well_founded_decl env loc path decl to_check =
     {type_iterators with it_type_expr =
      (fun self ty ->
        if TypeSet.mem ty !checked then () else begin
-         check_well_founded env loc path to_check visited ty;
+         check_well_founded  ~abs_env env loc path to_check visited ty;
          checked := TypeSet.add ty !checked;
          self.it_do_type_expr self ty
        end)} in
@@ -1124,24 +1124,25 @@ let transl_type_decl env rec_flag sdecl_list =
     List.map2 (fun (id, _) sdecl -> (id, sdecl.ptype_loc))
       ids_list sdecl_list
   in
+  (* [check_abbrev_regularity] and error messages cannot use the new
+     environment, as this might result in non-termination. Instead we use a
+     completely abstract version of the temporary environment, giving a reason
+     for why abbreviations cannot be expanded (#12334, #12368) *)
+  let abs_env =
+    List.fold_left2
+      (enter_type ~abstract_abbrevs:Rec_check_regularity rec_flag)
+      env sdecl_list ids_list in
   List.iter (fun (id, decl) ->
-    check_well_founded_manifest new_env (List.assoc id id_loc_list)
+    check_well_founded_manifest ~abs_env new_env (List.assoc id id_loc_list)
       (Path.Pident id) decl)
     decls;
   let to_check =
     function Path.Pident id -> List.mem_assoc id id_loc_list | _ -> false in
   List.iter (fun (id, decl) ->
-    check_well_founded_decl new_env (List.assoc id id_loc_list) (Path.Pident id)
+    check_well_founded_decl ~abs_env new_env (List.assoc id id_loc_list)
+      (Path.Pident id)
       decl to_check)
     decls;
-  (* [check_abbrev_regularity] cannot use the new environment, as this might
-     result in non-termination. Instead we use a completely abstract version
-     of the temporary environment, giving a reason for why abbreviations
-     cannot be expanded (#12334, #12368) *)
-  let abs_env =
-    List.fold_left2
-      (enter_type ~abstract_abbrevs:Rec_check_regularity rec_flag)
-      env sdecl_list ids_list in
   List.iter
     (check_abbrev_regularity ~abs_env new_env id_loc_list to_check)
     tdecls;
@@ -1823,7 +1824,7 @@ let check_recmod_typedecl env loc recmod_ids path decl =
   (* recmod_ids is the list of recursively-defined module idents.
      (path, decl) is the type declaration to be checked. *)
   let to_check path = Path.exists_free recmod_ids path in
-  check_well_founded_decl env loc path decl to_check;
+  check_well_founded_decl ~abs_env:env env loc path decl to_check;
   check_regularity ~abs_env:env env loc path decl to_check;
   (* additional coherence check, as one might build an incoherent signature,
      and use it to build an incoherent module, cf. #7851 *)


### PR DESCRIPTION
Currently, in OCaml 5.1.0 and trunk, the compiler fails to print the improved error messages for cyclic type definitions,

```ocaml
type 'a t = 'a t
```
> Error: The type abbreviation t is cyclic:
         'a t = 'a t

whenever the `-short-paths` option is enabled. More precisely, the compiler crashes with the scary-looking 

> Error: Fatal error: exception Stack overflow


The reason is that the path normalization of `short-paths` diverges in presence of  cyclic type definitions in the environment, and the error messages for cyclic definitions were using an environment containing the cycle under scrutiny as a printing environment.

This PR fixes this issue by using the abstract environments introduced in #12368 to print the error messages raised in the `check_well_founded` functions safely.
