### PR TITLE
Fix format tutorial on structural boxes

### DIFF
--- a/Changes
+++ b/Changes
@@ -79,6 +79,10 @@ _______________
 - #13045: Emphasize caution about behaviour of custom block finalizers.
   (Nick Barnes)
 
+- #13078: update Format tutorial on structural boxes to mention alignment
+  questions.
+  (Edwin Török, review by Florian Angeletti)
+
 ### Compiler user-interface and warnings:
 
 * #12084: Check link order when creating archive and when using ocamlopt

--- a/api_docgen/Format_tutorial.mld
+++ b/api_docgen/Format_tutorial.mld
@@ -256,6 +256,12 @@ this:
  )
 ]}
 
+Each break hint increases indentation by one, both for opening and closing
+parenthesis, because the parenthesis are just characters and don't have special
+meaning for the formatter.
+Notice that the closing parenthesis is not vertically aligned with the opening
+parenthesis.
+
 {1 Practical advice}
 
 When writing a pretty-printing routine, follow these simple rules:

--- a/api_docgen/Format_tutorial.mld
+++ b/api_docgen/Format_tutorial.mld
@@ -233,7 +233,7 @@ is enough room on the line, whereas with structural boxes each break hint will
 lead to a new line. For instance, when printing
 "\[(---\[(----\[(---b)\]b)\]b)\]", where "b" is a break hint without extra
 indentation ([print_cut ()]). If "\[" means opening of a packing "hov" box
-({!Format.open_hovbox}), "\[(---\[(----\[(---b)\]b)\]b)\]" is printed as
+({!Format.open_hovbox} 1), "\[(---\[(----\[(---b)\]b)\]b)\]" is printed as
 follows:
 
 {[
@@ -242,7 +242,7 @@ follows:
   (---)))
 ]}
 
-If we replace the packing boxes by structural boxes ({!Format.open_box}), each
+If we replace the packing boxes by structural boxes ({!Format.open_box} 1), each
 break hint that precedes a closing parenthesis can show the boxes structure, if
 it leads to a new line; hence "\[(---\[(----\[(---b)\]b)\]b)\]" is printed like
 this:

--- a/api_docgen/Format_tutorial.mld
+++ b/api_docgen/Format_tutorial.mld
@@ -251,9 +251,9 @@ this:
 (---
  (----
   (---
+   )
   )
  )
-)
 ]}
 
 {1 Practical advice}

--- a/api_docgen/Format_tutorial.mld
+++ b/api_docgen/Format_tutorial.mld
@@ -289,6 +289,10 @@ When writing a pretty-printing routine, follow these simple rules:
 + Never hesitate to open a box.
 + Output many break hints, otherwise the pretty-printer is in a bad situation
 where it tries to do its best, which is always "worse than your bad".
++ Break hints with negative indentation should only be used when you are sure
+that you don't exceed the indentation of the opening box (e.g. both part of
+the same function and an exact match). Exceeding the indentation of the opening
+box is not compositional.
 + Do not try to force spacing using explicit spaces in the character strings.
 For each space you want in the output emit a break hint ([print_space ()]),
 unless you explicitly don't want the line to be broken here. For instance,

--- a/api_docgen/Format_tutorial.mld
+++ b/api_docgen/Format_tutorial.mld
@@ -262,6 +262,24 @@ meaning for the formatter.
 Notice that the closing parenthesis is not vertically aligned with the opening
 parenthesis.
 
+We can line up the opening and closing parenthesis vertically in two ways:
+
+- by using a break hint "b" with negative indentation that matches the opening
+ indentation of the box `@;<0 -1>`, canceling it.
+- by using an additional box, and making all boxes and break hints use
+ no indentation: "\[(\[---\[(\[----\[(\[---\]b)\]\]b)\]\]b)\]"
+
+In both cases the output would be this:
+
+{[
+(---
+ (----
+  (---
+  )
+ )
+)
+]}
+
 {1 Practical advice}
 
 When writing a pretty-printing routine, follow these simple rules:


### PR DESCRIPTION
I was trying to use them as the format tutorial described, but it wasn't working. My initial thoughts were to use break hints with a negative indent, but surely there is a better way.
I'm not the only one who's confused by this, see the discussion at https://discuss.ocaml.org/t/format-module-from-the-standard-library/2254, which led me to https://hal.science/hal-01503081/file/format-unraveled.pdf.
Figure 2b) in that paper shows the solution: use 0 indentation structural boxes, but you need 2 of each, so that the closing parenthesis ends up in the right place.

To be fair the tutorial never said to use indented boxes, OTOH it also didn't say that you need to use 2, just one.
Keep the existing format string in the tutorial, but show what the real output is. And then show how to fix it with the additional structural boxes.
The commit messages contain sample code to show both outputs (with actual format strings and break hints, replacing `[` and `b` from the tutorial)

Finally, this is very error-prone (as evidenced by the tutorial itself being wrong, or at best ambiguous), and show how to write some helper functions (I'll probably propose including something similar into `Fmt`).
