### PR TITLE
Use WinAPI concurrency primitives on Windows ports (remove winpthreads)

### DIFF
--- a/.github/workflows/build-msvc.yml
+++ b/.github/workflows/build-msvc.yml
@@ -224,8 +224,7 @@ jobs:
           opam switch create '${{ env.OPAMSWITCH }}' --empty
           opam pin add --no-action --kind=path ocaml-variants .
           opam pin add --no-action flexdll flexdll
-          opam pin add --no-action winpthreads winpthreads
-          opam install --yes flexdll winpthreads
+          opam install --yes flexdll
           opam install --yes --assume-built ocaml-variants
           opam exec -- ocamlc -v
 

--- a/.gitmodules
+++ b/.gitmodules
@@ -3,8 +3,3 @@
 	url = https://github.com/ocaml/flexdll.git
 	shallow = true
 	branch = master
-[submodule "winpthreads"]
-	path = winpthreads
-	url = https://github.com/ocaml/winpthreads.git
-	shallow = true
-	branch = master

--- a/Changes
+++ b/Changes
@@ -124,6 +124,11 @@ Working version
   continuations without calling `caml_continuation_use`.
   (Max Slater, review by Nick Barnes and Stephen Dolan)
 
+- #13416: Implement concurrency primitives using WinAPI instead of
+  winpthreads on Windows.
+  (Antonin Décimo, review by Samuel Hym, Gabriel Scherer, Miod Vallat,
+  B. Szilvasy, and Nicolás Ojeda Bär)
+
 ### Code generation and optimizations:
 
 ### Standard library:

--- a/HACKING.adoc
+++ b/HACKING.adoc
@@ -220,7 +220,6 @@ has excellent documentation.
   link:toplevel/[]::             interactive system
   link:typing/[]::               typechecking -- see xref:typing/HACKING.adoc[]
   link:utils/[]::                utility libraries
