### PR TITLE
A new abstract data type of enumerations in `Set.Make(Ord).Enum`

### DIFF
--- a/stdlib/moreLabels.mli
+++ b/stdlib/moreLabels.mli
@@ -1321,12 +1321,97 @@ module Set : sig
       val of_seq : elt Seq.t -> t
       (** Build a set from the given bindings
           @since 4.07 *)
+
+      (** Enumerations of the elements of a set.
+
+          An enumeration is an immutable data structure: its implementation
+          involves no side effects. It represents the sequence of the elements
+          of a set, in increasing order. In addition to enumerating the elements
+          of the sequence (one by one), it supports skipping ahead in the
+          sequence to the point where a certain threshold is reached or
+          exceeded.
+          @since 5.3 *)
+      module Enum : sig
+
+        type set = t
+        (** The type [set] is a synonym for the type of sets.
+            @since 5.3 *)
+
+        type enum
+        (** The type of enumerations. An enumeration represents an increasing
+            sequence of elements of type [elt]. The sequence is increasing
+            according to [Ord.compare]: thus, if [x] appears earlier than [y] in
+            the sequence, then [Ord.compare x y < 0] holds.
+            @since 5.3 *)
+
+        type t = enum
+        (** A synonym for the type [enum].
+            @since 5.3 *)
+
+        val empty : enum
+        (** [empty] is the empty enumeration. It contains zero elements.
+            @since 5.3 *)
+
+        val is_empty : enum -> bool
+        (** [is_empty e] tests whether the enumeration [e] is empty.
+            @since 5.3 *)
+
+        val enum : set -> enum
+        (** [enum s] returns an enumeration of the set [s]. This enumeration
+            contains all of the elements of the set [s], in increasing order.
+            @since 5.3 *)
+
+        val enum_from : elt -> set -> enum
+        (** [enum_from x s] returns an enumeration of the subset of [s]
+            formed of just the elements that are no less than [x].
+            It is equivalent to [from x (enum s)].
+            @since 5.3 *)
+
+        val head : enum -> elt
+        (** [head e] returns the first element of the enumeration [e].
+            The enumeration [e] must be nonempty.
+            @since 5.3 *)
+
+        val tail : enum -> enum
+        (** [tail e] returns the enumeration [e], deprived of its first element.
+            The enumeration [e] must be nonempty.
+            @since 5.3 *)
+
+        val head_opt : enum -> elt option
+        (** If the enumeration [e] is nonempty, then [head_opt e] returns its
+            first element. Otherwise, it returns [None].
+            @since 5.3 *)
+
+        val tail_opt : enum -> enum option
+        (** If the enumeration [e] is nonempty, then [tail_opt e] returns the
+            enumeration [e], deprived of its first element. Otherwise, it
+            returns [None].
+            @since 5.3 *)
+
+        val from : elt -> enum -> enum
+        (** [from x e] returns the enumeration obtained from the enumeration [e]
+            by skipping the elements that lie below the threshold [x]. In other
+            words, only the elements of [e] that lie at or above the threshold
+            [x] are retained.
+            @since 5.3 *)
+
+        val to_seq : enum -> elt Seq.t
+        (** [to_seq] converts an enumeration into a (persistent) sequence.
+            @since 5.3 *)
+
+        val elements : enum -> set
+        (** [elements] converts an enumeration into a set.
+            @since 5.3 *)
+
+      end (* Enum *)
+
     end
   (** Output signature of the functor {!Make}. *)
 
     module Make : functor (Ord : OrderedType) -> S
     with type elt = Ord.t
      and type t = Set.Make(Ord).t
+     and type Enum.enum = Set.Make(Ord).Enum.enum
   (** Functor building an implementation of the set structure
      given a totally ordered type. *)
 

--- a/stdlib/set.ml
+++ b/stdlib/set.ml
@@ -609,15 +609,21 @@ module Make(Ord: OrderedType) =
 
     let to_rev_seq c = rev_seq_of_enum_ (snoc_enum c End)
 
