### PR TITLE
 manual: update runtime tracing chapter for custom events (ex #12335)

### DIFF
--- a/Changes
+++ b/Changes
@@ -127,6 +127,10 @@ Working version
 - #12352: Fix a typo in the documentation of Arg.write_arg
   (Christophe Raffalli, review by Florian Angeletti)
 
+- #12840: manual: update runtime tracing chapter for custom events (ex #12335)
+  (Lucas Pluvinage, Sadiq Jaffer and Olivier Nicole, review by Gabriel Scherer,
+   David Allsopp, Tim McGilchrist and Thomas Leonard)
+
 ### Compiler user-interface and warnings:
 
 - #12247: configure: --disable-ocamldebug can now be used instead

--- a/manual/src/cmds/runtime-tracing.etex
+++ b/manual/src/cmds/runtime-tracing.etex
@@ -8,7 +8,7 @@ very low overhead. The system and interfaces are low-level and tightly coupled
 to the runtime implementation, it is intended for end-users to rely on tooling
 to consume and visualise data of interest. Additional events can be declared and
 consumed, providing higher-level dynamic introspection capabilities to OCaml
-libraries, they are referred to as {\em custom events}.
+libraries. They are referred to as {\em custom events}.
 
 Data emitted includes:
 \begin{itemize}
@@ -97,7 +97,7 @@ In summary, there are three cases for the consumer when an event is received:
 \item event is not registered and has a custom event type: event is dropped.
 \end{itemize}
 The \texttt{Runtime_events.Type} module provides a way to use built-in event
-types and define new ones using an encoder-decoder pair.
+types and define custom ones using an encoder-decoder pair.
 
 Event consumers bind callbacks to event types, so they can work as generic
 listeners interpreting payloads coming from events that were not registered.

--- a/manual/src/cmds/runtime-tracing.etex
+++ b/manual/src/cmds/runtime-tracing.etex
@@ -6,7 +6,9 @@ This chapter describes the runtime events tracing system which enables
 continuous extraction of performance information from the OCaml runtime with
 very low overhead. The system and interfaces are low-level and tightly coupled
 to the runtime implementation, it is intended for end-users to rely on tooling
-to consume and visualise data of interest.
+to consume and visualise data of interest. Additional events can be declared and
+consumed, providing higher-level dynamic introspection capabilities to OCaml
+libraries, they are referred to as {\em custom events}.
 
 Data emitted includes:
 \begin{itemize}
@@ -56,7 +58,7 @@ which emit events and 2) the events transport that ingests and transports
 these events.
 
 \subsection{s:runtime-tracing-probes}{Probes}
-Probes collect events from the runtime system. These are further
+Probes collect events from the OCaml runtime system. These are further
 split in to two sets: 1) probes that are always available and 2) probes
 that are only available in the instrumented runtime.
 Probes in the instrumented runtime are primarily of
@@ -69,6 +71,39 @@ The full set of events emitted by probes and their documentation can be found in
 \else
  section~\ref{Runtime_events}.
 \fi
+
+\subsection{s:runtime-tracing-custom-events}{Custom events}
+The runtime events system supports defining custom events. Identified by a
+globally unique name, they are emitted with payloads of built-in (\texttt{unit},
+\texttt{int}, \texttt{span}) and user-defined types. They are registered using
+the \texttt{Runtime_events.User.register} function. Once an event is registered,
+values for that event are emitted using \texttt{Runtime_events.User.write}.
+
+As consumer and producer can be different programs, they might not have the same
+set of registered events. The event name is used by the consumer to identify
+producer events, with a fallback mechanism for unknown events of built-in types.
+Unknown events for user-defined types are currently ignored, even if the type is
+defined both in the producer and consumer side.
+
+An extensible variant \texttt{tag} provides a way to attach additional data to
+events. The tag is not serialized, so it is only available for \textit{known}
+events.
+
+In summary, there are three cases for the consumer when an event is received:
+\begin{itemize}
+\item event is registered: payload and tag are available.
+\item event is not registered and has a built-in event type (unit, int, span):
+    only the payload is available.
+\item event is not registered and has a custom event type: event is dropped.
+\end{itemize}
+The \texttt{Runtime_events.Type} module provides a way to use built-in event
+types and define new ones using an encoder-decoder pair.
+
+Event consumers bind callbacks to event types, so they can work as generic
+listeners interpreting payloads coming from events that were not registered.
+Because this only works for events of built-in types, it is useful to pair
+an event of custom type with an event of built-in type, enabling the design of
+a specialized consumer while staying compatible with generic tracing tools.
 
 \subsection{s:runtime-tracing-ingestion}{Events transport}
 