-  link:winpthreads/[]::          winpthreads submodule -- see <<winpthreads,further>>
   link:yacc/[]::                 parser generator
 
 [#tips]
@@ -770,39 +769,5 @@ OCAML_JOBS=10
 If you would like to receive email notifications of all commits made to the main
 git repository, you can subscribe to the caml-commits@inria.fr mailing list by
 visiting https://sympa.inria.fr/sympa/info/caml-commits[its web page.]
-
-[#winpthreads]
-=== The `winpthreads` library for the MSVC port
-
-The `winpthreads` library is used to emulate `pthread` for the MSVC
-port. Upstream bundles it along with all the MinGW libraries so our
-`winpthreads` submodule points to `git subtree` repository rather than
-upstream directly.
-
-To recreate the `winpthreads` repository from upstream, you can do:
-
-[source,sh]
-----
-git clone -o upstream https://git.code.sf.net/p/mingw-w64/mingw-w64 winpthreads
-cd winpthreads
-git checkout upstream/master
-git branch -D master
-git subtree -P mingw-w64-libraries/winpthreads split -b master
-----
-
-As subtree splitting is deterministic, repeating these operations later will
-allow to update `master`, for instance by:
-
-[source,sh]
-----
-git fetch upstream
-git checkout upstream/master
-git subtree -P mingw-w64-libraries/winpthreads split -b tmp
-git checkout master
-git merge --ff-only tmp
-git branch -d tmp
-----
-
-and then go on updating the `winpthreads` submodule in the `ocaml` repository.
 
 Happy Hacking!

--- a/Makefile
+++ b/Makefile
@@ -1199,15 +1199,6 @@ partialclean::
 
 ## Lists of source files
 
-ifneq "$(WINPTHREADS_SOURCE_DIR)" ""
-winpthreads_SOURCES = cond.c misc.c mutex.c rwlock.c sched.c spinlock.c thread.c
-
-winpthreads_OBJECTS = \
-  $(addprefix runtime/winpthreads/, $(winpthreads_SOURCES:.c=.$(O)))
-else
-winpthreads_OBJECTS =
-endif
-
 runtime_COMMON_C_SOURCES = \
   addrmap \
   afl \
@@ -1328,35 +1319,32 @@ endif
 
 
 libcamlrun_OBJECTS = \
-  $(runtime_BYTECODE_C_SOURCES:.c=.b.$(O)) $(winpthreads_OBJECTS)
+  $(runtime_BYTECODE_C_SOURCES:.c=.b.$(O))
 
 libcamlrun_non_shared_OBJECTS = \
   $(subst $(UNIX_OR_WIN32).b.$(O),$(UNIX_OR_WIN32)_non_shared.b.$(O), \
           $(libcamlrun_OBJECTS))
 
 libcamlrund_OBJECTS = $(runtime_BYTECODE_C_SOURCES:.c=.bd.$(O)) \
-  $(winpthreads_OBJECTS) runtime/instrtrace.bd.$(O)
+  runtime/instrtrace.bd.$(O)
 
 libcamlruni_OBJECTS = \
-  $(runtime_BYTECODE_C_SOURCES:.c=.bi.$(O)) $(winpthreads_OBJECTS)
+  $(runtime_BYTECODE_C_SOURCES:.c=.bi.$(O))
 
 libcamlrunpic_OBJECTS = \
-  $(runtime_BYTECODE_C_SOURCES:.c=.bpic.$(O)) $(winpthreads_OBJECTS)
+  $(runtime_BYTECODE_C_SOURCES:.c=.bpic.$(O))
 
 libasmrun_OBJECTS = \
-  $(runtime_NATIVE_C_SOURCES:.c=.n.$(O)) $(runtime_ASM_OBJECTS) \
-  $(winpthreads_OBJECTS)
+  $(runtime_NATIVE_C_SOURCES:.c=.n.$(O)) $(runtime_ASM_OBJECTS)
 
 libasmrund_OBJECTS = \
-  $(runtime_NATIVE_C_SOURCES:.c=.nd.$(O)) $(runtime_ASM_OBJECTS:.$(O)=.d.$(O)) \
-  $(winpthreads_OBJECTS)
+  $(runtime_NATIVE_C_SOURCES:.c=.nd.$(O)) $(runtime_ASM_OBJECTS:.$(O)=.d.$(O))
 
 libasmruni_OBJECTS = \
-  $(runtime_NATIVE_C_SOURCES:.c=.ni.$(O)) $(runtime_ASM_OBJECTS:.$(O)=.i.$(O)) \
-  $(winpthreads_OBJECTS)
+  $(runtime_NATIVE_C_SOURCES:.c=.ni.$(O)) $(runtime_ASM_OBJECTS:.$(O)=.i.$(O))
 
 libasmrunpic_OBJECTS = $(runtime_NATIVE_C_SOURCES:.c=.npic.$(O)) \
-  $(runtime_ASM_OBJECTS:.$(O)=_libasmrunpic.$(O)) $(winpthreads_OBJECTS)
+  $(runtime_ASM_OBJECTS:.$(O)=_libasmrunpic.$(O))
 
 libcomprmarsh_OBJECTS = runtime/zstd.npic.$(O)
 
@@ -1548,15 +1536,6 @@ endif # ifeq "$(COMPUTE_DEPS)" "true"
 	  $$(OUTPUTOBJ)$$@ -c $$<
 endef
 
-runtime/winpthreads/%.$(O): $(WINPTHREADS_SOURCE_DIR)/src/%.c \
-                            $(wildcard $(WINPTHREADS_SOURCE_DIR)/include/*.h) \
-                              | runtime/winpthreads
-	$(V_CC)$(CC) $(OC_CFLAGS) $(CFLAGS) $(OC_CPPFLAGS) $(CPPFLAGS) \
-	  $(OUTPUTOBJ)$@ -c $<
-
-runtime/winpthreads:
-	$(MKDIR) $@
-
 $(DEPDIR)/runtime:
 	$(MKDIR) $@
 
@@ -1643,7 +1622,7 @@ clean::
 	rm -f runtime/primitives runtime/primitives*.new runtime/prims.c \
 	  $(runtime_BUILT_HEADERS)
 	rm -f runtime/domain_state.inc
-	rm -rf $(DEPDIR) runtime/winpthreads
+	rm -rf $(DEPDIR)
 	rm -f stdlib/libcamlrun.a stdlib/libcamlrun.lib
 
 .PHONY: runtimeopt
@@ -2743,7 +2722,7 @@ endif
 	      boot/flexdll_*.o boot/flexdll_*.obj \
 	      boot/*.cm* boot/libcamlrun.a boot/libcamlrun.lib boot/ocamlc.opt
 	rm -f Makefile.config Makefile.build_config
-	rm -rf autom4te.cache winpthreads-sources flexdll-sources \
+	rm -rf autom4te.cache flexdll-sources \
          $(BYTE_BUILD_TREE) $(OPT_BUILD_TREE)
 	rm -f config.log config.status libtool
 

--- a/Makefile.build_config.in
+++ b/Makefile.build_config.in
@@ -94,7 +94,7 @@ OC_NATIVE_CFLAGS = @oc_native_cflags@ $(BUILD_MAP_CFLAGS)
 
 # The submodules should be searched *before* any other external -I paths
 OC_INCLUDES = $(addprefix -I $(ROOTDIR)/, \
-  runtime @flexdll_source_dir@ @winpthreads_source_include_dir@)
+  runtime @flexdll_source_dir@)
 OC_CPPFLAGS = $(OC_INCLUDES) @oc_cppflags@
 
 OC_BYTECODE_CPPFLAGS = $(OC_INCLUDES) @oc_bytecode_cppflags@
@@ -142,10 +142,6 @@ DOCUMENTATION_TOOL_CMD=@documentation_tool_cmd@
 # Git submodule)
 FLEXDLL_SOURCE_DIR=@flexdll_source_dir@
 BOOTSTRAPPING_FLEXDLL=@bootstrapping_flexdll@
-
-# The location of the Winpthreads sources to use (usually provided as the
-# winpthreads Git submodule)
-WINPTHREADS_SOURCE_DIR=@winpthreads_source_dir@
 
 ### Where to install documentation
 PACKAGE_TARNAME = @PACKAGE_TARNAME@

--- a/aclocal.m4
+++ b/aclocal.m4
@@ -363,16 +363,6 @@ EOF
   OCAML_CC_RESTORE_VARIABLES
 ])
 
-AC_DEFUN([OCAML_TEST_WINPTHREADS_PTHREAD_H], [
-  OCAML_CC_SAVE_VARIABLES
-
-  AS_IF([test -n "$1"],[CPPFLAGS="-I $1 $CPPFLAGS"])
-  AC_CHECK_HEADER([pthread.h],[],
-    [AC_MSG_ERROR([cannot find or use pthread.h from winpthreads])])
-
-  OCAML_CC_RESTORE_VARIABLES
-])
-
 AC_DEFUN([OCAML_TARGET_IS_EXECUTABLE], [
   AC_MSG_CHECKING([whether target executables can be run in the build])
   old_cross_compiling="$cross_compiling"

--- a/configure
+++ b/configure
@@ -894,8 +894,6 @@ AR
 launch_method_target
 launch_method
 shebangscripts
-winpthreads_source_include_dir
-winpthreads_source_dir
 flexdll_dir
 bootstrapping_flexdll
 flexdll_source_dir
@@ -1066,7 +1064,6 @@ enable_runtime_search
 enable_runtime_search_target
 with_afl
 with_flexdll
-with_winpthreads_msvc
 with_zstd
 enable_shared
 enable_static
@@ -1806,8 +1803,6 @@ Optional Packages:
                           --with-relative-libdir, defaults to ../lib/ocaml)
   --with-afl              use the AFL fuzzer
   --with-flexdll          bootstrap FlexDLL from the given sources
-  --with-winpthreads-msvc build winpthreads (only for the MSVC port) from the
-                          given sources
   --without-zstd          disable compression of compilation artefacts
   --with-gnu-ld           assume the C compiler uses GNU ld [default=no]
   --with-sysroot[=DIR]    Search for dependent libraries within DIR (or the
@@ -3564,8 +3559,6 @@ LINEAR_MAGIC_NUMBER=Caml1999L037
 
 
 
-
-
  # TODO: rename this variable
 
 
@@ -4496,17 +4489,6 @@ then :
   withval=$with_flexdll; if test x"$withval" = 'xyes'
 then :
   with_flexdll=flexdll
-fi
-fi
-
-
-
-# Check whether --with-winpthreads-msvc was given.
-if test ${with_winpthreads_msvc+y}
-then :
-  withval=$with_winpthreads_msvc; if test x"$withval" = 'xyes'
-then :
-  with_winpthreads_msvc=winpthreads
 fi
 fi
 
@@ -17640,104 +17622,6 @@ case $target in #(
   *) :
     encode_C_literal="encode-C-utf8-literal" ;;
 esac
-
-# Winpthreads emulation library for the MSVC port
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for winpthreads sources" >&5
-printf %s "checking for winpthreads sources... " >&6; }
-if test x"$with_winpthreads_msvc" = "xno"
-then :
-  winpthreads_source_dir=''
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: disabled" >&5
-printf "%s\n" "disabled" >&6; }
-else $as_nop
-  winpthreadmsg=''
-  case $target in #(
-  *-pc-windows) :
-                       if test x"$with_winpthreads_msvc" = 'x' || test x"$with_winpthreads_msvc" = x'winpthreads'
-then :
-  if test -f 'winpthreads/src/winpthread_internal.h'
-then :
-  winpthreads_source_dir=winpthreads
-else $as_nop
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: required but not available (uninitialized submodule?)" >&5
-printf "%s\n" "required but not available (uninitialized submodule?)" >&6; }
-        as_fn_error $? "exiting" "$LINENO" 5
-fi
-else $as_nop
-  rm -rf winpthreads-sources
-      if test -f "$with_winpthreads_msvc/src/winpthread_internal.h"
-then :
-  mkdir -p winpthreads-sources/src winpthreads-sources/include
-        cp "$with_winpthreads_msvc"/src/*.c winpthreads-sources/src
-        cp "$with_winpthreads_msvc"/src/*.h winpthreads-sources/src
-        cp "$with_winpthreads_msvc"/include/*.h winpthreads-sources/include
-        winpthreads_source_dir='winpthreads-sources'
-        winpthreadsmsg=" (from $with_winpthreads_msvc)"
-else $as_nop
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: requested but not available" >&5
-printf "%s\n" "requested but not available" >&6; }
-        as_fn_error $? "exiting" "$LINENO" 5
-fi
-fi
-    if test x"$winpthreads_source_dir" = 'x'
-then :
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
-printf "%s\n" "no" >&6; }
-else $as_nop
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $winpthreads_source_dir$winpthreadsmsg" >&5
-printf "%s\n" "$winpthreads_source_dir$winpthreadsmsg" >&6; }
-      winpthreads_source_include_dir="$winpthreads_source_dir/include"
-
-
-  saved_CC="$CC"
-  saved_CFLAGS="$CFLAGS"
-  saved_CPPFLAGS="$CPPFLAGS"
-  saved_LIBS="$LIBS"
-  saved_ac_ext="$ac_ext"
-  saved_ac_compile="$ac_compile"
-  # Move the content of confdefs.h to another file so it does not
-  # get included
-  mv confdefs.h confdefs.h.bak
-  touch confdefs.h
-
-
-  if test -n "$winpthreads_source_include_dir"
-then :
-  CPPFLAGS="-I $winpthreads_source_include_dir $CPPFLAGS"
-fi
-  ac_fn_c_check_header_compile "$LINENO" "pthread.h" "ac_cv_header_pthread_h" "$ac_includes_default"
-if test "x$ac_cv_header_pthread_h" = xyes
-then :
-
-else $as_nop
-  as_fn_error $? "cannot find or use pthread.h from winpthreads" "$LINENO" 5
-fi
-
-
-
-  # Restore the content of confdefs.h
-  mv confdefs.h.bak confdefs.h
-  ac_compile="$saved_ac_compile"
-  ac_ext="$saved_ac_ext"
-  CPPFLAGS="$saved_CPPFLAGS"
-  CFLAGS="$saved_CFLAGS"
-  CC="$saved_CC"
-  LIBS="$saved_LIBS"
-
-
-fi ;; #(
-  *) :
-    if test x"$with_winpthreads_msvc" != 'x'
-then :
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: requested but not supported" >&5
-printf "%s\n" "requested but not supported" >&6; }
-      as_fn_error $? "exiting" "$LINENO" 5
-else $as_nop
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: skipping on that platform" >&5
-printf "%s\n" "skipping on that platform" >&6; }
-fi ;;
-esac
-fi
 
 ## Program to use to install files
 

--- a/configure.ac
+++ b/configure.ac
@@ -193,8 +193,6 @@ AC_SUBST([bytecode_cppflags])
 AC_SUBST([flexdll_source_dir])
 AC_SUBST([bootstrapping_flexdll])
 AC_SUBST([flexdll_dir])
-AC_SUBST([winpthreads_source_dir])
-AC_SUBST([winpthreads_source_include_dir])
 AC_SUBST([shebangscripts])
 AC_SUBST([launch_method])
 AC_SUBST([launch_method_target])
@@ -755,11 +753,6 @@ AC_ARG_WITH([flexdll],
   [AS_HELP_STRING([--with-flexdll],
     [bootstrap FlexDLL from the given sources])],
   [AS_IF([test x"$withval" = 'xyes'],[with_flexdll=flexdll])])
-
-AC_ARG_WITH([winpthreads-msvc],
-  [AS_HELP_STRING([--with-winpthreads-msvc],
-    [build winpthreads (only for the MSVC port) from the given sources])],
-  [AS_IF([test x"$withval" = 'xyes'], [with_winpthreads_msvc=winpthreads])])
 
 AC_ARG_WITH([zstd],
   [AS_HELP_STRING([--without-zstd],
@@ -1347,44 +1340,6 @@ AS_CASE([$target],
   [*-w64-mingw32*|*-pc-windows],
     [encode_C_literal="encode-C-utf16-literal"],
   [encode_C_literal="encode-C-utf8-literal"])
-
-# Winpthreads emulation library for the MSVC port
-AC_MSG_CHECKING([for winpthreads sources])
-AS_IF([test x"$with_winpthreads_msvc" = "xno"],
-  [winpthreads_source_dir=''
-  AC_MSG_RESULT([disabled])],
-  [winpthreadmsg=''
-  AS_CASE([$target],
-    [*-pc-windows],
-    [dnl When bootstrapping from the git submodule (winpthreads directory),
-     dnl just use that, however if another directory has been specified with
-     dnl --with-winpthreads-msvc=<path> then copy the contents of <path> to
-     dnl winpthreads-sources.
-    AS_IF([m4_normalize([test x"$with_winpthreads_msvc" = 'x'
-                          || test x"$with_winpthreads_msvc" = x'winpthreads'])],
-      [AS_IF([test -f 'winpthreads/src/winpthread_internal.h'],
-        [winpthreads_source_dir=winpthreads],
-        [AC_MSG_RESULT([required but not available (uninitialized submodule?)])
-        AC_MSG_ERROR([exiting])])],
-      [rm -rf winpthreads-sources
-      AS_IF([test -f "$with_winpthreads_msvc/src/winpthread_internal.h"],
-        [mkdir -p winpthreads-sources/src winpthreads-sources/include
-        cp "$with_winpthreads_msvc"/src/*.c winpthreads-sources/src
-        cp "$with_winpthreads_msvc"/src/*.h winpthreads-sources/src
-        cp "$with_winpthreads_msvc"/include/*.h winpthreads-sources/include
-        winpthreads_source_dir='winpthreads-sources'
-        winpthreadsmsg=" (from $with_winpthreads_msvc)"],
-        [AC_MSG_RESULT([requested but not available])
-        AC_MSG_ERROR([exiting])])])
-    AS_IF([test x"$winpthreads_source_dir" = 'x'],
-      [AC_MSG_RESULT([no])],
-      [AC_MSG_RESULT([$winpthreads_source_dir$winpthreadsmsg])
-      winpthreads_source_include_dir="$winpthreads_source_dir/include"
-      OCAML_TEST_WINPTHREADS_PTHREAD_H([$winpthreads_source_include_dir])])],
-    [AS_IF([test x"$with_winpthreads_msvc" != 'x'],
-      [AC_MSG_RESULT([requested but not supported])
-      AC_MSG_ERROR([exiting])],
-      [AC_MSG_RESULT([skipping on that platform])])])])
 
 ## Program to use to install files
 AC_PROG_INSTALL

--- a/ocaml-variants.opam
+++ b/ocaml-variants.opam
@@ -46,11 +46,11 @@ depends: [
   # amd64 mingw-w64 / MSVC
   (("arch-x86_64" {build & os = "win32" & arch = "x86_64"} &
      (("system-mingw" {build} & "mingw-w64-shims" {os-distribution = "cygwin" & build}) |
-      ("system-msvc" {build} & "winpthreads" {os = "win32"} & "ocaml-option-no-compression" {build & os = "win32"}))) |
+      ("system-msvc" {build} & "ocaml-option-no-compression" {build & os = "win32"}))) |
   # i686 mingw-w64 / MSVC
    ("arch-x86_32" {build & os = "win32"} & "ocaml-option-bytecode-only" {build & os = "win32"} &
      (("system-mingw" {build} & "mingw-w64-shims" {os-distribution = "cygwin" & build}) |
-      ("system-msvc" {build} & "winpthreads" {os = "win32"} & "ocaml-option-no-compression" {build & os = "win32"}))) |
+      ("system-msvc" {build} & "ocaml-option-no-compression" {build & os = "win32"}))) |
   # Non-Windows systems
    "host-system-other" {os != "win32" & post})
 
@@ -81,7 +81,6 @@ build: [
     "--enable-runtime-search"
     "--enable-runtime-search-target=fallback"
     "--with-flexdll=%{flexdll:share}%" {os = "win32" & flexdll:installed}
-    "--with-winpthreads-msvc=%{winpthreads:share}%" {winpthreads:installed & system-msvc:installed}
     "-C"
     "--with-afl" {ocaml-option-afl:installed}
     "--disable-native-compiler" {ocaml-option-bytecode-only:installed}

--- a/otherlibs/systhreads/st_pthreads.h
+++ b/otherlibs/systhreads/st_pthreads.h
@@ -45,8 +45,6 @@ static int st_thread_create(st_thread_id * res,
   return rc;
 }
 
-#define ST_THREAD_FUNCTION void *
-
 /* Thread termination */
 
 static void st_thread_join(st_thread_id thr)

--- a/otherlibs/systhreads/st_stubs.c
+++ b/otherlibs/systhreads/st_stubs.c
@@ -1055,13 +1055,16 @@ static st_retcode caml_threadstatus_wait (value wrapper)
 /* Set the current thread's name. */
 CAMLprim value caml_set_current_thread_name(value name)
 {
-#if defined(_WIN32) && defined(HAS_SETTHREADDESCRIPTION)
+#if defined(_WIN32)
+#if defined(HAS_SETTHREADDESCRIPTION)
   wchar_t *thread_name = caml_stat_strdup_to_utf16(String_val(name));
   HRESULT hr = SetThreadDescription(GetCurrentThread(), thread_name);
   caml_stat_free(thread_name);
   if (FAILED(hr))
     caml_set_current_thread_name_warning("SetThreadDescription failed!");
-
+#else
+  caml_set_current_thread_name_warning("set thread name not implemented");
+#endif
 #elif defined(HAS_PRCTL)
   char buf[1024];
   int ret = prctl(PR_SET_NAME, String_val(name));

--- a/otherlibs/systhreads/st_stubs.c
+++ b/otherlibs/systhreads/st_stubs.c
@@ -303,6 +303,12 @@ static void caml_thread_enter_blocking_section(void)
 
 static void caml_thread_leave_blocking_section(void)
 {
+#ifdef _WIN32
+  /* TlsGetValue (called in This_thread) calls SetLastError which will mask any
+     error which occurred prior to the caml_thread_leave_blocking_section call.
+     EnterCriticalSection does not do this. */
+  DWORD error = GetLastError();
+#endif
   caml_thread_t th = This_thread;
   /* Wait until the runtime is free */
   thread_lock_acquire(th->domain_id);
@@ -310,6 +316,9 @@ static void caml_thread_leave_blocking_section(void)
      corresponding to the thread currently executing and restore the
      runtime state */
   restore_runtime_state(th);
+#ifdef _WIN32
+  SetLastError(error);
+#endif
 }
 
 /* Create and setup a new thread info block.

--- a/otherlibs/systhreads/st_stubs.c
+++ b/otherlibs/systhreads/st_stubs.c
@@ -14,31 +14,13 @@
 /**************************************************************************/
 
 #define CAML_INTERNALS
-
-/* These macros must be defined before any winpthreads headers are included for
-   any reason. In mingw-w64 13.0.0, a subtle change meant that time.h causes
-   pthread_compat.h to be read. For this reason, this next block must appear
-   before anything headers are included. */
-#if defined(_WIN32) && !defined(NATIVE_CODE) && !defined(_MSC_VER)
-/* Ensure that pthread.h marks symbols __declspec(dllimport) so that they can be
-   picked up from the runtime (which will have linked winpthreads statically).
-   mingw-w64 11.0.0 introduced WINPTHREADS_USE_DLLIMPORT to do this explicitly;
-   prior versions co-opted this on the internal DLL_EXPORT, but this is ignored
-   in 11.0 and later unless IN_WINPTHREAD is also defined, so we can safely
-   define both to support both versions.
-   When compiling with MSVC, we currently link directly the winpthreads objects
-   into our runtime, so we do not want to mark its symbols with
-   __declspec(dllimport). */
-#define WINPTHREADS_USE_DLLIMPORT
-#define DLL_EXPORT
-#endif
-
 #define _GNU_SOURCE /* helps to find pthread_setname_np() */
 #include "caml/config.h"
 
 #if defined(_WIN32)
 #  define WIN32_LEAN_AND_MEAN
 #  include <windows.h>
+#  include <process.h>
 #  include <processthreadsapi.h>
 #  include "caml/osdeps.h"
 
@@ -713,7 +695,8 @@ static void thread_destroy_current(caml_thread_t th)
 /* Create a thread */
 
 /* the thread lock is not held when entering */
-static void * caml_thread_start(void * v)
+static CAML_THREAD_FUNCTION
+caml_thread_start(void * v)
 {
   caml_thread_t th = (caml_thread_t) v;
   int dom_id = th->domain_id;
@@ -738,7 +721,7 @@ struct caml_thread_tick_args {
 };
 
 /* The tick thread: interrupt the domain periodically to force preemption  */
-static void * caml_thread_tick(void * arg)
+static CAML_THREAD_FUNCTION caml_thread_tick(void * arg)
 {
   struct caml_thread_tick_args* tick_thread_args =
     (struct caml_thread_tick_args*) arg;
@@ -756,7 +739,7 @@ static void * caml_thread_tick(void * arg)
     atomic_store_release(&domain->requested_external_interrupt, 1);
     caml_interrupt_self();
   }
-  return NULL;
+  return 0;
 }
 
 static st_retcode create_tick_thread(void)
@@ -1063,23 +1046,12 @@ static st_retcode caml_threadstatus_wait (value wrapper)
 /* Set the current thread's name. */
 CAMLprim value caml_set_current_thread_name(value name)
 {
-#if defined(_WIN32)
-#  if defined(HAS_SETTHREADDESCRIPTION)
+#if defined(_WIN32) && defined(HAS_SETTHREADDESCRIPTION)
   wchar_t *thread_name = caml_stat_strdup_to_utf16(String_val(name));
   HRESULT hr = SetThreadDescription(GetCurrentThread(), thread_name);
   caml_stat_free(thread_name);
   if (FAILED(hr))
     caml_set_current_thread_name_warning("SetThreadDescription failed!");
-#  endif
-
-#  if defined(HAVE_PTHREAD_SETNAME_NP)
-  // We are using both methods.
-  // See: https://github.com/ocaml/ocaml/pull/13504#discussion_r1786358928
-  char buf[1024];
-  int ret = pthread_setname_np(pthread_self(), String_val(name));
-  if (ret != 0)
-    caml_set_current_thread_name_warning(caml_strerror(ret, buf, sizeof(buf)));
-#  endif
 
 #elif defined(HAS_PRCTL)
   char buf[1024];

--- a/otherlibs/systhreads/st_win32.h
+++ b/otherlibs/systhreads/st_win32.h
@@ -30,4 +30,248 @@ Caml_inline void st_msleep(const st_timeout *timeout)
   Sleep(*timeout);
 }
 
-#include "st_pthreads.h"
+/* POSIX thread implementation of the "st" interface */
+
+#include <errno.h>
+#include <string.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <pthread.h>
+#include <signal.h>
+#include <time.h>
+#ifndef _WIN32
+#include <unistd.h>
+#endif
+
+
+typedef pthread_t st_thread_id;
+
+
+/* Thread creation. Created in detached mode if [res] is NULL. */
+static int st_thread_create(st_thread_id * res,
+                            void * (*fn)(void *), void * arg)
+{
+  pthread_t thr;
+  pthread_attr_t attr;
+  int rc;
+
+  pthread_attr_init(&attr);
+  if (res == NULL) pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_DETACHED);
+  rc = pthread_create(&thr, &attr, fn, arg);
+  if (res != NULL) *res = thr;
+  return rc;
+}
+
+#define ST_THREAD_FUNCTION void *
+
+/* Thread termination */
+
+static void st_thread_join(st_thread_id thr)
+{
+  pthread_join(thr, NULL);
+  /* best effort: ignore errors */
+}
+
+/* Thread-specific state */
+
+typedef pthread_key_t st_tlskey;
+
+static int st_tls_newkey(st_tlskey * res)
+{
+  return pthread_key_create(res, NULL);
+}
+
+Caml_inline void * st_tls_get(st_tlskey k)
+{
+  return pthread_getspecific(k);
+}
+
+Caml_inline void st_tls_set(st_tlskey k, void * v)
+{
+  pthread_setspecific(k, v);
+}
+
+/* The master lock.  This is a mutex that is held most of the time,
+   so we implement it in a slightly convoluted way to avoid
+   all risks of busy-waiting.  Also, we count the number of waiting
+   threads. */
+
+typedef struct {
+  bool init;                      /* have the mutex and the cond been
+                                     initialized already? */
+  pthread_mutex_t lock;           /* to protect contents */
+  bool busy;                      /* false = free, true = taken */
+  atomic_uintnat waiters;         /* number of threads waiting on master lock */
+  pthread_cond_t is_free;         /* signaled when free */
+} st_masterlock;
+
+/* Returns non-zero on failure */
+static int st_masterlock_init(st_masterlock * m)
+{
+  int rc;
+  if (!m->init) {
+    rc = pthread_mutex_init(&m->lock, NULL);
+    if (rc != 0) goto out_err;
+    rc = pthread_cond_init(&m->is_free, NULL);
+    if (rc != 0) goto out_err2;
+    m->init = true;
+  }
+  m->busy = true;
+  atomic_store_release(&m->waiters, 0);
+  return 0;
+
+ out_err2:
+  pthread_mutex_destroy(&m->lock);
+ out_err:
+  return rc;
+}
+
+static void st_masterlock_destroy(st_masterlock * m)
+{
+  int rc;
+  rc = pthread_cond_destroy(&m->is_free);
+  CAMLassert(!rc);
+  rc = pthread_mutex_destroy(&m->lock);
+  CAMLassert(!rc);
+  (void)rc;
+}
+
+static uintnat st_masterlock_waiters(st_masterlock * m)
+{
+  return atomic_load_acquire(&m->waiters);
+}
+
+static void st_masterlock_acquire(st_masterlock *m)
+{
+  pthread_mutex_lock(&m->lock);
+  while (m->busy) {
+    atomic_fetch_add(&m->waiters, +1);
+    pthread_cond_wait(&m->is_free, &m->lock);
+    atomic_fetch_add(&m->waiters, -1);
+  }
+  m->busy = true;
+  st_bt_lock_acquire();
+  pthread_mutex_unlock(&m->lock);
+
+  return;
+}
+
+static void st_masterlock_release(st_masterlock * m)
+{
+  pthread_mutex_lock(&m->lock);
+  m->busy = false;
+  st_bt_lock_release(st_masterlock_waiters(m) == 0);
+  pthread_cond_signal(&m->is_free);
+  pthread_mutex_unlock(&m->lock);
+
+  return;
+}
+
+/* Scheduling hints */
+
+/* This is mostly equivalent to release(); acquire(), but better. In particular,
+   release(); acquire(); leaves both us and the waiter we signal() racing to
+   acquire the lock. Calling yield or sleep helps there but does not solve the
+   problem. Sleeping ourselves is much more reliable--and since we're handing
+   off the lock to a waiter we know exists, it's safe, as they'll certainly
+   re-wake us later.
+*/
+Caml_inline void st_thread_yield(st_masterlock * m)
+{
+  pthread_mutex_lock(&m->lock);
+  /* We must hold the lock to call this. */
+
+  /* We already checked this without the lock, but we might have raced--if
+     there's no waiter, there's nothing to do and no one to wake us if we did
+     wait, so just keep going. */
+  uintnat waiters = st_masterlock_waiters(m);
+
+  if (waiters == 0) {
+    pthread_mutex_unlock(&m->lock);
+    return;
+  }
+
+  m->busy = false;
+  atomic_fetch_add(&m->waiters, +1);
+  pthread_cond_signal(&m->is_free);
+  /* releasing the domain lock but not triggering bt messaging
+     messaging the bt should not be required because yield assumes
+     that a thread will resume execution (be it the yielding thread
+     or a waiting thread */
+  caml_release_domain_lock();
+
+  do {
+    /* Note: the POSIX spec prevents the above signal from pairing with this
+       wait, which is good: we'll reliably continue waiting until the next
+       yield() or enter_blocking_section() call (or we see a spurious condvar
+       wakeup, which are rare at best.) */
+       pthread_cond_wait(&m->is_free, &m->lock);
+  } while (m->busy);
+
+  m->busy = true;
+  atomic_fetch_add(&m->waiters, -1);
+
+  caml_acquire_domain_lock();
+
+  pthread_mutex_unlock(&m->lock);
+
+  return;
+}
+
+/* Triggered events */
+
+typedef struct st_event_struct {
+  pthread_mutex_t lock;         /* to protect contents */
+  bool status;                  /* false = not triggered, true = triggered */
+  pthread_cond_t triggered;     /* signaled when triggered */
+} * st_event;
+
+
+static int st_event_create(st_event * res)
+{
+  int rc;
+  st_event e = caml_stat_alloc_noexc(sizeof(struct st_event_struct));
+  if (e == NULL) return ENOMEM;
+  rc = pthread_mutex_init(&e->lock, NULL);
+  if (rc != 0) { caml_stat_free(e); return rc; }
+  rc = pthread_cond_init(&e->triggered, NULL);
+  if (rc != 0)
+  { pthread_mutex_destroy(&e->lock); caml_stat_free(e); return rc; }
+  e->status = false;
+  *res = e;
+  return 0;
+}
+
+static int st_event_destroy(st_event e)
+{
+  int rc1, rc2;
+  rc1 = pthread_mutex_destroy(&e->lock);
+  rc2 = pthread_cond_destroy(&e->triggered);
+  caml_stat_free(e);
+  return rc1 != 0 ? rc1 : rc2;
+}
+
+static int st_event_trigger(st_event e)
+{
+  int rc;
+  rc = pthread_mutex_lock(&e->lock);
+  if (rc != 0) return rc;
+  e->status = true;
+  rc = pthread_mutex_unlock(&e->lock);
+  if (rc != 0) return rc;
+  rc = pthread_cond_broadcast(&e->triggered);
+  return rc;
+}
+
+static int st_event_wait(st_event e)
+{
+  int rc;
+  rc = pthread_mutex_lock(&e->lock);
+  if (rc != 0) return rc;
+  while(!e->status) {
+    rc = pthread_cond_wait(&e->triggered, &e->lock);
+    if (rc != 0) return rc;
+  }
+  rc = pthread_mutex_unlock(&e->lock);
+  return rc;
+}

--- a/otherlibs/systhreads/st_win32.h
+++ b/otherlibs/systhreads/st_win32.h
@@ -30,65 +30,78 @@ Caml_inline void st_msleep(const st_timeout *timeout)
   Sleep(*timeout);
 }
 
-/* POSIX thread implementation of the "st" interface */
-
 #include <errno.h>
 #include <string.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <pthread.h>
 #include <signal.h>
 #include <time.h>
-#ifndef _WIN32
-#include <unistd.h>
-#endif
+#include <caml/osdeps.h>
 
-
-typedef pthread_t st_thread_id;
-
+typedef HANDLE st_thread_id;
 
 /* Thread creation. Created in detached mode if [res] is NULL. */
 static int st_thread_create(st_thread_id * res,
-                            void * (*fn)(void *), void * arg)
+                            unsigned ( WINAPI *start_address )( void * ),
+                            void * arg)
 {
-  pthread_t thr;
-  pthread_attr_t attr;
-  int rc;
+  st_thread_id thr;
+  thr = (st_thread_id) _beginthreadex(
+    NULL, /* security: handle can't be inherited */
+    0,    /* stack size */
+    start_address,
+    arg,
+    0,    /* run immediately */
+    NULL  /* thread identifier */
+    );
+  if (thr == 0)
+    return errno;
 
-  pthread_attr_init(&attr);
-  if (res == NULL) pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_DETACHED);
-  rc = pthread_create(&thr, &attr, fn, arg);
-  if (res != NULL) *res = thr;
-  return rc;
+  if (res == NULL) {
+    /* detach */
+    if (!CloseHandle(thr)) {
+      int err = caml_posixerr_of_win32err(GetLastError());
+      return err == 0 ? EINVAL : err;
+    }
+  } else {
+    *res = thr;
+  }
+  return 0;
 }
