### PR TITLE
Fix evaluation order for toplevel bindings in classes with local opens

### DIFF
--- a/.depend
+++ b/.depend
@@ -3859,6 +3859,7 @@ lambda/translclass.cmo : \
     typing/path.cmi \
     utils/misc.cmi \
     lambda/matching.cmi \
+    parsing/longident.cmi \
     parsing/location.cmi \
     lambda/lambda.cmi \
     typing/ident.cmi \
@@ -3878,6 +3879,7 @@ lambda/translclass.cmx : \
     typing/path.cmx \
     utils/misc.cmx \
     lambda/matching.cmx \
+    parsing/longident.cmx \
     parsing/location.cmx \
     lambda/lambda.cmx \
     typing/ident.cmx \

--- a/Changes
+++ b/Changes
@@ -67,6 +67,10 @@ _______________
   current status.
   (Gabriel Scherer, review by Nick Roberts)
 
+- #13179: Fix evaluation of toplevel lets in classes containing
+  local opens
+  (Vincent Laviron)
+
 ### Standard library:
 
 - #13168: In Array.shuffle, clarify the code that validates the

--- a/lambda/translclass.ml
+++ b/lambda/translclass.ml
@@ -215,6 +215,9 @@ let rec build_object_init_0
     Tcl_let (_rec_flag, _defs, vals, cl) ->
       build_object_init_0
         ~scopes cl_table (vals@params) cl copy_env subst_env top ids
+  | Tcl_open (_descr, cl) ->
+      build_object_init_0
+        ~scopes cl_table params cl copy_env subst_env top ids
   | _ ->
       let self = Ident.create_local "self" in
       let env = Ident.create_local "env" in
@@ -413,6 +416,11 @@ let rec build_class_lets ~scopes cl =
       (env, fun lam_and_kind ->
           let lam, rkind = wrap lam_and_kind in
           Translcore.transl_let ~scopes rec_flag defs lam, rkind)
+  | Tcl_open (open_descr, cl) ->
+      (* Failsafe to ensure we get a compilation error if arbitrary
+         module expressions become allowed *)
+      let _ : Path.t * Longident.t loc = open_descr.open_expr in
+      build_class_lets ~scopes cl
   | _ ->
       (cl.cl_env, fun lam_and_kind -> lam_and_kind)
 

--- a/testsuite/tests/runtime-objects/toplevel_lets.ml
+++ b/testsuite/tests/runtime-objects/toplevel_lets.ml
@@ -1,0 +1,71 @@
+(* TEST *)
+
+(* Evaluation order for class expressions *)
+
+(* Everything in a class definition is evaluated at object creation time,
+   except for any toplevel let-bindings which are lifted away and
+   evaluated at class creation time. *)
+let () = print_endline "M1:"
+module M1 = struct
+  let () = print_endline "Before class"
+  class c =
+    let () = print_endline "Class init" in
+    object end
+  let () = print_endline "After class"
+  let o1 = new c
+  let o2 = new c
+end
+
+(* PR 13179 *)
+let () = print_endline "M2:"
+module M2 = struct
+  let () = print_endline "Before class"
+  class c =
+    let open Unit in
+    let () = print_endline "Class init" in
+    object end
+  let () = print_endline "After class"
+  let o1 = new c
+  let o2 = new c
+end
+
+(* Applications: argument evaluated later *)
+let () = print_endline "M3:"
+module M3 = struct
+  class with_param p = object end
+  let () = print_endline "Before class"
+  class c =
+    let () = print_endline "Class init" in
+    with_param (print_endline "Class param")
+  let () = print_endline "After class"
+  let o1 = new c
+  let o2 = new c
+end
+
+(* Nested bindings are not toplevel *)
+(* Not testing for side effects in arguments, as bytecode and native compilers
+   produce different evaluation orders *)
+let () = print_endline "M4:"
+module M4 = struct
+  class with_param p = object end
+  let () = print_endline "Before class"
+  class c =
+    (let () = print_endline "Class init" in
+     with_param)
+      ()
+  let () = print_endline "After class"
+  let o1 = new c
+  let o2 = new c
+end
+
+(* Constraints prevent lifting *)
+let () = print_endline "M5:"
+module M5 = struct
+  let () = print_endline "Before class"
+  class c =
+    (let () = print_endline "Class init" in
+     object end : object end)
+  let () = print_endline "After class"
+  let o1 = new c
+  let o2 = new c
+end

--- a/testsuite/tests/runtime-objects/toplevel_lets.reference
+++ b/testsuite/tests/runtime-objects/toplevel_lets.reference
@@ -1,0 +1,24 @@
+M1:
+Before class
+Class init
+After class
+M2:
+Before class
+Class init
+After class
+M3:
+Before class
+Class init
+After class
+Class param
+Class param
+M4:
+Before class
+After class
+Class init
+Class init
+M5:
+Before class
+After class
+Class init
+Class init


### PR DESCRIPTION
This PR fixes the issue with local opens in classes, as described in #13178.
I've added the examples from that issue in this PR, with their current semantics.