### PR TITLE
Fix warnings reported by MSVC (`-W2`) and clang-cl (`-W4`)

### DIFF
--- a/Changes
+++ b/Changes
@@ -117,6 +117,10 @@ _______________
   compiler attributes with clang-cl.
   (Antonin Décimo, review by Miod Vallat)
 
+- #13243: Enable C compiler warnings internally when building with
+  clang-cl or MSVC. Provide fixes too.
+  (Antonin Décimo, review by Miod Vallat and Xavier Leroy)
+
 ### Code generation and optimizations:
 
 - #13014: Enable compile-time option -function-sections on all previously

--- a/aclocal.m4
+++ b/aclocal.m4
@@ -426,7 +426,7 @@ AC_DEFUN([OCAML_C99_CHECK_FMA], [
   OCAML_RUN_IFELSE(
     [AC_LANG_PROGRAM([[#include <math.h>]],[[
   /* Tests 264-266 from testsuite/tests/fma/fma.ml. These tests trigger the
-     broken implementations of Cygwin64, mingw-w64 (x86_64) and VS2013-2017.
+     broken implementations of Cygwin64 and mingw-w64 (x86_64).
      The static volatile variables aim to thwart GCC's constant folding. */
   static volatile double x, y, z;
   volatile double t264, t265, t266;
@@ -458,11 +458,7 @@ AC_DEFUN([OCAML_C99_CHECK_FMA], [
       [no,*], [hard_error=true],
       [yes,*], [hard_error=false],
       [*,x86_64-w64-mingw32*|*,x86_64-*-cygwin*], [hard_error=false],
-      [AS_CASE([$ocaml_cc_vendor],
-        [msvc-*], [AS_IF([test "${ocaml_cc_vendor#msvc-}" -lt 1920 ],
-          [hard_error=false],
-          [hard_error=true])],
-        [hard_error=true])])
+      [hard_error=true])
     AS_IF([test x"$hard_error" = "xtrue"],
       [AC_MSG_ERROR(m4_normalize([
         fma does not work, enable emulation with

--- a/configure
+++ b/configure
@@ -13959,11 +13959,12 @@ case $ocaml_cc_vendor in #(
     outputobj='-Fo'
     case $ocaml_cc_vendor in #(
   msvc-*-clang-*) :
-    warn_error_flag='-WX' ;; #(
+    cc_warnings='-W4 -Wno-unused-parameter -Wno-sign-compare -Wundef'
+         warn_error_flag='-WX' ;; #(
   *) :
-    warn_error_flag='-WX -options:strict' ;;
-esac
-    cc_warnings='' ;; #(
+    cc_warnings='-W2'
+       warn_error_flag='-WX -options:strict' ;;
+esac ;; #(
   *) :
     outputobj='-o '
   warn_error_flag='-Werror'

--- a/configure
+++ b/configure
@@ -16734,8 +16734,8 @@ fi
   cross_compiling="$old_cross_compiling"
 
 
-  # Check whether fma works (regressed in mingw-w64 8.0.0; present, but broken,
-  # in VS2013-2017 and present but unimplemented in Cygwin64)
+  # Check whether fma works (regressed in mingw-w64 8.0.0; and present but
+  # unimplemented in Cygwin64)
 
   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether fma works" >&5
 printf %s "checking whether fma works... " >&6; }
@@ -16766,7 +16766,7 @@ main (void)
 {
 
   /* Tests 264-266 from testsuite/tests/fma/fma.ml. These tests trigger the
-     broken implementations of Cygwin64, mingw-w64 (x86_64) and VS2013-2017.
+     broken implementations of Cygwin64 and mingw-w64 (x86_64).
      The static volatile variables aim to thwart GCC's constant folding. */
   static volatile double x, y, z;
   volatile double t264, t265, t266;
@@ -16812,17 +16812,7 @@ printf "%s\n" "no" >&6; }
   *,x86_64-w64-mingw32*|*,x86_64-*-cygwin*) :
     hard_error=false ;; #(
   *) :
-    case $ocaml_cc_vendor in #(
-  msvc-*) :
-    if test "${ocaml_cc_vendor#msvc-}" -lt 1920
-then :
-  hard_error=false
-else $as_nop
-  hard_error=true
-fi ;; #(
-  *) :
     hard_error=true ;;
-esac ;;
 esac
     if test x"$hard_error" = "xtrue"
 then :
@@ -16842,26 +16832,7 @@ fi
 else $as_nop
   if test x"$enable_imprecise_c99_float_ops" != "xyes"
 then :
-  case $enable_imprecise_c99_float_ops,$ocaml_cc_vendor in #(
-  no,*) :
-    hard_error=true ;; #(
-  ,msvc-*) :
-    if test "${ocaml_cc_vendor#msvc-}" -lt 1800
-then :
-  hard_error=false
-else $as_nop
-  hard_error=true
-fi ;; #(
-  *) :
-    hard_error=true ;;
-esac
-     if test x"$hard_error" = 'xtrue'
-then :
   as_fn_error $? "C99 float ops unavailable, enable replacements with --enable-imprecise-c99-float-ops" "$LINENO" 5
-else $as_nop
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: C99 float ops unavailable, replacements enabled (ancient Visual Studio)" >&5
-printf "%s\n" "$as_me: WARNING: C99 float ops unavailable, replacements enabled (ancient Visual Studio)" >&2;}
-fi
 fi
 fi
 

