### PR TITLE
Dynarray.blit, which allows to extend the destination dynarray

### DIFF
--- a/Changes
+++ b/Changes
@@ -182,6 +182,11 @@ _______________
    review by KC Sivaramakrishnan, Miod Vallat and Nicolás Ojeda Bär,
    report by Vesa Karvonen)
 
+- #13197: Dynarray.blit, which allows to extend the destination
+  dynarray (0 <= dst_pos <= dst_length).
+  (Gabriel Scherer, report by Hazem Elmasry,
+   review by Olivier Nicole, Hazem Elmasry and Nicolás Ojeda Bär)
+
 * #13240: Add Uchar.seeded_hash, Change Uchar.hash implementation.
   Previously, Uchar.hash was aliased to Uchar.to_int. If you need that behavior,
   change your module instantiation from eg `module HT = Hashtbl.Make(Uchar)` to

--- a/stdlib/dynarray.ml
+++ b/stdlib/dynarray.ml
@@ -712,7 +712,7 @@ let blit_assume_room
     dst_arr dst.dummy dst_pos
     ~len:blit_length
 
-let blit src src_pos dst dst_pos len =
+let blit ~src ~src_pos ~dst ~dst_pos ~len =
   let src_length = length src in
   let dst_length = length dst in
   if len < 0 then

--- a/stdlib/dynarray.ml
+++ b/stdlib/dynarray.ml
@@ -169,10 +169,18 @@ module Dummy : sig
       ('a, 'stamp) with_dummy array -> int ->
       len:int ->
       unit
+
+    val blit :
+      ('a, 'stamp1) with_dummy array -> 'stamp1 dummy -> int ->
+      ('a, 'stamp2) with_dummy array -> 'stamp2 dummy -> int ->
+      len:int ->
+      unit
+
     val prefix :
       ('a, 'stamp) with_dummy array ->
       int ->
       ('a, 'stamp) with_dummy array
+
     val extend :
       ('a, 'stamp) with_dummy array ->
       length:int ->
@@ -265,6 +273,41 @@ end = struct
         for i = 0 to len - 1 do
           dst.(dst_pos + i) <- of_val src.(src_pos + i)
         done;
+      end
+
+    let blit src src_dummy src_pos dst dst_dummy dst_pos ~len =
+      if src_dummy == dst_dummy then
+        Array.blit src src_pos dst dst_pos len
+      else begin
+        if len < 0
+           || src_pos < 0
+           || src_pos + len < 0 (* overflow check *)
+           || src_pos + len > Array.length src
+           || dst_pos < 0
+           || dst_pos + len < 0 (* overflow check *)
+           || dst_pos + len > Array.length dst
+        then
+          (* We assume that the caller has already checked this and
+             will raise a proper error. The check here is only for
+             memory safety, it should not be reached and it is okay if
+             the error is uninformative. *)
+          assert false;
+        (* In case of self-blitting with overlap we must be careful about
+           the copying order -- we might overwrite an element we need later on.
+           Same logic as runtime/array.c *)
+        if src == dst && src_pos <= dst_pos then
+          (* copy in descending order *)
+          if src_pos = dst_pos then ()
+          else for i = len - 1 downto 0 do
+            Array.unsafe_set dst (dst_pos + i)
+              (Array.unsafe_get src (src_pos + i));
+          done
+        else
+          (* copy in ascending order *)
+          for i = 0 to len - 1 do
+            Array.unsafe_set dst (dst_pos + i)
+              (Array.unsafe_get src (src_pos + i));
+          done
       end
 
     let prefix arr n =
@@ -647,6 +690,55 @@ let append_iter a iter b =
 let append_seq a seq =
   Seq.iter (fun x -> add_last a x) seq
 
