### PR TITLE
4.x: protect memory-safety in the event of Lazy.force races

### DIFF
--- a/Changes
+++ b/Changes
@@ -32,6 +32,10 @@ OCaml 4.14 maintenance version
   (Vincent Laviron, report by François Pottier, review by Nathanaëlle Courant
   and Gabriel Scherer)
 
+- #13430, #13434: protect memory-safety on Lazy.force races
+  (Gabriel Scherer and Vincent Laviron, report by Edwin Török,
+   review by Vincent Laviron)
+
 OCaml 4.14.2 (14 March 2024)
 ----------------------------
 

--- a/testsuite/tests/backtrace/backtrace2.reference
+++ b/testsuite/tests/backtrace/backtrace2.reference
@@ -47,12 +47,12 @@ Called from Backtrace2.test_lazy.aux in file "backtrace2.ml", line 47, character
 Called from Backtrace2.test_lazy.aux in file "backtrace2.ml", line 47, characters 43-52
 Called from Backtrace2.test_lazy.aux in file "backtrace2.ml", line 47, characters 43-52
 Called from CamlinternalLazy.force_lazy_block in file "camlinternalLazy.ml", line 31, characters 17-27
-Re-raised at CamlinternalLazy.force_lazy_block in file "camlinternalLazy.ml", line 36, characters 4-11
+Re-raised at CamlinternalLazy.force_lazy_block in file "camlinternalLazy.ml", line 47, characters 4-11
 Called from Backtrace2.run in file "backtrace2.ml", line 62, characters 11-23
 Uncaught exception Not_found
 Raised at Stdlib__Hashtbl.find in file "hashtbl.ml", line 539, characters 13-28
 Called from Backtrace2.test_lazy.exception_raised_internally in file "backtrace2.ml", line 50, characters 8-41
-Re-raised at CamlinternalLazy.force_lazy_block.(fun) in file "camlinternalLazy.ml", line 35, characters 56-63
+Re-raised at CamlinternalLazy.force_lazy_block.(fun) in file "camlinternalLazy.ml", line 35, characters 38-45
 Called from CamlinternalLazy.force_lazy_block in file "camlinternalLazy.ml", line 31, characters 17-27
-Re-raised at CamlinternalLazy.force_lazy_block in file "camlinternalLazy.ml", line 36, characters 4-11
+Re-raised at CamlinternalLazy.force_lazy_block in file "camlinternalLazy.ml", line 47, characters 4-11
 Called from Backtrace2.run in file "backtrace2.ml", line 62, characters 11-23

--- a/testsuite/tests/backtrace/lazy.reference
+++ b/testsuite/tests/backtrace/lazy.reference
@@ -1,12 +1,12 @@
 Uncaught exception Not_found
 Raised at Lazy.l1 in file "lazy.ml", line 7, characters 28-45
 Called from CamlinternalLazy.force_lazy_block in file "camlinternalLazy.ml", line 31, characters 17-27
-Re-raised at CamlinternalLazy.force_lazy_block in file "camlinternalLazy.ml", line 36, characters 4-11
+Re-raised at CamlinternalLazy.force_lazy_block in file "camlinternalLazy.ml", line 47, characters 4-11
 Called from Lazy.test1 in file "lazy.ml", line 10, characters 11-24
 Called from Lazy.run in file "lazy.ml", line 19, characters 4-11
 Uncaught exception Not_found
 Raised at Lazy.l2 in file "lazy.ml", line 12, characters 28-45
 Called from CamlinternalLazy.force_lazy_block in file "camlinternalLazy.ml", line 31, characters 17-27
-Re-raised at CamlinternalLazy.force_lazy_block in file "camlinternalLazy.ml", line 36, characters 4-11
+Re-raised at CamlinternalLazy.force_lazy_block in file "camlinternalLazy.ml", line 47, characters 4-11
 Called from Lazy.test2 in file "lazy.ml", line 15, characters 6-15
 Called from Lazy.run in file "lazy.ml", line 19, characters 4-11


### PR DESCRIPTION
This is a 4.x fix for issue #13430.

cc @edwintorok, @lthls
