### PR TITLE
[refactor] typing/predef: introduce a variant of predefined type constructors

### DIFF
--- a/Changes
+++ b/Changes
@@ -80,6 +80,9 @@ Working version
   output of the pattern-matching compiler
   (Gabriel Scherer, review by Vincent Laviron and Nicolás Ojeda Bär)
 
+- #13460: introduce a variant of all predefined types
+  (Gabriel Scherer, review by Ulysse Gérard and Florian Angeletti)
+
 ### Build system:
 
 ### Bug fixes:

--- a/typing/predef.ml
+++ b/typing/predef.ml
@@ -28,6 +28,56 @@ let wrap create s =
 
 let ident_create = wrap Ident.create_predef
 
+type abstract_type_constr = [
+  | `Int
+  | `Char
+  | `String
+  | `Bytes
+  | `Float
+  | `Continuation
+  | `Array
+  | `Nativeint
+  | `Int32
+  | `Int64
+  | `Lazy_t
+  | `Extension_constructor
+  | `Floatarray
+]
+type data_type_constr = [
+  | `Bool
+  | `Unit
+  | `Exn
+  | `Eff
+  | `List
+  | `Option
+]
+type type_constr = [
+  | abstract_type_constr
+  | data_type_constr
+]
+
+let all_type_constrs = [
+  `Int;
+  `Char;
+  `String;
+  `Bytes;
+  `Float;
+  `Bool;
+  `Unit;
+  `Exn;
+  `Eff;
+  `Continuation;
+  `Array;
+  `List;
+  `Option;
+  `Nativeint;
+  `Int32;
+  `Int64;
+  `Lazy_t;
+  `Extension_constructor;
+  `Floatarray;
+]
+
 let ident_int = ident_create "int"
 and ident_char = ident_create "char"
 and ident_bytes = ident_create "bytes"
@@ -47,6 +97,27 @@ and ident_lazy_t = ident_create "lazy_t"
 and ident_string = ident_create "string"
 and ident_extension_constructor = ident_create "extension_constructor"
 and ident_floatarray = ident_create "floatarray"