@@ -203,6 +238,83 @@ instead, call the program as below to produce the same result:
 
 \begin{verbatim}
 OCAML_RUNTIME_EVENTS_START=1 ./example
+\end{verbatim}
+
+\subsubsection{s-runtime-tracing-custom-events}{Tracing custom events}
+
+The following program uses the \texttt{Runtime_events.User} and
+\texttt{Runtime_events.Type} modules to declare two custom events providing
+\texttt{span} and \texttt{int} values. The \texttt{tag} extensible variant is
+extended with \texttt{CustomSpan} and \texttt{CustomInt}.
+
+\begin{verbatim}
+type Runtime_events.User.tag += CustomSpan | CustomInt
+
+let count_span =
+    Runtime_events.User.register "count.span" CustomSpan
+        Runtime_events.Type.span
+
+let count_value =
+    Runtime_events.User.register "count.value" CustomInt
+        Runtime_events.Type.int
+
+let count () =
+    Runtime_events.User.write count_span Begin;
+    for i = 1 to 5 do
+        Runtime_events.User.write count_value i
+    done;
+    Runtime_events.User.write count_span End
+
+let () =
+    Runtime_events.start ();
+    for _ = 1 to 3 do
+        count ()
+    done
+\end{verbatim}
+
+On the consumer side, one can use the provided event tag and type to match on
+the relevant events.
+
+\begin{verbatim}
+let span_event_handler domain_id ts event value =
+    (* we're only interested in our CustomSpan event *)
+    match Runtime_events.User.tag event, value with
+    | CustomSpan, Runtime_events.Type.Begin -> Printf.printf "> count begin\n"
+    | CustomSpan, End -> Printf.printf "< count end\n"
+    | _ -> ()
+
+let int_event_handler domain_id ts event value =
+    (* we're only interested in our CustomInt event *)
+    match Runtime_events.User.tag event with
+    | CustomInt -> Printf.printf "| count %d\n" value
+    | _ -> ()
+
+let () =
+    let open Runtime_events in
+    let cursor = create_cursor None in
+    let callbacks =
+        Callbacks.create ()
+        |> Callbacks.add_user_event Type.span span_event_handler
+        |> Callbacks.add_user_event Type.int int_event_handler
+    in
+    for _ = 0 to 100 do
+        ignore(read_poll cursor callbacks None)
+    done
+\end{verbatim}
+
+Giving the following output:
+\begin{verbatim}
+> count begin
+| count 1
+| count 2
+| count 3
+| count 4
+| count 5
+< count end
+> count begin
+| count 1
+| count 2
+[...]
 \end{verbatim}
 
 \subsubsection{s-runtime-tracing-environment-variables}{Environment variables}

--- a/manual/src/cmds/runtime-tracing.etex
+++ b/manual/src/cmds/runtime-tracing.etex
@@ -6,9 +6,7 @@ This chapter describes the runtime events tracing system which enables
 continuous extraction of performance information from the OCaml runtime with
 very low overhead. The system and interfaces are low-level and tightly coupled
 to the runtime implementation, it is intended for end-users to rely on tooling
-to consume and visualise data of interest. Additional events can be declared and
-consumed, providing higher-level dynamic introspection capabilities to OCaml
-libraries. They are referred to as {\em custom events}.
+to consume and visualise data of interest.
 
 Data emitted includes:
 \begin{itemize}
@@ -16,6 +14,10 @@ Data emitted includes:
 \item Minor and major heap sizings and utilization
 \item Allocation and promotion rates between heaps
 \end{itemize}
+
+Additional events can be declared and consumed, providing higher-level
+monitoring capabilities to OCaml libraries. They are referred to as {\em
+custom events}.
 
 \section{s:runtime-tracing-overview}{Overview}
 
@@ -53,62 +55,30 @@ a particular query or operation takes longer than expected to complete.
 
 \section{s:runtime-tracing-architecture}{Architecture}
 
-The runtime tracing system conceptually consists of two parts: 1) the probes
-which emit events and 2) the events transport that ingests and transports
-these events.
+The runtime tracing system conceptually consists of two parts: 1) the event
+sources which emit events and 2) the events transport that ingests and
+transports these events.
 
