### PR TITLE
Rework package constraint checking to improve interaction with immediacy

### DIFF
--- a/.depend
+++ b/.depend
@@ -1751,6 +1751,7 @@ typing/typemod.cmo : \
     typing/typetexp.cmi \
     typing/types.cmi \
     typing/typedtree.cmi \
+    typing/typedecl_immediacy.cmi \
     typing/typedecl.cmi \
     typing/typecore.cmi \
     typing/typeclass.cmi \
@@ -1787,6 +1788,7 @@ typing/typemod.cmx : \
     typing/typetexp.cmx \
     typing/types.cmx \
     typing/typedtree.cmx \
+    typing/typedecl_immediacy.cmx \
     typing/typedecl.cmx \
     typing/typecore.cmx \
     typing/typeclass.cmx \

--- a/Changes
+++ b/Changes
@@ -78,7 +78,8 @@ _______________
 
 - #12924, #12930: Rework package constraint checking to improve interaction with
   immediacy
-  (Chris Casinghino, review by Florian Angeletti and Richard Eisenberg)
+  (Chris Casinghino and Florian Angeletti, review by Florian Angeletti and
+   Richard Eisenberg)
 
 OCaml 5.2.0
 ------------

--- a/Changes
+++ b/Changes
@@ -76,6 +76,10 @@ _______________
   command-line of the toplevel.
   (Nicolás Ojeda Bär, review by Florian Angeletti, report by Daniel Bünzli)
 
+- #12924, #12930: Rework package constraint checking to improve interaction with
+  immediacy
+  (Chris Casinghino, review by Richard Eisenberg)
+
 OCaml 5.2.0
 ------------
 

--- a/Changes
+++ b/Changes
@@ -78,7 +78,7 @@ _______________
 
 - #12924, #12930: Rework package constraint checking to improve interaction with
   immediacy
-  (Chris Casinghino, review by Richard Eisenberg)
+  (Chris Casinghino, review by Florian Angeletti and Richard Eisenberg)
 
 OCaml 5.2.0
 ------------

--- a/testsuite/tests/typing-modules-bugs/pr6293_bad.compilers.reference
+++ b/testsuite/tests/typing-modules-bugs/pr6293_bad.compilers.reference
@@ -4,7 +4,7 @@ File "pr6293_bad.ml", line 10, characters 18-37:
 Error: In this "with" constraint, the new definition of "t"
        does not match its original definition in the constrained signature:
        Type declarations do not match:
-         type t
+         type t = int
        is not included in
          type t = { a : int; b : int; }
        The first is abstract, but the second is a record.

--- a/testsuite/tests/typing-modules/package_constraint.ml
+++ b/testsuite/tests/typing-modules/package_constraint.ml
@@ -137,7 +137,6 @@ Error: In this "with" constraint, the new definition of "t"
 (* When using a package with constraint to give an abstract type a definition
    that is immediate, that immediacy information should be usable after
    unpacking. *)
-(* This is fixed in a subsequent commit. *)
 module type S = sig
   type t
 end
@@ -151,9 +150,7 @@ end;;
 [%%expect{|
 module type S = sig type t end
 type m = (module S with type t = int)
-Line 9, characters 2-28:
-9 |   type t = M.t [@@immediate]
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: Types marked with the immediate attribute must be non-pointer types
-       like "int" or "bool".
+module F :
+  functor (X : sig val x : m end) ->
+    sig module M : sig type t = int end type t = M.t [@@immediate] end
 |}];;

