### PR TITLE
Assertions cleanups, annotate unreachable code

### DIFF
--- a/Changes
+++ b/Changes
@@ -121,6 +121,10 @@ _______________
   clang-cl or MSVC. Provide fixes too.
   (Antonin Décimo, review by Miod Vallat and Xavier Leroy)
 
+- #13242: Define and use unreachable and trap annotation, and clean-up some
+  runtime assertions.
+  (Antonin Décimo, review by Miod Vallat, Gabriel Scherer, and David Allsopp)
+
 ### Code generation and optimizations:
 
 - #13014: Enable compile-time option -function-sections on all previously

--- a/otherlibs/unix/mmap_ba.c
+++ b/otherlibs/unix/mmap_ba.c
@@ -65,7 +65,8 @@ caml_unix_mapped_alloc(int flags, int num_dims, void * data, intnat * dim)
   struct caml_ba_array * b;
   intnat dimcopy[CAML_BA_MAX_NUM_DIMS];
 
-  CAMLassert(num_dims >= 0 && num_dims <= CAML_BA_MAX_NUM_DIMS);
+  CAMLassert(0 <= num_dims);
+  CAMLassert(num_dims <= CAML_BA_MAX_NUM_DIMS);
   CAMLassert((flags & CAML_BA_KIND_MASK) < CAML_BA_FIRST_UNIMPLEMENTED_KIND);
   for (int i = 0; i < num_dims; i++) dimcopy[i] = dim[i];
   asize = SIZEOF_BA_ARRAY + num_dims * sizeof(intnat);

--- a/otherlibs/unix/select_win32.c
+++ b/otherlibs/unix/select_win32.c
@@ -13,6 +13,7 @@
 /*                                                                        */
 /**************************************************************************/
 
+#define CAML_INTERNALS
 #include <caml/mlvalues.h>
 #include <caml/alloc.h>
 #include <caml/memory.h>
@@ -903,7 +904,7 @@ static value find_handle(LPSELECTRESULT iterResult, value readfds,
       list = exceptfds;
       break;
     case SELECT_MODE_NONE:
-      CAMLassert(0);
+      CAMLunreachable();
   };
 
   for(int i=0; list != Val_unit && i < iterResult->lpOrigIdx; ++i )
@@ -1264,7 +1265,7 @@ CAMLprim value caml_unix_select(value readfds, value writefds, value exceptfds,
                       except_list = l;
                       break;
                     case SELECT_MODE_NONE:
-                      CAMLassert(0);
+                      CAMLunreachable();
                     }
                 }
               /* We try to only process the first error, bypass other errors */

--- a/runtime/bigarray.c
+++ b/runtime/bigarray.c
@@ -230,7 +230,8 @@ caml_ba_alloc(int flags, int num_dims, void * data, intnat * dim)
   struct caml_ba_array * b;
   intnat dimcopy[CAML_BA_MAX_NUM_DIMS];
 
-  CAMLassert(num_dims >= 0 && num_dims <= CAML_BA_MAX_NUM_DIMS);
+  CAMLassert(0 <= num_dims);
+  CAMLassert(num_dims <= CAML_BA_MAX_NUM_DIMS);
   CAMLassert((flags & CAML_BA_KIND_MASK) < CAML_BA_FIRST_UNIMPLEMENTED_KIND);
   for (int i = 0; i < num_dims; i++) dimcopy[i] = dim[i];
   num_elts = 1;

--- a/runtime/bigarray.c
+++ b/runtime/bigarray.c
@@ -18,6 +18,7 @@
 #include <stddef.h>
 #include <stdarg.h>
 #include <string.h>
+#include <assert.h>
 #include "caml/alloc.h"
 #include "caml/bigarray.h"
 #include "caml/custom.h"
@@ -557,7 +558,7 @@ CAMLexport void caml_ba_serialize(value v,
   }
   /* Compute required size in OCaml heap.  Assumes struct caml_ba_array
      is exactly 4 + num_dims words */
-  CAMLassert(SIZEOF_BA_ARRAY == 4 * sizeof(value));
+  static_assert(SIZEOF_BA_ARRAY == 4 * sizeof(value), "");
   *wsize_32 = (4 + b->num_dims) * 4;
   *wsize_64 = (4 + b->num_dims) * 8;
 }

