### PR TITLE
Add a `-keywords <version?+list>` flag

### DIFF
--- a/.depend
+++ b/.depend
@@ -404,6 +404,7 @@ parsing/lexer.cmo : \
     parsing/location.cmi \
     utils/format_doc.cmi \
     parsing/docstrings.cmi \
+    utils/clflags.cmi \
     parsing/lexer.cmi
 parsing/lexer.cmx : \
     utils/warnings.cmx \
@@ -412,6 +413,7 @@ parsing/lexer.cmx : \
     parsing/location.cmx \
     utils/format_doc.cmx \
     parsing/docstrings.cmx \
+    utils/clflags.cmx \
     parsing/lexer.cmi
 parsing/lexer.cmi : \
     parsing/parser.cmi \

--- a/.depend
+++ b/.depend
@@ -404,7 +404,6 @@ parsing/lexer.cmo : \
     parsing/location.cmi \
     utils/format_doc.cmi \
     parsing/docstrings.cmi \
-    utils/clflags.cmi \
     parsing/lexer.cmi
 parsing/lexer.cmx : \
     utils/warnings.cmx \
@@ -413,7 +412,6 @@ parsing/lexer.cmx : \
     parsing/location.cmx \
     utils/format_doc.cmx \
     parsing/docstrings.cmx \
-    utils/clflags.cmx \
     parsing/lexer.cmi
 parsing/lexer.cmi : \
     parsing/parser.cmi \
@@ -453,6 +451,7 @@ parsing/parse.cmo : \
     parsing/lexer.cmi \
     utils/format_doc.cmi \
     parsing/docstrings.cmi \
+    utils/clflags.cmi \
     parsing/parse.cmi
 parsing/parse.cmx : \
     parsing/syntaxerr.cmx \
@@ -463,6 +462,7 @@ parsing/parse.cmx : \
     parsing/lexer.cmx \
     utils/format_doc.cmx \
     parsing/docstrings.cmx \
+    utils/clflags.cmx \
     parsing/parse.cmi
 parsing/parse.cmi : \
     parsing/parsetree.cmi \

--- a/Changes
+++ b/Changes
@@ -520,6 +520,11 @@ ___________
     The constant "42" has type ...
   (Jules Aguillon, review by Gabriel Scherer and Florian Angeletti)
 
+- #13471: add `-keywords <version?+list>` flag to define the list of keywords
+  recognized by the lexer, for instance `-keywords 5.2` disable the `effect`
+  keyword.
+  (Florian Angeletti, review by Gabriel Scherer)
+
 ### Internal/compiler-libs changes:
 
 - #11129, #11148: enforce that ppxs do not produce `parsetree`s with

--- a/driver/compenv.ml
+++ b/driver/compenv.ml
@@ -480,6 +480,8 @@ let read_one_param ppf position name v =
   | "dump" ->
       handle_dump_option ppf v
 
+  |  "keywords"  -> Clflags.keyword_edition := Some v
+
   | _ ->
     if not (List.mem name !can_discard) then begin
       can_discard := name :: !can_discard;

--- a/driver/main_args.ml
+++ b/driver/main_args.ml
@@ -412,7 +412,7 @@ let mk_keywords f =
   "<version+list>  set keywords following the <version+list> spec:\n
   \                -<version> if present specifies the base set of keywords\n
   \                  (if absent the current set of keywords is used)
-  \                 -<list> is a \"+\"-separated list of keywords to add to\n
+  \                -<list> is a \"+\"-separated list of keywords to add to\n
   \                   the base set of keywords.
   "
 

--- a/driver/main_args.ml
+++ b/driver/main_args.ml
@@ -409,7 +409,12 @@ let mk_ppx f =
 
 let mk_keywords f =
   "-keywords", Arg.String f,
-  "<version><list>   use the same keywords as <version> extended by <list>"
+  "<version+list>  set keywords following the <version+list> spec:\n
+  \                -<version> if present specifies the base set of keywords\n
+  \                  (if absent the current set of keywords is used)
+  \                 -<list> is a \"+\"-separated list of keywords to add to\n
+  \                   the base set of keywords.
+  "
 
 let mk_plugin f =
   "-plugin", Arg.String f,

