### PR TITLE
Identify mismatched class type parameters and class parameters by ordinal in error messages.

### DIFF
--- a/.depend
+++ b/.depend
@@ -728,6 +728,7 @@ typing/includeclass.cmo : \
     typing/types.cmi \
     typing/printtyp.cmi \
     typing/path.cmi \
+    utils/misc.cmi \
     typing/ctype.cmi \
     parsing/builtin_attributes.cmi \
     typing/includeclass.cmi
@@ -735,6 +736,7 @@ typing/includeclass.cmx : \
     typing/types.cmx \
     typing/printtyp.cmx \
     typing/path.cmx \
+    utils/misc.cmx \
     typing/ctype.cmx \
     parsing/builtin_attributes.cmx \
     typing/includeclass.cmi

--- a/Changes
+++ b/Changes
@@ -291,6 +291,10 @@ Working version
 - #12622: Give hints about existential types appearing in error messages
   (Leo White, review by Gabriel Scherer and Florian Angeletti)
 
+- #?????: When a class type parameter does not match, identify which type
+  parameter in the error message, instead of saying "A type parameter".
+  (Stefan Muenzel, review by ?????)
+
 ### Internal/compiler-libs changes:
 
 - #12447: Remove 32-bit targets from X86_proc.system

--- a/Changes
+++ b/Changes
@@ -291,9 +291,10 @@ Working version
 - #12622: Give hints about existential types appearing in error messages
   (Leo White, review by Gabriel Scherer and Florian Angeletti)
 
-- #?????: When a class type parameter does not match, identify which type
-  parameter in the error message, instead of saying "A type parameter".
-  (Stefan Muenzel, review by ?????)
+- #12671: When a class type parameter or class parameter does not match,
+  identify which parameter in the error message, instead of saying
+  "A type parameter" or "A parameter".
+  (Stefan Muenzel, review by Gabriel Scherer)
 
 ### Internal/compiler-libs changes:
 

--- a/testsuite/tests/typing-misc/includeclass_errors.ml
+++ b/testsuite/tests/typing-misc/includeclass_errors.ml
@@ -87,6 +87,33 @@ Error: Signature mismatch:
        The classes do not have the same number of type parameters
 |}]
 
+module Confusing: sig
+  class ['x, 'y] c: object end
+end = struct
+  class ['y, 'x] c  = object method private id (x : 'y) = x + 1 end
+end
+;;
+[%%expect{|
+Lines 3-5, characters 6-3:
+3 | ......struct
+4 |   class ['y, 'x] c  = object method private id (x : 'y) = x + 1 end
+5 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig
+           class ['a, 'x] c :
+             object constraint 'a = int method private id : 'a -> int end
+         end
+       is not included in
+         sig class ['x, 'y] c : object  end end
+       Class declarations do not match:
+         class ['a, 'x] c :
+           object constraint 'a = int method private id : 'a -> int end
+       does not match
+         class ['x, 'y] c : object  end
+       A type parameter has type "int" but is expected to have type "'x"
+|}]
+
 module M: sig
   class ['a] c: object constraint 'a = int end
 end = struct

--- a/testsuite/tests/typing-misc/includeclass_errors.ml
+++ b/testsuite/tests/typing-misc/includeclass_errors.ml
@@ -180,7 +180,30 @@ Error: Signature mismatch:
          class c : float -> object  end
        does not match
          class c : int -> object  end
-       A parameter has type "float" but is expected to have type "int"
+       The 1st parameter has type "float" but is expected to have type "int"
+|}]
+
+module M: sig
+  class c : int -> int -> object end
+end = struct
+  class c (_ : int) (x : float) = object end
+end
+;;
+[%%expect{|
+Lines 3-5, characters 6-3:
+3 | ......struct
+4 |   class c (_ : int) (x : float) = object end
+5 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig class c : int -> float -> object  end end
+       is not included in
+         sig class c : int -> int -> object  end end
+       Class declarations do not match:
+         class c : int -> float -> object  end
+       does not match
+         class c : int -> int -> object  end
+       The 2nd parameter has type "float" but is expected to have type "int"
 |}]
 
 class virtual foo: foo_t =

--- a/testsuite/tests/typing-misc/includeclass_errors.ml
+++ b/testsuite/tests/typing-misc/includeclass_errors.ml
@@ -111,7 +111,7 @@ Error: Signature mismatch:
            object constraint 'a = int method private id : 'a -> int end
        does not match
          class ['x, 'y] c : object  end
-       A type parameter has type "int" but is expected to have type "'x"
+       The 1st type parameter has type "int" but is expected to have type "'x"
 |}]
 
 module M: sig
