### PR TITLE
Format_doc: preserve the type of Foo.report_error, add Foo.report_error_doc

### DIFF
--- a/.depend
+++ b/.depend
@@ -7680,7 +7680,6 @@ debugger/command_line.cmo : \
     debugger/input_handling.cmi \
     debugger/history.cmi \
     debugger/frames.cmi \
-    utils/format_doc.cmi \
     debugger/events.cmi \
     debugger/eval.cmi \
     typing/envaux.cmi \
@@ -7720,7 +7719,6 @@ debugger/command_line.cmx : \
     debugger/input_handling.cmx \
     debugger/history.cmx \
     debugger/frames.cmx \
-    utils/format_doc.cmx \
     debugger/events.cmx \
     debugger/eval.cmx \
     typing/envaux.cmx \
@@ -7948,7 +7946,6 @@ debugger/main.cmo : \
     utils/load_path.cmi \
     debugger/input_handling.cmi \
     debugger/frames.cmi \
-    utils/format_doc.cmi \
     debugger/exec.cmi \
     debugger/debugger_config.cmi \
     utils/config.cmi \
@@ -7972,7 +7969,6 @@ debugger/main.cmx : \
     utils/load_path.cmx \
     debugger/input_handling.cmx \
     debugger/frames.cmx \
-    utils/format_doc.cmx \
     debugger/exec.cmx \
     debugger/debugger_config.cmx \
     utils/config.cmx \
@@ -8314,7 +8310,6 @@ ocamldoc/odoc_analyse.cmo : \
     ocamldoc/odoc_ast.cmi \
     parsing/location.cmi \
     parsing/lexer.cmi \
-    utils/format_doc.cmi \
     typing/env.cmi \
     driver/compmisc.cmi \
     utils/clflags.cmi \
@@ -8343,7 +8338,6 @@ ocamldoc/odoc_analyse.cmx : \
     ocamldoc/odoc_ast.cmx \
     parsing/location.cmx \
     parsing/lexer.cmx \
-    utils/format_doc.cmx \
     typing/env.cmx \
     driver/compmisc.cmx \
     utils/clflags.cmx \

--- a/Changes
+++ b/Changes
@@ -323,8 +323,8 @@ _______________
   platforms (Linux, *BSD).
   (Miod Vallat, review by Nicolás Ojeda Bär)
 
-- #13169: Introduce a document data type for compiler messages rather than
-  relying on `Format.formatter -> unit` closures.
+- #13169, #13311: Introduce a document data type for compiler messages
+  rather than relying on `Format.formatter -> unit` closures.
   (Florian Angeletti, review by Gabriel Scherer)
 
 - #13193: Remove the unused env_init field from class blocks

--- a/asmcomp/asmgen.ml
+++ b/asmcomp/asmgen.ml
@@ -312,7 +312,7 @@ let compile_implementation_linear target =
 module Style = Misc.Style
 let fprintf, dprintf = Format_doc.fprintf, Format_doc.dprintf
 
-let report_error ppf = function
+let report_error_doc ppf = function
   | Assembler_error file ->
       fprintf ppf "Assembler error, input left in file %a"
         Location.Doc.quoted_filename file
@@ -327,11 +327,13 @@ let report_error ppf = function
   | Asm_generation(fn, err) ->
      fprintf ppf
        "Error producing assembly code for function %a: %a"
-       Style.inline_code fn Emitaux.report_error err
+       Style.inline_code fn Emitaux.report_error_doc err
 
 let () =
   Location.register_error_of_exn
     (function
-      | Error err -> Some (Location.error_of_printer_file report_error err)
+      | Error err -> Some (Location.error_of_printer_file report_error_doc err)
       | _ -> None
     )
+
+let report_error = Format_doc.compat report_error_doc

--- a/asmcomp/asmgen.mli
+++ b/asmcomp/asmgen.mli
@@ -45,7 +45,8 @@ type error =
   | Asm_generation of string * Emitaux.error
 
 exception Error of error
-val report_error: error Format_doc.printer
+val report_error: error Format_doc.format_printer
+val report_error_doc: error Format_doc.printer
 
 val compile_unit
    : output_prefix:string

--- a/asmcomp/asmlibrarian.ml
+++ b/asmcomp/asmlibrarian.ml
@@ -86,17 +86,19 @@ let create_archive file_list lib_name =
 module Style = Misc.Style
 open Format_doc
 
-let report_error ppf = function
+let report_error_doc ppf = function
   | File_not_found name ->
       fprintf ppf "Cannot find file %a" Style.inline_code name
   | Archiver_error name ->
       fprintf ppf "Error while creating the library %a" Style.inline_code name
   | Link_error e ->
-      Linkdeps.report_error ~print_filename:Location.Doc.filename ppf e
+      Linkdeps.report_error_doc ~print_filename:Location.Doc.filename ppf e
 
 let () =
   Location.register_error_of_exn
     (function
-      | Error err -> Some (Location.error_of_printer_file report_error err)
+      | Error err -> Some (Location.error_of_printer_file report_error_doc err)
       | _ -> None
     )
+
+let report_error = Format_doc.compat report_error_doc

--- a/asmcomp/asmlibrarian.mli
+++ b/asmcomp/asmlibrarian.mli
@@ -24,4 +24,5 @@ type error =
 
 exception Error of error
 
