### PR TITLE
More reliable tests for TSan

### DIFF
--- a/testsuite/tests/tsan/array_elt.ml
+++ b/testsuite/tests/tsan/array_elt.ml
@@ -4,12 +4,23 @@
  set TSAN_OPTIONS="detect_deadlocks=0";
 
  tsan;
+ readonly_files = "waitgroup_stubs.c";
+ all_modules = "${readonly_files} waitgroup.ml array_elt.ml";
  native;
 
 *)
+let wg = Waitgroup.create 2
+
+let [@inline never] writer v () =
+  Waitgroup.join wg;
+  Array.set v 3 0
+
+let [@inline never] reader v =
+  ignore (Sys.opaque_identity (Array.get v 3));
+  Waitgroup.join wg
+
 let () =
   let v = Array.make 4 0 in
-  let t1 = Domain.spawn (fun () -> Array.set v 3 0; Unix.sleepf 0.1) in
-  let t2 = Domain.spawn (fun () -> ignore (Sys.opaque_identity (Array.get v 3)); Unix.sleepf 0.1) in
-  Domain.join t1;
-  Domain.join t2;
+  let d = Domain.spawn (writer v) in
+  reader v;
+  Domain.join d

--- a/testsuite/tests/tsan/array_elt.reference
+++ b/testsuite/tests/tsan/array_elt.reference
@@ -9,6 +9,12 @@ WARNING: ThreadSanitizer: data race (pid=<implemspecific>)
     #1 camlArray_elt.entry <implemspecific> (<implemspecific>)
     #2 caml_program <implemspecific> (<implemspecific>)
 
+  As if synchronized via sleep:
+    #0 usleep <implemspecific> (<implemspecific>)
+    #1 wg_wait <implemspecific> (<implemspecific>)
+    #2 camlArray_elt.writer_<implemspecific> <implemspecific> (<implemspecific>)
+    #3 camlStdlib__Domain.body_<implemspecific> <implemspecific> (<implemspecific>)
+
   Mutex M<implemspecific> (<implemspecific>) created at:
     #0 pthread_mutex_init <implemspecific> (<implemspecific>)
     #1 caml_plat_mutex_init <implemspecific> (<implemspecific>)

--- a/testsuite/tests/tsan/array_elt.reference
+++ b/testsuite/tests/tsan/array_elt.reference
@@ -1,12 +1,13 @@
 ==================
 WARNING: ThreadSanitizer: data race (pid=<implemspecific>)
-  Read of size 8 at <implemspecific> by thread T4 (mutexes: write M<implemspecific>):
-    #0 camlArray_elt.fun_<implemspecific> <implemspecific> (<implemspecific>)
+  Write of size 8 at <implemspecific> by thread T1 (mutexes: write M<implemspecific>):
+    #0 camlArray_elt.writer_<implemspecific> <implemspecific> (<implemspecific>)
     #1 camlStdlib__Domain.body_<implemspecific> <implemspecific> (<implemspecific>)
 
-  Previous write of size 8 at <implemspecific> by thread T1 (mutexes: write M<implemspecific>):
-    #0 camlArray_elt.fun_<implemspecific> <implemspecific> (<implemspecific>)
-    #1 camlStdlib__Domain.body_<implemspecific> <implemspecific> (<implemspecific>)
+  Previous read of size 8 at <implemspecific> by main thread (mutexes: write M<implemspecific>):
+    #0 camlArray_elt.reader_<implemspecific> <implemspecific> (<implemspecific>)
+    #1 camlArray_elt.entry <implemspecific> (<implemspecific>)
+    #2 caml_program <implemspecific> (<implemspecific>)
 
   Mutex M<implemspecific> (<implemspecific>) created at:
     #0 pthread_mutex_init <implemspecific> (<implemspecific>)
@@ -19,14 +20,6 @@ WARNING: ThreadSanitizer: data race (pid=<implemspecific>)
     #1 caml_plat_mutex_init <implemspecific> (<implemspecific>)
     #2 caml_init_domains <implemspecific> (<implemspecific>)
     #3 caml_init_gc <implemspecific> (<implemspecific>)
-
-  Thread T4 (tid=<implemspecific>, running) created by main thread at:
-    #0 pthread_create <implemspecific> (<implemspecific>)
-    #1 caml_domain_spawn <implemspecific> (<implemspecific>)
-    #2 caml_c_call <implemspecific> (<implemspecific>)
-    #3 camlStdlib__Domain.spawn_<implemspecific> <implemspecific> (<implemspecific>)
-    #4 camlArray_elt.entry <implemspecific> (<implemspecific>)
-    #5 caml_program <implemspecific> (<implemspecific>)
 
   Thread T1 (tid=<implemspecific>, running) created by main thread at:
     #0 pthread_create <implemspecific> (<implemspecific>)
@@ -36,6 +29,6 @@ WARNING: ThreadSanitizer: data race (pid=<implemspecific>)
     #4 camlArray_elt.entry <implemspecific> (<implemspecific>)
     #5 caml_program <implemspecific> (<implemspecific>)
 
-SUMMARY: ThreadSanitizer: data race (<systemspecific>:<implemspecific>) in camlArray_elt.fun_<implemspecific>
+SUMMARY: ThreadSanitizer: data race (<systemspecific>:<implemspecific>) in camlArray_elt.writer_<implemspecific>
 ==================
 ThreadSanitizer: reported 1 warnings

--- a/testsuite/tests/tsan/exn_from_c.reference
+++ b/testsuite/tests/tsan/exn_from_c.reference
@@ -22,6 +22,12 @@ WARNING: ThreadSanitizer: data race (pid=<implemspecific>)
     #2 camlExn_from_c.entry <implemspecific> (<implemspecific>)
     #3 caml_program <implemspecific> (<implemspecific>)
 
+  As if synchronized via sleep:
+    #0 usleep <implemspecific> (<implemspecific>)
+    #1 wg_wait <implemspecific> (<implemspecific>)
+    #2 camlExn_from_c.writer_<implemspecific> <implemspecific> (<implemspecific>)
+    #3 camlStdlib__Domain.body_<implemspecific> <implemspecific> (<implemspecific>)
+
   Mutex M<implemspecific> (<implemspecific>) created at:
     #0 pthread_mutex_init <implemspecific> (<implemspecific>)
     #1 caml_plat_mutex_init <implemspecific> (<implemspecific>)

--- a/testsuite/tests/tsan/exn_from_c.reference
+++ b/testsuite/tests/tsan/exn_from_c.reference
@@ -1,19 +1,19 @@
-entering f
-entering g
-entering h
-entering i
-calling print_and_raise...
+Entering f
+Entering g
+Entering h
+Entering i
+Calling print_and_raise...
 Hello from print_and_raise
-caught Failure "test"
-Raised by primitive operation at Exn_from_c.i in file "exn_from_c.ml", line 25, characters 2-20
-Called from Exn_from_c.h in file "exn_from_c.ml", line 30, characters 2-6
-Called from Exn_from_c.g in file "exn_from_c.ml", line 35, characters 2-6
-Called from Exn_from_c.f in file "exn_from_c.ml", line 40, characters 7-11
-leaving f
+Caught Failure "test"
+Raised by primitive operation at Exn_from_c.i in file "exn_from_c.ml", line 28, characters 2-20
+Called from Exn_from_c.h in file "exn_from_c.ml", line 33, characters 2-6
+Called from Exn_from_c.g in file "exn_from_c.ml", line 38, characters 2-6
+Called from Exn_from_c.f in file "exn_from_c.ml", line 43, characters 7-11
+Leaving f
 ==================
 WARNING: ThreadSanitizer: data race (pid=<implemspecific>)
   Write of size 8 at <implemspecific> by thread T1 (mutexes: write M<implemspecific>):
-    #0 camlExn_from_c.fun_<implemspecific> <implemspecific> (<implemspecific>)
+    #0 camlExn_from_c.writer_<implemspecific> <implemspecific> (<implemspecific>)
     #1 camlStdlib__Domain.body_<implemspecific> <implemspecific> (<implemspecific>)
 
   Previous read of size 8 at <implemspecific> by main thread (mutexes: write M<implemspecific>):
