### PR TITLE
Add missing functions from Array to Dynarray

### DIFF
--- a/Changes
+++ b/Changes
@@ -3744,6 +3744,9 @@ OCaml 4.13.0 (24 September 2021)
 - #10430: Add Format.print_bytes and Format.pp_print_bytes.
   (Gabriel Radanne, review by Gabriel Scherer and David Allsopp)
 
+- #13296: Add mem, memq, find_opt, find_index, find_map and find_mapi to Dynarray
+  (Jake H, review by Gabriel Scherer and Florian Angeletti)
+
 ### Other libraries:
 
 * #10084: Unix.open_process_args* functions now look up the program in the PATH.

--- a/Changes
+++ b/Changes
@@ -3744,7 +3744,7 @@ OCaml 4.13.0 (24 September 2021)
 - #10430: Add Format.print_bytes and Format.pp_print_bytes.
   (Gabriel Radanne, review by Gabriel Scherer and David Allsopp)
 
-- #13296: Add mem, memq, find_opt, find_index, find_map and find_mapi to Dynarray
+- #13296: Add mem, memq, find_opt, find_index, find_map and find_mapi to Dynarray.
   (Jake H, review by Gabriel Scherer and Florian Angeletti)
 
 ### Other libraries:

--- a/stdlib/dynarray.ml
+++ b/stdlib/dynarray.ml
@@ -891,6 +891,87 @@ let filter_map f a =
   ) a;
   b
 
+let mem x a =
+  let Pack {arr; length; dummy} = a in
+  check_valid_length length arr;
+  let rec loop i =
+    if i = length then false
+    else if Stdlib.compare (unsafe_get arr ~dummy ~i ~length) x = 0 then
+      true
+    else loop (succ i)
+  in
+  loop 0
+
+let memq x a =
+  let Pack {arr; length; dummy} = a in
+  check_valid_length length arr;
+  let rec loop i =
+    if i = length then false
+    else if (unsafe_get arr ~dummy ~i ~length) == x then
+      true
+    else loop (succ i)
+  in
+  loop 0
+
+let find_opt p a =
+  let Pack {arr; length; dummy} = a in
+  check_valid_length length arr;
+  let rec loop i =
+    if i = length then None
+    else
+      let x = unsafe_get arr ~dummy ~i ~length in
+      if p x then begin
+        check_same_length "find_opt" a ~length;
+        Some x
+      end
+      else loop (succ i)
+  in
+  loop 0
+
+let find_index p a =
+  let Pack {arr; length; dummy} = a in
+  check_valid_length length arr;
+  let rec loop i =
+    if i = length then None
+    else
+      let x = unsafe_get arr ~dummy ~i ~length in
+      if p x then begin
+        check_same_length "find_index" a ~length;
+        Some i
+      end
+      else loop (succ i)
+  in
+  loop 0
+
+let find_map p a =
+  let Pack {arr; length; dummy} = a in
+  check_valid_length length arr;
+  let rec loop i =
+    if i = length then None
+    else
+      match p (unsafe_get arr ~dummy ~i ~length) with
+      | None -> loop (succ i)
+      | Some _ as r ->
+        check_same_length "find_map" a ~length;
+        r
+  in
+  loop 0
+
+let find_mapi p a =
+  let Pack {arr; length; dummy} = a in
+  check_valid_length length arr;
+  let rec loop i =
+    if i = length then None
+    else
+      match p i (unsafe_get arr ~dummy ~i ~length) with
+      | None -> loop (succ i)
+      | Some _ as r ->
+        check_same_length "find_mapi" a ~length;
+        r
+  in
+  loop 0
+
+
 let equal eq a1 a2 =
   let Pack {arr = arr1; length = length; dummy = dum1} = a1 in
   let Pack {arr = arr2; length = len2; dummy = dum2} = a2 in

--- a/stdlib/dynarray.ml
+++ b/stdlib/dynarray.ml
@@ -900,7 +900,9 @@ let mem x a =
       true
     else loop (succ i)
   in
