### PR TITLE
The Pattern-Matching Bug: introduce a temporality heuristic to de-pessimize certain programs

### DIFF
--- a/Changes
+++ b/Changes
@@ -192,7 +192,7 @@ ___________
   unsupported native backends (POWER, riscv64 and s390x)
   (Miod Vallat, review by Nicolás Ojeda Bär)
 
-- #7241, #12555, #13076, #13138, #13338, #13152, #13153:
+- #7241, #12555, #13076, #13138, #13338, #13152, #13153, #13154:
   fix a soundness bug in the pattern-matching compiler
   when side-effects mutate the scrutinee during matching.
   (Gabriel Scherer, review by Nick Roberts)

--- a/testsuite/tests/match-side-effects/check_partial.ml
+++ b/testsuite/tests/match-side-effects/check_partial.ml
@@ -58,21 +58,19 @@ let lazy_needs_partial : _ * bool t ref -> int = function
          (let
            (*match*/299 =a (field_imm 0 param/298)
             *match*/301 =o (field_mut 0 (field_imm 1 param/298)))
-           (if (isint *match*/301)
-             (if *match*/301
-               (let
-                 (*match*/304 =
-                    (let (tag/303 =a (caml_obj_tag *match*/299))
-                      (if (== tag/303 250) (field_mut 0 *match*/299)
-                        (if (|| (== tag/303 246) (== tag/303 244))
-                          (apply (field_imm 1 (global CamlinternalLazy!))
-                            (opaque *match*/299))
-                          *match*/299)))
-                  *match*/306 =o (field_mut 0 (field_imm 1 param/298)))
-                 (if (isint *match*/306) (if *match*/306 12 (exit 3))
-                   (exit 3)))
-               0)
-             (exit 3)))
+           (switch* *match*/301
+            case int 0: 0
+            case int 1:
+             (let
+               (*match*/304 =
+                  (let (tag/303 =a (caml_obj_tag *match*/299))
+                    (if (== tag/303 250) (field_mut 0 *match*/299)
+                      (if (|| (== tag/303 246) (== tag/303 244))
+                        (apply (field_imm 1 (global CamlinternalLazy!))
+                          (opaque *match*/299))
+                        *match*/299)))
+                *match*/306 =o (field_mut 0 (field_imm 1 param/298)))
+               (if (isint *match*/306) (if *match*/306 12 (exit 3)) (exit 3)))))
         with (3)
          (raise (makeblock 0 (global Match_failure/20!) [0: "" 1 49])))))
   (apply (field_mut 1 (global Toploop!)) "lazy_needs_partial"

--- a/testsuite/tests/match-side-effects/partiality.ml
+++ b/testsuite/tests/match-side-effects/partiality.ml
@@ -199,35 +199,16 @@ let test = function
   | { contents = None } -> 0
   | { contents = Some (Int n) } -> n
 ;;
-(* Performance expectation: there should not be a Match_failure case.
-
-   Currently there *is* a Match_failure case, as the compiler is unable
-   to distinguish this situation from a situation where the matrix is split
-   and there are several accesses to the mutable field. *)
+(* Performance expectation: there should not be a Match_failure case. *)
 [%%expect {|
 0
 type _ t = Int : int -> int t | Bool : bool -> bool t
-Lines 3-5, characters 11-36:
-3 | ...........function
-4 |   | { contents = None } -> 0
-5 |   | { contents = Some (Int n) } -> n
-Warning 74 [degraded-to-partial-match]: This pattern-matching is compiled
-as partial, even if it appears to be total. It may generate a Match_failure
-exception. This typically occurs due to complex matches on mutable fields.
-(see manual section 13.5.5)
 (let
   (test/324 =
      (function param/326 : int
        (let (*match*/327 =o (field_mut 0 param/326))
-         (if *match*/327
-           (let (*match*/328 =a (field_imm 0 *match*/327))
-             (switch* *match*/328
-              case tag 0: (field_imm 0 *match*/328)
-              case tag 1:
-               (raise (makeblock 0 (global Match_failure/20!) [0: "" 3 11]))))
-           0))))
+         (if *match*/327 (field_imm 0 (field_imm 0 *match*/327)) 0))))
   (apply (field_mut 1 (global Toploop!)) "test" test/324))
-
 val test : int t option ref -> int = <fun>
 |}]
 


### PR DESCRIPTION
(This PR sits on top of #13152 and #13153; for now it is best reviewed by looking only at the latest commit.)

#13152 pessimizes Total matches in transitively mutable position. It gives two examples of code that now generates worse code:

```ocaml
(* case (A) *)
let f : bool option ref -> ... = function
| { contents = None } -> ...
| { contents = Some true } -> ...
| _ when guard () -> ...
| { contents = Some false } (* here *) -> ...

type _ gadt = Int : int t | Bool : bool t

(* case (B) *)
let g : int gadt ref -> ... = function
| { contents = Int } (* here *) -> ...
```

In the case A, the generated code first checks something about the argument root.0, then it checks a guard, then it goes back to the argument root.0. (We say that there are two "splits", resulting in three submatrices, that are checked in sequence.) When it goes back to root.0, its value could have changed in the meantime, so assuming that root.0.0 could only be `false` is wrong, and we really needed to make the code worse.

In the case B, the generated code reads the mutable field root.0, then immediately checks all possible cases on this constructor. In this case there cannot have been any mutation "in the meantime", this is the first time ever that we are checking this value. So generating a `Match_failure` case here was not necessary, and we are generating worse code than we could.

In general it is hard to know for sure "this is the first time we do something on this value". Tracking this precisely might be done with more context information, but it would be a tricky change with quickly diminishing returns. There is however a case where it is very easy to see that we are in this situation: where we have not generated any "split", any logic of the form "check this about the first value, and if that fails check that".

The present PR introduces a new piece of static context information used by the pattern-matching compiler to track this criterion. In code:

```ocaml
type temporality =
  | First
  | Following
(** The [temporality] information tracks information about the
    placement of the current submatrix within the
    whole pattern-matching.

    - [First]: this is the first submatrix on this position seen by values
      that flow into the submatrix.
    - [Following]: there was a split, some other submatrix was tried first
      and failed, and the control jumped to the current submatrix.

    This information is used in {!compute_arg_partial}.
*)
```

When deciding whether a switch on a given position should be pessimized, we now use a refined criterion: we are in a transitively mutable position *and* the current temporality is `Following`, we have already accessed this position before.

In particular, the example `g` above now produces good code again, as well as any reasonable usage of GADTs in mutable positions that I can think of.

It is, of course, possible to build examples where the heuristic is too coarse-grained and which will generate worse code than they could. For example:

```ocaml
type _ gadt = Int : int t | Bool : bool t

let test : int gadt ref -> unit = function
  | _ when Random.bool () -> ()
  | { contents = Int } -> ()
```
