### PR TITLE
disable CSE for atomic loads

### DIFF
--- a/Changes
+++ b/Changes
@@ -540,6 +540,11 @@ Working version
 - #12684: fix locations filename in AST produced by the `-pp` option
   (Gabriel Scherer, review by Florian Angeletti)
 
+- #12713, #12715: disable common subexpression elimination for atomic loads
+  (Gabriel Scherer and Vincent Laviron,
+   review by Vincent Laviron, KC Sivaramakrishnan and Xavier Leroy,
+   report by Vesa Karvonen and Carine Morel)
+
 OCaml 5.1.1
 -----------
 

--- a/asmcomp/CSEgen.ml
+++ b/asmcomp/CSEgen.ml
@@ -226,7 +226,10 @@ method class_of_operation op =
   | Icall_ind | Icall_imm _ | Itailcall_ind | Itailcall_imm _
   | Iextcall _ | Iopaque -> assert false       (* treated specially *)
   | Istackoffset _ -> Op_other
-  | Iload { mutability } -> Op_load mutability
+  | Iload { mutability; is_atomic } ->
+      (* #12173: disable CSE for atomic loads. *)
+      if is_atomic then Op_other
+      else Op_load mutability
   | Istore(_,_,asg) -> Op_store asg
   | Ialloc _ | Ipoll _ -> assert false     (* treated specially *)
   | Iintop(Icheckbound) -> Op_checkbound


### PR DESCRIPTION
(fixes #12713)

@lthls made the exact same recommendation in the discussion of #12713. I would be interested in @xavierleroy's confirmation that this is a reasonable thing to do.

(I wonder why this was not done back when Multicore was merged. Was it a blind spot, we didn't think of which compiler optimisations should be disabled? Did we say we would disable CSE and forget to do it? Are there other bugs of this category looking around?)