### PR TITLE
Refer to paper about polymorphic unification

### DIFF
--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -1926,6 +1926,15 @@ let local_non_recursive_abbrev uenv p ty =
                    (*  Polymorphic Unification  *)
                    (*****************************)
 
+(* Polymorphic unification is hard in the presence of recursive types.  A
+   correctness argument for the approach below can be made by reference to
+   "Numbering matters: first-order canonical forms for second-order recursive
+   types" (ICFP'04) by Gauthier & Pottier. That work describes putting numbers
+   on nodes; we do not do that here, but instead make a decision about whether
+   to abort or continue based on the comparison of the numbers if we calculated
+   them. A different approach would actually store the relevant numbers in the
+   [Tpoly] nodes. *)
+
 (* Since we cannot duplicate universal variables, unification must
    be done at meta-level, using bindings in univar_pairs *)
 let rec unify_univar t1 t2 = function

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -1933,7 +1933,9 @@ let local_non_recursive_abbrev uenv p ty =
    on nodes; we do not do that here, but instead make a decision about whether
    to abort or continue based on the comparison of the numbers if we calculated
    them. A different approach would actually store the relevant numbers in the
-   [Tpoly] nodes. *)
+   [Tpoly] nodes. (The algorithm here actually pre-dates that paper, which was
+   developed independently. But reading and understanding the paper will help
+   guide intuition for reading this algorithm nonetheless.) *)
 
 (* Since we cannot duplicate universal variables, unification must
    be done at meta-level, using bindings in univar_pairs *)


### PR DESCRIPTION
A discussion came up recently about `unify_univar` and friends. @lpw25 pointed us to [Numbering matters: first-order canonical forms for second-order recursive types](https://dl.acm.org/doi/abs/10.1145/1016848.1016872), which was very helpful in understanding the algorithm. I thought it would be good to include the reference right in the source code.

@fpottier and @garrigue may be interested.