### PR TITLE
#12738: better detect short path rewrites

### DIFF
--- a/Changes
+++ b/Changes
@@ -510,6 +510,10 @@ ___________
 
 ### Bug fixes:
 
+- #12738, #????: better integration between short-paths and path disambiguation
+  and error messages (`open Base` no longer rename `int` to `int/2`)
+  (Florian Angeletti, report by Nick Roberts , review by ????)
+
 - #12854: Add a test in the regression suite that flags the bug #12825.
   (Luc Maranget)
 

--- a/Changes
+++ b/Changes
@@ -510,9 +510,9 @@ ___________
 
 ### Bug fixes:
 
-- #12738, #????: better integration between short-paths and path disambiguation
+- #12738, #13433: better integration between short-paths and path disambiguation
   and error messages (`open Base` no longer rename `int` to `int/2`)
-  (Florian Angeletti, report by Nick Roberts , review by ????)
+  (Florian Angeletti, report by Nick Roberts , review by Gabriel Scherer)
 
 - #12854: Add a test in the regression suite that flags the bug #12825.
   (Luc Maranget)

--- a/testsuite/tests/typing-short-paths/abbrev.ml
+++ b/testsuite/tests/typing-short-paths/abbrev.ml
@@ -1,0 +1,3 @@
+type nonrec int = int
+type nonrec 'a list = 'a list
+type float = Stdlib.Float.t

--- a/testsuite/tests/typing-short-paths/persistent_abbrevs.ml
+++ b/testsuite/tests/typing-short-paths/persistent_abbrevs.ml
@@ -14,12 +14,27 @@ let x = [[1]; 2.0]
 Line 2, characters 14-17:
 2 | let x = [[1]; 2.0]
                   ^^^
-Error: The constant "2.0" has type "float/2"
-       but an expression was expected of type "int/2 list/2"
-       File "_none_", line 1:
-         Definition of type "float/2"
-       File "_none_", line 1:
-         Definition of type "int/2"
-       File "_none_", line 1:
-         Definition of type "list/2"
+Error: The constant "2.0" has type "float" but an expression was expected of type
+         "int list"
+|}]
+
+type a = A
+module M=struct
+  type a = B
+  let f A B = ()
+   let g f = f B A
+  let () = g f
+end
+[%%expect{|
+type a = A
+Line 6, characters 13-14:
+6 |   let () = g f
+                 ^
+Error: The value "f" has type "a/2 -> a -> unit"
+       but an expression was expected of type "a -> a/2 -> 'a"
+       Type "a/2" is not compatible with type "a"
+       Line 3, characters 2-12:
+         Definition of type "a"
+       Line 1, characters 0-10:
+         Definition of type "a/2"
 |}]

--- a/testsuite/tests/typing-short-paths/persistent_abbrevs.ml
+++ b/testsuite/tests/typing-short-paths/persistent_abbrevs.ml
@@ -1,0 +1,25 @@
+(* TEST
+ readonly_files = "abbrev.ml";
+ setup-ocamlc.byte-build-env;
+ module = "abbrev.ml";
+ ocamlc.byte;
+ flags = " -short-paths ";
+ expect;
+*)
+
+#directory "ocamlc.byte";;
+open Abbrev
+let x = [[1]; 2.0]
+[%%expect {|
+Line 2, characters 14-17:
+2 | let x = [[1]; 2.0]
+                  ^^^
+Error: The constant "2.0" has type "float/2"
+       but an expression was expected of type "int/2 list/2"
+       File "_none_", line 1:
+         Definition of type "float/2"
+       File "_none_", line 1:
+         Definition of type "int/2"
+       File "_none_", line 1:
+         Definition of type "list/2"
+|}]

--- a/testsuite/tests/typing-short-paths/persistent_abbrevs.ml
+++ b/testsuite/tests/typing-short-paths/persistent_abbrevs.ml
@@ -38,3 +38,26 @@ Error: The value "f" has type "a/2 -> a -> unit"
        Line 1, characters 0-10:
          Definition of type "a/2"
 |}]
+
+type int = A
+type int = B
+let f A = B
+let g f = 0 + f B
+let n = g f
+
+[%%expect{|
+type int = A
+type int = B
+val f : int/2 -> int = <fun>
+val g : (int -> int) -> int = <fun>
+Line 5, characters 10-11:
+5 | let n = g f
+              ^
+Error: The value "f" has type "int/2 -> int"
+       but an expression was expected of type "int -> int"
+       Type "int/2" is not compatible with type "int"
+       Line 2, characters 0-12:
+         Definition of type "int"
+       Line 1, characters 0-12:
+         Definition of type "int/2"
+|}]

--- a/typing/out_type.ml
+++ b/typing/out_type.ml
@@ -634,7 +634,8 @@ let best_type_path p =
    identifiers whenever the short-path algorithm detected a better path than
    the original one.*)
 let tree_of_best_type_path p p' =
-  if Path.same p p' then tree_of_path (Some Type) p'
+  if Path.same p p' && not (Path.Map.mem p' !printing_map) then
+    tree_of_path (Some Type) p'
   else tree_of_path ~disambiguation:false None p'
 
 (* Print a type expression *)


### PR DESCRIPTION
This PR fixes #12738 by improving the interaction between `-short-paths` and the identifier disambiguation in error messages.

Before this PR,
```open Base
let x = [[1]; 2.0 ]
```
yielded
>```
>Error: The constant "2.0" has type "float/2"
>       but an expression was expected of type "int/2 list/2"
>```
even with `-short-path` because the predefined identifier for `int` was not rewritten by `-short-path` which leads the type printer to use the path disambiguation specification.

The fix in this PR is to simply switch off identifier disambiguation when the path under consideration has either be rewritten by `-short-paths` or is a target of a short-path rewriting rule.  (This second part was missing).
With this fix, the error message reverts to

>```
>Error: The constant "2.0" has type "float" but an expression was expected of type
>         "int list"
>```

Close #12738