### PR TITLE
POWER back-end: fix issue with call to `caml_call_realloc_stack` from a DLL

### DIFF
--- a/Changes
+++ b/Changes
@@ -25,6 +25,10 @@ Working version
 
 ### Bug fixes:
 
+- #13140: POWER back-end: fix issue with call to `caml_call_realloc_stack`
+  from a DLL
+  (Xavier Leroy, review by Miod Vallat)
+
 OCaml 5.3.0
 ___________
 

--- a/asmcomp/power/emit.mlp
+++ b/asmcomp/power/emit.mlp
@@ -1007,8 +1007,9 @@ let fundecl fundecl =
   || max_frame_size >= stack_threshold_size then begin
     let overflow = new_label () and ret = new_label () in
     (* The return address is saved in a register not used for param passing *)
+    (* The size is passed in a register normally not used for param passing *)
     `{emit_label overflow}:	mflr	28\n`;
-    `	li	12, {emit_int (Config.stack_threshold + max_frame_size / 8)}\n`;
+    `	li	27, {emit_int (Config.stack_threshold + max_frame_size / 8)}\n`;
     emit_call "caml_call_realloc_stack";
     emit_call_nop ();
     `	mtlr	28\n`;

--- a/runtime/power.S
+++ b/runtime/power.S
@@ -388,14 +388,14 @@ caml_hot.code_end:
 caml_system__code_begin:
 
 /* Reallocate the stack when it is too small. */
-/* Desired size is passed in register TMP2. */
+/* Desired size is passed in register r27. */
 
 FUNCTION caml_call_realloc_stack
         ENTER_FUNCTION
    /* Save all registers, as well as ALLOC_PTR and TRAP_PTR */
-        SAVE_ALL_REGS  /* TMP2 is preserved */
+        SAVE_ALL_REGS  /* r27 is preserved */
    /* Recover desired size, to be passed in r3 */
-        mr      3, TMP2
+        mr      3, 27
    /* Switch stacks and call caml_try_realloc_stack */
         SWITCH_OCAML_TO_C
         Far_call(caml_try_realloc_stack)


### PR DESCRIPTION
Currently, the required stack frame size is passed to `caml_call_realloc_stack` in register 12.  However, this register is destroyed by the shims inserted by the dynamic loader.  Consequently, the required size can be corrupted if the caller of `caml_call_realloc_stack` is in a DLL.  This seems to be the root cause for https://github.com/LPCIC/coq-elpi/issues/678.

Trivial fix in this PR: use a different, non-temporary register to pass the required size.
