### PR TITLE
Improve robustness of statmemprof testsuite (a bit more)

### DIFF
--- a/testsuite/tests/statmemprof/moved_while_blocking.ml
+++ b/testsuite/tests/statmemprof/moved_while_blocking.ml
@@ -84,8 +84,7 @@ let global = ref static_ref
 let thread_fn () =
   await t2_begin;
   say "T2: alloc\n";
-  let r = ref 0 in
-  global := r;
+  global := ref 0;
   say "T2: minor GC\n";
   Gc.minor ();
   global := static_ref;


### PR DESCRIPTION
After #13107, we noticed one more statmemprof testsuite issue. This is an old issue, which has been there since the original implementation but fails very very rarely.

The issue is a race condition in `moved_while_blocking.ml`, which can spuriously fail if a thread switch occurs right at the end of `thread_fn` before the reference `r` is collectable. This can only occur on bytecode, since bytecode keeps named values alive until the end of their scope rather just to their last use.

The fix is to inline the definition of `r` (which is used only once), making both bytecode and native behave the same.