### PR TITLE
Fix tests that use Unix without checking whether Unix is available.

### DIFF
--- a/testsuite/tests/lib-runtime-events/test_user_event_signal.ml
+++ b/testsuite/tests/lib-runtime-events/test_user_event_signal.ml
@@ -1,6 +1,7 @@
 (* TEST
  include runtime_events;
  include unix;
+ hasunix;
  not-windows;
  {
    bytecode;

--- a/testsuite/tests/tsan/array_elt.ml
+++ b/testsuite/tests/tsan/array_elt.ml
@@ -1,6 +1,5 @@
 (* TEST
 
- include unix;
  set TSAN_OPTIONS="detect_deadlocks=0";
 
  tsan;

--- a/testsuite/tests/tsan/exn_from_c.ml
+++ b/testsuite/tests/tsan/exn_from_c.ml
@@ -1,7 +1,6 @@
 (* TEST
 
  ocamlopt_flags = "-g -ccopt -fsanitize=thread -ccopt -O1 -ccopt -fno-omit-frame-pointer -ccopt -g";
- include unix;
  set TSAN_OPTIONS="detect_deadlocks=0";
 
  tsan;

--- a/testsuite/tests/tsan/exn_in_callback.ml
+++ b/testsuite/tests/tsan/exn_in_callback.ml
@@ -1,7 +1,6 @@
 (* TEST
 
  ocamlopt_flags = "-g -ccopt -fsanitize=thread -ccopt -O1 -ccopt -fno-omit-frame-pointer -ccopt -g";
- include unix;
  set TSAN_OPTIONS="detect_deadlocks=0";
 
  tsan;

--- a/testsuite/tests/tsan/exn_reraise.ml
+++ b/testsuite/tests/tsan/exn_reraise.ml
@@ -1,7 +1,6 @@
 (* TEST
 
  ocamlopt_flags = "-g -ccopt -fsanitize=thread -ccopt -O1 -ccopt -fno-omit-frame-pointer -ccopt -g";
- include unix;
  set TSAN_OPTIONS="detect_deadlocks=0";
 
  tsan;

--- a/testsuite/tests/tsan/norace_atomics.ml
+++ b/testsuite/tests/tsan/norace_atomics.ml
@@ -1,6 +1,5 @@
 (* TEST
 
- include unix;
  set TSAN_OPTIONS="detect_deadlocks=0";
 
  tsan;

--- a/testsuite/tests/tsan/perform.ml
+++ b/testsuite/tests/tsan/perform.ml
@@ -1,7 +1,6 @@
 (* TEST
 
  ocamlopt_flags = "-g";
- include unix;
  set TSAN_OPTIONS="detect_deadlocks=0";
 
  tsan;

--- a/testsuite/tests/tsan/raise_through_handler.ml
+++ b/testsuite/tests/tsan/raise_through_handler.ml
@@ -1,7 +1,6 @@
 (* TEST
 
  ocamlopt_flags = "-g";
- include unix;
  set TSAN_OPTIONS="detect_deadlocks=0";
 
  tsan;

--- a/testsuite/tests/tsan/record_field.ml
+++ b/testsuite/tests/tsan/record_field.ml
@@ -1,6 +1,5 @@
 (* TEST
 
- include unix;
  set TSAN_OPTIONS="detect_deadlocks=0";
 
  tsan;

--- a/testsuite/tests/tsan/reperform.ml
+++ b/testsuite/tests/tsan/reperform.ml
@@ -1,7 +1,6 @@
 (* TEST
 
  ocamlopt_flags = "-g";
- include unix;
  set TSAN_OPTIONS="detect_deadlocks=0";
 
  tsan;

--- a/testsuite/tests/tsan/unhandled.ml
+++ b/testsuite/tests/tsan/unhandled.ml
@@ -1,7 +1,6 @@
 (* TEST
 
  ocamlopt_flags = "-g";
- include unix;
  set TSAN_OPTIONS="detect_deadlocks=0";
 
  tsan;

--- a/testsuite/tests/win-unicode/mltest.ml
+++ b/testsuite/tests/win-unicode/mltest.ml
@@ -1,5 +1,6 @@
 (* TEST
  include unix;
+ hasunix;
  flags += "-strict-sequence -w +A -warn-error +A";
  windows-unicode;
  toplevel;


### PR DESCRIPTION
`test_user_event_signal.ml` fails on Inria CI (job `other-configs`) on the minimal configuration, which doesn't compile the Unix library.

If you `include unix` in a test, you have to check for `hasunix`, `libunix`, or `libwin32unix`. I've fixed the other instances of this error, even though they are not tested by our CI.
