### PR TITLE
Add CFI expressions for RISC-V stack switch between C and OCaml.

### DIFF
--- a/Changes
+++ b/Changes
@@ -95,8 +95,8 @@ _______________
   with MSVC or clang-cl.
   (Antonin Décimo, review by Miod Vallat)
 
-- #13241, #13261: Add CFI_SIGNAL_FRAME to ARM64 and RiscV runtimes, for the
-  purpose of displaying backtraces correctly in GDB.
+- #13241, #13261, #13271: Add CFI_SIGNAL_FRAME to ARM64 and RiscV runtimes,
+  for the purpose of displaying backtraces correctly in GDB.
   (Tim McGilchrist, review by Miod Vallat, Gabriel Scherer and
    KC Sivaramakrishnan)
 

--- a/runtime/riscv.S
+++ b/runtime/riscv.S
@@ -32,6 +32,19 @@
 #define C_ARG_3 a2
 #define C_ARG_4 a3
 
+
+/* DWARF
+
+   These RISC-V specific register numbers come from
+   Table 19. "DWARF register number encodings" of:
+
+   RISC-V ABIs Specification, Document Version 1.0
+   https://github.com/riscv-non-isa/riscv-elf-psabi-doc/releases/tag/v1.0
+
+*/
+#define DW_REG_s4                 20
+#define DW_REG_sp                 2
+
         .set    domain_curr_field, 0
 #define DOMAIN_STATE(c_type, name) \
         .equ    domain_field_caml_##name, domain_curr_field ; \
@@ -112,6 +125,7 @@ name:
 
 /* struct stack_info */
 #define Stack_sp(reg)           0(reg)
+#define Stack_sp_offset         0
 #define Stack_exception(reg)    8(reg)
 #define Stack_handler(reg)      16(reg)
 #define Stack_handler_from_cont(reg) 15(reg)
@@ -119,6 +133,7 @@ name:
 /* struct c_stack_link */
 #define Cstack_stack(reg)       0(reg)
 #define Cstack_sp(reg)          8(reg)
+#define Cstack_sp_offset        8
 #define Cstack_prev(reg)        16(reg)
 
 /* struct stack_handler */
@@ -126,6 +141,7 @@ name:
 #define Handler_exception(reg)  8(reg)
 #define Handler_effect(reg)     16(reg)
 #define Handler_parent(reg)     24(reg)
+#define Handler_parent_offset   24
 
 /* Switch from OCaml to C stack. */
 .macro SWITCH_OCAML_TO_C
@@ -139,6 +155,10 @@ name:
     /* Switch to C stack */
         mv      sp, TMP2
         CFI_REMEMBER_STATE
+    /* sp points to the c_stack_link. */
+        .cfi_escape DW_CFA_def_cfa_expression, 5,                 \
+           DW_OP_breg + DW_REG_sp, Cstack_sp_offset, DW_OP_deref, \
+           DW_OP_plus_uconst, 16 /* fp + retaddr */
 .endm
 
 /* Switch from C to OCaml stack. */
@@ -602,8 +622,10 @@ FUNCTION(caml_start_program)
 
 L(jump_to_caml):
     /* Set up stack frame and save callee-save registers */
+        CFI_OFFSET(s0, -208)
         CFI_OFFSET(ra, -200)
         addi    sp, sp, -208
+        sd      s0, 0(sp)
         sd      ra, 8(sp)
         CFI_ADJUST(208)
         sd      s0, (2*8)(sp)
@@ -637,10 +659,10 @@ L(jump_to_caml):
     /* Build (16-byte aligned) struct c_stack_link on the C stack */
         ld      t2, Caml_state(c_stack)
         addi    sp, sp, -32
+        CFI_ADJUST(32)
         sd      t2, Cstack_prev(sp)
         sd      x0, Cstack_stack(sp)
         sd      x0, Cstack_sp(sp)
-        CFI_ADJUST(32)
         sd      sp, Caml_state(c_stack)
     /* Load the OCaml stack */
         ld      t2, Caml_state(current_stack)
