### PR TITLE
Fixes a false warning thrown when compiling with --enable-tsan

### DIFF
--- a/tools/ocamlmklib.ml
+++ b/tools/ocamlmklib.ml
@@ -164,6 +164,8 @@ let parse_arguments argv =
       c_opts := s :: !c_opts
     else if s = "-framework" then
       (let a = next_arg s in c_opts := a :: s :: !c_opts)
+    else if s = "-fsanitize=thread" then
+      c_opts := s :: !c_opts
     else if starts_with s "-" then
       prerr_endline ("Unknown option " ^ s)
     else

--- a/tools/ocamlmklib.ml
+++ b/tools/ocamlmklib.ml
@@ -165,7 +165,9 @@ let parse_arguments argv =
     else if s = "-framework" then
       (let a = next_arg s in c_opts := a :: s :: !c_opts)
     else if s = "-fsanitize=thread" then
-      c_opts := s :: !c_opts
+    (* Ignore TSAN option as it is already passed to ocamlc and ocamlopt;
+       creating a shared library does not need the option *)
+      ()
     else if starts_with s "-" then
       prerr_endline ("Unknown option " ^ s)
     else


### PR DESCRIPTION
When compiling otherlibs/unix the following warning is thrown

>   OCAMLMKLIB libunixbyt.a
  OCAMLMKLIB libunixbyt.a
Unknown option -fsanitize=thread

The following rule is used to compile `libunixbyte.a`
`lib$(CLIBNAME_BYTECODE).$(A): $(COBJS)
	$(V_OCAMLMKLIB)$(MKLIB) -oc $(CLIBNAME_NATIVE) $(COBJS_NATIVE) $(LDOPTS)`

LDOPTS does not seem to be mandatory when linking objects .a libraries.

