### PR TITLE
Use macros from `limits.h` to prevent signed integer wrap-around warnigns

### DIFF
--- a/Changes
+++ b/Changes
@@ -82,6 +82,7 @@ _______________
    Gabriel Scherer)
 
 - #13083: Use macros from limits.h to avoid signed-integer wrap-around.
+  Introduce CAML_{U,}INTNAT_{MIN,MAX} macros to expose {u,}intnat limits.
   (Antonin Décimo, review by Nick Barnes, Xavier Leroy, Gabriel Scherer,
    and Miod Vallat)
 

--- a/Changes
+++ b/Changes
@@ -81,6 +81,10 @@ _______________
   (Antonin Décimo, review by Nicolás Ojeda Bär, Xavier Leroy, and
    Gabriel Scherer)
 
+- #13083: Use macros from limits.h to avoid signed-integer wrap-around.
+  (Antonin Décimo, review by Nick Barnes, Xavier Leroy, Gabriel Scherer,
+   and Miod Vallat)
+
 ### Code generation and optimizations:
 
 - #13014: Enable compile-time option -function-sections on all previously

--- a/runtime/array.c
+++ b/runtime/array.c
@@ -25,7 +25,7 @@
 #include "caml/signals.h"
 #include "caml/runtime_events.h"
 
-static const mlsize_t mlsize_t_max = -1;
+static const mlsize_t mlsize_t_max = CAML_UINTNAT_MAX;
 
 /* returns number of elements (either fields or floats) */
 /* [ 'a array -> int ] */

--- a/runtime/bigarray.c
+++ b/runtime/bigarray.c
@@ -558,10 +558,10 @@ CAMLexport void caml_ba_serialize(value v,
   case CAML_BA_COMPLEX64:
     caml_serialize_block_8(b->data, num_elts * 2); break;
   case CAML_BA_CAML_INT:
-    caml_ba_serialize_longarray(b->data, num_elts, -0x40000000, 0x3FFFFFFF);
+    caml_ba_serialize_longarray(b->data, num_elts, INT32_MIN/2, INT32_MAX/2);
     break;
   case CAML_BA_NATIVE_INT:
-    caml_ba_serialize_longarray(b->data, num_elts, -0x80000000, 0x7FFFFFFF);
+    caml_ba_serialize_longarray(b->data, num_elts, INT32_MIN, INT32_MAX);
     break;
   }
   /* Compute required size in OCaml heap.  Assumes struct caml_ba_array

--- a/runtime/caml/config.h
+++ b/runtime/caml/config.h
@@ -138,8 +138,10 @@ typedef uint64_t uintnat;
 #error "No integer type available to represent pointers"
 #endif
 
-#define INTNAT_MIN INTPTR_MIN
-#define UINTNAT_MAX UINTPTR_MAX
+#define CAML_INTNAT_MIN INTPTR_MIN
+#define CAML_INTNAT_MAX INTPTR_MAX
+#define CAML_UINTNAT_MIN UINTPTR_MIN
+#define CAML_UINTNAT_MAX UINTPTR_MAX
 
 #endif /* CAML_CONFIG_H_NO_TYPEDEFS */
 

--- a/runtime/caml/config.h
+++ b/runtime/caml/config.h
@@ -49,6 +49,7 @@
 #ifndef CAML_CONFIG_H_NO_TYPEDEFS
 
 #include <stddef.h>
+#include <limits.h>
 
 #if defined(HAS_LOCALE_H) || defined(HAS_XLOCALE_H)
 #define HAS_LOCALE
@@ -137,7 +138,8 @@ typedef uint64_t uintnat;
 #error "No integer type available to represent pointers"
 #endif
 
-#define UINTNAT_MAX ((uintnat)-1)
+#define INTNAT_MIN INTPTR_MIN
+#define UINTNAT_MAX UINTPTR_MAX
 
 #endif /* CAML_CONFIG_H_NO_TYPEDEFS */
 

