### PR TITLE
Add caml_plat_lock_non_blocking & compatiblity between sync.h and platform.h

### DIFF
--- a/runtime/callback.c
+++ b/runtime/callback.c
@@ -357,7 +357,7 @@ CAMLprim value caml_register_named_value(value vname, value val)
   unsigned int h = hash_value_name(name);
   int found = 0;
 
-  caml_plat_lock(&named_value_lock);
+  caml_plat_lock_blocking(&named_value_lock);
   for (nv = named_value_table[h]; nv != NULL; nv = nv->next) {
     if (strcmp(name, nv->name) == 0) {
       caml_modify_generational_global_root(&nv->val, val);
@@ -381,7 +381,7 @@ CAMLprim value caml_register_named_value(value vname, value val)
 CAMLexport const value* caml_named_value(char const *name)
 {
   struct named_value * nv;
-  caml_plat_lock(&named_value_lock);
+  caml_plat_lock_blocking(&named_value_lock);
   for (nv = named_value_table[hash_value_name(name)];
        nv != NULL;
        nv = nv->next) {
@@ -397,7 +397,7 @@ CAMLexport const value* caml_named_value(char const *name)
 CAMLexport void caml_iterate_named_values(caml_named_action f)
 {
   int i;
-  caml_plat_lock(&named_value_lock);
+  caml_plat_lock_blocking(&named_value_lock);
   for(i = 0; i < Named_value_size; i++){
     struct named_value * nv;
     for (nv = named_value_table[i]; nv != NULL; nv = nv->next) {

--- a/runtime/caml/platform.h
+++ b/runtime/caml/platform.h
@@ -100,11 +100,40 @@ Caml_inline uintnat atomic_fetch_add_verify_ge0(atomic_uintnat* p, uintnat v) {
   return result;
 }
 
+/* Warning: blocking functions.
+
+   Blocking functions are for use in the runtime outside of the
+   mutator, or when the domain lock is not held.
+
+   In order to use them inside the mutator and while holding the
+   domain lock, one must make sure that the wait is very short, and
+   that no deadlock can arise from the interaction with the domain
+   locks and the stop-the-world sections.
+
+   In particular one must not call [caml_plat_lock] on a mutex while
+   the domain lock is held:
+    - if any critical section of the mutex crosses an allocation, a
+      blocking section releasing the domain lock, or any other
+      potential STW section, nor
+    - if the same lock is acquired at any point using [Mutex.lock] or
+      [caml_plat_lock_non_blocking] on the same domain (circular
+      deadlock with the domain lock).
+
+   Thus, as a general rule, prefer [caml_plat_lock_non_blocking] to
+   lock a mutex when inside the mutator and holding the domain lock.
+   The domain lock must be held in order to call
+   [caml_plat_lock_non_blocking].
+
+   These functions never raise exceptions; errors are fatal. Thus, for
+   usages where bugs are susceptible to be introduced by users, the
+   functions from caml/sync.h should be used instead.
+*/
 
 typedef pthread_mutex_t caml_plat_mutex;
 #define CAML_PLAT_MUTEX_INITIALIZER PTHREAD_MUTEX_INITIALIZER
 CAMLextern void caml_plat_mutex_init(caml_plat_mutex*);
-Caml_inline void caml_plat_lock(caml_plat_mutex*);
+Caml_inline void caml_plat_lock(caml_plat_mutex*); /* blocking */
+Caml_inline void caml_plat_lock_non_blocking(caml_plat_mutex*);
 Caml_inline int caml_plat_try_lock(caml_plat_mutex*);
 void caml_plat_assert_locked(caml_plat_mutex*);
 void caml_plat_assert_all_locks_unlocked(void);
@@ -113,7 +142,7 @@ void caml_plat_mutex_free(caml_plat_mutex*);
 typedef pthread_cond_t caml_plat_cond;
 #define CAML_PLAT_COND_INITIALIZER PTHREAD_COND_INITIALIZER
 void caml_plat_cond_init(caml_plat_cond*);
-void caml_plat_wait(caml_plat_cond*, caml_plat_mutex*);
+void caml_plat_wait(caml_plat_cond*, caml_plat_mutex*); /* blocking */
 void caml_plat_broadcast(caml_plat_cond*);
 void caml_plat_signal(caml_plat_cond*);
 void caml_plat_cond_free(caml_plat_cond*);
@@ -162,6 +191,15 @@ Caml_inline int caml_plat_try_lock(caml_plat_mutex* m)
     check_err("try_lock", r);
     DEBUG_LOCK(m);
     return 1;
+  }
+}
+
+CAMLextern void caml_plat_lock_non_blocking_actual(caml_plat_mutex* m);
+
+Caml_inline void caml_plat_lock_non_blocking(caml_plat_mutex* m)
+{
+  if (!caml_plat_try_lock(m)) {
+    caml_plat_lock_non_blocking_actual(m);
   }
 }
 

--- a/runtime/caml/platform.h
+++ b/runtime/caml/platform.h
@@ -110,12 +110,10 @@ void caml_plat_assert_locked(caml_plat_mutex*);
 void caml_plat_assert_all_locks_unlocked(void);
 Caml_inline void caml_plat_unlock(caml_plat_mutex*);
 void caml_plat_mutex_free(caml_plat_mutex*);
-typedef struct { pthread_cond_t cond; caml_plat_mutex* mutex; } caml_plat_cond;
-#define CAML_PLAT_COND_INITIALIZER(m) { PTHREAD_COND_INITIALIZER, m }
-void caml_plat_cond_init(caml_plat_cond*, caml_plat_mutex*);
-void caml_plat_wait(caml_plat_cond*);
-/* like caml_plat_wait, but if nanoseconds surpasses the second parameter
-   without a signal, then this function returns 1. */
+typedef pthread_cond_t caml_plat_cond;
+#define CAML_PLAT_COND_INITIALIZER PTHREAD_COND_INITIALIZER
+void caml_plat_cond_init(caml_plat_cond*);
+void caml_plat_wait(caml_plat_cond*, caml_plat_mutex*);
 void caml_plat_broadcast(caml_plat_cond*);
 void caml_plat_signal(caml_plat_cond*);
 void caml_plat_cond_free(caml_plat_cond*);

--- a/runtime/caml/platform.h
+++ b/runtime/caml/platform.h
@@ -110,8 +110,8 @@ Caml_inline uintnat atomic_fetch_add_verify_ge0(atomic_uintnat* p, uintnat v) {
    that no deadlock can arise from the interaction with the domain
    locks and the stop-the-world sections.
 
-   In particular one must not call [caml_plat_lock] on a mutex while
-   the domain lock is held:
+   In particular one must not call [caml_plat_lock_blocking] on a
+   mutex while the domain lock is held:
     - if any critical section of the mutex crosses an allocation, a
       blocking section releasing the domain lock, or any other
       potential STW section, nor
@@ -119,7 +119,7 @@ Caml_inline uintnat atomic_fetch_add_verify_ge0(atomic_uintnat* p, uintnat v) {
       [caml_plat_lock_non_blocking] on the same domain (circular
       deadlock with the domain lock).
 
-   Thus, as a general rule, prefer [caml_plat_lock_non_blocking] to
+   Hence, as a general rule, prefer [caml_plat_lock_non_blocking] to
    lock a mutex when inside the mutator and holding the domain lock.
    The domain lock must be held in order to call
    [caml_plat_lock_non_blocking].

--- a/runtime/caml/platform.h
+++ b/runtime/caml/platform.h
@@ -132,7 +132,7 @@ Caml_inline uintnat atomic_fetch_add_verify_ge0(atomic_uintnat* p, uintnat v) {
 typedef pthread_mutex_t caml_plat_mutex;
 #define CAML_PLAT_MUTEX_INITIALIZER PTHREAD_MUTEX_INITIALIZER
 CAMLextern void caml_plat_mutex_init(caml_plat_mutex*);
-Caml_inline void caml_plat_lock(caml_plat_mutex*); /* blocking */
+Caml_inline void caml_plat_lock_blocking(caml_plat_mutex*);
 Caml_inline void caml_plat_lock_non_blocking(caml_plat_mutex*);
 Caml_inline int caml_plat_try_lock(caml_plat_mutex*);
 void caml_plat_assert_locked(caml_plat_mutex*);
@@ -176,7 +176,7 @@ CAMLextern CAMLthread_local int caml_lockdepth;
 #define DEBUG_UNLOCK(m)
 #endif
 
-Caml_inline void caml_plat_lock(caml_plat_mutex* m)
+Caml_inline void caml_plat_lock_blocking(caml_plat_mutex* m)
 {
   check_err("lock", pthread_mutex_lock(m));
   DEBUG_LOCK(m);

--- a/runtime/caml/platform.h
+++ b/runtime/caml/platform.h
@@ -168,9 +168,9 @@ Caml_inline void check_err(const char* action, int err)
 }
 
 #ifdef DEBUG
-static CAMLthread_local int lockdepth;
-#define DEBUG_LOCK(m) (lockdepth++)
-#define DEBUG_UNLOCK(m) (lockdepth--)
+CAMLextern CAMLthread_local int caml_lockdepth;
+#define DEBUG_LOCK(m) (caml_lockdepth++)
+#define DEBUG_UNLOCK(m) (caml_lockdepth--)
 #else
 #define DEBUG_LOCK(m)
 #define DEBUG_UNLOCK(m)

--- a/runtime/caml/sync.h
+++ b/runtime/caml/sync.h
@@ -23,9 +23,11 @@
 #include "mlvalues.h"
 #include "platform.h"
 
-typedef pthread_mutex_t * sync_mutex;
+typedef caml_plat_mutex * sync_mutex;
+typedef caml_plat_cond * sync_condvar;
 
 #define Mutex_val(v) (* ((sync_mutex *) Data_custom_val(v)))
+#define Condition_val(v) (* (sync_condvar *) Data_custom_val(v))
 
 CAMLextern int caml_mutex_lock(sync_mutex mut);
 CAMLextern int caml_mutex_unlock(sync_mutex mut);

--- a/runtime/caml/sync.h
+++ b/runtime/caml/sync.h
@@ -23,6 +23,11 @@
 #include "mlvalues.h"
 #include "platform.h"
 
+/* OCaml mutexes and condition variables can also be manipulated from
+   C code with non-raising primitives from caml/platform.h. In this
+   case, pairs of lock/unlock for a critical section must come from
+   the same header (sync.h or platform.h). */
+
 typedef caml_plat_mutex * sync_mutex;
 typedef caml_plat_cond * sync_condvar;
 

--- a/runtime/codefrag.c
+++ b/runtime/codefrag.c
@@ -131,7 +131,7 @@ unsigned char *caml_digest_of_code_fragment(struct code_fragment *cf) {
      all cases. It would be possible to take a lock only in the
      DIGEST_LATER case, which occurs at most once per fragment, by
      using double-checked locking -- see #11791. */
-  caml_plat_lock(&cf->mutex);
+  caml_plat_lock_blocking(&cf->mutex);
   {
     if (cf->digest_status == DIGEST_IGNORE) {
       digest = NULL;

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -350,7 +350,7 @@ int caml_send_interrupt(struct interruptor* target)
   /* Signal the condition variable, in case the target is itself
      waiting for an interrupt to be processed elsewhere, or to wake up
      the backup thread. */
-  caml_plat_lock(&target->lock);
+  caml_plat_lock_blocking(&target->lock);
   caml_plat_broadcast(&target->cond); // OPT before/after unlock? elide?
   caml_plat_unlock(&target->lock);
 
@@ -562,7 +562,7 @@ static void domain_create(uintnat initial_minor_heap_wsize,
 
   /* take the all_domains_lock so that we can alter the STW participant
      set atomically */
-  caml_plat_lock(&all_domains_lock);
+  caml_plat_lock_blocking(&all_domains_lock);
 
   /* Wait until any in-progress STW sections end. */
   while (atomic_load_acquire(&stw_leader)) {
@@ -605,7 +605,7 @@ static void domain_create(uintnat initial_minor_heap_wsize,
    * shared with a domain which is terminating (see
    * domain_terminate). */
 
-  caml_plat_lock(&d->domain_lock);
+  caml_plat_lock_blocking(&d->domain_lock);
 
   /* Set domain_self if we have successfully allocated the
    * caml_domain_state. Otherwise domain_self will be NULL and it's up
@@ -1021,7 +1021,7 @@ static void* backup_thread_func(void* v)
         /* Wait safely if there is nothing to do. Will be woken from
          * caml_send_interrupt and domain_terminate.
          */
-        caml_plat_lock(&s->lock);
+        caml_plat_lock_blocking(&s->lock);
         msg = atomic_load_acquire (&di->backup_thread_msg);
         if (msg == BT_IN_BLOCKING_SECTION &&
             !caml_incoming_interrupts_queued())
@@ -1033,7 +1033,7 @@ static void* backup_thread_func(void* v)
          * Will be woken from caml_bt_exit_ocaml
          * or domain_terminate
          */
-        caml_plat_lock(&di->domain_lock);
+        caml_plat_lock_blocking(&di->domain_lock);
         msg = atomic_load_acquire (&di->backup_thread_msg);
         if (msg == BT_ENTERING_OCAML)
           caml_plat_wait(&di->domain_cond, &di->domain_lock);
@@ -1069,7 +1069,7 @@ static void install_backup_thread (dom_internal* di)
       /* Give a chance for backup thread on this domain to terminate */
       caml_plat_unlock (&di->domain_lock);
       cpu_relax ();
-      caml_plat_lock (&di->domain_lock);
+      caml_plat_lock_blocking(&di->domain_lock);
       msg = atomic_load_acquire(&di->backup_thread_msg);
     }
 
@@ -1179,7 +1179,7 @@ static void* domain_thread_func(void* v)
   p->newdom = domain_self;
 
   /* handshake with the parent domain */
-  caml_plat_lock(&p->parent->interruptor.lock);
+  caml_plat_lock_blocking(&p->parent->interruptor.lock);
   if (domain_self) {
     p->status = Dom_started;
     p->unique_id = domain_self->interruptor.unique_id;
@@ -1263,12 +1263,12 @@ CAMLprim value caml_domain_spawn(value callback, value term_sync)
   /* While waiting for the child thread to start up, we need to service any
      stop-the-world requests as they come in. */
   struct interruptor *interruptor = &domain_self->interruptor;
-  caml_plat_lock(&interruptor->lock);
+  caml_plat_lock_blocking(&interruptor->lock);
   while (p.status == Dom_starting) {
     if (caml_incoming_interrupts_queued()) {
       caml_plat_unlock(&interruptor->lock);
       handle_incoming(interruptor);
-      caml_plat_lock(&interruptor->lock);
+      caml_plat_lock_blocking(&interruptor->lock);
     } else {
       caml_plat_wait(&interruptor->cond, &interruptor->lock);
     }
@@ -1349,7 +1349,7 @@ static void decrement_stw_domains_still_processing(void)
 
   if( am_last ) {
     /* release the STW lock to allow new STW sections */
-    caml_plat_lock(&all_domains_lock);
+    caml_plat_lock_blocking(&all_domains_lock);
     atomic_store_release(&stw_leader, 0);
     caml_plat_broadcast(&all_domains_cond);
     caml_gc_log("clearing stw leader");
@@ -1799,7 +1799,7 @@ CAMLexport intnat caml_domain_is_multicore (void)
 CAMLexport void caml_acquire_domain_lock(void)
 {
   dom_internal* self = domain_self;
-  caml_plat_lock(&self->domain_lock);
+  caml_plat_lock_blocking(&self->domain_lock);
   caml_state = self->state;
 }
 
@@ -1889,7 +1889,7 @@ static void domain_terminate (void)
 
     /* take the all_domains_lock to try and exit the STW participant set
        without racing with a STW section being triggered */
-    caml_plat_lock(&all_domains_lock);
+    caml_plat_lock_blocking(&all_domains_lock);
 
     /* The interaction of termination and major GC is quite subtle.
 
@@ -1915,7 +1915,7 @@ static void domain_terminate (void)
       /* signal the interruptor condition variable
        * because the backup thread may be waiting on it
        */
-      caml_plat_lock(&s->lock);
+      caml_plat_lock_blocking(&s->lock);
       caml_plat_broadcast(&s->cond);
       caml_plat_unlock(&s->lock);
 

--- a/runtime/frame_descriptors.c
+++ b/runtime/frame_descriptors.c
@@ -330,7 +330,7 @@ static void remove_frame_descriptors(
   void *frametable;
   caml_frametable_list ** previous;
 
-  caml_plat_lock(&table->mutex);
+  caml_plat_lock_blocking(&table->mutex);
 
   previous = &table->frametables;
 

--- a/runtime/gc_stats.c
+++ b/runtime/gc_stats.c
@@ -83,7 +83,7 @@ static caml_plat_mutex orphan_lock = CAML_PLAT_MUTEX_INITIALIZER;
 static struct alloc_stats orphaned_alloc_stats = {0,};
 
 void caml_accum_orphan_alloc_stats(struct alloc_stats *acc) {
-  caml_plat_lock(&orphan_lock);
+  caml_plat_lock_blocking(&orphan_lock);
   caml_accum_alloc_stats(acc, &orphaned_alloc_stats);
   caml_plat_unlock(&orphan_lock);
 }
@@ -96,7 +96,7 @@ void caml_orphan_alloc_stats(caml_domain_state *domain) {
   caml_reset_domain_alloc_stats(domain);
 
   /* push them into the orphan stats */
-  caml_plat_lock(&orphan_lock);
+  caml_plat_lock_blocking(&orphan_lock);
   caml_accum_alloc_stats(&orphaned_alloc_stats, &alloc_stats);
   caml_plat_unlock(&orphan_lock);
 }

--- a/runtime/globroots.c
+++ b/runtime/globroots.c
@@ -51,14 +51,14 @@ struct skiplist caml_global_roots_old = SKIPLIST_STATIC_INITIALIZER;
 
 Caml_inline void caml_insert_global_root(struct skiplist * list, value * r)
 {
-  caml_plat_lock(&roots_mutex);
+  caml_plat_lock_blocking(&roots_mutex);
   caml_skiplist_insert(list, (uintnat) r, 0);
   caml_plat_unlock(&roots_mutex);
 }
 
 Caml_inline void caml_delete_global_root(struct skiplist * list, value * r)
 {
-  caml_plat_lock(&roots_mutex);
+  caml_plat_lock_blocking(&roots_mutex);
   caml_skiplist_remove(list, (uintnat) r);
   caml_plat_unlock(&roots_mutex);
 }
@@ -182,7 +182,7 @@ static link * caml_dyn_globals = NULL;
 
 void caml_register_dyn_globals(void **globals, int nglobals) {
   int i;
-  caml_plat_lock(&roots_mutex);
+  caml_plat_lock_blocking(&roots_mutex);
   for (i = 0; i < nglobals; i++)
     caml_dyn_globals = cons(globals[i],caml_dyn_globals);
   caml_plat_unlock(&roots_mutex);
@@ -195,7 +195,7 @@ static void scan_native_globals(scanning_action f, void* fdata)
   value* glob;
   link* lnk;
 
-  caml_plat_lock(&roots_mutex);
+  caml_plat_lock_blocking(&roots_mutex);
   dyn_globals = caml_dyn_globals;
   caml_plat_unlock(&roots_mutex);
 
@@ -232,7 +232,7 @@ Caml_inline void caml_iterate_global_roots(scanning_action f,
 
 /* Scan all global roots */
 void caml_scan_global_roots(scanning_action f, void* fdata) {
-  caml_plat_lock(&roots_mutex);
+  caml_plat_lock_blocking(&roots_mutex);
   caml_iterate_global_roots(f, &caml_global_roots, fdata);
   caml_iterate_global_roots(f, &caml_global_roots_young, fdata);
   caml_iterate_global_roots(f, &caml_global_roots_old, fdata);
@@ -246,7 +246,7 @@ void caml_scan_global_roots(scanning_action f, void* fdata) {
 /* Scan global roots for a minor collection */
 void caml_scan_global_young_roots(scanning_action f, void* fdata)
 {
-  caml_plat_lock(&roots_mutex);
+  caml_plat_lock_blocking(&roots_mutex);
 
   caml_iterate_global_roots(f, &caml_global_roots, fdata);
   caml_iterate_global_roots(f, &caml_global_roots_young, fdata);

--- a/runtime/io.c
+++ b/runtime/io.c
@@ -86,16 +86,8 @@ static CAMLthread_local struct channel* last_channel_locked = NULL;
 
 CAMLexport void caml_channel_lock(struct channel *chan)
 {
-  if( caml_plat_try_lock(&chan->mutex) ) {
-    last_channel_locked = chan;
-    return;
-  }
-
-  /* If unsuccessful, block on mutex */
-  caml_enter_blocking_section();
-  caml_plat_lock(&chan->mutex);
+  caml_plat_lock_non_blocking(&chan->mutex);
   last_channel_locked = chan;
-  caml_leave_blocking_section();
 }
 
 CAMLexport void caml_channel_unlock(struct channel *chan)

--- a/runtime/io.c
+++ b/runtime/io.c
@@ -560,7 +560,7 @@ void caml_finalize_channel(value vchan)
   }
   /* Don't run concurrently with caml_ml_out_channels_list that may resurrect
      a dead channel . */
-  caml_plat_lock (&caml_all_opened_channels_mutex);
+  caml_plat_lock_blocking(&caml_all_opened_channels_mutex);
   chan->refcount --;
   if (chan->refcount > 0 || notflushed) {
     /* We need to keep the channel around, either because it is being
@@ -613,7 +613,7 @@ CAMLprim value caml_ml_open_descriptor_in_with_flags(int fd, int flags)
   struct channel * chan = caml_open_descriptor_in(fd);
   chan->flags |= flags | CHANNEL_FLAG_MANAGED_BY_GC;
   chan->refcount = 1;
-  caml_plat_lock (&caml_all_opened_channels_mutex);
+  caml_plat_lock_blocking(&caml_all_opened_channels_mutex);
   link_channel (chan);
   caml_plat_unlock (&caml_all_opened_channels_mutex);
   return caml_alloc_channel(chan);
@@ -628,7 +628,7 @@ CAMLprim value caml_ml_open_descriptor_out_with_flags(int fd, int flags)
   struct channel * chan = caml_open_descriptor_out(fd);
   chan->flags |= flags | CHANNEL_FLAG_MANAGED_BY_GC;
   chan->refcount = 1;
-  caml_plat_lock (&caml_all_opened_channels_mutex);
+  caml_plat_lock_blocking(&caml_all_opened_channels_mutex);
   link_channel (chan);
   caml_plat_unlock (&caml_all_opened_channels_mutex);
   return caml_alloc_channel(chan);
@@ -665,7 +665,7 @@ CAMLprim value caml_ml_out_channels_list (value unit)
   struct channel_list *channel_list = NULL, *cl_tmp;
   mlsize_t i, num_channels = 0;
 
-  caml_plat_lock (&caml_all_opened_channels_mutex);
+  caml_plat_lock_blocking(&caml_all_opened_channels_mutex);
   for (channel = caml_all_opened_channels;
        channel != NULL;
        channel = channel->next) {

--- a/runtime/memory.c
+++ b/runtime/memory.c
@@ -533,7 +533,7 @@ static struct pool_block* get_pool_block(caml_stat_block b)
 /* Linking a pool block into the ring */
 static void link_pool_block(struct pool_block *pb)
 {
-  caml_plat_lock(&pool_mutex);
+  caml_plat_lock_blocking(&pool_mutex);
   pb->next = pool->next;
   pb->prev = pool;
   pool->next->prev = pb;
@@ -544,7 +544,7 @@ static void link_pool_block(struct pool_block *pb)
 /* Unlinking a pool block from the ring */
 static void unlink_pool_block(struct pool_block *pb)
 {
-    caml_plat_lock(&pool_mutex);
+    caml_plat_lock_blocking(&pool_mutex);
     pb->prev->next = pb->next;
     pb->next->prev = pb->prev;
     caml_plat_unlock(&pool_mutex);
@@ -566,7 +566,7 @@ CAMLexport void caml_stat_create_pool(void)
 
 CAMLexport void caml_stat_destroy_pool(void)
 {
-  caml_plat_lock(&pool_mutex);
+  caml_plat_lock_blocking(&pool_mutex);
   if (pool != NULL) {
     pool->prev->next = NULL;
     while (pool != NULL) {

--- a/runtime/memprof.c
+++ b/runtime/memprof.c
@@ -962,7 +962,7 @@ static void orphans_abandon(memprof_domain_t domain)
     ot = ot->next;
   }
 
-  caml_plat_lock(&orphans_lock);
+  caml_plat_lock_blocking(&orphans_lock);
   ot->next = orphans;
   orphans = domain->orphans;
   caml_plat_unlock(&orphans_lock);
@@ -979,7 +979,7 @@ static void orphans_adopt(memprof_domain_t domain)
     p = &(*p)->next;
   }
 
-  caml_plat_lock(&orphans_lock);
+  caml_plat_lock_blocking(&orphans_lock);
   *p = orphans;
   orphans = NULL;
   caml_plat_unlock(&orphans_lock);

--- a/runtime/misc.c
+++ b/runtime/misc.c
@@ -280,7 +280,8 @@ void caml_bad_caml_state(void)
    un-instruments function, this simply silences reports when the call stack
    contains a frame matching one of the lines starting with "race:". */
 const char * __tsan_default_suppressions(void) {
-  return "deadlock:caml_plat_lock\n" /* Avoids deadlock inversion messages */
+  return "deadlock:caml_plat_lock_blocking\n" /* Avoids deadlock inversion
+                                                 messages */
          "deadlock:pthread_mutex_lock\n"; /* idem */
 }
 #endif /* WITH_THREAD_SANITIZER */

--- a/runtime/platform.c
+++ b/runtime/platform.c
@@ -79,10 +79,12 @@ void caml_plat_assert_locked(caml_plat_mutex* m)
 #endif
 }
 
+CAMLexport CAMLthread_local int caml_lockdepth = 0;
+
 void caml_plat_assert_all_locks_unlocked(void)
 {
 #ifdef DEBUG
-  if (lockdepth) caml_fatal_error("Locks still locked at termination");
+  if (caml_lockdepth) caml_fatal_error("Locks still locked at termination");
 #endif
 }
 

--- a/runtime/platform.c
+++ b/runtime/platform.c
@@ -26,6 +26,7 @@
 #include "caml/fail.h"
 #include "caml/lf_skiplist.h"
 #include "caml/misc.h"
+#include "caml/signals.h"
 #ifdef HAS_SYS_MMAN_H
 #include <sys/mman.h>
 #endif
@@ -83,6 +84,16 @@ void caml_plat_assert_all_locks_unlocked(void)
 #ifdef DEBUG
   if (lockdepth) caml_fatal_error("Locks still locked at termination");
 #endif
+}
+
+CAMLexport void caml_plat_lock_non_blocking_actual(caml_plat_mutex* m)
+{
+  /* Avoid exceptions */
+  caml_enter_blocking_section_no_pending();
+  int rc = pthread_mutex_lock(m);
+  caml_leave_blocking_section();
+  check_err("lock_non_blocking", rc);
+  DEBUG_LOCK(m);
 }
 
 void caml_plat_mutex_free(caml_plat_mutex* m)

--- a/runtime/platform.c
+++ b/runtime/platform.c
@@ -99,38 +99,34 @@ static void caml_plat_cond_init_aux(caml_plat_cond *cond)
     _POSIX_MONOTONIC_CLOCK != (-1)
   pthread_condattr_setclock(&attr, CLOCK_MONOTONIC);
 #endif
-  pthread_cond_init(&cond->cond, &attr);
+  pthread_cond_init(cond, &attr);
 }
 
 /* Condition variables */
-void caml_plat_cond_init(caml_plat_cond* cond, caml_plat_mutex* m)
+void caml_plat_cond_init(caml_plat_cond* cond)
 {
   caml_plat_cond_init_aux(cond);
-  cond->mutex = m;
 }
 
-void caml_plat_wait(caml_plat_cond* cond)
+void caml_plat_wait(caml_plat_cond* cond, caml_plat_mutex* mut)
 {
-  caml_plat_assert_locked(cond->mutex);
-  check_err("wait", pthread_cond_wait(&cond->cond, cond->mutex));
+  caml_plat_assert_locked(mut);
+  check_err("wait", pthread_cond_wait(cond, mut));
 }
 
 void caml_plat_broadcast(caml_plat_cond* cond)
 {
-  caml_plat_assert_locked(cond->mutex);
-  check_err("cond_broadcast", pthread_cond_broadcast(&cond->cond));
+  check_err("cond_broadcast", pthread_cond_broadcast(cond));
 }
 
 void caml_plat_signal(caml_plat_cond* cond)
 {
-  caml_plat_assert_locked(cond->mutex);
-  check_err("cond_signal", pthread_cond_signal(&cond->cond));
+  check_err("cond_signal", pthread_cond_signal(cond));
 }
 
 void caml_plat_cond_free(caml_plat_cond* cond)
 {
-  check_err("cond_free", pthread_cond_destroy(&cond->cond));
-  cond->mutex=0;
+  check_err("cond_free", pthread_cond_destroy(cond));
 }
 
 

--- a/runtime/runtime_events.c
+++ b/runtime/runtime_events.c
@@ -382,7 +382,7 @@ static void runtime_events_create_from_stw_single(void) {
 
     // at the same instant: snapshot user_events list and set
     // runtime_events_enabled to 1
-    caml_plat_lock(&user_events_lock);
+    caml_plat_lock_blocking(&user_events_lock);
     value current_user_event = user_events;
     atomic_store_release(&runtime_events_enabled, 1);
     caml_plat_unlock(&user_events_lock);
@@ -685,7 +685,7 @@ CAMLprim value caml_runtime_events_user_register(value event_name,
   Field(event, 3) = event_tag;
 
 
-  caml_plat_lock(&user_events_lock);
+  caml_plat_lock_blocking(&user_events_lock);
   // critical section: when we update the user_events list we need to make sure
   // it is not updated while we construct the pointer to the next element
 
@@ -801,7 +801,7 @@ CAMLexport value caml_runtime_events_user_resolve(
   CAMLlocal3(event, cur_event_name, ml_event_name);
 
   // TODO: it might be possible to atomic load instead
-  caml_plat_lock(&user_events_lock);
+  caml_plat_lock_blocking(&user_events_lock);
   value current_user_event = user_events;
   caml_plat_unlock(&user_events_lock);
 

--- a/runtime/shared_heap.c
+++ b/runtime/shared_heap.c
@@ -150,7 +150,7 @@ static int move_all_pools(pool** src, _Atomic(pool*)* dst,
 void caml_teardown_shared_heap(struct caml_heap_state* heap) {
   int i;
   int released = 0, released_large = 0;
-  caml_plat_lock(&pool_freelist.lock);
+  caml_plat_lock_blocking(&pool_freelist.lock);
   for (i = 0; i < NUM_SIZECLASSES; i++) {
     released +=
       move_all_pools(&heap->avail_pools[i],
@@ -185,7 +185,7 @@ void caml_teardown_shared_heap(struct caml_heap_state* heap) {
 static pool* pool_acquire(struct caml_heap_state* local) {
   pool* r;
 
-  caml_plat_lock(&pool_freelist.lock);
+  caml_plat_lock_blocking(&pool_freelist.lock);
   if (!pool_freelist.free) {
     void* mem = caml_mem_map(Bsize_wsize(POOL_WSIZE), 0);
 
@@ -216,7 +216,7 @@ static void pool_release(struct caml_heap_state* local,
   CAMLassert(pool->sz == sz);
   local->stats.pool_words -= POOL_WSIZE;
   local->stats.pool_frag_words -= POOL_HEADER_WSIZE + wastage_sizeclass[sz];
-  caml_plat_lock(&pool_freelist.lock);
+  caml_plat_lock_blocking(&pool_freelist.lock);
   pool->next = pool_freelist.free;
   pool_freelist.free = pool;
   caml_plat_unlock(&pool_freelist.lock);
@@ -307,7 +307,7 @@ static pool* pool_global_adopt(struct caml_heap_state* local, sizeclass sz)
     return NULL;
 
   /* Haven't managed to find a pool locally, try the global ones */
-  caml_plat_lock(&pool_freelist.lock);
+  caml_plat_lock_blocking(&pool_freelist.lock);
   if( atomic_load_relaxed(&pool_freelist.global_avail_pools[sz]) ) {
     r = atomic_load_relaxed(&pool_freelist.global_avail_pools[sz]);
 
@@ -675,7 +675,7 @@ void caml_collect_heap_stats_sample(
 /* Add the orphan pool stats to a stats accumulator. */
 void caml_accum_orphan_heap_stats(struct heap_stats* acc)
 {
-  caml_plat_lock(&pool_freelist.lock);
+  caml_plat_lock_blocking(&pool_freelist.lock);
   caml_accum_heap_stats(acc, &pool_freelist.stats);
   caml_plat_unlock(&pool_freelist.lock);
 }
@@ -1285,7 +1285,7 @@ void caml_compact_heap(caml_domain_state* domain_state,
     pool* cur_pool;
     pool* next_pool;
 
-    caml_plat_lock(&pool_freelist.lock);
+    caml_plat_lock_blocking(&pool_freelist.lock);
     cur_pool = pool_freelist.free;
 
     while( cur_pool ) {
@@ -1431,7 +1431,7 @@ void caml_cycle_heap(struct caml_heap_state* local) {
   local->unswept_large = local->swept_large;
   local->swept_large = NULL;
 
-  caml_plat_lock(&pool_freelist.lock);
+  caml_plat_lock_blocking(&pool_freelist.lock);
   for (i = 0; i < NUM_SIZECLASSES; i++) {
     received_p += move_all_pools(
         (pool**)&pool_freelist.global_avail_pools[i],

--- a/runtime/signals.c
+++ b/runtime/signals.c
@@ -701,7 +701,7 @@ CAMLprim value caml_install_signal_handler(value signal_number, value action)
     if (caml_signal_handlers == 0) {
       tmp_signal_handlers = caml_alloc(NSIG, 0);
     }
-    caml_plat_lock(&signal_install_mutex);
+    caml_plat_lock_blocking(&signal_install_mutex);
     if (caml_signal_handlers == 0) {
       /* caml_alloc cannot raise asynchronous exceptions from signals
          so this is safe */

--- a/runtime/sync_posix.h
+++ b/runtime/sync_posix.h
@@ -23,13 +23,11 @@
 #include <pthread.h>
 #include <string.h>
 
+#include "caml/sync.h"
+
 typedef int sync_retcode;
 
 /* Mutexes */
-
-/* Already defined in <caml/sync.h> */
-/* typedef pthread_mutex_t * sync_mutex; */
-/* #define Mutex_val(v) (* ((sync_mutex *) Data_custom_val(v))) */
 
 Caml_inline int sync_mutex_create(sync_mutex * res)
 {
@@ -83,10 +81,6 @@ Caml_inline int sync_mutex_unlock(sync_mutex m)
 }
 
 /* Condition variables */
-
-typedef pthread_cond_t * sync_condvar;
-
-#define Condition_val(v) (* (sync_condvar *) Data_custom_val(v))
 
 Caml_inline int sync_condvar_create(sync_condvar * res)
 {


### PR DESCRIPTION
For the purposes of #12410, the runtime needs a version of `caml_plat_lock` that does not block. (Or equivalently, a version of `caml_ml_mutex_lock` that does not raise exceptions.)

In addition, the mutex in question comes from OCaml, but it is important to lock it from C. For the same purposes, we need to manipulate from C a condition variable coming from OCaml, again without raising exceptions.

In order to add the required functionality without making a mess, the plan is the following:
- Make mutexes and condvars from sync.h and platform.h explicitly compatible. (second commit)
- This requires changing a bit condvars from platform.h, but the reason for the discrepancy with sync.h is not convincing (cf. commit log). We gain in simplicity by aligning platform.h on sync.h with respect to condvars (first commit).
- Add the required function `caml_plat_lock_non_blocking`, document it, and use it at one place where this functionality was already required. (third commit)

An ulterior PR will introduce more usages of `caml_plat_lock_non_blocking` by auditing all current uses of `caml_plat_lock`.

No change entry needed (credit to reviewers can be given inside the Changes for #12410).

cc @kayceesrk 