### PR TITLE
Improve pretty-printing types' attributes and classes' parameters 

### DIFF
--- a/parsing/pprintast.ml
+++ b/parsing/pprintast.ml
@@ -1222,9 +1222,9 @@ and class_expr ctxt f x =
           (list (label_x_expression_param ctxt)) l
     | Pcl_constr (li, l) ->
         pp f "%a%a"
-          (fun f l-> if l <>[] then
-              pp f "[%a]@ "
-                (list (core_type ctxt) ~sep:",") l) l
+          (fun f l-> if l <> [] then
+              pp f "[@[<hov>%a@]]@ "
+                (list (core_type ctxt) ~sep:",@ ") l) l
           (with_loc type_longident) li
     | Pcl_constraint (ce, ct) ->
         pp f "(%a@ :@ %a)"
@@ -1661,7 +1661,7 @@ and type_def_list ctxt f (rf, exported, l) =
       else if exported then " ="
       else " :="
     in
-    pp f "@[<2>%s %a%a%a%s%a@]%a" kwd
+    pp f "@[<2>%s %a%a%a%s%a@]@,%a" kwd
       nonrec_flag rf
       (type_params ctxt) x.ptype_params
       ident_of_name x.ptype_name.txt

--- a/testsuite/tests/formatting/test_classes.ml
+++ b/testsuite/tests/formatting/test_classes.ml
@@ -1,0 +1,27 @@
+(* TEST
+ compile_only = "true";
+ {
+   setup-ocamlc.byte-build-env;
+   flags = "-dsource -stop-after parsing";
+   ocamlc.byte;
+   compiler_reference = "${test_source_directory}/test_classes.ml.reference";
+   check-ocamlc.byte-output;
+ }{
+   setup-ocamlc.byte-build-env;
+   flags = "-dsource -stop-after parsing";
+   ocamlc.byte;
+   compiler_reference = "${test_source_directory}/test_classes.ml.reference";
+   check-ocamlc.byte-output;
+ }
+*)
+class virtual ['inh,'extra,'syn] logic_t =
+  object
+    inherit
+      [(GT.string OCanren.logic, logic Std.List.logic) t,
+      (GT.string OCanren.logic, logic Std.List.logic) t,(GT.string
+                                                        OCanren.logic,
+                                                        logic
+                                                        Std.List.logic)
+                                                        t,
+      'inh,'extra,'syn] OCanren.logic_t
+  end

--- a/testsuite/tests/formatting/test_classes.ml.reference
+++ b/testsuite/tests/formatting/test_classes.ml.reference
@@ -1,0 +1,14 @@
+class virtual ['inh,'extra,'syn] logic_t =
+  object
+    inherit 
+      [(GT.string OCanren.logic, logic Std.List.logic) t,(GT.string
+                                                            OCanren.logic,
+                                                           logic
+                                                             Std.List.logic)
+                                                           t,(GT.string
+                                                                OCanren.logic,
+                                                               logic
+                                                                 Std.List.logic)
+                                                               t,'inh,
+      'extra,'syn] OCanren.logic_t
+  end

--- a/testsuite/tests/formatting/test_classes.ml.reference
+++ b/testsuite/tests/formatting/test_classes.ml.reference
@@ -1,14 +1,9 @@
 class virtual ['inh,'extra,'syn] logic_t =
   object
     inherit 
-      [(GT.string OCanren.logic, logic Std.List.logic) t,(GT.string
-                                                            OCanren.logic,
-                                                           logic
-                                                             Std.List.logic)
-                                                           t,(GT.string
-                                                                OCanren.logic,
-                                                               logic
-                                                                 Std.List.logic)
-                                                               t,'inh,
-      'extra,'syn] OCanren.logic_t
+      [(GT.string OCanren.logic, logic Std.List.logic) t,
+       (GT.string OCanren.logic, logic Std.List.logic) t,
+       (GT.string OCanren.logic, logic Std.List.logic) t, 'inh, 'extra, 
+       'syn]
+      OCanren.logic_t
   end

--- a/testsuite/tests/formatting/test_type_attributes.ml
+++ b/testsuite/tests/formatting/test_type_attributes.ml
@@ -1,0 +1,18 @@
+(* TEST
+ compile_only = "true";
+ {
+   setup-ocamlc.byte-build-env;
+   flags = "-dsource -stop-after parsing";
+   ocamlc.byte;
+   compiler_reference = "${test_source_directory}/test_type_attributes.ml.reference";
+   check-ocamlc.byte-output;
+ }{
+   setup-ocamlc.byte-build-env;
+   flags = "-dsource -stop-after parsing";
+   ocamlc.byte;
+   compiler_reference = "${test_source_directory}/test_type_attributes.ml.reference";
+   check-ocamlc.byte-output;
+ }
+*)
+type ground = (GT.string, ground Std.List.ground) t [@@deriving gaaaaaaa ~options:{ gmap }]
+

--- a/testsuite/tests/formatting/test_type_attributes.ml
+++ b/testsuite/tests/formatting/test_type_attributes.ml
@@ -14,5 +14,5 @@
    check-ocamlc.byte-output;
  }
 *)
-type ground = (GT.string, ground Std.List.ground) t [@@deriving gaaaaaaa ~options:{ gmap }]
-
+type foo = (GT.string, foo Std.List.ground) t [@@deriving bbbbbbbbbbbb ~options:{ qwer }]
+and bar = (GT.float, bar Std.List.ground) t [@@deriving ccccccccccccc ~options:{ asdf }]

--- a/testsuite/tests/formatting/test_type_attributes.ml.reference
+++ b/testsuite/tests/formatting/test_type_attributes.ml.reference
@@ -1,0 +1,3 @@
+type ground = (GT.string, ground Std.List.ground) t[@@deriving
+                                                     gaaaaaaa
+                                                       ~options:{ gmap }]

--- a/testsuite/tests/formatting/test_type_attributes.ml.reference
+++ b/testsuite/tests/formatting/test_type_attributes.ml.reference
@@ -1,3 +1,4 @@
-type ground = (GT.string, ground Std.List.ground) t[@@deriving
-                                                     gaaaaaaa
-                                                       ~options:{ gmap }]
+type foo = (GT.string, foo Std.List.ground) t
+[@@deriving bbbbbbbbbbbb ~options:{ qwer }]
+and bar = (GT.float, bar Std.List.ground) t
+[@@deriving ccccccccccccc ~options:{ asdf }]


### PR DESCRIPTION
In my project I have a PPX extension, and store in the cram file the generated code. This allows people to understand what is being generated from the browser. Unfortunately, output of syntax extension is not very nice, and I use ocamlformat to reformat the output. But it looks like, ocamlformat breaks it's behavior too often (maybe, even every release) without a config switch to make as it was before. So, I decided to improve pretty printer from the compiler. Maybe, in the future I will be able to get rid of ocamlformat in the tests suite.

Better to review this per commit. The first two commits add a test where classes and types' attributes are printer. The 3rd commit is about my changes, and the 4th is a promotion of the tests.