### PR TITLE
Cleanup `expand_abbrev_gen`

### DIFF
--- a/Changes
+++ b/Changes
@@ -419,6 +419,10 @@ Working version
 - #12640: Make the module separator used in symbol names configurable
   (Miod Vallat, review by Hugo Heuzard and Xavier Leroy)
 
+- #????? : Clean up Ctype.expand_abbrev_gen and
+  rename Env.add_local_type to add_local_constraint
+  (Takafumi Saikawa, Jacques Garrigue, review by ??)
+
 ### Build system:
 
 - #12198, #12321, #12586, #12616: continue the merge of the sub-makefiles

--- a/Changes
+++ b/Changes
@@ -419,9 +419,9 @@ Working version
 - #12640: Make the module separator used in symbol names configurable
   (Miod Vallat, review by Hugo Heuzard and Xavier Leroy)
 
-- #????? : Clean up Ctype.expand_abbrev_gen and
+- #12691 : Clean up Ctype.expand_abbrev_gen and
   rename Env.add_local_type to add_local_constraint
-  (Takafumi Saikawa, Jacques Garrigue, review by ??)
+  (Takafumi Saikawa and Jacques Garrigue, review by Florian Angeletti)
 
 ### Build system:
 

--- a/typing/env.ml
+++ b/typing/env.ml
@@ -674,6 +674,11 @@ let error err = raise (Error err)
 let lookup_error loc env err =
   error (Lookup_error(loc, env, err))
 
+let same_type_declarations e1 e2 =
+  e1.types == e2.types &&
+  e1.modules == e2.modules &&
+  e1.local_constraints == e2.local_constraints
+
 let same_constr = ref (fun _ _ _ -> assert false)
 
 let check_well_formed_module = ref (fun _ -> assert false)
@@ -2231,7 +2236,7 @@ let add_module_lazy ~update_summary id presence mty env =
   in
   add_module_declaration_lazy ~update_summary id presence md env
 
-let add_local_type path info env =
+let add_local_constraint path info env =
   { env with
     local_constraints = Path.Map.add path info env.local_constraints }
 

--- a/typing/env.mli
+++ b/typing/env.mli
@@ -60,6 +60,9 @@ val empty: t
 val initial: t
 val diff: t -> t -> Ident.t list
 
+(* approximation to the preimage equivalence class of [find_type] *)
+val same_type_declarations: t -> t -> bool
+
 type type_descr_kind =
   (label_description, constructor_description) type_kind
 
@@ -313,7 +316,7 @@ val add_modtype_lazy: update_summary:bool ->
    Ident.t -> Subst.Lazy.modtype_declaration -> t -> t
 val add_class: Ident.t -> class_declaration -> t -> t
 val add_cltype: Ident.t -> class_type_declaration -> t -> t
-val add_local_type: Path.t -> type_declaration -> t -> t
+val add_local_constraint: Path.t -> type_declaration -> t -> t
 
 (* Insertion of persistent signatures *)
 

--- a/typing/envaux.ml
+++ b/typing/envaux.ml
@@ -77,7 +77,7 @@ let rec env_from_summary sum subst =
       | Env_constraints(s, map) ->
           Path.Map.fold
             (fun path info ->
-              Env.add_local_type (Subst.type_path subst path)
+              Env.add_local_constraint (Subst.type_path subst path)
                 (Subst.type_declaration subst info))
             map (env_from_summary s subst)
       | Env_copy_types s ->


### PR DESCRIPTION
This PR is a cleanup of `Ctype.expand_abbrev_gen`.

- do not ignore the exception `Escape` in `Ctype.expand_abbrev_gen`;
  forget the possibly invalid expansion in that case.
- define `Env.same_type_declarations` to more carefully compare environments in `Ctype.check_abbrev`
- also rename `Env.add_local_type` to `Env.add_local_constraint` to clarify
  that this is the function that modifies `local_constraints`
