### PR TITLE
Fix the documentation of Bytes.split_on_char

### DIFF
--- a/stdlib/bytes.mli
+++ b/stdlib/bytes.mli
@@ -460,7 +460,7 @@ let s = Bytes.of_string "hello"
 val split_on_char: char -> bytes -> bytes list
 (** [split_on_char sep s] returns the list of all (possibly empty)
     subsequences of [s] that are delimited by the [sep] character.
-    If [s] is empty, the result is the singleton list [[""]].
+    If [s] is empty, the result is the singleton list [[empty]].
 
     The function's output is specified by the following invariants:
 

--- a/stdlib/bytesLabels.mli
+++ b/stdlib/bytesLabels.mli
@@ -460,7 +460,7 @@ let s = Bytes.of_string "hello"
 val split_on_char: sep:char -> bytes -> bytes list
 (** [split_on_char sep s] returns the list of all (possibly empty)
     subsequences of [s] that are delimited by the [sep] character.
-    If [s] is empty, the result is the singleton list [[""]].
+    If [s] is empty, the result is the singleton list [[empty]].
 
     The function's output is specified by the following invariants:
 


### PR DESCRIPTION
Sorry that I introduced a bug and didn't fix it fast enough in #12717. `""` is for strings, not for bytes. However, I'm not 100% sure what we should write instead. There are multiple correct options:
- `[s]`
- `[empty]`
- `[of_string ""]` (okay I admit this one is more like a joke)

I chose `[empty]` in the current patch because `[s]` might need more mental power. Happy to change it to `[s]` if people feel otherwise. Honestly I cannot feel the difference anymore after switching between `[s]` and `[empty]` so many times.