### PR TITLE
Run the testsuite with ThreadSanitizer on a PR when label run-thread-sanitizer is added

### DIFF
--- a/.github/workflows/tsan.yml
+++ b/.github/workflows/tsan.yml
@@ -1,0 +1,96 @@
+# Build the compiler and run the testsuite with ThreadSanitizer, if PR is
+# labelled with run-thread-sanitizer
+name: Run testsuite with ThreadSanitizer
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+
+# Restrict the GITHUB_TOKEN
+permissions: {}
+
+# https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#concurrency
+# Concurrent workflows are grouped by the PR or branch that triggered them
+# (github.ref) and the name of the workflow (github.workflow). The
+# 'cancel-in-progress' option then make sure that only one workflow is running
+# at a time. This doesn't prevent new jobs from running, rather it cancels
+# already running jobs before scheduling new jobs.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name == 'pull_request' || github.sha }}
+  cancel-in-progress: true
+
+jobs:
+# This job will do the initial build of the compiler (on linux).
+# We then upload the compiler tree as a build artifact to enable re-use in
+# subsequent jobs.
+  build:
+    if: contains(github.event.pull_request.labels.*.name, 'run-thread-sanitizer')
+    runs-on: 'ubuntu-latest'
+    outputs:
+      manual_changed: ${{ steps.manual.outputs.manual_changed }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          persist-credentials: false
+      - name: Install libunwind
+        run: sudo apt install -y libunwind-dev
+      - name: Configure tree
+        run: |
+          MAKE_ARG=-j CONFIG_ARG='--enable-cmm-invariants --enable-dependency-generation --enable-native-toplevel --enable-tsan --enable-ocamltest CFLAGS=-DTSAN_INSTRUMENT_ALL' OCAMLRUNPARAM=b,v=0 bash -xe tools/ci/actions/runner.sh configure
+      - name: Build
+        run: |
+          MAKE_ARG=-j bash -xe tools/ci/actions/runner.sh build
+      - name: Prepare Artifact
+        run: tar --zstd -cf /tmp/sources.tar.zstd .
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: compiler
+          path: /tmp/sources.tar.zstd
+          retention-days: 1
+
+# Testsuite run jobs:
+# normal: Run the full testsuite
+# debug: Run the full testsuite with the debug runtime and minor heap
+#        verification.
+  normal:
+    if: contains(github.event.pull_request.labels.*.name, 'run-thread-sanitizer')
+    name: ${{ matrix.name }}
+    needs: build
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - id: normal
+            name: normal
+            dependencies: libunwind-dev
+          # Running with the debug runtime is disabled until the data races in
+          # it are fixed (see #12902).
+          #- id: debug
+          #  name: debug runtime
+          #  dependencies: libunwind-dev
+    steps:
+      - name: Download Artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: compiler
+      - name: Unpack Artifact
+        run: |
+          tar --zstd -xf sources.tar.zstd
+          rm -f sources.tar.zstd
+      - name: Packages
+        if: matrix.dependencies != ''
+        run: |
+          sudo apt-get update -y && sudo apt-get install -y ${{ matrix.dependencies }}
+      - name: Run the testsuite
+        if: matrix.id == 'normal'
+        # Run testsuite with 30-minute timeout per test
+        run: |
+          TIMEOUT=1800 TSAN_OPTIONS=history_size=6 MAKE_ARG=-j OCAMLRUNPARAM=b,v=0 bash -xe tools/ci/actions/runner.sh test_sequential
+      - name: Run the testsuite (debug runtime)
+        if: matrix.id == 'debug'
+        env:
+          OCAMLRUNPARAM: v=0,V=1
+          USE_RUNTIME: d
+        run: |
+          bash -cxe "TSAN_OPTIONS=history_size=6 SHOW_TIMINGS=1 tools/ci/actions/runner.sh test_sequential"

--- a/Changes
+++ b/Changes
@@ -19,6 +19,11 @@ _______________
 
 ### Tools:
 
+- #12904: Run the testsuite with ThreadSanitizer on a PR when label
+  `run-thread-sanitizer` is added
+  (Olivier Nicole, suggested by Sébastien Hinderer and David Allsopp, review by
+   Gabriel Scherer)
+
 ### Toplevel:
 
 - #12891: Improved styling for initial prompt

--- a/tools/ci/actions/runner.sh
+++ b/tools/ci/actions/runner.sh
@@ -73,11 +73,16 @@ Test () {
   if [ "$1" = "sequential" ]; then
     echo Running the testsuite sequentially
     $MAKE -C testsuite all
-  else
-    echo Running the testsuite
+    cd ..
+  elif [ "$1" = "parallel" ]; then
+    echo Running the testsuite in parallel
     $MAKE -C testsuite parallel
+    cd ..
+  else
+    echo "Error: unexpected argument '$1' to function Test(). " \
+         "It should be 'sequential' or 'parallel'."
+    exit 1
   fi
-  cd ..
 }
 
 # By default, TestPrefix will attempt to run the tests
@@ -173,7 +178,7 @@ BasicCompiler () {
 case $1 in
 configure) Configure;;
 build) Build;;
-test) Test;;
+test) Test parallel;;
 test_sequential) Test sequential;;
 test_prefix) TestPrefix $2;;
 api-docs) API_Docs;;

--- a/tools/ci/actions/runner.sh
+++ b/tools/ci/actions/runner.sh
@@ -70,8 +70,13 @@ Build () {
 }
 
 Test () {
-  echo Running the testsuite
-  $MAKE -C testsuite parallel
+  if [ "$1" = "sequential" ]; then
+    echo Running the testsuite sequentially
+    $MAKE -C testsuite all
+  else
+    echo Running the testsuite
+    $MAKE -C testsuite parallel
+  fi
   cd ..
 }
 
@@ -169,6 +174,7 @@ case $1 in
 configure) Configure;;
 build) Build;;
 test) Test;;
+test_sequential) Test sequential;;
 test_prefix) TestPrefix $2;;
 api-docs) API_Docs;;
 install) Install;;


### PR DESCRIPTION
This PR proposes the possibility to run the full testsuite with ThreadSanitizer on any PR by tagging it with `run-thread-sanitizer`.

This is a good compromise between running TSan on all PRs and never running it. This way, the label can be added only to PRs that could use the added confidence. The TSan CI takes roughly 45 minutes.

Ideally, this job would run the full testsuite with both the normal runtime and the debug runtime, but for now I have commented out the latter, because of the races reported in #12902 which would generate a lot of noise.