### PR TITLE
Reinitialize IO mutexes after fork

### DIFF
--- a/Changes
+++ b/Changes
@@ -244,6 +244,9 @@ OCaml 5.2.0
 - #12810: Port ThreadSanitizer support to Linux and macOS on arm64
   (Miod Vallat, review by Tim McGilchrist)
 
+- #12886: Reinitialize IO mutexes after fork
+  (Max Slater, review by -)
+
 ### Code generation and optimizations:
 
 - #11239: on x86-64 and RISC-V, reduce alignment of OCaml stacks from 16 to 8.

--- a/Changes
+++ b/Changes
@@ -245,7 +245,7 @@ OCaml 5.2.0
   (Miod Vallat, review by Tim McGilchrist)
 
 - #12886: Reinitialize IO mutexes after fork
-  (Max Slater, review by -)
+  (Max Slater, review by Guillaume Munch-Maccagnoni and Xavier Leroy)
 
 ### Code generation and optimizations:
 

--- a/otherlibs/systhreads/st_stubs.c
+++ b/otherlibs/systhreads/st_stubs.c
@@ -413,7 +413,6 @@ static void caml_thread_reinitialize(void)
   /* Reinitialize IO mutexes, in case the fork happened while another thread
      had locked the channel. If so, we're likely in an inconsistent state,
      but we may be able to proceed anyway. */
-  caml_plat_mutex_init(&caml_all_opened_channels_mutex);
   for (chan = caml_all_opened_channels;
        chan != NULL;
        chan = chan->next) {

--- a/runtime/caml/io.h
+++ b/runtime/caml/io.h
@@ -111,7 +111,6 @@ CAMLextern void caml_channel_unlock(struct channel *);
 CAMLextern void caml_channel_cleanup_on_raise(void);
 
 CAMLextern struct channel * caml_all_opened_channels;
-CAMLextern caml_plat_mutex caml_all_opened_channels_mutex;
 
 /* Conversion between file_offset and int64_t */
 

--- a/runtime/caml/io.h
+++ b/runtime/caml/io.h
@@ -111,6 +111,7 @@ CAMLextern void caml_channel_unlock(struct channel *);
 CAMLextern void caml_channel_cleanup_on_raise(void);
 
 CAMLextern struct channel * caml_all_opened_channels;
+CAMLextern caml_plat_mutex caml_all_opened_channels_mutex;
 
 /* Conversion between file_offset and int64_t */
 

--- a/runtime/caml/platform.h
+++ b/runtime/caml/platform.h
@@ -103,7 +103,7 @@ Caml_inline uintnat atomic_fetch_add_verify_ge0(atomic_uintnat* p, uintnat v) {
 
 typedef pthread_mutex_t caml_plat_mutex;
 #define CAML_PLAT_MUTEX_INITIALIZER PTHREAD_MUTEX_INITIALIZER
-void caml_plat_mutex_init(caml_plat_mutex*);
+CAMLextern void caml_plat_mutex_init(caml_plat_mutex*);
 Caml_inline void caml_plat_lock(caml_plat_mutex*);
 Caml_inline int caml_plat_try_lock(caml_plat_mutex*);
 void caml_plat_assert_locked(caml_plat_mutex*);

--- a/runtime/platform.c
+++ b/runtime/platform.c
@@ -46,7 +46,7 @@ void caml_plat_fatal_error(const char * action, int err)
 
 /* Mutexes */
 
-void caml_plat_mutex_init(caml_plat_mutex * m)
+CAMLexport void caml_plat_mutex_init(caml_plat_mutex * m)
 {
   int rc;
   pthread_mutexattr_t attr;


### PR DESCRIPTION
(Upstreaming [this](https://github.com/ocaml-flambda/flambda-backend/pull/2160))

In OCaml 4, systhreads would re-initialize IO channel mutexes while resetting after a fork.
This PR makes the 5 runtime do so as well, fixing the relevant FIXME.

When resetting the mutexes matters, we're likely in an inconsistent state (i.e. another thread locked the mutex and then disappeared), but as the comment in `caml_thread_reinitialize` says, support for forking with threads is only best-effort. 

