### PR TITLE
remove Lazy in typing/

### DIFF
--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -1435,7 +1435,7 @@ let copy_sep ~copy_scope ~fixed ~(visited : type_expr TypeHash.t) sch =
   let delayed_copies = ref [] in
   let add_delayed_copy t ty =
     delayed_copies :=
-      lazy (Transient_expr.set_stub_desc t (Tlink (copy copy_scope ty))) ::
+      (fun () -> Transient_expr.set_stub_desc t (Tlink (copy copy_scope ty))) ::
       !delayed_copies
   in
   let rec copy_rec ~may_share (ty : type_expr) =
@@ -1476,7 +1476,7 @@ let copy_sep ~copy_scope ~fixed ~(visited : type_expr TypeHash.t) sch =
     end
   in
   let ty = copy_rec ~may_share:true sch in
-  List.iter Lazy.force !delayed_copies;
+  List.iter (fun force -> force ()) !delayed_copies;
   ty
 
 let instance_poly' copy_scope ~keep_names ~fixed univars sch =


### PR DESCRIPTION
We are trying to avoid using the 'lazy' machinery in the part of the compiler distribution that is used during bootstrap (to build ocamlc.byte). This avoids depending on the arguably complex runtime support for lazy, and it makes it easier to change this runtime support.

As discussed with @lthls yesterday, there was a use of `lazy` in typing/ctype.ml which does not appear to require any sharing/memoization; we replace it by `unit -> 'a` thunks. (I find it a bit surprising that we would use `lazy` when `unit -> 'a` suffices, so I would be reassured by a confirmation by @garrigue that the change is indeed correct.)

