### PR TITLE
otherlibs/systhreads/st_stubs.c: Avoid free of uninitialized pointer

### DIFF
--- a/Changes
+++ b/Changes
@@ -57,6 +57,11 @@ ___________
 
 ### Runtime system:
 
+- #13400: Initialize th->signal_stack to avoid free of uninitialized data
+  if the user calls caml_c_thread_unregister on the main thread.
+  (Richard W.M. Jones, review by Guillaume Munch-Maccagnoni and
+  Gabriel Scherer)
+
 - #13364: Emit major slice counters in the runtime events.
   (KC Sivaramakrishnan and Sadiq Jaffer, review by Gabriel Scherer)
 

--- a/otherlibs/systhreads/st_stubs.c
+++ b/otherlibs/systhreads/st_stubs.c
@@ -509,6 +509,7 @@ static void caml_thread_domain_initialize_hook(void)
   new_thread->prev = new_thread;
   new_thread->backtrace_last_exn = Val_unit;
   new_thread->memprof = caml_memprof_main_thread(Caml_state);
+  new_thread->signal_stack = NULL;
 
   st_tls_set(caml_thread_key, new_thread);
 


### PR DESCRIPTION
Calling caml_c_thread_unregister() will (amongst many other things) free the caml_thread_t signal_stack entry of the current thread.  The OCaml runtime initializes the main thread using special code in caml_thread_domain_initialize_hook, but this leaves the signal_stack entry uninitialized.

If you use glibc tunables to enable malloc checking, and especially use the malloc.perturb feature[1], then uninitialized areas of memory are filled with a repeating pattern.  This causes the process to crash if you free an uninitialized pointer.

Thus any program which calls caml_c_thread_unregister on the main thread, and is using glibc malloc checking, will crash.

Fix this by initializing the signal_stack to NULL (since free(NULL) is permitted and does nothing).

This was found when debugging a problem in the nbdkit OCaml plugin[2].

[1] https://www.gnu.org/software/libc/manual/html_node/Memory-Allocation-Tunables.html
[2] https://discuss.ocaml.org/t/free-uninitalized-data-when-calling-caml-c-thread-unregister-on-the-main-thread/15198

Fixes: https://github.com/ocaml/ocaml/issues/13400