### PR TITLE
Improvements to the Makefile/configure scripts for Windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -864,13 +864,13 @@ flexdll flexlink flexlink.opt:
 	@echo make invocation. Simply place the sources for FlexDLL in a
 	@echo sub-directory.
 	@echo This can either be done by downloading a source tarball from
-	@echo \  https://github.com/alainfrisch/flexdll/releases
+	@echo \  https://github.com/ocaml/flexdll/releases
 	@if [ -d .git ]; then \
 	  echo or by checking out the flexdll submodule with; \
 	  echo \  git submodule update --init; \
 	else \
 	  echo or by cloning the git repository; \
-	  echo \  git clone https://github.com/alainfrisch/flexdll.git; \
+	  echo \  git clone https://github.com/ocaml/flexdll.git; \
 	fi
 	@echo "Then pass --with-flexdll=<dir> to configure and build as normal."
 	@false

--- a/Makefile
+++ b/Makefile
@@ -2395,6 +2395,7 @@ depend: beforedepend
 
 .PHONY: distclean
 distclean: clean
+	if [ -f flexdll/Makefile ]; then $(MAKE) -C flexdll distclean MSVC_DETECT=0; fi
 	$(MAKE) -C manual distclean
 	rm -f ocamldoc/META
 	rm -f $(addprefix ocamltest/,ocamltest_config.ml ocamltest_unix.ml)

--- a/README.win32.adoc
+++ b/README.win32.adoc
@@ -84,7 +84,7 @@ Unless you are also compiling the Cygwin port of OCaml, you do not need the
 
 [[bmflex]]
 In addition to Cygwin, FlexDLL must also be installed, which is available from
-https://github.com/alainfrisch/flexdll. A binary distribution is available;
+https://github.com/ocaml/flexdll. A binary distribution is available;
 instructions on how to build FlexDLL from sources, including how to bootstrap
 FlexDLL and OCaml are given <<seflexdll,later in this document>>.  Unless you
 bootstrap FlexDLL, you will need to ensure that the directory to which you
@@ -308,10 +308,10 @@ You must extract the FlexDLL sources for Version 0.35 or later in the directory
 done in one of three ways:
 
  * Extracting the sources from a tarball from
-   https://github.com/alainfrisch/flexdll/releases
+   https://github.com/ocaml/flexdll/releases
  * Cloning the git repository by running:
 +
-  git clone https://github.com/alainfrisch/flexdll.git
+  git clone https://github.com/ocaml/flexdll.git
 
  * If you are compiling from a git clone of the OCaml repository, instead of
    using a sources tarball, you can run:

--- a/aclocal.m4
+++ b/aclocal.m4
@@ -45,15 +45,16 @@ AC_DEFUN([OCAML_CC_VENDOR], [
   AC_MSG_CHECKING([C compiler vendor])
   AC_PREPROC_IFELSE(
     [AC_LANG_SOURCE([
-#if defined(_MSC_VER) && defined(__clang_major__) && defined(__clang_minor__)
-msvc _MSC_VER clang __clang_major__ __clang_minor__
-#elif defined(_MSC_VER)
+#if defined(_MSC_VER)
 msvc _MSC_VER
+# if defined(__clang_major__) && defined(__clang_minor__)
+  clang __clang_major__ __clang_minor__
+# endif
 #elif defined(__INTEL_COMPILER)
 icc __INTEL_COMPILER
 #elif defined(__MINGW32__)
 #include <_mingw_mac.h>
-mingw32 __MINGW64_VERSION_MAJOR __MINGW64_VERSION_MINOR
+mingw __MINGW64_VERSION_MAJOR __MINGW64_VERSION_MINOR
 # if defined(__clang_major__) && defined(__clang_minor__)
   clang __clang_major__ __clang_minor__
 # elif defined(__GNUC__) && defined(__GNUC_MINOR__)

--- a/configure
+++ b/configure
@@ -3966,7 +3966,7 @@ if test ${enable_reserved_header_bits+y}
 then :
   enableval=$enable_reserved_header_bits; case $enable_reserved_header_bits in #(
   [0-9]|[1-2][0-9]|3[0-1]) :
-     reserved_header_bits=$enable_reserved_header_bits ;; #(
+    reserved_header_bits=$enable_reserved_header_bits ;; #(
   *) :
     as_fn_error $? "invalid argument to --enable-reserved-header-bits" "$LINENO" 5 ;;
 esac
@@ -14205,10 +14205,9 @@ rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
     case $host in #(
   *-w64-mingw32*|*-pc-windows) :
     flexlink_where="$(cmd /c "$flexlink" -where 2>/dev/null)"
-      if test -z "$flexlink_where"
+        if test -z "$flexlink_where"
 then :
   as_fn_error $? "$flexlink is not executable from a native Win32 process" "$LINENO" 5
-
 fi ;; #(
   *) :
      ;;
@@ -15330,7 +15329,7 @@ then :
     case $ocaml_cv_cc_vendor in #(
   xlc*) :
     mkdll_flags='-qmkshrobj -G'
-                supports_shared_libraries=true ;; #(
+          supports_shared_libraries=true ;; #(
   *) :
      ;;
 esac ;; #(