-val report_error: error Format_doc.printer
+val report_error: error Format_doc.format_printer
+val report_error_doc: error Format_doc.printer

--- a/asmcomp/asmlink.ml
+++ b/asmcomp/asmlink.ml
@@ -362,7 +362,7 @@ let link ~ppf_dump objfiles output_name =
 module Style = Misc.Style
 open Format_doc
 
-let report_error ppf = function
+let report_error_doc ppf = function
   | File_not_found name ->
       fprintf ppf "Cannot find file %a" Style.inline_code name
   | Not_an_object_file name ->
@@ -402,14 +402,16 @@ let report_error ppf = function
         Style.inline_code "-I"
         Style.inline_code (name^".cmx")
   | Link_error e ->
-      Linkdeps.report_error ~print_filename:Location.Doc.filename ppf e
+      Linkdeps.report_error_doc ~print_filename:Location.Doc.filename ppf e
 
 let () =
   Location.register_error_of_exn
     (function
-      | Error err -> Some (Location.error_of_printer_file report_error err)
+      | Error err -> Some (Location.error_of_printer_file report_error_doc err)
       | _ -> None
     )
+
+let report_error = Format_doc.compat report_error_doc
 
 let reset () =
   Cmi_consistbl.clear crc_interfaces;

--- a/asmcomp/asmlink.mli
+++ b/asmcomp/asmlink.mli
@@ -41,4 +41,5 @@ type error =
 
 exception Error of error
 
-val report_error: error Format_doc.printer
+val report_error: error Format_doc.format_printer
+val report_error_doc: error Format_doc.printer

--- a/asmcomp/asmpackager.ml
+++ b/asmcomp/asmpackager.ml
@@ -284,7 +284,7 @@ let package_files ~ppf_dump initial_env files targetcmx ~backend =
 open Format_doc
 module Style = Misc.Style
 
-let report_error ppf = function
+let report_error_doc ppf = function
     Illegal_renaming(name, file, id) ->
       fprintf ppf "Wrong file naming: %a@ contains the code for\
                    @ %a when %a was expected"
@@ -307,6 +307,8 @@ let report_error ppf = function
 let () =
   Location.register_error_of_exn
     (function
-      | Error err -> Some (Location.error_of_printer_file report_error err)
+      | Error err -> Some (Location.error_of_printer_file report_error_doc err)
       | _ -> None
     )
+
+let report_error = Format_doc.compat report_error_doc

--- a/asmcomp/asmpackager.mli
+++ b/asmcomp/asmpackager.mli
@@ -34,4 +34,5 @@ type error =
 
 exception Error of error
 
-val report_error: error Format_doc.printer
+val report_error: error Format_doc.format_printer
+val report_error_doc: error Format_doc.printer

--- a/asmcomp/emitaux.ml
+++ b/asmcomp/emitaux.ml
@@ -457,16 +457,18 @@ let reset () =
 let binary_backend_available = ref false
 let create_asm_file = ref true
 
-let report_error ppf = function
+let report_error_doc ppf = function
   | Stack_frame_too_large n ->
       Format_doc.fprintf ppf "stack frame too large (%d bytes)" n
 
 let () =
   Location.register_error_of_exn
     (function
-      | Error err -> Some (Location.error_of_printer_file report_error err)
+      | Error err -> Some (Location.error_of_printer_file report_error_doc err)
       | _ -> None
     )
