### PR TITLE
Reorder call to caml_reset_young_limit and tighten assertion

### DIFF
--- a/runtime/caml/config.h
+++ b/runtime/caml/config.h
@@ -223,8 +223,14 @@ typedef uint64_t uintnat;
 
 
 /* Minimum size of the minor zone (words).
-   This must be at least [Max_young_wosize + 1]. */
-#define Minor_heap_min (Max_young_wosize + 1)
+   This must be at least [Max_young_wosize + 1], however a higher value is
+   set to simplify reasoning about allocations in the minor heap: in
+   particular, a single allocation cannot now start in the first half of the
+   heap and exactly fill the whole heap.  Consequentially, the assertion in
+   caml_reset_young_limit can be strictly less than, which has been shown
+   to catch bugs.
+   */
+#define Minor_heap_min (Max_young_wosize * 2)
 
 /* Default size of the minor zone. (words)  */
 #define Minor_heap_def 262144

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -1649,7 +1649,7 @@ void caml_reset_young_limit(caml_domain_state * dom_st)
           dom_st->young_trigger : dom_st->memprof_young_trigger;
   CAMLassert ((uintnat)dom_st->young_ptr >=
               (uintnat)dom_st->memprof_young_trigger);
-  CAMLassert ((uintnat)dom_st->young_ptr >=
+  CAMLassert ((uintnat)dom_st->young_ptr >
               (uintnat)dom_st->young_trigger);
   /* An interrupt might have been queued in the meanwhile; this
      achieves the proper synchronisation. */
@@ -1760,10 +1760,12 @@ void caml_poll_gc_work(void)
        caml_poll_gc_work is called. */
   }
 
+  caml_reset_young_limit(d);
+
   if (atomic_load_acquire(&d->requested_external_interrupt)) {
+    /* This function might allocate (e.g. upon a systhreads yield). */
     caml_domain_external_interrupt_hook();
   }
-  caml_reset_young_limit(d);
 }
 
 void caml_handle_gc_interrupt(void)


### PR DESCRIPTION
Here is a nice straightforward one for the New Year!

In [this PR on the Flambda 2 repo](https://github.com/ocaml-flambda/flambda-backend/pull/2204), which is 5.1.1 plus a few backports, I describe a bug where this assertion fails:
```
void caml_reset_young_limit(caml_domain_state * dom_st)
{
  CAMLassert ((uintnat)dom_st->young_ptr > (uintnat)dom_st->young_trigger);
```
Note that this branch does _not_ contain #12742  which changed this assertion to be `>=`.  Neither does it contain #12824  which made the same change after #12382 inadvertently reverted it to `>`.

I believe the bug happens because `caml_domain_external_interrupt_hook`, which can allocate e.g. if `systhreads` is used, is called before `caml_reset_young_limit`.  Please see the first link above for more details.  This PR aims to fix the bug on `trunk` in the same way.

Now, from what I understand from @jmid , #12742 was introduced to fix the above assertion failure which had also been seen (suspiciously!) only when running `systhreads` tests.  Unfortunately I suspect this was the wrong diagnosis and it was actually the problem with the hook being seen.  (The equalities between the various GC pointers aren't the same as in my first PR above at the point of failure, but I think it is very likely another form of the same problem.)

Let's suppose for a moment it isn't the hook at fault and examine the situation in #12742 again.  For `caml_poll_gc_work` to set `young_trigger = young_start` itself _and_ to have `young_ptr = young_trigger` at the time of the assertion, it seems like you need an allocation large enough such that it is performed when the trigger is still at the midpoint (otherwise `caml_poll_gc_work` would have forced a minor collection), but it fills the heap entirely (and exactly).  (Call this Condition 1.)  I don't believe that could happen with the parameters given on #12742: the maximum object size is 256 words + 1 header word, so that isn't capable of overflowing from the first half of the heap to exactly the very end, if there are 1024 words in the heap.

I discussed this with @jmid who reported today: "To further confirm, this morning I cloned a fresh 5.1.1, reverted #12742 and moved `caml_reset_young_limit` as in [PR flambda-backend/2204](https://github.com/ocaml-flambda/flambda-backend/pull/2204) and reran the `multicoretests` test suite without any issues (well, technically there was an instance of a very long running test but that is an existing, known issue)".

Given this, and the fact that the strict `>` in the assertion has caught an obscure bug, I would prefer to see this assertion reverted to `>` on `trunk`.  That is assuming my reasoning is correct, of course, which it may well not be.

One problem remains: what happens if the minor heap is so small that an allocation can produce Condition 1 above?  I think this might mean that the assertion can be reached correctly with the equality holding.  What I've done in this PR is to simply disallow this situation by increasing the minimum size of the minor heap.  It is still very small (512 words) which seems fine, even for test cases that deliberately reduce the heap size -- but to my mind, it makes this extraordinarily subtle code rather easier to reason about.