@@ -662,6 +684,15 @@ L(jump_to_caml):
     /* Switch stacks and call the OCaml code */
         mv      sp, t2
         CFI_REMEMBER_STATE
+        .cfi_escape DW_CFA_def_cfa_expression, 3 + 2 + 2,             \
+            /* sp points to the exn handler on the OCaml stack */     \
+            /* sp + 16 contains the C_STACK_SP */                     \
+          DW_OP_breg + DW_REG_sp, 16 /* exn handler */, DW_OP_deref,  \
+            /* 32   struct c_stack_link + pad */                      \
+            /* 24*8 callee save regs */                               \
+            /* 16   fp + ret addr */                                  \
+            /* need to split to get under 127 limit */                \
+          DW_OP_plus_uconst, 120, DW_OP_plus_uconst, 120
     /* Call the OCaml code */
         jalr    TMP2
 L(caml_retaddr):
@@ -1147,6 +1178,15 @@ FUNCTION(caml_runstack)
     /* Switch to the new stack */
         mv      sp, t3
         CFI_REMEMBER_STATE
+        .cfi_escape DW_CFA_def_cfa_expression, 3+3+2,       \
+          DW_OP_breg + DW_REG_sp,                           \
+            16 /* exn */ +                                  \
+            8 /* gc_regs slot (unused) */ +                 \
+            8 /* C_STACK_SP for DWARF (unused) */           \
+            + Handler_parent_offset, DW_OP_deref,           \
+          DW_OP_plus_uconst, Stack_sp_offset, DW_OP_deref,  \
+          DW_OP_plus_uconst, 16 /* fp + ret addr */
+
     /* Call the function on the new stack */
         mv      a0, a2
         jalr    a3
@@ -1166,6 +1206,7 @@ L(frame_runstack):
         ld      s4, Stack_sp(TMP) /* saved across C call */
         CFI_RESTORE_STATE
         CFI_REMEMBER_STATE
+        CFI_DEF_CFA_REGISTER(DW_REG_s4)
         ld      TMP, Caml_state(c_stack)
         mv      sp, TMP
         call    PLT(caml_free_stack)


### PR DESCRIPTION
Another small improvement on https://github.com/ocaml/ocaml/pull/13241 on the same theme as https://github.com/ocaml/ocaml/pull/13261

Using the meander example from Retrofitting effect handlers onto OCaml https://dl.acm.org/doi/10.1145/3453483.3454039
but this time running a GDB session on Ubuntu 24.04/RiscV. Before this change the backtrace when jumping from C to OCaml and back again was broken see https://github.com/ocaml/ocaml/pull/13241#issuecomment-2190496323

