### PR TITLE
make Runtime_events.Type.register domain-safe

### DIFF
--- a/otherlibs/runtime_events/runtime_events.ml
+++ b/otherlibs/runtime_events/runtime_events.ml
@@ -206,11 +206,11 @@ module Type = struct
 
   let int = Int
 
-  let next_id = ref 3
+  let next_id = Atomic.make 3
 
   let register ~encode ~decode =
-    incr next_id;
-    Custom { serialize = encode; deserialize = decode; id = !next_id - 1}
+    let id = Atomic.fetch_and_add next_id 1 in
+    Custom { serialize = encode; deserialize = decode; id; }
 
   let id: type a. a t -> int = function
     | Unit -> 0


### PR DESCRIPTION
While looking at #12897 I crossed a domain-safety bug in Runtime_events, here is a fix.
