### PR TITLE
Fix `ocamlc` `-pp` wrong documentation

### DIFF
--- a/man/ocamlc.1
+++ b/man/ocamlc.1
@@ -600,12 +600,8 @@ Cause the compiler to call the given
 .I command
 as a preprocessor for each source file. The output of
 .I command
-is redirected to
-an intermediate file, which is compiled. If there are no compilation
-errors, the intermediate file is deleted afterwards. The name of this
-file is built from the basename of the source file with the
-extension .ppi for an interface (.mli) file and .ppo for an
-implementation (.ml) file.
+is redirected to an intermediate file, which is compiled. If there are
+no compilation errors, the intermediate file is deleted afterwards.
 .TP
 .BI \-ppx " command"
 After parsing, pipe the abstract syntax tree through the preprocessor

--- a/man/ocamlopt.1
+++ b/man/ocamlopt.1
@@ -529,9 +529,8 @@ Cause the compiler to call the given
 .I command
 as a preprocessor for each source file. The output of
 .I command
-is redirected to
-an intermediate file, which is compiled. If there are no compilation
-errors, the intermediate file is deleted afterwards.
+is redirected to an intermediate file, which is compiled. If there are
+no compilation errors, the intermediate file is deleted afterwards.
 .TP
 .BI \-ppx " command"
 After parsing, pipe the abstract syntax tree through the preprocessor


### PR DESCRIPTION
The `-pp` option never behaved as described. The suffix part of `Filename.temp_file` was always empty in `Pparse.call_external_preprocessor`.
We could also document that the intermediate file is deleted if the pre-processing fails, or keep it instead.