### PR TITLE
Fixing typos

### DIFF
--- a/Changes
+++ b/Changes
@@ -1746,7 +1746,7 @@ Some of those changes will benefit all OCaml packages.
 
 - #11846: Mark rbx as destroyed at C call for Win64 (mingw-w64 and Cygwin64).
   Reserve the shadow store for the ABI in the c_stack_link struct instead of
-  explictly when calling C functions. This simultaneously reduces the number of
+  explicitly when calling C functions. This simultaneously reduces the number of
   stack pointer manipulations and also fixes a bug when calling noalloc
   functions where the shadow store was not being reserved.
   (David Allsopp, report by Vesa Karvonen, review by Xavier Leroy and
@@ -2762,7 +2762,7 @@ OCaml 4.14.0 (28 March 2022)
 - #8516: Change representation of class signatures
   (Leo White, review by Thomas Refis)
 
-- #9444: -dtypedtree, print more explictly extra nodes in pattern ast.
+- #9444: -dtypedtree, print more explicitly extra nodes in pattern ast.
   (Frédéric Bour, review by Gabriel Scherer)
 
 - #10337: Normalize type_expr nodes on access

--- a/Makefile.common
+++ b/Makefile.common
@@ -284,7 +284,7 @@ endef # _OCAML_COMMON_BASE
 # Each program foo is characterised by the foo_LIBRARIES and foo_SOURCES
 # variables. The following macros provide the infrastructure to build foo
 # from the object files whose names are derived from these two
-# varialbes. In particular, the following macros define several
+# variables. In particular, the following macros define several
 # variables whose names are prefixed with foo_ to compute the
 # different lists of files used to build foo.
 

--- a/asmcomp/stackframegen.ml
+++ b/asmcomp/stackframegen.ml
@@ -42,7 +42,7 @@ method virtual trap_handler_size : int
    by treating them as non-tail calls, even if they are implemented as
    tail calls.
 
-   This method can be overriden in [Stackframe] to implement target-specific
+   This method can be overridden in [Stackframe] to implement target-specific
    behaviors. *)
 
 method is_call = function
@@ -61,7 +61,7 @@ method is_call = function
    This is the case if it contains calls, but also if it allocates
    variables on the stack.
 
-   This method can be overriden in [Stackframe] to implement target-specific
+   This method can be overridden in [Stackframe] to implement target-specific
    behaviors. *)
 
 method frame_required f contains_calls =

--- a/manual/src/cmds/intf-c.etex
+++ b/manual/src/cmds/intf-c.etex
@@ -2412,7 +2412,7 @@ The corresponding C type must be "intnat".
 It is possible to annotate with "[\@untagged]" any immediate type, i.e. types
 that are represented like "int". This includes "bool", "char", any variant
 type with only constant constructors. Note: this does not include
-"Unix.file_descr" which is not represented as an interger on all platforms.
+"Unix.file_descr" which is not represented as an integer on all platforms.
 
 \subsection{ss:c-direct-call}{Direct C call}
 

--- a/parsing/builtin_attributes.mli
+++ b/parsing/builtin_attributes.mli
@@ -172,7 +172,7 @@ val select_attributes :
 (** [attr_equals_builtin attr s] is true if the name of the attribute is [s] or
     ["ocaml." ^ s].  This is useful for manually inspecting attribute names, but
     note that doing so will not result in marking the attribute used for the
-    purpose of warning 53, so it is usually preferrable to use [has_attribute]
+    purpose of warning 53, so it is usually preferable to use [has_attribute]
     or [select_attributes]. *)
 val attr_equals_builtin : Parsetree.attribute -> string -> bool
 

--- a/release-info/introduction.md
+++ b/release-info/introduction.md
@@ -114,7 +114,7 @@ stability guarantees, and which can be tested by an increasingly wider audience:
   * stable feature sets
   * only emergency bug fixes
   * documentation PRs postponed to after the release
