### PR TITLE
remove abuses of levels in Ctype.limited_generalize

### DIFF
--- a/Changes
+++ b/Changes
@@ -517,6 +517,9 @@ Working version
   rename Env.add_local_type to add_local_constraint
   (Takafumi Saikawa and Jacques Garrigue, review by Florian Angeletti)
 
+- #12786 : Clean up the algorithm of Ctype.limited_generalize
+  (Takafumi Saikawa and Jacques Garrigue, review by Gabriel Scherer)
+
 ### Build system:
 
 - #12198, #12321, #12586, #12616, #12706: continue the merge of the

--- a/typing/btype.ml
+++ b/typing/btype.ml
@@ -46,9 +46,11 @@ end
 module TransientTypeHash = Hashtbl.Make(TransientTypeOps)
 module TypeHash = struct
   include TransientTypeHash
+  let mem hash = wrap_repr (mem hash)
   let add hash = wrap_repr (add hash)
   let remove hash = wrap_repr (remove hash)
   let find hash = wrap_repr (find hash)
+  let find_opt hash = wrap_repr (find_opt hash)
   let iter f = TransientTypeHash.iter (wrap_type_expr f)
 end
 module TransientTypePairs =

--- a/typing/btype.mli
+++ b/typing/btype.mli
@@ -39,9 +39,11 @@ module TypeMap : sig
 end
 module TypeHash : sig
   include Hashtbl.S with type key = transient_expr
+  val mem: 'a t -> type_expr -> bool
   val add: 'a t -> type_expr -> 'a -> unit
-  val remove : 'a t -> type_expr -> unit
+  val remove: 'a t -> type_expr -> unit
   val find: 'a t -> type_expr -> 'a
+  val find_opt: 'a t -> type_expr -> 'a option
   val iter: (type_expr -> 'a -> unit) -> 'a t -> unit
 end
 module TypePairs : sig


### PR DESCRIPTION
`Ctype.limited_generalize` is using an involved algorithm that exploits negative levels to
traverse an inverse graph of a type.

This PR simplifies the algorithm using `TypeHash` to implement the inverse graph,
and makes the code easier to understand.

Coauthored by @garrigue 