### PR TITLE
Include `CAML_LD_LIBRARY_PATH` in `ocamlrun -config`

### DIFF
--- a/Changes
+++ b/Changes
@@ -25,6 +25,11 @@ Working version
   pointers in C code (take 3).
   (Antonin Décimo, review by Stephen Dolan and Miod Vallat)
 
+- #13492: Parse the CAML_LD_LIBRARY_PATH environment variable for the
+  shared_libs_path item in `ocamlrun -config` in addition to displaying the
+  entries found in ld.conf.
+  (David Allsopp, review by ???)
+
 ### Code generation and optimizations:
 
 ### Standard library:

--- a/runtime/startup_byt.c
+++ b/runtime/startup_byt.c
@@ -422,6 +422,8 @@ static void do_print_config(void)
 
   /* Parse ld.conf and print the effective search path */
   puts("shared_libs_path:");
+  caml_decompose_path(&caml_shared_libs_path,
+                      caml_secure_getenv(T("CAML_LD_LIBRARY_PATH")));
   caml_parse_ld_conf();
   for (int i = 0; i < caml_shared_libs_path.size; i++) {
     dir = caml_shared_libs_path.contents[i];


### PR DESCRIPTION
#9284 added a `-config` diagnostic argument to `ocamlrun` (amongst other things). It includes an item `shared_libs_path` which displays the entries found in `ld.conf`. This list doesn't include those entries included in the `CAML_LD_LIBRARY_PATH` environment variable, but the search for `ld.conf` is affected by the `OCAMLLIB` environment variable which is gloriously inconsistent.

This little PR fixes the inconsistency (cf. `caml_build_primitive_table` in runtime/dynlink.c)