### PR TITLE
add user-friendly message to debug runtime

### DIFF
--- a/runtime/startup_aux.c
+++ b/runtime/startup_aux.c
@@ -133,6 +133,12 @@ int caml_startup_aux(int pooling)
     caml_fatal_error("caml_startup was called after the runtime "
                      "was shut down with caml_shutdown");
 
+#ifdef DEBUG
+  /* Note this must be executed after the call to caml_parse_ocamlrunparam. */
+  caml_gc_message (-1, "### OCaml runtime: debug mode ###\n");
+  caml_gc_message (-1, "### set OCAMLRUNPARAM=v=0 to silence this message\n");
+#endif
+
   /* Second and subsequent calls are ignored,
      since the runtime has already started */
   startup_count++;

--- a/runtime/startup_byt.c
+++ b/runtime/startup_byt.c
@@ -461,10 +461,6 @@ CAMLexport void caml_main(char_os **argv)
   /* Determine options */
   caml_parse_ocamlrunparam();
 
-#ifdef DEBUG
-  caml_gc_message (-1, "### OCaml runtime: debug mode ###\n");
-  caml_gc_message (-1, "### set OCAMLRUNPARAM=v=0 to silence this message\n");
-#endif
   if (!caml_startup_aux(/* pooling */ caml_params->cleanup_on_exit))
     return;
 
@@ -603,10 +599,6 @@ CAMLexport value caml_startup_code_exn(
   /* Determine options */
   caml_parse_ocamlrunparam();
 
-#ifdef DEBUG
-  caml_gc_message (-1, "### OCaml runtime: debug mode ###\n");
-  caml_gc_message (-1, "### set OCAMLRUNPARAM=v=0 to silence this message\n");
-#endif
   if (caml_params->cleanup_on_exit)
     pooling = 1;
   if (!caml_startup_aux(pooling))

--- a/runtime/startup_byt.c
+++ b/runtime/startup_byt.c
@@ -463,6 +463,7 @@ CAMLexport void caml_main(char_os **argv)
 
 #ifdef DEBUG
   caml_gc_message (-1, "### OCaml runtime: debug mode ###\n");
+  caml_gc_message (-1, "### set OCAMLRUNPARAM=v=0 to silence this message\n");
 #endif
   if (!caml_startup_aux(/* pooling */ caml_params->cleanup_on_exit))
     return;
@@ -604,6 +605,7 @@ CAMLexport value caml_startup_code_exn(
 
 #ifdef DEBUG
   caml_gc_message (-1, "### OCaml runtime: debug mode ###\n");
+  caml_gc_message (-1, "### set OCAMLRUNPARAM=v=0 to silence this message\n");
 #endif
   if (caml_params->cleanup_on_exit)
     pooling = 1;

--- a/runtime/startup_nat.c
+++ b/runtime/startup_nat.c
@@ -93,10 +93,6 @@ value caml_startup_common(char_os **argv, int pooling)
   /* Determine options */
   caml_parse_ocamlrunparam();
 
-#ifdef DEBUG
-  caml_gc_message (-1, "### OCaml runtime: debug mode ###\n");
-  caml_gc_message (-1, "### set OCAMLRUNPARAM=v=0 to silence this message\n");
-#endif
   if (caml_params->cleanup_on_exit)
     pooling = 1;
   if (!caml_startup_aux(pooling))

--- a/runtime/startup_nat.c
+++ b/runtime/startup_nat.c
@@ -95,6 +95,7 @@ value caml_startup_common(char_os **argv, int pooling)
 
 #ifdef DEBUG
   caml_gc_message (-1, "### OCaml runtime: debug mode ###\n");
+  caml_gc_message (-1, "### set OCAMLRUNPARAM=v=0 to silence this message\n");
 #endif
   if (caml_params->cleanup_on_exit)
     pooling = 1;


### PR DESCRIPTION
Make it explicit that the initial debug runtime message can be silenced with OCAMLRUNPARAM. This is useful for running the testsuite with runtime assertions.
