### PR TITLE
Make scope field a bitfield

### DIFF
--- a/Changes
+++ b/Changes
@@ -75,6 +75,11 @@ _______________
 - #12932: Remove useless code in Typecore.type_label_exp (was a fix for #4862)
   (Jacques Garrigue, review by Gabriel Scherer)
 
+- #12943: Make transient_expr.scope a bitfield, and use it to store marks.
+  Marks are automatically allocated, and removed when leaving their scope.
+  Falls back to using TransientTypeSet when marks are exhausted.
+  (Jacques Garrigue and Takafumi Saikawa, review by ???)
+
 ### Build system:
 
 - #12909: Reorganise how MKEXE_VIA_CC is built to make it correct for MSVC by

--- a/Changes
+++ b/Changes
@@ -78,7 +78,7 @@ _______________
 - #12943: Make transient_expr.scope a bitfield, and use it to store marks.
   Marks are automatically allocated, and removed when leaving their scope.
   Falls back to using TransientTypeSet when marks are exhausted.
-  (Jacques Garrigue and Takafumi Saikawa, review by ???)
+  (Jacques Garrigue and Takafumi Saikawa, review by Basile Clément)
 
 ### Build system:
 

--- a/toplevel/topdirs.ml
+++ b/toplevel/topdirs.ml
@@ -444,8 +444,7 @@ let is_nonrec_type id td =
     with_type_mark begin fun mark ->
       let it = Btype.{(type_iterators mark) with it_path} in
       it.it_type_declaration it td;
-      let unmark = Btype.unmark_iterators mark in
-      unmark.it_type_declaration unmark td
+      Btype.unmark_type_decl mark td
     end
   in
   match !recursive_use, !nonrecursive_use with

--- a/toplevel/topdirs.ml
+++ b/toplevel/topdirs.ml
@@ -440,10 +440,13 @@ let is_nonrec_type id td =
           nonrecursive_use:= true
     | _ -> ()
   in
-  let it =  Btype.{type_iterators with it_path } in
   let () =
-    it.it_type_declaration it td;
-    Btype.unmark_iterators.it_type_declaration Btype.unmark_iterators td
+    with_type_mark begin fun mark ->
+      let it = Btype.{(type_iterators mark) with it_path} in
+      it.it_type_declaration it td;
+      let unmark = Btype.unmark_iterators mark in
+      unmark.it_type_declaration unmark td
+    end
   in
   match !recursive_use, !nonrecursive_use with
   | false, true -> Trec_not
@@ -542,13 +545,16 @@ let is_rec_module id md =
     | Path.Pident id' -> if (Ident.same id id') then raise Exit
     | _ -> ()
   in
-  let it =  Btype.{type_iterators with it_path } in
-  let rs = match it.it_module_declaration it md with
+  with_type_mark begin fun mark ->
+    let it =  Btype.{(type_iterators mark) with it_path} in
+    let rs = match it.it_module_declaration it md with
     | () -> Trec_not
     | exception Exit -> Trec_first
-  in
-  Btype.unmark_iterators.it_module_declaration Btype.unmark_iterators md;
-  rs
+    in
+    let unmark = Btype.unmark_iterators mark in
+    unmark.it_module_declaration unmark md;
+    rs
+  end
 
 let secretly_the_same_path env path1 path2 =
   let norm path = Printtyp.rewrite_double_underscore_paths env path in

--- a/toplevel/topdirs.ml
+++ b/toplevel/topdirs.ml
@@ -443,8 +443,7 @@ let is_nonrec_type id td =
   let () =
     with_type_mark begin fun mark ->
       let it = Btype.{(type_iterators mark) with it_path} in
-      it.it_type_declaration it td;
-      Btype.unmark_type_decl mark td
+      it.it_type_declaration it td
     end
   in
   match !recursive_use, !nonrecursive_use with
@@ -546,13 +545,9 @@ let is_rec_module id md =
   in
   with_type_mark begin fun mark ->
     let it =  Btype.{(type_iterators mark) with it_path} in
-    let rs = match it.it_module_declaration it md with
+    match it.it_module_declaration it md with
     | () -> Trec_not
     | exception Exit -> Trec_first
-    in
-    let unmark = Btype.unmark_iterators mark in
-    unmark.it_module_declaration unmark md;
-    rs
   end
 
 let secretly_the_same_path env path1 path2 =

--- a/typing/btype.ml
+++ b/typing/btype.ml
@@ -723,33 +723,6 @@ let type_iterators mark =
   in
   {type_iterators with it_type_expr}
 
-(* Remove marks from a type. *)
-let rec unmark_type mark ty =
-  if try_unmark_node mark ty then iter_type_expr (unmark_type mark) ty
-
-let unmark_iterators mark =
-  let it_type_expr _it ty = unmark_type mark ty in
-  {(type_iterators mark) with it_type_expr}
-
-let unmark_type_decl mark decl =
-  let it = unmark_iterators mark in
-  it.it_type_declaration it decl
-
-let unmark_extension_constructor mark ext =
-  List.iter (unmark_type mark) ext.ext_type_params;
-  iter_type_expr_cstr_args (unmark_type mark) ext.ext_args;
-  Option.iter (unmark_type mark) ext.ext_ret_type
-
-let unmark_class_signature mark sign =
-  unmark_type mark sign.csig_self;
-  unmark_type mark sign.csig_self_row;
-  Vars.iter (fun _l (_m, _v, t) -> unmark_type mark t) sign.csig_vars;
-  Meths.iter (fun _l (_m, _v, t) -> unmark_type mark t) sign.csig_meths
-
-let unmark_class_type mark cty =
-  let it = unmark_iterators mark in
-  it.it_class_type it cty
-
 (**** Type information getter ****)
 
 let cstr_type_path cstr =

--- a/typing/btype.ml
+++ b/typing/btype.ml
@@ -25,6 +25,7 @@ open Local_store
 let wrap_repr f ty = f (Transient_expr.repr ty)
 let wrap_type_expr f tty = f (Transient_expr.type_expr tty)
 
+module TransientTypeSet = Set.Make(TransientTypeOps)
 module TypeSet = struct
   include TransientTypeSet
   let add = wrap_repr add
@@ -42,7 +43,6 @@ module TypeMap = struct
   let singleton ty = wrap_repr singleton ty
   let fold f = TransientTypeMap.fold (wrap_type_expr f)
 end
-module TransientTypeHash = Hashtbl.Make(TransientTypeOps)
 module TypeHash = struct
   include TransientTypeHash
   let mem hash = wrap_repr (mem hash)

--- a/typing/btype.mli
+++ b/typing/btype.mli
@@ -157,8 +157,6 @@ type type_iterators =
 val type_iterators: type_mark -> type_iterators
         (* Iteration on arbitrary type information.
            [it_type_expr] calls [mark_node] to avoid loops. *)
-val unmark_iterators: type_mark -> type_iterators
-        (* Unmark any structure containing types. See [unmark_type] below. *)
 
 val copy_type_desc:
     ?keep_names:bool -> (type_expr -> type_expr) -> type_desc -> type_desc
