### PR TITLE
Improvements to `$ocaml_cv_cc_vendor` in configure

### DIFF
--- a/Changes
+++ b/Changes
@@ -542,6 +542,10 @@ Working version
   (Sébastien Hinderer, review by Antonin Décimo, David Allsopp and Florian
   Angeletti)
 
+- #12768: Detect mingw-w64 coupling with GCC or LLVM, detect clang-cl,
+  and fix C compiler feature detection on macOS.
+  (Antonin Décimo, review by Miod Vallat and Sébastien Hinderer)
+
 ### Bug fixes:
 
 - # 12791: `extern` is applied to definitions of `caml_builtin_cprim`

--- a/aclocal.m4
+++ b/aclocal.m4
@@ -49,6 +49,14 @@ AC_DEFUN([OCAML_CC_VENDOR], [
 msvc _MSC_VER
 #elif defined(__INTEL_COMPILER)
 icc __INTEL_COMPILER
+#elif defined(__MINGW32__)
+#include <_mingw_mac.h>
+mingw32 __MINGW64_VERSION_MAJOR __MINGW64_VERSION_MINOR
+# if defined(__clang_major__) && defined(__clang_minor__)
+  clang __clang_major__ __clang_minor__
+# elif defined(__GNUC__) && defined(__GNUC_MINOR__)
+  gcc __GNUC__ __GNUC_MINOR__
+# endif
 #elif defined(__clang_major__) && defined(__clang_minor__)
 clang __clang_major__ __clang_minor__
 #elif defined(__GNUC__) && defined(__GNUC_MINOR__)
@@ -62,8 +70,8 @@ unknown
 #endif]
     )],
     [AC_CACHE_VAL([ocaml_cv_cc_vendor],
-      [ocaml_cv_cc_vendor=`grep ['^[a-z]'] conftest.i | tr -s ' ' '-' \
-                                                      | tr -d '\r'`])],
+      [ocaml_cv_cc_vendor=`sed -e '/^#/d' conftest.i | tr -s '[:space:]' '-' \
+                             | sed -e 's/^-//' -e 's/-$//'`])],
     [AC_MSG_FAILURE([unexpected preprocessor failure])])
   AC_MSG_RESULT([$ocaml_cv_cc_vendor])
 ])

--- a/aclocal.m4
+++ b/aclocal.m4
@@ -45,7 +45,9 @@ AC_DEFUN([OCAML_CC_VENDOR], [
   AC_MSG_CHECKING([C compiler vendor])
   AC_PREPROC_IFELSE(
     [AC_LANG_SOURCE([
-#if defined(_MSC_VER)
+#if defined(_MSC_VER) && defined(__clang_major__) && defined(__clang_minor__)
+msvc _MSC_VER clang __clang_major__ __clang_minor__
+#elif defined(_MSC_VER)
 msvc _MSC_VER
 #elif defined(__INTEL_COMPILER)
 icc __INTEL_COMPILER

--- a/configure
+++ b/configure
@@ -13558,6 +13558,14 @@ printf %s "checking C compiler vendor... " >&6; }
 msvc _MSC_VER
 #elif defined(__INTEL_COMPILER)
 icc __INTEL_COMPILER
+#elif defined(__MINGW32__)
+#include <_mingw_mac.h>
+mingw32 __MINGW64_VERSION_MAJOR __MINGW64_VERSION_MINOR
+# if defined(__clang_major__) && defined(__clang_minor__)
+  clang __clang_major__ __clang_minor__
+# elif defined(__GNUC__) && defined(__GNUC_MINOR__)
+  gcc __GNUC__ __GNUC_MINOR__
+# endif
 #elif defined(__clang_major__) && defined(__clang_minor__)
 clang __clang_major__ __clang_minor__
 #elif defined(__GNUC__) && defined(__GNUC_MINOR__)
@@ -13577,8 +13585,8 @@ then :
 then :
   printf %s "(cached) " >&6
 else $as_nop
-  ocaml_cv_cc_vendor=`grep '^[a-z]' conftest.i | tr -s ' ' '-' \
-                                                      | tr -d '\r'`
+  ocaml_cv_cc_vendor=`sed -e '/^#/d' conftest.i | tr -s '[:space:]' '-' \
+                             | sed -e 's/^-//' -e 's/-$//'`
 fi
 
 else $as_nop
@@ -13876,44 +13884,31 @@ esac
 # Concerning optimization level, -O3 is somewhat risky, so take -O2.
 # Concerning language version, recent enough versions of GCC and Clang
 # default to gnu11 (C11 + GNU extensions) or gnu17, which is fine.
-
-# Note: the vendor macro can not recognize MinGW because it calls the
-# C preprocessor directly so no compiler specific macro like __MING32__
-# is defined. We thus catch MinGW first by looking at host and examine
-# the vendor only as a fall-back. We could put tis part of the logic
-# in the macro itself, too
-case $host in #(
-  *-*-mingw32*) :
-    case $ocaml_cv_cc_vendor in #(
-  gcc-[01234]-*) :
-    as_fn_error $? "This version of MinGW-w64 GCC is too old. Please use GCC version 5 or above." "$LINENO" 5 ;; #(
-  gcc-*) :
-    internal_cflags="-Wno-unused $cc_warnings \
--fexcess-precision=standard"
-        # TODO: see whether the code can be fixed to avoid -Wno-unused
-        common_cflags="-O2 -fno-strict-aliasing -fwrapv -mms-bitfields"
-        internal_cppflags='-D__USE_MINGW_ANSI_STDIO=0 -DUNICODE -D_UNICODE'
-        internal_cppflags="$internal_cppflags -DWINDOWS_UNICODE="
-        internal_cppflags="${internal_cppflags}\$(WINDOWS_UNICODE)" ;; #(
-  *) :
-    as_fn_error $? "Unsupported C compiler for a MinGW-w64 build" "$LINENO" 5 ;;
-esac ;; #(
-  *) :
-    case $ocaml_cv_cc_vendor in #(
+case $ocaml_cv_cc_vendor in #(
   clang-*) :
     common_cflags="-O2 -fno-strict-aliasing -fwrapv";
