### PR TITLE
Unified GitHub Actions workflows across release branches for ease-of-maintenance [trunk version]

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,9 +71,25 @@ jobs:
           retention-days: 1
 
 # Full testsuite run, and other sanity checks
+# "extra" testsuite runs, reusing the previously built compiler tree.
+# debug: running the full testsuite with the
+#        debug runtime and minor heap verification.
+# debug-s4096: select testsuite run with the debug runtime and a small
+#              minor heap.
   normal:
+    name: ${{ matrix.name }}
     needs: build
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - id: normal
+            name: normal
+            dependencies: texlive-latex-extra texlive-fonts-recommended hevea sass
+          - id: debug
+            name: extra (debug)
+          - id: debug-s4096
+            name: extra (debug-s4096)
     steps:
       - name: Download Artifact
         uses: actions/download-artifact@v3
@@ -84,22 +100,43 @@ jobs:
           tar --zstd -xf sources.tar.zstd
           rm -f sources.tar.zstd
       - name: Packages
+        if: matrix.dependencies != ''
         run: |
-          sudo apt-get update -y && sudo apt-get install -y texlive-latex-extra texlive-fonts-recommended hevea sass
+          sudo apt-get update -y && sudo apt-get install -y ${{ matrix.dependencies }}
       - name: Run the testsuite
+        if: matrix.id == 'normal'
         run: |
           MAKE_ARG=-j OCAMLRUNPARAM=b,v=0 bash -xe tools/ci/actions/runner.sh test
+      - name: Run the testsuite (debug runtime)
+        if: matrix.id == 'debug'
+        env:
+          OCAMLRUNPARAM: v=0,V=1
+          USE_RUNTIME: d
+        run: |
+          bash -cxe "SHOW_TIMINGS=1 tools/ci/actions/runner.sh test"
+      - name: Run the testsuite (s=4096, debug runtime)
+        if: matrix.id == 'debug-s4096'
+        env:
+          OCAMLRUNPARAM: s=4096,v=0
+          USE_RUNTIME: d
+        run: |
+          for dir in $PARALLEL_TESTS; do \
+            bash -cxe "SHOW_TIMINGS=1 tools/ci/actions/runner.sh test_prefix $dir"; \
+          done
       - name: Build API Documentation
+        if: matrix.id == 'normal'
         run: |
           MAKE_ARG=-j OCAMLRUNPARAM=b,v=0 bash -xe tools/ci/actions/runner.sh api-docs
       - name: Install
+        if: matrix.id == 'normal'
         run: |
          MAKE_ARG=-j OCAMLRUNPARAM=b,v=0 bash -xe tools/ci/actions/runner.sh install
       - name: Build the manual
+        if: matrix.id == 'normal' && needs.build.outputs.manual_changed == 'true'
         run: |
           MAKE_ARG=-j OCAMLRUNPARAM=b,v=0 bash -xe tools/ci/actions/runner.sh manual
-        if: needs.build.outputs.manual_changed == 'true'
       - name: Other checks
+        if: matrix.id == 'normal'
         run: |
           MAKE_ARG=-j OCAMLRUNPARAM=b,v=0 bash -xe tools/ci/actions/runner.sh other-checks
 
@@ -125,7 +162,7 @@ jobs:
         run: brew install parallel
       - name: configure tree
         run: |
-          CONFIG_ARG=${{ matrix.config_arg }} MAKE_ARG=-j bash -xe tools/ci/actions/runner.sh configure
+          CONFIG_ARG='${{ matrix.config_arg }}' MAKE_ARG=-j bash -xe tools/ci/actions/runner.sh configure
       - name: Build
         run: |
           MAKE_ARG=-j bash -xe tools/ci/actions/runner.sh build
@@ -165,42 +202,3 @@ jobs:
       - name: Run the testsuite
         run: |
           bash -xe tools/ci/actions/runner.sh test