-
-#define ST_THREAD_FUNCTION void *
 
 /* Thread termination */
 
 static void st_thread_join(st_thread_id thr)
 {
-  pthread_join(thr, NULL);
+  WaitForSingleObject(thr, INFINITE);
   /* best effort: ignore errors */
 }
 
 /* Thread-specific state */
 
-typedef pthread_key_t st_tlskey;
+typedef DWORD st_tlskey;
 
 static int st_tls_newkey(st_tlskey * res)
 {
-  return pthread_key_create(res, NULL);
+  DWORD index = TlsAlloc();
+  if (index == TLS_OUT_OF_INDEXES) {
+    int err = caml_posixerr_of_win32err(GetLastError());
+    return err == 0 ? EINVAL : err;
+  }
+  *res = index;
+  return 0;
 }
 
 Caml_inline void * st_tls_get(st_tlskey k)
 {
-  return pthread_getspecific(k);
+  /* No errors are returned from pthread_getspecific(). Ignore
+   * TlsGetValue() errors.  */
+  return TlsGetValue(k);
 }
 
 Caml_inline void st_tls_set(st_tlskey k, void * v)
 {
-  pthread_setspecific(k, v);
+  (void)TlsSetValue(k, v);
 }
 
 /* The master lock.  This is a mutex that is held most of the time,
@@ -99,41 +112,28 @@ Caml_inline void st_tls_set(st_tlskey k, void * v)
 typedef struct {
   bool init;                      /* have the mutex and the cond been
                                      initialized already? */
