### PR TITLE
Use generic types in call to `subtype`

### DIFF
--- a/Changes
+++ b/Changes
@@ -559,6 +559,10 @@ ___________
   in Float.Array.
   (Gabriel Scherer, review by Nicolás Ojeda Bär)
 
+- #13464: Use generic types in call to `subtype`. This improves
+  inference of type-directed disambiguation in principal mode.
+  (Richard Eisenberg, review by Jacques Garrigue)
+
 - #13507: A small refactoring to [free_vars] to make it a bit faster
   by not allocating a list when the list is not necessary.
   (Richard Eisenberg, review by Jacques Garrigue)

--- a/testsuite/tests/typing-misc/coerce_principal.ml
+++ b/testsuite/tests/typing-misc/coerce_principal.ml
@@ -1,0 +1,18 @@
+(* TEST
+   expect;
+*)
+
+type t1 = A
+type t2 = A
+
+[%%expect{|
+type t1 = A
+type t2 = A
+|}]
+
+let f x = match (x :> t1) with
+  | A -> 1
+
+[%%expect{|
+val f : t1 -> int = <fun>
+|}]

--- a/testsuite/tests/typing-objects/Tests.ml
+++ b/testsuite/tests/typing-objects/Tests.ml
@@ -731,6 +731,9 @@ Error: Multiple definition of the type name "t".
 fun x -> (x :> < m : 'a -> 'a > as 'a);;
 [%%expect{|
 - : < m : (< m : 'a > as 'b) -> 'b as 'a; .. > -> 'b = <fun>
+|}, Principal{|
+- : < m : < m : 'a > -> < m : 'a > as 'a; .. > -> (< m : 'b -> 'b > as 'b) =
+<fun>
 |}];;
 
 fun x -> (x : int -> bool :> 'a -> 'a);;

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -4469,14 +4469,14 @@ and type_coerce
             && closed_type_expr ~env ty' ->
           if not gen && (* first try a single coercion *)
             let snap = snapshot () in
-            let ty, _b = enlarge_type env ty' in
+            let ty, _b = enlarge_type env (generic_instance ty') in
             try
               force (); Ctype.unify env arg_type ty; true
             with Unify _ ->
               backtrack snap; false
           then ()
           else begin try
-            let force' = subtype env arg_type ty' in
+            let force' = subtype env arg_type (generic_instance ty') in
             force (); force' ();
             if not gen && !Clflags.principal then
               Location.prerr_warning loc
@@ -4486,7 +4486,7 @@ and type_coerce
             raise (Error (loc, env, Not_subtype err))
           end;
       | _ ->
-          let ty, b = enlarge_type env ty' in
+          let ty, b = enlarge_type env (generic_instance ty') in
           force ();
           begin try Ctype.unify env arg_type ty with Unify err ->
             let expanded = full_expand ~may_forget_scope:true env ty' in

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -4446,7 +4446,9 @@ and type_coerce
   match sty with
   | None ->
     let (cty', ty', force) =
-      Typetexp.transl_simple_type_delayed env sty'
+      with_local_level_generalize_structure begin fun () ->
+        Typetexp.transl_simple_type_delayed env sty'
+      end
     in
     let arg, arg_type, gen =
       let lv = get_current_level () in
@@ -4505,7 +4507,9 @@ and type_coerce
         end
       in
       begin try
-        let force'' = subtype env (instance ty) (instance ty') in
+        let force'' =
+          subtype env (generic_instance ty) (generic_instance ty')
+        in
         force (); force' (); force'' ()
       with Subtype err ->
         raise (Error (loc, env, Not_subtype err))


### PR DESCRIPTION
This is a small change within the type-checker to use generic-level types in the call to `subtype`, used to implement the `:>` operator.

The change here causes no known change in behavior. However, in Jane Street's branch, we sometimes use information about whether a type in principally known to make decisions about which modes to pay attention to; this change _does_ make a differece in that branch. The reason I'm posting it here is that I think this small change in the code makes it a bit more semantically correct: the types in question are written by the user and therefore really should be treated at generic-level.

I think @garrigue is the right reviewer for this.