### PR TITLE
Improve the documentation of {String,Byte}.split_on_char

### DIFF
--- a/stdlib/bytes.mli
+++ b/stdlib/bytes.mli
@@ -460,6 +460,7 @@ let s = Bytes.of_string "hello"
 val split_on_char: char -> bytes -> bytes list
 (** [split_on_char sep s] returns the list of all (possibly empty)
     subsequences of [s] that are delimited by the [sep] character.
+    If [s] is empty, the result is the singleton list [[""]].
 
     The function's output is specified by the following invariants:
 

--- a/stdlib/bytesLabels.mli
+++ b/stdlib/bytesLabels.mli
@@ -460,6 +460,7 @@ let s = Bytes.of_string "hello"
 val split_on_char: sep:char -> bytes -> bytes list
 (** [split_on_char sep s] returns the list of all (possibly empty)
     subsequences of [s] that are delimited by the [sep] character.
+    If [s] is empty, the result is the singleton list [[""]].
 
     The function's output is specified by the following invariants:
 

--- a/stdlib/string.mli
+++ b/stdlib/string.mli
@@ -195,6 +195,7 @@ val sub : string -> int -> int -> string
 val split_on_char : char -> string -> string list
 (** [split_on_char sep s] is the list of all (possibly empty)
     substrings of [s] that are delimited by the character [sep].
+    If [s] is empty, the result is the singleton list [[""]].
 
     The function's result is specified by the following invariants:
     {ul

--- a/stdlib/stringLabels.mli
+++ b/stdlib/stringLabels.mli
@@ -195,6 +195,7 @@ val sub : string -> pos:int -> len:int -> string
 val split_on_char : sep:char -> string -> string list
 (** [split_on_char ~sep s] is the list of all (possibly empty)
     substrings of [s] that are delimited by the character [sep].
+    If [s] is empty, the result is the singleton list [[""]].
 
     The function's result is specified by the following invariants:
     {ul


### PR DESCRIPTION
The original documentation of `{String,Byte}.split_on_char` is complete and accurate, but it seems useful to highlight the most confusing case (that is, when the string is empty). This only takes one more sentence.

Also I believe no changelog entry is needed.