### PR TITLE
Fix marking of toplevel attributes in implementations

### DIFF
--- a/.depend
+++ b/.depend
@@ -6254,6 +6254,7 @@ driver/compile_common.cmi : \
     parsing/unit_info.cmi \
     typing/typedtree.cmi \
     parsing/parsetree.cmi \
+    utils/misc.cmi \
     typing/env.cmi
 driver/compmisc.cmo : \
     utils/warnings.cmi \

--- a/Changes
+++ b/Changes
@@ -296,6 +296,10 @@ _______________
   inside signatures.
   (Jacques Garrigue, report by Richard Eisenberg, review by Florian Angeletti)
 
+- #13170: Fix a bug that would result in some floating alerts `[@@@alert ...]`
+  incorrectly triggering Warning 53.
+  (Nicolás Ojeda Bär, review by Chris Casinghino)
+
 OCaml 5.2.0 (13 May 2024)
 -------------------------
 

--- a/Changes
+++ b/Changes
@@ -298,7 +298,7 @@ _______________
 
 - #13170: Fix a bug that would result in some floating alerts `[@@@alert ...]`
   incorrectly triggering Warning 53.
-  (Nicolás Ojeda Bär, review by Chris Casinghino)
+  (Nicolás Ojeda Bär, review by Chris Casinghino and Florian Angeletti)
 
 OCaml 5.2.0 (13 May 2024)
 -------------------------

--- a/driver/compile_common.mli
+++ b/driver/compile_common.mli
@@ -48,12 +48,13 @@ val with_info :
 val parse_intf : info -> Parsetree.signature
 (** [parse_intf info] parses an interface (usually an [.mli] file). *)
 
-val typecheck_intf : info -> Parsetree.signature -> Typedtree.signature
+val typecheck_intf :
+  info -> Parsetree.signature -> Misc.alerts * Typedtree.signature
 (** [typecheck_intf info parsetree] typechecks an interface and returns
     the typedtree of the associated signature.
 *)
 
-val emit_signature : info -> Parsetree.signature -> Typedtree.signature -> unit
+val emit_signature : info -> Misc.alerts -> Typedtree.signature -> unit
 (** [emit_signature info parsetree typedtree] emits the [.cmi] file
     containing the given signature.
 *)

--- a/parsing/builtin_attributes.ml
+++ b/parsing/builtin_attributes.ml
@@ -313,15 +313,19 @@ let warning_attribute ?(ppwarning = true) =
           with Arg.Bad msg -> warn_payload loc name.txt msg
         end
     | k ->
