### PR TITLE
Do not pass CFLAGS to linker

### DIFF
--- a/.github/workflows/tsan.yml
+++ b/.github/workflows/tsan.yml
@@ -42,7 +42,7 @@ jobs:
         run: sudo sysctl vm.mmap_rnd_bits=28
       - name: Configure tree
         run: |
-          MAKE_ARG=-j CONFIG_ARG='--enable-cmm-invariants --enable-dependency-generation --enable-native-toplevel --enable-tsan --enable-ocamltest CFLAGS=-DTSAN_INSTRUMENT_ALL' OCAMLRUNPARAM=b,v=0 bash -xe tools/ci/actions/runner.sh configure
+          MAKE_ARG=-j CONFIG_ARG='--enable-cmm-invariants --enable-dependency-generation --enable-native-toplevel --enable-tsan --enable-ocamltest CPPFLAGS=-DTSAN_INSTRUMENT_ALL' OCAMLRUNPARAM=b,v=0 bash -xe tools/ci/actions/runner.sh configure
       - name: Build
         run: |
           MAKE_ARG=-j bash -xe tools/ci/actions/runner.sh build

--- a/Changes
+++ b/Changes
@@ -236,6 +236,9 @@ _______________
 - #12996: Only link with -lgcc_eh when available.
   (Romain Beauxis, review by David Allsopp and Miod Vallat)
 
+* #13200: Do not use CFLAGS for linking
+  (Sébastien Hinderer, review by ?)
+
 ### Bug fixes:
 
 - #12854: Add a test in the regression suite that flags the bug #12825.

--- a/INSTALL.adoc
+++ b/INSTALL.adoc
@@ -169,7 +169,7 @@ and data segment size (type `limit` under csh or `ulimit -a` under bash). Make
 sure the limit on the stack size is at least 4M.
 
 Try recompiling the runtime system with optimizations turned off (change
-`OC_CFLAGS` in `runtime/Makefile`). The runtime system
+`OC_CFLAGS` in `Makefile.build_config`). The runtime system
 contains some complex, atypical pieces of C code which can uncover bugs in
 optimizing compilers.  Alternatively, try another C compiler (e.g. `gcc` instead
 of the vendor-supplied `cc`).

--- a/Makefile.build_config.in
+++ b/Makefile.build_config.in
@@ -90,8 +90,7 @@ OC_NATIVE_CFLAGS=@native_cflags@
 OC_LDFLAGS=@oc_ldflags@
 OC_DLL_LDFLAGS=@oc_dll_ldflags@
 
-MKEXE_VIA_CC=\
-  $(CC) $(OC_CFLAGS) $(CFLAGS) @mkexe_via_cc_ldflags@ @mkexe_via_cc_extra_cmd@
+MKEXE_VIA_CC=$(CC) @mkexe_via_cc_ldflags@ @mkexe_via_cc_extra_cmd@
 
 # Which tool to use to display differences between files
 DIFF=@DIFF@
@@ -145,10 +144,9 @@ DEFAULT_BUILD_TARGET = @default_build_target@
 # (other backends may be added in the future).
 #
 # ZZZ is either COMPFLAGS (compile-time flags) or LINKFLAGS (link-time flags).
-# Countrary to the C convention wrt. CFLAGS and LDFLAGS, the flags in the
-# COMPFLAGS category are not passed at link time, so if a flag is needed
-# at both stages, like e.g. -g, it should be added to both
-# XXX_YYY_COMPFLAGS and XXX_YYY_LINKFLAGS.
+# The flags in the COMPFLAGS category are not passed at link time,
+# so if a flag is needed at both stages, like e.g. -g, it should be
+# added to both XXX_YYY_COMPFLAGS and XXX_YYY_LINKFLAGS.
 
 OC_COMMON_COMPFLAGS = -g -strict-sequence -principal -absname \
   -w +a-4-9-40-41-42-44-45-48 -warn-error +a -bin-annot \

--- a/configure
+++ b/configure
@@ -3251,7 +3251,6 @@ CONFIGURE_ARGS="$*"
 # rely on $CFLAGS because these cannot be processed by flexlink (and are not
 # passed)
 mkexe_cmd='$(CC)'
