### PR TITLE
gcc: fix partial linking by using gcc -r instead of ld -r

### DIFF
--- a/Changes
+++ b/Changes
@@ -300,6 +300,10 @@ _______________
   incorrectly triggering Warning 53.
   (Nicolás Ojeda Bär, review by Chris Casinghino and Florian Angeletti)
 
+- #13202: Fix an issue where `-output-complete-obj` would fail due to an
+  inability to locate installed libraries.
+  (Nicolás Ojeda Bär, review by Antonin Décimo)
+
 OCaml 5.2.0 (13 May 2024)
 -------------------------
 

--- a/Changes
+++ b/Changes
@@ -300,8 +300,8 @@ _______________
   incorrectly triggering Warning 53.
   (Nicolás Ojeda Bär, review by Chris Casinghino and Florian Angeletti)
 
-- #13202: Fix an issue where `-output-complete-obj` would fail due to an
-  inability to locate installed libraries.
+- #13202: Fix an issue where `-output-complete-obj` would fail when using the
+  GCC compiler due to an inability to locate installed libraries.
   (Nicolás Ojeda Bär, review by Antonin Décimo)
 
 OCaml 5.2.0 (13 May 2024)

--- a/configure
+++ b/configure
@@ -16297,12 +16297,12 @@ esac
   # output filename. Don't assume that all C compilers understand GNU -ofoo
   # form, so ensure that the definition includes a space at the end (which is
   # achieved using the $(EMPTY) expansion trick in Makefile.config.in).
-  case "$ocaml_cc_vendor,$host" in #(
-  msvc-*,*) :
+  case "$ocaml_cc_vendor" in #(
+  msvc-*) :
     # For the Microsoft C compiler there must be no space at the end of the
       # string.
       PACKLD="link -lib -nologo $machine -out:" ;; #(
-  *gcc*,*-*-mingw32*) :
+  gcc-*) :
     PACKLD="$CC -r$PACKLD_FLAGS -o " ;; #(
   *) :
     PACKLD="$DIRECT_LD -r$PACKLD_FLAGS -o " ;;

--- a/configure
+++ b/configure
@@ -16302,7 +16302,7 @@ esac
     # For the Microsoft C compiler there must be no space at the end of the
       # string.
       PACKLD="link -lib -nologo $machine -out:" ;; #(
-  clang-*|gcc-*|mingw-*-*-gcc-*) :
+  *gcc*) :
     PACKLD="$CC -r$PACKLD_FLAGS -o " ;; #(
   *) :
     PACKLD="$DIRECT_LD -r$PACKLD_FLAGS -o " ;;

--- a/configure
+++ b/configure
@@ -16297,11 +16297,13 @@ esac
   # output filename. Don't assume that all C compilers understand GNU -ofoo
   # form, so ensure that the definition includes a space at the end (which is
   # achieved using the $(EMPTY) expansion trick in Makefile.config.in).
-  case "$ocaml_cc_vendor" in #(
-  msvc-*) :
+  case "$ocaml_cc_vendor,$host" in #(
+  msvc-*,*) :
     # For the Microsoft C compiler there must be no space at the end of the
       # string.
       PACKLD="link -lib -nologo $machine -out:" ;; #(
+  *gcc*,*-*-mingw32*) :
+    PACKLD="$CC -r$PACKLD_FLAGS -o " ;; #(
   *) :
     PACKLD="$DIRECT_LD -r$PACKLD_FLAGS -o " ;;
 esac

--- a/configure
+++ b/configure
@@ -16302,7 +16302,7 @@ esac
     # For the Microsoft C compiler there must be no space at the end of the
       # string.
       PACKLD="link -lib -nologo $machine -out:" ;; #(
-  gcc-*) :
+  clang-*|gcc-*|mingw-*-*-gcc-*) :
     PACKLD="$CC -r$PACKLD_FLAGS -o " ;; #(
   *) :
     PACKLD="$DIRECT_LD -r$PACKLD_FLAGS -o " ;;

