### PR TITLE
configure: fix test for whether ar supports @FILE

### DIFF
--- a/Changes
+++ b/Changes
@@ -321,6 +321,10 @@ _______________
   (Miod Vallat, report by Vesa Karvonen, review by Gabriel Scherer and
    Xavier Leroy)
 
+- #13209: Fix configure test that checks whether `ar` supports `@FILE`
+  arguments.
+  (Nicolás Ojeda Bär, report by Boris D.)
+
 OCaml 5.2.0 (13 May 2024)
 -------------------------
 

--- a/configure
+++ b/configure
@@ -13766,7 +13766,7 @@ ocamlsrcdir=${ocamlsrcdir%X}
 
 # Whether ar supports @FILE arguments
 
-case lt_cv_ar_at_file in #(
+case $lt_cv_ar_at_file in #(
   no) :
     ar_supports_response_files=false ;; #(
   *) :

--- a/configure.ac
+++ b/configure.ac
@@ -692,7 +692,7 @@ ocamlsrcdir=${ocamlsrcdir%X}
 
 # Whether ar supports @FILE arguments
 
-AS_CASE([lt_cv_ar_at_file],
+AS_CASE([$lt_cv_ar_at_file],
   [no], [ar_supports_response_files=false],
   [ar_supports_response_files=true])
 


### PR DESCRIPTION
Due to a missing `$`, the test for whether `ar` supports `@FILE` (#12070) was broken. Reported by @dboris in https://github.com/ocaml/ocaml/issues/12070#issuecomment-2143183565.