+
+let report_error = Format_doc.compat report_error_doc
 
 let mk_env f : Emitenv.per_function_env =
   {

--- a/asmcomp/emitaux.mli
+++ b/asmcomp/emitaux.mli
@@ -87,7 +87,8 @@ type error =
   | Stack_frame_too_large of int
 
 exception Error of error
-val report_error: error Format_doc.printer
+val report_error: error Format_doc.format_printer
+val report_error_doc: error Format_doc.printer
 
 val mk_env : Linear.fundecl -> Emitenv.per_function_env
 

--- a/bytecomp/bytelibrarian.ml
+++ b/bytecomp/bytelibrarian.ml
@@ -124,21 +124,23 @@ let create_archive file_list lib_name =
 open Format_doc
 module Style = Misc.Style
 
-let report_error ppf = function
+let report_error_doc ppf = function
   | File_not_found name ->
       fprintf ppf "Cannot find file %a" Style.inline_code name
   | Not_an_object_file name ->
       fprintf ppf "The file %a is not a bytecode object file"
         Location.Doc.quoted_filename name
   | Link_error e ->
-      Linkdeps.report_error ~print_filename:Location.Doc.filename ppf e
+      Linkdeps.report_error_doc ~print_filename:Location.Doc.filename ppf e
 
 let () =
   Location.register_error_of_exn
     (function
-      | Error err -> Some (Location.error_of_printer_file report_error err)
+      | Error err -> Some (Location.error_of_printer_file report_error_doc err)
       | _ -> None
     )
+
+let report_error = Format_doc.compat report_error_doc
 
 let reset () =
   lib_ccobjs := [];

--- a/bytecomp/bytelibrarian.mli
+++ b/bytecomp/bytelibrarian.mli
@@ -31,5 +31,6 @@ type error =
 
 exception Error of error
 
-val report_error: error Format_doc.printer
+val report_error: error Format_doc.format_printer
+val report_error_doc: error Format_doc.printer
 val reset: unit -> unit

--- a/bytecomp/bytelink.ml
+++ b/bytecomp/bytelink.ml
@@ -871,7 +871,7 @@ extern "C" {
 open Format_doc
 module Style = Misc.Style
 
-let report_error ppf = function
+let report_error_doc ppf = function
   | File_not_found name ->
       fprintf ppf "Cannot find file %a"
         Location.Doc.quoted_filename name
@@ -885,7 +885,7 @@ let report_error ppf = function
   | Symbol_error(name, err) ->
       fprintf ppf "Error while linking %a:@ %a"
         Location.Doc.quoted_filename name
-        Symtable.report_error err
+        Symtable.report_error_doc err
   | Inconsistent_import(intf, file1, file2) ->
       fprintf ppf
         "@[<hov>Files %a@ and %a@ \
@@ -906,14 +906,16 @@ let report_error ppf = function
         Style.inline_code header
         Style.inline_code msg
   | Link_error e ->
-      Linkdeps.report_error ~print_filename:Location.Doc.filename ppf e
+      Linkdeps.report_error_doc ~print_filename:Location.Doc.filename ppf e
 
 let () =
   Location.register_error_of_exn
     (function
-      | Error err -> Some (Location.error_of_printer_file report_error err)
+      | Error err -> Some (Location.error_of_printer_file report_error_doc err)
       | _ -> None
     )
+
+let report_error = Format_doc.compat report_error_doc
 
 let reset () =
   lib_ccobjs := [];

--- a/bytecomp/bytelink.mli
+++ b/bytecomp/bytelink.mli
@@ -44,4 +44,5 @@ type error =
 
 exception Error of error
 
-val report_error: error Format_doc.printer
+val report_error: error Format_doc.format_printer
+val report_error_doc: error Format_doc.printer

--- a/bytecomp/bytepackager.ml
+++ b/bytecomp/bytepackager.ml
@@ -347,7 +347,7 @@ let package_files ~ppf_dump initial_env files targetfile =
 open Format_doc
 module Style = Misc.Style
 
-let report_error ppf = function
+let report_error_doc ppf = function
     Forward_reference(file, compunit) ->
       fprintf ppf "Forward reference to %a in file %a"
         Style.inline_code (Compunit.name compunit)
@@ -372,6 +372,8 @@ let report_error ppf = function
 let () =
   Location.register_error_of_exn
     (function
-      | Error err -> Some (Location.error_of_printer_file report_error err)
+      | Error err -> Some (Location.error_of_printer_file report_error_doc err)
       | _ -> None
     )
+
+let report_error = Format_doc.compat report_error_doc

--- a/bytecomp/bytepackager.mli
+++ b/bytecomp/bytepackager.mli
@@ -28,4 +28,5 @@ type error =
 
 exception Error of error
 
-val report_error: error Format_doc.printer
+val report_error: error Format_doc.format_printer
+val report_error_doc: error Format_doc.printer

--- a/bytecomp/symtable.ml
+++ b/bytecomp/symtable.ml
@@ -440,7 +440,7 @@ let empty_global_map = GlobalMap.empty
 
 open Format_doc
 
-let report_error ppf = function
+let report_error_doc ppf = function
   | Undefined_global global ->
       fprintf ppf "Reference to undefined %a" Global.description global
   | Unavailable_primitive s ->
@@ -456,9 +456,11 @@ let report_error ppf = function
 let () =
   Location.register_error_of_exn
     (function
-      | Error err -> Some (Location.error_of_printer_file report_error err)
+      | Error err -> Some (Location.error_of_printer_file report_error_doc err)
       | _ -> None
     )
+
+let report_error = Format_doc.compat report_error_doc
 
 let reset () =
   global_table := GlobalMap.empty;

--- a/bytecomp/symtable.mli
+++ b/bytecomp/symtable.mli
@@ -90,6 +90,7 @@ type error =
 
 exception Error of error
 
-val report_error: error Format_doc.printer
+val report_error: error Format_doc.format_printer
+val report_error_doc: error Format_doc.printer
 
 val reset: unit -> unit

--- a/debugger/command_line.ml
+++ b/debugger/command_line.ml
@@ -516,7 +516,7 @@ let print_command depth ppf lexbuf =
       env_of_event !selected_event
     with
     | Envaux.Error msg ->
-        Format_doc.compat Envaux.report_error ppf msg;
+        Envaux.report_error ppf msg;
         raise Toplevel
   in
   List.iter (print_expr depth !selected_event env ppf) exprs
@@ -533,7 +533,7 @@ let instr_address ppf lexbuf =
       env_of_event !selected_event
     with
     | Envaux.Error msg ->
-        Format_doc.compat Envaux.report_error ppf msg;
+        Envaux.report_error ppf msg;
         raise Toplevel
   in
   let print_addr expr =
@@ -622,7 +622,7 @@ let instr_break ppf lexbuf =
             env_of_event !selected_event
           with
           | Envaux.Error msg ->
-              Format_doc.compat Envaux.report_error ppf msg;
+              Envaux.report_error ppf msg;
               raise Toplevel
         in
         begin try

--- a/debugger/main.ml
+++ b/debugger/main.ml
@@ -233,8 +233,8 @@ let main () =
   | Toplevel ->
       exit 2
   | Persistent_env.Error e ->
-      report (Format_doc.compat Persistent_env.report_error) e;
+      report Persistent_env.report_error e;
       exit 2
   | Cmi_format.Error e ->
-      report (Format_doc.compat Cmi_format.report_error) e;
+      report Cmi_format.report_error e;
       exit 2

--- a/driver/pparse.ml
+++ b/driver/pparse.ml
@@ -218,7 +218,7 @@ let file_aux ~tool_name ~sourcefile inputfile (type a) parse_fun invariant_fun
 let file ~tool_name inputfile parse_fun ast_kind =
   file_aux ~tool_name ~sourcefile:inputfile inputfile parse_fun ignore ast_kind
 
-let report_error ppf = function
+let report_error_doc ppf = function
   | CannotRun cmd ->
       fprintf ppf "Error while running external preprocessor@.\
                    Command line: %s@." cmd
@@ -229,9 +229,11 @@ let report_error ppf = function
 let () =
   Location.register_error_of_exn
     (function
-      | Error err -> Some (Location.error_of_printer_file report_error err)
+      | Error err -> Some (Location.error_of_printer_file report_error_doc err)
       | _ -> None
     )
+
+let report_error = Format_doc.compat report_error_doc
 
 let parse_file ~tool_name invariant_fun parse kind sourcefile =
   Location.input_name := sourcefile;

--- a/driver/pparse.mli
+++ b/driver/pparse.mli
@@ -51,7 +51,8 @@ val apply_rewriters_sig:
   ?restore:bool -> tool_name:string -> Parsetree.signature ->
   Parsetree.signature
 
-val report_error : error Format_doc.printer
+val report_error : error Format_doc.format_printer
+val report_error_doc: error Format_doc.printer
 
 
 val parse_implementation:

--- a/file_formats/cmi_format.ml
+++ b/file_formats/cmi_format.ml
@@ -96,7 +96,7 @@ let output_cmi filename oc cmi =
 
 open Format_doc
 
-let report_error ppf = function
+let report_error_doc ppf = function
   | Not_an_interface filename ->
       fprintf ppf "%a@ is not a compiled interface"
         Location.Doc.quoted_filename filename
@@ -112,6 +112,8 @@ let report_error ppf = function
 let () =
   Location.register_error_of_exn
     (function
-      | Error err -> Some (Location.error_of_printer_file report_error err)
+      | Error err -> Some (Location.error_of_printer_file report_error_doc err)
       | _ -> None
     )
+
+let report_error = Format_doc.compat report_error_doc

--- a/file_formats/cmi_format.mli
+++ b/file_formats/cmi_format.mli
@@ -45,4 +45,5 @@ type error =
 
 exception Error of error
 
-val report_error: error Format_doc.printer
+val report_error: error Format_doc.format_printer
+val report_error_doc: error Format_doc.printer

--- a/lambda/translclass.ml
+++ b/lambda/translclass.ml
@@ -997,7 +997,7 @@ let () =
 open Format_doc
 module Style = Misc.Style
 
-let report_error ppf = function
+let report_error_doc ppf = function
   | Tags (lab1, lab2) ->
       fprintf ppf "Method labels %a and %a are incompatible.@ %s"
         Style.inline_code lab1
@@ -1008,7 +1008,9 @@ let () =
   Location.register_error_of_exn
     (function
       | Error (loc, err) ->
-        Some (Location.error_of_printer ~loc report_error err)
+        Some (Location.error_of_printer ~loc report_error_doc err)
       | _ ->
         None
     )
+
+let report_error = Format_doc.compat report_error_doc

--- a/lambda/translclass.mli
+++ b/lambda/translclass.mli
@@ -26,4 +26,5 @@ type error = Tags of string * string
 
 exception Error of Location.t * error
 
-val report_error: error Format_doc.printer
+val report_error: error Format_doc.format_printer
+val report_error_doc: error Format_doc.printer

--- a/lambda/translcore.ml
+++ b/lambda/translcore.ml
@@ -1315,7 +1315,7 @@ let transl_let rec_flag pat_expr_list body =
 
 open Format_doc
 
-let report_error ppf = function
+let report_error_doc ppf = function
   | Free_super_var ->
       fprintf ppf
         "Ancestor names can only be used to select inherited methods"
@@ -1326,7 +1326,9 @@ let () =
   Location.register_error_of_exn
     (function
       | Error (loc, err) ->
-          Some (Location.error_of_printer ~loc report_error err)
+          Some (Location.error_of_printer ~loc report_error_doc err)
       | _ ->
         None
     )
+
+let report_error = Format_doc.compat report_error_doc

--- a/lambda/translcore.mli
+++ b/lambda/translcore.mli
@@ -45,7 +45,8 @@ type error =
 
 exception Error of Location.t * error
 
-val report_error: error Format_doc.printer
+val report_error: error Format_doc.format_printer
+val report_error_doc: error Format_doc.printer
 
 (* Forward declaration -- to be filled in by Translmod.transl_module *)
 val transl_module :

--- a/lambda/translprim.ml
+++ b/lambda/translprim.ml
@@ -873,7 +873,7 @@ let transl_primitive_application loc p env ty path exp args arg_exps =
 open Format_doc
 module Style = Misc.Style
 
-let report_error ppf = function
+let report_error_doc ppf = function
   | Unknown_builtin_primitive prim_name ->
       fprintf ppf "Unknown builtin primitive %a" Style.inline_code prim_name
   | Wrong_arity_builtin_primitive prim_name ->
@@ -884,7 +884,9 @@ let () =
   Location.register_error_of_exn
     (function
       | Error (loc, err) ->
-          Some (Location.error_of_printer ~loc report_error err)
+          Some (Location.error_of_printer ~loc report_error_doc err)
       | _ ->
         None
     )
+
+let report_error = Format_doc.compat report_error_doc

--- a/lambda/translprim.mli
+++ b/lambda/translprim.mli
@@ -49,4 +49,5 @@ type error =
 
 exception Error of Location.t * error
 
-val report_error :  error Format_doc.printer
+val report_error :  error Format_doc.format_printer
+val report_error_doc:  error Format_doc.printer

--- a/middle_end/compilenv.ml
+++ b/middle_end/compilenv.ml
@@ -455,7 +455,7 @@ let require_global global_ident =
 open Format_doc
 module Style = Misc.Style
 
-let report_error ppf = function
+let report_error_doc ppf = function
   | Not_a_unit_info filename ->
       fprintf ppf "%a@ is not a compilation unit description."
         Location.Doc.quoted_filename filename
@@ -485,6 +485,8 @@ let report_error ppf = function
 let () =
   Location.register_error_of_exn
     (function
-      | Error err -> Some (Location.error_of_printer_file report_error err)
+      | Error err -> Some (Location.error_of_printer_file report_error_doc err)
       | _ -> None
     )
+
+let report_error = Format_doc.compat report_error_doc

--- a/middle_end/compilenv.mli
+++ b/middle_end/compilenv.mli
@@ -158,4 +158,5 @@ type error =
 
 exception Error of error
 
-val report_error: error Format_doc.printer
+val report_error: error Format_doc.format_printer
+val report_error_doc: error Format_doc.printer

--- a/ocamldoc/odoc_analyse.ml
+++ b/ocamldoc/odoc_analyse.ml
@@ -51,7 +51,7 @@ let preprocess sourcefile =
     Pparse.preprocess sourcefile
   with Pparse.Error err ->
     Format.eprintf "Preprocessing error@.%a@."
-      (Format_doc.compat Pparse.report_error) err;
+      Pparse.report_error err;
     exit 2
 
 (** Analysis of an implementation file. Returns (Some typedtree) if

--- a/parsing/attr_helper.ml
+++ b/parsing/attr_helper.ml
@@ -41,7 +41,7 @@ let has_no_payload_attribute alt_names attrs =
 
 open Format_doc
 
-let report_error ppf = function
+let report_error_doc ppf = function
   | Multiple_attributes name ->
     fprintf ppf "Too many %a attributes" Style.inline_code name
   | No_payload_expected name ->
@@ -51,7 +51,9 @@ let () =
   Location.register_error_of_exn
     (function
       | Error (loc, err) ->
-        Some (Location.error_of_printer ~loc report_error err)
+        Some (Location.error_of_printer ~loc report_error_doc err)
       | _ ->
         None
     )
+
+let report_error = Format_doc.compat report_error_doc

--- a/parsing/attr_helper.mli
+++ b/parsing/attr_helper.mli
@@ -35,4 +35,5 @@ val has_no_payload_attribute : string -> attributes -> bool
 
 exception Error of Location.t * error
 
-val report_error: error Format_doc.printer
+val report_error: error Format_doc.format_printer
+val report_error_doc: error Format_doc.printer

--- a/toplevel/topcommon.ml
+++ b/toplevel/topcommon.ml
@@ -406,7 +406,7 @@ let try_run_directive ppf dir_name pdir_arg =
 let loading_hint_printer ppf cu =
   let open Format_doc in
   let global = Symtable.Global.Glob_compunit (Cmo_format.Compunit cu) in
-  Symtable.report_error ppf (Symtable.Undefined_global global);
+  Symtable.report_error_doc ppf (Symtable.Undefined_global global);
   let find_with_ext ext =
     try Some (Load_path.find_normalized (cu ^ ext)) with Not_found -> None
   in

--- a/typing/env.ml
+++ b/typing/env.ml
@@ -3563,7 +3563,7 @@ module Style = Misc.Style
 
 let quoted_longident = Style.as_inline_code pp_longident
 
-let report_lookup_error _loc env ppf = function
+let report_lookup_error_doc _loc env ppf = function
   | Unbound_value(lid, hint) -> begin
       fprintf ppf "Unbound value %a" quoted_longident lid;
       spellcheck ppf extract_values env lid;
@@ -3679,7 +3679,7 @@ let report_lookup_error _loc env ppf = function
         quoted_longident lid
         (Style.as_inline_code pp_path) p cause
 
-let report_error ppf = function
+let report_error_doc ppf = function
   | Missing_module(_, path1, path2) ->
       fprintf ppf "@[@[<hov>";
       if Path.same path1 path2 then
@@ -3696,7 +3696,7 @@ let report_error ppf = function
   | Illegal_value_name(_loc, name) ->
       fprintf ppf "%a is not a valid value identifier."
        Style.inline_code name
-  | Lookup_error(loc, t, err) -> report_lookup_error loc t ppf err
+  | Lookup_error(loc, t, err) -> report_lookup_error_doc loc t ppf err
 
 let () =
   Location.register_error_of_exn
@@ -3713,7 +3713,10 @@ let () =
             then Location.error_of_printer_file
             else Location.error_of_printer ~loc ?sub:None ?footnote:None
           in
-          Some (error_of_printer report_error err)
+          Some (error_of_printer report_error_doc err)
       | _ ->
           None
     )
+
+let report_lookup_error = Format_doc.compat2 report_lookup_error_doc
+let report_error = Format_doc.compat report_error_doc

--- a/typing/env.mli
+++ b/typing/env.mli
@@ -448,9 +448,13 @@ type error =
 exception Error of error
 
 
-val report_error: error Format_doc.printer
+val report_error: error Format_doc.format_printer
+val report_error_doc: error Format_doc.printer
 
-val report_lookup_error: Location.t -> t -> lookup_error Format_doc.printer
+val report_lookup_error:
+  Location.t -> t -> lookup_error Format_doc.format_printer
+val report_lookup_error_doc:
+  Location.t -> t -> lookup_error Format_doc.printer
 val in_signature: bool -> t -> t
 
 val is_in_signature: t -> bool

--- a/typing/envaux.ml
+++ b/typing/envaux.ml
@@ -104,7 +104,7 @@ let env_of_only_summary env =
 open Format_doc
 module Style = Misc.Style
 
-let report_error ppf = function
+let report_error_doc ppf = function
   | Module_not_found p ->
       fprintf ppf "@[Cannot find module %a@].@."
         (Style.as_inline_code Printtyp.path) p
@@ -112,6 +112,8 @@ let report_error ppf = function
 let () =
   Location.register_error_of_exn
     (function
-      | Error err -> Some (Location.error_of_printer_file report_error err)
+      | Error err -> Some (Location.error_of_printer_file report_error_doc err)
       | _ -> None
     )
+
+let report_error = Format_doc.compat report_error_doc

--- a/typing/envaux.mli
+++ b/typing/envaux.mli
@@ -31,4 +31,5 @@ type error =
 
 exception Error of error
 
-val report_error: error Format_doc.printer
+val report_error: error Format_doc.format_printer
+val report_error_doc: error Format_doc.printer

--- a/typing/includeclass.ml
+++ b/typing/includeclass.ml
@@ -103,9 +103,11 @@ let include_err mode ppf =
   | CM_Private_method lab ->
       fprintf ppf "@[The private method %s cannot become public@]" lab
 
-let report_error mode ppf = function
+let report_error_doc mode ppf = function
   |  [] -> ()
   | err :: errs ->
       let print_errs ppf errs =
         List.iter (fun err -> fprintf ppf "@ %a" (include_err mode) err) errs in
       fprintf ppf "@[<v>%a%a@]" (include_err mode) err print_errs errs
+
+let report_error mode = Format_doc.compat (report_error_doc mode)

--- a/typing/includeclass.mli
+++ b/typing/includeclass.mli
@@ -29,4 +29,6 @@ val class_declarations:
   class_match_failure list
 
 val report_error :
+  Printtyp.type_or_scheme -> class_match_failure list Format_doc.format_printer
+val report_error_doc :
   Printtyp.type_or_scheme -> class_match_failure list Format_doc.printer

--- a/typing/includemod_errorprinter.ml
+++ b/typing/includemod_errorprinter.ml
@@ -696,7 +696,7 @@ let core env id x =
         (Printtyp.tree_of_cltype_declaration id diff.got Trec_first)
         !Oprint.out_sig_item
         (Printtyp.tree_of_cltype_declaration id diff.expected Trec_first)
-        (Includeclass.report_error Type_scheme) diff.symptom
+        (Includeclass.report_error_doc Type_scheme) diff.symptom
   | Err.Class_declarations {got;expected;symptom} ->
       let t1 = Printtyp.tree_of_class_declaration id got Trec_first in
       let t2 = Printtyp.tree_of_class_declaration id expected Trec_first in
@@ -705,7 +705,7 @@ let core env id x =
          %a@;<1 -2>does not match@ %a@]@ %a"
         !Oprint.out_sig_item t1
         !Oprint.out_sig_item t2
-        (Includeclass.report_error Type_scheme) symptom
+        (Includeclass.report_error_doc Type_scheme) symptom
 
 let missing_field ppf item =
   let id, loc, kind =  Includemod.item_ident_name item in
@@ -940,13 +940,13 @@ let err_msgs ppf (env, err) =
   Printtyp.wrap_printing_env ~error:true env
     (fun () -> (coalesce @@ all env err)  ppf)
 
-let report_error err =
+let report_error_doc err =
   Location.errorf
     ~loc:Location.(in_file !input_name)
     ~footnote:Printtyp.Conflicts.err_msg
    "%a" err_msgs err
 
-let report_apply_error ~loc env (app_name, mty_f, args) =
+let report_apply_error_doc ~loc env (app_name, mty_f, args) =
   let footnote = Printtyp.Conflicts.err_msg in
   let d = Functor_suberror.App.patch env ~f:mty_f ~args in
   match d with
@@ -1014,10 +1014,10 @@ let coercion_in_package_subtype env mty c =
 let register () =
   Location.register_error_of_exn
     (function
-      | Includemod.Error err -> Some (report_error err)
+      | Includemod.Error err -> Some (report_error_doc err)
       | Includemod.Apply_error {loc; env; app_name; mty_f; args} ->
           Some (Printtyp.wrap_printing_env env ~error:true (fun () ->
-              report_apply_error ~loc env (app_name, mty_f, args))
+              report_apply_error_doc ~loc env (app_name, mty_f, args))
             )
       | _ -> None
     )

