### PR TITLE
Fix regression in #12403: quote source code also for marshalled ASTs

### DIFF
--- a/Changes
+++ b/Changes
@@ -483,7 +483,8 @@ Working version
   (Gabriel Scherer, review by Guillaume Munch-Maccagnoni
    and KC Sivaramakrishnan, report by Sadiq Jaffer)
 
-- #12238, #12403: read input files in one go to avoid source reprinting issues
+- #12238, #12403, #12698: read input files in one go to avoid source reprinting
+  issues.
   (Gabriel Scherer, report by Mike Spivey and Vincent Laviron, review by
    Nicolás Ojeda Bär, Xavier Leroy and Jeremy Yallop)
 

--- a/driver/pparse.ml
+++ b/driver/pparse.ml
@@ -175,6 +175,15 @@ let file_aux ~tool_name ~sourcefile inputfile (type a) parse_fun invariant_fun
       let ast =
         Fun.protect ~finally:close_ic @@ fun () ->
         Location.input_name := (input_value ic : string);
+        begin match In_channel.with_open_bin !Location.input_name In_channel.input_all with
+        | source ->
+            (* If the source file for the marshalled AST is found, then read it
+               fully into a lexing buffer to make it available to error printers
+               to quote source code at specific locations. *)
+            Location.input_lexbuf := Some (Lexing.from_string source)
+        | exception Sys_error _ ->
+            ()
+        end;
         if !Clflags.unsafe then
           Location.prerr_warning (Location.in_file !Location.input_name)
             Warnings.Unsafe_array_syntax_without_parsing;

--- a/driver/pparse.ml
+++ b/driver/pparse.ml
@@ -165,6 +165,18 @@ let parse (type a) (kind : a ast_kind) lexbuf : a =
   | Structure -> Parse.implementation lexbuf
   | Signature -> Parse.interface lexbuf
 
+let set_input_lexbuf ic =
+  let source =
+    (* We read the whole source file at once. This guarantees that all
+       input is in the lexing buffer and can be reused by error printers
+       to quote source code at specific locations -- see #12238 and the
+       Location.lines_around* functions. *)
+    In_channel.input_all ic
+  in
+  let lexbuf = Lexing.from_string source in
+  Location.input_lexbuf := Some lexbuf;
+  lexbuf
+
 let file_aux ~tool_name ~sourcefile inputfile (type a) parse_fun invariant_fun
              (kind : a ast_kind) : a =
   let ast =
@@ -175,14 +187,9 @@ let file_aux ~tool_name ~sourcefile inputfile (type a) parse_fun invariant_fun
       let ast =
         Fun.protect ~finally:close_ic @@ fun () ->
         Location.input_name := (input_value ic : string);
-        begin match In_channel.with_open_bin !Location.input_name In_channel.input_all with
-        | source ->
-            (* If the source file for the marshalled AST is found, then read it
-               fully into a lexing buffer to make it available to error printers
-               to quote source code at specific locations. *)
-            Location.input_lexbuf := Some (Lexing.from_string source)
-        | exception Sys_error _ ->
-            ()
+        begin match In_channel.with_open_bin !Location.input_name set_input_lexbuf with
+        | (_ : Lexing.lexbuf) -> ()
+        | exception Sys_error _ -> ()
         end;
         if !Clflags.unsafe then
           Location.prerr_warning (Location.in_file !Location.input_name)
@@ -193,18 +200,12 @@ let file_aux ~tool_name ~sourcefile inputfile (type a) parse_fun invariant_fun
       (* if all_ppx <> [], invariant_fun will be called by apply_rewriters *)
       ast
     end else begin
-      let source =
-        (* We read the whole source file at once. This guarantees that all
-           input is in the lexing buffer and can be reused by error printers
-           to quote source code at specific locations -- see #12238 and the
-           Location.lines_around* functions. *)
+      let lexbuf =
         Fun.protect ~finally:close_ic @@ fun () ->
         seek_in ic 0;
-        In_channel.input_all ic
+        set_input_lexbuf ic
       in
-      let lexbuf = Lexing.from_string source in
       Location.init lexbuf sourcefile;
-      Location.input_lexbuf := Some lexbuf;
       Profile.record_call "parser" (fun () -> parse_fun lexbuf)
     end
   in

--- a/driver/pparse.ml
+++ b/driver/pparse.ml
@@ -187,7 +187,9 @@ let file_aux ~tool_name ~sourcefile inputfile (type a) parse_fun invariant_fun
       let ast =
         Fun.protect ~finally:close_ic @@ fun () ->
         Location.input_name := (input_value ic : string);
-        begin match In_channel.with_open_bin !Location.input_name set_input_lexbuf with
+        begin match
+          In_channel.with_open_bin !Location.input_name set_input_lexbuf
+        with
         | (_ : Lexing.lexbuf) -> ()
         | exception Sys_error _ -> ()
         end;

--- a/testsuite/tests/tool-ocamlc-locations/foo.ml
+++ b/testsuite/tests/tool-ocamlc-locations/foo.ml
@@ -1,0 +1,1 @@
+let x : int = true

--- a/testsuite/tests/tool-ocamlc-locations/marshalled.compilers.reference
+++ b/testsuite/tests/tool-ocamlc-locations/marshalled.compilers.reference
@@ -1,0 +1,5 @@
+File "foo.ml", line 1, characters 14-18:
+1 | let x : int = true
+                  ^^^^
+Error: This expression has type "bool" but an expression was expected of type
+         "int"

--- a/testsuite/tests/tool-ocamlc-locations/marshalled.ml
+++ b/testsuite/tests/tool-ocamlc-locations/marshalled.ml
@@ -1,0 +1,24 @@
+(* TEST
+   readonly_files="foo.ml";
+   setup-ocamlc.byte-build-env;
+   {
+   include ocamlcommon;
+   program = "marshalled.byte";
+   all_modules = "marshalled.ml";
+   ocamlc.byte;
+   script = "./marshalled.byte";
+   script;
+   }
+   {
+   all_modules = "foo.marshalled.ml";
+   ocamlc_byte_exit_status = "2";
+   ocamlc.byte;
+   check-ocamlc.byte-output;
+   }
+*)
+
+(* This is a repro case for #12697 *)
+
+let () =
+  let ast = Pparse.parse_implementation ~tool_name:"test" "foo.ml" in
+  Pparse.write_ast Pparse.Structure "foo.marshalled.ml" ast


### PR DESCRIPTION
As mentioend in #12697, it appears that #12403 introduced a regression: when reading marshalled ASTs the compiler no longer quotes any source code in error messages. This is because the compiler no longer reads in the source file corresponding to the marshalled AST.

This PR proposes a fix by reading (if possible) the source file when unmarshalling the AST and making it available to later error printers.

Assigning to @gasche who authored #12403.

Fixes #12697