### PR TITLE
Use webman/*.html and webman/api for OCaml.org manuals

### DIFF
--- a/Changes
+++ b/Changes
@@ -50,6 +50,10 @@ _______________
   (Florian Angeletti, review by Fabrice Buoro, Kate Deplaix, Damien Doligez, and
    Gabriel Scherer)
 
+- #12976: Manual: use webman/<version>/*.html and
+  webman/<version>/api/ for OCaml.org HTML manual generation
+  (Shakthi Kannan, review by Hannes Mehnert, and Florian Angeletti)
+
 ### Compiler user-interface and warnings:
 
 * #12084: Check link order when creating archive and when using ocamlopt

--- a/manual/src/html_processing/Makefile
+++ b/manual/src/html_processing/Makefile
@@ -8,7 +8,9 @@ else
     DBG=quiet
 endif
 
-WEBDIR = ../webman
+VERSION = 5.3.0
+
+WEBDIR = ../$(VERSION)
 WEBDIRAPI = $(WEBDIR)/api
 WEBDIRCOMP = $(WEBDIRAPI)/compilerlibref
 

--- a/manual/src/html_processing/Makefile
+++ b/manual/src/html_processing/Makefile
@@ -8,7 +8,7 @@ else
     DBG=quiet
 endif
 
-VERSION = 5.3.0
+VERSION=$(shell grep 'OCAML_VERSION_SHORT=' ../../../configure | awk -F'=' '{print $$2}')
 
 WEBDIR = ../$(VERSION)
 WEBDIRAPI = $(WEBDIR)/api

--- a/manual/src/html_processing/Makefile
+++ b/manual/src/html_processing/Makefile
@@ -9,7 +9,6 @@ else
 endif
 
 WEBDIR = ../webman
-WEBDIRMAN = $(WEBDIR)/manual
 WEBDIRAPI = $(WEBDIR)/api
 WEBDIRCOMP = $(WEBDIRAPI)/compilerlibref
 
@@ -23,26 +22,26 @@ all: css js img
 $(WEBDIR)/%:
 	mkdir -p $@
 
-$(WEBDIRMAN)/manual.css: scss/_common.scss scss/manual.scss | $(WEBDIRMAN)
-	sass scss/manual.scss > $(WEBDIRMAN)/manual.css
+$(WEBDIR)/manual.css: scss/_common.scss scss/manual.scss | $(WEBDIR)
+	sass scss/manual.scss > $(WEBDIR)/manual.css
 
 $(WEBDIRAPI)/style.css: scss/_common.scss scss/style.scss | $(WEBDIRAPI) $(WEBDIRCOMP)
 	sass scss/style.scss > $(WEBDIRAPI)/style.css
 	cp $(WEBDIRAPI)/style.css $(WEBDIRCOMP)/style.css
 
-css: $(WEBDIRMAN)/manual.css $(WEBDIRAPI)/style.css
+css: $(WEBDIRAPI)/style.css $(WEBDIR)/manual.css
 
 # Just copy the JS files:
 #
 JS_FILES0 := scroll.js navigation.js
 JS_FILES1 := $(JS_FILES0) search.js
-JS_FILES := $(addprefix $(WEBDIRAPI)/, $(JS_FILES1)) $(addprefix $(WEBDIRCOMP)/, $(JS_FILES1)) $(addprefix $(WEBDIRMAN)/, $(JS_FILES0))
+JS_FILES := $(addprefix $(WEBDIRAPI)/, $(JS_FILES1)) $(addprefix $(WEBDIRCOMP)/, $(JS_FILES1)) $(addprefix $(WEBDIR)/, $(JS_FILES0))
 
 # There must be a more clever way
 $(WEBDIRAPI)/%.js: js/%.js | $(WEBDIRAPI)
 	cp $< $@
 
-$(WEBDIRMAN)/%.js: js/%.js | $(WEBDIRMAN)
+$(WEBDIR)/%.js: js/%.js | $(WEBDIR)
 	cp $< $@
 
 $(WEBDIRCOMP)/%.js: js/%.js | $(WEBDIRCOMP)
@@ -56,19 +55,19 @@ CURL = curl -s
 $(WEBDIRCOMP)/%: $(WEBDIRAPI)/% | $(WEBDIRCOMP)
 	cp $< $@
 
-$(WEBDIRMAN)/%: $(WEBDIRAPI)/% | $(WEBDIRMAN)
+$(WEBDIR)/%: $(WEBDIRAPI)/% | $(WEBDIR)
 	cp $< $@
 
 LOGO := colour-logo.svg
-$(WEBDIRAPI)/colour-logo.svg: | $(WEBDIRAPI) $(WEBDIRMAN) $(WEBDIRCOMP)
+$(WEBDIRAPI)/colour-logo.svg: | $(WEBDIRAPI) $(WEBDIR) $(WEBDIRCOMP)
 	$(CURL) "https://raw.githubusercontent.com/ocaml/ocaml-logo/master/Colour/SVG/colour-logo.svg" > $(WEBDIRAPI)/$(LOGO)
 
 ICON := favicon.ico
-$(WEBDIRAPI)/favicon.ico: | $(WEBDIRAPI) $(WEBDIRMAN) $(WEBDIRCOMP)
+$(WEBDIRAPI)/favicon.ico: | $(WEBDIRAPI) $(WEBDIR) $(WEBDIRCOMP)
 	$(CURL) "https://raw.githubusercontent.com/ocaml/ocaml-logo/master/Colour/Favicon/32x32.ico" > $(WEBDIRAPI)/$(ICON)
 
 IMG_FILES0 := colour-logo.svg
-IMG_FILES := $(addprefix $(WEBDIRAPI)/, $(IMG_FILES0)) $(addprefix $(WEBDIRCOMP)/, $(IMG_FILES0)) $(addprefix $(WEBDIRMAN)/, $(IMG_FILES0)) 
+IMG_FILES := $(addprefix $(WEBDIRAPI)/, $(IMG_FILES0)) $(addprefix $(WEBDIRCOMP)/, $(IMG_FILES0)) $(addprefix $(WEBDIR)/, $(IMG_FILES0))
 
 img: $(WEBDIRAPI)/favicon.ico $(WEBDIRCOMP)/favicon.ico $(IMG_FILES)
 

--- a/manual/src/html_processing/Makefile
+++ b/manual/src/html_processing/Makefile
@@ -1,4 +1,5 @@
-include ../../../Makefile.config
+ROOTDIR = ../../..
+include $(ROOTDIR)/Makefile.config
 
 DUNE_CMD := $(if $(wildcard dune/dune.exe),dune/dune.exe,dune)
 DUNE ?= $(DUNE_CMD)
@@ -12,8 +13,9 @@ endif
 
 VERSION := $(OCAML_VERSION_MAJOR).$(OCAML_VERSION_MINOR)
 
-WEBDIR = ../$(VERSION)
-WEBDIRAPI = $(WEBDIR)/api
+WEBDIR = ../webman
+WEBDIRMAN = $(WEBDIR)/$(VERSION)
+WEBDIRAPI = $(WEBDIRMAN)/api
 WEBDIRCOMP = $(WEBDIRAPI)/compilerlibref
 
 # The "all" target generates the Web Manual in the directories
@@ -26,26 +28,26 @@ all: css js img
 $(WEBDIR)/%:
 	mkdir -p $@
 
-$(WEBDIR)/manual.css: scss/_common.scss scss/manual.scss | $(WEBDIR)
-	sass scss/manual.scss > $(WEBDIR)/manual.css
+$(WEBDIRMAN)/manual.css: scss/_common.scss scss/manual.scss | $(WEBDIRMAN)
+	sass scss/manual.scss > $(WEBDIRMAN)/manual.css
 
 $(WEBDIRAPI)/style.css: scss/_common.scss scss/style.scss | $(WEBDIRAPI) $(WEBDIRCOMP)
 	sass scss/style.scss > $(WEBDIRAPI)/style.css
 	cp $(WEBDIRAPI)/style.css $(WEBDIRCOMP)/style.css
 
-css: $(WEBDIRAPI)/style.css $(WEBDIR)/manual.css
+css: $(WEBDIRMAN)/manual.css $(WEBDIRAPI)/style.css
 
 # Just copy the JS files:
 #
 JS_FILES0 := scroll.js navigation.js
 JS_FILES1 := $(JS_FILES0) search.js
-JS_FILES := $(addprefix $(WEBDIRAPI)/, $(JS_FILES1)) $(addprefix $(WEBDIRCOMP)/, $(JS_FILES1)) $(addprefix $(WEBDIR)/, $(JS_FILES0))
+JS_FILES := $(addprefix $(WEBDIRAPI)/, $(JS_FILES1)) $(addprefix $(WEBDIRCOMP)/, $(JS_FILES1)) $(addprefix $(WEBDIRMAN)/, $(JS_FILES0))
 
 # There must be a more clever way
 $(WEBDIRAPI)/%.js: js/%.js | $(WEBDIRAPI)
 	cp $< $@
 
-$(WEBDIR)/%.js: js/%.js | $(WEBDIR)
+$(WEBDIRMAN)/%.js: js/%.js | $(WEBDIRMAN)
 	cp $< $@
 
 $(WEBDIRCOMP)/%.js: js/%.js | $(WEBDIRCOMP)
@@ -59,19 +61,19 @@ CURL = curl -s
 $(WEBDIRCOMP)/%: $(WEBDIRAPI)/% | $(WEBDIRCOMP)
 	cp $< $@
 
-$(WEBDIR)/%: $(WEBDIRAPI)/% | $(WEBDIR)
+$(WEBDIRMAN)/%: $(WEBDIRAPI)/% | $(WEBDIRMAN)
 	cp $< $@
 
 LOGO := colour-logo.svg
-$(WEBDIRAPI)/colour-logo.svg: | $(WEBDIRAPI) $(WEBDIR) $(WEBDIRCOMP)
+$(WEBDIRAPI)/colour-logo.svg: | $(WEBDIRAPI) $(WEBDIRMAN) $(WEBDIRCOMP)
 	$(CURL) "https://raw.githubusercontent.com/ocaml/ocaml-logo/master/Colour/SVG/colour-logo.svg" > $(WEBDIRAPI)/$(LOGO)
 
 ICON := favicon.ico
-$(WEBDIRAPI)/favicon.ico: | $(WEBDIRAPI) $(WEBDIR) $(WEBDIRCOMP)
+$(WEBDIRAPI)/favicon.ico: | $(WEBDIRAPI) $(WEBDIRMAN) $(WEBDIRCOMP)
 	$(CURL) "https://raw.githubusercontent.com/ocaml/ocaml-logo/master/Colour/Favicon/32x32.ico" > $(WEBDIRAPI)/$(ICON)
 
 IMG_FILES0 := colour-logo.svg
-IMG_FILES := $(addprefix $(WEBDIRAPI)/, $(IMG_FILES0)) $(addprefix $(WEBDIRCOMP)/, $(IMG_FILES0)) $(addprefix $(WEBDIR)/, $(IMG_FILES0))
+IMG_FILES := $(addprefix $(WEBDIRAPI)/, $(IMG_FILES0)) $(addprefix $(WEBDIRCOMP)/, $(IMG_FILES0)) $(addprefix $(WEBDIRMAN)/, $(IMG_FILES0))
 
 img: $(WEBDIRAPI)/favicon.ico $(WEBDIRCOMP)/favicon.ico $(IMG_FILES)
 

--- a/manual/src/html_processing/Makefile
+++ b/manual/src/html_processing/Makefile
@@ -1,3 +1,5 @@
+include ../../../Makefile.config
+
 DUNE_CMD := $(if $(wildcard dune/dune.exe),dune/dune.exe,dune)
 DUNE ?= $(DUNE_CMD)
 
@@ -8,7 +10,7 @@ else
     DBG=quiet
 endif
 
-VERSION=$(shell grep 'OCAML_VERSION_SHORT=' ../../../configure | awk -F'=' '{print $$2}')
+VERSION := $(OCAML_VERSION_MAJOR).$(OCAML_VERSION_MINOR)
 
 WEBDIR = ../$(VERSION)
 WEBDIRAPI = $(WEBDIR)/api

--- a/manual/src/html_processing/src/common.ml.in
+++ b/manual/src/html_processing/src/common.ml.in
@@ -40,7 +40,7 @@ let docs_file = ( // ) docs_maindir
 let api_dir = web_dir // "api"
 
 (* How to go from manual to api *)
-let api_page_url = "api" (* "../" ^ ocaml_version ^ "/api" *)
+let api_page_url = "api"
 
 (* How to go from api to manual *)
 let manual_page_url = ".."

--- a/manual/src/html_processing/src/common.ml.in
+++ b/manual/src/html_processing/src/common.ml.in
@@ -107,6 +107,8 @@ let update_head ?(search = false) soup =
   |> append_child head;
   create_element "script" ~attributes:["src","navigation.js"]
   |> append_child head;
+  create_element "script" ~attributes:["src", "https://plausible.ci.dev/js/script.js"; "defer data-domain", "ocaml.org"]
+  |> append_child head;
   add_favicon head
 
 (* Add version number *)

--- a/manual/src/html_processing/src/common.ml.in
+++ b/manual/src/html_processing/src/common.ml.in
@@ -39,7 +39,7 @@ let docs_file = ( // ) docs_maindir
 (* Output for API *)
 let api_dir = web_dir // "api"
 
-(* How to go from manual to api *)
+(* How to go from htmlman manual to api *)
 let api_page_url = "../" ^ ocaml_version ^ "/api"
 
 (* How to go from api to manual *)

--- a/manual/src/html_processing/src/common.ml.in
+++ b/manual/src/html_processing/src/common.ml.in
@@ -27,8 +27,10 @@ let ( // ) = Filename.concat
 
 let process_dir = Filename.current_dir_name
 
+let ocaml_version = "5.3.0"
+
 (* Output directory *)
-let web_dir = Filename.parent_dir_name // "webman"
+let web_dir = Filename.parent_dir_name // ocaml_version
 
 (* Output for manual *)
 let docs_maindir = web_dir
@@ -38,7 +40,7 @@ let docs_file = ( // ) docs_maindir
 let api_dir = web_dir // "api"
 
 (* How to go from manual to api *)
-let api_page_url = "../webman/api"
+let api_page_url = "../" ^ ocaml_version ^ "/api"
 
 (* How to go from api to manual *)
 let manual_page_url = ".."

--- a/manual/src/html_processing/src/common.ml.in
+++ b/manual/src/html_processing/src/common.ml.in
@@ -39,8 +39,8 @@ let docs_file = ( // ) docs_maindir
 (* Output for API *)
 let api_dir = web_dir // "api"
 
-(* How to go from htmlman manual to api *)
-let api_page_url = "../" ^ ocaml_version ^ "/api"
+(* How to go from manual to api *)
+let api_page_url = "api" (* "../" ^ ocaml_version ^ "/api" *)
 
 (* How to go from api to manual *)
 let manual_page_url = ".."
@@ -96,7 +96,8 @@ let add_favicon head =
          favicon ^ {|">|})
   |> append_child head
 
-(* Update html <head> element with javascript and favicon *)
+(* Update html <head> element with javascript and favicon.
+   Including script.js for OCaml.org's instance of Plausible Analytics. *)
 let update_head ?(search = false) soup =
   let head = soup $ "head" in
   if search then begin

--- a/manual/src/html_processing/src/common.ml.in
+++ b/manual/src/html_processing/src/common.ml.in
@@ -31,7 +31,7 @@ let process_dir = Filename.current_dir_name
 let web_dir = Filename.parent_dir_name // "webman"
 
 (* Output for manual *)
-let docs_maindir = web_dir // "manual"
+let docs_maindir = web_dir
 let docs_file = ( // ) docs_maindir
 
 (* Output for API *)
@@ -41,7 +41,7 @@ let api_dir = web_dir // "api"
 let api_page_url = "../api"
 
 (* How to go from api to manual *)
- let manual_page_url = "../manual"
+let manual_page_url = ".."
 
 (* Set this to the directory where to find the html sources of all versions: *)
 let html_maindir = "../htmlman"

--- a/manual/src/html_processing/src/common.ml.in
+++ b/manual/src/html_processing/src/common.ml.in
@@ -30,7 +30,7 @@ let process_dir = Filename.current_dir_name
 let ocaml_version = "@OCAML_VERSION_SHORT@"
 
 (* Output directory *)
-let web_dir = Filename.parent_dir_name // ocaml_version
+let web_dir = Filename.parent_dir_name // "webman" // ocaml_version
 
 (* Output for manual *)
 let docs_maindir = web_dir

--- a/manual/src/html_processing/src/common.ml.in
+++ b/manual/src/html_processing/src/common.ml.in
@@ -38,7 +38,7 @@ let docs_file = ( // ) docs_maindir
 let api_dir = web_dir // "api"
 
 (* How to go from manual to api *)
-let api_page_url = "../api"
+let api_page_url = "../webman/api"
 
 (* How to go from api to manual *)
 let manual_page_url = ".."

--- a/manual/src/html_processing/src/common.ml.in
+++ b/manual/src/html_processing/src/common.ml.in
@@ -27,7 +27,7 @@ let ( // ) = Filename.concat
 
 let process_dir = Filename.current_dir_name
 
-let ocaml_version = "5.3.0"
+let ocaml_version = "@OCAML_VERSION_SHORT@"
 
 (* Output directory *)
 let web_dir = Filename.parent_dir_name // ocaml_version

--- a/manual/src/html_processing/src/process_manual.ml
+++ b/manual/src/html_processing/src/process_manual.ml
@@ -429,7 +429,7 @@ let get_xfiles = function
           let rf = li $ "a" |> R.attribute "href" in
           dbg "TOC reference = %s" rf;
           if not (String.contains rf '#') &&
-             not (starts_with ".." rf) &&
+             not (starts_with "api" rf) &&
              not (starts_with "http" rf)
           then begin
             li $ "a" |> set_attribute "href" (rf ^ "#start-section");


### PR DESCRIPTION
Theis PR builds the HTML manual pages directly under webman/ and not webman/manual/ as preferred in https://github.com/ocaml/ocaml.org/issues/534. This will further allow the following URLs to be served directly under OCaml.org for easy navigation and reference:

```
  https://ocaml.org/manual/<VERSION>/*.html
  https://ocaml.org/manual/<VERSION/api/*.html
```

Reference:
* https://github.com/ocaml/ocaml.org/issues/534#issuecomment-1318570350