### PR TITLE
error messages: include module inclusion errors for first class modules

### DIFF
--- a/.depend
+++ b/.depend
@@ -874,6 +874,7 @@ typing/includemod_errorprinter.cmo : \
     typing/types.cmi \
     typing/typedtree.cmi \
     typing/printtyp.cmi \
+    typing/primitive.cmi \
     typing/path.cmi \
     typing/oprint.cmi \
     utils/misc.cmi \
@@ -890,6 +891,7 @@ typing/includemod_errorprinter.cmx : \
     typing/types.cmx \
     typing/typedtree.cmx \
     typing/printtyp.cmx \
+    typing/primitive.cmx \
     typing/path.cmx \
     typing/oprint.cmx \
     utils/misc.cmx \
@@ -903,7 +905,10 @@ typing/includemod_errorprinter.cmx : \
     utils/clflags.cmx \
     typing/includemod_errorprinter.cmi
 typing/includemod_errorprinter.cmi : \
-    typing/includemod.cmi
+    typing/types.cmi \
+    typing/typedtree.cmi \
+    typing/includemod.cmi \
+    typing/env.cmi
 typing/mtype.cmo : \
     typing/types.cmi \
     typing/subst.cmi \
@@ -1770,6 +1775,7 @@ typing/typemod.cmo : \
     typing/includemod_errorprinter.cmi \
     typing/includemod.cmi \
     typing/ident.cmi \
+    typing/errortrace.cmi \
     typing/env.cmi \
     typing/ctype.cmi \
     file_formats/cmt_format.cmi \
@@ -1806,6 +1812,7 @@ typing/typemod.cmx : \
     typing/includemod_errorprinter.cmx \
     typing/includemod.cmx \
     typing/ident.cmx \
+    typing/errortrace.cmx \
     typing/env.cmx \
     typing/ctype.cmx \
     file_formats/cmt_format.cmx \

--- a/Changes
+++ b/Changes
@@ -55,6 +55,10 @@ _______________
 * #12084: Check link order when creating archive and when using ocamlopt
   (Hugo Heuzard, review by Stefan Muenzel and Sébastien Hinderer)
 
+- #12980: Explain type mismatch involving first-class modules by including
+  the module level error message
+  (Florian Angeletti, review by Vincent Laviron)
+
 ### Internal/compiler-libs changes:
 
 - #11129, #11148: enforce that ppxs do not produce `parsetree`s with

--- a/testsuite/tests/typing-misc/pr6416.ml
+++ b/testsuite/tests/typing-misc/pr6416.ml
@@ -154,7 +154,7 @@ Error: Signature mismatch:
          val f : (module s/2) -> t/2 -> t/2
        The type "(module s) -> t/2 -> t" is not compatible with the type
          "(module s/2) -> t/2 -> t/2"
-       Type "(module s)" is not compatible with type "(module s/2)"
+       Modules do not match: s is not included in s/2
        Line 5, characters 23-33:
          Definition of type "t"
        Line 3, characters 2-12:

--- a/testsuite/tests/typing-missing-cmi-3/user.ml
+++ b/testsuite/tests/typing-missing-cmi-3/user.ml
@@ -75,7 +75,7 @@ Line 2, characters 12-45:
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: Type "Middle.pack1" = "(module Original.T with type t = int)"
        is not a subtype of "(module T1)"
-       Module type Original.T could not be expanded.
+       The module alias "Original.T" could not be expanded
 |}]
 
 module type T2 = sig module M : sig type t = int end end
@@ -87,7 +87,7 @@ Line 2, characters 12-45:
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: Type "Middle.pack2" = "(module Middle.T with type M.t = int)"
        is not a subtype of "(module T2)"
-       Module type Original.T could not be expanded.
+       The module alias "Original.T" could not be expanded
 |}]
 
 (* Check the detection of type kind in type-directed disambiguation . *)

--- a/testsuite/tests/typing-missing-cmi-3/user.ml
+++ b/testsuite/tests/typing-missing-cmi-3/user.ml
@@ -75,6 +75,7 @@ Line 2, characters 12-45:
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: Type "Middle.pack1" = "(module Original.T with type t = int)"
        is not a subtype of "(module T1)"
+       Module type Original.T could not be expanded.
 |}]
 
 module type T2 = sig module M : sig type t = int end end
@@ -86,6 +87,7 @@ Line 2, characters 12-45:
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: Type "Middle.pack2" = "(module Middle.T with type M.t = int)"
        is not a subtype of "(module T2)"
