### PR TITLE
Bring `Uchar` hashing on par with other base types like `Int`, `Char`, ...

### DIFF
--- a/Changes
+++ b/Changes
@@ -141,6 +141,20 @@ _______________
    review by KC Sivaramakrishnan, Miod Vallat and Nicolás Ojeda Bär,
    report by Vesa Karvonen)
 
+* #13240: Add Uchar.seeded_hash, Change Uchar.hash implementation.
+  Previously, Uchar.hash was aliased to Uchar.to_int. If you need that behavior,
+  change your module instantiation from eg `module HT = Hashtbl.Make(Uchar)` to
+  ```
+    module HT = Hashtbl.Make(struct
+      ...
+      let hash = Uchar.to_int
+    end)
+  ```
+  If the current implementation is desired, and you have a hashtable module `HT`
+  (produced with the `Make` functor) in persistent storage, use `HT.rebuild` to
+  ensure it doesn't break when reading from or writing to buckets.
+  (Hazem ElMasry, review by Gabriel Scherer and Nicolás Ojeda Bär)
+
 ### Other libraries:
 
 ### Tools:

--- a/stdlib/uchar.ml
+++ b/stdlib/uchar.ml
@@ -17,7 +17,7 @@ external format_int : string -> int -> string = "caml_format_int"
 
 let err_no_pred = "U+0000 has no predecessor"
 let err_no_succ = "U+10FFFF has no successor"
-let err_not_sv i = format_int "%X" i ^ " is not an Unicode scalar value"
+let err_not_sv i = format_int "%X" i ^ " is not a Unicode scalar value"
 let err_not_latin1 u = "U+" ^ format_int "%04X" u ^ " is not a latin1 character"
 
 type t = int
@@ -55,7 +55,11 @@ let unsafe_to_char = Char.unsafe_chr
 
 let equal : int -> int -> bool = ( = )
 let compare : int -> int -> int = Stdlib.compare
-let hash = to_int
+
+external seeded_hash_param :
+  int -> int -> int -> 'a -> int = "caml_hash" [@@noalloc]
+let seeded_hash seed x = seeded_hash_param 10 100 seed x
+let hash x = seeded_hash_param 10 100 0 x
 
 (* UTF codecs tools *)
 

--- a/stdlib/uchar.mli
+++ b/stdlib/uchar.mli
@@ -95,8 +95,19 @@ val equal : t -> t -> bool
 val compare : t -> t -> int
 (** [compare u u'] is [Stdlib.compare u u']. *)
 
+val seeded_hash : int -> t -> int
+(** [seeded_hash seed u] A seeded hash function with the same output value as
+    {!Hashtbl.seeded_hash}. This function allows this module to be passed as an
+    argument to the functor {!Hashtbl.MakeSeeded}.
+
+    @since 5.3 *)
+
 val hash : t -> int
