### PR TITLE
ocamldoc: centralize lexical convention before utf-8

### DIFF
--- a/.depend
+++ b/.depend
@@ -8641,12 +8641,10 @@ ocamldoc/odoc_parameter.cmi : \
     typing/types.cmi \
     ocamldoc/odoc_types.cmi
 ocamldoc/odoc_parser.cmo : \
-    otherlibs/str/str.cmi \
     ocamldoc/odoc_types.cmi \
     ocamldoc/odoc_comments_global.cmi \
     ocamldoc/odoc_parser.cmi
 ocamldoc/odoc_parser.cmx : \
-    otherlibs/str/str.cmx \
     ocamldoc/odoc_types.cmx \
     ocamldoc/odoc_comments_global.cmx \
     ocamldoc/odoc_parser.cmi


### PR DESCRIPTION
This PR proposes to remove one redundant definition of OCaml lexical conventions in the ocamldoc parser to make it easier to make ocamldoc support utf8 encoded latin-9 in the future version of #11736 .

This is done by moving some of the lexing in the ocamldoc parser to the ocamldoc lexer.