### PR TITLE
toplevel: factorize phrase typechecking in topcommon

### DIFF
--- a/.depend
+++ b/.depend
@@ -7281,8 +7281,13 @@ toplevel/genprintval.cmi : \
     typing/env.cmi
 toplevel/topcommon.cmo : \
     parsing/unit_info.cmi \
+    typing/typemod.cmi \
     typing/typedtree.cmi \
+    typing/typecore.cmi \
     bytecomp/symtable.cmi \
+    typing/shape_reduce.cmi \
+    typing/shape.cmi \
+    typing/printtyped.cmi \
     parsing/printast.cmi \
     typing/predef.cmi \
     parsing/pprintast.cmi \
@@ -7297,6 +7302,7 @@ toplevel/topcommon.cmo : \
     parsing/location.cmi \
     utils/load_path.cmi \
     parsing/lexer.cmi \
+    typing/includemod.cmi \
     typing/ident.cmi \
     toplevel/genprintval.cmi \
     utils/format_doc.cmi \
@@ -7312,8 +7318,13 @@ toplevel/topcommon.cmo : \
     toplevel/topcommon.cmi
 toplevel/topcommon.cmx : \
     parsing/unit_info.cmx \
+    typing/typemod.cmx \
     typing/typedtree.cmx \
+    typing/typecore.cmx \
     bytecomp/symtable.cmx \
+    typing/shape_reduce.cmx \
+    typing/shape.cmx \
+    typing/printtyped.cmx \
     parsing/printast.cmx \
     typing/predef.cmx \
     parsing/pprintast.cmx \
@@ -7328,6 +7339,7 @@ toplevel/topcommon.cmx : \
     parsing/location.cmx \
     utils/load_path.cmx \
     parsing/lexer.cmx \
+    typing/includemod.cmx \
     typing/ident.cmx \
     toplevel/genprintval.cmx \
     utils/format_doc.cmx \
@@ -7491,16 +7503,11 @@ toplevel/trace.cmi : \
 toplevel/byte/topeval.cmo : \
     utils/warnings.cmi \
     typing/types.cmi \
-    typing/typemod.cmi \
     typing/typedtree.cmi \
-    typing/typecore.cmi \
     lambda/translmod.cmi \
     toplevel/topcommon.cmi \
     bytecomp/symtable.cmi \
     lambda/simplif.cmi \
-    typing/shape_reduce.cmi \
-    typing/shape.cmi \
-    typing/printtyped.cmi \
     typing/printtyp.cmi \
     lambda/printlambda.cmi \
     bytecomp/printinstr.cmi \
@@ -7513,7 +7520,6 @@ toplevel/byte/topeval.cmo : \
     bytecomp/meta.cmi \
     parsing/location.cmi \
     utils/load_path.cmi \
-    typing/includemod.cmi \
     typing/ident.cmi \
     typing/env.cmi \
     bytecomp/emitcode.cmi \
@@ -7527,16 +7533,11 @@ toplevel/byte/topeval.cmo : \
 toplevel/byte/topeval.cmx : \
     utils/warnings.cmx \
     typing/types.cmx \
-    typing/typemod.cmx \
     typing/typedtree.cmx \
-    typing/typecore.cmx \
     lambda/translmod.cmx \
     toplevel/topcommon.cmx \
     bytecomp/symtable.cmx \
     lambda/simplif.cmx \
-    typing/shape_reduce.cmx \
-    typing/shape.cmx \
-    typing/printtyped.cmx \
     typing/printtyp.cmx \
     lambda/printlambda.cmx \
     bytecomp/printinstr.cmx \
@@ -7549,7 +7550,6 @@ toplevel/byte/topeval.cmx : \
     bytecomp/meta.cmx \
     parsing/location.cmx \
     utils/load_path.cmx \
-    typing/includemod.cmx \
     typing/ident.cmx \
     typing/env.cmx \
     bytecomp/emitcode.cmx \
@@ -7630,16 +7630,11 @@ toplevel/byte/trace.cmi : \
 toplevel/native/topeval.cmo : \
     utils/warnings.cmi \
     typing/types.cmi \
-    typing/typemod.cmi \
     typing/typedtree.cmi \
-    typing/typecore.cmi \
     lambda/translmod.cmi \
     toplevel/native/tophooks.cmi \
     toplevel/topcommon.cmi \
     lambda/simplif.cmi \
-    typing/shape_reduce.cmi \
-    typing/shape.cmi \
-    typing/printtyped.cmi \
     typing/printtyp.cmi \
     lambda/printlambda.cmi \
     typing/predef.cmi \
@@ -7663,16 +7658,11 @@ toplevel/native/topeval.cmo : \
 toplevel/native/topeval.cmx : \
     utils/warnings.cmx \
     typing/types.cmx \
-    typing/typemod.cmx \
     typing/typedtree.cmx \
-    typing/typecore.cmx \
     lambda/translmod.cmx \
     toplevel/native/tophooks.cmx \
     toplevel/topcommon.cmx \
     lambda/simplif.cmx \
