### PR TITLE
Add flat_map in stdlib

### DIFF
--- a/Changes
+++ b/Changes
@@ -266,6 +266,9 @@ Working version
 - #12625: Remove the Closure module from Obj
   (Vincent Laviron, review by Xavier Leroy)
 
+- #12774: Add flat_map in Option, Result and List
+  (Xavier Van de Woestyne, review by ???)
+
 ### Other libraries:
 
 - #12213: Dynlink library, improve legibility of error messages

--- a/stdlib/list.ml
+++ b/stdlib/list.ml
@@ -289,6 +289,8 @@ and[@tail_mod_cons] prepend_concat_map ys f xs =
   | [] -> concat_map f xs
   | y :: ys -> y :: prepend_concat_map ys f xs
 
+let flat_map = concat_map
+
 let fold_left_map f accu l =
   let rec aux accu l_accu = function
     | [] -> accu, rev l_accu

--- a/stdlib/list.mli
+++ b/stdlib/list.mli
@@ -205,6 +205,11 @@ val concat_map : ('a -> 'b list) -> 'a list -> 'b list
     @since 4.10
 *)
 
+val flat_map : ('a -> 'b list) -> 'a list -> 'b list
+(** [flat_map] is an alias for [concat_map].
+
+    @since 5.2 *)
+
 val fold_left_map :
   ('acc -> 'a -> 'acc * 'b) -> 'acc -> 'a list -> 'acc * 'b list
 (** [fold_left_map] is  a combination of [fold_left] and [map] that threads an

--- a/stdlib/listLabels.mli
+++ b/stdlib/listLabels.mli
@@ -205,6 +205,11 @@ val concat_map : f:('a -> 'b list) -> 'a list -> 'b list
     @since 4.10
 *)
 
