### PR TITLE
typing: fix a try_expand_once forgotten from #10170

### DIFF
--- a/Changes
+++ b/Changes
@@ -2429,6 +2429,10 @@ OCaml 4.14 maintenance version
 - #12878: fix incorrect treatment of injectivity for private recursive types.
   (Jeremy Yallop, review by Gabriel Scherer and Jacques Garrigue)
 
+- #12971, #12974: fix an uncaught Ctype.Escape exception on some
+  invalid programs forming recursive types.
+  (Gabriel Scherer, review by Florian Angeletti, report by Neven Villani)
+
 - #12264, #12289: Fix compact_allocate to avoid a pathological case
   that causes very slow compaction.
   (Damien Doligez, report by Arseniy Alekseyev, review by Sadiq Jaffer)

--- a/testsuite/tests/typing-misc/occur_check.ml
+++ b/testsuite/tests/typing-misc/occur_check.ml
@@ -67,8 +67,10 @@ val wrong_to_seq : ('a Seq.t as 'a) Seq.t t -> 'a Seq.t Seq.t = <fun>
 
 let strange x = Seq.[cons x empty; cons empty x];;
 [%%expect{|
-Uncaught exception: Ctype.Escape(_)
-
-|}, Principal{|
-val strange : 'a Seq.t Seq.t -> 'a Seq.t Seq.t Seq.t list = <fun>
+Line 1, characters 12-48:
+1 | let strange x = Seq.[cons x empty; cons empty x];;
+                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This expression has type "('a Seq.t as 'a) Seq.t -> 'a Seq.t Seq.t list"
+       but an expression was expected of type
+         "('a Seq.t as 'a) Seq.t -> 'a Seq.t Seq.t list"
 |}];;

--- a/testsuite/tests/typing-misc/occur_check.ml
+++ b/testsuite/tests/typing-misc/occur_check.ml
@@ -15,6 +15,7 @@ Error: This expression has type "'a list"
        but an expression was expected of type "'a t" = "'a"
        The type variable "'a" occurs inside "'a list"
 |}];;
+
 let f (g : 'a * 'b -> 'a t -> 'a) s = g s s;;
 [%%expect{|
 Line 1, characters 42-43:
@@ -23,4 +24,51 @@ Line 1, characters 42-43:
 Error: This expression has type "'a * 'b"
        but an expression was expected of type "'a t" = "'a"
        The type variable "'a" occurs inside "'a * 'b"
+|}];;
+
+(* #12971 *)
+
+module Seq : sig
+  type 'a t = unit -> 'a node
+  and 'a node
+
+  val empty : 'a t
+  val cons : 'a -> 'a t -> 'a t
+end = struct
+  type 'a t = unit -> 'a node
+  and 'a node = unit
+
+  let empty () = ()
+  let cons x xs () = ()
+end;;
+[%%expect{|
+module Seq :
+  sig
+    type 'a t = unit -> 'a node
+    and 'a node
+    val empty : 'a t
+    val cons : 'a -> 'a t -> 'a t
+  end
+|}];;
+
+type 'a t = T of 'a;;
+let wrong_to_seq (xt : 'a t) : 'a Seq.t =
+  let T x = xt in
+  Seq.cons Seq.empty x
+;;
+(* Note: the current behavior of this function is believed to be
+   a bug, in the sense that it creates an equi-recursive type even in
+   absence of the -rectypes flag. On the other hand, it does not fail
+   with the Ctype.Escape exception, as it did from 4.13 to 5.1. *)
+[%%expect{|
+type 'a t = T of 'a
+val wrong_to_seq : ('a Seq.t as 'a) Seq.t t -> 'a Seq.t Seq.t = <fun>
+|}];;
+
+let strange x = Seq.[cons x empty; cons empty x];;
+[%%expect{|
+Uncaught exception: Ctype.Escape(_)
+
+|}, Principal{|
+val strange : 'a Seq.t Seq.t -> 'a Seq.t Seq.t Seq.t list = <fun>
 |}];;

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -1841,7 +1841,7 @@ let rec occur_rec env allow_recursive visited ty0 ty =
         let visited = TypeSet.add ty visited in
         iter_type_expr (occur_rec env allow_recursive visited ty0) ty
       with Occur -> try
-        let ty' = try_expand_head try_expand_once env ty in
+        let ty' = try_expand_head try_expand_safe env ty in
         (* This call used to be inlined, but there seems no reason for it.
            Message was referring to change in rev. 1.58 of the CVS repo. *)
         occur_rec env allow_recursive visited ty0 ty'


### PR DESCRIPTION
(In #10170, almost all callsites of `try_expand_once` were replaced by calls to `try_expand_safe` which catches the `Escape` exception and returns `None` instead, except a few places that were already catching `Escape`... and the one occurrence in the diff here, which should also have been replaced.)

On OCaml versions 5.1 and older, this glitch causes a `Ctype.Escape(_)` uncaught exception on the included test case. See #12971.

With the fix in the present PR (which applies cleanly to 4.14, trunk and everything in between), the included test case results in a proper error on OCaml 5.1 and older.

In OCaml 5.2 and trunk, the included test case does not raise an uncaught exception, and it does not fail with an error instead, the program is accepted with a (recursive) type. This is due to #12691 (included in 5.2), which improved the definition of some expansion functions to not raise `Escape` and do something more sensible instead. (**Edit**: not more sensible, it was in fact a regression, see discussion below.)

The summary of my understanding of the issue:

- The present PR is a trivial (obvious, one-line) fix to an uncaught-exception bug from 4.14 to 5.1, and even in trunk/5.2 it makes the code strictly more consistent.
- The behavior inherited from #12691 is even better than the one-line fix (**Edit**: wrong). But backporting it to older versions (as @Octachron suggested) would be *sensibly* more work -- I would not take the initiative to do it.

I therefore propose to merge the present PR in trunk, and backport it in 4.14 for now.