### PR TITLE
Enable software prefetching on MSVC and clang-cl x86 and x86_64

### DIFF
--- a/Changes
+++ b/Changes
@@ -91,6 +91,10 @@ _______________
   extension to enable threaded code interpretation.
   (Antonin Décimo, review by Miod Vallat)
 
+- #13238: Enable software prefetching on x86 and x86_64 when building
+  with MSVC or clang-cl.
+  (Antonin Décimo, review by Miod Vallat)
+
 ### Code generation and optimizations:
 
 - #13014: Enable compile-time option -function-sections on all previously

--- a/runtime/caml/misc.h
+++ b/runtime/caml/misc.h
@@ -178,9 +178,15 @@ CAMLdeprecated_typedef(addr, char *);
 /* Prefetching */
 
 #ifdef CAML_INTERNALS
-#if defined(__GNUC__) && (defined(__i386__) || defined(__x86_64__))
+#if (__has_builtin(__builtin_prefetch) || defined(__GNUC__)) && \
+    (defined(__i386__) || defined(__x86_64__) || \
+     defined(_M_IX86) || defined(_M_AMD64))
 #define caml_prefetch(p) __builtin_prefetch((p), 1, 3)
 /* 1 = intent to write; 3 = all cache levels */
+#elif defined(_MSC_VER) && (defined(_M_IX86) || defined(_M_AMD64))
+#include <intrin.h>
+#define caml_prefetch(p) _mm_prefetch((char const *) p, _MM_HINT_T0)
+/* PreFetchCacheLine(PF_TEMPORAL_LEVEL_1, p) */
 #else
 #define caml_prefetch(p)
 #endif

--- a/runtime/caml/misc.h
+++ b/runtime/caml/misc.h
@@ -29,7 +29,7 @@
 
 #include "camlatomic.h"
 
-/* Detection of available C attributes */
+/* Detection of available C attributes and compiler extensions */
 
 #ifndef __has_c_attribute
 #define __has_c_attribute(x) 0
@@ -37,6 +37,10 @@
 
 #ifndef __has_attribute
 #define __has_attribute(x) 0
+#endif
+
+#ifndef __has_builtin
+#define __has_builtin(x) 0
 #endif
 
 /* Deprecation warnings */
@@ -328,14 +332,6 @@ CAMLnoret CAMLextern void caml_fatal_error (char *, ...)
 #endif
 ;
 
-/* Detection of available C built-in functions, the Clang way. */
-
-#ifdef __has_builtin
-#define Caml_has_builtin(x) __has_builtin(x)
-#else
-#define Caml_has_builtin(x) 0
-#endif
-
 /* Integer arithmetic with overflow detection.
    The functions return 0 if no overflow, 1 if overflow.
    The result of the operation is always stored at [*res].
@@ -345,7 +341,7 @@ CAMLnoret CAMLextern void caml_fatal_error (char *, ...)
 
 Caml_inline int caml_uadd_overflow(uintnat a, uintnat b, uintnat * res)
 {
-#if __GNUC__ >= 5 || Caml_has_builtin(__builtin_add_overflow)
+#if __has_builtin(__builtin_add_overflow) || defined(__GNUC__) && __GNUC__ >= 5
   return __builtin_add_overflow(a, b, res);
 #else
   uintnat c = a + b;
@@ -356,7 +352,7 @@ Caml_inline int caml_uadd_overflow(uintnat a, uintnat b, uintnat * res)
 
 Caml_inline int caml_usub_overflow(uintnat a, uintnat b, uintnat * res)
 {
-#if __GNUC__ >= 5 || Caml_has_builtin(__builtin_sub_overflow)
+#if __has_builtin(__builtin_sub_overflow) || defined(__GNUC__) && __GNUC__ >= 5
   return __builtin_sub_overflow(a, b, res);
 #else
   uintnat c = a - b;
@@ -365,7 +361,7 @@ Caml_inline int caml_usub_overflow(uintnat a, uintnat b, uintnat * res)
 #endif
 }
 
-#if __GNUC__ >= 5 || Caml_has_builtin(__builtin_mul_overflow)
+#if __has_builtin(__builtin_mul_overflow) || defined(__GNUC__) && __GNUC__ >= 5
 Caml_inline int caml_umul_overflow(uintnat a, uintnat b, uintnat * res)
 {
   return __builtin_mul_overflow(a, b, res);

--- a/runtime/misc.c
+++ b/runtime/misc.c
@@ -210,7 +210,8 @@ void caml_ext_table_free(struct ext_table * tbl, int free_entries)
 
 /* Integer arithmetic with overflow detection */
 
-#if ! (__GNUC__ >= 5 || Caml_has_builtin(__builtin_mul_overflow))
+#if ! (__has_builtin(__builtin_mul_overflow) || \
+       defined(__GNUC__) && __GNUC__ >= 5)
 CAMLexport int caml_umul_overflow(uintnat a, uintnat b, uintnat * res)
 {
 #define HALF_SIZE (sizeof(uintnat) * 4)


### PR DESCRIPTION
Chasing the last bits of the MSVC/clang-cl restore, re-enable software prefetching hints to help the garbage collector on MSVC and clang-cl.

Both GCC and MSVC emit the `prefetcht0` instruction (check on [godbolt](https://godbolt.org/z/eKeaEzr5Y)).
Prefer clang's builtin instead of the intrinsic, I find it a bit cleaner and it's one fewer header.
With MSVC, call the intrinsic directly in order not to have to pull `winnt.h` via `windows.h` (for [`PreFetchCacheLine`](https://learn.microsoft.com/en-us/windows/win32/api/winnt/nf-winnt-prefetchcacheline)). I'm using the same definition as `PreFetchCacheLine`.

An ad-hoc benchmark using [hyperfine](https://github.com/sharkdp/hyperfine)'s defaults on Stephen Dolan's [markbench](https://github.com/ocaml-bench/sandmark/blob/main/benchmarks/markbench/markbench.ml) regression test for software prefetching gives:

```
$ hyperfine test-trunk.exe
Benchmark 1: test-trunk.exe
  Time (mean ± σ):     32.399 s ±  0.629 s    [User: 31.762 s, System: 0.331 s]
  Range (min … max):   30.834 s … 33.000 s    10 runs
```

```
$ hyperfine test-prefetch.exe
Benchmark 1: test-prefetch.exe
  Time (mean ± σ):     13.267 s ±  0.670 s    [User: 12.629 s, System: 0.301 s]
  Range (min … max):   12.664 s … 14.605 s    10 runs
```

Half the time, twice the fun!

The first commit aligns compiler builtin detection with compiler attributes detection, and reorders a bit the macros tests as clang-cl doesn't define `__GNUC__` and warns if `-Wundef` is enabled. It has the side-effect of enabling the built-in functions to perform arithmetic with overflow checking under clang-cl too.