### PR TITLE
Dynarray.rev_iter, rev_iteri

### DIFF
--- a/Changes
+++ b/Changes
@@ -53,6 +53,9 @@ Working version
   (Gabriel Scherer, review by Kate Deplaix, Nicolás Ojeda Bär, Richard Eisenberg
   and Jeremy Yallop)
 
+- #12877: Dynarray.rev_iter, Dynarray.rev_iteri
+  (Gabriel Scherer, review by Léo Andrès, Jeremy Yallop and Nicolás Ojeda Bär)
+
 ### Type system:
 
 - #13781: Set scope of internal type nodes during abbreviation expansion

--- a/stdlib/dynarray.ml
+++ b/stdlib/dynarray.ml
@@ -915,6 +915,22 @@ let iteri f a =
   done;
   check_same_length "iteri" a ~length
 
+let rev_iter f a =
+  let Pack {arr; length; dummy} = a in
+  check_valid_length length arr;
+  for i = length - 1 downto 0 do
+    f (unsafe_get arr ~dummy ~i ~length);
+  done;
+  check_same_length "rev_iter" a ~length
+
+let rev_iteri f a =
+  let Pack {arr; length; dummy} = a in
+  check_valid_length length arr;
+  for i = length - 1 downto 0 do
+    f i (unsafe_get arr ~dummy ~i ~length);
+  done;
+  check_same_length "rev_iteri" a ~length
+
 let map f a =
   let Pack {arr = arr_in; length; dummy} = a in
   check_valid_length length arr_in;

--- a/stdlib/dynarray.ml
+++ b/stdlib/dynarray.ml
@@ -374,30 +374,30 @@ let global_dummy = Dummy.fresh ()
    parameter helps us to avoid this assumption. *)
 
 module Error = struct
-  let[@inline never] index_out_of_bounds f ~i ~length =
+  let[@inline never] index_out_of_bounds fname ~i ~length =
     if length = 0 then
       Printf.ksprintf invalid_arg
         "Dynarray.%s: index %d out of bounds (empty dynarray)"
-        f i
+        fname i
     else
       Printf.ksprintf invalid_arg
         "Dynarray.%s: index %d out of bounds (0..%d)"
-        f i (length - 1)
+        fname i (length - 1)
 
-  let[@inline never] negative_length_requested f n =
+  let[@inline never] negative_length_requested fname n =
     Printf.ksprintf invalid_arg
       "Dynarray.%s: negative length %d requested"
-      f n
+      fname n
 
-  let[@inline never] negative_capacity_requested f n =
+  let[@inline never] negative_capacity_requested fname n =
     Printf.ksprintf invalid_arg
       "Dynarray.%s: negative capacity %d requested"
-      f n
+      fname n
 
-  let[@inline never] requested_length_out_of_bounds f requested_length =
+  let[@inline never] requested_length_out_of_bounds fname requested_length =
     Printf.ksprintf invalid_arg
       "Dynarray.%s: cannot grow to requested length %d (max_array_length is %d)"
-      f requested_length Sys.max_array_length
+      fname requested_length Sys.max_array_length
 
   (* When observing an invalid state ([missing_element],
      [invalid_length]), we do not give the name of the calling function
@@ -420,23 +420,23 @@ module Error = struct
       invalid_state_description
       length capacity
 
-  let[@inline never] length_change_during_iteration f ~expected ~observed =
+  let[@inline never] length_change_during_iteration fname ~expected ~observed =
     Printf.ksprintf invalid_arg
       "Dynarray.%s: a length change from %d to %d occurred during iteration"
-      f expected observed
+      fname expected observed
 
   (* When an [Empty] element is observed unexpectedly at index [i],
      it may be either an out-of-bounds access or an invalid-state situation
      depending on whether [i <= length]. *)
-  let[@inline never] unexpected_empty_element f ~i ~length =
+  let[@inline never] unexpected_empty_element fname ~i ~length =
     if i < length then
       missing_element ~i ~length
     else
-      index_out_of_bounds f ~i ~length
+      index_out_of_bounds fname ~i ~length
 
-  let[@inline never] empty_dynarray f =
+  let[@inline never] empty_dynarray fname =
     Printf.ksprintf invalid_arg
-      "Dynarray.%s: empty array" f
+      "Dynarray.%s: empty array" fname
 
   let[@inline never] different_lengths f ~length1 ~length2 =
     Printf.ksprintf invalid_arg
@@ -448,10 +448,10 @@ end
 
    See {!iter} below for a detailed usage example.
 *)