-(** [hash u] associates a non-negative integer to [u]. *)
+(** An unseeded hash function with the same output value as {!Hashtbl.hash}.
+    This function allows this module to be passed as an argument to the functor
+    {!Hashtbl.Make}.
+
+    @since 5.3 *)
 
 (** {1:utf UTF codecs tools}
 

--- a/testsuite/tests/lib-uchar/test.ml
+++ b/testsuite/tests/lib-uchar/test.ml
@@ -71,6 +71,14 @@ let test_compare () =
   assert (Uchar.(compare max min) = 1);
   ()
 
+let test_hash () =
+  let f u =
+    assert (Hashtbl.hash u = Uchar.hash u);
+    assert (Hashtbl.seeded_hash 42 u = Uchar.seeded_hash 42 u)
+  in
+  List.iter (Fun.compose f Uchar.of_int)
+    [0x0000; 0x002D; 0x00E9; 0x062D; 0x2014; 0x1F349]
+
 let test_utf_decode () =
   let d0 = Uchar.utf_decode 1 Uchar.min in
   let d1 = Uchar.utf_decode 4 Uchar.max in
@@ -109,6 +117,7 @@ let tests () =
   test_to_char ();
   test_equal ();
   test_compare ();
+  test_hash ();
   test_utf_decode ();
   test_utf_x_byte_length ();
   ()


### PR DESCRIPTION
### Executive summary
Previously, `Uchar.hash` was effectively `%identity` and there was no `seeded_hash`.
`hash` now uses the `caml_hash` prim like the rest of the base types. Additionally, having `seeded_hash` allows passing the module as–is to `Hashtbl.MakeSeeded` so it was added to increase interface uniformity.

### Design defails
Having `hash` be an identity or some simple bit manipulation is fine. It can however have a suboptimal distribution with a regular (easy to maliciously produce!) collision sequence. This is compared to a hashing function. Small ranges like `char` can have a perfect `Char.code`–indexed array, in essence an identity hash function, and everything else would be suboptimal in that case. `Uchar` isn't a small range however.
Consider if you will a hash table of [2<sup>n</sup> buckets](https://github.com/ocaml/ocaml/blob/ba6dbe91d4dee4edbdebed58cca30b0e40d8b7d5/stdlib/hashtbl.ml#L74) where n is initially small and bucket index is [determined by `hash mod len`](https://github.com/ocaml/ocaml/blob/ba6dbe91d4dee4edbdebed58cca30b0e40d8b7d5/stdlib/hashtbl.ml#L505), all uchars represented as m×2<sup>n</sup> would collide and cluster on index 0.
Even when the above, those downsides might be acceptable for the simplicity of implementation. This change offers more uniformity among base types without amassing any real implementation complexity—by making use of a good hashing function with a nice distribution that's already available to us as a primitive.

The change was motivated first by bringing the interface up to the constraints of `SeededHashedType`, but once that was done, it was only natural to adjust `hash` next. It is technically a breaking change. But three things to note:
1) the previous interface made no promises about the kind of value `hash` returns, just that it's a positive integer associated with the uchar argument.
2) the hashing algorithm itself changed halfway through OCaml's life (with plans to change it again). Although at the time of the change backwards compatibility was ensured by leaving the old implementation available and ensuring `Hashtbl` is aware of it, it still would've surely left a massive ripple effect if many users of the default `Hashtbl.hash` were sensitive to hash values like one might anticipate here. And in our case the backwards compatibility would just be aliasing `hash` to `to_int` again in the functor argument.
3) usage survey on sherlocode & github code search shows that `Uchar.t` hasn't been used as a key to `Hashtbl.Make` yet as far as I can tell. I don't imagine the function is critical by any means. There are [three](https://github.com/patoline/patoline/blob/75fd8c928efc68d0aaa400d3a699a0e668c26c5f/unicodelib/UCharInfo.ml#L108) [known](https://github.com/kumar-ish/chinese-dag/blob/61554d8777a7a55be3b7e1b27e27fd065a69aa47/lib/trie.ml#L6) [instances](https://github.com/ocaml/opam/blob/9c7a256f60e78d1a1cc5ea90f8069a351aeb86a5/src/core/opamConsole.ml#L114) where it's a key to a `Hashtbl`, but in this it uses the polymorphic hash anyway.
This last point doesn't cover proprietary users, but it's a notable indicator nonetheless. I imagine you're more likely to be using (normalized) strings as keys than you are single scalars for most Unicode needs. Two of the three above seem to have legitimate uses for uchar keys (description lookup table, and a bounded range of glyphs that are known to map 1:1 to scalars).

### Implementation details
- ~~I parametrized the hash function with `1` for meaningful nodes and `1` for total nodes since `Uchar.t` is immediate (honestly I have no idea why it's `10` and `100` respectively for other immediates. If that's desirable anyway, I don't feel strongly about using the magic numbers).~~ [hash params are the same as other modules](https://github.com/ocaml/ocaml/pull/13240#issuecomment-2172865029), I used `0` for the default seed as with `Hashtbl.hash`.
- I've also added a test to ensure the function conforms to the stricter specification of its counterparts, namely that it returns the same output as `Hashtbl.hash`. I chose arbitrary values to test, as with equivalent tests in other modules.
- While I was in the module I fixed a typo in one of the error messages.

Background info: #11246, #8878, #5225, #9763, #9764, https://github.com/ocaml/ocaml/pull/80#discussion_r14857426 (the origin of the function).