### PR TITLE
Add frame pointers support for ARM64 on Linux and macOS

### DIFF
--- a/Changes
+++ b/Changes
@@ -30,6 +30,10 @@ Working version
   entries found in ld.conf.
   (David Allsopp, review by Stephen Dolan)
 
+- #13500: Add frame pointers support for ARM64 on Linux and macOS.
+  (Tim McGilchrist, review by KC Sivaramakrishnan, Fabrice Buoro
+   and Miod Vallat)
+
 ### Code generation and optimizations:
 
 ### Standard library:

--- a/asmcomp/arm64/emit.mlp
+++ b/asmcomp/arm64/emit.mlp
@@ -747,18 +747,15 @@ let emit_instr env i =
           `	bl	{emit_symbol "caml_c_call"}\n`;
           `{record_frame env i.live (Dbg_other i.dbg)}\n`
         end else begin
-          (* Push frame pointer (x29) onto stack and restore later. *)
-          `	str	x29, [sp, -16]!\n`;
-          (* Store OCaml stack in the frame pointer register. *)
-          `	mov	x29, sp\n`;
+          (* Store OCaml stack in x19 register and restore later. *)
+          `	mov	x19, sp\n`;
           cfi_remember_state ();
           cfi_def_cfa_register ~reg:29;
           let offset = Domainstate.(idx_of_field Domain_c_stack) * 8 in
           `	ldr	{emit_reg reg_tmp1}, [{emit_reg reg_domain_state_ptr}, {emit_int offset}]\n`;
           `	mov	sp, {emit_reg reg_tmp1}\n`;
           `	bl	{emit_symbol func}\n`;
-          `	mov	sp, x29\n`;
-          `	ldr	x29, [sp], 16\n`;
+          `	mov	sp, x19\n`;
           cfi_restore_state ()
         end
     | Lop(Istackoffset n) ->

--- a/asmcomp/arm64/emit.mlp
+++ b/asmcomp/arm64/emit.mlp
@@ -82,10 +82,14 @@ let emit_wreg = function
     {loc = Reg r} -> emit_string int_reg_name_w.(r)
   | _ -> fatal_error "Emit.emit_wreg"
 
+let fp = Config.with_frame_pointers
+
 let initial_stack_offset f =
-  8 * f.fun_num_stack_slots.(0) +
-  8 * f.fun_num_stack_slots.(1) +
-  (if f.fun_frame_required then 8 else 0)
+  8 * f.fun_num_stack_slots.(0) + (* Local int variables *)
+  8 * f.fun_num_stack_slots.(1) + (* Local float variables *)
+    (if f.fun_frame_required then
+       8 + (if fp then 8 else 0) (* Return address plus optional Frame Pointer *)
+     else 0)
 
 let frame_size env =
   let sz =
@@ -98,10 +102,9 @@ let slot_offset env loc cl =
       assert (n >= 0);
       frame_size env + n
   | Local n ->
-      env.stack_offset +
-      (if cl = 0
-       then n * 8
-       else env.f.fun_num_stack_slots.(0) * 8 + n * 8)
+      if cl = 0
+      then env.stack_offset + n * 8
+      else env.stack_offset + (env.f.fun_num_stack_slots.(0) + n) * 8
   | Outgoing n ->
       assert (n >= 0);
       n
@@ -271,13 +274,16 @@ let emit_stack_adjustment n =
 
 (* Deallocate the stack frame and reload the return address
    before a return or tail call *)
-
 let output_epilogue env f =
   let n = frame_size env in
-  if env.f.fun_frame_required then
-    `	ldr	x30, [sp, #{emit_int (n-8)}]\n`;
   if n > 0 then
     emit_stack_adjustment n;
+  if env.f.fun_frame_required then
+    if fp then (
+      `	ldp	x29, x30, [sp, #-16]\n`;
+    ) else (
+      `	ldr	x30, [sp, #-8]\n`;
+    );
   f();
   (* reset CFA back because function body may continue *)
   if n > 0 then cfi_adjust_cfa_offset n
