### PR TITLE
Named binding operators, take two

### DIFF
--- a/Changes
+++ b/Changes
@@ -22,6 +22,10 @@ _______________
   (Leo White, Tom Kelly, Anil Madhavapeddy, KC Sivaramakrishnan, Xavier Leroy
    and Florian Angeletti, review by the same, Hugo Heuzard, and Ulysse Gérard)
 
+- Named binding operators: `let/map`, `let/bind` are supported in addition
+  to pre-existing `let+`, `let*`.
+  (Gabriel Scherer and Eduardo Rafael, review by ??)
+
 ### Type system
 
 - #11891, #12507: Allow to name new locally abstract types in constructor type

--- a/parsing/lexer.mll
+++ b/parsing/lexer.mll
@@ -426,6 +426,17 @@ let symbolchar_or_hash =
 let kwdopchar =
   ['$' '&' '*' '+' '-' '/' '<' '=' '>' '@' '^' '|']
 
+(* What we allow in binding operators:
+   - either operator symbols, for example let+, let*
+   - or '/ <lident>', for example let/map, let/bind
+
+   Note that '/' is part of [kwdopchar], so all of (let/), (let/!) and
+   (let/foo) are accepted.
+*)
+let binding_op_suffix =
+  ( kwdopchar dotsymbolchar*
+  | '/' lowercase identchar* )
+
 let ident = (lowercase | uppercase) identchar*
 let ident_ext = identstart_ext  identchar_ext*
 let extattrident = ident_ext ('.' ident_ext)*
@@ -674,9 +685,9 @@ rule token = parse
             { INFIXOP3 op }
   | '#' symbolchar_or_hash + as op
             { HASHOP op }
-  | "let" kwdopchar dotsymbolchar * as op
+  | "let" binding_op_suffix as op
             { LETOP op }
-  | "and" kwdopchar dotsymbolchar * as op
+  | "and" binding_op_suffix as op
             { ANDOP op }
   | eof { EOF }
   | (_ as illegal_char)


### PR DESCRIPTION
This PR proposes to extend the current "symbolic" binding operators (`( let+ )`, `( let* )`) with "named" binding operators (`( let/map )`, `( let/bind )`).

This PR is a reboot of @EduardoRFS's #10979, with a slightly different syntax (the initial proposal was `let.map`, `let.bind` proposed by @lpw25 in the broader discussion in #12015. There seems to be a broad consensus (in #10979, #12015 and in #2170) that the current "symbol operators" approach is too limited in terms of readability when mixing several different kinds of bindings, and that named operators would result in more readable code.

The current version does not support "mixed" symbol+names operators such as `let/map+` or `let/list*`, or maybe `let+/list` and `let+/option`. The plan is to eventually support a qualified form `Option.let/map` instead, but I would like to further discuss the syntax for this in #12015 so it is not in the first iteration of the present PR.