### PR TITLE
Fix inconsistency between source locations reported by `Printexc` and the compiler

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -196,12 +196,9 @@ runtime/caml/sizeclasses.h typo.missing-header
 
 # Tests which include references spanning multiple lines fail with \r\n
 # endings, so use \n endings only, even on Windows.
-testsuite/tests/backtrace/names.ml text eol=lf
-testsuite/tests/backtrace/print_location.ml text eol=lf
 testsuite/tests/basic-modules/anonymous.ml text eol=lf
 testsuite/tests/formatting/test_locations.ml text eol=lf
 testsuite/tests/functors/functors.ml text eol=lf
-testsuite/tests/lib-dynlink-initializers/test10_main.ml text eol=lf
 testsuite/tests/parsing/attributes.ml text eol=lf
 testsuite/tests/parsing/extensions.ml text eol=lf
 testsuite/tests/parsing/hash_ambiguity.ml text eol=lf

--- a/Changes
+++ b/Changes
@@ -199,6 +199,10 @@ Working version
 - #12809: Add ThreadSanitizer support to FreeBSD/amd64
   (Miod Vallat, review by Gabriel Scherer)
 
+- #12815: Correctly format multi-line locations in exception backtraces, in the
+  style that the compiler driver uses.
+  (David Allsopp, review by Gabriel Scherer)
+
 ### Code generation and optimizations:
 
 - #11239: on x86-64 and RISC-V, reduce alignment of OCaml stacks from 16 to 8.

--- a/runtime/backtrace.c
+++ b/runtime/backtrace.c
@@ -88,10 +88,15 @@ static void print_location(struct caml_loc_info * li, int index)
   }
   if (! li->loc_valid) {
     fprintf(stderr, "%s unknown location%s\n", info, inlined);
+  } else if (li->loc_start_lnum == li->loc_end_lnum) {
+    fprintf(stderr, "%s %s in file \"%s\"%s, line %d, characters %d-%d\n",
+            info, li->loc_defname, li->loc_filename, inlined,
+            li->loc_start_lnum, li->loc_start_chr, li->loc_end_chr);
   } else {
-    fprintf (stderr, "%s %s in file \"%s\"%s, line %d, characters %d-%d\n",
-             info, li->loc_defname, li->loc_filename, inlined,
-             li->loc_start_lnum, li->loc_start_chr, li->loc_end_offset);
+    fprintf(stderr, "%s %s in file \"%s\"%s, lines %d-%d, characters %d-%d\n",
+            info, li->loc_defname, li->loc_filename, inlined,
+            li->loc_start_lnum, li->loc_end_lnum, li->loc_start_chr,
+            li->loc_end_chr);
   }
 }
 

--- a/stdlib/printexc.ml
+++ b/stdlib/printexc.ml
@@ -152,10 +152,16 @@ let format_backtrace_slot pos slot =
       else
         Some (sprintf "%s unknown location" (info false))
   | Known_location l ->
-      Some (sprintf "%s %s in file \"%s\"%s, line %d, characters %d-%d"
+      let lines =
+        if l.start_lnum = l.end_lnum then
+          Printf.sprintf " %d" l.start_lnum
+        else
+          Printf.sprintf "s %d-%d" l.start_lnum l.end_lnum
+      in
+      Some (sprintf "%s %s in file \"%s\"%s, line%s, characters %d-%d"
               (info l.is_raise) l.defname l.filename
               (if l.is_inline then " (inlined)" else "")
-              l.start_lnum l.start_char l.end_offset)
+              lines l.start_char l.end_char)
 
 let print_exception_backtrace outchan backtrace =
   match backtrace with

