### PR TITLE
fix some test scripts

### DIFF
--- a/testsuite/tests/backtrace/backtrace_dynlink.ml
+++ b/testsuite/tests/backtrace/backtrace_dynlink.ml
@@ -52,29 +52,31 @@ let ()  =
  shared-libraries;
  native-dynlink;
  setup-ocamlopt.byte-build-env;
+
+ module = "backtrace_dynlink.ml";
+ flags = "-g";
+ ocamlopt.byte;
+
+ unset module;
+ program = "backtrace_dynlink_plugin.cmxs";
+ flags = "-shared -g";
+ all_modules = "backtrace_dynlink_plugin.ml";
+ ocamlopt.byte;
+
+ program = "${test_build_directory}/main.exe";
+ unset flags;
+ libraries = "dynlink";
+ all_modules = "backtrace_dynlink.cmx";
+ ocamlopt.byte;
+
+ ocamlrunparam += ",b=1";
+ run;
  {
-   module = "backtrace_dynlink.ml";
-   flags = "-g";
-   ocamlopt.byte;
+   no-flambda;
+   check-program-output;
  }{
-   program = "backtrace_dynlink_plugin.cmxs";
-   flags = "-shared -g";
-   all_modules = "backtrace_dynlink_plugin.ml";
-   ocamlopt.byte;
- }{
-   program = "${test_build_directory}/main.exe";
-   libraries = "dynlink";
-   all_modules = "backtrace_dynlink.cmx";
-   ocamlopt.byte;
-   ocamlrunparam += ",b=1";
-   run;
-   {
-     no-flambda;
-     check-program-output;
-   }{
-     reference = "${test_source_directory}/backtrace_dynlink.flambda.reference";
-     flambda;
-     check-program-output;
-   }
+   reference = "${test_source_directory}/backtrace_dynlink.flambda.reference";
+   flambda;
+   check-program-output;
  }
 *)

--- a/testsuite/tests/lib-dynlink-initializers/test10_main.ml
+++ b/testsuite/tests/lib-dynlink-initializers/test10_main.ml
@@ -64,41 +64,42 @@ let () =
  shared-libraries;
  {
    setup-ocamlc.byte-build-env;
-   {
-     module = "test10_main.ml";
-     ocamlc.byte;
-   }{
-     module = "test10_plugin.ml";
-     ocamlc.byte;
-   }{
-     program = "${test_build_directory}/test10.byte";
-     libraries = "dynlink";
-     all_modules = "test10_main.cmo";
-     ocamlc.byte;
-     run;
-     reference = "${test_source_directory}/test10_main.byte.reference";
-     check-program-output;
-   }
+
+   module = "test10_main.ml";
+   ocamlc.byte;
+
+   module = "test10_plugin.ml";
+   ocamlc.byte;
+
+   unset module;
+   program = "${test_build_directory}/test10.byte";
+   libraries = "dynlink";
+   all_modules = "test10_main.cmo";
+   ocamlc.byte;
+   run;
+   reference = "${test_source_directory}/test10_main.byte.reference";
+   check-program-output;
  }{
    no-flambda;
    native-dynlink;
    setup-ocamlopt.byte-build-env;
-   {
-     module = "test10_main.ml";
-     ocamlopt.byte;
-   }{
-     program = "test10_plugin.cmxs";
-     flags = "-shared";
-     all_modules = "test10_plugin.ml";
-     ocamlopt.byte;
-   }{
-     program = "${test_build_directory}/test10.exe";
-     libraries = "dynlink";
-     all_modules = "test10_main.cmx";
-     ocamlopt.byte;
-     run;
-     reference = "${test_source_directory}/test10_main.native.reference";
-     check-program-output;
-   }
+
+   module = "test10_main.ml";
+   ocamlopt.byte;
+
+   unset module;
+   program = "test10_plugin.cmxs";
+   flags = "-shared";
+   all_modules = "test10_plugin.ml";
+   ocamlopt.byte;
+
+   program = "${test_build_directory}/test10.exe";
+   unset flags;
+   libraries = "dynlink";
+   all_modules = "test10_main.cmx";
+   ocamlopt.byte;
+   run;
+   reference = "${test_source_directory}/test10_main.native.reference";
+   check-program-output;
  }
 *)

