### PR TITLE
Provide a system(3) replacement on Android (+ build OCaml on Android)

### DIFF
--- a/Changes
+++ b/Changes
@@ -29,6 +29,11 @@ Working version
   between domain exit and backup thread
   (Miod Vallat and Gabriel Scherer, report by Jan Midtgaard)
 
+- #13380, #13405: Provide a system(3) replacement on Android, allowing
+  to build OCaml on Android with Termux, and use Sys.command.
+  (Antonin Décimo, review by Miod Vallat and Gabriel Scherer,
+   report by @kid-with-phone)
+
 OCaml 5.3.0
 ___________
 

--- a/runtime/caml/misc.h
+++ b/runtime/caml/misc.h
@@ -477,7 +477,11 @@ extern double caml_log1p(double);
 #define chdir_os chdir
 #define mkdir_os mkdir
 #define getcwd_os getcwd
+#ifdef __ANDROID__
+#define system_os caml_sys_system
+#else
 #define system_os system
+#endif
 #define rmdir_os rmdir
 #define putenv_os putenv
 #define chmod_os chmod

--- a/runtime/sys.c
+++ b/runtime/sys.c
@@ -505,6 +505,54 @@ void caml_sys_init(char_os * exe_name, char_os **argv)
 #endif
 #endif
 
+#ifdef __ANDROID__
+#include <pthread.h>
+#include <spawn.h>
+
+/* Android 8 Oreo and later seem to block system(3). Provide a
+ * replacement, taken from musl.
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2005-2020 Rich Felker, et al.
+ * https://git.musl-libc.org/cgit/musl/tree/src/process/system.c?h=v1.2.5 */
+int caml_sys_system(const char *cmd)
+{
+  pid_t pid;
+  sigset_t old, reset;
+  struct sigaction sa = { .sa_handler = SIG_IGN }, oldint, oldquit;
+  int status = -1, ret;
+  posix_spawnattr_t attr;
+
+  /* Bionic does not provide thread cancellation */
+  /* pthread_testcancel(); */
+
+  if (!cmd) return 1;
+
+  sigaction(SIGINT, &sa, &oldint);
+  sigaction(SIGQUIT, &sa, &oldquit);
+  sigaddset(&sa.sa_mask, SIGCHLD);
+  sigprocmask(SIG_BLOCK, &sa.sa_mask, &old);
+
+  sigemptyset(&reset);
+  if (oldint.sa_handler != SIG_IGN) sigaddset(&reset, SIGINT);
+  if (oldquit.sa_handler != SIG_IGN) sigaddset(&reset, SIGQUIT);
+  posix_spawnattr_init(&attr);
+  posix_spawnattr_setsigmask(&attr, &old);
+  posix_spawnattr_setsigdefault(&attr, &reset);
+  posix_spawnattr_setflags(&attr, POSIX_SPAWN_SETSIGDEF|POSIX_SPAWN_SETSIGMASK);
+  ret = posix_spawn(&pid, "/bin/sh", 0, &attr,
+                    (char *[]){"sh", "-c", (char *)cmd, 0}, environ);
+  posix_spawnattr_destroy(&attr);
+
+  if (!ret) while (waitpid(pid, &status, 0)<0 && errno == EINTR);
+  sigaction(SIGINT, &oldint, NULL);
+  sigaction(SIGQUIT, &oldquit, NULL);
+  sigprocmask(SIG_SETMASK, &old, NULL);
+
+  if (ret) errno = ret;
+  return status;
+}
+#endif
+
 #ifdef HAS_SYSTEM
 CAMLprim value caml_sys_system_command(value command)
 {


### PR DESCRIPTION
This would fix #13380, where an user reported a failure to build OCaml on Android with Termux. I found out that OCaml internally calls [system()](https://pubs.opengroup.org/onlinepubs/9799919799/functions/system.html) ([bionic source](https://android.googlesource.com/platform/bionic.git/+/refs/heads/main/libc/bionic/system.cpp)) in [caml_sys_system_command](https://github.com/ocaml/ocaml/blob/55ee0e0eaf83e6f4276754ac16883855f800f968/runtime/sys.c#L509-L530) via [Ccomp.command](https://github.com/ocaml/ocaml/blob/55ee0e0eaf83e6f4276754ac16883855f800f968/utils/ccomp.ml#L18-L26) and [Pparse.call_external_preprocessor](https://github.com/ocaml/ocaml/blob/55ee0e0eaf83e6f4276754ac16883855f800f968/driver/pparse.ml#L26-L35). The problem is that `system` seems to have been blocked for security reasons, and thus `ocamlc` fails at invoking `gawk` as an external preprocessor (but note that `gawk` can still be called from the shell):

```console
$ make -j1 V=1
/data/data/com.termux/files/usr/bin/make coldstart
make[1]: Entering directory '/data/data/com.termux/files/home/ocaml'
/data/data/com.termux/files/usr/bin/make -C stdlib OCAMLRUN='$(ROOTDIR)/boot/ocamlrun' USE_BOOT_OCAMLC=true all
make[2]: Entering directory '/data/data/com.termux/files/home/ocaml/stdlib'
../boot/ocamlrun ../boot/ocamlc -strict-sequence -absname -w +a-4-9-41-42-44-45-48 -g -warn-error +A -bin-annot -nostdlib -principal  -nopervasives -no-alias-deps -w -49  -pp "$AWK -f ./expand_module_aliases.awk" -c stdlib.mli
sh: /data/data/com.termux/files/usr/bin/gawk: Permission denied
File "/data/data/com.termux/files/home/ocaml/stdlib/stdlib.mli", line 1:
Error: Error while running external preprocessor
Command line: gawk -f ./expand_module_aliases.awk 'stdlib.mli' > /data/data/com.termux/files/usr/tmp/ocamlpp102f05

make[2]: *** [Makefile:118: stdlib.cmi] Error 2
make[2]: Leaving directory '/data/data/com.termux/files/home/ocaml/stdlib'
make[1]: *** [Makefile:687: coldstart] Error 2
make[1]: Leaving directory '/data/data/com.termux/files/home/ocaml'
make: *** [Makefile:846: world.opt] Error 2

$ gawk -f ./expand_module_aliases.awk stdlib.mli > /data/data/com.termux/files/usr/tmp/ocamlpp102f05
$ ls -l /data/data/com.termux/files/usr/bin/gawk
-rwx------ 1 u0_a199 u0_a199 557672 Aug 23 12:15 /data/data/com.termux/files/usr/bin/gawk
```

Android hasn't disabled classic ways of spawning processes, and we can re-implement `system(3)`, which this PR does, with code directly taken from ~the POSIX spec (are there licensing issues?)~ the musl library (MIT-licensed).
Do let me know if supporting Android is not an interesting target.
I'm not sure if this implementation of `caml_sys_system` should do smarter things, like unload the runtime after the fork or other cleanups.
Is there another way to circumvent this problem?