@@ -21,14 +21,6 @@ WARNING: ThreadSanitizer: data race (pid=<implemspecific>)
     #1 camlExn_from_c.f_<implemspecific> <implemspecific> (<implemspecific>)
     #2 camlExn_from_c.entry <implemspecific> (<implemspecific>)
     #3 caml_program <implemspecific> (<implemspecific>)
-
-  As if synchronized via sleep:
-    #0 nanosleep <implemspecific> (<implemspecific>)
-    #1 caml_unix_sleep <implemspecific> (<implemspecific>)
-    #2 caml_c_call <implemspecific> (<implemspecific>)
-    #3 camlUnix.sleep_<implemspecific> <implemspecific> (<implemspecific>)
-    #4 camlExn_from_c.fun_<implemspecific> <implemspecific> (<implemspecific>)
-    #5 camlStdlib__Domain.body_<implemspecific> <implemspecific> (<implemspecific>)
 
   Mutex M<implemspecific> (<implemspecific>) created at:
     #0 pthread_mutex_init <implemspecific> (<implemspecific>)
@@ -50,6 +42,6 @@ WARNING: ThreadSanitizer: data race (pid=<implemspecific>)
     #4 camlExn_from_c.entry <implemspecific> (<implemspecific>)
     #5 caml_program <implemspecific> (<implemspecific>)
 
-SUMMARY: ThreadSanitizer: data race (<systemspecific>:<implemspecific>) in camlExn_from_c.fun_<implemspecific>
+SUMMARY: ThreadSanitizer: data race (<systemspecific>:<implemspecific>) in camlExn_from_c.writer_<implemspecific>
 ==================
 ThreadSanitizer: reported 1 warnings

--- a/testsuite/tests/tsan/exn_in_callback.ml
+++ b/testsuite/tests/tsan/exn_in_callback.ml
@@ -1,12 +1,12 @@
 (* TEST
 
- modules = "callbacks.c";
-
  ocamlopt_flags = "-g -ccopt -fsanitize=thread -ccopt -O1 -ccopt -fno-omit-frame-pointer -ccopt -g";
  include unix;
  set TSAN_OPTIONS="detect_deadlocks=0";
 
  tsan;
+ readonly_files = "callbacks.c waitgroup_stubs.c";
+ all_modules = "${readonly_files} waitgroup.ml exn_in_callback.ml";
  native;
 
 *)
@@ -17,45 +17,48 @@ external print_and_call_ocaml_h : unit -> unit = "print_and_call_ocaml_h"
 
 open Printf
 
+let wg = Waitgroup.create 2
 let r = ref 0
 
-let [@inline never] race () = ignore @@ !r
+let [@inline never] race () =
+  ignore @@ !r;
+  Waitgroup.join wg
 
 let [@inline never] i () =
-  printf "entering i\n%!";
-  printf "throwing Exn...\n%!";
-  (*race ();*)
+  printf "Entering i\n%!";
+  printf "Throwing ExnB...\n%!";
   ignore (raise ExnB);
-  printf "leaving i\n%!"
+  printf "Leaving i\n%!"
 
 let [@inline never] h () =
-  printf "entering h\n%!";
+  printf "Entering h\n%!";
   i ();
-  (* try i () with
-  | ExnA -> printf "caught an ExnA\n%!";
-  *)
-  printf "leaving h\n%!"
+  printf "Leaving h\n%!"
 
 let _ = Callback.register "ocaml_h" h
 
 let [@inline never] g () =
-  printf "entering g\n%!";
-  printf "calling C code\n%!";
+  printf "Entering g\n%!";
+  printf "Calling C code\n%!";
   print_and_call_ocaml_h ();
-  printf "back from C code\n%!";
-  printf "leaving g\n%!"
+  printf "Back from C code\n%!";
+  printf "Leaving g\n%!"
 
 let [@inline never] f () =
-  printf "entering f\n%!";
+  printf "Entering f\n%!";
   (try g () with
   | ExnB ->
-    printf "caught an ExnB\n%!";
+    printf "Caught an ExnB\n%!";
     Printexc.print_backtrace stdout;
     race ());
-  printf "leaving f\n%!"
+  printf "Leaving f\n%!"
+
+let [@inline never] writer () =
+  Waitgroup.join wg;
+  r := 1
 
 let () =
   Printexc.record_backtrace true;
-  let d = Domain.spawn (fun () -> Unix.sleep 1; r := 1) in
-  f (); Unix.sleep 1;
+  let d = Domain.spawn writer in
+  f ();
   Domain.join d

--- a/testsuite/tests/tsan/exn_in_callback.reference
+++ b/testsuite/tests/tsan/exn_in_callback.reference
@@ -1,18 +1,18 @@
-entering f
-entering g
-calling C code
+Entering f
+Entering g
+Calling C code
 Hello from print_and_call_ocaml_h
-entering h
-entering i
-throwing Exn...
-caught an ExnB
-Raised by primitive operation at Exn_in_callback.g in file "exn_in_callback.ml", line 44, characters 2-27
-Called from Exn_in_callback.f in file "exn_in_callback.ml", line 50, characters 7-11
-leaving f
+Entering h
+Entering i
+Throwing ExnB...
+Caught an ExnB
+Raised by primitive operation at Exn_in_callback.g in file "exn_in_callback.ml", line 43, characters 2-27
+Called from Exn_in_callback.f in file "exn_in_callback.ml", line 49, characters 7-11
+Leaving f
 ==================
 WARNING: ThreadSanitizer: data race (pid=<implemspecific>)
   Write of size 8 at <implemspecific> by thread T1 (mutexes: write M<implemspecific>):
-    #0 camlExn_in_callback.fun_<implemspecific> <implemspecific> (<implemspecific>)
+    #0 camlExn_in_callback.writer_<implemspecific> <implemspecific> (<implemspecific>)
     #1 camlStdlib__Domain.body_<implemspecific> <implemspecific> (<implemspecific>)
 
   Previous read of size 8 at <implemspecific> by main thread (mutexes: write M<implemspecific>):
@@ -20,14 +20,6 @@ WARNING: ThreadSanitizer: data race (pid=<implemspecific>)
     #1 camlExn_in_callback.f_<implemspecific> <implemspecific> (<implemspecific>)
     #2 camlExn_in_callback.entry <implemspecific> (<implemspecific>)
     #3 caml_program <implemspecific> (<implemspecific>)
-
-  As if synchronized via sleep:
-    #0 nanosleep <implemspecific> (<implemspecific>)
-    #1 caml_unix_sleep <implemspecific> (<implemspecific>)
-    #2 caml_c_call <implemspecific> (<implemspecific>)
-    #3 camlUnix.sleep_<implemspecific> <implemspecific> (<implemspecific>)
-    #4 camlExn_in_callback.fun_<implemspecific> <implemspecific> (<implemspecific>)
-    #5 camlStdlib__Domain.body_<implemspecific> <implemspecific> (<implemspecific>)
 
   Mutex M<implemspecific> (<implemspecific>) created at:
     #0 pthread_mutex_init <implemspecific> (<implemspecific>)
@@ -49,6 +41,6 @@ WARNING: ThreadSanitizer: data race (pid=<implemspecific>)
     #4 camlExn_in_callback.entry <implemspecific> (<implemspecific>)
     #5 caml_program <implemspecific> (<implemspecific>)
 
-SUMMARY: ThreadSanitizer: data race (<systemspecific>:<implemspecific>) in camlExn_in_callback.fun_<implemspecific>
+SUMMARY: ThreadSanitizer: data race (<systemspecific>:<implemspecific>) in camlExn_in_callback.writer_<implemspecific>
 ==================
 ThreadSanitizer: reported 1 warnings

--- a/testsuite/tests/tsan/exn_in_callback.reference
+++ b/testsuite/tests/tsan/exn_in_callback.reference
@@ -21,6 +21,12 @@ WARNING: ThreadSanitizer: data race (pid=<implemspecific>)
     #2 camlExn_in_callback.entry <implemspecific> (<implemspecific>)
     #3 caml_program <implemspecific> (<implemspecific>)
 
