### PR TITLE
ocamltest: skip ocamlobjinfo action if ocamlobjinfo is not available

### DIFF
--- a/ocamltest/ocaml_actions.ml
+++ b/ocamltest/ocaml_actions.ml
@@ -611,7 +611,13 @@ let objinfo log env =
 
 let ocamlobjinfo =
   Actions.make ~name:"ocamlobjinfo"
-    ~description:"Run ocamlobjinfo on the program" objinfo
+    ~description:"Run ocamlobjinfo on the program"
+    (fun log env ->
+       if Ocamltest_config.ocamlobjinfo then
+         objinfo log env
+       else
+         Result.skip_with_reason "ocamlobjinfo not available", env
+    )
 
 let mklib log env =
   let program = Environments.safe_lookup Builtin_variables.program env in

--- a/ocamltest/ocamltest_config.ml.in
+++ b/ocamltest/ocamltest_config.ml.in
@@ -65,6 +65,8 @@ let ocamldoc = @build_ocamldoc@
 
 let ocamldebug = @build_ocamldebug@
 
+let ocamlobjinfo = @build_ocamlobjinfo@
+
 let native_compiler = @native_compiler@
 
 let native_dynlink = @natdynlink@

--- a/ocamltest/ocamltest_config.mli
+++ b/ocamltest/ocamltest_config.mli
@@ -91,6 +91,9 @@ val ocamldoc : bool
 val ocamldebug : bool
 (** Whether ocamldebug has been enabled at configure time *)
 
+val ocamlobjinfo : bool
+(** Whether ocamlobjinfo has been enabled at configure time *)
+
 val native_compiler : bool
 (** Whether the native compiler has been enabled at configure time *)
 


### PR DESCRIPTION
If `ocamlobjinfo` is not available (eg because `--disable-ocamlobjinfo` was used), the `ocamlobjinfo` action is skipped by `ocamltest`.

Fixes https://github.com/ocaml/ocaml/pull/13390#issuecomment-2310193998
