### PR TITLE
Make test summaries more informative

### DIFF
--- a/ocamltest/main.ml
+++ b/ocamltest/main.ml
@@ -142,7 +142,7 @@ let run_test_tree log add_msg behavior env summ ast =
             let testenv = List.fold_left apply_modifiers env mods in
             let test = lookup_test name in
             let (result, newenv) = Tests.run log testenv test in
-            let msg = Result.string_of_result result in
+            let msg = "=> " ^ (Result.string_of_result result) in
             let sub_behavior =
               if Result.is_pass result then Run else Skip_all in
             (msg, sub_behavior, newenv, result)

--- a/ocamltest/result.ml
+++ b/ocamltest/result.ml
@@ -39,9 +39,9 @@ let skip_with_reason r = result_with_reason Skip r
 let fail_with_reason r = result_with_reason Fail r
 
 let string_of_status = function
-  | Pass -> "=> passed"
-  | Skip -> "=> skipped"
-  | Fail -> "=> failed"
+  | Pass -> "passed"
+  | Skip -> "skipped"
+  | Fail -> "failed"
 
 let string_of_reason = function
   | None -> ""

--- a/ocamltest/result.ml
+++ b/ocamltest/result.ml
@@ -55,3 +55,24 @@ let is_pass r = r.status = Pass
 let is_skip r = r.status = Skip
 
 let is_fail r = r.status = Fail
+
+module Join = struct
+  (* The sequential join passes if both tests pass.
+
+     This implies that a linear sequence of actions, a path along the
+     test tree, is considered succesful if all actions passed. *)
+  let sequential r1 r2 =
+    if is_pass r1 then r2 else r1
+
+  (* The parallel join passes if either test passes.
+
+     This implies that a test formed of several parallel branches is
+     considered succesful if at least one of the branches is succesful.
+  *)
+  let parallel r1 r2 =
+    match r1.status, r2.status with
+    | Pass, _ -> r1
+    | _, Pass -> r2
+    | Skip, Skip -> r1
+    | Fail, _ | _, Fail -> r1
+end

--- a/ocamltest/result.mli
+++ b/ocamltest/result.mli
@@ -41,3 +41,8 @@ val is_pass : t -> bool
 val is_skip : t -> bool
 
 val is_fail : t -> bool
+
+module Join : sig
+  val sequential : t -> t -> t
+  val parallel : t -> t -> t
+end

