### PR TITLE
Clarify comments on C strings

### DIFF
--- a/runtime/caml/memory.h
+++ b/runtime/caml/memory.h
@@ -132,11 +132,11 @@ CAMLextern caml_stat_block caml_stat_resize(caml_stat_block, asize_t);
 CAMLextern caml_stat_block caml_stat_resize_noexc(caml_stat_block, asize_t);
 
 
-/* A [caml_stat_block] containing a NULL-terminated string */
+/* A [caml_stat_block] containing a null-terminated string */
 typedef char* caml_stat_string;
 
 /* [caml_stat_strdup(s)] returns a pointer to a heap-allocated string which is a
-   copy of the NULL-terminated string [s]. It throws an OCaml exception in case
+   copy of the null-terminated string [s]. It throws an OCaml exception in case
    the request fails, and so requires the runtime lock to be held.
 */
 CAMLextern caml_stat_string caml_stat_strdup(const char *s);
@@ -149,8 +149,8 @@ CAMLextern wchar_t* caml_stat_wcsdup(const wchar_t *s);
 */
 CAMLextern caml_stat_string caml_stat_strdup_noexc(const char *s);
 
-/* [caml_stat_strconcat(nargs, strings)] concatenates NULL-terminated [strings]
-   (an array of [char*] of size [nargs]) into a new string, dropping all NULLs,
+/* [caml_stat_strconcat(nargs, strings)] concatenates null-terminated [strings]
+   (an array of [char*] of size [nargs]) into a new string, dropping all NULs,
    except for the very last one. It throws an OCaml exception in case the
    request fails, and so requires the runtime lock to be held.
 */

--- a/runtime/caml/osdeps.h
+++ b/runtime/caml/osdeps.h
@@ -159,7 +159,7 @@ extern void caml_init_os_params(void);
 
 #ifdef _WIN32
 
-/* [caml_stat_strdup_to_utf16(s)] returns a NULL-terminated copy of [s],
+/* [caml_stat_strdup_to_utf16(s)] returns a null-terminated copy of [s],
    re-encoded in UTF-16.  The encoding of [s] is assumed to be UTF-8 if
    [caml_windows_unicode_runtime_enabled] is non-zero **and** [s] is valid
    UTF-8, or the current Windows code page otherwise.
@@ -169,7 +169,7 @@ extern void caml_init_os_params(void);
 */
 CAMLextern wchar_t* caml_stat_strdup_to_utf16(const char *s);
 
-/* [caml_stat_strdup_of_utf16(s)] returns a NULL-terminated copy of [s],
+/* [caml_stat_strdup_of_utf16(s)] returns a null-terminated copy of [s],
    re-encoded in UTF-8 if [caml_windows_unicode_runtime_enabled] is non-zero or
    the current Windows code page otherwise.
 


### PR DESCRIPTION
C strings are terminated with a null character (a character with an internal value of zero, often called "NUL"). Using "NULL" is slightly misleading as it could be understood as the preprocessor macro defined to the null pointer constant.

Cf Wikipedia's [Null-terminated string](https://en.wikipedia.org/wiki/Null-terminated_string).