### PR TITLE
Add Runtime_events.EV_EMPTY_MINOR

### DIFF
--- a/Changes
+++ b/Changes
@@ -263,6 +263,9 @@ ___________
   runtime assertions.
   (Antonin Décimo, review by Miod Vallat, Gabriel Scherer, and David Allsopp)
 
+- #13407: Add Runtime_events.EV_EMPTY_MINOR
+  (Thomas Leonard)
+
 ### Code generation and optimizations:
 
 - #13014: Enable compile-time option -function-sections on all previously

--- a/otherlibs/runtime_events/runtime_events.ml
+++ b/otherlibs/runtime_events/runtime_events.ml
@@ -92,6 +92,7 @@ type runtime_phase =
 | EV_COMPACT_EVACUATE
 | EV_COMPACT_FORWARD
 | EV_COMPACT_RELEASE
+| EV_EMPTY_MINOR
 
 type lifecycle =
   EV_RING_START
@@ -200,6 +201,7 @@ let runtime_phase_name phase =
   | EV_COMPACT_EVACUATE -> "compaction_evacuate"
   | EV_COMPACT_FORWARD -> "compaction_forward"
   | EV_COMPACT_RELEASE -> "compaction_release"
+  | EV_EMPTY_MINOR -> "empty_minor"
 
 let lifecycle_name lifecycle =
   match lifecycle with

--- a/otherlibs/runtime_events/runtime_events.mli
+++ b/otherlibs/runtime_events/runtime_events.mli
@@ -450,6 +450,12 @@ evacuation during a compaction.
 Event spanning releasing the evacuated pools at the end of a compaction.
 @since 5.2
 *)
+| EV_EMPTY_MINOR
+(**
+Event spanning a domain needing to empty its minor heap for a new allocation.
+This includes time spent trying to become stop-the-world leader.
+@since 5.4
+*)
 
 (** Lifecycle events for Runtime_events and domains. *)
 type lifecycle =

--- a/runtime/caml/runtime_events.h
+++ b/runtime/caml/runtime_events.h
@@ -120,7 +120,8 @@ typedef enum {
     EV_COMPACT,
     EV_COMPACT_EVACUATE,
     EV_COMPACT_FORWARD,
-    EV_COMPACT_RELEASE
+    EV_COMPACT_RELEASE,
+    EV_EMPTY_MINOR
 } ev_runtime_phase;
 
 typedef enum {

--- a/runtime/minor_gc.c
+++ b/runtime/minor_gc.c
@@ -874,12 +874,16 @@ void caml_empty_minor_heaps_once (void)
   CAMLassert(!caml_domain_is_in_stw());
   #endif
 
+  CAML_EV_BEGIN(EV_EMPTY_MINOR);
+
   /* To handle the case where multiple domains try to execute a minor gc
      STW section */
   do {
     caml_try_empty_minor_heap_on_all_domains();
   } while (saved_minor_cycle ==
            atomic_load_relaxed(&caml_minor_cycles_started));
+
+  CAML_EV_END(EV_EMPTY_MINOR);
 }
 
 /* Called by minor allocations when [Caml_state->young_ptr] reaches


### PR DESCRIPTION
`EV_OS_WAIT` is useful to see in traces when OCaml asked the OS to suspend a domain. If the domain is waiting for another domain on the same CPU, this is the point where it is likely to be scheduled. **Update**: I have removed this for now.

`EV_EMPTY_MINOR` shows when a domain is trying to empty its minor heap. It may be a long time between starting this process and actually performing a minor GC if, for example, another domain is holding the platform lock. Without this event, profiling tools tend to under-report the amount of time spent on GC.

/cc @sadiqj @kayceesrk (https://discuss.ocaml.org/t/ocaml-5-performance/15014/19?u=talex5)

Example trace showing the new events:

![Trace showing new events](https://github.com/user-attachments/assets/a9e064e4-7aec-4d77-8045-d9592890d81a)