+
+let ident_of_type_constr = function
+  | `Int -> ident_int
+  | `Char -> ident_char
+  | `String -> ident_string
+  | `Bytes -> ident_bytes
+  | `Float -> ident_float
+  | `Bool -> ident_bool
+  | `Unit -> ident_unit
+  | `Exn -> ident_exn
+  | `Eff -> ident_eff
+  | `Continuation -> ident_continuation
+  | `Array -> ident_array
+  | `List -> ident_list
+  | `Option -> ident_option
+  | `Nativeint -> ident_nativeint
+  | `Int32 -> ident_int32
+  | `Int64 -> ident_int64
+  | `Lazy_t -> ident_lazy_t
+  | `Extension_constructor -> ident_extension_constructor
+  | `Floatarray -> ident_floatarray
 
 let path_int = Pident ident_int
 and path_char = Pident ident_char
@@ -68,27 +139,37 @@ and path_string = Pident ident_string
 and path_extension_constructor = Pident ident_extension_constructor
 and path_floatarray = Pident ident_floatarray
 
-let type_int = newgenty (Tconstr(path_int, [], ref Mnil))
-and type_char = newgenty (Tconstr(path_char, [], ref Mnil))
-and type_bytes = newgenty (Tconstr(path_bytes, [], ref Mnil))
-and type_float = newgenty (Tconstr(path_float, [], ref Mnil))
-and type_bool = newgenty (Tconstr(path_bool, [], ref Mnil))
-and type_unit = newgenty (Tconstr(path_unit, [], ref Mnil))
-and type_exn = newgenty (Tconstr(path_exn, [], ref Mnil))
-and type_eff t = newgenty (Tconstr(path_eff, [t], ref Mnil))
-and type_continuation t1 t2 =
-  newgenty (Tconstr(path_continuation, [t1; t2], ref Mnil))
-and type_array t = newgenty (Tconstr(path_array, [t], ref Mnil))
-and type_list t = newgenty (Tconstr(path_list, [t], ref Mnil))
-and type_option t = newgenty (Tconstr(path_option, [t], ref Mnil))
-and type_nativeint = newgenty (Tconstr(path_nativeint, [], ref Mnil))
-and type_int32 = newgenty (Tconstr(path_int32, [], ref Mnil))
-and type_int64 = newgenty (Tconstr(path_int64, [], ref Mnil))
-and type_lazy_t t = newgenty (Tconstr(path_lazy_t, [t], ref Mnil))
-and type_string = newgenty (Tconstr(path_string, [], ref Mnil))
-and type_extension_constructor =
-      newgenty (Tconstr(path_extension_constructor, [], ref Mnil))
-and type_floatarray = newgenty (Tconstr(path_floatarray, [], ref Mnil))
+let path_of_type_constr typ =
+  Pident (ident_of_type_constr typ)
+
+let tconstr p args = newgenty (Tconstr(p, args, ref Mnil))
+let type_int = tconstr path_int []
+and type_char = tconstr path_char []
+and type_bytes = tconstr path_bytes []
+and type_float = tconstr path_float []
+and type_bool = tconstr path_bool []
+and type_unit = tconstr path_unit []
+and type_exn = tconstr path_exn []
+and type_eff t = tconstr path_eff [t]
+and type_continuation t1 t2 = tconstr path_continuation [t1; t2]
+and type_array t = tconstr path_array [t]
+and type_list t = tconstr path_list [t]
+and type_option t = tconstr path_option [t]
+and type_nativeint = tconstr path_nativeint []
+and type_int32 = tconstr path_int32 []
+and type_int64 = tconstr path_int64 []
+and type_lazy_t t = tconstr path_lazy_t [t]
+and type_string = tconstr path_string []
+and type_extension_constructor = tconstr path_extension_constructor []
+and type_floatarray = tconstr path_floatarray []
+
+let find_type_constr =
+  let all_predef_paths =
+    all_type_constrs
+    |> List.map (fun tconstr -> path_of_type_constr tconstr, tconstr)
+    |> Path.Map.of_list
+  in
+  fun p -> Path.Map.find_opt p all_predef_paths
 
 let ident_match_failure = ident_create "Match_failure"
 and ident_out_of_memory = ident_create "Out_of_memory"
@@ -104,7 +185,6 @@ and ident_assert_failure = ident_create "Assert_failure"
 and ident_undefined_recursive_module =
         ident_create "Undefined_recursive_module"
 and ident_continuation_already_taken = ident_create "Continuation_already_taken"
-
 
 let all_predef_exns = [
   ident_match_failure;
@@ -126,16 +206,6 @@ let path_match_failure = Pident ident_match_failure
 and path_assert_failure = Pident ident_assert_failure
 and path_undefined_recursive_module = Pident ident_undefined_recursive_module
 
-let cstr id args =
-  {
-    cd_id = id;
-    cd_args = Cstr_tuple args;
-    cd_res = None;
-    cd_loc = Location.none;
-    cd_attributes = [];
-    cd_uid = Uid.of_predef_id id;
-  }
-
 let ident_false = ident_create "false"
 and ident_true = ident_create "true"
 and ident_void = ident_create "()"
@@ -144,15 +214,18 @@ and ident_cons = ident_create "::"
 and ident_none = ident_create "None"
 and ident_some = ident_create "Some"
 
-let mk_add_type add_type type_ident ?manifest
-    ?(immediate=Type_immediacy.Unknown) ?(kind=Type_abstract Definition) env =
-  let decl =
+let decl_of_type_constr =
+  let decl0
+      ?(immediate = Type_immediacy.Unknown)
+      ?(kind = Type_abstract Definition)
+      type_ident
+    =
     {type_params = [];
      type_arity = 0;
      type_kind = kind;
      type_loc = Location.none;
      type_private = Asttypes.Public;
-     type_manifest = manifest;
+     type_manifest = None;
      type_variance = [];
      type_separability = [];
      type_is_newtype = false;
@@ -163,54 +236,86 @@ let mk_add_type add_type type_ident ?manifest
      type_uid = Uid.of_predef_id type_ident;
     }
   in
-  add_type type_ident decl env
+  let decl1
+      ~variance
+      ?(separability = Separability.Ind)
+      ?(kind = fun _ -> Type_abstract Definition)
+      type_ident
+    =
+    let param = newgenvar () in
+    { (decl0 ~kind:(kind param) type_ident) with
+      type_params = [param];
+      type_arity = 1;
+      type_variance = [variance];
+      type_separability = [separability];
+    }
+  in
+  let decl2
+      ~variance:(var1, var2)
+      ?separability:((sep1, sep2) = (Separability.Ind, Separability.Ind))
+      ?(kind = fun _ _ -> Type_abstract Definition)
+      type_ident
+    =
+    let param1, param2 = newgenvar (), newgenvar () in
+    { (decl0 ~kind:(kind param1 param2) type_ident) with
+      type_params = [param1; param2];
+      type_arity = 2;
+      type_variance = [var1; var2];
+      type_separability = [sep1; sep2];
+    }
+  in
+  let cstr id args =
+    {
+      cd_id = id;
+      cd_args = Cstr_tuple args;
+      cd_res = None;
+      cd_loc = Location.none;
+      cd_attributes = [];
+      cd_uid = Uid.of_predef_id id;
+    }
+  in
+  let variant constrs =
+    Type_variant (constrs, Variant_regular) in
+  function
+  | `Int -> decl0 ~immediate:Always ident_int
+  | `Char -> decl0 ~immediate:Always ident_char
+  | `String -> decl0 ident_string
+  | `Bytes -> decl0 ident_bytes
+  | `Float -> decl0 ident_float
+  | `Bool ->
+      let kind = variant [cstr ident_false [];
+                          cstr ident_true []] in
+      decl0 ~immediate:Always ~kind ident_bool
+  | `Unit ->
+      let kind = variant [cstr ident_void []] in
+      decl0 ~immediate:Always ~kind ident_unit
+  | `Exn -> decl0 ~kind:Type_open ident_exn
+  | `Eff ->
+      let kind _ = Type_open in
+      decl1 ~variance:Variance.full ~kind ident_eff
+  | `Continuation ->
+      let variance = Variance.(contravariant, covariant) in
+      decl2 ~variance ident_continuation
+  | `Array ->
+      decl1 ~variance:Variance.full ident_array
+  | `List ->
+      let kind tvar =
+        variant [cstr ident_nil [];
+                 cstr ident_cons [tvar; type_list tvar]] in
+      decl1 ~variance:Variance.covariant ~kind ident_list
+  | `Option ->
+      let kind tvar =
+        variant [cstr ident_none [];
+                 cstr ident_some [tvar]] in
+      decl1 ~variance:Variance.covariant ~kind ident_option
+  | `Nativeint -> decl0 ident_nativeint
+  | `Int32 -> decl0 ident_int32
+  | `Int64 -> decl0 ident_int64
+  | `Lazy_t -> decl1 ~variance:Variance.covariant ident_lazy_t
+  | `Extension_constructor -> decl0 ident_extension_constructor
+  | `Floatarray -> decl0 ident_floatarray
 
 let build_initial_env add_type add_extension empty_env =
