### PR TITLE
Make Gc.compact do a complete compaction, add Gc.quick_compact

### DIFF
--- a/Changes
+++ b/Changes
@@ -7,6 +7,10 @@ _______________
 
 ### Runtime system:
 
+- #12859: Ensure Gc.compact does a full major before the compactor runs
+  (Sadiq Jaffer, review by Leo White, Mark Shinwell, Gabriel Scherer,
+   Josh Berdine, David Allsopp and KC Sivaramakrishnan)
+
 ### Code generation and optimizations:
 
 ### Standard library:

--- a/runtime/gc_ctrl.c
+++ b/runtime/gc_ctrl.c
@@ -265,7 +265,6 @@ static value gc_full_major_exn(void)
   /* In general, it can require up to 3 GC cycles for a
      currently-unreachable object to be collected. */
   for (i = 0; i < 3; i++) {
-    caml_empty_minor_heaps_once();
     caml_finish_major_cycle(0);
     exn = caml_process_pending_actions_exn();
     if (Is_exception_result(exn)) break;
@@ -297,7 +296,16 @@ CAMLprim value caml_gc_compaction(value v)
   Caml_check_caml_state();
   CAML_EV_BEGIN(EV_EXPLICIT_GC_COMPACT);
   CAMLassert (v == Val_unit);
-  value exn = gc_major_exn(1);
+  value exn = Val_unit;
+  int i;
+  /* We do a full major before this compaction.
+     See [caml_full_major_exn] for this needs
+     three iterations. */
+  for (i = 0; i < 3; i++) {
+    caml_finish_major_cycle(i == 2);
+    exn = caml_process_pending_actions_exn();
+    if (Is_exception_result(exn)) break;
+  }
   ++ Caml_state->stat_forced_major_collections;
   CAML_EV_END(EV_EXPLICIT_GC_COMPACT);
   return caml_raise_if_exception(exn);

--- a/runtime/gc_ctrl.c
+++ b/runtime/gc_ctrl.c
@@ -298,9 +298,8 @@ CAMLprim value caml_gc_compaction(value v)
   CAMLassert (v == Val_unit);
   value exn = Val_unit;
   int i;
-  /* We do a full major before this compaction.
-     See [caml_full_major_exn] for this needs
-     three iterations. */
+  /* We do a full major before this compaction. See [caml_full_major_exn] for
+     why this needs three iterations. */
   for (i = 0; i < 3; i++) {
     caml_finish_major_cycle(i == 2);
     exn = caml_process_pending_actions_exn();

--- a/testsuite/tests/compaction/test_compact_full.ml
+++ b/testsuite/tests/compaction/test_compact_full.ml
@@ -1,0 +1,12 @@
+(* TEST
+*)
+let () =
+  Gc.full_major (); (* do a major before compaction so there isn't any pending major
+                  cycles when we do compaction. *)
+  let heap_stats_before = Gc.quick_stat () in
+  Gc.compact ();
+  let heap_stats_after = Gc.quick_stat () in
+  (* assert that we have done an additional three major collections *)
+  assert (heap_stats_after.major_collections == heap_stats_before.major_collections+3);
+  (* also a compaction! *)
+  assert (heap_stats_after.compactions == heap_stats_before.compactions+1)

--- a/testsuite/tests/lib-runtime-events/test.reference
+++ b/testsuite/tests/lib-runtime-events/test.reference
@@ -1,2 +1,2 @@
-minors: 9, majors: 0
 minors: 18, majors: 0
+minors: 36, majors: 0

--- a/testsuite/tests/lib-runtime-events/test_caml.reference
+++ b/testsuite/tests/lib-runtime-events/test_caml.reference
@@ -1,1 +1,1 @@
-minors: 9000, major cycles: 3000
+minors: 6000, major cycles: 3000


### PR DESCRIPTION
Marked as draft because we may not want to merge. If there's consensus I'll add a few tests to the PR.

This PR makes `Gc.compact` do a full major cycle before compacting and adds a `Gc.quick_compact` which only does a single one.

The former ensures that everything unreachable before `Gc.compact` is called will be swept and it's space potentially used to relocate blocks during compaction. In the latter, this is not the case, unreachable blocks before `Gc.quick_compact` won't be swept before compaction. This obviously results in a bigger heap afterwards. The trade-off is that there's a two thirds reduction in the number of heap traversals required. While it varies substantially by heap composition, I have very sparse heap benchmarks where `Gc.quick_compact` takes only a third of the time that `Gc.compact` does.

With this change `Gc.compact` should work similarly to `Gc.compact` from 4.x (and matches the current doc on Gc.mli!) - not doing so has already caught out some early users.

If we are going to do this, we should make sure this is part of 5.2 .  (@Octachron )

probably of interest to @mshinwell @kayceesrk @damiendoligez