+  As if synchronized via sleep:
+    #0 usleep <implemspecific> (<implemspecific>)
+    #1 wg_wait <implemspecific> (<implemspecific>)
+    #2 camlExn_in_callback.writer_<implemspecific> <implemspecific> (<implemspecific>)
+    #3 camlStdlib__Domain.body_<implemspecific> <implemspecific> (<implemspecific>)
+
   Mutex M<implemspecific> (<implemspecific>) created at:
     #0 pthread_mutex_init <implemspecific> (<implemspecific>)
     #1 caml_plat_mutex_init <implemspecific> (<implemspecific>)

--- a/testsuite/tests/tsan/exn_reraise.ml
+++ b/testsuite/tests/tsan/exn_reraise.ml
@@ -5,6 +5,8 @@
  set TSAN_OPTIONS="detect_deadlocks=0";
 
  tsan;
+ readonly_files = "waitgroup_stubs.c";
+ all_modules = "${readonly_files} waitgroup.ml exn_reraise.ml";
  native;
 
 *)
@@ -13,38 +15,45 @@ exception ExnB
 
 open Printf
 
+let wg = Waitgroup.create 2
 let r = ref 0
 
-let [@inline never] race () = ignore @@ !r
+let [@inline never] race () =
+  ignore @@ !r;
+  Waitgroup.join wg
 
 let [@inline never] i () =
-  printf "entering i\n%!";
-  printf "throwing Exn...\n%!";
+  printf "Entering i\n%!";
+  printf "Throwing ExnA...\n%!";
   ignore (raise ExnA);
-  printf "leaving i\n%!"
+  printf "Leaving i\n%!"
 
 let [@inline never] h () =
-  printf "entering h\n%!";
+  printf "Entering h\n%!";
   try i () with
-  | ExnB -> printf "caught an ExnB\n%!";
-  printf "leaving h\n%!"
+  | ExnB -> printf "Caught an ExnB\n%!";
+  printf "Leaving h\n%!"
 
 let [@inline never] g () =
-  printf "entering g\n%!";
+  printf "Entering g\n%!";
   h ();
-  printf "leaving g\n%!"
+  printf "Leaving g\n%!"
 
 let [@inline never] f () =
-  printf "entering f\n%!";
+  printf "Entering f\n%!";
   (try g () with
   | ExnA ->
-    printf "caught an ExnA\n%!";
+    printf "Caught an ExnA\n%!";
     Printexc.print_backtrace stdout;
     race ());
-  printf "leaving f\n%!"
+  printf "Leaving f\n%!"
+
+let [@inline never] writer () =
+  Waitgroup.join wg;
+  r := 1
 
 let () =
   Printexc.record_backtrace true;
-  let d = Domain.spawn (fun () -> Unix.sleep 1; r := 1) in
-  f (); Unix.sleep 1;
+  let d = Domain.spawn writer in
+  f ();
   Domain.join d

--- a/testsuite/tests/tsan/exn_reraise.reference
+++ b/testsuite/tests/tsan/exn_reraise.reference
@@ -21,6 +21,12 @@ WARNING: ThreadSanitizer: data race (pid=<implemspecific>)
     #2 camlExn_reraise.entry <implemspecific> (<implemspecific>)
     #3 caml_program <implemspecific> (<implemspecific>)
 
+  As if synchronized via sleep:
+    #0 usleep <implemspecific> (<implemspecific>)
+    #1 wg_wait <implemspecific> (<implemspecific>)
+    #2 camlExn_reraise.writer_<implemspecific> <implemspecific> (<implemspecific>)
+    #3 camlStdlib__Domain.body_<implemspecific> <implemspecific> (<implemspecific>)
+
   Mutex M<implemspecific> (<implemspecific>) created at:
     #0 pthread_mutex_init <implemspecific> (<implemspecific>)
     #1 caml_plat_mutex_init <implemspecific> (<implemspecific>)

--- a/testsuite/tests/tsan/exn_reraise.reference
+++ b/testsuite/tests/tsan/exn_reraise.reference
@@ -1,18 +1,18 @@
-entering f
-entering g
-entering h
-entering i
-throwing Exn...
-caught an ExnA
-Raised at Exn_reraise.i in file "exn_reraise.ml", line 23, characters 9-21
-Called from Exn_reraise.h in file "exn_reraise.ml", line 28, characters 6-10
-Called from Exn_reraise.g in file "exn_reraise.ml", line 34, characters 2-6
-Called from Exn_reraise.f in file "exn_reraise.ml", line 39, characters 7-11
-leaving f
+Entering f
+Entering g
+Entering h
+Entering i
+Throwing ExnA...
+Caught an ExnA
+Raised at Exn_reraise.i in file "exn_reraise.ml", line 28, characters 9-21
+Called from Exn_reraise.h in file "exn_reraise.ml", line 33, characters 6-10
+Called from Exn_reraise.g in file "exn_reraise.ml", line 39, characters 2-6
+Called from Exn_reraise.f in file "exn_reraise.ml", line 44, characters 7-11
+Leaving f
 ==================
 WARNING: ThreadSanitizer: data race (pid=<implemspecific>)
   Write of size 8 at <implemspecific> by thread T1 (mutexes: write M<implemspecific>):
-    #0 camlExn_reraise.fun_<implemspecific> <implemspecific> (<implemspecific>)
+    #0 camlExn_reraise.writer_<implemspecific> <implemspecific> (<implemspecific>)
     #1 camlStdlib__Domain.body_<implemspecific> <implemspecific> (<implemspecific>)
 
   Previous read of size 8 at <implemspecific> by main thread (mutexes: write M<implemspecific>):
@@ -20,14 +20,6 @@ WARNING: ThreadSanitizer: data race (pid=<implemspecific>)
     #1 camlExn_reraise.f_<implemspecific> <implemspecific> (<implemspecific>)
     #2 camlExn_reraise.entry <implemspecific> (<implemspecific>)
     #3 caml_program <implemspecific> (<implemspecific>)
-
-  As if synchronized via sleep:
-    #0 nanosleep <implemspecific> (<implemspecific>)
-    #1 caml_unix_sleep <implemspecific> (<implemspecific>)
-    #2 caml_c_call <implemspecific> (<implemspecific>)
-    #3 camlUnix.sleep_<implemspecific> <implemspecific> (<implemspecific>)
-    #4 camlExn_reraise.fun_<implemspecific> <implemspecific> (<implemspecific>)
-    #5 camlStdlib__Domain.body_<implemspecific> <implemspecific> (<implemspecific>)
 
   Mutex M<implemspecific> (<implemspecific>) created at:
     #0 pthread_mutex_init <implemspecific> (<implemspecific>)
@@ -49,6 +41,6 @@ WARNING: ThreadSanitizer: data race (pid=<implemspecific>)
     #4 camlExn_reraise.entry <implemspecific> (<implemspecific>)
     #5 caml_program <implemspecific> (<implemspecific>)
 
-SUMMARY: ThreadSanitizer: data race (<systemspecific>:<implemspecific>) in camlExn_reraise.fun_<implemspecific>
+SUMMARY: ThreadSanitizer: data race (<systemspecific>:<implemspecific>) in camlExn_reraise.writer_<implemspecific>
 ==================
 ThreadSanitizer: reported 1 warnings

--- a/testsuite/tests/tsan/norace_atomics.ml
+++ b/testsuite/tests/tsan/norace_atomics.ml
@@ -4,15 +4,24 @@
  set TSAN_OPTIONS="detect_deadlocks=0";
 
  tsan;
+ readonly_files = "waitgroup_stubs.c";
+ all_modules = "${readonly_files} waitgroup.ml norace_atomics.ml";
  native;
 
 *)
 
+let wg = Waitgroup.create 2
 let v = Atomic.make 0
 
