### PR TITLE
Makefile.config: restore the {OCAMLC,OCAMLOPT}_{CFLAGS,CPPFLAGS} variables

### DIFF
--- a/Changes
+++ b/Changes
@@ -565,11 +565,12 @@ ___________
   (Sébastien Hinderer, review by Miod Vallat, Gabriel Scherer and
   Olivier Nicole)
 
-* #12578, #12589, #13322: Use configured CFLAGS and CPPFLAGS *only* during the
-  build of the compiler itself. Do not use them when compiling third-party
-  C sources through the compiler. Flags for compiling third-party C
-  sources can still be specified at configure time in the
-  COMPILER_{BYTECODE,NATIVE}_{CFLAGS,CPPFLAGS} configuration variables.
+* #12578, #12589, #13322, #13519: Use configured CFLAGS and CPPFLAGS *only*
+  during the build of the compiler itself. Do not use them when
+  compiling third-party C sources through the compiler. Flags for
+  compiling third-party C sources can still be specified at configure
+  time in the COMPILER_{BYTECODE,NATIVE}_{CFLAGS,CPPFLAGS}
+  configuration variables.
   (Sébastien Hinderer, report by William Hu, review by David Allsopp)
 
 - #13285: continue the merge of the sub-makefiles into the root

--- a/Makefile.config.in
+++ b/Makefile.config.in
@@ -221,6 +221,13 @@ NAKED_POINTERS=false
 
 # Deprecated variables
 
+## Variables deprecated since OCaml 5.3
+
+OCAMLC_CFLAGS=@bytecode_cflags@
+OCAMLOPT_CFLAGS=@native_cflags@
+OCAMLC_CPPFLAGS=@bytecode_cppflags@
+OCAMLOPT_CPPFLAGS=@native_cppflags@
+
 ## Variables deprecated since OCaml 5.2
 
 STDLIB_MANPAGES=@build_libraries_manpages@


### PR DESCRIPTION
They had been renamed in 31cdf416280053dcd38351b7858e818b23110779
(part of #12589) but we should keep the old names for backward compatibility.

This is thus a proposed fix for the issue #13503 and should probably go
through @dra27.