--- a/testsuite/tests/lib-dynlink-initializers/test1_main.ml
+++ b/testsuite/tests/lib-dynlink-initializers/test1_main.ml
@@ -5,43 +5,44 @@
  shared-libraries;
  {
    setup-ocamlc.byte-build-env;
-   {
-     module = "test1_main.ml";
-     ocamlc.byte;
-   }{
-     module = "test1_inited_second.ml";
-     ocamlc.byte;
-   }{
-     module = "test1_plugin.ml";
-     ocamlc.byte;
-   }{
-     program = "${test_build_directory}/test1.byte";
-     libraries = "dynlink";
-     all_modules = "test1_main.cmo test1_inited_second.cmo";
-     ocamlc.byte;
-     run;
-   }
+
+   module = "test1_main.ml";
+   ocamlc.byte;
+
+   module = "test1_inited_second.ml";
+   ocamlc.byte;
+
+   module = "test1_plugin.ml";
+   ocamlc.byte;
+
+   unset module;
+   program = "${test_build_directory}/test1.byte";
+   libraries = "dynlink";
+   all_modules = "test1_main.cmo test1_inited_second.cmo";
+   ocamlc.byte;
+   run;
  }{
    native-dynlink;
    setup-ocamlopt.byte-build-env;
-   {
-     module = "test1_main.ml";
-     ocamlopt.byte;
-   }{
-     module = "test1_inited_second.ml";
-     ocamlopt.byte;
-   }{
-     program = "test1_plugin.cmxs";
-     flags = "-shared";
-     all_modules = "test1_plugin.ml";
-     ocamlopt.byte;
-   }{
-     program = "${test_build_directory}/test1.exe";
-     libraries = "dynlink";
-     all_modules = "test1_main.cmx test1_inited_second.cmx";
-     ocamlopt.byte;
-     run;
-   }
+
+   module = "test1_main.ml";
+   ocamlopt.byte;
+
+   module = "test1_inited_second.ml";
+   ocamlopt.byte;
+
+   unset module;
+   program = "test1_plugin.cmxs";
+   flags = "-shared";
+   all_modules = "test1_plugin.ml";
+   ocamlopt.byte;
+
+   program = "${test_build_directory}/test1.exe";
+   unset flags;
+   libraries = "dynlink";
+   all_modules = "test1_main.cmx test1_inited_second.cmx";
+   ocamlopt.byte;
+   run;
  }
 *)
 

--- a/testsuite/tests/lib-dynlink-initializers/test2_main.ml
+++ b/testsuite/tests/lib-dynlink-initializers/test2_main.ml
@@ -5,43 +5,44 @@
  shared-libraries;
  {
    setup-ocamlc.byte-build-env;
-   {
-     module = "test2_inited_first.ml";
-     ocamlc.byte;
-   }{
-     module = "test2_main.ml";
-     ocamlc.byte;
-   }{
-     module = "test2_plugin.ml";
-     ocamlc.byte;
-   }{
-     program = "${test_build_directory}/test2.byte";
-     libraries = "dynlink";
-     all_modules = "test2_inited_first.cmo test2_main.cmo";
-     ocamlc.byte;
-     run;
-   }
+
+   module = "test2_inited_first.ml";
+   ocamlc.byte;
+
+   module = "test2_main.ml";
+   ocamlc.byte;
+
+   module = "test2_plugin.ml";
+   ocamlc.byte;
+
+   unset module;
+   program = "${test_build_directory}/test2.byte";
+   libraries = "dynlink";
+   all_modules = "test2_inited_first.cmo test2_main.cmo";
+   ocamlc.byte;
+   run;
  }{
    native-dynlink;
    setup-ocamlopt.byte-build-env;
-   {
-     module = "test2_inited_first.ml";
-     ocamlopt.byte;
-   }{
-     module = "test2_main.ml";
-     ocamlopt.byte;
-   }{
-     program = "test2_plugin.cmxs";
-     flags = "-shared";
-     all_modules = "test2_plugin.ml";
-     ocamlopt.byte;
-   }{
-     program = "${test_build_directory}/test2.exe";
-     libraries = "dynlink";
-     all_modules = "test2_inited_first.cmx test2_main.cmx";
-     ocamlopt.byte;
-     run;
-   }
+
+   module = "test2_inited_first.ml";
+   ocamlopt.byte;
+
+   module = "test2_main.ml";
+   ocamlopt.byte;
+
+   unset module;
+   program = "test2_plugin.cmxs";
+   flags = "-shared";
+   all_modules = "test2_plugin.ml";
+   ocamlopt.byte;
+
+   program = "${test_build_directory}/test2.exe";
+   unset flags;
+   libraries = "dynlink";
+   all_modules = "test2_inited_first.cmx test2_main.cmx";
+   ocamlopt.byte;
+   run;
  }
 *)
 

