### PR TITLE
#13388: local module type substitution can fail

### DIFF
--- a/Changes
+++ b/Changes
@@ -94,6 +94,11 @@ Working version
 - #13454: Output a correct trace of the C_CALLN bytecode.
   (Miod Vallat, review by Antonin Décimo)
 
+- #13388, #13540: raises an error message (and not an internal compiler error)
+  when two local substitutions are incompatible (for instance `module type
+  S:=sig end type t:=(module S)`)
+  (Florian Angeletti, report by Nailen Matschke, review by Gabriel Scherer)
+
 OCaml 5.3.0
 ___________
 

--- a/Changes
+++ b/Changes
@@ -97,7 +97,8 @@ Working version
 - #13388, #13540: raises an error message (and not an internal compiler error)
   when two local substitutions are incompatible (for instance `module type
   S:=sig end type t:=(module S)`)
-  (Florian Angeletti, report by Nailen Matschke, review by Gabriel Scherer)
+  (Florian Angeletti, report by Nailen Matschke, review by Gabriel Scherer, and
+  Leo White)
 
 OCaml 5.3.0
 ___________

--- a/testsuite/tests/typing-modules/module_type_substitution.ml
+++ b/testsuite/tests/typing-modules/module_type_substitution.ml
@@ -322,3 +322,48 @@ end
 [%%expect {|
 module type hidden = sig type u val x : int end
 |}]
+
+
+module type s = sig
+  module type t := sig end
+  type s := (module t)
+end
+[%%expect {|
+Line 3, characters 2-22:
+3 |   type s := (module t)
+      ^^^^^^^^^^^^^^^^^^^^
+Error: The module type "t" is not a valid type for a packed module:
+       it is defined as a local substitution (temporary name)
+       for an anonymous module type. (see manual section 12.7.3)
+|}]
+
+module type s = sig
+  module type t := sig end
+  module type r := t
+  type s := (module r)
+end
+[%%expect {|
+Line 4, characters 2-22:
+4 |   type s := (module r)
+      ^^^^^^^^^^^^^^^^^^^^
+Error: The module type "r" is not a valid type for a packed module:
+       it is defined as a local substitution (temporary name)
+       for an anonymous module type. (see manual section 12.7.3)
+|}]
+
+module type s = sig
+  module type t := sig end
+  module type r := sig
+      type s = (module t)
+  end
+  module type k = r
+end
+[%%expect {|
+Lines 3-5, characters 2-5:
+3 | ..module type r := sig
+4 |       type s = (module t)
+5 |   end
+Error: The module type "t" is not a valid type for a packed module:
+       it is defined as a local substitution (temporary name)
+       for an anonymous module type. (see manual section 12.7.3)
+|}]

--- a/typing/btype.ml
+++ b/typing/btype.ml
@@ -556,9 +556,8 @@ end = struct
 
   let with_scope f =
     let scope = { saved_desc = [] } in
-    let res = f scope in
-    cleanup scope;
-    res
+    Fun.protect ~finally:(fun () -> cleanup scope) (fun () -> f scope)
+
 end
 
                   (*******************************************)

--- a/typing/env.ml
+++ b/typing/env.ml
@@ -1651,7 +1651,7 @@ let prefix_idents root prefixing_sub sg =
       let p = Pdot(root, Ident.name id) in
       prefix_idents root
         ((SigL_modtype(id, mtd, vis), p) :: items_and_paths)
