### PR TITLE
Introduce `caml_alloc_vsprintf` and use it to simplify error reporting from runtime functions

### DIFF
--- a/runtime/caml/alloc.h
+++ b/runtime/caml/alloc.h
@@ -61,6 +61,7 @@ CAMLextern value caml_alloc_sprintf(const char * format, ...)
   __attribute__ ((format (printf, 1, 2)))
 #endif
 ;
+CAMLextern value caml_alloc_vsprintf(const char * format, va_list args);
 CAMLextern value caml_alloc_some(value);
 
 typedef void (*final_fun)(value);

--- a/runtime/caml/fail.h
+++ b/runtime/caml/fail.h
@@ -96,10 +96,20 @@ CAMLnoret CAMLextern void caml_failwith (char const *msg);
 
 CAMLnoret CAMLextern void caml_failwith_value (value msg);
 
+CAMLnoret CAMLextern void caml_failwith_format (const char * fmt, ...)
+#ifdef __GNUC__
+  __attribute__ ((format (printf, 1, 2)))
+#endif
+;
 CAMLnoret CAMLextern void caml_invalid_argument (char const *msg);
 
 CAMLnoret CAMLextern void caml_invalid_argument_value (value msg);
 
+CAMLnoret CAMLextern void caml_invalid_argument_format (const char * fmt, ...)
+#ifdef __GNUC__
+  __attribute__ ((format (printf, 1, 2)))
+#endif
+;
 CAMLnoret CAMLextern void caml_raise_out_of_memory (void);
 
 CAMLnoret CAMLextern void caml_raise_stack_overflow (void);

--- a/runtime/fail_byt.c
+++ b/runtime/fail_byt.c
@@ -140,6 +140,15 @@ CAMLexport void caml_failwith_value (value msg)
   CAMLnoreturn;
 }
 
+CAMLexport void caml_failwith_format (const char * format, ...)
+{
+  va_list args;
+  va_start(args, format);
+  value msg = caml_alloc_vsprintf(format, args);
+  va_end(args);
+  caml_failwith_value(msg);
+}
+
 Caml_inline value caml_get_invalid_argument_tag (char const *msg)
 {
   check_global_data_param("Invalid_argument", msg);
@@ -157,6 +166,15 @@ CAMLexport void caml_invalid_argument_value (value msg)
   value tag = caml_get_invalid_argument_tag(String_val(msg));
   caml_raise_with_arg(tag, msg);
   CAMLnoreturn;
+}
+
+CAMLexport void caml_invalid_argument_format (const char * format, ...)
+{
+  va_list args;
+  va_start(args, format);
+  value msg = caml_alloc_vsprintf(format, args);
+  va_end(args);
+  caml_invalid_argument_value(msg);
 }
 
 CAMLexport void caml_array_bound_error(void)

--- a/runtime/fail_nat.c
+++ b/runtime/fail_nat.c
@@ -140,6 +140,15 @@ void caml_failwith_value (value msg)
   caml_raise_with_arg((value) caml_exn_Failure, msg);
 }
 
+void caml_failwith_format (const char * format, ...)
+{
+  va_list args;
+  va_start(args, format);
+  value msg = caml_alloc_vsprintf(format, args);
+  va_end(args);
+  caml_failwith_value(msg);
+}
+
 void caml_invalid_argument (char const *msg)
 {
   caml_raise_with_string((value) caml_exn_Invalid_argument, msg);
@@ -148,6 +157,15 @@ void caml_invalid_argument (char const *msg)
 void caml_invalid_argument_value (value msg)
 {
   caml_raise_with_arg((value) caml_exn_Invalid_argument, msg);
+}
+
+void caml_invalid_argument_format (const char * format, ...)
+{
+  va_list args;
+  va_start(args, format);
+  value msg = caml_alloc_vsprintf(format, args);
+  va_end(args);
+  caml_invalid_argument_value(msg);
 }
 
 void caml_raise_out_of_memory(void)

--- a/runtime/str.c
+++ b/runtime/str.c
@@ -431,9 +431,7 @@ CAMLexport value caml_alloc_vsprintf(const char * format, va_list args0)
     /* Re-do the formatting, outputting directly in the Caml string.
        Note that caml_alloc_string left room for a '\0' at position n,
        so the size passed to vsnprintf is n+1. */
-    va_copy(args, args0);
-    vsnprintf((char *)String_val(res), n + 1, saved_format, args);
-    va_end(args);
+    vsnprintf((char *)String_val(res), n + 1, saved_format, args0);
     caml_stat_free(saved_format);
   }
   return res;
@@ -467,9 +465,7 @@ CAMLexport value caml_alloc_vsprintf(const char * format, va_list args0)
     /* Re-do the formatting, outputting directly in the Caml string.
        Note that caml_alloc_string left room for a '\0' at position n,
        so the size passed to _vsnprintf is n+1. */
-    va_copy(args, args0);
-    _vsnprintf((char *)String_val(res), n + 1, saved_format, args);
-    va_end(args);
+    _vsnprintf((char *)String_val(res), n + 1, saved_format, args0);
     caml_stat_free(saved_format);
   }
   return res;


### PR DESCRIPTION
The runtime provides a function
```
CAMLextern value caml_alloc_sprintf(const char * format, ...)
```
that is very useful to construct OCaml strings from C code using printf-style formats.

This PR goes one step forward in the same direction with a "v" variant that takes an already-captured list of arguments for the format:
```
CAMLextern value caml_alloc_vsprintf(const char * format, va_list args);
```
It is used to provide printf-style variants for raising Failure and Invalid_argument exceptions, as suggested by @stedolan in https://github.com/ocaml/ocaml/pull/12814#pullrequestreview-1775360180 :
```
CAMLnoret CAMLextern void caml_failwith_format (const char * fmt, ...)
CAMLnoret CAMLextern void caml_invalid_argument_format (const char * fmt, ...)
```
Finally, `caml_alloc_vsprintf` can also be used  for custom cleanup-then-raise-exception functions, as shown in the case of runtime/intern.c (third commit).
