### PR TITLE
add thread local storage

### DIFF
--- a/Changes
+++ b/Changes
@@ -172,6 +172,9 @@ Working version
 
 ### Standard library:
 
+- #12719: Add `Thread.TLS`.
+  (Vesa Karvonen, Simon Cruanes)
+
 - #12716: Add `Format.pp_print_nothing` function.
   (Léo Andrès, review by Gabriel Scherer and Nicolás Ojeda Bär)
 

--- a/otherlibs/systhreads/thread.ml
+++ b/otherlibs/systhreads/thread.ml
@@ -93,3 +93,90 @@ let wait_pid p = Unix.waitpid [] p
 external sigmask : Unix.sigprocmask_command -> int list -> int list
    = "caml_thread_sigmask"
 external wait_signal : int list -> int = "caml_wait_signal"
+
+
+module TLS = struct
+  type 'a key = {
+    index: int;  (** Unique index for this key. *)
+    compute: unit -> 'a;
+        (** Initializer for values for this key. Called at most
+          once per thread. *)
+  }
+
+  (** Counter used to allocate new keys *)
+  let counter = Atomic.make 0
+
+  (** Value used to detect a TLS slot that was not initialized yet.
+      Because [counter] is private and lives forever, no other
+      object the user can see will have the same address. *)
+  let[@inline] sentinel_value_for_uninit_tls_ () : Obj.t = Obj.repr counter
+
+  let new_key compute : _ key =
+    let index = Atomic.fetch_and_add counter 1 in
+    { index; compute }
+
+  type thread_internal_state = {
+    _id: int;  (** Thread ID (here for padding reasons) *)
+    mutable tls: Obj.t;  (** Our data, stowed away in this unused field *)
+    _other: Obj.t;
+        (** Here to avoid lying to ocamlopt/flambda about the size of [Thread.t] *)
+  }
+  (** A partial representation of the internal type [t], allowing
+    us to access the second field (unused after the thread
+    has started) and stash TLS data in it. *)
+
+  let ceil_pow_2_minus_1 (n : int) : int =
+    let n = n lor (n lsr 1) in
+    let n = n lor (n lsr 2) in
+    let n = n lor (n lsr 4) in
+    let n = n lor (n lsr 8) in
+    let n = n lor (n lsr 16) in
+    if Sys.int_size > 32 then
+      n lor (n lsr 32)
+    else
+      n
+
+  (** Grow the array so that [index] is valid. *)
+  let[@inline never] grow_tls (old : Obj.t array) (index : int) : Obj.t array =
+    let new_length = ceil_pow_2_minus_1 (index + 1) in
+    let new_ = Array.make new_length (sentinel_value_for_uninit_tls_ ()) in
+    Array.blit old 0 new_ 0 (Array.length old);
+    new_
+
+  let[@inline] get_tls_ (index : int) : Obj.t array =
+    let thread : thread_internal_state = Obj.magic (self ()) in
+    let tls = thread.tls in
+    if Obj.is_int tls then (
+      let new_tls = grow_tls [||] index in
+      thread.tls <- Obj.repr new_tls;
+      new_tls
+    ) else (
+      let tls = (Obj.obj tls : Obj.t array) in
+      if index < Array.length tls then
+        tls
+      else (
+        let new_tls = grow_tls tls index in
+        thread.tls <- Obj.repr new_tls;
+        new_tls
+      )
+    )
+
+  let[@inline never] get_compute_ tls (key : 'a key) : 'a =
+    let value = key.compute () in
+    Array.unsafe_set tls key.index (Obj.repr (Sys.opaque_identity value));
+    value
+
+  let[@inline] get (key : 'a key) : 'a =
+    let tls = get_tls_ key.index in
+    let value = Array.unsafe_get tls key.index in
+    if value != sentinel_value_for_uninit_tls_ () then
+      (* fast path *)
+      Obj.obj value
+    else
+      (* slow path: we need to compute the initial value *)
+      get_compute_ tls key
+
+  let[@inline] set key value : unit =
+    let tls = get_tls_ key.index in
+    Array.unsafe_set tls key.index (Obj.repr (Sys.opaque_identity value))
+end

--- a/otherlibs/systhreads/thread.ml
+++ b/otherlibs/systhreads/thread.ml
@@ -119,7 +119,8 @@ module TLS = struct
     _id: int;  (** Thread ID (here for padding reasons) *)
     mutable tls: Obj.t;  (** Our data, stowed away in this unused field *)
     _other: Obj.t;
-        (** Here to avoid lying to ocamlopt/flambda about the size of [Thread.t] *)
+        (** Here to avoid lying to ocamlopt/flambda about the size
+            of [t] *)
   }
   (** A partial representation of the internal type [t], allowing
     us to access the second field (unused after the thread

--- a/otherlibs/systhreads/thread.mli
+++ b/otherlibs/systhreads/thread.mli
@@ -172,3 +172,25 @@ val set_uncaught_exception_handler : (exn -> unit) -> unit
 
     If the newly set uncaught exception handler raise an exception,
     {!default_uncaught_exception_handler} will be called. *)
+
+(** Thread local storage.
+    @since 5.2 *)
+module TLS : sig
+  type 'a key
+  (** A TLS key for values of type ['a]. This allows the
+      storage of a single value of type ['a] per thread. *)
+
+  val new_key : (unit -> 'a) -> 'a key
+  (** Allocate a new, generative key.
+      When the key is used for the first time on a thread,
+      the function is called to produce it.
+
+      This should only ever be called at toplevel to produce
+      constants, do not use it in a loop. *)
+
+  val get : 'a key -> 'a
+  (** Get the value for the current thread. *)
+
+  val set : 'a key -> 'a -> unit
+  (** Set the value for the current thread. *)
+end

--- a/testsuite/tests/lib-threads/thread_tls.ml
+++ b/testsuite/tests/lib-threads/thread_tls.ml
@@ -31,7 +31,7 @@ let () =
     List.init 2 @@ fun d_idx ->
     Domain.join @@
     Domain.spawn @@ fun () ->
-    Array.to_list @@ 
+    Array.to_list @@
     Array.init 10 (fun t_idx -> Thread.create (run_thread ~d_idx ~t_idx) ())
   in
 

--- a/testsuite/tests/lib-threads/thread_tls.ml
+++ b/testsuite/tests/lib-threads/thread_tls.ml
@@ -1,0 +1,61 @@
+(* TEST
+ include systhreads;
+ hassysthreads;
+ {
+   bytecode;
+ }{
+   native;
+ }
+*)
+
+
+module TLS = Thread.TLS
+
+let k1 : int TLS.key = TLS.new_key (fun () -> 0)
+
+let () =
+  let n = 1_000_000 in
+  let values = Array.make 20 0 in
+
+  let run_thread ~d_idx ~t_idx () =
+    for _i = 1 to n do
+      let r = TLS.get k1 in
+      TLS.set k1 (r + 1)
+    done;
+    values.(d_idx * 10 + t_idx) <- TLS.get k1
+  in
+
+
+  let threads : Thread.t list =
+    List.concat @@
+    List.init 2 @@ fun d_idx ->
+    Domain.join @@
+    Domain.spawn @@ fun () ->
+    Array.to_list @@ 
+    Array.init 10 (fun t_idx -> Thread.create (run_thread ~d_idx ~t_idx) ())
+  in
+
+  List.iter Thread.join threads;
+  Array.iter (fun x -> assert (x = n)) values
+
+let k2 : int ref TLS.key = TLS.new_key (fun () -> ref 0)
+let k3 : int ref TLS.key = TLS.new_key (fun () -> ref 0)
+
+let () =
+  print_endline "starting";
+  let res = ref (0, 0) in
+  let run () =
+    for _i = 1 to 1000 do
+      let r2 = TLS.get k2 in
+      incr r2;
+      let r3 = TLS.get k3 in
+      r3 := !r3 + 2
+    done;
+    res := !(TLS.get k2), !(TLS.get k3)
+  in
+
+  let t = Thread.create run () in
+  Thread.join t;
+
+  assert (!res = (1000, 2000));
+  print_endline "ok"

--- a/testsuite/tests/lib-threads/thread_tls.reference
+++ b/testsuite/tests/lib-threads/thread_tls.reference
@@ -1,0 +1,2 @@
+starting
+ok


### PR DESCRIPTION
This PR adds `Thread.TLS`, a thread-local pendant to `Domain.DLS`.

The discussion that started this is
https://discuss.ocaml.org/t/a-hack-to-implement-efficient-tls-thread-local-storage/13264 .
I personally think that TLS is more useful than DLS because threads are more
flexible and convenient than domains (mostly because you can start many more
threads than domains).
