### PR TITLE
disable the finaliser_handover test

### DIFF
--- a/testsuite/tests/weak-ephe-final/finaliser_handover.ml
+++ b/testsuite/tests/weak-ephe-final/finaliser_handover.ml
@@ -1,4 +1,6 @@
-(* TEST *)
+(* TEST
+reason="this test is too flaky, see #12345";
+skip; *)
 
 (* ocaml-multicore issues 528 and 468 *)
 


### PR DESCRIPTION
The test is known to be flaky, as is reported and investigated in issue #12345. We now understand well why the test fails but devising a fix may take some time. It seems that the test is failing more often these days. There is little extra benefits from additional random CI failures, and they have a cost in terms of requiring a manual triaging action each time -- just accessing the logs to understand what fails takes some effort.