### PR TITLE
error messages: conflict explanations as a footnote

### DIFF
--- a/Changes
+++ b/Changes
@@ -134,6 +134,9 @@ _______________
 - #13099: Fix erroneous loading of cmis for some module type errors.
   (Nick Roberts, review by Florian Angeletti)
 
+- #13151, name conflicts explanation as a footnote
+  (Florian Angeletti, review by Gabriel Scherer)
+
 ### Internal/compiler-libs changes:
 
 - #11129, #11148: enforce that ppxs do not produce `parsetree`s with

--- a/parsing/location.mli
+++ b/parsing/location.mli
@@ -200,6 +200,7 @@ type report = {
   kind : report_kind;
   main : msg;
   sub : msg list;
+  footnote: unit -> (Format.formatter -> unit) option
 }
 
 type report_printer = {
@@ -321,12 +322,16 @@ val deprecated_script_alert: string -> unit
 type error = report
 (** An [error] is a [report] which [report_kind] must be [Report_error]. *)
 
-val error: ?loc:t -> ?sub:msg list -> string -> error
+type delayed_msg = unit -> (formatter->unit) option
 
-val errorf: ?loc:t -> ?sub:msg list ->
+val error: ?loc:t -> ?sub:msg list -> ?footnote:delayed_msg-> string -> error
+
+val errorf:
+  ?loc:t -> ?sub:msg list -> ?footnote:delayed_msg ->
   ('a, Format.formatter, unit, error) format4 -> 'a
 
-val error_of_printer: ?loc:t -> ?sub:msg list ->
+val error_of_printer:
+  ?loc:t -> ?sub:msg list -> ?footnote:delayed_msg ->
   (formatter -> 'a -> unit) -> 'a -> error
 
 val error_of_printer_file: (formatter -> 'a -> unit) -> 'a -> error
@@ -352,7 +357,7 @@ exception Already_displayed_error
 (** Raising [Already_displayed_error] signals an error which has already been
    printed. The exception will be caught, but nothing will be printed *)
 
-val raise_errorf: ?loc:t -> ?sub:msg list ->
+val raise_errorf: ?loc:t -> ?sub:msg list -> ?footnote:delayed_msg ->
   ('a, Format.formatter, unit, 'b) format4 -> 'a
 
 val report_exception: formatter -> exn -> unit

--- a/testsuite/tests/formatting/errors_batch.ml
+++ b/testsuite/tests/formatting/errors_batch.ml
@@ -38,6 +38,7 @@ let () =
       msg "@[<v>This second sub-message does not have \
            a location;@,ghost locations of submessages are \
            not printed.@]";
-    ]
+    ];
+    footnote=Fun.const None;
   } in
   print_report Format.std_formatter report

--- a/testsuite/tests/typing-misc/pr6416.ml
+++ b/testsuite/tests/typing-misc/pr6416.ml
@@ -88,14 +88,11 @@ Error: Signature mismatch:
          functor (X : s) -> ...
        is not included in
          functor (X : s/2) -> ...
-       Module types do not match:
-         s
-       does not include
-         s/2
-       Line 5, characters 6-19:
-         Definition of module type "s"
-       Line 2, characters 2-15:
-         Definition of module type "s/2"
+       Module types do not match: s does not include s/2
+Line 5, characters 6-19:
+  Definition of module type "s"
+Line 2, characters 2-15:
+  Definition of module type "s/2"
 |}]
 
 module L = struct
@@ -221,10 +218,10 @@ Error: Signature mismatch:
          class b : a/2
        The public method c cannot be hidden
        The first class type has no method m
-       Line 5, characters 4-74:
-         Definition of class type "a"
-       Line 2, characters 2-36:
-         Definition of class type "a/2"
+Line 5, characters 4-74:
+  Definition of class type "a"
+Line 2, characters 2-36:
+  Definition of class type "a/2"
 |}]
 
 module R = struct
@@ -252,10 +249,10 @@ Error: Signature mismatch:
        does not match
          class type b = a/2
        The first class type has no method m
