### PR TITLE
Disable flaky test under ThreadSanitizer

### DIFF
--- a/testsuite/tests/lib-systhreads/test_c_thread_register.ml
+++ b/testsuite/tests/lib-systhreads/test_c_thread_register.ml
@@ -1,6 +1,7 @@
 (* TEST
  modules = "test_c_thread_register_cstubs.c";
  include systhreads;
+ no-tsan; (* Flaky under TSan, disable until fixed (see issue #13472) *)
  hassysthreads;
  not-bsd;
  {


### PR DESCRIPTION
Test `lib-systhreads/test_c_thread_register` is flaky under ThreadSanitizer (tracking issue: #13472). I haven’t had time to investigate yet. The practical consequence is that my mailbox is clogged with reports from this Jenkins CI, and I now discard them because it is usually always this test.

Disabling this test will make the CI more useful by making me actually read the logs again, making sure unknown failures do not slip through the cracks.