### PR TITLE
Update link to ocaml-multicore issue 408

### DIFF
--- a/testsuite/tests/lib-threads/beat.ml
+++ b/testsuite/tests/lib-threads/beat.ml
@@ -3,7 +3,7 @@
    include systhreads;
    hassysthreads;
  }{
-   reason = "off-by-one error on MacOS+Clang (#408)";
+   reason = "off-by-one error on MacOS+Clang (https://github.com/ocaml-multicore/ocaml-multicore/issues/408)";
    skip;
    {
      bytecode;


### PR DESCRIPTION
Minor meta-data issue with the linked issue being ambiguous, it should point to https://github.com/ocaml-multicore/ocaml-multicore/issues/408