### PR TITLE
Add `caml_stat_char_array_{to,of}_os`

### DIFF
--- a/Changes
+++ b/Changes
@@ -14,6 +14,13 @@ Working version
 
 ### Runtime system:
 
+* #11449, #13497: Add caml_stat_char_array_{to,of}_os functions allowing
+  conversion of string data which may contain NUL characters. Correct
+  implementation of caml_stat_strdup_to_utf16 to raise Out_of_memory instead of
+  returning of NULL (the behaviour of caml_stat_strdup_to_os was inconsistent
+  between Unix/Windows).
+  (David Allsopp, review by Nick Barnes, Antonin Décimo and Miod Vallat)
+
 - #13352: Concurrency refactors and cleanups.
   (Antonin Décimo, review by Gabriel Scherer, David Allsopp, and Miod Vallat)
 
@@ -34,11 +41,6 @@ Working version
   warnings from the linker when using libasmrun_shared on amd64 and power. The
   other backends already carried these directives.
   (David Allsopp, review by Tim McGilchrist and Miod Vallat)
-
-* #13497: Correct implementation of caml_stat_strdup_to_utf16 to raise
-  Out_of_memory instead of returning of NULL (the behaviour of
-  caml_stat_strdup_to_os was inconsistent between Unix/Windows).
-  (David Allsopp, review by Nick Barnes, Antonin Décimo and Miod Vallat)
 
 - #13500: Add frame pointers support for ARM64 on Linux and macOS.
   (Tim McGilchrist, review by KC Sivaramakrishnan, Fabrice Buoro

--- a/Changes
+++ b/Changes
@@ -35,6 +35,11 @@ Working version
   other backends already carried these directives.
   (David Allsopp, review by Tim McGilchrist and Miod Vallat)
 
+* #13497: Correct implementation of caml_stat_strdup_to_utf16 to raise
+  Out_of_memory instead of returning of NULL (the behaviour of
+  caml_stat_strdup_to_os was inconsistent between Unix/Windows).
+  (David Allsopp, review by Nick Barnes, Antonin Décimo and Miod Vallat)
+
 - #13500: Add frame pointers support for ARM64 on Linux and macOS.
   (Tim McGilchrist, review by KC Sivaramakrishnan, Fabrice Buoro
    and Miod Vallat)

--- a/runtime/caml/memory.h
+++ b/runtime/caml/memory.h
@@ -172,6 +172,7 @@ CAMLextern wchar_t* caml_stat_wcsdup_noexc(const wchar_t *s);
    implementation of the Windows-only functions
    caml_stat_char_array_{to,from}_utf16.
 */
+CAMLmalloc(caml_stat_free, 1, 2) CAMLreturns_nonnull()
 CAMLextern caml_stat_string caml_stat_memdup(const char *s, asize_t size,
                                              asize_t *out_size);
 

--- a/runtime/caml/memory.h
+++ b/runtime/caml/memory.h
@@ -166,6 +166,15 @@ CAMLalloc(caml_stat_free, 1)
 CAMLextern wchar_t* caml_stat_wcsdup_noexc(const wchar_t *s);
 #endif
 
+/* [caml_stat_memdup(s, size, &out_size)] returns a copy of the first [size]
+   bytes of [s] (which may include NUL characters). If [out_size] is not [NULL],
+   then [size] is stored in [*out_size]. This function is the "dummy" Unix
+   implementation of the Windows-only functions
+   caml_stat_char_array_{to,from}_utf16.
+*/
+CAMLextern caml_stat_string caml_stat_memdup(const char *s, asize_t size,
+                                             asize_t *out_size);
+
 /* [caml_stat_strconcat(nargs, strings)] concatenates null-terminated [strings]
    (an array of [char*] of size [nargs]) into a new string, dropping all NULs,
    except for the very last one. It throws an OCaml exception in case the

--- a/runtime/caml/misc.h
+++ b/runtime/caml/misc.h
@@ -523,6 +523,7 @@ extern double caml_log1p(double);
 #define caml_stat_strconcat_os caml_stat_wcsconcat
 
 #define caml_stat_strdup_to_os caml_stat_strdup_to_utf16
+#define caml_stat_strdup_noexc_to_os caml_stat_strdup_noexc_to_utf16
 #define caml_stat_strdup_of_os caml_stat_strdup_of_utf16
 #define caml_stat_strdup_noexc_of_os caml_stat_strdup_noexc_of_utf16
 #define caml_copy_string_of_os caml_copy_string_of_utf16
@@ -565,6 +566,7 @@ extern double caml_log1p(double);
 #define caml_stat_strconcat_os caml_stat_strconcat
 
 #define caml_stat_strdup_to_os caml_stat_strdup
+#define caml_stat_strdup_noexc_to_os caml_stat_strdup_noexc
 #define caml_stat_strdup_of_os caml_stat_strdup
 #define caml_stat_strdup_noexc_of_os caml_stat_strdup_noexc
 #define caml_copy_string_of_os caml_copy_string

--- a/runtime/caml/misc.h
+++ b/runtime/caml/misc.h
@@ -526,6 +526,8 @@ extern double caml_log1p(double);
 #define caml_stat_strdup_noexc_to_os caml_stat_strdup_noexc_to_utf16
 #define caml_stat_strdup_of_os caml_stat_strdup_of_utf16
 #define caml_stat_strdup_noexc_of_os caml_stat_strdup_noexc_of_utf16
+#define caml_stat_char_array_to_os caml_stat_char_array_to_utf16
+#define caml_stat_char_array_of_os caml_stat_char_array_of_utf16
 #define caml_copy_string_of_os caml_copy_string_of_utf16
 
 #else /* _WIN32 */
@@ -569,6 +571,8 @@ extern double caml_log1p(double);
 #define caml_stat_strdup_noexc_to_os caml_stat_strdup_noexc
 #define caml_stat_strdup_of_os caml_stat_strdup
 #define caml_stat_strdup_noexc_of_os caml_stat_strdup_noexc
+#define caml_stat_char_array_to_os caml_stat_memdup
+#define caml_stat_char_array_of_os caml_stat_memdup
 #define caml_copy_string_of_os caml_copy_string
 
 #endif /* _WIN32 */

--- a/runtime/caml/osdeps.h
+++ b/runtime/caml/osdeps.h
@@ -175,6 +175,7 @@ extern unsigned short caml_win32_revision;
    If allocation fails, this returns NULL. This function never raises any
    exceptions when [s] is valid UTF-8 but may raise [Sys_error] if it is not.
 */
+CAMLalloc(caml_stat_free, 1)
 CAMLextern wchar_t* caml_stat_strdup_noexc_to_utf16(const char *s);
 
 /* [caml_stat_strdup_to_utf16(s)] returns a NUL-terminated copy of [s],
@@ -188,6 +189,7 @@ CAMLextern wchar_t* caml_stat_strdup_noexc_to_utf16(const char *s);
    If allocation fails, this raises Out_of_memory. This function may also raise
    [Sys_error] if [s] is not valid UTF-8.
 */
+CAMLalloc(caml_stat_free, 1) CAMLreturns_nonnull()
 CAMLextern wchar_t* caml_stat_strdup_to_utf16(const char *s);
 
 /* [caml_stat_strdup_noexc_of_utf16(s)] returns a NUL-terminated copy of [s],
@@ -200,6 +202,7 @@ CAMLextern wchar_t* caml_stat_strdup_to_utf16(const char *s);
    If allocation fails, this returns NULL. This function never raises any
    exceptions when [s] is valid UTF-16 but may raise [Sys_error] if it is not.
 */
+CAMLalloc(caml_stat_free, 1)
 CAMLextern char* caml_stat_strdup_noexc_of_utf16(const wchar_t *s);
 
 /* [caml_stat_strdup_of_utf16(s)] returns a NUL-terminated copy of [s],
@@ -212,6 +215,7 @@ CAMLextern char* caml_stat_strdup_noexc_of_utf16(const wchar_t *s);
    If allocation fails, this raises Out_of_memory. This function may also raise
    [Sys_error] if [s] is not valid UTF-16.
 */
+CAMLalloc(caml_stat_free, 1) CAMLreturns_nonnull()
 CAMLextern char* caml_stat_strdup_of_utf16(const wchar_t *s);
 
 /* [caml_stat_char_array_to_utf16(s, size, &out_size)] returns a copy of the
@@ -230,6 +234,7 @@ CAMLextern char* caml_stat_strdup_of_utf16(const wchar_t *s);
    If allocation fails, this raises Out_of_memory. This function may also raise
    [Sys_error] if [s] is not valid UTF-8.
 */
+CAMLmalloc(caml_stat_free, 1, 2) CAMLreturns_nonnull()
 CAMLextern wchar_t *caml_stat_char_array_to_utf16(const char *s, size_t size,
                                                   size_t *out_size);
 
@@ -248,6 +253,7 @@ CAMLextern wchar_t *caml_stat_char_array_to_utf16(const char *s, size_t size,
    If allocation fails, this raises Out_of_memory. This function may also raise
    [Sys_error] if [s] is not valid UTF-16.
 */
+CAMLalloc(caml_stat_free, 1) CAMLreturns_nonnull()
 CAMLextern char *caml_stat_char_array_of_utf16(const wchar_t *s, size_t size,
                                                size_t *out_size);
 

--- a/runtime/caml/osdeps.h
+++ b/runtime/caml/osdeps.h
@@ -164,13 +164,27 @@ extern unsigned short caml_win32_minor;
 extern unsigned short caml_win32_build;
 extern unsigned short caml_win32_revision;
 
+/* [caml_stat_strdup_noexc_to_utf16(s)] returns a null-terminated copy of [s],
+   re-encoded in UTF-16.  The encoding of [s] is assumed to be UTF-8 if
+   [caml_windows_unicode_runtime_enabled] is non-zero **and** [s] is valid
+   UTF-8, or the current Windows code page otherwise.
+
+   The returned string is allocated with [caml_stat_alloc_noexc], so it should
+   be freed using [caml_stat_free].
+
+   If allocation fails, this returns NULL.
+*/
+CAMLextern wchar_t* caml_stat_strdup_noexc_to_utf16(const char *s);
+
 /* [caml_stat_strdup_to_utf16(s)] returns a null-terminated copy of [s],
    re-encoded in UTF-16.  The encoding of [s] is assumed to be UTF-8 if
    [caml_windows_unicode_runtime_enabled] is non-zero **and** [s] is valid
    UTF-8, or the current Windows code page otherwise.
 
-   The returned string is allocated with [caml_stat_alloc], so it should be free
-   using [caml_stat_free].
+   The returned string is allocated with [caml_stat_alloc], so it should be
+   freed using [caml_stat_free].
+
+   If allocation fails, this raises Out_of_memory.
 */
 CAMLextern wchar_t* caml_stat_strdup_to_utf16(const char *s);
 
@@ -178,8 +192,8 @@ CAMLextern wchar_t* caml_stat_strdup_to_utf16(const char *s);
    re-encoded in UTF-8 if [caml_windows_unicode_runtime_enabled] is non-zero or
    the current Windows code page otherwise.
 
-   The returned string is allocated with [caml_stat_alloc_noexc], so
-   it should be freed using [caml_stat_free].
+   The returned string is allocated with [caml_stat_alloc_noexc], so it should
+   be freed using [caml_stat_free].
 
    If allocation fails, this returns NULL.
 */
@@ -189,8 +203,8 @@ CAMLextern char* caml_stat_strdup_noexc_of_utf16(const wchar_t *s);
    re-encoded in UTF-8 if [caml_windows_unicode_runtime_enabled] is non-zero or
    the current Windows code page otherwise.
 
-   The returned string is allocated with [caml_stat_alloc_noexc], so
-   it should be freed using [caml_stat_free].
+   The returned string is allocated with [caml_stat_alloc], so it should be
+   freed using [caml_stat_free].
 
    If allocation fails, this raises Out_of_memory.
 */

--- a/runtime/caml/osdeps.h
+++ b/runtime/caml/osdeps.h
@@ -164,7 +164,7 @@ extern unsigned short caml_win32_minor;
 extern unsigned short caml_win32_build;
 extern unsigned short caml_win32_revision;
 
-/* [caml_stat_strdup_noexc_to_utf16(s)] returns a null-terminated copy of [s],
+/* [caml_stat_strdup_noexc_to_utf16(s)] returns a NUL-terminated copy of [s],
    re-encoded in UTF-16.  The encoding of [s] is assumed to be UTF-8 if
    [caml_windows_unicode_runtime_enabled] is non-zero **and** [s] is valid
    UTF-8, or the current Windows code page otherwise.
@@ -172,11 +172,12 @@ extern unsigned short caml_win32_revision;
    The returned string is allocated with [caml_stat_alloc_noexc], so it should
    be freed using [caml_stat_free].
 
-   If allocation fails, this returns NULL.
+   If allocation fails, this returns NULL. This function never raises any
+   exceptions when [s] is valid UTF-8 but may raise [Sys_error] if it is not.
 */
 CAMLextern wchar_t* caml_stat_strdup_noexc_to_utf16(const char *s);
 
-/* [caml_stat_strdup_to_utf16(s)] returns a null-terminated copy of [s],
+/* [caml_stat_strdup_to_utf16(s)] returns a NUL-terminated copy of [s],
    re-encoded in UTF-16.  The encoding of [s] is assumed to be UTF-8 if
    [caml_windows_unicode_runtime_enabled] is non-zero **and** [s] is valid
    UTF-8, or the current Windows code page otherwise.
@@ -184,31 +185,71 @@ CAMLextern wchar_t* caml_stat_strdup_noexc_to_utf16(const char *s);
    The returned string is allocated with [caml_stat_alloc], so it should be
    freed using [caml_stat_free].
 
-   If allocation fails, this raises Out_of_memory.
+   If allocation fails, this raises Out_of_memory. This function may also raise
+   [Sys_error] if [s] is not valid UTF-8.
 */
 CAMLextern wchar_t* caml_stat_strdup_to_utf16(const char *s);
 
-/* [caml_stat_strdup_noexc_of_utf16(s)] returns a null-terminated copy of [s],
+/* [caml_stat_strdup_noexc_of_utf16(s)] returns a NUL-terminated copy of [s],
    re-encoded in UTF-8 if [caml_windows_unicode_runtime_enabled] is non-zero or
    the current Windows code page otherwise.
 
    The returned string is allocated with [caml_stat_alloc_noexc], so it should
    be freed using [caml_stat_free].
 
-   If allocation fails, this returns NULL.
+   If allocation fails, this returns NULL. This function never raises any
+   exceptions when [s] is valid UTF-16 but may raise [Sys_error] if it is not.
 */
 CAMLextern char* caml_stat_strdup_noexc_of_utf16(const wchar_t *s);
 
-/* [caml_stat_strdup_of_utf16(s)] returns a null-terminated copy of [s],
+/* [caml_stat_strdup_of_utf16(s)] returns a NUL-terminated copy of [s],
    re-encoded in UTF-8 if [caml_windows_unicode_runtime_enabled] is non-zero or
    the current Windows code page otherwise.
 
    The returned string is allocated with [caml_stat_alloc], so it should be
    freed using [caml_stat_free].
 
-   If allocation fails, this raises Out_of_memory.
+   If allocation fails, this raises Out_of_memory. This function may also raise
+   [Sys_error] if [s] is not valid UTF-16.
 */
 CAMLextern char* caml_stat_strdup_of_utf16(const wchar_t *s);
+
+/* [caml_stat_char_array_to_utf16(s, size, &out_size)] returns a copy of the
+   first [size] bytes of [s] re-encoded in UTF-16. [s] does not have to be NUL-
+   terminated and may contain embedded NUL characters. The encoding of [s] is
+   assumed to be UTF-8 if [caml_windows_unicode_runtime_enabled] is non-zero
+   **and** [s] is valid UTF-8, or the current Windows code page otherwise. If
+   [out_size] is not [NULL], then the number of UTF-16 code units in the result
+   is recorded in [*out_size].
+
+   [size] must be greater than zero.
+
+   The returned buffer is allocated with [caml_stat_alloc], so it should be
+   freed using [caml_stat_free].
+
+   If allocation fails, this raises Out_of_memory. This function may also raise
+   [Sys_error] if [s] is not valid UTF-8.
+*/
+CAMLextern wchar_t *caml_stat_char_array_to_utf16(const char *s, size_t size,
+                                                  size_t *out_size);
+
+/* [caml_stat_char_array_of_utf16(s, size, &out_size)] returns a copy of the
+   first [size] UTF-16 code units of [s] re-encoded in UTF-8 if
+   [caml_windows_unicode_runtime_enabled] is non-zero or the current Windows
+   code page otherwise. [s] does not have to be NUL-terminated and may contain
+   embedded NUL characters. If [out_size] is not [NULL], then the size of the
+   result in bytes recorded in [*out_size].
+
+   [size] must be greater than zero.
+
+   The returned buffer is allocated with [caml_stat_alloc], so it should be
+   freed using [caml_stat_free].
+
+   If allocation fails, this raises Out_of_memory. This function may also raise
+   [Sys_error] if [s] is not valid UTF-16.
+*/
+CAMLextern char *caml_stat_char_array_of_utf16(const wchar_t *s, size_t size,
+                                               size_t *out_size);
 
 /* [caml_copy_string_of_utf16(s)] returns an OCaml string containing a copy of
    [s] re-encoded in UTF-8 if [caml_windows_unicode_runtime_enabled] is non-zero

--- a/runtime/memory.c
+++ b/runtime/memory.c
@@ -729,6 +729,17 @@ CAMLexport caml_stat_string caml_stat_strdup(const char *s)
   return result;
 }
 
+CAMLexport caml_stat_string caml_stat_memdup(const char *s, asize_t size,
+                                             asize_t *out_size)
+{
+  CAMLassert(size > 0);
+  caml_stat_block result = caml_stat_alloc(size);
+  memcpy(result, s, size);
+  if (out_size != NULL)
+    *out_size = size;
+  return result;
+}
+
 #ifdef _WIN32
 
 CAMLexport wchar_t * caml_stat_wcsdup_noexc(const wchar_t *s)

--- a/runtime/win32.c
+++ b/runtime/win32.c
@@ -951,16 +951,25 @@ CAMLexport value caml_copy_string_of_utf16(const wchar_t *s)
   return v;
 }
 
-CAMLexport wchar_t* caml_stat_strdup_to_utf16(const char *s)
+CAMLexport wchar_t* caml_stat_strdup_noexc_to_utf16(const char *s)
 {
   wchar_t * ws;
   int retcode;
 
   retcode = caml_win32_multi_byte_to_wide_char(s, -1, NULL, 0);
   ws = caml_stat_alloc_noexc(retcode * sizeof(*ws));
-  caml_win32_multi_byte_to_wide_char(s, -1, ws, retcode);
+  if (ws != NULL)
+    caml_win32_multi_byte_to_wide_char(s, -1, ws, retcode);
 
   return ws;
+}
+
+CAMLexport wchar_t* caml_stat_strdup_to_utf16(const char *s)
+{
+  wchar_t out = caml_stat_strdup_noexc_to_utf16(s);
+  if (out == NULL)
+    caml_raise_out_of_memory();
+  return out;
 }
 
 CAMLexport caml_stat_string caml_stat_strdup_noexc_of_utf16(const wchar_t *s)

--- a/runtime/win32.c
+++ b/runtime/win32.c
@@ -951,44 +951,83 @@ CAMLexport value caml_copy_string_of_utf16(const wchar_t *s)
   return v;
 }
 
-CAMLexport wchar_t* caml_stat_strdup_noexc_to_utf16(const char *s)
+Caml_inline wchar_t *char_array_to_utf16_noexc(const char *s,
+                                               int slen, size_t *out_size)
 {
   wchar_t * ws;
   int retcode;
 
-  retcode = caml_win32_multi_byte_to_wide_char(s, -1, NULL, 0);
-  ws = caml_stat_alloc_noexc(retcode * sizeof(*ws));
-  if (ws != NULL)
-    caml_win32_multi_byte_to_wide_char(s, -1, ws, retcode);
+  retcode = caml_win32_multi_byte_to_wide_char(s, slen, NULL, 0);
+  ws = caml_stat_alloc_noexc(retcode * sizeof(wchar_t));
+  if (ws != NULL) {
+    caml_win32_multi_byte_to_wide_char(s, slen, ws, retcode);
+    if (out_size != NULL)
+      *out_size = retcode;
+  }
 
   return ws;
 }
 
-CAMLexport wchar_t* caml_stat_strdup_to_utf16(const char *s)
+CAMLexport wchar_t *caml_stat_strdup_noexc_to_utf16(const char *s)
 {
-  wchar_t out = caml_stat_strdup_noexc_to_utf16(s);
+  return char_array_to_utf16_noexc(s, -1, NULL);
+}
+
+CAMLexport wchar_t *caml_stat_strdup_to_utf16(const char *s)
+{
+  wchar_t *out = caml_stat_strdup_noexc_to_utf16(s);
   if (out == NULL)
     caml_raise_out_of_memory();
   return out;
 }
 
-CAMLexport caml_stat_string caml_stat_strdup_noexc_of_utf16(const wchar_t *s)
+CAMLexport wchar_t *caml_stat_char_array_to_utf16(const char *s, size_t size,
+                                                  size_t *out_size)
+{
+  CAMLassert(size > 0);
+  wchar_t *out = char_array_to_utf16_noexc(s, size, out_size);
+  if (out == NULL)
+    caml_raise_out_of_memory();
+  return out;
+}
+
+Caml_inline caml_stat_string char_array_of_utf16_noexc(const wchar_t *s,
+                                                       int slen,
+                                                       size_t *out_size)
 {
   caml_stat_string out;
   int retcode;
 
-  retcode = caml_win32_wide_char_to_multi_byte(s, -1, NULL, 0);
+  retcode = caml_win32_wide_char_to_multi_byte(s, slen, NULL, 0);
   out = caml_stat_alloc_noexc(retcode);
   if (out != NULL) {
-    caml_win32_wide_char_to_multi_byte(s, -1, out, retcode);
+    caml_win32_wide_char_to_multi_byte(s, slen, out, retcode);
+    if (out_size != NULL)
+      *out_size = retcode;
   }
 
   return out;
 }
 
+CAMLexport caml_stat_string caml_stat_strdup_noexc_of_utf16(const wchar_t *s)
+{
+  return char_array_of_utf16_noexc(s, -1, NULL);
+}
+
 CAMLexport caml_stat_string caml_stat_strdup_of_utf16(const wchar_t *s)
 {
   caml_stat_string out = caml_stat_strdup_noexc_of_utf16(s);
+  if (out == NULL)
+    caml_raise_out_of_memory();
+  return out;
+}
+
+CAMLexport caml_stat_string caml_stat_char_array_of_utf16(const wchar_t *s,
+                                                          size_t size,
+                                                          size_t *out_size)
+{
+  CAMLassert(size > 0);
+  caml_stat_string out = char_array_of_utf16_noexc(s, size, out_size);
   if (out == NULL)
     caml_raise_out_of_memory();
   return out;


### PR DESCRIPTION
Two related updates in the UTF-16 conversion functions:
1. Prompted by recent work on #13419, I noticed that the semantics of `caml_stat_strdup_to_utf16` are incorrect - it was using `caml_stat_alloc_noexc`. That's corrected, and having audited the places where `caml_stat_strdup_to_utf16` / `caml_stat_strdup_to_os` were used, I've also added `caml_stat_strdup_noexc_to_os` (`caml_stat_strdup_noexc_of_os` was added in #13419) and used it when parsing `ld.conf`, if somewhat pedantically as that code is executed early enough that it's written on the assumption that allocation can't fail.
2. Added `caml_stat_char_array_{to,of}_os` functions, as outlined in #11449. I need `caml_stat_char_array_to_os` for a relocatable compiler PR to be able to encode strings containing embedded NUL characters in UTF-16. It obviously makes sense to add `caml_stat_char_array_of_os` as its dual, and external use-cases for that function are outlined in the issue (reading Registry data, etc.). In the issue, I noted that the _os versions don't necessarily make sense, but that's not quite right - `caml_stat_char_array_to_os` is clearly useful, and so it makes sense to have `caml_stat_char_array_of_os`, even though it's likely only ever to be used in its Windows `caml_stat_char_array_of_utf16` variant.