### PR TITLE
Include "got" and "expected" details in method mismatch errors

### DIFF
--- a/Changes
+++ b/Changes
@@ -394,6 +394,10 @@ Working version
   `ocamlc -verbose`.
   (David Allsopp, review by Nicolás Ojeda Bär)
 
+- #12777: Add details about the actual and expected method types to the method
+  mismatch error messages.
+  (Javier Chávarri, review by Gabriel Scherer and Florian Angeletti)
+
 ### Internal/compiler-libs changes:
 
 - #12639: parsing: Attach a location to the RHS of Ptyp_alias

--- a/testsuite/tests/typing-modules/inclusion_errors.ml
+++ b/testsuite/tests/typing-modules/inclusion_errors.ml
@@ -272,8 +272,8 @@ Error: Signature mismatch:
          type t = < m : float * int; n : int >
        The type "< m : int; n : int >" is not equal to the type
          "< m : float * int; n : int >"
-       Types for method "m" are incompatible, the method has type "int",
-       but the expected method type was "float * int"
+       The method "m" has type "int", but the expected method type was
+       "float * int"
 |}];;
 
 module M4 : sig
@@ -897,8 +897,8 @@ Error: Signature mismatch:
          val f : < m : [< `Foo ] > -> unit
        The type "< m : 'a. [< `Foo ] as 'a > -> unit"
        is not compatible with the type "< m : [< `Foo ] > -> unit"
-       Types for method "m" are incompatible, the method has type
-       "'b. [< `Foo ] as 'b", but the expected method type was "[< `Foo ]"
+       The method "m" has type "'b. [< `Foo ] as 'b",
+       but the expected method type was "[< `Foo ]"
 |}];;
 
 module M : sig
@@ -922,8 +922,8 @@ Error: Signature mismatch:
          val f : < m : 'a. [< `Foo ] as 'a > -> unit
        The type "< m : [ `Foo ] > -> unit" is not compatible with the type
          "< m : 'a. [< `Foo ] as 'a > -> unit"
-       Types for method "m" are incompatible, the method has type "[ `Foo ]",
-       but the expected method type was "'b. [< `Foo ] as 'b"
+       The method "m" has type "[ `Foo ]", but the expected method type was
+       "'b. [< `Foo ] as 'b"
 |}];;
 
 module M : sig
@@ -1747,9 +1747,8 @@ Error: Signature mismatch:
          "A : (< x : 'b > as 'b) -> (< y : 'a > as 'a) t"
        The type "< x : 'a * 'a > as 'a" is not equal to the type
          "< x : 'b > as 'b"
-       Types for method "x" are incompatible, the method has type
-       "< x : 'c > * < x : 'c > as 'c", but the expected method type was
-       "< x : 'b > as 'b"
+       The method "x" has type "< x : 'c > * < x : 'c > as 'c",
+       but the expected method type was "< x : 'b > as 'b"
 |}]
 module R: sig
   type t = { a: (<x:'a> as 'a) }
@@ -1776,9 +1775,8 @@ Error: Signature mismatch:
          "a : < x : 'a > as 'a;"
        The type "< x : 'a * 'a > as 'a" is not equal to the type
          "< x : 'b > as 'b"
-       Types for method "x" are incompatible, the method has type
-       "< x : 'c > * < x : 'c > as 'c", but the expected method type was
-       "< x : 'b > as 'b"
+       The method "x" has type "< x : 'c > * < x : 'c > as 'c",
+       but the expected method type was "< x : 'b > as 'b"
 |}]
 type _ ext = ..
 module Ext: sig
@@ -1812,7 +1810,6 @@ Error: Signature mismatch:
          "A : (< x : 'b > as 'b) -> (< y : 'a > as 'a) ext"
        The type "< x : 'a * 'a > as 'a" is not equal to the type
          "< x : 'b > as 'b"
-       Types for method "x" are incompatible, the method has type
-       "< x : 'c > * < x : 'c > as 'c", but the expected method type was
-       "< x : 'b > as 'b"
+       The method "x" has type "< x : 'c > * < x : 'c > as 'c",
+       but the expected method type was "< x : 'b > as 'b"
 |}]

--- a/testsuite/tests/typing-modules/inclusion_errors.ml
+++ b/testsuite/tests/typing-modules/inclusion_errors.ml
@@ -272,7 +272,8 @@ Error: Signature mismatch:
          type t = < m : float * int; n : int >
        The type "< m : int; n : int >" is not equal to the type
          "< m : float * int; n : int >"
-       Types for method "m" are incompatible
+       Types for method "m" are incompatible, the method has type "int",
+       but the expected method type was "float * int"
 |}];;
 
 module M4 : sig
