### PR TITLE
13034 error messages: mismatched labels

### DIFF
--- a/Changes
+++ b/Changes
@@ -233,8 +233,9 @@ _______________
 - #12985, #12988: Better error messages for partially applied functors.
   (Florian Angeletti, report by Arthur Wendling, review by Gabriel Scherer)
 
-- #13034, ????: Better error messages for mismatched function labels
-  (Florian Angeletti, report by Daniel Bünzli, review by ???)
+- #13034, #13260: Better error messages for mismatched function labels
+  (Florian Angeletti, report by Daniel Bünzli, review by Gabriel Scherer and
+   Samuel Vivien)
 
 - #13051: Add a "Syntax error" to error messages for invalid package signatures.
   (Samuel Vivien, review by Gabriel Scherer)

--- a/Changes
+++ b/Changes
@@ -233,6 +233,9 @@ _______________
 - #12985, #12988: Better error messages for partially applied functors.
   (Florian Angeletti, report by Arthur Wendling, review by Gabriel Scherer)
 
+- #13034, ????: Better error messages for mismatched function labels
+  (Florian Angeletti, report by Daniel Bünzli, review by ???)
+
 - #13051: Add a "Syntax error" to error messages for invalid package signatures.
   (Samuel Vivien, review by Gabriel Scherer)
 

--- a/testsuite/tests/typing-misc/labels.ml
+++ b/testsuite/tests/typing-misc/labels.ml
@@ -172,7 +172,8 @@ Line 1, characters 26-33:
                               ^^^^^^^
 Error: This expression has type "x:'a -> unit"
        but an expression was expected of type "unit -> unit"
-       The argument "x" is labeled, but an unlabeled argument was expected
+       The first argument is labeled "x",
+       but an unlabeled argument was expected
 |}]
 
 let () = expect_labeled unlabeled
@@ -182,7 +183,7 @@ Line 1, characters 24-33:
                             ^^^^^^^^^
 Error: This expression has type "'a -> unit"
        but an expression was expected of type "x:'b -> unit"
-       A labeled argument "x" was expected
+       A label "x" was expected
 |}]
 
 let () = expect_labeled wrong_label

--- a/testsuite/tests/typing-misc/labels.ml
+++ b/testsuite/tests/typing-misc/labels.ml
@@ -151,3 +151,46 @@ val f : (x:int -> y:int -> int) -> int = <fun>
 module E : sig type t = (x:int -> y:int -> int) -> int end
 val g : 'a -> E.t = <fun>
 |}]
+
+let labeled ~x = ()
+let unlabeled x = ()
+let wrong_label ~y = ()
+let expect_unlabeled g = if true then g ()
+let expect_labeled g x = if true then g ~x;;
+[%%expect {|
+val labeled : x:'a -> unit = <fun>
+val unlabeled : 'a -> unit = <fun>
+val wrong_label : y:'a -> unit = <fun>
+val expect_unlabeled : (unit -> unit) -> unit = <fun>
+val expect_labeled : (x:'a -> unit) -> 'a -> unit = <fun>
+|}]
+
+let () = expect_unlabeled labeled
+[%%expect {|
+Line 1, characters 26-33:
+1 | let () = expect_unlabeled labeled
+                              ^^^^^^^
+Error: This expression has type "x:'a -> unit"
+       but an expression was expected of type "unit -> unit"
+       The argument "x" is labeled, but an unlabeled argument was expected
+|}]
+
+let () = expect_labeled unlabeled
+[%%expect {|
+Line 1, characters 24-33:
+1 | let () = expect_labeled unlabeled
+                            ^^^^^^^^^
+Error: This expression has type "'a -> unit"
+       but an expression was expected of type "x:'b -> unit"
+       A labeled argument "x" was expected
+|}]
+
+let () = expect_labeled wrong_label
+[%%expect {|
+Line 1, characters 24-35:
+1 | let () = expect_labeled wrong_label
+                            ^^^^^^^^^^^
+Error: This expression has type "y:'a -> unit"
+       but an expression was expected of type "x:'b -> unit"
+       Labels "y" and "x" do not match
+|}]

--- a/testsuite/tests/typing-modules/inclusion_errors.ml
+++ b/testsuite/tests/typing-modules/inclusion_errors.ml
@@ -1875,7 +1875,8 @@ Error: Signature mismatch:
        is not included in
          type t = int -> int
        The type "x:int -> int" is not equal to the type "int -> int"
-       The argument "x" is labeled, but an unlabeled argument was expected
+       The first argument is labeled "x",
+       but an unlabeled argument was expected
 |}]
 
 module Eq_label2: sig
