### PR TITLE
doc: add when some functions are introduced (`@since`)

### DIFF
--- a/stdlib/string.mli
+++ b/stdlib/string.mli
@@ -362,39 +362,55 @@ val of_seq : char Seq.t -> t
 
     @since 4.07 *)
 
-(** {1:utf UTF decoding and validations}
-
-    @since 4.14 *)
+(** {1:utf UTF decoding and validations} *)
 
 (** {2:utf_8 UTF-8} *)
 
 val get_utf_8_uchar : t -> int -> Uchar.utf_decode
 (** [get_utf_8_uchar b i] decodes an UTF-8 character at index [i] in
-    [b]. *)
+    [b].
+
+    @since 4.14
+*)
 
 val is_valid_utf_8 : t -> bool
 (** [is_valid_utf_8 b] is [true] if and only if [b] contains valid
-    UTF-8 data. *)
+    UTF-8 data.
+
+    @since 4.14
+*)
 
 (** {2:utf_16be UTF-16BE} *)
 
 val get_utf_16be_uchar : t -> int -> Uchar.utf_decode
 (** [get_utf_16be_uchar b i] decodes an UTF-16BE character at index
-    [i] in [b]. *)
+    [i] in [b].
+
+    @since 4.14
+*)
 
 val is_valid_utf_16be : t -> bool
 (** [is_valid_utf_16be b] is [true] if and only if [b] contains valid
-    UTF-16BE data. *)
+    UTF-16BE data.
+
+    @since 4.14
+*)
 
 (** {2:utf_16le UTF-16LE} *)
 
 val get_utf_16le_uchar : t -> int -> Uchar.utf_decode
 (** [get_utf_16le_uchar b i] decodes an UTF-16LE character at index
-    [i] in [b]. *)
+    [i] in [b].
+
+    @since 4.14
+*)
 
 val is_valid_utf_16le : t -> bool
 (** [is_valid_utf_16le b] is [true] if and only if [b] contains valid
-    UTF-16LE data. *)
+    UTF-16LE data.
+
+    @since 4.14
+*)
 
 (** {1 Binary decoding of integers} *)
 


### PR DESCRIPTION
This is a fix because the previous is not working (https://v2.ocaml.org/releases/5.1/api/String.html).

I think labeling in `no-change-entry-needed` would be fine.