-      internal_cflags="$cc_warnings -fno-common" ;; #(
-  gcc-[0123]-*|gcc-4-[0-8]) :
+    internal_cflags="$cc_warnings -fno-common" ;; #(
+  *gcc-[0123]-*|*gcc-4-[0-8]) :
     # No C11 support
-      as_fn_error 69 "This version of GCC is too old. Please use GCC version 4.9 or above." "$LINENO" 5 ;; #(
+    as_fn_error 69 "This version of GCC is too old. Please use GCC version 4.9 or above." "$LINENO" 5 ;; #(
   gcc-*) :
     common_cflags="-O2 -fno-strict-aliasing -fwrapv";
-      internal_cflags="$cc_warnings -fno-common -fexcess-precision=standard \
+    internal_cflags="$cc_warnings -fno-common -fexcess-precision=standard \
 -Wvla" ;; #(
+  mingw32-*-*-gcc-*) :
+    internal_cflags="-Wno-unused $cc_warnings \
+-fexcess-precision=standard"
+    # TODO: see whether the code can be fixed to avoid -Wno-unused
+    common_cflags="-O2 -fno-strict-aliasing -fwrapv -mms-bitfields"
+    internal_cppflags='-D__USE_MINGW_ANSI_STDIO=0 -DUNICODE -D_UNICODE'
+    internal_cppflags="$internal_cppflags -DWINDOWS_UNICODE="
+    internal_cppflags="${internal_cppflags}\$(WINDOWS_UNICODE)" ;; #(
+  mingw32-*) :
+    as_fn_error $? "Unsupported C compiler for a MinGW-w64 build" "$LINENO" 5 ;; #(
   msvc-*) :
     common_cflags="-nologo -O2 -Gy- -MD $cc_warnings"
-      common_cppflags="-D_CRT_SECURE_NO_DEPRECATE"
-      internal_cppflags='-DUNICODE -D_UNICODE'
+    common_cppflags="-D_CRT_SECURE_NO_DEPRECATE"
+    internal_cppflags='-DUNICODE -D_UNICODE'
 
   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether the C compiler supports -d2VolatileMetadata-" >&5
 printf %s "checking whether the C compiler supports -d2VolatileMetadata-... " >&6; }
@@ -13936,23 +13931,22 @@ fi
 rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
   CFLAGS="$saved_CFLAGS"
 
