### PR TITLE
clarify meaning of "non-path module type"

### DIFF
--- a/Changes
+++ b/Changes
@@ -296,6 +296,10 @@ Working version
   "A type parameter" or "A parameter".
   (Stefan Muenzel, review by Gabriel Scherer)
 
+- #12679: Add more detail to the error message and manual in case of
+  invalid module type substitutions.
+  (Stefan Muenzel, review by Gabriel Scherer and Florian Angeletti)
+
 ### Internal/compiler-libs changes:
 
 - #12639: parsing: Attach a location to the RHS of Ptyp_alias

--- a/manual/src/refman/extensions/signaturesubstitution.etex
+++ b/manual/src/refman/extensions/signaturesubstitution.etex
@@ -56,7 +56,7 @@ module type CompareInt = ComparableInt with type t := int
 
 \subsection{ss:local-substitution}{Local substitution declarations}
 
-(Introduced in OCaml 4.08)
+(Introduced in OCaml 4.08, module type substitution introduced in 4.13)
 
 \begin{syntax}
 specification:
@@ -99,6 +99,29 @@ module type S = sig
   type 'a poly_list := [ `Cons of 'a * 'a poly_list | `Nil ]
 end [@@expect error];;
 \end{caml_example}
+
+
+Local module type substitutions also allow for the removal of functor
+applications:
+
+\begin{caml_example}{toplevel}
+module type F = sig
+  module Z : sig type t end
+
+  module F : functor (Z : module type of Z) -> sig
+    module type FF = sig type ff end
+  end
+
+  module type M := F(Z).FF
+
+  val m : (module M)
+end;;
+\end{caml_example}
+
+
+Local module type substitutions are subject to the same limitations as module
+type substitutions, see section \ref{ss:module-type-substitution}.
+
 
 \subsection{ss:module-type-substitution}{Module type substitutions}
 
@@ -151,11 +174,20 @@ from the signature
 \begin{caml_example}{toplevel}
 module type ENDO' = ENDO with module type T := ENDO;;
 \end{caml_example}
-If the right hand side of the substitution is not a path, then the destructive
-substitution is only valid if the left-hand side of the substitution is never
-used as the type of a first-class module in the original module type.
+
+\subsubsection*{ss:module-type-substitution-limitations}{Limitations}
+
+If the right hand side of a module type substitution or a local module
+type substitution is not a @modtype-path@,
+then the destructive substitution is only valid if the left-hand side of the
+substitution is never used as the type of a first-class module in the original
+module type.
 
 \begin{caml_example}{verbatim}[error]
 module type T = sig module type S val x: (module S) end
 module type Error = T with module type S := sig end
+\end{caml_example}
+
+\begin{caml_example}{verbatim}[error]
+module type T = sig module type S := sig end val x: (module S) end
 \end{caml_example}

--- a/manual/src/refman/extensions/signaturesubstitution.etex
+++ b/manual/src/refman/extensions/signaturesubstitution.etex
@@ -101,20 +101,20 @@ end [@@expect error];;
 \end{caml_example}
 
 
-Local module type substitutions also allow for the removal of functor
-applications:
+Local substitutions can also be used to give a local name to a type or
+a module type introduced by a functor application:
 
 \begin{caml_example}{toplevel}
 module type F = sig
-  module Z : sig type t end
+  type set := Set.Make(Int).t
 
-  module F : functor (Z : module type of Z) -> sig
-    module type FF = sig type ff end
-  end
+  module type Type = sig type t end
+  module Nest : Type -> sig module type T = Type end
 
-  module type M := F(Z).FF
+  module type T := Nest(Int).T
 
-  val m : (module M)
+  val set: set
+  val m : (module T)
 end;;
 \end{caml_example}
 

--- a/testsuite/tests/typing-modules/module_type_substitution.ml
+++ b/testsuite/tests/typing-modules/module_type_substitution.ml
@@ -309,8 +309,8 @@ Line 3, characters 2-19:
 3 |   val x: (module t)
       ^^^^^^^^^^^^^^^^^
 Error: The module type "t" is not a valid type for a packed module:
-       it is defined as a temporary local name for an anonymous module type.
-       (see manual section 12.7.3)
+       it is defined as a local substitution (temporary local name)
+       for an anonymous module type. (see manual section 12.7.3)
 |}]
 
 

--- a/testsuite/tests/typing-modules/module_type_substitution.ml
+++ b/testsuite/tests/typing-modules/module_type_substitution.ml
@@ -309,7 +309,7 @@ Line 3, characters 2-19:
 3 |   val x: (module t)
       ^^^^^^^^^^^^^^^^^
 Error: The module type "t" is not a valid type for a packed module:
-       it is defined as a local substitution (temporary local name)
+       it is defined as a local substitution (temporary name)
        for an anonymous module type. (see manual section 12.7.3)
 |}]
 

--- a/testsuite/tests/typing-modules/module_type_substitution.ml
+++ b/testsuite/tests/typing-modules/module_type_substitution.ml
@@ -262,7 +262,8 @@ Line 3, characters 2-19:
 3 |   val x: (module t)
       ^^^^^^^^^^^^^^^^^
 Error: The module type "t" is not a valid type for a packed module:
-       it is defined as a local substitution for a non-path module type.
+       it is defined as a local substitution for a module type which
+       does not have a name.
 |}]
 
 

--- a/testsuite/tests/typing-modules/module_type_substitution.ml
+++ b/testsuite/tests/typing-modules/module_type_substitution.ml
@@ -184,6 +184,7 @@ Line 1, characters 25-58:
 1 | module type fst_erased = fst with module type t := sig end
                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This "with" constraint "t := sig end" makes a packed module ill-formed.
+       (see manual section 12.7.3)
 |}]
 
 module type fst_ok = fst with module type t = sig end
