### PR TITLE
Some unsigned helpers

### DIFF
--- a/Changes
+++ b/Changes
@@ -618,6 +618,12 @@ OCaml 5.3.0 (8 January 2025)
 
 ### Standard library:
 
+- #13368: Add integer math helper functions:
+  Int64.unsigned_of_int, Int64.unsigned_of_int32,
+  Int64.unsigned_32_to_64_mul, Int64.signed_32_to_64_mul,
+  Nativeint.unsigned_of_int.
+  (Demi Marie Obenour)
+
 - #12884: Add `Queue.drop`
   (Léo Andrès, review by Nicolás Ojeda Bär and Gabriel Scherer)
 

--- a/stdlib/.depend
+++ b/stdlib/.depend
@@ -470,9 +470,11 @@ stdlib__Int32.cmx : int32.ml \
     stdlib__Int32.cmi
 stdlib__Int32.cmi : int32.mli
 stdlib__Int64.cmo : int64.ml \
+    stdlib__Sys.cmi \
     stdlib.cmi \
     stdlib__Int64.cmi
 stdlib__Int64.cmx : int64.ml \
+    stdlib__Sys.cmx \
     stdlib.cmx \
     stdlib__Int64.cmi
 stdlib__Int64.cmi : int64.mli

--- a/stdlib/int64.ml
+++ b/stdlib/int64.ml
@@ -58,6 +58,28 @@ let unsigned_to_int =
     else
       None
 
+(* The next few functions are force-inlined so as to expose
+   unboxing opportunities. *)
+
+let unsigned_of_int32 (n: int32) =
+  logand (of_int32 n) 0xFFFFFFFFL
+  [@@inline always]
+
+let unsigned_of_int (n: int) =
+  match Sys.word_size with
+  | 64 -> logand (of_int n) 0x7FFFFFFFFFFFFFFFL
+  | 32 -> logand (of_int n) 0x7FFFFFFFL
+  | _ -> assert false
+  [@@inline always]
+
+let unsigned_32_to_64_mul a b =
+  mul (unsigned_of_int32 a) (unsigned_of_int32 b)
+  [@@inline always]
+
+let signed_32_to_64_mul a b =
+  mul (of_int32 a) (of_int32 b)
+  [@@inline always]
+
 external format : string -> int64 -> string = "caml_int64_format"
 let to_string n = format "%d" n
 

--- a/stdlib/int64.mli
+++ b/stdlib/int64.mli
@@ -161,6 +161,14 @@ external of_int32 : int32 -> int64 = "%int64_of_int32"
 (** Convert the given 32-bit integer (type [int32])
    to a 64-bit integer (type [int64]). *)
 
+val unsigned_of_int32 : int32 -> int64
+(** Convert the given unsigned 32-bit integer (type [int32])
+   to a 64-bit integer (type [int64]). *)
+
+val unsigned_of_int : int -> int64
+(** Convert the given unsigned integer (type [int])
+   to a 64-bit integer (type [int64]). *)
+
 external to_int32 : int64 -> int32 = "%int64_to_int32"
 (** Convert the given 64-bit integer (type [int64]) to a
    32-bit integer (type [int32]). The 64-bit integer
@@ -219,6 +227,16 @@ external float_of_bits : int64 -> float
 
 type t = int64
 (** An alias for the type of 64-bit integers. *)
+
+val unsigned_32_to_64_mul : int32 -> int32 -> int64
+(** Computes [mul1 * mul2] using unsigned math.
+    The result is guaranteed to be the same as if it was performed
+    using arbitrary-precision arithmetic. *)
+
+val signed_32_to_64_mul : int32 -> int32 -> int64
+(** Computes [mul1 * mul2] using signed math.
+    The result is guaranteed to be the same as if it was performed
+    using arbitrary-precision arithmetic. *)
 
 val compare: t -> t -> int
 (** The comparison function for 64-bit integers, with the same specification as

--- a/stdlib/nativeint.ml
+++ b/stdlib/nativeint.ml
@@ -57,6 +57,10 @@ let unsigned_to_int =
     else
       None
 
+let unsigned_of_int (n: int) =
+  logand (of_int n) max_int
+  [@@inline always] (* this had better generate good code *)
+
 external format : string -> nativeint -> string = "caml_nativeint_format"
 let to_string n = format "%d" n
 

--- a/stdlib/nativeint.mli
+++ b/stdlib/nativeint.mli
@@ -148,6 +148,11 @@ external of_int : int -> nativeint = "%nativeint_of_int"
 (** Convert the given integer (type [int]) to a native integer
    (type [nativeint]). *)
 
+val unsigned_of_int : int -> nativeint
+(** Same as {!of_int}, but interprets the argument as an {e unsigned} integer.
+
+    @since 4.08 *)
+
 external to_int : nativeint -> int = "%nativeint_to_int"
 (** Convert the given native integer (type [nativeint]) to an
    integer (type [int]).  The high-order bit is lost during


### PR DESCRIPTION
This adds some helpers for unsigned integer operations.  I needed `unsigned_of_int` for my Wayland work and the rest seemed natural.