### PR TITLE
Add closed_type_expr

### DIFF
--- a/Changes
+++ b/Changes
@@ -538,7 +538,7 @@ ___________
 
 - #13507: A small refactoring to [free_vars] to make it a bit faster
   by not allocating a list when the list is not necessary.
-  (Richard Eisenberg, review by ??)
+  (Richard Eisenberg, review by Jacques Garrigue)
 
 ### Build system:
 

--- a/Changes
+++ b/Changes
@@ -536,6 +536,10 @@ ___________
   in Float.Array.
   (Gabriel Scherer, review by Nicolás Ojeda Bär)
 
+- #13507: A small refactoring to [free_vars] to make it a bit faster
+  by not allocating a list when the list is not necessary.
+  (Richard Eisenberg, review by ??)
+
 ### Build system:
 
 - #12909: Reorganise how MKEXE_VIA_CC is built to make it correct for MSVC by

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -608,19 +608,19 @@ exception Non_closed of type_expr * variable_kind
    [free_variables] below drops the type/row information
    and only returns a [variable list].
  *)
-let free_vars ?env mark ty =
+let free_vars zero add_one ?env mark ty =
   let rec fv ~kind acc ty =
     if not (try_mark_node mark ty) then acc
     else match get_desc ty, env with
       | Tvar _, _ ->
-          (ty, kind) :: acc
+          add_one ty kind acc
       | Tconstr (path, tl, _), Some env ->
           let acc =
             match Env.find_type_expansion path env with
             | exception Not_found -> acc
             | (_, body, _) ->
                 if get_level body = generic_level then acc
-                else (ty, kind) :: acc
+                else add_one ty kind acc
           in
           List.fold_left (fv ~kind:Type_variable) acc tl
       | Tobject (ty, _), _ ->
@@ -636,15 +636,20 @@ let free_vars ?env mark ty =
           else fv ~kind:Row_variable acc (row_more row)
       | _    ->
           fold_type_expr (fv ~kind) acc ty
-  in fv ~kind:Type_variable [] ty
+  in fv ~kind:Type_variable zero ty
 
 let free_variables ?env ty =
-  with_type_mark (fun mark -> List.map fst (free_vars ?env mark ty))
+  let add_one ty _kind acc = ty :: acc in
+  with_type_mark (fun mark -> free_vars [] add_one ?env mark ty)
 
-let closed_type mark ty =
-  match free_vars mark ty with
-      []           -> ()
-  | (v, real) :: _ -> raise (Non_closed (v, real))
+let closed_type ?env mark ty =
+  let add_one ty kind _acc = raise (Non_closed (ty, kind)) in
+  free_vars () add_one ?env mark ty
+
+let closed_type_expr ?env ty =
+  with_type_mark (fun mark ->
+    try closed_type ?env mark ty; true
+    with Non_closed _ -> false)
 
 let closed_parameterized_type params ty =
   with_type_mark begin fun mark ->

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -607,7 +607,7 @@ exception Non_closed of type_expr * variable_kind
    [add_one] information about whether the variable is a normal type variable
    or a row variable.
  *)
-let free_vars ~zero ~add_one ?env mark ty =
+let free_vars ~init ~add_one ?env mark ty =
   let rec fv ~kind acc ty =
     if not (try_mark_node mark ty) then acc
     else match get_desc ty, env with
@@ -635,15 +635,15 @@ let free_vars ~zero ~add_one ?env mark ty =
           else fv ~kind:Row_variable acc (row_more row)
       | _    ->
           fold_type_expr (fv ~kind) acc ty
-  in fv ~kind:Type_variable zero ty
+  in fv ~kind:Type_variable init ty
 
 let free_variables ?env ty =
   let add_one ty _kind acc = ty :: acc in
-  with_type_mark (fun mark -> free_vars ~zero:[] ~add_one ?env mark ty)
+  with_type_mark (fun mark -> free_vars ~init:[] ~add_one ?env mark ty)
 
 let closed_type ?env mark ty =
   let add_one ty kind _acc = raise (Non_closed (ty, kind)) in
-  free_vars ~zero:() ~add_one ?env mark ty
+  free_vars ~init:() ~add_one ?env mark ty
 
 let closed_type_expr ?env ty =
   with_type_mark (fun mark ->

--- a/typing/ctype.mli
+++ b/typing/ctype.mli
@@ -451,6 +451,7 @@ type closed_class_failure = {
 
 val free_variables: ?env:Env.t -> type_expr -> type_expr list
         (* If env present, then check for incomplete definitions too *)
+val closed_type_expr: ?env:Env.t -> type_expr -> bool
 val closed_type_decl: type_declaration -> type_expr option
 val closed_extension_constructor: extension_constructor -> type_expr option
 val closed_class:

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -717,7 +717,7 @@ and build_as_type_extra env p = function
   | (Tpat_constraint {ctyp_type = ty; _}, _, _) :: rest ->
       (* If the type constraint is ground, then this is the best type
          we can return, so just return an instance (cf. #12313) *)
-      if free_variables ty = [] then instance ty else
+      if closed_type_expr ty then instance ty else
       (* Otherwise we combine the inferred type for the pattern with
          then non-ground constraint in a non-ambivalent way *)
       let as_ty = build_as_type_extra env p rest in
@@ -4463,8 +4463,8 @@ and type_coerce
           (* prerr_endline "self coercion"; *)
           r := loc :: !r;
           force ()
-      | _ when free_variables ~env arg_type = []
-            && free_variables ~env ty' = [] ->
+      | _ when closed_type_expr ~env arg_type
+            && closed_type_expr ~env ty' ->
           if not gen && (* first try a single coercion *)
             let snap = snapshot () in
             let ty, _b = enlarge_type env ty' in

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -2103,7 +2103,7 @@ let modtype_of_package env loc p fl =
 let package_subtype env p1 fl1 p2 fl2 =
   let mkmty p fl =
     let fl =
-      List.filter (fun (_n,t) -> Ctype.free_variables t = []) fl in
+      List.filter (fun (_n,t) -> Ctype.closed_type_expr t) fl in
     modtype_of_package env Location.none p fl
   in
   match mkmty p1 fl1, mkmty p2 fl2 with
@@ -2300,7 +2300,8 @@ and type_module_aux ~alias sttn funct_body anchor env smod =
       let mty =
         match get_desc (Ctype.expand_head env exp.exp_type) with
           Tpackage (p, fl) ->
-            if List.exists (fun (_n, t) -> Ctype.free_variables t <> []) fl then
+            if List.exists (fun (_n, t) -> not (Ctype.closed_type_expr t)) fl
+            then
               raise (Error (smod.pmod_loc, env,
                             Incomplete_packed_module exp.exp_type));
             if !Clflags.principal &&


### PR DESCRIPTION
This is just a tiny refactoring of `Ctype.free_variables`. It looks like it would be more efficient, but really my motivation is to make a `exists_free_variable` function in the Jane Street branch. Making this PR here because I think this is a small improvement regardless.