### PR TITLE
Simplify initialisation of caml_global_data

### DIFF
--- a/runtime/caml/fiber.h
+++ b/runtime/caml/fiber.h
@@ -239,7 +239,8 @@ struct c_stack_link {
  *   handle_exception function is executed on the parent stack.
  */
 
-/* The table of global identifiers */
+/* The table of global identifiers. Val_unit initially and replaced with a block
+   during bytecode startup. */
 extern value caml_global_data;
 
 #define Trap_pc(tp) (((code_t *)(tp))[0])

--- a/runtime/fail_byt.c
+++ b/runtime/fail_byt.c
@@ -67,7 +67,7 @@ CAMLexport void caml_raise(value v)
 */
 static void check_global_data(char const *exception_name)
 {
-  if (caml_global_data == 0 || !Is_block(caml_global_data)) {
+  if (!Is_block(caml_global_data)) {
     fprintf(stderr, "Fatal error: exception %s during initialisation\n",
             exception_name);
     exit(2);
@@ -76,7 +76,7 @@ static void check_global_data(char const *exception_name)
 
 static void check_global_data_param(char const *exception_name, char const *msg)
 {
-  if (caml_global_data == 0 || !Is_block(caml_global_data)) {
+  if (!Is_block(caml_global_data)) {
     fprintf(stderr, "Fatal error: exception %s(\"%s\")\n", exception_name, msg);
     exit(2);
   }
@@ -173,7 +173,7 @@ int caml_is_special_exception(value exn) {
 
   value f;
 
-  if (caml_global_data == 0 || !Is_block(caml_global_data)) {
+  if (!Is_block(caml_global_data)) {
     return 0;
   }
 

--- a/runtime/fiber.c
+++ b/runtime/fiber.c
@@ -332,7 +332,7 @@ void caml_maybe_expand_stack (void)
 
 #else /* End NATIVE_CODE, begin BYTE_CODE */
 
-value caml_global_data;
+value caml_global_data = Val_unit;
 
 CAMLprim value caml_alloc_stack(value hval, value hexn, value heff)
 {

--- a/runtime/interp.c
+++ b/runtime/interp.c
@@ -311,7 +311,6 @@ value caml_interprete(code_t prog, asize_t prog_size)
     Closinfo_val(raise_unhandled_effect_closure) = Make_closinfo(0, 2);
     raise_unhandled_effect = raise_unhandled_effect_closure;
     caml_register_generational_global_root(&raise_unhandled_effect);
-    caml_global_data = Val_unit;
     caml_register_generational_global_root(&caml_global_data);
     caml_init_callbacks();
     return Val_unit;


### PR DESCRIPTION
Tidy-up following on from the 4.14 version of this on #13516.

Prior to ocaml-multicore/ocaml-multicore#516 (which was merged before #10831), there was a more complicated mechanism for global roots which included, unsurprisingly, `caml_global_data`.

Now that it's just a `value`, it's slightly simpler to initialise it to `Val_unit` (as we do on 4.14) and that "simplifies" a couple of the checks on it during initialisation.