### PR TITLE
Unify MSVC and MinGW-w64 code paths

### DIFF
--- a/Changes
+++ b/Changes
@@ -178,6 +178,11 @@ Working version
   Updates usage of sigprocmask to pthread_sigmask in otherlibs/unix.
   (Max Slater, review by Miod Vallat and Xavier Leroy)
 
+- #12769: Unify MSVC and MinGW-w64 code paths, by always using WinAPI
+  directly.
+  (David Allsopp, Antonin Décimo, and Samuel Hym, review by Nicolas
+   Ojeda Bar)
+
 ### Code generation and optimizations:
 
 - #11239: on x86-64 and RISC-V, reduce alignment of OCaml stacks from 16 to 8.

--- a/configure
+++ b/configure
@@ -14568,13 +14568,12 @@ fi
 
 # Checks for header files
 
-ac_fn_c_check_header_compile "$LINENO" "math.h" "ac_cv_header_math_h" "$ac_includes_default"
-if test "x$ac_cv_header_math_h" = xyes
-then :
-
-fi
-
-       for ac_header in unistd.h
+# Don't check for unistd.h on Windows
+case $host in #(
+  *-*-mingw32*|*-pc-windows) :
+     ;; #(
+  *) :
+           for ac_header in unistd.h
 do :
   ac_fn_c_check_header_compile "$LINENO" "unistd.h" "ac_cv_header_unistd_h" "$ac_includes_default"
 if test "x$ac_cv_header_unistd_h" = xyes
@@ -14584,7 +14583,15 @@ then :
 
 fi
 
-done
+done ;;
+esac
+
+ac_fn_c_check_header_compile "$LINENO" "math.h" "ac_cv_header_math_h" "$ac_includes_default"
+if test "x$ac_cv_header_math_h" = xyes
+then :
+
+fi
+
 ac_fn_c_check_header_compile "$LINENO" "stdint.h" "ac_cv_header_stdint_h" "$ac_includes_default"
 if test "x$ac_cv_header_stdint_h" = xyes
 then :

--- a/configure.ac
+++ b/configure.ac
@@ -1035,8 +1035,12 @@ AC_SEARCH_LIBS([cos], [m],
 
 # Checks for header files
 
+# Don't check for unistd.h on Windows
+AS_CASE([$host],
+  [*-*-mingw32*|*-pc-windows], [],
+  [AC_CHECK_HEADERS([unistd.h],[AC_DEFINE([HAS_UNISTD])])])
+
 AC_CHECK_HEADER([math.h])
-AC_CHECK_HEADERS([unistd.h],[AC_DEFINE([HAS_UNISTD])])
 AC_CHECK_HEADER([stdint.h],[AC_DEFINE([HAS_STDINT_H])])
 AC_CHECK_HEADER([pthread_np.h],[AC_DEFINE([HAS_PTHREAD_NP_H])])
 AC_CHECK_HEADER([dirent.h], [AC_DEFINE([HAS_DIRENT])], [],

--- a/otherlibs/systhreads/st_pthreads.h
+++ b/otherlibs/systhreads/st_pthreads.h
@@ -22,7 +22,6 @@
 #include <pthread.h>
 #include <signal.h>
 #include <time.h>
-#include <sys/time.h>
 #ifdef HAS_UNISTD
 #include <unistd.h>
 #endif

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -22,7 +22,9 @@
 #include "caml/config.h"
 #include <stdbool.h>
 #include <stdio.h>
+#ifdef HAS_UNISTD
 #include <unistd.h>
+#endif
 #include <pthread.h>
 #include <string.h>
 #include <assert.h>

--- a/runtime/fiber.c
+++ b/runtime/fiber.c
@@ -18,8 +18,11 @@
 
 #define CAML_INTERNALS
 
+#include "caml/config.h"
 #include <string.h>
+#ifdef HAS_UNISTD
 #include <unistd.h>
+#endif
 #include <assert.h>
 #include "caml/alloc.h"
 #include "caml/callback.h"

--- a/runtime/platform.c
+++ b/runtime/platform.c
@@ -15,8 +15,11 @@
 /**************************************************************************/
 #define CAML_INTERNALS
 
+#include "caml/config.h"
 #include <string.h>
+#ifdef HAS_UNISTD
 #include <unistd.h>
+#endif
 #include <errno.h>
 #include "caml/osdeps.h"
 #include "caml/platform.h"
@@ -230,6 +233,10 @@ unsigned caml_plat_spin_wait(unsigned spins,
   if (spins < Slow_sleep_ns && Slow_sleep_ns <= next_spins) {
     caml_gc_log("Slow spin-wait loop in %s at %s:%d", function, file, line);
   }
+#ifdef _WIN32
+  Sleep(spins/1000000);
+#else
   usleep(spins/1000);
+#endif
   return next_spins;
 }

--- a/runtime/platform.c
+++ b/runtime/platform.c
@@ -18,7 +18,6 @@
 #include <string.h>
 #include <unistd.h>
 #include <errno.h>
-#include <sys/time.h>
 #include "caml/osdeps.h"
 #include "caml/platform.h"
 #include "caml/fail.h"

--- a/runtime/unix.c
+++ b/runtime/unix.c
@@ -27,7 +27,9 @@
 #include <errno.h>
 #include <sys/ioctl.h>
 #include <sys/types.h>
+#ifdef HAS_GETTIMEOFDAY
 #include <sys/time.h>
+#endif
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <errno.h>

--- a/yacc/main.c
+++ b/yacc/main.c
@@ -21,6 +21,9 @@
 #ifdef HAS_UNISTD
 #include <unistd.h>
 #endif
+#ifdef _WIN32
+#include <io.h>
+#endif
 
 #include "caml/version.h"
 


### PR DESCRIPTION
MinGW-w64 emulates functions from `<unistd.h>` using the WinAPI. The MSVC port doesn't provide this header, and we must use the WinAPI directly. In order to have one code path shared by the two ports, we never include `<unistd.h>` with MinGW-w64 and always use the WinAPI directly in the runtime.

MinGW-w64 [emulates](https://sourceforge.net/p/mingw-w64/mingw-w64/ci/master/tree/mingw-w64-crt/misc/mingw_usleep.c) [`usleep`](https://man7.org/linux/man-pages/man3/usleep.3.html) (µs-resolution) with [`Sleep`](https://learn.microsoft.com/en-us/windows/win32/api/synchapi/nf-synchapi-sleep) (ms-resolution). We simply call `Sleep` directly. We have a follow-up plan for higher-resolution sleeps on Windows.

We have checked that in all files used on Windows, `unistd.h` is guarded by `HAS_UNISTD`. This can be tested again with `grep -R -B1 '<unistd\.h>'`.

This goes towards restoring the MSVC port.