### PR TITLE
Use `runtime_CPPFLAGS` also to build `.*pic.o` files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1470,8 +1470,9 @@ $(DEPDIR)/runtime/%.bi.$(D): \
   OC_CPPFLAGS = $(OC_BYTECODE_CPPFLAGS) $(ocamlruni_CPPFLAGS)
 
 runtime/%.bpic.$(O): OC_CFLAGS = $(OC_BYTECODE_CFLAGS) $(SHAREDLIB_CFLAGS)
-runtime/%.bpic.$(O): OC_CPPFLAGS = $(OC_BYTECODE_CPPFLAGS)
-$(DEPDIR)/runtime/%.bpic.$(D): OC_CPPFLAGS = $(OC_BYTECODE_CPPFLAGS)
+runtime/%.bpic.$(O): OC_CPPFLAGS = $(OC_BYTECODE_CPPFLAGS) $(ocamlrun_CPPFLAGS)
+$(DEPDIR)/runtime/%.bpic.$(D): \
+  OC_CPPFLAGS = $(OC_BYTECODE_CPPFLAGS) $(ocamlrun_CPPFLAGS)
 
 runtime/%.n.$(O): OC_CFLAGS = $(OC_NATIVE_CFLAGS)
 runtime/%.n.$(O): OC_CPPFLAGS = $(OC_NATIVE_CPPFLAGS) $(ocamlrun_CPPFLAGS)
@@ -1489,8 +1490,9 @@ $(DEPDIR)/runtime/%.ni.$(D): \
   OC_CPPFLAGS = $(OC_NATIVE_CPPFLAGS) $(ocamlruni_CPPFLAGS)
 
 runtime/%.npic.$(O): OC_CFLAGS = $(OC_NATIVE_CFLAGS) $(SHAREDLIB_CFLAGS)
-runtime/%.npic.$(O): OC_CPPFLAGS = $(OC_NATIVE_CPPFLAGS)
-$(DEPDIR)/runtime/%.npic.$(D): OC_CPPFLAGS = $(OC_NATIVE_CPPFLAGS)
+runtime/%.npic.$(O): OC_CPPFLAGS = $(OC_NATIVE_CPPFLAGS) $(ocamlrun_CPPFLAGS)
+$(DEPDIR)/runtime/%.npic.$(D): \
+  OC_CPPFLAGS = $(OC_NATIVE_CPPFLAGS) $(ocamlrun_CPPFLAGS)
 
 ## Compilation of runtime C files
 


### PR DESCRIPTION
In commit 31cdf416280053dcd38351b7858e818b23110779 from #12589, the `runtime_CPPFLAGS` were dropped from the `OC_CPPFLAGS` for `.*pic.o` object files by accident, as at least `-DCAMLDLLIMPORT=` is necessary to build the Cygwin port without warnings.
Without that PR, the build with `-Werror` ends up with:

```
gcc -O2 -fno-strict-aliasing -fwrapv -g -Wall -Wint-conversion -Wstrict-prototypes -Wold-style-definition -Wundef -Wold-style-declaration -Wimplicit-fallthrough=5 -Werror -fno-common -fexcess-precision=standard -Wvla -fno-tree-vrp  -pthread -I ./runtime -I ./flexdll  -D_FILE_OFFSET_BITS=64 -U_WIN32   -o runtime/alloc.bpic.o -c runtime/alloc.c
runtime/alloc.c:33:18: error: 'caml_alloc' redeclared without dllimport attribute: previous dllimport ignored [-Werror=attributes]
   33 | CAMLexport value caml_alloc (mlsize_t wosize, tag_t tag)
      |                  ^~~~~~~~~~
...
```

A complete run is currently available [here](https://github.com/shym/ocaml/actions/runs/10700584878/job/29664638034).

I assume it was accidental as I didn’t find any mention of the fact that `-DCAMLDLLIMPORT` and `-DIN_CAML_RUNTIME` were dropped on purpose, either in the commit message or in the PR.

I’ve added a quick mashup of the Unixy CI workflow with the workflow we use in multicoretests to torture Cygwin to test this fix, but it’s not intended to be part of what is merged, if I understood correctly the plans for the Cygwin CI return.