### PR TITLE
Fix doc about custom block deserialize function

### DIFF
--- a/manual/src/cmds/intf-c.etex
+++ b/manual/src/cmds/intf-c.etex
@@ -2116,8 +2116,8 @@ reading back the data written by the "serialize" operation, using the
 in section~\ref{ss:c-custom-serialization}. It must then rebuild the data part
 of the custom block and store it at the pointer given as the "dst" argument.
 Finally, it returns the size in bytes of the data part of the custom block.
-This size must be identical to the "wsize_32" result of the "serialize"
-operation if the architecture is 32 bits, or "wsize_64" if the architecture is
+This size must be identical to the "bsize_32" result of the "serialize"
+operation if the architecture is 32 bits, or "bsize_64" if the architecture is
 64 bits.
 
 The "deserialize" field can be set to "custom_deserialize_default"


### PR DESCRIPTION
There's a mismatch in the manual in the explanation of the `serialize` and `deserialize` functions of a custom block. The first one talks about `bsize32` and `bsize64` (sizes in bytes), while the second one talks about `wsize32` and `wsize64` (supposedly, sizes in words, but it should be bytes).