### PR TITLE
Add manual chapter about ThreadSanitizer support

### DIFF
--- a/Changes
+++ b/Changes
@@ -318,6 +318,10 @@ Working version
   (Olivier Nicole, review by Miod Vallat, Gabriel Scherer, Guillaume
    Munch-Maccagnoni and Fabrice Buoro)
 
+- #12802: Add manual chapter about ThreadSanitizer support
+  (Olivier Nicole, review by Miod Vallat, Sebastien Hinderer, Fabrice Buoro and
+   Gabriel Scherer)
+
 ### Compiler user-interface and warnings:
 
 * #10613, #12405: Simplify the values used for the system variable (`system:` in

--- a/Changes
+++ b/Changes
@@ -319,8 +319,8 @@ Working version
    Munch-Maccagnoni and Fabrice Buoro)
 
 - #12802: Add manual chapter about ThreadSanitizer support
-  (Olivier Nicole, review by Miod Vallat, Sebastien Hinderer, Fabrice Buoro and
-   Gabriel Scherer)
+  (Olivier Nicole, review by Miod Vallat, Sebastien Hinderer, Fabrice Buoro,
+   Gabriel Scherer and KC Sivaramakrishnan)
 
 ### Compiler user-interface and warnings:
 

--- a/manual/src/allfiles.etex
+++ b/manual/src/allfiles.etex
@@ -75,6 +75,7 @@ and as a
 \input{afl-fuzz.tex}
 \input{runtime-tracing.tex}
 \input{tail-mod-cons.tex}
+\input{tsan.tex}
 
 \part{The OCaml library}
 \label{p:library}

--- a/manual/src/cmds/Makefile
+++ b/manual/src/cmds/Makefile
@@ -12,7 +12,7 @@ TRANSF = $(OCAMLRUN) $(TOOLS)/transf
 FILES = comp.tex top.tex runtime.tex native.tex lexyacc.tex intf-c.tex \
   ocamldep.tex profil.tex debugger.tex ocamldoc.tex \
   warnings-help.tex flambda.tex tail-mod-cons.tex \
-  afl-fuzz.tex runtime-tracing.tex unified-options.tex
+  afl-fuzz.tex runtime-tracing.tex unified-options.tex tsan.tex
 
 etex-files: $(FILES)
 all: $(FILES)

--- a/manual/src/cmds/tsan.etex
+++ b/manual/src/cmds/tsan.etex
@@ -128,7 +128,7 @@ produce false positives; that is, TSan will not emit spurious reports.
 
 When mixing OCaml and C code, through the use of C primitives, the very notion
 of false positive becomes less clear, as it involves two memory models.
-However, TSan should behave mostly as you expect: non-atomic reads and writes
+However, TSan should behave mostly as one would expect: non-atomic reads and writes
 in C will race with non-atomic reads and writes in OCaml, and C atomics will
 not race with OCaml atomics. There is one theoretical possibility of false
 positive: if a \texttt{value} is initialized from C without using