-    typing/shape_reduce.cmx \
-    typing/shape.cmx \
-    typing/printtyped.cmx \
     typing/printtyp.cmx \
     lambda/printlambda.cmx \
     typing/predef.cmx \

--- a/toplevel/byte/topeval.ml
+++ b/toplevel/byte/topeval.ml
@@ -123,16 +123,7 @@ let execute_phrase print_outcome ppf phr =
   match phr with
   | Ptop_def sstr ->
       let oldenv = !toplevel_env in
-      Typecore.reset_delayed_checks ();
-      let (str, sg, sn, shape, newenv) =
-        Typemod.type_toplevel_phrase oldenv sstr
-      in
-      if !Clflags.dump_typedtree then Printtyped.implementation ppf str;
-      let sg' = Typemod.Signature_names.simplify newenv sn sg in
-      ignore (Includemod.signatures ~mark:Mark_positive oldenv sg sg');
-      Typecore.force_delayed_checks ();
-      let shape = Shape_reduce.local_reduce Env.empty shape in
-      if !Clflags.dump_shape then Shape.print ppf shape;
+      let (str, sg', newenv) = typecheck_phrase ppf oldenv sstr in
       let lam = Translmod.transl_toplevel_definition str in
       Warnings.check_fatal ();
       begin try

--- a/toplevel/native/topeval.ml
+++ b/toplevel/native/topeval.ml
@@ -163,16 +163,7 @@ let execute_phrase print_outcome ppf phr =
       incr phrase_seqid;
       let phrase_name = "TOP" ^ string_of_int !phrase_seqid in
       Compilenv.reset ?packname:None phrase_name;
-      Typecore.reset_delayed_checks ();
-      let (str, sg, names, shape, newenv) =
-        Typemod.type_toplevel_phrase oldenv sstr
-      in
-      if !Clflags.dump_typedtree then Printtyped.implementation ppf str;
-      let sg' = Typemod.Signature_names.simplify newenv names sg in
-      ignore (Includemod.signatures oldenv ~mark:Mark_positive sg sg');
-      Typecore.force_delayed_checks ();
-      let shape = Shape_reduce.local_reduce Env.empty shape in
-      if !Clflags.dump_shape then Shape.print ppf shape;
+      let (str, sg', newenv) = typecheck_phrase ppf oldenv sstr in
       (* `let _ = <expression>` or even just `<expression>` require special
          handling in toplevels, or nothing is displayed. In bytecode, the
          lambda for <expression> is directly executed and the result _is_ the

--- a/toplevel/topcommon.ml
+++ b/toplevel/topcommon.ml
@@ -209,6 +209,19 @@ let preprocess_phrase ppf phr =
   if !Clflags.dump_source then Pprintast.top_phrase ppf phr;
   phr
 
+let typecheck_phrase ppf oldenv sstr =
+  Typecore.reset_delayed_checks ();
+  let (str, sg, sn, shape, newenv) =
+    Typemod.type_toplevel_phrase oldenv sstr
+  in
+  if !Clflags.dump_typedtree then Printtyped.implementation ppf str;
+  let sg' = Typemod.Signature_names.simplify newenv sn sg in
+  ignore (Includemod.signatures ~mark:Mark_positive oldenv sg sg');
+  Typecore.force_delayed_checks ();
+  let shape = Shape_reduce.local_reduce Env.empty shape in
+  if !Clflags.dump_shape then Shape.print ppf shape;
+  (str, sg', newenv)
+
 (* Phrase buffer that stores the last toplevel phrase (see
    [Location.input_phrase_buffer]). *)
 let phrase_buffer = Buffer.create 1024

--- a/toplevel/topcommon.mli
+++ b/toplevel/topcommon.mli
@@ -43,10 +43,18 @@ val toplevel_env : Env.t ref
         (* Typing environment for the toplevel *)
 val initialize_toplevel_env : unit -> unit
         (* Initialize the typing environment for the toplevel *)
+
 val preprocess_phrase :
-      formatter -> Parsetree.toplevel_phrase ->  Parsetree.toplevel_phrase
-        (* Preprocess the given toplevel phrase using regular and ppx
-           preprocessors. Return the updated phrase. *)
+  formatter -> Parsetree.toplevel_phrase -> Parsetree.toplevel_phrase
+(* Preprocess the given toplevel phrase using regular and ppx
+   preprocessors. Return the updated phrase. *)
+
+val typecheck_phrase :
+  formatter -> Env.t -> Parsetree.structure ->
+  Typedtree.structure * Types.signature * Env.t
+(* Type-check the current toplevel phrase (not a directive)
+   in the current typing environment, return an updated typing environment. *)
+
 val record_backtrace : unit -> unit
 
 


### PR DESCRIPTION
There is a silly duplication of the logic to type-check a toplevel phrase in byte/topeval.ml and native/topeval.ml. This one-commit PR deduplicates the code into topcommon.ml.