### PR TITLE
unix: move Int_val outside blocking section

### DIFF
--- a/otherlibs/unix/chmod.c
+++ b/otherlibs/unix/chmod.c
@@ -26,15 +26,16 @@
 #include <caml/osdeps.h>
 #include "caml/unixsupport.h"
 
-CAMLprim value caml_unix_chmod(value path, value perm)
+CAMLprim value caml_unix_chmod(value path, value vperm)
 {
-  CAMLparam2(path, perm);
+  CAMLparam2(path, vperm);
   char_os * p;
   int ret;
+  int perm = Int_val(vperm);
   caml_unix_check_path(path, "chmod");
   p = caml_stat_strdup_to_os(String_val(path));
   caml_enter_blocking_section();
-  ret = chmod_os(p, Int_val(perm));
+  ret = chmod_os(p, perm);
   caml_leave_blocking_section();
   caml_stat_free(p);
   if (ret == -1) caml_uerror("chmod", path);

--- a/otherlibs/unix/mkdir.c
+++ b/otherlibs/unix/mkdir.c
@@ -26,15 +26,16 @@
 #include <caml/signals.h>
 #include "caml/unixsupport.h"
 
-CAMLprim value caml_unix_mkdir(value path, value perm)
+CAMLprim value caml_unix_mkdir(value path, value vperm)
 {
-  CAMLparam2(path, perm);
+  CAMLparam2(path, vperm);
   char_os * p;
   int ret;
+  int perm = Int_val(vperm);
   caml_unix_check_path(path, "mkdir");
   p = caml_stat_strdup_to_os(String_val(path));
   caml_enter_blocking_section();
-  ret = mkdir_os(p, Int_val(perm));
+  ret = mkdir_os(p, perm);
   caml_leave_blocking_section();
   caml_stat_free(p);
   if (ret == -1) caml_uerror("mkdir", path);

--- a/otherlibs/unix/mkfifo.c
+++ b/otherlibs/unix/mkfifo.c
@@ -23,15 +23,16 @@
 
 #ifdef HAS_MKFIFO
 
-CAMLprim value caml_unix_mkfifo(value path, value mode)
+CAMLprim value caml_unix_mkfifo(value path, value vmode)
 {
-  CAMLparam2(path, mode);
+  CAMLparam2(path, vmode);
   char * p;
   int ret;
+  int mode = Int_val(vmode);
   caml_unix_check_path(path, "mkfifo");
   p = caml_stat_strdup(String_val(path));
   caml_enter_blocking_section();
-  ret = mkfifo(p, Int_val(mode));
+  ret = mkfifo(p, mode);
   caml_leave_blocking_section();
   caml_stat_free(p);
   if (ret == -1)
@@ -46,15 +47,16 @@ CAMLprim value caml_unix_mkfifo(value path, value mode)
 
 #ifdef S_IFIFO
 
-CAMLprim value caml_unix_mkfifo(value path, value mode)
+CAMLprim value caml_unix_mkfifo(value path, value vmode)
 {
-  CAMLparam2(path, mode);
+  CAMLparam2(path, vmode);
   char * p;
   int ret;
+  int mode = Int_val(vmode);
   caml_unix_check_path(path, "mkfifo");
   p = caml_stat_strdup(String_val(path));
   caml_enter_blocking_section();
-  ret = mknod(p, (Int_val(mode) & 07777) | S_IFIFO, 0);
+  ret = mknod(p, (mode & 07777) | S_IFIFO, 0);
   caml_leave_blocking_section();
   caml_stat_free(p);
   if (ret == -1)

--- a/otherlibs/unix/open_unix.c
+++ b/otherlibs/unix/open_unix.c
@@ -55,11 +55,12 @@ static const int open_cloexec_table[15] = {
   CLOEXEC, KEEPEXEC
 };
 
-CAMLprim value caml_unix_open(value path, value flags, value perm)
+CAMLprim value caml_unix_open(value path, value flags, value vperm)
 {
-  CAMLparam3(path, flags, perm);
+  CAMLparam3(path, flags, vperm);
   int fd, cv_flags, clo_flags, cloexec;
   char * p;
+  int perm = Int_val(vperm);
 
   caml_unix_check_path(path, "open");
   cv_flags = caml_convert_flag_list(flags, open_flag_table);
@@ -76,7 +77,7 @@ CAMLprim value caml_unix_open(value path, value flags, value perm)
   p = caml_stat_strdup(String_val(path));
   /* open on a named FIFO can block (PR#8005) */
   caml_enter_blocking_section();
-  fd = open(p, cv_flags, Int_val(perm));
+  fd = open(p, cv_flags, perm);
   caml_leave_blocking_section();
   caml_stat_free(p);
   if (fd == -1) caml_uerror("open", path);

--- a/otherlibs/unix/read_unix.c
+++ b/otherlibs/unix/read_unix.c
@@ -37,18 +37,19 @@ CAMLprim value caml_unix_read(value fd, value buf, value ofs, value len)
   CAMLreturn(Val_int(ret));
 }
 
-CAMLprim value caml_unix_read_bigarray(value fd, value vbuf,
+CAMLprim value caml_unix_read_bigarray(value vfd, value vbuf,
                                        value vofs, value vlen)
 {
-  CAMLparam4(fd, vbuf, vofs, vlen);
+  CAMLparam4(vfd, vbuf, vofs, vlen);
   intnat ofs, len, ret;
   void *buf;
 
   buf = Caml_ba_data_val(vbuf);
   ofs = Long_val(vofs);
   len = Long_val(vlen);
+  int fd = Int_val(vfd);
   caml_enter_blocking_section();
-  ret = read(Int_val(fd), (char *) buf + ofs, len);
+  ret = read(fd, (char *) buf + ofs, len);
   caml_leave_blocking_section();
   if (ret == -1) caml_uerror("read_bigarray", Nothing);
   CAMLreturn(Val_long(ret));

--- a/otherlibs/unix/socketpair_win32.c
+++ b/otherlibs/unix/socketpair_win32.c
@@ -170,18 +170,21 @@ fail:
   return SOCKET_ERROR;
 }
 
-CAMLprim value caml_unix_socketpair(value cloexec, value domain, value type,
-                               value protocol)
+CAMLprim value caml_unix_socketpair(value cloexec, value vdomain, value vtype,
+                               value vprotocol)
 {
-  CAMLparam4(cloexec, domain, type, protocol);
+  CAMLparam4(cloexec, vdomain, vtype, vprotocol);
   CAMLlocal1(result);
   SOCKET sv[2];
   int rc;
+  int domain = Int_val(vdomain);
+  int type = Int_val(vtype);
+  int protocol = Int_val(vprotocol);
 
   caml_enter_blocking_section();
-  rc = socketpair(caml_unix_socket_domain_table[Int_val(domain)],
-                  caml_unix_socket_type_table[Int_val(type)],
-                  Int_val(protocol),
+  rc = socketpair(caml_unix_socket_domain_table[domain],
+                  caml_unix_socket_type_table[type],
+                  protocol,
                   sv,
                   ! caml_unix_cloexec_p(cloexec));
   caml_leave_blocking_section();

--- a/otherlibs/unix/truncate_unix.c
+++ b/otherlibs/unix/truncate_unix.c
@@ -28,15 +28,16 @@
 
 #ifdef HAS_TRUNCATE
 
-CAMLprim value caml_unix_truncate(value path, value len)
+CAMLprim value caml_unix_truncate(value path, value vlen)
 {
-  CAMLparam2(path, len);
+  CAMLparam2(path, vlen);
   char * p;
   int ret;
+  file_offset len = Long_val(vlen);
   caml_unix_check_path(path, "truncate");
   p = caml_stat_strdup(String_val(path));
   caml_enter_blocking_section();
-  ret = truncate(p, Long_val(len));
+  ret = truncate(p, len);
   caml_leave_blocking_section();
   caml_stat_free(p);
   if (ret == -1)

--- a/otherlibs/unix/truncate_win32.c
+++ b/otherlibs/unix/truncate_win32.c
@@ -69,15 +69,16 @@ static int truncate(WCHAR * path, __int64 len)
   return ret;
 }
 
-CAMLprim value caml_unix_truncate(value path, value len)
+CAMLprim value caml_unix_truncate(value path, value vlen)
 {
-  CAMLparam2(path, len);
+  CAMLparam2(path, vlen);
   WCHAR * p;
   int ret;
+  file_offset len = Long_val(vlen);
   caml_unix_check_path(path, "truncate");
   p = caml_stat_strdup_to_utf16(String_val(path));
   caml_enter_blocking_section();
-  ret = truncate(p, Long_val(len));
+  ret = truncate(p, len);
   caml_leave_blocking_section();
   caml_stat_free(p);
   if (ret == -1)

--- a/otherlibs/unix/write_unix.c
+++ b/otherlibs/unix/write_unix.c
@@ -55,20 +55,21 @@ CAMLprim value caml_unix_write(value fd, value buf, value vofs, value vlen)
   CAMLreturn(Val_long(written));
 }
 
-CAMLprim value caml_unix_write_bigarray(value fd, value vbuf,
+CAMLprim value caml_unix_write_bigarray(value vfd, value vbuf,
                                         value vofs, value vlen, value vsingle)
 {
-  CAMLparam5(fd, vbuf, vofs, vlen, vsingle);
+  CAMLparam5(vfd, vbuf, vofs, vlen, vsingle);
   intnat ofs, len, written, ret;
   void *buf;
 
   buf = Caml_ba_data_val(vbuf);
   ofs = Long_val(vofs);
   len = Long_val(vlen);
+  int fd = Int_val(vfd);
   written = 0;
   caml_enter_blocking_section();
   while (len > 0) {
-    ret = write(Int_val(fd), (char *) buf + ofs, len);
+    ret = write(fd, (char *) buf + ofs, len);
     if (ret == -1) {
       if ((errno == EAGAIN || errno == EWOULDBLOCK) && written > 0) break;
       caml_leave_blocking_section();

--- a/runtime/sys.c
+++ b/runtime/sys.c
@@ -365,15 +365,16 @@ CAMLprim value caml_sys_chdir(value dirname)
   CAMLreturn(Val_unit);
 }
 
-CAMLprim value caml_sys_mkdir(value path, value perm)
+CAMLprim value caml_sys_mkdir(value path, value vperm)
 {
-  CAMLparam2(path, perm);
+  CAMLparam2(path, vperm);
   char_os * p;
   int ret;
+  int perm = Int_val(vperm);
   caml_sys_check_path(path);
   p = caml_stat_strdup_to_os(String_val(path));
   caml_enter_blocking_section();
-  ret = mkdir_os(p, Int_val(perm));
+  ret = mkdir_os(p, perm);
   caml_leave_blocking_section();
   caml_stat_free(p);
   if (ret == -1) caml_sys_error(path);


### PR DESCRIPTION
As discussed in #12737, using `Int_val` inside blocking sections can cause data races and is now seen as a bad idea.

(this causes a TSAN warning when using Dune, see ocaml/dune#10554)
