### PR TITLE
Make the unerasable optional argument warning stricter to enforce semantics

### DIFF
--- a/Changes
+++ b/Changes
@@ -475,7 +475,10 @@ Working version
 
 ### Bug fixes:
 
-- #10652, #12720: fix evaluation order in presence of optional arguments
+* #10652, #12720, #12739: fix evaluation order in presence of optional arguments
+  Warning 16 is now stricter, meaning that one may need to modify code in
+  order to ensure that all optional arguments are syntactillay followed by
+  a non-labeled argument in the same n-ary abstraction.
   (Jacques Garrigue, report by Leo White, review by Vincent Laviron)
 
 - #11800, #12707: fix an assertion race condition in `install_backup_thread`

--- a/Changes
+++ b/Changes
@@ -477,7 +477,7 @@ Working version
 
 * #10652, #12720, #12739: fix evaluation order in presence of optional arguments
   Warning 16 is now stricter, meaning that one may need to modify code in
-  order to ensure that all optional arguments are syntactillay followed by
+  order to ensure that all optional arguments are syntactically followed by
   a non-labeled argument in the same n-ary abstraction.
   (Jacques Garrigue, report by Leo White, review by Vincent Laviron)
 

--- a/lambda/translcore.ml
+++ b/lambda/translcore.ml
@@ -644,12 +644,19 @@ and transl_apply ~scopes
      The following code guarantees that:
      * arguments are evaluated right-to-left according to their order in
        the type of the function, before the function is called;
-     * side-effects occurring after receiving a non-optional parameter
+     * side-effects occurring after receiving an unlabeled parameter
        will occur exactly when all the arguments up to this parameter
        have been received;
-     * side-effects occurring after receiving an optional parameter
+     * side-effects occurring after receveing a labeled non-optional
+       parameter, which either is not preceded by any optional parameter,
+       or is not followed by any optional parameter, or is followed by an
+       unlabeled parameter before the next optional parameter, will occur
+       exactly when all the arguments up to this parameter have been received;
+     * side-effects occurring after receiving a labeled or optional parameter
        will occur at the latest when all the arguments up to the first
-       non-optional parameter that follows it have been received.
+       unlabeled parameter that follows it have been received, or when
+       all the received arguments form a prefix of the parameters of the
+       function, without gap.
   *)
   let rec build_apply lam args = function
       (None, optional) :: l ->

--- a/ocamldoc/odoc_html.ml
+++ b/ocamldoc/odoc_html.ml
@@ -1048,7 +1048,7 @@ class html =
     method list_class_types = list_class_types
 
     (** The header of pages. Must be prepared by the [prepare_header] method.*)
-    val mutable header = fun _ -> fun ?nav:_ -> fun ?comments:_ -> fun _ -> ()
+    val mutable header = fun _ ?nav:_ ?comments:_ _ -> ()
 
     (** Init the style. *)
     method init_style =

--- a/parsing/builtin_attributes.ml
+++ b/parsing/builtin_attributes.ml
@@ -277,7 +277,7 @@ let alerts_of_str str = alerts_of_attrs (attrs_of_str str)
 let warn_payload loc txt msg =
   Location.prerr_warning loc (Warnings.Attribute_payload (txt, msg))
 
-let warning_attribute ?(ppwarning = true) =
+let warning_attribute =
   let process loc name errflag payload =
     mark_used name;
     match string_of_payload payload with
@@ -315,7 +315,7 @@ let warning_attribute ?(ppwarning = true) =
             warn_payload loc name.txt "Invalid payload"
           end
   in
-  fun ({attr_name; attr_loc; attr_payload} as attr) ->
+  fun ?(ppwarning = true) ({attr_name; attr_loc; attr_payload} as attr) ->
     if attr_equals_builtin attr "warning" then
       process attr_loc attr_name false attr_payload
     else if attr_equals_builtin attr "warnerror" then

--- a/parsing/location.ml
+++ b/parsing/location.ml
@@ -831,8 +831,8 @@ let report_error ppf err =
 let mkerror loc sub txt =
   { kind = Report_error; main = { loc; txt }; sub }
 
-let errorf ?(loc = none) ?(sub = []) =
-  Format.kdprintf (mkerror loc sub)
+let errorf ?(loc = none) ?(sub = []) fmt =
+  Format.kdprintf (mkerror loc sub) fmt
 
 let error ?(loc = none) ?(sub = []) msg_str =
   mkerror loc sub (fun ppf -> Format.pp_print_string ppf msg_str)
@@ -992,5 +992,5 @@ let () =
       | _ -> None
     )
 
