### PR TITLE
manual: remove empty syntax block for lazy patterns

### DIFF
--- a/manual/src/refman/patterns.etex
+++ b/manual/src/refman/patterns.etex
@@ -295,10 +295,6 @@ let classify_char = function
 
 (Introduced in Objective Caml 3.11)
 
-\begin{syntax}
-pattern: ...
-\end{syntax}
-
 The pattern @"lazy" pattern@ matches a value \var{v} of type "Lazy.t",
 provided @pattern@ matches the result of forcing \var{v} with
 "Lazy.force". A successful match of a pattern containing @"lazy"@


### PR DESCRIPTION
This became empty in #2198 when lazy patterns were moved to core.