### PR TITLE
A document type for error messages

### DIFF
--- a/.depend
+++ b/.depend
@@ -81,27 +81,38 @@ utils/consistbl.cmi : \
     utils/misc.cmi
 utils/diffing.cmo : \
     utils/misc.cmi \
+    utils/format_doc.cmi \
     utils/diffing.cmi
 utils/diffing.cmx : \
     utils/misc.cmx \
+    utils/format_doc.cmx \
     utils/diffing.cmi
 utils/diffing.cmi : \
-    utils/misc.cmi
+    utils/misc.cmi \
+    utils/format_doc.cmi
 utils/diffing_with_keys.cmo : \
     utils/misc.cmi \
+    utils/format_doc.cmi \
     utils/diffing.cmi \
     utils/diffing_with_keys.cmi
 utils/diffing_with_keys.cmx : \
     utils/misc.cmx \
+    utils/format_doc.cmx \
     utils/diffing.cmx \
     utils/diffing_with_keys.cmi
 utils/diffing_with_keys.cmi : \
+    utils/format_doc.cmi \
     utils/diffing.cmi
 utils/domainstate.cmo : \
     utils/domainstate.cmi
 utils/domainstate.cmx : \
     utils/domainstate.cmi
 utils/domainstate.cmi :
+utils/format_doc.cmo : \
+    utils/format_doc.cmi
+utils/format_doc.cmx : \
+    utils/format_doc.cmi
+utils/format_doc.cmi :
 utils/identifiable.cmo : \
     utils/misc.cmi \
     utils/identifiable.cmi
@@ -121,11 +132,14 @@ utils/lazy_backtrack.cmx : \
 utils/lazy_backtrack.cmi :
 utils/linkdeps.cmo : \
     utils/misc.cmi \
+    utils/format_doc.cmi \
     utils/linkdeps.cmi
 utils/linkdeps.cmx : \
     utils/misc.cmx \
+    utils/format_doc.cmx \
     utils/linkdeps.cmi
-utils/linkdeps.cmi :
+utils/linkdeps.cmi : \
+    utils/format_doc.cmi
 utils/load_path.cmo : \
     utils/misc.cmi \
     utils/local_store.cmi \
@@ -143,14 +157,17 @@ utils/local_store.cmx : \
     utils/local_store.cmi
 utils/local_store.cmi :
 utils/misc.cmo : \
+    utils/format_doc.cmi \
     utils/config.cmi \
     utils/build_path_prefix_map.cmi \
     utils/misc.cmi
 utils/misc.cmx : \
+    utils/format_doc.cmx \
     utils/config.cmx \
     utils/build_path_prefix_map.cmx \
     utils/misc.cmi
 utils/misc.cmi : \
+    utils/format_doc.cmi \
     utils/build_path_prefix_map.cmi
 utils/numbers.cmo : \
     utils/misc.cmi \
@@ -195,11 +212,14 @@ utils/terminfo.cmx : \
 utils/terminfo.cmi :
 utils/warnings.cmo : \
     utils/misc.cmi \
+    utils/format_doc.cmi \
     utils/warnings.cmi
 utils/warnings.cmx : \
     utils/misc.cmx \
+    utils/format_doc.cmx \
     utils/warnings.cmi
-utils/warnings.cmi :
+utils/warnings.cmi : \
+    utils/format_doc.cmi
 parsing/ast_helper.cmo : \
     parsing/syntaxerr.cmi \
     parsing/parsetree.cmi \
@@ -259,6 +279,7 @@ parsing/ast_mapper.cmo : \
     parsing/longident.cmi \
     parsing/location.cmi \
     utils/load_path.cmi \
+    utils/format_doc.cmi \
     utils/config.cmi \
     utils/clflags.cmi \
     parsing/asttypes.cmi \
@@ -270,6 +291,7 @@ parsing/ast_mapper.cmx : \
     parsing/longident.cmx \
     parsing/location.cmx \
     utils/load_path.cmx \
+    utils/format_doc.cmx \
     utils/config.cmx \
     utils/clflags.cmx \
     parsing/asttypes.cmx \
@@ -290,6 +312,7 @@ parsing/attr_helper.cmo : \
     parsing/parsetree.cmi \
     utils/misc.cmi \
     parsing/location.cmi \
+    utils/format_doc.cmi \
     parsing/builtin_attributes.cmi \
     parsing/asttypes.cmi \
     parsing/attr_helper.cmi
@@ -297,12 +320,14 @@ parsing/attr_helper.cmx : \
     parsing/parsetree.cmi \
     utils/misc.cmx \
     parsing/location.cmx \
+    utils/format_doc.cmx \
     parsing/builtin_attributes.cmx \
     parsing/asttypes.cmx \
     parsing/attr_helper.cmi
 parsing/attr_helper.cmi : \
     parsing/parsetree.cmi \
     parsing/location.cmi \
+    utils/format_doc.cmi \
     parsing/asttypes.cmi
 parsing/builtin_attributes.cmo : \
     utils/warnings.cmi \
@@ -310,6 +335,7 @@ parsing/builtin_attributes.cmo : \
     utils/misc.cmi \
     parsing/longident.cmi \
     parsing/location.cmi \
+    utils/format_doc.cmi \
     utils/clflags.cmi \
     parsing/asttypes.cmi \
     parsing/ast_iterator.cmi \
@@ -321,6 +347,7 @@ parsing/builtin_attributes.cmx : \
     utils/misc.cmx \
     parsing/longident.cmx \
     parsing/location.cmx \
+    utils/format_doc.cmx \
     utils/clflags.cmx \
     parsing/asttypes.cmx \
     parsing/ast_iterator.cmx \
@@ -375,6 +402,7 @@ parsing/lexer.cmo : \
     parsing/parser.cmi \
     utils/misc.cmi \
     parsing/location.cmi \
+    utils/format_doc.cmi \
     parsing/docstrings.cmi \
     parsing/lexer.cmi
 parsing/lexer.cmx : \
@@ -382,6 +410,7 @@ parsing/lexer.cmx : \
     parsing/parser.cmx \
     utils/misc.cmx \
     parsing/location.cmx \
+    utils/format_doc.cmx \
     parsing/docstrings.cmx \
     parsing/lexer.cmi
 parsing/lexer.cmi : \
@@ -391,6 +420,7 @@ parsing/location.cmo : \
     utils/warnings.cmi \
     utils/terminfo.cmi \
     utils/misc.cmi \
+    utils/format_doc.cmi \
     utils/clflags.cmi \
     utils/build_path_prefix_map.cmi \
     parsing/location.cmi
@@ -398,11 +428,13 @@ parsing/location.cmx : \
     utils/warnings.cmx \
     utils/terminfo.cmx \
     utils/misc.cmx \
+    utils/format_doc.cmx \
     utils/clflags.cmx \
     utils/build_path_prefix_map.cmx \
     parsing/location.cmi
 parsing/location.cmi : \
-    utils/warnings.cmi
+    utils/warnings.cmi \
+    utils/format_doc.cmi
 parsing/longident.cmo : \
     utils/misc.cmi \
     parsing/longident.cmi
@@ -417,6 +449,7 @@ parsing/parse.cmo : \
     utils/misc.cmi \
     parsing/location.cmi \
     parsing/lexer.cmi \
+    utils/format_doc.cmi \
     parsing/docstrings.cmi \
     parsing/parse.cmi
 parsing/parse.cmx : \
@@ -426,6 +459,7 @@ parsing/parse.cmx : \
     utils/misc.cmx \
     parsing/location.cmx \
     parsing/lexer.cmx \
+    utils/format_doc.cmx \
     parsing/docstrings.cmx \
     parsing/parse.cmi
 parsing/parse.cmi : \
@@ -470,6 +504,7 @@ parsing/pprintast.cmo : \
     parsing/longident.cmi \
     parsing/location.cmi \
     parsing/lexer.cmi \
+    utils/format_doc.cmi \
     parsing/asttypes.cmi \
     parsing/pprintast.cmi
 parsing/pprintast.cmx : \
@@ -477,11 +512,13 @@ parsing/pprintast.cmx : \
     parsing/longident.cmx \
     parsing/location.cmx \
     parsing/lexer.cmx \
+    utils/format_doc.cmx \
     parsing/asttypes.cmx \
     parsing/pprintast.cmi
 parsing/pprintast.cmi : \
     parsing/parsetree.cmi \
-    parsing/longident.cmi
+    parsing/longident.cmi \
+    utils/format_doc.cmi
 parsing/printast.cmo : \
     parsing/pprintast.cmi \
     parsing/parsetree.cmi \
@@ -586,6 +623,7 @@ typing/ctype.cmo : \
     parsing/location.cmi \
     utils/local_store.cmi \
     typing/ident.cmi \
+    utils/format_doc.cmi \
     typing/errortrace.cmi \
     typing/env.cmi \
     utils/clflags.cmi \
@@ -603,6 +641,7 @@ typing/ctype.cmx : \
     parsing/location.cmx \
     utils/local_store.cmx \
     typing/ident.cmx \
+    utils/format_doc.cmx \
     typing/errortrace.cmx \
     typing/env.cmx \
     utils/clflags.cmx \
@@ -656,6 +695,7 @@ typing/env.cmo : \
     utils/load_path.cmi \
     utils/lazy_backtrack.cmi \
     typing/ident.cmi \
+    utils/format_doc.cmi \
     typing/datarepr.cmi \
     file_formats/cmi_format.cmi \
     utils/clflags.cmi \
@@ -679,6 +719,7 @@ typing/env.cmx : \
     utils/load_path.cmx \
     utils/lazy_backtrack.cmx \
     typing/ident.cmx \
+    utils/format_doc.cmx \
     typing/datarepr.cmx \
     file_formats/cmi_format.cmx \
     utils/clflags.cmx \
@@ -698,6 +739,7 @@ typing/env.cmi : \
     parsing/location.cmi \
     utils/load_path.cmi \
     typing/ident.cmi \
+    utils/format_doc.cmi \
     file_formats/cmi_format.cmi \
     parsing/asttypes.cmi
 typing/envaux.cmo : \
@@ -707,6 +749,7 @@ typing/envaux.cmo : \
     utils/misc.cmi \
     parsing/location.cmi \
     typing/ident.cmi \
+    utils/format_doc.cmi \
     typing/env.cmi \
     parsing/asttypes.cmi \
     typing/envaux.cmi
@@ -717,46 +760,55 @@ typing/envaux.cmx : \
     utils/misc.cmx \
     parsing/location.cmx \
     typing/ident.cmx \
+    utils/format_doc.cmx \
     typing/env.cmx \
     parsing/asttypes.cmx \
     typing/envaux.cmi
 typing/envaux.cmi : \
     typing/subst.cmi \
     typing/path.cmi \
+    utils/format_doc.cmi \
     typing/env.cmi
 typing/errortrace.cmo : \
     typing/types.cmi \
     typing/path.cmi \
+    utils/format_doc.cmi \
     parsing/asttypes.cmi \
     typing/errortrace.cmi
 typing/errortrace.cmx : \
     typing/types.cmx \
     typing/path.cmx \
+    utils/format_doc.cmx \
     parsing/asttypes.cmx \
     typing/errortrace.cmi
 typing/errortrace.cmi : \
     typing/types.cmi \
     typing/path.cmi \
+    utils/format_doc.cmi \
     parsing/asttypes.cmi
 typing/ident.cmo : \
     utils/misc.cmi \
     utils/local_store.cmi \
     utils/identifiable.cmi \
+    utils/format_doc.cmi \
     utils/clflags.cmi \
     typing/ident.cmi
 typing/ident.cmx : \
     utils/misc.cmx \
     utils/local_store.cmx \
     utils/identifiable.cmx \
+    utils/format_doc.cmx \
     utils/clflags.cmx \
     typing/ident.cmi
 typing/ident.cmi : \
-    utils/identifiable.cmi
+    utils/identifiable.cmi \
+    utils/format_doc.cmi
 typing/includeclass.cmo : \
     typing/types.cmi \
     typing/printtyp.cmi \
     typing/path.cmi \
     utils/misc.cmi \
+    utils/format_doc.cmi \
     typing/ctype.cmi \
     parsing/builtin_attributes.cmi \
     typing/includeclass.cmi
@@ -765,6 +817,7 @@ typing/includeclass.cmx : \
     typing/printtyp.cmx \
     typing/path.cmx \
     utils/misc.cmx \
+    utils/format_doc.cmx \
     typing/ctype.cmx \
     parsing/builtin_attributes.cmx \
     typing/includeclass.cmi
@@ -772,6 +825,7 @@ typing/includeclass.cmi : \
     typing/types.cmi \
     typing/printtyp.cmi \
     parsing/location.cmi \
+    utils/format_doc.cmi \
     typing/env.cmi \
     typing/ctype.cmi
 typing/includecore.cmo : \
@@ -783,6 +837,7 @@ typing/includecore.cmo : \
     typing/path.cmi \
     utils/misc.cmi \
     typing/ident.cmi \
+    utils/format_doc.cmi \
     typing/errortrace.cmi \
     typing/env.cmi \
     utils/diffing_with_keys.cmi \
@@ -800,6 +855,7 @@ typing/includecore.cmx : \
     typing/path.cmx \
     utils/misc.cmx \
     typing/ident.cmx \
+    utils/format_doc.cmx \
     typing/errortrace.cmx \
     typing/env.cmx \
     utils/diffing_with_keys.cmx \
@@ -815,6 +871,7 @@ typing/includecore.cmi : \
     typing/path.cmi \
     parsing/location.cmi \
     typing/ident.cmi \
+    utils/format_doc.cmi \
     typing/errortrace.cmi \
     typing/env.cmi \
     utils/diffing_with_keys.cmi
@@ -891,6 +948,7 @@ typing/includemod_errorprinter.cmo : \
     typing/includecore.cmi \
     typing/includeclass.cmi \
     typing/ident.cmi \
+    utils/format_doc.cmi \
     typing/env.cmi \
     utils/diffing.cmi \
     utils/clflags.cmi \
@@ -908,6 +966,7 @@ typing/includemod_errorprinter.cmx : \
     typing/includecore.cmx \
     typing/includeclass.cmx \
     typing/ident.cmx \
+    utils/format_doc.cmx \
     typing/env.cmx \
     utils/diffing.cmx \
     utils/clflags.cmx \
@@ -916,6 +975,7 @@ typing/includemod_errorprinter.cmi : \
     typing/types.cmi \
     typing/typedtree.cmi \
     typing/includemod.cmi \
+    utils/format_doc.cmi \
     typing/env.cmi
 typing/mtype.cmo : \
     typing/types.cmi \
@@ -950,18 +1010,22 @@ typing/oprint.cmo : \
     parsing/pprintast.cmi \
     typing/outcometree.cmi \
     parsing/lexer.cmi \
+    utils/format_doc.cmi \
     parsing/asttypes.cmi \
     typing/oprint.cmi
 typing/oprint.cmx : \
     parsing/pprintast.cmx \
     typing/outcometree.cmi \
     parsing/lexer.cmx \
+    utils/format_doc.cmx \
     parsing/asttypes.cmx \
     typing/oprint.cmi
 typing/oprint.cmi : \
-    typing/outcometree.cmi
+    typing/outcometree.cmi \
+    utils/format_doc.cmi
 typing/outcometree.cmi : \
     typing/type_immediacy.cmi \
+    utils/format_doc.cmi \
     parsing/asttypes.cmi
 typing/parmatch.cmo : \
     utils/warnings.cmi \
@@ -978,6 +1042,7 @@ typing/parmatch.cmo : \
     parsing/longident.cmi \
     parsing/location.cmi \
     typing/ident.cmi \
+    utils/format_doc.cmi \
     typing/env.cmi \
     typing/ctype.cmi \
     typing/btype.cmi \
@@ -998,6 +1063,7 @@ typing/parmatch.cmx : \
     parsing/longident.cmx \
     parsing/location.cmx \
     typing/ident.cmx \
+    utils/format_doc.cmx \
     typing/env.cmx \
     typing/ctype.cmx \
     typing/btype.cmx \
@@ -1013,13 +1079,16 @@ typing/parmatch.cmi : \
 typing/path.cmo : \
     parsing/lexer.cmi \
     typing/ident.cmi \
+    utils/format_doc.cmi \
     typing/path.cmi
 typing/path.cmx : \
     parsing/lexer.cmx \
     typing/ident.cmx \
+    utils/format_doc.cmx \
     typing/path.cmi
 typing/path.cmi : \
-    typing/ident.cmi
+    typing/ident.cmi \
+    utils/format_doc.cmi
 typing/patterns.cmo : \
     typing/types.cmi \
     typing/typedtree.cmi \
@@ -1053,6 +1122,7 @@ typing/persistent_env.cmo : \
     parsing/location.cmi \
     utils/load_path.cmi \
     utils/lazy_backtrack.cmi \
+    utils/format_doc.cmi \
     utils/consistbl.cmi \
     file_formats/cmi_format.cmi \
     utils/clflags.cmi \
@@ -1064,6 +1134,7 @@ typing/persistent_env.cmx : \
     parsing/location.cmx \
     utils/load_path.cmx \
     utils/lazy_backtrack.cmx \
+    utils/format_doc.cmx \
     utils/consistbl.cmx \
     file_formats/cmi_format.cmx \
     utils/clflags.cmx \
@@ -1075,6 +1146,7 @@ typing/persistent_env.cmi : \
     parsing/location.cmi \
     utils/load_path.cmi \
     utils/lazy_backtrack.cmi \
+    utils/format_doc.cmi \
     utils/consistbl.cmi \
     file_formats/cmi_format.cmi
 typing/predef.cmo : \
@@ -1108,6 +1180,7 @@ typing/primitive.cmo : \
     typing/outcometree.cmi \
     utils/misc.cmi \
     parsing/location.cmi \
+    utils/format_doc.cmi \
     parsing/attr_helper.cmi \
     typing/primitive.cmi
 typing/primitive.cmx : \
@@ -1115,6 +1188,7 @@ typing/primitive.cmx : \
     typing/outcometree.cmi \
     utils/misc.cmx \
     parsing/location.cmx \
+    utils/format_doc.cmx \
     parsing/attr_helper.cmx \
     typing/primitive.cmi
 typing/primitive.cmi : \
@@ -1125,16 +1199,19 @@ typing/printpat.cmo : \
     typing/types.cmi \
     typing/typedtree.cmi \
     typing/ident.cmi \
+    utils/format_doc.cmi \
     parsing/asttypes.cmi \
     typing/printpat.cmi
 typing/printpat.cmx : \
     typing/types.cmx \
     typing/typedtree.cmx \
     typing/ident.cmx \
+    utils/format_doc.cmx \
     parsing/asttypes.cmx \
     typing/printpat.cmi
 typing/printpat.cmi : \
     typing/typedtree.cmi \
+    utils/format_doc.cmi \
     parsing/asttypes.cmi
 typing/printtyp.cmo : \
     utils/warnings.cmi \
@@ -1154,6 +1231,7 @@ typing/printtyp.cmo : \
     parsing/longident.cmi \
     parsing/location.cmi \
     typing/ident.cmi \
+    utils/format_doc.cmi \
     typing/errortrace.cmi \
     typing/env.cmi \
     typing/ctype.cmi \
@@ -1179,6 +1257,7 @@ typing/printtyp.cmx : \
     parsing/longident.cmx \
     parsing/location.cmx \
     typing/ident.cmx \
+    utils/format_doc.cmx \
     typing/errortrace.cmx \
     typing/env.cmx \
     typing/ctype.cmx \
@@ -1194,8 +1273,10 @@ typing/printtyp.cmi : \
     parsing/longident.cmi \
     parsing/location.cmi \
     typing/ident.cmi \
+    utils/format_doc.cmi \
     typing/errortrace.cmi \
-    typing/env.cmi
+    typing/env.cmi \
+    parsing/asttypes.cmi
 typing/printtyped.cmo : \
     typing/types.cmi \
     typing/typedtree.cmi \
@@ -1228,12 +1309,14 @@ typing/rawprinttyp.cmo : \
     typing/types.cmi \
     parsing/pprintast.cmi \
     typing/path.cmi \
+    utils/format_doc.cmi \
     parsing/asttypes.cmi \
     typing/rawprinttyp.cmi
 typing/rawprinttyp.cmx : \
     typing/types.cmx \
     parsing/pprintast.cmx \
     typing/path.cmx \
+    utils/format_doc.cmx \
     parsing/asttypes.cmx \
     typing/rawprinttyp.cmi
 typing/rawprinttyp.cmi : \
@@ -1286,6 +1369,7 @@ typing/stypes.cmo : \
     typing/printtyp.cmi \
     utils/misc.cmi \
     parsing/location.cmi \
+    utils/format_doc.cmi \
     utils/clflags.cmi \
     typing/annot.cmi \
     typing/stypes.cmi
@@ -1294,6 +1378,7 @@ typing/stypes.cmx : \
     typing/printtyp.cmx \
     utils/misc.cmx \
     parsing/location.cmx \
+    utils/format_doc.cmx \
     utils/clflags.cmx \
     typing/annot.cmi \
     typing/stypes.cmi
@@ -1402,6 +1487,7 @@ typing/typeclass.cmo : \
     parsing/location.cmi \
     typing/includeclass.cmi \
     typing/ident.cmi \
+    utils/format_doc.cmi \
     typing/errortrace.cmi \
     typing/env.cmi \
     typing/ctype.cmi \
@@ -1431,6 +1517,7 @@ typing/typeclass.cmx : \
     parsing/location.cmx \
     typing/includeclass.cmx \
     typing/ident.cmx \
+    utils/format_doc.cmx \
     typing/errortrace.cmx \
     typing/env.cmx \
     typing/ctype.cmx \
@@ -1448,6 +1535,7 @@ typing/typeclass.cmi : \
     parsing/longident.cmi \
     parsing/location.cmi \
     typing/ident.cmi \
+    utils/format_doc.cmi \
     typing/errortrace.cmi \
     typing/env.cmi \
     typing/ctype.cmi \
@@ -1466,7 +1554,6 @@ typing/typecore.cmo : \
     typing/printpat.cmi \
     typing/primitive.cmi \
     typing/predef.cmi \
-    parsing/pprintast.cmi \
     typing/persistent_env.cmi \
     typing/path.cmi \
     parsing/parsetree.cmi \
@@ -1476,6 +1563,7 @@ typing/typecore.cmo : \
     parsing/longident.cmi \
     parsing/location.cmi \
     typing/ident.cmi \
+    utils/format_doc.cmi \
     typing/errortrace.cmi \
     typing/env.cmi \
     typing/ctype.cmi \
@@ -1500,7 +1588,6 @@ typing/typecore.cmx : \
     typing/printpat.cmx \
     typing/primitive.cmx \
     typing/predef.cmx \
-    parsing/pprintast.cmx \
     typing/persistent_env.cmx \
     typing/path.cmx \
     parsing/parsetree.cmi \
@@ -1510,6 +1597,7 @@ typing/typecore.cmx : \
     parsing/longident.cmx \
     parsing/location.cmx \
     typing/ident.cmx \
+    utils/format_doc.cmx \
     typing/errortrace.cmx \
     typing/env.cmx \
     typing/ctype.cmx \
@@ -1558,6 +1646,7 @@ typing/typedecl.cmo : \
     lambda/lambda.cmi \
     typing/includecore.cmi \
     typing/ident.cmi \
+    utils/format_doc.cmi \
     typing/errortrace.cmi \
     typing/env.cmi \
     typing/ctype.cmi \
@@ -1596,6 +1685,7 @@ typing/typedecl.cmx : \
     lambda/lambda.cmx \
     typing/includecore.cmx \
     typing/ident.cmx \
+    utils/format_doc.cmx \
     typing/errortrace.cmx \
     typing/env.cmx \
     typing/ctype.cmx \
@@ -1621,6 +1711,7 @@ typing/typedecl.cmi : \
     parsing/location.cmi \
     typing/includecore.cmi \
     typing/ident.cmi \
+    utils/format_doc.cmi \
     typing/errortrace.cmi \
     typing/env.cmi \
     parsing/asttypes.cmi
@@ -1743,6 +1834,7 @@ typing/typedtree.cmo : \
     parsing/longident.cmi \
     parsing/location.cmi \
     typing/ident.cmi \
+    utils/format_doc.cmi \
     typing/env.cmi \
     parsing/asttypes.cmi \
     typing/typedtree.cmi
@@ -1756,6 +1848,7 @@ typing/typedtree.cmx : \
     parsing/longident.cmx \
     parsing/location.cmx \
     typing/ident.cmx \
+    utils/format_doc.cmx \
     typing/env.cmx \
     parsing/asttypes.cmx \
     typing/typedtree.cmi
@@ -1769,6 +1862,7 @@ typing/typedtree.cmi : \
     parsing/longident.cmi \
     parsing/location.cmi \
     typing/ident.cmi \
+    utils/format_doc.cmi \
     typing/env.cmi \
     parsing/asttypes.cmi
 typing/typemod.cmo : \
@@ -1797,6 +1891,7 @@ typing/typemod.cmo : \
     typing/includemod_errorprinter.cmi \
     typing/includemod.cmi \
     typing/ident.cmi \
+    utils/format_doc.cmi \
     typing/errortrace.cmi \
     typing/env.cmi \
     typing/ctype.cmi \
@@ -1835,6 +1930,7 @@ typing/typemod.cmx : \
     typing/includemod_errorprinter.cmx \
     typing/includemod.cmx \
     typing/ident.cmx \
+    utils/format_doc.cmx \
     typing/errortrace.cmx \
     typing/env.cmx \
     typing/ctype.cmx \
@@ -1947,6 +2043,7 @@ typing/typetexp.cmo : \
     utils/misc.cmi \
     parsing/longident.cmi \
     parsing/location.cmi \
+    utils/format_doc.cmi \
     typing/errortrace.cmi \
     typing/env.cmi \
     typing/ctype.cmi \
@@ -1967,6 +2064,7 @@ typing/typetexp.cmx : \
     utils/misc.cmx \
     parsing/longident.cmx \
     parsing/location.cmx \
+    utils/format_doc.cmx \
     typing/errortrace.cmx \
     typing/env.cmx \
     typing/ctype.cmx \
@@ -1982,6 +2080,7 @@ typing/typetexp.cmi : \
     parsing/parsetree.cmi \
     parsing/longident.cmi \
     parsing/location.cmi \
+    utils/format_doc.cmi \
     typing/errortrace.cmi \
     typing/env.cmi \
     parsing/asttypes.cmi
@@ -2079,6 +2178,7 @@ bytecomp/bytelibrarian.cmo : \
     parsing/location.cmi \
     utils/load_path.cmi \
     utils/linkdeps.cmi \
+    utils/format_doc.cmi \
     bytecomp/emitcode.cmi \
     utils/config.cmi \
     file_formats/cmo_format.cmi \
@@ -2090,6 +2190,7 @@ bytecomp/bytelibrarian.cmx : \
     parsing/location.cmx \
     utils/load_path.cmx \
     utils/linkdeps.cmx \
+    utils/format_doc.cmx \
     bytecomp/emitcode.cmx \
     utils/config.cmx \
     file_formats/cmo_format.cmi \
@@ -2097,7 +2198,8 @@ bytecomp/bytelibrarian.cmx : \
     bytecomp/bytelink.cmx \
     bytecomp/bytelibrarian.cmi
 bytecomp/bytelibrarian.cmi : \
-    utils/linkdeps.cmi
+    utils/linkdeps.cmi \
+    utils/format_doc.cmi
 bytecomp/bytelink.cmo : \
     bytecomp/symtable.cmi \
     bytecomp/opcodes.cmi \
@@ -2106,6 +2208,7 @@ bytecomp/bytelink.cmo : \
     utils/load_path.cmi \
     utils/linkdeps.cmi \
     bytecomp/instruct.cmi \
+    utils/format_doc.cmi \
     bytecomp/emitcode.cmi \
     bytecomp/dll.cmi \
     utils/consistbl.cmi \
@@ -2124,6 +2227,7 @@ bytecomp/bytelink.cmx : \
     utils/load_path.cmx \
     utils/linkdeps.cmx \
     bytecomp/instruct.cmx \
+    utils/format_doc.cmx \
     bytecomp/emitcode.cmx \
     bytecomp/dll.cmx \
     utils/consistbl.cmx \
@@ -2138,6 +2242,7 @@ bytecomp/bytelink.cmi : \
     bytecomp/symtable.cmi \
     utils/misc.cmi \
     utils/linkdeps.cmi \
+    utils/format_doc.cmi \
     file_formats/cmo_format.cmi
 bytecomp/bytepackager.cmo : \
     parsing/unit_info.cmi \
@@ -2153,6 +2258,7 @@ bytecomp/bytepackager.cmo : \
     utils/load_path.cmi \
     bytecomp/instruct.cmi \
     typing/ident.cmi \
+    utils/format_doc.cmi \
     typing/env.cmi \
     bytecomp/emitcode.cmi \
     utils/config.cmi \
@@ -2176,6 +2282,7 @@ bytecomp/bytepackager.cmx : \
     utils/load_path.cmx \
     bytecomp/instruct.cmx \
     typing/ident.cmx \
+    utils/format_doc.cmx \
     typing/env.cmx \
     bytecomp/emitcode.cmx \
     utils/config.cmx \
@@ -2186,6 +2293,7 @@ bytecomp/bytepackager.cmx : \
     bytecomp/bytegen.cmx \
     bytecomp/bytepackager.cmi
 bytecomp/bytepackager.cmi : \
+    utils/format_doc.cmi \
     typing/env.cmi \
     file_formats/cmo_format.cmi
 bytecomp/bytesections.cmo : \
@@ -2217,6 +2325,7 @@ bytecomp/emitcode.cmo : \
     lambda/lambda.cmi \
     bytecomp/instruct.cmi \
     typing/ident.cmi \
+    utils/format_doc.cmi \
     typing/env.cmi \
     utils/config.cmi \
     utils/compression.cmi \
@@ -2237,6 +2346,7 @@ bytecomp/emitcode.cmx : \
     lambda/lambda.cmx \
     bytecomp/instruct.cmx \
     typing/ident.cmx \
+    utils/format_doc.cmx \
     typing/env.cmx \
     utils/config.cmx \
     utils/compression.cmx \
@@ -2312,6 +2422,7 @@ bytecomp/symtable.cmo : \
     parsing/location.cmi \
     lambda/lambda.cmi \
     typing/ident.cmi \
+    utils/format_doc.cmi \
     bytecomp/dll.cmi \
     utils/config.cmi \
     file_formats/cmo_format.cmi \
@@ -2325,6 +2436,7 @@ bytecomp/symtable.cmx : \
     parsing/location.cmx \
     lambda/lambda.cmx \
     typing/ident.cmx \
+    utils/format_doc.cmx \
     bytecomp/dll.cmx \
     utils/config.cmx \
     file_formats/cmo_format.cmi \
@@ -2333,6 +2445,7 @@ bytecomp/symtable.cmx : \
 bytecomp/symtable.cmi : \
     lambda/lambda.cmi \
     typing/ident.cmi \
+    utils/format_doc.cmi \
     file_formats/cmo_format.cmi
 asmcomp/CSE.cmo : \
     asmcomp/mach.cmi \
@@ -2423,6 +2536,7 @@ asmcomp/asmgen.cmo : \
     asmcomp/interval.cmi \
     asmcomp/interf.cmi \
     typing/ident.cmi \
+    utils/format_doc.cmi \
     asmcomp/emitaux.cmi \
     asmcomp/emit.cmi \
     asmcomp/deadcode.cmi \
@@ -2467,6 +2581,7 @@ asmcomp/asmgen.cmx : \
     asmcomp/interval.cmx \
     asmcomp/interf.cmx \
     typing/ident.cmx \
+    utils/format_doc.cmx \
     asmcomp/emitaux.cmx \
     asmcomp/emit.cmx \
     asmcomp/deadcode.cmx \
@@ -2486,6 +2601,7 @@ asmcomp/asmgen.cmx : \
 asmcomp/asmgen.cmi : \
     parsing/unit_info.cmi \
     lambda/lambda.cmi \
+    utils/format_doc.cmi \
     asmcomp/emitaux.cmi \
     asmcomp/cmm.cmi \
     middle_end/clambda.cmi \
@@ -2495,6 +2611,7 @@ asmcomp/asmlibrarian.cmo : \
     parsing/location.cmi \
     utils/load_path.cmi \
     utils/linkdeps.cmi \
+    utils/format_doc.cmi \
     middle_end/flambda/export_info.cmi \
     utils/config.cmi \
     middle_end/compilenv.cmi \
@@ -2509,6 +2626,7 @@ asmcomp/asmlibrarian.cmx : \
     parsing/location.cmx \
     utils/load_path.cmx \
     utils/linkdeps.cmx \
+    utils/format_doc.cmx \
     middle_end/flambda/export_info.cmx \
     utils/config.cmx \
     middle_end/compilenv.cmx \
@@ -2519,7 +2637,8 @@ asmcomp/asmlibrarian.cmx : \
     asmcomp/asmlink.cmx \
     asmcomp/asmlibrarian.cmi
 asmcomp/asmlibrarian.cmi : \
-    utils/linkdeps.cmi
+    utils/linkdeps.cmi \
+    utils/format_doc.cmi
 asmcomp/asmlink.cmo : \
     asmcomp/thread_sanitizer.cmi \
     lambda/runtimedef.cmi \
@@ -2528,6 +2647,7 @@ asmcomp/asmlink.cmo : \
     parsing/location.cmi \
     utils/load_path.cmi \
     utils/linkdeps.cmi \
+    utils/format_doc.cmi \
     asmcomp/emitaux.cmi \
     asmcomp/emit.cmi \
     utils/consistbl.cmi \
@@ -2548,6 +2668,7 @@ asmcomp/asmlink.cmx : \
     parsing/location.cmx \
     utils/load_path.cmx \
     utils/linkdeps.cmx \
+    utils/format_doc.cmx \
     asmcomp/emitaux.cmx \
     asmcomp/emit.cmx \
     utils/consistbl.cmx \
@@ -2563,6 +2684,7 @@ asmcomp/asmlink.cmx : \
 asmcomp/asmlink.cmi : \
     utils/misc.cmi \
     utils/linkdeps.cmi \
+    utils/format_doc.cmi \
     file_formats/cmx_format.cmi
 asmcomp/asmpackager.cmo : \
     parsing/unit_info.cmi \
@@ -2575,6 +2697,7 @@ asmcomp/asmpackager.cmo : \
     utils/load_path.cmi \
     lambda/lambda.cmi \
     typing/ident.cmi \
+    utils/format_doc.cmi \
     middle_end/flambda/flambda_middle_end.cmi \
     middle_end/flambda/export_info_for_pack.cmi \
     middle_end/flambda/export_info.cmi \
@@ -2600,6 +2723,7 @@ asmcomp/asmpackager.cmx : \
     utils/load_path.cmx \
     lambda/lambda.cmx \
     typing/ident.cmx \
+    utils/format_doc.cmx \
     middle_end/flambda/flambda_middle_end.cmx \
     middle_end/flambda/export_info_for_pack.cmx \
     middle_end/flambda/export_info.cmx \
@@ -2615,6 +2739,7 @@ asmcomp/asmpackager.cmx : \
     asmcomp/asmgen.cmx \
     asmcomp/asmpackager.cmi
 asmcomp/asmpackager.cmi : \
+    utils/format_doc.cmi \
     typing/env.cmi \
     middle_end/backend_intf.cmi
 asmcomp/branch_relaxation.cmo : \
@@ -2882,6 +3007,7 @@ asmcomp/emit.cmi : \
     asmcomp/linear.cmi \
     asmcomp/cmm.cmi
 asmcomp/emitaux.cmo : \
+    utils/format_doc.cmi \
     asmcomp/emitenv.cmi \
     lambda/debuginfo.cmi \
     utils/config.cmi \
@@ -2891,6 +3017,7 @@ asmcomp/emitaux.cmo : \
     asmcomp/arch.cmi \
     asmcomp/emitaux.cmi
 asmcomp/emitaux.cmx : \
+    utils/format_doc.cmx \
     asmcomp/emitenv.cmi \
     lambda/debuginfo.cmx \
     utils/config.cmx \
@@ -2901,6 +3028,7 @@ asmcomp/emitaux.cmx : \
     asmcomp/emitaux.cmi
 asmcomp/emitaux.cmi : \
     asmcomp/linear.cmi \
+    utils/format_doc.cmi \
     asmcomp/emitenv.cmi \
     lambda/debuginfo.cmi
 asmcomp/emitenv.cmi : \
@@ -3031,6 +3159,7 @@ asmcomp/polling.cmo : \
     utils/misc.cmi \
     asmcomp/mach.cmi \
     parsing/location.cmi \
+    utils/format_doc.cmi \
     lambda/debuginfo.cmi \
     asmcomp/dataflow.cmi \
     asmcomp/cmm.cmi \
