### PR TITLE
Add a missing `$(EXE)` extension

### DIFF
--- a/otherlibs/Makefile.otherlibs.common
+++ b/otherlibs/Makefile.otherlibs.common
@@ -34,7 +34,7 @@ COMPFLAGS=-absname -w +a-4-9-41-42-44-45-48 -warn-error +A -bin-annot -g \
 ifeq "$(FLAMBDA)" "true"
 OPTCOMPFLAGS += -O3
 endif
-MKLIB=$(OCAMLRUN) $(ROOTDIR)/tools/ocamlmklib
+MKLIB=$(OCAMLRUN) $(ROOTDIR)/tools/ocamlmklib$(EXE)
 
 # Variables that must be defined by individual libraries:
 # LIBNAME


### PR DESCRIPTION
The extension was unintentionally overwritten in cherry-pick commit 46c7122888c5f57b45d75098ca95f159a14420b8.

This doesn’t require a changelog entry.