### PR TITLE
Use and support -fvisibility=hidden

### DIFF
--- a/.github/workflows/build-msvc.yml
+++ b/.github/workflows/build-msvc.yml
@@ -121,7 +121,7 @@ jobs:
       - name: Assemble backend with MinGW GASM and compare
         shell: bash
         run: >-
-          x86_64-w64-mingw32-gcc -c -I./runtime  -I ./flexdll -D__USE_MINGW_ANSI_STDIO=0 -DUNICODE -D_UNICODE -DWINDOWS_UNICODE=1 -DCAMLDLLIMPORT= -DIN_CAML_RUNTIME -DNATIVE_CODE -DTARGET_amd64 -DMODEL_default -DSYS_mingw64 -o runtime/amd64.o runtime/amd64.S ;
+          x86_64-w64-mingw32-gcc -c -I./runtime  -I ./flexdll -D__USE_MINGW_ANSI_STDIO=0 -DUNICODE -D_UNICODE -DWINDOWS_UNICODE=1 -DCAMLDLLIMPORT= -DCAML_IN_RUNTIME -DNATIVE_CODE -DTARGET_amd64 -DMODEL_default -DSYS_mingw64 -o runtime/amd64.o runtime/amd64.S ;
           dumpbin /disasm:nobytes runtime/amd64nt.obj > runtime/amd64nt.dump ;
           awk -f tools/ci/actions/canonicalize-dumpbin.awk runtime/amd64nt.dump runtime/amd64nt.dump > runtime/amd64nt.canonical ;
           dumpbin /disasm:nobytes runtime/amd64.o > runtime/amd64.dump ;

--- a/Changes
+++ b/Changes
@@ -467,6 +467,10 @@ OCaml 5.3.0 (8 January 2025)
 
 ### Runtime system:
 
+* #13359: Only explicitly annotated symbols are exported from the OCaml runtime.
+  Additionally, C primitives can be built with -fvisibilty=hidden.  The use of
+  CAMLprim is now required in this case.
+
 - #13419: Fix memory bugs in runtime events system.
   (B. Szilvasy and Nick Barnes, review by Miod Vallat, Nick Barnes,
    Tim McGilchrist, and Gabriel Scherer)

--- a/Makefile
+++ b/Makefile
@@ -1335,7 +1335,7 @@ libcomprmarsh_OBJECTS = runtime/zstd.npic.$(O)
 
 ## General (non target-specific) assembler and compiler flags
 
-runtime_CPPFLAGS = -DCAMLDLLIMPORT= -DIN_CAML_RUNTIME
+runtime_CPPFLAGS = -DCAML_IN_RUNTIME
 ocamlrun_CPPFLAGS = $(runtime_CPPFLAGS)
 ocamlrund_CPPFLAGS = $(runtime_CPPFLAGS) -DDEBUG
 ocamlruni_CPPFLAGS = $(runtime_CPPFLAGS) -DCAML_INSTR

--- a/configure
+++ b/configure
@@ -15222,13 +15222,14 @@ esac
 case $ocaml_cc_vendor in #(
   clang-*) :
     common_cflags="-O2 -fno-strict-aliasing -fwrapv";
-    internal_cflags="$cc_warnings -fno-common" ;; #(
+    internal_cflags="$cc_warnings -fno-common -fvisibility=hidden" ;; #(
   *gcc-[0123]-*|*gcc-4-[0-8]) :
     # No C11 support
     as_fn_error 69 "This version of GCC is too old. Please use GCC version 4.9 or above." "$LINENO" 5 ;; #(
   gcc-*) :
     common_cflags="-O2 -fno-strict-aliasing -fwrapv";
     internal_cflags="$cc_warnings -fno-common -fexcess-precision=standard \
+-fvisibility=hidden \
 -Wvla" ;; #(
   mingw-*-*-gcc-*) :
     internal_cflags="-Wno-unused $cc_warnings \

