### PR TITLE
Stdlib: Add take, drop, take_while and drop_while to the List module

### DIFF
--- a/Changes
+++ b/Changes
@@ -11,6 +11,10 @@ _______________
 
 ### Standard library:
 
+- #12869: Add List.take, List.drop, List.take_while and List.drop_while
+  (Kate Deplaix, review by Nicolás Ojeda Bär, Craig Ferguson,
+   Gabriel Scherer and Oscar Butler-Aldridge)
+
 ### Other libraries:
 
 ### Tools:

--- a/Changes
+++ b/Changes
@@ -12,8 +12,8 @@ _______________
 ### Standard library:
 
 - #12869: Add List.take, List.drop, List.take_while and List.drop_while
-  (Kate Deplaix, review by Nicolás Ojeda Bär, Craig Ferguson,
-   Gabriel Scherer and Oscar Butler-Aldridge)
+  (Kate Deplaix and Oscar Butler-Aldridge review by Nicolás Ojeda Bär,
+   Craig Ferguson and Gabriel Scherer)
 
 ### Other libraries:
 

--- a/stdlib/list.ml
+++ b/stdlib/list.ml
@@ -289,6 +289,33 @@ and[@tail_mod_cons] prepend_concat_map ys f xs =
   | [] -> concat_map f xs
   | y :: ys -> y :: prepend_concat_map ys f xs
 
+let take n l =
+  let rec aux i acc = function
+    | x::l when i < n -> aux (i + 1) (x::acc) l
+    | _rest -> rev acc
+  in
+  if n < 0 then invalid_arg "List.take";
+  aux 0 [] l
+
+let drop n l =
+  let rec aux i = function
+    | _x::l when i < n -> aux (i + 1) l
+    | rest -> rest
+  in
+  if n < 0 then invalid_arg "List.drop";
+  aux 0 l
+
+let take_while p l =
+  let rec aux acc = function
+    | x::l when p x -> aux (x::acc) l
+    | _rest -> rev acc
+  in
+  aux [] l
+
+let rec drop_while p = function
+  | x::l when p x -> drop_while p l
+  | rest -> rest
+
 let fold_left_map f accu l =
   let rec aux accu l_accu = function
     | [] -> accu, rev l_accu

--- a/stdlib/list.ml
+++ b/stdlib/list.ml
@@ -307,11 +307,11 @@ let drop n l =
   aux 0 l
 
 let take_while p l =
-  let rec aux acc = function
-    | x::l when p x -> aux (x::acc) l
-    | _rest -> rev acc
+  let[@tail_mod_cons] rec aux = function
+    | x::l when p x -> x::aux l
+    | _rest -> []
   in
-  aux [] l
+  aux l
 
 let rec drop_while p = function
   | x::l when p x -> drop_while p l

--- a/stdlib/list.ml
+++ b/stdlib/list.ml
@@ -290,12 +290,13 @@ and[@tail_mod_cons] prepend_concat_map ys f xs =
   | y :: ys -> y :: prepend_concat_map ys f xs
 
 let take n l =
-  let rec aux i acc = function
-    | x::l when i < n -> aux (i + 1) (x::acc) l
-    | _rest -> rev acc
+  let[@tail_mod_cons] rec aux n l =
+    match n, l with
+    | 0, _ | _, [] -> []
+    | n, x::l -> x::aux (n - 1) l
   in
   if n < 0 then invalid_arg "List.take";
-  aux 0 [] l
+  aux n l
 
 let drop n l =
   let rec aux i = function

--- a/stdlib/list.mli
+++ b/stdlib/list.mli
@@ -359,6 +359,44 @@ val filteri : (int -> 'a -> bool) -> 'a list -> 'a list
    @since 4.11
 *)
 