@@ -191,13 +189,6 @@ val mark_type: type_mark -> type_expr -> unit
         (* Mark a type recursively *)
 val mark_type_params: type_mark -> type_expr -> unit
         (* Mark the sons of a type node recursively *)
-
-val unmark_type: type_mark -> type_expr -> unit
-val unmark_type_decl: type_mark -> type_declaration -> unit
-val unmark_extension_constructor: type_mark -> extension_constructor -> unit
-val unmark_class_type: type_mark -> class_type -> unit
-val unmark_class_signature: type_mark -> class_signature -> unit
-        (* Remove marks from a type *)
 
 (**** Memorization of abbreviation expansion ****)
 

--- a/typing/btype.mli
+++ b/typing/btype.mli
@@ -58,6 +58,9 @@ end
 (**** Levels ****)
 
 val generic_level: int
+        (* level of polymorphic variables; = Ident.highest_scope *)
+val lowest_level: int
+        (* lowest level for type nodes; = Ident.lowest_scope *)
 
 val newgenty: type_desc -> type_expr
         (* Create a generic type *)
@@ -66,13 +69,6 @@ val newgenvar: ?name:string -> unit -> type_expr
 val newgenstub: scope:int -> type_expr
         (* Return a fresh generic node, to be instantiated
            by [Transient_expr.set_stub_desc] *)
-
-(* Use Tsubst instead
-val newmarkedvar: int -> type_expr
-        (* Return a fresh marked variable *)
-val newmarkedgenvar: unit -> type_expr
-        (* Return a fresh marked generic variable *)
-*)
 
 (**** Types ****)
 
@@ -136,6 +132,14 @@ val iter_type_expr_cstr_args: (type_expr -> unit) ->
 val map_type_expr_cstr_args: (type_expr -> type_expr) ->
   (constructor_arguments -> constructor_arguments)
 
