### PR TITLE
Start Format_doc.Doc.iter with !first = true (not false).

### DIFF
--- a/utils/format_doc.ml
+++ b/utils/format_doc.ml
@@ -126,7 +126,7 @@ module Doc = struct
   let close_tag doc = add doc Close_tag
 
   let iter ?(sep=Fun.id) ~iter:iterator elt l doc =
-    let first = ref false in
+    let first = ref true in
     let rdoc = ref doc in
     let print x =
       if !first then (first := false; rdoc := elt x !rdoc)


### PR DESCRIPTION
Before (separator printed before first item):

```
# #mod_use "utils/format_doc.ml";;
module Format_doc :
  sig
...
  end
# Format_doc.(format_printer (pp_print_array ~pp_sep:comma pp_print_float) Format.std_formatter [|3.0|]);;
,
3.- : unit = ()
```

After (no separator printed before first item):

```
# #mod_use "utils/format_doc.ml";;
module Format_doc :
  sig
...
  end
#  Format_doc.(format_printer (pp_print_array ~pp_sep:comma pp_print_float) Format.std_formatter [|3.0|]);;
3.- : unit = ()
#
```