### PR TITLE
ocamltest: add an 'ocamltest' action to test ocamltest

### DIFF
--- a/ocamltest/ocaml_commands.ml
+++ b/ocamltest/ocaml_commands.ml
@@ -43,3 +43,8 @@ let ocamlrun_ocamlmklib =
 
 let ocamlrun_codegen =
   ocamlrun Ocaml_files.codegen
+
+let ocamltest =
+  (* ocamltest is compiled with -custom,
+     one should not use ocamlrun. *)
+  Ocaml_files.ocamltest

--- a/ocamltest/ocaml_commands.mli
+++ b/ocamltest/ocaml_commands.mli
@@ -33,3 +33,5 @@ val ocamlrun_ocamlobjinfo : string
 
 val ocamlrun_ocamlmklib : string
 val ocamlrun_codegen : string
+
+val ocamltest : string

--- a/ocamltest/ocaml_directories.ml
+++ b/ocamltest/ocaml_directories.ml
@@ -34,3 +34,6 @@ let runtime =
 
 let tools =
   Filename.make_path [srcdir; "tools"]
+
+let ocamltest =
+  Filename.make_path [srcdir; "ocamltest"]

--- a/ocamltest/ocaml_directories.mli
+++ b/ocamltest/ocaml_directories.mli
@@ -26,3 +26,5 @@ val toplevel : string
 val runtime : string
 
 val tools : string
+
+val ocamltest : string

--- a/ocamltest/ocaml_files.ml
+++ b/ocamltest/ocaml_files.ml
@@ -96,3 +96,6 @@ let asmgen_archmod =
     "asmgen_" ^ Ocamltest_config.arch ^ "." ^ Ocamltest_config.objext
   in
   Filename.make_path [Ocaml_directories.srcdir; "testsuite"; "tools"; objname]
+
+let ocamltest =
+  Filename.make_path [Ocaml_directories.ocamltest; Filename.mkexe "ocamltest"]

--- a/ocamltest/ocaml_files.mli
+++ b/ocamltest/ocaml_files.mli
@@ -51,3 +51,5 @@ val ocamlmklib : string
 val codegen : string
 
 val asmgen_archmod : string
+
+val ocamltest : string

--- a/ocamltest/ocaml_flags.ml
+++ b/ocamltest/ocaml_flags.ml
@@ -54,3 +54,5 @@ let runtime_flags env backend c_files =
 let toplevel_default_flags = "-noinit -no-version -noprompt"
 
 let ocamlobjinfo_default_flags = "-null-crc"
+
+let ocamltest_default_flags = ""

--- a/ocamltest/ocaml_flags.mli
+++ b/ocamltest/ocaml_flags.mli
@@ -27,3 +27,5 @@ val runtime_flags :
 val toplevel_default_flags : string
 
 val ocamlobjinfo_default_flags : string
+
+val ocamltest_default_flags : string


### PR DESCRIPTION
This is part of #13315, split out for easier reviewing. It adds an `ocamltest;` action in ocamltest, which allows to test ocamltest scripts. This sounds like a generally useful feature that I think we should integrate no matter what happens to #13315.

For example, suppose I want to test that the `not <test>;` feature from #13315 works properly. I write the following test script:

```
(* TEST
{ not pass; fail; }
{ not skip; pass; }
*)
```

The problem is that if I just add this to the testsuite, I will see that this test script succeeds, but I don't know if the feature works as intended. Maybe `not foo;` always skips, and therefore this test passes without doing what I think it does. I can check that this does not happen myself, by tweaking the test to say `{ not skip; fail }` instead of `{ not skip; pass }`, and checking that that fails. But I cannot commit this to the testsuite. How do I leave evidence in the testsuite that the `pass` action after the `not skip` indeed runs?

My solution is that instead of writing this as a `negation.ml` test, called with the usual driver, I write my test above as a `negation.test` file, with a `semantics.ml` driver test that reads as follows:

```
(* TEST
{
  readonly_files="negation.test negation.reference";
  program="negation.test";
  output="negation.result";
  flags="-e";
  ocamltest;
  reference="negation.reference";
  check-program-output;
}
*)
```

And then in `negation.reference` I put the result of running `ocamltest -e negation.test`, which is mostly unreadable *but* changes if I change the test or the `not` implementation. At this point I'm happy.