### PR TITLE
Add Unix.TCP_QUICKACK

### DIFF
--- a/Changes
+++ b/Changes
@@ -67,6 +67,9 @@ _______________
 
 ### Other libraries:
 
+- #13133: Add Unix.TCP_QUICKACK
+  (Robin Björklin, review by ?)
+
 ### Tools:
 
 - #12904: Run the testsuite with ThreadSanitizer on a PR when label

--- a/otherlibs/unix/sockopt_unix.c
+++ b/otherlibs/unix/sockopt_unix.c
@@ -83,6 +83,9 @@
 #ifndef TCP_NODELAY
 #define TCP_NODELAY (-1)
 #endif
+#ifndef TCP_QUICKACK
+#define TCP_QUICKACK (-1)
+#endif
 #ifndef SO_ERROR
 #define SO_ERROR (-1)
 #endif
@@ -117,6 +120,7 @@ static struct socket_option sockopt_bool[] = {
   { SOL_SOCKET, SO_OOBINLINE },
   { SOL_SOCKET, SO_ACCEPTCONN },
   { IPPROTO_TCP, TCP_NODELAY },
+  { IPPROTO_TCP, TCP_QUICKACK },
   { IPPROTO_IPV6, IPV6_V6ONLY},
   { SOL_SOCKET, SO_REUSEPORT }
 };

--- a/otherlibs/unix/sockopt_win32.c
+++ b/otherlibs/unix/sockopt_win32.c
@@ -24,6 +24,9 @@
 #ifndef SO_REUSEPORT
 #define SO_REUSEPORT (-1)
 #endif
+#ifndef TCP_QUICKACK
+#define TCP_QUICKACK (-1)
+#endif
 #ifndef IPPROTO_IPV6
 #define IPPROTO_IPV6 (-1)
 #endif
@@ -55,6 +58,7 @@ static struct socket_option sockopt_bool[] = {
   { SOL_SOCKET, SO_OOBINLINE },
   { SOL_SOCKET, SO_ACCEPTCONN },
   { IPPROTO_TCP, TCP_NODELAY },
+  { IPPROTO_TCP, TCP_QUICKACK },
   { IPPROTO_IPV6, IPV6_V6ONLY},
   { SOL_SOCKET, SO_REUSEPORT }
 };

--- a/otherlibs/unix/unix.mli
+++ b/otherlibs/unix/unix.mli
@@ -1588,6 +1588,8 @@ type socket_bool_option =
   | TCP_NODELAY    (** Control the Nagle algorithm for TCP sockets *)
   | IPV6_ONLY      (** Forbid binding an IPv6 socket to an IPv4 address *)
   | SO_REUSEPORT   (** Allow reuse of address and port bindings. @since 4.12. *)
+  | TCP_QUICKACK   (** Linux only: Send acknowledgments immediately.
+                      @since 5.3.0 *)
 (** The socket options that can be consulted with {!getsockopt}
    and modified with {!setsockopt}.  These options have a boolean
    ([true]/[false]) value. *)

--- a/otherlibs/unix/unixLabels.mli
+++ b/otherlibs/unix/unixLabels.mli
@@ -1588,6 +1588,8 @@ type socket_bool_option = Unix.socket_bool_option =
   | TCP_NODELAY    (** Control the Nagle algorithm for TCP sockets *)
   | IPV6_ONLY      (** Forbid binding an IPv6 socket to an IPv4 address *)
   | SO_REUSEPORT   (** Allow reuse of address and port bindings. @since 4.12. *)
+  | TCP_QUICKACK   (** Linux only: Send acknowledgments immediately.
+                      @since 5.3.0 *)
 (** The socket options that can be consulted with {!getsockopt}
    and modified with {!setsockopt}.  These options have a boolean
    ([true]/[false]) value. *)

--- a/otherlibs/unix/unix_unix.ml
+++ b/otherlibs/unix/unix_unix.ml
@@ -669,6 +669,7 @@ type socket_bool_option =
   | TCP_NODELAY
   | IPV6_ONLY
   | SO_REUSEPORT
+  | TCP_QUICKACK
 
 type socket_int_option =
     SO_SNDBUF

--- a/otherlibs/unix/unix_win32.ml
+++ b/otherlibs/unix/unix_win32.ml
@@ -772,6 +772,7 @@ type socket_bool_option =
   | TCP_NODELAY
   | IPV6_ONLY
   | SO_REUSEPORT
+  | TCP_QUICKACK
 
 type socket_int_option =
     SO_SNDBUF


### PR DESCRIPTION
If accepted this PR adds the `TCP_QUICKACK` socket option.

`TCP_QUICKACK` can be of use on low latency networks where a socket buffer may not fill up in the hard coded 200ms window. Setting `TCP_QUICKACK` will cause acknowledgements to be sent immediately.

> [Short version: set TCP_QUICKACK. If you find a case where that makes things worse, let me know.](https://news.ycombinator.com/item?id=10608356)
> 
> John Nagle

* [Best Practices for TCP Optimization](https://www.extrahop.com/blog/tcp-nodelay-nagle-quickack-best-practices)
* [Optimizing TCP: Nagle’s Algorithm and Beyond](https://assets.extrahop.com/whitepapers/TCP-Optimization-Guide-by-ExtraHop.pdf)

PS. This PR was heavily inspired by #9869 and I'm not convinced I did everything correctly. For example it is not clear to me why the `TCP_NODELAY` macro exists in `sockopt_unix.c` but not in `sockopt_win32.c` and because I don't understand I opted to not add the macro to `sockopt_win32.c`.

EDIT: The build failed without the macro in `sockopt_win32.c` so I ended up adding it after all.