--- a/typing/persistent_env.ml
+++ b/typing/persistent_env.ml
@@ -244,7 +244,7 @@ let check_pers_struct ~allow_hidden penv f ~loc name =
         Location.prerr_warning loc warn
   | Cmi_format.Error err ->
       let msg = Format.asprintf "%a"
-          (Format_doc.compat Cmi_format.report_error) err in
+          Cmi_format.report_error err in
       let warn = Warnings.No_cmi_file(name, Some msg) in
         Location.prerr_warning loc warn
   | Error err ->
@@ -351,7 +351,7 @@ let save_cmi penv psig pm =
     )
     ~exceptionally:(fun () -> remove_file filename)
 
-let report_error ppf =
+let report_error_doc ppf =
   let open Format_doc in
   function
   | Illegal_renaming(modname, ps_name, filename) -> fprintf ppf
@@ -377,6 +377,8 @@ let () =
   Location.register_error_of_exn
     (function
       | Error err ->
-          Some (Location.error_of_printer_file report_error err)
+          Some (Location.error_of_printer_file report_error_doc err)
       | _ -> None
     )
+
+let report_error = Format_doc.compat report_error_doc

--- a/typing/persistent_env.mli
+++ b/typing/persistent_env.mli
@@ -27,7 +27,8 @@ type error =
 
 exception Error of error
 