--- a/testsuite/tests/backtrace/backtrace_dynlink.flambda.reference
+++ b/testsuite/tests/backtrace/backtrace_dynlink.flambda.reference
@@ -1,25 +1,25 @@
 Raised by primitive operation at Backtrace_dynlink_plugin in file "backtrace_dynlink_plugin.ml", line 6, characters 13-38
 Called from Dynlink.Native.run.(fun) in file "native/dynlink.ml", line 83, characters 12-29
 Called from Stdlib__List.iter in file "list.ml" (inlined), line 112, characters 12-15
-Called from Dynlink.Native.run in file "native/dynlink.ml", line 82, characters 4-273
+Called from Dynlink.Native.run in file "native/dynlink.ml", lines 82-88, characters 4-47
 Called from Dynlink_common.Make.load.(fun) in file "dynlink_common.ml", line 358, characters 11-54
 Called from Stdlib__List.iter in file "list.ml" (inlined), line 112, characters 12-15
-Called from Dynlink_common.Make.load.(fun) in file "dynlink_common.ml" (inlined), line 354, characters 6-372
+Called from Dynlink_common.Make.load.(fun) in file "dynlink_common.ml" (inlined), lines 354-363, characters 6-13
 Called from Stdlib__Fun.protect in file "fun.ml" (inlined), line 34, characters 8-15
-Called from Dynlink_common.Make.load in file "dynlink_common.ml", line 347, characters 4-662
+Called from Dynlink_common.Make.load in file "dynlink_common.ml", lines 347-364, characters 4-7
 Called from Dynlink_common.Make.loadfile in file "dynlink_common.ml" (inlined), line 366, characters 26-45
 Called from Backtrace_dynlink in file "backtrace_dynlink.ml", line 39, characters 4-52
 execution of module initializers in the shared library failed: Failure("SUCCESS")
 Raised by primitive operation at Dynlink.Native.run.(fun) in file "native/dynlink.ml", line 83, characters 12-29
-Re-raised at Dynlink.Native.run.(fun) in file "native/dynlink.ml", line 85, characters 10-149
+Re-raised at Dynlink.Native.run.(fun) in file "native/dynlink.ml", lines 85-87, characters 10-43
 Called from Stdlib__List.iter in file "list.ml" (inlined), line 112, characters 12-15
-Called from Dynlink.Native.run in file "native/dynlink.ml", line 82, characters 4-273
+Called from Dynlink.Native.run in file "native/dynlink.ml", lines 82-88, characters 4-47
 Called from Dynlink_common.Make.load.(fun) in file "dynlink_common.ml", line 358, characters 11-54
 Called from Stdlib__List.iter in file "list.ml" (inlined), line 112, characters 12-15
-Called from Dynlink_common.Make.load.(fun) in file "dynlink_common.ml" (inlined), line 354, characters 6-372
+Called from Dynlink_common.Make.load.(fun) in file "dynlink_common.ml" (inlined), lines 354-363, characters 6-13
 Called from Stdlib__Fun.protect in file "fun.ml" (inlined), line 34, characters 8-15
-Called from Dynlink_common.Make.load in file "dynlink_common.ml", line 347, characters 4-662
+Called from Dynlink_common.Make.load in file "dynlink_common.ml", lines 347-364, characters 4-7
 Re-raised at Stdlib__Fun.protect in file "fun.ml" (inlined), line 39, characters 6-52
-Called from Dynlink_common.Make.load in file "dynlink_common.ml", line 347, characters 4-662
+Called from Dynlink_common.Make.load in file "dynlink_common.ml", lines 347-364, characters 4-7
 Called from Dynlink_common.Make.loadfile in file "dynlink_common.ml" (inlined), line 366, characters 26-45
 Called from Backtrace_dynlink in file "backtrace_dynlink.ml", line 39, characters 4-52

--- a/testsuite/tests/backtrace/backtrace_dynlink.reference
+++ b/testsuite/tests/backtrace/backtrace_dynlink.reference
@@ -8,7 +8,7 @@ Called from Dynlink_common.Make.loadfile in file "dynlink_common.ml" (inlined), 
 Called from Backtrace_dynlink in file "backtrace_dynlink.ml", line 39, characters 4-52
 execution of module initializers in the shared library failed: Failure("SUCCESS")
 Raised by primitive operation at Dynlink.Native.run.(fun) in file "native/dynlink.ml", line 83, characters 12-29