--- a/testsuite/tests/lib-dynlink-initializers/test3_main.ml
+++ b/testsuite/tests/lib-dynlink-initializers/test3_main.ml
@@ -5,51 +5,53 @@
  shared-libraries;
  {
    setup-ocamlc.byte-build-env;
-   {
-     module = "test3_main.ml";
-     ocamlc.byte;
-   }{
-     module = "test3_plugin_a.ml";
-     ocamlc.byte;
-   }{
-     module = "test3_plugin_b.ml";
-     ocamlc.byte;
-   }{
-     program = "test3_plugin.cma";
-     flags = "-a";
-     all_modules = "test3_plugin_a.cmo test3_plugin_b.cmo";
-     ocamlc.byte;
-   }{
-     program = "${test_build_directory}/test3.byte";
-     libraries = "dynlink";
-     all_modules = "test3_main.cmo";
-     ocamlc.byte;
-     run;
-   }
+
+   module = "test3_main.ml";
+   ocamlc.byte;
+
+   module = "test3_plugin_a.ml";
+   ocamlc.byte;
+
+   module = "test3_plugin_b.ml";
+   ocamlc.byte;
+
+   unset module;
+   program = "test3_plugin.cma";
+   flags = "-a";
+   all_modules = "test3_plugin_a.cmo test3_plugin_b.cmo";
+   ocamlc.byte;
+
+   program = "${test_build_directory}/test3.byte";
+   unset flags;
+   libraries = "dynlink";
+   all_modules = "test3_main.cmo";
+   ocamlc.byte;
+   run;
  }{
    native-dynlink;
    setup-ocamlopt.byte-build-env;
-   {
-     module = "test3_main.ml";
-     ocamlopt.byte;
-   }{
-     module = "test3_plugin_a.ml";
-     ocamlopt.byte;
-   }{
-     module = "test3_plugin_b.ml";
-     ocamlopt.byte;
-   }{
-     program = "test3_plugin.cmxs";
-     flags = "-shared";
-     all_modules = "test3_plugin_a.cmx test3_plugin_b.cmx";
-     ocamlopt.byte;
-   }{
-     program = "${test_build_directory}/test3.exe";
-     libraries = "dynlink";
-     all_modules = "test3_main.cmx";
-     ocamlopt.byte;
-     run;
-   }
+
+   module = "test3_main.ml";
+   ocamlopt.byte;
+
+   module = "test3_plugin_a.ml";
+   ocamlopt.byte;
+
+   module = "test3_plugin_b.ml";
+   ocamlopt.byte;
+
+   unset module;
+   program = "test3_plugin.cmxs";
+   flags = "-shared";
+   all_modules = "test3_plugin_a.cmx test3_plugin_b.cmx";
+   ocamlopt.byte;
+
+   unset flags;
+   program = "${test_build_directory}/test3.exe";
+   libraries = "dynlink";
+   all_modules = "test3_main.cmx";
+   ocamlopt.byte;
+   run;
  }
 *)
 