--- a/ocamltest/tests.ml
+++ b/ocamltest/tests.ml
@@ -66,7 +66,7 @@ let run_actions log testenv actions =
         Printf.fprintf log "\nRunning action %d/%d (%s)\n%!"
           action_number total (Actions.name action);
         let (result, env') = Actions.run log env action in
-        Printf.fprintf log "Action %d/%d (%s) %s\n%!"
+        Printf.fprintf log "Action %d/%d (%s) => %s\n%!"
           action_number total (Actions.name action)
           (Result.string_of_result result);
         if Result.is_pass result


### PR DESCRIPTION
(Opening this new PR because I have not been able to re-open #13552.)

(This PR continues work started by @nojb in PR #12895.
Its first commit tries to improve work done by @damiendoligez in PR #11100,
whereas its second commit is more related to the work done by
@gashce in PR #13508.)

When a test is skipped or fails, the present PR prints why in its 1-line
summary.

Consider for instance the following command, run on a machine where gdb is
*not* installed:

```
./ocamltest/ocamltest.opt testsuite/tests/native-debugger/linux-gdb-amd64.ml
```

Without this PR, the one-line output will simply say:

```
 ... testing 'linux-gdb-amd64.ml' => skipped
```

With this PR, in contrast, one gets:

```
 ... testing 'linux-gdb-amd64.ml' => skipped (gdb not available)
```

Making it easier, for instance, to discover that gdb is actually not
available on a CI machine.

Here is an excerpt from the diff between the test log before and
after this PR, to convey more intuition about its impact and benefit:

```
 Running tests from 'tests/afl-instrumentation' ...
- ... testing 'afl-fuzz-test.ml' => skipped
- ... testing 'afl-showmap-test.ml' => skipped
+ ... testing 'afl-fuzz-test.ml' => skipped (afl-fuzz not available)
+ ... testing 'afl-showmap-test.ml' => skipped (afl-showmap not available)
 Running tests from 'tests/arch-power' ...
- ... testing 'exn_raise.ml' => skipped
+ ... testing 'exn_raise.ml' => skipped (Target is not POWER architecture)
- ... testing 'lift_mutable_let_flambda.ml' => skipped
+ ... testing 'lift_mutable_let_flambda.ml' => skipped (support for flambda disabled)
- ... testing 'unrolling_flambda.ml' => skipped
- ... testing 'unrolling_flambda2.ml' => skipped
+ ... testing 'unrolling_flambda.ml' => skipped (support for flambda disabled)
+ ... testing 'unrolling_flambda2.ml' => skipped (support for flambda disabled)
- ... testing 'integr.cmm' => skipped
+ ... testing 'integr.cmm' => skipped (This test is currently broken)
 Running tests from 'tests/ephe-c-api' ...
- ... testing 'test.ml' => skipped
+ ... testing 'test.ml' => skipped (port the new Ephemeron C-api to multicore : https://github.com/ocaml/ocaml/pull/676)
 Running tests from 'tests/flambda' ...
- ... testing 'afl_lazy.ml' => skipped
+ ... testing 'afl_lazy.ml' => skipped (support for flambda disabled)
- ... testing 'specialise.ml' => skipped
+ ... testing 'specialise.ml' => skipped (support for flambda disabled)
 Running tests from 'tests/frame-pointers' ...
- ... testing 'c_call.ml' => skipped
- ... testing 'effects.ml' => skipped
- ... testing 'exception_handler.ml' => skipped
- ... testing 'exceptions.ml' => skipped
- ... testing 'reperform.ml' => skipped
+ ... testing 'c_call.ml' => skipped (frame-pointers not available)
+ ... testing 'effects.ml' => skipped (frame-pointers not available)
+ ... testing 'exception_handler.ml' => skipped (frame-pointers not available)
+ ... testing 'exceptions.ml' => skipped (frame-pointers not available)
+ ... testing 'reperform.ml' => skipped (frame-pointers not available)
- ... testing 'no_flat_float_array.ml' => skipped
+ ... testing 'no_flat_float_array.ml' => skipped (compiler configured with --enable-flat-float)
 Running tests from 'tests/manual-intf-c' ...
- ... testing 'prog.ml' => skipped
+ ... testing 'prog.ml' => skipped (curses can not be properly detected at the moment)
 Running tests from 'tests/native-debugger' ...
- ... testing 'linux-gdb-amd64.ml' => skipped
- ... testing 'linux-gdb-arm64.ml' => skipped
- ... testing 'linux-gdb-riscv.ml' => skipped
+ ... testing 'linux-gdb-amd64.ml' => skipped (gdb not available)
+ ... testing 'linux-gdb-arm64.ml' => skipped (Target is not ARM64 architecture)
+ ... testing 'linux-gdb-riscv.ml' => skipped (Target is not RISC-V architecture)
- ... testing 'linux-lldb-arm64.ml' => skipped
- ... testing 'macos-lldb-amd64.ml' => skipped
- ... testing 'macos-lldb-arm64.ml' => skipped
+ ... testing 'linux-lldb-arm64.ml' => skipped (Target is not ARM64 architecture)
+ ... testing 'macos-lldb-amd64.ml' => skipped (not on a MacOS system)
+ ... testing 'macos-lldb-arm64.ml' => skipped (not on a MacOS system)
 Running tests from 'tests/tsan' ...
- ... testing 'array_elt.ml' => skipped
- ... testing 'exn_from_c.ml' => skipped
- ... testing 'exn_in_callback.ml' => skipped
- ... testing 'exn_reraise.ml' => skipped
- ... testing 'handlers_at_tail.ml' => skipped
- ... testing 'norace_atomics.ml' => skipped
- ... testing 'perform.ml' => skipped
- ... testing 'raise_through_handler.ml' => skipped
- ... testing 'record_field.ml' => skipped
- ... testing 'reperform.ml' => skipped
- ... testing 'unhandled.ml' => skipped
+ ... testing 'array_elt.ml' => skipped (tsan not available)
+ ... testing 'exn_from_c.ml' => skipped (tsan not available)
+ ... testing 'exn_in_callback.ml' => skipped (tsan not available)
+ ... testing 'exn_reraise.ml' => skipped (tsan not available)
+ ... testing 'handlers_at_tail.ml' => skipped (tsan not available)
+ ... testing 'norace_atomics.ml' => skipped (tsan not available)
+ ... testing 'perform.ml' => skipped (tsan not available)
+ ... testing 'raise_through_handler.ml' => skipped (tsan not available)
+ ... testing 'record_field.ml' => skipped (tsan not available)
+ ... testing 'reperform.ml' => skipped (tsan not available)
+ ... testing 'unhandled.ml' => skipped (tsan not available)
- ... testing 'pr6939-no-flat-float-array.ml' => skipped
+ ... testing 'pr6939-no-flat-float-array.ml' => skipped (compiler configured with --enable-flat-float)
 Running tests from 'tests/typing-unboxed-types' ...
- ... testing 'test_no_flat.ml' => skipped
+ ... testing 'test_no_flat.ml' => skipped (compiler configured with --enable-flat-float)
 Running tests from 'tests/unwind' ...
- ... testing 'driver.ml' => skipped
+ ... testing 'driver.ml' => skipped (not on a MacOS system)
 Running tests from 'tests/win-unicode' ...
- ... testing 'mltest.ml' => skipped
+ ... testing 'mltest.ml' => skipped (Windows Unicode support not available)
```

In particular, with this PR it becomes easier to mark tests as disabled,
as can be seen from the test output for `integr.cmm`, whose test
block contains:

```
reason = "This test is currently broken";
skip;
```

As a final note, the semantics of the parallel join should be reviewed
very carefully as I am not confident at all in what I implemented.