### PR TITLE
Fix memory leaks in bytecode backtraces debug information

### DIFF
--- a/Changes
+++ b/Changes
@@ -549,6 +549,9 @@ _______________
   oversight. No known program triggers the bug.
   (Richard Eisenberg, review by Florian Angeletti)
 
+- #13385: Fix memory leaks in bytecode backtraces debug information.
+  (Antonin Décimo, review by Miod Vallat)
+
 OCaml 5.2.0 (13 May 2024)
 -------------------------
 

--- a/runtime/backtrace_byt.c
+++ b/runtime/backtrace_byt.c
@@ -235,7 +235,6 @@ value caml_add_debug_info(code_t code_start, value code_size, value events_heap)
 value caml_remove_debug_info(code_t start)
 {
   CAMLparam0();
-  CAMLlocal2(dis, prev);
 
   for (int i = 0; i < caml_debug_info.size; i++) {
     struct debug_info *di = caml_debug_info.contents[i];

--- a/runtime/backtrace_byt.c
+++ b/runtime/backtrace_byt.c
@@ -132,6 +132,8 @@ static int cmp_ev_info(const void *a, const void *b)
   return 0;
 }
 
+static const char defname_old_bytecode[] = "<old bytecode>";
+
 static struct ev_info *process_debug_events(code_t code_start,
                                             value events_heap,
                                             mlsize_t *num_events)
@@ -179,7 +181,7 @@ static struct ev_info *process_debug_events(code_t code_start,
         if (events[j].ev_defname == NULL)
           caml_fatal_error ("caml_add_debug_info: out of memory");
       } else {
-        events[j].ev_defname = "<old bytecode>";
+        events[j].ev_defname = (char *)defname_old_bytecode;
       }
 
       events[j].ev_start_lnum = Int_val(Field(ev_start, POS_LNUM));
@@ -239,6 +241,13 @@ value caml_remove_debug_info(code_t start)
   for (int i = 0; i < caml_debug_info.size; i++) {
     struct debug_info *di = caml_debug_info.contents[i];
     if (di->start == start) {
+      for (mlsize_t j = 0; j < di->num_events; j++) {
+        struct ev_info *event = &di->events[j];
+        caml_stat_free(event->ev_filename);
+        if (event->ev_defname != defname_old_bytecode)
+          caml_stat_free(event->ev_defname);
+      }
+      caml_stat_free(di->events);
       /* note that caml_ext_table_remove calls caml_stat_free on the
          removed resource, bracketing the caml_stat_alloc call in
          caml_add_debug_info. */


### PR DESCRIPTION
An `ext_table` (defined in `misc.h`) is an array of pointers to custom data. Each element has been allocated with a function from the `caml_stat_alloc` family. Although `caml_ext_table_remove` will call `caml_stat_free` on an element, it won't call a specific deallocator on that element, potentially leading to leaks if the element contains pointers to other allocated data.

This PR fixes such a leak on `debug_info` structures, appearing when handling exceptions and debug information in bytecode programs.

The problem can be observed by building trunk with the Leak Sanitizer.

<details>

The command:

```bash
$ (export LSAN_OPTIONS='detect_leaks=0,exitcode=0' && \
  ./configure --disable-ocamldoc --disable-native-compiler \
    LDFLAGS='-Wl,--no-as-needed,-ldl' \
    CC='cc -ldl -fsanitize=leak -fno-omit-frame-pointer -O1 -g' && \
  make) && \
  printf "leak:runtime/bigarray.c\nleak:runtime/unix.c" > suppr.txt && \
  LSAN_OPTIONS=suppressions=suppr.txt ./boot/ocamlrun ./ocaml -nostdlib -I ./stdlib -I toplevel -noinit -I otherlibs/dynlink -I otherlibs/runtime_events -I otherlibs/unix \
    <(echo 'raise Not_found;;')
```

yields

```
Exception: Not_found.

=================================================================
==46979==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 48 byte(s) in 1 object(s) allocated from:
    #0 0xfffed741dfcc in malloc (/lib64/liblsan.so.0+0x1dfcc) (BuildId: 8e698df6e4bf6eb6e54bad6c800f46fdb82b2335)
    #1 0x44f2a4 in process_debug_events runtime/backtrace_byt.c:153
    #2 0x44f99c in caml_add_debug_info runtime/backtrace_byt.c:226
    #3 0x442d78 in caml_reify_bytecode runtime/meta.c:79
    #4 0x451b0c in caml_interprete runtime/interp.c:1054
    #5 0x4536f4 in caml_main runtime/startup_byt.c:573
    #6 0x42098c in main runtime/main.c:37
    #7 0xfffed71a0a18 in __libc_start_call_main (/lib64/libc.so.6+0x30a18) (BuildId: b8190645cddcba17b7e5e44f6e4dc52bdac1b43c)
    #8 0xfffed71a0af8 in __libc_start_main_impl (/lib64/libc.so.6+0x30af8) (BuildId: b8190645cddcba17b7e5e44f6e4dc52bdac1b43c)
    #9 0x420a2c in _start (/home/antonin/Tarides/ocaml/trunk/boot/ocamlrun+0x420a2c) (BuildId: fa0905450bf3449bcd6b1692f9d28602bf9d9433)

Indirect leak of 17 byte(s) in 1 object(s) allocated from:
    #0 0xfffed741dfcc in malloc (/lib64/liblsan.so.0+0x1dfcc) (BuildId: 8e698df6e4bf6eb6e54bad6c800f46fdb82b2335)
    #1 0x440388 in caml_stat_alloc_noexc runtime/memory.c:580
    #2 0x440388 in caml_stat_strdup_noexc runtime/memory.c:717
    #3 0x44f324 in process_debug_events runtime/backtrace_byt.c:170
    #4 0x44f99c in caml_add_debug_info runtime/backtrace_byt.c:226
    #5 0x442d78 in caml_reify_bytecode runtime/meta.c:79
    #6 0x451b0c in caml_interprete runtime/interp.c:1054
    #7 0x4536f4 in caml_main runtime/startup_byt.c:573
    #8 0x42098c in main runtime/main.c:37
    #9 0xfffed71a0a18 in __libc_start_call_main (/lib64/libc.so.6+0x30a18) (BuildId: b8190645cddcba17b7e5e44f6e4dc52bdac1b43c)
    #10 0xfffed71a0af8 in __libc_start_main_impl (/lib64/libc.so.6+0x30af8) (BuildId: b8190645cddcba17b7e5e44f6e4dc52bdac1b43c)
    #11 0x420a2c in _start (/home/antonin/Tarides/ocaml/trunk/boot/ocamlrun+0x420a2c) (BuildId: fa0905450bf3449bcd6b1692f9d28602bf9d9433)

Indirect leak of 10 byte(s) in 1 object(s) allocated from:
    #0 0xfffed741dfcc in malloc (/lib64/liblsan.so.0+0x1dfcc) (BuildId: 8e698df6e4bf6eb6e54bad6c800f46fdb82b2335)
    #1 0x440388 in caml_stat_alloc_noexc runtime/memory.c:580
    #2 0x440388 in caml_stat_strdup_noexc runtime/memory.c:717
    #3 0x44f42c in process_debug_events runtime/backtrace_byt.c:178
    #4 0x44f99c in caml_add_debug_info runtime/backtrace_byt.c:226
    #5 0x442d78 in caml_reify_bytecode runtime/meta.c:79
    #6 0x451b0c in caml_interprete runtime/interp.c:1054
    #7 0x4536f4 in caml_main runtime/startup_byt.c:573
    #8 0x42098c in main runtime/main.c:37
    #9 0xfffed71a0a18 in __libc_start_call_main (/lib64/libc.so.6+0x30a18) (BuildId: b8190645cddcba17b7e5e44f6e4dc52bdac1b43c)
    #10 0xfffed71a0af8 in __libc_start_main_impl (/lib64/libc.so.6+0x30af8) (BuildId: b8190645cddcba17b7e5e44f6e4dc52bdac1b43c)
    #11 0x420a2c in _start (/home/antonin/Tarides/ocaml/trunk/boot/ocamlrun+0x420a2c) (BuildId: fa0905450bf3449bcd6b1692f9d28602bf9d9433)

-----------------------------------------------------
Suppressions used:
  count      bytes template
      5       1074 runtime/bigarray.c
      1        256 runtime/unix.c
-----------------------------------------------------

SUMMARY: LeakSanitizer: 75 byte(s) leaked in 3 allocation(s).
```

The same command with this patch applied yields:

```
Exception: Not_found.
-----------------------------------------------------
Suppressions used:
  count      bytes template
      5       1074 runtime/bigarray.c
      1        256 runtime/unix.c
-----------------------------------------------------
```

showing that the leak has been fixed.
</details>