### PR TITLE
Fix treatment of injectivity for private recursive types.

### DIFF
--- a/Changes
+++ b/Changes
@@ -53,6 +53,9 @@ _______________
 
 ### Bug fixes:
 
+- #12878: fix incorrect treatment of injectivity in module subtyping for
+  private recursive types.
+  (Jeremy Yallop, review by ???)
 
 OCaml 5.2.0
 ------------

--- a/Changes
+++ b/Changes
@@ -53,10 +53,6 @@ _______________
 
 ### Bug fixes:
 
-- #12878: fix incorrect treatment of injectivity in module subtyping for
-  private recursive types.
-  (Jeremy Yallop, review by ???)
-
 OCaml 5.2.0
 ------------
 
@@ -2319,6 +2315,9 @@ OCaml 4.14 maintenance version
   Sébastien Hinderer)
 
 ### Bug fixes:
+
+- #12878: fix incorrect treatment of injectivity for private recursive types.
+  (Jeremy Yallop, review by Gabriel Scherer and Jacques Garrigue)
 
 - #12264, #12289: Fix compact_allocate to avoid a pathological case
   that causes very slow compaction.

--- a/testsuite/tests/typing-misc/injectivity.ml
+++ b/testsuite/tests/typing-misc/injectivity.ml
@@ -442,3 +442,46 @@ end =
 [%%expect{|
 module rec A : sig type _ t = Foo : 'a -> 'a A.s t type 'a s = T of 'a end
 |}]
+
+(* #12878 *)
+module Priv1 :
+sig
+  type !'a t = private [`T of 'a t]
+  val eql : (int t, string t) eql
+end =
+struct
+  type 'a t = [`T of 'a t]
+  let eql = Refl
+end
+
+let boom_1 = let module U = Uninj (Priv1) in print_endline (coerce (U.uninj Priv1.eql) 0)
+;;
+[%%expect{|
+Line 3, characters 2-35:
+3 |   type !'a t = private [`T of 'a t]
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: In this definition, expected parameter variances are not satisfied.
+       The 1st type parameter was expected to be injective invariant,
+       but it is invariant.
+|}]
+
+module Priv2 :
+sig
+  type !'a t = private <m:'a t>
+  val eql : (int t, string t) eql
+end =
+struct
+  type 'a t = <m:'a t>
+  let eql = Refl
+end
+
+let boom_2 = let module U = Uninj (Priv2) in print_endline (coerce (U.uninj Priv2.eql) 0)
+;;
+[%%expect{|
+Line 3, characters 2-31:
+3 |   type !'a t = private <m:'a t>
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: In this definition, expected parameter variances are not satisfied.
+       The 1st type parameter was expected to be injective invariant,
+       but it is invariant.
+|}]

--- a/typing/typedecl_variance.ml
+++ b/typing/typedecl_variance.ml
@@ -228,7 +228,7 @@ let compute_variance_type env ~check (required, loc) decl tyl =
     List.iter (fun (_,ty) -> check ty) tyl;
   end;
   List.map2
