### PR TITLE
multicore: expose the domain index for advanced use-cases

### DIFF
--- a/Changes
+++ b/Changes
@@ -90,6 +90,13 @@ _______________
    review by Jeremy Yallop, Daniel Bünzli and Olivier Nicole,
    request by Olivier Nicole)
 
+- #13171: expose `Domain.self_index : unit -> int` (a somewhat-dense
+  indexing of currently-running domains) for advanced use-cases of
+  domain-indexed concurrent data structures.
+  (Gabriel Scherer,
+   review by KC Sivaramakrishnan, Miod Vallat and Nicolás Ojeda Bär,
+   report by Vesa Karvonen)
+
 ### Other libraries:
 
 ### Tools:

--- a/runtime/caml/domain.h
+++ b/runtime/caml/domain.h
@@ -97,6 +97,18 @@ Caml_inline intnat caml_domain_alone(void)
   return atomic_load_acquire(&caml_num_domains_running) == 1;
 }
 
+/* The index of the current domain. It is an integer unique among
+   currently-running domains, in the interval [0; N-1] where N is the
+   peak number of domains running simultaneously so far. The index of
+   a terminated domain may be reused for a new domain.
+
+   This function requires the domain lock to be held.
+*/
+Caml_inline int caml_domain_index(void)
+{
+  return Caml_state->id;
+}
+
 #ifdef DEBUG
 int caml_domain_is_in_stw(void);
 #endif

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -1299,6 +1299,12 @@ CAMLprim value caml_ml_domain_id(value unit)
   return Val_long(domain_self->interruptor.unique_id);
 }
 
+CAMLprim value caml_ml_domain_index(value unit)
+{
+  CAMLnoalloc;
+  return Val_long(domain_self->id);
+}
+
 /* sense-reversing barrier */
 #define BARRIER_SENSE_BIT 0x100000
 

--- a/stdlib/domain.ml
+++ b/stdlib/domain.ml
@@ -204,6 +204,9 @@ let self () = Raw.self ()
 
 let is_main_domain () = (self () :> int) = 0
 
+external self_index : unit -> int
+  = "caml_ml_domain_index" [@@noalloc]
+
 (******** Callbacks **********)
 
 (* first spawn, domain startup and at exit functionality *)

--- a/stdlib/domain.mli
+++ b/stdlib/domain.mli
@@ -91,6 +91,18 @@ val recommended_domain_count : unit -> int
 
     The value returned is at least [1]. *)
 
+val self_index : unit -> int
+(** The index of the current domain. It is an integer unique among
+    currently-running domains, in the interval [0; N-1] where N is the
+    peak number of domains running simultaneously so far.
+
+    The index of a terminated domain may be reused for a new
+    domain. Use [(Domain.self () :> int)] instead for an identifier
+    unique among all domains ever created by the program.
+
+    @since 5.3
+*)
+
 module DLS : sig
 (** Domain-local Storage *)
 


### PR DESCRIPTION
## Context 

The multicore runtime of OCaml uses two different notion of "identifier" for a domain:

- `Caml_state->id` is the index of the domain in the table of current domains. It is between 0 and the number of running domains at the time the domain was created. Spawning a new domain may reuse the index of another domain that has already terminated.
- `Caml_state->unique_id` is a unique identifier generated at domain startup time, almost-guaranteed to be distinct from the identifiers of all other domains (almost: overflows on 32bit systems can lose this guarantee).

But then the runtime only exposes `Caml_state->unique_id` to users, which is more principled.

## Proposed change: expose (non-unique) domain indices

The present PR exposes the non-unique identifiers `Caml_state->id` to users (in C and in OCaml), and calls it the "domain index".

The purpose of this simple change is to make it easier for expert users to implement data structures with per-domain values, which come up frequently in various concurrent designs. This can be done with Domain.DLS, but there is an ongoing discussion about changing the semantics of Domain.DLS to make it thread-local which would make it less suitable for certain use-cases. (See in particular the remnants of @polytypic's comments at https://github.com/ocaml/ocaml/pull/12719#issuecomment-1832179117 )

Exposing domain indices is a simpler, lower-level mechanism that puts advanced users in control of their implementation choices. They can experiment outside the standard library and runtime, with a useful building block that we had been hiding from them so far.