-  loop 0
+  let res = loop 0 in
+  check_same_length "mem" a ~length;
+  res
 
 let memq x a =
   let Pack {arr; length; dummy} = a in
@@ -911,7 +913,9 @@ let memq x a =
       true
     else loop (succ i)
   in
-  loop 0
+  let res = loop 0 in
+  check_same_length "memq" a ~length;
+  res
 
 let find_opt p a =
   let Pack {arr; length; dummy} = a in

--- a/stdlib/dynarray.ml
+++ b/stdlib/dynarray.ml
@@ -920,13 +920,12 @@ let find_opt p a =
     if i = length then None
     else
       let x = unsafe_get arr ~dummy ~i ~length in
-      if p x then begin
-        check_same_length "find_opt" a ~length;
-        Some x
-      end
+      if p x then Some x
       else loop (succ i)
   in
-  loop 0
+  let res = loop 0 in
+  check_same_length "find_opt" a ~length;
+  res
 
 let find_index p a =
   let Pack {arr; length; dummy} = a in
@@ -935,13 +934,12 @@ let find_index p a =
     if i = length then None
     else
       let x = unsafe_get arr ~dummy ~i ~length in
-      if p x then begin
-        check_same_length "find_index" a ~length;
-        Some i
-      end
+      if p x then Some i
       else loop (succ i)
   in
-  loop 0
+  let res = loop 0 in
+  check_same_length "find_index" a ~length;
+  res
 
 let find_map p a =
   let Pack {arr; length; dummy} = a in
@@ -951,11 +949,11 @@ let find_map p a =
     else
       match p (unsafe_get arr ~dummy ~i ~length) with
       | None -> loop (succ i)
-      | Some _ as r ->
-        check_same_length "find_map" a ~length;
-        r
+      | Some _ as r -> r
   in
-  loop 0
+  let res = loop 0 in
+  check_same_length "find_map" a ~length;
+  res
 
 let find_mapi p a =
   let Pack {arr; length; dummy} = a in
@@ -965,12 +963,11 @@ let find_mapi p a =
     else
       match p i (unsafe_get arr ~dummy ~i ~length) with
       | None -> loop (succ i)
-      | Some _ as r ->
-        check_same_length "find_mapi" a ~length;
-        r
+      | Some _ as r -> r
   in
-  loop 0
-
+  let res = loop 0 in
+  check_same_length "find_mapi" a ~length;
+  res
 
 let equal eq a1 a2 =
   let Pack {arr = arr1; length = length; dummy = dum1} = a1 in

--- a/stdlib/dynarray.mli
+++ b/stdlib/dynarray.mli
@@ -293,7 +293,7 @@ val filter_map : ('a -> 'b option) -> 'a t -> 'b t
     ignoring strings that cannot be converted to integers.
 *)
 
