### PR TITLE
Fix an `.o` extension in the Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1234,7 +1234,7 @@ libasmruni_OBJECTS = \
 libasmrunpic_OBJECTS = $(runtime_NATIVE_C_SOURCES:.c=.npic.$(O)) \
   $(runtime_ASM_OBJECTS:.$(O)=_libasmrunpic.$(O))
 
-libcomprmarsh_OBJECTS = runtime/zstd.n.o
+libcomprmarsh_OBJECTS = runtime/zstd.n.$(O)
 
 ## General (non target-specific) assembler and compiler flags
 


### PR DESCRIPTION
The Makefile modifications in #12758 use the `.o` extension directly for the `zstd.n.o` file. This tiny fix PR turns it into a `.$(O)` to accomodate the MSVC toolchain.