### PR TITLE
Don't use pthread.h in tests

### DIFF
--- a/testsuite/tests/lib-systhreads/test_c_thread_register_cstubs.c
+++ b/testsuite/tests/lib-systhreads/test_c_thread_register_cstubs.c
@@ -1,12 +1,18 @@
 #include <string.h>
+#ifdef _WIN32
+#include <windows.h>
+#define THREAD_FUNCTION DWORD WINAPI
+#else
 #include <pthread.h>
+#define THREAD_FUNCTION void *
+#endif
 #include "caml/mlvalues.h"
 #include "caml/gc.h"
 #include "caml/memory.h"
 #include "caml/callback.h"
 #include "threads.h"
 
-void *thread_func(void *fn) {
+THREAD_FUNCTION thread_func(void *fn) {
   caml_c_thread_register();
   caml_acquire_runtime_system();
   caml_callback((value) fn, Val_unit);
@@ -17,11 +23,15 @@ void *thread_func(void *fn) {
 
 value spawn_thread(value clos)
 {
+#ifdef _WIN32
+  CloseHandle(CreateThread(NULL, 0, &thread_func, (void *) clos, 0, NULL));
+#else
   pthread_t thr;
   pthread_attr_t attr;
 
   pthread_attr_init(&attr);
   pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_DETACHED);
   pthread_create(&thr, &attr, thread_func, (void *) clos);
+#endif
   return Val_unit;
 }


### PR DESCRIPTION
There are two tests in the testsuite dealing with registering C threads which weren't created by OCaml. The tests are morally improved on Windows by calling `CreateThread` directly (i.e. _actual_ OS threads), but also `pthread.h` won't be generally available in the MSVC port.