@@ -293,7 +299,7 @@ let rec emit_addimm rd rs n =
     let nl = n land 0xFFF and nh = n land 0xFFF_000 in
     `	add	{emit_reg rd}, {emit_reg rs}, #{emit_int nh}\n`;
     if nl <> 0 then
-      `	add	{emit_reg rd}, {emit_reg rd}, #{emit_int nl}\n`
+    `	add	{emit_reg rd}, {emit_reg rd}, #{emit_int nl}\n`
   end
 
 and emit_subimm rd rs n =
@@ -445,7 +451,7 @@ module BR = Branch_relaxation.Make (struct
 
   let prologue_size f =
     (if initial_stack_offset f > 0 then 2 else 0)
-      + (if f.fun_frame_required then 1 else 0)
+      + (if f.fun_frame_required then (if fp then 2 else 1) else 0)
 
   let epilogue_size f =
     if f.fun_frame_required then 3 else 2
@@ -535,7 +541,7 @@ module BR = Branch_relaxation.Make (struct
         + begin match lbl1 with None -> 0 | Some _ -> 1 end
         + begin match lbl2 with None -> 0 | Some _ -> 1 end
     | Lswitch jumptbl -> 3 + Array.length jumptbl
-    | Lentertrap -> 0
+    | Lentertrap -> if fp then 1 else 0
     | Ladjust_trap_depth _ -> 0
     | Lpushtrap _ -> 3
     | Lpoptrap -> 1
@@ -675,11 +681,20 @@ let emit_instr env i =
     | Lend -> ()
     | Lprologue ->
       let n = frame_size env in
-      if n > 0 then
-        emit_stack_adjustment (-n);
       if env.f.fun_frame_required then begin
-        cfi_offset ~reg:30 (* return address *) ~offset:(-8);
-        `	str	x30, [sp, #{emit_int (n-8)}]\n`
+          if fp then (
+            `	stp	x29, x30, [sp, #-16]\n`;
+            cfi_offset ~reg:29 (* frame pointer *) ~offset:(-16);
+            cfi_offset ~reg:30 (* return address *) ~offset:(-8)
+          ) else (
+            `	str	x30, [sp, #-8]\n`;
+            cfi_offset ~reg:30 (* return address *) ~offset:(-8)
+          );
+      end;
+      if n > 0 then begin
+          emit_stack_adjustment (-n);
+          if env.f.fun_frame_required && fp then
+            `	add	x29,  sp, #{emit_int (n-16)}\n`;
       end
     | Lop(Imove | Ispill | Ireload) ->
         let src = i.arg.(0) and dst = i.res.(0) in
@@ -1023,7 +1038,10 @@ let emit_instr env i =
         done
 *)
     | Lentertrap ->
-        ()
+       if fp then begin
+         let delta = (frame_size env) - 16 (* return address + frame pointer *) in
+         `	add	x29, sp, #{emit_int delta}\n`
+       end
     | Ladjust_trap_depth { delta_traps } ->
         (* each trap occupies 16 bytes on the stack *)
         let delta = 16 * delta_traps in

--- a/asmcomp/arm64/proc.ml
+++ b/asmcomp/arm64/proc.ml
@@ -248,9 +248,9 @@ let stack_ptr_dwarf_register_number = 31
 (* Registers destroyed by operations *)
 
 let destroyed_at_c_noalloc_call =
-  (* x19-x28, d8-d15 preserved *)
+  (* x20-x28, d8-d15 preserved *)
   Array.of_list (List.map phys_reg
-    [0;1;2;3;4;5;6;7;8;9;10;11;12;13;14;15;
+    [0;1;2;3;4;5;6;7;8;9;10;11;12;13;14;15;16;
      100;101;102;103;104;105;106;107;
      116;117;118;119;120;121;122;123;
      124;125;126;127;128;129;130;131])

--- a/configure
+++ b/configure
@@ -20452,7 +20452,7 @@ fi
 if test x"$enable_frame_pointers" = "xyes"
 then :
   case $host in #(
-  x86_64-*-linux*|x86_64-*-darwin*) :
+  x86_64-*-linux*|x86_64-*-darwin*|aarch64-*-linux*|aarch64-*-darwin*) :
     case $ocaml_cc_vendor in #(
   clang-*|gcc-*) :
     common_cflags="$common_cflags -g  -fno-omit-frame-pointer"

