### PR TITLE
Remove unused OCAMLRUNPARAMs list from manual

### DIFF
--- a/manual/src/cmds/runtime.etex
+++ b/manual/src/cmds/runtime.etex
@@ -109,8 +109,8 @@ The following environment variables are also consulted:
   A parameter specification is an option letter followed by an "="
   sign, a decimal number (or an hexadecimal number prefixed by "0x"),
   and an optional multiplier.  The options are documented below;
-  the options "a, i, l, m, M, n, o, O, s, v, w" correspond to
-  the fields of the "control" record documented in
+  the options "l, m, M, n, o, s, v" correspond to fields of the "control"
+  record documented in
 \ifouthtml
  \ahref{libref/Gc.html}{Module \texttt{Gc}}.
 \else


### PR DESCRIPTION
This removes 4 left-over `OCAMLRUNPARAM`s in a list from the manual.

Their descriptions were removed from the manual in #10890
and I then missed this mention when updating the `Gc` interface description in #13440

(no Changes entry needed)