### PR TITLE
4.14: build executables with `-no-pie` on x86/32bits Linux and *BSDs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -157,7 +157,7 @@ jobs:
   i386:
     runs-on: ubuntu-latest
     container:
-      image: debian:10
+      image: debian:12
       options: --platform linux/i386 --user root
     steps:
       - name: OS Dependencies

--- a/Changes
+++ b/Changes
@@ -62,6 +62,9 @@ OCaml 4.14 maintenance version
   (Gabriel Scherer and Nicolás Ojeda Bär, report by Sylvain Boilard, review by
   Gabriel Scherer)
 
+- #12116, #????: explicitly build non PIE executables on x86 32bits
+  architectures
+  (Florian Angeletti, review by ????)
 
 OCaml 4.14.1 (20 December 2022)
 ------------------------------

--- a/Changes
+++ b/Changes
@@ -62,9 +62,9 @@ OCaml 4.14 maintenance version
   (Gabriel Scherer and Nicolás Ojeda Bär, report by Sylvain Boilard, review by
   Gabriel Scherer)
 
-- #12116, #????: explicitly build non PIE executables on x86 32bits
+- #12116, #12993: explicitly build non PIE executables on x86 32bits
   architectures
-  (Florian Angeletti, review by ????)
+  (Florian Angeletti, review by David Allsopp)
 
 OCaml 4.14.1 (20 December 2022)
 ------------------------------

--- a/configure
+++ b/configure
@@ -13279,6 +13279,9 @@ esac
   *,x86_64-*-linux*) :
     $as_echo "#define HAS_ARCH_CODE32 1" >>confdefs.h
  ;; #(
+  *,i[3456]86-*) :
+    # Explicitly disable PIE executables on Linux and *BSD x86_32
+    mkexe="$mkexe -no-pie " ;; #(
   xlc*,powerpc-ibm-aix*) :
     mkexe="$mkexe "
      oc_ldflags="-brtl -bexpfull"

--- a/configure.ac
+++ b/configure.ac
@@ -835,6 +835,9 @@ AS_CASE([$cc_basename,$host],
     mkexedebugflag=''],
   [*,x86_64-*-linux*],
     AC_DEFINE([HAS_ARCH_CODE32], [1]),
+  [[*,i[3456]86-*]],
+    # Explicitly disable PIE executables on Linux and *BSD x86_32
+    [mkexe="$mkexe -no-pie "],
   [xlc*,powerpc-ibm-aix*],
     [mkexe="$mkexe "
      oc_ldflags="-brtl -bexpfull"


### PR DESCRIPTION
This PR proposes to explicitly build 32 bits executables in the non Position Independent mode on linux and *BSDs
as suggested in #12166.