### PR TITLE
Fix #13495: typechecker crash while typing objects 

### DIFF
--- a/Changes
+++ b/Changes
@@ -135,7 +135,6 @@ Working version
 - #13454: Output a correct trace of the C_CALLN bytecode.
   (Miod Vallat, review by Antonin Décimo)
 
-<<<<<<< HEAD
 - #131495: Fix typechecker crash while typing objects
   (Jacques Garrigue, report by Nicolás Ojeda Bär, review by Florian Angeletti)
 
@@ -145,12 +144,6 @@ Working version
   (Florian Angeletti, report by Nailen Matschke, review by Gabriel Scherer, and
   Leo White)
 
-||||||| parent of e8161515b1 (make out of scope universal variables fatal, except for equality)
-- #131495: Fix typechecker crash while typing objects
-  (Jacques Garrigue, report by Nicolás Ojeda Bär, review by ???)
-
-=======
->>>>>>> e8161515b1 (make out of scope universal variables fatal, except for equality)
 OCaml 5.3.0
 ___________
 

--- a/Changes
+++ b/Changes
@@ -135,6 +135,7 @@ Working version
 - #13454: Output a correct trace of the C_CALLN bytecode.
   (Miod Vallat, review by Antonin Décimo)
 
+<<<<<<< HEAD
 - #131495: Fix typechecker crash while typing objects
   (Jacques Garrigue, report by Nicolás Ojeda Bär, review by Florian Angeletti)
 
@@ -144,6 +145,12 @@ Working version
   (Florian Angeletti, report by Nailen Matschke, review by Gabriel Scherer, and
   Leo White)
 
+||||||| parent of e8161515b1 (make out of scope universal variables fatal, except for equality)
+- #131495: Fix typechecker crash while typing objects
+  (Jacques Garrigue, report by Nicolás Ojeda Bär, review by ???)
+
+=======
+>>>>>>> e8161515b1 (make out of scope universal variables fatal, except for equality)
 OCaml 5.3.0
 ___________
 
@@ -781,6 +788,10 @@ ___________
 - #13417: `Filename.quote_command`: fix handling of forward slashes in program
   path under Win32.
   (Nicolás Ojeda Bär, review by David Allsopp and Damien Doligez)
