### PR TITLE
configure: more tweaks to MSVC flags probing

### DIFF
--- a/configure
+++ b/configure
@@ -14025,16 +14025,16 @@ case $ocaml_cc_vendor in #(
     common_cppflags="-D_CRT_SECURE_NO_DEPRECATE"
     internal_cflags="$cc_warnings"
     internal_cppflags='-DUNICODE -D_UNICODE -D_CRT_NONSTDC_NO_WARNINGS'
-    as_CACHEVAR=`printf "%s\n" "ax_cv_check_cflags_$warn_error_flag_-d2VolatileMetadata-" | $as_tr_sh`
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether the C compiler accepts -d2VolatileMetadata-" >&5
-printf %s "checking whether the C compiler accepts -d2VolatileMetadata-... " >&6; }
+    as_CACHEVAR=`printf "%s\n" "ax_cv_check_cflags_$warn_error_flag_-volatileMetadata-" | $as_tr_sh`
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether the C compiler accepts -volatileMetadata-" >&5
+printf %s "checking whether the C compiler accepts -volatileMetadata-... " >&6; }
 if eval test \${$as_CACHEVAR+y}
 then :
   printf %s "(cached) " >&6
 else $as_nop
 
   ax_check_save_flags=$CFLAGS
-  CFLAGS="$CFLAGS $warn_error_flag -d2VolatileMetadata-"
+  CFLAGS="$CFLAGS $warn_error_flag -volatileMetadata-"
   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
@@ -14060,7 +14060,7 @@ eval ac_res=\$$as_CACHEVAR
 printf "%s\n" "$ac_res" >&6; }
 if eval test \"x\$"$as_CACHEVAR"\" = x"yes"
 then :
-  internal_cflags="$internal_cflags -d2VolatileMetadata-"
+  internal_cflags="$internal_cflags -volatileMetadata-"
 else $as_nop
   :
 fi

--- a/configure
+++ b/configure
@@ -13912,7 +13912,13 @@ case $ocaml_cc_vendor in #(
     outputobj='-o '; cc_warnings="" ;; #(
   msvc-*) :
     outputobj='-Fo'
+    case $ocaml_cc_vendor in #(
+  msvc-*-clang-*) :
     warn_error_flag='-WX'
+      msvc-* ;; #(
+  *) :
+    warn_error_flag='-WX -options:strict' ;;
+esac
     cc_warnings='' ;; #(
   *) :
     outputobj='-o '

--- a/configure.ac
+++ b/configure.ac
@@ -806,7 +806,9 @@ AS_CASE([$ocaml_cc_vendor],
     [outputobj='-o '; cc_warnings=""],
   [msvc-*],
     [outputobj='-Fo'
-    warn_error_flag='-WX'
+    AS_CASE([$ocaml_cc_vendor],
+      [msvc-*-clang-*], [warn_error_flag='-WX']
+      [msvc-*], [warn_error_flag='-WX -options:strict'])
     cc_warnings=''],
   [outputobj='-o '
   warn_error_flag='-Werror'

--- a/configure.ac
+++ b/configure.ac
@@ -871,8 +871,8 @@ AS_CASE([$ocaml_cc_vendor],
     common_cppflags="-D_CRT_SECURE_NO_DEPRECATE"
     internal_cflags="$cc_warnings"
     internal_cppflags='-DUNICODE -D_UNICODE -D_CRT_NONSTDC_NO_WARNINGS'
-    AX_CHECK_COMPILE_FLAG([-d2VolatileMetadata-],
-      [internal_cflags="$internal_cflags -d2VolatileMetadata-"], [],
+    AX_CHECK_COMPILE_FLAG([-volatileMetadata-],
+      [internal_cflags="$internal_cflags -volatileMetadata-"], [],
       [$warn_error_flag])
     internal_cppflags="$internal_cppflags -DWINDOWS_UNICODE=$windows_unicode"],
   [xlc-*],


### PR DESCRIPTION
1. [configure: add -options:strict to MSVC's warn error flag](https://github.com/ocaml/ocaml/commit/7521602b82833a6b120e5dcec837b9f221b696b8)

   Using solely `-WX` to turn warnings as errors isn't sufficient to probe MSVC for unknown options.
   
   ```console
   > cl -nologo -WX -empanadas test.c
   cl : Command line warning D9002 : ignoring unknown option '-empanadas'
   test.c
   > cl -nologo -options:strict -empanadas test.c
   cl : Command line error D8043 : unknown option '-empanadas'
   ```
    
2. [configure: use MSVC's documented /volatileMetadata[-] flag](https://github.com/ocaml/ocaml/commit/74003d6b49a701a7a2b47fe997cd82f018e0b4e3)

   `/d2VolatileMetadata[-]` is internal and undocumented.

   > `/volatileMetadata[-]` generate metadata on volatile memory accesses

   Neither `/d2VolatileMetadata` nor `/volatileMetadata` are supported as of clang-cl 17.0.3.
   
No change entry needed.