-        (* Don't [mark_used] in the [Some] cases - that happens in [Env] or
-           [type_mod] if they are in a valid place.  Do [mark_used] in the
-           [None] case, which is just malformed and covered by the "Invalid
-           payload" warning. *)
         match kind_and_message k with
         | Some ("all", _) ->
             warn_payload loc name.txt "The alert name 'all' is reserved"
-        | Some _ -> ()
+        | Some _ ->
+            (* Do [mark_used] in the [Some] case only if Warning 53 is
+               disabled. Later, they will be marked used (provided they are in a
+               valid place) in [compile_common], when they are extracted to be
+               persisted inside the [.cmi] file. *)
+            if not (Warnings.is_active (Misplaced_attribute ""))
+            then mark_used name
         | None -> begin
+            (* Do [mark_used] in the [None] case, which is just malformed and
+               covered by the "Invalid payload" warning. *)
             mark_used name;
             warn_payload loc name.txt "Invalid payload"
           end

--- a/parsing/builtin_attributes.ml
+++ b/parsing/builtin_attributes.ml
@@ -38,6 +38,7 @@ let attr_order a1 a2 =
 
 let warn_unused () =
   let keys = List.of_seq (Attribute_table.to_seq_keys unused_attrs) in
+  Attribute_table.clear unused_attrs;
   let keys = List.sort attr_order keys in
   List.iter (fun sloc ->
     Location.prerr_warning sloc.loc (Warnings.Misplaced_attribute sloc.txt))

--- a/parsing/builtin_attributes.ml
+++ b/parsing/builtin_attributes.ml
@@ -268,7 +268,10 @@ let rec attrs_of_sig = function
   | _ ->
       []
 
-let alerts_of_sig sg = alerts_of_attrs (attrs_of_sig sg)
+let alerts_of_sig ~mark sg =
+  let a = attrs_of_sig sg in
+  if mark then mark_alerts_used a;
+  alerts_of_attrs a
 
 let rec attrs_of_str = function
   | {pstr_desc = Pstr_attribute a} :: tl ->
@@ -276,7 +279,10 @@ let rec attrs_of_str = function
   | _ ->
       []
 
-let alerts_of_str str = alerts_of_attrs (attrs_of_str str)
+let alerts_of_str ~mark str =
+  let a = attrs_of_str str in
+  if mark then mark_alerts_used a;
+  alerts_of_attrs a
 
 let warn_payload loc txt msg =
   Location.prerr_warning loc (Warnings.Attribute_payload (txt, msg))

--- a/parsing/builtin_attributes.mli
+++ b/parsing/builtin_attributes.mli
@@ -115,8 +115,8 @@ val check_alerts_inclusion:
   def:Location.t -> use:Location.t -> Location.t -> Parsetree.attributes ->
   Parsetree.attributes -> string -> unit
 val alerts_of_attrs: Parsetree.attributes -> Misc.alerts
-val alerts_of_sig: Parsetree.signature -> Misc.alerts
-val alerts_of_str: Parsetree.structure -> Misc.alerts
+val alerts_of_sig: mark:bool -> Parsetree.signature -> Misc.alerts
+val alerts_of_str: mark:bool -> Parsetree.structure -> Misc.alerts
 
 val check_deprecated_mutable:
     Location.t -> Parsetree.attributes -> string -> unit

--- a/testsuite/tests/warnings/w53.compilers.reference
+++ b/testsuite/tests/warnings/w53.compilers.reference
@@ -902,3 +902,8 @@ File "w53.ml", line 506, characters 39-52:
 506 |   external z : int64 -> int64 = "x" [@@tail_mod_cons] (* rejected *)
                                              ^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "tail_mod_cons" attribute cannot appear in this context
+
+File "w53.ml", line 512, characters 10-15:
+512 |       [@@@alert foo "foo"] (* rejected *)
+                ^^^^^
+Warning 53 [misplaced-attribute]: the "alert" attribute cannot appear in this context

--- a/testsuite/tests/warnings/w53.compilers.reference
+++ b/testsuite/tests/warnings/w53.compilers.reference
@@ -23,887 +23,887 @@ File "w53.ml", line 26, characters 6-11:
            ^^^^^
 Warning 53 [misplaced-attribute]: the "alert" attribute cannot appear in this context
 
-File "w53.ml", line 31, characters 24-29:
-31 |   type t1 = { x : int [@boxed] } (* rejected *)
+File "w53.ml", line 34, characters 24-29:
+34 |   type t1 = { x : int [@boxed] } (* rejected *)
                              ^^^^^
 Warning 53 [misplaced-attribute]: the "boxed" attribute cannot appear in this context
 
-File "w53.ml", line 33, characters 16-21:
-33 |   val x : int [@boxed] (* rejected *)
+File "w53.ml", line 36, characters 16-21:
+36 |   val x : int [@boxed] (* rejected *)
                      ^^^^^
 Warning 53 [misplaced-attribute]: the "boxed" attribute cannot appear in this context
 
-File "w53.ml", line 37, characters 17-22:
-37 |   val y : int [@@boxed] (* rejected *)
+File "w53.ml", line 40, characters 17-22:
+40 |   val y : int [@@boxed] (* rejected *)
                       ^^^^^
 Warning 53 [misplaced-attribute]: the "boxed" attribute cannot appear in this context
 
-File "w53.ml", line 39, characters 6-11:
-39 |   [@@@boxed] (* rejected *)
+File "w53.ml", line 42, characters 6-11:
+42 |   [@@@boxed] (* rejected *)
            ^^^^^
 Warning 53 [misplaced-attribute]: the "boxed" attribute cannot appear in this context
 
-File "w53.ml", line 43, characters 16-21:
-43 |   let x = (42 [@boxed], 84) (* rejected *)
+File "w53.ml", line 46, characters 16-21:
+46 |   let x = (42 [@boxed], 84) (* rejected *)
                      ^^^^^
 Warning 53 [misplaced-attribute]: the "boxed" attribute cannot appear in this context
 
-File "w53.ml", line 45, characters 16-21:
-45 |   let y = 10 [@@boxed] (* rejected *)
+File "w53.ml", line 48, characters 16-21:
+48 |   let y = 10 [@@boxed] (* rejected *)
                      ^^^^^
 Warning 53 [misplaced-attribute]: the "boxed" attribute cannot appear in this context
 
-File "w53.ml", line 47, characters 6-11:
-47 |   [@@@boxed] (* rejected *)
+File "w53.ml", line 50, characters 6-11:
+50 |   [@@@boxed] (* rejected *)
            ^^^^^
 Warning 53 [misplaced-attribute]: the "boxed" attribute cannot appear in this context
 
-File "w53.ml", line 54, characters 16-26:
-54 |   val x : int [@deprecated] (* rejected *)
+File "w53.ml", line 57, characters 16-26:
+57 |   val x : int [@deprecated] (* rejected *)
                      ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "deprecated" attribute cannot appear in this context
 
-File "w53.ml", line 60, characters 6-16:
-60 |   [@@@deprecated] (* rejected *)
+File "w53.ml", line 63, characters 6-16:
+63 |   [@@@deprecated] (* rejected *)
            ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "deprecated" attribute cannot appear in this context
 
-File "w53.ml", line 64, characters 14-24:
-64 |   let x = 5 [@deprecated] (* rejected *)
+File "w53.ml", line 67, characters 14-24:
+67 |   let x = 5 [@deprecated] (* rejected *)
                    ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "deprecated" attribute cannot appear in this context
 
-File "w53.ml", line 66, characters 16-26:
-66 |   let y = 10 [@@deprecated] (* rejected *)
+File "w53.ml", line 69, characters 16-26:
+69 |   let y = 10 [@@deprecated] (* rejected *)
                      ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "deprecated" attribute cannot appear in this context
 
-File "w53.ml", line 68, characters 6-16:
-68 |   [@@@deprecated] (* rejected *)
+File "w53.ml", line 71, characters 6-16:
+71 |   [@@@deprecated] (* rejected *)
            ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "deprecated" attribute cannot appear in this context
 
-File "w53.ml", line 73, characters 19-37:
-73 |   type t1 = Foo1 [@deprecated_mutable] (* rejected *)
+File "w53.ml", line 76, characters 19-37:
+76 |   type t1 = Foo1 [@deprecated_mutable] (* rejected *)
                         ^^^^^^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "deprecated_mutable" attribute cannot appear in this context
 
-File "w53.ml", line 75, characters 16-34:
-75 |   val x : int [@deprecated_mutable] (* rejected *)
+File "w53.ml", line 78, characters 16-34:
+78 |   val x : int [@deprecated_mutable] (* rejected *)
                      ^^^^^^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "deprecated_mutable" attribute cannot appear in this context
 
-File "w53.ml", line 77, characters 21-39:
-77 |   type 'a t2 = 'a [@@deprecated_mutable] (* rejected *)
+File "w53.ml", line 80, characters 21-39:
+80 |   type 'a t2 = 'a [@@deprecated_mutable] (* rejected *)
                           ^^^^^^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "deprecated_mutable" attribute cannot appear in this context
 
-File "w53.ml", line 81, characters 24-42:
-81 |   type t4 = { x : int [@deprecated_mutable] } (* rejected *)
+File "w53.ml", line 84, characters 24-42:
+84 |   type t4 = { x : int [@deprecated_mutable] } (* rejected *)
                              ^^^^^^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "deprecated_mutable" attribute cannot appear in this context
 
-File "w53.ml", line 83, characters 17-35:
-83 |   val y : int [@@deprecated_mutable] (* rejected *)
+File "w53.ml", line 86, characters 17-35:
+86 |   val y : int [@@deprecated_mutable] (* rejected *)
                       ^^^^^^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "deprecated_mutable" attribute cannot appear in this context
 
-File "w53.ml", line 85, characters 6-24:
-85 |   [@@@deprecated_mutable] (* rejected *)
+File "w53.ml", line 88, characters 6-24:
+88 |   [@@@deprecated_mutable] (* rejected *)
            ^^^^^^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "deprecated_mutable" attribute cannot appear in this context
 
-File "w53.ml", line 89, characters 14-32:
-89 |   let x = 5 [@deprecated_mutable] (* rejected *)
+File "w53.ml", line 92, characters 14-32:
+92 |   let x = 5 [@deprecated_mutable] (* rejected *)
                    ^^^^^^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "deprecated_mutable" attribute cannot appear in this context
 
-File "w53.ml", line 91, characters 16-34:
-91 |   let y = 10 [@@deprecated_mutable] (* rejected *)
+File "w53.ml", line 94, characters 16-34:
+94 |   let y = 10 [@@deprecated_mutable] (* rejected *)
                      ^^^^^^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "deprecated_mutable" attribute cannot appear in this context
 
-File "w53.ml", line 93, characters 6-24:
-93 |   [@@@deprecated_mutable] (* rejected *)
+File "w53.ml", line 96, characters 6-24:
+96 |   [@@@deprecated_mutable] (* rejected *)
            ^^^^^^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "deprecated_mutable" attribute cannot appear in this context
 
-File "w53.ml", line 98, characters 32-46:
-98 |   type t1 = Foo1 of int * int [@explicit_arity] (* rejected *)
-                                     ^^^^^^^^^^^^^^
+File "w53.ml", line 101, characters 32-46:
+101 |   type t1 = Foo1 of int * int [@explicit_arity] (* rejected *)
+                                      ^^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "explicit_arity" attribute cannot appear in this context
 
-File "w53.ml", line 100, characters 16-30:
-100 |   val x : int [@explicit_arity] (* rejected *)
+File "w53.ml", line 103, characters 16-30:
+103 |   val x : int [@explicit_arity] (* rejected *)
                       ^^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "explicit_arity" attribute cannot appear in this context
 
-File "w53.ml", line 102, characters 20-34:
-102 |   type 'a t2 = 'a [@explicit_arity] (* rejected *)
+File "w53.ml", line 105, characters 20-34:
+105 |   type 'a t2 = 'a [@explicit_arity] (* rejected *)
                           ^^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "explicit_arity" attribute cannot appear in this context
 
-File "w53.ml", line 104, characters 17-31:
-104 |   val y : int [@@explicit_arity] (* rejected *)
+File "w53.ml", line 107, characters 17-31:
+107 |   val y : int [@@explicit_arity] (* rejected *)
                        ^^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "explicit_arity" attribute cannot appear in this context
 
-File "w53.ml", line 106, characters 6-20:
-106 |   [@@@explicit_arity] (* rejected *)
+File "w53.ml", line 109, characters 6-20:
+109 |   [@@@explicit_arity] (* rejected *)
             ^^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "explicit_arity" attribute cannot appear in this context
 
-File "w53.ml", line 110, characters 14-28:
-110 |   let x = 5 [@explicit_arity] (* rejected *)
+File "w53.ml", line 113, characters 14-28:
+113 |   let x = 5 [@explicit_arity] (* rejected *)
                     ^^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "explicit_arity" attribute cannot appear in this context
 
-File "w53.ml", line 112, characters 16-30:
-112 |   let y = 10 [@@explicit_arity] (* rejected *)
+File "w53.ml", line 115, characters 16-30:
+115 |   let y = 10 [@@explicit_arity] (* rejected *)
                       ^^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "explicit_arity" attribute cannot appear in this context
 
-File "w53.ml", line 114, characters 6-20:
-114 |   [@@@explicit_arity] (* rejected *)
+File "w53.ml", line 117, characters 6-20:
+117 |   [@@@explicit_arity] (* rejected *)
             ^^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "explicit_arity" attribute cannot appear in this context
 
-File "w53.ml", line 119, characters 18-27:
-119 |   type t1 = int [@immediate] (* rejected *)
+File "w53.ml", line 122, characters 18-27:
+122 |   type t1 = int [@immediate] (* rejected *)
                         ^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "immediate" attribute cannot appear in this context
 
-File "w53.ml", line 123, characters 16-25:
-123 |   val x : int [@immediate] (* rejected *)
+File "w53.ml", line 126, characters 16-25:
+126 |   val x : int [@immediate] (* rejected *)
                       ^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "immediate" attribute cannot appear in this context
 
-File "w53.ml", line 124, characters 17-26:
-124 |   val x : int [@@immediate] (* rejected *)
+File "w53.ml", line 127, characters 17-26:
+127 |   val x : int [@@immediate] (* rejected *)
                        ^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "immediate" attribute cannot appear in this context
 
-File "w53.ml", line 126, characters 6-15:
-126 |   [@@@immediate] (* rejected *)
+File "w53.ml", line 129, characters 6-15:
+129 |   [@@@immediate] (* rejected *)
             ^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "immediate" attribute cannot appear in this context
 
-File "w53.ml", line 127, characters 6-17:
-127 |   [@@@immediate64] (* rejected *)
+File "w53.ml", line 130, characters 6-17:
+130 |   [@@@immediate64] (* rejected *)
             ^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "immediate64" attribute cannot appear in this context
 
-File "w53.ml", line 131, characters 15-24:
-131 |   let x = (4 [@immediate], 42 [@immediate64]) (* rejected *)
+File "w53.ml", line 134, characters 15-24:
+134 |   let x = (4 [@immediate], 42 [@immediate64]) (* rejected *)
                      ^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "immediate" attribute cannot appear in this context
 
-File "w53.ml", line 131, characters 32-43:
-131 |   let x = (4 [@immediate], 42 [@immediate64]) (* rejected *)
+File "w53.ml", line 134, characters 32-43:
+134 |   let x = (4 [@immediate], 42 [@immediate64]) (* rejected *)
                                       ^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "immediate64" attribute cannot appear in this context
 
-File "w53.ml", line 132, characters 21-30:
-132 |   let y = (4, 42) [@@immediate] (* rejected *)
+File "w53.ml", line 135, characters 21-30:
+135 |   let y = (4, 42) [@@immediate] (* rejected *)
                            ^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "immediate" attribute cannot appear in this context
 
-File "w53.ml", line 133, characters 21-32:
-133 |   let z = (4, 42) [@@immediate64] (* rejected *)
+File "w53.ml", line 136, characters 21-32:
+136 |   let z = (4, 42) [@@immediate64] (* rejected *)
                            ^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "immediate64" attribute cannot appear in this context
 
-File "w53.ml", line 135, characters 18-27:
-135 |   type t1 = int [@immediate] (* rejected *)
+File "w53.ml", line 138, characters 18-27:
+138 |   type t1 = int [@immediate] (* rejected *)
                         ^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "immediate" attribute cannot appear in this context
 
-File "w53.ml", line 139, characters 6-15:
-139 |   [@@@immediate] (* rejected *)
+File "w53.ml", line 142, characters 6-15:
+142 |   [@@@immediate] (* rejected *)
             ^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "immediate" attribute cannot appear in this context
 
-File "w53.ml", line 140, characters 6-17:
-140 |   [@@@immediate64] (* rejected *)
+File "w53.ml", line 143, characters 6-17:
+143 |   [@@@immediate64] (* rejected *)
             ^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "immediate64" attribute cannot appear in this context
 
-File "w53.ml", line 145, characters 25-31:
-145 |   type t1 = int -> int [@inline] (* rejected *)
+File "w53.ml", line 148, characters 25-31:
+148 |   type t1 = int -> int [@inline] (* rejected *)
                                ^^^^^^
 Warning 53 [misplaced-attribute]: the "inline" attribute cannot appear in this context
 
-File "w53.ml", line 146, characters 26-32:
-146 |   type t2 = int -> int [@@inline] (* rejected *)
+File "w53.ml", line 149, characters 26-32:
+149 |   type t2 = int -> int [@@inline] (* rejected *)
                                 ^^^^^^
 Warning 53 [misplaced-attribute]: the "inline" attribute cannot appear in this context
 
-File "w53.ml", line 147, characters 25-32:
-147 |   type t3 = int -> int [@inlined] (* rejected *)
+File "w53.ml", line 150, characters 25-32:
+150 |   type t3 = int -> int [@inlined] (* rejected *)
                                ^^^^^^^
 Warning 53 [misplaced-attribute]: the "inlined" attribute cannot appear in this context
 
-File "w53.ml", line 148, characters 26-33:
-148 |   type t4 = int -> int [@@inlined] (* rejected *)
+File "w53.ml", line 151, characters 26-33:
+151 |   type t4 = int -> int [@@inlined] (* rejected *)
                                 ^^^^^^^
 Warning 53 [misplaced-attribute]: the "inlined" attribute cannot appear in this context
 
-File "w53.ml", line 150, characters 24-30:
-150 |   val f1 : int -> int [@inline] (* rejected *)
+File "w53.ml", line 153, characters 24-30:
+153 |   val f1 : int -> int [@inline] (* rejected *)
                               ^^^^^^
 Warning 53 [misplaced-attribute]: the "inline" attribute cannot appear in this context
 
-File "w53.ml", line 151, characters 25-31:
-151 |   val f2 : int -> int [@@inline] (* rejected *)
+File "w53.ml", line 154, characters 25-31:
+154 |   val f2 : int -> int [@@inline] (* rejected *)
                                ^^^^^^
 Warning 53 [misplaced-attribute]: the "inline" attribute cannot appear in this context
 
-File "w53.ml", line 152, characters 24-31:
-152 |   val f3 : int -> int [@inlined] (* rejected *)
+File "w53.ml", line 155, characters 24-31:
+155 |   val f3 : int -> int [@inlined] (* rejected *)
                               ^^^^^^^
 Warning 53 [misplaced-attribute]: the "inlined" attribute cannot appear in this context
 
-File "w53.ml", line 153, characters 25-32:
-153 |   val f4 : int -> int [@@inlined] (* rejected *)
+File "w53.ml", line 156, characters 25-32:
+156 |   val f4 : int -> int [@@inlined] (* rejected *)
                                ^^^^^^^
 Warning 53 [misplaced-attribute]: the "inlined" attribute cannot appear in this context
 
-File "w53.ml", line 155, characters 53-59:
-155 |   module type F = functor (X : sig end) -> sig end [@inline] (* rejected *)
+File "w53.ml", line 158, characters 53-59:
+158 |   module type F = functor (X : sig end) -> sig end [@inline] (* rejected *)
                                                            ^^^^^^
 Warning 53 [misplaced-attribute]: the "inline" attribute cannot appear in this context
 
-File "w53.ml", line 156, characters 54-60:
-156 |   module type G = functor (X : sig end) -> sig end [@@inline] (* rejected *)
+File "w53.ml", line 159, characters 54-60:
+159 |   module type G = functor (X : sig end) -> sig end [@@inline] (* rejected *)
                                                             ^^^^^^
 Warning 53 [misplaced-attribute]: the "inline" attribute cannot appear in this context
 
-File "w53.ml", line 158, characters 6-12:
-158 |   [@@@inline] (* rejected *)
+File "w53.ml", line 161, characters 6-12:
+161 |   [@@@inline] (* rejected *)
             ^^^^^^
 Warning 53 [misplaced-attribute]: the "inline" attribute cannot appear in this context
 
-File "w53.ml", line 159, characters 6-13:
-159 |   [@@@inlined] (* rejected *)
+File "w53.ml", line 162, characters 6-13:
+162 |   [@@@inlined] (* rejected *)
             ^^^^^^^
 Warning 53 [misplaced-attribute]: the "inlined" attribute cannot appear in this context
 
-File "w53.ml", line 163, characters 16-22:
-163 |   let h x = x [@inline] (* rejected *)
+File "w53.ml", line 166, characters 16-22:
+166 |   let h x = x [@inline] (* rejected *)
                       ^^^^^^
 Warning 53 [misplaced-attribute]: the "inline" attribute cannot appear in this context
 
-File "w53.ml", line 164, characters 16-28:
-164 |   let h x = x [@ocaml.inline] (* rejected *)
+File "w53.ml", line 167, characters 16-28:
+167 |   let h x = x [@ocaml.inline] (* rejected *)
                       ^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "ocaml.inline" attribute cannot appear in this context
 
-File "w53.ml", line 166, characters 16-23:
-166 |   let i x = x [@inlined] (* rejected *)
+File "w53.ml", line 169, characters 16-23:
+169 |   let i x = x [@inlined] (* rejected *)
                       ^^^^^^^
 Warning 53 [misplaced-attribute]: the "inlined" attribute cannot appear in this context
 
-File "w53.ml", line 167, characters 16-29:
-167 |   let j x = x [@ocaml.inlined] (* rejected *)
+File "w53.ml", line 170, characters 16-29:
+170 |   let j x = x [@ocaml.inlined] (* rejected *)
                       ^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "ocaml.inlined" attribute cannot appear in this context
 
-File "w53.ml", line 170, characters 18-25:
-170 |   let l x = h x [@inlined] (* rejected *)
+File "w53.ml", line 173, characters 18-25:
+173 |   let l x = h x [@inlined] (* rejected *)
                         ^^^^^^^
 Warning 53 [misplaced-attribute]: the "inlined" attribute cannot appear in this context
 
-File "w53.ml", line 178, characters 27-33:
-178 |   module C = struct end [@@inline] (* rejected *)
+File "w53.ml", line 181, characters 27-33:
+181 |   module C = struct end [@@inline] (* rejected *)
                                  ^^^^^^
 Warning 53 [misplaced-attribute]: the "inline" attribute cannot appear in this context
 
-File "w53.ml", line 179, characters 28-40:
-179 |   module C' = struct end [@@ocaml.inline] (* rejected *)
+File "w53.ml", line 182, characters 28-40:
+182 |   module C' = struct end [@@ocaml.inline] (* rejected *)
                                   ^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "ocaml.inline" attribute cannot appear in this context
 
-File "w53.ml", line 180, characters 27-34:
-180 |   module D = struct end [@@inlined] (* rejected *)
+File "w53.ml", line 183, characters 27-34:
+183 |   module D = struct end [@@inlined] (* rejected *)
                                  ^^^^^^^
 Warning 53 [misplaced-attribute]: the "inlined" attribute cannot appear in this context
 
-File "w53.ml", line 181, characters 28-41:
-181 |   module D' = struct end [@@ocaml.inlined] (* rejected *)
+File "w53.ml", line 184, characters 28-41:
+184 |   module D' = struct end [@@ocaml.inlined] (* rejected *)
                                   ^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "ocaml.inlined" attribute cannot appear in this context
 
-File "w53.ml", line 185, characters 18-24:
-185 |   module G = (A [@inline])(struct end) (* rejected *)
+File "w53.ml", line 188, characters 18-24:
+188 |   module G = (A [@inline])(struct end) (* rejected *)
                         ^^^^^^
 Warning 53 [misplaced-attribute]: the "inline" attribute cannot appear in this context
 
-File "w53.ml", line 186, characters 19-31:
-186 |   module G' = (A [@ocaml.inline])(struct end) (* rejected *)
+File "w53.ml", line 189, characters 19-31:
+189 |   module G' = (A [@ocaml.inline])(struct end) (* rejected *)
                          ^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "ocaml.inline" attribute cannot appear in this context
 
-File "w53.ml", line 190, characters 24-31:
-190 |   module I = Set.Make [@inlined] (* rejected *)
+File "w53.ml", line 193, characters 24-31:
+193 |   module I = Set.Make [@inlined] (* rejected *)
                               ^^^^^^^
 Warning 53 [misplaced-attribute]: the "inlined" attribute cannot appear in this context
 
-File "w53.ml", line 191, characters 25-38:
-191 |   module I' = Set.Make [@ocaml.inlined] (* rejected *)
+File "w53.ml", line 194, characters 25-38:
+194 |   module I' = Set.Make [@ocaml.inlined] (* rejected *)
                                ^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "ocaml.inlined" attribute cannot appear in this context
 
-File "w53.ml", line 193, characters 25-32:
-193 |   module J = Set.Make [@@inlined] (* rejected *)
+File "w53.ml", line 196, characters 25-32:
+196 |   module J = Set.Make [@@inlined] (* rejected *)
                                ^^^^^^^
 Warning 53 [misplaced-attribute]: the "inlined" attribute cannot appear in this context
 
-File "w53.ml", line 194, characters 26-39:
-194 |   module J' = Set.Make [@@ocaml.inlined] (* rejected *)
+File "w53.ml", line 197, characters 26-39:
+197 |   module J' = Set.Make [@@ocaml.inlined] (* rejected *)
                                 ^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "ocaml.inlined" attribute cannot appear in this context
 
-File "w53.ml", line 199, characters 21-28:
-199 |   type 'a t1 = 'a [@@noalloc] (* rejected *)
+File "w53.ml", line 202, characters 21-28:
+202 |   type 'a t1 = 'a [@@noalloc] (* rejected *)
                            ^^^^^^^
 Warning 53 [misplaced-attribute]: the "noalloc" attribute cannot appear in this context
 
-File "w53.ml", line 200, characters 19-26:
-200 |   type s1 = Foo1 [@noalloc] (* rejected *)
+File "w53.ml", line 203, characters 19-26:
+203 |   type s1 = Foo1 [@noalloc] (* rejected *)
                          ^^^^^^^
 Warning 53 [misplaced-attribute]: the "noalloc" attribute cannot appear in this context
 
-File "w53.ml", line 201, characters 19-26:
-201 |   val x : int64 [@@noalloc] (* rejected *)
+File "w53.ml", line 204, characters 19-26:
+204 |   val x : int64 [@@noalloc] (* rejected *)
                          ^^^^^^^
 Warning 53 [misplaced-attribute]: the "noalloc" attribute cannot appear in this context
 
-File "w53.ml", line 203, characters 24-31:
-203 |   external y : (int64 [@noalloc]) -> (int64 [@noalloc]) = "x" (* rejected *)
+File "w53.ml", line 206, characters 24-31:
+206 |   external y : (int64 [@noalloc]) -> (int64 [@noalloc]) = "x" (* rejected *)
                               ^^^^^^^
 Warning 53 [misplaced-attribute]: the "noalloc" attribute cannot appear in this context
 
-File "w53.ml", line 203, characters 46-53:
-203 |   external y : (int64 [@noalloc]) -> (int64 [@noalloc]) = "x" (* rejected *)
+File "w53.ml", line 206, characters 46-53:
+206 |   external y : (int64 [@noalloc]) -> (int64 [@noalloc]) = "x" (* rejected *)
                                                     ^^^^^^^
 Warning 53 [misplaced-attribute]: the "noalloc" attribute cannot appear in this context
 
-File "w53.ml", line 208, characters 21-28:
-208 |   type 'a t1 = 'a [@@noalloc] (* rejected *)
+File "w53.ml", line 211, characters 21-28:
+211 |   type 'a t1 = 'a [@@noalloc] (* rejected *)
                            ^^^^^^^
 Warning 53 [misplaced-attribute]: the "noalloc" attribute cannot appear in this context
 
-File "w53.ml", line 209, characters 19-26:
-209 |   type s1 = Foo1 [@noalloc] (* rejected *)
+File "w53.ml", line 212, characters 19-26:
+212 |   type s1 = Foo1 [@noalloc] (* rejected *)
                          ^^^^^^^
 Warning 53 [misplaced-attribute]: the "noalloc" attribute cannot appear in this context
 
-File "w53.ml", line 210, characters 25-32:
-210 |   let x : int64 = 42L [@@noalloc] (* rejected *)
+File "w53.ml", line 213, characters 25-32:
+213 |   let x : int64 = 42L [@@noalloc] (* rejected *)
                                ^^^^^^^
 Warning 53 [misplaced-attribute]: the "noalloc" attribute cannot appear in this context
 
-File "w53.ml", line 212, characters 24-31:
-212 |   external y : (int64 [@noalloc]) -> (int64 [@noalloc]) = "x" (* rejected *)
+File "w53.ml", line 215, characters 24-31:
+215 |   external y : (int64 [@noalloc]) -> (int64 [@noalloc]) = "x" (* rejected *)
                               ^^^^^^^
 Warning 53 [misplaced-attribute]: the "noalloc" attribute cannot appear in this context
 
-File "w53.ml", line 212, characters 46-53:
-212 |   external y : (int64 [@noalloc]) -> (int64 [@noalloc]) = "x" (* rejected *)
+File "w53.ml", line 215, characters 46-53:
+215 |   external y : (int64 [@noalloc]) -> (int64 [@noalloc]) = "x" (* rejected *)
                                                     ^^^^^^^
 Warning 53 [misplaced-attribute]: the "noalloc" attribute cannot appear in this context
 
-File "w53.ml", line 241, characters 21-29:
-241 |   type 'a t1 = 'a [@@tailcall] (* rejected *)
+File "w53.ml", line 244, characters 21-29:
+244 |   type 'a t1 = 'a [@@tailcall] (* rejected *)
                            ^^^^^^^^
 Warning 53 [misplaced-attribute]: the "tailcall" attribute cannot appear in this context
 
-File "w53.ml", line 242, characters 19-27:
-242 |   type s1 = Foo1 [@tailcall] (* rejected *)
+File "w53.ml", line 245, characters 19-27:
+245 |   type s1 = Foo1 [@tailcall] (* rejected *)
                          ^^^^^^^^
 Warning 53 [misplaced-attribute]: the "tailcall" attribute cannot appear in this context
 
-File "w53.ml", line 243, characters 16-24:
-243 |   val x : int [@tailcall] (* rejected *)
+File "w53.ml", line 246, characters 16-24:
+246 |   val x : int [@tailcall] (* rejected *)
                       ^^^^^^^^
 Warning 53 [misplaced-attribute]: the "tailcall" attribute cannot appear in this context
 
-File "w53.ml", line 245, characters 35-43:
-245 |   external z : int -> int = "x" [@@tailcall] (* rejected *)
+File "w53.ml", line 248, characters 35-43:
+248 |   external z : int -> int = "x" [@@tailcall] (* rejected *)
                                          ^^^^^^^^
 Warning 53 [misplaced-attribute]: the "tailcall" attribute cannot appear in this context
 
-File "w53.ml", line 247, characters 6-14:
-247 |   [@@@tailcall] (* rejected *)
+File "w53.ml", line 250, characters 6-14:
+250 |   [@@@tailcall] (* rejected *)
             ^^^^^^^^
 Warning 53 [misplaced-attribute]: the "tailcall" attribute cannot appear in this context
 
-File "w53.ml", line 251, characters 21-29:
-251 |   type 'a t1 = 'a [@@tailcall] (* rejected *)
+File "w53.ml", line 254, characters 21-29:
+254 |   type 'a t1 = 'a [@@tailcall] (* rejected *)
                            ^^^^^^^^
 Warning 53 [misplaced-attribute]: the "tailcall" attribute cannot appear in this context
 
-File "w53.ml", line 252, characters 19-27:
-252 |   type s1 = Foo1 [@tailcall] (* rejected *)
+File "w53.ml", line 255, characters 19-27:
+255 |   type s1 = Foo1 [@tailcall] (* rejected *)
                          ^^^^^^^^
 Warning 53 [misplaced-attribute]: the "tailcall" attribute cannot appear in this context
 
-File "w53.ml", line 254, characters 16-24:
-254 |   let m x = x [@tailcall] (* rejected *)
+File "w53.ml", line 257, characters 16-24:
+257 |   let m x = x [@tailcall] (* rejected *)
                       ^^^^^^^^
 Warning 53 [misplaced-attribute]: the "tailcall" attribute cannot appear in this context
 
-File "w53.ml", line 255, characters 16-30:
-255 |   let n x = x [@ocaml.tailcall] (* rejected *)
+File "w53.ml", line 258, characters 16-30:
+258 |   let n x = x [@ocaml.tailcall] (* rejected *)
                       ^^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "ocaml.tailcall" attribute cannot appear in this context
 
-File "w53.ml", line 258, characters 18-26:
-258 |   let q x = m x [@tailcall] (* rejected *)
+File "w53.ml", line 261, characters 18-26:
+261 |   let q x = m x [@tailcall] (* rejected *)
                         ^^^^^^^^
 Warning 53 [misplaced-attribute]: the "tailcall" attribute cannot appear in this context
 
-File "w53.ml", line 260, characters 35-43:
-260 |   external z : int -> int = "x" [@@tailcall] (* rejected *)
+File "w53.ml", line 263, characters 35-43:
+263 |   external z : int -> int = "x" [@@tailcall] (* rejected *)
                                          ^^^^^^^^
 Warning 53 [misplaced-attribute]: the "tailcall" attribute cannot appear in this context
 
-File "w53.ml", line 262, characters 6-14:
-262 |   [@@@tailcall] (* rejected *)
+File "w53.ml", line 265, characters 6-14:
+265 |   [@@@tailcall] (* rejected *)
             ^^^^^^^^
 Warning 53 [misplaced-attribute]: the "tailcall" attribute cannot appear in this context
 
-File "w53.ml", line 267, characters 24-31:
-267 |   type t1 = { x : int [@unboxed] } (* rejected *)
+File "w53.ml", line 270, characters 24-31:
+270 |   type t1 = { x : int [@unboxed] } (* rejected *)
                               ^^^^^^^
 Warning 53 [misplaced-attribute]: the "unboxed" attribute cannot appear in this context
 
-File "w53.ml", line 269, characters 16-23:
-269 |   val x : int [@unboxed] (* rejected *)
+File "w53.ml", line 272, characters 16-23:
+272 |   val x : int [@unboxed] (* rejected *)
                       ^^^^^^^
 Warning 53 [misplaced-attribute]: the "unboxed" attribute cannot appear in this context
 
-File "w53.ml", line 273, characters 17-24:
-273 |   val y : int [@@unboxed] (* rejected *)
+File "w53.ml", line 276, characters 17-24:
+276 |   val y : int [@@unboxed] (* rejected *)
                        ^^^^^^^
 Warning 53 [misplaced-attribute]: the "unboxed" attribute cannot appear in this context
 
-File "w53.ml", line 277, characters 6-13:
-277 |   [@@@unboxed] (* rejected *)
+File "w53.ml", line 280, characters 6-13:
+280 |   [@@@unboxed] (* rejected *)
             ^^^^^^^
 Warning 53 [misplaced-attribute]: the "unboxed" attribute cannot appear in this context
 
-File "w53.ml", line 281, characters 16-23:
-281 |   let x = (42 [@unboxed], 84) (* rejected *)
+File "w53.ml", line 284, characters 16-23:
+284 |   let x = (42 [@unboxed], 84) (* rejected *)
                       ^^^^^^^
 Warning 53 [misplaced-attribute]: the "unboxed" attribute cannot appear in this context
 
-File "w53.ml", line 283, characters 16-23:
-283 |   let y = 10 [@@unboxed] (* rejected *)
+File "w53.ml", line 286, characters 16-23:
+286 |   let y = 10 [@@unboxed] (* rejected *)
                       ^^^^^^^
 Warning 53 [misplaced-attribute]: the "unboxed" attribute cannot appear in this context
 
-File "w53.ml", line 287, characters 6-13:
-287 |   [@@@unboxed] (* rejected *)
+File "w53.ml", line 290, characters 6-13:
+290 |   [@@@unboxed] (* rejected *)
             ^^^^^^^
 Warning 53 [misplaced-attribute]: the "unboxed" attribute cannot appear in this context
 
-File "w53.ml", line 292, characters 21-29:
-292 |   type 'a t1 = 'a [@@untagged] (* rejected *)
+File "w53.ml", line 295, characters 21-29:
+295 |   type 'a t1 = 'a [@@untagged] (* rejected *)
                            ^^^^^^^^
 Warning 53 [misplaced-attribute]: the "untagged" attribute cannot appear in this context
 
-File "w53.ml", line 293, characters 19-27:
-293 |   type s1 = Foo1 [@untagged] (* rejected *)
+File "w53.ml", line 296, characters 19-27:
+296 |   type s1 = Foo1 [@untagged] (* rejected *)
                          ^^^^^^^^
 Warning 53 [misplaced-attribute]: the "untagged" attribute cannot appear in this context
 
-File "w53.ml", line 294, characters 17-25:
-294 |   val x : int [@@untagged] (* rejected *)
+File "w53.ml", line 297, characters 17-25:
+297 |   val x : int [@@untagged] (* rejected *)
                        ^^^^^^^^
 Warning 53 [misplaced-attribute]: the "untagged" attribute cannot appear in this context
 
-File "w53.ml", line 301, characters 21-29:
-301 |   type 'a t1 = 'a [@@untagged] (* rejected *)
+File "w53.ml", line 304, characters 21-29:
+304 |   type 'a t1 = 'a [@@untagged] (* rejected *)
                            ^^^^^^^^
 Warning 53 [misplaced-attribute]: the "untagged" attribute cannot appear in this context
 
-File "w53.ml", line 302, characters 19-27:
-302 |   type s1 = Foo1 [@untagged] (* rejected *)
+File "w53.ml", line 305, characters 19-27:
+305 |   type s1 = Foo1 [@untagged] (* rejected *)
                          ^^^^^^^^
 Warning 53 [misplaced-attribute]: the "untagged" attribute cannot appear in this context
 
-File "w53.ml", line 303, characters 22-30:
-303 |   let x : int = 42 [@@untagged] (* rejected *)
+File "w53.ml", line 306, characters 22-30:
+306 |   let x : int = 42 [@@untagged] (* rejected *)
                             ^^^^^^^^
 Warning 53 [misplaced-attribute]: the "untagged" attribute cannot appear in this context
 
-File "w53.ml", line 311, characters 24-32:
-311 |   type t1 = { x : int [@unrolled 42] } (* rejected *)
+File "w53.ml", line 314, characters 24-32:
+314 |   type t1 = { x : int [@unrolled 42] } (* rejected *)
                               ^^^^^^^^
 Warning 53 [misplaced-attribute]: the "unrolled" attribute cannot appear in this context
 
-File "w53.ml", line 312, characters 27-35:
-312 |   type t2 = { x : int } [@@unrolled 42] (* rejected *)
+File "w53.ml", line 315, characters 27-35:
+315 |   type t2 = { x : int } [@@unrolled 42] (* rejected *)
                                  ^^^^^^^^
 Warning 53 [misplaced-attribute]: the "unrolled" attribute cannot appear in this context
 
-File "w53.ml", line 314, characters 23-31:
-314 |   val f : int -> int [@unrolled 42] (* rejected *)
+File "w53.ml", line 317, characters 23-31:
+317 |   val f : int -> int [@unrolled 42] (* rejected *)
                              ^^^^^^^^
 Warning 53 [misplaced-attribute]: the "unrolled" attribute cannot appear in this context
 
-File "w53.ml", line 315, characters 24-32:
-315 |   val g : int -> int [@@unrolled 42] (* rejected *)
+File "w53.ml", line 318, characters 24-32:
+318 |   val g : int -> int [@@unrolled 42] (* rejected *)
                               ^^^^^^^^
 Warning 53 [misplaced-attribute]: the "unrolled" attribute cannot appear in this context
 
-File "w53.ml", line 317, characters 39-47:
-317 |   external z : float -> float = "x" [@@unrolled 42] (* rejected *)
+File "w53.ml", line 320, characters 39-47:
+320 |   external z : float -> float = "x" [@@unrolled 42] (* rejected *)
                                              ^^^^^^^^
 Warning 53 [misplaced-attribute]: the "unrolled" attribute cannot appear in this context
 
-File "w53.ml", line 319, characters 6-14:
-319 |   [@@@unrolled 42] (* rejected *)
+File "w53.ml", line 322, characters 6-14:
+322 |   [@@@unrolled 42] (* rejected *)
             ^^^^^^^^
 Warning 53 [misplaced-attribute]: the "unrolled" attribute cannot appear in this context
 
-File "w53.ml", line 323, characters 8-16:
-323 |   let [@unrolled 42] rec test_unrolled x = (* rejected *)
+File "w53.ml", line 326, characters 8-16:
+326 |   let [@unrolled 42] rec test_unrolled x = (* rejected *)
               ^^^^^^^^
 Warning 53 [misplaced-attribute]: the "unrolled" attribute cannot appear in this context
 
-File "w53.ml", line 330, characters 24-32:
-330 |   type t1 = { x : int [@unrolled 42] } (* rejected *)
+File "w53.ml", line 333, characters 24-32:
+333 |   type t1 = { x : int [@unrolled 42] } (* rejected *)
                               ^^^^^^^^
 Warning 53 [misplaced-attribute]: the "unrolled" attribute cannot appear in this context
 
-File "w53.ml", line 331, characters 27-35:
-331 |   type t2 = { x : int } [@@unrolled 42] (* rejected *)
+File "w53.ml", line 334, characters 27-35:
+334 |   type t2 = { x : int } [@@unrolled 42] (* rejected *)
                                  ^^^^^^^^
 Warning 53 [misplaced-attribute]: the "unrolled" attribute cannot appear in this context
 
-File "w53.ml", line 333, characters 22-30:
-333 |   let rec f x = f x [@unrolled 42] (* rejected *)
+File "w53.ml", line 336, characters 22-30:
+336 |   let rec f x = f x [@unrolled 42] (* rejected *)
                             ^^^^^^^^
 Warning 53 [misplaced-attribute]: the "unrolled" attribute cannot appear in this context
 
-File "w53.ml", line 334, characters 23-31:
-334 |   let rec f x = f x [@@unrolled 42] (* rejected *)
+File "w53.ml", line 337, characters 23-31:
+337 |   let rec f x = f x [@@unrolled 42] (* rejected *)
                              ^^^^^^^^
 Warning 53 [misplaced-attribute]: the "unrolled" attribute cannot appear in this context
 
-File "w53.ml", line 336, characters 39-47:
-336 |   external z : int -> int = "x" "y" [@@unrolled 42] (* rejected *)
+File "w53.ml", line 339, characters 39-47:
+339 |   external z : int -> int = "x" "y" [@@unrolled 42] (* rejected *)
                                              ^^^^^^^^
 Warning 53 [misplaced-attribute]: the "unrolled" attribute cannot appear in this context
 
-File "w53.ml", line 338, characters 6-14:
-338 |   [@@@unrolled 42] (* rejected *)
+File "w53.ml", line 341, characters 6-14:
+341 |   [@@@unrolled 42] (* rejected *)
             ^^^^^^^^
 Warning 53 [misplaced-attribute]: the "unrolled" attribute cannot appear in this context
 
-File "w53.ml", line 387, characters 25-48:
-387 |     | Lit_pat2 of int [@@warn_on_literal_pattern] (* rejected *)
+File "w53.ml", line 390, characters 25-48:
+390 |     | Lit_pat2 of int [@@warn_on_literal_pattern] (* rejected *)
                                ^^^^^^^^^^^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "warn_on_literal_pattern" attribute cannot appear in this context
 
-File "w53.ml", line 391, characters 16-39:
-391 |   val x : int [@warn_on_literal_pattern] (* rejected *)
+File "w53.ml", line 394, characters 16-39:
+394 |   val x : int [@warn_on_literal_pattern] (* rejected *)
                       ^^^^^^^^^^^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "warn_on_literal_pattern" attribute cannot appear in this context
 
-File "w53.ml", line 393, characters 21-44:
-393 |   type 'a t2 = 'a [@@warn_on_literal_pattern] (* rejected *)
+File "w53.ml", line 396, characters 21-44:
+396 |   type 'a t2 = 'a [@@warn_on_literal_pattern] (* rejected *)
                            ^^^^^^^^^^^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "warn_on_literal_pattern" attribute cannot appear in this context
 
-File "w53.ml", line 395, characters 17-40:
-395 |   val y : int [@@warn_on_literal_pattern] (* rejected *)
+File "w53.ml", line 398, characters 17-40:
+398 |   val y : int [@@warn_on_literal_pattern] (* rejected *)
                        ^^^^^^^^^^^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "warn_on_literal_pattern" attribute cannot appear in this context
 
-File "w53.ml", line 397, characters 6-29:
-397 |   [@@@warn_on_literal_pattern] (* rejected *)
+File "w53.ml", line 400, characters 6-29:
+400 |   [@@@warn_on_literal_pattern] (* rejected *)
             ^^^^^^^^^^^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "warn_on_literal_pattern" attribute cannot appear in this context
 
-File "w53.ml", line 403, characters 25-48:
-403 |     | Lit_pat2 of int [@@warn_on_literal_pattern] (* rejected *)
+File "w53.ml", line 406, characters 25-48:
+406 |     | Lit_pat2 of int [@@warn_on_literal_pattern] (* rejected *)
                                ^^^^^^^^^^^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "warn_on_literal_pattern" attribute cannot appear in this context
 
-File "w53.ml", line 405, characters 14-37:
-405 |   let x = 5 [@warn_on_literal_pattern] (* rejected *)
+File "w53.ml", line 408, characters 14-37:
+408 |   let x = 5 [@warn_on_literal_pattern] (* rejected *)
                     ^^^^^^^^^^^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "warn_on_literal_pattern" attribute cannot appear in this context
 
-File "w53.ml", line 407, characters 16-39:
-407 |   let y = 10 [@@warn_on_literal_pattern] (* rejected *)
+File "w53.ml", line 410, characters 16-39:
+410 |   let y = 10 [@@warn_on_literal_pattern] (* rejected *)
                       ^^^^^^^^^^^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "warn_on_literal_pattern" attribute cannot appear in this context
 
-File "w53.ml", line 409, characters 6-29:
-409 |   [@@@warn_on_literal_pattern] (* rejected *)
+File "w53.ml", line 412, characters 6-29:
+412 |   [@@@warn_on_literal_pattern] (* rejected *)
             ^^^^^^^^^^^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "warn_on_literal_pattern" attribute cannot appear in this context
 
-File "w53.ml", line 418, characters 21-25:
-418 |   type 'a t1 = 'a [@@poll error] (* rejected *)
+File "w53.ml", line 421, characters 21-25:
+421 |   type 'a t1 = 'a [@@poll error] (* rejected *)
                            ^^^^
 Warning 53 [misplaced-attribute]: the "poll" attribute cannot appear in this context
 
-File "w53.ml", line 419, characters 19-23:
-419 |   type s1 = Foo1 [@poll error] (* rejected *)
+File "w53.ml", line 422, characters 19-23:
+422 |   type s1 = Foo1 [@poll error] (* rejected *)
                          ^^^^
 Warning 53 [misplaced-attribute]: the "poll" attribute cannot appear in this context
 
-File "w53.ml", line 420, characters 19-23:
-420 |   val x : int64 [@@poll error] (* rejected *)
+File "w53.ml", line 423, characters 19-23:
+423 |   val x : int64 [@@poll error] (* rejected *)
                          ^^^^
 Warning 53 [misplaced-attribute]: the "poll" attribute cannot appear in this context
 
-File "w53.ml", line 422, characters 24-28:
-422 |   external y : (int64 [@poll error]) -> (int64 [@poll error]) = (* rejected *)
+File "w53.ml", line 425, characters 24-28:
+425 |   external y : (int64 [@poll error]) -> (int64 [@poll error]) = (* rejected *)
                               ^^^^
 Warning 53 [misplaced-attribute]: the "poll" attribute cannot appear in this context
 
-File "w53.ml", line 422, characters 49-53:
-422 |   external y : (int64 [@poll error]) -> (int64 [@poll error]) = (* rejected *)
+File "w53.ml", line 425, characters 49-53:
+425 |   external y : (int64 [@poll error]) -> (int64 [@poll error]) = (* rejected *)
                                                        ^^^^
 Warning 53 [misplaced-attribute]: the "poll" attribute cannot appear in this context
 
-File "w53.ml", line 424, characters 39-43:
-424 |   external z : int64 -> int64 = "x" [@@poll error] (* rejected *)
+File "w53.ml", line 427, characters 39-43:
+427 |   external z : int64 -> int64 = "x" [@@poll error] (* rejected *)
                                              ^^^^
 Warning 53 [misplaced-attribute]: the "poll" attribute cannot appear in this context
 
-File "w53.ml", line 428, characters 21-25:
-428 |   type 'a t1 = 'a [@@poll error] (* rejected *)
+File "w53.ml", line 431, characters 21-25:
+431 |   type 'a t1 = 'a [@@poll error] (* rejected *)
                            ^^^^
 Warning 53 [misplaced-attribute]: the "poll" attribute cannot appear in this context
 
-File "w53.ml", line 429, characters 19-23:
-429 |   type s1 = Foo1 [@poll error] (* rejected *)
+File "w53.ml", line 432, characters 19-23:
+432 |   type s1 = Foo1 [@poll error] (* rejected *)
                          ^^^^
 Warning 53 [misplaced-attribute]: the "poll" attribute cannot appear in this context
 
-File "w53.ml", line 430, characters 25-29:
-430 |   let x : int64 = 42L [@@poll error] (* rejected *)
+File "w53.ml", line 433, characters 25-29:
+433 |   let x : int64 = 42L [@@poll error] (* rejected *)
                                ^^^^
 Warning 53 [misplaced-attribute]: the "poll" attribute cannot appear in this context
 
-File "w53.ml", line 433, characters 24-28:
-433 |   external y : (int64 [@poll error]) -> (int64 [@poll error]) =  (* rejected *)
+File "w53.ml", line 436, characters 24-28:
+436 |   external y : (int64 [@poll error]) -> (int64 [@poll error]) =  (* rejected *)
                               ^^^^
 Warning 53 [misplaced-attribute]: the "poll" attribute cannot appear in this context
 
-File "w53.ml", line 433, characters 49-53:
-433 |   external y : (int64 [@poll error]) -> (int64 [@poll error]) =  (* rejected *)
+File "w53.ml", line 436, characters 49-53:
+436 |   external y : (int64 [@poll error]) -> (int64 [@poll error]) =  (* rejected *)
                                                        ^^^^
 Warning 53 [misplaced-attribute]: the "poll" attribute cannot appear in this context
 
-File "w53.ml", line 435, characters 39-43:
-435 |   external z : int64 -> int64 = "x" [@@poll error] (* rejected *)
+File "w53.ml", line 438, characters 39-43:
+438 |   external z : int64 -> int64 = "x" [@@poll error] (* rejected *)
                                              ^^^^
 Warning 53 [misplaced-attribute]: the "poll" attribute cannot appear in this context
 
-File "w53.ml", line 440, characters 21-31:
-440 |   type 'a t1 = 'a [@@specialise] (* rejected *)
+File "w53.ml", line 443, characters 21-31:
+443 |   type 'a t1 = 'a [@@specialise] (* rejected *)
                            ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "specialise" attribute cannot appear in this context
 
-File "w53.ml", line 441, characters 19-29:
-441 |   type s1 = Foo1 [@specialise] (* rejected *)
+File "w53.ml", line 444, characters 19-29:
+444 |   type s1 = Foo1 [@specialise] (* rejected *)
                          ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "specialise" attribute cannot appear in this context
 
-File "w53.ml", line 442, characters 19-29:
-442 |   val x : int64 [@@specialise] (* rejected *)
+File "w53.ml", line 445, characters 19-29:
+445 |   val x : int64 [@@specialise] (* rejected *)
                          ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "specialise" attribute cannot appear in this context
 
-File "w53.ml", line 444, characters 24-34:
-444 |   external y : (int64 [@specialise]) -> (int64 [@specialise]) = (* rejected *)
+File "w53.ml", line 447, characters 24-34:
+447 |   external y : (int64 [@specialise]) -> (int64 [@specialise]) = (* rejected *)
                               ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "specialise" attribute cannot appear in this context
 
-File "w53.ml", line 444, characters 49-59:
-444 |   external y : (int64 [@specialise]) -> (int64 [@specialise]) = (* rejected *)
+File "w53.ml", line 447, characters 49-59:
+447 |   external y : (int64 [@specialise]) -> (int64 [@specialise]) = (* rejected *)
                                                        ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "specialise" attribute cannot appear in this context
 
-File "w53.ml", line 446, characters 39-49:
-446 |   external z : int64 -> int64 = "x" [@@specialise] (* rejected *)
+File "w53.ml", line 449, characters 39-49:
+449 |   external z : int64 -> int64 = "x" [@@specialise] (* rejected *)
                                              ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "specialise" attribute cannot appear in this context
 
-File "w53.ml", line 450, characters 21-31:
-450 |   type 'a t1 = 'a [@@specialise] (* rejected *)
+File "w53.ml", line 453, characters 21-31:
+453 |   type 'a t1 = 'a [@@specialise] (* rejected *)
                            ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "specialise" attribute cannot appear in this context
 
-File "w53.ml", line 451, characters 19-29:
-451 |   type s1 = Foo1 [@specialise] (* rejected *)
+File "w53.ml", line 454, characters 19-29:
+454 |   type s1 = Foo1 [@specialise] (* rejected *)
                          ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "specialise" attribute cannot appear in this context
 
-File "w53.ml", line 452, characters 25-35:
-452 |   let x : int64 = 42L [@@specialise] (* rejected *)
+File "w53.ml", line 455, characters 25-35:
+455 |   let x : int64 = 42L [@@specialise] (* rejected *)
                                ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "specialise" attribute cannot appear in this context
 
-File "w53.ml", line 454, characters 16-26:
-454 |   let g x = (f[@specialise]) x (* rejected *)
+File "w53.ml", line 457, characters 16-26:
+457 |   let g x = (f[@specialise]) x (* rejected *)
                       ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "specialise" attribute cannot appear in this context
 
-File "w53.ml", line 456, characters 24-34:
-456 |   external y : (int64 [@specialise]) -> (int64 [@specialise]) = (* rejected *)
+File "w53.ml", line 459, characters 24-34:
+459 |   external y : (int64 [@specialise]) -> (int64 [@specialise]) = (* rejected *)
                               ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "specialise" attribute cannot appear in this context
 
-File "w53.ml", line 456, characters 49-59:
-456 |   external y : (int64 [@specialise]) -> (int64 [@specialise]) = (* rejected *)
+File "w53.ml", line 459, characters 49-59:
+459 |   external y : (int64 [@specialise]) -> (int64 [@specialise]) = (* rejected *)
                                                        ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "specialise" attribute cannot appear in this context
 
-File "w53.ml", line 458, characters 39-49:
-458 |   external z : int64 -> int64 = "x" [@@specialise] (* rejected *)
+File "w53.ml", line 461, characters 39-49:
+461 |   external z : int64 -> int64 = "x" [@@specialise] (* rejected *)
                                              ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "specialise" attribute cannot appear in this context
 
-File "w53.ml", line 463, characters 21-32:
-463 |   type 'a t1 = 'a [@@specialised] (* rejected *)
+File "w53.ml", line 466, characters 21-32:
+466 |   type 'a t1 = 'a [@@specialised] (* rejected *)
                            ^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "specialised" attribute cannot appear in this context
 
-File "w53.ml", line 464, characters 19-30:
-464 |   type s1 = Foo1 [@specialised] (* rejected *)
+File "w53.ml", line 467, characters 19-30:
+467 |   type s1 = Foo1 [@specialised] (* rejected *)
                          ^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "specialised" attribute cannot appear in this context
 
-File "w53.ml", line 465, characters 19-30:
-465 |   val x : int64 [@@specialised] (* rejected *)
+File "w53.ml", line 468, characters 19-30:
+468 |   val x : int64 [@@specialised] (* rejected *)
                          ^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "specialised" attribute cannot appear in this context
 
-File "w53.ml", line 467, characters 24-35:
-467 |   external y : (int64 [@specialised]) -> (int64 [@specialised]) = (* rejected *)
+File "w53.ml", line 470, characters 24-35:
+470 |   external y : (int64 [@specialised]) -> (int64 [@specialised]) = (* rejected *)
                               ^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "specialised" attribute cannot appear in this context
 
-File "w53.ml", line 467, characters 50-61:
-467 |   external y : (int64 [@specialised]) -> (int64 [@specialised]) = (* rejected *)
+File "w53.ml", line 470, characters 50-61:
+470 |   external y : (int64 [@specialised]) -> (int64 [@specialised]) = (* rejected *)
                                                         ^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "specialised" attribute cannot appear in this context
 
-File "w53.ml", line 469, characters 39-50:
-469 |   external z : int64 -> int64 = "x" [@@specialised] (* rejected *)
+File "w53.ml", line 472, characters 39-50:
+472 |   external z : int64 -> int64 = "x" [@@specialised] (* rejected *)
                                              ^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "specialised" attribute cannot appear in this context
 
-File "w53.ml", line 473, characters 21-32:
-473 |   type 'a t1 = 'a [@@specialised] (* rejected *)
+File "w53.ml", line 476, characters 21-32:
+476 |   type 'a t1 = 'a [@@specialised] (* rejected *)
                            ^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "specialised" attribute cannot appear in this context
 
-File "w53.ml", line 474, characters 19-30:
-474 |   type s1 = Foo1 [@specialised] (* rejected *)
+File "w53.ml", line 477, characters 19-30:
+477 |   type s1 = Foo1 [@specialised] (* rejected *)
                          ^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "specialised" attribute cannot appear in this context
 
-File "w53.ml", line 475, characters 25-36:
-475 |   let x : int64 = 42L [@@specialised] (* rejected *)
+File "w53.ml", line 478, characters 25-36:
+478 |   let x : int64 = 42L [@@specialised] (* rejected *)
                                ^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "specialised" attribute cannot appear in this context
 
-File "w53.ml", line 476, characters 8-19:
-476 |   let [@specialised] f x = x (* rejected *)
+File "w53.ml", line 479, characters 8-19:
+479 |   let [@specialised] f x = x (* rejected *)
               ^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "specialised" attribute cannot appear in this context
 
-File "w53.ml", line 479, characters 24-35:
-479 |   external y : (int64 [@specialised]) -> (int64 [@specialised]) = (* rejected *)
+File "w53.ml", line 482, characters 24-35:
+482 |   external y : (int64 [@specialised]) -> (int64 [@specialised]) = (* rejected *)
                               ^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "specialised" attribute cannot appear in this context
 
-File "w53.ml", line 479, characters 50-61:
-479 |   external y : (int64 [@specialised]) -> (int64 [@specialised]) = (* rejected *)
+File "w53.ml", line 482, characters 50-61:
+482 |   external y : (int64 [@specialised]) -> (int64 [@specialised]) = (* rejected *)
                                                         ^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "specialised" attribute cannot appear in this context
 
-File "w53.ml", line 481, characters 39-50:
-481 |   external z : int64 -> int64 = "x" [@@specialised] (* rejected *)
+File "w53.ml", line 484, characters 39-50:
+484 |   external z : int64 -> int64 = "x" [@@specialised] (* rejected *)
                                              ^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "specialised" attribute cannot appear in this context
 
-File "w53.ml", line 486, characters 21-34:
-486 |   type 'a t1 = 'a [@@tail_mod_cons] (* rejected *)
+File "w53.ml", line 489, characters 21-34:
+489 |   type 'a t1 = 'a [@@tail_mod_cons] (* rejected *)
                            ^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "tail_mod_cons" attribute cannot appear in this context
 
-File "w53.ml", line 487, characters 19-32:
-487 |   type s1 = Foo1 [@tail_mod_cons] (* rejected *)
+File "w53.ml", line 490, characters 19-32:
+490 |   type s1 = Foo1 [@tail_mod_cons] (* rejected *)
                          ^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "tail_mod_cons" attribute cannot appear in this context
 
-File "w53.ml", line 488, characters 19-32:
-488 |   val x : int64 [@@tail_mod_cons] (* rejected *)
+File "w53.ml", line 491, characters 19-32:
+491 |   val x : int64 [@@tail_mod_cons] (* rejected *)
                          ^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "tail_mod_cons" attribute cannot appear in this context
 
-File "w53.ml", line 490, characters 24-37:
-490 |   external y : (int64 [@tail_mod_cons]) -> (int64 [@tail_mod_cons]) =
+File "w53.ml", line 493, characters 24-37:
+493 |   external y : (int64 [@tail_mod_cons]) -> (int64 [@tail_mod_cons]) =
                               ^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "tail_mod_cons" attribute cannot appear in this context
 
-File "w53.ml", line 490, characters 52-65:
-490 |   external y : (int64 [@tail_mod_cons]) -> (int64 [@tail_mod_cons]) =
+File "w53.ml", line 493, characters 52-65:
+493 |   external y : (int64 [@tail_mod_cons]) -> (int64 [@tail_mod_cons]) =
                                                           ^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "tail_mod_cons" attribute cannot appear in this context
 
-File "w53.ml", line 493, characters 39-52:
-493 |   external z : int64 -> int64 = "x" [@@tail_mod_cons] (* rejected *)
+File "w53.ml", line 496, characters 39-52:
+496 |   external z : int64 -> int64 = "x" [@@tail_mod_cons] (* rejected *)
                                              ^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "tail_mod_cons" attribute cannot appear in this context
 
-File "w53.ml", line 497, characters 21-34:
-497 |   type 'a t1 = 'a [@@tail_mod_cons] (* rejected *)
+File "w53.ml", line 500, characters 21-34:
+500 |   type 'a t1 = 'a [@@tail_mod_cons] (* rejected *)
                            ^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "tail_mod_cons" attribute cannot appear in this context
 
-File "w53.ml", line 498, characters 19-32:
-498 |   type s1 = Foo1 [@tail_mod_cons] (* rejected *)
+File "w53.ml", line 501, characters 19-32:
+501 |   type s1 = Foo1 [@tail_mod_cons] (* rejected *)
                          ^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "tail_mod_cons" attribute cannot appear in this context
 
-File "w53.ml", line 499, characters 25-38:
-499 |   let x : int64 = 42L [@@tail_mod_cons] (* rejected *)
+File "w53.ml", line 502, characters 25-38:
+502 |   let x : int64 = 42L [@@tail_mod_cons] (* rejected *)
                                ^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "tail_mod_cons" attribute cannot appear in this context
 
-File "w53.ml", line 501, characters 16-29:
-501 |   let g x = (f[@tail_mod_cons]) x (* rejected *)
+File "w53.ml", line 504, characters 16-29:
+504 |   let g x = (f[@tail_mod_cons]) x (* rejected *)
                       ^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "tail_mod_cons" attribute cannot appear in this context
 
-File "w53.ml", line 503, characters 24-37:
-503 |   external y : (int64 [@tail_mod_cons]) -> (int64 [@tail_mod_cons]) =
+File "w53.ml", line 506, characters 24-37:
+506 |   external y : (int64 [@tail_mod_cons]) -> (int64 [@tail_mod_cons]) =
                               ^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "tail_mod_cons" attribute cannot appear in this context
 
-File "w53.ml", line 503, characters 52-65:
-503 |   external y : (int64 [@tail_mod_cons]) -> (int64 [@tail_mod_cons]) =
+File "w53.ml", line 506, characters 52-65:
+506 |   external y : (int64 [@tail_mod_cons]) -> (int64 [@tail_mod_cons]) =
                                                           ^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "tail_mod_cons" attribute cannot appear in this context
 
-File "w53.ml", line 506, characters 39-52:
-506 |   external z : int64 -> int64 = "x" [@@tail_mod_cons] (* rejected *)
+File "w53.ml", line 509, characters 39-52:
+509 |   external z : int64 -> int64 = "x" [@@tail_mod_cons] (* rejected *)
                                              ^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "tail_mod_cons" attribute cannot appear in this context
 
-File "w53.ml", line 512, characters 10-15:
-512 |       [@@@alert foo "foo"] (* rejected *)
+File "w53.ml", line 515, characters 10-15:
+515 |       [@@@alert foo "foo"] (* rejected *)
                 ^^^^^
 Warning 53 [misplaced-attribute]: the "alert" attribute cannot appear in this context

--- a/testsuite/tests/warnings/w53.ml
+++ b/testsuite/tests/warnings/w53.ml
@@ -505,3 +505,16 @@ module TestTailModConsStruct = struct
     "x"
   external z : int64 -> int64 = "x" [@@tail_mod_cons] (* rejected *)
 end
+
+module TestAlertClass = struct
+  class c1 =
+    object
+      [@@@alert foo "foo"] (* rejected *)
+    end
+
+  class c2 =
+    object
+      [@@@warning "-53"]
+      [@@@alert foo "foo"] (* accepted *)
+    end
+end

--- a/testsuite/tests/warnings/w53.ml
+++ b/testsuite/tests/warnings/w53.ml
@@ -24,6 +24,9 @@ module TestAlertStruct = struct
   let y = 10 [@@alert foo "foo"] (* rejected *)
 
   [@@@alert foo "foo"] (* rejected *)
+
+  [@@@warning "-53"]
+  [@@@alert foo "foo"] (* accepted *)
 end
 
 

--- a/testsuite/tests/warnings/w53_across_cmi.compilers.reference
+++ b/testsuite/tests/warnings/w53_across_cmi.compilers.reference
@@ -1,0 +1,52 @@
+File "w53_without_cmi.ml", line 6, characters 4-9:
+6 | [@@@alert xyz "xyz"] (* rejected *)
+        ^^^^^
+Warning 53 [misplaced-attribute]: the "alert" attribute cannot appear in this context
+
+File "w53_without_cmi.ml", line 9, characters 6-11:
+9 |   [@@@alert foo "foo"] (* rejected *)
+          ^^^^^
+Warning 53 [misplaced-attribute]: the "alert" attribute cannot appear in this context
+
+File "w53_with_cmi.mli", line 6, characters 4-9:
+6 | [@@@alert xyz "xyz"] (* rejected *)
+        ^^^^^
+Warning 53 [misplaced-attribute]: the "alert" attribute cannot appear in this context
+
+File "w53_with_cmi.ml", line 1, characters 4-9:
+1 | [@@@alert foo "foo"] (* rejected *)
+        ^^^^^
+Warning 53 [misplaced-attribute]: the "alert" attribute cannot appear in this context
+
+File "w53_with_cmi.ml", line 2, characters 4-9:
+2 | [@@@alert bar "bar"] (* rejected *)
+        ^^^^^
+Warning 53 [misplaced-attribute]: the "alert" attribute cannot appear in this context
+
+File "w53_with_cmi.ml", line 6, characters 4-9:
+6 | [@@@alert xyz "xyz"] (* rejected *)
+        ^^^^^
+Warning 53 [misplaced-attribute]: the "alert" attribute cannot appear in this context
+File "w53_across_cmi.ml", line 17, characters 5-20:
+17 | open W53_without_cmi
+          ^^^^^^^^^^^^^^^
+Alert bar: module W53_without_cmi
+bar
+
+File "w53_across_cmi.ml", line 17, characters 5-20:
+17 | open W53_without_cmi
+          ^^^^^^^^^^^^^^^
+Alert foo: module W53_without_cmi
+foo
+
+File "w53_across_cmi.ml", line 18, characters 5-17:
+18 | open W53_with_cmi
+          ^^^^^^^^^^^^
+Alert bar: module W53_with_cmi
+bar(I)
+
+File "w53_across_cmi.ml", line 18, characters 5-17:
+18 | open W53_with_cmi
+          ^^^^^^^^^^^^
+Alert foo: module W53_with_cmi
+foo(I)

--- a/testsuite/tests/warnings/w53_across_cmi.ml
+++ b/testsuite/tests/warnings/w53_across_cmi.ml
@@ -1,0 +1,18 @@
+(* TEST
+   readonly_files = "w53_without_cmi.ml w53_with_cmi.mli w53_with_cmi.ml";
+   setup-ocamlc.byte-build-env;
+   all_modules = "w53_without_cmi.ml w53_with_cmi.mli w53_with_cmi.ml";
+   flags = "-w +A-70";
+   compile_only = "true";
+   ocamlc.byte;
+   all_modules = "w53_across_cmi.ml";
+   flags = "-alert +all -w +A-33-70";
+   ocamlc.byte;
+   check-ocamlc.byte-output;
+*)
+
+(* This tests checks that alerts are correctly triggered across compilation
+   units. *)
+
+open W53_without_cmi
+open W53_with_cmi

--- a/testsuite/tests/warnings/w53_with_cmi.ml
+++ b/testsuite/tests/warnings/w53_with_cmi.ml
@@ -1,0 +1,6 @@
+[@@@alert foo "foo"] (* rejected *)
+[@@@alert bar "bar"] (* rejected *)
+
+let x = 42
+
+[@@@alert xyz "xyz"] (* rejected *)

--- a/testsuite/tests/warnings/w53_with_cmi.mli
+++ b/testsuite/tests/warnings/w53_with_cmi.mli
@@ -1,0 +1,6 @@
+[@@@alert foo "foo(I)"] (* accepted *)
+[@@@alert bar "bar(I)"] (* accepted *)
+
+val x: int
+
+[@@@alert xyz "xyz"] (* rejected *)

--- a/testsuite/tests/warnings/w53_without_cmi.ml
+++ b/testsuite/tests/warnings/w53_without_cmi.ml
@@ -1,0 +1,11 @@
+[@@@alert foo "foo"] (* accepted *)
+[@@@alert bar "bar"] (* accepted *)
+
+let x = 42
+
+[@@@alert xyz "xyz"] (* rejected *)
+
+module Sub = struct
+  [@@@alert foo "foo"] (* rejected *)
+  let x = 42
+end

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -1404,7 +1404,7 @@ and transl_with ~loc env remove_aliases (rev_tcstrs,sg) constr =
 
 
 
-and transl_signature ?(toplevel = false) env sg =
+and transl_signature env sg =
   let names = Signature_names.create () in
   let rec transl_sig env sg =
     match sg with
@@ -1706,7 +1706,7 @@ and transl_signature ?(toplevel = false) env sg =
             typedtree, sg, final_env
         | Psig_attribute x ->
             Builtin_attributes.warning_attribute x;
-            if toplevel || not (Warnings.is_active (Misplaced_attribute ""))
+            if not (Warnings.is_active (Misplaced_attribute ""))
             then Builtin_attributes.mark_alert_used x;
             let (trem,rem, final_env) = transl_sig env srem in
             mksig (Tsig_attribute x) env loc :: trem, rem, final_env
@@ -2868,8 +2868,8 @@ and type_structure ?(toplevel = false) funct_body anchor env sstr =
         raise (Error_forward (Builtin_attributes.error_of_extension ext))
     | Pstr_attribute x ->
         Builtin_attributes.warning_attribute x;
-        if toplevel || not (Warnings.is_active (Misplaced_attribute "")) then
-          Builtin_attributes.mark_alert_used x;
+        if not (Warnings.is_active (Misplaced_attribute ""))
+        then Builtin_attributes.mark_alert_used x;
         Tstr_attribute x, [], shape_map, env
   in
   let rec type_struct env shape_map sstr =
@@ -3157,8 +3157,8 @@ let type_implementation target initial_env ast =
              declarations like "let x = true;; let x = 1;;", because in this
              case, the inferred signature contains only the last declaration. *)
           let shape = Shape_reduce.local_reduce Env.empty shape in
