### PR TITLE
effect syntax: effect patterns as computation patterns

### DIFF
--- a/file_formats/cmt_format.ml
+++ b/file_formats/cmt_format.ml
@@ -268,7 +268,7 @@ let iter_on_occurrences
         fields
       | Tpat_any | Tpat_var _ | Tpat_alias _ | Tpat_constant _ | Tpat_tuple _
       | Tpat_variant _ | Tpat_array _ | Tpat_lazy _ | Tpat_value _
-      | Tpat_exception _ | Tpat_or _ -> ());
+      | Tpat_exception _ | Tpat_effect _ | Tpat_or _ -> ());
       List.iter  (fun (pat_extra, _, _) ->
         match pat_extra with
         | Tpat_open (path, lid, _) ->

--- a/testsuite/tests/effect-syntax/error_messages.ml
+++ b/testsuite/tests/effect-syntax/error_messages.ml
@@ -38,20 +38,43 @@ Error: This expression has type "(int, unit) continuation"
 
 let () = match () with
   | () -> ()
-  | effect A, [k] -> ()
+  | effect A _, [k] -> ()
 [%%expect {|
-Line 3, characters 14-17:
-3 |   | effect A, [k] -> ()
-                  ^^^
+Line 3, characters 4-19:
+3 |   | effect A _, [k] -> ()
+        ^^^^^^^^^^^^^^^
 Error: Invalid continuation pattern: only variables and _ are allowed .
 |}]
 
 let () = match [] with
   | _ -> ()
-  | [effect A, k] -> ()
+  | [effect A _, k] -> ()
 [%%expect {|
-Line 3, characters 5-16:
-3 |   | [effect A, k] -> ()
-         ^^^^^^^^^^^
-Error: Effect patterns must be at the top level of a match case.
+Line 3, characters 5-18:
+3 |   | [effect A _, k] -> ()
+         ^^^^^^^^^^^^^
+Error: Effect patterns are not allowed in this position.
+|}]
+
+let () = match [] with
+  | effect _, _ | exception Not_found -> ()
+[%%expect {|
+Lines 1-2, characters 9-43:
+1 | .........match [] with
+2 |   | effect _, _ | exception Not_found -> ()
+Error: None of the patterns in this "match" expression match values.
+|}]
+
+
+let n = match 0 with
+  | effect A _, _ -> 0
+  | x -> 1
+  | effect A _, _ -> 0
+[%%expect {|
+Line 4, characters 11-14:
+4 |   | effect A _, _ -> 0
+               ^^^
+Warning 11 [redundant-case]: this match case is unused.
+
+val n : int = 1
 |}]

--- a/testsuite/tests/effect-syntax/mixed.ml
+++ b/testsuite/tests/effect-syntax/mixed.ml
@@ -1,0 +1,52 @@
+(* TEST
+expect;
+*)
+
+type _ eff += A: int -> int eff | B: int -> int eff
+
+exception Exn of int
+
+
+let test f =
+  match f () with
+  | n | exception (Exn n)
+  | effect A n, _ | effect B n, _ -> n
+[%%expect {|
+type _ eff += A : int -> int eff | B : int -> int eff
+exception Exn of int
+val test : (unit -> int) -> int = <fun>
+|}]
+
+let a = test ignore
+[%%expect{|
+Line 1, characters 13-19:
+1 | let a = test ignore
+                 ^^^^^^
+Error: This expression has type "unit -> unit"
+       but an expression was expected of type "unit -> int"
+       Type "unit" is not compatible with type "int"
+|}]
+
+let b = test (fun () -> raise Exn 1)
+[%%expect{|
+Line 1, characters 34-35:
+1 | let b = test (fun () -> raise Exn 1)
+                                      ^
+Warning 20 [ignored-extra-argument]: this argument will not be used by the function.
+
+Line 1, characters 30-33:
+1 | let b = test (fun () -> raise Exn 1)
+                                  ^^^
+Error: The constructor "Exn" expects 1 argument(s),
+       but is applied here to 0 argument(s)
+|}]
+
+let b = test (fun () -> Effect.perform (A 2))
+[%%expect{|
+val b : int = 2
+|}]
+
+let c = test (fun () -> Effect.perform (B 3))
+[%%expect{|
+val c : int = 3
+|}]

--- a/testsuite/tests/match-exception-warnings/no_mixing_under_guard.ml
+++ b/testsuite/tests/match-exception-warnings/no_mixing_under_guard.ml
@@ -17,5 +17,5 @@ val r : string ref = {contents = ""}
 Line 7, characters 4-25:
 7 |   | true | exception Exit when r := "hello"; true -> !r
         ^^^^^^^^^^^^^^^^^^^^^
-Error: Mixing value and exception patterns under when-guards is not supported.
+Error: Mixing value and computation patterns under when-guards is not supported.
 |}]

--- a/typing/cmt2annot.ml
+++ b/typing/cmt2annot.ml
@@ -100,12 +100,10 @@ let rec iterator ~scope rebuild_env =
         bind_bindings exp.exp_loc bindings
     | Texp_let (Nonrecursive, bindings, body) ->
         bind_bindings body.exp_loc bindings
-    | Texp_match (_, f1, f2, _) ->
-        bind_cases f1;
-        bind_cases f2
-    | Texp_try (_, f1, f2) ->
-        bind_cases f1;
-        bind_cases f2
+    | Texp_match (_, f1, _) ->
+        bind_cases f1
+    | Texp_try (_, f1) ->
+        bind_cases f1
     | Texp_function (params, _) ->
         List.iter (bind_function_param exp.exp_loc) params
     | Texp_letmodule (_, modname, _, _, body ) ->

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -1282,6 +1282,16 @@ let new_local_type ?(loc = Location.none) ?manifest_and_scope origin =
     type_uid = Uid.mk ~current_unit:(Env.get_unit_name ());
   }
 
+let new_effect_type ~loc env ~body =
+    let decl = new_local_type ~loc Definition in
+    let scope = create_scope () in
+    let name = get_new_abstract_name env "%eff" in
+    let id = Ident.create_scoped ~scope name in
+    let new_env = Env.add_type ~check:false id decl env in
+    let ty_eff = newgenty (Tconstr (Path.Pident id,[],ref Mnil)) in
+    new_env,
+    (Predef.type_eff ty_eff, Predef.type_continuation ty_eff body)
+
 let existential_name name_counter ty =
   let name =
     match get_desc ty with

