### PR TITLE
Use scope field rather than level for marking

### DIFF
--- a/Changes
+++ b/Changes
@@ -551,6 +551,9 @@ Working version
 - #12764: Move all installable headers in `caml/` sub-directories.
   (Antonin Décimo, review by Gabriel Scherer and David Allsopp)
 
+- #12853: Use scope field rather than level for marking
+  (Jacques Garrigue with Takafumi Saikawa, ...)
+
 ### Build system:
 
 - #12198, #12321, #12586, #12616, #12706: continue the merge of the

--- a/typing/btype.ml
+++ b/typing/btype.ml
@@ -712,17 +712,17 @@ let instance_variable_type label sign =
   | exception Not_found -> assert false
 
                   (**********************************)
-                  (*  Utilities for level-marking   *)
+                  (*  Utilities for scope-marking   *)
                   (**********************************)
 
-let not_marked_node ty = get_level ty >= lowest_level
+let not_marked_node ty = get_scope ty >= lowest_level
     (* type nodes with negative levels are "marked" *)
 
 let flip_mark_node ty =
   let ty = Transient_expr.repr ty in
-  Transient_expr.set_level ty (pivot_level - ty.level)
+  Transient_expr.set_scope ty (pivot_level - ty.scope)
 let logged_mark_node ty =
-  set_level ty (pivot_level - get_level ty)
+  set_scope ty (pivot_level - get_scope ty)
 
 let try_mark_node ty = not_marked_node ty && (flip_mark_node ty; true)
 let try_logged_mark_node ty = not_marked_node ty && (logged_mark_node ty; true)
@@ -745,7 +745,7 @@ let type_iterators =
 
 (* Remove marks from a type. *)
 let rec unmark_type ty =
-  if get_level ty < lowest_level then begin
+  if get_scope ty < lowest_level then begin
     (* flip back the marked level *)
     flip_mark_node ty;
     iter_type_expr unmark_type ty

--- a/typing/btype.mli
+++ b/typing/btype.mli
@@ -185,7 +185,7 @@ module For_copy : sig
 end
 
 val lowest_level: int
-        (* Marked type: ty.level < lowest_level *)
+        (* Marked type: get_scope ty < lowest_level *)
 
 val not_marked_node: type_expr -> bool
         (* Return true if a type node is not yet marked *)


### PR DESCRIPTION
In #12852 we attempted to move marks out of `type_expr`, but the incurred cost seems large (close to 10% slowdown).
This PR uses the `scope` field rather than the `level` field for marking.
This seems a good idea, as `scope` is much less used, so we can expect less bad interactions with other features.