-      if test "x$cl_has_volatile_metadata" = "xtrue"
+    if test "x$cl_has_volatile_metadata" = "xtrue"
 then :
   internal_cflags='-d2VolatileMetadata-'
 fi
-      internal_cppflags="$internal_cppflags -DWINDOWS_UNICODE="
-      internal_cppflags="${internal_cppflags}\$(WINDOWS_UNICODE)" ;; #(
+    internal_cppflags="$internal_cppflags -DWINDOWS_UNICODE="
+    internal_cppflags="${internal_cppflags}\$(WINDOWS_UNICODE)" ;; #(
   xlc-*) :
     common_cflags="-O5 -qtune=balanced -qnoipa -qinline";
-      internal_cflags="$cc_warnings" ;; #(
+    internal_cflags="$cc_warnings" ;; #(
   sunc-*) :
     # Optimization should be >= O4 to inline functions
-              # and prevent unresolved externals
-      common_cflags="-O4 -xc99=all -D_XPG6 $CFLAGS";
-      internal_cflags="$cc_warnings" ;; #(
+            # and prevent unresolved externals
+    common_cflags="-O4 -xc99=all -D_XPG6 $CFLAGS";
+    internal_cflags="$cc_warnings" ;; #(
   *) :
     common_cflags="-O" ;;
-esac ;;
 esac
 
 # Enable SSE2 on x86 mingw to avoid using 80-bit registers.

--- a/configure
+++ b/configure
@@ -14344,7 +14344,7 @@ esac
 
 mkexe_cmd_exp="$CC"
 
-case $cc_basename,$host in #(
+case $ocaml_cv_cc_vendor,$host in #(
   *,x86_64-*-darwin*) :
     oc_ldflags='-Wl,-no_compact_unwind';
     printf "%s\n" "#define HAS_ARCH_CODE32 1" >>confdefs.h
@@ -14396,11 +14396,11 @@ esac
   *,x86_64-*-linux*) :
     printf "%s\n" "#define HAS_ARCH_CODE32 1" >>confdefs.h
  ;; #(
-  xlc*,powerpc-ibm-aix*) :
+  xlc-*,powerpc-ibm-aix*) :
     oc_ldflags='-brtl -bexpfull'
     printf "%s\n" "#define HAS_ARCH_CODE32 1" >>confdefs.h
  ;; #(
-  gcc*,powerpc-*-linux*) :
+  gcc-*,powerpc-*-linux*) :
     oc_ldflags="-mbss-plt" ;; #(
   *) :
      ;;
@@ -15342,8 +15342,8 @@ esac ;; #(
   *-*-linux*|*-*-freebsd[3-9]*|*-*-freebsd[1-9][0-9]*\
     |*-*-openbsd*|*-*-netbsd*|*-*-dragonfly*|*-*-gnu*|*-*-haiku*) :
     sharedlib_cflags="-fPIC"
-       case $cc_basename,$host in #(
-  *gcc*,powerpc-*-linux*) :
+       case $ocaml_cv_cc_vendor,$host in #(
+  gcc-*,powerpc-*-linux*) :
     mkdll_flags='-shared -mbss-plt' ;; #(
   *,i[3456]86-*) :
     # Disable DT_TEXTREL warnings on Linux and BSD i386
@@ -15474,7 +15474,7 @@ case $enable_native_toplevel,$natdynlink in #(
 esac
 
 # Try to work around the Skylake/Kaby Lake processor bug.
-case "$cc_basename,$host" in #(
+case "$ocaml_cv_cc_vendor,$host" in #(
   *gcc*,x86_64-*|*gcc*,i686-*) :
 
   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether the C compiler supports -fno-tree-vrp" >&5
@@ -15834,12 +15834,12 @@ fi
 
 if test -z "$PARTIALLD"
 then :
-  case "$host,$cc_basename" in #(
-  x86_64-*-darwin*,*gcc*) :
+  case "$host,$ocaml_cv_cc_vendor" in #(
+  x86_64-*-darwin*,gcc-*) :
     PACKLD_FLAGS=' -arch x86_64' ;; #(
