### PR TITLE
runtime_events_consumer: fix uninitialized and out of bounds reads

### DIFF
--- a/Changes
+++ b/Changes
@@ -513,6 +513,9 @@ _______________
   LDFLAGS contains several words.
   (Stéphane Glondu, review by Miod Vallat)
 
+- #13290: Fix uninitialized and out of bounds reads in runtime_events_consumer.c
+  (Edwin Török, review by Miod Vallat and Antonin Décimo)
+
 - #13306: An algorithm in the type-checker that checks two types for equality
   could sometimes, in theory, return the wrong answer. This patch fixes the
   oversight. No known program triggers the bug.

--- a/otherlibs/runtime_events/runtime_events_consumer.c
+++ b/otherlibs/runtime_events/runtime_events_consumer.c
@@ -403,7 +403,9 @@ caml_runtime_events_read_poll(struct caml_runtime_events_cursor *cursor,
   if (cursor->metadata.headers_offset > cursor->ring_file_size_bytes
       || !cursor->metadata.ring_size_elements
       || cursor->metadata.ring_size_elements * sizeof(uint64_t)
-         != cursor->metadata.ring_size_bytes) {
+         != cursor->metadata.ring_size_bytes
+      || cursor->metadata.ring_size_elements
+         > cursor->metadata.ring_size_bytes) {
         atomic_store(&cursor->cursor_in_poll, 0);
         return E_CORRUPT_STREAM;
   }

--- a/otherlibs/runtime_events/runtime_events_consumer.c
+++ b/otherlibs/runtime_events/runtime_events_consumer.c
@@ -229,6 +229,13 @@ caml_runtime_events_create_cursor(const char_os* runtime_events_path, int pid,
 
   cursor->metadata = *(struct runtime_events_metadata_header*)cursor->map;
 
+  if (cursor->metadata.max_domains > Max_domains_max) {
+    /* avoid overflow in multiplication below */
+    caml_stat_free(cursor);
+    caml_stat_free(runtime_events_loc);
+    return E_CORRUPT_STREAM;
+  }
+
   cursor->current_positions =
       caml_stat_alloc(cursor->metadata.max_domains * sizeof(uint64_t));
 

--- a/otherlibs/runtime_events/runtime_events_consumer.c
+++ b/otherlibs/runtime_events/runtime_events_consumer.c
@@ -462,6 +462,13 @@ caml_runtime_events_read_poll(struct caml_runtime_events_cursor *cursor,
         continue;
       }
 
+      if (!msg_length
+          || (msg_length < 2
+              && RUNTIME_EVENTS_ITEM_TYPE(header) != EV_INTERNAL)) {
+        atomic_store(&cursor->cursor_in_poll, 0);
+        return E_CORRUPT_STREAM;
+      }
+
       if (RUNTIME_EVENTS_ITEM_IS_RUNTIME(header)) {
         switch (RUNTIME_EVENTS_ITEM_TYPE(header)) {
         case EV_BEGIN:

--- a/testsuite/tests/lib-runtime-events/test_corrupted.ml
+++ b/testsuite/tests/lib-runtime-events/test_corrupted.ml
@@ -1,0 +1,118 @@
+(* TEST
+ include runtime_events;
+ include unix;
+ set OCAML_RUNTIME_EVENTS_PRESERVE = "1";
+ libunix;
+ {
+   bytecode;
+ }{
+   native;
+ }
+*)
+
+  let runtime_begin _ _ _ = ()
+  let runtime_end _ _ _ = ()
+  let runtime_counter _ _ _ _ = ()
+  let alloc _ _ _ = ()
+  let lifecycle _ _ _ _ = ()
+  let lost_events _ _ = ()
+  let callbacks = Runtime_events.Callbacks.create
+    ~runtime_begin ~runtime_end ~runtime_counter ~alloc ~lifecycle ~lost_events ()
+
+  let parse path_pid =
+    let cursor =
+        Runtime_events.create_cursor path_pid in
+    let finally () = Runtime_events.free_cursor cursor in
+    Fun.protect ~finally @@ fun () ->
+    Runtime_events.read_poll cursor callbacks None
+
+  let parse_corrupted path_pid =
+    try let (_:int) = parse path_pid in ()
+    with Failure _ | Invalid_argument _ ->
+      (* parsing corrupted rings, raises exceptions,
+         this is expected *)
+      ()
+
+  let buf = Bytes.create (8 * 8)
+
+  let with_ring ring_file f =
+    let fd = Unix.openfile ring_file [Unix.O_RDWR] 0 in
+    let finally () = Unix.close fd in
+    Fun.protect ~finally @@ fun () ->
+    let size = Int64.to_int Unix.LargeFile.((fstat fd).st_size) in
+    let n = Unix.read fd buf 0 (Bytes.length buf) in
+    assert (n = Bytes.length buf);
+    let version = Bytes.get_int64_ne buf 0 in
+    assert (version = 1L);
+    (* this needs to be updated if on-disk layout changes *)
+    let data_offset = Bytes.get_int64_ne buf (6*8) in
+
+    let write_event_header is_runtime event_type event_id event_length =
+      let (<<:) i n = Int64.(shift_left (of_int i) n) and (|:) = Int64.logor in
+      (* see runtime_events.h *)
+      let event_header =
+        (event_length <<: 54) |:
+        (is_runtime <<: 53) |:
+        (event_type <<: 49) |:
+        (event_id <<: 36)
+      in
+      Bytes.set_int64_ne buf 0 event_header;
+      let n = Unix.LargeFile.lseek fd data_offset Unix.SEEK_SET in
+      assert (n = data_offset);
+      let n = Unix.write fd buf 0 (Bytes.length buf) in
+      assert (n = Bytes.length buf)
+    in
+    
+    let write_metadata_header offset value =
+      let offset = Int64.of_int offset in
+      let n = Unix.LargeFile.lseek fd offset Unix.SEEK_SET in
+      assert (n = offset);
+      Bytes.set_int64_ne buf 0 value;
+      let n = Unix.write fd buf 0 (Bytes.length buf) in
+      assert (n = Bytes.length buf)
+    in
+
+    f ~size ~write_event_header ~write_metadata_header
+
+  (* this tests the preservation of ring buffers after termination *)
+
+  let () =
+    (* start runtime_events now to avoid a race *)
+    let parent_cwd = Sys.getcwd () in
+    let child_pid = Unix.fork () in
+    if child_pid == 0 then begin
+      (* we are in the child, so start Runtime_events *)
+      Runtime_events.start ();
+      (* this creates a ring buffer. Now exit. *)
+    end else begin
+      (* now wait for our child to finish *)
+      Unix.wait () |> ignore;
+      (* child has finished. We now have a valid ring *)
+      let ring_file =
+          Filename.concat parent_cwd (string_of_int child_pid ^ ".events")
+      and path_pid = Some (parent_cwd, child_pid);
+         in
+      let finally () = Unix.unlink ring_file in
+      Fun.protect ~finally @@ fun () ->
+      with_ring ring_file @@ fun ~size ~write_event_header ~write_metadata_header ->
+      (* we must succeed parsing it as is *)
+      let n = parse path_pid in
+      assert (n > 0);
+      let original = Bytes.to_string buf in
+
+      (* now overwrite various fields, corrupting the ring,
+         and check that we don't crash (raising exceptions is fine).
+       *)
+      for offset = 1 to 1 do
+        [0L; size * 3/4 |> Int64.of_int; size * 2 |> Int64.of_int;
+         Int64.max_int; Int64.min_int; Int64.(shift_right_logical max_int 1)
+        ] |> List.iter @@ fun value ->
+        write_metadata_header (8 * offset) value;
+        parse_corrupted path_pid;
+        (* restore original, we only corrupt and test one offset at a time,
+           otherwise we may not find missing bounds checks if we exit early
+           due to bounds error on an earlier offset
+         *)
+        Bytes.blit_string original 0 buf 0 (Bytes.length buf);
+      done
+    end

--- a/testsuite/tests/lib-runtime-events/test_corrupted.ml
+++ b/testsuite/tests/lib-runtime-events/test_corrupted.ml
@@ -114,5 +114,18 @@
            due to bounds error on an earlier offset
          *)
         Bytes.blit_string original 0 buf 0 (Bytes.length buf);
-      done
+        parse_corrupted path_pid
+      done;
+      for is_runtime = 0 to 1 do
+        for event_type = 0 to 15 (* event type is 4 bits *) do
+          for event_id = 0 to 64 (* event_id is 13 bits, but not all used yet *) do
+            for length = 0 to 1 (* short lengths trigger uninit read bugs *) do
+                (* modify just 1 event in the otherwise valid ring *)
+                write_event_header is_runtime event_type event_id length;
+                (* parse ring *)
+                parse_corrupted path_pid
+            done
+          done
+        done;
+      done;
     end


### PR DESCRIPTION
[As suggested in https://github.com/ocaml/ocaml/pull/13290#issuecomment-2226843600 I'm separating this fix from the MSAN CI changes]

---

`runtime_events_consumer.c` parses runtime events from a memory mapped file, created by another OCaml process.

There are 2 bugs here:
* uninitialized value read in `buf[2]` for `EV_RING_STOP` events
* SIGSEGV when parsing a runtime events ring that has been corrupted or truncated.

---

`EV_RING_STOP` is an event that doesn't have additional data, and has `msg_length == 2`. However `runtime_events_consumer` always read `buf[2]`, which contained uninitialized data, which is potentially undefined behaviour in C.
Avoid this by introducing bounds check before accessing `buf`. Most messages have a minimum length of 2, except for `EV_INTERNAL=0` used for padding, which can have a length of 1.
No messages can have a length of 0, because that'd result in an infinite loop. 

While running a fuzzer with an MSAN (memory sanitizer) enabled build I've found some crashes due to missing bounds checks.
It'd be useful to guard against these, because:
* the ring may have become corrupted due to bugs in the producer, and we should avoid a SIGSEGV in the consumer
* the file storing the event ring may have become corrupted or truncated when transferred
* it makes it difficult to use a fuzzer to find more uninitialized value reads, because the fuzzer keeps finding the crashes instead

Introduce additional bounds checks on all offsets and length in the metadata header. To prevent the header from being modified after the offsets have been validated, operate on a copy (the file header is not changed dynamically by the producer).
Also guard against multiplication overflow in the code, and in the bounds checks, e.g. restrict `max_domains` to `Max_domains_max`.

Some of these bugs were found by fuzzing with `afl++` on an  ASAN, and (separately) MSAN instrumented runtime, and some by reading the code after a deeper investigation was inspired by a [review comment](https://github.com/ocaml/ocaml/pull/13290#discussion_r1675348548).

I've included a testcase that takes a known good event ring, and corrupts each offset  in turn with various values. This reproduces most of the crashes without requiring the use of a fuzzer: they would crash on a regular ASAN sanitized build as performed by the CI currently.

I've run `afl++` on the updated runtime, instrumented with ASAN and MSAN and it didn't find more crashes. 
Notes on how to run the fuzzer can [be found here](https://gist.github.com/edwintorok/f7ccb146471cfb17b2e92510b8c12bd0)