### PR TITLE
Fix some memory bugs in `runtime_events_consumer.c`

### DIFF
--- a/otherlibs/runtime_events/runtime_events_consumer.c
+++ b/otherlibs/runtime_events/runtime_events_consumer.c
@@ -172,9 +172,9 @@ cursor_map_ring_file(struct caml_runtime_events_cursor *cursor,
   return E_SUCCESS;
 
  failed2:
-  CloseHandle(cursor->ring_file_handle);
- failed1:
   CloseHandle(cursor->ring_handle);
+ failed1:
+  CloseHandle(cursor->ring_file_handle);
   return ret;
 #else
   int ring_fd = open(runtime_events_loc, O_RDONLY, 0);

--- a/testsuite/tests/lib-runtime-events/test_create_cursor_failures.ml
+++ b/testsuite/tests/lib-runtime-events/test_create_cursor_failures.ml
@@ -1,0 +1,57 @@
+(* TEST
+ include unix;
+ include runtime_events;
+ hasunix;
+ {
+   bytecode;
+ }{
+   native;
+ }
+*)
+
+(* Tests that [create_cursor]:
+ * - fails on [None] if runtime events haven't been started
+ * - doesn't double-free when it fails to attach to [None]
+ * - does manage to attach to this process if we provide the right PID
+ *)
+
+let create_and_free ?(pid) () =
+  try
+    let dir_and_pid = Option.map (fun p -> ".", p) pid in
+    let cur = Runtime_events.create_cursor dir_and_pid in
+    Runtime_events.free_cursor cur;
+    print_endline "OK"
+  with Failure msg -> print_endline msg
+
+let start_and_pause () =
+  Runtime_events.start ();
+  Runtime_events.pause ()
+
+(* workaround for finding the events file even on Windows, where
+   [Unix.getpid] doesn't match the one used to open the file *)
+let find_events_file =
+  let list_events_files () =
+    List.filter
+      (String.ends_with ~suffix:".events")
+      (Array.to_list @@ Sys.readdir ".")
+  in
+  let startup_events_files = list_events_files () in
+  fun () ->
+  let is_new_event_file f = not (List.mem f startup_events_files) in
+  List.find is_new_event_file (list_events_files ())
+(* once again, Windows workaround to get the correct PID *)
+let find_events_pid () = Scanf.sscanf (find_events_file()) "%d.events" Fun.id
+
+(* force failure of [create_cursor None] *)
+let make_unreadable () = Unix.chmod (find_events_file()) 0o000
+
+let () =
+  create_and_free (); (* fail, not started *)
+  start_and_pause ();
+  let pid = find_events_pid () in
+  create_and_free ~pid (); (* success *)
+  create_and_free (); (* success *)
+  make_unreadable ();
+  create_and_free ~pid (); (* fail, cannot open *)
+  create_and_free (); (* fail, cannot open *)
+  create_and_free (); (* fail, cannot open *)

--- a/testsuite/tests/lib-runtime-events/test_create_cursor_failures.reference
+++ b/testsuite/tests/lib-runtime-events/test_create_cursor_failures.reference
@@ -1,0 +1,6 @@
+Runtime_events: no ring for current process.          Was runtime_events started?
+OK
+OK
+Runtime_events: could not create cursor for specified path.
+Runtime_events: could not create cursor for specified path.
+Runtime_events: could not create cursor for specified path.


### PR DESCRIPTION
This PR fixes a few memory bugs surrounding `runtime_events_loc` in `runtime_events_consumer.c`, as mentioned in #13089, specifically in [`caml_runtime_events_create_cursor`](https://github.com/ocaml/ocaml/blob/4c6a3849022ba19c23fb1860095f65eb09da157c/otherlibs/runtime_events/runtime_events_consumer.c#L92).

These bugs are:

- The code path for `Runtime_events.create_cursor None` (the `pid < 0` branch in the C code) allocates `runtime_events_loc` but reassigns it, making the old pointer unreachable without deallocating it:

https://github.com/ocaml/ocaml/blob/4c6a3849022ba19c23fb1860095f65eb09da157c/otherlibs/runtime_events/runtime_events_consumer.c#L108-L124

- The function frees `runtime_events_loc` after it is introduced if and only if the function returns with an error.[^1] This is incorrect, both because:
  - in the `pid < 0` code path, it shouldn't be freed at all, since [`caml_runtime_events_current_location()` does not return a new string](https://github.com/ocaml/ocaml/blob/4c6a3849022ba19c23fb1860095f65eb09da157c/runtime/runtime_events.c#L222)
  - in the `pid >= 0` code path, it should always be freed, since `runtime_events_loc` does not escape the function

This PR:

- Fixes these by moving `runtime_events_loc`'s allocation into the relevant branch, rewriting the function to be single-exit after cursor allocation succeeds, and by having both frees state their explicit guards:

https://github.com/ocaml/ocaml/blob/1c337f6d56604663f8b2eb839fe14abfb8230856/otherlibs/runtime_events/runtime_events_consumer.c#L237-L252

- Deduplicates the two identical `path`-freeing if-blocks in the `caml_ml_runtime_events_create_cursor` wrapper which calls it, for clarity. This does not change the behaviour of the program.
- Adds a test which tries to reach these cases, though only the double-free (and Windows on the commit before [#13089](/ocaml/ocaml/pull/13089)) actually causes a failure of the test.
  - This `chmod 000`s the ring buffer file in order to cause subsequent read attempts to fail.
  - It uses a slight workaround to find the correct PID and `.events` file, so it works on Windows (rather than skipping), because I wanted to actually test [#13089](/ocaml/ocaml/pull/13089).
  - The testsuite does fail on this commit.

[^1]: This is the correct behaviour for `cursor`, since the caller takes ownership of the returned cursor iff the function returns successfully