-\subsection{s:runtime-tracing-probes}{Probes}
-Probes collect events from the OCaml runtime system. These are further
-split in to two sets: 1) probes that are always available and 2) probes
-that are only available in the instrumented runtime.
-Probes in the instrumented runtime are primarily of
-interest to developers of the OCaml runtime and garbage collector and, at
-present, only consist of major heap allocation size counter events.
+\subsection{s:runtime-tracing-event-sources}{Event sources}
+Event sources are event-emitting points. There are a number of such sources in
+the OCaml runtime system. These are further split into two sets: 1) event
+sources that are always available and 2) event sources that are only available
+in the instrumented runtime. Event sources in the instrumented runtime are
+primarily of interest to developers of the OCaml runtime and garbage collector
+and, at present, only consist of major heap allocation size counter events.
 
-The full set of events emitted by probes and their documentation can be found in
+The full set of events emitted by event sources and their documentation can be
+found in
 \ifouthtml
  \moduleref{libref}{Runtime_events}{Module \texttt{Runtime_events}}.
 \else
  section~\ref{Runtime_events}.
 \fi
 
-\subsection{s:runtime-tracing-custom-events}{Custom events}
-The runtime events system supports defining custom events. Identified by a
-globally unique name, they are emitted with payloads of built-in (\texttt{unit},
-\texttt{int}, \texttt{span}) and user-defined types. They are registered using
-the \texttt{Runtime_events.User.register} function. Once an event is registered,
-values for that event are emitted using \texttt{Runtime_events.User.write}.
-
-As consumer and producer can be different programs, they might not have the same
-set of registered events. The event name is used by the consumer to identify
-producer events, with a fallback mechanism for unknown events of built-in types.
-Unknown events for user-defined types are currently ignored, even if the type is
-defined both in the producer and consumer side.
-
-An extensible variant \texttt{tag} provides a way to attach additional data to
-events. The tag is not serialized, so it is only available for \textit{known}
-events.
-
-In summary, there are three cases for the consumer when an event is received:
-\begin{itemize}
-\item event is registered: payload and tag are available.
-\item event is not registered and has a built-in event type (unit, int, span):
-    only the payload is available.
-\item event is not registered and has a custom event type: event is dropped.
-\end{itemize}
-The \texttt{Runtime_events.Type} module provides a way to use built-in event
-types and define custom ones using an encoder-decoder pair.
-
-Event consumers bind callbacks to event types, so they can work as generic
-listeners interpreting payloads coming from events that were not registered.
-Because this only works for events of built-in types, it is useful to pair
-an event of custom type with an event of built-in type, enabling the design of
-a specialized consumer while staying compatible with generic tracing tools.
-
 \subsection{s:runtime-tracing-ingestion}{Events transport}
 
-The events transport part of the system ingests events emitted by the probes
-and makes them available to consumers.
+The events transport part of the system ingests events emitted by the event
+sources and makes them available to consumers.
 
 \subsubsection{s:runtime-tracing-ringbuffers}{Ring buffers}
 
@@ -123,10 +93,12 @@ The ring buffer implementation used in runtime events can be written by at most
 one producer at a time but can be read simultaneously by multiple consumers
 without coordination from the producer. There is a unique ring buffer for every
 running domain and, on domain termination, ring buffers may be re-used for newly
