### PR TITLE
[refactoring] Simplify the Patomic_load primitive by dropping immediate information

### DIFF
--- a/asmcomp/cmmgen.ml
+++ b/asmcomp/cmmgen.ml
@@ -508,7 +508,7 @@ let rec transl env e =
       | ((Pfield_computed|Psequand
          | Prunstack | Pperform | Presume | Preperform
          | Pdls_get
-         | Patomic_load _
+         | Patomic_load
          | Psequor | Pnot | Pnegint | Paddint | Psubint
          | Pmulint | Pandint | Porint | Pxorint | Plslint
          | Plsrint | Pasrint | Pintoffloat | Pfloatofint
@@ -831,9 +831,7 @@ and transl_prim_1 env p arg dbg =
        dbg)
   | Pdls_get ->
       Cop(Cdls_get, [transl env arg], dbg)
-  | Patomic_load {immediate_or_pointer = Immediate} ->
-      Cop(mk_load_atomic Word_int, [transl env arg], dbg)
-  | Patomic_load {immediate_or_pointer = Pointer} ->
+  | Patomic_load ->
       Cop(mk_load_atomic Word_val, [transl env arg], dbg)
   | Ppoll ->
     (Csequence (remove_unit (transl env arg),
@@ -1024,7 +1022,7 @@ and transl_prim_2 env p arg1 arg2 dbg =
                      [transl_unbox_int dbg env bi arg1;
                       transl_unbox_int dbg env bi arg2], dbg)) dbg
   | Prunstack | Pperform | Presume | Preperform | Pdls_get
-  | Patomic_load _
+  | Patomic_load
   | Pnot | Pnegint | Pintoffloat | Pfloatofint | Pnegfloat
   | Pabsfloat | Pstringlength | Pbyteslength | Pbytessetu | Pbytessets
   | Pisint | Pbswap16 | Pint_as_pointer | Popaque | Pread_symbol _
@@ -1091,7 +1089,7 @@ and transl_prim_3 env p arg1 arg2 arg3 dbg =
            dbg)
 
   | Pperform | Pdls_get | Presume
-  | Patomic_load _
+  | Patomic_load
   | Pfield_computed | Psequand | Psequor | Pnot | Pnegint | Paddint
   | Psubint | Pmulint | Pandint | Porint | Pxorint | Plslint | Plsrint | Pasrint
   | Pintoffloat | Pfloatofint | Pnegfloat | Pabsfloat | Paddfloat | Psubfloat
@@ -1124,7 +1122,7 @@ and transl_prim_4 env p arg1 arg2 arg3 arg4 dbg =
   | Pbytessetu | Pbytessets | Parraysetu _
   | Parraysets _ | Pbytes_set _ | Pbigstring_set _
   | Prunstack | Preperform | Pperform | Pdls_get
-  | Patomic_load _
+  | Patomic_load
   | Pfield_computed | Psequand | Psequor | Pnot | Pnegint | Paddint
   | Psubint | Pmulint | Pandint | Porint | Pxorint | Plslint | Plsrint | Pasrint
   | Pintoffloat | Pfloatofint | Pnegfloat | Pabsfloat | Paddfloat | Psubfloat

--- a/bytecomp/bytegen.ml
+++ b/bytecomp/bytegen.ml
@@ -164,7 +164,7 @@ let preserve_tailcall_for_prim = function
   | Pbytes_set_64 _ | Pbigstring_load_16 _ | Pbigstring_load_32 _
   | Pbigstring_load_64 _ | Pbigstring_set_16 _ | Pbigstring_set_32 _
   | Pbigstring_set_64 _ | Pctconst _ | Pbswap16 | Pbbswap _ | Pint_as_pointer
-  | Patomic_load _
+  | Patomic_load
   | Pdls_get ->
       false
 
@@ -488,7 +488,7 @@ let comp_primitive stack_info p sz args =
   | Pint_as_pointer -> Kccall("caml_int_as_pointer", 1)
   | Pbytes_to_string -> Kccall("caml_string_of_bytes", 1)
   | Pbytes_of_string -> Kccall("caml_bytes_of_string", 1)
