### PR TITLE
Save and restore univar_pairs instead of clobbering

### DIFF
--- a/Changes
+++ b/Changes
@@ -115,6 +115,10 @@ _______________
   command-line of the toplevel.
   (Nicolás Ojeda Bär, review by Florian Angeletti, report by Daniel Bünzli)
 
+- #12910, #12920: Fix an unsound interaction between first-class modules
+  and polymorphic records by saving and restoring univar_pairs.
+  (Stephen Dolan, review by Gabriel Scherer, report by Jeremy Yallop)
+
 - #12924, #12930: Rework package constraint checking to improve interaction with
   immediacy
   (Chris Casinghino and Florian Angeletti, review by Florian Angeletti and

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -5080,7 +5080,10 @@ let subtype env ty1 ty2 =
       List.iter
         (function (trace0, t1, t2, pairs) ->
            try unify_pairs env t1 t2 pairs with Unify {trace} ->
-             subtype_error ~env ~trace:trace0 ~unification_trace:(List.tl trace))
+           subtype_error
+             ~env
+             ~trace:trace0
+             ~unification_trace:(List.tl trace))
         (List.rev cstrs))
 
                               (*******************)


### PR DESCRIPTION
#12910 demonstrates a soundness issue caused by several functions in `ctype.ml` (e.g. `Ctype.equal`) incorrectly clobbering `univar_pairs`. This patch has two changes to resolve this problem:

  1. Instead of overwriting, `univar_pairs` is now temporarily changed and restored afterwards, so e.g. univars remain available across a use of a `Ctype.equal`
  2. During `unify_univars`, if a univar is found that is missing from `univar_pairs`, the compiler issues a `Misc.fatal_error`

Previously, the clobbering of `univar_pairs` caused `mcomp` to incorrectly report that two identical types were incompatible, since univar_pairs was overwritten, and `unify_univars` reported this situation as "not unifiable".

Change (1) above is sufficient to fix the cases found by @yallop, as `univar_pairs` is no longer clobbered. Change (2) alone turns the soundness issue into a compiler failure, which is less bad. I propose doing both, since I'm not completely convinced that it's correct to reset `univar_pairs` to the empty list in all the places the compiler does so (even temporarily), and a `Misc.fatal_error` is better than a silent soundness bug.