### PR TITLE
Remove a now unused include from getgroups.c

### DIFF
--- a/Changes
+++ b/Changes
@@ -22,7 +22,7 @@ Working version
   `Thread.sigmask` using `Unix.sigprocmask`.
   (Xavier Leroy, review by Antonin Décimo, Gabriel Scherer, Miod Vallat)
 
-- #13442: Fix Unix.getgroups for users belonging to more than 32 groups
+- #13442, #13452: Fix Unix.getgroups for users belonging to more than 32 groups
   when using musl
   (Kate Deplaix, review by Gabriel Scherer, Antonin Décimo, Anil Madhavapeddy)
 

--- a/otherlibs/unix/getgroups.c
+++ b/otherlibs/unix/getgroups.c
@@ -24,7 +24,6 @@
 #ifdef HAS_UNISTD
 #include <unistd.h>
 #endif
-#include <limits.h>
 #include <errno.h>
 #include "caml/unixsupport.h"
 


### PR DESCRIPTION
Per @dustanddreams comment in https://github.com/ocaml/ocaml/pull/13442#pullrequestreview-2311737166