### PR TITLE
shapes: do not read_back entire shape to get aliases uids

### DIFF
--- a/Changes
+++ b/Changes
@@ -136,7 +136,7 @@ _______________
 
 - #13001: do not read_back entire shapes to get aliases' uids when building the
   usages index
-  (Ulysse Gérard, review by Gabriel Scherer)
+  (Ulysse Gérard, review by Gabriel Scherer and Nathanaëlle Courant)
 
 ### Build system:
 

--- a/Changes
+++ b/Changes
@@ -134,6 +134,10 @@ _______________
 - #13074, #13082, #13084: refactoring in the pattern-matching compiler
   (Gabriel Scherer, review by Thomas Refis, Vincent Laviron and Nick Roberts)
 
+- #13001: do not read_back entire shapes to get aliases' uids when building the
+  usages index
+  (Ulysse Gérard, review by Gabriel Scherer)
+
 ### Build system:
 
 - #12909: Reorganise how MKEXE_VIA_CC is built to make it correct for MSVC by

--- a/Changes
+++ b/Changes
@@ -134,10 +134,6 @@ _______________
 - #13074, #13082, #13084: refactoring in the pattern-matching compiler
   (Gabriel Scherer, review by Thomas Refis, Vincent Laviron and Nick Roberts)
 
-- #13001: do not read_back entire shapes to get aliases' uids when building the
-  usages index
-  (Ulysse Gérard, review by Gabriel Scherer and Nathanaëlle Courant)
-
 ### Build system:
 
 - #12909: Reorganise how MKEXE_VIA_CC is built to make it correct for MSVC by
@@ -849,6 +845,10 @@ OCaml 5.2.0
 - #12914: Slightly change the s390x assembly dialect in order to build with
   Clang's integrated assembler.
   (Miod Vallat, review by Gabriel Scherer)
+
+- #13001: do not read_back entire shapes to get aliases' uids when building the
+  usages index
+  (Ulysse Gérard, review by Gabriel Scherer and Nathanaëlle Courant)
 
 ### Build system:
 

--- a/testsuite/tests/shape-index/index_aliases.ml
+++ b/testsuite/tests/shape-index/index_aliases.ml
@@ -27,3 +27,26 @@ module D = C
 
 module G = B
 include G
+
+module type S = sig
+  module M : sig val s : unit end
+  module F : functor (S : sig end ) -> sig type t end
+ end
+let x = (module struct
+    module M = struct let s = () end
+    module F (_ : sig end) = struct type t end
+  end : S)
+
+module X = (val x)
+module Y = X.M
+module Z = Y
+
+(* FIXME: this sould be (Approx (No_uid)), not (Internal_error_no_uid) *)
+let _ = Z.s
+
+module Arg = struct end
+module FArg = X.F (Arg)
+open FArg
+
+(* FIXME: this sould be (Approx (No_uid)), not (Internal_error_no_uid) *)
+type u = t

--- a/testsuite/tests/shape-index/index_aliases.reference
+++ b/testsuite/tests/shape-index/index_aliases.reference
@@ -1,17 +1,34 @@
 Indexed shapes:
-Resolved_alias: Index_aliases.10 -> Index_aliases.2 -> Index_aliases.1 :
+Missing uid : t (File "index_aliases.ml", line 52, characters 9-10)
+Resolved: Index_aliases.26 :
+  FArg (File "index_aliases.ml", line 49, characters 5-9)
+Resolved: Index_aliases.25 :
+  Arg (File "index_aliases.ml", line 48, characters 19-22)
+Approximated: Index_aliases.22 :
+  X.F (File "index_aliases.ml", line 48, characters 14-17)
+Missing uid : Z.s (File "index_aliases.ml", line 45, characters 8-11)
+Alias: Index_aliases.23 -> Approximated: Index_aliases.22  :
+  Y (File "index_aliases.ml", line 42, characters 11-12)
+Approximated: Index_aliases.22 :
+  X.M (File "index_aliases.ml", line 41, characters 11-14)
+Resolved: Index_aliases.17 :
+  x (File "index_aliases.ml", line 40, characters 16-17)
+Resolved: Index_aliases.16 :
+  S (File "index_aliases.ml", line 38, characters 8-9)
+Alias: Index_aliases.10 -> Alias: Index_aliases.2 -> Resolved: Index_aliases.1
+                             :
   G (File "index_aliases.ml", line 29, characters 8-9)
-Resolved_alias: Index_aliases.2 -> Index_aliases.1 :
+Alias: Index_aliases.2 -> Resolved: Index_aliases.1  :
   B (File "index_aliases.ml", line 28, characters 11-12)
 Resolved: Index_aliases.7 :
   C (File "index_aliases.ml", line 26, characters 11-12)
-Resolved_alias: Index_aliases.2 -> Index_aliases.1 :
+Alias: Index_aliases.2 -> Resolved: Index_aliases.1  :
   B (File "index_aliases.ml", line 25, characters 14-15)
 Resolved: Index_aliases.5 :
   F (File "index_aliases.ml", line 25, characters 12-13)
 Resolved: Index_aliases.1 :
   A (File "index_aliases.ml", line 23, characters 14-15)
-Resolved_alias: Index_aliases.6 -> Index_aliases.5 :
+Alias: Index_aliases.6 -> Resolved: Index_aliases.5  :
   F' (File "index_aliases.ml", line 23, characters 11-13)
 Resolved: Index_aliases.5 :
   F (File "index_aliases.ml", line 22, characters 12-13)
