### PR TITLE
handle dump=[lambda | rawlambda | cmm | ...] in OCAMLPARAM

### DIFF
--- a/Changes
+++ b/Changes
@@ -19,6 +19,10 @@ Working version
 
 ### Compiler user-interface and warnings:
 
+- #13428: support dump=[source | parsetree | lambda | ... | cmm | ...]
+  in OCAMLRUNPARAM
+  (Gabriel Scherer, review by Vincent Laviron)
+
 ### Internal/compiler-libs changes:
 
 - #13425: undocumented -dmatchcomp flag for the debug

--- a/utils/clflags.ml
+++ b/utils/clflags.ml
@@ -125,19 +125,19 @@ and opaque = ref false                  (* -opaque *)
 
 and dump_cmm = ref false                (* -dcmm *)
 let dump_selection = ref false          (* -dsel *)
+let dump_combine = ref false            (* -dcombine *)
 let dump_cse = ref false                (* -dcse *)
 let dump_live = ref false               (* -dlive *)
 let dump_spill = ref false              (* -dspill *)
 let dump_split = ref false              (* -dsplit *)
 let dump_interf = ref false             (* -dinterf *)
 let dump_prefer = ref false             (* -dprefer *)
+let dump_interval = ref false           (* -dinterval *)
 let dump_regalloc = ref false           (* -dalloc *)
 let dump_reload = ref false             (* -dreload *)
 let dump_scheduling = ref false         (* -dscheduling *)
 let dump_linear = ref false             (* -dlinear *)
-let dump_interval = ref false           (* -dinterval *)
 let keep_startup_file = ref false       (* -dstartup *)
-let dump_combine = ref false            (* -dcombine *)
 let profile_columns : Profile.column list ref = ref [] (* -dprofile/-dtimings *)
 
 let native_code = ref false             (* set to true under ocamlopt *)
@@ -551,6 +551,197 @@ let set_save_ir_after pass enabled =
       other_passes
   in
   save_ir_after := new_passes
+
+module Dump_option = struct
+  type t =
+    | Source
+    | Parsetree
+    | Typedtree
+    | Shape
+    | Match_comp
+    | Raw_lambda
+    | Lambda
+    | Instr
+    | Raw_clambda
+    | Clambda
+    | Raw_flambda
+    | Flambda
+    | Cmm
+    | Selection
+    | Combine
+    | CSE
+    | Live
+    | Spill
+    | Split
+    | Interf
+    | Prefer
+    | Regalloc
+    | Scheduling
+    | Linear
+    | Interval
+
+  let compare (op1 : t) op2 =
+    Stdlib.compare op1 op2
+
+  let to_string = function
+    | Source -> "source"
+    | Parsetree -> "parsetree"
+    | Typedtree -> "typedtree"
+    | Shape -> "shape"
+    | Match_comp -> "matchcomp"
+    | Raw_lambda -> "rawlambda"
+    | Lambda -> "lambda"
+    | Instr -> "instr"
+    | Raw_clambda -> "rawclambda"
+    | Clambda -> "clambda"
+    | Raw_flambda -> "rawflambda"
+    | Flambda -> "flambda"
+    | Cmm -> "cmm"
+    | Selection -> "selection"
+    | Combine -> "combine"
+    | CSE -> "cse"
+    | Live -> "live"
+    | Spill -> "spill"
+    | Split -> "split"
+    | Interf -> "interf"
+    | Prefer -> "prefer"
+    | Regalloc -> "regalloc"
+    | Scheduling -> "scheduling"
+    | Linear -> "linear"
+    | Interval -> "interval"
+
+  let of_string = function
+    | "source" -> Some Source
+    | "parsetree" -> Some Parsetree
+    | "typedtree" -> Some Typedtree
+    | "shape" -> Some Shape
+    | "matchcomp" -> Some Match_comp
+    | "rawlambda" -> Some Raw_lambda
+    | "lambda" -> Some Lambda
+    | "instr" -> Some Instr
+    | "rawclambda" -> Some Raw_clambda
+    | "clambda" -> Some Clambda
+    | "rawflambda" -> Some Raw_flambda
+    | "flambda" -> Some Flambda
+    | "cmm" -> Some Cmm
+    | "selection" -> Some Selection
+    | "combine" -> Some Combine
+    | "cse" -> Some CSE
+    | "live" -> Some Live
+    | "spill" -> Some Spill
+    | "split" -> Some Split
+    | "interf" -> Some Interf
+    | "prefer" -> Some Prefer
+    | "regalloc" -> Some Regalloc
+    | "scheduling" -> Some Scheduling
+    | "linear" -> Some Linear
+    | "interval" -> Some Interval
+    | _ -> None
+
+  let flag = function
+    | Source -> dump_source
+    | Parsetree -> dump_parsetree
+    | Typedtree -> dump_typedtree
+    | Shape -> dump_shape
+    | Match_comp -> dump_matchcomp
+    | Raw_lambda -> dump_rawlambda
+    | Lambda -> dump_lambda
+    | Instr -> dump_instr
+    | Raw_clambda -> dump_rawclambda
+    | Clambda -> dump_clambda
+    | Raw_flambda -> dump_rawflambda
+    | Flambda -> dump_flambda
+    | Cmm -> dump_cmm
+    | Selection -> dump_selection
+    | Combine -> dump_combine
+    | CSE -> dump_cse
+    | Live -> dump_live
+    | Spill -> dump_spill
+    | Split -> dump_split
+    | Interf -> dump_interf
+    | Prefer -> dump_prefer
+    | Regalloc -> dump_regalloc
+    | Scheduling -> dump_scheduling
+    | Linear -> dump_linear
+    | Interval -> dump_interval
+
+  type middle_end =
+    | Flambda
+    | Any
+    | Closure
+
+  type class_ =
+    | Frontend
+    | Bytecode
+    | Middle of middle_end
+    | Backend
+
+  let _ =
+    (* no Closure-specific dump option for now, silence a warning *)
+    Closure
+
+  let classify : t -> class_ = function
+    | Source
+    | Parsetree
+    | Typedtree
+    | Shape
+    | Match_comp
+    | Raw_lambda
+    | Lambda
+      -> Frontend
+    | Instr
+      -> Bytecode
+    | Raw_clambda
+    | Clambda
+      -> Middle Any
+    | Raw_flambda
+    | Flambda
+      -> Middle Flambda
+    | Cmm
+    | Selection
+    | Combine
+    | CSE
+    | Live
+    | Spill
+    | Split
+    | Interf
+    | Prefer
+    | Regalloc
+    | Scheduling
+    | Linear
+    | Interval
+      -> Backend
+
+  let available (option : t) : (unit, string) result =
+    let pass = Result.ok () in
+    let ( let* ) = Result.bind in
+    let fail descr =
+      Error (
+        Printf.sprintf
+          "this compiler does not support %s-specific options"
+          descr
+      ) in
+    let guard descr cond =
+      if cond then pass
+      else fail descr in
+    let check_bytecode = guard "bytecode" (not !native_code) in
+    let check_native = guard "native" !native_code in
+    let check_middle_end = function
+      | Flambda -> guard "flambda" Config.flambda
+      | Closure -> guard "closure" (not Config.flambda)
+      | Any -> pass
+    in
+    match classify option with
+    | Frontend ->
+        pass
+    | Bytecode ->
+        check_bytecode
+    | Middle middle_end ->
+        let* () = check_native in
+        check_middle_end middle_end
+    | Backend ->
+        check_native
+end
 
 module String = Misc.Stdlib.String
 

