### PR TITLE
caml_result: an exception monad in C for resource-safe interfaces

### DIFF
--- a/Changes
+++ b/Changes
@@ -39,6 +39,12 @@ _______________
 - #13003: new, more consistent names for array-creation C functions
   (Gabriel Scherer, review by Olivier Nicole)
 
+- #13013: introduce a `caml_result` type to supersede the
+  use of 'encoded exception values' in the FFI.
+  (Gabriel Scherer, review by Damien Doligez,
+   Guillaume Munch-Maccagnoni and Xavier Leroy,
+   suggested by Guillaume Munch-Maccagnoni)
+
 - #13086: Avoid spurious major GC slices.
   (Damien Doligez, report by Stephen Dolan, review by Gabriel Scherer
    and Stephen Dolan)
@@ -91,7 +97,7 @@ _______________
    and Nicolás Ojeda Bär)
 
 - #12869: Add List.take, List.drop, List.take_while and List.drop_while
-  (Kate Deplaix and Oscar Butler-Aldridge review by Nicolás Ojeda Bär,
+  (Kate Deplaix and Oscar Butler-Aldridge, review by Nicolás Ojeda Bär,
    Craig Ferguson and Gabriel Scherer)
 
 - #12885: move Dynarray to an unboxed representation

--- a/runtime/callback.c
+++ b/runtime/callback.c
@@ -74,15 +74,6 @@ Caml_inline void restore_stack_parent(caml_domain_state* domain_state,
   }
 }
 
-/* support code for caml_result */
-CAMLexport value caml_run_result(caml_result res)
-{
-  if (res.is_exception)
-    caml_raise(res.data);
-  else
-    return res.data;
-}
-
 #ifndef NATIVE_CODE
 
 /* Bytecode callbacks */

--- a/runtime/callback.c
+++ b/runtime/callback.c
@@ -308,6 +308,33 @@ CAMLexport value caml_callbackN_exn(value closure, int narg, value args[]) {
 
 #endif
 
+/* Result-returning variants of the above */
+
+CAMLexport caml_result caml_callbackN_result(
+  value closure, int narg, value args[])
+{
+  return Result_encoded(caml_callbackN_exn(closure, narg, args));
+}
+
+CAMLexport caml_result caml_callback_result(
+  value closure, value arg)
+{
+  return Result_encoded(caml_callback_exn(closure, arg));
+}
+
+CAMLexport caml_result caml_callback2_result(
+  value closure, value arg1, value arg2)
+{
+  return Result_encoded(caml_callback2_exn(closure, arg1, arg2));
+}
+
+CAMLexport caml_result caml_callback3_result(
+  value closure, value arg1, value arg2, value arg3)
+{
+  return Result_encoded(caml_callback3_exn(closure, arg1, arg2, arg3));
+}
+
+
 /* Exception-propagating variants of the above */
 
 CAMLexport value caml_callback (value closure, value arg)

--- a/runtime/callback.c
+++ b/runtime/callback.c
@@ -309,25 +309,25 @@ Caml_inline caml_result Result_encoded(value encoded)
     return Result_value(encoded);
 }
 
