### PR TITLE
Treat universal variables as abstract in expected types

### DIFF
--- a/testsuite/tests/effects/backtrace.ml
+++ b/testsuite/tests/effects/backtrace.ml
@@ -45,9 +45,9 @@ let main () =
     exnc = (fun e ->
       let open Printexc in
       print_raw_backtrace stdout (get_raw_backtrace ()));
-    effc = fun (type a) (e : a t) ->
+    effc = fun e ->
       match e with
-      | Wait -> Some (fun (k : (a, _) continuation) ->
+      | Wait -> Some (fun k ->
           discontinue_with_backtrace k x bt)
       | _ -> None }
 

--- a/testsuite/tests/effects/cmphash.ml
+++ b/testsuite/tests/effects/cmphash.ml
@@ -7,7 +7,7 @@ type _ t += E : unit t
 
 let () =
   try_with perform E
-  { effc = fun (type a) (e : a t) ->
+  { effc = fun e ->
       match e with
       | E -> Some (fun k ->
           begin match k = k with

--- a/testsuite/tests/effects/evenodd.ml
+++ b/testsuite/tests/effects/evenodd.ml
@@ -8,7 +8,7 @@ type _ t += E : unit t
 let rec even n =
   if n = 0 then true
   else try_with odd (n-1)
-       { effc = fun (type a) (e : a t) ->
+       { effc = fun e ->
            match e with
            | E -> Some (fun k -> assert false)
            | _ -> None }

--- a/testsuite/tests/effects/issue479.ml
+++ b/testsuite/tests/effects/issue479.ml
@@ -31,9 +31,9 @@ let iter2gen : _ iter2gen = fun iter c ->
     match_with (iter suspending_f) c
     { retc = (fun _ -> fun () -> None);
       exnc = (fun e -> raise e);
-      effc = fun (type a) (e : a t) ->
+      effc = fun e ->
         match e with
-        | Hold -> Some (fun (k : (a,_) continuation) ->
+        | Hold -> Some (fun k ->
             fun () ->
               let x = !r in
               Printf.printf "Hold %s\n%!" (

--- a/testsuite/tests/effects/marshal.ml
+++ b/testsuite/tests/effects/marshal.ml
@@ -7,7 +7,7 @@ type _ t += E : unit t
 
 let () =
   try_with perform E
-  { effc = fun (type a) (e : a t) ->
+  { effc = fun e ->
       Some (fun k ->
           match Marshal.to_string k [] with
           | _ -> assert false

--- a/testsuite/tests/effects/overflow.ml
+++ b/testsuite/tests/effects/overflow.ml
@@ -33,7 +33,7 @@ let () =
   match_with (fun _ -> f 1 2 3 4 5 6 7 8) ()
   { retc = (fun n -> Printf.printf "%d\n" n);
     exnc = (fun e -> raise e);
-    effc = fun (type a) (e : a t) ->
+    effc = fun e ->
       match e with
       | E -> Some (fun k -> assert false)
       | _ -> None }

--- a/testsuite/tests/effects/partial.ml
+++ b/testsuite/tests/effects/partial.ml
@@ -8,7 +8,7 @@ exception Done
 
 let handle_partial f =
   try_with f ()
-  { effc = fun (type a) (e : a t) ->
+  { effc = fun e ->
       match e with
       | E -> Some (fun k -> assert false)
       | _ -> None }
@@ -21,7 +21,7 @@ let () =
     exnc = (function
       | Done -> print_string "ok\n"
       | e -> raise e);
-    effc = fun (type a) (e : a t) ->
+    effc = fun e ->
       match e with
-      | E -> Some (fun (k : (a, _) continuation) -> discontinue k Done)
+      | E -> Some (fun k -> discontinue k Done)
       | _ -> None }

--- a/testsuite/tests/effects/reperform.ml
+++ b/testsuite/tests/effects/reperform.ml
@@ -12,7 +12,7 @@ let rec nest = function
      match_with (fun _ -> Printf.printf "[%d\n" n; nest (n - 1)) ()
      { retc = (fun x -> Printf.printf " %d]\n" n; x);
        exnc = (fun e -> Printf.printf " !%d]\n" n; raise e);
-       effc = fun (type a) (e : a t) ->
+       effc = fun e ->
          match e with
          | F -> Some (fun k -> assert false)
          | _ -> None }
@@ -21,16 +21,16 @@ let () =
   match_with nest 5
   { retc = (fun x -> Printf.printf "= %d\n" x);
     exnc = (fun e -> raise e);
-    effc = fun (type a) (e : a t) ->
+    effc = fun e ->
       match e with
-      | E n -> Some (fun (k : (a, _) continuation) -> continue k (n + 100))
+      | E n -> Some (fun k -> continue k (n + 100))
       | _ -> None }
 
 let () =
   match_with nest 5
   { retc = (fun x -> assert false);
     exnc = (fun e -> Printf.printf "%s\n" (Printexc.to_string e));
-    effc = fun (type a) (e : a t) ->
+    effc = fun e ->
       match e with
       | F -> Some (fun k -> assert false)
       | _ -> None }

--- a/testsuite/tests/effects/sched.ml
+++ b/testsuite/tests/effects/sched.ml
@@ -26,13 +26,13 @@ let run main =
       exnc = (function
         | E -> say "!"; dequeue ()
         | e -> raise e);
-      effc = fun (type a) (e : a t) ->
+      effc = fun e ->
         match e with
-        | Yield -> Some (fun (k : (a, _) continuation) ->
+        | Yield -> Some (fun k ->
             say ","; enqueue k; dequeue ())
-        | Fork f -> Some (fun (k : (a, _) continuation) ->
+        | Fork f -> Some (fun k ->
             say "+"; enqueue k; spawn f)
-        | Ping -> Some (fun (k : (a, _) continuation) ->
+        | Ping -> Some (fun k ->
             say "["; discontinue k Pong)
         | _ -> None }
   in
@@ -47,9 +47,9 @@ let test () =
         exnc = (function
           | Pong -> say "]"
           | e -> raise e);
-        effc = fun (type a) (e : a t) ->
+        effc = fun e ->
           match e with
-          | Yield -> Some (fun (k : (a,_) continuation) -> failwith "what?")
+          | Yield -> Some (fun k -> failwith "what?")
           | _ -> None }
      end;
      raise E));

--- a/testsuite/tests/effects/shallow_state.ml
+++ b/testsuite/tests/effects/shallow_state.ml
@@ -23,11 +23,11 @@ let handle_state init f x =
       continue_with k x
       { retc = (fun result -> result, state);
         exnc = (fun e -> raise e);
-        effc = (fun (type b) (eff : b t) ->
+        effc = (fun eff ->
           match eff with
-          | Get -> Some (fun (k : (b,r) continuation) ->
+          | Get -> Some (fun k ->
               loop state k state)
-          | Set new_state -> Some (fun (k : (b,r) continuation) ->
+          | Set new_state -> Some (fun k ->
               loop new_state k ())
           | e -> None) }
   in

--- a/testsuite/tests/effects/test1.ml
+++ b/testsuite/tests/effects/test1.ml
@@ -8,7 +8,7 @@ type _ t += E : unit t
 let () =
   Printf.printf "%d\n%!" @@
     try_with (fun x -> x) 10
-    { effc = (fun (type a) (e : a t) ->
+    { effc = (fun e ->
         match e with
         | E -> Some (fun k -> 11)
         | e -> None) }

--- a/testsuite/tests/effects/test10.ml
+++ b/testsuite/tests/effects/test10.ml
@@ -13,17 +13,17 @@ let rec c i = b i + Random.int i
 let rec d i =
   Random.int i +
   try_with c i
-  { effc = fun (type a) (e : a t) ->
+  { effc = fun e ->
       match e with
-      | Poke -> Some (fun (k : (a,_) continuation) -> continue k ())
+      | Poke -> Some (fun k -> continue k ())
       | _ -> None }
 
 let rec e i =
   Random.int i +
   try_with d i
-  { effc = fun (type a) (e : a t) ->
+  { effc = fun e ->
       match e with
-      | Peek -> Some (fun (k : (a,_) continuation) ->
+      | Peek -> Some (fun k ->
           ignore (Deep.get_callstack k 100);
           continue k 42)
       | _ -> None }

--- a/testsuite/tests/effects/test11.ml
+++ b/testsuite/tests/effects/test11.ml
@@ -10,9 +10,9 @@ type _ t += E : int t
 
 let handle comp =
   try_with comp ()
-  { effc = fun (type a) (e : a t) ->
+  { effc = fun e ->
       match e with
-      | E -> Some (fun (k : (a,_) continuation) -> continue k 10)
+      | E -> Some (fun k -> continue k 10)
       | _ -> None }
 
 let () =

--- a/testsuite/tests/effects/test3.ml
+++ b/testsuite/tests/effects/test3.ml
@@ -15,7 +15,7 @@ let () =
       exnc = (function
         | X -> 10
         | e -> raise e);
-      effc = (fun (type a) (e : a t) ->
+      effc = (fun e ->
         match e with
         | E -> Some (fun k -> 11)
         | e -> None) }

--- a/testsuite/tests/effects/test4.ml
+++ b/testsuite/tests/effects/test4.ml
@@ -7,11 +7,11 @@ type _ t += Foo : int -> int t
 
 let r =
   try_with perform (Foo 3)
-  { effc = fun (type a) (e : a t) ->
+  { effc = fun e ->
       match e with
-      | Foo i -> Some (fun (k : (a,_) continuation) ->
+      | Foo i -> Some (fun k ->
           try_with (continue k) (i+1)
-          { effc = fun (type a) (e : a t) ->
+          { effc = fun e ->
               match e with
               | Foo i -> Some (fun k -> failwith "NO")
               | e -> None })

--- a/testsuite/tests/effects/test5.ml
+++ b/testsuite/tests/effects/test5.ml
@@ -10,11 +10,11 @@ let f () = (perform (Foo 3)) (* 3 + 1 *)
 
 let r =
   try_with f ()
-  { effc = fun (type a) (e : a t) ->
+  { effc = fun e ->
       match e with
-      | Foo i -> Some (fun (k : (a, _) continuation) ->
+      | Foo i -> Some (fun k ->
           try_with (continue k) (i + 1)
-          { effc = fun (type a) (e : a t) ->
+          { effc = fun e ->
               match e with
               | Foo i -> Some (fun k -> failwith "NO")
               | _ -> None })

--- a/testsuite/tests/effects/test6.ml
+++ b/testsuite/tests/effects/test6.ml
@@ -21,7 +21,7 @@ let () =
   Printf.printf "%b\n%!" !ok2;
 
   try_with (f E) ok3 {
-    effc = fun (type a) (e : a t) ->
+    effc = fun e ->
       match e with
       | F -> Some (fun k -> assert false)
       | _ -> None

--- a/testsuite/tests/effects/test_lazy.ml
+++ b/testsuite/tests/effects/test_lazy.ml
@@ -17,18 +17,18 @@ let _ =
   let l = lazy (f 1_000) in
   let v1 =
     try_with Lazy.force l
-    { effc = fun (type a) (e : a t) ->
+    { effc = fun e ->
         match e with
-        | Stop -> Some (fun (k : (a, _) continuation) -> continue k ())
+        | Stop -> Some (fun k -> continue k ())
         | _ -> None }
   in
   Printf.printf "%d\n" v1;
   let l2 = lazy (f 2_000) in
   let v2 =
     try_with Lazy.force l2
-    { effc = fun (type a) (e : a t) ->
+    { effc = fun e ->
         match e with
-        | Stop -> Some (fun (k : (a, _) continuation) ->
+        | Stop -> Some (fun k ->
             let d = Domain.spawn(fun () -> continue k ()) in
             Domain.join d)
         | _ -> None }
@@ -37,7 +37,7 @@ let _ =
   let l3 = lazy (f 3_000) in
   let _ =
     try_with Lazy.force l3
-    { effc = fun (type a) (e : a t) ->
+    { effc = fun e ->
         match e with
         | Stop -> Some (fun _ ->
             try

--- a/testsuite/tests/effects/used_cont.ml
+++ b/testsuite/tests/effects/used_cont.ml
@@ -10,9 +10,9 @@ let () =
   match_with (fun _ -> perform E; 42) ()
   { retc = (fun n -> assert (n = 42));
     exnc = (fun e -> raise e);
-    effc = fun (type a) (e : a t) ->
+    effc = fun e ->
       match e with
-      | E -> Some (fun (k : (a,_) continuation) ->
+      | E -> Some (fun k ->
           continue k ();
           r := Some (k : (unit, unit) continuation);
           Gc.full_major ();

--- a/testsuite/tests/shapes/simple.ml
+++ b/testsuite/tests/shapes/simple.ml
@@ -125,8 +125,8 @@ class c : object  end
 class type c = object end
 [%%expect{|
 {
- "c"[type] -> <.34>;
- "c"[class type] -> <.34>;
+ "c"[type] -> <.35>;
+ "c"[class type] -> <.35>;
  }
 class type c = object  end
 |}]

--- a/testsuite/tests/typing-gadts/pr10907.ml
+++ b/testsuite/tests/typing-gadts/pr10907.ml
@@ -45,9 +45,10 @@ val t : 'a some_iso = Iso (<fun>, <fun>)
 let unsound_cast : 'a 'b. 'a -> 'b = fun x ->
   match t with Iso (g, h) -> h (g x)
 [%%expect{|
-Lines 1-2, characters 37-36:
-1 | .....................................fun x ->
+Line 2, characters 29-36:
 2 |   match t with Iso (g, h) -> h (g x)
-Error: This definition has type "'c. 'c -> 'c" which is less general than
-         "'a 'b. 'a -> 'b"
+                                 ^^^^^^^
+Error: This expression has type "$a" but an expression was expected of type "$b"
+       Hint: "$a" and "$b" are abstract types
+         bound by the polymorphic annotation on "unsound_cast".
 |}]

--- a/testsuite/tests/typing-poly/poly.ml
+++ b/testsuite/tests/typing-poly/poly.ml
@@ -517,10 +517,12 @@ class ['a] id1 = object
 end
 ;;
 [%%expect {|
-Line 3, characters 12-17:
+Line 3, characters 16-17:
 3 |   method id x = x
-                ^^^^^
-Error: This method has type "'a -> 'a" which is less general than "'b. 'b -> 'a"
+                    ^
+Error: This expression has type "$b" but an expression was expected of type "'a"
+       The type constructor "$b" would escape its scope
+       Hint: "$b" is an abstract type bound by a polymorphic type annotation.
 |}];;
 
 class id2 (x : 'a) = object
@@ -529,10 +531,12 @@ class id2 (x : 'a) = object
 end
 ;;
 [%%expect {|
-Line 3, characters 12-17:
+Line 3, characters 16-17:
 3 |   method id x = x
-                ^^^^^
-Error: This method has type "'a -> 'a" which is less general than "'b. 'b -> 'a"
+                    ^
+Error: This expression has type "$b" but an expression was expected of type "'a"
+       The type constructor "$b" would escape its scope
+       Hint: "$b" is an abstract type bound by a polymorphic type annotation.
 |}];;
 
 class id3 x = object
@@ -542,10 +546,12 @@ class id3 x = object
 end
 ;;
 [%%expect {|
-Line 4, characters 12-17:
+Line 4, characters 16-17:
 4 |   method id _ = x
-                ^^^^^
-Error: This method has type "'b -> 'b" which is less general than "'a. 'a -> 'a"
+                    ^
+Error: This expression has type "'a" but an expression was expected of type "$a"
+       The type constructor "$a" would escape its scope
+       Hint: "$a" is an abstract type bound by a polymorphic type annotation.
 |}];;
 
 class id4 () = object
@@ -558,12 +564,12 @@ class id4 () = object
 end
 ;;
 [%%expect {|
-Lines 4-7, characters 12-17:
-4 | ............x =
-5 |     match r with
+Line 6, characters 24-25:
 6 |       None -> r <- Some x; x
-7 |     | Some y -> y
-Error: This method has type "'b -> 'b" which is less general than "'a. 'a -> 'a"
+                            ^
+Error: This expression has type "$a" but an expression was expected of type "'a"
+       The type constructor "$a" would escape its scope
+       Hint: "$a" is an abstract type bound by a polymorphic type annotation.
 |}];;
 
 class c = object
@@ -1378,11 +1384,12 @@ type 'a t = Leaf of 'a | Node of ('a * 'a) t
 val depth : 'a t -> int = <fun>
 val depth : 'a t -> int = <fun>
 val d : ('a * 'a) t -> int = <fun>
-Line 9, characters 2-46:
+Line 9, characters 39-46:
 9 |   function Leaf x -> x | Node x -> 1 + depth x;; (* fails *)
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This definition has type "int t -> int" which is less general than
-         "'a. 'a t -> int"
+                                           ^^^^^^^
+Error: This expression has type "$a" but an expression was expected of type "int"
+       Hint: "$a" is an abstract type bound by the polymorphic annotation on
+         "depth".
 |}];;
 
 (* compare with records (should be the same) *)
@@ -1450,8 +1457,10 @@ type t = { f : 'a. 'a -> unit; }
 Line 3, characters 19-20:
 3 | let f ?x y = y in {f};; (* fail *)
                        ^
-Error: This field value has type "unit -> unit" which is less general than
-         "'a. 'a -> unit"
+Error: This expression has type "$a -> $a"
+       but an expression was expected of type "$a -> unit"
+       Type "$a" is not compatible with type "unit"
+       Hint: "$a" is an abstract type bound by the polymorphic record field "f".
 |}];;
 
 (* Polux Moon caml-list 2011-07-26 *)
@@ -1983,9 +1992,11 @@ Line 3, characters 4-6:
 3 |   | `Y -> x
         ^^
 Error: This pattern matches values of type "[? `Y ]"
-       but a pattern was expected which matches values of type "[> `X of 'a ]"
-       The second variant type is bound to the universal type variable "'b",
+       but a pattern was expected which matches values of type "[> `X of $a ]"
+       The second variant type is bound to the universal type variable "'a",
        it may not allow the tag(s) "`Y"
+       Hint: "$a" is an abstract type bound by the polymorphic annotation on
+         "fail".
 |}]
 
 let fail_example_corrected: 'a . 'a -> [< `X of 'a | `Y ] -> 'a = fun x y ->
@@ -2008,11 +2019,11 @@ val discrepancy : < x : 'a; y : unit -> 'b; .. > -> 'a = <fun>
 
 let explicitly_quantified_row: 'a 'r. (<x:'a; ..> as 'r) -> 'a = fun o -> o#y (); o#x
 [%%expect {|
-Line 1, characters 65-85:
+Line 1, characters 74-75:
 1 | let explicitly_quantified_row: 'a 'r. (<x:'a; ..> as 'r) -> 'a = fun o -> o#y (); o#x
-                                                                     ^^^^^^^^^^^^^^^^^^^^
-Error: This definition has type "'b. < x : 'b; y : unit -> 'c; .. > -> 'b"
-       which is less general than "'a 'd. (< x : 'a; .. > as 'd) -> 'a"
+                                                                              ^
+Error: This expression has type "< x : $a; .. >"
+       It has no method "y"
 |}]
 
 
@@ -2049,11 +2060,7 @@ val coerce : ('b, 'b) Type.eq -> 'b -> 'b = <fun>
 let coerce : 'a 'b. ('a, 'b) Type.eq -> 'a -> 'b =
   fun Equal x -> x
 [%%expect {|
-Line 2, characters 2-18:
-2 |   fun Equal x -> x
-      ^^^^^^^^^^^^^^^^
-Error: This definition has type "'c. ('c, 'c) Type.eq -> 'c -> 'c"
-       which is less general than "'a 'b. ('a, 'b) Type.eq -> 'a -> 'b"
+val coerce : ('a, 'b) Type.eq -> 'a -> 'b = <fun>
 |}]
 
 (** Polymorphic method annotations give locally abstract types *)
@@ -2062,11 +2069,7 @@ class c = object
     fun Equal x -> x
 end
 [%%expect {|
-Line 3, characters 4-20:
-3 |     fun Equal x -> x
-        ^^^^^^^^^^^^^^^^
-Error: This method has type "'c. ('c, 'c) Type.eq -> 'c -> 'c"
-       which is less general than "'a 'b. ('a, 'b) Type.eq -> 'a -> 'b"
+class c : object method coerce : ('a, 'b) Type.eq -> 'a -> 'b end
 |}]
 
 (** Polymorphic record field types give locally abstract types *)
@@ -2075,9 +2078,5 @@ type t = { coerce : 'a 'b. ('a, 'b) Type.eq -> 'a -> 'b }
 let t = { coerce = fun Equal x -> x }
 [%%expect {|
 type t = { coerce : 'a 'b. ('a, 'b) Type.eq -> 'a -> 'b; }
-Line 3, characters 19-35:
-3 | let t = { coerce = fun Equal x -> x }
-                       ^^^^^^^^^^^^^^^^
-Error: This field value has type "'c. ('c, 'c) Type.eq -> 'c -> 'c"
-       which is less general than "'a 'b. ('a, 'b) Type.eq -> 'a -> 'b"
+val t : t = {coerce = <fun>}
 |}]

--- a/typing/btype.ml
+++ b/typing/btype.ml
@@ -125,12 +125,14 @@ let newmarkedgenvar () =
 let is_Tvar ty = match get_desc ty with Tvar _ -> true | _ -> false
 let is_Tunivar ty = match get_desc ty with Tunivar _ -> true | _ -> false
 let is_Tconstr ty = match get_desc ty with Tconstr _ -> true | _ -> false
+let is_poly ty = match get_desc ty with Tpoly(_, _ :: _) -> true | _ -> false
 let type_kind_is_abstract decl =
   match decl.type_kind with Type_abstract _ -> true | _ -> false
 let type_origin decl =
   match decl.type_kind with
   | Type_abstract origin -> origin
   | Type_variant _ | Type_record _ | Type_open -> Definition
+let label_is_poly lbl = is_poly lbl.lbl_arg
 
 let dummy_method = "*dummy method*"
 

--- a/typing/btype.mli
+++ b/typing/btype.mli
@@ -77,9 +77,11 @@ val newmarkedgenvar: unit -> type_expr
 val is_Tvar: type_expr -> bool
 val is_Tunivar: type_expr -> bool
 val is_Tconstr: type_expr -> bool
+val is_poly: type_expr -> bool
 val dummy_method: label
 val type_kind_is_abstract: type_declaration -> bool
 val type_origin : type_declaration -> type_origin
+val label_is_poly : label_description -> bool
 
 (**** polymorphic variants ****)
 

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -1237,14 +1237,14 @@ let rec copy ?partial ?keep_names copy_scope ty =
 
 (**** Variants of instantiations ****)
 
-let instance ?partial sch =
+let instance ?partial ?keep_names sch =
   let partial =
     match partial with
       None -> None
     | Some keep -> Some (compute_univars sch, keep)
   in
   For_copy.with_scope (fun copy_scope ->
-    copy ?partial copy_scope sch)
+    copy ?partial ?keep_names copy_scope sch)
 
 let generic_instance sch =
   let old = !current_level in
@@ -1259,18 +1259,30 @@ let instance_list schl =
 
 (* Create unique names to new type constructors.
    Used for existential types and local constraints. *)
-let get_new_abstract_name env s =
-  let name index =
-    if index = 0 && s <> "" && s.[String.length s - 1] <> '$' then s else
-    Printf.sprintf "%s%d" s index
-  in
+let get_new_abstract_name_gen env naming_fn =
   let check index =
-    match Env.find_type_by_name (Longident.Lident (name index)) env with
+    let name = naming_fn index in
+    match Env.find_type_by_name (Longident.Lident name) env with
     | _ -> false
     | exception Not_found -> true
   in
   let index = Misc.find_first_mono check in
-  name index
+  naming_fn index
+
+let get_new_abstract_name env s =
+  get_new_abstract_name_gen env
+    (fun index ->
+      if index = 0 && s <> "" && s.[String.length s - 1] <> '$' then s
+      else Printf.sprintf "%s%d" s index)
+
+let get_new_anonymous_abstract_name env =
+  get_new_abstract_name_gen env
+    (fun index -> "$" ^ Misc.letter_of_int index)
+
+let existential_name env ty =
+  match get_desc ty with
+  | Tvar (Some name) -> get_new_abstract_name env ("$" ^ name)
+  | _ -> get_new_anonymous_abstract_name env
 
 let new_local_type ?(loc = Location.none) ?manifest_and_scope origin =
   let manifest, expansion_scope =
@@ -1295,24 +1307,12 @@ let new_local_type ?(loc = Location.none) ?manifest_and_scope origin =
     type_uid = Uid.mk ~current_unit:(Env.get_unit_name ());
   }
 
-let existential_name name_counter ty =
-  let name =
-    match get_desc ty with
-    | Tvar (Some name) -> name
-    | _ ->
-        let name = Misc.letter_of_int !name_counter in
-        incr name_counter;
-        name
-  in
-  "$" ^ name
-
 type existential_treatment =
   | Keep_existentials_flexible
   | Make_existentials_abstract of Pattern_env.t
 
 let instance_constructor existential_treatment cstr =
   For_copy.with_scope (fun copy_scope ->
-    let name_counter = ref 0 in
     let copy_existential =
       match existential_treatment with
       | Keep_existentials_flexible -> copy copy_scope
@@ -1321,9 +1321,9 @@ let instance_constructor existential_treatment cstr =
             let env = penv.env in
             let fresh_constr_scope = penv.equations_scope in
             let decl = new_local_type (Existential cstr.cstr_name) in
-            let name = existential_name name_counter existential in
+            let name = existential_name env existential in
             let (id, new_env) =
-              Env.enter_type (get_new_abstract_name env name) decl env
+              Env.enter_type name decl env
                 ~scope:fresh_constr_scope in
             Pattern_env.set_env penv new_env;
             let to_unify = newty (Tconstr (Path.Pident id,[],ref Mnil)) in
@@ -1492,17 +1492,66 @@ let instance_poly' copy_scope ~keep_names ~fixed univars sch =
   let ty = copy_sep ~copy_scope ~fixed ~visited sch in
   vars, ty
 
-let instance_poly ?(keep_names=false) ~fixed univars sch =
+let abstract_poly_vars env origin ~scope vars =
+  let abstract_var (env, ids) var =
+    match get_desc var with
+    | Tvar var_name ->
+        let decl = new_local_type origin in
+        let name = existential_name env var in
+        let id, env = Env.enter_type name decl env ~scope in
+        let ty = newty (Tconstr (Path.Pident id,[],ref Mnil)) in
+        link_type var ty;
+        env, (id, var_name) :: ids
+    | _ ->
+        env, ids
+  in
+  let named_vars, unnamed_vars =
+    List.partition
+      (fun var ->
+        match get_desc var with
+        | Tvar (Some _) -> true
+        | _ -> false)
+      vars
+  in
+  let acc = List.fold_left abstract_var (env, []) named_vars in
+  List.fold_left abstract_var acc unnamed_vars
+
+let instance_poly_gen ~fixed ~keep_names univars sch =
   For_copy.with_scope (fun copy_scope ->
     instance_poly' copy_scope ~keep_names ~fixed univars sch
   )
 
-let instance_label ~fixed lbl =
+let instance_poly ~keep_names univars sch =
+  snd (instance_poly_gen ~keep_names ~fixed:false univars sch)
+
+type poly_instance =
+  { env : Env.t;
+    ids : (Ident.t * string option) list;
+    vars : type_expr list;
+    ty : type_expr; }
+
+let instance_poly_abstract env ~scope ~binding_name univars sch =
+    let vars, ty =
+      instance_poly_gen ~fixed:true ~keep_names:true univars sch
+    in
+    let env, ids =
+      abstract_poly_vars env (Polymorphic_binding binding_name) ~scope vars
+    in
+    { env; ids; vars; ty }
+
+let instance_poly_flexible env univars sch =
+    let vars, ty =
+      instance_poly_gen ~fixed:true ~keep_names:true univars sch
+    in
+    let ids = [] in
+    { env; ids; vars; ty }
+
+let instance_label_gen ~fixed ~keep_names lbl =
   For_copy.with_scope (fun copy_scope ->
     let vars, ty_arg =
       match get_desc lbl.lbl_arg with
         Tpoly (ty, tl) ->
-          instance_poly' copy_scope ~keep_names:false ~fixed tl ty
+          instance_poly' copy_scope ~keep_names ~fixed tl ty
       | _ ->
           [], copy copy_scope lbl.lbl_arg
     in
@@ -1510,6 +1559,26 @@ let instance_label ~fixed lbl =
     let ty_res = copy copy_scope lbl.lbl_res in
     (vars, ty_arg, ty_res)
   )
+
+let instance_label lbl =
+  instance_label_gen ~fixed:false ~keep_names:false lbl
+
+type abstract_label_instance =
+  { env : Env.t;
+    ids : (Ident.t * string option) list;
+    vars : type_expr list;
+    arg : type_expr;
+    res : type_expr; }
+
+let instance_label_abstract env ~scope lbl =
+    let vars, arg, res =
+      instance_label_gen ~fixed:true ~keep_names:true lbl
+    in
+    let env, ids =
+      abstract_poly_vars
+        env (Polymorphic_record_field lbl.lbl_name) ~scope vars
+    in
+    { env; ids; vars; arg; res }
 
 (**** Instantiation with parameter substitution ****)
 
@@ -4910,7 +4979,7 @@ let rec subtype_rec env trace t1 t2 cstrs =
     | (Tpoly (u1, []), Tpoly (u2, [])) ->
         subtype_rec env trace u1 u2 cstrs
     | (Tpoly (u1, tl1), Tpoly (u2, [])) ->
-        let _, u1' = instance_poly ~fixed:false tl1 u1 in
+        let u1' = instance_poly ~keep_names:false tl1 u1 in
         subtype_rec env trace u1' u2 cstrs
     | (Tpoly (u1, tl1), Tpoly (u2,tl2)) ->
         begin try

--- a/typing/ctype.mli
+++ b/typing/ctype.mli
@@ -162,7 +162,7 @@ val check_scope_escape : Env.t -> int -> type_expr -> unit
            to the level [lvl] without any scope escape.
            Raises [Escape] otherwise *)
 
-val instance: ?partial:bool -> type_expr -> type_expr
+val instance: ?partial:bool -> ?keep_names:bool -> type_expr -> type_expr
         (* Take an instance of a type scheme *)
         (* partial=None  -> normal
            partial=false -> newvar() for non generic subterms
@@ -206,14 +206,37 @@ val instance_class:
         type_expr list -> class_type -> type_expr list * class_type
 
 val instance_poly:
-        ?keep_names:bool -> fixed:bool ->
-        type_expr list -> type_expr -> type_expr list * type_expr
+        keep_names:bool -> type_expr list -> type_expr -> type_expr
         (* Take an instance of a type scheme containing free univars *)
+
+type poly_instance =
+  { env : Env.t;
+    ids : (Ident.t * string option) list;
+    vars : type_expr list;
+    ty : type_expr; }
+
+val instance_poly_abstract:
+        Env.t -> scope:int -> binding_name:string option
+        -> type_expr list -> type_expr -> poly_instance
+
+val instance_poly_flexible:
+        Env.t -> type_expr list -> type_expr -> poly_instance
+
 val polyfy: Env.t -> type_expr -> type_expr list -> type_expr * bool
 val instance_label:
-        fixed:bool ->
         label_description -> type_expr list * type_expr * type_expr
         (* Same, for a label *)
+
+type abstract_label_instance =
+  { env : Env.t;
+    ids : (Ident.t * string option) list;
+    vars : type_expr list;
+    arg : type_expr;
+    res : type_expr; }
+
+val instance_label_abstract:
+        Env.t -> scope:int -> label_description -> abstract_label_instance
+
 val apply:
         ?use_current_level:bool ->
         Env.t -> type_expr list -> type_expr -> type_expr list -> type_expr

--- a/typing/printtyp.ml
+++ b/typing/printtyp.ml
@@ -853,43 +853,99 @@ end = struct
         end
     | Pdot _ | Papply _ | Pextra_ty _ -> ()
 
+  let print_explanation kind origin ppf constr out_idents =
+    match out_idents with
+    | [] -> ()
+    | [out_ident] ->
+        fprintf ppf
+          "@ @[<2>@{<hint>Hint@}:@ %a@ is an %s type@ \
+               bound by the %s@ %a.@]"
+              (Style.as_inline_code !Oprint.out_ident) out_ident
+              kind origin
+              Style.inline_code constr
+    | out_ident :: out_idents ->
+        fprintf ppf
+          "@ @[<2>@{<hint>Hint@}:@ %a@ and %a@ are %s types@ \
+           bound by the %s@ %a.@]"
+          (Format.pp_print_list
+             ~pp_sep:(fun ppf () -> fprintf ppf ",@ ")
+             (Style.as_inline_code !Oprint.out_ident))
+          (List.rev out_idents)
+          (Style.as_inline_code !Oprint.out_ident) out_ident
+          kind origin
+          Style.inline_code constr
+
+  let print_anon_explanation kind origin ppf out_idents =
+    match out_idents with
+    | [] -> ()
+    | [out_ident] ->
+        fprintf ppf
+          "@ @[<2>@{<hint>Hint@}:@ %a@ is an %s type@ \
+               bound by a %s.@]"
+              (Style.as_inline_code !Oprint.out_ident) out_ident
+              kind origin
+    | out_ident :: out_idents ->
+        fprintf ppf
+          "@ @[<2>@{<hint>Hint@}:@ %a@ and %a@ are %s types@ \
+           bound by a %s.@]"
+          (Format.pp_print_list
+             ~pp_sep:(fun ppf () -> fprintf ppf ",@ ")
+             (Style.as_inline_code !Oprint.out_ident))
+          (List.rev out_idents)
+          (Style.as_inline_code !Oprint.out_ident) out_ident
+          kind origin
+
   let print_explanations env ppf =
-    let constrs =
+    let ext_constrs, poly_fields, poly_binds, anon_poly_binds =
       Ident.Set.fold
         (fun id acc ->
           let p = Pident id in
           match Env.find_type p env with
           | exception Not_found -> acc
           | decl ->
+              let (ext_constrs, poly_fields, poly_binds, anon_poly_binds) =
+                acc
+              in
               match type_origin decl with
               | Existential constr ->
-                  let prev = String.Map.find_opt constr acc in
-                  let prev = Option.value ~default:[] prev in
-                  String.Map.add constr (tree_of_path None p :: prev) acc
+                  let ext_constrs =
+                    String.Map.add_to_list
+                      constr (tree_of_path None p) ext_constrs
+                  in
+                  (ext_constrs, poly_fields, poly_binds, anon_poly_binds)
+              | Polymorphic_record_field field ->
+                  let poly_fields =
+                    String.Map.add_to_list
+                      field (tree_of_path None p) poly_fields
+                  in
+                  (ext_constrs, poly_fields, poly_binds, anon_poly_binds)
+              | Polymorphic_binding (Some bind) ->
+                  let poly_binds =
+                    String.Map.add_to_list
+                      bind (tree_of_path None p) poly_binds
+                  in
+                  (ext_constrs, poly_fields, poly_binds, anon_poly_binds)
+              | Polymorphic_binding None ->
+                  let anon_poly_binds =
+                    (tree_of_path None p) :: anon_poly_binds
+                  in
+                  (ext_constrs, poly_fields, poly_binds, anon_poly_binds)
+
               | Definition | Rec_check_regularity -> acc)
-        !names String.Map.empty
+        !names
+        (String.Map.empty, String.Map.empty, String.Map.empty, [])
     in
     String.Map.iter
-      (fun constr out_idents ->
-        match out_idents with
-        | [] -> ()
-        | [out_ident] ->
-            fprintf ppf
-              "@ @[<2>@{<hint>Hint@}:@ %a@ is an existential type@ \
-               bound by the constructor@ %a.@]"
-              (Style.as_inline_code !Oprint.out_ident) out_ident
-              Style.inline_code constr
-        | out_ident :: out_idents ->
-            fprintf ppf
-              "@ @[<2>@{<hint>Hint@}:@ %a@ and %a@ are existential types@ \
-               bound by the constructor@ %a.@]"
-              (Format.pp_print_list
-                 ~pp_sep:(fun ppf () -> fprintf ppf ",@ ")
-                 (Style.as_inline_code !Oprint.out_ident))
-              (List.rev out_idents)
-              (Style.as_inline_code !Oprint.out_ident) out_ident
-              Style.inline_code constr)
-      constrs
+      (print_explanation "existential" "constructor" ppf)
+      ext_constrs;
+    String.Map.iter
+      (print_explanation "abstract" "polymorphic record field" ppf)
+      poly_fields;
+    String.Map.iter
+      (print_explanation "abstract" "polymorphic annotation on" ppf)
+      poly_binds;
+    print_anon_explanation "abstract" "polymorphic type annotation"
+      ppf anon_poly_binds
 
 end
 
@@ -2513,7 +2569,8 @@ let warn_on_missing_def env ppf t =
               "@,@[<hov>Type %a was considered abstract@ when checking\
                @ constraints@ in this@ recursive type definition.@]"
               (Style.as_inline_code path) p
-        | Definition | Existential _ -> ()
+        | Definition | Existential _
+          | Polymorphic_record_field _ | Polymorphic_binding _-> ()
       end
   | _ -> ()
 

--- a/typing/typeclass.ml
+++ b/typing/typeclass.ml
@@ -779,7 +779,7 @@ let rec class_field_first_pass self_loc cl_num sign self_scope acc cf =
                    Ctype.unify val_env (Ctype.newty (Tpoly (ty', []))) ty;
                    Ctype.unify val_env (type_approx val_env sbody) ty'
                | Tpoly (ty1, tl) ->
-                   let _, ty1' = Ctype.instance_poly ~fixed:false tl ty1 in
+                   let ty1' = Ctype.instance_poly ~keep_names:false tl ty1 in
                    let ty2 = type_approx val_env sbody in
                    Ctype.unify val_env ty2 ty1'
                | _ -> assert false

--- a/typing/typecore.mli
+++ b/typing/typecore.mli
@@ -55,6 +55,7 @@ type pattern_variable =
     pv_type: type_expr;
     pv_loc: Location.t;
     pv_as_var: bool;
+    pv_uid : Uid.t;
     pv_attributes: Typedtree.attributes;
   }
 

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -528,7 +528,7 @@ let rec check_constraints_rec env loc visited ty =
       end;
       List.iter (check_constraints_rec env loc visited) args
   | Tpoly (ty, tl) ->
-      let _, ty = Ctype.instance_poly ~fixed:false tl ty in
+      let ty = Ctype.instance_poly ~keep_names:false tl ty in
       check_constraints_rec env loc visited ty
   | _ ->
       Btype.iter_type_expr (check_constraints_rec env loc visited) ty
@@ -946,8 +946,7 @@ let check_regularity ~abs_env env loc path decl to_check =
           end;
           List.iter (check_subtype cpath args prev_exp trace ty) args'
       | Tpoly (ty, tl) ->
-          let (_, ty) =
-            Ctype.instance_poly ~keep_names:true ~fixed:false tl ty in
+          let ty = Ctype.instance_poly ~keep_names:true tl ty in
           check_regular cpath args prev_exp trace ty
       | _ ->
           Btype.iter_type_expr

--- a/typing/types.ml
+++ b/typing/types.ml
@@ -259,6 +259,8 @@ and type_origin =
     Definition
   | Rec_check_regularity
   | Existential of string
+  | Polymorphic_record_field of string
+  | Polymorphic_binding of string option
 
 and record_representation =
     Record_regular                      (* All fields are boxed / tagged *)

--- a/typing/types.mli
+++ b/typing/types.mli
@@ -495,6 +495,8 @@ and type_origin =
     Definition
   | Rec_check_regularity       (* See Typedecl.transl_type_decl *)
   | Existential of string
+  | Polymorphic_record_field of string
+  | Polymorphic_binding of string option
 
 and record_representation =
     Record_regular                      (* All fields are boxed / tagged *)


### PR DESCRIPTION
Currently the following code:
```ocaml
type t = { coerce : 'a 'b. ('a, 'b) Type.eq -> 'a -> 'b }

let t = { coerce = fun Equal x -> x }
```
Does not type-check:
```ocaml
type t = { coerce : 'a 'b. ('a, 'b) Type.eq -> 'a -> 'b; }
Line 3, characters 19-35:
3 | let t = { coerce = fun Equal x -> x }
                       ^^^^^^^^^^^^^^^^
Error: This field value has type "'c. ('c, 'c) Type.eq -> 'c -> 'c"
       which is less general than "'a 'b. ('a, 'b) Type.eq -> 'a -> 'b"
```
and so must be explicitly annotated with locally abstact types:
```ocaml
let t = { coerce = fun (type a b) (Equal : (a, b) Type.eq) (x : a) : b -> x }
```

This PR makes fresh abstract types and uses them to stand for the universal variables in expected types. This allows the above example to type without additional annotations. This makes some APIs much more usable, for example the current API for deep effect handlers -- see the updated effect tests.

The same treatment is applied to polymorphic annotations on `let` and methods. For example, this now type-checks:
```ocaml
let coerce : 'a 'b. ('a, 'b) Type.eq -> 'a -> 'b =
  fun Equal x -> x
```

For simplicity, the new abstract treatment is not used for universal row variables.

This PR also extends the mechanism added in #12622 to give improved error messages. For example, this code:
```ocaml
let foo : 'a. bool -> 'a -> 'a =
    fun p x -> if p then x else x + 1
```
previously gave the following error:
```ocaml
Line 2, characters 4-37:
2 |     fun p x -> if p then x else x + 1;;
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Error: This definition has type bool -> int -> int which is less general than
         'a. bool -> 'a -> 'a
```
whereas this PR gives a much more localized error:
```ocaml
Line 2, characters 32-33:
2 |     fun p x -> if p then x else x + 1;;
                                    ^
Error: This expression has type "$a" but an expression was expected of type "int"
       Hint: "$a" is an abstract type bound by the polymorphic annotation on
         "foo".
```
In larger more realistic functions the increased precision of these errors is a real improvement, and I think that the `Hint` sufficiently compensates for the appearance of a fresh abstract type in the message.