### PR TITLE
Fix parallel recursive invocations of make causing sporadic "Other checks" CI failure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -240,7 +240,7 @@ META
 /runtime/caml/m.h
 /runtime/caml/s.h
 /runtime/primitives
-/runtime/primitives.new
+/runtime/primitives*.new
 /runtime/prims.c
 /runtime/caml/exec.h
 /runtime/caml/opnames.h

--- a/Makefile
+++ b/Makefile
@@ -1251,14 +1251,17 @@ runtime/ld.conf: $(ROOTDIR)/Makefile.config
 	$(V_GEN)echo "$(STUBLIBDIR)" > $@ && \
 	echo "$(LIBDIR)" >> $@
 
+PRIMITIVES_NEW := runtime/primitives$(shell echo "$$PPID").new
+
 # To speed up builds, we avoid changing "primitives" when files
 # containing primitives change but the primitives table does not
 runtime/primitives: runtime/gen_primitives.sh \
   $(shell runtime/gen_primitives.sh $(runtime_BYTECODE_C_SOURCES) \
-                    > runtime/primitives.new; \
-                    cmp -s runtime/primitives runtime/primitives.new || \
-                    echo runtime/primitives.new)
-	$(V_GEN)cp runtime/primitives.new $@
+                    > $(PRIMITIVES_NEW); \
+                    { cmp -s runtime/primitives $(PRIMITIVES_NEW) && \
+                        rm -f $(PRIMITIVES_NEW) ; } || \
+                    echo $(runtime_BYTECODE_C_SOURCES))
+	$(V_GEN)mv $(PRIMITIVES_NEW) $@
 
 runtime/prims.c: runtime/gen_primsc.sh runtime/primitives
 	$(V_GEN)runtime/gen_primsc.sh \
@@ -1488,7 +1491,7 @@ clean::
 	rm -f $(addprefix runtime/, ocamlrun ocamlrund ocamlruni ocamlruns sak)
 	rm -f $(addprefix runtime/, \
 	  ocamlrun.exe ocamlrund.exe ocamlruni.exe ocamlruns.exe sak.exe)
-	rm -f runtime/primitives runtime/primitives.new runtime/prims.c \
+	rm -f runtime/primitives runtime/primitives*.new runtime/prims.c \
 	  $(runtime_BUILT_HEADERS)
 	rm -f runtime/domain_state.inc
 	rm -rf $(DEPDIR)


### PR DESCRIPTION
Follow-up to failure observed in https://github.com/ocaml/ocaml/pull/10653#issuecomment-1806025231.

Since #11248 merged `runtime/Makefile` into the root `Makefile`, it is (known) to be the case that `runtime/primitives` is checked on each recursive invocation of `make`. The time taken to do this is insignificant, and it'll ultimately disappear, as the whole point of the `Makefile`-merge project is to eliminate recursive invocations of `make` entirely.

However, at present, various of the commands in `opt.opt` still emit parallel recursive calls to `make`, which risks a race on `runtime/primitives.new`. This is the underlying problem seen in #10653's CI failure. The problem will have only become noticeable recently, as it's the tools targets (`ocamldoc`, `ocamltest`, etc.) which are despatched in parallel, and they are the more recent, post 5.1.0, merges (see the `opt.opt` recipe).

I had a look back through all the failures in GitHub Actions to the end of August (which, sadly, is as far back as the logs go), and found these failures:
- Aug 31: https://github.com/ocaml/ocaml/actions/runs/6034382038/job/16372868475#step:9:161
- Oct 6: https://github.com/ocaml/ocaml/actions/runs/6436091854/job/17478902354#step:9:161
- Oct 16: https://github.com/ocaml/ocaml/actions/runs/6536625810/job/17749142477#step:9:161
- Nov 2: https://github.com/ocaml/ocaml/actions/runs/6733793513/job/18303588327#step:9:162
- Nov 3: https://github.com/ocaml/ocaml/actions/runs/6745734742/job/18338470359#step:9:162
- Nov 10: https://github.com/ocaml/ocaml/actions/runs/6823859603/job/18558924939#step:9:153
- Nov 10: https://github.com/ocaml/ocaml/actions/runs/6826817881/job/18567929427#step:9:153

In each case, I have pointed to a `GEN runtime/primitives` line which should not be happening (because nothing has changed). However, if `runtime/primitives.new` is partially overwritten (or, more likely, is empty at the start of the call - which would especially make sense for the missing primitive error in the Aug 31 log) then a rebuild of `runtime/primitives` which will be triggered. This will trigger rebuilds of the rest of the compiler which are unexpected at that point - i.e. the build system can't YET cope with that.

The fix I propose is simply to use `$PPID` in the filename (i.e. have each `make` invocation write a unique-enough file). I have PTSD-like recollections that the `mktemp` binary is remarkably non-portable, but `$PPID` is POSIX, and the `Makefile` is specified as executing with `sh`.

I haven't been able to trigger this failure locally, so it's hard to verify the fix. What I did do is put a debugging statement to stderr whenever `runtime/primitives.new` is being computed, and it is clearly apparent in those logs that there are two computations of this file by separate `make` instances issued at the same time.