### PR TITLE
[refactor] split constructor/fields types from Types to Data_types

### DIFF
--- a/.depend
+++ b/.depend
@@ -568,6 +568,7 @@ typing/btype.cmo : \
     utils/misc.cmi \
     utils/local_store.cmi \
     typing/ident.cmi \
+    typing/data_types.cmi \
     parsing/asttypes.cmi \
     typing/btype.cmi
 typing/btype.cmx : \
@@ -576,11 +577,13 @@ typing/btype.cmx : \
     utils/misc.cmx \
     utils/local_store.cmx \
     typing/ident.cmx \
+    typing/data_types.cmx \
     parsing/asttypes.cmx \
     typing/btype.cmi
 typing/btype.cmi : \
     typing/types.cmi \
     typing/path.cmi \
+    typing/data_types.cmi \
     parsing/asttypes.cmi
 typing/cmt2annot.cmo : \
     typing/types.cmi \
@@ -630,6 +633,7 @@ typing/ctype.cmo : \
     utils/format_doc.cmi \
     typing/errortrace.cmi \
     typing/env.cmi \
+    typing/data_types.cmi \
     utils/clflags.cmi \
     typing/btype.cmi \
     parsing/asttypes.cmi \
@@ -648,6 +652,7 @@ typing/ctype.cmx : \
     utils/format_doc.cmx \
     typing/errortrace.cmx \
     typing/env.cmx \
+    typing/data_types.cmx \
     utils/clflags.cmx \
     typing/btype.cmx \
     parsing/asttypes.cmx \
@@ -661,13 +666,35 @@ typing/ctype.cmi : \
     typing/ident.cmi \
     typing/errortrace.cmi \
     typing/env.cmi \
+    typing/data_types.cmi \
     typing/btype.cmi \
+    parsing/asttypes.cmi
+typing/data_types.cmo : \
+    typing/types.cmi \
+    typing/path.cmi \
+    parsing/parsetree.cmi \
+    parsing/location.cmi \
+    parsing/asttypes.cmi \
+    typing/data_types.cmi
+typing/data_types.cmx : \
+    typing/types.cmx \
+    typing/path.cmx \
+    parsing/parsetree.cmi \
+    parsing/location.cmx \
+    parsing/asttypes.cmx \
+    typing/data_types.cmi
+typing/data_types.cmi : \
+    typing/types.cmi \
+    typing/path.cmi \
+    parsing/parsetree.cmi \
+    parsing/location.cmi \
     parsing/asttypes.cmi
 typing/datarepr.cmo : \
     typing/types.cmi \
     typing/path.cmi \
     parsing/location.cmi \
     typing/ident.cmi \
+    typing/data_types.cmi \
     typing/btype.cmi \
     parsing/asttypes.cmi \
     typing/datarepr.cmi
@@ -676,6 +703,7 @@ typing/datarepr.cmx : \
     typing/path.cmx \
     parsing/location.cmx \
     typing/ident.cmx \
+    typing/data_types.cmx \
     typing/btype.cmx \
     parsing/asttypes.cmx \
     typing/datarepr.cmi
@@ -683,7 +711,8 @@ typing/datarepr.cmi : \
     parsing/unit_info.cmi \
     typing/types.cmi \
     typing/path.cmi \
-    typing/ident.cmi
+    typing/ident.cmi \
+    typing/data_types.cmi
 typing/env.cmo : \
     utils/warnings.cmi \
     parsing/unit_info.cmi \
@@ -702,6 +731,7 @@ typing/env.cmo : \
     typing/ident.cmi \
     utils/format_doc.cmi \
     typing/datarepr.cmi \
+    typing/data_types.cmi \
     file_formats/cmi_format.cmi \
     utils/clflags.cmi \
     parsing/builtin_attributes.cmi \
@@ -726,6 +756,7 @@ typing/env.cmx : \
     typing/ident.cmx \
     utils/format_doc.cmx \
     typing/datarepr.cmx \
+    typing/data_types.cmx \
     file_formats/cmi_format.cmx \
     utils/clflags.cmx \
     parsing/builtin_attributes.cmx \
@@ -745,6 +776,7 @@ typing/env.cmi : \
     utils/load_path.cmi \
     typing/ident.cmi \
     utils/format_doc.cmi \
+    typing/data_types.cmi \
     file_formats/cmi_format.cmi \
     parsing/asttypes.cmi
 typing/envaux.cmo : \
@@ -1176,6 +1208,7 @@ typing/parmatch.cmo : \
     typing/ident.cmi \
     utils/format_doc.cmi \
     typing/env.cmi \
+    typing/data_types.cmi \
     typing/ctype.cmi \
     typing/btype.cmi \
     parsing/asttypes.cmi \
@@ -1197,6 +1230,7 @@ typing/parmatch.cmx : \
     typing/ident.cmx \
     utils/format_doc.cmx \
     typing/env.cmx \
+    typing/data_types.cmx \
     typing/ctype.cmx \
     typing/btype.cmx \
     parsing/asttypes.cmx \
@@ -1207,6 +1241,7 @@ typing/parmatch.cmi : \
     parsing/parsetree.cmi \
     parsing/location.cmi \
     typing/env.cmi \
+    typing/data_types.cmi \
     parsing/asttypes.cmi
 typing/path.cmo : \
     parsing/lexer.cmi \
@@ -1228,6 +1263,7 @@ typing/patterns.cmo : \
     parsing/location.cmi \
     typing/ident.cmi \
     typing/env.cmi \
+    typing/data_types.cmi \
     typing/ctype.cmi \
     parsing/asttypes.cmi \
     typing/patterns.cmi
@@ -1238,6 +1274,7 @@ typing/patterns.cmx : \
     parsing/location.cmx \
     typing/ident.cmx \
     typing/env.cmx \
+    typing/data_types.cmx \
     typing/ctype.cmx \
     parsing/asttypes.cmx \
     typing/patterns.cmi
@@ -1246,6 +1283,7 @@ typing/patterns.cmi : \
     typing/typedtree.cmi \
     parsing/longident.cmi \
     typing/ident.cmi \
+    typing/data_types.cmi \
     parsing/asttypes.cmi
 typing/persistent_env.cmo : \
     utils/warnings.cmi \
