### PR TITLE
Confirm runtime events ring is still active after callback

### DIFF
--- a/Changes
+++ b/Changes
@@ -34,6 +34,9 @@ Working version
   (Tim McGilchrist, review by KC Sivaramakrishnan, Fabrice Buoro
    and Miod Vallat)
 
+- #13522: Confirm runtime events ring is still active after callback.
+  (KC Sivaramakrishnan, review by Sadiq Jaffer and Miod Vallat)
+
 - #13529: Do not write to event ring after going out of stw participant set.
   (KC Sivaramakrishnan, review by Sadiq Jaffer)
 

--- a/runtime/runtime_events.c
+++ b/runtime/runtime_events.c
@@ -776,6 +776,11 @@ CAMLprim value caml_runtime_events_user_write(
 
     res = caml_callback2(serializer, write_buffer, event_content);
 
+    /* Need to check whether the ring is active again as the ring might
+     * potentially have been destroyed during the callback. */
+    if ( !ring_is_active() )
+      CAMLreturn(Val_unit);
+
     uintnat len_bytes = Int_val(res);
     uintnat len_64bit_word = (len_bytes + sizeof(uint64_t)) / sizeof(uint64_t);
     uintnat offset_index = len_64bit_word * sizeof(uint64_t) - 1;


### PR DESCRIPTION
We need to check whether the ring is still active after a callback. It may be that the ring was destroyed during the callback execution. If this were the case, the subsequent call to `write_to_ring` would crash. 