+let [@inline never] writer () =
+  Waitgroup.join wg;
+  Atomic.set v 10
+
+let [@inline never] reader () =
+  ignore (Sys.opaque_identity (Atomic.get v));
+  Waitgroup.join wg
+
 let () =
-  let t1 = Domain.spawn (fun () -> Atomic.set v 10; Unix.sleep 1) in
-  let t2 = Domain.spawn (fun () ->
-      ignore (Sys.opaque_identity (Atomic.get v)); Unix.sleep 1) in
-  Domain.join t1;
-  Domain.join t2
+  let d = Domain.spawn writer in
+  reader ();
+  Domain.join d

--- a/testsuite/tests/tsan/perform.ml
+++ b/testsuite/tests/tsan/perform.ml
@@ -5,6 +5,8 @@
  set TSAN_OPTIONS="detect_deadlocks=0";
 
  tsan;
+ readonly_files = "waitgroup_stubs.c";
+ all_modules = "${readonly_files} waitgroup.ml perform.ml";
  native;
 
 *)
@@ -20,42 +22,47 @@ open Effect.Deep
 
 type _ Effect.t += E : int -> int t
 
-let g_ref1 = ref 0
-let g_ref2 = ref 0
-let g_ref3 = ref 0
+let wg1 = Waitgroup.create 2
+let wg2 = Waitgroup.create 2
+let r1 = ref 0
+let r2 = ref 0
+let r3 = ref 0
+
+(* Force synchronisation of test output with TSan output to stderr *)
+let print_endline s = Stdlib.print_endline s; flush stdout
 
 let [@inline never] race =
   function
-  | 0 -> g_ref1 := 42
-  | 1 -> g_ref2 := 42
-  | _ -> g_ref3 := 42
+  | 0 -> r1 := 42
+  | 1 -> r2 := 42
+  | _ -> r3 := 42
 
 let [@inline never] h () =
-  print_endline "entering h and perform-ing";
+  print_endline "Entering h and perform-ing";
   let v = perform (E 0) in
-  print_endline "resuming h";
+  print_endline "Resuming h";
   race 0;
-  print_endline "leaving h";
+  print_endline "Leaving h";
   v
 
 let [@inline never] g () =
-  print_endline "entering g";
+  print_endline "Entering g";
   let v = h () in
-  print_endline "leaving g";
+  print_endline "Leaving g";
   v
 
 let [@inline never] f () =
-  print_endline "computation, entering f";
+  print_endline "Computation, entering f";
   let v = g () in
