### PR TITLE
Update opam file dependency to 5.3 after branching 5.2

### DIFF
--- a/ocaml-variants.opam
+++ b/ocaml-variants.opam
@@ -14,7 +14,7 @@ authors: [
 homepage: "https://github.com/ocaml/ocaml/"
 bug-reports: "https://github.com/ocaml/ocaml/issues"
 depends: [
-  "ocaml" {= "5.2.0" & post}
+  "ocaml" {= "5.3.0" & post}
   "base-unix" {post}
   "base-bigarray" {post}
   "base-threads" {post}


### PR DESCRIPTION
Following the branching of 5.2 d46f79c omitted to bump the dependency from 5.2 to 5.3 in the opam file.

Cc: @Octachron 