### PR TITLE
Improve linking error for force-custom libraries

### DIFF
--- a/Changes
+++ b/Changes
@@ -61,6 +61,10 @@ Working version
   in OCAMLRUNPARAM
   (Gabriel Scherer, review by Vincent Laviron)
 
+- #13493: Clearer error message in ocamlc for conflicting link options for
+  C stubs when shared libraries are not available.
+  (David Allsopp, review by Gabriel Scherer)
+
 ### Internal/compiler-libs changes:
 
 - #13425: undocumented -dmatchcomp flag for the debug

--- a/bytecomp/bytelink.mli
+++ b/bytecomp/bytelink.mli
@@ -41,6 +41,7 @@ type error =
   | Cannot_open_dll of filepath
   | Camlheader of string * filepath
   | Link_error of Linkdeps.error
+  | Needs_custom_runtime of filepath
 
 exception Error of error
 


### PR DESCRIPTION
This little fix came about from my various forays into our linking mechanisms for the relocatable compiler work. Having been hit by it, it seemed worth clarifying. If the compiler is configured with `--disable-shared`, one can encounter the following confusing error:

```console
$ ocamlc -use-prims runtime/primitives -o hello -I +unix unix.cma foo.ml
File "foo.ml", line 1:
Error: I/O error: dllunixbyt.so: No such file or directory
```

The error is indeed to be expected; there cannot be `dllunixbyt.so` in a statically-linked compiler. This PR makes the error slightly less unclear:

```console
$ ocamlc -use-prims runtime/primitives -o hello -I +unix unix.cma foo.ml
File "foo.ml", line 1:
Error: unix.cma requires a custom runtime; link with -noautolink or without -use-prims and -use-runtime
```