### PR TITLE
Re-enable warning 34 for unused locally-abstract types

### DIFF
--- a/Changes
+++ b/Changes
@@ -249,6 +249,9 @@ _______________
 - #13251: Register printer for errors in Emitaux
   (Vincent Laviron, review by Miod Vallat and Florian Angeletti)
 
+- #13255: Re-enable warning 34 for unused locally abstract types
+  (Nick Roberts, review by Chris Casinghino and Florian Angeletti)
+
 ### Internal/compiler-libs changes:
 
 - #11129, #11148: enforce that ppxs do not produce `parsetree`s with

--- a/testsuite/tests/typing-warnings/unused_types.ml
+++ b/testsuite/tests/typing-warnings/unused_types.ml
@@ -530,3 +530,57 @@ Warning 69 [unused-field]: unused record field b.
 
 module Unused_field_disable_one_warning : sig end
 |}]
+
+(* Locally abstract types *)
+
+let u (type unused) = ()
+[%%expect {|
+val u : unit = ()
+|}]
+
+let u = fun (type unused) -> ()
+[%%expect {|
+Line 1, characters 8-31:
+1 | let u = fun (type unused) -> ()
+            ^^^^^^^^^^^^^^^^^^^^^^^
+Warning 34 [unused-type-declaration]: unused type unused.
+
+val u : unit = ()
+|}]
+
+let u : type unused. unit = ()
+[%%expect {|
+val u : unit = ()
+|}]
+
+let f (type unused) x = x
+[%%expect {|
+val f : 'a -> 'a = <fun>
+|}]
+
+let f = fun (type unused) x -> x
+[%%expect {|
+val f : 'a -> 'a = <fun>
+|}]
+
+let f = fun (type unused) x -> x
+[%%expect {|
+val f : 'a -> 'a = <fun>
+|}]
+
+let f (type used unused) (x : used) = x
+[%%expect {|
+val f : 'used -> 'used = <fun>
+|}]
+
+let f = fun (type used unused) (x : used) -> x
+
+[%%expect{|
+val f : 'used -> 'used = <fun>
+|}]
+
+let f : type used unused. used -> used = fun x -> x
+
+[%%expect{|
+val f : 'used -> 'used = <fun>
+|}]

--- a/testsuite/tests/typing-warnings/unused_types.ml
+++ b/testsuite/tests/typing-warnings/unused_types.ml
@@ -624,3 +624,50 @@ Warning 34 [unused-type-declaration]: unused type unused.
 
 val f : 'used -> 'used = <fun>
 |}]
+
+let f (type unused1 unused2) x = x
+[%%expect {|
+Line 1, characters 12-19:
+1 | let f (type unused1 unused2) x = x
+                ^^^^^^^
+Warning 34 [unused-type-declaration]: unused type unused1.
+
+Line 1, characters 20-27:
+1 | let f (type unused1 unused2) x = x
+                        ^^^^^^^
+Warning 34 [unused-type-declaration]: unused type unused2.
+
+val f : 'a -> 'a = <fun>
+|}]
+
+let f = fun (type unused1 unused2) x -> x
+
+[%%expect{|
+Line 1, characters 18-25:
+1 | let f = fun (type unused1 unused2) x -> x
+                      ^^^^^^^
+Warning 34 [unused-type-declaration]: unused type unused1.
+
+Line 1, characters 26-33:
+1 | let f = fun (type unused1 unused2) x -> x
+                              ^^^^^^^
+Warning 34 [unused-type-declaration]: unused type unused2.
+
+val f : 'a -> 'a = <fun>
+|}]
+
+let f : type unused1 unused2. 'a -> 'a = fun x -> x
+
+[%%expect{|
+Line 1, characters 13-20:
+1 | let f : type unused1 unused2. 'a -> 'a = fun x -> x
+                 ^^^^^^^
+Warning 34 [unused-type-declaration]: unused type unused1.
+
+Line 1, characters 21-28:
+1 | let f : type unused1 unused2. 'a -> 'a = fun x -> x
+                         ^^^^^^^
+Warning 34 [unused-type-declaration]: unused type unused2.
+
+val f : 'a -> 'a = <fun>
+|}]

