### PR TITLE
#13263: fix escaping of true and false in printing functions

### DIFF
--- a/.depend
+++ b/.depend
@@ -717,6 +717,7 @@ typing/env.cmo : \
     typing/subst.cmi \
     typing/shape.cmi \
     typing/predef.cmi \
+    parsing/pprintast.cmi \
     typing/persistent_env.cmi \
     typing/path.cmi \
     utils/misc.cmi \
@@ -742,6 +743,7 @@ typing/env.cmx : \
     typing/subst.cmx \
     typing/shape.cmx \
     typing/predef.cmx \
+    parsing/pprintast.cmx \
     typing/persistent_env.cmx \
     typing/path.cmx \
     utils/misc.cmx \
@@ -1132,7 +1134,6 @@ typing/out_type.cmo : \
     typing/shape.cmi \
     typing/primitive.cmi \
     typing/predef.cmi \
-    parsing/pprintast.cmi \
     typing/path.cmi \
     parsing/parsetree.cmi \
     typing/outcometree.cmi \
@@ -1157,7 +1158,6 @@ typing/out_type.cmx : \
     typing/shape.cmx \
     typing/primitive.cmx \
     typing/predef.cmx \
-    parsing/pprintast.cmx \
     typing/path.cmx \
     parsing/parsetree.cmi \
     typing/outcometree.cmi \

--- a/Changes
+++ b/Changes
@@ -738,6 +738,10 @@ ___________
   path under Win32.
   (Nicolás Ojeda Bär, review by David Allsopp and Damien Doligez)
 
+- #13263, #13560: fix printing true and false in toplevel and error
+  messages (no more unexpected \#true)
+  (Florian Angeletti, report by Samuel Vivien, review by Gabriel Scherer)
+
 OCaml 5.2.0 (13 May 2024)
 -------------------------
 

--- a/parsing/pprintast.mli
+++ b/parsing/pprintast.mli
@@ -24,6 +24,8 @@
 type space_formatter = (unit, Format.formatter, unit) format
 
 val longident : Format.formatter -> Longident.t -> unit
+val constr : Format.formatter -> Longident.t -> unit
+
 val expression : Format.formatter -> Parsetree.expression -> unit
 val string_of_expression : Parsetree.expression -> string
 
@@ -63,6 +65,7 @@ val tyvar: Format.formatter -> string -> unit
 (** {!Format_doc} functions for error messages *)
 module Doc:sig
   val longident: Longident.t Format_doc.printer
+  val constr: Longident.t Format_doc.printer
   val tyvar: string Format_doc.printer
 
   (** Returns a format document if the expression reads nicely as the subject

--- a/testsuite/tests/parsing/rawidents.ml
+++ b/testsuite/tests/parsing/rawidents.ml
@@ -114,3 +114,39 @@ let x = M.(true)
 module M : sig type \#true = true end
 val x : M.\#true = M.(true)
 |}]
