### PR TITLE
add Buffer.iter_chunks

### DIFF
--- a/Changes
+++ b/Changes
@@ -15,6 +15,8 @@ _______________
   (Kate Deplaix and Oscar Butler-Aldridge review by Nicolás Ojeda Bär,
    Craig Ferguson and Gabriel Scherer)
 
+- Add `Buffer.iter_chunks` (Simon Cruanes)
+
 ### Other libraries:
 
 ### Tools:

--- a/stdlib/buffer.ml
+++ b/stdlib/buffer.ml
@@ -67,8 +67,12 @@ let nth b ofs =
    invalid_arg "Buffer.nth"
   else Bytes.unsafe_get buffer ofs
 
-
 let length b = b.position
+
+let[@inline] iter_chunks b f =
+  let {position; inner={buffer; length}; _} = b in
+  let position = min position length in
+  if position > 0 then f buffer 0 position
 
 let clear b = b.position <- 0
 

--- a/stdlib/buffer.mli
+++ b/stdlib/buffer.mli
@@ -92,6 +92,15 @@ val nth : t -> int -> char
 val length : t -> int
 (** Return the number of characters currently contained in the buffer. *)
 
+val iter_chunks : t -> (bytes -> int -> int -> unit) -> unit
+(** [iter_chunks buf f] calls [f chunk offset len] for each contiguous chunk
+    of data in [buf]. [f] might not be called at all if [buf] is empty,
+    or might be called on one or more chunks.
+
+    The sum of the lengths of each chunk is equal to [length buf].
+    @since 5.3
+*)
+
 val clear : t -> unit
 (** Empty the buffer. *)
 

--- a/testsuite/tests/lib-buffer/test.ml
+++ b/testsuite/tests/lib-buffer/test.ml
@@ -309,4 +309,3 @@ let () =
   assert (to_string b = Buffer.contents b);
 
   print_endline "Buffer iter_chunks: tests passed"
-

--- a/testsuite/tests/lib-buffer/test.ml
+++ b/testsuite/tests/lib-buffer/test.ml
@@ -286,3 +286,27 @@ let () =
   Buffer.add_substitute b f " $(abc";
   assert (Buffer.contents b
             = {| FOO hash hash nil $foo \$foo \\$foo $ $! $(abc|})
+
+(* Tests for iter_chunks *)
+let () =
+  (* aggregate chunks into a string *)
+  let to_string b =
+    let chunks = ref [] in
+    Buffer.iter_chunks b (fun chunk off len ->
+      chunks := Bytes.sub_string chunk off len :: !chunks);
+    String.concat "" @@ List.rev !chunks
+  in
+
+  let b = Buffer.create 32 in
+  assert (to_string b = "");
+
+  Buffer.add_string b "hello world";
+  assert (to_string b = "hello world");
+
+  for i=1 to 100 do
+    Buffer.add_string b "another addition"
+  done;
+  assert (to_string b = Buffer.contents b);
+
+  print_endline "Buffer iter_chunks: tests passed"
+

--- a/testsuite/tests/lib-buffer/test.reference
+++ b/testsuite/tests/lib-buffer/test.reference
@@ -7,3 +7,4 @@ Buffer reset: zero passed
 Buffer add_utf_8_uchar: test against spec passed
 Buffer add_utf_16be_uchar: test against spec passed
 Buffer add_utf_16le_uchar: test against spec passed
+Buffer iter_chunks: tests passed


### PR DESCRIPTION
Seems like some maintainers [agree with this idea](https://github.com/ocaml/ocaml/discussions/12881) so here we go! If I wanted to push my luck I'd also submit:

```ocaml
val iter_chunks_look_no_need_for_closures : t -> ('ctx -> bytes -> int -> int -> unit) -> 'ctx -> unit
```

which can be used to skip one closure allocation in most contexts.