### PR TITLE
Fix memory corruption in caml_unix_alloc_sockaddr (#12796)

### DIFF
--- a/Changes
+++ b/Changes
@@ -669,6 +669,9 @@ Working version
 - #12755: Fix data race on global pools arrays of pool_freelist
   (Fabrice Buoro and Olivier Nicole, review by Gabriel Scherer)
 
+- #12796: Fix memory corruption in caml_unix_alloc_sockaddr
+  (Thomas Leonard)
+
 OCaml 5.1.1
 -----------
 

--- a/otherlibs/unix/socketaddr.c
+++ b/otherlibs/unix/socketaddr.c
@@ -117,7 +117,7 @@ value caml_unix_alloc_sockaddr(union sock_addr_union * adr /*in*/,
   if (adr_len < offsetof(struct sockaddr, sa_data)) {
     // Only possible for an unnamed AF_UNIX socket, in
     // which case sa_family might be uninitialized.
-    return alloc_unix_sockaddr(caml_alloc_string(0));
+    CAMLreturn(alloc_unix_sockaddr(caml_alloc_string(0)));
   }
 
   switch(adr->s_gen.sa_family) {


### PR DESCRIPTION
Fixes #12796