### PR TITLE
use `TypeHash` to mark types

### DIFF
--- a/Changes
+++ b/Changes
@@ -551,6 +551,9 @@ Working version
 - #12764: Move all installable headers in `caml/` sub-directories.
   (Antonin Décimo, review by Gabriel Scherer and David Allsopp)
 
+- #12852: Use TypeHash instead of negative levels to mark types
+  (Takafumi Saikawa and Jacques Garrigue, review by ??)
+
 ### Build system:
 
 - #12198, #12321, #12586, #12616, #12706: continue the merge of the

--- a/toplevel/topdirs.ml
+++ b/toplevel/topdirs.ml
@@ -440,11 +440,8 @@ let is_nonrec_type id td =
           nonrecursive_use:= true
     | _ -> ()
   in
-  let it =  Btype.{type_iterators with it_path } in
-  let () =
-    it.it_type_declaration it td;
-    Btype.unmark_iterators.it_type_declaration Btype.unmark_iterators td
-  in
+  let it = {(Btype.type_iterators ()) with it_path} in
+  let () = it.it_type_declaration it td in
   match !recursive_use, !nonrecursive_use with
   | false, true -> Trec_not
   | true, _ | _, false -> Trec_first
@@ -542,13 +539,10 @@ let is_rec_module id md =
     | Path.Pident id' -> if (Ident.same id id') then raise Exit
     | _ -> ()
   in
-  let it =  Btype.{type_iterators with it_path } in
-  let rs = match it.it_module_declaration it md with
-    | () -> Trec_not
-    | exception Exit -> Trec_first
-  in
-  Btype.unmark_iterators.it_module_declaration Btype.unmark_iterators md;
-  rs
+  let it = {(Btype.type_iterators ()) with it_path} in
+  match it.it_module_declaration it md with
+  | () -> Trec_not
+  | exception Exit -> Trec_first
 
 let secretly_the_same_path env path1 path2 =
   let norm path = Printtyp.rewrite_double_underscore_paths env path in

--- a/typing/btype.ml
+++ b/typing/btype.ml
@@ -103,24 +103,14 @@ let print_raw =
 
 let generic_level = Ident.highest_scope
 
-(* Used to mark a type during a traversal. *)
+(* The lowest possible level for types *)
 let lowest_level = Ident.lowest_scope
-let pivot_level = 2 * lowest_level - 1
-    (* pivot_level - lowest_level < lowest_level *)
 
 (**** Some type creators ****)
 
 let newgenty desc      = newty2 ~level:generic_level desc
 let newgenvar ?name () = newgenty (Tvar name)
 let newgenstub ~scope  = newty3 ~level:generic_level ~scope (Tvar None)
-
-(*
-let newmarkedvar level =
-  incr new_id; { desc = Tvar; level = pivot_level - level; id = !new_id }
-let newmarkedgenvar () =
-  incr new_id;
-  { desc = Tvar; level = pivot_level - generic_level; id = !new_id }
-*)
 
 (**** Check some types ****)
 
@@ -238,7 +228,6 @@ let set_static_row_name decl path =
           set_type_desc ty (Tvariant row)
       | _ -> ()
 
-
                   (**********************************)
                   (*  Utilities for type traversal  *)
                   (**********************************)
