### PR TITLE
Remove benign data race in parallel test

### DIFF
--- a/testsuite/tests/parallel/domain_parallel_spawn_burn.ml
+++ b/testsuite/tests/parallel/domain_parallel_spawn_burn.ml
@@ -29,9 +29,9 @@ let test_parallel_spawn () =
   done
 
 let () =
-  let running = ref true in
+  let running = Atomic.make true in
   let rec run_until_stop fn () =
-    while !running do
+    while Atomic.get running do
       fn ();
     done
   in
@@ -41,7 +41,7 @@ let () =
 
   test_parallel_spawn ();
 
-  running := false;
+  Atomic.set running false;
   join domain_minor_gc;
   join domain_major_gc;
 


### PR DESCRIPTION
The test `parallel/domain_parallel_spawn_burn.ml` contains a data race on the `running` flag. While allowed by the memory model and inconsequential, it makes the test show up regularly in the TSan-enabled CI.

This race can be removed for a small cost by making the flag atomic. It probably diminishes performance slightly, but not in a way that makes the test run longer than 11 s on my machine (with `OCAML_TEST_SIZE=2`).