### PR TITLE
Fix assertion failure from #12712

### DIFF
--- a/Changes
+++ b/Changes
@@ -475,6 +475,9 @@ Working version
 
 ### Bug fixes:
 
+- #12712, #12742: fix an assertion boundary case in `caml_reset_young_limit`
+  (Jan Midtgaard, review by Guillaume Munch-Maccagnoni)
+
 - #10652, #12720: fix evaluation order in presence of optional arguments
   (Jacques Garrigue, report by Leo White, review by Vincent Laviron)
 

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -1618,7 +1618,7 @@ void caml_interrupt_all_signal_safe(void)
    races. */
 void caml_reset_young_limit(caml_domain_state * dom_st)
 {
-  CAMLassert ((uintnat)dom_st->young_ptr > (uintnat)dom_st->young_trigger);
+  CAMLassert ((uintnat)dom_st->young_ptr >= (uintnat)dom_st->young_trigger);
   /* An interrupt might have been queued in the meanwhile; the
      atomic_exchange achieves the proper synchronisation with the
      reads that follow (an atomic_store is not enough). */


### PR DESCRIPTION
This little PR fixes the systhreads assertion failure from #12712.

By good old printf-debugging:tm: I found out that the failure happens
on a boundary condition when 4/5 minor heap pointers align:
```
 young_start: 4029677568
 young_limit: 4029677568
 young_trigger: 4029677568
 young_ptr: 4029677568
 young_end: 4029685760
```
Multiple reruns confirmed that the condition is the same (the
addresses naturally vary) every time the assertion fails.

Here's my current understanding:
- The minor heap uses a `young_ptr` bump allocator starting
  from `young_end` and working towards `young_start`.
- `young_trigger` typically marks the mid-point between the two,
  and hitting it triggers a major gc slice.
- Other domains may set `young_limit` to `UINTNAT_MAX` to notify
  a domain (irrelevant in the present systhread test with only 1 domain)

With the above in mind, AFAICS, the above condition may happen when
- a previous `young_ptr` allocation just fit perfectly
- `young_trigger` is set to `young_start` by `caml_poll_gc_work`

This also explains why running with a reduced minor heap
`OCAMLRUNPARAM="s=1024"` helps to reproduce the failure.

The PR simply proposes to adjust the assertion to account for the
boundary condition.

With the fix, the systhread test from #12712 runs fine across 20 iterations.
To confirm it further, I've also locally run
- the ocaml compiler test suite
- the multicoretests test suite both with and without the debug runtime
