### PR TITLE
Add an easier remember to alias for keeping testsuite artefacts

### DIFF
--- a/testsuite/Makefile
+++ b/testsuite/Makefile
@@ -153,10 +153,6 @@ default:
 	@echo "  clean                      delete generated files"
 	@echo "  report                     print the report for the last execution"
 	@echo
-	@echo "all*, parallel* and list can automatically re-run failed test"
-	@echo "directories if MAX_TESTSUITE_DIR_RETRIES permits"
-	@echo "(default value = $(MAX_TESTSUITE_DIR_RETRIES))"
-	@echo
 	@echo "Set the environment variable USE_RUNTIME to \"d\" or \"i\" to run"
 	@echo "the tests with the debug or the instrumented runtime."
 

--- a/testsuite/Makefile
+++ b/testsuite/Makefile
@@ -153,6 +153,10 @@ default:
 	@echo "  clean                      delete generated files"
 	@echo "  report                     print the report for the last execution"
 	@echo
+	@echo "By default, artefacts from tests which pass are not kept, but this can"
+	@echo "be changed by adding KEEP=1 to the make command line or by setting the"
+	@echo "KEEP_TEST_DIR_ON_SUCCESS environment variable to a non-empty value."
+	@echo
 	@echo "Set the environment variable USE_RUNTIME to \"d\" or \"i\" to run"
 	@echo "the tests with the debug or the instrumented runtime."
 

--- a/testsuite/Makefile
+++ b/testsuite/Makefile
@@ -87,7 +87,16 @@ endif
 # KEEP_TEST_DIR_ON_SUCCESS should be set by the user (to a non-empty value)
 # if they want to pass the -keep-test-dir-on-success option to ocamltest,
 # to preserve test data of successful tests.
+
+# KEEP is provided as a rather easier to remmber alias of
+# KEEP_TEST_DIR_ON_SUCCESS, but to prevent the risk of naming conflict it's only
+# recognised when used as make -C testsuite KEEP=1 ...
+ifeq "$(origin KEEP)" "command line"
+KEEP_TEST_DIR_ON_SUCCESS ?= $(KEEP)
+else
 KEEP_TEST_DIR_ON_SUCCESS ?=
+endif
+
 ifeq "$(KEEP_TEST_DIR_ON_SUCCESS)" ""
   OCAMLTEST_KEEP_TEST_DIR_ON_SUCCESS_FLAG =
 else


### PR DESCRIPTION
The testsuite deletes the results of tests which passed (this is a good default). I not infrequently need to inspect artefacts of tests which are (possibly supposedly) passing.

At this point, I remember that there's a way to do this beginning with `KEEP`, but I can _never_ remember that the full run is `make KEEP_TEST_DIR_ON_SUCCESS=1 ...`. There is no auto-completion for variables with GNU make (there is for targets). At this point I sigh and...
```
fgrep KEEP testsuite/Makefile
# select-and-copy KEEP_TEST_DIR_ON_SUCCESS
make -C testsuite <C-V>=1 ...
```

This PR addresses the shortcomings of my memory by allowing the rather easier to remember alias `KEEP` to be used, but only if it's used on the command line, i.e. one can say `make -C testsuite KEEP=1 one DIR=tests/lib-...` 