### PR TITLE
Include `windows.h` in a few places it is required

### DIFF
--- a/otherlibs/runtime_events/runtime_events_consumer.c
+++ b/otherlibs/runtime_events/runtime_events_consumer.c
@@ -34,6 +34,8 @@
 #include <sys/stat.h>
 
 #ifdef _WIN32
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
 #include <process.h>
 #include <processthreadsapi.h>
 #include <wtypes.h>

--- a/runtime/caml/winsupport.h
+++ b/runtime/caml/winsupport.h
@@ -19,7 +19,8 @@
 
 #if defined(_WIN32) && defined(CAML_INTERNALS)
 
-#include <windef.h>
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
 
 /*
  * This structure is defined inconsistently. mingw64 has it in ntdef.h (which

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -40,6 +40,8 @@
 typedef cpuset_t cpu_set_t;
 #endif
 #ifdef _WIN32
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
 #include <sysinfoapi.h>
 #endif
 #include "caml/alloc.h"

--- a/runtime/runtime_events.c
+++ b/runtime/runtime_events.c
@@ -32,6 +32,8 @@
 #include <sys/stat.h>
 
 #ifdef _WIN32
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
 #include <process.h>
 #include <processthreadsapi.h>
 #include <wtypes.h>


### PR DESCRIPTION
This PR is a simple step towards restoring the MSVC port, it affects only the MinGW and MSVC ports.

Including specific headers directly is not officially supported on Windows, so this PR adds an explicit `#include <windows.h>` when further inclusions fail due to undefined macros when building with MSVC.

In all those cases, the MSVC preprocessor reports an error when `winnt.h` gets included but the macros defining the architecture have not yet been defined. The `winnt.h` distributed with GCC MinGW nevertheless succeeds by using GCC builtin macros to detect the architecture, rather than some macro defined somewhere else in the header hierarchy.

As it affects the MinGW port, I checked in Github CI that the test suite runs successfully with it:
https://github.com/shym/ocaml/actions/runs/7222966978/job/19681052938