### PR TITLE
Don't issue warning 53 if the compiler is stopping early

### DIFF
--- a/Changes
+++ b/Changes
@@ -315,6 +315,10 @@ _______________
   incorrectly triggering Warning 53.
   (Nicolás Ojeda Bär, review by Chris Casinghino and Florian Angeletti)
 
+- #13203: Do not issue warning 53 is the compiler is stopping before attributes
+  have been accurately marked.
+  (Chris Casinghino, review by Florian Angeletti)
+
 - #13207: Be sure to reload the register caching the exception handler in
   caml_c_call and caml_c_call_stack_args, as its value may have been changed
   if the OCaml stack is expanded during a callback.

--- a/parsing/builtin_attributes.mli
+++ b/parsing/builtin_attributes.mli
@@ -75,7 +75,8 @@ val register_attr : current_phase -> string Location.loc -> unit
 val mark_payload_attrs_used : Parsetree.payload -> unit
 
 (** Issue misplaced attribute warnings for all attributes created with
-    [mk_internal] but not yet marked used. *)
+    [mk_internal] but not yet marked used. Does nothing if compilation
+    is stopped before lambda due to command-line flags. *)
 val warn_unused : unit -> unit
 
 (** {3 Warning 53 helpers for environment attributes}

--- a/testsuite/tests/warnings/w53_flags.ml
+++ b/testsuite/tests/warnings/w53_flags.ml
@@ -1,0 +1,39 @@
+(* TEST
+   readonly_files = "w53.ml";
+   setup-ocamlc.byte-build-env;
+   module = "w53.ml";
+
+   (* We don't issue warning 53 when -i is passed *)
+   {
+     flags = "-warn-error +53 -i -w +A-22-27-32-60-67-70-71-72";
+     compile_only = "true";
+     ocamlc_byte_exit_status = "0";
+     ocamlc.byte;
+   }
+
+   (* We don't issue warning 53 when -stop-after parsing or -stop-after typing
+      is passed *)
+   {
+     flags =
+       "-warn-error +53 -stop-after parsing -w +A-22-27-32-60-67-70-71-72";
+     compile_only = "true";
+     ocamlc_byte_exit_status = "0";
+     ocamlc.byte;
+   }
+   {
+     flags =
+       "-warn-error +53 -stop-after typing -w +A-22-27-32-60-67-70-71-72";
+     compile_only = "true";
+     ocamlc_byte_exit_status = "0";
+     ocamlc.byte;
+   }
+
+   (* We do issue warning 53 when -stop-after lambda (or later) is passed *)
+   {
+     flags =
+       "-warn-error +53 -stop-after lambda -w +A-22-27-32-60-67-70-71-72";
+     compile_only = "true";
+     ocamlc_byte_exit_status = "2";
+     ocamlc.byte;
+   }
+*)


### PR DESCRIPTION
While reviewing #13170 , I noticed yet another issue with the new warning 53 implementation. If the compiler is stopped before lambda (for example, because `-i` or `-stop-after typing` is passed), we can't issue warning 53 accurately - the compiler hasn't had a chance to consume all the attributes yet.  As a result, when those flags are passed, we end up issuing warning 53 for attributes that are in fact valid.

This PR is a fix for that unfortunate behavior. I've gone with a somewhat heavy-handed approach, just checking in `warn_unused` whether one of those flags is passed.  (Perhaps there are other similar flags I've missed.)

I'm not sure this is the best approach, and am happy to hear alternative suggestions. We could instead try to move the call to `warn_unused` to a place where it will only be reached if the relevant flags are not passed. I couldn't immediately spot a good place. (Plus, there are actually two calls to `warn_unused`, and I'm likely to add a third in response to #13155, so perhaps it's nice to keep the logic inside of it).