--- a/typing/ctype.mli
+++ b/typing/ctype.mli
@@ -176,6 +176,10 @@ val new_local_type:
         ?manifest_and_scope:(type_expr * int) ->
         type_origin -> type_declaration
 
+val new_effect_type:
+  loc:Location.t -> Env.t -> body:type_expr -> Env.t * (type_expr * type_expr)
+(* Create an effect type *)
+
 module Pattern_env : sig
   type t = private
     { mutable env : Env.t;
@@ -260,8 +264,6 @@ type typedecl_extraction_result =
 
 val extract_concrete_typedecl:
         Env.t -> type_expr -> typedecl_extraction_result
-
-val get_new_abstract_name : Env.t -> string -> string
 
 val unify: Env.t -> type_expr -> type_expr -> unit
         (* Unify the two types given. Raise [Unify] if not possible. *)

--- a/typing/parmatch.ml
+++ b/typing/parmatch.ml
@@ -1812,14 +1812,15 @@ let pressure_variants_in_computation_pattern tdefs patl =
     | None -> pss
     | Some p -> p :: pss
   in
-  let val_pss, exn_pss =
-    List.fold_right (fun pat (vpss, epss)->
-      let (vp, ep) = split_pattern pat in
-      add_row vpss vp, add_row epss ep
-    ) patl ([], [])
+  let val_pss, exn_pss, eff_pss =
+    List.fold_right (fun pat (vpss, epss,effss)->
+      let sp = split_pattern pat in
+      add_row vpss sp.value, add_row epss sp.exn, add_row effss sp.eff
+    ) patl ([], [], [])
   in
   pressure_variants tdefs val_pss;
-  pressure_variants tdefs exn_pss
+  pressure_variants tdefs exn_pss;
+  pressure_variants tdefs (List.map fst eff_pss)
 
 (*****************************)
 (* Utilities for diagnostics *)

--- a/typing/predef.ml
+++ b/typing/predef.ml
@@ -105,7 +105,6 @@ and ident_undefined_recursive_module =
         ident_create "Undefined_recursive_module"
 and ident_continuation_already_taken = ident_create "Continuation_already_taken"
 
-
 let all_predef_exns = [
   ident_match_failure;
   ident_out_of_memory;

--- a/typing/printpat.ml
+++ b/typing/printpat.ml
@@ -102,6 +102,10 @@ let rec pretty_val : type k . _ -> k general_pattern -> _ = fun ppf v ->
       fprintf ppf "@[(%a@ as %a)@]" pretty_val v Ident.print x
   | Tpat_value v ->
       fprintf ppf "%a" pretty_val (v :> pattern)
+  | Tpat_effect (v,None) ->
+      fprintf ppf "@[<2>effect@ %a,@ _]" pretty_arg v
+  | Tpat_effect (v, Some (id,_)) ->
+      fprintf ppf "@[<2>effect@ %a,@ %s]" pretty_arg v (Ident.name id)
   | Tpat_exception v ->
       fprintf ppf "@[<2>exception@ %a@]" pretty_arg v
   | Tpat_or _ ->

--- a/typing/printtyped.ml
+++ b/typing/printtyped.ml
@@ -267,6 +267,12 @@ and pattern : type k . _ -> _ -> k general_pattern -> unit = fun i ppf x ->
   | Tpat_exception p ->
       line i ppf "Tpat_exception\n";
       pattern i ppf p;
+  | Tpat_effect (p,None) ->
+      line i ppf "Tpat_effect\n";
+      pattern i ppf p;
+  | Tpat_effect (p,Some(k,_)) ->
+      line i ppf "Tpat_effect \"%a\"\n" fmt_ident k;
+      pattern i ppf p;
   | Tpat_value p ->
       line i ppf "Tpat_value\n";
       pattern i ppf (p :> pattern);
@@ -351,16 +357,15 @@ and expression i ppf x =
       line i ppf "Texp_apply\n";
       expression i ppf e;
       list i label_x_expression ppf l;
-  | Texp_match (e, l1, l2, partial) ->
-      line i ppf "Texp_match%a\n" fmt_partiality partial;
+  | Texp_match (e, l, partial) ->
+      line i ppf "Texp_match%a\n"
+        fmt_partiality partial;
       expression i ppf e;
-      list i case ppf l1;
-      list i case ppf l2;
-  | Texp_try (e, l1, l2) ->
+      list i case ppf l;
+  | Texp_try (e, l) ->
       line i ppf "Texp_try\n";
       expression i ppf e;
-      list i case ppf l1;
-      list i case ppf l2;
+      list i case ppf l;
   | Texp_tuple (l) ->
       line i ppf "Texp_tuple\n";
       list i expression ppf l;

--- a/typing/tast_iterator.ml
+++ b/typing/tast_iterator.ml
@@ -259,6 +259,9 @@ let pat
   | Tpat_lazy p -> sub.pat sub p
   | Tpat_value p -> sub.pat sub (p :> pattern)
   | Tpat_exception p -> sub.pat sub p
+  | Tpat_effect (p,k) ->
+      sub.pat sub p;
+      Option.iter (fun (_,s) -> iter_loc sub s) k
   | Tpat_or (p1, p2, _) ->
       sub.pat sub p1;
       sub.pat sub p2
@@ -309,14 +312,12 @@ let expr sub {exp_loc; exp_extra; exp_desc; exp_env; exp_attributes; _} =
   | Texp_apply (exp, list) ->
       sub.expr sub exp;
       List.iter (fun (_, o) -> Option.iter (sub.expr sub) o) list
-  | Texp_match (exp, cases, effs, _) ->
+  | Texp_match (exp, cases, _) ->
       sub.expr sub exp;
-      List.iter (sub.case sub) cases;
-      List.iter (sub.case sub) effs
-  | Texp_try (exp, cases, effs) ->
+      List.iter (sub.case sub) cases
+  | Texp_try (exp, cases) ->
       sub.expr sub exp;
-      List.iter (sub.case sub) cases;
-      List.iter (sub.case sub) effs
+      List.iter (sub.case sub) cases
   | Texp_tuple list -> List.iter (sub.expr sub) list
   | Texp_construct (lid, _, args) ->
       iter_loc sub lid;

--- a/typing/typeclass.ml
+++ b/typing/typeclass.ml
@@ -1183,7 +1183,7 @@ and class_expr_aux cl_num val_env met_env virt self_scope scl =
       let partial =
         let dummy = type_exp val_env (Ast_helper.Exp.unreachable ()) in
         Typecore.check_partial val_env pat.pat_type pat.pat_loc
-          [{c_lhs = pat; c_cont = None; c_guard = None; c_rhs = dummy}]
+          [{c_lhs = pat; c_guard = None; c_rhs = dummy}]
       in
       let cl =
         Ctype.with_raised_nongen_level

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -178,9 +178,8 @@ type error =
   | Invalid_interval
   | Invalid_for_loop_index
   | No_value_clauses
-  | Exception_pattern_disallowed
-  | Mixed_value_and_exception_patterns_under_guard
-  | Effect_pattern_below_toplevel
+  | Computation_pattern_disallowed of {exn:bool}
+  | Mixed_value_and_computation_patterns_under_guard
   | Invalid_continuation_pattern
   | Inlined_record_escape
   | Inlined_record_expected
@@ -250,7 +249,8 @@ let rp node =
   node
 
 let rcp node =
-  Cmt_format.add_saved_type (Cmt_format.Partial_pattern (Computation, node));
+  Cmt_format.add_saved_type
+    (Cmt_format.Partial_pattern (Computation {exn=true}, node));
   node
 
 
@@ -264,7 +264,7 @@ type recarg =
 let mk_expected ?explanation ty = { ty; explanation; }
 
 let case lhs rhs =
-  {c_lhs = lhs; c_cont = None; c_guard = None; c_rhs = rhs}
+  {c_lhs = lhs; c_guard = None; c_rhs = rhs}
 
 (* Typing of constants *)
 
@@ -378,23 +378,6 @@ let is_principal ty =
   not !Clflags.principal || get_level ty = generic_level
 
 (* Typing of patterns *)
-
-(* Simplified patterns for effect continuations *)
-let type_continuation_pat env expected_ty sp =
-  let loc = sp.ppat_loc in
-  match sp.ppat_desc with
-  | Ppat_any -> None
-  | Ppat_var name ->
-      let id = Ident.create_local name.txt in
-      let desc =
-        { val_type = expected_ty; val_kind = Val_reg;
-          Types.val_loc = loc; val_attributes = [];
-          val_uid = Uid.mk ~current_unit:(Env.get_unit_name ()); }
-      in
-        Some (id, desc)
-  | Ppat_extension ext ->
-      raise (Error_forward (Builtin_attributes.error_of_extension ext))
-  | _ -> raise (Error (loc, env, Invalid_continuation_pattern))
 
 (* unification inside type_exp and type_expect *)
 let unify_exp_types loc env ty expected_ty =
@@ -551,17 +534,7 @@ type type_pat_state =
     *)
   }
 
