### PR TITLE
Matching compilation: fix a pessimization from #13076

### DIFF
--- a/Changes
+++ b/Changes
@@ -131,7 +131,7 @@ _______________
   unsupported native backends (POWER, riscv64 and s390x)
   (Miod Vallat, review by Nicolás Ojeda Bär)
 
-- #7241, #12555, #13076, #13138: fix a soundness bug in the
+- #7241, #12555, #13076, #13138, #13338: fix a soundness bug in the
   pattern-matching compiler when side-effects mutate the scrutinee
   during matching.
   Note that #7241 is not fully fixed yet, see the issue for the

--- a/lambda/matching.ml
+++ b/lambda/matching.ml
@@ -3023,15 +3023,15 @@ let mk_failaction_pos partial seen ctx defs =
             in
             fails', jumps'
       | None ->
-          match partial.current with
+          match partial.global with
           | Total ->
-              (* In [Total] mode, if there are no exits left in the
-                 environment, we judge that the remaining failing patterns
-                 cannot arise. [mk_failaction_neg] has the same
-                 logic. *)
+              (* If the pattern-matching is globally [Total], all
+                 missing values are either ill-typed or they are
+                 handled by a matrix of the default environment. The
+                 remaining failing patterns cannot arise. *)
               [], Jumps.empty Total
           | Partial ->
