### PR TITLE
New `Format` and `Printf` `printf`-like functions that accept a heterogeneous list as arguments

### DIFF
--- a/stdlib/camlinternalFormat.ml
+++ b/stdlib/camlinternalFormat.ml
@@ -1953,6 +1953,35 @@ let rec strput_acc b acc = match acc with
   | End_of_acc               -> ()
 
 (******************************************************************************)
+                      (* Heterogeneous printf variants *)
+
+module Args = struct
+  (* List of heterogeneous values.
+     Type ['a] should match the type signature of the [printf] like functions.
+     Type ['r] should match the format's return type ([format6]'s ['f] type).
+  *)
+  type ('a, 'r) t =
+    | [] : ('r, 'r) t
+    | (::) : 'a * ('b, 'r) t -> ('a -> 'b, 'r) t
+
+  let rec apply: type a r .
+    a -> (a, r) t -> r =
+    fun f lst -> match lst with
+      | [] -> f
+      | arg :: rest -> apply (f arg) rest
+
+  let rec append : type a r1 r2.
+    (a, r1) t -> (r1, r2) t -> (a, r2) t =
+    fun lst1 lst2 ->
+    match lst1 with [] -> lst2 | x :: xs -> x :: append xs lst2
+
+  let ( @ ) lst1 lst2 = append lst1 lst2
+end
+
+let make_lprintf k acc fmt args =
+  Args.apply (make_printf k acc fmt) args
+
+(******************************************************************************)
                           (* Error management *)
 
 (* Raise [Failure] with a pretty-printed error message. *)

--- a/stdlib/camlinternalFormat.mli
+++ b/stdlib/camlinternalFormat.mli
@@ -67,6 +67,21 @@ val output_acc : out_channel -> (out_channel, unit) acc -> unit
 val bufput_acc : Buffer.t -> (Buffer.t, unit) acc -> unit
 val strput_acc : Buffer.t -> (unit, string) acc -> unit
 
