### PR TITLE
tools/gdb-macros: there is no Caml_state->heap_start

### DIFF
--- a/tools/gdb-macros
+++ b/tools/gdb-macros
@@ -128,7 +128,7 @@ define camlheap
     printf "YOUNG"
     set $camlheap_result = 1
   else
-    set $chunk = Caml_state->heap_start
+    set $chunk = * (unsigned long *) &caml_heap_start
     set $found = 0
     while $chunk != 0 && ! $found
       set $chunk_size = * (unsigned long *) ($chunk - 2 * $camlwordsize)
@@ -253,7 +253,7 @@ end
 
 # displays the list of heap chunks
 define camlchunks
-  set $chunk = * (unsigned long *) &Caml_state->heap_start
+  set $chunk = * (unsigned long *) &caml_heap_start
   while $chunk != 0
     set $chunk_size = * (unsigned long *) ($chunk - 2 * $camlwordsize)
     set $chunk_alloc = * (unsigned long *) ($chunk - 3 * $camlwordsize)
@@ -269,7 +269,7 @@ end
 # `camlvisitfun` can set `$camlvisitstop` to stop the iteration
 
 define camlvisit
-  set $cvchunk = * (unsigned long *) &Caml_state->heap_start
+  set $cvchunk = * (unsigned long *) &caml_heap_start
   set $camlvisitstop = 0
   while $cvchunk != 0 && ! $camlvisitstop
     set $cvchunk_size = * (unsigned long *) ($cvchunk - 2 * $camlwordsize)
@@ -290,7 +290,7 @@ define camlvisit
 end
 
 define caml_cv_check_fl0
-  if $hp == * (unsigned long *) &Caml_state->heap_start
+  if $hp == * (unsigned long *) &caml_heap_start
     set $flcheck_prev = ((unsigned long) &sentinels + 16)
   end
   if $color == 2 && $size > 5


### PR DESCRIPTION
There is only caml_heap_start.

Fixes: b304042b295c ("Fix missing Caml_state (#8940)")

Depending on the version of compiler and GDB you may also need this change (I have 2 systems, one that needs it, and another one that doesn't, so I haven't included this in the PR):
```diff
diff --git a/tools/gdb-macros b/tools/gdb-macros
index 197bf4793b91..7c5a733fe63f 100644
--- a/tools/gdb-macros
+++ b/tools/gdb-macros
@@ -124,7 +124,7 @@ define camlheader
 end

 define camlheap
-  if $arg0 >= Caml_state->young_start && $arg0 < Caml_state->young_end
+  if $arg0 >= Caml_state->_young_start && $arg0 < Caml_state->_young_end
     printf "YOUNG"
     set $camlheap_result = 1
   else
```

Context: I was debugging a stuck OCaml 4.14 process with @GabrielBuica and @mg12, where the fixed version of this gdb macro helped us track down the root cause, and there is no gdb.py on 4.14.

The PR is only for 4.14, because this is all different on trunk.