### PR TITLE
`make -C testsuite parallel` always runs tests in subdirs

### DIFF
--- a/Changes
+++ b/Changes
@@ -285,6 +285,9 @@ Working version
   from the upstream website at https://no-color.org.
   (Favonia, review by Gabriel Scherer)
 
+- #12744: ocamltest: run tests in recursive subdirs more eagerly
+  (Nick Roberts, review by Nicolás Ojeda Bär)
+
 ### Manual and documentation:
 
 - #12338: clarification of the documentation of process related function in

--- a/testsuite/Makefile
+++ b/testsuite/Makefile
@@ -266,20 +266,10 @@ one: lib tools
 
 .PHONY: exec-one
 exec-one:
-	@if $(ocamltest) -list-tests $(DIR) >/dev/null 2>&1; then \
-	  echo "Running tests from '$$DIR' ..."; \
-	  $(MAKE) exec-ocamltest DIR=$(DIR) \
+	@$(ocamltest) -find-test-dirs $(DIR) | while IFS='' read -r dir; do \
+	  echo "Running tests from '$$dir' ..."; \
+	  $(MAKE) exec-ocamltest DIR=$$dir \
 	    OCAMLTESTENV="OCAMLTESTDIR=$(OCAMLTESTDIR)"; \
-	fi; \
-	for dir in $(DIR)/*; do \
-	  case "$$dir" in \
-	    */_ocamltest) \
-	      continue \
-	      ;; \
-	  esac; \
-	  if [ -d $$dir ]; then \
-	    $(MAKE) exec-one DIR=$$dir; \
-	  fi; \
 	done
 
 .PHONY: exec-ocamltest

--- a/testsuite/Makefile
+++ b/testsuite/Makefile
@@ -270,13 +270,17 @@ exec-one:
 	  echo "Running tests from '$$DIR' ..."; \
 	  $(MAKE) exec-ocamltest DIR=$(DIR) \
 	    OCAMLTESTENV="OCAMLTESTDIR=$(OCAMLTESTDIR)"; \
-	else \
-	  for dir in $(DIR)/*; do \
-	    if [ -d $$dir ]; then \
-	      $(MAKE) exec-one DIR=$$dir; \
-	    fi; \
-	  done; \
-	fi
+	fi; \
+	for dir in $(DIR)/*; do \
+	  case "$$dir" in \
+	    */_ocamltest) \
+	      continue \
+	      ;; \
+	  esac; \
+	  if [ -d $$dir ]; then \
+	    $(MAKE) exec-one DIR=$$dir; \
+	  fi; \
+	done
 
 .PHONY: exec-ocamltest
 exec-ocamltest:


### PR DESCRIPTION
Make it so `make -C testsuite parallel` runs all tests in all (recursive) subdirectories of `testsuite/tests`. Previously, the test runner wouldn't descend recursively into subdirectories if the parent directory had any tests at all. This meant that one test wasn't being run by `make -C testsuite parallel` and so wasn't being run in CI (e.g. [this recent run](https://github.com/ocaml/ocaml/actions/runs/6703766947/job/18215223866?pr=12706)).

That test: `testsuite/tests/tool-toplevel/known-bugs/broken_rec_in_show.ml`

Prior to this PR, that test would not be run by either of these invocations:
  * `make -C testsuite parallel`
  * `make -C testsuite one DIR=tests/tool-toplevel`

Now, both of those invocations will run that test. You can verify this yourself in the [CI logs](https://github.com/ocaml/ocaml/actions/runs/6870002168/job/18684245198?pr=12744#step:5:3100), or by modifying the test locally and confirming that the error is raised by those invocations.

An alternative approach: moving that test up one level of directory structure. This PR's approach is preventative and helps avoid this mistake in the future.