+       Module type Original.T could not be expanded.
 |}]
 
 (* Check the detection of type kind in type-directed disambiguation . *)

--- a/testsuite/tests/typing-modules/firstclass.ml
+++ b/testsuite/tests/typing-modules/firstclass.ml
@@ -46,6 +46,99 @@ module type S3 = sig type u type t val x : int end
 Line 3, characters 2-67:
 3 |   (x : (module S3 with type t = 'a and type u = 'b) :> (module S'));; (* fail *)
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: Type "(module S3 with type t = int and type u = bool)"
-       is not a subtype of "(module S')"
+Error: Type "(module S3 with type t = 'a and type u = 'b)" is not a subtype of
+         "(module S')"
+       The two first-class module types differ by their runtime size.
 |}];;
+
+(* but you cannot move values (no physical coercions) *)
+module type S4 = sig val x : int  val mid:int  val y:int end
+module type S5 = sig val x:int val y:int end
+let g4 x =
+  (x : (module S4) :> (module S5));; (* fail *)
+[%%expect{|
+module type S4 = sig val x : int val mid : int val y : int end
+module type S5 = sig val x : int val y : int end
+Line 4, characters 2-34:
+4 |   (x : (module S4) :> (module S5));; (* fail *)
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: Type "(module S4)" is not a subtype of "(module S5)"
+       The two first-class module types do not share
+       the same position for runtime components.
+       For example, the value "y" occurs at the expected position of
+       the value "mid".
+|}];;
+
+
+let g5 x =
+  (x : (module S5) :> (module S4));; (* fail *)
+[%%expect{|
+Line 2, characters 2-34:
+2 |   (x : (module S5) :> (module S4));; (* fail *)
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: Type "(module S5)" is not a subtype of "(module S4)"
+       Modules do not match: S5 is not included in S4
+       The value "mid" is required but not provided
+|}];;
+
+module type Prim_Id = sig external id: 'a -> 'a = "%identity" end
+module type Id = sig val id: 'a -> 'a end
+module Named = struct end
+module type Alias = sig module Alias = Named end
+module type Nested = sig module Alias: sig end end
+[%%expect {|
+module type Prim_Id = sig external id : 'a -> 'a = "%identity" end
+module type Id = sig val id : 'a -> 'a end
+module Named : sig end
+module type Alias = sig module Alias = Named end
+module type Nested = sig module Alias : sig end end
+|}]
+
+let coerce_prim x = (x:(module Prim_Id):>(module Id))
+[%%expect {|
+Line 1, characters 20-53:
+1 | let coerce_prim x = (x:(module Prim_Id):>(module Id))
+                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: Type "(module Prim_Id)" is not a subtype of "(module Id)"
+       The two first-class module types differ by a coercion of
+       the primitive "%identity" to a value.
+|}]
+
+let coerce_alias x = (x:(module Alias):>(module Nested))
+[%%expect {|
+Line 1, characters 21-56:
+1 | let coerce_alias x = (x:(module Alias):>(module Nested))
+                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: Type "(module Alias)" is not a subtype of "(module Nested)"
+       The two first-class module types differ by a coercion of
+       a module alias "Named" to a module.
+|}]
+
+module type Nested_coercion = sig
+  module M: sig
+    external identity: 'a -> 'a = "%identity"
+  end
+end
+
+
+module type Nested_coercion_bis = sig
+  module M: sig
+    val identity: 'a -> 'a
+  end
+end
+
+let coerce_prim' x = (x:(module Nested_coercion):>(module Nested_coercion_bis))
+
+[%%expect{|
+module type Nested_coercion =
+  sig module M : sig external identity : 'a -> 'a = "%identity" end end
+module type Nested_coercion_bis =
+  sig module M : sig val identity : 'a -> 'a end end
+Line 14, characters 21-79:
+14 | let coerce_prim' x = (x:(module Nested_coercion):>(module Nested_coercion_bis))
+                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: Type "(module Nested_coercion)" is not a subtype of
+         "(module Nested_coercion_bis)"
+       The two first-class module types differ by a coercion of
+       the primitive "%identity" to a value, in module "M".
+|}]

--- a/testsuite/tests/typing-modules/firstclass.ml
+++ b/testsuite/tests/typing-modules/firstclass.ml
@@ -69,7 +69,7 @@ Line 4, characters 2-34:
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: Type "(module S4)" is not a subtype of "(module S5)"
        The two first-class module types do not share