+          let alerts = Builtin_attributes.alerts_of_str ~mark:true ast in
           if not !Clflags.dont_write_files then begin
-            let alerts = Builtin_attributes.alerts_of_str ast in
             let cmi =
               Env.save_signature ~alerts simple_sg (Unit_info.cmi target)
             in
@@ -3186,10 +3186,7 @@ let save_signature target tsg initial_env cmi =
     (Cmt_format.Interface tsg) initial_env (Some cmi) None
 
 let type_interface env ast =
-  transl_signature ~toplevel:true env ast
-
-let transl_signature env ast =
-  transl_signature ~toplevel:false env ast
+  transl_signature env ast
 
 (* "Packaging" of several compilation units into one unit
    having them as sub-modules.  *)

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -1706,8 +1706,6 @@ and transl_signature env sg =
             typedtree, sg, final_env
         | Psig_attribute x ->
             Builtin_attributes.warning_attribute x;
-            if not (Warnings.is_active (Misplaced_attribute ""))
-            then Builtin_attributes.mark_alert_used x;
             let (trem,rem, final_env) = transl_sig env srem in
             mksig (Tsig_attribute x) env loc :: trem, rem, final_env
         | Psig_extension (ext, _attrs) ->
@@ -2868,8 +2866,6 @@ and type_structure ?(toplevel = false) funct_body anchor env sstr =
         raise (Error_forward (Builtin_attributes.error_of_extension ext))
     | Pstr_attribute x ->
         Builtin_attributes.warning_attribute x;
-        if not (Warnings.is_active (Misplaced_attribute ""))
-        then Builtin_attributes.mark_alert_used x;
         Tstr_attribute x, [], shape_map, env
   in
   let rec type_struct env shape_map sstr =

--- a/typing/typemod.mli
+++ b/typing/typemod.mli
@@ -43,8 +43,6 @@ val type_implementation:
   Typedtree.implementation
 val type_interface:
         Env.t -> Parsetree.signature -> Typedtree.signature
-val transl_signature:
-        Env.t -> Parsetree.signature -> Typedtree.signature
 val check_nongen_signature:
         Env.t -> Types.signature -> unit
         (*


### PR DESCRIPTION
There seems to be a small regression in 5.2 (probably due to #12451, cc @ccasin): top-level attributes in implementations are not correctly marked as "used".

```
$ echo '[@@@alert unstable "foo"]' > a.ml
$ ocamlc -c a.ml
File "/home/nojebar/tmp/a.ml", line 1, characters 4-9:
1 | [@@@alert unstable "foo"]
        ^^^^^
Warning 53 [misplaced-attribute]: the "alert" attribute cannot appear in this context
```