### PR TITLE
Add `{In,Out}_channel.is_binary_mode`

### DIFF
--- a/Changes
+++ b/Changes
@@ -299,6 +299,11 @@ Working version
 - #12770: Add `Fun.compose`.
   (Justin Frank, review by Nicolás Ojeda Bär, Daniel Bünzli and Jeremy Yallop)
 
+- #12845: Add `{In,Out}_channel.is_binary_mode` as the dual of
+  `set_binary_mode`. This function was previously only available in the internal
+  C API.
+  (David Allsopp, review by Nicolás Ojeda Bär and Xavier Leroy)
+
 ### Other libraries:
 
 - #12213: Dynlink library, improve legibility of error messages

--- a/runtime/io.c
+++ b/runtime/io.c
@@ -784,6 +784,11 @@ CAMLprim value caml_ml_set_binary_mode(value vchannel, value mode)
   CAMLreturn (Val_unit);
 }
 
+CAMLprim value caml_ml_is_binary_mode(value vchannel)
+{
+  return Val_bool(caml_channel_binary_mode(Channel(vchannel)));
+}
+
 /*
    If the channel is closed, DO NOT raise a "bad file descriptor"
    exception, but do nothing (the buffer is already empty).

--- a/stdlib/in_channel.ml
+++ b/stdlib/in_channel.ml
@@ -204,4 +204,6 @@ let rec fold_lines f accu ic =
 
 let set_binary_mode = Stdlib.set_binary_mode_in
 
+external is_binary_mode : in_channel -> bool = "caml_ml_is_binary_mode"
+
 external isatty : t -> bool = "caml_sys_isatty"

--- a/stdlib/in_channel.mli
+++ b/stdlib/in_channel.mli
@@ -208,6 +208,12 @@ val set_binary_mode : t -> bool -> unit
     This function has no effect under operating systems that do not distinguish
     between text mode and binary mode. *)
 
+val is_binary_mode : t -> bool
+(** [is_binary_mode ic] returns whether the channel [ic] is in binary mode
+    (see {!set_binary_mode}).
+
+    @since 5.2 *)
+
 val isatty : t -> bool
 (** [isatty ic] is [true] if [ic] refers to a terminal or console window,
     [false] otherwise.

--- a/stdlib/out_channel.ml
+++ b/stdlib/out_channel.ml
@@ -67,7 +67,10 @@ let output_bigarray oc buf ofs len =
   if ofs < 0 || len < 0 || ofs > Bigarray.Array1.dim buf - len
   then invalid_arg "output_bigarray"
   else unsafe_output_bigarray oc buf ofs len
+
 let set_binary_mode = Stdlib.set_binary_mode_out
+
+external is_binary_mode : out_channel -> bool = "caml_ml_is_binary_mode"
 
 external set_buffered : t -> bool -> unit = "caml_ml_set_buffered"
 

--- a/stdlib/out_channel.mli
+++ b/stdlib/out_channel.mli
@@ -153,7 +153,6 @@ val length : t -> int64
     given channel is opened.  If the channel is opened on a file that is not a
     regular file, the result is meaningless. *)
 
-
 val set_binary_mode : t -> bool -> unit
 (** [set_binary_mode oc true] sets the channel [oc] to binary mode: no
     translations take place during output.
@@ -165,6 +164,12 @@ val set_binary_mode : t -> bool -> unit
 
     This function has no effect under operating systems that do not distinguish
     between text mode and binary mode. *)
+
+val is_binary_mode : t -> bool
+(** [is_binary_mode oc] returns whether the channel [oc] is in binary mode
+    (see {!set_binary_mode}).
+
+    @since 5.2 *)
 
 val set_buffered : t -> bool -> unit
 (** [set_buffered oc true] sets the channel [oc] to {e buffered} mode. In this


### PR DESCRIPTION
This is a further follow-on to the story of #12792. There are (good) ways of not needing to know the binary mode of a channel, but they mostly involve using the Unix library. In these guilt-free post-#10545 times, it seems we could risk having `is_binary_mode` as the dual of `set_binary_mode` in `In_channel` and `Out_channel` in the same way as we have `Out_channel.is_buffered` as the dual of `Out_channel.set_buffered`. Further, the function to get that mode was already exposed in the runtime's C API.