### PR TITLE
On Windows, only enable zstd if programs can run

### DIFF
--- a/configure
+++ b/configure
@@ -18867,6 +18867,104 @@ fi
 fi
 fi
 
+# When building the mingw-w64 port in Cygwin, it is very easy to have the
+# library available, but not have the DLL in PATH. This then causes the build to
+# fail as soon as ocamlrun is first executed. This check avoids automatically
+# enabling zstd when the resulting executable doesn't actually work.
+case $host in #(
+  *-w64-mingw32*|*-pc-windows) :
+    if test x"$build" = x"$host"
+then :
+
+      check_zstd_runs=true
+else $as_nop
+
+      case $build in #(
+  *-pc-msys|*-pc-cygwin*) :
+    check_zstd_runs=true ;; #(
+  *) :
+    check_zstd_runs=false ;;
+esac
+
+fi ;; #(
+  *) :
+    check_zstd_runs=false ;;
+esac
+
+if test x"$zstd_status" = "xok"
+then :
+
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether programs linked zstd can execute" >&5
+printf %s "checking whether programs linked zstd can execute... " >&6; }
+  if ! $check_zstd_runs
+then :
+
+    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: skipped" >&5
+printf "%s\n" "skipped" >&6; }
+else $as_nop
+
+
+  saved_CC="$CC"
+  saved_CFLAGS="$CFLAGS"
+  saved_CPPFLAGS="$CPPFLAGS"
+  saved_LIBS="$LIBS"
+  saved_ac_ext="$ac_ext"
+  saved_ac_compile="$ac_compile"
+  # Move the content of confdefs.h to another file so it does not
+  # get included
+  mv confdefs.h confdefs.h.bak
+  touch confdefs.h
+
+    LIBS="$LIBS $zstd_libs"
+    CFLAGS="$CFLAGS $zstd_flags"
+
+  old_cross_compiling="$cross_compiling"
+  if test "x$host_runnable" = 'xtrue'
+then :
+  cross_compiling='no'
+fi
+  if test "$cross_compiling" = yes
+then :
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: skipped" >&5
+printf "%s\n" "skipped" >&6; }
+else $as_nop
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+#include <zstd.h>
+int main(void) {
+  return (ZSTD_versionNumber() == 0);
+}
+
+_ACEOF
+if ac_fn_c_try_run "$LINENO"
+then :
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+printf "%s\n" "yes" >&6; }
+else $as_nop
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
+printf "%s\n" "no" >&6; }
+      zstd_status="programs linked with zstd do not appear to be executable."
+fi
+rm -f core *.core core.conftest.* gmon.out bb.out conftest$ac_exeext \
+  conftest.$ac_objext conftest.beam conftest.$ac_ext
+fi
+
+  cross_compiling="$old_cross_compiling"
+
+
+  # Restore the content of confdefs.h
+  mv confdefs.h.bak confdefs.h
+  ac_compile="$saved_ac_compile"
+  ac_ext="$saved_ac_ext"
+  CPPFLAGS="$saved_CPPFLAGS"
+  CFLAGS="$saved_CFLAGS"
+  CC="$saved_CC"
+  LIBS="$saved_LIBS"
+
+fi
+fi
+
 if test x"$zstd_status" = "xok"
 then :
   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: compressed compilation artefacts supported" >&5

--- a/configure.ac
+++ b/configure.ac
@@ -2285,6 +2285,41 @@ AS_IF([test x"$with_zstd" != "xno"],
         [[#include <zstd.h>]])],
       [zstd_status="zstd library not found"])]))
 
+# When building the mingw-w64 port in Cygwin, it is very easy to have the
+# library available, but not have the DLL in PATH. This then causes the build to
+# fail as soon as ocamlrun is first executed. This check avoids automatically
+# enabling zstd when the resulting executable doesn't actually work.
+AS_CASE([$host],
+  [*-w64-mingw32*|*-pc-windows],
+    [AS_IF([test x"$build" = x"$host"],[
+      check_zstd_runs=true],[
+      AS_CASE([$build],
+       [*-pc-msys|*-pc-cygwin*],
+         [check_zstd_runs=true],
+       [check_zstd_runs=false])
+    ])],
+  [check_zstd_runs=false])
+
+AS_IF([test x"$zstd_status" = "xok"],[
+  AC_MSG_CHECKING([whether programs linked zstd can execute])
+  AS_IF([! $check_zstd_runs],[
+    AC_MSG_RESULT([skipped])],[
+    OCAML_CC_SAVE_VARIABLES
+    LIBS="$LIBS $zstd_libs"
+    CFLAGS="$CFLAGS $zstd_flags"
+    OCAML_RUN_IFELSE(
+      [AC_LANG_SOURCE([[
+#include <zstd.h>
+int main(void) {
+  return (ZSTD_versionNumber() == 0);
+}
+      ]])],
+      [AC_MSG_RESULT([yes])],
+      [AC_MSG_RESULT([no])
+      zstd_status="programs linked with zstd do not appear to be executable."],
+      [AC_MSG_RESULT([skipped])])
+    OCAML_CC_RESTORE_VARIABLES])])
+
 AS_IF([test x"$zstd_status" = "xok"],
   [AC_MSG_NOTICE([compressed compilation artefacts supported])
    internal_cppflags="$internal_cppflags $zstd_flags"


### PR DESCRIPTION
When building the mingw-w64 port in Cygwin, if the mingw64-x86_64-zstd package is installed, then configure will enable compressed artefacts, since the tests will pass. However, ocamlrun et al will only be executable if the sys-root bin directory has been added to PATH, which is not the default.

This PR adds a check for the native Windows port so that compressed artefacts are only automatically enabled if the programs are runnable, in order to detect the failure before the build. If --with-zstd was specified, this test of course causes a hard error.