-  * inteded for wide testing (and detecting deployment or production issues among
+  * intended for wide testing (and detecting deployment or production issues among
     large private code base)
 
 Starting from the first alpha release, there is a small team effort to try to

--- a/runtime/caml/domain.h
+++ b/runtime/caml/domain.h
@@ -118,7 +118,7 @@ int caml_try_run_on_all_domains(
    [caml_try_run_on_all_domains*] runners, it will
    run on all participant domains in parallel.
 
-   The "STW critical section" is the runtime interval betweeen the
+   The "STW critical section" is the runtime interval between the
    start of the execution of the STW callback and the last barrier in
    the callback. During this interval, mutator code from registered
    participants cannot be running in parallel.

--- a/runtime/lf_skiplist.c
+++ b/runtime/lf_skiplist.c
@@ -354,7 +354,7 @@ int caml_lf_skiplist_insert(struct lf_skiplist *sk, uintnat key, uintnat data) {
       /* attentive readers will have noticed that we assume memory is aligned to
        * atleast even addresses. This is certainly the case on glibc amd64 and
        * Visual C++ on Windows though I can find no guarantees for other
-         platorms. */
+         platforms. */
       struct lf_skipcell *new_cell = caml_stat_alloc(
           SIZEOF_LF_SKIPCELL + (top_level + 1) * sizeof(struct lf_skipcell *));
       new_cell->top_level = top_level;

--- a/runtime/memprof.c
+++ b/runtime/memprof.c
@@ -591,7 +591,7 @@ static uintnat next_rand_geom;
    lambda].  We could use more a involved algorithm, but this should
    be good enough since, in the average use case, [lambda] <= 0.01 and
    therefore the generation of the binomial variable is amortized by
-   the initialialization of the corresponding block.
+   the initialization of the corresponding block.
 
    If needed, we could use algorithm BTRS from the paper:
      Hormann, Wolfgang. "The generation of binomial random variates."

--- a/runtime/tsan.c
+++ b/runtime/tsan.c
@@ -159,7 +159,7 @@
      the FFI rules on the condition that the GC does not run between the
      allocation and the end of initialization) and a conflicting access is made
      from OCaml after publication to other threads. There should be no data
-     race thanks to data dependency (see [MMOC] coment in memory.c), but TSan
+     race thanks to data dependency (see [MMOC] comment in memory.c), but TSan
      does not take data dependencies into account.
    - A field is accessed from C with `Field`, or more generally using a
      `volatile value *` or a relaxed atomic access, and that field is modified

--- a/stdlib/CONTRIBUTING.md
+++ b/stdlib/CONTRIBUTING.md
@@ -16,7 +16,7 @@ So: please contribute!
 
 Obviously, proposals made to evolve the standard library will be
 evaluated with very high standards, similar to those applied to the
-evolution of the surface langage, and much higher than those for
+evolution of the surface language, and much higher than those for
 internal compiler changes (optimizations, etc).
 
 A key property of the standard library is its stability.  Backward

--- a/stdlib/dynarray.ml
+++ b/stdlib/dynarray.ml
@@ -483,7 +483,7 @@ let append_array_if_room a b =
          reserved-but-not-yet-filled space, it will get a clean "missing
          element" error. This is worse than with the fill-then-notify
          approach where the new elements would only become visible
-         (to iterators, for removal, etc.) alltogether at the end of
+         (to iterators, for removal, etc.) altogether at the end of
          loop.
 
        To summarise, "reserve before fill" is better on add-add races,

--- a/stdlib/marshal.mli
+++ b/stdlib/marshal.mli
@@ -191,6 +191,6 @@ val total_size : bytes -> int -> int
     Care must be taken when marshaling a mutable value that may be modified by
     a different domain. Mutating a value that is being marshaled (i.e., turned
     into a sequence of bytes) is a programming error and might result in
-    suprising values (when unmarshaling) due to tearing, since marshaling
+    surprising values (when unmarshaling) due to tearing, since marshaling
     involves byte-per-byte copy.
 *)

--- a/stdlib/random.ml
+++ b/stdlib/random.ml
@@ -143,7 +143,7 @@ module State = struct
      * we use rejection sampling on the greatest interval [ [0, k*n-1] ]
      * that fits in [ [0, mask] ].  That is, we reject the
      * sample if it falls outside of this interval, and draw again.
-     * This is what the test below does, while carefuly avoiding
+     * This is what the test below does, while carefully avoiding
      * overflows and sparing a division [mask / n]. *)
     if r - v > mask - n + 1 then int_aux s n mask else v
 