-  print_endline "computation, leaving f";
+  print_endline "Computation, leaving f";
   v + 1
 
 let effh : type a. a t -> ((a, 'b) continuation -> 'b) option = function
   | E v -> Some (fun k ->
-      print_endline "in the effect handler";
+      print_endline "In the effect handler";
       race 1;
       let v = continue k (v + 1) in
-      print_endline "handler after continue";
+      print_endline "Handler after continue";
       v + 1
       )
   | e -> None
@@ -65,22 +72,24 @@ let[@inline never] main () =
   ignore (
     match_with f ()
     { retc = (fun v ->
-        print_endline "value handler";
+        print_endline "Value handler";
         race 2;
         v + 1
       );
       exnc = (fun e -> raise e);
       effc = effh }
   );
-  44
+  42
 
 let[@inline never] other_domain () =
-  ignore (Sys.opaque_identity (!g_ref1, !g_ref2, !g_ref3));
-  Unix.sleepf 0.66
+  ignore (Sys.opaque_identity (!r1, !r2, !r3));
+  Waitgroup.join wg1;
+  Waitgroup.join wg2
 
 let () =
   let d = Domain.spawn other_domain in
-  Unix.sleepf 0.33;
+  Waitgroup.join wg1;
   let v = main () in
-  printf "result = %d\n" v;
+  Waitgroup.join wg2;
+  eprintf "Result = %d\n" v;
   Domain.join d

--- a/testsuite/tests/tsan/perform.reference
+++ b/testsuite/tests/tsan/perform.reference
@@ -16,6 +16,12 @@ WARNING: ThreadSanitizer: data race (pid=<implemspecific>)
     #0 camlPerform.other_domain_<implemspecific> <implemspecific> (<implemspecific>)
     #1 camlStdlib__Domain.body_<implemspecific> <implemspecific> (<implemspecific>)
 
+  As if synchronized via sleep:
+    #0 usleep <implemspecific> (<implemspecific>)
+    #1 wg_wait <implemspecific> (<implemspecific>)
+    #2 camlPerform.entry <implemspecific> (<implemspecific>)
+    #3 caml_program <implemspecific> (<implemspecific>)
+
   Mutex M<implemspecific> (<implemspecific>) created at:
     #0 pthread_mutex_init <implemspecific> (<implemspecific>)
     #1 caml_plat_mutex_init <implemspecific> (<implemspecific>)
@@ -56,6 +62,12 @@ WARNING: ThreadSanitizer: data race (pid=<implemspecific>)
     #0 camlPerform.other_domain_<implemspecific> <implemspecific> (<implemspecific>)
     #1 camlStdlib__Domain.body_<implemspecific> <implemspecific> (<implemspecific>)
 
+  As if synchronized via sleep:
+    #0 usleep <implemspecific> (<implemspecific>)
+    #1 wg_wait <implemspecific> (<implemspecific>)
+    #2 camlPerform.entry <implemspecific> (<implemspecific>)
+    #3 caml_program <implemspecific> (<implemspecific>)
+
   Mutex M<implemspecific> (<implemspecific>) created at:
     #0 pthread_mutex_init <implemspecific> (<implemspecific>)
     #1 caml_plat_mutex_init <implemspecific> (<implemspecific>)
@@ -95,6 +107,12 @@ WARNING: ThreadSanitizer: data race (pid=<implemspecific>)
   Previous read of size 8 at <implemspecific> by thread T1 (mutexes: write M<implemspecific>):
     #0 camlPerform.other_domain_<implemspecific> <implemspecific> (<implemspecific>)
     #1 camlStdlib__Domain.body_<implemspecific> <implemspecific> (<implemspecific>)
+
+  As if synchronized via sleep:
+    #0 usleep <implemspecific> (<implemspecific>)
+    #1 wg_wait <implemspecific> (<implemspecific>)
+    #2 camlPerform.entry <implemspecific> (<implemspecific>)
+    #3 caml_program <implemspecific> (<implemspecific>)
 
   Mutex M<implemspecific> (<implemspecific>) created at:
     #0 pthread_mutex_init <implemspecific> (<implemspecific>)

--- a/testsuite/tests/tsan/perform.reference
+++ b/testsuite/tests/tsan/perform.reference
@@ -1,8 +1,8 @@
 Let's work!
-computation, entering f
-entering g
-entering h and perform-ing
-in the effect handler
+Computation, entering f
+Entering g
+Entering h and perform-ing
+In the effect handler
 ==================
 WARNING: ThreadSanitizer: data race (pid=<implemspecific>)
   Write of size 8 at <implemspecific> by main thread (mutexes: write M<implemspecific>):
@@ -15,13 +15,6 @@ WARNING: ThreadSanitizer: data race (pid=<implemspecific>)
   Previous read of size 8 at <implemspecific> by thread T1 (mutexes: write M<implemspecific>):
     #0 camlPerform.other_domain_<implemspecific> <implemspecific> (<implemspecific>)
     #1 camlStdlib__Domain.body_<implemspecific> <implemspecific> (<implemspecific>)
-
-  As if synchronized via sleep:
-    #0 nanosleep <implemspecific> (<implemspecific>)
-    #1 caml_unix_sleep <implemspecific> (<implemspecific>)
-    #2 caml_c_call <implemspecific> (<implemspecific>)
-    #3 camlPerform.entry <implemspecific> (<implemspecific>)
-    #4 caml_program <implemspecific> (<implemspecific>)
 
   Mutex M<implemspecific> (<implemspecific>) created at:
     #0 pthread_mutex_init <implemspecific> (<implemspecific>)
@@ -45,7 +38,7 @@ WARNING: ThreadSanitizer: data race (pid=<implemspecific>)
 
 SUMMARY: ThreadSanitizer: data race (<systemspecific>:<implemspecific>) in camlPerform.race_<implemspecific>
 ==================
-resuming h
+Resuming h
 ==================
 WARNING: ThreadSanitizer: data race (pid=<implemspecific>)
   Write of size 8 at <implemspecific> by main thread (mutexes: write M<implemspecific>):
@@ -63,13 +56,6 @@ WARNING: ThreadSanitizer: data race (pid=<implemspecific>)
     #0 camlPerform.other_domain_<implemspecific> <implemspecific> (<implemspecific>)
     #1 camlStdlib__Domain.body_<implemspecific> <implemspecific> (<implemspecific>)
 
-  As if synchronized via sleep:
-    #0 nanosleep <implemspecific> (<implemspecific>)
-    #1 caml_unix_sleep <implemspecific> (<implemspecific>)
-    #2 caml_c_call <implemspecific> (<implemspecific>)
-    #3 camlPerform.entry <implemspecific> (<implemspecific>)
-    #4 caml_program <implemspecific> (<implemspecific>)
-
   Mutex M<implemspecific> (<implemspecific>) created at:
     #0 pthread_mutex_init <implemspecific> (<implemspecific>)
     #1 caml_plat_mutex_init <implemspecific> (<implemspecific>)
@@ -92,10 +78,10 @@ WARNING: ThreadSanitizer: data race (pid=<implemspecific>)
 
 SUMMARY: ThreadSanitizer: data race (<systemspecific>:<implemspecific>) in camlPerform.race_<implemspecific>
 ==================
-leaving h
-leaving g
-computation, leaving f
-value handler
+Leaving h
+Leaving g
+Computation, leaving f
+Value handler
 ==================
 WARNING: ThreadSanitizer: data race (pid=<implemspecific>)
   Write of size 8 at <implemspecific> by main thread (mutexes: write M<implemspecific>):
@@ -110,13 +96,6 @@ WARNING: ThreadSanitizer: data race (pid=<implemspecific>)
     #0 camlPerform.other_domain_<implemspecific> <implemspecific> (<implemspecific>)
     #1 camlStdlib__Domain.body_<implemspecific> <implemspecific> (<implemspecific>)
 
-  As if synchronized via sleep:
-    #0 nanosleep <implemspecific> (<implemspecific>)
-    #1 caml_unix_sleep <implemspecific> (<implemspecific>)
-    #2 caml_c_call <implemspecific> (<implemspecific>)
-    #3 camlPerform.entry <implemspecific> (<implemspecific>)
-    #4 caml_program <implemspecific> (<implemspecific>)
-
   Mutex M<implemspecific> (<implemspecific>) created at:
     #0 pthread_mutex_init <implemspecific> (<implemspecific>)
     #1 caml_plat_mutex_init <implemspecific> (<implemspecific>)
@@ -139,6 +118,6 @@ WARNING: ThreadSanitizer: data race (pid=<implemspecific>)
 
 SUMMARY: ThreadSanitizer: data race (<systemspecific>:<implemspecific>) in camlPerform.race_<implemspecific>
 ==================
-handler after continue
-result = 44
+Handler after continue
+Result = 42
 ThreadSanitizer: reported 3 warnings

--- a/testsuite/tests/tsan/raise_through_handler.reference
+++ b/testsuite/tests/tsan/raise_through_handler.reference
@@ -14,6 +14,12 @@ WARNING: ThreadSanitizer: data race (pid=<implemspecific>)
     #2 camlRaise_through_handler.entry <implemspecific> (<implemspecific>)
     #3 caml_program <implemspecific> (<implemspecific>)
 
+  As if synchronized via sleep:
+    #0 usleep <implemspecific> (<implemspecific>)
+    #1 wg_wait <implemspecific> (<implemspecific>)
+    #2 camlRaise_through_handler.reader_<implemspecific> <implemspecific> (<implemspecific>)
+    #3 camlStdlib__Domain.body_<implemspecific> <implemspecific> (<implemspecific>)
+
   Mutex M<implemspecific> (<implemspecific>) created at:
     #0 pthread_mutex_init <implemspecific> (<implemspecific>)
     #1 caml_plat_mutex_init <implemspecific> (<implemspecific>)

--- a/testsuite/tests/tsan/raise_through_handler.reference
+++ b/testsuite/tests/tsan/raise_through_handler.reference
@@ -1,25 +1,18 @@
 Let's work!
-computation, entering f
-entering g
+Computation, entering f
+Entering g
 In exception handler
 ==================
 WARNING: ThreadSanitizer: data race (pid=<implemspecific>)
-  Write of size 8 at <implemspecific> by main thread (mutexes: write M<implemspecific>):
+  Read of size 8 at <implemspecific> by thread T1 (mutexes: write M<implemspecific>):
+    #0 camlRaise_through_handler.reader_<implemspecific> <implemspecific> (<implemspecific>)
+    #1 camlStdlib__Domain.body_<implemspecific> <implemspecific> (<implemspecific>)
+
+  Previous write of size 8 at <implemspecific> by main thread (mutexes: write M<implemspecific>):
     #0 camlRaise_through_handler.race_<implemspecific> <implemspecific> (<implemspecific>)
     #1 camlRaise_through_handler.main_<implemspecific> <implemspecific> (<implemspecific>)
     #2 camlRaise_through_handler.entry <implemspecific> (<implemspecific>)
     #3 caml_program <implemspecific> (<implemspecific>)
-
-  Previous read of size 8 at <implemspecific> by thread T1 (mutexes: write M<implemspecific>):
-    #0 camlRaise_through_handler.other_domain_<implemspecific> <implemspecific> (<implemspecific>)
-    #1 camlStdlib__Domain.body_<implemspecific> <implemspecific> (<implemspecific>)
-
-  As if synchronized via sleep:
-    #0 nanosleep <implemspecific> (<implemspecific>)
-    #1 caml_unix_sleep <implemspecific> (<implemspecific>)
-    #2 caml_c_call <implemspecific> (<implemspecific>)
-    #3 camlRaise_through_handler.entry <implemspecific> (<implemspecific>)
-    #4 caml_program <implemspecific> (<implemspecific>)
 
   Mutex M<implemspecific> (<implemspecific>) created at:
     #0 pthread_mutex_init <implemspecific> (<implemspecific>)
@@ -41,7 +34,7 @@ WARNING: ThreadSanitizer: data race (pid=<implemspecific>)
     #4 camlRaise_through_handler.entry <implemspecific> (<implemspecific>)
     #5 caml_program <implemspecific> (<implemspecific>)
 
-SUMMARY: ThreadSanitizer: data race (<systemspecific>:<implemspecific>) in camlRaise_through_handler.race_<implemspecific>
+SUMMARY: ThreadSanitizer: data race (<systemspecific>:<implemspecific>) in camlRaise_through_handler.reader_<implemspecific>
 ==================
-result = 44
+Result = 44
 ThreadSanitizer: reported 1 warnings

--- a/testsuite/tests/tsan/record_field.reference
+++ b/testsuite/tests/tsan/record_field.reference
@@ -9,6 +9,13 @@ WARNING: ThreadSanitizer: data race (pid=<implemspecific>)
     #0 camlRecord_field.writer_<implemspecific> <implemspecific> (<implemspecific>)
     #1 camlStdlib__Domain.body_<implemspecific> <implemspecific> (<implemspecific>)
 
+  As if synchronized via sleep:
+    #0 usleep <implemspecific> (<implemspecific>)
+    #1 wg_wait <implemspecific> (<implemspecific>)
+    #2 camlRecord_field.reader_<implemspecific> <implemspecific> (<implemspecific>)
+    #3 camlRecord_field.entry <implemspecific> (<implemspecific>)
+    #4 caml_program <implemspecific> (<implemspecific>)
+
   Mutex M<implemspecific> (<implemspecific>) created at:
     #0 pthread_mutex_init <implemspecific> (<implemspecific>)
     #1 caml_plat_mutex_init <implemspecific> (<implemspecific>)

--- a/testsuite/tests/tsan/record_field.reference
+++ b/testsuite/tests/tsan/record_field.reference
@@ -1,11 +1,12 @@
 ==================
 WARNING: ThreadSanitizer: data race (pid=<implemspecific>)
-  Read of size 8 at <implemspecific> by thread T4 (mutexes: write M<implemspecific>):
-    #0 camlRecord_field.fun_<implemspecific> <implemspecific> (<implemspecific>)
-    #1 camlStdlib__Domain.body_<implemspecific> <implemspecific> (<implemspecific>)
+  Read of size 8 at <implemspecific> by main thread (mutexes: write M<implemspecific>):
+    #0 camlRecord_field.reader_<implemspecific> <implemspecific> (<implemspecific>)
+    #1 camlRecord_field.entry <implemspecific> (<implemspecific>)
+    #2 caml_program <implemspecific> (<implemspecific>)
 
   Previous write of size 8 at <implemspecific> by thread T1 (mutexes: write M<implemspecific>):
-    #0 camlRecord_field.fun_<implemspecific> <implemspecific> (<implemspecific>)
+    #0 camlRecord_field.writer_<implemspecific> <implemspecific> (<implemspecific>)
     #1 camlStdlib__Domain.body_<implemspecific> <implemspecific> (<implemspecific>)
 
   Mutex M<implemspecific> (<implemspecific>) created at:
@@ -19,14 +20,6 @@ WARNING: ThreadSanitizer: data race (pid=<implemspecific>)
     #1 caml_plat_mutex_init <implemspecific> (<implemspecific>)
     #2 caml_init_domains <implemspecific> (<implemspecific>)
     #3 caml_init_gc <implemspecific> (<implemspecific>)
-
-  Thread T4 (tid=<implemspecific>, running) created by main thread at:
-    #0 pthread_create <implemspecific> (<implemspecific>)
-    #1 caml_domain_spawn <implemspecific> (<implemspecific>)
-    #2 caml_c_call <implemspecific> (<implemspecific>)
-    #3 camlStdlib__Domain.spawn_<implemspecific> <implemspecific> (<implemspecific>)
-    #4 camlRecord_field.entry <implemspecific> (<implemspecific>)
-    #5 caml_program <implemspecific> (<implemspecific>)
 
   Thread T1 (tid=<implemspecific>, running) created by main thread at:
     #0 pthread_create <implemspecific> (<implemspecific>)
@@ -36,6 +29,6 @@ WARNING: ThreadSanitizer: data race (pid=<implemspecific>)
     #4 camlRecord_field.entry <implemspecific> (<implemspecific>)
     #5 caml_program <implemspecific> (<implemspecific>)
 
-SUMMARY: ThreadSanitizer: data race (<systemspecific>:<implemspecific>) in camlRecord_field.fun_<implemspecific>
+SUMMARY: ThreadSanitizer: data race (<systemspecific>:<implemspecific>) in camlRecord_field.reader_<implemspecific>
 ==================
 ThreadSanitizer: reported 1 warnings

--- a/testsuite/tests/tsan/reperform.ml
+++ b/testsuite/tests/tsan/reperform.ml
@@ -5,6 +5,8 @@
  set TSAN_OPTIONS="detect_deadlocks=0";
 
  tsan;
+ readonly_files = "waitgroup_stubs.c";
+ all_modules = "${readonly_files} waitgroup.ml reperform.ml";
  native;
 
 *)
