### PR TITLE
Split runtime/array.c functions, use the new floatarray primitives in Float.Array

### DIFF
--- a/Changes
+++ b/Changes
@@ -398,6 +398,11 @@ _______________
   "user-friendly" functions in the `Printtyp` module.
   (Florian Angeletti, review by Gabriel Scherer)
 
+- #13361: split runtime/array.c functions to consistently expose
+  uniform_array and floatarray versions, use floatarray versions
+  in Float.Array.
+  (Gabriel Scherer, review by Nicolás Ojeda Bär)
+
 ### Build system:
 
 - #12909: Reorganise how MKEXE_VIA_CC is built to make it correct for MSVC by

--- a/runtime/array.c
+++ b/runtime/array.c
@@ -400,16 +400,12 @@ CAMLprim value caml_floatarray_blit(value a1, value ofs1, value a2, value ofs2,
   return Val_unit;
 }
 
-CAMLprim value caml_array_blit(value a1, value ofs1, value a2, value ofs2,
-                               value n)
+CAMLprim value caml_uniform_array_blit(
+  value a1, value ofs1, value a2, value ofs2, value n)
 {
   volatile value * src, * dst;
   intnat count;
 
-#ifdef FLAT_FLOAT_ARRAY
-  if (Tag_val(a2) == Double_array_tag)
-    return caml_floatarray_blit(a1, ofs1, a2, ofs2, n);
-#endif
   if (Long_val(n) == 0)
     /* See comment on size-0 floatarrays in [caml_floatarray_blit]. */
     return Val_unit;
@@ -448,6 +444,16 @@ CAMLprim value caml_array_blit(value a1, value ofs1, value a2, value ofs2,
      Give the minor GC a chance to run if it needs to. */
   caml_check_urgent_gc(Val_unit);
   return Val_unit;
+}
+
+CAMLprim value caml_array_blit(value a1, value ofs1, value a2, value ofs2,
+                               value n)
+{
+#ifdef FLAT_FLOAT_ARRAY
+  if (Tag_val(a2) == Double_array_tag)
+    return caml_floatarray_blit(a1, ofs1, a2, ofs2, n);
+#endif
+  return caml_uniform_array_blit(a1, ofs1, a2, ofs2, n);
 }
 
 /* A generic function for extraction and concatenation of sub-arrays */

--- a/runtime/array.c
+++ b/runtime/array.c
@@ -582,12 +582,45 @@ static value caml_array_gather(intnat num_arrays,
   return caml_uniform_array_gather(num_arrays, arrays, offsets, lengths);
 }
 
+CAMLprim value caml_floatarray_sub(value a, value ofs, value len)
+{
+  value arrays[1] = { a };
+  intnat offsets[1] = { Long_val(ofs) };
+  intnat lengths[1] = { Long_val(len) };
+  return caml_floatarray_gather(1, arrays, offsets, lengths);
+}
+
+CAMLprim value caml_uniform_array_sub(value a, value ofs, value len)
+{
+  value arrays[1] = { a };
+  intnat offsets[1] = { Long_val(ofs) };
+  intnat lengths[1] = { Long_val(len) };
+  return caml_uniform_array_gather(1, arrays, offsets, lengths);
+}
+
 CAMLprim value caml_array_sub(value a, value ofs, value len)
 {
   value arrays[1] = { a };
   intnat offsets[1] = { Long_val(ofs) };
   intnat lengths[1] = { Long_val(len) };
   return caml_array_gather(1, arrays, offsets, lengths);
+}
+
+CAMLprim value caml_floatarray_append(value a1, value a2)
+{
+  value arrays[2] = { a1, a2 };
+  intnat offsets[2] = { 0, 0 };
+  /* sizes are specified in number of floats */
+  intnat lengths[2] = { caml_array_length(a1), caml_array_length(a2) };
+  return caml_floatarray_gather(2, arrays, offsets, lengths);
+}
+
+CAMLprim value caml_uniform_array_append(value a1, value a2)
+{
+  value arrays[2] = { a1, a2 };
+  intnat offsets[2] = { 0, 0 };
+  intnat lengths[2] = { caml_array_length(a1), caml_array_length(a2) };
+  return caml_uniform_array_gather(2, arrays, offsets, lengths);
 }
 
 CAMLprim value caml_array_append(value a1, value a2)

--- a/stdlib/float.ml
+++ b/stdlib/float.ml
@@ -180,6 +180,9 @@ module Array = struct
   external unsafe_get : t -> int -> float = "%floatarray_unsafe_get"
   external unsafe_set : t -> int -> float -> unit = "%floatarray_unsafe_set"
 
+  external make : (int[@untagged]) -> (float[@unboxed]) -> t =
+    "caml_floatarray_make" "caml_floatarray_make_unboxed"
+
   let unsafe_fill a ofs len v =
     for i = ofs to ofs + len - 1 do unsafe_set a i v done
 
@@ -189,11 +192,6 @@ module Array = struct
   let check a ofs len msg =
     if ofs < 0 || len < 0 || ofs + len < 0 || ofs + len > length a then
       invalid_arg msg
-
-  let make n v =
-    let result = create n in
-    unsafe_fill result 0 n v;
-    result
 
   let init l f =
     if l < 0 then invalid_arg "Float.Array.init"

--- a/stdlib/float.ml
+++ b/stdlib/float.ml
@@ -190,9 +190,14 @@ module Array = struct
   external unsafe_blit: t -> int -> t -> int -> int -> unit =
     "caml_floatarray_blit" [@@noalloc]
 
+  external unsafe_sub : t -> int -> int -> t = "caml_floatarray_sub"
+  external append_prim : t -> t -> t = "caml_floatarray_append"
+
   let check a ofs len msg =
     if ofs < 0 || len < 0 || ofs + len < 0 || ofs + len > length a then
       invalid_arg msg
+
+  let empty = create 0
 
   let init l f =
     if l < 0 then invalid_arg "Float.Array.init"
@@ -229,14 +234,6 @@ module Array = struct
     end;
     res
 
-  let append a1 a2 =
-    let l1 = length a1 in
-    let l2 = length a2 in
-    let result = create (l1 + l2) in
-    unsafe_blit a1 0 result 0 l1;
-    unsafe_blit a2 0 result l1 l2;
-    result
-
   (* next 3 functions: modified copy of code from string.ml *)
   let ensure_ge (x:int) y =
     if x >= y then x else invalid_arg "Float.Array.concat"
@@ -261,15 +258,18 @@ module Array = struct
 
   let sub a ofs len =
     check a ofs len "Float.Array.sub";
-    let result = create len in
-    unsafe_blit a ofs result 0 len;
-    result
+    unsafe_sub a ofs len
 
   let copy a =
     let l = length a in
-    let result = create l in
-    unsafe_blit a 0 result 0 l;
-    result
+    if l = 0 then empty
+    else unsafe_sub a 0 l
+
+  let append a1 a2 =
+    let l1 = length a1 in
+    if l1 = 0 then copy a2
+    else if length a2 = 0 then unsafe_sub a1 0 l1
+    else append_prim a1 a2
 
   let fill a ofs len v =
     check a ofs len "Float.Array.fill";

--- a/stdlib/float.ml
+++ b/stdlib/float.ml
@@ -183,8 +183,9 @@ module Array = struct
   external make : (int[@untagged]) -> (float[@unboxed]) -> t =
     "caml_floatarray_make" "caml_floatarray_make_unboxed"
 
-  let unsafe_fill a ofs len v =
-    for i = ofs to ofs + len - 1 do unsafe_set a i v done
+  external unsafe_fill
+    : t -> (int[@untagged]) -> (int[@untagged]) -> (float[@unboxed]) -> unit
+    = "caml_floatarray_fill" "caml_floatarray_fill_unboxed"
 
   external unsafe_blit: t -> int -> t -> int -> int -> unit =
     "caml_floatarray_blit" [@@noalloc]


### PR DESCRIPTION
This PR is buildup work for https://github.com/ocaml/RFCs/pull/37. It splits the `caml_array_foo` functions in runtime/array.c in three versions, `caml_flotarray_foo`, `caml_uniform_array_foo`, and finally `caml_array_foo`. The new `floatarray_foo` versions are used in Float.Array, which could noticeably improve performance as they replace pure-OCaml implementations.

@nojb would you maybe be interested in reviewing this?