--- a/testsuite/tests/typing-modules/package_constraint.ml
+++ b/testsuite/tests/typing-modules/package_constraint.ml
@@ -1,0 +1,177 @@
+(* TEST
+ expect;
+*)
+
+(* You may constrain abstract types in packages. *)
+module type S = sig
+  type t
+end
+
+type m = (module S with type t = int);;
+[%%expect{|
+module type S = sig type t end
+type m = (module S with type t = int)
+|}];;
+
+(* You may use variables in the current environment in the new definitions. *)
+module type S = sig
+  type t
+end
+
+type 'a m = (module S with type t = 'a);;
+[%%expect{|
+module type S = sig type t end
+type 'a m = (module S with type t = 'a)
+|}];;
+
+(* It works with non-trivial paths. *)
+module type S = sig
+  module M : sig
+    type t
+  end
+end
+
+type m = (module S with type M.t = int)
+[%%expect{|
+module type S = sig module M : sig type t end end
+type m = (module S with type M.t = int)
+|}];;
+
+(* It should respect immediacy - [m1] should typecheck but not [m2]. *)
+(* This is fixed in subsequent commit. *)
+module type S = sig
+  type t [@@immediate]
+end
+
+type m1 = (module S with type t = int)
+type m2 = (module S with type t = string);;
+[%%expect{|
+module type S = sig type t [@@immediate] end
+Line 5, characters 10-38:
+5 | type m1 = (module S with type t = int)
+              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: In this "with" constraint, the new definition of "t"
+       does not match its original definition in the constrained signature:
+       Type declarations do not match:
+         type t
+       is not included in
+         type t [@@immediate]
+       The first is not an immediate type.
+|}];;
+
+(* You may not constrain types with a manifest in a package *)
+module type S = sig
+  type t = int
+end
+
+type m = (module S with type t = string);;
+[%%expect{|
+module type S = sig type t = int end
+Line 5, characters 9-40:
+5 | type m = (module S with type t = string);;
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: In this "with" constraint, the new definition of "t"
+       does not match its original definition in the constrained signature:
+       Type declarations do not match: type t is not included in type t = int
+       The type "t/2" is not equal to the type "int"
+       Line 2, characters 2-14:
+         Definition of type "t"
+       Line 5, characters 9-40:
+         Definition of type "t/2"
+|}];;
+
+(* Even if your constraint would be satisfied. *)
+(* It would be nice if this worked. *)
+module type S = sig
+  type t = int
+end
+
+type m = (module S with type t = int);;
+[%%expect{|
+module type S = sig type t = int end
+Line 5, characters 9-37:
+5 | type m = (module S with type t = int);;
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: In this "with" constraint, the new definition of "t"
+       does not match its original definition in the constrained signature:
+       Type declarations do not match: type t is not included in type t = int
+       The type "t/2" is not equal to the type "int"
+       Line 2, characters 2-14:
+         Definition of type "t"
+       Line 5, characters 9-37:
+         Definition of type "t/2"
+|}];;
+
+(* And even if the manifest is not obvious in the original definition. *)
+module M = struct
+  type t
+end
+
+module type S = sig
+  module P = M
+end
+
+type m = (module S with type P.t = int);;
+[%%expect{|
+module M : sig type t end
+module type S = sig module P = M end
+Line 9, characters 9-39:
+9 | type m = (module S with type P.t = int);;
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: In this "with" constraint, the new definition of "P.t"
+       does not match its original definition in the constrained signature:
+       Type declarations do not match: type t is not included in type t = M.t
+       The type "t/2" is not equal to the type "M.t"
+       Line 2, characters 2-8:
+         Definition of type "t"
+       Line 9, characters 9-39:
+         Definition of type "t/2"
+|}];;
+
+(* If writing a package constraint in a mutually recursive group of type decls,
+   checking that the constraint's immediacy may not rely on the definitions of
+   other elements of the mutually recursive group. *)
+(* It would be nice if this worked. *)
+module type S = sig
+  type t [@@immediate]
+end
+
+type t1 = int
+and t2 = (module S with type t = t1);;
+[%%expect{|
+module type S = sig type t [@@immediate] end
+Line 6, characters 9-36:
+6 | and t2 = (module S with type t = t1);;
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: In this "with" constraint, the new definition of "t"
+       does not match its original definition in the constrained signature:
+       Type declarations do not match:
+         type t
+       is not included in
+         type t [@@immediate]
+       The first is not an immediate type.
+|}];;
+
+(* When using a package with constraint to give an abstract type a definition
+   that is immediate, that immediacy information should be usable after
+   unpacking. *)
+(* This is fixed in a subsequent commit. *)
+module type S = sig
+  type t
+end
+
+type m = (module S with type t = int)
+
+module F (X : sig val x : m end) = struct
+  module M = (val X.x)
+  type t = M.t [@@immediate]
+end;;
+[%%expect{|
+module type S = sig type t end
+type m = (module S with type t = int)
+Line 9, characters 2-28:
+9 |   type t = M.t [@@immediate]
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: Types marked with the immediate attribute must be non-pointer types
+       like "int" or "bool".
+|}];;

--- a/testsuite/tests/typing-modules/package_constraint.ml
+++ b/testsuite/tests/typing-modules/package_constraint.ml
@@ -196,3 +196,46 @@ Line 13, characters 12-54:
 Error: In the constrained signature, type "t" is defined to be "[< `A | `B ]".
        Package "with" constraints may only be used on abstract types.
 |}]
+
+(* More row type examples to consider, if we ever start allowing package type
+   constraints to replace compatible manifests. *)
+module type Private_row = sig
+  type t = private [< `A ]
+end
+
+type t1 = (module Private_row with type t = [ `A ])
+[%%expect{|
+module type Private_row = sig type t = private [< `A ] end
+Line 5, characters 10-51:
+5 | type t1 = (module Private_row with type t = [ `A ])
+              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: In the constrained signature, type "t" is defined to be "[< `A ]".
+       Package "with" constraints may only be used on abstract types.
+|}]
+
+type t2 = (module Private_row with type t = [< `A ])
+[%%expect{|
+Line 1, characters 10-52:
+1 | type t2 = (module Private_row with type t = [< `A ])
+              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: In the constrained signature, type "t" is defined to be "[< `A ]".
+       Package "with" constraints may only be used on abstract types.
+|}]
+
+type 'a t3 = (module Private_row with type t = [< `A ]) as 'a
+[%%expect{|
+Line 1, characters 13-55:
+1 | type 'a t3 = (module Private_row with type t = [< `A ]) as 'a
+                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: In the constrained signature, type "t" is defined to be "[< `A ]".
+       Package "with" constraints may only be used on abstract types.
+|}]
+
+type 'a t4 = (module Private_row with type t = [< `A ] as 'a)
+[%%expect{|
+Line 1, characters 13-61:
+1 | type 'a t4 = (module Private_row with type t = [< `A ] as 'a)
+                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: In the constrained signature, type "t" is defined to be "[< `A ]".
+       Package "with" constraints may only be used on abstract types.
+|}]

