### PR TITLE
Save and restore frame pointer across Iextcall on ARM64

### DIFF
--- a/Changes
+++ b/Changes
@@ -34,6 +34,9 @@ _______________
   current status.
   (Gabriel Scherer, review by Nick Roberts)
 
+- #13079: Save and restore frame pointer across Iextcall on ARM64
+  (Tim McGilchrist, review by KC Sivaramakrishnan and Miod Vallat)
+
 ### Standard library:
 
 - #12133: Expose support for printing substrings in Format

--- a/asmcomp/arm64/emit.mlp
+++ b/asmcomp/arm64/emit.mlp
@@ -745,9 +745,9 @@ let emit_instr env i =
           `	bl	{emit_symbol "caml_c_call"}\n`;
           `{record_frame env i.live (Dbg_other i.dbg)}\n`
         end else begin
-          (* store ocaml stack in the frame pointer register
-             NB: no need to store previous x29 because OCaml frames don't
-             maintain frame pointer *)
+          (* Push frame pointer (x29) onto stack and restore later. *)
+          `	str	x29, [sp, -16]!\n`;
+          (* Store OCaml stack in the frame pointer register. *)
           `	mov	x29, sp\n`;
           cfi_remember_state ();
           cfi_def_cfa_register ~reg:29;
@@ -756,6 +756,7 @@ let emit_instr env i =
           `	mov	sp, {emit_reg reg_tmp1}\n`;
           `	bl	{emit_symbol func}\n`;
           `	mov	sp, x29\n`;
+          `	ldr	x29, [sp], 16\n`;
           cfi_restore_state ()
         end
     | Lop(Istackoffset n) ->

--- a/runtime/arm64.S
+++ b/runtime/arm64.S
@@ -639,6 +639,8 @@ END_FUNCTION(caml_c_call_stack_args)
 
 FUNCTION(caml_start_program)
         CFI_STARTPROC
+        CFI_SIGNAL_FRAME
+
 #if defined(WITH_THREAD_SANITIZER)
         str     x0, [sp, -16]!
         CFI_ADJUST(16)
@@ -653,6 +655,7 @@ FUNCTION(caml_start_program)
 #endif
     /* domain state is passed as arg from C */
         mov     TMP, C_ARG_1
+    /* Initial entry point is caml_program */
         ADDRGLOBAL(TMP2, caml_program)
 
 /* Code shared with caml_callback* */
@@ -662,10 +665,10 @@ FUNCTION(caml_start_program)
 
 L(jump_to_caml):
     /* Set up stack frame and save callee-save registers */
-        CFI_OFFSET(29, -160)
-        CFI_OFFSET(30, -152)
         stp     x29, x30, [sp, -160]!
         CFI_ADJUST(160)
+        CFI_OFFSET(29, 0)
+        CFI_OFFSET(30, 8)
         add     x29, sp, #0
         stp     x19, x20, [sp, 16]
         stp     x21, x22, [sp, 32]


### PR DESCRIPTION
This PR restores full backtraces on macOS ARM64 with lldb. 

In OCaml 5.1.1 lldb looses the full backtrace once it reaches OCaml code as shown in this lldb session using this example program:

```ocaml
(* fib.ml *)
let rec fib n =
  if n = 0 then 0
  else if n = 1 then 1
  else fib (n-1) + fib (n-2)

let main () =
  let a = 10 in
  let r = fib a in
  Printf.printf "fib(%d) = %d" a r

let _ = main ()
```

```
(lldb) br list
Current breakpoints:
1: name = 'caml_program', locations = 1, resolved = 1, hit count = 1
  1.1: where = fib-5.1.1.exe`caml_program, address = 0x0000000100003c10, resolved, hit count = 1 

3: address = fib-5.1.1.exe[0x0000000100006930], locations = 1
  3.1: where = fib-5.1.1.exe`camlFib.main_271, address = 0x0000000100006930, unresolved, hit count = 0 

(lldb) run
Process 64477 launched: '/Users/tsmc/projects/ocaml/fib-5.1.1.exe' (arm64)
Process 64477 stopped
* thread #1, queue = 'com.apple.main-thread', stop reason = breakpoint 1.1
    frame #0: 0x0000000100003c10 fib-5.1.1.exe`caml_program
