### PR TITLE
testsuite: a test case for a pessimization from 13076

### DIFF
--- a/testsuite/tests/match-side-effects/partiality.ml
+++ b/testsuite/tests/match-side-effects/partiality.ml
@@ -285,3 +285,116 @@ type _ t = Bool : bool t | Int : int t | Char : char t
   (apply (field_mut 1 (global Toploop!)) "test" test/358))
 val test : 'a t * 'a t -> unit = <fun>
 |}];;
+
+(* Another regression testcase from #13076, proposed by Nick Roberts.
+
+   Performance expectation: no Match_failure clause.
+*)
+type nothing = |
+type t = A | B | C of nothing
+let f : bool * t -> int = function
+  | true, A -> 3
+  | false, A -> 4
+  | _, B -> 5
+  | _, C _ -> .
+(* FAIL: a Match_failure clause is generated. *)
+[%%expect {|
+0
+type nothing = |
+0
+type t = A | B | C of nothing
+(let
+  (f/370 =
+     (function param/371 : int
+       (catch
+         (catch
+           (if (field_imm 0 param/371)
+             (let (*match*/373 =a (field_imm 1 param/371))
+               (if (isint *match*/373) (if *match*/373 (exit 26) 3)
+                 (exit 25)))
+             (let (*match*/374 =a (field_imm 1 param/371))
+               (if (isint *match*/374) (if *match*/374 (exit 26) 4)
+                 (exit 25))))
+          with (26) 5)
+        with (25)
+         (raise (makeblock 0 (global Match_failure/20!) [0: "" 3 26])))))
+  (apply (field_mut 1 (global Toploop!)) "f" f/370))
+val f : bool * t -> int = <fun>
+|}];;
+
+
+(* Another regression testcase from #13076, proposed by Nick Roberts.
+
+   Performance expectation: no Match_failure clause.
+*)
+type t =
+  | A of int
+  | B of string
+  | C of string
+  | D of string
+
+let compare t1 t2 =
+  match t1, t2 with
+  | A i, A j -> Int.compare i j
+  | B l1, B l2 -> String.compare l1 l2
+  | C l1, C l2 -> String.compare l1 l2
+  | D l1, D l2 -> String.compare l1 l2
+  | A _, (B _ | C _ | D _ ) -> -1
+  | (B _ | C _ | D _ ), A _ -> 1
+  | B _, (C _ | D _) -> -1
+  | (C _ | D _), B _ -> 1
+  | C _, D _ -> -1
+  | D _, C _ -> 1
+(* FAIL: a Match_failure clause is generated. *)
+[%%expect {|
+0
+type t = A of int | B of string | C of string | D of string
+(let
+  (compare/381 =
+     (function t1/382 t2/383 : int
+       (catch
+         (catch
+           (switch* t1/382
+            case tag 0:
+             (switch t2/383
+              case tag 0:
+               (apply (field_imm 8 (global Stdlib__Int!))
+                 (field_imm 0 t1/382) (field_imm 0 t2/383))
+              default: -1)
+            case tag 1:
+             (catch
+               (switch* t2/383
+                case tag 0: (exit 30)
+                case tag 1:
+                 (apply (field_imm 9 (global Stdlib__String!))
+                   (field_imm 0 t1/382) (field_imm 0 t2/383))
+                case tag 2: (exit 35)
+                case tag 3: (exit 35))
+              with (35) -1)
+            case tag 2:
+             (switch* t2/383
+              case tag 0: (exit 30)
+              case tag 1: (exit 30)
+              case tag 2:
+               (apply (field_imm 9 (global Stdlib__String!))
+                 (field_imm 0 t1/382) (field_imm 0 t2/383))
+              case tag 3: -1)
+            case tag 3:
+             (switch* t2/383
+              case tag 0: (exit 30)
+              case tag 1: (exit 30)
+              case tag 2: 1
+              case tag 3:
+               (apply (field_imm 9 (global Stdlib__String!))
+                 (field_imm 0 t1/382) (field_imm 0 t2/383))))
+          with (30)
+           (switch* t2/383
+            case tag 0: 1
+            case tag 1: 1
+            case tag 2: (exit 27)
+            case tag 3: (exit 27)))
+        with (27)
+         (raise (makeblock 0 (global Match_failure/20!) [0: "" 8 2])))))
+  (apply (field_mut 1 (global Toploop!)) "compare" compare/381))
+val compare : t -> t -> int = <fun>
+|}];;


### PR DESCRIPTION
#13076, part of The Pattern-Matching Bug PR series and already merged, introduced a small regression / pessimization -- some pattern-matching programs generate slightly worse code than before. I will be working on a fix, but a good first step is to introduce a testcase for the issue -- which would help reviewing a fix, and can serve as a regression test later. 