### PR TITLE
Fix use of no-flambda in two tests

### DIFF
--- a/testsuite/tests/backtrace/callstack.ml
+++ b/testsuite/tests/backtrace/callstack.ml
@@ -34,8 +34,8 @@ let () = Thread.join (Thread.create f3 ())
  flags = "-g";
  include systhreads;
  hassysthreads;
- no-flambda;
  {
+   no-flambda;
    native;
  }{
    bytecode;

--- a/testsuite/tests/lib-dynlink-initializers/test10_main.ml
+++ b/testsuite/tests/lib-dynlink-initializers/test10_main.ml
@@ -61,7 +61,6 @@ let () =
  readonly_files = "test10_plugin.ml";
  flags += "-g";
  libraries = "";
- no-flambda;
  shared-libraries;
  {
    setup-ocamlc.byte-build-env;
@@ -81,6 +80,7 @@ let () =
      check-program-output;
    }
  }{
+   no-flambda;
    native-dynlink;
    setup-ocamlopt.byte-build-env;
    {


### PR DESCRIPTION
Apparently I'm pushing my PR count for the year up as quickly as possible in the last weeks...

I actually got bitten (well, gently pecked) by testsuite/tests/lib-dynlink-initializers/test10_main.ml being completely disabled in flambda mode.