### PR TITLE
Update the logic of detecting NO_COLOR

### DIFF
--- a/Changes
+++ b/Changes
@@ -245,6 +245,14 @@ Working version
   input files are specified to build an executable.
   (Antonin Décimo, review by Sébastien Hinderer)
 
+- #12688: Setting the env variable `NO_COLOR` with an empty value no longer
+  has effects. Previously, setting `NO_COLOR` with any value, including
+  the empty value, would disable colors (unless `OCAML_COLOR` is also set).
+  After this change, the user must set `NO_COLOR` with an non-empty value
+  to disable colors. This reflects a specification clarification/change
+  from the upstream website at https://no-color.org.
+  (Favonia, review by Gabriel Scherer)
+
 ### Manual and documentation:
 
 - #12338: clarification of the documentation of process related function in

--- a/driver/compmisc.ml
+++ b/driver/compmisc.ml
@@ -88,10 +88,12 @@ let set_from_env flag Clflags.{ parse; usage; env_var } =
 
 let read_clflags_from_env () =
   set_from_env Clflags.color Clflags.color_reader;
-  if
-    Option.is_none !Clflags.color &&
-    Option.is_some (Sys.getenv_opt "NO_COLOR")
-  then
+  let no_color () = (* See https://no-color.org/ *)
+    match Sys.getenv_opt "NO_COLOR" with
+    | None | Some "" -> false
+    | _ -> true
+  in
+  if Option.is_none !Clflags.color && no_color () then
     Clflags.color := Some Misc.Color.Never;
   set_from_env Clflags.error_style Clflags.error_style_reader;
   ()


### PR DESCRIPTION
The specification has silently changed; now setting the environment variable `NO_COLOR` with an empty string does not count. The value must be a non-empty string to prevent ANSI coloring.

See the new wording on https://no-color.org:
> Command-line software which adds ANSI color to its output by default should check for a NO_COLOR environment variable that, when present and not an empty string (regardless of its value), prevents the addition of ANSI color.

~~PS: The PR very slightly changes the flow of the code---now it reads the environment variable `NO_COLOR` even if `OCAML_COLOR` is explicitly set. However, the alternative, "more efficient" code look worse. I hope this tiny change is okay.~~