@@ -134,7 +134,30 @@ Error: Signature mismatch:
          class ['a] c : object  end
        does not match
          class ['a] c : object constraint 'a = int end
-       A type parameter has type "'a" but is expected to have type "int"
+       The 1st type parameter has type "'a" but is expected to have type "int"
+|}]
+
+module M: sig
+  class ['a, 'b] c: object constraint 'b = int end
+end = struct
+  class ['a, 'b] c = object end
+end
+;;
+[%%expect{|
+Lines 3-5, characters 6-3:
+3 | ......struct
+4 |   class ['a, 'b] c = object end
+5 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig class ['a, 'b] c : object  end end
+       is not included in
+         sig class ['a, 'b] c : object constraint 'b = int end end
+       Class declarations do not match:
+         class ['a, 'b] c : object  end
+       does not match
+         class ['a, 'b] c : object constraint 'b = int end
+       The 2nd type parameter has type "'b" but is expected to have type "int"
 |}]
 
 module M: sig

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -4315,7 +4315,7 @@ let rec equal_private env params1 ty1 params2 ty2 =
 type class_match_failure =
     CM_Virtual_class
   | CM_Parameter_arity_mismatch of int * int
-  | CM_Type_parameter_mismatch of Env.t * equality_error
+  | CM_Type_parameter_mismatch of int * Env.t * equality_error
   | CM_Class_type_mismatch of Env.t * class_type * class_type
   | CM_Parameter_mismatch of Env.t * moregen_error
   | CM_Val_type_mismatch of string * Env.t * comparison_error
@@ -4556,11 +4556,11 @@ let match_class_declarations env patt_params patt_type subj_params subj_type =
         let ls = List.length subj_params in
         if lp  <> ls then
           raise (Failure [CM_Parameter_arity_mismatch (lp, ls)]);
-        List.iter2 (fun p s ->
+        Stdlib.List.iteri2 (fun n p s ->
           try eqtype true type_pairs subst env p s with Equality_trace trace ->
             raise (Failure
                      [CM_Type_parameter_mismatch
-                        (env, expand_to_equality_error env trace !subst)]))
+                        (n+1, env, expand_to_equality_error env trace !subst)]))
           patt_params subj_params;
      (* old code: equal_clty false type_pairs subst env patt_type subj_type; *)
         equal_clsig false type_pairs subst env sign1 sign2;

--- a/typing/ctype.mli
+++ b/typing/ctype.mli
@@ -320,7 +320,7 @@ exception Filter_method_failed of filter_method_failure
 type class_match_failure =
     CM_Virtual_class
   | CM_Parameter_arity_mismatch of int * int
-  | CM_Type_parameter_mismatch of Env.t * Errortrace.equality_error
+  | CM_Type_parameter_mismatch of int * Env.t * Errortrace.equality_error
   | CM_Class_type_mismatch of Env.t * class_type * class_type
   | CM_Parameter_mismatch of Env.t * Errortrace.moregen_error
   | CM_Val_type_mismatch of string * Env.t * Errortrace.comparison_error

