### PR TITLE
systhreads: mark `st_masterlock` and `st_event` bool fields as atomic

### DIFF
--- a/otherlibs/systhreads/st_pthreads.h
+++ b/otherlibs/systhreads/st_pthreads.h
@@ -167,10 +167,10 @@ Caml_inline void st_thread_yield(st_masterlock * m)
   m->busy = false;
   atomic_fetch_add(&m->waiters, +1);
   pthread_cond_signal(&m->is_free);
-  /* releasing the domain lock but not triggering bt messaging
-     messaging the bt should not be required because yield assumes
-     that a thread will resume execution (be it the yielding thread
-     or a waiting thread */
+  /* Releasing the domain lock but not triggering bt messaging.
+     Messaging the bt should not be required because yield assumes
+     that a thread will resume execution (either the yielding thread
+     or a waiting thread). */
   caml_release_domain_lock();
 
   do {

--- a/otherlibs/systhreads/st_pthreads.h
+++ b/otherlibs/systhreads/st_pthreads.h
@@ -80,10 +80,10 @@ Caml_inline void st_tls_set(st_tlskey k, void * v)
    threads. */
 
 typedef struct {
-  bool init;                      /* have the mutex and the cond been
+  atomic_bool init;               /* have the mutex and the cond been
                                      initialized already? */
   pthread_mutex_t lock;           /* to protect contents */
-  bool busy;                      /* false = free, true = taken */
+  atomic_bool busy;               /* false = free, true = taken */
   atomic_uintnat waiters;         /* number of threads waiting on master lock */
   pthread_cond_t is_free;         /* signaled when free */
 } st_masterlock;
@@ -195,7 +195,7 @@ Caml_inline void st_thread_yield(st_masterlock * m)
 
 typedef struct st_event_struct {
   pthread_mutex_t lock;         /* to protect contents */
-  bool status;                  /* false = not triggered, true = triggered */
+  atomic_bool status;           /* false = not triggered, true = triggered */
   pthread_cond_t triggered;     /* signaled when triggered */
 } * st_event;
 


### PR DESCRIPTION
An overzealous compiler (i.e. clang-cl) could optimize the following
into `if (m->busy) while (1)`, because `busy` is marked neither
`volatile` nor `atomic`.

```c
static void st_masterlock_acquire(st_masterlock *m)
{
  AcquireSRWLockExclusive(&m->lock);
  while (m->busy) {
```

Extracted from #13416 to make some progress and ease review.
cc @dustanddreams
no-change-entry-needed