### PR TITLE
Fix `snprintf_os` use in `runtime_events_consumer.c`

### DIFF
--- a/Changes
+++ b/Changes
@@ -172,9 +172,9 @@ _______________
   The syntax '-(1 [@foo])' was incorrectly parsed as '-1'.
   (Jules Aguillon, reviewed by Gabriel Scherer, report by Gabriel Scherer)
 
-- #13089: Fix `snprintf_os` call in runtime events consumer using a
-   byte string rather than an OS string.
-   (B. Szilvasy, review by Nicolás Ojeda Bär and Miod Vallat)
+- #13089: Fix bug in `runtime_events` library which could result in garbled
+  output under Windows.
+  (B. Szilvasy, review by Nicolás Ojeda Bär and Miod Vallat)
 
 OCaml 5.2.0
 ------------

--- a/Changes
+++ b/Changes
@@ -172,6 +172,9 @@ _______________
   The syntax '-(1 [@foo])' was incorrectly parsed as '-1'.
   (Jules Aguillon, reviewed by Gabriel Scherer, report by Gabriel Scherer)
 
+- #13089: Fix `snprintf_os` call in runtime events consumer using a
+   byte string rather than an OS string.
+   (B. Szilvasy, review by Nicolás Ojeda Bär and Miod Vallat)
 
 OCaml 5.2.0
 ------------

--- a/otherlibs/runtime_events/runtime_events_consumer.c
+++ b/otherlibs/runtime_events/runtime_events_consumer.c
@@ -124,10 +124,8 @@ caml_runtime_events_create_cursor(const char_os* runtime_events_path, int pid,
   } else {
   /* In this case we are reading the ring for a different process */
     if (runtime_events_path) {
-      char* path_u8 = caml_stat_strdup_of_os(runtime_events_path);
       ret = snprintf_os(runtime_events_loc, RING_FILE_NAME_MAX_LEN,
-                      T("%s/%d.events"), path_u8, pid);
-      caml_stat_free(path_u8);
+                        T("%s/%d.events"), runtime_events_path, pid);
     } else {
       ret =
           snprintf_os(runtime_events_loc, RING_FILE_NAME_MAX_LEN,


### PR DESCRIPTION
This PR fixes an incorrect use of `snprintf_os` for formatting the runtime events ring file path in the implementation of `otherlibs/runtime_events`. Specifically, this changes the call to use the OS string rather than a `char *` copy, which both matches how it is constructed in `runtime_events.c`:

https://github.com/ocaml/ocaml/blob/a7afade7ad7cf1cffc21579e7ab2cd821122376b/runtime/runtime_events.c#L96
https://github.com/ocaml/ocaml/blob/a7afade7ad7cf1cffc21579e7ab2cd821122376b/runtime/runtime_events.c#L264-L265

and is actually correct. It also has the benefit of removing a single alloc/free pair on all OSes.

---

This bug only manifests on Windows, where `char_os` is not `char`, and thus was unlikely to have been tested by anyone (before me, I suppose[^1]). Windows has further issues with this API, in how the `Unix` library handles PIDs on Windows (as `HANDLE`s casted to `int`, rather than real PIDs, see a similar issue in #11021), which makes some existing uses of `Runtime_events.create_cursor` still broken on Windows, with no unambiguous fix.[^2]

At a glance, there seem to be further bugs in this function too. For instance, `runtime_events_loc` is unconditionally initialised to `caml_stat_alloc_noexc(RING_FILE_NAME_MAX_LEN)`, but isn't freed on the code path with `pid < 0`, nor does it seem to be freed at all if the function completes unexceptionally. I'm also slightly weary of the use of `int` for the PID[^3].

I don't think a change entry is needed for this fix specifically, but it could be linked to the change entry with a bug fix for the above.

[^1]: I've successfully attached to another process using runtime events on a build of OCaml that includes this fix as well as another to fix the PID issue, but I could produce a program that attaches with just this fix, if desired.

[^2]: There are many different options: This function could perform the `HANDLE` to PID conversion, however that would fail if the user does provide an actual PID. The `Unix` library could also be changed: a `pidfd` type; providing a way to get the real PID; returning actual PIDs even on Windows; etc. Another option would be to sidestep the use of PIDs altogether, and add something like `OCAML_RUNTIME_EVENTS_FILE` to specify an exact file.

[^3]: It should work fine on Linux (`PID_MAX_LIMIT` is 2^22 on 64-bit systems, according to [proc(5)](https://www.man7.org/linux/man-pages/man5/proc.5.html)) and macOS (according to [this SO post](https://apple.stackexchange.com/questions/51119/whats-the-maximum-pid-for-mac-os-x), PIDs don't go higher than 99998). However it could be an issue on Windows, either if we interpret it as a `HANDLE` (which is a pointer), or as an actual PID (Raymond Chen claims to have seen PIDs in the 4 bn. range in [this SO comment](https://stackoverflow.com/questions/17868218/what-is-the-maximum-process-id-on-windows#comment26090248_17868515)).