### PR TITLE
Fix data race on global pools arrays of `pool_freelist`

### DIFF
--- a/Changes
+++ b/Changes
@@ -614,6 +614,9 @@ Working version
 - #12727, #12730: fix bug with value let-rec and labelled applications
   (Vincent Laviron, review by Gabriel Scherer)
 
+- #12755: Fix data race on global pools arrays of pool_freelist
+  (Fabrice Buoro and Olivier Nicole, review by Gabriel Scherer)
+
 OCaml 5.1.1
 -----------
 

--- a/runtime/shared_heap.c
+++ b/runtime/shared_heap.c
@@ -79,8 +79,8 @@ static struct {
   CAML_PLAT_MUTEX_INITIALIZER,
   NULL,
   { 0, },
-  { 0, },
-  { 0, },
+  { NULL, },
+  { NULL, },
   NULL
 };
 

--- a/runtime/shared_heap.c
+++ b/runtime/shared_heap.c
@@ -300,8 +300,8 @@ static pool* pool_global_adopt(struct caml_heap_state* local, sizeclass sz)
   int adopted_pool = 0;
 
   /* probably no available pools out there to be had */
-  if( !atomic_load_acquire(&pool_freelist.global_avail_pools[sz]) &&
-      !atomic_load_acquire(&pool_freelist.global_full_pools[sz]) )
+  if( !atomic_load_relaxed(&pool_freelist.global_avail_pools[sz]) &&
+      !atomic_load_relaxed(&pool_freelist.global_full_pools[sz]) )
     return NULL;
 
   /* Haven't managed to find a pool locally, try the global ones */


### PR DESCRIPTION
This PR, a joint work with @OlivierNicole, addresses data races on `global_avail_pools` and `global_full_pools` members of the `struct pool_freelist` in `shared_heap.c`.

Domains can access the `global_(avail|full)_pools` arrays in parallel while trying to adopt a pool with `pool_global_adopt`, so these arrays must be made of atomic pointers.
Since the `pool_freelist` struct is not exposed outside of the runtime, the choice was made to use a proper `_Atomic` qualifier rather than a `volatile` one. The downside is that read and write accesses have to be done through the `atomic_(load|store)_relaxed` functions to not cause more synchronisation than intended, which makes the code a bit more verbose.