### PR TITLE
Fix s390x stack reallocation code in PIC mode

### DIFF
--- a/Changes
+++ b/Changes
@@ -707,6 +707,9 @@ Working version
   (Olivier Nicole, review by Stefan Muenzel, Miod Vallat, Guillaume
    Munch-Maccagnoni, Gabriel Scherer and Xavier Leroy)
 
+- #12831: Fix call to caml_call_realloc_stack for s390x in PIC mode
+  (Vincent Laviron, report by Jerry James, review by Miod Vallat)
+
 OCaml 5.1.1
 -----------
 

--- a/asmcomp/s390x/emit.mlp
+++ b/asmcomp/s390x/emit.mlp
@@ -752,7 +752,7 @@ let fundecl fundecl =
       `	lay	%r15, -8(%r15)\n`;
       `	stg	%r14, 0(%r15)\n`;
       `	lgfi	%r12, {emit_int s}\n`;
-      `	brasl	%r14, {emit_symbol "caml_call_realloc_stack"}\n`;
+      emit_call "caml_call_realloc_stack";
       `	lg	%r14, 0(%r15)\n`;
       `	la	%r15, 8(%r15)\n`;
       `	brcl	15, {emit_label ret}\n`


### PR DESCRIPTION
The `emit_call` function adds a `@PLT` suffix in PIC mode, if it is missing the dynamic linker may not fix the reference appropriately.

Fixes #12829.