### PR TITLE
refactor toplevel/genprintval

### DIFF
--- a/toplevel/genprintval.ml
+++ b/toplevel/genprintval.ml
@@ -403,10 +403,13 @@ module Make(O : OBJ)(EVP : EVALPATH with type valu = O.t) = struct
 
       and tree_of_lazy depth obj ty_arg =
         let obj_tag = O.tag obj in
-        (* Lazy values are represented in three possible ways:
+        (* Lazy values are represented in several possible ways:
 
             1. a lazy thunk that is not yet forced has tag
               Obj.lazy_tag
+
+            1bis. a lazy thunk that is in the process of
+               being forced has tag Obj.forcing_tag
 
             2. a lazy thunk that has just been forced has tag
               Obj.forward_tag; its first field is the forced
@@ -427,6 +430,7 @@ module Make(O : OBJ)(EVP : EVALPATH with type valu = O.t) = struct
             an Obj module talking over a socket).
           *)
         if obj_tag = Obj.lazy_tag then Oval_stuff "<lazy>"
+        else if obj_tag = Obj.forcing_tag then Oval_stuff "<lazy (forcing)>"
         else begin
             let forced_obj =
               if obj_tag = Obj.forward_tag then O.field obj 0 else obj

--- a/toplevel/genprintval.ml
+++ b/toplevel/genprintval.ml
@@ -405,57 +405,9 @@ module Make(O : OBJ)(EVP : EVALPATH with type valu = O.t) = struct
                     tree_of_val depth obj
                       (instantiate_type env decl.type_params ty_list body)
                 | {type_kind = Type_variant (constr_list,rep)} ->
-                    let unbx = (rep = Variant_unboxed) in
-                    let tag =
-                      if unbx then Cstr_unboxed
-                      else if O.is_block obj
-                      then Cstr_block(O.tag obj)
-                      else Cstr_constant(O.obj obj) in
-                    let {cd_id;cd_args;cd_res} =
-                      Datarepr.find_constr_by_tag tag constr_list in
-                    let type_params =
-                      match cd_res with
-                        Some t ->
-                          begin match get_desc t with
-                            Tconstr (_,params,_) ->
-                              params
-                          | _ -> assert false end
-                      | None -> decl.type_params
-                    in
-                    begin
-                      match cd_args with
-                      | Cstr_tuple l ->
-                          let ty_args =
-                            instantiate_types env type_params ty_list l in
-                          tree_of_constr_with_args (tree_of_constr env path)
-                            (Ident.name cd_id) false 0 depth obj
-                            ty_args unbx
-                      | Cstr_record lbls ->
-                          let r =
-                            tree_of_record_fields depth
-                              env path type_params ty_list
-                              lbls 0 obj unbx
-                          in
-                          Oval_constr(tree_of_constr env path
-                                        (Out_name.create (Ident.name cd_id)),
-                                      [ r ])
-                    end
+                    tree_of_variant depth decl path ty_list obj constr_list rep
                 | {type_kind = Type_record(lbl_list, rep)} ->
-                    begin match check_depth depth obj ty with
-                      Some x -> x
-                    | None ->
-                        let pos =
-                          match rep with
-                          | Record_extension _ -> 1
-                          | _ -> 0
-                        in
-                        let unbx =
-                          match rep with Record_unboxed _ -> true | _ -> false
-                        in
-                        tree_of_record_fields depth
-                          env path decl.type_params ty_list
-                          lbl_list pos obj unbx
-                    end
+                    tree_of_record depth decl path ty_list obj lbl_list rep
                 | {type_kind = Type_open} ->
                     tree_of_extension path ty_list depth obj
               with
@@ -499,6 +451,59 @@ module Make(O : OBJ)(EVP : EVALPATH with type valu = O.t) = struct
           | Tpackage _ ->
               Oval_stuff "<module>"
         end
+
+      and tree_of_variant depth decl path ty_list obj constr_list rep =
+        let unbx = (rep = Variant_unboxed) in
+        let tag =
+          if unbx then Cstr_unboxed
+          else if O.is_block obj
+          then Cstr_block(O.tag obj)
+          else Cstr_constant(O.obj obj) in
+        let {cd_id;cd_args;cd_res} =
+          Datarepr.find_constr_by_tag tag constr_list in
+        let type_params =
+          match cd_res with
+            Some t ->
+              begin match get_desc t with
+                Tconstr (_,params,_) ->
+                  params
+              | _ -> assert false end
+          | None -> decl.type_params
+        in
+        begin
+          match cd_args with
+          | Cstr_tuple l ->
+              let ty_args =
+                instantiate_types env type_params ty_list l in
+              tree_of_constr_with_args (tree_of_constr env path)
+                (Ident.name cd_id) false 0 depth obj
+                ty_args unbx
+          | Cstr_record lbls ->
+              let r =
+                tree_of_record_fields depth
+                  env path type_params ty_list
+                  lbls 0 obj unbx
+              in
+              Oval_constr(tree_of_constr env path
+                            (Out_name.create (Ident.name cd_id)),
+                          [ r ])
+        end
+
+      and tree_of_record depth decl path ty_list obj lbl_list rep =
+        match check_depth depth obj ty with
+        | Some x -> x
+        | None ->
+            let pos =
+              match rep with
+              | Record_extension _ -> 1
+              | _ -> 0
+            in
+            let unbx =
+              match rep with Record_unboxed _ -> true | _ -> false
+            in
+            tree_of_record_fields depth
+              env path decl.type_params ty_list
+              lbl_list pos obj unbx
 
       and tree_of_record_fields depth env path type_params ty_list
           lbl_list pos obj unboxed =

