### PR TITLE
Dynlink.loadfile_private: don't hide loaded units until all have been loaded

### DIFF
--- a/Changes
+++ b/Changes
@@ -218,6 +218,10 @@ _______________
 - #13326: Implement Unix.O_APPEND on windows.
   (Romain Beauxis, review by Miod Vallat, Gabriel Scherer and Antonin Décimo)
 
+- #13376: Allow Dynlink.loadfile_private to load bytecode libraries with
+  internal dependencies
+  (Vincent Laviron, report by Stéphane Glondu, review by Nicolás Ojeda Bär)
+
 ### Tools:
 
 - #11716: ocamllex: mismatched parentheses and curly brackets are now caught

--- a/Changes
+++ b/Changes
@@ -218,9 +218,10 @@ _______________
 - #13326: Implement Unix.O_APPEND on windows.
   (Romain Beauxis, review by Miod Vallat, Gabriel Scherer and Antonin Décimo)
 
-- #13376: Allow Dynlink.loadfile_private to load bytecode libraries with
+* #13376: Allow Dynlink.loadfile_private to load bytecode libraries with
   internal dependencies
-  (Vincent Laviron, report by Stéphane Glondu, review by Nicolás Ojeda Bär)
+  (Vincent Laviron, report by Stéphane Glondu, review by Nicolás Ojeda Bär
+   and Xavier Leroy)
 
 ### Tools:
 

--- a/otherlibs/dynlink/byte/dynlink.ml
+++ b/otherlibs/dynlink/byte/dynlink.ml
@@ -60,7 +60,8 @@ module Bytecode = struct
     let unsafe_module (t : t) = t.cu_primitives <> []
   end
 
-  type handle = Stdlib.in_channel * filename * Digest.t * Symtable.global_map option
+  type handle =
+    Stdlib.in_channel * filename * Digest.t * Symtable.global_map option
 
   let default_crcs = ref []
   let default_global_map = ref Symtable.empty_global_map

--- a/otherlibs/dynlink/byte/dynlink.ml
+++ b/otherlibs/dynlink/byte/dynlink.ml
@@ -60,7 +60,7 @@ module Bytecode = struct
     let unsafe_module (t : t) = t.cu_primitives <> []
   end
 
-  type handle = Stdlib.in_channel * filename * Digest.t
+  type handle = Stdlib.in_channel * filename * Digest.t * Symtable.global_map option
 
   let default_crcs = ref []
   let default_global_map = ref Symtable.empty_global_map
@@ -118,9 +118,8 @@ module Bytecode = struct
     Obj.t * (unit -> Obj.t)
     = "caml_reify_bytecode"
 
-  let run lock (ic, file_name, file_digest) ~unit_header ~priv =
+  let run lock (ic, file_name, file_digest, _old_st) ~unit_header ~priv:_ =
     let clos = with_lock lock (fun () ->
-        let old_state = Symtable.current_state () in
         let compunit : compilation_unit = unit_header in
         seek_in ic compunit.cu_pos;
         let code =
@@ -157,7 +156,6 @@ module Bytecode = struct
             seek_in ic compunit.cu_debug;
             [| (Compression.input_value ic : instruct_debug_event list) |]
           end in
-        if priv then Symtable.hide_additions old_state;
         let _, clos = reify_bytecode code events (Some digest) in
         clos
       )
