### PR TITLE
Define `CAMLunreachable` in GCC < 10

### DIFF
--- a/runtime/caml/misc.h
+++ b/runtime/caml/misc.h
@@ -280,7 +280,7 @@ CAMLnoret CAMLextern void caml_failed_assert (char *, char_os *, int);
 #define CAMLassert(x) ((void) 0)
 #endif
 
-#if __has_builtin(__builtin_trap)
+#if __has_builtin(__builtin_trap) || defined(__GNUC__)
   #define CAMLunreachable() (__builtin_trap())
 #elif defined(_MSC_VER)
   #include <intrin.h>


### PR DESCRIPTION
~This also reverts commit 034f2731ec6ede060667ae9dd542d9c26b0ee30d.~

Tested ~in Ubuntu 20.04~ with GCC 9 in a Docker image.

```sh
$ cd ocaml
$ git checkout XXX # this branch or trunk
$ docker run --pull=missing --rm -v .:/mnt gcc:9 sh -c \
    'cd /mnt && git clean -fdX && ./configure --disable-ocamldoc && make -j$(nproc) runtime/ocamlrun'
```

Reported by @nojb in https://github.com/ocaml/ocaml/pull/13242#issuecomment-2246833417.
cc @gasche 