### PR TITLE
Fix misindexing related to `Gc.finalise_last`

### DIFF
--- a/Changes
+++ b/Changes
@@ -1098,6 +1098,10 @@ OCaml 5.2.0 (13 May 2024)
 
 ### Bug fixes:
 
+- #13502: Fix misindexing related to `Gc.finalise_last` that could prevent
+  finalisers from being run.
+  (Nick Roberts, review by Mark Shinwell)
+
 - #10652, #12720: fix evaluation order in presence of optional arguments
   (Jacques Garrigue, report by Leo White, review by Vincent Laviron)
 

--- a/runtime/finalise.c
+++ b/runtime/finalise.c
@@ -262,7 +262,7 @@ static void generic_final_minor_update
     for (i = final->old; i < final->young; i++) {
       CAMLassert (Is_block (final->table[i].val));
       CAMLassert (Tag_val (final->table[i].val) != Forward_tag);
-      if (Is_young(final->table[j].val) &&
+      if (Is_young(final->table[i].val) &&
           caml_get_header_val(final->table[i].val) != 0) {
         /** dead */
         fi->todo_tail->item[k] = final->table[i];


### PR DESCRIPTION
The runtime exposes multiple ways for the users to register finalisers; one way is `Gc.finalise_last`. The runtime occasionally checks whether any finaliser registered with `finalise_last` should be run. This check first counts how much work it should do:

https://github.com/ocaml/ocaml/blob/e30d23feaace434e9d85d81b9103e4bb2f6caf66/runtime/finalise.c#L239-L245

And then adds work to the queue:

https://github.com/ocaml/ocaml/blob/e30d23feaace434e9d85d81b9103e4bb2f6caf66/runtime/finalise.c#L261-L276

The indexing in the if-conditions are different, causing a bug. One way this bug can trigger: the first condition is true less often than the second condition, leading to the extra work enqueued (because the second condition was true) being dropped (because the length of the work queue is calculated from the number of times the first condition was true).

On my system, you can repro the issue with this program:

```ocaml
let glob = ref []

let allocate_a_lot_on_the_major_heap () =
  for _ = 0 to 10_000_000 do
    glob := ref 1 :: !glob
  done

let go () =
  allocate_a_lot_on_the_major_heap ();
  let small = Array.init 10 (fun _ -> ()) in
  Gc.finalise_last (fun () -> print_endline "small") small;
  let large = Array.init 100_000 (fun _ -> ()) in
  Gc.finalise_last (fun () -> print_endline "large") large;
  ignore (Sys.opaque_identity (large, small) : _);
  Gc.full_major ()

let () = go ()
```

This program only prints `small` for me. (And `large` will never be printed for as long as the program runs.) The PR fixes the issue so that both `small` and `large` are printed.