--- a/runtime/bigarray.c
+++ b/runtime/bigarray.c
@@ -299,8 +299,7 @@ CAMLexport void caml_ba_finalize(value v)
   case CAML_BA_MAPPED_FILE:
     /* Bigarrays for mapped files use a different finalization method */
     fallthrough;
-  default:
-    CAMLassert(0);
+  default: CAMLunreachable();
   }
 }
 
@@ -382,9 +381,7 @@ CAMLexport int caml_ba_compare(value v1, value v2)
   case CAML_BA_CAML_INT:
   case CAML_BA_NATIVE_INT:
     DO_INTEGER_COMPARISON(intnat);
-  default:
-    CAMLassert(0);
-    return 0;                   /* should not happen */
+  default: CAMLunreachable();
   }
 #undef DO_INTEGER_COMPARISON
 #undef DO_FLOAT_COMPARISON
@@ -750,9 +747,7 @@ value caml_ba_get_N(value vb, volatile value * vind, int nind)
       return copy_two_doubles(p[0], p[1]); }
   case CAML_BA_CHAR:
     return Val_int(((unsigned char *) b->data)[offset]);
-  default:
-    CAMLassert(0);
-    return Val_int(0);
+  default: CAMLunreachable();
   }
 }
 
@@ -896,8 +891,7 @@ static value caml_ba_set_aux(value vb, volatile value * vind,
       p[0] = Double_flat_field(newval, 0);
       p[1] = Double_flat_field(newval, 1);
       break; }
-  default:
-    CAMLassert(0);
+  default: CAMLunreachable();
   }
   return Val_unit;
 }
@@ -1340,8 +1334,7 @@ CAMLprim value caml_ba_fill(value vb, value vinit)
     FILL_COMPLEX_LOOP(double *);
     break;
   }
-  default:
-    CAMLassert(0);
+  default: CAMLunreachable();
   }
   CAMLreturn (Val_unit);
 }