+
+(** {1 List manipulation} *)
+
+
+val take : int -> 'a list -> 'a list
+(** [take n l] returns the prefix of [l] of length [n],
+    or a copy of [l] if [n > length l].
+
+    [n] must be nonnegative.
+
+    @raise Invalid_argument if [n] is negative.
+    @since 5.3
+*)
+
+val drop : int -> 'a list -> 'a list
+(** [drop n l] returns the suffix of [l] after [n] elements,
+    or [[]] if [n > length l].
+
+    [n] must be nonnegative.
+
+    @raise Invalid_argument if [n] is negative.
+    @since 5.3
+*)
+
+val take_while : ('a -> bool) -> 'a list -> 'a list
+(** [take_while p l] is the longest (possibly empty) prefix of [l]
+    containing only elements that satisfy [p].
+
+    @since 5.3
+*)
+
+val drop_while : ('a -> bool) -> 'a list -> 'a list
+(** [drop_while p l] is the longest (possibly empty) suffix of [l]
+    starting at the first element that does not satisfy [p].
+
+    @since 5.3
+*)
+
 val partition : ('a -> bool) -> 'a list -> 'a list * 'a list
 (** [partition f l] returns a pair of lists [(l1, l2)], where
    [l1] is the list of all the elements of [l] that

--- a/stdlib/listLabels.mli
+++ b/stdlib/listLabels.mli
@@ -359,6 +359,44 @@ val filteri : f:(int -> 'a -> bool) -> 'a list -> 'a list
    @since 4.11
 *)
 
+
+(** {1 List manipulation} *)
+
+
+val take : int -> 'a list -> 'a list
+(** [take n l] returns the prefix of [l] of length [n],
+    or a copy of [l] if [n > length l].
+
+    [n] must be nonnegative.
+
+    @raise Invalid_argument if [n] is negative.
+    @since 5.3
+*)
+
+val drop : int -> 'a list -> 'a list
+(** [drop n l] returns the suffix of [l] after [n] elements,
+    or [[]] if [n > length l].
+
+    [n] must be nonnegative.
+
+    @raise Invalid_argument if [n] is negative.
+    @since 5.3
+*)
+
+val take_while : f:('a -> bool) -> 'a list -> 'a list
+(** [take_while p l] is the longest (possibly empty) prefix of [l]
+    containing only elements that satisfy [p].
+
+    @since 5.3
+*)
+
+val drop_while : f:('a -> bool) -> 'a list -> 'a list
+(** [drop_while p l] is the longest (possibly empty) suffix of [l]
+    starting at the first element that does not satisfy [p].
+
+    @since 5.3
+*)
+
 val partition : f:('a -> bool) -> 'a list -> 'a list * 'a list
 (** [partition ~f l] returns a pair of lists [(l1, l2)], where
    [l1] is the list of all the elements of [l] that

--- a/testsuite/tests/lib-list/test.ml
+++ b/testsuite/tests/lib-list/test.ml
@@ -61,6 +61,29 @@ let () =
 
   assert (List.filteri (fun i _ -> i < 2) (List.rev l) = [9; 8]);
 
+  let hello = ['H';'e';'l';'l';'o'] in
+  let world = ['W';'o';'r';'l';'d';'!'] in
+  let hello_world = hello @ [' '] @ world in
+  assert (List.take 5 hello_world = hello);
+  assert (List.take 3 [1; 2; 3; 4; 5] = [1; 2; 3]);
+  assert (List.take 3 [1; 2] = [1; 2]);
+  assert (List.take 3 [] = []);
+  assert ((try List.take (-1) [1; 2] with Invalid_argument _ -> [999]) = [999]);
+  assert (List.take 0 [1; 2] = []);
+  assert (List.drop 6 hello_world = world);
+  assert (List.drop 3 [1; 2; 3; 4; 5] = [4; 5]);
+  assert (List.drop 3 [1; 2] = []);
+  assert (List.drop 3 [] = []);
+  assert ((try List.drop (-1) [1; 2] with Invalid_argument _ -> [999]) = [999]);
+  assert (List.drop 0 [1; 2] = [1; 2]);
+  assert (List.take_while (fun x -> x < 3) [1; 2; 3; 4; 1; 2; 3; 4]
+          = [1; 2]);
+  assert (List.take_while (fun x -> x < 9) [1; 2; 3] = [1; 2; 3]);
+  assert (List.take_while (fun x -> x < 0) [1; 2; 3] = []);
+  assert (List.drop_while (fun x -> x < 3) [1; 2; 3; 4; 5; 1; 2; 3]
+          = [3; 4; 5; 1; 2; 3]);
+  assert (List.drop_while (fun x -> x < 9) [1; 2; 3] = []);
+  assert (List.drop_while (fun x -> x < 0) [1; 2; 3] = [1; 2; 3]);
   assert (List.partition is_even [1; 2; 3; 4; 5]
           = ([2; 4], [1; 3; 5]));
   assert (List.partition_map string_of_even_or_int [1; 2; 3; 4; 5]


### PR DESCRIPTION
https://github.com/ocaml/ocaml/pull/9968 but without the controversial `split_at`.

I've also updated the behaviour of `take` and `drop` to match the behaviour of `Seq.take` and `Seq.drop`, as well as taken into account the reviews from @nojb and @craigfe (https://github.com/ocaml/ocaml/pull/9968#pullrequestreview-506146952)

cc @0scarB @gasche