### PR TITLE
Do not write to event ring after going out of stw participant set.

### DIFF
--- a/Changes
+++ b/Changes
@@ -34,6 +34,9 @@ Working version
   (Tim McGilchrist, review by KC Sivaramakrishnan, Fabrice Buoro
    and Miod Vallat)
 
+- #13529: Do not write to event ring after going out of stw participant set.
+  (KC Sivaramakrishnan, review by Sadiq Jaffer)
+
 ### Code generation and optimizations:
 
 ### Standard library:

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -576,6 +576,14 @@ static inline intnat diffmod (uintnat x1, uintnat x2)
   return (intnat) (x1 - x2);
 }
 
+/* The [log_events] parameter is used to disable writing to the ring for two
+   reasons:
+   1. To prevent spamming the ring with numerous events generated during
+      an opportunistic GC slice.
+   2. To avoid logging events when the calling domain is not part of the
+      Stop-The-World (STW) participant set. If the domain is not part of
+      the STW set, the ring could be torn down concurrently while this domain
+      attempts to write to it. */
 static void
 update_major_slice_work(intnat howmuch,
                         int may_access_gc_phase,
@@ -721,7 +729,6 @@ update_major_slice_work(intnat howmuch,
               );
 
   if (log_events) {
-    /* Avoid spamming the ring when doing opportunistic slices */
     CAML_EV_COUNTER(EV_C_MAJOR_HEAP_WORDS, (uintnat)heap_words);
     CAML_EV_COUNTER(EV_C_MAJOR_ALLOCATED_WORDS, my_alloc_count);
     CAML_EV_COUNTER(EV_C_MAJOR_ALLOCATED_WORK, alloc_work);
@@ -2124,8 +2131,10 @@ void caml_teardown_major_gc(void) {
    so we may not access the gc phase. */
   int may_access_gc_phase = 0;
 
-  /* account for latest allocations */
-  update_major_slice_work (0, may_access_gc_phase, 1);
+  /* Account for latest allocations, but do not write to the event ring since
+     we are out of the STW participant set; the ring may be torn down
+     concurrently. */
+  update_major_slice_work (0, may_access_gc_phase, 0);
   CAMLassert(!caml_addrmap_iter_ok(&d->mark_stack->compressed_stack,
                                    d->mark_stack->compressed_stack_iter));
   caml_addrmap_clear(&d->mark_stack->compressed_stack);


### PR DESCRIPTION
When the runtime events ring is destroyed, only the domains that are part of the stop-the-world (stw) participant list are stopped. So it is unsafe to write to ring when the domain is not part of the stw participant set.

This fixes the data race in `lib-runtime-events/test_dropped_events`. I was able to reliably trigger data race in `test_dropped_events` on M2 macOS on trunk.

```
> WARNING: ThreadSanitizer: data race (pid=15812)                                                                    
>   Write of size 8 at 0x00010469c920 by main thread (mutexes: write M0):           
>     #0 stw_teardown_runtime_events runtime_events.c:435 (test_dropped_events.opt:arm64+0x1000df800)
>     #1 caml_try_run_on_all_domains_with_spin_work domain.c:1691 (test_dropped_events.opt:arm64+0x1000aeec0)                                                                                                                             
>     #2 caml_try_run_on_all_domains domain.c:1713 (test_dropped_events.opt:arm64+0x1000acf44)                                                                                                                                            >     #3 caml_runtime_events_destroy runtime_events.c:232 (test_dropped_events.opt:arm64+0x1000df4b4)                                                                                                                                     
>     #4 caml_do_exit sys.c:188 (test_dropped_events.opt:arm64+0x1000e99d4)                                                                                                                                                               
>     #5 main main.c:38 (test_dropped_events.opt:arm64+0x1000cc59c)                                                                                                                                                                       
>                                                                                                                    
>   Previous read of size 8 at 0x00010469c920 by thread T1 (mutexes: write M1, write M2):
>     #0 write_to_ring runtime_events.c:529 (test_dropped_events.opt:arm64+0x1000df568)
>     #1 caml_ev_counter runtime_events.c:635 (test_dropped_events.opt:arm64+0x1000e03d8)                                                                                                                                                 >     #2 update_major_slice_work major_gc.c:733 (test_dropped_events.opt:arm64+0x1000cf8b8)
>     #3 caml_teardown_major_gc major_gc.c:2128 (test_dropped_events.opt:arm64+0x1000cf3c8)
>     #4 domain_thread_func domain.c:1248 (test_dropped_events.opt:arm64+0x1000ae534)
>                                                                                                                                                                                                                                         
>   Location is global 'current_metadata' at 0x00010469c920 (test_dropped_events.opt+0x10017c920)    
```

With this PR, the data race is gone.