### PR TITLE
Use proper C99 flexible array members

### DIFF
--- a/runtime/caml/bigarray.h
+++ b/runtime/caml/bigarray.h
@@ -85,20 +85,11 @@ struct caml_ba_array {
   intnat num_dims;            /* Number of dimensions */
   intnat flags;  /* Kind of element array + memory layout + allocation status */
   struct caml_ba_proxy * proxy; /* The proxy for sub-arrays, or NULL */
-  /* PR#5516: use C99's flexible array types if possible */
-#if (__STDC_VERSION__ >= 199901L)
   intnat dim[]  /*[num_dims]*/; /* Size in each dimension */
-#else
-  intnat dim[1] /*[num_dims]*/; /* Size in each dimension */
-#endif
 };
 
 /* Size of struct caml_ba_array, in bytes, without dummy first dimension */
-#if (__STDC_VERSION__ >= 199901L)
 #define SIZEOF_BA_ARRAY sizeof(struct caml_ba_array)
-#else
-#define SIZEOF_BA_ARRAY (sizeof(struct caml_ba_array) - sizeof(intnat))
-#endif
 
 #define Caml_ba_array_val(v) ((struct caml_ba_array *) Data_custom_val(v))
 

--- a/runtime/caml/bigarray.h
+++ b/runtime/caml/bigarray.h
@@ -88,7 +88,7 @@ struct caml_ba_array {
   intnat dim[]  /*[num_dims]*/; /* Size in each dimension */
 };
 
-/* Size of struct caml_ba_array, in bytes, without dummy first dimension */
+/* Size of struct caml_ba_array, in bytes, without [dim] array */
 #define SIZEOF_BA_ARRAY sizeof(struct caml_ba_array)
 
 #define Caml_ba_array_val(v) ((struct caml_ba_array *) Data_custom_val(v))

--- a/runtime/caml/lf_skiplist.h
+++ b/runtime/caml/lf_skiplist.h
@@ -48,11 +48,7 @@ struct lf_skipcell {
   uintnat top_level;
   void *stat_block;
   struct lf_skipcell *_Atomic garbage_next;
-#if (__STDC_VERSION__ >= 199901L)
-  struct lf_skipcell *_Atomic forward[]; /* variable-length array */
-#else
-  struct lf_skipcell *_Atomic forward[1]; /* variable-length array */
-#endif
+  struct lf_skipcell *_Atomic forward[]; /* flexible array member */
 };
 
 /* Initialize a skip list */

--- a/runtime/caml/skiplist.h
+++ b/runtime/caml/skiplist.h
@@ -39,11 +39,7 @@ struct skiplist {
 struct skipcell {
   uintnat key;
   uintnat data;
-#if (__STDC_VERSION__ >= 199901L)
-  struct skipcell * forward[];  /* variable-length array */
-#else
-  struct skipcell * forward[1]; /* variable-length array */
-#endif
+  struct skipcell * forward[];  /* flexible array member */
 };
 
 /* Initialize a skip list, statically */

--- a/runtime/lf_skiplist.c
+++ b/runtime/lf_skiplist.c
@@ -50,12 +50,7 @@
 #include <stddef.h>
 
 /* Size of struct lf_skipcell, in bytes, without the forward array */
-#if (__STDC_VERSION__ >= 199901L)
 #define SIZEOF_LF_SKIPCELL sizeof(struct lf_skipcell)
-#else
-#define SIZEOF_LF_SKIPCELL                                                     \
-  (sizeof(struct lf_skipcell) - sizeof(struct lf_skipcell *))
-#endif
 
 /* Generate a random level for a new node: 0 with probability 3/4,
    1 with probability 3/16, 2 with probability 3/64, etc.

--- a/runtime/memory.c
+++ b/runtime/memory.c
@@ -479,19 +479,10 @@ struct pool_block {
 #endif
   struct pool_block *next;
   struct pool_block *prev;
-  /* Use C99's flexible array types if possible */
-#if (__STDC_VERSION__ >= 199901L)
   union max_align data[];  /* not allocated, used for alignment purposes */
-#else
-  union max_align data[1];
-#endif
 };
 
-#if (__STDC_VERSION__ >= 199901L)
 #define SIZEOF_POOL_BLOCK sizeof(struct pool_block)
-#else
-#define SIZEOF_POOL_BLOCK offsetof(struct pool_block, data)
-#endif
 
 static struct pool_block *pool = NULL;
 static caml_plat_mutex pool_mutex = CAML_PLAT_MUTEX_INITIALIZER;

--- a/runtime/skiplist.c
+++ b/runtime/skiplist.c
@@ -26,11 +26,7 @@
 #include "caml/skiplist.h"
 
 /* Size of struct skipcell, in bytes, without the forward array */
-#if (__STDC_VERSION__ >= 199901L)
 #define SIZEOF_SKIPCELL sizeof(struct skipcell)
-#else
-#define SIZEOF_SKIPCELL (sizeof(struct skipcell) - sizeof(struct skipcell *))
-#endif
 
 /* Generate a random level for a new node: 0 with probability 3/4,
    1 with probability 3/16, 2 with probability 3/64, etc.


### PR DESCRIPTION
VLA stands for [variable-length arrays][vla]. We've disabled them.

[vla]: https://en.wikipedia.org/wiki/Variable-length_array#C99
[flm]: https://en.wikipedia.org/wiki/Flexible_array_member

Moreover, if we assume we're building OCaml at least in C99, it's possible to simply instances of this pattern, at least in `.c` files.
```c
/* Size of struct lf_skipcell, in bytes, without the forward array */
#if (__STDC_VERSION__ >= 199901L)
#define SIZEOF_LF_SKIPCELL sizeof(struct lf_skipcell)
#else
#define SIZEOF_LF_SKIPCELL                                                     \
  (sizeof(struct lf_skipcell) - sizeof(struct lf_skipcell *))
#endif
```

If we assume that user code is built with at least C99, we can also simplify the headers.