### PR TITLE
The Pattern-Matching Bug: testsuite improvements

### DIFF
--- a/testsuite/tests/match-side-effects/check_partial.ml
+++ b/testsuite/tests/match-side-effects/check_partial.ml
@@ -1,0 +1,122 @@
+(* TEST
+ flags = "-dlambda";
+ expect;
+*)
+
+(* This test exercises pattern-matching examples that mix mutable
+   state with code execution (through guards or lazy patterns). Some
+   of those tests appear to be exhaustive to the type-checker but are
+   in fact not exhaustive, forcing the pattern-matching compiler to
+   add Match_failure clauses for soundness. The pattern-matching
+   compiler also sometimes conservatively add Match_failure clauses in
+   cases that were in fact exhaustive.
+*)
+
+type _ t =
+  | Int : int -> int t
+  | True : bool t
+  | False : bool t
+
+let lazy_total : _ * bool t -> int = function
+  | ({ contents = _ }, True) -> 0
+  | ({ contents = lazy () }, False) -> 12
+(* This pattern-matching is in fact total: a Match_failure case is
+   not necessary for soundness. *)
+[%%expect {|
+0
+type _ t = Int : int -> int t | True : bool t | False : bool t
+(let
+  (lazy_total/281 =
+     (function param/283 : int
+       (let
+         (*match*/285 =o (field_mut 0 (field_imm 0 param/283))
+          *match*/286 =a (field_imm 1 param/283))
+         (if (isint *match*/286)
+           (if *match*/286
+             (let
+               (*match*/293 =
+                  (let (tag/288 =a (caml_obj_tag *match*/285))
+                    (if (== tag/288 250) (field_mut 0 *match*/285)
+                      (if (|| (== tag/288 246) (== tag/288 244))
+                        (apply (field_imm 1 (global CamlinternalLazy!))
+                          (opaque *match*/285))
+                        *match*/285))))
+               12)
+             0)
+           (raise (makeblock 0 (global Match_failure/18!) [0: "" 6 37]))))))
+  (apply (field_mut 1 (global Toploop!)) "lazy_total" lazy_total/281))
+val lazy_total : unit lazy_t ref * bool t -> int = <fun>
+|}];;
+
+let lazy_needs_partial : _ * bool t ref -> int = function
+  | (_, { contents = True }) -> 0
+  | (lazy (), { contents = False }) -> 12
+(* This pattern-matching is partial: a Match_failure case is
+   necessary for soundness. *)
+[%%expect {|
+(let
+  (lazy_needs_partial/295 =
+     (function param/297 : int
+       (catch
+         (let
+           (*match*/298 =a (field_imm 0 param/297)
+            *match*/300 =o (field_mut 0 (field_imm 1 param/297)))
+           (if (isint *match*/300)
+             (if *match*/300
+               (let
+                 (*match*/303 =
+                    (let (tag/302 =a (caml_obj_tag *match*/298))
+                      (if (== tag/302 250) (field_mut 0 *match*/298)
+                        (if (|| (== tag/302 246) (== tag/302 244))
+                          (apply (field_imm 1 (global CamlinternalLazy!))
+                            (opaque *match*/298))
+                          *match*/298)))
+                  *match*/305 =o (field_mut 0 (field_imm 1 param/297)))
+                 (if (isint *match*/305) (if *match*/305 12 (exit 3))
+                   (exit 3)))
+               0)
+             (exit 3)))
+        with (3)
+         (raise (makeblock 0 (global Match_failure/18!) [0: "" 1 49])))))
+  (apply (field_mut 1 (global Toploop!)) "lazy_needs_partial"
+    lazy_needs_partial/295))
+val lazy_needs_partial : unit lazy_t * bool t ref -> int = <fun>
+|}];;
+
+let guard_total : bool t ref -> int = function
+  | _ when Sys.opaque_identity false -> 1
+  | { contents = True } -> 0
+  | { contents = False } -> 12
+(* This pattern-matching is total: a Match_failure case is not
+   necessary for soundness. *)
+[%%expect {|
+(let
+  (guard_total/306 =
+     (function param/383 : int
+       (if (opaque 0) 1
+         (let (*match*/384 =o (field_mut 0 param/383))
+           (switch* *match*/384 case int 0: 0
+                                case int 1: 12)))))
+  (apply (field_mut 1 (global Toploop!)) "guard_total" guard_total/306))
+val guard_total : bool t ref -> int = <fun>
+|}];;
+
+let guard_needs_partial : bool t ref -> int = function
+  | { contents = True } -> 0
+  | _ when Sys.opaque_identity false -> 1
+  | { contents = False } -> 12
+(* This pattern-matching is partial: a Match_failure case is
+   necessary for soundness.
+
+   FAIL: the compiler is currently unsound here. *)
+[%%expect {|
+(let
+  (guard_needs_partial/385 =
+     (function param/387 : int
+       (let (*match*/388 =o (field_mut 0 param/387))
+         (catch (if (isint *match*/388) (if *match*/388 (exit 9) 0) (exit 9))
+          with (9) (if (opaque 0) 1 12)))))
+  (apply (field_mut 1 (global Toploop!)) "guard_needs_partial"
+    guard_needs_partial/385))
+val guard_needs_partial : bool t ref -> int = <fun>
+|}];;

