### PR TITLE
Fix compilation of native code systhreads

### DIFF
--- a/Changes
+++ b/Changes
@@ -751,6 +751,10 @@ ___________
   messages (no more unexpected \#true)
   (Florian Angeletti, report by Samuel Vivien, review by Gabriel Scherer)
 
+- #13520: Fix compilation of native-code version of systhreads. Bytecode fields
+  were being included in the thread descriptors.
+  (David Allsopp, review by Sébastien Hinderer and Miod Vallat)
+
 OCaml 5.2.0 (13 May 2024)
 -------------------------
 

--- a/otherlibs/systhreads/Makefile
+++ b/otherlibs/systhreads/Makefile
@@ -141,6 +141,7 @@ include $(addprefix $(DEPDIR)/, $(DEP_FILES))
 endif
 
 %.b.$(D): OC_CPPFLAGS = $(OC_BYTECODE_CPPFLAGS)
+%.n.$(O): OC_CPPFLAGS = $(OC_NATIVE_CPPFLAGS)
 %.n.$(D): OC_CPPFLAGS = $(OC_NATIVE_CPPFLAGS)
 
 define GEN_RULE


### PR DESCRIPTION
st_stubs.c uses `NATIVE_CODE`, which had stopped being defined in #12108.

On Unix, this appears to be mostly benign, but it causes a noticeable error on Windows in ocamlnat, where `caml_debugger_in_use` is not masked away by the linker.

The full fix for Windows is a little bit bigger (which @shindere is working on), but this fix ought to go in 5.2/5.3 as well.