+    (* [enum_from_aux low s c] constructs an enumeration whose elements are:
+       1- the elements [x] of the tree [s] such that [low <= x] holds,
+       followed with 2- the elements of the enumeration [c]. *)
+    let rec enum_from_aux low s c = match s with
+      | Empty -> c
+      | Node {l; r; v; _} ->
+          begin match Ord.compare v low with
+            | 0 -> More (v, r, c)
+            | n when n<0 -> enum_from_aux low r c
+            | _ -> enum_from_aux low l (More (v, r, c))
+          end
+
+    let[@inline] enum_from low s =
+      enum_from_aux low s End
+
     let to_seq_from low s =
-      let rec aux low s c = match s with
-        | Empty -> c
-        | Node {l; r; v; _} ->
-            begin match Ord.compare v low with
-              | 0 -> More (v, r, c)
-              | n when n<0 -> aux low r c
-              | _ -> aux low l (More (v, r, c))
-            end
-      in
-      seq_of_enum_ (aux low s End)
+      seq_of_enum_ (enum_from low s)
   end

--- a/stdlib/set.mli
+++ b/stdlib/set.mli
@@ -315,6 +315,90 @@ module type S =
     val of_seq : elt Seq.t -> t
     (** Build a set from the given bindings
         @since 4.07 *)
+
+    (** Enumerations of the elements of a set.
+
+        An enumeration is an immutable data structure: its implementation
+        involves no side effects. It represents the sequence of the elements
+        of a set, in increasing order. In addition to enumerating the elements
+        of the sequence (one by one), it supports skipping ahead in the
+        sequence to the point where a certain threshold is reached or
+        exceeded.
+        @since 5.3 *)
+    module Enum : sig
+
+      type set = t
+      (** The type [set] is a synonym for the type of sets.
+          @since 5.3 *)
+
+      type enum
+      (** The type of enumerations. An enumeration represents an increasing
+          sequence of elements of type [elt]. The sequence is increasing
+          according to [Ord.compare]: thus, if [x] appears earlier than [y] in
+          the sequence, then [Ord.compare x y < 0] holds.
+          @since 5.3 *)
+
+      type t = enum
+      (** A synonym for the type [enum].
+          @since 5.3 *)
+
+      val empty : enum
+      (** [empty] is the empty enumeration. It contains zero elements.
+          @since 5.3 *)
+
+      val is_empty : enum -> bool
+      (** [is_empty e] tests whether the enumeration [e] is empty.
+          @since 5.3 *)
+
+      val enum : set -> enum
+      (** [enum s] returns an enumeration of the set [s]. This enumeration
+          contains all of the elements of the set [s], in increasing order.
+          @since 5.3 *)
+
+      val enum_from : elt -> set -> enum
+      (** [enum_from x s] returns an enumeration of the subset of [s]
+          formed of just the elements that are no less than [x].
+          It is equivalent to [from x (enum s)].
+          @since 5.3 *)
+
+      val head : enum -> elt
+      (** [head e] returns the first element of the enumeration [e].
+          The enumeration [e] must be nonempty.
+          @since 5.3 *)
+
+      val tail : enum -> enum
+      (** [tail e] returns the enumeration [e], deprived of its first element.
+          The enumeration [e] must be nonempty.
+          @since 5.3 *)
+
+      val head_opt : enum -> elt option
+      (** If the enumeration [e] is nonempty, then [head_opt e] returns its
+          first element. Otherwise, it returns [None].
+          @since 5.3 *)
+
+      val tail_opt : enum -> enum option
+      (** If the enumeration [e] is nonempty, then [tail_opt e] returns the
+          enumeration [e], deprived of its first element. Otherwise, it
+          returns [None].
+          @since 5.3 *)
+
+      val from : elt -> enum -> enum
+      (** [from x e] returns the enumeration obtained from the enumeration [e]
+          by skipping the elements that lie below the threshold [x]. In other
+          words, only the elements of [e] that lie at or above the threshold
+          [x] are retained.
+          @since 5.3 *)
+
+      val to_seq : enum -> elt Seq.t
+      (** [to_seq] converts an enumeration into a (persistent) sequence.
+          @since 5.3 *)
+
+      val elements : enum -> set
+      (** [elements] converts an enumeration into a set.
+          @since 5.3 *)
+
+    end (* Enum *)
+
   end
 (** Output signature of the functor {!Make}. *)
 

