### PR TITLE
Remove spurious comma from Domain.DLS.new_key documentation

### DIFF
--- a/stdlib/domain.mli
+++ b/stdlib/domain.mli
@@ -111,7 +111,7 @@ module DLS : sig
 
     val new_key : ?split_from_parent:('a -> 'a) -> (unit -> 'a) -> 'a key
     (** [new_key f] returns a new key bound to initialiser [f] for accessing
-,        domain-local variables.
+        domain-local variables.
 
         If [split_from_parent] is not provided, the value for a new
         domain will be computed on-demand by the new domain: the first


### PR DESCRIPTION
Spotted while studying `man Domain.DLS` which rendered like this in my terminal:
```
       val new_key : ?split_from_parent:('a -> 'a) -> (unit -> 'a) -> 'a key

       new_key f returns a new key bound to initialiser f for accessing ,        domain-local variables.
```

Looks like this came in 5378de96de5 and was missed because it was at the beginning of the line.

No change entry needed... :sweat_smile: 