### PR TITLE
Fix segfault if exceptions are raised during initialisation (4.14)

### DIFF
--- a/Changes
+++ b/Changes
@@ -41,6 +41,11 @@ OCaml 4.14 maintenance version
   (Gabriel Scherer, review by Nicolás Ojeda Bär and Vincent Laviron,
    report by Simon Cruanes)
 
+- #13516: Fix regression where error conditions during bytecode initialisation
+  caused a segmentation fault rather than being properly reported (regression of
+  #5115 in #11788)
+  (David Allsopp, review by Nicolás Ojeda Bär)
+
 OCaml 4.14.2 (14 March 2024)
 ----------------------------
 

--- a/runtime/fail_byt.c
+++ b/runtime/fail_byt.c
@@ -98,7 +98,7 @@ CAMLexport void caml_raise_with_string(value tag, char const *msg)
 */
 static void check_global_data(char const *exception_name)
 {
-  if (caml_global_data == 0) {
+  if (!Is_block(caml_global_data)) {
     fprintf(stderr, "Fatal error: exception %s\n", exception_name);
     exit(2);
   }
@@ -106,7 +106,7 @@ static void check_global_data(char const *exception_name)
 
 static void check_global_data_param(char const *exception_name, char const *msg)
 {
-  if (caml_global_data == 0) {
+  if (!Is_block(caml_global_data)) {
     fprintf(stderr, "Fatal error: exception %s(\"%s\")\n", exception_name, msg);
     exit(2);
   }
@@ -208,7 +208,7 @@ int caml_is_special_exception(value exn) {
      a more readable textual representation of some exceptions. It is
      better to fall back to the general, less readable representation
      than to abort with a fatal error as above. */
-  if (caml_global_data == 0) return 0;
+  if (!Is_block(caml_global_data)) return 0;
   return exn == Field(caml_global_data, MATCH_FAILURE_EXN)
     || exn == Field(caml_global_data, ASSERT_FAILURE_EXN)
     || exn == Field(caml_global_data, UNDEFINED_RECURSIVE_MODULE_EXN);


### PR DESCRIPTION
#11788 changed the initial value of `caml_global_data` to be `Val_unit` rather than `NULL` (fixing a different bug) but didn't update the checks on `caml_global_data` in fail_byt.c. The effect is that running out of memory (or any other exception raised by intern.c, as noted in #5115) causes a segfault.

5.x is unaffected.