### PR TITLE
Constify C constructors, arrays, and flags tables (take 2)

### DIFF
--- a/Changes
+++ b/Changes
@@ -54,6 +54,10 @@ _______________
 - #13163: Enable frame pointers on macOS x86_64
   (Tim McGilchrist, review by Sébastien Hinderer and Fabrice Buoro)
 
+- #12951: Constify constructors and flags tables in C code (take 2).
+  Now these tables will go in the readonly segment, where they belong.
+  (Antonin Décimo, review by David Allsopp)
+
 ### Code generation and optimizations:
 
 - #13014: Enable compile-time option -function-sections on all previously

--- a/otherlibs/unix/getaddrinfo.c
+++ b/otherlibs/unix/getaddrinfo.c
@@ -31,8 +31,8 @@
 #include <netdb.h>
 #endif
 
-extern int caml_unix_socket_domain_table[]; /* from socket.c */
-extern int caml_unix_socket_type_table[];   /* from socket.c */
+extern const int caml_unix_socket_domain_table[]; /* from socket.c */
+extern const int caml_unix_socket_type_table[];   /* from socket.c */
 
 static value convert_addrinfo(struct addrinfo * a)
 {

--- a/otherlibs/unix/lseek_win32.c
+++ b/otherlibs/unix/lseek_win32.c
@@ -26,7 +26,7 @@
 #define SEEK_END 2
 #endif
 
-static DWORD seek_command_table[] = {
+static const DWORD seek_command_table[] = {
   FILE_BEGIN, FILE_CURRENT, FILE_END
 };
 

--- a/otherlibs/unix/socket_unix.c
+++ b/otherlibs/unix/socket_unix.c
@@ -23,7 +23,7 @@
 #include <sys/types.h>
 #include <sys/socket.h>
 
-int caml_unix_socket_domain_table[] = {
+const int caml_unix_socket_domain_table[] = {
   PF_UNIX, PF_INET,
 #if defined(HAS_IPV6)
   PF_INET6
@@ -34,7 +34,7 @@ int caml_unix_socket_domain_table[] = {
 #endif
 };
 
-int caml_unix_socket_type_table[] = {
+const int caml_unix_socket_type_table[] = {
   SOCK_STREAM, SOCK_DGRAM, SOCK_RAW, SOCK_SEQPACKET
 };
 

--- a/otherlibs/unix/socket_win32.c
+++ b/otherlibs/unix/socket_win32.c
@@ -17,11 +17,11 @@
 #include <caml/memory.h>
 #include "caml/unixsupport.h"
 
-int caml_unix_socket_domain_table[] = {
+const int caml_unix_socket_domain_table[] = {
   PF_UNIX, PF_INET, PF_INET6
 };
 
-int caml_unix_socket_type_table[] = {
+const int caml_unix_socket_type_table[] = {
   SOCK_STREAM, SOCK_DGRAM, SOCK_RAW, SOCK_SEQPACKET
 };
 

--- a/otherlibs/unix/socketpair_unix.c
+++ b/otherlibs/unix/socketpair_unix.c
@@ -22,7 +22,7 @@
 
 #include <sys/socket.h>
 
-extern int caml_unix_socket_domain_table[], caml_unix_socket_type_table[];
+extern const int caml_unix_socket_domain_table[], caml_unix_socket_type_table[];
 
 CAMLprim value caml_unix_socketpair(value cloexec, value domain,
                                value type, value proto)

--- a/otherlibs/unix/socketpair_win32.c
+++ b/otherlibs/unix/socketpair_win32.c
@@ -25,8 +25,8 @@
 #include "caml/socketaddr.h"
 #include <ws2tcpip.h>
 
-extern int caml_unix_socket_domain_table[]; /* from socket.c */
-extern int caml_unix_socket_type_table[]; /* from socket.c */
+extern const int caml_unix_socket_domain_table[]; /* from socket.c */
+extern const int caml_unix_socket_type_table[]; /* from socket.c */
 
 #ifdef HAS_SOCKETPAIR
 

--- a/otherlibs/unix/sockopt_unix.c
+++ b/otherlibs/unix/sockopt_unix.c
@@ -108,7 +108,7 @@ struct socket_option {
 
 /* Table of options, indexed by type */
 
-static struct socket_option sockopt_bool[] = {
+static const struct socket_option sockopt_bool[] = {
   { SOL_SOCKET, SO_DEBUG },
   { SOL_SOCKET, SO_BROADCAST },
   { SOL_SOCKET, SO_REUSEADDR },
@@ -121,7 +121,7 @@ static struct socket_option sockopt_bool[] = {
   { SOL_SOCKET, SO_REUSEPORT }
 };
 
-static struct socket_option sockopt_int[] = {
+static const struct socket_option sockopt_int[] = {
   { SOL_SOCKET, SO_SNDBUF },
   { SOL_SOCKET, SO_RCVBUF },
   { SOL_SOCKET, SO_ERROR },
@@ -129,20 +129,20 @@ static struct socket_option sockopt_int[] = {
   { SOL_SOCKET, SO_RCVLOWAT },
   { SOL_SOCKET, SO_SNDLOWAT } };
 
-static struct socket_option sockopt_linger[] = {
+static const struct socket_option sockopt_linger[] = {
   { SOL_SOCKET, SO_LINGER }
 };
 
-static struct socket_option sockopt_timeval[] = {
+static const struct socket_option sockopt_timeval[] = {
   { SOL_SOCKET, SO_RCVTIMEO },
   { SOL_SOCKET, SO_SNDTIMEO }
 };
 
-static struct socket_option sockopt_unix_error[] = {
+static const struct socket_option sockopt_unix_error[] = {
   { SOL_SOCKET, SO_ERROR }
 };
 
-static struct socket_option * sockopt_table[] = {
+static const struct socket_option * sockopt_table[] = {
   sockopt_bool,
   sockopt_int,
   sockopt_linger,
@@ -271,7 +271,7 @@ CAMLexport value caml_unix_setsockopt_aux(char * name,
 CAMLprim value caml_unix_getsockopt(value vty, value vsocket, value voption)
 {
   enum option_type ty = Int_val(vty);
-  struct socket_option * opt = &(sockopt_table[ty][Int_val(voption)]);
+  const struct socket_option * opt = &(sockopt_table[ty][Int_val(voption)]);
   return caml_unix_getsockopt_aux(getsockopt_fun_name[ty],
                              ty,
                              opt->level,
@@ -283,7 +283,7 @@ CAMLprim value caml_unix_setsockopt(value vty, value vsocket, value voption,
                                value val)
 {
   enum option_type ty = Int_val(vty);
-  struct socket_option * opt = &(sockopt_table[ty][Int_val(voption)]);
+  const struct socket_option * opt = &(sockopt_table[ty][Int_val(voption)]);
   return caml_unix_setsockopt_aux(setsockopt_fun_name[ty],
                              ty,
                              opt->level,

--- a/otherlibs/unix/sockopt_unix.c
+++ b/otherlibs/unix/sockopt_unix.c
@@ -150,7 +150,7 @@ static const struct socket_option * sockopt_table[] = {
   sockopt_unix_error
 };
 
-static char * getsockopt_fun_name[] = {
+static const char * getsockopt_fun_name[] = {
   "getsockopt",
   "getsockopt_int",
   "getsockopt_optint",
@@ -158,7 +158,7 @@ static char * getsockopt_fun_name[] = {
   "getsockopt_error"
 };
 
-static char * setsockopt_fun_name[] = {
+static const char * setsockopt_fun_name[] = {
   "setsockopt",
   "setsockopt_int",
   "setsockopt_optint",
@@ -172,7 +172,7 @@ union option_value {
   struct timeval tv;
 };
 
-CAMLexport value caml_unix_getsockopt_aux(char * name,
+CAMLexport value caml_unix_getsockopt_aux(const char * name,
                                      enum option_type ty, int level, int option,
                                      value socket)
 {
@@ -230,7 +230,7 @@ CAMLexport value caml_unix_getsockopt_aux(char * name,
   CAMLreturn(res);
 }
 
-CAMLexport value caml_unix_setsockopt_aux(char * name,
+CAMLexport value caml_unix_setsockopt_aux(const char * name,
                                      enum option_type ty, int level, int option,
                                      value socket, value val)
 {

--- a/otherlibs/unix/sockopt_win32.c
+++ b/otherlibs/unix/sockopt_win32.c
@@ -88,7 +88,7 @@ static const struct socket_option * sockopt_table[] = {
   sockopt_unix_error
 };
 
-static char * getsockopt_fun_name[] = {
+static const char * getsockopt_fun_name[] = {
   "getsockopt",
   "getsockopt_int",
   "getsockopt_optint",
@@ -96,7 +96,7 @@ static char * getsockopt_fun_name[] = {
   "getsockopt_error"
 };
 
-static char * setsockopt_fun_name[] = {
+static const char * setsockopt_fun_name[] = {
   "setsockopt",
   "setsockopt_int",
   "setsockopt_optint",
@@ -110,7 +110,7 @@ union option_value {
   struct timeval tv;
 };
 
-CAMLexport value caml_unix_getsockopt_aux(char * name,
+CAMLexport value caml_unix_getsockopt_aux(const char * name,
                                      enum option_type ty, int level, int option,
                                      value socket)
 {
@@ -168,7 +168,7 @@ CAMLexport value caml_unix_getsockopt_aux(char * name,
   CAMLreturn(res);
 }
 
-CAMLexport value caml_unix_setsockopt_aux(char * name,
+CAMLexport value caml_unix_setsockopt_aux(const char * name,
                                      enum option_type ty, int level, int option,
                                      value socket, value val)
 {

--- a/otherlibs/unix/sockopt_win32.c
+++ b/otherlibs/unix/sockopt_win32.c
@@ -46,7 +46,7 @@ struct socket_option {
 
 /* Table of options, indexed by type */
 
-static struct socket_option sockopt_bool[] = {
+static const struct socket_option sockopt_bool[] = {
   { SOL_SOCKET, SO_DEBUG },
   { SOL_SOCKET, SO_BROADCAST },
   { SOL_SOCKET, SO_REUSEADDR },
@@ -59,7 +59,7 @@ static struct socket_option sockopt_bool[] = {
   { SOL_SOCKET, SO_REUSEPORT }
 };
 
-static struct socket_option sockopt_int[] = {
+static const struct socket_option sockopt_int[] = {
   { SOL_SOCKET, SO_SNDBUF },
   { SOL_SOCKET, SO_RCVBUF },
   { SOL_SOCKET, SO_ERROR },
@@ -67,20 +67,20 @@ static struct socket_option sockopt_int[] = {
   { SOL_SOCKET, SO_RCVLOWAT },
   { SOL_SOCKET, SO_SNDLOWAT } };
 
-static struct socket_option sockopt_linger[] = {
+static const struct socket_option sockopt_linger[] = {
   { SOL_SOCKET, SO_LINGER }
 };
 
-static struct socket_option sockopt_timeval[] = {
+static const struct socket_option sockopt_timeval[] = {
   { SOL_SOCKET, SO_RCVTIMEO },
   { SOL_SOCKET, SO_SNDTIMEO }
 };
 
-static struct socket_option sockopt_unix_error[] = {
+static const struct socket_option sockopt_unix_error[] = {
   { SOL_SOCKET, SO_ERROR }
 };
 
-static struct socket_option * sockopt_table[] = {
+static const struct socket_option * sockopt_table[] = {
   sockopt_bool,
   sockopt_int,
   sockopt_linger,
@@ -211,7 +211,7 @@ CAMLexport value caml_unix_setsockopt_aux(char * name,
 CAMLprim value caml_unix_getsockopt(value vty, value vsocket, value voption)
 {
   enum option_type ty = Int_val(vty);
-  struct socket_option * opt = &(sockopt_table[ty][Int_val(voption)]);
+  const struct socket_option * opt = &(sockopt_table[ty][Int_val(voption)]);
   return caml_unix_getsockopt_aux(getsockopt_fun_name[ty],
                              ty,
                              opt->level,
@@ -223,7 +223,7 @@ CAMLprim value caml_unix_setsockopt(value vty, value vsocket, value voption,
                                value val)
 {
   enum option_type ty = Int_val(vty);
-  struct socket_option * opt = &(sockopt_table[ty][Int_val(voption)]);
+  const struct socket_option * opt = &(sockopt_table[ty][Int_val(voption)]);
   return caml_unix_setsockopt_aux(setsockopt_fun_name[ty],
                              ty,
                              opt->level,

--- a/otherlibs/unix/termios.c
+++ b/otherlibs/unix/termios.c
@@ -38,7 +38,7 @@ enum { Input, Output };
 
 /* Structure of the terminal_io record. Cf. unix.mli */
 
-static long terminal_io_descr[] = {
+static const long terminal_io_descr[] = {
   /* Input modes */
   Bool, iflags, IGNBRK,
   Bool, iflags, BRKINT,
@@ -90,7 +90,7 @@ static long terminal_io_descr[] = {
 #undef cflags
 #undef lflags
 
-static struct {
+static const struct {
   speed_t speed;
   int baud;
 } speedtable[] = {
@@ -192,10 +192,9 @@ static struct {
 
 static void encode_terminal_status(volatile value *dst, struct termios *src)
 {
-  long * pc;
   int i;
 
-  for(pc = terminal_io_descr; *pc != End; dst++) {
+  for(const long * pc = terminal_io_descr; *pc != End; dst++) {
     switch(*pc++) {
     case Bool:
       { tcflag_t * src_p = (tcflag_t *) ((char *)src + *pc++);
@@ -242,10 +241,9 @@ static void encode_terminal_status(volatile value *dst, struct termios *src)
 
 static void decode_terminal_status(struct termios *dst, volatile value *src)
 {
-  long * pc;
   int i;
 
-  for (pc = terminal_io_descr; *pc != End; src++) {
+  for (const long * pc = terminal_io_descr; *pc != End; src++) {
     switch(*pc++) {
     case Bool:
       { tcflag_t * dst_p = (tcflag_t *) ((char *)dst + *pc++);

--- a/otherlibs/unix/termios.c
+++ b/otherlibs/unix/termios.c
@@ -192,8 +192,6 @@ static const struct {
 
 static void encode_terminal_status(volatile value *dst, struct termios *src)
 {
-  int i;
-
   for(const long * pc = terminal_io_descr; *pc != End; dst++) {
     switch(*pc++) {
     case Bool:
@@ -206,7 +204,7 @@ static void encode_terminal_status(volatile value *dst, struct termios *src)
         int ofs = *pc++;
         int num = *pc++;
         tcflag_t msk = *pc++;
-        for (i = 0; i < num; i++) {
+        for (int i = 0; i < num; i++) {
           if ((*src_p & msk) == pc[i]) {
             *dst = Val_int(i + ofs);
             break;
@@ -224,7 +222,7 @@ static void encode_terminal_status(volatile value *dst, struct termios *src)
         case Input:
           speed = cfgetispeed(src); break;
         }
-        for (i = 0; i < NSPEEDS; i++) {
+        for (int i = 0; i < NSPEEDS; i++) {
           if (speed == speedtable[i].speed) {
             *dst = Val_int(speedtable[i].baud);
             break;
@@ -241,8 +239,6 @@ static void encode_terminal_status(volatile value *dst, struct termios *src)
 
 static void decode_terminal_status(struct termios *dst, volatile value *src)
 {
-  int i;
-
   for (const long * pc = terminal_io_descr; *pc != End; src++) {
     switch(*pc++) {
     case Bool:
@@ -258,7 +254,7 @@ static void decode_terminal_status(struct termios *dst, volatile value *src)
         int ofs = *pc++;
         int num = *pc++;
         tcflag_t msk = *pc++;
-        i = Int_val(*src) - ofs;
+        int i = Int_val(*src) - ofs;
         if (i >= 0 && i < num) {
           *dst_p = (*dst_p & ~msk) | pc[i];
         } else {
@@ -270,7 +266,7 @@ static void decode_terminal_status(struct termios *dst, volatile value *src)
       { int which = *pc++;
         int baud = Int_val(*src);
         int res = 0;
-        for (i = 0; i < NSPEEDS; i++) {
+        for (int i = 0; i < NSPEEDS; i++) {
           if (baud == speedtable[i].baud) {
             switch (which) {
             case Output:

--- a/runtime/array.c
+++ b/runtime/array.c
@@ -253,7 +253,7 @@ CAMLprim value caml_array_create_float(value len)
   return caml_floatarray_create (len);
 #else
   /* A signaling NaN, statically allocated */
-  static uintnat some_float_contents[] = {
+  static const uintnat some_float_contents[] = {
     Caml_out_of_heap_header(Double_wosize, Double_tag),
 #if defined(ARCH_SIXTYFOUR)
     0x7FF0000000000001

--- a/runtime/caml/fix_code.h
+++ b/runtime/caml/fix_code.h
@@ -34,7 +34,8 @@ void caml_set_instruction (code_t pos, opcode_t instr);
 int caml_is_instruction (opcode_t instr1, opcode_t instr2);
 
 #ifdef THREADED_CODE
-void caml_init_thread_code(void ** instr_table, void * instr_base);
+void caml_init_thread_code(const void * const * instr_table,
+                           const void * instr_base);
 void caml_thread_code (code_t code, asize_t len);
 #endif
 

--- a/runtime/fix_code.c
+++ b/runtime/fix_code.c
@@ -82,13 +82,14 @@ void caml_fixup_endianness(code_t code, asize_t len)
 
 #ifdef THREADED_CODE
 
-static char ** caml_instr_table;
-static char * caml_instr_base;
+static const char * const * caml_instr_table;
+static const char * caml_instr_base;
 
-void caml_init_thread_code(void ** instr_table, void * instr_base)
+void caml_init_thread_code(const void * const * instr_table,
+                           const void * instr_base)
 {
-  caml_instr_table = (char **) instr_table;
-  caml_instr_base = (char *) instr_base;
+  caml_instr_table = (const char * const *) instr_table;
+  caml_instr_base = (const char *) instr_base;
 }
 
 static int* opcode_nargs = NULL;

--- a/runtime/interp.c
+++ b/runtime/interp.c
@@ -283,7 +283,7 @@ value caml_interprete(code_t prog, asize_t prog_size)
 #endif
 
 #ifdef THREADED_CODE
-  static void * jumptable[] = {
+  static const void * const jumptable[] = {
 #    include "caml/jumptbl.h"
   };
 #endif

--- a/runtime/win32.c
+++ b/runtime/win32.c
@@ -1164,7 +1164,7 @@ void caml_plat_mem_unmap(void* mem, uintnat size)
 
 struct error_entry { DWORD win_code; int range; int posix_code; };
 
-static struct error_entry win_error_table[] = {
+static const struct error_entry win_error_table[] = {
   { ERROR_INVALID_FUNCTION, 0, EINVAL},
   { ERROR_FILE_NOT_FOUND, 0, ENOENT},
   { ERROR_PATH_NOT_FOUND, 0, ENOENT},


### PR DESCRIPTION
Constify more constructors, arrays, and flags tables in C code. Now these tables will go in the readonly segment, where they belong.
This PR accounts for missed opportunities from #12223. I believe I've missed these because I searched with regexes that were too strong (starting with `static`, using `int` but ignoring `DWORD`, …).
~I've tentatively modified the changes entry under the 5.2 section.~