### PR TITLE
Perform CI builds on macOS 14 for ARM64 and macOS 13 for x86_64.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,7 @@ jobs:
       manual_changed: ${{ steps.manual.outputs.manual_changed }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
       - name: Check for manual changes
@@ -156,7 +156,7 @@ jobs:
             os: macos-14
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
       - name: OS Dependencies

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -150,8 +150,10 @@ jobs:
           - name: linux-O0
             os: ubuntu-latest
             config_arg: CFLAGS='-O0'
-          - name: macos
-            os: macos-latest
+          - name: macos-x86_64
+            os: macos-13
+          - name: macos-arm64
+            os: macos-14
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
This PR makes 3 changes:

1. Adds macsOS 14 ARM64 runner under the name `macos-arm64`, which we didn't previously test on.
1. Updates macOS x86_64 to 13 from 12 under the name `macOS-x86_64`
1. Updates the version of actions/checkout to v4

See GitHub announcement here https://github.blog/changelog/2024-01-30-github-actions-macos-14-sonoma-is-now-available/ 