-  let add_type = mk_add_type add_type
-  and add_type1 type_ident
-      ~variance ~separability ?(kind=fun _ -> Type_abstract Definition) env =
-    let param = newgenvar () in
-    let decl =
-      {type_params = [param];
-       type_arity = 1;
-       type_kind = kind param;
-       type_loc = Location.none;
-       type_private = Asttypes.Public;
-       type_manifest = None;
-       type_variance = [variance];
-       type_separability = [separability];
-       type_is_newtype = false;
-       type_expansion_scope = lowest_level;
-       type_attributes = [];
-       type_immediate = Unknown;
-       type_unboxed_default = false;
-       type_uid = Uid.of_predef_id type_ident;
-      }
-    in
-    add_type type_ident decl env
-  and add_continuation type_ident env =
-    let tvar1 = newgenvar() in
-    let tvar2 = newgenvar() in
-    let arity = 2 in
-    let decl =
-      {type_params = [tvar1; tvar2];
-       type_arity = arity;
-       type_kind = Type_abstract Definition;
-       type_loc = Location.none;
-       type_private = Asttypes.Public;
-       type_manifest = None;
-       type_variance = [Variance.contravariant; Variance.covariant];
-       type_separability = Types.Separability.default_signature ~arity;
-       type_is_newtype = false;
-       type_expansion_scope = lowest_level;
-       type_attributes = [];
-       type_immediate = Unknown;
-       type_unboxed_default = false;
-       type_uid = Uid.of_predef_id type_ident;
-      }
-    in
-    add_type type_ident decl env
-  in
   let add_extension id l =
     add_extension id
       { ext_type_path = path_exn;
@@ -225,47 +330,9 @@ let build_initial_env add_type add_extension empty_env =
         ext_uid = Uid.of_predef_id id;
       }
   in
