### PR TITLE
docs: clarify behavior of Unix.write on closed fds

### DIFF
--- a/Changes
+++ b/Changes
@@ -314,6 +314,10 @@ Working version
 
 ### Manual and documentation:
 
+- #12762: clarification of the behavior of `Unix.write` on closed file
+  descriptors and how to handle `SIGPIPE` in those cases.
+  (Leandro Ostera, reviewed by ...)
+
 - #12338: clarification of the documentation of process related function in
   the unix module regarding the first element of args and shell's pid.
   (Christophe Raffalli, review by Florian Angeletti)

--- a/otherlibs/unix/unix.mli
+++ b/otherlibs/unix/unix.mli
@@ -395,7 +395,15 @@ val write : file_descr -> bytes -> int -> int -> int
     taking them from byte sequence [buf], starting at position [pos]
     in [buff]. Return the number of bytes actually written.  [write]
     repeats the writing operation until all bytes have been written or
-    an error occurs.  *)
+    an error occurs.
+
+    If the descriptor [fd] corresponds to a pipe whose other end is closed, or
+    to a socket whose other end was shut down, a [SIGPIPE] signal will be sent
+    to the running program. This will by default terminate the program. To
+    avoid this and instead have [write fd buf pos len] raise a [EPIPE] error,
+    consider marking this signal as ignored with:
+
+      [Sys.(set_signal sigpipe Signal_ignore)] *)
 
 val write_bigarray :
   file_descr ->

--- a/otherlibs/unix/unixLabels.mli
+++ b/otherlibs/unix/unixLabels.mli
@@ -395,7 +395,15 @@ val write : file_descr -> buf:bytes -> pos:int -> len:int -> int
     taking them from byte sequence [buf], starting at position [pos]
     in [buff]. Return the number of bytes actually written.  [write]
     repeats the writing operation until all bytes have been written or
-    an error occurs.  *)
+    an error occurs.
+
+    If the descriptor [fd] corresponds to a pipe whose other end is closed, or
+    to a socket whose other end was shut down, a [SIGPIPE] signal will be sent
+    to the running program. This will by default terminate the program. To
+    avoid this and instead have [write fd buf pos len] raise a [EPIPE] error,
+    consider marking this signal as ignored with:
+
+      [Sys.(set_signal sigpipe Signal_ignore)] *)
 
 val write_bigarray :
   file_descr ->


### PR DESCRIPTION
Hi folks 👋🏼 – just wasted a serious amount of time on this, and @stedolan was kind enough to point out what the fix was.

I figured clarifying how `Unix.write` behaves regarding closed sockets would be useful for the next person relying on it.

Happy to reword/rewrite anything here, just let me know :)

/ Leandro