-spawned domains. The ring buffers themselves are stored in a memory-mapped file
-with the processes identifier as the name and the extension ".events", this
-enables them to be read from outside the main OCaml process. See
-\moduleref{libref}{Runtime_events}{\texttt{Runtime_events}} for more information.
+spawned domains. Ring buffers are only allocated (including for the main
+domain) when runtime events are enabled. The ring buffers themselves are stored
+in a memory-mapped file with the processes identifier as the name and the
+extension ".events", this enables them to be read from outside the main OCaml
+process. See \moduleref{libref}{Runtime_events}{\texttt{Runtime_events}} for
+more information.
 
 \subsubsection{s:runtime-tracing-apis}{Consumption APIs}
 
@@ -140,12 +112,13 @@ is as follows:
   \item \texttt{Runtime_events.Callbacks.create} is called to register a callback function to receive the events.
   \item The cursor is polled via \texttt{Runtime_events.read_poll} using the callbacks
   created in the previous step. For each matching event in the ring buffers, the
-  provided callback functions are called.
+  provided callback functions are called. In addition to the emitted events,
+  callbacks are given the emitter domain's ID and the emission timestamp.
 \end{enumerate}
 
-\section{s-runtime-tracing-usage}{Usage}
+\section{s:runtime-tracing-usage}{Usage}
 
-\subsection{s-runtime-tracing-ocaml-apis}{With OCaml APIs}
+\subsection{s:runtime-tracing-ocaml-apis}{With OCaml APIs}
 
 We start with a simple example that prints the name, begin and end times
 of events emitted by the runtime event tracing system:
@@ -240,7 +213,185 @@ instead, call the program as below to produce the same result:
 OCAML_RUNTIME_EVENTS_START=1 ./example
 \end{verbatim}
 
