### PR TITLE
Fix build on arm32

### DIFF
--- a/configure
+++ b/configure
@@ -15553,21 +15553,21 @@ then :
   *) :
     if test "$ac_cv_alignof_double" -gt 4
 then :
-  align_double=true,
+  align_double=true
        printf "%s\n" "#define ARCH_ALIGN_DOUBLE 1" >>confdefs.h
 
 fi
      if test "x$ac_cv_sizeof_long" = "x8" &&
             test "$ac_cv_alignof_long" -gt 4
 then :
-  align_int64=true,
+  align_int64=true
        printf "%s\n" "#define ARCH_ALIGN_INT64 1" >>confdefs.h
 
 else $as_nop
   if test "x$ac_cv_sizeof_long_long" = "x8" &&
               test "$ac_cv_alignof_long_long" -gt 4
 then :
-  align_int64=true,
+  align_int64=true
        printf "%s\n" "#define ARCH_ALIGN_INT64 1" >>confdefs.h
 
 fi

--- a/configure.ac
+++ b/configure.ac
@@ -1239,15 +1239,15 @@ AS_IF([! $arch64],
   [AS_CASE([$target_cpu],
     [i686], [],
     [AS_IF([test "$ac_cv_alignof_double" -gt 4],
-      [align_double=true,
+      [align_double=true
        AC_DEFINE([ARCH_ALIGN_DOUBLE], [1])])
      AS_IF([test "x$ac_cv_sizeof_long" = "x8" &&
             test "$ac_cv_alignof_long" -gt 4],
-      [align_int64=true,
+      [align_int64=true
        AC_DEFINE([ARCH_ALIGN_INT64], [1])],
       [AS_IF([test "x$ac_cv_sizeof_long_long" = "x8" &&
               test "$ac_cv_alignof_long_long" -gt 4],
-      [align_int64=true,
+      [align_int64=true
        AC_DEFINE([ARCH_ALIGN_INT64], [1])])])
     ])])
 


### PR DESCRIPTION
As mentionned
[here](https://github.com/ocaml/ocaml/pull/12019#issuecomment-2376409419),
the present PR fixes #12019 by removing spurious commas which were added to
`configure.ac`, leading to wrong substitutions in the compiler's `Config`
module, in turn leading to a build failure on arm32.

The branch is currently going through precheck, see [build #984](https://ci.inria.fr/ocaml/job/precheck/984).