### PR TITLE
Update outdated comment in tsan.c

### DIFF
--- a/runtime/tsan.c
+++ b/runtime/tsan.c
@@ -166,8 +166,6 @@
      concurrently by OCaml code. Because `caml_modify` is instrumented as a
      plain write for proper detection of OCaml races, this case is seen as a
      data race.
-   - An OCaml heap value is accessed from C by two unordered, volatile
-     accesses, at least one of which is a write.
 
    3.3. volatile accesses
 


### PR DESCRIPTION
The merge of #12681 removed a class of TSan false positives, but we forgot to update the explanation comment accordingly. This fixes it.