-let continuation_variable = function
-  | None -> []
-  | Some (id, (desc:Types.value_description)) ->
-    [{pv_id = id;
-     pv_type = desc.val_type;
-     pv_loc = desc.val_loc;
-     pv_kind = Continuation_var;
-     pv_attributes = desc.val_attributes;
-     pv_uid= desc.val_uid}]
-
-let create_type_pat_state ?cont allow_modules =
+let create_type_pat_state allow_modules =
   let tps_module_variables =
     match allow_modules with
     | Modules_allowed { scope } ->
@@ -569,7 +542,7 @@ let create_type_pat_state ?cont allow_modules =
     | Modules_ignored -> Modvars_ignored
     | Modules_rejected -> Modvars_rejected
   in
-  { tps_pattern_variables = continuation_variable cont;
+  { tps_pattern_variables = [];
     tps_module_variables;
     tps_pattern_force = [];
   }
@@ -603,8 +576,7 @@ let maybe_add_pattern_variables_ghost loc_let env pv =
        end
     ) pv env
 
-let enter_variable ?(is_module=false) ?(is_as_variable=false) tps loc name ty
-    attrs =
+let enter_variable ?(is_module=false) ?(kind=Std_var) tps loc name ty attrs =
   if List.exists (fun {pv_id; _} -> Ident.name pv_id = name.txt)
       tps.tps_pattern_variables
   then raise(Error(loc, Env.empty, Multiply_bound_variable name.txt));
@@ -638,9 +610,9 @@ let enter_variable ?(is_module=false) ?(is_as_variable=false) tps loc name ty
     {pv_id = id;
      pv_type = ty;
      pv_loc = loc;
-     pv_kind = if is_as_variable then As_var else Std_var;
+     pv_kind = kind;
      pv_attributes = attrs;
-     pv_uid} :: tps.tps_pattern_variables;
+     pv_uid } :: tps.tps_pattern_variables;
   id, pv_uid
 
 let sort_pattern_variables vs =
@@ -1543,14 +1515,19 @@ let split_half_typed_cases env zipped_cases =
     | Some split_pat ->
         ({ htc.untyped_case with pattern = split_pat }, data) :: lst
   in
-  List.fold_right (fun (htc, data) (vals, exns) ->
+  List.fold_right (fun (htc, data) (vals, exns, effs) ->
       let pat = htc.typed_pat in
-      match split_pattern pat with
-      | Some _, Some _ when htc.untyped_case.has_guard ->
+      let sp = split_pattern pat in
+      match sp.value, sp.exn, sp.eff with
+      | Some _, Some _, _  | Some _, _, Some _ | _, Some _, Some _
+        when htc.untyped_case.has_guard ->
           raise (Error (pat.pat_loc, env,
-                        Mixed_value_and_exception_patterns_under_guard))
-      | vp, ep -> add_case vals htc data vp, add_case exns htc data ep
-    ) zipped_cases ([], [])
+                        Mixed_value_and_computation_patterns_under_guard))
+      | vp, ep, eff ->
+          add_case vals htc data vp,
+          add_case exns htc data ep,
+          add_case effs htc data eff
+    ) zipped_cases ([], [],[])
 
 let rec has_literal_pattern p = match p.ppat_desc with
   | Ppat_constant _
@@ -1619,18 +1596,21 @@ let pure
   = fun category pat ->
   match category with
   | Value -> pat