--- a/configure.ac
+++ b/configure.ac
@@ -1675,23 +1675,12 @@ AS_IF([$has_c99_float_ops],
   [AC_DEFINE([HAS_C99_FLOAT_OPS], [1])
   # Check whether round works (known bug in mingw-w64)
   OCAML_C99_CHECK_ROUND
-  # Check whether fma works (regressed in mingw-w64 8.0.0; present, but broken,
-  # in VS2013-2017 and present but unimplemented in Cygwin64)
+  # Check whether fma works (regressed in mingw-w64 8.0.0; and present but
+  # unimplemented in Cygwin64)
   OCAML_C99_CHECK_FMA],
   [AS_IF([test x"$enable_imprecise_c99_float_ops" != "xyes" ],
-    [AS_CASE([$enable_imprecise_c99_float_ops,$ocaml_cc_vendor],
-      [no,*], [hard_error=true],
-      [,msvc-*], [AS_IF([test "${ocaml_cc_vendor#msvc-}" -lt 1800 ],
-        [hard_error=false],
-        [hard_error=true])],
-      [hard_error=true])
-     AS_IF([test x"$hard_error" = 'xtrue'],
-       [AC_MSG_ERROR(m4_normalize([
-         C99 float ops unavailable, enable replacements
-         with --enable-imprecise-c99-float-ops]))],
-       [AC_MSG_WARN(m4_normalize([
-         C99 float ops unavailable, replacements enabled
-         (ancient Visual Studio)]))])])])
+    [AC_MSG_ERROR(m4_normalize([C99 float ops unavailable, enable replacements
+    with --enable-imprecise-c99-float-ops]))])])
 
 ## getentropy
 AC_CHECK_FUNC([getentropy], [AC_DEFINE([HAS_GETENTROPY], [1])])