-       the same position for runtime components.
+       the same positions for runtime components.
        For example, the value "mid" occurs at the expected position of
        the value "y".
 |}];;

--- a/testsuite/tests/typing-modules/firstclass.ml
+++ b/testsuite/tests/typing-modules/firstclass.ml
@@ -35,6 +35,11 @@ Line 5, characters 3-4:
 Error: This expression has type
          "(module S2 with type t = int and type u = bool)"
        but an expression was expected of type "(module S')"
+       Modules do not match:
+         S'
+       is not included in
+         sig type u = bool type t = int type w end
+       The type "w" is required but not provided
 |}];;
 
 (* but you cannot forget values (no physical coercions) *)
@@ -46,8 +51,8 @@ module type S3 = sig type u type t val x : int end
 Line 3, characters 2-67:
 3 |   (x : (module S3 with type t = 'a and type u = 'b) :> (module S'));; (* fail *)
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: Type "(module S3 with type t = 'a and type u = 'b)" is not a subtype of
-         "(module S')"
+Error: Type "(module S3 with type t = int and type u = bool)"
+       is not a subtype of "(module S')"
        The two first-class module types differ by their runtime size.
 |}];;
 

--- a/testsuite/tests/typing-modules/firstclass.ml
+++ b/testsuite/tests/typing-modules/firstclass.ml
@@ -65,8 +65,8 @@ Line 4, characters 2-34:
 Error: Type "(module S4)" is not a subtype of "(module S5)"
        The two first-class module types do not share
        the same position for runtime components.
-       For example, the value "y" occurs at the expected position of
-       the value "mid".
+       For example, the value "mid" occurs at the expected position of
+       the value "y".
 |}];;
 
 

--- a/testsuite/tests/typing-modules/inclusion_errors.ml
+++ b/testsuite/tests/typing-modules/inclusion_errors.ml
@@ -558,7 +558,7 @@ Error: Signature mismatch:
          val f : (module s/2) -> unit
        The type "(module s) -> unit" is not compatible with the type
          "(module s/2) -> unit"
-       Type "(module s)" is not compatible with type "(module s/2)"
+       Modules do not match: s is not included in s/2
        Line 6, characters 4-17:
          Definition of module type "s"
        Line 2, characters 2-15:

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -2922,6 +2922,7 @@ and unify3 uenv t1 t1' t2 t2' =
           | Error fm_err ->
               if not (in_pattern_mode uenv) then
                 raise_for Unify (Errortrace.First_class_module fm_err);
+              List.iter (fun (_n, ty) -> reify uenv ty) (fl1 @ fl2);
           | exception Not_found ->
             if not (in_pattern_mode uenv) then raise_unexplained_for Unify;
             List.iter (fun (_n, ty) -> reify uenv ty) (fl1 @ fl2);

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -2091,7 +2091,9 @@ let enter_poly_for tr_exn env univar_pairs t1 tl1 t2 tl2 f =
     enter_poly env univar_pairs t1 tl1 t2 tl2 f
   with Escape e -> raise_for tr_exn (Escape e)
 