-  | Computation -> as_computation_pattern pat
+  | Computation _ -> as_computation_pattern pat
 
 let only_impure
-  : type k . k pattern_category ->
+  : type k . exn:bool -> expected:k pattern_category ->
              computation general_pattern -> k general_pattern
-  = fun category pat ->
+  = fun ~exn ~expected:category pat ->
+  let no_computation_pattern ~exn =
+    let error =  Computation_pattern_disallowed {exn} in
+    raise (Error (pat.pat_loc, pat.pat_env, error))
+  in
   match category with
-  | Value ->
-     (* LATER: this exception could be renamed/generalized *)
-     raise (Error (pat.pat_loc, pat.pat_env,
-                   Exception_pattern_disallowed))
-  | Computation -> pat
+  | Value -> no_computation_pattern ~exn
+  | Computation expected ->
+      if expected.exn || not exn then pat
+      else no_computation_pattern ~exn
 
 let as_comp_pattern
   : type k . k pattern_category ->
@@ -1638,14 +1618,20 @@ let as_comp_pattern
   = fun category pat ->
   match category with
   | Value -> as_computation_pattern pat
-  | Computation -> pat
+  | Computation _ -> pat
+
+type expected_pat_typ = {
+  value_typ: type_expr;
+  eff_typ: (type_expr * type_expr) option;
+}
+let expected_pat_typ ?eff_typ value_typ = { value_typ; eff_typ}
 
 (** [type_pat] propagates the expected type, and
     unification may update the typing environment. *)
 let rec type_pat
   : type k . type_pat_state -> k pattern_category ->
       no_existentials: existential_restriction option ->
-      penv: Pattern_env.t -> Parsetree.pattern -> type_expr ->
+      penv: Pattern_env.t -> Parsetree.pattern -> expected_pat_typ ->
       k general_pattern
   = fun tps category ~no_existentials ~penv sp expected_ty ->
   Builtin_attributes.warning_scope sp.ppat_attributes
@@ -1656,9 +1642,11 @@ let rec type_pat
 and type_pat_aux
   : type k . type_pat_state -> k pattern_category -> no_existentials:_ ->
          penv:Pattern_env.t -> _ -> _ -> k general_pattern
-  = fun tps category ~no_existentials ~penv sp expected_ty ->
-  let type_pat tps category ?(penv=penv) =
-    type_pat tps category ~no_existentials ~penv
+  = fun tps category ~no_existentials ~penv sp pat_expected_ty ->
+  let expected_ty = pat_expected_ty.value_typ in
+  let type_pat tps category ?(penv=penv) p value_typ =
+    type_pat tps category ~no_existentials ~penv p
+      {pat_expected_ty with value_typ}
   in
   let loc = sp.ppat_loc in
   let solve_expected (x : pattern) : pattern =
@@ -1668,12 +1656,12 @@ and type_pat_aux
   let crp (x : k general_pattern) : k general_pattern =
     match category with
     | Value -> rp x
-    | Computation -> rcp x
+    | Computation _ -> rcp x
   in
   (* record {general,value,computation} pattern *)
   let rp = crp
   and rvp x = crp (pure category x)
-  and rcp x = crp (only_impure category x) in
+  and rcp ~exn x = crp (only_impure ~exn ~expected:category x) in
   match sp.ppat_desc with
     Ppat_any ->
       rvp {
@@ -1735,8 +1723,7 @@ and type_pat_aux
       let q = type_pat tps Value sq expected_ty in
       let ty_var = solve_Ppat_alias !!penv q in
       let id, uid =
-        enter_variable
-          ~is_as_variable:true tps name.loc name ty_var sp.ppat_attributes
+        enter_variable ~kind:As_var tps name.loc name ty_var sp.ppat_attributes
       in
       rvp { pat_desc = Tpat_alias(q, id, name, uid);
             pat_loc = loc; pat_extra=[];
@@ -2034,7 +2021,7 @@ and type_pat_aux
                                 loc, sp.ppat_attributes) :: p.pat_extra }
   | Ppat_exception p ->
       let p_exn = type_pat tps Value p Predef.type_exn in
-      rcp {
+      rcp ~exn:true {
         pat_desc = Tpat_exception p_exn;
         pat_loc = sp.ppat_loc;
         pat_extra = [];
@@ -2042,8 +2029,35 @@ and type_pat_aux
         pat_env = !!penv;
         pat_attributes = sp.ppat_attributes;
       }
-  | Ppat_effect _ ->
-      raise (Error (loc, !!penv, Effect_pattern_below_toplevel))
+  | Ppat_effect (p,k) ->
+      let eff_ty, cont_ty = match pat_expected_ty.eff_typ with
+        | None ->
+            (* effect type are generated in the type_pattern function
+               in presence of effect patterns. *)
+            assert false
+        | Some (e,c) -> e, c
+      in
+      let k =
+        match k.ppat_desc with
+        | Ppat_any -> None
+        | Ppat_var name ->
+            let ty = instance cont_ty in
+            let id, _uid =
+              enter_variable ~kind:Continuation_var tps loc name ty
+                sp.ppat_attributes
+            in
+            Some (id, name)
+        | _ -> raise (Error (loc, !!penv, Invalid_continuation_pattern))
+      in
+      let p = type_pat tps Value p eff_ty in
+      rcp ~exn:false {
+        pat_desc = Tpat_effect (p, k);
+        pat_loc = sp.ppat_loc;
+        pat_extra = [];
+        pat_type = expected_ty;
+        pat_env = !!penv;
+        pat_attributes = sp.ppat_attributes;
+      }
   | Ppat_extension ext ->
       raise (Error_forward (Builtin_attributes.error_of_extension ext))
 
@@ -2099,19 +2113,21 @@ let add_module_variables env module_variables =
     end
   ) env module_variables_as_list
 
-let type_pat tps category ?no_existentials penv =
-  type_pat tps category ~no_existentials ~penv
-
-let type_pattern category ~lev env spat expected_ty ?cont allow_modules =
-  let tps = create_type_pat_state ?cont allow_modules in
+let type_pattern category ~lev env spat expected_ty allow_modules =
+  let tps = create_type_pat_state allow_modules in
   let new_penv = Pattern_env.make env
       ~equations_scope:lev ~allow_recursive_equations:false in
