### PR TITLE
bytecode -custom supply missing externs

### DIFF
--- a/Changes
+++ b/Changes
@@ -514,6 +514,11 @@ Working version
 
 ### Bug fixes:
 
+- # 12791: `extern` is applied to definitions of `caml_builtin_cprim`
+    and `caml_names_of_builtin_cprim` when linking bytecode '-custom'
+    executables with a C++ linker
+  (Shayne Fletcher, review by Antonin Décimo and Xavier Leroy)
+
 - #12712, #12742: fix an assertion boundary case in `caml_reset_young_limit`
   (Jan Midtgaard, review by Guillaume Munch-Maccagnoni and KC Sivaramakrishnan)
 

--- a/bytecomp/symtable.ml
+++ b/bytecomp/symtable.ml
@@ -177,11 +177,17 @@ let output_primitive_table outchan =
     fprintf outchan "extern value %s(void);\n" prim.(i)
   done;
   fprintf outchan "typedef value (*c_primitive)(void);\n";
+  fprintf outchan "#if defined __cplusplus\n";
+  fprintf outchan "extern\n";
+  fprintf outchan "#endif\n";
   fprintf outchan "const c_primitive caml_builtin_cprim[] = {\n";
   for i = 0 to Array.length prim - 1 do
     fprintf outchan "  %s,\n" prim.(i)
   done;
   fprintf outchan "  0 };\n";
+  fprintf outchan "#if defined __cplusplus\n";
+  fprintf outchan "extern\n";
+  fprintf outchan "#endif\n";
   fprintf outchan "const char * const caml_names_of_builtin_cprim[] = {\n";
   for i = 0 to Array.length prim - 1 do
     fprintf outchan "  \"%s\",\n" prim.(i)


### PR DESCRIPTION
Since ocaml-5.1.0, bytecode `-custom` executables fail to link if given `-cc` a C++ compiler. 
```
$ cat > hello_world.ml
let () = print_string "Hello world!\n"
^D
$ ocamlc.opt -o hello-world ./hello_world.ml -custom -cc "clang++"
ld: Undefined symbols:
  _caml_builtin_cprim, referenced from:...
  _caml_names_of_builtin_cprim, referenced form:...
...
```
This is a consequence of certain symbols in generated code being assigned internal linkage by default. This PR addresses the issue by arranging to qualify these constants as `extern`.  Fixes https://github.com/ocaml/ocaml/issues/12790