--- a/manual/src/cmds/tsan.etex
+++ b/manual/src/cmds/tsan.etex
@@ -1,0 +1,207 @@
+\chapter{Runtime detection of data races with ThreadSanitizer}
+\label{c:tsan}\cutname{tsan.html}
+%HEVEA\cutname{tsan.html}
+
+\section{s:tsan-overview}{Overview and usage}
+
+OCaml, since version 5.0, allows shared-memory parallelism and thus mutation of
+shared data. This creates the possibility of data races, i.e., unordered
+accesses to the same data (one of them being a write). Data races can be
+dangerous as they are easy to miss and capable of causing unexpected results.
+More information about data races and their consequences can be found in
+section~\ref{s:par_mm_easy} and Chapter~\ref{c:memorymodel}.
+
+To help detect data races, OCaml supports the ThreadSanitizer runtime detector
+since OCaml 5.2. To use ThreadSanitizer (also known as TSan), you must install
+a dedicated version of the compiler configured with \texttt{--enable-tsan}.
+This can be done using opam:
+
+\begin{verbatim}
+opam switch create <YOUR-SWITCH-NAME-HERE> ocaml-option-tsan
+\end{verbatim}
+
+TSan support for OCaml is currently available for the x86_64 architecture, on
+GNU/Linux and macOS systems. Building OCaml with TSan support requires GCC or
+Clang. Minimal supported versions are GCC 11 and Clang 14. Note that TSan data
+race reports with GCC 11 are known to result in poor stack trace reporting (no
+line numbers), which is fixed in GCC 12.
+
+A TSan-enabled compiler differs from a regular compiler in the following way:
+all programs compiled by \texttt{ocamlopt} are instrumented with calls to the
+TSan runtime, and TSan will detect data races encountered during execution.
+
+For instance, consider the following program:
+
+\begin{caml_example*}{verbatim}
+let a = ref 0 and b = ref 0
+
+let d1 () =
+  a := 1;
+  !b
+
+let d2 () =
+  b := 1;
+  !a
+
+let () =
+  let h = Domain.spawn d2 in
+  let r1 = d1 () in
+  let r2 = Domain.join h in
+  assert (not (r1 = 0 && r2 = 0))
+\end{caml_example*}
+
+When compiling and running this program with \texttt{ocamlopt}, you may get
+data race reports on the standard error, such as:
+
+\begin{verbatim}
+==================
+WARNING: ThreadSanitizer: data race (pid=3808831)
+  Write of size 8 at 0x8febe0 by thread T1 (mutexes: write M90):
+    #0 camlSimple_race.d2_274 simple_race.ml:8 (simple_race.exe+0x420a72)
+    #1 camlDomain.body_706 stdlib/domain.ml:211 (simple_race.exe+0x440f2f)
+    #2 caml_start_program <null> (simple_race.exe+0x47cf37)
+    #3 caml_callback_exn runtime/callback.c:197 (simple_race.exe+0x445f7b)
+    #4 domain_thread_func runtime/domain.c:1167 (simple_race.exe+0x44a113)
+
+  Previous read of size 8 at 0x8febe0 by main thread (mutexes: write M86):
+    #0 camlSimple_race.d1_271 simple_race.ml:5 (simple_race.exe+0x420a22)
+    #1 camlSimple_race.entry simple_race.ml:13 (simple_race.exe+0x420d16)
+    #2 caml_program <null> (simple_race.exe+0x41ffb9)
+    #3 caml_start_program <null> (simple_race.exe+0x47cf37)
+[...]
+
+WARNING: ThreadSanitizer: data race (pid=3808831)
+  Read of size 8 at 0x8febf0 by thread T1 (mutexes: write M90):
+    #0 camlSimple_race.d2_274 simple_race.ml:9 (simple_race.exe+0x420a92)
+    #1 camlDomain.body_706 stdlib/domain.ml:211 (simple_race.exe+0x440f2f)
+    #2 caml_start_program <null> (simple_race.exe+0x47cf37)
+    #3 caml_callback_exn runtime/callback.c:197 (simple_race.exe+0x445f7b)
+    #4 domain_thread_func runtime/domain.c:1167 (simple_race.exe+0x44a113)
+
+  Previous write of size 8 at 0x8febf0 by main thread (mutexes: write M86):
+    #0 camlSimple_race.d1_271 simple_race.ml:4 (simple_race.exe+0x420a01)
+    #1 camlSimple_race.entry simple_race.ml:13 (simple_race.exe+0x420d16)
+    #2 caml_program <null> (simple_race.exe+0x41ffb9)
+    #3 caml_start_program <null> (simple_race.exe+0x47cf37)
+[...]
+
+==================
+ThreadSanitizer: reported 2 warnings
+\end{verbatim}
+
+For each detected data race, TSan reports the location of the conflicting
+accesses, their nature (read, write, atomic read, etc.), and the associated
+stack trace.
+
+If you run the above program several times, the output may vary: sometimes TSan
+will report two data races, sometimes one, and sometimes none. This is due to
+the combination of two factors:
+
+\begin{itemize}
+  \item First, TSan reports only the data races encountered during execution,
+    i.e., conflicting, unordered memory accesses that are effectively performed.
+  \item In addition, in this program, depending on executions, there may be no
+    such memory accesses: if \texttt{d1} returns before \texttt{d2} has
+    finished spawning, then all memory accesses originating from \texttt{d1}
+    may happen-before the ones originating from \texttt{d2}, since spawning a
+    domain involves some inter-thread synchronization. In that case, the
+    accesses are considered to be ordered and no data race is reported.
+\end{itemize}
+
+This example illustrates the fact that data races can sometimes be hidden by
+unrelated synchronizing operations.
+
+\section{s:tsan-false-neg-false-pos}{False negatives and false positives}
+
+As illustrated by the previous example, TSan will only report the data races
+effectively encountered during execution. Another important caveat is that TSan
+remembers only a finite number of memory accesses per memory location and per
+thread. At the time of writing, this number is 4. Data races involving a
+forgotten access will not be detected. Lastly, the
+\href{https://github.com/google/sanitizers/wiki/ThreadSanitizerAlgorithm}{documentation
+of TSan} states that there is a tiny probability to miss a race if two threads
+access the same location at the same time. These are the only three cases that
+can cause TSan to miss data races.
+
+For data races between two memory accesses made from OCaml code, TSan does not
+produce false positives; that is, TSan will not emit spurious reports.
+
+When mixing OCaml and C code, through the use of C primitives, the very notion
+of false positive becomes less clear, as it involves two memory models.
+However, TSan should behave mostly as you expect: non-atomic reads and writes
+in C will race with non-atomic reads and writes in OCaml, and C atomics will
+not race with OCaml atomics. There is one theoretical possibility of false
+positive: if a \texttt{value} is initialized from C without using
+\texttt{caml_initialize} (which is allowed under the condition that the GC does
+not run between the allocation and the write, see Chapter~\ref{c:intf-c}) and a
+conflicting access is made later by another thread. This does not constitute a
+data race, but TSan may report it as such.
+
+\section{s:tsan-runtime-flags}{Runtime options}
+
+TSan supports a number of configuration options at runtime using the
+\texttt{TSAN\_OPTIONS} environment variable. Notably, it allows to suppress
+some data races from TSan reports. See the
+\href{https://github.com/google/sanitizers/wiki/ThreadSanitizerFlags}{documentation
+of TSan flags} and the
+\href{https://github.com/google/sanitizers/wiki/SanitizerCommonFlags}{documentation
+of flags common to all sanitizers} for more information. Suppressing data races
+is useful for intentional races or libraries that cannot be fixed.
+
+For example, to suppress reports originating from functions in the OCaml module
+\texttt{My_module}, one could set
+\texttt{TSAN\_OPTIONS} to \texttt{"suppressions=suppr.txt"}, with
+\texttt{suppr.txt} a file containing:
+
+\begin{verbatim}
+race_top:^camlMy_module
+\end{verbatim}
+
+(Note that this depends on the format of OCaml symbols in the executable. Some
+builders, like Dune, might result in different formats. You should adapt this
+example to the symbols effectively present in your stack traces.)
+
+The \texttt{TSAN\_OPTIONS} variable also allows to increase the ``history
+size'', e.g.:
+
+\begin{verbatim}
+TSAN_OPTIONS="history_size=7" ./my_instrumented_program
+\end{verbatim}
+
+Increasing the history size can sometimes be necessary to obtain the second
+stack trace.
+
+\section{s:tsan-c-code}{Guidelines for linking}
+
+As a general rule, OCaml programs instrumented with TSan should only be linked
+with OCaml or C objects also instrumented with TSan. Doing otherwise can result
+in crashes. The only exception to this rule are C libraries that do not call
+into the OCaml runtime system in any way, i.e., do not allocate, raise
+exceptions, call back into OCaml code, etc. Examples include the libc or system
+libraries. Data races in non instrumented libraries will not be reported.
+
+C code interacting with OCaml should always be built through the
+\texttt{ocamlc} or \texttt{ocamlopt} commands, which will pass the required
+instrumentation flags to the C compiler. The \texttt{CAMLno_tsan} qualifier can
+be used to prevent functions from being instrumented:
+
+\begin{verbatim}
+CAMLno_tsan void f(int arg)
+{
+  /* This function will not be instrumented. */
+  ...
+}
+\end{verbatim}
+
+Un-instrumenting functions should be done by expert users only.
+
+\section{s:tsan-signal-changes}{Changes in the delivery of signals}
+
+TSan intercepts all signals and pass them down to the instrumented program.
+This overlay from TSan is not always transparent for the program. Synchronous
+signals such as \texttt{SIGSEV}, \texttt{SIGILL}, \texttt{SIGBUS}, etc.\ will be
+passed down immediately, whereas asynchronous signals such as \texttt{SIGINT}
+will be delayed until the next call to the TSan runtime (e.g.\ until the next
+access to mutable data). This limitation of TSan can have surprising effects:
+for instance, pure, recursive functions that do not allocate cannot be
+interrupted until they terminate.