+
+type t = { \#false:int; x:int }
+type u = { \#true:int }
+
+let f { \#false; \#true } = 0
+[%%expect {|
+type t = { \#false : int; x : int; }
+type u = { \#true : int; }
+Line 4, characters 17-23:
+4 | let f { \#false; \#true } = 0
+                     ^^^^^^
+Error: The record field "\#true" belongs to the type "u"
+       but is mixed here with fields of type "t"
+|}]
+
+
+module M = struct
+  type t = { \#true:int; y:int}
+  type r = { \#true:int; y:int}
+end
+type t = { \#false:int }
+let _ = ( { M.\#true=0 } : t );;
+[%%expect {|
+module M :
+  sig
+    type t = { \#true : int; y : int; }
+    type r = { \#true : int; y : int; }
+  end
+type t = { \#false : int; }
+Line 6, characters 12-20:
+6 | let _ = ( { M.\#true=0 } : t );;
+                ^^^^^^^^
+Error: The field "M.\#true" belongs to one of the following record types:
+         "M.r"  "M.t"
+       but a field was expected belonging to the record type "t"
+|}]

--- a/testsuite/tests/parsing/rawidents.ml
+++ b/testsuite/tests/parsing/rawidents.ml
@@ -98,3 +98,19 @@ let f ~\#let ?\#and () = 1
 [%%expect{|
 val f : \#let:'a -> ?\#and:'b -> unit -> int = <fun>
 |}]
+
+let x = (true:int)
+[%%expect {|
+Line 1, characters 9-13:
+1 | let x = (true:int)
+             ^^^^
+Error: The constructor "true" has type "bool"
+       but an expression was expected of type "int"
+|}]
+
+module M = struct type \#true = true end
+let x = M.(true)
+[%%expect {|
+module M : sig type \#true = true end
+val x : M.\#true = M.(true)
+|}]

--- a/testsuite/tests/tool-ocamlc-locations/marshalled.compilers.reference
+++ b/testsuite/tests/tool-ocamlc-locations/marshalled.compilers.reference
@@ -1,5 +1,5 @@
 File "foo.ml", line 1, characters 14-18:
 1 | let x : int = true
                   ^^^^
-Error: The constructor "\#true" has type "bool"
+Error: The constructor "true" has type "bool"
        but an expression was expected of type "int"

--- a/testsuite/tests/tool-toplevel/multi_phrase_line.compilers.reference
+++ b/testsuite/tests/tool-toplevel/multi_phrase_line.compilers.reference
@@ -21,7 +21,7 @@ Error: Syntax error
 Line 2, characters 16-20:
 2 | 11;; let x = 12+true;; 13;; (* Type error in second phrase. *)
                     ^^^^
-Error: The constructor "\#true" has type "bool"
+Error: The constructor "true" has type "bool"
        but an expression was expected of type "int"
 #   Line 2, characters 0-22:
 2 | match 14 with 15 -> ();; 16;; 17;; (* Warning + run-time error in 1st phrase. *)

--- a/testsuite/tests/typing-misc/pr7937.ml
+++ b/testsuite/tests/typing-misc/pr7937.ml
@@ -10,7 +10,7 @@ type 'a r = 'a constraint 'a = [< `X of int & 'a ]
 Line 3, characters 35-39:
 3 | let f: 'a. 'a r -> 'a r = fun x -> true;;
                                        ^^^^
-Error: The constructor "\#true" has type "bool"
+Error: The constructor "true" has type "bool"
        but an expression was expected of type "([< `X of int & 'a ] as 'a) r"
 |}]
 

--- a/testsuite/tests/typing-modules/Test.ml
+++ b/testsuite/tests/typing-modules/Test.ml
@@ -123,7 +123,7 @@ module F : (X : sig end) -> sig val x : int end
 Line 2, characters 0-3:
 2 | F.x;; (* fail *)
     ^^^
-Error: The module F is a functor, it cannot have any components
+Error: The module "F" is a functor, it cannot have any components
 |}];;
 
 type t = ..;;

--- a/testsuite/tests/typing-objects/Tests.ml
+++ b/testsuite/tests/typing-objects/Tests.ml
@@ -416,7 +416,7 @@ class c () = object val x = - true val y = -. () end;;
 Line 1, characters 30-34:
 1 | class c () = object val x = - true val y = -. () end;;
                                   ^^^^
-Error: The constructor "\#true" has type "bool"
+Error: The constructor "true" has type "bool"
        but an expression was expected of type "int"
 |}];;
 

--- a/testsuite/tests/typing-poly/poly.ml
+++ b/testsuite/tests/typing-poly/poly.ml
@@ -590,7 +590,7 @@ val f2 : id -> int * bool = <fun>
 Line 5, characters 24-28:
 5 | let f3 f = f#id 1, f#id true
                             ^^^^
-Error: The constructor "\#true" has type "bool"
+Error: The constructor "true" has type "bool"
        but an expression was expected of type "int"
 |}];;
 

--- a/typing/env.ml
+++ b/typing/env.ml
@@ -3524,10 +3524,6 @@ open Format_doc
 
 (* Forward declarations *)
 
-let print_longident : Longident.t printer ref = ref (fun _ _ -> assert false)
-
-let pp_longident ppf l = !print_longident ppf l
-
 let print_path: Path.t printer ref = ref (fun _ _ -> assert false)
 let pp_path ppf l = !print_path ppf l
 
@@ -3569,7 +3565,8 @@ let extract_instance_variables env =
 
 module Style = Misc.Style
 
-let quoted_longident = Style.as_inline_code pp_longident
+let quoted_longident = Style.as_inline_code Pprintast.Doc.longident
+let quoted_constr = Style.as_inline_code Pprintast.Doc.constr
 
 let report_lookup_error_doc _loc env ppf = function
   | Unbound_value(lid, hint) -> begin
@@ -3604,7 +3601,7 @@ let report_lookup_error_doc _loc env ppf = function
     end
   | Unbound_constructor lid ->
       fprintf ppf "Unbound constructor %a"
-        quoted_longident lid;
+        quoted_constr lid;
       spellcheck ppf extract_constructors env lid;
   | Unbound_label lid ->
       fprintf ppf "Unbound record field %a"
@@ -3668,7 +3665,7 @@ let report_lookup_error_doc _loc env ppf = function
         quoted_longident lid
   | Functor_used_as_structure lid ->
       fprintf ppf "@[The module %a is a functor, \
-                   it cannot have any components@]" pp_longident lid
+                   it cannot have any components@]" quoted_longident lid
   | Abstract_used_as_structure lid ->
       fprintf ppf "@[The module %a is abstract, \
                    it cannot have any components@]"

--- a/typing/env.mli
+++ b/typing/env.mli
@@ -486,8 +486,6 @@ val strengthen:
 (* Forward declaration to break mutual recursion with Ctype. *)
 val same_constr: (t -> type_expr -> type_expr -> bool) ref
 (* Forward declaration to break mutual recursion with Printtyp. *)
-val print_longident: Longident.t Format_doc.printer ref
-(* Forward declaration to break mutual recursion with Printtyp. *)
 val print_path: Path.t Format_doc.printer ref
 
 

--- a/typing/oprint.ml
+++ b/typing/oprint.ml
@@ -143,6 +143,9 @@ let print_constr ppf name =
     (* despite being keywords, these are constructor names
        and should not be escaped *)
     fprintf ppf "%s" c
+  | Oide_dot (id, ("true"|"false" as s)) ->
+      (* Similarly, M.true is invalid *)
+      fprintf ppf "%a.(%s)" print_ident id s
   | _ -> print_ident ppf name
 
 let print_out_value ppf tree =

--- a/typing/out_type.ml
+++ b/typing/out_type.ml
@@ -33,10 +33,6 @@ module Style = Misc.Style
 module Fmt = Format_doc
 open Format_doc
 
-let longident = Pprintast.Doc.longident
-
-let () = Env.print_longident := longident
-
 (* Print an identifier avoiding name collisions *)
 
 module Out_name = struct

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -1983,6 +1983,7 @@ end
 
 let quoted_out_type ppf ty = Style.as_inline_code !Oprint.out_type ppf ty
 let quoted_type ppf ty = Style.as_inline_code Printtyp.type_expr ppf ty
+let quoted_constr = Style.as_inline_code Pprintast.Doc.constr
 
 let report_error_doc ppf = function
   | Repeated_parameter ->
@@ -2111,20 +2112,20 @@ let report_error_doc ppf = function
       let msg = Format_doc.doc_printf in
       Errortrace_report.unification ppf env err
         (msg "The constructor %a@ has type"
-             (Style.as_inline_code Printtyp.longident) lid)
+             quoted_constr lid)
         (msg "but was expected to be of type")
   | Rebind_mismatch (lid, p, p') ->
       fprintf ppf
         "@[%s@ %a@ %s@ %a@ %s@ %s@ %a@]"
         "The constructor"
-        (Style.as_inline_code Printtyp.longident) lid
+        quoted_constr lid
         "extends type" Style.inline_code (Path.name p)
         "whose declaration does not match"
         "the declaration of type" Style.inline_code (Path.name p')
   | Rebind_private lid ->
       fprintf ppf "@[%s@ %a@ %s@]"
         "The constructor"
-        (Style.as_inline_code Printtyp.longident) lid
+        quoted_constr lid
         "is private"
   | Variance (Typedecl_variance.Bad_variance (n, v1, v2)) ->
       let variance (p,n,i) =


### PR DESCRIPTION
Both `true` and `false` should not be escaped using the raw identifier syntax if they appear in a context where a variant constructor is expected.  For instance, in

```ocaml
let x = true 0
```
we don't want to escape `true` in
>```
>Error: The constructor true expects 0 argument(s),
>       but is applied here to 1 argument(s)
>```


Similarly, it is better to print `Path.To.(true)` as `Path.To.(true)` and not `Path.To.true` nor `Path.To.\#true`.

This PRs tweak the constructor printer in `Oprint` to handle this last case and adds a specific printer for `variant constructor longident` for error messages in `Pprintast`.

Along the way, it removes a backpatched printer in `Env` that has not been needed since the implementation of the `longident` printers has moved to `Pprintast` rather than `Printtyp`, and it fixes a missing `inline code` tag in a nearby error message.

Close #13263