-val report_error: error Format_doc.printer
+val report_error: error Format_doc.format_printer
+val report_error_doc: error Format_doc.printer
 
 module Persistent_signature : sig
   type t =

--- a/typing/typeclass.ml
+++ b/typing/typeclass.ml
@@ -1977,7 +1977,7 @@ module Style=Misc.Style
 
 let out_type ppf t = Style.as_inline_code !Oprint.out_type ppf t
 
-let report_error env ppf =
+let report_error_doc env ppf =
   let pp_args ppf args =
     let args = List.map (Printtyp.tree_of_typexp Type) args in
     Style.as_inline_code !Oprint.out_type_args ppf args
@@ -2092,7 +2092,7 @@ let report_error env ppf =
        pp_args params
        pp_args cstrs
   | Class_match_failure error ->
-      Includeclass.report_error Type ppf error
+      Includeclass.report_error_doc Type ppf error
   | Unbound_val lab ->
       fprintf ppf "Unbound instance variable %a" Style.inline_code lab
   | Unbound_type_var (msg, reason) ->
@@ -2174,17 +2174,19 @@ let report_error env ppf =
        completely defined.@]"
       (Style.as_inline_code Printtyp.type_scheme) sign.csig_self
 
-let report_error env ppf err =
+let report_error_doc env ppf err =
   Printtyp.wrap_printing_env ~error:true