--- a/manual/src/cmds/tsan.etex
+++ b/manual/src/cmds/tsan.etex
@@ -111,6 +111,15 @@ the combination of two factors:
 This example illustrates the fact that data races can sometimes be hidden by
 unrelated synchronizing operations.
 
+\section{s:tsan-performance}{Performance implications}
+
+TSan instrumentation imposes a non-negligible cost at runtime. Empirically,
+this cost has been observed to cause a slowdown which can range from 2x to 7x.
+One of the main factors of high slowdowns is frequent of access to mutable
+data (in contast, reads from immutable data are not instrumented). The memory
+consumption is also increased, by a factor between 4 and 7. TSan also allocates
+very large amounts of virtual memory (but uses only a fraction of it).
+
 \section{s:tsan-false-neg-false-pos}{False negatives and false positives}
 
 As illustrated by the previous example, TSan will only report the data races
@@ -145,8 +154,8 @@ some data races from TSan reports. See the
 \href{https://github.com/google/sanitizers/wiki/ThreadSanitizerFlags}{documentation
 of TSan flags} and the
 \href{https://github.com/google/sanitizers/wiki/SanitizerCommonFlags}{documentation
-of flags common to all sanitizers} for more information. Suppressing data races
-is useful for intentional races or libraries that cannot be fixed.
+of flags common to all sanitizers} for more information. Suppressing data race
+reports is useful for intentional races or libraries that cannot be fixed.
 
 For example, to suppress reports originating from functions in the OCaml module
 \texttt{My_module}, one could set
