### PR TITLE
#12984: restore the filename computation for companion cmi

### DIFF
--- a/Changes
+++ b/Changes
@@ -692,8 +692,9 @@ OCaml 5.2.0
   in runtime/io.c
   (Gabriel Scherer, review by Xavier Leroy)
 
-- #12389, #12544: centralize the handling of metadata for compilation units and
-  artifacts in preparation for better unicode support for OCaml source files.
+- #12389, #12544, #12984, #12987: centralize the handling of metadata for
+  compilation units and artifacts in preparation for better unicode support for
+  OCaml source files.
   (Florian Angeletti, review by Gabriel Scherer)
 
 - #12532, #12553: improve readability of the pattern-matching debug output

--- a/Changes
+++ b/Changes
@@ -695,7 +695,7 @@ OCaml 5.2.0
 - #12389, #12544, #12984, #12987: centralize the handling of metadata for
   compilation units and artifacts in preparation for better unicode support for
   OCaml source files.
-  (Florian Angeletti, review by Gabriel Scherer)
+  (Florian Angeletti, review by Vincent Laviron and Gabriel Scherer)
 
 - #12532, #12553: improve readability of the pattern-matching debug output
   (Gabriel Scherer, review by Thomas Refis)

--- a/asmcomp/asmpackager.ml
+++ b/asmcomp/asmpackager.ml
@@ -263,8 +263,9 @@ let package_files ~ppf_dump initial_env files targetcmx ~backend =
         try Load_path.find f
         with Not_found -> raise(Error(File_not_found f)))
       files in
-  let cmi = Unit_info.(companion_cmi @@ Artifact.from_filename targetcmx) in
-  let obj = Unit_info.companion_obj cmi in
+  let cmx = Unit_info.Artifact.from_filename targetcmx in
+  let cmi = Unit_info.companion_cmi cmx in
+  let obj = Unit_info.companion_obj cmx in
   (* Set the name of the current "input" *)
   Location.input_name := targetcmx;
   (* Set the name of the current compunit *)

--- a/parsing/unit_info.ml
+++ b/parsing/unit_info.ml
@@ -103,8 +103,11 @@ let cmti f = mk_artifact ".cmti" f
 let annot f = mk_artifact ".annot" f
 
 let companion_obj f = companion_artifact Config.ext_obj f
-let companion_cmi f = companion_artifact ".cmi" f
 let companion_cmt f = companion_artifact ".cmt" f
+
+let companion_cmi f =
+  let prefix = Misc.chop_extensions f.Artifact.filename in
+  { f with Artifact.filename = prefix ^ ".cmi"}
 
 let mli_from_artifact f = Artifact.prefix f ^ !Config.interface_suffix
 let mli_from_source u =

--- a/parsing/unit_info.mli
+++ b/parsing/unit_info.mli
@@ -133,7 +133,6 @@ val companion_cmi: Artifact.t -> Artifact.t
  the other functions which only remove the rightmost extension.
  In other words, the companion cmi of a file [something.d.cmo] is
  [something.cmi] and not [something.d.cmi].
- This is done for bacward compatibility reason for pack users.
 *)
 
 (** {1:ml_mli_cmi_interaction Mli and cmi derived from implementation files } *)

--- a/parsing/unit_info.mli
+++ b/parsing/unit_info.mli
@@ -124,10 +124,17 @@ val annot: t -> Artifact.t
     extension of its filename.
     Those functions purposefully do not cover all artifact kinds because we want
     to track which artifacts are assumed to be bundled together. *)
-val companion_cmi: Artifact.t -> Artifact.t
 val companion_obj: Artifact.t -> Artifact.t
 val companion_cmt: Artifact.t -> Artifact.t
 
+val companion_cmi: Artifact.t -> Artifact.t
+(** Beware that [companion_cmi a] strips all extensions from the
+ filename of [a] before adding the [".cmi"] suffix contrarily to
+ the other functions which only remove the rightmost extension.
+ In other words, the companion cmi of a file [something.d.cmo] is
+ [something.cmi] and not [something.d.cmi].
+ This is done for bacward compatibility reason for pack users.
+*)
 
 (** {1:ml_mli_cmi_interaction Mli and cmi derived from implementation files } *)
 


### PR DESCRIPTION
My PR on uniformizing the handling of compilation unit and module names (#12389) went one step too far by making the computation of the companion cmi for a cmo artifact uses the same notion of file prefix than the other artifact filename transformation: `foo.bar.cmo` was expected to be bundled with `foo.bar.cmi` rather than `foo.cmi`.

However, #12984 discovered that this was a breaking change. This PR thus restores the specific filename computation for cmi companion artifact. 

This PR is probably best reviewed by checking in #12389 that the all uses of `chop_extensions`  for computing filename were replaced by calls to `companion_cmi`.

Close #12984