+(**** Utilities for type marking ****)
+
+val mark_type: type_mark -> type_expr -> unit
+        (* Mark a type recursively *)
+val mark_type_params: type_mark -> type_expr -> unit
+        (* Mark the sons of a type node recursively *)
+
+(**** (Object-oriented) iterator ****)
 
 type 'a type_iterators =
   { it_signature: 'a type_iterators -> signature -> unit;
@@ -168,6 +172,8 @@ val type_iterators_without_type_expr: type_iterators_without_type_expr
         (* Iteration on arbitrary type information.
            Cannot recurse on [type_expr]. *)
 
+(**** Utilities for copying ****)
+
 val copy_type_desc:
     ?keep_names:bool -> (type_expr -> type_expr) -> type_desc -> type_desc
         (* Copy on types *)
@@ -191,14 +197,6 @@ module For_copy : sig
         (* [with_scope f] calls [f] and restores saved type descriptions
            before returning its result. *)
 end
-
-val lowest_level: int
-        (* lowest level for type nodes *)
-
-val mark_type: type_mark -> type_expr -> unit
-        (* Mark a type recursively *)
-val mark_type_params: type_mark -> type_expr -> unit
-        (* Mark the sons of a type node recursively *)
 
 (**** Memorization of abbreviation expansion ****)
 

--- a/typing/btype.mli
+++ b/typing/btype.mli
@@ -137,26 +137,36 @@ val map_type_expr_cstr_args: (type_expr -> type_expr) ->
   (constructor_arguments -> constructor_arguments)
 
 
-type type_iterators =
-  { it_signature: type_iterators -> signature -> unit;
-    it_signature_item: type_iterators -> signature_item -> unit;
-    it_value_description: type_iterators -> value_description -> unit;
-    it_type_declaration: type_iterators -> type_declaration -> unit;
-    it_extension_constructor: type_iterators -> extension_constructor -> unit;
-    it_module_declaration: type_iterators -> module_declaration -> unit;
-    it_modtype_declaration: type_iterators -> modtype_declaration -> unit;
-    it_class_declaration: type_iterators -> class_declaration -> unit;
-    it_class_type_declaration: type_iterators -> class_type_declaration -> unit;
-    it_functor_param: type_iterators -> functor_parameter -> unit;
-    it_module_type: type_iterators -> module_type -> unit;
-    it_class_type: type_iterators -> class_type -> unit;
-    it_type_kind: type_iterators -> type_decl_kind -> unit;
-    it_do_type_expr: type_iterators -> type_expr -> unit;
-    it_type_expr: type_iterators -> type_expr -> unit;
+type 'a type_iterators =
+  { it_signature: 'a type_iterators -> signature -> unit;
+    it_signature_item: 'a type_iterators -> signature_item -> unit;
+    it_value_description: 'a type_iterators -> value_description -> unit;
+    it_type_declaration: 'a type_iterators -> type_declaration -> unit;
+    it_extension_constructor:
+        'a type_iterators -> extension_constructor -> unit;
+    it_module_declaration: 'a type_iterators -> module_declaration -> unit;
+    it_modtype_declaration: 'a type_iterators -> modtype_declaration -> unit;
+    it_class_declaration: 'a type_iterators -> class_declaration -> unit;
+    it_class_type_declaration:
+        'a type_iterators -> class_type_declaration -> unit;
+    it_functor_param: 'a type_iterators -> functor_parameter -> unit;
+    it_module_type: 'a type_iterators -> module_type -> unit;
+    it_class_type: 'a type_iterators -> class_type -> unit;
+    it_type_kind: 'a type_iterators -> type_decl_kind -> unit;
+    it_do_type_expr: 'a type_iterators -> 'a;
+    it_type_expr: 'a type_iterators -> type_expr -> unit;
     it_path: Path.t -> unit; }
-val type_iterators: type_mark -> type_iterators
-        (* Iteration on arbitrary type information.
+
+type type_iterators_full = (type_expr -> unit) type_iterators
+type type_iterators_without_type_expr = (unit -> unit) type_iterators
+
+val type_iterators: type_mark -> type_iterators_full
+        (* Iteration on arbitrary type information, including [type_expr].
            [it_type_expr] calls [mark_node] to avoid loops. *)
+
+val type_iterators_without_type_expr: type_iterators_without_type_expr
+        (* Iteration on arbitrary type information.
+           Cannot recurse on [type_expr]. *)
 
 val copy_type_desc:
     ?keep_names:bool -> (type_expr -> type_expr) -> type_desc -> type_desc

--- a/typing/btype.mli
+++ b/typing/btype.mli
@@ -154,10 +154,10 @@ type type_iterators =
     it_do_type_expr: type_iterators -> type_expr -> unit;
     it_type_expr: type_iterators -> type_expr -> unit;
     it_path: Path.t -> unit; }
-val type_iterators: type_iterators
+val type_iterators: type_mark -> type_iterators
         (* Iteration on arbitrary type information.
            [it_type_expr] calls [mark_node] to avoid loops. *)
-val unmark_iterators: type_iterators
+val unmark_iterators: type_mark -> type_iterators
         (* Unmark any structure containing types. See [unmark_type] below. *)
 
 val copy_type_desc:
@@ -185,38 +185,18 @@ module For_copy : sig
 end
 
 val lowest_level: int
-        (* Marked type: ty.level < lowest_level *)
+        (* lowest level for type nodes *)
 
-val not_marked_node: type_expr -> bool
-        (* Return true if a type node is not yet marked *)
-
-val logged_mark_node: type_expr -> unit
-        (* Mark a type node, logging the marking so it can be backtracked *)
-val try_logged_mark_node: type_expr -> bool
-        (* Mark a type node if it is not yet marked, logging the marking so it
-           can be backtracked.
-           Return false if it was already marked *)
-
-val flip_mark_node: type_expr -> unit
-        (* Mark a type node.
-           The marking is not logged and will have to be manually undone using
-           one of the various [unmark]'ing functions below. *)
-val try_mark_node: type_expr -> bool
-        (* Mark a type node if it is not yet marked.
-           The marking is not logged and will have to be manually undone using
-           one of the various [unmark]'ing functions below.
-
-           Return false if it was already marked *)
-val mark_type: type_expr -> unit
+val mark_type: type_mark -> type_expr -> unit
         (* Mark a type recursively *)
-val mark_type_params: type_expr -> unit
+val mark_type_params: type_mark -> type_expr -> unit
         (* Mark the sons of a type node recursively *)
 
-val unmark_type: type_expr -> unit
-val unmark_type_decl: type_declaration -> unit
-val unmark_extension_constructor: extension_constructor -> unit
-val unmark_class_type: class_type -> unit
-val unmark_class_signature: class_signature -> unit
+val unmark_type: type_mark -> type_expr -> unit
+val unmark_type_decl: type_mark -> type_declaration -> unit
+val unmark_extension_constructor: type_mark -> extension_constructor -> unit
+val unmark_class_type: type_mark -> class_type -> unit
+val unmark_class_signature: type_mark -> class_signature -> unit
         (* Remove marks from a type *)
 
 (**** Memorization of abbreviation expansion ****)

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -550,9 +550,9 @@ exception Non_closed of type_expr * variable_kind
    [free_variables] below drops the type/row information
    and only returns a [variable list].
  *)
-let free_vars ?env ty =
+let free_vars ?env mark ty =
   let rec fv ~kind acc ty =
-    if not (try_mark_node ty) then acc
+    if not (try_mark_node mark ty) then acc
     else match get_desc ty, env with
       | Tvar _, _ ->
           (ty, kind) :: acc
@@ -581,26 +581,29 @@ let free_vars ?env ty =
   in fv ~kind:Type_variable [] ty
 
 let free_variables ?env ty =
-  let tl = List.map fst (free_vars ?env ty) in
-  unmark_type ty;
-  tl
+  with_type_mark begin fun mark ->
+    let tl = List.map fst (free_vars ?env mark ty) in
+    unmark_type mark ty;
+    tl
+  end
 
-let closed_type ty =
-  match free_vars ty with
+let closed_type mark ty =
+  match free_vars mark ty with
       []           -> ()
   | (v, real) :: _ -> raise (Non_closed (v, real))
 
 let closed_parameterized_type params ty =
-  List.iter mark_type params;
-  let ok =
-    try closed_type ty; true with Non_closed _ -> false in
-  List.iter unmark_type params;
-  unmark_type ty;
-  ok
+  with_type_mark begin fun mark ->
+    List.iter (mark_type mark) params;
+    let ok =
+      try closed_type mark ty; true with Non_closed _ -> false in
+    List.iter (unmark_type mark) (ty :: params);
+    ok
+  end
 
 let closed_type_decl decl =
-  try
-    List.iter mark_type decl.type_params;
+  with_type_mark begin fun mark -> try
+    List.iter (mark_type mark) decl.type_params;
     begin match decl.type_kind with
       Type_abstract _ ->
         ()
@@ -611,36 +614,39 @@ let closed_type_decl decl =
             | Some _ -> ()
             | None ->
                 match cd_args with
-                | Cstr_tuple l ->  List.iter closed_type l
-                | Cstr_record l -> List.iter (fun l -> closed_type l.ld_type) l
+                | Cstr_tuple l ->  List.iter (closed_type mark) l
+                | Cstr_record l ->
+                    List.iter (fun l -> closed_type mark l.ld_type) l
           )
           v
     | Type_record(r, _rep) ->
-        List.iter (fun l -> closed_type l.ld_type) r
+        List.iter (fun l -> closed_type mark l.ld_type) r
     | Type_open -> ()
     end;
     begin match decl.type_manifest with
       None    -> ()
-    | Some ty -> closed_type ty
+    | Some ty -> closed_type mark ty
     end;
-    unmark_type_decl decl;
+    unmark_type_decl mark decl;
     None
   with Non_closed (ty, _) ->
-    unmark_type_decl decl;
+    unmark_type_decl mark decl;
     Some ty
+  end
 
 let closed_extension_constructor ext =
-  try
-    List.iter mark_type ext.ext_type_params;
+  with_type_mark begin fun mark -> try
+    List.iter (mark_type mark) ext.ext_type_params;
     begin match ext.ext_ret_type with
     | Some _ -> ()
-    | None -> iter_type_expr_cstr_args closed_type ext.ext_args
+    | None -> iter_type_expr_cstr_args (closed_type mark) ext.ext_args
     end;
-    unmark_extension_constructor ext;
+    unmark_extension_constructor mark ext;
     None
   with Non_closed (ty, _) ->
-    unmark_extension_constructor ext;
+    unmark_extension_constructor mark ext;
     Some ty
+  end
 
 type closed_class_failure = {
   free_variable: type_expr * variable_kind;
@@ -650,13 +656,14 @@ type closed_class_failure = {
 exception CCFailure of closed_class_failure
 
 let closed_class params sign =
-  List.iter mark_type params;
-  ignore (try_mark_node sign.csig_self_row);
+  with_type_mark begin fun mark ->
+  List.iter (mark_type mark) params;
+  ignore (try_mark_node mark sign.csig_self_row);
   try
     Meths.iter
       (fun lab (priv, _, ty) ->
         if priv = Mpublic then begin
-          try closed_type ty with Non_closed (ty0, variable_kind) ->
+          try closed_type mark ty with Non_closed (ty0, variable_kind) ->
             raise (CCFailure {
               free_variable = (ty0, variable_kind);
               meth = lab;
@@ -664,14 +671,14 @@ let closed_class params sign =
             })
         end)
       sign.csig_meths;
-    List.iter unmark_type params;
-    unmark_class_signature sign;
+    List.iter (unmark_type mark) params;
+    unmark_class_signature mark sign;
     None
   with CCFailure reason ->
-    List.iter unmark_type params;
-    unmark_class_signature sign;
+    List.iter (unmark_type mark) params;
+    unmark_class_signature mark sign;
     Some reason
-
+  end
 
                             (**********************)
                             (*  Type duplication  *)
@@ -786,35 +793,37 @@ let rec normalize_package_path env p =
           normalize_package_path env (Path.Pdot (p1', s))
       | _ -> p
 
-let rec check_scope_escape env level ty =
+let rec check_scope_escape mark env level ty =
   let orig_level = get_level ty in
-  if try_logged_mark_node ty then begin
+  if try_logged_mark_node mark ty then begin
     if level < get_scope ty then
       raise_scope_escape_exn ty;
     begin match get_desc ty with
     | Tconstr (p, _, _) when level < Path.scope p ->
         begin match !forward_try_expand_safe env ty with
         | ty' ->
-            check_scope_escape env level ty'
+            check_scope_escape mark env level ty'
         | exception Cannot_expand ->
             raise_escape_exn (Constructor p)
         end
     | Tpackage (p, fl) when level < Path.scope p ->
         let p' = normalize_package_path env p in
         if Path.same p p' then raise_escape_exn (Module_type p);
-        check_scope_escape env level
+        check_scope_escape mark env level
           (newty2 ~level:orig_level (Tpackage (p', fl)))
     | _ ->
-        iter_type_expr (check_scope_escape env level) ty
+        iter_type_expr (check_scope_escape mark env level) ty
     end;
   end
 
 let check_scope_escape env level ty =
   let snap = snapshot () in
-  try check_scope_escape env level ty; backtrack snap
+  with_type_mark begin fun mark -> try
+    check_scope_escape mark env level ty; backtrack snap
   with Escape e ->
     backtrack snap;
     raise (Escape { e with context = Some ty })
+  end
 
 let rec update_scope scope ty =
   if get_scope ty < scope then begin
@@ -1078,15 +1087,16 @@ let compute_univars ty =
 
 
 let fully_generic ty =
-  let rec aux ty =
-    if not_marked_node ty then
-      if get_level ty = generic_level then
-        (flip_mark_node ty; iter_type_expr aux ty)
-      else raise Exit
-  in
-  let res = try aux ty; true with Exit -> false in
-  unmark_type ty;
-  res
+  with_type_mark begin fun mark ->
+    let rec aux ty =
+      if try_mark_node mark ty then
+        if get_level ty = generic_level then iter_type_expr aux ty
+        else raise Exit
+    in
+    let res = try aux ty; true with Exit -> false in
+    unmark_type mark ty;
+    res
+  end
 
 
                               (*******************)
@@ -1967,10 +1977,11 @@ let unify_univar_for tr_exn t1 t2 univar_pairs =
 (* If [inj_only=true], only check injective positions *)
 let occur_univar ?(inj_only=false) env ty =
   let visited = ref TypeMap.empty in
+  with_type_mark begin fun mark ->
   let rec occur_rec bound ty =
-    if not_marked_node ty then
+    if not_marked_node mark ty then
       if TypeSet.is_empty bound then
-        (flip_mark_node ty; occur_desc bound ty)
+        (ignore (try_mark_node mark ty); occur_desc bound ty)
       else try
         let bound' = TypeMap.find ty !visited in
         if not (TypeSet.subset bound' bound) then begin
@@ -2009,10 +2020,9 @@ let occur_univar ?(inj_only=false) env ty =
           end
       | _ -> iter_type_expr (occur_rec bound) ty
   in
-  Misc.try_finally (fun () ->
-      occur_rec TypeSet.empty ty
-    )
-    ~always:(fun () -> unmark_type ty)
+  Misc.try_finally (fun () -> occur_rec TypeSet.empty ty)
+    ~always:(fun () -> unmark_type mark ty)
+  end
 
 let has_free_univars env ty =
   try occur_univar ~inj_only:false env ty; false with Escape _ -> true
@@ -2179,16 +2189,18 @@ let unexpanded_diff ~got ~expected =
 
 (* Return whether [t0] occurs in [ty]. Objects are also traversed. *)
 let deep_occur t0 ty =
+  with_type_mark begin fun mark ->
   let rec occur_rec ty =
-    if get_level ty >= get_level t0 && try_mark_node ty then begin
+    if get_level ty >= get_level t0 && try_mark_node mark ty then begin
       if eq_type ty t0 then raise Occur;
       iter_type_expr occur_rec ty
     end
   in
   try
-    occur_rec ty; unmark_type ty; false
+    occur_rec ty; unmark_type mark ty; false
   with Occur ->
-    unmark_type ty; true
+    unmark_type mark ty; true
+  end
 
 
 (* A local constraint can be added only if the rhs
@@ -2499,14 +2511,16 @@ let mcomp_for tr_exn env t1 t2 =
 
 let find_lowest_level ty =
   let lowest = ref generic_level in
-  let rec find ty =
-    if not_marked_node ty then begin
-      let level = get_level ty in
-      if level < !lowest then lowest := level;
-      flip_mark_node ty;
-      iter_type_expr find ty
-    end
-  in find ty; unmark_type ty; !lowest
+  with_type_mark begin fun mark ->
+    let rec find ty =
+      if try_mark_node mark ty then begin
+        let level = get_level ty in
+        if level < !lowest then lowest := level;
+        iter_type_expr find ty
+      end
+    in find ty; unmark_type mark ty
+  end;
+  !lowest
 
 (* This function can be called only in [Pattern] mode. *)
 let add_gadt_equation uenv source destination =
@@ -3710,16 +3724,17 @@ let generalize_class_signature_spine env sign =
    variables from the subject are not lowered.
 *)
 let moregen_occur env level ty =
-  let rec occur ty =
-    let lv = get_level ty in
-    if lv <= level then () else
-    if is_Tvar ty && lv >= generic_level - 1 then raise Occur else
-    if try_mark_node ty then iter_type_expr occur ty
-  in
-  begin try
-    occur ty; unmark_type ty
-  with Occur ->
-    unmark_type ty; raise_unexplained_for Moregen
+  with_type_mark begin fun mark ->
+    let rec occur ty =
+      let lv = get_level ty in
+      if lv <= level then () else
+      if is_Tvar ty && lv >= generic_level - 1 then raise Occur else
+      if try_mark_node mark ty then iter_type_expr occur ty
+    in
+    try
+      occur ty; unmark_type mark ty
+    with Occur ->
+      unmark_type mark ty; raise_unexplained_for Moregen
   end;
   (* also check for free univars *)
   occur_univar_for Moregen env ty;
@@ -3999,8 +4014,8 @@ let is_moregeneral env inst_nongen pat_sch subj_sch =
    and check validity after unification *)
 (* Simpler, no? *)
 
-let rec rigidify_rec vars ty =
-  if try_mark_node ty then
+let rec rigidify_rec mark vars ty =
+  if try_mark_node mark ty then
     begin match get_desc ty with
     | Tvar _ ->
         if not (TypeSet.mem ty !vars) then vars := TypeSet.add ty !vars
@@ -4013,18 +4028,17 @@ let rec rigidify_rec vars ty =
               ~name ~closed
           in link_type more (newty2 ~level:(get_level ty) (Tvariant row'))
         end;
-        iter_row (rigidify_rec vars) row;
+        iter_row (rigidify_rec mark vars) row;
         (* only consider the row variable if the variant is not static *)
         if not (static_row row) then
-          rigidify_rec vars (row_more row)
+          rigidify_rec mark vars (row_more row)
     | _ ->
-        iter_type_expr (rigidify_rec vars) ty
+        iter_type_expr (rigidify_rec mark vars) ty
     end
 
 let rigidify ty =
   let vars = ref TypeSet.empty in
-  rigidify_rec vars ty;
-  unmark_type ty;
+  with_type_mark (fun mark -> rigidify_rec mark vars ty; unmark_type mark ty);
   TypeSet.elements !vars
 
 let all_distinct_vars env vars =

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -5211,9 +5211,8 @@ let nongen_vars_in_class_declaration cty =
 
 (* Normalize a type before printing, saving... *)
 (* Cannot use mark_type because deep_occur uses it too *)
-let rec normalize_type_rec visited ty =
-  if not (TypeSet.mem ty !visited) then begin
-    visited := TypeSet.add ty !visited;
+let rec normalize_type_rec mark ty =
+  if try_mark_node mark ty then begin
     let tm = row_of_type ty in
     begin if not (is_Tconstr ty) && is_constr_row ~allow_ident:false tm then
       match get_desc tm with (* PR#7348 *)
@@ -5272,11 +5271,11 @@ let rec normalize_type_rec visited ty =
         set_type_desc fi (get_desc fi')
     | _ -> ()
     end;
-    iter_type_expr (normalize_type_rec visited) ty;
+    iter_type_expr (normalize_type_rec mark) ty;
   end
 
 let normalize_type ty =
-  normalize_type_rec (ref TypeSet.empty) ty
+  with_type_mark (fun mark -> normalize_type_rec mark ty)
 
 
                               (*************************)

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -2033,10 +2033,9 @@ let get_univar_family univar_pairs univars =
 (* Whether a family of univars escapes from a type *)
 let univars_escape env univar_pairs vl ty =
   let family = get_univar_family univar_pairs vl in
-  let visited = ref TypeSet.empty in
+  with_type_mark begin fun mark ->
   let rec occur t =
-    if TypeSet.mem t !visited then () else begin
-      visited := TypeSet.add t !visited;
+    if try_mark_node mark t then begin
       match get_desc t with
         Tpoly (t, tl) ->
           if List.exists (fun t -> TypeSet.mem t family) tl then ()
@@ -2058,6 +2057,7 @@ let univars_escape env univar_pairs vl ty =
     end
   in
   occur ty
+  end
 
 (* Wrapper checking that no variable escapes and updating univar_pairs *)
 let enter_poly env univar_pairs t1 tl1 t2 tl2 f =

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -780,7 +780,7 @@ let rec normalize_package_path env p =
 
 let rec check_scope_escape mark env level ty =
   let orig_level = get_level ty in
-  if try_logged_mark_node mark ty then begin
+  if try_mark_node mark ty then begin
     if level < get_scope ty then
       raise_scope_escape_exn ty;
     begin match get_desc ty with
@@ -802,11 +802,9 @@ let rec check_scope_escape mark env level ty =
   end
 
 let check_scope_escape env level ty =
-  let snap = snapshot () in
   with_type_mark begin fun mark -> try
-    check_scope_escape mark env level ty; backtrack snap
+    check_scope_escape mark env level ty
   with Escape e ->
-    backtrack snap;
     raise (Escape { e with context = Some ty })
   end
 

--- a/typing/datarepr.ml
+++ b/typing/datarepr.ml
@@ -40,8 +40,7 @@ let free_vars ?(param=false) ty =
         | _ ->
             iter_type_expr loop ty
     in
-    loop ty;
-    unmark_type mark ty
+    loop ty
   end;
   !ret
 

--- a/typing/datarepr.ml
+++ b/typing/datarepr.ml
@@ -23,24 +23,26 @@ open Btype
 (* Simplified version of Ctype.free_vars *)
 let free_vars ?(param=false) ty =
   let ret = ref TypeSet.empty in
-  let rec loop ty =
-    if try_mark_node ty then
-      match get_desc ty with
-      | Tvar _ ->
-          ret := TypeSet.add ty !ret
-      | Tvariant row ->
-          iter_row loop row;
-          if not (static_row row) then begin
-            match get_desc (row_more row) with
-            | Tvar _ when param -> ret := TypeSet.add ty !ret
-            | _ -> loop (row_more row)
-          end
-      (* XXX: What about Tobject ? *)
-      | _ ->
-          iter_type_expr loop ty
-  in
-  loop ty;
-  unmark_type ty;
+  with_type_mark begin fun mark ->
+    let rec loop ty =
+      if try_mark_node mark ty then
+        match get_desc ty with
+        | Tvar _ ->
+            ret := TypeSet.add ty !ret
+        | Tvariant row ->
+            iter_row loop row;
+            if not (static_row row) then begin
+              match get_desc (row_more row) with
+              | Tvar _ when param -> ret := TypeSet.add ty !ret
+              | _ -> loop (row_more row)
+            end
+                (* XXX: What about Tobject ? *)
+        | _ ->
+            iter_type_expr loop ty
+    in
+    loop ty;
+    unmark_type mark ty
+  end;
   !ret
 
 let newgenconstr path tyl = newgenty (Tconstr (path, tyl, ref Mnil))

--- a/typing/ident.ml
+++ b/typing/ident.ml
@@ -16,7 +16,7 @@
 open Local_store
 
 let lowest_scope  = 0
-let highest_scope = 100000000
+let highest_scope = 100_000_000
 
 type t =
   | Local of { name: string; stamp: int }

--- a/typing/ident.ml
+++ b/typing/ident.ml
@@ -17,6 +17,7 @@ open Local_store
 
 let lowest_scope  = 0
 let highest_scope = 100_000_000
+  (* assumed to fit in 27 bits, see Types.scope_field *)
 
 type t =
   | Local of { name: string; stamp: int }

--- a/typing/mtype.ml
+++ b/typing/mtype.ml
@@ -457,10 +457,10 @@ let collect_arg_paths mty =
   (* let rt = Ident.create "Root" in
      and prefix = ref (Path.Pident rt) in *)
   with_type_mark begin fun mark ->
-  let type_iterators = type_iterators mark in
+  let super = type_iterators mark in
   let it_path p = paths := Path.Set.union (get_arg_paths p) !paths
   and it_signature_item it si =
-    type_iterators.it_signature_item it si;
+    super.it_signature_item it si;
     match si with
     | Sig_module (id, _, {md_type=Mty_alias p}, _, _) ->
         bindings := Ident.add id p !bindings
@@ -473,7 +473,7 @@ let collect_arg_paths mty =
           sg
     | _ -> ()
   in
-  let it = {type_iterators with it_path; it_signature_item} in
+  let it = {super with it_path; it_signature_item} in
   it.it_module_type it mty;
   Path.Set.fold (fun p -> Ident.Set.union (collect_ids !subst !bindings p))
     !paths Ident.Set.empty
@@ -555,15 +555,15 @@ let scrape_for_type_of ~remove_aliases env mty =
 let lower_nongen nglev mty =
   let open Btype in
   with_type_mark begin fun mark ->
-  let type_iterators = type_iterators mark in
-  let it_type_expr it ty =
+  let super = type_iterators mark in
+  let it_do_type_expr it ty =
     match get_desc ty with
       Tvar _ ->
         let level = get_level ty in
         if level < generic_level && level > nglev then set_level ty nglev
     | _ ->
-        type_iterators.it_type_expr it ty
+        super.it_do_type_expr it ty
   in
-  let it = {type_iterators with it_type_expr} in
+  let it = {super with it_do_type_expr} in
   it.it_module_type it mty
   end

--- a/typing/mtype.ml
+++ b/typing/mtype.ml
@@ -456,6 +456,8 @@ let collect_arg_paths mty =
   and bindings = ref Ident.empty in
   (* let rt = Ident.create "Root" in
      and prefix = ref (Path.Pident rt) in *)
+  with_type_mark begin fun mark ->
+  let type_iterators = type_iterators mark in
   let it_path p = paths := Path.Set.union (get_arg_paths p) !paths
   and it_signature_item it si =
     type_iterators.it_signature_item it si;
@@ -473,9 +475,10 @@ let collect_arg_paths mty =
   in
   let it = {type_iterators with it_path; it_signature_item} in
   it.it_module_type it mty;
-  it.it_module_type unmark_iterators mty;
+  it.it_module_type (unmark_iterators mark) mty;
   Path.Set.fold (fun p -> Ident.Set.union (collect_ids !subst !bindings p))
     !paths Ident.Set.empty
+  end
 
 type remove_alias_args =
     { mutable modified: bool;
@@ -552,6 +555,8 @@ let scrape_for_type_of ~remove_aliases env mty =
 
 let lower_nongen nglev mty =
   let open Btype in
+  with_type_mark begin fun mark ->
+  let type_iterators = type_iterators mark in
   let it_type_expr it ty =
     match get_desc ty with
       Tvar _ ->
@@ -562,4 +567,5 @@ let lower_nongen nglev mty =
   in
   let it = {type_iterators with it_type_expr} in
   it.it_module_type it mty;
-  it.it_module_type unmark_iterators mty
+  it.it_module_type (unmark_iterators mark) mty
+  end

--- a/typing/mtype.ml
+++ b/typing/mtype.ml
@@ -475,7 +475,6 @@ let collect_arg_paths mty =
   in
   let it = {type_iterators with it_path; it_signature_item} in
   it.it_module_type it mty;
-  it.it_module_type (unmark_iterators mark) mty;
   Path.Set.fold (fun p -> Ident.Set.union (collect_ids !subst !bindings p))
     !paths Ident.Set.empty
   end
@@ -566,6 +565,5 @@ let lower_nongen nglev mty =
         type_iterators.it_type_expr it ty
   in
   let it = {type_iterators with it_type_expr} in
-  it.it_module_type it mty;
-  it.it_module_type (unmark_iterators mark) mty
+  it.it_module_type it mty
   end

--- a/typing/printtyp.ml
+++ b/typing/printtyp.ml
@@ -494,7 +494,7 @@ let rec raw_type ppf ty =
   if List.memq ty !visited then fprintf ppf "{id=%d}" ty.id else begin
     visited := ty :: !visited;
     fprintf ppf "@[<1>{id=%d;level=%d;scope=%d;desc=@,%a}@]" ty.id ty.level
-      ty.scope raw_type_desc ty.desc
+      (Transient_expr.get_scope ty) raw_type_desc ty.desc
   end
 and raw_type_list tl = raw_list raw_type tl
 and raw_lid_type_list tl =

--- a/typing/printtyp.ml
+++ b/typing/printtyp.ml
@@ -493,8 +493,10 @@ let rec raw_type ppf ty =
   let ty = safe_repr [] ty in
   if List.memq ty !visited then fprintf ppf "{id=%d}" ty.id else begin
     visited := ty :: !visited;
-    fprintf ppf "@[<1>{id=%d;level=%d;scope=%d;desc=@,%a}@]" ty.id ty.level
-      (Transient_expr.get_scope ty) raw_type_desc ty.desc
+    fprintf ppf "@[<1>{id=%d;level=%d;scope=%d;marks=%x;desc=@,%a}@]"
+      ty.id ty.level
+      (Transient_expr.get_scope ty) (Transient_expr.get_marks ty)
+      raw_type_desc ty.desc
   end
 and raw_type_list tl = raw_list raw_type tl
 and raw_lid_type_list tl =

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -2957,8 +2957,7 @@ let generalizable level ty =
       if try_mark_node mark ty then
         if get_level ty <= level then raise Exit else iter_type_expr check ty
     in
-    try check ty; unmark_type mark ty; true
-    with Exit -> unmark_type mark ty; false
+    try check ty; true with Exit -> false
   end
 
 (* Hack to allow coercion of self. Will clean-up later. *)
@@ -2982,8 +2981,7 @@ let contains_variant_either ty =
           iter_type_expr loop ty
       end
   in
-  try loop ty; unmark_type mark ty; false
-  with Exit -> unmark_type mark ty; true
+  try loop ty; false with Exit -> true
   end
 
 let shallow_iter_ppat f p =

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -2952,13 +2952,14 @@ let pattern_needs_partial_application_check p =
 
 (* Check that a type is generalizable at some level *)
 let generalizable level ty =
-  let rec check ty =
-    if not_marked_node ty then
-      if get_level ty <= level then raise Exit else
-      (flip_mark_node ty; iter_type_expr check ty)
-  in
-  try check ty; unmark_type ty; true
-  with Exit -> unmark_type ty; false
+  with_type_mark begin fun mark ->
+    let rec check ty =
+      if try_mark_node mark ty then
+        if get_level ty <= level then raise Exit else iter_type_expr check ty
+    in
+    try check ty; unmark_type mark ty; true
+    with Exit -> unmark_type mark ty; false
+  end
 
 (* Hack to allow coercion of self. Will clean-up later. *)
 let self_coercion = ref ([] : (Path.t * Location.t list ref) list)
@@ -2966,8 +2967,9 @@ let self_coercion = ref ([] : (Path.t * Location.t list ref) list)
 (* Helpers for type_cases *)
 
 let contains_variant_either ty =
+  with_type_mark begin fun mark ->
   let rec loop ty =
-    if try_mark_node ty then
+    if try_mark_node mark ty then
       begin match get_desc ty with
         Tvariant row ->
           if not (is_fixed row) then
@@ -2980,8 +2982,9 @@ let contains_variant_either ty =
           iter_type_expr loop ty
       end
   in
-  try loop ty; unmark_type ty; false
-  with Exit -> unmark_type ty; true
+  try loop ty; unmark_type mark ty; false
+  with Exit -> unmark_type mark ty; true
+  end
 
 let shallow_iter_ppat f p =
   match p.ppat_desc with

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -913,12 +913,14 @@ let check_well_founded_decl  ~abs_env env loc path decl to_check =
          type declaration that have common subexpressions. *)
       ref TypeMap.empty in
     let it =
-      {super with it_type_expr =
+      {super with it_do_type_expr =
        (fun self ty ->
          check_well_founded ~abs_env env loc path to_check visited ty;
          super.it_do_type_expr self ty
        )} in
-    it.it_type_declaration it (Ctype.generic_instance_declaration decl)
+    let decl = Ctype.generic_instance_declaration decl in
+    it.it_type_declaration it decl;
+    unmark_type_decl mark decl
   end
 
 (* Check for non-regular abbreviations; an abbreviation

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -918,9 +918,7 @@ let check_well_founded_decl  ~abs_env env loc path decl to_check =
          check_well_founded ~abs_env env loc path to_check visited ty;
          super.it_do_type_expr self ty
        )} in
-    let decl = Ctype.generic_instance_declaration decl in
-    it.it_type_declaration it decl;
-    unmark_type_decl mark decl
+    it.it_type_declaration it (Ctype.generic_instance_declaration decl)
   end
 
 (* Check for non-regular abbreviations; an abbreviation

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -416,8 +416,9 @@ let check_well_formed_module env loc context mty =
       | _ :: rem ->
           check_signature env rem
     in
-    (* we do not use marks here *)
-    let env, super = with_type_mark (fun mark -> iterator_with_env mark env) in
+    (* we are not using marks here ... *)
+    with_type_mark begin fun mark ->
+    let env, super = iterator_with_env mark env in
     { super with
       it_type_expr = (fun _self _ty -> ());
       it_signature = (fun self sg ->
@@ -426,6 +427,7 @@ let check_well_formed_module env loc context mty =
         check_signature env sg;
         super.it_signature self sg);
     }
+    end
   in
   iterator.it_module_type iterator mty
 

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -379,9 +379,7 @@ let do_check_after_substitution env ~loc ~lid paths unpackable_modtype sg =
        let error p = With_cannot_remove_packed_modtype(p,mty) in
        check_usage_of_module_types ~error ~paths ~loc env iterator
   in
-  iterator.Btype.it_signature iterator sg;
-  let unmark_it = Btype.unmark_iterators mark in
-  unmark_it.Btype.it_signature unmark_it sg
+  iterator.Btype.it_signature iterator sg
   end
 
 let check_usage_after_substitution env ~loc ~lid paths unpackable_modtype sg =
@@ -1192,9 +1190,7 @@ end = struct
           check_usage_of_module_types ~loc ~error ~paths
             (ref (lazy env)) (Btype.type_iterators mark)
         in
-        iterator.Btype.it_signature_item iterator component;
-        let unmark = Btype.unmark_iterators mark in
-        unmark.Btype.it_signature_item unmark component
+        iterator.Btype.it_signature_item iterator component
       end
 
   (* We usually require name uniqueness of signature components (e.g. types,

--- a/typing/types.ml
+++ b/typing/types.ml
@@ -852,11 +852,6 @@ let set_univar rty ty =
 let set_name nm v =
   log_change (Cname (nm, !nm)); nm := v
 
-let try_logged_mark_node mark ty =
-  let ty = repr ty in
-  (Transient_expr.not_marked_node mark ty) &&
-  (match mark with Mark{mark} -> set_scope_field ty (ty.scope lxor mark); true)
-
 let rec link_row_field_ext ~(inside : row_field) (v : row_field) =
   match inside with
   | RFeither {ext = {contents = RFnone} as e} ->

--- a/typing/types.ml
+++ b/typing/types.ml
@@ -589,11 +589,11 @@ type type_mark =
   | Mark of {mark: int; mutable marked: type_expr list}
   | Set of {mutable visited: TransientTypeSet.t}
 let type_marks =
+  (* All the bits in marks_mask *)
   List.init (Sys.int_size - 27) (fun x -> 1 lsl (x + 27))
 let available_marks = Local_store.s_ref type_marks
 let with_type_mark f =
   match !available_marks with
-  | [] -> f (Set {visited = TransientTypeSet.empty})
   | mark :: rem as old ->
       available_marks := rem;
       let mk = Mark {mark; marked = []} in
@@ -607,6 +607,9 @@ let with_type_mark f =
               marked
         | Set _ -> ()
       end
+  | [] ->
+      (* When marks are exhausted, fall back to using a set *)
+      f (Set {visited = TransientTypeSet.empty})
 
 (* getters for type_expr *)
 

--- a/typing/types.ml
+++ b/typing/types.ml
@@ -596,7 +596,7 @@ let type_marks =
 let available_marks = Local_store.s_ref type_marks
 let with_type_mark f =
   match !available_marks with
-  | mark :: rem as old when false ->
+  | mark :: rem as old ->
       available_marks := rem;
       let mk = Mark {mark; marked = []} in
       Misc.try_finally (fun () -> f mk) ~always: begin fun () ->
@@ -609,7 +609,7 @@ let with_type_mark f =
               marked
         | Set _ -> ()
       end
-  | _ ->
+  | [] ->
       (* When marks are exhausted, fall back to using a set *)
       f (Set {visited = TransientTypeHash.create 1})
 

--- a/typing/types.ml
+++ b/typing/types.ml
@@ -584,7 +584,7 @@ let scope_mask = (1 lsl 27) - 1
 let marks_mask = (-1) lxor scope_mask
 type type_mark = int
 let type_marks = List.map (fun x -> 1 lsl x) [27; 28; 29; 30]
-let available_marks = ref type_marks
+let available_marks = Local_store.s_ref type_marks
 let with_type_mark f =
   match !available_marks with
   | [] -> failwith "with_type_mark : no marks available"
@@ -610,6 +610,7 @@ module Transient_expr = struct
   let set_level ty lv = ty.level <- lv
   let set_scope_field ty sc = ty.scope <- sc
   let get_scope ty = ty.scope land scope_mask
+  let get_marks ty = ty.scope lsr 27
   let set_scope ty sc =
     assert (sc land marks_mask = 0);
     ty.scope <- (ty.scope land marks_mask) lor sc

--- a/typing/types.ml
+++ b/typing/types.ml
@@ -610,7 +610,7 @@ let with_type_mark f =
         | Hash _ -> ()
       end
   | [] ->
-      (* When marks are exhausted, fall back to using a set *)
+      (* When marks are exhausted, fall back to using a hash table *)
       f (Hash {visited = TransientTypeHash.create 1})
 
 (* getters for type_expr *)

--- a/typing/types.mli
+++ b/typing/types.mli
@@ -231,14 +231,10 @@ val not_marked_node: type_mark -> type_expr -> bool
 
 val try_mark_node: type_mark -> type_expr -> bool
         (* Mark a type node if it is not yet marked.
-           The marking is not logged and will have to be manually undone using
-           one of the various [unmark]'ing functions below.
+           Marks will be automatically removed when leaving the
+           scope of [with_type_mark].
 
            Return false if it was already marked *)
-
-val try_unmark_node: type_mark -> type_expr -> bool
-        (* Same as [try_mark_node] for unmarking.
-           Return false if it was not marked *)
 
 val try_logged_mark_node: type_mark -> type_expr -> bool
         (* Mark a type node if it is not yet marked, logging the marking so it
@@ -274,7 +270,6 @@ module Transient_expr : sig
 
   val not_marked_node: type_mark -> transient_expr -> bool
   val try_mark_node: type_mark -> transient_expr -> bool
-  val try_unmark_node: type_mark -> transient_expr -> bool
 end
 
 val create_expr: type_desc -> level: int -> scope: int -> id: int -> type_expr

--- a/typing/types.mli
+++ b/typing/types.mli
@@ -285,6 +285,8 @@ module TransientTypeOps : sig
   val hash : t -> int
 end
 
+module TransientTypeSet : Set.S with type elt = transient_expr
+
 (** Comparisons for [type_expr]; cannot be used for functors *)
 
 val eq_type: type_expr -> type_expr -> bool

--- a/typing/types.mli
+++ b/typing/types.mli
@@ -259,6 +259,7 @@ module Transient_expr : sig
 
   val create: type_desc -> level: int -> scope: int -> id: int -> transient_expr
   val get_scope: transient_expr -> int
+  val get_marks: transient_expr -> int
   val set_desc: transient_expr -> type_desc -> unit
   val set_level: transient_expr -> int -> unit
   val set_scope: transient_expr -> int -> unit

--- a/typing/types.mli
+++ b/typing/types.mli
@@ -221,18 +221,33 @@ val get_level: type_expr -> int
 val get_scope: type_expr -> int
 val get_id: type_expr -> int
 
+(** Access to marks. They are stored in the scope field. *)
+type type_mark
+val copy_mark: type_mark
+val not_marked_node: type_mark -> type_expr -> bool
+val mark_node: type_mark -> type_expr -> bool
+        (* [not_marked_node] and [may_mark_node] return true if the node
+           was not marked. Additionally, [may_mark_node] sets the node in
+           that case, without logging it for backtracking. *)
+val unmark_node: type_mark -> type_expr -> bool
+        (* [unmark_node] returns true if the node was marked *)
+val logged_mark_node: type_mark -> type_expr -> bool
+        (* same as [mark_node] but the change is logged for backtracking *)
+
 (** Transient [type_expr].
     Should only be used immediately after [Transient_expr.repr] *)
 type transient_expr = private
       { mutable desc: type_desc;
         mutable level: int;
-        mutable scope: int;
+        mutable scope: scope_field;
         id: int }
+and scope_field (* abstract *)
 
 module Transient_expr : sig
   (** Operations on [transient_expr] *)
 
   val create: type_desc -> level: int -> scope: int -> id: int -> transient_expr
+  val get_scope: transient_expr -> int
   val set_desc: transient_expr -> type_desc -> unit
   val set_level: transient_expr -> int -> unit
   val set_scope: transient_expr -> int -> unit
@@ -240,10 +255,12 @@ module Transient_expr : sig
   val type_expr: transient_expr -> type_expr
   val coerce: type_expr -> transient_expr
       (** Coerce without normalizing with [repr] *)
-
   val set_stub_desc: type_expr -> type_desc -> unit
       (** Instantiate a not yet instantiated stub.
           Fail if already instantiated. *)
+  val not_marked_node: type_mark -> transient_expr -> bool
+  val mark_node: type_mark -> transient_expr -> bool
+  val unmark_node: type_mark -> transient_expr -> bool
 end
 
 val create_expr: type_desc -> level: int -> scope: int -> id: int -> type_expr

--- a/typing/types.mli
+++ b/typing/types.mli
@@ -285,7 +285,7 @@ module TransientTypeOps : sig
   val hash : t -> int
 end
 
-module TransientTypeSet : Set.S with type elt = transient_expr
+module TransientTypeHash : Hashtbl.S with type key = transient_expr
 
 (** Comparisons for [type_expr]; cannot be used for functors *)
 

--- a/typing/types.mli
+++ b/typing/types.mli
@@ -263,7 +263,6 @@ module Transient_expr : sig
       (** Instantiate a not yet instantiated stub.
           Fail if already instantiated. *)
 
-  val not_marked_node: type_mark -> transient_expr -> bool
   val try_mark_node: type_mark -> transient_expr -> bool
 end
 

--- a/typing/types.mli
+++ b/typing/types.mli
@@ -236,11 +236,6 @@ val try_mark_node: type_mark -> type_expr -> bool
 
            Return false if it was already marked *)
 
-val try_logged_mark_node: type_mark -> type_expr -> bool
-        (* Mark a type node if it is not yet marked, logging the marking so it
-           can be backtracked.
-           Return false if it was already marked *)
-
 (** Transient [type_expr].
     Should only be used immediately after [Transient_expr.repr] *)
 type transient_expr = private

--- a/typing/typetexp.ml
+++ b/typing/typetexp.ml
@@ -784,10 +784,7 @@ let rec make_fixed_univars mark ty =
     end
 
 let make_fixed_univars ty =
-  with_type_mark begin fun mark ->
-    make_fixed_univars mark ty;
-    Btype.unmark_type mark ty
-  end
+  with_type_mark (fun mark -> make_fixed_univars mark ty)
 
 let transl_type env policy styp =
   transl_type env ~policy ~row_context:[] styp

--- a/typing/typetexp.ml
+++ b/typing/typetexp.ml
@@ -760,8 +760,8 @@ and transl_fields env ~policy ~row_context o fields =
 
 
 (* Make the rows "fixed" in this type, to make universal check easier *)
-let rec make_fixed_univars ty =
-  if Btype.try_mark_node ty then
+let rec make_fixed_univars mark ty =
+  if try_mark_node mark ty then
     begin match get_desc ty with
     | Tvariant row ->
         let Row {fields; more; name; closed} = row_repr row in
@@ -778,17 +778,19 @@ let rec make_fixed_univars ty =
             (Tvariant
                (create_row ~fields ~more ~name ~closed
                   ~fixed:(Some (Univar more))));
-        Btype.iter_row make_fixed_univars row
+        Btype.iter_row (make_fixed_univars mark) row
     | _ ->
-        Btype.iter_type_expr make_fixed_univars ty
+        Btype.iter_type_expr (make_fixed_univars mark) ty
     end
+
+let make_fixed_univars ty =
+  with_type_mark begin fun mark ->
+    make_fixed_univars mark ty;
+    Btype.unmark_type mark ty
+  end
 
 let transl_type env policy styp =
   transl_type env ~policy ~row_context:[] styp
-
-let make_fixed_univars ty =
-  make_fixed_univars ty;
-  Btype.unmark_type ty
 
 let transl_simple_type env ?univars ~closed styp =
   TyVarEnv.reset_locals ?univars ();


### PR DESCRIPTION
This PR makes the `scope` field of `Types.transient_expr` a bitfield, and uses it to store marks.
There are at least 4 marks, which can be used exclusively by using
```ocaml
val with_type_mark: (type_mark -> 'a) -> 'a
```
which also takes care of unmarking.
This alleviates the problem of nested uses.
There seems to be no impact on performance.

Subsumes #12852 and #12853.
Done in cooperation with @t6s .