--- a/testsuite/tests/lib-dynlink-initializers/test5_main.ml
+++ b/testsuite/tests/lib-dynlink-initializers/test5_main.ml
@@ -5,59 +5,61 @@
  shared-libraries;
  {
    setup-ocamlc.byte-build-env;
-   {
-     module = "test5_main.ml";
-     ocamlc.byte;
-   }{
-     module = "test5_plugin_a.ml";
-     ocamlc.byte;
-   }{
-     module = "test5_plugin_b.ml";
-     ocamlc.byte;
-   }{
-     module = "test5_second_plugin.ml";
-     ocamlc.byte;
-   }{
-     program = "test5_plugin.cma";
-     flags = "-a";
-     all_modules = "test5_plugin_a.cmo test5_plugin_b.cmo";
-     ocamlc.byte;
-   }{
-     program = "${test_build_directory}/test5.byte";
-     libraries = "dynlink";
-     all_modules = "test5_main.cmo";
-     ocamlc.byte;
-     run;
-   }
+
+   module = "test5_main.ml";
+   ocamlc.byte;
+
+   module = "test5_plugin_a.ml";
+   ocamlc.byte;
+
+   module = "test5_plugin_b.ml";
+   ocamlc.byte;
+
+   module = "test5_second_plugin.ml";
+   ocamlc.byte;
+
+   unset module;
+   program = "test5_plugin.cma";
+   flags = "-a";
+   all_modules = "test5_plugin_a.cmo test5_plugin_b.cmo";
+   ocamlc.byte;
+
+   program = "${test_build_directory}/test5.byte";
+   unset flags;
+   libraries = "dynlink";
+   all_modules = "test5_main.cmo";
+   ocamlc.byte;
+   run;
  }{
    native-dynlink;
    setup-ocamlopt.byte-build-env;
-   {
-     module = "test5_main.ml";
-     ocamlopt.byte;
-   }{
-     module = "test5_plugin_a.ml";
-     ocamlopt.byte;
-   }{
-     module = "test5_plugin_b.ml";
-     ocamlopt.byte;
-   }{
-     program = "test5_plugin.cmxs";
-     flags = "-shared";
-     all_modules = "test5_plugin_a.cmx test5_plugin_b.cmx";
-     ocamlopt.byte;
-   }{
-     program = "test5_second_plugin.cmxs";
-     flags = "-shared";
-     all_modules = "test5_second_plugin.ml";
-     ocamlopt.byte;
-   }{
-     program = "${test_build_directory}/test5.exe";
-     libraries = "dynlink";
-     all_modules = "test5_main.cmx";
-     ocamlopt.byte;
-     run;
-   }
+
+   module = "test5_main.ml";
+   ocamlopt.byte;
+
+   module = "test5_plugin_a.ml";
+   ocamlopt.byte;
+
+   module = "test5_plugin_b.ml";
+   ocamlopt.byte;
+
+   unset module;
+   program = "test5_plugin.cmxs";
+   flags = "-shared";
+   all_modules = "test5_plugin_a.cmx test5_plugin_b.cmx";
+   ocamlopt.byte;
+
+   program = "test5_second_plugin.cmxs";
+   flags = "-shared";
+   all_modules = "test5_second_plugin.ml";
+   ocamlopt.byte;
+
+   program = "${test_build_directory}/test5.exe";
+   unset flags;
+   libraries = "dynlink";
+   all_modules = "test5_main.cmx";
+   ocamlopt.byte;
+   run;
  }
 *)
 