--- a/utils/clflags.mli
+++ b/utils/clflags.mli
@@ -254,10 +254,50 @@ module Compiler_pass : sig
   val to_output_filename: t -> prefix:string -> string
   val of_input_filename: string -> t option
 end
+
 val stop_after : Compiler_pass.t option ref
 val should_stop_after : Compiler_pass.t -> bool
 val set_save_ir_after : Compiler_pass.t -> bool -> unit
 val should_save_ir_after : Compiler_pass.t -> bool
+
+module Dump_option : sig
+  type t =
+    | Source
+    | Parsetree
+    | Typedtree
+    | Shape
+    | Match_comp
+    | Raw_lambda
+    | Lambda
+    | Instr
+    | Raw_clambda
+    | Clambda
+    | Raw_flambda
+    | Flambda
+      (* Note: no support for [-dflambda-let <stamp>] for now. *)
+    | Cmm
+    | Selection
+    | Combine
+    | CSE
+    | Live
+    | Spill
+    | Split
+    | Interf
+    | Prefer
+    | Regalloc
+    | Scheduling
+    | Linear
+    | Interval
+
+  val compare : t -> t -> int
+
+  val of_string : string -> t option
+  val to_string : t -> string
+
+  val flag : t -> bool ref
+
+  val available : t -> (unit, string) Result.t
+end
 
 val arg_spec : (string * Arg.spec * string) list ref
 


### PR DESCRIPTION
In #13425, @lthls suggested that it would be useful to be able to dump intermediate representations (`-dlambda`, `-dcmm`, etc.) from OCAMLPARAM. The present PR implements this with a generic `dump=<option>` setting. Each `-dfoo` flag now has a corresponding `dump=foo` option, except for `-dflambda-let <stamp>` which I was too lazy to support, and can be kept for later.

```shell
$ OCAMLPARAM="_,dump=source,dump=typedtree,dump=lambda,dump=-typedtree" \
  ./runtime/ocamlrun ./ocamlc -nostdlib -I stdlib -c /tmp/test.ml
module M = struct  end
(setglobal Test! (let (M/271 = (makeblock 0)) (makeblock 0 M/271)))
```