### PR TITLE
Clarify barriers and spin macros with delayed expansion

### DIFF
--- a/Changes
+++ b/Changes
@@ -469,6 +469,9 @@ Working version
   into a match in typetexp.
   (Samuel Vivien, review by Gabriel Scherer)
 
+- #13224: Clarify barriers and spin macros with delayed expansion.
+  (Antonin Décimo, review by David Allsopp and Gabriel Scherer)
+
 ### Build system:
 
 - #13810: Support build of cross compilers to native freestanding targets

--- a/runtime/caml/domain.h
+++ b/runtime/caml/domain.h
@@ -246,15 +246,15 @@ void caml_global_barrier_release_as_final(barrier_status status);
 #define Caml_global_barrier_if_final_(/* symbols */ alone, b, go,       \
                                       /* params  */ num_participating)  \
   /* fast path when alone */                                            \
-  int alone = (num_participating) == 1;                                 \
+  bool alone = (num_participating) == 1;                                \
   barrier_status b = 0;                                                 \
   if (alone ||                                                          \
       (b = caml_global_barrier_and_check_final(num_participating)))     \
-    for (int go = 1; go;                                                \
+    for (bool go = true; go;                                            \
          /* release the barrier after the body has executed once */     \
          (alone ? (void)0 :                                             \
           caml_global_barrier_release_as_final(b)),                     \
-         go = 0)
+         go = false)
 
 #define Caml_global_barrier_if_final(num_participating)               \
   Caml_global_barrier_if_final_(CAML_GENSYM(alone), CAML_GENSYM(b),   \

--- a/runtime/caml/domain.h
+++ b/runtime/caml/domain.h
@@ -243,18 +243,22 @@ void caml_global_barrier_release_as_final(barrier_status status);
    Note: this expands to an [if] and [for] header, do not exit the body using
    jumps or returns, and do not put an [else] immediately after.
  */
-#define Caml_global_barrier_if_final(num_participating)                 \
+#define Caml_global_barrier_if_final_(/* symbols */ alone, b, go,       \
+                                      /* params  */ num_participating)  \
   /* fast path when alone */                                            \
-  int CAML_GENSYM(alone) = (num_participating) == 1;                    \
-  barrier_status CAML_GENSYM(b) = 0;                                    \
-  if (CAML_GENSYM(alone) ||                                             \
-      (CAML_GENSYM(b)                                                   \
-       = caml_global_barrier_and_check_final(num_participating)))       \
-    for (int CAML_GENSYM(continue) = 1; CAML_GENSYM(continue);          \
+  int alone = (num_participating) == 1;                                 \
+  barrier_status b = 0;                                                 \
+  if (alone ||                                                          \
+      (b = caml_global_barrier_and_check_final(num_participating)))     \
+    for (int go = 1; go;                                                \
          /* release the barrier after the body has executed once */     \
-         ((CAML_GENSYM(alone) ? (void)0 :                               \
-           caml_global_barrier_release_as_final(CAML_GENSYM(b))),       \
-          CAML_GENSYM(continue) = 0))
+         (alone ? (void)0 :                                             \
+          caml_global_barrier_release_as_final(b)),                     \
+         go = 0)
+
+#define Caml_global_barrier_if_final(num_participating)               \
+  Caml_global_barrier_if_final_(CAML_GENSYM(alone), CAML_GENSYM(b),   \
+                                CAML_GENSYM(go), (num_participating))
 
 /*
  * Termination helpers.

--- a/runtime/caml/misc.h
+++ b/runtime/caml/misc.h
@@ -781,10 +781,10 @@ CAMLextern int caml_snwprintf(wchar_t * buf,
 #  endif
 #endif
 
-/* Generate a named symbol that is unique within the current macro expansion */
-#define CAML_GENSYM_3(name, l) caml__##name##_##l
-#define CAML_GENSYM_2(name, l) CAML_GENSYM_3(name, l)
-#define CAML_GENSYM(name) CAML_GENSYM_2(name, __LINE__)
+/* Generate a named symbol that is unique */
+#define CAML_GENSYM__(name, id) caml__##name##_##id
+#define CAML_GENSYM_(name, id) CAML_GENSYM__(name, id)
+#define CAML_GENSYM(name) CAML_GENSYM_(name, __COUNTER__)
 
 #define MSEC_PER_SEC  UINT64_C(1000)
 #define USEC_PER_MSEC UINT64_C(1000)