@@ -15697,10 +15696,8 @@ printf "%s\n" "$as_me: the native compiler is disabled" >&6;} ;; #(
     native_compiler=false
     { printf "%s\n" "$as_me:${as_lineno-$LINENO}: the native compiler is not supported on this platform" >&5
 printf "%s\n" "$as_me: the native compiler is not supported on this platform" >&6;} ;; #(
-  *,*) :
-    native_compiler=true ;; #(
   *) :
-     ;;
+    native_compiler=true ;;
 esac
 
 if $native_compiler
@@ -15886,7 +15883,7 @@ case $arch in #(
   # expected to match "*-linux-musl" as well as "*-linux-musleabi*"
     *-linux-musl*) :
     # Alpine and other musl-based Linux distributions
-       common_cflags="-no-pie $common_cflags" ;; #(
+      common_cflags="-no-pie $common_cflags" ;; #(
   *) :
      ;;
 esac ;;
@@ -16495,10 +16492,7 @@ then :
   *,true) :
     instrumented_runtime=true ;; #(
   yes,false) :
-
-          as_fn_error $? "Instrumented runtime support requested \
-but no proper monotonic clock source was found." "$LINENO" 5
-         ;; #(
+    as_fn_error $? "Instrumented runtime support requested but no proper monotonic clock source was found." "$LINENO" 5 ;; #(
   auto,false) :
     instrumented_runtime=false
      ;; #(
@@ -16584,15 +16578,9 @@ else $as_nop
 fi
            ;; #(
   yes,false,*) :
-
-           as_fn_error $? "Instrumented runtime support requested \
-but clock_gettime is missing." "$LINENO" 5
-           ;; #(
+    as_fn_error $? "Instrumented runtime support requested but clock_gettime is missing." "$LINENO" 5 ;; #(
   yes,*,false) :
-
-           as_fn_error $? "Instrumented runtime support requested \
-but no proper monotonic clock source was found." "$LINENO" 5
-
+    as_fn_error $? "Instrumented runtime support requested but no proper monotonic clock source was found." "$LINENO" 5
        ;; #(
   *) :
      ;;
@@ -20025,10 +20013,8 @@ then :
     as_fn_error $? "mmap MAP_STACK not supported on FreeBSD" "$LINENO" 5 ;; #(
   *) :
     with_mmap_map_stack=true;
-            printf "%s\n" "#define USE_MMAP_MAP_STACK 1" >>confdefs.h
- ;; #(
-  *) :
-     ;;
+        printf "%s\n" "#define USE_MMAP_MAP_STACK 1" >>confdefs.h
+ ;;
 esac
 else $as_nop
   as_fn_error $? "mmap MAP_STACK requested but not found on $target" "$LINENO" 5
@@ -20043,9 +20029,7 @@ else $as_nop
       { printf "%s\n" "$as_me:${as_lineno-$LINENO}: using MAP_STACK on OpenBSD due to stack checking" >&5
 printf "%s\n" "$as_me: using MAP_STACK on OpenBSD due to stack checking" >&6;} ;; #(
   *) :
-    with_mmap_map_stack=false ;; #(
-  *) :
-     ;;
+    with_mmap_map_stack=false ;;
 esac
 
 fi
@@ -20068,33 +20052,29 @@ printf "%s\n" "$as_me: No support for function sections on $target." >&6;} ;; #(
     case $ocaml_cv_cc_vendor in #(
   gcc-0123-*|gcc-4-01234567) :
     function_sections=false;