@@ -168,8 +177,11 @@ size'', e.g.:
 TSAN_OPTIONS="history_size=7" ./my_instrumented_program
 \end{verbatim}
 
-Increasing the history size can sometimes be necessary to obtain the second
-stack trace.
+TSan’s history records events such as function entry and exit, and is used to
+reconstruct stack traces. Increasing the history size can sometimes be
+necessary to obtain the second stack trace, but it also increases memory
+consumption. This setting does not change the number of memory accesses
+remembered per memory location.
 
 \section{s:tsan-c-code}{Guidelines for linking}
 
@@ -181,9 +193,9 @@ exceptions, call back into OCaml code, etc. Examples include the libc or system
 libraries. Data races in non instrumented libraries will not be reported.
 
 C code interacting with OCaml should always be built through the
-\texttt{ocamlc} or \texttt{ocamlopt} commands, which will pass the required
-instrumentation flags to the C compiler. The \texttt{CAMLno_tsan} qualifier can
-be used to prevent functions from being instrumented:
+\texttt{ocamlopt} command, which will pass the required instrumentation flags
+to the C compiler. The \texttt{CAMLno_tsan} qualifier can be used to prevent
+functions from being instrumented:
 
 \begin{verbatim}
 CAMLno_tsan void f(int arg)
@@ -193,7 +205,15 @@ CAMLno_tsan void f(int arg)
 }
 \end{verbatim}
 
