### PR TITLE
Implement `O_APPEND` on windows

### DIFF
--- a/Changes
+++ b/Changes
@@ -190,6 +190,9 @@ _______________
   (Sébastien Hinderer and Stephen Dolan, review by Damien Doligez and
   Hugo Heuzard)
 
+- #13326: Implement Unix.O_APPEND on windows.
+  (Romain Beauxis)
+
 ### Tools:
 
 - #11716: ocamllex: mismatched parentheses and curly brackets are now caught

--- a/Changes
+++ b/Changes
@@ -191,7 +191,7 @@ _______________
   Hugo Heuzard)
 
 - #13326: Implement Unix.O_APPEND on windows.
-  (Romain Beauxis)
+  (Romain Beauxis, review by Miod Vallat, Gabriel Scherer and Antonin Décimo)
 
 ### Tools:
 

--- a/otherlibs/unix/open_win32.c
+++ b/otherlibs/unix/open_win32.c
@@ -22,6 +22,8 @@
 #include "caml/unixsupport.h"
 #include <fcntl.h>
 
+#defined OCAML_O_APPEND 4
+
 static const int open_access_flags[15] = {
   GENERIC_READ, GENERIC_WRITE, GENERIC_READ|GENERIC_WRITE,
   0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
@@ -71,7 +73,7 @@ CAMLprim value caml_unix_open(value path, value flags, value perm)
   else
     fileattrib = FILE_ATTRIBUTE_NORMAL;
 
-  if (flags & O_APPEND)
+  if (flags & OCAML_O_APPEND)
     fileaccess |= FILE_APPEND_DATA;
 
   cloexec = caml_convert_flag_list(flags, open_cloexec_flags);
@@ -92,7 +94,7 @@ CAMLprim value caml_unix_open(value path, value flags, value perm)
     caml_uerror("open", path);
   }
 
-  if (flags & O_APPEND) {
+  if (flags & OCAML_O_APPEND) {
     dwMoved = SetFilePointer(h, 0, NULL, FILE_END);
     if (dwMoved == INVALID_SET_FILE_POINTER) {
       caml_win32_maperr(GetLastError());

--- a/otherlibs/unix/open_win32.c
+++ b/otherlibs/unix/open_win32.c
@@ -22,11 +22,9 @@
 #include "caml/unixsupport.h"
 #include <fcntl.h>
 
-#defined OCAML_O_APPEND 4
-
 static const int open_access_flags[15] = {
   GENERIC_READ, GENERIC_WRITE, GENERIC_READ|GENERIC_WRITE,
-  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
+  0, FILE_APPEND_DATA, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
 };
 
 static const int open_create_flags[15] = {
@@ -73,9 +71,6 @@ CAMLprim value caml_unix_open(value path, value flags, value perm)
   else
     fileattrib = FILE_ATTRIBUTE_NORMAL;
 
-  if (flags & OCAML_O_APPEND)
-    fileaccess |= FILE_APPEND_DATA;
-
   cloexec = caml_convert_flag_list(flags, open_cloexec_flags);
   attr.nLength = sizeof(attr);
   attr.lpSecurityDescriptor = NULL;
@@ -94,7 +89,7 @@ CAMLprim value caml_unix_open(value path, value flags, value perm)
     caml_uerror("open", path);
   }
 
-  if (flags & OCAML_O_APPEND) {
+  if (fileaccess & FILE_APPEND_DATA) {
     dwMoved = SetFilePointer(h, 0, NULL, FILE_END);
     if (dwMoved == INVALID_SET_FILE_POINTER) {
       caml_win32_maperr(GetLastError());

--- a/otherlibs/unix/open_win32.c
+++ b/otherlibs/unix/open_win32.c
@@ -97,7 +97,7 @@ CAMLprim value caml_unix_open(value path, value flags, value perm)
     if (dwMoved == INVALID_SET_FILE_POINTER) {
       caml_win32_maperr(GetLastError());
       CloseHandle(h);
-      uerror("open", path);
+      caml_uerror("open", path);
     }
   }
 

--- a/otherlibs/unix/open_win32.c
+++ b/otherlibs/unix/open_win32.c
@@ -95,7 +95,7 @@ CAMLprim value caml_unix_open(value path, value flags, value perm)
   if (flags & O_APPEND) {
     dwMoved = SetFilePointer(h, 0, NULL, FILE_END);
     if (dwMoved == INVALID_SET_FILE_POINTER) {
-      win32_maperr(GetLastError());
+      caml_win32_maperr(GetLastError());
       CloseHandle(h);
       uerror("open", path);
     }

--- a/otherlibs/unix/open_win32.c
+++ b/otherlibs/unix/open_win32.c
@@ -72,7 +72,7 @@ CAMLprim value caml_unix_open(value path, value flags, value perm)
     fileattrib = FILE_ATTRIBUTE_NORMAL;
 
   if (flags & O_APPEND)
-    fileaccess = fileaccess | FILE_APPEND_DATA;
+    fileaccess |= FILE_APPEND_DATA;
 
   cloexec = caml_convert_flag_list(flags, open_cloexec_flags);
   attr.nLength = sizeof(attr);

--- a/testsuite/tests/lib-unix/common/append.ml
+++ b/testsuite/tests/lib-unix/common/append.ml
@@ -1,0 +1,43 @@
+(* TEST
+   include unix;
+   hasunix;
+   {
+     bytecode;
+   }{
+     native;
+   }
+*)
+
+let str = "Hello, OCaml!\r\n"
+
+let append () =
+  let fd =
+    Unix.openfile "append.txt"
+      [ Unix.O_WRONLY; Unix.O_CREAT; Unix.O_APPEND ]
+      0o644
+  in
+  let b = Bytes.unsafe_of_string str in
+  let len = Bytes.length b in
+  let rec f = function
+    | 0 -> ()
+    | rem ->
+        let n = Unix.write fd b (len - rem) rem in
+        f (rem - n)
+  in
+  f len;
+  Unix.close fd
+
+let () =
+  append ();
+  append ();
+  let fd = Unix.openfile "append.txt" [ Unix.O_RDONLY ] 0o644 in
+  let buf = Buffer.create 10 in
+  let b = Bytes.create 10 in
+  let rec f () =
+    let n = Unix.read fd b 0 10 in
+    Buffer.add_subbytes buf b 0 n;
+    if n <> 0 then f ()
+  in
+  f ();
+  Unix.close fd;
+  assert (Buffer.contents buf = str ^ str)

--- a/testsuite/tests/lib-unix/common/append.ml
+++ b/testsuite/tests/lib-unix/common/append.ml
@@ -8,7 +8,7 @@
    }
 *)
 
-let str = "Hello, OCaml!\r\n"
+let str = "Hello, OCaml!"
 
 let append () =
   let fd =


### PR DESCRIPTION
This PR implements support for the `Unix.O_APPEND` flag on windows, based on the documentation available [here](https://learn.microsoft.com/en-us/windows/win32/fileio/appending-one-file-to-another-file) and also adds a test.

Frankly, I am a little surprised that this was never supported nor documented. This seems like a pretty big liability when porting code designed and tested on unix to windows.