### PR TITLE
Avoid synchronising by sleep in a systhreads test

### DIFF
--- a/testsuite/tests/lib-threads/sockets.ml
+++ b/testsuite/tests/lib-threads/sockets.ml
@@ -16,7 +16,6 @@ open Printf
 let serve_connection s =
   let buf = Bytes.make 1024 '>' in
   let n = Unix.read s buf 2 (Bytes.length buf - 2) in
-  Thread.delay 1.0;
   ignore (Unix.write s buf 0 (n + 2));
   Unix.close s
 
@@ -26,14 +25,27 @@ let server sock =
     ignore(Thread.create serve_connection s)
   done
 
-let client (addr, msg) =
+let client1_done = Event.new_channel ()
+
+let wait_for_turn id =
+  if id = 2 then
+    Event.receive client1_done |> Event.sync |> ignore
+
+let signal_turn id =
+  if id = 1 then
+    Event.send client1_done 2 |> Event.sync
+
+let client (id, addr) =
+  let msg = "Client #" ^ Int.to_string id ^ "\n" in
   let sock =
     Unix.socket (Unix.domain_of_sockaddr addr) Unix.SOCK_STREAM 0 in
   Unix.connect sock addr;
   let buf = Bytes.make 1024 ' ' in
-  ignore(Unix.write_substring sock msg 0 (String.length msg));
+  ignore (Unix.write_substring sock msg 0 (String.length msg));
   let n = Unix.read sock buf 0 (Bytes.length buf) in
-  print_bytes (Bytes.sub buf 0 n); flush stdout
+  wait_for_turn id;
+  print_bytes (Bytes.sub buf 0 n); flush stdout;
+  signal_turn id
 
 let _ =
   let addr = Unix.ADDR_INET(Unix.inet_addr_loopback, 0) in
@@ -44,6 +56,6 @@ let _ =
   let addr = Unix.getsockname sock in
   Unix.listen sock 5;
   ignore (Thread.create server sock);
-  ignore (Thread.create client (addr, "Client #1\n"));
-  Thread.delay 0.5;
-  client (addr, "Client #2\n")
+  let c = Thread.create client (2, addr) in
+  client (1, addr);
+  Thread.join c


### PR DESCRIPTION
The `lib-threads/sockets.ml` test exercises systhreads and socket communication, by creating a server thread, two client threads, and a thread for each connection. The reproducibility of the output is ensured by inserting a half-second delay before starting the second client.

As it happens, half a second doesn’t seem to suffice when the program is monitored by ThreadSanitizer—at least not on some CI workers: this test has been failing intermittently on the TSan CI for a long while, generating noise.

@fabbing and I propose to remove the sleep and synchronise using a shared counter instead. It’s more robust and has the secondary benefit of making the test faster.