### PR TITLE
Fix type directed disambiguation of optional arg defaults

### DIFF
--- a/Changes
+++ b/Changes
@@ -339,7 +339,7 @@ Working version
   in Typecore in favor of local mutable state.
   (Nick Roberts, review by Takafumi Saikawa)
 
-- #12236, #12386, #12391, #12496: Use syntax as the sole determiner of fun arity
+- #12236, #12386, #12391, #12496, #12673: Use syntax as sole determiner of arity
   This changes function arity to be based solely on the source program's
   parsetree. Previously, the heuristic for arity had more subtle heuristics
   that involved type information about patterns.  Function arity is important

--- a/testsuite/tests/typing-extensions/disambiguation.ml
+++ b/testsuite/tests/typing-extensions/disambiguation.ml
@@ -259,23 +259,7 @@ let f3 ?x:((_ : M.t) = A) () = ();;
 
 [%%expect {|
 module M : sig type t = A | B end
-Line 5, characters 19-20:
-5 | let f1 ?(x : M.t = A) () = ();;
-                       ^
-Warning 41 [ambiguous-name]: A belongs to several types: M/5.y u x
-The first one was selected. Please disambiguate if this is wrong.
-Lines 1-3, characters 0-3:
-  Definition of module M
-Line 4, characters 0-46:
-  Definition of module M/5
-
-Line 5, characters 9-16:
-5 | let f1 ?(x : M.t = A) () = ();;
-             ^^^^^^^
-Error: This pattern matches values of type "M.t"
-       but a pattern was expected which matches values of type "M/5.y"
-       Lines 1-3, characters 0-3:
-         Definition of module "M"
-       Line 4, characters 0-46:
-         Definition of module "M/5"
+val f1 : ?x:M.t -> unit -> unit = <fun>
+val f2 : ?x:M.t -> unit -> unit = <fun>
+val f3 : ?x:M.t -> unit -> unit = <fun>
 |}]

--- a/testsuite/tests/typing-extensions/disambiguation.ml
+++ b/testsuite/tests/typing-extensions/disambiguation.ml
@@ -247,3 +247,35 @@ The first one was selected. Please disambiguate if this is wrong.
 
 val x : b = Unique
 |}]
+
+(* Optional argument defaults *)
+module M = struct
+  type t = A | B
+end;;
+
+let f1 ?(x : M.t = A) () = ();;
+let f2 ?x:(_ : M.t = A) () = ();;
+let f3 ?x:((_ : M.t) = A) () = ();;
+
+[%%expect {|
+module M : sig type t = A | B end
+Line 5, characters 19-20:
+5 | let f1 ?(x : M.t = A) () = ();;
+                       ^
+Warning 41 [ambiguous-name]: A belongs to several types: M/5.y u x
+The first one was selected. Please disambiguate if this is wrong.
+Lines 1-3, characters 0-3:
+  Definition of module M
+Line 4, characters 0-46:
+  Definition of module M/5
+
+Line 5, characters 9-16:
+5 | let f1 ?(x : M.t = A) () = ();;
+             ^^^^^^^
+Error: This pattern matches values of type "M.t"
+       but a pattern was expected which matches values of type "M/5.y"
+       Lines 1-3, characters 0-3:
+         Definition of module "M"
+       Line 4, characters 0-46:
+         Definition of module "M/5"
+|}]

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -4564,6 +4564,16 @@ and type_function
               try unify env (type_option ty_default) ty_arg
               with Unify _ -> assert false;
             end;
+            (* Issue#12668: Retain type-directed disambiguation of
+               ?x:(y : Variant.t = Constr)
+            *)
+            let default =
+              match pat.ppat_desc with
+              | Ppat_constraint (_, sty) ->
+                  let gloc = { default.pexp_loc with loc_ghost = true } in
+                  Ast_helper.Exp.constraint_ default sty ~loc:gloc
+              | _ -> default
+            in
             let default = type_expect env default (mk_expected ty_default) in
             ty_default, Some default
       in


### PR DESCRIPTION
Fix the specific issue in #12668.

The approach: In type-checking, I duplicate the type annotation on an optional argument's `Ppat_constraint` on the optional argument default expression. This is a bit of a hack but it is non-invasive.

I'm not confident that this approach fixes all potential backward-incompatibilities from #12236 (as optional argument defaults used to be type-checked more like `let` than like `match`) but I can't find another case where it matters. 
