### PR TITLE
Fixes `save_runtime_state` logic in `caml_thread_yield`

### DIFF
--- a/Changes
+++ b/Changes
@@ -546,7 +546,8 @@ Working version
 
 ### Bug fixes:
 
-- #12830: Use after free bug mentioned in issue #12773 fixed
+- #12773: Use after free bug due to wrong use of save_runtime_state() fixed
+  (Hari Hara Naveen S)
 
 - # 12791: `extern` is applied to definitions of `caml_builtin_cprim`
     and `caml_names_of_builtin_cprim` when linking bytecode '-custom'

--- a/Changes
+++ b/Changes
@@ -546,6 +546,8 @@ Working version
 
 ### Bug fixes:
 
+- #12830: Use after free bug mentioned in issue #12773 fixed
+
 - # 12791: `extern` is applied to definitions of `caml_builtin_cprim`
     and `caml_names_of_builtin_cprim` when linking bytecode '-custom'
     executables with a C++ linker

--- a/otherlibs/systhreads/st_stubs.c
+++ b/otherlibs/systhreads/st_stubs.c
@@ -762,8 +762,8 @@ CAMLprim value caml_thread_yield(value unit)
      does not contain anything interesting, do not bother saving
      errno.)
   */
-
-  save_runtime_state();
+  if(Active_thread == This_thread)
+    save_runtime_state();
   st_thread_yield(m);
   restore_runtime_state(This_thread);
   if (caml_check_pending_signals())


### PR DESCRIPTION
Modification from caml_state should be saved into this_thread only if this_thread is the active thread
Sometimes this is not the case, for example in `tests/parallel/test_c_thread_register.ml` ([this](https://github.com/ocaml/ocaml/issues/12773) issue)


```
let _ =
  let d =
    Domain.spawn begin fun () ->
      spawn_thread passed; (* creating a C thread *)
      Thread.delay 0.5
    end
  in
  let t = Thread.create (fun () -> Thread.delay 1.0) () in
  Thread.join t;
  Domain.join d
```

A simpler example is also 

```
external spawn_thread : (unit -> unit) -> unit = "spawn_thread"
let passed () = Printf.printf "passed\n"
let _ =
  spawn_thread passed; (* creating a C thread *)
  let t = Thread.create (fun () -> Thread.delay 1.0) () in
  Thread.join t  
```
