### PR TITLE
use C99 features to support arbitrary lvalues in CAMLxparam* macros

### DIFF
--- a/runtime/caml/memory.h
+++ b/runtime/caml/memory.h
@@ -302,80 +302,46 @@ struct caml__roots_block {
   CAMLxparamN (x, (size))
 
 #define CAMLxparam1(x) \
-  struct caml__roots_block caml__roots_##x; \
-  CAMLunused_start int caml__dummy_##x = ( \
-    (caml__roots_##x.next = *caml_local_roots_ptr), \
-    (*caml_local_roots_ptr = &caml__roots_##x), \
-    (caml__roots_##x.nitems = 1), \
-    (caml__roots_##x.ntables = 1), \
-    (caml__roots_##x.tables [0] = &x), \
-    0) \
-   CAMLunused_end
+  *caml_local_roots_ptr = &(struct caml__roots_block){ \
+    .next = *caml_local_roots_ptr, \
+    .nitems = 1, \
+    .ntables = 1, \
+    .tables = { &(x), } }
 
 #define CAMLxparam2(x, y) \
-  struct caml__roots_block caml__roots_##x; \
-  CAMLunused_start int caml__dummy_##x = ( \
-    (caml__roots_##x.next = *caml_local_roots_ptr), \
-    (*caml_local_roots_ptr = &caml__roots_##x), \
-    (caml__roots_##x.nitems = 1), \
-    (caml__roots_##x.ntables = 2), \
-    (caml__roots_##x.tables [0] = &x), \
-    (caml__roots_##x.tables [1] = &y), \
-    0) \
-   CAMLunused_end
+  *caml_local_roots_ptr = &(struct caml__roots_block){ \
+    .next = *caml_local_roots_ptr, \
+    .nitems = 1, \
+    .ntables = 2, \
+    .tables = { &(x), &(y) } }
 
 #define CAMLxparam3(x, y, z) \
-  struct caml__roots_block caml__roots_##x; \
-  CAMLunused_start int caml__dummy_##x = ( \
-    (caml__roots_##x.next = *caml_local_roots_ptr), \
-    (*caml_local_roots_ptr = &caml__roots_##x), \
-    (caml__roots_##x.nitems = 1), \
-    (caml__roots_##x.ntables = 3), \
-    (caml__roots_##x.tables [0] = &x), \
-    (caml__roots_##x.tables [1] = &y), \
-    (caml__roots_##x.tables [2] = &z), \
-    0) \
-  CAMLunused_end
+  *caml_local_roots_ptr = &(struct caml__roots_block){ \
+    .next = *caml_local_roots_ptr, \
+    .nitems = 1, \
+    .ntables = 3, \
+    .tables = { &(x), &(y), &(z) } }
 
 #define CAMLxparam4(x, y, z, t) \
-  struct caml__roots_block caml__roots_##x; \
-  CAMLunused_start int caml__dummy_##x = ( \
-    (caml__roots_##x.next = *caml_local_roots_ptr), \
-    (*caml_local_roots_ptr = &caml__roots_##x), \
-    (caml__roots_##x.nitems = 1), \
-    (caml__roots_##x.ntables = 4), \
-    (caml__roots_##x.tables [0] = &x), \
-    (caml__roots_##x.tables [1] = &y), \
-    (caml__roots_##x.tables [2] = &z), \
-    (caml__roots_##x.tables [3] = &t), \
-    0) \
-  CAMLunused_end
+  *caml_local_roots_ptr = &(struct caml__roots_block){ \
+    .next = *caml_local_roots_ptr, \
+    .nitems = 1, \
+    .ntables = 4, \
+    .tables = { &(x), &(y), &(z), &(t), } }
 
 #define CAMLxparam5(x, y, z, t, u) \
-  struct caml__roots_block caml__roots_##x; \
-  CAMLunused_start int caml__dummy_##x = ( \
-    (caml__roots_##x.next = *caml_local_roots_ptr), \
-    (*caml_local_roots_ptr = &caml__roots_##x), \
-    (caml__roots_##x.nitems = 1), \
-    (caml__roots_##x.ntables = 5), \
-    (caml__roots_##x.tables [0] = &x), \
-    (caml__roots_##x.tables [1] = &y), \
-    (caml__roots_##x.tables [2] = &z), \
-    (caml__roots_##x.tables [3] = &t), \
-    (caml__roots_##x.tables [4] = &u), \
-    0) \
-  CAMLunused_end
+  *caml_local_roots_ptr = &(struct caml__roots_block){ \
+    .next = *caml_local_roots_ptr, \
+    .nitems = 1, \
+    .ntables = 5, \
+    .tables = { &(x), &(y), &(z), &(t), &(u), } }
 
 #define CAMLxparamN(x, size) \
-  struct caml__roots_block caml__roots_##x; \
-  CAMLunused_start int caml__dummy_##x = ( \
-    (caml__roots_##x.next = *caml_local_roots_ptr), \
-    (*caml_local_roots_ptr = &caml__roots_##x), \
-    (caml__roots_##x.nitems = (size)), \
-    (caml__roots_##x.ntables = 1), \
-    (caml__roots_##x.tables[0] = &(x[0])), \
-    0) \
-  CAMLunused_end
+  *caml_local_roots_ptr = &(struct caml__roots_block){ \
+    .next = *caml_local_roots_ptr, \
+    .nitems = (size), \
+    .ntables = 1, \
+    .tables = { &(x[0]), } }
 
 #define CAMLlocal1(x) \
   value x = Val_unit; \


### PR DESCRIPTION
In the context of #13013, I would like to be able to use CAMLxparam1 on a lvalue that is not a variable:

    CAMLxparam1(result.data);

This is not currently supported, as the definition of CAMLxparam1 uses its argument to build a variable name:

    #define CAMLxparam1(x) \
      struct caml__roots_block caml__roots_##x; \
      CAMLunused_start int caml__dummy_##x = ( \
        (caml__roots_##x.next = *caml_local_roots_ptr), \
        (*caml_local_roots_ptr = &caml__roots_##x), \
        (caml__roots_##x.nitems = 1), \
        (caml__roots_##x.ntables = 1), \
        (caml__roots_##x.tables [0] = &x), \
        0) \
       CAMLunused_end

Let us break down this definition:

1. What the macro does is to add a new element to a singly-linked list stored in `*caml_local_roots_ptr`.

2. This element has type `struct caml__root_block`, and the structure is initialized by first declaring it and then initializing its fields. We use the macro argument `x` to derive the structure name, `caml__roots_##x`.

3. We want to initialize `caml__roots_##x` and also assign `*caml_local_roots_ptr`, but instead of a standard `do { ... } while (0)` block we place these assignments inside the declaration of an unused variable `caml__dummy_##x`. This is done to respect the C89 rule that all declarations must be grouped together at the beginning -- putting a statement here would break this property for declarations coming right after the macro invocation.

Now that we use C99, we can use a structure initializer to build the structure value without first declaring a variable of this type, and we don't need to group all definitions at the beginning so our macro can have arbitrary statements.

The present commit changes the definition of `CAMLxparam1` to become:

    #define CAMLxparam1(x) \
      *caml_local_roots_ptr = &(struct caml__roots_block){ \
        .next = *caml_local_roots_ptr, \
        .nitems = 1, \
        .ntables = 1, \
        .tables = { &(x), } }

which supports `CAMLxparam1(result.data)` just fine.

(All other `CAMLxparam*` macros are also adapted for consistency.)