### PR TITLE
Use `nanosleep` instead of `usleep`, if available

### DIFF
--- a/Changes
+++ b/Changes
@@ -112,6 +112,9 @@ Working version
   with compiler attributes for static analysis.
   (Antonin Décimo, review by Gabriel Scherer and Florian Angeletti)
 
+- #13539: Use nanosleep instead of usleep, if available.
+  (Antonin Décimo, review by Miod Vallat and Gabriel Scherer)
+
 ### Build system:
 
 ### Bug fixes:

--- a/runtime/platform.c
+++ b/runtime/platform.c
@@ -469,9 +469,14 @@ void caml_mem_unmap(void* mem, uintnat size)
 #endif
 }
 
-#define Min_sleep_ns       10000 // 10 us
-#define Slow_sleep_ns    1000000 //  1 ms
-#define Max_sleep_ns  1000000000 //  1 s
+#define POW10_3       1000
+#define POW10_4      10000
+#define POW10_6    1000000
+#define POW10_9 1000000000
+
+#define Min_sleep_ns  POW10_4 /* 10 us */
+#define Slow_sleep_ns POW10_6 /*  1 ms */
+#define Max_sleep_ns  POW10_9 /*  1 s  */
 
 unsigned caml_plat_spin_back_off(unsigned sleep_ns,
                                  const struct caml_plat_srcloc* loc)
@@ -484,9 +489,14 @@ unsigned caml_plat_spin_back_off(unsigned sleep_ns,
                 loc->function, loc->file, loc->line);
   }
 #ifdef _WIN32
-  Sleep(sleep_ns/1000000);
+  Sleep(sleep_ns / POW10_6);
+#elif defined (HAS_NANOSLEEP)
+  const struct timespec req = {
+    .tv_sec = sleep_ns / POW10_9,
+    .tv_nsec = sleep_ns % POW10_9 };
+  nanosleep(&req, NULL);
 #else
-  usleep(sleep_ns/1000);
+  usleep(sleep_ns / POW10_3);
 #endif
   return next_sleep_ns;
 }


### PR DESCRIPTION
[`usleep()`](https://pubs.opengroup.org/onlinepubs/009696899/functions/usleep.html) is deprecated in favour of [`nanosleep()`](https://pubs.opengroup.org/onlinepubs/9799919799/functions/nanosleep.html), and was marked obsolescent in Issue 6. The `nanosleep()` function conforms to IEEE Std 1003.1b-1993 ("POSIX.1b").