### PR TITLE
Update some GitHub Actions actions

### DIFF
--- a/.github/workflows/build-msvc.yml
+++ b/.github/workflows/build-msvc.yml
@@ -48,7 +48,7 @@ jobs:
           submodules: true
 
       - name: Restore Cygwin cache
-        uses: actions/cache/restore@v3
+        uses: actions/cache/restore@v4
         env:
           PATH: ${{ env.PRISTINE_PATH }}
         with:
@@ -63,7 +63,7 @@ jobs:
           install-dir: 'D:\cygwin'
 
       - name: Save Cygwin cache
-        uses: actions/cache/save@v3
+        uses: actions/cache/save@v4
         env:
           PATH: ${{ env.PRISTINE_PATH }}
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,7 +64,7 @@ jobs:
       - name: Prepare Artifact
         run: tar --zstd -cf /tmp/sources.tar.zstd .
       - name: Upload Artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: compiler
           path: /tmp/sources.tar.zstd
@@ -92,7 +92,7 @@ jobs:
             name: extra (debug-s4096)
     steps:
       - name: Download Artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: compiler
       - name: Unpack Artifact

--- a/.github/workflows/hygiene.yml
+++ b/.github/workflows/hygiene.yml
@@ -28,7 +28,7 @@ jobs:
         # context variable.
         if: failure()
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 50
           persist-credentials: false

--- a/.github/workflows/tsan.yml
+++ b/.github/workflows/tsan.yml
@@ -29,7 +29,7 @@ jobs:
       manual_changed: ${{ steps.manual.outputs.manual_changed }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
       - name: Install libunwind

--- a/.github/workflows/tsan.yml
+++ b/.github/workflows/tsan.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Prepare Artifact
         run: tar --zstd -cf /tmp/sources.tar.zstd .
       - name: Upload Artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: compiler
           path: /tmp/sources.tar.zstd
@@ -75,7 +75,7 @@ jobs:
             dependencies: libunwind-dev
     steps:
       - name: Download Artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: compiler
       - name: Unpack Artifact


### PR DESCRIPTION
- [gha: update checkout and caches actions from v3 to v4](https://github.com/ocaml/ocaml/commit/0226425796592b8b42675357e54ee2147be8b273)
  Removes an annoying warning about them using an outdated Node.js. We're not impacted by other changes.
- [gha: update artifacts actions](https://github.com/ocaml/ocaml/commit/43fcc9ffd6f4ae52db986f5420a8220ba1deb3e5)
  Should be much faster. We're not impacted by other changes.
  
(no change entry needed)