### PR TITLE
Implement the --disable-ocamlobjinfo option for the configure script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -512,7 +512,10 @@ ocamllex_PROGRAMS = $(addprefix lex/,ocamllex ocamllex.opt)
 ocamlyacc_PROGRAM = yacc/ocamlyacc
 
 # Tools to be compiled to native and bytecode, then installed
-TOOLS_TO_INSTALL_NAT = ocamldep ocamlobjinfo
+TOOLS_TO_INSTALL_NAT = ocamldep
+ifeq "$(build_ocamlobjinfo)" "true"
+  TOOLS_TO_INSTALL_NAT += ocamlobjinfo
+endif
 
 # Tools to be compiled to bytecode only, then installed
 TOOLS_TO_INSTALL_BYT = \

--- a/Makefile
+++ b/Makefile
@@ -529,7 +529,8 @@ endif
 # the configuration is not available during clean so we don't
 # know whether they have been configured / built or not
 clean::
-	rm -f $(addprefix tools/ocamlopt,p p.opt p.exe p.opt.exe)
+	rm -f $(addprefix tools/ocamlopt,p p.opt p.exe p.opt.exe) \
+	  tools/ocamlobjinfo $(addprefix tools/ocamlobjinfo,.opt .exe .opt.exe)
 
 TOOLS_NAT = $(TOOLS_TO_INSTALL_NAT)
 TOOLS_BYT = $(TOOLS_TO_INSTALL_BYT) dumpobj primreq stripdebug cmpbyt

--- a/Makefile.build_config.in
+++ b/Makefile.build_config.in
@@ -42,6 +42,7 @@ OCAMLTEST_TARGET = @ocamltest_target@
 OCAMLDOC_OPT_TARGET = @ocamldoc_opt_target@
 OCAMLTEST_OPT_TARGET = @ocamltest_opt_target@
 
+build_ocamlobjinfo = @build_ocamlobjinfo@
 build_ocamltest = @build_ocamltest@
 
 build_ocamltex = @build_ocamltex@

--- a/configure
+++ b/configure
@@ -821,6 +821,7 @@ ocamltest_opt_target
 ocamltest_target
 ocamltest
 build_ocamltest
+build_ocamlobjinfo
 documentation_tool_cmd
 documentation_tool
 with_ocamldoc
@@ -992,6 +993,7 @@ enable_unix_lib
 enable_bigarray_lib
 enable_ocamldoc
 with_odoc
+enable_ocamlobjinfo
 enable_ocamltest
 enable_native_toplevel
 enable_frame_pointers
@@ -1686,6 +1688,7 @@ Optional Features:
   --disable-str-lib       do not build the str library
   --disable-unix-lib      do not build the unix library
   --disable-ocamldoc      do not build the ocamldoc documentation system
+  --disable-ocamlobjinfo  do not build ocamlobjinfo
   --disable-ocamltest     do not build ocamltest
   --enable-native-toplevel
                           build the native toplevel
@@ -3514,6 +3517,7 @@ LINEAR_MAGIC_NUMBER=Caml1999L035
 
 
 
+
 ## Generated files
 
 ac_config_files="$ac_config_files Makefile.build_config"
@@ -3932,6 +3936,12 @@ then :
   withval=$with_odoc;
 fi
 
+
+# Check whether --enable-ocamlobjinfo was given.
+if test ${enable_ocamlobjinfo+y}
+then :
+  enableval=$enable_ocamlobjinfo;
+fi
 
 
 # Check whether --enable-ocamltest was given.
@@ -20582,7 +20592,12 @@ then :
 
 fi
 
-
+if test x"$enable_ocamlobjinfo" != 'xno'
+then :
+  build_ocamlobjinfo=true
+else $as_nop
+  build_ocamlobjinfo=false
+fi
 
 case $enable_ocamltest,true in #(
   yes,*|,true) :

--- a/configure.ac
+++ b/configure.ac
@@ -218,6 +218,7 @@ AC_SUBST([ocamldoc_opt_target])
 AC_SUBST([with_ocamldoc])
 AC_SUBST([documentation_tool])
 AC_SUBST([documentation_tool_cmd])
+AC_SUBST([build_ocamlobjinfo])
 AC_SUBST([build_ocamltest])
 AC_SUBST([ocamltest])
 AC_SUBST([ocamltest_target])
@@ -441,6 +442,9 @@ AC_ARG_WITH([odoc],
   [AS_HELP_STRING([--with-odoc],
     [build documentation with odoc])])
 
+AC_ARG_ENABLE([ocamlobjinfo],
+  [AS_HELP_STRING([--disable-ocamlobjinfo],
+    [do not build ocamlobjinfo])])
 
 AC_ARG_ENABLE([ocamltest],
   [AS_HELP_STRING([--disable-ocamltest],
@@ -2479,7 +2483,9 @@ AC_ARG_WITH([odoc],
 AS_IF([test "x$documentation_tool_cmd" = 'x']
  [documentation_tool_cmd="$documentation_tool"])
 
-
+AS_IF([test x"$enable_ocamlobjinfo" != 'xno'],
+  [build_ocamlobjinfo=true],
+  [build_ocamlobjinfo=false])
 
 AS_CASE([$enable_ocamltest,OCAML__DEVELOPMENT_VERSION],
   [yes,*|,true],


### PR DESCRIPTION
This allows to disable the build of the ocamlobjinfo tool.
When used in conjunction with --disable-native-compiler,
it makes it possible to avoid the build of Flambda completely
while one wants to test only the bytecode compiler.

Indeed, when building only the byte code compiler, it's only because of
its use in ocamlobjinfo that Flambda gets built.

When building the bytecode compiler only, also disabling the build of
ocamlobjinfo saves ~12s of build time on my machine for a sequential
build.