### PR TITLE
Add curry/uncurry functions to the Fun module

### DIFF
--- a/Changes
+++ b/Changes
@@ -278,6 +278,9 @@ Working version
 - #12784: Fix computation of minor-heap allocation in Gc.counters()
   and Gc.allocated_bytes(). (Nick Barnes, review by Gabriel Scherer)
 
+- #12749: Add `Fun.curry` and `Fun.uncurry` for 2-9 tuples.
+  (Justin Frank, review by ...)
+
 ### Other libraries:
 
 - #12213: Dynlink library, improve legibility of error messages

--- a/stdlib/fun.ml
+++ b/stdlib/fun.ml
@@ -18,6 +18,27 @@ let const c _ = c
 let flip f x y = f y x
 let negate p v = not (p v)
 
+let curry2 f x y = f (x, y)
+let curry3 f x y z = f (x, y, z)
+let curry4 f x y z w = f (x, y, z, w)
+let curry5 f x y z w a = f (x, y, z, w, a)
+let curry6 f x y z w a b = f (x, y, z, w, a, b)
+let curry7 f x y z w a b c = f (x, y, z, w, a, b, c)
+let curry8 f x y z w a b c d = f (x, y, z, w, a, b, c, d)
+let curry9 f x y z w a b c d e = f (x, y, z, w, a, b, c, d, e)
+
+let uncurry2 f (x, y) = f x y
+let uncurry3 f (x, y, z) = f x y z
+let uncurry4 f (x, y, z, w) = f x y z w
+let uncurry5 f (x, y, z, w, a) = f x y z w a
+let uncurry6 f (x, y, z, w, a, b) = f x y z w a b
+let uncurry7 f (x, y, z, w, a, b, c) = f x y z w a b c
+let uncurry8 f (x, y, z, w, a, b, c, d) = f x y z w a b c d
+let uncurry9 f (x, y, z, w, a, b, c, d, e) = f x y z w a b c d e
+
+let curry = curry2
+let uncurry = uncurry2
+
 exception Finally_raised of exn
 
 let () = Printexc.register_printer @@ function

