### PR TITLE
runtime/array.c: expose {uniform_,float}array_concat, use it in Float.Array

### DIFF
--- a/Changes
+++ b/Changes
@@ -376,6 +376,10 @@ Working version
 - #13314: Comment the code of Translclass
   (Vincent Laviron and Nathanaëlle Courant, review by Olivier Nicole)
 
+- #13362: reimplement Floatarray.concat in C (`caml_floatarray_concat`),
+  matching the implementation of Array.concat.
+  (Gabriel Scherer, review by Nicolás Ojeda Bär)
+
 - #13624: Added location to exception definitions and type extensions
   (Samuel Vivien, review by Gabriel Scherer)
 

--- a/runtime/array.c
+++ b/runtime/array.c
@@ -631,7 +631,13 @@ CAMLprim value caml_array_append(value a1, value a2)
   return caml_array_gather(2, arrays, offsets, lengths);
 }
 
-CAMLprim value caml_array_concat(value al)
+/* Function pointer type for the [caml_*_gather] functions. */
+typedef value (*gather_impl)(intnat num_arrays,
+                             value arrays[/*num_arrays*/],
+                             intnat offsets[/*num_arrays*/],
+                             intnat lengths[/*num_arrays*/]);
+
+static value generic_array_concat(gather_impl gather, value al)
 {
 #define STATIC_SIZE 16
   value static_arrays[STATIC_SIZE], * arrays;
@@ -661,14 +667,14 @@ CAMLprim value caml_array_concat(value al)
       caml_raise_out_of_memory();
     }
   }
-  /* Build the parameters to caml_array_gather */
+  /* Build the parameters for the [gather] function. */
   for (i = 0, l = al; l != Val_emptylist; l = Field(l, 1), i++) {
     arrays[i] = Field(l, 0);
     offsets[i] = 0;
     lengths[i] = caml_array_length(Field(l, 0));
   }
-  /* Do the concatenation */
-  res = caml_array_gather(n, arrays, offsets, lengths);
+  /* Call the [gather] function. */
+  res = (*gather)(n, arrays, offsets, lengths);
   /* Free the extra storage if needed */
   if (n > STATIC_SIZE) {
     caml_stat_free(arrays);
@@ -676,6 +682,21 @@ CAMLprim value caml_array_concat(value al)
     caml_stat_free(lengths);
   }
   return res;
+}
+
+CAMLprim value caml_floatarray_concat(value al)
+{
+  return generic_array_concat(&caml_floatarray_gather, al);
+}
+
+CAMLprim value caml_uniform_array_concat(value al)
+{
+  return generic_array_concat(&caml_uniform_array_gather, al);
+}
+
+CAMLprim value caml_array_concat(value al)
+{
+  return generic_array_concat(&caml_array_gather, al);
 }
 
 CAMLprim value caml_floatarray_fill_unboxed(

--- a/runtime/array.c
+++ b/runtime/array.c
@@ -654,7 +654,7 @@ CAMLprim value caml_array_concat(value al)
       caml_stat_free(arrays);
       caml_raise_out_of_memory();
     }
-    lengths = caml_stat_alloc_noexc(n * sizeof(value));
+    lengths = caml_stat_alloc_noexc(n * sizeof(intnat));
     if (lengths == NULL) {
       caml_stat_free(offsets);
       caml_stat_free(arrays);

--- a/stdlib/float.ml
+++ b/stdlib/float.ml
@@ -192,6 +192,7 @@ module Array = struct
 
   external unsafe_sub : t -> int -> int -> t = "caml_floatarray_sub"
   external append_prim : t -> t -> t = "caml_floatarray_append"
+  external concat : t list -> t = "caml_floatarray_concat"
 
   let check a ofs len msg =
     if ofs < 0 || len < 0 || ofs + len < 0 || ofs + len > length a then
@@ -233,28 +234,6 @@ module Array = struct
       done;
     end;
     res
-
-  (* next 3 functions: modified copy of code from string.ml *)
-  let ensure_ge (x:int) y =
-    if x >= y then x else invalid_arg "Float.Array.concat"
-
-  let rec sum_lengths acc = function
-    | [] -> acc
-    | hd :: tl -> sum_lengths (ensure_ge (length hd + acc) acc) tl
-
-  let concat l =
-    let len = sum_lengths 0 l in
-    let result = create len in
-    let rec loop l i =
-      match l with
-      | [] -> assert (i = len)
-      | hd :: tl ->
-        let hlen = length hd in
-        unsafe_blit hd 0 result i hlen;
-        loop tl (i + hlen)
-    in
-    loop l 0;
-    result
 
   let sub a ofs len =
     check a ofs len "Float.Array.sub";

--- a/testsuite/tests/lib-floatarray/floatarray.ml
+++ b/testsuite/tests/lib-floatarray/floatarray.ml
@@ -186,6 +186,8 @@ module Test (A : S) : sig end = struct
   (* check_inval omitted *)
 
   (* [concat] *)
+  assert (A.of_list [1.; 2.; 3.]
+          = A.concat [A.of_list [1.]; A.of_list [2.; 3.]]);
   let check l =
     let f (len, acc) n =
       (len + n, A.init n (fun i -> Float.of_int (len + i)) :: acc)


### PR DESCRIPTION
This is an immediate follow-up over #13361, sorry for the noise.

Yesterday I was intimidated by the length of the implementation of `caml_array_concat` (it is 43 lines of C code that traverses an OCaml list of arrays and accumulates them and their sizes into separate arrays to call `caml_array_gather`, with a cool optimization to avoid dynamic allocations below a certain input size). I gave up on the idea of finding out how to refactor it cleverly to avoid duplicating it twice into a `uniform_array` and a `floatarray` version.

Today I realized that I could use the power of Functional Programming, in this case, function pointers. I just abstract over the `gather` function, then define three one-liner instances for each usage.

Note: This is the last primitive function over arrays that is implemented in C in array.c and exposed as an external in array.ml. The present PR brings Float.Array at complete parity in terms of runtime support.

(cc @nojb)