### PR TITLE
Support running native debuggers in ocamltest

### DIFF
--- a/.depend
+++ b/.depend
@@ -9914,6 +9914,53 @@ ocamltest/builtin_variables.cmx : \
     ocamltest/builtin_variables.cmi
 ocamltest/builtin_variables.cmi : \
     ocamltest/variables.cmi
+ocamltest/debugger_actions.cmo : \
+    ocamltest/result.cmi \
+    ocamltest/ocamltest_stdlib.cmi \
+    ocamltest/ocaml_variables.cmi \
+    ocamltest/ocaml_directories.cmi \
+    ocamltest/ocaml_commands.cmi \
+    utils/misc.cmi \
+    ocamltest/environments.cmi \
+    ocamltest/debugger_variables.cmi \
+    ocamltest/debugger_flags.cmi \
+    utils/clflags.cmi \
+    ocamltest/builtin_variables.cmi \
+    ocamltest/actions_helpers.cmi \
+    ocamltest/actions.cmi \
+    ocamltest/debugger_actions.cmi
+ocamltest/debugger_actions.cmx : \
+    ocamltest/result.cmx \
+    ocamltest/ocamltest_stdlib.cmx \
+    ocamltest/ocaml_variables.cmx \
+    ocamltest/ocaml_directories.cmx \
+    ocamltest/ocaml_commands.cmx \
+    utils/misc.cmx \
+    ocamltest/environments.cmx \
+    ocamltest/debugger_variables.cmx \
+    ocamltest/debugger_flags.cmx \
+    utils/clflags.cmx \
+    ocamltest/builtin_variables.cmx \
+    ocamltest/actions_helpers.cmx \
+    ocamltest/actions.cmx \
+    ocamltest/debugger_actions.cmi
+ocamltest/debugger_actions.cmi : \
+    ocamltest/actions.cmi
+ocamltest/debugger_flags.cmo : \
+    ocamltest/ocaml_directories.cmi \
+    ocamltest/debugger_flags.cmi
+ocamltest/debugger_flags.cmx : \
+    ocamltest/ocaml_directories.cmx \
+    ocamltest/debugger_flags.cmi
+ocamltest/debugger_flags.cmi :
+ocamltest/debugger_variables.cmo : \
+    ocamltest/variables.cmi \
+    ocamltest/debugger_variables.cmi
+ocamltest/debugger_variables.cmx : \
+    ocamltest/variables.cmx \
+    ocamltest/debugger_variables.cmi
+ocamltest/debugger_variables.cmi : \
+    ocamltest/variables.cmi
 ocamltest/environments.cmo : \
     ocamltest/variables.cmi \
     ocamltest/ocamltest_stdlib.cmi \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -161,9 +161,29 @@ jobs:
         uses: actions/checkout@v4
         with:
           persist-credentials: false
-      - name: OS Dependencies
-        if: runner.os == 'macOS'
-        run: brew install parallel
+
+      - name: MacOS 13 Dependencies
+        if: matrix.os == 'macos-13'
+        run: |
+          brew install parallel
+          # Allows starting up lldb from a remote terminal
+          sudo DevToolsSecurity --enable
+          spctl developer-mode enable-terminal
+          # Select latest supported version
+          sudo xcode-select -s /Applications/Xcode_15.2.app/Contents/Developer
+          lldb --version
+
+      - name: MacOS 14 Dependencies
+        if: matrix.os == 'macos-14'
+        run: |
+          brew install parallel
+          # Allows starting up lldb from a remote terminal
+          sudo DevToolsSecurity --enable
+          spctl developer-mode enable-terminal
+          # Select latest supported version
+          sudo xcode-select -s /Applications/Xcode_15.4.app/Contents/Developer
+          lldb --version
+
       - name: configure tree
         run: |
           CONFIG_ARG='${{ matrix.config_arg }}' MAKE_ARG=-j bash -xe tools/ci/actions/runner.sh configure

--- a/Changes
+++ b/Changes
@@ -315,6 +315,10 @@ ___________
   LLDB support for them.
   (Nick Barnes).
 
+- #13199: Support running native debuggers in ocamltest.
+  (Tim McGilchrist and Sebastien Hinderer, review by Sebastien Hinderer,
+   Gabriel Scherer and Antonin Décimo)
+
 ### Toplevel:
 
 - #12891: Improved styling for initial prompt

--- a/Makefile
+++ b/Makefile
@@ -1920,7 +1920,10 @@ ocamltest_ocaml_PLUGIN = \
   ocaml_compilers.mli ocaml_compilers.ml \
   ocaml_toplevels.mli ocaml_toplevels.ml \
   ocaml_actions.mli ocaml_actions.ml \
-  ocaml_tests.mli ocaml_tests.ml
+  ocaml_tests.mli ocaml_tests.ml \
+  debugger_flags.mli debugger_flags.ml \
+  debugger_variables.mli debugger_variables.ml \
+  debugger_actions.mli debugger_actions.ml \
 
 ocamltest_SOURCES = $(addprefix ocamltest/, \
   $(ocamltest_CORE) $(ocamltest_ocaml_PLUGIN) \

--- a/ocamltest/builtin_actions.ml
+++ b/ocamltest/builtin_actions.ml
@@ -216,12 +216,12 @@ let arch_power = make
     "Target is POWER architecture"
     "Target is not POWER architecture")
 
-let arch_riscv64 = make
-  ~name:"arch_riscv64"
-  ~description:"Pass if target is a RiscV64 architecture"
-  (Actions_helpers.pass_or_skip (String.equal Ocamltest_config.arch "riscv64")
-     "Target is RiscV64 architecture"
-     "Target is not RiscV64 architecture")
+let arch_riscv = make
+  ~name:"arch_riscv"
+  ~description:"Pass if target is a RISC-V architecture"
+  (Actions_helpers.pass_or_skip (String.equal Ocamltest_config.arch "riscv")
+     "Target is RISC-V architecture"
+     "Target is not RISC-V architecture")
 
 let arch_s390x = make
   ~name:"arch_s390x"
@@ -391,7 +391,7 @@ let _ =
     arch_amd64;
     arch_i386;
     arch_power;
-    arch_riscv64;
+    arch_riscv;
     arch_s390x;
     function_sections;
     frame_pointers;

--- a/ocamltest/builtin_actions.ml
+++ b/ocamltest/builtin_actions.ml
@@ -139,6 +139,15 @@ let not_bsd = make
     "not on a BSD system"
     "on a BSD system")
 
+let linux_system = "linux"
+
+let linux = make
+  ~name:"linux"
+  ~description:"Pass if running on a Linux system"
+  (Actions_helpers.pass_or_skip (Ocamltest_config.system = linux_system)
+     "on a Linux system"
+     "not on a Linux system")
+
 let macos_system = "macosx"
 
 let macos = make
@@ -366,6 +375,7 @@ let _ =
     not_windows;
     bsd;
     not_bsd;
+    linux;
     macos;
     not_macos_amd64_tsan;
     arch32;

