### PR TITLE
Restore configure-cache compatibility on mingw-w64 / msvc

### DIFF
--- a/Changes
+++ b/Changes
@@ -805,7 +805,7 @@ OCaml 5.2.0
   mechanism `make TARGET_BINDIR=..` no longer works.
   (David Allsopp, review by Damien Doligez, Xavier Leroy and Olivier Nicole)
 
-- #12768: Detect mingw-w64 coupling with GCC or LLVM, detect clang-cl,
+- #12768, #13030: Detect mingw-w64 coupling with GCC or LLVM, detect clang-cl,
   and fix C compiler feature detection on macOS.
   (Antonin Décimo, review by Miod Vallat and Sébastien Hinderer)
 

--- a/aclocal.m4
+++ b/aclocal.m4
@@ -72,11 +72,14 @@ sunc __SUNPRO_C __SUNPRO_C
 unknown
 #endif]
     )],
-    [AC_CACHE_VAL([ocaml_cv_cc_vendor],
-      [ocaml_cv_cc_vendor=`sed -e '/^#/d' conftest.i | tr -s '[:space:]' '-' \
-                             | sed -e 's/^-//' -e 's/-$//'`])],
+    [AC_CACHE_VAL([ocaml_cv_cc_vendor2],
+      [ocaml_cv_cc_vendor2=`sed -e '/^#/d' conftest.i | tr -s '[:space:]' '-' \
+                             | sed -e 's/^-//' -e 's/-$//'`])
+    # Domain of values was changed in #12768, so the cache key became different
+    # from the variable
+    ocaml_cc_vendor="$ocaml_cv_cc_vendor2"],
     [AC_MSG_FAILURE([unexpected preprocessor failure])])
