### PR TITLE
Use the PIC object file zstd.npic.o in libcomprmarsh.a

### DIFF
--- a/Changes
+++ b/Changes
@@ -454,7 +454,7 @@ OCaml 5.2.0
 - #12625: Remove the Closure module from Obj
   (Vincent Laviron, review by Xavier Leroy)
 
-- #12758: Remove the `Marshal.Compression` flag to the
+- #12758, #12998: Remove the `Marshal.Compression` flag to the
   `Marshal.to_*` functions.  The compilers are still able to use
   ZSTD compression for compilation artefacts.
   This is a forward port and clean-up of the emergency fix that was introduced

--- a/Makefile
+++ b/Makefile
@@ -1234,7 +1234,7 @@ libasmruni_OBJECTS = \
 libasmrunpic_OBJECTS = $(runtime_NATIVE_C_SOURCES:.c=.npic.$(O)) \
   $(runtime_ASM_OBJECTS:.$(O)=_libasmrunpic.$(O))
 
-libcomprmarsh_OBJECTS = runtime/zstd.n.$(O)
+libcomprmarsh_OBJECTS = runtime/zstd.npic.$(O)
 
 ## General (non target-specific) assembler and compiler flags
 


### PR DESCRIPTION
This is a forward-port of #12783 to trunk/5.2 which should fix uses of ocamlcommon.cmxa with shared objects in an equivalent way.