### PR TITLE
[5.1] Use the PIC object file zstd.npic.o in ocamlcommon.a

### DIFF
--- a/Changes
+++ b/Changes
@@ -3,7 +3,7 @@ OCaml 5.1.1
 
 ### Standard library:
 
-* #12562, #12734: Remove the `Marshal.Compression` flag to the
+* #12562, #12734, #12783: Remove the `Marshal.Compression` flag to the
   `Marshal.to_*` functions introduced in 5.1 by #12006, as it cannot
   be implemented without risking to link -lzstd with all
   ocamlopt-generated executables.  The compilers are still able to use

--- a/compilerlibs/Makefile.compilerlibs
+++ b/compilerlibs/Makefile.compilerlibs
@@ -432,7 +432,7 @@ compilerlibs/ocamlcommon.cma: $(COMMON_CMI) $(ALL_CONFIG_CMO) $(COMMON)
 partialclean::
 	rm -f compilerlibs/ocamlcommon.cma
 
-ZSTD_OBJ=runtime/zstd.n.$(O)
+ZSTD_OBJ=runtime/zstd.npic.$(O)
 ZSTD_FLAGS=$(patsubst %, -ccopt %, $(filter-out -l%,$(ZSTD_LIBS))) \
            $(patsubst %, -cclib %, $(filter -l%,$(ZSTD_LIBS)))
 


### PR DESCRIPTION
This is a bug fix on top of #12734.

It is possible that ocamlcommon will be linked against the PIC runtime system. In this case, the zstd object that is part of ocamlcommon.a must use relocatable references to the hooks defined in extern.c and intern.c.

This is consistent with the way we build C code in otherlibs, namely always in PIC mode.
