### PR TITLE
toplevel: print shorter paths for constructors/labels in submodules of open modules

### DIFF
--- a/.depend
+++ b/.depend
@@ -7292,6 +7292,7 @@ toplevel/expunge.cmx : \
     toplevel/expunge.cmi
 toplevel/expunge.cmi :
 toplevel/genprintval.cmo : \
+    typing/untypeast.cmi \
     typing/types.cmi \
     parsing/syntaxerr.cmi \
     typing/printtyp.cmi \
@@ -7303,6 +7304,7 @@ toplevel/genprintval.cmo : \
     typing/oprint.cmi \
     utils/misc.cmi \
     parsing/longident.cmi \
+    parsing/location.cmi \
     parsing/lexer.cmi \
     typing/ident.cmi \
     utils/format_doc.cmi \
@@ -7313,6 +7315,7 @@ toplevel/genprintval.cmo : \
     typing/btype.cmi \
     toplevel/genprintval.cmi
 toplevel/genprintval.cmx : \
+    typing/untypeast.cmx \
     typing/types.cmx \
     parsing/syntaxerr.cmx \
     typing/printtyp.cmx \
@@ -7324,6 +7327,7 @@ toplevel/genprintval.cmx : \
     typing/oprint.cmx \
     utils/misc.cmx \
     parsing/longident.cmx \
+    parsing/location.cmx \
     parsing/lexer.cmx \
     typing/ident.cmx \
     utils/format_doc.cmx \

--- a/Changes
+++ b/Changes
@@ -120,6 +120,10 @@ Working version
   output.
   (Romain Beauxis, review by David Allsopp)
 
+- #12642, #13536: in the toplevel, print shorter paths for constructors
+  and labels when only some modules along their path are open.
+  (Gabriel Scherer, review by Florian Angeletti)
+
 ### Manual and documentation:
 
 - #13469, #13474, #13535: Document that [Hashtbl.create n] creates a hash table

--- a/testsuite/tests/tool-toplevel/constructor_printing.ml
+++ b/testsuite/tests/tool-toplevel/constructor_printing.ml
@@ -50,3 +50,25 @@ let it = (D, E, F)
 [%%expect {|
 val it : O.P.t * O.P.t * O.P.t = (D, E, F)
 |}]
+
+(* Introduce Q with a Sub submodule *)
+module Q = struct
+  module Sub = struct type t = A end
+end
+
+(* open Q: Q.Sub.A can now be printed as Sub.A *)
+open Q
+
+(* shadow the Sub module:
+   Sub.A is not a valid printing choice for Q.Sub.A anymore *)
+module Sub = struct end
+[%%expect {|
+module Q : sig module Sub : sig type t = A end end
+module Sub : sig end
+|}]
+
+(* Test the printing of Q.Sub.A *)
+let it = Q.Sub.A
+[%%expect {|
+val it : Q.Sub.t = Q.Sub.A
+|}]