--- a/testsuite/tests/typing-warnings/unused_types.ml
+++ b/testsuite/tests/typing-warnings/unused_types.ml
@@ -535,14 +535,19 @@ module Unused_field_disable_one_warning : sig end
 
 let u (type unused) = ()
 [%%expect {|
+Line 1, characters 12-18:
+1 | let u (type unused) = ()
+                ^^^^^^
+Warning 34 [unused-type-declaration]: unused type unused.
+
 val u : unit = ()
 |}]
 
 let u = fun (type unused) -> ()
 [%%expect {|
-Line 1, characters 8-31:
+Line 1, characters 18-24:
 1 | let u = fun (type unused) -> ()
-            ^^^^^^^^^^^^^^^^^^^^^^^
+                      ^^^^^^
 Warning 34 [unused-type-declaration]: unused type unused.
 
 val u : unit = ()
@@ -550,37 +555,72 @@ val u : unit = ()
 
 let u : type unused. unit = ()
 [%%expect {|
+Line 1, characters 13-19:
+1 | let u : type unused. unit = ()
+                 ^^^^^^
+Warning 34 [unused-type-declaration]: unused type unused.
+
 val u : unit = ()
 |}]
 
 let f (type unused) x = x
 [%%expect {|
+Line 1, characters 12-18:
+1 | let f (type unused) x = x
+                ^^^^^^
+Warning 34 [unused-type-declaration]: unused type unused.
+
 val f : 'a -> 'a = <fun>
 |}]
 
 let f = fun (type unused) x -> x
 [%%expect {|
+Line 1, characters 18-24:
+1 | let f = fun (type unused) x -> x
+                      ^^^^^^
+Warning 34 [unused-type-declaration]: unused type unused.
+
 val f : 'a -> 'a = <fun>
 |}]
 
 let f = fun (type unused) x -> x
 [%%expect {|
+Line 1, characters 18-24:
+1 | let f = fun (type unused) x -> x
+                      ^^^^^^
+Warning 34 [unused-type-declaration]: unused type unused.
+
 val f : 'a -> 'a = <fun>
 |}]
 
 let f (type used unused) (x : used) = x
 [%%expect {|
+Line 1, characters 17-23:
+1 | let f (type used unused) (x : used) = x
+                     ^^^^^^
+Warning 34 [unused-type-declaration]: unused type unused.
+
 val f : 'used -> 'used = <fun>
 |}]
 
 let f = fun (type used unused) (x : used) -> x
 
 [%%expect{|
+Line 1, characters 23-29:
+1 | let f = fun (type used unused) (x : used) -> x
+                           ^^^^^^
+Warning 34 [unused-type-declaration]: unused type unused.
+
 val f : 'used -> 'used = <fun>
 |}]
 
 let f : type used unused. used -> used = fun x -> x
 
 [%%expect{|
+Line 1, characters 18-24:
+1 | let f : type used unused. used -> used = fun x -> x
+                      ^^^^^^
+Warning 34 [unused-type-declaration]: unused type unused.
+
 val f : 'used -> 'used = <fun>
 |}]

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -4538,8 +4538,7 @@ and type_constraint_expect
 *)
 and type_newtype
   : type a. _ -> _ -> (Env.t -> a * type_expr) -> a * type_expr =
-  fun env name type_body ->
-  let { txt = name; loc = name_loc } : _ Location.loc = name in
+  fun env { txt = name; loc = name_loc } type_body ->
   let ty =
     if Typetexp.valid_tyvar_name name then
       newvar ~name ()

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -4246,8 +4246,8 @@ and type_expect_
       in
       re { exp with exp_extra =
              (Texp_poly cty, loc, sexp.pexp_attributes) :: exp.exp_extra }
-  | Pexp_newtype({txt=name}, sbody) ->
-      let body, ety = type_newtype loc env name (fun env ->
+  | Pexp_newtype(name, sbody) ->
+      let body, ety = type_newtype env name (fun env ->
         let expr = type_exp env sbody in
         expr, expr.exp_type)
       in
@@ -4255,7 +4255,8 @@ and type_expect_
          any new extra node in the typed AST. *)
       rue { body with exp_loc = loc; exp_type = ety;
             exp_extra =
-            (Texp_newtype name, loc, sexp.pexp_attributes) :: body.exp_extra }
+            (Texp_newtype name.txt, loc, sexp.pexp_attributes) :: body.exp_extra
+          }
   | Pexp_pack m ->
       let (p, fl) =
         match get_desc (Ctype.expand_head env (instance ty_expected)) with