--- a/stdlib/templates/set.template.mli
+++ b/stdlib/templates/set.template.mli
@@ -315,6 +315,90 @@ module type S =
     val of_seq : elt Seq.t -> t
     (** Build a set from the given bindings
         @since 4.07 *)
+
+    (** Enumerations of the elements of a set.
+
+        An enumeration is an immutable data structure: its implementation
+        involves no side effects. It represents the sequence of the elements
+        of a set, in increasing order. In addition to enumerating the elements
+        of the sequence (one by one), it supports skipping ahead in the
+        sequence to the point where a certain threshold is reached or
+        exceeded.
+        @since 5.3 *)
+    module Enum : sig
+
+      type set = t
+      (** The type [set] is a synonym for the type of sets.
+          @since 5.3 *)
+
+      type enum
+      (** The type of enumerations. An enumeration represents an increasing
+          sequence of elements of type [elt]. The sequence is increasing
+          according to [Ord.compare]: thus, if [x] appears earlier than [y] in
+          the sequence, then [Ord.compare x y < 0] holds.
+          @since 5.3 *)
+
+      type t = enum
+      (** A synonym for the type [enum].
+          @since 5.3 *)
+
+      val empty : enum
+      (** [empty] is the empty enumeration. It contains zero elements.
+          @since 5.3 *)
+
+      val is_empty : enum -> bool
+      (** [is_empty e] tests whether the enumeration [e] is empty.
+          @since 5.3 *)
+
+      val enum : set -> enum
+      (** [enum s] returns an enumeration of the set [s]. This enumeration
+          contains all of the elements of the set [s], in increasing order.
+          @since 5.3 *)
+
+      val enum_from : elt -> set -> enum
+      (** [enum_from x s] returns an enumeration of the subset of [s]
+          formed of just the elements that are no less than [x].
+          It is equivalent to [from x (enum s)].
+          @since 5.3 *)
+
+      val head : enum -> elt
+      (** [head e] returns the first element of the enumeration [e].
+          The enumeration [e] must be nonempty.
+          @since 5.3 *)
+
+      val tail : enum -> enum
+      (** [tail e] returns the enumeration [e], deprived of its first element.
+          The enumeration [e] must be nonempty.
+          @since 5.3 *)
+
+      val head_opt : enum -> elt option
+      (** If the enumeration [e] is nonempty, then [head_opt e] returns its
+          first element. Otherwise, it returns [None].
+          @since 5.3 *)
+
+      val tail_opt : enum -> enum option
+      (** If the enumeration [e] is nonempty, then [tail_opt e] returns the
+          enumeration [e], deprived of its first element. Otherwise, it
+          returns [None].
+          @since 5.3 *)
+
+      val from : elt -> enum -> enum
+      (** [from x e] returns the enumeration obtained from the enumeration [e]
+          by skipping the elements that lie below the threshold [x]. In other
+          words, only the elements of [e] that lie at or above the threshold
+          [x] are retained.
+          @since 5.3 *)
+
+      val to_seq : enum -> elt Seq.t
+      (** [to_seq] converts an enumeration into a (persistent) sequence.
+          @since 5.3 *)
+
+      val elements : enum -> set
+      (** [elements] converts an enumeration into a set.
+          @since 5.3 *)
+
+    end (* Enum *)
+
   end
 (** Output signature of the functor {!Make}. *)
 