-       Line 5, characters 4-29:
-         Definition of class type "a"
-       Line 2, characters 2-42:
-         Definition of class type "a/2"
+Line 5, characters 4-29:
+  Definition of class type "a"
+Line 2, characters 2-42:
+  Definition of class type "a/2"
 |}]
 
 module S = struct

--- a/testsuite/tests/typing-modules/functors.ml
+++ b/testsuite/tests/typing-modules/functors.ml
@@ -564,15 +564,12 @@ Error: This application of the functor "F" is ill-typed.
        do not match these parameters:
          functor (X : x) (B : b/2) (Y : y) -> ...
        1. Module $S1 matches the expected module type x
-       2. Modules do not match:
-            P.B : b
-          is not included in
-            b/2
-          Line 5, characters 2-15:
-            Definition of module type "b"
-          Line 2, characters 0-13:
-            Definition of module type "b/2"
+       2. Modules do not match: P.B : b is not included in b/2
        3. Modules do not match: $S3 : sig type w end is not included in y
+Line 5, characters 2-15:
+  Definition of module type "b"
+Line 2, characters 0-13:
+  Definition of module type "b/2"
 |}]
 
 module F(X:a) = struct type t end
@@ -589,10 +586,10 @@ Line 6, characters 13-19:
 6 |     type t = F(X).t
                  ^^^^^^
 Error: Modules do not match: a is not included in a/2
-     Line 3, characters 2-15:
-       Definition of module type "a"
-     Line 1, characters 0-13:
-       Definition of module type "a/2"
+Line 3, characters 2-15:
+  Definition of module type "a"
+Line 1, characters 0-13:
+  Definition of module type "a/2"
 |}]
 
 
@@ -625,14 +622,11 @@ Error: Signature mismatch:
        is not included in
          functor (X : a/2) (Y : a/2) -> ...
        1. Module types aa and a/2 match
-       2. Module types do not match:
-            a
-          does not include
-            a/2
-          Line 4, characters 2-15:
-            Definition of module type "a"
-          Line 1, characters 0-13:
-            Definition of module type "a/2"
+       2. Module types do not match: a does not include a/2
+Line 4, characters 2-15:
+  Definition of module type "a"
+Line 1, characters 0-13:
+  Definition of module type "a/2"
 |}]
 
 module X: functor ( X: sig end) -> sig end = functor(X: Set.OrderedType) -> struct end
@@ -1626,10 +1620,6 @@ Error: This application of the functor "F" is ill-typed.
           is not included in
             type t = Y of X.t
           The first is abstract, but the second is a variant.
-          File "_none_", line 1:
-            Definition of module "Y"
-          Line 6, characters 0-39:
-            Definition of module "Y/2"
        3. Modules do not match:
             Y : sig type t = Y.t = Y of int end
           is not included in
@@ -1641,6 +1631,10 @@ Error: This application of the functor "F" is ill-typed.
           Constructors have different names, "Y" and "Z".
        4. The following extra argument is provided
               Z : sig type t = Z.t = Z of int end
+File "_none_", line 1:
+  Definition of module "Y"
+Line 6, characters 0-39:
+  Definition of module "Y/2"
 |}]
 
 (** Final state in the presence of extensions

--- a/typing/env.ml
+++ b/typing/env.ml
@@ -3709,7 +3709,7 @@ let () =
           let error_of_printer =
             if loc = Location.none
             then Location.error_of_printer_file
-            else Location.error_of_printer ~loc ?sub:None
+            else Location.error_of_printer ~loc ?sub:None ?footnote:None
           in
           Some (error_of_printer report_error err)
       | _ ->

--- a/typing/printtyp.mli
+++ b/typing/printtyp.mli
@@ -86,8 +86,10 @@ module Conflicts: sig
   val print_located_explanations:
     Format.formatter -> explanation list -> unit
 
-  val print_explanations: Format.formatter -> unit
-  (** Print all conflict explanations collected up to this point *)
+  val err_msg: unit -> (Format.formatter -> unit) option
+  (** [err_msg ()] return an error message if there are pending conflict
+      explanations at this point. It is often important to check for conflicts
+      after all printing is done, thus the delayed nature of [err_msg]*)
 
   val reset: unit -> unit
 end

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -1128,8 +1128,10 @@ end) = struct
     if Warnings.is_active (Ambiguous_name ([],[],false,"")) then begin
       Printtyp.Conflicts.reset ();
       let paths = ambiguous_types env lbl rest in
