### PR TITLE
cmm: stricter computation of boxed number kinds

### DIFF
--- a/Changes
+++ b/Changes
@@ -3053,6 +3053,10 @@ OCaml 4.14 maintenance version
   (emitted for Linux in #8805)
   (Hannes Mehnert, review by Nicolás Ojeda Bär)
 
+- #13448, #13449: fix a code-generation bug on unsafe array accesses
+  at type int32, int64, nativeint, which has been introduced in OCaml 4.04.
+  (Gabriel Scherer, review by Nicolás Ojeda Bär and Vincent Laviron,
+   report by Simon Cruanes)
 
 OCaml 4.14.1 (20 December 2022)
 ------------------------------

--- a/testsuite/tests/float-unboxing/bug13448.ml
+++ b/testsuite/tests/float-unboxing/bug13448.ml
@@ -1,0 +1,19 @@
+(* TEST *)
+
+(* Regression test for #13448, see explanations in #13449.
+   This minimized test was proposed by Nicolas Ojeda Bar.
+*)
+
+external unsafe_get : 'a array -> int -> 'a = "%array_unsafe_get"
+let uget =
+  (* This intermediate definition avoids primitive specialization in
+     lambda/translprim at the call site below (so that the access
+     remain at kind Pgenval in the Lambda representation), but does
+     not prevent inlining during the Closure pass. *)
+  unsafe_get
+
+let () =
+  let int32 = 123456l in
+  let arr = [| int32 |] in
+  let n = uget arr 0 in
+  assert (n = int32)

--- a/testsuite/tests/float-unboxing/bug13448bis.ml
+++ b/testsuite/tests/float-unboxing/bug13448bis.ml
@@ -1,0 +1,26 @@
+(* TEST *)
+
+(* Regression test for #13448, see explanations in #13449.
+   Another variant of the bug, with GADTs instead of flat float arrays *)
+type _ t =
+  | Int32 : int32 t
+  | Float : float t
+
+let constant = 42l
+
+let[@inline always] default : type a . a t -> a = function
+  | Float ->
+     (* We want an expression that starts
+        with box<float>(...). *)
+     exp 0.
+  | Int32 ->
+     (* We want an expression that does not start
+        with box<int32>(...). *)
+     Sys.opaque_identity constant
+
+let () =
+  (* we use [opaque_identity] so that [default gadt] is not
+     reduced at compile-time. *)
+  let gadt = Sys.opaque_identity Int32 in
+  let n = default gadt in
+  assert (n = constant)


### PR DESCRIPTION
This is a proposed fix for #13448, a wrong-code generation bug that has presumably been around since #336 was merged in 4.04.
