### PR TITLE
show non-generalizable type parameters in type definitions

### DIFF
--- a/Changes
+++ b/Changes
@@ -689,6 +689,9 @@ Working version
 - #12831: Fix call to caml_call_realloc_stack for s390x in PIC mode
   (Vincent Laviron, report by Jerry James, review by Miod Vallat)
 
+- #12837: Show non-generalizable type parameters in type definitions
+  (Jacques Garrigue, review by ??)
+
 OCaml 5.1.1 (8 December 2023)
 ----------------------------
 

--- a/Changes
+++ b/Changes
@@ -689,7 +689,8 @@ Working version
 - #12831: Fix call to caml_call_realloc_stack for s390x in PIC mode
   (Vincent Laviron, report by Jerry James, review by Miod Vallat)
 
-- #12837: Show non-generalizable type parameters in type definitions
+* #12837: Show non-generalizable type parameters in type definitions
+  Changes type of type parameters in outcometree.mli.
   (Jacques Garrigue, review by ??)
 
 OCaml 5.1.1 (8 December 2023)

--- a/Changes
+++ b/Changes
@@ -691,7 +691,7 @@ Working version
 
 * #12837: Show non-generalizable type parameters in type definitions
   Changes type of type parameters in outcometree.mli.
-  (Jacques Garrigue, review by ??)
+  (Jacques Garrigue, review by Richard Eisenberg)
 
 OCaml 5.1.1 (8 December 2023)
 ----------------------------

--- a/testsuite/tests/typing-objects/errors.ml
+++ b/testsuite/tests/typing-objects/errors.ml
@@ -8,7 +8,7 @@ Line 1, characters 0-75:
 1 | class type virtual ['a] c = object constraint 'a = [<`A of int & float] end
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The type of this class,
-       "class virtual ['a] c :
+       "class virtual ['_a] c :
          object constraint '_a = [< `A of int & float ] as '_weak1 end",
        contains non-collapsible conjunctive types in constraints.
        Type "int" is not compatible with type "float"
@@ -60,4 +60,18 @@ Line 2, characters 26-40:
                               ^^^^^^^^^^^^^^
 Error: This inheritance does not override any methods or instance variables
        but is explicitly marked as overriding with "!".
+|}]
+
+
+class ['a] c = object val x : 'a list ref = ref [] end
+class ['a] x = let r = ref [] in object val x : 'a list ref = r end
+[%%expect{|
+class ['a] c : object val x : 'a list ref end
+Line 2, characters 0-67:
+2 | class ['a] x = let r = ref [] in object val x : 'a list ref = r end
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The type of this class,
+       "class ['_a] x : object val x : '_a list ref end",
+       contains the non-generalizable type variable(s): "'_a".
+       (see manual section 6.1.2)
 |}]

--- a/typing/oprint.ml
+++ b/typing/oprint.ml
@@ -417,15 +417,15 @@ let out_type_args = ref print_typargs
 
 (* Class types *)
 
-let print_type_parameter ppf s =
-  if s = "_" then fprintf ppf "_" else pr_var ppf s
+let print_type_parameter ?(non_gen=false) ppf s =
+  if s = "_" then fprintf ppf "_" else ty_var ~non_gen ppf s
 
-let type_parameter ppf (ty, (var, inj)) =
+let type_parameter ppf {ot_non_gen=non_gen; ot_name=ty; ot_variance=var,inj} =
   let open Asttypes in
   fprintf ppf "%s%s%a"
     (match var with Covariant -> "+" | Contravariant -> "-" | NoVariance ->  "")
     (match inj with Injective -> "!" | NoInjectivity -> "")
-    print_type_parameter ty
+    (print_type_parameter ~non_gen) ty
 
 let print_out_class_params ppf =
   function
@@ -769,7 +769,7 @@ and print_out_extension_constructor ppf ext =
         [] -> fprintf ppf "%a" print_lident ext.oext_type_name
       | [ty_param] ->
         fprintf ppf "@[%a@ %a@]"
-          print_type_parameter
+          (print_type_parameter ~non_gen:false)
           ty_param
           print_lident ext.oext_type_name
       | _ ->
@@ -790,7 +790,7 @@ and print_out_type_extension ppf te =
       [] -> fprintf ppf "%a" print_lident te.otyext_name
     | [param] ->
       fprintf ppf "@[%a@ %a@]"
-        print_type_parameter param
+        (print_type_parameter ~non_gen:false) param
         print_lident te.otyext_name
     | _ ->
         fprintf ppf "@[(@[%a)@]@ %a@]"

--- a/typing/outcometree.mli
+++ b/typing/outcometree.mli
@@ -57,7 +57,11 @@ type out_value =
   | Oval_variant of string * out_value option
   | Oval_lazy of out_value
 
-type out_type_param = string * (Asttypes.variance * Asttypes.injectivity)
+type out_type_param = {
+    ot_non_gen: bool;
+    ot_name: string;
+    ot_variance: Asttypes.variance * Asttypes.injectivity
+}
 
 type out_type =
   | Otyp_abstract

--- a/typing/printtyp.ml
+++ b/typing/printtyp.ml
@@ -1467,10 +1467,10 @@ let prepare_decl id decl =
 
 let tree_of_type_decl id decl =
   let ty_manifest, params = prepare_decl id decl in
-  let type_param =
+  let type_param ot_variance =
     function
-    | Otyp_var (_, id) -> id
-    | _ -> "?"
+    | Otyp_var (ot_non_gen, ot_name) -> {ot_non_gen; ot_name; ot_variance}
+    | _ -> {ot_non_gen=false; ot_name="?"; ot_variance}
   in
   let type_defined decl =
     let abstr =
@@ -1505,7 +1505,7 @@ let tree_of_type_decl id decl =
         decl.type_params decl.type_variance
     in
     (Ident.name id,
-     List.map2 (fun ty cocn -> type_param (tree_of_typexp Type ty), cocn)
+     List.map2 (fun ty cocn -> type_param cocn (tree_of_typexp Type ty))
        params vari)
   in
   let tree_of_manifest ty1 =
@@ -1831,11 +1831,11 @@ let class_type ppf cty =
   !Oprint.out_class_type ppf (tree_of_class_type Type [] cty)
 
 let tree_of_class_param param variance =
-  (match tree_of_typexp Type_scheme param with
-    Otyp_var (_, s) -> s
-  | _ -> "?"),
-  if is_Tvar param then Asttypes.(NoVariance, NoInjectivity)
-  else variance
+  let ot_variance =
+    if is_Tvar param then Asttypes.(NoVariance, NoInjectivity) else variance in
+  match tree_of_typexp Type_scheme param with
+    Otyp_var (ot_non_gen, ot_name) -> {ot_non_gen; ot_name; ot_variance}
+  | _ -> {ot_non_gen=false; ot_name="?"; ot_variance}
 
 let class_variance =
   let open Variance in let open Asttypes in


### PR DESCRIPTION
Error message used to be confusing, as it looked like there were two different variables.
Note that we are changing outcometree.mli, so this is a breaking change.