### PR TITLE
Fixes #12799 (race between runtime events teardown and event emission)

### DIFF
--- a/Changes
+++ b/Changes
@@ -704,6 +704,9 @@ Working version
   Changes type of type parameters in outcometree.mli.
   (Jacques Garrigue, review by Richard Eisenberg)
 
+- #12851: Fix race between runtime events teardown and event emission
+  (Olivier Nicole, review by Miod Vallat and Gabriel Scherer)
+
 OCaml 5.1.1 (8 December 2023)
 ----------------------------
 

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -1922,6 +1922,11 @@ static void domain_terminate (void)
 
       CAMLassert (domain_self->backup_thread_running);
       domain_self->backup_thread_running = 0;
+
+      /* We must signal domain termination before releasing [all_domains_lock]:
+         after that, this domain will no longer take part in STWs and emitting
+         an event could race with runtime events teardown. */
+      CAML_EV_LIFECYCLE(EV_DOMAIN_TERMINATE, getpid());
     }
     caml_plat_unlock(&all_domains_lock);
   }
@@ -1946,7 +1951,6 @@ static void domain_terminate (void)
   caml_free_intern_state();
   caml_free_extern_state();
   caml_teardown_major_gc();
-  CAML_EV_LIFECYCLE(EV_DOMAIN_TERMINATE, getpid());
 
   caml_teardown_shared_heap(domain_state->shared_heap);
   domain_state->shared_heap = 0;


### PR DESCRIPTION
Currently, a domain emits a runtime event to signal its termination after exiting the STW participant set. This creates the possibility of a race condition with runtime events teardown, since said teardown is performed in an STW section precisely not to race with, e.g., event emission. This moves up the emission of the domain termination event just a bit earlier, before releasing `all_domains_lock`, to ensure that no STW sections run concurrently.