@@ -3040,6 +3169,7 @@ asmcomp/polling.cmx : \
     utils/misc.cmx \
     asmcomp/mach.cmx \
     parsing/location.cmx \
+    utils/format_doc.cmx \
     lambda/debuginfo.cmx \
     asmcomp/dataflow.cmx \
     asmcomp/cmm.cmx \
@@ -3415,12 +3545,14 @@ middle_end/backend_intf.cmi : \
 middle_end/backend_var.cmo : \
     typing/path.cmi \
     typing/ident.cmi \
+    utils/format_doc.cmi \
     lambda/debuginfo.cmi \
     utils/clflags.cmi \
     middle_end/backend_var.cmi
 middle_end/backend_var.cmx : \
     typing/path.cmx \
     typing/ident.cmx \
+    utils/format_doc.cmx \
     lambda/debuginfo.cmx \
     utils/clflags.cmx \
     middle_end/backend_var.cmi
@@ -3500,6 +3632,7 @@ middle_end/compilenv.cmo : \
     utils/load_path.cmi \
     middle_end/linkage_name.cmi \
     typing/ident.cmi \
+    utils/format_doc.cmi \
     middle_end/flambda/export_info.cmi \
     typing/env.cmi \
     utils/config.cmi \
@@ -3520,6 +3653,7 @@ middle_end/compilenv.cmx : \
     utils/load_path.cmx \
     middle_end/linkage_name.cmx \
     typing/ident.cmx \
+    utils/format_doc.cmx \
     middle_end/flambda/export_info.cmx \
     typing/env.cmx \
     utils/config.cmx \
@@ -3535,6 +3669,7 @@ middle_end/compilenv.cmi : \
     middle_end/flambda/base_types/set_of_closures_id.cmi \
     middle_end/linkage_name.cmi \
     typing/ident.cmi \
+    utils/format_doc.cmi \
     middle_end/flambda/export_info.cmi \
     middle_end/compilation_unit.cmi \
     file_formats/cmx_format.cmi \
@@ -3829,6 +3964,7 @@ lambda/tmc.cmo : \
     parsing/location.cmi \
     lambda/lambda.cmi \
     typing/ident.cmi \
+    utils/format_doc.cmi \
     lambda/debuginfo.cmi \
     parsing/asttypes.cmi \
     lambda/tmc.cmi
@@ -3838,6 +3974,7 @@ lambda/tmc.cmx : \
     parsing/location.cmx \
     lambda/lambda.cmx \
     typing/ident.cmx \
+    utils/format_doc.cmx \
     lambda/debuginfo.cmx \
     parsing/asttypes.cmx \
     lambda/tmc.cmi
@@ -3883,6 +4020,7 @@ lambda/translclass.cmo : \
     parsing/location.cmi \
     lambda/lambda.cmi \
     typing/ident.cmi \
+    utils/format_doc.cmi \
     typing/env.cmi \
     lambda/debuginfo.cmi \
     utils/clflags.cmi \
@@ -3902,6 +4040,7 @@ lambda/translclass.cmx : \
     parsing/location.cmx \
     lambda/lambda.cmx \
     typing/ident.cmx \
+    utils/format_doc.cmx \
     typing/env.cmx \
     lambda/debuginfo.cmx \
     utils/clflags.cmx \
@@ -3914,6 +4053,7 @@ lambda/translclass.cmi : \
     parsing/location.cmi \
     lambda/lambda.cmi \
     typing/ident.cmi \
+    utils/format_doc.cmi \
     lambda/debuginfo.cmi \
     parsing/asttypes.cmi
 lambda/translcore.cmo : \
@@ -3934,6 +4074,7 @@ lambda/translcore.cmo : \
     parsing/location.cmi \
     lambda/lambda.cmi \
     typing/ident.cmi \
+    utils/format_doc.cmi \
     typing/env.cmi \
     lambda/debuginfo.cmi \
     utils/config.cmi \
@@ -3959,6 +4100,7 @@ lambda/translcore.cmx : \
     parsing/location.cmx \
     lambda/lambda.cmx \
     typing/ident.cmx \
+    utils/format_doc.cmx \
     typing/env.cmx \
     lambda/debuginfo.cmx \
     utils/config.cmx \
@@ -3972,6 +4114,7 @@ lambda/translcore.cmi : \
     parsing/location.cmi \
     lambda/lambda.cmi \
     typing/ident.cmi \
+    utils/format_doc.cmi \
     typing/env.cmi \
     lambda/debuginfo.cmi \
     parsing/asttypes.cmi
@@ -3992,6 +4135,7 @@ lambda/translmod.cmo : \
     parsing/location.cmi \
     lambda/lambda.cmi \
     typing/ident.cmi \
+    utils/format_doc.cmi \
     typing/env.cmi \
     lambda/debuginfo.cmi \
     typing/ctype.cmi \
@@ -4015,6 +4159,7 @@ lambda/translmod.cmx : \
     parsing/location.cmx \
     lambda/lambda.cmx \
     typing/ident.cmx \
+    utils/format_doc.cmx \
     typing/env.cmx \
     lambda/debuginfo.cmx \
     typing/ctype.cmx \
@@ -4065,6 +4210,7 @@ lambda/translprim.cmo : \
     parsing/location.cmi \
     lambda/lambda.cmi \
     typing/ident.cmi \
+    utils/format_doc.cmi \
     typing/env.cmi \
     lambda/debuginfo.cmi \
     utils/config.cmi \
@@ -4083,6 +4229,7 @@ lambda/translprim.cmx : \
     parsing/location.cmx \
     lambda/lambda.cmx \
     typing/ident.cmx \
+    utils/format_doc.cmx \
     typing/env.cmx \
     lambda/debuginfo.cmx \
     utils/config.cmx \
@@ -4097,6 +4244,7 @@ lambda/translprim.cmi : \
     parsing/location.cmi \
     lambda/lambda.cmi \
     typing/ident.cmi \
+    utils/format_doc.cmi \
     typing/env.cmi
 lambda/value_rec_compiler.cmo : \
     typing/value_rec_types.cmi \
@@ -4126,6 +4274,7 @@ file_formats/cmi_format.cmo : \
     typing/types.cmi \
     utils/misc.cmi \
     parsing/location.cmi \
+    utils/format_doc.cmi \
     utils/config.cmi \
     utils/compression.cmi \
     file_formats/cmi_format.cmi
@@ -4133,12 +4282,14 @@ file_formats/cmi_format.cmx : \
     typing/types.cmx \
     utils/misc.cmx \
     parsing/location.cmx \
+    utils/format_doc.cmx \
     utils/config.cmx \
     utils/compression.cmx \
     file_formats/cmi_format.cmi
 file_formats/cmi_format.cmi : \
     typing/types.cmi \
-    utils/misc.cmi
+    utils/misc.cmi \
+    utils/format_doc.cmi
 file_formats/cmo_format.cmi :
 file_formats/cmt_format.cmo : \
     parsing/unit_info.cmi \
@@ -4207,6 +4358,7 @@ file_formats/linear_format.cmo : \
     utils/misc.cmi \
     parsing/location.cmi \
     asmcomp/linear.cmi \
+    utils/format_doc.cmi \
     utils/config.cmi \
     asmcomp/cmm.cmi \
     file_formats/linear_format.cmi
@@ -4214,6 +4366,7 @@ file_formats/linear_format.cmx : \
     utils/misc.cmx \
     parsing/location.cmx \
     asmcomp/linear.cmx \
+    utils/format_doc.cmx \
     utils/config.cmx \
     asmcomp/cmm.cmx \
     file_formats/linear_format.cmi
@@ -6480,6 +6633,7 @@ driver/pparse.cmo : \
     parsing/parse.cmi \
     utils/misc.cmi \
     parsing/location.cmi \
+    utils/format_doc.cmi \
     utils/config.cmi \
     utils/clflags.cmi \
     utils/ccomp.cmi \
@@ -6493,6 +6647,7 @@ driver/pparse.cmx : \
     parsing/parse.cmx \
     utils/misc.cmx \
     parsing/location.cmx \
+    utils/format_doc.cmx \
     utils/config.cmx \
     utils/clflags.cmx \
     utils/ccomp.cmx \
@@ -6500,7 +6655,8 @@ driver/pparse.cmx : \
     parsing/ast_invariants.cmx \
     driver/pparse.cmi
 driver/pparse.cmi : \
-    parsing/parsetree.cmi
+    parsing/parsetree.cmi \
+    utils/format_doc.cmi
 toplevel/expunge.cmo : \
     parsing/unit_info.cmi \
     bytecomp/symtable.cmi \
@@ -6529,6 +6685,7 @@ toplevel/genprintval.cmo : \
     parsing/longident.cmi \
     parsing/lexer.cmi \
     typing/ident.cmi \
+    utils/format_doc.cmi \
     typing/env.cmi \
     typing/datarepr.cmi \
     typing/ctype.cmi \
@@ -6547,6 +6704,7 @@ toplevel/genprintval.cmx : \
     parsing/longident.cmx \
     parsing/lexer.cmx \
     typing/ident.cmx \
+    utils/format_doc.cmx \
     typing/env.cmx \
     typing/datarepr.cmx \
     typing/ctype.cmx \
@@ -6577,6 +6735,7 @@ toplevel/topcommon.cmo : \
     parsing/lexer.cmi \
     typing/ident.cmi \
     toplevel/genprintval.cmi \
+    utils/format_doc.cmi \
     typing/env.cmi \
     bytecomp/dll.cmi \
     utils/config.cmi \
@@ -6607,6 +6766,7 @@ toplevel/topcommon.cmx : \
     parsing/lexer.cmx \
     typing/ident.cmx \
     toplevel/genprintval.cmx \
+    utils/format_doc.cmx \
     typing/env.cmx \
     bytecomp/dll.cmx \
     utils/config.cmx \
@@ -6624,6 +6784,7 @@ toplevel/topcommon.cmi : \
     typing/path.cmi \
     parsing/parsetree.cmi \
     typing/outcometree.cmi \
+    typing/oprint.cmi \
     parsing/longident.cmi \
     parsing/location.cmi \
     utils/load_path.cmi \
@@ -6694,6 +6855,7 @@ toplevel/toploop.cmo : \
     parsing/location.cmi \
     utils/load_path.cmi \
     parsing/lexer.cmi \
+    utils/format_doc.cmi \
     typing/env.cmi \
     utils/config.cmi \
     driver/compmisc.cmi \
@@ -6710,6 +6872,7 @@ toplevel/toploop.cmx : \
     parsing/location.cmx \
     utils/load_path.cmx \
     parsing/lexer.cmx \
+    utils/format_doc.cmx \
     typing/env.cmx \
     utils/config.cmx \
     driver/compmisc.cmx \
@@ -6723,6 +6886,7 @@ toplevel/toploop.cmi : \
     typing/path.cmi \
     parsing/parsetree.cmi \
     typing/outcometree.cmi \
+    typing/oprint.cmi \
     parsing/longident.cmi \
     parsing/location.cmi \
     utils/load_path.cmi \
@@ -7169,6 +7333,7 @@ tools/dumpobj.cmo : \
     utils/misc.cmi \
     parsing/location.cmi \
     bytecomp/instruct.cmi \
+    utils/format_doc.cmi \
     utils/config.cmi \
     utils/compression.cmi \
     file_formats/cmo_format.cmi \
@@ -7181,6 +7346,7 @@ tools/dumpobj.cmx : \
     utils/misc.cmx \
     parsing/location.cmx \
     bytecomp/instruct.cmx \
+    utils/format_doc.cmx \
     utils/config.cmx \
     utils/compression.cmx \
     file_formats/cmo_format.cmi \
@@ -7241,6 +7407,7 @@ tools/objinfo.cmo : \
     parsing/location.cmi \
     middle_end/linkage_name.cmi \
     typing/ident.cmi \
+    utils/format_doc.cmi \
     middle_end/flambda/export_info.cmi \
     middle_end/compilation_unit.cmi \
     file_formats/cmxs_format.cmi \
@@ -7263,6 +7430,7 @@ tools/objinfo.cmx : \
     parsing/location.cmx \
     middle_end/linkage_name.cmx \
     typing/ident.cmx \
+    utils/format_doc.cmx \
     middle_end/flambda/export_info.cmx \
     middle_end/compilation_unit.cmx \
     file_formats/cmxs_format.cmi \
@@ -7499,6 +7667,7 @@ debugger/command_line.cmo : \
     debugger/input_handling.cmi \
     debugger/history.cmi \
     debugger/frames.cmi \
+    utils/format_doc.cmi \
     debugger/events.cmi \
     debugger/eval.cmi \
     typing/envaux.cmi \
@@ -7538,6 +7707,7 @@ debugger/command_line.cmx : \
     debugger/input_handling.cmx \
     debugger/history.cmx \
     debugger/frames.cmx \
+    utils/format_doc.cmx \
     debugger/events.cmx \
     debugger/eval.cmx \
     typing/envaux.cmx \
@@ -7614,6 +7784,7 @@ debugger/eval.cmo : \
     bytecomp/instruct.cmi \
     typing/ident.cmi \
     debugger/frames.cmi \
+    utils/format_doc.cmi \
     debugger/events.cmi \
     typing/env.cmi \
     debugger/debugcom.cmi \
@@ -7634,6 +7805,7 @@ debugger/eval.cmx : \
     bytecomp/instruct.cmx \
     typing/ident.cmx \
     debugger/frames.cmx \
+    utils/format_doc.cmx \
     debugger/events.cmx \
     typing/env.cmx \
     debugger/debugcom.cmx \
@@ -7722,6 +7894,7 @@ debugger/loadprinter.cmo : \
     parsing/longident.cmi \
     utils/load_path.cmi \
     typing/ident.cmi \
+    utils/format_doc.cmi \
     typing/env.cmi \
     otherlibs/dynlink/dynlink.cmi \
     typing/ctype.cmi \
@@ -7739,6 +7912,7 @@ debugger/loadprinter.cmx : \
     parsing/longident.cmx \
     utils/load_path.cmx \
     typing/ident.cmx \
+    utils/format_doc.cmx \
     typing/env.cmx \
     otherlibs/dynlink/dynlink.cmi \
     typing/ctype.cmx \
@@ -7761,6 +7935,7 @@ debugger/main.cmo : \
     utils/load_path.cmi \
     debugger/input_handling.cmi \
     debugger/frames.cmi \
+    utils/format_doc.cmi \
     debugger/exec.cmi \
     debugger/debugger_config.cmi \
     utils/config.cmi \
@@ -7784,6 +7959,7 @@ debugger/main.cmx : \
     utils/load_path.cmx \
     debugger/input_handling.cmx \
     debugger/frames.cmx \
+    utils/format_doc.cmx \
     debugger/exec.cmx \
     debugger/debugger_config.cmx \
     utils/config.cmx \
@@ -8125,6 +8301,7 @@ ocamldoc/odoc_analyse.cmo : \
     ocamldoc/odoc_ast.cmi \
     parsing/location.cmi \
     parsing/lexer.cmi \
+    utils/format_doc.cmi \
     typing/env.cmi \
     driver/compmisc.cmi \
     utils/clflags.cmi \
@@ -8153,6 +8330,7 @@ ocamldoc/odoc_analyse.cmx : \
     ocamldoc/odoc_ast.cmx \
     parsing/location.cmx \
     parsing/lexer.cmx \
+    utils/format_doc.cmx \
     typing/env.cmx \
     driver/compmisc.cmx \
     utils/clflags.cmx \

--- a/Changes
+++ b/Changes
@@ -220,6 +220,10 @@ _______________
   platforms (Linux, *BSD).
   (Miod Vallat, review by Nicolás Ojeda Bär)
 
+- #13169: Introduce a document data type for compiler messages rather than
+  relying on `Format.formatter -> unit` closures.
+  (Florian Angeletti, review by Gabriel Scherer)
+
 - #13193: Remove the unused env_init field from class blocks
   (Vincent Laviron, review by Jacques Garrigue)
 

--- a/Makefile
+++ b/Makefile
@@ -63,6 +63,7 @@ expunge := expunge$(EXE)
 utils_SOURCES = $(addprefix utils/, \
   config.mli config.ml \
   build_path_prefix_map.mli build_path_prefix_map.ml \
+  format_doc.mli format_doc.ml \
   misc.mli misc.ml \
   identifiable.mli identifiable.ml \
   numbers.mli numbers.ml \
@@ -2202,6 +2203,7 @@ ocamlprof_LIBRARIES =
 ocamlprof_SOURCES = \
   config.mli config.ml \
   build_path_prefix_map.mli build_path_prefix_map.ml \
+  format_doc.mli format_doc.ml \
   misc.mli misc.ml \
   identifiable.mli identifiable.ml \
   numbers.mli numbers.ml \
@@ -2228,6 +2230,7 @@ ocamlprof_SOURCES = \
 ocamlcp_ocamloptp_SOURCES = \
   config.mli config.ml \
   build_path_prefix_map.mli build_path_prefix_map.ml \
+  format_doc.mli format_doc.ml \
   misc.mli misc.ml \
   profile.mli profile.ml \
   warnings.mli warnings.ml \
@@ -2255,6 +2258,7 @@ ocamlmklib_LIBRARIES =
 ocamlmklib_SOURCES = \
   config.ml \
   build_path_prefix_map.ml \
+  format_doc.ml \
   misc.ml \
   ocamlmklib.mli ocamlmklib.ml
 
@@ -2264,6 +2268,7 @@ ocamlmktop_LIBRARIES =
 ocamlmktop_SOURCES = \
   config.mli config.ml \
   build_path_prefix_map.mli build_path_prefix_map.ml \
+  format_doc.mli format_doc.ml \
   misc.mli misc.ml \
   identifiable.mli identifiable.ml \
   numbers.mli numbers.ml \

--- a/asmcomp/asmgen.ml
+++ b/asmcomp/asmgen.ml
@@ -310,6 +310,7 @@ let compile_implementation_linear target =
 
 (* Error report *)
 module Style = Misc.Style
+let fprintf, dprintf = Format_doc.fprintf, Format_doc.dprintf
 
 let report_error ppf = function
   | Assembler_error file ->
@@ -317,8 +318,8 @@ let report_error ppf = function
         Location.print_filename file
   | Mismatched_for_pack saved ->
     let msg = function
-       | None -> Format.dprintf "without %a" Style.inline_code "-for-pack"
-       | Some s -> Format.dprintf "with %a" Style.inline_code ("-for-pack " ^ s)
+       | None -> dprintf "without %a" Style.inline_code "-for-pack"
+       | Some s -> dprintf "with %a" Style.inline_code ("-for-pack " ^ s)
      in
      fprintf ppf
        "This input file cannot be compiled %t: it was generated %t."

--- a/asmcomp/asmgen.ml
+++ b/asmcomp/asmgen.ml
@@ -315,7 +315,7 @@ let fprintf, dprintf = Format_doc.fprintf, Format_doc.dprintf
 let report_error ppf = function
   | Assembler_error file ->
       fprintf ppf "Assembler error, input left in file %a"
-        Location.print_filename file
+        Location.Doc.quoted_filename file
   | Mismatched_for_pack saved ->
     let msg = function
        | None -> dprintf "without %a" Style.inline_code "-for-pack"

--- a/asmcomp/asmgen.mli
+++ b/asmcomp/asmgen.mli
@@ -45,7 +45,7 @@ type error =
   | Asm_generation of string * Emitaux.error
 
 exception Error of error
-val report_error: Format.formatter -> error -> unit
+val report_error: error Format_doc.printer
 
 val compile_unit
    : output_prefix:string

--- a/asmcomp/asmlibrarian.ml
+++ b/asmcomp/asmlibrarian.ml
@@ -84,7 +84,7 @@ let create_archive file_list lib_name =
     )
 
 module Style = Misc.Style
-open Format
+open Format_doc
 
 let report_error ppf = function
   | File_not_found name ->

--- a/asmcomp/asmlibrarian.ml
+++ b/asmcomp/asmlibrarian.ml
@@ -92,7 +92,7 @@ let report_error ppf = function
   | Archiver_error name ->
       fprintf ppf "Error while creating the library %a" Style.inline_code name
   | Link_error e ->
-      Linkdeps.report_error ~print_filename:Location.print_filename ppf e
+      Linkdeps.report_error ~print_filename:Location.Doc.filename ppf e
 
 let () =
   Location.register_error_of_exn

--- a/asmcomp/asmlibrarian.mli
+++ b/asmcomp/asmlibrarian.mli
@@ -15,8 +15,6 @@
 
 (* Build libraries of .cmx files *)
 
-open Format
-
 val create_archive: string list -> string -> unit
 
 type error =
@@ -26,4 +24,4 @@ type error =
 
 exception Error of error
 
-val report_error: formatter -> error -> unit
+val report_error: error Format_doc.printer

--- a/asmcomp/asmlink.ml
+++ b/asmcomp/asmlink.ml
@@ -359,8 +359,8 @@ let link ~ppf_dump objfiles output_name =
 
 (* Error report *)
 
-open Format
 module Style = Misc.Style
+open Format_doc
 
 let report_error ppf = function
   | File_not_found name ->

--- a/asmcomp/asmlink.ml
+++ b/asmcomp/asmlink.ml
@@ -367,24 +367,24 @@ let report_error ppf = function
       fprintf ppf "Cannot find file %a" Style.inline_code name
   | Not_an_object_file name ->
       fprintf ppf "The file %a is not a compilation unit description"
-        (Style.as_inline_code Location.print_filename) name
+        Location.Doc.quoted_filename name
   | Inconsistent_interface(intf, file1, file2) ->
       fprintf ppf
        "@[<hov>Files %a@ and %a@ make inconsistent assumptions \
               over interface %a@]"
-       (Style.as_inline_code Location.print_filename) file1
-       (Style.as_inline_code Location.print_filename) file2
+       Location.Doc.quoted_filename file1
+       Location.Doc.quoted_filename file2
        Style.inline_code intf
   | Inconsistent_implementation(intf, file1, file2) ->
       fprintf ppf
        "@[<hov>Files %a@ and %a@ make inconsistent assumptions \
               over implementation %a@]"
-       (Style.as_inline_code Location.print_filename) file1
-       (Style.as_inline_code Location.print_filename) file2
+       Location.Doc.quoted_filename file1
+       Location.Doc.quoted_filename file2
        Style.inline_code intf
   | Assembler_error file ->
       fprintf ppf "Error while assembling %a"
-        (Style.as_inline_code Location.print_filename) file
+        Location.Doc.quoted_filename file
   | Linking_error exitcode ->
       fprintf ppf "Error during linking (exit code %d)" exitcode
   | Missing_cmx(filename, name) ->
@@ -394,15 +394,15 @@ let report_error ppf = function
          which was produced by %a.@ \
          Please recompile %a@ with the correct %a option@ \
          so that %a@ is found.@]"
-        (Style.as_inline_code Location.print_filename) filename
+        Location.Doc.quoted_filename filename
         Style.inline_code ".cmx"
         Style.inline_code name
         Style.inline_code "ocamlopt -for-pack"
-        (Style.as_inline_code Location.print_filename) filename
+        Location.Doc.quoted_filename filename
         Style.inline_code "-I"
         Style.inline_code (name^".cmx")
   | Link_error e ->
-      Linkdeps.report_error ~print_filename:Location.print_filename ppf e
+      Linkdeps.report_error ~print_filename:Location.Doc.filename ppf e
 
 let () =
   Location.register_error_of_exn

--- a/asmcomp/asmlink.mli
+++ b/asmcomp/asmlink.mli
@@ -41,4 +41,4 @@ type error =
 
 exception Error of error
 
-val report_error: formatter -> error -> unit
+val report_error: error Format_doc.printer

--- a/asmcomp/asmpackager.ml
+++ b/asmcomp/asmpackager.ml
@@ -281,7 +281,7 @@ let package_files ~ppf_dump initial_env files targetcmx ~backend =
 
 (* Error report *)
 
-open Format
+open Format_doc
 module Style = Misc.Style
 
 let report_error ppf = function

--- a/asmcomp/asmpackager.ml
+++ b/asmcomp/asmpackager.ml
@@ -288,14 +288,14 @@ let report_error ppf = function
     Illegal_renaming(name, file, id) ->
       fprintf ppf "Wrong file naming: %a@ contains the code for\
                    @ %a when %a was expected"
-        (Style.as_inline_code Location.print_filename) file
+        Location.Doc.quoted_filename file
         Style.inline_code name Style.inline_code id
   | Forward_reference(file, ident) ->
       fprintf ppf "Forward reference to %a in file %a" Style.inline_code ident
-        (Style.as_inline_code Location.print_filename) file
+        Location.Doc.quoted_filename file
   | Wrong_for_pack(file, path) ->
       fprintf ppf "File %a@ was not compiled with the %a option"
-        (Style.as_inline_code Location.print_filename) file
+        Location.Doc.quoted_filename file
         Style.inline_code ("-for-pack " ^ path)
   | File_not_found file ->
       fprintf ppf "File %a not found" Style.inline_code file

--- a/asmcomp/asmpackager.mli
+++ b/asmcomp/asmpackager.mli
@@ -34,4 +34,4 @@ type error =
 
 exception Error of error
 
-val report_error: Format.formatter -> error -> unit
+val report_error: error Format_doc.printer

--- a/asmcomp/emitaux.ml
+++ b/asmcomp/emitaux.ml
@@ -459,7 +459,7 @@ let create_asm_file = ref true
 
 let report_error ppf = function
   | Stack_frame_too_large n ->
-      Format.fprintf ppf "stack frame too large (%d bytes)" n
+      Format_doc.fprintf ppf "stack frame too large (%d bytes)" n
 
 let mk_env f : Emitenv.per_function_env =
   {

--- a/asmcomp/emitaux.mli
+++ b/asmcomp/emitaux.mli
@@ -87,7 +87,7 @@ type error =
   | Stack_frame_too_large of int
 
 exception Error of error
-val report_error: Format.formatter -> error -> unit
+val report_error: error Format_doc.printer
 
 val mk_env : Linear.fundecl -> Emitenv.per_function_env
 

--- a/asmcomp/polling.ml
+++ b/asmcomp/polling.ml
@@ -18,7 +18,7 @@
 (**************************************************************************)
 
 open Mach
-open Format
+open Format_doc
 
 module Int = Numbers.Int
 module String = Misc.Stdlib.String

--- a/asmcomp/polling.ml
+++ b/asmcomp/polling.ml
@@ -316,7 +316,7 @@ let report_error ppf = function
           | Poll -> ()
           | Alloc | Function_call | External_call ->
             fprintf ppf "\t%s at " (instr_type p);
-            Location.print_loc ppf (Debuginfo.to_location dbg);
+            Location.Doc.loc ppf (Debuginfo.to_location dbg);
             fprintf ppf "\n"
           end
         ) instrs;

--- a/bytecomp/bytelibrarian.ml
+++ b/bytecomp/bytelibrarian.ml
@@ -121,7 +121,7 @@ let create_archive file_list lib_name =
        output_binary_int outchan pos_toc;
     )
 
-open Format
+open Format_doc
 module Style = Misc.Style
 
 let report_error ppf = function

--- a/bytecomp/bytelibrarian.ml
+++ b/bytecomp/bytelibrarian.ml
@@ -129,9 +129,9 @@ let report_error ppf = function
       fprintf ppf "Cannot find file %a" Style.inline_code name
   | Not_an_object_file name ->
       fprintf ppf "The file %a is not a bytecode object file"
-        (Style.as_inline_code Location.print_filename) name
+        Location.Doc.quoted_filename name
   | Link_error e ->
-      Linkdeps.report_error ~print_filename:Location.print_filename ppf e
+      Linkdeps.report_error ~print_filename:Location.Doc.filename ppf e
 
 let () =
   Location.register_error_of_exn

--- a/bytecomp/bytelibrarian.mli
+++ b/bytecomp/bytelibrarian.mli
@@ -31,8 +31,5 @@ type error =
 
 exception Error of error
 
-open Format
-
-val report_error: formatter -> error -> unit
-
+val report_error: error Format_doc.printer
 val reset: unit -> unit

--- a/bytecomp/bytelink.ml
+++ b/bytecomp/bytelink.ml
@@ -868,7 +868,7 @@ extern "C" {
 
 (* Error report *)
 
-open Format
+open Format_doc
 module Style = Misc.Style
 
 let report_error ppf = function

--- a/bytecomp/bytelink.ml
+++ b/bytecomp/bytelink.ml
@@ -874,39 +874,39 @@ module Style = Misc.Style
 let report_error ppf = function
   | File_not_found name ->
       fprintf ppf "Cannot find file %a"
-        (Style.as_inline_code Location.print_filename) name
+        Location.Doc.quoted_filename name
   | Not_an_object_file name ->
       fprintf ppf "The file %a is not a bytecode object file"
-        (Style.as_inline_code Location.print_filename) name
+        Location.Doc.quoted_filename name
   | Wrong_object_name name ->
       fprintf ppf "The output file %a has the wrong name. The extension implies\
                   \ an object file but the link step was requested"
         Style.inline_code name
   | Symbol_error(name, err) ->
       fprintf ppf "Error while linking %a:@ %a"
-        (Style.as_inline_code Location.print_filename) name
+        Location.Doc.quoted_filename name
         Symtable.report_error err
   | Inconsistent_import(intf, file1, file2) ->
       fprintf ppf
         "@[<hov>Files %a@ and %a@ \
                  make inconsistent assumptions over interface %a@]"
-        (Style.as_inline_code Location.print_filename) file1
-        (Style.as_inline_code Location.print_filename) file2
+        Location.Doc.quoted_filename file1
+        Location.Doc.quoted_filename file2
         Style.inline_code intf
   | Custom_runtime ->
       fprintf ppf "Error while building custom runtime system"
   | File_exists file ->
       fprintf ppf "Cannot overwrite existing file %a"
-        (Style.as_inline_code Location.print_filename) file
+        Location.Doc.quoted_filename file
   | Cannot_open_dll file ->
       fprintf ppf "Error on dynamically loaded library: %a"
-        Location.print_filename file
+        Location.Doc.filename file
   | Camlheader (msg, header) ->
       fprintf ppf "System error while copying file %a: %a"
         Style.inline_code header
         Style.inline_code msg
   | Link_error e ->
-      Linkdeps.report_error ~print_filename:Location.print_filename ppf e
+      Linkdeps.report_error ~print_filename:Location.Doc.filename ppf e
 
 let () =
   Location.register_error_of_exn

--- a/bytecomp/bytelink.mli
+++ b/bytecomp/bytelink.mli
@@ -44,6 +44,4 @@ type error =
 
 exception Error of error
 
-open Format
-
-val report_error: formatter -> error -> unit
+val report_error: error Format_doc.printer

--- a/bytecomp/bytepackager.ml
+++ b/bytecomp/bytepackager.ml
@@ -344,7 +344,7 @@ let package_files ~ppf_dump initial_env files targetfile =
 
 (* Error report *)
 
-open Format
+open Format_doc
 module Style = Misc.Style
 
 let report_error ppf = function

--- a/bytecomp/bytepackager.ml
+++ b/bytecomp/bytepackager.ml
@@ -351,18 +351,18 @@ let report_error ppf = function
     Forward_reference(file, compunit) ->
       fprintf ppf "Forward reference to %a in file %a"
         Style.inline_code (Compunit.name compunit)
-        (Style.as_inline_code Location.print_filename) file
+        Location.Doc.quoted_filename file
   | Multiple_definition(file, compunit) ->
       fprintf ppf "File %a redefines %a"
-        (Style.as_inline_code Location.print_filename) file
+        Location.Doc.quoted_filename file
         Style.inline_code (Compunit.name compunit)
   | Not_an_object_file file ->
       fprintf ppf "%a is not a bytecode object file"
-        (Style.as_inline_code Location.print_filename) file
+        Location.Doc.quoted_filename file
   | Illegal_renaming(name, file, id) ->
       fprintf ppf "Wrong file naming: %a@ contains the code for\
                    @ %a when %a was expected"
-        (Style.as_inline_code Location.print_filename) file
+        Location.Doc.quoted_filename file
         Style.inline_code (Compunit.name name)
         Style.inline_code (Compunit.name id)
   | File_not_found file ->

--- a/bytecomp/bytepackager.mli
+++ b/bytecomp/bytepackager.mli
@@ -28,4 +28,4 @@ type error =
 
 exception Error of error
 
-val report_error: Format.formatter -> error -> unit
+val report_error: error Format_doc.printer

--- a/bytecomp/emitcode.ml
+++ b/bytecomp/emitcode.ml
@@ -38,7 +38,7 @@ let marshal_to_channel_with_possibly_32bit_compat ~filename ~kind outchan obj =
 
 
 let report_error ppf (file, kind) =
-  Format.fprintf ppf "Generated %s %S cannot be used on a 32-bit platform"
+  Format_doc.fprintf ppf "Generated %s %S cannot be used on a 32-bit platform"
                      kind file
 let () =
   Location.register_error_of_exn

--- a/bytecomp/symtable.ml
+++ b/bytecomp/symtable.ml
@@ -52,9 +52,10 @@ module Global = struct
 
   let description ppf = function
     | Glob_compunit (Compunit cu) ->
-        Format.fprintf ppf "compilation unit %a" Style.inline_code (quote cu)
+        Format_doc.fprintf ppf "compilation unit %a"
+          Style.inline_code (quote cu)
     | Glob_predef (Predef_exn exn) ->
-        Format.fprintf ppf "predefined exception %a"
+        Format_doc.fprintf ppf "predefined exception %a"
           Style.inline_code (quote exn)
 
   let of_ident id =
@@ -435,7 +436,7 @@ let empty_global_map = GlobalMap.empty
 
 (* Error report *)
 
-open Format
+open Format_doc
 
 let report_error ppf = function
   | Undefined_global global ->

--- a/bytecomp/symtable.mli
+++ b/bytecomp/symtable.mli
@@ -37,7 +37,7 @@ module Global : sig
     | Glob_compunit of compunit
     | Glob_predef of predef
   val name: t -> string
-  val description: Format.formatter -> t -> unit
+  val description: t Format_doc.printer
   val of_ident: Ident.t -> t option
   module Set : Set.S with type elt = t
   module Map : Map.S with type key = t
@@ -90,8 +90,6 @@ type error =
 
 exception Error of error
 
-open Format
-
-val report_error: formatter -> error -> unit
+val report_error: error Format_doc.printer
 
 val reset: unit -> unit

--- a/debugger/command_line.ml
+++ b/debugger/command_line.ml
@@ -516,7 +516,7 @@ let print_command depth ppf lexbuf =
       env_of_event !selected_event
     with
     | Envaux.Error msg ->
-        Envaux.report_error ppf msg;
+        Format_doc.compat Envaux.report_error ppf msg;
         raise Toplevel
   in
   List.iter (print_expr depth !selected_event env ppf) exprs
@@ -533,7 +533,7 @@ let instr_address ppf lexbuf =
       env_of_event !selected_event
     with
     | Envaux.Error msg ->
-        Envaux.report_error ppf msg;
+        Format_doc.compat Envaux.report_error ppf msg;
         raise Toplevel
   in
   let print_addr expr =
@@ -622,7 +622,7 @@ let instr_break ppf lexbuf =
             env_of_event !selected_event
           with
           | Envaux.Error msg ->
-              Envaux.report_error ppf msg;
+              Format_doc.compat Envaux.report_error ppf msg;
               raise Toplevel
         in
         begin try

--- a/debugger/eval.ml
+++ b/debugger/eval.ml
@@ -187,25 +187,28 @@ and find_label lbl env ty path tydesc pos = function
 open Format
 module Style = Misc.Style
 
+let as_inline_code pr = Format_doc.compat @@ Style.as_inline_code pr
+let inline_code = Format_doc.compat Style.inline_code
+
 let report_error ppf = function
   | Unbound_identifier id ->
       fprintf ppf "@[Unbound identifier %a@]@."
-        Style.inline_code (Ident.name id)
+        inline_code (Ident.name id)
   | Not_initialized_yet path ->
       fprintf ppf
         "@[The module path %a is not yet initialized.@ \
            Please run program forward@ \
            until its initialization code is executed.@]@."
-      (Style.as_inline_code Printtyp.path) path
+      (as_inline_code Printtyp.path) path
   | Unbound_long_identifier lid ->
       fprintf ppf "@[Unbound identifier %a@]@."
-        (Style.as_inline_code Printtyp.longident) lid
+        (as_inline_code Printtyp.longident) lid
   | Unknown_name n ->
       fprintf ppf "@[Unknown value name $%i@]@." n
   | Tuple_index(ty, len, pos) ->
       fprintf ppf
         "@[Cannot extract field number %i from a %i-tuple of type@ %a@]@."
-        pos len (Style.as_inline_code Printtyp.type_expr) ty
+        pos len (as_inline_code Printtyp.type_expr) ty
   | Array_index(len, pos) ->
       fprintf ppf
         "@[Cannot extract element number %i from an array of length %i@]@."
@@ -222,15 +225,15 @@ let report_error ppf = function
   | Wrong_item_type(ty, pos) ->
       fprintf ppf
         "@[Cannot extract item number %i from a value of type@ %a@]@."
-        pos (Style.as_inline_code Printtyp.type_expr) ty
+        pos (as_inline_code Printtyp.type_expr) ty
   | Wrong_label(ty, lbl) ->
       fprintf ppf
         "@[The record type@ %a@ has no label named %a@]@."
-        (Style.as_inline_code Printtyp.type_expr) ty
-        Style.inline_code lbl
+        (as_inline_code Printtyp.type_expr) ty
+        inline_code lbl
   | Not_a_record ty ->
       fprintf ppf
         "@[The type@ %a@ is not a record type@]@."
-        (Style.as_inline_code Printtyp.type_expr) ty
+        (as_inline_code Printtyp.type_expr) ty
   | No_result ->
       fprintf ppf "@[No result available at current program event@]@."

--- a/debugger/loadprinter.ml
+++ b/debugger/loadprinter.ml
@@ -140,6 +140,8 @@ let remove_printer lid =
 
 open Format
 module Style = Misc.Style
+let quoted_longident =
+  Format_doc.compat @@ Style.as_inline_code Printtyp.longident
 
 let report_error ppf = function
   | Load_failure e ->
@@ -147,15 +149,15 @@ let report_error ppf = function
         (Dynlink.error_message e)
   | Unbound_identifier lid ->
       fprintf ppf "@[Unbound identifier %a@]@."
-      (Style.as_inline_code Printtyp.longident) lid
+        quoted_longident lid
   | Unavailable_module(md, lid) ->
       fprintf ppf
         "@[The debugger does not contain the code for@ %a.@ \
-           Please load an implementation of %s first.@]@."
-        (Style.as_inline_code Printtyp.longident) lid md
+         Please load an implementation of %s first.@]@."
+        quoted_longident lid md
   | Wrong_type lid ->
       fprintf ppf "@[%a has the wrong type for a printing function.@]@."
