### PR TITLE
4.14 backport: threads and fork

### DIFF
--- a/Changes
+++ b/Changes
@@ -32,6 +32,9 @@ OCaml 4.14 maintenance version
 - #11633, #11636: bugfix in caml_unregister_frametable
   (Frédéric Recoules, review by Gabriel Scherer)
 
+- #12636, #12646: More prudent reinitialization of I/O mutexes after a fork()
+  (Xavier Leroy, report by Zach Baylin, review by Enguerrand Decorne)
+
 OCaml 4.14.1 (20 December 2022)
 ------------------------------
 

--- a/otherlibs/systhreads/st_posix.h
+++ b/otherlibs/systhreads/st_posix.h
@@ -27,7 +27,6 @@
 #ifdef __linux__
 #include <unistd.h>
 #endif
-#include <caml/domain.h>
 
 typedef int st_retcode;
 
@@ -393,24 +392,6 @@ static void * caml_thread_tick(void * arg)
     caml_record_signal(SIGPREEMPTION);
   }
   return NULL;
-}
-
-/* "At fork" processing */
-
-#if defined(__ANDROID__)
-/* Android's libc does not include declaration of pthread_atfork;
-   however, it implements it since API level 10 (Gingerbread).
-   The reason for the omission is that Android (GUI) applications
-   are not supposed to fork at all, however this workaround is still
-   included in case OCaml is used for an Android CLI utility. */
-int pthread_atfork(void (*prepare)(void), void (*parent)(void),
-                   void (*child)(void));
-#endif
-
-static int st_atfork(void (*fn)(void))
-{
-  caml_atfork_hook = fn;
-  return 0;
 }
 
 /* Signal handling */

--- a/otherlibs/systhreads/st_posix.h
+++ b/otherlibs/systhreads/st_posix.h
@@ -27,6 +27,7 @@
 #ifdef __linux__
 #include <unistd.h>
 #endif
+#include <caml/domain.h>
 
 typedef int st_retcode;
 
@@ -408,7 +409,8 @@ int pthread_atfork(void (*prepare)(void), void (*parent)(void),
 
 static int st_atfork(void (*fn)(void))
 {
-  return pthread_atfork(NULL, NULL, fn);
+  caml_atfork_hook = fn;
+  return 0;
 }
 
 /* Signal handling */

--- a/otherlibs/systhreads/st_posix.h
+++ b/otherlibs/systhreads/st_posix.h
@@ -197,29 +197,39 @@ Caml_inline void st_thread_yield(st_masterlock * m)
 
 typedef pthread_mutex_t * st_mutex;
 
-static int st_mutex_create(st_mutex * res)
+static int st_mutex_init(st_mutex m)
 {
   int rc;
   pthread_mutexattr_t attr;
-  st_mutex m;
 
   rc = pthread_mutexattr_init(&attr);
   if (rc != 0) goto error1;
   rc = pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_ERRORCHECK);
   if (rc != 0) goto error2;
-  m = caml_stat_alloc_noexc(sizeof(pthread_mutex_t));
-  if (m == NULL) { rc = ENOMEM; goto error2; }
   rc = pthread_mutex_init(m, &attr);
-  if (rc != 0) goto error3;
+  if (rc != 0) goto error2;
   pthread_mutexattr_destroy(&attr);
-  *res = m;
   return 0;
-error3:
-  caml_stat_free(m);
 error2:
   pthread_mutexattr_destroy(&attr);
 error1:
   return rc;
+}
+
+static int st_mutex_create(st_mutex * res)
+{
+  int rc;
+  st_mutex m;
+
+  m = caml_stat_alloc_noexc(sizeof(pthread_mutex_t));
+  if (m == NULL) { return ENOMEM; }
+  rc = st_mutex_init(m);
+  if (rc != 0) {
+    caml_stat_free(m);
+    return rc;
+  }
+  *res = m;
+  return 0;
 }
 
 static int st_mutex_destroy(st_mutex m)