fib-5.1.1.exe`caml_program:
->  0x100003c10 <+0>:  ldr    x16, [x28, #0x28]
    0x100003c14 <+4>:  add    x16, x16, #0x148
    0x100003c18 <+8>:  cmp    sp, x16
    0x100003c1c <+12>: b.lo   0x100003c00               ; caml_startup.code_begin + 8
Target 0: (fib-5.1.1.exe) stopped.
(lldb) bt
* thread #1, queue = 'com.apple.main-thread', stop reason = breakpoint 1.1
  * frame #0: 0x0000000100003c10 fib-5.1.1.exe`caml_program
    frame #1: 0x0000000100060290 fib-5.1.1.exe`caml_start_program + 132
    frame #2: 0x000000010005fb2c fib-5.1.1.exe`caml_startup_common(argv=0x000000016fdff330, pooling=<unavailable>) at startup_nat.c:132:9 [opt]
    frame #3: 0x000000010005fb90 fib-5.1.1.exe`caml_main [inlined] caml_startup_exn(argv=<unavailable>) at startup_nat.c:139:10 [opt]
    frame #4: 0x000000010005fb88 fib-5.1.1.exe`caml_main [inlined] caml_startup(argv=<unavailable>) at startup_nat.c:144:15 [opt]
    frame #5: 0x000000010005fb88 fib-5.1.1.exe`caml_main(argv=<unavailable>) at startup_nat.c:151:3 [opt]
    frame #6: 0x000000010004ebd4 fib-5.1.1.exe`main(argc=<unavailable>, argv=<unavailable>) at main.c:37:3 [opt]
    frame #7: 0x0000000197c860e0 dyld`start + 2360
(lldb) c
Process 64477 resuming
Process 64477 stopped
* thread #1, queue = 'com.apple.main-thread', stop reason = breakpoint 3.1
    frame #0: 0x0000000100006930 fib-5.1.1.exe`camlFib.main_271
fib-5.1.1.exe`camlFib.main_271:
->  0x100006930 <+0>:  ldr    x16, [x28, #0x28]
    0x100006934 <+4>:  add    x16, x16, #0x158
    0x100006938 <+8>:  cmp    sp, x16
    0x10000693c <+12>: b.lo   0x100006920               ; camlFib.fib_269 + 128
Target 0: (fib-5.1.1.exe) stopped.
(lldb) bt
* thread #1, queue = 'com.apple.main-thread', stop reason = breakpoint 3.1
  * frame #0: 0x0000000100006930 fib-5.1.1.exe`camlFib.main_271
    frame #1: 0x0000000100006a1c fib-5.1.1.exe`camlFib.entry + 108
    frame #2: 0x0000000100003dec fib-5.1.1.exe`caml_program + 476
    frame #3: 0x0000000100060290 fib-5.1.1.exe`caml_start_program + 132
    frame #4: 0x0000000100003dec fib-5.1.1.exe`caml_program + 476

```

With this change the full backtrace is present:

```
(lldb) bt
* thread #1, queue = 'com.apple.main-thread', stop reason = breakpoint 3.1
  * frame #0: 0x0000000100004420 fib.exe`camlFib.fib_270
    frame #1: 0x00000001000044dc fib.exe`camlFib.main_272 + 44
    frame #2: 0x00000001000045ac fib.exe`camlFib.entry + 124
    frame #3: 0x000000010000196c fib.exe`caml_program + 476
    frame #4: 0x00000001000640b4 fib.exe`caml_start_program + 132
    frame #5: 0x0000000100063948 fib.exe`caml_startup_common(argv=0x000000016fdff340, pooling=<unavailable>) at startup_nat.c:128:9 [opt]
    frame #6: 0x00000001000639ac fib.exe`caml_main [inlined] caml_startup_exn(argv=<unavailable>) at startup_nat.c:135:10 [opt]
    frame #7: 0x00000001000639a4 fib.exe`caml_main [inlined] caml_startup(argv=<unavailable>) at startup_nat.c:140:15 [opt]
    frame #8: 0x00000001000639a4 fib.exe`caml_main(argv=<unavailable>) at startup_nat.c:147:3 [opt]
    frame #9: 0x000000010004e640 fib.exe`main(argc=<unavailable>, argv=<unavailable>) at main.c:37:3 [opt]
    frame #10: 0x0000000197c860e0 dyld`start + 2360

```

Additionally on linux arm64 using gdb, adding `CFI_SIGNAL_FRAME` to `caml_start_program` replaces that frame with ` <signal handler called>` :

``` shell
(gdb) bt
#0  camlFib.main_272 () at fib.ml:7
#1  0x0000aaaaaaaf1584 in camlFib.entry () at fib.ml:12
#2  0x0000aaaaaaaeea44 in caml_program ()
#3  <signal handler called>
#4  0x0000aaaaaab4a178 in caml_startup_common (pooling=-1430712296, argv=0x10) at runtime/startup_nat.c:128
#5  caml_startup_common (argv=0x10, pooling=-1430712296) at runtime/startup_nat.c:87
#6  0x0000aaaaaab4a1f0 in caml_startup_exn (argv=<optimized out>) at runtime/startup_nat.c:135
#7  caml_startup (argv=<optimized out>) at runtime/startup_nat.c:140
#8  caml_main (argv=<optimized out>) at runtime/startup_nat.c:147
#9  0x0000aaaaaaaee6d0 in main (argc=<optimized out>, argv=<optimized out>) at runtime/main.c:37
```
This matches the backtraces generated on linux x86_64 but is not necessary to provide a full backtrace. Linux LLDB is unaffected by this change, it already had working backtraces.