-Un-instrumenting functions should be done by expert users only.
+Races from non instrumented functions will not be reported. Un-instrumenting
+functions should be done by expert users only. It can be used to reduce the
+performance overhead in certain corner cases, or to suppress some known alarms.
+For the latter, the mechanism of run-time suppressions should be preferred when
+possible, as it allows for finer-grained control, and un-instrumentation of a
+function \texttt{f} results in missing entries in TSan’s stack traces when a
+data race happens in a transitive callee of \texttt{f}.
+
+There is no way to disable instrumentation in OCaml code.
 
 \section{s:tsan-signal-changes}{Changes in the delivery of signals}
 

--- a/manual/src/cmds/tsan.etex
+++ b/manual/src/cmds/tsan.etex
@@ -5,16 +5,21 @@
 \section{s:tsan-overview}{Overview and usage}
 
 OCaml, since version 5.0, allows shared-memory parallelism and thus mutation of
-shared data. This creates the possibility of data races, i.e., unordered
-accesses to the same data (one of them being a write). Data races can be
-dangerous as they are easy to miss and capable of causing unexpected results.
-More information about data races and their consequences can be found in
-section~\ref{s:par_mm_easy} and Chapter~\ref{c:memorymodel}.
+data shared between multiple threads. This creates the possibility of data
+races, i.e., unordered accesses to the same memory location with at least one
+of them being a write. In OCaml, data races are easy to introduce, and the
+behaviour of programs with data races can be unintuitive — the observed
+behaviours cannot be explained by simply interleaving operations from different
+concurrent threads. More information about data races and their consequences
+can be found in section~\ref{s:par_mm_easy} and Chapter~\ref{c:memorymodel}.
 
-To help detect data races, OCaml supports the ThreadSanitizer runtime detector
-since OCaml 5.2. To use ThreadSanitizer (also known as TSan), you must install
-a dedicated version of the compiler configured with \texttt{--enable-tsan}.
-This can be done using opam:
+To help detect data races, OCaml supports ThreadSantizer (TSan), a dynamic data
+race detector that has been successfully used in languages such as C/C++,
+Swift, etc. TSan support for OCaml is available since OCaml 5.2.
+
+To use TSan, you must configure the compiler with \texttt{--enable-tsan}. You
+can also install an \texttt{opam} switch with the TSan feature enabled as
+follows:
 
 \begin{verbatim}
 opam switch create <YOUR-SWITCH-NAME-HERE> ocaml-option-tsan
@@ -50,7 +55,14 @@ let () =
   assert (not (r1 = 0 && r2 = 0))
 \end{caml_example*}
 
-When compiling and running this program with \texttt{ocamlopt}, you may get
+This program has data races. The memory locations \texttt{a} and \texttt{b}
+are read and written concurrently by multiple domains \texttt{d1} and
+\texttt{d2}. \texttt{a} and \texttt{b} are ``non-atomic'' locations according
+to the memory model (see Chapter~\ref{c:memorymodel}), and there is no
+synchronization between accesses to them. Hence, there are two data races here
+corresponding to the two memory locations \texttt{a} and \texttt{b}.
+
+When you compile and run this program with \texttt{ocamlopt}, you may observe
 data race reports on the standard error, such as:
 
 \begin{verbatim}
@@ -104,8 +116,8 @@ the combination of two factors:
     such memory accesses: if \texttt{d1} returns before \texttt{d2} has
     finished spawning, then all memory accesses originating from \texttt{d1}
     may happen-before the ones originating from \texttt{d2}, since spawning a
