### PR TITLE
Fix undefined behavior of left-shifting a negative number

### DIFF
--- a/Changes
+++ b/Changes
@@ -183,6 +183,9 @@ _______________
   output under Windows.
   (B. Szilvasy, review by Nicolás Ojeda Bär and Miod Vallat)
 
+- #13094: Fix undefined behavior of left-shifting a negative number.
+  (Antonin Décimo, review by Miod Vallat and Nicolás Ojeda Bär)
+
 OCaml 5.2.0
 ------------
 

--- a/runtime/bigarray.c
+++ b/runtime/bigarray.c
@@ -132,7 +132,7 @@ static uint16 caml_float_to_float16(float d)
       uint32_t mant_odd = (f.i >> 13) & 1; // resulting mantissa is odd
 
       // update exponent, rounding bias part 1
-      f.i += ((15 - 127) << 23) + 0xfff;
+      f.i += ((uint32_t)(15 - 127) << 23) + 0xfff;
       // rounding bias part 2
       f.i += mant_odd;
       // take the bits!


### PR DESCRIPTION
Compilers likely behave and cast (15-127) to unsigned, but strictly speaking this is UB and needs to be explicit, otherwise the compiler may warn or wrongly optimize.

    test.c:71:26: warning: shifting a negative signed value is undefined [-Wshift-negative-value]
          f.i += ((15 - 127) << 23) + 0xfff;
                  ~~~~~~~~~~ ^
    1 warning generated.
    
The warning is raised by clang. I've checked that the assembly code generated stays the same.