### PR TITLE
Raise `Invalid_arg` if `Hashtbl.create` is given a negative init size

### DIFF
--- a/Changes
+++ b/Changes
@@ -15,6 +15,10 @@ Working version
 
 ### Standard library:
 
+* #13469, #13474: Raise Invalid_arg if Hashtbl.create is given a negative init
+  size.
+  (Antonin Décimo, report by Nikolaus Huber and Jan Mitgaard)
+
 ### Other libraries:
 
 - #13429: add `Unix.sigwait`, a binding to the `sigwait` system call;

--- a/stdlib/hashtbl.ml
+++ b/stdlib/hashtbl.ml
@@ -71,6 +71,7 @@ let rec power_2_above x n =
   else power_2_above (x * 2) n
 
 let create ?(random = Atomic.get randomized) initial_size =
+  if initial_size < 0 then invalid_arg "Hashtbl.create";
   let s = power_2_above 16 initial_size in
   let seed =
     if random then Random.State.bits (Domain.DLS.get prng_key) else 0

--- a/stdlib/hashtbl.mli
+++ b/stdlib/hashtbl.mli
@@ -99,7 +99,9 @@ val create : ?random: (* thwart tools/sync_stdlib_docs *) bool ->
    setting the [R] flag in the [OCAMLRUNPARAM] environment variable.
 
    @before 4.00 the [~random] parameter was not present and all
-   hash tables were created in non-randomized mode. *)
+   hash tables were created in non-randomized mode.
+
+   @raise Invalid_argument if [n < 0] (since 5.4).*)
 
 val clear : ('a, 'b) t -> unit
 (** Empty a hash table. Use [reset] instead of [clear] to shrink the

--- a/stdlib/moreLabels.mli
+++ b/stdlib/moreLabels.mli
@@ -116,7 +116,9 @@ module Hashtbl : sig
      setting the [R] flag in the [OCAMLRUNPARAM] environment variable.
 
      @before 4.00 the [~random] parameter was not present and all
-     hash tables were created in non-randomized mode. *)
+     hash tables were created in non-randomized mode.
+
+     @raise Invalid_argument if [n < 0] (since 5.4).*)
 
   val clear : ('a, 'b) t -> unit
   (** Empty a hash table. Use [reset] instead of [clear] to shrink the

--- a/stdlib/templates/hashtbl.template.mli
+++ b/stdlib/templates/hashtbl.template.mli
@@ -99,7 +99,9 @@ val create : ?random: (* thwart tools/sync_stdlib_docs *) bool ->
    setting the [R] flag in the [OCAMLRUNPARAM] environment variable.
 
    @before 4.00 the [~random] parameter was not present and all
-   hash tables were created in non-randomized mode. *)
+   hash tables were created in non-randomized mode.
+
+   @raise Invalid_argument if [n < 0] (since 5.4).*)
 
 val clear : ('a, 'b) t -> unit
 (** Empty a hash table. Use [reset] instead of [clear] to shrink the

--- a/testsuite/tests/backtrace/backtrace2.reference
+++ b/testsuite/tests/backtrace/backtrace2.reference
@@ -35,7 +35,7 @@ Uncaught exception Invalid_argument("index out of bounds")
 Raised by primitive operation at Backtrace2.run in file "backtrace2.ml", line 62, characters 14-22
 test_Not_found
 Uncaught exception Not_found
-Raised at Stdlib__Hashtbl.find in file "hashtbl.ml", line 542, characters 13-28
+Raised at Stdlib__Hashtbl.find in file "hashtbl.ml", line 543, characters 13-28
 Called from Backtrace2.test_Not_found in file "backtrace2.ml", line 43, characters 9-42
 Re-raised at Backtrace2.test_Not_found in file "backtrace2.ml", line 43, characters 61-70
 Called from Backtrace2.run in file "backtrace2.ml", line 62, characters 11-23
@@ -50,7 +50,7 @@ Called from CamlinternalLazy.do_force_block in file "camlinternalLazy.ml", line 
 Re-raised at CamlinternalLazy.do_force_block in file "camlinternalLazy.ml", line 56, characters 4-11
 Called from Backtrace2.run in file "backtrace2.ml", line 62, characters 11-23
 Uncaught exception Not_found
-Raised at Stdlib__Hashtbl.find in file "hashtbl.ml", line 542, characters 13-28
+Raised at Stdlib__Hashtbl.find in file "hashtbl.ml", line 543, characters 13-28
 Called from Backtrace2.test_lazy.exception_raised_internally in file "backtrace2.ml", line 50, characters 8-41
 Re-raised at CamlinternalLazy.do_force_block.(fun) in file "camlinternalLazy.ml", line 54, characters 43-50
 Called from CamlinternalLazy.do_force_block in file "camlinternalLazy.ml", line 49, characters 17-27


### PR DESCRIPTION
Fix #13469. This is akin to e.g., `List.init`.