### PR TITLE
Fix testsuite operation on Windows

### DIFF
--- a/testsuite/Makefile
+++ b/testsuite/Makefile
@@ -266,7 +266,8 @@ one: lib tools
 
 .PHONY: exec-one
 exec-one:
-	@$(ocamltest) -find-test-dirs $(DIR) | while IFS='' read -r dir; do \
+	@IFS=$$(printf "\r\n"); \
+	$(ocamltest) -find-test-dirs $(DIR) | while IFS='' read -r dir; do \
 	  echo "Running tests from '$$dir' ..."; \
 	  $(MAKE) exec-ocamltest DIR=$$dir \
 	    OCAMLTESTENV="OCAMLTESTDIR=$(OCAMLTESTDIR)"; \

--- a/testsuite/Makefile
+++ b/testsuite/Makefile
@@ -55,8 +55,18 @@ ifeq "$(UNIX_OR_WIN32)" "unix"
   else # Non-cygwin Unix
     find := find
   endif
+  # $(IFS_LINE) for Unix simply clears IFS, so entire lines are read
+  IFS_LINE = IFS=''
 else # Windows
   find := /usr/bin/find
+	# On Windows, ocamltest will produce Windows line-endings (\r\n) and the final
+	# \r is kept by the shell. This can either be stripped with tr -d '\r' but we
+	# can avoid the additional process by instead setting IFS in the while loop to
+	# be the CR character (i.e. treat \r as a field delimiter).
+	# The dance with $(CR_CHAR) is because POSIX doesn't provide a way to write \r
+	# in a string.
+  export CR_CHAR := $(shell printf "\r")
+  IFS_LINE = IFS="$$CR_CHAR"
 endif
 
 ifeq "$(ocamltest_program)" ""
@@ -151,10 +161,9 @@ all:
 .PHONY: new-without-report
 new-without-report: lib tools
 	@rm -f $(failstamp)
