### PR TITLE
Fix `dune build @libs`

### DIFF
--- a/dune
+++ b/dune
@@ -58,13 +58,13 @@
    ;; TYPING
    ident path primitive shape shape_reduce types btype oprint subst predef
    datarepr cmi_format persistent_env env type_immediacy errortrace
-   typedtree printtyped ctype printtyp includeclass mtype envaux includecore
-   tast_iterator tast_mapper signature_group cmt_format untypeast
-   includemod includemod_errorprinter
+   typedtree printtyped ctype printtyp rawprinttyp includeclass mtype envaux
+   includecore tast_iterator tast_mapper signature_group cmt_format untypeast
+   includemod includemod_errorprinter errortrace_report
    typetexp patterns printpat parmatch stypes typeopt typedecl value_rec_check
    typecore
    typeclass typemod typedecl_variance typedecl_properties typedecl_immediacy
-   typedecl_unboxed typedecl_separability cmt2annot
+   typedecl_unboxed typedecl_separability cmt2annot out_type
    ; manual update: mli only files
    annot outcometree value_rec_types
 

--- a/stdlib/dynarray.ml
+++ b/stdlib/dynarray.ml
@@ -463,7 +463,7 @@ let make n x =
 let init (type a) n (f : int -> a) : a t =
   if n < 0 then Error.negative_length_requested "init" n;
   let Dummy.Fresh dummy = global_dummy in
-  let arr = Dummy.Array.init ~dummy n f in
+  let arr = Dummy.Array.init n f ~dummy in
   Pack {
     length = n;
     arr;
@@ -878,7 +878,7 @@ let iteri k a =
   let Pack {arr; length; dummy} = a in
   check_valid_length length arr;
   for i = 0 to length - 1 do
-    k i (unsafe_get arr ~i ~dummy ~length);
+    k i (unsafe_get arr ~dummy ~i ~length);
   done;
   check_same_length "iteri" a ~length
 

--- a/stdlib/format.ml
+++ b/stdlib/format.ml
@@ -1304,7 +1304,7 @@ let pp_print_text ppf s =
   let left = ref 0 in
   let right = ref 0 in
   let flush () =
-    pp_print_substring ppf s ~pos:!left ~len:(!right - !left);
+    pp_print_substring ~pos:!left ~len:(!right - !left) ppf s;
     incr right; left := !right;
   in
   while (!right <> len) do


### PR DESCRIPTION
I'm trying to learn some OCaml internal mechanism.
So I build the whole project according [HACKING.adoc](https://github.com/ocaml/ocaml/blob/trunk/HACKING.adoc). 

Then, to make Merlin work properly. I ran `make clean && dune build @libs`. But I get the following error: 
```sh
File "stdlib/dynarray.ml", line 466, characters 30-35:
466 |   let arr = Dummy.Array.init ~dummy n f in
                                    ^^^^^
Error: The function applied to this argument has type
         int ->
         (int -> 'a) ->
         dummy:'b Dummy.dummy -> ('a, 'b) Dummy.with_dummy array
This argument cannot be applied with label ~dummy
File "stdlib/format.ml", line 1307, characters 34-39:
1307 |     pp_print_substring ppf s ~pos:!left ~len:(!right - !left);
                                         ^^^^^
Error: The function applied to this argument has type
         formatter -> tag -> unit
This argument cannot be applied with label ~pos
File "typing/printtyp.mli", line 67, characters 6-29:
Error: Unbound module Out_type
File "typing/includeclass.mli", line 32, characters 2-25:
Error: Unbound module Out_type
```

This PR try to fix these errors and make `dune build @libs` generate `cmi` as more as possible, so merlin could be used at more places. 

I hope this PR would be useful. And thank you for maintaining this wonderful language!
