### PR TITLE
Fix datarace between oldify and allocation

### DIFF
--- a/Changes
+++ b/Changes
@@ -68,6 +68,12 @@ _______________
 
 ### Bug fixes:
 
+- #11040: Silences false data race observed between caml_shared_try_alloc
+  and oldify. Introduces macros to call tsan annotations which help annotate
+  a ``happens before'' relationship.
+  (Hari Hara Naveen S and Olivier Nicole,
+   review by Gabriel Scherer and Miod Vallat)
+
 - #12888: fix printing of uncaught exceptions in `.cmo` files passed on the
   command-line of the toplevel.
   (Nicolás Ojeda Bär, review by Florian Angeletti, report by Daniel Bünzli)

--- a/runtime/caml/tsan.h
+++ b/runtime/caml/tsan.h
@@ -40,6 +40,24 @@
 #  endif
 #endif
 
+/* TSAN annotates a release operation on encountering ANNOTATE_HAPPENS_BEFORE
+ * and similarly an acquire operation on encountering ANNOTATE_HAPPENS_AFTER */
+#define CAML_TSAN_ANNOTATE_HAPPENS_BEFORE(addr)
+#define CAML_TSAN_ANNOTATE_HAPPENS_AFTER(addr)
+
+#if defined(WITH_THREAD_SANITIZER)
+#  undef CAML_TSAN_ANNOTATE_HAPPENS_BEFORE
+#  undef CAML_TSAN_ANNOTATE_HAPPENS_AFTER
+
+#  define CAML_TSAN_ANNOTATE_HAPPENS_BEFORE(addr)                                \
+  AnnotateHappensBefore(__FILE__, __LINE__, (void *)(addr));
+#  define CAML_TSAN_ANNOTATE_HAPPENS_AFTER(addr)                                 \
+  AnnotateHappensAfter(__FILE__, __LINE__, (void *)(addr));
+
+extern void AnnotateHappensBefore(const char *f, int l, void *addr);
+extern void AnnotateHappensAfter(const char *f, int l, void *addr);
+#endif
+
 /* Macro used to un-instrument some functions of the runtime for performance
    reasons, except if TSAN_INSTRUMENT_ALL is set. */
 #if defined(TSAN_INSTRUMENT_ALL)

--- a/runtime/caml/tsan.h
+++ b/runtime/caml/tsan.h
@@ -40,8 +40,9 @@
 #  endif
 #endif
 
-/* TSAN annotates a release operation on encountering ANNOTATE_HAPPENS_BEFORE
- * and similarly an acquire operation on encountering ANNOTATE_HAPPENS_AFTER */
+/* TSan records a release operation on encountering ANNOTATE_HAPPENS_BEFORE
+ * and similarly an acquire operation on encountering ANNOTATE_HAPPENS_AFTER.
+   These annotations are used to eliminate false positives. */
 #define CAML_TSAN_ANNOTATE_HAPPENS_BEFORE(addr)
 #define CAML_TSAN_ANNOTATE_HAPPENS_AFTER(addr)
 
@@ -49,9 +50,9 @@
 #  undef CAML_TSAN_ANNOTATE_HAPPENS_BEFORE
 #  undef CAML_TSAN_ANNOTATE_HAPPENS_AFTER
 
-#  define CAML_TSAN_ANNOTATE_HAPPENS_BEFORE(addr)                                \
+#  define CAML_TSAN_ANNOTATE_HAPPENS_BEFORE(addr)              \
   AnnotateHappensBefore(__FILE__, __LINE__, (void *)(addr));