-  | Patomic_load _ -> Kccall("caml_atomic_load", 1)
+  | Patomic_load -> Kccall("caml_atomic_load", 1)
   | Pdls_get -> Kccall("caml_domain_dls_get", 1)
   | Ppoll -> Kccall("caml_process_pending_actions_with_root", 1)
   (* The cases below are handled in [comp_expr] before the [comp_primitive] call

--- a/lambda/lambda.ml
+++ b/lambda/lambda.ml
@@ -143,7 +143,7 @@ type primitive =
   (* Integer to external pointer *)
   | Pint_as_pointer
   (* Atomic operations *)
-  | Patomic_load of {immediate_or_pointer : immediate_or_pointer}
+  | Patomic_load
   (* Inhibition of optimisation *)
   | Popaque
   (* Fetching domain-local state *)

--- a/lambda/lambda.mli
+++ b/lambda/lambda.mli
@@ -29,7 +29,9 @@ type compile_time_constant =
 
 type immediate_or_pointer =
   | Immediate
+  (* The value must be immediate. *)
   | Pointer
+  (* The value may be a pointer or an immediate. *)
 
 type initialization_or_assignment =
   | Assignment

--- a/lambda/lambda.mli
+++ b/lambda/lambda.mli
@@ -155,7 +155,7 @@ type primitive =
   (* Integer to external pointer *)
   | Pint_as_pointer
   (* Atomic operations *)
-  | Patomic_load of {immediate_or_pointer : immediate_or_pointer}
+  | Patomic_load
   (* Inhibition of optimisation *)
   | Popaque
   (* Fetching domain-local state *)

--- a/lambda/printlambda.ml
+++ b/lambda/printlambda.ml
@@ -350,10 +350,7 @@ let primitive ppf = function
   | Pbswap16 -> fprintf ppf "bswap16"
   | Pbbswap(bi) -> print_boxed_integer "bswap" ppf bi
   | Pint_as_pointer -> fprintf ppf "int_as_pointer"
-  | Patomic_load {immediate_or_pointer} ->
-      (match immediate_or_pointer with
-        | Immediate -> fprintf ppf "atomic_load_imm"
-        | Pointer -> fprintf ppf "atomic_load_ptr")
+  | Patomic_load -> fprintf ppf "atomic_load"
   | Popaque -> fprintf ppf "opaque"
   | Pdls_get -> fprintf ppf "dls_get"
   | Ppoll -> fprintf ppf "poll"
@@ -459,10 +456,7 @@ let name_of_primitive = function
   | Pbswap16 -> "Pbswap16"
   | Pbbswap _ -> "Pbbswap"
   | Pint_as_pointer -> "Pint_as_pointer"
-  | Patomic_load {immediate_or_pointer} ->
-      (match immediate_or_pointer with
-        | Immediate -> "atomic_load_imm"
-        | Pointer -> "atomic_load_ptr")
+  | Patomic_load -> "Patomic_load"
   | Popaque -> "Popaque"
   | Prunstack -> "Prunstack"
   | Presume -> "Presume"

--- a/lambda/tmc.ml
+++ b/lambda/tmc.ml
@@ -865,7 +865,7 @@ let rec choice ctx t =
     | Prunstack | Pperform | Presume | Preperform | Pdls_get
 
     (* we don't handle atomic primitives *)
-    | Patomic_load _
+    | Patomic_load
 
     (* we don't handle array indices as destinations yet *)
     | (Pmakearray _ | Pduparray _)

--- a/lambda/translprim.ml
+++ b/lambda/translprim.ml
@@ -372,8 +372,7 @@ let primitives_table =
     "%greaterequal", Comparison(Greater_equal, Compare_generic);
     "%greaterthan", Comparison(Greater_than, Compare_generic);
     "%compare", Comparison(Compare, Compare_generic);
-    "%atomic_load",
-    Primitive ((Patomic_load {immediate_or_pointer=Pointer}), 1);
+    "%atomic_load", Primitive (Patomic_load, 1);
     "%atomic_exchange", External prim_atomic_exchange;
     "%atomic_cas", External prim_atomic_cas;
     "%atomic_fetch_add", External prim_atomic_fetch_add;
@@ -497,13 +496,6 @@ let specialize_primitive env ty ~has_constant_constructor prim =
       let useful = List.exists (fun knd -> knd <> Pgenval) shape in
       if useful then Some (Primitive (Pmakeblock(tag, mut, Some shape), arity))
       else None
-    end
-  | Primitive (Patomic_load { immediate_or_pointer = Pointer },
-               arity), _ ->begin
-      let is_int = match is_function_type env ty with
-        | None -> Pointer
-        | Some (_p1, rhs) -> maybe_pointer_type env rhs in
-      Some (Primitive (Patomic_load {immediate_or_pointer = is_int}, arity))
     end
   | Comparison(comp, Compare_generic), p1 :: _ ->
     if (has_constant_constructor
@@ -834,7 +826,7 @@ let lambda_primitive_needs_event_after = function
   | Pfloatcomp _ | Pstringlength | Pstringrefu | Pbyteslength | Pbytesrefu
   | Pbytessetu | Pmakearray ((Pintarray | Paddrarray | Pfloatarray), _)
   | Parraylength _ | Parrayrefu _ | Parraysetu _ | Pisint | Pisout
-  | Patomic_load _
+  | Patomic_load
   | Pintofbint _ | Pctconst _ | Pbswap16 | Pint_as_pointer | Popaque | Pdls_get
       -> false
 

--- a/lambda/value_rec_compiler.ml
+++ b/lambda/value_rec_compiler.ml
@@ -304,7 +304,7 @@ let compute_static_size lam =
     | Pbswap16
     | Pbbswap _
     | Pint_as_pointer
-    | Patomic_load _
+    | Patomic_load
     | Popaque
     | Pdls_get ->
         dynamic_size ()

--- a/middle_end/clambda_primitives.ml
+++ b/middle_end/clambda_primitives.ml
@@ -120,7 +120,7 @@ type primitive =
   (* Integer to external pointer *)
   | Pint_as_pointer
   (* Atomic operations *)
-  | Patomic_load of {immediate_or_pointer : immediate_or_pointer}
+  | Patomic_load
   (* Inhibition of optimisation *)
   | Popaque
   (* Fetch domain-local state *)

--- a/middle_end/clambda_primitives.mli
+++ b/middle_end/clambda_primitives.mli
@@ -123,7 +123,7 @@ type primitive =
   (* Integer to external pointer *)
   | Pint_as_pointer
   (* Atomic operations *)
-  | Patomic_load of {immediate_or_pointer : immediate_or_pointer}
+  | Patomic_load
   (* Inhibition of optimisation *)
   | Popaque
   (* Fetch domain-local state *)

--- a/middle_end/convert_primitives.ml
+++ b/middle_end/convert_primitives.ml
@@ -144,8 +144,7 @@ let convert (prim : Lambda.primitive) : Clambda_primitives.primitive =
   | Pbigarraydim dim -> Pbigarraydim dim
   | Pbswap16 -> Pbswap16
   | Pint_as_pointer -> Pint_as_pointer
-  | Patomic_load { immediate_or_pointer } ->
-      Patomic_load { immediate_or_pointer }
+  | Patomic_load -> Patomic_load
   | Popaque -> Popaque
   | Pdls_get -> Pdls_get
   | Ppoll -> Ppoll

--- a/middle_end/internal_variable_names.ml
+++ b/middle_end/internal_variable_names.ml
@@ -421,7 +421,7 @@ let of_primitive : Lambda.primitive -> string = function
   | Pbbswap _ -> pbbswap
   | Pint_as_pointer -> pint_as_pointer
   | Popaque -> popaque
-  | Patomic_load _ -> patomic_load
+  | Patomic_load -> patomic_load
   | Prunstack -> prunstack
   | Pperform -> pperform
   | Presume -> presume
@@ -531,7 +531,7 @@ let of_primitive_arg : Lambda.primitive -> string = function
   | Pbbswap _ -> pbbswap_arg
   | Pint_as_pointer -> pint_as_pointer_arg
   | Popaque -> popaque_arg
-  | Patomic_load _ -> patomic_load_arg
+  | Patomic_load -> patomic_load_arg
   | Prunstack -> prunstack_arg
   | Pperform -> pperform_arg
   | Presume -> presume_arg

--- a/middle_end/printclambda_primitives.ml
+++ b/middle_end/printclambda_primitives.ml
@@ -213,10 +213,7 @@ let primitive ppf (prim:Clambda_primitives.primitive) =
   | Pbswap16 -> fprintf ppf "bswap16"
   | Pbbswap(bi) -> print_boxed_integer "bswap" ppf bi
   | Pint_as_pointer -> fprintf ppf "int_as_pointer"
-  | Patomic_load {immediate_or_pointer} ->
-      (match immediate_or_pointer with
-        | Immediate -> fprintf ppf "atomic_load_imm"
-        | Pointer -> fprintf ppf "atomic_load_ptr")
+  | Patomic_load -> fprintf ppf "atomic_load"
   | Popaque -> fprintf ppf "opaque"
   | Pdls_get -> fprintf ppf "dls_get"
   | Ppoll -> fprintf ppf "poll"

--- a/middle_end/semantics_of_primitives.ml
+++ b/middle_end/semantics_of_primitives.ml
@@ -116,7 +116,7 @@ let for_primitive (prim : Clambda_primitives.primitive) =
   | Psetfield _
   | Psetfield_computed _
   | Psetfloatfield _
-  | Patomic_load _
+  | Patomic_load
   | Parraysetu _
   | Parraysets _
   | Pbytessetu


### PR DESCRIPTION
The Patomic_load primitive represents atomic loads (Atomic.get), and
it tracks whether the load type only contains immediate values, or
whether it contains both immediates and pointers. This comes at a
small cost in complexity in the compiler source, but is in fact
completely useless for two reasons:

1. We made a mistake in atomic.mli, which results in the information
   *never* being upgraded to Immediate: we declare
   `val get : 'a t -> 'a` instead of `external get : ...`,
   and as a consequence the compiler never specializes this primitive.

   (You can test this by compiling
     `let f (n : int Atomic.t) = Atomic.get n`
    and looking at the lambda or cmm output.)

2. The backend does not in fact depend on whether the value is
   immediate or not: even if we did track this information correctly,
   there would be no change in the generated code.
   (We checked this by reviewing atomic-load code production in all
   emit.mlp backends.)

This simplification will help (modestly) simplify the code of an
upcoming PR on atomic record fields.

Co-authored-by: Clément Allain <clef-men@orange.fr>