### PR TITLE
The Pattern-Matching Bug: fix totality information

### DIFF
--- a/Changes
+++ b/Changes
@@ -131,7 +131,7 @@ _______________
   unsupported native backends (POWER, riscv64 and s390x)
   (Miod Vallat, review by Nicolás Ojeda Bär)
 
-- #7241, #12555, #13076, #13138: fix a soundness bug in the
+- #7241, #12555, #13076, #13138, #13338: fix a soundness bug in the
   pattern-matching compiler when side-effects mutate the scrutinee
   during matching.
   Note that #7241 is not fully fixed yet, see the issue for the

--- a/Changes
+++ b/Changes
@@ -131,11 +131,9 @@ _______________
   unsupported native backends (POWER, riscv64 and s390x)
   (Miod Vallat, review by Nicolás Ojeda Bär)
 
-- #7241, #12555, #13076, #13138, #13338: fix a soundness bug in the
-  pattern-matching compiler when side-effects mutate the scrutinee
-  during matching.
-  Note that #7241 is not fully fixed yet, see the issue for the
-  current status.
+- #7241, #12555, #13076, #13138, #13338, #13152: fix a soundness bug
+  in the pattern-matching compiler when side-effects
+  mutate the scrutinee during matching.
   (Gabriel Scherer, review by Nick Roberts)
 
 - #13179: Fix evaluation of toplevel lets in classes containing

--- a/lambda/matching.ml
+++ b/lambda/matching.ml
@@ -3023,15 +3023,15 @@ let mk_failaction_pos partial seen ctx defs =
             in
             fails', jumps'
       | None ->
-          match partial.current with
+          match partial.global with
           | Total ->
-              (* In [Total] mode, if there are no exits left in the
-                 environment, we judge that the remaining failing patterns
-                 cannot arise. [mk_failaction_neg] has the same
-                 logic. *)
+              (* If the pattern-matching is globally [Total], all
+                 missing values are either ill-typed or they are
+                 handled by a matrix of the default environment. The
+                 remaining failing patterns cannot arise. *)
               [], Jumps.empty Total
           | Partial ->
-              (* in [Partial] mode, remaining failing patterns
+              (* in [Partial] mode, the remaining failing patterns
                  go to the final exit. *)
               let final_pats = List.map fst fail_pats_in_ctx in
               mk_fails final_pats (Default_environment.raise_final_exit defs),

--- a/testsuite/tests/match-side-effects/check_partial.ml
+++ b/testsuite/tests/match-side-effects/check_partial.ml
@@ -95,8 +95,8 @@ let guard_total : bool t ref -> int = function
      (function param/383 : int
        (if (opaque 0) 1
          (let (*match*/384 =o (field_mut 0 param/383))
-           (switch* *match*/384 case int 0: 0
-                                case int 1: 12)))))
+           (if (isint *match*/384) (if *match*/384 12 0)
+             (raise (makeblock 0 (global Match_failure/20!) [0: "" 1 38])))))))
   (apply (field_mut 1 (global Toploop!)) "guard_total" guard_total/306))
 val guard_total : bool t ref -> int = <fun>
 |}];;
@@ -106,16 +106,17 @@ let guard_needs_partial : bool t ref -> int = function
   | _ when Sys.opaque_identity false -> 1
   | { contents = False } -> 12
 (* This pattern-matching is partial: a Match_failure case is
-   necessary for soundness.
-
-   FAIL: the compiler is currently unsound here. *)
+   necessary for soundness. *)
 [%%expect {|
 (let
   (guard_needs_partial/385 =
      (function param/387 : int
        (let (*match*/388 =o (field_mut 0 param/387))
          (catch (if (isint *match*/388) (if *match*/388 (exit 9) 0) (exit 9))
-          with (9) (if (opaque 0) 1 12)))))
+          with (9)
+           (if (opaque 0) 1
+             (if (isint *match*/388) 12
+               (raise (makeblock 0 (global Match_failure/20!) [0: "" 1 46]))))))))
   (apply (field_mut 1 (global Toploop!)) "guard_needs_partial"
     guard_needs_partial/385))
 val guard_needs_partial : bool t ref -> int = <fun>