--- a/driver/main_args.ml
+++ b/driver/main_args.ml
@@ -407,6 +407,10 @@ let mk_ppx f =
   "-ppx", Arg.String f,
   "<command>  Pipe abstract syntax trees through preprocessor <command>"
 
+let mk_keywords f =
+  "-keywords", Arg.String f,
+  "<version><list>   use the same keywords as <version> extended by <list>"
+
 let mk_plugin f =
   "-plugin", Arg.String f,
   "<plugin>  (no longer supported)"
@@ -785,6 +789,7 @@ module type Common_options = sig
   val _nocwd : unit -> unit
   val _open : string -> unit
   val _ppx : string -> unit
+  val _keywords: string -> unit
   val _principal : unit -> unit
   val _no_principal : unit -> unit
   val _rectypes : unit -> unit
@@ -1057,6 +1062,7 @@ struct
     mk_no_keep_docs F._no_keep_docs;
     mk_keep_locs F._keep_locs;
     mk_no_keep_locs F._no_keep_locs;
+    mk_keywords F._keywords;
     mk_labels F._labels;
     mk_linkall F._linkall;
     mk_make_runtime F._make_runtime;
@@ -1166,6 +1172,7 @@ struct
     mk_nopervasives F._nopervasives;
     mk_open F._open;
     mk_ppx F._ppx;
+    mk_keywords F._keywords;
     mk_principal F._principal;
     mk_no_principal F._no_principal;
     mk_rectypes F._rectypes;
@@ -1264,6 +1271,7 @@ struct
     mk_no_keep_docs F._no_keep_docs;
     mk_keep_locs F._keep_locs;
     mk_no_keep_locs F._no_keep_locs;
+    mk_keywords F._keywords;
     mk_labels F._labels;
     mk_linkall F._linkall;
     mk_inline_max_depth F._inline_max_depth;
@@ -1401,6 +1409,7 @@ module Make_opttop_options (F : Opttop_options) = struct
     mk_inline_indirect_cost F._inline_indirect_cost;
     mk_inline_lifting_benefit F._inline_lifting_benefit;
     mk_inline_branch_factor F._inline_branch_factor;
+    mk_keywords F._keywords;
     mk_labels F._labels;
     mk_alias_deps F._alias_deps;
     mk_no_alias_deps F._no_alias_deps;
@@ -1499,6 +1508,7 @@ struct
     mk_intf F._intf;
     mk_intf_suffix F._intf_suffix;
     mk_intf_suffix_2 F._intf_suffix;
+    mk_keywords F._keywords;
     mk_labels F._labels;
     mk_modern F._labels;
     mk_alias_deps F._alias_deps;
@@ -1640,6 +1650,7 @@ module Default = struct
       Misc.set_or_ignore error_style_reader.parse error_style
     let _nopervasives = set nopervasives
     let _ppx s = Compenv.first_ppx := (s :: (!Compenv.first_ppx))
+    let _keywords s = Clflags.keyword_edition := (Some s)
     let _unsafe = set unsafe
     let _warn_error s =
       Warnings.parse_options true s |> Option.iter Location.(prerr_alert none)
@@ -1893,6 +1904,7 @@ module Default = struct
     let _intf_suffix s = Config.interface_suffix := s
     let _pp s = Clflags.preprocessor := (Some s)
     let _ppx s = Clflags.all_ppx := (s :: (!Clflags.all_ppx))
+    let _keywords s = Clflags.keyword_edition := Some s
     let _thread = set Clflags.use_threads
     let _v () = Compenv.print_version_and_library "documentation generator"
     let _verbose = set Clflags.verbose

--- a/driver/main_args.ml
+++ b/driver/main_args.ml
@@ -413,7 +413,7 @@ let mk_keywords f =
   \                -<version> if present specifies the base set of keywords\n
   \                  (if absent the current set of keywords is used)
   \                -<list> is a \"+\"-separated list of keywords to add to\n
