### PR TITLE
runtime/mlvalues.h: more careful definition of Tag_val

### DIFF
--- a/Changes
+++ b/Changes
@@ -522,6 +522,10 @@ Working version
   (Miod Vallat and Xavier Leroy, report by Jan Midtgaard, review by
    KC Sivaramakrishnan)
 
+- #12528, #12703: Avoid pointer arithmetic overflow in Tag_val macro
+  (very likely harmless, but can trigger alarms)
+  (Xavier Leroy, report by Sam Goldman, review by Guillaume Munch-Maccagnoni)
+
 - #12593: TSan should handle Effect.Unhandled correctly
   (Fabrice Buoro and Olivier Nicole, report by Jan Midtgaard and Miod Vallat,
    review by Gabriel Scherer)

--- a/runtime/caml/mlvalues.h
+++ b/runtime/caml/mlvalues.h
@@ -205,7 +205,7 @@ Caml_inline header_t Hd_val(value val)
 #define Tag_hp(hp) (((volatile unsigned char *) (hp)) [sizeof(value)-1])
                                                  /* Also an l-value. */
 #else
-#define Tag_val(val) (((volatile unsigned char *) (val)) [-sizeof(value)])
+#define Tag_val(val) (((volatile unsigned char *) (val)) [- (int)sizeof(value)])
                                                  /* Also an l-value. */
 #define Tag_hp(hp) (((volatile unsigned char *) (hp)) [0])
                                                  /* Also an l-value. */


### PR DESCRIPTION
The offset `- sizeof(value)` should be signed, otherwise pointer overflow can (formally) occur.

Fixes: #12528