### PR TITLE
sanitizers: actually enable UBSAN

### DIFF
--- a/tools/ci/inria/sanitizers/script
+++ b/tools/ci/inria/sanitizers/script
@@ -88,6 +88,44 @@ CFLAGS="-O1 -fno-omit-frame-pointer $sanitizers"
 LDFLAGS="$sanitizers -O1"
 CC=$clang
 
+# Test that UBSAN works
+cat >ubsan.c <<EOF
+#include <stdbool.h>
+#include <string.h>
+
+int main(int argc, char **argv) {
+  int x = 100;
+  bool b;
+  memcpy(&b, &x, sizeof(b));
+
+  return b;
+}
+EOF
+
+$CC $CFLAGS -c ubsan.c
+$CC $LDFLAGS ubsan.o -o ubsan
+
+./ubsan && exit 2
+test $? -eq 132
+rm -f ubsan ubsan.o ubsan.c
+
+# Test that ASAN works
+cat >asan.c <<EOF
+#include <stdlib.h>
+
+int main(int argc, char **argv) {
+  char* x = malloc(4);
+  free(x);
+  free(x);
+  return x[argc];
+}
+EOF
+
+$CC $CFLAGS -c asan.c
+$CC $LDFLAGS asan.o -o asan
+./asan && exit 2
+test $? -eq 1
+rm -f asan asan.o asan.c
 
 ./configure \
   CC="$CC" \

--- a/tools/ci/inria/sanitizers/script
+++ b/tools/ci/inria/sanitizers/script
@@ -84,7 +84,7 @@ unreachable"
 sanitizers="-fsanitize=address -fsanitize=$ubsan -fno-sanitize-recover=all"
 export UBSAN_OPTIONS="print_stacktrace=1"
 # Don't optimize too much to get better backtraces of errors
-CFLAGS="-O1 -fno-omit-frame-pointer $sanitizers"
+CFLAGS="-O1 -g -fno-omit-frame-pointer $sanitizers"
 LDFLAGS="$sanitizers -O1"
 CC=$clang
 

--- a/tools/ci/inria/sanitizers/script
+++ b/tools/ci/inria/sanitizers/script
@@ -84,8 +84,8 @@ unreachable"
 sanitizers="-fsanitize=address -fsanitize=$ubsan -fno-sanitize-recover=all"
 export UBSAN_OPTIONS="print_stacktrace=1"
 # Don't optimize too much to get better backtraces of errors
-CFLAGS="-O1 -g -fno-omit-frame-pointer $sanitizers"
-LDFLAGS="$sanitizers -O1"
+CFLAGS="-Og -g -fno-omit-frame-pointer $sanitizers"
+LDFLAGS="$sanitizers -Og -g"
 CC=$clang
 
 # Test that UBSAN works

--- a/tools/ci/inria/sanitizers/script
+++ b/tools/ci/inria/sanitizers/script
@@ -81,8 +81,8 @@ shift-exponent,\
 unreachable"
 
 # Select address sanitizer and UB sanitizer, with trap-on-error behavior
-sanitizers="-fsanitize=address -fsanitize=$ubsan -fsanitize-trap=$ubsan"
-
+sanitizers="-fsanitize=address -fsanitize=$ubsan -fno-sanitize-recover=all"
+export UBSAN_OPTIONS="print_stacktrace=1"
 # Don't optimize too much to get better backtraces of errors
 CFLAGS="-O1 -fno-omit-frame-pointer $sanitizers"
 LDFLAGS="$sanitizers -O1"
@@ -106,7 +106,7 @@ $CC $CFLAGS -c ubsan.c
 $CC $LDFLAGS ubsan.o -o ubsan
 
 ./ubsan && exit 2
-test $? -eq 132
+test $? -eq 1
 rm -f ubsan ubsan.o ubsan.c
 
 # Test that ASAN works

--- a/tools/ci/inria/sanitizers/script
+++ b/tools/ci/inria/sanitizers/script
@@ -88,7 +88,7 @@ sanitizers="-fsanitize=address -fsanitize=$ubsan -fsanitize-trap=$ubsan"
 ./configure \
   CC=$clang \
   CFLAGS="-O1 -fno-omit-frame-pointer $sanitizers" \
