### PR TITLE
Make [list_labels] pure

### DIFF
--- a/Changes
+++ b/Changes
@@ -200,6 +200,12 @@ _______________
 - #13094: Fix undefined behavior of left-shifting a negative number.
   (Antonin Décimo, review by Miod Vallat and Nicolás Ojeda Bär)
 
+- #13088: A few type-checker behaviors look at a type to see if there are
+  any labeled arguments in it. This sometimes required expansion, which
+  could, in obscure scenarios, result in superfluous type errors.
+  (Richard Eisenberg, review by Gabriel Scherer and Jacques Garrigue)
+
+
 OCaml 5.2.0
 ------------
 

--- a/testsuite/tests/typing-gadts/optional_args.ml
+++ b/testsuite/tests/typing-gadts/optional_args.ml
@@ -1,0 +1,66 @@
+(* TEST
+ expect;
+*)
+
+type (_, _) refl = Refl : ('a, 'a) refl
+
+[%%expect{|
+type (_, _) refl = Refl : ('a, 'a) refl
+|}]
+
+let apply (_ : unit -> 'a) : 'a = assert false
+let go (type a) (Refl : (unit, a) refl) = apply (fun () : a -> ())
+
+[%%expect{|
+val apply : (unit -> 'a) -> 'a = <fun>
+val go : (unit, 'a) refl -> 'a = <fun>
+|}]
+
+let apply (_ : x:unit -> unit -> 'a) : 'a = assert false
+let go (type a) (Refl : (unit, a) refl) = apply (fun ~x:_ () : a -> ())
+
+[%%expect{|
+val apply : (x:unit -> unit -> 'a) -> 'a = <fun>
+val go : (unit, 'a) refl -> 'a = <fun>
+|}]
+
+let apply (_ : ?x:unit -> unit -> 'a) : 'a = assert false
+let go (type a) (Refl : (unit, a) refl) = apply (fun ?x:_ () : a -> ())
+
+[%%expect{|
+val apply : (?x:unit -> unit -> 'a) -> 'a = <fun>
+Line 2, characters 42-71:
+2 | let go (type a) (Refl : (unit, a) refl) = apply (fun ?x:_ () : a -> ())
+                                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This expression has type "a" = "unit"
+       but an expression was expected of type "'a"
+       This instance of "unit" is ambiguous:
+       it would escape the scope of its equation
+|}]
+
+let apply (_ : unit -> x:unit -> 'a) : 'a = assert false
+let go (type a) (Refl : (unit, a) refl) = apply (fun () ~x:_ : a -> ())
+
+[%%expect{|
+val apply : (unit -> x:unit -> 'a) -> 'a = <fun>
+val go : (unit, 'a) refl -> 'a = <fun>
+|}]
+
+let apply (_ : unit -> ?x:unit -> 'a) : 'a = assert false
+let go (type a) (Refl : (unit, a) refl) = apply (fun () ?x:_ : a -> ())
+
+[%%expect{|
+val apply : (unit -> ?x:unit -> 'a) -> 'a = <fun>
+Line 2, characters 59-60:
+2 | let go (type a) (Refl : (unit, a) refl) = apply (fun () ?x:_ : a -> ())
+                                                               ^
+Warning 16 [unerasable-optional-argument]: this optional argument cannot be erased.
+
+Line 2, characters 42-71:
+2 | let go (type a) (Refl : (unit, a) refl) = apply (fun () ?x:_ : a -> ())
+                                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This expression has type "a" = "unit"
+       but an expression was expected of type "'a"
+       This instance of "unit" is ambiguous:
+       it would escape the scope of its equation
+|}]

--- a/testsuite/tests/typing-gadts/optional_args.ml
+++ b/testsuite/tests/typing-gadts/optional_args.ml
@@ -29,13 +29,7 @@ let go (type a) (Refl : (unit, a) refl) = apply (fun ?x:_ () : a -> ())
 
 [%%expect{|
 val apply : (?x:unit -> unit -> 'a) -> 'a = <fun>
-Line 2, characters 42-71:
-2 | let go (type a) (Refl : (unit, a) refl) = apply (fun ?x:_ () : a -> ())
-                                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This expression has type "a" = "unit"
-       but an expression was expected of type "'a"
-       This instance of "unit" is ambiguous:
-       it would escape the scope of its equation
+val go : (unit, 'a) refl -> 'a = <fun>
 |}]
 
 let apply (_ : unit -> x:unit -> 'a) : 'a = assert false
@@ -56,11 +50,5 @@ Line 2, characters 59-60:
                                                                ^
 Warning 16 [unerasable-optional-argument]: this optional argument cannot be erased.
 
-Line 2, characters 42-71:
-2 | let go (type a) (Refl : (unit, a) refl) = apply (fun () ?x:_ : a -> ())
-                                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This expression has type "a" = "unit"
-       but an expression was expected of type "'a"
-       This instance of "unit" is ambiguous:
-       it would escape the scope of its equation
+val go : (unit, 'a) refl -> 'a = <fun>
 |}]

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -2807,7 +2807,12 @@ let rec list_labels_aux env visited ls ty_fun =
       List.rev ls, is_Tvar ty
 
 let list_labels env ty =
-  wrap_trace_gadt_instances env (list_labels_aux env TypeSet.empty []) ty
+  let snap = Btype.snapshot () in
+  let result =
+    wrap_trace_gadt_instances env (list_labels_aux env TypeSet.empty []) ty
+  in
+  Btype.backtrack snap;
+  result
 
 (* Check that all univars are safe in a type. Both exp.exp_type and
    ty_expected should already be generalized. *)


### PR DESCRIPTION
In the handling of the unerasable argument warning, we have to check whether a function has any unlabeled arguments remaining. The check requires expansion, which affects GADT typing. This update makes the `list_labels` function pure, avoiding a degradation in typing from the unerasable argument check.

The first commit adds the failing test; the second commit fixes the bug and updates the test. 