-              { printf "%s\n" "$as_me:${as_lineno-$LINENO}: Function sections are not
-              supported in GCC prior to version 4.8." >&5
+            { printf "%s\n" "$as_me:${as_lineno-$LINENO}: Function sections are not
+            supported in GCC prior to version 4.8." >&5
 printf "%s\n" "$as_me: Function sections are not
-              supported in GCC prior to version 4.8." >&6;} ;; #(
+            supported in GCC prior to version 4.8." >&6;} ;; #(
   clang-012-*|clang-3-01234) :
     function_sections=false;
-              { printf "%s\n" "$as_me:${as_lineno-$LINENO}: Function sections are not supported
-              in Clang prior to version 3.5." >&5
+            { printf "%s\n" "$as_me:${as_lineno-$LINENO}: Function sections are not supported
+            in Clang prior to version 3.5." >&5
 printf "%s\n" "$as_me: Function sections are not supported
-              in Clang prior to version 3.5." >&6;} ;; #(
+            in Clang prior to version 3.5." >&6;} ;; #(
   gcc-*|clang-*) :
     function_sections=true;
-              oc_native_compflags='-function-sections'
-              internal_cflags="$internal_cflags -ffunction-sections";
-              printf "%s\n" "#define FUNCTION_SECTIONS 1" >>confdefs.h
+            oc_native_compflags='-function-sections'
+            internal_cflags="$internal_cflags -ffunction-sections";
+            printf "%s\n" "#define FUNCTION_SECTIONS 1" >>confdefs.h
  ;; #(
   *) :
     function_sections=false;
-              { printf "%s\n" "$as_me:${as_lineno-$LINENO}: Function sections are not supported by
-              $ocaml_cv_cc_vendor." >&5
+          { printf "%s\n" "$as_me:${as_lineno-$LINENO}: Function sections are not supported by
+          $ocaml_cv_cc_vendor." >&5
 printf "%s\n" "$as_me: Function sections are not supported by
-              $ocaml_cv_cc_vendor." >&6;} ;; #(
-  *) :
-     ;;
-esac ;; #(
-  *) :
-     ;;
+          $ocaml_cv_cc_vendor." >&6;} ;;
+esac ;;
 esac ;; #(
   *) :
     function_sections=false ;;

--- a/configure
+++ b/configure
@@ -13554,15 +13554,16 @@ printf %s "checking C compiler vendor... " >&6; }
   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
-#if defined(_MSC_VER) && defined(__clang_major__) && defined(__clang_minor__)
-msvc _MSC_VER clang __clang_major__ __clang_minor__
-#elif defined(_MSC_VER)
+#if defined(_MSC_VER)
 msvc _MSC_VER
+# if defined(__clang_major__) && defined(__clang_minor__)
+  clang __clang_major__ __clang_minor__
+# endif
 #elif defined(__INTEL_COMPILER)
 icc __INTEL_COMPILER
 #elif defined(__MINGW32__)
 #include <_mingw_mac.h>
-mingw32 __MINGW64_VERSION_MAJOR __MINGW64_VERSION_MINOR
+mingw __MINGW64_VERSION_MAJOR __MINGW64_VERSION_MINOR
 # if defined(__clang_major__) && defined(__clang_minor__)
   clang __clang_major__ __clang_minor__
 # elif defined(__GNUC__) && defined(__GNUC_MINOR__)
@@ -13897,7 +13898,7 @@ case $ocaml_cv_cc_vendor in #(
     common_cflags="-O2 -fno-strict-aliasing -fwrapv";
     internal_cflags="$cc_warnings -fno-common -fexcess-precision=standard \
 -Wvla" ;; #(
-  mingw32-*-*-gcc-*) :
+  mingw-*-*-gcc-*) :
     internal_cflags="-Wno-unused $cc_warnings \
 -fexcess-precision=standard"
     # TODO: see whether the code can be fixed to avoid -Wno-unused
@@ -13905,7 +13906,7 @@ case $ocaml_cv_cc_vendor in #(
     internal_cppflags='-D__USE_MINGW_ANSI_STDIO=0 -DUNICODE -D_UNICODE'
     internal_cppflags="$internal_cppflags -DWINDOWS_UNICODE="
     internal_cppflags="${internal_cppflags}\$(WINDOWS_UNICODE)" ;; #(