-        (Subst.add_modtype_id_to_path id p prefixing_sub)
+        (Subst.add_modtype id p prefixing_sub)
         rem
     | SigL_class(id, cd, rs, vis) :: rem ->
       (* pretend this is a type, cf. PR#6650 *)

--- a/typing/env.ml
+++ b/typing/env.ml
@@ -1651,7 +1651,7 @@ let prefix_idents root prefixing_sub sg =
       let p = Pdot(root, Ident.name id) in
       prefix_idents root
         ((SigL_modtype(id, mtd, vis), p) :: items_and_paths)
-        (Subst.add_modtype id (Mty_ident p) prefixing_sub)
+        (Subst.add_modtype_id_to_path id p prefixing_sub)
         rem
     | SigL_class(id, cd, rs, vis) :: rem ->
       (* pretend this is a type, cf. PR#6650 *)

--- a/typing/includemod.ml
+++ b/typing/includemod.ml
@@ -777,7 +777,7 @@ and signatures ~core ~direction ~loc env subst sig1 sig2 mod_shape =
             | Sig_module _ ->
                 Subst.add_module id2 (Path.Pident id1) subst
             | Sig_modtype _ ->
-                Subst.add_modtype id2 (Mty_ident (Path.Pident id1)) subst
+                Subst.add_modtype_id_to_path id2 (Path.Pident id1) subst
             | Sig_value _ | Sig_typext _
             | Sig_class _ | Sig_class_type _ ->
                 subst

--- a/typing/includemod.ml
+++ b/typing/includemod.ml
@@ -777,7 +777,7 @@ and signatures ~core ~direction ~loc env subst sig1 sig2 mod_shape =
             | Sig_module _ ->
                 Subst.add_module id2 (Path.Pident id1) subst
             | Sig_modtype _ ->
-                Subst.add_modtype_id_to_path id2 (Path.Pident id1) subst
+                Subst.add_modtype id2 (Path.Pident id1) subst
             | Sig_value _ | Sig_typext _
             | Sig_class _ | Sig_class_type _ ->
                 subst

--- a/typing/subst.ml
+++ b/typing/subst.ml
@@ -35,8 +35,9 @@ type s =
   }
 
 type 'a subst = s
-type t = [`Safe] subst
-type unsafe = [`Unsafe] subst
+type safe = [`Safe]
+type unsafe = [`Unsafe]
+type t = safe subst
 exception Module_type_path_substituted_away of Path.t * Types.module_type
 
 let identity =
@@ -840,6 +841,7 @@ let module_declaration scoping s decl =
 
 module Unsafe = struct
 
+  type t = unsafe subst
   type error = Fcm_type_substituted_away of Path.t * Types.module_type
 
   let add_modtype_path = add_modtype_gen

--- a/typing/subst.mli
+++ b/typing/subst.mli
@@ -48,13 +48,8 @@ val identity: 'a subst
 val unsafe: t -> unsafe
 
 val add_type: Ident.t -> Path.t -> 'k subst -> 'k subst
-val add_type_path: Path.t -> Path.t -> 'k subst -> 'k subst
-val add_type_function:
-  Path.t -> params:type_expr list -> body:type_expr -> 'k subst -> 'k subst
 val add_module: Ident.t -> Path.t -> 'k subst -> 'k subst
-val add_module_path: Path.t -> Path.t -> 'k subst -> 'k subst
 val add_modtype: Ident.t -> Path.t -> 'k subst -> 'k subst
-val add_modtype_path: Path.t -> Path.t -> 'k subst -> 'k subst
 
 val for_saving: t -> t
 val reset_for_saving: unit -> unit
@@ -105,13 +100,20 @@ module Unsafe: sig
   val add_modtype: Ident.t -> module_type -> 'any subst -> unsafe
   val add_modtype_path: Path.t -> module_type -> 'any subst -> unsafe
 
+  (** Deep editing inside a module type require to retypecheck the module, for
+      applicative functors in path and module aliases. *)
+  val add_type_path: Path.t -> Path.t -> unsafe -> unsafe
+  val add_type_function:
+    Path.t -> params:type_expr list -> body:type_expr -> unsafe -> unsafe
+  val add_module_path: Path.t -> Path.t -> unsafe -> unsafe
+
   type error =
-    | Fcm_type_substituted_away of Path.t
+    | Fcm_type_substituted_away of Path.t * Types.module_type
 
   type 'a res := ('a, error) result
 
