### PR TITLE
Concurrency refactors and cleanups

### DIFF
--- a/Changes
+++ b/Changes
@@ -134,6 +134,10 @@ _______________
   runtime assertions.
   (Antonin Décimo, review by Miod Vallat, Gabriel Scherer, and David Allsopp)
 
+- #13352: Concurrency refactors and cleanups.
+  (Antonin Décimo, review by Gabriel Scherer, David Allsopp,
+   and Miod Vallat)
+
 ### Code generation and optimizations:
 
 - #13014: Enable compile-time option -function-sections on all previously

--- a/otherlibs/systhreads/st_posix.h
+++ b/otherlibs/systhreads/st_posix.h
@@ -70,7 +70,7 @@ value caml_thread_sigmask(value cmd, value sigs)
   caml_enter_blocking_section();
   retcode = pthread_sigmask(how, &set, &oldset);
   caml_leave_blocking_section();
-  sync_check_error(retcode, "Thread.sigmask");
+  caml_check_error(retcode, "Thread.sigmask");
   /* Run any handlers for just-unmasked pending signals */
   caml_process_pending_actions();
   return st_encode_sigset(&oldset);
@@ -86,7 +86,7 @@ value caml_wait_signal(value sigs)
   caml_enter_blocking_section();
   retcode = sigwait(&set, &signo);
   caml_leave_blocking_section();
-  sync_check_error(retcode, "Thread.wait_signal");
+  caml_check_error(retcode, "Thread.wait_signal");
   return Val_int(caml_rev_convert_signal_number(signo));
 #else
   caml_invalid_argument("Thread.wait_signal not implemented");

--- a/otherlibs/systhreads/st_pthreads.h
+++ b/otherlibs/systhreads/st_pthreads.h
@@ -28,12 +28,6 @@
 
 typedef int st_retcode;
 
-/* OS-specific initialization */
-static int st_initialize(void)
-{
-  return 0;
-}
-
 typedef pthread_t st_thread_id;
 
 

--- a/otherlibs/systhreads/st_stubs.c
+++ b/otherlibs/systhreads/st_stubs.c
@@ -492,8 +492,6 @@ static void caml_thread_domain_initialize_hook(void)
   caml_thread_t new_thread;
 
   atomic_store_release(&Tick_thread_stop, 0);
-  /* OS-specific initialization */
-  st_initialize();
 
   int ret = st_masterlock_init(Thread_lock(Caml_state->id));
   caml_check_error(ret, "caml_thread_domain_initialize_hook");

--- a/otherlibs/systhreads/st_stubs.c
+++ b/otherlibs/systhreads/st_stubs.c
@@ -438,7 +438,7 @@ static void caml_thread_reinitialize(void)
      the effective owner of the lock. So there is no need to run
      st_masterlock_acquire (busy = 1) */
   st_masterlock *m = Thread_lock(Caml_state->id);
-  m->init = 0; /* force reinitialization */
+  m->init = false; /* force reinitialization */
   /* Note: initializing an already-initialized mutex and cond variable
      is UB (especially mutexes that are locked). This is best
      effort. */

--- a/otherlibs/systhreads/st_stubs.c
+++ b/otherlibs/systhreads/st_stubs.c
@@ -52,8 +52,6 @@
 #include "caml/sys.h"
 #include "caml/memprof.h"
 
-#include "../../runtime/sync_posix.h"
-
 /* "caml/threads.h" is *not* included since it contains the _external_
    declarations for the caml_c_thread_register and caml_c_thread_unregister
    functions. */
@@ -498,7 +496,7 @@ static void caml_thread_domain_initialize_hook(void)
   st_initialize();
 
   int ret = st_masterlock_init(Thread_lock(Caml_state->id));
-  sync_check_error(ret, "caml_thread_domain_initialize_hook");
+  caml_check_error(ret, "caml_thread_domain_initialize_hook");
 
   new_thread =
     (caml_thread_t) caml_stat_alloc(sizeof(struct caml_thread_struct));
@@ -696,7 +694,7 @@ CAMLprim value caml_thread_new(value clos)
      Because of PR#4666, we start the tick thread late, only when we create
      the first additional thread in the current process */
   st_retcode err = create_tick_thread();
-  sync_check_error(err, "Thread.create");
+  caml_check_error(err, "Thread.create");
 
   /* Create a thread info block */
   caml_thread_t th = thread_alloc_and_add();
