### PR TITLE
Update stats at the end of a major cycle (and potentially a compaction)

### DIFF
--- a/Changes
+++ b/Changes
@@ -61,6 +61,13 @@ Working version
   (Jacques Garrigue, report by Leo White, review by Gabriel Scherer)
 
 ### Runtime system:
+
+- #12850: Update Gc.quick_stat data at the end of major cycles and compaction
+  This PR adds an additional caml_collect_gc_stats_sample_stw to the major heap
+  cycling stw. This means that Gc.quick_stat now actually reflects the state of
+  the heap after a major cycle or compaction.
+  (Sadiq Jaffer, review by Miod Vallat)
+
 - #12193: Re-introduce GC compaction for shared pools
   Adds a parallel compactor for the shared pools (which contain major heap
   blocks sized less than 128 words). Explicit only for now, on calls to

--- a/runtime/gc_stats.c
+++ b/runtime/gc_stats.c
@@ -104,7 +104,8 @@ void caml_orphan_alloc_stats(caml_domain_state *domain) {
 /* The "sampled stats" of a domain are a recent copy of its
    domain-local stats, accessed without synchronization and only
    updated ("sampled") during stop-the-world events -- each minor
-   collection, including those happening during domain termination. */
+   collection, major cycle (which potentially includes compaction),
+   all of these events could happen during domain termination. */
 static struct gc_stats sampled_gc_stats[Max_domains];
 
 /* Update the sampled stats for the given domain during a STW section. */

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -1468,6 +1468,10 @@ static void stw_cycle_all_domains(caml_domain_state* domain, void* args,
     caml_compact_heap(domain, participating_count, participating);
   }
 
+  /* Update GC stats (as these could have significantly changed if there was a
+      compaction )*/
+  caml_collect_gc_stats_sample_stw(domain);
+
   /* Collect domain-local stats to emit to runtime events */
   struct heap_stats local_stats;
   caml_collect_heap_stats_sample(Caml_state->shared_heap, &local_stats);

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -1469,7 +1469,7 @@ static void stw_cycle_all_domains(caml_domain_state* domain, void* args,
   }
 
   /* Update GC stats (as these could have significantly changed if there was a
-      compaction )*/
+      compaction) */
   caml_collect_gc_stats_sample_stw(domain);
 
   /* Collect domain-local stats to emit to runtime events */

--- a/stdlib/gc.mli
+++ b/stdlib/gc.mli
@@ -231,9 +231,9 @@ external quick_stat : unit -> stat = "caml_gc_quick_stat"
 (** Same as [stat] except that [live_words], [live_blocks], [free_words],
     [free_blocks], [largest_free], and [fragments] are set to 0. Due to
     per-domain buffers it may only represent the state of the program's
-    total memory usage since the last minor collection. This function is
-    much faster than [stat] because it does not need to trigger a full
-    major collection. *)
+    total memory usage since the last minor collection or major cycle.
+    This function is much faster than [stat] because it does not need to
+    trigger a full major collection. *)
 
 external counters : unit -> float * float * float = "caml_gc_counters"
 (** Return [(minor_words, promoted_words, major_words)] for the current


### PR DESCRIPTION
Small change but one that bit me last week. This PR adds an additional `caml_collect_gc_stats_sample_stw` to the major heap cycling stw. This means that `Gc.quick_stat` now actually reflects the state of the heap after a major cycle or compaction.