### PR TITLE
README: more links to release-info

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -110,6 +110,14 @@ The complete OCaml distribution can be accessed at
 
 https://ocaml.org/docs/install.html
 
+== Releases
+
+More information about when and how new releases of OCaml are published is
+available at link:release-info/introduction.md[], see also
+link:release-info/calendar.md[] for a prospective calendar for future OCaml
+versions. For past versions, link:release-info/News[] contains a short
+description of major changes in previous versions.
+
 == Keeping in Touch with the Caml Community
 
 There is an active and friendly discussion forum at
@@ -142,6 +150,8 @@ https://github.com/ocaml/ocaml/issues
 To be effective, bug reports should include a complete program (preferably
 small) that exhibits the unexpected behavior, and the configuration you are
 using (machine type, etc).
+
+== Contributing
 
 For information on contributing to OCaml, see link:HACKING.adoc[] and
 link:CONTRIBUTING.md[].

--- a/release-info/introduction.md
+++ b/release-info/introduction.md
@@ -44,7 +44,8 @@ For instance, at the date of writing, the next planned releases of OCaml are:
 
 The timing is approximate, as we often delay a release to ensure quality when
 unforeseen issues come up. In consequence, releases are often late, typically by
-up to two months.
+up to two months. There is a prospective release calendar available at
+[calendar.md](calendar.md)
 
 We may release bugfix releases at any time.
 


### PR DESCRIPTION
This PR proposes to add a new section in the `README` to link to the user-friendly information available in `release-info`.
Along the way, it also splits the `Contributing` section from the `User-feedback` one.

Finally, this PR adds a missing link from the `release` introduction to the prospective calendar.