@@ -896,7 +897,8 @@ Error: Signature mismatch:
          val f : < m : [< `Foo ] > -> unit
        The type "< m : 'a. [< `Foo ] as 'a > -> unit"
        is not compatible with the type "< m : [< `Foo ] > -> unit"
-       Types for method "m" are incompatible
+       Types for method "m" are incompatible, the method has type
+       "'b. [< `Foo ] as 'b", but the expected method type was "[< `Foo ]"
 |}];;
 
 module M : sig
@@ -920,7 +922,8 @@ Error: Signature mismatch:
          val f : < m : 'a. [< `Foo ] as 'a > -> unit
        The type "< m : [ `Foo ] > -> unit" is not compatible with the type
          "< m : 'a. [< `Foo ] as 'a > -> unit"
-       Types for method "m" are incompatible
+       Types for method "m" are incompatible, the method has type "[ `Foo ]",
+       but the expected method type was "'b. [< `Foo ] as 'b"
 |}];;
 
 module M : sig
@@ -1744,7 +1747,9 @@ Error: Signature mismatch:
          "A : (< x : 'b > as 'b) -> (< y : 'a > as 'a) t"
        The type "< x : 'a * 'a > as 'a" is not equal to the type
          "< x : 'b > as 'b"
-       Types for method "x" are incompatible
+       Types for method "x" are incompatible, the method has type
+       "< x : 'c > * < x : 'c > as 'c", but the expected method type was
+       "< x : 'b > as 'b"
 |}]
 module R: sig
   type t = { a: (<x:'a> as 'a) }
@@ -1771,7 +1776,9 @@ Error: Signature mismatch:
          "a : < x : 'a > as 'a;"
        The type "< x : 'a * 'a > as 'a" is not equal to the type
          "< x : 'b > as 'b"
-       Types for method "x" are incompatible
+       Types for method "x" are incompatible, the method has type
+       "< x : 'c > * < x : 'c > as 'c", but the expected method type was
+       "< x : 'b > as 'b"
 |}]
 type _ ext = ..
 module Ext: sig
@@ -1805,5 +1812,7 @@ Error: Signature mismatch:
          "A : (< x : 'b > as 'b) -> (< y : 'a > as 'a) ext"
        The type "< x : 'a * 'a > as 'a" is not equal to the type
          "< x : 'b > as 'b"
-       Types for method "x" are incompatible
+       Types for method "x" are incompatible, the method has type
+       "< x : 'c > * < x : 'c > as 'c", but the expected method type was
+       "< x : 'b > as 'b"
 |}]

--- a/testsuite/tests/typing-objects-bugs/pr4018_bad.compilers.reference
+++ b/testsuite/tests/typing-objects-bugs/pr4018_bad.compilers.reference
@@ -19,4 +19,7 @@ Error: This type "entity" = "< destroy_subject : id subject; entity_id : id >"
          "(< destroy_subject : < add_observer : 'd -> 'b; .. >; .. > as 'a)
          entity_container as 'd" =
            "< add_entity : 'a -> 'b; notify : 'a -> id -> unit >"
-       Types for method "add_observer" are incompatible
+       Types for method "add_observer" are incompatible, the method has type
+       "(id subject, id) observer -> unit", but the expected method type was
+       "< destroy_subject : < add_observer : 'e; .. >; .. > entity_container ->
+       'b as 'e"

--- a/testsuite/tests/typing-objects-bugs/pr4018_bad.compilers.reference
+++ b/testsuite/tests/typing-objects-bugs/pr4018_bad.compilers.reference
@@ -19,7 +19,7 @@ Error: This type "entity" = "< destroy_subject : id subject; entity_id : id >"
          "(< destroy_subject : < add_observer : 'd -> 'b; .. >; .. > as 'a)
          entity_container as 'd" =
            "< add_entity : 'a -> 'b; notify : 'a -> id -> unit >"
-       Types for method "add_observer" are incompatible, the method has type
-       "(id subject, id) observer -> unit", but the expected method type was
+       The method "add_observer" has type "(id subject, id) observer -> unit",
+       but the expected method type was
        "< destroy_subject : < add_observer : 'e; .. >; .. > entity_container ->
        'b as 'e"

--- a/testsuite/tests/typing-poly/poly.ml
+++ b/testsuite/tests/typing-poly/poly.ml
@@ -1161,7 +1161,9 @@ Error: This expression has type
          "< m : 'b. 'b * ('b * < m : 'c. 'c * 'a > as 'a) >"
        but an expression was expected of type
          "< m : 'b. 'b * ('b * < m : 'c. 'c * ('c * 'd) >) > as 'd"
