### PR TITLE
Fix ocamltest reporting logic to report skipped tests as skipped

### DIFF
--- a/Changes
+++ b/Changes
@@ -46,6 +46,9 @@ Working version
   output.
   (Romain Beauxis, review by David Allsopp)
 
+- #13484: Fix ocamltest reporting logic to report skipped tests as skipped
+  (Tim McGilchrist, Miod Vallat, review by ???)
+
 ### Manual and documentation:
 
 ### Compiler user-interface and warnings:

--- a/ocamltest/main.ml
+++ b/ocamltest/main.ml
@@ -92,10 +92,11 @@ type result_summary = No_failure | Some_failure | All_skipped
 let join_result summary result =
   let open Result in
   match result.status, summary with
-  | Fail, _
-  | _, Some_failure -> Some_failure
-  | (Skip | Pass), All_skipped -> All_skipped
-  | _ -> No_failure
+  | Fail, (All_skipped | Some_failure | No_failure) -> Some_failure
+  | Skip, (All_skipped | No_failure) -> All_skipped
+  | Skip, Some_failure -> Some_failure
+  | Pass, Some_failure -> Some_failure
+  | Pass, (All_skipped | No_failure) -> No_failure
 
 let join_summaries sa sb =
   match sa, sb with


### PR DESCRIPTION
Fix for https://github.com/ocaml/ocaml/issues/13481  cc @shindere 

Currently ocamltest is incorrectly classifying skipped and passing tests as skipped.

For example running the `native-debugger` tests on Linux arm64 currently gives:
```shell
$ make one DIR=tests/native-debugger
Running tests from 'tests/native-debugger' ...
 ... testing 'linux-gdb-amd64-test.ml' => passed
 ... testing 'linux-gdb-arm64-test.ml' => failed
....
List of failed tests:
    tests/native-debugger/linux-gdb-arm64-test.ml
    tests/native-debugger/linux-lldb-arm64-test.ml

Summary:
     5 tests passed
     0 tests skipped
     2 tests failed
     0 tests not started (parent test skipped or failed)
     0 unexpected errors
     7 tests considered
#### Something failed. Exiting with error status.

make[1]: *** [Makefile:329: report] Error 4
make[1]: Leaving directory '/home/tsmc/ocaml/testsuite'
make: *** [Makefile:262: one] Error 2
```
The `linux-gdb-amd64-test.ml` is marked as passing when it should be skipped since I'm using an ARM64 CPU.

With this change the skipped tests are correctly reported and the failing tests 😢 are also reported correctly:
```shell
$ make one DIR=tests/native-debugger
Running tests from 'tests/native-debugger' ...
....
List of skipped tests:
    tests/native-debugger/linux-gdb-amd64-test.ml
    tests/native-debugger/linux-gdb-riscv-test.ml
    tests/native-debugger/linux-lldb-amd64-test.ml
    tests/native-debugger/macos-lldb-amd64.ml
    tests/native-debugger/macos-lldb-arm64.ml

List of failed tests:
    tests/native-debugger/linux-gdb-arm64-test.ml
    tests/native-debugger/linux-lldb-arm64-test.ml

Summary:
     0 tests passed
     5 tests skipped
     2 tests failed
     0 tests not started (parent test skipped or failed)
     0 unexpected errors
     7 tests considered
#### Something failed. Exiting with error status.

make[1]: *** [Makefile:329: report] Error 4
make[1]: Leaving directory '/home/tsmc/ocaml/testsuite'
make: *** [Makefile:262: one] Error 2
```