-    env (fun () -> report_error env ppf err)
+    env (fun () -> report_error_doc env ppf err)
 
 let () =
   Location.register_error_of_exn
     (function
       | Error (loc, env, err) ->
-        Some (Location.error_of_printer ~loc (report_error env) err)
+        Some (Location.error_of_printer ~loc (report_error_doc env) err)
       | Error_forward err ->
         Some err
       | _ ->
         None
     )
+
+let report_error = Format_doc.compat1 report_error_doc

--- a/typing/typeclass.mli
+++ b/typing/typeclass.mli
@@ -127,7 +127,8 @@ type error =
 exception Error of Location.t * Env.t * error
 exception Error_forward of Location.error
 
-val report_error : Env.t -> error Format_doc.printer
+val report_error : Env.t -> Format.formatter -> error -> unit
+val report_error_doc : Env.t -> error Format_doc.printer
 
 (* Forward decl filled in by Typemod.type_open_descr *)
 val type_open_descr :

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -1972,7 +1972,7 @@ module Reaching_path = struct
 end
 
 let quoted_type ppf ty = Style.as_inline_code !Oprint.out_type ppf ty
-let report_error ppf = function
+let report_error_doc ppf = function
   | Repeated_parameter ->
       fprintf ppf "A type parameter occurs several times"
   | Duplicate_constructor s ->
