### PR TITLE
List.for_all_ok, List.exists_ok

### DIFF
--- a/Changes
+++ b/Changes
@@ -293,6 +293,11 @@ Working version
 - #12770: Add `Fun.compose`.
   (Justin Frank, review by Nicolás Ojeda Bär, Daniel Bünzli and Jeremy Yallop)
 
+- #???: List.for_all_ok and List.exists_ok
+  List.for_all_ok: ('a -> ('b, 'e) result) -> 'a list -> ('b list, 'e) result
+  List.exists_ok: ('a -> ('b, 'e) result) -> 'a list -> ('b, 'e list) result
+  (Gabriel Scherer, review by ???)
+
 ### Other libraries:
 
 - #12213: Dynlink library, improve legibility of error messages

--- a/stdlib/list.mli
+++ b/stdlib/list.mli
@@ -291,6 +291,24 @@ val exists2 : ('a -> 'b -> bool) -> 'a list -> 'b list -> bool
    to have different lengths.
  *)
 
+val for_all_ok : ('a -> ('b, 'e) result) -> 'a list -> ('b list, 'e) result
+(** [for_all_ok p [a1; ...; an]] evaluates the predicate [p] for each
+    element [a1; ..; an] of the input list, from left to right.
+
+    If the [p a1]..[p an] all return [Ok b1]..[Ok bn], the result is
+    [Ok [b1; ..; bn]]. Otherwise evaluation stops on the leftmost [a]
+    such that [p a] returns [Error e], and the result is [Error e]. *)
+
+val exists_ok : ('a -> ('b, 'e) result) -> 'a list -> ('b, 'e list) result
+(** [for_all_ok p [a1; ...; an]] evaluates the predicate [p] for each
+    element [a1; ..; an] of the input list, from left to right.
+
+    On the leftmost [a] such that [p a] is [Ok v], we return [Ok v].
+    Otherwise, we reach the end of the list and all [p a1]..[p an] have
+    returned an error [Error b1]..[Error bn], and we return the list
+    of errors [Error [b1; ..; bn]]. *)
+
+
 val mem : 'a -> 'a list -> bool
 (** [mem a set] is true if and only if [a] is equal
    to an element of [set].

--- a/testsuite/tests/lib-list/test.ml
+++ b/testsuite/tests/lib-list/test.ml
@@ -59,6 +59,34 @@ let () =
     assert (List.find_map (f ~limit:30) l = None);
   end;
 
+  (* for_all_ok *)
+  begin
+    let f a =
+      if a = 5 then Error "five"
+      else if a > 5 then failwith "please stop at five"
+      else Ok [a]
+    in
+    assert (List.for_all_ok f [] = Ok []);
+    assert (List.for_all_ok f [1; 2; 4] = Ok [[1]; [2]; [4]]);
+    (* the [failwith] case checks that we evaluate
+       from left to right and stop on the first error. *)
+    assert (List.for_all_ok f [1; 2; 5; 6] = Error "five");
+  end;
+
+  (* exists_ok *)
+  begin
+    let f a =
+      if a = 5 then Ok "five"
+      else if a > 5 then failwith "please stop at five"
+      else Error [a]
+    in
+    assert (List.exists_ok f [] = Error []);
+    assert (List.exists_ok f [1; 2; 4] = Error [[1]; [2]; [4]]);
+    (* the [failwith] case checks that we evaluate
+       from left to right and stop on the first success. *)
+    assert (List.exists_ok f [1; 2; 5; 6] = Ok "five");
+  end;
+
   assert (List.filteri (fun i _ -> i < 2) (List.rev l) = [9; 8]);
 
   assert (List.partition is_even [1; 2; 3; 4; 5]


### PR DESCRIPTION
I was motivated by [this reddit question](https://www.reddit.com/r/ocaml/comments/18arpm6/how_to_turn_a_b_result_list_into_a_list_b_result/):

> is there an idiomatic way to turn a list of results `('a, 'b) result list` into a result that contains a list of all the `Result.Ok 'a` or the first `Result.Error 'b` that's encountered when doing the traversal, such that `('a list, 'b) result`? 

The answer is that the stdlib does not provide any help to do this in a reasonable way -- in particular, using `fold_left` is irritating because we cannot have a shortcut semantics, and many tempting approaches rely on exceptions for control flow, which is a performance antipattern for js_of_ocaml.

I propose the following innocuous functions that let people do this easily:

```ocaml
val for_all_ok : ('a -> ('b, 'e) result) -> 'a list -> ('b list, 'e) result
(** [for_all_ok p [a1; ...; an]] evaluates the predicate [p] for each
    element [a1; ..; an] of the input list, from left to right.

    If the [p a1]..[p an] all return [Ok b1]..[Ok bn], the result is
    [Ok [b1; ..; bn]]. Otherwise evaluation stops on the leftmost [a]
    such that [p a] returns [Error e], and the result is [Error e]. *)

val exists_ok : ('a -> ('b, 'e) result) -> 'a list -> ('b, 'e list) result
(** [for_all_ok p [a1; ...; an]] evaluates the predicate [p] for each
    element [a1; ..; an] of the input list, from left to right.

    On the leftmost [a] such that [p a] is [Ok v], we return [Ok v].
    Otherwise, we reach the end of the list and all [p a1]..[p an] have
    returned an error [Error b1]..[Error bn], and we return the list
    of errors [Error [b1; ..; bn]]. *)
```

Note: in the long run we would like to have monad-generic traversals, but let's wait for modular {implicits, explicits} for this :-)