### PR TITLE
Use Windows symlinks when available

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -59,6 +59,7 @@ META.in                  typo.missing-header
 # Github templates and scripts lack headers, have long lines
 /.github/**              typo.missing-header typo.long-line=may typo.very-long-line=may
 /.github/workflows/build-cross.yml typo.non-ascii
+/.github/workflows/build-msvc.yml typo.utf8
 
 /.mailmap                typo.long-line typo.missing-header typo.non-ascii
 /CONTRIBUTING.md         typo.non-ascii=may

--- a/.github/workflows/build-msvc.yml
+++ b/.github/workflows/build-msvc.yml
@@ -95,10 +95,12 @@ jobs:
           CC: ${{ matrix.cc }}
         run: >-
           eval $(tools/msvs-promote-path) ;
-          if ! ./configure --cache-file=config.cache --host=$HOST CC=$CC ; then
+          if ! ./configure --cache-file=config.cache --host=$HOST CC=$CC
+          --prefix "$PROGRAMFILES/Бактріан🐫"; then
           rm -rf config.cache ;
           failed=0 ;
-          ./configure --cache-file=config.cache --host=$HOST CC=$CC \
+          ./configure --cache-file=config.cache --host=$HOST CC=$CC
+          --prefix "$PROGRAMFILES/Бактріан🐫"
           || failed=$?;
           if ((failed)) ; then cat config.log ; exit $failed ; fi ;
           fi ;
@@ -136,3 +138,7 @@ jobs:
         run: >-
           eval $(tools/msvs-promote-path) ;
           make -j tests ;
+
+      - name: Install the compiler
+        shell: bash
+        run: make install

--- a/Changes
+++ b/Changes
@@ -233,6 +233,10 @@ Working version
   team.
   (Nathan Rebours, review by Florian Angeletti)
 
+- #13494: Use native symlinks on Windows for the OCaml installation, reducing
+  disk usage considerably.
+  (David Allsopp, review by Nicolás Ojeda Bär and Gabriel Scherer)
+
 * #13526: Simplify the build of cross compilers
   This replaces the configure `--with-target-bindir` option by an equivalent
   `TARGET_BINDIR` variable

--- a/Makefile.common
+++ b/Makefile.common
@@ -467,3 +467,12 @@ endef # INSTALL_STRIPPED_BYTE_PROG
 # boot/ as part of coldstart. See read_runtime_launch_info in
 # bytecomp/bytelink.ml for further details.
 HEADER_NAME = runtime-launch-info
+
+ifeq "$(UNIX_OR_WIN32)" "win32"
+# Ensure that no command can create Cygwin symbolic links by ensuring that
+# symlink(2) will fail if native NTFS symlinks aren't available.
+export CYGWIN := $(strip \
+  $(filter-out winsymlinks winsymlinks:%, $(CYGWIN)) winsymlinks:nativestrict)
+export MSYS := $(strip \
+  $(filter-out winsymlinks winsymlinks:%, $(MSYS)) winsymlinks:nativestrict)
+endif

--- a/aclocal.m4
+++ b/aclocal.m4
@@ -545,3 +545,18 @@ AC_DEFUN([OCAML_CC_SUPPORTS_LABELS_AS_VALUES], [
       [Define if the C compiler supports the labels as values extension.])
   fi
 ])
+
+AC_DEFUN([OCAML_CHECK_LN_ON_WINDOWS], [
+  AC_MSG_CHECKING([for a workable solution for ln -sf])
+  ln -sf configure conftestLink
+  AS_IF([test -z "$(cmd /c dir conftestLink 2>/dev/null | grep -F SYMLINK)"],
+    [rm -f conftestLink
+    CYGWIN=winsymlinks:native ln -sf configure conftestLink
+    AS_IF([test -z "$(cmd /c dir conftestLink 2>/dev/null | grep -F SYMLINK)"],
+      [ln='cp -pf'],
+      [ln='CYGWIN=winsymlinks:native ln -sf']
+    )],
+    [ln='ln -sf']
+  )
+  AC_MSG_RESULT([$ln])
+])

--- a/aclocal.m4
+++ b/aclocal.m4
@@ -548,15 +548,11 @@ AC_DEFUN([OCAML_CC_SUPPORTS_LABELS_AS_VALUES], [
 
 AC_DEFUN([OCAML_CHECK_LN_ON_WINDOWS], [
   AC_MSG_CHECKING([for a workable solution for ln -sf])
-  ln -sf configure conftestLink
-  AS_IF([test -z "$(cmd /c dir conftestLink 2>/dev/null | grep -F SYMLINK)"],
-    [rm -f conftestLink
-    CYGWIN=winsymlinks:native ln -sf configure conftestLink
-    AS_IF([test -z "$(cmd /c dir conftestLink 2>/dev/null | grep -F SYMLINK)"],
-      [ln='cp -pf'],
-      [ln='CYGWIN=winsymlinks:native ln -sf']
-    )],
-    [ln='ln -sf']
+  AS_IF([m4_normalize(MSYS=winsymlinks:nativestrict
+                      CYGWIN=winsymlinks:nativestrict
+                      ln -sf configure conftestLink 2>/dev/null)],
+    [ln='ln -sf'],
+    [ln='cp -pf']
   )
   AC_MSG_RESULT([$ln])
 ])

--- a/configure
+++ b/configure
@@ -14728,7 +14728,28 @@ ocamlsrcdir=${ocamlsrcdir%X}
 
 case $host in #(
   *-*-mingw32*|*-pc-windows) :
-    ln='cp -pf'
+
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for a workable solution for ln -sf" >&5
+printf %s "checking for a workable solution for ln -sf... " >&6; }
+  ln -sf configure conftestLink
+  if test -z "$(cmd /c dir conftestLink 2>/dev/null | grep -F SYMLINK)"
+then :
+  rm -f conftestLink
+    CYGWIN=winsymlinks:native ln -sf configure conftestLink
+    if test -z "$(cmd /c dir conftestLink 2>/dev/null | grep -F SYMLINK)"
+then :
+  ln='cp -pf'
+else $as_nop
+  ln='CYGWIN=winsymlinks:native ln -sf'
+
+fi
+else $as_nop
+  ln='ln -sf'
+
+fi
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ln" >&5
+printf "%s\n" "$ln" >&6; }
+
     ocamlsrcdir="$(LC_ALL=C.UTF-8 cygpath -w -- "$ocamlsrcdir")" ;; #(
   *) :
     ln='ln -sf' ;;

--- a/configure
+++ b/configure
@@ -14731,20 +14731,11 @@ case $host in #(
 
   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for a workable solution for ln -sf" >&5
 printf %s "checking for a workable solution for ln -sf... " >&6; }
-  ln -sf configure conftestLink
-  if test -z "$(cmd /c dir conftestLink 2>/dev/null | grep -F SYMLINK)"
+  if MSYS=winsymlinks:nativestrict CYGWIN=winsymlinks:nativestrict ln -sf configure conftestLink 2>/dev/null
 then :
-  rm -f conftestLink
-    CYGWIN=winsymlinks:native ln -sf configure conftestLink
-    if test -z "$(cmd /c dir conftestLink 2>/dev/null | grep -F SYMLINK)"
-then :
-  ln='cp -pf'
-else $as_nop
-  ln='CYGWIN=winsymlinks:native ln -sf'
-
-fi
-else $as_nop
   ln='ln -sf'
+else $as_nop
+  ln='cp -pf'
 
 fi
   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ln" >&5

--- a/configure.ac
+++ b/configure.ac
@@ -768,7 +768,7 @@ ocamlsrcdir=${ocamlsrcdir%X}
 
 AS_CASE([$host],
   [*-*-mingw32*|*-pc-windows],
-    [ln='cp -pf'
+    [OCAML_CHECK_LN_ON_WINDOWS
     ocamlsrcdir="$(LC_ALL=C.UTF-8 cygpath -w -- "$ocamlsrcdir")"],
   [ln='ln -sf'])
 


### PR DESCRIPTION
The impact of this is not as profound as it was prior to #11993, but it still saves in >60MiB on current trunk installations on Windows.

The mechanism used for creating native Windows symlinks is as introduced in #12198 - Cygwin will create native symlinks if `winsymlinks:native` is included in the `CYGWIN` environment variable (the MSYS2 fork of Cygwin uses the `MSYS` environment variable instead). The behaviour under this setting is to use native symlinks if available and fallback to emulation otherwise. If instead of `:native`, `:nativestrict` is used, then `ln -s` fails if native symlinks cannot be created. This creates a simple test in `configure`, and we fallback to the previous `cp -pf` otherwise.