### PR TITLE
Fix 5.0 Makefile manual build

### DIFF
--- a/manual/src/library/Makefile
+++ b/manual/src/library/Makefile
@@ -1,7 +1,10 @@
 ROOTDIR = ../../..
+include $(ROOTDIR)/Makefile.common
+LD_PATH = $(ROOTDIR)/otherlibs/str $(ROOTDIR)/otherlibs/unix
 
-TEXQUOTE = $(ROOTDIR)/runtime/ocamlrun ../../tools/texquote2
-CAMLLATEX = CAML_LD_LIBRARY_PATH="" $(OCAMLRUN) $(addprefix -I ,$(LD_PATH)) \
+TOOLS = ../../tools
+TEXQUOTE = $(OCAMLRUN) $(TOOLS)/texquote2
+CAMLLATEX = $(OCAMLRUN) $(addprefix -I ,$(LD_PATH)) \
   $(ROOTDIR)/tools/caml-tex -repo-root $(ROOTDIR) -n 80 -v false
 
 FILES = core.tex builtin.tex stdlib-blurb.tex compilerlibs.tex \

--- a/manual/src/library/Makefile
+++ b/manual/src/library/Makefile
@@ -1,9 +1,8 @@
 ROOTDIR = ../../..
 include $(ROOTDIR)/Makefile.common
-LD_PATH = $(ROOTDIR)/otherlibs/str $(ROOTDIR)/otherlibs/unix
 
-TOOLS = ../../tools
-TEXQUOTE = $(OCAMLRUN) $(TOOLS)/texquote2
+TEXQUOTE = $(ROOTDIR)/runtime/ocamlrun ../../tools/texquote2
+LD_PATH = $(ROOTDIR)/otherlibs/str $(ROOTDIR)/otherlibs/unix
 CAMLLATEX = $(OCAMLRUN) $(addprefix -I ,$(LD_PATH)) \
   $(ROOTDIR)/tools/caml-tex -repo-root $(ROOTDIR) -n 80 -v false
 


### PR DESCRIPTION
The 5.0-branch build step for the manual fails with:
```
CAML_LD_LIBRARY_PATH=""   ../../../tools/caml-tex -repo-root ../../.. -n 80 -v false core.etex -o core.gen.tex
/bin/sh: 1: ../../../tools/caml-tex: not found
```
The attached patch fixes the same to produce the required HTML files in `manual` and also for post-processing in `manual/src/html_processing`.