### PR TITLE
Only check that flexlink can be executed when building on a native windows machine.

### DIFF
--- a/Changes
+++ b/Changes
@@ -81,6 +81,10 @@ _______________
   grouping all the linker flags at the end of the C compiler commandline
   (David Allsopp and Samuel Hym, review by Nicolás Ojeda Bär)
 
+- #12992: Check that flexlink can be executed only when building in a native
+  windows environment.
+  (Romain Beauxis, review by David Allsopp)
+
 - #12996: Only link with -lgcc_eh when available.
   (Romain Beauxis, review by David Allsopp and Miod Vallat)
 

--- a/configure
+++ b/configure
@@ -14274,8 +14274,11 @@ rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
 
 
 
-    case $host in #(
-  *-w64-mingw32*|*-pc-windows) :
+    # When building on Cygwin/MSYS2, flexlink may be a shell script which
+    # then cannot be executed by ocamlc/ocamlopt. Having located flexlink,
+    # ensure it can be executed from a native Windows process.
+    case $build in #(
+  *-pc-msys|*-pc-cygwin*) :
     flexlink_where="$(cmd /c "$flexlink" -where 2>/dev/null)"
         if test -z "$flexlink_where"
 then :

--- a/configure.ac
+++ b/configure.ac
@@ -970,8 +970,11 @@ AS_IF([test x"$supports_shared_libraries" != 'xfalse'], [
     OCAML_TEST_FLEXLINK([$flexlink], [$flexdll_chain],
                         [$internal_cppflags], [$host])
 
-    AS_CASE([$host],
-      [*-w64-mingw32*|*-pc-windows],
+    # When building on Cygwin/MSYS2, flexlink may be a shell script which
+    # then cannot be executed by ocamlc/ocamlopt. Having located flexlink,
+    # ensure it can be executed from a native Windows process.
+    AS_CASE([$build],
+      [*-pc-msys|*-pc-cygwin*],
         [flexlink_where="$(cmd /c "$flexlink" -where 2>/dev/null)"
         AS_IF([test -z "$flexlink_where"],
           [AC_MSG_ERROR(m4_normalize([$flexlink is not executable from a native


### PR DESCRIPTION
I'm in the process of updating https://github.com/ocaml-cross/opam-cross-windows/ to support OCaml `5.1.1` and there are very little changes to `configure` required now! Pretty exciting!

This one of two changes: `flexlink` needs to be called as a shell command, not a windows command when cross-compiling.

I took the approach of assuming that the `cmd /c` prefix needs to be added only when the build host is windows. That seems like a logical decision to me.