### PR TITLE
Memory cleanup at exit [5.3 backport]

### DIFF
--- a/Changes
+++ b/Changes
@@ -57,6 +57,12 @@ ___________
 - #12789: Restore caml_unregister_frametable from OCaml 4
   (Frédéric Recoules, review by Gabriel Scherer)
 
+- #12964: Reintroduce "memory cleanup upon exit" mode. The cleanup will
+  however be incomplete if not all domains have been joined when the main
+  domain terminates.
+  (Miod Vallat, review by KC Sivaramakrishnan, feedback from Nick Barnes
+   and Gabriel Scherer)
+
 - #13003: new, more consistent names for array-creation C functions
   (Gabriel Scherer, review by Olivier Nicole)
 

--- a/otherlibs/systhreads/st_stubs.c
+++ b/otherlibs/systhreads/st_stubs.c
@@ -453,7 +453,7 @@ static void caml_thread_reinitialize(void)
   for (struct channel *chan = caml_all_opened_channels;
        chan != NULL;
        chan = chan->next) {
-    caml_plat_mutex_init(&chan->mutex);
+    caml_plat_mutex_reinit(&chan->mutex);
   }
 }
 
@@ -678,7 +678,10 @@ static st_retcode create_tick_thread(void)
   pthread_sigmask(SIG_SETMASK, &old_mask, NULL);
 #endif
 
-  if (err != 0) return err;
+  if (err != 0) {
+    caml_stat_free(tick_thread_args);
+    return err;
+  }
 
   Tick_thread_running = 1;
   return 0;