-  mingw32-*) :
+  mingw-*) :
     as_fn_error $? "Unsupported C compiler for a MinGW-w64 build" "$LINENO" 5 ;; #(
   msvc-*) :
     common_cflags="-nologo -O2 -Gy- -MD $cc_warnings"

--- a/configure.ac
+++ b/configure.ac
@@ -809,7 +809,7 @@ AS_CASE([$ocaml_cv_cc_vendor],
     [common_cflags="-O2 -fno-strict-aliasing -fwrapv";
     internal_cflags="$cc_warnings -fno-common -fexcess-precision=standard \
 -Wvla"],
-  [mingw32-*-*-gcc-*],
+  [mingw-*-*-gcc-*],
     [internal_cflags="-Wno-unused $cc_warnings \
 -fexcess-precision=standard"
     # TODO: see whether the code can be fixed to avoid -Wno-unused
@@ -817,7 +817,7 @@ AS_CASE([$ocaml_cv_cc_vendor],
     internal_cppflags='-D__USE_MINGW_ANSI_STDIO=0 -DUNICODE -D_UNICODE'
     internal_cppflags="$internal_cppflags -DWINDOWS_UNICODE="
     internal_cppflags="${internal_cppflags}\$(WINDOWS_UNICODE)"],
-  [mingw32-*],
+  [mingw-*],
     [AC_MSG_ERROR([Unsupported C compiler for a MinGW-w64 build])],
   [msvc-*],
     [common_cflags="-nologo -O2 -Gy- -MD $cc_warnings"

--- a/configure.ac
+++ b/configure.ac
@@ -493,7 +493,7 @@ AC_ARG_ENABLE([reserved-header-bits],
     [reserve BITS (between 0 and 31) bits in block headers])],
   [AS_CASE([$enable_reserved_header_bits],
     [[[0-9]]|[[1-2]][[0-9]]|3[[0-1]]],
-      [ reserved_header_bits=$enable_reserved_header_bits],
+      [reserved_header_bits=$enable_reserved_header_bits],
   [AC_MSG_ERROR([invalid argument to --enable-reserved-header-bits])])])
 
 AC_ARG_ENABLE([stdlib-manpages],
@@ -940,10 +940,10 @@ AS_IF([test x"$supports_shared_libraries" != 'xfalse'], [
 
     AS_CASE([$host],
       [*-w64-mingw32*|*-pc-windows],
-      [flexlink_where="$(cmd /c "$flexlink" -where 2>/dev/null)"
-      AS_IF([test -z "$flexlink_where"],
-        [AC_MSG_ERROR([$flexlink is not executable from a native Win32 process])
-      ])])
+        [flexlink_where="$(cmd /c "$flexlink" -where 2>/dev/null)"
+        AS_IF([test -z "$flexlink_where"],
+          [AC_MSG_ERROR(m4_normalize([$flexlink is not executable from a native
+            Win32 process]))])])
   ])
 
   OCAML_TEST_FLEXDLL_H([$flexdll_source_dir])
@@ -1165,9 +1165,9 @@ AS_IF([test x"$enable_shared" != "xno"],
       mkmaindll="flexlink -maindll ${mkdll_flags}"],
     [powerpc-ibm-aix*],
       [AS_CASE([$ocaml_cv_cc_vendor],
-               [xlc*],
-               [mkdll_flags='-qmkshrobj -G'
-                supports_shared_libraries=true])],
+        [xlc*],
+          [mkdll_flags='-qmkshrobj -G'
+          supports_shared_libraries=true])],
     [*-*-solaris*],
       [sharedlib_cflags="-fPIC"
       mkdll_flags='-shared'
@@ -1178,15 +1178,15 @@ AS_IF([test x"$enable_shared" != "xno"],
     |*-*-openbsd*|*-*-netbsd*|*-*-dragonfly*|*-*-gnu*|*-*-haiku*]],
       [sharedlib_cflags="-fPIC"
        AS_CASE([$ocaml_cv_cc_vendor,$host],
-           [gcc-*,powerpc-*-linux*],
+         [gcc-*,powerpc-*-linux*],
            [mkdll_flags='-shared -mbss-plt'],
-           [[*,i[3456]86-*]],
+         [[*,i[3456]86-*]],
            # Disable DT_TEXTREL warnings on Linux and BSD i386
            # See https://github.com/ocaml/ocaml/issues/9800
            [mkdll_flags='-shared -Wl,-z,notext'],
-           [mkdll_flags='-shared'])
+         [mkdll_flags='-shared'])
        AS_CASE([$host],
-           [[*-*-openbsd7.[3-9]|*-*-openbsd[89].*]],
+         [[*-*-openbsd7.[3-9]|*-*-openbsd[89].*]],
            [mkdll_flags="${mkdll_flags} -Wl,--no-execute-only"])
       oc_ldflags="$oc_ldflags -Wl,-E"
       rpath="-Wl,-rpath,"
