### PR TITLE
doc(Random.get_state): warn about duplicate random numbers

### DIFF
--- a/stdlib/random.mli
+++ b/stdlib/random.mli
@@ -254,7 +254,14 @@ end
 
 val get_state : unit -> State.t
 (** [get_state()] returns a fresh copy of the current state of the
-    domain-local generator (which is used by the basic functions). *)
+    domain-local generator (which is used by the basic functions).
+
+    The current state is unchanged, which means that random numbers
+    generated from multiple calls to [get_state ()] will be identical.
+
+    See {!Random.State.make_self_init} and {!Random.split} instead to obtain
+    a fresh state that is not shared.
+ *)
 
 val set_state : State.t -> unit
 (** [set_state s] updates the current state of the domain-local


### PR DESCRIPTION
`Random.get_state` is the first function in the `Random` module that returns a `State.t`, but it is rarely the function one should use, unless they really want identical random numbers being generated in different parts of a program.

It'd be much better to obtain a fresh state from `Random.State.make_self_init ()`, or on 5.0+ use `Random.split ()`.

Make the documentation more explicit about this.

This is not just a theoretical problem, I've spotted this problem during code review on a PR to XAPI https://github.com/xapi-project/xen-api

Context: Uuidm has deprecated its [v](https://ocaml.org/p/uuidm/latest/doc/Uuidm/index.html#val-v) function, requesting to use `Uuidm.v4_gen` which requires a Random.State.t as input.

`Random.get_state ()` may look deceptively like the function to use, but a closer reading of its documentation and a runtime test shows that it is not, and results in duplicate UUIDs:
```
utop # Uuidm.v4_gen (Random.get_state ()) () |> Uuidm.to_string;;
- : string = "452f33b4-4382-4d30-990a-ed3ccaaaeeb4"
─( 14:00:34 )─< command 8 >─────────────────────────────────────────────────────────────────────────────{ counter: 0 }─
utop # Uuidm.v4_gen (Random.get_state ()) () |> Uuidm.to_string;;
- : string = "452f33b4-4382-4d30-990a-ed3ccaaaeeb4"
```

Instead this works:
```
─( 14:00:22 )─< command 5 >─────────────────────────────────────────────────────────────────────────────{ counter: 0 }─
utop # Uuidm.v4_gen (Random.State.make_self_init ()) () |> Uuidm.to_string;;
- : string = "1cd8479a-b903-4e76-b49a-0abae94dfbc3"
─( 14:00:27 )─< command 6 >─────────────────────────────────────────────────────────────────────────────{ counter: 0 }─
utop # Uuidm.v4_gen (Random.State.make_self_init ()) () |> Uuidm.to_string;;
- : string = "d5787dff-173c-443e-8ddf-aac7a23df427"

```

Or on OCaml 5, the `split` function correctly updates the parent:
```
utop # Uuidm.v4_gen (Random.split ()) () |> Uuidm.to_string;;
- : string = "fef137ac-98ab-41ae-a784-bac9c261f067"
─( 14:04:07 )─< command 6 >─────────────────────────────────────────────────────────────────────────────{ counter: 0 }─
utop # Uuidm.v4_gen (Random.split ()) () |> Uuidm.to_string;;
- : string = "95c66c88-71ed-49e5-977d-a9cc4695f00f"
```