@@ -23,6 +25,8 @@ let print_endline s = Stdlib.print_endline s; flush stdout
 type _ t += E1 : int -> int t
 type _ t += E2 : int -> int t
 
+let wg1 = Waitgroup.create 2
+let wg2 = Waitgroup.create 2
 let g_ref1 = ref 0
 let g_ref2 = ref 0
 let g_ref3 = ref 0
@@ -34,22 +38,22 @@ let [@inline never] race =
   | _ -> g_ref3 := 1
 
 let [@inline never] h () =
-  print_endline "entering h";
+  print_endline "Entering h";
   let v = perform (E1 0) in
   race 1;
-  print_endline "leaving h";
+  print_endline "Leaving h";
   v
 
 let [@inline never] g () =
-  print_endline "entering g";
+  print_endline "Entering g";
   let v = h () in
-  print_endline "leaving g";
+  print_endline "Leaving g";
   v
 
 let f () =
-  print_endline "entering f";
+  print_endline "Entering f";
   let v = g () in
-  print_endline "leaving f";
+  print_endline "Leaving f";
   v + 1
 
 let [@inline never] fiber2 () =
@@ -79,10 +83,10 @@ let effh : type a. a t -> ((a, 'b) continuation -> 'b) option = function
 let [@inline never] fiber1 () =
   ignore @@ match_with fiber2 ()
   { retc = (fun v ->
-    print_endline "value handler"; v + 1);
+    print_endline "Value handler"; v + 1);
     exnc = (fun e -> raise e);
     effc = effh };
-  1338
+  41
 
 let[@inline never] main () =
   let v = fiber1 () in
@@ -90,12 +94,14 @@ let[@inline never] main () =
 
 let[@inline never] other_domain () =
   ignore @@ (!g_ref1, !g_ref2, !g_ref3);
-  Unix.sleepf 0.66
+  Waitgroup.join wg1;
+  Waitgroup.join wg2
 
 let () =
   let d = Domain.spawn other_domain in
-  Unix.sleepf 0.33;
+  Waitgroup.join wg1;
   let v = main () in
-  printf "result=%d\n%!" v;
+  printf "Result=%d\n%!" v;
   race 2;
+  Waitgroup.join wg2;
   Domain.join d

--- a/testsuite/tests/tsan/reperform.reference
+++ b/testsuite/tests/tsan/reperform.reference
@@ -16,6 +16,12 @@ WARNING: ThreadSanitizer: data race (pid=<implemspecific>)
     #0 camlReperform.other_domain_<implemspecific> <implemspecific> (<implemspecific>)
     #1 camlStdlib__Domain.body_<implemspecific> <implemspecific> (<implemspecific>)
 
+  As if synchronized via sleep:
+    #0 usleep <implemspecific> (<implemspecific>)
+    #1 wg_wait <implemspecific> (<implemspecific>)
+    #2 camlReperform.entry <implemspecific> (<implemspecific>)
+    #3 caml_program <implemspecific> (<implemspecific>)
+
   Mutex M<implemspecific> (<implemspecific>) created at:
     #0 pthread_mutex_init <implemspecific> (<implemspecific>)
     #1 caml_plat_mutex_init <implemspecific> (<implemspecific>)
@@ -58,6 +64,12 @@ WARNING: ThreadSanitizer: data race (pid=<implemspecific>)
     #0 camlReperform.other_domain_<implemspecific> <implemspecific> (<implemspecific>)
     #1 camlStdlib__Domain.body_<implemspecific> <implemspecific> (<implemspecific>)
 
+  As if synchronized via sleep:
+    #0 usleep <implemspecific> (<implemspecific>)
+    #1 wg_wait <implemspecific> (<implemspecific>)
+    #2 camlReperform.entry <implemspecific> (<implemspecific>)
+    #3 caml_program <implemspecific> (<implemspecific>)
+
   Mutex M<implemspecific> (<implemspecific>) created at:
     #0 pthread_mutex_init <implemspecific> (<implemspecific>)
     #1 caml_plat_mutex_init <implemspecific> (<implemspecific>)
@@ -96,6 +108,12 @@ WARNING: ThreadSanitizer: data race (pid=<implemspecific>)
   Previous read of size 8 at <implemspecific> by thread T1 (mutexes: write M<implemspecific>):
     #0 camlReperform.other_domain_<implemspecific> <implemspecific> (<implemspecific>)
     #1 camlStdlib__Domain.body_<implemspecific> <implemspecific> (<implemspecific>)
+
+  As if synchronized via sleep:
+    #0 usleep <implemspecific> (<implemspecific>)
+    #1 wg_wait <implemspecific> (<implemspecific>)
+    #2 camlReperform.entry <implemspecific> (<implemspecific>)
+    #3 caml_program <implemspecific> (<implemspecific>)
 
   Mutex M<implemspecific> (<implemspecific>) created at:
     #0 pthread_mutex_init <implemspecific> (<implemspecific>)

