### PR TITLE
add Format.pp_print_nothing

### DIFF
--- a/Changes
+++ b/Changes
@@ -172,6 +172,9 @@ Working version
 
 ### Standard library:
 
+- #12716: Add `Format.pp_print_nothing` function.
+  (Léo Andrès, review by Gabriel Scherer and Nicolás Ojeda Bär)
+
 - #11563: Add the Dynarray module to the stdlib. Dynamic arrays are
   arrays whose length can be changed by adding or removing elements at
   the end, similar to 'vectors' in C++ or Rust.

--- a/stdlib/format.ml
+++ b/stdlib/format.ml
@@ -649,6 +649,8 @@ let pp_print_bool state b = pp_print_string state (string_of_bool b)
 let pp_print_char state c =
   pp_print_as state 1 (String.make 1 c)
 
+let pp_print_nothing _state () = ()
+
 
 (* Opening boxes. *)
 let pp_open_hbox state () = pp_open_box_gen state 0 Pp_hbox

--- a/stdlib/format.mli
+++ b/stdlib/format.mli
@@ -263,6 +263,11 @@ val pp_print_bool : formatter -> bool -> unit
 val print_bool : bool -> unit
 (** Print a boolean in the current pretty-printing box. *)
 
+val pp_print_nothing : formatter -> unit -> unit
+(** Print nothing.
+    @since 5.2
+*)
+
 (** {1:breaks Break hints} *)
 
 (** A 'break hint' tells the pretty-printer to output some space or split the


### PR DESCRIPTION
Hi,

This adds a `Format.pp_print_nothing`. I noticed I'm often defining this function when I'm starting to have too much lines starting with `Format.pp_print_list ~pp_sep:(fun _fmt () -> ())`.

`Format.pp_print_list ~pp_sep:Format.pp_print_nothing` is not shorter - unless you have `Format` opened where you gain 3 characters :-) - but it makes code easier to read.