+module Args : sig
+  type ('a, 'r) t =
+    | [] : ('r, 'r) t
+    | (::) : 'a * ('b, 'r) t -> ('a -> 'b, 'r) t
+
+  val apply : 'a -> ('a, 'r) t -> 'r
+
+  val ( @ ) : ('a, 'r1) t -> ('r1, 'r2) t -> ('a, 'r2) t
+end
+
+val make_lprintf :
+  (('b, 'c) acc -> 'f) -> ('b, 'c) acc ->
+  ('a, 'b, 'c, 'c, 'c, 'f) CamlinternalFormatBasics.fmt ->
+  ('a, 'f) Args.t -> 'f
+
 val type_format :
   ('x, 'b, 'c, 't, 'u, 'v) CamlinternalFormatBasics.fmt ->
   ('a, 'b, 'c, 'd, 'e, 'f) CamlinternalFormatBasics.fmtty ->

--- a/stdlib/format.ml
+++ b/stdlib/format.ml
@@ -1491,6 +1491,31 @@ let kasprintf k (Format (fmt, _)) =
 
 let asprintf fmt = kasprintf id fmt
 
+(*
+
+  Defining heterogeneous list flavours of functions defined above
+
+*)
+
+module Args = Args
+
+let lfprintf ppf (Format (fmt, _)) args =
+  make_lprintf (output_acc ppf) End_of_acc fmt args
+
+let lprintf fmt args =
+  lfprintf (DLS.get std_formatter_key) fmt args
+
+let leprintf fmt args =
+  lfprintf (DLS.get err_formatter_key) fmt args
+
+let lasprintf (Format (fmt, _)) args =
+  let b = pp_make_buffer () in
+  let ppf = formatter_of_buffer b in
+  let k acc = output_acc ppf acc; flush_buffer_formatter b ppf in
+  make_lprintf k End_of_acc fmt args
+
+let ldprintf fmt args ppf = lfprintf ppf fmt args
+
 (* Flushing standard formatters at end of execution. *)
 
 let flush_standard_formatters () =

--- a/stdlib/format.mli
+++ b/stdlib/format.mli
@@ -1472,6 +1472,111 @@ val kasprintf : (string -> 'a) -> ('b, formatter, unit, 'a) format4 -> 'b
   @since 4.03
 *)
 
+(** Formatted Pretty-Printing with heterogeneous argument lists.
+
+  The following functions behave the same as their non-'l' counter-parts, but
+  receive their arguments bundled in a single heterogeneous list.
+
+  The heterogeneous list serves as a syntactically-delimited
+  collection of arguments, eliminating the need for continuation variants.
+  This approach also improves the clarity of type error messages,
+  especially when there is a mismatch between the format string and the
+  number of arguments provided.
+
+  For example:
+  {[
+    Format.lprintf "%s %d %.02f %c\n" [ "ocaml"; 42; 3.14; 'c' ]
+  ]}
+*)
+
+module Args : sig
+  type ('a, 'r) t =
+    | [] : ('r, 'r) t
+    | (::) : 'a * ('b, 'r) t -> ('a -> 'b, 'r) t
+
+  val apply : 'a -> ('a, 'r) t -> 'r
+
+  val ( @ ) : ('a, 'r1) t -> ('r1, 'r2) t -> ('a, 'r2) t
+end
+(** The [Args] module defines a heterogeneous list type, which can be
+    used as the argument of [printf]-like functions.
+
+    It is not required to open this module when using the functions
+    that accept an [Args.t]. Thanks to type-based disambiguation, the type
+    is inferred automatically, so the list syntax [[x; y; z]] can be used
+    directly for heterogeneous lists.
+
+    An example:
+  {[
+    (* without opening Args *)
+    Format.lprintf "%s %d %.02f@." [ "ocaml"; 42; 3.14 ]
+
+    (* or with explicit construction *)
+    let lst = let open Format.Args in "ocaml" :: [ 42; 3.14 ] @ [ 'c' ] in
+    Format.lprintf "%s %d %.02f %c@." lst
+  ]}
+
+  @since 5.5
+*)
+
+val lfprintf :
+  formatter -> ('a, formatter, unit) format ->
+  ('a, unit) Args.t -> unit
+(** Same as [fprintf] above, but with the arguments bundled in a single
+    heterogeneous list.
+
+    For example:
+  {[
+    let out = Format.formatter_of_out_channel @@ open_out "some/file.txt" in
+    Format.lfprintf out "@[%s@ %d@]@." [ "x ="; 1 ]
+  ]}
+
+  @since 5.5
+*)
+
+val lprintf :
+  ('a, formatter, unit) format ->
+  ('a, unit) Args.t -> unit
+(** Same as [printf] above, but with the arguments bundled in a single
+    heterogeneous list.
+
+  @since 5.5
+*)
+
+val leprintf :
+  ('a, formatter, unit) format ->
+  ('a, unit) Args.t -> unit
+(** Same as [eprintf] above, but with the arguments bundled in a single
+    heterogeneous list.
+
+  @since 5.5
+*)
+
+val lasprintf :
+  ('a, formatter, unit, string) format4 ->
+  ('a, string) Args.t -> string
+(** Same as [asprintf] above, but with the arguments bundled in a single
+    heterogeneous list.
+
+  @since 5.5
+*)
+
+val ldprintf :
+  ('a, formatter, unit, unit) format4 ->
+  ('a, unit) Args.t -> formatter -> unit
+(** Same as [dprintf] above, but with the arguments bundled in a single
+    heterogeneous list.
+
+    For example:
+  {[
+    let t = Format.ldprintf "%i@ %i@ %i" [ 1; 2; 3 ] in
+    ...
+    Format.lprintf "@[<v>%t@]" [ t ]
+  ]}
+
+  @since 5.5
+*)
+
 (** {1:examples Examples}
 
   A few warmup examples to get an idea of how Format is used.

--- a/stdlib/printf.ml
+++ b/stdlib/printf.ml
@@ -41,3 +41,29 @@ let ksprintf k (Format (fmt, _)) =
 let sprintf fmt = ksprintf (fun s -> s) fmt
 
 let kprintf = ksprintf
+
+(*
+  Defining heterogeneous list flavours of functions defined above
+*)
+
+module Args = Args
+
+let lfprintf oc (Format (fmt, _)) args =
+  make_lprintf (output_acc oc) End_of_acc fmt args
+
+let lbprintf b (Format (fmt, _)) args =
+  make_lprintf (bufput_acc b) End_of_acc fmt args
+
+let lprintf fmt args =
+  lfprintf stdout fmt args
+
+let leprintf fmt args =
+  lfprintf stderr fmt args
+
+let lsprintf (Format (fmt, _)) args =
+  let k acc =
+    let buf = Buffer.create 64 in
+    strput_acc buf acc;
+    (Buffer.contents buf)
+  in
+  make_lprintf k End_of_acc fmt args

--- a/stdlib/printf.mli
+++ b/stdlib/printf.mli
@@ -188,6 +188,82 @@ val ikbprintf : (Buffer.t -> 'd) -> Buffer.t ->
    @since 4.11
 *)
 
+(** Formatted output functions with heterogeneous argument lists.
+
+  The following functions behave the same as their non-'l' counter-parts, but
+  receive their arguments bundled in a single heterogeneous list.
+
+  The heterogeneous list serves as a syntactically-delimited
+  collection of arguments, eliminating the need for continuation variants.
+  This approach also improves the clarity of type error messages,
+  especially when there is a mismatch between the format string and the
+  number of arguments provided.
+
+  For example:
+  {[
+    Printf.lprintf "%s %d %.02f %c\n" [ "ocaml"; 42; 3.14; 'c' ]
+  ]}
+*)
+
+module Args : sig
+  type ('a, 'r) t =
+    | [] : ('r, 'r) t
+    | (::) : 'a * ('b, 'r) t -> ('a -> 'b, 'r) t
+
+  val apply : 'a -> ('a, 'r) t -> 'r
+
+  val ( @ ) : ('a, 'r1) t -> ('r1, 'r2) t -> ('a, 'r2) t
+end
+(** The [Args] module defines a heterogeneous list type, which can be
+    used as the argument of the [l*printf] functions.
+    For more documentation, see the similar module {!Format.Args}. *)
+
+val lfprintf : out_channel ->
+              ('a, out_channel, unit) format ->
+              ('a, unit) Args.t ->
+              unit
+(** Same as [fprintf] above, but with the arguments bundled in a single
+    heterogeneous list.
+    For example:
+  {[
+    Printf.lfprintf (open_out "some/file.txt") "@[%s@ %d@]@." [ "x ="; 1 ]
+  ]}
+   @since 5.5
+*)
+
+val lbprintf : Buffer.t ->
+              ('a, Buffer.t, unit) format ->
+              ('a, unit) Args.t ->
+              unit
+(** Same as [bprintf] above, but with the arguments bundled in a single
+    heterogeneous list.
+   @since 5.5
+*)
+
+val lprintf : ('a, out_channel, unit) format ->
+              ('a, unit) Args.t ->
+              unit
+(** Same as [printf] above, but with the arguments bundled in a single
+    heterogeneous list.
+   @since 5.5
+*)
+
+val leprintf : ('a, out_channel, unit) format ->
+              ('a, unit) Args.t ->
+              unit
+(** Same as [eprintf] above, but with the arguments bundled in a single
+    heterogeneous list.
+   @since 5.5
+*)
+
+val lsprintf : ('a, unit, string) format ->
+            ('a, string) Args.t ->
+            string
+(** Same as [sprintf] above, but with the arguments bundled in a single
+    heterogeneous list.
+   @since 5.5
+*)
+
 (** Deprecated *)
 
 val kprintf : (string -> 'b) -> ('a, unit, string, 'b) format4 -> 'a

--- a/testsuite/tests/lib-format/tlprintf.ml
+++ b/testsuite/tests/lib-format/tlprintf.ml
@@ -1,0 +1,64 @@
+(* TEST
+ include testing;
+ flags = "-no-strict-formats";
+*)
+
+(*
+
+A test file for the heterogeneous list variants Format module.
+
+*)
+
+open Testing;;
+open Format;;
+
+exception Test of string
+type tster = { x: string; y: int }
+
+let say s = Printf.printf s;;
+
+try
+
+  say "Delayed printf\n%!";
+  let t1 fmt = lfprintf fmt "%i - %s" [1; "bar"] in
+  test (lasprintf "foo %t" [t1] = "foo 1 - bar");
+  let t2 fmt = lfprintf fmt "%a@]" [(pp_print_list pp_print_int); [1; 2; 3]] in
+  test (lasprintf "foo @[<v>%t@,%s" [t2; "bar"] = "foo 1\n    2\n    3\nbar");
+  test (lasprintf "%t @[<h>%t" [t1; t2] = "1 - bar 123");
+
+  say "\nMiscellaneous tests\n%!";
+  test (lasprintf "%d, %.2f, %s" [42; 3.14159; "ocaml"] = "42, 3.14, ocaml");
+
+  let pp_custom fmt p = lfprintf fmt "x = %s, y = %d" [p.x; p.y] in
+  let p = { x = "ocaml"; y = 42 } in
+  test (lasprintf "%a" [pp_custom; p] = "x = ocaml, y = 42");
+
+  test (lasprintf "%s, %d, %.1f, %a" ["world"; 7; 2.718; pp_custom; p] = "world, 7, 2.7, x = ocaml, y = 42");
+
+  let pp_padded_list fmt l =
+    lfprintf fmt "[%s]" [ List.map (fun x -> lasprintf "%04d" [ x ]) l |> String.concat "; " ] in
+  test (lasprintf "%a" [pp_padded_list; [1; 23; 456]] = "[0001; 0023; 0456]");
+
+  test (lasprintf "%a" [(Format.pp_print_list Format.pp_print_int); [1; 23; 456]] = "123\n456");
+
+  let nested_format ppf = lfprintf ppf "%s, %d, %a" [ "final"; 42; pp_custom; p ] in
+  test (lasprintf "%s -> %t" [ "outer"; nested_format ] = "outer -> final, 42, x = ocaml, y = 42");
+
+  let delayed_format fmt = lfprintf fmt "%s, %d, %a" [ "final"; 42; pp_custom; p ] in
+  test (lasprintf "%s, %d, %.3f, %a, %t"
+    ["last"; 100; 3.141; pp_custom; p; delayed_format]
+    = "last, 100, 3.141, x = ocaml, y = 42, final, 42, x = ocaml, y = 42");
+
+  let l : _ Args.t = [ "ocaml"; 42; 3.14; 'c'; pp_custom; p ] in
+  test (lasprintf "%s, %d, %.3f, %c, %a" l = "ocaml, 42, 3.140, c, x = ocaml, y = 42");
+
+  (* emulating kfprintf *)
+  let test_exn fmt args = raise (Test (lasprintf fmt args)) in
+  test (try test_exn "%d %s" [ 42; "ocaml" ] with Test "42 ocaml" -> true | _ -> false);
+
+  say "\nend of tests\n%!";
+
+with e ->
+  say "unexpected exception: %s\n%!" (Printexc.to_string e);
+  test false;
+;;

--- a/testsuite/tests/lib-format/tlprintf.reference
+++ b/testsuite/tests/lib-format/tlprintf.reference
@@ -1,0 +1,7 @@
+Delayed printf
+ 0 1 2
+Miscellaneous tests
+ 3 4 5 6 7 8 9 10 11
+end of tests
+
+All tests succeeded.

--- a/testsuite/tests/lib-printf/tlprintf.ml
+++ b/testsuite/tests/lib-printf/tlprintf.ml
@@ -1,0 +1,55 @@
+(* TEST
+ include testing;
+ flags = "-no-strict-formats";
+*)
+
+(*
+
+A test file for the heterogeneous list variants of the Printf module.
+
+*)
+
+open Testing;;
+open Printf;;
+
+exception Test of string
+type tster = { x: string; y: int }
+
+let test_roundtrip fmt of_string s =
+  test (sprintf fmt (of_string s) = s)
+;;
+
+try
+  lprintf "Miscellaneous tests\n%!" [];
+  test (lsprintf "%d, %.2f, %s" [42; 3.14159; "ocaml"] = "42, 3.14, ocaml");
+
+  let pp_custom () p = lsprintf "x = %s, y = %d" [p.x; p.y] in
+  let p = { x = "ocaml"; y = 42 } in
+  test (lsprintf "%a" [pp_custom; p] = "x = ocaml, y = 42");
+
+  test (lsprintf "%s, %d, %.1f, %a" ["world"; 7; 2.718; pp_custom; p] = "world, 7, 2.7, x = ocaml, y = 42");
+
+  let pp_padded_list () l =
+    lsprintf "[%s]" [ List.map (fun x -> lsprintf "%04d" [ x ]) l |> String.concat "; " ] in
+  test (lsprintf "%a" [pp_padded_list; [1; 23; 456]] = "[0001; 0023; 0456]");
+
+  let nested_print () = lsprintf "%s, %d, %a" [ "final"; 42; pp_custom; p ] in
+  test (lsprintf "%s -> %t" [ "outer"; nested_print ] = "outer -> final, 42, x = ocaml, y = 42");
+
+  let delayed_print () = lsprintf "%s, %d, %a" [ "final"; 42; pp_custom; p ] in
+  test (lsprintf "%s, %d, %.3f, %a, %t"
+    ["last"; 100; 3.141; pp_custom; p; delayed_print]
+    = "last, 100, 3.141, x = ocaml, y = 42, final, 42, x = ocaml, y = 42");
+
+  let l : _ Args.t = [ "ocaml"; 42; 3.14; 'c'; pp_custom; p ] in
+  test (lsprintf "%s, %d, %.3f, %c, %a" l = "ocaml, 42, 3.140, c, x = ocaml, y = 42");
+
+  (* emulating kfprintf *)
+  let test_exn fmt args = raise (Test (lsprintf fmt args)) in
+  test (try test_exn "%d %s" [ 42; "ocaml" ] with Test "42 ocaml" -> true | _ -> false);
+
+  printf "\nend of tests\n%!";
+with e ->
+  printf "unexpected exception: %s\n%!" (Printexc.to_string e);
+  test false;
+;;

--- a/testsuite/tests/lib-printf/tlprintf.reference
+++ b/testsuite/tests/lib-printf/tlprintf.reference
@@ -1,0 +1,5 @@
+Miscellaneous tests
+ 0 1 2 3 4 5 6 7
+end of tests
+
+All tests succeeded.

--- a/tools/translate-all-tests
+++ b/tools/translate-all-tests
@@ -348,6 +348,7 @@ lib-format/print_array.ml \
 lib-format/print_if_newline.ml \
 lib-format/print_seq.ml \
 lib-format/tformat.ml \
+lib-format/tlprintf.ml \
 lib-fun/test.ml \
 lib-hashtbl/compatibility.ml \
 lib-hashtbl/hfun.ml \


### PR DESCRIPTION
Implements new `Format` and `Printf` functions that provide compile-time errors about supernumerary arguments (passed as a heterogeneous list), thus circumventing the problem described in issue ocaml#12262.

There is also no need for continuation variants (and for `dprintf`) of functions that use heterogeneous lists.

The new `Format` functions are named `l{,f,e,s,as}printf`.
The new `Printf` functions are named `l{,f,b,e,s}printf`.

---
### Implementation Details

- A new `make_lprintf` function was implemented, which takes advantage of the existing `CamlinternalFormat.make_printf` and applies the resulting function to the elements of the heterogeneous list.
- The heterogeneous list is implemented under `CamlinternalFormat.Arg_list`. There is a heterogeneous list definition in `CamlinternalFormat` already, but the one implemented here shadows the default list constructors, making it easier to provide arguments to the new functions.

### Future Work
- A secondary user of the present work is `Scanf`, which will see similar contributions from me if this one gets accepted!