### PR TITLE
Detect labels as values C extension to enable threaded code interpretation

### DIFF
--- a/Changes
+++ b/Changes
@@ -87,6 +87,10 @@ _______________
   (Antonin Décimo, review by Nick Barnes, Xavier Leroy, Gabriel Scherer,
    and Miod Vallat)
 
+- #13239: Check whether the compiler supports the labels as values
+  extension to enable threaded code interpretation.
+  (Antonin Décimo, review by Miod Vallat)
+
 ### Code generation and optimizations:
 
 - #13014: Enable compile-time option -function-sections on all previously

--- a/Makefile
+++ b/Makefile
@@ -1309,7 +1309,8 @@ runtime/caml/opnames.h : runtime/caml/instruct.h
 	    -e 's/{$$/[] = {/' \
 	    -e 's/\([[:upper:]][[:upper:]_0-9]*\)/"\1"/g' > $@
 
-# runtime/caml/jumptbl.h is required only if you have GCC 2.0 or later
+# runtime/caml/jumptbl.h is required only if the C compiler supports
+# the labels as values extension.
 runtime/caml/jumptbl.h : runtime/caml/instruct.h
 	$(V_GEN)tr -d '\r' < $< | \
 	sed -n -e '/^  /s/ \([A-Z]\)/ \&\&lbl_\1/gp' \

--- a/aclocal.m4
+++ b/aclocal.m4
@@ -536,3 +536,22 @@ AC_DEFUN([OCAML_CC_SUPPORTS_ATOMIC], [
 
   OCAML_CC_RESTORE_VARIABLES
 ])
+
+AC_DEFUN([OCAML_CC_SUPPORTS_LABELS_AS_VALUES], [
+  AC_CACHE_CHECK([whether $CC supports the labels as values extension],
+    [ocaml_cv_prog_cc_labels_as_values],
+    [AC_COMPILE_IFELSE([AC_LANG_PROGRAM([], [[
+  void *ptr;
+  ptr = &&foo;
+  goto *ptr;
+  return 1;
+  foo:
+     ]])],
+       [ocaml_cv_prog_cc_labels_as_values=yes],
+       [ocaml_cv_prog_cc_labels_as_values=no])
+  ])
+  if test "x$ocaml_cv_prog_cc_labels_as_values" = xyes; then
+    AC_DEFINE([HAVE_LABELS_AS_VALUES], [1],
+      [Define if the C compiler supports the labels as values extension.])
+  fi
+])

--- a/configure
+++ b/configure
@@ -16056,6 +16056,49 @@ rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
   CFLAGS="$saved_CFLAGS"
 
 
+# Check whether the C compiler supports the labels as values extension.
+
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether $CC supports the labels as values extension" >&5
+printf %s "checking whether $CC supports the labels as values extension... " >&6; }
+if test ${ocaml_cv_prog_cc_labels_as_values+y}
+then :
+  printf %s "(cached) " >&6
+else $as_nop
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+int
+main (void)
+{
+
+  void *ptr;
+  ptr = &&foo;
+  goto *ptr;
+  return 1;
+  foo:
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_compile "$LINENO"
+then :
+  ocaml_cv_prog_cc_labels_as_values=yes
+else $as_nop
+  ocaml_cv_prog_cc_labels_as_values=no
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
+
+fi
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ocaml_cv_prog_cc_labels_as_values" >&5
+printf "%s\n" "$ocaml_cv_prog_cc_labels_as_values" >&6; }
+  if test "x$ocaml_cv_prog_cc_labels_as_values" = xyes; then
+
+printf "%s\n" "#define HAVE_LABELS_AS_VALUES 1" >>confdefs.h
+
+  fi
+
+
 # Configure the native-code compiler
 
 arch=none

--- a/configure.ac
+++ b/configure.ac
@@ -1375,6 +1375,9 @@ OCAML_CC_SUPPORTS_ALIGNED
 ## Check whether __attribute__((optimize("tree-vectorize")))) is supported
 OCAML_CC_SUPPORTS_TREE_VECTORIZE
 
+# Check whether the C compiler supports the labels as values extension.
+OCAML_CC_SUPPORTS_LABELS_AS_VALUES
+
 # Configure the native-code compiler
 
 arch=none

--- a/runtime/caml/config.h
+++ b/runtime/caml/config.h
@@ -161,10 +161,9 @@ typedef uint64_t uintnat;
 #endif
 
 
-/* We use threaded code interpretation if the compiler provides labels
-   as first-class values (GCC 2.x). */
-
-#if defined(__GNUC__) && __GNUC__ >= 2 && !defined(DEBUG)
+/* We use threaded code interpretation if the C compiler supports the labels as
+   values extension. */
+#if defined(HAVE_LABELS_AS_VALUES) && !defined(DEBUG)
 #define THREADED_CODE
 #endif
 

--- a/runtime/caml/s.h.in
+++ b/runtime/caml/s.h.in
@@ -313,3 +313,9 @@
 #undef HAS_BSD_GETAFFINITY_NP
 
 #undef HAS_ZSTD
+
+/* 3. Language extensions. */
+
+#undef HAVE_LABELS_AS_VALUES
+
+/* Define if the C compiler supports the labels as values extension. */


### PR DESCRIPTION
LLVM and thus clang-cl have had support for [labels as values](https://gcc.gnu.org/onlinedocs/gcc/Labels-as-Values.html) (also called computed gotos) since 2.6~2.7 (released around 2010).  All LLVM-based compilers thus support this extension too. Add a test in the configure script for this extension.

This makes ocamlc build with clang-cl blazingly faster! In GitHub Actions, I see that OCaml build time is cut by 1 to 2 minutes, and the full testsuite execution time by 3 to 4 minutes.

It could be possible to achieve similar gains with MSVC using inline assembly gotos.


