### PR TITLE
cmt2annot: make the iterator and binary_part functions public

### DIFF
--- a/typing/cmt2annot.mli
+++ b/typing/cmt2annot.mli
@@ -15,6 +15,10 @@
 
 (* Generate an .annot file from a .cmt file. *)
 
+val iterator : scope:Location.t -> bool -> Tast_iterator.iterator
+
+val binary_part : Tast_iterator.iterator -> Cmt_format.binary_part -> unit
+
 val gen_annot :
   string option ->
   sourcefile:string option ->


### PR DESCRIPTION
In response to https://github.com/ocaml/ocaml/pull/11288#issuecomment-2157525418