--- a/testsuite/tests/lib-dynlink-initializers/test6_main.ml
+++ b/testsuite/tests/lib-dynlink-initializers/test6_main.ml
@@ -5,45 +5,46 @@
  shared-libraries;
  {
    setup-ocamlc.byte-build-env;
-   {
-     module = "test6_main.ml";
-     ocamlc.byte;
-   }{
-     module = "test6_plugin.ml";
-     ocamlc.byte;
-   }{
-     module = "test6_second_plugin.ml";
-     ocamlc.byte;
-   }{
-     program = "${test_build_directory}/test6.byte";
-     libraries = "dynlink";
-     all_modules = "test6_main.cmo";
-     ocamlc.byte;
-     run;
-   }
+
+   module = "test6_main.ml";
+   ocamlc.byte;
+
+   module = "test6_plugin.ml";
+   ocamlc.byte;
+
+   module = "test6_second_plugin.ml";
+   ocamlc.byte;
+
+   unset module;
+   program = "${test_build_directory}/test6.byte";
+   libraries = "dynlink";
+   all_modules = "test6_main.cmo";
+   ocamlc.byte;
+   run;
  }{
    native-dynlink;
    setup-ocamlopt.byte-build-env;
-   {
-     module = "test6_main.ml";
-     ocamlopt.byte;
-   }{
-     program = "test6_plugin.cmxs";
-     flags = "-shared";
-     all_modules = "test6_plugin.ml";
-     ocamlopt.byte;
-   }{
-     program = "test6_second_plugin.cmxs";
-     flags = "-shared";
-     all_modules = "test6_second_plugin.ml";
-     ocamlopt.byte;
-   }{
-     program = "${test_build_directory}/test6.exe";
-     libraries = "dynlink";
-     all_modules = "test6_main.cmx";
-     ocamlopt.byte;
-     run;
-   }
+
+   module = "test6_main.ml";
+   ocamlopt.byte;
+
+   unset module;
+   program = "test6_plugin.cmxs";
+   flags = "-shared";
+   all_modules = "test6_plugin.ml";
+   ocamlopt.byte;
+
+   program = "test6_second_plugin.cmxs";
+   flags = "-shared";
+   all_modules = "test6_second_plugin.ml";
+   ocamlopt.byte;
+
+   program = "${test_build_directory}/test6.exe";
+   unset flags;
+   libraries = "dynlink";
+   all_modules = "test6_main.cmx";
+   ocamlopt.byte;
+   run;
  }
 *)
 

--- a/testsuite/tests/lib-dynlink-initializers/test7_main.ml
+++ b/testsuite/tests/lib-dynlink-initializers/test7_main.ml
@@ -5,43 +5,44 @@
  shared-libraries;
  {
    setup-ocamlc.byte-build-env;
-   {
-     module = "test7_interface_only.mli";
-     ocamlc.byte;
-   }{
-     module = "test7_main.ml";
-     ocamlc.byte;
-   }{
-     module = "test7_plugin.ml";
-     ocamlc.byte;
-   }{
-     program = "${test_build_directory}/test7.byte";
-     libraries = "dynlink";
-     all_modules = "test7_main.cmo";
-     ocamlc.byte;
-     run;
-   }
+
+   module = "test7_interface_only.mli";
+   ocamlc.byte;
+
+   module = "test7_main.ml";
+   ocamlc.byte;
+
+   module = "test7_plugin.ml";
+   ocamlc.byte;
+
+   unset module;
+   program = "${test_build_directory}/test7.byte";
+   libraries = "dynlink";
+   all_modules = "test7_main.cmo";
+   ocamlc.byte;
+   run;
  }{
    native-dynlink;
    setup-ocamlopt.byte-build-env;
-   {
-     module = "test7_interface_only.mli";
-     ocamlopt.byte;
-   }{
-     module = "test7_main.ml";
-     ocamlopt.byte;
-   }{
-     program = "test7_plugin.cmxs";
-     flags = "-shared";
-     all_modules = "test7_plugin.ml";
-     ocamlopt.byte;
-   }{
-     program = "${test_build_directory}/test7.exe";
-     libraries = "dynlink";
-     all_modules = "test7_main.cmx";
-     ocamlopt.byte;
-     run;
-   }
+
+   module = "test7_interface_only.mli";
+   ocamlopt.byte;
+
+   module = "test7_main.ml";
+   ocamlopt.byte;
+
+   unset module;
+   program = "test7_plugin.cmxs";
+   flags = "-shared";
+   all_modules = "test7_plugin.ml";
+   ocamlopt.byte;
+
+   program = "${test_build_directory}/test7.exe";
+   unset flags;
+   libraries = "dynlink";
+   all_modules = "test7_main.cmx";
+   ocamlopt.byte;
+   run;
  }
 *)
 