@@ -708,7 +706,7 @@ CAMLprim value caml_thread_new(value clos)
   if (err != 0) {
     /* Creation failed, remove thread info block from list of threads */
     caml_thread_remove_and_free(th);
-    sync_check_error(err, "Thread.create");
+    caml_check_error(err, "Thread.create");
   }
 
   CAMLreturn(th->descr);
@@ -836,7 +834,7 @@ CAMLprim value caml_thread_yield(value unit)
 CAMLprim value caml_thread_join(value th)
 {
   st_retcode rc = caml_threadstatus_wait(Terminated(th));
-  sync_check_error(rc, "Thread.join");
+  caml_check_error(rc, "Thread.join");
   return Val_unit;
 }
 
@@ -871,7 +869,7 @@ static value caml_threadstatus_new (void)
 {
   st_event ts = NULL;           /* suppress warning */
   value wrapper;
-  sync_check_error(st_event_create(&ts), "Thread.create");
+  caml_check_error(st_event_create(&ts), "Thread.create");
   wrapper = caml_alloc_custom(&caml_threadstatus_ops,
                               sizeof(st_event *),
                               0, 1);

--- a/runtime/caml/fail.h
+++ b/runtime/caml/fail.h
@@ -73,6 +73,9 @@ struct caml_exception_context {
 
 int caml_is_special_exception(value exn);
 
+/* from runtime/sync.c */
+CAMLextern void caml_check_error(int err, char const * msg);
+
 #endif /* CAML_INTERNALS */
 
 #ifdef __cplusplus

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -112,8 +112,8 @@ static_assert(
    When the main C-stack for a domain enters a blocking call,
    a 'backup thread' becomes responsible for servicing the STW
    sections on behalf of the domain. Care is needed to hand off duties
-   for servicing STW sections between the main pthread and the backup
-   pthread when caml_enter_blocking_section and
+   for servicing STW sections between the main thread and the backup
+   thread when caml_enter_blocking_section and
    caml_leave_blocking_section are called.
 
    When the state for the backup thread is BT_IN_BLOCKING_SECTION
@@ -125,26 +125,26 @@ static_assert(
            BT_INIT  <---------------------------------------+
               |                                             |
    (install_backup_thread)                                  |
-       [main pthread]                                       |
+       [main thread]                                        |
               |                                             |
               v                                             |
        BT_ENTERING_OCAML  <-----------------+               |
               |                             |               |
 (caml_enter_blocking_section)               |               |
-       [main pthread]                       |               |
+        [main thread]                       |               |
               |                             |               |
               |                             |               |
               |               (caml_leave_blocking_section) |
-              |                      [main pthread]         |
+              |                       [main thread]         |
               v                             |               |
     BT_IN_BLOCKING_SECTION  ----------------+               |
               |                                             |
      (domain_terminate)                                     |
-       [main pthread]                                       |
+        [main thread]                                       |
               |                                             |
               v                                             |
         BT_TERMINATE                               (backup_thread_func)
-              |                                      [backup pthread]
+              |                                      [backup thread]
               |                                             |
               +---------------------------------------------+
 

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -1121,13 +1121,12 @@ static void install_backup_thread (dom_internal* di)
 
     atomic_store_release(&di->backup_thread_msg, BT_ENTERING_OCAML);
     err = pthread_create(&di->backup_thread, 0, backup_thread_func, (void*)di);
+    caml_check_error(err, "failed to create domain backup thread");
 
 #ifndef _WIN32
     pthread_sigmask(SIG_SETMASK, &old_mask, NULL);
 #endif
 
-    if (err != 0)
-      caml_check_error(err, "failed to create domain backup thread");
     di->backup_thread_running = 1;
     pthread_detach(di->backup_thread);
   }
@@ -1292,10 +1291,7 @@ CAMLprim value caml_domain_spawn(value callback, value term_sync)
   init_domain_ml_values(p.ml_values, callback, term_sync);
 
   err = pthread_create(&th, 0, domain_thread_func, (void*)&p);
-
-  if (err) {
-    caml_check_error(err, "failed to create domain thread: pthread_create");
-  }
+  caml_check_error(err, "failed to create domain thread: pthread_create");
 
   /* While waiting for the child thread to start up, we need to service any
      stop-the-world requests as they come in. */

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -1126,8 +1126,8 @@ static void install_backup_thread (dom_internal* di)
     pthread_sigmask(SIG_SETMASK, &old_mask, NULL);
 #endif
 
-    if (err)
-      caml_failwith("failed to create domain backup thread");
+    if (err != 0)
+      caml_check_error(err, "failed to create domain backup thread");
     di->backup_thread_running = 1;
     pthread_detach(di->backup_thread);
   }
@@ -1294,7 +1294,7 @@ CAMLprim value caml_domain_spawn(value callback, value term_sync)
   err = pthread_create(&th, 0, domain_thread_func, (void*)&p);
 
   if (err) {
-    caml_failwith("failed to create domain thread");
+    caml_check_error(err, "failed to create domain thread: pthread_create");
   }
 
   /* While waiting for the child thread to start up, we need to service any

--- a/runtime/frame_descriptors.c
+++ b/runtime/frame_descriptors.c
@@ -237,7 +237,7 @@ static void add_frame_descriptors(
 
 /* protected by STW sections */
 static caml_frame_descrs current_frame_descrs =
-  { 0, -1, NULL, NULL, NULL, PTHREAD_MUTEX_INITIALIZER };
+  { 0, -1, NULL, NULL, NULL, CAML_PLAT_MUTEX_INITIALIZER };
 
 static caml_frametable_list *cons(
   intnat *frametable, caml_frametable_list *tl)

--- a/runtime/platform.c
+++ b/runtime/platform.c
@@ -79,7 +79,9 @@ void caml_plat_assert_locked(caml_plat_mutex* m)
 #endif
 }
 
+#ifdef DEBUG
 CAMLexport CAMLthread_local int caml_lockdepth = 0;
+#endif
 
 void caml_plat_assert_all_locks_unlocked(void)
 {

--- a/runtime/sync.c
+++ b/runtime/sync.c
@@ -29,9 +29,25 @@
 /* System-dependent part */
 #include "sync_posix.h"
 
+/* Reporting errors */
+
 CAMLexport void caml_check_error(int retcode, char const * msg)
 {
-  sync_check_error(retcode, msg);
+  char const * err;
+  char buf[1024];
+  int errlen, msglen;
+  value str;
+
+  if (retcode == 0) return;
+  if (retcode == ENOMEM) caml_raise_out_of_memory();
+  err = caml_strerror(retcode, buf, sizeof(buf));
+  msglen = strlen(msg);
+  errlen = strlen(err);
+  str = caml_alloc_string(msglen + 2 + errlen);
+  memcpy(&Byte(str, 0), msg, msglen);
+  memcpy(&Byte(str, msglen), ": ", 2);
+  memcpy(&Byte(str, msglen + 2), err, errlen);
+  caml_raise_sys_error(str);
 }
 
 /* Mutex operations */

--- a/runtime/sync.c
+++ b/runtime/sync.c
@@ -29,6 +29,11 @@
 /* System-dependent part */
 #include "sync_posix.h"
 
+CAMLexport void caml_check_error(int retcode, char const * msg)
+{
+  sync_check_error(retcode, msg);
+}
+
 /* Mutex operations */
 
 static void caml_mutex_finalize(value wrapper)
@@ -74,7 +79,7 @@ CAMLprim value caml_ml_mutex_new(value unit)
   sync_mutex mut = NULL;
   value wrapper;
 
-  sync_check_error(sync_mutex_create(&mut), "Mutex.create");
+  caml_check_error(sync_mutex_create(&mut), "Mutex.create");
   wrapper = caml_alloc_custom(&caml_mutex_ops, sizeof(pthread_mutex_t *),
                               0, 1);
   Mutex_val(wrapper) = mut;
@@ -93,7 +98,7 @@ CAMLprim value caml_ml_mutex_lock(value wrapper)
     caml_enter_blocking_section();
     retcode = sync_mutex_lock(mut);
     caml_leave_blocking_section();
-    sync_check_error(retcode, "Mutex.lock");
+    caml_check_error(retcode, "Mutex.lock");
   }
   CAMLreturn(Val_unit);
 }
