### PR TITLE
Replace ssize_t with ptrdiff_t

### DIFF
--- a/runtime/backtrace_byt.c
+++ b/runtime/backtrace_byt.c
@@ -393,7 +393,7 @@ static value alloc_callstack(backtrace_slot *trace, size_t slots)
 size_t caml_get_callstack(size_t max_slots,
                           backtrace_slot **buffer_p,
                           size_t *alloc_size_p,
-                          ssize_t alloc_idx)
+                          ptrdiff_t alloc_idx)
 {
   CAMLassert(alloc_idx < 1); /* allocation indexes not used in bytecode */
   return get_callstack(Caml_state->current_stack->sp,

--- a/runtime/backtrace_nat.c
+++ b/runtime/backtrace_nat.c
@@ -88,7 +88,7 @@ void caml_free_backtrace_buffer(backtrace_slot *backtrace_buffer) {
 #define Frame_descr_slot(s) ((frame_descr*)(s))
 #define Slot_frame_descr(f) ((backtrace_slot)(f))
 
-static debuginfo debuginfo_extract(frame_descr *d, ssize_t alloc_idx);
+static debuginfo debuginfo_extract(frame_descr *d, ptrdiff_t alloc_idx);
 
 /* Stores the return addresses contained in the given stack fragment
    into the backtrace array ; this version is performance-sensitive as
@@ -140,7 +140,7 @@ void caml_stash_backtrace(value exn, uintnat pc, char * sp, char* trapsp)
    using a bounded buffer as [caml_stash_backtrace], we dynamically
    grow the allocated space as required. */
 static size_t get_callstack(struct stack_info* stack, intnat max_slots,
-                            ssize_t alloc_idx,
+                            ptrdiff_t alloc_idx,
                             backtrace_slot **backtrace_p,
                             size_t *alloc_size_p)
 {
@@ -205,7 +205,7 @@ static size_t get_callstack(struct stack_info* stack, intnat max_slots,
 size_t caml_get_callstack(size_t max_slots,
                           backtrace_slot **buffer_p,
                           size_t *alloc_size_p,
-                          ssize_t alloc_idx)
+                          ptrdiff_t alloc_idx)
 {
   return get_callstack(Caml_state->current_stack, max_slots,
                        alloc_idx,
@@ -262,7 +262,7 @@ CAMLprim value caml_get_continuation_callstack (value cont, value max_frames)
   return alloc_callstack(trace, slots);
 }
 
-static debuginfo debuginfo_extract(frame_descr *d, ssize_t alloc_idx)
+static debuginfo debuginfo_extract(frame_descr *d, ptrdiff_t alloc_idx)
 {
   unsigned char* infoptr;
   uint32_t debuginfo_offset;

--- a/runtime/caml/backtrace.h
+++ b/runtime/caml/backtrace.h
@@ -127,7 +127,7 @@ CAMLextern void caml_load_main_debug_info(void);
 extern size_t caml_get_callstack(size_t max_slots,
                                  backtrace_slot **buffer_p,
                                  size_t *alloc_size_p,
-                                 ssize_t alloc_idx);
+                                 ptrdiff_t alloc_idx);
 
 
 /* Default (C-level) printer for backtraces.  It is called if an

--- a/runtime/fiber.c
+++ b/runtime/fiber.c
@@ -441,7 +441,7 @@ static void rewrite_frame_pointers(struct stack_info *old_stack,
     struct frame_walker *base_addr;
     uintnat return_addr;
   } *frame, *next;
-  ssize_t delta;
+  ptrdiff_t delta;
   void *top, **p;
 
   delta = (char*)Stack_high(new_stack) - (char*)Stack_high(old_stack);


### PR DESCRIPTION
A few uses of `ssize_t` have crept into the runtime. We should avoid this as this type is not provided by MSVC on Windows. The closest equivalent standard type is `ptrdiff_t`. This PR replaces one with the other.

<details>
<summary>Background</summary>

`size_t` is an unsiged integral type defined by C standard headers, large enough to hold the size in bytes of any object, and is the result type of `sizeof()` and used as an argument or return type by many library functions. It's approximately "an unsigned integral type the same size as a pointer", at least on platforms on which large arrays are possible, pointers are addresses, and there's a linear address space.

`ssize_t` is a signed integral type of the same size as `size_t`. It's required by POSIX (_not_ by the C standard), and used where a size is usually wanted but exceptional conditions are signalled with a negative value. For instance, it's the return type of `write()`. However, the runtime has to compile on non-POSIX platforms, such as MSVC/Windows. MSVC doesn't provide `ssize_t` in any of its headers (although there is `SSIZE_T`). So we should avoid using `ssize_t`.

`ptrdiff_t` is the closest equivalent to `ssize_t` in the C standard. It is the signed integral type of the difference between two pointers (therefore, approximately, "a _signed_ integral type the same size as a pointer", at least on platforms on which large arrays are possible, pointers are addresses, and there's a linear address space).

In the backtrace code, our `ssize_t` is a really good fit for `ptrdiff_t` as it is exactly either an index into an array (the difference between two pointers) or -1 for the exceptional case. In the fibers code it's a bit more of a stretch (being the difference between pointers to two different objects) but ought still to work on all our platforms.
</details>