### PR TITLE
Branch-after-load scheme for OCaml memory model on Arm64

### DIFF
--- a/asmcomp/arm64/emit.mlp
+++ b/asmcomp/arm64/emit.mlp
@@ -468,10 +468,12 @@ module BR = Branch_relaxation.Make (struct
       else if alloc then 4
       else 8
     | Lop (Istackoffset _) -> 2
-    | Lop (Iload { memory_chunk; addressing_mode }) ->
+    | Lop (Iload { memory_chunk; addressing_mode; is_atomic; mutability }) ->
       let based = match addressing_mode with Iindexed _ -> 0 | Ibased _ -> 1
       and insns = match memory_chunk with
-        | Word_int | Word_val | Single -> 2
+        | Single -> 2
+        | (Word_int | Word_val)
+            when is_atomic || mutability = Asttypes.Mutable -> 2
         | _ -> 1
       in
       based + insns
@@ -766,7 +768,7 @@ let emit_instr env i =
         assert (n mod 16 = 0);
         emit_stack_adjustment (-n);
         env.stack_offset <- env.stack_offset + n
-    | Lop(Iload { memory_chunk; addressing_mode; is_atomic }) ->
+    | Lop(Iload { memory_chunk; addressing_mode; is_atomic; mutability }) ->
         assert(memory_chunk = Word_int || memory_chunk = Word_val || is_atomic = false);
         let dst = i.res.(0) in
         let base =
@@ -794,14 +796,19 @@ let emit_instr env i =
             `	fcvt	{emit_reg dst}, s7\n`
         | Word_int | Word_val ->
             if is_atomic then begin
-              assert (addressing_mode = Iindexed 0);
+              assert (addressing_mode = Iindexed 0 &&
+                      mutability = Asttypes.Mutable);
               `	dmb	ishld\n`;
               `	ldar	{emit_reg dst}, [{emit_reg i.arg.(0)}]\n`
             end else begin
-              let lbl = new_label () in
-              `	ldr	{emit_reg dst}, {emit_addressing addressing_mode base}\n`;
-              `	cbz	{emit_reg dst}, {emit_label lbl}\n`;
-              `{emit_label lbl}:\n`
+              match mutability with
+              | Asttypes.Mutable ->
+                  let lbl = new_label () in
+                  `    ldr     {emit_reg dst}, {emit_addressing addressing_mode base}\n`;
+                  `    cbz     {emit_reg dst}, {emit_label lbl}\n`;
+                  `{emit_label lbl}:\n`
+              | Immutable ->
+                  `    ldr     {emit_reg dst}, {emit_addressing addressing_mode base}\n`
             end
         | Double ->
             `	ldr	{emit_reg dst}, {emit_addressing addressing_mode base}\n`

--- a/asmcomp/arm64/emit.mlp
+++ b/asmcomp/arm64/emit.mlp
@@ -464,8 +464,8 @@ module BR = Branch_relaxation.Make (struct
     | Lop (Itailcall_imm { func; _ }) ->
       if func = f.fun_name then 1 else epilogue_size f
     | Lop (Iextcall {alloc; stack_ofs} ) ->
-      if stack_ofs > 0 then 6
-      else if alloc then 4
+      if stack_ofs > 0 then 5
+      else if alloc then 3
       else 8
     | Lop (Istackoffset _) -> 2
     | Lop (Iload { memory_chunk; addressing_mode; is_atomic; mutability }) ->
@@ -742,12 +742,10 @@ let emit_instr env i =
           emit_load_symbol_addr reg_x8 func;
           `	bl	{emit_symbol "caml_c_call_stack_args"}\n`;
           `{record_frame env i.live (Dbg_other i.dbg)}\n`;
-          `	dmb	ishld\n`
         end else if alloc then begin
           emit_load_symbol_addr reg_x8 func;
           `	bl	{emit_symbol "caml_c_call"}\n`;
           `{record_frame env i.live (Dbg_other i.dbg)}\n`;
-          `	dmb	ishld\n`
         end else begin
           (* Push frame pointer (x29) onto stack and restore later. *)
           `	str	x29, [sp, -16]!\n`;

--- a/asmcomp/arm64/emit.mlp
+++ b/asmcomp/arm64/emit.mlp
@@ -464,23 +464,21 @@ module BR = Branch_relaxation.Make (struct
     | Lop (Itailcall_imm { func; _ }) ->
       if func = f.fun_name then 1 else epilogue_size f
     | Lop (Iextcall {alloc; stack_ofs} ) ->
-      if stack_ofs > 0 then 5
-      else if alloc then 3
-      else 7
+      if stack_ofs > 0 then 6
+      else if alloc then 4
+      else 8
     | Lop (Istackoffset _) -> 2
-    | Lop (Iload  { memory_chunk; addressing_mode; is_atomic }) ->
+    | Lop (Iload { memory_chunk; addressing_mode }) ->
       let based = match addressing_mode with Iindexed _ -> 0 | Ibased _ -> 1
-      and barrier = if is_atomic then 1 else 0
-      and single = match memory_chunk with Single -> 2 | _ -> 1 in
-      based + barrier + single
-    | Lop (Istore (memory_chunk, addressing_mode, assignment)) ->
+      and insns = match memory_chunk with
+        | Word_int | Word_val | Single -> 2
+        | _ -> 1
+      in
+      based + insns
+    | Lop (Istore (memory_chunk, addressing_mode, _assignment)) ->
       let based = match addressing_mode with Iindexed _ -> 0 | Ibased _ -> 1
-      and barrier =
-        match memory_chunk, assignment with
-        | (Word_int | Word_val), true -> 1
-        | _ -> 0
       and single = match memory_chunk with Single -> 2 | _ -> 1 in
-      based + barrier + single
+      based + single
     | Lop (Ialloc _) when f.fun_fast -> 5
     | Lop (Ispecific (Ialloc_far _)) when f.fun_fast -> 6
     | Lop (Ipoll _) -> 3
@@ -741,11 +739,13 @@ let emit_instr env i =
           `	add	{emit_reg reg_stack_arg_end}, sp, #{emit_int (Misc.align stack_ofs 16)}\n`;
           emit_load_symbol_addr reg_x8 func;
           `	bl	{emit_symbol "caml_c_call_stack_args"}\n`;
-          `{record_frame env i.live (Dbg_other i.dbg)}\n`
+          `{record_frame env i.live (Dbg_other i.dbg)}\n`;
+          `	dmb	ishld\n`
         end else if alloc then begin
           emit_load_symbol_addr reg_x8 func;
           `	bl	{emit_symbol "caml_c_call"}\n`;
-          `{record_frame env i.live (Dbg_other i.dbg)}\n`
+          `{record_frame env i.live (Dbg_other i.dbg)}\n`;
+          `	dmb	ishld\n`
         end else begin
           (* Push frame pointer (x29) onto stack and restore later. *)
           `	str	x29, [sp, -16]!\n`;
@@ -759,6 +759,7 @@ let emit_instr env i =
           `	bl	{emit_symbol func}\n`;
           `	mov	sp, x29\n`;
           `	ldr	x29, [sp], 16\n`;
+          `	dmb	ishld\n`;
           cfi_restore_state ()
         end
     | Lop(Istackoffset n) ->
@@ -796,12 +797,16 @@ let emit_instr env i =
               assert (addressing_mode = Iindexed 0);
               `	dmb	ishld\n`;
               `	ldar	{emit_reg dst}, [{emit_reg i.arg.(0)}]\n`
-            end else
-              `	ldr	{emit_reg dst}, {emit_addressing addressing_mode base}\n`
+            end else begin
+              let lbl = new_label () in
+              `	ldr	{emit_reg dst}, {emit_addressing addressing_mode base}\n`;
+              `	cbz	{emit_reg dst}, {emit_label lbl}\n`;
+              `{emit_label lbl}:\n`
+            end
         | Double ->
             `	ldr	{emit_reg dst}, {emit_addressing addressing_mode base}\n`
         end
-    | Lop(Istore(size, addr, assignment)) ->
+    | Lop(Istore(size, addr, _assignment)) ->
         (* NB: assignments other than Word_int and Word_val do not follow the
         Multicore OCaml memory model and so do not emit a barrier *)
         let src = i.arg.(0) in
@@ -823,8 +828,6 @@ let emit_instr env i =
             `	fcvt	s7, {emit_reg src}\n`;
             `	str	s7, {emit_addressing addr base}\n`;
         | Word_int | Word_val ->
-            (* memory model barrier for non-initializing store *)
-            if assignment then `	dmb	ishld\n`;
             `	str	{emit_reg src}, {emit_addressing addr base}\n`
         | Double ->
             `	str	{emit_reg src}, {emit_addressing addr base}\n`

--- a/runtime/arm64.S
+++ b/runtime/arm64.S
@@ -544,6 +544,8 @@ FUNCTION(caml_c_call)
         str     TRAP_PTR, Caml_state(exn_handler)
     /* Call the function */
         blr     ADDITIONAL_ARG
+    /* Insert the fence for branch-after-load memory model */
+        dmb     ishld
     /* Reload new allocation pointer & exn handler */
         ldr     ALLOC_PTR, Caml_state(young_ptr)
         ldr     TRAP_PTR, Caml_state(exn_handler)
@@ -596,6 +598,8 @@ FUNCTION(caml_c_call_stack_args)
         b       1b
 2:  /* Call the function */
         blr     ADDITIONAL_ARG
+    /* Insert the fence for branch-after-load memory model */
+        dmb     ishld
     /* Restore stack */
         mov     sp, x19
     /* Reload new allocation pointer & exn handler */
@@ -638,6 +642,8 @@ FUNCTION(caml_start_program)
 /* Arguments to the OCaml code are in x0...x7 */
 
 L(jump_to_caml):
+    /* Insert the fence for branch-after-load memory model */
+        dmb     ishld
     /* Set up stack frame and save callee-save registers */
         CFI_OFFSET(29, -160)
         CFI_OFFSET(30, -152)


### PR DESCRIPTION
**Note:** The PR message is continually updated based on the conversation in the thread. As a result, the conversation thread may feel out of sync.

----

In [issue #13262](https://github.com/ocaml/ocaml/issues/13262), it was observed that there was a significant slowdown on macOS in OCaml 5 compared to OCaml 4. This was attributed to the `dmb ishld` fence before the non-atomic stores, which is necessary for preserving the load-to-store ordering for the OCaml memory model on Arm64. It was also [observed in the same thread](https://github.com/ocaml/ocaml/issues/13262#issuecomment-2194162201) that switching to an alternate scheme for enforcing the ordering (which inserts a dependent branch on the value read from a non-atomic load) suffers much less overhead. It was then suggested that we should consider providing the alternative compilation scheme in the OCaml compiler. This PR implements the scheme. 

The current scheme is the fence-before-store (FBS), implemented in [PR #10972 Arm64 multicore support](https://github.com/ocaml/ocaml/pull/10972). The reasoning for this scheme is explained in [PR #10995 Explain mapping between OCaml memory model and C](https://github.com/ocaml/ocaml/pull/10995). The alternative scheme inserts a branch-after-load (BAL). Both schemes are described in [Table 5 of the OCaml memory model paper](https://kcsrk.info/papers/pldi18-memory.pdf#page=9.15). We will attempt to follow a reasoning similar to the one used in [PR #10995](https://github.com/ocaml/ocaml/pull/10995). 

## Requirements

There are a couple of requirements for implementing BAL in the OCaml compiler.

**RQ1:** The non-atomic store should be implemented as cheaply as possible. Concretely, BAL avoids the `dmb ishlb` fence before the store.
**RQ2:** The non-atomic load is implemented using `Field` macro in C FFI. `Field` is an l-value, and must be preserved as one to avoid breaking the C FFI.

## Deriving the compilation scheme

Following from #10995, the operations are mapped to the following in C:

|OCaml operation | C operation |
|--|--|
| Atomic load | atomic_load_explicit(..., memory_order_seq_cst) |
| Atomic store | atomic_exchange_explicit(..., memory_order_seq_cst) |
| Non-atomic load | atomic_load_explicit(..., memory_order_acquire) |
| Non-atomic store | atomic_store_explicit(..., memory_order_release) |

Given that we have to maintain `Field` macro (RQ2), which does a non-atomic load, as an l-value, we can't use `atomic_load_explicit(...,memory_order_acquire)`. We either have to compile this to a `volatile*` as is the case today or make this an `_Atomic`, which would be too expensive. Hence, on the C FFI side, we follow the compilation scheme similar to FBS. 

| OCaml operation | C operation |
|--|--|
| Atomic load | atomic_thread_fence(memory_order_acquire); <br> atomic_load_explicit(..., memory_order_seq_cst) |
| Atomic store | atomic_thread_fence(memory_order_acquire); <br> atomic_exchange_explicit(..., memory_order_seq_cst) |
| Non-atomic load |	load `volatile*` field | 
| Nonatomic store | atomic_thread_fence(memory_order_acquire); <br> atomic_store_explicit(..., memory_order_release) |

Similar to #10995, we can start with the optimised instruction sequence for the FBS scheme on ARMv8:

| OCaml operation | ARMv8 operation |
|--|--|
| Atomic load | dmb ishld; ldar |
| Atomic store | L: ldaxr; stlxr; cbnz L; dmb st |
| Non-atomic load | ldr | 
| Non-atomic store | dmb ishld; str |

Our goal is to eliminate `dmb ishld` from the non-atomic store. `dmb ishld` waits for prior loads to complete and hence preserves load-store ordering. For the atomic load, `ldar` also guarantees that the atomic load is ordered before subsequent operations. So, the ordering between atomic load and non-atomic store is guaranteed even in the absence of `dmb ishld`. For ordering the non-atomic load before the non-atomic store, we can compile the non-atomic load by inserting a branch after load `ldr R, [x]; cbz R, L; L:` to introduce a control dependency which preserves the non-atomic load to non-atomic store order. See [section 4.4 in this tutorial intro to Arm and Power memory models](https://www.cl.cam.ac.uk/~pes20/ppc-supplemental/test7.pdf#page=15.86).

| OCaml operation | ARMv8 operation |
|--|--|
| Atomic load | dmb ishld; ldar |
| Atomic store | L: ldaxr; stlxr; cbnz L; dmb st |
| Non-atomic load | ldr R, [x]; cbz R, L; L: | 
| Non-atomic store | str |

## Refining the non-atomic stores

In the compiler, the non-atomic stores need to be further refined into the following classes:

1. Initialising stores
2. Non-initialising writes of integers (no publication)
3. Non-initialising writes of pointers (possible publication; `caml_modify`)

See the discussion at https://github.com/ocaml/ocaml/pull/10972#issuecomment-1030596278. Extending the table above

| OCaml operation | ARMv8 operation |
|--|--|
| Atomic load | dmb ishld; ldar |
| Atomic store | L: ldaxr; stlxr; cbnz L; dmb st |
| Non-atomic load | ldr R, [x]; cbz R, L; L: | 
| Non-atomic store -- initialising | str |
| Non-atomic store -- non-initialising & integer | str |
| Non-atomic store -- non-initialising & pointer | stlr (in `caml_modify`) |

For the non-initialising writes of pointers, `stlr` is necessary for publication safety in `caml_modify`. 

## Taking advantage of immutability 

Recall that we needed the branch after load to forbid po ∪ rf cycles which are possible on ARMv8 due to load buffering (see [section 7.3 in the paper](https://kcsrk.info/papers/pldi18-memory.pdf#page=9.15)). With the control dependencies alone, this cycle is forbidden. See `LB+ctrls` litmus test: https://github.com/herd/herdtools7/blob/master/doc/tst-arm/LB%2Bctrls.litmus. 

```
% cat LB+ctrls.litmus 
ARM LB+ctrls
"DpCtrldW Rfe DpCtrldW Rfe"
Cycle=Rfe DpCtrldW Rfe DpCtrldW
Prefetch=0:x=F,0:y=W,1:y=F,1:x=W
Com=Rf Rf
Orig=DpCtrldW Rfe DpCtrldW Rfe
{
%x0=x; %y0=y;
%y1=y; %x1=x;
}
 P0           | P1           ;
 LDR R0,[%x0] | LDR R0,[%y1] ; (* load *)
 CMP R0,R0    | CMP R0,R0    ;
 BNE LC00     | BNE LC01     ; (* introduce control dependency *)
 LC00:        | LC01:        ;
 MOV R1,#1    | MOV R1,#1    ;
 STR R1,[%y0] | STR R1,[%x1] ; (* store *)
exists
(0:R0=1 /\ 1:R0=1)
```

This corresponds to the program

```
P0          | P1
let r0 = !x | let r0 = !y
y := 1      | x := 1
```

```
% herd7 LB+ctrls.litmus
Test LB+ctrls Allowed
States 3
0:R0=0; 1:R0=0;
0:R0=0; 1:R0=1;
0:R0=1; 1:R0=0;
No
Witnesses
Positive: 0 Negative: 3
Condition exists (0:R0=1 /\ 1:R0=1)
Observation LB+ctrls Never 0 3
Time LB+ctrls 0.00
Hash=4b0b314730fba79fe7f1ecb94bafdc03
```

`0:R0=1 /\ 1:R0=1` is not allowed.

Observe that we cannot create a po ∪ rf cycle in a purely functional program. In the program above, if we consider the stores to be the initialising stores to that object, it can't be that the other thread knows about this location before the object is initialised. We need a publishing write. A minimal example would be something like:

```
type t = {f: int}

P0              | P1
let r0 = !x     | let r0 = !z
let y = {f = 1} | let r0 = r0.f
z := y          | x := 1
```

which uses `z` to publish the object `y`. The write to `z` would be a publishing write, and will be an `stlr`. This will ensure that prior memory operations are seen before the write to `z` is seen. This will prevent `r0`s on the different threads to both witness 1. Here is my attempt at capturing this as a limus test:

```
$  cat bal.litmus 
ARM BAL
{
%x0=x; %x1=x; 
%y0=y;
%z0=z;%z1=z;
}
 P0             | P1           ;
 LDR R0,[%x0]   | LDR R0,[%z1] ;
 CMP R0,R0      | LDR R0,[R0]  ;
 BNE LC00       | MOV R1,#1    ;
 LC00:          | STR R1,[%x1] ;
 MOV R1,#1      |              ; 
 STR R1,[%y0]   |              ;
 DMB            |              ;
 STR %y0,[%z0]  |              ;
exists
(0:R0=1 /\ 1:R0=1)
```

(Note: I'm new to herd tools. Unclear to me why I can't use STLR on P0 for the last 2 instructions. CC @maranget)

```
% herd7 bal.litmus
Test BAL Allowed
States 1
0:R0=0; 1:R0=1;
No
Witnesses
Positive: 0 Negative: 1
Condition exists (0:R0=1 /\ 1:R0=1)
Observation BAL Never 0 1
Time BAL 0.01
Hash=b9e34a85720b14a8d931928310d9d0b0
```

The only possible outcome is `0:R0=0; 1:R0=1`. 

With this, we arrive at an updated compilation scheme:

| OCaml operation | ARMv8 operation |
|--|--|
| Atomic load | dmb ishld; ldar |
| Atomic store | L: ldaxr; stlxr; cbnz L; dmb st |
| Non-atomic load -- immutable field | ldr | 
| Non-atomic load -- mutable field | ldr R, [x]; cbz R, L; L: | 
| Non-atomic store -- initialising | str |
| Non-atomic store -- non-initialising & integer | str |
| Non-atomic store -- non-initialising & pointer | stlr (in `caml_modify`) |

## Handling mixed C and OCaml access

While we have added control dependency to the non-atomic loads done in OCaml, we still haven't handled them in C. Since the C operations mirror the FBS scheme, the necessary acquire fence to enforce load-store ordering is still present before the C implementations of atomic load, atomic store, and non-atomic store. 

The problematic case is the mix of C and OCaml. Consider the case when there is a non-atomic load in C followed by a non-atomic store in OCaml. The non-atomic loads in C are loads of [volatile*] kind, but that does rule out load buffering (reordering of load and subsequent store) at the hardware level. To prevent load buffering, we insert a `dmb ishld` on the return path of external calls.

## Changes necessary for the BAL scheme

The changes necessary are:

1. Adding the control dependency after the non-atomic load of mutable fields.
2. Removing the `dmb ishld` fence from the non-atomic store.
3. Inserting a `dmb ishld` fence in the epilogue of external calls.

All of these changes are in the `asmcomp/arm64/emit.mlp` file.

## Status of the PR

The PR is still a draft to receive feedback. Currently, it replaces FBS with BAL scheme. As mentioned in https://github.com/ocaml/ocaml/issues/13262#issuecomment-2298077759, we'll need to implement a configure time option to choose between the schemes.

## Performance impact

### Runtime

On the [array blit benchmark from #13262](https://github.com/ocaml/ocaml/issues/13262#issuecomment-2194012673) on a M2 MacBook pro,

on `trunk`:

```
% make test
Benchmark 1: polymorphic array blit
  Time (mean ± σ):      55.6 ms ±   0.6 ms    [User: 54.5 ms, System: 0.5 ms]
  Range (min … max):    55.1 ms …  58.0 ms    54 runs
  
Benchmark 2: monomorphic array blit
  Time (mean ± σ):     701.9 ms ± 101.0 ms    [User: 689.3 ms, System: 1.6 ms]
  Range (min … max):   477.7 ms … 852.5 ms    30 runs
 
Benchmark 3: standard library Array.blit
  Time (mean ± σ):      45.9 ms ±   6.2 ms    [User: 43.9 ms, System: 0.6 ms]
  Range (min … max):    43.2 ms …  85.6 ms    68 runs
  
Benchmark 4: C library memcpy
  Time (mean ± σ):       3.9 ms ±   0.2 ms    [User: 3.2 ms, System: 0.5 ms]
  Range (min … max):     3.8 ms …   5.7 ms    766 runs
  
Summary
  C library memcpy ran
   11.71 ± 1.66 times faster than standard library Array.blit
   14.19 ± 0.68 times faster than polymorphic array blit
  179.06 ± 27.09 times faster than monomorphic array blit
```

on this PR:

```
% make test
Benchmark 1: polymorphic array blit
  Time (mean ± σ):      55.7 ms ±   0.5 ms    [User: 54.7 ms, System: 0.5 ms]
  Range (min … max):    55.2 ms …  57.7 ms    53 runs
 
Benchmark 2: monomorphic array blit
  Time (mean ± σ):      16.2 ms ±   0.2 ms    [User: 15.4 ms, System: 0.5 ms]
  Range (min … max):    16.0 ms …  17.4 ms    186 runs
  
Benchmark 3: standard library Array.blit
  Time (mean ± σ):      44.9 ms ±   0.8 ms    [User: 43.9 ms, System: 0.5 ms]
  Range (min … max):    43.8 ms …  47.0 ms    66 runs
 
Benchmark 4: C library memcpy
  Time (mean ± σ):       3.9 ms ±   0.1 ms    [User: 3.2 ms, System: 0.5 ms]
  Range (min … max):     3.8 ms …   4.8 ms    748 runs
  
Summary
  C library memcpy ran
    4.15 ± 0.11 times faster than monomorphic array blit
   11.53 ± 0.35 times faster than standard library Array.blit
   14.30 ± 0.37 times faster than polymorphic array blit
```

On 4.14.1:

```
 % make test
Benchmark 1: polymorphic array blit
  Time (mean ± σ):      56.9 ms ±   1.7 ms    [User: 55.9 ms, System: 0.5 ms]
  Range (min … max):    54.9 ms …  62.1 ms    51 runs
 
Benchmark 2: monomorphic array blit
  Time (mean ± σ):      14.4 ms ±   0.2 ms    [User: 13.7 ms, System: 0.5 ms]
  Range (min … max):    14.1 ms …  16.2 ms    208 runs
  
Benchmark 3: standard library Array.blit
  Time (mean ± σ):      43.5 ms ±   0.7 ms    [User: 42.6 ms, System: 0.5 ms]
  Range (min … max):    42.9 ms …  46.4 ms    69 runs
  
Benchmark 4: C library memcpy
  Time (mean ± σ):       3.7 ms ±   0.6 ms    [User: 3.0 ms, System: 0.4 ms]
  Range (min … max):     3.5 ms …  16.2 ms    796 runs
  
Summary
  C library memcpy ran
    3.92 ± 0.70 times faster than monomorphic array blit
   11.84 ± 2.10 times faster than standard library Array.blit
   15.49 ± 2.78 times faster than polymorphic array blit
```

The performance of monomorphic array blit is much closer to 4.14.1 with this PR. 

### Codesize

There is a marked code size impact for BAL (this PR). The code size is measured simply as the size of the binary (`ls -l`)

| program | trunk | this PR | % diff |
|--|--|--|--|
| ocamlopt.opt | 13408768 | 13984416 | 4.29 |
| ocamlc.opt | 10500648 | 11007400 | 4.83 |