### PR TITLE
Restore the caravan on AppVeyor 🐫

### DIFF
--- a/tools/ci/appveyor/appveyor_build.cmd
+++ b/tools/ci/appveyor/appveyor_build.cmd
@@ -61,7 +61,13 @@ if %ERRORLEVEL% equ 1 (
 goto :EOF
 
 :UpgradeCygwin
-if "%CYGWIN_INSTALL_PACKAGES%" neq "" "%CYG_ROOT%\setup-x86_64.exe" --quiet-mode --no-shortcuts --no-startmenu --no-desktop --only-site --root "%CYG_ROOT%" --site "%CYG_MIRROR%" --local-package-dir "%CYG_CACHE%" --packages %CYGWIN_INSTALL_PACKAGES:~1% > nul
+if %CYGWIN_UPGRADE_REQUIRED% equ 1 (
+  set CYGWIN_FLAGS=--upgrade-also
+  set CYGWIN_UPGRADE_REQUIRED=0
+) else (
+  set CYGWIN_FLAGS=
+)
+if "%CYGWIN_INSTALL_PACKAGES%" neq "" "%CYG_ROOT%\setup-x86_64.exe" --quiet-mode --no-shortcuts --no-startmenu --no-desktop --only-site --root "%CYG_ROOT%" --site "%CYG_MIRROR%" --local-package-dir "%CYG_CACHE%" %CYGWIN_FLAGS% --packages %CYGWIN_INSTALL_PACKAGES:~1%
 for %%P in (%CYGWIN_COMMANDS%) do "%CYG_ROOT%\bin\%%P.exe" --version 2> nul > nul || set CYGWIN_UPGRADE_REQUIRED=1
 "%CYG_ROOT%\bin\bash.exe" -lc "cygcheck -dc %CYGWIN_PACKAGES%"
 if %CYGWIN_UPGRADE_REQUIRED% equ 1 (

--- a/tools/ci/appveyor/appveyor_build.cmd
+++ b/tools/ci/appveyor/appveyor_build.cmd
@@ -21,7 +21,7 @@
 @echo off
 
 chcp 65001 > nul
-set BUILD_PREFIX=реализация
+set BUILD_PREFIX=🐫реализация
 set OCAMLROOT=%PROGRAMFILES%\Бактріан🐫
 
 if "%1" neq "install" goto %1


### PR DESCRIPTION
Restores the smoke-testing emoji temporarily reverted in #13069.

- [x] Upstream Cygwin release fixing [reported 3.5.0 regression](https://cygwin.com/pipermail/cygwin/2024-April/255807.html); testable by checking the [Cygwin main page](https://cygwin.com) and seeing if "The most recent version of the Cygwin DLL is x.y.z" shows x.y.z >= 3.6.0. _3.5.4 released 25-Aug-2024 with this fix_
- [x] AppVeyor images updated to be using that release; testable by checking [the deployment history](https://www.appveyor.com/updates/) for an update made after the Cygwin release. _See [4 Sep 2024](https://www.appveyor.com/updates/2024/09/04/)_