-      (Style.as_inline_code Printtyp.longident) lid
+        quoted_longident lid
   | No_active_printer lid ->
       fprintf ppf "@[%a is not currently active as a printing function.@]@."
-      (Style.as_inline_code Printtyp.longident) lid
+        quoted_longident lid

--- a/debugger/main.ml
+++ b/debugger/main.ml
@@ -233,8 +233,8 @@ let main () =
   | Toplevel ->
       exit 2
   | Persistent_env.Error e ->
-      report Persistent_env.report_error e;
+      report (Format_doc.compat Persistent_env.report_error) e;
       exit 2
   | Cmi_format.Error e ->
-      report Cmi_format.report_error e;
+      report (Format_doc.compat Cmi_format.report_error) e;
       exit 2

--- a/debugger/printval.ml
+++ b/debugger/printval.ml
@@ -17,6 +17,7 @@
 (* To print values *)
 
 open Format
+module Printtyp=Printtyp.Compat
 open Parser_aux
 open Types
 

--- a/driver/pparse.ml
+++ b/driver/pparse.ml
@@ -13,7 +13,7 @@
 (*                                                                        *)
 (**************************************************************************)
 
-open Format
+open Format_doc
 
 type error =
   | CannotRun of string

--- a/driver/pparse.mli
+++ b/driver/pparse.mli
@@ -20,8 +20,6 @@
 
 *)
 
-open Format
-
 type error =
   | CannotRun of string
   | WrongMagic of string
@@ -53,7 +51,7 @@ val apply_rewriters_sig:
   ?restore:bool -> tool_name:string -> Parsetree.signature ->
   Parsetree.signature
 
-val report_error : formatter -> error -> unit
+val report_error : error Format_doc.printer
 
 
 val parse_implementation:

--- a/dune
+++ b/dune
@@ -42,10 +42,11 @@
    annot asttypes cmo_format outcometree parsetree value_rec_types)
  (modules
    ;; UTILS
-   config build_path_prefix_map misc identifiable numbers arg_helper clflags
-   profile terminfo ccomp warnings consistbl strongly_connected_components
-   targetint load_path int_replace_polymorphic_compare binutils local_store
-   lazy_backtrack diffing diffing_with_keys unit_info compression linkdeps
+   config build_path_prefix_map misc identifiable numbers arg_helper
+   clflags profile terminfo ccomp format_doc warnings consistbl
+   strongly_connected_components targetint load_path
+   int_replace_polymorphic_compare binutils local_store lazy_backtrack diffing
+   diffing_with_keys unit_info compression linkdeps
 
    ;; PARSING
    location longident docstrings syntaxerr ast_helper camlinternalMenhirLib

--- a/file_formats/cmi_format.ml
+++ b/file_formats/cmi_format.ml
@@ -94,7 +94,7 @@ let output_cmi filename oc cmi =
 
 (* Error report *)
 
-open Format
+open Format_doc
 module Style = Misc.Style
 
 let report_error ppf = function

--- a/file_formats/cmi_format.ml
+++ b/file_formats/cmi_format.ml
@@ -95,20 +95,19 @@ let output_cmi filename oc cmi =
 (* Error report *)
 
 open Format_doc
-module Style = Misc.Style
 
 let report_error ppf = function
   | Not_an_interface filename ->
       fprintf ppf "%a@ is not a compiled interface"
-        (Style.as_inline_code Location.print_filename) filename
+        Location.Doc.quoted_filename filename
   | Wrong_version_interface (filename, older_newer) ->
       fprintf ppf
         "%a@ is not a compiled interface for this version of OCaml.@.\
          It seems to be for %s version of OCaml."
-        (Style.as_inline_code  Location.print_filename) filename older_newer
+        Location.Doc.quoted_filename filename older_newer
   | Corrupted_interface filename ->
       fprintf ppf "Corrupted compiled interface@ %a"
-        (Style.as_inline_code Location.print_filename) filename
+        Location.Doc.quoted_filename filename
 
 let () =
   Location.register_error_of_exn

--- a/file_formats/cmi_format.mli
+++ b/file_formats/cmi_format.mli
@@ -45,6 +45,4 @@ type error =
 
 exception Error of error
 
-open Format
-
-val report_error: formatter -> error -> unit
+val report_error: error Format_doc.printer

--- a/file_formats/linear_format.ml
+++ b/file_formats/linear_format.ml
@@ -76,7 +76,7 @@ let restore filename =
 
 (* Error report *)
 
-open Format
+open Format_doc
 module Style=Misc.Style
 
 let report_error ppf = function

--- a/file_formats/linear_format.ml
+++ b/file_formats/linear_format.ml
@@ -77,22 +77,21 @@ let restore filename =
 (* Error report *)
 
 open Format_doc
-module Style=Misc.Style
 
 let report_error ppf = function
   | Wrong_format filename ->
       fprintf ppf "Expected Linear format. Incompatible file %a"
-        (Style.as_inline_code Location.print_filename) filename
+         Location.Doc.quoted_filename filename
   | Wrong_version filename ->
       fprintf ppf
         "%a@ is not compatible with this version of OCaml"
-        (Style.as_inline_code Location.print_filename) filename
+        Location.Doc.quoted_filename filename
   | Corrupted filename ->
       fprintf ppf "Corrupted format@ %a"
-        (Style.as_inline_code Location.print_filename) filename
+        Location.Doc.quoted_filename filename
   | Marshal_failed filename ->
       fprintf ppf "Failed to marshal Linear to file@ %a"
-        (Style.as_inline_code Location.print_filename) filename
+         Location.Doc.quoted_filename filename
 
 let () =
   Location.register_error_of_exn

--- a/lambda/debuginfo.ml
+++ b/lambda/debuginfo.ml
@@ -216,7 +216,7 @@ let hash t =
 let rec print_compact ppf t =
   let print_item item =
     Format.fprintf ppf "%a:%i"
-      Location.print_filename item.dinfo_file
+      Location.Compat.print_filename item.dinfo_file
       item.dinfo_line;
     if item.dinfo_char_start >= 0 then begin
       Format.fprintf ppf ",%i--%i" item.dinfo_char_start item.dinfo_char_end

--- a/lambda/debuginfo.ml
+++ b/lambda/debuginfo.ml
@@ -216,7 +216,7 @@ let hash t =
 let rec print_compact ppf t =
   let print_item item =
     Format.fprintf ppf "%a:%i"
-      Location.Compat.print_filename item.dinfo_file
+      Location.print_filename item.dinfo_file
       item.dinfo_line;
     if item.dinfo_char_start >= 0 then begin
       Format.fprintf ppf ",%i--%i" item.dinfo_char_start item.dinfo_char_end

--- a/lambda/matching.ml
+++ b/lambda/matching.ml
@@ -93,7 +93,7 @@ open Types
 open Typedtree
 open Lambda
 open Parmatch
-open Printpat
+open Printpat.Compat
 
 module Scoped_location = Debuginfo.Scoped_location
 
@@ -3022,7 +3022,7 @@ let mk_failaction_pos partial seen ctx defs =
       Default_environment.pp defs
       Context.pp ctx
       (Format.pp_print_list ~pp_sep:Format.pp_print_cut
-         Printpat.pretty_pat) input_fail_pats
+         Printpat.Compat.pretty_pat) input_fail_pats
       pp_partial (Jumps.partial jumps)
       Jumps.pp jumps
     ;

--- a/lambda/printlambda.ml
+++ b/lambda/printlambda.ml
@@ -112,7 +112,7 @@ let record_rep ppf r =
   | Record_unboxed false -> fprintf ppf "unboxed"
   | Record_unboxed true -> fprintf ppf "inlined(unboxed)"
   | Record_float -> fprintf ppf "float"
-  | Record_extension path -> fprintf ppf "ext(%a)" Printtyp.path path
+  | Record_extension path -> fprintf ppf "ext(%a)" Printtyp.Compat.path path
 
 let block_shape ppf shape = match shape with
   | None | Some [] -> ()

--- a/lambda/tmc.ml
+++ b/lambda/tmc.ml
@@ -1003,7 +1003,7 @@ let () =
                Ambiguous_constructor_arguments
                  { explicit = false; arguments }) ->
           let print_msg ppf =
-            Format.fprintf ppf
+            Format_doc.fprintf ppf
               "%a:@ this@ constructor@ application@ may@ be@ \
                TMC-transformed@ in@ several@ different@ ways.@ \
                Please@ disambiguate@ by@ adding@ an@ explicit@ %a \
@@ -1028,7 +1028,7 @@ let () =
                Ambiguous_constructor_arguments
                  { explicit = true; arguments }) ->
           let print_msg ppf =
-            Format.fprintf ppf
+            Format_doc.fprintf ppf
               "%a:@ this@ constructor@ application@ may@ be@ \
                TMC-transformed@ in@ several@ different@ ways.@ Only@ one@ of@ \
                the@ arguments@ may@ become@ a@ TMC@ call,@ but@ several@ \

--- a/lambda/translclass.ml
+++ b/lambda/translclass.ml
@@ -986,7 +986,7 @@ let () =
 
 (* Error report *)
 
-open Format
+open Format_doc
 module Style = Misc.Style
 
 let report_error ppf = function

--- a/lambda/translclass.mli
+++ b/lambda/translclass.mli
@@ -26,6 +26,4 @@ type error = Tags of string * string
 
 exception Error of Location.t * error
 
-open Format
-
-val report_error: formatter -> error -> unit
+val report_error: error Format_doc.printer

--- a/lambda/translcore.ml
+++ b/lambda/translcore.ml
@@ -1313,7 +1313,7 @@ let transl_let rec_flag pat_expr_list body =
 
 (* Error report *)
 
-open Format
+open Format_doc
 
 let report_error ppf = function
   | Free_super_var ->

--- a/lambda/translcore.mli
+++ b/lambda/translcore.mli
@@ -45,9 +45,7 @@ type error =
 
 exception Error of Location.t * error
 
-open Format
-
-val report_error: formatter -> error -> unit
+val report_error: error Format_doc.printer
 
 (* Forward declaration -- to be filled in by Translmod.transl_module *)
 val transl_module :

--- a/lambda/translmod.ml
+++ b/lambda/translmod.ml
@@ -1657,14 +1657,14 @@ let transl_store_package component_names target_name coercion =
 
 (* Error report *)
 
-open Format
+open Format_doc
 module Style = Misc.Style
 
 let print_cycle ppf cycle =
-  let print_ident ppf (x,_) = Format.pp_print_string ppf (Ident.name x) in
+  let print_ident ppf (x,_) = pp_print_string ppf (Ident.name x) in
   let pp_sep ppf () = fprintf ppf "@ -> " in
-  Format.fprintf ppf "%a%a%s"
-    (Format.pp_print_list ~pp_sep print_ident) cycle
+  fprintf ppf "%a%a%s"
+    (pp_print_list ~pp_sep print_ident) cycle
     pp_sep ()
     (Ident.name @@ fst @@ List.hd cycle)
 (* we repeat the first element to make the cycle more apparent *)
@@ -1674,7 +1674,7 @@ let explanation_submsg (id, unsafe_info) =
   | Unnamed -> assert false (* can't be part of a cycle. *)
   | Unsafe {reason;loc;subid} ->
       let print fmt =
-        let printer = Format.dprintf fmt
+        let printer = doc_printf fmt
             Style.inline_code (Ident.name id)
             Style.inline_code (Ident.name subid) in
         Location.mkloc printer loc in

--- a/lambda/translprim.ml
+++ b/lambda/translprim.ml
@@ -870,7 +870,7 @@ let transl_primitive_application loc p env ty path exp args arg_exps =
 
 (* Error report *)
 
-open Format
+open Format_doc
 module Style = Misc.Style
 
 let report_error ppf = function

--- a/lambda/translprim.mli
+++ b/lambda/translprim.mli
@@ -49,6 +49,4 @@ type error =
 
 exception Error of Location.t * error
 
-open Format
-
-val report_error : formatter -> error -> unit
+val report_error :  error Format_doc.printer

--- a/manual/tests/Makefile
+++ b/manual/tests/Makefile
@@ -15,7 +15,7 @@ tools: cross-reference-checker
 
 cross-reference-checker: cross_reference_checker.ml
 	$(OCAMLC) $(ROOTDIR)/compilerlibs/ocamlcommon.cma \
-	  -I $(ROOTDIR)/parsing -I $(ROOTDIR)/driver \
+	  -I $(ROOTDIR)/utils -I $(ROOTDIR)/parsing -I $(ROOTDIR)/driver \
 	  $< -o $@
 
 # check cross-references between the manual and error messages

--- a/manual/tests/cross_reference_checker.ml
+++ b/manual/tests/cross_reference_checker.ml
@@ -27,8 +27,8 @@ type error =
   | No_aux_file
   | Wrong_attribute_payload of Location.t
 
-let pp_ref ppf = Format.pp_print_list ~pp_sep:( fun ppf () ->
-    Format.pp_print_string ppf ".") Format.pp_print_int ppf
+let pp_ref ppf = Format_doc.pp_print_list ~pp_sep:( fun ppf () ->
+    Format_doc.pp_print_string ppf ".") Format_doc.pp_print_int ppf
 
 let print_error error =
   Location.print_report Format.std_formatter @@ match error with

--- a/middle_end/backend_var.ml
+++ b/middle_end/backend_var.ml
@@ -29,7 +29,7 @@ module Provenance = struct
     let printf fmt = Format.fprintf ppf fmt in
     printf "@[<hov 1>(";
     printf "@[<hov 1>(module_path@ %a)@]@ "
-      Path.print module_path;
+      (Format_doc.compat Path.print) module_path;
     if !Clflags.locations then
       printf "@[<hov 1>(location@ %a)@]@ "
         Debuginfo.print_compact location;

--- a/middle_end/compilenv.ml
+++ b/middle_end/compilenv.ml
@@ -452,7 +452,7 @@ let require_global global_ident =
 
 (* Error report *)
 
-open Format
+open Format_doc
 module Style = Misc.Style
 
 let report_error ppf = function

--- a/middle_end/compilenv.ml
+++ b/middle_end/compilenv.ml
@@ -458,26 +458,26 @@ module Style = Misc.Style
 let report_error ppf = function
   | Not_a_unit_info filename ->
       fprintf ppf "%a@ is not a compilation unit description."
-        (Style.as_inline_code Location.print_filename) filename
+        Location.Doc.quoted_filename filename
   | Corrupted_unit_info filename ->
       fprintf ppf "Corrupted compilation unit description@ %a"
-        (Style.as_inline_code Location.print_filename) filename
+       Location.Doc.quoted_filename filename
   | Illegal_renaming(name, modname, filename) ->
       fprintf ppf "%a@ contains the description for unit\
                    @ %a when %a was expected"
-        (Style.as_inline_code Location.print_filename) filename
+        Location.Doc.quoted_filename filename
         Style.inline_code name
         Style.inline_code modname
   | Mismatching_for_pack(filename, pack_1, current_unit, None) ->
       fprintf ppf "%a@ was built with %a, but the \
                    @ current unit %a is not"
-        (Style.as_inline_code Location.print_filename) filename
+        Location.Doc.quoted_filename filename
         Style.inline_code ("-for-pack " ^ pack_1)
         Style.inline_code current_unit
   | Mismatching_for_pack(filename, pack_1, current_unit, Some pack_2) ->
       fprintf ppf "%a@ was built with %a, but the \
                    @ current unit %a is built with %a"
-        (Style.as_inline_code Location.print_filename) filename
+        Location.Doc.quoted_filename filename
         Style.inline_code ("-for-pack " ^ pack_1)
         Style.inline_code current_unit
         Style.inline_code ("-for-pack " ^ pack_2)

--- a/middle_end/compilenv.mli
+++ b/middle_end/compilenv.mli
@@ -158,4 +158,4 @@ type error =
 
 exception Error of error
 
-val report_error: Format.formatter -> error -> unit
+val report_error: error Format_doc.printer

--- a/ocamldoc/odoc_analyse.ml
+++ b/ocamldoc/odoc_analyse.ml
@@ -51,7 +51,7 @@ let preprocess sourcefile =
     Pparse.preprocess sourcefile
   with Pparse.Error err ->
     Format.eprintf "Preprocessing error@.%a@."
-      Pparse.report_error err;
+      (Format_doc.compat Pparse.report_error) err;
     exit 2
 
 (** Analysis of an implementation file. Returns (Some typedtree) if

--- a/ocamldoc/odoc_print.ml
+++ b/ocamldoc/odoc_print.ml
@@ -15,6 +15,7 @@
 
 open Format
 let () = Printtyp.Naming_context.enable false
+module Printtyp = Printtyp.Compat
 
 let new_fmt () =
   let buf = Buffer.create 512 in

--- a/ocamldoc/odoc_str.ml
+++ b/ocamldoc/odoc_str.ml
@@ -17,6 +17,7 @@
 
 module Name = Odoc_name
 let () = Printtyp.Naming_context.enable false
+module Printtyp = Printtyp.Compat
 
 let string_of_variance t v =
   if ( t.Odoc_type.ty_kind = Odoc_type.Type_abstract ||

--- a/ocamltest/tsl_semantics.ml
+++ b/ocamltest/tsl_semantics.ml
@@ -20,7 +20,7 @@ open Tsl_ast
 let string_of_location loc =
   let buf = Buffer.create 64 in
   let fmt = Format.formatter_of_buffer buf in
-  Location.print_loc fmt loc;
+  Location.Compat.print_loc fmt loc;
   Format.pp_print_flush fmt ();
   Buffer.contents buf
 

--- a/ocamltest/tsl_semantics.ml
+++ b/ocamltest/tsl_semantics.ml
@@ -20,7 +20,7 @@ open Tsl_ast
 let string_of_location loc =
   let buf = Buffer.create 64 in
   let fmt = Format.formatter_of_buffer buf in
-  Location.Compat.print_loc fmt loc;
+  Location.print_loc fmt loc;
   Format.pp_print_flush fmt ();
   Buffer.contents buf
 

--- a/otherlibs/dynlink/Makefile
+++ b/otherlibs/dynlink/Makefile
@@ -75,6 +75,7 @@ COMPILERLIBS_SOURCES=\
   utils/binutils.ml \
   utils/config.ml \
   utils/build_path_prefix_map.ml \
+  utils/format_doc.ml \
   utils/misc.ml \
   utils/identifiable.ml \
   utils/numbers.ml \
@@ -136,6 +137,7 @@ MINI_COMPILERLIBS_SOURCES=\
   utils/binutils.ml \
   utils/config.ml \
   utils/build_path_prefix_map.ml \
+  utils/format_doc.ml \
   utils/misc.ml
 
 # Rules to make a local copy of the .ml and .mli files required.  We also

--- a/otherlibs/dynlink/byte/dynlink.ml
+++ b/otherlibs/dynlink/byte/dynlink.ml
@@ -120,8 +120,8 @@ module Bytecode = struct
           let new_error : DT.linking_error =
             match error with
             | Symtable.Undefined_global global ->
-              Undefined_global
-                (Format.asprintf "%a" Symtable.Global.description global)
+              let desc = Format_doc.compat Symtable.Global.description in
+              Undefined_global (Format.asprintf "%a" desc global)
             | Symtable.Unavailable_primitive s -> Unavailable_primitive s
             | Symtable.Uninitialized_global global ->
               Uninitialized_global (Symtable.Global.name global)

--- a/parsing/ast_mapper.ml
+++ b/parsing/ast_mapper.ml
@@ -834,7 +834,7 @@ let default_mapper =
 let extension_of_error {kind; main; sub} =
   if kind <> Location.Report_error then
     raise (Invalid_argument "extension_of_error: expected kind Report_error");
-  let str_of_msg msg = Format.asprintf "%a" Format_doc.format msg in
+  let str_of_msg msg = Format.asprintf "%a" Format_doc.Doc.format msg in
   let extension_of_sub sub =
     { loc = sub.loc; txt = "ocaml.error" },
     PStr ([Str.eval (Exp.constant

--- a/parsing/ast_mapper.ml
+++ b/parsing/ast_mapper.ml
@@ -834,15 +834,15 @@ let default_mapper =
 let extension_of_error {kind; main; sub} =
   if kind <> Location.Report_error then
     raise (Invalid_argument "extension_of_error: expected kind Report_error");
-  let str_of_pp pp_msg = Format.asprintf "%t" pp_msg in
+  let str_of_msg msg = Format.asprintf "%a" Format_doc.format msg in
   let extension_of_sub sub =
     { loc = sub.loc; txt = "ocaml.error" },
     PStr ([Str.eval (Exp.constant
-                       (Const.string ~loc:sub.loc (str_of_pp sub.txt)))])
+                       (Const.string ~loc:sub.loc (str_of_msg sub.txt)))])
   in
   { loc = main.loc; txt = "ocaml.error" },
   PStr (Str.eval (Exp.constant
-                    (Const.string ~loc:main.loc (str_of_pp main.txt))) ::
+                    (Const.string ~loc:main.loc (str_of_msg main.txt))) ::
         List.map (fun msg -> Str.extension (extension_of_sub msg)) sub)
 
 let attribute_of_warning loc s =

--- a/parsing/attr_helper.ml
+++ b/parsing/attr_helper.ml
@@ -39,7 +39,7 @@ let has_no_payload_attribute alt_names attrs =
   | None   -> false
   | Some _ -> true
 
-open Format
+open Format_doc
 
 let report_error ppf = function
   | Multiple_attributes name ->

--- a/parsing/attr_helper.mli
+++ b/parsing/attr_helper.mli
@@ -35,4 +35,4 @@ val has_no_payload_attribute : string -> attributes -> bool
 
 exception Error of Location.t * error
 
-val report_error: Format.formatter -> error -> unit
+val report_error: error Format_doc.printer

--- a/parsing/builtin_attributes.ml
+++ b/parsing/builtin_attributes.ml
@@ -109,6 +109,7 @@ let string_of_opt_payload p =
   | Some s -> s
   | None -> ""
 
+module Style = Misc.Style
 let error_of_extension ext =
   let submessage_from main_loc main_txt = function
     | {pstr_desc=Pstr_extension
@@ -118,19 +119,18 @@ let error_of_extension ext =
                      ({pexp_desc=Pexp_constant
                            {pconst_desc=Pconst_string(msg, _, _); _}}, _)}
                ]) ->
-            { Location.loc; txt = fun ppf -> Format.pp_print_text ppf msg }
+            Location.msg ~loc "%a" Format_doc.pp_print_text msg
         | _ ->
-            { Location.loc; txt = fun ppf ->
-                Format.fprintf ppf
-                  "Invalid syntax for sub-message of extension '%s'." main_txt }
+            Location.msg ~loc "Invalid syntax for sub-message of extension %a."
+              Style.inline_code main_txt
         end
     | {pstr_desc=Pstr_extension (({txt; loc}, _), _)} ->
-        { Location.loc; txt = fun ppf ->
-            Format.fprintf ppf "Uninterpreted extension '%s'." txt }
+        Location.msg ~loc "Uninterpreted extension '%a'."
+          Style.inline_code txt
     | _ ->
-        { Location.loc = main_loc; txt = fun ppf ->
-            Format.fprintf ppf
-              "Invalid syntax for sub-message of extension '%s'." main_txt }
+        Location.msg ~loc:main_loc
+          "Invalid syntax for sub-message of extension %a."
+          Style.inline_code main_txt
   in
   match ext with
   | ({txt = ("ocaml.error"|"error") as txt; loc}, p) ->
@@ -141,7 +141,7 @@ let error_of_extension ext =
                       {pconst_desc=Pconst_string(msg, _, _)}}, _)}::
              inner) ->
           let sub = List.map (submessage_from loc txt) inner in
-          Location.error_of_printer ~loc ~sub Format.pp_print_text msg
+          Location.error_of_printer ~loc ~sub Format_doc.pp_print_text msg
       | _ ->
           Location.errorf ~loc "Invalid syntax for extension '%s'." txt
       end

--- a/parsing/lexer.mll
+++ b/parsing/lexer.mll
@@ -302,7 +302,7 @@ let comments () = List.rev !comment_list
 
 (* Error report *)
 
-open Format
+open Format_doc
 
 let prepare_error loc = function
   | Illegal_character c ->

--- a/parsing/location.ml
+++ b/parsing/location.ml
@@ -119,9 +119,9 @@ let echo_eof () =
   incr num_loc_lines
 
 (* This is used by the toplevel and the report printers below. *)
-let separate_new_message ppf =
+let separate_new_message ppf () =
   if not (is_first_message ()) then begin
-    Format.pp_print_newline ppf ();
+    Format_doc.pp_print_newline ppf ();
     incr num_loc_lines
   end
 
@@ -146,8 +146,12 @@ let print_updating_num_loc_lines ppf f arg =
   pp_print_flush ppf ();
   pp_set_formatter_out_functions ppf out_functions
 
+(** {1 Printing setup }*)
+
 let setup_tags () =
   Misc.Style.setup !Clflags.color
+
+module Fmt = Format_doc
 
 (******************************************************************************)
 (* Printing locations, e.g. 'File "foo.ml", line 3, characters 10-12' *)
@@ -205,7 +209,7 @@ let show_filename file =
   if !Clflags.absname then absolute_path file else file
 
 let print_filename ppf file =
