### PR TITLE
recmod: check consistency before subtyping (#12959)

### DIFF
--- a/Changes
+++ b/Changes
@@ -96,6 +96,9 @@ _______________
 - #12968: Attach location to constants in the parsetree
   (Jules Aguillon, review by Gabriel Scherer)
 
+- #12959, #13055: Avoid an internal error on recursive module type inconsistency
+  (Florian Angeletti, review by Jacques Garrigue and Gabriel Scherer)
+
 ### Build system:
 
 - #12909: Reorganise how MKEXE_VIA_CC is built to make it correct for MSVC by

--- a/testsuite/tests/typing-recmod/inconsistent_types.ml
+++ b/testsuite/tests/typing-recmod/inconsistent_types.ml
@@ -1,0 +1,92 @@
+(* TEST
+  expect;
+*)
+
+(* PR#12959  *)
+
+module rec A: sig
+  val x: 'a B.t -> unit
+end = struct
+  let x _ = ()
+end
+and B: sig
+  type +'a t
+end = struct
+  type t
+end
+  [%%expect {|
+Line 1:
+Error: Modules do not match:
+         sig type t end
+       is not included in
+         sig type +'a t end
+       Type declarations do not match: type t is not included in type +'a t
+       They have different arities.
+|}]
+
+module rec A: sig
+  val x: 'a F(B).t -> unit
+end = struct
+  let x _ = ()
+end
+and B: sig
+  type 'a t
+  type x
+end = struct
+  type 'a t
+  type x
+end
+and F: functor(X:sig type x end) -> sig type 'a t = 'a * X.x end =
+  functor(X:sig type y end) -> struct type t = int end
+  [%%expect {|
+Line 1:
+Error: Modules do not match:
+         functor (X : $S1) -> ...
+       is not included in
+         functor (X : $T1) -> ...
+       Module types do not match:
+         $S1 = sig type y end
+       does not include
+         $T1 = sig type x end
+       The type "y" is required but not provided
+|}]
+
+module type S = sig type 'a t end
+module rec A: sig val x: 'a B.t -> unit end = struct
+        let x _ = ()
+end
+and B : S = struct type t end;;
+[%%expect {|
+module type S = sig type 'a t end
+Line 1:
+Error: Modules do not match: sig type t end is not included in S
+       Type declarations do not match: type t is not included in type 'a t
+       They have different arities.
+|}]
+
+module rec A: sig val x: 'a B.M.t -> unit end = struct
+  let x _ = ()
+end
+and B: sig module type S=sig type 'a t end module M:S end = struct
+        module type S = sig type t end
+        module M: S = struct type t end
+       end
+[%%expect {|
+Line 1:
+Error: Modules do not match:
+         sig module type S = sig type t end module M : S end
+       is not included in
+         sig module type S = sig type 'a t end module M : S end
+       Module type declarations do not match:
+         module type S = sig type t end
+       does not match
+         module type S = sig type 'a t end
+       At position "module type S = <here>"
+       Module types do not match:
+         sig type t end
+       is not equal to
+         sig type 'a t end
+       At position "module type S = <here>"
+       Type declarations do not match: type t is not included in type 'a t
+       They have different arities.
+|}]

--- a/typing/includecore.ml
+++ b/typing/includecore.ml
@@ -70,6 +70,10 @@ type value_mismatch =
 
 exception Dont_match of value_mismatch
 
+(* A value description [vd1] is consistent with the value description [vd2] if
+   there is a context E such that [E |- vd1 <: vd2] for the ordinary subtyping.
+   For values, this is the case as soon as the kind of [vd1] is a subkind of the
+   [vd2] kind. *)
 let value_descriptions_consistency env vd1 vd2 =
   match (vd1.val_kind, vd2.val_kind) with
   | (Val_prim p1, Val_prim p2) -> begin
@@ -913,6 +917,11 @@ let type_manifest env ty1 params1 ty2 params2 priv2 kind2 =
       | () -> None
     end
 
+(* A type declarations [td1] is consistent with the type declaration [td2] if
+   there is a context E such E |- td1 <: td2 for the ordinary subtyping. For
+   types, this is the case as soon as the two type declarations share the same
+   arity and the privacy of [td1] is less than the privacy of [td2] (consider a
+   context E where all type constructors are equal). *)
 let type_declarations_consistency env decl1 decl2 =
   if decl1.type_arity <> decl2.type_arity then Some Arity
   else match privacy_mismatch env decl1 decl2 with

--- a/typing/includecore.mli
+++ b/typing/includecore.mli
@@ -104,9 +104,15 @@ type type_mismatch =
   | Unboxed_representation of position
   | Immediate of Type_immediacy.Violation.t
 
+val value_descriptions_consistency:
+  Env.t -> value_description -> value_description -> module_coercion
+
 val value_descriptions:
   loc:Location.t -> Env.t -> string ->
   value_description -> value_description -> module_coercion
+
+val type_declarations_consistency:
+  Env.t -> type_declaration -> type_declaration -> type_mismatch option
 
 val type_declarations:
   ?equality:bool ->

--- a/typing/includecore.mli
+++ b/typing/includecore.mli
@@ -104,15 +104,9 @@ type type_mismatch =
   | Unboxed_representation of position
   | Immediate of Type_immediacy.Violation.t
 
-val value_descriptions_consistency:
-  Env.t -> value_description -> value_description -> module_coercion
-
 val value_descriptions:
   loc:Location.t -> Env.t -> string ->
   value_description -> value_description -> module_coercion
-
-val type_declarations_consistency:
-  Env.t -> type_declaration -> type_declaration -> type_mismatch option
 
 val type_declarations:
   ?equality:bool ->
@@ -124,6 +118,21 @@ val extension_constructors:
   loc:Location.t -> Env.t -> mark:bool -> Ident.t ->
   extension_constructor -> extension_constructor ->
   extension_constructor_mismatch option
+
+(** The functions [value_descriptions_consistency] and
+    [type_declarations_consistency] check if two declaration are consistent.
+    Declarations are consistent when there exists an environment such that the
+    first declaration is a subtype of the second one.
+
+    Notably, if a type declaration [td1] is consistent with [td2] then a type
+    expression [te] which is well-formed with the [td2] declaration in scope
+    is still well-formed with the [td1] declaration: [E, td2 |- te] => [E, td1
+    |- te]. *)
+val value_descriptions_consistency:
+  Env.t -> value_description -> value_description -> module_coercion
+val type_declarations_consistency:
+  Env.t -> type_declaration -> type_declaration -> type_mismatch option
+
 (*
 val class_types:
         Env.t -> class_type -> class_type -> bool

--- a/typing/includemod.ml
+++ b/typing/includemod.ml
@@ -408,11 +408,17 @@ module Sign_diff = struct
     }
 end
 
-(** Core type system subtyping relation *)
+(** Core type system subtyping-like relation that we want to lift at the module
+    level. We have two relations that we want to lift:
+
+  - the normal subtyping relation [<:].
+  - the coarse-grain consistency relation [C], which is defined by
+   [d1 C d2] if there is an environment [E] such that [E |- d1 <: d2]. *)
 type 'a core_incl =
   loc:Location.t -> Env.t -> mark:mark -> Subst.t -> Ident.t ->
   'a -> 'a -> (module_coercion, Error.sigitem_symptom) result
-type core_inclusion = {
+
+type core_relation = {
   value_descriptions: Types.value_description core_incl;
   type_declarations: Types.type_declaration core_incl;
   extension_constructors: Types.extension_constructor core_incl;

--- a/typing/includemod.mli
+++ b/typing/includemod.mli
@@ -155,6 +155,10 @@ val modtypes:
   loc:Location.t -> Env.t -> mark:mark ->
   module_type -> module_type -> module_coercion
 
+
+val modtypes_consistency:
+  loc:Location.t -> Env.t -> module_type -> module_type -> unit
+
 val modtypes_with_shape:
   shape:Shape.t -> loc:Location.t -> Env.t -> mark:mark ->
   module_type -> module_type -> module_coercion * Shape.t

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -2722,6 +2722,8 @@ and type_structure ?(toplevel = false) funct_body anchor env sstr =
                let mty' =
                  enrich_module_type anchor name.txt modl.mod_type newenv
                in
+               Includemod.modtypes_consistency ~loc:modl.mod_loc newenv
+                mty' mty.mty_type;
                (id, name, mty, modl, mty', attrs, loc, shape, uid))
             decls sbind in
         let newenv = (* allow aliasing recursive modules from outside *)


### PR DESCRIPTION
This PR proposes to fix the internal error reported in #12959 which happens typing recursive modules where the implementation and the declared module type have inconsistent views on type definitions:
```ocaml
module rec A : sig val c : 'a B.t -> unit end = struct
  let c _ = ()
end
and B : sig type 'a t end = struct
  type t
end
```
> Fatal error: exception Invalid_argument("List.iter2")

This internal error is triggered because in the last stage of the typechecking of recursive modules, we check that we can derive a subtyping relationship between the inferred module types and the explicit module types.
And in order to do so, we extend the type of the modules in the recursive module types to their inferred types, before checking for inclusion. However, the core type system assumes that type definitions are consistent, and when it encounters the signature:
```ocaml
sig val c: 'a B.t -> unit end
```
in an environment where `B` has type
```ocaml
sig type t end
```
it fails immediately.

This PR proposes to fix this issue by adding a consistency step just before the last stage of the typechecking of recursive module bindings:
```ocaml
    module rec M_1: Decl_1 = Impl_1
    and M_2 : Decl_2 = Impl_2
    ...
```
This new test checks that the actual types `Actual_i` are consistent with the declared types `Decl_i` before trying to establish than `M_1:Actual_1, ... , M_n:Actual_n <: M_1:Decl_1, ..., M_n:Decl_n`

This step uses a very coarse-grained consistency relation `C` defined like `<:` except that inclusion for type declarations and value declarations are replaced by a consistency test, and all declarations of classes, class types and extensions constructors are seen as consistent.

For instance,
* `sig type -'a t end` C `sig type 'a t = A end`
*  `sig external x: float ="try" end` C `sig val x: int end`

( `C` is an equivalence on types ), but we have `sig type 'a t end` ₡ ~~`sig type 'a t end`~~ `sig type t end `

This step ensures that it is safe to add the equations `M_i` = `Impl_i` to the environment. 

And with this precaution added, the internal error above is replaced by a normal error message (which could be improved):
```ocaml
module rec A : sig val c : 'a B.t -> unit end = struct
  let c _ = ()
end
and B : sig type 'a t end = struct
  type t
end
```
>```
> Error: Modules do not match:
>         sig type t end
>       is not included in
>         sig type 'a t end
>       Type declarations do not match: type t is not included in type 'a t
>       They have different arities.
>```