--- a/otherlibs/systhreads/st_stubs.c
+++ b/otherlibs/systhreads/st_stubs.c
@@ -417,14 +417,11 @@ static void caml_thread_reinitialize(void)
   /* Tick thread is not currently running in child process, will be
      re-created at next Thread.create */
   caml_tick_thread_running = 0;
-  /* Destroy all IO mutexes; will be reinitialized on demand */
+  /* Reinitialize all IO mutexes */
   for (chan = caml_all_opened_channels;
        chan != NULL;
        chan = chan->next) {
-    if (chan->mutex != NULL) {
-      st_mutex_destroy(chan->mutex);
-      chan->mutex = NULL;
-    }
+    if (chan->mutex != NULL) st_mutex_init(chan->mutex);
   }
 }
 

--- a/otherlibs/systhreads/st_stubs.c
+++ b/otherlibs/systhreads/st_stubs.c
@@ -475,7 +475,7 @@ CAMLprim value caml_thread_initialize(value unit)   /* ML */
   caml_memprof_th_ctx_iter_hook = memprof_ctx_iter;
   /* Set up fork() to reinitialize the thread machinery in the child
      (PR#4577) */
-  st_atfork(caml_thread_reinitialize);
+  caml_atfork_hook = caml_thread_reinitialize;
   return Val_unit;
 }
 

--- a/otherlibs/systhreads/st_win32.h
+++ b/otherlibs/systhreads/st_win32.h
@@ -222,6 +222,12 @@ static DWORD st_mutex_destroy(st_mutex m)
   return 0;
 }
 
+/* Unused under Windows because there is no fork() */
+static DWORD st_mutex_init(st_mutex m)
+{
+  return 0;
+}
+
 /* Error codes with the 29th bit set are reserved for the application */
 
 #define MUTEX_DEADLOCK (1<<29 | 1)

--- a/otherlibs/systhreads/st_win32.h
+++ b/otherlibs/systhreads/st_win32.h
@@ -516,13 +516,6 @@ static DWORD WINAPI caml_thread_tick(void * arg)
   return 0;
 }
 
-/* "At fork" processing -- none under Win32 */
-
-static DWORD st_atfork(void (*fn)(void))
-{
-  return 0;
-}
-
 /* Signal handling -- none under Win32 */
 
 value caml_thread_sigmask(value cmd, value sigs) /* ML */

--- a/otherlibs/unix/fork.c
+++ b/otherlibs/unix/fork.c
@@ -15,6 +15,7 @@
 
 #define CAML_INTERNALS
 
+#include <caml/domain.h>
 #include <caml/mlvalues.h>
 #include <caml/debugger.h>
 #include <caml/eventlog.h>
@@ -27,6 +28,7 @@ CAMLprim value unix_fork(value unit)
   CAML_EV_FLUSH();
 
   ret = fork();
+  if (ret == 0 && caml_atfork_hook != NULL) caml_atfork_hook();
   if (ret == -1) uerror("fork", Nothing);
 
   CAML_EVENTLOG_DO({

--- a/runtime/caml/domain.h
+++ b/runtime/caml/domain.h
@@ -27,6 +27,8 @@ extern "C" {
 
 void caml_init_domain(void);
 
+CAMLextern void (*caml_atfork_hook)(void);
+
 #endif /* CAML_INTERNALS */
 
 #ifdef __cplusplus

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -92,3 +92,5 @@ void caml_init_domain (void)
   Caml_state->checking_pointer_pc = NULL;
   #endif
 }
+
+CAMLexport void (*caml_atfork_hook)(void) = NULL;


### PR DESCRIPTION
This is a backport to 4.14 of some of the changes in system threads related to the `fork` system call:
- Use a `caml_atfork_hook` instead of `pthread_atfork` to reinitialize the thread machinery after `Unix.fork` (backport of c6d00ee0d44555adb2ec1ce86e8519beff1182c2)
- Remove remaining code related to `pthread_atfork` (backport of 650acfccfc2f09ef88f5acded0e04715e69d6d73)
- Don't destroy locks on I/O channels, this may be dangerous (backport of a change in 5.0 that traces back to Multicore OCaml and that I failed to identify).

Could possibly fix #12636 (to be tested if at all possible).
