### PR TITLE
Remove obsolete `SHRINKED_GNUC` macro check

### DIFF
--- a/runtime/caml/config.h
+++ b/runtime/caml/config.h
@@ -177,8 +177,7 @@ typedef uint64_t uintnat;
 /* We use threaded code interpretation if the compiler provides labels
    as first-class values (GCC 2.x). */
 
-#if defined(__GNUC__) && __GNUC__ >= 2 && !defined(DEBUG) \
-    && !defined (SHRINKED_GNUC)
+#if defined(__GNUC__) && __GNUC__ >= 2 && !defined(DEBUG)
 #define THREADED_CODE
 #endif
 


### PR DESCRIPTION
It was introduced in c0d06c862a072df3e8047037e89ab78785714180 to support [Rhapsody](https://en.wikipedia.org/wiki/Rhapsody_(operating_system)), a development version of Mac OS X, and lasts remnants of that code were removed in 6676d9544caffa57de084bda110945573b29cfbb.