### PR TITLE
Simplify and clean up TSan annotations

### DIFF
--- a/Changes
+++ b/Changes
@@ -232,6 +232,9 @@ OCaml 5.2.0
 - #12735: Store both ends of the stack chain in continuations
   (Leo White, review by Miod Vallat and KC Sivaramakrishnan)
 
+- #12746: Simplify and clean up TSan annotations
+  (Olivier Nicole, review by Miod Vallat and Fabrice Buoro)
+
 - #12809: Add ThreadSanitizer support to FreeBSD/amd64
   (Miod Vallat, review by Gabriel Scherer)
 

--- a/runtime/caml/mlvalues.h
+++ b/runtime/caml/mlvalues.h
@@ -155,8 +155,7 @@ where 0 <= R <= 31 is HEADER_RESERVED_BITS, set with the
 #define Hd_with_color(hd, color) (((hd) &~ HEADER_COLOR_MASK) | (color))
 
 #define Hp_atomic_val(val) ((atomic_uintnat *)(val) - 1)
-CAMLno_tsan /* Disable TSan instrumentation for performance. */
-Caml_inline header_t Hd_val(value val)
+CAMLno_tsan_for_perf Caml_inline header_t Hd_val(value val)
 {
   return atomic_load_explicit(Hp_atomic_val(val), memory_order_relaxed);
 }

--- a/runtime/caml/tsan.h
+++ b/runtime/caml/tsan.h
@@ -16,42 +16,36 @@
 #define CAML_TSAN_H
 
 /* Macro used to deactivate thread sanitizer on some functions. */
-#define CAMLreally_no_tsan
+#define CAMLno_tsan
 /* __has_feature is Clang-specific, but GCC defines __SANITIZE_ADDRESS__ and
  * __SANITIZE_THREAD__. */
 #if defined(__has_feature)
 #  if __has_feature(thread_sanitizer)
-#    undef CAMLreally_no_tsan
+#    undef CAMLno_tsan
 #    if defined(__has_attribute)
 #      if __has_attribute(disable_sanitizer_instrumentation)
-#        define CAMLreally_no_tsan \
+#        define CAMLno_tsan \
            __attribute__((disable_sanitizer_instrumentation))
 #      else
-#        define CAMLreally_no_tsan __attribute__((no_sanitize("thread")))
+#        define CAMLno_tsan __attribute__((no_sanitize("thread")))
 #      endif
 #    else
-#      define CAMLreally_no_tsan __attribute__((no_sanitize("thread")))
+#      define CAMLno_tsan __attribute__((no_sanitize("thread")))
 #    endif
 #  endif
 #else
 #  if defined(__SANITIZE_THREAD__)
-#    undef CAMLreally_no_tsan
-#    define CAMLreally_no_tsan __attribute__((no_sanitize_thread))
+#    undef CAMLno_tsan
+#    define CAMLno_tsan __attribute__((no_sanitize_thread))
 #  endif
 #endif
 
-/* Macro used to deactivate ThreadSanitizer on some functions, but only in
-   ThreadSanitizer-enabled installations of OCaml. This has two functions:
-   removing some ThreadSanitizer warnings from the runtime in user programs on
-   a switch configured with --enable-tsan, and manually instrumenting some
-   functions, which requires disabling built-in instrumentation (see
-   [caml_modify]). This macro has no effect when OCaml is configured without
-   --enable-tsan, so that compiler developers can still detect bugs in these
-   functions using ThreadSanitizer. */
-#define CAMLno_tsan
-#if defined(WITH_THREAD_SANITIZER)
-#  undef CAMLno_tsan
-#  define CAMLno_tsan CAMLreally_no_tsan
+/* Macro used to un-instrument some functions of the runtime for performance
+   reasons, except if TSAN_INSTRUMENT_ALL is set. */
+#if defined(TSAN_INSTRUMENT_ALL)
+#  define CAMLno_tsan_for_perf
+#else
+#  define CAMLno_tsan_for_perf CAMLno_tsan
 #endif
 
 

--- a/runtime/fiber.c
+++ b/runtime/fiber.c
@@ -67,8 +67,6 @@ uintnat caml_get_init_stack_wsize (void)
   return stack_wsize;
 }
 
