### PR TITLE
Expose and use `cpp`, `cppflags`, and `cflags` in ocamltest

### DIFF
--- a/configure
+++ b/configure
@@ -13630,10 +13630,9 @@ case $ocaml_cv_cc_vendor in #(
     ocamltest_CPP="$CPP" ;; #(
   msvc-*) :
     CPP="$CC -nologo -EP"
-    ocamltest_CPP="$CPP 2>null" ;; #(
+    ocamltest_CPP="$CPP 2> nul" ;; #(
   *) :
-    #  TODO: why can we not use $CPP in multicore, fix this?
-  CPP="$CC -E -P"
+    CPP="$CC -E -P"
   ocamltest_CPP="$CPP" ;;
 esac
 

--- a/configure.ac
+++ b/configure.ac
@@ -648,8 +648,7 @@ AS_CASE([$ocaml_cv_cc_vendor],
     ocamltest_CPP="$CPP"],
   [msvc-*],
     [CPP="$CC -nologo -EP"
-    ocamltest_CPP="$CPP 2>null"],
-#  TODO: why can we not use $CPP in multicore, fix this?
+    ocamltest_CPP="$CPP 2> nul"],
   [CPP="$CC -E -P"
   ocamltest_CPP="$CPP"])
 

--- a/ocamltest/ocaml_actions.ml
+++ b/ocamltest/ocaml_actions.ml
@@ -1116,6 +1116,7 @@ let config_variables _log env =
     Ocaml_variables.mkexe, Ocamltest_config.mkexe;
     Ocaml_variables.c_preprocessor, Ocamltest_config.c_preprocessor;
     Ocaml_variables.cc, Ocamltest_config.cc;
+    Ocaml_variables.cflags, Ocamltest_config.cflags;
     Ocaml_variables.csc, Ocamltest_config.csc;
     Ocaml_variables.csc_flags, Ocamltest_config.csc_flags;
     Ocaml_variables.shared_library_cflags,

--- a/ocamltest/ocaml_actions.ml
+++ b/ocamltest/ocaml_actions.ml
@@ -1114,7 +1114,8 @@ let config_variables _log env =
     Ocaml_variables.nativecc_libs, Ocamltest_config.nativecc_libs;
     Ocaml_variables.mkdll, Ocamltest_config.mkdll;
     Ocaml_variables.mkexe, Ocamltest_config.mkexe;
-    Ocaml_variables.c_preprocessor, Ocamltest_config.c_preprocessor;
+    Ocaml_variables.cpp, Ocamltest_config.cpp;
+    Ocaml_variables.cppflags, Ocamltest_config.cppflags;
     Ocaml_variables.cc, Ocamltest_config.cc;
     Ocaml_variables.cflags, Ocamltest_config.cflags;
     Ocaml_variables.csc, Ocamltest_config.csc;