@@ -1254,7 +1254,7 @@ AS_CASE([$enable_native_toplevel,$natdynlink],
       The native toplevel requires native dynlink support]))],
   [yes,*],
     [install_ocamlnat=true],
-    [install_ocamlnat=false])
+  [install_ocamlnat=false])
 
 # Try to work around the Skylake/Kaby Lake processor bug.
 AS_CASE(["$ocaml_cv_cc_vendor,$host"],
@@ -1400,8 +1400,7 @@ AS_CASE([$enable_native_compiler,$has_native_backend],
   [*,no],
     [native_compiler=false
     AC_MSG_NOTICE([the native compiler is not supported on this platform])],
-  [*,*],
-    [native_compiler=true])
+  [native_compiler=true])
 
 AS_IF([$native_compiler],
   [default_build_target=world.opt],
@@ -1456,9 +1455,8 @@ AS_CASE([$arch],
   [AS_CASE([$host],
     # expected to match "*-linux-musl" as well as "*-linux-musleabi*"
     [*-linux-musl*],
-       # Alpine and other musl-based Linux distributions
-       [common_cflags="-no-pie $common_cflags"],
-    [])])
+      # Alpine and other musl-based Linux distributions
+      [common_cflags="-no-pie $common_cflags"])])
 
 # Assembler
 
@@ -1500,8 +1498,7 @@ AS_CASE([$as_target,$ocaml_cv_cc_vendor],
     default_aspp="$default_as"],
   [*-*-darwin*,clang-*],
     [default_as="$default_as -Wno-trigraphs"
-    default_aspp="$default_as"],
-  [])
+    default_aspp="$default_as"])
 
 AS_IF([test "$with_pic"],
   [fpic=true
@@ -1634,10 +1631,9 @@ AS_IF([test "x$enable_instrumented_runtime" != "xno" ],
       AS_CASE([$enable_instrumented_runtime,$has_monotonic_clock],
         [*,true],
           [instrumented_runtime=true],
-        [yes,false], [
-          AC_MSG_ERROR([Instrumented runtime support requested \
-but no proper monotonic clock source was found.])
-        ],
+        [yes,false],
+          [AC_MSG_ERROR(m4_normalize([Instrumented runtime support requested
+            but no proper monotonic clock source was found.]))],
         [auto,false],
           [instrumented_runtime=false]
     )],
@@ -1657,15 +1653,11 @@ but no proper monotonic clock source was found.])
             )
           ],
         [yes,false,*],
-          [
-           AC_MSG_ERROR([Instrumented runtime support requested \
-but clock_gettime is missing.])
-          ],
+          [AC_MSG_ERROR(m4_normalize([Instrumented runtime support requested
+            but clock_gettime is missing.]))],
         [yes,*,false],
-          [
-           AC_MSG_ERROR([Instrumented runtime support requested \
-but no proper monotonic clock source was found.])
-          ]
+          [AC_MSG_ERROR(m4_normalize([Instrumented runtime support requested
+            but no proper monotonic clock source was found.]))]
       )]
     )]
 )
@@ -1703,7 +1695,7 @@ AS_IF([$tsan],
 
   AS_CASE([$ocaml_cv_cc_vendor],
     [gcc-[[0123456789]]-*|gcc-10-*|clang-*],
-    [],
+      [],
     [oc_tsan_cflags="$oc_tsan_cflags -Wno-tsan"])
   AS_CASE([$ocaml_cv_cc_vendor],
     [gcc*],
@@ -2367,8 +2359,8 @@ AS_IF([test x"$enable_mmap_map_stack" = "xyes"],
     [AS_CASE([$target],
        [*-freebsd*],
          [AC_MSG_ERROR([mmap MAP_STACK not supported on FreeBSD])],
-       [*],[with_mmap_map_stack=true;
-            AC_DEFINE([USE_MMAP_MAP_STACK])])],
+       [with_mmap_map_stack=true;
+        AC_DEFINE([USE_MMAP_MAP_STACK])])],
     [AC_MSG_ERROR([mmap MAP_STACK requested but not found on $target])])
   ],
   [AS_CASE([$target],
@@ -2376,8 +2368,7 @@ AS_IF([test x"$enable_mmap_map_stack" = "xyes"],
      [with_mmap_map_stack=true;
       AC_DEFINE([USE_MMAP_MAP_STACK])
       AC_MSG_NOTICE([using MAP_STACK on OpenBSD due to stack checking])],
-    [*],
-     [with_mmap_map_stack=false])
+    [with_mmap_map_stack=false])
   ])
 
 oc_native_compflags=''