--- a/configure.ac
+++ b/configure.ac
@@ -1525,11 +1525,13 @@ AS_IF([test -z "$PARTIALLD"],
   # output filename. Don't assume that all C compilers understand GNU -ofoo
   # form, so ensure that the definition includes a space at the end (which is
   # achieved using the $(EMPTY) expansion trick in Makefile.config.in).
-  AS_CASE(["$ocaml_cc_vendor"],
-    [msvc-*],
+  AS_CASE(["$ocaml_cc_vendor,$host"],
+    [msvc-*,*],
       # For the Microsoft C compiler there must be no space at the end of the
       # string.
       [PACKLD="link -lib -nologo $machine -out:"],
+    [*gcc*,*-*-mingw32*],
+      [PACKLD="$CC -r$PACKLD_FLAGS -o "],
     [PACKLD="$DIRECT_LD -r$PACKLD_FLAGS -o "])],
   [PACKLD="$PARTIALLD -o "])
 

--- a/configure.ac
+++ b/configure.ac
@@ -1530,7 +1530,7 @@ AS_IF([test -z "$PARTIALLD"],
       # For the Microsoft C compiler there must be no space at the end of the
       # string.
       [PACKLD="link -lib -nologo $machine -out:"],
-    [clang-*|gcc-*|mingw-*-*-gcc-*],
+    [*gcc*],
       [PACKLD="$CC -r$PACKLD_FLAGS -o "],
     [PACKLD="$DIRECT_LD -r$PACKLD_FLAGS -o "])],
   [PACKLD="$PARTIALLD -o "])

--- a/configure.ac
+++ b/configure.ac
@@ -1530,7 +1530,7 @@ AS_IF([test -z "$PARTIALLD"],
       # For the Microsoft C compiler there must be no space at the end of the
       # string.
       [PACKLD="link -lib -nologo $machine -out:"],
-    [gcc-*],
+    [clang-*|gcc-*|mingw-*-*-gcc-*],
       [PACKLD="$CC -r$PACKLD_FLAGS -o "],
     [PACKLD="$DIRECT_LD -r$PACKLD_FLAGS -o "])],
   [PACKLD="$PARTIALLD -o "])

--- a/configure.ac
+++ b/configure.ac
@@ -1525,12 +1525,12 @@ AS_IF([test -z "$PARTIALLD"],
   # output filename. Don't assume that all C compilers understand GNU -ofoo
   # form, so ensure that the definition includes a space at the end (which is
   # achieved using the $(EMPTY) expansion trick in Makefile.config.in).
-  AS_CASE(["$ocaml_cc_vendor,$host"],
-    [msvc-*,*],
+  AS_CASE(["$ocaml_cc_vendor"],
+    [msvc-*],
       # For the Microsoft C compiler there must be no space at the end of the
       # string.
       [PACKLD="link -lib -nologo $machine -out:"],
-    [*gcc*,*-*-mingw32*],
+    [gcc-*],
       [PACKLD="$CC -r$PACKLD_FLAGS -o "],
     [PACKLD="$DIRECT_LD -r$PACKLD_FLAGS -o "])],
   [PACKLD="$PARTIALLD -o "])


### PR DESCRIPTION
Fixes #12487

See linked discussion for details. Roughly, under Mingw64 the command
```
$ touch t.ml
$ ocamlopt -output-complete-obj -I +unix unix.cmxa t.ml -o t.exe.o
```
fails today. This command calls the dynamic linker `ld` directly. Instead, here we propose to call `gcc` instead of `ld` which sets up the necessary entries in the load path so that linking succeeds.

Note that the same could probably be done under Unix, but since there is no problem under Unix today, I preferred to do a minimal fix for Mingw only.

Potential reviewers: @MisterDA @shindere @dra27 @dustanddreams 