### PR TITLE
Name the explicit constants used with caml_verb_gc

### DIFF
--- a/runtime/caml/misc.h
+++ b/runtime/caml/misc.h
@@ -549,19 +549,70 @@ CAMLextern int caml_read_directory(char_os * dirname,
 
 #ifdef CAML_INTERNALS
 
-/* GC flags and messages */
+/* runtime message flags. Settable with v= in OCAMLRUNPARAM */
 
 extern atomic_uintnat caml_verb_gc;
+
+/* Bits which may be set in caml_verb_gc. The quotations are from the
+ * OCaml manual. */
+
+/* "Start and end of major GC cycle" (unused) */
+#define CAML_GC_MSG_MAJOR           0x0001
+/* "Minor collection and major GC slice" (unused) */
+#define CAML_GC_MSG_MINOR           0x0002
+/* "Growing and shrinking of the heap" */
+#define CAML_GC_MSG_HEAPSIZE        0x0004
+/* "Resizing of stacks and memory manager tables" */
+#define CAML_GC_MSG_STACKSIZE       0x0008
+/* "Heap compaction" (unused) */
+#define CAML_GC_MSG_COMPACT         0x0010
+/* "Change of GC parameters" */
+#define CAML_GC_MSG_PARAMS          0x0020
+/* "Computation of major GC slice size" */
+#define CAML_GC_MSG_SLICESIZE       0x0040
+/* "Calling of finalization functions" */
+#define CAML_GC_MSG_FINALIZE        0x0080
+/* "Startup messages" */
+#define CAML_GC_MSG_STARTUP         0x0100
+/* "Computation of compaction-triggering condition" (unused) */
+#define CAML_GC_MSG_COMPACT_TRIGGER 0x0200
+/* "Output GC statistics at program exit" */
+#define CAML_GC_MSG_STATS           0x0400
+/* "GC debugging messages */
+#define CAML_GC_MSG_DEBUG           0x0800
+/* "Address space reservation changes" */
+#define CAML_GC_MSG_ADDRSPACE       0x1000
+
+/* Default set of messages when runtime invoked with -v */
+
+#define CAML_GC_MSG_VERBOSE (CAML_GC_MSG_MAJOR     | \
+                             CAML_GC_MSG_HEAPSIZE  | \
+                             CAML_GC_MSG_STACKSIZE | \
+                             CAML_GC_MSG_COMPACT   | \
+                             CAML_GC_MSG_PARAMS)
+
+/* Use to control messages which should be output at any non-zero verbosity */
+
+#define CAML_GC_MSG_ANY (-1)
+
+/* output message if caml_verb_gc includes any bits in `category`. */
+
+void caml_gc_message (int category, const char *, ...)
+#if __has_attribute(format) || defined(__GNUC__)
+  __attribute__ ((format (printf, 2, 3)))
+#endif
+;
+
+/* Short-hand for calls to `caml_gc_message` */
+
+#define CAML_GC_MESSAGE(category, ...) \
+    caml_gc_message(CAML_GC_MSG_ ## category, __VA_ARGS__)
+
+/* Output message if CAML_GC_MSG_DEBUG is set */
 
 void caml_gc_log (const char *, ...)
 #if __has_attribute(format) || defined(__GNUC__)
   __attribute__ ((format (printf, 1, 2)))
-#endif
-;
-
-void caml_gc_message (int, const char *, ...)
-#if __has_attribute(format) || defined(__GNUC__)
-  __attribute__ ((format (printf, 2, 3)))
 #endif
 ;
 

--- a/runtime/compare.c
+++ b/runtime/compare.c
@@ -51,7 +51,7 @@ static void compare_free_stack(struct compare_stack* stk)
 /* Same, then raise Out_of_memory */
 CAMLnoret static void compare_stack_overflow(struct compare_stack* stk)
 {
-  caml_gc_message (0x04, "Stack overflow in structural comparison\n");
+  CAML_GC_MESSAGE(HEAPSIZE, "Stack overflow in structural comparison\n");
   compare_free_stack(stk);
   caml_raise_out_of_memory();
 }

--- a/runtime/dynlink.c
+++ b/runtime/dynlink.c
@@ -147,7 +147,7 @@ static void open_shared_lib(char_os * name)
 
   realname = caml_search_dll_in_path(&caml_shared_libs_path, name);
   u8 = caml_stat_strdup_of_os(realname);
-  caml_gc_message(0x100, "Loading shared library %s\n", u8);
+  CAML_GC_MESSAGE(STARTUP, "Loading shared library %s\n", u8);
   caml_stat_free(u8);
   caml_enter_blocking_section();
   handle = caml_dlopen(realname, 1);
@@ -307,7 +307,7 @@ CAMLprim value caml_dynlink_open_lib(value filename)
   value result;
   char_os * p;
 
-  caml_gc_message(0x100, "Opening shared library %s\n",
+  CAML_GC_MESSAGE(STARTUP, "Opening shared library %s\n",
                   String_val(filename));
   p = caml_stat_strdup_to_os(String_val(filename));
   caml_enter_blocking_section();

--- a/runtime/extern.c
+++ b/runtime/extern.c
@@ -458,7 +458,8 @@ static void extern_failwith(struct caml_extern_state* s, const char *msg)
 
 static void extern_stack_overflow(struct caml_extern_state* s)
 {
-  caml_gc_message (0x04, "Stack overflow in marshaling value\n");
+  CAML_GC_MESSAGE(HEAPSIZE,
+                  "Stack overflow in marshaling value\n");
   free_extern_output(s);
   caml_raise_out_of_memory();
 }

--- a/runtime/finalise.c
+++ b/runtime/finalise.c
@@ -151,7 +151,8 @@ caml_result caml_final_do_calls_res(void)
   if (fi->running_finalisation_function) return Result_unit;
   if (fi->todo_head != NULL) {
     call_timing_hook(&caml_finalise_begin_hook);
-    caml_gc_message (0x80, "Calling finalisation functions.\n");
+    CAML_GC_MESSAGE(FINALIZE,
+                    "Calling finalisation functions.\n");
     while (1) {
       while (fi->todo_head != NULL && fi->todo_head->size == 0) {
         struct final_todo *next_head = fi->todo_head->next;
@@ -168,7 +169,8 @@ caml_result caml_final_do_calls_res(void)
       fi->running_finalisation_function = 0;
       if (caml_result_is_exception(res)) return res;
     }
-    caml_gc_message (0x80, "Done calling finalisation functions.\n");
+    CAML_GC_MESSAGE(FINALIZE,
+                    "Done calling finalisation functions.\n");
     call_timing_hook(&caml_finalise_end_hook);
   }
   return Result_unit;

--- a/runtime/gc_ctrl.c
+++ b/runtime/gc_ctrl.c
@@ -168,8 +168,9 @@ CAMLprim value caml_gc_set(value v)
 
   if (newpf != caml_percent_free){
     caml_percent_free = newpf;
-    caml_gc_message (0x20, "New space overhead: %"
-                     ARCH_INTNAT_PRINTF_FORMAT "u%%\n", caml_percent_free);
+    CAML_GC_MESSAGE(PARAMS,
+                    "New space overhead: %" ARCH_INTNAT_PRINTF_FORMAT "u%%\n",
+                    caml_percent_free);
   }
 
   atomic_store_relaxed(&caml_verb_gc, new_verb_gc);
@@ -178,29 +179,29 @@ CAMLprim value caml_gc_set(value v)
   if (Wosize_val (v) >= 11){
     if (new_custom_maj != caml_custom_major_ratio){
       caml_custom_major_ratio = new_custom_maj;
-      caml_gc_message (0x20, "New custom major ratio: %"
-                       ARCH_INTNAT_PRINTF_FORMAT "u%%\n",
-                       caml_custom_major_ratio);
+      CAML_GC_MESSAGE(PARAMS, "New custom major ratio: %"
+                      ARCH_INTNAT_PRINTF_FORMAT "u%%\n",
+                      caml_custom_major_ratio);
     }
     if (new_custom_min != caml_custom_minor_ratio){
       caml_custom_minor_ratio = new_custom_min;
-      caml_gc_message (0x20, "New custom minor ratio: %"
-                       ARCH_INTNAT_PRINTF_FORMAT "u%%\n",
-                       caml_custom_minor_ratio);
+      CAML_GC_MESSAGE(PARAMS, "New custom minor ratio: %"
+                      ARCH_INTNAT_PRINTF_FORMAT "u%%\n",
+                      caml_custom_minor_ratio);
     }
     if (new_custom_sz != caml_custom_minor_max_bsz){
       caml_custom_minor_max_bsz = new_custom_sz;
-      caml_gc_message (0x20, "New custom minor size limit: %"
-                       ARCH_INTNAT_PRINTF_FORMAT "u%%\n",
-                       caml_custom_minor_max_bsz);
+      CAML_GC_MESSAGE(PARAMS, "New custom minor size limit: %"
+                      ARCH_INTNAT_PRINTF_FORMAT "u%%\n",
+                      caml_custom_minor_max_bsz);
     }
   }
 
   /* Minor heap size comes last because it will trigger a minor collection
      (thus invalidating [v]) and it can raise [Out_of_memory]. */
   if (newminwsz != Caml_state->minor_heap_wsz) {
-    caml_gc_message (0x20, "New minor heap size: %"
-                     ARCH_INTNAT_PRINTF_FORMAT "uk words\n", newminwsz / 1024);
+    CAML_GC_MESSAGE(PARAMS, "New minor heap size: %"
+                    ARCH_INTNAT_PRINTF_FORMAT "uk words\n", newminwsz / 1024);
   }
 
   if (newminwsz > caml_minor_heap_max_wsz) {

--- a/runtime/intern.c
+++ b/runtime/intern.c
@@ -337,7 +337,7 @@ static void readfloats(struct caml_intern_state* s,
 
 CAMLnoret static void intern_stack_overflow(struct caml_intern_state* s)
 {
-  caml_gc_message (0x04, "Stack overflow in un-marshaling value\n");
+  CAML_GC_MESSAGE(HEAPSIZE, "Stack overflow in un-marshaling value\n");
   intern_cleanup(s);
   caml_raise_out_of_memory();
 }

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -660,30 +660,30 @@ update_major_slice_work(intnat howmuch,
 
   extra_work = (intnat) (my_extra_count * (double) total_cycle_work);
 
-  caml_gc_message (0x40, "heap_words = %"
-                         ARCH_INTNAT_PRINTF_FORMAT "u\n",
-                   (uintnat)heap_words);
-  caml_gc_message (0x40, "allocated_words = %"
-                         ARCH_INTNAT_PRINTF_FORMAT "u\n",
+  CAML_GC_MESSAGE(SLICESIZE,
+                  "heap_words = %" ARCH_INTNAT_PRINTF_FORMAT "u\n",
+                  (uintnat)heap_words);
+  CAML_GC_MESSAGE(SLICESIZE,
+                  "allocated_words = %" ARCH_INTNAT_PRINTF_FORMAT "u\n",
                    my_alloc_count);
-  caml_gc_message (0x40, "allocated_words_direct = %"
-                         ARCH_INTNAT_PRINTF_FORMAT "u\n",
+  CAML_GC_MESSAGE(SLICESIZE,
+                  "allocated_words_direct = %" ARCH_INTNAT_PRINTF_FORMAT "u\n",
                    my_alloc_direct_count);
-  caml_gc_message (0x40, "alloc work-to-do = %"
-                         ARCH_INTNAT_PRINTF_FORMAT "d\n",
+  CAML_GC_MESSAGE(SLICESIZE,
+                  "alloc work-to-do = %" ARCH_INTNAT_PRINTF_FORMAT "d\n",
                    alloc_work);
-  caml_gc_message (0x40, "dependent_words = %"
-                         ARCH_INTNAT_PRINTF_FORMAT "u\n",
+  CAML_GC_MESSAGE(SLICESIZE,
+                  "dependent_words = %" ARCH_INTNAT_PRINTF_FORMAT "u\n",
                    my_dependent_count);
-  caml_gc_message (0x40, "dependent work-to-do = %"
-                         ARCH_INTNAT_PRINTF_FORMAT "d\n",
-                   dependent_work);
-  caml_gc_message (0x40, "extra_heap_resources = %"
-                         ARCH_INTNAT_PRINTF_FORMAT "uu\n",
-                   (uintnat) (my_extra_count * 1000000));
-  caml_gc_message (0x40, "extra work-to-do = %"
-                         ARCH_INTNAT_PRINTF_FORMAT "d\n",
-                   extra_work);
+  CAML_GC_MESSAGE(SLICESIZE,
+                  "dependent work-to-do = %" ARCH_INTNAT_PRINTF_FORMAT "d\n",
+                  dependent_work);
+  CAML_GC_MESSAGE(SLICESIZE,
+                  "extra_heap_resources = %" ARCH_INTNAT_PRINTF_FORMAT "uu\n",
+                  (uintnat) (my_extra_count * 1000000));
+  CAML_GC_MESSAGE(SLICESIZE,
+                  "extra work-to-do = %" ARCH_INTNAT_PRINTF_FORMAT "d\n",
+                  extra_work);
 
   new_work = max3 (alloc_work, dependent_work, extra_work);
   atomic_fetch_add (&work_counter, dom_st->major_work_done_between_slices);
@@ -1335,9 +1335,9 @@ static void cycle_major_heap_from_stw_single(
               (long unsigned int)caml_major_cycles_completed);
 
   caml_major_cycles_completed++;
-  caml_gc_message(0x40, "Starting major GC cycle\n");
+  CAML_GC_MESSAGE(SLICESIZE, "Starting major GC cycle\n");
 
-  if (atomic_load_relaxed(&caml_verb_gc) & 0x400) {
+  if (atomic_load_relaxed(&caml_verb_gc) & CAML_GC_MSG_STATS) {
     struct gc_stats s;
     intnat heap_words, not_garbage_words, swept_words;
 
@@ -1656,7 +1656,8 @@ static void major_collection_slice(intnat howmuch,
   int may_access_gc_phase = (mode != Slice_opportunistic);
 
   int log_events = mode != Slice_opportunistic ||
-                   (atomic_load_relaxed(&caml_verb_gc) & 0x40);
+                   (atomic_load_relaxed(&caml_verb_gc) &
+                    CAML_GC_MSG_SLICESIZE);
 
   update_major_slice_work(howmuch, may_access_gc_phase, log_events);
 

--- a/runtime/meta.c
+++ b/runtime/meta.c
@@ -139,7 +139,7 @@ CAMLprim value caml_realloc_global(value size)
   actual_size = Wosize_val(old_global_data);
   if (requested_size >= actual_size) {
     requested_size = (requested_size + 0x100) & 0xFFFFFF00;
-    caml_gc_message (0x08, "Growing global data to %"
+    CAML_GC_MESSAGE(STACKSIZE, "Growing global data to %"
                      ARCH_INTNAT_PRINTF_FORMAT "u entries\n",
                      requested_size);
     new_global_data = caml_alloc_shr(requested_size, 0);

--- a/runtime/minor_gc.c
+++ b/runtime/minor_gc.c
@@ -755,7 +755,8 @@ int caml_do_opportunistic_major_slice
   int work_available = caml_opportunistic_major_work_available(domain_state);
   if (work_available) {
     /* NB: need to put guard around the ev logs to prevent spam when we poll */
-    uintnat log_events = atomic_load_relaxed(&caml_verb_gc) & 0x40;
+    uintnat log_events =
+        atomic_load_relaxed(&caml_verb_gc) & CAML_GC_MSG_SLICESIZE;
     if (log_events) CAML_EV_BEGIN(EV_MAJOR_MARK_OPPORTUNISTIC);
     caml_opportunistic_major_collection_slice(Major_slice_work_min);
     if (log_events) CAML_EV_END(EV_MAJOR_MARK_OPPORTUNISTIC);
@@ -967,7 +968,7 @@ static void realloc_generic_table
                          element_size);
   }else if (tbl->limit == tbl->threshold){
     CAML_EV_COUNTER (ev_counter_name, 1);
-    caml_gc_message (0x08, msg_threshold, 0);
+    CAML_GC_MESSAGE(STACKSIZE, msg_threshold, 0);
     tbl->limit = tbl->end;
     caml_request_minor_gc ();
   }else{
@@ -976,7 +977,7 @@ static void realloc_generic_table
 
     tbl->size *= 2;
     sz = (tbl->size + tbl->reserve) * element_size;
-    caml_gc_message (0x08, msg_growing, (intnat) sz/1024);
+    CAML_GC_MESSAGE(STACKSIZE, msg_growing, (intnat) sz/1024);
     tbl->base = caml_stat_resize_noexc (tbl->base, sz);
     if (tbl->base == NULL){
       caml_fatal_error ("%s", msg_error);

--- a/runtime/misc.c
+++ b/runtime/misc.c
@@ -82,7 +82,7 @@ atomic_uintnat caml_verb_gc = 0;
 
 void caml_gc_log (const char *msg, ...)
 {
-  if ((atomic_load_relaxed(&caml_verb_gc) & 0x800) != 0) {
+  if ((atomic_load_relaxed(&caml_verb_gc) & CAML_GC_MSG_DEBUG) != 0) {
     char fmtbuf[GC_LOG_LENGTH];
     va_list args;
     va_start (args, msg);

--- a/runtime/platform.c
+++ b/runtime/platform.c
@@ -400,13 +400,15 @@ void* caml_mem_map(uintnat size, int reserve_only)
   void* mem = caml_plat_mem_map(size, reserve_only);
 
   if (mem == 0) {
-    caml_gc_message(0x1000, "mmap %" ARCH_INTNAT_PRINTF_FORMAT "d bytes failed",
-                            size);
+    CAML_GC_MESSAGE(ADDRSPACE,
+                    "mmap %" ARCH_INTNAT_PRINTF_FORMAT "d bytes failed",
+                    size);
     return 0;
   }
 
-  caml_gc_message(0x1000, "mmap %" ARCH_INTNAT_PRINTF_FORMAT "d"
-                          " bytes at %p for heaps\n", size, mem);
+  CAML_GC_MESSAGE(ADDRSPACE,
+                  "mmap %" ARCH_INTNAT_PRINTF_FORMAT "d"
+                  " bytes at %p for heaps\n", size, mem);
 
 #ifdef DEBUG
   caml_lf_skiplist_insert(&mmap_blocks, (uintnat)mem, size);
@@ -418,16 +420,18 @@ void* caml_mem_map(uintnat size, int reserve_only)
 void* caml_mem_commit(void* mem, uintnat size)
 {
   CAMLassert(Is_page_aligned(size));
-  caml_gc_message(0x1000, "commit %" ARCH_INTNAT_PRINTF_FORMAT "d"
-                          " bytes at %p for heaps\n", size, mem);
+  CAML_GC_MESSAGE(ADDRSPACE,
+                  "commit %" ARCH_INTNAT_PRINTF_FORMAT "d"
+                  " bytes at %p for heaps\n", size, mem);
   return caml_plat_mem_commit(mem, size);
 }
 
 void caml_mem_decommit(void* mem, uintnat size)
 {
   if (size) {
-    caml_gc_message(0x1000, "decommit %" ARCH_INTNAT_PRINTF_FORMAT "d"
-                            " bytes at %p for heaps\n", size, mem);
+    CAML_GC_MESSAGE(ADDRSPACE,
+                    "decommit %" ARCH_INTNAT_PRINTF_FORMAT "d"
+                    " bytes at %p for heaps\n", size, mem);
     caml_plat_mem_decommit(mem, size);
   }
 }
@@ -439,8 +443,9 @@ void caml_mem_unmap(void* mem, uintnat size)
   CAMLassert(caml_lf_skiplist_find(&mmap_blocks, (uintnat)mem, &data) != 0);
   CAMLassert(data == size);
 #endif
-  caml_gc_message(0x1000, "munmap %" ARCH_INTNAT_PRINTF_FORMAT "d"
-                          " bytes at %p for heaps\n", size, mem);
+  CAML_GC_MESSAGE(ADDRSPACE,
+                  "munmap %" ARCH_INTNAT_PRINTF_FORMAT "d"
+                  " bytes at %p for heaps\n", size, mem);
   caml_plat_mem_unmap(mem, size);
 #ifdef DEBUG
   caml_lf_skiplist_remove(&mmap_blocks, (uintnat)mem);

--- a/runtime/startup_aux.c
+++ b/runtime/startup_aux.c
@@ -56,7 +56,7 @@ static void init_startup_params(void)
   params.runtime_events_log_wsize = Default_runtime_events_log_wsize;
 
 #ifdef DEBUG
-  atomic_store_relaxed(&caml_verb_gc, 0x3F);
+  atomic_store_relaxed(&caml_verb_gc, CAML_GC_MSG_VERBOSE | CAML_GC_MSG_MINOR);
 #endif
 #ifndef NATIVE_CODE
   cds_file = caml_secure_getenv(T("CAML_DEBUG_FILE"));
@@ -149,8 +149,8 @@ int caml_startup_aux(int pooling)
 
 #ifdef DEBUG
   /* Note this must be executed after the call to caml_parse_ocamlrunparam. */
-  caml_gc_message (-1, "### OCaml runtime: debug mode ###\n");
-  caml_gc_message (-1, "### set OCAMLRUNPARAM=v=0 to silence this message\n");
+  CAML_GC_MESSAGE(ANY, "### OCaml runtime: debug mode ###\n");
+  CAML_GC_MESSAGE(ANY, "### set OCAMLRUNPARAM=v=0 to silence this message\n");
 #endif
 
   /* Second and subsequent calls are ignored,

--- a/runtime/startup_byt.c
+++ b/runtime/startup_byt.c
@@ -125,12 +125,12 @@ int caml_attempt_open(char_os **name, struct exec_trailer *trail,
 
   truename = caml_search_exe_in_path(*name);
   u8 = caml_stat_strdup_of_os(truename);
-  caml_gc_message(0x100, "Opening bytecode executable %s\n", u8);
+  CAML_GC_MESSAGE(STARTUP, "Opening bytecode executable %s\n", u8);
   caml_stat_free(u8);
   fd = open_os(truename, O_RDONLY | O_BINARY);
   if (fd == -1) {
     caml_stat_free(truename);
-    caml_gc_message(0x100, "Cannot open file\n");
+    CAML_GC_MESSAGE(STARTUP, "Cannot open file\n");
     if (errno == EMFILE)
       return NO_FDS;
     else
@@ -141,7 +141,7 @@ int caml_attempt_open(char_os **name, struct exec_trailer *trail,
     if (err < 2 || (buf [0] == '#' && buf [1] == '!')) {
       close(fd);
       caml_stat_free(truename);
-      caml_gc_message(0x100, "Rejected #! script\n");
+      CAML_GC_MESSAGE(STARTUP, "Rejected #! script\n");
       return BAD_BYTECODE;
     }
   }
@@ -149,7 +149,7 @@ int caml_attempt_open(char_os **name, struct exec_trailer *trail,
   if (err != 0) {
     close(fd);
     caml_stat_free(truename);
-    caml_gc_message(0x100, "Not a bytecode executable\n");
+    CAML_GC_MESSAGE(STARTUP, "Not a bytecode executable\n");
     return err;
   }
   *name = truename;
@@ -320,7 +320,7 @@ static int parse_command_line(char_os **argv)
         params->trace_level += 1; /* ignored unless DEBUG mode */
         break;
       case 'v':
-        atomic_store_relaxed(&caml_verb_gc, 0x001+0x004+0x008+0x010+0x020);
+        atomic_store_relaxed(&caml_verb_gc, CAML_GC_MSG_VERBOSE);
         break;
       case 'p':
         for (int j = 0; caml_names_of_builtin_cprim[j] != NULL; j++)

--- a/runtime/sys.c
+++ b/runtime/sys.c
@@ -137,7 +137,7 @@ CAMLexport void caml_do_exit(int retcode)
   caml_domain_state* domain_state = Caml_state;
   struct gc_stats s;
 
-  if ((atomic_load_relaxed(&caml_verb_gc) & 0x400) != 0) {
+  if ((atomic_load_relaxed(&caml_verb_gc) & CAML_GC_MSG_STATS) != 0) {
     caml_compute_gc_stats(&s);
     {
       /* cf caml_gc_counters */
@@ -160,27 +160,33 @@ CAMLexport void caml_do_exit(int retcode)
         top_heap_words = caml_top_heap_words(Caml_state->shared_heap);
       }
 
-      caml_gc_message(0x400, "allocated_words: %"ARCH_INTNAT_PRINTF_FORMAT"d\n",
-                    (intnat)allocated_words);
-      caml_gc_message(0x400, "minor_words: %"ARCH_INTNAT_PRINTF_FORMAT"d\n",
-                    (intnat) minwords);
-      caml_gc_message(0x400, "promoted_words: %"ARCH_INTNAT_PRINTF_FORMAT"d\n",
-                      (intnat) s.alloc_stats.promoted_words);
-      caml_gc_message(0x400, "major_words: %"ARCH_INTNAT_PRINTF_FORMAT"d\n",
-                      (intnat) majwords);
-      caml_gc_message(0x400,
+      CAML_GC_MESSAGE(STATS,
+          "allocated_words: %"ARCH_INTNAT_PRINTF_FORMAT"d\n",
+          (intnat)allocated_words);
+      CAML_GC_MESSAGE(STATS,
+          "minor_words: %"ARCH_INTNAT_PRINTF_FORMAT"d\n",
+          (intnat) minwords);
+      CAML_GC_MESSAGE(STATS,
+          "promoted_words: %"ARCH_INTNAT_PRINTF_FORMAT"d\n",
+          (intnat) s.alloc_stats.promoted_words);
+      CAML_GC_MESSAGE(STATS,
+          "major_words: %"ARCH_INTNAT_PRINTF_FORMAT"d\n",
+          (intnat) majwords);
+      CAML_GC_MESSAGE(STATS,
           "minor_collections: %"ARCH_INTNAT_PRINTF_FORMAT"d\n",
           (intnat) atomic_load(&caml_minor_collections_count));
-      caml_gc_message(0x400,
+      CAML_GC_MESSAGE(STATS,
           "major_collections: %"ARCH_INTNAT_PRINTF_FORMAT"d\n",
           caml_major_cycles_completed);
-      caml_gc_message(0x400,
+      CAML_GC_MESSAGE(STATS,
           "forced_major_collections: %"ARCH_INTNAT_PRINTF_FORMAT"d\n",
           (intnat)s.alloc_stats.forced_major_collections);
-      caml_gc_message(0x400, "heap_words: %"ARCH_INTNAT_PRINTF_FORMAT"d\n",
-                    heap_words);
-      caml_gc_message(0x400, "top_heap_words: %"ARCH_INTNAT_PRINTF_FORMAT"d\n",
-                      top_heap_words);
+      CAML_GC_MESSAGE(STATS,
+          "heap_words: %"ARCH_INTNAT_PRINTF_FORMAT"d\n",
+          heap_words);
+      CAML_GC_MESSAGE(STATS,
+          "top_heap_words: %"ARCH_INTNAT_PRINTF_FORMAT"d\n",
+          top_heap_words);
     }
   }
 

--- a/runtime/win32.c
+++ b/runtime/win32.c
@@ -164,7 +164,7 @@ wchar_t * caml_search_in_path(struct ext_table * path, const wchar_t * name)
          /* not sure what empty path components mean under Windows */
     fullname = caml_stat_wcsconcat(3, dir, L"\\", name);
     u8 = caml_stat_strdup_of_utf16(fullname);
-    caml_gc_message(0x100, "Searching %s\n", u8);
+    CAML_GC_MESSAGE(STARTUP, "Searching %s\n", u8);
     caml_stat_free(u8);
     if (_wstati64(fullname, &st) == 0 && S_ISREG(st.st_mode))
       return fullname;
@@ -172,7 +172,7 @@ wchar_t * caml_search_in_path(struct ext_table * path, const wchar_t * name)
   }
  not_found:
   u8 = caml_stat_strdup_of_utf16(name);
-  caml_gc_message(0x100, "%s not found in search path\n", u8);
+  CAML_GC_MESSAGE(STARTUP, "%s not found in search path\n", u8);
   caml_stat_free(u8);
   return caml_stat_wcsdup(name);
 }
@@ -196,7 +196,7 @@ CAMLexport wchar_t * caml_search_exe_in_path(const wchar_t * name)
                          &filepart);
     if (retcode == 0) {
       u8 = caml_stat_strdup_of_utf16(name);
-      caml_gc_message(0x100, "%s not found in search path\n", u8);
+      CAML_GC_MESSAGE(STARTUP, "%s not found in search path\n", u8);
       caml_stat_free(u8);
       caml_stat_free(fullname);
       return caml_stat_strdup_os(name);
@@ -227,7 +227,7 @@ void * caml_dlopen(wchar_t * libname, int global)
   int flags = (global ? FLEXDLL_RTLD_GLOBAL : 0);
   handle = flexdll_wdlopen(libname, flags);
   if ((handle != NULL)
-     && ((atomic_load_relaxed(&caml_verb_gc) & 0x100) != 0)) {
+     && ((atomic_load_relaxed(&caml_verb_gc) & CAML_GC_MSG_STARTUP) != 0)) {
     flexdll_dump_exports(handle);
     fflush(stdout);
   }

--- a/stdlib/gc.mli
+++ b/stdlib/gc.mli
@@ -140,17 +140,19 @@ type control =
     (** This value controls the GC messages on standard error output.
        It is a sum of some of the following flags, to print messages
        on the corresponding events:
-       - [0x001] Start and end of major GC cycle.
-       - [0x002] Minor collection and major GC slice.
-       - [0x004] Growing and shrinking of the heap.
-       - [0x008] Resizing of stacks and memory manager tables.
-       - [0x010] Heap compaction.
-       - [0x020] Change of GC parameters.
-       - [0x040] Computation of major GC slice size.
-       - [0x080] Calling of finalisation functions.
-       - [0x100] Bytecode executable and shared library search at start-up.
-       - [0x200] Computation of compaction-triggering condition.
-       - [0x400] Output GC statistics at program exit.
+       - [0x0001] Start and end of major GC cycle.
+       - [0x0002] Minor collection and major GC slice.
+       - [0x0004] Growing and shrinking of the heap.
+       - [0x0008] Resizing of stacks and memory manager tables.
+       - [0x0010] Heap compaction.
+       - [0x0020] Change of GC parameters.
+       - [0x0040] Computation of major GC slice size.
+       - [0x0080] Calling of finalisation functions.
+       - [0x0100] Bytecode executable and shared library search at start-up.
+       - [0x0200] Computation of compaction-triggering condition.
+       - [0x0400] Output GC statistics at program exit.
+       - [0x0800] GC debugging messages.
+       - [0x1000] Address space reservation changes.
        Default: 0. *)
 
     max_overhead : int;


### PR DESCRIPTION
The runtime has many uses of explicit constants such as `0x400` which name bits in the `caml_verb_gc` variable set by `OCAMLRUNPARAM=v=` or invoking the runtime with `-v`. This change introduces names for all of those bits (and identifies those which are not currently used). Interested in review from @damiendoligez in particular.