### PR TITLE
ocamltest should report skipped test as skipped rather than passed

### DIFF
--- a/ocamltest/main.ml
+++ b/ocamltest/main.ml
@@ -94,7 +94,7 @@ let join_result summary result =
   match result.status, summary with
   | Fail, _
   | _, Some_failure -> Some_failure
-  | Skip, All_skipped -> All_skipped
+  | (Skip | Pass), All_skipped -> All_skipped
   | _ -> No_failure
 
 let join_summaries sa sb =


### PR DESCRIPTION
Proposed fix for issue #13481 reported earlier today.