-    (fun ty (p, n, i) ->
+    (fun ty (p, n, _i) ->
       let v = get_variance ty tvl in
       let tr = decl.type_private in
       (* Use required variance where relevant *)
@@ -236,7 +236,7 @@ let compute_variance_type env ~check (required, loc) decl tyl =
       let (p, n) =
         if tr = Private || not (Btype.is_Tvar ty) then (p, n) (* set *)
         else (false, false) (* only check *)
-      and i = concr  || i && tr = Private in
+      and i = concr in
       let v = union v (make p n i) in
       if not concr || Btype.is_Tvar ty then v else
       union v


### PR DESCRIPTION
## The bug

### Summary

There's a bad interaction between private recursive types (aliases), injectivity annotations, and module subtyping that can lead to non-injective types being treated as injective, and consequently to segmentation faults.  The bug is present in all OCaml versions from 4.12 onwards.

### Background: non-injective structural types

None of the following equirecursive types is injective in its type parameter:

```ocaml
   type 'a r = <m: 'a r>

   type 'a s = [`S of 'a s]

   type 'a t = (unit -> 'a t) (* with -rectypes *)
```

and OCaml rightly rejects attempts to mark them injective:

```
# type !'a r = <m: 'a r>;;
Line 1, characters 0-22:
1 | type !'a r = <m: 'a r>;;
    ^^^^^^^^^^^^^^^^^^^^^^
Error: In this definition, expected parameter variances are not satisfied.
       The 1st type parameter was expected to be injective invariant,
       but it is unrestricted.
```

(One intuition for this: equirecursive types in OCaml are regular, so the type `r` means something like `λ'a.μr.<m:m>`, which clearly makes no use of `'a'`.)

### Background: `private` and signature subtyping

Separately, module subtyping allows adding `private` annotations in the target signature that are not present in the source signature, like this:

```ocaml
module M : sig type 'a r = private <m: 'a r> end =
        struct type 'a r =         <m: 'a r> end
```

This is the core purpose of private aliases: it exposes the equality `'a r = <m: 'a r>` inside the module, but hides it outside.

### Background: injectivity subtyping

Here's an implementation detail: when a module type coercion adds `private` in the target to an alias in the source, the type checker does not check that variance and injectivity are maintained or restricted (https://github.com/ocaml/ocaml/issues/7321#issuecomment-473062142).  This is justified as follows: since the type checker infers variance and injectivity for aliases in both the target and the source, there is no need to check that they are consistent.

### Odd behaviour: `private` and injectivity

Here's something surprising.   When the noninjective equirecursive types above are marked `private`, OCaml allows them to also be marked injective:

```
# type !'a r = private <m: 'a r>;;
type 'a r = private < m : 'a r >
```

This is not the intended behaviour, which is that the addition of `private` should not change injectivity of type parameters or the treatment of injectivity annotations:

> For type abbreviations (public or private), the injectivity of parameters can be inferred from the body of the type, and annotations are only checked.
(from https://github.com/ocaml/ocaml/pull/9500#issuecomment-621189201)

While the behaviour is rather odd (and inconsistent with the behaviour of `private` and injectivity annotations for non-recursive types), I don't think that it's in itself unsound: injectivity means that whenever `x r` and `y r` are known to be equal, `x` and `y` are also known to be equal, and the `private` annotation hides the type equalities that make it possible to violate this property.

### Producing a segmentation fault

However, in conjunction with the optimisation that doesn't check injectivity for `private` subtyping, the odd behaviour is certainly unsound, as the following example shows.

The example involves adding an injectivity annotation to `M.r` and passing a type equality witness across the module boundary, constructing the witness in a context where `r` is not injective and exposing it to a context where `r` is injective:
 
```ocaml
open Type
module M :
sig
  type !'a r = private <m: 'a r>
  val eq : (int r, string r) eq
end =
struct
  type 'a r = <m: 'a r>
  let eq = Equal
end
```

At this point injectivity allows us to turn `M.eq` into a proof that `int = string`, with the obvious disastrous consequences:

```ocaml
let castt (type a b) (Equal : (a M.r, b M.r) eq) (x : a) : b = x
let boom = "abc" ^ castt M.eq 0
(* segmentation fault *) 
```

## Fixing the bug

Since the bug arises from a combination of several properties, there are several ways to fix it.  I suggest applying the simplest fix for now (Approach 1 below), but reconsidering the approach to private aliases and injectivity (Approach 3) in the longer term.

### Approach 1: ignore `private` when computing injectivity

The simplest fix (and the one which this PR proposes) is to restore the original intent that `private` should be ignored when computing injectivity for aliases.

In principle, this approach is not quite backwards compatible, since it causes some safe programs that are currently accepted (e.g. `type !'a r = private <m: 'a r>`) to be rejected.  However, it seems unlikely that there are very many (if any) such programs.

### Approach 2: refine signature subtyping to check injectivity for `private` aliases

Checking injectivity for `private` aliases (i.e. checking that the target of a coercion is no more injective than the source) would also fix the problem, and in a mostly backwards-compatible way.  However, it's a rather odd solution, since it introduces a check for a property that is by design guaranteed always to hold.

There is also a subtle backwards-compatibility issue with this approach.  At present the following valid program is accepted by OCaml:

```ocaml
module Id(X: sig type 'a t end) = X
module M : sig type !'a t = private 'a array end = Id(Array)
```

However, it is accepted as a result of the fortunate combination of two shortcomings in the type checker:
- the call to `Id` loses the fact that `Array.t` is injective (see https://github.com/ocaml/ocaml/issues/5984)
- the module subtyping check ignores the fact that the signature ascribed to `M` is more injective than the signature of the body

Fixing the second of these shortcomings without fixing the first would cause this program to be rejected.

### Approach 3: treat private aliases like abstract types for injectivity purposes.

A more radical approach is to revisit the treatment of private aliases and injectivity.  A private type alias lies between a public alias and an abstract type: like a public alias, it exposes certain details related to subtyping; like an abstract type, it hides certain details such as the equality between the constructor and the representation.

I think we should consider treating private aliases like abstract types for injectivity purposes: that is, we should make private aliases non-injective by default, allow the user to make them injective using an annotation, and extend the module subtyping to allow maintaining or reducing (but not increasing) injectivity.

```ocaml
module M1: sig type  !'a t = private 'a list end = (* ok: injectivity preserved *)
        struct type  !'a t = 'a * 'a end

module M2: sig type  'a t = private 'a * 'a end = (* ok: injectivity hidden *)
        struct type  !'a t = 'a * 'a end

module M3: sig type  'a t = private int end =  (* ok: (non)injectivity preserved *)
        struct type  'a t =         int end

module M4: sig type !'a t = private int end = (* not ok: signature more injective *)
        struct type  'a t =         int end

module F(X: sig type 'a t = private 'a list end) =
        struct type !'a t = 'a X.t end (* not ok: X.t is not injective *)

type !'a t = private int (* ok, if not enormously useful *)
```

Injectivity is a relation involving type equalities, and type equalities are hidden by `private`, so we should default to hiding the injectivity status of the type, too.

This extends the set of programs that can be written, since any private alias can now optionally be made injective in any parameter, and there are additional opportunities to hide injectivity where it is an implementation detail.  It is not completely backwards compatible, since programs that currently rely on the injectivity of private aliases would need to be updated with injectivity annotations, but I believe it is a more consistent and flexible design.

(A slight variant of this approach, similar to the treatment of variance for private aliases, allows only annotations that would still be valid if `private` were removed.  For variance that restriction is essential; I don't believe it is essential for injectivity, but would be happy to be convinced otherwise.  In any case, I think it'd be fine to have that restriction if we chose.)