-let univar_pairs = ref []
+type univar_pair =
+  (((Types.type_expr * Types.type_expr option ref) list) as 'm) * 'm
+let univar_pairs: univar_pair list ref = ref []
 
 (**** Instantiate a generic type into a poly type ***)
 
@@ -4823,13 +4825,15 @@ type subtype_constraints =
       trace:Types.type_expr Errortrace.Subtype.elt list;
       t1:Types.type_expr;
       t2:Types.type_expr;
-      univar_pairs: ((((Types.type_expr * Types.type_expr option ref) list) as 'm) * 'm) list
+      univar_pairs:univar_pair list
     }
   | Package_error of {
       trace:Types.type_expr Errortrace.Subtype.elt list;
       error: Errortrace.Subtype.package_error
     }
+
 let cstr trace t1 t2 = Unify_cstr {trace;t1;t2;univar_pairs= !univar_pairs}
+
 let subtype_error ~env ~trace ~secondary_trace =
   raise (Subtype (Subtype.error
                     ~trace:(expand_subtype_trace env (List.rev trace))

--- a/typing/ctype.mli
+++ b/typing/ctype.mli
@@ -466,7 +466,8 @@ val immediacy : Env.t -> type_expr -> Type_immediacy.t
 (* Stubs *)
 val package_subtype :
     (Env.t -> Path.t -> (Longident.t * type_expr) list ->
-      Path.t -> (Longident.t * type_expr) list -> bool) ref
+      Path.t -> (Longident.t * type_expr) list ->
+     (unit,Errortrace.Subtype.package_error) Result.t) ref
 
 (* Raises [Incompatible] *)
 val mcomp : Env.t -> type_expr -> type_expr -> unit

--- a/typing/ctype.mli
+++ b/typing/ctype.mli
@@ -467,7 +467,7 @@ val immediacy : Env.t -> type_expr -> Type_immediacy.t
 val package_subtype :
     (Env.t -> Path.t -> (Longident.t * type_expr) list ->
       Path.t -> (Longident.t * type_expr) list ->
-     (unit,Errortrace.Subtype.package_error) Result.t) ref
+     (unit,Errortrace.first_class_module) Result.t) ref
 
 (* Raises [Incompatible] *)
 val mcomp : Env.t -> type_expr -> type_expr -> unit

--- a/typing/errortrace.ml
+++ b/typing/errortrace.ml
@@ -185,6 +185,7 @@ module Subtype = struct
   type 'a secondary_trace =
     | Unification of 'a
     | Package of package_error
+
   type unification_secondary_trace = unification error secondary_trace
 
   type nonrec error =

--- a/typing/errortrace.ml
+++ b/typing/errortrace.ml
@@ -177,15 +177,23 @@ module Subtype = struct
   type trace       = type_expr t
   type error_trace = expanded_type t
 
-  type unification_error_trace = unification error (** To avoid shadowing *)
+  type package_error =
+    | Package_cannot_scrape of Path.t
+    | Package_inclusion of (Format.formatter -> unit)
+    | Package_coercion of (Format.formatter -> unit)
+
+  type 'a secondary_trace =
+    | Unification of 'a
+    | Package of package_error
+  type unification_secondary_trace = unification error secondary_trace
 
   type nonrec error =
     { trace             : error_trace
-    ; unification_trace : unification error }
+    ; secondary_trace : unification_secondary_trace }
 
-  let error ~trace ~unification_trace =
+  let error ~trace ~secondary_trace =
   assert (trace <> []);
-  { trace; unification_trace }
+  { trace; secondary_trace }
 
   let map_elt f = function
     | Diff x -> Diff (map_diff f x)

--- a/typing/errortrace.mli
+++ b/typing/errortrace.mli
@@ -84,6 +84,11 @@ type 'variety obj =
   (* Unification *)
   | Self_cannot_be_closed : unification obj
 
+type first_class_module =
+    | Package_cannot_scrape of Path.t
+    | Package_inclusion of (Format.formatter -> unit)
+    | Package_coercion of (Format.formatter -> unit)
+
 type ('a, 'variety) elt =
   (* Common *)
   | Diff : 'a diff -> ('a, _) elt