--- a/testsuite/tests/lib-dynlink-initializers/test8_main.ml
+++ b/testsuite/tests/lib-dynlink-initializers/test8_main.ml
@@ -5,57 +5,59 @@
  shared-libraries;
  {
    setup-ocamlc.byte-build-env;
-   {
-     module = "test8_main.ml";
-     ocamlc.byte;
-   }{
-     module = "test8_plugin_b.mli";
-     ocamlc.byte;
-   }{
-     module = "test8_plugin_a.ml";
-     ocamlc.byte;
-   }{
-     module = "test8_plugin_b.ml";
-     ocamlc.byte;
-   }{
-     program = "test8_plugin.cma";
-     flags = "-a";
-     all_modules = "test8_plugin_a.cmo test8_plugin_b.cmo";
-     ocamlc.byte;
-   }{
-     program = "${test_build_directory}/test8.byte";
-     libraries = "dynlink";
-     all_modules = "test8_main.cmo";
-     ocamlc.byte;
-     run;
-   }
+
+   module = "test8_main.ml";
+   ocamlc.byte;
+
+   module = "test8_plugin_b.mli";
+   ocamlc.byte;
+
+   module = "test8_plugin_a.ml";
+   ocamlc.byte;
+
+   module = "test8_plugin_b.ml";
+   ocamlc.byte;
+
+   unset module;
+   program = "test8_plugin.cma";
+   flags = "-a";
+   all_modules = "test8_plugin_a.cmo test8_plugin_b.cmo";
+   ocamlc.byte;
+
+   program = "${test_build_directory}/test8.byte";
+   unset flags;
+   libraries = "dynlink";
+   all_modules = "test8_main.cmo";
+   ocamlc.byte;
+   run;
  }{
    native-dynlink;
    setup-ocamlopt.byte-build-env;
-   {
-     module = "test8_main.ml";
-     ocamlopt.byte;
-   }{
-     module = "test8_plugin_b.mli";
-     ocamlopt.byte;
-   }{
-     module = "test8_plugin_a.ml";
-     ocamlopt.byte;
-   }{
-     module = "test8_plugin_b.ml";
-     ocamlopt.byte;
-   }{
-     program = "test8_plugin.cmxs";
-     flags = "-shared";
-     all_modules = "test8_plugin_a.cmx test8_plugin_b.cmx";
-     ocamlopt.byte;
-   }{
-     program = "${test_build_directory}/test8.exe";
-     libraries = "dynlink";
-     all_modules = "test8_main.cmx";
-     ocamlopt.byte;
-     run;
-   }
+
+   module = "test8_main.ml";
+   ocamlopt.byte;
+
+   module = "test8_plugin_b.mli";
+   ocamlopt.byte;
+
+   module = "test8_plugin_a.ml";
+   ocamlopt.byte;
+
+   module = "test8_plugin_b.ml";
+   ocamlopt.byte;
+
+   unset module;
+   program = "test8_plugin.cmxs";
+   flags = "-shared";
+   all_modules = "test8_plugin_a.cmx test8_plugin_b.cmx";
+   ocamlopt.byte;
+
+   program = "${test_build_directory}/test8.exe";
+   unset flags;
+   libraries = "dynlink";
+   all_modules = "test8_main.cmx";
+   ocamlopt.byte;
+   run;
  }
 *)
 

