### PR TITLE
manual: fix OCAMLRUNPARAM  l parameter documentation

### DIFF
--- a/Changes
+++ b/Changes
@@ -634,6 +634,10 @@ OCaml 5.2.0
   (Lucas Pluvinage, Sadiq Jaffer and Olivier Nicole, review by Gabriel Scherer,
    David Allsopp, Tim McGilchrist and Thomas Leonard)
 
+- #13066, update OCAMLRUNPARAM documentation for the stack size parameter l
+  (Florian Angeletti, review by Nicolás Ojeda Bär, Tim McGilchrist, and
+   Miod Vallat)
+
 ### Compiler user-interface and warnings:
 
 * #10613, #12405: Simplify the values used for the system variable (`system:` in

--- a/manual/src/cmds/runtime.etex
+++ b/manual/src/cmds/runtime.etex
@@ -132,9 +132,9 @@ The following environment variables are also consulted:
   \item[e] ("runtime_events_log_wsize") Size of the per-domain runtime events ring
         buffers in log powers of two words. Defaults to 16, giving 64k word or
         512kb buffers on 64-bit systems.
-  \item[l] ("stack_limit") The limit (in words) of the stack size. This is only
-        relevant to the byte-code runtime, as the native code runtime uses the
-        operating system's stack.
+  \item[l] ("stack_limit") The limit (in words) of the stack size. This is
+        relevant to both the byte-code runtime and the native code runtime:
+        OCaml always uses its own stack and not the operating system's stack.
   \item[m] ("custom_minor_ratio") Bound on floating garbage for
         out-of-heap memory
         held by custom values in the minor heap. A minor GC is triggered


### PR DESCRIPTION
The documentation of `OCAMLRUNPARAM=l=%d` was not updated when we switched to the OCaml-managed stack.
This PR updates the documentation to reflect that using `ulimit -s ` will not affect the OCaml-managed stack.