+  val type_declaration:  unsafe -> type_declaration -> type_declaration res
   val signature_item: scoping -> unsafe -> signature_item -> signature_item res
-
   val signature: scoping -> unsafe -> signature -> signature res
 
   val compose: unsafe -> unsafe -> unsafe res

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -652,7 +652,9 @@ let check_coherence env loc dpath decl =
                     let decl =
                       match Subst.Unsafe.type_declaration subst decl with
                       | Ok decl -> decl
-                      | Error (Fcm_type_substituted_away _) -> assert false
+                      | Error (Fcm_type_substituted_away _) ->
+                           (* no module type substitution in [subst] *)
+                          assert false
                     in
                     Includecore.type_declarations ~loc ~equality:true env
                       ~mark:true

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -647,13 +647,19 @@ let check_coherence env loc dpath decl =
                 | exception Ctype.Equality err ->
                     Some (Includecore.Constraint err)
                 | () ->
+                    let subst =
+                      Subst.Unsafe.add_type_path dpath path Subst.identity in
+                    let decl =
+                      match Subst.Unsafe.type_declaration subst decl with
+                      | Ok decl -> decl
+                      | Error (Fcm_type_substituted_away _) -> assert false
+                    in
                     Includecore.type_declarations ~loc ~equality:true env
                       ~mark:true
                       (Path.last path)
                       decl'
                       dpath
-                      (Subst.type_declaration
-                         (Subst.add_type_path dpath path Subst.identity) decl)
+                      decl
               end
             in
             if err <> None then

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -968,7 +968,7 @@ module Signature_names : sig
     | `Exported
     | `From_open
     | `Shadowable of shadowable
-    | `Substituted_away of Subst.unsafe
+    | `Substituted_away of Subst.Unsafe.t
   ]
 
   val create : unit -> t
@@ -1004,7 +1004,7 @@ end = struct
 
   type info = [
     | `From_open
-    | `Substituted_away of Subst.unsafe
+    | `Substituted_away of Subst.Unsafe.t
     | bound_info
   ]
 
@@ -1013,7 +1013,7 @@ end = struct
     | Shadowed_by of Ident.t * Location.t
 
   type to_be_removed = {
-    mutable subst: Subst.unsafe;
+    mutable subst: Subst.Unsafe.t;
     mutable hide: (Sig_component_kind.t * Location.t * hide_reason) Ident.Map.t;
   }
 

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -76,7 +76,7 @@ type error =
   | Badly_formed_signature of string * Typedecl.error
   | Cannot_hide_id of hiding_error
   | Invalid_type_subst_rhs
-  | Unpackable_local_modtype_subst of Path.t
+  | Non_packable_local_modtype_subst of Path.t
   | With_cannot_remove_packed_modtype of Path.t * module_type
   | Cannot_alias of Path.t
 
@@ -344,21 +344,7 @@ let check_usage_of_path_of_substituted_item paths ~loc ~lid env super =
       );
     }
 
-(* When doing a module type destructive substitution [with module type T = RHS]
-   where RHS is not a module type path, we need to check that the module type
-   T was not used as a path for a packed module
-*)
-let check_usage_of_module_types ~error ~paths ~loc env super =
-  let it_do_type_expr it ty = match get_desc ty with
-    | Tpackage (p, _) ->
-       begin match List.find_opt (Path.same p) paths with
-       | Some p -> raise (Error(loc,Lazy.force !env,error p))
-       | _ -> super.Btype.it_do_type_expr it ty
-       end
-    | _ -> super.Btype.it_do_type_expr it ty in
-  { super with Btype.it_do_type_expr }
-
-let do_check_after_substitution env ~loc ~lid paths unpackable_modtype sg =
+let do_check_after_substitution env ~loc ~lid paths sg =
   with_type_mark begin fun mark ->
   let env, iterator = iterator_with_env (Btype.type_iterators mark) env in
   let last, rest = match List.rev paths with