+
+- #131495: Fix typechecker crash while typing objects
+  (Jacques Garrigue, report by Nicolás Ojeda Bär, review by
+   Nicolas Ojeda Bär, Gabriel Scherer, Stephen Dolan)
 
 - #13263, #13560: fix printing true and false in toplevel and error
   messages (no more unexpected \#true)

--- a/Changes
+++ b/Changes
@@ -135,6 +135,9 @@ Working version
 - #13454: Output a correct trace of the C_CALLN bytecode.
   (Miod Vallat, review by Antonin Décimo)
 
+- #131495: Fix typechecker crash while typing objects
+  (Jacques Garrigue, report by Nicolás Ojeda Bär, review by Florian Angeletti)
+
 - #13388, #13540: raises an error message (and not an internal compiler error)
   when two local substitutions are incompatible (for instance `module type
   S:=sig end type t:=(module S)`)

--- a/Changes
+++ b/Changes
@@ -135,9 +135,6 @@ Working version
 - #13454: Output a correct trace of the C_CALLN bytecode.
   (Miod Vallat, review by Antonin Décimo)
 
-- #131495: Fix typechecker crash while typing objects
-  (Jacques Garrigue, report by Nicolás Ojeda Bär, review by Florian Angeletti)
-
 - #13388, #13540: raises an error message (and not an internal compiler error)
   when two local substitutions are incompatible (for instance `module type
   S:=sig end type t:=(module S)`)
@@ -782,9 +779,9 @@ ___________
   path under Win32.
   (Nicolás Ojeda Bär, review by David Allsopp and Damien Doligez)
 
-- #131495: Fix typechecker crash while typing objects
+- #13495, #13514: Fix typechecker crash while typing objects
   (Jacques Garrigue, report by Nicolás Ojeda Bär, review by
-   Nicolas Ojeda Bär, Gabriel Scherer, Stephen Dolan)
+   Nicolas Ojeda Bär, Gabriel Scherer, Stephen Dolan, Florian Angeletti)
 
 - #13263, #13560: fix printing true and false in toplevel and error
   messages (no more unexpected \#true)

--- a/testsuite/tests/typing-objects/pr13495.ml
+++ b/testsuite/tests/typing-objects/pr13495.ml
@@ -1,0 +1,26 @@
+(* TEST
+ expect;
+*)
+
+class type gui =
+  object
+    method sub: 'b. 'b -> 'b
+  end
+
+class virtual local_sub =
+  object
+    method virtual sub: 'b. 'b -> 'b option
+  end
+[%%expect{|
+class type gui = object method sub : 'b -> 'b end
+class virtual local_sub : object method virtual sub : 'b -> 'b option end
+|}]
+
+class virtual ['a] compound_gui =
+  object (_: #gui)
+    constraint 'a = #local_sub
+  end
+[%%expect{|
+class virtual ['a] compound_gui :
+  object constraint 'a = #local_sub method virtual sub : 'b -> 'b end
+|}]

--- a/testsuite/tests/typing-recmod/pr13514.ml
+++ b/testsuite/tests/typing-recmod/pr13514.ml
@@ -1,0 +1,17 @@
+(* TEST
+ expect;
+*)
+
+module rec M: sig
+  type t = { r: 'a 'b. 'a -> ' b -> 'a }
+  val f: t -> t
+end = struct
+  type t = { r : 'a. 'a -> 'a -> 'a }
+  let f: t -> M.t = fun x -> x
+end
+[%%expect{|
+Line 6, characters 29-30:
+6 |   let f: t -> M.t = fun x -> x
+                                 ^
+Error: The value "x" has type "t" but an expression was expected of type "M.t"
+|}]

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -1969,7 +1969,7 @@ let rec unify_univar t1 t2 = function
           raise Cannot_unify_universal_variables
       end
   | [] ->
-     Misc.fatal_error "Ctype.unify_univar: univar not in scope"
+      raise Cannot_unify_universal_variables
 
 (* The same as [unify_univar], but raises the appropriate exception instead of
    [Cannot_unify_universal_variables] *)
@@ -2321,12 +2321,21 @@ let rec expands_to_datatype env ty =
       end
   | _ -> false
 
-(* [mcomp] tests if two types are "compatible" -- i.e., if they could ever
-   unify.  (This is distinct from [eqtype], which checks if two types *are*
-   exactly the same.)  This is used to decide whether GADT cases are
-   unreachable.  It is broadly part of unification. *)
+(* [mcomp] tests if two types are "compatible" -- i.e., if there could
+   exist a witness of their equality. This is distinct from [eqtype],
+   which checks if two types *are*  exactly the same.)
+   [mcomp] is used to decide whether GADT cases are unreachable.
+   The existence of a witness is necessarily an incomplete property,
+   i.e. there exists types for which we cannot tell if an equality
+   witness could exist or not. Typically, this is the case for
+   abstract types, which could be equal to anything, depending on
+   their actual definition. As a result [mcomp] overapproximates
+   compatibilty, i.e. when it says that two types are incompatible, we
+   are sure that there exists no equality witness, but if it does not
+   say so, there is no guarantee that such a witness could exist.
+ *)
 
-(* mcomp type_pairs subst env t1 t2 does not raise an
+(* [mcomp type_pairs subst env t1 t2] should not raise an
    exception if it is possible that t1 and t2 are actually
    equal, assuming the types in type_pairs are equal and
    that the mapping subst holds.
@@ -2385,16 +2394,9 @@ let rec mcomp type_pairs env t1 t2 =
             mcomp_fields type_pairs env t1' t2'
         | (Tnil, Tnil) ->
             ()
-        | (Tpoly (t1, []), Tpoly (t2, [])) ->
+        | (Tpoly (t1, _), Tpoly (t2, _)) ->
             mcomp type_pairs env t1 t2
-        | (Tpoly (t1, tl1), Tpoly (t2, tl2)) ->
-            (try
-               enter_poly env
-                 t1 tl1 t2 tl2 (mcomp type_pairs env)
-             with Escape _ -> raise Incompatible)
-        | (Tunivar _, Tunivar _) ->
-            (try unify_univar t1' t2' !univar_pairs
-             with Cannot_unify_universal_variables -> raise Incompatible)
+        | (Tunivar _, Tunivar _) -> ()
         | (_, _) ->
             raise Incompatible
       end

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -134,6 +134,8 @@ exception Cannot_subst
 
 exception Cannot_unify_universal_variables
 
+exception Out_of_scope_universal_variable
+
 exception Matches_failure of Env.t * unification_error
 
 exception Incompatible
@@ -1969,13 +1971,19 @@ let rec unify_univar t1 t2 = function
           raise Cannot_unify_universal_variables
       end
   | [] ->
-      raise Cannot_unify_universal_variables
+      raise Out_of_scope_universal_variable
 
 (* The same as [unify_univar], but raises the appropriate exception instead of
    [Cannot_unify_universal_variables] *)
-let unify_univar_for tr_exn t1 t2 univar_pairs =
-  try unify_univar t1 t2 univar_pairs
-  with Cannot_unify_universal_variables -> raise_unexplained_for tr_exn
+let unify_univar_for (type a) (tr_exn : a trace_exn) t1 t2 univar_pairs =
+  try unify_univar t1 t2 univar_pairs with
+  | Cannot_unify_universal_variables -> raise_unexplained_for tr_exn
+  | Out_of_scope_universal_variable ->
+      (* allow unscoped univars when checking for equality;
+         see Typedecl_variance (#13514) for instance *)
+      match tr_exn with
+      | Equality -> raise_unexplained_for tr_exn
+      | _ -> fatal_error "Ctype.unify_univar_for: univar not in scope"
 
 (* Test the occurrence of free univars in a type *)
 (* That's way too expensive. Must do some kind of caching *)
@@ -2323,7 +2331,7 @@ let rec expands_to_datatype env ty =
 
 (* [mcomp] tests if two types are "compatible" -- i.e., if there could
    exist a witness of their equality. This is distinct from [eqtype],
-   which checks if two types *are*  exactly the same.)
+   which checks if two types *are*  exactly the same.
    [mcomp] is used to decide whether GADT cases are unreachable.
    The existence of a witness is necessarily an incomplete property,
    i.e. there exists types for which we cannot tell if an equality

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -1979,7 +1979,8 @@ let unify_univar_for (type a) (tr_exn : a trace_exn) t1 t2 univar_pairs =
   try unify_univar t1 t2 univar_pairs with
   | Cannot_unify_universal_variables -> raise_unexplained_for tr_exn
   | Out_of_scope_universal_variable ->
-      (* allow unscoped univars when checking for equality;
+      (* Allow unscoped univars when checking for equality, since one
+         might want to compare arbitrary subparts of types, ignoring scopes;
          see Typedecl_variance (#13514) for instance *)
       match tr_exn with
       | Equality -> raise_unexplained_for tr_exn

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -2402,9 +2402,18 @@ let rec mcomp type_pairs env t1 t2 =
             mcomp_fields type_pairs env t1' t2'
         | (Tnil, Tnil) ->
             ()
-        | (Tpoly (t1, _), Tpoly (t2, _)) ->
+        | (Tpoly (t1, []), Tpoly (t2, [])) ->
             mcomp type_pairs env t1 t2
-        | (Tunivar _, Tunivar _) -> ()
+        | (Tpoly (t1, tl1), Tpoly (t2, tl2)) ->
+            (try
+               enter_poly env
+                 t1 tl1 t2 tl2 (mcomp type_pairs env)
+             with Escape _ -> raise Incompatible)
+        | (Tunivar _, Tunivar _) ->
+            begin try unify_univar t1' t2' !univar_pairs with
+            | Cannot_unify_universal_variables -> raise Incompatible
+            | Out_of_scope_universal_variable -> ()
+            end
         | (_, _) ->
             raise Incompatible
       end


### PR DESCRIPTION
The crash in issue #13495 was caused by the addition of a fatal error in `unify_univar`, which was triggered by calling `eqtype` on types containing univars.

The solution proposed consists of:
1) replacing the fatal error of PR #12920 by a normal failure, which just causes `eqtype` to return `false`, which is fine in the concerned place (it is an improvement to injectivity inferrence in Typedecl_variance).
2) weaken `mcomp`, so that is now ignores univars. Since `mcomp` is an approximation anyway, this is fine, and avoids potential soundness issues. Also added some explanations to `mcomp` to emphasize the approximation aspect.