@@ -1921,7 +1922,8 @@ Error: Signature mismatch:
        is not included in
          val f : int -> unit
        The type "x:'a -> unit" is not compatible with the type "int -> unit"
-       The argument "x" is labeled, but an unlabeled argument was expected
+       The first argument is labeled "x",
+       but an unlabeled argument was expected
 |}]
 
 module Label2 : sig
@@ -1949,7 +1951,8 @@ Error: Signature mismatch:
        is not included in
          val f : int -> unit
        The type "?x:'a -> unit" is not compatible with the type "int -> unit"
-       The argument "?x" is optional, but an unlabeled argument was expected
+       The first argument is labeled "?x",
+       but an unlabeled argument was expected
 |}]
 
 
@@ -1978,7 +1981,7 @@ Error: Signature mismatch:
        is not included in
          val f : x:int -> unit
        The type "?x:'a -> unit" is not compatible with the type "x:int -> unit"
-       The optional argument "?x" was not expected to be optional
+       The label "?x" was expected to not be optional
 |}]
 
 
@@ -2031,5 +2034,5 @@ Error: Signature mismatch:
        is not included in
          val f : ?x:int -> unit
        The type "'a -> unit" is not compatible with the type "?x:int -> unit"
-       An optional argument "?x" was expected
+       A label "?x" was expected
 |}]

--- a/testsuite/tests/typing-modules/inclusion_errors.ml
+++ b/testsuite/tests/typing-modules/inclusion_errors.ml
@@ -1853,3 +1853,183 @@ Error: Signature mismatch:
        The value "x" is required but not provided
        The value "y" is required but not provided
 |}];;
