### PR TITLE
Disable control flow integrity on OpenBSD

### DIFF
--- a/Changes
+++ b/Changes
@@ -2314,6 +2314,10 @@ OCaml 4.14 maintenance version
   (Xavier Leroy and Anil Madhavapeddy, review by Anil Madhavapeddy and
   Sébastien Hinderer)
 
+- #12903: Disable control flow integrity on OpenBSD >= 7.4 to avoid
+  illegal instruction errors on certain CPUs.
+  (Michael Hendricks, review by Miod Vallat)
+
 ### Bug fixes:
 
 - #12878: fix incorrect treatment of injectivity for private recursive types.

--- a/configure
+++ b/configure
@@ -15429,6 +15429,17 @@ case $host in #(
      ;;
 esac
 
+# Disable control flow integrity
+
+case $host in #(
+  *-*-openbsd7.[4-9]|*-*-openbsd[89].*) :
+    oc_ldflags="$oc_ldflags -Wl,-z,nobtcfi"
+     natdynlinkopts="$natdynlinkopts -Wl,-z,nobtcfi" ;; #(
+  *) :
+     ;;
+esac
+
+
 # Configure native dynlink
 
 natdynlink=false

--- a/configure.ac
+++ b/configure.ac
@@ -1211,6 +1211,14 @@ AS_CASE([$host],
     [oc_ldflags="$oc_ldflags -Wl,--no-execute-only"
      natdynlinkopts="$natdynlinkopts -Wl,--no-execute-only"])
 
+# Disable control flow integrity
+
+AS_CASE([$host],
+  [[*-*-openbsd7.[4-9]|*-*-openbsd[89].*]],
+    [oc_ldflags="$oc_ldflags -Wl,-z,nobtcfi"
+     natdynlinkopts="$natdynlinkopts -Wl,-z,nobtcfi"])
+
+
 # Configure native dynlink
 
 natdynlink=false


### PR DESCRIPTION
This patch lets me build OCaml on all my OpenBSD machines, and still works for me on my macOS, Alpine, Ubuntu, and Debian machines.

I chose to enable `nobtcfi` only on OpenBSD 7.4 or later because my reading of the change logs suggest that's the only place it's relevant.  I don't have an OpenBSD 7.3 machine with a processor that would let me verify for certain.

Fixes #12903