### PR TITLE
C fixes for Windows

### DIFF
--- a/otherlibs/unix/access.c
+++ b/otherlibs/unix/access.c
@@ -24,7 +24,9 @@
 #ifdef HAS_UNISTD
 # include <unistd.h>
 #else
-# ifndef _WIN32
+# ifdef _WIN32
+#  include <io.h>
+# else
 #  include <sys/file.h>
 # endif
 # ifndef R_OK

--- a/otherlibs/unix/chmod.c
+++ b/otherlibs/unix/chmod.c
@@ -17,6 +17,9 @@
 
 #include <sys/types.h>
 #include <sys/stat.h>
+#ifdef _WIN32
+#include <io.h>
+#endif
 #include <caml/mlvalues.h>
 #include <caml/memory.h>
 #include <caml/signals.h>

--- a/otherlibs/unix/close_win32.c
+++ b/otherlibs/unix/close_win32.c
@@ -13,6 +13,7 @@
 /*                                                                        */
 /**************************************************************************/
 
+#include <io.h>
 #include <caml/mlvalues.h>
 #include "caml/unixsupport.h"
 #include <caml/io.h>

--- a/otherlibs/unix/dup_win32.c
+++ b/otherlibs/unix/dup_win32.c
@@ -20,6 +20,7 @@
 
 #define _WIN32_LEAN_AND_MEAN
 #include <winsock2.h>
+#include <io.h>
 
 static HANDLE duplicate_handle(BOOL inherit, HANDLE oldh)
 {

--- a/otherlibs/unix/select_win32.c
+++ b/otherlibs/unix/select_win32.c
@@ -330,7 +330,6 @@ static void read_console_poll(HANDLE hStop, void *_data)
 
   DEBUG_PRINT("Waiting for data on console");
 
-  record;
   waitRes = 0;
   n = 0;
   lpSelectData = (LPSELECTDATA)_data;

--- a/otherlibs/unix/socketaddr.c
+++ b/otherlibs/unix/socketaddr.c
@@ -27,6 +27,7 @@
 #ifdef _WIN32
 #undef EAFNOSUPPORT
 #define EAFNOSUPPORT WSAEAFNOSUPPORT
+#include <io.h>
 #endif
 
 CAMLexport value caml_unix_alloc_inet_addr(struct in_addr * a)

--- a/runtime/backtrace_byt.c
+++ b/runtime/backtrace_byt.c
@@ -26,6 +26,9 @@
 #ifdef HAS_UNISTD
 #include <unistd.h>
 #endif
+#ifdef _WIN32
+#include <io.h>
+#endif
 
 #include "caml/mlvalues.h"
 #include "caml/alloc.h"

--- a/runtime/dynlink.c
+++ b/runtime/dynlink.c
@@ -26,6 +26,9 @@
 #ifdef HAS_UNISTD
 #include <unistd.h>
 #endif
+#ifdef _WIN32
+#include <io.h>
+#endif
 #include "caml/alloc.h"
 #include "caml/dynlink.h"
 #include "caml/fail.h"

--- a/runtime/startup_byt.c
+++ b/runtime/startup_byt.c
@@ -27,6 +27,7 @@
 #include <unistd.h>
 #endif
 #ifdef _WIN32
+#include <io.h>
 #include <process.h>
 #endif
 #include "caml/alloc.h"

--- a/runtime/sys.c
+++ b/runtime/sys.c
@@ -28,6 +28,7 @@
 #include <sys/stat.h>
 #ifdef _WIN32
 #include <direct.h> /* for _wchdir and _wgetcwd */
+#include <io.h> /* for _wopen and close */
 #else
 #include <sys/wait.h>
 #endif

--- a/yacc/error.c
+++ b/yacc/error.c
@@ -77,7 +77,7 @@ static void print_pos(char *st_line, char *st_cptr)
 }
 
 
-static Noreturn void gen_error(int st_lineno, char *st_line, char *st_cptr, char *msg)
+CAMLnoret static void gen_error(int st_lineno, char *st_line, char *st_cptr, char *msg)
 {
     fprintf(stderr, "File \"%s\", line %d: %s\n",
             virtual_input_file_name, st_lineno, msg);


### PR DESCRIPTION
A collection of C fixes for Windows, found by compiling OCaml with clang-cl (more on that later). clang-cl reports these issues by default, blocking compilation. ~IMO these should be backported to 5.2 as they improve code quality under MSVC.~

[Add missing includes of io.h for Windows](https://github.com/ocaml/ocaml/commit/1d898886bc0d89ef13cc31df87d715e644e254cf) escaped our sight as functions missing prototypes were returning already `int`, and the compiler assumes a default return type of `int` (so no mismatch reported); and MSVC doesn't warn for missing function prototypes by default.

no change entry needed?