### PR TITLE
Fix data races between marking and `verify_pool`

### DIFF
--- a/.github/workflows/tsan.yml
+++ b/.github/workflows/tsan.yml
@@ -64,11 +64,9 @@ jobs:
           - id: normal
             name: normal
             dependencies: libunwind-dev
-          # Running with the debug runtime is disabled until the data races in
-          # it are fixed (see #12902).
-          #- id: debug
-          #  name: debug runtime
-          #  dependencies: libunwind-dev
+          - id: debug
+            name: debug runtime
+            dependencies: libunwind-dev
     steps:
       - name: Download Artifact
         uses: actions/download-artifact@v3

--- a/runtime/shared_heap.c
+++ b/runtime/shared_heap.c
@@ -1320,7 +1320,11 @@ static void verify_pool(pool* a, sizeclass sz, struct mem_stats* s) {
     s->overhead += POOL_SLAB_WOFFSET(sz);
 
     while (p + wh <= end) {
-      header_t hd = (header_t)*p;
+      /* This header can be read here and concurrently marked by the GC, but
+         this is fine: marking can only turn UNMARKED objects into MARKED or
+         NOT_MARKABLE, which is of no consequence for this verification
+         (namely, that there is no garbage left). */
+      header_t hd = Hd_hp(p);
       CAMLassert(hd == 0 || !Has_status_hd(hd, caml_global_heap_state.GARBAGE));
       if (hd) {
         s->live += Whsize_hd(hd);

--- a/testsuite/tests/regression/pr9853/compaction_corner_case.ml
+++ b/testsuite/tests/regression/pr9853/compaction_corner_case.ml
@@ -1,4 +1,12 @@
-(* TEST *)
+(* TEST
+ no-tsan;
+ {
+   bytecode;
+ }
+ {
+   native;
+ }
+*)
 
 (* Compaction crash when there is only one heap chunk and it is fully used. *)
 let c = ref []


### PR DESCRIPTION
`verify_pool` is a function used to check the invariant that a major pool should contain no garbage after sweeping. It is obviously allowed to race with marking (which can only turn UNMARKED objects into MARKED or NOT_MARKABLE, but not into GARBAGE), we only need to mark the read as `volatile`—here through `Hd_hp`. This fixes #12902.

The fix removes the annoying noise that had prevented us from exercising the debug runtime in the TSan CI (the one that is triggered by a PR label), so this PR adds exercising the debug runtime to that CI job. I had to exclude the test `regression/pr9853/compaction_corner_case.ml` when TSan is `--enable`d, because it runs for more than 30 minutes (the same is done in #12907).