+(* blitting *)
+
+let blit_assume_room
+    (Pack src) src_pos src_length
+    (Pack dst) dst_pos dst_length
+    blit_length
+=
+  (* The caller of [blit_assume_room] typically calls
+     [ensure_capacity] right before. This could run asynchronous
+     code. We want to fail reliably on any asynchronous length change,
+     as it may invalidate the source and target ranges provided by the
+     user. So we double-check that the lengths have not changed.  *)
+  let src_arr = src.arr in
+  let dst_arr = dst.arr in
+  check_same_length "blit" (Pack src) ~length:src_length;
+  check_same_length "blit" (Pack dst) ~length:dst_length;
+  if dst_pos + blit_length > dst_length then begin
+    dst.length <- dst_pos + blit_length;
+  end;
+  (* note: [src] and [dst] may be equal when self-blitting, so
+     [src.length] may have been mutated here. *)
+  Dummy.Array.blit
+    src_arr src.dummy src_pos
+    dst_arr dst.dummy dst_pos
+    ~len:blit_length
+
+let blit src src_pos dst dst_pos len =
+  let src_length = length src in
+  let dst_length = length dst in
+  if len < 0 then
+    Printf.ksprintf invalid_arg
+      "Dynarray.blit: invalid blit length (%d)"
+      len;
+  if src_pos < 0 || src_pos + len > src_length then
+    Printf.ksprintf invalid_arg
+      "Dynarray.blit: invalid source region (%d..%d) \
+       in source dynarray of length %d"
+      src_pos (src_pos + len) src_length;
+  if dst_pos < 0 || dst_pos > dst_length then
+    Printf.ksprintf invalid_arg
+      "Dynarray.blit: invalid target region (%d..%d) \
+       in target dynarray of length %d"
+      dst_pos (dst_pos + len) dst_length;
+  ensure_capacity dst (dst_pos + len);
+  blit_assume_room
+    src src_pos src_length
+    dst dst_pos dst_length
+    len
+
 (* append_array: same [..._if_room] and loop logic as [add_last]. *)
 
 let append_array_if_room (Pack a) b =
@@ -695,27 +787,24 @@ let append_array a b =
       then grow_and_append a b
     in grow_and_append a b  end
 
-(* append: same [..._if_room] and loop logic as [add_last],
-   same reserve-before-fill logic as [append_array]. *)
+(* append: same [..._if_room] and loop logic as [add_last]. *)
 
 (* It is a programming error to mutate the length of [b] during a call
    to [append a b]. To detect this mistake we keep track of the length
    of [b] throughout the computation and check it that does not
    change.
 *)
-let append_if_room (Pack a) (Pack b) ~length_b =
+let append_if_room (Pack a) b ~length_b =
   let {arr = arr_a; length = length_a; _} = a in
   if length_a + length_b > Array.length arr_a then false
   else begin
-    let arr_b = b.arr in
-    check_valid_length length_b arr_b;
-    a.length <- length_a + length_b;
-    for i = 0 to length_b - 1 do
-      Array.unsafe_set arr_a (length_a + i)
-        (Dummy.of_val
-           (unsafe_get arr_b ~dummy:b.dummy ~i ~length:length_b))
-    done;
-    check_same_length "append" (Pack b) ~length:length_b;
+    (* blit [0..length_b-1]
+       into [length_a..length_a+length_b-1]. *)
+    blit_assume_room
+      b 0 length_b
+      (Pack a) length_a length_a
+      length_b;
+    check_same_length "append" b ~length:length_b;
     true
   end
 

--- a/stdlib/dynarray.mli
+++ b/stdlib/dynarray.mli
@@ -181,6 +181,23 @@ val append_iter :
     [1], [2], and then [3] at the end of [a].
     [append_iter a Queue.iter q] adds elements from the queue [q]. *)
 
