### PR TITLE
Add a note about what is needed to start lldb from a remote terminal on MacOS.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -180,6 +180,8 @@ jobs:
         run: |
           brew install parallel
           # Allows starting up lldb from a remote terminal
+          #   Note: in order to start lldb, the user must also be in
+          #   one of these groups: "admin" or "_developer".
           sudo DevToolsSecurity --enable
           spctl developer-mode enable-terminal
           # Select latest supported version


### PR DESCRIPTION
I'm not sure where to put this information but the error message was not helpful and  I had to do some digging to figure it out, so I think it should be recorded somewhere.

cc @tmcgilchrist 