--- a/testsuite/tests/lib-dynlink-initializers/test9_main.ml
+++ b/testsuite/tests/lib-dynlink-initializers/test9_main.ml
@@ -5,51 +5,52 @@
  shared-libraries;
  {
    setup-ocamlc.byte-build-env;
-   {
-     module = "test9_second_plugin.mli";
-     ocamlc.byte;
-   }{
-     module = "test9_main.ml";
-     ocamlc.byte;
-   }{
-     module = "test9_plugin.ml";
-     ocamlc.byte;
-   }{
-     module = "test9_second_plugin.ml";
-     ocamlc.byte;
-   }{
-     program = "${test_build_directory}/test9.byte";
-     libraries = "dynlink";
-     all_modules = "test9_main.cmo";
-     ocamlc.byte;
-     run;
-   }
+
+   module = "test9_second_plugin.mli";
+   ocamlc.byte;
+
+   module = "test9_main.ml";
+   ocamlc.byte;
+
+   module = "test9_plugin.ml";
+   ocamlc.byte;
+
+   module = "test9_second_plugin.ml";
+   ocamlc.byte;
+
+   unset module;
+   program = "${test_build_directory}/test9.byte";
+   libraries = "dynlink";
+   all_modules = "test9_main.cmo";
+   ocamlc.byte;
+   run;
  }{
    native-dynlink;
    setup-ocamlopt.byte-build-env;
-   {
-     module = "test9_second_plugin.mli";
-     ocamlopt.byte;
-   }{
-     module = "test9_main.ml";
-     ocamlopt.byte;
-   }{
-     program = "test9_plugin.cmxs";
-     flags = "-shared";
-     all_modules = "test9_plugin.ml";
-     ocamlopt.byte;
-   }{
-     program = "test9_second_plugin.cmxs";
-     flags = "-shared";
-     all_modules = "test9_second_plugin.ml";
-     ocamlopt.byte;
-   }{
-     program = "${test_build_directory}/test9.exe";
-     libraries = "dynlink";
-     all_modules = "test9_main.cmx";
-     ocamlopt.byte;
-     run;
-   }
+
+   module = "test9_second_plugin.mli";
+   ocamlopt.byte;
+
+   module = "test9_main.ml";
+   ocamlopt.byte;
+
+   unset module;
+   program = "test9_plugin.cmxs";
+   flags = "-shared";
+   all_modules = "test9_plugin.ml";
+   ocamlopt.byte;
+
+   program = "test9_second_plugin.cmxs";
+   flags = "-shared";
+   all_modules = "test9_second_plugin.ml";
+   ocamlopt.byte;
+
+   program = "${test_build_directory}/test9.exe";
+   unset flags;
+   libraries = "dynlink";
+   all_modules = "test9_main.cmx";
+   ocamlopt.byte;
+   run;
  }
 *)
 