--- a/toplevel/genprintval.ml
+++ b/toplevel/genprintval.ml
@@ -304,61 +304,8 @@ module Make(O : OBJ)(EVP : EVALPATH with type valu = O.t) = struct
 
               | Tconstr (path, [ty_arg], _)
                 when Path.same path Predef.path_lazy_t ->
-                let obj_tag = O.tag obj in
-                (* Lazy values are represented in three possible ways:
+                tree_of_lazy depth obj ty_arg
 
-                    1. a lazy thunk that is not yet forced has tag
-                      Obj.lazy_tag
-
-                    2. a lazy thunk that has just been forced has tag
-                      Obj.forward_tag; its first field is the forced
-                      result, which we can print
-
-                    3. when the GC moves a forced trunk with forward_tag,
-                      or when a thunk is directly created from a value,
-                      we get a third representation where the value is
-                      directly exposed, without the Obj.forward_tag
-                      (if its own tag is not ambiguous, that is neither
-                      lazy_tag nor forward_tag)
-
-                    Note that using Lazy.is_val and Lazy.force would be
-                    unsafe, because they use the Obj.* functions rather
-                    than the O.* functions of the functor argument, and
-                    would thus crash if called from the toplevel
-                    (debugger/printval instantiates Genprintval.Make with
-                    an Obj module talking over a socket).
-                  *)
-                if obj_tag = Obj.lazy_tag then Oval_stuff "<lazy>"
-                else begin
-                    let forced_obj =
-                      if obj_tag = Obj.forward_tag then O.field obj 0 else obj
-                    in
-                    (* calling oneself recursively on forced_obj risks
-                        having a false positive for cycle detection;
-                        indeed, in case (3) above, the value is stored
-                        as-is instead of being wrapped in a forward
-                        pointer. It means that, for (lazy "foo"), we have
-                          forced_obj == obj
-                        and it is easy to wrongly print (lazy <cycle>) in such
-                        a case (PR#6669).
-
-                        Unfortunately, there is a corner-case that *is*
-                        a real cycle: using unboxed types one can define
-
-                          type t = T : t Lazy.t -> t [@@unboxed]
-                          let rec x = lazy (T x)
-
-                        which creates a Forward_tagged block that points to
-                        itself. For this reason, we still "nest"
-                        (detect head cycles) on forward tags.
-                      *)
-                    let v =
-                      if obj_tag = Obj.forward_tag
-                      then nest tree_of_val depth forced_obj ty_arg
-                      else      tree_of_val depth forced_obj ty_arg
-                    in
-                    Oval_lazy v
-                  end
             | _ -> begin try
                 let decl = Env.find_type path env in
                 match decl with
@@ -453,6 +400,63 @@ module Make(O : OBJ)(EVP : EVALPATH with type valu = O.t) = struct
                 else tree_list
               in
               Oval_array (List.rev (tree_of_items [] 0))
+
+      and tree_of_lazy depth obj ty_arg =
+        let obj_tag = O.tag obj in
+        (* Lazy values are represented in three possible ways:
+
+            1. a lazy thunk that is not yet forced has tag
+              Obj.lazy_tag
+
+            2. a lazy thunk that has just been forced has tag
+              Obj.forward_tag; its first field is the forced
+              result, which we can print
+
+            3. when the GC moves a forced trunk with forward_tag,
+              or when a thunk is directly created from a value,
+              we get a third representation where the value is
+              directly exposed, without the Obj.forward_tag
+              (if its own tag is not ambiguous, that is neither
+              lazy_tag nor forward_tag)
+
+            Note that using Lazy.is_val and Lazy.force would be
+            unsafe, because they use the Obj.* functions rather
+            than the O.* functions of the functor argument, and
+            would thus crash if called from the toplevel
+            (debugger/printval instantiates Genprintval.Make with
+            an Obj module talking over a socket).
+          *)
+        if obj_tag = Obj.lazy_tag then Oval_stuff "<lazy>"
+        else begin
+            let forced_obj =
+              if obj_tag = Obj.forward_tag then O.field obj 0 else obj
+            in
+            (* calling oneself recursively on forced_obj risks
+                having a false positive for cycle detection;
+                indeed, in case (3) above, the value is stored
+                as-is instead of being wrapped in a forward
+                pointer. It means that, for (lazy "foo"), we have
+                  forced_obj == obj
+                and it is easy to wrongly print (lazy <cycle>) in such
+                a case (PR#6669).
+
+                Unfortunately, there is a corner-case that *is*
+                a real cycle: using unboxed types one can define
+
+                  type t = T : t Lazy.t -> t [@@unboxed]
+                  let rec x = lazy (T x)
+
+                which creates a Forward_tagged block that points to
+                itself. For this reason, we still "nest"
+                (detect head cycles) on forward tags.
+              *)
+            let v =
+              if obj_tag = Obj.forward_tag
+              then nest tree_of_val depth forced_obj ty_arg
+              else      tree_of_val depth forced_obj ty_arg
+            in
+            Oval_lazy v
+          end
 
       and tree_of_variant depth decl path ty_list obj constr_list rep =
         let unbx = (rep = Variant_unboxed) in


### PR DESCRIPTION
This PR is extracted from my in-progress rebase of unboxed constructors. I propose it for trunk inclusion now because @Octachron has worked on this part of the codebase recently ( https://github.com/ocaml/ocaml/commit/62726f00f9443c77f2f90d90b5f8c3ed800d9b00 ) and would have benefited from it being already included.

This is mostly moving code around for readability, there is a change to update printing of lazy values to OCaml 5, and then a commit to clarify the flow of exceptions.

(I guess @Octachron would be a natural reviewer given that he worked on exactly this part of the code 2 hours ago.)