### PR TITLE
Refactor caml_c_thread_(un)register to fix various bugs

### DIFF
--- a/Changes
+++ b/Changes
@@ -234,9 +234,9 @@ OCaml 5.2.0
    Ojeda Bar)
 
 - #11911, #12382, #12383: Restore statmemprof functionality in part
-  (backtrace buffers, per-thread and per-domain data
-  structures). (Nick Barnes, review by Gabriel Scherer, Fabrice Buoro,
-  Sadiq Jaffer, and Guillaume Munch-Maccagnoni).
+  (backtrace buffers, per-thread and per-domain data structures).
+  (Nick Barnes, review by Gabriel Scherer, Fabrice Buoro, Sadiq
+   Jaffer, and Guillaume Munch-Maccagnoni).
 
 - #12735: Store both ends of the stack chain in continuations
   (Leo White, review by Miod Vallat and KC Sivaramakrishnan)
@@ -259,6 +259,12 @@ OCaml 5.2.0
 - #12815: Correctly format multi-line locations in exception backtraces, in the
   style that the compiler driver uses.
   (David Allsopp, review by Gabriel Scherer)
+
+- #12773, #12830, #12834: Rewrite `caml_c_thread_(un)register` to fix
+  various bugs.
+  (Guillaume Munch-Maccagnoni, reported by Miod Vallat, suggested by
+   Hari Hara Naveen S, reviewed by Fabrice Buoro, Gabriel Scherer and
+   Miod Vallat)
 
 - #12839: Remove ATOMIC_UINTNAT_INIT from camlatomic.h (as part of a larger
   cleanup of camlatomic.h)

--- a/otherlibs/systhreads/st_stubs.c
+++ b/otherlibs/systhreads/st_stubs.c
@@ -323,6 +323,7 @@ void caml_thread_free_info(caml_thread_t th)
      external_raise: stack-allocated
      init_mask: stack-allocated
   */
+  caml_memprof_delete_thread(th->memprof);
   caml_free_stack(th->current_stack);
   caml_free_backtrace_buffer(th->backtrace_buffer);
 
@@ -407,7 +408,6 @@ static void caml_thread_reinitialize(void)
   th = Active_thread->next;
   while (th != Active_thread) {
     next = th->next;
-    caml_memprof_delete_thread(th->memprof);
     caml_thread_free_info(th);
     th = next;
   }
@@ -571,9 +571,6 @@ static void caml_thread_stop(void)
   /* The main domain thread does not go through [caml_thread_stop]. There is
      always one more thread in the chain at this point in time. */
   CAMLassert(Active_thread->next != Active_thread);
-
-  /* Tell memprof that this thread is terminating */
-  caml_memprof_delete_thread(Active_thread->memprof);
 
   /* Signal that the thread has terminated */
   caml_threadstatus_terminate(Terminated(Active_thread->descr));

--- a/otherlibs/systhreads/st_stubs.c
+++ b/otherlibs/systhreads/st_stubs.c
@@ -673,6 +673,7 @@ CAMLexport int caml_c_thread_register(void)
   /* Already registered? */
   if (This_thread != NULL) return 0;
 
+  /* At this point we should not hold any domain lock */
   CAMLassert(Caml_state_opt == NULL);
   caml_init_domain_self(Dom_c_threads);
 
@@ -724,7 +725,7 @@ CAMLexport int caml_c_thread_unregister(void)
   st_tls_set(caml_thread_key, NULL);
   /* Remove thread info block from list of threads, and free it */
   caml_thread_remove_and_free(th);
-  /* Release the runtime */
+  /* Release the runtime, also sets Caml_state_opt to NULL */
   thread_lock_release(Dom_c_threads);
   return 1;
 }

--- a/otherlibs/systhreads/st_stubs.c
+++ b/otherlibs/systhreads/st_stubs.c
@@ -723,18 +723,15 @@ out_err:
 /* the thread lock is not held when entering */
 CAMLexport int caml_c_thread_unregister(void)
 {
-  caml_thread_t th = This_thread;
-
-  /* If this thread is not set, then it was not registered */
-  if (th == NULL) return 0;
-  /* Wait until the runtime is available */
-  thread_lock_acquire(Dom_c_threads);
-  /*  Forget the thread descriptor */
+  /* If This_thread is not set, then the thread was not registered */
+  if (This_thread == NULL) return 0;
+  /* Acquire the domain lock the regular way */
+  caml_leave_blocking_section();
+  /* Terminate thread from the OCaml runtime perspective, also sets
+     Caml_state_opt to NULL */
+  caml_thread_stop();
+  /* Forget the thread info */
   st_tls_set(caml_thread_key, NULL);
-  /* Remove thread info block from list of threads, and free it */
-  caml_thread_remove_and_free(th);
-  /* Release the runtime, also sets Caml_state_opt to NULL */
-  thread_lock_release(Dom_c_threads);
   return 1;
 }
 


### PR DESCRIPTION
Another systhread rabbit-hole: `caml_c_thread_(un)register`. In order to make it better understandable, I refactored it in order to share code with thread_new, thread_start and thread_stop. Differences between thread_new+thread_start and c_thread_register are subtle and come down to when is the GC available to allocate the thread descriptor. ~We could share even more code if we change a few details, I can share some idea if someone has the time to implement it.~

I think several bugs are fixed by this refactor:

- Fix #12773 : Missing restore (via @Johan511 & #12830)
- Fix calling c_thread_register without having initialized systhreads
- Fix invalid raising of exception and leak if tick thread is not created
- Fix missing `memprof_delete_thread`s
- Fix situation where the main thread tries to stop before the registered C thread (?)
- Fix missing signal stack