-              (* in [Partial] mode, remaining failing patterns
+              (* in [Partial] mode, the remaining failing patterns
                  go to the final exit. *)
               let final_pats = List.map fst fail_pats_in_ctx in
               mk_fails final_pats (Default_environment.raise_final_exit defs),

--- a/testsuite/tests/match-side-effects/partiality.ml
+++ b/testsuite/tests/match-side-effects/partiality.ml
@@ -388,7 +388,7 @@ let f x y =
  | `X1, `Y3
  | `X2, `Y2
  | `X3, _  -> 3
-(* FAIL: a Match_failure case is generated *)
+(* PASS: no Match_failure generated *)
 [%%expect {|
 (let
   (f/503 =
@@ -396,22 +396,16 @@ let f x y =
        (catch
          (catch
            (catch
-             (catch
-               (if (isint y/505) (if (!= y/505 19896) (exit 45) 0) (exit 45))
-              with (45)
-               (if (!= x/504 19674)
-                 (if (>= x/504 19675) (exit 44)
-                   (if (isint y/505)
-                     (if (!= y/505 19897)
-                       (if (!= y/505 19898) (exit 41) (exit 42)) 1)
-                     (exit 41)))
-                 (if (isint y/505) (if (!= y/505 19897) (exit 44) (exit 42))
-                   (exit 44))))
-            with (44)
-             (if (isint y/505) (if (!= y/505 19898) (exit 42) 2) (exit 42)))
-          with (42) 3)
-        with (41)
-         (raise (makeblock 0 (global Match_failure/20!) [0: "" 2 1])))))
+             (if (isint y/505) (if (!= y/505 19896) (exit 45) 0) (exit 45))
+            with (45)
+             (if (!= x/504 19674)
+               (if (>= x/504 19675) (exit 44)
+                 (if (>= y/505 19898) (exit 42) 1))
+               (if (isint y/505) (if (!= y/505 19897) (exit 44) (exit 42))
+                 (exit 44))))
+          with (44)
+           (if (isint y/505) (if (!= y/505 19898) (exit 42) 2) (exit 42)))
+        with (42) 3)))
   (apply (field_mut 1 (global Toploop!)) "f" f/503))
 val f : [< `X1 | `X2 | `X3 ] -> [< `Y1 | `Y2 | `Y3 ] -> int = <fun>
 |}];;
@@ -423,45 +417,36 @@ let check_results r1 r2 =
   | (Error `A as r), Error _
   | Error _, (Error `A as r) -> r
   | (Error `B as r), Error `B -> r
-(* FAIL: a Match_failure case is generated *)
+(* PASS: no Match_failure case generated *)
 [%%expect {|
 (let
   (check_results/506 =
      (function r1/508 r2/509
-       (catch
-         (let (*match*/515 = (apply r1/508 r2/509))
+       (let (*match*/515 = (apply r1/508 r2/509))
+         (catch
            (catch
-             (catch
-               (let (r/514 =a (field_imm 0 *match*/515))
-                 (catch
-                   (switch* r/514
-                    case tag 0: (exit 50 r/514)
-                    case tag 1:
-                     (catch
-                       (if (>= (field_imm 0 r/514) 66)
-                         (let (*match*/523 =a (field_imm 1 *match*/515))
-                           (switch* *match*/523
-                            case tag 0: (exit 52)
-                            case tag 1:
-                             (let (*match*/524 =a (field_imm 0 *match*/523))
-                               (if (isint *match*/524)
-                                 (if (!= *match*/524 66) (exit 53) r/514)
-                                 (exit 53)))))
-                         (switch* (field_imm 1 *match*/515)
+             (let (r/514 =a (field_imm 0 *match*/515))
+               (catch
+                 (switch* r/514
+                  case tag 0: (exit 50 r/514)
+                  case tag 1:
+                   (catch
+                     (if (>= (field_imm 0 r/514) 66)
+                       (let (*match*/523 =a (field_imm 1 *match*/515))
+                         (switch* *match*/523
                           case tag 0: (exit 52)
-                          case tag 1: (exit 51 r/514)))
-                      with (53)
-                       (let
-                         (r/518 =a (field_imm 1 *match*/515)
-                          *match*/527 =a (field_imm 0 r/518))
-                         (if (isint *match*/527)
-                           (if (!= *match*/527 65) (exit 49) (exit 51 r/518))
-                           (exit 49)))))
-                  with (52) (exit 50 (field_imm 1 *match*/515))))
-              with (50 r/510) r/510)
-            with (51 r/512) r/512))
-        with (49)
-         (raise (makeblock 0 (global Match_failure/20!) [0: "" 2 2])))))
+                          case tag 1:
+                           (let (*match*/524 =a (field_imm 0 *match*/523))
+                             (if (isint *match*/524)
+                               (if (!= *match*/524 66) (exit 53) r/514)
+                               (exit 53)))))
+                       (switch* (field_imm 1 *match*/515)
+                        case tag 0: (exit 52)
+                        case tag 1: (exit 51 r/514)))
+                    with (53) (exit 51 (field_imm 1 *match*/515))))
+                with (52) (exit 50 (field_imm 1 *match*/515))))
+            with (50 r/510) r/510)
+          with (51 r/512) r/512))))
   (apply (field_mut 1 (global Toploop!)) "check_results" check_results/506))
 val check_results :
   ('a -> ('b, [< `A | `B ]) result * ('b, [< `A | `B ]) result) ->

--- a/testsuite/tests/match-side-effects/partiality.ml
+++ b/testsuite/tests/match-side-effects/partiality.ml
@@ -375,3 +375,95 @@ type t = A of int | B of string | C of string | D of string
   (apply (field_mut 1 (global Toploop!)) "compare" compare/381))
 val compare : t -> t -> int = <fun>
 |}];;
+
+
+(* Different testcases involving or-patterns and polymorphic variants,
+   proposed by Nick Roberts. In both cases, we do *not* expect a Match_failure case. *)
+
+let f x y =
+ match x, y with
+ | _, `Y1 -> 0
+ | `X1, `Y2 -> 1
+ | (`X2 | `X3), `Y3 -> 2
+ | `X1, `Y3
+ | `X2, `Y2
+ | `X3, _  -> 3
+(* FAIL: a Match_failure case is generated *)
+[%%expect {|
+(let
+  (f/503 =
+     (function x/504[int] y/505[int] : int
+       (catch
+         (catch
+           (catch
+             (catch
+               (if (isint y/505) (if (!= y/505 19896) (exit 45) 0) (exit 45))
+              with (45)
+               (if (!= x/504 19674)
+                 (if (>= x/504 19675) (exit 44)
+                   (if (isint y/505)
+                     (if (!= y/505 19897)
+                       (if (!= y/505 19898) (exit 41) (exit 42)) 1)
+                     (exit 41)))
+                 (if (isint y/505) (if (!= y/505 19897) (exit 44) (exit 42))
+                   (exit 44))))
+            with (44)
+             (if (isint y/505) (if (!= y/505 19898) (exit 42) 2) (exit 42)))
+          with (42) 3)
+        with (41)
+         (raise (makeblock 0 (global Match_failure/20!) [0: "" 2 1])))))
+  (apply (field_mut 1 (global Toploop!)) "f" f/503))
+val f : [< `X1 | `X2 | `X3 ] -> [< `Y1 | `Y2 | `Y3 ] -> int = <fun>
+|}];;
+
+
+let check_results r1 r2 =
+  match r1 r2 with
+  | (Ok _ as r), _ | _, (Ok _ as r) -> r
+  | (Error `A as r), Error _
+  | Error _, (Error `A as r) -> r
+  | (Error `B as r), Error `B -> r
+(* FAIL: a Match_failure case is generated *)
+[%%expect {|
+(let
+  (check_results/506 =
+     (function r1/508 r2/509
+       (catch
+         (let (*match*/515 = (apply r1/508 r2/509))
+           (catch
+             (catch
+               (let (r/514 =a (field_imm 0 *match*/515))
+                 (catch
+                   (switch* r/514
+                    case tag 0: (exit 50 r/514)
+                    case tag 1:
+                     (catch
+                       (if (>= (field_imm 0 r/514) 66)
+                         (let (*match*/523 =a (field_imm 1 *match*/515))
+                           (switch* *match*/523
+                            case tag 0: (exit 52)
+                            case tag 1:
+                             (let (*match*/524 =a (field_imm 0 *match*/523))
+                               (if (isint *match*/524)
+                                 (if (!= *match*/524 66) (exit 53) r/514)
+                                 (exit 53)))))
+                         (switch* (field_imm 1 *match*/515)
+                          case tag 0: (exit 52)
+                          case tag 1: (exit 51 r/514)))
+                      with (53)
+                       (let
+                         (r/518 =a (field_imm 1 *match*/515)
+                          *match*/527 =a (field_imm 0 r/518))
+                         (if (isint *match*/527)
+                           (if (!= *match*/527 65) (exit 49) (exit 51 r/518))
+                           (exit 49)))))
+                  with (52) (exit 50 (field_imm 1 *match*/515))))
+              with (50 r/510) r/510)
+            with (51 r/512) r/512))
+        with (49)
+         (raise (makeblock 0 (global Match_failure/20!) [0: "" 2 2])))))
+  (apply (field_mut 1 (global Toploop!)) "check_results" check_results/506))
+val check_results :
+  ('a -> ('b, [< `A | `B ]) result * ('b, [< `A | `B ]) result) ->
+  'a -> ('b, [> `A | `B ]) result = <fun>
+|}];;

--- a/testsuite/tests/match-side-effects/partiality.ml
+++ b/testsuite/tests/match-side-effects/partiality.ml
@@ -258,7 +258,7 @@ let test : type a . a t * a t -> unit = function
   | Bool, Bool -> ()
   | _, Char -> ()
 ;;
-(* FAIL: currently a Match_failure clause is generated. *)
+(* PASS: no Match_failure clause generated. *)
 [%%expect {|
 0
 type _ t = Bool : bool t | Int : int t | Char : char t
@@ -266,22 +266,9 @@ type _ t = Bool : bool t | Int : int t | Char : char t
   (test/358 =
      (function param/360 : int
        (catch
-         (catch
-           (switch* (field_imm 0 param/360)
-            case int 0:
-             (switch* (field_imm 1 param/360)
-              case int 0: 0
-              case int 1: (exit 23)
-              case int 2: (exit 24))
-            case int 1:
-             (switch* (field_imm 1 param/360)
-              case int 0: (exit 23)
-              case int 1: 0
-              case int 2: (exit 24))
-            case int 2: (exit 24))
-          with (24) 0)
-        with (23)
-         (raise (makeblock 0 (global Match_failure/20!) [0: "" 2 40])))))
+         (if (>= (field_imm 0 param/360) 2) (exit 24)
+           (if (>= (field_imm 1 param/360) 2) (exit 24) 0))
+        with (24) 0)))
   (apply (field_mut 1 (global Toploop!)) "test" test/358))
 val test : 'a t * 'a t -> unit = <fun>
 |}];;
