### PR TITLE
optimize Dynarray.of_list

### DIFF
--- a/stdlib/dynarray.ml
+++ b/stdlib/dynarray.ml
@@ -722,6 +722,7 @@ let to_array a =
 
 let of_list li =
   let a = create () in
+  ensure_capacity a (List.length li);
   List.iter (fun x -> add_last a x) li;
   a
 


### PR DESCRIPTION
I missed a natural optimization of Dynarray.of_list, which is to use List.length to guess the right size for the resulting dynarray instead of using the dynamic resizing strategy.

A microbenchmark suggests that this is always a win, small (10% speedup) on small lists and large (2x-3x faster) on large lists.