--- a/testsuite/tests/match-side-effects/partiality.ml
+++ b/testsuite/tests/match-side-effects/partiality.ml
@@ -388,7 +388,7 @@ let f x y =
  | `X1, `Y3
  | `X2, `Y2
  | `X3, _  -> 3
-(* FAIL: a Match_failure case is generated *)
+(* PASS: no Match_failure generated *)
 [%%expect {|
 (let
   (f/503 =
@@ -396,22 +396,16 @@ let f x y =
        (catch
          (catch
            (catch
-             (catch
-               (if (isint y/505) (if (!= y/505 19896) (exit 45) 0) (exit 45))
-              with (45)
-               (if (!= x/504 19674)
-                 (if (>= x/504 19675) (exit 44)
-                   (if (isint y/505)
-                     (if (!= y/505 19897)
-                       (if (!= y/505 19898) (exit 41) (exit 42)) 1)
-                     (exit 41)))
-                 (if (isint y/505) (if (!= y/505 19897) (exit 44) (exit 42))
-                   (exit 44))))
-            with (44)
-             (if (isint y/505) (if (!= y/505 19898) (exit 42) 2) (exit 42)))
-          with (42) 3)
-        with (41)
-         (raise (makeblock 0 (global Match_failure/20!) [0: "" 2 1])))))
+             (if (isint y/505) (if (!= y/505 19896) (exit 45) 0) (exit 45))
+            with (45)
+             (if (!= x/504 19674)
+               (if (>= x/504 19675) (exit 44)
+                 (if (>= y/505 19898) (exit 42) 1))
+               (if (isint y/505) (if (!= y/505 19897) (exit 44) (exit 42))
+                 (exit 44))))
+          with (44)
+           (if (isint y/505) (if (!= y/505 19898) (exit 42) 2) (exit 42)))
+        with (42) 3)))
   (apply (field_mut 1 (global Toploop!)) "f" f/503))
 val f : [< `X1 | `X2 | `X3 ] -> [< `Y1 | `Y2 | `Y3 ] -> int = <fun>
 |}];;
@@ -423,45 +417,36 @@ let check_results r1 r2 =
   | (Error `A as r), Error _
   | Error _, (Error `A as r) -> r
   | (Error `B as r), Error `B -> r
-(* FAIL: a Match_failure case is generated *)
+(* PASS: no Match_failure case generated *)
 [%%expect {|
 (let
   (check_results/506 =
      (function r1/508 r2/509
-       (catch
-         (let (*match*/515 = (apply r1/508 r2/509))
+       (let (*match*/515 = (apply r1/508 r2/509))
+         (catch
            (catch
-             (catch
-               (let (r/514 =a (field_imm 0 *match*/515))
-                 (catch
-                   (switch* r/514
-                    case tag 0: (exit 50 r/514)
-                    case tag 1:
-                     (catch
-                       (if (>= (field_imm 0 r/514) 66)
-                         (let (*match*/523 =a (field_imm 1 *match*/515))
-                           (switch* *match*/523
-                            case tag 0: (exit 52)
-                            case tag 1:
-                             (let (*match*/524 =a (field_imm 0 *match*/523))
-                               (if (isint *match*/524)
-                                 (if (!= *match*/524 66) (exit 53) r/514)
-                                 (exit 53)))))
-                         (switch* (field_imm 1 *match*/515)
+             (let (r/514 =a (field_imm 0 *match*/515))
+               (catch
+                 (switch* r/514
+                  case tag 0: (exit 50 r/514)
+                  case tag 1:
+                   (catch
+                     (if (>= (field_imm 0 r/514) 66)
+                       (let (*match*/523 =a (field_imm 1 *match*/515))
+                         (switch* *match*/523
                           case tag 0: (exit 52)
-                          case tag 1: (exit 51 r/514)))
-                      with (53)
-                       (let
-                         (r/518 =a (field_imm 1 *match*/515)
-                          *match*/527 =a (field_imm 0 r/518))
-                         (if (isint *match*/527)
-                           (if (!= *match*/527 65) (exit 49) (exit 51 r/518))
-                           (exit 49)))))
-                  with (52) (exit 50 (field_imm 1 *match*/515))))
-              with (50 r/510) r/510)
-            with (51 r/512) r/512))
-        with (49)
-         (raise (makeblock 0 (global Match_failure/20!) [0: "" 2 2])))))
+                          case tag 1:
+                           (let (*match*/524 =a (field_imm 0 *match*/523))
+                             (if (isint *match*/524)
+                               (if (!= *match*/524 66) (exit 53) r/514)
+                               (exit 53)))))
+                       (switch* (field_imm 1 *match*/515)
+                        case tag 0: (exit 52)
+                        case tag 1: (exit 51 r/514)))
+                    with (53) (exit 51 (field_imm 1 *match*/515))))
+                with (52) (exit 50 (field_imm 1 *match*/515))))
+            with (50 r/510) r/510)
+          with (51 r/512) r/512))))
   (apply (field_mut 1 (global Toploop!)) "check_results" check_results/506))
 val check_results :
   ('a -> ('b, [< `A | `B ]) result * ('b, [< `A | `B ]) result) ->

--- a/testsuite/tests/match-side-effects/partiality.ml
+++ b/testsuite/tests/match-side-effects/partiality.ml
@@ -375,3 +375,95 @@ type t = A of int | B of string | C of string | D of string
   (apply (field_mut 1 (global Toploop!)) "compare" compare/381))
 val compare : t -> t -> int = <fun>
 |}];;
+
+
+(* Different testcases involving or-patterns and polymorphic variants,
+   proposed by Nick Roberts. In both cases, we do *not* expect a Match_failure case. *)
+
+let f x y =
+ match x, y with
+ | _, `Y1 -> 0
+ | `X1, `Y2 -> 1
+ | (`X2 | `X3), `Y3 -> 2
+ | `X1, `Y3
+ | `X2, `Y2
+ | `X3, _  -> 3
+(* FAIL: a Match_failure case is generated *)
+[%%expect {|
+(let
+  (f/503 =
+     (function x/504[int] y/505[int] : int
+       (catch
+         (catch
+           (catch
+             (catch
+               (if (isint y/505) (if (!= y/505 19896) (exit 45) 0) (exit 45))
+              with (45)
+               (if (!= x/504 19674)
+                 (if (>= x/504 19675) (exit 44)
+                   (if (isint y/505)
+                     (if (!= y/505 19897)
+                       (if (!= y/505 19898) (exit 41) (exit 42)) 1)
+                     (exit 41)))
+                 (if (isint y/505) (if (!= y/505 19897) (exit 44) (exit 42))
+                   (exit 44))))
+            with (44)
+             (if (isint y/505) (if (!= y/505 19898) (exit 42) 2) (exit 42)))
+          with (42) 3)
+        with (41)
+         (raise (makeblock 0 (global Match_failure/20!) [0: "" 2 1])))))
+  (apply (field_mut 1 (global Toploop!)) "f" f/503))
+val f : [< `X1 | `X2 | `X3 ] -> [< `Y1 | `Y2 | `Y3 ] -> int = <fun>
+|}];;
+
+
+let check_results r1 r2 =
+  match r1 r2 with
+  | (Ok _ as r), _ | _, (Ok _ as r) -> r
+  | (Error `A as r), Error _
+  | Error _, (Error `A as r) -> r
+  | (Error `B as r), Error `B -> r
+(* FAIL: a Match_failure case is generated *)
+[%%expect {|
+(let
+  (check_results/506 =
+     (function r1/508 r2/509
+       (catch
+         (let (*match*/515 = (apply r1/508 r2/509))
+           (catch
+             (catch
+               (let (r/514 =a (field_imm 0 *match*/515))
+                 (catch
+                   (switch* r/514
+                    case tag 0: (exit 50 r/514)
+                    case tag 1:
+                     (catch
+                       (if (>= (field_imm 0 r/514) 66)
+                         (let (*match*/523 =a (field_imm 1 *match*/515))
+                           (switch* *match*/523
+                            case tag 0: (exit 52)
+                            case tag 1:
+                             (let (*match*/524 =a (field_imm 0 *match*/523))
+                               (if (isint *match*/524)
+                                 (if (!= *match*/524 66) (exit 53) r/514)
+                                 (exit 53)))))
+                         (switch* (field_imm 1 *match*/515)
+                          case tag 0: (exit 52)
+                          case tag 1: (exit 51 r/514)))
+                      with (53)
+                       (let
+                         (r/518 =a (field_imm 1 *match*/515)
+                          *match*/527 =a (field_imm 0 r/518))
+                         (if (isint *match*/527)
+                           (if (!= *match*/527 65) (exit 49) (exit 51 r/518))
+                           (exit 49)))))
+                  with (52) (exit 50 (field_imm 1 *match*/515))))
+              with (50 r/510) r/510)
+            with (51 r/512) r/512))
+        with (49)
+         (raise (makeblock 0 (global Match_failure/20!) [0: "" 2 2])))))
+  (apply (field_mut 1 (global Toploop!)) "check_results" check_results/506))
+val check_results :
+  ('a -> ('b, [< `A | `B ]) result * ('b, [< `A | `B ]) result) ->
+  'a -> ('b, [> `A | `B ]) result = <fun>
+|}];;

--- a/testsuite/tests/match-side-effects/partiality.ml
+++ b/testsuite/tests/match-side-effects/partiality.ml
@@ -258,7 +258,7 @@ let test : type a . a t * a t -> unit = function
   | Bool, Bool -> ()
   | _, Char -> ()
 ;;
-(* FAIL: currently a Match_failure clause is generated. *)
+(* PASS: no Match_failure clause generated. *)
 [%%expect {|
 0
 type _ t = Bool : bool t | Int : int t | Char : char t
@@ -266,22 +266,9 @@ type _ t = Bool : bool t | Int : int t | Char : char t
   (test/358 =
      (function param/360 : int
        (catch
-         (catch
-           (switch* (field_imm 0 param/360)
-            case int 0:
-             (switch* (field_imm 1 param/360)
-              case int 0: 0
-              case int 1: (exit 23)
-              case int 2: (exit 24))
-            case int 1:
-             (switch* (field_imm 1 param/360)
-              case int 0: (exit 23)
-              case int 1: 0
-              case int 2: (exit 24))
-            case int 2: (exit 24))
-          with (24) 0)
-        with (23)
-         (raise (makeblock 0 (global Match_failure/20!) [0: "" 2 40])))))
+         (if (>= (field_imm 0 param/360) 2) (exit 24)
+           (if (>= (field_imm 1 param/360) 2) (exit 24) 0))
+        with (24) 0)))
   (apply (field_mut 1 (global Toploop!)) "test" test/358))
 val test : 'a t * 'a t -> unit = <fun>
 |}];;