@@ -91,6 +96,7 @@ type ('a, 'variety) elt =
   | Obj : 'variety obj -> ('a, 'variety) elt
   | Escape : 'a escape -> ('a, _) elt
   | Incompatible_fields : { name:string; diff: type_expr diff } -> ('a, _) elt
+  | First_class_module: first_class_module -> ('a,_) elt
   (* Unification & Moregen; included in Equality for simplicity *)
   | Rec_occur : type_expr * type_expr -> ('a, _) elt
 
@@ -155,23 +161,14 @@ module Subtype : sig
   type trace       = type_expr t
   type error_trace = expanded_type t
 
-  type package_error =
-    | Package_cannot_scrape of Path.t
-    | Package_inclusion of (Format.formatter -> unit)
-    | Package_coercion of (Format.formatter -> unit)
-
-  type 'a secondary_trace =
-    | Unification of 'a
-    | Package of package_error
-
-  type unification_secondary_trace = unification error secondary_trace
+  type unification_error_trace = unification error (** To avoid shadowing *)
 
   type nonrec error = private
     { trace             : error_trace
-    ; secondary_trace : unification_secondary_trace }
+    ; unification_trace : unification error }
 
   val error :
-    trace:error_trace -> secondary_trace:unification_secondary_trace -> error
+    trace:error_trace -> unification_trace:unification_error_trace -> error
 
   val map : ('a -> 'b) -> 'a t -> 'b t
 end

--- a/typing/errortrace.mli
+++ b/typing/errortrace.mli
@@ -155,14 +155,22 @@ module Subtype : sig
   type trace       = type_expr t
   type error_trace = expanded_type t
 
-  type unification_error_trace = unification error (** To avoid shadowing *)
+  type package_error =
+    | Package_cannot_scrape of Path.t
+    | Package_inclusion of (Format.formatter -> unit)
+    | Package_coercion of (Format.formatter -> unit)
+
+  type 'a secondary_trace =
+    | Unification of 'a
+    | Package of package_error
+  type unification_secondary_trace = unification error secondary_trace
 
   type nonrec error = private
     { trace             : error_trace
-    ; unification_trace : unification error }
+    ; secondary_trace : unification_secondary_trace }
 
   val error :
-    trace:error_trace -> unification_trace:unification_error_trace -> error
+    trace:error_trace -> secondary_trace:unification_secondary_trace -> error
 
   val map : ('a -> 'b) -> 'a t -> 'b t
 end

--- a/typing/errortrace.mli
+++ b/typing/errortrace.mli
@@ -163,6 +163,7 @@ module Subtype : sig
   type 'a secondary_trace =
     | Unification of 'a
     | Package of package_error
+
   type unification_secondary_trace = unification error secondary_trace
 
   type nonrec error = private

--- a/typing/includemod_errorprinter.ml
+++ b/typing/includemod_errorprinter.ml
@@ -181,8 +181,8 @@ module Runtime_coercion = struct
   let illegal_permutation ctx_printer env ppf (mty,c) =
     match first_change c with
     | None | Some (_, (Primitive_coercion _ | Alias_coercion _)) ->
-        (* those kind coercions are not inversible, and raise an error earlier when
-           checking for module type equivalence *)
+        (* those kind coercions are not inversible, and raise an error earlier
+           when checking for module type equivalence *)
         assert false
     | Some (path, Transposition (k,l)) ->
     try

--- a/typing/includemod_errorprinter.ml
+++ b/typing/includemod_errorprinter.ml
@@ -226,7 +226,7 @@ module Runtime_coercion = struct
            the same position for runtime components.@]@ \
            @[For example,%a@ the %a@ occurs at the expected position of@ \
            the %a.@]@]"
-          ctx_printer ctx pp_item (item mt l) pp_item (item mt k)
+          ctx_printer ctx pp_item (item mt k) pp_item (item mt l)
   with Not_found ->
     Format.fprintf ppf
       "@[The two packages types do not share@ \

--- a/typing/includemod_errorprinter.ml
+++ b/typing/includemod_errorprinter.ml
@@ -230,7 +230,7 @@ module Runtime_coercion = struct
   with Not_found ->
     Format.fprintf ppf
       "@[The two packages types do not share@ \
-       the@ same@ position@ for@ runtime@ components.@]"
+       the@ same@ positions@ for@ runtime@ components.@]"
 
 end
 

--- a/typing/includemod_errorprinter.ml
+++ b/typing/includemod_errorprinter.ml
@@ -104,17 +104,15 @@ module Illegal_permutation = struct
   let rec transposition_under path (coerc:Typedtree.module_coercion) =
     match coerc with
     | Tcoerce_structure(c,_) ->
-          (either
-             (not_fixpoint path 0) c
-             (first_non_id path 0) c
-          )
+        either
+          (not_fixpoint path 0) c
+          (first_non_id path 0) c
     | Tcoerce_functor(arg,res) ->
         either
           (transposition_under (InArg::path)) arg
           (transposition_under (InBody::path)) res
     | Tcoerce_none -> None
     | Tcoerce_alias _ | Tcoerce_primitive _ -> None
-    (* those two coercions cannot happen at toplevel *)
 
   (* we search the first point which is not invariant at the current level *)
   and not_fixpoint path pos = function

--- a/typing/includemod_errorprinter.ml
+++ b/typing/includemod_errorprinter.ml
@@ -223,7 +223,7 @@ module Runtime_coercion = struct
     | Transposition (k,l) ->
         Format.fprintf ppf
           "@[@[The two first-class module types do not share@ \
-           the same position for runtime components.@]@ \
+           the same positions for runtime components.@]@ \
            @[For example,%a@ the %a@ occurs at the expected position of@ \
            the %a.@]@]"
           ctx_printer ctx pp_item (item mt k) pp_item (item mt l)