@@ -104,7 +109,7 @@ CAMLprim value caml_ml_mutex_unlock(value wrapper)
   sync_mutex mut = Mutex_val(wrapper);
   /* PR#4351: no need to release and reacquire master lock */
   retcode = sync_mutex_unlock(mut);
-  sync_check_error(retcode, "Mutex.unlock");
+  caml_check_error(retcode, "Mutex.unlock");
   return Val_unit;
 }
 
@@ -114,7 +119,7 @@ CAMLprim value caml_ml_mutex_try_lock(value wrapper)
   sync_retcode retcode;
   retcode = sync_mutex_trylock(mut);
   if (retcode == MUTEX_ALREADY_LOCKED) return Val_false;
-  sync_check_error(retcode, "Mutex.try_lock");
+  caml_check_error(retcode, "Mutex.try_lock");
   return Val_true;
 }
 
@@ -153,7 +158,7 @@ CAMLprim value caml_ml_condition_new(value unit)
   value wrapper;
   sync_condvar cond = NULL;
 
-  sync_check_error(sync_condvar_create(&cond), "Condition.create");
+  caml_check_error(sync_condvar_create(&cond), "Condition.create");
   wrapper = caml_alloc_custom(&caml_condition_ops, sizeof(sync_condvar *),
                               0, 1);
   Condition_val(wrapper) = cond;
