### PR TITLE
Various build cleanups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,6 +92,7 @@ META
 /emacs/*.elc
 
 /flexdll-sources
+/winpthreads-sources
 
 /lambda/runtimedef.ml
 

--- a/Makefile
+++ b/Makefile
@@ -2464,7 +2464,8 @@ distclean: clean
 	      boot/flexdll_*.o boot/flexdll_*.obj \
 	      boot/*.cm* boot/libcamlrun.a boot/libcamlrun.lib boot/ocamlc.opt
 	rm -f Makefile.config Makefile.build_config
-	rm -rf autom4te.cache flexdll-sources $(BYTE_BUILD_TREE) $(OPT_BUILD_TREE)
+	rm -rf autom4te.cache winpthreads-sources flexdll-sources \
+         $(BYTE_BUILD_TREE) $(OPT_BUILD_TREE)
 	rm -f config.log config.status libtool
 
 # Installation

--- a/Makefile
+++ b/Makefile
@@ -868,9 +868,6 @@ flexlink.opt$(EXE): \
 	cd $(OPT_BINDIR); $(LN) $(call ROOT_FROM, $(OPT_BINDIR))/$@ flexlink$(EXE)
 	cp $(addprefix $(BYTE_BINDIR)/, $(FLEXDLL_OBJECTS)) $(OPT_BINDIR)
 
-partialclean::
-	rm -f flexlink.opt$(EXE) $(OPT_BINDIR)/flexlink$(EXE)
-
 else
 
 flexdll flexlink flexlink.opt:
@@ -890,6 +887,10 @@ flexdll flexlink flexlink.opt:
 	@false
 
 endif # ifeq "$(BOOTSTRAPPING_FLEXDLL)" "true"
+
+partialclean::
+	rm -f flexlink.opt flexlink.opt.exe \
+        $(OPT_BINDIR)/flexlink $(OPT_BINDIR)/flexlink.exe
 
 INSTALL_COMPLIBDIR = $(DESTDIR)$(COMPLIBDIR)
 INSTALL_FLEXDLLDIR = $(INSTALL_LIBDIR)/flexdll

--- a/Makefile
+++ b/Makefile
@@ -1631,7 +1631,8 @@ $(ocamlyacc_PROGRAM)$(EXE): $(ocamlyacc_OBJECTS)
 	$(V_MKEXE)$(MKEXE) -o $@ $^
 
 clean::
-	rm -f $(ocamlyacc_MODULES:=.o) $(ocamlyacc_MODULES:=.obj)
+	rm -f $(ocamlyacc_MODULES:=.o) $(ocamlyacc_MODULES:=.obj) \
+        yacc/wstr.o yacc/wstr.obj
 
 $(ocamlyacc_OTHER_MODULES:=.$(O)): yacc/defs.h
 

--- a/Makefile
+++ b/Makefile
@@ -650,6 +650,15 @@ $(BYTE_BINDIR)/flexlink$(EXE): \
 partialclean::
 	rm -f $(BYTE_BINDIR)/flexlink $(BYTE_BINDIR)/flexlink.exe
 
+ifneq "$(FLEXDLL_SUBMODULE_PRESENT)" ""
+clean::
+	$(MAKE) -C flexdll clean
+endif
+ifneq "$(wildcard flexdll-sources/Makefile)" ""
+clean::
+	$(MAKE) -C flexdll-sources clean
+endif
+
 ifeq "$(BOOTSTRAPPING_FLEXDLL)" "true"
 # The recipe for runtime/ocamlruns$(EXE) also produces runtime/primitives
 boot/ocamlrun$(EXE): runtime/ocamlruns$(EXE)
@@ -2449,7 +2458,9 @@ depend: beforedepend
 
 .PHONY: distclean
 distclean: clean
-	if [ -f flexdll/Makefile ]; then $(MAKE) -C flexdll distclean MSVC_DETECT=0; fi
+ifneq "$(FLEXDLL_SUBMODULE_PRESENT)" ""
+	$(MAKE) -C flexdll distclean MSVC_DETECT=0
+endif
 	$(MAKE) -C manual distclean
 	rm -f ocamldoc/META
 	rm -f $(addprefix ocamltest/,ocamltest_config.ml ocamltest_unix.ml)

--- a/Makefile
+++ b/Makefile
@@ -1103,12 +1103,12 @@ winpthreads_SOURCES = $(addprefix $(WINPTHREADS_SOURCE_DIR)/src/, \
   thread.c)
 
 winpthreads_OBJECTS = $(winpthreads_SOURCES:.c=.$(O))
-
-clean::
-	rm -f $(winpthreads_OBJECTS)
 else
 winpthreads_OBJECTS =
 endif
+
+clean::
+	rm -f winpthreads-sources/src/*.obj winpthreads/src/*.obj
 
 runtime_COMMON_C_SOURCES = \
   addrmap \

--- a/Makefile
+++ b/Makefile
@@ -1102,22 +1102,13 @@ partialclean::
 ## Lists of source files
 
 ifneq "$(WINPTHREADS_SOURCE_DIR)" ""
-winpthreads_SOURCES = $(addprefix $(WINPTHREADS_SOURCE_DIR)/src/, \
-  cond.c \
-  misc.c \
-  mutex.c \
-  rwlock.c \
-  sched.c \
-  spinlock.c \
-  thread.c)
+winpthreads_SOURCES = cond.c misc.c mutex.c rwlock.c sched.c spinlock.c thread.c
 
-winpthreads_OBJECTS = $(winpthreads_SOURCES:.c=.$(O))
+winpthreads_OBJECTS = \
+  $(addprefix runtime/winpthreads/, $(winpthreads_SOURCES:.c=.$(O)))
 else
 winpthreads_OBJECTS =
 endif
-
-clean::
-	rm -f winpthreads-sources/src/*.obj winpthreads/src/*.obj
 
 runtime_COMMON_C_SOURCES = \
   addrmap \
@@ -1450,6 +1441,15 @@ endif # ifeq "$(COMPUTE_DEPS)" "true"
 	  $$(OUTPUTOBJ)$$@ $$<
 endef
 
+runtime/winpthreads/%.$(O): $(WINPTHREADS_SOURCE_DIR)/src/%.c \
+                            $(wildcard $(WINPTHREADS_SOURCE_DIR)/include/*.h) \
+                              | runtime/winpthreads
+	$(V_CC)$(CC) -c $(OC_CFLAGS) $(CFLAGS) $(OC_CPPFLAGS) $(CPPFLAGS) \
+	  $(OUTPUTOBJ)$@ $<
+
+runtime/winpthreads:
+	$(MKDIR) $@
+
 $(DEPDIR)/runtime:
 	$(MKDIR) $@
 
@@ -1536,7 +1536,7 @@ clean::
 	rm -f runtime/primitives runtime/primitives*.new runtime/prims.c \
 	  $(runtime_BUILT_HEADERS)
 	rm -f runtime/domain_state.inc
-	rm -rf $(DEPDIR)
+	rm -rf $(DEPDIR) runtime/winpthreads
 	rm -f stdlib/libcamlrun.a stdlib/libcamlrun.lib
 
 .PHONY: runtimeopt

--- a/Makefile.build_config.in
+++ b/Makefile.build_config.in
@@ -65,7 +65,10 @@ COMPUTE_DEPS=@compute_deps@
 
 # Build-system flags to use to compile C files
 OC_CFLAGS=@oc_cflags@
-OC_CPPFLAGS=-I$(ROOTDIR)/runtime @oc_cppflags@
+# The submodules should be searched *before* any other external -I paths
+OC_INCLUDES = $(addprefix -I $(ROOTDIR)/, \
+  runtime @flexdll_source_dir@ @winpthreads_source_include_dir@)
+OC_CPPFLAGS = $(OC_INCLUDES) @oc_cppflags@
 
 # The following variable defines flags to be passed to the C preprocessor
 # when compiling C files to be linked with native code. This includes

--- a/configure
+++ b/configure
@@ -14170,7 +14170,7 @@ then :
   if test -f 'flexdll/flexdll.h'
 then :
   flexdll_source_dir=flexdll
-          iflexdir='$(ROOTDIR)/flexdll'
+                    iflexdir='$(ROOTDIR)/flexdll'
           with_flexdll="$iflexdir"
 else $as_nop
   if test x"$with_flexdll" != 'x'
@@ -14187,7 +14187,7 @@ then :
   mkdir -p flexdll-sources
           cp -r "$with_flexdll"/* flexdll-sources/
           flexdll_source_dir='flexdll-sources'
-          iflexdir='$(ROOTDIR)/flexdll-sources'
+                    iflexdir='$(ROOTDIR)/flexdll-sources'
           flexmsg=" (from $with_flexdll)"
 else $as_nop
   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: requested but not available" >&5
@@ -14578,7 +14578,7 @@ then :
   if test -f 'winpthreads/src/winpthread_internal.h'
 then :
   winpthreads_source_dir=winpthreads
-        iwinpthreadsdir="$ocamlsrcdir\winpthreads\include"
+                iwinpthreadsdir='$(ROOTDIR)/winpthreads/include'
 else $as_nop
   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: required but not available (uninitialized submodule?)" >&5
 printf "%s\n" "required but not available (uninitialized submodule?)" >&6; }
@@ -14593,7 +14593,7 @@ then :
         cp "$with_winpthreads_msvc"/src/*.h winpthreads-sources/src
         cp "$with_winpthreads_msvc"/include/*.h winpthreads-sources/include
         winpthreads_source_dir='winpthreads-sources'
-        iwinpthreadsdir="$ocamlsrcdir\\winpthreads-sources\\include"
+                iwinpthreadsdir='$(ROOTDIR)/winpthreads-sources/includes'
         winpthreadsmsg=" (from $with_winpthreads_msvc)"
 else $as_nop
   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: requested but not available" >&5
@@ -14622,9 +14622,9 @@ printf "%s\n" "$winpthreads_source_dir$winpthreadmsg" >&6; }
   touch confdefs.h
 
 
-  if test -n "$iwinpthreadsdir"
+  if test -n "$winpthreads_source_dir/include"
 then :
-  CPPFLAGS="-I $iwinpthreadsdir $CPPFLAGS"
+  CPPFLAGS="-I $winpthreads_source_dir/include $CPPFLAGS"
 fi
   ac_fn_c_check_header_compile "$LINENO" "pthread.h" "ac_cv_header_pthread_h" "$ac_includes_default"
 if test "x$ac_cv_header_pthread_h" = xyes
@@ -14646,7 +14646,7 @@ fi
   LIBS="$saved_LIBS"
 
 
-      internal_cppflags="$internal_cppflags -I$iwinpthreadsdir"
+      internal_cppflags="$internal_cppflags -I $iwinpthreadsdir"
 fi ;; #(
   *) :
     if test x"$with_winpthreads_msvc" != 'x'

--- a/configure
+++ b/configure
@@ -856,6 +856,7 @@ supports_shared_libraries
 mklib
 AR
 shebangscripts
+winpthreads_source_include_dir
 winpthreads_source_dir
 flexlink_flags
 flexdll_dir
@@ -3371,6 +3372,7 @@ LINEAR_MAGIC_NUMBER=Caml1999L035
 # Note: This is present for the flexdll bootstrap where it exposed as the old
 # TOOLPREF variable. It would be better if flexdll where updated to require
 # WINDRES instead.
+
 
 
 
@@ -14204,8 +14206,6 @@ else $as_nop
 printf "%s\n" "$iflexdir$flexmsg" >&6; }
         bootstrapping_flexdll=true
         flexdll_dir=\"+flexdll\"
-        # The submodule should be searched *before* any other -I paths
-        internal_cppflags="-I $iflexdir $internal_cppflags"
 fi ;; #(
   *) :
     if test x"$with_flexdll" != 'x'
@@ -14608,6 +14608,7 @@ printf "%s\n" "no" >&6; }
 else $as_nop
   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $winpthreads_source_dir$winpthreadmsg" >&5
 printf "%s\n" "$winpthreads_source_dir$winpthreadmsg" >&6; }
+      winpthreads_source_include_dir="$winpthreads_source_dir/include"
 
 
   saved_CC="$CC"
@@ -14622,9 +14623,9 @@ printf "%s\n" "$winpthreads_source_dir$winpthreadmsg" >&6; }
   touch confdefs.h
 
 
-  if test -n "$winpthreads_source_dir/include"
+  if test -n "$winpthreads_source_include_dir"
 then :
-  CPPFLAGS="-I $winpthreads_source_dir/include $CPPFLAGS"
+  CPPFLAGS="-I $winpthreads_source_include_dir $CPPFLAGS"
 fi
   ac_fn_c_check_header_compile "$LINENO" "pthread.h" "ac_cv_header_pthread_h" "$ac_includes_default"
 if test "x$ac_cv_header_pthread_h" = xyes
@@ -14646,7 +14647,6 @@ fi
   LIBS="$saved_LIBS"
 
 
-      internal_cppflags="$internal_cppflags -I $iwinpthreadsdir"
 fi ;; #(
   *) :
     if test x"$with_winpthreads_msvc" != 'x'

--- a/configure
+++ b/configure
@@ -14172,8 +14172,6 @@ then :
   if test -f 'flexdll/flexdll.h'
 then :
   flexdll_source_dir=flexdll
-                    iflexdir='$(ROOTDIR)/flexdll'
-          with_flexdll="$iflexdir"
 else $as_nop
   if test x"$with_flexdll" != 'x'
 then :
@@ -14189,7 +14187,6 @@ then :
   mkdir -p flexdll-sources
           cp -r "$with_flexdll"/* flexdll-sources/
           flexdll_source_dir='flexdll-sources'
-                    iflexdir='$(ROOTDIR)/flexdll-sources'
           flexmsg=" (from $with_flexdll)"
 else $as_nop
   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: requested but not available" >&5
@@ -14202,8 +14199,8 @@ then :
   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
 printf "%s\n" "no" >&6; }
 else $as_nop
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $iflexdir$flexmsg" >&5
-printf "%s\n" "$iflexdir$flexmsg" >&6; }
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $flexdll_source_dir$flexmsg" >&5
+printf "%s\n" "$flexdll_source_dir$flexmsg" >&6; }
         bootstrapping_flexdll=true
         flexdll_dir=\"+flexdll\"
 fi ;; #(
@@ -14578,7 +14575,6 @@ then :
   if test -f 'winpthreads/src/winpthread_internal.h'
 then :
   winpthreads_source_dir=winpthreads
-                iwinpthreadsdir='$(ROOTDIR)/winpthreads/include'
 else $as_nop
   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: required but not available (uninitialized submodule?)" >&5
 printf "%s\n" "required but not available (uninitialized submodule?)" >&6; }
@@ -14593,7 +14589,6 @@ then :
         cp "$with_winpthreads_msvc"/src/*.h winpthreads-sources/src
         cp "$with_winpthreads_msvc"/include/*.h winpthreads-sources/include
         winpthreads_source_dir='winpthreads-sources'
-                iwinpthreadsdir='$(ROOTDIR)/winpthreads-sources/includes'
         winpthreadsmsg=" (from $with_winpthreads_msvc)"
 else $as_nop
   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: requested but not available" >&5
@@ -14606,8 +14601,8 @@ then :
   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
 printf "%s\n" "no" >&6; }
 else $as_nop
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $winpthreads_source_dir$winpthreadmsg" >&5
-printf "%s\n" "$winpthreads_source_dir$winpthreadmsg" >&6; }
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $winpthreads_source_dir$winpthreadsmsg" >&5
+printf "%s\n" "$winpthreads_source_dir$winpthreadsmsg" >&6; }
       winpthreads_source_include_dir="$winpthreads_source_dir/include"
 
 

--- a/configure.ac
+++ b/configure.ac
@@ -177,6 +177,7 @@ AC_SUBST([bootstrapping_flexdll])
 AC_SUBST([flexdll_dir])
 AC_SUBST([flexlink_flags])
 AC_SUBST([winpthreads_source_dir])
+AC_SUBST([winpthreads_source_include_dir])
 AC_SUBST([shebangscripts])
 AC_SUBST([AR])
 AC_SUBST([mklib])
@@ -978,9 +979,7 @@ AS_IF([test x"$supports_shared_libraries" != 'xfalse'], [
         [AC_MSG_RESULT([no])],
         [AC_MSG_RESULT([$iflexdir$flexmsg])
         bootstrapping_flexdll=true
-        flexdll_dir=\"+flexdll\"
-        # The submodule should be searched *before* any other -I paths
-        internal_cppflags="-I $iflexdir $internal_cppflags"])],
+        flexdll_dir=\"+flexdll\"])],
       [AS_IF([test x"$with_flexdll" != 'x'],
         [AC_MSG_RESULT([requested but not supported])
         AC_MSG_ERROR([exiting])])])])
@@ -1113,8 +1112,8 @@ AS_IF([test x"$with_winpthreads_msvc" = "xno"],
     AS_IF([test x"$winpthreads_source_dir" = 'x'],
       [AC_MSG_RESULT([no])],
       [AC_MSG_RESULT([$winpthreads_source_dir$winpthreadmsg])
-      OCAML_TEST_WINPTHREADS_PTHREAD_H([$winpthreads_source_dir/include])
-      internal_cppflags="$internal_cppflags -I $iwinpthreadsdir"])],
+      winpthreads_source_include_dir="$winpthreads_source_dir/include"
+      OCAML_TEST_WINPTHREADS_PTHREAD_H([$winpthreads_source_include_dir])])],
     [AS_IF([test x"$with_winpthreads_msvc" != 'x'],
       [AC_MSG_RESULT([requested but not supported])
       AC_MSG_ERROR([exiting])],

--- a/configure.ac
+++ b/configure.ac
@@ -958,6 +958,7 @@ AS_IF([test x"$supports_shared_libraries" != 'xfalse'], [
                             || test x"$with_flexdll" = 'xflexdll'])],
         [AS_IF([test -f 'flexdll/flexdll.h'],
           [flexdll_source_dir=flexdll
+          dnl Use $(ROOTDIR) to ensure that the build only uses relative paths
           iflexdir='$(ROOTDIR)/flexdll'
           with_flexdll="$iflexdir"],
           [AS_IF([test x"$with_flexdll" != 'x'],
@@ -968,6 +969,7 @@ AS_IF([test x"$supports_shared_libraries" != 'xfalse'], [
           [mkdir -p flexdll-sources
           cp -r "$with_flexdll"/* flexdll-sources/
           flexdll_source_dir='flexdll-sources'
+          dnl Use $(ROOTDIR) to ensure that the build only uses relative paths
           iflexdir='$(ROOTDIR)/flexdll-sources'
           flexmsg=" (from $with_flexdll)"],
           [AC_MSG_RESULT([requested but not available])
@@ -1092,7 +1094,8 @@ AS_IF([test x"$with_winpthreads_msvc" = "xno"],
                           || test x"$with_winpthreads_msvc" = x'winpthreads'])],
       [AS_IF([test -f 'winpthreads/src/winpthread_internal.h'],
         [winpthreads_source_dir=winpthreads
-        iwinpthreadsdir="$ocamlsrcdir\winpthreads\include"],
+        dnl Use $(ROOTDIR) to ensure that the build only uses relative paths
+        iwinpthreadsdir='$(ROOTDIR)/winpthreads/include'],
         [AC_MSG_RESULT([required but not available (uninitialized submodule?)])
         AC_MSG_ERROR([exiting])])],
       [rm -rf winpthreads-sources
@@ -1102,15 +1105,16 @@ AS_IF([test x"$with_winpthreads_msvc" = "xno"],
         cp "$with_winpthreads_msvc"/src/*.h winpthreads-sources/src
         cp "$with_winpthreads_msvc"/include/*.h winpthreads-sources/include
         winpthreads_source_dir='winpthreads-sources'
-        iwinpthreadsdir="$ocamlsrcdir\\winpthreads-sources\\include"
+        dnl Use $(ROOTDIR) to ensure that the build only uses relative paths
+        iwinpthreadsdir='$(ROOTDIR)/winpthreads-sources/includes'
         winpthreadsmsg=" (from $with_winpthreads_msvc)"],
         [AC_MSG_RESULT([requested but not available])
         AC_MSG_ERROR([exiting])])])
     AS_IF([test x"$winpthreads_source_dir" = 'x'],
       [AC_MSG_RESULT([no])],
       [AC_MSG_RESULT([$winpthreads_source_dir$winpthreadmsg])
-      OCAML_TEST_WINPTHREADS_PTHREAD_H([$iwinpthreadsdir])
-      internal_cppflags="$internal_cppflags -I$iwinpthreadsdir"])],
+      OCAML_TEST_WINPTHREADS_PTHREAD_H([$winpthreads_source_dir/include])
+      internal_cppflags="$internal_cppflags -I $iwinpthreadsdir"])],
     [AS_IF([test x"$with_winpthreads_msvc" != 'x'],
       [AC_MSG_RESULT([requested but not supported])
       AC_MSG_ERROR([exiting])],

--- a/configure.ac
+++ b/configure.ac
@@ -958,10 +958,7 @@ AS_IF([test x"$supports_shared_libraries" != 'xfalse'], [
       AS_IF([m4_normalize([test x"$with_flexdll" = 'x'
                             || test x"$with_flexdll" = 'xflexdll'])],
         [AS_IF([test -f 'flexdll/flexdll.h'],
-          [flexdll_source_dir=flexdll
-          dnl Use $(ROOTDIR) to ensure that the build only uses relative paths
-          iflexdir='$(ROOTDIR)/flexdll'
-          with_flexdll="$iflexdir"],
+          [flexdll_source_dir=flexdll],
           [AS_IF([test x"$with_flexdll" != 'x'],
             [AC_MSG_RESULT([requested but not available])
             AC_MSG_ERROR([exiting])])])],
@@ -970,14 +967,12 @@ AS_IF([test x"$supports_shared_libraries" != 'xfalse'], [
           [mkdir -p flexdll-sources
           cp -r "$with_flexdll"/* flexdll-sources/
           flexdll_source_dir='flexdll-sources'
-          dnl Use $(ROOTDIR) to ensure that the build only uses relative paths
-          iflexdir='$(ROOTDIR)/flexdll-sources'
           flexmsg=" (from $with_flexdll)"],
           [AC_MSG_RESULT([requested but not available])
           AC_MSG_ERROR([exiting])])])
       AS_IF([test x"$flexdll_source_dir" = 'x'],
         [AC_MSG_RESULT([no])],
-        [AC_MSG_RESULT([$iflexdir$flexmsg])
+        [AC_MSG_RESULT([$flexdll_source_dir$flexmsg])
         bootstrapping_flexdll=true
         flexdll_dir=\"+flexdll\"])],
       [AS_IF([test x"$with_flexdll" != 'x'],
@@ -1092,9 +1087,7 @@ AS_IF([test x"$with_winpthreads_msvc" = "xno"],
     AS_IF([m4_normalize([test x"$with_winpthreads_msvc" = 'x'
                           || test x"$with_winpthreads_msvc" = x'winpthreads'])],
       [AS_IF([test -f 'winpthreads/src/winpthread_internal.h'],
-        [winpthreads_source_dir=winpthreads
-        dnl Use $(ROOTDIR) to ensure that the build only uses relative paths
-        iwinpthreadsdir='$(ROOTDIR)/winpthreads/include'],
+        [winpthreads_source_dir=winpthreads],
         [AC_MSG_RESULT([required but not available (uninitialized submodule?)])
         AC_MSG_ERROR([exiting])])],
       [rm -rf winpthreads-sources
@@ -1104,14 +1097,12 @@ AS_IF([test x"$with_winpthreads_msvc" = "xno"],
         cp "$with_winpthreads_msvc"/src/*.h winpthreads-sources/src
         cp "$with_winpthreads_msvc"/include/*.h winpthreads-sources/include
         winpthreads_source_dir='winpthreads-sources'
-        dnl Use $(ROOTDIR) to ensure that the build only uses relative paths
-        iwinpthreadsdir='$(ROOTDIR)/winpthreads-sources/includes'
         winpthreadsmsg=" (from $with_winpthreads_msvc)"],
         [AC_MSG_RESULT([requested but not available])
         AC_MSG_ERROR([exiting])])])
     AS_IF([test x"$winpthreads_source_dir" = 'x'],
       [AC_MSG_RESULT([no])],
-      [AC_MSG_RESULT([$winpthreads_source_dir$winpthreadmsg])
+      [AC_MSG_RESULT([$winpthreads_source_dir$winpthreadsmsg])
       winpthreads_source_include_dir="$winpthreads_source_dir/include"
       OCAML_TEST_WINPTHREADS_PTHREAD_H([$winpthreads_source_include_dir])])],
     [AS_IF([test x"$with_winpthreads_msvc" != 'x'],

--- a/manual/src/html_processing/Makefile
+++ b/manual/src/html_processing/Makefile
@@ -1,5 +1,5 @@
 ROOTDIR = ../../..
-include $(ROOTDIR)/Makefile.config
+include $(ROOTDIR)/Makefile.config_if_required
 
 DUNE_CMD := $(if $(wildcard dune/dune.exe),dune/dune.exe,dune)
 DUNE ?= $(DUNE_CMD)


### PR DESCRIPTION
This PR collects a whole load of related tweaks together which started from some checking done in #13093.

- As I noted in https://github.com/ocaml/ocaml/pull/13093#discussion_r1572325531, the build should avoid ever using absolute paths as we end up in the Dante's missing 10th circle (escaping rules). The first commit switches the winpthreads submodule to be referred using a relative path and adds comments in `configure.ac` which I should have put in #10135 originally.
- The next commit then simplifies the meta-programming between `configure.ac` and `Makefile` for these two submodules - i.e. `configure.ac` stops generating `Makefile`-fragments and simply emits strings, like it's supposed to.
- The next commit is a `.gitignore` entry we missed in #12954 (we also missed cleaning `winpthreads-sources` in `distclean` which is fixed a few commits later).
- I'm not sure how long it's been wrong, but the rule for cleaning `yacc/wstr.obj` (a Windows-specific object) didn't work because it relies on `Makefile.build_config` which isn't loaded in a clean target. That's also a bit of meta-programming / layer violation between configure/make which I'm not terribly fond of, but I don't have a better solution to hand at the moment.
- #12976 accidentally broke the ability to run `make distclean` from an unconfigured tree.
- Similarly to the yacc/wstr.obj issue, the winpthreads objects were never cleaned because the instructions relied on configuration which isn't loaded in a clean target.
- Morally, `make clean` ought to clean the `flexdll` objects, which is done in the next commit (it's only morally because `make clean` does clean the flexlink executable and for reasons of history flexdll's Makefile always compiles by specifying the `.ml` files on the command line, rather than the more traditional separate compilation and linking, so flexlink was always completely recompiled after a `make clean`).
- Finally, there's an unfortunate nit when working on the MSVC port that the winpthreads submodule ends up with untracked content because of the `.obj` files. I've fixed that by instead putting the winpthreads objects in `runtime/winpthreads` during the build.

cc @shindere, @shym, @MisterDA 🙂