@@ -373,19 +359,13 @@ let do_check_after_substitution env ~loc ~lid paths unpackable_modtype sg =
     | _ :: _ ->
         check_usage_of_path_of_substituted_item rest ~loc ~lid env iterator
   in
-  let iterator = match unpackable_modtype with
-    | None -> iterator
-    | Some mty ->
-       let error p = With_cannot_remove_packed_modtype(p,mty) in
-       check_usage_of_module_types ~error ~paths ~loc env iterator
-  in
   iterator.Btype.it_signature iterator sg
   end
 
-let check_usage_after_substitution env ~loc ~lid paths unpackable_modtype sg =
-  match paths, unpackable_modtype with
-  | [_], None -> ()
-  | _ -> do_check_after_substitution env ~loc ~lid paths unpackable_modtype sg
+let check_usage_after_substitution env ~loc ~lid paths sg =
+  match paths with
+  | [_] -> ()
+  | _ -> do_check_after_substitution env ~loc ~lid paths sg
 
 (* After substitution one also needs to re-check the well-foundedness
    of type declarations in recursive modules *)
@@ -480,7 +460,6 @@ let merge_constraint initial_env loc sg lid constr =
     | With_typesubst _ | With_modsubst _ | With_modtypesubst _  -> true
   in
   let real_ids = ref [] in
-  let unpackable_modtype = ref None in
   let split_row_id s ghosts =
     let srow = s ^ "#row" in
     let rec split before = function
@@ -612,10 +591,6 @@ let merge_constraint initial_env loc sg lid constr =
         else begin
           let path = Pident id in
           real_ids := [path];
-          begin match mty.mty_type with
-          | Mty_ident _ -> ()
-          | mty -> unpackable_modtype := Some mty
-          end;
           return ~replace_by:None
             (Pident id, lid, Some (Twith_modtypesubst mty))
         end
@@ -672,8 +647,7 @@ let merge_constraint initial_env loc sg lid constr =
     let names = Longident.flatten lid.txt in
     let (tcstr, sg) = merge_signature initial_env sg names in
     if destructive_substitution then
-      check_usage_after_substitution ~loc ~lid initial_env !real_ids
-        !unpackable_modtype sg;
+      check_usage_after_substitution ~loc ~lid initial_env !real_ids sg;
     let sg =
     match tcstr with
     | (_, _, Some (Twith_typesubst tdecl)) ->
@@ -716,10 +690,15 @@ let merge_constraint initial_env loc sg lid constr =
        (* See explanation in the [Twith_typesubst] case above. *)
        Subst.signature Make_local sub sg
     | (_, _, Some (Twith_modtypesubst tmty)) ->
-        let add s p = Subst.add_modtype_path p tmty.mty_type s in
+        let add s p = Subst.Local.add_modtype_path p tmty.mty_type s in
         let sub = Subst.change_locs Subst.identity loc in
         let sub = List.fold_left add sub !real_ids in
-        Subst.signature Make_local sub sg
+        begin match Subst.Local.signature Make_local sub sg with
+        | Ok x -> x
+        | Error (Fcm_type_substituted_away p) ->
+            let error = With_cannot_remove_packed_modtype(p,tmty.mty_type) in
+            raise (Error(loc,initial_env,error))
+        end
     | _ ->
        sg
     in
@@ -988,8 +967,7 @@ module Signature_names : sig
     | `Exported
     | `From_open
     | `Shadowable of shadowable
-    | `Substituted_away of Subst.t
-    | `Unpackable_modtype_substituted_away of Ident.t * Subst.t
+    | `Substituted_away of Subst.local
   ]
 
   val create : unit -> t
@@ -1025,8 +1003,7 @@ end = struct
 
   type info = [
     | `From_open
-    | `Substituted_away of Subst.t
-    | `Unpackable_modtype_substituted_away of Ident.t * Subst.t
+    | `Substituted_away of Subst.local
     | bound_info
   ]
 
