### PR TITLE
follow-up on #13150: improve the closure-computation algorithm again

### DIFF
--- a/Changes
+++ b/Changes
@@ -241,8 +241,8 @@ _______________
 - #13103: FreeBSD/amd64: properly annotate .o files with non-executable stack
   notes (Konstantin Belousov, review by Nicolás Ojeda Bär)
 
-- #13150: improve a transitive-closure computation algorithm in the flambda
-  middle-end to avoid a compilation time blowup on Menhir-generated code
+- #13150, #????: improve a flambda transitive-closure computation algorithm
+  to avoid a compilation time blowup on Menhir-generated code
   (Florian Weimer, review by Gabriel Scherer and Pierre Chambart,
    report by Richard Jones)
 


### PR DESCRIPTION
The Flambda backend contains a transitive-closure computation algorithm that misbehaves on certain Menhir-generated programs. #13150 introduced an improved algorithm that fixes the case known to misbehave, but is asymptotically disappointing in other cases -- see the discussions there for the details. The cases where #13150 performs worse than it should have not been found in the wild yet, but were exhibited by the simple relations in the  benchmark script proposed by @fweimer-rh. I was nerd-sniped and decided to tweak the algorithm to perform better.

The PR improves the asymptotic behavior of the closure-computation by ensuring that closure-computation work is shared between nodes instead of being duplicated.

Consider for example the relation

  a -> b
  b -> c
  c -> a

The previous code would first compute

  a -> [b, c, a]

by traversing the graph, then

  b -> [c, a, b]

by traversing the graph again, then

  c -> [a, b, c]

again. The new code traverses the graph until it finds a cyclic node (starting from [a] this would be [a]), then compute

  a -> [a, b, c]

using the same algorithm as before, and then immediately computes the result for c and b from the result of a, without any additional traversal.

Performance results using the benchmark script of Florian Weimer ( https://gitlab.com/gasche-snippets/transitive-closure ).

Implementations:
- `old` is the code in 5.2
- `new` is #13150
- `again` is the algorithm in this commit

Tests:
- `isolated` is a diagonal relation (1 -> 1, 2 -> 2, 3 -> 3, ...)
- `cycle` is (1 -> 2, 2 -> 3, 3 -> 4, ..., n -> 1)
- `complete` is (1 -> [1, 2, ..., n], 2 -> [1, 2, ..., n], ...)

| isolated |   Mean [ms] |    Relative |
|:---------|------------:|------------:|
| `old`    | 162.1 ± 6.3 | 1.66 ± 0.08 |
| `new`    |  97.7 ± 2.9 |        1.00 |
| `again`  | 203.1 ± 4.1 | 2.08 ± 0.07 |

| cycle   |      Mean [s] |        Relative |
|:--------|--------------:|----------------:|
| `old`   | 1.952 ± 0.054 | 596.91 ± 154.38 |
| `new`   | 0.034 ± 0.002 |    10.29 ± 2.71 |
| `again` | 0.003 ± 0.001 |            1.00 |

| complete |    Mean [ms] |     Relative |
|:---------|-------------:|-------------:|
| `old`    |   59.3 ± 5.3 |  8.46 ± 1.38 |
| `new`    | 218.5 ± 15.8 | 31.15 ± 4.83 |
| `again`  |    7.0 ± 1.0 |         1.00 |

The new code has a larger constant factor than the #13150 algorithm for isolated graphs, which shows as a 2x slowdown. This makes it slightly slower than the "old" code in 5.2 in this trivial case.

It performs much better than both trunk and 5.2 in the other cases.