-Re-raised at Dynlink.Native.run.(fun) in file "native/dynlink.ml", line 85, characters 10-149
+Re-raised at Dynlink.Native.run.(fun) in file "native/dynlink.ml", lines 85-87, characters 10-43
 Called from Stdlib__List.iter in file "list.ml", line 112, characters 12-15
 Called from Dynlink_common.Make.load.(fun) in file "dynlink_common.ml", line 358, characters 11-54
 Called from Stdlib__List.iter in file "list.ml", line 112, characters 12-15

--- a/testsuite/tests/backtrace/names.reference
+++ b/testsuite/tests/backtrace/names.reference
@@ -25,4 +25,4 @@ Called from Names.Mod1.Nested.apply in file "names.ml", line 21, characters 33-3
 Called from Names.fn_poly in file "names.ml", line 17, characters 2-5
 Called from Names.fn_function in file "names.ml", line 14, characters 9-13
 Called from Names.fn_multi in file "names.ml", line 11, characters 36-40
-Called from Names in file "names.ml", line 110, characters 4-493
+Called from Names in file "names.ml", lines 110-128, characters 4-11

--- a/testsuite/tests/backtrace/print_location.reference
+++ b/testsuite/tests/backtrace/print_location.reference
@@ -1,3 +1,3 @@
 Fatal error: exception Stdlib.Exit
-Raised at Print_location.f in file "print_location.ml", line 8, characters 11-23
+Raised at Print_location.f in file "print_location.ml", lines 8-9, characters 11-6
 Called from Print_location in file "print_location.ml", line 12, characters 2-6

--- a/testsuite/tests/lib-dynlink-initializers/test10_main.byte.reference
+++ b/testsuite/tests/lib-dynlink-initializers/test10_main.byte.reference
@@ -4,9 +4,9 @@ Called from Test10_plugin.g in file "test10_plugin.ml", line 3, characters 2-21
 Called from Test10_plugin.f in file "test10_plugin.ml", line 6, characters 2-6
 Called from Test10_plugin in file "test10_plugin.ml", line 10, characters 2-6
 Called from Dynlink.Bytecode.run in file "byte/dynlink.ml", line 152, characters 16-25
-Re-raised at Dynlink.Bytecode.run in file "byte/dynlink.ml", line 154, characters 6-137
+Re-raised at Dynlink.Bytecode.run in file "byte/dynlink.ml", lines 154-156, characters 6-39
 Called from Dynlink_common.Make.load.(fun) in file "dynlink_common.ml", line 358, characters 11-54
 Called from Stdlib__List.iter in file "list.ml", line 112, characters 12-15
 Called from Stdlib__Fun.protect in file "fun.ml", line 34, characters 8-15
 Re-raised at Stdlib__Fun.protect in file "fun.ml", line 39, characters 6-52
-Called from Test10_main in file "test10_main.ml", line 51, characters 13-69
+Called from Test10_main in file "test10_main.ml", lines 51-53, characters 13-7

--- a/testsuite/tests/lib-dynlink-initializers/test10_main.native.reference
+++ b/testsuite/tests/lib-dynlink-initializers/test10_main.native.reference
@@ -1,10 +1,10 @@
 Error: Failure("Plugin error")
 Raised by primitive operation at Dynlink.Native.run.(fun) in file "native/dynlink.ml", line 83, characters 12-29