-
-# "extra" testsuite runs, reusing the previously built compiler tree.
-# debug: running the full testsuite with the
-#        debug runtime and minor heap verification.
-# debug-s4086: select testsuite run with the debug runtime and a small
-#              minor heap.
-  extra:
-    needs: build
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        id:
-          - debug
-          - debug-s4096
-    steps:
-      - name: Download artifact
-        uses: actions/download-artifact@v3
-        with:
-          name: compiler
-      - name: Unpack Artifact
-        run: |
-          tar --zstd -xf sources.tar.zstd
-          rm -f sources.tar.zstd
-      - name: Run the testsuite (debug runtime)
-        if: ${{ matrix.id == 'debug' }}
-        env:
-          OCAMLRUNPARAM: v=0,V=1
-          USE_RUNTIME: d
-        run: |
-          bash -cxe "SHOW_TIMINGS=1 tools/ci/actions/runner.sh test"
-      - name: Run the testsuite (s=4096, debug runtime)
-        if: ${{ matrix.id == 'debug-s4096' }}
-        env:
-          OCAMLRUNPARAM: s=4096,v=0
-          USE_RUNTIME: d
-        run: |
-          for dir in $PARALLEL_TESTS; do \
-            bash -cxe "SHOW_TIMINGS=1 tools/ci/actions/runner.sh test_prefix $dir"; \
-          done

--- a/.github/workflows/hygiene.yml
+++ b/.github/workflows/hygiene.yml
@@ -18,7 +18,7 @@ concurrency:
 jobs:
   hygiene:
     name: Checks
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - name: GitHub Context
         run: echo $GITHUB_CONTEXT

--- a/tools/ci/actions/runner.sh
+++ b/tools/ci/actions/runner.sh
@@ -39,7 +39,9 @@ EOF
 
   configure_flags="\
     --prefix=$PREFIX \
-    --enable-debug-runtime \
+    --enable-flambda-invariants \
+    --enable-ocamltest \
+    --disable-dependency-generation \
     $CONFIG_ARG"
 
   ./configure $configure_flags


### PR DESCRIPTION
I have some work in the pipeline for a wider overhaul of our GitHub Actions workflows, mainly to bring in faster testing for Windows, especially with the MSVC port around the corner.

The purpose of this PR, and #12847, #12848 and #12849 is to unify the workflows between 4.14, 5.0, 5.1 and trunk. 4.14 maintenance will continue for some time, and I already had to do some mildly tedious housekeeping in #12520, which I'd like to make a little more mechanical for the future. There's likely to be a 5.1.2 at some point, and it seems daft to have just 5.0 missing, hence the set of PRs.

This PR makes three minor changes:
- In #11294, it was necessary to force the hygiene to run on ubuntu-22.04, as the 22.04 image (with autoconf 2.71) was still experimental. We can revert to ubuntu-latest.
- A small diff in `runner.sh` in the flags passed to `configure` between 4.14 and 5.0 is reverted:
  - `--enable-debug-runtime` is redundant, as it's the default
  - The optimisation of `--disable-dependency-generation` got lost in the multicore merge and updates
  - Likewise `--enable-flambda-invariants` got lost
  - Explicitly passing `--enable-ocamltest` ensures release tags get built properly, although these are at present being skipped anyway
- The "extra" job and "normal" jobs are unified to a single "job". It can be checked, by inspection, that these do the same thing.

The following additional PRs and parts of PRs are then back-ported to branch 5.1 (see #12847):
- #12465 (except the cosmetic update to `.gitattributes` in https://github.com/ocaml/ocaml/pull/12465/commits/8bc2e39c9c94844a58ec3ad71922097316666eae)
- #12461
- The Stale bot workflow is removed, since it's only required on trunk

The following additional PRs and parts of PRs are then back-ported to branch 5.0 (see #12848):
- #11311
- #11331
- #11143
- #11405
- #11346
- #11730
- #12285
- #11617 (the part which renamed `b.cmi` in the testsuite)

At this point, the contents of `.github/workflows` and `tools/ci/actions` are now identical across branches 5.0, 5.1 and trunk. That workflow is then grafted on to 4.14, with just these changes (see #12849):

- The parallel tests machinery removed (since there aren't any)
- The debug-s4096 job removed
- The Linux -O0 job replaced with a no-naked-pointers run