### PR TITLE
Fix native flexlink check on Cygwin

### DIFF
--- a/Changes
+++ b/Changes
@@ -105,9 +105,9 @@ _______________
   grouping all the linker flags at the end of the C compiler commandline
   (David Allsopp and Samuel Hym, review by Nicolás Ojeda Bär)
 
-- #12992: Check that flexlink can be executed only when building in a native
-  windows environment.
-  (Romain Beauxis, review by David Allsopp)
+- #12992, #13009: Check that flexlink can be executed only when building in a
+  native windows environment.
+  (Romain Beauxis, review by David Allsopp and Sébastien Hinderer)
 
 - #12996: Only link with -lgcc_eh when available.
   (Romain Beauxis, review by David Allsopp and Miod Vallat)

--- a/configure
+++ b/configure
@@ -14298,17 +14298,23 @@ rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
 
     # When building on Cygwin/MSYS2, flexlink may be a shell script which
     # then cannot be executed by ocamlc/ocamlopt. Having located flexlink,
-    # ensure it can be executed from a native Windows process.
-    case $build in #(
+    # ensure it can be executed from a native Windows process. The check
+    # is only necessary when cross-compiling.
+    if test x"$build" != x"$host"
+then :
+
+      case $build in #(
   *-pc-msys|*-pc-cygwin*) :
     flexlink_where="$(cmd /c "$flexlink" -where 2>/dev/null)"
-        if test -z "$flexlink_where"
+          if test -z "$flexlink_where"
 then :
   as_fn_error $? "$flexlink is not executable from a native Win32 process" "$LINENO" 5
 fi ;; #(
   *) :
      ;;
 esac
+
+fi
 
 fi
 

--- a/configure.ac
+++ b/configure.ac
@@ -982,13 +982,16 @@ AS_IF([test x"$supports_shared_libraries" != 'xfalse'], [
 
     # When building on Cygwin/MSYS2, flexlink may be a shell script which
     # then cannot be executed by ocamlc/ocamlopt. Having located flexlink,
-    # ensure it can be executed from a native Windows process.
-    AS_CASE([$build],
-      [*-pc-msys|*-pc-cygwin*],
-        [flexlink_where="$(cmd /c "$flexlink" -where 2>/dev/null)"
-        AS_IF([test -z "$flexlink_where"],
-          [AC_MSG_ERROR(m4_normalize([$flexlink is not executable from a native
-            Win32 process]))])])
+    # ensure it can be executed from a native Windows process. The check
+    # is only necessary when cross-compiling.
+    AS_IF([test x"$build" != x"$host"],[
+      AS_CASE([$build],
+        [*-pc-msys|*-pc-cygwin*],
+          [flexlink_where="$(cmd /c "$flexlink" -where 2>/dev/null)"
+          AS_IF([test -z "$flexlink_where"],
+            [AC_MSG_ERROR(m4_normalize([$flexlink is not executable from a
+            native Win32 process]))])])
+    ])
   ])
 
   OCAML_TEST_FLEXDLL_H([$flexdll_source_dir])


### PR DESCRIPTION
Follow-up to #12992, as @jmid reports that the Cygwin build has been broken when flexdll is not being bootstrapped.

flexlink needs to be executable from a native Windows process when:
- Cross-compiling
- Building on Cygwin or MSYS2

Beforehand, only the second check was being made, which had the effect of breaking the Cygwin build when using Cygwin's flexdll package.

Tested on both Cygwin and MSYS2.