### PR TITLE
Update a documentation comment about the structure of continuation objects

### DIFF
--- a/runtime/caml/fiber.h
+++ b/runtime/caml/fiber.h
@@ -175,7 +175,9 @@ struct c_stack_link {
  * the fiber chain.
  *
  * The second field of a continuation object stores a pointer to the other end
- * of the fiber chain, i.e., to the parent-most fiber.
+ * of the fiber chain, i.e., to the parent-most fiber. It is also tagged as an
+ * integer.
+ *
  *
  *  Native code
  *  -----------

--- a/runtime/caml/fiber.h
+++ b/runtime/caml/fiber.h
@@ -167,14 +167,20 @@ struct c_stack_link {
  * implemented in the assembly files for an architecture (such as
  * runtime/amd64.S).
  *
- * A continuation object represents a suspended OCaml stack. It is a block
- * containing as its first field the stack pointer tagged as an integer to
- * avoid being followed by the GC.
+ * A continuation object represents a suspended OCaml stack. It is a block with
+ * tag Cont_tag, containing as its first field the stack pointer tagged as an
+ * integer to avoid being followed by the GC.
+ *
  * In the code the tagged pointer can be referred to as a 'fiber':
  *     fiber := Val_ptr(stack)
  *
- * The second field of a continuation object stores a pointer to the fiber at
- * other end of the fiber chain that the continuation currently belongs to.
+ * This stack pointer always points inside a fiber that is at the end of a
+ * chain of fibers, linked by their `parent` pointers. In other words, it is an
+ * invariant that the stack pointer always points inside the childmost fiber of
+ * the fiber chain.
+ *
+ * The second field of a continuation object stores a pointer to the other end
+ * of the fiber chain, i.e., to the parent-most fiber.
  *
  * caml_runstack new_stack function argument
  *  caml_runstack launches a function (with an argument) in a new OCaml

--- a/runtime/caml/fiber.h
+++ b/runtime/caml/fiber.h
@@ -159,13 +159,8 @@ struct c_stack_link {
  *  Retrofitting Effect Handlers onto OCaml, KC Sivaramakrishnan, et al.
  *  PLDI 2021
  *
- *  Native code
- *  -----------
- *
- * In native compilation the stack switching primitives Prunstack,
- * Pperform, Preperform and Presume make use of corresponding functions
- * implemented in the assembly files for an architecture (such as
- * runtime/amd64.S).
+ *  Representation of continuation values
+ *  -------------------------------------
  *
  * A continuation object represents a suspended OCaml stack. It is a block with
  * tag Cont_tag, containing as its first field the stack pointer tagged as an
@@ -181,6 +176,14 @@ struct c_stack_link {
  *
  * The second field of a continuation object stores a pointer to the other end
  * of the fiber chain, i.e., to the parent-most fiber.
+ *
+ *  Native code
+ *  -----------
+ *
+ * In native compilation the stack switching primitives Prunstack,
+ * Pperform, Preperform and Presume make use of corresponding functions
+ * implemented in the assembly files for an architecture (such as
+ * runtime/amd64.S).
  *
  * caml_runstack new_stack function argument
  *  caml_runstack launches a function (with an argument) in a new OCaml

--- a/runtime/caml/fiber.h
+++ b/runtime/caml/fiber.h
@@ -167,10 +167,14 @@ struct c_stack_link {
  * implemented in the assembly files for an architecture (such as
  * runtime/amd64.S).
  *
- * A continuation object represents a suspended OCaml stack. It contains
- * the stack pointer tagged as an integer to avoid being followed by the GC.
+ * A continuation object represents a suspended OCaml stack. It is a block
+ * containing as its first field the stack pointer tagged as an integer to
+ * avoid being followed by the GC.
  * In the code the tagged pointer can be referred to as a 'fiber':
  *     fiber := Val_ptr(stack)
+ *
+ * The second field of a continuation object stores a pointer to the fiber at
+ * other end of the fiber chain that the continuation currently belongs to.
  *
  * caml_runstack new_stack function argument
  *  caml_runstack launches a function (with an argument) in a new OCaml

--- a/runtime/caml/fiber.h
+++ b/runtime/caml/fiber.h
@@ -162,21 +162,18 @@ struct c_stack_link {
  *  Representation of continuation values
  *  -------------------------------------
  *
- * A continuation object represents a suspended OCaml stack. It is a block with
- * tag Cont_tag, containing as its first field the stack pointer tagged as an
- * integer to avoid being followed by the GC.
+ * A continuation object represents a suspended OCaml stack fragment. It is a
+ * block with tag Cont_tag, containing as its first field the stack pointer
+ * tagged as an integer to avoid being followed by the GC.
  *
- * In the code the tagged pointer can be referred to as a 'fiber':
- *     fiber := Val_ptr(stack)
- *
- * This stack pointer always points inside a fiber that is at the end of a
- * chain of fibers, linked by their `parent` pointers. In other words, it is an
- * invariant that the stack pointer always points inside the childmost fiber of
- * the fiber chain.
+ * This stack pointer always points inside a stack fragment that is at the end
+ * of a chain of stack fragments, linked by their `parent` pointers. In other
+ * words, it is an invariant that the stack pointer always points inside the
+ * childmost fiber of the stack fragment chain.
  *
  * The second field of a continuation object stores a pointer to the other end
- * of the fiber chain, i.e., to the parent-most fiber. It is also tagged as an
- * integer.
+ * of the stack fragment chain, i.e., to the parent-most stack fragment. It is
+ * also tagged as an integer.
  *
  *
  *  Native code


### PR DESCRIPTION
Since #12735, continuations objects have two fields instead of one. This proposes to update the documentation comment in the implementation (`fiber.c`) accordingly.