### PR TITLE
Include prims.o in libcamlrun_shared.so

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1359,7 +1359,7 @@ runtime/libcamlruni.$(A): $(libcamlruni_OBJECTS)
 runtime/libcamlrun_pic.$(A): $(libcamlrunpic_OBJECTS)
 	$(V_MKLIB)$(call MKLIB,$@, $^)
 
-runtime/libcamlrun_shared.$(SO): $(libcamlrunpic_OBJECTS)
+runtime/libcamlrun_shared.$(SO): runtime/prims.$(O) $(libcamlrunpic_OBJECTS)
 	$(V_MKDLL)$(MKDLL) -o $@ $^ $(BYTECCLIBS)
 
 runtime/libasmrun.$(A): $(libasmrun_OBJECTS)


### PR DESCRIPTION
I'd like to use `libcamlrun_shared.so` from other languages, but it has an undefined symbol `caml_names_of_builtin_cprim`:

```
$ python3 -c "import ctypes; ctypes.CDLL('runtime/libcamlrun_shared.so')"

Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/usr/lib/python3.11/ctypes/__init__.py", line 376, in __init__
    self._handle = _dlopen(self._name, mode)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^
OSError: runtime/libcamlrun_shared.so: undefined symbol: caml_names_of_builtin_cprim
```

This PR includes `prims.o` in the shared object so that the symbol is no longer undefined:

```
$ python3 -c "import ctypes; ctypes.CDLL('runtime/libcamlrun_shared.so')"
$
```