+
+
+module Eq_label: sig
+  type t = int -> int
+end = struct
+  type t = x:int -> int
+end
+[%%expect {|
+Lines 3-5, characters 6-3:
+3 | ......struct
+4 |   type t = x:int -> int
+5 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig type t = x:int -> int end
+       is not included in
+         sig type t = int -> int end
+       Type declarations do not match:
+         type t = x:int -> int
+       is not included in
+         type t = int -> int
+       The type "x:int -> int" is not equal to the type "int -> int"
+       The argument "x" is labeled, but an unlabeled argument was expected
+|}]
+
+module Eq_label2: sig
+  type t = y:int -> int
+end = struct
+  type t = x:int -> int
+end
+[%%expect {|
+Lines 3-5, characters 6-3:
+3 | ......struct
+4 |   type t = x:int -> int
+5 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig type t = x:int -> int end
+       is not included in
+         sig type t = y:int -> int end
+       Type declarations do not match:
+         type t = x:int -> int
+       is not included in
+         type t = y:int -> int
+       The type "x:int -> int" is not equal to the type "y:int -> int"
+       Labels "x" and "y" do not match
+|}]
+
+module Label1 : sig
+  val f: int -> unit
+end = struct
+  let f ~x = ()
+end
+[%%expect {|
+Lines 3-5, characters 6-3:
+3 | ......struct
+4 |   let f ~x = ()
+5 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig val f : x:'a -> unit end
+       is not included in
+         sig val f : int -> unit end
+       Values do not match:
+         val f : x:'a -> unit
+       is not included in
+         val f : int -> unit
+       The type "x:'a -> unit" is not compatible with the type "int -> unit"
+       The argument "x" is labeled, but an unlabeled argument was expected
+|}]
+
+module Label2 : sig
+  val f: int -> unit
+end = struct
+  let f ?x = ()
+end
+[%%expect {|
+Line 4, characters 9-10:
+4 |   let f ?x = ()
+             ^
+Warning 16 [unerasable-optional-argument]: this optional argument cannot be erased.
+
+Lines 3-5, characters 6-3:
+3 | ......struct
+4 |   let f ?x = ()
+5 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig val f : ?x:'a -> unit end
+       is not included in
+         sig val f : int -> unit end
+       Values do not match:
+         val f : ?x:'a -> unit
+       is not included in
+         val f : int -> unit
+       The type "?x:'a -> unit" is not compatible with the type "int -> unit"
+       The argument "?x" is optional, but an unlabeled argument was expected
+|}]
+
+
+module Label3 : sig
+  val f: x:int -> unit
+end = struct
+  let f ?x = ()
+end
+[%%expect {|
+Line 4, characters 9-10:
+4 |   let f ?x = ()
+             ^
+Warning 16 [unerasable-optional-argument]: this optional argument cannot be erased.
+
+Lines 3-5, characters 6-3:
+3 | ......struct
+4 |   let f ?x = ()
+5 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig val f : ?x:'a -> unit end
+       is not included in
+         sig val f : x:int -> unit end
+       Values do not match:
+         val f : ?x:'a -> unit
+       is not included in
+         val f : x:int -> unit
+       The type "?x:'a -> unit" is not compatible with the type "x:int -> unit"
+       The optional argument "?x" was not expected to be optional
+|}]
+
+
+module Label4 : sig
+  val f: ?x:int -> unit
+end = struct
+  let f ?y = ()
+end
+[%%expect {|
+Line 4, characters 9-10:
+4 |   let f ?y = ()
+             ^
+Warning 16 [unerasable-optional-argument]: this optional argument cannot be erased.
+
+Lines 3-5, characters 6-3:
+3 | ......struct
+4 |   let f ?y = ()
+5 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig val f : ?y:'a -> unit end
+       is not included in
+         sig val f : ?x:int -> unit end
+       Values do not match:
+         val f : ?y:'a -> unit
+       is not included in
+         val f : ?x:int -> unit
+       The type "?y:'a -> unit" is not compatible with the type "?x:int -> unit"
+       Labels "?y" and "?x" do not match
+|}]
+
+
+module Label5 : sig
+  val f: ?x:int -> unit
+end = struct
+  let f x = ()
+end
+[%%expect {|
+Lines 3-5, characters 6-3:
+3 | ......struct
+4 |   let f x = ()
+5 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig val f : 'a -> unit end
+       is not included in
+         sig val f : ?x:int -> unit end
+       Values do not match:
+         val f : 'a -> unit
+       is not included in
+         val f : ?x:int -> unit
+       The type "'a -> unit" is not compatible with the type "?x:int -> unit"
+       An optional argument "?x" was expected
+|}]

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -2836,16 +2836,16 @@ and unify3 uenv t1 t1' t2 t2' =
     try
       begin match (d1, d2) with
         (Tarrow (l1, t1, u1, c1), Tarrow (l2, t2, u2, c2)) ->
-          if
-            compatible_labels ~in_pattern_mode:(in_pattern_mode uenv) l1 l2
-          then begin unify uenv t1 t2; unify uenv u1 u2;
-            match is_commu_ok c1, is_commu_ok c2 with
-            | false, true -> set_commu_ok c1
-            | true, false -> set_commu_ok c2
-            | false, false -> link_commu ~inside:c1 c2
-            | true, true -> ()
-          end else
-            raise_for Unify (Function_label_mismatch {got=l1; expected=l2})
+          if not (compatible_labels ~in_pattern_mode:(in_pattern_mode uenv)
+                    l1 l2)
+          then raise_for Unify (Function_label_mismatch {got=l1; expected=l2});
+          unify uenv t1 t2; unify uenv u1 u2;
+          begin match is_commu_ok c1, is_commu_ok c2 with
+          | false, true -> set_commu_ok c1
+          | true, false -> set_commu_ok c2
+          | false, false -> link_commu ~inside:c1 c2
+          | true, true -> ()
+          end
       | (Ttuple tl1, Ttuple tl2) ->
           unify_list uenv tl1 tl2
       | (Tconstr (p1, tl1, _), Tconstr (p2, tl2, _)) when Path.same p1 p2 ->