--- a/testsuite/tests/typing-modules/package_constraint.ml
+++ b/testsuite/tests/typing-modules/package_constraint.ml
@@ -154,3 +154,18 @@ module F :
   functor (X : sig val x : m end) ->
     sig module M : sig type t = int end type t = M.t [@@immediate] end
 |}];;
+
+(* Checking such a constraint may require expanding definitions from the module
+   being updated. *)
+module type S = sig
+  module type S1 = sig
+    type t
+  end
+  module M : S1
+end
+
+type t = (module S with type M.t = int)
+[%%expect{|
+module type S = sig module type S1 = sig type t end module M : S1 end
+type t = (module S with type M.t = int)
+|}];;

--- a/testsuite/tests/typing-modules/package_constraint.ml
+++ b/testsuite/tests/typing-modules/package_constraint.ml
@@ -38,7 +38,6 @@ type m = (module S with type M.t = int)
 |}];;
 
 (* It should respect immediacy - [m1] should typecheck but not [m2]. *)
-(* This is fixed in subsequent commit. *)
 module type S = sig
   type t [@@immediate]
 end
@@ -47,13 +46,14 @@ type m1 = (module S with type t = int)
 type m2 = (module S with type t = string);;
 [%%expect{|
 module type S = sig type t [@@immediate] end
-Line 5, characters 10-38:
-5 | type m1 = (module S with type t = int)
-              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+type m1 = (module S with type t = int)
+Line 6, characters 10-41:
+6 | type m2 = (module S with type t = string);;
+              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: In this "with" constraint, the new definition of "t"
        does not match its original definition in the constrained signature:
        Type declarations do not match:
-         type t
+         type t = string
        is not included in
          type t [@@immediate]
        The first is not an immediate type.
@@ -70,14 +70,8 @@ module type S = sig type t = int end
 Line 5, characters 9-40:
 5 | type m = (module S with type t = string);;
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: In this "with" constraint, the new definition of "t"
-       does not match its original definition in the constrained signature:
-       Type declarations do not match: type t is not included in type t = int
-       The type "t/2" is not equal to the type "int"
-       Line 2, characters 2-14:
-         Definition of type "t"
-       Line 5, characters 9-40:
-         Definition of type "t/2"
+Error: In the constrained signature, type "t" is defined to be "int".
+       Package "with" constraints may only be used on abstract types.
 |}];;
 
 (* Even if your constraint would be satisfied. *)
@@ -92,14 +86,8 @@ module type S = sig type t = int end
 Line 5, characters 9-37:
 5 | type m = (module S with type t = int);;
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: In this "with" constraint, the new definition of "t"
-       does not match its original definition in the constrained signature:
-       Type declarations do not match: type t is not included in type t = int
-       The type "t/2" is not equal to the type "int"
-       Line 2, characters 2-14:
-         Definition of type "t"
-       Line 5, characters 9-37:
-         Definition of type "t/2"
+Error: In the constrained signature, type "t" is defined to be "int".
+       Package "with" constraints may only be used on abstract types.
 |}];;
 
 (* And even if the manifest is not obvious in the original definition. *)
@@ -118,14 +106,8 @@ module type S = sig module P = M end
 Line 9, characters 9-39:
 9 | type m = (module S with type P.t = int);;
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: In this "with" constraint, the new definition of "P.t"
-       does not match its original definition in the constrained signature:
-       Type declarations do not match: type t is not included in type t = M.t
-       The type "t/2" is not equal to the type "M.t"
-       Line 2, characters 2-8:
-         Definition of type "t"
-       Line 9, characters 9-39:
-         Definition of type "t/2"
+Error: In the constrained signature, type "P.t" is defined to be "M.t".
+       Package "with" constraints may only be used on abstract types.
 |}];;
 
 (* If writing a package constraint in a mutually recursive group of type decls,
@@ -146,7 +128,7 @@ Line 6, characters 9-36:
 Error: In this "with" constraint, the new definition of "t"
        does not match its original definition in the constrained signature:
        Type declarations do not match:
-         type t
+         type t = t1
        is not included in
          type t [@@immediate]
        The first is not an immediate type.

--- a/typing/printtyp.ml
+++ b/typing/printtyp.ml
@@ -497,6 +497,10 @@ let rec raw_type ppf ty =
       ty.scope raw_type_desc ty.desc
   end
 and raw_type_list tl = raw_list raw_type tl
+and raw_lid_type_list tl =
+  raw_list (fun ppf (lid, typ) ->
+             fprintf ppf "(@,%a,@,%a)" longident lid raw_type typ)
+    tl
 and raw_type_desc ppf = function
     Tvar name -> fprintf ppf "Tvar %a" print_name name
   | Tarrow(l,t1,t2,c) ->
@@ -546,8 +550,7 @@ and raw_type_desc ppf = function
           | Some(p,tl) ->
               fprintf ppf "Some(@,%a,@,%a)" path p raw_type_list tl)
   | Tpackage (p, fl) ->
-      fprintf ppf "@[<hov1>Tpackage(@,%a@,%a)@]" path p
-        raw_type_list (List.map snd fl)
+    fprintf ppf "@[<hov1>Tpackage(@,%a,@,%a)@]" path p raw_lid_type_list fl
 and raw_row_fixed ppf = function
 | None -> fprintf ppf "None"
 | Some Types.Fixed_private -> fprintf ppf "Some Fixed_private"

