### PR TITLE
gha: use all available cores when building MSVC

### DIFF
--- a/.github/workflows/build-msvc.yml
+++ b/.github/workflows/build-msvc.yml
@@ -97,7 +97,7 @@ jobs:
           rm -rf config.cache ;
           ./configure --cache-file=config.cache --host=$HOST CC=$CC ;
           fi ;
-          make ;
+          make -j ;
           runtime/ocamlrun ocamlc -config ;
           # Don't add indentation or comments, it breaks Bash on
           # Windows when the yaml text block scalar is processed as a
@@ -129,4 +129,4 @@ jobs:
         shell: bash
         run: >-
           eval $(tools/msvs-promote-path) ;
-          make tests ;
+          make -j tests ;


### PR DESCRIPTION
A comparison of the "Build OCaml" task, sequential versus parallel. According to [the docs](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories), runners have 4 CPUs. "cached" means that the configure script results have been cached. Considering these ad-hoc benchmarks of GitHub Actions on my fork, I'm going with the `-j` option of Make, which will not limit the number of jobs that can run simultaneously.

This is similar to what we already do in AppVeyor for MinGW-w64 builds, although we bound the number of simultaneous jobs with `-j$NUMBER_OF_PROCESSORS` (equivalent to `-j$(nproc)` on Linux).

|                  | sequential | parallel, `-j4` | parallel, `-j4`, cached | parallel, `-j`, cached |
|------------------|:----------:|:---------------:|:-----------------------:|:----------------------:|
| MSVC 64 bits     |   13m 26s  |      6m 21s     |          6m 19s         |          6m 5s         |
| clang-cl 64 bits |   14m 58s  |      8m 17s     |          7m 21s         |          7m 4s         |
| MSVC 32 bits     |   8m 28s   |      4m 31s     |          4m 35s         |         3m 56s         |

This PR currently sits on my previous PR enabling the Autoconf cache. I'll rebase once it's merged.
- [x] #13125 