### PR TITLE
toplevel: print "#help;;" as inline code in the introduction

### DIFF
--- a/Changes
+++ b/Changes
@@ -15,6 +15,11 @@ _______________
 
 ### Tools:
 
+### Toplevel:
+
+- #12891: Improved styling for initial prompt
+  (Florian Angeletti, review by Gabriel Scherer)
+
 ### Manual and documentation:
 
 ### Compiler user-interface and warnings:

--- a/toplevel/toploop.ml
+++ b/toplevel/toploop.ml
@@ -385,13 +385,15 @@ let process_phrases ppf snap phrs =
     end
 
 let loop ppf =
+  Misc.Style.setup !Clflags.color;
   Clflags.debug := true;
   Location.formatter_for_warnings := ppf;
   if not !Clflags.noversion then
-    fprintf ppf "OCaml version %s%s%s@.Enter #help;; for help.@.@."
+    fprintf ppf "OCaml version %s%s%s@.Enter %a for help.@.@."
       Config.version
       (if Topeval.implementation_label = "" then "" else " - ")
-      Topeval.implementation_label;
+      Topeval.implementation_label
+      Misc.Style.inline_code "#help;;";
   begin
     try initialize_toplevel_env ()
     with Env.Error _ | Typetexp.Error _ as exn ->


### PR DESCRIPTION
This nano PR updates the toplevel initial prompt to use the styling for inline code for the `#help;;` directive.
In other words, 

> OCaml version 5.2.0
>Enter #help;; for help.

is updated to

> OCaml version 5.2.0
>Enter **#help;;** for help.

when the terminal support ANSI colors and to

> OCaml version 5.2.0
>Enter "#help;;" for help.

otherwise.