### PR TITLE
Add `-vnum`/`-version` to ocamlobjinfo and ocamlcmt

### DIFF
--- a/tools/objinfo.ml
+++ b/tools/objinfo.ml
@@ -433,6 +433,14 @@ let dump_obj filename =
   then dump_cmxs ic
   else exit_magic_error ~expected_kind:None (Parse_error head_error)
 
+let print_version () =
+  Format.printf "ocamlobjinfo, version %s@." Sys.ocaml_version;
+  exit 0
+
+let print_version_num () =
+  Format.printf "%s@." Sys.ocaml_version;
+  exit 0
+
 let arg_list = [
   "-quiet", Arg.Set quiet,
     " Only print explicitly required information";
@@ -447,6 +455,8 @@ let arg_list = [
   "-decls", Arg.Set decls,
     " Print a list of all declarations in the module";
   "-null-crc", Arg.Set no_crc, " Print a null CRC for imported interfaces";
+  "-version", Arg.Unit print_version, " Print version and exit";
+  "-vnum", Arg.Unit print_version_num, " Print version number and exit";
   "-args", Arg.Expand Arg.read_arg,
      "<file> Read additional newline separated command line arguments \n\
      \      from <file>";

--- a/tools/ocamlcmt.ml
+++ b/tools/ocamlcmt.ml
@@ -19,6 +19,14 @@ let print_info_arg = ref false
 let target_filename = ref None
 let save_cmt_info = ref false
 
+let print_version () =
+  Format.printf "ocamlcmt, version %s@." Sys.ocaml_version;
+  exit 0
+
+let print_version_num () =
+  Format.printf "%s@." Sys.ocaml_version;
+  exit 0
+
 let arg_list = Arg.align [
   "-o", Arg.String (fun s -> target_filename := Some s),
     "<file> Dump to file <file> (or stdout if -)";
@@ -29,6 +37,10 @@ let arg_list = Arg.align [
   "-src", Arg.Set gen_ml,
     " Convert .cmt or .cmti back to source code (without comments)";
   "-info", Arg.Set print_info_arg, " : print information on the file";
+  "-version", Arg.Unit print_version,
+              "     Print version and exit";
+  "-vnum", Arg.Unit print_version_num,
+           "        Print version number and exit";
   "-args", Arg.Expand Arg.read_arg,
     "<file> Read additional newline separated command line arguments \n\
     \      from <file>";


### PR DESCRIPTION
Very minor in the wealth of PRs at the moment, but these are the only two tool binaries installed by OCaml which don't report their version number.

Motivation was a test ensuring the correctness of relocatable binaries, which wants to be able to run everything installed to BINDIR by OCaml with a single flag - with this PR, everything we put in BINDIR accepts `-vnum` or `-version` and exits with code 0 having printed a single line.