The RISC-V runtime was missing the CFI expressions to describe where to find the stacks and the saved registers, these have been added in 8e7225667733daa944955ac9e57c29fdb962e6f5. Now running the same GDB session we get accurate backtraces:
```
Breakpoint 2, <signal handler called>                                                                                                                     
(gdb) bt                                                                                                                                                  
#0  <signal handler called>                                                                                                                               
#1  0x0000002aaaae6a62 in caml_startup_common (pooling=<optimized out>, argv=0x3ffffff2d8) at runtime/startup_nat.c:128                                   
#2  caml_startup_common (argv=0x3ffffff2d8, pooling=<optimized out>) at runtime/startup_nat.c:87                                                          
#3  0x0000002aaaae6ab6 in caml_startup_exn (argv=<optimized out>) at runtime/startup_nat.c:135
#4  caml_startup (argv=<optimized out>) at runtime/startup_nat.c:140
#5  caml_main (argv=<optimized out>) at runtime/startup_nat.c:147
#6  0x0000002aaaac528a in main (argc=<optimized out>, argv=<optimized out>) at runtime/main.c:37
(gdb) c
Continuing.

Breakpoint 1, 0x0000002aaaac5350 in caml_program ()
(gdb) bt
#0  0x0000002aaaac5350 in caml_program ()
#1  <signal handler called>
#2  0x0000002aaaae6a62 in caml_startup_common (pooling=<optimized out>, argv=0x2aaab318c0) at runtime/startup_nat.c:128
#3  caml_startup_common (argv=0x2aaab318c0, pooling=<optimized out>) at runtime/startup_nat.c:87
#4  0x0000002aaaae6ab6 in caml_startup_exn (argv=<optimized out>) at runtime/startup_nat.c:135
#5  caml_startup (argv=<optimized out>) at runtime/startup_nat.c:140
#6  caml_main (argv=<optimized out>) at runtime/startup_nat.c:147
#7  0x0000002aaaac528a in main (argc=<optimized out>, argv=<optimized out>) at runtime/main.c:37
(gdb) c
Continuing.

Breakpoint 3, 0x0000002aaaacb3f0 in ocaml_to_c ()
(gdb) bt
#0  0x0000002aaaacb3f0 in ocaml_to_c ()
#1  <signal handler called>
#2  0x0000002aaaac5cd4 in camlMeander.omain_278 ()
#3  0x0000002aaaac5e80 in camlMeander.entry ()
#4  0x0000002aaaac53ec in caml_program ()
#5  <signal handler called>
#6  0x0000002aaaae6a62 in caml_startup_common (pooling=<optimized out>, argv=0x2aaab31888) at runtime/startup_nat.c:128
#7  caml_startup_common (argv=0x2aaab31888, pooling=<optimized out>) at runtime/startup_nat.c:87
#8  0x0000002aaaae6ab6 in caml_startup_exn (argv=<optimized out>) at runtime/startup_nat.c:135
#9  caml_startup (argv=<optimized out>) at runtime/startup_nat.c:140
#10 caml_main (argv=<optimized out>) at runtime/startup_nat.c:147
#11 0x0000002aaaac528a in main (argc=<optimized out>, argv=<optimized out>) at runtime/main.c:37
(gdb) c
Continuing.

Breakpoint 2, <signal handler called>
(gdb) bt
#0  <signal handler called>
#1  0x0000002aaaacc0be in caml_callback_exn (closure=<optimized out>, arg=<optimized out>) at runtime/callback.c:206
#2  0x0000002aaaacc4c4 in caml_callback (closure=<optimized out>, arg=<optimized out>) at runtime/callback.c:347
#3  0x0000002aaaacb3fc in ocaml_to_c ()
#4  <signal handler called>
#5  0x0000002aaaac5cd4 in camlMeander.omain_278 ()
#6  0x0000002aaaac5e80 in camlMeander.entry ()
#7  0x0000002aaaac53ec in caml_program ()
#8  <signal handler called>
#9  0x0000002aaaae6a62 in caml_startup_common (pooling=<optimized out>, argv=0x2aaab31888) at runtime/startup_nat.c:128
#10 caml_startup_common (argv=0x2aaab31888, pooling=<optimized out>) at runtime/startup_nat.c:87
#11 0x0000002aaaae6ab6 in caml_startup_exn (argv=<optimized out>) at runtime/startup_nat.c:135
#12 caml_startup (argv=<optimized out>) at runtime/startup_nat.c:140
#13 caml_main (argv=<optimized out>) at runtime/startup_nat.c:147
#14 0x0000002aaaac528a in main (argc=<optimized out>, argv=<optimized out>) at runtime/main.c:37
(gdb) info br
Num     Type           Disp Enb Address            What
1       breakpoint     keep y   0x0000002aaaac5350 <caml_program+8>
        breakpoint already hit 1 time
2       breakpoint     keep y   0x0000002aaaae7044 <caml_start_program+40>
        breakpoint already hit 2 times
3       breakpoint     keep y   0x0000002aaaacb3f0 <ocaml_to_c+12>
        breakpoint already hit 1 time
4       breakpoint     keep y   0x0000002aaaac5c88 <camlMeander.c_to_ocaml_273+28>
(gdb) 
```

Thanks to @dustanddreams who helped with understanding RiscV assembly.