-mkexe_cflags='$(OC_CFLAGS) $(CFLAGS)'
 mkexe_extra_flags=''
 mkexe_via_cc_extra_cmd=''
 mkexe_ldflags_prefix=''
@@ -14500,7 +14499,6 @@ case $ocaml_cc_vendor,$host in #(
 then :
   mkexe_cmd_exp="flexlink -exe -chain ${flexdll_chain} ${flexlink_flags}"
       mkexe_cmd="flexlink -exe -chain ${flexdll_chain} ${flexlink_flags}"
-      mkexe_cflags=''
       mkexe_ldflags_prefix='-link '
 else $as_nop
   mkexe_extra_flags=''
@@ -14519,7 +14517,6 @@ esac
     toolchain="mingw"
     mkexe_cmd_exp="flexlink -exe -chain ${flexdll_chain} ${flexlink_flags}"
     mkexe_cmd="flexlink -exe -chain ${flexdll_chain} ${flexlink_flags}"
-    mkexe_cflags=''
     mkexe_ldflags_prefix='-link '
     oc_exe_ldflags='-municode'
     mkexe_extra_flags="$mkexe_ldflags_prefix$oc_exe_ldflags"
@@ -14529,7 +14526,6 @@ esac
     ostype="Win32"
     mkexe_cmd_exp="flexlink -exe -chain ${flexdll_chain} ${flexlink_flags}"
     mkexe_cmd="flexlink -exe -chain ${flexdll_chain} ${flexlink_flags}"
-    mkexe_cflags=''
     mkexe_ldflags_prefix='-link '
     mkexe_via_cc_ldflags_prefix='/link '
     oc_exe_ldflags='/ENTRY:wmainCRTStartup'
@@ -21016,11 +21012,6 @@ fi
   # Construct $mkexe
   mkexe="$mkexe_cmd"
   mkexe_exp="$mkexe_cmd_exp"
-  if test -n "$mkexe_cflags"
-then :
-  mkexe="$mkexe $mkexe_cflags"
-    mkexe_exp="$mkexe_exp $common_cflags $CFLAGS"
-fi
   if test -n "$mkexe_extra_flags"
 then :
   mkexe="$mkexe $mkexe_extra_flags"

--- a/configure.ac
+++ b/configure.ac
@@ -36,7 +36,6 @@ CONFIGURE_ARGS="$*"
 # rely on $CFLAGS because these cannot be processed by flexlink (and are not
 # passed)
 mkexe_cmd='$(CC)'
-mkexe_cflags='$(OC_CFLAGS) $(CFLAGS)'
 mkexe_extra_flags=''
 mkexe_via_cc_extra_cmd=''
 mkexe_ldflags_prefix=''
