### PR TITLE
Iterate over all persistent modules in `Env.iter_env`

### DIFF
--- a/typing/env.ml
+++ b/typing/env.ml
@@ -1511,13 +1511,12 @@ let iter_env wrap proj1 proj2 f env () =
        | Mod_unbound _ -> ()
        | Mod_local data ->
            iter_components (Pident id) path data.mda_components
-       | Mod_persistent ->
-           let modname = Ident.name id in
-           match Persistent_env.find_in_cache !persistent_env modname with
-           | None -> ()
-           | Some data ->
-               iter_components (Pident id) path data.mda_components)
-    env.modules
+       | Mod_persistent -> ())
+    env.modules;
+  Persistent_env.fold !persistent_env (fun name data () ->
+    let id = Ident.create_persistent name in
+    let path = Pident id in
+    iter_components path path data.mda_components) ()
 
 let run_iter_cont l =
   iter_env_cont := [];


### PR DESCRIPTION
From ocaml-flambda/flambda-backend#1962.

Currently, `Env.iter_env` doesn't involve `Persistent_env` unless something in the `Env.t` is bound to a persistent module. This risks missing possibilities for path shortening, since most persistent modules are only stored in `Persistent_env`.