### PR TITLE
Remove benign data race in parallel test

### DIFF
--- a/testsuite/tests/parallel/domain_serial_spawn_burn.ml
+++ b/testsuite/tests/parallel/domain_serial_spawn_burn.ml
@@ -37,9 +37,9 @@ let test_serial_domain_spawn () =
   done
 
 let () =
-  let running = ref true in
+  let running = Atomic.make true in
   let rec run_until_stop fn () =
-    while !running do
+    while Atomic.get running do
       fn ();
     done
   in
@@ -49,7 +49,7 @@ let () =
 
   test_serial_domain_spawn ();
 
-  running := false;
+  Atomic.set running false;
   join domain_minor_gc;
   join domain_major_gc;
 


### PR DESCRIPTION
The situation is the exact same as in #12680: The test `parallel/domain_serial_spawn_burn` contains a data race on the `running` flag. While allowed by the memory model and inconsequential, it makes the test flaky in the TSan-enabled CI.

This race can be removed for a small cost by making the flag atomic. It probably diminishes performance slightly, but not in a noticeable way on my machine.
