### PR TITLE
testsuite: disable test_dropped_events on Windows

### DIFF
--- a/ocamltest/builtin_actions.ml
+++ b/ocamltest/builtin_actions.ml
@@ -120,6 +120,13 @@ let not_windows = make
     "not running on Windows"
     "running on Windows")
 
+let not_msvc = make
+  ~name:"not-msvc"
+  ~description:"Pass if not using MSVC / clang-cl"
+  (Actions_helpers.pass_or_skip (Ocamltest_config.ccomptype <> "msvc")
+    "not using MSVC / clang-cl"
+    "using MSVC / clang-cl")
+
 let is_bsd_system s =
   match s with
   | "bsd_elf" | "netbsd" | "freebsd" | "openbsd" -> true
@@ -373,6 +380,7 @@ let _ =
     libwin32unix;
     windows;
     not_windows;
+    not_msvc;
     bsd;
     not_bsd;
     linux;

--- a/testsuite/tests/lib-runtime-events/test_dropped_events.ml
+++ b/testsuite/tests/lib-runtime-events/test_dropped_events.ml
@@ -1,5 +1,5 @@
 (* TEST
- not-windows; (* FIXME: currently broken on clang-cl 64 bits *)
+ not-msvc; (* FIXME: currently flaky on clang-cl 64 bits *)
  include runtime_events;
  include unix;
  set OCAMLRUNPARAM = "e=6";

--- a/testsuite/tests/lib-runtime-events/test_dropped_events.ml
+++ b/testsuite/tests/lib-runtime-events/test_dropped_events.ml
@@ -1,4 +1,5 @@
 (* TEST
+ not-windows; (* FIXME: currently broken on clang-cl 64 bits *)
  include runtime_events;
  include unix;
  set OCAMLRUNPARAM = "e=6";


### PR DESCRIPTION
lib-runtime-events/test_dropped_events is flaky on Windows in trunk, and it makes dealing with new PRs annoying (for example it makes the CI fail for clang-cl on #13467 and #13475). There is an investigation of this test in #12397, but identifying and fixing the issue may take a while, and in the meantime we have a broken CI in trunk and this is bad.

The present PR disables the test on Windows, to hide the failure away and resume normal development life where CI is green. The failure is probably due to a real bug that should be fixed, but this bug should be only a problem for people who maintain runtime-events, not for everyone.

(Maybe the test is more fragile than just Windows and should be disabled entirely, I propose to wait to see if it is flaky in practice on non-Windows system to move to that.)