-    domain involves some inter-thread synchronization. In that case, the
-    accesses are considered to be ordered and no data race is reported.
+    domain involves inter-thread synchronization. In that case, the accesses
+    are considered to be ordered and no data race is reported.
 \end{itemize}
 
 This example illustrates the fact that data races can sometimes be hidden by
@@ -116,17 +128,18 @@ unrelated synchronizing operations.
 TSan instrumentation imposes a non-negligible cost at runtime. Empirically,
 this cost has been observed to cause a slowdown which can range from 2x to 7x.
 One of the main factors of high slowdowns is frequent of access to mutable
-data (in contrast, reads from immutable data are not instrumented). The memory
-consumption is also increased, by a factor between 4 and 7. TSan also allocates
-very large amounts of virtual memory (but uses only a fraction of it).
+data. In contrast, the initialising writes to and reads from immutable memory
+locations are not instrumented. TSan also allocates very large amounts of virtual
+memory, although it uses only a fraction of it. The memory consumption is
+increased by a factor between 4 and 7.
 
 \section{s:tsan-false-neg-false-pos}{False negatives and false positives}
 
 As illustrated by the previous example, TSan will only report the data races
-effectively encountered during execution. Another important caveat is that TSan
-remembers only a finite number of memory accesses per memory location and per
-thread. At the time of writing, this number is 4. Data races involving a
-forgotten access will not be detected. Lastly, the
+encountered during execution. Another important caveat is that TSan remembers
+only a finite number of memory accesses per memory location and per thread. At
+the time of writing, this number is 4. Data races involving a forgotten access
+will not be detected. Lastly, the
 \href{https://github.com/google/sanitizers/wiki/ThreadSanitizerAlgorithm}{documentation
 of TSan} states that there is a tiny probability to miss a race if two threads
 access the same location at the same time. These are the only three cases that
@@ -136,10 +149,11 @@ For data races between two memory accesses made from OCaml code, TSan does not
 produce false positives; that is, TSan will not emit spurious reports.
 
 When mixing OCaml and C code, through the use of C primitives, the very notion
-of false positive becomes less clear, as it involves two memory models.
-However, TSan should behave mostly as one would expect: non-atomic reads and writes
-in C will race with non-atomic reads and writes in OCaml, and C atomics will
-not race with OCaml atomics. There is one theoretical possibility of false
+of false positive becomes less clear, as it involves two memory models -- OCaml
+and C11.
+However, TSan should behave mostly as one would expect: non-atomic reads and
+writes in C will race with non-atomic reads and writes in OCaml, and C atomics
+will not race with OCaml atomics. There is one theoretical possibility of false
 positive: if a \texttt{value} is initialized from C without using
 \texttt{caml_initialize} (which is allowed under the condition that the GC does
 not run between the allocation and the write, see Chapter~\ref{c:intf-c}) and a
@@ -149,18 +163,24 @@ data race, but TSan may report it as such.
 \section{s:tsan-runtime-flags}{Runtime options}
 
 TSan supports a number of configuration options at runtime using the
-\texttt{TSAN\_OPTIONS} environment variable. Notably, it allows to suppress
-some data races from TSan reports. See the
+\texttt{TSAN\_OPTIONS} environment variable. \texttt{TSAN\_OPTIONS} should
+contain one or more options separated by spaces. See the
 \href{https://github.com/google/sanitizers/wiki/ThreadSanitizerFlags}{documentation
 of TSan flags} and the
 \href{https://github.com/google/sanitizers/wiki/SanitizerCommonFlags}{documentation
-of flags common to all sanitizers} for more information. Suppressing data race
-reports is useful for intentional races or libraries that cannot be fixed.
+of flags common to all sanitizers} for more information. Notably,
+\texttt{TSAN\_OPTIONS} allows to suppress some data races from TSan reports.
+Suppressing data race reports is useful for intentional races or libraries that
+cannot be fixed.
 
 For example, to suppress reports originating from functions in the OCaml module
