### PR TITLE
headernt.c: fix segmentation fault when runtime not found

### DIFF
--- a/Changes
+++ b/Changes
@@ -584,6 +584,11 @@ Working version
   (Antonin Décimo, review by Miod Vallat, Gabriel Scherer,
    Xavier Leroy, and David Allsopp)
 
+- #12726: fix segmentation fault under Windows when executing a bytecode file if
+  the runtime (`ocamlrun.exe`) cannot be found.
+  (Vadim Zborovskii, Nicolás Ojeda Bär, report by Vadim Zborovskii, review by
+  David Allsopp)
+
 OCaml 5.1.1
 -----------
 

--- a/stdlib/headernt.c
+++ b/stdlib/headernt.c
@@ -123,7 +123,7 @@ static __inline void __declspec(noreturn) run_runtime(wchar_t * runtime,
   PROCESS_INFORMATION procinfo;
   DWORD retcode;
   if (SearchPath(NULL, runtime, L".exe", sizeof(path)/sizeof(wchar_t),
-                 path, &runtime) == 0) {
+                 path, NULL) == 0) {
     HANDLE errh;
     errh = GetStdHandle(STD_ERROR_HANDLE);
     write_console(errh, L"Cannot exec ");


### PR DESCRIPTION
Fixes a segmentation fault under Windows when the runtime (`ocamlrun.exe`) is not found in the PATH.

The bug and the fix were identified by @vadim-z. @dra27 had a similar fix in one of his working branches as well.

Fixes #12722