### PR TITLE
manual: fix command‘s compilation error and warning in `tutorials/parallelism.etex`

### DIFF
--- a/manual/src/tutorials/parallelism.etex
+++ b/manual/src/tutorials/parallelism.etex
@@ -580,7 +580,7 @@ let _ = main ()
 \end{verbatim}
 
 \begin{verbatim}
-$ ocamlopt -I +threads unix.cmxa threads.cmxa -o dom_thr.exe dom_thr.ml
+$ ocamlopt -I +threads -I +unix unix.cmxa threads.cmxa -o dom_thr.exe dom_thr.ml
 $ ./dom_thr.exe
 Thread 1 running on domain 1 saw initial write
 Thread 0 running on domain 0 saw the write by thread 1

--- a/manual/src/tutorials/parallelism.etex
+++ b/manual/src/tutorials/parallelism.etex
@@ -229,7 +229,7 @@ programs that utilise libraries installed through
 \href{https://opam.ocaml.org/}{opam}.
 
 \begin{verbatim}
-$ ocamlfind ocamlopt -package domainslib -linkpkg -o fib_par2.exe fib_par2.ml
+$ ocamlfind ocamlopt -thread -package domainslib -linkpkg -o fib_par2.exe fib_par2.ml
 $ ./fib_par2.exe 1 42
 fib(42) = 433494437
 $ hyperfine './fib.exe 42' './fib_par2.exe 2 42' \
@@ -367,7 +367,7 @@ code to set up and tear down the pools.
 
 \begin{verbatim}
 $ ocamlopt -o spectralnorm.exe spectralnorm.ml
-$ ocamlfind ocamlopt -package domainslib -linkpkg -o spectralnorm_par.exe \
+$ ocamlfind ocamlopt -thread -package domainslib -linkpkg -o spectralnorm_par.exe \
   spectralnorm_par.ml
 $ hyperfine './spectralnorm.exe 4096' './spectralnorm_par.exe 2 4096' \
             './spectralnorm_par.exe 4 4096' './spectralnorm_par.exe 8 4096'
@@ -580,7 +580,7 @@ let _ = main ()
 \end{verbatim}
 
 \begin{verbatim}
-$ ocamlopt -I +threads unix.cmxa threads.cmxa -o dom_thr.exe dom_thr.ml
+$ ocamlopt -I +threads -I +unix unix.cmxa threads.cmxa -o dom_thr.exe dom_thr.ml
 $ ./dom_thr.exe
 Thread 1 running on domain 1 saw initial write
 Thread 0 running on domain 0 saw the write by thread 1

--- a/manual/src/tutorials/parallelism.etex
+++ b/manual/src/tutorials/parallelism.etex
@@ -229,7 +229,7 @@ programs that utilise libraries installed through
 \href{https://opam.ocaml.org/}{opam}.
 
 \begin{verbatim}
-$ ocamlfind ocamlopt -thread -package domainslib -linkpkg -o fib_par2.exe fib_par2.ml
+$ ocamlfind ocamlopt -package domainslib -linkpkg -o fib_par2.exe fib_par2.ml
 $ ./fib_par2.exe 1 42
 fib(42) = 433494437
 $ hyperfine './fib.exe 42' './fib_par2.exe 2 42' \
@@ -367,7 +367,7 @@ code to set up and tear down the pools.
 
 \begin{verbatim}
 $ ocamlopt -o spectralnorm.exe spectralnorm.ml
-$ ocamlfind ocamlopt -thread -package domainslib -linkpkg -o spectralnorm_par.exe \
+$ ocamlfind ocamlopt -package domainslib -linkpkg -o spectralnorm_par.exe \
   spectralnorm_par.ml
 $ hyperfine './spectralnorm.exe 4096' './spectralnorm_par.exe 2 4096' \
             './spectralnorm_par.exe 4 4096' './spectralnorm_par.exe 8 4096'
@@ -580,7 +580,7 @@ let _ = main ()
 \end{verbatim}
 
 \begin{verbatim}
-$ ocamlopt -I +threads -I +unix unix.cmxa threads.cmxa -o dom_thr.exe dom_thr.ml
+$ ocamlopt -I +threads unix.cmxa threads.cmxa -o dom_thr.exe dom_thr.ml
 $ ./dom_thr.exe
 Thread 1 running on domain 1 saw initial write
 Thread 0 running on domain 0 saw the write by thread 1


### PR DESCRIPTION
- `threads.cmxa` not find when compiling `fib_par2.ml` and `spectralnorm_par.ml`
- fix `ocamlopt`'s warning output when missing the param `-I +unix`

Details:
1. fix(temporarily) error output:

When compiling `fib_par2.ml` and `spectralnorm_par.ml`, the following error will occur:
```shell
> ocamlopt -v
The OCaml native-code compiler, version 5.2.0
Standard library directory: /Users/x/.opam/ocaml.5.2.0/lib/ocaml
...
> ocamlfind ocamlopt -package domainslib -linkpkg -o fib_par2.exe fib_par2.ml
File "fib_par2.ml", line 1:
Error: Cannot find file /Users/x/.opam/ocaml.5.2.0/lib/ocaml/threads.cmxa
> ocamlfind ocamlopt -package domainslib -linkpkg -o spectralnorm_par.exe \
  spectralnorm_par.ml
File "spectralnorm_par.ml", line 1:
Error: Cannot find file /Users/x/.opam/ocaml.5.2.0/lib/ocaml/threads.cmxa
```

Following the error output, I found similar problems:
- [Ocamlfind can’t find threads.cmxa after adding `-package threads`](https://discuss.ocaml.org/t/ocamlfind-cant-find-threads-cmxa-after-adding-package-threads/14344)
- [Disable various parts of -thread handling for 5.x #76](https://github.com/ocaml/ocamlfind/pull/76)

I suppose it's better to add `-thread` in the `ocamlfind` command (fix the compilation error temporarily for tutorial purpose) and remove them in the future after [ocamlfind #76](https://github.com/ocaml/ocamlfind/pull/76) Merged.

This will make readers smoothly compile the code in the tutorial.

For example, the following command will work:
```shell
ocamlfind ocamlopt -thread -package domainslib -linkpkg -o fib_par2.exe fib_par2.ml
```

2. fix warning output:

Compiling `dom_thr.ml` will output the following warning:
```shell
> ocamlopt -I +threads unix.cmxa threads.cmxa -o dom_thr.exe dom_thr.ml
File "_none_", line 1:
Alert ocaml_deprecated_auto_include:
OCaml's lib directory layout changed in 5.0. The unix subdirectory has been
automatically added to the search path, but you should add -I +unix to the
command-line to silence this alert (e.g. by adding unix to the list of
libraries in your dune file, or adding use_unix to your _tags file for
ocamlbuild, or using -package unix for ocamlfind).
```

To fix the warning, I add `-I +unix` in the `ocamlopt` command. (Without `-I +unix`, the command still work, but it will always output the warning).