-let check_same_length f (Pack a) ~length =
+let check_same_length fname (Pack a) ~length =
   let length_a = a.length in
   if length <> length_a then
-    Error.length_change_during_iteration f
+    Error.length_change_during_iteration fname
       ~expected:length ~observed:length_a
 
 (** Careful unsafe access. *)
@@ -873,7 +873,7 @@ let append a b =
    each other and leave the length unchanged at the next check.
 *)
 
-let iter_ f k a =
+let iter_ fname f a =
   let Pack {arr; length; dummy} = a in
   (* [check_valid_length length arr] is used for memory safety, it
      guarantees that the backing array has capacity at least [length],
@@ -900,18 +900,18 @@ let iter_ f k a =
   *)
   check_valid_length length arr;
   for i = 0 to length - 1 do
-    k (unsafe_get arr ~dummy ~i ~length);
+    f (unsafe_get arr ~dummy ~i ~length);
   done;
-  check_same_length f a ~length
+  check_same_length fname a ~length
 
-let iter k a =
-  iter_ "iter" k a
+let iter f a =
+  iter_ "iter" f a
 
-let iteri k a =
+let iteri f a =
   let Pack {arr; length; dummy} = a in
   check_valid_length length arr;
   for i = 0 to length - 1 do
-    k i (unsafe_get arr ~dummy ~i ~length);
+    f i (unsafe_get arr ~dummy ~i ~length);
   done;
   check_same_length "iteri" a ~length
 

--- a/stdlib/dynarray.mli
+++ b/stdlib/dynarray.mli
@@ -247,10 +247,26 @@ val clear : 'a t -> unit
 *)
 
 val iter : ('a -> unit) -> 'a t -> unit
-(** [iter f a] calls [f] on each element of [a]. *)
+(** [iter f a] calls [f] on each element of [a], from the element of
+    index [0] to the element of index [length a - 1]. *)
+
+val rev_iter : ('a -> unit) -> 'a t -> unit
+(** [rev_iter f a] calls [f] on each element of [a], from the element
+    of index [length a - 1] to the element of index [0].
+
+    @since 5.5
+*)
 
 val iteri : (int -> 'a -> unit) -> 'a t -> unit
-(** [iteri f a] calls [f i x] for each [x] at index [i] in [a]. *)
+(** [iteri f a] calls [f i x] for each [x] at index [i] in [a],
+    from the index [0] to the index [length a - 1]. *)
+
+val rev_iteri : (int -> 'a -> unit) -> 'a t -> unit
+(** [rev_iteri f a] calls [f i x] for each [x] at index [i] in [a],
+    from the index [length a - 1] down to the index [0].
+
+    @since 5.5
+*)
 
 val map : ('a -> 'b) -> 'a t -> 'b t
 (** [map f a] is a new array of elements of the form [f x]

--- a/testsuite/tests/lib-dynarray/test.ml
+++ b/testsuite/tests/lib-dynarray/test.ml
@@ -276,6 +276,20 @@ let () =
 
 (** {1:iteration Iteration} *)
 
+(** iter, rev_iter *)
+
+let () =
+  let a = A.of_list [1; 2; 3] in
+  let seen = ref [] in
+  A.iter (fun i -> seen := i :: !seen) a;
+  assert (!seen = [3; 2; 1])
+
+let () =
+  let a = A.of_list [1; 2; 3] in
+  let seen = ref [] in
+  A.rev_iter (fun i -> seen := i :: !seen) a;
+  assert (!seen = [1; 2; 3])
+
 (** map *)
 
 let () =


### PR DESCRIPTION
`Stack.iter` iterates from the top of the stack to the bottom of the stack. If people use Dynarrays for stack-like workflows, they may want an easy way to iterate in the same order. This is now provided by `Dynarray.rev_iter`, `Dynarray.rev_iteri`.

(I briefly wondered about `iter_rev` vs. `rev_iter`. The name `rev_iter` reads better to me, and it is consistent with the existing `List.rev_map`.)