### PR TITLE
Fix overflow in ocamllex's table backend

### DIFF
--- a/Changes
+++ b/Changes
@@ -453,6 +453,10 @@ OCaml 5.2.0
 - #12744: ocamltest: run tests in recursive subdirs more eagerly
   (Nick Roberts, review by Nicolás Ojeda Bär)
 
+- #12901, 12908: ocamllex: add overflow checks to prevent generating incorrect
+  lexers; use unsigned numbers in the table encoding when possible.
+  (Vincent Laviron, report by Edwin Török, review by Xavier Leroy)
+
 ### Manual and documentation:
 
 - #12338: clarification of the documentation of process related function in

--- a/runtime/lexing.c
+++ b/runtime/lexing.c
@@ -54,8 +54,12 @@ struct lexing_table {
 #define Short(tbl,n) \
   (*((unsigned char *)((tbl) + (n) * 2)) + \
           (*((signed char *)((tbl) + (n) * 2 + 1)) << 8))
+#define UShort(tbl,n) \
+  (*((unsigned char *)((tbl) + (n) * 2)) + \
+          (*((unsigned char *)((tbl) + (n) * 2 + 1)) << 8))
 #else
 #define Short(tbl,n) (((short *)(tbl))[(n)])
+#define UShort(tbl,n) (((unsigned short *)(tbl))[(n)])
 #endif
 
 CAMLprim value caml_lex_engine(value vtbl, value start_state, value vlexbuf)
@@ -176,7 +180,7 @@ CAMLprim value caml_new_lex_engine(value vtbl, value start_state,
     /* Lookup base address or action number for current state */
     base = Short(tbl->lex_base, state);
     if (base < 0) {
-      int pc_off = Short(tbl->lex_base_code, state) ;
+      int pc_off = UShort(tbl->lex_base_code, state) ;
       run_tag(Bp_val(tbl->lex_code) + pc_off, lexbuf->lex_mem);
       /*      fprintf(stderr,"Perform: %d\n",-base-1) ; */
       return Val_int(-base-1);
@@ -184,7 +188,7 @@ CAMLprim value caml_new_lex_engine(value vtbl, value start_state,
     /* See if it's a backtrack point */
     backtrk = Short(tbl->lex_backtrk, state);
     if (backtrk >= 0) {
-      int pc_off =  Short(tbl->lex_backtrk_code, state);
+      int pc_off =  UShort(tbl->lex_backtrk_code, state);
       run_tag(Bp_val(tbl->lex_code) + pc_off, lexbuf->lex_mem);
       lexbuf->lex_last_pos = lexbuf->lex_curr_pos;
       lexbuf->lex_last_action = Val_int(backtrk);
@@ -218,12 +222,12 @@ CAMLprim value caml_new_lex_engine(value vtbl, value start_state,
       }
     }else{
       /* If some transition, get and perform memory moves */
-      int base_code = Short(tbl->lex_base_code, pstate) ;
+      int base_code = UShort(tbl->lex_base_code, pstate) ;
       int pc_off ;
       if (Short(tbl->lex_check_code, base_code + c) == pstate)
-        pc_off = Short(tbl->lex_trans_code, base_code + c) ;
+        pc_off = UShort(tbl->lex_trans_code, base_code + c) ;
       else
-        pc_off = Short(tbl->lex_default_code, pstate) ;
+        pc_off = UShort(tbl->lex_default_code, pstate) ;
       if (pc_off > 0)
         run_mem(Bp_val(tbl->lex_code) + pc_off, lexbuf->lex_mem,
                 lexbuf->lex_curr_pos) ;


### PR DESCRIPTION
Fixes #12901 by raising a proper error when `ocamllex` produces an automata too big to be properly encoded in the table format.

I've taken the opportunity to also change the interpretation of some of the numbers from signed shorts to unsigned shorts, when it makes sense, as it allows to represent bigger tables (up to 2^16 bytes instead of 2^15).
I can discard this change or split it into a separate commit if it helps reviewing. It does make the standalone lexer examples from #12901 pass, although I don't know if the original case is small enough for that.