-       Types for method "m" are incompatible
+       Types for method "m" are incompatible, the method has type
+       "'c. 'c * ('b * < m : 'c. 'e >) as 'e", but the expected method type was
+       "'c. 'c * ('c * < m : 'b. 'b * ('b * < m : 'c. 'f >) >) as 'f"
 |}];;
 
 module M

--- a/testsuite/tests/typing-poly/poly.ml
+++ b/testsuite/tests/typing-poly/poly.ml
@@ -1161,8 +1161,8 @@ Error: This expression has type
          "< m : 'b. 'b * ('b * < m : 'c. 'c * 'a > as 'a) >"
        but an expression was expected of type
          "< m : 'b. 'b * ('b * < m : 'c. 'c * ('c * 'd) >) > as 'd"
-       Types for method "m" are incompatible, the method has type
-       "'c. 'c * ('b * < m : 'c. 'e >) as 'e", but the expected method type was
+       The method "m" has type "'c. 'c * ('b * < m : 'c. 'e >) as 'e",
+       but the expected method type was
        "'c. 'c * ('c * < m : 'b. 'b * ('b * < m : 'c. 'f >) >) as 'f"
 |}];;
 

--- a/testsuite/tests/typing-poly/pr9603.ml
+++ b/testsuite/tests/typing-poly/pr9603.ml
@@ -29,7 +29,7 @@ Error: This expression has type
          "< m : 'left 'right. < left : 'left; right : 'right > pair >"
        but an expression was expected of type
          "< m : 'left 'right. < left : 'left; right : 'right > pair >"
-       Types for method "m" are incompatible, the method has type
+       The method "m" has type
        "'left 'right. < left : 'left; right : 'right > pair",
        but the expected method type was
        "'left 'right. < left : 'left; right : 'right > pair"

--- a/testsuite/tests/typing-poly/pr9603.ml
+++ b/testsuite/tests/typing-poly/pr9603.ml
@@ -29,5 +29,8 @@ Error: This expression has type
          "< m : 'left 'right. < left : 'left; right : 'right > pair >"
        but an expression was expected of type
          "< m : 'left 'right. < left : 'left; right : 'right > pair >"
-       Types for method "m" are incompatible
+       Types for method "m" are incompatible, the method has type
+       "'left 'right. < left : 'left; right : 'right > pair",
+       but the expected method type was
+       "'left 'right. < left : 'left; right : 'right > pair"
 |}]

--- a/typing/printtyp.ml
+++ b/typing/printtyp.ml
@@ -2437,6 +2437,8 @@ let explain_object (type variety) : variety Errortrace.obj -> _ = function
       Some (dprintf "@,Self type cannot be unified with a closed object type")
 
 let explain_incompatible_fields name (diff: Types.type_expr Errortrace.diff) =
+  reserve_names diff.got;
+  reserve_names diff.expected;
   dprintf "@,@[The method %a has type@ %a,@ \
   but the expected method type was@ %a@]"
     Style.inline_code name
@@ -2455,8 +2457,6 @@ let explanation (type variety) intro prev env
         dprintf "@[%t@;<1 2>%a@]" intro
           (Style.as_inline_code type_expr_with_reserved_names) ctx
       | None, Univ _, Some(Errortrace.Incompatible_fields {name; diff}) ->
-        reserve_names diff.got;
-        reserve_names diff.expected;
         explain_incompatible_fields name diff
       | _ -> ignore
     in

--- a/typing/printtyp.ml
+++ b/typing/printtyp.ml
@@ -2458,10 +2458,15 @@ let explanation (type variety) intro prev env
       | _ -> ignore
     in
     explain_escape pre kind
-  | Errortrace.Incompatible_fields { name; _ } ->
-      Some(dprintf "@,Types for method %a are incompatible"
-             Style.inline_code name
-          )
+  | Errortrace.Incompatible_fields { name; diff} ->
+    reserve_names diff.got;
+    reserve_names diff.expected;
+    Some(dprintf "@,@[Types for method %a are incompatible, the method has \
+                    type@ %a,@ but the expected method type was@ %a@]"
+      Style.inline_code name
+      (Style.as_inline_code type_expr_with_reserved_names) diff.got
+      (Style.as_inline_code type_expr_with_reserved_names) diff.expected
+    )
   | Errortrace.Variant v ->
     explain_variant v
   | Errortrace.Obj o ->


### PR DESCRIPTION
This PR adds more details to the end of the error message, detailing the difference between the expected and actual type of the method that failed. The code follows the same approach than the `Errortrace.Escape` branch.