### PR TITLE
Add a "Syntax error" to a syntax error message that didn't have that information

### DIFF
--- a/Changes
+++ b/Changes
@@ -72,6 +72,9 @@ _______________
 - #12985, #12988: Better error messages for partially applied functors.
   (Florian Angeletti, report by Arthur Wendling, review by Gabriel Scherer)
 
+- #13051: Add a "Syntax error" to error messages for invalid package signatures.
+  (Samuel Vivien, review by Gabriel Scherer)
+
 ### Internal/compiler-libs changes:
 
 - #11129, #11148: enforce that ppxs do not produce `parsetree`s with

--- a/parsing/parse.ml
+++ b/parsing/parse.ml
@@ -161,7 +161,7 @@ let prepare_error err =
               "only module type identifier and %a constraints are supported"
               Style.inline_code "with type"
       in
-      Location.errorf ~loc "invalid package type: %a" invalid ipt
+      Location.errorf ~loc "Syntax error: invalid package type: %a" invalid ipt
   | Removed_string_set loc ->
       Location.errorf ~loc
         "Syntax error: strings are immutable, there is no assignment \

--- a/testsuite/tests/parse-errors/unclosed_simple_pattern.compilers.reference
+++ b/testsuite/tests/parse-errors/unclosed_simple_pattern.compilers.reference
@@ -25,7 +25,7 @@ Line 3, characters 4-5:
 Line 6, characters 18-25:
 6 |   | (module Foo : sig end
                       ^^^^^^^
-Error: invalid package type: only module type identifier and "with type" constraints are supported
+Error: Syntax error: invalid package type: only module type identifier and "with type" constraints are supported
 Line 7, characters 0-2:
 7 | ;;
     ^^


### PR DESCRIPTION
This PR just adds a `Syntax error:` to an error message to help people understand where this error is coming from.