### PR TITLE
ocamldoc: replace newlines with spaces in source code style blocks

### DIFF
--- a/Changes
+++ b/Changes
@@ -404,6 +404,9 @@ OCaml 5.2.0
 
 ### Manual and documentation:
 
+- #12865: ocamldoc: replace newlines with spaces in source code style blocks.
+  (William Hu, report by Antonin Décimo, review by ?)
+
 - #12338: clarification of the documentation of process related function in
   the unix module regarding the first element of args and shell's pid.
   (Christophe Raffalli, review by Florian Angeletti)

--- a/manual/src/cmds/ocamldoc.etex
+++ b/manual/src/cmds/ocamldoc.etex
@@ -774,7 +774,7 @@ inline-text: {{inline-text-element}}
 @||@&@ '{ol' list '}' @ & build an enumerated list. \\
 @||@&@ '{{:' string '}' inline-text '}' @ & put a link to the given address
 (given as @string@) on the given @text@. \\
-@||@&@ '[' string ']' @ & set the given @string@ in source code style. \\
+@||@&@ '[' string ']' @ & set the given @string@ in source code style. Newlines (and whitespace following a newline) are collapsed into a single space. \\
 @||@&@ '{[' string ']}' @ & set the given @string@ in preformatted
 				source code style.\\
 @||@&@ '{v' string 'v}' @ & set the given @string@ in verbatim style. \\

--- a/ocamldoc/odoc_html.ml
+++ b/ocamldoc/odoc_html.ml
@@ -353,14 +353,21 @@ class virtual text =
     method html_of_Raw b s = bs b (self#escape s)
 
     method html_of_Code b s =
+      (* convert any whitespace starting with a newline to single space
+         (i.e., long sequences of newlines become a single space)
+       *)
+      let strip_s = Str.global_replace (Str.regexp "\n[ \n\t\r]*") " " s in
       if !colorize_code then
-        self#html_of_code b ~with_pre: false s
+        (* with_pre = true assumes that style.css sets white-space : pre
+           for <code> elements
+         *)
+        self#html_of_code b ~with_pre: true strip_s
       else
         (
          bs b "<code class=\"";
          bs b Odoc_ocamlhtml.code_class ;
          bs b "\">";
-         bs b (self#escape s);
+         bs b (self#escape strip_s);
          bs b "</code>"
         )
 
@@ -925,6 +932,7 @@ class html =
 
         "a {color: #416DFF; text-decoration: none}";
         "a:hover {background-color: #ddd; text-decoration: underline}";
+        "code { white-space : pre }";
         "pre { margin-bottom: 4px; font-family: monospace; }" ;
         "pre.verbatim, pre.codepre { }";
 


### PR DESCRIPTION
Tried to find a solution that would fix the issues while breaking the fewest things. Following ideas outlined in #12259, here are two fixes:

1. (fix random newlines in square-bracket code): in `html_of_code`, replace all newlines (and subsequent whitespace) with a space inside inline code blocks. The intent is to fix rendering of documentation code blocks that straddle lines (for example, see the documentation for `map` in `Set.S` or the `Scanf` examples in #12259) without requiring reviewing documentation to fix these newlines in code blocks.

CodePre blocks seem to be a reasonable alternative for situations where code is supposed to be split along multiple lines. I updated the manual to mention this new quirk, but let me know if this is too big of a change.

(If this is reasonable, should I change the code for other doc formats besides HTML?)

2. (fix differing behavior when `-colorize-code` is activated): make `html_of_code` assume that source code blocks are rendered in `pre` whitespace style in the CSS. Currently ocamldoc translates docstrings that have spaces such as `[hello     world]` as `<code>hello     world</code>`, which, given a browser-default style sheet, renders as `hello world` (the space gets collapsed). But I am not a CSS expert so I would not be surprised if there are more elegant ways to do this.