### PR TITLE
add Queue.drop

### DIFF
--- a/Changes
+++ b/Changes
@@ -115,6 +115,9 @@ _______________
 
 ### Standard library:
 
+- #12884: Add `Queue.drop`
+  (Léo Andrès, review by Nicolás Ojeda Bär and Gabriel Scherer)
+
 - #13168: In Array.shuffle, clarify the code that validates the
   result of the user-supplied function `rand`, and improve the
   error message that is produced when this result is invalid.

--- a/stdlib/queue.ml
+++ b/stdlib/queue.ml
@@ -93,6 +93,15 @@ let take_opt q =
 let pop =
   take
 
+let drop q =
+  match q.first with
+  | Nil -> raise Empty
+  | Cons { content = _; next = Nil } ->
+    clear q
+  | Cons { content = _; next } ->
+    q.length <- q.length - 1;
+    q.first <- next
+
 let copy =
   let rec copy q_res prev cell =
     match cell with

--- a/stdlib/queue.mli
+++ b/stdlib/queue.mli
@@ -72,6 +72,11 @@ val peek_opt : 'a t -> 'a option
 val top : 'a t -> 'a
 (** [top] is a synonym for [peek]. *)
 
+val drop : 'a t -> unit
+(** [drop q] removes the first element in queue [q], or raises {!Empty}
+   if the queue is empty.
+   @since 5.3 *)
+
 val clear : 'a t -> unit
 (** Discard all elements from a queue. *)
 

--- a/testsuite/tests/lib-queue/test.ml
+++ b/testsuite/tests/lib-queue/test.ml
@@ -8,7 +8,7 @@ end
 
 let does_raise f q =
   try
-    ignore (f q : int);
+    ignore (f q);
     false
   with Q.Empty ->
     true
@@ -135,6 +135,13 @@ let () =
   Q.transfer q1 q2;
   assert (Q.length q1 = 0); assert (Q.to_list q1 = [                      ]);
   assert (Q.length q2 = 8); assert (Q.to_list q2 = [5; 6; 7; 8; 1; 2; 3; 4]);
+;;
+
+let () =
+  let q = Q.create () in
+  Q.add 1 q; Q.drop q; assert (does_raise Q.drop q);
+  Q.add 2 q; Q.drop q; assert (does_raise Q.drop q);
+  assert (Q.length q = 0);
 ;;
 
 let () = print_endline "OK"


### PR DESCRIPTION
Hi,

This adds a `val drop : 'a t -> unit` function to the `Queue` module.