### PR TITLE
Make sure TSan false positive from #12282 is silenced

### DIFF
--- a/runtime/weak.c
+++ b/runtime/weak.c
@@ -183,6 +183,11 @@ static void clean_field (value e, mlsize_t offset)
 CAMLreally_no_tsan /* This function performs volatile writes, which we consider
                       to be non-racy, but TSan reports data races, so we never
                       instrument it with TSan. */
+#if defined(WITH_THREAD_SANITIZER)
+Caml_noinline /* Unfortunately, Clang disregards the no_tsan attribute on
+                 inlined functions, so we prevent inlining of this one when
+                 tsan is enabled. */
+#endif
 static void do_set (value e, mlsize_t offset, value v)
 {
   if (Is_block(v) && Is_young(v)) {


### PR DESCRIPTION
The current way we handle `volatile` accesses creates rare false positives. (In fact, if I’m not mistaken, this is the only one to date.)

It was silenced using `CAMLno_tsan`; unfortunately, Clang disregards that attribute on inlined functions, so we prevent inlining of is function when tsan is enabled. This should make the failure go away in the TSan CI. Hopefully, https://github.com/ocaml/ocaml/pull/12681 or an improvement thereof will get rid of such false positives more cleanly.