### PR TITLE
Fix a data race in `caml_darken_cont`

### DIFF
--- a/Changes
+++ b/Changes
@@ -87,6 +87,9 @@ _______________
   command-line of the toplevel.
   (Nicolás Ojeda Bär, review by Florian Angeletti, report by Daniel Bünzli)
 
+- #12969: Fix a data race in caml_darken_cont
+  (Fabrice Buoro and Olivier Nicole, review by Gabriel Scherer and Miod Vallat)
+
 OCaml 5.2.0
 ------------
 


### PR DESCRIPTION
This PR proposes to fix a data race detected by the TSan CI when using the debug runtime.
The data race occurs in the `parallel/test_issue_11094.ml` test, involving `caml_scan_stack` and `caml_free_stack`. Using the debug runtime causes the stack to be poisoned ([runtime/fiber.c#L573](https://github.com/fabbing/ocaml/blob/d0df650399c10c79841489f0b734c212c5df3521/runtime/fiber.c#L573)), making the data race visible to TSan.

<details>
<summary>TSan data-race report</summary>

```
Write of size 8 at 0x7b5403f88318 by thread T4 (mutexes: write M0):
  #0 __tsan_memset /usr/src/debug/gcc/gcc/libsanitizer/tsan/tsan_interceptors_posix.cpp:3089 (libtsan.so.2+0x79601) (BuildId: c39405aada755398a542cde01e23149afb1204d1)
  #1 caml_free_stack runtime/fiber.c:573 (a.out+0xbe4f8) (BuildId: 5b510af01dbe393db8bb15cea51b9ae5ccd81175)
  #2 caml_runstack <null> (a.out+0xf49ac) (BuildId: 5b510af01dbe393db8bb15cea51b9ae5ccd81175)
  #3 camlStdlib__Domain.body_710 [...]/ocaml/stdlib/domain.ml:207 (a.out+0x8574f) (BuildId: 5b510af01dbe393db8bb15cea51b9ae5ccd81175)
  #4 caml_start_program <null> (a.out+0xf41a7) (BuildId: 5b510af01dbe393db8bb15cea51b9ae5ccd81175)
  #5 caml_callback_exn runtime/callback.c:201 (a.out+0xafe7b) (BuildId: 5b510af01dbe393db8bb15cea51b9ae5ccd81175)
  #6 domain_thread_func runtime/domain.c:1205 (a.out+0xb5253) (BuildId: 5b510af01dbe393db8bb15cea51b9ae5ccd81175)

Previous read of size 8 at 0x7b5403f88318 by thread T1 (mutexes: write M1):
  #0 scan_stack_frames runtime/fiber.c:250 (a.out+0xbdff0) (BuildId: 5b510af01dbe393db8bb15cea51b9ae5ccd81175)
  #1 caml_scan_stack runtime/fiber.c:285 (a.out+0xbdff0)
  #2 caml_darken_cont runtime/major_gc.c:1195 (a.out+0xd4aa8) (BuildId: 5b510af01dbe393db8bb15cea51b9ae5ccd81175)
  #3 do_some_marking runtime/major_gc.c:1033 (a.out+0xd5bd7) (BuildId: 5b510af01dbe393db8bb15cea51b9ae5ccd81175)
  #4 mark runtime/major_gc.c:1148 (a.out+0xd5d9b) (BuildId: 5b510af01dbe393db8bb15cea51b9ae5ccd81175)
  #5 major_collection_slice runtime/major_gc.c:1721 (a.out+0xd66b7) (BuildId: 5b510af01dbe393db8bb15cea51b9ae5ccd81175)
  #6 caml_major_collection_slice runtime/major_gc.c:1901 (a.out+0xd7754) (BuildId: 5b510af01dbe393db8bb15cea51b9ae5ccd81175)
  #7 caml_poll_gc_work runtime/domain.c:1739 (a.out+0xb5d3d) (BuildId: 5b510af01dbe393db8bb15cea51b9ae5ccd81175)
  #8 stw_handler runtime/domain.c:1391 (a.out+0xb6225) (BuildId: 5b510af01dbe393db8bb15cea51b9ae5ccd81175)
  #9 handle_incoming runtime/domain.c:330 (a.out+0xb6225)
  #10 caml_handle_incoming_interrupts runtime/domain.c:343 (a.out+0xb745b) (BuildId: 5b510af01dbe393db8bb15cea51b9ae5ccd81175)
  #11 caml_handle_gc_interrupt runtime/domain.c:1765 (a.out+0xb745b)
  #12 caml_enter_blocking_section runtime/signals.c:174 (a.out+0xe6cc4) (BuildId: 5b510af01dbe393db8bb15cea51b9ae5ccd81175)
  #13 caml_ml_mutex_lock runtime/sync.c:93 (a.out+0xea4e4) (BuildId: 5b510af01dbe393db8bb15cea51b9ae5ccd81175)
  #14 caml_c_call <null> (a.out+0xf402d) (BuildId: 5b510af01dbe393db8bb15cea51b9ae5ccd81175)
  #15 camlTest_issue_11094.with_mutex_296 [...]/ocaml/testsuite/tests/parallel/test_issue_11094.ml:19 (a.out+0x4f6b7) (BuildId: 5b510af01dbe393db8bb15cea51b9ae5ccd81175)
  #16 camlTest_issue_11094.fun_633 [...]/ocaml/testsuite/tests/parallel/test_issue_11094.ml:48 (a.out+0x4fdc0) (BuildId: 5b510af01dbe393db8bb15cea51b9ae5ccd81175)
  #17 camlStdlib__Domain.body_710 [...]/ocaml/stdlib/domain.ml:207 (a.out+0x8574f) (BuildId: 5b510af01dbe393db8bb15cea51b9ae5ccd81175)
  #18 caml_start_program <null> (a.out+0xf41a7) (BuildId: 5b510af01dbe393db8bb15cea51b9ae5ccd81175)
  #19 caml_callback_exn runtime/callback.c:201 (a.out+0xafe7b) (BuildId: 5b510af01dbe393db8bb15cea51b9ae5ccd81175)
  #20 domain_thread_func runtime/domain.c:1205 (a.out+0xb5253) (BuildId: 5b510af01dbe393db8bb15cea51b9ae5ccd81175)
```
</details>

## The data race
Both domains have executed `caml_darken_cont` at some point, one coming from a GC major scan, and the other one from `caml_continuation_use` while `resume`ing the continuation.

```c
void caml_darken_cont(value cont)
{
  CAMLassert(Is_block(cont) && !Is_young(cont) && Tag_val(cont) == Cont_tag);
  {
    SPIN_WAIT {
      header_t hd = atomic_load_relaxed(Hp_atomic_val(cont));
      CAMLassert(!Has_status_hd(hd, caml_global_heap_state.GARBAGE));
      if (Has_status_hd(hd, caml_global_heap_state.MARKED))
        break;
      if (Has_status_hd(hd, caml_global_heap_state.UNMARKED) &&
          atomic_compare_exchange_strong(
              Hp_atomic_val(cont), &hd,
              With_status_hd(hd, NOT_MARKABLE))) {
        value stk = Field(cont, 0);
        if (Ptr_val(stk) != NULL)
          caml_scan_stack(&caml_darken, darken_scanning_flags, Caml_state,
                          Ptr_val(stk), 0);
        atomic_store_release(Hp_atomic_val(cont),
                             With_status_hd(hd, caml_global_heap_state.MARKED));
      }
    }
  }
}
```

- The GC domain, performing a `major_collection_slice`, reached `caml_darken_cont`, marked the fiber's stack with `caml_scan_stack` and updated the continuation header to `MARKED` with an `atomic_store_release`.
- Later, the other domain, which `resume`d the continuation called `caml_continuation_use_noexc`, also reached `caml_darken_cont`, read the continuation header with an `atomic_load_relaxed`, found the `MARKED` tag, and so skipped the stack marking.

Alas, in the C11 memory model, there is no `happens-before` relationship caused by this `release` store and the `relaxed` load, and so TSan reported the race.

## Proposed fix

The `atomic_load_relaxed` of `caml_darken_cont` is replaced by an `atomic_load_acquire` ([runtime/major_gc.c#L1185](https://github.com/fabbing/ocaml/blob/d0df650399c10c79841489f0b734c212c5df3521/runtime/major_gc.c#L1185)).

- Pro: This is a well-defined synchronization according to the C11 memory model, and so TSan is happy.
- Con: `atomic_load_acquire` is free for `amd64`, but not for `arm64` (and other weak architectures?) and will have a performance cost.

## Alternative fix 1

We keep the `atomic_load_relaxed` and use the recently added TSan notation from #12894, to notify this relaxed load synchronizes with the release store.

```diff
diff --git a/runtime/major_gc.c b/runtime/major_gc.c
index 78ccf358d3..353351519e 100644
--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -1183,6 +1183,7 @@ void caml_darken_cont(value cont)
   {
     SPIN_WAIT {
       header_t hd = atomic_load_relaxed(Hp_atomic_val(cont));
+      CAML_TSAN_ANNOTATE_HAPPENS_AFTER(Hp_atomic_val(cont));
       CAMLassert(!Has_status_hd(hd, caml_global_heap_state.GARBAGE));
       if (Has_status_hd(hd, caml_global_heap_state.MARKED))
         break;
```

Indeed, this may have been thes code's intention, as according to the Linux-Kernel Memory Consistency Model:
```
W ->rfe R implies that W and R are on different CPUs.  It also means
that W's store must have propagated to R's CPU before R executed;
otherwise R could not have read the value stored by W.  Therefore W
must have executed before R, and so we have W ->hb R.
```
But I can't convince myself, that having a simple `ldr` with the `atomic_load_acquire` makes no difference with the `ldar` (implicit acquire fence) instruction with an `atomic_load_acquire`. A (real) memory model expert opinion on this would be welcome.

- Pro: No performance cost, TSan is happy
- Con: UB to C11 memory model (but fine for LKMM?), brittle as it relies on TSan instrumenting `atomic_store_release` with the same mechanism as with  `CAML_TSAN_ANNOTATE_HAPPENS_AFTER`.

## Alternative fix 2

We silence TSan reports for `caml_free_stack`.
- Pro: CI is happy
- Con: Would also hide some other race

## Acknowledgment
A lot of work went into this one-line PR, with @OlivierNicole.