### PR TITLE
runtime/array.c: blitting from flat to non-flat is not supported

### DIFF
--- a/runtime/array.c
+++ b/runtime/array.c
@@ -371,6 +371,8 @@ static void wo_memmove (volatile value* const dst,
 CAMLprim value caml_floatarray_blit(value a1, value ofs1, value a2, value ofs2,
                                     value n)
 {
+  CAMLassert (Tag_val(a1) == Double_array_tag);
+  CAMLassert (Tag_val(a2) == Double_array_tag);
   /* See memory model [MM] notes in memory.c */
   atomic_thread_fence(memory_order_acquire);
   memmove((double *)a2 + Long_val(ofs2),

--- a/runtime/array.c
+++ b/runtime/array.c
@@ -389,6 +389,7 @@ CAMLprim value caml_array_blit(value a1, value ofs1, value a2, value ofs2,
   if (Tag_val(a2) == Double_array_tag)
     return caml_floatarray_blit(a1, ofs1, a2, ofs2, n);
 #endif
+  CAMLassert (Tag_val(a1) != Double_array_tag);
   CAMLassert (Tag_val(a2) != Double_array_tag);
   if (Is_young(a2)) {
     /* Arrays of values, destination is in young generation.

--- a/runtime/array.c
+++ b/runtime/array.c
@@ -371,6 +371,10 @@ static void wo_memmove (volatile value* const dst,
 CAMLprim value caml_floatarray_blit(value a1, value ofs1, value a2, value ofs2,
                                     value n)
 {
+  if (Long_val(n) == 0) return Val_unit;
+  /* Note: size-0 floatarrays do not have Double_array_tag,
+     but only size-0 blits are possible on them, so they
+     do not reach this point. */
   CAMLassert (Tag_val(a1) == Double_array_tag);
   CAMLassert (Tag_val(a2) == Double_array_tag);
   /* See memory model [MM] notes in memory.c */
@@ -391,6 +395,9 @@ CAMLprim value caml_array_blit(value a1, value ofs1, value a2, value ofs2,
   if (Tag_val(a2) == Double_array_tag)
     return caml_floatarray_blit(a1, ofs1, a2, ofs2, n);
 #endif
+  if (Long_val(n) == 0)
+    /* See comment on size-0 floatarrays in [caml_floatarray_blit]. */
+    return Val_unit;
   CAMLassert (Tag_val(a1) != Double_array_tag);
   CAMLassert (Tag_val(a2) != Double_array_tag);
   if (Is_young(a2)) {


### PR DESCRIPTION
In general, to work with uniform arrays it is enough to ensure that the arrays we consider are always initialized with a non-float value. (Context: https://github.com/ocaml/ocaml/pull/12885 , https://github.com/ocaml/RFCs/pull/37 )

In the process of reviewing #12885, @OlivierNicole found what could be considered an exception to this rule: it is invalid to call `Array.blit` on non-flat-float destination array if the source array is itself a flat-float array.

This PR minimally documents this fact by adding a `CAMLassert` call in `caml_array_blit` (the C implementation of `Array.blit` in the runtime) that checks that the source array is not a flat float array. (The implementation is not correct in this case.) This would have sufficed to find the issue in #12885, as the CI runs the testsuite in a debug build.

(One might argue that `Array.blit` should support this use-case of blitting from flat-float to non-flat-float array, but this is more work and it only matters for unsafe applications that can also be careful and/or avoid `Array.blit` entirely.)

cc @OlivierNicole and also @xavierleroy 