-  \                   the base set of keywords.
+  \                  the base set of keywords.
   "
 
 let mk_plugin f =

--- a/driver/main_args.mli
+++ b/driver/main_args.mli
@@ -33,6 +33,7 @@ module type Common_options = sig
   val _nocwd : unit -> unit
   val _open : string -> unit
   val _ppx : string -> unit
+  val _keywords: string -> unit
   val _principal : unit -> unit
   val _no_principal : unit -> unit
   val _rectypes : unit -> unit

--- a/man/ocamlc.1
+++ b/man/ocamlc.1
@@ -454,6 +454,22 @@ Keep documentation strings in generated .cmi files.
 .B \-keep-locs
 Keep locations in generated .cmi files.
 .TP
+.BI \-keywords " version+list"
+Set keywords according to the
+.IR version+list
+specification.
+
+This specification starts with an optional version number, defining the base
+set of keywords, followed by a
+.IR +
+separated list of supplementary keywords to add to this base set.
+Without an explicit version number, the base set of keywords is the
+set of keywords in the current version of OCaml.
+Supplementary keywords that does not match any known keyword in the current
+version of the compiler triggers an error whenever they are present in the
+source code.
+
+.TP
 .B \-labels
 Labels are not ignored in types, labels may be used in applications,
 and labelled parameters can be given in any order.  This is the default.

--- a/man/ocamlc.1
+++ b/man/ocamlc.1
@@ -462,11 +462,11 @@ specification.
 This specification starts with an optional version number, defining the base
 set of keywords, followed by a
 .IR +
-separated list of supplementary keywords to add to this base set.
+separated list of additional keywords to add to this base set.
 Without an explicit version number, the base set of keywords is the
 set of keywords in the current version of OCaml.
-Supplementary keywords that does not match any known keyword in the current
-version of the compiler triggers an error whenever they are present in the
+Additional keywords that do not match any known keyword in the current
+version of the language trigger an error whenever they are present in the
 source code.
 
 .TP

--- a/manual/src/cmds/unified-options.etex
+++ b/manual/src/cmds/unified-options.etex
@@ -363,6 +363,20 @@ Recognize file names ending with \var{string} as interface files
 (instead of the default ".mli").
 }%\notop
 
+\item["-keywords" \var{version+list}]
+Set keywords according to the \var{version+list}
+specification.
+
+This specification starts with an optional version number, defining the
+base set of keywords, followed by a \var{+}-separated list of supplementary
+keywords to add to this base set.
+
+Without an explicit version number, the base set of keywords is the
+set of keywords in the current version of OCaml.
+Supplementary keywords that does not match any known keyword in the current
+version of the compiler triggers an error whenever they are present in the
+source code.
+
 \item["-labels"]
 Labels are not ignored in types, labels may be used in applications,
 and labelled parameters can be given in any order.  This is the default.

--- a/manual/src/cmds/unified-options.etex
+++ b/manual/src/cmds/unified-options.etex
@@ -367,14 +367,14 @@ Recognize file names ending with \var{string} as interface files
 Set keywords according to the \var{version+list}
 specification.
 
-This specification starts with an optional version number, defining the
-base set of keywords, followed by a \var{+}-separated list of supplementary
-keywords to add to this base set.
+This specification starts with an optional version number, defining the base set
+of keywords, followed by a \var{+}-separated list of additional keywords to add
+to this base set.
 
 Without an explicit version number, the base set of keywords is the
 set of keywords in the current version of OCaml.
-Supplementary keywords that does not match any known keyword in the current
-version of the compiler triggers an error whenever they are present in the
+Additional keywords that do not match any known keyword in the current
+version of the language trigger an error whenever they are present in the
 source code.
 
 \item["-labels"]

--- a/parsing/lexer.mli
+++ b/parsing/lexer.mli
@@ -40,6 +40,7 @@ type error =
   | Invalid_char_in_ident of Uchar.t
   | Non_lowercase_delimiter of string
   | Capitalized_raw_identifier of string
