### PR TITLE
Stdlib: Add NonEmpty data structure for non-empty lists

### DIFF
--- a/stdlib/.depend
+++ b/stdlib/.depend
@@ -546,6 +546,18 @@ stdlib__Nativeint.cmx : nativeint.ml \
     stdlib.cmx \
     stdlib__Nativeint.cmi
 stdlib__Nativeint.cmi : nativeint.mli
+stdlib__NonEmpty.cmo : nonEmpty.ml \
+    stdlib__Seq.cmi \
+    stdlib__List.cmi \
+    stdlib__Int.cmi \
+    stdlib__NonEmpty.cmi
+stdlib__NonEmpty.cmx : nonEmpty.ml \
+    stdlib__Seq.cmx \
+    stdlib__List.cmx \
+    stdlib__Int.cmx \
+    stdlib__NonEmpty.cmi
+stdlib__NonEmpty.cmi : nonEmpty.mli \
+    stdlib__Seq.cmi
 stdlib__Obj.cmo : obj.ml \
     stdlib__Sys.cmi \
     stdlib__Int32.cmi \

--- a/stdlib/StdlibModules
+++ b/stdlib/StdlibModules
@@ -50,6 +50,7 @@ STDLIB_MODULE_BASENAMES = \
   char \
   uchar \
   list \
+  nonEmpty \
   int \
   bytes \
   string \

--- a/stdlib/nonEmpty.ml
+++ b/stdlib/nonEmpty.ml
@@ -1,0 +1,47 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*             Xavier Leroy, projet Cristal, INRIA Rocquencourt           *)
+(*                                                                        *)
+(*   Copyright 1996 Institut National de Recherche en Informatique et     *)
+(*     en Automatique.                                                    *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+type 'a t = Head of 'a * 'a list
+
+external unsafe_of_list : 'a list -> 'a t = "%identity"
+
+let of_list = function
+    [] -> None
+  | l -> Some (unsafe_of_list l)
+
+external to_list : 'a t -> 'a list = "%identity"
+
+let length (Head (_, t)) = Int.succ (List.length t)
+
+let singleton x = Head (x, [])
+let cons x ne = Head (x, to_list ne)
+
+let hd (Head (h, _)) = h
+let tl (Head (_, t)) = t
+
+let map f (Head (h, t)) = Head (f h, List.map f t)
+let iter f (Head (h, t)) = f h; List.iter f t
+
+let append ne1 ne2 = unsafe_of_list (to_list ne1 @ to_list ne2)
+let append_list_right ne l = unsafe_of_list (to_list ne @ l)
+let append_list_left l ne = unsafe_of_list (l @ to_list ne)
+
+let to_seq (Head (h, t)) () =
+  Seq.Cons (h, List.to_seq t)
+
+let of_seq seq =
+  match seq () with
+  | Seq.Nil -> None
+  | Seq.Cons (x, seq) -> Some (Head (x, List.of_seq seq))

--- a/stdlib/nonEmpty.mli
+++ b/stdlib/nonEmpty.mli
@@ -1,0 +1,38 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*             Xavier Leroy, projet Cristal, INRIA Rocquencourt           *)
+(*                                                                        *)
+(*   Copyright 1996 Institut National de Recherche en Informatique et     *)
+(*     en Automatique.                                                    *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+type 'a t = Head of 'a * 'a list
+
+val of_list : 'a list -> 'a t option
+
+external to_list : 'a t -> 'a list = "%identity"
+
+val length : 'a t -> int
+
+val singleton : 'a -> 'a t
+val cons : 'a -> 'a t -> 'a t
+
+val hd : 'a t -> 'a
+val tl : 'a t -> 'a list
+
+val map : ('a -> 'b) -> 'a t -> 'b t
+val iter : ('a -> unit) -> 'a t -> unit
+
+val append : 'a t -> 'a t -> 'a t
+val append_list_right : 'a t -> 'a list -> 'a t
+val append_list_left : 'a list -> 'a t -> 'a t
+
+val to_seq : 'a t -> 'a Seq.t
+val of_seq : 'a Seq.t -> 'a t option

--- a/stdlib/stdlib.ml
+++ b/stdlib/stdlib.ml
@@ -620,6 +620,7 @@ module Marshal        = Marshal
 module MoreLabels     = MoreLabels
 module Mutex          = Mutex
 module Nativeint      = Nativeint
+module NonEmpty       = NonEmpty
 module Obj            = Obj
 module Oo             = Oo
 module Option         = Option

--- a/stdlib/stdlib.mli
+++ b/stdlib/stdlib.mli
@@ -1433,6 +1433,7 @@ module Marshal        = Marshal
 module MoreLabels     = MoreLabels
 module Mutex          = Mutex
 module Nativeint      = Nativeint
+module NonEmpty       = NonEmpty
 module Obj            = Obj
 module Oo             = Oo
 module Option         = Option


### PR DESCRIPTION
This is a draft pr for adding a data structure for non-empty lists. This is useful when you want to provide non-excepting alternatives to certain functions/maintain a list being non-empty as an invariant. It also is good as a guide to using interfaces that have this as a precondition, as this ensures that the user has to consider where the check should take place. Uses OCaml's memory model to make converting to a list the identity (though converting a list to a nonempty requires a check). If there is interest in adding this to the standard library I can flesh it out with some more helper functions and documentation. 