--- a/configure.ac
+++ b/configure.ac
@@ -949,7 +949,7 @@ AS_CASE([$target],
 AS_CASE([$ocaml_cc_vendor],
   [clang-*],
     [common_cflags="-O2 -fno-strict-aliasing -fwrapv";
-    internal_cflags="$cc_warnings -fno-common"],
+    internal_cflags="$cc_warnings -fno-common -fvisibility=hidden"],
   [*gcc-[[0123]]-*|*gcc-4-[[0-8]]],
     # No C11 support
     [AC_MSG_ERROR(m4_normalize([This version of GCC is too old.
@@ -957,6 +957,7 @@ AS_CASE([$ocaml_cc_vendor],
   [gcc-*],
     [common_cflags="-O2 -fno-strict-aliasing -fwrapv";
     internal_cflags="$cc_warnings -fno-common -fexcess-precision=standard \
+-fvisibility=hidden \
 -Wvla"],
   [mingw-*-*-gcc-*],
     [internal_cflags="-Wno-unused $cc_warnings \

--- a/runtime/backtrace_byt.c
+++ b/runtime/backtrace_byt.c
@@ -260,7 +260,7 @@ int caml_alloc_backtrace_buffer (void)
   return 0;
 }
 
-void caml_free_backtrace_buffer(backtrace_slot *backtrace_buffer) {
+CAMLexport void caml_free_backtrace_buffer(backtrace_slot *backtrace_buffer) {
   if (backtrace_buffer != NULL)
     caml_stat_free(backtrace_buffer);
 }
@@ -298,7 +298,7 @@ void caml_stash_backtrace(value exn, value * sp, int reraise)
    updates *sp to point to the following one, and *trap_spoff to the next
    trap frame, which we will skip when we reach it  */
 
-code_t caml_next_frame_pointer(value* stack_high, value ** sp,
+static code_t caml_next_frame_pointer(value* stack_high, value ** sp,
                           intnat * trap_spoff)
 {
   while (*sp < stack_high) {
@@ -515,12 +515,12 @@ CAMLexport void caml_load_main_debug_info(void)
   }
 }
 
-int caml_debug_info_available(void)
+CAMLexport int caml_debug_info_available(void)
 {
   return (caml_debug_info.size != 0);
 }
 
-int caml_debug_info_status(void)
+CAMLexport int caml_debug_info_status(void)
 {
   if (!caml_debug_info_available()) {
     return 0;
@@ -576,7 +576,7 @@ struct ev_info * caml_exact_event_for_location(code_t pc)
 
 /* Extract location information for the given PC */
 
-void caml_debuginfo_location(debuginfo dbg,
+CAMLexport void caml_debuginfo_location(debuginfo dbg,
                              /*out*/ struct caml_loc_info * li)
 {
   code_t pc = dbg;
@@ -599,12 +599,12 @@ void caml_debuginfo_location(debuginfo dbg,
   li->loc_end_offset = event->ev_end_offset;
 }
 
-debuginfo caml_debuginfo_extract(backtrace_slot slot)
+CAMLexport debuginfo caml_debuginfo_extract(backtrace_slot slot)
 {
   return (debuginfo)slot;
 }
 
-debuginfo caml_debuginfo_next(debuginfo dbg)
+CAMLexport debuginfo caml_debuginfo_next(debuginfo dbg)
 {
   /* No inlining in bytecode */
   return NULL;

--- a/runtime/backtrace_nat.c
+++ b/runtime/backtrace_nat.c
@@ -69,7 +69,7 @@ frame_descr * caml_next_frame_descriptor
   }
 }
 
-int caml_alloc_backtrace_buffer(void){
+CAMLexport int caml_alloc_backtrace_buffer(void){
   CAMLassert(Caml_state->backtrace_pos == 0);
   Caml_state->backtrace_buffer =
     caml_stat_alloc_noexc(BACKTRACE_BUFFER_SIZE * sizeof(backtrace_slot));
@@ -77,7 +77,7 @@ int caml_alloc_backtrace_buffer(void){
   return 0;
 }
 
-void caml_free_backtrace_buffer(backtrace_slot *backtrace_buffer) {
+CAMLexport void caml_free_backtrace_buffer(backtrace_slot *backtrace_buffer) {
   if (backtrace_buffer != NULL)
     caml_stat_free(backtrace_buffer);
 }
@@ -101,7 +101,8 @@ static debuginfo debuginfo_extract(frame_descr *d, ptrdiff_t alloc_idx);
    TODO: Consider rewriting this to use get_callstack, so we only have
    one body of code capturing callstacks.
 */
-void caml_stash_backtrace(value exn, uintnat pc, char * sp, const char* trapsp)
+CAMLexport void
+caml_stash_backtrace(value exn, uintnat pc, char * sp, const char* trapsp)
 {
   caml_domain_state* domain_state = Caml_state;
   caml_frame_descrs* fds;
@@ -202,7 +203,7 @@ static size_t get_callstack(struct stack_info* stack, intnat max_slots,
  * allocation point and may therefore include an initial entry of the
  * allocation point itself.
  */
-
+CAMLexport
 size_t caml_get_callstack(size_t max_slots,
                           backtrace_slot **buffer_p,
                           size_t *alloc_size_p,
@@ -306,6 +307,7 @@ static debuginfo debuginfo_extract(frame_descr *d, ptrdiff_t alloc_idx)
   return (debuginfo)(infoptr + debuginfo_offset);
 }
 
+CAMLexport
 debuginfo caml_debuginfo_extract(backtrace_slot slot)
 {
   if (Slot_is_debuginfo(slot)) {
@@ -316,6 +318,7 @@ debuginfo caml_debuginfo_extract(backtrace_slot slot)
   }
 }
 
+CAMLexport
 debuginfo caml_debuginfo_next(debuginfo dbg)
 {
   uint32_t * infoptr;
@@ -350,7 +353,8 @@ struct name_and_loc_info {
 };
 
 /* Extract location information for the given frame descriptor */
-void caml_debuginfo_location(debuginfo dbg, /*out*/ struct caml_loc_info * li)
+CAMLexport void
+caml_debuginfo_location(debuginfo dbg, /*out*/ struct caml_loc_info * li)
 {
   uint32_t info1, info2;
 
@@ -417,22 +421,24 @@ void caml_debuginfo_location(debuginfo dbg, /*out*/ struct caml_loc_info * li)
   }
 }
 
-value caml_add_debug_info(backtrace_slot start, value size, value events)
+CAMLexport value
+caml_add_debug_info(backtrace_slot start, value size, value events)
 {
   return Val_unit;
 }
 
-value caml_remove_debug_info(backtrace_slot start)
+CAMLexport value
+caml_remove_debug_info(backtrace_slot start)
 {
   return Val_unit;
 }
 
-int caml_debug_info_available(void)
+CAMLexport int caml_debug_info_available(void)
 {
   return 1;
 }
 
-int caml_debug_info_status(void)
+CAMLexport int caml_debug_info_status(void)
 {
   return 1;
 }

--- a/runtime/bigarray.c
+++ b/runtime/bigarray.c
@@ -923,7 +923,7 @@ CAMLprim value caml_ba_set_3(value vb, value vind1, value vind2, value vind3,
   return caml_ba_set_aux(vb, vind, 3, newval);
 }
 
-value caml_ba_set_N(value vb, value * vind, int nargs)
+CAMLexport value caml_ba_set_N(value vb, value * vind, int nargs)
 {
   return caml_ba_set_aux(vb, vind, nargs - 1, vind[nargs - 1]);
 }

--- a/runtime/callback.c
+++ b/runtime/callback.c
@@ -85,7 +85,7 @@ Caml_inline void restore_stack_parent(caml_domain_state* domain_state,
 
 static opcode_t callback_code[] = { STOP };
 
-void caml_init_callbacks(void)
+CAMLexport void caml_init_callbacks(void)
 {
   caml_register_code_fragment((char *) callback_code,
                               (char *) callback_code + sizeof(callback_code),

--- a/runtime/caml/addrmap.h
+++ b/runtime/caml/addrmap.h
@@ -14,6 +14,7 @@
 
 #ifndef CAML_ADDRMAP_H
 #define CAML_ADDRMAP_H
+#include "mlvalues.h"
 
 #include "mlvalues.h"
 

--- a/runtime/caml/domain_state.h
+++ b/runtime/caml/domain_state.h
@@ -46,7 +46,7 @@ enum {
 
 #define LAST_DOMAIN_STATE_MEMBER extra_params
 
-#if defined(HAS_FULL_THREAD_VARIABLES) || defined(IN_CAML_RUNTIME)
+#if defined(HAS_FULL_THREAD_VARIABLES) || defined(CAML_IN_RUNTIME)
   CAMLextern CAMLthread_local caml_domain_state* caml_state;
   #define Caml_state_opt caml_state
 #else

--- a/runtime/caml/misc.h
+++ b/runtime/caml/misc.h
@@ -120,19 +120,30 @@ CAMLdeprecated_typedef(addr, char *);
   #define Caml_noinline
 #endif
 
-/* Export control (to mark primitives and to handle Windows DLL) */
-
-#ifndef CAMLDLLIMPORT
-  #if defined(SUPPORT_DYNAMIC_LINKING) && defined(ARCH_SIXTYFOUR) \
-      && (defined(__CYGWIN__) || defined(__MINGW32__))
-    #define CAMLDLLIMPORT __declspec(dllimport)
+/* Export control (to mark primitives and to handle Windows DLLs and
+ * ELF visibility) */
+#if (defined(__CYGWIN__) || defined(__MINGW32__))
+  #if defined(SUPPORT_DYNAMIC_LINKING) && defined(ARCH_SIXTYFOUR)
+    #ifdef CAML_IN_RUNTIME
+      #define CAMLDLLIMPORT
+    #else
+      #define CAMLDLLIMPORT __declspec(dllimport)
+    #endif
+    #define CAMLexport __declspec(dllexport)
   #else
+    #define CAMLexport
     #define CAMLDLLIMPORT
   #endif
+#elif defined(__GNUC__) && __GNUC__ >= 4 && \
+    (defined (__ELF__) || defined(__APPLE__))
+  #define CAMLexport __attribute__((visibility("default")))
+  #define CAMLDLLIMPORT __attribute__((visibility("default")))
+#else
+  #define CAMLexport
+  #define CAMLDLLIMPORT
 #endif
 
-#define CAMLexport
-#define CAMLprim
+#define CAMLprim CAMLexport
 #define CAMLextern CAMLDLLIMPORT extern
 
 /* Weak function definitions that can be overridden by external libs */

--- a/runtime/clambda_checks.c
+++ b/runtime/clambda_checks.c
@@ -21,7 +21,7 @@
 
 #include "caml/mlvalues.h"
 
-value caml_check_value_is_closure(value v, value v_descr)
+CAMLprim value caml_check_value_is_closure(value v, value v_descr)
 {
   const char* descr = String_val(v_descr);
   value orig_v = v;
@@ -52,7 +52,7 @@ value caml_check_value_is_closure(value v, value v_descr)
   return orig_v;
 }
 
-value caml_check_field_access(value v, value pos, value v_descr)
+CAMLprim value caml_check_field_access(value v, value pos, value v_descr)
 {
   const char* descr = String_val(v_descr);
   value orig_v = v;

--- a/runtime/codefrag.c
+++ b/runtime/codefrag.c
@@ -39,11 +39,12 @@ static struct lf_skiplist code_fragments_by_num;
 
 static int _Atomic code_fragments_counter = 1;
 
-void caml_init_codefrag(void) {
+CAMLexport void caml_init_codefrag(void) {
   caml_lf_skiplist_init(&code_fragments_by_pc);
   caml_lf_skiplist_init(&code_fragments_by_num);
 }
 
+CAMLexport
 int caml_register_code_fragment(char *start, char *end,
                                 enum digest_status digest_kind,
                                 unsigned char *opt_digest) {
@@ -80,7 +81,7 @@ static void caml_free_code_fragment(struct code_fragment *cf) {
   caml_stat_free(cf);
 }
 
-void caml_remove_code_fragment(struct code_fragment *cf) {
+CAMLexport void caml_remove_code_fragment(struct code_fragment *cf) {
   struct code_fragment_garbage *cf_cell;
 
   caml_lf_skiplist_remove(&code_fragments_by_pc, (uintnat)cf->code_start);

--- a/runtime/debugger.c
+++ b/runtime/debugger.c
@@ -34,9 +34,9 @@
 #include "caml/skiplist.h"
 #include "caml/sys.h"
 
-int caml_debugger_in_use = 0;
+CAMLexport int caml_debugger_in_use = 0;
 uintnat caml_event_count;
-int caml_debugger_fork_mode = 1; /* parent by default */
+CAMLexport int caml_debugger_fork_mode = 1; /* parent by default */
 #if !defined(HAS_SOCKETS) || defined(NATIVE_CODE)
 
 void caml_debugger_init(void)

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -996,7 +996,7 @@ void caml_init_domains(uintnat max_domains, uintnat minor_heap_wsz)
   caml_init_signal_handling();
 }
 
-void caml_init_domain_self(int domain_id) {
+CAMLexport void caml_init_domain_self(int domain_id) {
   CAMLassert(0 <= domain_id);
   CAMLassert(domain_id < caml_params->max_domains);
   domain_self = &all_domains[domain_id];
@@ -1753,7 +1753,7 @@ int caml_try_run_on_all_domains_async(
                                                  leader_setup, 0, 0);
 }
 
-void caml_interrupt_self(void)
+CAMLexport void caml_interrupt_self(void)
 {
   interrupt_domain_local(Caml_state);
 }
@@ -1761,7 +1761,7 @@ void caml_interrupt_self(void)
 /*  This function is async-signal-safe as [all_domains] and
     [caml_params->max_domains] are set before signal handlers are installed and
     do not change afterwards. */
-void caml_interrupt_all_signal_safe(void)
+CAMLexport void caml_interrupt_all_signal_safe(void)
 {
   for (dom_internal *d = all_domains;
        d < &all_domains[caml_params->max_domains];

--- a/runtime/fiber.c
+++ b/runtime/fiber.c
@@ -54,7 +54,7 @@ static_assert(sizeof(struct stack_info) == Stack_ctx_words * sizeof(value), "");
 
 static _Atomic int64_t fiber_id = 0;
 
-uintnat caml_get_init_stack_wsize (void)
+CAMLexport uintnat caml_get_init_stack_wsize (void)
 {
   uintnat default_stack_wsize = Wsize_bsize(Stack_init_bsize);
   uintnat stack_wsize;
@@ -67,7 +67,7 @@ uintnat caml_get_init_stack_wsize (void)
   return stack_wsize;
 }
 
-void caml_change_max_stack_size (uintnat new_max_wsize)
+CAMLexport void caml_change_max_stack_size (uintnat new_max_wsize)
 {
   struct stack_info *current_stack = Caml_state->current_stack;
   asize_t wsize = Stack_high(current_stack) - (value*)current_stack->sp
@@ -209,7 +209,7 @@ alloc_size_class_stack_noexc(mlsize_t wosize, int cache_bucket, value hval,
 }
 
 /* allocate a stack with at least "wosize" usable words of stack */
-struct stack_info*
+CAMLexport struct stack_info*
 caml_alloc_stack_noexc(mlsize_t wosize, value hval, value hexn, value heff,
                        int64_t id)
 {
@@ -220,7 +220,7 @@ caml_alloc_stack_noexc(mlsize_t wosize, value hval, value hexn, value heff,
 
 #ifdef NATIVE_CODE
 
-value caml_alloc_stack (value hval, value hexn, value heff) {
+CAMLprim value caml_alloc_stack (value hval, value hexn, value heff) {
   const int64_t id = atomic_fetch_add(&fiber_id, 1);
   struct stack_info* stack =
     alloc_size_class_stack_noexc(caml_fiber_wsz, 0 /* first bucket */,
@@ -235,7 +235,7 @@ value caml_alloc_stack (value hval, value hexn, value heff) {
 }
 
 
-void caml_get_stack_sp_pc (struct stack_info* stack,
+CAMLprim void caml_get_stack_sp_pc (struct stack_info* stack,
                            char** sp /* out */, uintnat* pc /* out */)
 {
   char* p = (char*)stack->sp;
@@ -293,7 +293,7 @@ next_chunk:
   }
 }
 
-void caml_scan_stack(
+CAMLexport void caml_scan_stack(
   scanning_action f, scanning_action_flags fflags, void* fdata,
   struct stack_info* stack, value* gc_regs)
 {
@@ -308,7 +308,7 @@ void caml_scan_stack(
   }
 }
 
-void caml_maybe_expand_stack (void)
+CAMLexport void caml_maybe_expand_stack (void)
 {
   struct stack_info* stk = Caml_state->current_stack;
   uintnat stack_available =
@@ -332,7 +332,7 @@ void caml_maybe_expand_stack (void)
 
 #else /* End NATIVE_CODE, begin BYTE_CODE */
 
-value caml_global_data = Val_unit;
+CAMLexport value caml_global_data = Val_unit;
 
 CAMLprim value caml_alloc_stack(value hval, value hexn, value heff)
 {
@@ -418,7 +418,7 @@ void caml_scan_stack(
 
 #ifdef NATIVE_CODE
 /* Update absolute exception pointers for new stack*/
-void caml_rewrite_exception_stack(struct stack_info *old_stack,
+CAMLexport void caml_rewrite_exception_stack(struct stack_info *old_stack,
                                   value** exn_ptr, struct stack_info *new_stack)
 {
   fiber_debug_log("Old [%p, %p]", Stack_base(old_stack), Stack_high(old_stack));
@@ -447,7 +447,7 @@ void caml_rewrite_exception_stack(struct stack_info *old_stack,
 }
 #endif
 
-int caml_try_realloc_stack(asize_t required_space)
+CAMLexport int caml_try_realloc_stack(asize_t required_space)
 {
   struct stack_info *old_stack, *new_stack;
   asize_t wsize;
@@ -530,7 +530,7 @@ int caml_try_realloc_stack(asize_t required_space)
   return 1;
 }
 
-struct stack_info* caml_alloc_main_stack (uintnat init_wsize)
+CAMLexport struct stack_info* caml_alloc_main_stack (uintnat init_wsize)
 {
   const int64_t id = atomic_fetch_add(&fiber_id, 1);
   struct stack_info* stk =
@@ -538,7 +538,7 @@ struct stack_info* caml_alloc_main_stack (uintnat init_wsize)
   return stk;
 }
 
-void caml_free_stack (struct stack_info* stack)
+CAMLexport void caml_free_stack (struct stack_info* stack)
 {
   CAMLnoalloc;
   struct stack_info** cache = Caml_state->stack_cache;
@@ -565,7 +565,7 @@ void caml_free_stack (struct stack_info* stack)
   }
 }
 
-void caml_free_gc_regs_buckets(value *gc_regs_buckets)
+CAMLexport void caml_free_gc_regs_buckets(value *gc_regs_buckets)
 {
   while (gc_regs_buckets != NULL) {
     value *next = (value*)gc_regs_buckets[0];
@@ -632,7 +632,7 @@ CAMLprim value caml_continuation_use_and_update_handler_noexc
   return stack;
 }
 
-void caml_continuation_replace(value cont, struct stack_info* stk)
+CAMLexport void caml_continuation_replace(value cont, struct stack_info* stk)
 {
   value n = Val_ptr(NULL);
   int b = atomic_compare_exchange_strong(Op_atomic_val(cont), &n, Val_ptr(stk));
@@ -667,7 +667,7 @@ CAMLexport void caml_raise_continuation_already_resumed(void)
   caml_raise(*exn);
 }
 
-value caml_make_unhandled_effect_exn (value effect)
+CAMLprim value caml_make_unhandled_effect_exn (value effect)
 {
   CAMLparam1(effect);
   value res;

--- a/runtime/misc.c
+++ b/runtime/misc.c
@@ -272,6 +272,7 @@ int caml_runtime_warnings_active(void)
   return 1;
 }
 
+CAMLexport
 void caml_bad_caml_state(void)
 {
   caml_fatal_error("no domain lock held");

--- a/runtime/runtime_events.c
+++ b/runtime/runtime_events.c
@@ -182,7 +182,8 @@ static void runtime_events_teardown_from_stw_single(int remove_file) {
     atomic_store_release(&runtime_events_enabled, 0);
 }
 
-void caml_runtime_events_post_fork(void) {
+CAMLexport void
+caml_runtime_events_post_fork(void) {
   /* We are here in the child process after a call to fork (which can only
      happen when there is a single domain) and no mutator code that can spawn a
      new domain can have run yet. Let's be double sure. */
@@ -205,7 +206,8 @@ void caml_runtime_events_post_fork(void) {
    if runtime events are not enabled. This is used in the consumer to
    read the ring buffers of the current process. Always returns a
    freshly-allocated string. */
-char_os* caml_runtime_events_current_location(void) {
+CAMLexport char_os*
+caml_runtime_events_current_location(void) {
   if( atomic_load_acquire(&runtime_events_enabled) ) {
     return caml_stat_strdup_noexc_os(current_ring_loc);
   } else {
@@ -215,7 +217,8 @@ char_os* caml_runtime_events_current_location(void) {
 
 /* Write a lifecycle event and then trigger a stop the world to tear down the
   ring buffers */
-void caml_runtime_events_destroy(void) {
+CAMLexport void
+caml_runtime_events_destroy(void) {
   if (atomic_load_acquire(&runtime_events_enabled)) {
     write_to_ring(
       EV_RUNTIME, (ev_message_type){.runtime=EV_LIFECYCLE}, EV_RING_STOP, 0,
@@ -634,7 +637,7 @@ void caml_ev_counter(ev_runtime_counter counter, uint64_t val) {
   }
 }
 
-void caml_ev_lifecycle(ev_lifecycle lifecycle, int64_t data) {
+CAMLexport void caml_ev_lifecycle(ev_lifecycle lifecycle, int64_t data) {
   if ( ring_is_active() ) {
     write_to_ring(EV_RUNTIME, (ev_message_type){.runtime=EV_LIFECYCLE},
                   lifecycle, 1, (uint64_t *)&data, 0);

--- a/runtime/signals.c
+++ b/runtime/signals.c
@@ -216,7 +216,7 @@ CAMLexport void caml_leave_blocking_section(void)
 
 static value caml_signal_handlers;
 
-void caml_init_signal_handling(void) {
+CAMLexport void caml_init_signal_handling(void) {
   caml_signal_handlers = caml_alloc_shr(NSIG, 0);
   for (mlsize_t i = 0; i < NSIG; i++)
     Field(caml_signal_handlers, i) = Val_unit;
@@ -225,7 +225,7 @@ void caml_init_signal_handling(void) {
 
 /* Execute a signal handler immediately */
 
-caml_result caml_execute_signal_res(int signal_number)
+CAMLexport caml_result caml_execute_signal_res(int signal_number)
 {
 #ifdef POSIX_SIGNALS
   sigset_t nsigs, sigs;
@@ -247,7 +247,7 @@ caml_result caml_execute_signal_res(int signal_number)
 
 /* Arrange for a garbage collection to be performed as soon as possible */
 
-void caml_request_major_slice (int global)
+CAMLexport void caml_request_major_slice (int global)
 {
   if (global){
     Caml_state->requested_global_major_slice = 1;
@@ -257,7 +257,7 @@ void caml_request_major_slice (int global)
   caml_interrupt_self();
 }
 
-void caml_request_minor_gc (void)
+CAMLexport void caml_request_minor_gc (void)
 {
   Caml_state->requested_minor_gc = 1;
   caml_interrupt_self();
@@ -330,7 +330,7 @@ CAMLexport int caml_check_pending_actions(void)
   return check_pending_actions(Caml_state);
 }
 
-caml_result caml_do_pending_actions_res(void)
+CAMLexport caml_result caml_do_pending_actions_res(void)
 {
   /* 1. Non-delayable actions that do not run OCaml code. */
 
@@ -374,7 +374,7 @@ exception:
   return result;
 }
 
-caml_result caml_process_pending_actions_with_root_res(value root)
+CAMLexport caml_result caml_process_pending_actions_with_root_res(value root)
 {
   if (caml_check_pending_actions()) {
     CAMLparam1(root);
@@ -522,7 +522,7 @@ CAMLexport int caml_rev_convert_signal_number(int signo)
   return signo;
 }
 
-void * caml_init_signal_stack(void)
+CAMLexport void * caml_init_signal_stack(void)
 {
 #ifdef POSIX_SIGNALS
   stack_t stk;
@@ -558,7 +558,7 @@ void * caml_init_signal_stack(void)
 #endif /* POSIX_SIGNALS */
 }
 
-void caml_free_signal_stack(void * signal_stack)
+CAMLexport void caml_free_signal_stack(void * signal_stack)
 {
 #ifdef POSIX_SIGNALS
   stack_t stk, disable;
@@ -588,7 +588,7 @@ void caml_free_signal_stack(void * signal_stack)
 static void * caml_signal_stack_0 = NULL;
 #endif
 
-void caml_init_signals(void)
+CAMLexport void caml_init_signals(void)
 {
   /* Set up alternate signal stack for domain 0 */
 #ifdef POSIX_SIGNALS
@@ -614,7 +614,7 @@ void caml_init_signals(void)
 #endif
 }
 
-void caml_terminate_signals(void)
+CAMLexport void caml_terminate_signals(void)
 {
 #ifdef POSIX_SIGNALS
   caml_free_signal_stack(caml_signal_stack_0);

--- a/runtime/startup_aux.c
+++ b/runtime/startup_aux.c
@@ -41,7 +41,7 @@ extern void caml_win32_unregister_overflow_detection (void);
 /* Configuration parameters and flags */
 
 static struct caml_params params;
-const struct caml_params* const caml_params = &params;
+CAMLexport const struct caml_params* const caml_params = &params;
 
 static void init_startup_params(void)
 {

--- a/testsuite/tests/lib-dynlink-bytecode/stub1.c
+++ b/testsuite/tests/lib-dynlink-bytecode/stub1.c
@@ -18,7 +18,7 @@
 #include <caml/alloc.h>
 #include <stdio.h>
 
-value stub1(void) {
+CAMLprim value stub1(void) {
   CAMLparam0();
   CAMLlocal1(x);
   printf("This is stub1!\n"); fflush(stdout);

--- a/testsuite/tests/lib-dynlink-bytecode/stub2.c
+++ b/testsuite/tests/lib-dynlink-bytecode/stub2.c
@@ -20,7 +20,7 @@
 
 CAMLextern value stub1(void);
 
-value stub2(void) {
+CAMLprim value stub2(void) {
   printf("This is stub2, calling stub1:\n"); fflush(stdout);
   stub1();
   printf("Ok!\n"); fflush(stdout);


### PR DESCRIPTION
This uses ELF symbol visibility to hide symbols that are private to the runtime.  Furthermore, this allows building files containing primitive functions with -fvisibility=hidden, which is recommended practice for shared libraries.  As a result of this commit, CAMLprim is no longer a no-op.