@@ -1035,9 +1012,8 @@ end = struct
     | Shadowed_by of Ident.t * Location.t
 
   type to_be_removed = {
-    mutable subst: Subst.t;
+    mutable subst: Subst.local;
     mutable hide: (Sig_component_kind.t * Location.t * hide_reason) Ident.Map.t;
-    mutable unpackable_modtypes: Ident.Set.t;
   }
 
   type names_infos = (string, bound_info) Hashtbl.t
@@ -1072,7 +1048,6 @@ end = struct
     to_be_removed = {
       subst = Subst.identity;
       hide = Ident.Map.empty;
-      unpackable_modtypes = Ident.Set.empty;
     };
   }
 
@@ -1087,15 +1062,20 @@ end = struct
     | Class -> names.classes
     | Class_type -> names.class_types
 
+ let check_local_subst loc env: _ result -> _ = function
+    | Ok x -> x
+    | Error (Subst.Local.Fcm_type_substituted_away p) ->
+        raise (Error (loc, env, Non_packable_local_modtype_subst p))
+
   let check cl t loc id (info : info) =
     let to_be_removed = t.to_be_removed in
     match info with
     | `Substituted_away s ->
-        to_be_removed.subst <- Subst.compose s to_be_removed.subst;
-    | `Unpackable_modtype_substituted_away (id,s) ->
-        to_be_removed.subst <- Subst.compose s to_be_removed.subst;
-        to_be_removed.unpackable_modtypes <-
-          Ident.Set.add id to_be_removed.unpackable_modtypes
+        let subst =
+          check_local_subst loc Env.empty @@
+          Subst.Local.compose s to_be_removed.subst
+        in
+        to_be_removed.subst <- subst;
     | `From_open ->
         to_be_removed.hide <-
           Ident.Map.add id (cl, loc, From_open) to_be_removed.hide
@@ -1165,31 +1145,6 @@ end = struct
        thus never appear in includes *)
      List.iter (check ?info names loc) (Signature_group.rec_items item.group)
 
-  (*
-    Before applying local module type substitutions where the
-    right-hand side is not a path, we need to check that those module types
-    where never used to pack modules. For instance
-    {[
-    module type T := sig end
-    val x: (module T)
-    ]}
-    should raise an error.
-  *)
-  let check_unpackable_modtypes ~loc ~env to_remove component =
-    if not (Ident.Set.is_empty to_remove.unpackable_modtypes) then
-      with_type_mark begin fun mark ->
-        let iterator =
-          let error p = Unpackable_local_modtype_subst p in
-          let paths =
-            List.map (fun id -> Pident id)
-              (Ident.Set.elements to_remove.unpackable_modtypes)
-          in
-          check_usage_of_module_types ~loc ~error ~paths
-            (ref (lazy env)) (Btype.type_iterators mark)
-        in
-        iterator.Btype.it_signature_item iterator component
-      end
-
   (* We usually require name uniqueness of signature components (e.g. types,
      modules, etc), however in some situation reusing the name is allowed: if
      the component is a value or an extension, or if the name is introduced by
@@ -1200,7 +1155,6 @@ end = struct
      If some reference cannot be removed, then we error out with
      [Cannot_hide_id].
   *)
-
   let simplify env t sg =
     let to_remove = t.to_be_removed in
     let ids_to_remove =
@@ -1230,10 +1184,8 @@ end = struct
           if to_remove.subst == Subst.identity then
             component
           else
-            begin
-              check_unpackable_modtypes ~loc:user_loc ~env to_remove component;
-              Subst.signature_item Keep to_remove.subst component
-            end
+            check_local_subst user_loc env @@
+            Subst.Local.signature_item Keep to_remove.subst component
         in
         let component =
           match ids_to_remove with
@@ -1611,10 +1563,9 @@ and transl_signature env sg =
                     (* parsetree invariant, see Ast_invariants *)
                     assert false
               in
-              let subst = Subst.add_modtype mtd.mtd_id mty Subst.identity in
-              match mty with
-              | Mty_ident _ -> `Substituted_away subst
-              | _ -> `Unpackable_modtype_substituted_away (mtd.mtd_id,subst)
+              let subst =
+                Subst.Local.add_modtype mtd.mtd_id mty Subst.identity in
+              `Substituted_away subst
             in
             Signature_names.check_modtype ~info names pmtd.pmtd_loc mtd.mtd_id;
             let (trem, rem, final_env) = transl_sig newenv srem in
