### PR TITLE
Detect the C# compiler in configure for the testsuite

### DIFF
--- a/configure
+++ b/configure
@@ -768,6 +768,7 @@ LIBUNWIND_LDFLAGS
 LIBUNWIND_CPPFLAGS
 DLLIBS
 PARTIALLD
+csc
 target_os
 target_vendor
 target_cpu
@@ -3697,19 +3698,65 @@ case $host in #(
   syslib='-l$(1)' ;;
 esac
 
-case $host in #(
+# Extract the first word of "csc", so it can be a program name with args.
+set dummy csc; ac_word=$2
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
+printf %s "checking for $ac_word... " >&6; }
+if test ${ac_cv_prog_csc+y}
+then :
+  printf %s "(cached) " >&6
+else $as_nop
+  if test -n "$csc"; then
+  ac_cv_prog_csc="$csc" # Let the user override the test.
+else
+as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
+for as_dir in $PATH
+do
+  IFS=$as_save_IFS
+  case $as_dir in #(((
+    '') as_dir=./ ;;
+    */) ;;
+    *) as_dir=$as_dir/ ;;
+  esac
+    for ac_exec_ext in '' $ac_executable_extensions; do
+  if as_fn_executable_p "$as_dir$ac_word$ac_exec_ext"; then
+    ac_cv_prog_csc="csc"
+    printf "%s\n" "$as_me:${as_lineno-$LINENO}: found $as_dir$ac_word$ac_exec_ext" >&5
+    break 2
+  fi
+done
+  done
+IFS=$as_save_IFS
+
+fi
+fi
+csc=$ac_cv_prog_csc
+if test -n "$csc"; then
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $csc" >&5
+printf "%s\n" "$csc" >&6; }
+else
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
+printf "%s\n" "no" >&6; }
+fi
+
+
+if test -n "$csc"
+then :
+  case $host in #(
   *-*-mingw32*|*-pc-windows) :
     CSC=csc
-    CSCFLAGS="/nologo /nowarn:1668"
-    case $host_cpu in #(
+      CSCFLAGS="/nologo /nowarn:1668"
+      case $host_cpu in #(
   i*86) :
     CSCFLAGS="$CSCFLAGS /platform:x86" ;; #(
   *) :
      ;;
 esac ;; #(
   *) :
-     ;;
+    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: Mono is not yet supported - C sharp tests disabled" >&5
+printf "%s\n" "$as_me: WARNING: Mono is not yet supported - C sharp tests disabled" >&2;} ;;
 esac
+fi
 
 # Environment variables that are taken into account
 

--- a/configure.ac
+++ b/configure.ac
@@ -323,11 +323,14 @@ AS_CASE([$host],
   outputexe='-o '
   syslib='-l$(1)'])
 
-AS_CASE([$host],
-  [*-*-mingw32*|*-pc-windows],
-    [CSC=csc
-    CSCFLAGS="/nologo /nowarn:1668"
-    AS_CASE([$host_cpu], [i*86], [CSCFLAGS="$CSCFLAGS /platform:x86"])])
+AC_CHECK_PROG([csc],[csc],[csc])
+AS_IF([test -n "$csc"],
+  [AS_CASE([$host],
+    [*-*-mingw32*|*-pc-windows],
+      [CSC=csc
+      CSCFLAGS="/nologo /nowarn:1668"
+      AS_CASE([$host_cpu], [i*86], [CSCFLAGS="$CSCFLAGS /platform:x86"])],
+    [AC_MSG_WARN([Mono is not yet supported - C sharp tests disabled])])])
 
 # Environment variables that are taken into account
 


### PR DESCRIPTION
At present (and since forever), running the testsuite for mingw-w64 has required the C# compiler or the lib-dynlink-csharp tests fail, being unable to run `csc`. We've simply worked around that on the CI systems by ensuring Visual Studio is available on AppVeyor and the Jenkins workers.

Quite a long time ago, in a pandemic hopefully far far away, I wrote a commit which fixes this daft situation, but it has sat in other branches until today...