### PR TITLE
Execute preemptive systhread switching as a delayed pending action

### DIFF
--- a/Changes
+++ b/Changes
@@ -221,6 +221,14 @@ OCaml 5.2.0
   (Guillaume Munch-Maccagnoni, review by Anil Madhavapeddy and KC
    Sivaramakrishnan)
 
+- #12875, #12879, #12882: Execute preemptive systhread switching as a
+  delayed pending action. This ensures that one can reason within the
+  FFI that no mutation happens on the same domain when allocating on
+  the OCaml heap from C, consistently with OCaml 4. This also fixes
+  further bugs with the multicore systhreads implementation.
+  (Guillaume Munch-Maccagnoni, bug reports and suggestion by Mark
+   Shinwell, review by Nick Barnes and Stephen Dolan)
+
 - #12408: `Domain.spawn` no longer leaks its functional argument for
   the whole duration of the children domain lifetime.
   (Guillaume Munch-Maccagnoni, review by Gabriel Scherer)

--- a/Changes
+++ b/Changes
@@ -255,7 +255,7 @@ OCaml 5.2.0
 
 - #11307: Finish adapting the implementation of asynchronous actions for
   multicore: soundness, liveness, and performance issues.
-  Do not crash if a signal handler is  called from an unregistered C
+  Do not crash if a signal handler is called from an unregistered C
   thread, and other possible soundness issues. Prevent issues where join
   on other domains could make the toplevel unresponsible to Ctrl-C. Avoid
   needless repeated polling in C code when callbacks cannot run

--- a/manual/src/cmds/intf-c.etex
+++ b/manual/src/cmds/intf-c.etex
@@ -1268,16 +1268,18 @@ has taken place since "r" was allocated.
 
 \subsection{ss:c-process-pending-actions}{Pending actions and asynchronous exceptions}
 
-Since 4.10, allocation functions are guaranteed not to call any OCaml
-callbacks from C, including finalisers and signal handlers, and delay
-their execution instead.
+Since 4.10, allocation functions are guaranteed not to run any OCaml
+code, including finalisers, signal handlers and other threads running
+on the same domain. Instead, their execution is delayed to a later
+safe point.
 
 The function \verb"caml_process_pending_actions" from
 "<caml/signals.h>" executes any pending signal handlers and
-finalisers, Memprof callbacks, and requested minor and major garbage
-collections. In particular, it can raise asynchronous exceptions. It
-is recommended to call it regularly at safe points inside long-running
-non-blocking C code.
+finalisers, Memprof callbacks, preemptive systhread switching, and
+requested minor and major garbage collections. In particular, it can
+raise asynchronous exceptions and cause mutations on the OCaml heap
+from the same domain. It is recommended to call it regularly at safe
+points inside long-running non-blocking C code.
 
 The variant \verb"caml_process_pending_actions_exn" is provided, that
 returns the exception instead of raising it directly into OCaml code.

--- a/otherlibs/systhreads/st_stubs.c
+++ b/otherlibs/systhreads/st_stubs.c
@@ -509,7 +509,7 @@ static void caml_thread_domain_initialize_hook(void)
   caml_memprof_enter_thread(new_thread->memprof);
 }
 
