### PR TITLE
Enable frame pointers on macOS x86_64

### DIFF
--- a/Changes
+++ b/Changes
@@ -51,6 +51,9 @@ _______________
   (David Allsopp, review by Antonin Décimo, Sébastien Hinderer, Samuel Hym,
    Guillaume Munch-Maccagnoni and Miod Vallat)
 
+- #13163: Enable frame pointers on macOS x86_64
+  (Tim McGilchrist, review by Sébastien Hinderer and Fabrice Buoro)
+
 ### Code generation and optimizations:
 
 - #13014: Enable compile-time option -function-sections on all previously

--- a/configure
+++ b/configure
@@ -20384,14 +20384,20 @@ fi
 
 if test x"$enable_frame_pointers" = "xyes"
 then :
-  case "$host,$ocaml_cc_vendor" in #(
-  x86_64-*-linux*,gcc-*|x86_64-*-linux*,clang-*) :
+  case $host in #(
+  x86_64-*-linux*|x86_64-*-darwin*) :
+    case $ocaml_cc_vendor in #(
+  clang-*|gcc-*) :
     common_cflags="$common_cflags -g  -fno-omit-frame-pointer"
-      frame_pointers=true
-      printf "%s\n" "#define WITH_FRAME_POINTERS 1" >>confdefs.h
+         frame_pointers=true
+         printf "%s\n" "#define WITH_FRAME_POINTERS 1" >>confdefs.h
 
-      { printf "%s\n" "$as_me:${as_lineno-$LINENO}: using frame pointers" >&5
+         { printf "%s\n" "$as_me:${as_lineno-$LINENO}: using frame pointers" >&5
 printf "%s\n" "$as_me: using frame pointers" >&6;} ;; #(
+  *) :
+    as_fn_error $? "frame pointers not supported on this platform" "$LINENO" 5
+       ;;
+esac ;; #(
   *) :
     as_fn_error $? "frame pointers not supported on this platform" "$LINENO" 5
    ;;

--- a/configure.ac
+++ b/configure.ac
@@ -2456,12 +2456,16 @@ AS_IF([$native_compiler],
 ## Frame pointers
 
 AS_IF([test x"$enable_frame_pointers" = "xyes"],
-  [AS_CASE(["$host,$ocaml_cc_vendor"],
-    [x86_64-*-linux*,gcc-*|x86_64-*-linux*,clang-*],
-      [common_cflags="$common_cflags -g  -fno-omit-frame-pointer"
-      frame_pointers=true
-      AC_DEFINE([WITH_FRAME_POINTERS])
-      AC_MSG_NOTICE([using frame pointers])],
+  [AS_CASE([$host],
+    [x86_64-*-linux*|x86_64-*-darwin*],
+     [AS_CASE([$ocaml_cc_vendor],
+        [clang-*|gcc-*],
+         [common_cflags="$common_cflags -g  -fno-omit-frame-pointer"
+         frame_pointers=true
+         AC_DEFINE([WITH_FRAME_POINTERS])
+         AC_MSG_NOTICE([using frame pointers])],
+         [AC_MSG_ERROR([frame pointers not supported on this platform])]
+      )],
     [AC_MSG_ERROR([frame pointers not supported on this platform])]
   )],
   [AC_MSG_NOTICE([not using frame pointers])


### PR DESCRIPTION
Enables frame pointers on macOS x86_64 reusing the existing code for Linux x86_64 frame pointers.