### PR TITLE
Document how to use MSAN

### DIFF
--- a/tools/ci/inria/sanitizers/script
+++ b/tools/ci/inria/sanitizers/script
@@ -148,11 +148,27 @@ TSAN_OPTIONS="" $run_testsuite
 # # Select memory sanitizer
 # # Don't optimize at all to get better backtraces of errors
 
+# CFLAGS="-Og -g -fno-omit-frame-pointer -fsanitize=memory -fsanitize-memory-track-origins"
+# LDFLAGS="-fsanitize=memory"
+
+# # Test that MSAN works
+# cat >msan.c <<EOF
+# #include <stdlib.h>
+# int main(int argc, char **argv) {
+#   char* x = malloc(4);
+#   return x[0];
+# }
+# EOF
+#
+# $CC $CFLAGS -c msan.c
+# $CC $LDFLAGS msan.o -o msan
+# ./msan && exit 2
+# test $? -eq 1
+
 # ./configure \
 #   CC=clang-9 \
-#   CFLAGS="-Og -g -fno-omit-frame-pointer \
-#           -fsanitize=memory -fsanitize-memory-track-origins" \
-#   LDFLAGS="-fsanitize=memory" \
+#   CFLAGS="${CFLAGS}"
+#   LDFLAGS="${LDFLAGS}" \
 #   --disable-native-compiler --without-zstd
 # # A tool that makes error backtraces nicer
 # # Need to pick the one that matches clang-6.0

--- a/tools/ci/inria/sanitizers/script
+++ b/tools/ci/inria/sanitizers/script
@@ -150,9 +150,10 @@ TSAN_OPTIONS="" $run_testsuite
 
 # ./configure \
 #   CC=clang-9 \
-#   CFLAGS="-O0 -g -fno-omit-frame-pointer -fsanitize=memory" \
+#   CFLAGS="-Og -g -fno-omit-frame-pointer \
+#           -fsanitize=memory -fsanitize-memory-track-origins" \
 #   LDFLAGS="-fsanitize=memory" \
-#   --disable-native-compiler
+#   --disable-native-compiler --without-zstd
 # # A tool that makes error backtraces nicer
 # # Need to pick the one that matches clang-6.0
 # export MSAN_SYMBOLIZER_PATH=/usr/lib/llvm-6.0/bin/llvm-symbolizer


### PR DESCRIPTION
Split from https://github.com/ocaml/ocaml/pull/13290.

Back in 2018 tools/ci/inria/sanitizers/script claimed that MSAN output is impossible to debug.
clang has improved a lot since then, and in fact with clang-18 on Fedora40 it only reports 2 bug, both of which I was able to track down.

First of all zstd has to be disabled with -fsanitize=memory, because all external libraries would have to be compiled with -fsanitize=memory, otherwise the instrumentation won't see the writes performed by these and consider all memory written to by these functions uninitialized.

With these 2 changes the testsuite now passes.

I've included some compile flag improvements as well, the manual recommends -O1 or higher, not -O0.

ocamlopt has to be kept disabled, it'd need a similar solution to TSAN to enable it (ocamlopt would have to emit calls to instrumentation functions compatible with Clang's, otherwise it won't see any of the writes from OCaml and consider them uninitialized).

I've kept the memory sanitizer commented out for now, but if desired it could be enabled.

Draft, because it conflicts with the other sanitizer CI PRs and needs to be rebased once they are merged.