### PR TITLE
Remove erroneous optimization from eqtype

### DIFF
--- a/Changes
+++ b/Changes
@@ -466,6 +466,11 @@ _______________
   LDFLAGS contains several words.
   (Stéphane Glondu, review by Miod Vallat)
 
+- #13306: An algorithm in the type-checker that checks two types for equality
+  could sometimes, in theory, return the wrong answer. No known program
+  triggers the bug.
+  (Richard Eisenberg, review by Florian Angeletti)
+
 OCaml 5.2.0 (13 May 2024)
 -------------------------
 

--- a/Changes
+++ b/Changes
@@ -467,8 +467,8 @@ _______________
   (Stéphane Glondu, review by Miod Vallat)
 
 - #13306: An algorithm in the type-checker that checks two types for equality
-  could sometimes, in theory, return the wrong answer. No known program
-  triggers the bug.
+  could sometimes, in theory, return the wrong answer. This patch fixes the
+  oversight. No known program triggers the bug.
   (Richard Eisenberg, review by Florian Angeletti)
 
 OCaml 5.2.0 (13 May 2024)

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -4139,7 +4139,7 @@ let rec eqtype rename type_pairs subst env t1 t2 =
      first ['a] and ['b] would be identified in [eqtype_subst], and then the
      second ['a] and ['a] would be [eq_type]. So we do not call [eq_type] here.
 
-     On the other hand, when [rename] is false we need to check for phyiscal
+     On the other hand, when [rename] is false we need to check for physical
      equality, as that's the only way variables can be identified.
   *)
   if check_phys_eq t1 t2 then () else

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -4347,7 +4347,7 @@ let eqtype rename type_pairs subst env t1 t2 =
 let equal env rename tyl1 tyl2 =
   if List.length tyl1 <> List.length tyl2 then
     raise_unexplained_for Equality;
-  if not rename && List.for_all2 eq_type tyl1 tyl2 then () else
+  if List.for_all2 eq_type tyl1 tyl2 then () else
   let subst = ref [] in
   try eqtype_list_same_length rename (TypePairs.create 11) subst env tyl1 tyl2
   with Equality_trace trace ->

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -4131,8 +4131,11 @@ let eqtype_subst type_pairs subst t1 t2 =
   end
 
 let rec eqtype rename type_pairs subst env t1 t2 =
-  if eq_type t1 t2 then () else
-
+  (* It's tempting to check for physical equality via [eq_type] here, but that
+     would be incorrect: imagine comparing ['a * 'a] with ['b * 'a]. The
+     first ['a] and ['b] would be identified in [eqtype_subst], and then
+     the second ['a] and ['a] would be [eq_type]. So we do not call [eq_type]
+     here. *)
   try
     match (get_desc t1, get_desc t2) with
       (Tvar _, Tvar _) when rename ->

--- a/typing/printtyp.ml
+++ b/typing/printtyp.ml
@@ -802,7 +802,7 @@ end = struct
   (* We map from types to names, but not directly; we also store a substitution,
      which maps from types to types.  The lookup process is
      "type -> apply substitution -> find name".  The substitution is presumed to
-     be acyclic. *)
+     be one-shot. *)
   let names = ref ([] : (transient_expr * string) list)
   let name_subst = ref ([] : (transient_expr * transient_expr) list)
   let name_counter = ref 0
@@ -839,9 +839,9 @@ end = struct
           printer_iter_type_expr add_named_vars ty
     end
 
-  let rec substitute ty =
+  let substitute ty =
     match List.assq ty !name_subst with
-    | ty' -> substitute ty'
+    | ty' -> ty'
     | exception Not_found -> ty
 
   let add_subst subst =


### PR DESCRIPTION
From the top of `Ctype.eqtype`, I've removed a call to `eq_type` and added this comment:

```
  (* It's tempting to check for physical equality via [eq_type] here, but that
     would be incorrect: imagine comparing ['a * 'a] with ['b * 'a]. The
     first ['a] and ['b] would be identified in [eqtype_subst], and then
     the second ['a] and ['a] would be [eq_type]. So we do not call [eq_type]
     here. *)
```

See if you agree with the comment.

There is no known actual bug that this fixes, and thus no test case. But I'm doing some other work around here in the Jane Street branch, and the check is causing problems in that context.