-  let pat = type_pat tps category new_penv spat expected_ty in
+  let pat =
+    type_pat tps category ~no_existentials:None ~penv:new_penv spat
+      expected_ty in
   let { tps_pattern_variables = pvs;
         tps_module_variables = mvs;
         tps_pattern_force = pattern_forces;
       } = tps in
   (pat, !!new_penv, pattern_forces, pvs, mvs)
+
+let type_pat tps category ?no_existentials penv p expected_ty =
+  type_pat tps category ~no_existentials ~penv p (expected_pat_typ expected_ty)
 
 let type_pattern_list
     category no_existentials env spatl expected_tys allow_modules
@@ -2558,9 +2574,9 @@ let rec final_subexpression exp =
   match exp.exp_desc with
     Texp_let (_, _, e)
   | Texp_sequence (_, e)
-  | Texp_try (e, _, _)
+  | Texp_try (e, _)
   | Texp_ifthenelse (_, e, _)
-  | Texp_match (_, {c_rhs=e} :: _, _, _)
+  | Texp_match (_, {c_rhs=e} :: _, _)
   | Texp_letmodule (_, _, _, _, e)
   | Texp_letexception (_, e)
   | Texp_open (_, e)
@@ -2581,21 +2597,21 @@ let rec is_nonexpansive exp =
       is_nonexpansive body
   | Texp_apply(e, (_,None)::el) ->
       is_nonexpansive e && List.for_all is_nonexpansive_opt (List.map snd el)
-  | Texp_match(e, cases, _, _) ->
+  | Texp_match(e, cases, _) ->
      (* Not sure this is necessary, if [e] is nonexpansive then we shouldn't
          care if there are exception patterns. But the previous version enforced
          that there be none, so... *)
-      let contains_exception_pat pat =
+      let contains_computation_pat pat =
         exists_general_pattern { f = fun (type k) (p : k general_pattern) ->
           match p.pat_desc with
-          | Tpat_exception _ -> true
+          | Tpat_exception _ | Tpat_effect _  -> true
           | _ -> false } pat
       in
       is_nonexpansive e &&
       List.for_all
         (fun {c_lhs; c_guard; c_rhs} ->
            is_nonexpansive_opt c_guard && is_nonexpansive c_rhs
-           && not (contains_exception_pat c_lhs)
+           && not (contains_computation_pat c_lhs)
         ) cases
   | Texp_tuple el ->
       List.for_all is_nonexpansive el
@@ -2961,13 +2977,10 @@ let check_partial_application ~statement exp =
             | Texp_extension_constructor _ | Texp_ifthenelse (_, _, None)
             | Texp_function _ ->
                 check_statement ()
-            | Texp_match (_, cases, eff_cases, _) ->
-                List.iter (fun {c_rhs; _} -> check c_rhs) cases;
-                List.iter (fun {c_rhs; _} -> check c_rhs) eff_cases
-            | Texp_try (e, cases, eff_cases) ->
-                check e;
-                List.iter (fun {c_rhs; _} -> check c_rhs) cases;
-                List.iter (fun {c_rhs; _} -> check c_rhs) eff_cases
+            | Texp_match (_, cases, _) ->
+                List.iter (fun {c_rhs; _} -> check c_rhs) cases
+            | Texp_try (e, cases) ->
+                check e; List.iter (fun {c_rhs; _} -> check c_rhs) cases
             | Texp_ifthenelse (_, e1, Some e2) ->
                 check e1; check e2
             | Texp_let (_, _, e) | Texp_sequence (_, e) | Texp_open (_, e)
@@ -3046,7 +3059,7 @@ let shallow_iter_ppat f p =
   | Ppat_extension _
   | Ppat_type _ | Ppat_unpack _ -> ()
   | Ppat_array pats -> List.iter f pats
-  | Ppat_or (p1,p2)
+  | Ppat_or (p1,p2) -> f p1; f p2
   | Ppat_effect(p1, p2) -> f p1; f p2
   | Ppat_variant (_, arg) -> Option.iter f arg
   | Ppat_tuple lst ->  List.iter f lst
@@ -3077,6 +3090,9 @@ let contains_gadt p =
      match p.pat_desc with
      | Tpat_construct (_, cd, _, _) when cd.cstr_generalized -> true
      | _ -> false } p
