### PR TITLE
Fix GC alarm regression

### DIFF
--- a/Changes
+++ b/Changes
@@ -179,6 +179,9 @@ _______________
   ensure it doesn't break when reading from or writing to buckets.
   (Hazem ElMasry, review by Gabriel Scherer and Nicolás Ojeda Bär)
 
+- #13318: Fix regression in GC alarms.
+  (Guillaume Munch-Maccagnoni, report by, review by)
+
 ### Other libraries:
 
 - #11996: release the dependency of dynlink on compilerlibs.

--- a/Changes
+++ b/Changes
@@ -179,8 +179,9 @@ _______________
   ensure it doesn't break when reading from or writing to buckets.
   (Hazem ElMasry, review by Gabriel Scherer and Nicolás Ojeda Bär)
 
-- #13318: Fix regression in GC alarms.
-  (Guillaume Munch-Maccagnoni, report by, review by)
+- #13318: Fix regression in GC alarms, and fix them for flambda.
+  (Guillaume Munch-Maccagnoni, report by Benjamin Monate, review by
+   Vincent Laviron and Gabriel Scherer)
 
 ### Other libraries:
 

--- a/stdlib/gc.ml
+++ b/stdlib/gc.ml
@@ -115,10 +115,11 @@ let rec call_alarm arec =
 let delete_alarm a = Atomic.set a false
 
 let create_alarm f =
-  let arec = { active = Atomic.make true; f = f } in
-  Domain.at_exit (fun () -> delete_alarm arec.active);
+  let alarm = Atomic.make true in
+  Domain.at_exit (fun () -> delete_alarm alarm);
+  let arec = { active = alarm; f = f } in
   finalise call_alarm arec;
-  arec.active
+  alarm
 
 
 module Memprof =

--- a/stdlib/gc.ml
+++ b/stdlib/gc.ml
@@ -114,7 +114,8 @@ let rec call_alarm arec =
 
 let delete_alarm a = Atomic.set a false
 
-let create_alarm f =
+(* never inline, to prevent [arec] from being allocated statically *)
+let[@inline never] create_alarm f =
   let alarm = Atomic.make true in
   Domain.at_exit (fun () -> delete_alarm alarm);
   let arec = { active = alarm; f = f } in

--- a/testsuite/tests/callback/test_gc_alarm.ml
+++ b/testsuite/tests/callback/test_gc_alarm.ml
@@ -1,0 +1,14 @@
+(* TEST *)
+
+let success () = exit 0
+let failure () = failwith "The end was reached without triggering the GC alarm"
+
+let () =
+  let _ = Gc.create_alarm success in
+  let g = Array.init 120000 (fun i -> Array.init 1 (fun i -> i)) in
+  for i = 0 to 10000 do
+    let a = Array.init 12000 (fun i -> i) in
+    g.(i) <- a;
+    a.(0) <- 42;
+  done;
+  failure ()


### PR DESCRIPTION
The PR #12558 introduced the following regression: GC alarms did not run any more. (Reported at https://discuss.ocaml.org/t/changes-in-handling-of-gc-parameters-and-alarms-in-5-2-0/14986/2)

The arec variable was referenced in the closure for `at_exit`, which prevented the value from being finalised.

I wondered why it was not caught, and in fact the testsuite had no test for alarms. So naturally I add a regression test, based on the provided reproducer.