### PR TITLE
[refactor] typing/outcometree: use a record for record labels (fields)

### DIFF
--- a/typing/oprint.ml
+++ b/typing/oprint.ml
@@ -385,10 +385,13 @@ and print_typargs ppf =
       pp_print_char ppf ')';
       pp_close_box ppf ();
       pp_print_space ppf ()
-and print_out_label ppf (name, mut, arg) =
-  fprintf ppf "@[<2>%s%a :@ %a@];" (if mut then "mutable " else "")
-    print_lident name
-    print_out_type arg
+and print_out_label ppf {olab_name; olab_mut; olab_type} =
+  fprintf ppf "@[<2>%s%a :@ %a@];"
+    (match olab_mut with
+     | Mutable -> "mutable "
+     | Immutable -> "")
+    print_lident olab_name
+    print_out_type olab_type
 
 let out_label = ref print_out_label
 

--- a/typing/oprint.mli
+++ b/typing/oprint.mli
@@ -20,7 +20,7 @@ type 'a toplevel_printer = (Format.formatter -> 'a -> unit) ref
 
 val out_ident: out_ident printer
 val out_value : out_value toplevel_printer
-val out_label : (string * bool * out_type ) printer
+val out_label : out_label printer
 val out_type : out_type printer
 val out_type_args : out_type list printer
 val out_constr : out_constructor printer

--- a/typing/out_type.ml
+++ b/typing/out_type.ml
@@ -1251,7 +1251,11 @@ let prepare_type_constructor_arguments = function
   | Cstr_record l -> List.iter (fun l -> prepare_type l.ld_type) l
 
 let tree_of_label l =
-  (Ident.name l.ld_id, l.ld_mutable = Mutable, tree_of_typexp Type l.ld_type)
+  {
+    olab_name = Ident.name l.ld_id;
+    olab_mut = l.ld_mutable;
+    olab_type = tree_of_typexp Type l.ld_type;
+  }
 
 let tree_of_constructor_arguments = function
   | Cstr_tuple l -> tree_of_typlist Type l

--- a/typing/out_type.mli
+++ b/typing/out_type.mli
@@ -126,7 +126,7 @@ val hide_variant_name: Types.type_expr -> Types.type_expr
 val prepare_type_constructor_arguments: constructor_arguments -> unit
 val tree_of_constructor_arguments: constructor_arguments -> out_type list
 
-val tree_of_label: label_declaration -> string * bool * out_type
+val tree_of_label: label_declaration -> out_label
 
 val add_constructor_to_preparation : constructor_declaration -> unit
 val prepared_constructor : constructor_declaration printer

--- a/typing/outcometree.mli
+++ b/typing/outcometree.mli
@@ -72,7 +72,7 @@ type out_type =
   | Otyp_constr of out_ident * out_type list
   | Otyp_manifest of out_type * out_type
   | Otyp_object of { fields: (string * out_type) list; open_row:bool}
-  | Otyp_record of (string * bool * out_type) list
+  | Otyp_record of out_label list
   | Otyp_stuff of string
   | Otyp_sum of out_constructor list
   | Otyp_tuple of out_type list
@@ -81,6 +81,12 @@ type out_type =
   | Otyp_poly of string list * out_type
   | Otyp_module of out_ident * (string * out_type) list
   | Otyp_attribute of out_type * out_attribute
+
+and out_label = {
+  olab_name: string;
+  olab_mut: Asttypes.mutable_flag;
+  olab_type: out_type;
+}
 
 and out_constructor = {
   ocstr_name: string;


### PR DESCRIPTION
This is a micro-refactoring turning a tuple into a record, which is useful for the upcoming implementation work on atomic record fields. Reviews/approvals welcome.