-\subsubsection{s-runtime-tracing-custom-events}{Tracing custom events}
+\subsubsection{s:runtime-tracing-environment-variables}{Environment variables}
+
+Environment variables can be used to control different aspects of the runtime
+event tracing system. The following environment variables are available:
+
+\begin{itemize}
+  \item OCAML_RUNTIME_EVENTS_START if set will cause the runtime events system
+  to be started as part of the OCaml runtime initialization.
+  \item OCAML_RUNTIME_EVENTS_DIR sets the directory where the ".events"
+  files containing the runtime event tracing system's ring buffers will be located.
+  If not present the program's working directory will be used.
+  \item OCAML_RUNTIME_EVENTS_PRESERVE if set will make the OCaml runtime
+  preserve the runtime events ring buffer files past the termination of the OCaml program.
+  This can be useful for monitoring very short running programs.
+  If not set, the ".events" files of the OCaml program will be deleted
+  at program termination.
+\end{itemize}
+
+The size of the runtime events ring buffers can be configured via OCAMLRUNPARAM,
+see section \ref{s:ocamlrun-options} for more information.
+
+\subsubsection{s:runtime-tracing-instrumented-runtime}{Building with the instrumented runtime}
+
+Some events are only emitted by the instrumented runtime. To receive them, the
+OCaml program needs to be compiled and linked against the instrumented runtime.
+For our example program from earlier, this is achieved as follows:
+
+\begin{verbatim}
+ocamlopt -runtime-variant i -I +runtime_events -I +unix unix.cmxa runtime_events.cmxa example.ml -o example
+\end{verbatim}
+
+And for dune:
+
+\begin{verbatim}
+(executable
+ (name example)
+ (modules example)
+ (flags "-runtime-variant=i")
+ (libraries unix runtime_events))
+\end{verbatim}
+
+\subsection{s:runtime-tracing-tooling}{With tooling}
+
+Programmatic access to events is intended primarily for writers of observability
+libraries and tooling for end-users. The flexible API enables use of the
+performance data from runtime events for logging and monitoring purposes.
+
+In this section we cover several utilities in the \texttt{runtime_events_tools}
+package which provide simple ways of extracting and summarising data from runtime
+events. The trace utility in particular produces similar data to the previous
+'eventlog' instrumentation system available in OCaml 4.12 to 4.14.
+
+First, install \texttt{runtime_events_tools} in an OCaml 5.0+ opam switch:
+
+\begin{verbatim}
+opam install runtime_events_tools
+\end{verbatim}
+
+This should install the olly tool in your path. You can now generate
+runtime traces for programs compiled with OCaml 5.0+ using the trace subcommand:
+
+\begin{verbatim}
+olly trace trace.json 'your_program.exe .. args ..'
+\end{verbatim}
+
+Runtime tracing data will be generated in the json Trace Event Format to trace.json.
+This can then be loaded into the Chrome tracing viewer or into \ifouthtml
+\ahref{https://ui.perfetto.dev/}{Perfetto}
+\else
+Perfetto
+\fi
+to visualize the collected trace.
+
+\subsubsection{s:runtime-tracing-latency}{Measuring GC latency}
+
+The olly utility also includes a latency subcommand which consumes runtime
+events data and on program completion emits a parseable histogram summary of
+pause durations. It can be run as follows:
+
+\begin{verbatim}
+olly latency 'your_program.exe .. args ..'
+\end{verbatim}
+
+This should produce an output similar to the following:
+
+\begin{verbatim}
+GC latency profile:
+#[Mean (ms):	2.46,	 Stddev (ms):	3.87]
+#[Min (ms):	0.01,	 max (ms):	9.17]
+
+Percentile 	 Latency (ms)
+25.0000 	 0.01
+50.0000 	 0.23
+60.0000 	 0.23
+70.0000 	 0.45
+75.0000 	 0.45
+80.0000 	 0.45
+85.0000 	 0.45
+90.0000 	 9.17
+95.0000 	 9.17
+96.0000 	 9.17
+97.0000 	 9.17
+98.0000 	 9.17
+99.0000 	 9.17
+99.9000 	 9.17
+99.9900 	 9.17
+99.9990 	 9.17
+99.9999 	 9.17
+100.0000 	 9.17
+\end{verbatim}
+
+\section{s:runtime-tracing-custom-events}{Custom events}
+
+\subsection{s:runtime-tracing-custom-events-overview}{Overview}
+
+The runtime events system supports defining custom events. Identified by a
+globally unique name, they are emitted with payloads of built-in (\texttt{unit},
+\texttt{int}, \texttt{span}) and user-defined types. To understand the
+manipulation of custom events, it is useful to know how they are transported and
+stored: their representation consists of a name string (in fact, an index into
+an array of all custom names) and an arbitrary byte sequence. Custom event
+types can be \emph{registered} by providing encoding and decoding functions to
+and from a byte sequence, via the function
+\texttt{Runtime_events.Type.register}.
+
+Defining a new custom event (whether its payload is of a built-in type or a
+custom type) is done via another registration function,
+\texttt{Runtime_events.User.register}. This function records the association
+between the custom event's name, its type, and a \emph{tag}. The tag is then
+used when emitting or consuming custom events; it acts as a shorthand for the
+event name.
+
+Once an event is registered, values for that event are emitted using
+\texttt{Runtime_events.User.write}.
+
+To summarize, for a user to emit and consume custom events using a custom type
+they need to:
+
+\begin{enumerate}
+\item register the custom type
+\item extend the \texttt{Runtime_events.User.tag} variant with a new constructor
+\item register the new custom event, binding together the custom event name, the
+  new tag, and the new custom type
+\item emit instances of the event using \texttt{Runtime_events.User.write}
+\item indicate a callback which should receive all events of the custom
+  type using \texttt{Runtime_events.Callbacks.add_user_event} to register it
+  inside a \texttt{Runtime_events.Callbacks.t} object to be used when polling
+  (see section~\ref{s:runtime-tracing-ocaml-apis} above).
+\item \emph{(Optional, if there are distinct events registered with the same
+  custom type:)} In that callback, pattern-match on the event tag in order to
+  discriminate between different event tags of the same custom type.
+\end{enumerate}
+
+Note that if the emitter and the consumer are different programs, both must
+perform steps 1 to 3 to register custom events and custom event types (if any).
+Note that the tag values need not be the same in both programs; the only values
+that should match are the names.
+
+Unregistered events for user-defined types are currently ignored. As a fallback,
+unregistered, custom events of a built-in type are available, but are all
+tagged \texttt{UNK} (unknown).
+
+There are thus three cases for the consumer when an event is received:
+\begin{itemize}
+\item event is registered: payload and tag are available.
+\item event is not registered and has a built-in event type (unit, int, span):
+    only the payload is available.
+\item event is not registered and has a custom event type: event is dropped.
+\end{itemize}
+
+Note that event consumers bind callbacks to event \emph{types}, so they can work
+as generic listeners interpreting payloads coming from events that were not
+registered. Because this only works for events of built-in types, it can be
+useful to emit events in pairs: an event of a custom type with an event of a
+built-in type, enabling the design of a specialized consumer while staying
+compatible with generic tracing tools.
+
+\subsection{s:runtime-tracing-custom-events-usage}{Tracing custom events: an
+example}
 
 The following program uses the \texttt{Runtime_events.User} and
 \texttt{Runtime_events.Type} modules to declare two custom events providing
@@ -273,9 +424,21 @@ let () =
 \end{verbatim}
 
 On the consumer side, one can use the provided event tag and type to match on
-the relevant events.
+the relevant events. For the sake of completeness, we assume that the consumer
+is a different program, and repeat the definition of the new tag constructors,
+as well as the registering of the custom events.
 
 \begin{verbatim}
+type Runtime_events.User.tag += CustomSpan | CustomInt
+
+let count_span =
+    Runtime_events.User.register "count.span" CustomSpan
+        Runtime_events.Type.span
+
+let count_value =
+    Runtime_events.User.register "count.value" CustomInt
+        Runtime_events.Type.int
+
 let span_event_handler domain_id ts event value =
     (* we're only interested in our CustomSpan event *)
     match Runtime_events.User.tag event, value with
@@ -315,115 +478,4 @@ Giving the following output:
 | count 1
 | count 2
 [...]
-\end{verbatim}
-
-\subsubsection{s-runtime-tracing-environment-variables}{Environment variables}
-
-Environment variables can be used to control different aspects of the runtime
-event tracing system. The following environment variables are available:
-
-\begin{itemize}
-  \item OCAML_RUNTIME_EVENTS_START if set will cause the runtime events system
-  to be started as part of the OCaml runtime initialization.
-  \item OCAML_RUNTIME_EVENTS_DIR sets the directory where the ".events"
-  files containing the runtime event tracing system's ring buffers will be located.
-  If not present the program's working directory will be used.
-  \item OCAML_RUNTIME_EVENTS_PRESERVE if set will make the OCaml runtime
-  preserve the runtime events ring buffer files past the termination of the OCaml program.
-  This can be useful for monitoring very short running programs.
-  If not set, the ".events" files of the OCaml program will be deleted
-  at program termination.
-\end{itemize}
-
-The size of the runtime events ring buffers can be configured via OCAMLRUNPARAM,
-see section \ref{s:ocamlrun-options} for more information.
-
-\subsubsection{s-runtime-tracing-instrumented-runtime}{Building with the instrumented runtime}
-
-To receive events that are only available in the instrumented runtime, the
-OCaml program needs to be compiled and linked against the instrumented runtime.
-For our example program from earlier, this is achieved as follows:
-
-\begin{verbatim}
-ocamlopt -runtime-variant i -I +runtime_events -I +unix unix.cmxa runtime_events.cmxa example.ml -o example
-\end{verbatim}
-
-And for dune:
-
-\begin{verbatim}
-(executable
- (name example)
- (modules example)
- (flags "-runtime-variant=i")
- (libraries unix runtime_events))
-\end{verbatim}
-
-\subsection{s-runtime-tracing-tooling}{With tooling}
-
-Programmatic access to events is intended primarily for writers of observability
-libraries and tooling that end-users use. The flexible API enables use of
-the performance data from runtime events for logging and monitoring purposes.
-
-In this section we cover several utilities in the \texttt{runtime_events_tools}
-package which provide simple ways of extracting and summarising data from runtime
-events. The trace utility in particular produces similar data to the previous
-'eventlog' instrumentation system available in OCaml 4.12 to 4.14.
-
-First, install \texttt{runtime_events_tools} in an OCaml 5.0+ opam switch:
-
-\begin{verbatim}
-opam install runtime_events_tools
-\end{verbatim}
-
-This should install the olly tool in your path. You can now generate
-runtime traces for programs compiled with OCaml 5.0+ using the trace subcommand:
-
-\begin{verbatim}
-olly trace trace.json 'your_program.exe .. args ..'
-\end{verbatim}
-
-Runtime tracing data will be generated in the json Trace Event Format to trace.json.
-This can then be loaded into the Chrome tracing viewer or into \ifouthtml
-\ahref{https://ui.perfetto.dev/}{Perfetto}
-\else
-Perfetto
-\fi
-to visualize the collected trace.
-
-\subsubsection{s-runtime-tracing-latency}{Measuring GC latency}
-
-The olly utility also includes a latency subcommand which consumes runtime
-events data and on program completion emits a parseable histogram summary of
-pause durations. It can be run as follows:
-
-\begin{verbatim}
-olly latency 'your_program.exe .. args ..'
-\end{verbatim}
-
-This should produce an output similar to the following:
-
-\begin{verbatim}
-GC latency profile:
-#[Mean (ms):	2.46,	 Stddev (ms):	3.87]
-#[Min (ms):	0.01,	 max (ms):	9.17]
-
-Percentile 	 Latency (ms)
-25.0000 	 0.01
-50.0000 	 0.23
-60.0000 	 0.23
-70.0000 	 0.45
-75.0000 	 0.45
-80.0000 	 0.45
-85.0000 	 0.45
-90.0000 	 9.17
-95.0000 	 9.17
-96.0000 	 9.17
-97.0000 	 9.17
-98.0000 	 9.17
-99.0000 	 9.17
-99.9000 	 9.17
-99.9900 	 9.17
-99.9990 	 9.17
-99.9999 	 9.17
-100.0000 	 9.17
 \end{verbatim}

--- a/otherlibs/runtime_events/runtime_events.mli
+++ b/otherlibs/runtime_events/runtime_events.mli
@@ -207,7 +207,7 @@ module User : sig
   (** [write t v] emits value [v] for event [t]. *)
 
   val name : _ t -> string
-  (** [name t] is the uniquely identifying name of event [t]. *)
+  (** [name t] is the unique identifying name of event [t]. *)
 
   val tag : 'a t -> tag
   (** [tag t] is the associated tag of event [t], when it is known.

--- a/otherlibs/runtime_events/runtime_events.mli
+++ b/otherlibs/runtime_events/runtime_events.mli
@@ -46,7 +46,7 @@
     very short running programs.
 *)
 
-(** The type for counter events emitted by the runtime *)
+(** The type for counter events emitted by the runtime. *)
 type runtime_counter =
 | EV_C_FORCE_MINOR_ALLOC_SMALL
 | EV_C_FORCE_MINOR_MAKE_VECT
@@ -88,7 +88,7 @@ Live blocks of a Domain's major heap pools.
 Live blocks of a Domain's major heap large allocations.
 @since 5.1 *)
 
-(** The type for span events emitted by the runtime *)
+(** The type for span events emitted by the runtime. *)
 type runtime_phase =
 | EV_EXPLICIT_GC_SET
 | EV_EXPLICIT_GC_STAT
@@ -131,7 +131,7 @@ type runtime_phase =
 | EV_DOMAIN_CONDITION_WAIT
 | EV_DOMAIN_RESIZE_HEAP_RESERVATION
 
-(** Lifecycle events for the ring itself *)
+(** Lifecycle events for the ring itself. *)
 type lifecycle =
   EV_RING_START
 | EV_RING_STOP
@@ -143,38 +143,38 @@ type lifecycle =
 | EV_DOMAIN_TERMINATE
 
 val lifecycle_name : lifecycle -> string
-(** Return a string representation of a given lifecycle event type *)
+(** Return a string representation of a given lifecycle event type. *)
 
 val runtime_phase_name : runtime_phase -> string
-(** Return a string representation of a given runtime phase event type *)
+(** Return a string representation of a given runtime phase event type. *)
 
 val runtime_counter_name : runtime_counter -> string
-(** Return a string representation of a given runtime counter type *)
+(** Return a string representation of a given runtime counter type. *)
 
 type cursor
-(** Type of the cursor used when consuming *)
+(** Type of the cursor used when consuming. *)
 
 module Timestamp : sig
     type t
-    (** Type for the int64 timestamp to allow for future changes *)
+    (** Type for the int64 timestamp to allow for future changes. *)
 
     val to_int64 : t -> int64
 end
 
 module Type : sig
   type 'a t
-  (** The type for a user event content type *)
+  (** The type for a user event content type. *)
 
   val unit : unit t
-  (** An event that has no data associated with it *)
+  (** An event that has no data associated with it. *)
 
   type span = Begin | End
 
   val span : span t
-  (** An event that has a beginning and an end *)
+  (** An event that has a beginning and an end. *)
 
   val int : int t
-  (** An event containing an integer value *)
+  (** An event containing an integer value. *)
 
   val register : encode:(bytes -> 'a -> int) -> decode:(bytes -> int -> 'a)
                                                                         -> 'a t
@@ -193,21 +193,21 @@ module User : sig
 
   type tag = ..
   (** The type for a user event tag. Tags are used to discriminate between
-      user events of the same type *)
+      user events of the same type. *)
 
   type 'value t
   (** The type for a user event. User events describe their tag, carried data
-      type and an unique string-based name *)
+      type and an unique string-based name. *)
 
   val register : string -> tag -> 'value Type.t -> 'value t
   (** [register name tag ty] registers a new event with an unique [name],
-      carrying a [tag] and values of type [ty] *)
+      carrying a [tag] and values of type [ty]. *)
 
   val write : 'value t -> 'value -> unit