--- a/testsuite/tests/match-side-effects/partiality.ml
+++ b/testsuite/tests/match-side-effects/partiality.ml
@@ -44,24 +44,45 @@ val f : t -> int = <fun>
    inside a mutable position. *)
 type t = {a: bool; mutable b: int option}
 
-let f x =
+let simple x =
   match x with
-  | {a = false; b = _} -> 0
-  | {a = _;     b = None} -> 1
-  | {a = true;  b = Some y} -> y
+  | {b = None} -> 1
+  | {b = Some y} -> y
 ;;
 (* Performance expectation: there should not be a Match_failure case. *)
 [%%expect {|
 0
 type t = { a : bool; mutable b : int option; }
 (let
-  (f/291 =
-     (function x/292 : int
-       (if (field_int 0 x/292)
-         (let (*match*/296 =o (field_mut 1 x/292))
-           (if *match*/296 (field_imm 0 *match*/296) 1))
+  (simple/291 =
+     (function x/293 : int
+       (let (*match*/296 =o (field_mut 1 x/293))
+         (if *match*/296 (field_imm 0 *match*/296) 1))))
+  (apply (field_mut 1 (global Toploop!)) "simple" simple/291))
+val simple : t -> int = <fun>
+|}]
+
+(* This more complex case has the switch on [b] split across two cases
+   on [a], so it may need a [Match_failure] for soundness -- it does
+   if the two accesses to [b] are done on different reads of the same
+   mutable field.
+
+   PASS: a single read of [field_mut 1 x], no Match_failure case. *)
+let f x =
+  match x with
+  | {a = false; b = _} -> 0
+  | {a = _;     b = None} -> 1
+  | {a = true;  b = Some y} -> y
+;;
+[%%expect {|
+(let
+  (f/297 =
+     (function x/298 : int
+       (if (field_int 0 x/298)
+         (let (*match*/302 =o (field_mut 1 x/298))
+           (if *match*/302 (field_imm 0 *match*/302) 1))
          0)))
-  (apply (field_mut 1 (global Toploop!)) "f" f/291))
+  (apply (field_mut 1 (global Toploop!)) "f" f/297))
 val f : t -> int = <fun>
 |}]
 
@@ -76,7 +97,7 @@ let f r =
   | None -> 3
 ;;
 (* Correctness condition: there should either be a single
-   (field_mut 1) access, or the second access should include
+   (field_mut 0) access, or the second access should include
    a Match_failure case.
 
    FAIL: the second occurrence of (field_mut 0) is used with a direct
@@ -84,21 +105,21 @@ let f r =
    unsound here. *)
 [%%expect {|
 (let
-  (f/298 =
-     (function r/299 : int
-       (let (*match*/301 = (makeblock 0 r/299))
+  (f/304 =
+     (function r/305 : int
+       (let (*match*/307 = (makeblock 0 r/305))
          (catch
-           (if *match*/301
-             (let (*match*/303 =o (field_mut 0 (field_imm 0 *match*/301)))
-               (if *match*/303 (exit 11) 0))
-             (exit 11))
-          with (11)
-           (if (seq (setfield_ptr 0 r/299 0) 0) 1
-             (if *match*/301
-               (let (*match*/305 =o (field_mut 0 (field_imm 0 *match*/301)))
-                 (field_imm 0 *match*/305))
+           (if *match*/307
+             (let (*match*/309 =o (field_mut 0 (field_imm 0 *match*/307)))
+               (if *match*/309 (exit 13) 0))
+             (exit 13))
+          with (13)
+           (if (seq (setfield_ptr 0 r/305 0) 0) 1
+             (if *match*/307
+               (let (*match*/311 =o (field_mut 0 (field_imm 0 *match*/307)))
+                 (field_imm 0 *match*/311))
                3))))))
-  (apply (field_mut 1 (global Toploop!)) "f" f/298))
+  (apply (field_mut 1 (global Toploop!)) "f" f/304))
 val f : int option ref -> int = <fun>
 |}]
 
@@ -118,10 +139,10 @@ let test = function
 0
 type _ t = Int : int -> int t | Bool : bool -> bool t
 (let
-  (test/309 =
-     (function param/312 : int
-       (if param/312 (field_imm 0 (field_imm 0 param/312)) 0)))
-  (apply (field_mut 1 (global Toploop!)) "test" test/309))
+  (test/315 =
+     (function param/318 : int
+       (if param/318 (field_imm 0 (field_imm 0 param/318)) 0)))
+  (apply (field_mut 1 (global Toploop!)) "test" test/315))
 val test : int t option -> int = <fun>
 |}]
 
@@ -139,11 +160,11 @@ let test = function
 0
 type _ t = Int : int -> int t | Bool : bool -> bool t
 (let
-  (test/317 =
-     (function param/319 : int
-       (let (*match*/320 =o (field_mut 0 param/319))
-         (if *match*/320 (field_imm 0 (field_imm 0 *match*/320)) 0))))
-  (apply (field_mut 1 (global Toploop!)) "test" test/317))
+  (test/323 =
+     (function param/325 : int
+       (let (*match*/326 =o (field_mut 0 param/325))
+         (if *match*/326 (field_imm 0 (field_imm 0 *match*/326)) 0))))
+  (apply (field_mut 1 (global Toploop!)) "test" test/323))
 val test : int t option ref -> int = <fun>
 |}]
 
