### PR TITLE
Fix data races in minor_gc.c and caml_natdynlink_open

### DIFF
--- a/Changes
+++ b/Changes
@@ -703,6 +703,10 @@ Working version
 - #12796, #12801: Fix memory corruption in caml_unix_alloc_sockaddr
   (Thomas Leonard, review by Nicolás Ojeda Bär)
 
+- #12737: Fix data races in minor_gc.c and caml_natdynlink_open
+  (Olivier Nicole, review by Stefan Muenzel, Miod Vallat, Guillaume
+   Munch-Maccagnoni, Gabriel Scherer and Xavier Leroy)
+
 OCaml 5.1.1
 -----------
 

--- a/runtime/dynlink_nat.c
+++ b/runtime/dynlink_nat.c
@@ -82,12 +82,14 @@ CAMLprim value caml_natdynlink_open(value filename, value global)
   void *sym;
   void *dlhandle;
   char_os *p;
+  int global_dup;
 
   /* TODO: dlclose in case of error... */
 
   p = caml_stat_strdup_to_os(String_val(filename));
+  global_dup = Int_val(global);
   caml_enter_blocking_section();
-  dlhandle = caml_dlopen(p, Int_val(global));
+  dlhandle = caml_dlopen(p, global_dup);
   caml_leave_blocking_section();
   caml_stat_free(p);
 

--- a/runtime/minor_gc.c
+++ b/runtime/minor_gc.c
@@ -186,7 +186,6 @@ header_t caml_get_header_val(value v) {
 }
 
 
-CAMLno_tsan /* Disable TSan reports from this function (see #11040) */
 static int try_update_object_header(value v, volatile value *p, value result,
                                     mlsize_t infix_offset) {
   int success = 0;

--- a/runtime/minor_gc.c
+++ b/runtime/minor_gc.c
@@ -234,7 +234,6 @@ static int try_update_object_header(value v, volatile value *p, value result,
 static scanning_action_flags oldify_scanning_flags =
   SCANNING_ONLY_YOUNG_VALUES;
 
-CAMLno_tsan /* Disable TSan reports from this function (see #11040) */
 /* Note that the tests on the tag depend on the fact that Infix_tag,
    Forward_tag, and No_scan_tag are contiguous. */
 static void oldify_one (void* st_v, value v, volatile value *p)
@@ -548,7 +547,11 @@ void caml_empty_minor_heap_promote(caml_domain_state* domain,
 
       for( r = ref_start ; r < foreign_major_ref->ptr && r < ref_end ; r++ )
       {
-        oldify_one (&st, **r, *r);
+        /* Because the work on the remembered set is shared, other threads may
+           attempt to promote the same value; this is fine, but we need the
+           writes and reads (here, `*pr`) to be at least `volatile`. */
+        value_ptr pr = *r;
+        oldify_one (&st, *pr, pr);
         remembered_roots++;
       }
 


### PR DESCRIPTION
This proposes to fix two data races reported in #11040.

The first race happens during minor GC, when promoting the values that are in the remembered set. This is a task done in parallel by all existing domains, with a static work sharing policy, to avoid situations where a domain has much more work to do, e.g. if it continually updates some globals with newly allocated data. In the section of `caml_empty_minor_heap_promote` that performs this task, a thread can read a value

https://github.com/ocaml/ocaml/blob/9b059b1e7a66e9d2f04d892a4de34c418cd96f69/runtime/minor_gc.c#L549
(the problematic operation is the second plain read resulting from `**r`)

… that is being promoted by another thread (through a `volatile` write in `oldify_one`).

https://github.com/ocaml/ocaml/blob/9b059b1e7a66e9d2f04d892a4de34c418cd96f69/runtime/minor_gc.c#L252

It suffices to make the read `volatile` as well: promotion to the major heap can only happen once, so even if the first thread reads an old value, when attempting to promote it `oldify_one` will detect that it has already been done and will simply update the value.

The second race is in `caml_natdynlink_open`: this primitive is accessing one of its `CAMLlocal` variables after calling `caml_enter_blocking_section` (it’s against the rules!) allowing this to happen even during a stop-the-world section. As a result, the GC can concurrently promote the value (by a direct write on the stack). To get rid of the race, one just needs to copy the value (which is cast using `Int_val`) to a local `int`.

This PR is best reviewed commit by commit.

(Edit: the rest of this description no longer applies and was moved to a separate PR: #12746)

~~It also tidies up a few things regarding TSan annotations:~~
-  ~~Initially, we introduced `CAMLreally_no_tsan` as a complement to `CAMLno_tsan`. The idea was that `CAMLno_tsan` should be used to de-instrument functions that we don’t want instrumented with `--enable-tsan`, while `CAMLreally_no_tsan` de-instruments them in all cases, including when, e.g., `-fsanitize=thread` is passed through the `CFLAGS`. However, experience shows that it is vastly more convenient to chase data races in the runtime using `--enable-tsan` than by modifying CFLAGS. As a consequence, `CAMLreally_no_tsan` is not really relevant anymore. I replace the pair `CAMLno_tsan` / `CAMLreally_no_tsan` with `CAMLno_tsan` / `CAMLno_tsan_for_perf`. Functions marked `CAMLno_tsan` are never instrumented, whereas functions marked `CAMLno_tsan_for_perf` are not instrumented to save performance, except when `TSAN_INSTRUMENT_ALL` is defined. Defining `TSAN_INSTRUMENT_ALL` ensure maximum coverage when looking for data races in the runtime.~~
- ~~A number of TSan false positives related to `volatile` writes were removed by the merge of #12681, and we no longer need to silence the corresponding reports.~~
- ~~Outdated TSan silencing annotations are removed, and 2 added, to match the state of the todo-list in #11040.~~