### PR TITLE
Add link to TSan on macOS bug report.

### DIFF
--- a/Changes
+++ b/Changes
@@ -403,7 +403,7 @@ _______________
 - #13221: Compute more accurate instruction sizes for branch relocation on
   POWER.
   (Miod Vallat, review by Gabriel Scherer)
-  
+
 - #13252: Rework register assignment in the interpreter code on m68k on Linux,
   due to the %a5 register being used by Glibc.
   (Miod Vallat, report by Stéphane Glondu, review by Gabriel Scherer and

--- a/Changes
+++ b/Changes
@@ -394,6 +394,11 @@ _______________
   POWER.
   (Miod Vallat, review by Gabriel Scherer)
 
+- #13247: Disable lib_unix/kill test for MacOS AMD64 with TSan, linking
+  to llvm bug report causing infinite signal loops.
+  (Tim McGilchrist, review by Olivier Nicole, Miod Vallat, Sébastien Hinderer
+  and Gabriel Scherer)
+
 OCaml 5.2.0 (13 May 2024)
 -------------------------
 

--- a/ocamltest/builtin_actions.ml
+++ b/ocamltest/builtin_actions.ml
@@ -148,6 +148,16 @@ let macos = make
     "on a MacOS system"
     "not on a MacOS system")
 
+let not_macos_amd64_tsan = make
+  ~name:"not_macos_amd64_tsan"
+  ~description:"Pass if not running on a MacOS amd64 system with TSan enabled"
+  (Actions_helpers.pass_or_skip
+     (not ((Ocamltest_config.system = macos_system)
+           && (String.equal Ocamltest_config.arch "amd64")
+           && (Ocamltest_config.tsan)))
+     "not on a MacOS amd64 system with TSan enabled"
+     "on a MacOS amd64 system with TSan enabled")
+
 let arch32 = make
   ~name:"arch32"
   ~description:"Pass if running on a 32-bit architecture"
@@ -357,6 +367,7 @@ let _ =
     bsd;
     not_bsd;
     macos;
+    not_macos_amd64_tsan;
     arch32;
     arch64;
     has_symlink;

--- a/testsuite/tests/lib-unix/kill/unix_kill.ml
+++ b/testsuite/tests/lib-unix/kill/unix_kill.ml
@@ -1,6 +1,12 @@
 (* TEST
  include unix;
  libunix;
+ (*
+   Disabled on MacOS amd64 with TSan due to a
+   possible infinite signal loop with TSan under MacOS
+   see https://github.com/llvm/llvm-project/issues/63824
+ *)
+ not_macos_amd64_tsan;
  {
    bytecode;
  }{


### PR DESCRIPTION
This test case will hang under macOS x86_64 when run with `enable-tsan`.  Adding link back to the llvm bug report to save future developers chasing this down.

cc @OlivierNicole 