### PR TITLE
Remove "mean space overhead" computation.

### DIFF
--- a/runtime/caml/major_gc.h
+++ b/runtime/caml/major_gc.h
@@ -61,8 +61,6 @@ void caml_finalise_heap (void);
    so it need not be atomic */
 extern uintnat caml_major_cycles_completed;
 
-double caml_mean_space_overhead(void);
-
 #endif /* CAML_INTERNALS */
 
 #endif /* CAML_MAJOR_GC_H */

--- a/runtime/sys.c
+++ b/runtime/sys.c
@@ -181,8 +181,6 @@ CAMLexport void caml_do_exit(int retcode)
                     heap_words);
       caml_gc_message(0x400, "top_heap_words: %"ARCH_INTNAT_PRINTF_FORMAT"d\n",
                       top_heap_words);
-      caml_gc_message(0x400, "mean_space_overhead: %lf\n",
-                      caml_mean_space_overhead());
     }
   }
 


### PR DESCRIPTION
The "mean space overhead" computation in the GC has various problems: (a) it allocates an indefinitely growing amount of memory; (b) it doesn't cope with allocation failure; (c) the statistic it computes and logs is of little statistical meaning or use (according to @kayceesrk who initially implemented it). This change removes it, while retaining the per-cycle space overhead computation and logging.
This fixes #13212, which is (b) above. For more detail, see the comments on that issue.