### PR TITLE
Remove dead code from `camlatomic.h` and remove the dependency of `domain.h` on `platform.h`

### DIFF
--- a/Changes
+++ b/Changes
@@ -200,6 +200,11 @@ Working version
   style that the compiler driver uses.
   (David Allsopp, review by Gabriel Scherer)
 
+- #12839: Remove ATOMIC_UINTNAT_INIT from camlatomic.h (as part of a larger
+  cleanup of camlatomic.h)
+  (David Allsopp, review by Antonin Décimo, Sébastien Hinderer, Samuel Hym,
+   Guillaume Munch-Maccagnoni and Miod Vallat)
+
 ### Code generation and optimizations:
 
 - #11239: on x86-64 and RISC-V, reduce alignment of OCaml stacks from 16 to 8.

--- a/configure
+++ b/configure
@@ -14635,14 +14635,6 @@ then :
 fi
 
 
-ac_fn_c_check_header_compile "$LINENO" "stdatomic.h" "ac_cv_header_stdatomic_h" "$ac_includes_default"
-if test "x$ac_cv_header_stdatomic_h" = xyes
-then :
-  printf "%s\n" "#define HAS_STDATOMIC_H 1" >>confdefs.h
-
-fi
-
-
 ac_fn_c_check_header_compile "$LINENO" "sys/mman.h" "ac_cv_header_sys_mman_h" "$ac_includes_default"
 if test "x$ac_cv_header_sys_mman_h" = xyes
 then :