--- a/testsuite/tests/tool-toplevel/constructor_printing.ml
+++ b/testsuite/tests/tool-toplevel/constructor_printing.ml
@@ -1,0 +1,53 @@
+(* TEST
+ expect;
+*)
+
+module M = struct
+  module N = struct
+    type t = A | B | C
+  end
+end
+[%%expect {|
+module M : sig module N : sig type t = A | B | C end end
+|}]
+
+let it = (M.N.A, M.N.B, M.N.C)
+[%%expect {|
+val it : M.N.t * M.N.t * M.N.t = (M.N.A, M.N.B, M.N.C)
+|}]
+
+open M
+let it = (N.A, N.B, N.C)
+(* The behavior in this case is known to be suboptimal: #12642. *)
+[%%expect {|
+val it : M.N.t * M.N.t * M.N.t = (M.N.A, M.N.B, M.N.C)
+|}]
+
+open N
+
+let it = (A, B, C)
+[%%expect {|
+val it : M.N.t * M.N.t * M.N.t = (A, B, C)
+|}]
+
+
+module O = struct
+  module P = struct
+    type t = D | E | F
+  end
+end
+[%%expect {|
+module O : sig module P : sig type t = D | E | F end end
+|}]
+
+let it = (O.P.D, O.P.E, O.P.F)
+[%%expect {|
+val it : O.P.t * O.P.t * O.P.t = (O.P.D, O.P.E, O.P.F)
+|}]
+
+open O.P
+
+let it = (D, E, F)
+[%%expect {|
+val it : O.P.t * O.P.t * O.P.t = (D, E, F)
+|}]

--- a/testsuite/tests/tool-toplevel/constructor_printing.ml
+++ b/testsuite/tests/tool-toplevel/constructor_printing.ml
@@ -18,9 +18,8 @@ val it : M.N.t * M.N.t * M.N.t = (M.N.A, M.N.B, M.N.C)
 
 open M
 let it = (N.A, N.B, N.C)
-(* The behavior in this case is known to be suboptimal: #12642. *)
 [%%expect {|
-val it : M.N.t * M.N.t * M.N.t = (M.N.A, M.N.B, M.N.C)
+val it : M.N.t * M.N.t * M.N.t = (N.A, N.B, N.C)
 |}]
 
 open N

--- a/testsuite/tests/tool-toplevel/constructor_printing.ml
+++ b/testsuite/tests/tool-toplevel/constructor_printing.ml
@@ -72,3 +72,30 @@ let it = Q.Sub.A
 [%%expect {|
 val it : Q.Sub.t = Q.Sub.A
 |}]
+
+(* A "hellish example" from Florian Angeletti. *)
+module M = struct
+  module N = struct
+    module A = struct
+      module B = struct
+        type t = X
+      end
+    end
+    module F(X:sig type t end) = struct type t = A of X.t end
+  end
+end
+open M open N open A open B
+[%%expect {|
+module M :
+  sig
+    module N :
+      sig
+        module A : sig module B : sig type t = X end end
+        module F : (X : sig type t end) -> sig type t = A of X.t end
+      end
+  end
+|}]
+let x = let module FB = F(B) in FB.A X
+[%%expect {|
+val x : M.N.F(M.N.A.B).t = M.N.F(M.N.A.B).A X
+|}]

--- a/toplevel/genprintval.ml
+++ b/toplevel/genprintval.ml
@@ -206,34 +206,70 @@ module Make(O : OBJ)(EVP : EVALPATH with type valu = O.t) = struct
        it comes from. Attempt to omit the prefix if the type comes from
        a module that has been opened. *)
 
-    let tree_of_qualified find env ty_path name =
-      match ty_path with
-      | Pident _ ->
-          tree_of_name name
-      | Pdot(p, _s) ->
-          if
-            match get_desc (find (Lident name) env) with
-            | Tconstr(ty_path', _, _) -> Path.same ty_path ty_path'
-            | _ -> false
-            | exception Not_found -> false
-          then tree_of_name name
-          else Oide_dot (Out_type.tree_of_path p, name)
-      | Papply _ ->
-          Out_type.tree_of_path ty_path
-      | Pextra_ty _ ->
-          (* These can only appear directly inside of the associated
-             constructor so we can just drop the prefix *)
-          tree_of_name name
+    let tree_of_qualified lookup_all get_path env ty_path name =
+      (* If [ty_path] is [M.N.t] and [name] is [Foo], we want to find
+         a short name for [M.N.Foo] in the current typing environment.
+         Our strategy is to try [Foo], [N.Foo] and [M.N.Foo] in
+         turn. *)
+
+      (* Start by transforming the path [M.N.t] into the Longident [M.N.Foo]. *)
+      let lid = match Untypeast.lident_of_path ty_path with
+        | Lident _ -> Lident name
+        | Ldot (p,_) -> Ldot(p,name)
+        | x -> x
+      in
+
+      (* [candidates exn M.N.Foo] is [Foo; N.Foo; M.N.Foo].
+         @raise [exn] on functor application. *)
+      let candidates apply_exn lid =
+        (* [loop M.N [Foo]] is [[Foo]; [N; Foo]; [M; N; Foo]] *)
+        let rec loop lid suff = match lid with
+          | Lident last -> [suff; (last :: suff)]
+          | Ldot(p, s) -> suff :: loop p (s :: suff)
+          | Lapply _ -> raise apply_exn
+        in
+        loop lid [] (* [[]; [Foo]; [N; Foo]; [M; N; Foo]] *)
+        |> List.filter_map Longident.unflatten
+      in
+
+      (* A shorter name is correct (matches) if one of its possible
+         interpretations (there may be several constructors with the
+         same name at different types in a module) has the same type
+         path as the one we are printing. *)
+      let matches lid =
+        match lookup_all lid env with
+        | Error _ -> false
+        | Ok cstrs ->
+            List.exists (fun (cstr, _) ->
+              Path.same (get_path cstr) ty_path
+            ) cstrs
+      in
+
+      let rec tree_of_lident = function
+        | Lident name ->
+            tree_of_name name
+        | Ldot (lid, name) ->
+            Oide_dot (tree_of_lident lid, name)
+        | Lapply (lid1, lid2) ->
+            Oide_apply (tree_of_lident lid1, tree_of_lident lid2)
+      in
+
+      let exception Functor_application in
+      match List.find matches (candidates Functor_application lid) with
+      | exception (Functor_application | Not_found) ->
+          tree_of_lident lid
+      | best_lid ->
+          tree_of_lident best_lid
 
     let tree_of_constr =
       tree_of_qualified
-        (fun lid env ->
-          (Env.find_constructor_by_name lid env).cstr_res)
+        (Env.lookup_all_constructors ~use:false ~loc:Location.none Env.Positive)
+        Data_types.cstr_res_type_path
 
     and tree_of_label =
       tree_of_qualified
-        (fun lid env ->
-          (Env.find_label_by_name lid env).lbl_res)
+        (Env.lookup_all_labels ~use:false ~loc:Location.none Env.Construct)
+        Data_types.lbl_res_type_path
 
     (* An abstract type *)
 

--- a/typing/data_types.ml
+++ b/typing/data_types.ml
@@ -71,8 +71,9 @@ let cstr_res_type_path cstr =
 
 type label_description =
   { lbl_name: string;                   (* Short name *)
-    lbl_res: type_expr;                 (* Type of the result *)
-    lbl_arg: type_expr;                 (* Type of the argument *)
+    lbl_res: type_expr;                 (* Type of the result (the record) *)
+    lbl_arg: type_expr;                 (* Type of the argument
+                                           (the field value) *)
     lbl_mut: mutable_flag;              (* Is this a mutable field? *)
     lbl_pos: int;                       (* Position in block *)
     lbl_all: label_description array;   (* All the labels in this type *)
@@ -82,3 +83,8 @@ type label_description =
     lbl_attributes: Parsetree.attributes;
     lbl_uid: Uid.t;
    }
+
+let lbl_res_type_path lbl =
+  match get_desc lbl.lbl_res with
+  | Tconstr (p, _, _) -> p
+  | _ -> assert false

--- a/typing/data_types.mli
+++ b/typing/data_types.mli
@@ -57,8 +57,9 @@ val cstr_res_type_path : constructor_description -> Path.t
 
 type label_description =
   { lbl_name: string;                   (* Short name *)
-    lbl_res: type_expr;                 (* Type of the result *)
-    lbl_arg: type_expr;                 (* Type of the argument *)
+    lbl_res: type_expr;                 (* Type of the result (the record) *)
+    lbl_arg: type_expr;                 (* Type of the argument
+                                           (the field value) *)
     lbl_mut: mutable_flag;              (* Is this a mutable field? *)
     lbl_pos: int;                       (* Position in block *)
     lbl_all: label_description array;   (* All the labels in this type *)
@@ -68,3 +69,6 @@ type label_description =
     lbl_attributes: Parsetree.attributes;
     lbl_uid: Uid.t;
   }
+
+(* Type constructor of the label record type. *)
+val lbl_res_type_path : label_description -> Path.t


### PR DESCRIPTION
This is my attempt at fixing #12642. Reminder of what the issue is:

```ocaml
# module M = struct
    module N = struct
      type t = A | B | C
      let x = (A, B, C)
  end
end;;

(* Expected output. *)
# M.N.x;;
- : M.N.t * M.N.t * M.N.t = (M.N.A, M.N.B, M.N.C)
(* with short-paths: same output *)

# open M;;

(* Unexpected output. This is the problem here: *)
# N.x;;
- : M.N.t * M.N.t * M.N.t = (M.N.A, M.N.B, M.N.C)
(* with -short-paths:
- : N.t * N.t * N.t = (M.N.A, M.N.B, M.N.C)
*)

# open N;;

(* Expected output. *)
# x;;
- : M.N.t * M.N.t * M.N.t = (A, B, C)
(* with -short-paths:
- : t * t * t = (A, B, C)
*)
```

Currently, to print `M.N.Foo`, the toplevel printer tries to get lucky and see if just `Foo` works, and otherwise it prints `M.N.Foo`. With the proposed changes, it will try all of `Foo`, `N.Foo` and `M.N.Foo` in order.

(There is a surprising amount of list gymnastics involved, because paths/idents are snoc lists, and computing the list [Foo; N.Foo; M.N.Foo] is harder than I would have guessed.)

At the risk of putting too much weight on the same camel, I'm afraid that @Octachron is the perfect reviewer for this.