--- a/configure.ac
+++ b/configure.ac
@@ -2448,7 +2448,7 @@ AS_IF([$native_compiler],
 
 AS_IF([test x"$enable_frame_pointers" = "xyes"],
   [AS_CASE([$host],
-    [x86_64-*-linux*|x86_64-*-darwin*],
+    [x86_64-*-linux*|x86_64-*-darwin*|aarch64-*-linux*|aarch64-*-darwin*],
      [AS_CASE([$ocaml_cc_vendor],
         [clang-*|gcc-*],
          [common_cflags="$common_cflags -g  -fno-omit-frame-pointer"

--- a/runtime/arm64.S
+++ b/runtime/arm64.S
@@ -303,6 +303,32 @@ G(name):
         ldr     TRAP_PTR, Caml_state(exn_handler)
 .endm
 
+/* Updates the oldest saved frame pointer in the target fiber.
+
+   A fiber stack may need to grow, causing the reallocation of the entire fiber,
+   including stack_info and stack_handler structures.
+   caml_try_realloc_stack will not be able to update the linked list of
+   frame-pointers if it has been split (i.e., in a continuation).
+   caml_resume and caml_reperform use this macro to update the oldest saved x29
+   (highest one in the stack) in case the fiber was reallocated to reattach the
+   frame-pointer linked list.
+
+   REG: Stack_handler(target_fiber)
+
+   The frame pointer will be pushed into the stack immediately after these
+   instructions. The offset of the oldest saved x29 in a fiber from the stack
+   handler is 48 = 4 words (caml_runstack) + 2 words (x30 and x29).
+   */
+#ifdef WITH_FRAME_POINTERS
+.macro UPDATE_BASE_POINTER reg
+        sub     TMP2, sp, 16
+        str     TMP2, [\reg, -48]
+.endm
+#else
+.macro UPDATE_BASE_POINTER reg
+.endm
+#endif
+
 #if defined(WITH_THREAD_SANITIZER) /* { */
 
 /* Push the current value of the link register to the stack. */
@@ -643,7 +669,7 @@ L(jump_to_caml):
         CFI_OFFSET(30, -152)
         stp     x29, x30, [sp, -160]!
         CFI_ADJUST(160)
-        add     x29, sp, #0
+        mov     x29, sp
         stp     x19, x20, [sp, 16]
         stp     x21, x22, [sp, 32]
         stp     x23, x24, [sp, 48]
@@ -962,7 +988,6 @@ END_FUNCTION(caml_callback3_asm)
         LEAVE_FUNCTION
 .endm
 
-
 /*
  * A continuation is a one word object that points to a fiber. A fiber [f] will
  * point to its parent at Handler_parent(Stack_handler(f)). In the following,
@@ -1048,13 +1073,16 @@ END_FUNCTION(caml_perform)
 
 FUNCTION(caml_reperform)
         CFI_STARTPROC
-    /*  x0: effect to perform
+    /*  x0: effect to reperform
         x1: continuation
         x2: last_fiber */
         ldr     TMP, Stack_handler_from_cont(x2)
         ldr     x2, Caml_state(current_stack) /* x2 := old stack */
         str     x2, Handler_parent(TMP) /* Append to last_fiber */
         add     x3, x2, 1 /* x3 (last_fiber) := Val_ptr(old stack) */
+    /* Need to update the oldest saved frame pointer here as the execution of
+       the handler may have caused the current fiber stack to reallocate. */
+        UPDATE_BASE_POINTER TMP
         b       L(do_perform)
         CFI_ENDPROC
 END_FUNCTION(caml_reperform)
@@ -1102,6 +1130,10 @@ FUNCTION(caml_resume)
         ldr     x8, Stack_handler(x3)
         ldr     x9, Caml_state(current_stack)
         str     x9, Handler_parent(x8)
+    /* Need to update the oldest saved frame pointer here as the current fiber
+       stack may have been reallocated or we may be resuming a computation
+       that was not originally run here. */
+        UPDATE_BASE_POINTER x8
         SWITCH_OCAML_STACKS x9, x0
         mov     x0, x2
         br      x4

--- a/testsuite/tests/frame-pointers/exception_handler.ml
+++ b/testsuite/tests/frame-pointers/exception_handler.ml
@@ -11,8 +11,8 @@ external fp_backtrace : string -> unit = "fp_backtrace" [@@noalloc]
 exception Exn1
 exception Exn2
 
-(* We want to be sure to use some stack space so that rbp is shifted,
-* preventing inlining seems enough *)
+(* We want to be sure to use some stack space so that frame pointer is shifted,
+ * preventing inlining seems enough *)
 let[@inline never] raiser i =
   match i with
   | 1 -> raise Exn1
@@ -21,10 +21,10 @@ let[@inline never] raiser i =
 
 let[@inline never][@local never] f x = x
 
-(* This give us a chance to overwrite the memory address pointed by rbp if it
-* is still within 'raiser' stack frame.
-* Technically we don't need to overwrite it but by doing so we avoid some
-* infinite loop while walking the stack. *)
+(* This give us a chance to overwrite the memory address pointed by frame
+ * pointer if it is still within 'raiser' stack frame.
+ * Technically we don't need to overwrite it but by doing so we avoid some
+ * infinite loop while walking the stack. *)
 let[@inline never] handler () =
   (* Force spilling of x0, x1, x2 *)
   let x0 = Sys.opaque_identity 0x6f56df77 (* 0xdeadbeef *) in
@@ -48,7 +48,7 @@ let[@inline never] nested i =
   i
 
 (* Check that we haven't broken anything by raising directly from this
-* function, it doesn't require rbp to be adjusted *)
+ * function, it doesn't require the frame pointer to be adjusted. *)
 let[@inline never] bare i =
   begin
     try

--- a/testsuite/tests/frame-pointers/exceptions.ml
+++ b/testsuite/tests/frame-pointers/exceptions.ml
@@ -1,0 +1,34 @@
+(* TEST
+   frame_pointers;
+   readonly_files = "fp_backtrace.c";
+   all_modules = "${readonly_files} exceptions.ml";
+   native;
+ *)
+
+external fp_backtrace : string -> unit = "fp_backtrace" [@@noalloc]
+
+exception FortyTwo
+
+(* We want to ensure backtraces from raiser, handler and catcher are correct.
+ *)
+let [@inline never] handler i =
+  Printf.printf "# handler %d\n%!" i;
+  fp_backtrace Sys.argv.(0);
+  i + 1
+
+let [@inline never] raiser i =
+  Printf.printf "# raiser %d\n%!" i;
+  fp_backtrace Sys.argv.(0);
+  match i with
+  | 42 -> raise FortyTwo
+  | _ -> i
+
+let [@inline never] catcher i =
+  Printf.printf "# catcher %d\n%!" i;
+  fp_backtrace Sys.argv.(0);
+  try raiser i with
+  | FortyTwo -> ignore (handler i);
+                i
+
+let () =
+  ignore (catcher 42)

--- a/testsuite/tests/frame-pointers/exceptions.reference
+++ b/testsuite/tests/frame-pointers/exceptions.reference
@@ -1,0 +1,14 @@
+# catcher 42
+camlExceptions.catcher
+camlExceptions.entry
+caml_program
+# raiser 42
+camlExceptions.raiser
+camlExceptions.catcher
+camlExceptions.entry
+caml_program
+# handler 42
+camlExceptions.handler
+camlExceptions.catcher
+camlExceptions.entry
+caml_program

--- a/testsuite/tests/frame-pointers/fp_backtrace.c
+++ b/testsuite/tests/frame-pointers/fp_backtrace.c
@@ -19,13 +19,13 @@
 
 typedef struct frame_info
 {
-  struct frame_info*  prev;     /* rbp */
-  void*               retaddr;  /* rip */
+  struct frame_info*  prev;     /* base pointer / frame pointer */
+  void*               retaddr;  /* instruction pointer / program counter */
 } frame_info;
 
 /*
  * A backtrace symbol looks like this on Linux:
- * ./path/to/binary(camlModule_fn_123+0xAABBCC) [0xAABBCCDDEE]
+ * ./path/to/binary(camlModule.fn_123+0xAABBCC) [0xAABBCCDDEE]
  *
  * or this on macOS:
  * 0   c_call.opt                          0x000000010e621079 camlC_call.entry + 57

--- a/testsuite/tests/frame-pointers/stack_realloc.arm64.reference
+++ b/testsuite/tests/frame-pointers/stack_realloc.arm64.reference
@@ -1,0 +1,10 @@
+camlStack_realloc.callback
+caml_start_program
+caml_callback_exn
+caml_callback
+c_fun
+caml_c_call
+camlStack_realloc.f_comp
+caml_runstack
+camlStack_realloc.entry
+caml_program

--- a/testsuite/tests/frame-pointers/stack_realloc.ml
+++ b/testsuite/tests/frame-pointers/stack_realloc.ml
@@ -22,7 +22,7 @@ let[@inline never] consume_stack () =
    * and Stack_threshold_words = 32 *)
   (* in words *)
   let size = 128 in
-  let allocated = 2 * 2 (* 2 spilled registers *) + 1 (* saved rbp *) in
+  let allocated = 2 * 2 (* 2 spilled registers *) + 1 (* saved frame pointer *) in
   let count = size / allocated in
   let[@inline never] rec gobbler i =
     (* Force spilling of x0 and x1 *)

--- a/testsuite/tests/frame-pointers/stack_realloc.ml
+++ b/testsuite/tests/frame-pointers/stack_realloc.ml
@@ -2,7 +2,17 @@
  frame_pointers;
  readonly_files = "fp_backtrace.c stack_realloc_.c";
  all_modules = "${readonly_files} stack_realloc.ml";
- native;
+ {
+ (* NOTE clang on macOS and gcc on Linux are less eager to inline
+         certain C functions in the runtime. *)
+   reference = "${test_source_directory}/stack_realloc.arm64.reference";
+   arch_arm64;
+   native;
+ } {
+   reference = "${test_source_directory}/stack_realloc.reference";
+   arch_amd64;
+   native;
+ }
 *)
 
 open Effect

--- a/testsuite/tests/frame-pointers/stack_realloc2.arm64.reference
+++ b/testsuite/tests/frame-pointers/stack_realloc2.arm64.reference
@@ -1,0 +1,10 @@
+camlStack_realloc2.callback
+caml_start_program
+caml_callback_exn
+caml_callback
+c_fun
+caml_c_call
+camlStack_realloc2.f_comp
+caml_runstack
+camlStack_realloc2.entry
+caml_program

--- a/testsuite/tests/frame-pointers/stack_realloc2.ml
+++ b/testsuite/tests/frame-pointers/stack_realloc2.ml
@@ -22,7 +22,7 @@ let[@inline never] consume_stack () =
    * and Stack_threshold_words = 32 *)
   (* in words *)
   let size = 128 in
-  let allocated = 2 * 2 (* 2 spilled registers *) + 1 (* saved rbp *) in
+  let allocated = 2 * 2 (* 2 spilled registers *) + 1 (* saved frame pointer *) in
   let count = size / allocated in
   let[@inline never] rec gobbler i =
     (* Force spilling of x0 and x1 *)

--- a/testsuite/tests/frame-pointers/stack_realloc2.ml
+++ b/testsuite/tests/frame-pointers/stack_realloc2.ml
@@ -2,7 +2,17 @@
  frame_pointers;
  readonly_files = "fp_backtrace.c stack_realloc_.c";
  all_modules = "${readonly_files} stack_realloc2.ml";
- native;
+ {
+   (* NOTE clang on MacOS and gcc on Linux are less eager to inline
+           certain C functions in the runtime. *)
+   reference = "${test_source_directory}/stack_realloc2.arm64.reference";
+   arch_arm64;
+   native;
+ } {
+   reference = "${test_source_directory}/stack_realloc2.reference";
+   arch_amd64;
+   native;
+ }
 *)
 
 open Effect


### PR DESCRIPTION
### Add frame pointers support for ARM64 on Linux and macOS

Frame pointers can be used to walk the stack of function calls in a program. This stack-walking technique is commonly used by external profilers and debuggers, including Linux perf and eBPF, FreeBSD and macOS Dtrace, and GDB and LLDB, to reconstruct the call graph for programs. Enabling frame pointers opens up opportunities for third party debugging and performance tools to understand OCaml programs, without needing OCaml specific changes to understand OCaml's calling conventions.

The OCaml compiler already has an option for `enable-frame-pointers` since 4.14 on amd64 (Originally introduced by @lefessan in #5721, first released in OCaml 4.01 in 2013). In OCaml 5.1 support was added back for Linux in [#11144](https://github.com/ocaml/ocaml/pull/11144) with macOS [#13163](https://github.com/ocaml/ocaml/pull/13163) support coming in 5.3.

This PR extends frame pointer support to ARM64 macOS and Linux. Note sp is the stack pointer register, x29 is the frame pointer register and x30 is the link register. Thanks to @fabbing and @dustanddreams for their assistance.

### Changes

22fee2d Stores sp in temporary register x19 during Iextcall in the same way as amd64 backend. Previously this was implemented in [Save and restore frame pointer across Iextcall on ARM64 #13079](https://github.com/ocaml/ocaml/pull/13079) as push/pop on the stack, however this interferes with frame pointers.

aa2a86d Implements frame pointer save and restore in both the code generation and arm64 runtime. I am using the `stp` and `ldp` instruction plus an extra `add` instruction for updating `x29`.  This results in an extra `add` plus saving an extra register for functions allocating a stack frame. In assembly this typically looks like:

``` assembly
;; prologue
	stp	x29, x30, [sp, #-16]
	sub	sp, sp, #16
	add	x29,  sp, #0

;; epilogue
	add	sp, sp, #16
	ldp	x29, x30, [sp, #-16]
```

The compiler already maintains `x29` register when calling into C and when using TSan. There is minimal extra stack space usage, as we needed to be quad word aligned anyway, so the `x29` is going into an already allocated space on the stack. I borrowed the same `UPDATE_BASE_POINTER` and `Lentertrap` tricks from https://github.com/ocaml/ocaml/pull/11144 and https://github.com/ocaml/ocaml/pull/11031.

fea28d6 and caccae2 work around inlining differences across platforms and add a simple backtrace tests for exceptions, which I felt was missing previously.

18ad55c Enables frame-pointers in CI to demonstrate the test suite passes but I expect frame pointer support in GitHub CI to be done differently.

I haven't done comprehensive performance testing of this change across Linux and macOS, however I would expect the impact to be similar to x86_64. If someone would like some hard numbers, I can run some tests.

### Background

It's interesting to note that the [ABI on macOS](https://developer.apple.com/documentation/xcode/writing-arm64-code-for-apple-platforms) requires maintaining frame pointers, and certain popular Linux distributions like [Ubuntu](https://ubuntu.com/blog/ubuntu-performance-engineering-with-frame-pointers-by-default), [Fedora](https://pagure.io/fesco/issue/2923) and [Arch](https://gitlab.archlinux.org/archlinux/rfcs/-/merge_requests/26) are reenabling frame pointers in recent distributions. 

### Fixing perf profiling
As a further demonstration that this fixes issues with misattributed frames in perf 
(See [#12563](https://github.com/ocaml/ocaml/issues/12563) for a longer discussion on the topic).

Using this test program compiled with `ocamlopt sched.ml -o sched.exe` in a switch with this change on Ubuntu 24.04 LTS (which is compiled with frame pointers turned on):
```ocaml
open Effect
open Effect.Deep

exception E
type _ t += Yield : unit t
          | Fork : (unit -> string) -> unit t
          | Ping : unit t
exception Pong

let say _ =
  (* Printf.printf "%s%!" x *)
  ignore(Sys.opaque_identity(Array.make 1_000 0))

let run main =
  let run_q = Queue.create () in
  let enqueue k = Queue.push k run_q in
  let rec dequeue () =
    if Queue.is_empty run_q then `Finished
    else continue (Queue.pop run_q) ()
  in
  let rec spawn f =
    let[@inline never] spawn_retc = function
      | "ok" -> say "."; dequeue ()
      | s -> failwith ("Unexpected result: " ^ s)
    in
    let[@inline never] spawn_exnc = function
      | E -> say "!"; dequeue ()
      | e -> raise e
    in
    let[@inline never] spawn_effc (type a) (e : a t) =
      match e with
        | Yield -> Some (fun (k : (a, _) continuation) ->
            say ","; enqueue k; dequeue ())
        | Fork f -> Some (fun (k : (a, _) continuation) ->
            say "+"; enqueue k; spawn f)
        | Ping -> Some (fun (k : (a, _) continuation) ->
            say "["; discontinue k Pong)
        | _ -> None
    in
    match_with f ()
    { retc = spawn_retc;
      exnc = spawn_exnc;
      effc = spawn_effc }
  in
  spawn main

let[@inline never] g () =
  let[@inline never] g_comp () = perform Ping; failwith "no pong" in
  let[@inline never] g_retc x = x in
  let[@inline never] g_exnc = function | Pong -> say "]" | e -> raise e in
  let[@inline never] g_effc (type a) (e : a t) =
    match e with
    | Yield -> Some (fun (k : (a,_) continuation) -> failwith "what?")
    | _ -> None in
  perform Yield; say "C"; perform Yield;
  begin match_with g_comp ()
  { retc = g_retc;
    exnc = g_exnc;
    effc = g_effc }
  end;
  raise E

let[@inline never] h () = say "B"; "ok"

let[@inline never] test () =
  say "A";
  perform (Fork g);
  perform (Fork h);
  say "D";
  perform Yield;
  say "E";
  "ok"

let () =
  for a = 1 to 100_000 do
  let `Finished = run test in
  say "\n"
  done
```
First using `sudo perf record --call-graph dwarf -o sched-perf-dwarf.data ./sched.exe`, note `cfree` pointing to an address.
<img width="934" alt="Screenshot 2024-09-25 at 2 57 34 PM" src="https://github.com/user-attachments/assets/70084d4d-22bb-4b21-a28f-57c8042dde9b">

Now with `sudo perf record --call-graph fp -o sched-perf-fp.data ./sched.exe` the `cfree` node is correctly included.
<img width="933" alt="Screenshot 2024-09-25 at 2 57 17 PM" src="https://github.com/user-attachments/assets/040e565d-cb3b-47c0-afb6-1638b28dca98">
