### PR TITLE
restore caml_process_pending_actions_exn

### DIFF
--- a/runtime/caml/fail.h
+++ b/runtime/caml/fail.h
@@ -139,6 +139,18 @@ Caml_inline value caml_get_value_or_raise (struct caml_result_private result)
     return result.data;
 }
 
+#ifdef CAML_INTERNALS
+// internals only, provided for backward-compatibility
+Caml_inline value caml_result_get_encoded_exception(
+  struct caml_result_private result)
+{
+  if (result.is_exception)
+    return Make_exception_result(result.data);
+  else
+    return result.data;
+}
+#endif // CAML_INTERNALS
+
 #ifdef __cplusplus
 }
 #endif

--- a/runtime/signals.c
+++ b/runtime/signals.c
@@ -409,6 +409,13 @@ CAMLexport void caml_process_pending_actions(void)
     caml_process_pending_actions_res());
 }
 
+/* deprecated, but kept around for backward-compatibility */
+CAMLexport value caml_process_pending_actions_exn(void)
+{
+  caml_result res = caml_process_pending_actions_res();
+  return caml_result_get_encoded_exception(res);
+}
+
 /* OS-independent numbering of signals */
 
 #ifndef SIGABRT


### PR DESCRIPTION
I made a mistake when introducing `caml_process_pending_actions_res` (#13013), currently in trunk `caml_process_pending_actions_exn` is exported in signals.h but its implementation is removed.

This function is not CAML_INTERNALS, and Coq uses it.

To restore this function I reintroduced a helper function to transform `caml_result` values back into encoded exception (earlier #13013 designs had this). It is named `caml_result_get_encoded_exception`, in fail.h, CAML_INTERNALS-only.