### PR TITLE
Complete `caml_startup_*_exn` functions with `caml_startup_*_res` variants

### DIFF
--- a/bytecomp/bytelink.ml
+++ b/bytecomp/bytelink.ml
@@ -685,6 +685,15 @@ value caml_startup_exn(char_os ** argv)
                                argv);
 }
 
+caml_result caml_startup_res(char_os ** argv)
+{
+  return caml_startup_code_res(caml_code, sizeof(caml_code),
+                               caml_data, sizeof(caml_data),
+                               caml_sections, sizeof(caml_sections),
+                               /* pooling */ 0,
+                               argv);
+}
+
 void caml_startup_pooled(char_os ** argv)
 {
   caml_startup_code(caml_code, sizeof(caml_code),
@@ -697,6 +706,15 @@ void caml_startup_pooled(char_os ** argv)
 value caml_startup_pooled_exn(char_os ** argv)
 {
   return caml_startup_code_exn(caml_code, sizeof(caml_code),
+                               caml_data, sizeof(caml_data),
+                               caml_sections, sizeof(caml_sections),
+                               /* pooling */ 1,
+                               argv);
+}
+
+caml_result caml_startup_pooled_res(char_os ** argv)
+{
+  return caml_startup_code_res(caml_code, sizeof(caml_code),
                                caml_data, sizeof(caml_data),
                                caml_sections, sizeof(caml_sections),
                                /* pooling */ 1,

--- a/runtime/callback.c
+++ b/runtime/callback.c
@@ -299,15 +299,6 @@ CAMLexport value caml_callbackN_exn(value closure, int narg, value args[]) {
 #endif
 
 /* Result-returning variants of the above */
-
-Caml_inline caml_result Result_encoded(value encoded)
-{
-  if (Is_exception_result(encoded))
-    return Result_exception(Extract_exception(encoded));
-  else
-    return Result_value(encoded);
-}
-
 CAMLexport caml_result caml_callbackN_res(
   value closure, int narg, value args[])
 {

--- a/runtime/caml/fail.h
+++ b/runtime/caml/fail.h
@@ -149,6 +149,14 @@ Caml_inline value caml_result_get_encoded_exception(
   else
     return result.data;
 }
+
+Caml_inline caml_result Result_encoded(value encoded)
+{
+  if (Is_exception_result(encoded))
+    return Result_exception(Extract_exception(encoded));
+  else
+    return Result_value(encoded);
+}
 #endif // CAML_INTERNALS
 
 #ifdef __cplusplus

--- a/runtime/caml/startup.h
+++ b/runtime/caml/startup.h
@@ -29,6 +29,13 @@ CAMLextern void caml_startup_code(
            int pooling,
            char_os **argv);
 
+CAMLextern caml_result caml_startup_code_res(
+  code_t code, asize_t code_size,
+  char *data, asize_t data_size,
+  char *section_table, asize_t section_table_size,
+  int pooling,
+  char_os **argv);
+
 CAMLextern value caml_startup_code_exn(
   code_t code, asize_t code_size,
   char *data, asize_t data_size,

--- a/runtime/startup_byt.c
+++ b/runtime/startup_byt.c
@@ -657,6 +657,20 @@ CAMLexport value caml_startup_code_exn(
   return res;
 }
 
+CAMLexport caml_result caml_startup_code_res(
+           code_t code, asize_t code_size,
+           char *data, asize_t data_size,
+           char *section_table, asize_t section_table_size,
+           int pooling,
+           char_os **argv)
+{
+    value res =
+        caml_startup_code_exn(code, code_size, data, data_size,
+                              section_table, section_table_size,
+                              pooling, argv);
+    return Result_encoded(res);
+}
+
 CAMLexport void caml_startup_code(
            code_t code, asize_t code_size,
            char *data, asize_t data_size,

--- a/runtime/startup_nat.c
+++ b/runtime/startup_nat.c
@@ -83,7 +83,7 @@ extern void caml_install_invalid_parameter_handler(void);
 
 #endif
 
-value caml_startup_common(char_os **argv, int pooling)
+value caml_startup_common_exn(char_os **argv, int pooling)
 {
   char_os * exe_name, * proc_self_exe;
   value res;
@@ -131,7 +131,13 @@ value caml_startup_common(char_os **argv, int pooling)
 
 value caml_startup_exn(char_os **argv)
 {
-  return caml_startup_common(argv, /* pooling */ 0);
+  return caml_startup_common_exn(argv, /* pooling */ 0);
+}
+
+caml_result caml_startup_res(char_os **argv)
+{
+  value res = caml_startup_exn(argv);
+  return Result_encoded(res);
 }
 
 void caml_startup(char_os **argv)
@@ -148,7 +154,13 @@ void caml_main(char_os **argv)
 
 value caml_startup_pooled_exn(char_os **argv)
 {
-  return caml_startup_common(argv, /* pooling */ 1);
+  return caml_startup_common_exn(argv, /* pooling */ 1);
+}
+
+caml_result caml_startup_pooled_res(char_os **argv)
+{
+  value res = caml_startup_pooled_exn(argv);
+  return Result_encoded(res);
 }
 
 void caml_startup_pooled(char_os **argv)


### PR DESCRIPTION
This PR is a continuation of #13013. The `caml_startup` functions start running OCaml code and are meant to be called from a main C program. They provide `_exn` variants to let C callers recover from OCaml-side exceptions, using the now-deprecated "encoded exception" representation. This PR adds `_res` variants of these functions that return a `caml_result` instead, completing the runtime transition from encoded exceptions to results.