### PR TITLE
Rework fixed register assignments on m68k.

### DIFF
--- a/Changes
+++ b/Changes
@@ -7,6 +7,11 @@ OCaml 5.2 maintenance version
   (Miod Vallat, report by Vesa Karvonen, review by Gabriel Scherer and
    Xavier Leroy)
 
+- #13252: Rework register assignment in the interpreter code on m68k on Linux,
+  due to the %a5 register being used by Glibc.
+  (Miod Vallat, report by Stéphane Glondu, review by Gabriel Scherer and
+   Xavier Leroy)
+
 OCaml 5.2.0 (13 May 2024)
 -------------------------
 

--- a/runtime/interp.c
+++ b/runtime/interp.c
@@ -209,7 +209,7 @@ Caml_inline void check_trap_barrier_for_effect
 #define ACCU_REG asm("%r16")
 #endif
 #ifdef __mc68000__
-#define PC_REG asm("a5")
+#define PC_REG asm("a3")
 #define SP_REG asm("a4")
 #define ACCU_REG asm("d7")
 #endif


### PR DESCRIPTION
The use of %a5 conflicts with its internal usage as a GOT base by Glibc, so shift assignments one register down.

Origin: https://github.com/ocaml/ocaml/pull/13252