### PR TITLE
Fix gc hole in runtime/gc_ctrl.c

### DIFF
--- a/Changes
+++ b/Changes
@@ -36,6 +36,9 @@ _______________
 - #13382: Add more documentation for Runtime_events types
   (Sadiq Jaffer, review by Tim McGilchrist, Miod Vallat and KC Sivaramakrishnan)
 
+- #13370: Fix a low-probability crash when calling Gc.counters.
+  (Demi Marie Obenour, review by Gabriel Scherer)
+
 - #13272: Allow maximum number of domains to be specified as a OCAMLRUNPARAM
   parameter.
   (KC Sivaramakrishnan, review by Guillaume Munch-Maccagnoni, Miod Vallat,
@@ -250,6 +253,10 @@ _______________
   (Samuel Vivien, review by Florian Angeletti)
 
 ### Manual and documentation:
+
+- #13370: Document that that temporary variables holding GCd pointers must
+  not be live across a GC.
+  (Demi Marie Obenour)
 
 - #12298: Manual: emphasize that Bigarray.int refers to an OCaml integer,
   which does not match the C int type.

--- a/manual/src/cmds/intf-c.etex
+++ b/manual/src/cmds/intf-c.etex
@@ -1003,7 +1003,10 @@ Primitives (C functions that can be called from OCaml) should never return void.
 Local variables of type "value" must be declared with one of the
 "CAMLlocal" macros.  Arrays of "value"s are declared with
 "CAMLlocalN".  These macros must be used at the beginning of the
-function, not in a nested block.
+function, not in a nested block.  Temporaries are equivalent to
+local variables, but they cannot be registered with the garbage
+collector, so a temporary of type "value" must not be live when
+a garbage collection may occur.
 \end{gcrule}
 
 The macros "CAMLlocal1" to "CAMLlocal5" declare and initialize one to

--- a/runtime/gc_ctrl.c
+++ b/runtime/gc_ctrl.c
@@ -104,7 +104,7 @@ CAMLprim value caml_gc_minor_words(value v)
 CAMLprim value caml_gc_counters(value v)
 {
   CAMLparam0 (); /* v is ignored */
-  CAMLlocal3 (minwords_, prowords_, majwords_);
+  CAMLlocal4 (minwords_, prowords_, majwords_, res);
 
   /* get a copy of these before allocating anything... */
   double minwords = caml_gc_minor_words_unboxed();
@@ -115,11 +115,8 @@ CAMLprim value caml_gc_counters(value v)
   minwords_ = caml_copy_double(minwords);
   prowords_ = caml_copy_double(prowords);
   majwords_ = caml_copy_double(majwords);
-  v = caml_alloc_small(3, 0);
-  Field(v, 0) = minwords_;
-  Field(v, 1) = prowords_;
-  Field(v, 2) = majwords_;
-  CAMLreturn(v);
+  res = caml_alloc_3(0, minwords_, prowords_, majwords_);
+  CAMLreturn(res);
 }
 
 CAMLprim value caml_gc_get(value v)

--- a/runtime/gc_ctrl.c
+++ b/runtime/gc_ctrl.c
@@ -103,8 +103,8 @@ CAMLprim value caml_gc_minor_words(value v)
 
 CAMLprim value caml_gc_counters(value v)
 {
-  CAMLparam0 ();   /* v is ignored */
-  CAMLlocal1 (res);
+  CAMLparam0 (); /* v is ignored */
+  CAMLlocal3 (minwords_, prowords_, majwords_);
 
   /* get a copy of these before allocating anything... */
   double minwords = caml_gc_minor_words_unboxed();
@@ -112,11 +112,14 @@ CAMLprim value caml_gc_counters(value v)
   double majwords = Caml_state->stat_major_words +
                     (double) Caml_state->allocated_words;
 
-  res = caml_alloc_3(0,
-    caml_copy_double (minwords),
-    caml_copy_double (prowords),
-    caml_copy_double (majwords));
-  CAMLreturn (res);
+  minwords_ = caml_copy_double(minwords);
+  prowords_ = caml_copy_double(prowords);
+  majwords_ = caml_copy_double(majwords);
+  v = caml_alloc_small(3, 0);
+  Field(v, 0) = minwords_;
+  Field(v, 1) = prowords_;
+  Field(v, 2) = majwords_;
+  CAMLreturn(v);
 }
 
 CAMLprim value caml_gc_get(value v)


### PR DESCRIPTION
If the evaluation of one of the arguments to caml_alloc_3 triggers a garbage collection, the other arguments will not be valid anymore.

This rule was not documented in the OCaml manual, so I added an explanation of the problem.