### PR TITLE
We depend on <stdint.h> absolutely, not conditionally.

### DIFF
--- a/configure
+++ b/configure
@@ -14858,13 +14858,6 @@ then :
 
 fi
 
-ac_fn_c_check_header_compile "$LINENO" "stdint.h" "ac_cv_header_stdint_h" "$ac_includes_default"
-if test "x$ac_cv_header_stdint_h" = xyes
-then :
-  printf "%s\n" "#define HAS_STDINT_H 1" >>confdefs.h
-
-fi
-
 ac_fn_c_check_header_compile "$LINENO" "pthread_np.h" "ac_cv_header_pthread_np_h" "$ac_includes_default"
 if test "x$ac_cv_header_pthread_np_h" = xyes
 then :

--- a/configure.ac
+++ b/configure.ac
@@ -1136,7 +1136,6 @@ AS_CASE([$host],
   [AC_CHECK_HEADERS([unistd.h],[AC_DEFINE([HAS_UNISTD])])])
 
 AC_CHECK_HEADER([math.h])
-AC_CHECK_HEADER([stdint.h],[AC_DEFINE([HAS_STDINT_H])])
 AC_CHECK_HEADER([pthread_np.h],[AC_DEFINE([HAS_PTHREAD_NP_H])])
 AC_CHECK_HEADER([dirent.h], [AC_DEFINE([HAS_DIRENT])], [],
   [#include <sys/types.h>])

--- a/runtime/caml/bigarray.h
+++ b/runtime/caml/bigarray.h
@@ -21,15 +21,8 @@
 
 typedef signed char caml_ba_int8;
 typedef unsigned char caml_ba_uint8;
-#if defined(HAS_STDINT_H)
 typedef int16_t caml_ba_int16;
 typedef uint16_t caml_ba_uint16;
-#elif SIZEOF_SHORT == 2
-typedef short caml_ba_int16;
-typedef unsigned short caml_ba_uint16;
-#else
-#error "No 16-bit integer type available"
-#endif
 
 #define CAML_BA_MAX_NUM_DIMS 16
 

--- a/runtime/caml/config.h
+++ b/runtime/caml/config.h
@@ -54,9 +54,8 @@
 #define HAS_LOCALE
 #endif
 
-#ifdef HAS_STDINT_H
 #include <stdint.h>
-#endif
+#define HAS_STDINT_H
 
 /* Disable the mingw-w64 *printf shims */
 #if defined(CAML_INTERNALS) && defined(__MINGW32__)
@@ -118,21 +117,6 @@
   #else
     #error "No 64-bit integer type available"
   #endif
-#endif
-
-#ifndef HAS_STDINT_H
-/* Not a C99 compiler, typically MSVC.  Define the C99 types we use. */
-typedef ARCH_INT32_TYPE int32_t;
-typedef ARCH_UINT32_TYPE uint32_t;
-typedef ARCH_INT64_TYPE int64_t;
-typedef ARCH_UINT64_TYPE uint64_t;
-#if SIZEOF_SHORT == 2
-typedef short int16_t;
-typedef unsigned short uint16_t;
-#else
-#error "No 16-bit integer type available"
-#endif
-typedef unsigned char uint8_t;
 #endif
 
 #if SIZEOF_PTR == SIZEOF_LONG

--- a/runtime/caml/s.h.in
+++ b/runtime/caml/s.h.in
@@ -104,8 +104,6 @@
 
 #undef HAS_IPV6
 
-#undef HAS_STDINT_H
-
 #undef HAS_PTHREAD_NP_H
 
 #undef HAS_UNISTD


### PR DESCRIPTION
In discussion on https://github.com/ocaml/ocaml/pull/13083 it was noted that `<stdint.h>` is a non-negotiable dependency for the OCaml runtime these days, so checking for its presence and trying to work around its absence are no longer appropriate.

Maybe there are other headers etc to which this also applies?