-
-CAMLno_tsan /* Disable TSan reports from this function (see #11040) */
 void caml_change_max_stack_size (uintnat new_max_wsize)
 {
   struct stack_info *current_stack = Caml_state->current_stack;

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -980,7 +980,10 @@ static void mark_slice_darken(struct mark_stack* stk, value child,
   }
 }
 
-static Caml_noinline CAMLno_tsan
+static CAMLno_tsan
+#if defined(WITH_THREAD_SANITIZER)
+Caml_noinline
+#endif
 value volatile_load_uninstrumented(volatile value* p) {
   return *p;
 }

--- a/runtime/memory.c
+++ b/runtime/memory.c
@@ -292,9 +292,9 @@ CAMLexport void caml_adjust_minor_gc_speed (mlsize_t res, mlsize_t max)
 
    [caml_initialize] never calls the GC, so you may call it while a block is
    unfinished (i.e. just after a call to [caml_alloc_shr].) */
-CAMLreally_no_tsan /* Avoid instrumenting initializing writes with TSan: they
-                      should never cause data races (albeit for reasons outside
-                      of the C11 memory model). */
+CAMLno_tsan /* Avoid instrumenting initializing writes with TSan: they should
+               never cause data races (albeit for reasons outside of the C11
+               memory model). */
 CAMLexport CAMLweakdef void caml_initialize (volatile value *fp, value val)
 {
 #ifdef DEBUG

--- a/runtime/minor_gc.c
+++ b/runtime/minor_gc.c
@@ -171,7 +171,7 @@ static void spin_on_header(value v) {
   }
 }
 
