### PR TITLE
Fix CSE across atomic loads again

### DIFF
--- a/Changes
+++ b/Changes
@@ -225,6 +225,10 @@ Working version
 - #1809, #12181: rewrite `compare x y op 0` to `x op y` when values are integers
   (Xavier Clerc, Stefan Muenzel, review by Gabriel Scherer and Vincent Laviron)
 
+- #12825: disable common subexpression elimination for atomic loads... again.
+  (Gabriel Scherer, review by KC Sivaramakrishnan, Xavier Leroy
+   and Vincent Laviron, report by Vesa Karvonen)
+
 ### Standard library:
 
 - #12716: Add `Format.pp_print_nothing` function.


### PR DESCRIPTION
Fixes #12825 by handling atomic loads as stores.

(Intuition: atomic loads update the view/frontier of the current thread, so some previous loads of non-atomic locations are not valid anymore.)