### PR TITLE
Fix summary computation in ocamltest

### DIFF
--- a/ocamltest/main.ml
+++ b/ocamltest/main.ml
@@ -143,7 +143,7 @@ let rec run_test_tree log common_prefix behavior env summ ast =
     let newast = Ast (stmts, subs) in
     run_test_tree log common_prefix children_behavior newenv newsumm newast
   | Ast ([], subs) ->
-    List.fold_left join_summaries All_skipped
+    List.fold_left join_summaries summ
       (List.map (run_test_tree log common_prefix behavior env All_skipped) subs)
 
 let get_test_source_directory test_dirname =


### PR DESCRIPTION
A tiny regression from #12243. Independently, ~~Both~~,  @xavierleroy, @NickBarnes and I noticed today that ocamltest wasn't keeping test directories when tests failed.

The summary will have always been `All_skipped` before - the side-effects of that were:
- Logs not displayed on error
- Test directories always deleted, regardless of error
- Timings not displayed for slow-tests

(none of which are serious - the statuses of the tests themselves were reported correctly!)