### PR TITLE
Fix minor-heap allocation computation in Gc.counters()

### DIFF
--- a/Changes
+++ b/Changes
@@ -268,6 +268,9 @@ Working version
 - #12625: Remove the Closure module from Obj
   (Vincent Laviron, review by Xavier Leroy)
 
+- #12784: Fix computation of minor-heap allocation in Gc.counters()
+  and Gc.allocated_bytes(). (Nick Barnes, review by Gabriel Scherer)
+
 ### Other libraries:
 
 - #12213: Dynlink library, improve legibility of error messages

--- a/runtime/gc_ctrl.c
+++ b/runtime/gc_ctrl.c
@@ -93,8 +93,8 @@ CAMLprim value caml_gc_quick_stat(value v)
 double caml_gc_minor_words_unboxed (void)
 {
   return (Caml_state->stat_minor_words
-          + ((double) ((uintnat)Caml_state->young_end -
-              (uintnat)Caml_state->young_ptr)) / sizeof(value));
+          + ((double) Wsize_bsize((uintnat)Caml_state->young_end -
+                                  (uintnat)Caml_state->young_ptr)));
 }
 
 CAMLprim value caml_gc_minor_words(value v)
@@ -109,9 +109,7 @@ CAMLprim value caml_gc_counters(value v)
   CAMLlocal1 (res);
 
   /* get a copy of these before allocating anything... */
-  double minwords = Caml_state->stat_minor_words
-    + ((double) Wsize_bsize ((uintnat)Caml_state->young_end -
-        (uintnat) Caml_state->young_ptr)) / sizeof(value);
+  double minwords = caml_gc_minor_words_unboxed();
   double prowords = Caml_state->stat_promoted_words;
   double majwords = Caml_state->stat_major_words +
                     (double) Caml_state->allocated_words;


### PR DESCRIPTION
`Gc.counters()` computes minor-heap allocation incorrectly: it divides the allocation *in words* since the last collection by the word size.