### PR TITLE
[4.14] Don't pass duplicate libraries to the linker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -703,7 +703,7 @@ beforedepend:: parsing/lexer.ml
 
 ocamlc.opt$(EXE): compilerlibs/ocamlcommon.cmxa \
                   compilerlibs/ocamlbytecomp.cmxa $(BYTESTART:.cmo=.cmx)
-	$(CAMLOPT_CMD) $(LINKFLAGS) -o $@ $^ -cclib "$(BYTECCLIBS)"
+	$(CAMLOPT_CMD) $(LINKFLAGS) -o $@ $^ $(PTHREAD_CAML_LIBS)
 
 partialclean::
 	rm -f ocamlc.opt$(EXE)

--- a/otherlibs/systhreads/Makefile
+++ b/otherlibs/systhreads/Makefile
@@ -66,14 +66,14 @@ all: lib$(LIBNAME).$(A) $(LIBNAME).cma $(CMIFILES)
 allopt: lib$(LIBNAME)nat.$(A) $(LIBNAME).cmxa $(CMIFILES)
 
 lib$(LIBNAME).$(A): $(BYTECODE_C_OBJS)
-	$(MKLIB_CMD) -o $(LIBNAME) $(BYTECODE_C_OBJS) $(PTHREAD_LIBS)
+	$(MKLIB_CMD) -o $(LIBNAME) $(BYTECODE_C_OBJS)
 
 lib$(LIBNAME)nat.$(A): $(NATIVECODE_C_OBJS)
 	$(MKLIB_CMD) -o $(LIBNAME)nat $^
 
+# Bytecode programs always link with pthread libraries
 $(LIBNAME).cma: $(THREADS_BCOBJS)
-	$(MKLIB) -o $(LIBNAME) -ocamlc '$(CAMLC)' -linkall \
-	  $(PTHREAD_CAML_LIBS) $^
+	$(MKLIB) -o $(LIBNAME) -ocamlc '$(CAMLC)' -linkall $^
 
 # See remark above: force static linking of libthreadsnat.a
 $(LIBNAME).cmxa: $(THREADS_NCOBJS)

--- a/otherlibs/systhreads/Makefile
+++ b/otherlibs/systhreads/Makefile
@@ -72,17 +72,8 @@ lib$(LIBNAME)nat.$(A): $(NATIVECODE_C_OBJS)
 	$(MKLIB_CMD) -o $(LIBNAME)nat $^
 
 $(LIBNAME).cma: $(THREADS_BCOBJS)
-ifeq "$(UNIX_OR_WIN32)" "unix"
-	$(MKLIB) -o $(LIBNAME) -ocamlc '$(CAMLC)' -cclib -lunix -linkall \
+	$(MKLIB) -o $(LIBNAME) -ocamlc '$(CAMLC)' -linkall \
 	  $(PTHREAD_CAML_LIBS) $^
-# TODO: Figure out why -cclib -lunix is used here.
-# It may be because of the threadsUnix module which is deprecated.
-# It may hence be good to figure out whether this module shouldn't be
-# removed, and then -cclib -lunix arguments.
-else # Windows
-	$(MKLIB) -o $(LIBNAME) -ocamlc "$(CAMLC)" -linkall \
-	  $(PTHREAD_CAML_LIBS) $^
-endif
 
 # See remark above: force static linking of libthreadsnat.a
 $(LIBNAME).cmxa: $(THREADS_NCOBJS)


### PR DESCRIPTION
While looking at something on Jenkins, I noticed that the macOS M1 worker is returning some linker warnings (e.g. on [this run](https://ci.inria.fr/ocaml/job/main/4093/flambda=false,label=ocaml-macos-m1/consoleFull)):

- `ld: warning: ignoring duplicate libraries: '-lm'` when compiling `ocamlc.opt`
- A string of `ld: warning: ignoring duplicate libraries: '-lpthread', '-lunix'` in the testsuite with the systhreads tests

The warning is benign during the build, but it obviously causes problems for the testsuite.

The commit messages include explanations for the changes.