### PR TITLE
In C++, give `Bool_val` the type `bool`

### DIFF
--- a/Changes
+++ b/Changes
@@ -71,6 +71,9 @@ Working version
   of `caml_read_directory`.  Also, check for overflows in ext table sizes.
   (Xavier Leroy, report by Arseniy Alekseyev, review by Gabriel Scherer)
 
+- #11332, #12702: make sure `Bool_val(v)` has type `bool` in C++
+  (Xavier Leroy, report by ygrek, review by Gabriel Scherer)
+
 - #12223: Constify constructors and flags tables in C code. Now these
   tables will go in the readonly segment, where they belong.
   (Antonin Décimo, review by Gabriel Scherer and Xavier Leroy)

--- a/runtime/caml/mlvalues.h
+++ b/runtime/caml/mlvalues.h
@@ -425,7 +425,11 @@ CAMLextern value caml_atom(tag_t);
 /* Booleans are integers 0 or 1 */
 
 #define Val_bool(x) Val_int((x) != 0)
+#ifdef __cplusplus
+#define Bool_val(x) ((bool) Int_val(x))
+#else
 #define Bool_val(x) Int_val(x)
+#endif
 #define Val_false Val_int(0)
 #define Val_true Val_int(1)
 #define Val_not(x) (Val_false + Val_true - (x))


### PR DESCRIPTION
C++ 11 makes it an error to convert automatically from `int` to `bool` in some contexts (list initialization). C has no `bool` type by default, only `_Bool`, which is not in C++ by default. So we end up with two definitions of `Bool_val`, one for C and one for C++.

Fixes: #11332