### PR TITLE
Don't exit while a domain is still running.

### DIFF
--- a/testsuite/tests/lazy/lazy3.ml
+++ b/testsuite/tests/lazy/lazy3.ml
@@ -2,6 +2,17 @@
  ocamlopt_flags += " -O3 ";
 *)
 
+(* In this test we force a lazy from two concurrent domains without
+   synchronization. This leads to unspecified behavior but still
+   should not crash. Currently, the implementation raises Undefined,
+   and that's what we test here.
+
+   Note: due to a bug in the current implementation of
+   cleanup-at-exit, we must be careful to join d1 before we exit the
+   main domain at the end of the program.
+*)
+
+
 let f count =
   let _n = (Domain.self ():> int) in
   let r = ref 0 in

--- a/testsuite/tests/lazy/lazy3.ml
+++ b/testsuite/tests/lazy/lazy3.ml
@@ -17,11 +17,12 @@ let main () =
         let _n = (Domain.self ():> int) in
         Lazy.force l)
   in
-  let n2 = Lazy.force l in
+  let n2 = try Some (Lazy.force l) with Lazy.Undefined -> None in
   let n1 = Domain.join d1 in
   (n1, n2)
 
 let _ =
   match main () with
-  | (n1, n2) -> Printf.printf "n1=%d n2=%d\n" n1 n2
+  | (n1, Some n2) -> Printf.printf "n1=%d n2=%d\n" n1 n2
+  | (_, None) -> print_endline "Undefined"
   | exception Lazy.Undefined -> print_endline "Undefined"


### PR DESCRIPTION
See also commit 78fd956

This test segfaults on my machine in cleanup-at-exit mode.
