### PR TITLE
Make caml_failed_assert friendlier to debuggers

### DIFF
--- a/runtime/caml/misc.h
+++ b/runtime/caml/misc.h
@@ -274,9 +274,12 @@ typedef char char_os;
 #define __OSFILE__ __FILE__
 #endif
 
+/* Although caml_failed_assert never returns, it is not marked as such.
+   This prevents the C compiler optimising away all of the useful context
+   from the callsite, making debuggers able to see it. */
 #define CAMLassert(x) \
   (CAMLlikely(x) ? (void) 0 : caml_failed_assert ( #x , __OSFILE__, __LINE__))
-CAMLnoret CAMLextern void caml_failed_assert (char *, char_os *, int);
+CAMLextern void caml_failed_assert (char *, char_os *, int);
 #else
 #define CAMLassert(x) ((void) 0)
 #endif

--- a/runtime/caml/misc.h
+++ b/runtime/caml/misc.h
@@ -279,7 +279,15 @@ typedef char char_os;
    from the callsite, making debuggers able to see it. */
 #define CAMLassert(x) \
   (CAMLlikely(x) ? (void) 0 : caml_failed_assert ( #x , __OSFILE__, __LINE__))
-CAMLextern void caml_failed_assert (char *, char_os *, int);
+CAMLextern void caml_failed_assert (char *, char_os *, int)
+#if defined(__has_feature)
+  /* However, we do inform clang-analyzer that this function never returns,
+     since that improves analysis without breaking debugging */
+  #if __has_feature(attribute_analyzer_noreturn)
+    __attribute__((analyzer_noreturn))
+  #endif
+#endif
+;
 #else
 #define CAMLassert(x) ((void) 0)
 #endif

--- a/runtime/misc.c
+++ b/runtime/misc.c
@@ -44,6 +44,9 @@ void caml_failed_assert (char * expr, char_os * file_os, int line)
           (Caml_state_opt != NULL) ? Caml_state_opt->id : -1, file, line, expr);
   fflush(stderr);
   caml_stat_free(file);
+#ifdef __GNUC__
+  __builtin_trap();
+#endif
   abort();
 }
 #endif

--- a/runtime/misc.c
+++ b/runtime/misc.c
@@ -44,7 +44,7 @@ void caml_failed_assert (char * expr, char_os * file_os, int line)
           (Caml_state_opt != NULL) ? Caml_state_opt->id : -1, file, line, expr);
   fflush(stderr);
   caml_stat_free(file);
-#ifdef __GNUC__
+#if __has_builtin(__builtin_trap) || defined(__GNUC__)
   __builtin_trap();
 #endif
   abort();


### PR DESCRIPTION
This patch contains two quality-of-life improvements for those of us who break the runtime on a regular basis.

Currently, the experience of debugging a runtime assertion failure with `gdb` is something like the following, where I added a `CAMLassert(0);` to `caml_scan_stack`:

```
Program received signal SIGABRT, Aborted.
0x00007ffff684e52f in raise () from /lib64/libc.so.6
(gdb) up
#1  0x00007ffff6821e65 in abort () from /lib64/libc.so.6
(gdb) up
#2  0x000000000043aa02 in caml_failed_assert (expr=expr@entry=0x4578b2 "0", file_os=file_os@entry=0x4543b2 "runtime/fiber.c", line=line@entry=395) at runtime/misc.c:47
47	  abort();
(gdb) up
#3  0x00000000004233af in caml_scan_stack (f=f@entry=0x438f00 <oldify_one>, fflags=fflags@entry=0, fdata=fdata@entry=0x7fffffffce30, stack=stack@entry=0x499a80, v_gc_regs=v_gc_regs@entry=0x1)
    at runtime/fiber.c:395
395	      CAMLassert(0);
(gdb) info locals
v = <optimized out>
sp = <optimized out>
low = <optimized out>
high = <optimized out>
```

There are (at least...) two sources of annoyance here:
  1. You need to go `up` three frames to find the runtime, because the actual signal arrives deep in the implementation of `abort`. (This isn't so bad when running normally, but is much more annoying when running under `rr`).
  2. Many local variables are optimised away.

This patch helps with both, giving in this case:
```
Program received signal SIGILL, Illegal instruction.
caml_failed_assert (expr=expr@entry=0x45b8e3 "0", file_os=file_os@entry=0x4583f2 "runtime/fiber.c", line=line@entry=395) at runtime/misc.c:48
48	  __builtin_trap();
(gdb) up
#1  0x000000000042456e in caml_scan_stack (f=f@entry=0x43bb30 <oldify_one>, fflags=fflags@entry=0, fdata=fdata@entry=0x7fffffffcc20, stack=stack@entry=0x49ea80, v_gc_regs=v_gc_regs@entry=0x7fffffffcc20)
    at runtime/fiber.c:395
395	      CAMLassert(0);
(gdb) info locals
v = 140737062604632
sp = 0x4a2738
low = <optimized out>
high = 0x4a2c20
```

The concrete changes are:

  - Use `__builtin_trap` rather than `abort` where available, so that the crash happens inside the runtime rather than in the implementation of `abort`.
  - Do not mark `caml_failed_assert` as noreturn, so the C compiler does not get to optimise away all local variables by assuming that they're not live any more. Even though this function will never in fact return, if we don't inform the C compiler of this then it is obliged to keep local state alive, so we can view it in the debugger.