### PR TITLE
Display primitives retrieval command in `ocamlc -verbose`

### DIFF
--- a/Changes
+++ b/Changes
@@ -370,6 +370,10 @@ Working version
   invalid module type substitutions.
   (Stefan Muenzel, review by Gabriel Scherer and Florian Angeletti)
 
+- #12750: Display the command executed to extract primitives in
+  `ocamlc -verbose`.
+  (David Allsopp, review by Nicolás Ojeda Bär)
+
 ### Internal/compiler-libs changes:
 
 - #12639: parsing: Attach a location to the RHS of Ptyp_alias

--- a/bytecomp/symtable.ml
+++ b/bytecomp/symtable.ml
@@ -256,6 +256,8 @@ let init () =
              ~stdout:primfile
              ["-p"]
          in
+         if !Clflags.verbose then
+           Printf.eprintf "+ %s\n%!" cmd;
          if Sys.command cmd <> 0
          then raise(Error(Wrong_vm !Clflags.use_runtime));
          set_prim_table_from_file primfile


### PR DESCRIPTION
`-verbose` is supposed to display all the external commands run by the compiler, but it didn't show the command used to extract the primitives when `-use-runtime` is given. Now:

```console
dra@thor:~/ocaml-14$ ./ocamlc.opt -verbose -o hello -I stdlib -use-runtime runtime/ocamlrun hello.ml
+ 'runtime/ocamlrun' '-p' >'/tmp/camlprims0ddd96'
```

Not the most major patch in history. I briefly debated doing something with `Ccomp.command`, but a dependency between `Symtable` and `Ccomp` is not great, and it seemed quite a lot of API effort for the sake of one `Printf.eprintf`.