### PR TITLE
MinGW/MSVC Sys.rename cornercase regression

### DIFF
--- a/Changes
+++ b/Changes
@@ -255,6 +255,11 @@ _______________
   (Florian Weimer, review by Gabriel Scherer and Pierre Chambart,
    report by Richard Jones)
 
+- #13166: Fix a MinGW/MSVC Sys.rename regression on renaming a parent directory
+  to an empty child directory.
+  (Jan Midtgaard, review by Antonin Décimo, Sébastien Hinderer, and
+   David Allsopp)
+
 OCaml 5.2.0
 ------------
 

--- a/configure
+++ b/configure
@@ -20808,11 +20808,12 @@ ocamlc_cppflags="$common_cppflags $CPPFLAGS"
 
 case $host in #(
   *-*-mingw32*) :
-    cclibs="$cclibs -lole32 -luuid -lversion" ;; #(
+    cclibs="$cclibs -lole32 -luuid -lversion -lshlwapi" ;; #(
   *-pc-windows) :
     # For whatever reason, flexlink includes -ladvapi32 and -lshell32 for
     # mingw-w64, but doesn't include advapi32.lib and shell32.lib for MSVC
-    cclibs="$cclibs ole32.lib uuid.lib advapi32.lib shell32.lib version.lib" ;; #(
+    cclibs=\
+"$cclibs ole32.lib uuid.lib advapi32.lib shell32.lib version.lib shlwapi.lib" ;; #(
   *) :
      ;;
 esac

--- a/configure.ac
+++ b/configure.ac
@@ -2621,11 +2621,12 @@ ocamlc_cppflags="$common_cppflags $CPPFLAGS"
 
 AS_CASE([$host],
   [*-*-mingw32*],
-    [cclibs="$cclibs -lole32 -luuid -lversion"],
+    [cclibs="$cclibs -lole32 -luuid -lversion -lshlwapi"],
   [*-pc-windows],
     [# For whatever reason, flexlink includes -ladvapi32 and -lshell32 for
     # mingw-w64, but doesn't include advapi32.lib and shell32.lib for MSVC
-    cclibs="$cclibs ole32.lib uuid.lib advapi32.lib shell32.lib version.lib"])
+    cclibs=\
+"$cclibs ole32.lib uuid.lib advapi32.lib shell32.lib version.lib shlwapi.lib"])
 
 AC_CONFIG_COMMANDS_PRE([cclibs="$cclibs $mathlib $DLLIBS $PTHREAD_LIBS"])
 

--- a/runtime/win32.c
+++ b/runtime/win32.c
@@ -28,6 +28,7 @@
 #include <winsock2.h>
 #include <winioctl.h>
 #include <shlobj.h>
+#include <shlwapi.h>
 #include <direct.h>
 #include <stdlib.h>
 #include <stdio.h>
@@ -809,7 +810,8 @@ int caml_win32_rename(const wchar_t * oldpath, const wchar_t * newpath)
   if ((old_attribs != INVALID_FILE_ATTRIBUTES) &&
       (old_attribs & FILE_ATTRIBUTE_DIRECTORY) != 0 &&
       (new_attribs != INVALID_FILE_ATTRIBUTES) &&
-      (new_attribs & FILE_ATTRIBUTE_DIRECTORY) != 0) {
+      (new_attribs & FILE_ATTRIBUTE_DIRECTORY) != 0 &&
+      !PathIsPrefix(oldpath, newpath)) {
     /* Try to delete: RemoveDirectoryW fails on non-empty dirs as intended.
        Then try again. */
     RemoveDirectoryW(newpath);

--- a/testsuite/tests/lib-sys/rename.ml
+++ b/testsuite/tests/lib-sys/rename.ml
@@ -102,3 +102,13 @@ let _ =
   safe_remove_dir "foo";
   safe_remove f2;
   safe_remove_dir f2;
+  print_string "Rename parent directory to empty child directory: ";
+  Sys.mkdir "foo" 0o755;
+  let bar = Filename.concat "foo" "bar" in
+  Sys.mkdir bar 0o755;
+  testfailure "foo" bar;
+  assert (Sys.file_exists "foo");
+  assert (Sys.file_exists bar);
+  print_newline();
+  safe_remove_dir bar;
+  safe_remove_dir "foo";

--- a/testsuite/tests/lib-sys/rename.reference
+++ b/testsuite/tests/lib-sys/rename.reference
@@ -8,3 +8,4 @@ Rename directory to a non-empty directory: fails as expected
 Rename directory to existing empty directory: passed
 Rename existing empty directory to itself: source directory still exists!
 Rename directory to existing file: fails as expected
+Rename parent directory to empty child directory: fails as expected


### PR DESCRIPTION
Last year, #12184 and #12320 fixed two MinGW `Sys.rename` cornercases. 
I found a third one which sadly flew under the radar:
```ocaml
# Sys.mkdir "sandbox\\eee" 0o755;;
- : unit = ()
# Sys.rename "sandbox" "sandbox\\eee";;
Exception: Sys_error "Invalid argument".
# Sys.file_exists "sandbox\\eee";;
- : bool = false
```

This happens only when the target is an empty child directory of the source, in which case
- it fails as expected
- but has the side effect of removing the target.

This is a consequence of the try-then-retry strategy of #12320.
Using `PathIsPrefix` to avoid retrying on a less-common error path does not seem too invasive IMHO.