--- a/runtime/blake2.c
+++ b/runtime/blake2.c
@@ -171,7 +171,8 @@ CAMLexport void
 caml_BLAKE2Final(struct BLAKE2_context * s,
                  size_t hashlen, unsigned char * hash)
 {
-  CAMLassert (0 < hashlen && hashlen <= 64);
+  CAMLassert(0 < hashlen);
+  CAMLassert(hashlen <= 64);
   /* The final block is composed of the remaining data padded with zeros. */
   memset(s->buffer + s->numbytes, 0, BLAKE2_BLOCKSIZE - s->numbytes);
   caml_BLAKE2Compress(s, s->buffer, s->numbytes, 1);

--- a/runtime/caml/bigarray.h
+++ b/runtime/caml/bigarray.h
@@ -42,8 +42,8 @@ enum caml_ba_kind {
   CAML_BA_CHAR,                /* Characters */
   CAML_BA_FLOAT16,             /* Half-precision floats */
   CAML_BA_FIRST_UNIMPLEMENTED_KIND,
-  CAML_BA_KIND_MASK = 0xFF     /* Mask for kind in flags field */
 };
+#define CAML_BA_KIND_MASK 0xFF /* Mask for kind in flags field */
 
 #define Caml_ba_kind_val(v) Int_val(v)
 
@@ -52,9 +52,9 @@ enum caml_ba_kind {
 enum caml_ba_layout {
   CAML_BA_C_LAYOUT = 0,           /* Row major, indices start at 0 */
   CAML_BA_FORTRAN_LAYOUT = 0x100, /* Column major, indices start at 1 */
-  CAML_BA_LAYOUT_MASK = 0x100,    /* Mask for layout in flags field */
-  CAML_BA_LAYOUT_SHIFT = 8        /* Bit offset of layout flag */
 };
+#define CAML_BA_LAYOUT_SHIFT 8    /* Bit offset of layout flag */
+#define CAML_BA_LAYOUT_MASK 0x100 /* Mask for layout in flags field */
 
 #define Caml_ba_layout_val(v) (Int_val(v) << CAML_BA_LAYOUT_SHIFT)
 
@@ -64,8 +64,8 @@ enum caml_ba_managed {
   CAML_BA_EXTERNAL = 0,        /* Data is not allocated by OCaml */
   CAML_BA_MANAGED = 0x200,     /* Data is allocated by OCaml */
   CAML_BA_MAPPED_FILE = 0x400, /* Data is a memory mapped file */
-  CAML_BA_MANAGED_MASK = 0x600 /* Mask for "managed" bits in flags field */
 };
+#define CAML_BA_MANAGED_MASK 0x600 /* Mask for "managed" bits in flags field */
 
 enum caml_ba_subarray {
   CAML_BA_SUBARRAY = 0x800     /* Data is shared with another bigarray */

--- a/runtime/caml/misc.h
+++ b/runtime/caml/misc.h
@@ -280,6 +280,17 @@ CAMLnoret CAMLextern void caml_failed_assert (char *, char_os *, int);
 #define CAMLassert(x) ((void) 0)
 #endif
 
+#if __has_builtin(__builtin_trap)
+  #define CAMLunreachable() (__builtin_trap())
+#elif defined(_MSC_VER)
+  #include <intrin.h>
+  CAMLnoret Caml_inline void caml_fastfail(unsigned int);
+  void caml_fastfail(unsigned int i) { __fastfail(i); }
+  #define CAMLunreachable() (caml_fastfail(7 /* FAST_FAIL_FATAL_APP_EXIT */))
+#else
+  #define CAMLunreachable() (CAMLassert(0))
+#endif
+
 #if __has_builtin(__builtin_expect) || defined(__GNUC__)
 #define CAMLlikely(e)   __builtin_expect(!!(e), 1)
 #define CAMLunlikely(e) __builtin_expect(!!(e), 0)

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -985,7 +985,8 @@ void caml_init_domains(uintnat max_domains, uintnat minor_heap_wsz)
 }
 
 void caml_init_domain_self(int domain_id) {
-  CAMLassert (domain_id >= 0 && domain_id < caml_params->max_domains);
+  CAMLassert(0 <= domain_id);
+  CAMLassert(domain_id < caml_params->max_domains);
   domain_self = &all_domains[domain_id];
   caml_state = domain_self->state;
 }

--- a/runtime/extern.c
+++ b/runtime/extern.c
@@ -20,6 +20,8 @@
 /* The interface of this file is "caml/intext.h" */
 
 #include <string.h>
+#include <assert.h>
+
 #include "caml/alloc.h"
 #include "caml/codefrag.h"
 #include "caml/config.h"
@@ -766,6 +768,9 @@ static void extern_rec(struct caml_extern_state* s, value v)
   uintnat h = 0;
   uintnat pos = 0;
 
+  /* for Double_tag and Double_array_tag */
+  static_assert(sizeof(double) == 8, "");
+
   extern_init_position_table(s);
   sp = s->extern_stack;
 
@@ -821,7 +826,6 @@ static void extern_rec(struct caml_extern_state* s, value v)
       break;
     }
     case Double_tag: {
-      CAMLassert(sizeof(double) == 8);
       extern_double(s, v);
       s->size_32 += 1 + 2;
       s->size_64 += 1 + 1;
@@ -830,7 +834,6 @@ static void extern_rec(struct caml_extern_state* s, value v)
     }
     case Double_array_tag: {
       mlsize_t nfloats;
-      CAMLassert(sizeof(double) == 8);
       nfloats = Wosize_val(v) / Double_wosize;
       extern_double_array(s, v, nfloats);
       s->size_32 += 1 + nfloats * 2;

--- a/runtime/fail.c
+++ b/runtime/fail.c
@@ -22,8 +22,8 @@
 #include "caml/memory.h"
 #include "caml/mlvalues.h"
 
-#define Assert_is_exn_constructor(v)                    \
-  (CAMLassert(Is_block(v) && Tag_val(v) == Object_tag))
+#define Assert_is_exn_constructor(v)                                    \
+  (CAMLassert(Is_block(v)), CAMLassert(Tag_val(v) == Object_tag))
 
 CAMLexport value caml_exception_constant(value exn_constr)
 {

--- a/runtime/fiber.c
+++ b/runtime/fiber.c
@@ -623,7 +623,8 @@ CAMLprim value caml_continuation_use_noexc (value cont)
 
   fiber_debug_log("cont: is_block(%d) tag_val(%ul) is_young(%d)",
                   Is_block(cont), Tag_val(cont), Is_young(cont));
-  CAMLassert(Is_block(cont) && Tag_val(cont) == Cont_tag);
+  CAMLassert(Is_block(cont));
+  CAMLassert(Tag_val(cont) == Cont_tag);
 
   /* this forms a barrier between execution and any other domains
      that might be marking this continuation */

--- a/runtime/finalise.c
+++ b/runtime/finalise.c
@@ -221,7 +221,7 @@ void caml_final_do_young_roots
     Call_action (act, fdata, f->first.table[i].val);
   }
 
-  CAMLassert (f->last.old <= f->last.old);
+  CAMLassert (f->last.old <= f->last.young);
   for (uintnat i = f->last.old; i < f->last.young; i++) {
     Call_action (act, fdata, f->last.table[i].fun);
     if (do_last_val)

--- a/runtime/floats.c
+++ b/runtime/floats.c
@@ -29,6 +29,7 @@
 #include <string.h>
 #include <float.h>
 #include <limits.h>
+#include <assert.h>
 
 #include "caml/alloc.h"
 #include "caml/fail.h"
@@ -81,11 +82,12 @@
 
 #ifdef ARCH_ALIGN_DOUBLE
 
+static_assert(sizeof(double) == 2 * sizeof(value), "");
+
 CAMLexport double caml_Double_val(value val)
 {
   union { value v[2]; double d; } buffer;
 
-  CAMLassert(sizeof(double) == 2 * sizeof(value));
   buffer.v[0] = Field(val, 0);
   buffer.v[1] = Field(val, 1);
   return buffer.d;
@@ -95,7 +97,6 @@ CAMLexport void caml_Store_double_val(value val, double dbl)
 {
   union { value v[2]; double d; } buffer;
 
-  CAMLassert(sizeof(double) == 2 * sizeof(value));
   buffer.d = dbl;
   Field(val, 0) = buffer.v[0];
   Field(val, 1) = buffer.v[1];

--- a/runtime/intern.c
+++ b/runtime/intern.c
@@ -230,7 +230,8 @@ static void intern_init(struct caml_intern_state* s, const void * src,
   /* This is asserted at the beginning of demarshaling primitives.
      If it fails, it probably means that an exception was raised
      without calling intern_cleanup() during the previous demarshaling. */
-  CAMLassert (s->intern_input == NULL && s->intern_obj_table == NULL);
+  CAMLassert(s->intern_input == NULL);
+  CAMLassert(s->intern_obj_table == NULL);
   s->intern_src = src;
   s->intern_input = input;
 }

--- a/runtime/intern.c
+++ b/runtime/intern.c
@@ -725,8 +725,7 @@ static void intern_rec(struct caml_intern_state* s,
      may crash. */
   *dest = v;
   break;
-  default:
-    CAMLassert(0);
+  default: CAMLunreachable();
   }
   }
   /* We are done. Cleanup the stack and leave the function */

--- a/runtime/intern.c
+++ b/runtime/intern.c
@@ -726,7 +726,6 @@ static void intern_rec(struct caml_intern_state* s,
      may crash. */
   *dest = v;
   break;
-  default: CAMLunreachable();
   }
   }
   /* We are done. Cleanup the stack and leave the function */

--- a/runtime/interp.c
+++ b/runtime/interp.c
@@ -1414,7 +1414,7 @@ do_resume: {
 #ifndef THREADED_CODE
     default:
 #ifdef _MSC_VER
-      __assume(0);
+      CAMLunreachable();
 #else
       caml_fatal_error("bad opcode (%"
                            ARCH_INTNAT_PRINTF_FORMAT "x)",

--- a/runtime/lf_skiplist.c
+++ b/runtime/lf_skiplist.c
@@ -329,7 +329,8 @@ int caml_lf_skiplist_insert(struct lf_skiplist *sk, uintnat key, uintnat data) {
   struct lf_skipcell *preds[NUM_LEVELS];
   struct lf_skipcell *succs[NUM_LEVELS];
 
-  CAMLassert(key > 0 && key < CAML_UINTNAT_MAX);
+  CAMLassert(0 < key);
+  CAMLassert(key < CAML_UINTNAT_MAX);
 
   while (1) {
     /* We first try to find a node with [key] in the skip list. If it exists

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -251,7 +251,8 @@ Caml_inline void pb_fill_mode(prefetch_buffer_t *pb)
 
 Caml_inline void pb_push(prefetch_buffer_t* pb, value v)
 {
-  CAMLassert(Is_block(v) && !Is_young(v));
+  CAMLassert(Is_block(v));
+  CAMLassert(!Is_young(v));
   CAMLassert(v != Debug_free_major);
   CAMLassert(pb->enqueued < pb->dequeued + PREFETCH_BUFFER_SIZE);
 
@@ -841,7 +842,8 @@ static intnat mark_stack_push_block(struct mark_stack* stk, value block)
   }
 
   CAMLassert(Has_status_val(block, caml_global_heap_state.MARKED));
-  CAMLassert(Is_block(block) && !Is_young(block));
+  CAMLassert(Is_block(block));
+  CAMLassert(!Is_young(block));
   CAMLassert(Tag_val(block) != Infix_tag);
   CAMLassert(Tag_val(block) < No_scan_tag);
   CAMLassert(Tag_val(block) != Cont_tag);
@@ -1138,7 +1140,9 @@ static scanning_action_flags darken_scanning_flags = 0;
 
 void caml_darken_cont(value cont)
 {
-  CAMLassert(Is_block(cont) && !Is_young(cont) && Tag_val(cont) == Cont_tag);
+  CAMLassert(Is_block(cont));
+  CAMLassert(!Is_young(cont));
+  CAMLassert(Tag_val(cont) == Cont_tag);
   {
     SPIN_WAIT {
       header_t hd = atomic_load_relaxed(Hp_atomic_val(cont));

--- a/runtime/memory.c
+++ b/runtime/memory.c
@@ -597,7 +597,8 @@ CAMLexport void* caml_stat_alloc_aligned_noexc(asize_t sz, int modulo,
 {
   char *raw_mem;
   uintnat aligned_mem;
-  CAMLassert (0 <= modulo && modulo < Page_size);
+  CAMLassert(0 <= modulo);
+  CAMLassert(modulo < Page_size);
   raw_mem = (char *) caml_stat_alloc_noexc(sz + Page_size);
   if (raw_mem == NULL) return NULL;
   *b = raw_mem;

--- a/runtime/memprof.c
+++ b/runtime/memprof.c
@@ -1163,7 +1163,8 @@ static uintnat rand_geom(memprof_domain_t domain)
   if (domain->rand_pos == RAND_BLOCK_SIZE)
     rand_batch(domain);
   res = domain->rand_geom_buff[domain->rand_pos++];
-  CAMLassert(1 <= res && res <= Max_long);
+  CAMLassert(1 <= res);
+  CAMLassert(res <= Max_long);
   return res;
 }
 
@@ -1769,7 +1770,9 @@ static caml_result run_callback_res(
   } else {
     value v = res.data;
     /* Callback returned [Some _]. Store the value in [user_data]. */
-    CAMLassert(Is_block(v) && Tag_val(v) == 0 && Wosize_val(v) == 1);
+    CAMLassert(Is_block(v));
+    CAMLassert(Tag_val(v) == 0);
+    CAMLassert(Wosize_val(v) == 1);
     e->user_data = Some_val(v);
     if (Is_block(e->user_data) && Is_young(e->user_data) &&
         i < es->young)
@@ -1972,8 +1975,8 @@ void caml_memprof_set_trigger(caml_domain_state *state)
     }
   }
 
-  CAMLassert((trigger >= state->young_start) &&
-             (trigger <= state->young_ptr));
+  CAMLassert(trigger >= state->young_start);
+  CAMLassert(trigger <= state->young_ptr);
   state->memprof_young_trigger = trigger;
 }
 
@@ -2030,9 +2033,9 @@ void caml_memprof_sample_young(uintnat wosize, int from_caml,
   }
 
   /* The memprof trigger lies in (young_ptr, young_ptr + whsize] */
-  CAMLassert(Caml_state->young_ptr < Caml_state->memprof_young_trigger &&
-             Caml_state->memprof_young_trigger <=
-               Caml_state->young_ptr + whsize);
+  CAMLassert(Caml_state->young_ptr < Caml_state->memprof_young_trigger);
+  CAMLassert(Caml_state->memprof_young_trigger <=
+             Caml_state->young_ptr + whsize);
 
   /* Trigger offset from the base of the combined allocation. We
    * reduce this for each sample in this comballoc. Signed so it can

--- a/runtime/minor_gc.c
+++ b/runtime/minor_gc.c
@@ -273,7 +273,8 @@ static void oldify_one (void* st_v, value v, volatile value *p)
 
   if (tag == Cont_tag) {
     value stack_value = Field(v, 0);
-    CAMLassert(Wosize_hd(hd) == 2 && infix_offset == 0);
+    CAMLassert(Wosize_hd(hd) == 2);
+    CAMLassert(infix_offset == 0);
     result = alloc_shared(st->domain, 2, Cont_tag, Reserved_hd(hd));
     if( try_update_object_header(v, p, result, 0) ) {
       struct stack_info* stk = Ptr_val(stack_value);

--- a/runtime/parsing.c
+++ b/runtime/parsing.c
@@ -299,7 +299,6 @@ CAMLprim value caml_parse_engine(value vtables, value venv,
 
   default:                      /* Should not happen */
     CAMLunreachable();
-    return RAISE_PARSE_ERROR;   /* Keeps gcc -Wall happy */
   }
 }
 

--- a/runtime/parsing.c
+++ b/runtime/parsing.c
@@ -300,7 +300,7 @@ CAMLprim value caml_parse_engine(value vtables, value venv,
     goto loop;
 
   default:                      /* Should not happen */
-    CAMLassert(0);
+    CAMLunreachable();
     return RAISE_PARSE_ERROR;   /* Keeps gcc -Wall happy */
   }
 

--- a/runtime/parsing.c
+++ b/runtime/parsing.c
@@ -75,12 +75,10 @@ struct parser_env {       /* Mirrors parser_env in ../stdlib/parsing.ml */
 
 /* Input codes */
 /* Mirrors parser_input in ../stdlib/parsing.ml */
-#define START 0
-#define TOKEN_READ 1
-#define STACKS_GROWN_1 2
-#define STACKS_GROWN_2 3
-#define SEMANTIC_ACTION_COMPUTED 4
-#define ERROR_DETECTED 5
+enum input_codes {
+  START, TOKEN_READ, STACKS_GROWN_1, STACKS_GROWN_2, SEMANTIC_ACTION_COMPUTED,
+  ERROR_DETECTED,
+};
 
 /* Output codes */
 /* Mirrors parser_output in ../stdlib/parsing.ml */
@@ -167,7 +165,7 @@ CAMLprim value caml_parse_engine(value vtables, value venv,
   int errflag;
   int n, n1, n2, m, state1;
 
-  switch(Int_val(cmd)) {
+  switch((enum input_codes)Int_val(cmd)) {
 
   case START:
     state = 0;
@@ -303,7 +301,6 @@ CAMLprim value caml_parse_engine(value vtables, value venv,
     CAMLunreachable();
     return RAISE_PARSE_ERROR;   /* Keeps gcc -Wall happy */
   }
-
 }
 
 /* Control printing of debugging info */

--- a/runtime/shared_heap.c
+++ b/runtime/shared_heap.c
@@ -1364,8 +1364,8 @@ static void verify_swept (struct caml_heap_state* local) {
   /* sweeping should be done by this point */
   CAMLassert(local->next_to_sweep == NUM_SIZECLASSES);
   for (int i = 0; i < NUM_SIZECLASSES; i++) {
-    CAMLassert(local->unswept_avail_pools[i] == NULL &&
-               local->unswept_full_pools[i] == NULL);
+    CAMLassert(local->unswept_avail_pools[i] == NULL);
+    CAMLassert(local->unswept_full_pools[i] == NULL);
     for (pool *p = local->avail_pools[i]; p; p = p->next)
       verify_pool(p, i, &pool_stats);
     for (pool *p = local->full_pools[i]; p; p = p->next) {

--- a/runtime/signals_nat.c
+++ b/runtime/signals_nat.c
@@ -57,7 +57,9 @@ void caml_garbage_collection(void)
   { /* Find the frame descriptor for the current allocation */
     d = caml_find_frame_descr(fds, retaddr);
     /* Must be an allocation frame */
-    CAMLassert(d && !frame_return_to_C(d) && frame_has_allocs(d));
+    CAMLassert(d);
+    CAMLassert(!frame_return_to_C(d));
+    CAMLassert(frame_has_allocs(d));
   }
 
   { /* Compute the total allocation size at this point,


### PR DESCRIPTION
This PR sports small cleanups around assertions in the runtime.

- Use a definition of `unreachable()` to mark unreachable code where it makes sense, and allow C compilers to optimize the code.
- Split conjunctions of `CAMLassert(A && B);` into `CAMLassert(A); CAMLassert(B)` to better identify which part of the assertion fails. 
- Some `CAMLassert` can be replaced with `static_assert`.

(using the unreachable annotation will later be useful to optimize `ocamlc` too!)

~No change entry needed, I think.~
cc @NickBarnes 