### PR TITLE
Fix #12727 (partial applications in Rec_check)

### DIFF
--- a/Changes
+++ b/Changes
@@ -592,6 +592,9 @@ Working version
   (Vadim Zborovskii, Nicolás Ojeda Bär, report by Vadim Zborovskii, review by
   David Allsopp)
 
+- #12727, #12730: fix bug with value let-rec and labelled applications
+  (Vincent Laviron, review by ???)
+
 OCaml 5.1.1
 -----------
 

--- a/Changes
+++ b/Changes
@@ -593,7 +593,7 @@ Working version
   David Allsopp)
 
 - #12727, #12730: fix bug with value let-rec and labelled applications
-  (Vincent Laviron, review by ???)
+  (Vincent Laviron, review by Gabriel Scherer)
 
 OCaml 5.1.1
 -----------

--- a/testsuite/tests/letrec-check/partial_application.ml
+++ b/testsuite/tests/letrec-check/partial_application.ml
@@ -1,0 +1,54 @@
+(* TEST
+ expect;
+*)
+
+let f ~x:_ ~y:_ ~z:_ = ();;
+[%%expect{|
+val f : x:'a -> y:'b -> z:'c -> unit = <fun>
+|}];;
+
+(* Passing self immediately: forbidden *)
+let rec x = f ~x;;
+[%%expect{|
+Line 1, characters 12-16:
+1 | let rec x = f ~x;;
+                ^^^^
+Error: This kind of expression is not allowed as right-hand side of "let rec"
+|}];;
+
+(* Passing self after an omitted argument: allowed *)
+let rec y = f ~y;;
+[%%expect{|
+val y : x:'a -> z:'b -> unit = <fun>
+|}];;
+
+(* Passing self immediately: forbidden even if other arguments are omitted *)
+let rec x = f ~x ~z:0;;
+[%%expect{|
+Line 1, characters 12-21:
+1 | let rec x = f ~x ~z:0;;
+                ^^^^^^^^^
+Error: This kind of expression is not allowed as right-hand side of "let rec"
+|}];;
+
+(* Calling self: allowed if the first argument is omitted *)
+let g ~omitted ~given = fun ~given:_ -> given ~omitted
+let rec f : omitted:_ -> given:_ -> _ = g ~given:(f ~given:0);;
+[%%expect{|
+val g : omitted:'a -> given:(omitted:'a -> 'b) -> given:'c -> 'b = <fun>
+val f : omitted:'a -> given:int -> 'b = <fun>
+|}];;
+
+(* Calling self: forbidden if the first argument is passed *)
+let g ~omitted_g ~given = fun ~omitted_f:_ ~given:_ -> given ~omitted_f:()
+let rec f : omitted_g:_ -> omitted_f:_ -> given:_ -> _ =
+  g ~given:(f ~omitted_g:() ~given:0);;
+[%%expect{|
+val g :
+  omitted_g:'a ->
+  given:(omitted_f:unit -> 'b) -> omitted_f:'c -> given:'d -> 'b = <fun>
+Line 3, characters 2-37:
+3 |   g ~given:(f ~omitted_g:() ~given:0);;
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This kind of expression is not allowed as right-hand side of "let rec"
+|}];;

--- a/typing/rec_check.ml
+++ b/typing/rec_check.ml
@@ -583,8 +583,9 @@ let rec expression : Typedtree.expression -> term_judg =
            function immediately, so they are dereferenced. The arguments after
            the first omitted one are stored in a closure, so guarded.
            The function itself is called immediately (dereferenced) if there
-           is at least one argument before the first omitted one, stored in
-           the closure (guarded) otherwise. *)
+           is at least one argument before the first omitted one.
+           On the other hand, if the first argument is omitted then the
+           function is stored in the closure without being called. *)
         let rec split_args before_omitted = function
           | (_, None) :: rest -> before_omitted, rest
           | ((_, Some _) as arg) :: rest ->


### PR DESCRIPTION
This makes `Rec_check` follow the current semantics for labelled applications: all arguments before the first omitted one are passed to the function immediately, all arguments after that are stored in a closure.
There is no particular support for optional arguments, so a few cases end up rejected even though with the current state of the compiler that could have been allowed.
Here is such an example:
```ocaml
let f ?x ~y ~z = ()
let rec x = f ~x ~z:()
```
I don't think this is going to bother anyone.

I suggest @gasche or @yallop as reviewer; this PR is completely independent from my ongoing work around compilation of let-recs, and is a bug in the mode computations (or in how the rest of the compiler handles labelled partial applications, depending on your point of view).