@@ -2259,7 +2259,9 @@ let () =
   Location.register_error_of_exn
     (function
       | Error (loc, err) ->
-        Some (Location.error_of_printer ~loc report_error err)
+        Some (Location.error_of_printer ~loc report_error_doc err)
       | _ ->
         None
     )
+
+let report_error = Format_doc.compat report_error_doc

--- a/typing/typedecl.mli
+++ b/typing/typedecl.mli
@@ -109,4 +109,5 @@ type error =
 
 exception Error of Location.t * error
 
-val report_error: error Format_doc.printer
+val report_error: error Format_doc.format_printer
+val report_error_doc: error Format_doc.printer

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -3447,7 +3447,9 @@ let report_error ~loc _env = function
         "The type of this packed module refers to %a, which is missing"
         (Style.as_inline_code path) p
   | Badly_formed_signature (context, err) ->
-      Location.errorf ~loc "@[In %s:@ %a@]" context Typedecl.report_error err
+      Location.errorf ~loc "@[In %s:@ %a@]"
+        context
+        Typedecl.report_error_doc err
   | Cannot_hide_id Illegal_shadowing
       { shadowed_item_kind; shadowed_item_id; shadowed_item_loc;
         shadower_id; user_id; user_kind; user_loc } ->

--- a/typing/typetexp.ml
+++ b/typing/typetexp.ml
@@ -854,7 +854,7 @@ module Style = Misc.Style
 let pp_tag ppf t = fprintf ppf "`%s" t
 let pp_type ppf ty = Style.as_inline_code !Oprint.out_type ppf ty
 