-{1:dynarray_scanning Dynarray scanning }
+(** {1:dynarray_scanning Dynarray scanning } *)
 
 val exists : ('a -> bool) -> 'a t -> bool
 (** [exists f a] is [true] if some element of [a] satisfies [f].

--- a/stdlib/dynarray.mli
+++ b/stdlib/dynarray.mli
@@ -308,6 +308,46 @@ val filter_map : ('a -> 'b option) -> 'a t -> 'b t
     ignoring strings that cannot be converted to integers.
 *)
 
+val mem : 'a -> 'a t -> bool
+(** [mem a set] is true if and only if [a] is structurally equal
+    to an element of [set] (i.e. there is an [x] in [set] such that
+    [compare a x = 0]).
+*)
+
+val memq : 'a -> 'a t -> bool
+(** Same as {!mem}, but uses physical equality
+   instead of structural equality to compare array elements.
+ *)
+
+val find_opt : ('a -> bool) -> 'a t -> 'a option
+(** [find_opt f a] returns the first element of the array [a] that satisfies
+    the predicate [f], or [None] if there is no value that satisfies [f] in the
+    array [a].
+
+*)
+
+val find_index : ('a -> bool) -> 'a t -> int option
+(** [find_index f a] returns [Some i], where [i] is the index of the first
+    element of the array [a] that satisfies [f x], if there is such an
+    element.
+
+    It returns [None] if there is no such element.
+
+*)
+
+val find_map : ('a -> 'b option) -> 'a t -> 'b option
+(** [find_map f a] applies [f] to the elements of [a] in order, and returns the
+    first result of the form [Some v], or [None] if none exist.
+
+    @since 4.13 *)
+
+val find_mapi : (int -> 'a -> 'b option) -> 'a t -> 'b option
+(** Same as [find_map], but the predicate is applied to the index of
+   the element as first argument (counting from 0), and the element
+   itself as second argument.
+
+ *)
+
 (** {1:comparison Comparison functions}
 
     Comparison functions iterate over their arguments; it is

--- a/stdlib/dynarray.mli
+++ b/stdlib/dynarray.mli
@@ -339,7 +339,7 @@ val find_map : ('a -> 'b option) -> 'a t -> 'b option
 (** [find_map f a] applies [f] to the elements of [a] in order, and returns the
     first result of the form [Some v], or [None] if none exist.
 
-    @since 4.13 *)
+*)
 
 val find_mapi : (int -> 'a -> 'b option) -> 'a t -> 'b option
 (** Same as [find_map], but the predicate is applied to the index of

--- a/stdlib/dynarray.mli
+++ b/stdlib/dynarray.mli
@@ -270,21 +270,6 @@ val fold_right : ('a -> 'acc -> 'acc) -> 'a t -> 'acc -> 'acc
     where [x0], [x1], ..., [xn] are the elements of [a].
 *)
 
-val exists : ('a -> bool) -> 'a t -> bool
-(** [exists f a] is [true] if some element of [a] satisfies [f].
-
-    For example, if the elements of [a] are [x0], [x1], [x2], then
-    [exists f a] is [f x0 || f x1 || f x2].
-*)
-
-val for_all : ('a -> bool) -> 'a t -> bool
-(** [for_all f a] is [true] if all elements of [a] satisfy [f].
-    This includes the case where [a] is empty.
-
-    For example, if the elements of [a] are [x0], [x1], then
-    [exists f a] is [f x0 && f x1 && f x2].
-*)
-
 val filter : ('a -> bool) -> 'a t -> 'a t
 (** [filter f a] is a new array of all the elements of [a] that satisfy [f].
     In other words, it is an array [b] such that, for each element [x]
@@ -306,6 +291,23 @@ val filter_map : ('a -> 'b option) -> 'a t -> 'b t
     For example, [filter_map int_of_string_opt inputs] returns
     a new array of integers read from the strings in [inputs],
     ignoring strings that cannot be converted to integers.
+*)
+
+{1:dynarray_scanning Dynarray scanning }
+
+val exists : ('a -> bool) -> 'a t -> bool
+(** [exists f a] is [true] if some element of [a] satisfies [f].
+
+    For example, if the elements of [a] are [x0], [x1], [x2], then
+    [exists f a] is [f x0 || f x1 || f x2].
+*)
+
+val for_all : ('a -> bool) -> 'a t -> bool
+(** [for_all f a] is [true] if all elements of [a] satisfy [f].
+    This includes the case where [a] is empty.
+
+    For example, if the elements of [a] are [x0], [x1], then
+    [exists f a] is [f x0 && f x1 && f x2].
 *)
 
 val mem : 'a -> 'a t -> bool

--- a/stdlib/dynarray.mli
+++ b/stdlib/dynarray.mli
@@ -314,11 +314,15 @@ val mem : 'a -> 'a t -> bool
 (** [mem a set] is true if and only if [a] is structurally equal
     to an element of [set] (i.e. there is an [x] in [set] such that
     [compare a x = 0]).
+
+    @since 5.3
 *)
 
 val memq : 'a -> 'a t -> bool
 (** Same as {!mem}, but uses physical equality
-   instead of structural equality to compare array elements.
+    instead of structural equality to compare array elements.
+
+    @since 5.3
  *)
 
 val find_opt : ('a -> bool) -> 'a t -> 'a option
@@ -326,6 +330,7 @@ val find_opt : ('a -> bool) -> 'a t -> 'a option
     the predicate [f], or [None] if there is no value that satisfies [f] in the
     array [a].
 
+    @since 5.3
 *)
 
 val find_index : ('a -> bool) -> 'a t -> int option
@@ -335,19 +340,22 @@ val find_index : ('a -> bool) -> 'a t -> int option
 
     It returns [None] if there is no such element.
 
+    @since 5.3
 *)
 
 val find_map : ('a -> 'b option) -> 'a t -> 'b option
 (** [find_map f a] applies [f] to the elements of [a] in order, and returns the
     first result of the form [Some v], or [None] if none exist.
-
+    
+    @since 5.3
 *)
 
 val find_mapi : (int -> 'a -> 'b option) -> 'a t -> 'b option
 (** Same as [find_map], but the predicate is applied to the index of
    the element as first argument (counting from 0), and the element
    itself as second argument.
-
+   
+   @since 5.3
  *)
 
 (** {1:comparison Comparison functions}

--- a/testsuite/tests/lib-dynarray/test.ml
+++ b/testsuite/tests/lib-dynarray/test.ml
@@ -208,6 +208,45 @@ let () =
   let a = A.mapi (fun i e -> Printf.sprintf "%i %i" i e) a in
   assert (A.to_list a = ["0 1"; "1 2"; "2 3"]);;
 
+(** mem *)
+let () =
+  let a = A.of_list [1;2;3;4;5] in
+  assert (A.mem 1 a = true);
+  assert (A.mem 7 a = false)
+
+(** memq *)
+let () =
+  let five = 5 in
+  let a = A.of_list [five; 6; 7] in
+  assert (A.memq five a = true)
+
+(** find_opt *)
+let () =
+  let a = A.of_list [1;4;9] in
+  assert (A.find_opt (fun x -> x / 2 = 2) a = Some 4);
+  assert (A.find_opt (fun x -> x = 5) a = None)
+
+(** find_index *)
+let () = 
+  let a = A.of_list [1;2;3] in
+  assert (A.find_index (fun x -> x = 1) a = Some 0);
+  assert (A.find_index (fun x -> x = 5) a = None)
+
+(** find_map *)
+let () =
+  let a = A.of_list [1;2;3;4;5] in
+  let b = A.of_list [1;2;3] in
+  let go x = if x > 3 then Some x else None in
+  assert (A.find_map go a = Some 4);
+  assert (A.find_map go b = None)
+
+(** find_mapi *)
+let () =
+  let a = A.of_list [1;1;3] in
+  let b = A.of_list [3;2;1] in
+  let go i x = if i = x then Some (i, x) else None in
+  assert (A.find_mapi go a = Some (1,1));
+  assert (A.find_mapi go b = None)
 
 (** Iterator invalidation *)
 

--- a/testsuite/tests/lib-dynarray/test.ml
+++ b/testsuite/tests/lib-dynarray/test.ml
@@ -227,7 +227,7 @@ let () =
   assert (A.find_opt (fun x -> x = 5) a = None)
 
 (** find_index *)
-let () = 
+let () =
   let a = A.of_list [1;2;3] in
   assert (A.find_index (fun x -> x = 1) a = Some 0);
   assert (A.find_index (fun x -> x = 5) a = None)


### PR DESCRIPTION
Added:
- mem
- memq
- find_opt
- find_index
- find_map
- find_mapi

All implementations are based off the implementation in Array. I have tried my best, based on the given comments, and other functions, to add all the correct checks; if I have missed any, please feel free to note or edit, and similar with the quality/number of tests - please inform me if these are not sufficient.

I also apologies; I could not quite figure out the format of the "Changes" file, so I haven't included that change here currently.


Background:
I was attempting to port some code from `List` to `Dynarray`; I promptly realized that `Dynarray` did not have `find_opt` or similar, and decided that it would probably be easier to implement them myself than raise an issue and wait for someone else to do it.