-  (** [write t v] records a new event [t] with value [v] *)
+  (** [write t v] emits value [v] for event [t]. *)
 
   val name : _ t -> string
-  (** [name t] is the uniquely identifying name of event [t] *)
+  (** [name t] is the uniquely identifying name of event [t]. *)
 
   val tag : 'a t -> tag
   (** [tag t] is the associated tag of event [t], when it is known.
@@ -218,7 +218,7 @@ end
 
 module Callbacks : sig
   type t
-  (** Type of callbacks *)
+  (** Type of callbacks. *)
 
   val create : ?runtime_begin:(int -> Timestamp.t -> runtime_phase
                                 -> unit) ->
@@ -285,7 +285,7 @@ val create_cursor : (string * int) option -> cursor
    external process to monitor. *)
 
 val free_cursor : cursor -> unit
-(** Free a previously created runtime_events cursor *)
+(** Free a previously created runtime_events cursor. *)
 
 val read_poll : cursor -> Callbacks.t -> int option -> int
 (** [read_poll cursor callbacks max_option] calls the corresponding functions

--- a/runtime/caml/runtime_events.h
+++ b/runtime/caml/runtime_events.h
@@ -296,7 +296,9 @@ void caml_ev_alloc_flush(void);
 CAMLextern value caml_runtime_events_user_register(value event_name,
    value event_tag, value event_type);
 
-/* Write event data to ring buffer. */
+/* Write event data to ring buffer. Should not be called when the runtime lock
+   is not held, i.e., after [caml_enter_blocking_section()] and before
+   [caml_leave_blocking_section()]. */
 CAMLextern value caml_runtime_events_user_write(value event,
    value event_content);
 


### PR DESCRIPTION
This PR intends to be the new #12335, taking over @TheLortex and @sadiqj to address reviewers’ requests.

It contains the same commits as the original PR, with the following changes in the last two commits:

- As suggested by @sadiqj, I moved the description of custom events to the end, after the documentation of built-in events. I find that it makes the presentation more progressive and clearer.
- I attempted to clarify and justify the API of custom runtime events by explaining what is stored, clarifying the role of tags, and expliciting the sequence of steps involved in registering and using custom types and/or custom events.
- Nit: I uniformized section labels to make them consistent with the rest of the manual.

(Since there was discussion about possible future improvements of the API: having done my best to clarify it, I have the impression that there may be room for simplification regarding tags: I am not sure what is the interest of exposing them, rather than the event names directly.)