--- a/testsuite/tests/basic/stringmatch.ml
+++ b/testsuite/tests/basic/stringmatch.ml
@@ -31,7 +31,7 @@ let () =
   assert (tst02 "\000\000\000\003" = 3) ;
   ()
 
-(* Keword reckognition *)
+(* Keyword recognition *)
 
 let s00 = "get_const"
 let t00 = "set_congt"

--- a/testsuite/tests/frame-pointers/fp_backtrace.c
+++ b/testsuite/tests/frame-pointers/fp_backtrace.c
@@ -126,7 +126,7 @@ void fp_backtrace(value argv0)
     if (!is_from_executable(symbol, execname))
       goto skip;
 
-    /* Exctract the full function name */
+    /* Extract the full function name */
     regmatch_t funcname = func_name_from_symbol(symbol);
     if (funcname.rm_so == -1)
       goto skip;

--- a/testsuite/tests/typing-modules/inclusion_errors.ml
+++ b/testsuite/tests/typing-modules/inclusion_errors.ml
@@ -1329,7 +1329,7 @@ Error: Signature mismatch:
 type w = private float
 type q = private (int * w)
 type u = private (int * q)
-module M : sig (* Confussing error message :( *)
+module M : sig (* Confusing error message :( *)
   type t = private (int * (int * int))
 end = struct
   type t = private u

--- a/tools/objinfo.ml
+++ b/tools/objinfo.ml
@@ -435,7 +435,7 @@ let dump_obj filename =
 
 let arg_list = [
   "-quiet", Arg.Set quiet,
-    " Only print explicitely required information";
+    " Only print explicitly required information";
   "-no-approx", Arg.Set no_approx,
     " Do not print module approximation information";
   "-no-code", Arg.Set no_code,

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -4737,7 +4737,7 @@ and type_function
                     [type_argument] on the cases, and discard the cases'
                     inferred type in favor of the constrained type. (Function
                     cases aren't inferred, so [type_argument] would just call
-                    [type_expect] straightaway, so we do the same here.)
+                    [type_expect] straight away, so we do the same here.)
                   - [type_without_constraint]: If there is just a coercion and
                     no constraint, call [type_exp] on the cases and surface the
                     cases' inferred type to [type_constraint_expect]. *)

--- a/typing/value_rec_check.ml
+++ b/typing/value_rec_check.ml
@@ -154,7 +154,7 @@ let classify_expression : Typedtree.expression -> sd =
         (* Note on module presence:
            For absent modules (i.e. module aliases), the module being bound
            does not have a physical representation, but its size can still be
-           derived from the alias itself, so we can re-use the same code as
+           derived from the alias itself, so we can reuse the same code as
            for modules that are present. *)
         let size = classify_module_expression env mexp in
         let env = Ident.add mid size env in

--- a/utils/linkdeps.mli
+++ b/utils/linkdeps.mli
@@ -51,7 +51,7 @@ type error =
 
 val check : t -> error option
 (** [check t] should be called once all the compilation units to be linked
-    have been added.  It retuns some error if:
+    have been added.  It returns some error if:
     - There are some missing implementations
       and [complete] is [true]
     - Some implementation appear

--- a/utils/local_store.mli
+++ b/utils/local_store.mli
@@ -14,7 +14,8 @@
 (**************************************************************************)
 
 (** This module provides some facilities for creating references (and hash
-    tables) which can easily be snapshotted and restored to an arbitrary version.
+    tables) which can easily be snapshotted and restored to an arbitrary
+    version.
 
     It is used throughout the frontend (read: typechecker), to register all
     (well, hopefully) the global state. Thus making it easy for tools like

--- a/utils/local_store.mli
+++ b/utils/local_store.mli
@@ -14,7 +14,7 @@
 (**************************************************************************)
 
 (** This module provides some facilities for creating references (and hash
-    tables) which can easily be snapshoted and restored to an arbitrary version.
+    tables) which can easily be snapshotted and restored to an arbitrary version.
 
     It is used throughout the frontend (read: typechecker), to register all
     (well, hopefully) the global state. Thus making it easy for tools like


### PR DESCRIPTION
Typos found with codespell https://github.com/codespell-project/codespell