### PR TITLE
Fix ocamlnat by registering frametables correctly

### DIFF
--- a/Changes
+++ b/Changes
@@ -634,6 +634,10 @@ OCaml 5.1.1
   to correctly handle nested packs
   (Vincent Laviron, report by Javier Chávarri, review by Pierre Chambart)
 
+- #12757: Fix ocamlnat (native toplevel) by registering frametables correctly
+  (Stephen Dolan, Nick Barnes and Mark Shinwell,
+   review by Vincent Laviron and Sébastien Hinderer)
+
 OCaml 5.1.0 (14 September 2023)
 -------------------------------
 

--- a/runtime/dynlink_nat.c
+++ b/runtime/dynlink_nat.c
@@ -174,7 +174,7 @@ CAMLprim value caml_natdynlink_run(value handle_v, value symbol) {
 CAMLprim value caml_natdynlink_run_toplevel(value filename, value symbol)
 {
   CAMLparam2 (filename, symbol);
-  CAMLlocal3 (res, v, handle_v);
+  CAMLlocal4 (res, v, handle_v, symbols);
   void *handle;
   char_os *p;
 
@@ -192,10 +192,16 @@ CAMLprim value caml_natdynlink_run_toplevel(value filename, value symbol)
     Store_field(res, 0, v);
   } else {
     handle_v = Val_handle(handle);
+
+    symbols = caml_alloc_small(1, 0);
+    Field(symbols, 0) = symbol;
+    (void) caml_natdynlink_register(handle_v, symbols);
+
     res = caml_alloc(1,0);
     v = caml_natdynlink_run(handle_v, symbol);
     Store_field(res, 0, v);
   }
+
   CAMLreturn(res);
 }
 

--- a/testsuite/tests/tool-toplevel/topeval.ml
+++ b/testsuite/tests/tool-toplevel/topeval.ml
@@ -55,3 +55,13 @@ external foo : int -> int -> int = "%addint"
 module S = String
 let x = 42
 ;;
+
+(* Check that frametables are correctly loaded by triggering GC *)
+let () =
+  Gc.minor ();
+  let r = List.init 1000 Sys.opaque_identity in
+  Gc.minor ();
+  let _ = Sys.opaque_identity (List.init 1000 (fun _ -> "!")) in
+  List.iteri (fun i j -> assert (i = j)) r;
+  ()
+;;


### PR DESCRIPTION
Yesterday, @NickBarnes and I (and independently, @mshinwell) noticed that #11935 introduced a bug that breaks `ocamlnat`, the native toplevel.

#11935 modifies Dynlink to separate registering frametables from running initialisers, so that frametables can be registered in batch. However, ocamlnat has a separate entrypoint into Dynlink which was not updated, meaning that frametables are not registered at all.

This completely broke ocamlnat: anything which triggers GC segfaults at the toplevel. It is surprising that CI passed at all, but it turns out ocamlnat was only tested with very short programs that do not trigger GC. (This patch also adds a test that does GC)