### PR TITLE
Cleanup compiler C flags used when compiling the systhreads library

### DIFF
--- a/Changes
+++ b/Changes
@@ -381,7 +381,7 @@ _______________
   (Sébastien Hinderer, review by Miod Vallat, Gabriel Scherer and
   Olivier Nicole)
 
-* #12578, #12589: Use configured CFLAGS and CPPFLAGS *only* during the
+* #12578, #12589, #13322: Use configured CFLAGS and CPPFLAGS *only* during the
   build of the compiler itself. Do not use them when compiling third-party
   C sources through the compiler. Flags for compiling third-party C
   sources can still be specified at configure time in the

--- a/otherlibs/systhreads/Makefile
+++ b/otherlibs/systhreads/Makefile
@@ -18,10 +18,6 @@ ROOTDIR=../..
 include $(ROOTDIR)/Makefile.common
 include $(ROOTDIR)/Makefile.best_binaries
 
-ifneq "$(CCOMPTYPE)" "msvc"
-OC_CFLAGS += -g
-endif
-
 OC_CFLAGS += $(SHAREDLIB_CFLAGS)
 
 LIBS = $(STDLIBFLAGS) -I $(ROOTDIR)/otherlibs/unix

--- a/otherlibs/systhreads/Makefile
+++ b/otherlibs/systhreads/Makefile
@@ -18,7 +18,8 @@ ROOTDIR=../..
 include $(ROOTDIR)/Makefile.common
 include $(ROOTDIR)/Makefile.best_binaries
 
-OC_CFLAGS += $(SHAREDLIB_CFLAGS)
+OC_BYTECODE_CFLAGS += $(SHAREDLIB_CFLAGS)
+OC_NATIVE_CFLAGS += $(SHAREDLIB_CFLAGS)
 
 LIBS = $(STDLIBFLAGS) -I $(ROOTDIR)/otherlibs/unix
 
@@ -54,10 +55,12 @@ all: lib$(LIBNAME).$(A) $(LIBNAME).cma $(CMIFILES)
 
 allopt: lib$(LIBNAME)nat.$(A) $(LIBNAME).cmxa $(CMIFILES)
 
+lib$(LIBNAME).$(A): OC_CFLAGS = $(OC_BYTECODE_CFLAGS)
+
 lib$(LIBNAME).$(A): $(BYTECODE_C_OBJS)
 	$(V_OCAMLMKLIB)$(MKLIB) -o $(LIBNAME) $(BYTECODE_C_OBJS)
 
-lib$(LIBNAME)nat.$(A): OC_CFLAGS += $(OC_NATIVE_CFLAGS)
+lib$(LIBNAME)nat.$(A): OC_CFLAGS = $(OC_NATIVE_CFLAGS)
 
 lib$(LIBNAME)nat.$(A): $(NATIVECODE_C_OBJS)
 	$(V_OCAMLMKLIB)$(MKLIB) -o $(LIBNAME)nat $^


### PR DESCRIPTION
This small PR consists of two commits:

 1. `otherlibs/systhreads/Makefile` should not add `-g` to the CFLAGS since this is dealt with globally by the build system. So, before this commit `-g` was passed twice when compiling `st_stubs.c`. With this commit `-g` is passed only once.
 2. #12589 and in particular 31cdf41628 has introduced a duplication of C compiler flags which this commit eliminates.