### PR TITLE
Replace startup code block with loop to call all entry stubs.

### DIFF
--- a/.depend
+++ b/.depend
@@ -2796,6 +2796,7 @@ asmcomp/cmm_helpers.cmo : \
     utils/numbers.cmi \
     utils/misc.cmi \
     lambda/lambda.cmi \
+    typing/ident.cmi \
     lambda/debuginfo.cmi \
     utils/config.cmi \
     middle_end/compilenv.cmi \
@@ -2818,6 +2819,7 @@ asmcomp/cmm_helpers.cmx : \
     utils/numbers.cmx \
     utils/misc.cmx \
     lambda/lambda.cmx \
+    typing/ident.cmx \
     lambda/debuginfo.cmx \
     utils/config.cmx \
     middle_end/compilenv.cmx \

--- a/Changes
+++ b/Changes
@@ -113,6 +113,10 @@ _______________
   (Vincent Laviron, review by Hugo Heuzard, Nathanaëlle Courant
    and Gabriel Scherer)
 
+- #13217: Call entry functions in caml_program using a loop.
+  (Tim McGilchrist, original work by Pierre Oechsel,
+  reviewed by ????)
+
 ### Standard library:
 
 - #13168: In Array.shuffle, clarify the code that validates the

--- a/Changes
+++ b/Changes
@@ -179,6 +179,11 @@ Working version
   The pattern is uncommon in hand-written code but some ppxes produce it.
   (Vincent Laviron, report by Sacha-Élie Ayoun, review by Gabriel Scherer)
 
+- #13217: Generate `caml_program` as a loop over a table of module entry points
+  instead of emitting one call block per module, making the size of the startup
+  code independent of the number of linked modules.
+  (Pierre Oechsel and Tim McGilchrist, review by Stefan Muenzel)
+
 ### Standard library:
 
 - #10798: Atomic helper function

--- a/asmcomp/asmlink.ml
+++ b/asmcomp/asmlink.ml
@@ -205,18 +205,19 @@ let make_startup_file ~ppf_dump units_list ~crc_interfaces =
   Emit.begin_assembly ();
   let name_list =
     List.flatten (List.map (fun (info,_,_) -> info.ui_defines) units_list) in
-  let entry = Cmm_helpers.entry_point name_list in
-  let entry =
-    if Config.tsan then
-      match entry with
-      | Cfunction ({ fun_body; _ } as cf) ->
-          Cmm.Cfunction
-            { cf with fun_body = Thread_sanitizer.wrap_entry_exit fun_body }
-      | _ -> assert false
-    else
-      entry
+  let entries = match Cmm_helpers.entry_point name_list with
+    | [d;entry] ->
+      if Config.tsan then
+        match entry with
+        | Cfunction ({ fun_body; _ } as cf) ->
+           [d;Cmm.Cfunction
+             { cf with fun_body = Thread_sanitizer.wrap_entry_exit fun_body }]
+        | a -> [d;a]
+      else
+        [d;entry]
+    | _ -> assert false;
   in
-  compile_phrase entry;
+  List.iter compile_phrase entries;
   let units = List.map (fun (info,_,_) -> info) units_list in
   List.iter compile_phrase
     (Cmm_helpers.emit_preallocated_blocks [] (* add gc_roots (for dynlink) *)

--- a/asmcomp/asmlink.ml
+++ b/asmcomp/asmlink.ml
@@ -215,18 +215,15 @@ let make_startup_file ~ppf_dump units_list ~crc_interfaces =
   Emit.begin_assembly ();
   let name_list =
     List.flatten (List.map (fun (info,_,_) -> info.ui_defines) units_list) in
-  let entry = Cmm_helpers.entry_point name_list in
-  let entry =
-    if Config.tsan then
-      match entry with
-      | Cfunction ({ fun_body; _ } as cf) ->
-          Cmm.Cfunction
-            { cf with fun_body = Thread_sanitizer.wrap_entry_exit fun_body }
-      | _ -> assert false
-    else
-      entry
+  let wrap_tsan (phrase : Cmm.phrase) =
+    match phrase with
+    | Cfunction ({ fun_body; _ } as cf) when Config.tsan ->
+        Cmm.Cfunction
+          { cf with fun_body = Thread_sanitizer.wrap_entry_exit fun_body }
+    | phrase -> phrase
   in
-  compile_phrase entry;
+  List.iter (fun phrase -> compile_phrase (wrap_tsan phrase))
+    (Cmm_helpers.entry_point name_list);
   let units = List.map (fun (info,_,_) -> info) units_list in
   List.iter compile_phrase
     (Cmm_helpers.emit_preallocated_blocks [] (* add gc_roots (for dynlink) *)

--- a/asmcomp/cmm_helpers.ml
+++ b/asmcomp/cmm_helpers.ml
@@ -2594,7 +2594,20 @@ let emit_float_array_constant symb fields cont =
     (Misc.map_end (fun f -> Cdouble f) fields cont)
 
 (* Generate the entry point *)
-
+(*
+ * CAMLprim value caml_program()
+ * {
+ *   int id = 0;
+ *   while (true) {
+ *     if (id == len_caml_globals_entry_functions) goto out;
+ *     caml_globals_entry_functions[id]();
+ *     caml_globals_inited += 1;
+ *     id += 1;
+ *   }
+ *   out:
+ *   return 1;
+ * }
+ *)
 let entry_point namelist =
   let dbg = placeholder_dbg in
   let cconst_int i = Cconst_int (i, dbg ()) in
@@ -2605,23 +2618,48 @@ let entry_point namelist =
          Cop(Caddi, [Cop(mk_load_mut Word_int,
                        [cconst_symbol "caml_globals_inited"], dbg ());
                      cconst_int 1], dbg ())], dbg ()) in
