### PR TITLE
Array.shuffle: explicitly validate the result of [rand].

### DIFF
--- a/Changes
+++ b/Changes
@@ -66,6 +66,12 @@ _______________
 
 ### Standard library:
 
+- #13168: In Array.shuffle, clarify the code that validates the
+  result of the user-supplied function `rand`, and improve the
+  error message that is produced when this result is invalid.
+  (François Pottier, review by Florian Angeletti, Daniel Bünzli
+   and Gabriel Scherer)
+
 - #12133: Expose support for printing substrings in Format
   (Florian Angeletti, review by Daniel Bünzli, Gabriel Scherer
    and Nicolás Ojeda Bär)

--- a/stdlib/.depend
+++ b/stdlib/.depend
@@ -18,9 +18,11 @@ stdlib__Arg.cmx : arg.ml \
     stdlib__Arg.cmi
 stdlib__Arg.cmi : arg.mli
 stdlib__Array.cmo : array.ml \
+    stdlib__String.cmi \
     stdlib__Seq.cmi \
     stdlib__Array.cmi
 stdlib__Array.cmx : array.ml \
+    stdlib__String.cmx \
     stdlib__Seq.cmx \
     stdlib__Array.cmi
 stdlib__Array.cmi : array.mli \

--- a/stdlib/array.ml
+++ b/stdlib/array.ml
@@ -440,12 +440,13 @@ let stable_sort cmp a =
 let fast_sort = stable_sort
 
 let shuffle_contract_violation i j =
-  let msg =
-    "Array.shuffle: 'rand " ^ string_of_int (i + 1) ^ "'" ^
-    " returned " ^ string_of_int j ^
-    ", out of expected range [0; " ^ string_of_int i ^ "]"
-  in
-  invalid_arg msg
+  let int = string_of_int in
+  String.concat "" [
+    "Array.shuffle: 'rand "; int (i + 1);
+    "' returned "; int j;
+    ", out of expected range [0; "; int i; "]"
+  ]
+  |> invalid_arg
 
 let shuffle ~rand a = (* Fisher-Yates *)
   for i = length a - 1 downto 1 do

--- a/stdlib/array.ml
+++ b/stdlib/array.ml
@@ -439,10 +439,18 @@ let stable_sort cmp a =
 
 let fast_sort = stable_sort
 
+let shuffle_contract_violation i j =
+  let msg =
+    "Array.shuffle: rand(" ^ string_of_int (i + 1) ^ ")" ^
+    " returned " ^ string_of_int j ^
+    ", outside of the expected range [0; " ^ string_of_int i ^ "]"
+  in
+  invalid_arg msg
+
 let shuffle ~rand a = (* Fisher-Yates *)
   for i = length a - 1 downto 1 do
     let j = rand (i + 1) in
-    if not (0 <= j && j <= i) then invalid_arg "Array.shuffle";
+    if not (0 <= j && j <= i) then shuffle_contract_violation i j;
     let v = unsafe_get a i in
     unsafe_set a i (unsafe_get a j);
     unsafe_set a j v

--- a/stdlib/array.ml
+++ b/stdlib/array.ml
@@ -442,8 +442,9 @@ let fast_sort = stable_sort
 let shuffle ~rand a = (* Fisher-Yates *)
   for i = length a - 1 downto 1 do
     let j = rand (i + 1) in
+    if not (0 <= j && j <= i) then invalid_arg "Array.shuffle";
     let v = unsafe_get a i in
-    unsafe_set a i (get a j);
+    unsafe_set a i (unsafe_get a j);
     unsafe_set a j v
   done
 

--- a/stdlib/array.ml
+++ b/stdlib/array.ml
@@ -441,9 +441,9 @@ let fast_sort = stable_sort
 
 let shuffle_contract_violation i j =
   let msg =
-    "Array.shuffle: rand(" ^ string_of_int (i + 1) ^ ")" ^
+    "Array.shuffle: 'rand " ^ string_of_int (i + 1) ^ "'" ^
     " returned " ^ string_of_int j ^
-    ", outside of the expected range [0; " ^ string_of_int i ^ "]"
+    ", out of expected range [0; " ^ string_of_int i ^ "]"
   in
   invalid_arg msg
 


### PR DESCRIPTION
This yields more readable code (the previous code used [get] instead of [unsafe_get] in a way that was quite cryptic), a more precise runtime check (in the previous code, a violation of [rand]'s contract could go unnoticed), and a more understandable exception (namely, [Invalid_argument "Array.shuffle"] instead of
[Invalid_argument "array index out of bounds"]).