--- a/typing/signature_group.mli
+++ b/typing/signature_group.mli
@@ -73,9 +73,7 @@ type in_place_patch = {
 
 (**
   [!replace_in_place patch sg] replaces the first element of the signature
-   for which [patch ~rec_group ~ghosts component] returns [Some (value,patch)].
-   The [rec_group] argument is the remaining part of the mutually
-   recursive group of [component].
+   for which [patch ~ghosts component] returns [Some (value,patch)].
    The [ghosts] list is the current prefix of ghost components associated to
    [component]
 *)

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -1719,10 +1719,10 @@ let transl_with_constraint id ?fixed_row_path ~sig_env ~sig_decl ~outer_env
   in
   let no_row = not (is_fixed_type sdecl) in
   let (tman, man) =  match sdecl.ptype_manifest with
-      None -> None, None
+      None -> Misc.fatal_error "Typedecl.transl_with_constraint: no manifest"
     | Some sty ->
         let cty = transl_simple_type env ~closed:no_row sty in
-        Some cty, Some cty.ctyp_type
+        cty, cty.ctyp_type
   in
   (* In the second part, we check the consistency between the two
      declarations and compute a "merged" declaration; we now need to
@@ -1756,7 +1756,7 @@ let transl_with_constraint id ?fixed_row_path ~sig_env ~sig_decl ~outer_env
   && sdecl.ptype_private = Private then
     Location.deprecated loc "spurious use of private";
   let type_kind, type_unboxed_default =
-    if arity_ok && man <> None then
+    if arity_ok then
       sig_decl.type_kind, sig_decl.type_unboxed_default
     else
       Type_abstract Definition, false
@@ -1766,7 +1766,7 @@ let transl_with_constraint id ?fixed_row_path ~sig_env ~sig_decl ~outer_env
       type_arity = arity;
       type_kind;
       type_private = priv;
-      type_manifest = man;
+      type_manifest = Some man;
       type_variance = [];
       type_separability = Types.Separability.default_signature ~arity;
       type_is_newtype = false;
@@ -1826,7 +1826,7 @@ let transl_with_constraint id ?fixed_row_path ~sig_env ~sig_decl ~outer_env
     typ_type = new_sig_decl;
     typ_cstrs = constraints;
     typ_loc = loc;
-    typ_manifest = tman;
+    typ_manifest = Some tman;
     typ_kind = Ttype_abstract;
     typ_private = sdecl.ptype_private;
     typ_attributes = sdecl.ptype_attributes;

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -1834,6 +1834,33 @@ let transl_with_constraint id ?fixed_row_path ~sig_env ~sig_decl ~outer_env
   end
   ~post:(fun ttyp -> generalize_decl ttyp.typ_type)
 
+(* A simplified version of [transl_with_constraint], for the case of packages.
+   Package constraints are much simpler than normal with type constraints (e.g.,
+   they can not have parameters and can only update abstract types.) *)
+let transl_package_constraint ~loc env ty =
+  let new_sig_decl =
+    { type_params = [];
+      type_arity = 0;
+      type_kind = Type_abstract Definition;
+      type_private = Public;
+      type_manifest = Some ty;
+      type_variance = [];
+      type_separability = [];
+      type_is_newtype = false;
+      type_expansion_scope = Btype.lowest_level;
+      type_loc = loc;
+      type_attributes = [];
+      type_immediate = Unknown;
+      type_unboxed_default = false;
+      type_uid = Uid.mk ~current_unit:(Env.get_unit_name ())
+    }
+  in
+  let new_type_immediate =
+    (* Typedecl_immediacy.compute_decl never raises *)
+    Typedecl_immediacy.compute_decl env new_sig_decl
+  in
+  { new_sig_decl with type_immediate = new_type_immediate }
+
 (* Approximate a type declaration: just make all types abstract *)
 
 let abstract_type_decl ~injective arity =

--- a/typing/typedecl.mli
+++ b/typing/typedecl.mli
@@ -46,6 +46,9 @@ val transl_with_constraint:
     outer_env:Env.t -> Parsetree.type_declaration ->
     Typedtree.type_declaration
 
+val transl_package_constraint:
+  loc:Location.t -> Env.t -> type_expr -> Types.type_declaration
+
 val abstract_type_decl: injective:bool -> int -> type_declaration
 val approx_type_decl:
     Parsetree.type_declaration list ->

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -735,7 +735,7 @@ let merge_package_constraint initial_env loc sg lid cty =
       when Ident.name id = s ->
         let sig_env = Env.add_signature sg_for_env outer_sig_env in
         let sg = extract_sig sig_env loc md.md_type in
-        let ((), newsg) = merge_signature sig_env sg namelist in
+        let newsg = merge_signature sig_env sg namelist in
         let item =
           match md.md_type with
             Mty_alias _ ->
@@ -752,15 +752,15 @@ let merge_package_constraint initial_env loc sg lid cty =
     match
       Signature_group.replace_in_place (patch_item namelist env sg) sg
     with
-    | Some (x,sg) -> x, sg
+    | Some ((),sg) -> sg
     | None -> raise(Error(loc, env, With_no_component lid.txt))
   in
   try
     let names = Longident.flatten lid.txt in
-    let (tcstr, sg) = merge_signature initial_env sg names in
+    let sg = merge_signature initial_env sg names in
     check_well_formed_module initial_env loc "this instantiated signature"
       (Mty_signature sg);
-    (tcstr, sg)
+    sg
   with Includemod.Error explanation ->
     raise(Error(loc, initial_env, With_mismatch(lid.txt, explanation)))
 
@@ -769,7 +769,7 @@ let check_package_with_type_constraints loc env mty constraints =
   let sg =
     List.fold_left
       (fun sg (lid, cty) ->
-         snd (merge_package_constraint env loc sg lid cty))
+         merge_package_constraint env loc sg lid cty)
       sg constraints
   in
   let scope = Ctype.create_scope () in

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -467,11 +467,14 @@ type with_info =
   | With_modsubst of Longident.t loc * Path.t * Types.module_declaration
   | With_modtype of Typedtree.module_type
   | With_modtypesubst of Typedtree.module_type
+  | With_type_package of Typedtree.core_type
+    (* Package with type constraints only use this last case.  Normal module
+       with constraints never use it. *)
 
 let merge_constraint initial_env loc sg lid constr =
   let destructive_substitution =
     match constr with
-    | With_type _ | With_module _ | With_modtype _ -> false
+    | With_type _ | With_type_package _ | With_module _ | With_modtype _ -> false
     | With_typesubst _ | With_modsubst _ | With_modtypesubst _  -> true
   in
   let real_ids = ref [] in
@@ -545,7 +548,7 @@ let merge_constraint initial_env loc sg lid constr =
         in
         return ~ghosts
           ~replace_by:(Some (Sig_type(id, newdecl, rs, priv)))
-          (Pident id, lid, Twith_type tdecl)
+          (Pident id, lid, Some (Twith_type tdecl))
     | Sig_type(id, sig_decl, rs, priv) , [s],
        (With_type sdecl | With_typesubst sdecl as constr)
       when Ident.name id = s ->
@@ -562,12 +565,26 @@ let merge_constraint initial_env loc sg lid constr =
           With_type _ ->
             return ~ghosts
               ~replace_by:(Some(Sig_type(id, newdecl, rs, priv)))
-              (Pident id, lid, Twith_type tdecl)
+              (Pident id, lid, Some (Twith_type tdecl))
         | (* With_typesubst *) _ ->
             real_ids := [Pident id];
             return ~ghosts ~replace_by:None
-              (Pident id, lid, Twith_typesubst tdecl)
+              (Pident id, lid, Some (Twith_typesubst tdecl))
         end
+    | Sig_type(id, sig_decl, rs, priv), [s], With_type_package cty
+      when Ident.name id = s ->
+        begin match sig_decl.type_manifest with
+        | None -> ()
+        | Some ty ->
+          raise (Error(loc, outer_sig_env, With_package_manifest (lid.txt, ty)))
+        end;
+        let tdecl =
+          Typedecl.transl_package_constraint ~loc outer_sig_env cty.ctyp_type
+        in
+        check_type_decl outer_sig_env sg_for_env loc id None tdecl sig_decl;
+        let tdecl = { tdecl with type_manifest = None } in
+        return ~ghosts ~replace_by:(Some(Sig_type(id, tdecl, rs, priv)))
+          (Pident id, lid, None)
     | Sig_modtype(id, mtd, priv), [s],
       (With_modtype mty | With_modtypesubst mty)
       when Ident.name id = s ->
@@ -589,7 +606,7 @@ let merge_constraint initial_env loc sg lid constr =
           in
           return
             ~replace_by:(Some(Sig_modtype(id, mtd', priv)))
-            (Pident id, lid, Twith_modtype mty)
+            (Pident id, lid, Some (Twith_modtype mty))
         else begin
           let path = Pident id in
           real_ids := [path];
@@ -597,7 +614,8 @@ let merge_constraint initial_env loc sg lid constr =
           | Mty_ident _ -> ()
           | mty -> unpackable_modtype := Some mty
           end;
-          return ~replace_by:None (Pident id, lid, Twith_modtypesubst mty)
+          return ~replace_by:None
+            (Pident id, lid, Some (Twith_modtypesubst mty))
         end
     | Sig_module(id, pres, md, rs, priv), [s],
       With_module {lid=lid'; md=md'; path; remove_aliases}
@@ -611,7 +629,7 @@ let merge_constraint initial_env loc sg lid constr =
                  newmd.md_type md.md_type);
         return
           ~replace_by:(Some(Sig_module(id, pres, newmd, rs, priv)))
-          (Pident id, lid, Twith_module (path, lid'))
+          (Pident id, lid, Some (Twith_module (path, lid')))
     | Sig_module(id, _, md, _rs, _), [s], With_modsubst (lid',path,md')
       when Ident.name id = s ->
         let sig_env = Env.add_signature sg_for_env outer_sig_env in
@@ -620,7 +638,8 @@ let merge_constraint initial_env loc sg lid constr =
           (Includemod.strengthened_module_decl ~loc ~mark:Mark_both
              ~aliasable sig_env md' path md);
         real_ids := [Pident id];
-        return ~replace_by:None (Pident id, lid, Twith_modsubst (path, lid'))
+        return ~replace_by:None
+          (Pident id, lid, Some (Twith_modsubst (path, lid')))
     | Sig_module(id, _, md, rs, priv) as item, s :: namelist, constr
       when Ident.name id = s ->
         let sig_env = Env.add_signature sg_for_env outer_sig_env in
@@ -655,7 +674,7 @@ let merge_constraint initial_env loc sg lid constr =
         !unpackable_modtype sg;
     let sg =
     match tcstr with
-    | (_, _, Twith_typesubst tdecl) ->
+    | (_, _, Some (Twith_typesubst tdecl)) ->
        let how_to_extend_subst =
          let sdecl =
            match constr with
@@ -684,7 +703,7 @@ let merge_constraint initial_env loc sg lid constr =
           making it local makes it unlikely that we will ever use the result of
           this function unfreshened without issue. *)
        Subst.signature Make_local sub sg
-    | (_, _, Twith_modsubst (real_path, _)) ->
+    | (_, _, Some (Twith_modsubst (real_path, _))) ->
        let sub = Subst.change_locs Subst.identity loc in
        let sub =
          List.fold_left
@@ -694,7 +713,7 @@ let merge_constraint initial_env loc sg lid constr =
        in
        (* See explanation in the [Twith_typesubst] case above. *)
        Subst.signature Make_local sub sg
-    | (_, _, Twith_modtypesubst tmty) ->
+    | (_, _, Some (Twith_modtypesubst tmty)) ->
         let add s p = Subst.add_modtype_path p tmty.mty_type s in
         let sub = Subst.change_locs Subst.identity loc in
         let sub = List.fold_left add sub !real_ids in
@@ -708,61 +727,9 @@ let merge_constraint initial_env loc sg lid constr =
   with Includemod.Error explanation ->
     raise(Error(loc, initial_env, With_mismatch(lid.txt, explanation)))
 
-(* A simplified version of [merge_constraint] for the case of packages. Package
-   constraints are much simpler - they must be "with type" constraints for types
-   with no parameters and can only update abstract types. *)
 let merge_package_constraint initial_env loc sg lid cty =
-  let rec patch_item namelist outer_sig_env sg_for_env ~ghosts item =
-    let return replace_by =
-      Some ((), {Signature_group.ghosts; replace_by=Some replace_by})
-    in
-    match item, namelist with
-    | Sig_type(id, sig_decl, rs, priv) , [s]
-      when Ident.name id = s ->
-        begin match sig_decl.type_manifest with
-        | None -> ()
-        | Some ty ->
-          raise (Error(loc, outer_sig_env, With_package_manifest (lid.txt, ty)))
-        end;
-        let new_sig_decl =
-          Typedecl.transl_package_constraint ~loc outer_sig_env cty.ctyp_type
-        in
-        check_type_decl outer_sig_env sg_for_env loc id None
-          new_sig_decl sig_decl;
-        let new_sig_decl = { new_sig_decl with type_manifest = None } in
-        return (Sig_type(id, new_sig_decl, rs, priv))
-    | Sig_module(id, _, md, rs, priv) as item, s :: namelist
-      when Ident.name id = s ->
-        let sig_env = Env.add_signature sg_for_env outer_sig_env in
-        let sg = extract_sig sig_env loc md.md_type in
-        let newsg = merge_signature sig_env sg namelist in
-        let item =
-          match md.md_type with
-            Mty_alias _ ->
-              (* A module alias cannot be refined, so keep it
-                 and just check that the constraint is correct *)
-              item
-          | _ ->
-              let newmd = {md with md_type = Mty_signature newsg} in
-              Sig_module(id, Mp_present, newmd, rs, priv)
-        in
-        return item
-    | _ -> None
-  and merge_signature env sg namelist =
-    match
-      Signature_group.replace_in_place (patch_item namelist env sg) sg
-    with
-    | Some ((),sg) -> sg
-    | None -> raise(Error(loc, env, With_no_component lid.txt))
-  in
-  try
-    let names = Longident.flatten lid.txt in
-    let sg = merge_signature initial_env sg names in
-    check_well_formed_module initial_env loc "this instantiated signature"
-      (Mty_signature sg);
-    sg
-  with Includemod.Error explanation ->
-    raise(Error(loc, initial_env, With_mismatch(lid.txt, explanation)))
+  let _, s = merge_constraint initial_env loc sg lid (With_type_package cty) in
+  s
 
 let check_package_with_type_constraints loc env mty constraints =
   let sg = extract_sig env loc mty in
@@ -1428,8 +1395,10 @@ and transl_with ~loc env remove_aliases (rev_tcstrs,sg) constr =
         let mty = transl_modtype env smty in
         l, With_modtypesubst mty
   in
-  let (tcstr, sg) = merge_constraint env loc sg lid with_info in
-  (tcstr :: rev_tcstrs, sg)
+  let ((path, lid, tcstr), sg) = merge_constraint env loc sg lid with_info in
+  (* Only package with constraints result in None here. *)
+  let tcstr = Option.get tcstr in
+  ((path, lid, tcstr) :: rev_tcstrs, sg)
 
 
 

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -474,7 +474,8 @@ type with_info =
 let merge_constraint initial_env loc sg lid constr =
   let destructive_substitution =
     match constr with
-    | With_type _ | With_type_package _ | With_module _ | With_modtype _ -> false
+    | With_type _ | With_module _ | With_modtype _
+    | With_type_package _ -> false
     | With_typesubst _ | With_modsubst _ | With_modtypesubst _  -> true
   in
   let real_ids = ref [] in

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -2089,7 +2089,9 @@ let rec package_constraints_sig env loc sg constrs =
       | Sig_type (id, ({type_params=[]} as td), rs, priv)
         when List.mem_assoc [Ident.name id] constrs ->
           let ty = List.assoc [Ident.name id] constrs in
-          Sig_type (id, {td with type_manifest = Some ty}, rs, priv)
+          let td = {td with type_manifest = Some ty} in
+          let type_immediate = Typedecl_immediacy.compute_decl env td in
+          Sig_type (id, {td with type_immediate}, rs, priv)
       | Sig_module (id, pres, md, rs, priv) ->
           let rec aux = function
             | (m :: ((_ :: _) as l), t) :: rest when m = Ident.name id ->

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -714,7 +714,7 @@ let merge_constraint initial_env loc sg lid constr =
 let merge_package_constraint initial_env loc sg lid cty =
   let rec patch_item namelist outer_sig_env sg_for_env ~ghosts item =
     let return replace_by =
-      Some ((), {Signature_group.ghosts; replace_by})
+      Some ((), {Signature_group.ghosts; replace_by=Some replace_by})
     in
     match item, namelist with
     | Sig_type(id, sig_decl, rs, priv) , [s]
@@ -730,7 +730,7 @@ let merge_package_constraint initial_env loc sg lid cty =
         check_type_decl outer_sig_env sg_for_env loc id None
           new_sig_decl sig_decl;
         let new_sig_decl = { new_sig_decl with type_manifest = None } in
-        return (Some(Sig_type(id, new_sig_decl, rs, priv)))
+        return (Sig_type(id, new_sig_decl, rs, priv))
     | Sig_module(id, _, md, rs, priv) as item, s :: namelist
       when Ident.name id = s ->
         let sig_env = Env.add_signature sg_for_env outer_sig_env in
@@ -746,7 +746,7 @@ let merge_package_constraint initial_env loc sg lid cty =
               let newmd = {md with md_type = Mty_signature newsg} in
               Sig_module(id, Mp_present, newmd, rs, priv)
         in
-        return (Some item)
+        return item
     | _ -> None
   and merge_signature env sg namelist =
     match
@@ -3383,8 +3383,8 @@ let report_error ~loc _env = function
         Misc.print_see_manual manual_ref
   | With_package_manifest (lid, ty) ->
       Location.errorf ~loc
-        "@[In the constrained signature, type %a is defined to be %a.@ \
-         Package %a constraints may only be used on abstract types.@]"
+        "In the constrained signature, type %a is defined to be %a.@ \
+         Package %a constraints may only be used on abstract types."
         (Style.as_inline_code longident) lid
         (Style.as_inline_code Printtyp.type_expr) ty
         Style.inline_code "with"

--- a/typing/typemod.mli
+++ b/typing/typemod.mli
@@ -117,6 +117,7 @@ type error =
       Longident.t * Path.t * Includemod.explanation
   | With_changes_module_alias of Longident.t * Ident.t * Path.t
   | With_cannot_remove_constrained_type
+  | With_package_manifest of Longident.t * type_expr
   | Repeated_name of Sig_component_kind.t * string
   | Non_generalizable of { vars : type_expr list; expression : type_expr }
   | Non_generalizable_module of

--- a/typing/typetexp.ml
+++ b/typing/typetexp.ml
@@ -338,6 +338,7 @@ end
 
 let transl_modtype_longident = ref (fun _ -> assert false)
 let transl_modtype = ref (fun _ -> assert false)
+let check_package_with_type_constraints = ref (fun _ -> assert false)
 
 let sort_constraints_no_duplicates loc env l =
   List.sort
@@ -345,23 +346,6 @@ let sort_constraints_no_duplicates loc env l =
        if s1.txt = s2.txt then
          raise (Error (loc, env, Multiple_constraints_on_type s1.txt));
        compare s1.txt s2.txt)
-    l
-
-let create_package_mty loc p l =
-  List.fold_left
-    (fun mty (s, _) ->
-      let d = {ptype_name = mkloc (Longident.last s.txt) s.loc;
-               ptype_params = [];
-               ptype_cstrs = [];
-               ptype_kind = Ptype_abstract;
-               ptype_private = Asttypes.Public;
-               ptype_manifest = None;
-               ptype_attributes = [];
-               ptype_loc = loc} in
-      Ast_helper.Mty.mk ~loc
-        (Pmty_with (mty, [ Pwith_type ({ txt = s.txt; loc }, d) ]))
-    )
-    (Ast_helper.Mty.mk ~loc (Pmty_ident p))
     l
 
 (* Translation of type expressions *)
@@ -679,19 +663,23 @@ and transl_type_aux env ~row_context ~aliased ~policy styp =
   | Ptyp_package (p, l) ->
       let loc = styp.ptyp_loc in
       let l = sort_constraints_no_duplicates loc env l in
-      let mty = create_package_mty loc p l in
+      let mty = Ast_helper.Mty.mk ~loc (Pmty_ident p) in
+      let mty = TyVarEnv.with_local_scope (fun () -> !transl_modtype env mty) in
+      let ptys =
+        List.map (fun (s, pty) -> s, transl_type env ~policy ~row_context pty) l
+      in
       let mty =
-        TyVarEnv.with_local_scope (fun () -> !transl_modtype env mty) in
-      let ptys = List.map (fun (s, pty) ->
-                             s, transl_type env ~policy ~row_context pty
-                          ) l in
+        if ptys <> [] then
+          !check_package_with_type_constraints loc env mty.mty_type ptys
+        else mty.mty_type
+      in
       let path = !transl_modtype_longident loc env p.txt in
       let ty = newty (Tpackage (path,
                        List.map (fun (s, cty) -> (s.txt, cty.ctyp_type)) ptys))
       in
       ctyp (Ttyp_package {
             pack_path = path;
-            pack_type = mty.mty_type;
+            pack_type = mty;
             pack_fields = ptys;
             pack_txt = p;
            }) ty

--- a/typing/typetexp.mli
+++ b/typing/typetexp.mli
@@ -102,3 +102,7 @@ val transl_modtype_longident:  (* from Typemod *)
     (Location.t -> Env.t -> Longident.t -> Path.t) ref
 val transl_modtype: (* from Typemod *)
     (Env.t -> Parsetree.module_type -> Typedtree.module_type) ref
+val check_package_with_type_constraints: (* from Typemod *)
+    (Location.t -> Env.t -> Types.module_type ->
+     (Longident.t Asttypes.loc * Typedtree.core_type) list ->
+     Types.module_type) ref


### PR DESCRIPTION
The goal of this PR is to fix two bugs related to the interaction of package `with type` constraints and immediacy.  One of the bugs is #12924.  The other is that if you use a package `with type` constraint to add an immediate manifest to an abstract type declaration, you can not use the fact that the resulting declaration is immediate (an example is added as a test).

This PR fixes these issues by reworking the typechecking of package `with type` constraints.  Package constraints are different than normal signature constraints.  They are much simpler in most ways (e.g., they do not work on type declarations with parameters or manifests and do not support destructive substitution).  But they are slightly more complicated in one way, in that they they may make use of the current type variable environment while normal signature constraints may not.  For example:
```ocaml
module type S = sig
  type t
end

type 'a m = (module S with type t = 'a)
```
The existing implementation tries to paper over these differences by constructing a fake, malformed bit of parse tree and relying on the existing checking for normal signature constraints (explained in more detail below).  I think the new implementation here, which directly checks the package constraint rather than re-using the normal signature constraint checking, is simpler and clearer.  But I am happy to hear other opinions. Also, I am not an expert on first class modules, so it is possible I have missed something.

I've broken this into several commits, which can be read independently.
- The first couple make minor related fixes I noticed while working on this.
- The third adds tests documenting the current behavior of package constraints, including its flaws, some of which are fixed in subsequent commits.
- The fourth does the bulk of the rework, fixing #12924.
- The fifth does a small bit of cleanup in `Typedecl`, now that `transl_with_constraint` no longer needs to check for the weird fake package constriants.
- The sixth fixes the related second bug in unpacking.

Reviewers **can stop reading here** and go look at the code, if they like.  The rest of this is just text describing my understanding of how things used to work and how they work after the PR, which may or may not be helpful.

### How package constraints work before this PR

Package type expressions are handled by the `Ptyp_package` case of `Typetexp.transl_type_aux`.  This function relies on a helper function `create_package_mty` to construct a fake (non-first-class) parsetree module type that vaguely resembles the constrained package.  This fake module type has with constraints, but they have no manifests - a situation which can never arise from the actual parser.  So a package type like `(module S with type t = int)` results in a fake module type that looks something like `S with type t`.

We then translate this module type.  Normal module `with type` constraints are handled by `Typemod.merge_constraint`, which translates the constraint to a type decl using `Typedecl.transl_with_constraint` and then checking that this type decl is included in the constrained type decl from the original signature.  `transl_with_constraint` has special case logic to handle these declarations with no manifests, since normal `with type` constraints must have them.  Finally these new type decls are merged into the original signature, which has no effect in the case of package constraints (because they have no manifests) except to update some locations.

Finally, we separately translate the types from the package constraints, and build a `Tpackage` type including them.  Here we are crucially relying on the fact that the fake package constraint checked successfully with no manifests.  This implies that the constrained type in the original signature is fully abstract, and so any constraint is fine - no need to compare the type in the constraint against the original signature.

### Can't we just fix this by adding manifests to the fake module type built by `create_package_mty`?

No.  There are two problems.

First, the existing implementation of `transl_with_constraint` in `Typedecl` uses the absence of a manifest to detect and provide a bit of special case logic for the "fake" with type constriants used in package checking.  See #6293.

Second, as shown in the example near the top of this PR, package constraints may use the current type variable environment in a way that normal module `with type` constraints may not.  Package constraint bodies that make use of the environment don't typecheck properly as normal signature constraints.

### New approach

The new approach proposed by this PR is to write a much simplified version of `with type` constraint checking that is specific to package constraints, rather than constructing a fake module type and trying to check package constraints as module type constraints.  `create_package_mty` is eliminated, and there are new functions `Typedecl.transl_package_constraint` and `Typemod.merge_package_constraint` that mirror `Typedecl.transl_with_constraint` and `Typemod.merge_constraint` respectively, but are much simpler because package constraints are always simple non-destructive `with type` constraints.

It would be possible to go even farther in this direction.  E.g., `Includecore.type_declarations` does a lot of work that is not needed for decls arising from package constriants.  This felt like the best middle ground to me - clarifying how package constraints work without duplicating too much code.