-\texttt{My_module}, one could set
-\texttt{TSAN\_OPTIONS} to \texttt{"suppressions=suppr.txt"}, with
-\texttt{suppr.txt} a file containing:
+\texttt{My_module}, one can run
+
+\begin{verbatim}
+TSAN_OPTIONS="suppressions=suppr.txt" ./my_instrumented_program
+\end{verbatim}
+
+with \texttt{suppr.txt} a file containing:
 
 \begin{verbatim}
 race_top:^camlMy_module
@@ -186,11 +206,11 @@ remembered per memory location.
 \section{s:tsan-c-code}{Guidelines for linking}
 
 As a general rule, OCaml programs instrumented with TSan should only be linked
-with OCaml or C objects also instrumented with TSan. Doing otherwise can result
+with OCaml or C objects also instrumented with TSan. Doing otherwise may result
 in crashes. The only exception to this rule are C libraries that do not call
 into the OCaml runtime system in any way, i.e., do not allocate, raise
 exceptions, call back into OCaml code, etc. Examples include the libc or system
-libraries. Data races in non instrumented libraries will not be reported.
+libraries. Data races in non-instrumented libraries will not be reported.
 
 C code interacting with OCaml should always be built through the
 \texttt{ocamlopt} command, which will pass the required instrumentation flags
@@ -205,13 +225,14 @@ CAMLno_tsan void f(int arg)
 }
 \end{verbatim}
 
-Races from non instrumented functions will not be reported. Un-instrumenting
-functions should be done by expert users only. It can be used to reduce the
-performance overhead in certain corner cases, or to suppress some known alarms.
-For the latter, the mechanism of run-time suppressions should be preferred when
-possible, as it allows for finer-grained control, and un-instrumentation of a
-function \texttt{f} results in missing entries in TSan’s stack traces when a
-data race happens in a transitive callee of \texttt{f}.
+Races from non-instrumented functions will not be reported.
+\texttt{CAMLno_tsan} should only be used by experts. It can be used to reduce
+the performance overhead in certain corner cases, or to suppress some known
+alarms. For the latter, using a suppressions file with \texttt{TSAN\_OPTIONS}
+should be preferred when possible, as it allows for finer-grained control, and
+qualifying a function \texttt{f} with \texttt{CAMLno_tsan} results in missing
+entries in TSan’s stack traces when a data race happens in a transitive callee
+of \texttt{f}.
 
 There is no way to disable instrumentation in OCaml code.
 

--- a/manual/src/cmds/tsan.etex
+++ b/manual/src/cmds/tsan.etex
@@ -116,7 +116,7 @@ unrelated synchronizing operations.
 TSan instrumentation imposes a non-negligible cost at runtime. Empirically,
 this cost has been observed to cause a slowdown which can range from 2x to 7x.
 One of the main factors of high slowdowns is frequent of access to mutable
-data (in contast, reads from immutable data are not instrumented). The memory
+data (in contrast, reads from immutable data are not instrumented). The memory
 consumption is also increased, by a factor between 4 and 7. TSan also allocates
 very large amounts of virtual memory (but uses only a fraction of it).
 

--- a/manual/src/cmds/tsan.etex
+++ b/manual/src/cmds/tsan.etex
@@ -217,7 +217,7 @@ There is no way to disable instrumentation in OCaml code.
 
 \section{s:tsan-signal-changes}{Changes in the delivery of signals}
 
-TSan intercepts all signals and pass them down to the instrumented program.
+TSan intercepts all signals and passes them down to the instrumented program.
 This overlay from TSan is not always transparent for the program. Synchronous
 signals such as \texttt{SIGSEV}, \texttt{SIGILL}, \texttt{SIGBUS}, etc.\ will be
 passed down immediately, whereas asynchronous signals such as \texttt{SIGINT}


### PR DESCRIPTION
This adds documentation of the compiler support for ThreadSanitizer, its usage, what can be expected in terms of correctness, the guidelines to follow when linking with external code, and a few caveats to be aware of.

It attempts to be complete (documenting some facts that the sparse documentation available about TSan does not specify) and to give a few examples.