### PR TITLE
Fix data race between marking and sweeping

### DIFF
--- a/.github/workflows/tsan.yml
+++ b/.github/workflows/tsan.yml
@@ -64,11 +64,9 @@ jobs:
           - id: normal
             name: normal
             dependencies: libunwind-dev
-          # Running with the debug runtime is disabled until the data races in
-          # it are fixed (see #12902).
-          #- id: debug
-          #  name: debug runtime
-          #  dependencies: libunwind-dev
+          - id: debug
+            name: debug runtime
+            dependencies: libunwind-dev
     steps:
       - name: Download Artifact
         uses: actions/download-artifact@v3

--- a/Changes
+++ b/Changes
@@ -68,6 +68,10 @@ _______________
 
 ### Bug fixes:
 
+- #12934: Fix data races between marking and sweeping functions
+  (Olivier Nicole, suggested by Stephen Dolan, review by Gabriel Scherer,
+   Miod Vallat and Damien Doligez)
+
 - #12888: fix printing of uncaught exceptions in `.cmo` files passed on the
   command-line of the toplevel.
   (Nicolás Ojeda Bär, review by Florian Angeletti, report by Daniel Bünzli)

--- a/runtime/shared_heap.c
+++ b/runtime/shared_heap.c
@@ -541,7 +541,10 @@ static intnat large_alloc_sweep(struct caml_heap_state* local) {
   local->unswept_large = a->next;
 
   p = (value*)((char*)a + LARGE_ALLOC_HEADER_SZ);
-  hd = (header_t)*p;
+  /* The header being read here may be concurrently written by a thread doing
+     marking. This is fine because marking can only make UNMARKED objects
+     MARKED or NOT_MARKABLE, all of which are treated identically here. */
+  hd = Hd_hp(p);
   if (Has_status_hd(hd, caml_global_heap_state.GARBAGE)) {
     if (Tag_hd (hd) == Custom_tag) {
       void (*final_fun)(value) = Custom_ops_val(Val_hp(p))->finalize;

--- a/runtime/shared_heap.c
+++ b/runtime/shared_heap.c
@@ -1323,7 +1323,11 @@ static void verify_pool(pool* a, sizeclass sz, struct mem_stats* s) {
     s->overhead += POOL_SLAB_WOFFSET(sz);
 
     while (p + wh <= end) {
-      header_t hd = (header_t)*p;
+      /* This header can be read here and concurrently marked by the GC, but
+         this is fine: marking can only turn UNMARKED objects into MARKED or
+         NOT_MARKABLE, which is of no consequence for this verification
+         (namely, that there is no garbage left). */
+      header_t hd = Hd_hp(p);
       CAMLassert(hd == 0 || !Has_status_hd(hd, caml_global_heap_state.GARBAGE));
       if (hd) {
         s->live += Whsize_hd(hd);

--- a/testsuite/tests/regression/pr9853/compaction_corner_case.ml
+++ b/testsuite/tests/regression/pr9853/compaction_corner_case.ml
@@ -1,5 +1,11 @@
 (* TEST
- no-tsan; (* Takes too much time with tsan, at least on Linux/riscv64 *)
+ no-tsan; (* Takes too much time with tsan *)
+ {
+ bytecode;
+ }
+ {
+ native;
+ }
 *)
 
 (* Compaction crash when there is only one heap chunk and it is fully used. *)


### PR DESCRIPTION
This fixes #12916. As reminded by @stedolan, a sweeping thread is allowed to read a header while a marking concurrently writes to it: the marking thread can only make UNMARKED objects MARKED, both being treated identically by the sweeping code. All it takes is therefore to mark the header read as a relaxed atomic load.