### PR TITLE
Use the best native compiler available to build ocaml{doc,test}.opt

### DIFF
--- a/Changes
+++ b/Changes
@@ -798,7 +798,7 @@ OCaml 5.2.0
 
 ### Build system:
 
-- #12198, #12321, #12586, #12616, #12706: continue the merge of the
+- #12198, #12321, #12586, #12616, #12706, #13048: continue the merge of the
   sub-makefiles into the root Makefile started with #11243, #11248,
   #11268, #11420 and #11675.
   (Sébastien Hinderer, review by David Allsopp and Florian Angeletti)

--- a/Makefile
+++ b/Makefile
@@ -1768,7 +1768,7 @@ ocamldoc/ocamldoc$(EXE): ocamlc ocamlyacc ocamllex
 .PHONY: ocamldoc.opt
 ocamldoc.opt: ocamldoc/ocamldoc.opt$(EXE)
 
-ocamldoc/ocamldoc.opt$(EXE): ocamlc.opt ocamlyacc ocamllex
+ocamldoc/ocamldoc.opt$(EXE): ocamlopt ocamlyacc ocamllex
 
 # OCamltest
 
@@ -1893,7 +1893,7 @@ ocamltest/ocamltest$(EXE): ocamlc ocamlyacc ocamllex
 ocamltest.opt: ocamltest/ocamltest.opt$(EXE) \
   testsuite/lib/testing.cmxa $(asmgen_OBJECT) testsuite/tools/codegen$(EXE)
 
-ocamltest/ocamltest.opt$(EXE): ocamlc.opt ocamlyacc ocamllex
+ocamltest/ocamltest.opt$(EXE): ocamlopt ocamlyacc ocamllex
 
 # ocamltest does _not_ want to have access to the Unix interface by default,
 # to ensure functions and types are only used via Ocamltest_stdlib.Unix

--- a/Makefile
+++ b/Makefile
@@ -1760,6 +1760,8 @@ OCAMLDOC_LIBCMTS=$(OCAMLDOC_LIBMLIS:.mli=.cmt) $(OCAMLDOC_LIBMLIS:.mli=.cmti)
 
 ocamldoc/%: CAMLC = $(BEST_OCAMLC) $(STDLIBFLAGS)
 
+ocamldoc/%: CAMLOPT = $(BEST_OCAMLOPT) $(STDLIBFLAGS)
+
 .PHONY: ocamldoc
 ocamldoc: ocamldoc/ocamldoc$(EXE) ocamldoc/odoc_test.cmo
 
@@ -1847,6 +1849,8 @@ $(ocamltest_DEP_FILES): $(DEPDIR)/ocamltest/%.$(D): ocamltest/%.c
 	$(V_CCDEPS)$(DEP_CC) $(OC_CPPFLAGS) $(CPPFLAGS) $< -MT '$*.$(O)' -MF $@
 
 ocamltest/%: CAMLC = $(BEST_OCAMLC) $(STDLIBFLAGS)
+
+ocamltest/%: CAMLOPT = $(BEST_OCAMLOPT) $(STDLIBFLAGS)
 
 ocamltest: ocamltest/ocamltest$(EXE) \
   testsuite/lib/lib.cmo testsuite/lib/testing.cma testsuite/tools/expect$(EXE)


### PR DESCRIPTION
This fixes issue #12921 by re-introducing the use of the `BEST_OCAMLOPT`
mechanism which had been forgotten during the merge of the corresponding
makefiles into the root one (second commit of this pull request).

The first commit fixes the dependencies of ocamldoc.opt and ocamltest.opt:
these two native programs were depending on ocamlc.opt, which is obviously
incorrect. This error seems to have been there from the beginning, see
commit 8486ca3e4 where there is likely a copy paste error between the
targets for ocamldoc and ocamldoc.opt, many thanks to @dra27 for
having done the investigation.