### PR TITLE
Manual: caution about custom block finalizers

### DIFF
--- a/Changes
+++ b/Changes
@@ -70,6 +70,9 @@ _______________
   webman/<version>/api/ for OCaml.org HTML manual generation
   (Shakthi Kannan, review by Hannes Mehnert, and Florian Angeletti)
 
+- #13045: Emphasize caution about behaviour of custom block finalizers.
+  (Nick Barnes)
+
 ### Compiler user-interface and warnings:
 
 * #12084: Check link order when creating archive and when using ocamlopt

--- a/manual/src/cmds/intf-c.etex
+++ b/manual/src/cmds/intf-c.etex
@@ -1936,6 +1936,11 @@ when the block becomes unreachable and is about to be reclaimed.
 The block is passed as first argument to the function.
 The "finalize" field can also be "custom_finalize_default" to indicate that no
 finalization function is associated with the block.
+Note the caution below: there are many restrictions on the behaviour
+of these custom block finalizers; they must not allocate on the Caml
+heap, or call OCaml code or allow it to be called (for example, they
+should not call "caml_release_runtime_system()"). For more powerful
+and flexible finalization, use "Gc.finalise" (see \stdmoduleref{Gc}).
 
 \item "int (*compare)(value v1, value v2)" \\
 The "compare" field contains a pointer to a C function that is
@@ -2025,7 +2030,7 @@ specified in the "fixed_length" structure, and do not consume space in
 the serialized output.
 \end{itemize}
 
-Note: the "finalize", "compare", "hash", "serialize", and "deserialize"
+\emph{Caution}: the "finalize", "compare", "hash", "serialize", and "deserialize"
 functions attached to custom blocks descriptors are only allowed limited
 interactions with the OCaml runtime. Within these functions, do not call any of
 the OCaml allocation functions, and do not perform any callback into OCaml


### PR DESCRIPTION
Small change to the manual emphasizing the existing warning about behaviour of custom block finalizers. Fixes #12820, in the sense that the problem there was caused by a finalizer calling `caml_enter_blocking_section()`.

[edited to remove question answered by @shindere in comments]