### PR TITLE
Reorganise how MKEXE_VIA_CC is built to make it correct for MSVC

### DIFF
--- a/Changes
+++ b/Changes
@@ -47,6 +47,10 @@ _______________
 
 ### Build system:
 
+- #12909: Reorganise how MKEXE_VIA_CC is built to make it correct for MSVC by
+  grouping all the linker flags at the end of the C compiler commandline
+  (David Allsopp and Samuel Hym, review by Nicolás Ojeda Bär)
+
 ### Bug fixes:
 
 

--- a/Makefile.build_config.in
+++ b/Makefile.build_config.in
@@ -86,10 +86,9 @@ OC_NATIVE_CFLAGS=@native_cflags@
 # our own symbols):
 OC_LDFLAGS=@oc_ldflags@
 OC_DLL_LDFLAGS=@oc_dll_ldflags@
-OC_EXE_LDFLAGS=@oc_exe_ldflags@
 
 MKEXE_VIA_CC=\
-  $(CC) $(OC_EXE_LDFLAGS) $(OC_CFLAGS) $(CFLAGS) @mkexe_via_cc_ldflags@
+  $(CC) $(OC_CFLAGS) $(CFLAGS) @mkexe_via_cc_ldflags@ @mkexe_via_cc_extra_cmd@
 
 # Which tool to use to display differences between files
 DIFF=@DIFF@

--- a/configure
+++ b/configure
@@ -864,7 +864,6 @@ ocamlc_cppflags
 ocamlc_cflags
 native_ldflags
 cclibs
-oc_exe_ldflags
 oc_dll_ldflags
 oc_ldflags
 oc_cppflags
@@ -873,6 +872,7 @@ tsan
 oc_cflags
 toolchain
 ccomptype
+mkexe_via_cc_extra_cmd
 mkexe_via_cc_ldflags
 mkexe_extra_flags
 mkexedebugflag
@@ -20512,19 +20512,12 @@ fi
   mkdll_exp="$mkdll_exp $mkdll_ldflags_exp"
   mkmaindll="$mkmaindll $mkdll_ldflags_exp"
   mkmaindll_exp="$mkmaindll_exp $mkdll_ldflags_exp"
-  # Do similarly with $mkexe_via_cc_ldflags_prefix, but this is only needed for
-  # the msvc ports.
-  if test -n "$mkexe_via_cc_ldflags_prefix"
+  mkexe_via_cc_ldflags="${mkexe_via_cc_ldflags_prefix}"
+  if test -n "${oc_exe_ldflags}"
 then :
-
-    mkexe_via_cc_ldflags=\
-"\$(addprefix ${mkexe_via_cc_ldflags_prefix},\$(OC_LDFLAGS) \$(LDFLAGS))"
-
-else $as_nop
-
-    mkexe_via_cc_ldflags='$(OC_LDFLAGS) $(LDFLAGS)'
-
+  mkexe_via_cc_ldflags="${mkexe_via_cc_ldflags}${oc_exe_ldflags} "
 fi
+  mkexe_via_cc_ldflags="${mkexe_via_cc_ldflags}\$(OC_LDFLAGS) \$(LDFLAGS)"
   # cl requires linker flags after the objects.
   if test "$ccomptype" = 'msvc'
 then :
@@ -20533,10 +20526,6 @@ then :
 else $as_nop
   mkexe_via_cc_ldflags=\
 "$mkexe_via_cc_ldflags \$(OUTPUTEXE)\$(1) \$(2)"
-fi
-  if test -n "$mkexe_via_cc_extra_cmd"
-then :
-  mkexe_via_cc_ldflags="$mkexe_via_cc_ldflags $mkexe_via_cc_extra_cmd"
 fi
 
 

--- a/configure.ac
+++ b/configure.ac
@@ -156,6 +156,7 @@ AC_SUBST([mkexe_exp])
 AC_SUBST([mkexedebugflag])
 AC_SUBST([mkexe_extra_flags])
 AC_SUBST([mkexe_via_cc_ldflags])
