### PR TITLE
Don't add the flexdll object directory to the linker path with `-nostdlib`

### DIFF
--- a/Changes
+++ b/Changes
@@ -193,6 +193,11 @@ _______________
   The syntax '-(1 [@foo])' was incorrectly parsed as '-1'.
   (Jules Aguillon, reviewed by Gabriel Scherer, report by Gabriel Scherer)
 
+* #13070: On Windows, when configured with bootstrapped flexdll, don't add
+  +flexdll to the search path when -nostdlib is specified (which then means
+  -L <path-to-flexdll> no longer gets passed to the system linker).
+  (David Allsopp, review by Florian Angeletti)
+
 - #13089: Fix bug in `runtime_events` library which could result in garbled
   output under Windows.
   (B. Szilvasy, review by Nicolás Ojeda Bär and Miod Vallat)

--- a/driver/compmisc.ml
+++ b/driver/compmisc.ml
@@ -38,7 +38,9 @@ let init_path ?(auto_include=auto_include) ?(dir="") () =
     List.concat
       [!Compenv.last_include_dirs;
        visible;
-       Config.flexdll_dirs;
+       (* Config.flexdll_dirs is either [] or ["+flexdll"]: don't include a
+          reference to the Standard Library when -nostdlib was specified. *)
+       (if !Clflags.no_std_include then [] else Config.flexdll_dirs);
        !Compenv.first_include_dirs]
   in
   let visible =

--- a/tools/ci/appveyor/appveyor_build.cmd
+++ b/tools/ci/appveyor/appveyor_build.cmd
@@ -22,7 +22,7 @@
 
 chcp 65001 > nul
 set BUILD_PREFIX=реализация
-set OCAMLROOT=%PROGRAMFILES%\Бактріан
+set OCAMLROOT=%PROGRAMFILES%\Бактріан🐫
 
 if "%1" neq "install" goto %1
 setlocal enabledelayedexpansion


### PR DESCRIPTION
Spotted while working on #13069, this is a long-standing mistake when building with bootstrapped flexdll. In this mode, the linker is effectively run with `-I +flexdll`, but this should not be done when `-nostdlib` was specified. The previous behaviour violated the hermeticity of the build; fixing it is technically a breaking change, but I don't anticipate any issues with this.