### PR TITLE
check-typo: be more lax with urls

### DIFF
--- a/tools/check-typo
+++ b/tools/check-typo
@@ -404,7 +404,7 @@ EXIT_CODE=0
 
         $0 !~ /\t/ && length($0) > 80 {
           t = utf8_decode($0);
-          sub(/https?:[A-Za-z0-9._~:\/?#\[\]@!$&\047()*+,;=%-]{73,}$/, "", t);
+          sub(/https?:[A-Za-z0-9._~:\/?#\[\]@!$&\047()*+,;=%-]{73,}/, "", t);
           if (length(t) > 80) {
             RSTART = 81;
             RLENGTH = 0;
@@ -416,6 +416,7 @@ EXIT_CODE=0
           RSTART = 133;
           RLENGTH = 0;
           t = utf8_decode($0);
+          sub(/https?:[A-Za-z0-9._~:\/?#\[\]@!$&\047()*+,;=%-]{125,}/, "", t);
           if (length(t) > 132) {
             err("very-long-line", "line is over 132 columns");
           }


### PR DESCRIPTION
This micro-PR proposes to be more lax with urls within check-typo to make it easier to add links to external urls in documentation comments (see #12508 as an example of `check-typo` triggering on an url).

More precisely, this PR proposes that urls don't count in the line size restriction even if they are not at the end of the line or if they are in the midst of very long line. 