### PR TITLE
Fix Gc.quick_stat documentation

### DIFF
--- a/Changes
+++ b/Changes
@@ -330,6 +330,10 @@ ___________
   (KC Sivaramakrishnan, review by Anil Madhavapeddy, Florian Angeletti and Miod
    Vallat)
 
+- #13424: Fix `Gc.quick_stat` documentation to clarify that returned fields
+  `live_words`, `live_blocks`, `free_words`, and `fragments` are not zero.
+  (Jan Midtgaard, review by Damien Doligez and KC Sivaramakrishnan)
+
 ### Compiler user-interface and warnings:
 
 * #12084: Check link order when creating archive and when using ocamlopt

--- a/stdlib/gc.mli
+++ b/stdlib/gc.mli
@@ -42,7 +42,7 @@ type stat =
 
     heap_chunks : int;
     (** Number of contiguous pieces of memory that make up the major heap.
-        This metrics is currently not available in OCaml 5: the field value is
+        This metric is currently not available in OCaml 5: the field value is
         always [0]. *)
 
     live_words : int;
@@ -71,12 +71,12 @@ type stat =
 
     free_blocks : int;
     (** Number of blocks in the free list.
-        This metrics is currently not available in OCaml 5: the field value is
+        This metric is currently not available in OCaml 5: the field value is
         always [0]. *)
 
     largest_free : int;
     (** Size (in words) of the largest block in the free list.
-        This metrics is currently not available in OCaml 5: the field value
+        This metric is currently not available in OCaml 5: the field value
         is always [0]. *)
 
     fragments : int;
@@ -92,7 +92,7 @@ type stat =
 
     stack_size: int;
     (** Current size of the stack, in words.
-        This metrics is currently not available in OCaml 5: the field value is
+        This metric is currently not available in OCaml 5: the field value is
         always [0].
         @since 3.12 *)
 
@@ -224,16 +224,19 @@ type control =
 
 external stat : unit -> stat = "caml_gc_stat"
 (** Return the current values of the memory management counters in a
-   [stat] record that represent the program's total memory stats.
-   This function causes a full major collection. *)
+    [stat] record that represents the program's total memory stats.
+    The [heap_chunks], [free_blocks], [largest_free], and [stack_size] metrics
+    are currently not available in OCaml 5: their returned field values are
+    therefore [0].
+    This function causes a full major collection. *)
 
 external quick_stat : unit -> stat = "caml_gc_quick_stat"
-(** Same as [stat] except that [live_words], [live_blocks], [free_words],
-    [free_blocks], [largest_free], and [fragments] are set to 0. Due to
-    per-domain buffers it may only represent the state of the program's
-    total memory usage since the last minor collection or major cycle.
-    This function is much faster than [stat] because it does not need to
-    trigger a full major collection. *)
+(** Returns a record with the current values of the memory management counters
+    like [stat]. Unlike [stat], [quick_stat] does not perform a full major
+    collection, and hence, is much faster. However, [quick_stat] reports the
+    counters sampled at the last minor collection or at the end of the last
+    major collection cycle (whichever is the latest). Hence, the memory stats
+    returned by [quick_stat] are not instantaneously accurate. *)
 
 external counters : unit -> float * float * float = "caml_gc_counters"
 (** Return [(minor_words, promoted_words, major_words)] for the current


### PR DESCRIPTION
While torturing the poor `Gc` module, a test spotted that the `Gc.quick_stat` documentation was a bit off.

- the promised `live_words`, `live_blocks`, `free_words`, and `fragments` fields are not zero
- the `largest_free` and `stack_size` fields returned by `Gc.stat` are also 0 (along with `heap_chunks` and `free_blocks` - as documented in the `stat` record type at the top) and hence better be documented in the `stat` function
- nit alert: while not being a native speaker, I believe singular "this metric" is preferable


I can see https://github.com/ocaml/ocaml/pull/12850 included in 5.2.0 made adjustments to the `Gc.quick_stat` functionality and documentation, but OCaml5 has returned non-zero fields for these entries since 5.0.0 AFAICS.


A top-level example to illustrate:
```
OCaml version 5.4.0+dev0-2024-08-25
Enter #help;; for help.

Gc.compact ();;
- : unit = ()
Gc.quick_stat ();;
- : Gc.stat =
{Gc.minor_words = 757748.; promoted_words = 204684.; major_words = 402624.;
 minor_collections = 18; major_collections = 9; heap_words = 435112;
 heap_chunks = 0; live_words = 349577; live_blocks = 80388;
 free_words = 82724; free_blocks = 0; largest_free = 0; fragments = 2811;
 compactions = 1; top_heap_words = 485635; stack_size = 0;
 forced_major_collections = 2}
Gc.stat ();;
- : Gc.stat =
{Gc.minor_words = 794089.; promoted_words = 205774.; major_words = 403714.;
 minor_collections = 24; major_collections = 12; heap_words = 435112;
 heap_chunks = 0; live_words = 349957; live_blocks = 80491;
 free_words = 82344; free_blocks = 0; largest_free = 0; fragments = 2811;
 compactions = 1; top_heap_words = 485635; stack_size = 0;
 forced_major_collections = 3}
```