### PR TITLE
Remove no longer needed `CAMLno_tsan` attributes

### DIFF
--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -766,7 +766,6 @@ static void realloc_mark_stack (struct mark_stack* stk)
   mark_stack_prune(stk);
 }
 
-CAMLno_tsan /* Disable TSan reports from this function (see #11040) */
 Caml_inline void mark_stack_push_range(struct mark_stack* stk,
                                        value_ptr start, value_ptr end)
 {
@@ -780,7 +779,6 @@ Caml_inline void mark_stack_push_range(struct mark_stack* stk,
   me->end = end;
 }
 
-CAMLno_tsan /* Disable TSan reports from this function (see #11040) */
 /* returns the work done by skipping unmarkable objects */
 static intnat mark_stack_push_block(struct mark_stack* stk, value block)
 {
@@ -851,7 +849,6 @@ void caml_shrink_mark_stack (void)
 
 void caml_darken_cont(value cont);
 
-CAMLno_tsan /* Disable TSan reports from this function (see #11040) */
 static void mark_slice_darken(struct mark_stack* stk, value child,
                               intnat* work)
 {
@@ -896,7 +893,10 @@ static void mark_slice_darken(struct mark_stack* stk, value child,
   }
 }
 
-CAMLno_tsan /* Disable TSan reports from this function (see #11040) */
+CAMLno_tsan /* Loading from a location in the OCaml heap can cause false alarms
+               in TSan when this location is concurrently written to by
+               caml_modify. This false positive is due to the way we map OCaml
+               accesses to C11 accesses for TSan and is unlikely to go away. */
 Caml_noinline static intnat do_some_marking(struct mark_stack* stk,
                                             intnat budget) {
   prefetch_buffer_t pb = { .enqueued = 0, .dequeued = 0,


### PR DESCRIPTION
This removes a number of `CAMLno_tsan` function attributes which are no longer necessary since the data races that they used to silence have been fixed by #12030. For the one that we cannot remove due to a false positive, update the justification comment accordingly.