### PR TITLE
Fix attributes CAMLno_tsan and CAMLno_asan on GCC 14

### DIFF
--- a/runtime/caml/misc.h
+++ b/runtime/caml/misc.h
@@ -586,8 +586,10 @@ CAMLextern int caml_snwprintf(wchar_t * buf,
 
 /* Macro used to deactivate address sanitizer on some functions. */
 #define CAMLno_asan
-/* __has_feature is Clang-specific, but GCC defines __SANITIZE_ADDRESS__ and
- * __SANITIZE_THREAD__. */
+/* `__has_feature` is present in Clang and recent GCCs (14 and later). Older
+   GCCs define `__SANITIZE_ADDRESS__`. In addition, starting from version 14
+   GCC supports the Clang-originating syntax `no_sanitize("address")`.
+   This should select the right attribute in all circumstances. */
 #if defined(__has_feature)
 #  if __has_feature(address_sanitizer)
 #    undef CAMLno_asan

--- a/runtime/caml/tsan.h
+++ b/runtime/caml/tsan.h
@@ -17,8 +17,13 @@
 
 /* Macro used to deactivate thread sanitizer on some functions. */
 #define CAMLno_tsan
-/* __has_feature is Clang-specific, but GCC defines __SANITIZE_ADDRESS__ and
- * __SANITIZE_THREAD__. */
+/* `__has_feature` is present in Clang and recent GCCs (14 and later). Older
+   GCCs define `__SANITIZE_THREAD__`. In addition, starting from version 14
+   GCC supports the Clang-originating syntax `no_sanitize("thread")`.
+   With Clang, `no_sanitize("thread")` does not seem to disable instrumentation
+   entirely, so we need to use the stronger, Clang-specific attribute
+   `disable_sanitizer_instrumentation`.
+   This should select the right attribute in all circumstances. */
 #if defined(__has_feature)
 #  if __has_feature(thread_sanitizer)
 #    undef CAMLno_tsan


### PR DESCRIPTION
The macro `__has_feature` is defined with GCC starting from version 14. As a consequence, the definition of `CAMLno_tsan` and `CAMLno_asan` is no longer correct, as it used the existence of this macro as a criterion to decide between a Clang-specific attribute and a more generic (but less precise) one for GCC. (As signalled by @edwintorok in https://github.com/ocaml/ocaml/pull/12114#issuecomment-2211309530.)

This fix, proposed by @edwintorok, swaps the order of the two tests so that the definition is correct again.

I’m not sure if this needs a regression test, nor how such a test would be written. I checked manually that annotated functions are not instrumented.