### PR TITLE
Ensure the minor heap is actually empty before reallocating it

### DIFF
--- a/runtime/minor_gc.c
+++ b/runtime/minor_gc.c
@@ -129,8 +129,11 @@ void caml_set_minor_heap_size (asize_t wsize)
 
   if (domain_state->young_ptr != domain_state->young_end) {
     CAML_EV_COUNTER (EV_C_FORCE_MINOR_SET_MINOR_HEAP_SIZE, 1);
-    caml_minor_collection();
+    // Don't call caml_minor_collection, since that can run the
+    // caml_domain_external_interrupt_hook, which can allocate.
+    caml_empty_minor_heaps_once();
   }
+  CAMLassert (domain_state->young_ptr == domain_state->young_end);
 
   if(caml_reallocate_minor_heap(wsize) < 0) {
     caml_fatal_error("Fatal error: No memory for minor heap");
@@ -768,6 +771,7 @@ caml_stw_empty_minor_heap_no_major_slice(caml_domain_state* domain,
 
   CAML_EV_END(EV_MINOR_CLEAR);
   caml_gc_log("finished stw empty_minor_heap");
+  CAMLassert(domain->young_ptr == domain->young_end);
 }
 
 static void caml_stw_empty_minor_heap (caml_domain_state* domain, void* unused,


### PR DESCRIPTION
The `caml_domain_external_interrupt_hook` strikes again. When `caml_set_minor_heap_size` is called, the minor heap is emptied by calling `caml_minor_collection`, before the existing minor heap for the domain concerned is freed and reallocated. Except that `caml_minor_collection` doesn't necessarily leave the heap empty, because of the hook.

To fix this, in this PR we use `caml_empty_minor_heaps_once`, which doesn't call the hook. The test case that was failing is a bit intermittent but I have reasonable confidence this fix has solved the problem.

I added an assertion at the end of `caml_stw_empty_minor_heap_no_major_slice` to show that the minor heap is indeed empty at the end of that function, since this isn't that obvious.

This makes me wonder: maybe under the debug runtime, we should make that hook always allocate a small value.  At the moment the behaviour is intermittent because it is relying on thread yields.

(Fix originally from https://github.com/ocaml-flambda/flambda-backend/pull/2208)