### PR TITLE
use abort() to define CAMLunreachable()

### DIFF
--- a/runtime/caml/misc.h
+++ b/runtime/caml/misc.h
@@ -300,7 +300,7 @@ CAMLextern void caml_failed_assert (char *, char_os *, int)
   void caml_fastfail(unsigned int i) { __fastfail(i); }
   #define CAMLunreachable() (caml_fastfail(7 /* FAST_FAIL_FATAL_APP_EXIT */))
 #else
-  #define CAMLunreachable() (CAMLassert(0))
+  #define CAMLunreachable() (abort())
 #endif
 
 #if __has_builtin(__builtin_expect) || defined(__GNUC__)

--- a/runtime/caml/misc.h
+++ b/runtime/caml/misc.h
@@ -293,14 +293,25 @@ CAMLextern void caml_failed_assert (char *, char_os *, int)
 #endif
 
 #if __has_builtin(__builtin_trap) || defined(__GNUC__)
-  #define CAMLunreachable() (__builtin_trap())
+  CAMLnoret Caml_inline void caml_abort(void) {
+    __builtin_trap();
+  }
 #elif defined(_MSC_VER)
   #include <intrin.h>
-  CAMLnoret Caml_inline void caml_fastfail(unsigned int);
-  void caml_fastfail(unsigned int i) { __fastfail(i); }
-  #define CAMLunreachable() (caml_fastfail(7 /* FAST_FAIL_FATAL_APP_EXIT */))
+  CAMLnoret Caml_inline void caml_abort(void) {
+    __fastfail(7 /* FAST_FAIL_FATAL_APP_EXIT */);
+  }
 #else
-  #define CAMLunreachable() (abort())
+  CAMLnoret Caml_inline void caml_abort(void) {
+    abort();
+  }
+#endif
+
+#ifdef DEBUG
+CAMLnoret CAMLextern void caml_debug_abort(char_os *, int);
+#define CAMLunreachable() (caml_debug_abort(__OSFILE__, __LINE__))
+#else
+#define CAMLunreachable() (caml_abort())
 #endif
 
 #if __has_builtin(__builtin_expect) || defined(__GNUC__)


### PR DESCRIPTION
See https://github.com/ocaml/ocaml/pull/13331#issuecomment-2247673918 for the context.

The new `CAMLunreachable` macro from #13242 has three definitions: one for gcc and clang, one for MSVC, and one for the weird other cases. In the last cases it uses `CAMLassert(0)`, which is clearly wrong for something that should be `[[noreturn]]` (at it does nothing in the non-debug runtime), and will become even more wrong after #13344 (which makes it not-`[[noreturn]]` even in debug mode).

In this version of the definition I propose to simply use `abort()`, which is `[[noreturn]]` as intended and should be available in all C11 compilers.

**Edit**: later iterations of this PR moved to a `caml_abort()` helper, and first some debug printing in DEBUG mode.

cc @MisterDA, @nojb