-  powerpc64le*-*-linux*,*gcc*) :
+  powerpc64le*-*-linux*,gcc-*) :
     PACKLD_FLAGS=' -m elf64lppc' ;; #(
-  powerpc*-*-linux*,*gcc*) :
+  powerpc*-*-linux*,gcc-*) :
     if $arch64
 then :
   PACKLD_FLAGS=' -m elf64ppc'
@@ -15853,14 +15853,14 @@ esac
   # output filename. Don't assume that all C compilers understand GNU -ofoo
   # form, so ensure that the definition includes a space at the end (which is
   # achieved using the $(EMPTY) expansion trick in Makefile.config.in).
-  if test x"$cc_basename" = "xcl"
-then :
-  # For the Microsoft C compiler there must be no space at the end of the
-    # string.
-    PACKLD="link -lib -nologo $machine -out:"
-else $as_nop
-  PACKLD="$DIRECT_LD -r$PACKLD_FLAGS -o "
-fi
+  case "$ocaml_cv_cc_vendor" in #(
+  msvc-*) :
+    # For the Microsoft C compiler there must be no space at the end of the
+      # string.
+      PACKLD="link -lib -nologo $machine -out:" ;; #(
+  *) :
+    PACKLD="$DIRECT_LD -r$PACKLD_FLAGS -o " ;;
+esac
 else $as_nop
   PACKLD="$PARTIALLD -o "
 fi
@@ -19708,8 +19708,8 @@ fi
 
 if test x"$enable_frame_pointers" = "xyes"
 then :
-  case "$host,$cc_basename" in #(
-  x86_64-*-linux*,gcc*|x86_64-*-linux*,clang*) :
+  case "$host,$ocaml_cv_cc_vendor" in #(
+  x86_64-*-linux*,gcc-*|x86_64-*-linux*,clang-*) :
     common_cflags="$common_cflags -g  -fno-omit-frame-pointer"
       frame_pointers=true
       printf "%s\n" "#define WITH_FRAME_POINTERS 1" >>confdefs.h

--- a/configure
+++ b/configure
@@ -13554,7 +13554,9 @@ printf %s "checking C compiler vendor... " >&6; }
   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
-#if defined(_MSC_VER)
+#if defined(_MSC_VER) && defined(__clang_major__) && defined(__clang_minor__)
+msvc _MSC_VER clang __clang_major__ __clang_minor__
+#elif defined(_MSC_VER)
 msvc _MSC_VER
 #elif defined(__INTEL_COMPILER)
 icc __INTEL_COMPILER

--- a/configure
+++ b/configure
@@ -16614,8 +16614,7 @@ then :
   gcc-*|clang-*) :
     tsan=true ;; #(
   *) :
-    as_fn_error $? "thread sanitizer not supported with compiler \
-$cc_basename\"" "$LINENO" 5
+    as_fn_error $? "thread sanitizer not supported with vendor=$ocaml_cv_cc_vendor\"" "$LINENO" 5
           ;;
 esac ;; #(
   *) :