+  let table_symbol =
+    Compilenv.make_symbol (Some "caml_globals_entry_functions") in
+  let call i =
+    (* address of caml_globals_entry_functions[i] *)
+    let entry_slot =
+      Cop(Cadda, [cconst_symbol table_symbol;
+                  Cop(Clsl, [i; cconst_int (Misc.log2 Arch.size_addr)],
+                      dbg ())], dbg ()) in
+    Csequence(Cop(Capply typ_void,
+                  [Cop(mk_load_immut Word_int, [entry_slot], dbg ())], dbg ()),
+              incr_global_inited ()) in
+  let data =
+    List.map
+      (fun name ->
+        Csymbol_address (Compilenv.make_symbol ~unitname:name (Some "entry")))
+      namelist in
+  let data = Cdefine_symbol table_symbol :: data in
+  let raise_num = Lambda.next_raise_count () in
+  let id = VP.create (V.create_local "*id*") in
+  let var_id = Cvar (VP.var id) in
+  let high = cconst_int (List.length namelist) in
   let body =
-    List.fold_right
-      (fun name next ->
-        let entry_sym = Compilenv.make_symbol ~unitname:name (Some "entry") in
-        Csequence(Cop(Capply typ_void,
-                         [cconst_symbol entry_sym], dbg ()),
-                  Csequence(incr_global_inited (), next)))
-      namelist (cconst_int 1) in
+    let next_iteration =
+      Cexit(raise_num, [Cop(Caddi, [var_id; cconst_int 1], dbg ())]) in
+    Ccatch(Recursive,
+           [raise_num, [id, typ_int],
+            Cifthenelse(Cop(Ccmpi Ceq, [var_id; high], dbg ()),
+                        dbg (), Ctuple [],
+                        dbg (), Csequence(call var_id, next_iteration),
+                        dbg ()),
+            dbg ()],
+           Cexit(raise_num, [cconst_int 0])) in
   let fun_name = "caml_program" in
   let fun_dbg = placeholder_fun_dbg ~human_name:fun_name in
-  Cfunction {fun_name;
-             fun_args = [];
-             fun_body = body;
-             fun_codegen_options = [Reduce_code_size];
-             fun_poll = Default_poll;
-             fun_dbg;
-            }
+  [ Cdata data;
+    Cfunction {fun_name;
+               fun_args = [];
+               fun_body = Csequence(body, cconst_int 1);
+               fun_codegen_options = [Reduce_code_size];
+               fun_poll = Default_poll;
+               fun_dbg;
+              } ]
 
 (* Generate the table of globals *)
 

--- a/asmcomp/cmm_helpers.mli
+++ b/asmcomp/cmm_helpers.mli
@@ -595,7 +595,7 @@ val placeholder_dbg : unit -> Debuginfo.t
 val placeholder_fun_dbg : human_name:string -> Debuginfo.t
 
 (** Entry point *)
-val entry_point : string list -> phrase
+val entry_point : string list -> phrase list
 
 (** Generate the caml_globals table *)
 val global_table: string list -> phrase

--- a/asmcomp/cmm_helpers.mli
+++ b/asmcomp/cmm_helpers.mli
@@ -600,7 +600,7 @@ val placeholder_dbg : unit -> Debuginfo.t
 val placeholder_fun_dbg : human_name:string -> Debuginfo.t
 
 (** Entry point *)
-val entry_point : string list -> phrase
+val entry_point : string list -> phrase list
 
 (** Generate the caml_globals table *)
 val global_table: string list -> phrase


### PR DESCRIPTION
This is a small improvement to rewrite the entry_point code generated by `cmm_helpers.ml` to be data driven.

When starting a native OCaml program the call stack goes through C functions (caml_main, caml_startup_common and caml_startup_common,  in `startup_nat.c` before jumping to the processor specific assembly in `runtime/arm64.s` (or whatever architecture you have) starting at `caml_start_program`. Before it jumps to `caml_program` which calls the module `.entry` point for the modules included in an executable. At this point currently OCaml generates a block of assembly code for each module entry point that needs to be called, 35 for a minimal program that just relies on the Stdlib (potentially more?). This change re-writes this code to be a loop equivalent to this C code:

``` c
 {
   int id = 0;
   while (true) {
     if (id == len_caml_globals_entry_functions) goto out;
     caml_globals_entry_functions[id]();
     caml_globals_inited += 1;
     id += 1;
   }
   out:
   return 1;
 }
```

What is gained by making this change? More compact assembly code that is data driven using a loop and lookup table of symbols. Possibly faster startup but I have no data to back this up. The work was done original in PR https://github.com/ocaml-flambda/flambda-backend/pull/1425 by @poechsel, I have only cherry picked it here after noticing the repeated assembly code blocks.

@poechsel please correct any attribution as you see fit.