@@ -1328,17 +1366,17 @@ typing/primitive.cmi : \
     typing/outcometree.cmi \
     parsing/location.cmi
 typing/printpat.cmo : \
-    typing/types.cmi \
     typing/typedtree.cmi \
     typing/ident.cmi \
     utils/format_doc.cmi \
+    typing/data_types.cmi \
     parsing/asttypes.cmi \
     typing/printpat.cmi
 typing/printpat.cmx : \
-    typing/types.cmx \
     typing/typedtree.cmx \
     typing/ident.cmx \
     utils/format_doc.cmx \
+    typing/data_types.cmx \
     parsing/asttypes.cmx \
     typing/printpat.cmi
 typing/printpat.cmi : \
@@ -1678,6 +1716,7 @@ typing/typecore.cmo : \
     typing/errortrace_report.cmi \
     typing/errortrace.cmi \
     typing/env.cmi \
+    typing/data_types.cmi \
     typing/ctype.cmi \
     file_formats/cmt_format.cmi \
     utils/clflags.cmi \
@@ -1715,6 +1754,7 @@ typing/typecore.cmx : \
     typing/errortrace_report.cmx \
     typing/errortrace.cmx \
     typing/env.cmx \
+    typing/data_types.cmx \
     typing/ctype.cmx \
     file_formats/cmt_format.cmx \
     utils/clflags.cmx \
@@ -1734,6 +1774,7 @@ typing/typecore.cmi : \
     typing/ident.cmi \
     typing/errortrace.cmi \
     typing/env.cmi \
+    typing/data_types.cmi \
     parsing/asttypes.cmi
 typing/typedecl.cmo : \
     utils/warnings.cmi \
@@ -1954,6 +1995,7 @@ typing/typedtree.cmo : \
     parsing/location.cmi \
     typing/ident.cmi \
     typing/env.cmi \
+    typing/data_types.cmi \
     parsing/asttypes.cmi \
     typing/typedtree.cmi
 typing/typedtree.cmx : \
@@ -1967,6 +2009,7 @@ typing/typedtree.cmx : \
     parsing/location.cmx \
     typing/ident.cmx \
     typing/env.cmx \
+    typing/data_types.cmx \
     parsing/asttypes.cmx \
     typing/typedtree.cmi
 typing/typedtree.cmi : \
@@ -1980,6 +2023,7 @@ typing/typedtree.cmi : \
     parsing/location.cmi \
     typing/ident.cmi \
     typing/env.cmi \
+    typing/data_types.cmi \
     parsing/asttypes.cmi
 typing/typemod.cmo : \
     utils/warnings.cmi \
@@ -4423,6 +4467,7 @@ lambda/matching.cmo : \
     typing/ident.cmi \
     typing/env.cmi \
     lambda/debuginfo.cmi \
+    typing/data_types.cmi \
     utils/clflags.cmi \
     typing/btype.cmi \
     parsing/asttypes.cmi \
@@ -4446,6 +4491,7 @@ lambda/matching.cmx : \
     typing/ident.cmx \
     typing/env.cmx \
     lambda/debuginfo.cmx \
+    typing/data_types.cmx \
     utils/clflags.cmx \
     typing/btype.cmx \
     parsing/asttypes.cmx \
@@ -4638,6 +4684,7 @@ lambda/translcore.cmo : \
     utils/format_doc.cmi \
     typing/env.cmi \
     lambda/debuginfo.cmi \
+    typing/data_types.cmi \
     utils/config.cmi \
     utils/clflags.cmi \
     typing/btype.cmi \
@@ -4665,6 +4712,7 @@ lambda/translcore.cmx : \
     utils/format_doc.cmx \
     typing/env.cmx \
     lambda/debuginfo.cmx \
+    typing/data_types.cmx \
     utils/config.cmx \
     utils/clflags.cmx \
     typing/btype.cmx \
@@ -4761,7 +4809,6 @@ lambda/translobj.cmi : \
     typing/ident.cmi \
     typing/env.cmi
 lambda/translprim.cmo : \
-    typing/types.cmi \
     typing/typeopt.cmi \
     typing/typedtree.cmi \
     typing/primitive.cmi \
@@ -4780,7 +4827,6 @@ lambda/translprim.cmo : \
     parsing/asttypes.cmi \
     lambda/translprim.cmi
 lambda/translprim.cmx : \
-    typing/types.cmx \
     typing/typeopt.cmx \
     typing/typedtree.cmx \
     typing/primitive.cmx \
@@ -4870,6 +4916,7 @@ file_formats/cmt_format.cmo : \
     parsing/lexer.cmi \
     typing/ident.cmi \
     typing/env.cmi \
+    typing/data_types.cmi \
     utils/config.cmi \
     utils/compression.cmi \
     file_formats/cmi_format.cmi \
@@ -4893,6 +4940,7 @@ file_formats/cmt_format.cmx : \
     parsing/lexer.cmx \
     typing/ident.cmx \
     typing/env.cmx \
+    typing/data_types.cmx \
     utils/config.cmx \
     utils/compression.cmx \
     file_formats/cmi_format.cmx \
@@ -7251,6 +7299,7 @@ toplevel/genprintval.cmo : \
     utils/format_doc.cmi \
     typing/env.cmi \
     typing/datarepr.cmi \
+    typing/data_types.cmi \
     typing/ctype.cmi \
     typing/btype.cmi \
     toplevel/genprintval.cmi
@@ -7271,6 +7320,7 @@ toplevel/genprintval.cmx : \
     utils/format_doc.cmx \
     typing/env.cmx \
     typing/datarepr.cmx \
+    typing/data_types.cmx \
     typing/ctype.cmx \
     typing/btype.cmx \
     toplevel/genprintval.cmi
@@ -7385,6 +7435,7 @@ toplevel/topdirs.cmo : \
     typing/ident.cmi \
     typing/env.cmi \
     bytecomp/dll.cmi \
+    typing/data_types.cmi \
     typing/ctype.cmi \
     utils/config.cmi \
     driver/compenv.cmi \
@@ -7411,6 +7462,7 @@ toplevel/topdirs.cmx : \
     typing/ident.cmx \
     typing/env.cmx \
     bytecomp/dll.cmx \