-let raise_errorf ?(loc = none) ?(sub = []) =
-  Format.kdprintf (fun txt -> raise (Error (mkerror loc sub txt)))
+let raise_errorf ?(loc = none) ?(sub = []) fmt =
+  Format.kdprintf (fun txt -> raise (Error (mkerror loc sub txt))) fmt

--- a/testsuite/tests/basic-more/labels_evaluation_order.ml
+++ b/testsuite/tests/basic-more/labels_evaluation_order.ml
@@ -14,3 +14,20 @@ let f = foo ~a:(print_endline "a argument") ~c:(print_endline "c argument")
 let _ = print_endline "f defined"
 
 let _ = f ~b:(print_endline "b argument")
+
+
+let many ?(arg1=print_endline"arg1") ?(arg2=print_endline"arg2")
+  ?(arg3=print_endline"arg3") ?(arg4=print_endline"arg4")
+  ?(arg5=print_endline"arg5") ?(arg6=print_endline"arg6")
+  ?(arg7=print_endline"arg7") ?(arg8=print_endline"arg8")
+  ?(arg9=print_endline"arg9") ?(arg10=print_endline"arg10")
+  ?(arg11=print_endline"arg11") ?(arg12=print_endline"arg12")
+  ?(arg13=print_endline"arg13") ?(arg14=print_endline"arg14")
+  ?(arg15=print_endline"arg15") ?(arg16=print_endline"arg16")
+  ?(arg17=print_endline"arg17") ?(arg18=print_endline"arg18")
+  ?(arg19=print_endline"arg19") ?(arg20=print_endline"arg20") =
+  print_endline "all options"; fun () -> print_endline "all args"
+
+let f = many ~arg10:() ~arg20:()
+let g = f ~arg19:()
+let () = g ()

--- a/testsuite/tests/basic-more/labels_evaluation_order.ml
+++ b/testsuite/tests/basic-more/labels_evaluation_order.ml
@@ -15,7 +15,7 @@ let _ = print_endline "f defined"
 
 let _ = f ~b:(print_endline "b argument")
 
-
+(* Example with many arguments *)
 let many ?(arg1=print_endline"arg1") ?(arg2=print_endline"arg2")
   ?(arg3=print_endline"arg3") ?(arg4=print_endline"arg4")
   ?(arg5=print_endline"arg5") ?(arg6=print_endline"arg6")
@@ -31,3 +31,32 @@ let many ?(arg1=print_endline"arg1") ?(arg2=print_endline"arg2")
 let f = many ~arg10:() ~arg20:()
 let g = f ~arg19:()
 let () = g ()
+
+(* Example of delayed side-effect after labelled non-optional argument *)
+[@@@warning "-unerasable-optional-argument"]
+let foo2 = prerr_endline "foo2";
+  fun ?(a=()) -> print_endline "a";
+  fun ~b:() -> print_endline "b";
+  fun ?(c=()) ?(d=()) () -> print_endline "all"
+
+let f = print_endline "f"; foo2 ~b:()
+let g = print_endline "g"; f ~d:()
+let h = print_endline "h"; g ~a:()
+let i = print_endline "i"; h ()
+
+(* Cannot happen if there is an unlabelled argument before the remaining
+   optional ones *)
+let foo3 = prerr_endline "foo3";
+  fun ?(a=()) -> print_endline "a";
+  fun ~b:() -> print_endline "b";
+  fun () ?(c=()) ?(d=()) () -> print_endline "all"
+
+let f = print_endline "f"; foo3 ~b:()
+let g = print_endline "g"; f ~d:()
+let h = print_endline "h"; g ()
+let i = print_endline "i"; h ()
+
+let e = print_endline "e"; foo3 ()
+let f = print_endline "f"; e ~b:()
+let g = print_endline "g"; f ~d:()
+let h = print_endline "h"; g ()

--- a/testsuite/tests/basic-more/labels_evaluation_order.reference
+++ b/testsuite/tests/basic-more/labels_evaluation_order.reference
@@ -24,3 +24,26 @@ arg17
 arg18
 all options
 all args
+foo2
+f
+g
+h
+i
+a
+b
+all
+foo3
+f
+g
+h
+a
+b
+i
+all
+e
+f
+a
+b
+g
+h
+all

--- a/testsuite/tests/basic-more/labels_evaluation_order.reference
+++ b/testsuite/tests/basic-more/labels_evaluation_order.reference
@@ -5,3 +5,22 @@ b argument
 a parameter
 b parameter
 c parameter