+
+let contains_effects p =
+  exists_ppat (function {ppat_desc=Ppat_effect _} -> true | _ -> false) p
 
 (* There are various things that we need to do in presence of GADT constructors
    that aren't required if there are none.
@@ -3574,66 +3590,28 @@ and type_expect_
         with_local_level (fun () -> type_exp env sarg)
           ~post:(may_lower_contravariant_then_generalize env)
       in
-      let rec split_cases valc effc conts = function
-        | [] -> List.rev valc, List.rev effc, List.rev conts
-        | {pc_lhs = {ppat_desc=Ppat_effect(p1, p2)}} as c :: rest ->
-            split_cases valc
-              (({c with pc_lhs = p1}) :: effc) (p2 :: conts) rest
-        | c :: rest ->
-            split_cases (c :: valc) effc conts rest
-      in
-      let val_caselist, eff_caselist, eff_conts =
-        split_cases [] [] [] caselist
-      in
-      if val_caselist = [] && eff_caselist <> [] then
-        raise (Error (loc, env, No_value_clauses));
-      let val_cases, partial =
-        type_cases Computation env arg.exp_type ty_expected_explained
-          ~check_if_total:true loc val_caselist
-      in
-      let eff_cases =
-        match eff_caselist with
-        | [] -> []
-        | eff_caselist ->
-            type_effect_cases Value env ty_expected_explained loc eff_caselist
-              eff_conts
-      in
+      let cases, partial =
+        type_cases (Computation {exn=true}) env
+          arg.exp_type ty_expected_explained
+          ~check_if_total:true loc caselist in
       if
         List.for_all (fun c -> pattern_needs_partial_application_check c.c_lhs)
-          val_cases
+          cases
       then check_partial_application ~statement:false arg;
       re {
-        exp_desc = Texp_match(arg, val_cases, eff_cases, partial);
+        exp_desc = Texp_match(arg, cases, partial);
         exp_loc = loc; exp_extra = [];
         exp_type = instance ty_expected;
         exp_attributes = sexp.pexp_attributes;
         exp_env = env }
   | Pexp_try(sbody, caselist) ->
       let body = type_expect env sbody ty_expected_explained in
-      let rec split_cases exnc effc conts = function
-        | [] -> List.rev exnc, List.rev effc, List.rev conts
-        | {pc_lhs = {ppat_desc=Ppat_effect(p1, p2)}} as c :: rest ->
-            split_cases exnc
-              (({c with pc_lhs = p1}) :: effc) (p2 :: conts) rest
-        | c :: rest ->
-            split_cases (c :: exnc) effc conts rest
-      in
-      let exn_caselist, eff_caselist, eff_conts =
-        split_cases [] [] [] caselist
-      in
-      let exn_cases, _ =
-        type_cases Value env Predef.type_exn ty_expected_explained
-          ~check_if_total:false loc exn_caselist
-      in
-      let eff_cases =
-        match eff_caselist with
-        | [] -> []
-        | eff_caselist ->
-            type_effect_cases Value env ty_expected_explained loc eff_caselist
-              eff_conts
-      in
+      let cases, _ =
+        type_cases (Computation {exn=false}) env
+          Predef.type_exn ty_expected_explained
+          ~check_if_total:false loc caselist in
       re {
-        exp_desc = Texp_try(body, exn_cases, eff_cases);
+        exp_desc = Texp_try(body, cases);
         exp_loc = loc; exp_extra = [];
         exp_type = body.exp_type;
         exp_attributes = sexp.pexp_attributes;
@@ -4736,7 +4714,7 @@ and type_function
           (* We don't make use of [case_data] here so we pass unit. *)
           [ { pattern = pat; has_guard = false; needs_refute = false }, () ]
           ~type_body:begin
-            fun () pat ~when_env:_ ~ext_env ~cont:_ ~ty_expected ~ty_infer:_
+            fun () pat ~when_env:_ ~ext_env ~ty_expected ~ty_infer:_
               ~contains_gadt:param_contains_gadt ->
               let _, params, body, newtypes, suffix_contains_gadt =
                 type_function ext_env rest body_constraint body
@@ -5652,22 +5630,21 @@ and type_statement ?explanation env sexp =
 *)
 and map_half_typed_cases
   : type k ret case_data.
-    ?additional_checks_for_split_cases:((_ * ret) list -> unit) -> ?conts:_
+    ?additional_checks_for_split_cases:((_ * ret) list -> unit)
     -> k pattern_category -> _ -> _ -> _ -> _
     -> (untyped_case * case_data) list
     -> type_body:(
         case_data
         -> k general_pattern (* the typed pattern *)
         -> when_env:_ (* environment with module/pattern variables *)
-        -> ext_env:_ (* when_env + continuation var*)
-        -> cont:_
+        -> ext_env:_ (* `when_env` + continuation variables *)
         -> ty_expected:_ (* type to check body in scope of *)
         -> ty_infer:_ (* type to infer for body *)
         -> contains_gadt:_ (* whether the pattern contains a GADT *)
         -> ret)
     -> check_if_total:bool (* if false, assume Partial right away *)
     -> ret list * partial
-  = fun ?additional_checks_for_split_cases ?conts
+  = fun ?additional_checks_for_split_cases
     category env ty_arg ty_res loc caselist ~type_body ~check_if_total ->
   (* ty_arg is _fully_ generalized *)
   let patterns = List.map (fun ((x : untyped_case), _) -> x.pattern) caselist in
@@ -5679,6 +5656,12 @@ and map_half_typed_cases
   let ty_arg =
     if (may_contain_gadts || erase_either) && not !Clflags.principal
     then correct_levels ty_arg else ty_arg
+  in
+  let env, eff_typ =
+    if List.exists contains_effects patterns then
+      let env, eff_typ = new_effect_type ~loc env ~body:ty_res in
+      env, Some eff_typ
+    else env, None
   in
   let rec is_var spat =
     match spat.ppat_desc with
@@ -5708,10 +5691,6 @@ and map_half_typed_cases
     if erase_either
     then Some false else None
   in
-  let map_conts f conts caselist = match conts with
-    | None -> List.map (fun c -> f c None) caselist
-    | Some conts -> List.map2 f caselist conts
-  in
   let half_typed_cases, ty_res, do_copy_types, ty_arg' =
    (* propagation of the argument *)
     with_local_level begin fun () ->
@@ -5719,8 +5698,8 @@ and map_half_typed_cases
       (*  Format.printf "@[%i %i@ %a@]@." lev (get_current_level())
           Printtyp.raw_type_expr ty_arg; *)
       let half_typed_cases =
-        map_conts
-        (fun ({ Parmatch.pattern; _ } as untyped_case, case_data) cont ->
+        List.map
+        (fun ({ Parmatch.pattern; _ } as untyped_case, case_data) ->
           let htc =
             with_local_level_if_principal begin fun () ->
               let ty_arg =
@@ -5729,8 +5708,8 @@ and map_half_typed_cases
                   (fun () -> instance ?partial:take_partial_instance ty_arg)
               in
               let (pat, ext_env, force, pvs, mvs) =
-                type_pattern ?cont category ~lev env pattern ty_arg
-                  allow_modules
+                type_pattern category ~lev env pattern
+                  (expected_pat_typ ?eff_typ ty_arg) allow_modules
               in
               pattern_force := force @ !pattern_force;
               { typed_pat = pat;
@@ -5753,7 +5732,7 @@ and map_half_typed_cases
           let pat = htc.typed_pat in
           {htc with typed_pat = { pat with pat_type = instance pat.pat_type }}
         )
-        conts caselist in
+        caselist in
       let patl =
         List.map (fun { typed_pat; _ } -> typed_pat) half_typed_cases in
       let does_contain_gadt =
@@ -5797,10 +5776,10 @@ and map_half_typed_cases
   (* type bodies *)
   let ty_res' = instance ty_res in
   let result = with_local_level_if_principal ~post:ignore begin fun () ->
-    map_conts
+    List.map
     (fun { typed_pat = pat; branch_env = ext_env;
-           pat_vars = pvs; module_vars = mvs;
-           case_data; contains_gadt; _ } cont
+            pat_vars = pvs; module_vars = mvs;
+            case_data; contains_gadt; _ }
         ->
         let ext_env =
           if contains_gadt then
@@ -5820,6 +5799,10 @@ and map_half_typed_cases
         in
         let when_env = add_pattern_vars ext_env pvs in
         let when_env = add_module_variables when_env mvs in
+        (* It is crucial that the continuation is not used in the `when'
+           expression as the extent of the continuation is yet to be determined.
+           We make the continuation inaccessible by using a `when_env'
+           environment which does not bind the continuation variable. *)
         let ext_env = add_pattern_vars when_env cont_vars in
         let ty_expected =
           if contains_gadt && not !Clflags.principal then
@@ -5827,9 +5810,9 @@ and map_half_typed_cases
                 type information from preceding branches *)
             correct_levels ty_res
           else ty_res in
-        type_body case_data pat ~when_env ~ext_env ~cont ~ty_expected
+        type_body case_data pat ~when_env ~ext_env ~ty_expected
           ~ty_infer:ty_res' ~contains_gadt)
-    conts half_typed_cases
+    half_typed_cases
   end in
   let do_init = may_contain_gadts || needs_exhaust_check in
   let ty_arg_check =
@@ -5848,7 +5831,7 @@ and map_half_typed_cases
      corresponding element in [result] before handing it off to the caller's
      custom checks.
   *)
-  let val_cases_with_result, exn_cases_with_result =
+  let val_cases_with_result, exn_cases_with_result, eff_cases_with_result =
     match category with
     | Value ->
         let val_cases =
@@ -5858,13 +5841,20 @@ and map_half_typed_cases
             half_typed_cases
             result
         in
-        (val_cases : (pattern Parmatch.parmatch_case * ret) list), []
-    | Computation ->
+        (val_cases : (pattern Parmatch.parmatch_case * ret) list), [], []
+    | Computation _ ->
         split_half_typed_cases env (List.combine half_typed_cases result)
+  in
+  let eff_cases_with_result =
+    let without_cont ((p:_ Parmatch.parmatch_case),r) =
+      { p with pattern = fst p.pattern },r
+    in
+    List.map without_cont eff_cases_with_result
   in
   let val_cases = List.map fst val_cases_with_result in
   let exn_cases = List.map fst exn_cases_with_result in
-  if val_cases = [] && exn_cases <> [] then
+  let eff_cases = List.map fst eff_cases_with_result in
+  if val_cases = [] && (exn_cases <> [] || eff_cases <> []) then
     raise (Error (loc, env, No_value_clauses));
   let partial =
     if check_if_total then
@@ -5878,7 +5868,8 @@ and map_half_typed_cases
     ) half_typed_cases;
     with_level_if delayed ~level:lev begin fun () ->
       check_unused ~lev env ty_arg_check val_cases ;
-      check_unused ~lev env Predef.type_exn exn_cases ;
+      check_unused ~lev env Predef.type_exn exn_cases;
+      Option.iter (fun (e,_) -> check_unused ~lev env e eff_cases) eff_typ;
     end;
   in
   if contains_polyvars then
@@ -5892,6 +5883,7 @@ and map_half_typed_cases
     | Some check ->
         check val_cases_with_result;
         check exn_cases_with_result;
+        check eff_cases_with_result;
   end;
   (result, partial), [ty_res']
   end
@@ -5900,11 +5892,11 @@ and map_half_typed_cases
 
 (* Typing of match cases *)
 and type_cases
-    : type k . k pattern_category -> _ -> _ -> _ -> ?conts:_ ->
-               check_if_total:bool -> _ -> Parsetree.case list ->
-               k case list * partial
+    : type k . k pattern_category ->
+           _ -> _ -> _ -> check_if_total:bool -> _ -> Parsetree.case list ->
+           k case list * partial
   = fun category env
-        ty_arg ty_res_explained ?conts ~check_if_total loc caselist ->
+        ty_arg ty_res_explained ~check_if_total loc caselist ->
   let { ty = ty_res; explanation } = ty_res_explained in
   let caselist =
     List.map (fun case -> Parmatch.untyped_case case, case) caselist
@@ -5913,22 +5905,14 @@ and type_cases
      is to typecheck the guards and the cases, and then to check for some
      warnings that can fire in the presence of guards.
   *)
-  map_half_typed_cases ?conts category env ty_arg ty_res loc caselist
-    ~check_if_total
+  map_half_typed_cases category env ty_arg ty_res loc caselist ~check_if_total
     ~type_body:begin
-      fun { pc_guard; pc_rhs } pat ~when_env ~ext_env ~cont ~ty_expected
-        ~ty_infer ~contains_gadt:_ ->
-        let cont = Option.map (fun (id,_) -> id) cont in
+      fun { pc_guard; pc_rhs } pat ~when_env ~ext_env ~ty_expected ~ty_infer
+          ~contains_gadt:_ ->
         let guard =
           match pc_guard with
           | None -> None
           | Some scond ->
-            (* It is crucial that the continuation is not used in the
-               `when' expression as the extent of the continuation is
-               yet to be determined. We make the continuation
-               inaccessible by typing the `when' expression using the
-               environment `ext_env' which does not bind the
-               continuation variable. *)
             Some
               (type_expect when_env scond
                 (mk_expected ~explanation:When_guard Predef.type_bool))
@@ -5938,7 +5922,6 @@ and type_cases
         in
         {
           c_lhs = pat;
-          c_cont = cont;
           c_guard = guard;
           c_rhs = {exp with exp_type = ty_infer}
         }
@@ -5975,33 +5958,6 @@ and type_function_cases_expect
     unify_exp_types loc env ty_fun (instance ty_expected);
     cases, partial, ty_fun
   end
-
-and type_effect_cases
-    : type k . k pattern_category -> _ -> _ -> _ -> Parsetree.case list -> _
-               -> k case list
-  = fun category env ty_res_explained loc caselist conts ->
-      let { ty = ty_res; explanation = _ } = ty_res_explained in
-      let _ = newvar () in
-      (* remember original level *)
-      with_local_level begin fun () ->
-        (* Create a locally type abstract type for effect type. *)
-        let new_env, ty_arg, ty_cont =
-          let decl = Ctype.new_local_type ~loc Definition in
-          let scope = create_scope () in
-          let name = Ctype.get_new_abstract_name env "%eff" in
-          let id = Ident.create_scoped ~scope name in
-          let new_env = Env.add_type ~check:false id decl env in
-          let ty_eff = newgenty (Tconstr (Path.Pident id,[],ref Mnil)) in
-          new_env,
-          Predef.type_eff ty_eff,
-          Predef.type_continuation ty_eff ty_res
-        in
-        let conts = List.map (type_continuation_pat env ty_cont) conts in
-        let cases, _ = type_cases category new_env ty_arg
-          ty_res_explained ~conts ~check_if_total:false loc caselist
-        in
-          cases
-        end
 
 (* Typing of let bindings *)
 
@@ -6959,16 +6915,16 @@ let report_error ~loc env = function
       Location.errorf ~loc
         "None of the patterns in this %a expression match values."
         Style.inline_code "match"
-  | Exception_pattern_disallowed ->
+  | Computation_pattern_disallowed {exn=true} ->
       Location.errorf ~loc
         "@[Exception patterns are not allowed in this position.@]"
-  | Mixed_value_and_exception_patterns_under_guard ->
+  | Computation_pattern_disallowed {exn=false} ->
       Location.errorf ~loc
-        "@[Mixing value and exception patterns under when-guards is not \
+        "@[Effect patterns are not allowed in this position.@]"
+  | Mixed_value_and_computation_patterns_under_guard ->
+      Location.errorf ~loc
+        "@[Mixing value and computation patterns under when-guards is not \
          supported.@]"
-  | Effect_pattern_below_toplevel ->
-      Location.errorf ~loc
-        "@[Effect patterns must be at the top level of a match case.@]"
   | Invalid_continuation_pattern ->
       Location.errorf ~loc
         "@[Invalid continuation pattern: only variables and _ are allowed .@]"

--- a/typing/typecore.mli
+++ b/typing/typecore.mli
@@ -218,9 +218,8 @@ type error =
   | Invalid_interval
   | Invalid_for_loop_index
   | No_value_clauses
-  | Exception_pattern_disallowed
-  | Mixed_value_and_exception_patterns_under_guard
-  | Effect_pattern_below_toplevel
+  | Computation_pattern_disallowed of {exn:bool}
+  | Mixed_value_and_computation_patterns_under_guard
   | Invalid_continuation_pattern
   | Inlined_record_escape
   | Inlined_record_expected

--- a/typing/untypeast.ml
+++ b/typing/untypeast.ml
@@ -352,6 +352,9 @@ let pattern : type k . _ -> k T.general_pattern -> _ = fun sub pat ->
     | Tpat_lazy p -> Ppat_lazy (sub.pat sub p)
 
     | Tpat_exception p -> Ppat_exception (sub.pat sub p)
+    | Tpat_effect (p, None) -> Ppat_effect (sub.pat sub p, Pat.mk Ppat_any)
+    | Tpat_effect (p, Some(_,name)) ->
+        Ppat_effect (sub.pat sub p, Pat.mk (Ppat_var name))
     | Tpat_value p -> (sub.pat sub (p :> pattern)).ppat_desc
     | Tpat_or (p1, p2, _) -> Ppat_or (sub.pat sub p1, sub.pat sub p2)
   in
@@ -450,32 +453,10 @@ let expression sub exp =
                 None -> list
               | Some exp -> (label, sub.expr sub exp) :: list
           ) list [])
-    | Texp_match (exp, cases, eff_cases, _) ->
-      let merged_cases = List.map (sub.case sub) cases
-        @ List.map
-          (fun c ->
-            let uc = sub.case sub c in
-            let pat = { uc.pc_lhs
-                        (* XXX KC: The 2nd argument of Ppat_effect is wrong *)
-                        with ppat_desc = Ppat_effect (uc.pc_lhs, uc.pc_lhs) }
-            in
-            { uc with pc_lhs = pat })
-          eff_cases
-      in
-      Pexp_match (sub.expr sub exp, merged_cases)
-    | Texp_try (exp, exn_cases, eff_cases) ->
-        let merged_cases = List.map (sub.case sub) exn_cases
-        @ List.map
-          (fun c ->
-            let uc = sub.case sub c in
-            let pat = { uc.pc_lhs
-                        (* XXX KC: The 2nd argument of Ppat_effect is wrong *)
-                        with ppat_desc = Ppat_effect (uc.pc_lhs, uc.pc_lhs) }
-            in
-            { uc with pc_lhs = pat })
-          eff_cases
-        in
-        Pexp_try (sub.expr sub exp, merged_cases)
+    | Texp_match (exp, cases, _) ->
+      Pexp_match (sub.expr sub exp, List.map (sub.case sub) cases)
+    | Texp_try (exp, cases) ->
+        Pexp_try (sub.expr sub exp, List.map (sub.case sub) cases)
     | Texp_tuple list ->
         Pexp_tuple (List.map (sub.expr sub) list)
     | Texp_construct (lid, _, args) ->


### PR DESCRIPTION
This PR is meant to be read at the top of the effect-syntax PR(#12309). In particular, only the last commit is new.

This commit aims at making the typechecker part of the effect syntax changes smaller.
This is done by merging back effect patterns into the computation pattern umbrella in the typechecker part of the compiler.  Splitting patterns by kind is then done when compiling to the lambda IR.

This change also has the advantage of making the error messages for non-toplevel computation patterns more uniform:

```ocaml
let f [effect _, _] = ()
```
> Error: Effect patterns are not allowed in this position.
```ocaml
let g [exception _ ] = ()
```
> Error: Exception patterns are not allowed in this position.

Incidentally, it makes the compiler support cases containing mixed effect, exception and value cases:

```ocaml
let catch f = match f () with _  | exception _ | effect _, _ -> ( )
type _ Effect.t += A: unit Effect.t
type _ Effect.t += B: unit Effect.t

let () = catch ignore; catch (fun () -> raise Not_found); catch (fun () -> Effect.perform A)
```

However, the feature is mostly useless, since effect types require type equations to be useful, and we discard type equations introduced under or-patterns. In other words, it is impossible to bind the continuation in the pattern above:
```
let test f = match f () with k | effect A, k -> ()
```
>```
> Error: The variable k on the left-hand side of this or-pattern has type 'a
>       but on the right-hand side it has type (%eff, 'b) continuation
>       The type constructor %eff would escape its scope
>```