+val flat_map : f:('a -> 'b list) -> 'a list -> 'b list
+(** [flat_map] is an alias for [concat_map].
+
+    @since 5.2 *)
+
 val fold_left_map :
   f:('acc -> 'a -> 'acc * 'b) -> init:'acc -> 'a list -> 'acc * 'b list
 (** [fold_left_map] is  a combination of [fold_left] and [map] that threads an

--- a/stdlib/option.ml
+++ b/stdlib/option.ml
@@ -20,6 +20,7 @@ let some v = Some v
 let value o ~default = match o with Some v -> v | None -> default
 let get = function Some v -> v | None -> invalid_arg "option is None"
 let bind o f = match o with None -> None | Some v -> f v
+let flat_map f o = bind o f
 let join = function Some o -> o | None -> None
 let map f o = match o with None -> None | Some v -> Some (f v)
 let fold ~none ~some = function Some v -> some v | None -> none

--- a/stdlib/option.mli
+++ b/stdlib/option.mli
@@ -47,6 +47,11 @@ val join : 'a option option -> 'a option
 val map : ('a -> 'b) -> 'a option -> 'b option
 (** [map f o] is [None] if [o] is [None] and [Some (f v)] if [o] is [Some v]. *)
 
+val flat_map : ('a -> 'b option) -> 'a option -> 'b option
+(** [flat_map f o] is [bind o f].
+
+    @since 5.2 *)
+
 val fold : none:'a -> some:('b -> 'a) -> 'b option -> 'a
 (** [fold ~none ~some o] is [none] if [o] is [None] and [some v] if [o] is
     [Some v]. *)

--- a/stdlib/result.ml
+++ b/stdlib/result.ml
@@ -21,6 +21,7 @@ let value r ~default = match r with Ok v -> v | Error _ -> default
 let get_ok = function Ok v -> v | Error _ -> invalid_arg "result is Error _"
 let get_error = function Error e -> e | Ok _ -> invalid_arg "result is Ok _"
 let bind r f = match r with Ok v -> f v | Error _ as e -> e
+let flat_map f r = bind r f
 let join = function Ok r -> r | Error _ as e -> e
 let map f = function Ok v -> Ok (f v) | Error _ as e -> e
 let map_error f = function Error e -> Error (f e) | Ok _ as v -> v

--- a/stdlib/result.mli
+++ b/stdlib/result.mli
@@ -53,6 +53,11 @@ val join : (('a, 'e) result, 'e) result -> ('a, 'e) result
 val map : ('a -> 'b) -> ('a, 'e) result -> ('b, 'e) result
 (** [map f r] is [Ok (f v)] if [r] is [Ok v] and [r] if [r] is [Error _]. *)
 
+val flat_map : ('a -> ('b, 'e) result) -> ('a, 'e) result -> ('b, 'e) result
+(** [flat_map f o] is [bind o f].
+
+    @since 5.2 *)
+
 val map_error : ('e -> 'f) -> ('a, 'e) result -> ('a, 'f) result
 (** [map_error f r] is [Error (f e)] if [r] is [Error e] and [r] if
     [r] is [Ok _]. *)

--- a/testsuite/tests/match-side-effects/test_contexts_code.ml
+++ b/testsuite/tests/match-side-effects/test_contexts_code.ml
@@ -31,15 +31,15 @@ let example_1 () =
   | { a = true; b = Either.Left y } -> Result.Ok y;;
 (let
   (example_1/310 =
-     (function param/334[int]
+     (function param/335[int]
        (let (input/312 = (makemutable 0 (int,*) 1 [0: 1]))
          (if (field_int 0 input/312)
-           (let (*match*/337 =o (field_mut 1 input/312))
-             (switch* *match*/337
+           (let (*match*/338 =o (field_mut 1 input/312))
+             (switch* *match*/338
               case tag 0:
                (if (seq (setfield_ptr 1 input/312 [1: 3]) 0) [1: 3]
-                 (let (*match*/339 =o (field_mut 1 input/312))
-                   (makeblock 0 (int) (field_imm 0 *match*/339))))
+                 (let (*match*/340 =o (field_mut 1 input/312))
+                   (makeblock 0 (int) (field_imm 0 *match*/340))))
               case tag 1: [1: 2]))
            [1: 1]))))
   (apply (field_mut 1 (global Toploop!)) "example_1" example_1/310))
@@ -71,20 +71,20 @@ let example_2 () =
       Result.Error 3
   | { a = true; b = { mut = Either.Left y } } -> Result.Ok y;;
 (let
-  (example_2/346 =
-     (function param/350[int]
-       (let (input/348 = (makeblock 0 (int,*) 1 (makemutable 0 [0: 1])))
-         (if (field_int 0 input/348)
-           (let (*match*/354 =o (field_mut 0 (field_imm 1 input/348)))
-             (switch* *match*/354
+  (example_2/347 =
+     (function param/351[int]
+       (let (input/349 = (makeblock 0 (int,*) 1 (makemutable 0 [0: 1])))
+         (if (field_int 0 input/349)
+           (let (*match*/355 =o (field_mut 0 (field_imm 1 input/349)))
+             (switch* *match*/355
               case tag 0:
-               (if (seq (setfield_ptr 0 (field_imm 1 input/348) [1: 3]) 0)
+               (if (seq (setfield_ptr 0 (field_imm 1 input/349) [1: 3]) 0)
                  [1: 3]
-                 (let (*match*/357 =o (field_mut 0 (field_imm 1 input/348)))
-                   (makeblock 0 (int) (field_imm 0 *match*/357))))
+                 (let (*match*/358 =o (field_mut 0 (field_imm 1 input/349)))
+                   (makeblock 0 (int) (field_imm 0 *match*/358))))
               case tag 1: [1: 2]))
            [1: 1]))))
-  (apply (field_mut 1 (global Toploop!)) "example_2" example_2/346))
+  (apply (field_mut 1 (global Toploop!)) "example_2" example_2/347))
 val example_2 : unit -> (bool, int) Result.t = <fun>
 |}]
 
@@ -111,16 +111,16 @@ let example_3 () =
       Result.Error 3
   | { mut = (true, Either.Left y) } -> Result.Ok y;;
 (let
-  (example_3/363 =
-     (function param/367[int]
-       (let (input/365 =mut [0: 1 [0: 1]] *match*/368 =o *input/365)
-         (if (field_imm 0 *match*/368)
-           (switch* (field_imm 1 *match*/368)
+  (example_3/364 =
+     (function param/368[int]
+       (let (input/366 =mut [0: 1 [0: 1]] *match*/369 =o *input/366)
+         (if (field_imm 0 *match*/369)
+           (switch* (field_imm 1 *match*/369)
             case tag 0:
-             (if (seq (assign input/365 [0: 1 [1: 3]]) 0) [1: 3]
-               (makeblock 0 (int) (field_imm 0 (field_imm 1 *match*/368))))
+             (if (seq (assign input/366 [0: 1 [1: 3]]) 0) [1: 3]
+               (makeblock 0 (int) (field_imm 0 (field_imm 1 *match*/369))))
             case tag 1: [1: 2])
            [1: 1]))))
-  (apply (field_mut 1 (global Toploop!)) "example_3" example_3/363))
+  (apply (field_mut 1 (global Toploop!)) "example_3" example_3/364))
 val example_3 : unit -> (bool, int) Result.t = <fun>
 |}]


### PR DESCRIPTION
The `flat_map` function is already available in the `Seq` module (which also includes a `concat_map` function as an alias) and `Result` and `Option` introduce `bind` where `flat_map` is a flipped alias.

The main reason is that when I'm prototyping a small project with few dependencies (so no infix operators or binding operators), the order of the parameters makes function piping laborious. For example : 

```ocaml
let _ = x |> Result.map f |> (fun r -> Result.bind r g) (* or Fun.flip Result.bind *)
(* becomes *)
let _ = x |> Result.map f |> Result.flat_map g
```

I think the name `flat_map` is fairly common (used in particular by the Scala community and by the `Seq` module). And I have a lot of cases where I end up rebuilding `let*` or `>>=` because I find that `bind` makes pipelines hard to read.