### PR TITLE
Fix TSan false positives due to volatile write handling

### DIFF
--- a/Changes
+++ b/Changes
@@ -165,6 +165,10 @@ Working version
   (KC Sivaramakrishnan, report by Gabriel Scherer, review by Gabriel Scherer,
   Sadiq Jaffer and Fabrice Buoro)
 
+- #12681: Fix TSan false positives due to volatile write handling
+  (Olivier Nicole, Fabrice Buoro and Anmol Sahoo, review by Luc Maranget,
+   Gabriel Scherer, Hernan Ponce de Leon and Xavier Leroy)
+
 ### Code generation and optimizations:
 
 - #11239: on x86-64 and RISC-V, reduce alignment of OCaml stacks from 16 to 8.

--- a/runtime/tsan.c
+++ b/runtime/tsan.c
@@ -377,8 +377,7 @@ extern uint##bitsize##_t __tsan_atomic##bitsize##_fetch_add(                   \
                                                                                \
 CAMLreally_no_tsan void __tsan_volatile_read##size(void *ptr)                  \
 {                                                                              \
-  const bool is_atomic = size <= sizeof(long long) &&                          \
-             is_aligned(ptr, 8);                                               \
+  const bool is_atomic = size <= sizeof(long long) && is_aligned(ptr, 8);      \
   if (is_atomic)                                                               \
     __tsan_atomic##bitsize##_load(ptr, memory_order_relaxed);                  \
   else                                                                         \
@@ -390,8 +389,7 @@ CAMLreally_no_tsan void __tsan_unaligned_volatile_read##size(void *ptr)        \
 }                                                                              \
 CAMLreally_no_tsan void __tsan_volatile_write##size(void *ptr)                 \
 {                                                                              \
-  const bool is_atomic = size <= sizeof(long long) &&                          \
-             is_aligned(ptr, 8);                                               \
+  const bool is_atomic = size <= sizeof(long long) && is_aligned(ptr, 8);      \
   if (is_atomic) {                                                             \
     /* Signal a relaxed atomic store to TSan. We don't have access to the      \
        actual value written so we do a fetch_add of 0 which has the effect of  \

--- a/runtime/tsan.c
+++ b/runtime/tsan.c
@@ -186,12 +186,10 @@
 
    More details and examples can be found in PR #12681.
 
-  Our current make-do solution is that `__tsan_volatile_readN` performs a dummy
-  call to `__tsan_atomic64_load`, which is sufficient for TSan to view them as
-  relaxed loads; but `__tsan_volatile_writeN` simply calls `__tsan_write8`,
-  i.e., volatile writes are still treated as plain writes. This has the
-  unfortunate consequence that two volatile accesses may be considered racy by
-  TSan, which is a false positive, as mentioned above. */
+   Our current make-do solution is that `__tsan_volatile_readN` performs a
+   dummy call to `__tsan_atomic64_load`, which is sufficient for TSan to view
+   them as relaxed loads; and `__tsan_volatile_writeN` performs a dummy
+   fetch_add of zero. */
 
 
 Caml_inline void caml_tsan_debug_log_pc(const char* msg, uintnat pc)
@@ -366,19 +364,16 @@ Caml_inline bool is_aligned(void *ptr, size_t byte_count)
 
 #include <stdint.h>
 
-extern uint8_t __tsan_atomic8_load(void*, int);
-extern uint16_t __tsan_atomic16_load(void*, int);
-extern uint32_t __tsan_atomic32_load(void*, int);
-extern uint64_t __tsan_atomic64_load(void*, int);
-extern unsigned __int128 __tsan_atomic128_load(void*, int);
-
-/* Make TSan see volatile reads as relaxed atomic loads. Volatile stores are
-   still seen as plain stores. Refer to the detailed comments at the beginning
-   of this file. */
+/* Make TSan see word-aligned volatile accesses as relaxed atomic accesses.
+   Refer to the detailed comments at the beginning of this file. */
 #define DEFINE_TSAN_VOLATILE_READ_WRITE(size, bitsize)                         \
                                                                                \
 extern void __tsan_read##size(void*);                                          \
 extern void __tsan_write##size(void*);                                         \
+                                                                               \
+extern uint##bitsize##_t __tsan_atomic##bitsize##_load(void*, int);            \
+extern uint##bitsize##_t __tsan_atomic##bitsize##_fetch_add(                   \
+    volatile void*, uint##bitsize##_t, memory_order);                          \
                                                                                \
 CAMLreally_no_tsan void __tsan_volatile_read##size(void *ptr)                  \
 {                                                                              \
@@ -395,7 +390,15 @@ CAMLreally_no_tsan void __tsan_unaligned_volatile_read##size(void *ptr)        \
 }                                                                              \
 CAMLreally_no_tsan void __tsan_volatile_write##size(void *ptr)                 \
 {                                                                              \
-  __tsan_write##size(ptr);                                                     \
+  const bool is_atomic = size <= sizeof(long long) &&                          \
+             is_aligned(ptr, 8);                                               \
+  if (is_atomic) {                                                             \
+    /* Signal a relaxed atomic store to TSan. We don't have access to the      \
+       actual value written so we do a fetch_add of 0 which has the effect of  \
+       signaling a relaxed store without changing the value. */                \
+    __tsan_atomic##bitsize##_fetch_add(ptr, 0, memory_order_relaxed);          \
+  } else                                                                       \
+    __tsan_write##size(ptr);                                                   \
 }                                                                              \
 CAMLreally_no_tsan void __tsan_unaligned_volatile_write##size(void *ptr)       \
 {                                                                              \
@@ -406,4 +409,26 @@ DEFINE_TSAN_VOLATILE_READ_WRITE(1, 8);
 DEFINE_TSAN_VOLATILE_READ_WRITE(2, 16);
 DEFINE_TSAN_VOLATILE_READ_WRITE(4, 32);
 DEFINE_TSAN_VOLATILE_READ_WRITE(8, 64);
-DEFINE_TSAN_VOLATILE_READ_WRITE(16, 128);
+
+/* We do not treat accesses to 128-bit values as atomic, since it is dubious
+   that they can be treated as such. */
+
+extern void __tsan_read16(void*);
+extern void __tsan_write16(void*);
+
+CAMLreally_no_tsan void __tsan_volatile_read16(void *ptr)
+{
+    __tsan_read16(ptr);
+}
+CAMLreally_no_tsan void __tsan_unaligned_volatile_read16(void *ptr)
+{
+  __tsan_read16(ptr);
+}
+CAMLreally_no_tsan void __tsan_volatile_write16(void *ptr)
+{
+    __tsan_write16(ptr);
+}
+CAMLreally_no_tsan void __tsan_unaligned_volatile_write16(void *ptr)
+{
+  __tsan_write16(ptr);
+}

--- a/runtime/tsan.c
+++ b/runtime/tsan.c
@@ -408,8 +408,12 @@ DEFINE_TSAN_VOLATILE_READ_WRITE(2, 16);
 DEFINE_TSAN_VOLATILE_READ_WRITE(4, 32);
 DEFINE_TSAN_VOLATILE_READ_WRITE(8, 64);
 
-/* We do not treat accesses to 128-bit values as atomic, since it is dubious
-   that they can be treated as such. */
+/* We do not treat accesses to 128-bit (a.k.a. 16-byte) values as atomic, since
+   it is dubious that they can be treated as such. Still, the functions below
+   are needed because, without them, building a C library for OCaml with TSan
+   enabled will fail at the linking step with an unresolved symbol error if it
+   contains volatile accesses to 128-bit values. It is better to have 128-bit
+   volatiles behave silently like plain 128-bit values. */
 
 extern void __tsan_read16(void*);
 extern void __tsan_write16(void*);


### PR DESCRIPTION
For reasons related to the C FFI, it has been decided that in the runtime and in C libraries, we will consider `volatile` accesses as equivalent to relaxed atomics (see https://github.com/ocaml/ocaml/pull/12473).

It is not trivial to explain that to TSan. Fortunately, both GCC and Clang have an option to distinguish `volatile` writes in a custom way, by instrumenting them with a call to a function that we must implement. This option has been introduced to support KCSan, the kernel concurrency sanitizer of the Linux kernel. However, as KCSan is very different from TSan, `volatile` accesses are instrumented in a way that makes it difficult to handle `volatile` writes the way we would like. To explain it I will draw from [an explanation](https://github.com/ocaml/ocaml/pull/12030#issuecomment-1451847104) by @fabbing from a while ago. While `gcc`/`clang` replace `atomic` read/write operations with TSan calls that update TSan's internal state and perform the actual memory operation themselves, `volatile` read/write operations are merely decorated with a TSan call, and then the actual operation is performed.

<details>
<summary>An example using an atomic read operation</summary>


```c
_Atomic uint64_t a = 41;

__attribute__((noinline))
uint64_t an_atomic_read(void)
{
  return a;
}
```

Reading `a` is replaced with a call to `__tsan_atomic64_load` that notifies TSan of the read operation and returns the actual value.

```
__attribute__((noinline))
uint64_t an_atomic_read(void)
{
    117a:       53                      push   %rbx
    117b:       48 8b 7c 24 08          mov    0x8(%rsp),%rdi
    1180:       e8 bb fe ff ff          call   1040 <__tsan_func_entry@plt>
  return a;
    1185:       be 05 00 00 00          mov    $0x5,%esi
    118a:       48 8d 3d af 2e 00 00    lea    0x2eaf(%rip),%rdi        # 4040 <a>
    1191:       e8 ba fe ff ff          call   1050 <__tsan_atomic64_load@plt>
    1196:       48 89 c3                mov    %rax,%rbx
    1199:       e8 c2 fe ff ff          call   1060 <__tsan_func_exit@plt>
}
    119e:       48 89 d8                mov    %rbx,%rax
    11a1:       5b                      pop    %rbx
    11a2:       c3                      ret
```
</details>

<details>
<summary>An example using a volatile read operation</summary>


```c
uint64_t v = 42;

__attribute__((noinline))
uint64_t a_volatile_read(void)
{
  return *(volatile uint64_t*)&v;
}
```

When reading `v` a call to `__tsan_volatile_read8` (at `11b5`) precedes the actual memory read operation (at `11ba`).

```
__attribute__((noinline))
uint64_t a_volatile_read(void)
{
    11a3:       53                      push   %rbx
    11a4:       48 8b 7c 24 08          mov    0x8(%rsp),%rdi
    11a9:       e8 92 fe ff ff          call   1040 <__tsan_func_entry@plt>
  return *(volatile uint64_t*)&v;
    11ae:       48 8d 3d 83 2e 00 00    lea    0x2e83(%rip),%rdi        # 4038 <v>
    11b5:       e8 bf ff ff ff          call   1179 <__tsan_volatile_read8>
    11ba:       48 8b 1d 77 2e 00 00    mov    0x2e77(%rip),%rbx        # 4038 <v>
    11c1:       e8 9a fe ff ff          call   1060 <__tsan_func_exit@plt>
}
    11c6:       48 89 d8                mov    %rbx,%rax
    11c9:       5b                      pop    %rbx
    11ca:       c3                      ret
```
</details>

Similarly, atomic stores are instrumented by _replacing_ the memory access, whereas `volatile` stores are only decorated.

Our current make-do solution is that `__tsan_volatile_readN` performs a dummy call to `__tsan_atomic64_load`, which is sufficient for correctness; and `__tsan_volatile_writeN` simply calls `__tsan_write8`, i.e., is treated as a plain write. The consequence is that (rare) false positives can arise, such as https://github.com/ocaml/ocaml/issues/12282.

## Proposed change

I propose a new make-do solution: signal the write to TSan as a relaxed atomic write. Because TSan insists on actually performing the write, we first read the location using a relaxed load and use that value in the write, thus making sure that we merely write the current value (from the point of view of the thread). Example for 64-bit words:

```c
CAMLreally_no_tsan void __tsan_volatile_write8(void *ptr)
{
  if (is_aligned(ptr, 8)) {
    uint64_t value =
      atomic_load_explicit((_Atomic uint64_t *)ptr, memory_order_relaxed);
    __tsan_atomic64_store(ptr, value, memory_order_relaxed);
  } else
    __tsan_write8(ptr);
}
```

This should remove the existing false positives caused by `volatile` writes being seen by TSan as plain stores. And indeed it makes the false positive noticed in `weaktest_par_load` in the CI (https://github.com/ocaml/ocaml/pull/12644#issuecomment-1770451372) disappear.

## Correctness arguments

The three questions that arise upon such a change are: does it change the actual semantics of the program, defined as the set of possible execution traces (modulo TSan reports)? Does it introduce new false positives? Does it introduce false negatives, i.e., does it hide races?

Relaxed atomics do not imply any synchronizations between threads, so no races should be hidden by this. And atomics are not racy, so the change does not create new possibilities of false positives, either.

Finally, is the semantics of the program preserved? I believe so.

<details>
<summary>Attempt at a proof sketch</summary>

Disclaimer: I am no memory model expert, so this is only an amateur’s poor attempt at manipulating the tricky concepts of C11.

I think this fact can be derived from the following, more general statement: in a C program, inserting a relaxed load that yields `v` followed by a relaxed store of `v` into the same location `l` preserves the semantics. It is obviously the case inside the thread where the insertion occurs. Other threads do not see any “new” values for that location, because we wrote one of the previous values for that location.

More formally, let us show that the instructions inserted into thread A do not modify the semantics by showing that any trace in thread B that reads the value `v` in `l` is, in fact, already present in the initial program.

There are two possibilities: either there exists a synchronizes-with relation from A to B after the initial write of `v` in A, or not. If there isn’t, then nothing prevents B from reading `v` in `l`.

If there are such synchronizes-with relation, then the departing point of the first such synchronizes-with relation in A—let’s call it S— is either sequenced-before our inserted instructions in A, or after (indeed, our inserted instructions are relaxed atomics, and cannot be themselves synchronizing).

- If S is sequenced-before the insertion point in A: then B can read `v` in `l` even in the initial program.
- If S is sequenced-after the insertion point in A: then, either there is an event E in A that is sequenced-after the inserted instructions and before S, and that causes `l` to contain `v'` ≠ `v` from the point of view of A; or there isn’t. If there is no such event, then B can read `v` in `l` even in the initial program. If there is one, then our inserted instructions read and re-write the value `v'` ≠ `v` in `l`, such that B will see `v'` or a newer value. But this was already the case in the initial program.
</details>
