### PR TITLE
-dsource: fix raw literal escape (#13391)

### DIFF
--- a/Changes
+++ b/Changes
@@ -779,6 +779,11 @@ ___________
   messages (no more unexpected \#true)
   (Florian Angeletti, report by Samuel Vivien, review by Gabriel Scherer)
 
+- #13391, #13551: fix a printing bug with `-dsource` when using
+  raw literal inside a locally abstract type constraint
+  (i.e. `let f: type \#for. ... `)
+  (Florian Angeletti, report by Nick Roberts, review by Richard Eisenberg)
+
 - #13520: Fix compilation of native-code version of systhreads. Bytecode fields
   were being included in the thread descriptors.
   (David Allsopp, review by Sébastien Hinderer and Miod Vallat)

--- a/parsing/pprintast.ml
+++ b/parsing/pprintast.ml
@@ -1412,7 +1412,7 @@ and binding ctxt f {pvb_pat=p; pvb_expr=x; pvb_constraint = ct; _} =
         (simple_pattern ctxt) p (core_type ctxt) typ (expression ctxt) x
   | Some (Pvc_constraint { locally_abstract_univars = vars; typ }) ->
       pp f "%a@;: type@;%a.@;%a@;=@;%a"
-        (simple_pattern ctxt) p (list pp_print_string ~sep:"@;")
+        (simple_pattern ctxt) p (list ident_of_name ~sep:"@;")
         (List.map (fun x -> x.txt) vars)
         (core_type ctxt) typ (expression ctxt) x
   | Some (Pvc_coercion {ground=None; coercion }) ->

--- a/testsuite/tests/parsetree/source.ml
+++ b/testsuite/tests/parsetree/source.ml
@@ -7479,6 +7479,8 @@ let x = new M.\#begin
 
 let f = fun x (type \#begin) (type \#end) -> 1
 
+let f: type \#if. \#if -> \#if = fun x -> x
+
 (* check pretty-printing of local module open in core_type *)
 type t = String.( t )
 


### PR DESCRIPTION
Close #13391 by making sure that escaped raw literal escape in value constraints   

```ocaml
let f: type \#while \#if \#let . \#if -> \#let -> \#while = ...
```

are escaped correctly by `-dsource`.

  