### PR TITLE
Update documentation of Sys.opaque_identity (issue #13287)

### DIFF
--- a/Changes
+++ b/Changes
@@ -230,6 +230,10 @@ _______________
 - #13045: Emphasize caution about behaviour of custom block finalizers.
   (Nick Barnes)
 
+- #13287: stdlib/sys.mli: Update documentation on Sys.opaque_identity
+  following #9412.
+  (Matt Walker, review by Guillaume Munch-Maccagnoni and Vincent Laviron)
+
 ### Compiler user-interface and warnings:
 
 * #12084: Check link order when creating archive and when using ocamlopt

--- a/stdlib/sys.mli
+++ b/stdlib/sys.mli
@@ -411,7 +411,9 @@ external opaque_identity : 'a -> 'a = "%opaque"
 (** For the purposes of optimization, [opaque_identity] behaves like an
     unknown (and thus possibly side-effecting) function.
 
-    At runtime, [opaque_identity] disappears altogether.
+    At runtime, [opaque_identity] disappears altogether.  However, it does
+    prevent the argument from being garbage collected until the location
+    where the call would have occurred.
 
     A typical use of this function is to prevent pure computations from being
     optimized away in benchmarking loops.  For example:


### PR DESCRIPTION
Include information on liveness analysis, as changed in PR #9412.

In particular, note that the garbage collector cannot collect the argument of `opaque_identity` until after the call has completed.