-  pthread_mutex_t lock;           /* to protect contents */
+  SRWLOCK lock;                   /* to protect contents */
   bool busy;                      /* false = free, true = taken */
   atomic_uintnat waiters;         /* number of threads waiting on master lock */
-  pthread_cond_t is_free;         /* signaled when free */
+  CONDITION_VARIABLE is_free;     /* signaled when free */
 } st_masterlock;
 
 /* Returns non-zero on failure */
 static int st_masterlock_init(st_masterlock * m)
 {
-  int rc;
   if (!m->init) {
-    rc = pthread_mutex_init(&m->lock, NULL);
-    if (rc != 0) goto out_err;
-    rc = pthread_cond_init(&m->is_free, NULL);
-    if (rc != 0) goto out_err2;
+    InitializeSRWLock(&m->lock);
+    InitializeConditionVariable(&m->is_free);
     m->init = true;
   }
   m->busy = true;
   atomic_store_release(&m->waiters, 0);
   return 0;
-
- out_err2:
-  pthread_mutex_destroy(&m->lock);
- out_err:
-  return rc;
 }
 
 static void st_masterlock_destroy(st_masterlock * m)
 {
-  int rc;
-  rc = pthread_cond_destroy(&m->is_free);
-  CAMLassert(!rc);
-  rc = pthread_mutex_destroy(&m->lock);
-  CAMLassert(!rc);
-  (void)rc;
+  (void) m;
 }
 
 static uintnat st_masterlock_waiters(st_masterlock * m)
@@ -143,26 +143,27 @@ static uintnat st_masterlock_waiters(st_masterlock * m)
 
 static void st_masterlock_acquire(st_masterlock *m)
 {
-  pthread_mutex_lock(&m->lock);
+  AcquireSRWLockExclusive(&m->lock);
   while (m->busy) {
     atomic_fetch_add(&m->waiters, +1);
-    pthread_cond_wait(&m->is_free, &m->lock);
+    SleepConditionVariableSRW(&m->is_free, &m->lock,
+                              INFINITE, 0 /* exclusive */);
     atomic_fetch_add(&m->waiters, -1);
   }
   m->busy = true;
   st_bt_lock_acquire();
-  pthread_mutex_unlock(&m->lock);
+  ReleaseSRWLockExclusive(&m->lock);
 
   return;
 }
 
 static void st_masterlock_release(st_masterlock * m)
 {
-  pthread_mutex_lock(&m->lock);
+  AcquireSRWLockExclusive(&m->lock);
   m->busy = false;
   st_bt_lock_release(st_masterlock_waiters(m) == 0);
-  pthread_cond_signal(&m->is_free);
-  pthread_mutex_unlock(&m->lock);
+  WakeConditionVariable(&m->is_free);
+  ReleaseSRWLockExclusive(&m->lock);
 
   return;
 }
@@ -178,7 +179,7 @@ static void st_masterlock_release(st_masterlock * m)
 */
 Caml_inline void st_thread_yield(st_masterlock * m)
 {
-  pthread_mutex_lock(&m->lock);
+  AcquireSRWLockExclusive(&m->lock);
   /* We must hold the lock to call this. */
 
   /* We already checked this without the lock, but we might have raced--if
@@ -187,13 +188,13 @@ Caml_inline void st_thread_yield(st_masterlock * m)
   uintnat waiters = st_masterlock_waiters(m);
 
   if (waiters == 0) {
-    pthread_mutex_unlock(&m->lock);
+    ReleaseSRWLockExclusive(&m->lock);
     return;
   }
 
   m->busy = false;
   atomic_fetch_add(&m->waiters, +1);
-  pthread_cond_signal(&m->is_free);
+  WakeConditionVariable(&m->is_free);
   /* releasing the domain lock but not triggering bt messaging
      messaging the bt should not be required because yield assumes
      that a thread will resume execution (be it the yielding thread
@@ -205,7 +206,8 @@ Caml_inline void st_thread_yield(st_masterlock * m)
        wait, which is good: we'll reliably continue waiting until the next
        yield() or enter_blocking_section() call (or we see a spurious condvar
        wakeup, which are rare at best.) */
-       pthread_cond_wait(&m->is_free, &m->lock);
+       SleepConditionVariableSRW(&m->is_free, &m->lock,
+                                 INFINITE, 0 /* exclusive */);
   } while (m->busy);
 
   m->busy = true;
@@ -213,7 +215,7 @@ Caml_inline void st_thread_yield(st_masterlock * m)
 
   caml_acquire_domain_lock();
 
-  pthread_mutex_unlock(&m->lock);
+  ReleaseSRWLockExclusive(&m->lock);
 
   return;
 }
