### PR TITLE
Remove the unused env_init field from class blocks

### DIFF
--- a/Changes
+++ b/Changes
@@ -220,6 +220,9 @@ _______________
   platforms (Linux, *BSD).
   (Miod Vallat, review by Nicolás Ojeda Bär)
 
+- #13193: Remove the unused env_init field from class blocks
+  (Vincent Laviron, review by Jacques Garrigue)
+
 ### Build system:
 
 - #12909: Reorganise how MKEXE_VIA_CC is built to make it correct for MSVC by

--- a/lambda/translclass.ml
+++ b/lambda/translclass.ml
@@ -641,6 +641,19 @@ open M
     class_init: inheritance function (table -> env -> obj_init)
       (one by source code)
     env: local environment
+
+   The local environment is used for cached classes. When a
+   class definition occurs under a call to Translobj.oo_wrap
+   (typically inside a functor), the class creation code is
+   split between a static part (depending only on toplevel names)
+   and a dynamic part, the environment. The static part is cached
+   in a toplevel structure, so that only the first class creation
+   computes it and the subsequent classes can reuse it. Because of
+   that, the (static) [class_init] function takes the environment
+   as parameter, and when called is given the [env] field of the
+   class. For the [obj_init] part, an [env_init] function (of type
+   [env -> obj_init]) is stored in the cache, and called on the
+   environment to generate the [obj_init] at class creation time.
 *)
 
 (*

--- a/lambda/translclass.ml
+++ b/lambda/translclass.ml
@@ -284,7 +284,7 @@ let rec build_class_init ~scopes cla cstr super inh_init cl_init msubst top cl =
            Llet (Strict, Pgenval, obj_init,
                  mkappl(Lprim(Pfield (1, Pointer, Mutable),
                               [path_lam], Loc_unknown), Lvar cla ::
-                        if top then [Lprim(Pfield (3, Pointer, Mutable),
+                        if top then [Lprim(Pfield (2, Pointer, Mutable),
                                      [path_lam], Loc_unknown)]
                         else []),
                  bind_super cla super cl_init))
@@ -529,8 +529,7 @@ let transl_class_rebind ~scopes cl vf =
                    lfunction [envs, Pgenval]
                      (mkappl(Lvar new_init,
                              [mkappl(Lvar env_init, [Lvar envs])]))));
-           lfield cla 2;
-           lfield cla 3],
+           lfield cla 2],
           Loc_unknown)))
   with Exit ->
     lambda_unit
@@ -822,7 +821,7 @@ let transl_class ~scopes ids cl_id pub_meths cl vflag =
       mkappl (oo_prim "init_class", [Lvar table]),
       Lprim(Pmakeblock(0, Immutable, None),
             [mkappl (Lvar env_init, [lambda_unit]);
-             Lvar class_init; Lvar env_init; lambda_unit],
+             Lvar class_init; lambda_unit],
             Loc_unknown)))),
       Static
   and lbody_virt lenvs =
@@ -833,7 +832,7 @@ let transl_class ~scopes ids cl_id pub_meths cl vflag =
                           ~loc:Loc_unknown
                           ~return:Pgenval
                           ~params:[cla, Pgenval] ~body:cl_init;
-           lambda_unit; lenvs],
+           lenvs],
          Loc_unknown),
     Static
   in
@@ -861,7 +860,7 @@ let transl_class ~scopes ids cl_id pub_meths cl vflag =
   and linh_envs =
     List.map
       (fun (_, path_lam, _) ->
-        Lprim(Pfield (3, Pointer, Mutable), [path_lam], Loc_unknown))
+        Lprim(Pfield (2, Pointer, Mutable), [path_lam], Loc_unknown))
       (List.rev inh_init)
   in
   let make_envs (lam, rkind) =
@@ -951,9 +950,8 @@ let transl_class ~scopes ids cl_id pub_meths cl vflag =
         (if concrete then
           [mkappl (lfield cached 0, [lenvs]);
            lfield cached 1;
-           lfield cached 0;
            lenvs]
-        else [lambda_unit; lfield cached 0; lambda_unit; lenvs]),
+        else [lambda_unit; lfield cached 0; lenvs]),
         Loc_unknown
        ),
     Static)))

--- a/lambda/translclass.ml
+++ b/lambda/translclass.ml
@@ -648,12 +648,13 @@ open M
    split between a static part (depending only on toplevel names)
    and a dynamic part, the environment. The static part is cached
    in a toplevel structure, so that only the first class creation