@@ -303,6 +292,32 @@ let rec iter_abbrev f = function
   | Mcons(_, _, ty, ty', rem) -> f ty; f ty'; iter_abbrev f rem
   | Mlink rem              -> iter_abbrev f !rem
 
+                  (**********************************)
+                  (*  Utilities for level-marking   *)
+                  (**********************************)
+
+type type_marks = unit TypeHash.t
+
+let create_type_marks () = TypeHash.create 7
+
+let not_marked_node marks ty = not (TypeHash.mem marks ty)
+
+let mark_node marks ty = TypeHash.add marks ty ()
+
+let try_mark_node marks ty =
+  not_marked_node marks ty && (mark_node marks ty; true)
+
+let rec mark_type marks ty =
+  if try_mark_node marks ty then
+    iter_type_expr (mark_type marks) ty
+
+let mark_type_params marks ty =
+  iter_type_expr (mark_type marks) ty
+
+                  (**********************************)
+                  (*  (Object-oriented) iterator    *)
+                  (**********************************)
+
 type type_iterators =
   { it_signature: type_iterators -> signature -> unit;
     it_signature_item: type_iterators -> signature_item -> unit;
@@ -344,8 +359,7 @@ let iter_type_expr_kind f = function
   | Type_open ->
       ()
 
-
-let type_iterators =
+let type_iterators ?(marks=create_type_marks ()) () =
   let it_signature it =
     List.iter (it.it_signature_item it)
   and it_signature_item it = function
@@ -415,13 +429,19 @@ let type_iterators =
     | Tvariant row ->
         Option.iter (fun (p,_) -> it.it_path p) (row_name row)
     | _ -> ()
+  and it_type_expr it ty =
+    if try_mark_node marks ty then it.it_do_type_expr it ty
   and it_path _p = ()
   in
-  { it_path; it_type_expr = it_do_type_expr; it_do_type_expr;
+  { it_path; it_type_expr; it_do_type_expr;
     it_type_kind; it_class_type; it_functor_param; it_module_type;
     it_signature; it_class_type_declaration; it_class_declaration;
     it_modtype_declaration; it_module_declaration; it_extension_constructor;
     it_type_declaration; it_value_description; it_signature_item; }
+
+                  (**********************************)
+                  (*  Utilities for copying         *)
+                  (**********************************)
 
 let copy_row f fixed row keep more =
   let Row {fields = orig_fields; fixed = orig_fixed; closed; name = orig_name} =
@@ -467,8 +487,8 @@ let rec copy_type_desc ?(keep_names=false) f = function
       Tpoly (f ty, tyl)
   | Tpackage (p, fl)  -> Tpackage (p, List.map (fun (n, ty) -> (n, f ty)) fl)
 
-(* Utilities for copying *)
 
+(* NB: rename to [module Copy_scope]? *)
 module For_copy : sig
   type copy_scope
 
@@ -711,66 +731,9 @@ let instance_variable_type label sign =
   | (_, _, ty) -> ty
   | exception Not_found -> assert false
 
-                  (**********************************)
-                  (*  Utilities for level-marking   *)
-                  (**********************************)
-
-let not_marked_node ty = get_level ty >= lowest_level
-    (* type nodes with negative levels are "marked" *)
-
-let flip_mark_node ty =
-  let ty = Transient_expr.repr ty in
-  Transient_expr.set_level ty (pivot_level - ty.level)
-let logged_mark_node ty =
-  set_level ty (pivot_level - get_level ty)
-
-let try_mark_node ty = not_marked_node ty && (flip_mark_node ty; true)
-let try_logged_mark_node ty = not_marked_node ty && (logged_mark_node ty; true)
-
-let rec mark_type ty =
-  if not_marked_node ty then begin
-    flip_mark_node ty;
-    iter_type_expr mark_type ty
-  end
-
-let mark_type_params ty =
-  iter_type_expr mark_type ty
-
-let type_iterators =
-  let it_type_expr it ty =
-    if try_mark_node ty then it.it_do_type_expr it ty
-  in
-  {type_iterators with it_type_expr}
-
-
-(* Remove marks from a type. *)
-let rec unmark_type ty =
-  if get_level ty < lowest_level then begin
-    (* flip back the marked level *)
-    flip_mark_node ty;
-    iter_type_expr unmark_type ty
-  end
-
-let unmark_iterators =
-  let it_type_expr _it ty = unmark_type ty in
-  {type_iterators with it_type_expr}
-
-let unmark_type_decl decl =
-  unmark_iterators.it_type_declaration unmark_iterators decl
-
-let unmark_extension_constructor ext =
-  List.iter unmark_type ext.ext_type_params;
-  iter_type_expr_cstr_args unmark_type ext.ext_args;
-  Option.iter unmark_type ext.ext_ret_type
-
-let unmark_class_signature sign =
-  unmark_type sign.csig_self;
-  unmark_type sign.csig_self_row;
-  Vars.iter (fun _l (_m, _v, t) -> unmark_type t) sign.csig_vars;
-  Meths.iter (fun _l (_m, _v, t) -> unmark_type t) sign.csig_meths
-
-let unmark_class_type cty =
-  unmark_iterators.it_class_type unmark_iterators cty
+                  (**********)
+                  (*  Misc  *)
+                  (**********)
 
 (**** Type information getter ****)
 

--- a/typing/btype.ml
+++ b/typing/btype.ml
@@ -316,7 +316,7 @@ let iter_type_expr_kind f = function
       ()
 
                   (**********************************)
-                  (*  Utilities for level-marking   *)
+                  (*  Utilities for type-marking    *)
                   (**********************************)
 
 type type_marks = unit TypeHash.t

--- a/typing/btype.ml
+++ b/typing/btype.ml
@@ -321,11 +321,21 @@ let iter_type_expr_kind f = function
 
 type type_marks = unit TypeHash.t
 
-let create_type_marks () = TypeHash.create 7
+let create_type_marks () = TypeHash.create 1
 
 let not_marked_node marks ty = not (TypeHash.mem marks ty)
 
 let mark_node marks ty = TypeHash.add marks ty ()
+
+(*
+type type_marks = TypeSet.t ref
+
+let create_type_marks () = ref TypeSet.empty
+
+let not_marked_node marks ty = not (TypeSet.mem ty !marks)
+
+let mark_node marks ty = marks := TypeSet.add ty !marks
+*)
 
 let try_mark_node marks ty =
   not_marked_node marks ty && (mark_node marks ty; true)

--- a/typing/btype.mli
+++ b/typing/btype.mli
@@ -134,7 +134,7 @@ val map_type_expr_cstr_args: (type_expr -> type_expr) ->
 
 (**** Utilities for type marking ****)
 
-type type_marks = unit TypeHash.t
+type type_marks
 
 val create_type_marks: unit -> type_marks
 

--- a/typing/btype.mli
+++ b/typing/btype.mli
@@ -132,7 +132,7 @@ val iter_type_expr_cstr_args: (type_expr -> unit) ->
 val map_type_expr_cstr_args: (type_expr -> type_expr) ->
   (constructor_arguments -> constructor_arguments)
 
-(**** Utilities for level marking ****)
+(**** Utilities for type marking ****)
 
 type type_marks = unit TypeHash.t
 

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -1958,21 +1958,17 @@ let unify_univar_for tr_exn t1 t2 univar_pairs =
 (* That's way too expensive. Must do some kind of caching *)
 (* If [inj_only=true], only check injective positions *)
 let occur_univar ?(inj_only=false) env ty =
-  let marks = create_type_marks () in
   let visited = ref TypeMap.empty in
   let rec occur_rec bound ty =
-    if not_marked_node marks ty then
-      if TypeSet.is_empty bound then
-        (mark_node marks ty; occur_desc bound ty)
-      else try
-        let bound' = TypeMap.find ty !visited in
-        if not (TypeSet.subset bound' bound) then begin
-          visited := TypeMap.add ty (TypeSet.inter bound bound') !visited;
-          occur_desc bound ty
-        end
-      with Not_found ->
-        visited := TypeMap.add ty bound !visited;
+    try
+      let bound' = TypeMap.find ty !visited in
+      if not (TypeSet.subset bound' bound) then begin
+        visited := TypeMap.add ty (TypeSet.inter bound bound') !visited;
         occur_desc bound ty
+      end
+    with Not_found ->
+      visited := TypeMap.add ty bound !visited;
+      occur_desc bound ty
   and occur_desc bound ty =
       match get_desc ty with
         Tunivar _ ->

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -1958,17 +1958,21 @@ let unify_univar_for tr_exn t1 t2 univar_pairs =
 (* That's way too expensive. Must do some kind of caching *)
 (* If [inj_only=true], only check injective positions *)
 let occur_univar ?(inj_only=false) env ty =
+  let marks = create_type_marks () in
   let visited = ref TypeMap.empty in
   let rec occur_rec bound ty =
-    try
-      let bound' = TypeMap.find ty !visited in
-      if not (TypeSet.subset bound' bound) then begin
-        visited := TypeMap.add ty (TypeSet.inter bound bound') !visited;
+    if not_marked_node marks ty then
+      if TypeSet.is_empty bound then
+        (mark_node marks ty; occur_desc bound ty)
+      else try
+        let bound' = TypeMap.find ty !visited in
+        if not (TypeSet.subset bound' bound) then begin
+          visited := TypeMap.add ty (TypeSet.inter bound bound') !visited;
+          occur_desc bound ty
+        end
+      with Not_found ->
+        visited := TypeMap.add ty bound !visited;
         occur_desc bound ty
-      end
-    with Not_found ->
-      visited := TypeMap.add ty bound !visited;
-      occur_desc bound ty
   and occur_desc bound ty =
       match get_desc ty with
         Tunivar _ ->

--- a/typing/datarepr.ml
+++ b/typing/datarepr.ml
@@ -23,8 +23,9 @@ open Btype
 (* Simplified version of Ctype.free_vars *)
 let free_vars ?(param=false) ty =
   let ret = ref TypeSet.empty in
+  let marks = create_type_marks () in
   let rec loop ty =
-    if try_mark_node ty then
+    if try_mark_node marks ty then
       match get_desc ty with
       | Tvar _ ->
           ret := TypeSet.add ty !ret
@@ -40,7 +41,6 @@ let free_vars ?(param=false) ty =
           iter_type_expr loop ty
   in
   loop ty;
-  unmark_type ty;
   !ret
 
 let newgenconstr path tyl = newgenty (Tconstr (path, tyl, ref Mnil))

--- a/typing/mtype.ml
+++ b/typing/mtype.ml
@@ -456,9 +456,10 @@ let collect_arg_paths mty =
   and bindings = ref Ident.empty in
   (* let rt = Ident.create "Root" in
      and prefix = ref (Path.Pident rt) in *)
+  let super = type_iterators () in
   let it_path p = paths := Path.Set.union (get_arg_paths p) !paths
   and it_signature_item it si =
-    type_iterators.it_signature_item it si;
+    super.it_signature_item it si;
     match si with
     | Sig_module (id, _, {md_type=Mty_alias p}, _, _) ->
         bindings := Ident.add id p !bindings
@@ -471,9 +472,8 @@ let collect_arg_paths mty =
           sg
     | _ -> ()
   in
-  let it = {type_iterators with it_path; it_signature_item} in
+  let it = {super with it_path; it_signature_item} in
   it.it_module_type it mty;
-  it.it_module_type unmark_iterators mty;
   Path.Set.fold (fun p -> Ident.Set.union (collect_ids !subst !bindings p))
     !paths Ident.Set.empty
 
@@ -552,14 +552,14 @@ let scrape_for_type_of ~remove_aliases env mty =
 
 let lower_nongen nglev mty =
   let open Btype in
-  let it_type_expr it ty =
+  let super = type_iterators () in
+  let it_do_type_expr it ty =
     match get_desc ty with
       Tvar _ ->
         let level = get_level ty in
         if level < generic_level && level > nglev then set_level ty nglev
     | _ ->
-        type_iterators.it_type_expr it ty
+        super.it_do_type_expr it ty
   in
-  let it = {type_iterators with it_type_expr} in
-  it.it_module_type it mty;
-  it.it_module_type unmark_iterators mty
+  let it = {super with it_do_type_expr} in
+  it.it_module_type it mty

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -265,7 +265,7 @@ let path_is_strict_prefix =
 
 let iterator_with_env env =
   let env = ref (lazy env) in
-  let super = Btype.type_iterators in
+  let super = Btype.type_iterators () in
   env, { super with
     Btype.it_signature = (fun self sg ->
       (* add all items to the env before recursing down, to handle recursive
@@ -377,8 +377,7 @@ let do_check_after_substitution env ~loc ~lid paths unpackable_modtype sg =
        let error p = With_cannot_remove_packed_modtype(p,mty) in
        check_usage_of_module_types ~error ~paths ~loc env iterator
   in
-  iterator.Btype.it_signature iterator sg;
-  Btype.(unmark_iterators.it_signature unmark_iterators) sg
+  iterator.Btype.it_signature iterator sg
 
 let check_usage_after_substitution env ~loc ~lid paths unpackable_modtype sg =
   match paths, unpackable_modtype with
@@ -1143,10 +1142,9 @@ end = struct
             (Ident.Set.elements to_remove.unpackable_modtypes)
         in
         check_usage_of_module_types ~loc ~error ~paths
-          (ref (lazy env)) Btype.type_iterators
+          (ref (lazy env)) (Btype.type_iterators ())
       in
-      iterator.Btype.it_signature_item iterator component;
-      Btype.(unmark_iterators.it_signature_item unmark_iterators) component
+      iterator.Btype.it_signature_item iterator component
     end
 
   (* We usually require name uniqueness of signature components (e.g. types,

--- a/typing/typetexp.ml
+++ b/typing/typetexp.ml
@@ -772,8 +772,8 @@ and transl_fields env ~policy ~row_context o fields =
 
 
 (* Make the rows "fixed" in this type, to make universal check easier *)
-let rec make_fixed_univars ty =
-  if Btype.try_mark_node ty then
+let rec make_fixed_univars marks ty =
+  if Btype.try_mark_node marks ty then
     begin match get_desc ty with
     | Tvariant row ->
         let Row {fields; more; name; closed} = row_repr row in
@@ -790,17 +790,17 @@ let rec make_fixed_univars ty =
             (Tvariant
                (create_row ~fields ~more ~name ~closed
                   ~fixed:(Some (Univar more))));
-        Btype.iter_row make_fixed_univars row
+        Btype.iter_row (make_fixed_univars marks) row
     | _ ->
-        Btype.iter_type_expr make_fixed_univars ty
+        Btype.iter_type_expr (make_fixed_univars marks) ty
     end
+
+let make_fixed_univars ty =
+  let marks = Btype.create_type_marks () in
+  make_fixed_univars marks ty
 
 let transl_type env policy styp =
   transl_type env ~policy ~row_context:[] styp
-
-let make_fixed_univars ty =
-  make_fixed_univars ty;
-  Btype.unmark_type ty
 
 let transl_simple_type env ?univars ~closed styp =
   TyVarEnv.reset_locals ?univars ();


### PR DESCRIPTION
The type-marking mechanism provided in `Btype` has been using negative levels for the marks,
rendering invariants and reasoning on levels tricky.

This PR modifies the mechanism to use `TypeHash` instead of negative levels to remove that obfuscation.
An additional gain is the removal of `unmark_*` functions.