-#  define CAML_TSAN_ANNOTATE_HAPPENS_AFTER(addr)                                 \
+#  define CAML_TSAN_ANNOTATE_HAPPENS_AFTER(addr)               \
   AnnotateHappensAfter(__FILE__, __LINE__, (void *)(addr));
 
 extern void AnnotateHappensBefore(const char *f, int l, void *addr);

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -946,6 +946,7 @@ static void mark_slice_darken(struct mark_stack* stk, value child,
   /* This part of the code is duplicated in do_some_marking for performance
    * reasons.
    * Changes here should probably be reflected in do_some_marking. */
+    CAML_TSAN_ANNOTATE_HAPPENS_AFTER(Hp_val(child));
     chd = Hd_val(child);
     if (Tag_hd(chd) == Infix_tag) {
       child -= Infix_offset_hd(chd);
@@ -1007,6 +1008,7 @@ Caml_noinline static intnat do_some_marking(struct mark_stack* stk,
       /* This part of the code is a duplicate of mark_slice_darken for
        * performance reasons.
        * Changes here should probably be reflected here in mark_slice_darken. */
+      CAML_TSAN_ANNOTATE_HAPPENS_AFTER(Hp_val(block));
       header_t hd = Hd_val(block);
 
       if (Tag_hd(hd) == Infix_tag) {

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -946,6 +946,9 @@ static void mark_slice_darken(struct mark_stack* stk, value child,
   /* This part of the code is duplicated in do_some_marking for performance
    * reasons.
    * Changes here should probably be reflected in do_some_marking. */
+  /* Annotating an acquire barrier on the header because TSan does not see the
+   * happens-before relationship established by address dependencies with
+   * initializing writes in shared_heap.c allocation (#12894) */
     CAML_TSAN_ANNOTATE_HAPPENS_AFTER(Hp_val(child));
     chd = Hd_val(child);
     if (Tag_hd(chd) == Infix_tag) {
@@ -1007,7 +1010,10 @@ Caml_noinline static intnat do_some_marking(struct mark_stack* stk,
 
       /* This part of the code is a duplicate of mark_slice_darken for
        * performance reasons.
-       * Changes here should probably be reflected here in mark_slice_darken. */
+       * Changes here should probably be reflected here in mark_slice_darken.*/
+      /* Annotating an acquire barrier on the header because TSan does not see
+       * the happens-before relationship established by address dependencies
+       * with initializing writes in shared_heap.c allocation (#12894) */
       CAML_TSAN_ANNOTATE_HAPPENS_AFTER(Hp_val(block));
       header_t hd = Hd_val(block);
 

--- a/runtime/shared_heap.c
+++ b/runtime/shared_heap.c
@@ -253,7 +253,6 @@ static void calc_pool_stats(pool* a, sizeclass sz, struct heap_stats* s)
 }
 
 /* Initialize a pool and its object freelist */
-CAMLno_tsan  /* Disable TSan reports from this function (see #11040) */
 Caml_inline void pool_initialize(pool* r,
                                  sizeclass sz,
                                  caml_domain_state* owner)
@@ -426,7 +425,6 @@ static void* large_allocate(struct caml_heap_state* local, mlsize_t sz) {
   return (char*)a + LARGE_ALLOC_HEADER_SZ;
 }
 
-CAMLno_tsan /* Disable TSan reports from this function (see #11040) */
 value* caml_shared_try_alloc(struct caml_heap_state* local, mlsize_t wosize,
                              tag_t tag, reserved_t reserved)
 {

--- a/runtime/shared_heap.c
+++ b/runtime/shared_heap.c
@@ -455,6 +455,7 @@ value* caml_shared_try_alloc(struct caml_heap_state* local, mlsize_t wosize,
   }
   colour = caml_global_heap_state.MARKED;
   Hd_hp (p) = Make_header_with_reserved(wosize, tag, colour, reserved);
+  CAML_TSAN_ANNOTATE_HAPPENS_BEFORE(p);
 #ifdef DEBUG
   {
     int i;

--- a/runtime/shared_heap.c
+++ b/runtime/shared_heap.c
@@ -453,6 +453,10 @@ value* caml_shared_try_alloc(struct caml_heap_state* local, mlsize_t wosize,
   }
   colour = caml_global_heap_state.MARKED;
   Hd_hp (p) = Make_header_with_reserved(wosize, tag, colour, reserved);
+  /* Annotating a release barrier on `p` because TSan does not see the
+   * happens-before relationship established by address dependencies
+   * between the initializing writes here and the read in major_gc.c
+   * marking (#12894) */
   CAML_TSAN_ANNOTATE_HAPPENS_BEFORE(p);
 #ifdef DEBUG
   {


### PR DESCRIPTION
There had been 2 dataraces reported in `parallel/multicore_systhreads .ml` and `test_issue_11094.ml` between oldify and allocation of the object being oldified.

TSAN logs reported are : 
[`parallel/multicore_systhreads.ml`](https://gist.github.com/Johan511/867fcbf361a9e7ddb3ff2bd0c3c4e5b0)
[`test_issue_11094.ml`](https://gist.github.com/Johan511/6ecc8204f82d2f5ae6fb370ceaaeff35)

Code can be fetched using
```
git fetch https://github.com/Johan511/ocaml e09d63cca9375fce8d2c91d0188591dbe0db142e
git checkout FETCH_HEAD
```


To replicate the datarace
```
git fetch https://github.com/Johan511/ocaml e09d63cca9375fce8d2c91d0188591dbe0db142e
git checkout FETCH_HEAD
./configure --enable-tsan
make -j6
cd testsuite
KEEP_TEST_DIR_ON_SUCCESS=On make one TEST=tests/parallel/multicore_systhreads.ml
```
(datarace is much harder to trigger in `test_issue_11094.ml`)


The datarace is reported because TSAN is unable to realise a happens before (hb) relatioship between the initialising write to a header and the read from it.

The fix uses TSAN's AnnotateHappensBefore and AnnotateHappensAfter functions is annotate the hb relatioship