-CAMLno_tsan /* Disable TSan instrumentation for performance. */
+CAMLno_tsan_for_perf
 Caml_inline header_t get_header_val(value v) {
   header_t hd = atomic_load_acquire(Hp_atomic_val(v));
   if (!Is_update_in_progress(hd))
@@ -382,7 +382,7 @@ static void oldify_one (void* st_v, value v, volatile value *p)
    Note that [oldify_one] itself is called by oldify_mopup, so we
    have to be careful to remove the first entry from the list before
    oldifying its fields. */
-CAMLno_tsan /* Disable TSan instrumentation for performance. */
+CAMLno_tsan_for_perf
 static void oldify_mopup (struct oldify_state* st, int do_ephemerons)
 {
   value v, new_v, f;

--- a/runtime/misc.c
+++ b/runtime/misc.c
@@ -281,10 +281,6 @@ void caml_bad_caml_state(void)
    contains a frame matching one of the lines starting with "race:". */
 const char * __tsan_default_suppressions(void) {
   return "deadlock:caml_plat_lock\n" /* Avoids deadlock inversion messages */
-         "deadlock:pthread_mutex_lock\n" /* idem */
-         "race:create_domain\n"
-         "race:mark_slice_darken\n"
-         "race:caml_darken_cont\n"
-         "race:caml_shared_try_alloc\n";
+         "deadlock:pthread_mutex_lock\n"; /* idem */
 }
 #endif /* WITH_THREAD_SANITIZER */

--- a/runtime/shared_heap.c
+++ b/runtime/shared_heap.c
@@ -531,7 +531,6 @@ static intnat pool_sweep(struct caml_heap_state* local, pool** plist,
   return work;
 }
 
-CAMLno_tsan /* Disable TSan reports from this function (see #11040) */
 static intnat large_alloc_sweep(struct caml_heap_state* local) {
   value* p;
   header_t hd;

--- a/runtime/shared_heap.c
+++ b/runtime/shared_heap.c
@@ -253,6 +253,7 @@ static void calc_pool_stats(pool* a, sizeclass sz, struct heap_stats* s)
 }
 
 /* Initialize a pool and its object freelist */
+CAMLno_tsan  /* Disable TSan reports from this function (see #11040) */
 Caml_inline void pool_initialize(pool* r,
                                  sizeclass sz,
                                  caml_domain_state* owner)
@@ -425,6 +426,7 @@ static void* large_allocate(struct caml_heap_state* local, mlsize_t sz) {
   return (char*)a + LARGE_ALLOC_HEADER_SZ;
 }
 
+CAMLno_tsan /* Disable TSan reports from this function (see #11040) */
 value* caml_shared_try_alloc(struct caml_heap_state* local, mlsize_t wosize,
                              tag_t tag, reserved_t reserved)
 {

--- a/runtime/shared_heap.c
+++ b/runtime/shared_heap.c
@@ -286,7 +286,7 @@ Caml_inline void pool_initialize(pool* r,
 }
 
 /* Allocating an object from a pool */
-CAMLno_tsan /* Disable TSan instrumentation for performance. */
+CAMLno_tsan_for_perf
 static intnat pool_sweep(struct caml_heap_state* local,
                          pool**,
                          sizeclass sz ,

--- a/runtime/str.c
+++ b/runtime/str.c
@@ -268,7 +268,9 @@ CAMLprim value caml_bytes_set64(value str, value index, value newval)
   return Val_unit;
 }
 
-CAMLno_tsan /* Disable TSan instrumentation for performance. */
+CAMLno_tsan_for_perf /* This attribute needs to stay on its own line for this
+                        function to be detected as a primitive by the build
+                        system. */
 CAMLprim value caml_string_equal(value s1, value s2)
 {
   mlsize_t sz1, sz2;

--- a/runtime/tsan.c
+++ b/runtime/tsan.c
@@ -327,7 +327,7 @@ void caml_tsan_exit_on_perform(uintnat pc, char* sp)
    of iteration.
    - [pc] is the program counter where `caml_perform` was called.
    - [sp] is the stack pointer at the perform point. */
-CAMLreally_no_tsan void caml_tsan_entry_on_resume(uintnat pc, char* sp,
+CAMLno_tsan void caml_tsan_entry_on_resume(uintnat pc, char* sp,
     struct stack_info const* stack)
 {
   caml_frame_descrs fds = caml_get_frame_descrs();
@@ -373,7 +373,7 @@ extern uint##bitsize##_t __tsan_atomic##bitsize##_load(void*, int);            \
 extern uint##bitsize##_t __tsan_atomic##bitsize##_fetch_add(                   \
     volatile void*, uint##bitsize##_t, memory_order);                          \
                                                                                \
-CAMLreally_no_tsan void __tsan_volatile_read##size(void *ptr)                  \
+CAMLno_tsan void __tsan_volatile_read##size(void *ptr)                         \
 {                                                                              \
   const bool is_atomic = size <= sizeof(long long) && is_aligned(ptr, 8);      \
   if (is_atomic)                                                               \
@@ -381,11 +381,11 @@ CAMLreally_no_tsan void __tsan_volatile_read##size(void *ptr)                  \
   else                                                                         \
     __tsan_read##size(ptr);                                                    \
 }                                                                              \
-CAMLreally_no_tsan void __tsan_unaligned_volatile_read##size(void *ptr)        \
+CAMLno_tsan void __tsan_unaligned_volatile_read##size(void *ptr)               \
 {                                                                              \
   __tsan_volatile_read##size(ptr);                                             \
 }                                                                              \
-CAMLreally_no_tsan void __tsan_volatile_write##size(void *ptr)                 \
+CAMLno_tsan void __tsan_volatile_write##size(void *ptr)                        \
 {                                                                              \
   const bool is_atomic = size <= sizeof(long long) && is_aligned(ptr, 8);      \
   if (is_atomic) {                                                             \
@@ -396,7 +396,7 @@ CAMLreally_no_tsan void __tsan_volatile_write##size(void *ptr)                 \
   } else                                                                       \
     __tsan_write##size(ptr);                                                   \
 }                                                                              \
-CAMLreally_no_tsan void __tsan_unaligned_volatile_write##size(void *ptr)       \
+CAMLno_tsan void __tsan_unaligned_volatile_write##size(void *ptr)              \
 {                                                                              \
   __tsan_volatile_write##size(ptr);                                            \
 }
@@ -416,19 +416,19 @@ DEFINE_TSAN_VOLATILE_READ_WRITE(8, 64);
 extern void __tsan_read16(void*);
 extern void __tsan_write16(void*);
 
-CAMLreally_no_tsan void __tsan_volatile_read16(void *ptr)
+CAMLno_tsan void __tsan_volatile_read16(void *ptr)
 {
     __tsan_read16(ptr);
 }
-CAMLreally_no_tsan void __tsan_unaligned_volatile_read16(void *ptr)
+CAMLno_tsan void __tsan_unaligned_volatile_read16(void *ptr)
 {
   __tsan_read16(ptr);
 }
-CAMLreally_no_tsan void __tsan_volatile_write16(void *ptr)
+CAMLno_tsan void __tsan_volatile_write16(void *ptr)
 {
     __tsan_write16(ptr);
 }
-CAMLreally_no_tsan void __tsan_unaligned_volatile_write16(void *ptr)
+CAMLno_tsan void __tsan_unaligned_volatile_write16(void *ptr)
 {
   __tsan_write16(ptr);
 }

--- a/runtime/weak.c
+++ b/runtime/weak.c
@@ -180,14 +180,6 @@ static void clean_field (value e, mlsize_t offset)
     do_check_key_clean(e, offset);
 }
 
-CAMLno_tsan /* This function performs volatile writes, which we consider to be
-               non-racy, but TSan reports data races, so we never instrument it
-               with TSan. Refer to section 3.2 of comment in tsan.c. */
-#if defined(WITH_THREAD_SANITIZER)
-Caml_noinline /* Unfortunately, Clang disregards the no_tsan attribute on
-                 inlined functions, so we prevent inlining of this one when
-                 tsan is enabled. */
-#endif
 static void do_set (value e, mlsize_t offset, value v)
 {
   if (Is_block(v) && Is_young(v)) {

--- a/runtime/weak.c
+++ b/runtime/weak.c
@@ -180,9 +180,9 @@ static void clean_field (value e, mlsize_t offset)
     do_check_key_clean(e, offset);
 }
 
-CAMLreally_no_tsan /* This function performs volatile writes, which we consider
-                      to be non-racy, but TSan reports data races, so we never
-                      instrument it with TSan. */
+CAMLno_tsan /* This function performs volatile writes, which we consider to be
+               non-racy, but TSan reports data races, so we never instrument it
+               with TSan. Refer to section 3.2 of comment in tsan.c. */
 #if defined(WITH_THREAD_SANITIZER)
 Caml_noinline /* Unfortunately, Clang disregards the no_tsan attribute on
                  inlined functions, so we prevent inlining of this one when

--- a/tools/ci/inria/sanitizers/script
+++ b/tools/ci/inria/sanitizers/script
@@ -121,6 +121,7 @@ git clean -q -f -d -x
 ./configure \
   CC=clang-14 \
   --enable-tsan \
+  CFLAGS="-DTSAN_INSTRUMENT_ALL" \
   --disable-stdlib-manpages --enable-dependency-generation
 
 # Build the system


### PR DESCRIPTION
While working on removing the last known data races in the runtime, I had to update a number of TSan-related annotations in the code. The two primary reasons are that #12681 made some of them redundant, and that the distinction between `CAMLno_tsan` and `CAMLreally_no_tsan` is confusing and—as I discovered—not really useful in practice.

This PR is a collection of arguably independent commits, but on the other hand all of them are very small.

This PR is best reviewed commit by commit:

-  Initially, we introduced `CAMLreally_no_tsan` as a complement to `CAMLno_tsan`. The idea was that `CAMLno_tsan` should be used to de-instrument functions that we don’t want instrumented with `--enable-tsan`, while `CAMLreally_no_tsan` de-instruments them in all cases, including when, e.g., `-fsanitize=thread` is passed through the `CFLAGS`. However, experience shows that it is vastly more convenient to chase data races in the runtime using `--enable-tsan` than by modifying CFLAGS. As a consequence, `CAMLreally_no_tsan` is not really relevant anymore. I replace the pair `CAMLno_tsan` / `CAMLreally_no_tsan` with `CAMLno_tsan` / `CAMLno_tsan_for_perf`. Functions marked `CAMLno_tsan` are never instrumented, whereas functions marked `CAMLno_tsan_for_perf` are not instrumented to save performance, except when `TSAN_INSTRUMENT_ALL` is defined. Defining `TSAN_INSTRUMENT_ALL` ensure maximum coverage when looking for data races in the runtime.
As a consequence, I update the Inria TSan CI to define `TSAN_INSTRUMENT_ALL`.
- A number of TSan false positives related to `volatile` writes were removed by the merge of #12681, and we no longer need to silence the corresponding reports.
- For maximum coverage, rather than marking the whole `do_some_marking` function with `CAMLno_tsan`, I un-instrumented only the instruction that could cause a false positive.
- I removed TSan annotations on functions on which I can no longer trigger data race reports.
- On the other hand, some functions started to cause data races reports again—they probably were previously silenced indirectly by the silencing directives in `__tsan_default_suppressions`. All of them races are already known (#11040). I added two `CAMLno_tsan` annotations to silence those reports until we fixed those races, so that they don’t clog the CI logs.