### PR TITLE
Fix data race in scan_native_globals

### DIFF
--- a/runtime/globroots.c
+++ b/runtime/globroots.c
@@ -191,7 +191,7 @@ void caml_register_dyn_globals(void **globals, int nglobals) {
 static void scan_native_globals(scanning_action f, void* fdata)
 {
   int i, j;
-  static link* dyn_globals;
+  link* dyn_globals;
   value* glob;
   link* lnk;
 


### PR DESCRIPTION
Currently on rare occasions, the function `scan_native_globals` can run concurrently with itself and race on the `static` local variable `dyn_globals`. (Reported in #12902)

This variable is used to cache the current value of a global, but it is unclear to @fabbing and I why the variable is `static`, since it is overwritten on each function invocation. Removing the `static` qualifier should get rid of the race without changing the expected semantics.