-CAMLexport caml_result caml_callbackN_result(
+CAMLexport caml_result caml_callbackN_res(
   value closure, int narg, value args[])
 {
   return Result_encoded(caml_callbackN_exn(closure, narg, args));
 }
 
-CAMLexport caml_result caml_callback_result(
+CAMLexport caml_result caml_callback_res(
   value closure, value arg)
 {
   return Result_encoded(caml_callback_exn(closure, arg));
 }
 
-CAMLexport caml_result caml_callback2_result(
+CAMLexport caml_result caml_callback2_res(
   value closure, value arg1, value arg2)
 {
   return Result_encoded(caml_callback2_exn(closure, arg1, arg2));
 }
 
-CAMLexport caml_result caml_callback3_result(
+CAMLexport caml_result caml_callback3_res(
   value closure, value arg1, value arg2, value arg3)
 {
   return Result_encoded(caml_callback3_exn(closure, arg1, arg2, arg3));

--- a/runtime/callback.c
+++ b/runtime/callback.c
@@ -337,25 +337,31 @@ CAMLexport caml_result caml_callback3_result(
 
 /* Exception-propagating variants of the above */
 
+static value encoded_value_or_raise(value res)
+{
+  if (Is_exception_result(res)) caml_raise(Extract_exception(res));
+  return res;
+}
+
 CAMLexport value caml_callback (value closure, value arg)
 {
-  return caml_raise_if_exception(caml_callback_exn(closure, arg));
+  return encoded_value_or_raise(caml_callback_exn(closure, arg));
 }
 
 CAMLexport value caml_callback2 (value closure, value arg1, value arg2)
 {
-  return caml_raise_if_exception(caml_callback2_exn(closure, arg1, arg2));
+  return encoded_value_or_raise(caml_callback2_exn(closure, arg1, arg2));
 }
 
 CAMLexport value caml_callback3 (value closure, value arg1, value arg2,
                                  value arg3)
 {
-  return caml_raise_if_exception(caml_callback3_exn(closure, arg1, arg2, arg3));
+  return encoded_value_or_raise(caml_callback3_exn(closure, arg1, arg2, arg3));
 }
 
 CAMLexport value caml_callbackN (value closure, int narg, value args[])
 {
-  return caml_raise_if_exception(caml_callbackN_exn(closure, narg, args));
+  return encoded_value_or_raise(caml_callbackN_exn(closure, narg, args));
 }
 
 /* Naming of OCaml values */

--- a/runtime/callback.c
+++ b/runtime/callback.c
@@ -74,6 +74,14 @@ Caml_inline void restore_stack_parent(caml_domain_state* domain_state,
   }
 }
 
+/* support code for caml_result */
+CAMLexport value caml_run_result(caml_result res)
+{
+  if (res.is_exception)
+    caml_raise(res.data);
+  else
+    return res.data;
+}
 
 #ifndef NATIVE_CODE
 

--- a/runtime/callback.c
+++ b/runtime/callback.c
@@ -301,6 +301,14 @@ CAMLexport value caml_callbackN_exn(value closure, int narg, value args[]) {
 
 /* Result-returning variants of the above */
 
+Caml_inline caml_result Result_encoded(value encoded)
+{
+  if (Is_exception_result(encoded))
+    return Result_exception(Extract_exception(encoded));
+  else
+    return Result_value(encoded);
+}
+
 CAMLexport caml_result caml_callbackN_result(
   value closure, int narg, value args[])
 {

--- a/runtime/caml/callback.h
+++ b/runtime/caml/callback.h
@@ -35,9 +35,22 @@ CAMLextern value caml_callback3 (value closure, value arg1, value arg2,
                                  value arg3);
 CAMLextern value caml_callbackN (value closure, int narg, value args[]);
 
-/* If the callback raises an exception, the functions
-   caml_callback{,2,3,N}_exn do not propagate it, they return the exception
-   as an 'encoded exceptional result value' (see mlvalues.h) */
+/* The functions caml_callback{,2,3,N}_result return
+   a structure containing either the value or an exception,
+   they do not propagate exceptions directly to their caller. */
+CAMLextern caml_result caml_callback_result (value closure, value arg);
+CAMLextern caml_result caml_callback2_result (
+  value closure, value arg1, value arg2);
+CAMLextern caml_result caml_callback3_result (
+  value closure, value arg1, value arg2, value arg3);
+CAMLextern caml_result caml_callbackN_result (
+  value closure, int narg, value args[]);
+
+/* These functions are similar to the caml_callback*_result variants
+   above, but they return an 'encoded exceptional value' (see mlvalues.h)
+   which represents either a value or an exception. This interface is unsafe
+   and it is easy to make mistakes due to the lack of type information,
+   we strongly recommend the *_result variants instead. */
 CAMLextern value caml_callback_exn (value closure, value arg);
 CAMLextern value caml_callback2_exn (value closure, value arg1, value arg2);
 CAMLextern value caml_callback3_exn (value closure,

--- a/runtime/caml/callback.h
+++ b/runtime/caml/callback.h
@@ -35,22 +35,22 @@ CAMLextern value caml_callback3 (value closure, value arg1, value arg2,
                                  value arg3);
 CAMLextern value caml_callbackN (value closure, int narg, value args[]);
 
-/* The functions caml_callback{,2,3,N}_result return
-   a structure containing either the value or an exception,
+/* The functions caml_callback{,2,3,N}_res return
+   a caml_result structure containing either the value or an exception,
    they do not propagate exceptions directly to their caller. */
-CAMLextern caml_result caml_callback_result (value closure, value arg);
-CAMLextern caml_result caml_callback2_result (
+CAMLextern caml_result caml_callback_res (value closure, value arg);
+CAMLextern caml_result caml_callback2_res (
   value closure, value arg1, value arg2);
-CAMLextern caml_result caml_callback3_result (
+CAMLextern caml_result caml_callback3_res (
   value closure, value arg1, value arg2, value arg3);
-CAMLextern caml_result caml_callbackN_result (
+CAMLextern caml_result caml_callbackN_res (
   value closure, int narg, value args[]);
 
-/* These functions are similar to the caml_callback*_result variants
+/* These functions are similar to the caml_callback*_res variants
    above, but they return an 'encoded exceptional value' (see mlvalues.h)
    which represents either a value or an exception. This interface is unsafe
    and it is easy to make mistakes due to the lack of type information,
-   we strongly recommend the *_result variants instead. */
+   we strongly recommend the *_res variants instead. */
 CAMLextern value caml_callback_exn (value closure, value arg);
 CAMLextern value caml_callback2_exn (value closure, value arg1, value arg2);
 CAMLextern value caml_callback3_exn (value closure,

--- a/runtime/caml/fail.h
+++ b/runtime/caml/fail.h
@@ -116,7 +116,7 @@ CAMLnoret CAMLextern void caml_raise_sys_blocked_io (void);
 
 /* Returns the value of a [caml_result] or raises the exception.
    This function replaced [caml_raise_if_exception] in 5.3. */
-Caml_inline value caml_get_value_or_raise (caml_result result)
+Caml_inline value caml_get_value_or_raise (struct caml_result_private result)
 {
   if (result.is_exception)
     caml_raise(result.data);

--- a/runtime/caml/fail.h
+++ b/runtime/caml/fail.h
@@ -114,6 +114,19 @@ CAMLnoret CAMLextern void caml_array_bound_error (void);
 
 CAMLnoret CAMLextern void caml_raise_sys_blocked_io (void);
 
+
+#ifdef CAML_INTERNALS
+/* Returns the value of a [caml_result] or raises the exception.
+   This function replaced [caml_raise_if_exception] in 5.3. */
+Caml_inline value caml_get_value_or_raise (caml_result result)
+{
+  if (result.is_exception)
+    caml_raise(result.data);
+  else
+    return result.data;
+}
+#endif
+
 #ifdef __cplusplus
 }
 #endif

--- a/runtime/caml/fail.h
+++ b/runtime/caml/fail.h
@@ -73,8 +73,6 @@ struct caml_exception_context {
 
 int caml_is_special_exception(value exn);
 
-CAMLextern value caml_raise_if_exception(value res);
-
 #endif /* CAML_INTERNALS */
 
 #ifdef __cplusplus

--- a/runtime/caml/fail.h
+++ b/runtime/caml/fail.h
@@ -114,8 +114,6 @@ CAMLnoret CAMLextern void caml_array_bound_error (void);
 
 CAMLnoret CAMLextern void caml_raise_sys_blocked_io (void);
 
-
-#ifdef CAML_INTERNALS
 /* Returns the value of a [caml_result] or raises the exception.
    This function replaced [caml_raise_if_exception] in 5.3. */
 Caml_inline value caml_get_value_or_raise (caml_result result)
@@ -125,7 +123,6 @@ Caml_inline value caml_get_value_or_raise (caml_result result)
   else
     return result.data;
 }
-#endif
 
 #ifdef __cplusplus
 }

--- a/runtime/caml/finalise.h
+++ b/runtime/caml/finalise.h
@@ -71,7 +71,7 @@ void caml_final_merge_finalisable (struct finalisable *source,
                                    struct finalisable *target);
 int caml_final_update_first (caml_domain_state* d);
 int caml_final_update_last (caml_domain_state* d);
-value caml_final_do_calls_exn (void);
+caml_result caml_final_do_calls_result (void);
 void caml_final_do_roots (
   scanning_action f, scanning_action_flags fflags, void* fdata,
   caml_domain_state* domain, int do_val);

--- a/runtime/caml/finalise.h
+++ b/runtime/caml/finalise.h
@@ -71,7 +71,7 @@ void caml_final_merge_finalisable (struct finalisable *source,
                                    struct finalisable *target);
 int caml_final_update_first (caml_domain_state* d);
 int caml_final_update_last (caml_domain_state* d);
-caml_result caml_final_do_calls_result (void);
+caml_result caml_final_do_calls_res (void);
 void caml_final_do_roots (
   scanning_action f, scanning_action_flags fflags, void* fdata,
   caml_domain_state* domain, int do_val);

--- a/runtime/caml/memory.h
+++ b/runtime/caml/memory.h
@@ -405,6 +405,10 @@ struct caml__roots_block {
     x[caml__i_##x] = Val_unit; \
   }
 
+#define CAMLlocalresult(res) \
+  res.data = Val_unit; \
+  CAMLxparam1 (res.data);
+
 #define CAMLdrop do{              \
   *caml_local_roots_ptr = caml__frame; \
 }while (0)

--- a/runtime/caml/memory.h
+++ b/runtime/caml/memory.h
@@ -377,6 +377,17 @@ struct caml__roots_block {
     0) \
   CAMLunused_end
 
+#define CAMLxparamresult(x) \
+  struct caml__roots_block caml__roots_##x; \
+  CAMLunused_start int caml__dummy_##x = ( \
+    (caml__roots_##x.next = *caml_local_roots_ptr), \
+    (*caml_local_roots_ptr = &caml__roots_##x), \
+    (caml__roots_##x.nitems = 1), \
+    (caml__roots_##x.ntables = 1), \
+    (caml__roots_##x.tables [0] = &(x.data)), \
+    0) \
+   CAMLunused_end
+
 #define CAMLlocal1(x) \
   value x = Val_unit; \
   CAMLxparam1 (x)
@@ -406,8 +417,8 @@ struct caml__roots_block {
   }
 
 #define CAMLlocalresult(res) \
-  res.data = Val_unit; \
-  CAMLxparam1 (res.data);
+  caml_result res = Result_unit; \
+  CAMLxparamresult (res)
 
 #define CAMLdrop do{              \
   *caml_local_roots_ptr = caml__frame; \

--- a/runtime/caml/memprof.h
+++ b/runtime/caml/memprof.h
@@ -104,7 +104,7 @@ extern void caml_memprof_set_trigger(caml_domain_state *state);
 /* Run any pending callbacks for the current domain (or adopted from a
  * terminated domain). */
 
-extern value caml_memprof_run_callbacks_exn(void);
+extern caml_result caml_memprof_run_callbacks_result(void);
 
 
 /*** Multi-domain support. ***/

--- a/runtime/caml/memprof.h
+++ b/runtime/caml/memprof.h
@@ -104,7 +104,7 @@ extern void caml_memprof_set_trigger(caml_domain_state *state);
 /* Run any pending callbacks for the current domain (or adopted from a
  * terminated domain). */
 
-extern caml_result caml_memprof_run_callbacks_result(void);
+extern caml_result caml_memprof_run_callbacks_res(void);
 
 
 /*** Multi-domain support. ***/

--- a/runtime/caml/mlvalues.h
+++ b/runtime/caml/mlvalues.h
@@ -508,21 +508,6 @@ CAMLextern value caml_set_oo_id(value obj);
 #define Is_exception_result(v) (((v) & 3) == 2)
 #define Extract_exception(v) ((v) & ~3)
 
-Caml_inline value Encoded_result(caml_result res) {
-  if (res.is_exception)
-    return Make_exception_result(res.data);
-  else
-    return res.data;
-}
-
-Caml_inline caml_result Result_encoded(value encoded)
-{
-  if (Is_exception_result(encoded))
-    return Result_exception(Extract_exception(encoded));
-  else
-    return Result_value(encoded);
-}
-
 #ifdef __cplusplus
 }
 #endif

--- a/runtime/caml/mlvalues.h
+++ b/runtime/caml/mlvalues.h
@@ -105,6 +105,8 @@ typedef struct {
 #define Result_value(v) (caml_result){ .is_exception = 0, .data = v }
 #define Result_exception(exn) (caml_result){ .is_exception = 1, .data = exn }
 
+#define Result_unit Result_value(Val_unit)
+
 /* returns the value or raises the exception. */
 CAMLextern value caml_run_result(caml_result res);
 

--- a/runtime/caml/mlvalues.h
+++ b/runtime/caml/mlvalues.h
@@ -110,32 +110,6 @@ typedef struct {
 /* returns the value or raises the exception. */
 CAMLextern value caml_run_result(caml_result res);
 
-/* Before caml_result was available, we used an unsafe encoding of it
-   into the 'value' type, where encoded exceptions have their second
-   bit set. These encoded exceptions are invalid values and must not
-   be seen by the garbage collector. This is unsafe, and the
-   C type-checker does not help. We strongly recommend using the
-   caml_result type above instead. It is GC-safe and more
-   type-safe. */
-
-#define Make_exception_result(v) ((v) | 2)
-#define Is_exception_result(v) (((v) & 3) == 2)
-#define Extract_exception(v) ((v) & ~3)
-
-Caml_inline value Encoded_result(caml_result res) {
-  if (res.is_exception)
-    return Make_exception_result(res.data);
-  else
-    return res.data;
-}
-
-Caml_inline caml_result Result_encoded(value encoded)
-{
-  if (Is_exception_result(encoded))
-    return Result_exception(Extract_exception(encoded));
-  else
-    return Result_value(encoded);
-}
 
 /* Structure of the header:
 
@@ -516,6 +490,36 @@ CAMLextern value caml_set_oo_id(value obj);
 
 #define Caml_out_of_heap_header(wosize, tag)                           \
         Caml_out_of_heap_header_with_reserved(wosize, tag, 0)
+
+
+/* Deprecated/discouraged suppport for unsafe encoded exceptions.
+
+   Before caml_result was available, we used an unsafe encoding of it
+   into the 'value' type, where encoded exceptions have their second
+   bit set. These encoded exceptions are invalid values and must not
+   be seen by the garbage collector. This is unsafe, and the
+   C type-checker does not help. We strongly recommend using the
+   caml_result type above instead. It is GC-safe and more
+   type-safe. */
+
+#define Make_exception_result(v) ((v) | 2)
+#define Is_exception_result(v) (((v) & 3) == 2)
+#define Extract_exception(v) ((v) & ~3)
+
+Caml_inline value Encoded_result(caml_result res) {
+  if (res.is_exception)
+    return Make_exception_result(res.data);
+  else
+    return res.data;
+}
+
+Caml_inline caml_result Result_encoded(value encoded)
+{
+  if (Is_exception_result(encoded))
+    return Result_exception(Extract_exception(encoded));
+  else
+    return Result_value(encoded);
+}
 
 #ifdef __cplusplus
 }

--- a/runtime/caml/mlvalues.h
+++ b/runtime/caml/mlvalues.h
@@ -103,7 +103,7 @@ typedef opcode_t * code_t;
    from fail.h.
 */
 typedef struct {
-  _Bool is_exception;
+  int is_exception;
   value data;
 } caml_result;
 

--- a/runtime/caml/mlvalues.h
+++ b/runtime/caml/mlvalues.h
@@ -87,28 +87,35 @@ typedef opcode_t * code_t;
 /* A 'result' type for OCaml computations. */
 
 /* The [caml_result] type represents the result of computing an OCaml
-   term -- either a value or an exception:
-   - if [is_exception] is false,
-     the computation resulted in a value stored in [data]
-   - if [is_exception] is true,
-     the computation resulted in an exception stored in [data]
+   term -- either a value or an exception.
 
    This plays a similar role to the [('a, exn) result] type in OCaml,
    with a different representation. Returning this type, instead of
    raising exceptions directly, lets the caller implement proper
    cleanup and propagate the exception themselves.
-
-   To extract the value or raise the exception, use
-     value caml_get_value_or_raise(caml_result)
-   from fail.h.
 */
-typedef struct {
+typedef struct caml_result_private caml_result;
+
+/* This structure should be considered internal, its definition may
+   change in the future. Its public interface is formed of
+   - Result_value, Result_exception
+   - caml_result_is_exception
+   - caml_get_value_or_raise (in fail.h)
+*/
+struct caml_result_private {
   int is_exception;
   value data;
-} caml_result;
+};
 
-#define Result_value(v) (caml_result){ .is_exception = 0, .data = v }
-#define Result_exception(exn) (caml_result){ .is_exception = 1, .data = exn }
+#define Result_value(v) \
+  (struct caml_result_private){ .is_exception = 0, .data = v }
+#define Result_exception(exn) \
+  (struct caml_result_private){ .is_exception = 1, .data = exn }
+
+Caml_inline int caml_result_is_exception(struct caml_result_private result)
+{
+  return result.is_exception;
+}
 
 #define Result_unit Result_value(Val_unit)
 

--- a/runtime/caml/mlvalues.h
+++ b/runtime/caml/mlvalues.h
@@ -492,7 +492,7 @@ CAMLextern value caml_set_oo_id(value obj);
         Caml_out_of_heap_header_with_reserved(wosize, tag, 0)
 
 
-/* Deprecated/discouraged suppport for unsafe encoded exceptions.
+/* Obsolete -- suppport for unsafe encoded exceptions.
 
    Before caml_result was available, we used an unsafe encoding of it
    into the 'value' type, where encoded exceptions have their second

--- a/runtime/caml/mlvalues.h
+++ b/runtime/caml/mlvalues.h
@@ -96,7 +96,12 @@ typedef opcode_t * code_t;
    This plays a similar role to the [('a, exn) result] type in OCaml,
    with a different representation. Returning this type, instead of
    raising exceptions directly, lets the caller implement proper
-   cleanup and propagate the exception themselves. */
+   cleanup and propagate the exception themselves.
+
+   To extract the value or raise the exception, use
+     value caml_get_value_or_raise(caml_result)
+   from fail.h.
+*/
 typedef struct {
   _Bool is_exception;
   value data;
@@ -106,9 +111,6 @@ typedef struct {
 #define Result_exception(exn) (caml_result){ .is_exception = 1, .data = exn }
 
 #define Result_unit Result_value(Val_unit)
-
-/* returns the value or raises the exception. */
-CAMLextern value caml_run_result(caml_result res);
 
 
 /* Structure of the header:

--- a/runtime/caml/signals.h
+++ b/runtime/caml/signals.h
@@ -46,6 +46,33 @@ CAMLextern caml_result caml_process_pending_actions_result (void);
    kept around for compatibility. */
 CAMLextern value caml_process_pending_actions_exn (void);
 
+#ifdef CAML_INTERNALS
+value caml_process_pending_actions_with_root (value extra_root); // raises
+/* This is identical to [caml_process_pending_actions], except that it
+   registers its argument as a root and eventually returns it. This is
+   useful to safely process pending actions before returning from
+   functions that manipulate a 'value' without proper rooting.
+
+   This would be incorrect:
+     {
+       value ret;
+       ...
+       caml_process_pending_actions(); // this may call a GC
+       return ret; // 'ret' was not rooted and may have been moved
+     }
+
+   This is correct:
+     {
+       value ret;
+       ...
+       ret = caml_process_pending_actions_with_root(ret);
+       return ret;
+     }
+*/
+
+caml_result caml_process_pending_actions_with_root_result (value extra_root);
+#endif
+
 CAMLextern int caml_check_pending_actions (void);
 /* Returns 1 if there are pending actions, 0 otherwise. */
 
@@ -74,8 +101,6 @@ CAMLextern void caml_record_signal(int signal_number);
 CAMLextern caml_result caml_process_pending_signals_result(void);
 CAMLextern void caml_set_action_pending(caml_domain_state *);
 caml_result caml_do_pending_actions_result(void);
-value caml_process_pending_actions_with_root (value extra_root); // raises
-caml_result caml_process_pending_actions_with_root_result (value extra_root);
 
 void caml_init_signal_handling(void);
 void caml_init_signals(void);

--- a/runtime/caml/signals.h
+++ b/runtime/caml/signals.h
@@ -39,10 +39,10 @@ CAMLextern void caml_process_pending_actions (void);
 
 /* Same as [caml_process_pending_actions], but returns the reified
    result instead of raising exceptions directly (if any). */
-CAMLextern caml_result caml_process_pending_actions_result (void);
+CAMLextern caml_result caml_process_pending_actions_res (void);
 
 /* Returns [Val_unit] or an encoded exception.
-   Superseded by the safer [_result] variant above,
+   Superseded by the safer [_res] variant above,
    kept around for compatibility. */
 CAMLextern value caml_process_pending_actions_exn (void);
 
@@ -70,7 +70,7 @@ value caml_process_pending_actions_with_root (value extra_root); // raises
      }
 */
 
-caml_result caml_process_pending_actions_with_root_result (value extra_root);
+caml_result caml_process_pending_actions_with_root_res (value extra_root);
 #endif
 
 CAMLextern int caml_check_pending_actions (void);
@@ -96,11 +96,11 @@ void caml_request_major_slice (int global);
 void caml_request_minor_gc (void);
 CAMLextern int caml_convert_signal_number (int);
 CAMLextern int caml_rev_convert_signal_number (int);
-caml_result caml_execute_signal_result(int signal_number);
+caml_result caml_execute_signal_res(int signal_number);
 CAMLextern void caml_record_signal(int signal_number);
-CAMLextern caml_result caml_process_pending_signals_result(void);
+CAMLextern caml_result caml_process_pending_signals_res(void);
 CAMLextern void caml_set_action_pending(caml_domain_state *);
-caml_result caml_do_pending_actions_result(void);
+caml_result caml_do_pending_actions_res(void);
 
 void caml_init_signal_handling(void);
 void caml_init_signals(void);

--- a/runtime/caml/signals.h
+++ b/runtime/caml/signals.h
@@ -37,10 +37,14 @@ CAMLextern void caml_process_pending_actions (void);
    finalisers, and Memprof callbacks. Assumes that the runtime lock is
    held. Can raise exceptions asynchronously into OCaml code. */
 
+/* Same as [caml_process_pending_actions], but returns the reified
+   result instead of raising exceptions directly (if any). */
+CAMLextern caml_result caml_process_pending_actions_result (void);
+
+/* Returns [Val_unit] or an encoded exception.
+   Superseded by the safer [_result] variant above,
+   kept around for compatibility. */
 CAMLextern value caml_process_pending_actions_exn (void);
-/* Same as [caml_process_pending_actions], but returns the encoded
-   exception (if any) instead of raising it directly (otherwise
-   returns [Val_unit]). */
 
 CAMLextern int caml_check_pending_actions (void);
 /* Returns 1 if there are pending actions, 0 otherwise. */
@@ -65,13 +69,13 @@ void caml_request_major_slice (int global);
 void caml_request_minor_gc (void);
 CAMLextern int caml_convert_signal_number (int);
 CAMLextern int caml_rev_convert_signal_number (int);
-value caml_execute_signal_exn(int signal_number);
+caml_result caml_execute_signal_result(int signal_number);
 CAMLextern void caml_record_signal(int signal_number);
-CAMLextern value caml_process_pending_signals_exn(void);
+CAMLextern caml_result caml_process_pending_signals_result(void);
 CAMLextern void caml_set_action_pending(caml_domain_state *);
-value caml_do_pending_actions_exn(void);
+caml_result caml_do_pending_actions_result(void);
 value caml_process_pending_actions_with_root (value extra_root); // raises
-value caml_process_pending_actions_with_root_exn (value extra_root);
+caml_result caml_process_pending_actions_with_root_result (value extra_root);
 
 void caml_init_signal_handling(void);
 void caml_init_signals(void);

--- a/runtime/compare.c
+++ b/runtime/compare.c
@@ -99,16 +99,16 @@ static intnat compare_val(value v1, value v2, int total)
 static void run_pending_actions(struct compare_stack* stk,
                                 struct compare_item* sp)
 {
-  value exn;
+  caml_result result;
   value* roots_start = (value*)(stk->stack);
   size_t roots_length =
     (sp - stk->stack)
     * sizeof(struct compare_item) / sizeof(value);
   Begin_roots_block(roots_start, roots_length);
-  exn = caml_do_pending_actions_exn();
+  result = caml_do_pending_actions_result();
   End_roots();
-  if (Is_exception_result(exn)) {
-    exn = Extract_exception(exn);
+  if (result.is_exception) {
+    value exn = result.data;
     compare_free_stack(stk);
     caml_raise(exn);
   }

--- a/runtime/compare.c
+++ b/runtime/compare.c
@@ -107,10 +107,9 @@ static void run_pending_actions(struct compare_stack* stk,
   Begin_roots_block(roots_start, roots_length);
   result = caml_do_pending_actions_result();
   End_roots();
-  if (result.is_exception) {
-    value exn = result.data;
+  if (caml_result_is_exception(result)) {
     compare_free_stack(stk);
-    caml_raise(exn);
+    (void) caml_get_value_or_raise(result);
   }
 }
 

--- a/runtime/compare.c
+++ b/runtime/compare.c
@@ -105,11 +105,11 @@ static void run_pending_actions(struct compare_stack* stk,
     (sp - stk->stack)
     * sizeof(struct compare_item) / sizeof(value);
   Begin_roots_block(roots_start, roots_length);
-  result = caml_do_pending_actions_result();
+  result = caml_do_pending_actions_res();
   End_roots();
   if (caml_result_is_exception(result)) {
     compare_free_stack(stk);
-    (void) caml_get_value_or_raise(result);
+    (void) caml_get_value_or_raise(result);;
   }
 }
 

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -1122,18 +1122,15 @@ CAMLexport _Atomic caml_timing_hook caml_domain_terminated_hook =
 
 static void domain_terminate(void);
 
-static value make_finished(value res_or_exn)
+static value make_finished(caml_result result)
 {
   CAMLparam0();
   CAMLlocal1(res);
-  if (Is_exception_result(res_or_exn)) {
-    res = Extract_exception(res_or_exn);
-    /* [Error res] */
-    res = caml_alloc_1(1, res);
-  } else {
-    /* [Ok res_of_exn] */
-    res = caml_alloc_1(0, res_or_exn);
-  }
+  res = caml_alloc_1(
+    (result.is_exception ?
+     1 /* Error */ :
+     0 /* Ok */),
+    result.data);
   /* [Finished res] */
   res = caml_alloc_1(0, res);
   CAMLreturn(res);
@@ -1204,8 +1201,8 @@ static void* domain_thread_func(void* v)
        see the [note about callbacks and GC] in callback.c */
     value unrooted_callback = ml_values->callback;
     caml_modify_generational_global_root(&ml_values->callback, Val_unit);
-    value res_or_exn = caml_callback_exn(unrooted_callback, Val_unit);
-    value res = make_finished(res_or_exn);
+    value res =
+      make_finished(caml_callback_result(unrooted_callback, Val_unit));
     sync_result(ml_values->term_sync, res);
 
     sync_mutex mut = Mutex_val(*Term_mutex(ml_values->term_sync));

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -1127,7 +1127,7 @@ static value make_finished(caml_result result)
   CAMLparam0();
   CAMLlocal1(res);
   res = caml_alloc_1(
-    (result.is_exception ?
+    (caml_result_is_exception(result) ?
      1 /* Error */ :
      0 /* Ok */),
     result.data);

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -1202,7 +1202,7 @@ static void* domain_thread_func(void* v)
     value unrooted_callback = ml_values->callback;
     caml_modify_generational_global_root(&ml_values->callback, Val_unit);
     value res =
-      make_finished(caml_callback_result(unrooted_callback, Val_unit));
+      make_finished(caml_callback_res(unrooted_callback, Val_unit));
     sync_result(ml_values->term_sync, res);
 
     sync_mutex mut = Mutex_val(*Term_mutex(ml_values->term_sync));

--- a/runtime/fail_byt.c
+++ b/runtime/fail_byt.c
@@ -38,10 +38,11 @@ CAMLexport void caml_raise(value v)
 
   caml_channel_cleanup_on_raise();
 
-  // avoid calling caml_raise recursively
-  v = caml_process_pending_actions_with_root_exn(v);
-  if (Is_exception_result(v))
-    v = Extract_exception(v);
+  caml_result result = caml_process_pending_actions_with_root_result(v);
+  /* If the result is a value, we want to assign it to [v].
+     If the result is an exception, we want to raise it instead of [v].
+     The line below does both these things at once. */
+  v = result.data;
 
   if (Caml_state->external_raise == NULL) {
     caml_terminate_signals();

--- a/runtime/fail_byt.c
+++ b/runtime/fail_byt.c
@@ -207,12 +207,6 @@ CAMLexport void caml_raise_sys_blocked_io(void)
   caml_raise_constant(Field(caml_global_data, SYS_BLOCKED_IO));
 }
 
-CAMLexport value caml_raise_if_exception(value res)
-{
-  if (Is_exception_result(res)) caml_raise(Extract_exception(res));
-  return res;
-}
-
 int caml_is_special_exception(value exn) {
   /* this function is only used in caml_format_exception to produce
      a more readable textual representation of some exceptions. It is

--- a/runtime/fail_byt.c
+++ b/runtime/fail_byt.c
@@ -38,7 +38,7 @@ CAMLexport void caml_raise(value v)
 
   caml_channel_cleanup_on_raise();
 
-  caml_result result = caml_process_pending_actions_with_root_result(v);
+  caml_result result = caml_process_pending_actions_with_root_res(v);
   /* If the result is a value, we want to assign it to [v].
      If the result is an exception, we want to raise it instead of [v].
      The line below does both these things at once. */

--- a/runtime/fail_nat.c
+++ b/runtime/fail_nat.c
@@ -64,10 +64,11 @@ void caml_raise(value v)
 
   caml_channel_cleanup_on_raise();
 
-  // avoid calling caml_raise recursively
-  v = caml_process_pending_actions_with_root_exn(v);
-  if (Is_exception_result(v))
-    v = Extract_exception(v);
+  caml_result result = caml_process_pending_actions_with_root_result(v);
+  /* If the result is a value, we want to assign it to [v].
+     If the result is an exception, we want to raise it instead of [v].
+     The line below does both these things at once. */
+  v = result.data;
 
   exception_pointer = (char*)Caml_state->c_stack;
 

--- a/runtime/fail_nat.c
+++ b/runtime/fail_nat.c
@@ -189,12 +189,6 @@ void caml_raise_sys_blocked_io(void)
   caml_raise_constant((value) caml_exn_Sys_blocked_io);
 }
 
-CAMLexport value caml_raise_if_exception(value res)
-{
-  if (Is_exception_result(res)) caml_raise(Extract_exception(res));
-  return res;
-}
-
 /* We use a pre-allocated exception because we can't
    do a GC before the exception is raised (lack of stack descriptors
    for the ccall to [caml_array_bound_error]).  */

--- a/runtime/fail_nat.c
+++ b/runtime/fail_nat.c
@@ -64,7 +64,7 @@ void caml_raise(value v)
 
   caml_channel_cleanup_on_raise();
 
-  caml_result result = caml_process_pending_actions_with_root_result(v);
+  caml_result result = caml_process_pending_actions_with_root_res(v);
   /* If the result is a value, we want to assign it to [v].
      If the result is an exception, we want to raise it instead of [v].
      The line below does both these things at once. */

--- a/runtime/finalise.c
+++ b/runtime/finalise.c
@@ -166,7 +166,7 @@ caml_result caml_final_do_calls_result(void)
       fi->running_finalisation_function = 1;
       res = caml_callback_result (f.fun, f.val + f.offset);
       fi->running_finalisation_function = 0;
-      if (res.is_exception) return res;
+      if (caml_result_is_exception(res)) return res;
     }
     caml_gc_message (0x80, "Done calling finalisation functions.\n");
     call_timing_hook(&caml_finalise_end_hook);

--- a/runtime/finalise.c
+++ b/runtime/finalise.c
@@ -142,7 +142,7 @@ int caml_final_update_last (caml_domain_state* d)
 /* Call the finalisation functions for the finalising set.
    Note that this function must be reentrant.
 */
-caml_result caml_final_do_calls_result(void)
+caml_result caml_final_do_calls_res(void)
 {
   struct final f;
   caml_result res;
@@ -164,7 +164,7 @@ caml_result caml_final_do_calls_result(void)
       --fi->todo_head->size;
       f = fi->todo_head->item[fi->todo_head->size];
       fi->running_finalisation_function = 1;
-      res = caml_callback_result (f.fun, f.val + f.offset);
+      res = caml_callback_res (f.fun, f.val + f.offset);
       fi->running_finalisation_function = 0;
       if (caml_result_is_exception(res)) return res;
     }

--- a/runtime/finalise.c
+++ b/runtime/finalise.c
@@ -142,13 +142,13 @@ int caml_final_update_last (caml_domain_state* d)
 /* Call the finalisation functions for the finalising set.
    Note that this function must be reentrant.
 */
-value caml_final_do_calls_exn(void)
+caml_result caml_final_do_calls_result(void)
 {
   struct final f;
-  value res;
+  caml_result res;
   struct caml_final_info *fi = Caml_state->final_info;
 
-  if (fi->running_finalisation_function) return Val_unit;
+  if (fi->running_finalisation_function) return Result_unit;
   if (fi->todo_head != NULL) {
     call_timing_hook(&caml_finalise_begin_hook);
     caml_gc_message (0x80, "Calling finalisation functions.\n");
@@ -164,14 +164,14 @@ value caml_final_do_calls_exn(void)
       --fi->todo_head->size;
       f = fi->todo_head->item[fi->todo_head->size];
       fi->running_finalisation_function = 1;
-      res = caml_callback_exn (f.fun, f.val + f.offset);
+      res = caml_callback_result (f.fun, f.val + f.offset);
       fi->running_finalisation_function = 0;
-      if (Is_exception_result(res)) return res;
+      if (res.is_exception) return res;
     }
     caml_gc_message (0x80, "Done calling finalisation functions.\n");
     call_timing_hook(&caml_finalise_end_hook);
   }
-  return Val_unit;
+  return Result_unit;
 }
 
 /* Call a scanning_action [f] on [x]. */

--- a/runtime/gc_ctrl.c
+++ b/runtime/gc_ctrl.c
@@ -263,7 +263,7 @@ static caml_result gc_full_major_result(void)
   for (i = 0; i < 3; i++) {
     caml_finish_major_cycle(0);
     caml_result res = caml_process_pending_actions_result();
-    if (res.is_exception) return res;
+    if (caml_result_is_exception(res)) return res;
   }
   ++ Caml_state->stat_forced_major_collections;
   CAML_EV_END(EV_EXPLICIT_GC_FULL_MAJOR);
@@ -299,7 +299,7 @@ CAMLprim value caml_gc_compaction(value v)
   for (i = 0; i < 3; i++) {
     caml_finish_major_cycle(i == 2);
     result = caml_process_pending_actions_result();
-    if (result.is_exception) break;
+    if (caml_result_is_exception(result)) break;
   }
   ++ Caml_state->stat_forced_major_collections;
   CAML_EV_END(EV_EXPLICIT_GC_COMPACT);
@@ -311,7 +311,7 @@ CAMLprim value caml_gc_stat(value v)
   caml_result result;
   CAML_EV_BEGIN(EV_EXPLICIT_GC_STAT);
   result = gc_full_major_result();
-  if (result.is_exception) goto out;
+  if (caml_result_is_exception(result)) goto out;
   result = Result_value(caml_gc_quick_stat(Val_unit));
  out:
   CAML_EV_END(EV_EXPLICIT_GC_STAT);

--- a/runtime/gc_ctrl.c
+++ b/runtime/gc_ctrl.c
@@ -232,7 +232,7 @@ CAMLprim value caml_gc_minor(value v)
   caml_minor_collection ();
   caml_result result = caml_process_pending_actions_result();
   CAML_EV_END(EV_EXPLICIT_GC_MINOR);
-  return caml_run_result(result);
+  return caml_get_value_or_raise(result);
 }
 
 static caml_result gc_major_result(int force_compaction)
@@ -250,7 +250,7 @@ CAMLprim value caml_gc_major(value v)
 {
   Caml_check_caml_state();
   CAMLassert (v == Val_unit);
-  return caml_run_result(gc_major_result(0));
+  return caml_get_value_or_raise(gc_major_result(0));
 }
 
 static caml_result gc_full_major_result(void)
@@ -275,7 +275,7 @@ CAMLprim value caml_gc_full_major(value v)
 {
   Caml_check_caml_state();
   CAMLassert (v == Val_unit);
-  return caml_run_result(gc_full_major_result());
+  return caml_get_value_or_raise(gc_full_major_result());
 }
 
 CAMLprim value caml_gc_major_slice (value v)
@@ -285,7 +285,7 @@ CAMLprim value caml_gc_major_slice (value v)
   caml_major_collection_slice(Long_val(v));
   caml_result result = caml_process_pending_actions_result();
   CAML_EV_END(EV_EXPLICIT_GC_MAJOR_SLICE);
-  return caml_run_result(result);
+  return caml_get_value_or_raise(result);
 }
 
 CAMLprim value caml_gc_compaction(value v)
@@ -304,7 +304,7 @@ CAMLprim value caml_gc_compaction(value v)
   }
   ++ Caml_state->stat_forced_major_collections;
   CAML_EV_END(EV_EXPLICIT_GC_COMPACT);
-  return caml_run_result(result);
+  return caml_get_value_or_raise(result);
 }
 
 CAMLprim value caml_gc_stat(value v)
@@ -316,7 +316,7 @@ CAMLprim value caml_gc_stat(value v)
   result = Result_value(caml_gc_quick_stat(Val_unit));
  out:
   CAML_EV_END(EV_EXPLICIT_GC_STAT);
-  return caml_run_result(result);
+  return caml_get_value_or_raise(result);
 }
 
 CAMLprim value caml_get_minor_free (value v)

--- a/runtime/gc_ctrl.c
+++ b/runtime/gc_ctrl.c
@@ -230,52 +230,52 @@ CAMLprim value caml_gc_minor(value v)
   CAML_EV_BEGIN(EV_EXPLICIT_GC_MINOR);
   CAMLassert (v == Val_unit);
   caml_minor_collection ();
-  value exn = caml_process_pending_actions_exn();
+  caml_result result = caml_process_pending_actions_result();
   CAML_EV_END(EV_EXPLICIT_GC_MINOR);
-  return caml_raise_if_exception(exn);
+  return caml_run_result(result);
 }
 
-static value gc_major_exn(int force_compaction)
+static caml_result gc_major_result(int force_compaction)
 {
   CAML_EV_BEGIN(EV_EXPLICIT_GC_MAJOR);
   caml_gc_log ("Major GC cycle requested");
   caml_empty_minor_heaps_once();
   caml_finish_major_cycle(force_compaction);
-  value exn = caml_process_pending_actions_exn();
+  caml_result result = caml_process_pending_actions_result();
   CAML_EV_END(EV_EXPLICIT_GC_MAJOR);
-  return exn;
+  return result;
 }
 
 CAMLprim value caml_gc_major(value v)
 {
   Caml_check_caml_state();
   CAMLassert (v == Val_unit);
-  return caml_raise_if_exception(gc_major_exn(0));
+  return caml_run_result(gc_major_result(0));
 }
 
-static value gc_full_major_exn(void)
+static caml_result gc_full_major_result(void)
 {
   int i;
-  value exn = Val_unit;
+  caml_result result = Result_unit;
   CAML_EV_BEGIN(EV_EXPLICIT_GC_FULL_MAJOR);
   caml_gc_log ("Full Major GC requested");
   /* In general, it can require up to 3 GC cycles for a
      currently-unreachable object to be collected. */
   for (i = 0; i < 3; i++) {
     caml_finish_major_cycle(0);
-    exn = caml_process_pending_actions_exn();
-    if (Is_exception_result(exn)) break;
+    result = caml_process_pending_actions_result();
+    if (result.is_exception) break;
   }
   ++ Caml_state->stat_forced_major_collections;
   CAML_EV_END(EV_EXPLICIT_GC_FULL_MAJOR);
-  return exn;
+  return result;
 }
 
 CAMLprim value caml_gc_full_major(value v)
 {
   Caml_check_caml_state();
   CAMLassert (v == Val_unit);
-  return caml_raise_if_exception(gc_full_major_exn());
+  return caml_run_result(gc_full_major_result());
 }
 
 CAMLprim value caml_gc_major_slice (value v)
@@ -283,9 +283,9 @@ CAMLprim value caml_gc_major_slice (value v)
   CAML_EV_BEGIN(EV_EXPLICIT_GC_MAJOR_SLICE);
   CAMLassert (Is_long (v));
   caml_major_collection_slice(Long_val(v));
-  value exn = caml_process_pending_actions_exn();
+  caml_result result = caml_process_pending_actions_result();
   CAML_EV_END(EV_EXPLICIT_GC_MAJOR_SLICE);
-  return caml_raise_if_exception(exn);
+  return caml_run_result(result);
 }
 
 CAMLprim value caml_gc_compaction(value v)
@@ -293,30 +293,30 @@ CAMLprim value caml_gc_compaction(value v)
   Caml_check_caml_state();
   CAML_EV_BEGIN(EV_EXPLICIT_GC_COMPACT);
   CAMLassert (v == Val_unit);
-  value exn = Val_unit;
+  caml_result result = Result_unit;
   int i;
-  /* We do a full major before this compaction. See [caml_full_major_exn] for
+  /* We do a full major before this compaction. See [caml_full_major_result] for
      why this needs three iterations. */
   for (i = 0; i < 3; i++) {
     caml_finish_major_cycle(i == 2);
-    exn = caml_process_pending_actions_exn();
-    if (Is_exception_result(exn)) break;
+    result = caml_process_pending_actions_result();
+    if (result.is_exception) break;
   }
   ++ Caml_state->stat_forced_major_collections;
   CAML_EV_END(EV_EXPLICIT_GC_COMPACT);
-  return caml_raise_if_exception(exn);
+  return caml_run_result(result);
 }
 
 CAMLprim value caml_gc_stat(value v)
 {
-  value res;
+  caml_result result;
   CAML_EV_BEGIN(EV_EXPLICIT_GC_STAT);
-  res = gc_full_major_exn();
-  if (Is_exception_result(res)) goto out;
-  res = caml_gc_quick_stat(Val_unit);
+  result = gc_full_major_result();
+  if (result.is_exception) goto out;
+  result = Result_value(caml_gc_quick_stat(Val_unit));
  out:
   CAML_EV_END(EV_EXPLICIT_GC_STAT);
-  return caml_raise_if_exception(res);
+  return caml_run_result(result);
 }
 
 CAMLprim value caml_get_minor_free (value v)

--- a/runtime/gc_ctrl.c
+++ b/runtime/gc_ctrl.c
@@ -256,19 +256,18 @@ CAMLprim value caml_gc_major(value v)
 static caml_result gc_full_major_result(void)
 {
   int i;
-  caml_result result = Result_unit;
   CAML_EV_BEGIN(EV_EXPLICIT_GC_FULL_MAJOR);
   caml_gc_log ("Full Major GC requested");
   /* In general, it can require up to 3 GC cycles for a
      currently-unreachable object to be collected. */
   for (i = 0; i < 3; i++) {
     caml_finish_major_cycle(0);
-    result = caml_process_pending_actions_result();
-    if (result.is_exception) break;
+    caml_result res = caml_process_pending_actions_result();
+    if (res.is_exception) return res;
   }
   ++ Caml_state->stat_forced_major_collections;
   CAML_EV_END(EV_EXPLICIT_GC_FULL_MAJOR);
-  return result;
+  return Result_unit;
 }
 
 CAMLprim value caml_gc_full_major(value v)

--- a/runtime/gc_ctrl.c
+++ b/runtime/gc_ctrl.c
@@ -230,18 +230,18 @@ CAMLprim value caml_gc_minor(value v)
   CAML_EV_BEGIN(EV_EXPLICIT_GC_MINOR);
   CAMLassert (v == Val_unit);
   caml_minor_collection ();
-  caml_result result = caml_process_pending_actions_result();
+  caml_result result = caml_process_pending_actions_res();
   CAML_EV_END(EV_EXPLICIT_GC_MINOR);
   return caml_get_value_or_raise(result);
 }
 
-static caml_result gc_major_result(int force_compaction)
+static caml_result gc_major_res(int force_compaction)
 {
   CAML_EV_BEGIN(EV_EXPLICIT_GC_MAJOR);
   caml_gc_log ("Major GC cycle requested");
   caml_empty_minor_heaps_once();
   caml_finish_major_cycle(force_compaction);
-  caml_result result = caml_process_pending_actions_result();
+  caml_result result = caml_process_pending_actions_res();
   CAML_EV_END(EV_EXPLICIT_GC_MAJOR);
   return result;
 }
@@ -250,10 +250,10 @@ CAMLprim value caml_gc_major(value v)
 {
   Caml_check_caml_state();
   CAMLassert (v == Val_unit);
-  return caml_get_value_or_raise(gc_major_result(0));
+  return caml_get_value_or_raise(gc_major_res(0));
 }
 
-static caml_result gc_full_major_result(void)
+static caml_result gc_full_major_res(void)
 {
   int i;
   CAML_EV_BEGIN(EV_EXPLICIT_GC_FULL_MAJOR);
@@ -262,7 +262,7 @@ static caml_result gc_full_major_result(void)
      currently-unreachable object to be collected. */
   for (i = 0; i < 3; i++) {
     caml_finish_major_cycle(0);
-    caml_result res = caml_process_pending_actions_result();
+    caml_result res = caml_process_pending_actions_res();
     if (caml_result_is_exception(res)) return res;
   }
   ++ Caml_state->stat_forced_major_collections;
@@ -274,7 +274,7 @@ CAMLprim value caml_gc_full_major(value v)
 {
   Caml_check_caml_state();
   CAMLassert (v == Val_unit);
-  return caml_get_value_or_raise(gc_full_major_result());
+  return caml_get_value_or_raise(gc_full_major_res());
 }
 
 CAMLprim value caml_gc_major_slice (value v)
@@ -282,7 +282,7 @@ CAMLprim value caml_gc_major_slice (value v)
   CAML_EV_BEGIN(EV_EXPLICIT_GC_MAJOR_SLICE);
   CAMLassert (Is_long (v));
   caml_major_collection_slice(Long_val(v));
-  caml_result result = caml_process_pending_actions_result();
+  caml_result result = caml_process_pending_actions_res();
   CAML_EV_END(EV_EXPLICIT_GC_MAJOR_SLICE);
   return caml_get_value_or_raise(result);
 }
@@ -294,11 +294,11 @@ CAMLprim value caml_gc_compaction(value v)
   CAMLassert (v == Val_unit);
   caml_result result = Result_unit;
   int i;
-  /* We do a full major before this compaction. See [caml_full_major_result] for
+  /* We do a full major before this compaction. See [caml_full_major_res] for
      why this needs three iterations. */
   for (i = 0; i < 3; i++) {
     caml_finish_major_cycle(i == 2);
-    result = caml_process_pending_actions_result();
+    result = caml_process_pending_actions_res();
     if (caml_result_is_exception(result)) break;
   }
   ++ Caml_state->stat_forced_major_collections;
@@ -310,7 +310,7 @@ CAMLprim value caml_gc_stat(value v)
 {
   caml_result result;
   CAML_EV_BEGIN(EV_EXPLICIT_GC_STAT);
-  result = gc_full_major_result();
+  result = gc_full_major_res();
   if (caml_result_is_exception(result)) goto out;
   result = Result_value(caml_gc_quick_stat(Val_unit));
  out:

--- a/runtime/memprof.c
+++ b/runtime/memprof.c
@@ -1869,7 +1869,7 @@ static value entries_run_callbacks_exn(memprof_thread_t thread,
  * change the various indexes into an entries table while iterating
  * over it, whereas domain_apply_actions assumes that can't happen. */
 
-value caml_memprof_run_callbacks_exn(void)
+static value run_callbacks_exn(void)
 {
   memprof_domain_t domain = Caml_state->memprof;
   CAMLassert(domain);
@@ -1917,6 +1917,11 @@ value caml_memprof_run_callbacks_exn(void)
   orphans_update_pending(domain);
   update_suspended(domain, false);
   return res;
+}
+
+caml_result caml_memprof_run_callbacks_result(void)
+{
+  return Result_encoded(run_callbacks_exn());
 }
 
 /**** Sampling ****/

--- a/runtime/memprof.c
+++ b/runtime/memprof.c
@@ -2009,7 +2009,7 @@ void caml_memprof_sample_young(uintnat wosize, int from_caml,
   CAMLassert(thread);
   entries_t entries = &thread->entries;
   uintnat whsize = Whsize_wosize(wosize);
-  caml_result res = Result_unit;
+  CAMLlocalresult(res);
   CAMLlocal1(config);
   config = entries->config;
 

--- a/runtime/minor_gc.c
+++ b/runtime/minor_gc.c
@@ -860,7 +860,7 @@ void caml_alloc_small_dispatch (caml_domain_state * dom_st,
     if (flags & CAML_FROM_CAML)
       /* In the case of allocations performed from OCaml, execute
          asynchronous callbacks. */
-      caml_raise_if_exception(caml_do_pending_actions_exn());
+      caml_run_result(caml_do_pending_actions_result());
     else {
       /* In the case of allocations performed from C, only perform
          non-delayable actions. */

--- a/runtime/minor_gc.c
+++ b/runtime/minor_gc.c
@@ -860,7 +860,7 @@ void caml_alloc_small_dispatch (caml_domain_state * dom_st,
     if (flags & CAML_FROM_CAML)
       /* In the case of allocations performed from OCaml, execute
          asynchronous callbacks. */
-      caml_run_result(caml_do_pending_actions_result());
+      caml_get_value_or_raise(caml_do_pending_actions_result());
     else {
       /* In the case of allocations performed from C, only perform
          non-delayable actions. */

--- a/runtime/minor_gc.c
+++ b/runtime/minor_gc.c
@@ -860,7 +860,7 @@ void caml_alloc_small_dispatch (caml_domain_state * dom_st,
     if (flags & CAML_FROM_CAML)
       /* In the case of allocations performed from OCaml, execute
          asynchronous callbacks. */
-      caml_get_value_or_raise(caml_do_pending_actions_result());
+      caml_get_value_or_raise(caml_do_pending_actions_res());
     else {
       /* In the case of allocations performed from C, only perform
          non-delayable actions. */

--- a/runtime/printexc.c
+++ b/runtime/printexc.c
@@ -124,7 +124,7 @@ static void default_fatal_uncaught_exception(value exn)
   saved_backtrace_pos = Caml_state->backtrace_pos;
   Caml_state->backtrace_active = 0;
   at_exit = caml_named_value("Pervasives.do_at_exit");
-  if (at_exit != NULL) caml_callback_result(*at_exit, Val_unit);
+  if (at_exit != NULL) caml_callback_res(*at_exit, Val_unit);
   Caml_state->backtrace_active = saved_backtrace_active;
   Caml_state->backtrace_pos = saved_backtrace_pos;
   /* Display the uncaught exception */

--- a/runtime/printexc.c
+++ b/runtime/printexc.c
@@ -124,7 +124,7 @@ static void default_fatal_uncaught_exception(value exn)
   saved_backtrace_pos = Caml_state->backtrace_pos;
   Caml_state->backtrace_active = 0;
   at_exit = caml_named_value("Pervasives.do_at_exit");
-  if (at_exit != NULL) caml_callback_exn(*at_exit, Val_unit);
+  if (at_exit != NULL) caml_callback_result(*at_exit, Val_unit);
   Caml_state->backtrace_active = saved_backtrace_active;
   Caml_state->backtrace_pos = saved_backtrace_pos;
   /* Display the uncaught exception */

--- a/runtime/runtime_events.c
+++ b/runtime/runtime_events.c
@@ -739,12 +739,7 @@ CAMLprim value caml_runtime_events_user_write(
     value record = Field(event_type, 0);
     value serializer = Field(record, 0);
 
-    res = caml_callback2_exn(serializer, write_buffer, event_content);
-
-    if (Is_exception_result(res)) {
-      res = Extract_exception(res);
-      caml_raise(res);
-    }
+    res = caml_callback2(serializer, write_buffer, event_content);
 
     uintnat len_bytes = Int_val(res);
     uintnat len_64bit_word = (len_bytes + sizeof(uint64_t)) / sizeof(uint64_t);

--- a/runtime/signals.c
+++ b/runtime/signals.c
@@ -94,7 +94,7 @@ CAMLexport caml_result caml_process_pending_signals_result(void)
         if ((curr & mask) == 0) goto next_bit;
       }
       caml_result result = caml_execute_signal_result(signo);
-      if (result.is_exception) return result;
+      if (caml_result_is_exception(result)) return result;
       /* curr probably changed during the evaluation of the signal handler;
          refresh it from memory */
       curr = atomic_load_relaxed(&caml_pending_signals[i]);
@@ -350,15 +350,15 @@ caml_result caml_do_pending_actions_result(void)
 
   /* Call signal handlers first */
   caml_result result = caml_process_pending_signals_result();
-  if (result.is_exception) goto exception;
+  if (caml_result_is_exception(result)) goto exception;
 
   /* Call memprof callbacks */
   result = caml_memprof_run_callbacks_result();
-  if (result.is_exception) goto exception;
+  if (caml_result_is_exception(result)) goto exception;
 
   /* Call finalisers */
   result = caml_final_do_calls_result();
-  if (result.is_exception) goto exception;
+  if (caml_result_is_exception(result)) goto exception;
 
   /* Process external interrupts (e.g. preemptive systhread switching).
      By doing this last, we do not need to set the action pending flag
@@ -382,7 +382,7 @@ caml_result caml_process_pending_actions_with_root_result(value root)
   if (caml_check_pending_actions()) {
     CAMLparam1(root);
     caml_result result = caml_do_pending_actions_result();
-    if (result.is_exception) CAMLreturnT(caml_result, result);
+    if (caml_result_is_exception(result)) CAMLreturnT(caml_result, result);
     CAMLdrop;
   }
   return Result_value(root);

--- a/runtime/signals.c
+++ b/runtime/signals.c
@@ -59,11 +59,10 @@ CAMLexport int caml_check_pending_signals(void)
 
 /* Execute all pending signals */
 
-CAMLexport value caml_process_pending_signals_exn(void)
+CAMLexport caml_result caml_process_pending_signals_result(void)
 {
   int i, j, signo;
   uintnat curr, mask ;
-  value exn;
 #ifdef POSIX_SIGNALS
   sigset_t set;
 #endif
@@ -71,7 +70,7 @@ CAMLexport value caml_process_pending_signals_exn(void)
   /* Check that there is indeed a pending signal before issuing the
       syscall in [pthread_sigmask]. */
   if (!caml_check_pending_signals())
-    return Val_unit;
+    return Result_unit;
 
 #ifdef POSIX_SIGNALS
   pthread_sigmask(/* dummy */ SIG_BLOCK, NULL, &set);
@@ -94,8 +93,8 @@ CAMLexport value caml_process_pending_signals_exn(void)
         if (curr == 0) goto next_word;
         if ((curr & mask) == 0) goto next_bit;
       }
-      exn = caml_execute_signal_exn(signo);
-      if (Is_exception_result(exn)) return exn;
+      caml_result result = caml_execute_signal_result(signo);
+      if (result.is_exception) return result;
       /* curr probably changed during the evaluation of the signal handler;
          refresh it from memory */
       curr = atomic_load_relaxed(&caml_pending_signals[i]);
@@ -104,7 +103,7 @@ CAMLexport value caml_process_pending_signals_exn(void)
     }
   next_word: /* skip */;
   }
-  return Val_unit;
+  return Result_unit;
 }
 
 /* Record the delivery of a signal, and arrange for it to be processed
@@ -172,7 +171,7 @@ CAMLexport void caml_enter_blocking_section(void)
          are further async callbacks pending beyond OCaml signal
          handlers. */
       caml_handle_gc_interrupt();
-      caml_raise_if_exception(caml_process_pending_signals_exn());
+      caml_run_result(caml_process_pending_signals_result());
     }
     caml_enter_blocking_section_hook ();
     /* Check again if a signal arrived in the meanwhile. If none,
@@ -229,7 +228,7 @@ void caml_init_signal_handling(void) {
 
 /* Execute a signal handler immediately */
 
-value caml_execute_signal_exn(int signal_number)
+caml_result caml_execute_signal_result(int signal_number)
 {
 #ifdef POSIX_SIGNALS
   sigset_t nsigs, sigs;
@@ -241,7 +240,7 @@ value caml_execute_signal_exn(int signal_number)
 #endif
   value handler = Field(caml_signal_handlers, signal_number);
   value signum = Val_int(caml_rev_convert_signal_number(signal_number));
-  value res = caml_callback_exn(handler, signum);
+  caml_result res = caml_callback_result(handler, signum);
 #ifdef POSIX_SIGNALS
   /* Restore the original signal mask */
   pthread_sigmask(SIG_SETMASK, &sigs, NULL);
@@ -334,7 +333,7 @@ CAMLexport int caml_check_pending_actions(void)
   return check_pending_actions(Caml_state);
 }
 
-value caml_do_pending_actions_exn(void)
+caml_result caml_do_pending_actions_result(void)
 {
   /* 1. Non-delayable actions that do not run OCaml code. */
 
@@ -350,16 +349,16 @@ value caml_do_pending_actions_exn(void)
   Caml_state->action_pending = 0;
 
   /* Call signal handlers first */
-  value exn = caml_process_pending_signals_exn();
-  if (Is_exception_result(exn)) goto exception;
+  caml_result result = caml_process_pending_signals_result();
+  if (result.is_exception) goto exception;
 
   /* Call memprof callbacks */
-  exn = caml_memprof_run_callbacks_exn();
-  if (Is_exception_result(exn)) goto exception;
+  result = caml_memprof_run_callbacks_result();
+  if (result.is_exception) goto exception;
 
   /* Call finalisers */
-  exn = caml_final_do_calls_exn();
-  if (Is_exception_result(exn)) goto exception;
+  result = caml_final_do_calls_result();
+  if (result.is_exception) goto exception;
 
   /* Process external interrupts (e.g. preemptive systhread switching).
      By doing this last, we do not need to set the action pending flag
@@ -367,7 +366,7 @@ value caml_do_pending_actions_exn(void)
      at this point. */
   caml_process_external_interrupt();
 
-  return Val_unit;
+  return Result_unit;
 
 exception:
   /* If an exception is raised during an asynchronous callback, then
@@ -375,29 +374,29 @@ exception:
      needed. Therefore, we set [Caml_state->action_pending] again in
      order to force reexamination of callbacks. */
   caml_set_action_pending(Caml_state);
-  return exn;
+  return result;
 }
 
-value caml_process_pending_actions_with_root_exn(value root)
+caml_result caml_process_pending_actions_with_root_result(value root)
 {
   if (caml_check_pending_actions()) {
     CAMLparam1(root);
-    value exn = caml_do_pending_actions_exn();
-    if (Is_exception_result(exn)) CAMLreturn(exn);
+    caml_result result = caml_do_pending_actions_result();
+    if (result.is_exception) CAMLreturnT(caml_result, result);
     CAMLdrop;
   }
-  return root;
+  return Result_value(root);
 }
 
 CAMLprim value caml_process_pending_actions_with_root(value root)
 {
-  return caml_raise_if_exception(
-    caml_process_pending_actions_with_root_exn(root));
+  return caml_run_result(
+    caml_process_pending_actions_with_root_result(root));
 }
 
-CAMLexport value caml_process_pending_actions_exn(void)
+CAMLexport caml_result caml_process_pending_actions_result(void)
 {
-  return caml_process_pending_actions_with_root_exn(Val_unit);
+  return caml_process_pending_actions_with_root_result(Val_unit);
 }
 
 CAMLexport void caml_process_pending_actions(void)
@@ -711,6 +710,6 @@ CAMLprim value caml_install_signal_handler(value signal_number, value action)
     caml_modify(&Field(caml_signal_handlers, sig), Field(action, 0));
     caml_plat_unlock(&signal_install_mutex);
   }
-  caml_raise_if_exception(caml_process_pending_signals_exn());
+  caml_run_result(caml_process_pending_signals_result());
   CAMLreturn (res);
 }

--- a/runtime/signals.c
+++ b/runtime/signals.c
@@ -171,7 +171,7 @@ CAMLexport void caml_enter_blocking_section(void)
          are further async callbacks pending beyond OCaml signal
          handlers. */
       caml_handle_gc_interrupt();
-      caml_run_result(caml_process_pending_signals_result());
+      caml_get_value_or_raise(caml_process_pending_signals_result());
     }
     caml_enter_blocking_section_hook ();
     /* Check again if a signal arrived in the meanwhile. If none,
@@ -390,7 +390,7 @@ caml_result caml_process_pending_actions_with_root_result(value root)
 
 CAMLprim value caml_process_pending_actions_with_root(value root)
 {
-  return caml_run_result(
+  return caml_get_value_or_raise(
     caml_process_pending_actions_with_root_result(root));
 }
 
@@ -405,7 +405,7 @@ CAMLexport caml_result caml_process_pending_actions_result(void)
 
 CAMLexport void caml_process_pending_actions(void)
 {
-  caml_run_result(
+  caml_get_value_or_raise(
     caml_process_pending_actions_result());
 }
 
@@ -715,6 +715,6 @@ CAMLprim value caml_install_signal_handler(value signal_number, value action)
     caml_modify(&Field(caml_signal_handlers, sig), Field(action, 0));
     caml_plat_unlock(&signal_install_mutex);
   }
-  caml_run_result(caml_process_pending_signals_result());
+  caml_get_value_or_raise(caml_process_pending_signals_result());
   CAMLreturn (res);
 }

--- a/runtime/signals.c
+++ b/runtime/signals.c
@@ -396,12 +396,17 @@ CAMLprim value caml_process_pending_actions_with_root(value root)
 
 CAMLexport caml_result caml_process_pending_actions_result(void)
 {
-  return caml_process_pending_actions_with_root_result(Val_unit);
+  if (caml_check_pending_actions()) {
+    return caml_do_pending_actions_result();
+  } else {
+    return Result_unit;
+  }
 }
 
 CAMLexport void caml_process_pending_actions(void)
 {
-  caml_process_pending_actions_with_root(Val_unit);
+  caml_run_result(
+    caml_process_pending_actions_result());
 }
 
 /* OS-independent numbering of signals */

--- a/runtime/startup_aux.c
+++ b/runtime/startup_aux.c
@@ -158,7 +158,7 @@ static void call_registered_value(char* name)
 {
   const value *f = caml_named_value(name);
   if (f != NULL)
-    caml_callback_result(*f, Val_unit);
+    caml_callback_res(*f, Val_unit);
 }
 
 CAMLexport void caml_shutdown(void)

--- a/runtime/startup_aux.c
+++ b/runtime/startup_aux.c
@@ -158,7 +158,7 @@ static void call_registered_value(char* name)
 {
   const value *f = caml_named_value(name);
   if (f != NULL)
-    caml_callback_exn(*f, Val_unit);
+    caml_callback_result(*f, Val_unit);
 }
 
 CAMLexport void caml_shutdown(void)


### PR DESCRIPTION
In the OCaml runtime, some C functions that in turn call OCaml code come in two variant:
- the "raising' variant, for example `caml_callback`, will raise exceptions directly, as OCaml code would
- the 'encoded exception' variant, for example `caml_callback_exn`, will not raise exceptions but encode them into the return value

The 'encoded exception' variant is important for resource-safe interfaces because the caller may want to run some cleanup/release code before propagating the exception, which the 'raising' variant cannot express -- C code cannot create OCaml exception handlers. On the other hand, the encoding of exceptions into the `value` type is a big hack that is unsafe in two different ways:
- dynamically, the `value` encoding exceptions are not valid OCaml values, the GC will blow up if it encounters them; callers have to follow a strict discipline of checking for an exception right away and discarding the fake `value`
- statically, reusing the `value` type means that the C compiler cannot check that we use these exceptions as intended, and will happily let us mix them with real values by mistake, making the dynamic unsafety harder to guard against

In #12407, @gadmm proposed to extend the approach of 'encoded exceptions' to more parts of the runtime, to make it possible to write resource-safe code in more places, but @xavierleroy pushed against the design due to the unsafety of encoded exceptions.
To be able to move forward, we need an approach for resource-safe APIs that is consensual; the present PR, which grew out of the discussios in #12407 and in particular discussions with @gadmm, is a proposed approach.

The PR proposes a new 'result' variant: `caml_callback_result` is similar to `caml_callback_exn`, but instead of returning an unsafe `value` it returns a new, distinct C type `caml_result`, that properly represents either a value or an exception. This is more safe:
- dynamically, no invalid values are produced
- statically, the type is incompatible with `value`, reminding us to deal with the exception in the caller

```c
typedef struct {
  _Bool is_exception;
  value data;
} caml_result;
```

The present PR:
1. introoduces this `caml_result` type,
2. exposes `_result` variants for all functions that previously had an `_exn` variant, and
3. removes almost all uses of encoded exceptions in the runtime code itself.

For the `_exn` variants, the ones that were part of the public API are kept for compatibility, and those that were under CAML_INTERNALS are removed.

(The places where encoded exceptions are retained are the implementation of the `caml_callback*_exn` functions, which touch the bytecode interpreter and the assembly code in the runtime system. I preferred to leave them as-is, and wrap them inside `caml_result` on the outside.)
