### PR TITLE
Annotate alloc/free open/close functions with compiler attributes

### DIFF
--- a/Changes
+++ b/Changes
@@ -95,6 +95,10 @@ Working version
 - #13460: introduce a variant of all predefined types
   (Gabriel Scherer, review by Ulysse Gérard and Florian Angeletti)
 
+- #13457, #13537: Annotate alloc/free open/close pairs of functions
+  with compiler attributes for static analysis.
+  (Antonin Décimo, review by Gabriel Scherer and Florian Angeletti)
+
 ### Build system:
 
 ### Bug fixes:

--- a/runtime/caml/io.h
+++ b/runtime/caml/io.h
@@ -76,9 +76,11 @@ enum {
 
 /* Creating and closing channels from C */
 
-CAMLextern struct channel * caml_open_descriptor_in (int);
-CAMLextern struct channel * caml_open_descriptor_out (int);
 CAMLextern void caml_close_channel (struct channel *);
+CAMLalloc(caml_close_channel, 1) CAMLreturns_nonnull()
+CAMLextern struct channel * caml_open_descriptor_in (int);
+CAMLalloc(caml_close_channel, 1) CAMLreturns_nonnull()
+CAMLextern struct channel * caml_open_descriptor_out (int);
 CAMLextern file_offset caml_channel_size (struct channel *);
 CAMLextern void caml_seek_in (struct channel *, file_offset);
 CAMLextern void caml_seek_out (struct channel *, file_offset);

--- a/runtime/caml/memory.h
+++ b/runtime/caml/memory.h
@@ -79,16 +79,21 @@ CAMLextern void caml_stat_destroy_pool(void);
 
 #endif /* CAML_INTERNALS */
 
+/* [caml_stat_free(block)] deallocates the provided [block]. */
+CAMLextern void caml_stat_free(caml_stat_block);
+
 /* [caml_stat_alloc(size)] allocates a memory block of the requested [size]
    (in bytes) and returns a pointer to it. It throws an OCaml exception in case
    the request fails, and so requires the runtime lock to be held.
 */
+CAMLmalloc(caml_stat_free, 1, 1) CAMLreturns_nonnull()
 CAMLextern caml_stat_block caml_stat_alloc(asize_t);
 
 /* [caml_stat_alloc_noexc(size)] allocates a memory block of the requested
    [size] (in bytes) and returns a pointer to it, or NULL in case the request
    fails.
 */
+CAMLmalloc(caml_stat_free, 1, 1)
 CAMLextern caml_stat_block caml_stat_alloc_noexc(asize_t);
 
 /* [caml_stat_alloc_aligned(size, modulo, block*)] allocates a memory block of
@@ -97,12 +102,14 @@ CAMLextern caml_stat_block caml_stat_alloc_noexc(asize_t);
    well as the unaligned [block] (as an output parameter). It throws an OCaml
    exception in case the request fails, and so requires the runtime lock.
 */
+CAMLaligned_alloc(caml_stat_free, 1, 1, 2) CAMLreturns_nonnull()
 CAMLextern void* caml_stat_alloc_aligned(asize_t, int modulo, caml_stat_block*);
 
 /* [caml_stat_alloc_aligned_noexc] is a variant of [caml_stat_alloc_aligned]
    that returns NULL in case the request fails, and doesn't require the runtime
    lock to be held.
 */
+CAMLaligned_alloc(caml_stat_free, 1, 1, 2)
 CAMLextern void* caml_stat_alloc_aligned_noexc(asize_t, int modulo,
                                                caml_stat_block*);
 
@@ -111,10 +118,8 @@ CAMLextern void* caml_stat_alloc_aligned_noexc(asize_t, int modulo,
    bits to zero, effectively allocating a zero-initialized memory block of
    [num * size] bytes. It returns NULL in case the request fails.
 */
+CAMLcalloc(caml_stat_free, 1, 1, 2)
 CAMLextern caml_stat_block caml_stat_calloc_noexc(asize_t, asize_t);
-
-/* [caml_stat_free(block)] deallocates the provided [block]. */
-CAMLextern void caml_stat_free(caml_stat_block);
 
 /* [caml_stat_resize(block, size)] changes the size of the provided [block] to
    [size] bytes. The function may move the memory block to a new location (whose
@@ -124,11 +129,13 @@ CAMLextern void caml_stat_free(caml_stat_block);
    portion is indeterminate. The function throws an OCaml exception in case the
    request fails, and so requires the runtime lock to be held.
 */
+CAMLrealloc(2) CAMLreturns_nonnull()
 CAMLextern caml_stat_block caml_stat_resize(caml_stat_block, asize_t);
 
 /* [caml_stat_resize_noexc] is a variant of [caml_stat_resize] that returns NULL
    in case the request fails, and doesn't require the runtime lock.
 */
+CAMLrealloc(2)
 CAMLextern caml_stat_block caml_stat_resize_noexc(caml_stat_block, asize_t);
 
 
@@ -139,11 +146,13 @@ typedef char* caml_stat_string;
    copy of the null-terminated string [s]. It throws an OCaml exception in case
    the request fails, and so requires the runtime lock to be held.
 */
+CAMLalloc(caml_stat_free, 1) CAMLreturns_nonnull()
 CAMLextern caml_stat_string caml_stat_strdup(const char *s);
 
 /* [caml_stat_strdup_noexc] is a variant of [caml_stat_strdup] that returns NULL
    in case the request fails, and doesn't require the runtime lock.
 */
+CAMLalloc(caml_stat_free, 1)
 CAMLextern caml_stat_string caml_stat_strdup_noexc(const char *s);
 
 #ifdef _WIN32
@@ -151,7 +160,9 @@ CAMLextern caml_stat_string caml_stat_strdup_noexc(const char *s);
  * obvious equivalents of [caml_stat_strdup] and
  * [caml_stat_strdup_noexc] for wide characters.
  */
+CAMLalloc(caml_stat_free, 1) CAMLreturns_nonnull()
 CAMLextern wchar_t* caml_stat_wcsdup(const wchar_t *s);
+CAMLalloc(caml_stat_free, 1)
 CAMLextern wchar_t* caml_stat_wcsdup_noexc(const wchar_t *s);
 #endif
 
@@ -160,8 +171,10 @@ CAMLextern wchar_t* caml_stat_wcsdup_noexc(const wchar_t *s);
    except for the very last one. It throws an OCaml exception in case the
    request fails, and so requires the runtime lock to be held.
 */
+CAMLalloc(caml_stat_free, 1) CAMLreturns_nonnull()
 CAMLextern caml_stat_string caml_stat_strconcat(int n, ...);
 #ifdef _WIN32
+CAMLalloc(caml_stat_free, 1) CAMLreturns_nonnull()
 CAMLextern wchar_t* caml_stat_wcsconcat(int n, ...);
 #endif
 

--- a/runtime/caml/misc.h
+++ b/runtime/caml/misc.h
@@ -220,6 +220,72 @@ CAMLdeprecated_typedef(addr, char *);
 #endif
 #endif /* CAML_INTERNALS */
 
+/* Function attributes to give hints to the C compiler about optimizations and
+   static analysis. Intended for functions allocating and deallocating memory,
+   or opening and closing resources.
+   https://clang.llvm.org/docs/AttributeReference.html#function-attributes
+   https://gcc.gnu.org/onlinedocs/gcc-14.2.0/gcc/Common-Function-Attributes.html
+*/
+#if __has_attribute(malloc) && __has_attribute(warn_unused_result) &&   \
+    __has_attribute(alloc_size) && __has_attribute(alloc_align) &&      \
+    __has_attribute(returns_nonnull) &&                                 \
+    ((defined(__GNUC__) && __GNUC__ >= 14) || /* false-positives in GCC<14 */ \
+     defined(__llvm__))
+
+/* Indicates that a particular function always returns a non-null pointer. */
+#define CAMLreturns_nonnull() __attribute__ ((returns_nonnull))
+
+/* [CAMLrealloc(n)] indicates that the function is [realloc]-like, and implies
+   that the [n]-th argument number equals the number of available bytes at the
+   returned pointer. */
+#define CAMLrealloc(alloc_size_N,...)                           \
+  __attribute__ ((warn_unused_result,alloc_size(alloc_size_N)))
+
+/* [CAMLalloc(dealloc, p)] indicates that the function allocates a resource,
+   which must be deallocated by passing it as the [p]-th argument of the
+   function [dealloc]. */
+#if defined(__GNUC__) && !defined(__llvm__)
+#define CAMLalloc(deallocator,ptr_index,...)                            \
+  __attribute__ ((malloc,malloc(deallocator,ptr_index),warn_unused_result))
+#else
+#define CAMLalloc(deallocator,ptr_index,...)    \
+  __attribute__ ((malloc,warn_unused_result))
+#endif
+
+/* [CAMLmalloc(dealloc, p, n)] indicates that the function is [malloc]-like, and
+   implies that it allocates a memory block whose size is set by the function's
+   [n]-th argument, and which must be deallocated by passing it as the [p]-th
+   argument of the function [dealloc]. */
+#define CAMLmalloc(deallocator,ptr_index,alloc_size_N,...)      \
+  CAMLalloc(deallocator,ptr_index)                              \
+    __attribute__ ((alloc_size(alloc_size_N)))
+
+/* [CAMLcalloc(dealloc, p, n, m)] indicates that the function is [calloc]-like,
+   and implies that it allocates a memory block whose size is set by the product
+   of the function's [n]-th and [m]-th arguments, and which must be deallocated
+   by passing it as the [p]-th argument of the function [dealloc]. */
+#define CAMLcalloc(deallocator,ptr_index,alloc_size_N,alloc_size_M,...) \
+  CAMLalloc(deallocator,ptr_index)                                      \
+    __attribute__ ((alloc_size(alloc_size_N,alloc_size_M)))
+
+/* [CAMLaligned_alloc(dealloc, p, n, a)] indicates that the function is
+   [aligned_alloc]-like, and implies that it allocates a memory block whose size
+   is set by the function's [n]-th argument, aligned on a boundary given by the
+   function's [a]-th argument, and which must be deallocated by passing it as
+   the [p]-th argument of the function [dealloc]. */
+#define CAMLaligned_alloc(deallocator,ptr_index,alloc_size_N,alloc_align_,...) \
+  CAMLmalloc(deallocator,ptr_index,alloc_size_N)                        \
+    __attribute__ ((alloc_align(alloc_align_)))
+
+#else
+#define CAMLreturns_nonnull()
+#define CAMLrealloc(...)
+#define CAMLalloc(...)
+#define CAMLmalloc(...)
+#define CAMLcalloc(...)
+#define CAMLaligned_alloc(...)
+#endif
+
 /* GC timing hooks. These can be assigned by the user. These hooks
    must not allocate, change any heap value, nor call OCaml code. They
    can obtain the domain id with Caml_state->id. These functions must

--- a/runtime/caml/osdeps.h
+++ b/runtime/caml/osdeps.h
@@ -64,14 +64,15 @@ CAMLextern char_os * caml_search_exe_in_path(const char_os * name);
 extern char_os * caml_search_dll_in_path(struct ext_table * path,
                                          const char_os * name);
 
+/* Close a shared library handle */
+extern void caml_dlclose(void * handle);
+
 /* Open a shared library and return a handle on it.
    If [global] is true, symbols from the shared library can be used
    to resolve for other libraries to be opened later on.
    Return [NULL] on error. */
+CAMLalloc(caml_dlclose, 1)
 extern void * caml_dlopen(char_os * libname, int global);
-
-/* Close a shared library handle */
-extern void caml_dlclose(void * handle);
 
 /* Look up the given symbol in the given shared library.
    Return [NULL] if not found, or symbol value if found. */


### PR DESCRIPTION
This helps the compiler optimize code, and static analysis by detecting potential mismatches in alloc/free pairs.

With GCC, restrict the attributes usage to GCC >= 14, as GCC 13 reports false positives on the runtime code.
The only change from #13457 is to restrict this PR to GCC >= 14, or LLVM-based compilers. It was reverted in bce3bb7927bae3a120ebcd8e3a6b872309613ee7, as builds using GCC 13 would fail.

- malloc

> The malloc attribute indicates that the function acts like a system
> memory allocation function, returning a pointer to allocated storage
> disjoint from the storage for any other object accessible to the
> caller.

https://clang.llvm.org/docs/AttributeReference.html#malloc

> Associating a function with a deallocator helps detect calls to
> mismatched allocation and deallocation functions and diagnose them
> under the control of options such as -Wmismatched-dealloc. It also
> makes it possible to diagnose attempts to deallocate objects that
> were not allocated dynamically, by -Wfree-nonheap-object. To
> indicate that an allocation function both satisifies the nonaliasing
> property and has a deallocator associated with it, both the plain
> form of the attribute and the one with the deallocator argument must
> be used.

> The warnings guarded by -fanalyzer respect allocation and
> deallocation pairs marked with the malloc.

https://gcc.gnu.org/onlinedocs/gcc/Common-Function-Attributes.html#index-malloc-function-attribute

Note that the malloc attribute can only be applied to functions returning pointers. The OCaml value type is a typedef to an integer type, and the C compiler will refuse applying the attribute to a function returning an OCaml value.

- nodiscard / warn_unused_result

Prevent memory leaks by warning if the result of an allocation is ignored.

https://clang.llvm.org/docs/AttributeReference.html#nodiscard-warn-unused-result

- alloc_align

> GCC uses this information to improve pointer alignment analysis.

https://clang.llvm.org/docs/AttributeReference.html#alloc-align https://gcc.gnu.org/onlinedocs/gcc/Common-Function-Attributes.html#index-alloc_005falign-function-attribute

- alloc_size

> GCC uses this information to improve the results of
> __builtin_object_size.

https://clang.llvm.org/docs/AttributeReference.html#alloc-size https://gcc.gnu.org/onlinedocs/gcc/Common-Function-Attributes.html#index-alloc_005fsize-function-attribute

- returns_nonnull

> lets the compiler optimize callers based on the knowledge that the
> return value will never be null.

> The analyzer considers the possibility that an allocation function
> could fail and return null. […] If the allocator always returns
> non-null, use __attribute__ ((returns_nonnull)) to suppress these
> warnings.

https://gcc.gnu.org/onlinedocs/gcc/Common-Function-Attributes.html#index-returns_005fnonnull-function-attribute

Invoked on the following test program, GCC 14.2.0 reports:

```c
#include <caml/memory.h> /* with this patch */
#include <stdio.h>

void test_alloc_wrong_free(void)
{
  void *data = caml_stat_alloc(42);
  free(data);
}

void test_discard_alloc_result(void)
{
  caml_stat_alloc(42);
}

void test_alloc_noexec_null(void)
{
  void *data = caml_stat_alloc(42);
  printf("hello, world!");
}
```

```sh
opam exec -- gcc $(ocamlopt -config-var native_c_flags) \
                 -I $(ocamlopt -config-var standard_library_default) \
                 $(ocamlopt -config-var native_ldflags) -c \
                 -Wall -fanalyzer ./test.c
```

```
./test.c: In function ‘test_alloc_noexec_null’:
./test.c:17:9: warning: unused variable ‘data’ [-Wunused-variable]
   17 |   void *data = caml_stat_alloc(42);
      |         ^~~~
./test.c: In function ‘test_discard_alloc_result’:
./test.c:12:3: warning: ignoring return value of ‘caml_stat_alloc’ declared with attribute ‘warn_unused_result’ [-Wunused-result]
   12 |   caml_stat_alloc(42);
      |   ^~~~~~~~~~~~~~~~~~~
./test.c: In function ‘test_alloc_wrong_free’:
./test.c:7:3: warning: ‘data’ should have been deallocated with ‘caml_stat_free’ but was deallocated with ‘free’ [CWE-762] [-Wanalyzer-mismatching-deallocation]
    7 |   free(data);
      |   ^~~~~~~~~~
  ‘test_alloc_wrong_free’: events 1-2
    |
    |    6 |   void *data = caml_stat_alloc(42);
    |      |                ^~~~~~~~~~~~~~~~~~~
    |      |                |
    |      |                (1) allocated here
    |    7 |   free(data);
    |      |   ~~~~~~~~~~    
    |      |   |
    |      |   (2) deallocated with ‘free’ here
    |
./test.c: In function ‘test_alloc_noexec_null’:
./test.c:19:1: warning: leak of ‘data’ [CWE-401] [-Wanalyzer-malloc-leak]
   19 | }
      | ^
  ‘test_alloc_noexec_null’: events 1-2
    |
    |   17 |   void *data = caml_stat_alloc(42);
    |      |                ^~~~~~~~~~~~~~~~~~~
    |      |                |
    |      |                (1) allocated here
    |   18 |   printf("hello, world!");
    |   19 | }
    |      | ~               
    |      | |
    |      | (2) ‘data’ leaks here; was allocated at (1)
    |
./test.c: In function ‘test_alloc_wrong_free’:
./test.c:7:3: warning: ‘free’ called on pointer returned from a mismatched allocation function [-Wmismatched-dealloc]
    7 |   free(data);
      |   ^~~~~~~~~~
./test.c:6:16: note: returned from ‘caml_stat_alloc’
    6 |   void *data = caml_stat_alloc(42);
      |                ^~~~~~~~~~~~~~~~~~~
```

Simply using `-Wall` turns on more checks. The `-fanalyzer` warning has both false positive and false negatives and I'm *not* turning it on on the codebase. I believe this code may help users writing C FFI code for OCaml. No warnings have been raised on the current trunk or on Lwt. Let me know if there are packages containing C code that could be tested.

glibc has annotated functions in [`malloc/malloc.h`](https://github.com/bminor/glibc/blob/master/malloc/malloc.h), but as we're keeping track of C heap allocations, the compiler cannot propagate the annotations to the call sites of `caml_stat_*` functions.

I don't have insights on whether code gen has improved or worsened.

cc @gasche and @Octachron, who reviewed the previous version of this PR.