### PR TITLE
Fix version in opam-file after 5.4 version bump

### DIFF
--- a/ocaml-variants.opam
+++ b/ocaml-variants.opam
@@ -14,7 +14,7 @@ authors: [
 homepage: "https://github.com/ocaml/ocaml/"
 bug-reports: "https://github.com/ocaml/ocaml/issues"
 depends: [
-  "ocaml" {= "5.3.0" & post}
+  "ocaml" {= "5.4.0" & post}
   "base-unix" {post}
   "base-bigarray" {post}
   "base-threads" {post}


### PR DESCRIPTION
This fixes a `5.3` left in the opam file after 5.3 branching and trunk's 5.4 version bump.