### PR TITLE
Update manual with short syntax for dependent functor types.

### DIFF
--- a/Changes
+++ b/Changes
@@ -15,7 +15,7 @@ _______________
 
 ### Language features:
 
-- #12828: Add short syntax for dependent functor types `(X:A) -> ...`
+- #12828, #13282: Add short syntax for dependent functor types `(X:A) -> ...`
   (Jeremy Yallop, review by Nicolás Ojeda Bär and Gabriel Scherer)
 
 - Add syntax support for deep effect handlers

--- a/manual/src/refman/modtypes.etex
+++ b/manual/src/refman/modtypes.etex
@@ -22,7 +22,7 @@ specify the general shape and type properties of modules.
 module-type:
           modtype-path
         | 'sig' { specification [';;'] } 'end'
-        | 'functor' '(' module-name ':' module-type ')' '->' module-type
+        | ['functor'] '(' module-name ':' module-type ')' '->' module-type
         | module-type '->' module-type
         | module-type 'with' mod-constraint { 'and' mod-constraint }
         | '(' module-type ')'
@@ -200,8 +200,8 @@ For specifying a module component that is a functor, one may write
 instead of
 \begin{center}
 @'module' module-name ':'
- 'functor' '(' name_1 ':' module-type_1 ')' '->' \ldots
-                                            '->' module-type@
+  '(' name_1 ':' module-type_1 ')' '->' \ldots
+  '(' name_n ':' module-type_n ')' '->' module-type@
 \end{center}
 
 \subsubsection*{sss:mty-mty}{Module type specifications}
@@ -249,7 +249,7 @@ refer to a module type that is a signature, not a functor type.
 \ikwd{functor\@\texttt{functor}}
 
 The module type expression
-@'functor' '(' module-name ':' module-type_1 ')' '->' module-type_2@
+@['functor'] '(' module-name ':' module-type_1 ')' '->' module-type_2@
 is the type of functors (functions from modules to modules) that take
 as argument a module of type @module-type_1@ and return as result a
 module of type @module-type_2@. The module type @module-type_2@ can
@@ -264,13 +264,13 @@ particular, a functor may take another functor as argument
 
 When the result module type is itself a functor,
 \begin{center}
-@'functor' '(' name_1 ':' module-type_1 ')' '->' \ldots '->'
- 'functor' '(' name_n ':' module-type_n ')' '->' module-type@
+@'(' name_1 ':' module-type_1 ')' '->' \ldots '->'
+ '(' name_n ':' module-type_n ')' '->' module-type@
 \end{center}
 one may use the abbreviated form
 \begin{center}
-@'functor' '(' name_1 ':' module-type_1 ')' \ldots
-           '(' name_n ':' module-type_n ')' '->' module-type@
+@'(' name_1 ':' module-type_1 ')' \ldots
+ '(' name_n ':' module-type_n ')' '->' module-type@
 \end{center}
 
 \subsection{ss:mty-with}{The "with" operator}

--- a/manual/src/refman/modtypes.etex
+++ b/manual/src/refman/modtypes.etex
@@ -200,7 +200,7 @@ For specifying a module component that is a functor, one may write
 instead of
 \begin{center}
 @'module' module-name ':'
-  '(' name_1 ':' module-type_1 ')' '->' \ldots
+  '(' name_1 ':' module-type_1 ')' \ldots
   '(' name_n ':' module-type_n ')' '->' module-type@
 \end{center}
 

--- a/manual/src/tutorials/moduleexamples.etex
+++ b/manual/src/tutorials/moduleexamples.etex
@@ -227,7 +227,7 @@ their code. This can be achieved by restricting "Set" by a suitable
 functor signature:
 \begin{caml_example}{toplevel}
 module type SETFUNCTOR =
-  functor (Elt: ORDERED_TYPE) ->
+  (Elt: ORDERED_TYPE) ->
     sig
       type element = Elt.t      (* concrete *)
       type set                  (* abstract *)
@@ -252,7 +252,7 @@ module type SET =
     val add : element -> set -> set
     val member : element -> set -> bool
   end;;
-module WrongSet = (Set : functor(Elt: ORDERED_TYPE) -> SET);;
+module WrongSet = (Set : (Elt: ORDERED_TYPE) -> SET);;
 module WrongStringSet = WrongSet(OrderedString);;
 WrongStringSet.add "gee" WrongStringSet.empty [@@expect error];;
 \end{caml_example}
@@ -269,7 +269,7 @@ not exist. To overcome this difficulty, OCaml provides a
 with extra type equalities:
 \begin{caml_example}{toplevel}
 module AbstractSet2 =
-  (Set : functor(Elt: ORDERED_TYPE) -> (SET with type element = Elt.t));;
+  (Set : (Elt: ORDERED_TYPE) -> (SET with type element = Elt.t));;
 \end{caml_example}
 
 As in the case of simple structures, an alternate syntax is provided


### PR DESCRIPTION
Update the manual with the short syntax for dependent functor types added in #12828.