+  | Unknown_keyword of string
 
 exception Error of error * Location.t
 

--- a/parsing/lexer.mli
+++ b/parsing/lexer.mli
@@ -20,7 +20,7 @@
 
 *)
 
-val init : unit -> unit
+val init : ?keyword_edition:((int*int) option * string list) -> unit -> unit
 val token: Lexing.lexbuf -> Parser.token
 val skip_hash_bang: Lexing.lexbuf -> unit
 

--- a/parsing/lexer.mll
+++ b/parsing/lexer.mll
@@ -115,12 +115,23 @@ let keyword_table =
   let tbl = Hashtbl.create 149 in
   refresh_keywords tbl;
   tbl
-
 let keyword_edition v =
-  Option.iter (fun v ->
-    if v < (5, 3) then
-      Hashtbl.remove keyword_table "effect"
-  ) v
+  if v < (3,7) then begin
+      Hashtbl.add keyword_table "parser" None;
+      if v < (1,0) then (
+        List.iter (Hashtbl.remove keyword_table)
+          ["class"; "inherit";"method";"new";"private";"constraint";"private";
+           "virtual"]
+      );
+      if v < (1,6) then (
+        Hashtbl.remove keyword_table "lazy";
+        Hashtbl.remove keyword_table "assert"
+      )
+    end;
+  if v < (4,2) then
+    Hashtbl.remove keyword_table "nonrec";
+  if v < (5, 3) then
+    Hashtbl.remove keyword_table "effect"
 
 let parse_keyword_edition s =
   let parse_version s =
@@ -148,7 +159,7 @@ let set_keyword_edition =
     | _ -> refresh_keywords keyword_table;
     end;
     keyword_last_edition := edition, add;