@@ -164,18 +185,18 @@ let test n =
 0
 type _ t = Int : int -> int t | Bool : bool -> bool t
 (let
-  (test/325 =
-     (function n/326 : int
+  (test/331 =
+     (function n/332 : int
        (let
-         (*match*/329 =
+         (*match*/335 =
             (makeblock 0 (makeblock 0 (makemutable 0 (int) 1) [0: 42])))
-         (if *match*/329
+         (if *match*/335
            (let
-             (*match*/330 =a (field_imm 0 *match*/329)
-              *match*/332 =o (field_mut 0 (field_imm 0 *match*/330)))
-             (if *match*/332 (field_imm 0 (field_imm 1 *match*/330))
-               (~ (field_imm 0 (field_imm 1 *match*/330)))))
+             (*match*/336 =a (field_imm 0 *match*/335)
+              *match*/338 =o (field_mut 0 (field_imm 0 *match*/336)))
+             (if *match*/338 (field_imm 0 (field_imm 1 *match*/336))
+               (~ (field_imm 0 (field_imm 1 *match*/336)))))
            3))))
-  (apply (field_mut 1 (global Toploop!)) "test" test/325))
+  (apply (field_mut 1 (global Toploop!)) "test" test/331))
 val test : 'a -> int = <fun>
 |}]


### PR DESCRIPTION
I am still working on #7241; the next installment of bugfixing PRs is taking a bit more effort than I expected, and here is a PR that only improves the testsuite for this bug in order to make reviewer's life easier in the short future. (cc @Octachron, @trefis, @lthls, @ncik-roberts)

The first commit refines an existing test in a "simple" and a "complex" version. Currently there is only the "complex" version in the testsuite, but both versions behave differently in some cases, and while trying to reason about the compiler behavior I found the behavior surprising. (If someone remembers the full details, we considered two approaches to fix the "context" part of the #7241 bug, and eventually I decided on one; the testsuite was written when I was still working on the first/earlier approach, and so it lacks distinctions that did not matter with that different implementation.)

The second commit adds a more complex test for the "totality bug" part of the fix of #7241, fix which has not been merged yet. This is about testing what happens on argument positions that are immutable themselves (they result from projecting an immutable field) but they are "transitively mutable", they are transitively under a mutable position. This is related to a discussion that we had with @ncik-roberts in https://github.com/ocaml/ocaml/pull/12555#discussion_r1552374951 . Adding a new testcase for this behavior proved very useful because it let me realize that my current "fix for the totality issue" was incomplete in this situation. (I went back and forth on how to handle transitivity, and my working branches include a simplistic approach that I thought was complete and in fact is not.)

The third commit adds coverage for cases that are currently handled by the `check_partial` logic within runtime/matching.ml, which is a pre-existing, incomplete criterion to downgrade certain pattern-matching problems from Total to Partial. (This heuristic fires when one clause has both mutable fields and either a lazy pattern or a guard.) The final fix for the Pattern-Matching Bug subsumes this incomplete criterion (in a way that also lets us un-pessimize certain programs I think), so that logic will be removed in a further PR. The new testcases ensure that we would detect a regression coming from this, by testing the various settings where it applies.