### PR TITLE
[4.14] Fix `_BitScanForward` detection

### DIFF
--- a/configure
+++ b/configure
@@ -16618,8 +16618,8 @@ if test "x$ac_cv_func_ffs" = xyes; then :
 
 fi
 
-ac_fn_c_check_func "$LINENO" "_BitScanForward" "ac_cv_func__BitScanForward"
-if test "x$ac_cv_func__BitScanForward" = xyes; then :
+ac_fn_c_check_decl "$LINENO" "_BitScanForward" "ac_cv_have_decl__BitScanForward" "$ac_includes_default"
+if test "x$ac_cv_have_decl__BitScanForward" = xyes; then :
   $as_echo "#define HAS_BITSCANFORWARD 1" >>confdefs.h
 
 fi

--- a/configure.ac
+++ b/configure.ac
@@ -1768,7 +1768,7 @@ AC_CHECK_HEADER([spawn.h],
 ## ffs or _BitScanForward
 
 AC_CHECK_FUNC([ffs], [AC_DEFINE([HAS_FFS])])
-AC_CHECK_FUNC([_BitScanForward], [AC_DEFINE([HAS_BITSCANFORWARD])])
+AC_CHECK_DECL([_BitScanForward], [AC_DEFINE([HAS_BITSCANFORWARD])], [])
 
 ## Determine whether the debugger should/can be built
 


### PR DESCRIPTION
`_BitScanForward` is a compiler intrinsic, so there's no symbol visible by the linker and `AC_CHECK_FUNC` fails with:

    conftest.c(94): warning C4391: 'char _BitScanForward()': incorrect return type for intrinsic function, expected 'unsigned char'
    conftest.c(105): error C2168: '_BitScanForward': too few actual parameters for intrinsic function

`AC_CHECK_DECL` can be used instead (as for a macro). The `<intrin.h>` header doesn't seem to be needed.

I thought I'd submit this since the detection is broken and there's code that uses `_BitScanForward` in the best-fit allocator. There's a fallback when neither `ffs` nor `_BitScanForward` are detected, so it's not a huge problem (targeting OCaml 4.14 under MSVC anyway).