--- a/configure.ac
+++ b/configure.ac
@@ -1678,10 +1678,9 @@ AS_IF([test "x$enable_tsan" = "xyes" ],
       [AS_CASE(["$system"],
         [freebsd|linux|macosx],
         [AS_CASE(["$ocaml_cv_cc_vendor"],
-          [gcc-*|clang-*],
-          [tsan=true],
-          [AC_MSG_ERROR([thread sanitizer not supported with compiler \
-$cc_basename"])]
+          [gcc-*|clang-*], [tsan=true],
+          [AC_MSG_ERROR(m4_normalize([thread sanitizer not supported with
+            vendor=$ocaml_cv_cc_vendor"]))]
          )],
        )],
       [AC_MSG_ERROR([thread sanitizer not supported on arch $arch])]

--- a/configure.ac
+++ b/configure.ac
@@ -797,56 +797,45 @@ AS_CASE([$enable_warn_error,OCAML__DEVELOPMENT_VERSION],
 # Concerning optimization level, -O3 is somewhat risky, so take -O2.
 # Concerning language version, recent enough versions of GCC and Clang
 # default to gnu11 (C11 + GNU extensions) or gnu17, which is fine.
-
-# Note: the vendor macro can not recognize MinGW because it calls the
-# C preprocessor directly so no compiler specific macro like __MING32__
-# is defined. We thus catch MinGW first by looking at host and examine
-# the vendor only as a fall-back. We could put tis part of the logic
-# in the macro itself, too
-AS_CASE([$host],
-  [*-*-mingw32*],
-    [AS_CASE([$ocaml_cv_cc_vendor],
-      [gcc-[[01234]]-*],
-        [AC_MSG_ERROR(m4_normalize([This version of MinGW-w64 GCC is too old.
-          Please use GCC version 5 or above.]))],
-      [gcc-*],
-        [internal_cflags="-Wno-unused $cc_warnings \
--fexcess-precision=standard"
-        # TODO: see whether the code can be fixed to avoid -Wno-unused
-        common_cflags="-O2 -fno-strict-aliasing -fwrapv -mms-bitfields"
-        internal_cppflags='-D__USE_MINGW_ANSI_STDIO=0 -DUNICODE -D_UNICODE'
-        internal_cppflags="$internal_cppflags -DWINDOWS_UNICODE="
-        internal_cppflags="${internal_cppflags}\$(WINDOWS_UNICODE)"],
-      [AC_MSG_ERROR([Unsupported C compiler for a MinGW-w64 build])])],
-  [AS_CASE([$ocaml_cv_cc_vendor],
-    [clang-*],
-      [common_cflags="-O2 -fno-strict-aliasing -fwrapv";
-      internal_cflags="$cc_warnings -fno-common"],
-    [gcc-[[0123]]-*|gcc-4-[[0-8]]],
-      # No C11 support
-      [AC_MSG_ERROR(m4_normalize([This version of GCC is too old.
-        Please use GCC version 4.9 or above.]), 69)],
-    [gcc-*],
-      [common_cflags="-O2 -fno-strict-aliasing -fwrapv";
-      internal_cflags="$cc_warnings -fno-common -fexcess-precision=standard \
+AS_CASE([$ocaml_cv_cc_vendor],
+  [clang-*],
+    [common_cflags="-O2 -fno-strict-aliasing -fwrapv";
+    internal_cflags="$cc_warnings -fno-common"],
+  [*gcc-[[0123]]-*|*gcc-4-[[0-8]]],
+    # No C11 support
+    [AC_MSG_ERROR(m4_normalize([This version of GCC is too old.
+      Please use GCC version 4.9 or above.]), 69)],
+  [gcc-*],
+    [common_cflags="-O2 -fno-strict-aliasing -fwrapv";
+    internal_cflags="$cc_warnings -fno-common -fexcess-precision=standard \
 -Wvla"],
-    [msvc-*],
-      [common_cflags="-nologo -O2 -Gy- -MD $cc_warnings"
-      common_cppflags="-D_CRT_SECURE_NO_DEPRECATE"
-      internal_cppflags='-DUNICODE -D_UNICODE'
-      OCAML_CL_HAS_VOLATILE_METADATA
-      AS_IF([test "x$cl_has_volatile_metadata" = "xtrue"],
-            [internal_cflags='-d2VolatileMetadata-'])
-      internal_cppflags="$internal_cppflags -DWINDOWS_UNICODE="
-      internal_cppflags="${internal_cppflags}\$(WINDOWS_UNICODE)"],
-    [xlc-*],
-      [common_cflags="-O5 -qtune=balanced -qnoipa -qinline";
-      internal_cflags="$cc_warnings"],
-    [sunc-*], # Optimization should be >= O4 to inline functions
-              # and prevent unresolved externals
-      [common_cflags="-O4 -xc99=all -D_XPG6 $CFLAGS";
-      internal_cflags="$cc_warnings"],
-    [common_cflags="-O"])])
+  [mingw32-*-*-gcc-*],
+    [internal_cflags="-Wno-unused $cc_warnings \
+-fexcess-precision=standard"
+    # TODO: see whether the code can be fixed to avoid -Wno-unused
+    common_cflags="-O2 -fno-strict-aliasing -fwrapv -mms-bitfields"
+    internal_cppflags='-D__USE_MINGW_ANSI_STDIO=0 -DUNICODE -D_UNICODE'
+    internal_cppflags="$internal_cppflags -DWINDOWS_UNICODE="
+    internal_cppflags="${internal_cppflags}\$(WINDOWS_UNICODE)"],
+  [mingw32-*],
+    [AC_MSG_ERROR([Unsupported C compiler for a MinGW-w64 build])],
+  [msvc-*],
+    [common_cflags="-nologo -O2 -Gy- -MD $cc_warnings"
+    common_cppflags="-D_CRT_SECURE_NO_DEPRECATE"
+    internal_cppflags='-DUNICODE -D_UNICODE'
+    OCAML_CL_HAS_VOLATILE_METADATA
+    AS_IF([test "x$cl_has_volatile_metadata" = "xtrue"],
+          [internal_cflags='-d2VolatileMetadata-'])
+    internal_cppflags="$internal_cppflags -DWINDOWS_UNICODE="
+    internal_cppflags="${internal_cppflags}\$(WINDOWS_UNICODE)"],
+  [xlc-*],
+    [common_cflags="-O5 -qtune=balanced -qnoipa -qinline";
+    internal_cflags="$cc_warnings"],
+  [sunc-*], # Optimization should be >= O4 to inline functions
+            # and prevent unresolved externals
+    [common_cflags="-O4 -xc99=all -D_XPG6 $CFLAGS";
+    internal_cflags="$cc_warnings"],
+  [common_cflags="-O"])
 
 # Enable SSE2 on x86 mingw to avoid using 80-bit registers.
 AS_CASE([$host],

--- a/configure.ac
+++ b/configure.ac
@@ -971,7 +971,7 @@ AS_CASE([$flexdll_source_dir,$supports_shared_libraries,$flexlink,$host],
 
 mkexe_cmd_exp="$CC"
 
-AS_CASE([$cc_basename,$host],
+AS_CASE([$ocaml_cv_cc_vendor,$host],
   [*,x86_64-*-darwin*],
     [oc_ldflags='-Wl,-no_compact_unwind';
     AC_DEFINE([HAS_ARCH_CODE32], [1])],
@@ -1013,10 +1013,10 @@ AS_CASE([$cc_basename,$host],
     mkexedebugflag=''],
   [*,x86_64-*-linux*],
     AC_DEFINE([HAS_ARCH_CODE32], [1]),
-  [xlc*,powerpc-ibm-aix*],
+  [xlc-*,powerpc-ibm-aix*],
     [oc_ldflags='-brtl -bexpfull'
     AC_DEFINE([HAS_ARCH_CODE32], [1])],
-  [gcc*,powerpc-*-linux*],
+  [gcc-*,powerpc-*-linux*],
     [oc_ldflags="-mbss-plt"])
 
 ## Program to use to install files
@@ -1177,8 +1177,8 @@ AS_IF([test x"$enable_shared" != "xno"],
     [[*-*-linux*|*-*-freebsd[3-9]*|*-*-freebsd[1-9][0-9]*\
     |*-*-openbsd*|*-*-netbsd*|*-*-dragonfly*|*-*-gnu*|*-*-haiku*]],
       [sharedlib_cflags="-fPIC"
-       AS_CASE([$cc_basename,$host],
-           [*gcc*,powerpc-*-linux*],
+       AS_CASE([$ocaml_cv_cc_vendor,$host],
+           [gcc-*,powerpc-*-linux*],
            [mkdll_flags='-shared -mbss-plt'],
            [[*,i[3456]86-*]],
            # Disable DT_TEXTREL warnings on Linux and BSD i386
@@ -1257,7 +1257,7 @@ AS_CASE([$enable_native_toplevel,$natdynlink],
     [install_ocamlnat=false])
 
 # Try to work around the Skylake/Kaby Lake processor bug.
-AS_CASE(["$cc_basename,$host"],
+AS_CASE(["$ocaml_cv_cc_vendor,$host"],
   [*gcc*,x86_64-*|*gcc*,i686-*],
     [OCAML_CC_HAS_FNO_TREE_VRP
     AS_IF([$cc_has_fno_tree_vrp],
@@ -1418,10 +1418,10 @@ AC_DEFINE_UNQUOTED([OCAML_OS_TYPE], ["$ostype"])
 
 AC_CHECK_TOOL([DIRECT_LD],[ld])
 AS_IF([test -z "$PARTIALLD"],
-  [AS_CASE(["$host,$cc_basename"],
-    [x86_64-*-darwin*,*gcc*], [PACKLD_FLAGS=' -arch x86_64'],
-    [powerpc64le*-*-linux*,*gcc*], [PACKLD_FLAGS=' -m elf64lppc'],
-    [powerpc*-*-linux*,*gcc*],
+  [AS_CASE(["$host,$ocaml_cv_cc_vendor"],
+    [x86_64-*-darwin*,gcc-*], [PACKLD_FLAGS=' -arch x86_64'],
+    [powerpc64le*-*-linux*,gcc-*], [PACKLD_FLAGS=' -m elf64lppc'],
+    [powerpc*-*-linux*,gcc-*],
        [AS_IF([$arch64],
               [PACKLD_FLAGS=' -m elf64ppc'],
               [PACKLD_FLAGS=' -m elf32ppclinux'])],
@@ -1430,10 +1430,11 @@ AS_IF([test -z "$PARTIALLD"],
   # output filename. Don't assume that all C compilers understand GNU -ofoo
   # form, so ensure that the definition includes a space at the end (which is
   # achieved using the $(EMPTY) expansion trick in Makefile.config.in).
-  AS_IF([test x"$cc_basename" = "xcl"],
-    # For the Microsoft C compiler there must be no space at the end of the
-    # string.
-    [PACKLD="link -lib -nologo $machine -out:"],
+  AS_CASE(["$ocaml_cv_cc_vendor"],
+    [msvc-*],
+      # For the Microsoft C compiler there must be no space at the end of the
+      # string.
+      [PACKLD="link -lib -nologo $machine -out:"],
     [PACKLD="$DIRECT_LD -r$PACKLD_FLAGS -o "])],
   [PACKLD="$PARTIALLD -o "])
 
@@ -2264,8 +2265,8 @@ AS_IF([$native_compiler],
 ## Frame pointers
 
 AS_IF([test x"$enable_frame_pointers" = "xyes"],
-  [AS_CASE(["$host,$cc_basename"],
-    [x86_64-*-linux*,gcc*|x86_64-*-linux*,clang*],
+  [AS_CASE(["$host,$ocaml_cv_cc_vendor"],
+    [x86_64-*-linux*,gcc-*|x86_64-*-linux*,clang-*],
       [common_cflags="$common_cflags -g  -fno-omit-frame-pointer"
       frame_pointers=true
       AC_DEFINE([WITH_FRAME_POINTERS])


### PR DESCRIPTION
This PR improves the detection of the C compiler on Windows, and replaces uses of `$cc_basename` by our `$ocaml_cv_cc_vendor`. More specifically, it:

1. Allows to properly discover whether mingw-w64 is used (`$ocaml_cv_cc_vendor` used to conflate it with GCC), and whether mingw-w64 is coupled to GCC or Clang. The build with mingw-w64+clang is currently rejected (but a follow-up PR with a couple of patches might appear on the net). I've chosen the `mingw32` prefix, we can go with another. I haven't found a case where a previous match for "gcc-\*" that wouldn't match after this PR (because the match is now "mingw32-\*") would be problematic, apart from removing `-latomic` on i686 that apparently has no effect.
2. Detects clang-cl, a clang that's [ABI compatible](https://clang.llvm.org/docs/MSVCCompatibility.html) and [command-line compatible](https://clang.llvm.org/docs/UsersManual.html#clang-cl) with MSVC. Considering that we're interested in it first and foremost for its compatibility with MSVC, I've chosen to make it report as "msvc-xx-clang-yy" rather than "clang-yy-msvc-xx" so that configure scripts for MSVC also apply to this compiler. 
3. Fixes TSan detection on macOS: configure would look for "clang" in the cc basename and would fail, because the default compiler is "cc". This would also happen if one were to run `./configure --enable-tsan CC=cc`, even if `cc` supported TSan.
4. Removes uses of `$cc_basename` as it is an internal and undocumented feature of Autoconf, and prefer our `$ocaml_cv_cc_vendor` instead. This is prompted by point 3, and I hope it'll prevent future problems.

Accurate reports of the C compiler vendor also improve the quality of bug reports! "What C compiler are you using on Windows?" is now "oh configure has picked this compiler at this version".