-Re-raised at Dynlink.Native.run.(fun) in file "native/dynlink.ml", line 85, characters 10-149
+Re-raised at Dynlink.Native.run.(fun) in file "native/dynlink.ml", lines 85-87, characters 10-43
 Called from Stdlib__List.iter in file "list.ml", line 112, characters 12-15
 Called from Dynlink_common.Make.load.(fun) in file "dynlink_common.ml", line 358, characters 11-54
 Called from Stdlib__List.iter in file "list.ml", line 112, characters 12-15
 Called from Stdlib__Fun.protect in file "fun.ml", line 34, characters 8-15
 Re-raised at Stdlib__Fun.protect in file "fun.ml", line 39, characters 6-52
 Called from Dynlink_common.Make.loadfile in file "dynlink_common.ml" (inlined), line 366, characters 26-45
-Called from Test10_main in file "test10_main.ml", line 49, characters 30-87
+Called from Test10_main in file "test10_main.ml", lines 49-51, characters 30-7

--- a/testsuite/tests/lib-threads/uncaught_exception_handler.reference
+++ b/testsuite/tests/lib-threads/uncaught_exception_handler.reference
@@ -1,15 +1,15 @@
 Thread 1 killed on uncaught exception Uncaught_exception_handler.CallbackExn
-Raised at Uncaught_exception_handler.fn in file "uncaught_exception_handler.ml", line 28, characters 12-113
+Raised at Uncaught_exception_handler.fn in file "uncaught_exception_handler.ml", lines 28-30, characters 12-45
 Called from Thread.create.(fun) in file "thread.ml", line 48, characters 8-14
 [thread 2] caught Uncaught_exception_handler.CallbackExn
-Raised at Uncaught_exception_handler.fn in file "uncaught_exception_handler.ml", line 28, characters 12-113
+Raised at Uncaught_exception_handler.fn in file "uncaught_exception_handler.ml", lines 28-30, characters 12-45
 Called from Thread.create.(fun) in file "thread.ml", line 48, characters 8-14
 Thread 2 killed on uncaught exception Uncaught_exception_handler.CallbackExn
-Raised at Uncaught_exception_handler.fn in file "uncaught_exception_handler.ml", line 28, characters 12-113
+Raised at Uncaught_exception_handler.fn in file "uncaught_exception_handler.ml", lines 28-30, characters 12-45
 Called from Thread.create.(fun) in file "thread.ml", line 48, characters 8-14
 Thread 2 uncaught exception handler raised Uncaught_exception_handler.UncaughtHandlerExn
 Raised at Uncaught_exception_handler.handler in file "uncaught_exception_handler.ml", line 26, characters 2-17
 Called from Thread.create.(fun) in file "thread.ml", line 57, characters 10-41
 [thread 3] caught Uncaught_exception_handler.CallbackExn
-Raised at Uncaught_exception_handler.fn in file "uncaught_exception_handler.ml", line 28, characters 12-113
+Raised at Uncaught_exception_handler.fn in file "uncaught_exception_handler.ml", lines 28-30, characters 12-45
 Called from Thread.create.(fun) in file "thread.ml", line 48, characters 8-14


### PR DESCRIPTION
Split off from #12297, since that PR carries three related, but independently reviewable changes.

#8541 converted multi-line locations from:

```
Line STARTLINE, characters STARTCHAR-OFFSET
```
to
```
Lines STARTLINE-ENDLINE, characters STARTCHAR-ENDCHAR
```

by updating `Location.print_loc`. This means, however, that source locations are reported differently between the compiler driver and `Printexc` (and also the `caml_print_exception_backtrace` function in the runtime). At the time, making these two consistent would have been difficult, because the required information was not present in the backtrace, but this was addressed in #10111.

This PR changes the string representation of a backtrace slot where the source location spans multiple lines so that it is now presented in the same way as `Location.print_loc`.

I haven't marked this as a breaking change, because I think the string actually returned by these functions may be regarded as opaque (i.e. if you wanted to pass this information for parsing, one should be serialising the backtrace slot record, not parsing its string representation).

I think the inconsistency stands on its own, but also means that the backtrace printed is not affected by the CRLF/LF formatting of the source files themselves.