@@ -221,22 +223,18 @@ Caml_inline void st_thread_yield(st_masterlock * m)
 /* Triggered events */
 
 typedef struct st_event_struct {
-  pthread_mutex_t lock;         /* to protect contents */
+  SRWLOCK lock;                 /* to protect contents */
   bool status;                  /* false = not triggered, true = triggered */
-  pthread_cond_t triggered;     /* signaled when triggered */
+  CONDITION_VARIABLE triggered; /* signaled when triggered */
 } * st_event;
 
 
 static int st_event_create(st_event * res)
 {
-  int rc;
   st_event e = caml_stat_alloc_noexc(sizeof(struct st_event_struct));
   if (e == NULL) return ENOMEM;
-  rc = pthread_mutex_init(&e->lock, NULL);
-  if (rc != 0) { caml_stat_free(e); return rc; }
-  rc = pthread_cond_init(&e->triggered, NULL);
-  if (rc != 0)
-  { pthread_mutex_destroy(&e->lock); caml_stat_free(e); return rc; }
+  InitializeSRWLock(&e->lock);
+  InitializeConditionVariable(&e->triggered);
   e->status = false;
   *res = e;
   return 0;
@@ -244,34 +242,30 @@ static int st_event_create(st_event * res)
 
 static int st_event_destroy(st_event e)
 {
-  int rc1, rc2;
-  rc1 = pthread_mutex_destroy(&e->lock);
-  rc2 = pthread_cond_destroy(&e->triggered);
   caml_stat_free(e);
-  return rc1 != 0 ? rc1 : rc2;
+  return 0;
 }
 
 static int st_event_trigger(st_event e)
 {
-  int rc;
-  rc = pthread_mutex_lock(&e->lock);
-  if (rc != 0) return rc;
+  AcquireSRWLockExclusive(&e->lock);
   e->status = true;
-  rc = pthread_mutex_unlock(&e->lock);
-  if (rc != 0) return rc;
-  rc = pthread_cond_broadcast(&e->triggered);
-  return rc;
+  ReleaseSRWLockExclusive(&e->lock);
+  WakeAllConditionVariable(&e->triggered);
+  return 0;
 }
 
 static int st_event_wait(st_event e)
 {
-  int rc;
-  rc = pthread_mutex_lock(&e->lock);
-  if (rc != 0) return rc;
+  AcquireSRWLockExclusive(&e->lock);
   while(!e->status) {
-    rc = pthread_cond_wait(&e->triggered, &e->lock);
-    if (rc != 0) return rc;
+    BOOL rc = SleepConditionVariableSRW(&e->triggered, &e->lock,
+                                        INFINITE, 0 /* exclusive */);
+    if (!rc) {
+      int err = caml_posixerr_of_win32err(GetLastError());
+      return err == 0 ? EINVAL : err;
+    }
   }
-  rc = pthread_mutex_unlock(&e->lock);
-  return rc;
+  ReleaseSRWLockExclusive(&e->lock);
+  return 0;
 }

--- a/runtime/caml/io.h
+++ b/runtime/caml/io.h
@@ -23,18 +23,7 @@
 #include "camlatomic.h"
 #include "misc.h"
 #include "mlvalues.h"
-
-#ifndef _MSC_VER
 #include "platform.h"
-#else
-/* We avoid including platform.h (which is really only necessary here to declare
-   caml_plat_mutex) because that would end up pulling in pthread.h but we want
-   to hide it on the MSVC port as it is not the native way to handle threads.
-   So we inline here just the implementation of caml_plat_mutex on that port,
-   this should be kept in sync */
-#include <stdint.h>
-typedef intptr_t caml_plat_mutex;
-#endif
 
 #if defined(_WIN32)
 typedef int64_t file_offset;

--- a/runtime/caml/platform.h
+++ b/runtime/caml/platform.h
@@ -113,8 +113,13 @@ Caml_inline void cpu_relax(void) {
 
 #ifdef _WIN32
 
-typedef SRWLOCK caml_plat_mutex;
-#define CAML_PLAT_MUTEX_INITIALIZER SRWLOCK_INIT
+typedef struct {
+  SRWLOCK lock;
+  _Atomic DWORD owner_tid;      /* 0 if not owned */
+  /* The "owner_tid" field is not always protected by "lock"; it is
+   * also accessed without holding "lock". */
+} caml_plat_mutex;
+#define CAML_PLAT_MUTEX_INITIALIZER { SRWLOCK_INIT, 0 }
 
 typedef CONDITION_VARIABLE caml_plat_cond;
 #define CAML_PLAT_COND_INITIALIZER CONDITION_VARIABLE_INIT
@@ -622,25 +627,37 @@ CAMLextern CAMLthread_local int caml_lockdepth;
 
 Caml_inline void caml_plat_lock_blocking(caml_plat_mutex* m)
 {
-  AcquireSRWLockExclusive(m);
-  DEBUG_LOCK(m);
+  DWORD self_tid = GetCurrentThreadId();
+  if (m->owner_tid != self_tid) {
+    AcquireSRWLockExclusive(&m->lock);
+    m->owner_tid = self_tid;
+    DEBUG_LOCK(m);
+  } else {
+    check_err("lock", EDEADLK);
+  }
 }
 
 Caml_inline int caml_plat_try_lock(caml_plat_mutex* m)
 {
-  BOOLEAN rc = TryAcquireSRWLockExclusive(m);
-  if (!rc) {
-    return 0;
-  } else {
+  if (TryAcquireSRWLockExclusive(&m->lock)) {
+    m->owner_tid = GetCurrentThreadId();
     DEBUG_LOCK(m);
     return 1;
+  } else {
+    return 0;
   }
 }
 
 Caml_inline void caml_plat_unlock(caml_plat_mutex* m)
 {
+  DWORD self_tid = GetCurrentThreadId();
   DEBUG_UNLOCK(m);
-  ReleaseSRWLockExclusive(m);
+  if (m->owner_tid == self_tid) {
+    m->owner_tid = 0;
+    ReleaseSRWLockExclusive(&m->lock);
+  } else {
+    check_err("unlock", EPERM);
+  }
 }
 
 #else

--- a/runtime/caml/platform.h
+++ b/runtime/caml/platform.h
@@ -104,6 +104,9 @@ Caml_inline void cpu_relax(void) {
 typedef pthread_mutex_t caml_plat_mutex;
 #define CAML_PLAT_MUTEX_INITIALIZER PTHREAD_MUTEX_INITIALIZER
 
+typedef pthread_cond_t caml_plat_cond;
+#define CAML_PLAT_COND_INITIALIZER PTHREAD_COND_INITIALIZER
+
 typedef pthread_t caml_plat_thread;
 typedef pthread_attr_t caml_plat_thread_attr;
 
@@ -165,8 +168,6 @@ void caml_plat_assert_all_locks_unlocked(void);
 Caml_inline void caml_plat_unlock(caml_plat_mutex*);
 void caml_plat_mutex_free(caml_plat_mutex*);
 CAMLextern void caml_plat_mutex_reinit(caml_plat_mutex*);
-typedef pthread_cond_t caml_plat_cond;
-#define CAML_PLAT_COND_INITIALIZER PTHREAD_COND_INITIALIZER
 void caml_plat_cond_init(caml_plat_cond*);
 void caml_plat_wait(caml_plat_cond*, caml_plat_mutex*); /* blocking */
 void caml_plat_broadcast(caml_plat_cond*);
@@ -523,6 +524,12 @@ Caml_inline int caml_plat_try_lock(caml_plat_mutex* m)
   }
 }
 
+Caml_inline void caml_plat_unlock(caml_plat_mutex* m)
+{
+  DEBUG_UNLOCK(m);
+  check_err("unlock", pthread_mutex_unlock(m));
+}
+
 CAMLextern void caml_plat_lock_non_blocking_actual(caml_plat_mutex* m);
 
 Caml_inline void caml_plat_lock_non_blocking(caml_plat_mutex* m)
@@ -530,12 +537,6 @@ Caml_inline void caml_plat_lock_non_blocking(caml_plat_mutex* m)
   if (!caml_plat_try_lock(m)) {
     caml_plat_lock_non_blocking_actual(m);
   }
-}
-
-Caml_inline void caml_plat_unlock(caml_plat_mutex* m)
-{
-  DEBUG_UNLOCK(m);
-  check_err("unlock", pthread_mutex_unlock(m));
 }
 
 extern intnat caml_plat_pagesize;

--- a/runtime/caml/platform.h
+++ b/runtime/caml/platform.h
@@ -103,6 +103,59 @@ Caml_inline void cpu_relax(void) {
 
 typedef pthread_mutex_t caml_plat_mutex;
 #define CAML_PLAT_MUTEX_INITIALIZER PTHREAD_MUTEX_INITIALIZER
+
+typedef pthread_t caml_plat_thread;
+typedef pthread_attr_t caml_plat_thread_attr;
+
+Caml_inline
+int caml_plat_thread_create(caml_plat_thread *restrict thread,
+                            const caml_plat_thread_attr *restrict attr,
+                            void *(*start_routine)(void *),
+                            void *restrict arg)
+{
+  return pthread_create(thread, attr, start_routine, arg);
+}
+
+Caml_inline
+int caml_plat_thread_equal(caml_plat_thread t1, caml_plat_thread t2)
+{
+  return pthread_equal(t1, t2);
+}
+
+Caml_inline
+caml_plat_thread caml_plat_thread_self(void)
+{
+  return pthread_self();
+}
+
+Caml_inline
+int caml_plat_thread_detach(caml_plat_thread thread)
+{
+  return pthread_detach(thread);
+}
+
+Caml_inline
+int caml_plat_thread_join(caml_plat_thread thread)
+{
+  return pthread_join(thread, NULL);
+}
+
+Caml_inline
+void caml_plat_thread_exit(void)
+{
+  pthread_exit(NULL);
+}
+
+Caml_inline
+int caml_plat_thread_cancel(caml_plat_thread t)
+{
+#ifdef HAVE_PTHREAD_CANCEL
+  return pthread_cancel(t);
+#else
+  return 0;
+#endif
+}
+
 CAMLextern void caml_plat_mutex_init(caml_plat_mutex*);
 Caml_inline void caml_plat_lock_blocking(caml_plat_mutex*);
 Caml_inline void caml_plat_lock_non_blocking(caml_plat_mutex*);

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -183,12 +183,12 @@ Caml_inline void interruptor_set_pending(struct interruptor *s)
 struct dom_internal {
   /* readonly fields, initialised and never modified */
   int id;
-  pthread_t tid;
+  caml_plat_thread tid;
   caml_domain_state* state;
   struct interruptor interruptor;
 
   /* backup thread */
-  pthread_t backup_thread;
+  caml_plat_thread backup_thread;
   atomic_uintnat backup_thread_msg;
   caml_plat_mutex domain_lock;
   caml_plat_cond domain_cond;
@@ -1241,7 +1241,8 @@ static value install_backup_thread_exn (dom_internal* di)
 #endif
 
   atomic_store_release(&di->backup_thread_msg, BT_ENTERING_OCAML);
-  err = pthread_create(&di->backup_thread, 0, backup_thread_func, (void*)di);
+  err = caml_plat_thread_create(&di->backup_thread, 0, backup_thread_func,
+                                (void*)di);
 
 #ifndef _WIN32
   pthread_sigmask(SIG_SETMASK, &old_mask, NULL);
@@ -1249,7 +1250,7 @@ static value install_backup_thread_exn (dom_internal* di)
 
   if (err != 0)
       return caml_check_error_exn(err, "failed to create domain backup thread");
-  pthread_detach(di->backup_thread);
+  caml_plat_thread_detach(di->backup_thread);
   return Val_unit;
 }
 
@@ -1403,7 +1404,7 @@ static void* domain_thread_func(void* v)
     handshake_failure(p, "failed to allocate domain: domain_create");
     goto out2;
   }
-  domain_self->tid = pthread_self();
+  domain_self->tid = caml_plat_thread_self();
   /* this domain is now part of the STW participant set */
   handshake_success(p);
 
@@ -1474,7 +1475,7 @@ CAMLprim value caml_domain_spawn(value callback, value term_sync)
 {
   CAMLparam2 (callback, term_sync);
   struct domain_startup_params p;
-  pthread_t th;
+  caml_plat_thread th;
   int err;
 
   if (atomic_load_relaxed(&domains_exiting) != 0) {
@@ -1488,7 +1489,7 @@ CAMLprim value caml_domain_spawn(value callback, value term_sync)
 
   /* Domain 0 does not need a backup thread when it is the sole
      domain. We create its backup thread before spawning domain 1. */
-  domain_self->tid = pthread_self();
+  domain_self->tid = caml_plat_thread_self();
   if (!backup_thread_running(domain_self)) {
     value res = install_backup_thread_exn(domain_self);
     if (Is_exception_result(res)) caml_raise(Extract_exception(res));
@@ -1502,10 +1503,11 @@ CAMLprim value caml_domain_spawn(value callback, value term_sync)
                                     sizeof(struct domain_ml_values));
   init_domain_ml_values(p.ml_values, callback, term_sync);
 
-  err = pthread_create(&th, 0, domain_thread_func, (void*)&p);
+  err = caml_plat_thread_create(&th, 0, domain_thread_func, (void*)&p);
   if (err) {
     free_domain_ml_values(p.ml_values);
-    caml_check_error(err, "failed to create domain thread: pthread_create");
+    caml_check_error(err, "failed to create domain thread: "
+                     "caml_plat_thread_create");
   }
 
   /* p.ml_values is now owned by the new domain */
@@ -1529,11 +1531,11 @@ CAMLprim value caml_domain_spawn(value callback, value term_sync)
   if (p.status == Dom_started) {
     /* successfully created a domain.
        p.ml_values is now owned by that domain */
-    pthread_detach(th);
+    caml_plat_thread_detach(th);
   } else {
     CAMLassert (p.status == Dom_failed);
     /* failed */
-    pthread_join(th, 0);
+    caml_plat_thread_join(th);
     caml_failwith(p.error);
   }
 
@@ -2171,7 +2173,8 @@ CAMLexport int caml_bt_is_in_blocking_section(void)
 
 CAMLexport int caml_bt_is_self(void)
 {
-  return pthread_equal(domain_self->backup_thread, pthread_self());
+  return caml_plat_thread_equal(domain_self->backup_thread,
+                                caml_plat_thread_self());
 }
 
 CAMLexport intnat caml_domain_is_multicore (void)
@@ -2428,14 +2431,12 @@ static void stw_terminate_domain(caml_domain_state *domain, void *data,
   int participating_count,
   caml_domain_state **participating)
 {
-  if (!pthread_equal(domain_self->tid, *(pthread_t *)data)) {
+  if (!caml_plat_thread_equal(domain_self->tid, *(caml_plat_thread *)data)) {
     if (caml_bt_is_self()) {
       /* If this STW request is handled by the backup thread, the
          domain thread is currently running C code. */
       domain_self->domain_canceled = true;
-#ifdef HAVE_PTHREAD_CANCEL
-      (void)pthread_cancel(domain_self->tid);
-#endif
+      (void)caml_plat_thread_cancel(domain_self->tid);
       /* We are intentionally not waiting for the thread to terminate here,
          and not decrementing the number of running domains either, since
          we don't know the state of the various locks and condition
@@ -2450,7 +2451,7 @@ static void stw_terminate_domain(caml_domain_state *domain, void *data,
       /* No particular memory resource cleanup is attempted here, for we
          have no idea which state each domain is in. */
     }
-    pthread_exit(0);
+    caml_plat_thread_exit();
   }
 }
 
@@ -2458,7 +2459,7 @@ void caml_stop_all_domains(void)
 {
   atomic_store_relaxed(&domains_exiting, 1);
 
-  pthread_t myself = pthread_self();
+  caml_plat_thread myself = caml_plat_thread_self();
   do {} while (!caml_try_run_on_all_domains(
                &stw_terminate_domain, &myself, NULL));
 

--- a/runtime/platform.c
+++ b/runtime/platform.c
@@ -107,7 +107,7 @@ void caml_plat_futex_init(caml_plat_futex* ftx, caml_plat_futex_value value) {
 
 void caml_plat_futex_free(caml_plat_futex* ftx) {
   caml_plat_mutex_free(&ftx->mutex);
-  check_err("cond_destroy", pthread_cond_destroy(&ftx->cond));
+  caml_plat_cond_free(&ftx->cond);
 }
 
 #else /* ! CAML_PLAT_FUTEX_FALLBACK */

--- a/runtime/platform.c
+++ b/runtime/platform.c
@@ -48,37 +48,6 @@ void caml_plat_fatal_error(const char * action, int err)
 
 /* Mutexes */
 
-CAMLexport void caml_plat_mutex_init(caml_plat_mutex * m)
-{
-  int rc;
-  pthread_mutexattr_t attr;
-  rc = pthread_mutexattr_init(&attr);
-  if (rc != 0) goto error1;
-  rc = pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_ERRORCHECK);
-  if (rc != 0) goto error2;
-  rc = pthread_mutex_init(m, &attr);
-  // fall through
-error2:
-  pthread_mutexattr_destroy(&attr);
-error1:
-  check_err("mutex_init", rc);
-}
-
-void caml_plat_assert_locked(caml_plat_mutex* m)
-{
-#ifdef DEBUG
-  int r = pthread_mutex_trylock(m);
-  if (r == EBUSY) {
-    /* ok, it was locked */
-    return;
-  } else if (r == 0) {
-    caml_fatal_error("Required mutex not locked");
-  } else {
-    check_err("assert_locked", r);
-  }
-#endif
-}
-
 #ifdef DEBUG
 CAMLexport CAMLthread_local int caml_lockdepth = 0;
 #endif
@@ -88,21 +57,6 @@ void caml_plat_assert_all_locks_unlocked(void)
 #ifdef DEBUG
   if (caml_lockdepth) caml_fatal_error("Locks still locked at termination");
 #endif
-}
-
-CAMLexport void caml_plat_lock_non_blocking_actual(caml_plat_mutex* m)
-{
-  /* Avoid exceptions */
-  caml_enter_blocking_section_no_pending();
-  int rc = pthread_mutex_lock(m);
-  caml_leave_blocking_section();
-  check_err("lock_non_blocking", rc);
-  DEBUG_LOCK(m);
-}
-
-void caml_plat_mutex_free(caml_plat_mutex* m)
-{
-  check_err("mutex_free", pthread_mutex_destroy(m));
 }
 
 CAMLexport void caml_plat_mutex_reinit(caml_plat_mutex *m)
@@ -120,45 +74,6 @@ CAMLexport void caml_plat_mutex_reinit(caml_plat_mutex *m)
   }
 #endif
   caml_plat_mutex_init(m);
-}
-
-/* Condition variables */
-static void caml_plat_cond_init_aux(caml_plat_cond *cond)
-{
-  pthread_condattr_t attr;
-  pthread_condattr_init(&attr);
-#if defined(_POSIX_TIMERS) && \
-    defined(_POSIX_MONOTONIC_CLOCK) && \
-    _POSIX_MONOTONIC_CLOCK != (-1)
-  pthread_condattr_setclock(&attr, CLOCK_MONOTONIC);
-#endif
-  pthread_cond_init(cond, &attr);
-}
-
-void caml_plat_cond_init(caml_plat_cond* cond)
-{
-  caml_plat_cond_init_aux(cond);
-}
-
-void caml_plat_wait(caml_plat_cond* cond, caml_plat_mutex* mut)
-{
-  caml_plat_assert_locked(mut);
-  check_err("wait", pthread_cond_wait(cond, mut));
-}
-
-void caml_plat_broadcast(caml_plat_cond* cond)
-{
-  check_err("cond_broadcast", pthread_cond_broadcast(cond));
-}
-
-void caml_plat_signal(caml_plat_cond* cond)
-{
-  check_err("cond_signal", pthread_cond_signal(cond));
-}
-
-void caml_plat_cond_free(caml_plat_cond* cond)
-{
-  check_err("cond_free", pthread_cond_destroy(cond));
 }
 
 /* Futexes */

--- a/runtime/startup_aux.c
+++ b/runtime/startup_aux.c
@@ -19,6 +19,10 @@
    and native code. */
 
 #include <stdio.h>
+#ifdef __MINGW32__
+/* See caml_startup_aux */
+#include <pthread.h>
+#endif
 #include "caml/backtrace.h"
 #include "caml/memory.h"
 #include "caml/callback.h"
@@ -146,6 +150,13 @@ static int shutdown_happened = 0;
 
 int caml_startup_aux(int pooling)
 {
+#ifdef __MINGW32__
+  /* On mingw-w64 only, this dummy call ensures that thread.o from winpthreads
+     is linked. This is done to ensure that pthreads calls synthesised by GCC
+     for TLS are linked statically. */
+  (void) pthread_getconcurrency();
+#endif
+
   if (shutdown_happened == 1)
     caml_fatal_error("caml_startup was called after the runtime "
                      "was shut down with caml_shutdown");

--- a/runtime/sync.c
+++ b/runtime/sync.c
@@ -27,7 +27,11 @@
 #include "caml/runtime_events.h"
 
 /* System-dependent part */
+#ifdef _WIN32
+#include "sync_win32.h"
+#else
 #include "sync_posix.h"
+#endif
 
 /* Reporting errors */
 

--- a/runtime/sync_win32.h
+++ b/runtime/sync_win32.h
@@ -33,9 +33,10 @@ typedef int sync_retcode;
 
 Caml_inline int sync_mutex_create(sync_mutex * res)
 {
-  sync_mutex m = caml_stat_alloc_noexc(sizeof(SRWLOCK));
+  sync_mutex m = caml_stat_alloc_noexc(sizeof(caml_plat_mutex));
   if (m == NULL) return ENOMEM;
-  InitializeSRWLock(m);
+  InitializeSRWLock(&m->lock);
+  m->owner_tid = 0;
   *res = m;
   return 0;
 }
@@ -48,8 +49,14 @@ Caml_inline int sync_mutex_destroy(sync_mutex m)
 
 Caml_inline int sync_mutex_lock(sync_mutex m)
 {
-  AcquireSRWLockExclusive(m);
-  return 0;
+  DWORD self_tid = GetCurrentThreadId();
+  if (m->owner_tid != self_tid) {
+    AcquireSRWLockExclusive(&m->lock);
+    m->owner_tid = self_tid;
+    return 0;
+  } else {
+    return EDEADLK;
+  }
 }
 
 #define MUTEX_PREVIOUSLY_UNLOCKED 0
@@ -57,14 +64,24 @@ Caml_inline int sync_mutex_lock(sync_mutex m)
 
 Caml_inline int sync_mutex_trylock(sync_mutex m)
 {
-  return TryAcquireSRWLockExclusive(m) ?
-    MUTEX_PREVIOUSLY_UNLOCKED : MUTEX_ALREADY_LOCKED;
+  if (TryAcquireSRWLockExclusive(&m->lock)) {
+    m->owner_tid = GetCurrentThreadId();
+    return MUTEX_PREVIOUSLY_UNLOCKED;
+  } else {
+    return MUTEX_ALREADY_LOCKED;
+  }
 }
 
 Caml_inline int sync_mutex_unlock(sync_mutex m)
 {
-  ReleaseSRWLockExclusive(m);
-  return 0;
+  DWORD self_tid = GetCurrentThreadId();
+  if (m->owner_tid == self_tid) {
+    m->owner_tid = 0;
+    ReleaseSRWLockExclusive(&m->lock);
+    return 0;
+  } else {
+    return EPERM;
+  }
 }
 
 /* Condition variables */
@@ -98,11 +115,22 @@ Caml_inline int sync_condvar_broadcast(sync_condvar c)
 
 Caml_inline int sync_condvar_wait(sync_condvar c, sync_mutex m)
 {
-  if (!SleepConditionVariableSRW(c, m, INFINITE, 0 /* exclusive */)) {
-    int rc = caml_posixerr_of_win32err(GetLastError());
-    return rc == 0 ? EINVAL : rc;
+  DWORD self_tid = GetCurrentThreadId();
+  int rc = 0;
+  if (m->owner_tid == self_tid) {
+    m->owner_tid = 0;
+    if (SleepConditionVariableSRW(c, &m->lock, INFINITE,
+                                  0 /* exclusive */)) {
+      m->owner_tid = self_tid;
+    } else {
+      rc = caml_posixerr_of_win32err(GetLastError());
+      /* Not clear if the thread owns the mutex or not, but there's a
+       * fatal error anyway.  */
+    }
+  } else {
+    rc = EPERM;
   }
-  return 0;
+  return rc;
 }
 
 #endif /* CAML_SYNC_WIN32_H */

--- a/runtime/sync_win32.h
+++ b/runtime/sync_win32.h
@@ -1,0 +1,119 @@
+/**************************************************************************/
+/*                                                                        */
+/*                                 OCaml                                  */
+/*                                                                        */
+/*          Xavier Leroy and Damien Doligez, INRIA Rocquencourt           */
+/*                                                                        */
+/*   Copyright 1996 Institut National de Recherche en Informatique et     */
+/*     en Automatique.                                                    */
+/*                                                                        */
+/*   All rights reserved.  This file is distributed under the terms of    */
+/*   the GNU Lesser General Public License version 2.1, with the          */
+/*   special exception on linking described in the file LICENSE.          */
+/*                                                                        */
+/**************************************************************************/
+
+/* POSIX thread implementation of the user facing Mutex and Condition */
+/* To be included in runtime/sync.c */
+
+#ifndef CAML_SYNC_POSIX_H
+#define CAML_SYNC_POSIX_H
+
+#include <errno.h>
+#include <pthread.h>
+#include <string.h>
+
+#include "caml/sync.h"
+
+typedef int sync_retcode;
+
+/* Mutexes */
+
+Caml_inline int sync_mutex_create(sync_mutex * res)
+{
+  int rc;
+  pthread_mutexattr_t attr;
+  sync_mutex m;
+
+  rc = pthread_mutexattr_init(&attr);
+  if (rc != 0) goto error1;
+  rc = pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_ERRORCHECK);
+  if (rc != 0) goto error2;
+  m = caml_stat_alloc_noexc(sizeof(pthread_mutex_t));
+  if (m == NULL) { rc = ENOMEM; goto error2; }
+  rc = pthread_mutex_init(m, &attr);
+  if (rc != 0) goto error3;
+  pthread_mutexattr_destroy(&attr);
+  *res = m;
+  return 0;
+error3:
+  caml_stat_free(m);
+error2:
+  pthread_mutexattr_destroy(&attr);
+error1:
+  return rc;
+}
+
+Caml_inline int sync_mutex_destroy(sync_mutex m)
+{
+  int rc;
+  rc = pthread_mutex_destroy(m);
+  caml_stat_free(m);
+  return rc;
+}
+
+Caml_inline int sync_mutex_lock(sync_mutex m)
+{
+  return pthread_mutex_lock(m);
+}
+
+#define MUTEX_PREVIOUSLY_UNLOCKED 0
+#define MUTEX_ALREADY_LOCKED EBUSY
+
+Caml_inline int sync_mutex_trylock(sync_mutex m)
+{
+  return pthread_mutex_trylock(m);
+}
+
+Caml_inline int sync_mutex_unlock(sync_mutex m)
+{
+  return pthread_mutex_unlock(m);
+}
+
+/* Condition variables */
+
+Caml_inline int sync_condvar_create(sync_condvar * res)
+{
+  int rc;
+  sync_condvar c = caml_stat_alloc_noexc(sizeof(pthread_cond_t));
+  if (c == NULL) return ENOMEM;
+  rc = pthread_cond_init(c, NULL);
+  if (rc != 0) { caml_stat_free(c); return rc; }
+  *res = c;
+  return 0;
+}
+
+Caml_inline int sync_condvar_destroy(sync_condvar c)
+{
+  int rc;
+  rc = pthread_cond_destroy(c);
+  caml_stat_free(c);
+  return rc;
+}
+
+Caml_inline int sync_condvar_signal(sync_condvar c)
+{
+ return pthread_cond_signal(c);
+}
+
+Caml_inline int sync_condvar_broadcast(sync_condvar c)
+{
+    return pthread_cond_broadcast(c);
+}
+
+Caml_inline int sync_condvar_wait(sync_condvar c, sync_mutex m)
+{
+  return pthread_cond_wait(c, m);
+}
+
+#endif /* CAML_SYNC_POSIX_H */

--- a/runtime/unix.c
+++ b/runtime/unix.c
@@ -612,3 +612,91 @@ CAMLextern char_os* caml_locate_standard_library (const char *exe_name,
     return caml_stat_strdup(stdlib_default);
   }
 }
+
+/* Mutexes */
+
+CAMLexport void caml_plat_mutex_init(caml_plat_mutex * m)
+{
+  int rc;
+  pthread_mutexattr_t attr;
+  rc = pthread_mutexattr_init(&attr);
+  if (rc != 0) goto error1;
+  rc = pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_ERRORCHECK);
+  if (rc != 0) goto error2;
+  rc = pthread_mutex_init(m, &attr);
+  // fall through
+error2:
+  pthread_mutexattr_destroy(&attr);
+error1:
+  check_err("mutex_init", rc);
+}
+
+void caml_plat_assert_locked(caml_plat_mutex* m)
+{
+#ifdef DEBUG
+  int r = pthread_mutex_trylock(m);
+  if (r == EBUSY) {
+    /* ok, it was locked */
+    return;
+  } else if (r == 0) {
+    caml_fatal_error("Required mutex not locked");
+  } else {
+    check_err("assert_locked", r);
+  }
+#endif
+}
+
+CAMLexport void caml_plat_lock_non_blocking_actual(caml_plat_mutex* m)
+{
+  /* Avoid exceptions */
+  caml_enter_blocking_section_no_pending();
+  int rc = pthread_mutex_lock(m);
+  caml_leave_blocking_section();
+  check_err("lock_non_blocking", rc);
+  DEBUG_LOCK(m);
+}
+
+void caml_plat_mutex_free(caml_plat_mutex* m)
+{
+  check_err("mutex_free", pthread_mutex_destroy(m));
+}
+
+/* Condition variables */
+
+static void caml_plat_cond_init_aux(caml_plat_cond *cond)
+{
+  pthread_condattr_t attr;
+  pthread_condattr_init(&attr);
+#if defined(_POSIX_TIMERS) &&                   \
+  defined(_POSIX_MONOTONIC_CLOCK) &&            \
+  _POSIX_MONOTONIC_CLOCK != (-1)
+  pthread_condattr_setclock(&attr, CLOCK_MONOTONIC);
+#endif
+  pthread_cond_init(cond, &attr);
+}
+
+void caml_plat_cond_init(caml_plat_cond* cond)
+{
+  caml_plat_cond_init_aux(cond);
+}
+
+void caml_plat_wait(caml_plat_cond* cond, caml_plat_mutex* mut)
+{
+  caml_plat_assert_locked(mut);
+  check_err("wait", pthread_cond_wait(cond, mut));
+}
+
+void caml_plat_broadcast(caml_plat_cond* cond)
+{
+  check_err("cond_broadcast", pthread_cond_broadcast(cond));
+}
+
+void caml_plat_signal(caml_plat_cond* cond)
+{
+  check_err("cond_signal", pthread_cond_signal(cond));
+}
+
+void caml_plat_cond_free(caml_plat_cond* cond)
+{
+  check_err("cond_free", pthread_cond_destroy(cond));
+}

--- a/runtime/win32.c
+++ b/runtime/win32.c
@@ -1435,13 +1435,14 @@ CAMLextern char_os* caml_locate_standard_library (const wchar_t *exe_name,
 
 CAMLexport void caml_plat_mutex_init(caml_plat_mutex * m)
 {
-  InitializeSRWLock(m);
+  InitializeSRWLock(&m->lock);
+  m->owner_tid = 0;
 }
 
 void caml_plat_assert_locked(caml_plat_mutex *m)
 {
 #ifdef DEBUG
-  BOOLEAN r = TryAcquireSRWLockExclusive(m);
+  BOOLEAN r = TryAcquireSRWLockExclusive(&m->lock);
   if (r == 0) {
     /* ok, it was locked */
     return;
@@ -1455,7 +1456,13 @@ CAMLexport void caml_plat_lock_non_blocking_actual(caml_plat_mutex* m)
 {
   /* Avoid exceptions */
   caml_enter_blocking_section_no_pending();
-  AcquireSRWLockExclusive(m);
+  DWORD self_tid = GetCurrentThreadId();
+  if (m->owner_tid != self_tid) {
+    AcquireSRWLockExclusive(&m->lock);
+    m->owner_tid = self_tid;
+  } else {
+    check_err("lock_non_blocking", EDEADLK);
+  }
   caml_leave_blocking_section();
   DEBUG_LOCK(m);
 }
@@ -1475,8 +1482,22 @@ void caml_plat_cond_init(caml_plat_cond *cond)
 void caml_plat_wait(caml_plat_cond *cond, caml_plat_mutex* mut)
 {
   caml_plat_assert_locked(mut);
-  BOOL rc = SleepConditionVariableSRW(cond, mut, INFINITE, 0 /* exclusive */);
-  check_err("wait", rc == 0);
+  DWORD self_tid = GetCurrentThreadId();
+  int rc = 0;
+  if (mut->owner_tid == self_tid) {
+    mut->owner_tid = 0;
+    if (SleepConditionVariableSRW(cond, &mut->lock, INFINITE,
+                                  0 /* exclusive */)) {
+      mut->owner_tid = self_tid;
+    } else {
+      rc = caml_posixerr_of_win32err(GetLastError());
+      /* Not clear if the thread owns the mutex or not, but there's a
+       * fatal error anyway.  */
+    }
+  } else {
+    rc = EPERM;
+  }
+  check_err("wait", rc);
 }
 
 void caml_plat_broadcast(caml_plat_cond* cond)

--- a/runtime/win32.c
+++ b/runtime/win32.c
@@ -1428,3 +1428,91 @@ CAMLextern char_os* caml_locate_standard_library (const wchar_t *exe_name,
     return caml_stat_wcsdup(stdlib_default);
   }
 }
+
+/* Mutexes */
+
+CAMLexport void caml_plat_mutex_init(caml_plat_mutex * m)
+{
+  int rc;
+  pthread_mutexattr_t attr;
+  rc = pthread_mutexattr_init(&attr);
+  if (rc != 0) goto error1;
+  rc = pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_ERRORCHECK);
+  if (rc != 0) goto error2;
+  rc = pthread_mutex_init(m, &attr);
+  // fall through
+error2:
+  pthread_mutexattr_destroy(&attr);
+error1:
+  check_err("mutex_init", rc);
+}
+
+void caml_plat_assert_locked(caml_plat_mutex* m)
+{
+#ifdef DEBUG
+  int r = pthread_mutex_trylock(m);
+  if (r == EBUSY) {
+    /* ok, it was locked */
+    return;
+  } else if (r == 0) {
+    caml_fatal_error("Required mutex not locked");
+  } else {
+    check_err("assert_locked", r);
+  }
+#endif
+}
+
+CAMLexport void caml_plat_lock_non_blocking_actual(caml_plat_mutex* m)
+{
+  /* Avoid exceptions */
+  caml_enter_blocking_section_no_pending();
+  int rc = pthread_mutex_lock(m);
+  caml_leave_blocking_section();
+  check_err("lock_non_blocking", rc);
+  DEBUG_LOCK(m);
+}
+
+void caml_plat_mutex_free(caml_plat_mutex* m)
+{
+  check_err("mutex_free", pthread_mutex_destroy(m));
+}
+
+/* Condition variables */
+
+static void caml_plat_cond_init_aux(caml_plat_cond *cond)
+{
+  pthread_condattr_t attr;
+  pthread_condattr_init(&attr);
+#if defined(_POSIX_TIMERS) &&                   \
+  defined(_POSIX_MONOTONIC_CLOCK) &&            \
+  _POSIX_MONOTONIC_CLOCK != (-1)
+  pthread_condattr_setclock(&attr, CLOCK_MONOTONIC);
+#endif
+  pthread_cond_init(cond, &attr);
+}
+
+void caml_plat_cond_init(caml_plat_cond* cond)
+{
+  caml_plat_cond_init_aux(cond);
+}
+
+void caml_plat_wait(caml_plat_cond* cond, caml_plat_mutex* mut)
+{
+  caml_plat_assert_locked(mut);
+  check_err("wait", pthread_cond_wait(cond, mut));
+}
+
+void caml_plat_broadcast(caml_plat_cond* cond)
+{
+  check_err("cond_broadcast", pthread_cond_broadcast(cond));
+}
+
+void caml_plat_signal(caml_plat_cond* cond)
+{
+  check_err("cond_signal", pthread_cond_signal(cond));
+}
+
+void caml_plat_cond_free(caml_plat_cond* cond)
+{
+  check_err("cond_free", pthread_cond_destroy(cond));
+}

--- a/stdlib/mutex.mli
+++ b/stdlib/mutex.mli
@@ -38,15 +38,11 @@ val lock : t -> unit
    by another thread will suspend until the other thread unlocks
    the mutex.
 
-   @raise Sys_error if the mutex is already locked by the thread
-   calling {!Mutex.lock} on Unix platforms. On Windows, recursive
-   locking deadlocks.
+   @raise Sys_error if the mutex is already locked by the thread calling
+   {!Mutex.lock}.
 
    @before 4.12 {!Sys_error} was not raised for recursive locking
-   (platform-dependent behaviour).
-
-   @since 5.3 On Windows, {!Sys_error} is not raised for recursive
-   locking. *)
+   (platform-dependent behaviour) *)
 
 val try_lock : t -> bool
 (** Same as {!Mutex.lock}, but does not suspend the calling thread if
@@ -58,15 +54,10 @@ val unlock : t -> unit
 (** Unlock the given mutex. Other threads suspended trying to lock
    the mutex will restart.  The mutex must have been previously locked
    by the thread that calls {!Mutex.unlock}.
-
-   @raise Sys_error if the mutex is unlocked or was locked by another
-   thread. This doesn't apply on Windows since OCaml 5.3.
+   @raise Sys_error if the mutex is unlocked or was locked by another thread.
 
    @before 4.12 {!Sys_error} was not raised when unlocking an unlocked mutex
-   or when unlocking a mutex from a different thread.
-
-   @since 5.3 On Windows, {!Sys_error} is not raised if the mutex is
-   unlocked or was locked by another thread. *)
+   or when unlocking a mutex from a different thread. *)
 
 val protect : t -> (unit -> 'a) -> 'a
 (** [protect mutex f] runs [f()] in a critical section where [mutex]

--- a/stdlib/mutex.mli
+++ b/stdlib/mutex.mli
@@ -38,11 +38,15 @@ val lock : t -> unit
    by another thread will suspend until the other thread unlocks
    the mutex.
 
-   @raise Sys_error if the mutex is already locked by the thread calling
-   {!Mutex.lock}.
+   @raise Sys_error if the mutex is already locked by the thread
+   calling {!Mutex.lock} on Unix platforms. On Windows, recursive
+   locking deadlocks.
 
    @before 4.12 {!Sys_error} was not raised for recursive locking
-   (platform-dependent behaviour) *)
+   (platform-dependent behaviour).
+
+   @since 5.3 On Windows, {!Sys_error} is not raised for recursive
+   locking. *)
 
 val try_lock : t -> bool
 (** Same as {!Mutex.lock}, but does not suspend the calling thread if
@@ -54,10 +58,15 @@ val unlock : t -> unit
 (** Unlock the given mutex. Other threads suspended trying to lock
    the mutex will restart.  The mutex must have been previously locked
    by the thread that calls {!Mutex.unlock}.
-   @raise Sys_error if the mutex is unlocked or was locked by another thread.
+
+   @raise Sys_error if the mutex is unlocked or was locked by another
+   thread. This doesn't apply on Windows since OCaml 5.3.
 
    @before 4.12 {!Sys_error} was not raised when unlocking an unlocked mutex
-   or when unlocking a mutex from a different thread. *)
+   or when unlocking a mutex from a different thread.
+
+   @since 5.3 On Windows, {!Sys_error} is not raised if the mutex is
+   unlocked or was locked by another thread. *)
 
 val protect : t -> (unit -> 'a) -> 'a
 (** [protect mutex f] runs [f()] in a critical section where [mutex]

--- a/testsuite/tests/lib-threads/mutex_errors.ml
+++ b/testsuite/tests/lib-threads/mutex_errors.ml
@@ -2,6 +2,7 @@
  include systhreads;
  hassysthreads;
  no-tsan; (* tsan detects the mutex errors and fails *)
+ not-windows; (* Windows' SRWLock differ from pthreads ERRORCHECK mutexes. *)
  {
    bytecode;
  }{

--- a/testsuite/tests/lib-threads/mutex_errors.ml
+++ b/testsuite/tests/lib-threads/mutex_errors.ml
@@ -2,7 +2,6 @@
  include systhreads;
  hassysthreads;
  no-tsan; (* tsan detects the mutex errors and fails *)
- not-windows; (* Windows' SRWLock differ from pthreads ERRORCHECK mutexes. *)
  {
    bytecode;
  }{

--- a/testsuite/tools/testToplevel.ml
+++ b/testsuite/tools/testToplevel.ml
@@ -42,16 +42,6 @@ let run config env mode =
                     if Sys.file_exists threads_plugin then
                       Harness.fail_because
                         "threads.cmxs is not expected to exist"
-                    else if Sys.win32 then
-                      (* cf. note in ocaml/ocaml#13520 - threads.cmxa is
-                         correctly compiled assuming winpthreads is statically
-                         in the same image (so without defining
-                         WINPTHREADS_USE_DLLIMPORT), but this is incorrect for
-                         threads.cmxs, as threads.cmxs may load more than 2GiB
-                         away from the main executable. For native Windows, it's
-                         not possible to rely on ocamlnat's automatic
-                         cmxa -> cmxs recompilation. *)
-                      "cmxs"
                     else
                       (* cf. ocaml/ocaml#12250 - no threads.cmxs *)
                       "cmxa"
@@ -78,11 +68,8 @@ let run config env mode =
       (* Systems configured with --disable-shared can't load bytecode libraries
          which need C stubs *)
       if Sys.cygwin && mode = Native && List.mem "unix" libraries
-      || Sys.win32 && mode = Native && List.mem "threads" libraries
       || has_c_stubs && not Config.supports_shared_libraries then
-        (* cf. ocaml/flexdll#146 - Cygwin's ocamlnat can't load unix.cmxs and
-           the lines above will have triggered native Windows being unable to
-           load threads.cmxs *)
+        (* cf. ocaml/flexdll#146 - Cygwin's ocamlnat can't load unix.cmxs *)
         125
       else
         0

--- a/tools/ci/appveyor/appveyor_build.sh
+++ b/tools/ci/appveyor/appveyor_build.sh
@@ -30,6 +30,17 @@ fi
 unset ORIGINAL_PATH
 unset __VSCMD_PREINIT_PATH
 
+# There are some utilities on the AppVeyor runner which include mingw-w64
+# runtime DLLs which we don't want to be available in the build.
+export PATH="$(tr ':' '\n' <<<"$PATH" |
+               grep -vxFf <(which -a libwinpthread-1.dll |
+               xargs -r dirname) |
+               paste -sd:)"
+if which 'libwinpthread-1.dll' 2>/dev/null; then
+  echo 'Failed to remove libwinpthread-1.dll from PATH'
+  exit 1
+fi
+
 git config --global --add safe.directory '*'
 
 function run {

--- a/tools/ci/inria/main
+++ b/tools/ci/inria/main
@@ -162,7 +162,6 @@ check_make_alldepend=false
 jobs=''
 bootstrap=false
 init_submodule_flexdll=false
-init_submodule_winpthreads=false
 
 memory_model_tests="tests/memory-model/forbidden.ml \
 tests/memory-model/publish.ml"
@@ -214,7 +213,6 @@ case "${OCAML_ARCH}" in
     instdir='C:/ocamlms'
     cleanup=true
     init_submodule_flexdll=true
-    init_submodule_winpthreads=true
   ;;
   msvc64)
     build='--build=x86_64-pc-cygwin'
@@ -222,7 +220,6 @@ case "${OCAML_ARCH}" in
     instdir='C:/ocamlms64'
     cleanup=true
     init_submodule_flexdll=true
-    init_submodule_winpthreads=true
   ;;
   *) arch_error;;
 esac
@@ -253,14 +250,6 @@ if $init_submodule_flexdll; then
 elif [ -f flexdll/Makefile ]; then
   if grep -Fq flexdll .gitmodules; then
     git submodule deinit --force flexdll
-  fi
-fi
-
-if $init_submodule_winpthreads; then
-  git submodule update --init winpthreads
-elif [ -f winpthreads/Makefile.in ]; then
-  if grep -Fq winpthreads .gitmodules; then
-    git submodule deinit --force winpthreads
   fi
 fi
 


### PR DESCRIPTION
The goal is to remove winpthreads (a library emulating pthreads on top of _old_ Windows APIs), and use _modern_ Windows APIs in both the MSVC and MinGW-w64 ports.

~It would be great if this PR could be considered for inclusion in 5.3: although we were already using the system winpthreads for the MinGW-w64 port, we introduced it as a submodule during the 5.3 development cycle to support the MSVC port. If we could remove it now, end users won't ever (unknowingly) depend on it.~ This PR is also based on #13352.

One commit removes winpthreads (breaking the OCaml build on the MSVC/clang-cl ports) and another implements the `caml_plat_*` and `st_*` functions required to abstract over pthreads and Windows concurrency APIs. 

Note that Windows [Mutex Objects](https://learn.microsoft.com/en-us/windows/win32/sync/mutex-objects) cannot be used with condition variables. The right pairing consists of [Slim Reader/Writer Locks](https://learn.microsoft.com/en-us/windows/win32/sync/slim-reader-writer--srw--locks) (SRW locks) and [condition variables](https://learn.microsoft.com/en-us/windows/win32/sync/condition-variables). SRW locks support shared locking (only readers) and exclusive locking (one writer). I've chosen to use exclusive locking in all cases. Windows condition variables have the problem that they cannot be statically initialized.

Both pthreads and WinAPI are quite similar, except for a few points that I've noted:
1. The type of a function that starts a thread. They return a `void *` pointer on pthreads, and an `unsigned int` on Windows, but it seems not to be a concern for us.
2. We use pthread `ERRORCHECK` mutexes. [POSIX states](https://pubs.opengroup.org/onlinepubs/9799919799/functions/pthread_mutex_lock.html):

   > The `pthread_mutex_lock()` function shall fail if:
   > [`EDEADLK`]
   >   The mutex type is `PTHREAD_MUTEX_ERRORCHECK` and the current thread already owns the mutex.

   The [Windows documentation states](https://learn.microsoft.com/en-us/windows/win32/sync/slim-reader-writer--srw--locks):

   > Exclusive mode SRW locks cannot be acquired recursively. If a thread tries to acquire a lock that it already holds, that attempt will […] deadlock (for `AcquireSRWLockExclusive`).

   Deadlocks caused by recursive attempts to lock cannot be detected on Windows. We cannot either detect double unlocks, or attempts to unlock a lock owned by another thread. This would revert the `Stdlib.Mutex` module guarantees to those of before OCaml 4.12 _on Windows only_.
   
   I've thus chosen to implement so-called `ERRORCHECK` mutexes with a pair of a SRWLock, and the thread id of the owner, accessed atomically. The value 0 is used when the thread is not owned, and is a valid sentinel value.

3. A Windows thread is "detached" if all handles referring to the thread have been closed: it cannot be joined (waited on in Windows terminology) anymore but is not ended. pthreads has a thread attribute to control the detached state.

I'd like to thank my colleagues at Tarides who have helped my write (and debug!) this code.