### PR TITLE
Remove configure detection of `ffs` and `_BitScanForward`

### DIFF
--- a/configure
+++ b/configure
@@ -18325,23 +18325,6 @@ fi
 fi
 
 
-## ffs or _BitScanForward
-
-ac_fn_c_check_func "$LINENO" "ffs" "ac_cv_func_ffs"
-if test "x$ac_cv_func_ffs" = xyes
-then :
-  printf "%s\n" "#define HAS_FFS 1" >>confdefs.h
-
-fi
-
-ac_fn_c_check_func "$LINENO" "_BitScanForward" "ac_cv_func__BitScanForward"
-if test "x$ac_cv_func__BitScanForward" = xyes
-then :
-  printf "%s\n" "#define HAS_BITSCANFORWARD 1" >>confdefs.h
-
-fi
-
-
 if test -n "$ac_tool_prefix"; then
   # Extract the first word of "${ac_tool_prefix}pkg-config", so it can be a program name with args.
 set dummy ${ac_tool_prefix}pkg-config; ac_word=$2

--- a/configure.ac
+++ b/configure.ac
@@ -2083,11 +2083,6 @@ AC_CHECK_HEADER([spawn.h],
   [AC_CHECK_FUNC([posix_spawn],
     [AC_CHECK_FUNC([posix_spawnp], [AC_DEFINE([HAS_POSIX_SPAWN])])])])
 
-## ffs or _BitScanForward
-
-AC_CHECK_FUNC([ffs], [AC_DEFINE([HAS_FFS])])
-AC_CHECK_FUNC([_BitScanForward], [AC_DEFINE([HAS_BITSCANFORWARD])])
-
 AC_PATH_TOOL([PKG_CONFIG], [pkg-config], [false])
 
 ## ZSTD compression library

--- a/runtime/caml/s.h.in
+++ b/runtime/caml/s.h.in
@@ -289,9 +289,6 @@
 
 #undef HAS_POSIX_SPAWN
 
-#undef HAS_FFS
-#undef HAS_BITSCANFORWARD
-
 #undef HAS_SIGWAIT
 
 #undef HAS_HUGE_PAGES


### PR DESCRIPTION
They were only needed for the best-fit allocator policy, removed in OCaml 5.