-CAMLprim value caml_thread_yield(value unit);
+static void thread_yield(void);
 
 void caml_thread_interrupt_hook(void)
 {
@@ -521,7 +521,7 @@ void caml_thread_interrupt_hook(void)
     &Caml_state->requested_external_interrupt;
 
   if (atomic_compare_exchange_strong(req_external_interrupt, &is_on, 0)) {
-    caml_thread_yield(Val_unit);
+    thread_yield();
   }
 
   return;
@@ -780,26 +780,33 @@ CAMLprim value caml_thread_uncaught_exception(value exn)
 
 /* Allow re-scheduling */
 
-CAMLprim value caml_thread_yield(value unit)
+static void thread_yield(void)
 {
   st_masterlock *m = Thread_lock(Caml_state->id);
   if (st_masterlock_waiters(m) == 0)
-    return Val_unit;
+    return;
 
   /* Do all the parts of a blocking section enter&leave except lock
      manipulation, which we will do more efficiently in
-     st_thread_yield, and asynchronous actions (since
-     [caml_thread_yield] must not raise). (Since our blocking section
-     does not contain anything interesting, do not bother saving
-     errno.)
+     st_thread_yield, and executing signal handlers (which is already
+     done at this point as part of the asynchronous actions mechanism
+     when forcing a systhread yield). (Since our blocking section does
+     not contain anything interesting, do not bother saving errno.)
   */
 
   save_runtime_state();
   st_thread_yield(m);
   restore_runtime_state(This_thread);
+
+  /* Switching threads might have unmasked some signal. */
   if (caml_check_pending_signals())
     caml_set_action_pending(Caml_state);
+}
 
+CAMLprim value caml_thread_yield(value unit)
+{
+  caml_process_pending_actions();
+  thread_yield();
   return Val_unit;
 }
 

--- a/runtime/caml/domain.h
+++ b/runtime/caml/domain.h
@@ -62,6 +62,7 @@ int caml_incoming_interrupts_queued(void);
 
 void caml_poll_gc_work(void);
 void caml_handle_gc_interrupt(void);
+void caml_process_external_interrupt(void);
 void caml_handle_incoming_interrupts(void);
 
 CAMLextern void caml_interrupt_self(void);

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -1644,6 +1644,8 @@ void caml_reset_young_limit(caml_domain_state * dom_st)
      achieves the proper synchronisation. */
   atomic_exchange(&dom_st->young_limit, (uintnat)trigger);
 
+  /* For non-delayable asynchronous actions, we immediately interrupt
+     the domain again. */
   dom_internal * d = &all_domains[dom_st->id];
   if (atomic_load_relaxed(&d->interruptor.interrupt_pending)
       || dom_st->requested_minor_gc

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -1648,16 +1648,16 @@ void caml_reset_young_limit(caml_domain_state * dom_st)
   if (atomic_load_relaxed(&d->interruptor.interrupt_pending)
       || dom_st->requested_minor_gc
       || dom_st->requested_major_slice
-      || dom_st->major_slice_epoch < atomic_load (&caml_major_slice_epoch)
-      || atomic_load_relaxed(&dom_st->requested_external_interrupt)) {
+      || dom_st->major_slice_epoch < atomic_load (&caml_major_slice_epoch)) {
     interrupt_domain_local(dom_st);
   }
-  /* We might be here due to a recently-recorded signal, so we
-     need to remember that we must run signal handlers. In
-     addition, in the case of long-running C code (that may
-     regularly poll with caml_process_pending_actions), we want to
-     force a query of all callbacks at every minor collection or
-     major slice (similarly to the OCaml behaviour). */
+  /* We might be here due to a recently-recorded signal or forced
+     systhread switching, so we need to remember that we must run
+     signal handlers or systhread's yield. In addition, in the case of
+     long-running C code (that may regularly poll with
+     caml_process_pending_actions), we want to force a query of all
+     callbacks at every minor collection or major slice (similarly to
+     the OCaml behaviour). */
   caml_set_action_pending(dom_st);
 }
 
@@ -1749,9 +1749,6 @@ void caml_poll_gc_work(void)
        caml_poll_gc_work is called. */
   }
 
-  if (atomic_load_acquire(&d->requested_external_interrupt)) {
-    caml_domain_external_interrupt_hook();
-  }
   caml_reset_young_limit(d);
 }
 
@@ -1767,6 +1764,14 @@ void caml_handle_gc_interrupt(void)
   }
 
   caml_poll_gc_work();
+}
+
+/* Preemptive systhread switching */
+void caml_process_external_interrupt(void)
+{
+  if (atomic_load_acquire(&Caml_state->requested_external_interrupt)) {
+    caml_domain_external_interrupt_hook();
+  }
 }
 
 CAMLexport int caml_bt_is_in_blocking_section(void)


### PR DESCRIPTION
Background: in OCaml 4, preemptive systhread switching (happening every 50ms) used to be done via signal handlers. This means that there were the same guarantees for the C FFI regarding code running concurrently on the same domain, as there was regarding OCaml signal handlers running asynchronously. In particular, allocating on the OCaml heap from C could not cause another systhread on the same domain to run before the allocation function returned. This property has been lost with OCaml 5 and the rewriting of the systhreads runtime.

The rewriting of systhreads with multicore uses a more straightforward mechanism to communicate preemption (the atomic flag `requested_external_interrupt`). Initially, multicore was not as careful regarding the guarantees about asynchronous callbacks, but this was progressively fixed. Systhread's yield being executed during allocations from C is a remnant of this old multicore implementation.

In addition, @mshinwell has found two critical bugs related to the misplacement of preemptive systhread switching being called from `caml_poll_gc_work`, which is not expected to execute OCaml code (#12875, #12879).

With this PR, preemptive systhread switching is considered again as an asynchronous action whose execution can be delayed until an appropriate safe point is reached. This restores the guarantee described above, and fixes the two bugs.

This PR is targeted towards backporting to 5.2, given that it fixes critical bugs.

(Cc @kayceesrk with whom the change was previously discussed.)