--- a/runtime/caml/domain.h
+++ b/runtime/caml/domain.h
@@ -23,6 +23,8 @@ extern "C" {
 
 #ifdef CAML_INTERNALS
 
+#include <stdbool.h>
+
 #include "camlatomic.h"
 #include "config.h"
 #include "mlvalues.h"
@@ -117,6 +119,7 @@ int caml_domain_is_in_stw(void);
 
 int caml_domain_terminating(caml_domain_state *);
 int caml_domain_is_terminating(void);
+void caml_domain_terminate(bool last);
 
 int caml_try_run_on_all_domains_with_spin_work(
   int sync,
@@ -233,6 +236,17 @@ void caml_global_barrier_release_as_final(barrier_status status);
          ((CAML_GENSYM(alone) ? (void)0 :                               \
            caml_global_barrier_release_as_final(CAML_GENSYM(b))),       \
           CAML_GENSYM(continue) = 0))
+
+/*
+ * Termination helpers.
+ */
+
+/* Force all other domains to stop their operation. */
+void caml_stop_all_domains(void);
+
+/* Try and release all synchronisation resources set up by
+   caml_init_domains(). Returns whether all resources could be released. */
+bool caml_free_domains(void);
 
 #endif /* CAML_INTERNALS */
 

--- a/runtime/caml/gc_stats.h
+++ b/runtime/caml/gc_stats.h
@@ -85,6 +85,8 @@ void caml_compute_gc_stats(struct gc_stats* buf);
 
 void caml_init_gc_stats (uintnat max_domains);
 
+void caml_free_gc_stats(void);
+
 #endif /* CAML_INTERNALS */
 
 #endif /* CAML_GC_STATS_H */

--- a/runtime/caml/major_gc.h
+++ b/runtime/caml/major_gc.h
@@ -48,15 +48,6 @@ int caml_mark_stack_is_empty(void);
 void caml_orphan_ephemerons(caml_domain_state*);
 void caml_orphan_finalisers(caml_domain_state*);
 
-/* Forces finalisation of all heap-allocated values,
-   disregarding both local and global roots.
-
-   Warning: finalisation is performed by means of forced sweeping, which may
-   result in pointers referencing nonexistent values; therefore the function
-   should only be used on runtime shutdown.
-*/
-void caml_finalise_heap (void);
-
 /* This variable is only written with the world stopped,
    so it need not be atomic */
 extern uintnat caml_major_cycles_completed;

--- a/runtime/caml/platform.h
+++ b/runtime/caml/platform.h
@@ -112,6 +112,7 @@ void caml_plat_assert_locked(caml_plat_mutex*);
 void caml_plat_assert_all_locks_unlocked(void);
 Caml_inline void caml_plat_unlock(caml_plat_mutex*);
 void caml_plat_mutex_free(caml_plat_mutex*);
+CAMLextern void caml_plat_mutex_reinit(caml_plat_mutex*);
 typedef pthread_cond_t caml_plat_cond;
 #define CAML_PLAT_COND_INITIALIZER PTHREAD_COND_INITIALIZER
 void caml_plat_cond_init(caml_plat_cond*);

--- a/runtime/caml/shared_heap.h
+++ b/runtime/caml/shared_heap.h
@@ -105,6 +105,15 @@ void caml_cycle_heap(struct caml_heap_state*);
 /* Heap invariant verification (for debugging) */
 void caml_verify_heap_from_stw(caml_domain_state *domain);
 
+/* Forces finalisation of all heap-allocated values,
+   disregarding both local and global roots.
+
+   Warning: this function should only be used on runtime shutdown.
+*/
+void caml_finalise_heap(void);
+
+void caml_finalise_freelist(void);
+
 #ifdef DEBUG
 /* [is_garbage(v)] returns true if [v] is a garbage value */
 int is_garbage (value);

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -139,8 +139,8 @@ static_assert(
               v                             |               |
     BT_IN_BLOCKING_SECTION  ----------------+               |
               |                                             |
-     (domain_terminate)                                     |
-       [main pthread]                                       |
+     (caml_domain_terminate)                                |
+        [main pthread]                                      |
               |                                             |
               v                                             |
         BT_TERMINATE                               (backup_thread_func)
@@ -182,15 +182,17 @@ Caml_inline void interruptor_set_pending(struct interruptor *s)
 struct dom_internal {
   /* readonly fields, initialised and never modified */
   int id;
+  pthread_t tid;
   caml_domain_state* state;
   struct interruptor interruptor;
 
   /* backup thread */
-  int backup_thread_running;
+  atomic_uintnat backup_thread_running;
   pthread_t backup_thread;
   atomic_uintnat backup_thread_msg;
   caml_plat_mutex domain_lock;
   caml_plat_cond domain_cond;
+  bool domain_canceled;
 
   /* modified only during STW sections */
   uintnat minor_heap_area_start;
@@ -235,8 +237,9 @@ static atomic_uintnat /* dom_internal* */ stw_leader = 0;
 static uintnat stw_requests_suspended = 0; /* protected by all_domains_lock */
 static caml_plat_cond requests_suspended_cond = CAML_PLAT_COND_INITIALIZER;
 static dom_internal* all_domains;
+static atomic_intnat domains_exiting = 0;
 
-CAMLexport atomic_uintnat caml_num_domains_running;
+CAMLexport atomic_uintnat caml_num_domains_running = 0;
 
 /* size of the virtual memory reservation for the minor heap, per domain */
 uintnat caml_minor_heap_max_wsz;
@@ -338,6 +341,8 @@ int caml_incoming_interrupts_queued(void)
 {
   return interruptor_has_pending(&domain_self->interruptor);
 }
+
+static void terminate_backup_thread(dom_internal *di);
 
 /* must NOT be called with s->lock held */
 static void stw_handler(caml_domain_state* domain);
@@ -624,7 +629,7 @@ static void domain_create(uintnat initial_minor_heap_wsize,
 
   /* Note: until we take d->domain_lock, the domain_state may still be
    * shared with a domain which is terminating (see
-   * domain_terminate). */
+   * caml_domain_terminate). */
 
   caml_plat_lock_blocking(&d->domain_lock);
 
@@ -794,7 +799,7 @@ CAMLexport void caml_reset_domain_lock(void)
        portability on POSIX the lock should be released and destroyed
        prior to calling fork and then init afterwards in both parent
        and child. */
-  caml_plat_mutex_init(&self->domain_lock);
+  caml_plat_mutex_reinit(&self->domain_lock);
   caml_plat_cond_init(&self->domain_cond);
 
   return;
@@ -938,6 +943,9 @@ void caml_update_minor_heap_max(uintnat requested_wsz) {
 
 void caml_init_domains(uintnat max_domains, uintnat minor_heap_wsz)
 {
+  atomic_store_relaxed(&domains_exiting, 0);
+  atomic_store_relaxed(&caml_num_domains_running, 0);
+
   /* Use [caml_stat_calloc_noexc] to zero initialize [all_domains]. */
   all_domains = caml_stat_calloc_noexc(max_domains, sizeof(dom_internal));
   if (all_domains == NULL)
@@ -975,6 +983,7 @@ void caml_init_domains(uintnat max_domains, uintnat minor_heap_wsz)
     caml_plat_cond_init(&dom->domain_cond);
     dom->backup_thread_running = 0;
     dom->backup_thread_msg = BT_INIT;
+    dom->domain_canceled = false;
   }
 
   domain_create(minor_heap_wsz, NULL);
@@ -1059,7 +1068,7 @@ static void* backup_thread_func(void* v)
           }
         }
         /* Wait safely if there is nothing to do. Will be woken from
-         * caml_send_interrupt and domain_terminate.
+         * caml_send_interrupt and caml_domain_terminate.
          */
         caml_plat_lock_blocking(&s->lock);
         msg = atomic_load_acquire (&di->backup_thread_msg);
@@ -1069,9 +1078,9 @@ static void* backup_thread_func(void* v)
         caml_plat_unlock(&s->lock);
         break;
       case BT_ENTERING_OCAML:
-        /* Main thread wants to enter OCaml
+        /* Main thread wants to enter OCaml.
          * Will be woken from caml_bt_exit_ocaml
-         * or domain_terminate
+         * or caml_domain_terminate.
          */
         caml_plat_lock_blocking(&di->domain_lock);
         msg = atomic_load_acquire (&di->backup_thread_msg);
@@ -1087,6 +1096,7 @@ static void* backup_thread_func(void* v)
   }
 
   /* doing terminate */
+  atomic_store_release(&di->backup_thread_running, 0);
   atomic_store_release(&di->backup_thread_msg, BT_INIT);
 
   return 0;
@@ -1099,12 +1109,11 @@ static void install_backup_thread (dom_internal* di)
   sigset_t mask, old_mask;
 #endif
 
-  if (di->backup_thread_running == 0) {
+  if (atomic_load_acquire(&di->backup_thread_running) != 0) {
+    /* If the backup thread is running, but has been instructed to terminate,
+       we need to wait for it to stop until we can spawn another. */
     uintnat msg;
     msg = atomic_load_acquire(&di->backup_thread_msg);
-    CAMLassert (msg == BT_INIT || /* Using fresh domain */
-                msg == BT_TERMINATE); /* Reusing domain */
-
     while (msg != BT_INIT) {
       /* Give a chance for backup thread on this domain to terminate */
       caml_plat_unlock (&di->domain_lock);
@@ -1112,24 +1121,38 @@ static void install_backup_thread (dom_internal* di)
       caml_plat_lock_blocking(&di->domain_lock);
       msg = atomic_load_acquire(&di->backup_thread_msg);
     }
+  }
+
+  CAMLassert(atomic_load_acquire(&di->backup_thread_msg) == BT_INIT);
 
 #ifndef _WIN32
-    /* No signals on the backup thread */
-    sigfillset(&mask);
-    pthread_sigmask(SIG_BLOCK, &mask, &old_mask);
+  /* No signals on the backup thread */
+  sigfillset(&mask);
+  pthread_sigmask(SIG_BLOCK, &mask, &old_mask);
 #endif
 
-    atomic_store_release(&di->backup_thread_msg, BT_ENTERING_OCAML);
-    err = pthread_create(&di->backup_thread, 0, backup_thread_func, (void*)di);
+  atomic_store_release(&di->backup_thread_msg, BT_ENTERING_OCAML);
+  err = pthread_create(&di->backup_thread, 0, backup_thread_func, (void*)di);
 
 #ifndef _WIN32
-    pthread_sigmask(SIG_SETMASK, &old_mask, NULL);
+  pthread_sigmask(SIG_SETMASK, &old_mask, NULL);
 #endif
 
-    if (err)
-      caml_failwith("failed to create domain backup thread");
-    di->backup_thread_running = 1;
-    pthread_detach(di->backup_thread);
+  if (err)
+    caml_failwith("failed to create domain backup thread");
+  atomic_store_release(&di->backup_thread_running, 1);
+  pthread_detach(di->backup_thread);
+}
+
+static void terminate_backup_thread(dom_internal *di)
+{
+  CAMLassert(!caml_bt_is_self());
+
+  if (atomic_load_acquire(&di->backup_thread_running) != 0) {
+    atomic_store_release(&di->backup_thread_msg, BT_TERMINATE);
+    /* Wakeup backup thread if it is sleeping */
+    caml_plat_broadcast(&di->interruptor.cond);
+    caml_plat_signal(&di->domain_cond);
   }
 }
 
@@ -1159,8 +1182,6 @@ CAMLexport void (*caml_domain_external_interrupt_hook)(void) =
 
 CAMLexport _Atomic caml_timing_hook caml_domain_terminated_hook =
   (caml_timing_hook)NULL;
-
-static void domain_terminate(void);
 
 static value make_finished(caml_result result)
 {
@@ -1211,6 +1232,8 @@ static void* domain_thread_func(void* v)
 #endif
 
   domain_create(caml_params->init_minor_heap_wsz, p->parent->state);
+  if (domain_self)
+    domain_self->tid = pthread_self();
 
   /* this domain is now part of the STW participant set */
   p->newdom = domain_self;
@@ -1246,11 +1269,11 @@ static void* domain_thread_func(void* v)
     sync_result(ml_values->term_sync, res);
 
     sync_mutex mut = Mutex_val(*Term_mutex(ml_values->term_sync));
-    domain_terminate();
+    caml_domain_terminate(false);
 
     /* This domain currently holds [mut], and has signaled all the
        waiting domains to be woken up. We unlock [mut] to release the
-       joining domains. The unlock is done after [domain_terminate] to
+       joining domains. The unlock is done after [caml_domain_terminate] to
        ensure that this domain has released all of its runtime state.
        We call [caml_mutex_unlock] directly instead of
        [caml_ml_mutex_unlock] because the domain no longer exists at
@@ -1278,6 +1301,10 @@ CAMLprim value caml_domain_spawn(value callback, value term_sync)
   struct domain_startup_params p;
   pthread_t th;
   int err;
+
+  if (atomic_load_relaxed(&domains_exiting) != 0) {
+    caml_failwith("domain creation not allowed during shutdown");
+  }
 
 #ifndef NATIVE_CODE
   if (caml_debugger_in_use)
@@ -1325,7 +1352,9 @@ CAMLprim value caml_domain_spawn(value callback, value term_sync)
   }
   /* When domain 0 first spawns a domain, the backup thread is not active, we
      ensure it is started here. */
-  install_backup_thread(domain_self);
+  domain_self->tid = pthread_self();
+  if (atomic_load_acquire(&domain_self->backup_thread_running) == 0)
+    install_backup_thread(domain_self);
 
   CAMLreturn (Val_long(p.unique_id));
 }
@@ -1534,9 +1563,9 @@ int caml_domain_is_in_stw(void) {
    - Domain cleanup code runs after the terminating domain may run in
      parallel to a STW section, but only after that domain has safely
      removed itself from the STW participant set: the
-     [domain_terminate] function is careful to only leave the STW set
-     when (1) it has the [all_domains_lock] and (2) it hasn't received
-     any request to participate in a STW section.
+     [caml_domain_terminate] function is careful to only leave the STW
+     set when (1) it has the [all_domains_lock] and (2) it hasn't
+     received any request to participate in a STW section.
 
    Each domain leaves the section as soon as it is finished running
    the STW section callback. In particular, a mutator may resume while
@@ -1552,11 +1581,11 @@ int caml_domain_is_in_stw(void) {
    but additional synchronization would be required to update it
    during domain cleanup.
 
-   Note: in the case of both [domain_create] and [domain_terminate] it
-   is important that the loops (waiting for STW sections to finish)
+   Note: in the case of both [domain_create] and [caml_domain_terminate]
+   it is important that the loops (waiting for STW sections to finish)
    regularly release [all_domains_lock], to avoid deadlocks scenario
    with in-progress STW sections.
-    - For [domain_terminate] we release the lock and join
+    - For [caml_domain_terminate] we release the lock and join
       the STW section before resuming.
     - For [domain_create] we wait until the end of the section using
       the condition variable [all_domains_cond] over
@@ -1923,7 +1952,9 @@ CAMLexport int caml_bt_is_self(void)
 CAMLexport intnat caml_domain_is_multicore (void)
 {
   dom_internal *self = domain_self;
-  return (!caml_domain_alone() || self->backup_thread_running);
+  uintnat backup_thread_running =
+    atomic_load_acquire(&self->backup_thread_running);
+  return (!caml_domain_alone() || backup_thread_running);
 }
 
 CAMLexport void caml_acquire_domain_lock(void)
@@ -1936,10 +1967,12 @@ CAMLexport void caml_acquire_domain_lock(void)
 CAMLexport void caml_bt_enter_ocaml(void)
 {
   dom_internal* self = domain_self;
+  uintnat backup_thread_running =
+    atomic_load_acquire(&self->backup_thread_running);
 
-  CAMLassert(caml_domain_alone() || self->backup_thread_running);
+  CAMLassert(caml_domain_alone() || backup_thread_running);
 
-  if (self->backup_thread_running) {
+  if (backup_thread_running) {
     atomic_store_release(&self->backup_thread_msg, BT_ENTERING_OCAML);
   }
 }
@@ -1954,10 +1987,12 @@ CAMLexport void caml_release_domain_lock(void)
 CAMLexport void caml_bt_exit_ocaml(void)
 {
   dom_internal* self = domain_self;
+  uintnat backup_thread_running =
+    atomic_load_acquire(&self->backup_thread_running);
 
-  CAMLassert(caml_domain_alone() || self->backup_thread_running);
+  CAMLassert(caml_domain_alone() || backup_thread_running);
 
-  if (self->backup_thread_running) {
+  if (backup_thread_running) {
     atomic_store_release(&self->backup_thread_msg, BT_IN_BLOCKING_SECTION);
     /* Wakeup backup thread if it is sleeping */
     caml_plat_signal(&self->domain_cond);
@@ -1990,7 +2025,7 @@ int caml_domain_is_terminating (void)
   return domain_terminating(domain_self);
 }
 
-static void domain_terminate (void)
+void caml_domain_terminate(bool last)
 {
   caml_domain_state* domain_state = domain_self->state;
   struct interruptor* s = &domain_self->interruptor;
@@ -2012,10 +2047,19 @@ static void domain_terminate (void)
     /* Note: [caml_empty_minor_heaps_once] will also join any ongoing
        STW sections that has sent an interrupt to this domain. */
 
+    if (last)
+      caml_finish_major_cycle(0);
+
     caml_finish_marking();
 
     caml_orphan_ephemerons(domain_state);
     caml_orphan_finalisers(domain_state);
+
+    /* No need to check for interrupts if we are the last domain running. */
+    if (last) {
+      CAML_EV_LIFECYCLE(EV_DOMAIN_TERMINATE, getpid());
+      break;
+    }
 
     /* take the all_domains_lock to try and exit the STW participant set
        without racing with a STW section being triggered */
@@ -2049,9 +2093,6 @@ static void domain_terminate (void)
       caml_plat_broadcast(&s->cond);
       caml_plat_unlock(&s->lock);
 
-      CAMLassert (domain_self->backup_thread_running);
-      domain_self->backup_thread_running = 0;
-
       /* We must signal domain termination before releasing [all_domains_lock]:
          after that, this domain will no longer take part in STWs and emitting
          an event could race with runtime events teardown. */
@@ -2081,6 +2122,9 @@ static void domain_terminate (void)
   caml_free_extern_state();
   caml_teardown_major_gc();
 
+  if (last)
+    caml_finalise_heap();
+
   caml_teardown_shared_heap(domain_state->shared_heap);
   domain_state->shared_heap = 0;
   caml_free_minor_tables(domain_state->minor_tables);
@@ -2105,15 +2149,99 @@ static void domain_terminate (void)
   /* signal the domain termination to the backup thread
      NB: for a program with no additional domains, the backup thread
      will not have been started */
-  atomic_store_release(&domain_self->backup_thread_msg, BT_TERMINATE);
-  caml_plat_signal(&domain_self->domain_cond);
+  terminate_backup_thread(domain_self);
   caml_plat_unlock(&domain_self->domain_lock);
 
   caml_plat_assert_all_locks_unlocked();
   /* This is the last thing we do because we need to be able to rely
      on caml_domain_alone (which uses caml_num_domains_running) in at least
-     the shared_heap lockfree fast paths */
-  atomic_fetch_add(&caml_num_domains_running, -1);
+     the shared_heap lockfree fast paths. Also, we don't want to decrement
+     it back to zero when the last domain exits, for caml_domain_alone()
+     to remain accurate. */
+  if (!last)
+    atomic_fetch_add(&caml_num_domains_running, -1);
+}
+
+/* Try and terminate the currently running domain.
+   This is only invoked when extra domains are left running while the
+   main one is terminating. In this case, we are not in a state where
+   we can safely release resources. The best we can do is cancel the
+   extra running threads. */
+static void stw_terminate_domain(caml_domain_state *domain, void *data,
+  int participating_count,
+  caml_domain_state **participating)
+{
+  if (!pthread_equal(domain_self->tid, *(pthread_t *)data)) {
+    if (caml_bt_is_self()) {
+      /* If this STW request is handled by the backup thread, the
+         domain thread is currently running C code. */
+      domain_self->domain_canceled = true;
+      (void)pthread_cancel(domain_self->tid);
+      /* We are intentionally not waiting for the thread to terminate here,
+         and not decrementing the number of running domains either, since
+         we don't know the state of the various locks and condition
+         variables in this state. */
+      atomic_store_release(&domain_self->backup_thread_running, 0);
+      atomic_store_release(&domain_self->backup_thread_msg, BT_INIT);
+    } else {
+      /* Domain threads forced to exit here will not have a chance to
+         run caml_domain_terminate() on their own, so we need to ask
+         the backup thread to terminate here. */
+      terminate_backup_thread(domain_self);
+      caml_plat_unlock(&domain_self->domain_lock);
+      /* No particular memory resource cleanup is attempted here, for we
+         have no idea which state each domain is in. */
+    }
+    pthread_exit(0);
+  }
+}
+
+void caml_stop_all_domains(void)
+{
+  atomic_store_relaxed(&domains_exiting, 1);
+
+  pthread_t myself = pthread_self();
+  do {} while (!caml_try_run_on_all_domains(
+               &stw_terminate_domain, &myself, NULL));
+
+  terminate_backup_thread(domain_self);
+  caml_plat_unlock(&domain_self->domain_lock);
+
+  caml_plat_assert_all_locks_unlocked();
+}
+
+bool caml_free_domains(void)
+{
+  bool result = true;
+
+  for (int i = 0; i < caml_params->max_domains; i++) {
+    struct dom_internal* dom = &all_domains[i];
+
+    /* Give the backup thread time to terminate gracefully, if needed */
+    while (atomic_load_acquire(&dom->backup_thread_running) != 0) {
+      cpu_relax();
+    }
+
+    dom->interruptor.interrupt_word = NULL;
+    caml_plat_mutex_free(&dom->interruptor.lock);
+    caml_plat_cond_free(&dom->interruptor.cond);
+
+    if (dom->domain_canceled)
+      result = false;
+    else
+      caml_plat_mutex_free(&dom->domain_lock);
+    caml_plat_cond_free(&dom->domain_cond);
+  }
+
+#ifdef WITH_THREAD_SANITIZER
+  /* When running with TSan, there will be reports of races between
+     freeing the all_domains synchronization objects and domain threads
+     accessing them, even though we wait first for the domain threads to
+     have terminated in the above loop. */
+  result = false;
+#endif
+
+  return result;
 }
 
 CAMLprim value caml_ml_domain_cpu_relax(value t)

--- a/runtime/gc_stats.c
+++ b/runtime/gc_stats.c
@@ -117,6 +117,13 @@ void caml_init_gc_stats (uintnat max_domains)
     caml_fatal_error("Failed to allocate sampled_gc_stats");
 }
 
+void caml_free_gc_stats(void)
+{
+  if (sampled_gc_stats != NULL)
+    caml_stat_free(sampled_gc_stats);
+  sampled_gc_stats = NULL;
+}
+
 /* Update the sampled stats for the given domain during a STW section. */
 void caml_collect_gc_stats_sample_stw(caml_domain_state* domain)
 {

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -167,7 +167,7 @@ gc_phase_t caml_gc_phase;
    We know of two situations in the runtime that could run in parallel
    with a phase update, and cannot safely access the gc phase:
 
-   - The domain_terminate logic runs after the thread has un-registered
+   - The caml_domain_terminate logic runs after the thread has un-registered
      itself as a STW participant, so it may race with a STW section.
 
    - Opportunistic collections may happen while a domain is waiting on
@@ -459,7 +459,8 @@ void caml_orphan_finalisers (caml_domain_state* domain_state)
     atomic_fetch_add_verify_ge0(&num_domains_orphaning_finalisers, -1);
   }
 
-  /* [caml_orphan_finalisers] is called in a while loop in [domain_terminate].
+  /* [caml_orphan_finalisers] is called in a while loop in
+     [caml_domain_terminate].
      We take care to decrement the [num_domains_to_final_update*] counters only
      if we have not already decremented it for the current cycle. */
   if(!f->updated_first) {
@@ -2142,9 +2143,4 @@ void caml_teardown_major_gc(void) {
   caml_stat_free(d->mark_stack->stack);
   caml_stat_free(d->mark_stack);
   d->mark_stack = NULL;
-}
-
-void caml_finalise_heap (void)
-{
-  return;
 }

--- a/runtime/startup_aux.c
+++ b/runtime/startup_aux.c
@@ -22,11 +22,14 @@
 #include "caml/backtrace.h"
 #include "caml/memory.h"
 #include "caml/callback.h"
+#include "caml/domain.h"
 #include "caml/major_gc.h"
 #ifndef NATIVE_CODE
 #include "caml/dynlink.h"
 #endif
+#include "caml/gc_stats.h"
 #include "caml/osdeps.h"
+#include "caml/shared_heap.h"
 #include "caml/startup_aux.h"
 #include "caml/prims.h"
 #include "caml/signals.h"
@@ -175,6 +178,7 @@ static void call_registered_value(char* name)
 CAMLexport void caml_shutdown(void)
 {
   Caml_check_caml_state();
+
   if (startup_count <= 0)
     caml_fatal_error("a call to caml_shutdown has no "
                      "corresponding call to caml_startup");
@@ -186,12 +190,21 @@ CAMLexport void caml_shutdown(void)
 
   call_registered_value("Pervasives.do_at_exit");
   call_registered_value("Thread.at_shutdown");
-  caml_finalise_heap();
+  if (!caml_domain_alone()) {
+    caml_gc_log("Some domains have not been joined prior to shutdown");
+    caml_stop_all_domains();
+  } else {
+    /* These calls are not safe to use if there are domains left running */
+    caml_domain_terminate(true);
+    caml_finalise_freelist();
+  }
+  caml_free_gc_stats();
   caml_free_locale();
 #ifndef NATIVE_CODE
   caml_free_shared_libs();
 #endif
-  caml_stat_destroy_pool();
+  if (caml_free_domains())
+    caml_stat_destroy_pool();
   caml_terminate_signals();
 #if defined(_WIN32) && defined(NATIVE_CODE)
   caml_win32_unregister_overflow_detection();


### PR DESCRIPTION
Back-porting #12964 to 5.3 is not completely trivial without #13352 - PR for CI and precheck.