### PR TITLE
Dynarrays, unboxed (with local dummies)

### DIFF
--- a/Changes
+++ b/Changes
@@ -61,6 +61,10 @@ _______________
   (Kate Deplaix and Oscar Butler-Aldridge review by Nicolás Ojeda Bär,
    Craig Ferguson and Gabriel Scherer)
 
+- #12885: move Dynarray to an unboxed representation
+  (Gabriel Scherer, suggestions by Vincent Laviron,
+   review by Olivier Nicole and Simon Cruanes, Yann Leray, Alain Frisch)
+
 - #13047: Add Sys.poll_actions to (only) run pending runtime actions.
   (Nick Barnes, review by Gabriel Scherer, Guillaume Munch-Maccagnoni, and
   Vincent Laviron)

--- a/stdlib/.depend
+++ b/stdlib/.depend
@@ -237,6 +237,7 @@ stdlib__Dynarray.cmo : dynarray.ml \
     stdlib__Seq.cmi \
     stdlib__Printf.cmi \
     stdlib__Obj.cmi \
+    camlinternalOO.cmi \
     stdlib__Array.cmi \
     stdlib__Dynarray.cmi
 stdlib__Dynarray.cmx : dynarray.ml \
@@ -244,6 +245,7 @@ stdlib__Dynarray.cmx : dynarray.ml \
     stdlib__Seq.cmx \
     stdlib__Printf.cmx \
     stdlib__Obj.cmx \
+    camlinternalOO.cmx \
     stdlib__Array.cmx \
     stdlib__Dynarray.cmi
 stdlib__Dynarray.cmi : dynarray.mli \

--- a/stdlib/.depend
+++ b/stdlib/.depend
@@ -236,14 +236,14 @@ stdlib__Dynarray.cmo : dynarray.ml \
     stdlib__Sys.cmi \
     stdlib__Seq.cmi \
     stdlib__Printf.cmi \
-    stdlib__List.cmi \
+    stdlib__Obj.cmi \
     stdlib__Array.cmi \
     stdlib__Dynarray.cmi
 stdlib__Dynarray.cmx : dynarray.ml \
     stdlib__Sys.cmx \
     stdlib__Seq.cmx \
     stdlib__Printf.cmx \
-    stdlib__List.cmx \
+    stdlib__Obj.cmx \
     stdlib__Array.cmx \
     stdlib__Dynarray.cmi
 stdlib__Dynarray.cmi : dynarray.mli \

--- a/stdlib/StdlibModules
+++ b/stdlib/StdlibModules
@@ -73,7 +73,6 @@ STDLIB_MODULE_BASENAMES = \
   domain \
   camlinternalFormat \
   printf \
-  dynarray \
   arg \
   printexc \
   fun \
@@ -91,6 +90,7 @@ STDLIB_MODULE_BASENAMES = \
   camlinternalOO \
   oo \
   camlinternalMod \
+  dynarray \
   ephemeron \
   filename \
   complex \

--- a/stdlib/dynarray.ml
+++ b/stdlib/dynarray.ml
@@ -153,6 +153,8 @@ module Dummy : sig
       int -> (int -> 'a) -> dummy:'stamp dummy ->
       ('a, 'stamp) with_dummy array
 
+    val copy : 'a array -> dummy:'stamp dummy -> ('a, 'stamp) with_dummy array
+
     val blit_array :
       'a array -> int ->
       ('a, 'stamp) with_dummy array -> int ->
@@ -200,6 +202,16 @@ end = struct
       else begin
         let arr = Array.make n (of_dummy dummy) in
         Array.fill arr 0 n (of_val x);
+        arr
+      end
+
+   let copy a ~dummy =
+      if Obj.(tag (repr a) <> double_array_tag) then
+        Array.copy a
+      else begin
+        let n = Array.length a in
+        let arr = Array.make n (of_dummy dummy) in
+        Array.blit a 0 arr 0 n;
         arr
       end
 
@@ -840,7 +852,7 @@ let of_array a =
   let Dummy.Fresh dummy = Dummy.fresh () in
   Pack {
     length;
-    arr = Dummy.Array.init ~dummy length (fun i -> Array.unsafe_get a i);
+    arr = Dummy.Array.copy a ~dummy;
     dummy;
   }
 

--- a/stdlib/dynarray.ml
+++ b/stdlib/dynarray.ml
@@ -239,7 +239,10 @@ end = struct
       else begin
         let n = Array.length a in
         let arr = Array.make n (of_dummy dummy) in
-        Array.blit a 0 arr 0 n;
+        for i = 0 to n - 1 do
+          Array.unsafe_set arr i
+            (of_val (Array.unsafe_get a i));
+        done;
         arr
       end
 
@@ -256,7 +259,13 @@ end = struct
       arr
 
     let blit_array src src_pos dst dst_pos ~len =
-      Array.blit src src_pos dst dst_pos len
+      if Obj.(tag (repr src) <> double_array_tag) then
+        Array.blit src src_pos dst dst_pos len
+      else begin
+        for i = 0 to len - 1 do
+          dst.(dst_pos + i) <- of_val src.(src_pos + i)
+        done;
+      end
 
     let prefix arr n =
       (* Note: the safety of the [Array.sub] call below, with respect to

--- a/stdlib/dynarray.mli
+++ b/stdlib/dynarray.mli
@@ -39,10 +39,6 @@
     The {!Stack} module provides a last-in first-out data structure
     that can be easily implemented on top of dynamic arrays.
 
-    {b Warning.} In their current implementation, the memory layout
-    of dynamic arrays differs from the one of {!Array}s. See the
-    {{!section:memory_layout} Memory Layout} section for more information.
-
     @since 5.2
 *)
 
@@ -493,34 +489,6 @@ val reset : 'a t -> unit
     particular, no user-provided values are "leaked" by being present
     in the backing array in position [length a] or later.
 *)
