### PR TITLE
ocamltest: refactor `run_test_tree`

### DIFF
--- a/ocamltest/ocaml_actions.ml
+++ b/ocamltest/ocaml_actions.ml
@@ -220,7 +220,7 @@ let compile_program (compiler : Ocaml_compilers.compiler) log env =
   let output_variable = compiler#output_variable in
   let prepare = prepare_module output_variable log env in
   let modules =
-    List.concatmap prepare (List.map Ocaml_filetypes.filetype all_modules) in
+    List.concat_map prepare (List.map Ocaml_filetypes.filetype all_modules) in
   let has_c_file = List.exists is_c_file modules in
   let c_headers_flags =
     if has_c_file then Ocaml_flags.c_includes else "" in
@@ -350,7 +350,7 @@ let find_source_modules log env =
       ((plugins env) @ (modules env) @ [(Actions_helpers.testfile env)]) in
   print_module_names log "Specified" specified_modules;
   let source_modules =
-    List.concatmap
+    List.concat_map
       (add_module_interface source_directory)
       specified_modules in
   print_module_names log "Source" source_modules;

--- a/ocamltest/ocamltest_stdlib.ml
+++ b/ocamltest/ocamltest_stdlib.ml
@@ -48,6 +48,13 @@ module List = struct
   let rec concatmap f = function
     | [] -> []
     | x::xs -> (f x) @ (concatmap f xs)
+
+  let rec fold_left_result f acc = function
+    | [] -> Ok acc
+    | x :: xs ->
+        match f acc x with
+        | Error _ as err -> err
+        | Ok acc -> fold_left_result f acc xs
 end
 
 module String = struct

--- a/ocamltest/ocamltest_stdlib.ml
+++ b/ocamltest/ocamltest_stdlib.ml
@@ -45,9 +45,6 @@ end
 
 module List = struct
   include List
-  let rec concatmap f = function
-    | [] -> []
-    | x::xs -> (f x) @ (concatmap f xs)
 
   let rec fold_left_result f acc = function
     | [] -> Ok acc

--- a/ocamltest/ocamltest_stdlib.mli
+++ b/ocamltest/ocamltest_stdlib.mli
@@ -35,7 +35,6 @@ end
 
 module List : sig
   include module type of List
-  val concatmap : ('a -> 'b list) -> 'a list -> 'b list
   val fold_left_result :
     ('acc -> 'a -> ('acc, 'e) result) -> 'acc -> 'a list -> ('acc, 'e) result
 end

--- a/ocamltest/ocamltest_stdlib.mli
+++ b/ocamltest/ocamltest_stdlib.mli
@@ -36,6 +36,8 @@ end
 module List : sig
   include module type of List
   val concatmap : ('a -> 'b list) -> 'a list -> 'b list
+  val fold_left_result :
+    ('acc -> 'a -> ('acc, 'e) result) -> 'acc -> 'a list -> ('acc, 'e) result
 end
 
 module String : sig


### PR DESCRIPTION
This is a fragment of #13315, separated out for easier reviewing: this is just a simple refactoring and anyone is free to have a look.

`run_test_tree` is the core function of ocamltest that executes a test.

Justification for the change: I want to implement support for `<stmts>; !{ ... }`, which should execute `{ ... }` if one of the statements in `<stmts>` skips. Determining this -- whether one of the statement skips -- is not possible/easy with the current structure of `run_test_tree`, and it is very easy with the new proposed structure.

The PR is split as three small commits, it is easier to review it commit-by-commit (but maybe not too hard to review in bulk as well).