@@ -171,7 +176,7 @@ CAMLprim value caml_ml_condition_wait(value wcond, value wmut)
   caml_enter_blocking_section();
   retcode = sync_condvar_wait(cond, mut);
   caml_leave_blocking_section();
-  sync_check_error(retcode, "Condition.wait");
+  caml_check_error(retcode, "Condition.wait");
   CAML_EV_END(EV_DOMAIN_CONDITION_WAIT);
 
   CAMLreturn(Val_unit);
@@ -179,14 +184,14 @@ CAMLprim value caml_ml_condition_wait(value wcond, value wmut)
 
 CAMLprim value caml_ml_condition_signal(value wrapper)
 {
-  sync_check_error(sync_condvar_signal(Condition_val(wrapper)),
+  caml_check_error(sync_condvar_signal(Condition_val(wrapper)),
                  "Condition.signal");
   return Val_unit;
 }
 
 CAMLprim value caml_ml_condition_broadcast(value wrapper)
 {
-  sync_check_error(sync_condvar_broadcast(Condition_val(wrapper)),
+  caml_check_error(sync_condvar_broadcast(Condition_val(wrapper)),
                  "Condition.broadcast");
   return Val_unit;
 }

--- a/runtime/sync.c
+++ b/runtime/sync.c
@@ -96,7 +96,7 @@ CAMLprim value caml_ml_mutex_new(value unit)
   value wrapper;
 
   caml_check_error(sync_mutex_create(&mut), "Mutex.create");
-  wrapper = caml_alloc_custom(&caml_mutex_ops, sizeof(pthread_mutex_t *),
+  wrapper = caml_alloc_custom(&caml_mutex_ops, sizeof(sync_mutex *),
                               0, 1);
   Mutex_val(wrapper) = mut;
   return wrapper;

--- a/runtime/sync_posix.h
+++ b/runtime/sync_posix.h
@@ -116,25 +116,4 @@ Caml_inline int sync_condvar_wait(sync_condvar c, sync_mutex m)
   return pthread_cond_wait(c, m);
 }
 
-/* Reporting errors */
-
-static void sync_check_error(int retcode, char * msg)
-{
-  char * err;
-  char buf[1024];
-  int errlen, msglen;
-  value str;
-
-  if (retcode == 0) return;
-  if (retcode == ENOMEM) caml_raise_out_of_memory();
-  err = caml_strerror(retcode, buf, sizeof(buf));
-  msglen = strlen(msg);
-  errlen = strlen(err);
-  str = caml_alloc_string(msglen + 2 + errlen);
-  memcpy (&Byte(str, 0), msg, msglen);
-  memcpy (&Byte(str, msglen), ": ", 2);
-  memcpy (&Byte(str, msglen + 2), err, errlen);
-  caml_raise_sys_error(str);
-}
-
 #endif /* CAML_SYNC_POSIX_H */


### PR DESCRIPTION
While working on replacing winpthreads (the pthreads emulation layer on Windows) with direct use of the WinAPI concurrency primitives, I've gathered a few refactors and cleanups on systhreads and the runtime.
The end goal is to share common code between platforms using pthreads and Windows, and have platform specific code in different files. As it doesn't make much sense to have `st_pthreads.h` and `st_posix.h` I'm removing `st_pthreads.h` and inlining relevant code in either `st_posix.h` or `st_win32.h`, and introducing a new `st_stubs.h` for common code.
I'm opening this PR now because it mildly conflicts with #12410 and #13348, and I don't enjoy dealing with conflicts too much (but yay for `git rerere`), so better now than later? (of course if they get merged first, I'll rebase this PR).