### PR TITLE
Scan runtime/*.c for primitives less often

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1251,17 +1251,8 @@ runtime/ld.conf: $(ROOTDIR)/Makefile.config
 	$(V_GEN)echo "$(STUBLIBDIR)" > $@ && \
 	echo "$(LIBDIR)" >> $@
 
-PRIMITIVES_NEW := runtime/primitives$(shell echo "$$PPID").new
-
-# To speed up builds, we avoid changing "primitives" when files
-# containing primitives change but the primitives table does not
-runtime/primitives: runtime/gen_primitives.sh \
-  $(shell runtime/gen_primitives.sh $(runtime_BYTECODE_C_SOURCES) \
-                    > $(PRIMITIVES_NEW); \
-                    { cmp -s runtime/primitives $(PRIMITIVES_NEW) && \
-                        rm -f $(PRIMITIVES_NEW) ; } || \
-                    echo $(runtime_BYTECODE_C_SOURCES))
-	$(V_GEN)mv $(PRIMITIVES_NEW) $@
+runtime/primitives: runtime/gen_primitives.sh $(runtime_BYTECODE_C_SOURCES)
+	$(V_GEN)runtime/gen_primitives.sh $@ $(runtime_BYTECODE_C_SOURCES)
 
 runtime/prims.c: runtime/gen_primsc.sh runtime/primitives
 	$(V_GEN)runtime/gen_primsc.sh \

--- a/runtime/dune
+++ b/runtime/dune
@@ -26,7 +26,7 @@
    dynlink.c backtrace_byt.c backtrace.c afl.c bigarray.c prng.c)
  (action
    (progn
-     (with-stdout-to primitives (run %{dep:gen_primitives.sh} %{deps}))
+     (run %{dep:gen_primitives.sh} primitives %{deps})
      (with-stdout-to prims.c (run %{dep:gen_primsc.sh} primitives %{deps})))))
 
 (rule

--- a/runtime/gen_primitives.sh
+++ b/runtime/gen_primitives.sh
@@ -39,5 +39,21 @@
 
 export LC_ALL=C
 
+case $# in
+  0) echo "Usage: gen_primitives.sh <primitives file> <.c files>" 1>&2
+     exit 2;;
+  *) primitives="$1"; shift;;
+esac
+
+tmp_primitives="$primitives.tmp$$"
+
 sed -n -e 's/^CAMLprim value \([a-z][a-z0-9_]*\).*$/\1/p' "$@" | \
-sort | uniq
+sort | uniq > "$tmp_primitives"
+
+# To speed up builds, we avoid changing "primitives" when files
+# containing primitives change but the primitives table does not
+
+if test -f "$primitives" && cmp -s "$tmp_primitives" "$primitives"
+then rm "$tmp_primitives"
+else mv "$tmp_primitives" "$primitives"
+fi


### PR DESCRIPTION
This is a follow-up to #12731 by @dra27 and more specifically to my comment https://github.com/ocaml/ocaml/pull/12731#issuecomment-1812028662 .  @shindere challenged me to submit a PR about this.  Here is my proposal:

- If runtime/primitives is more recent than $(runtime_BYTECODE_C_SOURCES), there's no need to rescan these sources with the gen_primitive.sh script.

- Otherwise, we keep the current behavior: the C sources are systematically rescanned, but runtime/primitives keeps its modification date in the past if its contents are unchanged, avoiding further recompilations.

As a side benefit (?), the "move if changed" machinery is moved from the top Makefile to runtime/gen_primitives.sh, reducing Makefile clutter.