### PR TITLE
Add manual build dependency packages

### DIFF
--- a/manual/README.md
+++ b/manual/README.md
@@ -14,6 +14,18 @@ Prerequisites
 Note that you must make sure `hevea.sty` is installed into TeX properly. Your
 package manager may not do this for you. Run `kpsewhich hevea.sty` to check.
 
+On a pristine Ubuntu 22.04.1 LTS environment, ensure that you have the
+following additional packages installed:
+
+```
+apt install hevea sass
+```
+
+The `lambdasoup` package is also required on the local opam switch:
+
+```
+opam install lambdasoup
+```
 
 Building the manual
 --------

--- a/manual/README.md
+++ b/manual/README.md
@@ -14,17 +14,10 @@ Prerequisites
 Note that you must make sure `hevea.sty` is installed into TeX properly. Your
 package manager may not do this for you. Run `kpsewhich hevea.sty` to check.
 
-On a pristine Ubuntu 22.04.1 LTS environment, ensure that you have the
-following additional packages installed:
+On a pristine Ubuntu 22.04.1 LTS environment, ensure that you have the `hevea` package installed:
 
 ```
-apt install hevea sass
-```
-
-The `lambdasoup` package is also required on the local opam switch:
-
-```
-opam install lambdasoup
+apt install hevea
 ```
 
 Building the manual

--- a/manual/src/html_processing/README.md
+++ b/manual/src/html_processing/README.md
@@ -18,7 +18,8 @@ They both use a common module `common.ml`.
 ## Prerequisites
 
 In order to do postprocessing of the HTML manual, ensure that you have
-the `sass` package installed:
+the `sass` package installed. On Debian-based Linux distributions, you
+can install the package by:
 
 ```
 apt install sass

--- a/manual/src/html_processing/README.md
+++ b/manual/src/html_processing/README.md
@@ -15,6 +15,21 @@ There are two different scripts, `process_manual.ml` and
 manual, while the latter deals with the api generated with `ocamldoc`.
 They both use a common module `common.ml`.
 
+## Prerequisites
+
+In order to do postprocessing of the HTML manual, ensure that you have
+the `sass` package installed:
+
+```
+apt install sass
+```
+
+The `lambdasoup` package is also required on the local opam switch:
+
+```
+opam install lambdasoup
+```
+
 ## How to build
 
 With dependencies to build the whole manual:


### PR DESCRIPTION
The HTML and API reference manuals require additional packages to be installed on Ubuntu (22.04.1 LTS, for example) in order to build the same. They have been explicitly mentioned in the README.md for reference.