--- a/runtime/caml/lf_skiplist.h
+++ b/runtime/caml/lf_skiplist.h
@@ -69,7 +69,7 @@ extern int caml_lf_skiplist_find(struct lf_skiplist *sk, uintnat key,
 extern int caml_lf_skiplist_find_below(struct lf_skiplist *sk, uintnat k,
                                        /*out*/ uintnat *key,
                                        /*out*/ uintnat *data);
-/* Insertion in a skip list. [key] must be between 1 and UINTNAT_MAX-1.
+/* Insertion in a skip list. [key] must be between 1 and CAML_UINTNAT_MAX-1.
    If [key] was already there, change the associated data and return 1.
    If [key] was not there, insert new [key, data] binding and return 0. */
 extern int caml_lf_skiplist_insert(struct lf_skiplist *sk, uintnat key,

--- a/runtime/compare.c
+++ b/runtime/compare.c
@@ -119,7 +119,7 @@ static void run_pending_actions(struct compare_stack* stk,
 #define LESS -1
 #define EQUAL 0
 #define GREATER 1
-#define UNORDERED ((intnat)1 << (8 * sizeof(value) - 1))
+#define UNORDERED INTNAT_MIN
 
 /* The return value of compare_val is as follows:
       > 0                 v1 is greater than v2

--- a/runtime/compare.c
+++ b/runtime/compare.c
@@ -119,7 +119,7 @@ static void run_pending_actions(struct compare_stack* stk,
 #define LESS -1
 #define EQUAL 0
 #define GREATER 1
-#define UNORDERED INTNAT_MIN
+#define UNORDERED CAML_INTNAT_MIN
 
 /* The return value of compare_val is as follows:
       > 0                 v1 is greater than v2

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -326,12 +326,12 @@ CAMLexport caml_domain_state* caml_get_domain_state(void)
 Caml_inline void interrupt_domain(struct interruptor* s)
 {
   atomic_uintnat * interrupt_word = atomic_load_relaxed(&s->interrupt_word);
-  atomic_store_release(interrupt_word, UINTNAT_MAX);
+  atomic_store_release(interrupt_word, CAML_UINTNAT_MAX);
 }
 
 Caml_inline void interrupt_domain_local(caml_domain_state* dom_st)
 {
-  atomic_store_relaxed(&dom_st->young_limit, UINTNAT_MAX);
+  atomic_store_relaxed(&dom_st->young_limit, CAML_UINTNAT_MAX);
 }
 
 int caml_incoming_interrupts_queued(void)

--- a/runtime/ints.c
+++ b/runtime/ints.c
@@ -81,7 +81,7 @@ static intnat parse_intnat(value s, int nbits, const char *errmsg)
   int sign, base, signedness, d;
 
   p = parse_sign_and_base(String_val(s), &base, &signedness, &sign);
-  threshold = ((uintnat) -1) / base;
+  threshold = UINTNAT_MAX / base;
   d = parse_digit(*p);
   if (d < 0 || d >= base) caml_failwith(errmsg);
   for (p++, res = d; /*nothing*/; p++) {
@@ -251,7 +251,7 @@ CAMLprim value caml_int32_div(value v1, value v2)
   if (divisor == 0) caml_raise_zero_divide();
   /* PR#4740: on some processors, division crashes on overflow.
      Implement the same behavior as for type "int". */
-  if (dividend == (1<<31) && divisor == -1) return v1;
+  if (dividend == INT32_MIN && divisor == -1) return v1;
   return caml_copy_int32(dividend / divisor);
 }
 
@@ -262,7 +262,7 @@ CAMLprim value caml_int32_mod(value v1, value v2)
   if (divisor == 0) caml_raise_zero_divide();
   /* PR#4740: on some processors, modulus crashes if division overflows.
      Implement the same behavior as for type "int". */
-  if (dividend == (1<<31) && divisor == -1) return caml_copy_int32(0);
+  if (dividend == INT32_MIN && divisor == -1) return caml_copy_int32(0);
   return caml_copy_int32(dividend % divisor);
 }
 
@@ -450,8 +450,6 @@ CAMLprim value caml_int64_sub(value v1, value v2)
 CAMLprim value caml_int64_mul(value v1, value v2)
 { return caml_copy_int64(Int64_val(v1) * Int64_val(v2)); }
 
-#define Int64_min_int ((intnat) 1 << (sizeof(intnat) * 8 - 1))
-
 CAMLprim value caml_int64_div(value v1, value v2)
 {
   int64_t dividend = Int64_val(v1);
@@ -459,7 +457,7 @@ CAMLprim value caml_int64_div(value v1, value v2)
   if (divisor == 0) caml_raise_zero_divide();
   /* PR#4740: on some processors, division crashes on overflow.
      Implement the same behavior as for type "int". */
-  if (dividend == ((int64_t)1 << 63) && divisor == -1) return v1;
+  if (dividend == INT64_MIN && divisor == -1) return v1;
   return caml_copy_int64(dividend / divisor);
 }
 
@@ -470,7 +468,7 @@ CAMLprim value caml_int64_mod(value v1, value v2)
   if (divisor == 0) caml_raise_zero_divide();
   /* PR#4740: on some processors, division crashes on overflow.
      Implement the same behavior as for type "int". */
-  if (dividend == ((int64_t)1 << 63) && divisor == -1){
+  if (dividend == INT64_MIN && divisor == -1){
     return caml_copy_int64(0);
   }
   return caml_copy_int64(dividend % divisor);
@@ -666,7 +664,7 @@ static void nativeint_serialize(value v, uintnat * bsize_32,
 {
   intnat l = Nativeint_val(v);
 #ifdef ARCH_SIXTYFOUR
-  if (l >= -((intnat)1 << 31) && l < ((intnat)1 << 31)) {
+  if ((intnat)INT32_MIN <= l && l <= (intnat)INT32_MAX) {
     caml_serialize_int_1(1);
     caml_serialize_int_4((int32_t) l);
   } else {
@@ -731,8 +729,6 @@ CAMLprim value caml_nativeint_sub(value v1, value v2)
 CAMLprim value caml_nativeint_mul(value v1, value v2)
 { return caml_copy_nativeint(Nativeint_val(v1) * Nativeint_val(v2)); }
 
-#define Nativeint_min_int ((intnat) 1 << (sizeof(intnat) * 8 - 1))
-
 CAMLprim value caml_nativeint_div(value v1, value v2)
 {
   intnat dividend = Nativeint_val(v1);
@@ -740,7 +736,7 @@ CAMLprim value caml_nativeint_div(value v1, value v2)
   if (divisor == 0) caml_raise_zero_divide();
   /* PR#4740: on some processors, modulus crashes if division overflows.
      Implement the same behavior as for type "int". */
-  if (dividend == Nativeint_min_int && divisor == -1) return v1;
+  if (dividend == INTNAT_MIN && divisor == -1) return v1;
   return caml_copy_nativeint(dividend / divisor);
 }
 
@@ -751,7 +747,7 @@ CAMLprim value caml_nativeint_mod(value v1, value v2)
   if (divisor == 0) caml_raise_zero_divide();
   /* PR#4740: on some processors, modulus crashes if division overflows.
      Implement the same behavior as for type "int". */
-  if (dividend == Nativeint_min_int && divisor == -1){
+  if (dividend == INTNAT_MIN && divisor == -1){
     return caml_copy_nativeint(0);
   }
   return caml_copy_nativeint(dividend % divisor);

--- a/runtime/ints.c
+++ b/runtime/ints.c
@@ -81,7 +81,7 @@ static intnat parse_intnat(value s, int nbits, const char *errmsg)
   int sign, base, signedness, d;
 
   p = parse_sign_and_base(String_val(s), &base, &signedness, &sign);
-  threshold = UINTNAT_MAX / base;
+  threshold = CAML_UINTNAT_MAX / base;
   d = parse_digit(*p);
   if (d < 0 || d >= base) caml_failwith(errmsg);
   for (p++, res = d; /*nothing*/; p++) {
@@ -736,7 +736,7 @@ CAMLprim value caml_nativeint_div(value v1, value v2)
   if (divisor == 0) caml_raise_zero_divide();
   /* PR#4740: on some processors, modulus crashes if division overflows.
      Implement the same behavior as for type "int". */
-  if (dividend == INTNAT_MIN && divisor == -1) return v1;
+  if (dividend == CAML_INTNAT_MIN && divisor == -1) return v1;
   return caml_copy_nativeint(dividend / divisor);
 }
 
@@ -747,7 +747,7 @@ CAMLprim value caml_nativeint_mod(value v1, value v2)
   if (divisor == 0) caml_raise_zero_divide();
   /* PR#4740: on some processors, modulus crashes if division overflows.
      Implement the same behavior as for type "int". */
-  if (dividend == INTNAT_MIN && divisor == -1){
+  if (dividend == CAML_INTNAT_MIN && divisor == -1){
     return caml_copy_nativeint(0);
   }
   return caml_copy_nativeint(dividend % divisor);

--- a/runtime/lf_skiplist.c
+++ b/runtime/lf_skiplist.c
@@ -105,7 +105,7 @@ void caml_lf_skiplist_init(struct lf_skiplist *sk) {
 
   sk->tail = caml_stat_alloc(SIZEOF_LF_SKIPCELL +
                              NUM_LEVELS * sizeof(struct lf_skipcell *));
-  sk->tail->key = UINTNAT_MAX;
+  sk->tail->key = CAML_UINTNAT_MAX;
   sk->tail->data = 0;
   sk->tail->garbage_next = NULL;
   sk->tail->top_level = NUM_LEVELS - 1;
@@ -329,7 +329,7 @@ int caml_lf_skiplist_insert(struct lf_skiplist *sk, uintnat key, uintnat data) {
   struct lf_skipcell *preds[NUM_LEVELS];
   struct lf_skipcell *succs[NUM_LEVELS];
 
-  CAMLassert(key > 0 && key < UINTNAT_MAX);
+  CAMLassert(key > 0 && key < CAML_UINTNAT_MAX);
 
   while (1) {
     /* We first try to find a node with [key] in the skip list. If it exists

--- a/runtime/signals.c
+++ b/runtime/signals.c
@@ -178,7 +178,7 @@ CAMLexport void caml_enter_blocking_section(void)
        done; otherwise, try again. Since we do not hold the domain
        lock, we cannot read [young_ptr] and we cannot call
        [Caml_check_gc_interrupt]. */
-    if (atomic_load_relaxed(&domain->young_limit) != UINTNAT_MAX) break;
+    if (atomic_load_relaxed(&domain->young_limit) != CAML_UINTNAT_MAX) break;
     caml_leave_blocking_section_hook ();
   }
 }


### PR DESCRIPTION
The code is currently correct since we use wrap-around semantics for signed integers (`-fwrapv`), but:
- it's difficult to communicate that fact to static analyzers, which warn when computing the minimum integer with left-shifting 1 to the sign bit position (most-significant bit);
- MSVC doesn't support wrap-around semantics, but historically hasn't optimized for this (so no harm), and might innocuously warn. 

Using constants from `<limits.h>` instead allows for self-documenting code and silences these warnings.

**Computing the minimum signed integer**

From the standard (which I recall doesn't consider wrap-around semantics for signed integers):

> The result of `E1 << E2` is `E1` left-shifted `E2` bit positions; vacated bits are filled with zeros. […] If `E1` has a signed type and nonnegative value, and `E1 × 2^E2` is can't be represented in the result type, then that is the resulting value; otherwise, the behavior is undefined.

The problem being that the result of `1 << CHAR_BIT * sizeof(int) - 1` to compute the minimum `int` can't be represented in the result type (it's 2^63, but the maximum is 2^63-1); without wrap-around.

Introduce the `INTNAT_MIN` macro to avoid independent re-definitions of this value.


Is a change entry needed?
This also prevents warnings raised under Windows by clang-cl and improves code quality with MSVC.

(I might have confused _undefined_ behavior with _unspecified_ behavior, oh well)