-  let variant constrs = Type_variant (constrs, Variant_regular) in
-  empty_env
-  (* Predefined types - alphabetical order *)
-  |> add_type1 ident_array
-       ~variance:Variance.full
-       ~separability:Separability.Ind
-  |> add_type ident_bool
-       ~immediate:Always
-       ~kind:(variant [cstr ident_false []; cstr ident_true []])
-  |> add_type ident_char ~immediate:Always
-  |> add_type ident_exn ~kind:Type_open
-  |> add_type1 ident_eff
-       ~variance:Variance.full
-       ~separability:Separability.Ind
-       ~kind:(fun _ -> Type_open)
-  |> add_continuation ident_continuation
-  |> add_type ident_extension_constructor
-  |> add_type ident_float
-  |> add_type ident_floatarray
-  |> add_type ident_int ~immediate:Always
-  |> add_type ident_int32
-  |> add_type ident_int64
-  |> add_type1 ident_lazy_t
-       ~variance:Variance.covariant
-       ~separability:Separability.Ind
-  |> add_type1 ident_list
-       ~variance:Variance.covariant
-       ~separability:Separability.Ind
-       ~kind:(fun tvar ->
-         variant [cstr ident_nil []; cstr ident_cons [tvar; type_list tvar]])
-  |> add_type ident_nativeint
-  |> add_type1 ident_option
-       ~variance:Variance.covariant
-       ~separability:Separability.Ind
-       ~kind:(fun tvar ->
-         variant [cstr ident_none []; cstr ident_some [tvar]])
-  |> add_type ident_string
-  |> add_type ident_bytes
-  |> add_type ident_unit
-       ~immediate:Always
-       ~kind:(variant [cstr ident_void []])
+  List.fold_left (fun env tconstr ->
+    add_type (ident_of_type_constr tconstr) (decl_of_type_constr tconstr) env
+  ) empty_env all_type_constrs
   (* Predefined exceptions - alphabetical order *)
   |> add_extension ident_assert_failure
        [newgenty (Ttuple[type_string; type_int; type_int])]

--- a/typing/predef.mli
+++ b/typing/predef.mli
@@ -17,6 +17,36 @@
 
 open Types
 
+type abstract_type_constr = [
+  | `Int
+  | `Char
+  | `String
+  | `Bytes
+  | `Float
+  | `Continuation
+  | `Array
+  | `Nativeint
+  | `Int32
+  | `Int64
+  | `Lazy_t
+  | `Extension_constructor
+  | `Floatarray
+]
+type data_type_constr = [
+  | `Bool
+  | `Unit
+  | `Exn
+  | `Eff
+  | `List
+  | `Option
+]
+type type_constr = [
+  | abstract_type_constr
+  | data_type_constr
+]
+
+val find_type_constr : Path.t -> type_constr option
+
 val type_int: type_expr
 val type_char: type_expr
 val type_string: type_expr


### PR DESCRIPTION
predef.ml contains the definition of all "predefined" type constructors, that are defined in the compiler rather than the standard library. Some type analyses need special cases for those predefined types, whose property often cannot be defined from their definition. 

Currently the check for these special cases is done with an or-cascade of boolean checks, for example Typeopt.classify (for compilation of `lazy` thunks):

https://github.com/ocaml/ocaml/blob/d753ea1992d27aa22dcb449f4a0ac178d167d52c/typing/typeopt.ml#L92-L101

This is not very robust, because no one remembers to update those analyses when new predefined types are introduced. And of course, the code I quoted above does not contain the logic one could expect for the predefined types `floatarray`, `eff` and `continuation`.

To make this code more robust, we add in typing/Predef a variant type of all predefined type constructors (it is split in two classes, the "abstract" type constructors and the "data" type constructors that have a datatype definition, because analyses typically only need to special-case the abstract ones). They are used just enough in the module to force people to add a new variant each time they add a predefined type.

The PR also includes a `find_type_constr` function to decide whether am arbitrary type constructor is predefined, and uses it to update the definition in Typeopt.classify -- which revealed the missing cases.