### PR TITLE
Use another variable to pass CFLAGS/CPPFLAGS to user OCaml code

### DIFF
--- a/Changes
+++ b/Changes
@@ -80,6 +80,8 @@ _______________
 - #12909: Reorganise how MKEXE_VIA_CC is built to make it correct for MSVC by
   grouping all the linker flags at the end of the C compiler commandline
   (David Allsopp and Samuel Hym, review by Nicolás Ojeda Bär)
+- #12975: Use another variable to pass CFLAGS/CPPFLAGS to user OCaml code
+  (William Hu, ...)
 
 ### Bug fixes:
 

--- a/configure
+++ b/configure
@@ -767,6 +767,8 @@ WINDOWS_UNICODE_MODE
 LIBUNWIND_LDFLAGS
 LIBUNWIND_CPPFLAGS
 DLLIBS
+PASS_THRU_CPPFLAGS
+PASS_THRU_CFLAGS
 PARTIALLD
 csc
 target_os
@@ -1026,6 +1028,8 @@ target_alias
 AS
 ASPP
 PARTIALLD
+PASS_THRU_CFLAGS
+PASS_THRU_CPPFLAGS
 DLLIBS
 LIBUNWIND_CPPFLAGS
 LIBUNWIND_LDFLAGS
@@ -1734,6 +1738,12 @@ Some influential environment variables:
   AS          which assembler to use
   ASPP        which assembler (with preprocessor) to use
   PARTIALLD   how to build partial (relocatable) object files
+  PASS_THRU_CFLAGS
+              Additional C compiler flags that OCaml compilers will use on
+              user programs
+  PASS_THRU_CPPFLAGS
+              Additional C preprocessor flags that OCaml compilers will use on
+              user programs
   DLLIBS      which libraries to use (in addition to -ldl) to load dynamic
               libs
   LIBUNWIND_CPPFLAGS
@@ -3764,6 +3774,8 @@ esac
 fi
 
 # Environment variables that are taken into account
+
+
 
 
 
@@ -20253,8 +20265,9 @@ fi
 
 oc_cflags="$common_cflags $internal_cflags"
 oc_cppflags="$common_cppflags $internal_cppflags"
-ocamlc_cflags="$ocamlc_cflags $common_cflags $sharedlib_cflags $CFLAGS"
-ocamlc_cppflags="$common_cppflags $CPPFLAGS"
+ocamlc_cflags="$ocamlc_cflags $common_cflags $sharedlib_cflags \
+$PASS_THRU_CFLAGS"
+ocamlc_cppflags="$common_cppflags $PASS_THRU_CPPFLAGS"
 
 case $host in #(
   *-*-mingw32*) :

--- a/configure.ac
+++ b/configure.ac
@@ -338,6 +338,10 @@ AS_IF([test -n "$csc"],
 AC_ARG_VAR([AS], [which assembler to use])
 AC_ARG_VAR([ASPP], [which assembler (with preprocessor) to use])
 AC_ARG_VAR([PARTIALLD], [how to build partial (relocatable) object files])
+AC_ARG_VAR([PASS_THRU_CFLAGS], [Additional C compiler flags that OCaml
+            compilers will use on user programs])
+AC_ARG_VAR([PASS_THRU_CPPFLAGS], [Additional C preprocessor flags that
+            OCaml compilers will use on user programs])
 
 # Command-line arguments to configure
 
@@ -2501,8 +2505,9 @@ AS_IF([test "$ccomptype" != "msvc"],
 
 oc_cflags="$common_cflags $internal_cflags"
 oc_cppflags="$common_cppflags $internal_cppflags"
-ocamlc_cflags="$ocamlc_cflags $common_cflags $sharedlib_cflags $CFLAGS"
-ocamlc_cppflags="$common_cppflags $CPPFLAGS"
+ocamlc_cflags="$ocamlc_cflags $common_cflags $sharedlib_cflags \
+$PASS_THRU_CFLAGS"
+ocamlc_cppflags="$common_cppflags $PASS_THRU_CPPFLAGS"
 
 AS_CASE([$host],
   [*-*-mingw32*],


### PR DESCRIPTION
I took a stab at not passing `CFLAGS` into all user compiled code (#12578, #12589) while keeping most of the current mechanism intact in new environment variables `PASS_THRU_CFLAGS` and `PASS_THRU_CPPFLAGS`.

This allows one to call `./configure PASS_THRU_CFLAGS=-Duseful_macro` and pass those flags onto user commands such as `ocamlc hello.c`.

I wasn't sure what linker flag features were desired so I left those alone for now. 