### PR TITLE
Be more selective when linking with gcc_eh

### DIFF
--- a/Changes
+++ b/Changes
@@ -81,6 +81,9 @@ _______________
   grouping all the linker flags at the end of the C compiler commandline
   (David Allsopp and Samuel Hym, review by Nicolás Ojeda Bär)
 
+- #12996: Only link gcc_eh when available.
+  (Romain Beauxis, review by David Allsop and Miod Vallat)
+
 ### Bug fixes:
 
 - #12888: fix printing of uncaught exceptions in `.cmo` files passed on the

--- a/Changes
+++ b/Changes
@@ -81,8 +81,8 @@ _______________
   grouping all the linker flags at the end of the C compiler commandline
   (David Allsopp and Samuel Hym, review by Nicolás Ojeda Bär)
 
-- #12996: Only link gcc_eh when available.
-  (Romain Beauxis, review by David Allsop and Miod Vallat)
+- #12996: Only link with -lgcc_eh when available.
+  (Romain Beauxis, review by David Allsopp and Miod Vallat)
 
 ### Bug fixes:
 

--- a/configure
+++ b/configure
@@ -18801,9 +18801,51 @@ esac
 
 ## Determine how to link with the POSIX threads library
 
+link_gcc_eh=''
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for printf in -lgcc_eh" >&5
+printf %s "checking for printf in -lgcc_eh... " >&6; }
+if test ${ac_cv_lib_gcc_eh_printf+y}
+then :
+  printf %s "(cached) " >&6
+else $as_nop
+  ac_check_lib_save_LIBS=$LIBS
+LIBS="-lgcc_eh  $LIBS"
+cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+/* Override any GCC internal prototype to avoid an error.
+   Use char because int might match the return type of a GCC
+   builtin and then its argument prototype would still apply.  */
+char printf ();
+int
+main (void)
+{
+return printf ();
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_link "$LINENO"
+then :
+  ac_cv_lib_gcc_eh_printf=yes
+else $as_nop
+  ac_cv_lib_gcc_eh_printf=no
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.beam \
+    conftest$ac_exeext conftest.$ac_ext
+LIBS=$ac_check_lib_save_LIBS
+fi
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib_gcc_eh_printf" >&5
+printf "%s\n" "$ac_cv_lib_gcc_eh_printf" >&6; }
+if test "x$ac_cv_lib_gcc_eh_printf" = xyes
+then :
+  link_gcc_eh="-lgcc_eh"
+fi
+
+
 case $host in #(
   *-*-mingw32*) :
-    PTHREAD_LIBS="-l:libpthread.a -lgcc_eh" ;; #(
+    PTHREAD_LIBS="-l:libpthread.a $link_gcc_eh" ;; #(
   *-pc-windows) :
     PTHREAD_LIBS="-l:libpthread.lib" ;; #(
   *) :

--- a/configure
+++ b/configure
@@ -18801,8 +18801,10 @@ esac
 
 ## Determine how to link with the POSIX threads library
 
-link_gcc_eh=''
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for printf in -lgcc_eh" >&5
+case $host in #(
+  *-*-mingw32*) :
+    link_gcc_eh=''
+     { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for printf in -lgcc_eh" >&5
 printf %s "checking for printf in -lgcc_eh... " >&6; }
 if test ${ac_cv_lib_gcc_eh_printf+y}
 then :
@@ -18842,10 +18844,7 @@ then :
   link_gcc_eh="-lgcc_eh"
 fi
 
-
-case $host in #(
-  *-*-mingw32*) :
-    PTHREAD_LIBS="-l:libpthread.a $link_gcc_eh" ;; #(
+     PTHREAD_LIBS="-l:libpthread.a $link_gcc_eh" ;; #(
   *-pc-windows) :
     PTHREAD_LIBS="-l:libpthread.lib" ;; #(
   *) :

--- a/configure.ac
+++ b/configure.ac
@@ -2268,12 +2268,11 @@ AS_CASE([$enable_debug_runtime],
 
 ## Determine how to link with the POSIX threads library
 
-link_gcc_eh=''
-AC_CHECK_LIB([gcc_eh], [printf], [link_gcc_eh="-lgcc_eh"])
-
 AS_CASE([$host],
   [*-*-mingw32*],
-    [PTHREAD_LIBS="-l:libpthread.a $link_gcc_eh"],
+    [link_gcc_eh=''
+     AC_CHECK_LIB([gcc_eh], [printf], [link_gcc_eh="-lgcc_eh"])
+     PTHREAD_LIBS="-l:libpthread.a $link_gcc_eh"],
   [*-pc-windows],
     [PTHREAD_LIBS="-l:libpthread.lib"],
   [AX_PTHREAD(

--- a/configure.ac
+++ b/configure.ac
@@ -2268,9 +2268,12 @@ AS_CASE([$enable_debug_runtime],
 
 ## Determine how to link with the POSIX threads library
 
+link_gcc_eh=''
+AC_CHECK_LIB([gcc_eh], [printf], [link_gcc_eh="-lgcc_eh"])
+
 AS_CASE([$host],
   [*-*-mingw32*],
-    [PTHREAD_LIBS="-l:libpthread.a -lgcc_eh"],
+    [PTHREAD_LIBS="-l:libpthread.a $link_gcc_eh"],
   [*-pc-windows],
     [PTHREAD_LIBS="-l:libpthread.lib"],
   [AX_PTHREAD(


### PR DESCRIPTION
This is the second change required to build OCaml `5.1.1` in https://github.com/ocaml-cross/opam-cross-windows/  after https://github.com/ocaml/ocaml/pull/12992.

Some cross-compiled `mingw` compiler may not have `gcc_eh` available. This happened at least with the static compiler.

This PR changes the test to only add `-lgcc_eh` when it is actually available.