### PR TITLE
flambda: Improve transitive closure in invariant_params_in_recursion

### DIFF
--- a/Changes
+++ b/Changes
@@ -236,6 +236,11 @@ _______________
 - #13103: FreeBSD/amd64: properly annotate .o files with non-executable stack
   notes (Konstantin Belousov, review by Nicolás Ojeda Bär)
 
+- #13150: improve a transitive-closure computation algorithm in the flambda
+  middle-end to avoid a compilation time blowup on Menhir-generated code
+  (Florian Weimer, review by Gabriel Scherer and Pierre Chambart,
+   report by Richard Jones)
+
 OCaml 5.2.0
 ------------
 

--- a/middle_end/flambda/invariant_params.ml
+++ b/middle_end/flambda/invariant_params.ml
@@ -86,12 +86,11 @@ let transitive_closure state =
       else
         loop cs frontier result
   in
-    Variable.Pair.Map.filter_map
+    Variable.Pair.Map.mapi
       (fun _ set ->
-         Some (match set with
-	       | Top -> Top
-	       | Implication set ->
-	         loop [] (Variable.Pair.Set.elements set) set))
+         match set with
+	 | Top -> Top
+	 | Implication set -> loop [] (Variable.Pair.Set.elements set) set)
       state
 
 (* CR-soon pchambart: to move to Flambda_utils and document

--- a/middle_end/flambda/invariant_params.ml
+++ b/middle_end/flambda/invariant_params.ml
@@ -73,8 +73,8 @@ let transitive_closure state =
     | ([], []) -> Implication result
     | ([], frontier::fs) ->
       (* Obtain fresh candidate for the frontier argument. *)
-      (match (try Variable.Pair.Map.find frontier state with
-              | Not_found -> Implication Variable.Pair.Set.empty) with
+      (match Variable.Pair.Map.find frontier state with
+       | exception Not_found -> loop [] fs result
        | Top -> Top
        | Implication candidate ->
          loop (Variable.Pair.Set.elements candidate) fs result)
@@ -86,8 +86,8 @@ let transitive_closure state =
       else
         loop cs frontier result
   in
-    Variable.Pair.Map.mapi
-      (fun _ set ->
+    Variable.Pair.Map.map
+      (fun set ->
          match set with
 	 | Top -> Top
 	 | Implication set -> loop [] (Variable.Pair.Set.elements set) set)

--- a/middle_end/flambda/invariant_params.ml
+++ b/middle_end/flambda/invariant_params.ml
@@ -65,47 +65,34 @@ let implies relation from to_ =
       relation
 
 let transitive_closure state =
-  let union s1 s2 =
-    match s1, s2 with
-    | Top, _ | _, Top -> Top
-    | Implication s1, Implication s2 ->
-      Implication (Variable.Pair.Set.union s1 s2)
+  (* Depth-first search for all implications for one argument.
+     Arguments are moved from candidate to frontier, assuming
+     they are newly added to the result. *)
+  let rec loop candidate frontier result =
+    match (candidate, frontier) with
+    | ([], []) -> Implication result
+    | ([], frontier::fs) ->
+      (* Obtain fresh candidate for the frontier argument. *)
+      (match (try Variable.Pair.Map.find frontier state with
+              | Not_found -> Implication Variable.Pair.Set.empty) with
+       | Top -> Top
+       | Implication candidate ->
+         loop (Variable.Pair.Set.elements candidate) fs result)
+    | (candidate::cs, frontier) ->
+      let result' = Variable.Pair.Set.add candidate result in
+      if result' != result then
+        (* Result change means candidate becomes part of frontier. *)
+        loop cs (candidate :: frontier) result'
+      else
+        loop cs frontier result
   in
-  let equal s1 s2 =
-    match s1, s2 with
-    | Top, Implication _ | Implication _, Top -> false
-    | Top, Top -> true
-    | Implication s1, Implication s2 -> Variable.Pair.Set.equal s1 s2
-  in
-  let update arg state =
-    let original_set =
-      try Variable.Pair.Map.find arg state with
-      | Not_found -> Implication Variable.Pair.Set.empty
-    in
-    match original_set with
-    | Top -> state
-    | Implication arguments ->
-        let set =
-          Variable.Pair.Set.fold
-            (fun orig acc->
-               let set =
-                 try Variable.Pair.Map.find orig state with
-                 | Not_found -> Implication Variable.Pair.Set.empty in
-               union set acc)
-            arguments original_set
-        in
-        Variable.Pair.Map.add arg set state
-  in
-  let once state =
-    Variable.Pair.Map.fold (fun arg _ state -> update arg state) state state
-  in
-  let rec fp state =
-    let state' = once state in
-    if Variable.Pair.Map.equal equal state state'
-    then state
-    else fp state'
-  in
-  fp state
+    Variable.Pair.Map.filter_map
+      (fun _ set ->
+         Some (match set with
+	       | Top -> Top
+	       | Implication set ->
+	         loop [] (Variable.Pair.Set.elements set) set))
+      state
 
 (* CR-soon pchambart: to move to Flambda_utils and document
    mshinwell: I think this calculation is basically the same as

--- a/middle_end/flambda/invariant_params.ml
+++ b/middle_end/flambda/invariant_params.ml
@@ -89,8 +89,8 @@ let transitive_closure state =
     Variable.Pair.Map.map
       (fun set ->
          match set with
-	 | Top -> Top
-	 | Implication set -> loop [] (Variable.Pair.Set.elements set) set)
+         | Top -> Top
+         | Implication set -> loop [] (Variable.Pair.Set.elements set) set)
       state
 
 (* CR-soon pchambart: to move to Flambda_utils and document


### PR DESCRIPTION
This change rewrites the transitive closure computation for `invariant_params_in_recursion`. I believe this is more or less a traditional implementation (of the depth-first search variant).

It fixes a performance issue where Coccinelle can barely be compiled by flambda:

* [[cocci] Very long compile times on parsing_cocci/parser_cocci_menhir.ml](https://lore.kernel.org/cocci/20240502085433.GA30267@redhat.com/#r)

The relation that triggers this is not even particularly large (12,732 arguments with 3,449 Top relations and 56,289 non-Top relations).