### PR TITLE
Ci tweaks for msvc

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -185,6 +185,14 @@ stdlib/hashbang -text
 tools/autogen text eol=lf
 tools/bump-magic-numbers eol=lf typo.long-line
 tools/ci/inria/bootstrap/remove-sinh-primitive.patch -text
+tools/ci/inria/launch text eol=lf
+tools/ci/inria/light text eol=lf
+tools/ci/inria/main text eol=lf
+tools/ci/inria/main/bootstrap/script text eol=lf
+tools/ci/inria/main/dyne-build/script text eol=lf
+tools/ci/inria/main/other-configs/script text eol=lf
+tools/ci/inria/main/sanitizers/script text eol=lf
+tools/ci/inria/main/step-by-step-build/script text eol=lf
 tools/check-typo text eol=lf
 tools/check-symbol-names text eol=lf
 tools/msvs-promote-path text eol=lf

--- a/tools/ci/inria/main
+++ b/tools/ci/inria/main
@@ -190,12 +190,14 @@ case "${OCAML_ARCH}" in
     host='--host=i686-pc-windows'
     instdir='C:/ocamlms'
     cleanup=true
+    init_submodule=true
   ;;
   msvc64)
     build='--build=x86_64-pc-cygwin'
     host='--host=x86_64-pc-windows'
     instdir='C:/ocamlms64'
     cleanup=true
+    init_submodule=true
   ;;
   *) arch_error;;
 esac


### PR DESCRIPTION
These changes are needed to make Inria's CI work on the MSVC workers:

- for `.gitattributes`: we want to be able to check out with git-for-windows, so the shell script files must be correctly annotated. This needs to be updated now because I switched the msvc-64 worker from cygwin git to git-for-windows because of a random failure with cygwin git.
- for `ci/inria/main`: we are updating MSVC on the worker machines, and (as noted in `README.win32.adoc`) we can't use a precompiled Flexdll with newer versions of MSVC.
