### PR TITLE
fix locations filename in AST produced by the `-pp` option

### DIFF
--- a/Changes
+++ b/Changes
@@ -496,6 +496,9 @@ Working version
   (Fabrice Buoro and Olivier Nicole, report by Jan Midtgaard and Miod Vallat,
    review by Gabriel Scherer)
 
+- #12684: fix locations filename in AST produced by the `-pp` option
+  (Gabriel Scherer, review by Florian Angeletti)
+
 OCaml 5.1.1
 -----------
 

--- a/driver/pparse.ml
+++ b/driver/pparse.ml
@@ -165,7 +165,7 @@ let parse (type a) (kind : a ast_kind) lexbuf : a =
   | Structure -> Parse.implementation lexbuf
   | Signature -> Parse.interface lexbuf
 
-let file_aux ~tool_name inputfile (type a) parse_fun invariant_fun
+let file_aux ~tool_name ~sourcefile inputfile (type a) parse_fun invariant_fun
              (kind : a ast_kind) : a =
   let ast =
     let ast_magic = magic_of_kind kind in
@@ -194,7 +194,7 @@ let file_aux ~tool_name inputfile (type a) parse_fun invariant_fun
         In_channel.input_all ic
       in
       let lexbuf = Lexing.from_string source in
-      Location.init lexbuf inputfile;
+      Location.init lexbuf sourcefile;
       Location.input_lexbuf := Some lexbuf;
       Profile.record_call "parser" (fun () -> parse_fun lexbuf)
     end
@@ -204,7 +204,7 @@ let file_aux ~tool_name inputfile (type a) parse_fun invariant_fun
     )
 
 let file ~tool_name inputfile parse_fun ast_kind =
-  file_aux ~tool_name inputfile parse_fun ignore ast_kind
+  file_aux ~tool_name ~sourcefile:inputfile inputfile parse_fun ignore ast_kind
 
 let report_error ppf = function
   | CannotRun cmd ->
@@ -227,7 +227,7 @@ let parse_file ~tool_name invariant_fun parse kind sourcefile =
   Misc.try_finally
     (fun () ->
        Profile.record_call "parsing" @@ fun () ->
-       file_aux ~tool_name inputfile parse invariant_fun kind)
+       file_aux ~tool_name ~sourcefile inputfile parse invariant_fun kind)
     ~always:(fun () -> remove_preprocessed inputfile)
 
 let parse_implementation ~tool_name sourcefile =


### PR DESCRIPTION
I was reading the code of `Pparse.file_aux` to review #12654 and I found a bug in the choice of filename used in AST locations. (cc @malekbr @Octachron)

```shell
$ echo "()" > test.ml

# expected behavior
$ ocamlc -dparsetree -stop-after parsing test.ml
[
  structure_item (test.ml[1,0+0]..[1,0+2])
    Pstr_eval
    expression (test.ml[1,0+0]..[1,0+2])
      Pexp_construct "()" (test.ml[1,0+0]..[1,0+2])
      None
]

# the bug: adding a '-pp' flag should not change the locations
$ ocamlc -dparsetree -stop-after parsing -pp cat test.ml
[
  structure_item (/tmp/ocamlppb3505d[1,0+0]..[1,0+2])
    Pstr_eval
    expression (/tmp/ocamlppb3505d[1,0+0]..[1,0+2])
      Pexp_construct "()" (/tmp/ocamlppb3505d[1,0+0]..[1,0+2])
      None
]
```

When using the `-pp` option, the locations in the AST mention the temporary file created to implement `-pp`, instead of mentioning the source file. The present PR fixes this bug.