### PR TITLE
Update `msvs-promote-path` to upstream's 0.6.0

### DIFF
--- a/tools/msvs-promote-path
+++ b/tools/msvs-promote-path
@@ -4,6 +4,7 @@
 #*                                 OCaml                                  *
 #*                                                                        *
 #*                David Allsopp, MetaStack Solutions Ltd.                 *
+#*                           Samuel Hym, Tarides                          *
 #*                                                                        *
 #*   Copyright 2015 MetaStack Solutions Ltd.                              *
 #*                                                                        *
@@ -13,39 +14,34 @@
 #*                                                                        *
 #**************************************************************************
 
-# Ensure that the Microsoft Linker isn't being messed up by /usr/bin/link
-if [ "`link --version | head -1 | \
-     fgrep "Microsoft (R) Incremental Linker"`" != "" ] ; then
+# Ensure that the Microsoft Linker isn't being shadowed by /usr/bin/link
+# We expect the Microsoft Linker to be in the same directory as the C compiler
+
+if ! clpath="$(command -v cl)" ; then
+  echo "The Microsoft C compiler was not found in any of the PATH entries!">&2
+  exit 1
+fi
+clpath="${clpath%/*}"
+
+if ! linkpath="$(command -v link)" ; then
+  echo "The Microsoft Linker was not found in any of the PATH entries!">&2
+  exit 1
+fi
+
+if [ "${linkpath%/*}" = "$clpath" ]; then
   echo "link already refers to the Microsoft Linker">&2
   exit 0
 fi
 
+NEWPATH="$clpath"
 IFS=:
-T=
-FOUND=0
-FIRST=1
 for i in $PATH
 do
-  if [ $FIRST -eq 1 ] ; then
-    T="$i"
-    FIRST=0
-  else
-    if [ $FOUND -eq 0 -a -x $i/link ] && [ "`$i/link --version | head -1 | \
-                       fgrep "Microsoft (R) Incremental Linker"`" != "" ] ; then
-      FOUND=1
-      T="$i:$T"
-      PROM=$i
-    else
-      T="$T:$i"
-    fi
+  if [[ $i != $clpath ]]; then
+    NEWPATH="$NEWPATH:$i"
   fi
 done
 unset IFS
 
-if [ $FOUND -eq 0 ] ; then
-  echo The Microsoft Linker was not found in any of the PATH entries!>&2
-  exit 1
-else
-  echo "$PROM moved to the front of \$PATH">&2
-  echo export PATH=\"$T\"
-fi
+echo "$clpath moved to the front of \$PATH">&2
+echo "export PATH='"${NEWPATH//\'/\'\"\'\"\'}"'"


### PR DESCRIPTION
The `msvs-promote-path` script is recommended in the Windows README as a way to update the `PATH` when using the Microsoft Linker.

Our vendored copy of the script hasn't been updated in a while - this brings it up to the 0.6.0 release and includes a fix from me, some shell discipline from @MisterDA and a glorious simplification from @shym!

I'm opening this on trunk and separately from the MSVC restoration PRs because it should be cherry-picked to 4.14.

This doesn't need "reviewing" per se, as it's a vendored script, but the original PR is at metastack/msvs-tools#14 and bug reports are very much welcomed there!