@@ -297,7 +284,7 @@ let f : bool * t -> int = function
   | false, A -> 4
   | _, B -> 5
   | _, C _ -> .
-(* FAIL: a Match_failure clause is generated. *)
+(* PASS: no Match_failure clause generated. *)
 [%%expect {|
 0
 type nothing = |
@@ -307,17 +294,14 @@ type t = A | B | C of nothing
   (f/370 =
      (function param/371 : int
        (catch
-         (catch
-           (if (field_imm 0 param/371)
-             (let (*match*/373 =a (field_imm 1 param/371))
-               (if (isint *match*/373) (if *match*/373 (exit 26) 3)
-                 (exit 25)))
-             (let (*match*/374 =a (field_imm 1 param/371))
-               (if (isint *match*/374) (if *match*/374 (exit 26) 4)
-                 (exit 25))))
-          with (26) 5)
-        with (25)
-         (raise (makeblock 0 (global Match_failure/20!) [0: "" 3 26])))))
+         (if (field_imm 0 param/371)
+           (switch* (field_imm 1 param/371)
+            case int 0: 3
+            case int 1: (exit 27))
+           (switch* (field_imm 1 param/371)
+            case int 0: 4
+            case int 1: (exit 27)))
+        with (27) 5)))
   (apply (field_mut 1 (global Toploop!)) "f" f/370))
 val f : bool * t -> int = <fun>
 |}];;