-  Format.pp_print_string ppf (show_filename file)
+  Fmt.pp_print_string ppf (show_filename file)
 
 (* Best-effort printing of the text describing a location, of the form
    'File "foo.ml", line 3, characters 10-12'.
@@ -242,12 +246,12 @@ let print_loc ppf loc =
     if !first then (first := false; String.capitalize_ascii s)
     else s in
   let comma () =
-    if !first then () else Format.fprintf ppf ", " in
+    if !first then () else Fmt.fprintf ppf ", " in
 
-  Format.fprintf ppf "@{<loc>";
+  Fmt.fprintf ppf "@{<loc>";
 
   if file_valid file then
-    Format.fprintf ppf "%s \"%a\"" (capitalize "file") print_filename file;
+    Fmt.fprintf ppf "%s \"%a\"" (capitalize "file") print_filename file;
 
   (* Print "line 1" in the case of a dummy line number. This is to please the
      existing setup of editors that parse locations in error messages (e.g.
@@ -256,22 +260,29 @@ let print_loc ppf loc =
   let startline = if line_valid startline then startline else 1 in
   let endline = if line_valid endline then endline else startline in
   begin if startline = endline then
-    Format.fprintf ppf "%s %i" (capitalize "line") startline
+    Fmt.fprintf ppf "%s %i" (capitalize "line") startline
   else
-    Format.fprintf ppf "%s %i-%i" (capitalize "lines") startline endline
+    Fmt.fprintf ppf "%s %i-%i" (capitalize "lines") startline endline
   end;
 
   if chars_valid ~startchar ~endchar then (
     comma ();
-    Format.fprintf ppf "%s %i-%i" (capitalize "characters") startchar endchar
+    Fmt.fprintf ppf "%s %i-%i" (capitalize "characters") startchar endchar
   );
 
-  Format.fprintf ppf "@}"
+  Fmt.fprintf ppf "@}"
 
 (* Print a comma-separated list of locations *)
 let print_locs ppf locs =
-  Format.pp_print_list ~pp_sep:(fun ppf () -> Format.fprintf ppf ",@ ")
+  Fmt.pp_print_list ~pp_sep:(fun ppf () -> Fmt.fprintf ppf ",@ ")
     print_loc ppf locs
+
+module Compat = struct
+  let print_filename = Fmt.compat print_filename
+  let print_loc = Fmt.compat print_loc
+  let print_locs = Fmt.compat print_locs
+  let separate_new_message = Fmt.compat separate_new_message
+end
 
 (******************************************************************************)
 (* An interval set structure; additionally, it stores user-provided information
@@ -497,13 +508,13 @@ let highlight_quote ppf
            Option.fold ~some:Int.to_string ~none:"" lnum,
            start_pos))
       in
-    Format.fprintf ppf "@[<v>";
+    Fmt.fprintf ppf "@[<v>";
     begin match lines with
     | [] | [("", _, _)] -> ()
     | [(line, line_nb, line_start_cnum)] ->
         (* Single-line error *)
-        Format.fprintf ppf "%s | %s@," line_nb line;
-        Format.fprintf ppf "%*s   " (String.length line_nb) "";
+        Fmt.fprintf ppf "%s | %s@," line_nb line;
+        Fmt.fprintf ppf "%*s   " (String.length line_nb) "";
         (* Iterate up to [rightmost], which can be larger than the length of
            the line because we may point to a location after the end of the
            last token on the line, for instance:
@@ -515,21 +526,21 @@ let highlight_quote ppf
         for i = 0 to rightmost.pos_cnum - line_start_cnum - 1 do
           let pos = line_start_cnum + i in
           if ISet.is_start iset ~pos <> None then
-            Format.fprintf ppf "@{<%s>" highlight_tag;
-          if ISet.mem iset ~pos then Format.pp_print_char ppf '^'
+            Fmt.fprintf ppf "@{<%s>" highlight_tag;
+          if ISet.mem iset ~pos then Fmt.pp_print_char ppf '^'
           else if i < String.length line then begin
             (* For alignment purposes, align using a tab for each tab in the
                source code *)
-            if line.[i] = '\t' then Format.pp_print_char ppf '\t'
-            else Format.pp_print_char ppf ' '
+            if line.[i] = '\t' then Fmt.pp_print_char ppf '\t'
+            else Fmt.pp_print_char ppf ' '
           end;
           if ISet.is_end iset ~pos <> None then
-            Format.fprintf ppf "@}"
+            Fmt.fprintf ppf "@}"
         done;
-        Format.fprintf ppf "@}@,"
+        Fmt.fprintf ppf "@}@,"
     | _ ->
         (* Multi-line error *)
-        Misc.pp_two_columns ~sep:"|" ~max_lines ppf
+        Fmt.pp_two_columns ~sep:"|" ~max_lines ppf
         @@ List.map (fun (line, line_nb, line_start_cnum) ->
           let line = String.mapi (fun i car ->
             if ISet.mem iset ~pos:(line_start_cnum + i) then car else '.'
@@ -537,7 +548,7 @@ let highlight_quote ppf
           (line_nb, line)
         ) lines
     end;
-    Format.fprintf ppf "@]"
+    Fmt.fprintf ppf "@]"
 
 
 
@@ -633,10 +644,10 @@ let lines_around_from_current_input ~start_pos ~end_pos =
 (******************************************************************************)
 (* Reporting errors and warnings *)
 
-type msg = (Format.formatter -> unit) loc
+type msg = Fmt.t loc
 
 let msg ?(loc = none) fmt =
-  Format.kdprintf (fun txt -> { loc; txt }) fmt
+  Fmt.kdoc_printf (fun txt -> { loc; txt }) fmt
 
 type report_kind =
   | Report_error
@@ -649,7 +660,7 @@ type report = {
   kind : report_kind;
   main : msg;
   sub : msg list;
-  footnote: unit -> (Format.formatter -> unit) option;
+  footnote: Fmt.t option;
 }
 
 type report_printer = {
@@ -662,7 +673,7 @@ type report_printer = {
   pp_main_loc : report_printer -> report ->
     Format.formatter -> t -> unit;
   pp_main_txt : report_printer -> report ->
-    Format.formatter -> (Format.formatter -> unit) -> unit;
+    Format.formatter -> Fmt.t -> unit;
   pp_submsgs : report_printer -> report ->
     Format.formatter -> msg list -> unit;
   pp_submsg : report_printer -> report ->
@@ -670,7 +681,7 @@ type report_printer = {
   pp_submsg_loc : report_printer -> report ->
     Format.formatter -> t -> unit;
   pp_submsg_txt : report_printer -> report ->
-    Format.formatter -> (Format.formatter -> unit) -> unit;
+    Format.formatter -> Fmt.t -> unit;
 }
 
 let is_dummy_loc loc =
@@ -726,15 +737,16 @@ let batch_mode_printer : report_printer =
       | Misc.Error_style.Short ->
           ()
     in
-    Format.fprintf ppf "@[<v>%a:@ %a@]" print_loc loc highlight loc
+    Format.fprintf ppf "@[<v>%a:@ %a@]" Compat.print_loc loc
+      (Fmt.compat highlight) loc
   in
-  let pp_txt ppf txt = Format.fprintf ppf "@[%t@]" txt in
+  let pp_txt ppf txt = Format.fprintf ppf "@[%a@]" Fmt.format txt in
   let pp_footnote ppf f =
-    Option.iter (Format.fprintf ppf "@,%a" pp_txt) (f ())
+    Option.iter (Format.fprintf ppf "@,%a" pp_txt) f
   in
   let pp self ppf report =
     setup_tags ();
-    separate_new_message ppf;
+    Fmt.compat separate_new_message ppf ();
     (* Make sure we keep [num_loc_lines] updated.
        The tabulation box is here to give submessage the option
        to be aligned with the main message box
@@ -801,7 +813,7 @@ let terminfo_toplevel_printer (lb: lexbuf): report_printer =
   let pp_main_loc _ _ _ _ = () in
   let pp_submsg_loc _ _ ppf loc =
     if not loc.loc_ghost then
-      Format.fprintf ppf "%a:@ " print_loc loc in
+      Format.fprintf ppf "%a:@ " Compat.print_loc loc in
   { batch_mode_printer with pp; pp_main_loc; pp_submsg_loc }
 
 let best_toplevel_printer () =
@@ -829,22 +841,22 @@ let print_report ppf report =
 (* Reporting errors *)
 
 type error = report
-type delayed_msg = unit -> (Format.formatter -> unit) option
+type delayed_msg = unit -> Fmt.t option
 
 let report_error ppf err =
   print_report ppf err
 
 let mkerror loc sub footnote txt =
-  { kind = Report_error; main = { loc; txt }; sub; footnote }
+  { kind = Report_error; main = { loc; txt }; sub; footnote=footnote () }
 
 let errorf ?(loc = none) ?(sub = []) ?(footnote=Fun.const None) =
-  Format.kdprintf (mkerror loc sub footnote)
+  Fmt.kdoc_printf (mkerror loc sub footnote)
 
 let error ?(loc = none) ?(sub = []) ?(footnote=Fun.const None) msg_str =
-  mkerror loc sub footnote (fun ppf -> Format.pp_print_string ppf msg_str)
+  mkerror loc sub footnote Fmt.(Core.string msg_str empty)
 
 let error_of_printer ?(loc = none) ?(sub = []) ?(footnote=Fun.const None) pp x =
-  mkerror loc sub footnote (fun ppf -> pp ppf x)
+  mkerror loc sub footnote (Fmt.doc_printf "%a" pp x)
 
 let error_of_printer_file print x =
   error_of_printer ~loc:(in_file !input_name) print x
@@ -857,13 +869,13 @@ let default_warning_alert_reporter report mk (loc: t) w : report option =
   match report w with
   | `Inactive -> None
   | `Active { Warnings.id; message; is_error; sub_locs } ->
-      let msg_of_str str = fun ppf -> Format.pp_print_string ppf str in
+      let msg_of_str str = Format_doc.(empty |> Core.string str) in
       let kind = mk is_error id in
       let main = { loc; txt = msg_of_str message } in
       let sub = List.map (fun (loc, sub_message) ->
         { loc; txt = msg_of_str sub_message }
       ) sub_locs in
-      Some { kind; main; sub; footnote=Fun.const None }
+      Some { kind; main; sub; footnote=None }
 
 
 let default_warning_reporter =
@@ -913,7 +925,7 @@ let deprecated ?def ?use loc message =
 module Style = Misc.Style
 
 let auto_include_alert lib =
-  let message = Format.asprintf "\
+  let message = Fmt.asprintf "\
     OCaml's lib directory layout changed in 5.0. The %a subdirectory has been \
     automatically added to the search path, but you should add %a to the \
     command-line to silence this alert (e.g. by adding %a to the list of \
@@ -932,7 +944,7 @@ let auto_include_alert lib =
   prerr_alert none alert
 
 let deprecated_script_alert program =
-  let message = Format.asprintf "\
+  let message = Fmt.asprintf "\
     Running %a where the first argument is an implicit basename with no \
     extension (e.g. %a) is deprecated. Either rename the script \
     (%a) or qualify the basename (%a)"
@@ -999,4 +1011,4 @@ let () =
     )
 
 let raise_errorf ?(loc = none) ?(sub = []) ?(footnote=Fun.const None) =
-  Format.kdprintf (fun txt -> raise (Error (mkerror loc sub footnote txt)))
+  Fmt.kdoc_printf (fun txt -> raise (Error (mkerror loc sub footnote txt)))

--- a/parsing/location.ml
+++ b/parsing/location.ml
@@ -740,7 +740,7 @@ let batch_mode_printer : report_printer =
     Format.fprintf ppf "@[<v>%a:@ %a@]" Compat.print_loc loc
       (Fmt.compat highlight) loc
   in
-  let pp_txt ppf txt = Format.fprintf ppf "@[%a@]" Fmt.format txt in
+  let pp_txt ppf txt = Format.fprintf ppf "@[%a@]" Fmt.Doc.format txt in
   let pp_footnote ppf f =
     Option.iter (Format.fprintf ppf "@,%a" pp_txt) f
   in
@@ -853,7 +853,7 @@ let errorf ?(loc = none) ?(sub = []) ?(footnote=Fun.const None) =
   Fmt.kdoc_printf (mkerror loc sub footnote)
 
 let error ?(loc = none) ?(sub = []) ?(footnote=Fun.const None) msg_str =
-  mkerror loc sub footnote Fmt.(Core.string msg_str empty)
+  mkerror loc sub footnote Fmt.Doc.(string msg_str empty)
 
 let error_of_printer ?(loc = none) ?(sub = []) ?(footnote=Fun.const None) pp x =
   mkerror loc sub footnote (Fmt.doc_printf "%a" pp x)
@@ -869,7 +869,7 @@ let default_warning_alert_reporter report mk (loc: t) w : report option =
   match report w with
   | `Inactive -> None
   | `Active { Warnings.id; message; is_error; sub_locs } ->
-      let msg_of_str str = Format_doc.(empty |> Core.string str) in
+      let msg_of_str str = Format_doc.Doc.(empty |> string str) in
       let kind = mk is_error id in
       let main = { loc; txt = msg_of_str message } in
       let sub = List.map (fun (loc, sub_message) ->

--- a/parsing/location.mli
+++ b/parsing/location.mli
@@ -88,7 +88,6 @@ val input_phrase_buffer: Buffer.t option ref
 (** {1 Toplevel-specific functions} *)
 
 val echo_eof: unit -> unit
-val separate_new_message: unit Format_doc.printer
 val reset: unit -> unit
 
 
@@ -169,16 +168,18 @@ val show_filename: string -> string
     (** In -absname mode, return the absolute path for this filename.
         Otherwise, returns the filename unchanged. *)
 
-module Compat: sig
-  val print_filename: formatter -> string -> unit
-  val print_loc: formatter -> t -> unit
-  val print_locs: formatter -> t list -> unit
-  val separate_new_message: formatter -> unit -> unit
-end
+val print_filename: formatter -> string -> unit
+val print_loc: formatter -> t -> unit
+val print_locs: formatter -> t list -> unit
+val separate_new_message: formatter -> unit
 
-val print_filename: string Format_doc.printer
-val print_loc: t Format_doc.printer
-val print_locs: t list Format_doc.printer
+module Doc: sig
+  val separate_new_message: unit Format_doc.printer
+  val filename: string Format_doc.printer
+  val quoted_filename: string Format_doc.printer
+  val loc: t Format_doc.printer
+  val locs: t list Format_doc.printer
+end
 
 (** {1 Toplevel-specific location highlighting} *)
 

--- a/parsing/location.mli
+++ b/parsing/location.mli
@@ -88,7 +88,7 @@ val input_phrase_buffer: Buffer.t option ref
 (** {1 Toplevel-specific functions} *)
 
 val echo_eof: unit -> unit
-val separate_new_message: formatter -> unit
+val separate_new_message: unit Format_doc.printer
 val reset: unit -> unit
 
 
@@ -169,11 +169,16 @@ val show_filename: string -> string
     (** In -absname mode, return the absolute path for this filename.
         Otherwise, returns the filename unchanged. *)
 
-val print_filename: formatter -> string -> unit
+module Compat: sig
+  val print_filename: formatter -> string -> unit
+  val print_loc: formatter -> t -> unit
+  val print_locs: formatter -> t list -> unit
+  val separate_new_message: formatter -> unit -> unit
+end
 
-val print_loc: formatter -> t -> unit
-val print_locs: formatter -> t list -> unit
-
+val print_filename: string Format_doc.printer
+val print_loc: t Format_doc.printer
+val print_locs: t list Format_doc.printer
 
 (** {1 Toplevel-specific location highlighting} *)
 
@@ -185,9 +190,9 @@ val highlight_terminfo:
 
 (** {2 The type of reports and report printers} *)
 
-type msg = (Format.formatter -> unit) loc
+type msg = Format_doc.t loc
 
-val msg: ?loc:t -> ('a, Format.formatter, unit, msg) format4 -> 'a
+val msg: ?loc:t -> ('a, Format_doc.formatter, unit, msg) format4 -> 'a
 
 type report_kind =
   | Report_error
@@ -200,7 +205,7 @@ type report = {
   kind : report_kind;
   main : msg;
   sub : msg list;
-  footnote: unit -> (Format.formatter -> unit) option
+  footnote: Format_doc.t option
 }
 
 type report_printer = {
@@ -213,7 +218,7 @@ type report_printer = {
   pp_main_loc : report_printer -> report ->
     Format.formatter -> t -> unit;
   pp_main_txt : report_printer -> report ->
-    Format.formatter -> (Format.formatter -> unit) -> unit;
+    Format.formatter -> Format_doc.t -> unit;
   pp_submsgs : report_printer -> report ->
     Format.formatter -> msg list -> unit;
   pp_submsg : report_printer -> report ->
@@ -221,7 +226,7 @@ type report_printer = {
   pp_submsg_loc : report_printer -> report ->
     Format.formatter -> t -> unit;
   pp_submsg_txt : report_printer -> report ->
-    Format.formatter -> (Format.formatter -> unit) -> unit;
+    Format.formatter -> Format_doc.t -> unit;
 }
 (** A printer for [report]s, defined using open-recursion.
     The goal is to make it easy to define new printers by re-using code from
@@ -322,19 +327,17 @@ val deprecated_script_alert: string -> unit
 type error = report
 (** An [error] is a [report] which [report_kind] must be [Report_error]. *)
 
-type delayed_msg = unit -> (formatter->unit) option
+type delayed_msg = unit -> Format_doc.t option
 
-val error: ?loc:t -> ?sub:msg list -> ?footnote:delayed_msg-> string -> error
+val error: ?loc:t -> ?sub:msg list -> ?footnote:delayed_msg -> string -> error
 
-val errorf:
-  ?loc:t -> ?sub:msg list -> ?footnote:delayed_msg ->
-  ('a, Format.formatter, unit, error) format4 -> 'a
+val errorf: ?loc:t -> ?sub:msg list -> ?footnote:delayed_msg ->
+  ('a, Format_doc.formatter, unit, error) format4 -> 'a
 
-val error_of_printer:
-  ?loc:t -> ?sub:msg list -> ?footnote:delayed_msg ->
-  (formatter -> 'a -> unit) -> 'a -> error
+val error_of_printer: ?loc:t -> ?sub:msg list -> ?footnote:delayed_msg ->
+  (Format_doc.formatter -> 'a -> unit) -> 'a -> error
 
-val error_of_printer_file: (formatter -> 'a -> unit) -> 'a -> error
+val error_of_printer_file: (Format_doc.formatter -> 'a -> unit) -> 'a -> error
 
 
 (** {1 Automatically reporting errors for raised exceptions} *)
@@ -358,7 +361,7 @@ exception Already_displayed_error
    printed. The exception will be caught, but nothing will be printed *)
 
 val raise_errorf: ?loc:t -> ?sub:msg list -> ?footnote:delayed_msg ->
-  ('a, Format.formatter, unit, 'b) format4 -> 'a
+  ('a, Format_doc.formatter, unit, 'b) format4 -> 'a
 
 val report_exception: formatter -> exn -> unit
 (** Reraise the exception if it is unknown. *)

--- a/parsing/parse.ml
+++ b/parsing/parse.ml
@@ -138,7 +138,7 @@ let prepare_error err =
       Location.errorf ~loc
         "In this scoped type, variable %a \
          is reserved for the local type %a."
-        (Style.as_inline_code Pprintast.tyvar) var
+        (Style.as_inline_code Pprintast.Doc.tyvar) var
         Style.inline_code var
   | Other loc ->
       Location.errorf ~loc "Syntax error"
@@ -148,16 +148,16 @@ let prepare_error err =
   | Invalid_package_type (loc, ipt) ->
       let invalid ppf ipt = match ipt with
         | Syntaxerr.Parameterized_types ->
-            Format.fprintf ppf "parametrized types are not supported"
+            Format_doc.fprintf ppf "parametrized types are not supported"
         | Constrained_types ->
-            Format.fprintf ppf "constrained types are not supported"
+            Format_doc.fprintf ppf "constrained types are not supported"
         | Private_types ->
-            Format.fprintf ppf  "private types are not supported"
+            Format_doc.fprintf ppf  "private types are not supported"
         | Not_with_type ->
-            Format.fprintf ppf "only %a constraints are supported"
+            Format_doc.fprintf ppf "only %a constraints are supported"
               Style.inline_code "with type t ="
         | Neither_identifier_nor_with_type ->
-            Format.fprintf ppf
+            Format_doc.fprintf ppf
               "only module type identifier and %a constraints are supported"
               Style.inline_code "with type"
       in

--- a/parsing/pprintast.mli
+++ b/parsing/pprintast.mli
@@ -59,3 +59,9 @@ val tyvar: Format.formatter -> string -> unit
   (** Print a type variable name as a valid identifier, taking care of the
       special treatment required for the single quote character in second
       position, or for keywords by escaping them with \#. No-op on "_". *)
+
+(** {!Format_doc} functions for error messages *)
+module Doc:sig
+  val longident: Longident.t Format_doc.printer
+  val tyvar: string Format_doc.printer
+end

--- a/testsuite/tests/formatting/errors_batch.ml
+++ b/testsuite/tests/formatting/errors_batch.ml
@@ -2,6 +2,8 @@
  include ocamlcommon;
 *)
 
+module Fmt = Format_doc
+
 let () =
   let open Location in
   (* Some dummy locations for demo purposes *)
@@ -27,18 +29,18 @@ let () =
   } in
   let report = {
     kind = Report_error;
-    main = msg ~loc:loc1 "%a" Format.pp_print_text
+    main = msg ~loc:loc1 "%a" Fmt.pp_print_text
         "These are the contents of the main error message. \
          It is very long and should wrap across several lines.";
     sub = [
       msg ~loc:loc2 "A located first sub-message.";
-      msg ~loc:loc3 "%a" Format.pp_print_text
+      msg ~loc:loc3 "%a" Fmt.pp_print_text
         "Longer sub-messages that do not fit on the \
          same line as the location get indented.";
       msg "@[<v>This second sub-message does not have \
            a location;@,ghost locations of submessages are \
            not printed.@]";
     ];
-    footnote=Fun.const None;
+    footnote=None;
   } in
   print_report Format.std_formatter report

--- a/testsuite/tests/typing-misc/pr6416.ml
+++ b/testsuite/tests/typing-misc/pr6416.ml
@@ -55,7 +55,7 @@ Error: Signature mismatch:
        Constructors do not match:
          "A of t"
        is not the same as:
-         "A of t"
+         "A of t/2"
        The type "t" is not equal to the type "t/2"
        Line 4, characters 9-19:
          Definition of type "t"
@@ -121,7 +121,7 @@ Error: Signature mismatch:
        Constructors do not match:
          "A of T.t"
        is not the same as:
-         "A of T.t"
+         "A of T/2.t"
        The type "T.t" is not equal to the type "T/2.t"
        Line 5, characters 6-34:
          Definition of module "T"

--- a/testsuite/tests/typing-poly/error_messages.ml
+++ b/testsuite/tests/typing-poly/error_messages.ml
@@ -58,11 +58,11 @@ Lines 5-7, characters 10-5:
 5 | ..........(object
 6 |     method f _ = 0
 7 |  end)..
-Error: This expression has type "< f : 'b -> int >"
+Error: This expression has type "< f : 'a -> int >"
        but an expression was expected of type "t_a"
-       The method "f" has type "'b -> int", but the expected method type was
-       "'a. 'a -> int"
-       The universal variable "'a" would escape its scope
+       The method "f" has type "'a -> int", but the expected method type was
+       "'a0. 'a0 -> int"
+       The universal variable "'a0" would escape its scope
 |}
 ]
 
@@ -77,11 +77,11 @@ val f : uv -> int = <fun>
 Line 4, characters 11-49:
 4 | let () = f ( `A (object method f _ = 0 end): _ v);;
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This expression has type "'b v" but an expression was expected of type
+Error: This expression has type "'a v" but an expression was expected of type
          "uv"
-       The method "f" has type "'b -> int", but the expected method type was
-       "'a. 'a -> int"
-       The universal variable "'a" would escape its scope
+       The method "f" has type "'a -> int", but the expected method type was
+       "'a0. 'a0 -> int"
+       The universal variable "'a0" would escape its scope
 |}]
 
 (* Issue #8702: row types unified with universally quantified types*)

--- a/testsuite/tests/utils/edit_distance.ml
+++ b/testsuite/tests/utils/edit_distance.ml
@@ -1,7 +1,7 @@
 (* TEST
  include config;
  include testing;
- binary_modules = "config build_path_prefix_map misc identifiable numbers";
+ binary_modules = "config build_path_prefix_map format_doc misc identifiable numbers";
  bytecode;
 *)
 

--- a/testsuite/tests/utils/find_first_mono.ml
+++ b/testsuite/tests/utils/find_first_mono.ml
@@ -1,7 +1,7 @@
 (* TEST
  include config;
  include testing;
- binary_modules = "config build_path_prefix_map misc";
+ binary_modules = "config build_path_prefix_map format_doc misc";
  bytecode;
 *)
 

--- a/testsuite/tests/utils/magic_number.ml
+++ b/testsuite/tests/utils/magic_number.ml
@@ -1,6 +1,6 @@
 (* TEST
  include config;
- binary_modules = "config build_path_prefix_map misc";
+ binary_modules = "config build_path_prefix_map format_doc misc";
  bytecode;
 *)
 

--- a/testsuite/tests/utils/overflow_detection.ml
+++ b/testsuite/tests/utils/overflow_detection.ml
@@ -1,7 +1,7 @@
 (* TEST
  include config;
  include testing;
- binary_modules = "config build_path_prefix_map misc identifiable numbers";
+ binary_modules = "config build_path_prefix_map format_doc misc identifiable numbers";
  bytecode;
 *)
 

--- a/testsuite/tests/utils/test_strongly_connected_components.ml
+++ b/testsuite/tests/utils/test_strongly_connected_components.ml
@@ -1,7 +1,7 @@
 (* TEST
  include config;
  include testing;
- binary_modules = "config build_path_prefix_map misc identifiable numbers strongly_connected_components";
+ binary_modules = "config build_path_prefix_map format_doc misc identifiable numbers strongly_connected_components";
  bytecode;
 *)
 

--- a/tools/dumpobj.ml
+++ b/tools/dumpobj.ml
@@ -161,8 +161,9 @@ let print_getglobal_name ic =
     if n >= Array.length !globals || n < 0
     then print_string "<global table overflow>"
     else match !globals.(n) with
-         | Glob glob -> print_string
-                       (Format.asprintf "%a" Symtable.Global.description glob)
+         | Glob glob ->
+             let desc = Format_doc.compat Symtable.Global.description in
+             print_string (Format.asprintf "%a" desc glob)
          | Constant obj -> print_obj obj
   end
 
@@ -190,8 +191,8 @@ let print_setglobal_name ic =
     then print_string "<global table overflow>"
     else match !globals.(n) with
          | Glob glob ->
-             print_string
-               (Format.asprintf "%a" Symtable.Global.description glob)
+             let desc = Format_doc.compat Symtable.Global.description in
+             print_string (Format.asprintf "%a" desc glob)
          | Constant _ -> print_string "<unexpected constant>"
   end
 

--- a/tools/objinfo.ml
+++ b/tools/objinfo.ml
@@ -122,7 +122,7 @@ let print_cmt_infos cmt =
     List.iter (fun (loc, item) ->
       let pp_loc fmt { Location.txt; loc } =
         Format.fprintf fmt "%a (%a)"
-          Pprintast.longident txt Location.print_loc loc
+          Pprintast.longident txt Location.Compat.print_loc loc
       in
       Format.printf "@[<hov 2>%a:@ %a@]@;"
         Shape_reduce.print_result item pp_loc loc)
@@ -156,7 +156,7 @@ let print_cmt_infos cmt =
       in
       let pp_loc fmt { Location.txt; loc } =
         Format.fprintf fmt "%s (%a)"
-           txt Location.print_loc loc
+           txt Location.Compat.print_loc loc
       in
       Format.printf "@[<hov 2>%a:@ %a@]@;"
         Shape.Uid.print uid
@@ -179,8 +179,8 @@ let print_global_table table =
   printf "Globals defined:\n";
   Symtable.iter_global_map
     (fun global _ ->
-       print_line
-         (Format.asprintf "%a" Symtable.Global.description global)
+       let desc = Format_doc.compat Symtable.Global.description in
+       print_line (Format.asprintf "%a" desc global)
     )
     table
 

--- a/tools/objinfo.ml
+++ b/tools/objinfo.ml
@@ -122,7 +122,7 @@ let print_cmt_infos cmt =
     List.iter (fun (loc, item) ->
       let pp_loc fmt { Location.txt; loc } =
         Format.fprintf fmt "%a (%a)"
-          Pprintast.longident txt Location.Compat.print_loc loc
+          Pprintast.longident txt Location.print_loc loc
       in
       Format.printf "@[<hov 2>%a:@ %a@]@;"
         Shape_reduce.print_result item pp_loc loc)
@@ -156,7 +156,7 @@ let print_cmt_infos cmt =
       in
       let pp_loc fmt { Location.txt; loc } =
         Format.fprintf fmt "%s (%a)"
-           txt Location.Compat.print_loc loc
+           txt Location.print_loc loc
       in
       Format.printf "@[<hov 2>%a:@ %a@]@;"
         Shape.Uid.print uid

--- a/toplevel/byte/topeval.ml
+++ b/toplevel/byte/topeval.ml
@@ -164,7 +164,7 @@ let execute_phrase print_outcome ppf phr =
         begin match out_phr with
         | Ophr_signature [] -> ()
         | _ ->
-            Location.separate_new_message ppf;
+            Location.Compat.separate_new_message ppf ();
             !print_out_phrase ppf out_phr;
         end;
         if Printexc.backtrace_status ()
@@ -172,7 +172,7 @@ let execute_phrase print_outcome ppf phr =
           match !backtrace with
             | None -> ()
             | Some b ->
-                Location.separate_new_message ppf;
+                Location.Compat.separate_new_message ppf ();
                 pp_print_string ppf b;
                 pp_print_flush ppf ();
                 backtrace := None;

--- a/toplevel/byte/topeval.ml
+++ b/toplevel/byte/topeval.ml
@@ -164,7 +164,7 @@ let execute_phrase print_outcome ppf phr =
         begin match out_phr with
         | Ophr_signature [] -> ()
         | _ ->
-            Location.Compat.separate_new_message ppf ();
+            Location.separate_new_message ppf;
             !print_out_phrase ppf out_phr;
         end;
         if Printexc.backtrace_status ()
@@ -172,7 +172,7 @@ let execute_phrase print_outcome ppf phr =
           match !backtrace with
             | None -> ()
             | Some b ->
-                Location.Compat.separate_new_message ppf ();
+                Location.separate_new_message ppf;
                 pp_print_string ppf b;
                 pp_print_flush ppf ();
                 backtrace := None;

--- a/toplevel/byte/topmain.ml
+++ b/toplevel/byte/topmain.ml
@@ -24,6 +24,7 @@ let tracing_function_ptr =
   get_code_pointer
     (Obj.repr (fun arg -> Trace.print_trace (current_environment()) arg))
 
+module Printtyp = Printtyp.Compat
 let dir_trace ppf lid =
   match Env.find_value_by_name lid !Topcommon.toplevel_env with
   | (path, desc) -> begin

--- a/toplevel/byte/trace.ml
+++ b/toplevel/byte/trace.ml
@@ -66,6 +66,7 @@ let print_label ppf l =
 
 (* If a function returns a functional value, wrap it into a trace code *)
 
+module Printtyp = Printtyp.Compat
 let rec instrument_result env name ppf clos_typ =
   match get_desc (Ctype.expand_head env clos_typ) with
   | Tarrow(l, t1, t2, _) ->

--- a/toplevel/native/topeval.ml
+++ b/toplevel/native/topeval.ml
@@ -249,7 +249,7 @@ let execute_phrase print_outcome ppf phr =
         begin match out_phr with
         | Ophr_signature [] -> ()
         | _ ->
-            Location.separate_new_message ppf;
+            Location.Compat.separate_new_message ppf ();
             !print_out_phrase ppf out_phr;
         end;
         begin match out_phr with

--- a/toplevel/native/topeval.ml
+++ b/toplevel/native/topeval.ml
@@ -249,7 +249,7 @@ let execute_phrase print_outcome ppf phr =
         begin match out_phr with
         | Ophr_signature [] -> ()
         | _ ->
-            Location.Compat.separate_new_message ppf ();
+            Location.separate_new_message ppf;
             !print_out_phrase ppf out_phr;
         end;
         begin match out_phr with

--- a/toplevel/topcommon.ml
+++ b/toplevel/topcommon.ml
@@ -28,7 +28,7 @@ open Ast_helper
 
 let parse_toplevel_phrase = ref Parse.toplevel_phrase
 let parse_use_file = ref Parse.use_file
-let print_location = Location.Compat.print_loc
+let print_location = Location.print_loc
 let print_error = Location.print_report
 let print_warning = Location.print_warning
 let input_name = Location.input_name

--- a/toplevel/topcommon.mli
+++ b/toplevel/topcommon.mli
@@ -59,20 +59,16 @@ val find_eval_phrase :
 val max_printer_depth: int ref
 val max_printer_steps: int ref
 
+type 'a printer := 'a Oprint.printer
+
 val print_out_value :
   (formatter -> Outcometree.out_value -> unit) ref
-val print_out_type :
-  (formatter -> Outcometree.out_type -> unit) ref
-val print_out_class_type :
-  (formatter -> Outcometree.out_class_type -> unit) ref
-val print_out_module_type :
-  (formatter -> Outcometree.out_module_type -> unit) ref
-val print_out_type_extension :
-  (formatter -> Outcometree.out_type_extension -> unit) ref
-val print_out_sig_item :
-  (formatter -> Outcometree.out_sig_item -> unit) ref
-val print_out_signature :
-  (formatter -> Outcometree.out_sig_item list -> unit) ref
+val print_out_type : Outcometree.out_type printer
+val print_out_class_type :  Outcometree.out_class_type printer
+val print_out_module_type : Outcometree.out_module_type printer
+val print_out_type_extension : Outcometree.out_type_extension printer
+val print_out_sig_item :  Outcometree.out_sig_item printer
+val print_out_signature :  Outcometree.out_sig_item list printer
 val print_out_phrase :
   (formatter -> Outcometree.out_phrase -> unit) ref
 

--- a/toplevel/topdirs.ml
+++ b/toplevel/topdirs.ml
@@ -289,14 +289,14 @@ let find_printer lid =
   | exception Not_found ->
     let report ppf =
       fprintf ppf "Unbound value %a.@."
-        Printtyp.longident lid
+        Printtyp.Compat.longident lid
     in Error report
   | (path, desc) ->
     match match_printer_type desc with
     | None ->
       let report ppf =
         fprintf ppf "%a has the wrong type for a printing function.@."
-          Printtyp.longident lid
+          Printtyp.Compat.longident lid
       in Error report
     | Some kind -> Ok (path, kind)
 
@@ -325,7 +325,7 @@ let remove_installed_printer path =
   | exception Not_found ->
     let report ppf =
       fprintf ppf "The printer named %a is not installed.@."
-        Printtyp.path path
+        Printtyp.Compat.path path
     in Error report
 
 let dir_install_printer ppf lid =
@@ -393,13 +393,13 @@ let show_prim to_sig ppf lid =
       | Longident.Lident s -> s
       | Longident.Ldot (_,s) -> s
       | Longident.Lapply _ ->
-          fprintf ppf "Invalid path %a@." Printtyp.longident lid;
+          fprintf ppf "Invalid path %a@." Printtyp.Compat.longident lid;
           raise Exit
     in
     let id = Ident.create_persistent s in
     let sg = to_sig env loc id lid in
     Printtyp.wrap_printing_env ~error:false env
-      (fun () -> fprintf ppf "@[%a@]@." Printtyp.signature sg)
+      (fun () -> fprintf ppf "@[%a@]@." Printtyp.Compat.signature sg)
   with
   | Not_found ->
       fprintf ppf "@[Unknown element.@]@."

--- a/toplevel/toploop.ml
+++ b/toplevel/toploop.ml
@@ -388,7 +388,7 @@ let loop ppf =
       Config.version
       (if Topeval.implementation_label = "" then "" else " - ")
       Topeval.implementation_label
-      Misc.Style.inline_code "#help;;";
+      (Format_doc.compat Misc.Style.inline_code) "#help;;";
   let lb = Lexing.from_function refill_lexbuf in
   Location.init lb "//toplevel//";
   Location.input_name := "//toplevel//";

--- a/toplevel/toploop.mli
+++ b/toplevel/toploop.mli
@@ -144,18 +144,14 @@ val input_name : string ref
 
 val print_out_value :
   (formatter -> Outcometree.out_value -> unit) ref
-val print_out_type :
-  (formatter -> Outcometree.out_type -> unit) ref
-val print_out_class_type :
-  (formatter -> Outcometree.out_class_type -> unit) ref
-val print_out_module_type :
-  (formatter -> Outcometree.out_module_type -> unit) ref
-val print_out_type_extension :
-  (formatter -> Outcometree.out_type_extension -> unit) ref
-val print_out_sig_item :
-  (formatter -> Outcometree.out_sig_item -> unit) ref
-val print_out_signature :
-  (formatter -> Outcometree.out_sig_item list -> unit) ref
+
+type 'a oprinter := 'a Oprint.printer
+val print_out_type : Outcometree.out_type oprinter
+val print_out_class_type : Outcometree.out_class_type oprinter
+val print_out_module_type : Outcometree.out_module_type oprinter
+val print_out_type_extension : Outcometree.out_type_extension oprinter
+val print_out_sig_item : Outcometree.out_sig_item oprinter
+val print_out_signature : Outcometree.out_sig_item list oprinter
 val print_out_phrase :
   (formatter -> Outcometree.out_phrase -> unit) ref
 

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -119,10 +119,11 @@ let raise_scope_escape_exn ty = raise (scope_escape_exn ty)
 exception Tags of label * label
 
 let () =
+  let open Format_doc in
   Location.register_error_of_exn
     (function
       | Tags (l, l') ->
-          let pp_tag ppf s = Format.fprintf ppf "`%s" s in
+          let pp_tag ppf s = fprintf ppf "`%s" s in
           let inline_tag = Misc.Style.as_inline_code pp_tag in
           Some
             Location.

--- a/typing/env.mli
+++ b/typing/env.mli
@@ -447,12 +447,10 @@ type error =
 
 exception Error of error
 
-open Format
 
-val report_error: formatter -> error -> unit
+val report_error: error Format_doc.printer
 
-val report_lookup_error: Location.t -> t -> formatter -> lookup_error -> unit
-
+val report_lookup_error: Location.t -> t -> lookup_error Format_doc.printer
 val in_signature: bool -> t -> t
 
 val is_in_signature: t -> bool
@@ -482,9 +480,9 @@ val strengthen:
 (* Forward declaration to break mutual recursion with Ctype. *)
 val same_constr: (t -> type_expr -> type_expr -> bool) ref
 (* Forward declaration to break mutual recursion with Printtyp. *)
-val print_longident: (Format.formatter -> Longident.t -> unit) ref
+val print_longident: Longident.t Format_doc.printer ref
 (* Forward declaration to break mutual recursion with Printtyp. *)
-val print_path: (Format.formatter -> Path.t -> unit) ref
+val print_path: Path.t Format_doc.printer ref
 
 
 (** Folds *)

--- a/typing/envaux.ml
+++ b/typing/envaux.ml
@@ -101,7 +101,7 @@ let env_of_only_summary env =
 
 (* Error report *)
 
-open Format
+open Format_doc
 module Style = Misc.Style
 
 let report_error ppf = function

--- a/typing/envaux.mli
+++ b/typing/envaux.mli
@@ -14,8 +14,6 @@
 (*                                                                        *)
 (**************************************************************************)
 
-open Format
-
 (* Convert environment summaries to environments *)
 
 val env_from_summary : Env.summary -> Subst.t -> Env.t
@@ -33,4 +31,4 @@ type error =
 
 exception Error of error
 
-val report_error: formatter -> error -> unit
+val report_error: error Format_doc.printer

--- a/typing/errortrace.ml
+++ b/typing/errortrace.ml
@@ -16,7 +16,7 @@
 (**************************************************************************)
 
 open Types
-open Format
+open Format_doc
 
 type position = First | Second
 
@@ -100,8 +100,8 @@ type 'variety obj =
 
 type first_class_module =
     | Package_cannot_scrape of Path.t
-    | Package_inclusion of (Format.formatter -> unit)
-    | Package_coercion of (Format.formatter -> unit)
+    | Package_inclusion of Format_doc.doc
+    | Package_coercion of Format_doc.doc
 
 type ('a, 'variety) elt =
   (* Common *)

--- a/typing/errortrace.mli
+++ b/typing/errortrace.mli
@@ -20,7 +20,7 @@ open Types
 type position = First | Second
 
 val swap_position : position -> position
-val print_pos : Format.formatter -> position -> unit
+val print_pos : position Format_doc.printer
 
 type expanded_type = { ty: type_expr; expanded: type_expr }
 
@@ -86,8 +86,8 @@ type 'variety obj =
 
 type first_class_module =
     | Package_cannot_scrape of Path.t
-    | Package_inclusion of (Format.formatter -> unit)
-    | Package_coercion of (Format.formatter -> unit)
+    | Package_inclusion of Format_doc.doc
+    | Package_coercion of Format_doc.doc
 
 type ('a, 'variety) elt =
   (* Common *)

--- a/typing/ident.ml
+++ b/typing/ident.ml
@@ -138,24 +138,24 @@ let is_predef = function
   | _ -> false
 
 let print ~with_scope ppf =
-  let open Format in
+  let open Format_doc in
   function
   | Global name -> fprintf ppf "%s!" name
   | Predef { name; stamp = n } ->
       fprintf ppf "%s%s!" name
-        (if !Clflags.unique_ids then sprintf "/%i" n else "")
+        (if !Clflags.unique_ids then asprintf "/%i" n else "")
   | Local { name; stamp = n } ->
       fprintf ppf "%s%s" name
-        (if !Clflags.unique_ids then sprintf "/%i" n else "")
+        (if !Clflags.unique_ids then asprintf "/%i" n else "")
   | Scoped { name; stamp = n; scope } ->
       fprintf ppf "%s%s%s" name
-        (if !Clflags.unique_ids then sprintf "/%i" n else "")
-        (if with_scope then sprintf "[%i]" scope else "")
+        (if !Clflags.unique_ids then asprintf "/%i" n else "")
+        (if with_scope then asprintf "[%i]" scope else "")
 
 let print_with_scope ppf id = print ~with_scope:true ppf id
 
-let print ppf id = print ~with_scope:false ppf id
-
+let doc_print ppf id = print ~with_scope:false ppf id
+let print ppf id = Format_doc.compat doc_print ppf id
 (* For the documentation of ['a Ident.tbl], see ident.mli.
 
    The implementation is a copy-paste specialization of

--- a/typing/ident.mli
+++ b/typing/ident.mli
@@ -24,7 +24,8 @@ include Identifiable.S with type t := t
    - [compare] compares identifiers by binding location
 *)
 
-val print_with_scope : Format.formatter -> t -> unit
+val doc_print: t Format_doc.printer
+val print_with_scope : t Format_doc.printer
         (** Same as {!print} except that it will also add a "[n]" suffix
             if the scope of the argument is [n]. *)
 

--- a/typing/includeclass.ml
+++ b/typing/includeclass.ml
@@ -40,7 +40,7 @@ let class_declarations env cty1 cty2 =
         cty1.cty_params cty1.cty_type
         cty2.cty_params cty2.cty_type
 
-open Format
+open Format_doc
 open Ctype
 
 (*
@@ -50,6 +50,7 @@ let rec hide_params = function
 *)
 
 let include_err mode ppf =
+  let msg fmt = Format_doc.Core.msg fmt in
   function
   | CM_Virtual_class ->
       fprintf ppf "A class cannot be changed from virtual to concrete"
@@ -58,11 +59,9 @@ let include_err mode ppf =
         "The classes do not have the same number of type parameters"
   | CM_Type_parameter_mismatch (n, env, err) ->
       Printtyp.report_equality_error ppf mode env err
-        (function ppf ->
-           fprintf ppf "The %d%s type parameter has type"
+        (msg "The %d%s type parameter has type"
              n (Misc.ordinal_suffix n))
-        (function ppf ->
-           fprintf ppf "but is expected to have type")
+        (msg "but is expected to have type")
   | CM_Class_type_mismatch (env, cty1, cty2) ->
       Printtyp.wrap_printing_env ~error:true env (fun () ->
         fprintf ppf
@@ -72,23 +71,17 @@ let include_err mode ppf =
           Printtyp.class_type cty2)
   | CM_Parameter_mismatch (n, env, err) ->
       Printtyp.report_moregen_error ppf mode env err
-        (function ppf ->
-           fprintf ppf "The %d%s parameter has type"
+        (msg "The %d%s parameter has type"
              n (Misc.ordinal_suffix n))
-        (function ppf ->
-          fprintf ppf "but is expected to have type")
+        (msg "but is expected to have type")
   | CM_Val_type_mismatch (lab, env, err) ->
       Printtyp.report_comparison_error ppf mode env err
-        (function ppf ->
-          fprintf ppf "The instance variable %s@ has type" lab)
-        (function ppf ->
-          fprintf ppf "but is expected to have type")
+        (msg "The instance variable %s@ has type" lab)
+        (msg "but is expected to have type")
   | CM_Meth_type_mismatch (lab, env, err) ->
       Printtyp.report_comparison_error ppf mode env err
-        (function ppf ->
-          fprintf ppf "The method %s@ has type" lab)
-        (function ppf ->
-          fprintf ppf "but is expected to have type")
+        (msg "The method %s@ has type" lab)
+        (msg "but is expected to have type")
   | CM_Non_mutable_value lab ->
       fprintf ppf
        "@[The non-mutable instance variable %s cannot become mutable@]" lab

--- a/typing/includeclass.ml
+++ b/typing/includeclass.ml
@@ -50,7 +50,7 @@ let rec hide_params = function
 *)
 
 let include_err mode ppf =
-  let msg fmt = Format_doc.Core.msg fmt in
+  let msg fmt = Format_doc.Doc.msg fmt in
   function
   | CM_Virtual_class ->
       fprintf ppf "A class cannot be changed from virtual to concrete"

--- a/typing/includeclass.mli
+++ b/typing/includeclass.mli
@@ -17,7 +17,6 @@
 
 open Types
 open Ctype
-open Format
 
 val class_types:
         Env.t -> class_type -> class_type -> class_match_failure list
@@ -30,4 +29,4 @@ val class_declarations:
   class_match_failure list
 
 val report_error :
-  Printtyp.type_or_scheme -> formatter -> class_match_failure list -> unit
+  Printtyp.type_or_scheme -> class_match_failure list Format_doc.printer

--- a/typing/includecore.ml
+++ b/typing/includecore.ml
@@ -240,13 +240,13 @@ let report_value_mismatch first second env ppf err =
   | Not_a_primitive ->
       pr "The implementation is not a primitive."
   | Type trace ->
-      let msg = Fmt.Core.msg in
+      let msg = Fmt.Doc.msg in
       Printtyp.report_moregen_error ppf Type_scheme env trace
         (msg "The type")
         (msg "is not compatible with the type")
 
 let report_type_inequality env ppf err =
-  let msg = Fmt.Core.msg in
+  let msg = Fmt.Doc.msg in
   Printtyp.report_equality_error ppf Type_scheme env err
     (msg "The type")
     (msg "is not equal to the type")

--- a/typing/includecore.ml
+++ b/typing/includecore.ml
@@ -208,9 +208,10 @@ type type_mismatch =
   | Immediate of Type_immediacy.Violation.t
 
 module Style = Misc.Style
+module Fmt = Format_doc
 
 let report_primitive_mismatch first second ppf err =
-  let pr fmt = Format.fprintf ppf fmt in
+  let pr fmt = Fmt.fprintf ppf fmt in
   match (err : primitive_mismatch) with
   | Name ->
       pr "The names of the primitives are not the same"
@@ -231,7 +232,7 @@ let report_primitive_mismatch first second ppf err =
         n (Misc.ordinal_suffix n)
 
 let report_value_mismatch first second env ppf err =
-  let pr fmt = Format.fprintf ppf fmt in
+  let pr fmt = Fmt.fprintf ppf fmt in
   pr "@ ";
   match (err : value_mismatch) with
   | Primitive_mismatch pm ->
@@ -239,14 +240,16 @@ let report_value_mismatch first second env ppf err =
   | Not_a_primitive ->
       pr "The implementation is not a primitive."
   | Type trace ->
+      let msg = Fmt.Core.msg in
       Printtyp.report_moregen_error ppf Type_scheme env trace
-        (fun ppf -> Format.fprintf ppf "The type")
-        (fun ppf -> Format.fprintf ppf "is not compatible with the type")
+        (msg "The type")
+        (msg "is not compatible with the type")
 
 let report_type_inequality env ppf err =
+  let msg = Fmt.Core.msg in
   Printtyp.report_equality_error ppf Type_scheme env err
-    (fun ppf -> Format.fprintf ppf "The type")
-    (fun ppf -> Format.fprintf ppf "is not equal to the type")
+    (msg "The type")
+    (msg "is not equal to the type")
 
 let report_privacy_mismatch ppf err =
   let singular, item =
@@ -256,7 +259,7 @@ let report_privacy_mismatch ppf err =
     | Private_record_type        -> true,  "record constructor"
     | Private_extensible_variant -> true,  "extensible variant"
     | Private_row_type           -> true,  "row type"
-  in Format.fprintf ppf "%s %s would be revealed."
+  in Format_doc.fprintf ppf "%s %s would be revealed."
        (if singular then "A private" else "Private")
        item
 
@@ -265,20 +268,20 @@ let report_label_mismatch first second env ppf err =
   | Type err ->
       report_type_inequality env ppf err
   | Mutability ord ->
-      Format.fprintf ppf "%s is mutable and %s is not."
+      Format_doc.fprintf ppf "%s is mutable and %s is not."
         (String.capitalize_ascii (choose ord first second))
         (choose_other ord first second)
 
 let pp_record_diff first second prefix decl env ppf (x : record_change) =
   match x with
   | Delete cd ->
-      Format.fprintf ppf "%aAn extra field, %a, is provided in %s %s."
+      Fmt.fprintf ppf "%aAn extra field, %a, is provided in %s %s."
         prefix x Style.inline_code (Ident.name cd.delete.ld_id) first decl
   | Insert cd ->
-      Format.fprintf  ppf "%aA field, %a, is missing in %s %s."
+      Fmt.fprintf  ppf "%aA field, %a, is missing in %s %s."
         prefix x Style.inline_code (Ident.name cd.insert.ld_id) first decl
   | Change Type {got=lbl1; expected=lbl2; reason} ->
-      Format.fprintf ppf
+      Fmt.fprintf ppf
         "@[<hv>%aFields do not match:@;<1 2>\
          %a@ is not the same as:\
          @;<1 2>%a@ %a@]"
@@ -287,34 +290,34 @@ let pp_record_diff first second prefix decl env ppf (x : record_change) =
         (Style.as_inline_code Printtyp.label) lbl2
         (report_label_mismatch first second env) reason
   | Change Name n ->
-      Format.fprintf ppf "%aFields have different names, %a and %a."
+      Fmt.fprintf ppf "%aFields have different names, %a and %a."
         prefix x
         Style.inline_code n.got
         Style.inline_code n.expected
   | Swap sw ->
-      Format.fprintf ppf "%aFields %a and %a have been swapped."
+      Fmt.fprintf ppf "%aFields %a and %a have been swapped."
         prefix x
         Style.inline_code sw.first
         Style.inline_code sw.last
   | Move {name; got; expected } ->
-      Format.fprintf ppf
+      Fmt.fprintf ppf
         "@[<2>%aField %a has been moved@ from@ position %d@ to %d.@]"
         prefix x Style.inline_code name expected got
 
 let report_patch pr_diff first second decl env ppf patch =
-  let nl ppf () = Format.fprintf ppf "@," in
+  let nl ppf () = Fmt.fprintf ppf "@," in
   let no_prefix _ppf _ = () in
   match patch with
   | [ elt ] ->
-      Format.fprintf ppf "@[<hv>%a@]"
+      Fmt.fprintf ppf "@[<hv>%a@]"
         (pr_diff first second no_prefix decl env) elt
   | _ ->
       let pp_diff = pr_diff first second Diffing_with_keys.prefix decl env in
-      Format.fprintf ppf "@[<hv>%a@]"
-        (Format.pp_print_list ~pp_sep:nl pp_diff) patch
+      Fmt.fprintf ppf "@[<hv>%a@]"
+        (Fmt.pp_print_list ~pp_sep:nl pp_diff) patch
 
 let report_record_mismatch first second decl env ppf err =
-  let pr fmt = Format.fprintf ppf fmt in
+  let pr fmt = Fmt.fprintf ppf fmt in
   match err with
   | Label_mismatch patch ->
       report_patch pp_record_diff first second decl env ppf patch
@@ -324,7 +327,7 @@ let report_record_mismatch first second decl env ppf err =
         "uses unboxed float representation"
 
 let report_constructor_mismatch first second decl env ppf err =
-  let pr fmt  = Format.fprintf ppf fmt in
+  let pr fmt  = Fmt.fprintf ppf fmt in
   match (err : constructor_mismatch) with
   | Type err -> report_type_inequality env ppf err
   | Arity -> pr "They have different arities."
@@ -342,13 +345,13 @@ let report_constructor_mismatch first second decl env ppf err =
 let pp_variant_diff first second prefix decl env ppf (x : variant_change) =
   match x with
   | Delete cd ->
-      Format.fprintf ppf  "%aAn extra constructor, %a, is provided in %s %s."
+      Fmt.fprintf ppf  "%aAn extra constructor, %a, is provided in %s %s."
         prefix x Style.inline_code (Ident.name cd.delete.cd_id) first decl
   | Insert cd ->
-      Format.fprintf ppf "%aA constructor, %a, is missing in %s %s."
+      Fmt.fprintf ppf "%aA constructor, %a, is missing in %s %s."
         prefix x Style.inline_code (Ident.name cd.insert.cd_id) first decl
   | Change Type {got; expected; reason} ->
-      Format.fprintf ppf
+      Fmt.fprintf ppf
         "@[<hv>%aConstructors do not match:@;<1 2>\
          %a@ is not the same as:\
          @;<1 2>%a@ %a@]"
@@ -357,24 +360,24 @@ let pp_variant_diff first second prefix decl env ppf (x : variant_change) =
         (Style.as_inline_code Printtyp.constructor) expected
         (report_constructor_mismatch first second decl env) reason
   | Change Name n ->
-      Format.fprintf ppf
+      Fmt.fprintf ppf
         "%aConstructors have different names, %a and %a."
         prefix x
         Style.inline_code n.got
         Style.inline_code n.expected
   | Swap sw ->
-      Format.fprintf ppf
+      Fmt.fprintf ppf
         "%aConstructors %a and %a have been swapped."
         prefix x
         Style.inline_code sw.first
         Style.inline_code sw.last
   | Move {name; got; expected} ->
-      Format.fprintf ppf
+      Fmt.fprintf ppf
         "@[<2>%aConstructor %a has been moved@ from@ position %d@ to %d.@]"
         prefix x Style.inline_code name expected got
 
 let report_extension_constructor_mismatch first second decl env ppf err =
-  let pr fmt = Format.fprintf ppf fmt in
+  let pr fmt = Fmt.fprintf ppf fmt in
   match (err : extension_constructor_mismatch) with
   | Constructor_privacy ->
       pr "Private extension constructor(s) would be revealed."
@@ -390,8 +393,8 @@ let report_extension_constructor_mismatch first second decl env ppf err =
 
 
 let report_private_variant_mismatch first second decl env ppf err =
-  let pr fmt = Format.fprintf ppf fmt in
-  let pp_tag ppf x = Format.fprintf ppf "`%s" x in
+  let pr fmt = Fmt.fprintf ppf fmt in
+  let pp_tag ppf x = Fmt.fprintf ppf "`%s" x in
   match (err : private_variant_mismatch) with
   | Only_outer_closed ->
       (* It's only dangerous in one direction, so we don't have a position *)
@@ -408,14 +411,14 @@ let report_private_variant_mismatch first second decl env ppf err =
       report_type_inequality env ppf err
 
 let report_private_object_mismatch env ppf err =
-  let pr fmt = Format.fprintf ppf fmt in
+  let pr fmt = Fmt.fprintf ppf fmt in
   match (err : private_object_mismatch) with
   | Missing s ->
       pr "The implementation is missing the method %a" Style.inline_code s
   | Types err -> report_type_inequality env ppf err
 
 let report_kind_mismatch first second ppf (kind1, kind2) =
-  let pr fmt = Format.fprintf ppf fmt in
+  let pr fmt = Fmt.fprintf ppf fmt in
   let kind_to_string = function
   | Kind_abstract -> "abstract"
   | Kind_record -> "a record"
@@ -428,7 +431,7 @@ let report_kind_mismatch first second ppf (kind1, kind2) =
     (kind_to_string kind2)
 
 let report_type_mismatch first second decl env ppf err =
-  let pr fmt = Format.fprintf ppf fmt in
+  let pr fmt = Fmt.fprintf ppf fmt in
   pr "@ ";
   match err with
   | Arity ->

--- a/typing/includecore.mli
+++ b/typing/includecore.mli
@@ -141,14 +141,14 @@ val class_types:
 val report_value_mismatch :
   string -> string ->
   Env.t ->
-  Format.formatter -> value_mismatch -> unit
+  value_mismatch Format_doc.printer
 
 val report_type_mismatch :
   string -> string -> string ->
   Env.t ->
-  Format.formatter -> type_mismatch -> unit
+  type_mismatch Format_doc.printer
 
 val report_extension_constructor_mismatch :
   string -> string -> string ->
   Env.t ->
-  Format.formatter -> extension_constructor_mismatch -> unit
+  extension_constructor_mismatch Format_doc.printer

--- a/typing/includemod.ml
+++ b/typing/includemod.ml
@@ -313,7 +313,7 @@ let rec print_coercion ppf c =
         Rawprinttyp.type_expr pc_type
   | Tcoerce_alias (_, p, c) ->
       pr "@[<2>alias %a@ (%a)@]"
-        Printtyp.path p
+        Printtyp.Compat.path p
         print_coercion c
 and print_coercion2 ppf (n, c) =
   Format.fprintf ppf "@[%d,@ %a@]" n print_coercion c

--- a/typing/includemod_errorprinter.ml
+++ b/typing/includemod_errorprinter.ml
@@ -14,6 +14,7 @@
 (**************************************************************************)
 
 module Style = Misc.Style
+module Fmt = Format_doc
 
 module Context = struct
   type pos =
@@ -34,28 +35,28 @@ module Context = struct
 
   let rec context ppf = function
       Module id :: rem ->
-        Format.fprintf ppf "@[<2>module %a%a@]" Printtyp.ident id args rem
+        Fmt.fprintf ppf "@[<2>module %a%a@]" Printtyp.ident id args rem
     | Modtype id :: rem ->
-        Format.fprintf ppf "@[<2>module type %a =@ %a@]"
+        Fmt.fprintf ppf "@[<2>module type %a =@ %a@]"
           Printtyp.ident id context_mty rem
     | Body x :: rem ->
-        Format.fprintf ppf "functor (%s) ->@ %a" (argname x) context_mty rem
+        Fmt.fprintf ppf "functor (%s) ->@ %a" (argname x) context_mty rem
     | Arg x :: rem ->
-        Format.fprintf ppf "functor (%s : %a) -> ..."
+        Fmt.fprintf ppf "functor (%s : %a) -> ..."
           (argname x) context_mty rem
     | [] ->
-        Format.fprintf ppf "<here>"
+        Fmt.fprintf ppf "<here>"
   and context_mty ppf = function
       (Module _ | Modtype _) :: _ as rem ->
-        Format.fprintf ppf "@[<2>sig@ %a@;<1 -2>end@]" context rem
+        Fmt.fprintf ppf "@[<2>sig@ %a@;<1 -2>end@]" context rem
     | cxt -> context ppf cxt
   and args ppf = function
       Body x :: rem ->
-        Format.fprintf ppf "(%s)%a" (argname x) args rem
+        Fmt.fprintf ppf "(%s)%a" (argname x) args rem
     | Arg x :: rem ->
-        Format.fprintf ppf "(%s :@ %a) : ..." (argname  x) context_mty rem
+        Fmt.fprintf ppf "(%s :@ %a) : ..." (argname  x) context_mty rem
     | cxt ->
-        Format.fprintf ppf " :@ %a" context_mty cxt
+        Fmt.fprintf ppf " :@ %a" context_mty cxt
   and argname = function
     | Types.Unit -> ""
     | Types.Named (None, _) -> "_"
@@ -64,19 +65,19 @@ module Context = struct
   let alt_pp ppf cxt =
     if cxt = [] then () else
     if List.for_all (function Module _ -> true | _ -> false) cxt then
-      Format.fprintf ppf ",@ in module %a"
+      Fmt.fprintf ppf ",@ in module %a"
         (Style.as_inline_code Printtyp.path) (path_of_context cxt)
     else
-      Format.fprintf ppf ",@ @[<hv 2>at position@ %a@]"
+      Fmt.fprintf ppf ",@ @[<hv 2>at position@ %a@]"
         (Style.as_inline_code context) cxt
 
   let pp ppf cxt =
     if cxt = [] then () else
     if List.for_all (function Module _ -> true | _ -> false) cxt then
-      Format.fprintf ppf "In module %a:@ "
+      Fmt.fprintf ppf "In module %a:@ "
         (Style.as_inline_code Printtyp.path) (path_of_context cxt)
     else
-      Format.fprintf ppf "@[<hv 2>At position@ %a@]@ "
+      Fmt.fprintf ppf "@[<hv 2>At position@ %a@]@ "
         (Style.as_inline_code context) cxt
 end
 
@@ -174,7 +175,7 @@ module Runtime_coercion = struct
   let item mt k = Includemod.item_ident_name (runtime_item k mt)
 
   let pp_item ppf (id,_,kind) =
-    Format.fprintf ppf "%s %a"
+    Fmt.fprintf ppf "%s %a"
       (Includemod.kind_of_field_desc kind)
       Style.inline_code (Ident.name id)
 
@@ -187,13 +188,13 @@ module Runtime_coercion = struct
     | Some (path, Transposition (k,l)) ->
     try
       let ctx, mt = find env path mty in
-      Format.fprintf ppf
+      Fmt.fprintf ppf
         "@[<hv 2>Illegal permutation of runtime components in a module type.@ \
          @[For example%a,@]@ @[the %a@ and the %a are not in the same order@ \
          in the expected and actual module types.@]@]"
         ctx_printer ctx pp_item (item mt k) pp_item (item mt l)
     with Not_found -> (* this should not happen *)
-      Format.fprintf ppf
+      Fmt.fprintf ppf
         "Illegal permutation of runtime components in a module type."
 
   let in_package_subtype ctx_printer env mty c ppf =
@@ -202,33 +203,33 @@ module Runtime_coercion = struct
         (* The coercion looks like the identity but was not simplified to
            [Tcoerce_none], this only happens when the two first-class module
            types differ by runtime size *)
-        Format.fprintf ppf
+        Fmt.fprintf ppf
           "The two first-class module types differ by their runtime size."
     | Some (path, c) ->
   try
     let ctx, mt = find env path mty in
     match c with
     | Primitive_coercion prim_name ->
-        Format.fprintf ppf
+        Fmt.fprintf ppf
           "@[The two first-class module types differ by a coercion of@ \
            the primitive %a@ to a value%a.@]"
           Style.inline_code prim_name
           ctx_printer ctx
     | Alias_coercion path ->
-        Format.fprintf ppf
+        Fmt.fprintf ppf
           "@[The two first-class module types differ by a coercion of@ \
            a module alias %a@ to a module%a.@]"
           (Style.as_inline_code Printtyp.path) path
           ctx_printer ctx
     | Transposition (k,l) ->
-        Format.fprintf ppf
+        Fmt.fprintf ppf
           "@[@[The two first-class module types do not share@ \
            the same positions for runtime components.@]@ \
            @[For example,%a@ the %a@ occurs at the expected position of@ \
            the %a.@]@]"
           ctx_printer ctx pp_item (item mt k) pp_item (item mt l)
   with Not_found ->
-    Format.fprintf ppf
+    Fmt.fprintf ppf
       "@[The two packages types do not share@ \
        the@ same@ positions@ for@ runtime@ components.@]"
 
@@ -251,7 +252,7 @@ let is_big obj =
 let show_loc msg ppf loc =
   let pos = loc.Location.loc_start in
   if List.mem pos.Lexing.pos_fname [""; "_none_"; "//toplevel//"] then ()
-  else Format.fprintf ppf "@\n@[<2>%a:@ %s@]" Location.print_loc loc msg
+  else Fmt.fprintf ppf "@\n@[<2>%a:@ %s@]" Location.print_loc loc msg
 
 let show_locs ppf (loc1, loc2) =
   show_loc "Expected declaration" ppf loc2;
@@ -260,9 +261,9 @@ let show_locs ppf (loc1, loc2) =
 
 let dmodtype mty =
   let tmty = Printtyp.tree_of_modtype mty in
-  Format.dprintf "%a" !Oprint.out_module_type tmty
+  Fmt.dprintf "%a" !Oprint.out_module_type tmty
 
-let space ppf () = Format.fprintf ppf "@ "
+let space ppf () = Fmt.fprintf ppf "@ "
 
 (**
    In order to display a list of functor arguments in a compact format,
@@ -311,8 +312,8 @@ module With_shorthand = struct
 
   let make side pos =
     match side with
-    | Got -> Format.sprintf "$S%d" pos
-    | Expected -> Format.sprintf "$T%d" pos
+    | Got -> Fmt.asprintf "$S%d" pos
+    | Expected -> Fmt.asprintf "$T%d" pos
     | Unneeded -> "..."
 
   (** Add shorthands to a patch *)
@@ -357,43 +358,43 @@ module With_shorthand = struct
   (** Printing of arguments with shorthands *)
   let pp ppx = function
     | Original x -> ppx x
-    | Synthetic s -> Format.dprintf "%s" s.name
+    | Synthetic s -> Fmt.dprintf "%s" s.name
 
   let pp_orig ppx = function
     | Original x | Synthetic { item=x; _ } -> ppx x
 
   let definition x = match functor_param x with
-    | Unit -> Format.dprintf "()"
+    | Unit -> Fmt.dprintf "()"
     | Named(_,short_mty) ->
         match short_mty with
         | Original mty -> dmodtype mty
         | Synthetic {name; item = mty} ->
-            Format.dprintf
+            Fmt.dprintf
               "%s@ =@ %t" name (dmodtype mty)
 
   let param x = match functor_param x with
-    | Unit -> Format.dprintf "()"
+    | Unit -> Fmt.dprintf "()"
     | Named (_, short_mty) ->
         pp dmodtype short_mty
 
   let qualified_param x = match functor_param x with
-    | Unit -> Format.dprintf "()"
+    | Unit -> Fmt.dprintf "()"
     | Named (None, Original (Mty_signature []) ) ->
-        Format.dprintf "(sig end)"
+        Fmt.dprintf "(sig end)"
     | Named (None, short_mty) ->
         pp dmodtype short_mty
     | Named (Some p, short_mty) ->
-        Format.dprintf "(%s : %t)"
+        Fmt.dprintf "(%s : %t)"
           (Ident.name p) (pp dmodtype short_mty)
 
   let definition_of_argument ua =
     let arg, mty = ua.item in
     match (arg: Err.functor_arg_descr) with
-    | Unit -> Format.dprintf "()"
-    | Empty_struct -> Format.dprintf "(struct end)"
+    | Unit -> Fmt.dprintf "()"
+    | Empty_struct -> Fmt.dprintf "(struct end)"
     | Named p ->
         let mty = modtype { ua with item = mty } in
-        Format.dprintf
+        Fmt.dprintf
           "%a@ :@ %t"
           Printtyp.path p
           (pp_orig dmodtype mty)
@@ -402,14 +403,14 @@ module With_shorthand = struct
         begin match short_mty with
         | Original mty -> dmodtype mty
         | Synthetic {name; item=mty} ->
-            Format.dprintf "%s@ :@ %t" name (dmodtype mty)
+            Fmt.dprintf "%s@ :@ %t" name (dmodtype mty)
         end
 
   let arg ua =
     let arg, mty = ua.item in
     match (arg: Err.functor_arg_descr) with
-    | Unit -> Format.dprintf "()"
-    | Empty_struct -> Format.dprintf "(struct end)"
+    | Unit -> Fmt.dprintf "()"
+    | Empty_struct -> Fmt.dprintf "(struct end)"
     | Named p -> fun ppf -> Printtyp.path ppf p
     | Anonymous ->
         let short_mty = modtype { ua with item=mty } in
@@ -429,10 +430,10 @@ module Functor_suberror = struct
   let pretty_params sep proj printer patch =
     let elt (x,param) =
       let sty = Diffing.(style @@ classify x) in
-      Format.dprintf "%a%t%a"
-        Format.pp_open_stag (Style.Style sty)
+      Fmt.dprintf "%a%t%a"
+        Fmt.pp_open_stag (Style.Style sty)
         (printer param)
-        Format.pp_close_stag ()
+        Fmt.pp_close_stag ()
     in
     let params = List.filter_map proj @@ List.map snd patch in
     Printtyp.functor_parameters ~sep elt params
@@ -471,17 +472,17 @@ module Functor_suberror = struct
       pretty_params space extract With_shorthand.qualified_param d
 
     let insert mty =
-      Format.dprintf
+      Fmt.dprintf
         "An argument appears to be missing with module type@;<1 2>@[%t@]"
         (With_shorthand.definition mty)
 
     let delete mty =
-      Format.dprintf
+      Fmt.dprintf
         "An extra argument is provided of module type@;<1 2>@[%t@]"
         (With_shorthand.definition mty)
 
       let ok x y =
-        Format.dprintf
+        Fmt.dprintf
           "Module types %t and %t match"
           (With_shorthand.param x)
           (With_shorthand.param y)
@@ -489,17 +490,17 @@ module Functor_suberror = struct
       let diff g e more =
         let g = With_shorthand.definition g in
         let e = With_shorthand.definition e in
-        Format.dprintf
+        Fmt.dprintf
           "Module types do not match:@ @[%t@]@;<1 -2>does not include@ \
            @[%t@]%t"
           g e (more ())
 
       let incompatible = function
         | Types.Unit ->
-            Format.dprintf
+            Fmt.dprintf
               "The functor was expected to be applicative at this position"
         | Types.Named _ ->
-            Format.dprintf
+            Fmt.dprintf
               "The functor was expected to be generative at this position"
 
       let patch env got expected =
@@ -525,7 +526,7 @@ module Functor_suberror = struct
       pretty_params space extract With_shorthand.arg d
 
     let delete mty =
-      Format.dprintf
+      Fmt.dprintf
         "The following extra argument is provided@;<1 2>@[%t@]"
         (With_shorthand.definition_of_argument mty)
 
@@ -534,10 +535,10 @@ module Functor_suberror = struct
     let ok x y =
       let pp_orig_name = match With_shorthand.functor_param y with
         | With_shorthand.Named (_, Original mty) ->
-            Format.dprintf " %t" (dmodtype mty)
+            Fmt.dprintf " %t" (dmodtype mty)
         | _ -> ignore
       in
-      Format.dprintf
+      Fmt.dprintf
         "Module %t matches the expected module type%t"
         (With_shorthand.arg x)
         pp_orig_name
@@ -545,7 +546,7 @@ module Functor_suberror = struct
     let diff g e more =
       let g = With_shorthand.definition_of_argument g in
       let e = With_shorthand.definition e in
-      Format.dprintf
+      Fmt.dprintf
         "Modules do not match:@ @[%t@]@;<1 -2>\
          is not included in@ @[%t@]%t"
         g e (more ())
@@ -556,10 +557,10 @@ module Functor_suberror = struct
     let single_diff g e more =
       let _arg, mty = g.With_shorthand.item in
       let e = match e.With_shorthand.item with
-        | Types.Unit -> Format.dprintf "()"
+        | Types.Unit -> Fmt.dprintf "()"
         | Types.Named(_, mty) -> dmodtype mty
       in
-      Format.dprintf
+      Fmt.dprintf
         "Modules do not match:@ @[%t@]@;<1 -2>\
          is not included in@ @[%t@]%t"
         (dmodtype mty) e (more ())
@@ -567,10 +568,10 @@ module Functor_suberror = struct
 
     let incompatible = function
       | Unit ->
-          Format.dprintf
+          Fmt.dprintf
             "The functor was expected to be applicative at this position"
       | Named _ | Anonymous ->
-          Format.dprintf
+          Fmt.dprintf
             "The functor was expected to be generative at this position"
       | Empty_struct ->
           (* an empty structure can be used in both applicative and generative
@@ -580,18 +581,18 @@ module Functor_suberror = struct
 
   let subcase sub ~expansion_token env (pos, diff) =
     Location.msg "%a%a%a%a@[<hv 2>%t@]%a"
-      Format.pp_print_tab ()
-      Format.pp_open_tbox ()
+      Fmt.pp_print_tab ()
+      Fmt.pp_open_tbox ()
       Diffing.prefix (pos, Diffing.classify diff)
-      Format.pp_set_tab ()
+      Fmt.pp_set_tab ()
       (Printtyp.wrap_printing_env env ~error:true
          (fun () -> sub ~expansion_token env diff)
       )
-     Format.pp_close_tbox ()
+     Fmt.pp_close_tbox ()
 
   let onlycase sub ~expansion_token env (_, diff) =
     Location.msg "%a@[<hv 2>%t@]"
-      Format.pp_print_tab ()
+      Fmt.pp_print_tab ()
       (Printtyp.wrap_printing_env env ~error:true
          (fun () -> sub ~expansion_token env diff)
       )
@@ -638,25 +639,24 @@ let coalesce msgs =
   | [] -> ignore
   | before ->
       let ctx ppf =
-        Format.pp_print_list ~pp_sep:space
-          (fun ppf x -> x.Location.txt ppf)
+        Fmt.pp_print_list ~pp_sep:space
+          (fun ppf x -> Fmt.pp_doc ppf x.Location.txt)
           ppf before in
       ctx
 
 let subcase_list l ppf = match l with
   | [] -> ()
   | _ :: _ ->
-      Format.fprintf ppf "@;<1 -2>@[%a@]"
-        (Format.pp_print_list ~pp_sep:space
-           (fun ppf f -> f.Location.txt ppf)
-        )
+      let pp_msg ppf lmsg = Fmt.pp_doc ppf lmsg.Location.txt in
+      Fmt.fprintf ppf "@;<1 -2>@[%a@]"
+        (Fmt.pp_print_list ~pp_sep:space pp_msg)
         (List.rev l)
 
 (* Printers for leaves *)
 let core env id x =
   match x with
   | Err.Value_descriptions diff ->
-      Format.dprintf "@[<v>@[<hv>%s:@;<1 2>%a@ %s@;<1 2>%a@]%a%a@]"
+      Fmt.dprintf "@[<v>@[<hv>%s:@;<1 2>%a@ %s@;<1 2>%a@]%a%a@]"
         "Values do not match"
         !Oprint.out_sig_item
         (Printtyp.tree_of_value_description id diff.got)
@@ -667,7 +667,7 @@ let core env id x =
            "the first" "the second" env) diff.symptom
         show_locs (diff.got.val_loc, diff.expected.val_loc)
   | Err.Type_declarations diff ->
-      Format.dprintf "@[<v>@[<hv>%s:@;<1 2>%a@ %s@;<1 2>%a@]%a%a@]"
+      Fmt.dprintf "@[<v>@[<hv>%s:@;<1 2>%a@ %s@;<1 2>%a@]%a%a@]"
         "Type declarations do not match"
         !Oprint.out_sig_item
         (Printtyp.tree_of_type_declaration id diff.got Trec_first)
@@ -678,7 +678,7 @@ let core env id x =
            "the first" "the second" "declaration" env) diff.symptom
         show_locs (diff.got.type_loc, diff.expected.type_loc)
   | Err.Extension_constructors diff ->
-      Format.dprintf "@[<v>@[<hv>%s:@;<1 2>%a@ %s@;<1 2>%a@]@ %a%a@]"
+      Fmt.dprintf "@[<v>@[<hv>%s:@;<1 2>%a@ %s@;<1 2>%a@]@ %a%a@]"
         "Extension declarations do not match"
         !Oprint.out_sig_item
         (Printtyp.tree_of_extension_constructor id diff.got Text_first)
@@ -689,7 +689,7 @@ let core env id x =
            "the first" "the second" "declaration" env) diff.symptom
         show_locs (diff.got.ext_loc, diff.expected.ext_loc)
   | Err.Class_type_declarations diff ->
-      Format.dprintf
+      Fmt.dprintf
         "@[<hv 2>Class type declarations do not match:@ \
          %a@;<1 -2>does not match@ %a@]@ %a"
         !Oprint.out_sig_item
@@ -700,7 +700,7 @@ let core env id x =
   | Err.Class_declarations {got;expected;symptom} ->
       let t1 = Printtyp.tree_of_class_declaration id got Trec_first in
       let t2 = Printtyp.tree_of_class_declaration id expected Trec_first in
-      Format.dprintf
+      Fmt.dprintf
         "@[<hv 2>Class declarations do not match:@ \
          %a@;<1 -2>does not match@ %a@]@ %a"
         !Oprint.out_sig_item t1
@@ -709,34 +709,34 @@ let core env id x =
 
 let missing_field ppf item =
   let id, loc, kind =  Includemod.item_ident_name item in
-  Format.fprintf ppf "The %s %a is required but not provided%a"
+  Fmt.fprintf ppf "The %s %a is required but not provided%a"
     (Includemod.kind_of_field_desc kind)
     (Style.as_inline_code Printtyp.ident) id
     (show_loc "Expected declaration") loc
 
 let module_types {Err.got=mty1; expected=mty2} =
-  Format.dprintf
+  Fmt.dprintf
     "@[<hv 2>Modules do not match:@ \
      %a@;<1 -2>is not included in@ %a@]"
     !Oprint.out_module_type (Printtyp.tree_of_modtype mty1)
     !Oprint.out_module_type (Printtyp.tree_of_modtype mty2)
 
 let eq_module_types {Err.got=mty1; expected=mty2} =
-  Format.dprintf
+  Fmt.dprintf
     "@[<hv 2>Module types do not match:@ \
      %a@;<1 -2>is not equal to@ %a@]"
     !Oprint.out_module_type (Printtyp.tree_of_modtype mty1)
     !Oprint.out_module_type (Printtyp.tree_of_modtype mty2)
 
 let module_type_declarations id {Err.got=d1 ; expected=d2} =
-  Format.dprintf
+  Fmt.dprintf
     "@[<hv 2>Module type declarations do not match:@ \
      %a@;<1 -2>does not match@ %a@]"
     !Oprint.out_sig_item (Printtyp.tree_of_modtype_declaration id d1)
     !Oprint.out_sig_item (Printtyp.tree_of_modtype_declaration id d2)
 
 let interface_mismatch ppf (diff: _ Err.diff) =
-  Format.fprintf ppf
+  Fmt.fprintf ppf
     "The implementation %a@ does not match the interface %a:@ "
     Style.inline_code diff.got Style.inline_code diff.expected
 
@@ -745,7 +745,7 @@ let core_module_type_symptom (x:Err.core_module_type_symptom)  =
   | Not_an_alias | Not_an_identifier | Abstract_module_type
   | Incompatible_aliases -> None
   | Unbound_module_path path ->
-      Some(Format.dprintf "Unbound module %a"
+      Some(Fmt.dprintf "Unbound module %a"
              (Style.as_inline_code Printtyp.path) path
           )
 
@@ -787,7 +787,7 @@ and module_type_symptom ~eqmode ~expansion_token ~env ~before ~ctx = function
       module_type ~eqmode ~expansion_token ~env ~before ~ctx diff
   | Invalid_module_alias path ->
       let printer =
-        Format.dprintf "Module %a cannot be aliased"
+        Fmt.dprintf "Module %a cannot be aliased"
           (Style.as_inline_code Printtyp.path) path
       in
       dwith_context ctx printer :: before
@@ -797,7 +797,7 @@ and functor_params ~expansion_token ~env ~before ~ctx {got;expected;_} =
   let actual = Functor_suberror.Inclusion.got d in
   let expected = Functor_suberror.expected d in
   let main =
-    Format.dprintf
+    Fmt.dprintf
       "@[<hv 2>Modules do not match:@ \
        @[functor@ %t@ -> ...@]@;<1 -2>is not included in@ \
        @[functor@ %t@ -> ...@]@]"
@@ -823,8 +823,8 @@ and signature ~expansion_token ~env:_ ~before ~ctx sgs =
           if expansion_token then
             let init_missings, last_missing = Misc.split_last missings in
             List.map (Location.msg "%a" missing_field) init_missings
-            @ [ with_context ctx missing_field last_missing ]
-            @ before
+            @ with_context ctx missing_field last_missing
+            :: before
           else
             before
       | [], a :: _ -> sigitem ~expansion_token ~env:sgs.env ~before ~ctx a
@@ -936,16 +936,15 @@ let all env = function
 
 (* General error reporting *)
 
-let err_msgs (env, err) =
+let err_msgs ppf (env, err) =
   Printtyp.wrap_printing_env ~error:true env
-    (fun () -> coalesce @@ all env err)
+    (fun () -> (coalesce @@ all env err)  ppf)
 
 let report_error err =
-  let main = err_msgs err in
   Location.errorf
     ~loc:Location.(in_file !input_name)
     ~footnote:Printtyp.Conflicts.err_msg
-   "%t" main
+   "%a" err_msgs err
 
 let report_apply_error ~loc env (app_name, mty_f, args) =
   let footnote = Printtyp.Conflicts.err_msg in
@@ -986,12 +985,12 @@ let report_apply_error ~loc env (app_name, mty_f, args) =
         let intro ppf =
           match app_name with
           | Includemod.Anonymous_functor ->
-              Format.fprintf ppf "This functor application is ill-typed."
+              Fmt.fprintf ppf "This functor application is ill-typed."
           | Includemod.Full_application_path lid ->
-              Format.fprintf ppf "The functor application %a is ill-typed."
+              Fmt.fprintf ppf "The functor application %a is ill-typed."
                 (Style.as_inline_code Printtyp.longident) lid
           |  Includemod.Named_leftmost_functor lid ->
-              Format.fprintf ppf
+              Fmt.fprintf ppf
                 "This application of the functor %a is ill-typed."
                  (Style.as_inline_code Printtyp.longident) lid
         in
@@ -1008,8 +1007,9 @@ let report_apply_error ~loc env (app_name, mty_f, args) =
           intro
           actual expected
 
-let coercion_in_package_subtype env mty c ppf =
-    Runtime_coercion.in_package_subtype Context.alt_pp env mty c ppf
+let coercion_in_package_subtype env mty c =
+  Format_doc.doc_printf "%t" @@
+  Runtime_coercion.in_package_subtype Context.alt_pp env mty c
 
 let register () =
   Location.register_error_of_exn

--- a/typing/includemod_errorprinter.ml
+++ b/typing/includemod_errorprinter.ml
@@ -252,7 +252,7 @@ let is_big obj =
 let show_loc msg ppf loc =
   let pos = loc.Location.loc_start in
   if List.mem pos.Lexing.pos_fname [""; "_none_"; "//toplevel//"] then ()
-  else Fmt.fprintf ppf "@\n@[<2>%a:@ %s@]" Location.print_loc loc msg
+  else Fmt.fprintf ppf "@\n@[<2>%a:@ %s@]" Location.Doc.loc loc msg
 
 let show_locs ppf (loc1, loc2) =
   show_loc "Expected declaration" ppf loc2;

--- a/typing/includemod_errorprinter.mli
+++ b/typing/includemod_errorprinter.mli
@@ -13,8 +13,7 @@
 (*                                                                        *)
 (**************************************************************************)
 
-val err_msgs: Includemod.explanation -> Format.formatter -> unit
+val err_msgs: Includemod.explanation Format_doc.printer
 val coercion_in_package_subtype:
-  Env.t -> Types.module_type -> Typedtree.module_coercion -> Format.formatter ->
-  unit
+  Env.t -> Types.module_type -> Typedtree.module_coercion -> Format_doc.doc
 val register: unit -> unit

--- a/typing/oprint.ml
+++ b/typing/oprint.ml
@@ -13,7 +13,7 @@
 (*                                                                        *)
 (**************************************************************************)
 
-open Format
+open Format_doc
 open Outcometree
 
 exception Ellipsis
@@ -249,7 +249,7 @@ let print_out_value ppf tree =
   in
   cautious print_tree_1 ppf tree
 
-let out_value = ref print_out_value
+let out_value = ref (compat print_out_value)
 
 (* Types *)
 
@@ -267,7 +267,7 @@ let rec print_list pr sep ppf =
 let pr_present =
   print_list (fun ppf s -> fprintf ppf "`%s" s) (fun ppf -> fprintf ppf "@ ")
 
-let pr_var = Pprintast.tyvar
+let pr_var = Pprintast.Doc.tyvar
 let ty_var ~non_gen ppf s =
   pr_var ppf (if non_gen then "_" ^ s else s)
 
@@ -813,6 +813,8 @@ let _ = out_functor_parameters := print_out_functor_parameters
 
 (* Phrases *)
 
+open Format
+
 let print_out_exception ppf exn outv =
   match exn with
     Sys.Break -> fprintf ppf "Interrupted.@."
@@ -847,23 +849,26 @@ let rec print_items ppf =
           otyext_constructors = exts;
           otyext_private = ext.oext_private }
       in
-        fprintf ppf "@[%a@]" !out_type_extension te;
+        fprintf ppf "@[%a@]" (Format_doc.compat !out_type_extension) te;
         if items <> [] then fprintf ppf "@ %a" print_items items
   | (tree, valopt) :: items ->
       begin match valopt with
         Some v ->
-          fprintf ppf "@[<2>%a =@ %a@]" !out_sig_item tree
+          fprintf ppf "@[<2>%a =@ %a@]" (Format_doc.compat !out_sig_item) tree
             !out_value v
-      | None -> fprintf ppf "@[%a@]" !out_sig_item tree
+      | None -> fprintf ppf "@[%a@]" (Format_doc.compat !out_sig_item) tree
       end;
       if items <> [] then fprintf ppf "@ %a" print_items items
 
 let print_out_phrase ppf =
   function
     Ophr_eval (outv, ty) ->
-      fprintf ppf "@[- : %a@ =@ %a@]@." !out_type ty !out_value outv
+      fprintf ppf "@[- : %a@ =@ %a@]@." (compat !out_type) ty !out_value outv
   | Ophr_signature [] -> ()
   | Ophr_signature items -> fprintf ppf "@[<v>%a@]@." print_items items
   | Ophr_exception (exn, outv) -> print_out_exception ppf exn outv
 
 let out_phrase = ref print_out_phrase
+
+type 'a printer = 'a Format_doc.printer ref
+type 'a toplevel_printer = (Format.formatter -> 'a -> unit) ref

--- a/typing/oprint.mli
+++ b/typing/oprint.mli
@@ -13,24 +13,24 @@
 (*                                                                        *)
 (**************************************************************************)
 
-open Format
 open Outcometree
 
-val out_ident : (formatter -> out_ident -> unit) ref
-val out_value : (formatter -> out_value -> unit) ref
-val out_label : (formatter -> string * bool * out_type -> unit) ref
-val out_type : (formatter -> out_type -> unit) ref
-val out_type_args : (formatter -> out_type list -> unit) ref
-val out_constr : (formatter -> out_constructor -> unit) ref
-val out_class_type : (formatter -> out_class_type -> unit) ref
-val out_module_type : (formatter -> out_module_type -> unit) ref
-val out_sig_item : (formatter -> out_sig_item -> unit) ref
-val out_signature : (formatter -> out_sig_item list -> unit) ref
+type 'a printer = 'a Format_doc.printer ref
+type 'a toplevel_printer = (Format.formatter -> 'a -> unit) ref
+
+val out_ident: out_ident printer
+val out_value : out_value toplevel_printer
+val out_label : (string * bool * out_type ) printer
+val out_type : out_type printer
+val out_type_args : out_type list printer
+val out_constr : out_constructor printer
+val out_class_type : out_class_type printer
+val out_module_type : out_module_type printer
+val out_sig_item : out_sig_item printer
+val out_signature :out_sig_item list printer
 val out_functor_parameters :
-  (formatter ->
-   (string option * Outcometree.out_module_type) option list -> unit)
-    ref
-val out_type_extension : (formatter -> out_type_extension -> unit) ref
-val out_phrase : (formatter -> out_phrase -> unit) ref
+  (string option * Outcometree.out_module_type) option list printer
+val out_type_extension : out_type_extension printer
+val out_phrase : out_phrase toplevel_printer
 
 val parenthesized_ident : string -> bool

--- a/typing/outcometree.mli
+++ b/typing/outcometree.mli
@@ -49,7 +49,7 @@ type out_value =
   | Oval_int64 of int64
   | Oval_nativeint of nativeint
   | Oval_list of out_value list
-  | Oval_printer of (Format.formatter -> unit)
+  | Oval_printer of (Format_doc.formatter -> unit)
   | Oval_record of (out_ident * out_value) list
   | Oval_string of string * int * out_string (* string, size-to-print, kind *)
   | Oval_stuff of string

--- a/typing/parmatch.ml
+++ b/typing/parmatch.ml
@@ -1884,7 +1884,7 @@ let do_check_partial ~pred loc casel pss = match pss with
     | Seq.Cons (v, _rest) ->
       if Warnings.is_active (Warnings.Partial_match "") then begin
         let errmsg =
-          let doc = ref Format_doc.empty in
+          let doc = ref Format_doc.Doc.empty in
           let fmt = Format_doc.formatter doc in
           Format_doc.fprintf fmt "@[<v>%a" Printpat.top_pretty v;
           if do_match (initial_only_guarded casel) [v] then

--- a/typing/parmatch.ml
+++ b/typing/parmatch.ml
@@ -1884,20 +1884,20 @@ let do_check_partial ~pred loc casel pss = match pss with
     | Seq.Cons (v, _rest) ->
       if Warnings.is_active (Warnings.Partial_match "") then begin
         let errmsg =
-          let buf = Buffer.create 16 in
-          let fmt = Format.formatter_of_buffer buf in
-          Format.fprintf fmt "@[<v>%a" Printpat.pretty_pat v;
+          let doc = ref Format_doc.empty in
+          let fmt = Format_doc.formatter doc in
+          Format_doc.fprintf fmt "@[<v>%a" Printpat.top_pretty v;
           if do_match (initial_only_guarded casel) [v] then
-            Format.fprintf fmt
+            Format_doc.fprintf fmt
               "@,(However, some guarded clause may match this value.)";
           if contains_extension v then
-            Format.fprintf fmt
+            Format_doc.fprintf fmt
               "@,@[Matching over values of extensible variant types \
                (the *extension* above)@,\
                must include a wild card pattern@ in order to be exhaustive.@]"
           ;
-          Format.fprintf fmt "@]@?";
-          Buffer.contents buf
+          Format_doc.fprintf fmt "@]";
+          Format_doc.(asprintf "%a" pp_doc) !doc
         in
         Location.prerr_warning loc (Warnings.Partial_match errmsg)
       end;

--- a/typing/path.ml
+++ b/typing/path.ml
@@ -104,8 +104,8 @@ let rec name ?(paren=kfalse) = function
 let rec print ppf = function
   | Pident id -> Ident.print_with_scope ppf id
   | Pdot(p, s) | Pextra_ty (p, Pcstr_ty s) ->
-      Format.fprintf ppf "%a.%s" print p s
-  | Papply(p1, p2) -> Format.fprintf ppf "%a(%a)" print p1 print p2
+      Format_doc.fprintf ppf "%a.%s" print p s
+  | Papply(p1, p2) -> Format_doc.fprintf ppf "%a(%a)" print p1 print p2
   | Pextra_ty (p, Pext_ty) -> print ppf p
 
 let rec head = function

--- a/typing/path.mli
+++ b/typing/path.mli
@@ -68,7 +68,7 @@ val name: ?paren:(string -> bool) -> t -> string
     (* [paren] tells whether a path suffix needs parentheses *)
 val head: t -> Ident.t
 
-val print: Format.formatter -> t -> unit
+val print: t Format_doc.printer
 
 val heads: t -> Ident.t list
 

--- a/typing/persistent_env.ml
+++ b/typing/persistent_env.ml
@@ -243,14 +243,15 @@ let check_pers_struct ~allow_hidden penv f ~loc name =
       let warn = Warnings.No_cmi_file(name, None) in
         Location.prerr_warning loc warn
   | Cmi_format.Error err ->
-      let msg = Format.asprintf "%a" Cmi_format.report_error err in
+      let msg = Format.asprintf "%a"
+          (Format_doc.compat Cmi_format.report_error) err in
       let warn = Warnings.No_cmi_file(name, Some msg) in
         Location.prerr_warning loc warn
   | Error err ->
       let msg =
         match err with
         | Illegal_renaming(name, ps_name, filename) ->
-            Format.asprintf
+            Format_doc.doc_printf
               " %a@ contains the compiled interface for @ \
                %a when %a was expected"
               (Style.as_inline_code Location.print_filename) filename
@@ -258,10 +259,11 @@ let check_pers_struct ~allow_hidden penv f ~loc name =
               Style.inline_code name
         | Inconsistent_import _ -> assert false
         | Need_recursive_types name ->
-            Format.asprintf
+            Format_doc.doc_printf
               "%a uses recursive types"
               Style.inline_code name
       in
+      let msg = Format_doc.(asprintf "%a" pp_doc) msg in
       let warn = Warnings.No_cmi_file(name, Some msg) in
         Location.prerr_warning loc warn
 
@@ -350,7 +352,7 @@ let save_cmi penv psig pm =
     ~exceptionally:(fun () -> remove_file filename)
 
 let report_error ppf =
-  let open Format in
+  let open Format_doc in
   function
   | Illegal_renaming(modname, ps_name, filename) -> fprintf ppf
       "Wrong file naming: %a@ contains the compiled interface for@ \

--- a/typing/persistent_env.ml
+++ b/typing/persistent_env.ml
@@ -254,7 +254,7 @@ let check_pers_struct ~allow_hidden penv f ~loc name =
             Format_doc.doc_printf
               " %a@ contains the compiled interface for @ \
                %a when %a was expected"
-              (Style.as_inline_code Location.print_filename) filename
+              Location.Doc.quoted_filename filename
               Style.inline_code ps_name
               Style.inline_code name
         | Inconsistent_import _ -> assert false
@@ -357,14 +357,14 @@ let report_error ppf =
   | Illegal_renaming(modname, ps_name, filename) -> fprintf ppf
       "Wrong file naming: %a@ contains the compiled interface for@ \
        %a when %a was expected"
-      (Style.as_inline_code Location.print_filename) filename
+      Location.Doc.quoted_filename filename
       Style.inline_code ps_name
       Style.inline_code modname
   | Inconsistent_import(name, source1, source2) -> fprintf ppf
       "@[<hov>The files %a@ and %a@ \
               make inconsistent assumptions@ over interface %a@]"
-      (Style.as_inline_code Location.print_filename) source1
-      (Style.as_inline_code Location.print_filename) source2
+      Location.Doc.quoted_filename source1
+      Location.Doc.quoted_filename source2
       Style.inline_code name
   | Need_recursive_types(import) ->
       fprintf ppf

--- a/typing/persistent_env.mli
+++ b/typing/persistent_env.mli
@@ -27,7 +27,7 @@ type error =
 
 exception Error of error
 
-val report_error: Format.formatter -> error -> unit
+val report_error: error Format_doc.printer
 
 module Persistent_signature : sig
   type t =

--- a/typing/primitive.ml
+++ b/typing/primitive.ml
@@ -232,16 +232,16 @@ module Style = Misc.Style
 let report_error ppf err =
   match err with
   | Old_style_float_with_native_repr_attribute ->
-    Format.fprintf ppf "Cannot use %a in conjunction with %a/%a."
+    Format_doc.fprintf ppf "Cannot use %a in conjunction with %a/%a."
       Style.inline_code "float"
       Style.inline_code "[@unboxed]"
       Style.inline_code  "[@untagged]"
   | Old_style_noalloc_with_noalloc_attribute ->
-    Format.fprintf ppf "Cannot use %a in conjunction with %a."
+    Format_doc.fprintf ppf "Cannot use %a in conjunction with %a."
       Style.inline_code "noalloc"
       Style.inline_code "[@@noalloc]"
   | No_native_primitive_with_repr_attribute ->
-    Format.fprintf ppf
+    Format_doc.fprintf ppf
       "@[The native code version of the primitive is mandatory@ \
        when attributes %a or %a are present.@]"
       Style.inline_code "[@untagged]"

--- a/typing/printpat.ml
+++ b/typing/printpat.ml
@@ -18,7 +18,7 @@
 open Asttypes
 open Typedtree
 open Types
-open Format
+open Format_doc
 
 let is_cons = function
 | {cstr_name = "::"} -> true
@@ -99,7 +99,7 @@ let rec pretty_val : type k . _ -> k general_pattern -> _ = fun ppf v ->
   | Tpat_lazy v ->
       fprintf ppf "@[<2>lazy@ %a@]" pretty_arg v
   | Tpat_alias (v, x,_,_) ->
-      fprintf ppf "@[(%a@ as %a)@]" pretty_val v Ident.print x
+      fprintf ppf "@[(%a@ as %a)@]" pretty_val v Ident.doc_print x
   | Tpat_value v ->
       fprintf ppf "%a" pretty_val (v :> pattern)
   | Tpat_exception v ->
@@ -144,20 +144,30 @@ and pretty_lvals ppf = function
       fprintf ppf "%s=%a;@ %a"
         lbl.lbl_name pretty_val v pretty_lvals rest
 
+let top_pretty ppf v =
+  fprintf ppf "@[%a@]" pretty_val v
+
 let pretty_pat ppf p =
-  fprintf ppf "@[%a@]" pretty_val p
+  top_pretty ppf p ;
+  pp_print_flush ppf ()
 
 type 'k matrix = 'k general_pattern list list
 
 let pretty_line ppf line =
-  Format.fprintf ppf "@[";
+  fprintf ppf "@[";
   List.iter (fun p ->
-    Format.fprintf ppf "<%a>@ "
-      pretty_val p
-  ) line;
-  Format.fprintf ppf "@]"
+      fprintf ppf "<%a>@ "
+        pretty_val p
+    ) line;
+  fprintf ppf "@]"
 
 let pretty_matrix ppf (pss : 'k matrix) =
-  Format.fprintf ppf "@[<v 2>  %a@]"
-    (Format.pp_print_list ~pp_sep:Format.pp_print_cut pretty_line)
+  fprintf ppf "@[<v 2>  %a@]"
+    (pp_print_list ~pp_sep:pp_print_cut pretty_line)
     pss
+
+module Compat = struct
+  let pretty_pat ppf x = compat pretty_pat ppf x
+  let pretty_line ppf x = compat pretty_line ppf x
+  let pretty_matrix ppf x = compat pretty_matrix ppf x
+end

--- a/typing/printpat.mli
+++ b/typing/printpat.mli
@@ -17,11 +17,12 @@
 
 val pretty_const
   : Asttypes.constant -> string
-val pretty_val : Format.formatter -> 'k Typedtree.general_pattern -> unit
 
-val pretty_pat
-    : Format.formatter -> 'k Typedtree.general_pattern -> unit
-val pretty_line
-    : Format.formatter -> 'k Typedtree.general_pattern list -> unit
-val pretty_matrix
-    : Format.formatter -> 'k Typedtree.general_pattern list list -> unit
+val top_pretty: 'k Typedtree.general_pattern Format_doc.printer
+
+module Compat: sig
+  val pretty_pat: Format.formatter -> 'k Typedtree.general_pattern -> unit
+  val pretty_line: Format.formatter -> 'k Typedtree.general_pattern list -> unit
+  val pretty_matrix:
+    Format.formatter -> 'k Typedtree.general_pattern list list -> unit
+end

--- a/typing/printtyp.ml
+++ b/typing/printtyp.ml
@@ -2241,7 +2241,7 @@ let explain_fixed_row pos expl = match expl with
            Internal_names.add p;
            print_path p ppf))
       p
-  | Rigid -> Format_doc.empty
+  | Rigid -> Format_doc.Doc.empty
 
 let explain_variant (type variety) : variety Errortrace.variant -> _ = function
   (* Common *)
@@ -2360,7 +2360,7 @@ let explanation (type variety) intro prev env
           (Style.as_inline_code type_expr_with_reserved_names) ctx
       | None, Univ _, Some(Errortrace.Incompatible_fields {name; diff}) ->
         explain_incompatible_fields name diff
-      | _ -> Format_doc.empty
+      | _ -> Format_doc.Doc.empty
     in
     explain_escape pre kind
   | Errortrace.Incompatible_fields { name; diff} ->
@@ -2386,7 +2386,7 @@ let explanation (type variety) intro prev env
     | _ ->
         (* We had a delayed unification of the type variable with
            a non-variable after the occur check. *)
-        Some Format_doc.empty
+        Some Format_doc.Doc.empty
         (* There is no need to search further for an explanation, but
            we don't want to print a message of the form:
              {[ The type int occurs inside int list -> 'a |}
@@ -2422,7 +2422,7 @@ let prepare_expansion_head empty_tr = function
   | _ -> None
 
 let head_error_printer mode txt_got txt_but = function
-  | None -> Format_doc.empty
+  | None -> Format_doc.Doc.empty
   | Some d ->
       let d = Errortrace.map_diff (trees_of_type_expansion mode) d in
       doc_printf "%a@;<1 2>%a@ %a@;<1 2>%a"
@@ -2484,7 +2484,7 @@ let error trace_format mode subst env tr txt1 ppf txt2 ty_expect_explanation =
 
 let report_error trace_format ppf mode env tr
       ?(subst = [])
-      ?(type_expected_explanation = Fmt.empty)
+      ?(type_expected_explanation = Fmt.Doc.empty)
       txt1 txt2 =
   wrap_printing_env ~error:true env (fun () ->
     error trace_format mode subst env tr txt1 ppf txt2

--- a/typing/printtyp.ml
+++ b/typing/printtyp.ml
@@ -435,7 +435,7 @@ let tree_of_path ?disambiguation namespace p =
     (rewrite_double_underscore_paths !printing_env p)
 
 let path ppf p =
-  !Oprint.out_ident ppf (tree_of_path None p)
+  !Oprint.out_ident ppf (tree_of_path ~disambiguation:false None p)
 
 let string_of_path p =
   Format.asprintf "%a" path p

--- a/typing/printtyp.ml
+++ b/typing/printtyp.ml
@@ -161,7 +161,7 @@ module Conflicts = struct
 
   let pp_explanation ppf r=
     Fmt.fprintf ppf "@[<v 2>%a:@,Definition of %s %a@]"
-      Location.print_loc r.location (Sig_component_kind.to_string r.kind)
+      Location.Doc.loc r.location (Sig_component_kind.to_string r.kind)
       Style.inline_code r.name
 
   let print_located_explanations ppf l =

--- a/typing/printtyp.mli
+++ b/typing/printtyp.mli
@@ -15,18 +15,18 @@
 
 (* Printing functions *)
 
-open Format
+open Format_doc
 open Types
 open Outcometree
 
-val longident: formatter -> Longident.t -> unit
-val ident: formatter -> Ident.t -> unit
+val longident: Longident.t printer
+val ident: Ident.t printer
 val namespaced_ident: Shape.Sig_component_kind.t -> Ident.t -> string
 val tree_of_path: Path.t -> out_ident
-val path: formatter -> Path.t -> unit
+val path: Path.t printer
 val string_of_path: Path.t -> string
 
-val type_path: formatter -> Path.t -> unit
+val type_path: Path.t printer
 (** Print a type path taking account of [-short-paths].
     Calls should be within [wrap_printing_env]. *)
 
@@ -45,14 +45,6 @@ val wrap_printing_env: error:bool -> Env.t -> (unit -> 'a) -> 'a
     (* Call the function using the environment for type path shortening *)
     (* This affects all the printing functions below *)
     (* Also, if [~error:true], then disable the loading of cmis *)
-
-(** [wrap_printing_env_error env f] ensures that all printing functions in a
-    [Location.error] report are evaluated within the [wrap_printing_env
-    ~error:true env] context. (The original call to [f] is also evaluated
-    within that context.)
- *)
-val wrap_printing_env_error :
-  Env.t -> (unit -> Location.error) -> Location.error
 
 module Naming_context: sig
   val enable: bool -> unit
@@ -80,10 +72,9 @@ module Conflicts: sig
     collected up to this point, and reset the list of collected
     explanations *)
 
-  val print_located_explanations:
-    Format.formatter -> explanation list -> unit
+  val print_located_explanations: explanation list printer
 
-  val err_msg: unit -> (Format.formatter -> unit) option
+  val err_msg: unit -> doc option
   (** [err_msg ()] return an error message if there are pending conflict
       explanations at this point. It is often important to check for conflicts
       after all printing is done, thus the delayed nature of [err_msg]*)
@@ -99,7 +90,7 @@ val reset: unit -> unit
     other type formatters such as [prepared_type_expr].)  If you want multiple
     types to use common names for type variables, see [prepare_for_printing] and
     [prepared_type_expr].  *)
-val type_expr: formatter -> type_expr -> unit
+val type_expr: type_expr printer
 
 (** [prepare_for_printing] resets the global printing environment, a la [reset],
     and prepares the types for printing by reserving names and marking loops.
@@ -112,7 +103,7 @@ val prepare_for_printing: type_expr list -> unit
 *)
 val add_type_to_preparation: type_expr -> unit
 
-val prepared_type_expr: formatter -> type_expr -> unit
+val prepared_type_expr: type_expr printer
 (** The function [prepared_type_expr] is a less-safe but more-flexible version
     of [type_expr] that should only be called on [type_expr]s that have been
     passed to [prepare_for_printing].  Unlike [type_expr], this function does no
@@ -123,11 +114,11 @@ val prepared_type_expr: formatter -> type_expr -> unit
     [prepared_type_expr], they will use the same names for the same type
     variables. *)
 
-val constructor_arguments: formatter -> constructor_arguments -> unit
+val constructor_arguments: constructor_arguments printer
 val tree_of_type_scheme: type_expr -> out_type
-val type_scheme: formatter -> type_expr -> unit
-val prepared_type_scheme: formatter -> type_expr -> unit
-val shared_type_scheme: formatter -> type_expr -> unit
+val type_scheme: type_expr printer
+val prepared_type_scheme: type_expr printer
+val shared_type_scheme: type_expr printer
 (** [shared_type_scheme] is very similar to [type_scheme], but does not reset
     the printing context first.  This is intended to be used in cases where the
     printing should have a particularly wide context, such as documentation
@@ -135,39 +126,39 @@ val shared_type_scheme: formatter -> type_expr -> unit
     for which [type_scheme] is better suited. *)
 
 val tree_of_value_description: Ident.t -> value_description -> out_sig_item
-val value_description: Ident.t -> formatter -> value_description -> unit
-val label : formatter -> label_declaration -> unit
+val value_description: Ident.t -> value_description printer
+val label : label_declaration printer
 val add_constructor_to_preparation : constructor_declaration -> unit
-val prepared_constructor : formatter -> constructor_declaration -> unit
-val constructor : formatter -> constructor_declaration -> unit
+val prepared_constructor : constructor_declaration printer
+val constructor : constructor_declaration printer
 val tree_of_type_declaration:
     Ident.t -> type_declaration -> rec_status -> out_sig_item
 val add_type_declaration_to_preparation :
   Ident.t -> type_declaration -> unit
-val prepared_type_declaration: Ident.t -> formatter -> type_declaration -> unit
-val type_declaration: Ident.t -> formatter -> type_declaration -> unit
+val prepared_type_declaration: Ident.t -> type_declaration printer
+val type_declaration: Ident.t -> type_declaration printer
 val tree_of_extension_constructor:
     Ident.t -> extension_constructor -> ext_status -> out_sig_item
 val add_extension_constructor_to_preparation :
     extension_constructor -> unit
 val prepared_extension_constructor:
-    Ident.t -> formatter -> extension_constructor -> unit
+    Ident.t -> extension_constructor printer
 val extension_constructor:
-    Ident.t -> formatter -> extension_constructor -> unit
+    Ident.t -> extension_constructor printer
 (* Prints extension constructor with the type signature:
      type ('a, 'b) bar += A of float
 *)
 
 val extension_only_constructor:
-    Ident.t -> formatter -> extension_constructor -> unit
+    Ident.t -> extension_constructor printer
 (* Prints only extension constructor without type signature:
      A of float
 *)
 
 val tree_of_module:
     Ident.t -> ?ellipsis:bool -> module_type -> rec_status -> out_sig_item
-val modtype: formatter -> module_type -> unit
-val signature: formatter -> signature -> unit
+val modtype: module_type printer
+val signature: signature printer
 val tree_of_modtype: module_type -> out_module_type
 val tree_of_modtype_declaration:
     Ident.t -> modtype_declaration -> out_sig_item
@@ -183,55 +174,67 @@ val tree_of_modtype_declaration:
     expect: (_: sig end) (Y:X.T) (_:sig end) (Z:X.T)
 *)
 val functor_parameters:
-  sep:(Format.formatter -> unit -> unit) ->
-  ('b -> Format.formatter -> unit) ->
-  (Ident.t option * 'b) list -> Format.formatter -> unit
+  sep:unit printer -> ('b -> Format_doc.formatter -> unit) ->
+  (Ident.t option * 'b) list -> Format_doc.formatter -> unit
 
 type type_or_scheme = Type | Type_scheme
 
 val tree_of_signature: Types.signature -> out_sig_item list
 val tree_of_typexp: type_or_scheme -> type_expr -> out_type
-val modtype_declaration: Ident.t -> formatter -> modtype_declaration -> unit
-val class_type: formatter -> class_type -> unit
+val modtype_declaration: Ident.t -> modtype_declaration printer
+val class_type: class_type printer
 val tree_of_class_declaration:
     Ident.t -> class_declaration -> rec_status -> out_sig_item
-val class_declaration: Ident.t -> formatter -> class_declaration -> unit
+val class_declaration: Ident.t -> class_declaration printer
 val tree_of_cltype_declaration:
     Ident.t -> class_type_declaration -> rec_status -> out_sig_item
-val cltype_declaration: Ident.t -> formatter -> class_type_declaration -> unit
+val cltype_declaration: Ident.t -> class_type_declaration printer
 val type_expansion :
-  type_or_scheme -> Format.formatter -> Errortrace.expanded_type -> unit
+  type_or_scheme -> Errortrace.expanded_type printer
 val prepare_expansion: Errortrace.expanded_type -> Errortrace.expanded_type
+
+module Compat: sig
+  (** {!Format} compatible printers *)
+  type 'a printer := Format.formatter -> 'a -> unit
+  val longident : Longident.t printer
+  val path: Path.t printer
+  val type_expr: type_expr printer
+  val shared_type_scheme: type_expr printer
+  val signature: signature printer
+  val modtype: module_type printer
+  val class_type: class_type printer
+  val string_of_label: Asttypes.arg_label -> string
+end
+
 val report_ambiguous_type_error:
     formatter -> Env.t -> (Path.t * Path.t) -> (Path.t * Path.t) list ->
-    (formatter -> unit) -> (formatter -> unit) -> (formatter -> unit) -> unit
+    Format_doc.t -> Format_doc.t -> Format_doc.t -> unit
 
 val report_unification_error :
   formatter ->
   Env.t -> Errortrace.unification_error ->
-  ?type_expected_explanation:(formatter -> unit) ->
-  (formatter -> unit) -> (formatter -> unit) ->
+  ?type_expected_explanation:Format_doc.t -> Format_doc.t -> Format_doc.t ->
   unit
 
 val report_equality_error :
   formatter ->
   type_or_scheme ->
   Env.t -> Errortrace.equality_error ->
-  (formatter -> unit) -> (formatter -> unit) ->
+   Format_doc.t -> Format_doc.t ->
   unit
 
 val report_moregen_error :
   formatter ->
   type_or_scheme ->
   Env.t -> Errortrace.moregen_error ->
-  (formatter -> unit) -> (formatter -> unit) ->
+  Format_doc.t -> Format_doc.t ->
   unit
 
 val report_comparison_error :
   formatter ->
   type_or_scheme ->
   Env.t -> Errortrace.comparison_error ->
-  (formatter -> unit) -> (formatter -> unit) ->
+  Format_doc.t -> Format_doc.t  ->
   unit
 
 module Subtype : sig
@@ -253,4 +256,4 @@ val rewrite_double_underscore_paths: Env.t -> Path.t -> Path.t
 
 (** [printed_signature sourcefile ppf sg] print the signature [sg] of
     [sourcefile] with potential warnings for name collisions *)
-val printed_signature: string -> formatter -> signature -> unit
+val printed_signature: string -> Format.formatter -> signature -> unit

--- a/typing/rawprinttyp.ml
+++ b/typing/rawprinttyp.ml
@@ -51,7 +51,7 @@ let print_name ppf = function
     None -> fprintf ppf "None"
   | Some name -> fprintf ppf "\"%s\"" name
 
-let path = Path.print
+let path = Format_doc.compat Path.print
 
 let visited = ref []
 let rec raw_type ppf ty =
@@ -77,7 +77,7 @@ and raw_type_desc ppf = function
   | Ttuple tl ->
       fprintf ppf "@[<1>Ttuple@,%a@]" raw_type_list tl
   | Tconstr (p, tl, abbrev) ->
-      fprintf ppf "@[<hov1>Tconstr(@,%a,@,%a,@,%a)@]" Path.print p
+      fprintf ppf "@[<hov1>Tconstr(@,%a,@,%a,@,%a)@]" path p
         raw_type_list tl
         (raw_list path) (list_of_memo !abbrev)
   | Tobject (t, nm) ->

--- a/typing/stypes.ml
+++ b/typing/stypes.ml
@@ -148,7 +148,10 @@ let print_info pp prev_loc ti =
       printtyp_reset_maybe loc;
       Format.pp_print_string Format.str_formatter "  ";
       Printtyp.wrap_printing_env ~error:false env
-        (fun () -> Printtyp.shared_type_scheme Format.str_formatter typ);
+        (fun () ->
+           Format_doc.compat Printtyp.shared_type_scheme Format.str_formatter
+             typ
+        );
       Format.pp_print_newline Format.str_formatter ();
       let s = Format.flush_str_formatter () in
       output_string pp s;

--- a/typing/typeclass.ml
+++ b/typing/typeclass.ml
@@ -1999,7 +1999,7 @@ let report_error env ppf =
   | Repeated_parameter ->
       fprintf ppf "A type parameter occurs several times"
   | Unconsistent_constraint err ->
-      let msg = Format_doc.Core.msg in
+      let msg = Format_doc.Doc.msg in
       fprintf ppf "@[<v>The class constraints are not consistent.@ ";
       Printtyp.report_unification_error ppf env err
         (msg "Type")
@@ -2082,7 +2082,7 @@ let report_error env ppf =
            but is here applied to %i type argument(s)@]"
         (Style.as_inline_code Printtyp.longident) lid expected provided
   | Parameter_mismatch err ->
-      let msg = Format_doc.Core.msg in
+      let msg = Format_doc.Doc.msg in
       Printtyp.report_unification_error ppf env err
         (msg  "The type parameter")
         (msg "does not meet its constraint: it should be")
@@ -2147,7 +2147,7 @@ let report_error env ppf =
            Some occurrences are contravariant@]"
         (Style.as_inline_code Printtyp.type_scheme) ty
   | Non_collapsable_conjunction (id, clty, err) ->
-      let msg = Format_doc.Core.msg in
+      let msg = Format_doc.Doc.msg in
       fprintf ppf
         "@[The type of this class,@ %a,@ \
            contains non-collapsible conjunctive types in constraints.@ %t@]"
@@ -2157,7 +2157,7 @@ let report_error env ppf =
             (msg "is not compatible with type")
         )
   | Self_clash err ->
-      let msg = Format_doc.Core.msg in
+      let msg = Format_doc.Doc.msg in
       Printtyp.report_unification_error ppf env err
         (msg "This object is expected to have type")
         (msg "but actually has type")

--- a/typing/typeclass.ml
+++ b/typing/typeclass.ml
@@ -19,7 +19,6 @@ open Path
 open Types
 open Typecore
 open Typetexp
-open Format
 
 
 type 'a class_info = {
@@ -48,7 +47,7 @@ type class_type_info = {
 
 type 'a full_class = {
   id : Ident.t;
-  id_loc : tag loc;
+  id_loc : string loc;
   clty: class_declaration;
   ty_id: Ident.t;
   cltydef: class_type_declaration;
@@ -94,7 +93,7 @@ type error =
   | Bad_class_type_parameters of Ident.t * type_expr list * type_expr list
   | Class_match_failure of Ctype.class_match_failure list
   | Unbound_val of string
-  | Unbound_type_var of (formatter -> unit) * Ctype.closed_class_failure
+  | Unbound_type_var of Format_doc.t * Ctype.closed_class_failure
   | Non_generalizable_class of
       { id : Ident.t
       ; clty : Types.class_declaration
@@ -1743,8 +1742,8 @@ let final_decl env define_class
   | Some reason ->
       let printer =
         if define_class
-        then function ppf -> Printtyp.class_declaration id ppf clty
-        else function ppf -> Printtyp.cltype_declaration id ppf cltydef
+        then Format_doc.doc_printf "%a" (Printtyp.class_declaration id) clty
+        else Format_doc.doc_printf "%a" (Printtyp.cltype_declaration id) cltydef
       in
       raise(Error(cl.pci_loc, env, Unbound_type_var(printer, reason)))
   end;
@@ -1980,7 +1979,7 @@ let approx_class_declarations env sdecls =
 
 (* Error report *)
 
-open Format
+open Format_doc
 
 let non_virtual_string_of_kind : kind -> string = function
   | Object -> "object"
@@ -1988,6 +1987,8 @@ let non_virtual_string_of_kind : kind -> string = function
   | Class_type -> "non-virtual class type"
 
 module Style=Misc.Style
+
+let out_type ppf t = Style.as_inline_code !Oprint.out_type ppf t
 
 let report_error env ppf =
   let pp_args ppf args =
@@ -1998,17 +1999,17 @@ let report_error env ppf =
   | Repeated_parameter ->
       fprintf ppf "A type parameter occurs several times"
   | Unconsistent_constraint err ->
+      let msg = Format_doc.Core.msg in
       fprintf ppf "@[<v>The class constraints are not consistent.@ ";
       Printtyp.report_unification_error ppf env err
-        (fun ppf -> fprintf ppf "Type")
-        (fun ppf -> fprintf ppf "is not compatible with type");
+        (msg "Type")
+        (msg "is not compatible with type");
       fprintf ppf "@]"
   | Field_type_mismatch (k, m, err) ->
+      let msg  = Format_doc.doc_printf in
       Printtyp.report_unification_error ppf env err
-        (function ppf ->
-           fprintf ppf "The %s %a@ has type" k Style.inline_code m)
-        (function ppf ->
-           fprintf ppf "but is expected to have type")
+        (msg "The %s %a@ has type" k Style.inline_code m)
+        (msg "but is expected to have type")
   | Unexpected_field (ty, lab) ->
       fprintf ppf
         "@[@[<2>This object is expected to have type :@ %a@]\
@@ -2046,20 +2047,16 @@ let report_error env ppf =
       Printtyp.prepare_for_printing [abbrev; actual; expected];
       fprintf ppf "@[The abbreviation@ %a@ expands to type@ %a@ \
        but is used with type@ %a@]"
-        (Style.as_inline_code !Oprint.out_type)
-        (Printtyp.tree_of_typexp Type abbrev)
-        (Style.as_inline_code !Oprint.out_type)
-        (Printtyp.tree_of_typexp Type actual)
-        (Style.as_inline_code !Oprint.out_type)
-        (Printtyp.tree_of_typexp Type expected)
+        out_type (Printtyp.tree_of_typexp Type abbrev)
+        out_type (Printtyp.tree_of_typexp Type actual)
+        out_type (Printtyp.tree_of_typexp Type expected)
   | Constructor_type_mismatch (c, err) ->
+      let msg = Format_doc.doc_printf in
       Printtyp.report_unification_error ppf env err
-        (function ppf ->
-           fprintf ppf "The expression %a has type"
+        (msg "The expression %a has type"
              Style.inline_code ("new " ^ c)
         )
-        (function ppf ->
-           fprintf ppf "but is used with type")
+        (msg "but is used with type")
   | Virtual_class (kind, mets, vals) ->
       let kind = non_virtual_string_of_kind kind in
       let missings =
@@ -2085,11 +2082,10 @@ let report_error env ppf =
            but is here applied to %i type argument(s)@]"
         (Style.as_inline_code Printtyp.longident) lid expected provided
   | Parameter_mismatch err ->
+      let msg = Format_doc.Core.msg in
       Printtyp.report_unification_error ppf env err
-        (function ppf ->
-           fprintf ppf "The type parameter")
-        (function ppf ->
-           fprintf ppf "does not meet its constraint: it should be")
+        (msg  "The type parameter")
+        (msg "does not meet its constraint: it should be")
   | Bad_parameters (id, params, cstrs) ->
       Printtyp.prepare_for_printing (params @ cstrs);
       fprintf ppf
@@ -2112,7 +2108,7 @@ let report_error env ppf =
       Includeclass.report_error Type ppf error
   | Unbound_val lab ->
       fprintf ppf "Unbound instance variable %a" Style.inline_code lab
-  | Unbound_type_var (printer, reason) ->
+  | Unbound_type_var (msg, reason) ->
       let print_reason ppf { Ctype.free_variable; meth; meth_ty; } =
         let (ty0, kind) = free_variable in
         let ty1 =
@@ -2122,17 +2118,16 @@ let report_error env ppf =
         in
         Printtyp.add_type_to_preparation meth_ty;
         Printtyp.add_type_to_preparation ty1;
-        let pp_type ppf ty = Style.as_inline_code !Oprint.out_type ppf ty in
         fprintf ppf
           "The method %a@ has type@;<1 2>%a@ where@ %a@ is unbound"
           Style.inline_code meth
-          pp_type (Printtyp.tree_of_typexp Type meth_ty)
-          pp_type (Printtyp.tree_of_typexp Type ty0)
+          out_type (Printtyp.tree_of_typexp Type meth_ty)
+          out_type (Printtyp.tree_of_typexp Type ty0)
       in
       fprintf ppf
-        "@[<v>@[Some type variables are unbound in this type:@;<1 2>%t@]@ \
+        "@[<v>@[Some type variables are unbound in this type:@;<1 2>%a@]@ \
               @[%a@]@]"
-       printer print_reason reason
+       pp_doc msg print_reason reason
   | Non_generalizable_class {id;  clty; nongen_vars } ->
       let[@manual.ref "ss:valuerestriction"] manual_ref = [ 6; 1; 2] in
       Printtyp.prepare_for_printing nongen_vars;
@@ -2152,20 +2147,20 @@ let report_error env ppf =
            Some occurrences are contravariant@]"
         (Style.as_inline_code Printtyp.type_scheme) ty
   | Non_collapsable_conjunction (id, clty, err) ->
+      let msg = Format_doc.Core.msg in
       fprintf ppf
         "@[The type of this class,@ %a,@ \
            contains non-collapsible conjunctive types in constraints.@ %t@]"
         (Style.as_inline_code @@ Printtyp.class_declaration id) clty
         (fun ppf -> Printtyp.report_unification_error ppf env err
-            (fun ppf -> fprintf ppf "Type")
-            (fun ppf -> fprintf ppf "is not compatible with type")
+            (msg "Type")
+            (msg "is not compatible with type")
         )
   | Self_clash err ->
+      let msg = Format_doc.Core.msg in
       Printtyp.report_unification_error ppf env err
-        (function ppf ->
-           fprintf ppf "This object is expected to have type")
-        (function ppf ->
-           fprintf ppf "but actually has type")
+        (msg "This object is expected to have type")
+        (msg "but actually has type")
   | Mutability_mismatch (_lab, mut) ->
       let mut1, mut2 =
         if mut = Immutable then "mutable", "immutable"

--- a/typing/typeclass.mli
+++ b/typing/typeclass.mli
@@ -15,8 +15,6 @@
 
 open Asttypes
 open Types
-open Format
-
 type 'a class_info = {
   cls_id : Ident.t;
   cls_id_loc : string loc;
@@ -111,7 +109,7 @@ type error =
   | Bad_class_type_parameters of Ident.t * type_expr list * type_expr list
   | Class_match_failure of Ctype.class_match_failure list
   | Unbound_val of string
-  | Unbound_type_var of (formatter -> unit) * Ctype.closed_class_failure
+  | Unbound_type_var of Format_doc.t * Ctype.closed_class_failure
   | Non_generalizable_class of
       { id : Ident.t
       ; clty : Types.class_declaration
@@ -129,7 +127,7 @@ type error =
 exception Error of Location.t * Env.t * error
 exception Error_forward of Location.error
 
-val report_error : Env.t -> formatter -> error -> unit
+val report_error : Env.t -> error Format_doc.printer
 
 (* Forward decl filled in by Typemod.type_open_descr *)
 val type_open_descr :

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -1184,7 +1184,7 @@ end) = struct
     if Warnings.is_active (Name_out_of_scope ("",[],false)) then begin
       let path_s =
         Printtyp.wrap_printing_env ~error:true env
-          (fun () -> Printtyp.string_of_path tpath) in
+          (fun () -> Format.asprintf "%a" Printtyp.type_path tpath) in
       warn lid.loc
         (Warnings.Name_out_of_scope (path_s, [Longident.last lid.txt], false))
     end

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -201,6 +201,10 @@ type error =
   | Wrong_expected_kind of wrong_kind_sort * wrong_kind_context * type_expr
   | Expr_not_a_record_type of type_expr
 
+
+let not_principal fmt =
+  Format_doc.Core.kmsg (fun x -> Warnings.Not_principal x) fmt
+
 exception Error of Location.t * Env.t * error
 exception Error_forward of Location.error
 
@@ -947,7 +951,7 @@ let solve_Ppat_construct ~refine tps penv loc constr no_existentials
           generalize_structure t2;
           if not (fully_generic t1 && fully_generic t2) then
             let msg =
-              Format.asprintf
+              Format_doc.doc_printf
                 "typing this pattern requires considering@ %a@ and@ %a@ as \
                 equal.@,\
                 But the knowledge of these types"
@@ -1164,7 +1168,7 @@ end) = struct
       let paths = ambiguous_types env lbl rest in
       let expansion = match Printtyp.Conflicts.err_msg () with
         | None -> ""
-        | Some msg -> Format.asprintf "%t" msg
+        | Some msg -> Format_doc.(asprintf "%a" pp_doc) msg
       in
       if paths <> [] then
         warn lid.loc
@@ -1176,15 +1180,14 @@ end) = struct
   let warn_non_principal warn lid =
     let name = Datatype_kind.label_name kind in
     warn lid.loc
-      (Warnings.Not_principal
-         ("this type-based " ^ name ^ " disambiguation"))
+      (not_principal "this type-based %s disambiguation" name)
 
   (* we selected a name out of the lexical scope *)
   let warn_out_of_scope warn lid env tpath =
     if Warnings.is_active (Name_out_of_scope ("",[],false)) then begin
       let path_s =
         Printtyp.wrap_printing_env ~error:true env
-          (fun () -> Format.asprintf "%a" Printtyp.type_path tpath) in
+          (fun () -> Format_doc.asprintf "%a" Printtyp.type_path tpath) in
       warn lid.loc
         (Warnings.Name_out_of_scope (path_s, [Longident.last lid.txt], false))
     end
@@ -1424,7 +1427,7 @@ let disambiguate_lid_a_list loc closed env usage expected_type lid_a_list =
   in
   if !w_pr then
     Location.prerr_warning loc
-      (Warnings.Not_principal "this type-based record disambiguation")
+      (not_principal  "this type-based record disambiguation")
   else begin
     match List.rev !w_amb with
       (_,types,ex)::_ as amb ->
@@ -3364,7 +3367,7 @@ and type_expect_
       | Tconstr(path, _, _) when Path.same path fmt6_path ->
         if !Clflags.principal && get_level ty_exp <> generic_level then
           Location.prerr_warning loc
-            (Warnings.Not_principal "this coercion to format6");
+            (not_principal "this coercion to format6");
         true
       | _ -> false
     in
@@ -3996,7 +3999,7 @@ and type_expect_
         | Tpoly (ty, tl) ->
             if !Clflags.principal && get_level typ <> generic_level then
               Location.prerr_warning loc
-                (Warnings.Not_principal "this use of a polymorphic method");
+                (not_principal "this use of a polymorphic method");
             snd (instance_poly ~fixed:false tl ty)
         | Tvar _ ->
             let ty' = newvar () in
@@ -4263,7 +4266,7 @@ and type_expect_
                 < Btype.generic_level
             then
               Location.prerr_warning loc
-                (Warnings.Not_principal "this module packing");
+                (not_principal "this module packing");
             (p, fl)
         | Tvar _ ->
             raise (Error (loc, env, Cannot_infer_signature))
@@ -4456,7 +4459,7 @@ and type_coerce
             force (); force' ();
             if not gen && !Clflags.principal then
               Location.prerr_warning loc
-                (Warnings.Not_principal "this ground coercion");
+                (not_principal "this ground coercion");
           with Subtype err ->
             (* prerr_endline "coercion failed"; *)
             raise (Error (loc, env, Not_subtype err))
@@ -5426,7 +5429,7 @@ and type_application env funct sargs =
             (fun () -> type_argument env sarg ty ty0)
           else begin
             may_warn sarg.pexp_loc
-              (Warnings.Not_principal "using an optional argument here");
+              (not_principal "using an optional argument here");
             (fun () -> option_some env (type_argument env sarg
                                           (extract_option_type env ty)
                                           (extract_option_type env ty0)))
@@ -5465,7 +5468,7 @@ and type_application env funct sargs =
             | Some (l', sarg, commuted, remaining_sargs) ->
                 if commuted then begin
                   may_warn sarg.pexp_loc
-                    (Warnings.Not_principal "commuting this argument")
+                    (not_principal "commuting this argument")
                 end;
                 if not optional && is_optional l' then
                   Location.prerr_warning sarg.pexp_loc
@@ -6466,7 +6469,8 @@ let spellcheck ppf unbound_name valid_names =
 let spellcheck_idents ppf unbound valid_idents =
   spellcheck ppf (Ident.name unbound) (List.map Ident.name valid_idents)
 
-open Format
+open Format_doc
+module Fmt = Format_doc
 
 let longident = Printtyp.longident
 
@@ -6496,7 +6500,7 @@ let report_literal_type_constraint expected_type const =
       Some '.'
     else None
   in
-  let pp_const ppf (c,s) = Format.fprintf ppf "%s%c" c s in
+  let pp_const ppf (c,s) = Fmt.fprintf ppf "%s%c" c s in
   match const_str, suffix with
   | Some c, Some s -> [
       Location.msg
@@ -6536,8 +6540,8 @@ let report_pattern_type_clash_hints pat diff =
   | Some (Ppat_constant const) -> report_literal_type_constraint const diff
   | _ -> []
 
-let report_type_expected_explanation expl ppf =
-  let because expl_str = fprintf ppf "@ because it is in %s" expl_str in
+let report_type_expected_explanation expl =
+  let because expl_str = doc_printf "@ because it is in %s" expl_str in
   match expl with
   | If_conditional ->
       because "the condition of an if-statement"
@@ -6560,10 +6564,10 @@ let report_type_expected_explanation expl ppf =
   | When_guard ->
       because "a when-guard"
 
-let report_type_expected_explanation_opt expl ppf =
+let report_type_expected_explanation_opt expl =
   match expl with
-  | None -> ()
-  | Some expl -> report_type_expected_explanation expl ppf
+  | None -> Format_doc.empty
+  | Some expl -> report_type_expected_explanation expl
 
 let report_unification_error ~loc ?sub env err
     ?type_expected_explanation txt1 txt2 =
@@ -6573,11 +6577,11 @@ let report_unification_error ~loc ?sub env err
   ) ()
 
 let report_this_function ppf funct =
-  if Typedtree.exp_is_nominal funct then
-    let pexp = Untypeast.untype_expression funct in
-    Format.fprintf ppf "The function %a"
-      (Style.as_inline_code Pprintast.expression) pexp
-  else Format.fprintf ppf "This function"
+  match Typedtree.nominal_exp_doc Printtyp.longident funct with
+  | None -> Fmt.fprintf ppf "This function"
+  | Some name ->
+    Fmt.fprintf ppf "The function %a"
+      (Style.as_inline_code Fmt.pp_doc) name
 
 let report_too_many_arg_error ~funct ~func_ty ~previous_arg_loc
     ~extra_arg_loc ~returns_unit loc =
@@ -6609,6 +6613,8 @@ let report_too_many_arg_error ~funct ~func_ty ~previous_arg_loc
      @ It is applied to too many arguments@]"
     report_this_function funct Printtyp.type_expr func_ty
 
+let msg = Fmt.doc_printf
+
 let report_error ~loc env = function
   | Constructor_arity_mismatch(lid, expected, provided) ->
       Location.errorf ~loc
@@ -6617,27 +6623,20 @@ let report_error ~loc env = function
        (Style.as_inline_code longident) lid expected provided
   | Label_mismatch(lid, err) ->
       report_unification_error ~loc env err
-        (function ppf ->
-           fprintf ppf "The record field %a@ belongs to the type"
+        (msg "The record field %a@ belongs to the type"
                    (Style.as_inline_code longident) lid)
-        (function ppf ->
-           fprintf ppf "but is mixed here with fields of type")
+        (msg "but is mixed here with fields of type")
   | Pattern_type_clash (err, pat) ->
       let diff = type_clash_of_trace err.trace in
       let sub = report_pattern_type_clash_hints pat diff in
       report_unification_error ~loc ~sub env err
-        (function ppf ->
-          fprintf ppf "This pattern matches values of type")
-        (function ppf ->
-          fprintf ppf "but a pattern was expected which matches values of \
-                       type");
+        (msg "This pattern matches values of type")
+        (msg "but a pattern was expected which matches values of type");
   | Or_pattern_type_clash (id, err) ->
       report_unification_error ~loc env err
-        (function ppf ->
-          fprintf ppf "The variable %a on the left-hand side of this \
+        (msg "The variable %a on the left-hand side of this \
                        or-pattern has type" Style.inline_code (Ident.name id))
-        (function ppf ->
-          fprintf ppf "but on the right-hand side it has type")
+        (msg "but on the right-hand side it has type")
   | Multiply_bound_variable name ->
       Location.errorf ~loc
         "Variable %a is bound several times in this matching"
@@ -6657,10 +6656,8 @@ let report_error ~loc env = function
       report_unification_error ~loc ~sub env err
         ~type_expected_explanation:
           (report_type_expected_explanation_opt explanation)
-        (function ppf ->
-           fprintf ppf "This expression has type")
-        (function ppf ->
-           fprintf ppf "but an expression was expected of type");
+        (msg "This expression has type")
+        (msg "but an expression was expected of type");
   | Function_arity_type_clash {
       syntactic_arity; type_constraint; trace = { trace };
     } ->
@@ -6759,10 +6756,10 @@ let report_error ~loc env = function
               (Style.as_inline_code Printtyp.type_path) type_path;
           end else begin
             fprintf ppf
-              "@[@[<2>%s type@ %a%t@]@ \
+              "@[@[<2>%s type@ %a%a@]@ \
                There is no %s %a within type %a@]"
               eorp (Style.as_inline_code Printtyp.type_expr) ty
-              (report_type_expected_explanation_opt explanation)
+              pp_doc (report_type_expected_explanation_opt explanation)
               (Datatype_kind.label_name kind)
               Style.inline_code name.txt
               (Style.as_inline_code Printtyp.type_path) type_path;
@@ -6774,17 +6771,14 @@ let report_error ~loc env = function
       let name = Datatype_kind.label_name kind in
       Location.error_of_printer ~loc (fun ppf () ->
         Printtyp.report_ambiguous_type_error ppf env tp tpl
-          (function ppf ->
-             fprintf ppf "The %s %a@ belongs to the %s type"
+          (msg "The %s %a@ belongs to the %s type"
                name (Style.as_inline_code longident) lid
               type_name)
-          (function ppf ->
-             fprintf ppf "The %s %a@ belongs to one of the following %s types:"
+          (msg "The %s %a@ belongs to one of the following %s types:"
                name (Style.as_inline_code longident) lid type_name)
-          (function ppf ->
-             fprintf ppf "but a %s was expected belonging to the %s type"
+          (msg "but a %s was expected belonging to the %s type"
                name type_name)
-      ) ()
+        ) ()
   | Invalid_format msg ->
       Location.errorf ~loc "%s" msg
   | Not_an_object (ty, explanation) ->
@@ -6792,7 +6786,7 @@ let report_error ~loc env = function
       fprintf ppf "This expression is not an object;@ \
                    it has type %a"
         (Style.as_inline_code Printtyp.type_expr) ty;
-      report_type_expected_explanation_opt explanation ppf
+      pp_doc ppf @@ report_type_expected_explanation_opt explanation
     ) ()
   | Undefined_method (ty, me, valid_methods) ->
       Location.error_of_printer ~loc (fun ppf () ->
@@ -6836,14 +6830,15 @@ let report_error ~loc env = function
         Style.inline_code v
   | Coercion_failure (ty_exp, err, b) ->
       Location.error_of_printer ~loc (fun ppf () ->
+          let intro =
+            let ty_exp = Printtyp.prepare_expansion ty_exp in
+            doc_printf "This expression cannot be coerced to type@;<1 2>%a;@ \
+                        it has type"
+              (Style.as_inline_code @@ Printtyp.type_expansion Type) ty_exp
+          in
         Printtyp.report_unification_error ppf env err
-          (function ppf ->
-             let ty_exp = Printtyp.prepare_expansion ty_exp in
-             fprintf ppf "This expression cannot be coerced to type@;<1 2>%a;@ \
-                          it has type"
-             (Style.as_inline_code @@ Printtyp.type_expansion Type) ty_exp)
-          (function ppf ->
-             fprintf ppf "but is here used with type");
+          intro
+          (Fmt.doc_printf "but is here used with type");
         if b then
           fprintf ppf
             ".@.@[<hov>This simple coercion was not fully general.@ \
@@ -6854,15 +6849,15 @@ let report_error ~loc env = function
   | Not_a_function (ty, explanation) ->
       Location.errorf ~loc
         "This expression should not be a function,@ \
-         the expected type is@ %a%t"
+         the expected type is@ %a%a"
         (Style.as_inline_code Printtyp.type_expr) ty
-        (report_type_expected_explanation_opt explanation)
+        pp_doc (report_type_expected_explanation_opt explanation)
   | Too_many_arguments (ty, explanation) ->
       Location.errorf ~loc
         "This function expects too many arguments,@ \
-         it should have type@ %a%t"
+         it should have type@ %a%a"
         (Style.as_inline_code Printtyp.type_expr) ty
-        (report_type_expected_explanation_opt explanation)
+        pp_doc (report_type_expected_explanation_opt explanation)
   | Abstract_wrong_label {got; expected; expected_type; explanation} ->
       let label ~long ppf = function
         | Nolabel -> fprintf ppf "unlabeled"
@@ -6877,10 +6872,10 @@ let report_error ~loc env = function
         | _                       -> false
       in
       Location.errorf ~loc
-        "@[<v>@[<2>This function should have type@ %a%t@]@,\
+        "@[<v>@[<2>This function should have type@ %a%a@]@,\
          @[but its first argument is %a@ instead of %s%a@]@]"
         (Style.as_inline_code Printtyp.type_expr) expected_type
-        (report_type_expected_explanation_opt explanation)
+        pp_doc (report_type_expected_explanation_opt explanation)
         (label ~long:true) got
         (if second_long then "being " else "")
         (label ~long:second_long) expected
@@ -6913,8 +6908,8 @@ let report_error ~loc env = function
         This is only allowed when the real type is known."
   | Less_general (kind, err) ->
       report_unification_error ~loc env err
-        (fun ppf -> fprintf ppf "This %s has type" kind)
-        (fun ppf -> fprintf ppf "which is less general than")
+        (Fmt.doc_printf "This %s has type" kind)
+        (Fmt.doc_printf "which is less general than")
   | Modules_not_allowed ->
       Location.errorf ~loc "Modules are not allowed in this pattern."
   | Cannot_infer_signature ->
@@ -6984,7 +6979,7 @@ let report_error ~loc env = function
         "@[%s@ %s@ @[%a@]@]"
         "This match case could not be refuted."
         "Here is an example of a value that would reach it:"
-        (Style.as_inline_code Printpat.pretty_val) pat
+        (Style.as_inline_code Printpat.top_pretty) pat
   | Invalid_extension_constructor_payload ->
       Location.errorf ~loc
         "Invalid %a payload, a constructor is expected."
@@ -7014,22 +7009,16 @@ let report_error ~loc env = function
         "This kind of recursive class expression is not allowed"
   | Letop_type_clash(name, err) ->
       report_unification_error ~loc env err
-        (function ppf ->
-          fprintf ppf "The operator %a has type" Style.inline_code name)
-        (function ppf ->
-          fprintf ppf "but it was expected to have type")
+        (msg "The operator %a has type" Style.inline_code name)
+        (msg "but it was expected to have type")
   | Andop_type_clash(name, err) ->
       report_unification_error ~loc env err
-        (function ppf ->
-          fprintf ppf "The operator %a has type" Style.inline_code name)
-        (function ppf ->
-          fprintf ppf "but it was expected to have type")
+        (msg "The operator %a has type" Style.inline_code name)
+        (msg "but it was expected to have type")
   | Bindings_type_clash(err) ->
       report_unification_error ~loc env err
-        (function ppf ->
-          fprintf ppf "These bindings have type")
-        (function ppf ->
-          fprintf ppf "but bindings were expected of type")
+        (Fmt.doc_printf "These bindings have type")
+        (Fmt.doc_printf  "but bindings were expected of type")
   | Unbound_existential (ids, ty) ->
       let pp_ident ppf id = pp_print_string ppf (Ident.name id) in
       let pp_type ppf (ids,ty)=
@@ -7076,9 +7065,9 @@ let report_error ~loc env = function
       in
       Location.errorf ~loc
         "This %s should not be a %s,@ \
-         the expected type is@ %a%t"
+         the expected type is@ %a%a"
         ctx sort (Style.as_inline_code Printtyp.type_expr) ty
-        (report_type_expected_explanation_opt explanation)
+        pp_doc (report_type_expected_explanation_opt explanation)
   | Expr_not_a_record_type ty ->
       Location.errorf ~loc
         "This expression has type %a@ \
@@ -7086,7 +7075,7 @@ let report_error ~loc env = function
         (Style.as_inline_code Printtyp.type_expr) ty
 
 let report_error ~loc env err =
-  Printtyp.wrap_printing_env_error env
+  Printtyp.wrap_printing_env ~error:true env
     (fun () -> report_error ~loc env err)
 
 let () =

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -203,7 +203,7 @@ type error =
 
 
 let not_principal fmt =
-  Format_doc.Core.kmsg (fun x -> Warnings.Not_principal x) fmt
+  Format_doc.Doc.kmsg (fun x -> Warnings.Not_principal x) fmt
 
 exception Error of Location.t * Env.t * error
 exception Error_forward of Location.error
@@ -6566,7 +6566,7 @@ let report_type_expected_explanation expl =
 
 let report_type_expected_explanation_opt expl =
   match expl with
-  | None -> Format_doc.empty
+  | None -> Format_doc.Doc.empty
   | Some expl -> report_type_expected_explanation expl
 
 let report_unification_error ~loc ?sub env err

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -2037,7 +2037,7 @@ let report_error ppf = function
            "the original" "this" "definition" env)
         err
   | Constraint_failed (env, err) ->
-      let msg = Format_doc.Core.msg in
+      let msg = Format_doc.Doc.msg in
       fprintf ppf "@[<v>Constraints are not satisfied in this type.@ ";
       Printtyp.report_unification_error ppf env err
         (msg "Type")
@@ -2063,14 +2063,14 @@ let report_error ppf = function
              Reaching_path.pp_colon reaching_path
            else fprintf pp ".@ ")
   | Inconsistent_constraint (env, err) ->
-      let msg = Format_doc.Core.msg in
+      let msg = Format_doc.Doc.msg in
       fprintf ppf "@[<v>The type constraints are not consistent.@ ";
       Printtyp.report_unification_error ppf env err
         (msg "Type")
         (msg "is not compatible with type");
       fprintf ppf "@]"
   | Type_clash (env, err) ->
-      let msg = Format_doc.Core.msg in
+      let msg = Format_doc.Doc.msg in
       Printtyp.report_unification_error ppf env err
         (msg "This type constructor expands to type")
         (msg "but is used here with type")

--- a/typing/typedecl.mli
+++ b/typing/typedecl.mli
@@ -16,8 +16,6 @@
 (* Typing of type definitions and primitive definitions *)
 
 open Types
-open Format
-
 val transl_type_decl:
     Env.t -> Asttypes.rec_flag -> Parsetree.type_declaration list ->
     Typedtree.type_declaration list * Env.t * Shape.t list
@@ -111,4 +109,4 @@ type error =
 
 exception Error of Location.t * error
 
-val report_error: formatter -> error -> unit
+val report_error: error Format_doc.printer

--- a/typing/typedtree.ml
+++ b/typing/typedtree.ml
@@ -901,29 +901,30 @@ let split_pattern pat =
    - Do not contain spaces when printed.
 *)
 let nominal_exp_doc lid t =
-  let longident l = Format_doc.core lid l.Location.txt in
+  let open Format_doc.Doc in
+  let longident l = Format_doc.doc_printer lid l.Location.txt in
   let rec nominal_exp_doc doc exp =
     match exp.exp_desc with
     | _ when exp.exp_attributes <> [] -> None
     | Texp_ident (_,l,_) ->
         Some (longident l doc)
     | Texp_instvar (_,_,s) ->
-        Some (Format_doc.Core.string s.Location.txt doc)
+        Some (string s.Location.txt doc)
     | Texp_constant _ -> assert false
     | Texp_variant (lbl, None) ->
-        Some (Format_doc.Core.printf "`%s" lbl doc)
+        Some (printf "`%s" lbl doc)
     | Texp_construct (l, _, []) -> Some (longident l doc)
     | Texp_field (parent, lbl, _) ->
         Option.map
-          (Format_doc.Core.printf ".%t" (longident lbl))
+          (printf ".%t" (longident lbl))
           (nominal_exp_doc doc parent)
     | Texp_send (parent, meth) ->
         let name = match meth with
           | Tmeth_name name -> name
           | Tmeth_val id | Tmeth_ancestor (id,_) -> Ident.name id in
         Option.map
-          (Format_doc.Core.printf "#%s" name)
+          (printf "#%s" name)
           (nominal_exp_doc doc parent)
     | _ -> None
   in
-  nominal_exp_doc Format_doc.empty t
+  nominal_exp_doc empty t

--- a/typing/typedtree.ml
+++ b/typing/typedtree.ml
@@ -899,13 +899,31 @@ let split_pattern pat =
    if they satisfy one of:
    - Similar to an identifier: words separated by '.' or '#'.
    - Do not contain spaces when printed.
-  *)
-let rec exp_is_nominal exp =
-  match exp.exp_desc with
-  | _ when exp.exp_attributes <> [] -> false
-  | Texp_ident _ | Texp_instvar _ | Texp_constant _
-  | Texp_variant (_, None)
-  | Texp_construct (_, _, []) ->
-      true
-  | Texp_field (parent, _, _) | Texp_send (parent, _) -> exp_is_nominal parent
-  | _ -> false
+*)
+let nominal_exp_doc lid t =
+  let longident l = Format_doc.core lid l.Location.txt in
+  let rec nominal_exp_doc doc exp =
+    match exp.exp_desc with
+    | _ when exp.exp_attributes <> [] -> None
+    | Texp_ident (_,l,_) ->
+        Some (longident l doc)
+    | Texp_instvar (_,_,s) ->
+        Some (Format_doc.Core.string s.Location.txt doc)
+    | Texp_constant _ -> assert false
+    | Texp_variant (lbl, None) ->
+        Some (Format_doc.Core.printf "`%s" lbl doc)
+    | Texp_construct (l, _, []) -> Some (longident l doc)
+    | Texp_field (parent, lbl, _) ->
+        Option.map
+          (Format_doc.Core.printf ".%t" (longident lbl))
+          (nominal_exp_doc doc parent)
+    | Texp_send (parent, meth) ->
+        let name = match meth with
+          | Tmeth_name name -> name
+          | Tmeth_val id | Tmeth_ancestor (id,_) -> Ident.name id in
+        Option.map
+          (Format_doc.Core.printf "#%s" name)
+          (nominal_exp_doc doc parent)
+    | _ -> None
+  in
+  nominal_exp_doc Format_doc.empty t

--- a/typing/typedtree.mli
+++ b/typing/typedtree.mli
@@ -920,6 +920,8 @@ val pat_bound_idents_full:
 val split_pattern:
   computation general_pattern -> pattern option * pattern option
 
-(** Whether an expression looks nice as the subject of a sentence in a error
-    message. *)
-val exp_is_nominal : expression -> bool
+(** Returns a format document if the expression reads nicely as the subject of a
+    sentence in a error message. *)
+val nominal_exp_doc :
+  Longident.t Format_doc.printer -> expression
+  -> Format_doc.t option

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -2182,7 +2182,7 @@ let simplify_app_summary app_view = match app_view.arg with
     | false, Some p -> Includemod.Error.Named p, mty
     | false, None   -> Includemod.Error.Anonymous, mty
 
-let not_principal msg = Warnings.Not_principal (Format_doc.Core.msg msg)
+let not_principal msg = Warnings.Not_principal (Format_doc.Doc.msg msg)
 
 let rec type_module ?(alias=false) sttn funct_body anchor env smod =
   Builtin_attributes.warning_scope smod.pmod_attributes

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -3406,11 +3406,11 @@ let report_error ~loc _env = function
       Location.errorf ~loc
         "@[The interface %a@ declares values, not just types.@ \
            An implementation must be provided.@]"
-        Location.print_filename intf_name
+        Location.Doc.quoted_filename intf_name
   | Interface_not_compiled intf_name ->
       Location.errorf ~loc
         "@[Could not find the .cmi file for interface@ %a.@]"
-        Location.print_filename intf_name
+        Location.Doc.quoted_filename intf_name
   | Not_allowed_in_functor_body ->
       Location.errorf ~loc
         "@[This expression creates fresh types.@ %s@]"

--- a/typing/typetexp.ml
+++ b/typing/typetexp.ml
@@ -885,12 +885,12 @@ let report_error env ppf = function
   | Recursive_type ->
     fprintf ppf "This type is recursive"
   | Type_mismatch trace ->
-      let msg = Format_doc.Core.msg in
+      let msg = Format_doc.Doc.msg in
       Printtyp.report_unification_error ppf Env.empty trace
         (msg "This type")
         (msg "should be an instance of type")
   | Alias_type_mismatch trace ->
-      let msg = Format_doc.Core.msg in
+      let msg = Format_doc.Doc.msg in
       Printtyp.report_unification_error ppf Env.empty trace
         (msg "This alias is bound to type")
         (msg "but is used as an instance of type")

--- a/typing/typetexp.ml
+++ b/typing/typetexp.ml
@@ -857,11 +857,11 @@ let transl_type_scheme env styp =
 
 (* Error report *)
 
-open Format
+open Format_doc
 open Printtyp
 module Style = Misc.Style
-let pp_tag ppf t = Format.fprintf ppf "`%s" t
-
+let pp_tag ppf t = fprintf ppf "`%s" t
+let pp_type ppf ty = Style.as_inline_code !Oprint.out_type ppf ty
 
 let report_error env ppf = function
   | Unbound_type_variable (name, in_scope_names) ->
@@ -881,21 +881,19 @@ let report_error env ppf = function
       (Style.as_inline_code longident) lid expected provided
   | Bound_type_variable name ->
       fprintf ppf "Already bound type parameter %a"
-        (Style.as_inline_code Pprintast.tyvar) name
+        (Style.as_inline_code Pprintast.Doc.tyvar) name
   | Recursive_type ->
     fprintf ppf "This type is recursive"
   | Type_mismatch trace ->
+      let msg = Format_doc.Core.msg in
       Printtyp.report_unification_error ppf Env.empty trace
-        (function ppf ->
-           fprintf ppf "This type")
-        (function ppf ->
-           fprintf ppf "should be an instance of type")
+        (msg "This type")
+        (msg "should be an instance of type")
   | Alias_type_mismatch trace ->
+      let msg = Format_doc.Core.msg in
       Printtyp.report_unification_error ppf Env.empty trace
-        (function ppf ->
-           fprintf ppf "This alias is bound to type")
-        (function ppf ->
-           fprintf ppf "but is used as an instance of type")
+        (msg "This alias is bound to type")
+        (msg "but is used as an instance of type")
   | Present_has_conjunction l ->
       fprintf ppf "The present constructor %a has a conjunctive type"
         Style.inline_code l
@@ -912,7 +910,6 @@ let report_error env ppf = function
         Style.inline_code ">"
         (Style.as_inline_code pp_tag) l
   | Constructor_mismatch (ty, ty') ->
-      let pp_type ppf ty = Style.as_inline_code !Oprint.out_type ppf ty in
       wrap_printing_env ~error:true env (fun ()  ->
         Printtyp.prepare_for_printing [ty; ty'];
         fprintf ppf "@[<hov>%s %a@ %s@ %a@]"
@@ -942,7 +939,7 @@ let report_error env ppf = function
   | Cannot_quantify (name, v) ->
       fprintf ppf
         "@[<hov>The universal type variable %a cannot be generalized:@ "
-        (Style.as_inline_code Pprintast.tyvar) name;
+        (Style.as_inline_code Pprintast.Doc.tyvar) name;
       if Btype.is_Tvar v then
         fprintf ppf "it escapes its scope"
       else if Btype.is_Tunivar v then

--- a/typing/typetexp.mli
+++ b/typing/typetexp.mli
@@ -95,7 +95,7 @@ type error =
 
 exception Error of Location.t * Env.t * error
 
-val report_error: Env.t -> Format.formatter -> error -> unit
+val report_error: Env.t -> error Format_doc.printer
 
 (* Support for first-class modules. *)
 val transl_modtype_longident:  (* from Typemod *)

--- a/utils/diffing.ml
+++ b/utils/diffing.ml
@@ -42,10 +42,11 @@ let style = function
   | Modification -> Misc.Style.[ FG Magenta; Bold]
 
 let prefix ppf (pos, p) =
+  let open Format_doc in
   let sty = style p in
-  Format.pp_open_stag ppf (Misc.Style.Style sty);
-  Format.fprintf ppf "%i. " pos;
-  Format.pp_close_stag ppf ()
+  pp_open_stag ppf (Misc.Style.Style sty);
+  fprintf ppf "%i. " pos;
+  pp_close_stag ppf ()
 
 
 let (let*) = Option.bind

--- a/utils/diffing.mli
+++ b/utils/diffing.mli
@@ -79,7 +79,7 @@ type change_kind =
   | Insertion
   | Modification
   | Preservation
-val prefix: Format.formatter -> (int * change_kind) -> unit
+val prefix: (int * change_kind) Format_doc.printer
 val style: change_kind -> Misc.Style.style list
 
 

--- a/utils/diffing_with_keys.ml
+++ b/utils/diffing_with_keys.ml
@@ -37,8 +37,8 @@ let prefix ppf x =
   in
   let style k ppf inner =
     let sty = Diffing.style k in
-    Format.pp_open_stag ppf (Misc.Style.Style sty);
-    Format.kfprintf (fun ppf -> Format.pp_close_stag ppf () ) ppf inner
+    Format_doc.pp_open_stag ppf (Misc.Style.Style sty);
+    Format_doc.kfprintf (fun ppf -> Format_doc.pp_close_stag ppf () ) ppf inner
   in
   match x with
   | Change (Name {pos; _ } | Type {pos; _})
@@ -53,7 +53,7 @@ let prefix ppf x =
 
 (** To detect [move] and [swaps], we are using the fact that
     there are 2-cycles in the graph of name renaming.
-    - [Change (x,y,_) is then an edge from
+    - [Change (x,y,_)] is then an edge from
       [key_left x] to [key_right y].
     - [Insert x] is an edge between the special node epsilon and
       [key_left x]

--- a/utils/diffing_with_keys.mli
+++ b/utils/diffing_with_keys.mli
@@ -46,7 +46,7 @@ type ('l,'r,'diff) change =
   | Insert of {pos:int; insert:'r}
   | Delete of {pos:int; delete:'l}
 
-val prefix: Format.formatter -> ('l,'r,'diff) change -> unit
+val prefix: ('l,'r,'diff) change Format_doc.printer
 
 module Define(D:Diffing.Defs with type eq := unit): sig
 

--- a/utils/format_doc.ml
+++ b/utils/format_doc.ml
@@ -1,0 +1,476 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*             Florian Angeletti, projet Cambium, Inria Paris             *)
+(*                                                                        *)
+(*   Copyright 2021 Institut National de Recherche en Informatique et     *)
+(*     en Automatique.                                                    *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+
+type box_type =
+  | H
+  | V
+  | HV
+  | HoV
+  | B
+
+type stag = Format.stag
+
+type element =
+  | Text of string
+  | With_size of int
+  | Open_box of { kind: box_type ; indent:int }
+  | Close_box
+  | Open_tag of Format.stag
+  | Close_tag
+  | Open_tbox
+  | Tab_break of { width : int; offset : int }
+  | Set_tab
+  | Close_tbox
+  | Simple_break of { spaces : int; indent: int }
+  | Break of { fits : string * int * string as 'a; breaks : 'a }
+  | Flush of { newline:bool }
+  | Newline
+  | If_newline
+
+  | Deprecated of (Format.formatter -> unit)
+
+type doc = { rev:element list } [@@unboxed]
+
+type t = doc
+
+let empty : doc = { rev = [] }
+
+let to_list doc = List.rev doc.rev
+let add doc x = { rev = x :: doc.rev }
+let fold f acc doc = List.fold_left f acc (to_list doc)
+let append left right = { rev = right.rev @ left.rev }
+
+let format_open_box_gen ppf kind indent =
+  match kind with
+  | H-> Format.pp_open_hbox ppf ()
+  | V -> Format.pp_open_vbox ppf indent
+  | HV -> Format.pp_open_hvbox ppf indent
+  | HoV -> Format.pp_open_hovbox ppf indent
+  | B -> Format.pp_open_box ppf indent
+
+let interpret_elt ppf = function
+  | Text x -> Format.pp_print_string ppf x
+  | Open_box { kind; indent } -> format_open_box_gen ppf kind indent
+  | Close_box -> Format.pp_close_box ppf ()
+  | Open_tag tag -> Format.pp_open_stag ppf tag
+  | Close_tag -> Format.pp_close_stag ppf ()
+  | Open_tbox -> Format.pp_open_tbox ppf ()
+  | Tab_break {width;offset} -> Format.pp_print_tbreak ppf width offset
+  | Set_tab -> Format.pp_set_tab ppf ()
+  | Close_tbox -> Format.pp_close_tbox ppf ()
+  | Simple_break {spaces;indent} -> Format.pp_print_break ppf spaces indent
+  | Break {fits;breaks} -> Format.pp_print_custom_break ppf ~fits ~breaks
+  | Flush {newline=true} -> Format.pp_print_newline ppf ()
+  | Flush {newline=false} -> Format.pp_print_flush ppf ()
+  | Newline -> Format.pp_force_newline ppf ()
+  | If_newline -> Format.pp_print_if_newline ppf ()
+  | With_size _ ->  ()
+  | Deprecated pr -> pr ppf
+
+let rec interpret ppf = function
+  | [] -> ()
+  | With_size size :: Text text :: l ->
+      Format.pp_print_as ppf size text;
+      interpret ppf l
+  | x :: l ->
+      interpret_elt ppf x;
+      interpret ppf l
+
+let format ppf doc = interpret ppf (to_list doc)
+
+module Core = struct
+
+  let open_box kind indent doc = add doc (Open_box {kind;indent})
+  let close_box doc = add doc Close_box
+
+  let string s doc = add doc (Text s)
+  let bytes b doc = add doc (Text (Bytes.to_string b))
+  let with_size size doc = add doc (With_size size)
+
+  let int n doc = add doc (Text (string_of_int n))
+  let float f doc = add doc (Text (string_of_float f))
+  let char c doc = add doc (Text (String.make 1 c))
+  let bool c doc = add doc (Text (Bool.to_string c))
+
+  let break ~spaces ~indent doc = add doc (Simple_break {spaces; indent})
+  let space doc = break ~spaces:1 ~indent:0 doc
+  let cut = break ~spaces:0 ~indent:0
+
+  let custom_break ~fits ~breaks doc = add doc (Break {fits;breaks})
+
+  let force_newline doc = add doc Newline
+  let if_newline doc = add doc If_newline
+
+  let flush doc = add doc (Flush {newline=false})
+  let force_stop doc = add doc (Flush {newline=true})
+
+  let open_tbox doc = add doc Open_tbox
+  let set_tab doc = add doc Set_tab
+  let tab_break ~width ~offset doc = add doc (Tab_break {width;offset})
+  let tab doc = tab_break ~width:0 ~offset:0 doc
+  let close_tbox doc = add doc Close_tbox
+
+  let open_tag stag doc = add doc (Open_tag stag)
+  let close_tag doc = add doc Close_tag
+
+  let iter ?(sep=Fun.id) ~iter:iterator elt l doc =
+    let first = ref false in
+    let rdoc = ref doc in
+    let print x =
+      if !first then (first := false; rdoc := elt x !rdoc)
+      else rdoc := !rdoc |> sep |> elt x
+    in
+    iterator print l;
+    !rdoc
+
+  let rec list ?(sep=Fun.id) elt l doc = match l with
+    | [] -> doc
+    | [a] -> elt a doc
+    | a :: ((_ :: _) as q) ->
+        doc |> elt a |> sep |> list ~sep elt q
+
+  let array ?sep elt a doc = iter ?sep ~iter:Array.iter elt a doc
+  let seq ?sep elt s doc = iter ?sep ~iter:Seq.iter elt s doc
+
+  let option ?(none=Fun.id) elt o doc = match o with
+    | None -> none doc
+    | Some x -> elt x doc
+
+  let either ~left ~right x doc = match x with
+    | Either.Left x -> left x doc
+    | Either.Right x -> right x doc
+
+  let result ~ok ~error x doc = match x with
+    | Ok x -> ok x doc
+    | Error x -> error x doc
+
+  (* To format free-flowing text *)
+  let rec subtext len left right s doc =
+    let flush doc =
+      doc |> string (String.sub s left (right - left))
+    in
+    let after_flush doc = subtext len (right+1) (right+1) s doc in
+    if right = len then
+      if left <> len then flush doc else doc
+    else
+      match s.[right] with
+      | '\n' ->
+          doc |> flush |> force_newline |> after_flush
+      | ' ' ->
+          doc |> flush |> space |> after_flush
+      (* there is no specific support for '\t'
+         as it is unclear what a right semantics would be *)
+      | _ -> subtext len left (right + 1) s doc
+
+  let text s doc =
+    subtext (String.length s) 0 0 s doc
+
+  type ('a,'b) fmt = ('a, doc, doc, 'b) format4
+  type printer0 = doc -> doc
+  type 'a printer = 'a -> printer0
+
+  let output_formatting_lit fmting_lit doc =
+    let open CamlinternalFormatBasics in
+    match fmting_lit with
+    | Close_box    -> close_box doc
+    | Close_tag                 -> close_tag doc
+    | Break (_, width, offset)  -> break ~spaces:width ~indent:offset doc
+    | FFlush                    -> flush doc
+    | Force_newline             -> force_newline doc
+    | Flush_newline             -> force_stop doc
+    | Magic_size (_, n)         -> with_size n doc
+    | Escaped_at                -> char '@' doc
+    | Escaped_percent           -> char '%' doc
+    | Scan_indic c              -> doc |> char '@' |> char c
+
+  let to_string doc =
+    let b = Buffer.create 20 in
+    let convert = function
+      | Text s -> Buffer.add_string b s
+      | _ -> ()
+    in
+    fold (fun () x -> convert x) () doc;
+    Buffer.contents b
+
+  let box_type =
+    let open CamlinternalFormatBasics in
+    function
+    | Pp_fits -> H
+    | Pp_hbox -> H
+    | Pp_vbox -> V
+    | Pp_hovbox -> HoV
+    | Pp_hvbox -> HV
+    | Pp_box -> B
+
+  let rec compose_acc acc doc =
+    let open CamlinternalFormat in
+    match acc with
+    | CamlinternalFormat.Acc_formatting_lit (p, f) ->
+        doc |> compose_acc p |> output_formatting_lit f
+    | Acc_formatting_gen (p, Acc_open_tag acc') ->
+        let tag = to_string (compose_acc acc' empty) in
+        let doc = compose_acc p doc in
+        doc |> open_tag (Format.String_tag tag)
+    | Acc_formatting_gen (p, Acc_open_box acc') ->
+        let doc = compose_acc p doc in
+        let box = to_string (compose_acc acc' empty) in
+        let (indent, bty) = CamlinternalFormat.open_box_of_string box in
+        doc |> open_box (box_type bty) indent
+    | Acc_string_literal (p, s)
+    | Acc_data_string (p, s)   ->
+        doc |> compose_acc p |> string s
+    | Acc_char_literal (p, c)
+    | Acc_data_char (p, c)     -> doc |> compose_acc p |> char c
+    | Acc_delay (p, f)         -> doc |> compose_acc p |> f
+    | Acc_flush p              -> doc |> compose_acc p |> flush
+    | Acc_invalid_arg (_p, msg) ->  invalid_arg msg;
+    | End_of_acc               -> doc
+
+  let kprintf k (CamlinternalFormatBasics.Format (fmt, _))  =
+    CamlinternalFormat.make_printf
+      (fun acc doc -> doc |> compose_acc acc |> k )
+      End_of_acc fmt
+
+  let printf doc = kprintf Fun.id doc
+  let kmsg k  (CamlinternalFormatBasics.Format (fmt, _)) =
+    CamlinternalFormat.make_printf
+      (fun acc -> k (compose_acc acc empty))
+      End_of_acc fmt
+
+  let msg fmt = kmsg Fun.id fmt
+
+end
+
+(** Compatibility interface *)
+
+type formatter = doc ref
+type 'a printer = formatter -> 'a -> unit
+
+let formatter d = d
+
+(** {1 Primitive functions }*)
+
+let pp_print_string ppf s = ppf := Core.string s !ppf
+
+let pp_print_as ppf size s =
+  ppf := !ppf |> Core.with_size size |> Core.string s
+
+let pp_print_substring ~pos ~len ppf s =
+ ppf := Core.string (String.sub s pos len) !ppf
+
+let pp_print_substring_as ~pos ~len ppf size s =
+  ppf :=
+  !ppf
+  |> Core.with_size size
+  |> Core.string (String.sub s pos len)
+
+let pp_print_bytes ppf s = ppf := Core.string (Bytes.to_string s) !ppf
+let pp_print_text ppf s = ppf := Core.text s !ppf
+let pp_print_char ppf c = ppf := Core.char c !ppf
+let pp_print_int ppf c = ppf := Core.int c !ppf
+let pp_print_float ppf f = ppf := Core.float f !ppf
+let pp_print_bool ppf b = ppf := Core.bool b !ppf
+let pp_print_nothing _ _ = ()
+
+let pp_close_box ppf () = ppf := Core.close_box !ppf
+let pp_close_stag ppf () = ppf := Core.close_tag !ppf
+
+let pp_print_break ppf spaces indent = ppf := Core.break ~spaces ~indent !ppf
+
+let pp_print_custom_break ppf ~fits ~breaks =
+  ppf := Core.custom_break ~fits ~breaks !ppf
+
+let pp_print_space ppf () = pp_print_break ppf 1 0
+let pp_print_cut ppf () = pp_print_break ppf 0 0
+
+let pp_print_flush ppf () = ppf := Core.flush !ppf
+let pp_force_newline ppf () = ppf := Core.force_newline !ppf
+let pp_print_newline ppf () = ppf := Core.force_stop !ppf
+let pp_print_if_newline ppf () =ppf := Core.if_newline !ppf
+
+let pp_open_stag ppf stag = ppf := !ppf |> Core.open_tag stag
+
+let pp_open_box_gen ppf indent bxty =
+  let box_type = Core.box_type bxty in
+   ppf := !ppf |> Core.open_box box_type indent
+
+let pp_open_box ppf indent = pp_open_box_gen ppf indent Pp_box
+
+
+let pp_open_tbox ppf () = ppf := !ppf |> Core.open_tbox
+
+let pp_close_tbox ppf () = ppf := !ppf |> Core.close_tbox
+
+let pp_set_tab ppf () = ppf := !ppf |> Core.set_tab
+
+let pp_print_tab ppf () = ppf := !ppf |> Core.tab
+
+let pp_print_tbreak ppf width offset =
+  ppf := !ppf |> Core.tab_break ~width ~offset
+
+let pp_doc ppf doc = ppf := append !ppf doc
+
+module Driver = struct
+  (* Interpret a formatting entity on a formatter. *)
+  let output_formatting_lit ppf
+      (fmting_lit:CamlinternalFormatBasics.formatting_lit)
+    = match fmting_lit with
+    | Close_box                 -> pp_close_box ppf ()
+    | Close_tag                 -> pp_close_stag ppf ()
+    | Break (_, width, offset)  -> pp_print_break ppf width offset
+    | FFlush                    -> pp_print_flush ppf ()
+    | Force_newline             -> pp_force_newline ppf ()
+    | Flush_newline             -> pp_print_newline ppf ()
+    | Magic_size (_, _)         -> ()
+    | Escaped_at                -> pp_print_char ppf '@'
+    | Escaped_percent           -> pp_print_char ppf '%'
+    | Scan_indic c              -> pp_print_char ppf '@'; pp_print_char ppf c
+
+
+
+  let compute_tag output tag_acc =
+    let buf = Buffer.create 16 in
+    let buf_fmt = Format.formatter_of_buffer buf in
+    let ppf = ref empty in
+    output ppf tag_acc;
+    pp_print_flush ppf ();
+    format buf_fmt !ppf;
+    let len = Buffer.length buf in
+    if len < 2 then Buffer.contents buf
+    else Buffer.sub buf 1 (len - 2)
+
+  (* Recursively output an "accumulator" containing a reversed list of
+     printing entities (string, char, flus, ...) in an output_stream. *)
+  (* Differ from Printf.output_acc by the interpretation of formatting. *)
+  (* Used as a continuation of CamlinternalFormat.make_printf. *)
+  let rec output_acc ppf (acc: _ CamlinternalFormat.acc) =
+    match acc with
+    | Acc_string_literal (Acc_formatting_lit (p, Magic_size (_, size)), s)
+    | Acc_data_string (Acc_formatting_lit (p, Magic_size (_, size)), s) ->
+        output_acc ppf p;
+        pp_print_as ppf size s;
+    | Acc_char_literal (Acc_formatting_lit (p, Magic_size (_, size)), c)
+    | Acc_data_char (Acc_formatting_lit (p, Magic_size (_, size)), c) ->
+        output_acc ppf p;
+        pp_print_as ppf size (String.make 1 c);
+    | Acc_formatting_lit (p, f) ->
+        output_acc ppf p;
+        output_formatting_lit ppf f;
+    | Acc_formatting_gen (p, Acc_open_tag acc') ->
+        output_acc ppf p;
+        pp_open_stag ppf (Format.String_tag (compute_tag output_acc acc'))
+    | Acc_formatting_gen (p, Acc_open_box acc') ->
+        output_acc ppf p;
+        let (indent, bty) =
+          let box_info = compute_tag output_acc acc' in
+          CamlinternalFormat.open_box_of_string box_info
+        in
+        pp_open_box_gen ppf indent bty
+    | Acc_string_literal (p, s)
+    | Acc_data_string (p, s)   -> output_acc ppf p; pp_print_string ppf s;
+    | Acc_char_literal (p, c)
+    | Acc_data_char (p, c)     -> output_acc ppf p; pp_print_char ppf c;
+    | Acc_delay (p, f)         -> output_acc ppf p; f ppf;
+    | Acc_flush p              -> output_acc ppf p; pp_print_flush ppf ();
+    | Acc_invalid_arg (p, msg) -> output_acc ppf p; invalid_arg msg;
+    | End_of_acc               -> ()
+end
+
+let kfprintf k ppf (CamlinternalFormatBasics.Format (fmt, _))  =
+  CamlinternalFormat.make_printf
+    (fun acc -> Driver.output_acc ppf acc; k ppf)
+    End_of_acc fmt
+let fprintf doc fmt = kfprintf ignore doc fmt
+
+
+let kdprintf k (CamlinternalFormatBasics.Format (fmt, _)) =
+  CamlinternalFormat.make_printf
+    (fun acc -> k (fun ppf -> Driver.output_acc ppf acc))
+    End_of_acc fmt
+
+let dprintf fmt = kdprintf (fun i -> i) fmt
+
+let doc_printf fmt =
+  let ppf = ref empty in
+  kfprintf (fun _ -> let doc = !ppf in ppf := empty; doc) ppf fmt
+
+let kdoc_printf k fmt =
+  let ppf = ref empty in
+  kfprintf (fun ppf ->
+      let doc = !ppf in
+      ppf := empty;
+      k doc
+    )
+    ppf fmt
+
+let core f x doc =
+  let r = ref doc in
+  f r x;
+  !r
+
+let format_printer f ppf x =
+  let doc = core f x empty in
+  format ppf doc
+let compat = format_printer
+
+let kasprintf k fmt =
+  kdoc_printf (fun doc -> k (Format.asprintf "%a" format doc)) fmt
+let asprintf fmt = kasprintf Fun.id fmt
+
+let pp_print_iter ?(pp_sep=pp_print_cut) iter elt ppf c =
+      let sep = core pp_sep () in
+      ppf:= Core.iter ~sep ~iter (core elt) c !ppf
+
+let pp_print_list ?(pp_sep=pp_print_cut) elt ppf l =
+  ppf := Core.list ~sep:(core pp_sep ()) (core elt) l !ppf
+
+let pp_print_array ?pp_sep elt ppf a =
+  pp_print_iter ?pp_sep Array.iter elt ppf a
+let pp_print_seq ?pp_sep elt ppf s = pp_print_iter ?pp_sep Seq.iter elt ppf s
+
+let pp_print_option  ?(none=fun _ () -> ()) elt ppf o =
+  ppf := Core.option ~none:(core none ()) (core elt) o !ppf
+
+let pp_print_result  ~ok ~error ppf r =
+   ppf := Core.result ~ok:(core ok) ~error:(core error) r !ppf
+
+let pp_print_either  ~left ~right ppf e =
+  ppf := Core.either ~left:(core left) ~right:(core right) e !ppf
+
+let comma ppf () = fprintf ppf ",@ "
+
+let pp_two_columns ?(sep = "|") ?max_lines ppf (lines: (string * string) list) =
+  let left_column_size =
+    List.fold_left (fun acc (s, _) -> Int.max acc (String.length s)) 0 lines in
+  let lines_nb = List.length lines in
+  let ellipsed_first, ellipsed_last =
+    match max_lines with
+    | Some max_lines when lines_nb > max_lines ->
+        let printed_lines = max_lines - 1 in (* the ellipsis uses one line *)
+        let lines_before = printed_lines / 2 + printed_lines mod 2 in
+        let lines_after = printed_lines / 2 in
+        (lines_before, lines_nb - lines_after - 1)
+    | _ -> (-1, -1)
+  in
+  fprintf ppf "@[<v>";
+  List.iteri (fun k (line_l, line_r) ->
+      if k = ellipsed_first then fprintf ppf "...@,";
+      if ellipsed_first <= k && k <= ellipsed_last then ()
+      else fprintf ppf "%*s %s %s@," left_column_size line_l sep line_r
+    ) lines;
+  fprintf ppf "@]"
+
+let deprecated_printer pr ppf = ppf := add !ppf (Deprecated pr)

--- a/utils/format_doc.mli
+++ b/utils/format_doc.mli
@@ -1,0 +1,290 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*             Florian Angeletti, projet Cambium, Inria Paris             *)
+(*                                                                        *)
+(*   Copyright 2024 Institut National de Recherche en Informatique et     *)
+(*     en Automatique.                                                    *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+(** Composable document for the {!Format} formatting engine. *)
+
+(** This module introduces a pure and immutable document type which represents a
+    sequence of formatting instructions to be printed by a formatting engine at
+    later point. At the same time, it also provides format string interpreter
+    which produces this document type from format string and their associated
+    printers.
+
+    The module is designed to be source compatible with code defining format
+    printers: replacing `Format` by `Format_doc` in your code will convert
+    `Format` printers to `Format_doc` printers.
+*)
+
+(** Format box types *)
+type box_type =
+  | H
+  | V
+  | HV
+  | HoV
+  | B
+
+type stag = Format.stag
+
+(** Base formatting instruction recognized by {!Format} *)
+type element =
+  | Text of string
+  | With_size of int
+  | Open_box of { kind: box_type ; indent:int }
+  | Close_box
+  | Open_tag of Format.stag
+  | Close_tag
+  | Open_tbox
+  | Tab_break of { width : int; offset : int }
+  | Set_tab
+  | Close_tbox
+  | Simple_break of { spaces : int; indent : int }
+  | Break of { fits : string * int * string as 'a; breaks : 'a }
+  | Flush of { newline:bool }
+  | Newline
+  | If_newline
+
+  | Deprecated of (Format.formatter -> unit)
+    (** Escape hatch: a {!Format} printer used to provide backward-compatibility
+        for user-defined printer (from the [#install_printer] toplevel directive
+        for instance). *)
+
+ (** Immutable document type*)
+type t
+type doc = t
+
+(** Empty document *)
+val empty: t
+
+(** [format ppf doc] sends the format instruction of [doc] to the Format's
+    formatter [doc]. *)
+val format: Format.formatter -> doc -> unit
+
+(** Fold over a document as a sequence of instructions *)
+val fold: ('acc -> element -> 'acc) -> 'acc -> doc -> 'acc
+
+(** Immutable API for composing {!doc} *)
+module Core: sig
+  type ('a,'b) fmt = ('a, doc, doc,'b) format4
+
+  type printer0 = doc -> doc
+  type 'a printer = 'a -> printer0
+
+
+  (** {!msg} and {!kmsg} produce a document from a format string and its
+      argument *)
+  val msg: ('a,doc) fmt -> 'a
+  val kmsg: (doc -> 'b) -> ('a,'b) fmt -> 'a
+
+  (** {!printf} and {!kprintf} produce a printer from a format string and its
+      argument*)
+  val printf: ('a, printer0) fmt -> 'a
+  val kprintf: (doc -> 'b) -> ('a, doc -> 'b) fmt -> 'a
+
+  (** The functions below mirror {!Format} printers, without the [pp_print_]
+      prefix naming convention *)
+  val open_box: box_type -> int -> printer0
+  val close_box: printer0
+
+  val text: string printer
+  val string: string printer
+  val bytes: bytes printer
+  val with_size: int printer
+
+  val int: int printer
+  val float: float printer
+  val char: char printer
+  val bool: bool printer
+
+  val space: printer0
+  val cut: printer0
+  val break: spaces:int -> indent:int -> printer0
+
+  val custom_break:
+    fits:(string * int * string as 'a) -> breaks:'a -> printer0
+  val force_newline: printer0
+  val if_newline: printer0
+
+  val flush: printer0
+  val force_stop: printer0
+
+  val open_tbox: printer0
+  val set_tab: printer0
+  val tab: printer0
+  val tab_break: width:int -> offset:int -> printer0
+  val close_tbox: printer0
+
+  val open_tag: stag printer
+  val close_tag: printer0
+
+  val list: ?sep:printer0 -> 'a printer -> 'a list printer
+  val iter:
+    ?sep:printer0 -> iter:(('a -> unit) -> 'b -> unit) -> 'a printer
+    ->'b printer
+  val array: ?sep:printer0 -> 'a printer -> 'a array printer
+  val seq: ?sep:printer0 -> 'a printer -> 'a Seq.t printer
+
+  val option: ?none:printer0 -> 'a printer -> 'a option printer
+  val result: ok:'a printer -> error:'e printer -> ('a,'e) result printer
+  val either: left:'a printer -> right:'b printer -> ('a,'b) Either.t printer
+
+end
+
+(** {1 Compatibility API} *)
+
+(** The functions and types below provides source compatibility with format
+printers and conversion function from {!Format_doc} printers to {!Format}
+printers. The reverse direction is implemented using an escape hatch in the
+formatting instruction and should only be used to preserve backward
+compatibility. *)
+
+type formatter
+type 'a printer = formatter -> 'a -> unit
+
+val formatter: doc ref -> formatter
+(** [formatter rdoc] creates a {!formatter} that updates the [rdoc] reference *)
+
+(** Translate a {!Format_doc} printer to a {!Format} one. *)
+val compat: 'a printer -> Format.formatter -> 'a -> unit
+
+(** If necessary, embbed a {!Format} printer inside a formatting instruction
+    stream. This breaks every guarantees provided by {!Format_doc}. *)
+val deprecated_printer: (Format.formatter -> unit) -> formatter -> unit
+
+
+(** {2 Format string interpreters }*)
+
+val fprintf : formatter -> ('a, formatter,unit) format -> 'a
+val kfprintf:
+  (formatter -> 'a) -> formatter ->
+  ('b, formatter, unit, 'a) format4 -> 'b
+
+val asprintf :  ('a, formatter, unit, string) format4 -> 'a
+val kasprintf : (string -> 'a) -> ('b, formatter, unit, 'a) format4 -> 'b
+
+
+val dprintf : ('a, formatter, unit, formatter -> unit) format4 -> 'a
+val kdprintf:
+  ((formatter -> unit) -> 'a) ->
+  ('b, formatter, unit, 'a) format4 -> 'b
+
+(** {!doc_printf} and {!kdoc_printf} creates a document directly *)
+val doc_printf: ('a, formatter, unit, doc) format4 -> 'a
+val kdoc_printf: (doc -> 'r) -> ('a, formatter, unit, 'r) format4 -> 'a
+
+(** {2 Compatibility with {!Core} }*)
+
+val core: 'a printer -> 'a Core.printer
+val pp_doc: doc printer
+
+(** {2 Source compatibility with Format}*)
+
+(** {3 String printers } *)
+
+val pp_print_string: string printer
+val pp_print_substring: pos:int -> len:int -> string printer
+val pp_print_text: string printer
+val pp_print_bytes: bytes printer
+
+val pp_print_as: formatter -> int -> string -> unit
+val pp_print_substring_as:
+  pos:int -> len:int -> formatter -> int -> string -> unit
+
+(** {3 Primitive type printers }*)
+
+val pp_print_char: char printer
+val pp_print_int: int printer
+val pp_print_float: float printer
+val pp_print_bool: bool printer
+val pp_print_nothing: unit printer
+
+(** {3 Printer combinators }*)
+
+val pp_print_iter:
+  ?pp_sep:unit printer -> (('a -> unit) -> 'b -> unit) ->
+  'a printer -> 'b printer
+
+val pp_print_list: ?pp_sep:unit printer -> 'a printer -> 'a list printer
+val pp_print_array: ?pp_sep:unit printer -> 'a printer -> 'a array printer
+val pp_print_seq: ?pp_sep:unit printer -> 'a printer -> 'a Seq.t printer
+
+val pp_print_option: ?none:unit printer -> 'a printer -> 'a option printer
+val pp_print_result: ok:'a printer -> error:'e printer -> ('a,'e) result printer
+val pp_print_either:
+  left:'a printer -> right:'b printer -> ('a,'b) Either.t printer
+
+
+(** {3 Boxes and tags }*)
+
+val pp_open_stag: Format.stag printer
+val pp_close_stag: unit printer
+
+val pp_open_box: int printer
+val pp_close_box: unit printer
+
+(** {3 Break hints} *)
+
+val pp_print_space: unit printer
+val pp_print_cut: unit printer
+val pp_print_break: formatter -> int -> int -> unit
+val pp_print_custom_break:
+  formatter -> fits:(string * int * string as 'c) -> breaks:'c -> unit
+
+(** {3 Tabulations }*)
+
+val pp_open_tbox: unit printer
+val pp_close_tbox: unit printer
+val pp_set_tab: unit printer
+val pp_print_tab: unit printer
+val pp_print_tbreak: formatter -> int -> int -> unit
+
+(** {3 Newlines and flushing }*)
+
+val pp_print_if_newline: unit printer
+val pp_force_newline: unit printer
+val pp_print_flush: unit printer
+val pp_print_newline: unit printer
+
+(** {1 Compiler specific functions }*)
+
+(** {2 Separators }*)
+
+val comma: unit printer
+
+(** {2 Compiler output} *)
+
+val pp_two_columns :
+  ?sep:string -> ?max_lines:int ->
+  formatter -> (string * string) list -> unit
+(** [pp_two_columns ?sep ?max_lines ppf l] prints the lines in [l] as two
+   columns separated by [sep] ("|" by default). [max_lines] can be used to
+   indicate a maximum number of lines to print -- an ellipsis gets inserted at
+   the middle if the input has too many lines.
+
+   Example:
+
+    {v pp_two_columns ~max_lines:3 Format.std_formatter [
+      "abc", "hello";
+      "def", "zzz";
+      "a"  , "bllbl";
+      "bb" , "dddddd";
+    ] v}
+
+    prints
+
+    {v
+    abc | hello
+    ...
+    bb  | dddddd
+    v}
+*)

--- a/utils/linkdeps.ml
+++ b/utils/linkdeps.ml
@@ -99,7 +99,7 @@ let check t =
 
 (* Error report *)
 
-open Format
+open Format_doc
 
 let print_reference print_fname ppf {compunit; filename} =
   fprintf ppf "%a (%a)" Style.inline_code compunit print_fname filename

--- a/utils/linkdeps.mli
+++ b/utils/linkdeps.mli
@@ -57,8 +57,6 @@ val check : t -> error option
     - Some implementation appear
       before their dependencies *)
 
-open Format
 
-val report_error
-  :  print_filename:(formatter -> string -> unit)
-  -> formatter -> error -> unit
+val report_error :
+  print_filename:string Format_doc.printer -> error Format_doc.printer

--- a/utils/misc.mli
+++ b/utils/misc.mli
@@ -445,7 +445,8 @@ val spellcheck : string list -> string -> string list
     list of suggestions taken from [env], that are close enough to
     [name] that it may be a typo for one of them. *)
 
-val did_you_mean : Format.formatter -> (unit -> string list) -> unit
+val did_you_mean :
+    Format_doc.formatter -> (unit -> string list) -> unit
 (** [did_you_mean ppf get_choices] hints that the user may have meant
     one of the option returned by calling [get_choices]. It does nothing
     if the returned list is empty.
@@ -505,8 +506,8 @@ module Style : sig
     inline_code: tag_style;
   }
 
-  val as_inline_code: (Format.formatter -> 'a -> unit as 'printer) -> 'printer
-  val inline_code: Format.formatter -> string -> unit
+  val as_inline_code: 'a Format_doc.printer -> 'a Format_doc.printer
+  val inline_code: string Format_doc.printer
 
   val default_styles: styles
   val get_styles: unit -> styles
@@ -536,33 +537,7 @@ val print_if :
   Format.formatter -> bool ref -> (Format.formatter -> 'a -> unit) -> 'a -> 'a
 (** [print_if ppf flag fmt x] prints [x] with [fmt] on [ppf] if [b] is true. *)
 
-val pp_two_columns :
-  ?sep:string -> ?max_lines:int ->
-  Format.formatter -> (string * string) list -> unit
-(** [pp_two_columns ?sep ?max_lines ppf l] prints the lines in [l] as two
-   columns separated by [sep] ("|" by default). [max_lines] can be used to
-   indicate a maximum number of lines to print -- an ellipsis gets inserted at
-   the middle if the input has too many lines.
-
-   Example:
-
-    {v pp_two_columns ~max_lines:3 Format.std_formatter [
-      "abc", "hello";
-      "def", "zzz";
-      "a"  , "bllbl";
-      "bb" , "dddddd";
-    ] v}
-
-    prints
-
-    {v
-    abc | hello
-    ...
-    bb  | dddddd
-    v}
-*)
-
-val print_see_manual : Format.formatter -> int list -> unit
+val print_see_manual : int list Format_doc.printer
 (** See manual section *)
 
 (** {1 Displaying configuration variables} *)

--- a/utils/warnings.ml
+++ b/utils/warnings.ml
@@ -52,7 +52,7 @@ type t =
   | Implicit_public_methods of string list  (* 15 *)
   | Unerasable_optional_argument            (* 16 *)
   | Undeclared_virtual_method of string     (* 17 *)
-  | Not_principal of string                 (* 18 *)
+  | Not_principal of Format_doc.t           (* 18 *)
   | Non_principal_labels of string          (* 19 *)
   | Ignored_extra_argument                  (* 20 *)
   | Nonreturning_statement                  (* 21 *)
@@ -926,7 +926,9 @@ let message = function
       ^ String.concat " " l ^ "."
   | Unerasable_optional_argument -> "this optional argument cannot be erased."
   | Undeclared_virtual_method m -> "the virtual method "^m^" is not declared."
-  | Not_principal s -> s^" is not principal."
+  | Not_principal msg ->
+      Format_doc.asprintf "%a is not principal."
+        Format_doc.pp_doc msg
   | Non_principal_labels s -> s^" without principality."
   | Ignored_extra_argument -> "this argument will not be used by the function."
   | Nonreturning_statement ->
@@ -1040,7 +1042,7 @@ let message = function
         "Code should not depend on the actual values of\n\
          this constructor's arguments. They are only for information\n\
          and may change in future versions. %a"
-        Misc.print_see_manual ref_manual
+        (Format_doc.compat Misc.print_see_manual) ref_manual
   | Unreachable_case ->
       "this match case is unreachable.\n\
        Consider replacing it with a refutation case '<pat> -> .'"
@@ -1071,7 +1073,7 @@ let message = function
          %s.\n\
          Only the first match will be used to evaluate the guard expression.\n\
          %a"
-        vars_explanation Misc.print_see_manual ref_manual
+        vars_explanation (Format_doc.compat Misc.print_see_manual) ref_manual
   | No_cmx_file name ->
       Printf.sprintf
         "no cmx file was found in path for module %s, \

--- a/utils/warnings.mli
+++ b/utils/warnings.mli
@@ -57,7 +57,7 @@ type t =
   | Implicit_public_methods of string list  (* 15 *)
   | Unerasable_optional_argument            (* 16 *)
   | Undeclared_virtual_method of string     (* 17 *)
-  | Not_principal of string                 (* 18 *)
+  | Not_principal of Format_doc.t           (* 18 *)
   | Non_principal_labels of string          (* 19 *)
   | Ignored_extra_argument                  (* 20 *)
   | Nonreturning_statement                  (* 21 *)


### PR DESCRIPTION
Currently when the compiler needs to build a fragment of an error message while playing nice with `Format`, the best option is to construct a `Format.formatter -> unit` closure. This construction is used in many part of the compilers.
However, it has proven to be quite brittle due to the simultaneous uses of many global states when printing error messages, see #13099 for a recent example (which was triggered by a printing closure run in a different environment that the one it was built in).

This PR proposes to remove this brittleness by a introducing a `document` type which represents a list of formatting instructions 
```ocaml
type element =
  | Text of string
  | Open_box of { kind: box_type ; indent:int }
  | Close_box
  | Open_tag of Format.stag
  | Close_tag
  |  ...
```
to be sent to an actual formatting engine at a later point. Since this `document` type contains only data and no closures (except for an escape hatch), we are guaranteed that printing this type does not create side-effects without losing  any of the formatting abilities of `Format`. In particular, this document type can be serialized while preserving all the break hints, formatting boxes and tags (which semantics could then be reimplemented by developer tools). 

In term of implementation, this PR adds a new `Format_doc` module which provides:
* format string interpreters that output this new `document` type
* printing functions that mirrors the printing functions in the `Format` module
* a conversion function from `Format_doc` printer to `Format` printer
* a "deprecated" conversion function in the other direction which uses a temporary escape hatches
* A  submodule for building `document` in an immutable way
 
As a consequence the `Format_doc` module is source-compatible with the `Format` module, and for most of the compiler modules replacing `open Format` by an `open Format_doc` is enough to switch to the new kinds of printers.