+    typing/data_types.cmx \
     typing/ctype.cmx \
     utils/config.cmx \
     driver/compenv.cmx \

--- a/.depend
+++ b/.depend
@@ -568,7 +568,6 @@ typing/btype.cmo : \
     utils/misc.cmi \
     utils/local_store.cmi \
     typing/ident.cmi \
-    typing/data_types.cmi \
     parsing/asttypes.cmi \
     typing/btype.cmi
 typing/btype.cmx : \
@@ -577,13 +576,11 @@ typing/btype.cmx : \
     utils/misc.cmx \
     utils/local_store.cmx \
     typing/ident.cmx \
-    typing/data_types.cmx \
     parsing/asttypes.cmx \
     typing/btype.cmi
 typing/btype.cmi : \
     typing/types.cmi \
     typing/path.cmi \
-    typing/data_types.cmi \
     parsing/asttypes.cmi
 typing/cmt2annot.cmo : \
     typing/types.cmi \

--- a/.depend
+++ b/.depend
@@ -1807,6 +1807,7 @@ typing/typedecl.cmo : \
     typing/errortrace_report.cmi \
     typing/errortrace.cmi \
     typing/env.cmi \
+    typing/data_types.cmi \
     typing/ctype.cmi \
     utils/config.cmi \
     utils/clflags.cmi \
@@ -1848,6 +1849,7 @@ typing/typedecl.cmx : \
     typing/errortrace_report.cmx \
     typing/errortrace.cmx \
     typing/env.cmx \
+    typing/data_types.cmx \
     typing/ctype.cmx \
     utils/config.cmx \
     utils/clflags.cmx \
@@ -9006,7 +9008,7 @@ ocamldoc/odoc_ast.cmo : \
     ocamldoc/odoc_class.cmi \
     parsing/location.cmi \
     typing/ident.cmi \
-    typing/btype.cmi \
+    typing/data_types.cmi \
     parsing/asttypes.cmi \
     ocamldoc/odoc_ast.cmi
 ocamldoc/odoc_ast.cmx : \
@@ -9030,7 +9032,7 @@ ocamldoc/odoc_ast.cmx : \
     ocamldoc/odoc_class.cmx \
     parsing/location.cmx \
     typing/ident.cmx \
-    typing/btype.cmx \
+    typing/data_types.cmx \
     parsing/asttypes.cmx \
     ocamldoc/odoc_ast.cmi
 ocamldoc/odoc_ast.cmi : \

--- a/Makefile
+++ b/Makefile
@@ -119,6 +119,7 @@ typing_SOURCES = \
   typing/outcometree.mli \
   typing/shape.mli typing/shape.ml \
   typing/types.mli typing/types.ml \
+  typing/data_types.mli typing/data_types.ml \
   typing/rawprinttyp.mli typing/rawprinttyp.ml \
   typing/gprinttyp.mli typing/gprinttyp.ml \
   typing/btype.mli typing/btype.ml \

--- a/file_formats/cmt_format.ml
+++ b/file_formats/cmt_format.ml
@@ -158,16 +158,16 @@ let iter_on_occurrences
   in
   let add_constructor_description env lid =
     function
-    | { Types.cstr_tag = Cstr_extension (path, _); _ } ->
+    | { Data_types.cstr_tag = Cstr_extension (path, _); _ } ->
         f ~namespace:Extension_constructor env path lid
-    | { Types.cstr_uid = Predef name; _} ->
+    | { Data_types.cstr_uid = Predef name; _} ->
         let id = List.assoc name Predef.builtin_idents in
         f ~namespace:Constructor env (Pident id) lid
-    | { Types.cstr_res; cstr_name; _ } ->
+    | { Data_types.cstr_res; cstr_name; _ } ->
         let path = path_in_type cstr_res cstr_name in
         Option.iter (fun path -> f ~namespace:Constructor env path lid) path
   in
-  let add_label env lid { Types.lbl_name; lbl_res; _ } =
+  let add_label env lid { Data_types.lbl_name; lbl_res; _ } =
     let path = path_in_type lbl_res lbl_name in
     Option.iter (fun path -> f ~namespace:Label env path lid) path
   in

--- a/lambda/matching.ml
+++ b/lambda/matching.ml
@@ -90,6 +90,7 @@
 open Misc
 open Asttypes
 open Types
+open Data_types
 open Typedtree
 open Lambda
 open Parmatch
@@ -117,7 +118,7 @@ let pp_partial ppf = function
 *)
 
 module MayCompat = Parmatch.Compat (struct
-  let equal = Types.may_equal_constr
+  let equal = Data_types.may_equal_constr
 end)
 
 let may_compat = MayCompat.compat
@@ -436,7 +437,7 @@ let matcher discr (p : Simple.pattern) rem =
       (* NB: may_equal_constr considers (potential) constructor rebinding;
           Types.may_equal_constr does check that the arities are the same,
           preserving row-size coherence. *)
