### PR TITLE
minimize assignments to `Ctype.current_level`

### DIFF
--- a/Changes
+++ b/Changes
@@ -674,6 +674,9 @@ OCaml 5.2.0
   (Ulysse Gérard, Nathanaëlle Courant, suggestions by Gabriel Scherer and Thomas
   Refis, review by Florian Angeletti, Gabriel Scherer and Thomas Refis)
 
+- #12838 : Minimize assignments to Ctype.current_level
+  (Takafumi Saikawa and Jacques Garrigue, review by Florian Angeletti)
+
 ### Build system:
 
 - #12198, #12321, #12586, #12616, #12706: continue the merge of the

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -712,7 +712,7 @@ let rec generalize ~outer_level ty =
   end
 
 (* Note: the public version of this function is called with
-   [ty] = [!current_level] *)
+   [outer_level] = [!current_level] *)
 let generalize ~outer_level ty =
   simple_abbrevs := Mnil;
   generalize ~outer_level ty
@@ -986,7 +986,7 @@ let rec generalize_class_type' gen =
       generalize_class_type' gen cty
 
 (* Note: the public version of this function is called with
-   [ty] = [!current_level] *)
+   [outer_level] = [!current_level] *)
 let generalize_class_type ~outer_level cty =
   generalize_class_type' (generalize ~outer_level) cty
 
@@ -1238,7 +1238,7 @@ let rec copy ?partial ?keep_names ~level copy_scope ty =
 (**** Variants of instantiations ****)
 
 (* Note: the public version of this function is called with
-   [ty] = [!current_level] *)
+   [level] = [!current_level] *)
 let instance ?partial ~level sch =
   let partial =
     match partial with
@@ -1338,7 +1338,7 @@ let instance_constructor existential_treatment cstr =
   )
 
 (* Note: the public version of this function is called with
-   [ty] = [!current_level] *)
+   [level] = [!current_level] *)
 let instance_parameterized_type ?keep_names ~level sch_args sch =
   For_copy.with_scope (fun copy_scope ->
     let ty_args =
@@ -1368,7 +1368,7 @@ let map_kind f = function
 
 
 (* Note: the public version of this function is called with
-   [ty] = [!current_level] *)
+   [level] = [!current_level] *)
 let instance_declaration ~level decl =
   For_copy.with_scope (fun copy_scope ->
     {decl with type_params = List.map (copy ~level copy_scope) decl.type_params;
@@ -1381,7 +1381,7 @@ let generic_instance_declaration decl =
   instance_declaration ~level:generic_level decl
 
 (* Note: the public version of this function is called with
-   [ty] = [!current_level] *)
+   [level] = [!current_level] *)
 let instance_class ~level params cty =
   let rec copy_class_type copy_scope = function
     | Cty_constr (path, tyl, cty) ->

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -1191,7 +1191,7 @@ let rec copy ?partial ?keep_names ~level copy_scope ty =
                 | Tconstr _ | Tnil ->
                     copy more
                 | Tvar _ | Tunivar _ ->
-                    if keep then more else newty mored
+                    if keep then more else newty2 ~level mored
                 |  _ -> assert false
               in
               let row =
@@ -1215,7 +1215,7 @@ let rec copy ?partial ?keep_names ~level copy_scope ty =
                     if row_closed row && not (is_fixed row)
                     && TypeSet.is_empty (free_univars ty)
                     && not (List.for_all not_reither fields) then
-                      let more' = newvar () in
+                      let more' = newvar2 level in
                       (more',
                        create_row ~fields:(List.filter not_reither fields)
                          ~more:more' ~closed:false ~fixed:None ~name:None)
@@ -1325,7 +1325,8 @@ let instance_constructor existential_treatment cstr =
               Env.enter_type (get_new_abstract_name env name) decl env
                 ~scope:fresh_constr_scope in
             Pattern_env.set_env penv new_env;
-            let to_unify = newty (Tconstr (Path.Pident id,[],ref Mnil)) in
+            let to_unify =
+              newty2 ~level (Tconstr (Path.Pident id,[],ref Mnil)) in
             let tv = copy ~level copy_scope existential in
             assert (is_Tvar tv);
             link_type tv to_unify;

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -5579,7 +5579,7 @@ let immediacy env typ =
         Type_immediacy.Always
   | _ -> Type_immediacy.Unknown
 
-(* delete [level] optional argument *)
+(* hide [level, outer_level] arguments *)
 let instance ?partial sch =
   instance ?partial ~level:!current_level sch
 let instance_parameterized_type ?keep_names sch_args sch =

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -2082,9 +2082,9 @@ let enter_poly env univar_pairs t1 tl1 t2 tl2 f =
       TypeSet.empty old_univars
   in
   if List.exists (fun t -> TypeSet.mem t known_univars) tl1 then
-     univars_escape env old_univars tl1 (newty(Tpoly(t2,tl2)));
+    univars_escape env old_univars tl1 (newgenty(Tpoly(t2,tl2)));
   if List.exists (fun t -> TypeSet.mem t known_univars) tl2 then
-    univars_escape env old_univars tl2 (newty(Tpoly(t1,tl1)));
+    univars_escape env old_univars tl2 (newgenty(Tpoly(t1,tl1)));
   let cl1 = List.map (fun t -> t, ref None) tl1
   and cl2 = List.map (fun t -> t, ref None) tl2 in
   univar_pairs := (cl1,cl2) :: (cl2,cl1) :: old_univars;


### PR DESCRIPTION
This PR removes assignments to `Ctype.current_level` except for those in `begin/end_def` API.
