### PR TITLE
[refactor] equal_tag => equal_constr

### DIFF
--- a/.depend
+++ b/.depend
@@ -4458,6 +4458,7 @@ lambda/matching.cmo : \
     typing/primitive.cmi \
     typing/predef.cmi \
     typing/patterns.cmi \
+    typing/path.cmi \
     typing/parmatch.cmi \
     utils/misc.cmi \
     parsing/longident.cmi \
@@ -4482,6 +4483,7 @@ lambda/matching.cmx : \
     typing/primitive.cmx \
     typing/predef.cmx \
     typing/patterns.cmx \
+    typing/path.cmx \
     typing/parmatch.cmx \
     utils/misc.cmx \
     parsing/longident.cmx \

--- a/lambda/matching.ml
+++ b/lambda/matching.ml
@@ -1397,14 +1397,15 @@ let can_group discr pat =
   | Constant (Const_int64 _), Constant (Const_int64 _)
   | Constant (Const_nativeint _), Constant (Const_nativeint _) ->
       true
-  | Construct { cstr_tag = Cstr_extension _ as discr_tag }, Construct pat_cstr
+  | Construct { cstr_tag = Cstr_extension (p1, _) },
+    Construct { cstr_tag = Cstr_extension (p2, _) }
     ->
       (* Extension constructors with distinct names may be equal thanks to
          constructor rebinding. So we need to produce a specialized
          submatrix for each syntactically-distinct constructor (with a threading
          of exits such that each submatrix falls back to the
          potentially-compatible submatrices below it).  *)
-      Data_types.equal_tag discr_tag pat_cstr.cstr_tag
+      Path.same p1 p2
   | Construct _, Construct _
   | Tuple _, (Tuple _ | Any)
   | Record _, (Record _ | Any)
@@ -2059,7 +2060,7 @@ let get_expr_args_constr ~scopes head { arg; mut; _ } rem =
 let divide_constructor ~scopes ctx pm =
   divide
     (get_expr_args_constr ~scopes)
-    (fun cstr1 cstr2 -> Data_types.equal_tag cstr1.cstr_tag cstr2.cstr_tag)
+    Data_types.equal_constr
     get_key_constr
     get_pat_args_constr
     ctx pm

--- a/typing/data_types.ml
+++ b/typing/data_types.ml
@@ -48,8 +48,8 @@ let equal_tag t1 t2 =
   | Cstr_constant i1, Cstr_constant i2 -> i2 = i1
   | Cstr_block i1, Cstr_block i2 -> i2 = i1
   | Cstr_unboxed, Cstr_unboxed -> true
-  | Cstr_extension (path1, b1), Cstr_extension (path2, b2) ->
-      Path.same path1 path2 && b1 = b2
+  | Cstr_extension (path1, _), Cstr_extension (path2, _) ->
+      Path.same path1 path2
   | (Cstr_constant _|Cstr_block _|Cstr_unboxed|Cstr_extension _), _ -> false
 
 let may_equal_constr c1 c2 =

--- a/typing/data_types.ml
+++ b/typing/data_types.ml
@@ -52,6 +52,9 @@ let equal_tag t1 t2 =
       Path.same path1 path2
   | (Cstr_constant _|Cstr_block _|Cstr_unboxed|Cstr_extension _), _ -> false
 
+let equal_constr c1 c2 =
+  equal_tag c1.cstr_tag c2.cstr_tag
+
 let may_equal_constr c1 c2 =
   c1.cstr_arity = c2.cstr_arity
   && (match c1.cstr_tag,c2.cstr_tag with

--- a/typing/data_types.mli
+++ b/typing/data_types.mli
@@ -43,10 +43,12 @@ and constructor_tag =
   | Cstr_extension of Path.t * bool     (* Extension constructor
                                            true if a constant false if a block*)
 
-(* Constructors are the same *)
-val equal_tag :  constructor_tag -> constructor_tag -> bool
+(* Constructors are the same: they return (structurally)-equal values
+   when applied to equal arguments. *)
+val equal_constr :
+    constructor_description ->  constructor_description -> bool
 
-(* Constructors may be the same, given potential rebinding *)
+(* Constructors may be the same, given potential rebinding. *)
 val may_equal_constr :
     constructor_description ->  constructor_description -> bool
 

--- a/typing/parmatch.ml
+++ b/typing/parmatch.ml
@@ -341,7 +341,7 @@ end
 module SyntacticCompat =
   Compat
     (struct
-      let equal c1 c2 = Data_types.equal_tag c1.cstr_tag c2.cstr_tag
+      let equal = Data_types.equal_constr
     end)
 
 let compat =  SyntacticCompat.compat
@@ -376,7 +376,7 @@ let simple_match d h =
   let open Patterns.Head in
   match d.pat_desc, h.pat_desc with
   | Construct c1, Construct c2 ->
-      Data_types.equal_tag c1.cstr_tag c2.cstr_tag
+      Data_types.equal_constr c1 c2
   | Variant { tag = t1; _ }, Variant { tag = t2 } ->
       t1 = t2
   | Constant c1, Constant c2 -> const_compare c1 c2 = 0
@@ -1694,7 +1694,7 @@ let rec le_pat p q =
   | _, Tpat_alias(q,_,_,_) -> le_pat p q
   | Tpat_constant(c1), Tpat_constant(c2) -> const_compare c1 c2 = 0
   | Tpat_construct(_,c1,ps,_), Tpat_construct(_,c2,qs,_) ->
-      Data_types.equal_tag c1.cstr_tag c2.cstr_tag && le_pats ps qs
+      Data_types.equal_constr c1 c2 && le_pats ps qs
   | Tpat_variant(l1,Some p1,_), Tpat_variant(l2,Some p2,_) ->
       (l1 = l2 && le_pat p1 p2)
   | Tpat_variant(l1,None,_r1), Tpat_variant(l2,None,_) ->
@@ -1748,7 +1748,7 @@ let rec lub p q = match p.pat_desc,q.pat_desc with
     let r = lub p q in
     make_pat (Tpat_lazy r) p.pat_type p.pat_env
 | Tpat_construct (lid,c1,ps1,_), Tpat_construct (_,c2,ps2,_)
-      when Data_types.equal_tag c1.cstr_tag c2.cstr_tag  ->
+      when Data_types.equal_constr c1 c2 ->
         let rs = lubs ps1 ps2 in
         make_pat (Tpat_construct (lid, c1, rs, None))
           p.pat_type p.pat_env


### PR DESCRIPTION
(This PR is on top of #13466.)

The type-checker and pattern-matching compiler rely on a check that the "tags" of two constructors are equal. This check is hard to extend to new/funky sorts of constructors (extension constructor (existing), unboxed constructors (upcoming!)), and is also performance-sensitive ( #406 ). 

Most uses in the codebase are not actually trying to check tag equality, but just whether two constructors are equal. We refactor the codebase to introduce a new `equal_constr` function and use it directly. This makes the intent clearer, it will be easier to extend with newer kinds of constructors, and it would probably help to make the check more efficient.