### PR TITLE
Consistent errors on closed channels

### DIFF
--- a/runtime/io.c
+++ b/runtime/io.c
@@ -449,6 +449,9 @@ CAMLexport intnat caml_really_getblock(struct channel *chan, char *p, intnat n)
 CAMLexport void caml_seek_in(struct channel *channel, file_offset dest)
 {
   file_offset res;
+  /* If the desired position happens to live within our input buffer,
+     we don't need to actually call [lseek] on the file descriptor, it
+     suffices to move the current position within the buffer. */
   if (dest >= channel->offset - (channel->max - channel->buff)
       && dest <= channel->offset
       && (channel->flags & CHANNEL_TEXT_MODE) == 0) {

--- a/testsuite/tests/lib-channels/close_in.ml
+++ b/testsuite/tests/lib-channels/close_in.ml
@@ -10,9 +10,9 @@ let () =
   let ic = open_in_bin Sys.argv.(0) in
   seek_in ic nb_bytes;
   close_in ic;
-  seek_in ic 0;
   assert (
     try
+      seek_in ic 0;
       ignore (input_byte ic);
       false
     with

--- a/testsuite/tests/lib-channels/close_in.ml
+++ b/testsuite/tests/lib-channels/close_in.ml
@@ -18,3 +18,16 @@ let () =
     with
     | Sys_error _ -> true
     | _           -> false)
+
+
+(* A variant of #11878, which #11965 failed to fix. *)
+let () =
+  let ic = open_in_bin Sys.argv.(0) in
+  close_in ic;
+  begin try
+    seek_in ic (-1);
+    ignore (input_byte ic);
+    assert false;
+  with
+  | Sys_error _ -> ()
+  end

--- a/testsuite/tests/lib-channels/close_out.ml
+++ b/testsuite/tests/lib-channels/close_out.ml
@@ -1,0 +1,19 @@
+(* TEST
+
+   arguments = "${test_build_directory}/testfile.tmp";
+*)
+
+(* Test that output to a closed out_channel triggers an exception every
+   time, not just the first time. *)
+
+let () =
+  let oc = open_out_bin Sys.argv.(1) in
+  close_out oc;
+  begin match output_byte oc 0 with
+  | exception Sys_error _ -> ()
+  | () -> assert false
+  end;
+  begin match output_byte oc 0 with
+  | exception Sys_error _ -> ()
+  | () -> assert false
+  end


### PR DESCRIPTION
This PR is a proposal to fix #12898, ensuring that read and write operations on closed channels consistently fail.

(This relies on @jmid's helpful investigation in https://github.com/ocaml/ocaml/issues/12898#issuecomment-1900333151 )

The Putch and Getch macros are performance-sensitive, and we don't want to check on each call if the channel has been closed in the meantime. So when closing a channel, we use the trick of bumping the "current position in the (input,output) buffer" (`channel->curr`) to the end of the buffer, to force the next read or write to take the slow path (to flush or refill the buffer), and that slow path will fail on closed channels. To fail gracefully, the current position must be at the end of the buffer.

But then #12314 broke this logic slightly by ensuring that the current position of the buffer is reset to the beginning of the buffer (`channel->buff`) in certain permanent failure conditions, to cooperate with some logic in the finalizer that is careful to *not* reclaim output channels if they have some buffered data left to be written. To be reclaimed gracefully, the current position must be at the beginning of the buffer.

One of those "failure conditions" happens when the channel is closed, and at this point the current position gets moved from the end of the buffer to the beginning of the buffer, making Putch, Getch not notice anymore that the channel is closed.

The fix I propose is to ensure that, when either we close the channel or we hit a permanent failure, we 'close' the buffer by moving the current position *and* the end position to the beginning of the channel.

Note: In order to understand the code and feel confident in my proposed fix, I changed the behavior of `caml_seek_in` slightly. In the common case, calling `seek_in` on a closed buffer fails. But there is a corner case (when the requested position lies within the input buffer) where it works, and in that case the current position in the buffer gets changed, so again we stop noticing that the channel is closed anymore. #11878 and #11965 tweaked the `close_in` code to ensure that a following `seek_in` would not hit this corner case. I find the resulting code too hard to reason about, and now `seek_in` consistently fails on closed channels.