@@ -345,7 +329,7 @@ let compare t1 t2 =
   | (C _ | D _), B _ -> 1
   | C _, D _ -> -1
   | D _, C _ -> 1
-(* FAIL: a Match_failure clause is generated. *)
+(* PASS: no Match_failure clause generated. *)
 [%%expect {|
 0
 type t = A of int | B of string | C of string | D of string
@@ -353,48 +337,41 @@ type t = A of int | B of string | C of string | D of string
   (compare/381 =
      (function t1/382 t2/383 : int
        (catch
-         (catch
-           (switch* t1/382
+         (switch* t1/382
+          case tag 0:
+           (switch t2/383
             case tag 0:
-             (switch t2/383
-              case tag 0:
-               (apply (field_imm 8 (global Stdlib__Int!))
-                 (field_imm 0 t1/382) (field_imm 0 t2/383))
-              default: -1)
-            case tag 1:
-             (catch
-               (switch* t2/383
-                case tag 0: (exit 30)
-                case tag 1:
-                 (apply (field_imm 9 (global Stdlib__String!))
-                   (field_imm 0 t1/382) (field_imm 0 t2/383))
-                case tag 2: (exit 35)
-                case tag 3: (exit 35))
-              with (35) -1)
-            case tag 2:
+             (apply (field_imm 8 (global Stdlib__Int!)) (field_imm 0 t1/382)
+               (field_imm 0 t2/383))
+            default: -1)
+          case tag 1:
+           (catch
              (switch* t2/383
-              case tag 0: (exit 30)
-              case tag 1: (exit 30)
-              case tag 2:
+              case tag 0: (exit 31)
+              case tag 1:
                (apply (field_imm 9 (global Stdlib__String!))
                  (field_imm 0 t1/382) (field_imm 0 t2/383))
-              case tag 3: -1)
-            case tag 3:
-             (switch* t2/383
-              case tag 0: (exit 30)
-              case tag 1: (exit 30)
-              case tag 2: 1
-              case tag 3:
-               (apply (field_imm 9 (global Stdlib__String!))
-                 (field_imm 0 t1/382) (field_imm 0 t2/383))))
-          with (30)
+              case tag 2: (exit 36)
+              case tag 3: (exit 36))
+            with (36) -1)
+          case tag 2:
            (switch* t2/383
-            case tag 0: 1
-            case tag 1: 1
-            case tag 2: (exit 27)
-            case tag 3: (exit 27)))
-        with (27)
-         (raise (makeblock 0 (global Match_failure/20!) [0: "" 8 2])))))
+            case tag 0: (exit 31)
+            case tag 1: (exit 31)
+            case tag 2:
+             (apply (field_imm 9 (global Stdlib__String!))
+               (field_imm 0 t1/382) (field_imm 0 t2/383))
+            case tag 3: -1)
+          case tag 3:
+           (switch* t2/383
+            case tag 0: (exit 31)
+            case tag 1: (exit 31)
+            case tag 2: 1
+            case tag 3:
+             (apply (field_imm 9 (global Stdlib__String!))
+               (field_imm 0 t1/382) (field_imm 0 t2/383))))
+        with (31) (switch* t2/383 case tag 0: 1
+                                  case tag 1: 1))))
   (apply (field_mut 1 (global Toploop!)) "compare" compare/381))
 val compare : t -> t -> int = <fun>
 |}];;


### PR DESCRIPTION
This PR, which sits on top of #13337, proposes a fix for the pessimization of pattern-matching compilation analyzed in https://github.com/ocaml/ocaml/pull/13076#issuecomment-2256391500 . The fix is precisely along the lines proposed in that comment, to track the "global" (or toplevel) partiality of pattern-matching separately from the "current" (or local) partiality of the submatrix.