### PR TITLE
Simplify `opam pin` command in `HACKING.adoc`

### DIFF
--- a/HACKING.adoc
+++ b/HACKING.adoc
@@ -252,8 +252,7 @@ work locally) by pinning:
 
 ----
 opam switch create my-switch-name --empty
-# Replace $VERSION by the trunk version
-opam pin add ocaml-variants.$VERSION+branch git+https://$REPO#branch
+opam pin add ocaml-variants git+https://$REPO#branch
 ----
 
 ==== Incremental builds with `opam`


### PR DESCRIPTION
Apropos https://github.com/ocaml/ocaml/issues/12641#issuecomment-1766451766, the compiler's `ocaml-variants.opam` always includes the version field, so there's no need to edit it further.