### PR TITLE
More descriptive failure messages for unmarshaling

### DIFF
--- a/Changes
+++ b/Changes
@@ -199,6 +199,9 @@ Working version
 - #12809: Add ThreadSanitizer support to FreeBSD/amd64
   (Miod Vallat, review by Gabriel Scherer)
 
+- #12814: More detailed failure messages from `input_value` and `Marshal.from_*`
+  (Xavier Leroy, review by Stephen Dolan and Anil Madhavapeddy)
+
 - #12815: Correctly format multi-line locations in exception backtraces, in the
   style that the compiler driver uses.
   (David Allsopp, review by Gabriel Scherer)

--- a/runtime/caml/custom.h
+++ b/runtime/caml/custom.h
@@ -77,7 +77,8 @@ CAMLextern mlsize_t caml_custom_get_max_major (void);
 #define caml_compare_unordered (Caml_state_field(compare_unordered))
 
 #ifdef CAML_INTERNALS
-extern struct custom_operations * caml_find_custom_operations(char * ident);
+extern struct custom_operations *
+          caml_find_custom_operations(const char * ident);
 extern struct custom_operations *
           caml_final_custom_operations(void (*fn)(value));
 

--- a/runtime/custom.c
+++ b/runtime/custom.c
@@ -146,7 +146,7 @@ caml_register_custom_operations(const struct custom_operations * ops)
   push_custom_ops(&custom_ops_table, ops);
 }
 
-struct custom_operations * caml_find_custom_operations(char * ident)
+struct custom_operations * caml_find_custom_operations(const char * ident)
 {
   struct custom_operations_list * l;
   for (l = atomic_load(&custom_ops_table); l != NULL; l = l->next)


### PR DESCRIPTION
Unmarshaling (`input_value`, etc) can fail in a number of ways, raising the `Failure` exception with an error message.

This PR changes some of these error messages to be more descriptive.  In particular, errors related to Custom blocks now include the custom identifier (e.g. `_n` for native integers, `_z` for Zarith's big integers, etc), making thme a bit less mysterious.

~~The motivation is this bug in Zarith: https://github.com/ocaml/Zarith/issues/148, and the proposed fix : https://github.com/ocaml/Zarith/pull/149~~ Edit: the Zarith stuff can be addressed another way, so it's not a real motivation.