### PR TITLE
Fix #13185: Type-level module alias for functor parameter accepted

### DIFF
--- a/Changes
+++ b/Changes
@@ -285,8 +285,9 @@ _______________
   (Jan Midtgaard, review by Antonin Décimo, Sébastien Hinderer, and
    David Allsopp)
 
-- #13185: Type-level module alias for functor parameter accepted
-  (Jacques Garrigue, report by Richard Eisenberg)
+- #13185, #13192: Reject type-level module aliases on functor parameter
+  inside signatures.
+  (Jacques Garrigue, report by Richard Eisenberg, review by Florian Angeletti)
 
 OCaml 5.2.0 (13 May 2024)
 -------------------------

--- a/Changes
+++ b/Changes
@@ -285,6 +285,9 @@ _______________
   (Jan Midtgaard, review by Antonin Décimo, Sébastien Hinderer, and
    David Allsopp)
 
+- #13185: Type-level module alias for functor parameter accepted
+  (Jacques Garrigue, report by Richard Eisenberg)
+
 OCaml 5.2.0 (13 May 2024)
 -------------------------
 

--- a/testsuite/tests/typing-modules/pr13185.ml
+++ b/testsuite/tests/typing-modules/pr13185.ml
@@ -11,5 +11,5 @@ module type S1 = sig end
 Line 2, characters 41-53:
 2 | module type S2 = functor (X : S1) -> sig module M = X end
                                              ^^^^^^^^^^^^
-Error: Cannot alias the module "X", it is a functor argument
+Error: Functor arguments, such as "X", cannot be aliased
 |}]

--- a/testsuite/tests/typing-modules/pr13185.ml
+++ b/testsuite/tests/typing-modules/pr13185.ml
@@ -1,0 +1,15 @@
+(* TEST
+ expect;
+*)
+
+(* #13185 *)
+
+module type S1 = sig end
+module type S2 = functor (X : S1) -> sig module M = X end
+[%%expect{|
+module type S1 = sig end
+Line 2, characters 41-53:
+2 | module type S2 = functor (X : S1) -> sig module M = X end
+                                             ^^^^^^^^^^^^
+Error: Cannot alias the module "X", it is a functor argument
+|}]

--- a/testsuite/tests/typing-sigsubst/sigsubst.ml
+++ b/testsuite/tests/typing-sigsubst/sigsubst.ml
@@ -208,7 +208,7 @@ type (_, _) eq = Refl : ('a, 'a) eq
 Line 8, characters 4-16:
 8 |     module N = M
         ^^^^^^^^^^^^
-Error: Cannot alias the module "M", it is a functor argument
+Error: Functor arguments, such as "M", cannot be aliased
 |}]
 
 (* Checking that the uses of M.t are rewritten regardless of how they

--- a/testsuite/tests/typing-sigsubst/sigsubst.ml
+++ b/testsuite/tests/typing-sigsubst/sigsubst.ml
@@ -205,15 +205,10 @@ end = struct
 end;;
 [%%expect {|
 type (_, _) eq = Refl : ('a, 'a) eq
-Line 11, characters 18-58:
-11 |   module type T = S with type N.t = M.t with module N := N;;
-                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: In this "with" constraint, the new definition of "N"
-       does not match its original definition in the constrained signature:
-       Modules do not match:
-         sig type t = M.t val compare : t -> t -> int end
-       is not included in
-         (module M)
+Line 8, characters 4-16:
+8 |     module N = M
+        ^^^^^^^^^^^^
+Error: Cannot alias the module "M", it is a functor argument
 |}]
 
 (* Checking that the uses of M.t are rewritten regardless of how they

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -3449,7 +3449,7 @@ let report_error ~loc _env = function
         (Style.as_inline_code path) p
   | Cannot_alias p ->
       Location.errorf ~loc
-        "Cannot alias the module %a, it is a functor argument"
+        "Functor arguments, such as %a, cannot be aliased"
         (Style.as_inline_code path) p
   | Cannot_scrape_package_type p ->
       Location.errorf ~loc

--- a/typing/typemod.mli
+++ b/typing/typemod.mli
@@ -137,6 +137,7 @@ type error =
   | Invalid_type_subst_rhs
   | Unpackable_local_modtype_subst of Path.t
   | With_cannot_remove_packed_modtype of Path.t * module_type
+  | Cannot_alias of Path.t
 
 exception Error of Location.t * Env.t * error
 exception Error_forward of Location.error


### PR DESCRIPTION
Add a new error message when a functor parameter is aliased inside a signature.
Fixes #13185.