--- a/runtime/caml/platform.h
+++ b/runtime/caml/platform.h
@@ -552,11 +552,13 @@ void caml_plat_barrier_wait_sense(caml_plat_barrier*,
 #define Max_spins_medium 300
 #define Max_spins_short 30
 
-#define SPIN_WAIT_NTIMES(N)                             \
-  unsigned CAML_GENSYM(spins) = 0;                      \
-  unsigned CAML_GENSYM(max_spins) = (N);                \
-  for (; CAML_GENSYM(spins) < CAML_GENSYM(max_spins);   \
-       cpu_relax(), ++CAML_GENSYM(spins))
+#define SPIN_WAIT_NTIMES_(/* symbols */ spins, max_spins, /* params */ N) \
+  const unsigned max_spins = (N);                                       \
+  for (unsigned spins = 0; spins < max_spins; cpu_relax(), ++spins)
+
+#define SPIN_WAIT_NTIMES(N)                                             \
+  SPIN_WAIT_NTIMES_(CAML_GENSYM(spins), CAML_GENSYM(max_spins), (N))
+
 #define SPIN_WAIT_BOUNDED SPIN_WAIT_NTIMES(Max_spins_medium)
 #define SPIN_WAIT SPIN_WAIT_BACK_OFF(Max_spins_long)
 
@@ -585,14 +587,18 @@ Caml_inline unsigned caml_plat_spin_step(unsigned spins,
   }
 }
 
-#define SPIN_WAIT_BACK_OFF(max_spins)                                   \
-  unsigned CAML_GENSYM(spins) = 0;                                      \
-  unsigned CAML_GENSYM(max_spins) = (max_spins);                        \
-  static const struct caml_plat_srcloc CAML_GENSYM(loc) = {             \
-    __FILE__, __LINE__, __func__                                        \
-  };                                                                    \
-  for (; 1; CAML_GENSYM(spins) = caml_plat_spin_step(                   \
-         CAML_GENSYM(spins), CAML_GENSYM(max_spins), &CAML_GENSYM(loc)))
+#define SPIN_WAIT_BACK_OFF_(/* symbols */ spins, max_spins, loc,  \
+                            /* params  */ N)                      \
+  const unsigned max_spins = (N);                                 \
+  static const struct caml_plat_srcloc loc =                      \
+    { __FILE__, __LINE__, __func__ };                             \
+  for (unsigned spins = 0;                                        \
+       1;                                                         \
+       spins = caml_plat_spin_step(spins, max_spins, &loc))
+
+#define SPIN_WAIT_BACK_OFF(N)                                     \
+  SPIN_WAIT_BACK_OFF_(CAML_GENSYM(spins), CAML_GENSYM(max_spins), \
+                      CAML_GENSYM(loc), (N))
 
 /* Memory management primitives (mmap) */
 

--- a/runtime/caml/platform.h
+++ b/runtime/caml/platform.h
@@ -33,6 +33,7 @@
 
 #include <errno.h>
 #include <string.h>
+#include <stdbool.h>
 #include "config.h"
 #include "mlvalues.h"
 #include "sys.h"
@@ -593,7 +594,7 @@ Caml_inline unsigned caml_plat_spin_step(unsigned spins,
   static const struct caml_plat_srcloc loc =                      \
     { __FILE__, __LINE__, __func__ };                             \
   for (unsigned spins = 0;                                        \
-       1;                                                         \
+       true;                                                      \
        spins = caml_plat_spin_step(spins, max_spins, &loc))
 
 #define SPIN_WAIT_BACK_OFF(N)                                     \


### PR DESCRIPTION
It's possible to simplify the code content of the macros using delayed macro expansion to generate the identifiers.

The macro `__COUNTER__` expands to sequential integral values starting from 0. `__COUNTER__` is documented by [GCC][], [clang][], [MSVC][], and [xlc][] (but what of Sun C)?

Also reduce the scope of for loop iterators, and use C99 booleans.

(no change entry needed)

[GCC]: https://gcc.gnu.org/onlinedocs/cpp/Common-Predefined-Macros.html
[clang]: https://clang.llvm.org/docs/LanguageExtensions.html#builtin-macros
[MSVC]: https://learn.microsoft.com/en-us/cpp/preprocessor/predefined-macros?view=msvc-170
[xlc]: https://www.ibm.com/docs/en/SSGH3R_16.1.0/pdf/compiler.pdf#_OPENTOPIC_TOC_PROCESSING_d135e153465