### PR TITLE
Use pthread_sigmask instead of sigprocmask

### DIFF
--- a/Changes
+++ b/Changes
@@ -174,6 +174,10 @@ Working version
   (Olivier Nicole, Fabrice Buoro and Anmol Sahoo, review by Luc Maranget,
    Gabriel Scherer, Hernan Ponce de Leon and Xavier Leroy)
 
+- #12743: Use pthread_sigmask instead of sigprocmask
+  Updates usage of sigprocmask to pthread_sigmask in otherlibs/unix.
+  (Max Slater, review by Miod Vallat and Xavier Leroy)
+
 ### Code generation and optimizations:
 
 - #11239: on x86-64 and RISC-V, reduce alignment of OCaml stacks from 16 to 8.

--- a/otherlibs/unix/signals.c
+++ b/otherlibs/unix/signals.c
@@ -63,7 +63,7 @@ CAMLprim value caml_unix_sigprocmask(value vaction, value vset)
   how = sigprocmask_cmd[Int_val(vaction)];
   decode_sigset(vset, &set);
   caml_enter_blocking_section();
-  retcode = sigprocmask(how, &set, &oldset);
+  retcode = pthread_sigmask(how, &set, &oldset);
   caml_leave_blocking_section();
   /* Run any handlers for just-unmasked pending signals */
   caml_process_pending_actions();


### PR DESCRIPTION
Currently `otherlibs/unix/signals.c` uses `sigprocmask`, which has unspecified behavior in a multithreaded process.
It also passes `retcode` to `caml_unix_error` in the error case, but `sigprocmask` sets `errno` instead of returning the error code.

I think this should just be using `pthread_sigmask` instead. Pre-multicore, this line called `caml_sigmask_hook`, which was installed as `pthread_sigmask` when systhreads was in use -- but now the runtime is always multithreaded.