@@ -2390,25 +2381,23 @@ AS_IF([test x"$enable_function_sections" = "xno"],
         [*-cygwin*|*-mingw*|*-windows|*-apple-darwin*],
           [function_sections=false;
            AC_MSG_NOTICE([No support for function sections on $target.])],
-        [*],
-          [AS_CASE([$ocaml_cv_cc_vendor],
-            [gcc-[0123]-*|gcc-4-[01234567]],
-              [function_sections=false;
-              AC_MSG_NOTICE([Function sections are not
-              supported in GCC prior to version 4.8.])],
-            [clang-[012]-*|clang-3-[01234]],
-              [function_sections=false;
-              AC_MSG_NOTICE([Function sections are not supported
-              in Clang prior to version 3.5.])],
-            [gcc-*|clang-*],
-              [function_sections=true;
-              oc_native_compflags='-function-sections'
-              internal_cflags="$internal_cflags -ffunction-sections";
-              AC_DEFINE([FUNCTION_SECTIONS])],
-            [*],
-              [function_sections=false;
-              AC_MSG_NOTICE([Function sections are not supported by
-              $ocaml_cv_cc_vendor.])])])],
+        [AS_CASE([$ocaml_cv_cc_vendor],
+          [gcc-[0123]-*|gcc-4-[01234567]],
+            [function_sections=false;
+            AC_MSG_NOTICE([Function sections are not
+            supported in GCC prior to version 4.8.])],
+          [clang-[012]-*|clang-3-[01234]],
+            [function_sections=false;
+            AC_MSG_NOTICE([Function sections are not supported
+            in Clang prior to version 3.5.])],
+          [gcc-*|clang-*],
+            [function_sections=true;
+            oc_native_compflags='-function-sections'
+            internal_cflags="$internal_cflags -ffunction-sections";
+            AC_DEFINE([FUNCTION_SECTIONS])],
+          [function_sections=false;
+          AC_MSG_NOTICE([Function sections are not supported by
+          $ocaml_cv_cc_vendor.])])])],
     [function_sections=false]);
   AS_IF([test x"$function_sections" = "xfalse"],
     [AS_IF([test x"$enable_function_sections" = "xyes"],

--- a/utils/binutils.ml
+++ b/utils/binutils.ml
@@ -568,7 +568,7 @@ module FlexDLL = struct
     array_find (function ({name; _} : section) -> name = sectname) sections
 
   (* We extract the list of exported symbols as encoded by flexlink, see
-     https://github.com/alainfrisch/flexdll/blob/bd636def70d941674275b2f4b6c13a34ba23f9c9/reloc.ml
+     https://github.com/ocaml/flexdll/blob/bd636def70d941674275b2f4b6c13a34ba23f9c9/reloc.ml
      #L500-L525 *)
 
   let read_symbols d {image_base; _} sections =


### PR DESCRIPTION
The first commix fixes a mistake I made. I lost all the suggestions from the review of PR 12768 after a rebase of the branch, probably after switching machines and a force-push, sorry for that. The review comments were cosmetic.

The second patch calls `make distclean` recursively on `flexdll/`.

The last commit deals with inconsistent, weird indentation of Autonconf' [`AS_CASE`](https://www.gnu.org/software/autoconf/manual/autoconf-2.71/html_node/Common-Shell-Constructs.html#index-AS_005fCASE-1) clauses. Note that the last clause, if present, is the default. We can then simplify `[*], [...]` clauses. I know that these reformatting commits are usually frowned upon, but I do believe that sensible indentation helps the confused programmer.

No change entry needed.
cc @shindere 