@@ -297,7 +284,7 @@ let f : bool * t -> int = function
   | false, A -> 4
   | _, B -> 5
   | _, C _ -> .
-(* FAIL: a Match_failure clause is generated. *)
+(* PASS: no Match_failure clause generated. *)
 [%%expect {|
 0
 type nothing = |
@@ -307,17 +294,14 @@ type t = A | B | C of nothing
   (f/370 =
      (function param/371 : int
        (catch
-         (catch
-           (if (field_imm 0 param/371)
-             (let (*match*/373 =a (field_imm 1 param/371))
-               (if (isint *match*/373) (if *match*/373 (exit 26) 3)
-                 (exit 25)))
-             (let (*match*/374 =a (field_imm 1 param/371))
-               (if (isint *match*/374) (if *match*/374 (exit 26) 4)
-                 (exit 25))))
-          with (26) 5)
-        with (25)
-         (raise (makeblock 0 (global Match_failure/20!) [0: "" 3 26])))))
+         (if (field_imm 0 param/371)
+           (switch* (field_imm 1 param/371)
+            case int 0: 3
+            case int 1: (exit 27))
+           (switch* (field_imm 1 param/371)
+            case int 0: 4
+            case int 1: (exit 27)))
+        with (27) 5)))
   (apply (field_mut 1 (global Toploop!)) "f" f/370))
 val f : bool * t -> int = <fun>
 |}];;
