### PR TITLE
Correct libs used in output-complete-obj test

### DIFF
--- a/testsuite/tests/output-complete-obj/test.ml
+++ b/testsuite/tests/output-complete-obj/test.ml
@@ -6,7 +6,7 @@
    flags = "-w -a -output-complete-obj";
    program = "test.ml.bc.${objext}";
    ocamlc.byte;
-   script = "${mkexe} -I${ocamlsrcdir}/runtime -o test.ml_bc_stub.exe test.ml.bc.${objext} ${nativecc_libs} test.ml_stub.c";
+   script = "${mkexe} -I${ocamlsrcdir}/runtime -o test.ml_bc_stub.exe test.ml.bc.${objext} ${bytecc_libs} test.ml_stub.c";
    output = "${compiler_output}";
    script;
    program = "./test.ml_bc_stub.exe";
@@ -18,7 +18,7 @@
    flags = "-w -a -output-complete-obj";
    program = "test.ml.exe.${objext}";
    ocamlopt.byte;
-   script = "${mkexe} -I${ocamlsrcdir}/runtime -o test.ml_stub.exe test.ml.exe.${objext} ${bytecc_libs} test.ml_stub.c";
+   script = "${mkexe} -I${ocamlsrcdir}/runtime -o test.ml_stub.exe test.ml.exe.${objext} ${nativecc_libs} test.ml_stub.c";
    output = "${compiler_output}";
    script;
    program = "./test.ml_stub.exe";


### PR DESCRIPTION
This has been "wrong" since the test was first upgraded, but it's not mattered because normally both bytecode and native code have the same set of libraries. As part of recent experiments on zstd, we had a version where libcamlrun and libasmrun had different libraries, and this test failed because it was using `${nativecc_libs}` with with `ocamlc` and `${bytecc_libs}` with `ocamlopt`

(opened as a PR just to be sure of no CI surprises...)