+arg1
+arg2
+arg3
+arg4
+arg5
+arg6
+arg7
+arg8
+arg9
+arg11
+arg12
+arg13
+arg14
+arg15
+arg16
+arg17
+arg18
+all options
+all args

--- a/testsuite/tests/typing-warnings/warning16.ml
+++ b/testsuite/tests/typing-warnings/warning16.ml
@@ -6,7 +6,9 @@ let foo ?x = ()
 Line 1, characters 9-10:
 1 | let foo ?x = ()
              ^
-Warning 16 [unerasable-optional-argument]: this optional argument cannot be erased.
+Warning 16 [unerasable-optional-argument]: this optional argument
+is not followed by an unlabeled argument in the same n-ary abstraction.
+It might not be erasable, and it may cause side-effects to be delayed.
 
 val foo : ?x:'a -> unit = <fun>
 |}]
@@ -16,7 +18,9 @@ let foo ?x ~y = ()
 Line 1, characters 9-10:
 1 | let foo ?x ~y = ()
              ^
-Warning 16 [unerasable-optional-argument]: this optional argument cannot be erased.
+Warning 16 [unerasable-optional-argument]: this optional argument
+is not followed by an unlabeled argument in the same n-ary abstraction.
+It might not be erasable, and it may cause side-effects to be delayed.
 
 val foo : ?x:'a -> y:'b -> unit = <fun>
 |}]
@@ -36,7 +40,9 @@ class bar ?x = object end
 Line 1, characters 11-12:
 1 | class bar ?x = object end
                ^
-Warning 16 [unerasable-optional-argument]: this optional argument cannot be erased.
+Warning 16 [unerasable-optional-argument]: this optional argument
+is not followed by an unlabeled argument in the same n-ary abstraction.
+It might not be erasable, and it may cause side-effects to be delayed.
 
 class bar : ?x:'a -> object  end
 |}]
@@ -46,7 +52,9 @@ class bar ?x ~y = object end
 Line 1, characters 11-12:
 1 | class bar ?x ~y = object end
                ^
-Warning 16 [unerasable-optional-argument]: this optional argument cannot be erased.
+Warning 16 [unerasable-optional-argument]: this optional argument
+is not followed by an unlabeled argument in the same n-ary abstraction.
+It might not be erasable, and it may cause side-effects to be delayed.
 
 class bar : ?x:'a -> y:'b -> object  end
 |}]

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -1561,7 +1561,7 @@ and type_pat_aux
   : type k . type_pat_state -> k pattern_category -> no_existentials:_ ->
          penv:Pattern_env.t -> _ -> _ -> k general_pattern
   = fun tps category ~no_existentials ~penv sp expected_ty ->
-  let type_pat tps category ?(penv=penv) =
+  let type_pat ?(penv=penv) tps category =
     type_pat tps category ~no_existentials ~penv
   in
   let loc = sp.ppat_loc in
@@ -2249,8 +2249,8 @@ let enter_nonsplit_or info =
 
 let rec check_counter_example_pat
     ~info ~(penv : Pattern_env.t) type_pat_state tp expected_ty k =
-  let check_rec ?(info=info) ?(penv=penv) =
-    check_counter_example_pat ~info ~penv type_pat_state in
+  let check_rec ?(info=info) ?(penv=penv) tp =
+    check_counter_example_pat ~info ~penv type_pat_state tp in
   let loc = tp.pat_loc in
   let refine = true in
   let solve_expected (x : pattern) : pattern =

--- a/utils/warnings.ml
+++ b/utils/warnings.ml
@@ -924,7 +924,10 @@ let message = function
   | Implicit_public_methods l ->
       "the following private methods were made public implicitly:\n "
       ^ String.concat " " l ^ "."
-  | Unerasable_optional_argument -> "this optional argument cannot be erased."
+  | Unerasable_optional_argument ->
+    "this optional argument\n\
+    is not followed by an unlabeled argument in the same n-ary abstraction.\n\
+    It might not be erasable, and it may cause side-effects to be delayed."
   | Undeclared_virtual_method m -> "the virtual method "^m^" is not declared."
   | Not_principal s -> s^" is not principal."
   | Non_principal_labels s -> s^" without principality."


### PR DESCRIPTION
As discussed in #10653, the current compilation scheme only preserves the strict-eager semantics of partial application if all optional arguments are followed by an unlabeled one in the same n-ary abstraction.
This PR modifies warning 16 to enforce this.
It will trigger for lablgtk, and maybe some other libraries which make un-orthodox use of optional arguments, but it clarifies the semantics.
Only merge after discussion.