### PR TITLE
Fix finaliser handover flakiness

### DIFF
--- a/Changes
+++ b/Changes
@@ -161,6 +161,10 @@ Working version
   used by ocamlrun.
   (Xavier Leroy, motivation, review and improvements by Antonin Décimo)
 
+- #12345, #12710: Fix issues with finaliser orphaning at domain termination
+  (KC Sivaramakrishnan, report by Gabriel Scherer, review by Gabriel Scherer,
+  Sadiq Jaffer and Fabrice Buoro)
+
 ### Code generation and optimizations:
 
 - #11239: on x86-64 and RISC-V, reduce alignment of OCaml stacks from 16 to 8.

--- a/runtime/caml/major_gc.h
+++ b/runtime/caml/major_gc.h
@@ -45,13 +45,8 @@ void caml_finish_major_cycle(int force_compaction);
 #ifdef DEBUG
 int caml_mark_stack_is_empty(void);
 #endif
-/* Ephemerons and finalisers */
-void caml_orphan_allocated_words(void);
-void caml_add_to_orphaned_ephe_list(struct caml_ephe_info* ephe_info);
-void caml_add_orphaned_finalisers (struct caml_final_info*);
-void caml_final_domain_terminate (caml_domain_state *domain_state);
-void caml_incr_num_domains_orphaning_finalisers (void);
-void caml_decr_num_domains_orphaning_finalisers (void);
+void caml_orphan_ephemerons(caml_domain_state*);
+void caml_orphan_finalisers(caml_domain_state*);
 
 /* Forces finalisation of all heap-allocated values,
    disregarding both local and global roots.

--- a/runtime/caml/major_gc.h
+++ b/runtime/caml/major_gc.h
@@ -50,6 +50,8 @@ void caml_orphan_allocated_words(void);
 void caml_add_to_orphaned_ephe_list(struct caml_ephe_info* ephe_info);
 void caml_add_orphaned_finalisers (struct caml_final_info*);
 void caml_final_domain_terminate (caml_domain_state *domain_state);
+void caml_incr_num_domains_orphaning_finalisers (void);
+void caml_decr_num_domains_orphaning_finalisers (void);
 
 /* Forces finalisation of all heap-allocated values,
    disregarding both local and global roots.

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -1836,9 +1836,12 @@ static void handover_finalisers(caml_domain_state* domain_state)
   if (f->todo_head != NULL || f->first.size != 0 || f->last.size != 0) {
     /* have some final structures */
     if (caml_gc_phase != Phase_sweep_and_mark_main) {
-      /* Force a major GC cycle to simplify constraints for
-       * handing over finalisers. */
+      /* Force a major GC cycle to simplify constraints for orphaning
+         finalisers. See note attached to the declaration of
+         [num_domains_orphaning_finalisers] variable in major_gc.c */
+      caml_incr_num_domains_orphaning_finalisers();
       caml_finish_major_cycle(0);
+      caml_decr_num_domains_orphaning_finalisers();
       CAMLassert(caml_gc_phase == Phase_sweep_and_mark_main);
     }
     caml_add_orphaned_finalisers (f);

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -423,6 +423,7 @@ void caml_orphan_ephemerons (caml_domain_state* domain_state)
     ephe_info->must_sweep_ephe = 0;
     atomic_fetch_add_verify_ge0(&num_domains_to_ephe_sweep, -1);
   }
+  CAMLassert (ephe_info->must_sweep_ephe == 0);
   CAMLassert (ephe_info->live == 0);
   CAMLassert (ephe_info->todo == 0);
 }
@@ -451,8 +452,7 @@ void caml_orphan_finalisers (caml_domain_state* domain_state)
     caml_plat_unlock(&orphaned_lock);
 
     /* Create a dummy final info */
-    domain_state->final_info = caml_alloc_final_info();
-    f = domain_state->final_info;
+    f = domain_state->final_info = caml_alloc_final_info();
     atomic_fetch_add_verify_ge0(&num_domains_orphaning_finalisers, -1);
   }
 

--- a/testsuite/tests/weak-ephe-final/finaliser_handover.ml
+++ b/testsuite/tests/weak-ephe-final/finaliser_handover.ml
@@ -1,6 +1,4 @@
-(* TEST
-reason="this test is too flaky, see #12345";
-skip; *)
+(* TEST *)
 
 (* ocaml-multicore issues 528 and 468 *)
 


### PR DESCRIPTION
This is a fix for #12345. 

## Problem

Finalisers can only be orphaned and adopted in `Phase_sweep_and_mark_main`. This simplifies invariants since finalisers are only processed in the two subsequent phases -- `Gc.finalise` (finalise first) finalisers in `Phase_mark_final` and `Gc.finalise_last` (finalise last) finalisers in `Phase_sweep_ephe`. The existing code attempts to get to `Phase_sweep_and_mark_main` by performing a `caml_finish_major_cycle` in `handover_finalisers` and assumes that after the call to `caml_finish_major_cycle`, the GC is in `Phase_sweep_and_mark_main`. However, given that there may be incoming interrupts from other domains to concurrently switch phases, we may move past `Phase_mark_and_sweep_main`. This triggers the assertion failure. 

## Solution

The fix is in the first commit. It will be useful to review this PR commit by commit. We introduce a global counter `num_domains_orphaning_finalisers` that keeps track of terminating domains orphaning their finalisers. If such domains exist, then we prevent the GC phase from moving past `Phase_sweep_and_mark_main`. The orphaned finalisers are guaranteed to be adopted since there is already a check that only allows phase changes when there is no orphaned work. 

The second commit is semantics preserving and adds code comments for some of the global variables that are involved in phase changes. I thought it might be a good idea to add code comments when I'm actively looking at these details. It also does a bit of tidying up of the code. 

## Testing

For testing, I followed @Octachron's advice of spawning a large number of concurrent tests. Without this fix, on the debug runtime, I regularly saw assertion failures. With the fix, I don't have the failures anymore. 