### PR TITLE
Add `pthread_cond_timedwait` to Condition and Semaphore

### DIFF
--- a/Changes
+++ b/Changes
@@ -15,6 +15,9 @@ _______________
   (Kate Deplaix and Oscar Butler-Aldridge review by Nicolás Ojeda Bär,
    Craig Ferguson and Gabriel Scherer)
 
+- #12867: Add Condition.timed_wait, Semaphore.Counting.timed_acquire and Semaphore.Binary.timed_acquire
+  (Simon Grondin, review by ...)
+
 ### Other libraries:
 
 ### Tools:

--- a/runtime/sync_posix.h
+++ b/runtime/sync_posix.h
@@ -122,6 +122,12 @@ Caml_inline int sync_condvar_wait(sync_condvar c, sync_mutex m)
   return pthread_cond_wait(c, m);
 }
 
+Caml_inline int sync_condvar_timedwait(sync_condvar c, sync_mutex m,
+                                       const struct timespec * ts)
+{
+  return pthread_cond_timedwait(c, m, ts);
+}
+
 /* Reporting errors */
 
 static void sync_check_error(int retcode, char * msg)

--- a/stdlib/condition.ml
+++ b/stdlib/condition.ml
@@ -16,5 +16,7 @@
 type t
 external create: unit -> t = "caml_ml_condition_new"
 external wait: t -> Mutex.t -> unit = "caml_ml_condition_wait"
+external timed_wait: t -> Mutex.t -> float -> bool
+                   = "caml_ml_condition_timedwait"
 external signal: t -> unit = "caml_ml_condition_signal"
 external broadcast: t -> unit = "caml_ml_condition_broadcast"

--- a/stdlib/condition.mli
+++ b/stdlib/condition.mli
@@ -160,6 +160,16 @@ val wait : t -> Mutex.t -> unit
    variable [c] holds when [wait] returns; one must explicitly test
    whether {i P} holds after calling [wait]. *)
 
+val timed_wait : t -> Mutex.t -> float -> bool
+(**[timed_wait c m t] is the same as {!wait}, but only waits up to
+    [t] seconds.
+    If a timeout occured, it returns [false].
+    If woken up for any other reason be it success or a "spurious wakeup",
+    it returns [true].
+
+    @since 5.3
+*)
+
 val signal : t -> unit
 (**[signal c] wakes up one of the threads waiting on the condition
    variable [c], if there is one. If there is none, this call has

--- a/stdlib/semaphore.mli
+++ b/stdlib/semaphore.mli
@@ -68,6 +68,17 @@ val acquire : t -> unit
     is not zero, then atomically decrements the value of [s] and returns.
 *)
 