-
-(** {2:memory_layout Memory layout of dynarrays}
-
-    In the current implementation, the backing array of an
-    ['a Dynarray.t] is not an ['a array], but something with the same
-    representation as an ['a option array] or ['a ref array].
-    Each element is in a "box", allocated when the element is first
-    added to the array -- see the implementation for more details.
-
-    Using an ['a array] would be delicate, as there is no obvious
-    type-correct way to represent the empty space at the end of the
-    backing array -- using user-provided values would either
-    complicate the API or violate the {{!section:noleaks}no leaks}
-    guarantee. The constraint of remaining memory-safe under
-    unsynchronized concurrent usage makes it even more
-    difficult. Various unsafe ways to do this have been discussed,
-    with no consensus on a standard implementation so far.
-
-    On a realistic automated-theorem-proving program that relies
-    heavily on dynamic arrays, we measured the overhead of this extra
-    "boxing" as at most 25%. We believe that the overhead for most
-    uses of dynarray is much smaller, negligible in many cases, but
-    you may still prefer to use your own specialized implementation
-    for performance. (If you know that you do not need the
-    {{:noleaks}no leaks} guarantee, you can also speed up deleting
-    elements.)
-*)
-
 
 
 (** {1:examples Code examples}


### PR DESCRIPTION
We recently merged Dynarray in the stdlib (yay! #11882 ), with the caveat that its implementation is 'boxed', it uses a representation similar to `'a option array` to safely represent 'empty' values without leaking user data.

#11882 started its life as an attempt to un-block @c-cube's #11563, the previous proposal for Dynarray in the stdlib, which used an 'unboxed' representation. The PR discussion had ground to a halt because we disagreed on how which unsafe tricks to use to implement this unboxed approach.

The present PR proposes to move Dynarray to an unboxed representation, using one of the two approaches discussed in #11563.so there will be at least one release with boxed dynarrays.

The design was in particular informed by discussions with @lthls and @xavierleroy.
I was motivated to work on this now by @backtracking's interest in building efficient data structures on top of Dynarray (see #12871).

Timing remark: Dynarray will be released with OCaml 5.2, but the present PR might be merged in 5.3 at best, so there will be at least one release with boxed dynarrays. Boxed dynarrays are just fine.

#### How to review

I think that correctness is the main question when reviewing this PR. It should be clear that the implementation is indeed unboxed, and I think that the performance benefits of this choice are well-understood. On the other hand, it is not clear that the implementation is safe/sound -- that the user can never observe a type-incorrect dummy -- and this is what needs reviewing foremost.


## Performance

The performance of the unboxed version are *generally* better, especially on very large arrays (one million elements). For example, on a microbenchmark that starts from an empty dynarray and repeatedly adds 1000 elements and pops them again, we get the following results:

```
  Stack ran
    1.11 ± 0.05 times faster than Queue
    1.22 ± 0.05 times faster than CCVector
    1.33 ± 0.05 times faster than Dynarray_unboxed
    1.59 ± 0.06 times faster than Dynarray_boxed
    1.61 ± 0.06 times faster than Base_stack
```

where `Stack` and `Queue` are the stdlib modules, `CCVector` is the dynarray of Containers, `Dynarray_boxed` is the current stdlib implementation, `Dynarray_unboxed` is our new implementation, and `Base_stack` is the `Stack` module of Base. (Both Base and Containers use an unboxed representation.)

Please keep in mind that those are *small* performance differences for a benchmark that measures only the data structure and no useful user work: for containers of size 1000, Array is 2x faster than all those Dynarray implementations at random access, and Hashtbl is 42x slower than Array.

The main advantage of unboxed representations is to avoid surprises regarding memory layout and usage, and to benefit from better locality. Locality effects are hard to measure, especially in microbenchmarks, so I did not try to do so -- let us keep in mind that there are probably more performance benefits in real-world programs than shown above. I did a more representative study of the impact of boxing on a real-world program in the previous PR ( https://github.com/ocaml/ocaml/pull/11882#issuecomment-1405867624 ), where making one of @c-cube's implementations boxed caused a 25% slowdown at worst on some dynarray-critical programs.


## Dummies

A dynarray that contains `length` user values is represented by a "backing array" of length `capacity`, with `capacity >= length`. The positions from `0` to `length - 1` are the "user space", storing the values provided by the user, and the positions from `length` to `capacity - 1` are the "empty space". Adding a new element increments the mutable field `length`, increasing the user space and shrinking the empty space.

An unboxing representation is achieved by using a 'dummy' in the empty space. With OCaml 5, we cannot guarantee that the bound check on the current `length` whether a given element is a dummy or not: there could be data races on the dynarray that result in reading dummy values in the user space. So we need to find a 'dummy' that we can distinguish at runtime from any user value -- in particular the old trick of using `Obj.magic ()` does not work.

In #11563 we discussed two approaches for dummies:

1. Local dummies, where we allocate a private reference (we never show the value to anyone), and we use this reference as the dummy, using physical equality to check whether an element is the dummy or not.
2. Atomic dummies, where we use "atoms" of non-zero tag, which are low-level values expressible in the OCaml runtime representation but not currenty used to represent any OCaml value.

If you want the details, the discussion of these approaches starts at https://github.com/ocaml/ocaml/pull/11563#issuecomment-1257271948 and there is a lot of it. The summary is that both approaches have downsides, but (2) got a fairly strong veto from Xavier, so I think that (1) is a safer bet if we want an unboxed representation. The present PR implements 1.

I don't expect any performance implication to using (1) or (2), except for the following. The implementation of (1) makes dynarrays 3-field records instead of 2-field records, and allocates a dummy value on each new dynarray creation, so it may be slightly slower when creating a lot of extremely small dynarrays.

### Details on the current implementation

If you are an expert, you may wonder how the approach deals with marshalling, and how it avoids issues coming from flat float arrays. The answer to both these questions is in the long implementation comment at the beginning of stdlib/dynarray.ml. Go review my code!

### A type-rich API for dummies

Initially I implemented dummies using `Obj.magic` and that's it: you have an `'a array`, but some values are not in fact valid `'a` values and you better be careful about it -- forget a `v == Obj.obj dummy` check and that's a segfault for your users.

Then I realized that I could hide the definition of dummies inside a submodule enforcing a type discipline on the use of dummies. Something like:

```ocaml
type dummy
val fresh : unit -> dummy

type 'a or_dummy
val of_val : 'a -> 'a or_dummy
val of_dummy : dummy -> 'a or_dummy
val find : 'a or_dummy -> 'a option
```

In fact you can do even better, by using a `'stamp` type parameter on dummies, to give a different type to two distinct dummy values. (This is also called "branding" sometimes.)

```ocaml
type 'stamp dummy
type fresh_dummy = Fresh : 'stamp dummy -> fresh_dummy
val fresh : unit -> fresh_dummy

type ('a, 'stamp) or_dummy
val of_val : 'a -> ('a, 'stamp) or_dummy
val of_dummy : 'stamp dummy -> ('a, 'stamp) or_dummy
val find : ('a, 'stamp) or_dummy -> 'a option
```

This is exactly the sort of improductive type over-engineering that I like, so of course I implemented it. And it *caught a bug* in my code.

The bug was in `append : 'a Dynarray.t -> 'a Dynarray.t -> unit`, `append a b` adds all the elements of `b` to `a`. I implemented this by using `Array.blit` to blit the elements of `b`'s backing array, but this is unsound because `a` and `b` may use different dummy values, so you have to carefully fail on dummy elements in `b`'s user space. This became a hard type error with the above strongly typed API.

(Besides the over-engineered typing, which has upsides and downsides, I like the fact that this approach forced me to isolate all the unsafe code and low-level reasoning in a submodule with a clear boundary from the rest of the Dynarray code.)
