### PR TITLE
Add explanation to the doc of `Hashtbl.create`

### DIFF
--- a/Changes
+++ b/Changes
@@ -79,6 +79,12 @@ Working version
 
 ### Manual and documentation:
 
+- #13469, #13474, #13535: Document that [Hashtbl.create n] creates a hash table
+  with a default minimal size, even if [n] is very small or negative.
+  (Antonin Décimo, Nick Bares, report by Nikolaus Huber and Jan Midtgaard,
+   review by Florian Angeletti, Anil Madhavapeddy, Gabriel Scherer,
+   and Miod Vallat)
+
 ### Compiler user-interface and warnings:
 
 - #13428: support dump=[source | parsetree | lambda | ... | cmm | ...]

--- a/stdlib/hashtbl.mli
+++ b/stdlib/hashtbl.mli
@@ -64,11 +64,12 @@ type (!'a, !'b) t
 
 val create : ?random: (* thwart tools/sync_stdlib_docs *) bool ->
              int -> ('a, 'b) t
-(** [Hashtbl.create n] creates a new, empty hash table, with
-   initial size [n].  For best results, [n] should be on the
-   order of the expected number of elements that will be in
-   the table.  The table grows as needed, so [n] is just an
-   initial guess.
+(** [Hashtbl.create n] creates a new, empty hash table, with initial
+   size greater or equal to the suggested size [n].  For best results,
+   [n] should be on the order of the expected number of elements that
+   will be in the table.  The table grows as needed, so [n] is just an
+   initial guess.  If [n] is very small or negative then it is
+   disregarded and a small default size is used.
 
    The optional [~random] parameter (a boolean) controls whether
    the internal organization of the hash table is randomized at each

--- a/stdlib/moreLabels.mli
+++ b/stdlib/moreLabels.mli
@@ -81,11 +81,12 @@ module Hashtbl : sig
 
   val create : ?random: (* thwart tools/sync_stdlib_docs *) bool ->
                int -> ('a, 'b) t
-  (** [Hashtbl.create n] creates a new, empty hash table, with
-     initial size [n].  For best results, [n] should be on the
-     order of the expected number of elements that will be in
-     the table.  The table grows as needed, so [n] is just an
-     initial guess.
+  (** [Hashtbl.create n] creates a new, empty hash table, with initial
+     size greater or equal to the suggested size [n].  For best results,
+     [n] should be on the order of the expected number of elements that
+     will be in the table.  The table grows as needed, so [n] is just an
+     initial guess.  If [n] is very small or negative then it is
+     disregarded and a small default size is used.
 
      The optional [~random] parameter (a boolean) controls whether
      the internal organization of the hash table is randomized at each

--- a/stdlib/templates/hashtbl.template.mli
+++ b/stdlib/templates/hashtbl.template.mli
@@ -64,11 +64,12 @@ type (!'a, !'b) t
 
 val create : ?random: (* thwart tools/sync_stdlib_docs *) bool ->
              int -> ('a, 'b) t
-(** [Hashtbl.create n] creates a new, empty hash table, with
-   initial size [n].  For best results, [n] should be on the
-   order of the expected number of elements that will be in
-   the table.  The table grows as needed, so [n] is just an
-   initial guess.
+(** [Hashtbl.create n] creates a new, empty hash table, with initial
+   size greater or equal to the suggested size [n].  For best results,
+   [n] should be on the order of the expected number of elements that
+   will be in the table.  The table grows as needed, so [n] is just an
+   initial guess.  If [n] is very small or negative then it is
+   disregarded and a small default size is used.
 
    The optional [~random] parameter (a boolean) controls whether
    the internal organization of the hash table is randomized at each


### PR DESCRIPTION
Majority view in the triage discussion of #13474 concluded that we should allow negative values but document that they are disregarded.
Fix #13469.
cc @NickBarnes 