### PR TITLE
Fix `caml_stat_wcsdup_noexc` raising in out-of-memory

### DIFF
--- a/runtime/memory.c
+++ b/runtime/memory.c
@@ -734,7 +734,7 @@ CAMLexport caml_stat_string caml_stat_strdup(const char *s)
 CAMLexport wchar_t * caml_stat_wcsdup_noexc(const wchar_t *s)
 {
   size_t slen = wcslen(s);
-  wchar_t* result = caml_stat_alloc((slen + 1)*sizeof(wchar_t));
+  wchar_t* result = caml_stat_alloc_noexc((slen + 1)*sizeof(wchar_t));
   if (result == NULL)
     return NULL;
   memcpy(result, s, (slen + 1)*sizeof(wchar_t));


### PR DESCRIPTION
Introduced in [3ca771e](https://github.com/ocaml/ocaml/commit/3ca771eaafeb609b80c966a1981baa66e44e39b0#diff-619cc3868df8ee59cc68190a3cb39c9403184abe22688543ede23506b2f781a0).
cc @NickBarnes

This PR could be added to #13419 (currently in trunk) changes entry, or just no-change-entry-needed.