--- a/testsuite/tests/tsan/reperform.reference
+++ b/testsuite/tests/tsan/reperform.reference
@@ -1,6 +1,6 @@
-entering f
-entering g
-entering h
+Entering f
+Entering g
+Entering h
 E1 handler before continue
 ==================
 WARNING: ThreadSanitizer: data race (pid=<implemspecific>)
@@ -15,13 +15,6 @@ WARNING: ThreadSanitizer: data race (pid=<implemspecific>)
   Previous read of size 8 at <implemspecific> by thread T1 (mutexes: write M<implemspecific>):
     #0 camlReperform.other_domain_<implemspecific> <implemspecific> (<implemspecific>)
     #1 camlStdlib__Domain.body_<implemspecific> <implemspecific> (<implemspecific>)
-
-  As if synchronized via sleep:
-    #0 nanosleep <implemspecific> (<implemspecific>)
-    #1 caml_unix_sleep <implemspecific> (<implemspecific>)
-    #2 caml_c_call <implemspecific> (<implemspecific>)
-    #3 camlReperform.entry <implemspecific> (<implemspecific>)
-    #4 caml_program <implemspecific> (<implemspecific>)
 
   Mutex M<implemspecific> (<implemspecific>) created at:
     #0 pthread_mutex_init <implemspecific> (<implemspecific>)
@@ -65,13 +58,6 @@ WARNING: ThreadSanitizer: data race (pid=<implemspecific>)
     #0 camlReperform.other_domain_<implemspecific> <implemspecific> (<implemspecific>)
     #1 camlStdlib__Domain.body_<implemspecific> <implemspecific> (<implemspecific>)
 
-  As if synchronized via sleep:
-    #0 nanosleep <implemspecific> (<implemspecific>)
-    #1 caml_unix_sleep <implemspecific> (<implemspecific>)
-    #2 caml_c_call <implemspecific> (<implemspecific>)
-    #3 camlReperform.entry <implemspecific> (<implemspecific>)
-    #4 caml_program <implemspecific> (<implemspecific>)
-
   Mutex M<implemspecific> (<implemspecific>) created at:
     #0 pthread_mutex_init <implemspecific> (<implemspecific>)
     #1 caml_plat_mutex_init <implemspecific> (<implemspecific>)
@@ -94,12 +80,12 @@ WARNING: ThreadSanitizer: data race (pid=<implemspecific>)
 
 SUMMARY: ThreadSanitizer: data race (<systemspecific>:<implemspecific>) in camlReperform.race_<implemspecific>
 ==================
-leaving h
-leaving g
-leaving f
-value handler
+Leaving h
+Leaving g
+Leaving f
+Value handler
 E1 handler after continue
-result=1339
+Result=42
 ==================
 WARNING: ThreadSanitizer: data race (pid=<implemspecific>)
   Write of size 8 at <implemspecific> by main thread (mutexes: write M<implemspecific>):
@@ -110,13 +96,6 @@ WARNING: ThreadSanitizer: data race (pid=<implemspecific>)
   Previous read of size 8 at <implemspecific> by thread T1 (mutexes: write M<implemspecific>):
     #0 camlReperform.other_domain_<implemspecific> <implemspecific> (<implemspecific>)
     #1 camlStdlib__Domain.body_<implemspecific> <implemspecific> (<implemspecific>)
-
-  As if synchronized via sleep:
-    #0 nanosleep <implemspecific> (<implemspecific>)
-    #1 caml_unix_sleep <implemspecific> (<implemspecific>)
-    #2 caml_c_call <implemspecific> (<implemspecific>)
-    #3 camlReperform.entry <implemspecific> (<implemspecific>)
-    #4 caml_program <implemspecific> (<implemspecific>)
 
   Mutex M<implemspecific> (<implemspecific>) created at:
     #0 pthread_mutex_init <implemspecific> (<implemspecific>)

--- a/testsuite/tests/tsan/unhandled.ml
+++ b/testsuite/tests/tsan/unhandled.ml
@@ -5,6 +5,8 @@
  set TSAN_OPTIONS="detect_deadlocks=0";
 
  tsan;
+ readonly_files = "waitgroup_stubs.c";
+ all_modules = "${readonly_files} waitgroup.ml unhandled.ml";
  native;
 
 *)
@@ -17,33 +19,35 @@ let print_endline s = Stdlib.print_endline s; flush stdout
 
 type _ t += E : int -> int t
 
-let g_ref1 = ref 0
-let g_ref2 = ref 0
+let wg1 = Waitgroup.create 2
+let wg2 = Waitgroup.create 2
+let r1 = ref 0
+let r2 = ref 0
 
 let [@inline never] race = function
-  | 0 -> g_ref1 := 42
-  | 1 -> g_ref2 := 42
+  | 0 -> r1 := 42
+  | 1 -> r2 := 42
   | _ -> assert false
 
 let [@inline never] h () =
-  print_endline "entering h";
+  print_endline "Entering h";
   let v =
     try perform (E 0)
     with Unhandled _ -> race 1; 1
   in
-  print_endline "leaving h";
+  print_endline "Leaving h";
   v
 
 let [@inline never] g () =
-  print_endline "entering g";
+  print_endline "Entering g";
   let v = h () in
-  print_endline "leaving g";
+  print_endline "Leaving g";
   v
 
 let f () =
-  print_endline "entering f";
+  print_endline "Entering f";
   let v = g () in
-  print_endline "leaving f";
+  print_endline "Leaving f";
   v + 1
 
 let [@inline never] fiber2 () =
@@ -58,26 +62,28 @@ let effh : type a. a t -> ((a, 'b) continuation -> 'b) option = fun _ -> None
 let [@inline never] fiber1 () =
   ignore @@ match_with fiber2 ()
   { retc = (fun v ->
-      print_endline "value handler"; v + 1);
+      print_endline "Value handler"; v + 1);
     exnc = (fun e -> raise e);
     effc = effh };
-  1338
+  41
 
 let[@inline never] main () =
-  print_endline "performing an unhandled effect from the main fiber";
+  print_endline "Performing an unhandled effect from the main fiber";
   try perform (E 42) with
   | Effect.Unhandled _ -> race 0;
-  print_endline "performing an unhandled effect from another fiber";
+  print_endline "Performing an unhandled effect from another fiber";
   let v = fiber1 () in
   v + 1
 
 let[@inline never] other_domain () =
-  ignore @@ (Sys.opaque_identity !g_ref1, !g_ref2);
-  Unix.sleepf 0.66
+  ignore @@ (Sys.opaque_identity !r1, !r2);
+  Waitgroup.join wg1;
+  Waitgroup.join wg2
 
 let () =
   let d = Domain.spawn other_domain in
-  Unix.sleepf 0.33;
+  Waitgroup.join wg1;
   let v = main () in
-  printf "result=%d\n%!" v;
+  Waitgroup.join wg2;
+  printf "Result=%d\n%!" v;
   Domain.join d

--- a/testsuite/tests/tsan/unhandled.reference
+++ b/testsuite/tests/tsan/unhandled.reference
@@ -1,4 +1,4 @@
-performing an unhandled effect from the main fiber
+Performing an unhandled effect from the main fiber
 ==================
 WARNING: ThreadSanitizer: data race (pid=<implemspecific>)
   Write of size 8 at <implemspecific> by main thread (mutexes: write M<implemspecific>):
@@ -10,13 +10,6 @@ WARNING: ThreadSanitizer: data race (pid=<implemspecific>)
   Previous read of size 8 at <implemspecific> by thread T1 (mutexes: write M<implemspecific>):
     #0 camlUnhandled.other_domain_<implemspecific> <implemspecific> (<implemspecific>)
     #1 camlStdlib__Domain.body_<implemspecific> <implemspecific> (<implemspecific>)
