### PR TITLE
Fix `Filename.quote_command` hanlding of forward slashes in program path under Win32

### DIFF
--- a/Changes
+++ b/Changes
@@ -605,6 +605,10 @@ ___________
   from a DLL
   (Xavier Leroy, review by Miod Vallat)
 
+- #13417: `Filename.quote_command`: fix handling of forward slashes in program
+  path under Win32.
+  (Nicolás Ojeda Bär)
+
 OCaml 5.2.0 (13 May 2024)
 -------------------------
 

--- a/Changes
+++ b/Changes
@@ -607,7 +607,7 @@ ___________
 
 - #13417: `Filename.quote_command`: fix handling of forward slashes in program
   path under Win32.
-  (Nicolás Ojeda Bär)
+  (Nicolás Ojeda Bär, review by David Allsopp and Damien Doligez)
 
 OCaml 5.2.0 (13 May 2024)
 -------------------------

--- a/stdlib/filename.ml
+++ b/stdlib/filename.ml
@@ -219,12 +219,12 @@ Quoting commands for execution by cmd.exe is difficult.
       s;
     Buffer.contents b
   let quote_cmd_filename f =
+    (* In cmd.exe, forward slashes in the program path (argument 0) are
+       interpreted as introducing a flag. *)
+    let f = if String.contains f '/' then String.map (function '/' -> '\\' | c -> c) f else f in
     if String.exists (function '\"' | '%' -> true | _ -> false) f then
       failwith ("Filename.quote_command: bad file name " ^ f)
-    else if String.exists (function ' ' | '/' -> true | _ -> false) f then
-      (* In cmd.exe, one cannot use forward slashes as path separators in the
-         program path (argument 0), unless it is quoted.  Otherwise, cmd.exe
-         will interpret the slash as introducing a flag. *)
+    else if String.contains f ' ' then
       String.concat "" ["\""; f; "\""]
     else
       f

--- a/stdlib/filename.ml
+++ b/stdlib/filename.ml
@@ -221,7 +221,10 @@ Quoting commands for execution by cmd.exe is difficult.
   let quote_cmd_filename f =
     if String.exists (function '\"' | '%' -> true | _ -> false) f then
       failwith ("Filename.quote_command: bad file name " ^ f)
-    else if String.contains f ' ' then
+    else if String.exists (function ' ' | '/' -> true | _ -> false) f then
+      (* In cmd.exe, one cannot use forward slashes as path separators in the
+         program path (argument 0), unless it is quoted.  Otherwise, cmd.exe
+         will interpret the slash as introducing a flag. *)
       String.concat "" ["\""; f; "\""]
     else
       f

--- a/stdlib/filename.ml
+++ b/stdlib/filename.ml
@@ -221,7 +221,11 @@ Quoting commands for execution by cmd.exe is difficult.
   let quote_cmd_filename f =
     (* In cmd.exe, forward slashes in the program path (argument 0) are
        interpreted as introducing a flag. *)
-    let f = if String.contains f '/' then String.map (function '/' -> '\\' | c -> c) f else f in
+    let f =
+      if String.contains f '/' then
+        String.map (function '/' -> '\\' | c -> c) f
+      else f
+    in
     if String.exists (function '\"' | '%' -> true | _ -> false) f then
       failwith ("Filename.quote_command: bad file name " ^ f)
     else if String.contains f ' ' then

--- a/testsuite/tests/lib-filename/quotecommand.ml
+++ b/testsuite/tests/lib-filename/quotecommand.ml
@@ -53,16 +53,17 @@ let cat_file f =
 let myecho =
   Filename.concat Filename.current_dir_name "my echo.exe"
 
-let run ?stdin ?stdout ?stderr args =
+let run prog ?stdin ?stdout ?stderr args =
   flush Stdlib.stdout;
   let rc =
-   Sys.command (Filename.quote_command myecho ?stdin ?stdout ?stderr args) in
+   Sys.command (Filename.quote_command prog ?stdin ?stdout ?stderr args) in
   if rc > 0 then begin
-    printf "!!! my echo failed\n";
+    printf "!!! %s failed\n" prog;
     exit 2
   end
 
 let _ =
+  let run = run myecho in
   copy_file "myecho.exe" "my echo.exe";
   printf "-------- Spaces\n";
   run ["Lorem ipsum dolor"; "sit amet,"; "consectetur adipiscing elit,"];
@@ -100,3 +101,9 @@ let _ =
                "in voluptate"; "-out"; "velit esse cillum"; "-err"; "dolore"];
   cat_file "my file.tmp"; Sys.remove "my file.tmp";
   Sys.remove "my echo.exe"
+
+let _ =
+  if not (Sys.file_exists "sub") then Sys.mkdir "sub" 0o777;
+  copy_file "myecho.exe" "sub/myecho.exe";
+  printf "-------- Forward slashes in program position\n";
+  run "sub/myecho.exe" ["alea iacta est"]

--- a/testsuite/tests/lib-filename/quotecommand.ml
+++ b/testsuite/tests/lib-filename/quotecommand.ml
@@ -103,7 +103,5 @@ let _ =
   Sys.remove "my echo.exe"
 
 let _ =
-  if not (Sys.file_exists "sub") then Sys.mkdir "sub" 0o777;
-  copy_file "myecho.exe" "sub/myecho.exe";
   printf "-------- Forward slashes in program position\n";
-  run "sub/myecho.exe" ["alea iacta est"]
+  run "./myecho.exe" ["alea iacta est"]

--- a/testsuite/tests/lib-filename/quotecommand.reference
+++ b/testsuite/tests/lib-filename/quotecommand.reference
@@ -36,3 +36,5 @@ argv[4] = {|in reprehenderit|}
 argv[5] = {|in voluptate|}
 argv[7] = {|velit esse cillum|}
 argv[9] = {|dolore|}
+-------- Forward slashes in program position
+argv[1] = {|alea iacta est|}


### PR DESCRIPTION
Fixes #13415 

Tweak the code to quote the program path if it contains a forward slash.