### PR TITLE
#12971 bis, occur_rec: don't expand already visited type nodes

### DIFF
--- a/testsuite/tests/typing-misc/occur_check.ml
+++ b/testsuite/tests/typing-misc/occur_check.ml
@@ -62,15 +62,28 @@ let wrong_to_seq (xt : 'a t) : 'a Seq.t =
    with the Ctype.Escape exception, as it did from 4.13 to 5.1. *)
 [%%expect{|
 type 'a t = T of 'a
-val wrong_to_seq : ('a Seq.t as 'a) Seq.t t -> 'a Seq.t Seq.t = <fun>
+Line 4, characters 2-22:
+4 |   Seq.cons Seq.empty x
+      ^^^^^^^^^^^^^^^^^^^^
+Error: This expression has type "'a Seq.t Seq.t" = "unit -> 'a Seq.t Seq.node"
+       but an expression was expected of type
+         "'a Seq.t Seq.t Seq.t" = "unit -> 'a Seq.t Seq.t Seq.node"
+       Type "'a Seq.t" = "unit -> 'a Seq.node" is not compatible with type
+         "'a Seq.t Seq.t" = "unit -> 'a Seq.t Seq.node"
+       Type "'a" is not compatible with type "'a Seq.t" = "unit -> 'a Seq.node"
+       The type variable "'a" occurs inside "'a Seq.t"
 |}];;
 
 let strange x = Seq.[cons x empty; cons empty x];;
 [%%expect{|
-Line 1, characters 12-48:
+Line 1, characters 35-47:
 1 | let strange x = Seq.[cons x empty; cons empty x];;
-                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This expression has type "('a Seq.t as 'a) Seq.t -> 'a Seq.t Seq.t list"
+                                       ^^^^^^^^^^^^
+Error: This expression has type "'a Seq.t Seq.t" = "unit -> 'a Seq.t Seq.node"
        but an expression was expected of type
-         "('a Seq.t as 'a) Seq.t -> 'a Seq.t Seq.t list"
+         "'a Seq.t Seq.t Seq.t" = "unit -> 'a Seq.t Seq.t Seq.node"
+       Type "'a Seq.t" = "unit -> 'a Seq.node" is not compatible with type
+         "'a Seq.t Seq.t" = "unit -> 'a Seq.t Seq.node"
+       Type "'a" is not compatible with type "'a Seq.t" = "unit -> 'a Seq.node"
+       The type variable "'a" occurs inside "'a Seq.t"
 |}];;


### PR DESCRIPTION
Currently on trunk (and since OCaml 4.01 for some variant of the code below), the following code is accepted
```ocaml
let should_fail (x:'a) = 
  let sub = Seq.(cons empty x) in
  let error = (sub:'a Seq.t) in
  error 
```
and function `should_fail` is typed as `('a Seq.t as 'a) Seq.t -> 'a Seq.t Seq.t` without any  `-rectypes` option in sight.

What happens is that during the unification of the `'a Seq.t` constraint with the type
`'a Seq.t Seq.t`, the `occur_rec` check is called on this digraph

![0300-occur-rec-step-error-l3 14-28](https://github.com/ocaml/ocaml/assets/7689388/d586be93-c0a8-43e2-a65f-f32af27dc3bc)

and concludes that the node `25` doesn't occur in the subgraph reachable from node `24`.
This is obviously false.

The underlying issue is that the digraph already contains cycles in the expansion of the node `24`. When the direct path in `occur_rec` function fails, the `occur_rec` function falls back to expanding the node `24` (into node `79`); and after cycling twice through this expansion, it concludes that it has explored all the reachable subgraph of node `24`.

To fix this cycle, this PR modifies the `occur_rec` function to elide the expansion path when we have already visited the current constructor node (and recursive types are not allowed). In other words, it restricts the expansion alternative path to the earliest occurrence of a given constructor node in the visited path.