### PR TITLE
Define and use the `CAMLthread_local` macro for TLS variables

### DIFF
--- a/Changes
+++ b/Changes
@@ -197,6 +197,9 @@ Working version
   style that the compiler driver uses.
   (David Allsopp, review by Gabriel Scherer)
 
+- #12811: Define and use the CAMLthread_local macro for TLS variables.
+  (Antonin Décimo and Samuel Hym, review by Miod Vallat and Xavier Leroy)
+
 ### Code generation and optimizations:
 
 - #11239: on x86-64 and RISC-V, reduce alignment of OCaml stacks from 16 to 8.

--- a/configure
+++ b/configure
@@ -15287,8 +15287,8 @@ as_fn_error $? "C11 atomic support is required, use another C compiler
 See \`config.log' for more details" "$LINENO" 5; }
 fi
 
-# Full support for C11 __thread variables
-# macOS and MinGW-64 have problems with __thread variables accessed from DLLs
+# Full support for thread local storage
+# macOS and MinGW-w64 have problems with thread local storage accessed from DLLs
 
 case $host in #(
   *-apple-darwin*|*-mingw32*) :

--- a/configure.ac
+++ b/configure.ac
@@ -1130,8 +1130,8 @@ OCAML_CC_SUPPORTS_ATOMIC([$cclibs])
 AS_IF([! $cc_supports_atomic],
   [AC_MSG_FAILURE([C11 atomic support is required, use another C compiler])])
 
-# Full support for C11 __thread variables
-# macOS and MinGW-64 have problems with __thread variables accessed from DLLs
+# Full support for thread local storage
+# macOS and MinGW-w64 have problems with thread local storage accessed from DLLs
 
 AS_CASE([$host],
   [*-apple-darwin*|*-mingw32*], [],

--- a/runtime/callback.c
+++ b/runtime/callback.c
@@ -78,9 +78,10 @@ Caml_inline void restore_stack_parent(caml_domain_state* domain_state,
 #include "caml/fix_code.h"
 #include "caml/fiber.h"
 
-static __thread opcode_t callback_code[] = { ACC, 0, APPLY, 0, POP, 1, STOP };
+static CAMLthread_local opcode_t callback_code[] =
+  { ACC, 0, APPLY, 0, POP, 1, STOP };
 
-static __thread int callback_code_inited = 0;
+static CAMLthread_local int callback_code_inited = 0;
 
 static void init_callback_code(void)
 {

--- a/runtime/caml/domain_state.h
+++ b/runtime/caml/domain_state.h
@@ -43,7 +43,7 @@ enum {
 #define LAST_DOMAIN_STATE_MEMBER extra_params
 
 #if defined(HAS_FULL_THREAD_VARIABLES) || defined(IN_CAML_RUNTIME)
-  CAMLextern __thread caml_domain_state* caml_state;
+  CAMLextern CAMLthread_local caml_domain_state* caml_state;
   #define Caml_state_opt caml_state
 #else
 #ifdef __GNUC__

--- a/runtime/caml/instrtrace.h
+++ b/runtime/caml/instrtrace.h
@@ -23,7 +23,7 @@
 #include "mlvalues.h"
 #include "misc.h"
 
-extern __thread intnat caml_icount;
+extern CAMLthread_local intnat caml_icount;
 void caml_stop_here (void);
 void caml_disasm_instr (code_t pc);
 void caml_trace_value_file (value v, code_t prog, asize_t proglen, FILE * f);

--- a/runtime/caml/misc.h
+++ b/runtime/caml/misc.h
@@ -154,6 +154,13 @@ CAMLdeprecated_typedef(addr, char *);
 #error "How do I align values on this platform?"
 #endif
 
+#if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 202311L || \
+    defined(__cplusplus)
+#define CAMLthread_local thread_local
+#else
+#define CAMLthread_local _Thread_local
+#endif
+
 /* Prefetching */
 
 #ifdef CAML_INTERNALS

--- a/runtime/caml/platform.h
+++ b/runtime/caml/platform.h
@@ -141,7 +141,7 @@ Caml_inline void check_err(const char* action, int err)
 }
 
 #ifdef DEBUG
-static __thread int lockdepth;
+static CAMLthread_local int lockdepth;
 #define DEBUG_LOCK(m) (lockdepth++)
 #define DEBUG_UNLOCK(m) (lockdepth--)
 #else

--- a/runtime/caml/s.h.in
+++ b/runtime/caml/s.h.in
@@ -44,9 +44,9 @@
 
 #undef HAS_FULL_THREAD_VARIABLES
 
-/* Define HAS_FULL_THREAD_VARIABLES if C11 __thread variables are fully
-   supported, including across DLLs.  This is not the case with
-   macOS and with Windows + MinGW-64. */
+/* Define HAS_FULL_THREAD_VARIABLES if thread-local storage is fully supported,
+   including across DLLs. This is not the case with macOS and with Windows +
+   MinGW-w64. */
 
 #undef HAS_C99_FLOAT_OPS
 

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -247,7 +247,7 @@ uintnat caml_minor_heap_max_wsz;
 
 CAMLexport uintnat caml_minor_heaps_start;
 CAMLexport uintnat caml_minor_heaps_end;
-static __thread dom_internal* domain_self;
+static CAMLthread_local dom_internal* domain_self;
 
 /*
  * This structure is protected by all_domains_lock
@@ -302,7 +302,7 @@ static dom_internal* next_free_domain(void) {
   return stw_domains.domains[stw_domains.participating_domains];
 }
 
-CAMLexport __thread caml_domain_state* caml_state;
+CAMLexport CAMLthread_local caml_domain_state* caml_state;
 
 #ifndef HAS_FULL_THREAD_VARIABLES
 /* Export a getter for caml_state, to be used in DLLs */

--- a/runtime/instrtrace.c
+++ b/runtime/instrtrace.c
@@ -36,7 +36,7 @@
 
 extern code_t caml_start_code;
 
-__thread intnat caml_icount = 0;
+CAMLthread_local intnat caml_icount = 0;
 
 void caml_stop_here (void)
 {

--- a/runtime/interp.c
+++ b/runtime/interp.c
@@ -239,7 +239,7 @@ Caml_inline void check_trap_barrier_for_effect
 #endif
 
 #ifdef DEBUG
-static __thread intnat caml_bcodcount;
+static CAMLthread_local intnat caml_bcodcount;
 #endif
 
 static value raise_unhandled_effect;

--- a/runtime/io.c
+++ b/runtime/io.c
@@ -68,7 +68,7 @@
    currently locked channel (if any), which is then called by
    [caml_raise].
  */
-static __thread struct channel* last_channel_locked = NULL;
+static CAMLthread_local struct channel* last_channel_locked = NULL;
 
 CAMLexport void caml_channel_lock(struct channel *chan)
 {

--- a/runtime/misc.c
+++ b/runtime/misc.c
@@ -59,7 +59,7 @@ void caml_failed_assert (char * expr, char_os * file_os, int line)
 #endif
 
 #if defined(DEBUG)
-static __thread int noalloc_level = 0;
+static CAMLthread_local int noalloc_level = 0;
 int caml_noalloc_begin(void)
 {
   return noalloc_level++;

--- a/testsuite/tests/lib-marshal/intextaux_par.c
+++ b/testsuite/tests/lib-marshal/intextaux_par.c
@@ -20,7 +20,7 @@
 #define CAML_INTERNALS
 
 #define BLOCK_SIZE 512
-static __thread char marshal_block[BLOCK_SIZE];
+static CAMLthread_local char marshal_block[BLOCK_SIZE];
 
 value marshal_to_block(value vlen, value v, value vflags)
 {


### PR DESCRIPTION
The current way of declaring Thread-Local Storage for variables, `__thread`, isn't available under MSVC.

To declare a variable in Thread-Local Storage (TLS):
- GNU C compatible compilers have the [`__thread`](https://gcc.gnu.org/onlinedocs/gcc/Thread-Local.html) storage class keyword;
- MSVC has the [`__declspec(thread)`](https://learn.microsoft.com/en-us/cpp/cpp/thread?view=msvc-170) extended storage-class modifier;
- C11 has the [`_Thread_local`](https://en.cppreference.com/w/c/keyword/_Thread_local) storage-class specifier, and the [`thread_local`](https://en.cppreference.com/w/c/thread/thread_local) macro defined in the (optionally provided) `<threads.h>` header;
- C23 has the `thread_local` storage-class specifier as a keyword, and ~_removes_~ obsoletes `_Thread_local`;
- C++11 has the `thread_local` storage-class specifier as a keyword;
- In C11/C17, if implementations don't provide `<threads.h>`, they must define `__STDC_NO_THREADS__`. Neither [MinGW][mingw-bug] nor [MSVC][msvc-bug] provide the header or define the macro (non-compliant compilers…).

[mingw-bug]: https://sourceforge.net/p/mingw-w64/mailman/message/51781776/
[msvc-bug]: https://developercommunity.visualstudio.com/t/C11-Define-__STDC_NO_THREADS__-if-C1/10510770

Adding `#define __thread __declspec(thread)` for MSVC wouldn't be standard-compliant, as identifiers beginning with an underscore are reserved.

Although it would be nice to use `thread_local` everywhere, if we use it in a public header we risk it may conflict with a previous declaration from a user. That's unlikely, because users not having a sane definition of `thread_local` as a macro would expose themselves to the same compatibility problems, and their code will start breaking in C23 when it becomes a keyword.
If we had private headers we could also have used `thread_local` internally, and have a compatibility definition for our public headers.

We take the disruptive approach of using standard keywords instead of compilers extensions, and the conservative approach of hiding them below the new `CAMLthread_local` macro.

In the `caml/misc.h` header, we assume that the file is being compiled at least in C11 or C++11. We already use the `_Atomic` keyword in public headers, introduced in C11. C++11 is also required for atomics.