### PR TITLE
Less tagging in asmcomp-optimized switches

### DIFF
--- a/Changes
+++ b/Changes
@@ -51,6 +51,11 @@ Working version
 
 ### Code generation and optimizations:
 
+- #13565: less tagging in switches compiled to affine transformations
+  by ocamlopt.
+  (Gabriel Scherer and Clément Allain, review by Vincent Laviron,
+   report by Vesa Karvonen)
+
 ### Standard library:
 
 - #13543: Remove some String-Bytes conversion from the stdlib to behave better

--- a/asmcomp/cmm_helpers.ml
+++ b/asmcomp/cmm_helpers.ml
@@ -106,11 +106,19 @@ let alloc_boxedintnat_header dbg = Cconst_natint (boxedintnat_header, dbg)
 let max_repr_int = max_int asr 1
 let min_repr_int = min_int asr 1
 
+let tag_const (n : int) : nativeint =
+  Nativeint.(add (shift_left (of_int n) 1) 1n)
+
+let untag_const (n : nativeint) : int =
+  if Nativeint.(logand n 1n <> 1n) then
+    Misc.fatal_error
+      "Cmm_helpers.untag_const was called on an non-tagged constant";
+  Nativeint.(to_int (shift_right n 1))
+
 let int_const dbg n =
   if n <= max_repr_int && n >= min_repr_int
   then Cconst_int((n lsl 1) + 1, dbg)
-  else Cconst_natint
-          (Nativeint.add (Nativeint.shift_left (Nativeint.of_int n) 1) 1n, dbg)
+  else Cconst_natint (tag_const n, dbg)
 
 let natint_const_untagged dbg n =
   if n > Nativeint.of_int max_int
@@ -119,7 +127,7 @@ let natint_const_untagged dbg n =
   else Cconst_int (Nativeint.to_int n, dbg)
 
 let cint_const n =
-  Cint(Nativeint.add (Nativeint.shift_left (Nativeint.of_int n) 1) 1n)
+  Cint(tag_const n)
 
 let targetint_const n =
   Targetint.add (Targetint.shift_left (Targetint.of_int n) 1)
@@ -1435,11 +1443,27 @@ let int_comp_caml cmp arg1 arg2 dbg =
 
 (* Build an actual switch (ie jump table) *)
 
+type switch_arg = Tagged of expression | Untagged of expression
+
+(** This function takes a switch on immedate values,
+    for example:
+      int 0: 1
+      int 1: 3
+      int 2: 5
+
+    It tries to perform two optimizations:
+    - If the switch implements an affine function [x -> a*x + b],
+      produce the affine expression [a * arg + b]. In particular, when
+      a=1 and b=0, return the argument [arg] unchanged.
+    - If the switch only has constant right-hand-sides (but is not an
+      affine function), produce a table lookup.
+*)
 let make_switch arg cases actions dbg =
+  (* We only apply those optimizations if the right-hand-side is
+     made of valid OCaml constants. In particular, if all machine
+     integers appearing in the right-hand-side are tagged (least bit 1). *)
   let extract_uconstant =
     function
-    (* Constant integers loaded from a table should end in 1,
-       so that Cload never produces untagged integers *)
     | Cconst_int     (n, _), _dbg when (n land 1) = 1 ->
         Some (Cint (Nativeint.of_int n))
     | Cconst_natint     (n, _), _dbg
@@ -1454,10 +1478,27 @@ let make_switch arg cases actions dbg =
     if length >= 2
     then begin
       match const_actions.(cases.(0)), const_actions.(cases.(1)) with
-      | Cint v0, Cint v1 ->
-          let slope = Nativeint.sub v1 v0 in
+      | Cint n0, Cint n1 ->
+          (* The right-hand-sides are tagged, so we can translate them
+             back to OCaml integers without loss of information, to
+             compute the offset and slope on OCaml integers.
+
+             For example, consider the identity function on OCaml integers
+               0 -> 0
+               1 -> 1
+               2 -> 2
+             If we computed the slope with native integers on the
+             right-hand-side, we would see
+               0 -> 1n
+               1 -> 3n
+               2 -> 5n
+             and compute offset=1n, slope=2n.
+             We want offset=0, slope=1 instead.
+          *)
+          let v0, v1 = untag_const n0, untag_const n1 in
+          let slope = v1 - v0 in
           let check i = function