--- a/typing/includemod_errorprinter.mli
+++ b/typing/includemod_errorprinter.mli
@@ -14,4 +14,5 @@
 (**************************************************************************)
 
 val err_msgs: Includemod.explanation -> Format.formatter -> unit
+val coercion_in_package_subtype: Env.t -> Types.module_type -> Typedtree.module_coercion -> Format.formatter -> unit
 val register: unit -> unit

--- a/typing/includemod_errorprinter.mli
+++ b/typing/includemod_errorprinter.mli
@@ -14,5 +14,7 @@
 (**************************************************************************)
 
 val err_msgs: Includemod.explanation -> Format.formatter -> unit
-val coercion_in_package_subtype: Env.t -> Types.module_type -> Typedtree.module_coercion -> Format.formatter -> unit
+val coercion_in_package_subtype:
+  Env.t -> Types.module_type -> Typedtree.module_coercion -> Format.formatter ->
+  unit
 val register: unit -> unit

--- a/typing/printtyp.ml
+++ b/typing/printtyp.ml
@@ -2459,8 +2459,6 @@ let explain_first_class_module = function
   | Errortrace.Package_coercion pr ->
       Some(dprintf "@,@[%t@]" pr)
 
-
-
 let explanation (type variety) intro prev env
   : (Errortrace.expanded_type, variety) Errortrace.elt -> _ = function
   | Errortrace.Diff {got; expected} ->

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -2068,7 +2068,9 @@ let package_subtype env p1 fl1 p2 fl2 =
     match Includemod.modtypes ~loc ~mark:Mark_both env mty1 mty2 with
     | Tcoerce_none -> Ok ()
     | c ->
-        let msg = Includemod_errorprinter.coercion_in_package_subtype env mty1 c in
+        let msg =
+          Includemod_errorprinter.coercion_in_package_subtype env mty1 c
+        in
         Result.Error (Errortrace.Package_coercion msg)
     | exception Includemod.Error e ->
         let msg = Includemod_errorprinter.err_msgs e in

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -2062,17 +2062,17 @@ let package_subtype env p1 fl1 p2 fl2 =
   in
   match mkmty p1 fl1, mkmty p2 fl2 with
   | exception Error(_, _, Cannot_scrape_package_type r) ->
-      Result.Error (Errortrace.Subtype.Package_cannot_scrape r)
+      Result.Error (Errortrace.Package_cannot_scrape r)
   | mty1, mty2 ->
     let loc = Location.none in
     match Includemod.modtypes ~loc ~mark:Mark_both env mty1 mty2 with
     | Tcoerce_none -> Ok ()
     | c ->
         let msg = Includemod_errorprinter.coercion_in_package_subtype env mty1 c in
-        Result.Error (Errortrace.Subtype.Package_coercion msg)
+        Result.Error (Errortrace.Package_coercion msg)
     | exception Includemod.Error e ->
         let msg = Includemod_errorprinter.err_msgs e in
-        Result.Error (Errortrace.Subtype.Package_inclusion msg)
+        Result.Error (Errortrace.Package_inclusion msg)
 
 let () = Ctype.package_subtype := package_subtype
 


### PR DESCRIPTION
Currently, the error message for subtyping errors on first class modules:
```ocaml
module type XY = sig  val x: int val y: int end
module type XYZ = sig include XY val z:int end
let convert x = (x: < f : < g : int -> (module XY); h:int >; i:int > :> <f: <g: int -> (module XYZ) > >)
```
stops abruptly at the frontier between the core level and the module level:
>```
>Error: Type < f : < g : int -> (module XYZ); h : int >; i : int >
>       is not a subtype of < f : < g : int -> (module XY) > >
>       Type (module XY) is not a subtype of (module XYZ)
>```

This PR proposes to expand the subtyping error message with the inclusion trace for first class modules:

>```
>Error: Type < f : < g : int -> (module XY); h : int >; i : int >
>       is not a subtype of < f : < g : int -> (module XYZ) > >
>       Type (module XY) is not a subtype of (module XYZ)
>       Modules do not match: XY is not included in XYZ
>       The value z is required but not provided
>```


This changes also makes it possible to explain that if
```
let convert x = (x: (module XYZ):>(module XY))
```

fails with

> Error: Type (module XYZ) is not a subtype of (module XY)

it is because the first-class module subtyping relationship requires that the two first-class modules share the same
memory representation:

>```
> Error: Type (module XYZ) is not a subtype of (module XY)
>       The two first-class module types differ by their runtime size.
>```
