### PR TITLE
Workaround Cygwin 3.5.x regression in AppVeyor

### DIFF
--- a/tools/ci/appveyor/appveyor_build.cmd
+++ b/tools/ci/appveyor/appveyor_build.cmd
@@ -21,8 +21,8 @@
 @echo off
 
 chcp 65001 > nul
-set BUILD_PREFIX=🐫реализация
-set OCAMLROOT=%PROGRAMFILES%\Бактріан🐫
+set BUILD_PREFIX=реализация
+set OCAMLROOT=%PROGRAMFILES%\Бактріан
 
 if "%1" neq "install" goto %1
 setlocal enabledelayedexpansion

--- a/tools/ci/appveyor/appveyor_build.sh
+++ b/tools/ci/appveyor/appveyor_build.sh
@@ -217,7 +217,7 @@ case "$1" in
         # For an explanation of the sed command, see
         # https://github.com/appveyor/ci/issues/1824
         script --quiet --return --command \
-          "$MAKE -C ../$BUILD_PREFIX-$PORT world.opt" \
+          "$MAKE -C ../$BUILD_PREFIX-$PORT" \
           "../$BUILD_PREFIX-$PORT/build.log" |
             sed -e 's/\d027\[K//g' \
                 -e 's/\d027\[m/\d027[0m/g' \

--- a/tools/ci/appveyor/appveyor_build.sh
+++ b/tools/ci/appveyor/appveyor_build.sh
@@ -83,7 +83,7 @@ function set_configuration {
     mkdir -p "$CACHE_DIRECTORY"
 
     local CACHE_KEY CACHE_FILE_PREFIX CACHE_FILE
-    CACHE_KEY=$({ cat configure; uname; } | shasum | cut -c 1-7)
+    CACHE_KEY=$({ cat configure; uname; } | sha1sum | cut -c 1-7)
     CACHE_FILE_PREFIX="$CACHE_DIRECTORY/config.cache-$1"
     CACHE_FILE="$CACHE_FILE_PREFIX-$CACHE_KEY"
 


### PR DESCRIPTION
Two minor corrections to the AppVeyor build scripts spotted while debugging this.

The 🐪 emojus in our AppVeyor build directory is present in order to verify that UTF-16 surrogate pairs don't break the build. It's been tripped by Cygwin 3.5.x (see [upstream report](https://cygwin.com/pipermail/cygwin/2024-April/255807.html)).

Temporarily remove this until there's a diagnosis of the underlying problem / upstream fix.