### PR TITLE
Use the `strip` command detected by libtool

### DIFF
--- a/Makefile.config.in
+++ b/Makefile.config.in
@@ -192,6 +192,7 @@ OC_NATIVE_CFLAGS=@native_cflags@
 
 NATIVECCLIBS=@cclibs@
 SYSTHREAD_SUPPORT=@systhread_support@
+STRIP=@STRIP@
 PACKLD=@PACKLD@$(EMPTY)
 CCOMPTYPE=@ccomptype@
 TOOLCHAIN=@toolchain@

--- a/stdlib/Makefile
+++ b/stdlib/Makefile
@@ -98,7 +98,7 @@ tmpheader.exe: $(HEADERPROGRAM).$(O)
 	$(V_MKEXE)$(call MKEXE_VIA_CC,$@,$^)
 # FIXME This is wrong - mingw could invoke strip; MSVC equivalent?
 ifneq "$(UNIX_OR_WIN32)" "win32"
-	strip $@
+	$(STRIP) $@
 endif
 
 stdlib.cma: $(OBJS)

--- a/stdlib/Makefile
+++ b/stdlib/Makefile
@@ -96,10 +96,7 @@ endif
 .INTERMEDIATE: tmpheader.exe
 tmpheader.exe: $(HEADERPROGRAM).$(O)
 	$(V_MKEXE)$(call MKEXE_VIA_CC,$@,$^)
-# FIXME This is wrong - mingw could invoke strip; MSVC equivalent?
-ifneq "$(UNIX_OR_WIN32)" "win32"
 	$(STRIP) $@
-endif
 
 stdlib.cma: $(OBJS)
 	$(V_LINKC)$(CAMLC) -a -o $@ $^


### PR DESCRIPTION
This PR proposes to use the `strip` command detected by `libtool` during configure so that it is replaced with `:` when the command is absent and it becomes easy to override it if need be, such as in cross-compilation cases.
It also proposes to strip `tmpheader.exe` also on Windows, as it seems that GNU `strip` can be called safely on binaries generated by cl as well as by MinGW GCC (even if it doesn't produce a smaller executable for cl-generated binaries).

Using GNU strip 2.42 on a basic hello-world example, I get:

| size (bytes) | executable                | generated with              |
| -----------: | :------------------------ | :-------------------------- |
|       143360 | hello.cl.exe              | cl                          |
|       143360 | hello.cl.strip.exe        | cl, stripped                |
|       647168 | hello.clZi.exe            | cl with /Zi                 |
|       647168 | hello.clZi.strip.exe      | cl with /Zi, stripped       |
|       143360 | hello.clangcl.exe         | clang-cl                    |
|       143360 | hello.clangcl.strip.exe   | clang-cl, stripped          |
|       651264 | hello.clangclZi.exe       | clang-cl with /Zi           |
|       651264 | hello.clangclZi.strip.exe | clang-cl with /Zi, stripped |
|       258048 | hello.mingw.exe           | MinGW gcc                   |
|        40960 | hello.mingw.strip.exe     | MinGW gcc, stripped         |
|       262144 | hello.mingw-g.exe         | MinGW gcc with -g           |
|        40960 | hello.mingw-g.strip.exe   | MinGW gcc with -g, stripped |

I compared the output of `dumpbin /all` before and after stripping. Symbols no longer appear in the stripped versions for `cl` and `clang-cl` even if the files keep the exact same size, strangely.

All the binaries run as expected, but that’s not a big test.