### PR TITLE
Add `caml_*_of_string_unboxed` primitives for boxed int parsing

### DIFF
--- a/runtime/ints.c
+++ b/runtime/ints.c
@@ -334,9 +334,14 @@ CAMLprim value caml_int32_format(value fmt, value arg)
   return caml_alloc_sprintf(format_string, Int32_val(arg));
 }
 
+CAMLprim int32_t caml_int32_of_string_unboxed(value s)
+{
+  return (int32_t) parse_intnat(s, 32, INT32_ERRMSG);
+}
+
 CAMLprim value caml_int32_of_string(value s)
 {
-  return caml_copy_int32((int32_t) parse_intnat(s, 32, INT32_ERRMSG));
+  return caml_copy_int32(caml_int32_of_string_unboxed(s));
 }
 
 int32_t caml_int32_bits_of_float_unboxed(double d)
@@ -573,7 +578,7 @@ CAMLprim value caml_int64_format(value fmt, value arg)
   return caml_alloc_sprintf(format_string, Int64_val(arg));
 }
 
-CAMLprim value caml_int64_of_string(value s)
+CAMLprim int64_t caml_int64_of_string_unboxed(value s)
 {
   const char * p;
   uint64_t res, threshold;
@@ -607,7 +612,12 @@ CAMLprim value caml_int64_of_string(value s)
     }
   }
   if (sign < 0) res = - res;
-  return caml_copy_int64(res);
+  return res;
+}
+
+CAMLprim value caml_int64_of_string(value s)
+{
+  return caml_copy_int64(caml_int64_of_string_unboxed(s));
 }
 
 int64_t caml_int64_bits_of_float_unboxed(double d)
@@ -836,7 +846,12 @@ CAMLprim value caml_nativeint_format(value fmt, value arg)
   return caml_alloc_sprintf(format_string, Nativeint_val(arg));
 }
 
+CAMLprim intnat caml_nativeint_of_string_unboxed(value s)
+{
+  return parse_intnat(s, 8 * sizeof(value), INTNAT_ERRMSG);
+}
+
 CAMLprim value caml_nativeint_of_string(value s)
 {
-  return caml_copy_nativeint(parse_intnat(s, 8 * sizeof(value), INTNAT_ERRMSG));
+  return caml_copy_nativeint(caml_nativeint_of_string_unboxed(s));
 }

--- a/stdlib/int32.ml
+++ b/stdlib/int32.ml
@@ -71,7 +71,8 @@ let unsigned_to_int =
 external format : string -> int32 -> string = "caml_int32_format"
 let to_string n = format "%d" n
 
-external of_string : string -> int32 = "caml_int32_of_string"
+external of_string : string -> (int32[@unboxed])
+  = "caml_int32_of_string" "caml_int32_of_string_unboxed"
 
 let of_string_opt s =
   try Some (of_string s)

--- a/stdlib/int32.mli
+++ b/stdlib/int32.mli
@@ -157,7 +157,8 @@ external to_float : int32 -> float
   [@@unboxed] [@@noalloc]
 (** Convert the given 32-bit integer to a floating-point number. *)
 
-external of_string : string -> int32 = "caml_int32_of_string"
+external of_string : string -> (int32[@unboxed])
+  = "caml_int32_of_string" "caml_int32_of_string_unboxed"
 (** Convert the given string to a 32-bit integer.
    The string is read in decimal (by default, or if the string
    begins with [0u]) or in hexadecimal, octal or binary if the

--- a/stdlib/int64.ml
+++ b/stdlib/int64.ml
@@ -61,7 +61,8 @@ let unsigned_to_int =
 external format : string -> int64 -> string = "caml_int64_format"
 let to_string n = format "%d" n
 
-external of_string : string -> int64 = "caml_int64_of_string"
+external of_string : string -> (int64[@unboxed])
+  = "caml_int64_of_string" "caml_int64_of_string_unboxed"
 
 let of_string_opt s =
   try Some (of_string s)

--- a/stdlib/int64.mli
+++ b/stdlib/int64.mli
@@ -177,7 +177,8 @@ external to_nativeint : int64 -> nativeint = "%int64_to_nativeint"
    is taken modulo 2{^32}.  On 64-bit platforms,
    the conversion is exact. *)
 