-	@(IFS=$$(printf "\r\n"); \
-	$(ocamltest) -find-test-dirs tests | while IFS='' read -r dir; do \
+	@($(ocamltest) -find-test-dirs tests | while $(IFS_LINE) read -r dir; do \
 	  echo Running tests from \'$$dir\' ... ; \
-	  $(MAKE) exec-ocamltest DIR=$$dir \
+	  $(MAKE) exec-ocamltest DIR="$$dir" \
 	    OCAMLTESTENV=""; \
 	done || echo outer loop >> $(failstamp)) 2>&1 | tee $(TESTLOG)
 	@$(MAKE) check-failstamp
@@ -266,10 +275,9 @@ one: lib tools
 
 .PHONY: exec-one
 exec-one:
-	@IFS=$$(printf "\r\n"); \
-	$(ocamltest) -find-test-dirs $(DIR) | while IFS='' read -r dir; do \
+	@$(ocamltest) -find-test-dirs $(DIR) | while $(IFS_LINE) read -r dir; do \
 	  echo "Running tests from '$$dir' ..."; \
-	  $(MAKE) exec-ocamltest DIR=$$dir \
+	  $(MAKE) exec-ocamltest DIR="$$dir" \
 	    OCAMLTESTENV="OCAMLTESTDIR=$(OCAMLTESTDIR)"; \
 	done
 
@@ -277,10 +285,9 @@ exec-one:
 exec-ocamltest:
 	@if [ -z "$(DIR)" ]; then exit 1; fi
 	@if [ ! -d "$(DIR)" ]; then exit 1; fi
-	@(IFS=$$(printf "\r\n"); \
-	$(ocamltest) -list-tests $(DIR) | while IFS='' read -r testfile; do \
+	@($(ocamltest) -list-tests $(DIR) | while $(IFS_LINE) read -r testfile; do \
 	   TERM=dumb $(OCAMLTESTENV) \
-	     $(ocamltest) $(OCAMLTESTFLAGS) $(DIR)/$$testfile || \
+	     $(ocamltest) $(OCAMLTESTFLAGS) "$(DIR)/$$testfile" || \
 	   echo " ... testing '$$testfile' => unexpected error"; \
 	done) || echo directory "$(DIR)" >>$(failstamp)
 

--- a/testsuite/summarize.awk
+++ b/testsuite/summarize.awk
@@ -134,6 +134,10 @@ function record_unexp() {
     record_unexp();
 }
 
+/make[^:]*: \*\*\* \[[^]]*\] Error/ {
+    errored = 1;
+}
+
 END {
     if (in_test) record_unexp();
 


### PR DESCRIPTION
#12744 has accidentally broken the testsuite on Windows. Yes, I'm afraid you read that correctly. At present, Jenkins is reporting:

```
Summary:
    0 tests passed
    0 tests skipped
    0 tests failed
    0 tests not started (parent test skipped or failed)
    0 unexpected errors
    0 tests considered
```

and you can see a smaller version of the problem [on AppVeyor](https://ci.appveyor.com/project/avsm/ocaml/builds/48531134?fullLog=true#L3087) where the `parallel-lib-dynlink` test is failing:

```
-=-=- test dynlink mingw64 -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
make: Entering directory '/cygdrive/c/projects/🐫реализация-mingw64/testsuite'
  OCAMLYACC parsecmm.mli
  OCAMLLEX lexcmm.ml
' ...
make[2]: *** [Makefile:278: exec-ocamltest] Error 1
make[1]: *** [Makefile:269: exec-one] Error 2
' ...
make[2]: *** [Makefile:278: exec-ocamltest] Error 1
make[1]: *** [Makefile:269: exec-one] Error 2
' ...
make[2]: *** [Makefile:278: exec-ocamltest] Error 1
make[1]: *** [Makefile:269: exec-one] Error 2
' ...
make[2]: *** [Makefile:278: exec-ocamltest] Error 1
make[1]: *** [Makefile:269: exec-one] Error 2
' ...
make[2]: *** [Makefile:278: exec-ocamltest] Error 1
make[1]: *** [Makefile:269: exec-one] Error 2
' ...
make[2]: *** [Makefile:278: exec-ocamltest] Error 1
make[1]: *** [Makefile:269: exec-one] Error 2
' ...
make[2]: *** [Makefile:278: exec-ocamltest] Error 1
make[1]: *** [Makefile:269: exec-one] Error 2
' ...
make[2]: *** [Makefile:278: exec-ocamltest] Error 1
make[1]: *** [Makefile:269: exec-one] Error 2
' ...
make[2]: *** [Makefile:278: exec-ocamltest] Error 1
make[1]: *** [Makefile:269: exec-one] Error 2
' ...
make[2]: *** [Makefile:278: exec-ocamltest] Error 1
make[1]: *** [Makefile:269: exec-one] Error 2
' ...
make[2]: *** [Makefile:278: exec-ocamltest] Error 1
make[1]: *** [Makefile:269: exec-one] Error 2
' ...
make[2]: *** [Makefile:278: exec-ocamltest] Error 1
make[1]: *** [Makefile:269: exec-one] Error 2
make[1]: Entering directory '/cygdrive/c/projects/🐫реализация-mingw64/testsuite'
List of directories returning no results:
    tests/lib-dynlink-packed
    tests/lib-dynlink-init-info
    tests/lib-dynlink-pr4839
    tests/lib-dynlink-bytecode
    tests/lib-dynlink-initializers
    tests/lib-dynlink-pr6950
    tests/lib-dynlink-pr9209
    tests/lib-dynlink-native
    tests/lib-dynlink-domains
    tests/lib-dynlink-pr4229
    tests/lib-dynlink-private
    tests/lib-dynlink-csharp
Summary:
    0 tests passed
    0 tests skipped
    0 tests failed
    0 tests not started (parent test skipped or failed)
    0 unexpected errors
    0 tests considered
make[1]: Leaving directory '/cygdrive/c/projects/🐫реализация-mingw64/testsuite'
```

It's not all bad news - `make all` is still working, which fortunately is what AppVeyor does for the _main_ testsuite runs, so PRs have been testing something.

This PR does three things:
1. A tiny change to `summarize.awk` to turn the present state into a catchable error. All kinds of errors in tests themselves (including a complete failure to run tests) were caught before, but there was nothing to catch a failure of the testing system itself.
2. A simple fix for the original fault.
3. A better fix for the CRLF handling, which as a bonus means the testsuite runs in MSYS2 properly (which it didn't even prior to #12744).

The fundamental problem is dealing with Windows line endings coming out of `ocamltest` - the trailing `\r` is preserved by the shell. The previous trick, due - I think - to @shindere, was to set IFS="\r\n" in the subshells. This wasn't done in #12744 for the new case, and the simple fix is just to copy the extra `IFS` line. However, it's a really nefarious shell trick, and it doesn't work 100% correctly:

```
DRA@Thor /cygdrive/c/Devel/ocaml-11/testsuite
$ make parallel-lib-dynlink-bytecode
' ...ng tests from 'tests/lib-dynlink-bytecode
 ... testing 'main.ml' with line 5 (shared-libraries) => passed
```
as the "Running tests from " line gets mangled by a CR character. FWIW the approach would also fail if we ever included a directory with a space in it in the testsuite. The third commit contains both comments and a commit message to explain an alternate use of `IFS` _in the while loop_ to control this. As it happens, I had already noticed (but not actually debugged) that this original trick was not working at all when running the testsuite in MSYS2. I can't convince myself as to why, but the new trick is rather more POSIX-like, slightly less nefarious (reading whole lines in `while` loops is a tricky but well-known shell puzzle), and works on both MSYS2 and Cygwin.

I realise we would like both not to be using Awk to process the log and also not to be relying on so much Shell and make code for the outer testsuite infrastructure, but may I ask that we leave that conversation for another day and focus on getting the testsuite running again in CI for today? 🙂