@@ -205,6 +206,7 @@ Line 8, characters 16-49:
 8 | module type R = S with module type M.T := sig end
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This "with" constraint "M.T := sig end" makes a packed module ill-formed.
+       (see manual section 12.7.3)
 |}]
 
 
@@ -222,6 +224,7 @@ Line 8, characters 16-49:
 8 | module type R = S with module type M.T := sig end
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This "with" constraint "T := sig end" makes a packed module ill-formed.
+       (see manual section 12.7.3)
 |}]
 
 
@@ -253,7 +256,51 @@ Error: Multiple definition of the type name "a".
        Names must be unique in a given structure or signature.
 |}]
 
-module type fst = sig
+(* Only local module type substitutions resulting in paths may
+   be used in first class modules. *)
+
+module X = struct
+  module type s = sig type t end
+  module Y(Z : s) = struct
+    module type Ys = sig end
+  end
+end
+
+module type fcm_path = sig
+  module type t_s := X.s
+  module Z : sig type t end
+  module type t_Ys := X.Y(Z).Ys
+
+  module F : functor (Z : module type of Z) -> sig
+    module type t_F = sig type ff end
+  end
+
+  module type t_FF := F(Z).t_F
+
+  val x_s: (module t_s)
+  val x_sY: (module t_Ys)
+  val x_sFF : (module t_FF)
+end
+
+[%%expect {|
+module X :
+  sig
+    module type s = sig type t end
+    module Y : functor (Z : s) -> sig module type Ys = sig end end
+  end
+module type fcm_path =
+  sig
+    module Z : sig type t end
+    module F :
+      functor (Z : sig type t end) ->
+        sig module type t_F = sig type ff end end
+    val x_s : (module X.s)
+    val x_sY : (module X.Y(Z).Ys)
+    val x_sFF : (module F(Z).t_F)
+  end
+|}]
+
+module type fcm_signature = sig
   module type t := sig end
   val x: (module t)
 end
@@ -262,8 +309,8 @@ Line 3, characters 2-19:
 3 |   val x: (module t)
       ^^^^^^^^^^^^^^^^^
 Error: The module type "t" is not a valid type for a packed module:
-       it is defined as a local substitution for a module type which
-       does not have a name.
+       it is defined as a temporary local name for an anonymous module type.
+       (see manual section 12.7.3)
 |}]
 
 

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -3456,7 +3456,7 @@ let report_error ~loc _env = function
       in
       Location.errorf ~loc
         "The module type@ %a@ is not a valid type for a packed module:@ \
-         it is defined as a local substitution (temporary local name)@ \
+         it is defined as a local substitution (temporary name)@ \
          for an anonymous module type.@ %a"
         Style.inline_code (Path.name p)
         Misc.print_see_manual manual_ref

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -3456,8 +3456,8 @@ let report_error ~loc _env = function
       in
       Location.errorf ~loc
         "The module type@ %a@ is not a valid type for a packed module:@ \
-         it is defined as a temporary local name for an anonymous@ \
-         module type.@ %a"
+         it is defined as a local substitution (temporary local name)@ \
+         for an anonymous module type.@ %a"
         Style.inline_code (Path.name p)
         Misc.print_see_manual manual_ref
 

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -3449,7 +3449,8 @@ let report_error ~loc _env = function
   | Unpackable_local_modtype_subst p ->
       Location.errorf ~loc
         "The module type@ %a@ is not a valid type for a packed module:@ \
-         it is defined as a local substitution for a non-path module type."
+         it is defined as a local substitution for a module type which@ \
+         does not have a name."
         Style.inline_code (Path.name p)
 
 let report_error env ~loc err =

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -3314,14 +3314,18 @@ let report_error ~loc _env = function
               types (other than when replacing a type constructor with @ \
               a type constructor with the same arguments).@]"
   | With_cannot_remove_packed_modtype (p,mty) ->
+      let[@manual.ref "ss:module-type-substitution"] manual_ref =
+        [ 12; 7; 3 ]
+      in
       let pp_constraint ppf () =
         Format.fprintf ppf "%s := %a"
           (Path.name p) Printtyp.modtype mty
       in
       Location.errorf ~loc
-        "This %a constraint@ %a@ makes a packed module ill-formed."
+        "This %a constraint@ %a@ makes a packed module ill-formed.@ %a"
         Style.inline_code "with"
         (Style.as_inline_code pp_constraint) ()
+        Misc.print_see_manual manual_ref
   | Repeated_name(kind, name) ->
       Location.errorf ~loc
         "@[Multiple definition of the %s name %a.@ \
@@ -3447,11 +3451,15 @@ let report_error ~loc _env = function
       Location.errorf ~loc "Only type synonyms are allowed on the right of %a"
         Style.inline_code  ":="
   | Unpackable_local_modtype_subst p ->
+      let[@manual.ref "ss:module-type-substitution"] manual_ref =
+        [ 12; 7; 3 ]
+      in
       Location.errorf ~loc
         "The module type@ %a@ is not a valid type for a packed module:@ \
-         it is defined as a local substitution for a module type which@ \
-         does not have a name."
+         it is defined as a temporary local name for an anonymous@ \
+         module type.@ %a"
         Style.inline_code (Path.name p)
+        Misc.print_see_manual manual_ref
 
 let report_error env ~loc err =
   Printtyp.wrap_printing_env ~error:true env


### PR DESCRIPTION
The error produced when we do the following:
```ocaml
module type fst = sig
  module type t := sig end
  val x: (module t)
end
```
uses the term "non-path module type", which is not defined in the manual. This PR replaces it with "a module type which does not have a name", which I think is equivalent, and should be more understandable to those who are not as familiar with module types.

I don't believe this needs a changes entry, since it's just a small wording change.