-  LDFLAGS="$sanitizers" \
+  LDFLAGS="$sanitizers -O1" \
   --disable-stdlib-manpages --enable-dependency-generation
 
 # Build the system.  We want to check for memory leaks, hence

--- a/tools/ci/inria/sanitizers/script
+++ b/tools/ci/inria/sanitizers/script
@@ -84,11 +84,15 @@ unreachable"
 sanitizers="-fsanitize=address -fsanitize=$ubsan -fsanitize-trap=$ubsan"
 
 # Don't optimize too much to get better backtraces of errors
+CFLAGS="-O1 -fno-omit-frame-pointer $sanitizers"
+LDFLAGS="$sanitizers -O1"
+CC=$clang
+
 
 ./configure \
-  CC=$clang \
-  CFLAGS="-O1 -fno-omit-frame-pointer $sanitizers" \
-  LDFLAGS="$sanitizers -O1" \
+  CC="$CC" \
+  CFLAGS="$CFLAGS" \
+  LDFLAGS="$LDFLAGS" \
   --disable-stdlib-manpages --enable-dependency-generation
 
 # Build the system.  We want to check for memory leaks, hence
@@ -124,7 +128,7 @@ echo "======== clang ${llvm_version}, thread sanitizer ========"
 git clean -q -f -d -x
 
 ./configure \
-  CC=$clang \
+  CC="$CC" \
   --enable-tsan \
   CPPFLAGS="-DTSAN_INSTRUMENT_ALL" \
   --disable-stdlib-manpages --enable-dependency-generation
@@ -153,7 +157,7 @@ TSAN_OPTIONS="" $run_testsuite
 # # Don't optimize at all to get better backtraces of errors
 
 # ./configure \
-#   CC=$clang \
+#   CC="$CC" \
 #   CFLAGS="-O0 -g -fno-omit-frame-pointer -fsanitize=memory" \
 #   LDFLAGS="-fsanitize=memory" \
 #   --disable-native-compiler

--- a/tools/ci/inria/sanitizers/script
+++ b/tools/ci/inria/sanitizers/script
@@ -81,7 +81,7 @@ shift-exponent,\
 unreachable"
 
 # Select address sanitizer and UB sanitizer, with trap-on-error behavior
-sanitizers="-fsanitize=address -fsanitize-trap=$ubsan"
+sanitizers="-fsanitize=address -fsanitize=$ubsan -fsanitize-trap=$ubsan"
 
 # Don't optimize too much to get better backtraces of errors
 


### PR DESCRIPTION
While working on https://github.com/ocaml/ocaml/pull/13290#issuecomment-2224116176 I noticed that UBSAN is not active.

Using `-fsanitize-trap` is a trap: it doesn't actually do anything on its own (I would've expected it to at least warn me, but it doesn't).
The latest https://clang.llvm.org/docs/UndefinedBehaviorSanitizer.html#usage documents this:
> -fsanitize-trap= and -fsanitize-recover= are a no-op in the absence of a -fsanitize= option. There is no unused 
command line option warning.

The fix is simple: use `-fsanitize=$ubsan -fsanitize-trap=$ubsan` instead of just `-fsanitize-trap=$ubsan`.

Interestingly it was then complaining that `-O0` is not valid for `-fsanitize=object-size` (this extra message would cause a testsuite failure), and the only way to fix that is to put an `-O1` into `LDFLAGS`.

To avoid falling into similar traps I've added 2 small tests in the CI script itself, which compiles 2 known buggy  C programs, and checks whether the sanitizers find the expected bug (fails early otherwise).

I've also replaced `-fsanitize-trap` with `-fno-sanitize-recover=all` and `UBSAN_OPTIONS=print_stacktrace=1`. This should make UBSAN work a bit like ASAN, I think in the CI a stacktrace is better than a coredump.
If a coredump is desired for local debugging then the script can be changed to `UBSAN_OPTIONS="abort_on_error=1"`.

Successful run in Inria's CI: https://ci.inria.fr/ocaml/job/precheck-sanitizers/2/consoleText
(sorry I couldn't figure how to create a user, so created/launched it as anonymous user)

This PR probably doesn't need a Changes entry, it only changes the CI.