--- a/stdlib/fun.mli
+++ b/stdlib/fun.mli
@@ -43,7 +43,10 @@ val curry7 : ('a * 'b * 'c * 'd * 'e * 'f * 'g -> 'h) -> 'a -> 'b -> 'c -> 'd ->
 val curry8 : ('a * 'b * 'c * 'd * 'e * 'f * 'g * 'h -> 'i) -> 'a -> 'b -> 'c -> 'd -> 'e -> 'f -> 'g -> 'h -> 'i
 val curry9 : ('a * 'b * 'c * 'd * 'e * 'f * 'g * 'h * 'i -> 'j) -> 'a -> 'b -> 'c -> 'd -> 'e -> 'f -> 'g -> 'h -> 'i -> 'j
 (** [curryN f] is a function that takes N arguments one at a time
-    and calls [f] with them packaged as an N-tuple. *)
+    and calls [f] with them packaged as an N-tuple.
+    For any arguments [f], [x], and [y], [curry2 f x y] is [f (x, y)].
+
+    @since 5.2 *)
 
 val uncurry2 : ('a -> 'b -> 'c) -> 'a * 'b -> 'c
 val uncurry3 : ('a -> 'b -> 'c -> 'd) -> 'a * 'b * 'c -> 'd
@@ -54,13 +57,20 @@ val uncurry7 : ('a -> 'b -> 'c -> 'd -> 'e -> 'f -> 'g -> 'h) -> 'a * 'b * 'c * 
 val uncurry8 : ('a -> 'b -> 'c -> 'd -> 'e -> 'f -> 'g -> 'h -> 'i) -> 'a * 'b * 'c * 'd * 'e * 'f * 'g * 'h -> 'i
 val uncurry9 : ('a -> 'b -> 'c -> 'd -> 'e -> 'f -> 'g -> 'h -> 'i -> 'j) -> 'a * 'b * 'c * 'd * 'e * 'f * 'g * 'h * 'i -> 'j
 (** [uncurryN f] is a function that takes an N-tuple and calls [f]
-    with those arguments one at a time. *)
+    with those arguments one at a time.
+    For any arguments [f], [x], and [y], [uncurry2 f (x, y)] is [f x y].
+
+    @since 5.2 *)
 
 val curry : ('a * 'b -> 'c) -> 'a -> 'b -> 'c
-(** Synonym for [curry2]. *)
+(** Synonym for [curry2].
+
+    @since 5.2 *)
 
 val uncurry : ('a -> 'b -> 'c) -> 'a * 'b -> 'c
-(** Synonym for [uncurry2]. *)
+(** Synonym for [uncurry2].
+
+    @since 5.2 *)
 
 (** {1:exception Exception handling} *)
 

--- a/stdlib/fun.mli
+++ b/stdlib/fun.mli
@@ -34,6 +34,34 @@ val negate : ('a -> bool) -> ('a -> bool)
 (** [negate p] is the negation of the predicate function [p]. For any
     argument [x], [(negate p) x] is [not (p x)]. *)
 
+val curry2 : ('a * 'b -> 'c) -> 'a -> 'b -> 'c
+val curry3 : ('a * 'b * 'c -> 'd) -> 'a -> 'b -> 'c -> 'd
+val curry4 : ('a * 'b * 'c * 'd -> 'e) -> 'a -> 'b -> 'c -> 'd -> 'e
+val curry5 : ('a * 'b * 'c * 'd * 'e -> 'f) -> 'a -> 'b -> 'c -> 'd -> 'e -> 'f
+val curry6 : ('a * 'b * 'c * 'd * 'e * 'f -> 'g) -> 'a -> 'b -> 'c -> 'd -> 'e -> 'f -> 'g
+val curry7 : ('a * 'b * 'c * 'd * 'e * 'f * 'g -> 'h) -> 'a -> 'b -> 'c -> 'd -> 'e -> 'f -> 'g -> 'h
+val curry8 : ('a * 'b * 'c * 'd * 'e * 'f * 'g * 'h -> 'i) -> 'a -> 'b -> 'c -> 'd -> 'e -> 'f -> 'g -> 'h -> 'i
+val curry9 : ('a * 'b * 'c * 'd * 'e * 'f * 'g * 'h * 'i -> 'j) -> 'a -> 'b -> 'c -> 'd -> 'e -> 'f -> 'g -> 'h -> 'i -> 'j
+(** [curryN f] is a function that takes N arguments one at a time
+    and calls [f] with them packaged as an N-tuple. *)
+
+val uncurry2 : ('a -> 'b -> 'c) -> 'a * 'b -> 'c
+val uncurry3 : ('a -> 'b -> 'c -> 'd) -> 'a * 'b * 'c -> 'd
+val uncurry4 : ('a -> 'b -> 'c -> 'd -> 'e) -> 'a * 'b * 'c * 'd -> 'e
+val uncurry5 : ('a -> 'b -> 'c -> 'd -> 'e -> 'f) -> 'a * 'b * 'c * 'd * 'e -> 'f
+val uncurry6 : ('a -> 'b -> 'c -> 'd -> 'e -> 'f -> 'g) -> 'a * 'b * 'c * 'd * 'e * 'f -> 'g
+val uncurry7 : ('a -> 'b -> 'c -> 'd -> 'e -> 'f -> 'g -> 'h) -> 'a * 'b * 'c * 'd * 'e * 'f * 'g -> 'h
+val uncurry8 : ('a -> 'b -> 'c -> 'd -> 'e -> 'f -> 'g -> 'h -> 'i) -> 'a * 'b * 'c * 'd * 'e * 'f * 'g * 'h -> 'i
+val uncurry9 : ('a -> 'b -> 'c -> 'd -> 'e -> 'f -> 'g -> 'h -> 'i -> 'j) -> 'a * 'b * 'c * 'd * 'e * 'f * 'g * 'h * 'i -> 'j
+(** [uncurryN f] is a function that takes an N-tuple and calls [f]
+    with those arguments one at a time. *)
+
+val curry : ('a * 'b -> 'c) -> 'a -> 'b -> 'c
+(** Synonym for [curry2]. *)
+
+val uncurry : ('a -> 'b -> 'c) -> 'a * 'b -> 'c
+(** Synonym for [uncurry2]. *)
+
 (** {1:exception Exception handling} *)
 
 val protect : finally:(unit -> unit) -> (unit -> 'a) -> 'a

--- a/testsuite/tests/backtrace/backtrace_dynlink.flambda.reference
+++ b/testsuite/tests/backtrace/backtrace_dynlink.flambda.reference
@@ -5,7 +5,7 @@ Called from Dynlink.Native.run in file "native/dynlink.ml", line 82, characters 
 Called from Dynlink_common.Make.load.(fun) in file "dynlink_common.ml", line 358, characters 11-54
 Called from Stdlib__List.iter in file "list.ml" (inlined), line 112, characters 12-15
 Called from Dynlink_common.Make.load.(fun) in file "dynlink_common.ml" (inlined), line 354, characters 6-372
-Called from Stdlib__Fun.protect in file "fun.ml" (inlined), line 33, characters 8-15
+Called from Stdlib__Fun.protect in file "fun.ml" (inlined), line 54, characters 8-15
 Called from Dynlink_common.Make.load in file "dynlink_common.ml", line 347, characters 4-662
 Called from Dynlink_common.Make.loadfile in file "dynlink_common.ml" (inlined), line 366, characters 26-45
 Called from Backtrace_dynlink in file "backtrace_dynlink.ml", line 39, characters 4-52
@@ -17,9 +17,9 @@ Called from Dynlink.Native.run in file "native/dynlink.ml", line 82, characters 
 Called from Dynlink_common.Make.load.(fun) in file "dynlink_common.ml", line 358, characters 11-54
 Called from Stdlib__List.iter in file "list.ml" (inlined), line 112, characters 12-15
 Called from Dynlink_common.Make.load.(fun) in file "dynlink_common.ml" (inlined), line 354, characters 6-372
-Called from Stdlib__Fun.protect in file "fun.ml" (inlined), line 33, characters 8-15
+Called from Stdlib__Fun.protect in file "fun.ml" (inlined), line 54, characters 8-15
 Called from Dynlink_common.Make.load in file "dynlink_common.ml", line 347, characters 4-662
-Re-raised at Stdlib__Fun.protect in file "fun.ml" (inlined), line 38, characters 6-52
+Re-raised at Stdlib__Fun.protect in file "fun.ml" (inlined), line 59, characters 6-52
 Called from Dynlink_common.Make.load in file "dynlink_common.ml", line 347, characters 4-662
 Called from Dynlink_common.Make.loadfile in file "dynlink_common.ml" (inlined), line 366, characters 26-45
 Called from Backtrace_dynlink in file "backtrace_dynlink.ml", line 39, characters 4-52

--- a/testsuite/tests/backtrace/backtrace_dynlink.reference
+++ b/testsuite/tests/backtrace/backtrace_dynlink.reference
@@ -3,7 +3,7 @@ Called from Dynlink.Native.run.(fun) in file "native/dynlink.ml", line 83, chara
 Called from Stdlib__List.iter in file "list.ml", line 112, characters 12-15
 Called from Dynlink_common.Make.load.(fun) in file "dynlink_common.ml", line 358, characters 11-54
 Called from Stdlib__List.iter in file "list.ml", line 112, characters 12-15
-Called from Stdlib__Fun.protect in file "fun.ml", line 33, characters 8-15
+Called from Stdlib__Fun.protect in file "fun.ml", line 54, characters 8-15
 Called from Dynlink_common.Make.loadfile in file "dynlink_common.ml" (inlined), line 366, characters 26-45
 Called from Backtrace_dynlink in file "backtrace_dynlink.ml", line 39, characters 4-52
 execution of module initializers in the shared library failed: Failure("SUCCESS")
@@ -12,7 +12,7 @@ Re-raised at Dynlink.Native.run.(fun) in file "native/dynlink.ml", line 85, char
 Called from Stdlib__List.iter in file "list.ml", line 112, characters 12-15
 Called from Dynlink_common.Make.load.(fun) in file "dynlink_common.ml", line 358, characters 11-54
 Called from Stdlib__List.iter in file "list.ml", line 112, characters 12-15
-Called from Stdlib__Fun.protect in file "fun.ml", line 33, characters 8-15
-Re-raised at Stdlib__Fun.protect in file "fun.ml", line 38, characters 6-52
+Called from Stdlib__Fun.protect in file "fun.ml", line 54, characters 8-15
+Re-raised at Stdlib__Fun.protect in file "fun.ml", line 59, characters 6-52
 Called from Dynlink_common.Make.loadfile in file "dynlink_common.ml" (inlined), line 366, characters 26-45
 Called from Backtrace_dynlink in file "backtrace_dynlink.ml", line 39, characters 4-52

--- a/testsuite/tests/lib-dynlink-initializers/test10_main.byte.reference
+++ b/testsuite/tests/lib-dynlink-initializers/test10_main.byte.reference
@@ -7,6 +7,6 @@ Called from Dynlink.Bytecode.run in file "byte/dynlink.ml", line 152, characters
 Re-raised at Dynlink.Bytecode.run in file "byte/dynlink.ml", line 154, characters 6-137
 Called from Dynlink_common.Make.load.(fun) in file "dynlink_common.ml", line 358, characters 11-54
 Called from Stdlib__List.iter in file "list.ml", line 112, characters 12-15
-Called from Stdlib__Fun.protect in file "fun.ml", line 33, characters 8-15
-Re-raised at Stdlib__Fun.protect in file "fun.ml", line 38, characters 6-52
+Called from Stdlib__Fun.protect in file "fun.ml", line 54, characters 8-15
+Re-raised at Stdlib__Fun.protect in file "fun.ml", line 59, characters 6-52
 Called from Test10_main in file "test10_main.ml", line 51, characters 13-69

--- a/testsuite/tests/lib-dynlink-initializers/test10_main.native.reference
+++ b/testsuite/tests/lib-dynlink-initializers/test10_main.native.reference
@@ -4,7 +4,7 @@ Re-raised at Dynlink.Native.run.(fun) in file "native/dynlink.ml", line 85, char
 Called from Stdlib__List.iter in file "list.ml", line 112, characters 12-15
 Called from Dynlink_common.Make.load.(fun) in file "dynlink_common.ml", line 358, characters 11-54
 Called from Stdlib__List.iter in file "list.ml", line 112, characters 12-15
-Called from Stdlib__Fun.protect in file "fun.ml", line 33, characters 8-15
-Re-raised at Stdlib__Fun.protect in file "fun.ml", line 38, characters 6-52
+Called from Stdlib__Fun.protect in file "fun.ml", line 54, characters 8-15
+Re-raised at Stdlib__Fun.protect in file "fun.ml", line 59, characters 6-52
 Called from Dynlink_common.Make.loadfile in file "dynlink_common.ml" (inlined), line 366, characters 26-45
 Called from Test10_main in file "test10_main.ml", line 49, characters 30-87


### PR DESCRIPTION
Adds curry/uncurry function combinators to the Fun module. I included functions for up to 9-tuples, with `curry` and `uncurry` being synonyms for the 2-tuple versions.