### PR TITLE
Add Linux x86_64 and macOS ARM64 frame pointer builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -156,6 +156,12 @@ jobs:
             os: macos-13
           - name: macos-arm64
             os: macos-14
+          - name: linux-frame-pointers
+            os: ubuntu-latest
+            config_arg: --enable-frame-pointers
+          - name: macos-arm64-frame-pointers
+            os: macos-14
+            config_arg: --enable-frame-pointers
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -152,6 +152,9 @@ jobs:
           - name: linux-O0
             os: ubuntu-latest
             config_arg: CFLAGS='-O0'
+          - name: linux-arm64
+            os: ubuntu-24.04-arm
+            config_arg: --enable-frame-pointers
           - name: macos-x86_64
             os: macos-13
           - name: macos-arm64


### PR DESCRIPTION
Follow on PR from #13500 to add Linux x86_64 and macOS ARM64 builds for frame pointers. 

I'm looking for guidance as to whether adding these extra builds is worthwhile for the platforms we can target using GitHub CI resources. Alternatively a build could be added to https://ci.inria.fr/ocaml/ if there isn't already one. 