@@ -171,7 +169,7 @@ module Bytecode = struct
         (DT.Error (Library's_module_initializers_failed exn))
         (Printexc.get_raw_backtrace ())
 
-  let load ~filename:file_name ~priv:_ =
+  let load ~filename:file_name ~priv =
     let ic =
       try open_in_bin file_name
       with exc -> raise (DT.Error (Cannot_open_dynamic_library exc))
@@ -183,7 +181,13 @@ module Bytecode = struct
         try really_input_string ic (String.length Config.cmo_magic_number)
         with End_of_file -> raise (DT.Error (Not_a_bytecode_file file_name))
       in
-      let handle = ic, file_name, file_digest in
+      let old_symtable =
+        if priv then
+          Some (Symtable.current_state ())
+        else
+          None
+      in
+      let handle = ic, file_name, file_digest, old_symtable in
       if buffer = Config.cmo_magic_number then begin
         let compunit_pos = input_binary_int ic in  (* Go to descriptor *)
         seek_in ic compunit_pos;
@@ -219,7 +223,12 @@ module Bytecode = struct
     | exception _ -> None
     | obj -> Some obj
 
-  let finish (ic, _filename, _digest) =
+  let finish (ic, _filename, _digest, restore_symtable) =
+    begin match restore_symtable with
+    | Some old_state ->
+      Symtable.hide_additions old_state
+    | None -> ()
+    end;
     close_in ic
 end
 

--- a/testsuite/tests/lib-dynlink-initializers/test10_main.byte.reference
+++ b/testsuite/tests/lib-dynlink-initializers/test10_main.byte.reference
@@ -3,8 +3,8 @@ Raised at Stdlib.failwith in file "stdlib.ml", line 29, characters 17-33
 Called from Test10_plugin.g in file "test10_plugin.ml", line 3, characters 2-21
 Called from Test10_plugin.f in file "test10_plugin.ml", line 6, characters 2-6
 Called from Test10_plugin in file "test10_plugin.ml", line 10, characters 2-6
-Called from Dynlink.Bytecode.run in file "otherlibs/dynlink/byte/dynlink.ml", line 166, characters 16-25
-Re-raised at Dynlink.Bytecode.run in file "otherlibs/dynlink/byte/dynlink.ml", lines 168-170, characters 6-39
+Called from Dynlink.Bytecode.run in file "otherlibs/dynlink/byte/dynlink.ml", line 167, characters 16-25
+Re-raised at Dynlink.Bytecode.run in file "otherlibs/dynlink/byte/dynlink.ml", lines 169-171, characters 6-39
 Called from Dynlink_common.Make.load.(fun) in file "otherlibs/dynlink/dynlink_common.ml", line 356, characters 11-54
 Called from Stdlib__List.iter in file "list.ml", line 112, characters 12-15
 Called from Stdlib__Fun.protect in file "fun.ml", line 34, characters 8-15

--- a/testsuite/tests/lib-dynlink-initializers/test10_main.byte.reference
+++ b/testsuite/tests/lib-dynlink-initializers/test10_main.byte.reference
@@ -3,8 +3,8 @@ Raised at Stdlib.failwith in file "stdlib.ml", line 29, characters 17-33
 Called from Test10_plugin.g in file "test10_plugin.ml", line 3, characters 2-21
 Called from Test10_plugin.f in file "test10_plugin.ml", line 6, characters 2-6
 Called from Test10_plugin in file "test10_plugin.ml", line 10, characters 2-6
-Called from Dynlink.Bytecode.run in file "otherlibs/dynlink/byte/dynlink.ml", line 168, characters 16-25
-Re-raised at Dynlink.Bytecode.run in file "otherlibs/dynlink/byte/dynlink.ml", lines 170-172, characters 6-39
+Called from Dynlink.Bytecode.run in file "otherlibs/dynlink/byte/dynlink.ml", line 166, characters 16-25
+Re-raised at Dynlink.Bytecode.run in file "otherlibs/dynlink/byte/dynlink.ml", lines 168-170, characters 6-39
 Called from Dynlink_common.Make.load.(fun) in file "otherlibs/dynlink/dynlink_common.ml", line 356, characters 11-54
 Called from Stdlib__List.iter in file "list.ml", line 112, characters 12-15
 Called from Stdlib__Fun.protect in file "fun.ml", line 34, characters 8-15


### PR DESCRIPTION
Fix for #13374.

I'm not 100% convinced that we should apply this fix (after all, `loadfile_private` might be expected to load all units of a library as individual private modules, so the error reported in #13374 would be expected).
But given that this fix was not very complex, I feel the discussion would be more productive with the code available.

Note that changing the native version to match the bytecode one (i.e. error when loading privately several files which depend on each other) is probably possible too, although it involves changing how we check crcs (from checking the whole library to checking individual units).