### PR TITLE
Fix documentation for functors with multiple arguments

### DIFF
--- a/Changes
+++ b/Changes
@@ -63,7 +63,7 @@ ___________
 
 ### Language features:
 
-- #12828, #13282: Add short syntax for dependent functor types `(X:A) -> ...`
+- #12828, #13283: Add short syntax for dependent functor types `(X:A) -> ...`
   (Jeremy Yallop, review by Nicolás Ojeda Bär and Gabriel Scherer)
 
 - Add syntax support for deep effect handlers

--- a/manual/src/refman/modtypes.etex
+++ b/manual/src/refman/modtypes.etex
@@ -22,7 +22,7 @@ specify the general shape and type properties of modules.
 module-type:
           modtype-path
         | 'sig' { specification [';;'] } 'end'
-        | ['functor'] '(' module-name ':' module-type ')' '->' module-type
+        | ['functor'] {{ '(' module-name ':' module-type ')' }} '->' module-type
         | module-type '->' module-type
         | module-type 'with' mod-constraint { 'and' mod-constraint }
         | '(' module-type ')'

--- a/manual/src/refman/modules.etex
+++ b/manual/src/refman/modules.etex
@@ -22,7 +22,7 @@ for the specifications expressed in module types.
 module-expr:
           module-path
         | 'struct' [ module-items ] 'end'
-        | 'functor' '(' module-name ':' module-type ')' '->' module-expr
+        | 'functor' {{ '(' module-name ':' module-type ')' }} '->' module-expr
         | module-expr '(' module-expr ')'
         | '(' module-expr ')'
         | '(' module-expr ':' module-type ')'
@@ -245,4 +245,3 @@ The expression @module-expr_1 '(' module-expr_2 ')'@ evaluates
 @module-expr_1@ to a functor and @module-expr_2@ to a module, and
 applies the former to the latter. The type of @module-expr_2@ must
 match the type expected for the arguments of the functor @module-expr_1@.
-


### PR DESCRIPTION
Functors are currently documented as
```
[functor] ( module-name : module-type ) -> module-type
```
but it has been
```
[functor] {( module-name : module-type )}+ -> module-type
```
since #16.


I fixed a PR number in the Changes file too.