+AC_SUBST([mkexe_via_cc_extra_cmd])
 AC_SUBST([ccomptype])
 AC_SUBST([toolchain])
 AC_SUBST([oc_cflags])
@@ -164,7 +165,6 @@ AC_SUBST([tsan_native_runtime_c_sources])
 AC_SUBST([oc_cppflags])
 AC_SUBST([oc_ldflags])
 AC_SUBST([oc_dll_ldflags])
-AC_SUBST([oc_exe_ldflags])
 AC_SUBST([cclibs])
 AC_SUBST([native_ldflags])
 AC_SUBST([ocamlc_cflags])
@@ -2575,22 +2575,16 @@ ${mkdll_ldflags}"
   mkdll_exp="$mkdll_exp $mkdll_ldflags_exp"
   mkmaindll="$mkmaindll $mkdll_ldflags_exp"
   mkmaindll_exp="$mkmaindll_exp $mkdll_ldflags_exp"
-  # Do similarly with $mkexe_via_cc_ldflags_prefix, but this is only needed for
-  # the msvc ports.
-  AS_IF([test -n "$mkexe_via_cc_ldflags_prefix"],[
-    mkexe_via_cc_ldflags=\
-"\$(addprefix ${mkexe_via_cc_ldflags_prefix},\$(OC_LDFLAGS) \$(LDFLAGS))"
-  ],[
-    mkexe_via_cc_ldflags='$(OC_LDFLAGS) $(LDFLAGS)'
-  ])
+  mkexe_via_cc_ldflags="${mkexe_via_cc_ldflags_prefix}"
+  AS_IF([test -n "${oc_exe_ldflags}"],
+    [mkexe_via_cc_ldflags="${mkexe_via_cc_ldflags}${oc_exe_ldflags} "])
+  mkexe_via_cc_ldflags="${mkexe_via_cc_ldflags}\$(OC_LDFLAGS) \$(LDFLAGS)"
   # cl requires linker flags after the objects.
   AS_IF([test "$ccomptype" = 'msvc'],
     [mkexe_via_cc_ldflags=\
 "\$(OUTPUTEXE)\$(1) \$(2) $mkexe_via_cc_ldflags"],
     [mkexe_via_cc_ldflags=\
 "$mkexe_via_cc_ldflags \$(OUTPUTEXE)\$(1) \$(2)"])
-  AS_IF([test -n "$mkexe_via_cc_extra_cmd"],
-    [mkexe_via_cc_ldflags="$mkexe_via_cc_ldflags $mkexe_via_cc_extra_cmd"])
 ])
 
 AC_OUTPUT


### PR DESCRIPTION
This PR is joint work with @dra27. It brings changes that are required to restore the MSVC port and should make no difference to other ports.

MSVC cl command-line option `/link` allows to pass options to the linker using the following scheme:
```
cl [cl arguments...] /link [link arguments...]
```

In order to accomodate all our supported C compilers, this requires a reshuffling of how the MKEXE_VIA_CC command line is built so that `$oc_exe_ldflags` are indeed inserted after the `/link` for cl. This commit also ensures that `/link` (`$mkexe_via_cc_ldflags_prefix`) is inserted exactly once on the cl command line (rather than once per argument, which is how flexlink expects these arguments). Finally, this commit moves the usage of `mkexe_via_cc_extra_cmd` (which is used only for the MSVC toolchain, to inject the manifest in the executable) to the MKEXE_VIA_CC variable instead of hiding it into `mkexe_via_cc_ldflags` where it doesn't belong.

For non-MSVC ports, this commit:
- removes the `$(OC_EXE_LDFLAGS)` Makefile variable as it is no longer used,
- reorders the `${oc_exe_ldflags}` after the `$(CFLAGS)`,
all which are hopefully innocuous enough.