-      let expansion =
-        Format.asprintf "%t" Printtyp.Conflicts.print_explanations in
+      let expansion = match Printtyp.Conflicts.err_msg () with
+        | None -> ""
+        | Some msg -> Format.asprintf "%t" msg
+      in
       if paths <> [] then
         warn lid.loc
           (Warnings.Ambiguous_name ([Longident.last lid.txt],

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -3295,7 +3295,8 @@ let report_error ~loc _env = function
         (Style.as_inline_code modtype) mty
   | Not_included errs ->
       let main = Includemod_errorprinter.err_msgs errs in
-      Location.errorf ~loc "@[<v>Signature mismatch:@ %t@]" main
+      let footnote = Printtyp.Conflicts.err_msg in
+      Location.errorf ~loc ~footnote "@[<v>Signature mismatch:@ %t@]" main
   | Cannot_eliminate_dependency mty ->
       Location.errorf ~loc
         "@[This functor has type@ %a@ \
@@ -3315,7 +3316,8 @@ let report_error ~loc _env = function
         (Style.as_inline_code longident) lid
   | With_mismatch(lid, explanation) ->
       let main = Includemod_errorprinter.err_msgs explanation in
-      Location.errorf ~loc
+      let footnote = Printtyp.Conflicts.err_msg in
+      Location.errorf ~loc ~footnote
         "@[<v>\
            @[In this %a constraint, the new definition of %a@ \
              does not match its original definition@ \
@@ -3325,7 +3327,8 @@ let report_error ~loc _env = function
         (Style.as_inline_code longident) lid main
   | With_makes_applicative_functor_ill_typed(lid, path, explanation) ->
       let main = Includemod_errorprinter.err_msgs explanation in
-      Location.errorf ~loc
+      let footnote = Printtyp.Conflicts.err_msg in
+      Location.errorf ~loc ~footnote
         "@[<v>\
            @[This %a constraint on %a makes the applicative functor @ \
              type %a ill-typed in the constrained signature:@]@ \

--- a/utils/warnings.ml
+++ b/utils/warnings.ml
@@ -1096,7 +1096,7 @@ let message = function
   | Erroneous_printed_signature s ->
       "The printed interface differs from the inferred interface.\n\
        The inferred interface contained items which could not be printed\n\
-       properly due to name collisions between identifiers."
+       properly due to name collisions between identifiers.\n"
      ^ s
      ^ "\nBeware that this warning is purely informational and will not catch\n\
         all instances of erroneous printed interface."


### PR DESCRIPTION
This PR proposes to make the name conflicts part of error messages
```
Line 5, characters 4-74:
  Definition of class type "a"
Line 2, characters 2-36:
  Definition of class type "a/2"
```
an explicit footnote, by adding a footnote field in the error report type.

This has three advantages from my point of view:

- First, it makes it clearer than the name conflict explanation is semantically not part of the main error messages nor any of the error submessages. And when we switch to structured output, it will make it easier for external tools to isolate this part of the error message (and display it as a footnote?).

- Second, this makes it easier to handle the `name conflicts` global state. With this changes, we are by construction checking the existence of name conflicts once, when producing the final error report. This removes the temptation to print name conflict explanations at intermediary points (which is currently done for first class modules and functors).

- Third, the new behavior is easier to reproduce while removing global states from the error message printing machinery.
(I have upcoming PR that makes this point clearer, but I thought that this change stand on its own).