### PR TITLE
Make the CI dump `config.log` and verbosely print failed commands

### DIFF
--- a/.github/workflows/build-msvc.yml
+++ b/.github/workflows/build-msvc.yml
@@ -97,9 +97,9 @@ jobs:
           fi ;
           make -j ;
           runtime/ocamlrun ocamlc -config ;
-          # Don't add indentation or comments, it breaks Bash on
-          # Windows when the yaml text block scalar is processed as a
-          # single line.
+        # Don't add indentation or comments, it breaks Bash on
+        # Windows when the yaml text block scalar is processed as a
+        # single line.
 
       - name: Save Autoconf cache
         uses: actions/cache/save@v4
@@ -118,9 +118,9 @@ jobs:
           awk -f tools/ci/actions/canonicalize-dumpbin.awk runtime/amd64.dump runtime/amd64.dump > runtime/amd64.canonical ;
           git diff --no-index -- runtime/amd64*.canonical ;
           wc -l runtime/amd64*.dump runtime/amd64*.canonical ;
-          # ^ The final wc is there to make sure that the canonical files are
-          # reasonable cleaned-up versions of the raw dumpbins and not simply
-          # empty
+        # ^ The final wc is there to make sure that the canonical files are
+        # reasonable cleaned-up versions of the raw dumpbins and not simply
+        # empty
         if: matrix.x86_64
 
       - name: Run the test suite

--- a/.github/workflows/build-msvc.yml
+++ b/.github/workflows/build-msvc.yml
@@ -12,6 +12,10 @@ on:
       - 'trunk'
   pull_request:
 
+# env:
+  # Fully print commands executed by Make
+  # MAKEFLAGS: V=1
+
 jobs:
   build:
     permissions: {}

--- a/.github/workflows/build-msvc.yml
+++ b/.github/workflows/build-msvc.yml
@@ -102,7 +102,8 @@ jobs:
           || failed=$?;
           if ((failed)) ; then cat config.log ; exit $failed ; fi ;
           fi ;
-          make -j ;
+          make -j || failed=$? ;
+          if ((failed)) ; then make -j1 V=1 ; exit $failed ; fi ;
           runtime/ocamlrun ocamlc -config ;
         # Don't add indentation or comments, it breaks Bash on
         # Windows when the yaml text block scalar is processed as a

--- a/.github/workflows/build-msvc.yml
+++ b/.github/workflows/build-msvc.yml
@@ -97,7 +97,10 @@ jobs:
           eval $(tools/msvs-promote-path) ;
           if ! ./configure --cache-file=config.cache --host=$HOST CC=$CC ; then
           rm -rf config.cache ;
-          ./configure --cache-file=config.cache --host=$HOST CC=$CC ;
+          failed=0 ;
+          ./configure --cache-file=config.cache --host=$HOST CC=$CC \
+          || failed=$?;
+          if ((failed)) ; then cat config.log ; exit $failed ; fi ;
           fi ;
           make -j ;
           runtime/ocamlrun ocamlc -config ;

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -160,7 +160,7 @@ jobs:
         with:
           persist-credentials: false
       - name: OS Dependencies
-        if: runner.os == 'MacOS'
+        if: runner.os == 'macOS'
         run: brew install parallel
       - name: configure tree
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,6 +16,8 @@ env:
   # directories are selected because of their tendencies to reach corner cases
   # in the runtime system.
   PARALLEL_TESTS: parallel callback gc-roots weak-ephe-final
+  # Fully print commands executed by Make
+  # MAKEFLAGS: V=1
 
 # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#concurrency
 # Concurrent workflows are grouped by the PR or branch that triggered them

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,10 +11,10 @@ on:
 # Restrict the GITHUB_TOKEN
 permissions: {}
 
-# List of test directories for the debug-s4096 and linux-O0 jobs.
-# These directories are selected because of their tendencies to reach corner
-# cases in the runtime system.
 env:
+  # List of test directories for the debug-s4096 and linux-O0 jobs. These
+  # directories are selected because of their tendencies to reach corner cases
+  # in the runtime system.
   PARALLEL_TESTS: parallel callback gc-roots weak-ephe-final
 
 # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#concurrency

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -36,6 +36,8 @@ environment:
     OCAMLRUNPARAM: v=0,b
     FORCE_CYGWIN_UPGRADE: 0
     BUILD_MODE: world.opt
+    # Fully print commands executed by Make
+    # MAKEFLAGS: V=1
   matrix:
     - PORT: mingw64
       BOOTSTRAP_FLEXDLL: true

--- a/tools/ci/actions/runner.sh
+++ b/tools/ci/actions/runner.sh
@@ -44,7 +44,9 @@ EOF
     --disable-dependency-generation \
     $CONFIG_ARG"
 
-  ./configure $configure_flags
+  local failed
+  ./configure $configure_flags || failed=$?
+  if ((failed)) ; then cat config.log ; exit $failed ; fi
 }
 
 Build () {
@@ -136,7 +138,9 @@ This test checks the global structure of the reference manual
 --------------------------------------------------------------------------
 EOF
   # we need some of the configuration data provided by configure
-  ./configure
+  local failed
+  ./configure || failed=$?
+  if ((failed)) ; then cat config.log ; exit $failed ; fi
   $MAKE check-stdlib check-case-collision -C manual/tests
 
 }
@@ -164,9 +168,12 @@ ReportBuildStatus () {
 BasicCompiler () {
   trap ReportBuildStatus ERR
 
+  local failed
   ./configure --disable-dependency-generation \
               --disable-debug-runtime \
-              --disable-instrumented-runtime
+              --disable-instrumented-runtime \
+      || failed=$?
+  if ((failed)) ; then cat config.log ; exit $failed ; fi
 
   # Need a runtime
   make -j coldstart

--- a/tools/ci/actions/runner.sh
+++ b/tools/ci/actions/runner.sh
@@ -48,6 +48,7 @@ EOF
 }
 
 Build () {
+  export TERM=ansi
   if [ "$(uname)" = 'Darwin' ]; then
     script -q build.log $MAKE_WARN
   else

--- a/tools/ci/appveyor/appveyor_build.sh
+++ b/tools/ci/appveyor/appveyor_build.sh
@@ -97,8 +97,11 @@ function set_configuration {
     if ! ./configure --cache-file="$CACHE_FILE" $dep $build $man $host \
                      --prefix="$2" --enable-ocamltest ; then
         rm -f -- "$CACHE_FILE"
+        local failed
         ./configure --cache-file="$CACHE_FILE" $dep $build $man $host \
-                    --prefix="$2" --enable-ocamltest
+                    --prefix="$2" --enable-ocamltest \
+            || failed=$?
+        if ((failed)) ; then cat config.log ; exit $failed ; fi
     fi
 
 #    FILE=$(pwd | cygpath -f - -m)/Makefile.config


### PR DESCRIPTION
I've been hacking the configure script and the Makefiles a lot lately, and although the CI build matrix is immensely useful to test the variety of systems at once, it's not great when one has to debug why the configure script failed or print the commands Make invokes.
This PR will:
- in case `configure` fails, dump `config.log` (the list of all commands executed by the configure script, with their output) ;
- ~in case `make` fails, re-run `make` dry-run, printing the last commands, including the one that failed, without executing them (as suggested in #11844)~;
- in case `make` fails, re-run it and print the commands executed.

I haven't changed the Make invocations in the AppVeyor script, which is a bit more complex, or the Inria precheck scripts.

I've included other little cleanups to the Github Actions script.

I've also added an easy way of toggling make's full printing of executed commands, with the `MAKEFLAGS` env var set to `V=1`.

(no change entry needed)