### PR TITLE
Fix mingw64 ucrt build

### DIFF
--- a/runtime/caml/config.h
+++ b/runtime/caml/config.h
@@ -93,7 +93,7 @@
 #endif
 #endif
 
-#if defined(__MINGW32__) && !__USE_MINGW_ANSI_STDIO
+#if defined(__MINGW32__) && !__USE_MINGW_ANSI_STDIO && !defined(_UCRT)
   #define ARCH_INT64_TYPE long long
   #define ARCH_UINT64_TYPE unsigned long long
   #define ARCH_INT64_PRINTF_FORMAT "I64"


### PR DESCRIPTION
What it says on the tin. It would be good to have this bug fix in 5.3. The `I64` format specifier is not understood by the UCRT it seems:
```
$ make V=1
runtime/gen_primsc.sh \
                    runtime/primitives runtime/addrmap.c runtime/afl.c runtime/alloc.c runtime/array.c runtime/backtrace.c runtime/bigarray.c runtime/blake2.c runtime/callback.c runtime/codefrag.c runtime/compare.c runtime/custom.c runtime/debugger.c runtime/domain.c runtime/dynlink.c runtime/extern.c runtime/fail.c runtime/fiber.c runtime/finalise.c runtime/floats.c runtime/gc_ctrl.c runtime/gc_stats.c runtime/globroots.c runtime/hash.c runtime/intern.c runtime/ints.c runtime/io.c runtime/lexing.c runtime/lf_skiplist.c runtime/main.c runtime/major_gc.c runtime/md5.c runtime/memory.c runtime/memprof.c runtime/meta.c runtime/minor_gc.c runtime/misc.c runtime/obj.c runtime/parsing.c runtime/platform.c runtime/printexc.c runtime/prng.c runtime/roots.c runtime/runtime_events.c runtime/shared_heap.c runtime/signals.c runtime/skiplist.c runtime/startup_aux.c runtime/str.c runtime/sync.c runtime/sys.c runtime/win32.c runtime/weak.c runtime/backtrace_byt.c runtime/fail_byt.c runtime/fix_code.c runtime/interp.c runtime/startup_byt.c runtime/zstd.c \
                    > runtime/prims.c
x86_64-w64-mingw32-gcc -O2 -fno-strict-aliasing -fwrapv -mms-bitfields -g -Wno-unused -Wall -Wint-conversion -Wstrict-prototypes -Wold-style-definition -Wundef -Wold-style-declaration -Wimplicit-fallthrough=5 -Werror -fexcess-precision=standard -fno-tree-vrp  -I ./runtime -I ./flexdll  -D__USE_MINGW_ANSI_STDIO=0 -DUNICODE -D_UNICODE -DWINDOWS_UNICODE=1   -o runtime/prims.o -c runtime/prims.c
x86_64-w64-mingw32-gcc -O2 -fno-strict-aliasing -fwrapv -mms-bitfields -g -Wno-unused -Wall -Wint-conversion -Wstrict-prototypes -Wold-style-definition -Wundef -Wold-style-declaration -Wimplicit-fallthrough=5 -Werror -fexcess-precision=standard -fno-tree-vrp  -I ./runtime -I ./flexdll  -D__USE_MINGW_ANSI_STDIO=0 -DUNICODE -D_UNICODE -DWINDOWS_UNICODE=1  -DCAMLDLLIMPORT= -DIN_CAML_RUNTIME  -o runtime/parsing.b.o -c runtime/parsing.c
runtime/parsing.c: In function 'print_token':
runtime/parsing.c:127:23: error: format '%d' expects argument of type 'int', but argument 3 has type 'value' {aka 'long long int'} [-Werror=format=]
  127 |       fprintf(stderr, "%" ARCH_INTNAT_PRINTF_FORMAT "d", Long_val(v));
      |                       ^~~
runtime/parsing.c:127:54: note: format string is defined here
  127 |       fprintf(stderr, "%" ARCH_INTNAT_PRINTF_FORMAT "d", Long_val(v));
      |                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
      |                                                      |
      |                                                      int
      |                        %" ARCH_INTNAT_PRINTF_FORMAT "lld
cc1.exe: all warnings being treated as errors
make: *** [Makefile:1541: runtime/parsing.b.o] Error 1
```