### PR TITLE
gha: use latest Visual Studio compiler

### DIFF
--- a/.github/workflows/build-msvc.yml
+++ b/.github/workflows/build-msvc.yml
@@ -38,8 +38,6 @@ jobs:
       - name: Set up MSVC
         uses: ilammy/msvc-dev-cmd@v1
         with:
-          # This is cl version 19.38, Visual Studio version 17.8
-          toolset: 14.38
           arch: ${{ matrix.x86_64 && 'x64' || 'x86' }}
 
       - name: Fetch OCaml


### PR DESCRIPTION
The CI for MSVC/clang-cl have started failing, because as per https://github.com/actions/runner-images/issues/9701, GitHub has removed all VC++ toolsets except the latest one (for now it's 14.39). That's why the version 14.38 was not found. (see also https://github.com/ilammy/msvc-dev-cmd/issues/80).
If we don't hard-code a version, then the action will default to the latest toolset. I haven't found a way to (at least) log the version that's used. I haven't looked at installing a specific version. I think we're fine defaulting to the latest available version.