+val blit : 'a t -> int -> 'a t -> int -> int -> unit
+(** [blit src src_pos dst dst_pos len] copies [len] elements from
+    a source dynarray [src], starting at index [src_pos], to
+    a destination dynarray [dst], starting at index [dst_pos]. It
+    works correctly even if [src] and [dst] are the same array, and
+    the source and destination chunks overlap.
+
+    Unlike {!Array.blit}, {!Dynarray.blit} can extend the destination
+    array with new elements: it is valid to call [blit] even when
+    [dst_pos + len] is larger than [length dst]. The only requirement
+    is that [dst_pos] must be at most [length dst] (included), so that
+    there is no gap between the current elements and the blit
+    region.
+
+    @raise Invalid_argument if [src_pos] and [len] do not designate
+    a valid subarray of [src], or if [dst_pos] is strictly below [0]
+    or strictly above [length dst]. *)
 
 (** {1:removing Removing elements} *)
 

--- a/stdlib/dynarray.mli
+++ b/stdlib/dynarray.mli
@@ -181,8 +181,8 @@ val append_iter :
     [1], [2], and then [3] at the end of [a].
     [append_iter a Queue.iter q] adds elements from the queue [q]. *)
 
-val blit : 'a t -> int -> 'a t -> int -> int -> unit
-(** [blit src src_pos dst dst_pos len] copies [len] elements from
+val blit : src:'a t -> src_pos:int -> dst:'a t -> dst_pos:int -> len:int -> unit
+(** [blit ~src ~src_pos ~dst ~dst_pos ~len] copies [len] elements from
     a source dynarray [src], starting at index [src_pos], to
     a destination dynarray [dst], starting at index [dst_pos]. It
     works correctly even if [src] and [dst] are the same array, and

--- a/testsuite/tests/lib-dynarray/test.ml
+++ b/testsuite/tests/lib-dynarray/test.ml
@@ -160,44 +160,48 @@ let () =
     (* normal blit works ok *)
     let a = A.of_list [1; 2; 3; 4; 5; 6] in
     let b = A.of_list [7; 8; 9; 10; 11] in
-    A.blit b 1 a 2 3;
+    A.blit ~src:b ~src_pos:1 ~dst:a ~dst_pos:2 ~len:3;
     assert (A.to_list a = [1; 2; 8; 9; 10; 6])
   in
   let () =
     (* source range overflows source array: error *)
     let a = A.of_list [1; 2] in
     let b = A.of_list [3; 4] in
-    assert (match A.blit b 2 a 0 2 with exception _ -> true | _ -> false)
+    assert (match
+              A.blit ~src:b ~src_pos:2 ~dst:a ~dst_pos:0 ~len:2
+            with exception _ -> true | _ -> false)
   in
   let () =
     (* target range overflows target array: extend the array *)
     let a = A.of_list [1; 2] in
     let b = A.of_list [3; 4; 5] in
-    A.blit b 0 a 1 3;
+    A.blit ~src:b ~src_pos:0 ~dst:a ~dst_pos:1 ~len:3;
     assert (A.to_list a = [1; 3; 4; 5]);
     (* call [fit_capacity] to test the resize logic later on. *)
     A.fit_capacity a;
     (* this works even at the end *)
-    A.blit b 0 a 4 2;
+    A.blit ~src:b ~src_pos:0 ~dst:a ~dst_pos:4 ~len:2;
     assert (A.to_list a = [1; 3; 4; 5; 3; 4]);
     (* ... but it fails if the extension would leave a gap *)
     assert (A.length a = 6);
-    assert (match A.blit b 0 a 7 2 with exception _ -> true | _ -> false)
+    assert (match
+              A.blit ~src:b ~src_pos:0 ~dst:a ~dst_pos:7 ~len:2
+            with exception _ -> true | _ -> false)
   in
   let () =
     (* self-blitting scenarios *)
     (* src_pos > dst_pos *)
     let a = A.of_list [1; 2; 3] in
-    A.blit a 1 a 0 2;
+    A.blit ~src:a ~src_pos:1 ~dst:a ~dst_pos:0 ~len:2;
     assert (A.to_list a = [2; 3; 3]);
-    A.blit a 0 a 2 3;
+    A.blit ~src:a ~src_pos:0 ~dst:a ~dst_pos:2 ~len:3;
     assert (A.to_list a = [2; 3; 2; 3; 3]);
     let b = A.of_list [1; 2; 3; 4] in
     (* src_pos = dst_pos *)
-    A.blit b 1 b 1 2;
+    A.blit ~src:b ~src_pos:1 ~dst:b ~dst_pos:1 ~len:2;
     assert (A.to_list b = [1; 2; 3; 4]);
     (* src_pos < dst_pos *)
-    A.blit b 0 b 2 2;
+    A.blit ~src:b ~src_pos:0 ~dst:b ~dst_pos:2 ~len:2;
     assert (A.to_list b = [1; 2; 1; 2]);
   in
   ()

--- a/testsuite/tests/lib-dynarray/test.ml
+++ b/testsuite/tests/lib-dynarray/test.ml
@@ -154,6 +154,54 @@ let () =
   assert (0. +. 1. +. 8. +. 10. +. 12. = A.fold_left (+.) 0. a);;
 
 
+(** blit *)
+let () =
+  let () =
+    (* normal blit works ok *)
+    let a = A.of_list [1; 2; 3; 4; 5; 6] in
+    let b = A.of_list [7; 8; 9; 10; 11] in
+    A.blit b 1 a 2 3;
+    assert (A.to_list a = [1; 2; 8; 9; 10; 6])
+  in
+  let () =
+    (* source range overflows source array: error *)
+    let a = A.of_list [1; 2] in
+    let b = A.of_list [3; 4] in
+    assert (match A.blit b 2 a 0 2 with exception _ -> true | _ -> false)
+  in
+  let () =
+    (* target range overflows target array: extend the array *)
+    let a = A.of_list [1; 2] in
+    let b = A.of_list [3; 4; 5] in
+    A.blit b 0 a 1 3;
+    assert (A.to_list a = [1; 3; 4; 5]);
+    (* call [fit_capacity] to test the resize logic later on. *)
+    A.fit_capacity a;
+    (* this works even at the end *)
+    A.blit b 0 a 4 2;
+    assert (A.to_list a = [1; 3; 4; 5; 3; 4]);
+    (* ... but it fails if the extension would leave a gap *)
+    assert (A.length a = 6);
+    assert (match A.blit b 0 a 7 2 with exception _ -> true | _ -> false)
+  in
+  let () =
+    (* self-blitting scenarios *)
+    (* src_pos > dst_pos *)
+    let a = A.of_list [1; 2; 3] in
+    A.blit a 1 a 0 2;
+    assert (A.to_list a = [2; 3; 3]);
+    A.blit a 0 a 2 3;
+    assert (A.to_list a = [2; 3; 2; 3; 3]);
+    let b = A.of_list [1; 2; 3; 4] in
+    (* src_pos = dst_pos *)
+    A.blit b 1 b 1 2;
+    assert (A.to_list b = [1; 2; 3; 4]);
+    (* src_pos < dst_pos *)
+    A.blit b 0 b 2 2;
+    assert (A.to_list b = [1; 2; 1; 2]);
+  in
+  ()
+
 (** {1:removing Removing elements} *)
 
 


### PR DESCRIPTION
We allow `blit` to extend the destination array with new elements at the end. In other words, `Dynarray.blit src src_pos dst dst_pos blit_len` is valid when `0 <= dst_pos <= length dst`, in contrast to `Array.blit` which is only valid when `0 <= dst_pos <= length dst - blit_len`.

Self-blitting is also allowed: whereas `Dynarray.append a a` is invalid, `Dynarray.blit a 0 a (length a) (length a)` extends `a` with a copy of itself.

This feature came up in the discussion of #13196, when @hyphenrf proposes to add a `Dynarray.insert` which cannot easily&efficiently be implemented outside the abstraction boundary. The present PR does not take a position on whether `Dynarray.insert` should go in the stdlib, but it proposes to add `.blit` as a building block that would be useful for this and other use-cases as well.