--- a/typing/ctype.mli
+++ b/typing/ctype.mli
@@ -322,7 +322,7 @@ type class_match_failure =
   | CM_Parameter_arity_mismatch of int * int
   | CM_Type_parameter_mismatch of int * Env.t * Errortrace.equality_error
   | CM_Class_type_mismatch of Env.t * class_type * class_type
-  | CM_Parameter_mismatch of Env.t * Errortrace.moregen_error
+  | CM_Parameter_mismatch of int * Env.t * Errortrace.moregen_error
   | CM_Val_type_mismatch of string * Env.t * Errortrace.comparison_error
   | CM_Meth_type_mismatch of string * Env.t * Errortrace.comparison_error
   | CM_Non_mutable_value of string

--- a/typing/includeclass.ml
+++ b/typing/includeclass.ml
@@ -56,12 +56,13 @@ let include_err mode ppf =
   | CM_Parameter_arity_mismatch _ ->
       fprintf ppf
         "The classes do not have the same number of type parameters"
-  | CM_Type_parameter_mismatch (env, err) ->
+  | CM_Type_parameter_mismatch (n, env, err) ->
       Printtyp.report_equality_error ppf mode env err
         (function ppf ->
-          fprintf ppf "A type parameter has type")
+           fprintf ppf "The %d%s type parameter has type"
+             n (Misc.ordinal_suffix n))
         (function ppf ->
-          fprintf ppf "but is expected to have type")
+           fprintf ppf "but is expected to have type")
   | CM_Class_type_mismatch (env, cty1, cty2) ->
       Printtyp.wrap_printing_env ~error:true env (fun () ->
         fprintf ppf

--- a/typing/includeclass.ml
+++ b/typing/includeclass.ml
@@ -70,10 +70,11 @@ let include_err mode ppf =
           Printtyp.class_type cty1
           "is not matched by the class type"
           Printtyp.class_type cty2)
-  | CM_Parameter_mismatch (env, err) ->
+  | CM_Parameter_mismatch (n, env, err) ->
       Printtyp.report_moregen_error ppf mode env err
         (function ppf ->
-          fprintf ppf "A parameter has type")
+           fprintf ppf "The %d%s parameter has type"
+             n (Misc.ordinal_suffix n))
         (function ppf ->
           fprintf ppf "but is expected to have type")
   | CM_Val_type_mismatch (lab, env, err) ->

--- a/utils/misc.ml
+++ b/utils/misc.ml
@@ -133,6 +133,14 @@ module Stdlib = struct
       in
       aux [] l1 l2
 
+    let rec iteri2 i f l1 l2 =
+      match (l1, l2) with
+        ([], []) -> ()
+      | (a1::l1, a2::l2) -> f i a1 a2; iteri2 (i + 1) f l1 l2
+      | (_, _) -> raise (Invalid_argument "iteri2")
+
+    let iteri2 f l1 l2 = iteri2 0 f l1 l2
+
     let some_if_all_elements_are_some l =
       let rec aux acc l =
         match l with

--- a/utils/misc.mli
+++ b/utils/misc.mli
@@ -131,6 +131,10 @@ module Stdlib : sig
         If [l1] is of length n and [l2 = h2 @ t2] with h2 of length n,
         r1 is [List.map2 f l1 h1] and r2 is t2. *)
 
+    val iteri2 : (int -> 'a -> 'b -> unit) -> 'a list -> 'b list -> unit
+    (** Same as {!iter2}, but the function is applied to the index of
+        the element as first argument (counting from 0) *)
+
     val split_at : int -> 'a t -> 'a t * 'a t
     (** [split_at n l] returns the pair [before, after] where [before] is
         the [n] first elements of [l] and [after] the remaining ones.


### PR DESCRIPTION
The current error message for class type parameter mismatches looks like this:
```
A type parameter has type "'a" but is expected to have type "int"
```
This patch identifies the type parameter:
```
The 1st type parameter has type "'a" but is expected to have type "int"
```