-            | Cint v -> v = Nativeint.(add (mul (of_int i) slope) v0)
+            | Cint n -> untag_const n = (slope * i + v0)
             | _ -> false
           in
           if Misc.Stdlib.Array.for_alli
@@ -1469,29 +1510,42 @@ let make_switch arg cases actions dbg =
     end
     else None
   in
-  let make_table_lookup ~cases ~const_actions arg dbg =
+  let make_switch ~arg_untagged ~cases ~actions =
+    (* We need an untagged argument here. *)
+    Cswitch (arg_untagged, cases, actions, dbg)
+  in
+  let make_table_lookup ~arg_tagged ~cases ~const_actions =
+    (* We need a tagged argument here, to call a [*_array_ref] helper. *)
     let table = Compilenv.new_const_symbol () in
     Cmmgen_state.add_constant table (Const_table (Local,
         Array.to_list (Array.map (fun act ->
           const_actions.(act)) cases)));
-    addr_array_ref (Cconst_symbol (table, dbg)) (tag_int arg dbg) dbg
+    (* Constant integers loaded from a table are tagged,
+       so that Cload never produces untagged integers. *)
+    addr_array_ref (Cconst_symbol (table, dbg)) arg_tagged dbg
   in
-  let make_affine_computation ~offset ~slope arg dbg =
-    (* In case the resulting integers are an affine function of the index, we
-       don't emit a table, and just compute the result directly *)
-    add_int
-      (mul_int arg (natint_const_untagged dbg slope) dbg)
-      (natint_const_untagged dbg offset)
-      dbg
+  let make_affine_computation ~arg_tagged ~offset ~slope =
+    (* Asking for a tagged argument here does not introduce extra tagging,
+       as any (tag_int ..) logic around the argument will be undone by
+       [mul_int_caml]. *)
+    add_int_caml
+      (mul_int_caml (int_const dbg slope) arg_tagged dbg)
+      (int_const dbg offset) dbg
+  in
+  let arg_tagged, arg_untagged =
+    match arg with
+    | Tagged arg_tagged -> arg_tagged, untag_int arg_tagged dbg
+    | Untagged arg_untagged -> tag_int arg_untagged dbg, arg_untagged
   in
   match Misc.Stdlib.Array.all_somes (Array.map extract_uconstant actions) with
   | None ->
-      Cswitch (arg,cases,actions,dbg)
+      make_switch ~arg_untagged ~cases ~actions
   | Some const_actions ->
       match extract_affine ~cases ~const_actions with
       | Some (offset, slope) ->
-          make_affine_computation ~offset ~slope arg dbg
-      | None -> make_table_lookup ~cases ~const_actions arg dbg
+          make_affine_computation ~arg_tagged ~offset ~slope
+      | None ->
+          make_table_lookup ~arg_tagged ~cases ~const_actions
 
 module SArgBlocks =
 struct
@@ -1523,7 +1577,7 @@ struct
       Debuginfo.none)
   let make_switch dbg arg cases actions =
     let actions = Array.map (fun expr -> expr, dbg) actions in
-    make_switch arg cases actions dbg
+    make_switch (Untagged arg) cases actions dbg
   let bind arg body = bind "switcher" arg body
 
   let make_catch handler = match handler with

--- a/asmcomp/cmm_helpers.mli
+++ b/asmcomp/cmm_helpers.mli
@@ -538,10 +538,12 @@ val bigstring_set :
 (** [transl_isout h arg dbg] *)
 val transl_isout : expression -> expression -> Debuginfo.t -> expression
 
+type switch_arg = Tagged of expression | Untagged of expression
 (** [make_switch arg cases actions dbg] : Generate a Cswitch construct,
-    or optimize as a static table lookup when possible. *)
+    or optimize as a static table lookup when possible.
+*)
 val make_switch :
-  expression -> int array -> (expression * Debuginfo.t) array -> Debuginfo.t ->
+  switch_arg -> int array -> (expression * Debuginfo.t) array -> Debuginfo.t ->
   expression
 
 (** [transl_int_switch loc arg low high cases default] *)

--- a/asmcomp/cmmgen.ml
+++ b/asmcomp/cmmgen.ml
@@ -568,7 +568,7 @@ let rec transl env e =
          can be checked *)
       if Array.length s.us_index_blocks = 0 then
         make_switch
-          (untag_int (transl env arg) dbg)
+          (Tagged (transl env arg))
           s.us_index_consts
           (Array.map (fun expr -> transl env expr, dbg) s.us_actions_consts)
           dbg


