### PR TITLE
Fix signed integer overflows when computing min int 

### DIFF
--- a/runtime/caml/config.h
+++ b/runtime/caml/config.h
@@ -135,21 +135,26 @@ typedef unsigned short uint16_t;
 typedef unsigned char uint8_t;
 #endif
 
+#include <limits.h>
+
 #if SIZEOF_PTR == SIZEOF_LONG
 /* Standard models: ILP32 or I32LP64 */
 typedef long intnat;
 typedef unsigned long uintnat;
 #define ARCH_INTNAT_PRINTF_FORMAT "l"
+#define INTNAT_MIN LONG_MIN
 #elif SIZEOF_PTR == SIZEOF_INT
 /* Hypothetical IP32L64 model */
 typedef int intnat;
 typedef unsigned int uintnat;
 #define ARCH_INTNAT_PRINTF_FORMAT ""
+#define INTNAT_MIN INT_MIN
 #elif SIZEOF_PTR == 8
 /* Win64 model: IL32P64 */
 typedef int64_t intnat;
 typedef uint64_t uintnat;
 #define ARCH_INTNAT_PRINTF_FORMAT ARCH_INT64_PRINTF_FORMAT
+#define INTNAT_MIN INT64_MIN
 #else
 #error "No integer type available to represent pointers"
 #endif

--- a/runtime/compare.c
+++ b/runtime/compare.c
@@ -120,7 +120,7 @@ static void run_pending_actions(struct compare_stack* stk,
 #define LESS -1
 #define EQUAL 0
 #define GREATER 1
-#define UNORDERED ((intnat)1 << (8 * sizeof(value) - 1))
+#define UNORDERED INTNAT_MIN
 
 /* The return value of compare_val is as follows:
       > 0                 v1 is greater than v2

--- a/runtime/ints.c
+++ b/runtime/ints.c
@@ -251,7 +251,7 @@ CAMLprim value caml_int32_div(value v1, value v2)
   if (divisor == 0) caml_raise_zero_divide();
   /* PR#4740: on some processors, division crashes on overflow.
      Implement the same behavior as for type "int". */
-  if (dividend == (1<<31) && divisor == -1) return v1;
+  if (dividend == INT32_MIN && divisor == -1) return v1;
   return caml_copy_int32(dividend / divisor);
 }
 
@@ -262,7 +262,7 @@ CAMLprim value caml_int32_mod(value v1, value v2)
   if (divisor == 0) caml_raise_zero_divide();
   /* PR#4740: on some processors, modulus crashes if division overflows.
      Implement the same behavior as for type "int". */
-  if (dividend == (1<<31) && divisor == -1) return caml_copy_int32(0);
+  if (dividend == INT32_MIN && divisor == -1) return caml_copy_int32(0);
   return caml_copy_int32(dividend % divisor);
 }
 
@@ -472,7 +472,7 @@ CAMLprim_int64_2(div)(int64_t dividend, int64_t divisor)
   if (divisor == 0) caml_raise_zero_divide();
   /* PR#4740: on some processors, division crashes on overflow.
      Implement the same behavior as for type "int". */
-  if (dividend == ((int64_t)1 << 63) && divisor == -1) return dividend;
+  if (dividend == INT64_MIN && divisor == -1) return dividend;
   return dividend / divisor;
 }
 
@@ -481,7 +481,7 @@ CAMLprim_int64_2(mod)(int64_t dividend, int64_t divisor)
   if (divisor == 0) caml_raise_zero_divide();
   /* PR#4740: on some processors, division crashes on overflow.
      Implement the same behavior as for type "int". */
-  if (dividend == ((int64_t)1 << 63) && divisor == -1) return 0;
+  if (dividend == INT64_MIN && divisor == -1) return 0;
   return dividend % divisor;
 }
 
@@ -675,7 +675,7 @@ static void nativeint_serialize(value v, uintnat * bsize_32,
 {
   intnat l = Nativeint_val(v);
 #ifdef ARCH_SIXTYFOUR
-  if (l >= -((intnat)1 << 31) && l < ((intnat)1 << 31)) {
+  if (-(intnat)INT32_MIN <= l && l < (intnat)INT32_MIN) {
     caml_serialize_int_1(1);
     caml_serialize_int_4((int32_t) l);
   } else {
@@ -740,8 +740,6 @@ CAMLprim value caml_nativeint_sub(value v1, value v2)
 CAMLprim value caml_nativeint_mul(value v1, value v2)
 { return caml_copy_nativeint(Nativeint_val(v1) * Nativeint_val(v2)); }
 
-#define Nativeint_min_int ((intnat) 1 << (sizeof(intnat) * 8 - 1))
-
 CAMLprim value caml_nativeint_div(value v1, value v2)
 {
   intnat dividend = Nativeint_val(v1);
@@ -749,7 +747,7 @@ CAMLprim value caml_nativeint_div(value v1, value v2)
   if (divisor == 0) caml_raise_zero_divide();
   /* PR#4740: on some processors, modulus crashes if division overflows.
      Implement the same behavior as for type "int". */
-  if (dividend == Nativeint_min_int && divisor == -1) return v1;
+  if (dividend == INTNAT_MIN && divisor == -1) return v1;
   return caml_copy_nativeint(dividend / divisor);
 }
 
@@ -760,7 +758,7 @@ CAMLprim value caml_nativeint_mod(value v1, value v2)
   if (divisor == 0) caml_raise_zero_divide();
   /* PR#4740: on some processors, modulus crashes if division overflows.
      Implement the same behavior as for type "int". */
-  if (dividend == Nativeint_min_int && divisor == -1){
+  if (dividend == INTNAT_MIN && divisor == -1){
     return caml_copy_nativeint(0);
   }
   return caml_copy_nativeint(dividend % divisor);


### PR DESCRIPTION
The C standard, paragraph 6.5.7-4, reads

> `E1 << E2`
> If E1 has a signed type and nonnegative value, and E1 × 2^E2 is representable in the result type, then that is the resulting value; otherwise, the behavior is undefined.

Thus, for a signed type `t`, `1 << (sizeof(t)-1)` is undefined as it equals to the maximum value representable in type `t`, plus one. It usually overflows and amounts to the minimum value representable in type `t`, but that's still UB. Use constants from `limits.h`. because the minimum value cannot be easily computed.

Introduce the macro `INTNAT_MIN`. The name seems sensible, since we already have `UINTNAT_MAX`.