### PR TITLE
Uniform usage message for all tools

### DIFF
--- a/debugger/main.ml
+++ b/debugger/main.ml
@@ -198,6 +198,8 @@ let report report_error error =
   eprintf "Debugger [version %s] environment error:@ @[@;%a@]@.;"
     Config.version report_error error
 
+let usage = "Usage: ocamldebug [options] <program> [arguments]\nOptions are:"
+
 let main () =
   Callback.register "Debugger.function_placeholder" function_placeholder;
   try
@@ -211,11 +213,8 @@ let main () =
                                 ("camldebug" ^ (Int.to_string (Unix.getpid ())))
       );
     begin try
-      Arg.parse speclist anonymous "";
-      Arg.usage speclist
-        "No program name specified\n\
-         Usage: ocamldebug [options] <program> [arguments]\n\
-         Options are:";
+      Arg.parse speclist anonymous usage;
+      Arg.usage speclist ("No program name specified\n" ^ usage);
       exit 2
     with Found_program_name ->
       for j = !Arg.current + 1 to Array.length Sys.argv - 1 do

--- a/lex/main.ml
+++ b/lex/main.ml
@@ -21,7 +21,7 @@ let ml_automata = ref false
 let source_name = ref None
 let output_name = ref None
 
-let usage = "usage: ocamllex [options] sourcefile"
+let usage = "Usage: ocamllex [options] sourcefile\nOptions are:"
 
 let print_version_string () =
   print_string "The OCaml lexer generator, version ";

--- a/tools/ocamlcmt.ml
+++ b/tools/ocamlcmt.ml
@@ -41,7 +41,9 @@ let arg_list = Arg.align [
   ]
 
 let arg_usage =
-  "ocamlcmt [OPTIONS] FILE.cmt : read FILE.cmt and print related information"
+  "Read FILE.cmt and print related information\n\
+   Usage: ocamlcmt [options] FILE.cmt\n\
+   Options are:"
 
 let dummy_crc = String.make 32 '-'
 

--- a/tools/ocamlcp_common.ml
+++ b/tools/ocamlcp_common.ml
@@ -40,7 +40,7 @@ module Make(T: OCAMLCP) = struct
     if Filename.check_suffix filename ".ml" then with_ml := true;
     if Filename.check_suffix filename ".mli" then with_mli := true
 
-  let usage = "Usage: " ^ name ^ " <options> <files>\noptions are:"
+  let usage = "Usage: " ^ name ^ " <options> <files>\nOptions are:"
 
   let incompatible o =
     Printf.eprintf "%s: profiling is incompatible with the %s option\n" name o;

--- a/tools/ocamlprof.ml
+++ b/tools/ocamlprof.ml
@@ -482,7 +482,7 @@ let process_anon_file filename =
 
 open Format
 
-let usage = "Usage: ocamlprof <options> <files>\noptions are:"
+let usage = "Usage: ocamlprof <options> <files>\nOptions are:"
 
 let print_version () =
   printf "ocamlprof, version %s@." Sys.ocaml_version;


### PR DESCRIPTION
I noticed that ocamldebug was missing the usage line when displaying its help. That's fixed, and I've also changed other tools to report their help in a consistent fashion.

No change entry needed.