-external of_string : string -> int64 = "caml_int64_of_string"
+external of_string : string -> (int64[@unboxed])
+  = "caml_int64_of_string" "caml_int64_of_string_unboxed"
 (** Convert the given string to a 64-bit integer.
    The string is read in decimal (by default, or if the string
    begins with [0u]) or in hexadecimal, octal or binary if the

--- a/stdlib/nativeint.ml
+++ b/stdlib/nativeint.ml
@@ -60,7 +60,8 @@ let unsigned_to_int =
 external format : string -> nativeint -> string = "caml_nativeint_format"
 let to_string n = format "%d" n
 
-external of_string: string -> nativeint = "caml_nativeint_of_string"
+external of_string: string -> (nativeint[@unboxed])
+  = "caml_nativeint_of_string" "caml_nativeint_of_string_unboxed"
 
 let of_string_opt s =
   try Some (of_string s)

--- a/stdlib/nativeint.mli
+++ b/stdlib/nativeint.mli
@@ -185,7 +185,8 @@ external to_int32 : nativeint -> int32 = "%nativeint_to_int32"
    i.e. the top 32 bits are lost.  On 32-bit platforms,
    the conversion is exact. *)
 
-external of_string : string -> nativeint = "caml_nativeint_of_string"
+external of_string: string -> (nativeint[@unboxed])
+  = "caml_nativeint_of_string" "caml_nativeint_of_string_unboxed"
 (** Convert the given string to a native integer.
    The string is read in decimal (by default, or if the string
    begins with [0u]) or in hexadecimal, octal or binary if the

--- a/testsuite/tests/lib-marshal/compressed.ml
+++ b/testsuite/tests/lib-marshal/compressed.ml
@@ -67,7 +67,7 @@ let test_out ?(flags = []) filename =
     (Nativeint.shift_left (Nativeint.of_string "123456789") 32);
   output_value oc
     (Nativeint.shift_left (Nativeint.of_string "-123456789") 32);
-  let i = Int64.of_string "123456789123456" in
+  let i = Sys.opaque_identity (Int64.of_string "123456789123456") in
     output_value oc (i,i);
   close_out oc
 

--- a/testsuite/tests/lib-marshal/intext.ml
+++ b/testsuite/tests/lib-marshal/intext.ml
@@ -70,7 +70,7 @@ let test_out ?(flags = []) filename =
     (Nativeint.shift_left (Nativeint.of_string "123456789") 32) flags;
   Marshal.to_channel oc
     (Nativeint.shift_left (Nativeint.of_string "-123456789") 32) flags;
-  let i = Int64.of_string "123456789123456" in
+  let i = Sys.opaque_identity (Int64.of_string "123456789123456") in
     Marshal.to_channel oc (i,i) flags;
   close_out oc
 

--- a/testsuite/tests/lib-marshal/intext_par.ml
+++ b/testsuite/tests/lib-marshal/intext_par.ml
@@ -81,7 +81,8 @@ let test_out filename =
   output_value oc (Nativeint.of_string "-123456");
   output_value oc (Nativeint.shift_left (Nativeint.of_string "123456789") 32);
   output_value oc (Nativeint.shift_left (Nativeint.of_string "-123456789") 32);
-  let i = Int64.of_string "123456789123456" in output_value oc (i,i);
+  let i = Sys.opaque_identity (Int64.of_string "123456789123456") in
+  output_value oc (i,i);
   close_out oc
 
 


### PR DESCRIPTION
Add `caml_int32_of_string_unboxed`, `caml_int64_of_string_unboxed`, and `caml_nativeint_of_string_unboxed` primitives. These runtime primitives return the result value unboxed rather than forcing allocation.