### PR TITLE
Avoid excessive GC work during unmarshalling-heavy ramp-up phases 

### DIFF
--- a/runtime/caml/domain_state.tbl
+++ b/runtime/caml/domain_state.tbl
@@ -81,6 +81,12 @@ DOMAIN_STATE(uintnat, allocated_words_direct)
 /* Number of words allocated directly to the major heap since the latest
    slice. (subset of allocated_words) */
 
+DOMAIN_STATE(uintnat, allocated_words_longlived)
+/* Number of words allocated to the major heap since the latest slice,
+   which we believe will be long-lived, stay alive almost until the
+   end of the program (or: the next forced full collection).
+   (subset of allocated_words) */
+
 DOMAIN_STATE(uintnat, swept_words)
 
 DOMAIN_STATE(uintnat, major_slice_epoch)

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -723,6 +723,7 @@ static void domain_create(uintnat initial_minor_heap_wsize,
 
   domain_state->allocated_words = 0;
   domain_state->allocated_words_direct = 0;
+  domain_state->allocated_words_longlived = 0;
   domain_state->swept_words = 0;
 
   domain_state->local_roots = NULL;

--- a/runtime/intern.c
+++ b/runtime/intern.c
@@ -439,6 +439,15 @@ static value intern_alloc_obj(struct caml_intern_state* s, caml_domain_state* d,
     }
     d->allocated_words += Whsize_wosize(wosize);
     d->allocated_words_direct += Whsize_wosize(wosize);
+    /* #13300: We assume that marshalled data whose total payload size
+       is above Max_young_wosize (2Mio on 64 machines) is long-lived.
+       This avoids situations where the GC works too hard due to
+       a 'ramp up' phase which is unmarhsalling-heavy and does not
+       free much memory (for example: when we type-check a .ml file,
+       we typically start by loading many .cmi files of dependencies,
+       and the GC should not try to compensate with more
+       marking work). */
+    d->allocated_words_longlived += Whsize_wosize(wosize);
     Hd_hp(p) = Make_header (wosize, tag, caml_global_heap_state.MARKED);
     caml_memprof_sample_block(Val_hp(p), wosize,
                               Whsize_wosize(wosize),

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -581,12 +581,14 @@ static void update_major_slice_work(intnat howmuch,
   caml_domain_state *dom_st = Caml_state;
 
   intnat my_alloc_count = dom_st->allocated_words;
-  intnat my_alloc_direct_count = dom_st->allocated_words_direct;
+  intnat my_alloc_count_direct = dom_st->allocated_words_direct;
+  intnat my_alloc_count_longlived = dom_st->allocated_words_longlived;
   intnat my_dependent_count = dom_st->dependent_allocated;
   double my_extra_count = dom_st->extra_heap_resources;
   dom_st->stat_major_words += dom_st->allocated_words;
   dom_st->allocated_words = 0;
   dom_st->allocated_words_direct = 0;
+  dom_st->allocated_words_longlived = 0;
   dom_st->dependent_allocated = 0;
   dom_st->extra_heap_resources = 0.0;
   /*
@@ -597,13 +599,19 @@ static void update_major_slice_work(intnat howmuch,
      Assuming steady state and enforcing a constant allocation rate, then
      FM is divided in 2/3 for garbage and 1/3 for free list.
               G = 2 * FM / 3
-     G is also the amount of memory that will be used during this cycle
-     (still assuming steady state).
+
+     We distinguish 'long lived' allocations, that are likely to remain
+     alive until the end of time or the next forced full-major GC.
+     Assuming steady state, G is also the amount of non-longlived words
+     that will be allocated during this cycle.
+
+       allocated_words_steady = dom->allocated_words
+                                - dom_st->allocated_words_longlived
 
      Proportion of G consumed since the previous slice:
-              PH = dom_st->allocated_words / G
-                = dom_st->allocated_words * 3 * (100 + caml_percent_free)
-                  / (2 * heap_words * caml_percent_free)
+              PH = allocated_words_steady / G
+                 = allocated_words_steady * 3 * (100 + caml_percent_free)
+                   / (2 * heap_words * caml_percent_free)
      Proportion of extra-heap resources consumed since the previous slice:
               PE = dom_st->extra_heap_resources
      Proportion of total work to do in this slice:
@@ -636,7 +644,8 @@ static void update_major_slice_work(intnat howmuch,
       total_cycle_work
       * 3.0 * (100 + caml_percent_free)
       / heap_words / caml_percent_free / 2.0;
-    alloc_work = (intnat) (my_alloc_count * alloc_ratio);
+    intnat my_alloc_count_steady = my_alloc_count - my_alloc_count_longlived;
+    alloc_work = (intnat) (my_alloc_count_steady * alloc_ratio);
   } else {
     alloc_work = 0;
   }
@@ -662,7 +671,10 @@ static void update_major_slice_work(intnat howmuch,
                    my_alloc_count);
   caml_gc_message (0x40, "allocated_words_direct = %"
                          ARCH_INTNAT_PRINTF_FORMAT "u\n",
-                   my_alloc_direct_count);
+                   my_alloc_count_direct);
+  caml_gc_message (0x40, "allocated_words_longlived = %"
+                         ARCH_INTNAT_PRINTF_FORMAT "u\n",
+                   my_alloc_count_longlived);
   caml_gc_message (0x40, "alloc work-to-do = %"
                          ARCH_INTNAT_PRINTF_FORMAT "d\n",
                    alloc_work);
@@ -1956,6 +1968,7 @@ void caml_finish_marking (void)
     Caml_state->stat_major_words += Caml_state->allocated_words;
     Caml_state->allocated_words = 0;
     Caml_state->allocated_words_direct = 0;
+    Caml_state->allocated_words_longlived = 0;
     CAML_EV_END(EV_MAJOR_FINISH_MARKING);
   }
 }

--- a/runtime/memory.c
+++ b/runtime/memory.c
@@ -419,7 +419,7 @@ CAMLexport void caml_set_fields (value obj, value v)
 }
 
 Caml_inline value alloc_shr(mlsize_t wosize, tag_t tag, reserved_t reserved,
-                            int noexc)
+                            int noexc, int longlived)
 {
   Caml_check_caml_state();
   caml_domain_state *dom_st = Caml_state;
@@ -434,6 +434,9 @@ Caml_inline value alloc_shr(mlsize_t wosize, tag_t tag, reserved_t reserved,
 
   dom_st->allocated_words += Whsize_wosize(wosize);
   dom_st->allocated_words_direct += Whsize_wosize(wosize);
+  if (longlived)
+      dom_st->allocated_words_longlived += Whsize_wosize(wosize);
+
   if (dom_st->allocated_words_direct > dom_st->minor_heap_wsz / 5) {
     CAML_EV_COUNTER (EV_C_REQUEST_MAJOR_ALLOC_SHR, 1);
     caml_request_major_slice(1);
@@ -454,19 +457,19 @@ Caml_inline value alloc_shr(mlsize_t wosize, tag_t tag, reserved_t reserved,
 
 CAMLexport value caml_alloc_shr(mlsize_t wosize, tag_t tag)
 {
-  return alloc_shr(wosize, tag, 0, 0);
+  return alloc_shr(wosize, tag, 0, 0, 0);
 }
 
 CAMLexport value caml_alloc_shr_reserved(mlsize_t wosize,
                                          tag_t tag,
                                          reserved_t reserved)
 {
-  return alloc_shr(wosize, tag, reserved, 0);
+  return alloc_shr(wosize, tag, reserved, 0, 0);
 }
 
 
 CAMLexport value caml_alloc_shr_noexc(mlsize_t wosize, tag_t tag) {
-  return alloc_shr(wosize, tag, 0, 1);
+  return alloc_shr(wosize, tag, 0, 1, 0);
 }
 
 /* Global memory pool.


### PR DESCRIPTION
When tracking a Coq performance regression in OCaml 5 (#13300), we (@OlivierNicole and myself) realized that the GC work-computation heuristics are bad for ramp-up phases of programs that do a lot of unmarshalling, such as the loading of Coq .vo files implied by its `Require Import` directives.

The problem is that the GC assumes a steady state, where it should work to release approximately the same amount of memory that was allocated since the beginning of the cycle. When allocating a large amount of long-lived memory, this assumption results in excessive marking work (traversing the heap to find free memory).
(This is what I reconstructed from the explanation of @NickBarnes in https://github.com/ocaml/ocaml/issues/13300#issuecomment-2233053966, and further in-person comments from @damiendoligez)

The fix introduces a sub-category of `major_allocated_words` (the number of words allocated into the major heap), called `major_allocated_words_longlived`, which counts the major-heap memory that we expect to live until the end of time, or the next request for a full major GC, and is not taken into account to decide marking work.

The only place where this new "longlived" category is used in this commit is in the unmarshalling code, only in the case where the post-unmarshalling data is larged than Max_young_wosize (cannot be allocated as a single block in the minor heap), that is currently 2Kio on a 64bit system.

This heuristic could be a problem for OCaml programs that allocate a lot of short-lived memory through unmarshalling, by packets of more than 2Kio each. Those programs could suffer from vastly increased memory consuptmion.

Performance numbers for this change, with the Coq default GC settings:

```
Summary
  coqc.5.2+backport+change ran
    1.22 ± 0.02 times faster than coqc.5.2+backport
    1.29 ± 0.10 times faster than coqc.5.2
```

with the OCaml default GC settings:

```
Summary
  coqc.5.2+backport+change ran
    1.30 ± 0.03 times faster than coqc.5.2+backport
    1.41 ± 0.11 times faster than coqc.5.2
```

In these numbers:

- coqc.5.2 is with the stock 5.2 runtime
- coqc.5.2+backport has a backport of #13086, which changed the GC pacing slightly
- coqc.5.2+backport+change is the described change, on top of the backport