### PR DESCRIPTION
`ocamlopt` optimizes switches that return only constants (from jump tables to lookup tables). Furthermore it optimizes switches where the constants are all tagged integers that happen to determine an affine transformation of the switch index; this is #8547, implemented by @smuenzel-js.

One aspect of this optimization that is slightly frustrating is that it often generates more tagging noise than we would like. This is particularly visible on identity transformations:

```ocaml
type t = A0 | A1 | A2 | A3

let test = function
  | A0 -> 0
  | A1 -> 1
  | A2 -> 2
  | A3 -> 3
```

One would reasonably expect `test` to be just the identity at runtime, but in fact it is not, as shown in the `-dcmm` output:

```ocaml
(function camlMicro.test_401 (param/403: val)
  (+ (<< (>>s param/403 1) 1) 1))
```

The present PR tweaks the affine-detection logic to instead generate the identity function for real.

```ocaml
(function camlMicro.test_403 (param/405: val)
  param/405)
```

This PR was written with the help of @clef-men, who was reading the code of kcas by @polytypic which contains [a comment about this infelicity](https://github.com/ocaml-multicore/kcas/blob/571518183c47ef140590d839c360c338ae78cd03/src/kcas/kcas.ml#L237-L249).

### Obligatory micro-benchmark

```ocaml
(* micro.ml *)
let n =
  match int_of_string Sys.argv.(1) with
  | n -> n
  | exception _ -> failwith "An integer (iteration count) was expected as first command-line argument."

type t = A0 | A1 | A2 | A3

let test = function
  | A0 -> 0
  | A1 -> 1
  | A2 -> 2
  | A3 -> 3

let () =
  for i = 1 to n do
    ignore (Sys.opaque_identity (test (Sys.opaque_identity A0)));
    ignore (Sys.opaque_identity (test (Sys.opaque_identity A1)));
    ignore (Sys.opaque_identity (test (Sys.opaque_identity A2)));
    ignore (Sys.opaque_identity (test (Sys.opaque_identity A3)));
  done
```

```shell
> hyperfine -L v trunk,branch "./micro.{v}.opt 100_000_000"
Benchmark 1: ./micro.trunk.opt 100_000_000
  Time (mean ± σ):     251.5 ms ±   1.7 ms    [User: 249.3 ms, System: 1.9 ms]
  Range (min … max):   249.2 ms … 254.2 ms    11 runs
 
Benchmark 2: ./micro.branch.opt 100_000_000
  Time (mean ± σ):      86.3 ms ±   1.5 ms    [User: 83.9 ms, System: 2.0 ms]
  Range (min … max):    83.4 ms …  88.9 ms    33 runs
 
Summary
  ./micro.branch.opt 100_000_000 ran
    2.91 ± 0.06 times faster than ./micro.trunk.opt 100_000_000
```

### How this works

The reason why there are more tagging operations than expected, in trunk, is that the affine function is computed on the tagged representations of the OCaml integers, rather than their untagged representations. In the example of the identity above, the affine function that is computed is not (0 -> 0, 1 -> 1, 2 -> 2, 3 -> 3) (slope 1, offset 0) but instead (0 -> 1n, 1 -> 3n, 2 -> 5n, 3 -> 7n) (slope 2n, offset 1n). To apply the affine function to an argument, we first untag it, and then apply the affine transformation: `arg` becomes `2 * (arg >> 1) + 1`. The cmm_helpers smart contructors cannot rewrite this into the identity `arg`, because this rewriting is not correct in general (only for `arg` that have their least bit set).

In the PR, we instead compute the affine transformation on OCaml (untagged) integers. Instead of computing `slope * untag(arg) + offset`, we compute `tag(slope) *caml arg +caml tag(offset)`, which generates nicer code and in particular simplifies into just `arg` when we have (slope=1, offset=0).

There is a subtlety in the PR implementation, which is that the `make_switch` function responsible for this optimization is called in two different contexts in trunk, sometimes (from cmmgen) on tagged integers and sometimes (from Switch) on untagged integers. If we just change `make_switch` to not require untagging in cmmgen, but introduce tagging in Switch to compensate, we risk adding a small performance regression in the Switch case. Instead we make the function support both calling contexts, and ensure that the minimal amount of tagging/untagging is performed -- in particular, never more than before.

### How to review

The PR is designed to be read commit-by-commit -- first a refactoring that just moves code around, then a test, then the behavior change that updates the test reference.

(cc @smuenzel-js , @lthls )