@@ -4536,8 +4537,9 @@ and type_constraint_expect
     nodes for the newtype properly linked.
 *)
 and type_newtype
-  : type a. _ -> _ -> _ -> (Env.t -> a * type_expr) -> a * type_expr =
-  fun loc env name type_body ->
+  : type a. _ -> _ -> (Env.t -> a * type_expr) -> a * type_expr =
+  fun env name type_body ->
+  let { txt = name; loc = name_loc } : _ Location.loc = name in
   let ty =
     if Typetexp.valid_tyvar_name name then
       newvar ~name ()
@@ -4547,7 +4549,7 @@ and type_newtype
   (* Use [with_local_level] just for scoping *)
   with_local_level begin fun () ->
     (* Create a fake abstract type declaration for [name]. *)
-    let decl = new_local_type ~loc Definition in
+    let decl = new_local_type ~loc:name_loc Definition in
     let scope = create_scope () in
     let (id, new_env) = Env.enter_type ~scope name decl env in
 
@@ -4685,7 +4687,7 @@ and type_function
   | { pparam_desc = Pparam_newtype newtype; pparam_loc = _ } :: rest ->
       (* Check everything else in the scope of (type a). *)
       let (params, body, newtypes, contains_gadt), exp_type =
-        type_newtype loc env newtype.txt (fun env ->
+        type_newtype env newtype (fun env ->
           let exp_type, params, body, newtypes, contains_gadt =
             (* mimic the typing of Pexp_newtype by minting a new type var,
               like [type_exp].


### PR DESCRIPTION
Fix the issue described in #13254 (and introduced in #12236). Add regression tests.

#12236 stopped warning when locally-abstract types went unused in almost all scenarios. That's because the check for unused types (and unused bindings in general) doesn't raise a warning if the type's location is a ghost location, and 12236 started providing a ghost location as the location of `(type a)` parameters to functions.

**Prior to 12236:**

| Source code  | Parsed as... | Has ghost location? | Location provided to check|
| ------------- | ------------- |-|-|
| `fun (type a) x -> expr`  | `Pexp_newtype ("a", Pexp_fun ("x", expr))`  | no | loc of `Pexp_newtype` |
| RHS of `let f (type a) x = expr`  | same as previous row | no | same as previous row |

**After 12236:**
| Source code  | Parsed as... | Has ghost location? | Location provided to check|
| ------------- | ------------- |-|-|
| `fun (type a) x -> expr`  | `Pexp_function ([ Pparam_newtype "a"; Pparam_val "x" ], expr)`  | no | synthesized ghost location |
| RHS of `let f (type a) x = expr`  | same as previous row | yes | synthesized ghost location |

There are a few alternatives we could explore:
- Change the unused bindings check to not consult the ghost-ness of a location. This seems like a good change to make, but I'm not confident in making it (it might be backward incompatible).
- Attempt to provide the same locations to the check as prior to 12236. This is a bit unnatural, as those location are not readily available in the post-12236 parsetree. This would also involve reverting the part of 12236 that changed let-bound function sugar to be given a ghost location. (See the tables above.)
  - The reason that we decided in 12236 to give let-bound function sugar a ghost location is because the location of the function expression doesn't correspond directly to a span in the source program. But perhaps this is the wrong criterion to have in mind.
- Provide a different location to the check for `type a` parameters that is routinely not a ghost location.

This PR takes the last option, providing the location of the type name `a` in `(type a)` to the check. This location is never ghost in parser-generated ASTs. This has a benefit apart from re-enabling the warning: the error location points directly at the unused name.

This change is OK for parser-generated ASTs. What about ppx-generated ASTs? It's just barely possible to imagine a ppx that used to generate a ghost-location `Pexp_newtype` in order to suppress warning 34; the change in this PR would stop suppressing that warning if the ident's loc is not ghost. I haven't found any such case in a large codebase that uses many of the ppxes available on opam. To me it seems that the old behavior here is undocumented and hopefully not relied upon anywhere, though I invite opposing opinions.

## Review

The first commit adds a regression test and commits the bad output. The second commit fixes the behavior and updates the test output.