-
-  As if synchronized via sleep:
-    #0 nanosleep <implemspecific> (<implemspecific>)
-    #1 caml_unix_sleep <implemspecific> (<implemspecific>)
-    #2 caml_c_call <implemspecific> (<implemspecific>)
-    #3 camlUnhandled.entry <implemspecific> (<implemspecific>)
-    #4 caml_program <implemspecific> (<implemspecific>)
 
   Mutex M<implemspecific> (<implemspecific>) created at:
     #0 pthread_mutex_init <implemspecific> (<implemspecific>)
@@ -40,10 +33,10 @@ WARNING: ThreadSanitizer: data race (pid=<implemspecific>)
 
 SUMMARY: ThreadSanitizer: data race (<systemspecific>:<implemspecific>) in camlUnhandled.race_<implemspecific>
 ==================
-performing an unhandled effect from another fiber
-entering f
-entering g
-entering h
+Performing an unhandled effect from another fiber
+Entering f
+Entering g
+Entering h
 ==================
 WARNING: ThreadSanitizer: data race (pid=<implemspecific>)
   Write of size 8 at <implemspecific> by main thread (mutexes: write M<implemspecific>):
@@ -63,13 +56,6 @@ WARNING: ThreadSanitizer: data race (pid=<implemspecific>)
     #0 camlUnhandled.other_domain_<implemspecific> <implemspecific> (<implemspecific>)
     #1 camlStdlib__Domain.body_<implemspecific> <implemspecific> (<implemspecific>)
 
-  As if synchronized via sleep:
-    #0 nanosleep <implemspecific> (<implemspecific>)
-    #1 caml_unix_sleep <implemspecific> (<implemspecific>)
-    #2 caml_c_call <implemspecific> (<implemspecific>)
-    #3 camlUnhandled.entry <implemspecific> (<implemspecific>)
-    #4 caml_program <implemspecific> (<implemspecific>)
-
   Mutex M<implemspecific> (<implemspecific>) created at:
     #0 pthread_mutex_init <implemspecific> (<implemspecific>)
     #1 caml_plat_mutex_init <implemspecific> (<implemspecific>)
@@ -92,9 +78,9 @@ WARNING: ThreadSanitizer: data race (pid=<implemspecific>)
 
 SUMMARY: ThreadSanitizer: data race (<systemspecific>:<implemspecific>) in camlUnhandled.race_<implemspecific>
 ==================
-leaving h
-leaving g
-leaving f
-value handler
-result=1339
+Leaving h
+Leaving g
+Leaving f
+Value handler
+Result=42
 ThreadSanitizer: reported 2 warnings

--- a/testsuite/tests/tsan/unhandled.reference
+++ b/testsuite/tests/tsan/unhandled.reference
@@ -11,6 +11,12 @@ WARNING: ThreadSanitizer: data race (pid=<implemspecific>)
     #0 camlUnhandled.other_domain_<implemspecific> <implemspecific> (<implemspecific>)
     #1 camlStdlib__Domain.body_<implemspecific> <implemspecific> (<implemspecific>)
 
+  As if synchronized via sleep:
+    #0 usleep <implemspecific> (<implemspecific>)
+    #1 wg_wait <implemspecific> (<implemspecific>)
+    #2 camlUnhandled.entry <implemspecific> (<implemspecific>)
+    #3 caml_program <implemspecific> (<implemspecific>)
+
   Mutex M<implemspecific> (<implemspecific>) created at:
     #0 pthread_mutex_init <implemspecific> (<implemspecific>)
     #1 caml_plat_mutex_init <implemspecific> (<implemspecific>)
@@ -55,6 +61,12 @@ WARNING: ThreadSanitizer: data race (pid=<implemspecific>)
   Previous read of size 8 at <implemspecific> by thread T1 (mutexes: write M<implemspecific>):
     #0 camlUnhandled.other_domain_<implemspecific> <implemspecific> (<implemspecific>)
     #1 camlStdlib__Domain.body_<implemspecific> <implemspecific> (<implemspecific>)
+
+  As if synchronized via sleep:
+    #0 usleep <implemspecific> (<implemspecific>)
+    #1 wg_wait <implemspecific> (<implemspecific>)
+    #2 camlUnhandled.entry <implemspecific> (<implemspecific>)
+    #3 caml_program <implemspecific> (<implemspecific>)
 
   Mutex M<implemspecific> (<implemspecific>) created at:
     #0 pthread_mutex_init <implemspecific> (<implemspecific>)

--- a/testsuite/tests/tsan/waitgroup.ml
+++ b/testsuite/tests/tsan/waitgroup.ml
@@ -1,0 +1,7 @@
+type t
+
+external create : int -> t = "wg_create" [@@noalloc]
+external finish : t -> unit = "wg_finish" [@@noalloc]
+external wait : t -> unit = "wg_wait" [@@noalloc]
+
+let [@inline never] join t = finish t; wait t

--- a/testsuite/tests/tsan/waitgroup_stubs.c
+++ b/testsuite/tests/tsan/waitgroup_stubs.c
@@ -1,0 +1,51 @@
+#include <assert.h>
+#include <stdatomic.h>
+#include <unistd.h>
+
+#include <caml/mlvalues.h>
+#include <caml/tsan.h>
+
+#define MAX_WAITGROUP   8
+#define SPIN_WAIT_MS    10
+
+typedef struct {
+  unsigned    limit; /* Number of threads participating to the checkpoint */
+  atomic_uint count; /* Number of threads that have reach the checkpoint */
+} waitgroup;
+
+static waitgroup waitgroups[MAX_WAITGROUP] = { 0 };
+
+static atomic_uint index = 0;
+
+CAMLno_tsan static waitgroup* wg_get(unsigned idx)
+{
+  assert(idx < MAX_WAITGROUP);
+
+  waitgroup* wg = &waitgroups[idx];
+  return wg;
+}
+
+CAMLno_tsan value wg_create(value n)
+{
+  waitgroup* wg = wg_get(index);
+
+  wg->limit = Int_val(n);
+  wg->count = 0;
+  return Val_int(index++);
+}
+
+CAMLno_tsan value wg_finish(value t)
+{
+  waitgroup* wg = wg_get(Int_val(t));
+
+  wg->count += 1;
+  return Val_unit;
+}
+
+CAMLno_tsan value wg_wait(value t)
+{
+  waitgroup* wg = wg_get(Int_val(t));
+
+  while (wg->count != wg->limit) { /* spinwait */ }
+  return Val_unit;
+}


### PR DESCRIPTION
With TSan on its way to get back a dedicated run on the Iniria CI (#12644), this PR brings some love to the TSan tests in the testsuite.

`tsan` tests need to confirm that TSan is able to detect the presence (or less often, the absence) of data races in specific code, by checking that TSan prints expected reports to stderr.
These tests involve at least 2 `domain`s to create a data race, and they must be 'synchronised' so that this happens without inter-thread happens-before, which would 'hide' the data race from TSan.

Some challenges that require synchronisation are:
- a spawned `domain` shouldn't terminate before the main `domain` finishes its job to create a data race
- enforcing an order on which thread reads or writes to a memory location first, so that TSan can deterministically report which event happened before the other.

All these 'synchronisations' must be invisible to TSan, not to hide the data race. As a simple -and extremely brittle- solution, we used `sleep` for this purpose. This PR removes them completely.

Some other proper synchronisation mechanisms were ruled out:
- `pthread` mutex and condition variable because TSan runtime intercepts function calls to `pthread` library even in code annotated with `notsan`
- C11 concurrency library (`thrd_t`, `cnd_t`...), which is still incompatible with TSan

To avoid any interaction with the GC, a `Waitgroup` type (inspired by Go's [Waitgroup](https://pkg.go.dev/sync#WaitGroup) interface) is used with most of its implementation in C, and without allocation.
These `waitgroup`s allow threads to reach a 'checkpoint' in the tests, and wait for the other(s) thread(s) to also reach the checkpoint before continuing further. `join`ing on a `waitgoup` is implemented with a spinwait.
This allows for TSan-invisible, proper synchronisation, and more deterministic tests.