-let report_error env ppf = function
+let report_error_doc env ppf = function
   | Unbound_type_variable (name, in_scope_names) ->
     fprintf ppf "The type variable %a is unbound in this type declaration.@ %a"
       Style.inline_code name
@@ -962,9 +962,11 @@ let () =
   Location.register_error_of_exn
     (function
       | Error (loc, env, err) ->
-        Some (Location.error_of_printer ~loc (report_error env) err)
+        Some (Location.error_of_printer ~loc (report_error_doc env) err)
       | Error_forward err ->
         Some err
       | _ ->
         None
     )
+
+let report_error env = Format_doc.compat (report_error_doc env)

--- a/typing/typetexp.mli
+++ b/typing/typetexp.mli
@@ -95,7 +95,8 @@ type error =
 
 exception Error of Location.t * Env.t * error
 
-val report_error: Env.t -> error Format_doc.printer
+val report_error: Env.t -> error Format_doc.format_printer
+val report_error_doc: Env.t -> error Format_doc.printer
 
 (* Support for first-class modules. *)
 val transl_modtype_longident:  (* from Typemod *)

--- a/utils/format_doc.ml
+++ b/utils/format_doc.ml
@@ -422,10 +422,14 @@ let doc_printer f x doc =
   f r x;
   !r
 
+type 'a format_printer = Format.formatter -> 'a -> unit
+
 let format_printer f ppf x =
   let doc = doc_printer f x Doc.empty in
   Doc.format ppf doc
 let compat = format_printer
+let compat1 f p1 = compat (f p1)
+let compat2 f p1 p2 = compat (f p1 p2)
 
 let kasprintf k fmt =
   kdoc_printf (fun doc -> k (Format.asprintf "%a" Doc.format doc)) fmt

--- a/utils/format_doc.mli
+++ b/utils/format_doc.mli
@@ -159,7 +159,10 @@ val formatter: doc ref -> formatter
 (** [formatter rdoc] creates a {!formatter} that updates the [rdoc] reference *)
 
 (** Translate a {!Format_doc} printer to a {!Format} one. *)
-val compat: 'a printer -> Format.formatter -> 'a -> unit
+type 'a format_printer = Format.formatter -> 'a -> unit
+val compat: 'a printer -> 'a format_printer
+val compat1: ('p1 -> 'a printer) -> ('p1 -> 'a format_printer)
+val compat2: ('p1 -> 'p2 -> 'a printer) -> ('p1 -> 'p2 -> 'a format_printer)
 
 (** If necessary, embbed a {!Format} printer inside a formatting instruction
     stream. This breaks every guarantees provided by {!Format_doc}. *)

--- a/utils/linkdeps.ml
+++ b/utils/linkdeps.ml
@@ -107,7 +107,7 @@ let print_reference print_fname ppf {compunit; filename} =
 let pp_list_comma f =
   pp_print_list ~pp_sep:(fun ppf () -> fprintf ppf ",@ ") f
 
-let report_error ~print_filename ppf = function
+let report_error_doc ~print_filename ppf = function
   | Missing_implementations l ->
       let print_modules ppf =
         List.iter
@@ -137,3 +137,6 @@ let report_error ~print_filename ppf = function
       in
       fprintf ppf "@[<hov 2> Duplicated implementations:%a@]"
         (pp_list_comma print) l
+
+let report_error ~print_filename =
+  Format_doc.compat (report_error_doc ~print_filename)

--- a/utils/linkdeps.mli
+++ b/utils/linkdeps.mli
@@ -59,4 +59,6 @@ val check : t -> error option
 
 
 val report_error :
+  print_filename:string Format_doc.printer -> error Format_doc.format_printer
+val report_error_doc :
   print_filename:string Format_doc.printer -> error Format_doc.printer


### PR DESCRIPTION
The introduction of Format_doc in #13169 changed the type of various 'report_error' functions in the compiler codebase. But this breaks user code. An alternative proposed here is to keep 'report_error' at the same type as before and introduce 'report_error_doc' in addition.

(I had a discussion with @Octachron this morning on how long it would take to write this PR. For now my current time is 40mn.)