### PR TITLE
ocamldep documentation: fix example makefile and provide more context

### DIFF
--- a/manual/src/cmds/ocamldep.etex
+++ b/manual/src/cmds/ocamldep.etex
@@ -3,10 +3,12 @@
 
 The "ocamldep" command scans a set of OCaml source files
 (".ml" and ".mli" files) for references to external compilation units,
-and outputs dependency lines in a format suitable for the "make"
-utility. This ensures that "make" will compile the source files in the
-correct order, and recompile those files that need to when a source
-file is modified.
+and outputs dependency lines in a subset of "make" syntax understood by
+make and other build tools, such as \href{https://dune.build/}{dune},
+\href{https://ninja-build.org/manual.html#ref_headers}{ninja}, and
+\href{https://buck2.build/docs/rule_authors/dynamic_dependencies/}{buck2}.
+The dependency information is used by build tools to compile source fles in the correct order,
+and recompile those files that need to when a source file is modified.
 
 The typical usage is:
 \begin{alltt}
@@ -14,7 +16,7 @@ The typical usage is:
 \end{alltt}
 where "*.mli *.ml" expands to all source files in the current
 directory and ".depend" is the file that should contain the
-dependencies. (See below for a typical "Makefile".)
+dependencies. (See below for an example "Makefile".)
 
 Dependencies are generated both for compiling with the bytecode
 compiler "ocamlc" and with the native-code compiler "ocamlopt".
@@ -149,55 +151,64 @@ Display a short usage summary and exit.
 %
 \end{options}
 
-\section{s:ocamldep-makefile}{A typical Makefile}
+\section{s:ocamldep-makefile}{A Makefile}
 
-Here is a template "Makefile" for a OCaml program.
+Here is an example "Makefile" for a OCaml program.
+
+Note that it is recommended to use
+higher-level build tools like \href{https://dune.build/}{dune} rather than make.
 
 \begin{verbatim}
 OCAMLC=ocamlc
 OCAMLOPT=ocamlopt
 OCAMLDEP=ocamldep
-INCLUDES=                 # all relevant -I options here
-OCAMLFLAGS=$(INCLUDES)    # add other options for ocamlc here
+INCLUDES=  # all relevant -I options here
+OCAMLFLAGS=$(INCLUDES)	# add other options for ocamlc here
 OCAMLOPTFLAGS=$(INCLUDES) # add other options for ocamlopt here
 
 # prog1 should be compiled to bytecode, and is composed of three
 # units: mod1, mod2 and mod3.
 
-# The list of object files for prog1
+# The list of object files for prog1 in (manually maintained) link order.
+# The build will fail if (for example) Mod1 depends on Mod2.
+# Note that the link order corresponds to initialization order of modules, and thus
+# different ordering can lead to different program behavior.
 PROG1_OBJS=mod1.cmo mod2.cmo mod3.cmo
 
 prog1: $(PROG1_OBJS)
-        $(OCAMLC) -o prog1 $(OCAMLFLAGS) $(PROG1_OBJS)
+		$(OCAMLC) -o prog1 $(OCAMLFLAGS) $(PROG1_OBJS)
 
 # prog2 should be compiled to native-code, and is composed of two
 # units: mod4 and mod5.
 
-# The list of object files for prog2
+# The list of object files for prog2 in (manually maintained) link order
+# This link order is incorrect if Mod4 depends on Mod5
 PROG2_OBJS=mod4.cmx mod5.cmx
 
 prog2: $(PROG2_OBJS)
-        $(OCAMLOPT) -o prog2 $(OCAMLFLAGS) $(PROG2_OBJS)
+		$(OCAMLOPT) -o prog2 $(OCAMLFLAGS) $(PROG2_OBJS)
 
 # Common rules
 
 %.cmo: %.ml
-        $(OCAMLC) $(OCAMLFLAGS) -c $<
+		$(OCAMLC) $(OCAMLFLAGS) -c $<
 
 %.cmi: %.mli
-        $(OCAMLC) $(OCAMLFLAGS) -c $<
+		$(OCAMLC) $(OCAMLFLAGS) -c $<
 
 %.cmx: %.ml
-        $(OCAMLOPT) $(OCAMLOPTFLAGS) -c $<
+		$(OCAMLOPT) $(OCAMLOPTFLAGS) -c $<
 
 # Clean up
 clean:
-        rm -f prog1 prog2
-        rm -f *.cm[iox]
+		rm -f prog1 prog2
+		rm -f *.cm[iox]
+		rm -f *.o
+		rm .depend
 
 # Dependencies
-depend:
-        $(OCAMLDEP) $(INCLUDES) *.mli *.ml > .depend
+.depend:
+		$(OCAMLDEP) $(INCLUDES) *.mli *.ml > .depend
 
 include .depend
 \end{verbatim}


### PR DESCRIPTION
Fix #12925

- make the makefile able to produce binaries:
  - tabs instead of spaces
  - 'clean' cleans everything
- clarify the relationship between ocamldep and make:
  - Point out where in the makefile the dependency graph must be maintained manually. This is to help future readers from the same misunderstanding I had, which was that ocamldep enabled writing a makefile without having to hard-code the module the dependency structure
the recommended way to build OCaml
  - ocamldep outputs dependency lines in a subset of makefile syntax that can be consumed by multiple tools.

Steps to check that the updated makefile works correctly:

```
echo 'let value = "hello1"' > mod1.ml
echo 'let () = print_endline Mod1.value' > mod2.ml
echo 'let value = "hello1"' > mod2.ml
echo '' > mod3.ml
echo 'let value = "hello2"' > mod4.ml
echo 'let () = print_endline Mod4.value' > mod5.ml
# should print "hello1"
make prog1 && ./prog1
# should print "hello2"
make prog2 && ./prog2
make clean
 # should be empty
ls -I '*.ml' -I makefile
```

>  Note: I wasn't able to check that the TEX still compiles and renders correctly because `make` in the `manual` directory fails for me on Mac on trunk 