### PR TITLE
Add functions to check if a string is NUL-terminated

### DIFF
--- a/Changes
+++ b/Changes
@@ -145,6 +145,10 @@ _______________
 
 ### Standard library:
 
+- #13367: Add standard library functions for finding NUL bytes
+  in strings.
+  (Demi Marie Obenour)
+
 - #12884: Add `Queue.drop`
   (Léo Andrès, review by Nicolás Ojeda Bär and Gabriel Scherer)
 

--- a/runtime/str.c
+++ b/runtime/str.c
@@ -468,6 +468,12 @@ CAMLexport value caml_alloc_sprintf(const char * format, ...)
 #endif
 }
 
+CAMLprim value caml_string_first_nul(value v)
+{
+    /* Due to the Max_wosize limit, the Val_int can never truncate. */
+    return Val_int(strlen(String_val(v)));
+}
+
 CAMLprim value caml_string_of_bytes(value bv)
 {
   return bv;

--- a/stdlib/bytes.ml
+++ b/stdlib/bytes.ml
@@ -37,6 +37,8 @@ external unsafe_blit : bytes -> int -> bytes -> int -> int -> unit
                      = "caml_blit_bytes" [@@noalloc]
 external unsafe_blit_string : string -> int -> bytes -> int -> int -> unit
                      = "caml_blit_string" [@@noalloc]
+external first_nul : bytes -> (int[@untagged])
+                   = "caml_string_first_nul" "strlen" [@@noalloc]
 
 let make n c =
   let s = create n in
@@ -104,6 +106,9 @@ let blit_string s1 ofs1 s2 ofs2 len =
              || ofs2 < 0 || ofs2 > length s2 - len
   then invalid_arg "String.blit / Bytes.blit_string"
   else unsafe_blit_string s1 ofs1 s2 ofs2 len
+
+(* duplicated in string.ml *)
+let is_c_safe a = first_nul a = length a [@@inline always]
 
 (* duplicated in string.ml *)
 let iter f a =

--- a/stdlib/bytes.mli
+++ b/stdlib/bytes.mli
@@ -543,6 +543,27 @@ val is_valid_utf_16le : t -> bool
 (** [is_valid_utf_16le b] is [true] if and only if [b] contains valid
     UTF-16LE data. *)
 
+(** {1 Checking if a [bytes] contains NUL bytes} *)
+
+(** The functions in this section are useful whenever NUL has a special
+    meaning in a [bytes].  This could be because it is a terminator, a
+    separator, or is simply forbidden. *)
+
+external first_nul : bytes -> (int[@untagged])
+                   = "caml_string_first_nul" "strlen" [@@noalloc]
+(** [first_nul b] is the position of [b]'s first NUL byte,
+    or [length b] if none exists.
+
+    @since 5.3
+*)
+
+val is_c_safe : bytes -> bool
+(** [is_c_safe b] returns [true] if [b] has no NUL bytes,
+    or [false] otherwise.
+
+    @since 5.3
+*)
+
 (** {1 Binary encoding/decoding of integers} *)
 
 (** The functions in this section binary encode and decode integers to

--- a/stdlib/bytesLabels.mli
+++ b/stdlib/bytesLabels.mli
@@ -543,6 +543,27 @@ val is_valid_utf_16le : t -> bool
 (** [is_valid_utf_16le b] is [true] if and only if [b] contains valid
     UTF-16LE data. *)
 
+(** {1 Checking if a [bytes] contains NUL bytes} *)
+
+(** The functions in this section are useful whenever NUL has a special
+    meaning in a [bytes].  This could be because it is a terminator, a
+    separator, or is simply forbidden. *)
+
+external first_nul : bytes -> (int[@untagged])
+                   = "caml_string_first_nul" "strlen" [@@noalloc]
+(** [first_nul b] is the position of [b]'s first NUL byte,
+    or [length b] if none exists.
+
+    @since 5.3
+*)
+
+val is_c_safe : bytes -> bool
+(** [is_c_safe b] returns [true] if [b] has no NUL bytes,
+    or [false] otherwise.
+
+    @since 5.3
+*)
+
 (** {1 Binary encoding/decoding of integers} *)
 
 (** The functions in this section binary encode and decode integers to

--- a/stdlib/string.ml
+++ b/stdlib/string.ml
@@ -26,6 +26,8 @@ external get : string -> int -> char = "%string_safe_get"
 external unsafe_get : string -> int -> char = "%string_unsafe_get"
 external unsafe_blit : string -> int ->  bytes -> int -> int -> unit
                      = "caml_blit_string" [@@noalloc]
+external first_nul : string -> (int[@untagged])
+                   = "caml_string_first_nul" "strlen" [@@noalloc]
 
 module B = Bytes
 
@@ -237,6 +239,9 @@ type t = string
 
 let compare (x: t) (y: t) = Stdlib.compare x y
 external equal : string -> string -> bool = "caml_string_equal" [@@noalloc]
+
+(* duplicated in bytes.ml *)
+let is_c_safe a = first_nul a = length a
 
 (** {1 Iterators} *)
 

--- a/stdlib/string.mli
+++ b/stdlib/string.mli
@@ -362,6 +362,27 @@ val of_seq : char Seq.t -> t
 
     @since 4.07 *)
 
+(** {1 Checking if a [string] contains NUL bytes} *)
+
+(** The functions in this section are useful whenever NUL has a special
+    meaning in a [string].  This could be because it is a terminator, a
+    separator, or is simply forbidden. *)
+
+external first_nul : string -> (int[@untagged])
+                   = "caml_string_first_nul" "strlen" [@@noalloc]
+(** [first_nul b] is the position of [b]'s first NUL byte,
+    or [length b] if none exists.
+
+    @since 5.3
+*)
+
+val is_c_safe : string -> bool
+(** [is_c_safe b] returns [true] if [b] has no NUL bytes,
+    or [false] otherwise.
+
+    @since 5.3
+*)
+
 (** {1:utf UTF decoding and validations}
 
     @since 4.14 *)

--- a/stdlib/stringLabels.mli
+++ b/stdlib/stringLabels.mli
@@ -362,6 +362,27 @@ val of_seq : char Seq.t -> t
 
     @since 4.07 *)
 
+(** {1 Checking if a [string] contains NUL bytes} *)
+
+(** The functions in this section are useful whenever NUL has a special
+    meaning in a [string].  This could be because it is a terminator, a
+    separator, or is simply forbidden. *)
+
+external first_nul : string -> (int[@untagged])
+                   = "caml_string_first_nul" "strlen" [@@noalloc]
+(** [first_nul b] is the position of [b]'s first NUL byte,
+    or [length b] if none exists.
+
+    @since 5.3
+*)
+
+val is_c_safe : string -> bool
+(** [is_c_safe b] returns [true] if [b] has no NUL bytes,
+    or [false] otherwise.
+
+    @since 5.3
+*)
+
 (** {1:utf UTF decoding and validations}
 
     @since 4.14 *)

--- a/testsuite/tests/lib-string/test_string.ml
+++ b/testsuite/tests/lib-string/test_string.ml
@@ -38,8 +38,16 @@ let () =
   for i = 0 to String.length s do
     check_split ' ' (String.sub s 0 i)
   done
-;;
 
+let () =
+  assert (String.first_nul "" = 0);
+  assert (String.first_nul "a" = 1);
+  assert (String.first_nul "\000a" = 0);
+  assert (String.first_nul "a\000" = 1);
+  assert (String.is_c_safe "");
+  assert (String.is_c_safe "a");
+  assert (not (String.is_c_safe "\000a"));
+  assert (not (String.is_c_safe "a\000"));
 
 let () =
   printf "-- Hashtbl.hash raw_string: %x\n%!" (Hashtbl.hash raw_string);


### PR DESCRIPTION
OCaml already exposes this to C code, but not to OCaml!

The use of "strlen" as a C primitive is questionable, especially on systems using pointer authentication.  I can rewrite this to call a wrapper.