### PR TITLE
Fix attributes using C23 syntax and revert `Noreturn` definition

### DIFF
--- a/runtime/caml/misc.h
+++ b/runtime/caml/misc.h
@@ -110,7 +110,7 @@ CAMLdeprecated_typedef(addr, char *);
 #define CAMLnoreturn_start CAMLnoret
 #define CAMLnoreturn_end
 #ifdef __GNUC__
-  #define Noreturn CAMLnoret
+  #define Noreturn __attribute__ ((noreturn))
 #else
   #define Noreturn
 #endif

--- a/runtime/caml/misc.h
+++ b/runtime/caml/misc.h
@@ -100,7 +100,8 @@ CAMLdeprecated_typedef(addr, char *);
    Note: CAMLnoreturn is a different macro defined in memory.h,
    to be used in function bodies rather than as a function attribute.
 */
-#if __has_c_attribute(noreturn) || defined(__cplusplus)
+#if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 202311L || \
+    defined(__cplusplus)
   #define CAMLnoret [[noreturn]]
 #else
   #define CAMLnoret _Noreturn
@@ -188,8 +189,8 @@ CAMLdeprecated_typedef(addr, char *);
      CAMLunused_start foo CAMLunused_end;
    which supports both GCC/Clang and MSVC.
 */
-#if __has_c_attribute(maybe_unused)                     \
-    || defined(__cplusplus) && __cplusplus >= 201703L
+#if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 202311L || \
+    defined(__cplusplus) && __cplusplus >= 201703L
   #define CAMLunused [[maybe_unused]]
   #define CAMLunused_start CAMLunused
   #define CAMLunused_end
@@ -209,8 +210,8 @@ CAMLdeprecated_typedef(addr, char *);
 #endif
 
 #ifdef CAML_INTERNALS
-#if (defined(__cplusplus) && __cplusplus >= 201703L) || \
-    __has_c_attribute(fallthrough)
+#if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 202311L || \
+    defined(__cplusplus) && __cplusplus >= 201703L
   #define fallthrough [[fallthrough]]
 #elif __has_attribute(fallthrough)
   #define fallthrough __attribute__ ((fallthrough))

--- a/testsuite/tests/c-api/c_noreturn.ml
+++ b/testsuite/tests/c-api/c_noreturn.ml
@@ -1,0 +1,5 @@
+(* TEST
+  modules = "c_noreturn_stubs.c";
+ *)
+
+let () = ()

--- a/testsuite/tests/c-api/c_noreturn_stubs.c
+++ b/testsuite/tests/c-api/c_noreturn_stubs.c
@@ -1,0 +1,12 @@
+#include <caml/misc.h>
+#include <stdlib.h>
+
+CAMLnoret extern void f(void);
+CAMLnoreturn_start extern void g(void) CAMLnoreturn_end;
+Noreturn extern void h(void);
+extern void i(void) Noreturn;
+
+void f(void) { abort(); }
+void g(void) { abort(); }
+void h(void) { abort(); }
+void i(void) { abort(); }


### PR DESCRIPTION
@punchagan as part of the Sandmark effort is regularly building `trunk` and uses it to build some packages. He reported a [failure to build Lwt](https://github.com/ocaml/infrastructure/issues/149#issuecomment-2250203025) since the merge of https://github.com/ocaml/ocaml/pull/13280. It is fixed by reverting to defining `Noreturn` with a compiler attribute: contrary to the C++/C23 `[[noreturn]]` annotation or to the C11 `_Noreturn` keyword, both of which can only be found before the function return type in a function prototype, the `__attribute__ ((noreturn))` annotation can be placed at the end of the function prototype. Lots of third-party code actually use it this way, which means we cannot use a standard definition for `Noreturn`, and must revert to the compiler attribute.

In the meantime, I've also found out that the detection of compilers attributes was slightly wrong and would lead to using C23 `[[]]` syntax for attributes even before the compiler would advertise C23 support.

> The special operator `__has_c_attribute (operand)` may be used in `#if` and `#elif` expressions in C code to test whether the attribute referenced by its operand is recognized by GCC in attributes using the `[[]]` syntax.

https://gcc.gnu.org/onlinedocs/cpp/_005f_005fhas_005fc_005fattribute.html

Turns out `__has_c_attribute` is also defined by GCC and clang even when they don't default to the C23 standard, even when specifying an older (e,g,. C11) standard, even with the `-pedantic` flag.

In short, relying on this macro to avoid using the `[[]]` syntax before C23 is doomed to fail. Prefer checking whether the compiler is actually using C23. The attributes are all mandated by the C23 standard.

cc @dustanddreams 
(no change entry needed)