### PR TITLE
Avoid using _Bool in public headers for the sake of C++ compatibility

### DIFF
--- a/Changes
+++ b/Changes
@@ -81,6 +81,11 @@ Working version
 - #11332, #12702: make sure `Bool_val(v)` has type `bool` in C++
   (Xavier Leroy, report by ygrek, review by Gabriel Scherer)
 
+- #12772, #12787: Avoid using _Bool in public headers for the sake of C++
+  compatibility
+  (Guillaume Munch-Maccagnoni, report by KC Sivaramakrishnan, review
+  by Xavier Leroy and KC Sivaramakrishnan)
+
 - #12223: Constify constructors and flags tables in C code. Now these
   tables will go in the readonly segment, where they belong.
   (Antonin Décimo, review by Gabriel Scherer and Xavier Leroy)

--- a/runtime/amd64.S
+++ b/runtime/amd64.S
@@ -693,7 +693,7 @@ ENDFUNCTION(G(caml_allocN))
      #include <stdint.h>
 
      typedef struct { _Atomic(uint64_t) young_limit;
-                      _Bool action_pending; } caml_domain_state;
+                      int64_t action_pending; } caml_domain_state;
 
      void ret_from_c_call(caml_domain_state *dom_st)
      {
@@ -704,6 +704,7 @@ ENDFUNCTION(G(caml_allocN))
 
 */
 #define RET_FROM_C_CALL                         \
+        /* Test the least-significant byte of action_pending */ \
         cmpb    $0, Caml_state(action_pending); \
         jne     1f;                             \
         ret;                                    \

--- a/runtime/arm64.S
+++ b/runtime/arm64.S
@@ -418,8 +418,8 @@ FUNCTION(caml_allocN)
 /* Function to call is in ADDITIONAL_ARG */
 
 .macro RET_FROM_C_CALL
-        ldrb    w16, Caml_state(action_pending)
-        cbnz    w16, 1f
+        ldr     TMP, Caml_state(action_pending)
+        cbnz    TMP, 1f
         ret
 1:      mov     TMP, #-1
         str     TMP, Caml_state(young_limit)

--- a/runtime/caml/domain_state.tbl
+++ b/runtime/caml/domain_state.tbl
@@ -42,9 +42,9 @@ DOMAIN_STATE(struct stack_info*, current_stack)
 DOMAIN_STATE(void*, exn_handler)
 /* Pointer into the current stack */
 
-DOMAIN_STATE(_Bool, action_pending)
+DOMAIN_STATE(intnat, action_pending)
 /* Whether we are due to start the processing of delayable pending
-   actions. See runtime/signal.c. */
+   actions. See runtime/signal.c. Valid values: 0,1. */
 
 DOMAIN_STATE(struct c_stack_link*, c_stack)
 /* The C stack associated with this domain.

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -679,7 +679,7 @@ static void domain_create(uintnat initial_minor_heap_wsize) {
   domain_state->c_stack = NULL;
   domain_state->exn_handler = NULL;
 
-  domain_state->action_pending = false;
+  domain_state->action_pending = 0;
 
   domain_state->gc_regs_buckets = NULL;
   domain_state->gc_regs = NULL;

--- a/runtime/power.S
+++ b/runtime/power.S
@@ -293,8 +293,8 @@ ENDFUNCTION caml_call_gc
 /* Call a C function from OCaml.  Function to call is in C_CALL_FUN */
 
 .macro RET_FROM_C_CALL
-        lbz     TMP, Caml_state(action_pending)
-        cmplwi  TMP, 0
+        ld      TMP, Caml_state(action_pending)
+        cmpdi   TMP, 0
         beqlr+  0
         li      TMP, -1
         std     TMP, Caml_state(young_limit)

--- a/runtime/riscv.S
+++ b/runtime/riscv.S
@@ -337,7 +337,7 @@ END_FUNCTION(caml_allocN)
 /* Function to call is in ADDITIONAL_ARG */
 
 .macro RET_FROM_C_CALL
-        lbu     TMP, Caml_state(action_pending)
+        ld      TMP, Caml_state(action_pending)
         bnez    TMP, 1f
         ret
 1:      li      TMP, -1

--- a/runtime/s390x.S
+++ b/runtime/s390x.S
@@ -386,7 +386,8 @@ ENDFUNCTION(G(caml_allocN))
 /******************************************************************************/
 
 #define RET_FROM_C_CALL                           \
-        cli     Caml_state(action_pending), 0;    \
+        /* Test the least-significant byte of action_pending */ \
+        cli     7+Caml_state(action_pending), 0;  \
         ber     %r14;                             \
         lghi    TMP, -1;                          \
         stg     TMP, Caml_state(young_limit);     \

--- a/runtime/signals.c
+++ b/runtime/signals.c
@@ -318,7 +318,7 @@ void caml_request_minor_gc (void)
 /* We assume that we have unique access to dom_st. */
 CAMLexport void caml_set_action_pending(caml_domain_state * dom_st)
 {
-  dom_st->action_pending = true;
+  dom_st->action_pending = 1;
 }
 
 static int check_pending_actions(caml_domain_state * dom_st)
@@ -344,7 +344,7 @@ value caml_do_pending_actions_exn(void)
 
      We can now clear the action_pending flag since we are going to
      execute all actions. */
-  Caml_state->action_pending = false;
+  Caml_state->action_pending = 0;
 
   /* Call signal handlers first */
   value exn = caml_process_pending_signals_exn();


### PR DESCRIPTION
Headers must be compatible with C++ so they cannot refer to _Bool. We replace _Bool for Caml_state->action_pending with intnat where only the least-significant byte is taken into account.

Fixes: #12772. See discussion there regarding the choice for s390x.

Precheck passes: https://ci.inria.fr/ocaml/job/precheck/915/