### PR TITLE
Remove some String to/form Bytes conversion to behave better with jsoo

### DIFF
--- a/Changes
+++ b/Changes
@@ -53,6 +53,10 @@ Working version
 
 ### Standard library:
 
+- #13543: Remove some String-Bytes conversion from the stdlib to behave better
+  with js_of_ocaml
+  (Hugo Heuzard, review by Gabriel Scherer)
+
 ### Other libraries:
 
 - #13429: add `Unix.sigwait`, a binding to the `sigwait` system call;

--- a/runtime/blake2.c
+++ b/runtime/blake2.c
@@ -244,3 +244,9 @@ CAMLprim value caml_blake2_string(value hashlen, value key,
   caml_BLAKE2Final(&ctx, hlen, &Byte_u(hash, 0));
   return hash;
 }
+
+CAMLprim value caml_blake2_bytes(value hashlen, value key,
+                                  value buf, value ofs, value len)
+{
+  return caml_blake2_string(hashlen, key, buf, ofs, len);
+}

--- a/runtime/md5.c
+++ b/runtime/md5.c
@@ -37,6 +37,11 @@ CAMLprim value caml_md5_string(value str, value ofs, value len)
   return res;
 }
 
+CAMLprim value caml_md5_bytes(value b, value ofs, value len)
+{
+  return caml_md5_string(b, ofs, len);
+}
+
 CAMLexport value caml_md5_channel(struct channel *chan, intnat toread)
 {
   CAMLparam0();

--- a/stdlib/buffer.ml
+++ b/stdlib/buffer.ml
@@ -148,7 +148,7 @@ let rec add_utf_16le_uchar b u =
 
 let add_substring b s offset len =
   if offset < 0 || len < 0 || offset > String.length s - len
-  then invalid_arg "Buffer.add_substring/add_subbytes";
+  then invalid_arg "Buffer.add_substring";
   let position = b.position in
   let {buffer;length} = b.inner in
   let new_position = position + len in
@@ -159,22 +159,24 @@ let add_substring b s offset len =
     Bytes.unsafe_blit_string s offset buffer position len;
   b.position <- new_position
 
-let add_subbytes b s offset len =
-  add_substring b (Bytes.unsafe_to_string s) offset len
-
-let add_string b s =
-  let len = String.length s in
+let add_subbytes b bytes offset len =
+  if offset < 0 || len < 0 || offset > Bytes.length bytes - len
+  then invalid_arg "Buffer.add_subbytes";
   let position = b.position in
-  let {buffer; length} = b.inner in
+  let {buffer;length} = b.inner in
   let new_position = position + len in
   if new_position > length then (
     resize b len;
-    Bytes.blit_string s 0 b.inner.buffer b.position len;
+    Bytes.blit bytes offset b.inner.buffer b.position len
   ) else
-    Bytes.unsafe_blit_string s 0 buffer position len;
+    Bytes.unsafe_blit bytes offset buffer position len;
   b.position <- new_position
 
-let add_bytes b s = add_string b (Bytes.unsafe_to_string s)
+let add_string b s =
+  add_substring b s 0 (String.length s)
+
+let add_bytes b bytes =
+  add_subbytes b bytes 0 (Bytes.length bytes)
 
 let add_buffer b bs =
   add_subbytes b bs.inner.buffer 0 bs.position

--- a/stdlib/digest.ml
+++ b/stdlib/digest.ml
@@ -74,7 +74,7 @@ module BLAKE2 (X: sig val hash_length : int end) : S = struct
   type state
 
   external create_gen: int -> string -> state = "caml_blake2_create"
-  external update: state -> string -> int -> int -> unit = "caml_blake2_update"
+  external update: state -> bytes -> int -> int -> unit = "caml_blake2_update"
   external final: state -> int -> t = "caml_blake2_final"
   external unsafe_string: int -> string -> string -> int -> int -> t
                         = "caml_blake2_string"
@@ -104,7 +104,7 @@ module BLAKE2 (X: sig val hash_length : int end) : S = struct
         let n = In_channel.input ic buf 0 buf_size in
         if n = 0
         then final ctx hash_length
-        else (update ctx (Bytes.unsafe_to_string buf) 0 n; do_read ())
+        else (update ctx buf 0 n; do_read ())
       in do_read ()
     end else begin
       let rec do_read toread =
@@ -113,7 +113,7 @@ module BLAKE2 (X: sig val hash_length : int end) : S = struct
           if n = 0
           then raise End_of_file
           else begin
-            update ctx (Bytes.unsafe_to_string buf) 0 n;
+            update ctx buf 0 n;
             do_read (toread - n)
           end
         end

--- a/stdlib/string.ml
+++ b/stdlib/string.ml
@@ -108,7 +108,11 @@ let escaped s =
   let b = bos s in
   (* We satisfy [unsafe_escape]'s precondition by passing an
      immutable byte sequence [b]. *)
-  bts (B.unsafe_escape b)
+  let b' = B.unsafe_escape b in
+  (* With js_of_ocaml, [bos] and [bts] are not the identity.
+     We can avoid a [bts] conversion if [unsafe_escape] returned
+     its argument. *)
+  if b == b' then s else bts b'
 
 (* duplicated in bytes.ml *)
 let rec index_rec s lim i c =


### PR DESCRIPTION
Context
======
Js_of_ocaml uses different memory representation for bytes and strings. It leverages JavaScript immutable strings to implement ocaml ones  (initial change in https://github.com/ocsigen/js_of_ocaml/pull/923, enabled by default in https://github.com/ocsigen/js_of_ocaml/pull/976).

This means that `Bytes.unsafe_to_string`, `Bytes.unsafe_of_string` are not longer the identity.
The additional cost is usually ok because theses conversions often comes next to computations that are linear in the size of the argument of the conversions. However, some use cases convert large strings/bytes but only look at a small substring/subbytes.

This issue was spotted by @vouillon in https://github.com/ocsigen/js_of_ocaml/issues/1703.
The Yojson parser/lexer uses the following helper that currently result in converting the whole lexbuf to string over and over again.   

```ocaml
  let add_lexeme buf (lexbuf : Lexing.lexbuf) =
    let len = lexbuf.lex_curr_pos - lexbuf.lex_start_pos in
    Buffer.add_subbytes buf lexbuf.lex_buffer lexbuf.lex_start_pos len
``` 
 

This PR
======

In this PR, One tried to find and fix such problematic usage in the stdlib.

- Buffer.add_subbytes no longer rely on the string implementation.
  and as a result Buffer.add_bytes not longer perform conversion either.

- Digest.(sub)?bytes and Digest.MD5.(sub)?bytes no longer rely on the string implementation.
- In addition, one has removed useless conversions when hashing the content of a channel. 

The PR also contains another kind of change, that has to do with "fixing" the fast path of `String.escaped` with jsoo. 
`String.escaped` now avoids a conversion from bytes to string if the optimisation/fastpath in Bytes.unsafe_escape triggers. This change could be dropped from this PR if it's problematic.