### PR TITLE
Escape `'\r'` in `sak`

### DIFF
--- a/runtime/sak.c
+++ b/runtime/sak.c
@@ -61,13 +61,15 @@ static void encode_C_literal(const char_os * path)
   putchar('"');
 
   while ((c = *path++) != 0) {
-    /* Escape \, " and \n */
+    /* Escape \, ", \n and \r */
     if (c == '\\') {
       printf("\\\\");
     } else if (c == '"') {
       printf("\\\"");
     } else if (c == '\n') {
       printf("\\n");
+    } else if (c == '\r') {
+      printf("\\r");
 #ifndef _WIN32
     /* On Unix, nothing else needs escaping */
     } else {


### PR DESCRIPTION
Add the missing `'\r'` to the characters that must be escaped in all cases in `sak`.