### PR TITLE
Mention useful TSan option exitcode=0 in manual

### DIFF
--- a/manual/src/cmds/tsan.etex
+++ b/manual/src/cmds/tsan.etex
@@ -206,6 +206,11 @@ necessary to obtain the second stack trace, but it also increases memory
 consumption. This setting does not change the number of memory accesses
 remembered per memory location.
 
+Another useful runtime option is \texttt{exitcode=0}, which still reports data
+races but does not change the exit code. This can be useful if TSan complains
+about data races in programs that you don't care about and the non-zero exit
+code disturbs your workflow.
+
 \section{s:tsan-c-code}{Guidelines for linking}
 
 As a general rule, OCaml programs instrumented with TSan should only be linked


### PR DESCRIPTION
As reported by @kit-ty-kate, this option would be useful to display in the manual. You can imagine tools (like Dune) necessary to compile a project, that a particular developer doesn't care about. That developer will want to silence any data races in that tool to be able to work on their project.