### PR TITLE
testsuite: flush stdout when testing printing

### DIFF
--- a/testsuite/tests/typing-objects/Exemples.ml
+++ b/testsuite/tests/typing-objects/Exemples.ml
@@ -270,8 +270,9 @@ let p = new printable_point 7;;
 [%%expect{|
 val p : printable_point = <obj>
 |}];;
-p#print;;
+p#print; Format.print_newline ();;
 [%%expect{|
+7
 - : unit = ()
 |}];;
 
@@ -309,8 +310,9 @@ let p' = new printable_color_point 7 "red";;
 [%%expect{|
 val p' : printable_color_point = <obj>
 |}];;
-p'#print;;
+p'#print; Format.print_newline ();;
 [%%expect{|
+(7, red)
 - : unit = ()
 |}];;
 
@@ -424,8 +426,9 @@ let l1 = new cons 3 (new cons 10 (new nil ()));;
 val l1 : int lst = <obj>
 |}];;
 
-l1#print Format.print_int;;
+l1#print Format.print_int; Format.print_newline ();;
 [%%expect{|
+(3::10::[])
 - : unit = ()
 |}];;
 
@@ -433,8 +436,9 @@ let l2 = l1#map (fun x -> x + 1);;
 [%%expect{|
 val l2 : int lst = <obj>
 |}];;
-l2#print Format.print_int;;
+l2#print Format.print_int; Format.print_newline ();;
 [%%expect{|
+(4::11::[])
 - : unit = ()
 |}];;
 
@@ -449,8 +453,9 @@ let p1 = (map_list (fun x -> new printable_color_point x "red") l1);;
 [%%expect{|
 val p1 : printable_color_point lst = <obj>
 |}];;
-p1#print (fun x -> x#print);;
+p1#print (fun x -> x#print); Format.print_newline () ;;
 [%%expect{|
+((3, red)::(10, red)::[])
 - : unit = ()
 |}];;
 
@@ -616,7 +621,7 @@ val l : int_comparable list = [<obj>; <obj>; <obj>]
 |}];;
 pr l;;
 [%%expect{|
-7(7, red)(3::10::[])(4::11::[])((3, red)::(10, red)::[])5 2 4
+5 2 4
 - : unit = ()
 |}];;
 pr (sort l);;


### PR DESCRIPTION
This nano PR fixes  a test that was converted to an expect test without flushing `stdout` after testing print functions.
(This PR helps to make this test more reliable when changing the compiler logging architecture.)