### PR TITLE
Restore the {ocamlc,ocamlopt}_{cflags,cppflags} config vars

### DIFF
--- a/Changes
+++ b/Changes
@@ -312,7 +312,7 @@ _______________
   (Sébastien Hinderer, review by Gabriel Scherer, Antonin Décimo,
   Miod Vallat and Samuel Hym)
 
-* #13201: Fix and speedup builds with TSan.
+- #13201, #13244: Fix and speedup builds with TSan.
   (Sébastien Hinderer, review by Miod Vallat, Gabriel Scherer and
   Olivier Nicole)
 

--- a/utils/config.common.ml.in
+++ b/utils/config.common.ml.in
@@ -78,9 +78,13 @@ let configuration_variables () =
   p "ccomp_type" ccomp_type;
   p "c_compiler" c_compiler;
   p "bytecode_cflags" bytecode_cflags;
+  p "ocamlc_cflags" bytecode_cflags;
   p "bytecode_cppflags" bytecode_cppflags;
+  p "ocamlc_cppflags" bytecode_cppflags;
   p "native_cflags" native_cflags;
+  p "ocamlopt_cflags" native_cflags;
   p "native_cppflags" native_cppflags;
+  p "ocamlopt_cppflags" native_cppflags;
   p "bytecomp_c_compiler" bytecomp_c_compiler;
   p "native_c_compiler" native_c_compiler;
   p "bytecomp_c_libraries" bytecomp_c_libraries;


### PR DESCRIPTION
These variables have been renamed by #13201 but should actually have
been preserved so that the use of `ocamlc -config` remains
backward-compatible.