@@ -1030,7 +1029,6 @@ AS_CASE([$ocaml_cc_vendor,$host],
     AS_IF([$supports_shared_libraries],
       [mkexe_cmd_exp="flexlink -exe -chain ${flexdll_chain} ${flexlink_flags}"
       mkexe_cmd="flexlink -exe -chain ${flexdll_chain} ${flexlink_flags}"
-      mkexe_cflags=''
       mkexe_ldflags_prefix='-link '],
       [mkexe_extra_flags=''
       oc_ldflags='-Wl,--stack,16777216']
@@ -1043,7 +1041,6 @@ AS_CASE([$ocaml_cc_vendor,$host],
     toolchain="mingw"
     mkexe_cmd_exp="flexlink -exe -chain ${flexdll_chain} ${flexlink_flags}"
     mkexe_cmd="flexlink -exe -chain ${flexdll_chain} ${flexlink_flags}"
-    mkexe_cflags=''
     mkexe_ldflags_prefix='-link '
     oc_exe_ldflags='-municode'
     mkexe_extra_flags="$mkexe_ldflags_prefix$oc_exe_ldflags"
@@ -1053,7 +1050,6 @@ AS_CASE([$ocaml_cc_vendor,$host],
     ostype="Win32"
     mkexe_cmd_exp="flexlink -exe -chain ${flexdll_chain} ${flexlink_flags}"
     mkexe_cmd="flexlink -exe -chain ${flexdll_chain} ${flexlink_flags}"
-    mkexe_cflags=''
     mkexe_ldflags_prefix='-link '
     mkexe_via_cc_ldflags_prefix='/link '
     oc_exe_ldflags='/ENTRY:wmainCRTStartup'
@@ -2651,9 +2647,6 @@ AC_CONFIG_COMMANDS_PRE([
   # Construct $mkexe
   mkexe="$mkexe_cmd"
   mkexe_exp="$mkexe_cmd_exp"
-  AS_IF([test -n "$mkexe_cflags"],
-    [mkexe="$mkexe $mkexe_cflags"
-    mkexe_exp="$mkexe_exp $common_cflags $CFLAGS"])
   AS_IF([test -n "$mkexe_extra_flags"],
     [mkexe="$mkexe $mkexe_extra_flags"
     mkexe_exp="$mkexe_exp $mkexe_extra_flags"])

--- a/runtime/HACKING.adoc
+++ b/runtime/HACKING.adoc
@@ -151,8 +151,8 @@ TODO: it would be nice to migrate some information here.
 === ThreadSanitizer ===
 
 You can instrument the runtime to detect data races in it, by adding
-`-fsanitize=thread` to the `CFLAGS`. It will make the compiler build rather
-slow.
+`-fsanitize=thread` to both `CFLAGS` and `LDFLAGS`. It will however make the
+compiler build rather slow.
 
 Note that this is different from passing `--enable-tsan` to the configure
 script. `--enable-tsan` not only instruments the runtime, but also the code

--- a/tools/ci/inria/sanitizers/script
+++ b/tools/ci/inria/sanitizers/script
@@ -84,6 +84,7 @@ sanitizers="-fsanitize=address -fsanitize-trap=$ubsan"
 ./configure \
   CC=clang-14 \
   CFLAGS="-O1 -fno-omit-frame-pointer $sanitizers" \
+  LDFLAGS="$sanitizers" \
   --disable-stdlib-manpages --enable-dependency-generation
 
 # Build the system.  We want to check for memory leaks, hence
@@ -121,7 +122,7 @@ git clean -q -f -d -x
 ./configure \
   CC=clang-14 \
   --enable-tsan \
-  CFLAGS="-DTSAN_INSTRUMENT_ALL" \
+  CPPFLAGS="-DTSAN_INSTRUMENT_ALL" \
   --disable-stdlib-manpages --enable-dependency-generation
 
 # Build the system
@@ -150,6 +151,7 @@ TSAN_OPTIONS="" $run_testsuite
 # ./configure \
 #   CC=clang-9 \
 #   CFLAGS="-O0 -g -fno-omit-frame-pointer -fsanitize=memory" \
+#   LDFLAGS="-fsanitize=memory" \
 #   --disable-native-compiler
 # # A tool that makes error backtraces nicer
 # # Need to pick the one that matches clang-6.0


### PR DESCRIPTION
The present PR is a follow-up to both #9824 (Build system: honour the
CFLAGS and CPPFLAGS build variables) and #9837 (Build system: use
OC_CFLAGS and CFLAGS even during the link stage).

After #9824 was merged, Inria's `extra-checks` CI job got broken
because the link stage needed the sanitizer-related flags, too.
The fix that was then provided in #9837 was actually not correct: rather
than using CFLAGS also during the link stage, which is not what GNU make does
by default, we should rather
duplicate the relevant flags into LDFLAGS.

This makes sense because even a flag with the same name does not
have the same semantics depending on whether it is in CFLAGS or LDFLAGS.
For the instrumentation flags, for instance, when in CFLAGS they request the
code to be compiled with instrumentation, whereas when in LDFLAGS they
request that the runtime support for instrumentation to be linked in, which
is of course related but still slightly different.

The reason why the flags intended to be in CFLAGS and those intended to be
in LDFLAGS often have the same name is to make it possible to do both
compile and link in one go, which we still were doing sometimes at the time
of #9824 and #9837 (e.g. for `checkstack`) but do not do any longer
nowadays: our build system pays a lot of attention not to confuse
compile and link commands, be it for programs / libraries in C or in OCaml.

This PR opens the road to an improvement in the way TSan build flags are
handled, which will considerably speed-up the build of TSan-enabled
compilers. Once this PR is merged, we will also be able to bring #12589 to
its clean and ocrrect completion.