-      yesif (Types.may_equal_constr cstr cstr')
+      yesif (Data_types.may_equal_constr cstr cstr')
   | Construct _, (Constant _ | Variant _ | Lazy | Array _ | Record _ | Tuple _)
     ->
       no ()
@@ -1403,7 +1404,7 @@ let can_group discr pat =
          submatrix for each syntactically-distinct constructor (with a threading
          of exits such that each submatrix falls back to the
          potentially-compatible submatrices below it).  *)
-      Types.equal_tag discr_tag pat_cstr.cstr_tag
+      Data_types.equal_tag discr_tag pat_cstr.cstr_tag
   | Construct _, Construct _
   | Tuple _, (Tuple _ | Any)
   | Record _, (Record _ | Any)
@@ -2058,7 +2059,7 @@ let get_expr_args_constr ~scopes head { arg; mut; _ } rem =
 let divide_constructor ~scopes ctx pm =
   divide
     (get_expr_args_constr ~scopes)
-    (fun cstr1 cstr2 -> Types.equal_tag cstr1.cstr_tag cstr2.cstr_tag)
+    (fun cstr1 cstr2 -> Data_types.equal_tag cstr1.cstr_tag cstr2.cstr_tag)
     get_key_constr
     get_pat_args_constr
     ctx pm

--- a/lambda/translcore.ml
+++ b/lambda/translcore.ml
@@ -20,6 +20,7 @@ open Misc
 open Asttypes
 open Primitive
 open Types
+open Data_types
 open Typedtree
 open Typeopt
 open Lambda

--- a/lambda/translprim.ml
+++ b/lambda/translprim.ml
@@ -18,7 +18,6 @@
 open Misc
 open Asttypes
 open Primitive
-open Types
 open Typedtree
 open Typeopt
 open Lambda

--- a/ocamldoc/odoc_ast.ml
+++ b/ocamldoc/odoc_ast.ml
@@ -269,7 +269,7 @@ module Analyser =
 
         | Typedtree.Tpat_construct (_, cons_desc, _, _) when
             (* we give a name to the parameter only if it is unit *)
-            Path.same (Btype.cstr_type_path cons_desc) Predef.path_unit
+            Path.same (Data_types.cstr_res_type_path cons_desc) Predef.path_unit
           ->
             (* a () argument, it never has description *)
             Simple_name { sn_name = "()" ;

--- a/toplevel/genprintval.ml
+++ b/toplevel/genprintval.ml
@@ -20,6 +20,7 @@ open Format
 open Longident
 open Path
 open Types
+open Data_types
 open Outcometree
 module Out_name = Out_type.Out_name
 

--- a/toplevel/topdirs.ml
+++ b/toplevel/topdirs.ml
@@ -18,6 +18,7 @@
 open Format
 open Misc
 open Types
+open Data_types
 open Toploop
 
 let error_fmt () =

--- a/toplevel/topdirs.ml
+++ b/toplevel/topdirs.ml
@@ -484,7 +484,7 @@ let () =
        let desc = Env.lookup_constructor ~loc Env.Positive lid env in
        if is_exception_constructor env desc.cstr_res then
          raise Not_found;
-       let path = Btype.cstr_type_path desc in
+       let path = Data_types.cstr_res_type_path desc in
        let type_decl = Env.find_type path env in
        if is_extension_constructor desc.cstr_tag then
          let ret_type =

--- a/typing/btype.ml
+++ b/typing/btype.ml
@@ -17,7 +17,6 @@
 
 open Asttypes
 open Types
-open Data_types
 
 open Local_store
 
@@ -172,7 +171,6 @@ let type_origin decl =
   match decl.type_kind with
   | Type_abstract origin -> origin
   | Type_variant _ | Type_record _ | Type_open -> Definition
-let label_is_poly lbl = is_poly_Tpoly lbl.lbl_arg
 
 let dummy_method = "*dummy method*"
 

--- a/typing/btype.ml
+++ b/typing/btype.ml
@@ -776,15 +776,3 @@ let instance_variable_type label sign =
   match Vars.find label sign.csig_vars with
   | (_, _, ty) -> ty
   | exception Not_found -> assert false
-
-
-                  (**********)
-                  (*  Misc  *)
-                  (**********)
-
-(**** Type information getter ****)
-
-let cstr_type_path cstr =
-  match get_desc cstr.cstr_res with
-  | Tconstr (p, _, _) -> p
-  | _ -> assert false

--- a/typing/btype.ml
+++ b/typing/btype.ml
@@ -17,6 +17,7 @@
 
 open Asttypes
 open Types
+open Data_types
 
 open Local_store
 

--- a/typing/btype.mli
+++ b/typing/btype.mli
@@ -17,7 +17,6 @@
 
 open Asttypes
 open Types
-open Data_types
 
 (**** Sets, maps and hashtables of types ****)
 
@@ -93,7 +92,6 @@ val is_poly_Tpoly: type_expr -> bool
 val dummy_method: label
 val type_kind_is_abstract: type_declaration -> bool
 val type_origin: type_declaration -> type_origin
-val label_is_poly: label_description -> bool
 
 (**** polymorphic variants ****)
 

--- a/typing/btype.mli
+++ b/typing/btype.mli
@@ -17,6 +17,7 @@
 
 open Asttypes
 open Types
+open Data_types
 
 (**** Sets, maps and hashtables of types ****)
 
@@ -308,4 +309,4 @@ val instance_variable_type : label -> class_signature -> type_expr
 
 (**** Type information getter ****)
 
-val cstr_type_path : constructor_description -> Path.t
+val cstr_type_path : Data_types.constructor_description -> Path.t

--- a/typing/btype.mli
+++ b/typing/btype.mli
@@ -306,7 +306,3 @@ val method_type : label -> class_signature -> type_expr
 (* Return the type of an instance variable.
    @raises [Assert_failure] if the class has no such method. *)
 val instance_variable_type : label -> class_signature -> type_expr
-
-(**** Type information getter ****)
-
-val cstr_type_path : Data_types.constructor_description -> Path.t

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -18,6 +18,7 @@
 open Misc
 open Asttypes
 open Types
+open Data_types
 open Btype
 open Errortrace
 

--- a/typing/ctype.mli
+++ b/typing/ctype.mli
@@ -193,9 +193,12 @@ type existential_treatment =
   | Keep_existentials_flexible
   | Make_existentials_abstract of Pattern_env.t
 
-val instance_constructor: existential_treatment ->
-        constructor_description -> type_expr list * type_expr * type_expr list
-        (* Same, for a constructor. Also returns existentials. *)
+val instance_constructor:
+  existential_treatment ->
+  Data_types.constructor_description ->
+  type_expr list * type_expr * type_expr list
+(* Same, for a constructor. Also returns existentials. *)
+
 val instance_parameterized_type:
         ?keep_names:bool ->
         type_expr list -> type_expr -> type_expr list * type_expr
@@ -210,10 +213,13 @@ val instance_poly:
         type_expr list -> type_expr -> type_expr list * type_expr
         (* Take an instance of a type scheme containing free univars *)
 val polyfy: Env.t -> type_expr -> type_expr list -> type_expr * bool
+
 val instance_label:
-        fixed:bool ->
-        label_description -> type_expr list * type_expr * type_expr
-        (* Same, for a label *)
+  fixed:bool ->
+  Data_types.label_description ->
+  type_expr list * type_expr * type_expr
+(* Same, for a label *)
+
 val apply:
         ?use_current_level:bool ->
         Env.t -> type_expr list -> type_expr -> type_expr list -> type_expr

--- a/typing/data_types.ml
+++ b/typing/data_types.ml
@@ -1,0 +1,76 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*   Gabriel Scherer, projet Picube, INRIA Paris                          *)
+(*                                                                        *)
+(*   Copyright 2024 Institut National de Recherche en Informatique et     *)
+(*     en Automatique.                                                    *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+open Asttypes
+open Types
+
+(* Constructor and record label descriptions inserted held in typing
+   environments *)
+
+type constructor_description =
+  { cstr_name: string;                  (* Constructor name *)
+    cstr_res: type_expr;                (* Type of the result *)
+    cstr_existentials: type_expr list;  (* list of existentials *)
+    cstr_args: type_expr list;          (* Type of the arguments *)
+    cstr_arity: int;                    (* Number of arguments *)
+    cstr_tag: constructor_tag;          (* Tag for heap blocks *)
+    cstr_consts: int;                   (* Number of constant constructors *)
+    cstr_nonconsts: int;                (* Number of non-const constructors *)
+    cstr_generalized: bool;             (* Constrained return type? *)
+    cstr_private: private_flag;         (* Read-only constructor? *)
+    cstr_loc: Location.t;
+    cstr_attributes: Parsetree.attributes;
+    cstr_inlined: type_declaration option;
+    cstr_uid: Uid.t;
+   }
+
+and constructor_tag =
+    Cstr_constant of int                (* Constant constructor (an int) *)
+  | Cstr_block of int                   (* Regular constructor (a block) *)
+  | Cstr_unboxed                        (* Constructor of an unboxed type *)
+  | Cstr_extension of Path.t * bool     (* Extension constructor
+                                           true if a constant false if a block*)
+
+let equal_tag t1 t2 =
+  match (t1, t2) with
+  | Cstr_constant i1, Cstr_constant i2 -> i2 = i1
+  | Cstr_block i1, Cstr_block i2 -> i2 = i1
+  | Cstr_unboxed, Cstr_unboxed -> true
+  | Cstr_extension (path1, b1), Cstr_extension (path2, b2) ->
+      Path.same path1 path2 && b1 = b2
+  | (Cstr_constant _|Cstr_block _|Cstr_unboxed|Cstr_extension _), _ -> false
+
+let may_equal_constr c1 c2 =
+  c1.cstr_arity = c2.cstr_arity
+  && (match c1.cstr_tag,c2.cstr_tag with
+     | Cstr_extension _,Cstr_extension _ ->
+         (* extension constructors may be rebindings of each other *)
+         true
+     | tag1, tag2 ->
+         equal_tag tag1 tag2)
+
+type label_description =
+  { lbl_name: string;                   (* Short name *)
+    lbl_res: type_expr;                 (* Type of the result *)
+    lbl_arg: type_expr;                 (* Type of the argument *)
+    lbl_mut: mutable_flag;              (* Is this a mutable field? *)
+    lbl_pos: int;                       (* Position in block *)
+    lbl_all: label_description array;   (* All the labels in this type *)
+    lbl_repres: record_representation;  (* Representation for this record *)
+    lbl_private: private_flag;          (* Read-only field? *)
+    lbl_loc: Location.t;
+    lbl_attributes: Parsetree.attributes;
+    lbl_uid: Uid.t;
+   }

--- a/typing/data_types.ml
+++ b/typing/data_types.ml
@@ -61,6 +61,11 @@ let may_equal_constr c1 c2 =
      | tag1, tag2 ->
          equal_tag tag1 tag2)
 
+let cstr_res_type_path cstr =
+  match get_desc cstr.cstr_res with
+  | Tconstr (p, _, _) -> p
+  | _ -> assert false
+
 type label_description =
   { lbl_name: string;                   (* Short name *)
     lbl_res: type_expr;                 (* Type of the result *)

--- a/typing/data_types.mli
+++ b/typing/data_types.mli
@@ -50,6 +50,9 @@ val equal_tag :  constructor_tag -> constructor_tag -> bool
 val may_equal_constr :
     constructor_description ->  constructor_description -> bool
 
+(* Type constructor of the constructor's result type. *)
+val cstr_res_type_path : constructor_description -> Path.t
+
 type label_description =
   { lbl_name: string;                   (* Short name *)
     lbl_res: type_expr;                 (* Type of the result *)

--- a/typing/data_types.mli
+++ b/typing/data_types.mli
@@ -1,0 +1,65 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*   Gabriel Scherer, projet Picube, INRIA Paris                          *)
+(*                                                                        *)
+(*   Copyright 2024 Institut National de Recherche en Informatique et     *)
+(*     en Automatique.                                                    *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+open Asttypes
+open Types
+
+(* Constructor and record label descriptions inserted held in typing
+   environments *)
+
+type constructor_description =
+  { cstr_name: string;                  (* Constructor name *)
+    cstr_res: type_expr;                (* Type of the result *)
+    cstr_existentials: type_expr list;  (* list of existentials *)
+    cstr_args: type_expr list;          (* Type of the arguments *)
+    cstr_arity: int;                    (* Number of arguments *)
+    cstr_tag: constructor_tag;          (* Tag for heap blocks *)
+    cstr_consts: int;                   (* Number of constant constructors *)
+    cstr_nonconsts: int;                (* Number of non-const constructors *)
+    cstr_generalized: bool;             (* Constrained return type? *)
+    cstr_private: private_flag;         (* Read-only constructor? *)
+    cstr_loc: Location.t;
+    cstr_attributes: Parsetree.attributes;
+    cstr_inlined: type_declaration option;
+    cstr_uid: Uid.t;
+   }
+
+and constructor_tag =
+    Cstr_constant of int                (* Constant constructor (an int) *)
+  | Cstr_block of int                   (* Regular constructor (a block) *)
+  | Cstr_unboxed                        (* Constructor of an unboxed type *)
+  | Cstr_extension of Path.t * bool     (* Extension constructor
+                                           true if a constant false if a block*)
+
+(* Constructors are the same *)
+val equal_tag :  constructor_tag -> constructor_tag -> bool
+
+(* Constructors may be the same, given potential rebinding *)
+val may_equal_constr :
+    constructor_description ->  constructor_description -> bool
+
+type label_description =
+  { lbl_name: string;                   (* Short name *)
+    lbl_res: type_expr;                 (* Type of the result *)
+    lbl_arg: type_expr;                 (* Type of the argument *)
+    lbl_mut: mutable_flag;              (* Is this a mutable field? *)
+    lbl_pos: int;                       (* Position in block *)
+    lbl_all: label_description array;   (* All the labels in this type *)
+    lbl_repres: record_representation;  (* Representation for this record *)
+    lbl_private: private_flag;          (* Read-only field? *)
+    lbl_loc: Location.t;
+    lbl_attributes: Parsetree.attributes;
+    lbl_uid: Uid.t;
+  }

--- a/typing/datarepr.ml
+++ b/typing/datarepr.ml
@@ -18,6 +18,7 @@
 
 open Asttypes
 open Types
+open Data_types
 open Btype
 
 (* Simplified version of Ctype.free_vars *)

--- a/typing/datarepr.mli
+++ b/typing/datarepr.mli
@@ -17,6 +17,7 @@
    determining their representation. *)
 
 open Types
+open Data_types
 
 val extension_descr:
   current_unit:(Unit_info.t option) -> Path.t -> extension_constructor ->

--- a/typing/env.ml
+++ b/typing/env.ml
@@ -2622,7 +2622,7 @@ let mark_label_used usage ld =
   | exception Not_found -> ()
 
 let mark_constructor_description_used usage env cstr =
-  let ty_path = Btype.cstr_type_path cstr in
+  let ty_path = cstr_res_type_path cstr in
   mark_type_path_used env ty_path;
   match Types.Uid.Tbl.find !used_constructors cstr.cstr_uid with
   | mark -> mark usage

--- a/typing/env.ml
+++ b/typing/env.ml
@@ -21,6 +21,7 @@ open Asttypes
 open Longident
 open Path
 open Types
+open Data_types
 
 open Local_store
 

--- a/typing/env.mli
+++ b/typing/env.mli
@@ -16,6 +16,7 @@
 (* Environment handling *)
 
 open Types
+open Data_types
 open Misc
 
 type value_unbound_reason =

--- a/typing/parmatch.ml
+++ b/typing/parmatch.ml
@@ -18,6 +18,7 @@
 open Misc
 open Asttypes
 open Types
+open Data_types
 open Typedtree
 
 type 'pattern parmatch_case =
@@ -291,8 +292,8 @@ let records_args l1 l2 =
 module Compat
     (Constr:sig
       val equal :
-          Types.constructor_description ->
-            Types.constructor_description ->
+          Data_types.constructor_description ->
+            Data_types.constructor_description ->
               bool
     end) = struct
 
@@ -340,7 +341,7 @@ end
 module SyntacticCompat =
   Compat
     (struct
-      let equal c1 c2 =  Types.equal_tag c1.cstr_tag c2.cstr_tag
+      let equal c1 c2 = Data_types.equal_tag c1.cstr_tag c2.cstr_tag
     end)
 
 let compat =  SyntacticCompat.compat
@@ -375,7 +376,7 @@ let simple_match d h =
   let open Patterns.Head in
   match d.pat_desc, h.pat_desc with
   | Construct c1, Construct c2 ->
-      Types.equal_tag c1.cstr_tag c2.cstr_tag
+      Data_types.equal_tag c1.cstr_tag c2.cstr_tag
   | Variant { tag = t1; _ }, Variant { tag = t2 } ->
       t1 = t2
   | Constant c1, Constant c2 -> const_compare c1 c2 = 0
@@ -1693,7 +1694,7 @@ let rec le_pat p q =
   | _, Tpat_alias(q,_,_,_) -> le_pat p q
   | Tpat_constant(c1), Tpat_constant(c2) -> const_compare c1 c2 = 0
   | Tpat_construct(_,c1,ps,_), Tpat_construct(_,c2,qs,_) ->
-      Types.equal_tag c1.cstr_tag c2.cstr_tag && le_pats ps qs
+      Data_types.equal_tag c1.cstr_tag c2.cstr_tag && le_pats ps qs
   | Tpat_variant(l1,Some p1,_), Tpat_variant(l2,Some p2,_) ->
       (l1 = l2 && le_pat p1 p2)
   | Tpat_variant(l1,None,_r1), Tpat_variant(l2,None,_) ->
@@ -1747,7 +1748,7 @@ let rec lub p q = match p.pat_desc,q.pat_desc with
     let r = lub p q in
     make_pat (Tpat_lazy r) p.pat_type p.pat_env
 | Tpat_construct (lid,c1,ps1,_), Tpat_construct (_,c2,ps2,_)
-      when  Types.equal_tag c1.cstr_tag c2.cstr_tag  ->
+      when Data_types.equal_tag c1.cstr_tag c2.cstr_tag  ->
         let rs = lubs ps1 ps2 in
         make_pat (Tpat_construct (lid, c1, rs, None))
           p.pat_type p.pat_env

--- a/typing/parmatch.mli
+++ b/typing/parmatch.mli
@@ -18,6 +18,7 @@
 open Asttypes
 open Typedtree
 open Types
+open Data_types
 
 (** Most checks in this file need not access all information about a case,
     and just need a few pieces of information. [parmatch_case] is those
@@ -55,8 +56,8 @@ module Compat :
   functor
     (_ : sig
       val equal :
-          Types.constructor_description ->
-            Types.constructor_description ->
+          Data_types.constructor_description ->
+            Data_types.constructor_description ->
               bool
      end) -> sig
        val compat : pattern -> pattern -> bool

--- a/typing/patterns.ml
+++ b/typing/patterns.ml
@@ -16,6 +16,7 @@
 
 open Asttypes
 open Types
+open Data_types
 open Typedtree
 
 (* useful pattern auxiliary functions *)

--- a/typing/patterns.mli
+++ b/typing/patterns.mli
@@ -17,6 +17,7 @@
 open Asttypes
 open Typedtree
 open Types
+open Data_types
 
 val omega : pattern
 (** aka. "Tpat_any" or "_"  *)

--- a/typing/printpat.ml
+++ b/typing/printpat.ml
@@ -17,7 +17,7 @@
 
 open Asttypes
 open Typedtree
-open Types
+open Data_types
 open Format_doc
 
 let is_cons = function

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -5133,7 +5133,7 @@ and type_label_exp create env loc ty_expected
           (lid, label, sarg) =
   (* Here also ty_expected may be at generic_level *)
   let separate = !Clflags.principal || Env.has_local_constraints env in
-  let is_poly = label_is_poly label in
+  let is_poly = is_poly_Tpoly label.lbl_arg in
   let (vars, arg) =
     (* raise level to check univars *)
     with_local_level_generalize_if is_poly begin fun () ->

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -448,7 +448,7 @@ let unify_pat ?sdesc_for_hint env pat expected_ty =
 
 (* unification of a type with a Tconstr with freshly created arguments *)
 let unify_head_only ~refine loc penv ty constr =
-  let path = cstr_type_path constr in
+  let path = cstr_res_type_path constr in
   let decl = Env.find_type path !!penv in
   let ty' = Ctype.newconstr path (Ctype.instance_list decl.type_params) in
   unify_pat_types_refine ~refine loc penv ty' ty

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -22,6 +22,7 @@ open Misc
 open Asttypes
 open Parsetree
 open Types
+open Data_types
 open Typedtree
 open Btype
 open Ctype

--- a/typing/typecore.mli
+++ b/typing/typecore.mli
@@ -190,7 +190,7 @@ type error =
   | Virtual_class of Longident.t
   | Private_type of type_expr
   | Private_label of Longident.t * type_expr
-  | Private_constructor of constructor_description * type_expr
+  | Private_constructor of Data_types.constructor_description * type_expr
   | Unbound_instance_variable of string * string list
   | Instance_variable_not_mutable of string
   | Not_subtype of Errortrace.Subtype.error

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -1258,12 +1258,13 @@ let transl_extension_constructor ~scope env type_path type_params
             typext_params
         end;
         (* Ensure that constructor's type matches the type being extended *)
-        let cstr_type_path = Btype.cstr_type_path cdescr in
-        let cstr_type_params = (Env.find_type cstr_type_path env).type_params in
+        let cstr_res_type_path = Data_types.cstr_res_type_path cdescr in
+        let cstr_res_type_params =
+          (Env.find_type cstr_res_type_path env).type_params in
         let cstr_types =
           (Btype.newgenty
-             (Tconstr(cstr_type_path, cstr_type_params, ref Mnil)))
-          :: cstr_type_params
+             (Tconstr(cstr_res_type_path, cstr_res_type_params, ref Mnil)))
+          :: cstr_res_type_params
         in
         let ext_types =
           (Btype.newgenty
@@ -1272,7 +1273,7 @@ let transl_extension_constructor ~scope env type_path type_params
         in
         if not (Ctype.is_equal env true cstr_types ext_types) then
           raise (Error(lid.loc,
-                       Rebind_mismatch(lid.txt, cstr_type_path, type_path)));
+                   Rebind_mismatch(lid.txt, cstr_res_type_path, type_path)));
         (* Disallow rebinding private constructors to non-private *)
         begin
           match cdescr.cstr_private, priv with

--- a/typing/typedtree.ml
+++ b/typing/typedtree.ml
@@ -17,6 +17,7 @@
 
 open Asttypes
 open Types
+open Data_types
 
 module Uid = Shape.Uid
 
@@ -111,7 +112,7 @@ and expression_desc =
       Longident.t loc * constructor_description * expression list
   | Texp_variant of label * expression option
   | Texp_record of {
-      fields : ( Types.label_description * record_label_definition ) array;
+      fields : ( Data_types.label_description * record_label_definition ) array;
       representation : Types.record_representation;
       extended_expression : expression option;
     }

--- a/typing/typedtree.mli
+++ b/typing/typedtree.mli
@@ -91,7 +91,7 @@ and 'k pattern_desc =
             Invariant: n >= 2
          *)
   | Tpat_construct :
-      Longident.t loc * Types.constructor_description *
+      Longident.t loc * Data_types.constructor_description *
         value general_pattern list * (Ident.t loc list * core_type) option ->
       value pattern_desc
         (** C                             ([], None)
@@ -111,9 +111,12 @@ and 'k pattern_desc =
             See {!Types.row_desc} for an explanation of the last parameter.
          *)
   | Tpat_record :
-      (Longident.t loc * Types.label_description * value general_pattern) list *
-        closed_flag ->
-      value pattern_desc
+      (Longident.t loc
+       * Data_types.label_description
+       * value general_pattern
+      ) list
+      * closed_flag
+      -> value pattern_desc
         (** { l1=P1; ...; ln=Pn }     (flag = Closed)
             { l1=P1; ...; ln=Pn; _}   (flag = Open)
 
@@ -230,14 +233,14 @@ and expression_desc =
   | Texp_tuple of expression list
         (** (E1, ..., EN) *)
   | Texp_construct of
-      Longident.t loc * Types.constructor_description * expression list
+      Longident.t loc * Data_types.constructor_description * expression list
         (** C                []
             C E              [E]
             C (E1, ..., En)  [E1;...;En]
          *)
   | Texp_variant of label * expression option
   | Texp_record of {
-      fields : ( Types.label_description * record_label_definition ) array;
+      fields : ( Data_types.label_description * record_label_definition ) array;
       representation : Types.record_representation;
       extended_expression : expression option;
     }
@@ -252,9 +255,9 @@ and expression_desc =
               { fields = [| l1, Kept t1; l2 Override P2 |]; representation;
                 extended_expression = Some E0 }
         *)
-  | Texp_field of expression * Longident.t loc * Types.label_description
+  | Texp_field of expression * Longident.t loc * Data_types.label_description
   | Texp_setfield of
-      expression * Longident.t loc * Types.label_description * expression
+      expression * Longident.t loc * Data_types.label_description * expression
   | Texp_array of expression list
   | Texp_ifthenelse of expression * expression * expression option
   | Texp_sequence of expression * expression

--- a/typing/types.ml
+++ b/typing/types.ml
@@ -406,52 +406,6 @@ and ext_status =
   | Text_next                      (* not first constructor of an extension *)
   | Text_exception                 (* an exception *)
 
-
-(* Constructor and record label descriptions inserted held in typing
-   environments *)
-
-type constructor_description =
-  { cstr_name: string;                  (* Constructor name *)
-    cstr_res: type_expr;                (* Type of the result *)
-    cstr_existentials: type_expr list;  (* list of existentials *)
-    cstr_args: type_expr list;          (* Type of the arguments *)
-    cstr_arity: int;                    (* Number of arguments *)
-    cstr_tag: constructor_tag;          (* Tag for heap blocks *)
-    cstr_consts: int;                   (* Number of constant constructors *)
-    cstr_nonconsts: int;                (* Number of non-const constructors *)
-    cstr_generalized: bool;             (* Constrained return type? *)
-    cstr_private: private_flag;         (* Read-only constructor? *)
-    cstr_loc: Location.t;
-    cstr_attributes: Parsetree.attributes;
-    cstr_inlined: type_declaration option;
-    cstr_uid: Uid.t;
-   }
-
-and constructor_tag =
-    Cstr_constant of int                (* Constant constructor (an int) *)
-  | Cstr_block of int                   (* Regular constructor (a block) *)
-  | Cstr_unboxed                        (* Constructor of an unboxed type *)
-  | Cstr_extension of Path.t * bool     (* Extension constructor
-                                           true if a constant false if a block*)
-
-let equal_tag t1 t2 =
-  match (t1, t2) with
-  | Cstr_constant i1, Cstr_constant i2 -> i2 = i1
-  | Cstr_block i1, Cstr_block i2 -> i2 = i1
-  | Cstr_unboxed, Cstr_unboxed -> true
-  | Cstr_extension (path1, b1), Cstr_extension (path2, b2) ->
-      Path.same path1 path2 && b1 = b2
-  | (Cstr_constant _|Cstr_block _|Cstr_unboxed|Cstr_extension _), _ -> false
-
-let may_equal_constr c1 c2 =
-  c1.cstr_arity = c2.cstr_arity
-  && (match c1.cstr_tag,c2.cstr_tag with
-     | Cstr_extension _,Cstr_extension _ ->
-         (* extension constructors may be rebindings of each other *)
-         true
-     | tag1, tag2 ->
-         equal_tag tag1 tag2)
-
 let item_visibility = function
   | Sig_value (_, _, vis)
   | Sig_type (_, _, _, vis)
@@ -460,20 +414,6 @@ let item_visibility = function
   | Sig_modtype (_, _, vis)
   | Sig_class (_, _, _, vis)
   | Sig_class_type (_, _, _, vis) -> vis
-
-type label_description =
-  { lbl_name: string;                   (* Short name *)
-    lbl_res: type_expr;                 (* Type of the result *)
-    lbl_arg: type_expr;                 (* Type of the argument *)
-    lbl_mut: mutable_flag;              (* Is this a mutable field? *)
-    lbl_pos: int;                       (* Position in block *)
-    lbl_all: label_description array;   (* All the labels in this type *)
-    lbl_repres: record_representation;  (* Representation for this record *)
-    lbl_private: private_flag;          (* Read-only field? *)
-    lbl_loc: Location.t;
-    lbl_attributes: Parsetree.attributes;
-    lbl_uid: Uid.t;
-   }
 
 let rec bound_value_identifiers = function
     [] -> []

--- a/typing/types.mli
+++ b/typing/types.mli
@@ -661,54 +661,6 @@ and ext_status =
 
 val item_visibility : signature_item -> visibility
 
-(* Constructor and record label descriptions inserted held in typing
-   environments *)
-
-type constructor_description =
-  { cstr_name: string;                  (* Constructor name *)
-    cstr_res: type_expr;                (* Type of the result *)
-    cstr_existentials: type_expr list;  (* list of existentials *)
-    cstr_args: type_expr list;          (* Type of the arguments *)
-    cstr_arity: int;                    (* Number of arguments *)
-    cstr_tag: constructor_tag;          (* Tag for heap blocks *)
-    cstr_consts: int;                   (* Number of constant constructors *)
-    cstr_nonconsts: int;                (* Number of non-const constructors *)
-    cstr_generalized: bool;             (* Constrained return type? *)
-    cstr_private: private_flag;         (* Read-only constructor? *)
-    cstr_loc: Location.t;
-    cstr_attributes: Parsetree.attributes;
-    cstr_inlined: type_declaration option;
-    cstr_uid: Uid.t;
-   }
-
-and constructor_tag =
-    Cstr_constant of int                (* Constant constructor (an int) *)
-  | Cstr_block of int                   (* Regular constructor (a block) *)
-  | Cstr_unboxed                        (* Constructor of an unboxed type *)
-  | Cstr_extension of Path.t * bool     (* Extension constructor
-                                           true if a constant false if a block*)
-
-(* Constructors are the same *)
-val equal_tag :  constructor_tag -> constructor_tag -> bool
-
-(* Constructors may be the same, given potential rebinding *)
-val may_equal_constr :
-    constructor_description ->  constructor_description -> bool
-
-type label_description =
-  { lbl_name: string;                   (* Short name *)
-    lbl_res: type_expr;                 (* Type of the result *)
-    lbl_arg: type_expr;                 (* Type of the argument *)
-    lbl_mut: mutable_flag;              (* Is this a mutable field? *)
-    lbl_pos: int;                       (* Position in block *)
-    lbl_all: label_description array;   (* All the labels in this type *)
-    lbl_repres: record_representation;  (* Representation for this record *)
-    lbl_private: private_flag;          (* Read-only field? *)
-    lbl_loc: Location.t;
-    lbl_attributes: Parsetree.attributes;
-    lbl_uid: Uid.t;
-  }
-
 (** Extracts the list of "value" identifiers bound by a signature.
     "Value" identifiers are identifiers for signature components that
     correspond to a run-time value: values, extensions, modules, classes.


### PR DESCRIPTION
One must be careful about changing typing/Types, because (some of) the types it defined are used in .cmi files, so any change to those requires a delicate bootstrap and magic number bump.

This refactoring splits off a part of Types that is *not* used in .cmi files -- information about record fields and variant constructors. They move to a new typing/Data_types compilation unit, which can evolve more freely.