--- a/ocamltest/builtin_variables.ml
+++ b/ocamltest/builtin_variables.ml
@@ -31,6 +31,9 @@ let cwd = Variables.make ("cwd",
 let commandline = Variables.make ("commandline",
   "Specify the commandline of a tool")
 
+let dev_null = Variables.make ("dev_null",
+                               "Path to /dev/null")
+
 let dst = Variables.make ("dst", "Location where to copy files and directories")
 
 let exit_status = Variables.make ("exit_status",
@@ -119,6 +122,7 @@ let _ = List.iter Variables.register_variable
     arguments;
     cwd;
     commandline;
+    dev_null;
     dst;
     exit_status;
     file;

--- a/ocamltest/builtin_variables.mli
+++ b/ocamltest/builtin_variables.mli
@@ -23,6 +23,8 @@ val cwd : Variables.t
 
 val commandline : Variables.t
 
+val dev_null : Variables.t
+
 val dst : Variables.t
 
 val exit_status : Variables.t

--- a/ocamltest/debugger_actions.ml
+++ b/ocamltest/debugger_actions.ml
@@ -1,0 +1,129 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                           Tim McGilchrist, Tarides                     *)
+(*                                                                        *)
+(*   Copyright 2024 Tarides.                                              *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+open Ocamltest_stdlib
+open Actions
+
+let env_setting env_reader default_setting =
+  Printf.sprintf "%s=%s"
+    env_reader.Clflags.env_var
+    (env_reader.Clflags.print default_setting)
+
+let default_debugger_env = [|
+    "TERM=dumb";
+    env_setting Clflags.color_reader Misc.Color.default_setting;
+    env_setting Clflags.error_style_reader Misc.Error_style.default_setting;
+  |]
+
+let env_with_lib_unix env =
+  let libunixdir = Ocaml_directories.libunix in
+  let newlibs =
+    match Environments.lookup Ocaml_variables.caml_ld_library_path env with
+    | None -> libunixdir
+    | Some libs -> libunixdir ^ " " ^ libs
+  in
+  Environments.add Ocaml_variables.caml_ld_library_path newlibs env
+
+type debugger_type = LLDB | GDB | Bytecode
+
+let debugger_type_to_string = function
+  | LLDB -> "lldb"
+  | GDB -> "gdb"
+  | Bytecode -> "ocamldebug"
+
+let debug debugger_type log env =
+  let program = Environments.safe_lookup Builtin_variables.program env in
+  let what = Printf.sprintf "Debugging program %s with %s" program
+               (debugger_type_to_string debugger_type) in
+  Printf.fprintf log "%s\n%!" what;
+  let commandline = match debugger_type with
+    | LLDB -> [
+        "lldb";
+        Debugger_flags.lldb_default_flags;
+        "-s " ^ (Environments.safe_lookup
+                   Debugger_variables.debugger_script env);
+        program ]
+    | GDB -> [
+        "gdb";
+        Debugger_flags.gdb_default_flags;
+        "-x " ^ (Environments.safe_lookup
+                   Debugger_variables.debugger_script env);
+        program ]
+    | Bytecode -> [
+        Ocaml_commands.ocamlrun_ocamldebug;
+        Debugger_flags.ocamldebug_default_flags;
+        program
+      ]
+  in
+  let systemenv =
+    match debugger_type with
+    | LLDB | GDB ->
+       Environments.append_to_system_env
+         default_debugger_env env
+    | Bytecode ->
+       Environments.append_to_system_env
+         default_debugger_env
+         (env_with_lib_unix env)
+  in
+  let stdin_variable = match debugger_type with
+    | LLDB | GDB ->  Builtin_variables.dev_null
+    | Bytecode -> Debugger_variables.debugger_script
+  in
+  let expected_exit_status = 0 in
+  let exit_status =
+    Actions_helpers.run_cmd
+      ~environment:systemenv
+      ~stdin_variable:stdin_variable
+      ~stdout_variable:Builtin_variables.output
+      ~stderr_variable:Builtin_variables.output
+      ~append:true
+      log (env_with_lib_unix env) commandline in
+  if exit_status=expected_exit_status
+  then (Result.pass, env)
+  else begin
+    let reason =
+      (Actions_helpers.mkreason
+         what (String.concat " " commandline) exit_status) in
+    (Result.fail_with_reason reason, env)
+  end
+
+let lldb =
+  Actions.make ~name:"lldb"
+    ~description:"Run LLDB on the program" (debug LLDB)
+
+let gdb =
+  Actions.make ~name:"gdb"
+    ~description:"Run GDB on the program" (debug GDB)
+
+let ocamldebug =
+  Actions.make ~name:"ocamldebug"
+    ~description:"Run ocamldebug on the program" (debug Bytecode)
+
+let initialize_test_exit_status_variables _log env =
+  Environments.add_bindings
+    [
+      Builtin_variables.test_pass, "0";
+      Builtin_variables.test_fail, "1";
+      Builtin_variables.test_skip, "125";
+    ] env
+
+let _ =
+  Environments.register_initializer Environments.Post
+    "test_exit_status_variables" initialize_test_exit_status_variables;
+  List.iter register
+    [
+      lldb;
+      gdb;
+      ocamldebug;
+    ]

--- a/ocamltest/debugger_actions.mli
+++ b/ocamltest/debugger_actions.mli
@@ -2,10 +2,9 @@
 (*                                                                        *)
 (*                                 OCaml                                  *)
 (*                                                                        *)
-(*             Sebastien Hinderer, projet Gallium, INRIA Paris            *)
+(*                           Tim McGilchrist, Tarides                     *)
 (*                                                                        *)
-(*   Copyright 2018 Institut National de Recherche en Informatique et     *)
-(*     en Automatique.                                                    *)
+(*   Copyright 2024 Tarides.                                              *)
 (*                                                                        *)
 (*   All rights reserved.  This file is distributed under the terms of    *)
 (*   the GNU Lesser General Public License version 2.1, with the          *)
@@ -13,23 +12,11 @@
 (*                                                                        *)
 (**************************************************************************)
 
-(* Helper functions to build OCaml-related commands *)
+(** Run LLDB debugger *)
+val lldb : Actions.t
 
-val ocamlrun_ocamlc : string
+(** Run GDB debugger *)
+val gdb : Actions.t
 
-val ocamlrun_ocamlopt : string
-
-val ocamlrun_ocaml : string
-
-val ocamlrun_expect : string
-
-val ocamlrun_ocamllex : string
-
-val ocamlrun_ocamldoc : string
-
-val ocamlrun_ocamldebug : string
-
-val ocamlrun_ocamlobjinfo : string
-
-val ocamlrun_ocamlmklib : string
-val ocamlrun_codegen : string
+(** Run ocamldebug (bytecode) debugger *)
+val ocamldebug : Actions.t

--- a/ocamltest/debugger_flags.ml
+++ b/ocamltest/debugger_flags.ml
@@ -2,10 +2,9 @@
 (*                                                                        *)
 (*                                 OCaml                                  *)
 (*                                                                        *)
-(*             Sebastien Hinderer, projet Gallium, INRIA Paris            *)
+(*                           Tim McGilchrist, Tarides                     *)
 (*                                                                        *)
-(*   Copyright 2018 Institut National de Recherche en Informatique et     *)
-(*     en Automatique.                                                    *)
+(*   Copyright 2024 Tarides.                                              *)
 (*                                                                        *)
 (*   All rights reserved.  This file is distributed under the terms of    *)
 (*   the GNU Lesser General Public License version 2.1, with the          *)
@@ -13,23 +12,10 @@
 (*                                                                        *)
 (**************************************************************************)
 
-(* Helper functions to build OCaml-related commands *)
+let ocamldebug_default_flags =
+  "-no-version -no-prompt -no-time -no-breakpoint-message " ^
+    ("-I " ^ Ocaml_directories.stdlib ^ " ")
 
-val ocamlrun_ocamlc : string
+let lldb_default_flags = "--no-use-colors"
 
-val ocamlrun_ocamlopt : string
-
-val ocamlrun_ocaml : string
-
-val ocamlrun_expect : string
-
-val ocamlrun_ocamllex : string
-
-val ocamlrun_ocamldoc : string
-
-val ocamlrun_ocamldebug : string
-
-val ocamlrun_ocamlobjinfo : string
-
-val ocamlrun_ocamlmklib : string
-val ocamlrun_codegen : string
+let gdb_default_flags = "--quiet --batch"

--- a/ocamltest/debugger_flags.mli
+++ b/ocamltest/debugger_flags.mli
@@ -2,10 +2,9 @@
 (*                                                                        *)
 (*                                 OCaml                                  *)
 (*                                                                        *)
-(*             Sebastien Hinderer, projet Gallium, INRIA Paris            *)
+(*                           Tim McGilchrist, Tarides                     *)
 (*                                                                        *)
-(*   Copyright 2018 Institut National de Recherche en Informatique et     *)
-(*     en Automatique.                                                    *)
+(*   Copyright 2024 Tarides.                                              *)
 (*                                                                        *)
 (*   All rights reserved.  This file is distributed under the terms of    *)
 (*   the GNU Lesser General Public License version 2.1, with the          *)
@@ -13,23 +12,11 @@
 (*                                                                        *)
 (**************************************************************************)
 
-(* Helper functions to build OCaml-related commands *)
+(* Flags used in LLDB commands *)
+val lldb_default_flags : string
 
-val ocamlrun_ocamlc : string
+(* Flags used in GDB commands *)
+val gdb_default_flags : string
 
-val ocamlrun_ocamlopt : string
-
-val ocamlrun_ocaml : string
-
-val ocamlrun_expect : string
-
-val ocamlrun_ocamllex : string
-
-val ocamlrun_ocamldoc : string
-
-val ocamlrun_ocamldebug : string
-
-val ocamlrun_ocamlobjinfo : string
-
-val ocamlrun_ocamlmklib : string
-val ocamlrun_codegen : string
+(* Flags used in Ocamldebug (bytecode debugger) commands *)
+val ocamldebug_default_flags : string

--- a/ocamltest/debugger_variables.ml
+++ b/ocamltest/debugger_variables.ml
@@ -2,10 +2,9 @@
 (*                                                                        *)
 (*                                 OCaml                                  *)
 (*                                                                        *)
-(*             Sebastien Hinderer, projet Gallium, INRIA Paris            *)
+(*                           Tim McGilchrist, Tarides                     *)
 (*                                                                        *)
-(*   Copyright 2018 Institut National de Recherche en Informatique et     *)
-(*     en Automatique.                                                    *)
+(*   Copyright 2024 Tarides.                                              *)
 (*                                                                        *)
 (*   All rights reserved.  This file is distributed under the terms of    *)
 (*   the GNU Lesser General Public License version 2.1, with the          *)
@@ -13,23 +12,10 @@
 (*                                                                        *)
 (**************************************************************************)
 
-(* Helper functions to build OCaml-related commands *)
+let debugger_script = Variables.make ("debugger_script",
+  "Where the debugger should read its commands")
 
-val ocamlrun_ocamlc : string
-
-val ocamlrun_ocamlopt : string
-
-val ocamlrun_ocaml : string
-
-val ocamlrun_expect : string
-
-val ocamlrun_ocamllex : string
-
-val ocamlrun_ocamldoc : string
-
-val ocamlrun_ocamldebug : string
-
-val ocamlrun_ocamlobjinfo : string
-
-val ocamlrun_ocamlmklib : string
-val ocamlrun_codegen : string
+let _ = List.iter Variables.register_variable
+  [
+    debugger_script;
+  ]

--- a/ocamltest/debugger_variables.mli
+++ b/ocamltest/debugger_variables.mli
@@ -2,10 +2,9 @@
 (*                                                                        *)
 (*                                 OCaml                                  *)
 (*                                                                        *)
-(*             Sebastien Hinderer, projet Gallium, INRIA Paris            *)
+(*                           Tim McGilchrist, Tarides                     *)
 (*                                                                        *)
-(*   Copyright 2018 Institut National de Recherche en Informatique et     *)
-(*     en Automatique.                                                    *)
+(*   Copyright 2024 Tarides.                                              *)
 (*                                                                        *)
 (*   All rights reserved.  This file is distributed under the terms of    *)
 (*   the GNU Lesser General Public License version 2.1, with the          *)
@@ -13,23 +12,8 @@
 (*                                                                        *)
 (**************************************************************************)
 
-(* Helper functions to build OCaml-related commands *)
+(* Definition of variables used by debugger actions *)
 
-val ocamlrun_ocamlc : string
+(* The variables are listed in alphabetical order *)
 
-val ocamlrun_ocamlopt : string
-
-val ocamlrun_ocaml : string
-
-val ocamlrun_expect : string
-
-val ocamlrun_ocamllex : string
-
-val ocamlrun_ocamldoc : string
-
-val ocamlrun_ocamldebug : string
-
-val ocamlrun_ocamlobjinfo : string
-
-val ocamlrun_ocamlmklib : string
-val ocamlrun_codegen : string
+val debugger_script : Variables.t

--- a/ocamltest/main.ml
+++ b/ocamltest/main.ml
@@ -235,6 +235,7 @@ let test_file test_filename =
        let make = try Sys.getenv "MAKE" with Not_found -> "make" in
        let initial_environment = Environments.from_bindings
            [
+             Builtin_variables.dev_null, "/dev/null";
              Builtin_variables.make, make;
              Builtin_variables.test_file, test_basename;
              Builtin_variables.reference, reference_filename;

--- a/ocamltest/ocaml_actions.ml
+++ b/ocamltest/ocaml_actions.ml
@@ -550,6 +550,7 @@ let debug debugger_type log env =
     | LLDB -> [
         Ocaml_commands.lldb_run;
         Ocaml_flags.lldb_default_flags;
+        "-s " ^ (Environments.safe_lookup Ocaml_variables.debugger_script env);
         program ]
     | GDB -> [
         Ocaml_commands.gdb_run;
@@ -565,15 +566,18 @@ let debug debugger_type log env =
       default_ocaml_env
       (env_with_lib_unix env)
   in
+  let stdin_variable = match debugger_type with
+    | LLDB | GDB ->  Builtin_variables.dev_null
+    | Bytecode -> Ocaml_variables.debugger_script
+  in
   let expected_exit_status = 0 in
   let exit_status =
     Actions_helpers.run_cmd
       ~environment:systemenv
-      ~stdin_variable:Ocaml_variables.debugger_script
+      ~stdin_variable:stdin_variable
       ~stdout_variable:Builtin_variables.output
       ~stderr_variable:Builtin_variables.output
       ~append:true
-      ~timeout:1
       log (env_with_lib_unix env) commandline in
   if exit_status=expected_exit_status
   then (Result.pass, env)

--- a/ocamltest/ocaml_actions.ml
+++ b/ocamltest/ocaml_actions.ml
@@ -534,73 +534,6 @@ let env_with_lib_unix env =
   in
   Environments.add Ocaml_variables.caml_ld_library_path newlibs env
 
-type debugger_type = LLDB | GDB | Bytecode
-
-let debugger_type_to_string = function
-  | LLDB -> "lldb"
-  | GDB -> "gdb"
-  | Bytecode -> "ocamldebug"
-
-let debug debugger_type log env =
-  let program = Environments.safe_lookup Builtin_variables.program env in
-  let what = Printf.sprintf "Debugging program %s with %s" program
-               (debugger_type_to_string debugger_type) in
-  Printf.fprintf log "%s\n%!" what;
-  let commandline = match debugger_type with
-    | LLDB -> [
-        Ocaml_commands.lldb_run;
-        Ocaml_flags.lldb_default_flags;
-        "-s " ^ (Environments.safe_lookup Ocaml_variables.debugger_script env);
-        program ]
-    | GDB -> [
-        Ocaml_commands.gdb_run;
-        Ocaml_flags.gdb_default_flags;
-        "-x " ^ (Environments.safe_lookup Ocaml_variables.debugger_script env);
-        program ]
-    | Bytecode -> [
-        Ocaml_commands.ocamlrun_ocamldebug;
-        Ocaml_flags.ocamldebug_default_flags;
-        program ]
-  in
-  let systemenv =
-    Environments.append_to_system_env
-      default_ocaml_env
-      (env_with_lib_unix env)
-  in
-  let stdin_variable = match debugger_type with
-    | LLDB | GDB ->  Builtin_variables.dev_null
-    | Bytecode -> Ocaml_variables.debugger_script
-  in
-  let expected_exit_status = 0 in
-  let exit_status =
-    Actions_helpers.run_cmd
-      ~environment:systemenv
-      ~stdin_variable:stdin_variable
-      ~stdout_variable:Builtin_variables.output
-      ~stderr_variable:Builtin_variables.output
-      ~append:true
-      log (env_with_lib_unix env) commandline in
-  if exit_status=expected_exit_status
-  then (Result.pass, env)
-  else begin
-    let reason =
-      (Actions_helpers.mkreason
-         what (String.concat " " commandline) exit_status) in
-    (Result.fail_with_reason reason, env)
-  end
-
-let lldb =
-  Actions.make ~name:"lldb" ~description:"Run LLDB on the program"
-    (debug_native LLDB)
-
-let gdb =
-  Actions.make ~name:"gdb" ~description:"Run GDB on the program"
-    (debug_native GDB)
-
-let ocamldebug =
-  Actions.make ~name:"ocamldebug" ~description:"Run ocamldebug on the program"
-    (debug Bytecode)
-
 let objinfo log env =
   let tools_directory = Ocaml_directories.tools in
   let program = Environments.safe_lookup Builtin_variables.program env in
@@ -1474,9 +1407,6 @@ let _ =
     setup_ocamldoc_build_env;
     run_ocamldoc;
     check_ocamldoc_output;
-    ocamldebug;
-    lldb;
-    gdb;
     ocamlmklib;
     codegen;
     cc;

--- a/ocamltest/ocaml_actions.ml
+++ b/ocamltest/ocaml_actions.ml
@@ -555,6 +555,7 @@ let debug debugger_type log env =
     | GDB -> [
         Ocaml_commands.gdb_run;
         Ocaml_flags.gdb_default_flags;
+        "-x " ^ (Environments.safe_lookup Ocaml_variables.debugger_script env);
         program ]
     | Bytecode -> [
         Ocaml_commands.ocamlrun_ocamldebug;

--- a/ocamltest/ocaml_commands.ml
+++ b/ocamltest/ocaml_commands.ml
@@ -43,3 +43,7 @@ let ocamlrun_ocamlmklib =
 
 let ocamlrun_codegen =
   ocamlrun Ocaml_files.codegen
+
+let lldb_run = "lldb"
+
+let gdb_run = "gdb"

--- a/ocamltest/ocaml_commands.ml
+++ b/ocamltest/ocaml_commands.ml
@@ -43,7 +43,3 @@ let ocamlrun_ocamlmklib =
 
 let ocamlrun_codegen =
   ocamlrun Ocaml_files.codegen
-
-let lldb_run = "lldb"
-
-let gdb_run = "gdb"

--- a/ocamltest/ocaml_commands.mli
+++ b/ocamltest/ocaml_commands.mli
@@ -33,3 +33,8 @@ val ocamlrun_ocamlobjinfo : string
 
 val ocamlrun_ocamlmklib : string
 val ocamlrun_codegen : string
+
+(* Helper functions to build native debugger-related commands *)
+val lldb_run : string
+
+val gdb_run : string

--- a/ocamltest/ocaml_flags.ml
+++ b/ocamltest/ocaml_flags.ml
@@ -53,12 +53,4 @@ let runtime_flags env backend c_files =
 
 let toplevel_default_flags = "-noinit -no-version -noprompt"
 
-let ocamldebug_default_flags =
-  "-no-version -no-prompt -no-time -no-breakpoint-message " ^
-  ("-I " ^ Ocaml_directories.stdlib ^ " ")
-
 let ocamlobjinfo_default_flags = "-null-crc"
-
-let lldb_default_flags = "--no-use-colors"
-
-let gdb_default_flags = "--quiet --batch"

--- a/ocamltest/ocaml_flags.ml
+++ b/ocamltest/ocaml_flags.ml
@@ -58,3 +58,7 @@ let ocamldebug_default_flags =
   ("-I " ^ Ocaml_directories.stdlib ^ " ")
 
 let ocamlobjinfo_default_flags = "-null-crc"
+
+let lldb_default_flags = "--no-use-colors"
+
+let gdb_default_flags = ""

--- a/ocamltest/ocaml_flags.ml
+++ b/ocamltest/ocaml_flags.ml
@@ -61,4 +61,4 @@ let ocamlobjinfo_default_flags = "-null-crc"
 
 let lldb_default_flags = "--no-use-colors"
 
-let gdb_default_flags = ""
+let gdb_default_flags = "--quiet --batch"

--- a/ocamltest/ocaml_flags.mli
+++ b/ocamltest/ocaml_flags.mli
@@ -29,3 +29,9 @@ val toplevel_default_flags : string
 val ocamldebug_default_flags : string
 
 val ocamlobjinfo_default_flags : string
+
+(* Flags used in LLDB commands *)
+val lldb_default_flags : string
+
+(* Flags used in GDB commands *)
+val gdb_default_flags : string

--- a/ocamltest/ocaml_flags.mli
+++ b/ocamltest/ocaml_flags.mli
@@ -26,12 +26,4 @@ val runtime_flags :
 
 val toplevel_default_flags : string
 
-val ocamldebug_default_flags : string
-
 val ocamlobjinfo_default_flags : string
-
-(* Flags used in LLDB commands *)
-val lldb_default_flags : string
-
-(* Flags used in GDB commands *)
-val gdb_default_flags : string

--- a/ocamltest/ocaml_variables.ml
+++ b/ocamltest/ocaml_variables.ml
@@ -203,9 +203,6 @@ let ocamlsrcdir = make ("ocamlsrcdir",
 let ocamldebug_flags = make ("ocamldebug_flags",
   "Flags for ocamldebug")
 
-let debugger_script = make ("debugger_script",
-  "Where the debugger should read its commands")
-
 let os_type = make ("os_type",
   "The OS we are running on")
 
@@ -301,7 +298,6 @@ let _ = List.iter register_variable
     ocamldoc_reference;
     ocamldoc_exit_status;
     ocamldebug_flags;
-    debugger_script;
     ocaml_script_as_argument;
     os_type;
     plugins;

--- a/ocamltest/ocaml_variables.ml
+++ b/ocamltest/ocaml_variables.ml
@@ -203,11 +203,8 @@ let ocamlsrcdir = make ("ocamlsrcdir",
 let ocamldebug_flags = make ("ocamldebug_flags",
   "Flags for ocamldebug")
 
-let ocamldebug_script = make ("ocamldebug_script",
-  "Where ocamldebug should read its commands")
-
 let debugger_script = make ("debugger_script",
-  "Where lldb should read its commands")
+  "Where the debugger should read its commands")
 
 let os_type = make ("os_type",
   "The OS we are running on")
@@ -304,7 +301,6 @@ let _ = List.iter register_variable
     ocamldoc_reference;
     ocamldoc_exit_status;
     ocamldebug_flags;
-    ocamldebug_script;
     debugger_script;
     ocaml_script_as_argument;
     os_type;

--- a/ocamltest/ocaml_variables.ml
+++ b/ocamltest/ocaml_variables.ml
@@ -206,6 +206,9 @@ let ocamldebug_flags = make ("ocamldebug_flags",
 let ocamldebug_script = make ("ocamldebug_script",
   "Where ocamldebug should read its commands")
 
+let debugger_script = make ("debugger_script",
+  "Where lldb should read its commands")
+
 let os_type = make ("os_type",
   "The OS we are running on")
 
@@ -302,6 +305,7 @@ let _ = List.iter register_variable
     ocamldoc_exit_status;
     ocamldebug_flags;
     ocamldebug_script;
+    debugger_script;
     ocaml_script_as_argument;
     os_type;
     plugins;

--- a/ocamltest/ocaml_variables.mli
+++ b/ocamltest/ocaml_variables.mli
@@ -119,7 +119,6 @@ val ocamlsrcdir : Variables.t
 
 val ocamldebug_flags : Variables.t
 
-val debugger_script : Variables.t
 
 val os_type : Variables.t
 

--- a/ocamltest/ocaml_variables.mli
+++ b/ocamltest/ocaml_variables.mli
@@ -121,6 +121,8 @@ val ocamldebug_flags : Variables.t
 
 val ocamldebug_script : Variables.t
 
+val debugger_script : Variables.t
+
 val os_type : Variables.t
 
 val ocamldoc_flags : Variables.t

--- a/ocamltest/ocaml_variables.mli
+++ b/ocamltest/ocaml_variables.mli
@@ -119,8 +119,6 @@ val ocamlsrcdir : Variables.t
 
 val ocamldebug_flags : Variables.t
 
-val ocamldebug_script : Variables.t
-
 val debugger_script : Variables.t
 
 val os_type : Variables.t

--- a/testsuite/tests/asmcomp/func_sections.ml
+++ b/testsuite/tests/asmcomp/func_sections.ml
@@ -22,7 +22,7 @@
    reference = "${test_source_directory}/func_sections.arm.reference";
    native;
  }{
-   arch_riscv64;
+   arch_riscv;
    reference = "${test_source_directory}/func_sections.reference";
    native;
  }{

--- a/testsuite/tests/native-debugger/gdb-script
+++ b/testsuite/tests/native-debugger/gdb-script
@@ -1,0 +1,15 @@
+break *(&caml_start_program+0)
+break caml_program
+break ocaml_to_c
+break meander.ml:5
+set debuginfod enabled off
+run
+backtrace
+continue
+backtrace
+continue
+backtrace
+continue
+backtrace
+continue
+quit

--- a/testsuite/tests/native-debugger/has_gdb.sh
+++ b/testsuite/tests/native-debugger/has_gdb.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+if ! which gdb > /dev/null 2>&1; then
+    echo "gdb not available" > ${ocamltest_response}
+    exit ${TEST_SKIP}
+else
+    exit ${TEST_PASS}
+fi

--- a/testsuite/tests/native-debugger/has_gdb.sh
+++ b/testsuite/tests/native-debugger/has_gdb.sh
@@ -1,7 +1,18 @@
 #!/bin/sh
+
+version () {
+    echo "$@" | awk -F. '{ printf("%d%03d%03d\n", $1,$2,$3); }'
+}
+
 if ! which gdb > /dev/null 2>&1; then
-    echo "gdb not available" > ${ocamltest_response}
+    echo "gdb not available" > "${ocamltest_response}"
     exit ${TEST_SKIP}
 else
-    exit ${TEST_PASS}
+    # Linux check for GDB version
+    GDB_VERSION=$(gdb --version |head -n 1 | awk -F' ' '{print $5}')
+    if [ $(version "$GDB_VERSION") -ge $(version "12.1") ]; then
+        exit ${TEST_PASS}
+    else
+        exit ${TEST_SKIP}
+    fi
 fi

--- a/testsuite/tests/native-debugger/has_lldb.sh
+++ b/testsuite/tests/native-debugger/has_lldb.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+OCAML_OS="$1"
+
+# Extract the first 4 parts of an LLDB version number
+version () {
+    echo "$@" | awk -F. '{ printf("%d%03d%03d%03d\n", $1,$2,$3,$4); }'
+}
+
+if ! which lldb > /dev/null 2>&1; then
+    echo "lldb not available" > "${ocamltest_response}"
+    exit ${TEST_SKIP}
+else
+    if [ "$OCAML_OS" = "macos" ]; then
+        # macOS version
+        LLDB_VERSION=$(lldb --version |head -n 1 | awk -F'-' '{print $2}')
+        # We need XCode 15.3 or greater
+        # lldb-1500.0.404.7
+        # Apple Swift version 5.10 (swiftlang-5.10.0.13 clang-1500.3.9.4)
+        if [ $(version "$LLDB_VERSION") -ge $(version "1500.0.404.7") ]; then
+            exit ${TEST_PASS}
+        else
+            exit ${TEST_SKIP}
+        fi
+    elif [ "$OCAML_OS" = "linux" ]; then
+        # Linux version
+        LLDB_VERSION=$(lldb --version |awk -F' ' '{print $3}')
+        if [ $(version "$LLDB_VERSION") -ge $(version "14.0.0") ]; then
+            exit ${TEST_PASS}
+        else
+            exit ${TEST_SKIP}
+        fi
+    else
+        exit ${TEST_SKIP}
+    fi
+
+
+fi

--- a/testsuite/tests/native-debugger/linux-gdb-amd64-test.ml
+++ b/testsuite/tests/native-debugger/linux-gdb-amd64-test.ml
@@ -1,0 +1,19 @@
+(* TEST
+   native-compiler;
+   linux;
+   arch_amd64;
+   script = "sh ${test_source_directory}/has_gdb.sh";
+   script;
+   readonly_files = "meander.ml meander_c.c lldb_test.py";
+   setup-ocamlopt.byte-build-env;
+   program = "${test_build_directory}/meander";
+   flags = "-g";
+   all_modules = "meander.ml meander_c.c";
+   ocamlopt.byte;
+   debugger_script = "${test_source_directory}/gdb-script";
+   gdb;
+   script = "sh ${test_source_directory}/sanitize.sh ${test_source_directory} \
+             ${test_build_directory} ${ocamltest_response} linux-gdb-amd64-test";
+   script;
+   check-program-output;
+ *)

--- a/testsuite/tests/native-debugger/linux-gdb-amd64-test.reference
+++ b/testsuite/tests/native-debugger/linux-gdb-amd64-test.reference
@@ -1,0 +1,60 @@
+Breakpoint 1 at 0x00000000000000
+Breakpoint 2 at 0x00000000000000
+Breakpoint 3 at 0x00000000000000: file meander_c.c, line 4.
+Breakpoint 4 at 0x00000000000000: file meander.ml, line 5.
+[Thread debugging using libthread_db enabled]
+Using host libthread_db library "/lib/$ARCH-linux-gnu/libthread_db.so.1".
+
+Breakpoint 1, <signal handler called>
+#0  <signal handler called>
+#1  0x00000000000000 in caml_startup_common (pooling=<optimised out>, argv=0x00000000000000) at runtime/startup_nat.c:128
+#2  caml_startup_common (argv=0x00000000000000, pooling=<optimised out>) at runtime/startup_nat.c:87
+#3  0x00000000000000 in caml_startup_exn (argv=<optimised out>) at runtime/startup_nat.c:135
+#4  caml_startup (argv=<optimised out>) at runtime/startup_nat.c:140
+#5  caml_main (argv=<optimised out>) at runtime/startup_nat.c:147
+#6  0x00000000000000 in main (argc=<optimised out>, argv=<optimised out>) at runtime/main.c:37
+
+Breakpoint 2, 0x00000000000000 in caml_program ()
+#0  0x00000000000000 in caml_program ()
+#1  <signal handler called>
+#2  0x00000000000000 in caml_startup_common (pooling=<optimised out>, argv=0x00000000000000) at runtime/startup_nat.c:128
+#3  caml_startup_common (argv=0x00000000000000, pooling=<optimised out>) at runtime/startup_nat.c:87
+#4  0x00000000000000 in caml_startup_exn (argv=<optimised out>) at runtime/startup_nat.c:135
+#5  caml_startup (argv=<optimised out>) at runtime/startup_nat.c:140
+#6  caml_main (argv=<optimised out>) at runtime/startup_nat.c:147
+#7  0x00000000000000 in main (argc=<optimised out>, argv=<optimised out>) at runtime/main.c:37
+
+Breakpoint 3, ocaml_to_c (unit=1) at meander_c.c:4
+4	value ocaml_to_c (value unit) {
+#0  ocaml_to_c (unit=1) at meander_c.c:4
+#1  <signal handler called>
+#2  0x00000000000000 in camlMeander.omain_278 () at meander.ml:10
+#3  0x00000000000000 in camlMeander.entry () at meander.ml:13
+#4  0x00000000000000 in caml_program ()
+#5  <signal handler called>
+#6  0x00000000000000 in caml_startup_common (pooling=<optimised out>, argv=0x00000000000000) at runtime/startup_nat.c:128
+#7  caml_startup_common (argv=0x00000000000000, pooling=<optimised out>) at runtime/startup_nat.c:87
+#8  0x00000000000000 in caml_startup_exn (argv=<optimised out>) at runtime/startup_nat.c:135
+#9  caml_startup (argv=<optimised out>) at runtime/startup_nat.c:140
+#10 caml_main (argv=<optimised out>) at runtime/startup_nat.c:147
+#11 0x00000000000000 in main (argc=<optimised out>, argv=<optimised out>) at runtime/main.c:37
+
+Breakpoint 4, camlMeander.c_to_ocaml_273 () at meander.ml:5
+5	let c_to_ocaml () = raise E1
+#0  camlMeander.c_to_ocaml_273 () at meander.ml:5
+#1  <signal handler called>
+#2  0x00000000000000 in caml_callback_exn (closure=<optimised out>, arg=<optimised out>, arg@entry=1) at runtime/callback.c:206
+#3  0x00000000000000 in caml_callback (closure=<optimised out>, arg=arg@entry=1) at runtime/callback.c:347
+#4  0x00000000000000 in ocaml_to_c (unit=<optimised out>) at meander_c.c:5
+#5  <signal handler called>
+#6  0x00000000000000 in camlMeander.omain_278 () at meander.ml:10
+#7  0x00000000000000 in camlMeander.entry () at meander.ml:13
+#8  0x00000000000000 in caml_program ()
+#9  <signal handler called>
+#10 0x00000000000000 in caml_startup_common (pooling=<optimised out>, argv=0x00000000000000) at runtime/startup_nat.c:128
+#11 caml_startup_common (argv=0x00000000000000, pooling=<optimised out>) at runtime/startup_nat.c:87
+#12 0x00000000000000 in caml_startup_exn (argv=<optimised out>) at runtime/startup_nat.c:135
+#13 caml_startup (argv=<optimised out>) at runtime/startup_nat.c:140
+#14 caml_main (argv=<optimised out>) at runtime/startup_nat.c:147
+#15 0x00000000000000 in main (argc=<optimised out>, argv=<optimised out>) at runtime/main.c:37
+[Inferior 1 (process XXXX) exited normally]

--- a/testsuite/tests/native-debugger/linux-gdb-arm64-test.ml
+++ b/testsuite/tests/native-debugger/linux-gdb-arm64-test.ml
@@ -1,0 +1,19 @@
+(* TEST
+   native-compiler;
+   linux;
+   arch_arm64;
+   script = "sh ${test_source_directory}/has_gdb.sh";
+   script;
+   readonly_files = "meander.ml meander_c.c lldb_test.py";
+   setup-ocamlopt.byte-build-env;
+   program = "${test_build_directory}/meander";
+   flags = "-g";
+   all_modules = "meander.ml meander_c.c";
+   ocamlopt.byte;
+   debugger_script = "${test_source_directory}/gdb-script";
+   gdb;
+   script = "sh ${test_source_directory}/sanitize.sh ${test_source_directory} \
+   ${test_build_directory} ${ocamltest_response} linux-gdb-arm64-test";
+   script;
+   check-program-output;
+ *)

--- a/testsuite/tests/native-debugger/linux-gdb-arm64-test.reference
+++ b/testsuite/tests/native-debugger/linux-gdb-arm64-test.reference
@@ -1,0 +1,60 @@
+Breakpoint 1 at 0x00000000000000
+Breakpoint 2 at 0x00000000000000
+Breakpoint 3 at 0x00000000000000: file meander_c.c, line 5.
+Breakpoint 4 at 0x00000000000000: file meander.ml, line 5.
+[Thread debugging using libthread_db enabled]
+Using host libthread_db library "/lib/aarch64-linux-gnu/libthread_db.so.1".
+
+Breakpoint 1, <signal handler called>
+#0  <signal handler called>
+#1  0x00000000000000 in caml_startup_common (pooling=0, argv=0x00000000000000) at runtime/startup_nat.c:127
+#2  caml_startup_common (argv=0x00000000000000, pooling=0) at runtime/startup_nat.c:86
+#3  0x00000000000000 in caml_startup_exn (argv=<optimized out>) at runtime/startup_nat.c:134
+#4  caml_startup (argv=<optimized out>) at runtime/startup_nat.c:139
+#5  caml_main (argv=<optimized out>) at runtime/startup_nat.c:146
+#6  0x00000000000000 in main (argc=<optimized out>, argv=<optimized out>) at runtime/main.c:37
+
+Breakpoint 2, 0x00000000000000 in caml_program ()
+#0  0x00000000000000 in caml_program ()
+#1  <signal handler called>
+#2  0x00000000000000 in caml_startup_common (pooling=0, argv=0x00000000000000) at runtime/startup_nat.c:127
+#3  caml_startup_common (argv=0x00000000000000, pooling=0) at runtime/startup_nat.c:86
+#4  0x00000000000000 in caml_startup_exn (argv=<optimized out>) at runtime/startup_nat.c:134
+#5  caml_startup (argv=<optimized out>) at runtime/startup_nat.c:139
+#6  caml_main (argv=<optimized out>) at runtime/startup_nat.c:146
+#7  0x00000000000000 in main (argc=<optimized out>, argv=<optimized out>) at runtime/main.c:37
+
+Breakpoint 3, ocaml_to_c (unit=1) at meander_c.c:5
+5	    caml_callback(*caml_named_value
+#0  ocaml_to_c (unit=1) at meander_c.c:5
+#1  <signal handler called>
+#2  0x00000000000000 in camlMeander.omain_278 () at meander.ml:10
+#3  0x00000000000000 in camlMeander.entry () at meander.ml:13
+#4  0x00000000000000 in caml_program ()
+#5  <signal handler called>
+#6  0x00000000000000 in caml_startup_common (pooling=4, argv=0x00000000000000) at runtime/startup_nat.c:127
+#7  caml_startup_common (argv=0x00000000000000, pooling=4) at runtime/startup_nat.c:86
+#8  0x00000000000000 in caml_startup_exn (argv=<optimized out>) at runtime/startup_nat.c:134
+#9  caml_startup (argv=<optimized out>) at runtime/startup_nat.c:139
+#10 caml_main (argv=<optimized out>) at runtime/startup_nat.c:146
+#11 0x00000000000000 in main (argc=<optimized out>, argv=<optimized out>) at runtime/main.c:37
+
+Breakpoint 4, camlMeander.c_to_ocaml_273 () at meander.ml:5
+5	let c_to_ocaml () = raise E1
+#0  camlMeander.c_to_ocaml_273 () at meander.ml:5
+#1  <signal handler called>
+#2  0x00000000000000 in caml_callback_exn (closure=<optimized out>, arg=<optimized out>, arg@entry=1) at runtime/callback.c:205
+#3  0x00000000000000 in caml_callback (closure=<optimized out>, arg=arg@entry=1) at runtime/callback.c:346
+#4  0x00000000000000 in ocaml_to_c (unit=<optimized out>) at meander_c.c:5
+#5  <signal handler called>
+#6  0x00000000000000 in camlMeander.omain_278 () at meander.ml:10
+#7  0x00000000000000 in camlMeander.entry () at meander.ml:13
+#8  0x00000000000000 in caml_program ()
+#9  <signal handler called>
+#10 0x00000000000000 in caml_startup_common (pooling=4, argv=0x00000000000000) at runtime/startup_nat.c:127
+#11 caml_startup_common (argv=0x00000000000000, pooling=4) at runtime/startup_nat.c:86
+#12 0x00000000000000 in caml_startup_exn (argv=<optimized out>) at runtime/startup_nat.c:134
+#13 caml_startup (argv=<optimized out>) at runtime/startup_nat.c:139
+#14 caml_main (argv=<optimized out>) at runtime/startup_nat.c:146
+#15 0x00000000000000 in main (argc=<optimized out>, argv=<optimized out>) at runtime/main.c:37
+[Inferior 1 (process XXXX) exited normally]

--- a/testsuite/tests/native-debugger/linux-gdb-riscv-test.ml
+++ b/testsuite/tests/native-debugger/linux-gdb-riscv-test.ml
@@ -1,0 +1,19 @@
+(* TEST
+   native-compiler;
+   linux;
+   arch_riscv;
+   script = "sh ${test_source_directory}/has_gdb.sh";
+   script;
+   readonly_files = "meander.ml meander_c.c lldb_test.py";
+   setup-ocamlopt.byte-build-env;
+   program = "${test_build_directory}/meander";
+   flags = "-g";
+   all_modules = "meander.ml meander_c.c";
+   ocamlopt.byte;
+   debugger_script = "${test_source_directory}/gdb-script";
+   gdb;
+   script = "sh ${test_source_directory}/sanitize.sh ${test_source_directory} \
+   ${test_build_directory} ${ocamltest_response} linux-gdb-riscv-test";
+   script;
+   check-program-output;
+ *)

--- a/testsuite/tests/native-debugger/linux-gdb-riscv-test.reference
+++ b/testsuite/tests/native-debugger/linux-gdb-riscv-test.reference
@@ -1,0 +1,60 @@
+Breakpoint 1 at 0x00000000000000
+Breakpoint 2 at 0x00000000000000
+Breakpoint 3 at 0x00000000000000: file meander_c.c, line 5.
+Breakpoint 4 at 0x00000000000000: file meander.ml, line 5.
+[Thread debugging using libthread_db enabled]
+Using host libthread_db library "/lib/$ARCH-linux-gnu/libthread_db.so.1".
+
+Breakpoint 1, <signal handler called>
+#0  <signal handler called>
+#1  0x00000000000000 in caml_startup_common (pooling=<optimized out>, argv=0x00000000000000) at runtime/startup_nat.c:128
+#2  caml_startup_common (argv=0x00000000000000, pooling=<optimized out>) at runtime/startup_nat.c:87
+#3  0x00000000000000 in caml_startup_exn (argv=<optimized out>) at runtime/startup_nat.c:135
+#4  caml_startup (argv=<optimized out>) at runtime/startup_nat.c:140
+#5  caml_main (argv=<optimized out>) at runtime/startup_nat.c:147
+#6  0x00000000000000 in main (argc=<optimized out>, argv=<optimized out>) at runtime/main.c:37
+
+Breakpoint 2, 0x00000000000000 in caml_program ()
+#0  0x00000000000000 in caml_program ()
+#1  <signal handler called>
+#2  0x00000000000000 in caml_startup_common (pooling=<optimized out>, argv=0x00000000000000) at runtime/startup_nat.c:128
+#3  caml_startup_common (argv=0x00000000000000, pooling=<optimized out>) at runtime/startup_nat.c:87
+#4  0x00000000000000 in caml_startup_exn (argv=<optimized out>) at runtime/startup_nat.c:135
+#5  caml_startup (argv=<optimized out>) at runtime/startup_nat.c:140
+#6  caml_main (argv=<optimized out>) at runtime/startup_nat.c:147
+#7  0x00000000000000 in main (argc=<optimized out>, argv=<optimized out>) at runtime/main.c:37
+
+Breakpoint 3, ocaml_to_c (unit=1) at meander_c.c:5
+5	    caml_callback(*caml_named_value
+#0  ocaml_to_c (unit=1) at meander_c.c:5
+#1  <signal handler called>
+#2  0x00000000000000 in camlMeander.omain_278 () at meander.ml:10
+#3  0x00000000000000 in camlMeander.entry () at meander.ml:13
+#4  0x00000000000000 in caml_program ()
+#5  <signal handler called>
+#6  0x00000000000000 in caml_startup_common (pooling=<optimized out>, argv=0x00000000000000) at runtime/startup_nat.c:128
+#7  caml_startup_common (argv=0x00000000000000, pooling=<optimized out>) at runtime/startup_nat.c:87
+#8  0x00000000000000 in caml_startup_exn (argv=<optimized out>) at runtime/startup_nat.c:135
+#9  caml_startup (argv=<optimized out>) at runtime/startup_nat.c:140
+#10 caml_main (argv=<optimized out>) at runtime/startup_nat.c:147
+#11 0x00000000000000 in main (argc=<optimized out>, argv=<optimized out>) at runtime/main.c:37
+
+Breakpoint 4, camlMeander.c_to_ocaml_273 () at meander.ml:5
+5	let c_to_ocaml () = raise E1
+#0  camlMeander.c_to_ocaml_273 () at meander.ml:5
+#1  <signal handler called>
+#2  0x00000000000000 in caml_callback_exn (closure=<optimized out>, arg=<optimized out>, arg@entry=1) at runtime/callback.c:206
+#3  0x00000000000000 in caml_callback (closure=<optimized out>, arg=arg@entry=1) at runtime/callback.c:347
+#4  0x00000000000000 in ocaml_to_c (unit=<optimized out>) at meander_c.c:5
+#5  <signal handler called>
+#6  0x00000000000000 in camlMeander.omain_278 () at meander.ml:10
+#7  0x00000000000000 in camlMeander.entry () at meander.ml:13
+#8  0x00000000000000 in caml_program ()
+#9  <signal handler called>
+#10 0x00000000000000 in caml_startup_common (pooling=<optimized out>, argv=0x00000000000000) at runtime/startup_nat.c:128
+#11 caml_startup_common (argv=0x00000000000000, pooling=<optimized out>) at runtime/startup_nat.c:87
+#12 0x00000000000000 in caml_startup_exn (argv=<optimized out>) at runtime/startup_nat.c:135
+#13 caml_startup (argv=<optimized out>) at runtime/startup_nat.c:140
+#14 caml_main (argv=<optimized out>) at runtime/startup_nat.c:147
+#15 0x00000000000000 in main (argc=<optimized out>, argv=<optimized out>) at runtime/main.c:37
+[Inferior 1 (process XXXX) exited normally]

--- a/testsuite/tests/native-debugger/linux-lldb-amd64-test.ml
+++ b/testsuite/tests/native-debugger/linux-lldb-amd64-test.ml
@@ -1,0 +1,19 @@
+(* TEST
+   native-compiler;
+   linux;
+   arch_amd64;
+   script = "sh ${test_source_directory}/has_lldb.sh linux";
+   script;
+   readonly_files = "meander.ml meander_c.c lldb_test.py";
+   setup-ocamlopt.byte-build-env;
+   program = "${test_build_directory}/meander";
+   flags = "-g";
+   all_modules = "meander.ml meander_c.c";
+   ocamlopt.byte;
+   debugger_script = "${test_source_directory}/lldb-script";
+   lldb;
+   script = "sh ${test_source_directory}/sanitize.sh ${test_source_directory} \
+             ${test_build_directory} ${ocamltest_response} linux-lldb-amd64-test";
+   script;
+   check-program-output;
+ *)

--- a/testsuite/tests/native-debugger/linux-lldb-amd64-test.reference
+++ b/testsuite/tests/native-debugger/linux-lldb-amd64-test.reference
@@ -1,0 +1,111 @@
+(lldb) target create "XXXX"
+Current executable set to 'XXXX' ($ARCH).
+(lldb) command source -s 0 'XXXX'
+Executing commands in 'XXXX'.
+(lldb) settings set stop-disassembly-display never
+(lldb) command script import ./lldb_test.py
+(lldb) create caml_start_program
+Breakpoint created for regex caml_start_program.
+(lldb) create caml_program
+Breakpoint created for regex caml_program.
+(lldb) create camlMeander.c_to_ocaml*
+Breakpoint created for regex camlMeander.c_to_ocaml*.
+(lldb) create ocaml_to_c
+Breakpoint created for regex ocaml_to_c.
+(lldb) run
+Process XXXX stopped
+* thread #1, name = 'XXXX', stop reason = breakpoint 1.1
+    frame #0: 0x00000000000000 meander`caml_start_program
+Process XXXX launched: 'XXXX' ($ARCH)
+(lldb) backtrace
+frame 0: meander`caml_start_program
+frame 1: meander`caml_startup_common
+frame 2: meander`caml_startup_common
+frame 3: meander`caml_startup_exn
+frame 4: meander`caml_startup
+frame 5: meander`caml_main
+frame 6: meander`main
+frame 7: libc.so.6`__libc_start_call_main
+frame 8: libc.so.6`__libc_start_main_impl
+frame 9: meander`_start
+(lldb) continue
+Process XXXX resuming
+Process XXXX stopped
+* thread #1, name = 'XXXX', stop reason = breakpoint 2.1
+    frame #0: 0x00000000000000 meander`caml_program
+(lldb) backtrace
+frame 0: meander`caml_program
+frame 1: meander`caml_start_program
+frame 2: meander`caml_startup_common
+frame 3: meander`caml_startup_common
+frame 4: meander`caml_startup_exn
+frame 5: meander`caml_startup
+frame 6: meander`caml_main
+frame 7: meander`main
+frame 8: libc.so.6`__libc_start_call_main
+frame 9: libc.so.6`__libc_start_main_impl
+frame 10: meander`_start
+(lldb) continue
+Process XXXX resuming
+Process XXXX stopped
+* thread #1, name = 'XXXX', stop reason = breakpoint 4.1
+    frame #0: 0x00000000000000 meander`ocaml_to_c(unit=1) at meander_c.c:4:31
+   1   	#include <caml/mlvalues.h>
+   2   	#include <caml/callback.h>
+   3   	
+-> 4   	value ocaml_to_c (value unit) {
+    	                              ^
+   5   	    caml_callback(*caml_named_value
+   6   	                  ("c_to_ocaml"), Val_unit);
+   7   	    return Val_int(0);
+(lldb) backtrace
+frame 0: meander`ocaml_to_c
+frame 1: meander`caml_c_call
+frame 2: meander`camlMeander.omain_278
+frame 3: meander`camlMeander.entry
+frame 4: meander`caml_program
+frame 5: meander`caml_start_program
+frame 6: meander`caml_startup_common
+frame 7: meander`caml_startup_common
+frame 8: meander`caml_startup_exn
+frame 9: meander`caml_startup
+frame 10: meander`caml_main
+frame 11: meander`main
+frame 12: libc.so.6`__libc_start_call_main
+frame 13: libc.so.6`__libc_start_main_impl
+frame 14: meander`_start
+(lldb) continue
+This version of LLDB has no plugin for the language "assembler". Inspection of frame variables will be limited.
+Process XXXX resuming
+Process XXXX stopped
+* thread #1, name = 'XXXX', stop reason = breakpoint 3.1
+    frame #0: 0x00000000000000 meander`camlMeander.c_to_ocaml_273 at meander.ml:5:20
+   2   	         : unit -> int = "ocaml_to_c"
+   3   	exception E1
+   4   	exception E2
+-> 5   	let c_to_ocaml () = raise E1
+    	                   ^
+   6   	let _ = Callback.register
+   7   	          "c_to_ocaml" c_to_ocaml
+   8   	let omain () =
+(lldb) backtrace
+frame 0: meander`camlMeander.c_to_ocaml_273
+frame 1: meander`caml_start_program
+frame 2: meander`caml_callback_exn
+frame 3: meander`caml_callback
+frame 4: meander`ocaml_to_c
+frame 5: meander`caml_c_call
+frame 6: meander`camlMeander.omain_278
+frame 7: meander`camlMeander.entry
+frame 8: meander`caml_program
+frame 9: meander`caml_start_program
+frame 10: meander`caml_startup_common
+frame 11: meander`caml_startup_common
+frame 12: meander`caml_startup_exn
+frame 13: meander`caml_startup
+frame 14: meander`caml_main
+frame 15: meander`main
+frame 16: libc.so.6`__libc_start_call_main
+frame 17: libc.so.6`__libc_start_main_impl
+frame 18: meander`_start
+(lldb) quit

--- a/testsuite/tests/native-debugger/linux-lldb-arm64-test.ml
+++ b/testsuite/tests/native-debugger/linux-lldb-arm64-test.ml
@@ -1,0 +1,19 @@
+(* TEST
+   native-compiler;
+   linux;
+   arch_arm64;
+   script = "sh ${test_source_directory}/has_lldb.sh linux";
+   script;
+   readonly_files = "meander.ml meander_c.c lldb_test.py";
+   setup-ocamlopt.byte-build-env;
+   program = "${test_build_directory}/meander";
+   flags = "-g";
+   all_modules = "meander.ml meander_c.c";
+   ocamlopt.byte;
+   debugger_script = "${test_source_directory}/lldb-script";
+   lldb;
+   script = "sh ${test_source_directory}/sanitize.sh ${test_source_directory} \
+   ${test_build_directory} ${ocamltest_response} linux-lldb-arm64-test";
+   script;
+   check-program-output;
+ *)

--- a/testsuite/tests/native-debugger/linux-lldb-arm64-test.reference
+++ b/testsuite/tests/native-debugger/linux-lldb-arm64-test.reference
@@ -1,0 +1,110 @@
+(lldb) target create "XXXX"
+Current executable set to 'XXXX' (aarch64).
+(lldb) command source -s 0 'XXXX'
+Executing commands in 'XXXX'.
+(lldb) settings set stop-disassembly-display never
+(lldb) command script import ./lldb_test.py
+(lldb) create caml_start_program
+Breakpoint created for regex caml_start_program.
+(lldb) create caml_program
+Breakpoint created for regex caml_program.
+(lldb) create camlMeander.c_to_ocaml*
+Breakpoint created for regex camlMeander.c_to_ocaml*.
+(lldb) create ocaml_to_c
+Breakpoint created for regex ocaml_to_c.
+(lldb) run
+Process XXXX launched: 'XXXX' (aarch64)
+Process XXXX stopped
+* thread #1, name = 'XXXX', stop reason = breakpoint 1.1
+    frame #0: 0x00000000000000 meander`caml_start_program
+(lldb) backtrace
+frame 0: meander`caml_start_program
+frame 1: meander`caml_startup_common
+frame 2: meander`caml_startup_common
+frame 3: meander`caml_startup_exn
+frame 4: meander`caml_startup
+frame 5: meander`caml_main
+frame 6: meander`main
+frame 7: libc.so.6`__libc_start_call_main
+frame 8: libc.so.6`__libc_start_main_impl
+frame 9: meander`_start
+(lldb) continue
+Process XXXX resuming
+Process XXXX stopped
+* thread #1, name = 'XXXX', stop reason = breakpoint 2.1
+    frame #0: 0x00000000000000 meander`caml_program
+(lldb) backtrace
+frame 0: meander`caml_program
+frame 1: meander`caml_start_program
+frame 2: meander`caml_startup_common
+frame 3: meander`caml_startup_common
+frame 4: meander`caml_startup_exn
+frame 5: meander`caml_startup
+frame 6: meander`caml_main
+frame 7: meander`main
+frame 8: libc.so.6`__libc_start_call_main
+frame 9: libc.so.6`__libc_start_main_impl
+frame 10: meander`_start
+(lldb) continue
+Process XXXX resuming
+Process XXXX stopped
+* thread #1, name = 'XXXX', stop reason = breakpoint 4.1
+    frame #0: 0x00000000000000 meander`ocaml_to_c(unit=1) at meander_c.c:4:31
+   1   	#include <caml/mlvalues.h>
+   2   	#include <caml/callback.h>
+   3   	
+-> 4   	value ocaml_to_c (value unit) {
+    	                              ^
+   5   	    caml_callback(*caml_named_value
+   6   	                  ("c_to_ocaml"), Val_unit);
+   7   	    return Val_int(0);
+(lldb) backtrace
+frame 0: meander`ocaml_to_c
+frame 1: meander`caml_c_call
+frame 2: meander`camlMeander.omain_278
+frame 3: meander`camlMeander.entry
+frame 4: meander`caml_program
+frame 5: meander`caml_start_program
+frame 6: meander`caml_startup_common
+frame 7: meander`caml_startup_common
+frame 8: meander`caml_startup_exn
+frame 9: meander`caml_startup
+frame 10: meander`caml_main
+frame 11: meander`main
+frame 12: libc.so.6`__libc_start_call_main
+frame 13: libc.so.6`__libc_start_main_impl
+frame 14: meander`_start
+(lldb) continue
+warning: This version of LLDB has no plugin for the language "assembler". Inspection of frame variables will be limited.
+Process XXXX resuming
+Process XXXX stopped
+* thread #1, name = 'XXXX', stop reason = breakpoint 3.1
+    frame #0: 0x00000000000000 meander`camlStd_exit.code_end at meander.ml:5
+   2   	         : unit -> int = "ocaml_to_c"
+   3   	exception E1
+   4   	exception E2
+-> 5   	let c_to_ocaml () = raise E1
+   6   	let _ = Callback.register
+   7   	          "c_to_ocaml" c_to_ocaml
+   8   	let omain () =
+(lldb) backtrace
+frame 0: meander`camlStd_exit.code_end
+frame 1: meander`caml_start_program
+frame 2: meander`caml_callback_exn
+frame 3: meander`caml_callback
+frame 4: meander`ocaml_to_c
+frame 5: meander`caml_c_call
+frame 6: meander`camlMeander.omain_278
+frame 7: meander`camlMeander.entry
+frame 8: meander`caml_program
+frame 9: meander`caml_start_program
+frame 10: meander`caml_startup_common
+frame 11: meander`caml_startup_common
+frame 12: meander`caml_startup_exn
+frame 13: meander`caml_startup
+frame 14: meander`caml_main
+frame 15: meander`main
+frame 16: libc.so.6`__libc_start_call_main
+frame 17: libc.so.6`__libc_start_main_impl
+frame 18: meander`_start
+(lldb) quit

--- a/testsuite/tests/native-debugger/lldb-script
+++ b/testsuite/tests/native-debugger/lldb-script
@@ -1,0 +1,15 @@
+settings set stop-disassembly-display never
+command script import ./lldb_test.py
+create caml_start_program
+create caml_program
+create camlMeander.c_to_ocaml*
+create ocaml_to_c
+run
+backtrace
+continue
+backtrace
+continue
+backtrace
+continue
+backtrace
+quit

--- a/testsuite/tests/native-debugger/lldb_test.py
+++ b/testsuite/tests/native-debugger/lldb_test.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python
+from __future__ import print_function
+
+import lldb
+
+# Print backtrace by walking LLDB frames
+#
+def print_backtrace(debugger, command, result, dict):
+    """
+    Walk process call stack printing out frame names
+    """
+    target = debugger.GetSelectedTarget()
+    if target:
+        process = target.GetProcess()
+        if process:
+            frame_info = {}
+            thread = process.GetSelectedThread()
+            for thread in process:
+                for frame in thread:
+                    print("frame %i: %s`%s"% (frame.idx, frame.module.file.basename, frame.name))
+        else:
+            result.SetError('No current process for the debugger. Has a process to debug been launched?')
+    else:
+        result.SetError('No current target for the debugger. Has a process to debug been launched?')
+
+# Create breakpoint at address
+# lldb.target.BreakpointCreateByAddress(0x0000000100005ad0)
+
+# Create breakpoint on Regex
+# lldb.target.BreakpointCreateByRegex("camlFib.fib_*")
+
+def create_breakpoint(debugger, command, result, dict):
+    """
+    Create breakpoints based on symbol names
+    """
+    target = debugger.GetSelectedTarget()
+    if target:
+        breakpoint = target.BreakpointCreateByRegex(command)
+        if (breakpoint and breakpoint.GetNumLocations() == 1):
+            print(f"Breakpoint created for regex {command}." )
+        else:
+            print(f"No matches for breakpoint regex {command}.")
+            result.SetError(f"No matches for breakpoint regex {command}.")
+    else:
+        result.SetError('No current target for the debugger. Has a process to debug been launched?')
+
+def __lldb_init_module(debugger, internal_dict):
+    # Install commands for printing backtrace and setting breakpoints
+    debugger.HandleCommand('command script add -f %s.print_backtrace backtrace' % __name__)
+    debugger.HandleCommand('command script add -f %s.create_breakpoint create' % __name__)

--- a/testsuite/tests/native-debugger/macos-lldb-amd64.ml
+++ b/testsuite/tests/native-debugger/macos-lldb-amd64.ml
@@ -1,0 +1,19 @@
+(* TEST
+   native-compiler;
+   macos;
+   arch_amd64;
+   script = "sh ${test_source_directory}/has_lldb.sh macos";
+   script;
+   readonly_files = "meander.ml meander_c.c lldb_test.py";
+   setup-ocamlopt.byte-build-env;
+   program = "${test_build_directory}/meander";
+   flags = "-g";
+   all_modules = "meander.ml meander_c.c";
+   ocamlopt.byte;
+   debugger_script = "${test_source_directory}/lldb-script";
+   lldb;
+   script = "sh ${test_source_directory}/sanitize.sh ${test_source_directory} \
+             ${test_build_directory} ${ocamltest_response} macos-lldb-amd64";
+   script;
+   check-program-output;
+ *)

--- a/testsuite/tests/native-debugger/macos-lldb-amd64.reference
+++ b/testsuite/tests/native-debugger/macos-lldb-amd64.reference
@@ -1,0 +1,95 @@
+(lldb) target create "XXXX"
+Current executable set to 'XXXX' ($ARCH).
+(lldb) command source -s 0 'XXXX'
+Executing commands in 'XXXX'.
+(lldb) settings set stop-disassembly-display never
+(lldb) command script import ./lldb_test.py
+(lldb) create caml_start_program
+Breakpoint created for regex caml_start_program.
+(lldb) create caml_program
+Breakpoint created for regex caml_program.
+(lldb) create camlMeander.c_to_ocaml*
+Breakpoint created for regex camlMeander.c_to_ocaml*.
+(lldb) create ocaml_to_c
+Breakpoint created for regex ocaml_to_c.
+(lldb) run
+Process XXXX stopped
+* thread #1, queue = 'XXXX', stop reason = breakpoint 1.1
+    frame #0: 0x00000000000000 meander`caml_start_program
+Target 0: (meander) stopped.
+Process XXXX launched: 'XXXX' ($ARCH)
+(lldb) backtrace
+frame 0: meander`caml_start_program
+frame 1: meander`caml_startup_common
+frame 2: meander`caml_startup_exn
+frame 3: meander`caml_startup
+frame 4: meander`caml_main
+frame 5: meander`main
+frame 6: dyld`start
+(lldb) continue
+Process XXXX resuming
+Process XXXX stopped
+* thread #1, queue = 'XXXX', stop reason = breakpoint 2.1
+    frame #0: 0x00000000000000 meander`caml_program
+Target 0: (meander) stopped.
+(lldb) backtrace
+frame 0: meander`caml_program
+frame 1: meander`caml_start_program
+frame 2: meander`caml_startup_common
+frame 3: meander`caml_startup_exn
+frame 4: meander`caml_startup
+frame 5: meander`caml_main
+frame 6: meander`main
+frame 7: dyld`start
+(lldb) continue
+warning: meander was compiled with optimization - stepping may behave oddly;
+Process XXXX resuming
+Process XXXX stopped
+* thread #1, queue = 'XXXX', stop reason = breakpoint 4.1
+    frame #0: 0x00000000000000 meander`ocaml_to_c(unit=1) at meander_c.c:5:20 [opt]
+   2   	#include <caml/callback.h>
+   3   	
+   4   	value ocaml_to_c (value unit) {
+-> 5   	    caml_callback(*caml_named_value
+    	                   ^
+   6   	                  ("c_to_ocaml"), Val_unit);
+   7   	    return Val_int(0);
+   8   	}
+Target 0: (meander) stopped.
+(lldb) backtrace
+frame 0: meander`ocaml_to_c
+frame 1: meander`caml_c_call
+frame 2: meander`camlMeander.omain_278
+frame 3: meander`camlMeander.entry
+frame 4: meander`caml_program
+frame 5: meander`caml_start_program
+frame 6: meander`caml_startup_common
+frame 7: meander`caml_startup_exn
+frame 8: meander`caml_startup
+frame 9: meander`caml_main
+frame 10: meander`main
+frame 11: dyld`start
+(lldb) continue
+Process XXXX resuming
+Process XXXX stopped
+* thread #1, queue = 'XXXX', stop reason = breakpoint 3.1
+    frame #0: 0x00000000000000 meander`camlMeander.c_to_ocaml_273
+Target 0: (meander) stopped.
+(lldb) backtrace
+frame 0: meander`camlMeander.c_to_ocaml_273
+frame 1: meander`caml_start_program
+frame 2: meander`caml_callback_exn
+frame 3: meander`caml_callback
+frame 4: meander`ocaml_to_c
+frame 5: meander`caml_c_call
+frame 6: meander`camlMeander.omain_278
+frame 7: meander`camlMeander.entry
+frame 8: meander`caml_program
+frame 9: meander`caml_start_program
+frame 10: meander`caml_startup_common
+frame 11: meander`caml_startup_exn
+frame 12: meander`caml_startup
+frame 13: meander`caml_main
+frame 14: meander`main
+frame 15: dyld`start
+(lldb) quit

--- a/testsuite/tests/native-debugger/macos-lldb-arm64.ml
+++ b/testsuite/tests/native-debugger/macos-lldb-arm64.ml
@@ -1,0 +1,19 @@
+(* TEST
+   native-compiler;
+   macos;
+   arch_arm64;
+   script = "sh ${test_source_directory}/has_lldb.sh macos";
+   script;
+   readonly_files = "meander.ml meander_c.c lldb_test.py";
+   setup-ocamlopt.byte-build-env;
+   program = "${test_build_directory}/meander";
+   flags = "-g";
+   all_modules = "meander.ml meander_c.c";
+   ocamlopt.byte;
+   debugger_script = "${test_source_directory}/lldb-script";
+   lldb;
+   script = "sh ${test_source_directory}/sanitize.sh ${test_source_directory} \
+             ${test_build_directory} ${ocamltest_response} macos-lldb-arm64";
+   script;
+   check-program-output;
+ *)

--- a/testsuite/tests/native-debugger/macos-lldb-arm64.reference
+++ b/testsuite/tests/native-debugger/macos-lldb-arm64.reference
@@ -1,0 +1,95 @@
+(lldb) target create "XXXX"
+Current executable set to 'XXXX' ($ARCH).
+(lldb) command source -s 0 'XXXX'
+Executing commands in 'XXXX'.
+(lldb) settings set stop-disassembly-display never
+(lldb) command script import ./lldb_test.py
+(lldb) create caml_start_program
+Breakpoint created for regex caml_start_program.
+(lldb) create caml_program
+Breakpoint created for regex caml_program.
+(lldb) create camlMeander.c_to_ocaml*
+Breakpoint created for regex camlMeander.c_to_ocaml*.
+(lldb) create ocaml_to_c
+Breakpoint created for regex ocaml_to_c.
+(lldb) run
+Process XXXX stopped
+* thread #1, queue = 'XXXX', stop reason = breakpoint 1.1
+    frame #0: 0x00000000000000 meander`caml_start_program
+Target 0: (meander) stopped.
+Process XXXX launched: 'XXXX' ($ARCH)
+(lldb) backtrace
+frame 0: meander`caml_start_program
+frame 1: meander`caml_startup_common
+frame 2: meander`caml_startup_exn
+frame 3: meander`caml_startup
+frame 4: meander`caml_main
+frame 5: meander`main
+frame 6: dyld`start
+(lldb) continue
+Process XXXX resuming
+Process XXXX stopped
+* thread #1, queue = 'XXXX', stop reason = breakpoint 2.1
+    frame #0: 0x00000000000000 meander`caml_program
+Target 0: (meander) stopped.
+(lldb) backtrace
+frame 0: meander`caml_program
+frame 1: meander`caml_start_program
+frame 2: meander`caml_startup_common
+frame 3: meander`caml_startup_exn
+frame 4: meander`caml_startup
+frame 5: meander`caml_main
+frame 6: meander`main
+frame 7: dyld`start
+(lldb) continue
+warning: meander was compiled with optimization - stepping may behave oddly;
+Process XXXX resuming
+Process XXXX stopped
+* thread #1, queue = 'XXXX', stop reason = breakpoint 4.1
+    frame #0: 0x00000000000000 meander`ocaml_to_c(unit=1) at meander_c.c:5:20 [opt]
+   2   	#include <caml/callback.h>
+   3   	
+   4   	value ocaml_to_c (value unit) {
+-> 5   	    caml_callback(*caml_named_value
+    	                   ^
+   6   	                  ("c_to_ocaml"), Val_unit);
+   7   	    return Val_int(0);
+   8   	}
+Target 0: (meander) stopped.
+(lldb) backtrace
+frame 0: meander`ocaml_to_c
+frame 1: meander`caml_c_call
+frame 2: meander`camlMeander.omain_279
+frame 3: meander`camlMeander.entry
+frame 4: meander`caml_program
+frame 5: meander`caml_start_program
+frame 6: meander`caml_startup_common
+frame 7: meander`caml_startup_exn
+frame 8: meander`caml_startup
+frame 9: meander`caml_main
+frame 10: meander`main
+frame 11: dyld`start
+(lldb) continue
+Process XXXX resuming
+Process XXXX stopped
+* thread #1, queue = 'XXXX', stop reason = breakpoint 3.1
+    frame #0: 0x00000000000000 meander`camlMeander.c_to_ocaml_274
+Target 0: (meander) stopped.
+(lldb) backtrace
+frame 0: meander`camlMeander.c_to_ocaml_274
+frame 1: meander`caml_start_program
+frame 2: meander`caml_callback_exn
+frame 3: meander`caml_callback
+frame 4: meander`ocaml_to_c
+frame 5: meander`caml_c_call
+frame 6: meander`camlMeander.omain_279
+frame 7: meander`camlMeander.entry
+frame 8: meander`caml_program
+frame 9: meander`caml_start_program
+frame 10: meander`caml_startup_common
+frame 11: meander`caml_startup_exn
+frame 12: meander`caml_startup
+frame 13: meander`caml_main
+frame 14: meander`main
+frame 15: dyld`start
+(lldb) quit

--- a/testsuite/tests/native-debugger/meander.ml
+++ b/testsuite/tests/native-debugger/meander.ml
@@ -1,0 +1,13 @@
+external ocaml_to_c
+         : unit -> int = "ocaml_to_c"
+exception E1
+exception E2
+let c_to_ocaml () = raise E1
+let _ = Callback.register
+          "c_to_ocaml" c_to_ocaml
+let omain () =
+  try (* h1 *)
+    try (* h2 *) ocaml_to_c ()
+    with E2 -> 0
+  with E1 -> 42
+let _ = assert (omain () = 42)

--- a/testsuite/tests/native-debugger/meander_c.c
+++ b/testsuite/tests/native-debugger/meander_c.c
@@ -1,0 +1,8 @@
+#include <caml/mlvalues.h>
+#include <caml/callback.h>
+
+value ocaml_to_c (value unit) {
+    caml_callback(*caml_named_value
+                  ("c_to_ocaml"), Val_unit);
+    return Val_int(0);
+}

--- a/testsuite/tests/native-debugger/sanitize.awk
+++ b/testsuite/tests/native-debugger/sanitize.awk
@@ -25,6 +25,12 @@
     gsub("(arm64)", "$ARCH")
     gsub("(riscv64)", "$ARCH")
 
+    # Replace offsets in disassembly output
+    gsub(/\<\+[0-9]+\>/, "<+XX>")
+
+    # Replace comments with blank comments
+    gsub(/; [a-zA-Z0-9._+ ]+/, ";")
+
     # Replace printed match results
     gsub("1 match found in /(.*):$", "1 match found in \"XXXX\":")
     print $0

--- a/testsuite/tests/native-debugger/sanitize.awk
+++ b/testsuite/tests/native-debugger/sanitize.awk
@@ -1,0 +1,31 @@
+# Replace sections of LLDB output
+# This primarily looks for hex addresses, process ids, filepaths and
+# other specific details of the machine the test is running on.
+{
+    # Replace single quoted file paths
+    gsub(/'(.*)'/,"'XXXX'")
+
+    # Replace target create for executable
+    gsub(/target create "(.*)"/,"target create \"XXXX\"")
+
+    # Replace hex addresses, not offset values less than 4 digits.
+    gsub(/0x[0-9a-f][0-9a-f][0-9a-f][0-9a-f]+/, "0x00000000000000")
+
+    # Sanitise executable name in image lookup
+    gsub("5 matches found in /(.*):$", "5 matches found in XXXX")
+
+    # Replace debug process forked by lldb
+    gsub("Process ([0-9]+)", "Process XXXX")
+
+    # Replace debug process forked by gdb
+    gsub("[Inferior 1 (process [0-9]+) exited normally]", "[Inferior 1 (process XXXX) exited normally]")
+
+    # Replace architecture identifiers
+    gsub("(x86_64)", "$ARCH")
+    gsub("(arm64)", "$ARCH")
+    gsub("(riscv64)", "$ARCH")
+
+    # Replace printed match results
+    gsub("1 match found in /(.*):$", "1 match found in \"XXXX\":")
+    print $0
+}

--- a/testsuite/tests/native-debugger/sanitize.sh
+++ b/testsuite/tests/native-debugger/sanitize.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+test_source_directory="$1"
+test_build_directory="$2"
+ocamltest_response="$3"
+test_name="$4"
+
+awk -f ${test_source_directory}/sanitize.awk \
+    ${test_build_directory}/${test_name}.opt.output > ${test_build_directory}/${test_name}.opt.awk.output
+
+mv ${test_build_directory}/${test_name}.opt.output ${test_build_directory}/${test_name}.opt.output.bak
+cp ${test_build_directory}/${test_name}.opt.awk.output ${test_build_directory}/${test_name}.opt.output

--- a/testsuite/tests/tool-debugger/basic/debuggee.ml
+++ b/testsuite/tests/tool-debugger/basic/debuggee.ml
@@ -1,7 +1,7 @@
 (* TEST
  set foo = "bar";
  flags += " -g ";
- ocamldebug_script = "${test_source_directory}/input_script";
+ debugger_script = "${test_source_directory}/input_script";
  debugger;
  shared-libraries;
  setup-ocamlc.byte-build-env;

--- a/testsuite/tests/tool-debugger/dynlink/host.ml
+++ b/testsuite/tests/tool-debugger/dynlink/host.ml
@@ -3,7 +3,7 @@
  readonly_files = "host.ml plugin.ml";
  libraries = "";
  flags += " -g ";
- ocamldebug_script = "${test_source_directory}/input_script";
+ debugger_script = "${test_source_directory}/input_script";
  debugger;
  shared-libraries;
  setup-ocamlc.byte-build-env;

--- a/testsuite/tests/tool-debugger/find-artifacts/debuggee.ml
+++ b/testsuite/tests/tool-debugger/find-artifacts/debuggee.ml
@@ -1,5 +1,5 @@
 (* TEST
- ocamldebug_script = "${test_source_directory}/input_script";
+ debugger_script = "${test_source_directory}/input_script";
  debugger;
  shared-libraries;
  setup-ocamlc.byte-build-env;

--- a/testsuite/tests/tool-debugger/module_named_main/main.ml
+++ b/testsuite/tests/tool-debugger/module_named_main/main.ml
@@ -31,7 +31,7 @@ debug ();
 
 (* TEST
  flags += " -g ";
- ocamldebug_script = "${test_source_directory}/input_script";
+ debugger_script = "${test_source_directory}/input_script";
  debugger;
  shared-libraries;
  setup-ocamlc.byte-build-env;

--- a/testsuite/tests/tool-debugger/no_debug_event/noev.ml
+++ b/testsuite/tests/tool-debugger/no_debug_event/noev.ml
@@ -1,6 +1,6 @@
 (* TEST
  readonly_files = "a.ml b.ml";
- ocamldebug_script = "${test_source_directory}/input_script";
+ debugger_script = "${test_source_directory}/input_script";
  debugger;
  shared-libraries;
  setup-ocamlc.byte-build-env;

--- a/testsuite/tests/tool-debugger/printer/debuggee.ml
+++ b/testsuite/tests/tool-debugger/printer/debuggee.ml
@@ -23,7 +23,7 @@ let () = f 3
 
 (* TEST
  flags += " -g ";
- ocamldebug_script = "${test_source_directory}/input_script";
+ debugger_script = "${test_source_directory}/input_script";
  readonly_files = "printer.ml";
  include debugger;
  debugger;


### PR DESCRIPTION
This change introduces the ability to run native debuggers (LLDB and GDB) as part of the ocaml testsuite.

[GBD](https://sourceware.org/gdb/current/onlinedocs/gdb.html/Python-API.html#Python-API) and [LLDB](https://lldb.llvm.org/python_api.html) both provide Python APIs for interacting with the debugger. This makes it possible to write Python scripted tests, e.g. setting breakpoints, inspecting stack frames and looking up symbol information. In particular LLDB has a test suite for the Python API https://github.com/llvm/llvm-project/tree/main/lldb/test/API with many useful examples of what is possible.

Of course you can still provide CLI arguments to the debugger, with some extra work to sanitize the output
to remove machine information (hex-addresses, process ids, file paths etc). For that I've re-used the existing awk dependency which should be sufficient for the Unix platforms that will be initially supported. 

Having support in ocamltest for LLDB and GDB will help ensure that any future changes don't break the debugging experience and more tests can be written in Python to exercise OCaml debugging functionality.

6d101c0 is a small refactor to make the existing bytecode debugger tests use `debugger_script` as the name of the commands file to run against the debugger. To run a debugger test you would have:
`debugger_script` to point to the commands and choose which debugger to run (gdb|lldb|ocamldebug).

This change should be taken as a whole with the commits squashed before merging. 