### PR TITLE
#13388: local type substitution should not contain to-be-deleted module types

### DIFF
--- a/Changes
+++ b/Changes
@@ -682,6 +682,14 @@ ___________
   oversight. No known program triggers the bug.
   (Richard Eisenberg, review by Florian Angeletti)
 
+- #13338, #?????: Fail with a clean error whenever a local type substitution
+  contains first-class module types bound to a temporary module type name:
+  ```
+     module type s := sig end
+     type t := <x: (module s) >
+  ```
+  (Florian Angeletti, review by ????)
+
 - #13400: Initialize th->signal_stack to avoid free of uninitialized data
   if the user calls caml_c_thread_unregister on the main thread.
   (Richard W.M. Jones, review by Guillaume Munch-Maccagnoni and

--- a/testsuite/tests/typing-modules/module_type_substitution.ml
+++ b/testsuite/tests/typing-modules/module_type_substitution.ml
@@ -322,3 +322,29 @@ end
 [%%expect {|
 module type hidden = sig type u val x : int end
 |}]
+
+(** Ok: the type [t] disappear before the end of the module *)
+module type s = sig
+  module type r := sig end
+  module type l := sig
+    type t := (module r)
+  end
+  module type inner = l
+end
+[%%expect {|
+module type s = sig module type inner = sig end end
+|}]
+
+module type s = sig
+  module type r := sig end
+  type t := (module r)
+  type s = t
+end
+[%%expect {|
+Line 3, characters 2-22:
+3 |   type t := (module r)
+      ^^^^^^^^^^^^^^^^^^^^
+Error: The module type "r" is not a valid type for a packed module:
+       it is defined as a local substitution (temporary name)
+       for an anonymous module type. (see manual section 12.7.3)
+|}]


### PR DESCRIPTION
This PRs ensure that whenever a local type substitution refers to a non-path local module type substitution
```
module type s := sig end
type u := (module s)
```
the typechecker fails with an error messor

> ```
>Error: The module type s is not a valid type for a packed module:
>       it is defined as a local substitution (temporary name)
>       for an anonymous module type. (see manual section 12.7.3)
>```

rather than with an internal error as reported in  #13388

Close #13388