-    keyword_edition edition;
+    Option.iter keyword_edition edition;
     List.iter (fun k ->
     match Hashtbl.find keyword_table_all k with
     | name -> Hashtbl.replace keyword_table k (Some name)

--- a/parsing/lexer.mll
+++ b/parsing/lexer.mll
@@ -432,8 +432,8 @@ let prepare_error loc = function
          Style.inline_code name
   | Unknown_keyword name ->
       Location.errorf ~loc
-      "%a has been marked as a future keyword,@ \
-      but this version of OCaml cannot handle it."
+      "%a has been defined as an additional keyword.@ \
+       This version of OCaml does not support this keyword."
       Style.inline_code name
 
 let () =

--- a/parsing/lexer.mll
+++ b/parsing/lexer.mll
@@ -124,12 +124,15 @@ let keyword_edition v =
 
 let parse_keyword_edition s =
   let parse_version s =
+  let bad_version () =
+    raise (Arg.Bad "Ill-formed version in keywords flag,\n\
+                    the expected format is %d.%d .")
+  in
   if s = "" then None else match String.split_on_char '.' s with
-  | [] | [_] | _ :: _ :: _ :: _ ->
-    raise (Arg.Bad "Ill-formed version in keywords flag")
+  | [] | [_] | _ :: _ :: _ :: _ -> bad_version ()
   | [major;minor] -> match int_of_string_opt major, int_of_string_opt minor with
     | Some major, Some minor -> Some (major,minor)
-    | _ -> raise (Arg.Bad "Ill-formed version in keywords flag")
+    | _ -> bad_version ()
   in
   match String.split_on_char '+' s with
   | [] -> None, []

--- a/parsing/parse.ml
+++ b/parsing/parse.ml
@@ -46,7 +46,10 @@ type 'a parser =
 let wrap (parser : 'a parser) lexbuf : 'a =
   try
     Docstrings.init ();
-    Lexer.init ();
+    let keyword_edition =
+      Clflags.(Option.map parse_keyword_edition !keyword_edition)
+    in
+    Lexer.init ?keyword_edition ();
     let ast = parser token lexbuf in
     Parsing.clear_parser();
     Docstrings.warn_bad_docstrings ();

--- a/utils/clflags.ml
+++ b/utils/clflags.ml
@@ -745,6 +745,23 @@ module Dump_option = struct
         check_native
 end
 
+let parse_keyword_edition s =
+  let parse_version s =
+  let bad_version () =
+    raise (Arg.Bad "Ill-formed version in keywords flag,\n\
+                    the expected format is %d.%d .")
+  in
+  if s = "" then None else match String.split_on_char '.' s with
+  | [] | [_] | _ :: _ :: _ :: _ -> bad_version ()
+  | [major;minor] -> match int_of_string_opt major, int_of_string_opt minor with
+    | Some major, Some minor -> Some (major,minor)
+    | _ -> bad_version ()
+  in
+  match String.split_on_char '+' s with
+  | [] -> None, []
+  | [s] -> parse_version s, []
+  | v :: rest -> parse_version v, rest
+
 module String = Misc.Stdlib.String
 
 let arg_spec = ref []

--- a/utils/clflags.ml
+++ b/utils/clflags.ml
@@ -749,7 +749,7 @@ let parse_keyword_edition s =
   let parse_version s =
   let bad_version () =
     raise (Arg.Bad "Ill-formed version in keywords flag,\n\
-                    the expected format is %d.%d .")
+                    the supported format is <major>.<minor>, for example 5.2 .")
   in
   if s = "" then None else match String.split_on_char '.' s with
   | [] | [_] | _ :: _ :: _ :: _ -> bad_version ()

--- a/utils/clflags.ml
+++ b/utils/clflags.ml
@@ -119,6 +119,8 @@ and dump_flambda_verbose = ref false    (* -dflambda-verbose *)
 and dump_instr = ref false              (* -dinstr *)
 and keep_camlprimc_file = ref false     (* -dcamlprimc *)
 
+let keyword_edition: string option ref = ref None
+
 let keep_asm_file = ref false           (* -S *)
 let optimize_for_speed = ref true       (* -compact *)
 and opaque = ref false                  (* -opaque *)

--- a/utils/clflags.mli
+++ b/utils/clflags.mli
@@ -225,6 +225,7 @@ val dump_into_file : bool ref
 val dump_dir : string option ref
 
 val keyword_edition: string option ref
+val parse_keyword_edition: string -> (int*int) option * string list
 
 (* Support for flags that can also be set from an environment variable *)
 type 'a env_reader = {

--- a/utils/clflags.mli
+++ b/utils/clflags.mli
@@ -224,6 +224,8 @@ val set_dumped_pass : string -> bool -> unit
 val dump_into_file : bool ref
 val dump_dir : string option ref
 
+val keyword_edition: string option ref
+
 (* Support for flags that can also be set from an environment variable *)
 type 'a env_reader = {
   parse : string -> 'a option;


### PR DESCRIPTION
This PR proposes to add a `-keywords <version?+list>` which takes as argument:
- an optional version `v` number (formatted as `%d.%d`)
- a `+`-separated list of additional keywords

and defines the set of keywords recognized by the lexer as the set of keywords at the version `v` of OCaml (defaulting to the current version if no versions were given) completed by the list of additional keywords.

In other words,
```
-keywords 5.2+effect
```
is equivalent to
```
-keywords 5.3
```
whereas
```bash
-keywords 4.1
```
makes the lexer read both `nonrec` and `effect` as ordinary lower case identifiers.

Moreover, codebases worrying about future compatibility can now register additional keywords with
```bash
-keywords +atomic+effect
```
Whenever the lexer encounters registered keywords with an unknown semantic (like `atomic`) in source, it raises an "unknown keyword" error.:
```
Error: atomic has been marked as a future keyword,
       but this version of OCaml cannot handle it.
```

To help with compatibility with old codebase, the new flag can be provided through OCAMLPARAM:

```bash
OCAMLPARAM=_,keywords=5.2 ocamlopt ...
```

Note that PR proposal is a slight alternative to the compiler flags for enabling and disabling keywords suggested in https://github.com/ocaml/RFCs/pull/27 