### PR TITLE
Silence cl output when building executables without flexlink

### DIFF
--- a/configure
+++ b/configure
@@ -21131,7 +21131,7 @@ fi
   if test "$ccomptype" = 'msvc'
 then :
   mkexe_via_cc_ldflags=\
-"\$(OUTPUTEXE)\$(1) \$(2) $mkexe_via_cc_ldflags"
+"/nologo \$(OUTPUTEXE)\$(1) \$(2) $mkexe_via_cc_ldflags"
 else $as_nop
   mkexe_via_cc_ldflags=\
 "$mkexe_via_cc_ldflags \$(OUTPUTEXE)\$(1) \$(2)"

--- a/configure.ac
+++ b/configure.ac
@@ -2708,7 +2708,7 @@ ${mkdll_ldflags}"
   # cl requires linker flags after the objects.
   AS_IF([test "$ccomptype" = 'msvc'],
     [mkexe_via_cc_ldflags=\
-"\$(OUTPUTEXE)\$(1) \$(2) $mkexe_via_cc_ldflags"],
+"/nologo \$(OUTPUTEXE)\$(1) \$(2) $mkexe_via_cc_ldflags"],
     [mkexe_via_cc_ldflags=\
 "$mkexe_via_cc_ldflags \$(OUTPUTEXE)\$(1) \$(2)"])
 ])


### PR DESCRIPTION
PR #13200 ceased passing `CLFAGS` to the linker. The `CFLAGS` contained `/nologo`, which silences the compiler verbose-ish output. Add it back for a quieter build.

No change entry needed.
cc @shindere 