### PR TITLE
AFL stability fix: avoid inlining of lazy forcing

### DIFF
--- a/lambda/matching.ml
+++ b/lambda/matching.ml
@@ -2097,7 +2097,7 @@ let inline_lazy_force arg loc =
         ap_loc = loc;
         ap_func = Lazy.force code_force_lazy;
         ap_args = [ Lconst (Const_base (Const_int 0)); arg ];
-        ap_inlined = Default_inline;
+        ap_inlined = Never_inline;
         ap_specialised = Default_specialise
       }
   else if !Clflags.native_code then


### PR DESCRIPTION
Extend the fix originally made in https://github.com/ocaml/ocaml/pull/1754 to be more airtight.

That PR has more context on why it's important for the forcing of lazy values to not be inlined when AFL instrumentation is enabled.

The present PR makes it obviously true that this comment (from just above the change) holds:

```ocaml
    (* Disable inlining optimisation if AFL instrumentation active,
       so that the GC forwarding optimisation is not visible in the
       instrumentation output.
       (see https://github.com/stedolan/crowbar/issues/14) *)
```