-  AC_MSG_RESULT([$ocaml_cv_cc_vendor])
+  AC_MSG_RESULT([$ocaml_cc_vendor])
 ])
 
 AC_DEFUN([OCAML_SIGNAL_HANDLERS_SEMANTICS], [
@@ -515,8 +518,8 @@ int main (void) {
       [no,*], [hard_error=true],
       [yes,*], [hard_error=false],
       [*,x86_64-w64-mingw32*|*,x86_64-*-cygwin*], [hard_error=false],
-      [AS_CASE([$ocaml_cv_cc_vendor],
-        [msvc-*], [AS_IF([test "${ocaml_cv_cc_vendor#msvc-}" -lt 1920 ],
+      [AS_CASE([$ocaml_cc_vendor],
+        [msvc-*], [AS_IF([test "${ocaml_cc_vendor#msvc-}" -lt 1920 ],
           [hard_error=false],
           [hard_error=true])],
         [hard_error=true])])

--- a/configure
+++ b/configure
@@ -13667,14 +13667,17 @@ unknown
 _ACEOF
 if ac_fn_c_try_cpp "$LINENO"
 then :
-  if test ${ocaml_cv_cc_vendor+y}
+  if test ${ocaml_cv_cc_vendor2+y}
 then :
   printf %s "(cached) " >&6
 else $as_nop
-  ocaml_cv_cc_vendor=`sed -e '/^#/d' conftest.i | tr -s '[:space:]' '-' \
+  ocaml_cv_cc_vendor2=`sed -e '/^#/d' conftest.i | tr -s '[:space:]' '-' \
                              | sed -e 's/^-//' -e 's/-$//'`
 fi
 
+    # Domain of values was changed in #12768, so the cache key became different
+    # from the variable
+    ocaml_cc_vendor="$ocaml_cv_cc_vendor2"
 else $as_nop
   { { printf "%s\n" "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
 printf "%s\n" "$as_me: error: in \`$ac_pwd':" >&2;}
@@ -13682,8 +13685,8 @@ as_fn_error $? "unexpected preprocessor failure
 See \`config.log' for more details" "$LINENO" 5; }
 fi
 rm -f conftest.err conftest.i conftest.$ac_ext
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ocaml_cv_cc_vendor" >&5
-printf "%s\n" "$ocaml_cv_cc_vendor" >&6; }
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ocaml_cc_vendor" >&5
+printf "%s\n" "$ocaml_cc_vendor" >&6; }
 
 
 ## In cross-compilation mode, can we run executables produced?
@@ -13731,7 +13734,7 @@ fi
 # We thus figure out how to invoke the C preprocessor directly but
 # let the CPP variable untouched, except for the MSVC port where we set it
 # manually to make sure the backward compatibility is preserved
-case $ocaml_cv_cc_vendor in #(
+case $ocaml_cc_vendor in #(
   xlc-*) :
     CPP="$CC -E -qnoppline" # suppress incompatible XLC line directives
     ocamltest_CPP="$CPP" ;; #(
@@ -13898,7 +13901,7 @@ fi
 
 ## Determine which flags to use for the C compiler
 
-case $ocaml_cv_cc_vendor in #(
+case $ocaml_cc_vendor in #(
   xlc-*) :
     outputobj='-o '
     warn_error_flag=''
@@ -13973,7 +13976,7 @@ esac
 # Concerning optimization level, -O3 is somewhat risky, so take -O2.
 # Concerning language version, recent enough versions of GCC and Clang
 # default to gnu11 (C11 + GNU extensions) or gnu17, which is fine.
-case $ocaml_cv_cc_vendor in #(
+case $ocaml_cc_vendor in #(
   clang-*) :
     common_cflags="-O2 -fno-strict-aliasing -fwrapv";
     internal_cflags="$cc_warnings -fno-common" ;; #(
@@ -14438,7 +14441,7 @@ esac
 
 mkexe_cmd_exp="$CC"
 
-case $ocaml_cv_cc_vendor,$host in #(
+case $ocaml_cc_vendor,$host in #(
   *,x86_64-*-darwin*) :
     oc_ldflags='-Wl,-no_compact_unwind';
     printf "%s\n" "#define HAS_ARCH_CODE32 1" >>confdefs.h
@@ -15420,7 +15423,7 @@ fi
 
 if ! $arch64
 then :
-  case $ocaml_cv_cc_vendor in #(
+  case $ocaml_cc_vendor in #(
   gcc-*) :
     cclibs="$cclibs -latomic" ;; #(
   *) :
@@ -15512,7 +15515,7 @@ then :
       mkmaindll_exp="flexlink -maindll ${mkdll_flags}"
       mkmaindll="flexlink -maindll ${mkdll_flags}" ;; #(
   powerpc-ibm-aix*) :
-    case $ocaml_cv_cc_vendor in #(
+    case $ocaml_cc_vendor in #(
   xlc*) :
     mkdll_flags='-qmkshrobj -G'
           supports_shared_libraries=true ;; #(
@@ -15528,7 +15531,7 @@ esac ;; #(
   *-*-linux*|*-*-freebsd[3-9]*|*-*-freebsd[1-9][0-9]*\
     |*-*-openbsd*|*-*-netbsd*|*-*-dragonfly*|*-*-gnu*|*-*-haiku*) :
     sharedlib_cflags="-fPIC"
-       case $ocaml_cv_cc_vendor,$host in #(
+       case $ocaml_cc_vendor,$host in #(
   gcc-*,powerpc-*-linux*) :
     mkdll_flags='-shared -mbss-plt' ;; #(
   *,i[3456]86-*) :
@@ -15671,7 +15674,7 @@ case $enable_native_toplevel,$natdynlink in #(
 esac
 
 # Try to work around the Skylake/Kaby Lake processor bug.
-case "$ocaml_cv_cc_vendor,$host" in #(
+case "$ocaml_cc_vendor,$host" in #(
   *gcc*,x86_64-*|*gcc*,i686-*) :
 
   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether the C compiler supports -fno-tree-vrp" >&5
@@ -16029,7 +16032,7 @@ fi
 
 if test -z "$PARTIALLD"
 then :
-  case "$host,$ocaml_cv_cc_vendor" in #(
+  case "$host,$ocaml_cc_vendor" in #(
   x86_64-*-darwin*,gcc-*) :
     PACKLD_FLAGS=' -arch x86_64' ;; #(
   powerpc64le*-*-linux*,gcc-*) :
@@ -16048,7 +16051,7 @@ esac
   # output filename. Don't assume that all C compilers understand GNU -ofoo
   # form, so ensure that the definition includes a space at the end (which is
   # achieved using the $(EMPTY) expansion trick in Makefile.config.in).
-  case "$ocaml_cv_cc_vendor" in #(
+  case "$ocaml_cc_vendor" in #(
   msvc-*) :
     # For the Microsoft C compiler there must be no space at the end of the
       # string.
@@ -16119,7 +16122,7 @@ fi
 default_as="$CC -c"
 default_aspp="$CC -c"
 
-case $as_target,$ocaml_cv_cc_vendor in #(
+case $as_target,$ocaml_cc_vendor in #(
   *-*-linux*,gcc-*) :
     case $as_cpu in #(
   x86_64|arm*|aarch64*|i[3-6]86|riscv*) :
@@ -16413,9 +16416,9 @@ printf "%s\n" "no" >&6; }
   *,x86_64-w64-mingw32*|*,x86_64-*-cygwin*) :
     hard_error=false ;; #(
   *) :
-    case $ocaml_cv_cc_vendor in #(
+    case $ocaml_cc_vendor in #(
   msvc-*) :
-    if test "${ocaml_cv_cc_vendor#msvc-}" -lt 1920
+    if test "${ocaml_cc_vendor#msvc-}" -lt 1920
 then :
   hard_error=false
 else $as_nop
@@ -16443,11 +16446,11 @@ fi
 else $as_nop
   if test x"$enable_imprecise_c99_float_ops" != "xyes"
 then :
-  case $enable_imprecise_c99_float_ops,$ocaml_cv_cc_vendor in #(
+  case $enable_imprecise_c99_float_ops,$ocaml_cc_vendor in #(
   no,*) :
     hard_error=true ;; #(
   ,msvc-*) :
-    if test "${ocaml_cv_cc_vendor#msvc-}" -lt 1800
+    if test "${ocaml_cc_vendor#msvc-}" -lt 1800
 then :
   hard_error=false
 else $as_nop
@@ -16795,11 +16798,11 @@ then :
   amd64) :
     case "$system" in #(
   freebsd|linux|macosx) :
-    case "$ocaml_cv_cc_vendor" in #(
+    case "$ocaml_cc_vendor" in #(
   gcc-*|clang-*) :
     tsan=true ;; #(
   *) :
-    as_fn_error $? "thread sanitizer not supported with vendor=$ocaml_cv_cc_vendor\"" "$LINENO" 5
+    as_fn_error $? "thread sanitizer not supported with vendor=$ocaml_cc_vendor\"" "$LINENO" 5
           ;;
 esac ;; #(
   *) :
@@ -16809,11 +16812,11 @@ esac ;; #(
   arm64) :
     case "$system" in #(
   linux|macosx) :
-    case "$ocaml_cv_cc_vendor" in #(
+    case "$ocaml_cc_vendor" in #(
   gcc-*|clang-*) :
     tsan=true ;; #(
   *) :
-    as_fn_error $? "thread sanitizer not supported with vendor=$ocaml_cv_cc_vendor\"" "$LINENO" 5
+    as_fn_error $? "thread sanitizer not supported with vendor=$ocaml_cc_vendor\"" "$LINENO" 5
           ;;
 esac ;; #(
   *) :
@@ -16823,11 +16826,11 @@ esac ;; #(
   power) :
     case "$system" in #(
   linux) :
-    case "$ocaml_cv_cc_vendor" in #(
+    case "$ocaml_cc_vendor" in #(
   gcc-*|clang-*) :
     tsan=true ;; #(
   *) :
-    as_fn_error $? "thread sanitizer not supported with vendor=$ocaml_cv_cc_vendor\"" "$LINENO" 5
+    as_fn_error $? "thread sanitizer not supported with vendor=$ocaml_cc_vendor\"" "$LINENO" 5
           ;;
 esac ;; #(
   *) :
@@ -16837,11 +16840,11 @@ esac ;; #(
   riscv) :
     case "$system" in #(
   linux) :
-    case "$ocaml_cv_cc_vendor" in #(
+    case "$ocaml_cc_vendor" in #(
   gcc-*|clang-*) :
     tsan=true ;; #(
   *) :
-    as_fn_error $? "thread sanitizer not supported with vendor=$ocaml_cv_cc_vendor\"" "$LINENO" 5
+    as_fn_error $? "thread sanitizer not supported with vendor=$ocaml_cc_vendor\"" "$LINENO" 5
           ;;
 esac ;; #(
   *) :
@@ -16851,11 +16854,11 @@ esac ;; #(
   s390x) :
     case "$system" in #(
   linux) :
-    case "$ocaml_cv_cc_vendor" in #(
+    case "$ocaml_cc_vendor" in #(
   gcc-*|clang-*) :
     tsan=true ;; #(
   *) :
-    as_fn_error $? "thread sanitizer not supported with vendor=$ocaml_cv_cc_vendor\"" "$LINENO" 5
+    as_fn_error $? "thread sanitizer not supported with vendor=$ocaml_cc_vendor\"" "$LINENO" 5
           ;;
 esac ;; #(
   *) :
@@ -16872,8 +16875,8 @@ fi
 
 if $tsan
 then :
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: using thread sanitizer with vendor=$ocaml_cv_cc_vendor" >&5
-printf "%s\n" "$as_me: using thread sanitizer with vendor=$ocaml_cv_cc_vendor" >&6;}
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: using thread sanitizer with vendor=$ocaml_cc_vendor" >&5
+printf "%s\n" "$as_me: using thread sanitizer with vendor=$ocaml_cc_vendor" >&6;}
 
   # Check for libtsan library files (necessary on some Linux distributions)
   SAVED_LDFLAGS="$LDFLAGS"
@@ -16900,13 +16903,13 @@ rm -f core conftest.err conftest.$ac_objext conftest.beam \
     conftest$ac_exeext conftest.$ac_ext
   LDFLAGS="$SAVED_LDFLAGS"
 
-  case $ocaml_cv_cc_vendor in #(
+  case $ocaml_cc_vendor in #(
   gcc-[0123456789]-*|gcc-10-*|clang-*) :
      ;; #(
   *) :
     oc_tsan_cflags="$oc_tsan_cflags -Wno-tsan" ;;
 esac
-  case $ocaml_cv_cc_vendor in #(
+  case $ocaml_cc_vendor in #(
   gcc*) :
     tsan_distinguish_volatile_cflags="--param=tsan-distinguish-volatile=1" ;; #(
   clang*) :
@@ -18071,7 +18074,7 @@ fi
 
 
 ## -fdebug-prefix-map support by the C compiler
-case $ocaml_cv_cc_vendor,$host in #(
+case $ocaml_cc_vendor,$host in #(
   *,*-*-mingw32*) :
     cc_has_debug_prefix_map=false ;; #(
   *,*-pc-windows) :
@@ -20005,7 +20008,7 @@ fi
 
 if test x"$enable_frame_pointers" = "xyes"
 then :
-  case "$host,$ocaml_cv_cc_vendor" in #(
+  case "$host,$ocaml_cc_vendor" in #(
   x86_64-*-linux*,gcc-*|x86_64-*-linux*,clang-*) :
     common_cflags="$common_cflags -g  -fno-omit-frame-pointer"
       frame_pointers=true
@@ -20357,7 +20360,7 @@ else $as_nop
            { printf "%s\n" "$as_me:${as_lineno-$LINENO}: No support for function sections on $target." >&5
 printf "%s\n" "$as_me: No support for function sections on $target." >&6;} ;; #(
   *) :
-    case $ocaml_cv_cc_vendor in #(
+    case $ocaml_cc_vendor in #(
   gcc-0123-*|gcc-4-01234567) :
     function_sections=false;
             { printf "%s\n" "$as_me:${as_lineno-$LINENO}: Function sections are not
@@ -20379,9 +20382,9 @@ printf "%s\n" "$as_me: Function sections are not supported
   *) :
     function_sections=false;
           { printf "%s\n" "$as_me:${as_lineno-$LINENO}: Function sections are not supported by
-          $ocaml_cv_cc_vendor." >&5
+          $ocaml_cc_vendor." >&5
 printf "%s\n" "$as_me: Function sections are not supported by
-          $ocaml_cv_cc_vendor." >&6;} ;;
+          $ocaml_cc_vendor." >&6;} ;;
 esac ;;
 esac ;; #(
   *) :

--- a/configure.ac
+++ b/configure.ac
@@ -667,7 +667,7 @@ OCAML_HOST_IS_EXECUTABLE
 # We thus figure out how to invoke the C preprocessor directly but
 # let the CPP variable untouched, except for the MSVC port where we set it
 # manually to make sure the backward compatibility is preserved
-AS_CASE([$ocaml_cv_cc_vendor],
+AS_CASE([$ocaml_cc_vendor],
   [xlc-*],
     [CPP="$CC -E -qnoppline" # suppress incompatible XLC line directives
     ocamltest_CPP="$CPP"],
@@ -801,7 +801,7 @@ AS_IF(
 
 ## Determine which flags to use for the C compiler
 
-AS_CASE([$ocaml_cv_cc_vendor],
+AS_CASE([$ocaml_cc_vendor],
   [xlc-*],
     [outputobj='-o '
     warn_error_flag=''
@@ -833,7 +833,7 @@ AS_CASE([$enable_warn_error,OCAML__DEVELOPMENT_VERSION],
 # Concerning optimization level, -O3 is somewhat risky, so take -O2.
 # Concerning language version, recent enough versions of GCC and Clang
 # default to gnu11 (C11 + GNU extensions) or gnu17, which is fine.
-AS_CASE([$ocaml_cv_cc_vendor],
+AS_CASE([$ocaml_cc_vendor],
   [clang-*],
     [common_cflags="-O2 -fno-strict-aliasing -fwrapv";
     internal_cflags="$cc_warnings -fno-common"],
@@ -1016,7 +1016,7 @@ AS_CASE([$flexdll_source_dir,$supports_shared_libraries,$flexlink,$host],
 
 mkexe_cmd_exp="$CC"
 
-AS_CASE([$ocaml_cv_cc_vendor,$host],
+AS_CASE([$ocaml_cc_vendor,$host],
   [*,x86_64-*-darwin*],
     [oc_ldflags='-Wl,-no_compact_unwind';
     AC_DEFINE([HAS_ARCH_CODE32], [1])],
@@ -1204,7 +1204,7 @@ AS_IF([! $arch64],
 # Atomics library
 
 AS_IF([! $arch64],
-  [AS_CASE([$ocaml_cv_cc_vendor],
+  [AS_CASE([$ocaml_cc_vendor],
     [gcc-*], [cclibs="$cclibs -latomic"])])
 
 # Support for C11 atomic types
@@ -1247,7 +1247,7 @@ AS_IF([test x"$enable_shared" != "xno"],
       mkmaindll_exp="flexlink -maindll ${mkdll_flags}"
       mkmaindll="flexlink -maindll ${mkdll_flags}"],
     [powerpc-ibm-aix*],
-      [AS_CASE([$ocaml_cv_cc_vendor],
+      [AS_CASE([$ocaml_cc_vendor],
         [xlc*],
           [mkdll_flags='-qmkshrobj -G'
           supports_shared_libraries=true])],
@@ -1260,7 +1260,7 @@ AS_IF([test x"$enable_shared" != "xno"],
     [[*-*-linux*|*-*-freebsd[3-9]*|*-*-freebsd[1-9][0-9]*\
     |*-*-openbsd*|*-*-netbsd*|*-*-dragonfly*|*-*-gnu*|*-*-haiku*]],
       [sharedlib_cflags="-fPIC"
-       AS_CASE([$ocaml_cv_cc_vendor,$host],
+       AS_CASE([$ocaml_cc_vendor,$host],
          [gcc-*,powerpc-*-linux*],
            [mkdll_flags='-shared -mbss-plt'],
          [[*,i[3456]86-*]],
@@ -1348,7 +1348,7 @@ AS_CASE([$enable_native_toplevel,$natdynlink],
   [install_ocamlnat=false])
 
 # Try to work around the Skylake/Kaby Lake processor bug.
-AS_CASE(["$ocaml_cv_cc_vendor,$host"],
+AS_CASE(["$ocaml_cc_vendor,$host"],
   [*gcc*,x86_64-*|*gcc*,i686-*],
     [OCAML_CC_HAS_FNO_TREE_VRP
     AS_IF([$cc_has_fno_tree_vrp],
@@ -1508,7 +1508,7 @@ AC_DEFINE_UNQUOTED([OCAML_OS_TYPE], ["$ostype"])
 
 AC_CHECK_TOOL([DIRECT_LD],[ld])
 AS_IF([test -z "$PARTIALLD"],
-  [AS_CASE(["$host,$ocaml_cv_cc_vendor"],
+  [AS_CASE(["$host,$ocaml_cc_vendor"],
     [x86_64-*-darwin*,gcc-*], [PACKLD_FLAGS=' -arch x86_64'],
     [powerpc64le*-*-linux*,gcc-*], [PACKLD_FLAGS=' -m elf64lppc'],
     [powerpc*-*-linux*,gcc-*],
@@ -1520,7 +1520,7 @@ AS_IF([test -z "$PARTIALLD"],
   # output filename. Don't assume that all C compilers understand GNU -ofoo
   # form, so ensure that the definition includes a space at the end (which is
   # achieved using the $(EMPTY) expansion trick in Makefile.config.in).
-  AS_CASE(["$ocaml_cv_cc_vendor"],
+  AS_CASE(["$ocaml_cc_vendor"],
     [msvc-*],
       # For the Microsoft C compiler there must be no space at the end of the
       # string.
@@ -1576,7 +1576,7 @@ AS_IF([test -n "$target_alias"],
 default_as="$CC -c"
 default_aspp="$CC -c"
 
-AS_CASE([$as_target,$ocaml_cv_cc_vendor],
+AS_CASE([$as_target,$ocaml_cc_vendor],
   [*-*-linux*,gcc-*],
     [AS_CASE([$as_cpu],
       [x86_64|arm*|aarch64*|i[[3-6]]86|riscv*],
@@ -1628,9 +1628,9 @@ AS_IF([$has_c99_float_ops],
   # in VS2013-2017 and present but unimplemented in Cygwin64)
   OCAML_C99_CHECK_FMA],
   [AS_IF([test x"$enable_imprecise_c99_float_ops" != "xyes" ],
-    [AS_CASE([$enable_imprecise_c99_float_ops,$ocaml_cv_cc_vendor],
+    [AS_CASE([$enable_imprecise_c99_float_ops,$ocaml_cc_vendor],
       [no,*], [hard_error=true],
-      [,msvc-*], [AS_IF([test "${ocaml_cv_cc_vendor#msvc-}" -lt 1800 ],
+      [,msvc-*], [AS_IF([test "${ocaml_cc_vendor#msvc-}" -lt 1800 ],
         [hard_error=false],
         [hard_error=true])],
       [hard_error=true])
@@ -1760,50 +1760,50 @@ AS_IF([test "x$enable_tsan" = "xyes" ],
     [amd64],
       [AS_CASE(["$system"],
         [freebsd|linux|macosx],
-        [AS_CASE(["$ocaml_cv_cc_vendor"],
+        [AS_CASE(["$ocaml_cc_vendor"],
           [gcc-*|clang-*], [tsan=true],
           [AC_MSG_ERROR(m4_normalize([thread sanitizer not supported with
-            vendor=$ocaml_cv_cc_vendor"]))]
+            vendor=$ocaml_cc_vendor"]))]
          )],
         [AC_MSG_ERROR([thread sanitizer not supported on system $system])]
        )],
     [arm64],
       [AS_CASE(["$system"],
         [linux|macosx],
-        [AS_CASE(["$ocaml_cv_cc_vendor"],
+        [AS_CASE(["$ocaml_cc_vendor"],
           [gcc-*|clang-*], [tsan=true],
           [AC_MSG_ERROR(m4_normalize([thread sanitizer not supported with
-            vendor=$ocaml_cv_cc_vendor"]))]
+            vendor=$ocaml_cc_vendor"]))]
          )],
         [AC_MSG_ERROR([thread sanitizer not supported on system $system])]
        )],
     [power],
       [AS_CASE(["$system"],
         [linux],
-        [AS_CASE(["$ocaml_cv_cc_vendor"],
+        [AS_CASE(["$ocaml_cc_vendor"],
           [gcc-*|clang-*], [tsan=true],
           [AC_MSG_ERROR(m4_normalize([thread sanitizer not supported with
-            vendor=$ocaml_cv_cc_vendor"]))]
+            vendor=$ocaml_cc_vendor"]))]
          )],
         [AC_MSG_ERROR([thread sanitizer not supported on system $system])]
        )],
     [riscv],
       [AS_CASE(["$system"],
         [linux],
-        [AS_CASE(["$ocaml_cv_cc_vendor"],
+        [AS_CASE(["$ocaml_cc_vendor"],
           [gcc-*|clang-*], [tsan=true],
           [AC_MSG_ERROR(m4_normalize([thread sanitizer not supported with
-            vendor=$ocaml_cv_cc_vendor"]))]
+            vendor=$ocaml_cc_vendor"]))]
          )],
         [AC_MSG_ERROR([thread sanitizer not supported on system $system])]
        )],
     [s390x],
       [AS_CASE(["$system"],
         [linux],
-        [AS_CASE(["$ocaml_cv_cc_vendor"],
+        [AS_CASE(["$ocaml_cc_vendor"],
           [gcc-*|clang-*], [tsan=true],
           [AC_MSG_ERROR(m4_normalize([thread sanitizer not supported with
-            vendor=$ocaml_cv_cc_vendor"]))]
+            vendor=$ocaml_cc_vendor"]))]
          )],
         [AC_MSG_ERROR([thread sanitizer not supported on system $system])]
        )],
@@ -1812,7 +1812,7 @@ AS_IF([test "x$enable_tsan" = "xyes" ],
   [tsan=false])
 
 AS_IF([$tsan],
-  [AC_MSG_NOTICE([using thread sanitizer with vendor=$ocaml_cv_cc_vendor])
+  [AC_MSG_NOTICE([using thread sanitizer with vendor=$ocaml_cc_vendor])
 
   # Check for libtsan library files (necessary on some Linux distributions)
   SAVED_LDFLAGS="$LDFLAGS"
@@ -1824,11 +1824,11 @@ AS_IF([$tsan],
                    Try installing it on your system.])])
   LDFLAGS="$SAVED_LDFLAGS"
 
-  AS_CASE([$ocaml_cv_cc_vendor],
+  AS_CASE([$ocaml_cc_vendor],
     [gcc-[[0123456789]]-*|gcc-10-*|clang-*],
       [],
     [oc_tsan_cflags="$oc_tsan_cflags -Wno-tsan"])
-  AS_CASE([$ocaml_cv_cc_vendor],
+  AS_CASE([$ocaml_cc_vendor],
     [gcc*],
       [tsan_distinguish_volatile_cflags="--param=tsan-distinguish-volatile=1"],
     [clang*],
@@ -2155,7 +2155,7 @@ AC_CHECK_HEADER([sys/mman.h],
 AC_CHECK_FUNC([pwrite], [AC_DEFINE([HAS_PWRITE])])
 
 ## -fdebug-prefix-map support by the C compiler
-AS_CASE([$ocaml_cv_cc_vendor,$host],
+AS_CASE([$ocaml_cc_vendor,$host],
   [*,*-*-mingw32*], [cc_has_debug_prefix_map=false],
   [*,*-pc-windows], [cc_has_debug_prefix_map=false],
   [xlc*,powerpc-ibm-aix*], [cc_has_debug_prefix_map=false],
@@ -2396,7 +2396,7 @@ AS_IF([$native_compiler],
 ## Frame pointers
 
 AS_IF([test x"$enable_frame_pointers" = "xyes"],
-  [AS_CASE(["$host,$ocaml_cv_cc_vendor"],
+  [AS_CASE(["$host,$ocaml_cc_vendor"],
     [x86_64-*-linux*,gcc-*|x86_64-*-linux*,clang-*],
       [common_cflags="$common_cflags -g  -fno-omit-frame-pointer"
       frame_pointers=true
@@ -2520,7 +2520,7 @@ AS_IF([test x"$enable_function_sections" = "xno"],
         [*-cygwin*|*-mingw*|*-windows|*-apple-darwin*],
           [function_sections=false;
            AC_MSG_NOTICE([No support for function sections on $target.])],
-        [AS_CASE([$ocaml_cv_cc_vendor],
+        [AS_CASE([$ocaml_cc_vendor],
           [gcc-[0123]-*|gcc-4-[01234567]],
             [function_sections=false;
             AC_MSG_NOTICE([Function sections are not
@@ -2536,7 +2536,7 @@ AS_IF([test x"$enable_function_sections" = "xno"],
             AC_DEFINE([FUNCTION_SECTIONS])],
           [function_sections=false;
           AC_MSG_NOTICE([Function sections are not supported by
-          $ocaml_cv_cc_vendor.])])])],
+          $ocaml_cc_vendor.])])])],
     [function_sections=false]);
   AS_IF([test x"$function_sections" = "xfalse"],
     [AS_IF([test x"$enable_function_sections" = "xyes"],


### PR DESCRIPTION
#12768 improved the domain of values for `$ocaml_cv_cc_vendor`, but this had the side-effect that configure caches don't work across the change. This was mitigated in #12701, but I missed the other thing which should have been altered in the original PR - we should have changed the key being used in the cache!

autoconf will cache _all_ variables containing `_cv_` in their name, so this PR becomes noisy as it has to rename `$ocaml_cv_cc_vendor` to `$ocaml_cc_vendor`.

`configure` runs extemely slowly under Cygwin, so having to erase configure caches when switch to (not that old) maintenance branches or when bisecting is a bit painful. With this commit, there's just a fairly small bubble of trunk where that would matter in future.