### PR TITLE
Silence ld warning with libasmrun_shared.so

### DIFF
--- a/Changes
+++ b/Changes
@@ -30,6 +30,11 @@ Working version
   entries found in ld.conf.
   (David Allsopp, review by Stephen Dolan)
 
+- #13496: Add missing .type and .size directives to main frametable to silence
+  warnings from the linker when using libasmrun_shared on amd64 and power. The
+  other backends already carried these directives.
+  (David Allsopp, review by Tim McGilchrist and Miod Vallat)
+
 - #13500: Add frame pointers support for ARM64 on Linux and macOS.
   (Tim McGilchrist, review by KC Sivaramakrishnan, Fabrice Buoro
    and Miod Vallat)

--- a/runtime/amd64.S
+++ b/runtime/amd64.S
@@ -74,6 +74,11 @@
 
 #endif
 
+#define OBJECT(name) \
+        .globl name; \
+        .align EIGHT_ALIGN; \
+        name:
+
 #if defined(SYS_linux) || defined(SYS_gnu)
 #define ENDFUNCTION(name) \
         .size name, . - name
@@ -1324,9 +1329,7 @@ ENDFUNCTION(G(caml_assert_stack_invariants))
 G(caml_system__code_end):
 
         .data
-        .globl  G(caml_system.frametable)
-        .align  EIGHT_ALIGN
-G(caml_system.frametable):
+OBJECT(G(caml_system.frametable))
         .quad   2           /* two descriptors */
         .quad   LBL(108)    /* return address into callback */
         .value  -1          /* negative frame size => use callback link */
@@ -1335,7 +1338,7 @@ G(caml_system.frametable):
         .quad   LBL(frame_runstack) /* return address into fiber_val_handler */
         .value  -1          /* negative frame size => use callback link */
         .value  0           /* no roots here */
-        ENDOBJECT(G(caml_system.frametable))
+ENDOBJECT(G(caml_system.frametable))
 
 #if defined(SYS_macosx)
         .literal16

--- a/runtime/amd64.S
+++ b/runtime/amd64.S
@@ -77,8 +77,12 @@
 #if defined(SYS_linux) || defined(SYS_gnu)
 #define ENDFUNCTION(name) \
         .size name, . - name
+#define ENDOBJECT(name) \
+        .type name, @object; \
+        .size name, . - name;
 #else
 #define ENDFUNCTION(name)
+#define ENDOBJECT(name)
 #endif
 
 #include "../runtime/caml/asm.h"
@@ -1331,6 +1335,7 @@ G(caml_system.frametable):
         .quad   LBL(frame_runstack) /* return address into fiber_val_handler */
         .value  -1          /* negative frame size => use callback link */
         .value  0           /* no roots here */
+        ENDOBJECT(G(caml_system.frametable))
 
 #if defined(SYS_macosx)
         .literal16

--- a/runtime/power.S
+++ b/runtime/power.S
@@ -96,7 +96,17 @@ caml_hot.code_end:
 .endm
 
 .macro ENDFUNCTION name
-       .size \name, . - \name
+        .size \name, . - \name
+.endm
+
+.macro OBJECT name
+        .globl \name
+        .type \name, @object
+\name:
+.endm
+
+.macro ENDOBJECT name
+        .size \name, . - \name
 .endm
 
 /* Function prologue and epilogue */
@@ -1181,9 +1191,7 @@ caml_system__code_end:
 /* Frame table */
 
         .section ".data"
-        .globl  caml_system.frametable
-        .type   caml_system.frametable, @object
-caml_system.frametable:
+OBJECT caml_system.frametable
         .quad   2               /* two descriptors */
         .quad   .Lcaml_retaddr + 4  /* return address into callback */
         .short  -1              /* negative frame size => use callback link */
@@ -1193,7 +1201,7 @@ caml_system.frametable:
         .short  -1              /* negative frame size => use callback link */
         .short  0               /* no roots here */
         .align 3
-        .size   caml_system.frametable, .-caml_system.frametable
+ENDOBJECT caml_system.frametable
 
 /* TOC entries */
 

--- a/runtime/power.S
+++ b/runtime/power.S
@@ -1193,6 +1193,7 @@ caml_system.frametable:
         .short  -1              /* negative frame size => use callback link */
         .short  0               /* no roots here */
         .align 3
+        .size   caml_system.frametable, .-caml_system.frametable
 
 /* TOC entries */
 

--- a/runtime/s390x.S
+++ b/runtime/s390x.S
@@ -64,6 +64,14 @@ caml_hot.code_end:
 
 #define ENDFUNCTION(name)
 
+#define OBJECT(name) \
+        .align 8; \
+        .globl name; \
+        .type name, @object; \
+        name:
+
+#define ENDOBJECT(name)
+
 /* Stack space to be reserved by the caller of a C function */
 #define RESERVED_STACK          160
 
@@ -1199,10 +1207,7 @@ caml_system__code_end:
 /* Frame table */
 
         .section ".data"
-        .align 8
-        .globl  caml_system.frametable
-        .type   caml_system.frametable, @object
-caml_system.frametable:
+OBJECT(caml_system.frametable)
         .quad   2               /* two descriptors */
         .quad   LBL(caml_retaddr)  /* return address into callback */
         .short  -1              /* negative size count => use callback link */
@@ -1212,6 +1217,7 @@ caml_system.frametable:
         .short  -1              /* negative size count => use callback link */
         .short  0               /* no roots here */
         .align  8
+ENDOBJECT(caml_system.frametable)
 
 /* Mark stack as non-executable */
         .section .note.GNU-stack,"",%progbits


### PR DESCRIPTION
The amd64 and power backends were missing .type and .size directives on caml_system.frametable which causes a warning from ld when linking against the shared runtime.

Prior to this PR, when linking with libasmrun.so, ld emits:

```
/usr/bin/ld: warning: type and size of dynamic symbol `caml_system.frametable' are not defined
```

I'd like to put this on 4.14, where the i386 backend also has the same issue.