### PR TITLE
configure: fix typo when selecting msvc's warn-error-flag

### DIFF
--- a/configure
+++ b/configure
@@ -13914,8 +13914,7 @@ case $ocaml_cc_vendor in #(
     outputobj='-Fo'
     case $ocaml_cc_vendor in #(
   msvc-*-clang-*) :
-    warn_error_flag='-WX'
-      msvc-* ;; #(
+    warn_error_flag='-WX' ;; #(
   *) :
     warn_error_flag='-WX -options:strict' ;;
 esac

--- a/configure.ac
+++ b/configure.ac
@@ -807,8 +807,8 @@ AS_CASE([$ocaml_cc_vendor],
   [msvc-*],
     [outputobj='-Fo'
     AS_CASE([$ocaml_cc_vendor],
-      [msvc-*-clang-*], [warn_error_flag='-WX']
-      [msvc-*], [warn_error_flag='-WX -options:strict'])
+      [msvc-*-clang-*], [warn_error_flag='-WX'],
+      [warn_error_flag='-WX -options:strict'])
     cc_warnings=''],
   [outputobj='-o '
   warn_error_flag='-Werror'


### PR DESCRIPTION
A typo (missing a comma) that I introduced yesterday in #13182. I missed it in the whole configure log, sorry about that.
I felt too guilty overnight of my poor attempt at backdooring OCaml's build system…