### PR TITLE
Fix label evaluation order

### DIFF
--- a/Changes
+++ b/Changes
@@ -459,8 +459,8 @@ Working version
 
 ### Bug fixes:
 
-- #10653, #12720: Fix evaluation order in presence of optional arguments
-  (Jacques Garrigue, Nick Roberts, report by Leo White)
+- #10652, #12720: fix evaluation order in presence of optional arguments
+  (Jacques Garrigue, report by Leo White, review by Vincent Laviron)
 
 - #11800, #12707: fix an assertion race condition in `install_backup_thread`
   (Jan Midtgaard, review by Gabriel Scherer)

--- a/Changes
+++ b/Changes
@@ -459,6 +459,9 @@ Working version
 
 ### Bug fixes:
 
+- #10653, #12720: Fix evaluation order in presence of optional arguments
+  (Jacques Garrigue, Nick Roberts, report by Leo White)
+
 - #11800, #12707: fix an assertion race condition in `install_backup_thread`
   (Jan Midtgaard, review by Gabriel Scherer)
 

--- a/lambda/translcore.ml
+++ b/lambda/translcore.ml
@@ -685,7 +685,7 @@ and transl_apply ~scopes
         let lam =
           if args = [] then lam else lapply lam (List.rev_map fst args)
         in
-        (* Evaluate the function, possibly applied to the arguments in [args] *)
+        (* Evaluate the function, applied to the arguments in [args] *)
         let handle = protect "func" lam in
         (* Evaluate the arguments whose applications was delayed;
            if we already passed here this is a no-op. *)

--- a/lambda/translcore.ml
+++ b/lambda/translcore.ml
@@ -652,8 +652,21 @@ and transl_apply ~scopes
           ap_specialised=specialised;
         }
   in
+  (* Build a function application.
+     Particular care is required for out-of-order partial applications.
+     The following code guarantees that:
+     * arguments are evaluated right-to-left according to their order in
+       the type of the function, before the function is called;
+     * side-effects occurring after receiving a non-optional parameter
+       will occur exactly when all the arguments up to this parameter
+       have been received;
+     * side-effects occurring after receiving an optional parameter
+       will occur at the latest when all the arguments up to the first
+       non-optional parameter that follows it have been received.
+  *)
   let rec build_apply lam args = function
       (None, optional) :: l ->
+        (* Out-of-order partial application; we will need to build a closure *)
         let defs = ref [] in
         let protect name lam =
           match lam with
@@ -663,6 +676,8 @@ and transl_apply ~scopes
               defs := (id, lam) :: !defs;
               Lvar id
         in
+        (* If all arguments in [args] were optional, delay their application
+           until after this one is received *)
         let args, args' =
           if List.for_all (fun (_,opt) -> opt) args then [], args
           else args, []
@@ -670,14 +685,20 @@ and transl_apply ~scopes
         let lam =
           if args = [] then lam else lapply lam (List.rev_map fst args)
         in
+        (* Evaluate the function, possibly applied to the arguments in [args] *)
         let handle = protect "func" lam in
+        (* Evaluate the arguments whose applications was delayed;
+           if we already passed here this is a no-op. *)
         let args' =
           List.map (fun (arg, opt) -> protect "arg" arg, opt) args'
         in
+        (* Evaluate the remaining arguments;
+           if we already passed here this is a no-op. *)
         let l =
           List.map (fun (arg, opt) -> Option.map (protect "arg") arg, opt) l
         in
         let id_arg = Ident.create_local "param" in
+        (* Process remaining arguments and build closure *)
         let body =
           match build_apply handle ((Lvar id_arg, optional)::args') l with
             Lfunction{kind = Curried; params = ids; return; body; attr; loc}
@@ -689,6 +710,8 @@ and transl_apply ~scopes
                         ~return:Pgenval ~body
                         ~attr:default_stub_attribute ~loc
         in
+        (* Wrap "protected" definitions, starting from the left,
+           so that evaluation is right-to-left. *)
         List.fold_right
           (fun (id, lam) body -> Llet(Strict, Pgenval, id, lam, body))
           !defs body

--- a/lambda/translcore.ml
+++ b/lambda/translcore.ml
@@ -671,7 +671,7 @@ and transl_apply ~scopes
           if args = [] then lam else lapply lam (List.rev_map fst args)
         in
         let handle = protect "func" lam in
-        let args' = 
+        let args' =
           List.map (fun (arg, opt) -> protect "arg" arg, opt) args'
         in
         let l =

--- a/testsuite/tests/basic-more/labels_evaluation_order.ml
+++ b/testsuite/tests/basic-more/labels_evaluation_order.ml
@@ -1,0 +1,16 @@
+(* TEST
+*)
+
+[@@@warning "-unerasable-optional-argument"]
+let foo ?a =
+    print_endline "a parameter";
+    fun ~b ->
+    print_endline "b parameter";
+    fun ~c ->
+    print_endline "c parameter"
+
+let f = foo ~a:(print_endline "a argument") ~c:(print_endline "c argument")
+
+let _ = print_endline "f defined"
+
+let _ = f ~b:(print_endline "b argument")

--- a/testsuite/tests/basic-more/labels_evaluation_order.reference
+++ b/testsuite/tests/basic-more/labels_evaluation_order.reference
@@ -1,0 +1,7 @@
+c argument
+a argument
+f defined
+b argument
+a parameter
+b parameter
+c parameter


### PR DESCRIPTION
Alternative to #10653, preserving the delaying of partial applications of optional arguments to avoid code blow up.