--- a/testsuite/tests/lib-dynlink-packed/loader.ml
+++ b/testsuite/tests/lib-dynlink-packed/loader.ml
@@ -5,66 +5,62 @@
  shared-libraries;
  {
    setup-ocamlc.byte-build-env;
-   {
-     flags = "-for-pack Packed";
-     module = "a.ml";
-     ocamlc.byte;
-   }{
-     flags = "-for-pack Packed";
-     module = "b.ml";
-     ocamlc.byte;
-   }{
-     program = "packed.cmo";
-     flags = "-pack";
-     all_modules = "a.cmo b.cmo";
-     ocamlc.byte;
-   }{
-     program = "${test_build_directory}/loader.byte";
-     flags = "-linkall";
-     include ocamlcommon;
-     libraries += "dynlink";
-     all_modules = "loader.ml";
-     ocamlc.byte;
-     arguments = "packed.cmo";
-     exit_status = "0";
-     run;
-     reference = "${test_source_directory}/byte.reference";
-     check-program-output;
-   }
+
+   flags = "-for-pack Packed";
+   module = "a.ml";
+   ocamlc.byte;
+   module = "b.ml";
+   ocamlc.byte;
+
+   unset module;
+   program = "packed.cmo";
+   flags = "-pack";
+   all_modules = "a.cmo b.cmo";
+   ocamlc.byte;
+
+   program = "${test_build_directory}/loader.byte";
+   flags = "-linkall";
+   include ocamlcommon;
+   libraries += "dynlink";
+   all_modules = "loader.ml";
+   ocamlc.byte;
+   arguments = "packed.cmo";
+   exit_status = "0";
+   run;
+   reference = "${test_source_directory}/byte.reference";
+   check-program-output;
  }{
    native-dynlink;
    setup-ocamlopt.byte-build-env;
-   {
-     flags = "-for-pack Packed";
-     module = "a.ml";
-     ocamlopt.byte;
-   }{
-     flags = "-for-pack Packed";
-     module = "b.ml";
-     ocamlopt.byte;
-   }{
-     program = "packed.cmx";
-     flags = "-pack";
-     all_modules = "a.cmx b.cmx";
-     ocamlopt.byte;
-   }{
-     program = "plugin.cmxs";
-     flags = "-shared";
-     all_modules = "packed.cmx";
-     ocamlopt.byte;
-   }{
-     program = "${test_build_directory}/loader.exe";
-     flags = "-linkall";
-     include ocamlcommon;
-     libraries += "dynlink";
-     all_modules = "loader.ml";
-     ocamlopt.byte;
-     arguments = "plugin.cmxs";
-     exit_status = "0";
-     run;
-     reference = "${test_source_directory}/native.reference";
-     check-program-output;
-   }
+
+   flags = "-for-pack Packed";
+   module = "a.ml";
+   ocamlopt.byte;
+   module = "b.ml";
+   ocamlopt.byte;
+
+   unset module;
+   program = "packed.cmx";
+   flags = "-pack";
+   all_modules = "a.cmx b.cmx";
+   ocamlopt.byte;
+
+   program = "plugin.cmxs";
+   flags = "-shared";
+   all_modules = "packed.cmx";
+   ocamlopt.byte;
+
+   program = "${test_build_directory}/loader.exe";
+   flags = "-linkall";
+   include ocamlcommon;
+   libraries += "dynlink";
+   all_modules = "loader.ml";
+   ocamlopt.byte;
+   arguments = "plugin.cmxs";
+   exit_status = "0";
+   run;
+   reference = "${test_source_directory}/native.reference";
+   check-program-output;
  }
 *)
 let () =

--- a/testsuite/tests/lib-dynlink-pr4229/main.ml
+++ b/testsuite/tests/lib-dynlink-pr4229/main.ml
@@ -53,24 +53,24 @@
    ocamlopt.byte;
    module = "static.ml";
    ocamlopt.byte;
-   {
-     program = "client.cmxs";
-     flags = "-shared";
-     module = "";
-     all_modules = "client.ml";
-     ocamlopt.byte;
-   }{
-     module = "main.ml";
-     ocamlopt.byte;
-     program = "${test_build_directory}/main_native";
-     libraries = "dynlink";
-     module = "";
-     all_modules = "abstract.cmx static.cmx main.cmx";
-     ocamlopt.byte;
-     exit_status = "2";
-     run;
-     check-program-output;
-   }
+   program = "client.cmxs";
+   flags = "-shared";
+   module = "";
+   all_modules = "client.ml";
+   ocamlopt.byte;
+   module = "main.ml";
+   unset program;
+   unset flags;
+   unset all_modules;
+   ocamlopt.byte;
+   program = "${test_build_directory}/main_native";
+   libraries = "dynlink";
+   module = "";
+   all_modules = "abstract.cmx static.cmx main.cmx";
+   ocamlopt.byte;
+   exit_status = "2";
+   run;
+   check-program-output;
  }
 *)
 


### PR DESCRIPTION
Following up to https://github.com/ocaml/ocaml/pull/12185#issuecomment-1516526837:

A number of test scripts have some parallel blocks that in fact need to be executed in sequence because of dependencies.

While fixing this, I found a rather annoying deficiency of the scripting language: the block structure serves two purposes that should be independent:
- delimiting the scope of variable assignments
- describing the (lack of) dependencies between parts of the script.

I'm not sure if we really want to make changes to the language to address this problem, as it doesn't seem to affect many test scripts.
