### PR TITLE
Vendored files and languages in .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -108,7 +108,7 @@ runtime/sak.c            typo.non-ascii
 stdlib/hashbang     typo.white-at-eol typo.missing-lf
 
 testsuite/tests/**                                      typo.missing-header typo.long-line=may
-testsuite/tests/lib-bigarray-2/bigarrf.f                typo.tab
+testsuite/tests/lib-bigarray-2/bigarrf.f                typo.tab linguist-language=Fortran
 testsuite/tests/lib-unix/win-stat/fakeclock.c           typo.missing-header=false
 testsuite/tests/misc-unsafe/almabench.ml                typo.long-line
 testsuite/tests/tool-toplevel/strings.ml                typo.utf8
@@ -156,6 +156,17 @@ tools/magic                       typo.missing-header
 
 /tools/ci/appveyor/appveyor_build.cmd text eol=crlf
 
+Makefile* linguist-language=Makefile
+*.c linguist-language=C
+*.h linguist-language=C
+*.h.in linguist-language=C
+*.hva linguist-language=TeX
+*.ml linguist-language=OCaml
+*.ml? linguist-language=OCaml
+*.mld linguist-documentation
+*.ml*.in linguist-language=OCaml
+*.tbl linguist-language=C
+
 aclocal.m4 typo.tab -linguist-vendored
 configure.ac text eol=lf
 # These scripts are all parts of autoconf and are tagged linguist-generated
@@ -177,7 +188,7 @@ tools/ci/inria/bootstrap/remove-sinh-primitive.patch -text
 tools/check-typo text eol=lf
 tools/check-symbol-names text eol=lf
 tools/msvs-promote-path text eol=lf
-tools/gdb-macros text eol=lf
+tools/gdb-macros text eol=lf linguist-language=GDB
 tools/magic text eol=lf
 tools/ocamlsize text eol=lf
 tools/pre-commit-githook text eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -148,7 +148,7 @@ tools/magic                       typo.missing-header
 *.sh text eol=lf
 *.sh.in text eol=lf
 *.awk text eol=lf
-*.m4 text eol=lf
+*.m4 text eol=lf linguist-language=M4Sugar
 
 # ocamltest hooks which are used in the testsuite
 *.check-program-output text eol=lf
@@ -167,7 +167,7 @@ Makefile* linguist-language=Makefile
 *.ml*.in linguist-language=OCaml
 *.tbl linguist-language=C
 
-aclocal.m4 typo.tab -linguist-vendored
+aclocal.m4 typo.tab -linguist-vendored linguist-language=M4Sugar
 configure.ac text eol=lf
 # These scripts are all parts of autoconf and are tagged linguist-generated
 # to suppress inclusion in PR diffs.
@@ -178,7 +178,7 @@ build-aux/install-sh linguist-generated text eol=lf
 build-aux/ltmain.sh linguist-generated text eol=lf
 build-aux/missing linguist-generated text eol=lf
 build-aux/*.m4 linguist-vendored
-build-aux/ocaml_version.m4 -linguist-vendored
+build-aux/ocaml_version.m4 -linguist-vendored linguist-language=M4Sugar
 ocamltest/OCAMLTEST.org typo.long-line=may typo.missing-header
 stdlib/Compflags text eol=lf
 stdlib/hashbang -text

--- a/.gitattributes
+++ b/.gitattributes
@@ -156,7 +156,7 @@ tools/magic                       typo.missing-header
 
 /tools/ci/appveyor/appveyor_build.cmd text eol=crlf
 
-aclocal.m4 typo.tab
+aclocal.m4 typo.tab -linguist-vendored
 configure.ac text eol=lf
 # These scripts are all parts of autoconf and are tagged linguist-generated
 # to suppress inclusion in PR diffs.
@@ -166,6 +166,8 @@ build-aux/config.sub linguist-generated text eol=lf
 build-aux/install-sh linguist-generated text eol=lf
 build-aux/ltmain.sh linguist-generated text eol=lf
 build-aux/missing linguist-generated text eol=lf
+build-aux/*.m4 linguist-vendored
+build-aux/ocaml_version.m4 -linguist-vendored
 ocamltest/OCAMLTEST.org typo.long-line=may typo.missing-header
 stdlib/Compflags text eol=lf
 stdlib/hashbang -text

--- a/.gitattributes
+++ b/.gitattributes
@@ -158,11 +158,14 @@ tools/magic                       typo.missing-header
 
 aclocal.m4 typo.tab
 configure.ac text eol=lf
-build-aux/compile text eol=lf
+# These scripts are all parts of autoconf and are tagged linguist-generated
+# to suppress inclusion in PR diffs.
+build-aux/compile linguist-generated text eol=lf
 build-aux/config.guess linguist-generated text eol=lf
 build-aux/config.sub linguist-generated text eol=lf
-build-aux/install-sh text eol=lf
-build-aux/missing text eol=lf
+build-aux/install-sh linguist-generated text eol=lf
+build-aux/ltmain.sh linguist-generated text eol=lf
+build-aux/missing linguist-generated text eol=lf
 ocamltest/OCAMLTEST.org typo.long-line=may typo.missing-header
 stdlib/Compflags text eol=lf
 stdlib/hashbang -text


### PR DESCRIPTION
Slow morning here...  a PR from the #12296 school of cleaning.

The actual point was to add `linguist-generated` to a few more autoconf support files which suppresses their display in diffs, etc. (cf. #12465). While here, I had a quick play with [github-linguist](https://github.com/github-linguist/linguist), and got it so that GitHub stops reporting some of our files as Standard ML, etc. in its stats:

| Language | Before | After
| -------- | -----: | ----:
| OCaml    |  83.4% | 84.8%
| C        |  11.0% | 11.1%
| Shell    |   2.6% |  1.1%
| Assembly |   1.0% |  1.0%
| Makefile |   0.8% |  0.9%
| M4       |   0.6% |  0.5%
| Other    |   0.6% |  0.6%