### PR TITLE
Dynarray.{equal, compare}

### DIFF
--- a/Changes
+++ b/Changes
@@ -82,6 +82,11 @@ _______________
   (Nick Barnes, review by Gabriel Scherer, Guillaume Munch-Maccagnoni, and
   Vincent Laviron)
 
+- #13144: Dynarray.{equal, compare}
+  (Gabriel Scherer,
+   review by Jeremy Yallop, Daniel Bünzli and Olivier Nicole,
+   request by Olivier Nicole)
+
 ### Other libraries:
 
 ### Tools:

--- a/stdlib/dynarray.ml
+++ b/stdlib/dynarray.ml
@@ -891,6 +891,50 @@ let filter_map f a =
   ) a;
   b
 
+let equal eq a1 a2 =
+  let Pack {arr = arr1; length = length; dummy = dum1} = a1 in
+  let Pack {arr = arr2; length = len2; dummy = dum2} = a2 in
+  if length <> len2 then false
+  else begin
+    check_valid_length length arr1;
+    check_valid_length length arr2;
+    let rec loop i =
+      if i = length then true
+      else
+        eq
+          (unsafe_get arr1 ~dummy:dum1 ~i ~length)
+          (unsafe_get arr2 ~dummy:dum2 ~i ~length)
+        && loop (i + 1)
+    in
+    let r = loop 0 in
+    check_same_length "equal" a1 ~length;
+    check_same_length "equal" a2 ~length;
+    r
+  end
+
+let compare cmp a1 a2 =
+  let Pack {arr = arr1; length = length; dummy = dum1} = a1 in
+  let Pack {arr = arr2; length = len2; dummy = dum2} = a2 in
+  if length <> len2 then length - len2
+  else begin
+    check_valid_length length arr1;
+    check_valid_length length arr2;
+    let rec loop i =
+      if i = length then 0
+      else
+        let c =
+          cmp
+            (unsafe_get arr1 ~dummy:dum1 ~i ~length)
+            (unsafe_get arr2 ~dummy:dum2 ~i ~length)
+        in
+        if c <> 0 then c
+        else loop (i + 1)
+    in
+    let r = loop 0 in
+    check_same_length "compare" a1 ~length;
+    check_same_length "compare" a2 ~length;
+    r
+  end
 
 (** {1:conversions Conversions to other data structures} *)
 

--- a/stdlib/dynarray.mli
+++ b/stdlib/dynarray.mli
@@ -308,6 +308,32 @@ val filter_map : ('a -> 'b option) -> 'a t -> 'b t
     ignoring strings that cannot be converted to integers.
 *)
 
+(** {1:comparison Comparison functions}
+
+    Comparison functions iterate over their arguments; it is
+    a programming error to change their length during the iteration,
+    see the {{!section:iteration} Iteration} section above.
+ *)
+
+val equal : ('a -> 'a -> bool) -> 'a t -> 'a t -> bool
+(** [equal eq a b] holds when [a] and [b] have the same length,
+    and for all indices [i] we have [eq (get a i) (get b i)].
+
+    @since 5.3
+*)
+
+val compare : ('a -> 'a -> int) -> 'a t -> 'a t -> int
+(** Provided the function [cmp] defines a preorder on elements,
+    [compare cmp a b] compares first [a] and [b] by their length,
+    and then, if equal, by their elements according to
+    the lexicographic preorder.
+
+    For more details on comparison functions, see {!Array.sort}.
+
+    @since 5.3
+*)
+
+
 (** {1:conversions Conversions to other data structures}
 
     Note: the [of_*] functions raise [Invalid_argument] if the

--- a/testsuite/tests/lib-dynarray/test.ml
+++ b/testsuite/tests/lib-dynarray/test.ml
@@ -266,6 +266,38 @@ let () =
   ))
 
 
+(** {1:comparison Comparison functions} *)
+
+let () =
+  let a = A.of_list [1; 2; 3] in
+  A.ensure_capacity a 1000;
+  let b = A.of_list [1; 2; 3] in
+  assert (A.equal (=) a a);
+  assert (A.compare Int.compare a a = 0);
+  assert (A.equal (=) a b);
+  assert (A.compare Int.compare a b = 0);
+  ()
+
+let () =
+  let same eq l1 l2 = A.equal eq (A.of_list l1) (A.of_list l2) in
+  assert (not (same (=) [1; 2; 3] [1; 3; 2]));
+  assert (not (same (=) [1; 2; 3] [1; 2]));
+  assert (not (same (=) [1] [1; 2]));
+  assert (not (same (=) [] [1; 2]));
+  assert (same (fun _ _ -> true) [1; 2] [3; 4]);
+  assert (not (same (fun _ _ -> true) [1; 2] [3]));
+  ()
+
+let () =
+  let compare cmp l1 l2 = A.compare cmp (A.of_list l1) (A.of_list l2) in
+  assert (compare Int.compare [] [] = 0);
+  assert (compare Int.compare [1; 2] [1; 2] = 0);
+  assert (compare Int.compare [min_int] [max_int] < 0);
+  assert (compare Int.compare [10] [0; 1] < 0);
+  assert (compare Int.compare [10] [0] > 0);
+  assert (compare (Fun.flip Int.compare) [10] [0] < 0);
+  ()
+
 (** {1:conversions Conversions to other data structures} *)
 
 (** {of,to}_{list,array,seq{,_rev}{,_rentrant}} *)


### PR DESCRIPTION
This was suggested by @OlivierNicole in https://github.com/ocaml/ocaml/pull/12885#issuecomment-2067761369 .

Having comparison functions for `Dynarray` is useful because they do not have a canonical representation: two dynarrays may have the same elements, but yet have `(=)` return false or `Stdlib.compare` return non-0 due to having a different capacity.

I reused and adapted the docstring of List.equal and Seq.compare.

## Comparing of different-length arrays

For `compare` there is a choice between:
1. what wikipedia calls the lexicographic order: `[10] > [1; 2]` because `10 > 1`
2. what wikipedia calls the "shortlex" order: `[10] < [1; 2]` because the first list is shorter (before comparing the elements)

Using `Stdlib.compare (Dynarray.to_list a) (Dynarray.to_list b)` would result in lexicographic order (1), and `Stdlib.compare (Dynarray.to_array a) (Dynarray.to_array b)` would result in shortlex order (2). (In other words, "doing the same as other data structures" does not force us to choose one or the other.)

I went for the shortlex order which is slightly faster.