### PR TITLE
Fix cyclic type error messages in presence of `-short-paths`: 5.1.1 version

### DIFF
--- a/Changes
+++ b/Changes
@@ -6,6 +6,10 @@ OCaml 5.1.1
 - #12623, fix the computation of variance composition
   (Florian Angeletti, report by Vesa Karvonen, review by Gabriel Scherer)
 
+- #12645, #12649 fix error messages for cyclic type definitions in presence of
+  the `-short-paths` flag.
+  (Florian Angeletti, report by Vesa Karvonen, review by Gabriel Scherer)
+
 OCaml 5.1.0 (14 September 2023)
 -------------------------------
 

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -95,6 +95,11 @@ let add_type ~check id decl env =
   Builtin_attributes.warning_scope ~ppwarning:false decl.type_attributes
     (fun () -> Env.add_type ~check id decl env)
 
+(* Add a dummy type declaration to the environment, with the given arity.
+   The [type_kind] is [Type_abstract], but there is a generic [type_manifest]
+   for abbreviations, to allow polymorphic expansion, except if
+   [abstract_abbrevs] is [true].
+   This function is only used in [transl_type_decl]. *)
 let enter_type ~abstract_abbrevs rec_flag env sdecl (id, uid) =
   let needed =
     match rec_flag with


### PR DESCRIPTION
This is the 5.1.1 compatible version of #12645, which imports a minimal amount of refactoring changes from trunk to create abstract environments for printing.

cc @gasche