@@ -345,7 +329,7 @@ let compare t1 t2 =
   | (C _ | D _), B _ -> 1
   | C _, D _ -> -1
   | D _, C _ -> 1
-(* FAIL: a Match_failure clause is generated. *)
+(* PASS: no Match_failure clause generated. *)
 [%%expect {|
 0
 type t = A of int | B of string | C of string | D of string
@@ -353,48 +337,41 @@ type t = A of int | B of string | C of string | D of string
   (compare/381 =
      (function t1/382 t2/383 : int
        (catch
-         (catch
-           (switch* t1/382
+         (switch* t1/382
+          case tag 0:
+           (switch t2/383
             case tag 0:
-             (switch t2/383
-              case tag 0:
-               (apply (field_imm 8 (global Stdlib__Int!))
-                 (field_imm 0 t1/382) (field_imm 0 t2/383))
-              default: -1)
-            case tag 1:
-             (catch
-               (switch* t2/383
-                case tag 0: (exit 30)
-                case tag 1:
-                 (apply (field_imm 9 (global Stdlib__String!))
-                   (field_imm 0 t1/382) (field_imm 0 t2/383))
-                case tag 2: (exit 35)
-                case tag 3: (exit 35))
-              with (35) -1)
-            case tag 2:
+             (apply (field_imm 8 (global Stdlib__Int!)) (field_imm 0 t1/382)
+               (field_imm 0 t2/383))
+            default: -1)
+          case tag 1:
+           (catch
              (switch* t2/383
-              case tag 0: (exit 30)
-              case tag 1: (exit 30)
-              case tag 2:
+              case tag 0: (exit 31)
+              case tag 1:
                (apply (field_imm 9 (global Stdlib__String!))
                  (field_imm 0 t1/382) (field_imm 0 t2/383))
-              case tag 3: -1)
-            case tag 3:
-             (switch* t2/383
-              case tag 0: (exit 30)
-              case tag 1: (exit 30)
-              case tag 2: 1
-              case tag 3:
-               (apply (field_imm 9 (global Stdlib__String!))
-                 (field_imm 0 t1/382) (field_imm 0 t2/383))))
-          with (30)
+              case tag 2: (exit 36)
+              case tag 3: (exit 36))
+            with (36) -1)
+          case tag 2:
            (switch* t2/383
-            case tag 0: 1
-            case tag 1: 1
-            case tag 2: (exit 27)
-            case tag 3: (exit 27)))
-        with (27)
-         (raise (makeblock 0 (global Match_failure/20!) [0: "" 8 2])))))
+            case tag 0: (exit 31)
+            case tag 1: (exit 31)
+            case tag 2:
+             (apply (field_imm 9 (global Stdlib__String!))
+               (field_imm 0 t1/382) (field_imm 0 t2/383))
+            case tag 3: -1)
+          case tag 3:
+           (switch* t2/383
+            case tag 0: (exit 31)
+            case tag 1: (exit 31)
+            case tag 2: 1
+            case tag 3:
+             (apply (field_imm 9 (global Stdlib__String!))
+               (field_imm 0 t1/382) (field_imm 0 t2/383))))
+        with (31) (switch* t2/383 case tag 0: 1
+                                  case tag 1: 1))))
   (apply (field_mut 1 (global Toploop!)) "compare" compare/381))
 val compare : t -> t -> int = <fun>
 |}];;

