### PR TITLE
Run the test_dropped_events.ml everywhere again

### DIFF
--- a/testsuite/tests/lib-runtime-events/test_dropped_events.ml
+++ b/testsuite/tests/lib-runtime-events/test_dropped_events.ml
@@ -1,5 +1,4 @@
 (* TEST
- not-msvc; (* FIXME: currently flaky on clang-cl 64 bits *)
  include runtime_events;
  include unix;
  ocamlrunparam += ",e=6";


### PR DESCRIPTION
Apropos the various fixes detailed in #13446, this test should happily drop events on all platforms again!