--- a/testsuite/tests/generalized-open/accepted_expect.ml
+++ b/testsuite/tests/generalized-open/accepted_expect.ml
@@ -49,6 +49,23 @@ val to_seq : t -> elt Seq.t = <fun>
 val to_rev_seq : t -> elt Seq.t = <fun>
 val add_seq : elt Seq.t -> t -> t = <fun>
 val of_seq : elt Seq.t -> t = <fun>
+module Enum :
+  sig
+    type set = t
+    type enum = Set.Make(String).Enum.enum
+    type t = enum
+    val empty : enum
+    val is_empty : enum -> bool
+    val enum : set -> enum
+    val enum_from : elt -> set -> enum
+    val head : enum -> elt
+    val tail : enum -> enum
+    val head_opt : enum -> elt option
+    val tail_opt : enum -> enum option
+    val from : elt -> enum -> enum
+    val to_seq : enum -> elt Seq.t
+    val elements : enum -> set
+  end
 |}]
 
 let e = empty;;

--- a/testsuite/tests/shapes/comp_units.ml
+++ b/testsuite/tests/shapes/comp_units.ml
@@ -150,6 +150,23 @@ module Without_constraint :
     val to_rev_seq : t -> elt Seq.t
     val add_seq : elt Seq.t -> t -> t
     val of_seq : elt Seq.t -> t
+    module Enum :
+      sig
+        type set = t
+        type enum = Set.Make(Int).Enum.enum
+        type t = enum
+        val empty : enum
+        val is_empty : enum -> bool
+        val enum : set -> enum
+        val enum_from : elt -> set -> enum
+        val head : enum -> elt
+        val tail : enum -> enum
+        val head_opt : enum -> elt option
+        val tail_opt : enum -> enum option
+        val from : elt -> enum -> enum
+        val to_seq : enum -> elt Seq.t
+        val elements : enum -> set
+      end
   end
 |}]
 

--- a/testsuite/tests/typing-modules/aliases.ml
+++ b/testsuite/tests/typing-modules/aliases.ml
@@ -322,6 +322,23 @@ module StringSet :
     val to_rev_seq : t -> elt Seq.t
     val add_seq : elt Seq.t -> t -> t
     val of_seq : elt Seq.t -> t
+    module Enum :
+      sig
+        type set = t
+        type enum = Set.Make(String).Enum.enum
+        type t = enum
+        val empty : enum
+        val is_empty : enum -> bool
+        val enum : set -> enum
+        val enum_from : elt -> set -> enum
+        val head : enum -> elt
+        val tail : enum -> enum
+        val head_opt : enum -> elt option
+        val tail_opt : enum -> enum option
+        val from : elt -> enum -> enum
+        val to_seq : enum -> elt Seq.t
+        val elements : enum -> set
+      end
   end
 module SSet :
   sig
@@ -370,6 +387,23 @@ module SSet :
     val to_rev_seq : t -> elt Seq.t
     val add_seq : elt Seq.t -> t -> t
     val of_seq : elt Seq.t -> t
+    module Enum :
+      sig
+        type set = t
+        type enum = Set.Make(S).Enum.enum
+        type t = enum
+        val empty : enum
+        val is_empty : enum -> bool
+        val enum : set -> enum
+        val enum_from : elt -> set -> enum
+        val head : enum -> elt
+        val tail : enum -> enum
+        val head_opt : enum -> elt option
+        val tail_opt : enum -> enum option
+        val from : elt -> enum -> enum
+        val to_seq : enum -> elt Seq.t
+        val elements : enum -> set
+      end
   end
 val f : StringSet.t -> SSet.t = <fun>
 |}];;
@@ -450,6 +484,23 @@ module A :
         val to_rev_seq : t -> elt Seq.t
         val add_seq : elt Seq.t -> t -> t
         val of_seq : elt Seq.t -> t
