### PR TITLE
Add ocaml-variants.install

### DIFF
--- a/ocaml-variants.install
+++ b/ocaml-variants.install
@@ -1,0 +1,4 @@
+share_root: [
+  "config.cache" {"ocaml/config.cache"}
+  "config.status" {"ocaml/config.status"}
+]


### PR DESCRIPTION
The ocaml-base-compiler and ocaml-variants packages in opam-repository have needed a .install file since https://github.com/ocaml/opam-repository/pull/14626, which installed config.cache.

It was already silly storing this file multiple times in opam-repository, and following a policy-change in opam-repository, it now lives in a very archive-y location at https://github.com/ocaml/opam-source-archives/blob/main/patches/ocaml-variants/ocaml-variants.install.

This PR does three things:
- It allows the file to be permanently in the ocaml/ocaml repository, which is kind of where it belongs (it's odd to have a primary-source-of-truth in ocaml/opam-source-archives, which was originally created to store lost upstream tarballs)
- It adds the installation of config.status, which is actually the superior file to be installing as it allows the tree to be immediately reconstructed
- It plumbs the ocaml-variants.install into the ocaml-variants.opam file

cc @Octachron