--- a/ocamltest/ocaml_variables.ml
+++ b/ocamltest/ocaml_variables.ml
@@ -38,8 +38,11 @@ let binary_modules = make ("binary_modules",
 let bytecc_libs = make ("bytecc_libs",
   "Libraries to link with for bytecode")
 
-let c_preprocessor = make ("c_preprocessor",
+let cpp = make ("cpp",
   "Command to use to invoke the C preprocessor")
+
+let cppflags = make ("cppflags",
+  "Flags passed to the C preprocessor")
 
 let cc = make ("cc",
   "Command to use to invoke the C compiler")
@@ -247,7 +250,8 @@ let _ = List.iter register_variable
     arch;
     binary_modules;
     bytecc_libs;
-    c_preprocessor;
+    cpp;
+    cppflags;
     cc;
     cflags;
     caml_ld_library_path;

--- a/ocamltest/ocaml_variables.ml
+++ b/ocamltest/ocaml_variables.ml
@@ -44,6 +44,9 @@ let c_preprocessor = make ("c_preprocessor",
 let cc = make ("cc",
   "Command to use to invoke the C compiler")
 
+let cflags = make ("cflags",
+  "Flags passed to the C compiler")
+
 let caml_ld_library_path_name = "CAML_LD_LIBRARY_PATH"
 
 let export_caml_ld_library_path value =
@@ -245,6 +248,8 @@ let _ = List.iter register_variable
     binary_modules;
     bytecc_libs;
     c_preprocessor;
+    cc;
+    cflags;
     caml_ld_library_path;
     codegen_exit_status;
     compare_programs;

--- a/ocamltest/ocaml_variables.mli
+++ b/ocamltest/ocaml_variables.mli
@@ -30,6 +30,8 @@ val c_preprocessor : Variables.t
 
 val cc : Variables.t
 
+val cflags : Variables.t
+
 val caml_ld_library_path : Variables.t
 
 val codegen_exit_status : Variables.t

--- a/ocamltest/ocaml_variables.mli
+++ b/ocamltest/ocaml_variables.mli
@@ -26,7 +26,9 @@ val binary_modules : Variables.t
 val bytecc_libs : Variables.t
 (** Libraries to link with for bytecode *)
 
-val c_preprocessor : Variables.t
+val cpp : Variables.t
+
+val cppflags : Variables.t
 
 val cc : Variables.t
 

--- a/ocamltest/ocamltest_config.ml.in
+++ b/ocamltest/ocamltest_config.ml.in
@@ -23,6 +23,10 @@ let afl_instrument = @afl@
 
 let asm = {@QS@|@AS@|@QS@}
 
+let cpp = {@QS@|@ocamltest_CPP@|@QS@}
+
+let cppflags = {@QS@|@oc_cppflags@|@QS@}
+
 let cc = {@QS@|@CC@|@QS@}
 
 let cflags = {@QS@|@oc_cflags@|@QS@}
@@ -47,8 +51,6 @@ let libext = {@QS@|@libext@|@QS@}
 let asmext = {@QS@|@S@|@QS@}
 
 let system = {@QS@|@system@|@QS@}
-
-let c_preprocessor = {@QS@|@ocamltest_CPP@|@QS@}
 
 let ocamlsrcdir = {@QS@|@ocamlsrcdir@|@QS@}
 

--- a/ocamltest/ocamltest_config.mli
+++ b/ocamltest/ocamltest_config.mli
@@ -25,7 +25,7 @@ val asm : string
 (** Path to the assembler *)
 
 val cc : string
-(** Path to the C compiler *)
+(** Command to use to invoke the C compiler *)
 
 val cflags : string
 (** Flags to pass to the C compiler *)

--- a/ocamltest/ocamltest_config.mli
+++ b/ocamltest/ocamltest_config.mli
@@ -24,6 +24,12 @@ val afl_instrument : bool
 val asm : string
 (** Path to the assembler *)
 
+val cpp : string
+(** Command to use to invoke the C preprocessor *)
+
+val cppflags : string
+(** Flags to pass to the C preprocessor *)
+
 val cc : string
 (** Command to use to invoke the C compiler *)
 
@@ -63,9 +69,6 @@ val asmext : string
 
 val system : string
 (** The content of the SYSTEM Make variable *)
-
-val c_preprocessor : string
-(** Command to use to invoke the C preprocessor *)
 
 val ocamlc_default_flags : string
 (** Flags passed by default to ocamlc.byte and ocamlc.opt *)

--- a/testsuite/tests/basic/constprop.ml.c
+++ b/testsuite/tests/basic/constprop.ml.c
@@ -1,5 +1,5 @@
 (* TEST
- flags = "-pp '${c_preprocessor}'";
+ flags = "-pp '${cpp} ${cppflags}'";
  ocaml_filetype_flag = "-impl";
  {
    compare_programs = "false";

--- a/testsuite/tests/output-complete-obj/test.ml
+++ b/testsuite/tests/output-complete-obj/test.ml
@@ -6,7 +6,9 @@
    flags = "-w -a -output-complete-obj";
    program = "test.ml.bc.${objext}";
    ocamlc.byte;
-   script = "${mkexe} -I${ocamlsrcdir}/runtime -o test.ml_bc_stub.exe test.ml.bc.${objext} ${bytecc_libs} test.ml_stub.c";
+   script = "${cc} ${cppflags} ${cflags} -I${ocamlsrcdir}/runtime -c test.ml_stub.c";
+   script;
+   script = "${mkexe} -I${ocamlsrcdir}/runtime -o test.ml_bc_stub.exe test.ml.bc.${objext} ${bytecc_libs} test.ml_stub.${objext}";
    output = "${compiler_output}";
    script;
    program = "./test.ml_bc_stub.exe";
@@ -18,7 +20,9 @@
    flags = "-w -a -output-complete-obj";
    program = "test.ml.exe.${objext}";
    ocamlopt.byte;
-   script = "${mkexe} -I${ocamlsrcdir}/runtime -o test.ml_stub.exe test.ml.exe.${objext} ${nativecc_libs} test.ml_stub.c";
+   script = "${cc} ${cppflags} ${cflags} -I${ocamlsrcdir}/runtime -c test.ml_stub.c";
+   script;
+   script = "${mkexe} -I${ocamlsrcdir}/runtime -o test.ml_stub.exe test.ml.exe.${objext} ${nativecc_libs} test.ml_stub.${objext}";
    output = "${compiler_output}";
    script;
    program = "./test.ml_stub.exe";


### PR DESCRIPTION
Exposing these variables is needed to improve a test with MSVC. The definition of `ocamltest_CPP` was slightly wrong for a while: using `null` instead of `nul` or `/dev/null`.