### PR TITLE
The Pattern-Matching Bug: propagate mutability of argument positions

### DIFF
--- a/Changes
+++ b/Changes
@@ -42,8 +42,9 @@ _______________
   unsupported native backends (POWER, riscv64 and s390x)
   (Miod Vallat, review by Nicolás Ojeda Bär)
 
-- #7241, #12555: fix a soundness bug in the pattern-matching compiler
-  when side-effects mutate the scrutinee during matching.
+- #7241, #12555, #13076, #13138: fix a soundness bug in the
+  pattern-matching compiler when side-effects mutate the scrutinee
+  during matching.
   Note that #7241 is not fully fixed yet, see the issue for the
   current status.
   (Gabriel Scherer, review by Nick Roberts)


### PR DESCRIPTION
This is the next PR in the stack to fix #7241. To fix the bug, we need to pessimize the totality information coming from the type-checker when we switch on arguments/positions that may have been mutated. As suggested by the testcase [match-side-effects/partiality.ml:deep](https://github.com/ocaml/ocaml/blob/63ec086cef237c23aa0120eadc80dfaf2ab7f89c/testsuite/tests/match-side-effects/partiality.ml#L206-L242), positions affected are not just those immediately below a mutable field, but also those that are *transitively* mutable -- there is a mutable field somewhere between the root of the value and the current position.

The present PR does not change the compilation behavior, it just adds a `mut` field to argument records to track whether the argument is in transitively-mutable position. (Currently this information is not tracked at all, unlike the information "immediately mutable" that can be reconstructed from the binding kind of the argument expression.)

(cc @ncik-roberts, @Octachron, @lthls )