@@ -21,13 +38,29 @@ Resolved: Index_aliases.1 :
   A (File "index_aliases.ml", line 19, characters 11-12)
 
 Uid of decls:
+Index_aliases.12: M (File "index_aliases.ml", line 32, characters 9-10)
 Index_aliases.1: A (File "index_aliases.ml", line 18, characters 7-8)
 Index_aliases.2: B (File "index_aliases.ml", line 19, characters 7-8)
+Index_aliases.18: s (File "index_aliases.ml", line 36, characters 26-27)
+Index_aliases.17: x (File "index_aliases.ml", line 35, characters 4-5)
 Index_aliases.5: F (File "index_aliases.ml", line 21, characters 7-8)
+Index_aliases.26: FArg (File "index_aliases.ml", line 48, characters 7-11)
 Index_aliases.7: C (File "index_aliases.ml", line 23, characters 7-8)
+Index_aliases.24: Z (File "index_aliases.ml", line 42, characters 7-8)
+Index_aliases.20: t (File "index_aliases.ml", line 37, characters 41-42)
 Index_aliases.9: D (File "index_aliases.ml", line 26, characters 7-8)
+Index_aliases.15: F (File "index_aliases.ml", line 33, characters 9-10)
+Index_aliases.19: M (File "index_aliases.ml", line 36, characters 11-12)
 Index_aliases.8: C' (File "index_aliases.ml", line 25, characters 7-9)
+Index_aliases.23: Y (File "index_aliases.ml", line 41, characters 7-8)
+Index_aliases.14: t (File "index_aliases.ml", line 33, characters 48-49)
 Index_aliases.10: G (File "index_aliases.ml", line 28, characters 7-8)
+Index_aliases.27: u (File "index_aliases.ml", line 52, characters 5-6)
+Index_aliases.22: X (File "index_aliases.ml", line 40, characters 7-8)
+Index_aliases.16: S (File "index_aliases.ml", line 31, characters 12-13)
+Index_aliases.25: Arg (File "index_aliases.ml", line 47, characters 7-10)
+Index_aliases.21: F (File "index_aliases.ml", line 37, characters 11-12)
 Index_aliases.6: F' (File "index_aliases.ml", line 22, characters 7-9)
 Index_aliases.3: t (File "index_aliases.ml", line 21, characters 23-24)
+Index_aliases.11: s (File "index_aliases.ml", line 32, characters 21-22)
 Index_aliases.0: t (File "index_aliases.ml", line 18, characters 23-24)

--- a/testsuite/tests/shape-index/index_functor.reference
+++ b/testsuite/tests/shape-index/index_functor.reference
@@ -1,7 +1,7 @@
 Indexed shapes:
 Resolved: Index_functor.3 :
   N (File "index_functor.ml", line 22, characters 8-9)
-Resolved_alias: Index_functor.4 -> Index_functor.0 :
+Alias: Index_functor.4 -> Resolved: Index_functor.0  :
   O (File "index_functor.ml", line 21, characters 8-9)
 Resolved: Index_functor.0 :
   N.M (File "index_functor.ml", line 20, characters 11-14)

--- a/typing/shape_reduce.mli
+++ b/typing/shape_reduce.mli
@@ -18,10 +18,10 @@
 (** The result of reducing a shape and looking for its uid *)
 type result =
   | Resolved of Shape.Uid.t (** Shape reduction succeeded and a uid was found *)
-  | Resolved_alias of Shape.Uid.t list (** Reduction led to an alias chain *)
+  | Resolved_alias of Shape.Uid.t * result (** Reduction led to an alias *)
   | Unresolved of Shape.t (** Result still contains [Comp_unit] terms *)
   | Approximated of Shape.Uid.t option
-    (** Reduction failed: it can arrive with first-clsss modules for example *)
+    (** Reduction failed: it can arrive with first-class modules for example *)
   | Internal_error_missing_uid
     (** Reduction succeeded but no uid was found, this should never happen *)
 


### PR DESCRIPTION
Fully reducing the shapes of large modules (and all their components) is an expensive process. Merlin, when trying to jump to a module, used to do that to get the uid of the module, and thus it's location. This wasteful reduction slowed the query and we introduced "weak_reduction" which does not reduce a module's components when all we are interested in is the module's uid itself.

In #12508, we redesigned this feature along with @Ekdohibs and @gasche in the form of the `reduce_for_uid` function that doesn't leak incorrect shapes anymore. This function performs weak reduction and returns only the resulting uid. When looking for a module alias it returns the list of the aliases uids and the aliased module uid:

```
module X = struct end
module A_1 = X
...
module A_N = A_N-1
```

`reduce_for_uid 'path to A_N'` returns `[uid_of_A_N; ...; uid_of_A_1; uid_of_X]`. 

This information allows Merlin to traverse aliases and jump to the actual definition of X, but keep aliasing information which is useful for other use cases like `occurrences`.

To return this list I used a call  to `read_back` before looking at the shape description to get the head aliases. This was, of course, a mistake since it will perform full reduction of the module's body. This lead to blow up when indexing large codebases and slower locate queries when jumping to an aliased module.

This PR fixes that by only forcing step by step the shape reduction to get the head aliases. 

@Octachron I think the performance issue I described should not have a large impact during the partial indexation that we are introducing in 5.2 because it only reduce shapes locally. It would take a very pathological compilation unit for the issue to manifest itself in a significant way. Still, it might be better to have this fix in the 5.2 branch.