### PR TITLE
Fix Unix.getgroups for users belonging to more than 32 groups when using musl

### DIFF
--- a/Changes
+++ b/Changes
@@ -22,6 +22,10 @@ Working version
   `Thread.sigmask` using `Unix.sigprocmask`.
   (Xavier Leroy, review by Antonin Décimo, Gabriel Scherer, Miod Vallat)
 
+- #13442: Fix Unix.getgroups for users belonging to more than 32 groups
+  when using musl
+  (Kate Deplaix, review by Gabriel Scherer, Antonin Décimo, Anil Madhavapeddy)
+
 ### Tools:
 
 ### Manual and documentation:


### PR DESCRIPTION
See thread on the musl mailing-list: https://www.openwall.com/lists/musl/2023/11/14/8

Failure can also happen on a hypothetic system where the runtime value of NGROUPS_MAX (as returned by sysconf(_SC_NGROUPS_MAX)) is above the one defined in the libc and the current number of groups falls between those two values.