--- a/testsuite/tests/match-side-effects/pr13152.ml
+++ b/testsuite/tests/match-side-effects/pr13152.ml
@@ -1,0 +1,38 @@
+(* TEST
+ expect;
+*)
+
+(** This example from Nick Roberts demonstrates that the following combination is possible:
+    - the pattern-matching is Total according to the type-checker
+    - the last clause is not taken, we get Match_failure instead
+    - the scrutinee changes values, but it *never* matches the last clause.
+
+    In particular, "optimizing" the last clause into a wildcard when
+    the whole pattern-matching is total would give fairly dubious
+    behavior here. We suspect that the example could be tweaked with
+    judicious uses of GADTs to break type-soundness if optimized in
+    this way. *)
+
+type 'a myref = { mutable mut : 'a }
+type abc = A | B | C
+type t = {a: bool; b: abc myref }
+
+let example () =
+  let input = { a = true; b = { mut = A } } in
+  match input with
+  | {a = false; b = _} -> 1
+  | {a = _;     b = { mut = B }} -> 2
+  | {a = _;     b = _} when (input.b.mut <- B; false) -> 3
+  | {a = true;  b = { mut = A }} -> 4
+  | {a = _;     b = _} when (input.b.mut <- A; false) -> 5
+  | {a = true;  b = { mut = C }} -> 6
+;;
+
+let (_ : int) = example ()
+[%%expect {|
+type 'a myref = { mutable mut : 'a; }
+type abc = A | B | C
+type t = { a : bool; b : abc myref; }
+val example : unit -> int = <fun>
+Exception: Match_failure ("", 18, 2).
+|}];;

