### PR TITLE
Some holiday testsuite cheer

### DIFF
--- a/testsuite/summarize.awk
+++ b/testsuite/summarize.awk
@@ -211,13 +211,13 @@ END {
         }
         printf("\n");
         printf("Summary:\n");
-        printf("  %3d tests passed\n", passed);
-        printf("  %3d tests skipped\n", skipped);
-        printf("  %3d tests failed\n", failed);
-        printf("  %3d tests not started (parent test skipped or failed)\n",
+        printf("  %4d tests passed\n", passed);
+        printf("  %4d tests skipped\n", skipped);
+        printf("  %4d tests failed\n", failed);
+        printf("  %4d tests not started (parent test skipped or failed)\n",
                ignored);
-        printf("  %3d unexpected errors\n", unexped);
-        printf("  %3d tests considered", nresults);
+        printf("  %4d unexpected errors\n", unexped);
+        printf("  %4d tests considered", nresults);
         if (nresults != passed + skipped + ignored + failed + unexped){
             printf (" (totals don't add up??)");
         }

--- a/testsuite/summarize.awk
+++ b/testsuite/summarize.awk
@@ -13,6 +13,14 @@
 #*                                                                        *
 #**************************************************************************
 
+BEGIN {
+  # awk trick to detect whether a function exists. x is undefined. If asort is
+  # present then asort (x) returns 0 (no elements sorted). If asort is not
+  # present then the _space_ before the bracket turns it into string
+  # concatenation of two undefined variables (which returns "").
+  has_asort = (asort (x) == "0")
+}
+
 function check() {
     if (!in_test){
         printf("error at line %d: found test result without test start\n", NR);
@@ -176,6 +184,13 @@ END {
             }else if (r == "n"){
                 ++ ignored;
             }
+        }
+        if (has_asort) {
+          asort(skips);
+          asort(blanks);
+          asort(fail);
+          asort(unexp);
+          asort(slow);
         }
         printf("\n");
         if (skipped != 0){

--- a/testsuite/summarize.awk
+++ b/testsuite/summarize.awk
@@ -152,6 +152,7 @@ function record_unexp() {
 }
 
 END {
+    if (ENVIRON["GITHUB_ACTIONS"] == "true") start_group = "::group::";
     if (in_test) record_unexp();
 
     if (errored){
@@ -197,12 +198,14 @@ END {
         isort(slow, slowcount);
         printf("\n");
         if (skipped != 0){
-            printf("\nList of skipped tests:\n");
+            printf("\n%sList of skipped tests:\n", start_group);
             for (i=0; i < skipidx; i++) printf("    %s\n", skips[i]);
+            if (ENVIRON["GITHUB_ACTIONS"] == "true") print "::endgroup::";
         }
         if (slowcount != 0){
-            printf("\n\nTests taking longer than 10s:\n");
+            printf("\n\n%sTests taking longer than 10s:\n", start_group);
             for (i=0; i < slowcount; i++) printf("    %s\n", slow[i]);
+            if (ENVIRON["GITHUB_ACTIONS"] == "true") print "::endgroup::";
         }
         if (empty != 0){
             printf("\nList of directories returning no results:\n");

--- a/testsuite/summarize.awk
+++ b/testsuite/summarize.awk
@@ -13,12 +13,17 @@
 #*                                                                        *
 #**************************************************************************
 
-BEGIN {
-  # awk trick to detect whether a function exists. x is undefined. If asort is
-  # present then asort (x) returns 0 (no elements sorted). If asort is not
-  # present then the _space_ before the bracket turns it into string
-  # concatenation of two undefined variables (which returns "").
-  has_asort = (asort (x) == "0")
+# Insertion sort in awk, because asort is a GNU extension. Lifted carefully
+# with tongs out of the mawk manpage.
+function isort(A, n) {
+  for (i = 1; i < n; i++) {
+    hold = A[j = i];
+    while (A[j-1] > hold) {
+      j--;
+      A[j+1] = A[j];
+    }
+    A[j] = hold;
+  }
 }
 
 function check() {
@@ -185,13 +190,11 @@ END {
                 ++ ignored;
             }
         }
-        if (has_asort) {
-          asort(skips);
-          asort(blanks);
-          asort(fail);
-          asort(unexp);
-          asort(slow);
-        }
+        isort(skips, skipidx);
+        isort(blanks, empty);
+        isort(fail, failed);
+        isort(unexp, unexped);
+        isort(slow, slowcount);
         printf("\n");
         if (skipped != 0){
             printf("\nList of skipped tests:\n");

--- a/testsuite/summarize.awk
+++ b/testsuite/summarize.awk
@@ -197,6 +197,10 @@ END {
             printf("\nList of skipped tests:\n");
             for (i=0; i < skipidx; i++) printf("    %s\n", skips[i]);
         }
+        if (slowcount != 0){
+            printf("\n\nTests taking longer than 10s:\n");
+            for (i=0; i < slowcount; i++) printf("    %s\n", slow[i]);
+        }
         if (empty != 0){
             printf("\nList of directories returning no results:\n");
             for (i=0; i < empty; i++) printf("    %s\n", blanks[i]);
@@ -220,10 +224,6 @@ END {
         printf("  %4d tests considered", nresults);
         if (nresults != passed + skipped + ignored + failed + unexped){
             printf (" (totals don't add up??)");
-        }
-        if (slowcount != 0){
-            printf("\n\nTests taking longer than 10s:\n");
-            for (i=0; i < slowcount; i++) printf("    %s\n", slow[i]);
         }
         printf ("\n");
         if (failed || unexped){


### PR DESCRIPTION
Some testsuite reporting tweaks:
- The results of the tables are sorted - I find the unsorted results particularly irritating when addressing failures. Initially, I thought this could be done "elegantly", so that users with GNU awk would get sorted results, but the report would still display in obsolete implementations such as mawk, but alas no. We all get sorted results, just pretend that there isn't an insertion sort function at the top of the file.
- @gasche's wish in #12337 is addressed as suggested, by moving the list of slow tests immediately below the list of skipped tests.
- The formatting of numbers is increased, as it is possible to trigger numbers of 1000 these days.
- The skipped and slow test log results are folded in the GitHub Actions logs.