+        module Enum :
+          sig
+            type set = t
+            type enum = Set.Make(B).Enum.enum
+            type t = enum
+            val empty : enum
+            val is_empty : enum -> bool
+            val enum : set -> enum
+            val enum_from : elt -> set -> enum
+            val head : enum -> elt
+            val tail : enum -> enum
+            val head_opt : enum -> elt option
+            val tail_opt : enum -> enum option
+            val from : elt -> enum -> enum
+            val to_seq : enum -> elt Seq.t
+            val elements : enum -> set
+          end
       end
     val empty : S.t
   end
@@ -582,6 +633,23 @@ module SInt :
     val to_rev_seq : t -> elt Seq.t
     val add_seq : elt Seq.t -> t -> t
     val of_seq : elt Seq.t -> t
+    module Enum :
+      sig
+        type set = t
+        type enum = Set.Make(Int).Enum.enum
+        type t = enum
+        val empty : enum
+        val is_empty : enum -> bool
+        val enum : set -> enum
+        val enum_from : elt -> set -> enum
+        val head : enum -> elt
+        val tail : enum -> enum
+        val head_opt : enum -> elt option
+        val tail_opt : enum -> enum option
+        val from : elt -> enum -> enum
+        val to_seq : enum -> elt Seq.t
+        val elements : enum -> set
+      end
   end
 type (_, _) eq = Eq : ('a, 'a) eq
 type wrap = W of (SInt.t, SInt.t) eq

--- a/testsuite/tests/typing-modules/pr7818.ml
+++ b/testsuite/tests/typing-modules/pr7818.ml
@@ -278,6 +278,23 @@ module MkT :
       val to_rev_seq : t -> elt Seq.t
       val add_seq : elt Seq.t -> t -> t
       val of_seq : elt Seq.t -> t
+      module Enum :
+        sig
+          type set = t
+          type enum = Set.Make(X).Enum.enum
+          type t = enum
+          val empty : enum
+          val is_empty : enum -> bool
+          val enum : set -> enum
+          val enum_from : elt -> set -> enum
+          val head : enum -> elt
+          val tail : enum -> enum
+          val head_opt : enum -> elt option
+          val tail_opt : enum -> enum option
+          val from : elt -> enum -> enum
+          val to_seq : enum -> elt Seq.t
+          val elements : enum -> set
+        end
     end
 module type S =
   sig

--- a/tools/unlabel-patches/4.mli
+++ b/tools/unlabel-patches/4.mli
@@ -1,3 +1,4 @@
   module Make : functor (Ord : OrderedType) -> S
     with type elt = Ord.t
      and type t = Set.Make(Ord).t
+     and type Enum.enum = Set.Make(Ord).Enum.enum


### PR DESCRIPTION
This PR extends the API of sets (as produced by `Set.Make`) with a new submodule `Enum`. This submodule offers an abstract data type of enumerations.

An enumeration is an immutable data structure: its implementation involves no side effects. It represents the sequence of the elements of a set, in increasing order. In addition to enumerating the elements of the sequence (one by one), it supports skipping ahead in the sequence to the point where a certain threshold is reached or exceeded.

The operation that skips ahead, `from`, is believed (hoped) to have worst-case time complexity *O(log d)*, where *d* is the distance traveled, that is, the number of elements that are skipped. This is believed (hoped) to imply that if an enumeration of length *n* is exhausted via *k* successive calls to `from` then the total cost of this sequence of calls is *O(k . log (n/k))*.

This can be used, for instance, to efficiently iterate over the intersection of two (or more) sets without explicitly constructing this intersection in memory. This idea was inspired to me by the paper [Leapfrog Triejoin: a worst-case optimal join algorithm](https://arxiv.org/abs/1210.0481) by Todd L. Veldhuizen, where a similar kind of iteration API is proposed (in an imperative setting).

So far, the code in `Set.Enum` is complete (I believe) and has been lightly (manually) tested.

If there is interest in this PR, I propose to first extend the test suite with some tests of `Set.Enum`, then to define `Map.Enum` in a similar way.