--- a/configure.ac
+++ b/configure.ac
@@ -835,9 +835,11 @@ AS_CASE([$ocaml_cc_vendor],
   [msvc-*],
     [outputobj='-Fo'
     AS_CASE([$ocaml_cc_vendor],
-      [msvc-*-clang-*], [warn_error_flag='-WX'],
-      [warn_error_flag='-WX -options:strict'])
-    cc_warnings=''],
+      [msvc-*-clang-*],
+        [cc_warnings='-W4 -Wno-unused-parameter -Wno-sign-compare -Wundef'
+         warn_error_flag='-WX'],
+      [cc_warnings='-W2'
+       warn_error_flag='-WX -options:strict'])],
   [outputobj='-o '
   warn_error_flag='-Werror'
   cc_warnings="-Wall -Wint-conversion -Wstrict-prototypes \

--- a/ocamltest/run_win32.c
+++ b/ocamltest/run_win32.c
@@ -42,7 +42,7 @@ static void report_error(
 {
   WCHAR windows_error_message[1024];
   DWORD error = GetLastError();
-  char *caml_error_message, buf[256];
+  char *caml_error_message;
   if (FormatMessage(
     FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
     NULL, error, 0, windows_error_message,
@@ -272,7 +272,6 @@ int run_command(const command_settings *settings)
   WCHAR *commandline = NULL;
 
   LPVOID environment = NULL;
-  LPCWSTR current_directory = NULL;
   STARTUPINFO startup_info;
   PROCESS_INFORMATION process_info;
   BOOL wait_result;

--- a/otherlibs/unix/channels_win32.c
+++ b/otherlibs/unix/channels_win32.c
@@ -102,7 +102,6 @@ CAMLprim value caml_unix_inchannel_of_filedescr(value handle)
   CAMLlocal1(vchan);
   int flags = 0;
   int fd;
-  struct channel * chan;
   DWORD err;
 
   err = check_stream_semantics(handle);
@@ -123,7 +122,6 @@ CAMLprim value caml_unix_outchannel_of_filedescr(value handle)
   CAMLlocal1(vchan);
   int fd;
   int flags = 0;
-  struct channel * chan;
   DWORD err;
 
   err = check_stream_semantics(handle);

--- a/otherlibs/unix/createprocess.c
+++ b/otherlibs/unix/createprocess.c
@@ -154,8 +154,7 @@ CAMLprim value caml_unix_create_process(value * argv, int argn)
 
 static int has_console(void)
 {
-  HANDLE h, log;
-  int i;
+  HANDLE h;
 
   h = CreateFile(L"CONOUT$", GENERIC_WRITE, FILE_SHARE_WRITE, NULL,
                  OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);

--- a/otherlibs/unix/execvp.c
+++ b/otherlibs/unix/execvp.c
@@ -15,12 +15,12 @@
 
 #define _GNU_SOURCE  /* helps to find execvpe() */
 #include <string.h>
+#include <errno.h>
 #include <caml/mlvalues.h>
 #include <caml/memory.h>
 #define CAML_INTERNALS
 #include <caml/osdeps.h>
 #include "caml/unixsupport.h"
-#include "errno.h"
 
 CAMLprim value caml_unix_execvp(value path, value args)
 {

--- a/otherlibs/unix/gettimeofday_win32.c
+++ b/otherlibs/unix/gettimeofday_win32.c
@@ -25,7 +25,7 @@
 double caml_unix_gettimeofday_unboxed(value unit)
 {
   CAML_ULONGLONG_FILETIME utime;
-  double tm;
+  ULONGLONG tm;
   GetSystemTimeAsFileTime(&utime.ft);
   tm = utime.ul - CAML_NT_EPOCH_100ns_TICKS;
   return (tm * 1e-7);  /* tm is in 100ns */

--- a/otherlibs/unix/mmap_win32.c
+++ b/otherlibs/unix/mmap_win32.c
@@ -44,8 +44,7 @@ CAMLprim value caml_unix_map_file(value vfd, value vkind, value vlayout,
   intnat dim[CAML_BA_MAX_NUM_DIMS];
   __int64 startpos, data_size;
   LARGE_INTEGER file_size;
-  uintnat array_size, page, delta;
-  char c;
+  uintnat array_size, delta;
   void * addr;
   LARGE_INTEGER li;
   SYSTEM_INFO sysinfo;

--- a/otherlibs/unix/select_win32.c
+++ b/otherlibs/unix/select_win32.c
@@ -1066,7 +1066,7 @@ CAMLprim value caml_unix_select(value readfds, value writefds, value exceptfds,
 
       if (tm >= 0.0)
         {
-          milliseconds = 1000 * tm;
+          milliseconds = (DWORD)(1000 * tm);
           DEBUG_PRINT("Will wait %d ms", milliseconds);
         }
       else

--- a/otherlibs/unix/select_win32.c
+++ b/otherlibs/unix/select_win32.c
@@ -59,8 +59,6 @@ static void handle_set_init (LPSELECTHANDLESET hds, LPHANDLE lpHdl, DWORD max)
 
 static void handle_set_add (LPSELECTHANDLESET hds, HANDLE hdl)
 {
-  LPSELECTHANDLESET res;
-
   if (hds->nLast < hds->nMax)
   {
     hds->lpHdl[hds->nLast] = hdl;
@@ -184,7 +182,6 @@ static LPSELECTDATA select_data_new (LPSELECTDATA lpSelectData,
 {
   /* Allocate the data structure */
   LPSELECTDATA res;
-  DWORD        i;
 
   res = (LPSELECTDATA)caml_stat_alloc(sizeof(SELECTDATA));
 
@@ -211,8 +208,6 @@ static LPSELECTDATA select_data_new (LPSELECTDATA lpSelectData,
 /* Free select data */
 static void select_data_free (LPSELECTDATA lpSelectData)
 {
-  DWORD i;
-
   DEBUG_PRINT("Freeing data of %x", lpSelectData);
 
   /* Free APC related data, if they exists */
@@ -995,9 +990,6 @@ CAMLprim value caml_unix_select(value readfds, value writefds, value exceptfds,
   /* Is there static select data */
   BOOL  hasStaticData = FALSE;
 
-  /* Wait return */
-  DWORD waitRet;
-
   /* Set of handle */
   SELECTHANDLESET hds;
   DWORD           hdsMax;
@@ -1065,7 +1057,6 @@ CAMLprim value caml_unix_select(value readfds, value writefds, value exceptfds,
       iterSelectData = NULL;
       iterResult     = NULL;
       hasStaticData  = 0;
-      waitRet        = 0;
       readfds_len    = caml_list_length(readfds);
       writefds_len   = caml_list_length(writefds);
       exceptfds_len  = caml_list_length(exceptfds);

--- a/otherlibs/unix/sleep_win32.c
+++ b/otherlibs/unix/sleep_win32.c
@@ -19,9 +19,9 @@
 
 CAMLprim value caml_unix_sleep(value t)
 {
-  double d = Double_val(t);
+  DWORD ms = (DWORD)(Double_val(t) * 1e3);
   caml_enter_blocking_section();
-  Sleep(d * 1e3);
+  Sleep(ms);
   caml_leave_blocking_section();
   return Val_unit;
 }

--- a/otherlibs/unix/startup.c
+++ b/otherlibs/unix/startup.c
@@ -25,7 +25,6 @@ value caml_win32_process_id;
 CAMLprim value caml_unix_startup(value unit)
 {
   WSADATA wsaData;
-  int i;
   HANDLE h;
 
   (void) WSAStartup(MAKEWORD(2, 0), &wsaData);

--- a/otherlibs/unix/stat_win32.c
+++ b/otherlibs/unix/stat_win32.c
@@ -166,7 +166,6 @@ static int safe_do_stat(int do_lstat, int use_64, wchar_t* path, HANDLE fstat, _
 {
   BY_HANDLE_FILE_INFORMATION info;
   wchar_t* ptr;
-  char c;
   HANDLE h;
   unsigned short mode;
   int is_symlink = 0;
@@ -391,7 +390,6 @@ CAMLprim value caml_unix_lstat_64(value path)
 
 static value do_fstat(value handle, int use_64)
 {
-  int ret;
   struct _stat64 buf;
   __int64 st_ino;
   HANDLE h;

--- a/otherlibs/unix/unixsupport_win32.c
+++ b/otherlibs/unix/unixsupport_win32.c
@@ -98,7 +98,7 @@ void caml_win32_maperr(DWORD win32err)
   } else {
     /* Not found: save original error code, negated so that we can
        recognize it in caml_unix_error_message */
-    errno = -win32err;
+    errno = -(int)win32err;
   }
 }
 

--- a/otherlibs/unix/windbug.c
+++ b/otherlibs/unix/windbug.c
@@ -17,10 +17,10 @@
 
 int caml_win32_debug_test (void)
 {
-  static int debug_init = 0;
   static int debug = 0;
 
 #ifdef DEBUG
+  static int debug_init = 0;
   if (!debug_init)
   {
     debug = (getenv("OCAMLDEBUG") != NULL);

--- a/otherlibs/unix/winworker.c
+++ b/otherlibs/unix/winworker.c
@@ -238,8 +238,6 @@ void caml_win32_worker_push(LPWORKER lpWorker)
 
 void caml_win32_worker_init (void)
 {
-  int i = 0;
-
   /* Init a shared variable. The only way to ensure that no other
      worker will be at the same point is to use a critical section.
      */

--- a/runtime/caml/config.h
+++ b/runtime/caml/config.h
@@ -40,11 +40,7 @@
 /* No longer used in the codebase, but kept because it was exported */
 #define INT64_LITERAL(s) s ## LL
 
-#if defined(_MSC_VER) && !defined(__cplusplus)
-#define Caml_inline static __inline
-#else
 #define Caml_inline static inline
-#endif
 
 #ifndef CAML_CONFIG_H_NO_TYPEDEFS
 
@@ -70,7 +66,7 @@
   #define __USE_MINGW_ANSI_STDIO 0
 #endif
 
-#if defined(__MINGW32__) || (defined(_MSC_VER) && _MSC_VER < 1800)
+#if defined(__MINGW32__)
 #define ARCH_SIZET_PRINTF_FORMAT "I"
 #else
 #define ARCH_SIZET_PRINTF_FORMAT "z"

--- a/runtime/caml/frame_descriptors.h
+++ b/runtime/caml/frame_descriptors.h
@@ -100,7 +100,7 @@ Caml_inline bool frame_has_debug(frame_descr *d) {
 /* Used to compute offsets in frame tables.
    ty must have power-of-2 size */
 #define Align_to(p, ty) \
-  (void*)(((uintnat)(p) + sizeof(ty) - 1) & -sizeof(ty))
+  (void*)(((uintnat)(p) + sizeof(ty) - 1) & ~(sizeof(ty) - 1))
 
 #define Hash_retaddr(addr, mask)                          \
   (((uintnat)(addr) >> 3) & (mask))

--- a/runtime/caml/misc.h
+++ b/runtime/caml/misc.h
@@ -188,13 +188,18 @@ CAMLdeprecated_typedef(addr, char *);
      CAMLunused_start foo CAMLunused_end;
    which supports both GCC/Clang and MSVC.
 */
-#if defined(__GNUC__) && (__GNUC__ > 2 || (__GNUC__ == 2 && __GNUC_MINOR__ > 7))
-  #define CAMLunused_start __attribute__ ((unused))
+#if __has_c_attribute(maybe_unused)                     \
+    || defined(__cplusplus) && __cplusplus >= 201703L
+  #define CAMLunused [[maybe_unused]]
+  #define CAMLunused_start CAMLunused
   #define CAMLunused_end
+#elif __has_attribute(unused) || defined(__GNUC__)
   #define CAMLunused __attribute__ ((unused))
+  #define CAMLunused_start CAMLunused
+  #define CAMLunused_end
 #elif defined(_MSC_VER)
-  #define CAMLunused_start  __pragma( warning (push) )           \
-    __pragma( warning (disable:4189 ) )
+  #define CAMLunused_start __pragma( warning (push) )   \
+          __pragma( warning (disable:4189 ) )
   #define CAMLunused_end __pragma( warning (pop))
   #define CAMLunused
 #else

--- a/runtime/caml/misc.h
+++ b/runtime/caml/misc.h
@@ -401,7 +401,7 @@ extern double caml_log1p(double);
 #define unlink_os _wunlink
 #define rename_os caml_win32_rename
 #define chdir_os _wchdir
-#define mkdir_os(path, perm) _wmkdir(path)
+#define mkdir_os(path, perm) ((void) (perm), _wmkdir(path))
 #define getcwd_os _wgetcwd
 #define system_os _wsystem
 #define rmdir_os _wrmdir

--- a/runtime/caml/platform.h
+++ b/runtime/caml/platform.h
@@ -67,7 +67,7 @@ Caml_inline void cpu_relax(void) {
 
 /* Atomic read-modify-write instructions, with full fences */
 
-Caml_inline uintnat atomic_fetch_add_verify_ge0(atomic_uintnat* p, uintnat v) {
+Caml_inline uintnat atomic_fetch_add_verify_ge0(atomic_uintnat* p, intnat v) {
   uintnat result = atomic_fetch_add(p,v);
   CAMLassert ((intnat)result > 0);
   return result;

--- a/runtime/caml/tsan.h
+++ b/runtime/caml/tsan.h
@@ -70,7 +70,7 @@ extern void AnnotateHappensAfter(const char *f, int l, void *addr);
 
 #ifdef CAML_INTERNALS
 
-#include "caml/mlvalues.h"
+#include "mlvalues.h"
 
 struct stack_info;
 

--- a/runtime/gc_ctrl.c
+++ b/runtime/gc_ctrl.c
@@ -108,7 +108,7 @@ CAMLprim value caml_gc_counters(value v)
 
   /* get a copy of these before allocating anything... */
   double minwords = caml_gc_minor_words_unboxed();
-  double prowords = Caml_state->stat_promoted_words;
+  double prowords = (double)Caml_state->stat_promoted_words;
   double majwords = Caml_state->stat_major_words +
                     (double) Caml_state->allocated_words;
 

--- a/runtime/ints.c
+++ b/runtime/ints.c
@@ -604,7 +604,7 @@ CAMLprim value caml_int64_of_string(value s)
       if (res >  (uint64_t)1 << 63) caml_failwith(INT64_ERRMSG);
     }
   }
-  if (sign < 0) res = - res;
+  if (sign < 0) res = -(int64_t)res;
   return caml_copy_int64(res);
 }
 

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -1350,7 +1350,7 @@ static void cycle_major_heap_from_stw_single(
          space_overhead@N =
          100.0 * (heap_words@N - live_words@N) / live_words@N
       */
-      double live_words = last_cycle.not_garbage_words - swept_words;
+      intnat live_words = last_cycle.not_garbage_words - swept_words;
       double space_overhead = 100.0 * (double)(last_cycle.heap_words
                                                - live_words) / live_words;
 

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -315,7 +315,7 @@ static void ephe_todo_list_emptied (void)
 
   /* Since the todo list is empty, this domain does not need to participate in
    * further ephemeron cycles. */
-  atomic_fetch_add(&ephe_cycle_info.num_domains_todo, -1);
+  atomic_fetch_sub(&ephe_cycle_info.num_domains_todo, 1);
   CAMLassert(atomic_load_acquire(&ephe_cycle_info.num_domains_done) <=
              atomic_load_acquire(&ephe_cycle_info.num_domains_todo));
 

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -649,7 +649,7 @@ static void update_major_slice_work(intnat howmuch,
     double dependent_ratio =
       total_cycle_work
       * (100 + caml_percent_free)
-      / dom_st-> dependent_size / caml_percent_free;
+        / (double)dom_st->dependent_size / (double)caml_percent_free;
     dependent_work = (intnat) (my_dependent_count * dependent_ratio);
   }else{
     dependent_work = 0;

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -578,12 +578,11 @@ static inline intnat diffmod (uintnat x1, uintnat x2)
 static void update_major_slice_work(intnat howmuch,
                                     int may_access_gc_phase)
 {
-  double heap_words;
   intnat alloc_work, dependent_work, extra_work, new_work;
   intnat my_alloc_count, my_alloc_direct_count, my_dependent_count;
   double my_extra_count;
   caml_domain_state *dom_st = Caml_state;
-  uintnat heap_size, heap_sweep_words, total_cycle_work;
+  uintnat heap_words, heap_size, heap_sweep_words, total_cycle_work;
 
   my_alloc_count = dom_st->allocated_words;
   my_alloc_direct_count = dom_st->allocated_words_direct;
@@ -629,11 +628,12 @@ static void update_major_slice_work(intnat howmuch,
                  S = P * TW
   */
   heap_size = caml_heap_size(dom_st->shared_heap);
-  heap_words = (double)Wsize_bsize(heap_size);
+  heap_words = Wsize_bsize(heap_size);
   heap_sweep_words = heap_words;
 
   total_cycle_work =
-    heap_sweep_words + (heap_words * 100 / (100 + caml_percent_free));
+    heap_sweep_words
+    + (uintnat) ((double) heap_words * 100.0 / (100.0 + caml_percent_free));
 
   if (heap_words > 0) {
     double alloc_ratio =

--- a/runtime/memory.c
+++ b/runtime/memory.c
@@ -732,7 +732,7 @@ CAMLexport caml_stat_string caml_stat_strdup(const char *s)
 
 CAMLexport wchar_t * caml_stat_wcsdup(const wchar_t *s)
 {
-  int slen = wcslen(s);
+  size_t slen = wcslen(s);
   wchar_t* result = caml_stat_alloc((slen + 1)*sizeof(wchar_t));
   if (result == NULL)
     caml_raise_out_of_memory();

--- a/runtime/memprof.c
+++ b/runtime/memprof.c
@@ -1100,7 +1100,7 @@ Caml_inline float log_approx(uint32_t y)
 {
   union { float f; int32_t i; } u;
   u.f = y + 0.5f;
-  float exp = u.i >> 23;
+  float exp = (float)(u.i >> 23);
   u.i = (u.i & 0x7FFFFF) | 0x3F800000;
   float x = u.f;
   return (-111.70172433407f +

--- a/runtime/misc.c
+++ b/runtime/misc.c
@@ -15,16 +15,6 @@
 
 #define CAML_INTERNALS
 
-#if defined(_MSC_VER) && _MSC_VER >= 1400 && _MSC_VER < 1700
-/* Microsoft introduced a regression in Visual Studio 2005 (technically it's
-   not present in the Windows Server 2003 SDK which has a pre-release version)
-   and the abort function ceased to be declared __declspec(noreturn). This was
-   fixed in Visual Studio 2012. Trick stdlib.h into not defining abort (this
-   means exit and _exit are not defined either, but they aren't required). */
-#define _CRT_TERMINATE_DEFINED
-__declspec(noreturn) void __cdecl abort(void);
-#endif
-
 #include <stdio.h>
 #include <string.h>
 #include <stdarg.h>

--- a/runtime/platform.c
+++ b/runtime/platform.c
@@ -378,7 +378,7 @@ uintnat caml_mem_round_up_pages(uintnat size)
 #define Is_page_aligned(size) ((size & (caml_plat_pagesize - 1)) == 0)
 
 #ifdef DEBUG
-static struct lf_skiplist mmap_blocks = {NULL};
+static struct lf_skiplist mmap_blocks;
 #endif
 
 #ifndef _WIN32

--- a/runtime/runtime_events.c
+++ b/runtime/runtime_events.c
@@ -240,11 +240,11 @@ void caml_runtime_events_destroy(void) {
 static void runtime_events_create_from_stw_single(void) {
   /* Don't initialise runtime_events twice */
   if (!atomic_load_acquire(&runtime_events_enabled)) {
-    int ret, ring_headers_length, ring_data_length;
+    int ring_headers_length, ring_data_length;
 #ifdef _WIN32
     DWORD pid = GetCurrentProcessId();
 #else
-    int ring_fd;
+    int ring_fd, ret;
     long int pid = getpid();
 #endif
 

--- a/runtime/sak.c
+++ b/runtime/sak.c
@@ -28,18 +28,6 @@
 #include <string.h>
 #include <ctype.h>
 
-#ifdef _WIN32
-#define strncmp_os wcsncmp
-#define toupper_os towupper
-#define printf_os wprintf
-#else
-#define strncmp_os strncmp
-/* NOTE: See CAVEATS section in https://man.netbsd.org/ctype.3 */
-/* and NOTE section in https://man7.org/linux/man-pages/man3/toupper.3.html */
-#define toupper_os(x) toupper((unsigned char)x)
-#define printf_os printf
-#endif
-
 /* Operations
    - encode-C-literal. Used for the OCAML_STDLIB_DIR macro in
      runtime/build_config.h to ensure the LIBDIR make variable is correctly
@@ -51,7 +39,7 @@
      `L"C:\\OCaml\xd83d\xdc2b\\lib"`
  */
 
-void usage(void)
+static void usage(void)
 {
   printf(
     "OCaml Build System Swiss Army Knife\n"
@@ -63,7 +51,7 @@ void usage(void)
 
 /* Converts the supplied path (UTF-8 on Unix and UCS-2ish on Windows) to a valid
    C string literal. On Windows, this is always a wchar_t* (L"..."). */
-void encode_C_literal(char_os *path)
+static void encode_C_literal(const char_os * path)
 {
   char_os c;
 

--- a/runtime/signals.c
+++ b/runtime/signals.c
@@ -509,7 +509,7 @@ static const int posix_signals[] = {
 
 CAMLexport int caml_convert_signal_number(int signo)
 {
-  if (signo < 0 && signo >= -(sizeof(posix_signals) / sizeof(int)))
+  if (signo < 0 && signo >= -(int)(sizeof(posix_signals) / sizeof(int)))
     return posix_signals[-signo-1];
   else
     return signo;
@@ -517,7 +517,7 @@ CAMLexport int caml_convert_signal_number(int signo)
 
 CAMLexport int caml_rev_convert_signal_number(int signo)
 {
-  for (int i = 0; i < sizeof(posix_signals) / sizeof(int); i++)
+  for (int i = 0; i < (int)(sizeof(posix_signals) / sizeof(int)); i++)
     if (signo == posix_signals[i]) return -i - 1;
   return signo;
 }

--- a/runtime/win32.c
+++ b/runtime/win32.c
@@ -359,7 +359,7 @@ static void expand_argument(wchar_t * arg)
 
 static void expand_pattern(wchar_t * pat)
 {
-  wchar_t * prefix, * p, * name;
+  wchar_t * prefix, * name;
   intptr_t handle;
   struct _wfinddata_t ffblk;
   size_t i;
@@ -1092,7 +1092,6 @@ CAMLexport clock_t caml_win32_clock(void)
 {
   FILETIME _creation, _exit;
   CAML_ULONGLONG_FILETIME stime, utime;
-  ULARGE_INTEGER tmp;
   ULONGLONG clocks_per_sec;
 
   if (!(GetProcessTimes(GetCurrentProcess(), &_creation, &_exit,

--- a/stdlib/headernt.c
+++ b/stdlib/headernt.c
@@ -31,20 +31,14 @@
 #endif
 #endif
 
-static
-#ifdef _MSC_VER
-__forceinline
-#else
-__inline
-#endif
-unsigned long read_size(const char * const ptr)
+Caml_inline unsigned long read_size(const char * const ptr)
 {
   const unsigned char * const p = (const unsigned char * const) ptr;
   return ((unsigned long) p[0] << 24) | ((unsigned long) p[1] << 16) |
          ((unsigned long) p[2] << 8) | p[3];
 }
 
-static __inline char * read_runtime_path(HANDLE h)
+Caml_inline char * read_runtime_path(HANDLE h)
 {
   char buffer[TRAILER_SIZE];
   static char runtime_path[MAX_PATH];
@@ -106,7 +100,7 @@ static void write_console(HANDLE hOut, WCHAR *wstr)
   }
 }
 
-CAMLnoret static __inline void run_runtime(wchar_t * runtime,
+CAMLnoret Caml_inline void run_runtime(wchar_t * runtime,
          wchar_t * const cmdline)
 {
   wchar_t path[MAX_PATH];
@@ -121,9 +115,6 @@ CAMLnoret static __inline void run_runtime(wchar_t * runtime,
     write_console(errh, runtime);
     write_console(errh, L"\r\n");
     ExitProcess(2);
-#ifdef _MSC_VER
-    __assume(0); /* Not reached */
-#endif
   }
   /* Need to ignore ctrl-C and ctrl-break, otherwise we'll die and take
      the underlying OCaml program with us! */
@@ -144,18 +135,12 @@ CAMLnoret static __inline void run_runtime(wchar_t * runtime,
     write_console(errh, runtime);
     write_console(errh, L"\r\n");
     ExitProcess(2);
-#ifdef _MSC_VER
-    __assume(0); /* Not reached */
-#endif
   }
   CloseHandle(procinfo.hThread);
   WaitForSingleObject(procinfo.hProcess , INFINITE);
   GetExitCodeProcess(procinfo.hProcess , &retcode);
   CloseHandle(procinfo.hProcess);
   ExitProcess(retcode);
-#ifdef _MSC_VER
-    __assume(0); /* Not reached */
-#endif
 }
 
 int wmain(void)
@@ -176,18 +161,9 @@ int wmain(void)
     write_console(errh, truename);
     write_console(errh, L" not found or is not a bytecode executable file\r\n");
     ExitProcess(2);
-#ifdef _MSC_VER
-    __assume(0); /* Not reached */
-#endif
   }
   CloseHandle(h);
   MultiByteToWideChar(CP, 0, runtime_path, -1, wruntime_path,
                       sizeof(wruntime_path)/sizeof(wchar_t));
   run_runtime(wruntime_path , cmdline);
-#ifdef _MSC_VER
-    __assume(0); /* Not reached */
-#endif
-#ifdef __MINGW32__
-    return 0;
-#endif
 }

--- a/testsuite/tests/basic-manyargs/manyargsprim.c
+++ b/testsuite/tests/basic-manyargs/manyargsprim.c
@@ -13,8 +13,8 @@
 /*                                                                        */
 /**************************************************************************/
 
-#include "caml/mlvalues.h"
-#include "stdio.h"
+#include <caml/mlvalues.h>
+#include <stdio.h>
 
 value manyargs(value a, value b, value c, value d, value e, value f,
                value g, value h, value i, value j, value k)

--- a/testsuite/tests/c-api/aligned_alloc_stubs.c
+++ b/testsuite/tests/c-api/aligned_alloc_stubs.c
@@ -1,6 +1,6 @@
 #include <stdio.h>
 #include <stdlib.h>
-#include "caml/alloc.h"
+#include <caml/alloc.h>
 
 CAMLprim value caml_atomic_is_aligned(value val)
 {

--- a/testsuite/tests/c-api/alloc_async_stubs.c
+++ b/testsuite/tests/c-api/alloc_async_stubs.c
@@ -1,9 +1,9 @@
 #include <stdio.h>
 #include <stdlib.h>
-#include "caml/alloc.h"
-#include "caml/memory.h"
+#include <caml/alloc.h>
+#include <caml/memory.h>
 #define CAML_INTERNALS
-#include "caml/gc_ctrl.h"
+#include <caml/gc_ctrl.h>
 
 
 void print_status(const char *str, int n)

--- a/testsuite/tests/c-api/test_c_thread_has_lock_cstubs.c
+++ b/testsuite/tests/c-api/test_c_thread_has_lock_cstubs.c
@@ -1,6 +1,6 @@
-#include "caml/mlvalues.h"
-#include "caml/domain_state.h"
-#include "caml/signals.h"
+#include <caml/mlvalues.h>
+#include <caml/domain_state.h>
+#include <caml/signals.h>
 
 value with_lock(value unit)
 {

--- a/testsuite/tests/callback/callbackprim.c
+++ b/testsuite/tests/callback/callbackprim.c
@@ -14,9 +14,9 @@
 /**************************************************************************/
 
 #include <signal.h>
-#include "caml/mlvalues.h"
-#include "caml/memory.h"
-#include "caml/callback.h"
+#include <caml/mlvalues.h>
+#include <caml/memory.h>
+#include <caml/callback.h>
 
 value mycallback1(value fun, value arg)
 {

--- a/testsuite/tests/callback/test1_.c
+++ b/testsuite/tests/callback/test1_.c
@@ -13,9 +13,9 @@
 /*                                                                        */
 /**************************************************************************/
 
-#include "caml/mlvalues.h"
-#include "caml/memory.h"
-#include "caml/callback.h"
+#include <caml/mlvalues.h>
+#include <caml/memory.h>
+#include <caml/callback.h>
 
 value mycallback1(value fun, value arg)
 {

--- a/testsuite/tests/callback/test_signalhandler_.c
+++ b/testsuite/tests/callback/test_signalhandler_.c
@@ -17,10 +17,10 @@
 
 #define CAML_INTERNALS
 
-#include "caml/mlvalues.h"
-#include "caml/memory.h"
-#include "caml/callback.h"
-#include "caml/signals.h"
+#include <caml/mlvalues.h>
+#include <caml/memory.h>
+#include <caml/callback.h>
+#include <caml/signals.h>
 
 value mycallback1(value fun, value arg)
 {

--- a/testsuite/tests/ephe-c-api/stubs.c
+++ b/testsuite/tests/ephe-c-api/stubs.c
@@ -1,7 +1,7 @@
-#include<stdio.h>
-#include "caml/alloc.h"
-#include "caml/memory.h"
-#include "caml/weak.h"
+#include <stdio.h>
+#include <caml/alloc.h>
+#include <caml/memory.h>
+#include <caml/weak.h>
 
 /* C version of ephetest.ml */
 

--- a/testsuite/tests/frame-pointers/c_call_.c
+++ b/testsuite/tests/frame-pointers/c_call_.c
@@ -14,7 +14,7 @@
 /**************************************************************************/
 
 #include <assert.h>
-#include "caml/mlvalues.h"
+#include <caml/mlvalues.h>
 
 void fp_backtrace(value);
 

--- a/testsuite/tests/frame-pointers/fp_backtrace.c
+++ b/testsuite/tests/frame-pointers/fp_backtrace.c
@@ -5,7 +5,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include "caml/mlvalues.h"
+#include <caml/mlvalues.h>
 
 #define ARR_SIZE(a)    (sizeof(a) / sizeof(*(a)))
 

--- a/testsuite/tests/frame-pointers/stack_realloc_.c
+++ b/testsuite/tests/frame-pointers/stack_realloc_.c
@@ -1,7 +1,7 @@
 #define CAML_NAME_SPACE
-#include "caml/mlvalues.h"
-#include "caml/fail.h"
-#include "caml/callback.h"
+#include <caml/mlvalues.h>
+#include <caml/fail.h>
+#include <caml/callback.h>
 
 value c_fun(void)
 {

--- a/testsuite/tests/gc-roots/globrootsprim.c
+++ b/testsuite/tests/gc-roots/globrootsprim.c
@@ -15,12 +15,12 @@
 
 #define CAML_INTERNALS
 
-#include "caml/mlvalues.h"
-#include "caml/memory.h"
-#include "caml/alloc.h"
-#include "caml/gc.h"
-#include "caml/shared_heap.h"
-#include "caml/callback.h"
+#include <caml/mlvalues.h>
+#include <caml/memory.h>
+#include <caml/alloc.h>
+#include <caml/gc.h>
+#include <caml/shared_heap.h>
+#include <caml/callback.h>
 
 struct block { value header; value v; };
 

--- a/testsuite/tests/lf_skiplist/stubs.c
+++ b/testsuite/tests/lf_skiplist/stubs.c
@@ -1,7 +1,7 @@
 #define CAML_INTERNALS
 
-#include "caml/lf_skiplist.h"
-#include "caml/memory.h"
+#include <caml/lf_skiplist.h>
+#include <caml/memory.h>
 #include <assert.h>
 #define FMT ARCH_INTNAT_PRINTF_FORMAT
 

--- a/testsuite/tests/lib-digest/blake2b_self_test_stubs.c
+++ b/testsuite/tests/lib-digest/blake2b_self_test_stubs.c
@@ -3,10 +3,10 @@
 
 #define CAML_NAME_SPACE
 
-#include "caml/mlvalues.h"
-#include "caml/memory.h"
+#include <caml/mlvalues.h>
+#include <caml/memory.h>
 #define CAML_INTERNALS
-#include "caml/blake2.h"
+#include <caml/blake2.h>
 #undef CAML_INTERNALS
 
 #include <stdio.h>

--- a/testsuite/tests/lib-dynlink-bytecode/stub1.c
+++ b/testsuite/tests/lib-dynlink-bytecode/stub1.c
@@ -13,9 +13,9 @@
 /*                                                                        */
 /**************************************************************************/
 
-#include "caml/mlvalues.h"
-#include "caml/memory.h"
-#include "caml/alloc.h"
+#include <caml/mlvalues.h>
+#include <caml/memory.h>
+#include <caml/alloc.h>
 #include <stdio.h>
 
 value stub1(void) {

--- a/testsuite/tests/lib-dynlink-bytecode/stub2.c
+++ b/testsuite/tests/lib-dynlink-bytecode/stub2.c
@@ -13,9 +13,9 @@
 /*                                                                        */
 /**************************************************************************/
 
-#include "caml/mlvalues.h"
-#include "caml/memory.h"
-#include "caml/alloc.h"
+#include <caml/mlvalues.h>
+#include <caml/memory.h>
+#include <caml/alloc.h>
 #include <stdio.h>
 
 CAMLextern value stub1(void);

--- a/testsuite/tests/lib-dynlink-native/factorial.c
+++ b/testsuite/tests/lib-dynlink-native/factorial.c
@@ -13,9 +13,9 @@
 /*                                                                        */
 /**************************************************************************/
 
-#include "caml/mlvalues.h"
-#include "caml/memory.h"
-#include "caml/alloc.h"
+#include <caml/mlvalues.h>
+#include <caml/memory.h>
+#include <caml/alloc.h>
 #include <stdio.h>
 
 value factorial(value n){

--- a/testsuite/tests/lib-runtime-events/stubs.c
+++ b/testsuite/tests/lib-runtime-events/stubs.c
@@ -1,11 +1,11 @@
 #define CAML_NAME_SPACE
 
-#include "caml/alloc.h"
-#include "caml/runtime_events.h"
-#include "caml/runtime_events_consumer.h"
-#include "caml/fail.h"
-#include "caml/memory.h"
-#include "caml/mlvalues.h"
+#include <caml/alloc.h>
+#include <caml/runtime_events.h>
+#include <caml/runtime_events_consumer.h>
+#include <caml/fail.h>
+#include <caml/memory.h>
+#include <caml/mlvalues.h>
 
 #include <assert.h>
 

--- a/testsuite/tests/lib-systhreads/test_c_thread_register_cstubs.c
+++ b/testsuite/tests/lib-systhreads/test_c_thread_register_cstubs.c
@@ -6,11 +6,11 @@
 #include <pthread.h>
 #define THREAD_FUNCTION void *
 #endif
-#include "caml/mlvalues.h"
-#include "caml/gc.h"
-#include "caml/memory.h"
-#include "caml/callback.h"
-#include "caml/threads.h"
+#include <caml/mlvalues.h>
+#include <caml/gc.h>
+#include <caml/memory.h>
+#include <caml/callback.h>
+#include <caml/threads.h>
 
 THREAD_FUNCTION thread_func(void *fn) {
   caml_c_thread_register();

--- a/testsuite/tests/lib-unix/common/fdstatus_aux.c
+++ b/testsuite/tests/lib-unix/common/fdstatus_aux.c
@@ -62,8 +62,8 @@ void process_fd(const char * s)
 
 #endif
 
-#include "caml/mlvalues.h"
-#include "caml/memory.h"
+#include <caml/mlvalues.h>
+#include <caml/memory.h>
 
 CAMLprim value caml_process_fd(value CAMLnum, value CAMLfd)
 {

--- a/testsuite/tests/parallel/recommended_domain_count_cstubs.c
+++ b/testsuite/tests/parallel/recommended_domain_count_cstubs.c
@@ -1,9 +1,9 @@
 #define CAML_INTERNALS
 
-#include "caml/domain.h"
-#include "caml/memory.h"
-#include "caml/misc.h"
-#include "caml/startup_aux.h"
+#include <caml/domain.h>
+#include <caml/memory.h>
+#include <caml/misc.h>
+#include <caml/startup_aux.h>
 
 CAMLprim value
 caml_get_max_domains(value nada)

--- a/testsuite/tests/parallel/test_c_thread_register_cstubs.c
+++ b/testsuite/tests/parallel/test_c_thread_register_cstubs.c
@@ -6,11 +6,11 @@
 #include <pthread.h>
 #define THREAD_FUNCTION void *
 #endif
-#include "caml/mlvalues.h"
-#include "caml/gc.h"
-#include "caml/memory.h"
-#include "caml/callback.h"
-#include "caml/threads.h"
+#include <caml/mlvalues.h>
+#include <caml/gc.h>
+#include <caml/memory.h>
+#include <caml/callback.h>
+#include <caml/threads.h>
 
 void *create_root(value v)
 {

--- a/testsuite/tests/runtime-C-exceptions/stub_test.c
+++ b/testsuite/tests/runtime-C-exceptions/stub_test.c
@@ -1,9 +1,9 @@
 #define _CRT_NONSTDC_NO_WARNINGS  /* for strdup */
 #include <string.h>
-#include "caml/memory.h"
-#include "caml/alloc.h"
-#include "caml/mlvalues.h"
-#include "caml/fail.h"
+#include <caml/memory.h>
+#include <caml/alloc.h>
+#include <caml/mlvalues.h>
+#include <caml/fail.h>
 
 char *some_dynamic_string_that_should_be_freed()
 {

--- a/testsuite/tests/statmemprof/minor_no_postpone_stub.c
+++ b/testsuite/tests/statmemprof/minor_no_postpone_stub.c
@@ -1,4 +1,4 @@
-#include "caml/alloc.h"
+#include <caml/alloc.h>
 
 value alloc_stub(value v) {
   return caml_alloc(1, 0);

--- a/testsuite/tests/tsan/callbacks.c
+++ b/testsuite/tests/tsan/callbacks.c
@@ -2,10 +2,10 @@
 #include <time.h>
 
 #define CAML_NAME_SPACE
-#include "caml/mlvalues.h"
-#include "caml/fail.h"
-#include "caml/memory.h"
-#include "caml/callback.h"
+#include <caml/mlvalues.h>
+#include <caml/fail.h>
+#include <caml/memory.h>
+#include <caml/callback.h>
 
 value print_and_call_ocaml_h(value unit)
 {


### PR DESCRIPTION
This PR fixes warnings raised by MSVC at level 2, and clang-cl at level 4 (minus unused parameters and sign-compare). It should be rather uneventful. I think it's sane to enable _some_ warnings rather than none at all (the current), but C compilers (and sometimes programmers too) have a tendency of being overzealous when they report issues.

MSVC really likes to warn when an assignment of two different ranges, like float to int, is made without an explicit cast. If the warnings [C4244](https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-2-c4244?view=msvc-170) and [C4146](https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-2-c4146?view=msvc-170) are too annoying, they could also be disabled.

Clang-cl `-Wall` is equivalent to clang `-Weverything`, which is *really* too noisy, and enables some C++ warnings. Levels above 2 for MSVC are also noisy, and some warnings are even checking for C++ things in C. Someone with spare time might revisit this later…