+val timed_acquire : t -> float -> bool
+(** [timed_acquire s t] is the same as {!acquire}, but only waits up to
+    [t] seconds.
+    If semaphore [s] becomes non-zero within the allowed duration, it
+    atomically decrements the value of [s] and returns [true].
+    If semaphore [s] times out, the semaphore's value remains 0 and it
+    returns [false].
+
+    @since 5.3
+*)
+
 val try_acquire : t -> bool
 (** [try_acquire s] immediately returns [false] if the value of semaphore [s]
     is zero.  Otherwise, the value of [s] is atomically decremented
@@ -129,6 +140,17 @@ val acquire : t -> unit
 (** [acquire s] blocks the calling thread until the semaphore [s]
     has value 1 (is available), then atomically sets it to 0
     and returns.
+*)
+
+val timed_acquire : t -> float -> bool
+(** [timed_acquire s t] is the same as {!acquire}, but only waits up to
+    [t] seconds.
+    If the value of semaphore [s] becomes 1 within the allowed duration, it
+    atomically sets it to 0 and returns [true].
+    If semaphore [s] times out, the semaphore's value remains 0 and it
+    returns [false].
+
+    @since 5.3
 *)
 
 val try_acquire : t -> bool

--- a/testsuite/tests/lib-threads/timed_wait.ml
+++ b/testsuite/tests/lib-threads/timed_wait.ml
@@ -1,0 +1,67 @@
+(* TEST
+ include systhreads;
+ hassysthreads;
+ {
+   native;
+ }{
+   bytecode;
+ }
+*)
+
+module type S = sig
+  type t
+  val take : t -> unit
+  val put : t -> int -> unit
+end
+
+module Make (M : sig
+  type t
+  type u
+  val make : u -> t
+  val timed_acquire : t -> float -> bool
+  val release : t -> unit
+end) = struct
+  type t = {
+    sem: M.t;
+    mutable cell: int;
+  }
+
+  let take { sem; cell } =
+    if M.timed_acquire sem 0.1
+    then Format.printf "Read %d@." cell
+    else Format.printf "Timed out@."
+
+  let put t x =
+    t.cell <- x;
+    M.release t.sem
+
+  let create init = { sem = M.make init; cell = 0 }
+end
+
+let run (type t) t m x =
+  let module M = (val m : S with type t = t) in
+  M.put t x;
+  let d = Thread.create (fun _ ->
+    M.take t;
+    M.take t
+  ) ()
+  in
+  Thread.join d
+
+let _ =
+  let module M = Make (struct
+    include Semaphore.Binary
+    type u = bool
+  end) in
+  let t = M.create false in
+  run t (module M) 111;
+  print_endline "Done Semaphore.Binary"
+
+let _ =
+  let module M = Make (struct
+    include Semaphore.Counting
+    type u = int
+  end) in
+  let t = M.create 0 in
+  run t (module M) 222;
+  print_endline "Done Semaphore.Counting"

--- a/testsuite/tests/lib-threads/timed_wait.reference
+++ b/testsuite/tests/lib-threads/timed_wait.reference
@@ -1,0 +1,6 @@
+Read 111
+Timed out
+Done Semaphore.Binary
+Read 222
+Timed out
+Done Semaphore.Counting


### PR DESCRIPTION
### Changes

This PR adds
- `Condition.timed_wait : t -> Mutex.t -> float -> bool`
- `Semaphore.Counting.timed_acquire : t -> float -> bool`
- `Semaphore.Binary.timed_acquire : t -> float -> bool`

### Justification

@xavierleroy in [#4104](https://github.com/ocaml/ocaml/issues/4104#issuecomment-473674943):
> The main reason against Condition.timedwait was that it was difficult to implement in the VM threads library. Since the VM threads library is now gone, we can reconsider the addition of Condition.timedwait. If anyone cares enough to submit a pull request...

The issue was closed due to inactivity.

This feature will come in handy for the development of a low level pool of systhreads in the Eio library.

### Technical details

I tried to follow the C style as much as possible, but I wouldn't be surprised if I missed something, please tear it apart if necessary!

- I'm unsure about the C casting guidelines, I've seen multiple different styles in the codebase.
- I'm also unsure about `defined(HAS_POSIX_MONOTONIC_CLOCK)` versus `defined(_POSIX_TIMERS) && defined(_POSIX_MONOTONIC_CLOCK) && _POSIX_MONOTONIC_CLOCK != (-1)`
- In [platform.c](https://github.com/ocaml/ocaml/blob/b72d99b3dbf3a593f9ff38acc4a375a2e2fd8749/runtime/platform.c#L99), the `pthread_cond` clock is set to a monotonic clock if such a clock is available. Therefore this PR uses `clock_gettime(CLOCK_MONOTONIC)` time when it's available.
- In [osdeps.h](https://github.com/ocaml/ocaml/blob/b72d99b3dbf3a593f9ff38acc4a375a2e2fd8749/runtime/caml/osdeps.h#L154), the function `uint64_t caml_time_counter(void)` is defined, it is then implemented twice: once in [unix.c](https://github.com/ocaml/ocaml/blob/b72d99b3dbf3a593f9ff38acc4a375a2e2fd8749/runtime/unix.c#L430) and once in [win32.c](https://github.com/ocaml/ocaml/blob/b72d99b3dbf3a593f9ff38acc4a375a2e2fd8749/runtime/win32.c#L1129). However `caml_time_counter()` cannot be used for this PR because it does not always return a value related to a wall clock.
  - Therefore this PR implements the required behavior directly in `sync.c`.
  - Should I instead take that logic and package it as a new function `caml_get_timestamp` and place it alongside `caml_time_counter` in `unix.c` and `win32.c`?
  - The [configure script](https://github.com/ocaml/ocaml/blob/b72d99b3dbf3a593f9ff38acc4a375a2e2fd8749/configure#L16472-L16473) sets `has_monotonic_clock=true` for Windows. I believe this is in relation to `caml_time_counter`, but please let me know if I should be calling a different (monotonic) clock on Windows instead of `GetSystemTimeAsFileTime`.
- Should I move `CAML_NT_EPOCH_100ns_TICKS` from [otherlibs/unix/caml/unixsupport.h](https://github.com/ocaml/ocaml/blob/b72d99b3dbf3a593f9ff38acc4a375a2e2fd8749/otherlibs/unix/caml/unixsupport.h#L91-L94) to somewhere else (where?) to avoid redefining it in this PR?

This is my first contribution to the repo, I tried to make this PR as complete and idiomatic as possible to not waste the maintainers' time. I will apply all suggestions and make all necessary changes.

Thank you for your time