### PR TITLE
Improve "undefined Makefile variables" warning and fix it for GNU make 4.4.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -604,6 +604,7 @@ USE_STDLIB = -nostdlib -I ../stdlib
 FLEXDLL_OBJECTS = \
   flexdll_$(FLEXDLL_CHAIN).$(O) flexdll_initer_$(FLEXDLL_CHAIN).$(O)
 FLEXLINK_BUILD_ENV = \
+  MSVCC_ROOT= \
   MSVC_DETECT=0 OCAML_CONFIG_FILE=../Makefile.config \
   CHAINS=$(FLEXDLL_CHAIN) ROOTDIR=..
 FLEXDLL_SOURCES = \

--- a/Makefile
+++ b/Makefile
@@ -656,8 +656,7 @@ boot/ocamlrun$(EXE):
 # Start up the system from the distribution compiler
 .PHONY: coldstart
 coldstart: boot/ocamlrun$(EXE) runtime/libcamlrun.$(A)
-	$(MAKE) -C stdlib OCAMLRUN='$$(ROOTDIR)/$<' \
-	  USE_BOOT_OCAMLC=true BOOT_CAMLC_FLAGS='$(USE_RUNTIME_PRIMS)' all
+	$(MAKE) -C stdlib OCAMLRUN='$$(ROOTDIR)/$<' USE_BOOT_OCAMLC=true all
 	rm -f $(addprefix boot/, libcamlrun.$(A) $(LIBFILES))
 	cp $(addprefix stdlib/, $(LIBFILES)) boot
 	cd boot; $(LN) ../runtime/libcamlrun.$(A) .

--- a/Makefile
+++ b/Makefile
@@ -656,7 +656,7 @@ boot/ocamlrun$(EXE):
 .PHONY: coldstart
 coldstart: boot/ocamlrun$(EXE) runtime/libcamlrun.$(A)
 	$(MAKE) -C stdlib OCAMLRUN='$$(ROOTDIR)/$<' \
-	  CAMLC='$$(BOOT_OCAMLC) $(USE_RUNTIME_PRIMS)' all
+	  USE_BOOT_OCAMLC=true BOOT_CAMLC_FLAGS='$(USE_RUNTIME_PRIMS)' all
 	rm -f $(addprefix boot/, libcamlrun.$(A) $(LIBFILES))
 	cp $(addprefix stdlib/, $(LIBFILES)) boot
 	cd boot; $(LN) ../runtime/libcamlrun.$(A) .

--- a/stdlib/Makefile
+++ b/stdlib/Makefile
@@ -30,20 +30,16 @@ TARGET_BINDIR ?= $(BINDIR)
 #      - using ../ocamlc which runs on ../boot/ocamlrun
 # 3. During coreboot (via library-cross),
 #      - using ../ocamlc which at that point runs on ../runtime/ocamlrun
-# If $(USE_BOOT_OCAMLC) is non-empty, we select case 1 and add any additional
-# flags specified in $(BOOT_OCAMLC_FLAGS), since coldstart needs to add
-# -use-prims to the calls (as the boot compiler may not have the same primitive
-# table as the root compiler).
+# If $(USE_BOOT_OCAMLC) is non-empty, we select case 1 and use $(BOOT_OCAMLC).
 # Otherwise, we use $(OCAMLRUN) ../ocamlc, with $(OCAMLRUN) being
 # ../boot/ocamlrun by default, but able to overridden by library-cross to
 # ../runtime/ocamlrun.
 USE_BOOT_OCAMLC ?=
-BOOT_OCAMLC_FLAGS ?=
 
 ifeq "$(USE_BOOT_OCAMLC)" ""
 CAMLC = $(OCAMLRUN) $(ROOTDIR)/ocamlc$(EXE)
 else
-CAMLC = $(BOOT_OCAMLC) $(BOOT_OCAMLC_FLAGS)
+CAMLC = $(BOOT_OCAMLC)
 endif
 COMPFLAGS = -strict-sequence -absname -w +a-4-9-41-42-44-45-48 \
             -g -warn-error +A -bin-annot -nostdlib -principal
@@ -240,7 +236,7 @@ stdlib__%.cmx:
 	           -o $@ -c $(filter %.ml, $^)
 
 # Dependencies on the compiler
-COMPILER_DEPS=$(filter-out -use-prims $(OCAMLRUN), $(CAMLC))
+COMPILER_DEPS=$(filter-out $(OCAMLRUN), $(CAMLC))
 $(OBJS) std_exit.cmo: $(COMPILER_DEPS)
 $(OBJS:.cmo=.cmi) std_exit.cmi: $(COMPILER_DEPS)
 $(OBJS:.cmo=.cmx) std_exit.cmx: $(OPTCOMPILER)

--- a/stdlib/Makefile
+++ b/stdlib/Makefile
@@ -23,10 +23,30 @@ include $(ROOTDIR)/Makefile.common
 
 TARGET_BINDIR ?= $(BINDIR)
 
-COMPILER=$(ROOTDIR)/ocamlc$(EXE)
-CAMLC=$(OCAMLRUN) $(COMPILER)
-COMPFLAGS=-strict-sequence -absname -w +a-4-9-41-42-44-45-48 \
-          -g -warn-error +A -bin-annot -nostdlib -principal
+# There are three ways the Standard Library is compiled in bytecode:
+# 1. During coldstart
+#      - using ../boot/ocamlc which runs on ../boot/ocamlrun
+# 2. During coreall (via library),
+#      - using ../ocamlc which runs on ../boot/ocamlrun
+# 3. During coreboot (via library-cross),
+#      - using ../ocamlc which at that point runs on ../runtime/ocamlrun
+# If $(USE_BOOT_OCAMLC) is non-empty, we select case 1 and add any additional
+# flags specified in $(BOOT_OCAMLC_FLAGS), since coldstart needs to add
+# -use-prims to the calls (as the boot compiler may not have the same primitive
+# table as the root compiler).
+# Otherwise, we use $(OCAMLRUN) ../ocamlc, with $(OCAMLRUN) being
+# ../boot/ocamlrun by default, but able to overridden by library-cross to
+# ../runtime/ocamlrun.
+USE_BOOT_OCAMLC ?=
+BOOT_OCAMLC_FLAGS ?=
+
+ifeq "$(USE_BOOT_OCAMLC)" ""
+CAMLC = $(OCAMLRUN) $(ROOTDIR)/ocamlc$(EXE)
+else
+CAMLC = $(BOOT_OCAMLC) $(BOOT_OCAMLC_FLAGS)
+endif
+COMPFLAGS = -strict-sequence -absname -w +a-4-9-41-42-44-45-48 \
+            -g -warn-error +A -bin-annot -nostdlib -principal
 ifeq "$(FLAMBDA)" "true"
 OPTCOMPFLAGS += -O3
 endif

--- a/tools/ci/actions/runner.sh
+++ b/tools/ci/actions/runner.sh
@@ -53,7 +53,8 @@ Build () {
   fi
   failed=0
   if grep -Fq ' warning: undefined variable ' build.log; then
-    echo Undefined Makefile variables detected
+    echo Undefined Makefile variables detected:
+    grep -F ' warning: undefined variable ' build.log
     failed=1
   fi
   rm build.log


### PR DESCRIPTION
CI would dutifully report "Undefined Makefile variables detected" but leave the actual list of variables as an exercise for the reader. The list is now displayed too.

GNU make 4.4.1 triggers the warning on the way we presently invoke the stdlib `Makefile`. While that's likely to change soon, it's a nuisance now when working on a system which has GNU make 4.4.1 (bleeding-edge Linux, macOS, or Windows).