### PR TITLE
Add an argument to Arg.parse_* to allow the user to reject bare option arguments that start with hyphens

### DIFF
--- a/Changes
+++ b/Changes
@@ -15,6 +15,14 @@ Working version
 
 ### Standard library:
 
+- #????: add an optional argument `allow_hyphen_values`
+  to option parsing functions of `Arg`.
+  When set to `true`, it requires option that starts with hyphens
+  to be passed with `--option='-value'`
+  to prevent accidental incorrect invocation with missing arguments
+  when multiple options are used.
+  (Daniil Baturin, review by ????)
+
 ### Other libraries:
 
 - #13429: add `Unix.sigwait`, a binding to the `sigwait` system call;

--- a/stdlib/arg.mli
+++ b/stdlib/arg.mli
@@ -113,8 +113,13 @@ type usage_msg = string
 type anon_fun = (string -> unit)
 
 val parse :
-  (key * spec * doc) list -> anon_fun -> usage_msg -> unit
+  ?allow_hyphen_values:bool -> (key * spec * doc) list ->
+  anon_fun -> usage_msg -> unit
 (** [Arg.parse speclist anon_fun usage_msg] parses the command line.
+    [allow_hyphen_values] controls whether arguments
+    that start with hyphens are allowed to be passed in all cases (default)
+    or must be passed with [--option-name='-option-value'].
+    while trying to write [--option-name -option-value] is an error.
     [speclist] is a list of triples [(key, spec, doc)].
     [key] is the option keyword, it must start with a ['-'] character.
     [spec] gives the option type and the function to call when this option
@@ -142,7 +147,8 @@ val parse :
 *)
 
 val parse_dynamic :
-  (key * spec * doc) list ref -> anon_fun -> usage_msg -> unit
+  ?allow_hyphen_values:bool -> (key * spec * doc) list ref ->
+  anon_fun -> usage_msg -> unit
 (** Same as {!Arg.parse}, except that the [speclist] argument is a reference
     and may be updated during the parsing. A typical use for this feature
     is to parse command lines of the form:
@@ -151,8 +157,8 @@ val parse_dynamic :
     @since 4.01
 *)
 
-val parse_argv : ?current: int ref -> string array ->
-  (key * spec * doc) list -> anon_fun -> usage_msg -> unit
+val parse_argv : ?allow_hyphen_values:bool -> ?current: int ref ->
+  string array -> (key * spec * doc) list -> anon_fun -> usage_msg -> unit
 (** [Arg.parse_argv ~current args speclist anon_fun usage_msg] parses
   the array [args] as if it were the command line.  It uses and updates
   the value of [~current] (if given), or {!Arg.current}.  You must set
@@ -164,16 +170,17 @@ val parse_argv : ?current: int ref -> string array ->
   as argument.
 *)
 
-val parse_argv_dynamic : ?current:int ref -> string array ->
-  (key * spec * doc) list ref -> anon_fun -> string -> unit
+val parse_argv_dynamic : ?allow_hyphen_values:bool -> ?current:int ref ->
+    string array -> (key * spec * doc) list ref -> anon_fun -> string -> unit
 (** Same as {!Arg.parse_argv}, except that the [speclist] argument is a
     reference and may be updated during the parsing.
     See {!Arg.parse_dynamic}.
     @since 4.01
 *)
 
-val parse_and_expand_argv_dynamic : int ref -> string array ref ->
-  (key * spec * doc) list ref -> anon_fun -> string -> unit
+val parse_and_expand_argv_dynamic : ?allow_hyphen_values:bool -> int ref ->
+    string array ref -> (key * spec * doc) list ref -> anon_fun ->
+    string -> unit
 (** Same as {!Arg.parse_argv_dynamic}, except that the [argv] argument is a
     reference and may be updated during the parsing of [Expand] arguments.
     See {!Arg.parse_argv_dynamic}.
@@ -181,7 +188,8 @@ val parse_and_expand_argv_dynamic : int ref -> string array ref ->
 *)
 
 val parse_expand:
-  (key * spec * doc) list -> anon_fun -> usage_msg -> unit
+  ?allow_hyphen_values:bool -> (key * spec * doc) list -> anon_fun ->
+  usage_msg -> unit
 (** Same as {!Arg.parse}, except that the [Expand] arguments are allowed and
     the {!current} reference is not updated.
     @since 4.05


### PR DESCRIPTION
The `Arg` module from the standard library is one of the libraries that allow bare option arguments to start with hyphens. That can lead to confusing and counterintuitive behaviors when the user messes up the invocation.

Many newer libraries disallow that entirely (like Python's `argparse`) or require an option to allow it (Rust's `clap`).

This PR makes the behavior configurable. It uses a named optional argument that defaults to `false` to avoid breaking compatibility for existing programs. The argument is named `allow_hyphen_values` — that name is modeled after [Rust's clap](https://docs.rs/clap/latest/clap/struct.Arg.html#method.allow_hyphen_values) and I'm open to any suggestions if anyone thinks that name is bad.

Here's a sample program:

```
let args = Arg.align [("--some-option", Arg.String (fun s -> Printf.printf "some-option: %s" s), "Just some option")]

let () = Arg.parse ~allow_hyphen_values:false args (fun _ -> ()) ""
```

Trying to invoke it with a bare hyphen-initial argument will cause an error. To pass that argument the user will need to use `--some-option='--hyphen-value'`. 

```
$ ./test --some-option --hyphen-value
./test: option '--some-option' needs an argument.

$ ./test --some-option='--hyphen-value'

some-option: --hyphen-value
```

## Why is it relevant?

I will demonstrate the problem using the famous GNU hello utility that allows the user to supply a custom greeting with `--greeting <string>`. It uses GNU getopt for option parsing, that has the same behavior as `Arg`. 

This is the expected usage:

```
$ hello --greeting bonsoir
bonsoir
```

Now, let's consider the following command that someone may accidentally produce  via inattentive command line editing: `$ hello --greeting --version`.

Logically, that command invocation is incorrect: it has `--greeting` without its required argument and `--version` option that should conflict with or override `--greeting`.

However, what actually happens is that `--version` is interpreted as the argument of `--greeting` and the program prints the string `--version`, instead of warning the user of incorrect usage.

In interactive use, that behavior is a minor annoyance. However, when commands are automatically generated in shell scripts or CI jobs, that can cause real issues. Consider the following hypothetical command:

```
frobnicate --output-file ${OUT_FILE} --verbose`
```

If `${OUT_FILE}` is accidentally empty, the command will be interpreted as `frobnicate --output-file="--verbose"` and the script will do useless work and save it in a file where nothing/no one will find it.

P.S. This PR is missing tests at the moment. I'm confused by the structure of tests under `testsuite/test/lib-arg` — I'm happy to add tests, but I'd like to hear maintainer opinions which file to add them to.