--- a/testsuite/tests/match-side-effects/test_contexts_code.ml
+++ b/testsuite/tests/match-side-effects/test_contexts_code.ml
@@ -87,7 +87,12 @@ let example_2 () =
                (if (seq (setfield_ptr 0 (field_imm 1 input/348) [1: 3]) 0)
                  [1: 3]
                  (let (*match*/357 =o (field_mut 0 (field_imm 1 input/348)))
-                   (makeblock 0 (int) (field_imm 0 *match*/357))))
+                   (switch* *match*/357
+                    case tag 0: (makeblock 0 (int) (field_imm 0 *match*/357))
+                    case tag 1:
+                     (raise
+                       (makeblock 0 (global Match_failure/20!)
+                         [0: "contexts_2.ml" 11 2])))))
               case tag 1: [1: 2]))
            [1: 1]))))
   (apply (field_mut 1 (global Toploop!)) "example_2" example_2/346))

--- a/testsuite/tests/match-side-effects/test_contexts_results.ml
+++ b/testsuite/tests/match-side-effects/test_contexts_results.ml
@@ -24,10 +24,9 @@ val example_2 : unit -> (bool, int) Result.t = <fun>
 |}];;
 
 let _ = example_2 ();;
-(* <unknown constructor> means that we got an 'unsound boolean',
-   which is neither 'true' nor 'false'. There was a bug here! *)
+(* same as [example_1 ()] *)
 [%%expect {|
-- : (bool, int) Result.t = Result.Ok <unknown constructor>
+Exception: Match_failure ("contexts_2.ml", 11, 2).
 |}]
 
 #use "contexts_3.ml";;


### PR DESCRIPTION
This PR is part of the #7241 fix; it is the first un-merged PR in the stack and is ripe for review.)

#13138 introduces information on the "transitive mutability" of argument positions in pattern-matching submatrices: an argument is transitively mutable if it is located transitively under a mutable field (from the root of the value).

The present PR uses this information to pessimize the compilation of switches generated by the pattern-matching compiler. All switches that are in a transitively mutable position are assumed to be Partial, even if the type-checker says that they are Total. (If you want, there is a longer explanation as a code comment in the PR itself.)

This change fixes all known remaining instances of the issue describe in #7241 (unsound interaction between pattern-matching and mutation), in particular all known-wrong behaviors in the testsuite.

(TODO: this is missing a Changes entry.)

### Degradation in generated code

The code generated by the pattern-matching compiler will be degraded if the following conditions are all met:

1. The position is transitively mutable.

2. At the position that we are generating a switch for, a language construction is used for which Total improves the quality of generated code. This can happen if either (A) only a strict subset of possible constructors is handled at in this submatrix, with the rest having been handled before, or (B) all valid constructors are handled by this submatrix, but this relies on checking that GADT equations are unsatisfiable, and the pattern-matching compiler does not know this. (On the other hand, the pattern-matching compiler *does* know about the set of constructors possible for a non-GADT sum type or for closed polymorphic variants.)

So the affected code looks like one of those:

```ocaml
(* case (A) above *)
let f : bool option ref -> ... = function
| { contents = None } -> ...
| { contents = Some true } -> ...
| _ when guard () -> ...
| { contents = Some false } (* here *) -> ...

type _ gadt = Int : int t | Bool : bool t

(* case (B) above *)
let g : int gadt ref -> ... = function
| { contents = Int } (* here *) -> ...
```

In the case (A) (example `f`), the behavior was previously unsound (in particular if we consider concurrent mutations). There are instances of (B) (example `g`) where the compiler was sound, and now generates slightly worse code -- the function `g` above is one such example -- by including a test with a Match_failure case.

In a follow-up PR I implement a simple heuristic that re-optimizes the compilation of some GADT matchings in mutable position, so that the function `g` above is not pessimized anymore.