@@ -3796,12 +3796,11 @@ let rec moregen inst_nongen type_pairs env t1 t2 =
               update_scope_for Moregen (get_scope t1') t2;
               link_type t1' t2
           | (Tarrow (l1, t1, u1, _), Tarrow (l2, t2, u2, _)) ->
-              if compatible_labels ~in_pattern_mode:false l1 l2 then begin
-                moregen inst_nongen type_pairs env t1 t2;
-                moregen inst_nongen type_pairs env u1 u2
-              end else
+              if not (compatible_labels ~in_pattern_mode:false l1 l2) then
                 raise_for Moregen
-                  (Function_label_mismatch {got=l1; expected=l2})
+                  (Function_label_mismatch {got=l1; expected=l2});
+              moregen inst_nongen type_pairs env t1 t2;
+              moregen inst_nongen type_pairs env u1 u2
           | (Ttuple tl1, Ttuple tl2) ->
               moregen_list inst_nongen type_pairs env tl1 tl2
           | (Tconstr (p1, tl1, _), Tconstr (p2, tl2, _))
@@ -4151,12 +4150,11 @@ let rec eqtype rename type_pairs subst env t1 t2 =
             (Tvar _, Tvar _) when rename ->
               eqtype_subst type_pairs subst t1' t2'
           | (Tarrow (l1, t1, u1, _), Tarrow (l2, t2, u2, _)) ->
-              if compatible_labels ~in_pattern_mode:false l1 l2 then begin
-                eqtype rename type_pairs subst env t1 t2;
-                eqtype rename type_pairs subst env u1 u2;
-              end else
+              if not (compatible_labels ~in_pattern_mode:false l1 l2) then
                 raise_for Equality
-                  (Function_label_mismatch {got=l1; expected=l2})
+                  (Function_label_mismatch {got=l1; expected=l2});
+              eqtype rename type_pairs subst env t1 t2;
+              eqtype rename type_pairs subst env u1 u2
           | (Ttuple tl1, Ttuple tl2) ->
               eqtype_list rename type_pairs subst env tl1 tl2
           | (Tconstr (p1, tl1, _), Tconstr (p2, tl2, _))

--- a/typing/errortrace.ml
+++ b/typing/errortrace.ml
@@ -109,6 +109,7 @@ type ('a, 'variety) elt =
   | Variant : 'variety variant -> ('a, 'variety) elt
   | Obj : 'variety obj -> ('a, 'variety) elt
   | Escape : 'a escape -> ('a, _) elt
+  | Function_label_mismatch of Asttypes.arg_label diff
   | Incompatible_fields : { name:string; diff: type_expr diff } -> ('a, _) elt
       (* Could move [Incompatible_fields] into [obj] *)
   | First_class_module: first_class_module -> ('a,_) elt
@@ -126,8 +127,8 @@ let map_elt (type variety) f : ('a, variety) elt -> ('b, variety) elt = function
       Escape { kind = Equation (f x); context }
   | Escape {kind = (Univ _ | Self | Constructor _ | Module_type _ | Constraint);
             _}
-  | Variant _ | Obj _ | Incompatible_fields _ | Rec_occur (_, _)
-  | First_class_module _  as x -> x
+  | Variant _ | Obj _ | Function_label_mismatch _ | Incompatible_fields _
+  | Rec_occur (_, _) | First_class_module _  as x -> x
 
 let map f t = List.map (map_elt f) t
 

--- a/typing/errortrace.mli
+++ b/typing/errortrace.mli
@@ -95,6 +95,7 @@ type ('a, 'variety) elt =
   | Variant : 'variety variant -> ('a, 'variety) elt
   | Obj : 'variety obj -> ('a, 'variety) elt
   | Escape : 'a escape -> ('a, _) elt
+  | Function_label_mismatch of Asttypes.arg_label diff
   | Incompatible_fields : { name:string; diff: type_expr diff } -> ('a, _) elt
   | First_class_module: first_class_module -> ('a,_) elt
   (* Unification & Moregen; included in Equality for simplicity *)


### PR DESCRIPTION
This PR adds a specialized explanation for mismatched function labels in type error messages.
For instance, in

```ocaml
module Label1 : sig
  val f: int -> unit
end = struct
  let f ~x = ()
end
```
the existing error message
>```Error: Signature mismatch:
>       Modules do not match:
>         sig val f : x:'a -> unit end
>       is not included in
>         sig val f : int -> unit end
>       Values do not match:
>         val f : x:'a -> unit
>       is not included in
>         val f : int -> unit
>       The type "x:'a -> unit" is not compatible with the type "int -> unit"
is extended with
>```
>       The argument "x" is labeled, but an unlabeled argument was expected
>```

This complements the existing specialized error message for syntactic argument with a label incompatible with the expected type.

close  #13034