### PR TITLE
Implement maximal delay

### DIFF
--- a/lambda/translcore.ml
+++ b/lambda/translcore.ml
@@ -644,74 +644,48 @@ and transl_apply ~scopes
      The following code guarantees that:
      * arguments are evaluated right-to-left according to their order in
        the type of the function, before the function is called;
-     * side-effects occurring after receiving a non-optional parameter
-       will occur exactly when all the arguments up to this parameter
-       have been received;
-     * side-effects occurring after receiving an optional parameter
-       will occur at the latest when all the arguments up to the first
-       non-optional parameter that follows it have been received.
+     * if there is a gap in the arguments given to the function in a
+       n-ary application, then all side-effects of the function itself
+       are delayed until all the arguments in the gap are given to the
+       function (maximum delay).
   *)
-  let rec build_apply lam args = function
-      (None, optional) :: l ->
-        (* Out-of-order partial application; we will need to build a closure *)
-        let defs = ref [] in
-        let protect name lam =
-          match lam with
-            Lvar _ | Lconst _ -> lam
-          | _ ->
-              let id = Ident.create_local name in
-              defs := (id, lam) :: !defs;
-              Lvar id
-        in
-        (* If all arguments in [args] were optional, delay their application
-           until after this one is received *)
-        let args, args' =
-          if List.for_all (fun (_,opt) -> opt) args then [], args
-          else args, []
-        in
-        let lam =
-          if args = [] then lam else lapply lam (List.rev_map fst args)
-        in
-        (* Evaluate the function, applied to the arguments in [args] *)
-        let handle = protect "func" lam in
-        (* Evaluate the arguments whose applications was delayed;
-           if we already passed here this is a no-op. *)
-        let args' =
-          List.map (fun (arg, opt) -> protect "arg" arg, opt) args'
-        in
-        (* Evaluate the remaining arguments;
-           if we already passed here this is a no-op. *)
-        let l =
-          List.map (fun (arg, opt) -> Option.map (protect "arg") arg, opt) l
-        in
-        let id_arg = Ident.create_local "param" in
-        (* Process remaining arguments and build closure *)
-        let body =
-          match build_apply handle ((Lvar id_arg, optional)::args') l with
-            Lfunction{kind = Curried; params = ids; return; body; attr; loc}
-            when List.length ids < Lambda.max_arity () ->
-              lfunction ~kind:Curried ~params:((id_arg, Pgenval)::ids)
-                        ~return ~body ~attr ~loc
-          | body ->
-              lfunction ~kind:Curried ~params:[id_arg, Pgenval]
-                        ~return:Pgenval ~body
-                        ~attr:default_stub_attribute ~loc
-        in
-        (* Wrap "protected" definitions, starting from the left,
-           so that evaluation is right-to-left. *)
-        List.fold_right
-          (fun (id, lam) body -> Llet(Strict, Pgenval, id, lam, body))
-          !defs body
-    | (Some arg, optional) :: l ->
-        build_apply lam ((arg, optional) :: args) l
-    | [] ->
-        lapply lam (List.rev_map fst args)
+  let args =
+    List.map (fun (_l, x) -> Option.map (transl_exp ~scopes) x) sargs in
+  (* All arguments are contiguous = normal application *)
+  let in_order = List.for_all Option.is_some args in
+  if in_order then lapply lam (List.map Option.get args) else
+  (* Out-of-order partial application; we will need to build a closure *)
+  let defs = ref [] and params = ref [] in
+  let protect name lam =
+    match lam with
+      Lvar _ | Lconst _ -> lam
+    | _ ->
+        let id = Ident.create_local name in
+        defs := (id, lam) :: !defs;
+        Lvar id
+  and mkparam name =
+    let id = Ident.create_local name in
+    params := (id, Pgenval) :: !params;
+    Lvar id
   in
-  (build_apply lam [] (List.map (fun (l, x) ->
-                                   Option.map (transl_exp ~scopes) x,
-                                   Btype.is_optional l)
-                                sargs)
-     : Lambda.lambda)
+  (* Evaluate the function, before building the closure *)
+  let handle = protect "func" lam in
+  (* Evaluate the arguments *)
+  let args =
+    List.map
+      (function None -> mkparam "param" | Some x -> protect "arg" x)
+      args
+  in
+  let body = lapply handle args in
+  let func =
+    lfunction ~kind:Curried ~params:(List.rev !params)
+              ~return:Pgenval ~body ~attr:default_stub_attribute ~loc
+  in
+  (* Wrap "protected" definitions, starting from the left,
+     so that evaluation is right-to-left. *)
+  List.fold_right
+    (fun (id, lam) body -> Llet(Strict, Pgenval, id, lam, body))
+    !defs func
 
 (* There are two cases in function translation:
     - [Tupled]. It takes a tupled argument, and we can flatten it.


### PR DESCRIPTION
Implement maximum delay as described in #10653: side-effects are delayed as long as there is a gap in arguments.