### PR TITLE
Export `Cmt2annot.{iterator,binary_part}`

### DIFF
--- a/.depend
+++ b/.depend
@@ -611,6 +611,8 @@ typing/cmt2annot.cmx : \
     typing/annot.cmi \
     typing/cmt2annot.cmi
 typing/cmt2annot.cmi : \
+    typing/tast_iterator.cmi \
+    parsing/location.cmi \
     file_formats/cmt_format.cmi
 typing/ctype.cmo : \
     typing/types.cmi \

--- a/Changes
+++ b/Changes
@@ -198,6 +198,10 @@ _______________
 - #13151, name conflicts explanation as a footnote
   (Florian Angeletti, review by Gabriel Scherer)
 
+- #13228: Re-export Cmt2annot.{iterator,binary_part} which had become hidden
+  since #11288 and broke ocamlbrowser.
+  (David Allsopp, report by Jacques Garrigue, review by ??)
+
 ### Internal/compiler-libs changes:
 
 - #11129, #11148: enforce that ppxs do not produce `parsetree`s with

--- a/typing/cmt2annot.mli
+++ b/typing/cmt2annot.mli
@@ -20,3 +20,7 @@ val gen_annot :
   sourcefile:string option ->
   use_summaries:bool -> Cmt_format.binary_annots ->
   unit
+
+val iterator : scope:Location.t -> bool -> Tast_iterator.iterator
+
+val binary_part : Tast_iterator.iterator -> Cmt_format.binary_part -> unit


### PR DESCRIPTION
Following up https://github.com/ocaml/ocaml/pull/11288#issuecomment-2157525418 - there may be some further discussion wanted as to how much support should remain here for annot files, but as a starting point and to track the issue, here's a PR re-exporting those functions again.

cc @garrigue