--- a/configure.ac
+++ b/configure.ac
@@ -1047,8 +1047,6 @@ AC_CHECK_HEADER([dirent.h], [AC_DEFINE([HAS_DIRENT])], [],
 AC_CHECK_HEADER([sys/select.h], [AC_DEFINE([HAS_SYS_SELECT_H])], [],
   [#include <sys/types.h>])
 
-AC_CHECK_HEADER([stdatomic.h], [AC_DEFINE([HAS_STDATOMIC_H])])
-
 AC_CHECK_HEADER([sys/mman.h], [AC_DEFINE([HAS_SYS_MMAN_H])])
 
 # Checks for types

--- a/runtime/afl.c
+++ b/runtime/afl.c
@@ -16,6 +16,7 @@
 
 #define CAML_INTERNALS
 
+#include <string.h>
 #include "caml/config.h"
 #include "caml/memory.h"
 #include "caml/mlvalues.h"

--- a/runtime/caml/camlatomic.h
+++ b/runtime/caml/camlatomic.h
@@ -45,4 +45,19 @@ typedef _Atomic intnat atomic_intnat;
 
 #endif
 
+#ifdef CAML_INTERNALS
+
+/* Loads and stores with acquire, release and relaxed semantics */
+
+#define atomic_load_acquire(p)                    \
+  atomic_load_explicit((p), memory_order_acquire)
+#define atomic_load_relaxed(p)                    \
+  atomic_load_explicit((p), memory_order_relaxed)
+#define atomic_store_release(p, v)                      \
+  atomic_store_explicit((p), (v), memory_order_release)
+#define atomic_store_relaxed(p, v)                      \
+  atomic_store_explicit((p), (v), memory_order_relaxed)
+
+#endif /* CAML_INTERNALS */
+
 #endif /* CAML_ATOMIC_H */

--- a/runtime/caml/camlatomic.h
+++ b/runtime/caml/camlatomic.h
@@ -18,10 +18,8 @@
 
 #include "config.h"
 
-/* On platforms supporting C11 atomics, this file just includes <stdatomic.h>.
-
-   On other platforms, this file includes platform-specific stubs for
-   the subset of C11 atomics needed by the OCaml runtime
+/*
+ * C11 atomics types and utility macros.
  */
 
 #ifdef __cplusplus
@@ -38,48 +36,13 @@ using std::memory_order_acq_rel;
 using std::memory_order_seq_cst;
 }
 
-#elif defined(HAS_STDATOMIC_H)
+#else
 
 #include <stdatomic.h>
 #define ATOMIC_UINTNAT_INIT(x) (x)
 typedef _Atomic uintnat atomic_uintnat;
 typedef _Atomic intnat atomic_intnat;
 
-#elif defined(__GNUC__)
-
-/* Support for versions of gcc which have built-in atomics but do not
-   expose stdatomic.h (e.g. gcc 4.8) */
-typedef enum memory_order {
-  memory_order_relaxed = __ATOMIC_RELAXED,
-  memory_order_acquire = __ATOMIC_ACQUIRE,
-  memory_order_release = __ATOMIC_RELEASE,
-  memory_order_acq_rel = __ATOMIC_ACQ_REL,
-  memory_order_seq_cst = __ATOMIC_SEQ_CST
-} memory_order;
-
-#define ATOMIC_UINTNAT_INIT(x) { (x) }
-typedef struct { uintnat repr; } atomic_uintnat;
-typedef struct { intnat repr; } atomic_intnat;
-
-#define atomic_load_explicit(x, m) __atomic_load_n(&(x)->repr, (m))
-#define atomic_load(x) atomic_load_explicit((x), memory_order_seq_cst)
-#define atomic_store_explicit(x, v, m) __atomic_store_n(&(x)->repr, (v), (m))
-#define atomic_store(x, v) atomic_store_explicit((x), (v), memory_order_seq_cst)
-#define atomic_compare_exchange_strong(x, oldv, newv) \
-  __atomic_compare_exchange_n( \
-    &(x)->repr, \
-    (oldv), (newv), 0, \
-    memory_order_seq_cst, memory_order_seq_cst)
-#define atomic_exchange(x, newv) \
-  __atomic_exchange_n(&(x)->repr, (newv), memory_order_seq_cst)
-#define atomic_fetch_add(x, n) \
-  __atomic_fetch_add(&(x)->repr, (n), memory_order_seq_cst)
-#define atomic_fetch_or(x, n) \
-  __atomic_fetch_or(&(x)->repr, (n), memory_order_seq_cst)
-#define atomic_thread_fence __atomic_thread_fence
-
-#else
-#error "C11 atomics are unavailable on this platform. See camlatomic.h"
 #endif
 
 #endif /* CAML_ATOMIC_H */

--- a/runtime/caml/camlatomic.h
+++ b/runtime/caml/camlatomic.h
@@ -26,7 +26,6 @@
 
 extern "C++" {
 #include <atomic>
-#define ATOMIC_UINTNAT_INIT(x) (x)
 typedef std::atomic<uintnat> atomic_uintnat;
 typedef std::atomic<intnat> atomic_intnat;
 using std::memory_order_relaxed;
@@ -39,7 +38,6 @@ using std::memory_order_seq_cst;
 #else
 
 #include <stdatomic.h>
-#define ATOMIC_UINTNAT_INIT(x) (x)
 typedef _Atomic uintnat atomic_uintnat;
 typedef _Atomic intnat atomic_intnat;
 

--- a/runtime/caml/domain.h
+++ b/runtime/caml/domain.h
@@ -27,7 +27,6 @@ extern "C" {
 #include "config.h"
 #include "mlvalues.h"
 #include "domain_state.h"
-#include "platform.h"
 
 /* The runtime currently has a hard limit on the number of domains.
    This hard limit may go away in the future. */

--- a/runtime/caml/platform.h
+++ b/runtime/caml/platform.h
@@ -53,17 +53,6 @@ Caml_inline void cpu_relax(void) {
 #endif
 }
 
-/* Loads and stores with acquire, release and relaxed semantics */
-
-#define atomic_load_acquire(p)                    \
-  atomic_load_explicit((p), memory_order_acquire)
-#define atomic_load_relaxed(p)                    \
-  atomic_load_explicit((p), memory_order_relaxed)
-#define atomic_store_release(p, v)                      \
-  atomic_store_explicit((p), (v), memory_order_release)
-#define atomic_store_relaxed(p, v)                      \
-  atomic_store_explicit((p), (v), memory_order_relaxed)
-
 /* Spin-wait loops */
 
 #define Max_spins 1000

--- a/runtime/caml/s.h.in
+++ b/runtime/caml/s.h.in
@@ -78,8 +78,6 @@
 
 #undef HAS_ISSETUGID
 
-#undef HAS_STDATOMIC_H
-
 #undef HAS_SYS_MMAN_H
 
 /* 2. For the Unix library. */

--- a/runtime/caml/sync.h
+++ b/runtime/caml/sync.h
@@ -21,6 +21,7 @@
 #ifdef CAML_INTERNALS
 
 #include "mlvalues.h"
+#include "platform.h"
 
 typedef pthread_mutex_t * sync_mutex;
 

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -206,17 +206,7 @@ static struct {
   atomic_uintnat barrier;
 
   caml_domain_state* participating[Max_domains];
-} stw_request = {
-  ATOMIC_UINTNAT_INIT(0),
-  ATOMIC_UINTNAT_INIT(0),
-  NULL,
-  NULL,
-  NULL,
-  NULL,
-  0,
-  ATOMIC_UINTNAT_INIT(0),
-  { 0 },
-};
+} stw_request = { 0, 0, NULL, NULL, NULL, NULL, 0, 0, { 0 } };
 
 static caml_plat_mutex all_domains_lock = CAML_PLAT_MUTEX_INITIALIZER;
 static caml_plat_cond all_domains_cond =

--- a/runtime/fail_nat.c
+++ b/runtime/fail_nat.c
@@ -199,7 +199,7 @@ CAMLexport value caml_raise_if_exception(value res)
    for the ccall to [caml_array_bound_error]).  */
 static value array_bound_exn(void)
 {
-  static atomic_uintnat exn_cache = ATOMIC_UINTNAT_INIT(0);
+  static atomic_uintnat exn_cache = 0;
   const value* exn = (const value*)atomic_load_acquire(&exn_cache);
   if (!exn) {
     exn = caml_named_value("Pervasives.array_bound_error");

--- a/runtime/gc_stats.c
+++ b/runtime/gc_stats.c
@@ -17,6 +17,7 @@
 
 #include "caml/gc_stats.h"
 #include "caml/minor_gc.h"
+#include "caml/platform.h"
 #include "caml/shared_heap.h"
 
 Caml_inline intnat intnat_max(intnat a, intnat b) {

--- a/runtime/globroots.c
+++ b/runtime/globroots.c
@@ -19,6 +19,7 @@
 
 #include "caml/mlvalues.h"
 #include "caml/memory.h"
+#include "caml/platform.h"
 #include "caml/roots.h"
 #include "caml/globroots.h"
 #include "caml/skiplist.h"

--- a/runtime/runtime_events.c
+++ b/runtime/runtime_events.c
@@ -22,6 +22,7 @@
 #include "caml/memory.h"
 #include "caml/mlvalues.h"
 #include "caml/osdeps.h"
+#include "caml/platform.h"
 #include "caml/startup_aux.h"
 
 #include <fcntl.h>

--- a/runtime/signals.c
+++ b/runtime/signals.c
@@ -30,6 +30,7 @@
 #include "caml/memory.h"
 #include "caml/misc.h"
 #include "caml/mlvalues.h"
+#include "caml/platform.h"
 #include "caml/roots.h"
 #include "caml/signals.h"
 #include "caml/sys.h"


### PR DESCRIPTION
This PR makes two related changes (the second, which is what I'm after, morally relies on the first):
- `camlatomic.h` includes pre-C11 support for old versions of GCC. This was from the early days of the multicore project, but since #11295 that code can't be reached. The unnecessary check for `stdatomic.h` in `configure.ac` is likewise removed.
- Removal of the dependency of `domain.h` on `platform.h`. This is extremely useful for the testsuite with the MSVC port. The problem is that `platform.h` necessarily uses `pthread.h` and this is only available during the build. `domain.h` only requires the utility macros for atomics, which would appear to be reasonable candidates for inclusion in `camlatomic.h` instead.

Note that all these changes occur within `CAML_INTERNALS` blocks. We don't include `pthread.h` in any public part of the runtime headers.

For info, the tests affected are:
  - embedded/cmcaml.ml
  - gc-roots/globroots.ml
  - gc-roots/globroots_parallel.ml
  - gc-roots/globroots_parallel_spawn_burn.ml
  - gc-roots/globroots_sequential.ml
  - lf_skiplist/test.ml
  - lf_skiplist/test_parallel.ml
  - lib-unix/win-env/test_env.ml
  - output-complete-obj/test.ml
  - parallel/recommended_domain_count.ml

It's possible to simulate this on mingw-w64 by temporarily removing `pthread.h` when running the testsuite.