### PR TITLE
Prevent tail call optimization in unwind test

### DIFF
--- a/testsuite/tests/unwind/stack_walker.c
+++ b/testsuite/tests/unwind/stack_walker.c
@@ -63,6 +63,10 @@ value ml_perform_stack_walk(value unused) {
     return Val_unit;
 }
 
-value ml_do_no_alloc(value unused) {
-    return ml_perform_stack_walk(unused);
+value ml_do_no_alloc(value unit) {
+    (void) ml_perform_stack_walk(unit);
+    /* In order to prevent the C compiler from performing tail-call
+       optimization, we return the argument rather than the constant
+       Val_unit. */
+    return unit;
 }


### PR DESCRIPTION
My C compiler compiles the function `ml_do_no_alloc` to a single Jump instruction; as a consequence, it doesn't appear in the stack bactrace and the test fails.

By returning a value that the C compiler cannot predict, we make sure that it cannot optimize away the stack frame.