-   computes it and the subsequent classes can reuse it. Because of
-   that, the (static) [class_init] function takes the environment
-   as parameter, and when called is given the [env] field of the
-   class. For the [obj_init] part, an [env_init] function (of type
-   [env -> obj_init]) is stored in the cache, and called on the
-   environment to generate the [obj_init] at class creation time.
+   computes it and the subsequent classes can reuse it.
+   Because of that, the (static) [class_init] function takes both
+   the class table to be filled and the environment as parameters,
+   and when called is given the [env] field of the class.
+   For the [obj_init] part, an [env_init] function (of type [env -> obj_init])
+   is stored in the cache, and called on the environment to generate
+   the [obj_init] at class creation time.
 *)
 
 (*

--- a/lambda/translclass.ml
+++ b/lambda/translclass.ml
@@ -635,16 +635,12 @@ open M
     * class without local dependencies -> direct translation
     * with local dependencies -> generate a stubs tree,
       with a node for every local classes inherited
-   A class is a 4-tuple:
-    (obj_init, class_init, env_init, env)
-    obj_init: creation function (unit -> obj)
-    class_init: inheritance function (table -> env_init)
+   A class is a 3-tuple:
+    (obj_init, class_init, env)
+    obj_init: creation function (unit -> params -> obj)
+    class_init: inheritance function (table -> env -> obj_init)
       (one by source code)
-    env_init: parameterisation by the local environment
-      (env -> params -> obj_init)
-      (one for each combination of inherited class_init )
     env: local environment
-   If ids=0 (immediate object), then only env_init is conserved.
 *)
 
 (*

--- a/stdlib/camlinternalMod.ml
+++ b/stdlib/camlinternalMod.ml
@@ -69,9 +69,9 @@ let rec update_mod_field modu i shape n =
   | Value _ ->
      () (* the value is already there *)
   | Class ->
-     assert (Obj.tag n = 0 && Obj.size n = 4);
+     assert (Obj.tag n = 0 && Obj.size n = 3);
      let cl = Obj.field modu i in
-     for j = 0 to 3 do
+     for j = 0 to 2 do
        Obj.set_field cl j (Obj.field n j)
      done
   | Module comps ->

--- a/stdlib/camlinternalOO.ml
+++ b/stdlib/camlinternalOO.ml
@@ -313,7 +313,7 @@ let init_class table =
   table.initializers <- List.rev table.initializers;
   resize table (3 + Obj.magic table.methods.(1) * 16 / Sys.word_size)
 
-let inherits cla vals virt_meths concr_meths (_, super, _, env) top =
+let inherits cla vals virt_meths concr_meths (_, super, env) top =
   narrow cla vals virt_meths concr_meths;
   let init =
     if top then super cla env else Obj.repr (super cla) in
@@ -329,7 +329,7 @@ let make_class pub_meths class_init =
   let table = create_table pub_meths in
   let env_init = class_init table in
   init_class table;
-  (env_init (Obj.repr 0), class_init, env_init, Obj.repr 0)
+  (env_init (Obj.repr 0), class_init, Obj.repr 0)
 
 type init_table = { mutable env_init: t; mutable class_init: table -> t }
 [@@warning "-unused-field"]
@@ -343,7 +343,7 @@ let make_class_store pub_meths class_init init_table =
 
 let dummy_class loc =
   let undef = fun _ -> raise (Undefined_recursive_module loc) in
-  (Obj.magic undef, undef, undef, Obj.repr 0)
+  (Obj.magic undef, undef, Obj.repr 0)
 
 (**** Objects ****)
 

--- a/stdlib/camlinternalOO.mli
+++ b/stdlib/camlinternalOO.mli
@@ -46,16 +46,16 @@ val create_table : string array -> table
 val init_class : table -> unit
 val inherits :
     table -> string array -> string array -> string array ->
-    (t * (table -> obj -> Obj.t) * t * obj) -> bool -> Obj.t array
+    (t * (table -> obj -> Obj.t) * obj) -> bool -> Obj.t array
 val make_class :
     string array -> (table -> Obj.t -> t) ->
-    (t * (table -> Obj.t -> t) * (Obj.t -> t) * Obj.t)
+    (t * (table -> Obj.t -> t) * Obj.t)
 type init_table
 val make_class_store :
     string array -> (table -> t) -> init_table -> unit
 val dummy_class :
     string * int * int ->
-    (t * (table -> Obj.t -> t) * (Obj.t -> t) * Obj.t)
+    (t * (table -> Obj.t -> t) * Obj.t)
 
 (** {1 Objects} *)
 


### PR DESCRIPTION
I eventually noticed (after spending some amount of time looking through the class and object code, for other reasons) that one of the four fields of class blocks was written to but never read from.
I looked around in all the suspicious places, and when I was convinced that there were indeed no accesses to this field directly or indirectly in all the places I knew where related to classes, I tentatively removed it (to find out if there were places manipulating classes that I was not aware of). The testsuite runs cleanly.

So I'm now convinced that the field isn't actually used, but I'm not sure whether it's a good idea to remove it or not. I'm submitting this PR to share my findings (and because I had written the code anyway), but I wouldn't be particularly disappointed if it was closed for one reason or another (if it's because the field is not actually unused, I want to hear about it though).

Cc @garrigue, who I assume is the person most likely to know about this.