@@ -3347,14 +3298,13 @@ let report_error ~loc _env = function
       let[@manual.ref "ss:module-type-substitution"] manual_ref =
         [ 12; 7; 3 ]
       in
-      let pp_constraint ppf () =
-        fprintf ppf "%s := %a"
-          (Path.name p) modtype mty
+      let pp_constraint ppf (p,mty) =
+        fprintf ppf "%s := %a" (Path.name p) modtype mty
       in
       Location.errorf ~loc
         "This %a constraint@ %a@ makes a packed module ill-formed.@ %a"
         Style.inline_code "with"
-        (Style.as_inline_code pp_constraint) ()
+        (Style.as_inline_code pp_constraint) (p,mty)
         Misc.print_see_manual manual_ref
   | With_package_manifest (lid, ty) ->
       Location.errorf ~loc
@@ -3493,7 +3443,7 @@ let report_error ~loc _env = function
   | Invalid_type_subst_rhs ->
       Location.errorf ~loc "Only type synonyms are allowed on the right of %a"
         Style.inline_code  ":="
-  | Unpackable_local_modtype_subst p ->
+  | Non_packable_local_modtype_subst p ->
       let[@manual.ref "ss:module-type-substitution"] manual_ref =
         [ 12; 7; 3 ]
       in

--- a/typing/typemod.mli
+++ b/typing/typemod.mli
@@ -133,7 +133,7 @@ type error =
   | Badly_formed_signature of string * Typedecl.error
   | Cannot_hide_id of hiding_error
   | Invalid_type_subst_rhs
-  | Unpackable_local_modtype_subst of Path.t
+  | Non_packable_local_modtype_subst of Path.t
   | With_cannot_remove_packed_modtype of Path.t * module_type
   | Cannot_alias of Path.t
 


### PR DESCRIPTION
Local substitutions for module types

```
module type t := sig end
```

or

```
s with module type t := sig end
```

may fail to produce well-formed types when trying to substitute a module type path inside the type of first class module, for instance
```ocaml
module type s = sig
  module type t := sig end
  type u := (module t)
end
```

Before this PR, the part of `Typemod` module handling the erasure of local substitution was tracking independently whenever a substitution could be applied safely or not on a type expression. However, this logic was incomplete and did not cover correctly the composition of substitutions.

Rather than extending this logic as proposed in #13524, this PRs introduces an alternative (and easier to maintain) approach which splits substitutions from the `Subst` module in two variants belonging to the same type family and distinguished by a phantom type parameter:

- standard substitutions that are guaranteed to succeed
- local substitutions that may fail

With this two types, the definition of substitution composition is defined in one place the `Subst` module.
Local substitutions are created by adding a generic module type substitution to a substitution and
applying a local substitution require to handle the failure case.

With this change, the  `Typemod`  module can use the new local substitutions to detect whenever a substitution fail to create a well-formed type.

```ocaml
module type s = sig
  module type t := sig end
  module type r := t
  type s := (module r)
end
```

>```Line 4, characters 2-22:
> 4 |   type s := (module r)
>      ^^^^^^^^^^^^^^^^^^^^
>Error: The module type "r" is not a valid type for a packed module:
>       it is defined as a local substitution (temporary name)
>       for an anonymous module type. (see manual section 12.7.3)
>```


without affecting the rest of the typechecker.